### PR TITLE
Use neutral placeholder for unknown account usage

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -1737,7 +1737,7 @@ private extension CodexAccount {
 		case "usage_limited":
 			return "Limited"
 		case "probe_failed":
-			return "Usage unknown"
+			return "-"
 		case "expired":
 			return "Refresh needed"
 		case "disabled":

--- a/apps/decodex-app/Sources/DecodexApp/Models.swift
+++ b/apps/decodex-app/Sources/DecodexApp/Models.swift
@@ -138,7 +138,7 @@ struct CodexAccount: Decodable, Identifiable, Equatable {
 		switch status {
 		case "available": return "Ready"
 		case "usage_limited": return "Limited"
-		case "probe_failed": return "Usage unknown"
+		case "probe_failed": return "-"
 		case "expired": return "Refresh needed"
 		case "disabled": return "Disabled"
 		case "cooldown": return "Cooling"
@@ -152,7 +152,7 @@ struct CodexAccount: Decodable, Identifiable, Equatable {
 			return .danger
 		}
 		if status == "probe_failed" {
-			return .warning
+			return .neutral
 		}
 		if codexActive {
 			return .codexActive


### PR DESCRIPTION
## Summary
- render account `probe_failed` status as `-` instead of `Usage unknown`
- keep unknown usage in the neutral text tone instead of warning color

## Validation
- `swift build --package-path apps/decodex-app`
- `cargo +nightly fmt --all -- --check`
- `cargo make test-decodex-app-stage`
- local app restarted against full `decodex serve`; current accounts report `usage probe ok`
