### PR TITLE
XY-565: Harden Decodex tracker summary validation so completed lanes do not fail at public writeback

### DIFF
--- a/apps/decodex/src/agent/tracker_tool_bridge.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge.rs
@@ -2,6 +2,7 @@ mod review;
 mod tools;
 
 use std::{
+	borrow::Cow,
 	cell::RefCell,
 	env,
 	error::Error,
@@ -22,7 +23,10 @@ use crate::{
 	github,
 	prelude::eyre,
 	state::StateStore,
-	tracker::{IssueTracker, TrackerIssue, privacy_classifier::PublicProjectionPrivacyClassifier},
+	tracker::{
+		IssueTracker, TrackerIssue, privacy_classifier::PublicProjectionPrivacyClassifier,
+		public_text,
+	},
 	workflow::WorkflowDocument,
 };
 
@@ -37,6 +41,11 @@ pub(crate) const ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME: &str = "issue_close
 pub(crate) const ISSUE_TERMINAL_FINALIZE_TOOL_NAME: &str = "issue_terminal_finalize";
 
 const REVIEW_POLICY_CONVERGENCE_BUDGET: i64 = 3;
+const REVIEW_HANDOFF_PUBLIC_SUMMARY_FALLBACK: &str =
+	"Implementation completed and the PR is ready for review.";
+const REVIEW_REPAIR_PUBLIC_SUMMARY_FALLBACK: &str =
+	"Review repair completed and the PR is ready for fresh review.";
+const CLOSEOUT_PUBLIC_SUMMARY_FALLBACK: &str = "Retained closeout completed for the merged PR.";
 
 static GH_PULL_REQUEST_INSPECTOR: GhPullRequestInspector = GhPullRequestInspector;
 static LOCAL_GIT_REPO_INSPECTOR: LocalGitRepoInspector = LocalGitRepoInspector;
@@ -1184,9 +1193,18 @@ fn normalize_optional_progress_field(value: Option<String>) -> Option<String> {
 	})
 }
 
