### PR TITLE
Make Decodex probe threads ephemeral

### DIFF
--- a/apps/decodex/src/agent/app_server.rs
+++ b/apps/decodex/src/agent/app_server.rs
@@ -308,6 +308,7 @@ pub(crate) struct AppServerRunRequest<'a> {
 	pub(crate) continuation_user_input: Option<String>,
 	pub(crate) activity_marker_path: Option<PathBuf>,
 	pub(crate) resume_thread_id: Option<String>,
+	pub(crate) ephemeral_thread: bool,
 	pub(crate) command_exec_health_check: Option<CommandExecHealthCheck>,
 	pub(crate) dynamic_tool_handler: Option<&'a dyn DynamicToolHandler>,
 	pub(crate) continuation_guard: Option<&'a dyn TurnContinuationGuard>,
@@ -924,6 +925,7 @@ pub(crate) fn probe_app_server(listen: &str) -> crate::prelude::Result<AppServer
 			continuation_user_input: None,
 			activity_marker_path: None,
 			resume_thread_id: None,
+			ephemeral_thread: true,
 			command_exec_health_check: Some(CommandExecHealthCheck::probe()),
 			dynamic_tool_handler: Some(&probe_tool_handler),
 			continuation_guard: None,
@@ -2565,6 +2567,7 @@ fn build_thread_start_request(
 		cwd: Some(request.cwd.clone()),
 		dynamic_tools,
 		developer_instructions: Some(request.developer_instructions.clone()),
+		ephemeral: request.ephemeral_thread.then_some(true),
 		..ThreadStartRequest::default()
 	})
 }

--- a/apps/decodex/src/agent/app_server/tests.rs
+++ b/apps/decodex/src/agent/app_server/tests.rs
@@ -297,6 +297,7 @@ fn thread_start_and_resume_requests_inherit_runtime_config() {
 		assert!(value.get("approvalPolicy").is_none());
 		assert!(value.get("sandbox").is_none());
 		assert!(value.get("config").is_none());
+		assert!(value.get("ephemeral").is_none());
 	}
 
 	let start =
@@ -359,11 +360,23 @@ fn minimal_run_request<'a>() -> super::AppServerRunRequest<'a> {
 		continuation_user_input: None,
 		activity_marker_path: None,
 		resume_thread_id: None,
+		ephemeral_thread: false,
 		command_exec_health_check: None,
 		dynamic_tool_handler: None,
 		continuation_guard: None,
 		codex_account_provider: None,
 	}
+}
+
+#[test]
+fn synthetic_probe_thread_start_is_ephemeral_when_requested() {
+	let mut request = minimal_run_request();
+	request.ephemeral_thread = true;
+
+	let start = super::build_thread_start_request(&request).expect("request should build");
+	let value = serde_json::to_value(&start).expect("thread start request should serialize");
+
+	assert_eq!(value["ephemeral"], true);
 }
 
 #[test]
@@ -1258,6 +1271,7 @@ fn live_app_server_resume_round_trip_updates_marker_and_state() {
 			)),
 			activity_marker_path: Some(marker_path.clone()),
 			resume_thread_id: None,
+			ephemeral_thread: false,
 			command_exec_health_check: None,
 			dynamic_tool_handler: Some(&handler),
 			continuation_guard: Some(&guard),
@@ -1301,6 +1315,7 @@ fn live_app_server_resume_round_trip_updates_marker_and_state() {
 			continuation_user_input: None,
 			activity_marker_path: Some(marker_path.clone()),
 			resume_thread_id: Some(first_result.thread_id.clone()),
+			ephemeral_thread: false,
 			command_exec_health_check: None,
 			dynamic_tool_handler: Some(&handler),
 			continuation_guard: None,

--- a/apps/decodex/src/agent/app_server/tests.rs
+++ b/apps/decodex/src/agent/app_server/tests.rs
@@ -371,6 +371,7 @@ fn minimal_run_request<'a>() -> super::AppServerRunRequest<'a> {
 #[test]
 fn synthetic_probe_thread_start_is_ephemeral_when_requested() {
 	let mut request = minimal_run_request();
+
 	request.ephemeral_thread = true;
 
 	let start = super::build_thread_start_request(&request).expect("request should build");

--- a/apps/decodex/src/orchestrator/execution.rs
+++ b/apps/decodex/src/orchestrator/execution.rs
@@ -452,6 +452,7 @@ where
 			)),
 			activity_marker_path: Some(issue_run.worktree.path.clone()),
 			resume_thread_id: resolve_resume_thread_id(state_store, issue_run)?,
+			ephemeral_thread: false,
 			command_exec_health_check: None,
 			dynamic_tool_handler: Some(&decodex_tool_bridge),
 			continuation_guard: Some(&continuation_guard),

--- a/docs/spec/app-server.md
+++ b/docs/spec/app-server.md
@@ -167,6 +167,7 @@ The MVP thread start request owns these fields:
 - `cwd`
 - `dynamicTools` when the run exposes issue-scoped tracker tools
 - `developerInstructions`
+- `ephemeral` only for synthetic Decodex probe threads
 
 Decodex must not inject project-owned config, model, personality, service-tier, sandbox, or approval-policy overrides into `thread/start`. Child runs inherit runtime defaults from the active Codex runtime.
 
@@ -302,6 +303,8 @@ The `decodex probe` command must verify at least:
 5. The local client can complete the bounded app-server capability preflight after
    `initialize` and before `thread/start`.
 6. The local client can complete one bounded standalone `command/exec` health check after `initialize`.
-7. The local client can complete one `dynamicTools -> item/tool/call -> response` round trip and still finish with the expected final output.
+7. The local client can complete one ephemeral
+   `dynamicTools -> item/tool/call -> response` round trip and still finish with the
+   expected final output without materializing a probe thread on disk.
 
 The probe command is the first gate before deeper orchestrator logic depends on the protocol.


### PR DESCRIPTION
Summary
- Mark synthetic Decodex probe thread starts as ephemeral so PROBE_OK protocol checks do not materialize on disk.
- Keep retained lane and resume paths non-ephemeral.
- Update the app-server spec and request-shape tests.

Verification
- cargo make fmt-check
- cargo nextest run -p decodex app_server::tests
- cargo make check-rust
- semantic drift helper: no stale phrase hits