### PR TITLE
XY-577: Harden app-server plugin/list preflight timeouts for queued runs

### DIFF
--- a/apps/decodex/src/agent/app_server.rs
+++ b/apps/decodex/src/agent/app_server.rs
@@ -58,6 +58,7 @@ pub(crate) const ACTIVE_RUN_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
 const PROBE_TIMEOUT: Duration = Duration::from_secs(30);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const MCP_PREFLIGHT_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+const PLUGIN_PREFLIGHT_MAX_ATTEMPTS: u32 = 2;
 const PROBE_RUN_ID: &str = "protocol-probe-run";
 const PROBE_ISSUE_ID: &str = "protocol-probe";
 const PROBE_EXPECTED_OUTPUT: &str = "PROBE_OK";
@@ -185,7 +186,26 @@ impl AppServerCapabilityPreflightFailure {
 		report: AppServerCapabilityPreflightReport,
 	) -> Self {
 		Self {
-			kind: AppServerCapabilityPreflightFailureKind::MethodFailed { method, error },
+			kind: AppServerCapabilityPreflightFailureKind::MethodFailed {
+				method,
+				error,
+				timed_out: false,
+			},
+			report,
+		}
+	}
+
+	fn method_timed_out(
+		method: &'static str,
+		error: String,
+		report: AppServerCapabilityPreflightReport,
+	) -> Self {
+		Self {
+			kind: AppServerCapabilityPreflightFailureKind::MethodFailed {
+				method,
+				error,
+				timed_out: true,
+			},
 			report,
 		}
 	}
@@ -199,8 +219,28 @@ impl AppServerCapabilityPreflightFailure {
 		Self::blocked(report)
 	}
 
+	#[cfg(test)]
+	pub(crate) fn method_timed_out_for_test(method: &'static str, error: String) -> Self {
+		let mut report = AppServerCapabilityPreflightReport::new();
+
+		report.push_blocked(
+			check_name_for_method(method),
+			format!("`{method}` timed out."),
+			BTreeMap::new(),
+		);
+
+		Self::method_timed_out(method, error, report)
+	}
+
 	pub(crate) fn error_class(&self) -> &'static str {
