### PR TITLE
Remove dashboard issue author display

### DIFF
--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -5615,16 +5615,6 @@
 				return facts.map(([label, value]) => renderRunMetaFact(label, value)).join("");
 			}
 
-			function runAuthor(run) {
-				return String(run?.author || run?.issue_author || "").trim();
-			}
-
-			function renderRunAuthorInline(run) {
-				const author = runAuthor(run);
-
-				return author ? renderRunMetaFact("author", author) : "";
-			}
-
 			function codexAccount(run) {
 				const selected = run?.account || run?.codex_account || null;
 				if (selected) {
@@ -6497,7 +6487,6 @@
 
 				function renderRunMetaLine(run) {
 					const items = [
-						renderRunAuthorInline(run),
 						renderRunCodexAccountInline(run),
 						renderRunTelemetryMetaItems(run),
 					]
@@ -8605,7 +8594,6 @@
 										<summary>Debug Details</summary>
 									<div class="grid debug-grid">
 										${field("Run", run.run_id)}
-										${field("Author", runAuthor(run) || "none")}
 										${field("Attempt status", run.attempt_status || run.status)}
 										${field("Updated", formatTimestamp(run.updated_at))}
 										${field("Codex thread", runThreadSummary(run))}
@@ -9025,7 +9013,6 @@
 				for (const key of [
 					"issue_identifier",
 					"title",
-					"author",
 					"account",
 					"accounts",
 					"codex_account",

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -416,7 +416,8 @@ fn operator_dashboard_renders_account_usage_controls() {
 
 	assert!(response.contains("function codexAccount(run)"));
 	assert!(response.contains("function codexAccounts(run)"));
-	assert!(response.contains("function renderRunAuthorInline(run)"));
+	assert!(!response.contains("function runAuthor(run)"));
+	assert!(!response.contains("function renderRunAuthorInline(run)"));
 	assert!(response.contains("function codexAccountDisplayName(account)"));
 	assert!(response.contains("function codexAccountTokenLabel(refreshStatus)"));
 	assert!(response.contains("function codexAccountWindowLabel(seconds)"));
@@ -1497,7 +1498,8 @@ fn operator_dashboard_run_activity_preserves_snapshot_detail_fields() {
 	assert!(response.contains("function snapshotWithLiveRunActivity(snapshot)"));
 	assert!(response.contains("\"issue_identifier\""));
 	assert!(response.contains("\"title\""));
-	assert!(response.contains("\"author\""));
+	assert!(!response.contains("field(\"Author\","));
+	assert!(!response.contains("\"author\",\n"));
 	assert!(response.contains("\"child_agent_activity\""));
 	assert!(response.contains("\"protocol_activity\""));
 	assert!(response.contains("!dashboardRunFieldHasValue(activityRun[key])"));


### PR DESCRIPTION
## Summary
- Remove tracker issue author from the operator dashboard run metadata and debug details.
- Keep Codex account identity display on the existing alias/email privacy switch.
- Stop live run activity patches from reintroducing snapshot-only author data into the UI merge path.

## Verification
- cargo +nightly fmt --all -- --check
- cargo nextest run -p decodex --all-targets --all-features operator_dashboard
- git diff --check