### PR TITLE
Use compact account fallback placeholders

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -791,7 +791,7 @@ struct AccountUsageMeterView: View {
 
 	private var remainingText: String {
 		guard let remainingPercent else {
-			return "n/a"
+			return "-"
 		}
 
 		return "\(remainingPercent)%"
@@ -878,9 +878,9 @@ private struct UsageResetDisplay {
 	static func make(resetAtUnixEpoch: Int?) -> UsageResetDisplay {
 		guard let seconds = resetAtUnixEpoch, seconds > 0 else {
 			return UsageResetDisplay(
-				short: "not reported",
+				short: "-",
 				date: "",
-				accessibility: "reset not reported"
+				accessibility: "reset unavailable"
 			)
 		}
 

--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -6139,7 +6139,7 @@
 				}
 
 				function codexAccountPlanLabel(account) {
-					return account?.plan_type ? humanizeToken(account.plan_type) : "not reported";
+					return account?.plan_type ? humanizeToken(account.plan_type) : "-";
 				}
 
 				function codexAccountTokenLabel(refreshStatus) {
@@ -6297,9 +6297,9 @@
 					const distance = codexAccountResetDistance(data.resetAt);
 					if (resetAt === "unknown" && distance.short === "unknown") {
 						return {
-							short: "not reported",
+							short: "-",
 							date: "",
-							aria: "reset not reported",
+							aria: "reset unavailable",
 						};
 					}
 
@@ -6445,7 +6445,7 @@
 						return balance;
 					}
 					if (account.credits_has_credits === true) {
-						return "not reported";
+						return "-";
 					}
 
 					return null;
@@ -6515,18 +6515,18 @@
 					const data = codexAccountWindowData(account, prefix);
 					const label = codexAccountWindowLabel(data.windowSeconds);
 					const remaining =
-						data.remainingPercent == null ? "not reported" : `${data.remainingPercent}%`;
+						data.remainingPercent == null ? "-" : `${data.remainingPercent}%`;
 					const reset = codexAccountResetDisplay(data);
 					const windowTone = codexAccountWindowTone(data.remainingPercent);
 					const toneClass = windowTone ? ` is-${windowTone}` : "";
-					const isUnreported = data.remainingPercent == null && reset.short === "not reported";
+					const isUnreported = data.remainingPercent == null && reset.short === "-";
 					const resetTitle = `${label} ${remaining}, ${reset.aria}`;
 
 					if (isUnreported) {
 						return `
-							<div class="account-window is-${escapeHtml(prefix)}${toneClass}" aria-label="${escapeHtml(label)} usage not reported" title="${escapeHtml(resetTitle)}">
+							<div class="account-window is-${escapeHtml(prefix)}${toneClass}" aria-label="${escapeHtml(label)} usage unavailable" title="${escapeHtml(resetTitle)}">
 								<span class="account-window-label" aria-hidden="true">${escapeHtml(label)}</span>
-								<strong>not reported</strong>
+								<strong>-</strong>
 							</div>
 						`;
 					}
@@ -6570,7 +6570,7 @@
 							${renderCodexAccountPoolWindow(account, "secondary")}
 							<div class="account-row-credit${creditClass}">
 								<span>credits</span>
-								<strong>${escapeHtml(credits || "not reported")}</strong>
+								<strong>${escapeHtml(credits || "-")}</strong>
 							</div>
 							<div class="account-row-state">
 								<strong class="account-status">${escapeHtml(codexAccountStatusLabel(account))}</strong>

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -791,7 +791,7 @@ fn operator_dashboard_accounts_keeps_identity_rows_compact() {
 	assert!(response.contains("text-align: center;"));
 	assert!(response.contains("function codexAccountPlanLabel(account)"));
 	assert!(response.contains(
-		"return account?.plan_type ? humanizeToken(account.plan_type) : \"not reported\";"
+		"return account?.plan_type ? humanizeToken(account.plan_type) : \"-\";"
 	));
 	assert!(response.contains("const plan = codexAccountPlanLabel(account);"));
 	assert!(response.contains("const identityClass = codexAccountShowsEmail(account) ? \" is-machine\" : \"\";"));
@@ -921,7 +921,7 @@ fn operator_dashboard_accounts_keeps_debug_credit_and_reset_copy_compact() {
 	assert!(response.contains("const credits = codexAccountCreditsSummary(account);"));
 	assert!(response.contains("const creditTone = codexAccountCreditsTone(account);"));
 	assert!(response.contains("<span>credits</span>"));
-	assert!(response.contains("<strong>${escapeHtml(credits || \"not reported\")}</strong>"));
+	assert!(response.contains("<strong>${escapeHtml(credits || \"-\")}</strong>"));
 
 	let account_credit_index = response
 		.find("<div class=\"account-row-credit${creditClass}\">")
@@ -937,7 +937,7 @@ fn operator_dashboard_accounts_keeps_debug_credit_and_reset_copy_compact() {
 	assert!(response.contains("return \"Ready\";"));
 	assert!(response.contains("return \"Refresh failed\";"));
 	assert!(response.contains("return codexAccountTokenValue(account.refresh_status);"));
-	assert!(response.contains("return \"not reported\";"));
+	assert!(response.contains("return \"-\";"));
 	assert!(!response.contains("depleted"));
 	assert!(response.contains("rate_limit_reached_type"));
 	assert!(response.contains("if (normalizedStatus === \"available\")"));
@@ -957,10 +957,10 @@ fn operator_dashboard_accounts_keeps_debug_credit_and_reset_copy_compact() {
 	assert!(response.contains("return { short, phrase: `resets in ${short}`, isPast: false };"));
 	assert!(response.contains("date: \"\","));
 	assert!(response.contains("date: resetAt,"));
-	assert!(response.contains("aria: \"reset not reported\","));
+	assert!(response.contains("aria: \"reset unavailable\","));
 	assert!(response.contains("reset at ${resetAt}, ${distance.phrase}"));
-	assert!(response.contains("data.remainingPercent == null ? \"not reported\" : `${data.remainingPercent}%`;"));
-	assert!(response.contains("aria-label=\"${escapeHtml(label)} usage not reported\""));
+	assert!(response.contains("data.remainingPercent == null ? \"-\" : `${data.remainingPercent}%`;"));
+	assert!(response.contains("aria-label=\"${escapeHtml(label)} usage unavailable\""));
 	assert!(response.contains("const resetTitle = `${label} ${remaining}, ${reset.aria}`;"));
 	assert!(response.contains("<span class=\"account-window-reset\">${escapeHtml(reset.short)}</span>"));
 	assert!(response.contains("${reset.date ? `<span class=\"account-window-date\">${escapeHtml(reset.date)}</span>` : \"\"}"));


### PR DESCRIPTION
## Summary
- Render missing account plan, usage, reset, and credits data with `-` instead of long fallback labels
- Keep accessibility labels explicit with unavailable wording
- Update dashboard string assertions for the new compact placeholders

## Verification
- `cargo test -p decodex operator_dashboard_accounts`
- `swift build --package-path apps/decodex-app`
- `cargo make fmt-rust-check`
- `git diff --check`
- semantic drift helper: no docs changes or stale phrase hits