-		match self.kind {
+		match &self.kind {
+			AppServerCapabilityPreflightFailureKind::MethodFailed {
+				method: "plugin/list",
+				timed_out: true,
+				..
+			} => "app_server_plugin_list_timeout",
+			AppServerCapabilityPreflightFailureKind::MethodFailed { timed_out: true, .. } =>
+				"app_server_preflight_timeout",
 			AppServerCapabilityPreflightFailureKind::MethodFailed { .. } =>
 				"app_server_introspection_method_failed",
 			AppServerCapabilityPreflightFailureKind::BlockedState =>
@@ -209,14 +249,39 @@ impl AppServerCapabilityPreflightFailure {
 	}
 
 	pub(crate) fn terminal_next_action(&self, recovery_gate: &str) -> String {
-		format!(
-			"inspect the Codex app-server preflight status, repair the local Codex runtime configuration, restart `decodex serve`, {recovery_gate}"
-		)
+		match &self.kind {
+			AppServerCapabilityPreflightFailureKind::MethodFailed {
+				method: "plugin/list",
+				timed_out: true,
+				..
+			} => format!(
+				"inspect local app_server_preflight_failed evidence for the `plugin/list` timeout, restart `decodex serve` if the app-server is stale, run `decodex probe` to confirm plugin inventory recovers, {recovery_gate}"
+			),
+			AppServerCapabilityPreflightFailureKind::MethodFailed {
+				method,
+				timed_out: true,
+				..
+			} => format!(
+				"inspect local app_server_preflight_failed evidence for the `{method}` timeout, restart `decodex serve` if the app-server is stale, run `decodex probe` to confirm app-server preflight recovers, {recovery_gate}"
+			),
+			AppServerCapabilityPreflightFailureKind::MethodFailed { .. }
+			| AppServerCapabilityPreflightFailureKind::BlockedState => format!(
+				"inspect the Codex app-server preflight status, repair the local Codex runtime configuration, restart `decodex serve`, {recovery_gate}"
+			),
+		}
 	}
 
 	fn blocker_summary(&self) -> String {
 		match &self.kind {
-			AppServerCapabilityPreflightFailureKind::MethodFailed { method, error } => {
+			AppServerCapabilityPreflightFailureKind::MethodFailed {
+				method,
+				error,
+				timed_out: true,
+			} => format!(
+				"{}: `{method}` timed out during preflight: {error}",
+				check_name_for_method(method)
+			),
+			AppServerCapabilityPreflightFailureKind::MethodFailed { method, error, .. } => {
 				format!("{}: `{method}` returned {error}", check_name_for_method(method))
 			},
 			AppServerCapabilityPreflightFailureKind::BlockedState => self.report.blocker_summary(),
@@ -859,7 +924,7 @@ enum AppServerCapabilityPreflightStatus {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum AppServerCapabilityPreflightFailureKind {
-	MethodFailed { method: &'static str, error: String },
+	MethodFailed { method: &'static str, error: String, timed_out: bool },
 	BlockedState,
 }
 
@@ -2078,9 +2143,14 @@ fn run_app_server_capability_preflight(
 
 	record_skills_preflight(&mut report, cwd, &skills);
 
-	let plugins = preflight_request(recorder, &report, "plugin/list", || {
-		client.list_plugins(&plugin_list_params_for_preflight(cwd))
-	})?;
+	let plugins = preflight_request_with_timeout_retry(
+		recorder,
+		&report,
+		"plugin/list",
+		REQUEST_TIMEOUT,
+		PLUGIN_PREFLIGHT_MAX_ATTEMPTS,
+		|| client.list_plugins(&plugin_list_params_for_preflight(cwd)),
+	)?;
 
 	record_plugin_preflight(&mut report, &plugins);
 
@@ -2090,7 +2160,14 @@ fn run_app_server_capability_preflight(
 			record_mcp_preflight_degraded(&mut report, &error);
 		},
 		Err(error) => {
-			return preflight_method_failure(recorder, &report, "mcpServerStatus/list", error);
+			return preflight_method_failure(
+				recorder,
+				&report,
+				"mcpServerStatus/list",
+				MCP_PREFLIGHT_REQUEST_TIMEOUT,
+				1,
+				error,
+			);
 		},
 	}
 
@@ -2114,27 +2191,47 @@ fn preflight_method_failure<T>(
 	recorder: &mut RunRecorder<'_>,
 	report: &AppServerCapabilityPreflightReport,
 	method: &'static str,
+	request_timeout: Duration,
+	attempt_count: u32,
 	error: Report,
 ) -> crate::prelude::Result<T> {
 	let error_message = error.to_string();
+	let timed_out = preflight_error_timed_out(&error);
+	let retry_count = attempt_count.saturating_sub(1);
 	let mut failed_report = report.clone();
 	let mut details = BTreeMap::new();
 
 	details.insert(String::from("method"), method.to_owned());
 	details.insert(String::from("error"), error_message.clone());
+	details.insert(String::from("attempt_count"), attempt_count.to_string());
+
+	if retry_count > 0 {
+		details.insert(String::from("retry_count"), retry_count.to_string());
+	}
+	if timed_out {
+		details.insert(String::from("failure_reason"), String::from("timeout"));
+		details.insert(String::from("timeout_seconds"), request_timeout.as_secs().to_string());
+	}
+
 	failed_report.push_blocked(
 		check_name_for_method(method),
-		format!("`{method}` failed before thread/start."),
+		if timed_out {
+			format!("`{method}` timed out before thread/start after {attempt_count} attempts.")
+		} else {
+			format!("`{method}` failed before thread/start.")
+		},
 		details,
 	);
 
 	record_app_server_preflight_report(recorder, &failed_report)?;
 
-	Err(Report::new(AppServerCapabilityPreflightFailure::method_failed(
-		method,
-		error_message,
-		failed_report,
-	)))
+	let failure = if timed_out {
+		AppServerCapabilityPreflightFailure::method_timed_out(method, error_message, failed_report)
+	} else {
+		AppServerCapabilityPreflightFailure::method_failed(method, error_message, failed_report)
+	};
+
+	Err(Report::new(failure))
 }
 
 fn preflight_request<T, F>(
@@ -2148,7 +2245,48 @@ where
 {
 	match request() {
 		Ok(response) => Ok(response),
-		Err(error) => preflight_method_failure(recorder, report, method, error),
+		Err(error) => preflight_method_failure(recorder, report, method, REQUEST_TIMEOUT, 1, error),
+	}
+}
+
+fn preflight_request_with_timeout_retry<T, F>(
+	recorder: &mut RunRecorder<'_>,
+	report: &AppServerCapabilityPreflightReport,
+	method: &'static str,
+	request_timeout: Duration,
+	max_attempts: u32,
+	mut request: F,
+) -> crate::prelude::Result<T>
+where
+	F: FnMut() -> crate::prelude::Result<T>,
+{
+	let max_attempts = max_attempts.max(1);
+	let mut attempt_count = 1;
+
+	loop {
+		match request() {
+			Ok(response) => return Ok(response),
+			Err(error) if preflight_error_timed_out(&error) && attempt_count < max_attempts => {
+				tracing::warn!(
+					method,
+					attempt = attempt_count,
+					max_attempts,
+					"Retrying app-server preflight method after timeout."
+				);
+
+				attempt_count += 1;
+			},
+			Err(error) => {
+				return preflight_method_failure(
+					recorder,
+					report,
+					method,
+					request_timeout,
+					attempt_count,
+					error,
+				);
+			},
+		}
 	}
 }
 
@@ -2425,6 +2563,10 @@ fn record_mcp_preflight(
 }
 
 fn mcp_preflight_can_degrade(error: &Report) -> bool {
+	preflight_error_timed_out(error)
+}
+
+fn preflight_error_timed_out(error: &Report) -> bool {
 	error.downcast_ref::<AppServerOutputTimeout>().is_some()
 }
 

--- a/apps/decodex/src/agent/app_server/tests.rs
+++ b/apps/decodex/src/agent/app_server/tests.rs
@@ -18,8 +18,9 @@ use crate::{
 			AppServerDynamicToolFailure, AppServerRunResult, AppServerThreadArchiveRequest,
 			AppServerTurnFailure, CommandExecHealthCheck, CommandExecResponse,
 			EffectiveThreadConfig, InitializeResponse, ModelProviderCapabilitiesReadResponse,
-			PluginListResponse, ProbeDynamicToolHandler, RequestWaitPhase, RunRecorder,
-			RuntimeConfigSummary, SkillsListResponse, TurnContinuationGuard, UserInput,
+			PluginListResponse, ProbeDynamicToolHandler, REQUEST_TIMEOUT, RequestWaitPhase,
+			RunRecorder, RuntimeConfigSummary, SkillsListResponse, TurnContinuationGuard,
+			UserInput,
 		},
 		json_rpc::{
 			AppServerHomePreflightFailure, AppServerOutputTimeout, AppServerProcessEnv,
@@ -852,6 +853,79 @@ fn capability_preflight_request_error_records_method_blocker() {
 	assert!(failure.to_string().contains("model/list"));
 	assert!(failure.to_string().contains("Method not found"));
 	assert!(failure.report().has_blockers());
+	assert_eq!(state_store.event_count("run-1").expect("event count should load"), 1);
+}
+
+#[test]
+fn plugin_list_preflight_timeout_retries_once_before_success() {
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let mut recorder = RunRecorder::new(&state_store, "run-1", 1, None);
+	let report = AppServerCapabilityPreflightReport::new();
+	let mut attempts = 0;
+	let response = super::preflight_request_with_timeout_retry(
+		&mut recorder,
+		&report,
+		"plugin/list",
+		REQUEST_TIMEOUT,
+		2,
+		|| {
+			attempts += 1;
+
+			if attempts == 1 { Err(Report::new(AppServerOutputTimeout)) } else { Ok("plugins-ok") }
+		},
+	)
+	.expect("second plugin/list attempt should recover");
+
+	assert_eq!(response, "plugins-ok");
+	assert_eq!(attempts, 2);
+	assert_eq!(state_store.event_count("run-1").expect("event count should load"), 0);
+}
+
+#[test]
+fn plugin_list_preflight_timeout_failure_is_typed_operator_blocker() {
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let mut recorder = RunRecorder::new(&state_store, "run-1", 1, None);
+	let report = AppServerCapabilityPreflightReport::new();
+	let mut attempts = 0;
+	let error = super::preflight_request_with_timeout_retry::<(), _>(
+		&mut recorder,
+		&report,
+		"plugin/list",
+		REQUEST_TIMEOUT,
+		2,
+		|| {
+			attempts += 1;
+
+			Err(Report::new(AppServerOutputTimeout))
+		},
+	)
+	.expect_err("exhausted plugin/list timeout should fail preflight");
+	let failure = error
+		.downcast_ref::<AppServerCapabilityPreflightFailure>()
+		.expect("plugin/list timeout should be typed");
+	let check = &failure.report().checks()[0];
+	let timeout_seconds = REQUEST_TIMEOUT.as_secs().to_string();
+
+	assert_eq!(attempts, 2);
+	assert_eq!(failure.error_class(), "app_server_plugin_list_timeout");
+	assert!(failure.to_string().contains("app_server_preflight_failed"));
+	assert!(failure.to_string().contains("plugin/list"));
+	assert!(failure.to_string().contains("timed out"));
+	assert!(
+		failure
+			.terminal_next_action("clear label `decodex:needs-attention`")
+			.contains("app_server_preflight_failed evidence for the `plugin/list` timeout")
+	);
+	assert!(failure.report().has_blockers());
+	assert_eq!(check.name, "plugins");
+	assert_eq!(check.status, super::AppServerCapabilityPreflightStatus::Blocked);
+	assert_eq!(check.details.get("failure_reason").map(String::as_str), Some("timeout"));
+	assert_eq!(check.details.get("attempt_count").map(String::as_str), Some("2"));
+	assert_eq!(check.details.get("retry_count").map(String::as_str), Some("1"));
+	assert_eq!(
+		check.details.get("timeout_seconds").map(String::as_str),
+		Some(timeout_seconds.as_str())
+	);
 	assert_eq!(state_store.event_count("run-1").expect("event count should load"), 1);
 }
 

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -1582,6 +1582,10 @@ where
 		(reason == "issue_needs_attention").then(|| String::from("needs_attention_label"));
 	let attention_record =
 		operator_queued_issue_latest_attention_record(tracker, project, state_store, issue);
+	let attention_error_class =
+		attention_record.as_ref().and_then(|record| record.error_class.clone());
+	let attention_next_action =
+		attention_record.as_ref().and_then(|record| record.next_action.clone());
 	let attempt_status = marker
 		.as_ref()
 		.and_then(|marker| state_store.run_attempt(marker.run_id()).transpose())
@@ -1594,6 +1598,7 @@ where
 		attempt_status.as_deref(),
 		retry_budget_attempts,
 		worktree_has_tracked_changes,
+		attention_error_class.as_deref(),
 	);
 	let process_liveness = marker.as_ref().and_then(marker_process_liveness_for_marker);
 
@@ -1611,12 +1616,8 @@ where
 			.map(str::to_owned),
 		attempt_status,
 		auto_retry_blocked_reason,
-		attention_error_class: attention_record
-			.as_ref()
-			.and_then(|record| record.error_class.clone()),
-		attention_next_action: attention_record
-			.as_ref()
-			.and_then(|record| record.next_action.clone()),
+		attention_error_class,
+		attention_next_action,
 		retry_budget_attempt_count,
 		retry_budget_max_attempts,
 		last_activity_at: marker
@@ -1717,10 +1718,16 @@ fn operator_queued_issue_attention_summary(
 	attempt_status: Option<&str>,
 	retry_budget_attempts: i64,
 	worktree_has_tracked_changes: bool,
+	attention_error_class: Option<&str>,
 ) -> String {
 	if retry_budget_attempts > 0 && worktree_has_tracked_changes {
 		return format!(
 			"Partial worktree changes are retained after {retry_budget_attempts} failed attempts; inspect the patch, finish validation, then land or reset manually."
+		);
+	}
+	if attention_error_class == Some("app_server_plugin_list_timeout") {
+		return String::from(
+			"app_server_preflight_failed: plugin/list timed out during Codex app-server preflight; operator recovery required.",
 		);
 	}
 	if marker

--- a/apps/decodex/src/orchestrator/tests/operator/status/queue.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/queue.rs
@@ -398,6 +398,66 @@ fn live_operator_status_snapshot_surfaces_needs_attention_event_cause() {
 }
 
 #[test]
+fn live_operator_status_snapshot_surfaces_plugin_list_preflight_timeout() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue_with_sort_fields(
+		"issue-needs-attention",
+		"PUB-109",
+		"Todo",
+		&["decodex:needs-attention"],
+		Some(2),
+		"2026-03-13T09:16:17.133Z",
+	);
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+
+	tracker.issue_comments.borrow_mut().insert(
+		issue.id.clone(),
+		vec![linear_execution_history_comment(
+			&issue,
+			"terminal_failure",
+			"2026-03-13T09:20:00Z",
+			"app-server-plugin-list-timeout",
+			|record| {
+				record.error_class = Some(String::from("app_server_plugin_list_timeout"));
+				record.next_action = Some(String::from(
+					"inspect local app_server_preflight_failed evidence for the `plugin/list` timeout, restart `decodex serve`, run `decodex probe`, clear label `decodex:needs-attention`",
+				));
+				record.summary = Some(String::from("Decodex run failed and needs attention."));
+				record.blockers = Some(vec![String::from(
+					"plugin/list timed out during app-server preflight",
+				)]);
+				record.evidence = Some(vec![String::from(
+					"app_server_preflight_failed happened before thread/start",
+				)]);
+			},
+		)],
+	);
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let candidate = snapshot
+		.queued_candidates
+		.iter()
+		.find(|candidate| candidate.issue_identifier == "PUB-109")
+		.expect("needs-attention queued issue should exist");
+	let attention = candidate.attention.as_ref().expect("attention details should render");
+	let rendered = orchestrator::render_operator_status(&snapshot);
+
+	assert_eq!(attention.attention_error_class.as_deref(), Some("app_server_plugin_list_timeout"));
+	assert!(attention.summary.contains("app_server_preflight_failed: plugin/list timed out"));
+	assert!(rendered.contains("attention_cause: app_server_plugin_list_timeout"));
+	assert!(rendered.contains("attention_next_action: inspect local app_server_preflight_failed"));
+	assert!(rendered.contains("plugin/list"));
+}
+
+#[test]
 fn live_operator_status_snapshot_surfaces_retained_partial_progress() {
 	let (_temp_dir, config, workflow) = temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");

--- a/apps/decodex/src/orchestrator/tests/runtime/failure.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/failure.rs
@@ -463,6 +463,14 @@ fn app_server_terminal_failures_preserve_specific_error_classes() {
 			"repair the local Codex runtime configuration",
 		),
 		(
+			Report::new(AppServerCapabilityPreflightFailure::method_timed_out_for_test(
+				"plugin/list",
+				String::from("Timed out while waiting for app-server output."),
+			)),
+			"app_server_plugin_list_timeout",
+			"app_server_preflight_failed evidence for the `plugin/list` timeout",
+		),
+		(
 			Report::new(AppServerHomePreflightFailure::resolution_failed(String::from(
 				"app_server_preflight_failed: HOME is not set, so Decodex cannot resolve the shared Codex home for app-server dispatch.",
 			))),

--- a/docs/runbook/self-dogfood-pilot.md
+++ b/docs/runbook/self-dogfood-pilot.md
@@ -362,6 +362,10 @@ wants to observe the self-bootstrap loop without reading source code.
    pinned to the shared `$HOME/.codex` Codex home and state home; do not repair this
    by assigning a per-account `CODEX_HOME` or by overriding model, sandbox, approval,
    or personality settings from project policy.
+   If the status cause is `app_server_plugin_list_timeout`, inspect the local
+   `app_server_preflight_failed` evidence for the `plugin/list` timeout, restart
+   `decodex serve` if the app-server process is stale, and run `decodex probe` until
+   plugin inventory responds before clearing `decodex:needs-attention`.
 
 4. In Linear, choose two or three small `decodex` issues for the demo batch. Keep each
    issue in a startable state such as `Todo`, make sure it does not carry
@@ -759,6 +763,11 @@ repo gate commands. Linear should carry only the coarse team-visible failure sum
   login state; for home mismatches, ensure `HOME` points at the user account that
   owns the shared `$HOME/.codex` tree. Restart `decodex serve` before clearing
   `decodex:needs-attention`.
+- If status reports `attention_cause: app_server_plugin_list_timeout`, treat it as a
+  bounded app-server preflight timeout before `thread/start`: inspect the retained
+  worktree's local preflight evidence for `plugin/list`, restart `decodex serve` if
+  stale, verify `decodex probe`, then clear `decodex:needs-attention` and move the
+  issue back to a startable state only when another automated run is desired.
 - If `status` reports retained partial progress or the dashboard shows `Partial patch held`, inspect the named worktree first. Treat the retained patch as local recovery evidence: finish the repo gate and PR handoff if the patch is useful, or reset the worktree before clearing `decodex:needs-attention`.
 - If the run moved back to `Todo` with `decodex:needs-attention`, inspect the worktree, fix the blocking problem, clear `decodex:needs-attention`, and then move the issue back into a startable state for another automated attempt.
 - If the issue should never be automated again, add `decodex:manual-only`.

--- a/docs/spec/app-server.md
+++ b/docs/spec/app-server.md
@@ -106,6 +106,12 @@ model, personality, sandbox, or approval-policy overrides on behalf of
 `WORKFLOW.md`. `plugin/list` preflight must pass `marketplaceKinds = ["local"]`
 so remote catalog, featured-plugin, or marketplace-discovery failures do not gate a
 business lane before its thread is created.
+Because `plugin/list` is observational and local-marketplace-only, Decodex may retry
+one app-server output timeout before failing the lane. If the retry is exhausted,
+the terminal failure must remain an app-server preflight failure, report
+`app_server_plugin_list_timeout`, and include the `plugin/list` timeout cause in local
+preflight evidence and operator recovery output rather than looking like a repository
+implementation failure.
 
 When dynamic tools are enabled, `decodex` must also:
 


### PR DESCRIPTION
## Summary
- Retry local-marketplace `plugin/list` app-server preflight once after output timeout.
- Classify exhausted `plugin/list` timeouts as `app_server_plugin_list_timeout` and surface `app_server_preflight_failed` recovery text in status.
- Document the operator recovery path in the app-server spec and self-dogfood runbook.

## Verification
- `cargo make fmt`
- `cargo make lint-fix`
- `cargo make test` (829 passed, 1 skipped)