### PR TITLE
Fix dashboard model time progress reuse

### DIFF
--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -6855,6 +6855,10 @@
 				return `${childBucketSharePercent(bucket, totalWall)}% · ${formatDuration(seconds)} / ${formatDuration(totalWall)}`;
 			}
 
+			function childBucketRenderKey(bucket) {
+				return `child-bucket:${bucket?.name || "unknown"}`;
+			}
+
 			function childDiagnosticBucketRank(bucket) {
 				const name = String(bucket?.name || "").toLowerCase();
 				if (name.includes("protocol")) {
@@ -6955,7 +6959,7 @@
 													const width = childBucketWidth(bucket, totalWall);
 
 													return `
-														<div class="child-bucket is-share" data-duration="wall-share">
+														<div class="child-bucket is-share" data-render-key="${escapeHtml(childBucketRenderKey(bucket))}" data-duration="wall-share">
 															<span class="child-bucket-name">${escapeHtml(humanizeToken(bucket.name))}</span>
 															<span class="child-bucket-bar" aria-hidden="true" style="--bucket-width: ${width}%"><span></span></span>
 															<span class="child-bucket-value">${escapeHtml(childBucketShareLabel(bucket, totalWall))}</span>
@@ -6982,7 +6986,7 @@
 													const signalSummary = childBucketDiagnosticSummary(bucket);
 
 													return `
-														<div class="${bucketClass}"${bucketState}>
+														<div class="${bucketClass}" data-render-key="${escapeHtml(childBucketRenderKey(bucket))}"${bucketState}>
 															<span class="child-bucket-name">${escapeHtml(humanizeToken(bucket.name))}</span>
 															<span class="child-bucket-signals" aria-label="${escapeHtml(signalSummary)}">
 																${renderChildBucketDiagnosticSignals(bucket)}

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -276,7 +276,6 @@ fn operator_dashboard_child_bucket_rows_split_time_bars_from_event_diagnostics()
 	assert!(response.contains("childAgentLargeOutputWarnings"));
 	assert!(response.contains("childAgentLargeOutputSummary"));
 	assert!(response.contains("childBucketShareLabel"));
-	assert!(response.contains("function childBucketRenderKey(bucket)"));
 	assert!(response.contains("childBucketWidth"));
 	assert!(response.contains("function renderMetricText(text)"));
 	assert!(response.contains("function setMetricText(node, text)"));
@@ -290,12 +289,6 @@ fn operator_dashboard_child_bucket_rows_split_time_bars_from_event_diagnostics()
 	assert!(response.contains("child-bucket is-event-only"));
 	assert!(response.contains("child-bucket-signals"));
 	assert!(response.contains("child-bucket-signal"));
-	assert_eq!(
-		response
-			.matches("data-render-key=\"${escapeHtml(childBucketRenderKey(bucket))}\"")
-			.count(),
-		2
-	);
 	assert!(response.contains("data-duration=\"wall-share\""));
 	assert!(response.contains("data-duration=\"event-diagnostics\""));
 	assert!(response.contains("data-duration=\"diagnostic\""));
@@ -373,6 +366,19 @@ fn operator_dashboard_child_bucket_rows_split_time_bars_from_event_diagnostics()
 	assert!(response.contains(
 		"No lane owns this worktree; inspect before cleanup."
 	));
+}
+
+#[test]
+fn operator_dashboard_keys_child_bucket_rows_for_stable_patching() {
+	let response = dashboard_response();
+
+	assert!(response.contains("function childBucketRenderKey(bucket)"));
+	assert_eq!(
+		response
+			.matches("data-render-key=\"${escapeHtml(childBucketRenderKey(bucket))}\"")
+			.count(),
+		2
+	);
 }
 
 #[test]

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -276,6 +276,7 @@ fn operator_dashboard_child_bucket_rows_split_time_bars_from_event_diagnostics()
 	assert!(response.contains("childAgentLargeOutputWarnings"));
 	assert!(response.contains("childAgentLargeOutputSummary"));
 	assert!(response.contains("childBucketShareLabel"));
+	assert!(response.contains("function childBucketRenderKey(bucket)"));
 	assert!(response.contains("childBucketWidth"));
 	assert!(response.contains("function renderMetricText(text)"));
 	assert!(response.contains("function setMetricText(node, text)"));
@@ -289,6 +290,12 @@ fn operator_dashboard_child_bucket_rows_split_time_bars_from_event_diagnostics()
 	assert!(response.contains("child-bucket is-event-only"));
 	assert!(response.contains("child-bucket-signals"));
 	assert!(response.contains("child-bucket-signal"));
+	assert_eq!(
+		response
+			.matches("data-render-key=\"${escapeHtml(childBucketRenderKey(bucket))}\"")
+			.count(),
+		2
+	);
 	assert!(response.contains("data-duration=\"wall-share\""));
 	assert!(response.contains("data-duration=\"event-diagnostics\""));
 	assert!(response.contains("data-duration=\"diagnostic\""));


### PR DESCRIPTION
## Summary
- add stable render keys to child-agent bucket rows in the operator dashboard
- prevent bucket reordering from reusing another row's progress bar width during live time updates
- lock the dashboard HTML contract in adjacent operator dashboard tests

## Verification
- cargo test -p decodex operator_dashboard
- cargo make fmt-rust-check
- cargo make check-vstyle-rust
- git diff --check
- mock dashboard browser smoke: Model bucket rendered at 83% with no console errors
