### PR TITLE
Remove README showcase placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ Repo-native agent orchestration and public Codex signal publishing.
 [![GitHub last commit](https://img.shields.io/github/last-commit/hack-ink/decodex?color=red&style=plastic)](https://github.com/hack-ink/decodex)
 [![GitHub code lines](https://tokei.rs/b1/github/hack-ink/decodex)](https://github.com/hack-ink/decodex)
 
-https://decodex.space
-
-<img src="assets/logo-source.png" alt="Decodex logo" width="360">
-
 </div>
 
 ## Feature Highlights


### PR DESCRIPTION
## Summary
- Remove the bare site URL and logo image from the README centered header.
- Leave the rsnap-style top section as title, description, and badges only until Decodex has real showcase screenshots or recordings.

## Verification
- git diff --check

## Semantic drift
- Not required: this only removes a visual placeholder and does not change behavior, commands, status text, or config claims.