+fn public_summary_or_fallback<'a>(summary: &'a str, fallback: &'static str) -> Cow<'a, str> {
+	if public_text::validate_public_text_field("summary", summary).is_ok() {
+		Cow::Borrowed(summary)
+	} else {
+		Cow::Borrowed(fallback)
+	}
+}
+
 fn format_review_handoff_comment(
 	review_context: &ReviewHandoffContext,
 	pending_review_handoff: &PendingReviewAction,
+	summary: &str,
 ) -> String {
 	format!(
 		"decodex run completed and is ready for review\n\n- run_id: `{run_id}`\n- attempt: `{attempt}`\n- finished_at: `{finished_at}`\n- branch: `{branch}`\n- pr_url: `{pr_url}`\n- worktree_path: `{worktree_path}`\n- validation_result: `passed`\n- summary: {summary}",
@@ -1196,13 +1214,14 @@ fn format_review_handoff_comment(
 		branch = review_context.branch_name,
 		pr_url = pending_review_handoff.pr_url,
 		worktree_path = review_context.worktree_path,
-		summary = pending_review_handoff.summary,
+		summary = summary,
 	)
 }
 
 fn format_review_repair_comment(
 	review_context: &ReviewHandoffContext,
 	pending_review_repair: &PendingReviewAction,
+	summary: &str,
 ) -> String {
 	format!(
 		"decodex review repair completed and requested fresh review\n\n- run_id: `{run_id}`\n- attempt: `{attempt}`\n- finished_at: `{finished_at}`\n- branch: `{branch}`\n- pr_url: `{pr_url}`\n- worktree_path: `{worktree_path}`\n- validation_result: `passed`\n- summary: {summary}",
@@ -1212,7 +1231,7 @@ fn format_review_repair_comment(
 		branch = review_context.branch_name,
 		pr_url = pending_review_repair.pr_url,
 		worktree_path = review_context.worktree_path,
-		summary = pending_review_repair.summary,
+		summary = summary,
 	)
 }
 

--- a/apps/decodex/src/agent/tracker_tool_bridge/review.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/review.rs
@@ -2,10 +2,12 @@ use color_eyre::Report;
 
 use crate::{
 	agent::tracker_tool_bridge::{
-		self, ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME, ISSUE_PROGRESS_CHECKPOINT_TOOL_NAME,
-		ISSUE_REVIEW_HANDOFF_TOOL_NAME, ISSUE_REVIEW_REPAIR_COMPLETE_TOOL_NAME,
-		ISSUE_TRANSITION_TOOL_NAME, LocalRepoDetails, PendingReviewCompletion, PullRequestDetails,
-		REVIEW_POLICY_CONVERGENCE_BUDGET, ReviewExecutionMode, ReviewHandoffContext,
+		self, CLOSEOUT_PUBLIC_SUMMARY_FALLBACK, ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME,
+		ISSUE_PROGRESS_CHECKPOINT_TOOL_NAME, ISSUE_REVIEW_HANDOFF_TOOL_NAME,
+		ISSUE_REVIEW_REPAIR_COMPLETE_TOOL_NAME, ISSUE_TRANSITION_TOOL_NAME, LocalRepoDetails,
+		PendingReviewAction, PendingReviewCompletion, PullRequestDetails,
+		REVIEW_HANDOFF_PUBLIC_SUMMARY_FALLBACK, REVIEW_POLICY_CONVERGENCE_BUDGET,
+		REVIEW_REPAIR_PUBLIC_SUMMARY_FALLBACK, ReviewExecutionMode, ReviewHandoffContext,
 		ReviewHandoffWritebackFailed, ReviewPolicyPhase, ReviewPolicyState, ReviewPolicyStatus,
 		ReviewPolicyStopReason, ReviewPolicyStopRequested, RunCompletionDisposition, ScopeArgs,
 		TrackerToolBridge,
@@ -14,7 +16,7 @@ use crate::{
 	state::{self, ReviewHandoffMarker, ReviewOrchestrationMarker},
 	tracker::{
 		self, TrackerIssue,
-		records::{self},
+		records::{self, LinearExecutionEventPublicProjection},
 	},
 };
 
@@ -414,23 +416,6 @@ impl<'a> TrackerToolBridge<'a> {
 		let pull_request = self
 			.validate_review_action_pr(review_context, &pending_review_handoff.pr_url)
 			.map_err(|error| eyre::eyre!(error))?;
-		let completion_comment = tracker_tool_bridge::format_review_handoff_comment(
-			review_context,
-			&pending_review_handoff,
-		);
-		let handoff_record = linear_execution_review_event(
-			self.issue,
-			review_context,
-			&pull_request,
-			"review_handoff",
-			"review_handoff",
-			&pending_review_handoff.summary,
-		);
-		let projection = tracker::prepare_linear_execution_event_comment(
-			&completion_comment,
-			&handoff_record,
-			self.public_projection_privacy_classifier,
-		)?;
 		let success_state = self.workflow.frontmatter().tracker().success_state();
 		let success_state_id = self.issue.state_id_for_name(success_state).ok_or_else(|| {
 			eyre::eyre!(
@@ -438,6 +423,12 @@ impl<'a> TrackerToolBridge<'a> {
 				self.issue.identifier
 			)
 		})?;
+		let projection = self.prepare_review_handoff_projection(
+			review_context,
+			&pending_review_handoff,
+			&pull_request,
+			success_state,
+		)?;
 		let handoff_marker = ReviewHandoffMarker::new(
 			review_context.run_id.clone(),
 			review_context.attempt_number,
@@ -499,6 +490,47 @@ impl<'a> TrackerToolBridge<'a> {
 		Ok(())
 	}
 
+	fn prepare_review_handoff_projection(
+		&self,
+		review_context: &ReviewHandoffContext,
+		pending_review_handoff: &PendingReviewAction,
+		pull_request: &PullRequestDetails,
+		success_state: &str,
+	) -> crate::prelude::Result<LinearExecutionEventPublicProjection> {
+		let public_summary = tracker_tool_bridge::public_summary_or_fallback(
+			&pending_review_handoff.summary,
+			REVIEW_HANDOFF_PUBLIC_SUMMARY_FALLBACK,
+		);
+		let completion_comment = tracker_tool_bridge::format_review_handoff_comment(
+			review_context,
+			pending_review_handoff,
+			public_summary.as_ref(),
+		);
+		let handoff_record = linear_execution_review_event(
+			self.issue,
+			review_context,
+			pull_request,
+			"review_handoff",
+			"review_handoff",
+			public_summary.as_ref(),
+		);
+
+		tracker::prepare_linear_execution_event_comment(
+			&completion_comment,
+			&handoff_record,
+			self.public_projection_privacy_classifier,
+		)
+		.map_err(|error| {
+			Report::new(ReviewHandoffWritebackFailed {
+				issue_identifier: self.issue.identifier.clone(),
+				run_id: review_context.run_id.clone(),
+				pr_url: pull_request.url.clone(),
+				success_state: success_state.to_owned(),
+				source: format!("failed to prepare the tracker review handoff record: {error}"),
+			})
+		})
+	}
+
 	pub(crate) fn apply_review_repair(&self) -> crate::prelude::Result<()> {
 		let Some(review_context) = self.review_context.as_ref() else {
 			eyre::bail!(
@@ -523,9 +555,14 @@ impl<'a> TrackerToolBridge<'a> {
 		let pull_request = self
 			.validate_review_action_pr(review_context, &pending_review_repair.pr_url)
 			.map_err(|error| eyre::eyre!(error))?;
+		let public_summary = tracker_tool_bridge::public_summary_or_fallback(
+			&pending_review_repair.summary,
+			REVIEW_REPAIR_PUBLIC_SUMMARY_FALLBACK,
+		);
 		let completion_comment = tracker_tool_bridge::format_review_repair_comment(
 			review_context,
 			&pending_review_repair,
+			public_summary.as_ref(),
 		);
 		let handoff_record = linear_execution_review_event(
 			self.issue,
@@ -533,7 +570,7 @@ impl<'a> TrackerToolBridge<'a> {
 			&pull_request,
 			"repair_handoff",
 			"review_repair",
-			&pending_review_repair.summary,
+			public_summary.as_ref(),
 		);
 		let review_handoff = ReviewHandoffMarker::new(
 			review_context.run_id.clone(),
@@ -701,8 +738,16 @@ impl<'a> TrackerToolBridge<'a> {
 			self.validate_closeout_issue_completed_state().map_err(|error| eyre::eyre!(error))?;
 		}
 
-		let closeout_record =
-			linear_execution_closeout_event(self.issue, review_context, &pull_request, summary);
+		let public_summary = tracker_tool_bridge::public_summary_or_fallback(
+			summary,
+			CLOSEOUT_PUBLIC_SUMMARY_FALLBACK,
+		);
+		let closeout_record = linear_execution_closeout_event(
+			self.issue,
+			review_context,
+			&pull_request,
+			public_summary.as_ref(),
+		);
 		let closeout_comment = format!(
 			"decodex closeout completed\n\n- run_id: `{}`\n- attempt: `{}`\n- finished_at: `{}`\n- branch: `{}`\n- pr_url: `{}`\n- worktree_path: `{}`\n- summary: {}",
 			review_context.run_id,
@@ -711,7 +756,7 @@ impl<'a> TrackerToolBridge<'a> {
 			review_context.branch_name,
 			pull_request.url,
 			review_context.worktree_path,
-			summary,
+			public_summary,
 		);
 		let projection = tracker::prepare_linear_execution_event_comment(
 			&closeout_comment,

--- a/apps/decodex/src/agent/tracker_tool_bridge/tests/review/handoff.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests/review/handoff.rs
@@ -528,6 +528,151 @@ fn reports_review_handoff_writeback_failure_when_tracker_comment_write_fails() {
 }
 
 #[test]
+fn review_handoff_writeback_replaces_private_summary_with_public_fallback() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let tracker = FakeTracker::new();
+	let issue = sample_issue();
+	let workflow = sample_workflow();
+	let pull_request = PullRequestDetails {
+		head_ref_name: String::from("x/decodex-pub-618"),
+		head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
+		head_repository_name: String::from("decodex"),
+		head_repository_owner: String::from("hack-ink"),
+		is_draft: false,
+		state: String::from("OPEN"),
+		base_ref_name: String::from("main"),
+		url: String::from("https://github.com/hack-ink/decodex/pull/151"),
+	};
+	let inspector = FakePullRequestInspector::new(vec![
+		Ok(pull_request.clone()),
+		Ok(pull_request.clone()),
+	]);
+	let local_repo_inspector =
+		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
+	let review_context = sample_review_context_in(temp_dir.path());
+	let bridge = TrackerToolBridge::with_review_handoff_for_test(
+		&tracker,
+		&issue,
+		&workflow,
+		review_context.clone(),
+		&inspector,
+		&local_repo_inspector,
+	);
+
+	write_clean_review_checkpoint(&review_context);
+
+	let response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_REVIEW_HANDOFF_TOOL_NAME,
+		serde_json::json!({
+			"pr_url": pull_request.url,
+			"summary": "Completed from /Users/example/repo with GITHUB_PAT_Y configured."
+		}),
+	);
+
+	assert!(response.success);
+
+	bridge.apply_review_handoff().expect("private-looking summaries should use fallback text");
+
+	let comments = tracker.comments.borrow();
+	let comment = comments.first().expect("review handoff comment should write");
+
+	assert!(comment.contains("Implementation completed and the PR is ready for review."));
+	assert!(!comment.contains("/Users/example/repo"));
+	assert!(!comment.contains("GITHUB_PAT_Y"));
+
+	let record = records::parse_linear_execution_event_record(comment)
+		.expect("review handoff should write a valid Linear execution event");
+
+	assert_eq!(
+		record.summary.as_deref(),
+		Some("Implementation completed and the PR is ready for review.")
+	);
+	assert_eq!(
+		record.pr_url.as_deref(),
+		Some("https://github.com/hack-ink/decodex/pull/151")
+	);
+}
+
+#[test]
+fn review_handoff_validation_failure_reports_recoverable_writeback_with_pr_url() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let tracker = FakeTracker::new();
+	let issue = sample_issue();
+	let workflow = sample_workflow();
+	let pull_request = PullRequestDetails {
+		head_ref_name: String::from("x/decodex-pub-618"),
+		head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
+		head_repository_name: String::from("decodex"),
+		head_repository_owner: String::from("hack-ink"),
+		is_draft: false,
+		state: String::from("OPEN"),
+		base_ref_name: String::from("main"),
+		url: String::from("https://github.com/hack-ink/decodex/pull/152"),
+	};
+	let inspector = FakePullRequestInspector::new(vec![
+		Ok(pull_request.clone()),
+		Ok(pull_request.clone()),
+	]);
+	let local_repo_inspector =
+		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
+	let mut review_context = sample_review_context_in(temp_dir.path());
+
+	review_context.worktree_path =
+		String::from("/Users/example/repo/.worktrees/PUB-618");
+
+	let bridge = TrackerToolBridge::with_review_handoff_for_test(
+		&tracker,
+		&issue,
+		&workflow,
+		review_context.clone(),
+		&inspector,
+		&local_repo_inspector,
+	);
+
+	write_clean_review_checkpoint(&review_context);
+
+	let response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_REVIEW_HANDOFF_TOOL_NAME,
+		serde_json::json!({
+			"pr_url": pull_request.url,
+			"summary": "Ready for review."
+		}),
+	);
+
+	assert!(response.success);
+
+	let error = bridge
+		.apply_review_handoff()
+		.expect_err("remaining public writeback validation failures should be recoverable");
+	let writeback_error = error
+		.downcast_ref::<ReviewHandoffWritebackFailed>()
+		.expect("validation failure should use dedicated writeback error type");
+
+	assert_eq!(
+		writeback_error.pr_url,
+		"https://github.com/hack-ink/decodex/pull/152"
+	);
+	assert_eq!(writeback_error.success_state, "In Review");
+	assert!(writeback_error.source.contains("failed to prepare the tracker review handoff record"));
+	assert!(
+		writeback_error.source.contains("public/team-visible")
+			|| writeback_error.source.contains("repository-relative"),
+		"unexpected writeback source: {}",
+		writeback_error.source
+	);
+	assert!(tracker.comments.borrow().is_empty());
+	assert!(tracker.state_updates.borrow().is_empty());
+	assert!(
+		bridge_state_store(&bridge)
+			.review_handoff_marker(TEST_SERVICE_ID, &issue.id, "x/decodex-pub-618")
+			.expect("runtime handoff marker read should succeed")
+			.is_none()
+	);
+}
+
+#[test]
 fn review_handoff_persists_runtime_state_without_local_marker_cache() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();

--- a/apps/decodex/src/orchestrator/execution.rs
+++ b/apps/decodex/src/orchestrator/execution.rs
@@ -32,6 +32,7 @@ impl Drop for AgentGitCredentialEnvironment {
 struct TerminalFailureLifecycle<'a> {
 	error_class: &'a str,
 	next_action: &'a str,
+	pr_url: Option<&'a str>,
 	target_state: &'a str,
 	worktree_path: &'a str,
 	manual_attention_requested: bool,
@@ -370,6 +371,7 @@ fn terminal_failure_lifecycle_event(
 		issue_run.attempt_number
 	)]);
 	record.summary = Some(String::from("Decodex run failed and needs attention."));
+	record.pr_url = failure.pr_url.map(ToOwned::to_owned);
 	record.target_state = Some(failure.target_state.to_owned());
 
 	if failure.manual_attention_requested {
@@ -843,6 +845,7 @@ where
 				{
 					Report::new(ReviewHandoffNeedsAttention {
 						issue_identifier: writeback_error.issue_identifier.clone(),
+						pr_url: writeback_error.pr_url.clone(),
 						run_id: writeback_error.run_id.clone(),
 					})
 					.wrap_err(error)
@@ -1297,11 +1300,13 @@ where
 	);
 	let (error_class, next_action) =
 		terminal_failure_comment_details(manual_attention_requested, error, &recovery_gate);
+	let pr_url = terminal_failure_pr_url(error);
 	let comment = format_terminal_failure_comment(
 		&issue_run.run_id,
 		issue_run.attempt_number,
 		worktree_path.to_owned(),
 		&issue_run.worktree.branch_name,
+		pr_url,
 		error_class,
 		&next_action,
 	);
@@ -1311,6 +1316,7 @@ where
 		TerminalFailureLifecycle {
 			error_class,
 			next_action: &next_action,
+			pr_url,
 			target_state: terminal_failure_state_name,
 			worktree_path,
 			manual_attention_requested,

--- a/apps/decodex/src/orchestrator/selection.rs
+++ b/apps/decodex/src/orchestrator/selection.rs
@@ -149,15 +149,22 @@ fn format_terminal_failure_comment(
 	attempt_number: i64,
 	worktree_path: String,
 	branch_name: &str,
+	pr_url: Option<&str>,
 	error_class: &str,
 	next_action: &str,
 ) -> String {
+	let pr_url_line = pr_url.map_or_else(String::new, |pr_url| format!("\n- pr_url: `{pr_url}`"));
+
 	format!(
-		"decodex run failed and needs attention\n\n- run_id: `{run_id}`\n- attempt: `{attempt_number}`\n- failed_at: `{failed_at}`\n- branch: `{branch}`\n- worktree_path: `{worktree}`\n- error_class: `{error_class}`\n- next_action: `{next_action}`\n- error_summary: `Sensitive runtime details were withheld from the tracker comment; inspect the local lane for the full failure context.`",
+		"decodex run failed and needs attention\n\n- run_id: `{run_id}`\n- attempt: `{attempt_number}`\n- failed_at: `{failed_at}`\n- branch: `{branch}`{pr_url_line}\n- worktree_path: `{worktree}`\n- error_class: `{error_class}`\n- next_action: `{next_action}`\n- error_summary: `Sensitive runtime details were withheld from the tracker comment; inspect the local lane for the full failure context.`",
 		failed_at = current_timestamp(),
 		branch = branch_name,
 		worktree = worktree_path
 	)
+}
+
+fn terminal_failure_pr_url(error: &Report) -> Option<&str> {
+	error.downcast_ref::<ReviewHandoffNeedsAttention>().map(|error| error.pr_url.as_str())
 }
 
 fn terminal_failure_comment_details(

--- a/apps/decodex/src/orchestrator/tests/runtime/failure.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/failure.rs
@@ -59,6 +59,7 @@ fn terminal_failure_comments_surface_actionable_error_classes() {
 			1,
 			String::from(".worktrees/PUB-101"),
 			"x/pubfi-pub-101",
+			None,
 			error_class,
 			next_action,
 		);
@@ -70,6 +71,23 @@ fn terminal_failure_comments_surface_actionable_error_classes() {
 			assert!(comment.contains(expected_snippet), "{error_class} missing {expected_snippet}");
 		}
 	}
+}
+
+#[test]
+fn terminal_failure_comments_surface_review_handoff_pr_url_when_available() {
+	let pr_url = "https://github.com/hack-ink/decodex/pull/101";
+	let comment = orchestrator::format_terminal_failure_comment(
+		"pub-101-attempt-1-123",
+		1,
+		String::from(".worktrees/PUB-101"),
+		"x/pubfi-pub-101",
+		Some(pr_url),
+		"review_handoff_writeback_failed",
+		"repair the incomplete review handoff manually",
+	);
+
+	assert!(comment.contains(&format!("- pr_url: `{pr_url}`")));
+	assert!(comment.contains("- error_class: `review_handoff_writeback_failed`"));
 }
 
 #[test]
@@ -249,6 +267,7 @@ fn review_policy_terminal_failure_comments_use_runtime_owned_error_classes() {
 			1,
 			String::from(".worktrees/PUB-101"),
 			"x/pubfi-pub-101",
+			None,
 			error_class,
 			next_action,
 		);

--- a/apps/decodex/src/orchestrator/types.rs
+++ b/apps/decodex/src/orchestrator/types.rs
@@ -347,14 +347,15 @@ impl Error for ManualAttentionRequested {}
 #[derive(Debug)]
 struct ReviewHandoffNeedsAttention {
 	issue_identifier: String,
+	pr_url: String,
 	run_id: String,
 }
 impl Display for ReviewHandoffNeedsAttention {
 	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
 		write!(
 			f,
-			"Run `{}` for issue `{}` partially applied review handoff writeback; stop retries and repair the issue manually.",
-			self.run_id, self.issue_identifier
+			"Run `{}` for issue `{}` partially applied review handoff writeback for PR `{}`; stop retries and repair the issue manually.",
+			self.run_id, self.issue_identifier, self.pr_url
 		)
 	}
 }

--- a/docs/spec/linear-execution-ledger.md
+++ b/docs/spec/linear-execution-ledger.md
@@ -86,6 +86,12 @@ activity markers. Linear records should continue to use public collaboration
 identifiers such as PR URLs, issue identifiers, branch names, commit SHAs, and
 repository-relative paths.
 
+PR lifecycle writeback must not copy an agent-authored review, repair, or closeout
+summary into Linear when that summary fails the baseline public-text guard. The
+writeback must replace the rejected summary with fixed public-safe fallback text before
+rendering the Linear comment and ledger record. This fallback does not weaken the guard:
+the rejected private text remains absent from the public record.
+
 Decodex may additionally run public projection free-text through an optional local
 privacy classifier before publishing the Linear comment. That classifier is a secondary
 semantic warning layer after schema allowlisting and the deterministic public-text

--- a/docs/spec/tracker-tools.md
+++ b/docs/spec/tracker-tools.md
@@ -144,6 +144,11 @@ In either invalid case, `decodex` must fail the attempt rather than infer which 
 - `issue_review_repair_complete` must validate that the supplied PR belongs to the current repository and retained lane branch, points at the validated lane HEAD, is open, and is ready for fresh review before `decodex` accepts retained repair completion.
 - `issue_review_handoff` records the success metadata during the turn, but `decodex` owns the final completion comment and `In Review` transition after service-side validation succeeds.
 - `issue_review_repair_complete` records retained repair completion metadata during the turn, but `decodex` owns the final completion comment and refreshed retained-lineage marker after service-side validation succeeds.
+- Agent-authored PR lifecycle summaries are public text inputs. If the summary recorded
+  by `issue_review_handoff`, `issue_review_repair_complete`, or `issue_closeout_complete`
+  fails the public-text guard during Decodex-owned writeback, Decodex must use fixed
+  public-safe fallback summary text for the Linear comment and ledger record instead
+  of failing the otherwise valid PR lifecycle transition.
 - Adding the configured `needs_attention_label` is an explicit human-required
   failure exit for the active lane. In that case the agent must call
   `issue_comment` with kind `manual_attention` so Decodex can render the
@@ -206,6 +211,11 @@ In either invalid case, `decodex` must fail the attempt rather than infer which 
 - If the turn completes without a valid recorded `issue_review_handoff` and without an explicit human-attention exit, `decodex` must treat the run as failed rather than silently moving the issue to `In Review`.
 - If the turn completes without a matching `issue_terminal_finalize` call for the resolved terminal path, `decodex` must treat the run as failed before reporting the attempt as successful.
 - If PR-backed success writeback partially succeeds, for example the issue reaches `In Review` but the completion comment fails to post, `decodex` must treat the lane as human-required and must not place it back on the automatic retry path.
+- If a remaining public writeback validation failure occurs after successful PR
+  validation, Decodex must classify it as `review_handoff_writeback_failed`, preserve
+  the PR URL in the public recovery record when available, and stop in a recoverable
+  human-required state instead of downgrading the completed implementation work to a
+  generic coding failure.
 
 ## Future expansion
 


### PR DESCRIPTION
## Summary
- Replace rejected PR lifecycle summaries with fixed public-safe fallback text before Linear tracker writeback.
- Preserve recoverable review-handoff writeback failure classification with PR URL for remaining post-PR validation failures.
- Add regression coverage and tracker spec updates for fallback/recoverable behavior.

## Verification
- cargo test -p decodex review_handoff --all-features
- cargo make fmt
- cargo make lint-fix
- cargo make test
- git diff --check