### PR TITLE
Fix Decodex plugin skill metadata

### DIFF
--- a/plugins/decodex/skills/automation/SKILL.md
+++ b/plugins/decodex/skills/automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: automation
-description: Use for Decodex runtime-owned automation: registered projects, `serve`, automatic issue intake, retained lanes, tracker tools, review handoff, repair, landing, closeout, cleanup, and operator recovery. Does not own manual commit or manual PR landing details.
+description: "Use for Decodex runtime-owned automation: registered projects, `serve`, automatic issue intake, retained lanes, tracker tools, review handoff, repair, landing, closeout, cleanup, and operator recovery. Does not own manual commit or manual PR landing details."
 ---
 
 # Automation

--- a/plugins/decodex/skills/manual-cli/SKILL.md
+++ b/plugins/decodex/skills/manual-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manual-cli
-description: Use for human-driven Decodex CLI workflows: project registration, probe, status, dry-run probes, live-run routing, commit, land, archive hygiene, and local operator inspection. Does not own retained-lane automation policy beyond routing to the automation skill.
+description: "Use for human-driven Decodex CLI workflows: project registration, probe, status, dry-run probes, live-run routing, commit, land, archive hygiene, and local operator inspection. Does not own retained-lane automation policy beyond routing to the automation skill."
 ---
 
 # Manual CLI


### PR DESCRIPTION
## Summary
- quote Decodex plugin skill descriptions that contain YAML colons
- keep the installable plugin metadata parseable after syncing to ~/.codex

## Verification
- parsed 6 Decodex skill frontmatters with Ruby YAML
- diffed ~/.codex plugin cache against plugins/decodex
- checked active plugin paths for stale Maestro references
- git diff --check
- git verify-commit HEAD