### PR TITLE
Treat pending land checks as wait

### DIFF
--- a/apps/decodex/src/manual.rs
+++ b/apps/decodex/src/manual.rs
@@ -806,6 +806,15 @@ fn validate_landing_state(
 	) {
 		eyre::bail!("Pull request `{pr_url}` has failed required checks that need repair.");
 	}
+
+	if let Some(other) = gate_view.status_check_rollup_state
+		&& pull_request::checks_require_wait(Some(other))
+	{
+		eyre::bail!(
+			"Pull request `{pr_url}` is still waiting on checks: statusCheckRollup=`{other}`."
+		);
+	}
+
 	if pull_request::mergeability_unknown(gate_view) {
 		eyre::bail!(
 			"Pull request `{pr_url}` mergeability is still unknown after retry; wait for GitHub to recompute mergeability and retry `decodex land`."
@@ -825,9 +834,6 @@ fn validate_landing_state(
 	}
 
 	match gate_view.status_check_rollup_state {
-		Some(other) if pull_request::checks_require_wait(Some(other)) => eyre::bail!(
-			"Pull request `{pr_url}` is still waiting on checks: statusCheckRollup=`{other}`."
-		),
 		Some("SUCCESS") | None => {
 			debug_assert!(pull_request::manual_landing_gates_satisfied(gate_view));
 
@@ -2107,6 +2113,27 @@ exit 1\n",
 
 		assert!(error.to_string().contains("mergeability is still unknown after retry"));
 		assert!(error.to_string().contains("retry `decodex land`"));
+	}
+
+	#[test]
+	fn landing_state_validation_treats_pending_checks_as_wait_even_when_merge_blocked() {
+		let mut landing_state = sample_landing_state();
+
+		landing_state.base_ref_name = String::from("main");
+		landing_state.merge_state_status = String::from("BLOCKED");
+		landing_state.status_check_rollup_state = Some(String::from("PENDING"));
+
+		let error = manual::validate_landing_state(
+			&landing_state,
+			"https://github.com/hack-ink/decodex/pull/64",
+			"main",
+			"XY-225",
+			"deadbeef",
+		)
+		.expect_err("pending checks should wait rather than report a generic blocked merge state");
+
+		assert!(error.to_string().contains("still waiting on checks"));
+		assert!(error.to_string().contains("statusCheckRollup=`PENDING`"));
 	}
 
 	#[test]

--- a/plugins/decodex/skills/land/SKILL.md
+++ b/plugins/decodex/skills/land/SKILL.md
@@ -28,8 +28,8 @@ with GitHub UI, `gh pr merge`, merge queue actions, raw `git`, or direct API mut
 
 ## Sequence
 
-1. Confirm the PR exists, the intended base and head are the ones being landed, and the
-   repository expects Decodex-owned landing.
+1. Confirm the PR exists, the intended base and head are the ones being landed, required
+   checks are green, and the repository expects Decodex-owned landing.
 2. Run `decodex land "<summary>"`.
 3. For a deliberate non-issue lane, run
    `decodex land --manual-authority --pr <URL> "<summary>"`.
@@ -52,6 +52,9 @@ but intentionally skips tracker closeout and active-label ownership checks.
 ## Fail-Closed Rules
 
 - If `decodex land` is required, it must run and succeed.
+- If `decodex land` reports that checks are still pending or expected, treat that as a
+  wait condition: keep the tracker issue in its retained review state, keep the active
+  ownership label in place, wait for CI, and retry `decodex land`.
 - Do not substitute `gh pr merge`, GitHub UI, merge queue, raw `git`, direct GitHub API
   mutation, or a hand-assembled merge for a failed or unavailable `decodex land`.
 - If GitHub merge already happened but `decodex land` stopped during closeout or


### PR DESCRIPTION
## Summary
- classify pending/expected land checks as an explicit wait condition before generic mergeStateStatus rejection
- document that pending checks must keep retained review state and active ownership until CI is green

## Validation
- cargo test -p decodex landing_state_validation -- --nocapture
- cargo test -p decodex pull_request::tests::landing_gates_handle_green_pending_and_review_request_cases -- --nocapture
- cargo make check