### PR TITLE
Fix operator claimed lane visibility

### DIFF
--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -7490,12 +7490,21 @@
 				const historyRuns = sessionHistoryRuns(snapshot);
 				const postReviewLanes = snapshot?.post_review_lanes ?? [];
 				const postReviewIssueKeys = new Set(postReviewLanes.flatMap(issueIdentityKeys));
-				const activeRunByIssue = new Map(activeRuns.map((run) => [run.issue_id, run]));
+				const activeRunByIssue = new Map();
+				for (const run of activeRuns) {
+					for (const key of issueIdentityKeys(run)) {
+						if (!activeRunByIssue.has(key)) {
+							activeRunByIssue.set(key, run);
+						}
+					}
+				}
 				const queuedCandidates = [...(snapshot?.queued_candidates ?? [])]
 					.map((candidate) => {
-						const activeRun = activeRunByIssue.get(candidate.issue_id);
+						const activeRun = issueIdentityKeys(candidate)
+							.map((key) => activeRunByIssue.get(key))
+							.find(Boolean);
 
-						if (activeRun && candidate.classification === "claimed") {
+						if (activeRun) {
 							return {
 								...candidate,
 								display_classification: "owned_active",
@@ -7509,7 +7518,6 @@
 				const queueBacklogCandidates = queuedCandidates.filter(
 					(candidate) =>
 						candidate.display_classification !== "owned_active" &&
-						candidate.classification !== "claimed" &&
 						candidate.classification !== "closed" &&
 						!issueMatchesKeySet(candidate, postReviewIssueKeys),
 				);

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -1319,7 +1319,6 @@ fn operator_dashboard_flow_counts_distinguish_intake_attention() {
 	assert!(response.contains("intakeAttentionCount"));
 	assert!(response.contains("queuedBlockedWithoutAttention"));
 	assert!(response.contains("attention.thread_status && attention.thread_status !== \"systemError\""));
-	assert!(response.contains("candidate.classification !== \"claimed\""));
 	assert!(response.contains("queueBacklogCandidates.filter(queuedCandidateNeedsAttention).length"));
 	assert!(response.contains(
 		"${pluralize(derived.postReviewLanes.length, \"PR\")} · ${pluralize(derived.reviewBlockerCount, \"needs attention\", \"need attention\")}"
@@ -1333,6 +1332,18 @@ fn operator_dashboard_flow_counts_distinguish_intake_attention() {
 	assert!(!response.contains("Ready, capacity-limited, or blocked issues appear here before they start."));
 	assert!(!response.contains("claimed without local lane"));
 	assert!(!response.contains("const repairCount = attentionItems.length;"));
+}
+
+#[test]
+fn operator_dashboard_does_not_hide_claimed_queue_without_local_lane() {
+	let response = dashboard_response();
+
+	assert!(response.contains("const activeRunByIssue = new Map();"));
+	assert!(response.contains("for (const key of issueIdentityKeys(run))"));
+	assert!(response.contains("const activeRun = issueIdentityKeys(candidate)"));
+	assert!(response.contains("if (activeRun) {"));
+	assert!(!response.contains("activeRun && candidate.classification === \"claimed\""));
+	assert!(!response.contains("candidate.classification !== \"claimed\" &&"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- keep claimed queue candidates visible when no local running lane matches them
- hide queue echoes for any matching active lane, even when WebSocket activity arrives before the next full snapshot
- add dashboard contract coverage for the claimed-without-local-lane case

## Validation
- cargo nextest run -p decodex operator_dashboard_does_not_hide_claimed_queue_without_local_lane
- cargo nextest run -p decodex operator_dashboard_flow_counts_distinguish_intake_attention
- cargo nextest run -p decodex live_operator_status_snapshot_excludes_claimed_candidates_from_waiting_intake_count
- cargo make checks