### PR TITLE
Fix Decodex dashboard project activity state

### DIFF
--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -8098,10 +8098,8 @@
 					(project.cleanup_blocked_count ?? 0) +
 					(project.cleanup_pending_count ?? 0) +
 					(project.post_review_lane_count ?? 0);
-				const connector = projectConnectorSummary(project);
-				const syncNeedsAttention = project.enabled && ["backoff", "degraded", "stale"].includes(connector);
 
-				return workCount > 0 || (project.warning_count ?? 0) > 0 || syncNeedsAttention;
+				return workCount > 0;
 			}
 
 			function activeProjects(projects) {
@@ -8124,6 +8122,9 @@
 				if ((project.cleanup_blocked_count ?? 0) > 0) {
 					return { label: "cleanup blocked", tone: "tone-wait", title: "Post-land cleanup needs operator action" };
 				}
+				if ((project.cleanup_pending_count ?? 0) > 0) {
+					return { label: "cleanup pending", tone: "tone-retained", title: "Post-land cleanup pending" };
+				}
 				if (project.connector_state === "backoff") {
 					return {
 						label: "sync backoff",
@@ -8135,14 +8136,7 @@
 					(project.warning_count ?? 0) > 0 ||
 					["degraded", "stale_cache"].includes(project.connector_state)
 				) {
-					if ((project.cleanup_pending_count ?? 0) > 0) {
-						return { label: "cleanup pending", tone: "tone-retained", title: "Post-land cleanup pending" };
-					}
-
-					return { label: "sync degraded", tone: "tone-wait", title: "Tracker sync or retry state degraded" };
-				}
-				if ((project.cleanup_pending_count ?? 0) > 0) {
-					return { label: "cleanup pending", tone: "tone-retained", title: "Post-land cleanup pending" };
+					return { label: "sync degraded", tone: "tone-muted", title: "Tracker sync or retry state degraded" };
 				}
 
 				return { label: "ok", tone: "tone-ready", title: "No project warnings" };
@@ -8458,13 +8452,13 @@
 				if ((project.cleanup_pending_count ?? 0) > 0) {
 					return 4;
 				}
-				if (["backoff", "degraded", "stale_cache"].includes(project.connector_state)) {
+				if (projectHasActiveWork(project)) {
 					return 5;
 				}
-				if ((project.warning_count ?? 0) > 0) {
+				if (["backoff", "degraded", "stale_cache"].includes(project.connector_state)) {
 					return 6;
 				}
-				if (projectHasActiveWork(project)) {
+				if ((project.warning_count ?? 0) > 0) {
 					return 7;
 				}
 

--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -9165,7 +9165,7 @@
 			function recoveryWorktreeShouldDefaultOpen(renderedWorktree) {
 				const role = renderedWorktree.role;
 
-				return role.tone === "tone-blocked" || role.label.includes("cleanup");
+				return role.tone === "tone-blocked";
 			}
 
 			function renderWorktrees(snapshot) {

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -1140,7 +1140,8 @@ fn operator_dashboard_projects_show_compact_activity_work_and_location() {
 	assert!(response.contains("return projects.filter(projectHasActiveWork);"));
 	assert!(response.contains("project.queued_candidate_count ?? 0"));
 	assert!(response.contains("project.post_review_lane_count ?? 0"));
-	assert!(response.contains("return workCount > 0 || (project.warning_count ?? 0) > 0 || syncNeedsAttention;"));
+	assert!(response.contains("return workCount > 0;"));
+	assert!(!response.contains("syncNeedsAttention"));
 	assert!(!response.contains("project.retained_worktree_count ?? 0);"));
 	assert!(!response.contains("projectHasRecentActivity(project)"));
 	assert!(response.contains("class=\"project-activity\""));
@@ -1157,6 +1158,7 @@ fn operator_dashboard_projects_show_compact_activity_work_and_location() {
 	assert!(response.contains("return { label: \"cleanup pending\", tone: \"tone-retained\""));
 	assert!(response.contains("label: \"sync backoff\""));
 	assert!(response.contains("label: \"sync degraded\""));
+	assert!(response.contains("label: \"sync degraded\", tone: \"tone-muted\""));
 	assert!(response.contains("return { label: \"ok\", tone: \"tone-ready\""));
 	assert!(!response.contains("function projectSyncMeta(project, health)"));
 	assert!(!response.contains("const connectorCopy = projectSyncMeta(project, health);"));

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -1326,7 +1326,8 @@ fn operator_dashboard_flow_counts_distinguish_intake_attention() {
 	assert!(response.contains("? pluralize(retainedWorktrees.length, \"worktree\")"));
 	assert!(!response.contains("retained or cleanup"));
 	assert!(response.contains("function recoveryWorktreeShouldDefaultOpen(renderedWorktree)"));
-	assert!(response.contains("role.tone === \"tone-blocked\" || role.label.includes(\"cleanup\")"));
+	assert!(response.contains("role.tone === \"tone-blocked\""));
+	assert!(!response.contains("role.label.includes(\"cleanup\")"));
 	assert!(response.contains("label: isDirty ? \"post-review cleanup blocked\" : \"post-review cleanup\""));
 	assert!(response.contains("retainedWorktrees.some(recoveryWorktreeShouldDefaultOpen)"));
 	assert!(!response.contains("syncDefaultDetailOpenState(nodes.panels.worktrees, retainedWorktrees.length > 0);"));


### PR DESCRIPTION
## Summary

- fold recovery worktrees by default unless they are actually blocked
- make the Projects active filter count only real work, not warning/degraded connector state
- render no-work sync degraded projects as muted instead of warning-yellow

## Verification

- cargo test -p decodex --all-features operator_dashboard
- cargo +nightly fmt --all -- --check
- git diff --check
- vstyle curate --language rust --workspace --all-features
- served updated dashboard HTML on 127.0.0.1:8913 and confirmed the new JS is present
- read 127.0.0.1:8912 live dashboard snapshot: all listed projects had work=0, warning=1, connector=degraded, matching the reported filter/color symptom
