### PR TITLE
Stabilize Decodex account run capsules

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
@@ -234,6 +234,7 @@ final class AccountStore: ObservableObject {
 
 			let activity = OperatorRunActivitySnapshot(
 				activeRuns: activeRuns,
+				activeRunsComplete: payload.activeRunsComplete ?? true,
 				emittedAt: payload.emittedAt ?? Date()
 			)
 			if let operatorSnapshotUpdatedAt,

--- a/apps/decodex-app/Sources/DecodexApp/OperatorSnapshotModels.swift
+++ b/apps/decodex-app/Sources/DecodexApp/OperatorSnapshotModels.swift
@@ -80,13 +80,30 @@ struct OperatorSnapshotResponse: Decodable, Sendable {
 		activeRuns(for: account).count
 	}
 
-	func mergingRunActivity(_ activityRuns: [OperatorRunStatus]) -> OperatorSnapshotResponse {
+	func mergingRunActivity(
+		_ activityRuns: [OperatorRunStatus],
+		activeRunsComplete: Bool = true
+	) -> OperatorSnapshotResponse {
+		let activityRunsByID = activityRuns.reduce(into: [String: OperatorRunStatus]()) { runsByID, run in
+			runsByID[run.runID] = run
+		}
 		let snapshotRunsByID = activeRuns.reduce(into: [String: OperatorRunStatus]()) { runsByID, run in
 			runsByID[run.runID] = run
 		}
-		let mergedRuns = activityRuns.map { activityRun in
-			snapshotRunsByID[activityRun.runID]?.mergingActivity(activityRun) ?? activityRun
+		let mergedSnapshotRuns = activeRuns.compactMap { snapshotRun -> OperatorRunStatus? in
+			if let activityRun = activityRunsByID[snapshotRun.runID] {
+				return snapshotRun.mergingActivity(activityRun)
+			}
+			if activeRunsComplete || activityRuns.isEmpty {
+				return nil
+			}
+
+			return snapshotRun.shouldRetainDuringPartialRunActivity ? snapshotRun : nil
 		}
+		let newActivityRuns = activityRuns.filter { activityRun in
+			snapshotRunsByID[activityRun.runID] == nil
+		}
+		let mergedRuns = mergedSnapshotRuns + newActivityRuns
 		let activeCountsByProject = Dictionary(grouping: mergedRuns.compactMap(\.projectID)) { $0 }
 			.mapValues(\.count)
 		let mergedProjects = projects.map { project in
@@ -346,6 +363,14 @@ struct OperatorRunStatus: Decodable, Identifiable, Sendable {
 
 	func isAssigned(to account: CodexAccount) -> Bool {
 		self.account?.matches(account) == true
+			|| accounts.contains { $0.isSelected && $0.matches(account) }
+	}
+
+	var shouldRetainDuringPartialRunActivity: Bool {
+		activeLease == true
+			|| processAlive == true
+			|| status == "running"
+			|| phase == "executing"
 	}
 
 	func mergingActivity(_ activity: OperatorRunStatus) -> OperatorRunStatus {
@@ -540,6 +565,7 @@ struct OperatorDashboardSocketPayload: Decodable, Sendable {
 	let snapshotPublishedAtUnixEpoch: Int64?
 	let snapshot: OperatorSnapshotResponse?
 	let activeRuns: [OperatorRunStatus]?
+	let activeRunsComplete: Bool?
 
 	var emittedAt: Date? {
 		date(fromUnixEpoch: emittedAtUnixEpoch)
@@ -554,11 +580,13 @@ struct OperatorDashboardSocketPayload: Decodable, Sendable {
 		case snapshotPublishedAtUnixEpoch
 		case snapshot
 		case activeRuns
+		case activeRunsComplete
 	}
 }
 
 struct OperatorRunActivitySnapshot: Sendable {
 	let activeRuns: [OperatorRunStatus]
+	let activeRunsComplete: Bool
 	let emittedAt: Date
 
 	func shouldOverlay(snapshotPublishedAt: Date?) -> Bool {
@@ -570,7 +598,7 @@ struct OperatorRunActivitySnapshot: Sendable {
 	}
 
 	func merging(into snapshot: OperatorSnapshotResponse) -> OperatorSnapshotResponse {
-		snapshot.mergingRunActivity(activeRuns)
+		snapshot.mergingRunActivity(activeRuns, activeRunsComplete: activeRunsComplete)
 	}
 }
 
@@ -663,6 +691,11 @@ struct OperatorChildAgentBucket: Decodable, Identifiable, Sendable {
 struct OperatorRunAccountSummary: Decodable, Sendable {
 	let accountFingerprint: String
 	let email: String?
+	let status: String?
+
+	var isSelected: Bool {
+		status?.caseInsensitiveCompare("selected") == .orderedSame
+	}
 
 	func matches(_ account: CodexAccount) -> Bool {
 		if accountFingerprint.isEmpty == false, accountFingerprint == account.accountFingerprint {
@@ -679,6 +712,7 @@ struct OperatorRunAccountSummary: Decodable, Sendable {
 		case accountFingerprint = "account_fingerprint"
 		case email
 		case accountEmail = "account_email"
+		case status
 	}
 
 	init(from decoder: Decoder) throws {
@@ -687,6 +721,7 @@ struct OperatorRunAccountSummary: Decodable, Sendable {
 		accountFingerprint = try container.decodeIfPresent(String.self, forKey: .accountFingerprint) ?? ""
 		email = try container.decodeIfPresent(String.self, forKey: .email)
 			?? container.decodeIfPresent(String.self, forKey: .accountEmail)
+		status = try container.decodeIfPresent(String.self, forKey: .status)
 	}
 }
 

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountModelTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountModelTests.swift
@@ -144,6 +144,46 @@ final class AccountModelTests: XCTestCase {
 		XCTAssertTrue(snapshot.activeRuns(for: poolOnlyAccount).isEmpty)
 	}
 
+	func testOperatorSnapshotAssignsSelectedAccountWhenPrimaryAccountIsMissing() throws {
+		let assignedAccount = makeAccount(
+			status: "available",
+			email: "copy@example.com",
+			accountFingerprint: "...123456"
+		)
+		let poolOnlyAccount = makeAccount(
+			status: "available",
+			email: "pool@example.com",
+			accountFingerprint: "...654321"
+		)
+		let payload = """
+		{
+		  "active_runs": [
+		    {
+		      "run_id": "run-1",
+		      "issue_identifier": "XY-689",
+		      "accounts": [
+		        {
+		          "email": "copy@example.com",
+		          "account_fingerprint": "...123456",
+		          "status": "selected"
+		        },
+		        {
+		          "email": "pool@example.com",
+		          "account_fingerprint": "...654321",
+		          "status": "available"
+		        }
+		      ]
+		    }
+		  ]
+		}
+		""".data(using: .utf8)!
+
+		let snapshot = try JSONDecoder().decode(OperatorSnapshotResponse.self, from: payload)
+
+		XCTAssertEqual(snapshot.activeRuns(for: assignedAccount).map(\.runID), ["run-1"])
+		XCTAssertTrue(snapshot.activeRuns(for: poolOnlyAccount).isEmpty)
+	}
+
 	func testOperatorRunActivityOverlayDoesNotReplaceNewerSnapshot() throws {
 		let account = makeAccount(
 			status: "available",
@@ -185,11 +225,134 @@ final class AccountModelTests: XCTestCase {
 			.activeRuns ?? []
 		let overlay = OperatorRunActivitySnapshot(
 			activeRuns: activity,
+			activeRunsComplete: true,
 			emittedAt: Date(timeIntervalSince1970: 10)
 		)
 
 		XCTAssertFalse(overlay.shouldOverlay(snapshotPublishedAt: Date(timeIntervalSince1970: 20)))
 		XCTAssertEqual(snapshot.activeRuns(for: account).map(\.runID), ["run-new"])
+	}
+
+	func testPartialRunActivityPreservesSnapshotActiveRuns() throws {
+		let account = makeAccount(
+			status: "available",
+			email: "copy@example.com",
+			accountFingerprint: "...123456"
+		)
+		let snapshotPayload = """
+		{
+		  "active_runs": [
+		    {
+		      "run_id": "run-689",
+		      "issue_identifier": "XY-689",
+		      "active_lease": true,
+		      "account": {
+		        "email": "copy@example.com",
+		        "account_fingerprint": "...123456"
+		      }
+		    },
+		    {
+		      "run_id": "run-690",
+		      "issue_identifier": "XY-690",
+		      "active_lease": true,
+		      "account": {
+		        "email": "copy@example.com",
+		        "account_fingerprint": "...123456"
+		      }
+		    }
+		  ]
+		}
+		""".data(using: .utf8)!
+		let activityPayload = """
+		{
+		  "activeRunsComplete": false,
+		  "activeRuns": [
+		    {
+		      "run_id": "run-690",
+		      "issue_identifier": "XY-690",
+		      "account": {
+		        "email": "copy@example.com",
+		        "account_fingerprint": "...123456"
+		      }
+		    }
+		  ]
+		}
+		""".data(using: .utf8)!
+
+		let snapshot = try JSONDecoder().decode(OperatorSnapshotResponse.self, from: snapshotPayload)
+		let event = try JSONDecoder()
+			.decode(OperatorDashboardSocketPayload.self, from: activityPayload)
+		let overlay = OperatorRunActivitySnapshot(
+			activeRuns: event.activeRuns ?? [],
+			activeRunsComplete: event.activeRunsComplete ?? true,
+			emittedAt: Date(timeIntervalSince1970: 30)
+		)
+		let merged = overlay.merging(into: snapshot)
+
+		XCTAssertTrue(overlay.shouldOverlay(snapshotPublishedAt: Date(timeIntervalSince1970: 20)))
+		XCTAssertEqual(merged.activeRuns.map(\.runID), ["run-689", "run-690"])
+		XCTAssertEqual(merged.activeRuns(for: account).map(\.runID), ["run-689", "run-690"])
+	}
+
+	func testCompleteRunActivityReplacesSnapshotActiveRuns() throws {
+		let account = makeAccount(
+			status: "available",
+			email: "copy@example.com",
+			accountFingerprint: "...123456"
+		)
+		let snapshotPayload = """
+		{
+		  "active_runs": [
+		    {
+		      "run_id": "run-689",
+		      "issue_identifier": "XY-689",
+		      "active_lease": true,
+		      "account": {
+		        "email": "copy@example.com",
+		        "account_fingerprint": "...123456"
+		      }
+		    },
+		    {
+		      "run_id": "run-690",
+		      "issue_identifier": "XY-690",
+		      "active_lease": true,
+		      "account": {
+		        "email": "copy@example.com",
+		        "account_fingerprint": "...123456"
+		      }
+		    }
+		  ]
+		}
+		""".data(using: .utf8)!
+		let activityPayload = """
+		{
+		  "activeRunsComplete": true,
+		  "activeRuns": [
+		    {
+		      "run_id": "run-690",
+		      "issue_identifier": "XY-690",
+		      "account": {
+		        "email": "copy@example.com",
+		        "account_fingerprint": "...123456"
+		      }
+		    }
+		  ]
+		}
+		""".data(using: .utf8)!
+
+		let snapshot = try JSONDecoder().decode(OperatorSnapshotResponse.self, from: snapshotPayload)
+		let event = try JSONDecoder()
+			.decode(OperatorDashboardSocketPayload.self, from: activityPayload)
+		let overlay = OperatorRunActivitySnapshot(
+			activeRuns: event.activeRuns ?? [],
+			activeRunsComplete: event.activeRunsComplete ?? true,
+			emittedAt: Date(timeIntervalSince1970: 30)
+		)
+		let merged = overlay.merging(into: snapshot)
+
+		XCTAssertTrue(overlay.shouldOverlay(snapshotPublishedAt: Date(timeIntervalSince1970: 20)))
+		XCTAssertEqual(merged.activeRuns.map(\.runID), ["run-690"])
+		XCTAssertEqual(merged.activeRuns(for: account).map(\.runID), ["run-690"])
 	}
 
 	func testNewerEmptyRunActivityClearsSnapshotRuns() throws {
@@ -215,6 +378,7 @@ final class AccountModelTests: XCTestCase {
 		let snapshot = try JSONDecoder().decode(OperatorSnapshotResponse.self, from: snapshotPayload)
 		let overlay = OperatorRunActivitySnapshot(
 			activeRuns: [],
+			activeRunsComplete: true,
 			emittedAt: Date(timeIntervalSince1970: 30)
 		)
 		let merged = overlay.merging(into: snapshot)

--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -3860,6 +3860,8 @@
 			let dashboardSocket = null;
 			let dashboardSocketReconnectTimer = null;
 			let dashboardLiveActiveRuns = [];
+			let dashboardLiveRunActivitySeen = false;
+			let dashboardLiveActiveRunsComplete = true;
 			let dashboardLiveAccounts = null;
 			let dashboardLiveAccountControl = null;
 			let dashboardStreamState = {
@@ -10173,7 +10175,11 @@
 				return lookup;
 			}
 
-			function mergeDashboardActiveRuns(snapshot, activeRunRows) {
+			function dashboardRunShouldRetainDuringPartialActivity(run) {
+				return run?.active_lease === true || run?.process_alive === true || runCountsAsRunning(run);
+			}
+
+			function mergeDashboardActiveRuns(snapshot, activeRunRows, activeRunsComplete = true) {
 				const snapshotActiveRuns = snapshot.active_runs || [];
 				const snapshotRunLookup = dashboardRunLookup(snapshotActiveRuns);
 				const seenSnapshotRuns = new Set();
@@ -10192,7 +10198,11 @@
 				}
 
 				for (const snapshotRun of snapshotActiveRuns) {
-					if (!seenSnapshotRuns.has(snapshotRun)) {
+					if (
+						!activeRunsComplete &&
+						!seenSnapshotRuns.has(snapshotRun) &&
+						dashboardRunShouldRetainDuringPartialActivity(snapshotRun)
+					) {
 						mergedRuns.push(snapshotRun);
 					}
 				}
@@ -10204,7 +10214,14 @@
 				const activeRunRows = activeRuns
 					.filter((run) => run && typeof run === "object")
 					.map((run) => ({ ...run }));
-				const mergedActiveRuns = mergeDashboardActiveRuns(snapshot, activeRunRows);
+				const activeRunsComplete =
+					activityPayload.activeRunsComplete !== false &&
+					activityPayload.activeRunScope !== "filtered";
+				const mergedActiveRuns = mergeDashboardActiveRuns(
+					snapshot,
+					activeRunRows,
+					activeRunsComplete,
+				);
 				const activeById = new Map(
 					mergedActiveRuns
 						.filter((run) => run.run_id)
@@ -10276,6 +10293,7 @@
 				}
 
 				if (
+					!dashboardLiveRunActivitySeen &&
 					!dashboardLiveActiveRuns.length &&
 					!dashboardLiveAccounts &&
 					!dashboardLiveAccountControl
@@ -10286,6 +10304,7 @@
 				return mergeDashboardRunActivity(snapshot, dashboardLiveActiveRuns, {
 					accountControl: dashboardLiveAccountControl,
 					accounts: dashboardLiveAccounts,
+					activeRunsComplete: dashboardLiveActiveRunsComplete,
 				});
 			}
 
@@ -10303,6 +10322,9 @@
 				dashboardLiveActiveRuns = payload.activeRuns
 					.filter((run) => run && typeof run === "object")
 					.map((run) => ({ ...run }));
+				dashboardLiveRunActivitySeen = true;
+				dashboardLiveActiveRunsComplete =
+					payload.activeRunsComplete !== false && payload.activeRunScope !== "filtered";
 				dashboardLiveAccounts = Array.isArray(payload.accounts) && payload.accounts.length
 					? payload.accounts.filter(Boolean).map((account) => ({ ...account }))
 					: null;
@@ -10466,6 +10488,8 @@
 				};
 				dashboardSocket.onclose = () => {
 					dashboardLiveActiveRuns = [];
+					dashboardLiveRunActivitySeen = false;
+					dashboardLiveActiveRunsComplete = true;
 					dashboardLiveAccounts = null;
 					dashboardLiveAccountControl = null;
 					updateDashboardStreamState({
@@ -10476,6 +10500,8 @@
 				};
 				dashboardSocket.onerror = () => {
 					dashboardLiveActiveRuns = [];
+					dashboardLiveRunActivitySeen = false;
+					dashboardLiveActiveRunsComplete = true;
 					dashboardLiveAccounts = null;
 					dashboardLiveAccountControl = null;
 					updateDashboardStreamState({

--- a/apps/decodex/src/orchestrator/operator_http.rs
+++ b/apps/decodex/src/orchestrator/operator_http.rs
@@ -511,6 +511,8 @@ fn build_operator_run_activity_event(state_store: &StateStore) -> Result<Dashboa
 		"accountControl": &account_control,
 		"accounts": &accounts,
 		"activeRuns": &active_runs,
+		"activeRunsComplete": true,
+		"activeRunScope": "complete",
 	});
 	let fingerprint = serde_json::to_vec(&fingerprint_payload)?;
 	let payload = json!({
@@ -518,6 +520,8 @@ fn build_operator_run_activity_event(state_store: &StateStore) -> Result<Dashboa
 		"accountControl": account_control,
 		"accounts": accounts,
 		"activeRuns": active_runs,
+		"activeRunsComplete": true,
+		"activeRunScope": "complete",
 	});
 
 	Ok(DashboardRunActivityEvent {
@@ -1292,6 +1296,8 @@ fn dashboard_event_for_subscription(
 	let mut payload = event.payload.clone();
 
 	payload["activeRuns"] = Value::Array(active_runs);
+	payload["activeRunsComplete"] = Value::Bool(false);
+	payload["activeRunScope"] = Value::String(String::from("filtered"));
 
 	Some(DashboardBroadcastEvent { event_type: event.event_type, payload })
 }

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -1614,12 +1614,16 @@ fn operator_dashboard_run_activity_preserves_snapshot_detail_fields() {
 	let response = dashboard_response();
 
 	assert!(response.contains("function mergeDashboardRunRecord(snapshotRun, activityRun)"));
-	assert!(response.contains("function mergeDashboardActiveRuns(snapshot, activeRunRows)"));
+	assert!(
+		response.contains("function mergeDashboardActiveRuns(snapshot, activeRunRows, activeRunsComplete = true)")
+	);
 	assert!(response.contains("function dashboardRunTitleIsOperationFallback(run)"));
 	assert!(response.contains("const operationFallback = displayToken(run.current_operation || run.phase);"));
 	assert!(response.contains("!(fallback !== \"unknown\" && title === operationFallback)"));
 	assert!(response.contains("return fallback !== \"unknown\" ? fallback : operationFallback;"));
 	assert!(response.contains("let dashboardLiveActiveRuns = [];"));
+	assert!(response.contains("let dashboardLiveRunActivitySeen = false;"));
+	assert!(response.contains("let dashboardLiveActiveRunsComplete = true;"));
 	assert!(response.contains("let dashboardLiveAccounts = null;"));
 	assert!(response.contains("let dashboardLiveAccountControl = null;"));
 	assert!(response.contains("function snapshotWithLiveRunActivity(snapshot)"));
@@ -1637,9 +1641,14 @@ fn operator_dashboard_run_activity_preserves_snapshot_detail_fields() {
 	assert!(response.contains("dashboardRunTitleIsOperationFallback(activityRun)"));
 	assert!(response.contains("merged.title = snapshotRun.title;"));
 	assert!(
-		response.contains("const mergedActiveRuns = mergeDashboardActiveRuns(snapshot, activeRunRows);")
+		response.contains("const activeRunsComplete =\n\t\t\t\t\tactivityPayload.activeRunsComplete !== false")
+	);
+	assert!(
+		response.contains("const mergedActiveRuns = mergeDashboardActiveRuns(\n\t\t\t\t\tsnapshot,\n\t\t\t\t\tactiveRunRows,\n\t\t\t\t\tactiveRunsComplete,\n\t\t\t\t);")
 	);
 	assert!(response.contains("dashboardLiveActiveRuns = payload.activeRuns"));
+	assert!(response.contains("dashboardLiveRunActivitySeen = true;"));
+	assert!(response.contains("dashboardLiveActiveRunsComplete ="));
 	assert!(response.contains("snapshot: snapshotWithLiveRunActivity(payload.snapshot),"));
 	assert!(response.contains("account_control: accountControl,"));
 	assert!(response.contains("accounts,"));

--- a/apps/decodex/src/orchestrator/tests/operator/status/http.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/http.rs
@@ -735,6 +735,8 @@ fn operator_dashboard_websocket_filters_run_activity_by_subscription() {
 	assert_eq!(active_runs[0]["project_id"], "pubfi");
 	assert_eq!(active_runs[0]["issue_id"], "PUB-102");
 	assert_eq!(active_runs[0]["run_id"], "run-2");
+	assert_eq!(activity["payload"]["activeRunsComplete"], false);
+	assert_eq!(activity["payload"]["activeRunScope"], "filtered");
 
 	drop(client);
 
@@ -1174,9 +1176,13 @@ fn operator_dashboard_run_activity_event_summarizes_active_runs() {
 
 	assert_eq!(payload["type"], "runActivity");
 	assert_eq!(data["accountControl"]["mode"], "balanced");
+	assert_eq!(data["activeRunsComplete"], true);
+	assert_eq!(data["activeRunScope"], "complete");
 	assert!(data["accounts"].is_array());
 	assert!(fingerprint.get("emittedAtUnixEpoch").is_none());
 	assert_eq!(fingerprint["accountControl"]["mode"], "balanced");
+	assert_eq!(fingerprint["activeRunsComplete"], true);
+	assert_eq!(fingerprint["activeRunScope"], "complete");
 	assert!(fingerprint["accounts"].is_array());
 	assert_eq!(fingerprint["activeRuns"][0]["run_id"], "run-1");
 	assert_eq!(

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -153,7 +153,10 @@ same runtime database, not a browser-dashboard polling authority and not a sign 
 the dev listener owns scheduling. The current browser UI keeps live updates
 unscoped and exposes explicit stop controls for active lanes with a known live child
 process plus account-pool selection controls; project watch, project pause/resume,
-and manual retry controls are intentionally not shown.
+and manual retry controls are intentionally not shown. `runActivity.activeRunsComplete`
+marks whether a payload is the complete active-run list; subscription-filtered
+payloads set it to `false`, so consumers must not treat a missing run in that payload
+as ended.
 The stop control signals the recorded child process for that run, marks the local
 attempt interrupted, and releases the local queue lease. `ack` is dashboard-local
 acknowledgement only. The socket is not a browser connection to Codex app-server,


### PR DESCRIPTION
## Summary
- mark runActivity payloads as complete vs subscription-filtered so clients do not interpret filtered omissions as ended runs
- make the Decodex App and browser dashboard replace active runs only for complete payloads, preserving active snapshot rows only for explicit partial payloads
- assign account-row capsules from selected accounts[] entries when the primary account field is missing

## Verification
- swift test --package-path apps/decodex-app
- cargo make checks
- semantic drift audit: pass; docs claim matches operator_http complete/filtered fields and App/dashboard consumers
