### PR TITLE
Default release delta to latest pair

### DIFF
--- a/site/src/components/ReleaseDeltaPanel.astro
+++ b/site/src/components/ReleaseDeltaPanel.astro
@@ -43,14 +43,7 @@ const latestComparison = delta.comparisons.find(
     comparison.prerelease_tag_name === delta.prerelease.tag_name,
 );
 const latestComparisonTrackedCount = latestComparison?.tracked_signal_slugs.length ?? 0;
-const activeComparison =
-  (latestComparison &&
-  trackedSignalsForSlugs(latestComparison.tracked_signal_slugs, trackedSignals).length > 0
-    ? latestComparison
-    : delta.comparisons.find(
-        (comparison) =>
-          trackedSignalsForSlugs(comparison.tracked_signal_slugs, trackedSignals).length > 0,
-      )) ?? defaultComparison(delta);
+const activeComparison = latestComparison ?? defaultComparison(delta);
 
 function hasConcreteTryPath(signal: SignalCardData): boolean {
   return Boolean(signal.how_to_try && signal.expected_effect);

--- a/site/src/lib/release-delta.ts
+++ b/site/src/lib/release-delta.ts
@@ -81,13 +81,5 @@ export function defaultComparison(delta: ReleaseDeltaData): ReleaseComparisonDat
       comparison.prerelease_tag_name === delta.prerelease.tag_name,
   );
 
-  if (releaseDefault?.tracked_signal_slugs.length) {
-    return releaseDefault;
-  }
-
-  return (
-    delta.comparisons.find((comparison) => comparison.tracked_signal_slugs.length > 0) ??
-    releaseDefault ??
-    delta.comparisons[0]
-  );
+  return releaseDefault ?? delta.comparisons[0];
 }


### PR DESCRIPTION
## Summary

- make the release-delta module default to the canonical latest stable/prerelease pair even when that pair has zero curated signals
- keep older signal-bearing release windows available only through the selectors

## Verification

- npm ci in site
- cargo make check-site-content
- npm run build
- npm run check
- git diff --check
- cargo make decodex-checks
- local preview curl confirms selected 0.130.0 -> 0.131.0-alpha.9 and hides 0.118.0 -> 0.119.0-alpha.13