### PR TITLE
Bypass inherited Git credential helpers

### DIFF
--- a/apps/decodex/src/agent/json_rpc.rs
+++ b/apps/decodex/src/agent/json_rpc.rs
@@ -786,26 +786,28 @@ mod tests {
 		assert_eq!(envs.get("GIT_TERMINAL_PROMPT").map(String::as_str), Some("0"));
 		assert_eq!(envs.get("GCM_INTERACTIVE").map(String::as_str), Some("never"));
 		assert_eq!(envs.get("GIT_ASKPASS").map(String::as_str), Some("/tmp/decodex-askpass.sh"));
-		assert_eq!(envs.get("GIT_CONFIG_COUNT").map(String::as_str), Some("9"));
+		assert_eq!(envs.get("GIT_CONFIG_COUNT").map(String::as_str), Some("10"));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_0").map(String::as_str), Some("credential.helper"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_0").map(String::as_str), Some(""));
 		assert_eq!(
-			envs.get("GIT_CONFIG_KEY_1").map(String::as_str),
+			envs.get("GIT_CONFIG_KEY_2").map(String::as_str),
 			Some("url.https://github.com/.insteadOf")
 		);
-		assert_eq!(envs.get("GIT_CONFIG_VALUE_1").map(String::as_str), Some("git@github.com-x:"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_2").map(String::as_str), Some("git@github.com-x:"));
 		assert_eq!(
-			envs.get("GIT_CONFIG_KEY_5").map(String::as_str),
+			envs.get("GIT_CONFIG_KEY_6").map(String::as_str),
 			Some("url.https://github.com/.insteadOf")
 		);
 		assert_eq!(
-			envs.get("GIT_CONFIG_VALUE_5").map(String::as_str),
+			envs.get("GIT_CONFIG_VALUE_6").map(String::as_str),
 			Some("ssh://git@github.com-y/")
 		);
-		assert_eq!(envs.get("GIT_CONFIG_KEY_6").map(String::as_str), Some("commit.gpgsign"));
-		assert_eq!(envs.get("GIT_CONFIG_VALUE_6").map(String::as_str), Some("false"));
-		assert_eq!(envs.get("GIT_CONFIG_KEY_7").map(String::as_str), Some("tag.gpgsign"));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_7").map(String::as_str), Some("commit.gpgsign"));
 		assert_eq!(envs.get("GIT_CONFIG_VALUE_7").map(String::as_str), Some("false"));
-		assert_eq!(envs.get("GIT_CONFIG_KEY_8").map(String::as_str), Some("user.signingkey"));
-		assert_eq!(envs.get("GIT_CONFIG_VALUE_8").map(String::as_str), Some(""));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_8").map(String::as_str), Some("tag.gpgsign"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_8").map(String::as_str), Some("false"));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_9").map(String::as_str), Some("user.signingkey"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_9").map(String::as_str), Some(""));
 	}
 
 	#[test]

--- a/apps/decodex/src/default_branch_sync.rs
+++ b/apps/decodex/src/default_branch_sync.rs
@@ -376,18 +376,20 @@ mod tests {
 			envs.get("GIT_ASKPASS").map(String::as_str),
 			Some("/tmp/decodex-default-branch-askpass.sh")
 		);
-		assert_eq!(envs.get("GIT_CONFIG_COUNT").map(String::as_str), Some("9"));
+		assert_eq!(envs.get("GIT_CONFIG_COUNT").map(String::as_str), Some("10"));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_0").map(String::as_str), Some("credential.helper"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_0").map(String::as_str), Some(""));
 		assert_eq!(
-			envs.get("GIT_CONFIG_KEY_0").map(String::as_str),
+			envs.get("GIT_CONFIG_KEY_1").map(String::as_str),
 			Some("url.https://github.com/.insteadOf")
 		);
-		assert_eq!(envs.get("GIT_CONFIG_VALUE_0").map(String::as_str), Some("git@github.com:"));
-		assert_eq!(envs.get("GIT_CONFIG_KEY_6").map(String::as_str), Some("commit.gpgsign"));
-		assert_eq!(envs.get("GIT_CONFIG_VALUE_6").map(String::as_str), Some("false"));
-		assert_eq!(envs.get("GIT_CONFIG_KEY_7").map(String::as_str), Some("tag.gpgsign"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_1").map(String::as_str), Some("git@github.com:"));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_7").map(String::as_str), Some("commit.gpgsign"));
 		assert_eq!(envs.get("GIT_CONFIG_VALUE_7").map(String::as_str), Some("false"));
-		assert_eq!(envs.get("GIT_CONFIG_KEY_8").map(String::as_str), Some("user.signingkey"));
-		assert_eq!(envs.get("GIT_CONFIG_VALUE_8").map(String::as_str), Some(""));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_8").map(String::as_str), Some("tag.gpgsign"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_8").map(String::as_str), Some("false"));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_9").map(String::as_str), Some("user.signingkey"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_9").map(String::as_str), Some(""));
 	}
 
 	#[test]

--- a/apps/decodex/src/git_credentials.rs
+++ b/apps/decodex/src/git_credentials.rs
@@ -106,6 +106,9 @@ impl GitCredentialEnvironment {
 		let mut git_config_entries = Vec::new();
 
 		if self.github_token.is_some() && self.git_askpass_path.is_some() {
+			// Empty helper resets inherited helpers so routed askpass owns GitHub auth.
+			git_config_entries.push((String::from("credential.helper"), String::new()));
+
 			for ssh_prefix in GITHUB_SSH_URL_PREFIXES {
 				git_config_entries.push((
 					format!("url.{GITHUB_HTTPS_URL_BASE}.insteadOf"),


### PR DESCRIPTION
## Summary
- clear inherited Git credential helpers for routed GitHub credential commands
- keep Decodex askpass as the owned auth path for default-branch fetch/sync
- update the default-branch sync credential test to cover the empty helper

## Verification
- cargo test -p decodex default_branch_git_commands_use_routed_noninteractive_credentials
- cargo test -p decodex git_credentials
- cargo make fmt
- cargo make lint-fix
- git diff --check