### PR TITLE
XY-700: Lane control P0: make dashboard active-lane controls observe-only

### DIFF
--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -1462,51 +1462,6 @@
 				color: var(--success);
 			}
 
-			.control-button.icon-button {
-				width: 26px;
-				min-width: 26px;
-				height: 26px;
-				padding: 0;
-				border-radius: 999px;
-			}
-
-			.status-line .run-stop-button {
-				width: 18px;
-				min-width: 18px;
-				height: 18px;
-				min-height: 18px;
-				margin-left: -7px;
-				padding: 0;
-				border: 0;
-				border-radius: 2px;
-				background: transparent;
-				color: color-mix(in srgb, var(--danger) 86%, var(--text));
-				opacity: 0.92;
-			}
-
-			.status-line .run-stop-button:hover {
-				border: 0;
-				background: transparent;
-				color: color-mix(in srgb, var(--danger) 88%, var(--text));
-				opacity: 1;
-			}
-
-			.status-line .run-stop-button:focus-visible {
-				outline: 1px solid color-mix(in srgb, var(--danger) 58%, transparent);
-				outline-offset: 2px;
-			}
-
-			.control-button.icon-button svg {
-				display: block;
-				width: 13px;
-				height: 13px;
-			}
-
-			.status-line .run-stop-button svg {
-				width: 14px;
-				height: 14px;
-			}
-
 			.control-button[disabled] {
 				cursor: not-allowed;
 				opacity: 0.5;
@@ -9579,31 +9534,6 @@
 				);
 			}
 
-			function runInterruptControlEnabled(run) {
-				return Boolean(
-					run.project_id &&
-						run.issue_id &&
-						run.run_id &&
-						run.process_id &&
-						run.process_alive === true,
-				);
-			}
-
-			function renderRunStopControl(run) {
-				const interruptEnabled = runInterruptControlEnabled(run);
-				if (!interruptEnabled) {
-					return "";
-				}
-
-				return `
-					<button class="control-button icon-button run-stop-button" type="button" data-dashboard-control="interruptRun" data-project-id="${escapeHtml(run.project_id || "")}" data-issue-id="${escapeHtml(run.issue_id || "")}" data-run-id="${escapeHtml(run.run_id || "")}" title="Stop this active Decodex work." aria-label="Stop this active Decodex work">
-						<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-							<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M4.35 2.25h7.3c1.16 0 2.1.94 2.1 2.1v7.3c0 1.16-.94 2.1-2.1 2.1h-7.3c-1.16 0-2.1-.94-2.1-2.1v-7.3c0-1.16.94-2.1 2.1-2.1Zm1.25 2.55h1.05c.42 0 .75.33.75.75v4.9c0 .42-.33.75-.75.75H5.6c-.42 0-.75-.33-.75-.75v-4.9c0-.42.33-.75.75-.75Zm3.75 0h1.05c.42 0 .75.33.75.75v4.9c0 .42-.33.75-.75.75H9.35c-.42 0-.75-.33-.75-.75v-4.9c0-.42.33-.75.75-.75Z"></path>
-						</svg>
-					</button>
-				`;
-			}
-
 			function renderActiveRuns(snapshot, derived) {
 				const runs = snapshot?.active_runs ?? [];
 				setPanelMeta(
@@ -9660,12 +9590,6 @@
 								}
 							}
 							const attemptNumber = attemptNumberFromRun(run);
-							const stopControl = renderRunStopControl(run);
-							const statusLineParts = [...statusBits];
-							if (stopControl) {
-								statusLineParts.splice(1, 0, stopControl);
-							}
-
 							return `
 							<article class="run-card ${tone}" data-render-key="${escapeHtml(renderKey)}">
 								<div class="row-head">
@@ -9681,7 +9605,7 @@
 										${runNeedsAttention(run) ? `<span>${escapeHtml(runHealthText(run))}</span>` : ""}
 									</div>
 								</div>
-									<div class="status-line">${statusLineParts.join("")}</div>
+									<div class="status-line">${statusBits.join("")}</div>
 									${summary ? `<p class="row-summary">${escapeHtml(summary)}</p>` : ""}
 									${renderRunMetaLine(run, snapshot)}
 									${renderChildAgentBreakdown(run)}
@@ -10470,9 +10394,6 @@
 			}
 
 			function dashboardControlActionLabel(action) {
-				if (action === "interruptRun" || action === "interrupt") {
-					return "Stop";
-				}
 				return displayToken(action);
 			}
 
@@ -10602,21 +10523,6 @@
 						: "0 PRs · 0 need attention · 0 ready · 0 waiting · 0 cleanup",
 				);
 				renderWorktrees(snapshot);
-			}
-
-			function handleDashboardControlClick(button) {
-				const control = button.dataset.dashboardControl;
-				const projectId = button.dataset.projectId || null;
-				const issueId = button.dataset.issueId || null;
-				const runId = button.dataset.runId || null;
-
-				switch (control) {
-					case "interruptRun":
-						sendDashboardControl(control, { projectId, issueId, runId });
-						break;
-					default:
-						break;
-				}
 			}
 
 			function startDashboardStream() {
@@ -10847,13 +10753,6 @@
 					if (lastDashboardRender) {
 						renderDashboardState(lastDashboardRender);
 					}
-					return;
-				}
-
-				const controlButton = event.target.closest("[data-dashboard-control]");
-				if (controlButton) {
-					event.preventDefault();
-					handleDashboardControlClick(controlButton);
 					return;
 				}
 

--- a/apps/decodex/src/orchestrator/operator_http.rs
+++ b/apps/decodex/src/orchestrator/operator_http.rs
@@ -1,13 +1,9 @@
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine as _;
 use sha1::{Digest as _, Sha1};
-use libc::SIGTERM;
 
 use crate::accounts;
 use crate::accounts::AccountUseRequest;
-
-#[cfg(test)]
-type DashboardRunInterrupterForTest = fn(u32) -> Result<()>;
 
 const OPERATOR_DASHBOARD_HTML: &str =
 	include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/orchestrator/operator_dashboard.html"));
@@ -20,10 +16,6 @@ const OPERATOR_DASHBOARD_LOGO_TOUCH_PNG: &[u8] = include_bytes!(concat!(
 	"/src/orchestrator/assets/logo-touch.png"
 ));
 const OPERATOR_HTTP_READ_TIMEOUT: Duration = Duration::from_millis(250);
-
-#[cfg(test)]
-static DASHBOARD_RUN_INTERRUPTER_FOR_TEST: Mutex<Option<DashboardRunInterrupterForTest>> =
-	Mutex::new(None);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum OperatorRequestRoute {
@@ -155,21 +147,6 @@ struct DashboardControlAck<'a> {
 struct DashboardRunActivityEvent {
 	fingerprint: Vec<u8>,
 	event: DashboardBroadcastEvent,
-}
-
-#[cfg(test)]
-struct DashboardRunInterrupterGuardForTest {
-	previous: Option<DashboardRunInterrupterForTest>,
-}
-#[cfg(test)]
-impl Drop for DashboardRunInterrupterGuardForTest {
-	fn drop(&mut self) {
-		let mut slot = DASHBOARD_RUN_INTERRUPTER_FOR_TEST
-			.lock()
-			.expect("dashboard run interrupter test hook should not be poisoned");
-
-		*slot = self.previous.take();
-	}
 }
 
 fn run_operator_state_endpoint(
@@ -781,9 +758,6 @@ fn dashboard_control_ready_payload(subscription: &DashboardClientSubscription) -
 			"subscribe",
 			"focus",
 			"clearFocus",
-			"pauseProject",
-			"resumeProject",
-			"interruptRun",
 			"selectAccount",
 			"clearAccountSelection",
 			"ack"
@@ -856,12 +830,6 @@ fn handle_dashboard_control_action(
 		"focus" => dashboard_focus_control_ack(session, message, action),
 		"clearFocus" | "clearSubscription" =>
 			dashboard_clear_focus_control_ack(session, message, action),
-		"pause" | "pauseProject" =>
-			dashboard_project_enabled_control_ack(session, state_store, message, action, false),
-		"resume" | "resumeProject" =>
-			dashboard_project_enabled_control_ack(session, state_store, message, action, true),
-		"interrupt" | "interruptRun" =>
-			dashboard_interrupt_control_ack(session, state_store, message, action),
 		"selectAccount" =>
 			dashboard_account_selection_control_ack(session, state_store, message, action, true),
 		"clearAccountSelection" =>
@@ -911,40 +879,6 @@ fn dashboard_clear_focus_control_ack(
 		project_id: None,
 		issue_id: None,
 		run_id: None,
-		subscription: Some(&session.subscription),
-	})
-}
-
-fn dashboard_project_enabled_control_ack(
-	session: &DashboardWebSocketSession,
-	state_store: &StateStore,
-	message: &DashboardClientMessage,
-	action: &str,
-	enabled: bool,
-) -> Value {
-	let Some(project_id) = dashboard_required_project_id(message) else {
-		return dashboard_missing_project_control_ack(session, message, action);
-	};
-	let result = state_store.set_project_enabled(project_id, enabled);
-	let (accepted, status, copy) = match (enabled, result) {
-		(true, Ok(())) => (true, "resumed", String::from("Project dispatch resumed.")),
-		(false, Ok(())) => (
-			true,
-			"paused",
-			String::from("Project dispatch paused; active lanes are not killed."),
-		),
-		(_, Err(error)) => (false, "failed", error.to_string()),
-	};
-
-	dashboard_control_ack_value(DashboardControlAck {
-		request_id: message.request_id.as_deref(),
-		action,
-		accepted,
-		status,
-		message: &copy,
-		project_id: Some(project_id),
-		issue_id: message.issue_id.as_deref(),
-		run_id: message.run_id.as_deref(),
 		subscription: Some(&session.subscription),
 	})
 }
@@ -1006,83 +940,6 @@ fn dashboard_account_selection_control_ack(
 		run_id: message.run_id.as_deref(),
 		subscription: Some(&session.subscription),
 	})
-}
-
-fn dashboard_interrupt_control_ack(
-	session: &DashboardWebSocketSession,
-	state_store: &StateStore,
-	message: &DashboardClientMessage,
-	action: &str,
-) -> Value {
-	let Some(project_id) = dashboard_required_project_id(message) else {
-		return dashboard_missing_project_control_ack(session, message, action);
-	};
-	let Some(issue_id) = dashboard_required_issue_id(message) else {
-		return dashboard_control_ack_value(DashboardControlAck {
-			request_id: message.request_id.as_deref(),
-			action,
-			accepted: false,
-			status: "missing_issue",
-			message: "Stop requires an issue id.",
-			project_id: Some(project_id),
-			issue_id: message.issue_id.as_deref(),
-			run_id: message.run_id.as_deref(),
-			subscription: Some(&session.subscription),
-		});
-	};
-	let Some(run_id) = dashboard_required_run_id(message) else {
-		return dashboard_control_ack_value(DashboardControlAck {
-			request_id: message.request_id.as_deref(),
-			action,
-			accepted: false,
-			status: "missing_run",
-			message: "Stop requires a run id.",
-			project_id: Some(project_id),
-			issue_id: Some(issue_id),
-			run_id: message.run_id.as_deref(),
-			subscription: Some(&session.subscription),
-		});
-	};
-
-	match interrupt_dashboard_run(state_store, project_id, issue_id, run_id) {
-		Ok(process_id) => dashboard_control_ack_value(DashboardControlAck {
-			request_id: message.request_id.as_deref(),
-			action,
-			accepted: true,
-			status: "interrupted",
-			message: &format!("Stopped run `{run_id}` by signaling process {process_id}."),
-			project_id: Some(project_id),
-			issue_id: Some(issue_id),
-			run_id: Some(run_id),
-			subscription: Some(&session.subscription),
-		}),
-		Err(error) => dashboard_control_ack_value(DashboardControlAck {
-			request_id: message.request_id.as_deref(),
-			action,
-			accepted: false,
-			status: "failed",
-			message: &error.to_string(),
-			project_id: Some(project_id),
-			issue_id: Some(issue_id),
-			run_id: Some(run_id),
-			subscription: Some(&session.subscription),
-		}),
-	}
-}
-
-fn dashboard_missing_project_control_ack(
-	session: &DashboardWebSocketSession,
-	message: &DashboardClientMessage,
-	action: &str,
-) -> Value {
-	dashboard_control_ack_for_message(
-		session,
-		message,
-		action,
-		false,
-		"missing_project",
-		"Control action requires a project id.",
-	)
 }
 
 fn dashboard_unsupported_control_ack(
@@ -1153,18 +1010,6 @@ fn dashboard_subscription_payload(subscription: &DashboardClientSubscription) ->
 	})
 }
 
-fn dashboard_required_project_id(message: &DashboardClientMessage) -> Option<&str> {
-	message.project_id.as_deref().map(str::trim).filter(|value| !value.is_empty())
-}
-
-fn dashboard_required_issue_id(message: &DashboardClientMessage) -> Option<&str> {
-	message.issue_id.as_deref().map(str::trim).filter(|value| !value.is_empty())
-}
-
-fn dashboard_required_run_id(message: &DashboardClientMessage) -> Option<&str> {
-	message.run_id.as_deref().map(str::trim).filter(|value| !value.is_empty())
-}
-
 fn dashboard_required_account_selector(message: &DashboardClientMessage) -> Option<&str> {
 	message
 		.account_selector
@@ -1178,100 +1023,6 @@ fn dashboard_clean_scope_value(value: Option<&str>) -> Option<String> {
 		.map(str::trim)
 		.filter(|value| !value.is_empty())
 		.map(str::to_owned)
-}
-
-fn interrupt_dashboard_run(
-	state_store: &StateStore,
-	project_id: &str,
-	issue_id: &str,
-	run_id: &str,
-) -> Result<u32> {
-	let run_attempt = state_store
-		.run_attempt(run_id)?
-		.ok_or_else(|| eyre::eyre!("Decodex run `{run_id}` is not recorded."))?;
-
-	if run_attempt.issue_id() != issue_id {
-		eyre::bail!(
-			"Decodex run `{run_id}` belongs to issue `{}`, not `{issue_id}`.",
-			run_attempt.issue_id()
-		);
-	}
-	if !matches!(run_attempt.status(), "starting" | "running") {
-		eyre::bail!(
-			"Decodex run `{run_id}` is `{}` and cannot be stopped.",
-			run_attempt.status()
-		);
-	}
-
-	let worktree = state_store
-		.worktree_for_issue(issue_id)?
-		.ok_or_else(|| eyre::eyre!("Issue `{issue_id}` has no recorded worktree."))?;
-
-	if worktree.project_id() != project_id {
-		eyre::bail!(
-			"Issue `{issue_id}` belongs to project `{}`, not `{project_id}`.",
-			worktree.project_id()
-		);
-	}
-
-	let marker = state::read_run_activity_marker_snapshot(worktree.worktree_path())?
-		.ok_or_else(|| eyre::eyre!("Run `{run_id}` has no activity marker."))?;
-
-	if marker.run_id() != run_id || marker.attempt_number() != run_attempt.attempt_number() {
-		eyre::bail!("Run `{run_id}` activity marker does not match the active attempt.");
-	}
-
-	let process_id = marker
-		.process_id()
-		.ok_or_else(|| eyre::eyre!("Run `{run_id}` has no recorded process id."))?;
-
-	interrupt_dashboard_process(process_id)?;
-
-	state_store.update_run_status(run_id, "interrupted")?;
-	state_store.clear_lease(issue_id)?;
-
-	Ok(process_id)
-}
-
-fn interrupt_dashboard_process(process_id: u32) -> Result<()> {
-	#[cfg(test)]
-	if let Some(interrupter) = *DASHBOARD_RUN_INTERRUPTER_FOR_TEST
-		.lock()
-		.expect("dashboard run interrupter test hook should not be poisoned")
-	{
-		return interrupter(process_id);
-	}
-
-	if process_id == process::id() {
-		eyre::bail!("Refusing to stop the Decodex control-plane process.");
-	}
-
-	let process_id = pid_t::try_from(process_id)
-		.map_err(|error| eyre::eyre!("Run process id is out of range: {error}"))?;
-
-	if process_id <= 0 {
-		eyre::bail!("Run process id must be positive.");
-	}
-
-	let result = unsafe { libc::kill(process_id, SIGTERM) };
-
-	if result == 0 {
-		return Ok(());
-	}
-
-	eyre::bail!("Failed to stop run process `{process_id}`.");
-}
-
-#[cfg(test)]
-fn install_dashboard_run_interrupter_for_test(
-	interrupter: DashboardRunInterrupterForTest,
-) -> DashboardRunInterrupterGuardForTest {
-	let mut slot = DASHBOARD_RUN_INTERRUPTER_FOR_TEST
-		.lock()
-		.expect("dashboard run interrupter test hook should not be poisoned");
-	let previous = slot.replace(interrupter);
-
-	DashboardRunInterrupterGuardForTest { previous }
 }
 
 fn dashboard_event_for_subscription(

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -1088,7 +1088,7 @@ fn operator_dashboard_accounts_keeps_debug_credit_and_reset_copy_compact() {
 }
 
 #[test]
-fn operator_dashboard_omits_watch_and_project_pause_controls() {
+fn operator_dashboard_omits_lane_mutation_controls() {
 	let response = dashboard_response();
 
 	assert!(!response.contains("function dashboardSubscriptionMatches(subscription)"));
@@ -1106,17 +1106,16 @@ fn operator_dashboard_omits_watch_and_project_pause_controls() {
 	assert!(!response.contains(">Resume</button>"));
 	assert!(!response.contains("data-dashboard-control=\"retryRun\""));
 	assert!(!response.contains(">Retry now</button>"));
-	assert!(response.contains("data-dashboard-control=\"interruptRun\""));
-	assert!(response.contains("aria-label=\"Stop this active Decodex work\""));
-	assert!(response.contains("const statusLineParts = [...statusBits];"));
-	assert!(response.contains("statusLineParts.splice(1, 0, stopControl);"));
-	assert!(response.contains(".status-line .run-stop-button {"));
-	assert!(response.contains("width: 18px;"));
-	assert!(response.contains("border: 0;"));
-	assert!(response.contains("background: transparent;"));
-	assert!(response.contains("color: color-mix(in srgb, var(--danger) 86%, var(--text));"));
-	assert!(response.contains("<path fill=\"currentColor\" fill-rule=\"evenodd\" clip-rule=\"evenodd\""));
-	assert!(response.contains("d=\"M4.35 2.25h7.3"));
+	assert!(!response.contains("data-dashboard-control=\"interruptRun\""));
+	assert!(!response.contains("aria-label=\"Stop this active Decodex work\""));
+	assert!(!response.contains("runInterruptControlEnabled"));
+	assert!(!response.contains("renderRunStopControl"));
+	assert!(!response.contains("const statusLineParts = [...statusBits];"));
+	assert!(!response.contains("statusLineParts.splice(1, 0, stopControl);"));
+	assert!(!response.contains(".status-line .run-stop-button {"));
+	assert!(!response.contains("action === \"interruptRun\""));
+	assert!(!response.contains("case \"interruptRun\""));
+	assert!(response.contains("<div class=\"status-line\">${statusBits.join(\"\")}</div>"));
 	assert!(!response.contains("<rect x=\"4.2\" y=\"3.2\" width=\"2.9\" height=\"9.6\""));
 	assert!(!response.contains("class=\"row-head run-row-head\""));
 	assert!(!response.contains("class=\"run-head-aside\""));

--- a/apps/decodex/src/orchestrator/tests/operator/status/http.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/http.rs
@@ -121,9 +121,6 @@ fn assert_dashboard_html_control_surface(response: &str) {
 		"WebSocket",
 		"applyDashboardRunActivity",
 		"sendDashboardControl",
-		"data-dashboard-control=\"interruptRun\"",
-		"aria-label=\"Stop this active Decodex work\"",
-		"if (!interruptEnabled) {",
 		"controlAck",
 	] {
 		assert!(response.contains(required), "missing required dashboard control marker `{required}`");
@@ -131,6 +128,12 @@ fn assert_dashboard_html_control_surface(response: &str) {
 	for forbidden in [
 		"/state",
 		"/readyz",
+		"data-dashboard-control=\"interruptRun\"",
+		"aria-label=\"Stop this active Decodex work\"",
+		"runInterruptControlEnabled",
+		"renderRunStopControl",
+		"action === \"interruptRun\"",
+		"case \"interruptRun\"",
 		"data-dashboard-control=\"focusProject\"",
 		"data-dashboard-control=\"focusRun\"",
 		"data-dashboard-control=\"pauseProject\"",
@@ -430,7 +433,7 @@ fn operator_dashboard_websocket_sends_current_run_activity_on_connect() {
 }
 
 #[test]
-fn operator_dashboard_websocket_accepts_subscription_and_project_pause_control() {
+fn operator_dashboard_websocket_accepts_subscription_and_account_selection_controls() {
 	let (_temp_dir, config, _workflow) = temp_project_layout();
 	let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
 	let address = listener.local_addr().expect("listener address should resolve");
@@ -471,6 +474,27 @@ fn operator_dashboard_websocket_accepts_subscription_and_project_pause_control()
 
 	assert!(response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"));
 
+	let control_ready = read_websocket_json_until(&mut client, &mut frame, |payload| {
+		payload["type"] == "controlReady"
+	});
+	let supported_actions = control_ready["payload"]["supportedActions"]
+		.as_array()
+		.expect("supported actions should list");
+
+	assert!(supported_actions.iter().any(|action| action.as_str() == Some("subscribe")));
+	assert!(supported_actions.iter().any(|action| action.as_str() == Some("focus")));
+	assert!(supported_actions.iter().any(|action| action.as_str() == Some("clearFocus")));
+	assert!(supported_actions.iter().any(|action| action.as_str() == Some("selectAccount")));
+	assert!(
+		supported_actions
+			.iter()
+			.any(|action| action.as_str() == Some("clearAccountSelection"))
+	);
+	assert!(supported_actions.iter().any(|action| action.as_str() == Some("ack")));
+	assert!(!supported_actions.iter().any(|action| action.as_str() == Some("pauseProject")));
+	assert!(!supported_actions.iter().any(|action| action.as_str() == Some("resumeProject")));
+	assert!(!supported_actions.iter().any(|action| action.as_str() == Some("interruptRun")));
+
 	client
 		.write_all(&websocket_client_text_frame(
 			r#"{"type":"subscribe","requestId":"sub-1","projectId":"pubfi"}"#,
@@ -483,50 +507,6 @@ fn operator_dashboard_websocket_accepts_subscription_and_project_pause_control()
 
 	assert_eq!(subscribe_ack["payload"]["accepted"], true);
 	assert_eq!(subscribe_ack["payload"]["subscription"]["projectId"], "pubfi");
-
-	client
-		.write_all(&websocket_client_text_frame(
-			r#"{"type":"control","requestId":"pause-1","action":"pauseProject","projectId":"pubfi"}"#,
-		))
-		.expect("client should send pause");
-
-	let pause_ack = read_websocket_json_until(&mut client, &mut frame, |payload| {
-		payload["type"] == "controlAck" && payload["payload"]["requestId"] == "pause-1"
-	});
-
-	assert_eq!(pause_ack["payload"]["accepted"], true);
-	assert_eq!(pause_ack["payload"]["status"], "paused");
-	assert!(
-		!state_store
-			.list_projects()
-			.expect("projects should list")
-			.into_iter()
-			.find(|project| project.service_id() == "pubfi")
-			.expect("project should remain registered")
-			.enabled()
-	);
-
-	client
-		.write_all(&websocket_client_text_frame(
-			r#"{"type":"control","requestId":"resume-1","action":"resumeProject","projectId":"pubfi"}"#,
-		))
-		.expect("client should send resume");
-
-	let resume_ack = read_websocket_json_until(&mut client, &mut frame, |payload| {
-		payload["type"] == "controlAck" && payload["payload"]["requestId"] == "resume-1"
-	});
-
-	assert_eq!(resume_ack["payload"]["accepted"], true);
-	assert_eq!(resume_ack["payload"]["status"], "resumed");
-	assert!(
-		state_store
-			.list_projects()
-			.expect("projects should list")
-			.into_iter()
-			.find(|project| project.service_id() == "pubfi")
-			.expect("project should remain registered")
-			.enabled()
-	);
 
 	assert_dashboard_account_selection_controls(&mut client, &mut frame, config.repo_root());
 	drop(client);
@@ -745,51 +725,33 @@ fn operator_dashboard_websocket_filters_run_activity_by_subscription() {
 }
 
 #[test]
-fn operator_dashboard_websocket_interrupt_control_stops_active_run_process() {
+fn operator_dashboard_websocket_rejects_lane_mutation_controls() {
 	let (_temp_dir, config, _workflow) = temp_project_layout();
 	let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
 	let address = listener.local_addr().expect("listener address should resolve");
 	let snapshot = Arc::new(Mutex::new(PublishedOperatorSnapshot::default()));
 	let state_store = Arc::new(StateStore::open_in_memory().expect("state store should open"));
 	let issue = sample_issue("Todo", &[]);
-	let worktree_path = config.worktree_root().join("PUB-101");
 	let dashboard_events = DashboardEventHub::default();
 	let server_snapshot = Arc::clone(&snapshot);
 	let server_state_store = Arc::clone(&state_store);
 	let server_dashboard_events = dashboard_events.clone();
-	let interrupter_calls = dashboard_run_interrupter_calls_for_test();
+	let registration = ProjectRegistration::from_config(
+		config.service_id(),
+		&service_config_path(config.repo_root()),
+		&config,
+		true,
+		"test-fingerprint",
+	);
 
+	state_store.upsert_project(&registration).expect("project should register");
 	state_store
 		.record_run_attempt("run-1", &issue.id, 1, "running")
 		.expect("run attempt should record");
 	state_store
 		.upsert_lease(config.service_id(), &issue.id, "run-1", "In Progress")
 		.expect("lease should record");
-	state_store
-		.upsert_worktree(
-			config.service_id(),
-			&issue.id,
-			"x/pubfi-pub-101",
-			&worktree_path.display().to_string(),
-		)
-		.expect("worktree should record");
 
-	state::write_run_operation_marker_for_process(
-		&worktree_path,
-		"run-1",
-		1,
-		4_242,
-		RUN_OPERATION_AGENT_RUN,
-	)
-	.expect("run operation marker should write");
-
-	interrupter_calls
-		.lock()
-		.expect("dashboard run interrupter calls should not be poisoned")
-		.clear();
-
-	let _interrupter_guard =
-		orchestrator::install_dashboard_run_interrupter_for_test(fake_dashboard_run_interrupter);
 	let server = thread::spawn(move || {
 		let (stream, _) = listener.accept().expect("listener should accept a connection");
 
@@ -806,130 +768,57 @@ fn operator_dashboard_websocket_interrupt_control_stops_active_run_process() {
 
 	assert!(response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"));
 
-	let interrupt_message = format!(
-		r#"{{"type":"control","requestId":"interrupt-1","action":"interruptRun","projectId":"{}","issueId":"{}","runId":"run-1"}}"#,
-		config.service_id(),
-		issue.id,
-	);
+	for (request_id, action) in [
+		("pause-1", "pauseProject"),
+		("resume-1", "resumeProject"),
+		("interrupt-1", "interruptRun"),
+	] {
+		let control_message = format!(
+			r#"{{"type":"control","requestId":"{request_id}","action":"{action}","projectId":"{}","issueId":"{}","runId":"run-1"}}"#,
+			config.service_id(),
+			issue.id,
+		);
 
-	client
-		.write_all(&websocket_client_text_frame(&interrupt_message))
-		.expect("client should send interrupt");
+		client
+			.write_all(&websocket_client_text_frame(&control_message))
+			.expect("client should send unsupported dashboard control");
 
-	let interrupt_ack = read_websocket_json_until(&mut client, &mut frame, |payload| {
-		payload["type"] == "controlAck" && payload["payload"]["requestId"] == "interrupt-1"
-	});
+		let ack = read_websocket_json_until(&mut client, &mut frame, |payload| {
+			payload["type"] == "controlAck" && payload["payload"]["requestId"] == request_id
+		});
 
-	assert_eq!(interrupt_ack["payload"]["accepted"], true);
-	assert_eq!(interrupt_ack["payload"]["status"], "interrupted");
-	assert_eq!(interrupt_ack["payload"]["projectId"], config.service_id());
-	assert_eq!(interrupt_ack["payload"]["issueId"], issue.id);
-	assert_eq!(interrupt_ack["payload"]["runId"], "run-1");
+		assert_eq!(ack["payload"]["accepted"], false);
+		assert_eq!(ack["payload"]["status"], "unsupported_action");
+		assert_eq!(ack["payload"]["action"], action);
+		assert_eq!(ack["payload"]["projectId"], config.service_id());
+		assert_eq!(ack["payload"]["issueId"], issue.id);
+		assert_eq!(ack["payload"]["runId"], "run-1");
+	}
+
 	assert!(
-		interrupt_ack["payload"]["message"]
-			.as_str()
-			.expect("interrupt ack message should be text")
-			.contains("process 4242")
+		state_store
+			.list_projects()
+			.expect("projects should list")
+			.into_iter()
+			.find(|project| project.service_id() == config.service_id())
+			.expect("project should remain registered")
+			.enabled(),
+		"unsupported project controls should not pause dispatch"
 	);
-
-	let calls = interrupter_calls
-		.lock()
-		.expect("dashboard run interrupter calls should not be poisoned");
-
-	assert_eq!(calls.len(), 1);
-	assert_eq!(calls[0], 4_242);
 	assert_eq!(
 		state_store
 			.run_attempt("run-1")
 			.expect("run lookup should succeed")
 			.expect("run should remain recorded")
 			.status(),
-		"interrupted",
+		"running",
 	);
 	assert!(
 		state_store
 			.lease_for_issue(&issue.id)
 			.expect("lease lookup should succeed")
-			.is_none(),
-		"interrupt should release the queue lease"
-	);
-
-	drop(calls);
-	drop(client);
-
-	dashboard_events.close_clients_for_test();
-	server.join().expect("server thread should complete");
-}
-
-#[test]
-fn operator_dashboard_websocket_interrupt_control_reports_validation_errors() {
-	let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
-	let address = listener.local_addr().expect("listener address should resolve");
-	let snapshot = Arc::new(Mutex::new(PublishedOperatorSnapshot::default()));
-	let state_store = Arc::new(StateStore::open_in_memory().expect("state store should open"));
-	let dashboard_events = DashboardEventHub::default();
-	let server_snapshot = Arc::clone(&snapshot);
-	let server_state_store = Arc::clone(&state_store);
-	let server_dashboard_events = dashboard_events.clone();
-	let server = thread::spawn(move || {
-		let (stream, _) = listener.accept().expect("listener should accept a connection");
-
-		orchestrator::handle_operator_state_endpoint_connection(
-			stream,
-			&server_snapshot,
-			&server_dashboard_events,
-			&OperatorControlRequests::default(),
-			&server_state_store,
-		)
-		.expect("websocket handler should complete after client disconnect");
-	});
-	let (mut client, response, mut frame) = open_dashboard_websocket_client(address);
-
-	assert!(response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"));
-
-	client
-		.write_all(&websocket_client_text_frame(
-			r#"{"type":"control","requestId":"missing-project","action":"pauseProject"}"#,
-		))
-		.expect("client should send missing-project control");
-
-	let missing_project_ack = read_websocket_json_until(&mut client, &mut frame, |payload| {
-		payload["type"] == "controlAck" && payload["payload"]["requestId"] == "missing-project"
-	});
-
-	assert_eq!(missing_project_ack["payload"]["accepted"], false);
-	assert_eq!(missing_project_ack["payload"]["status"], "missing_project");
-
-	client
-		.write_all(&websocket_client_text_frame(
-			r#"{"type":"control","requestId":"missing-run","action":"interruptRun","projectId":"pubfi","issueId":"PUB-101"}"#,
-		))
-		.expect("client should send missing-run control");
-
-	let missing_run_ack = read_websocket_json_until(&mut client, &mut frame, |payload| {
-		payload["type"] == "controlAck" && payload["payload"]["requestId"] == "missing-run"
-	});
-
-	assert_eq!(missing_run_ack["payload"]["accepted"], false);
-	assert_eq!(missing_run_ack["payload"]["status"], "missing_run");
-
-	client
-		.write_all(&websocket_client_text_frame(
-			r#"{"type":"control","requestId":"unknown-run","action":"interruptRun","projectId":"pubfi","issueId":"PUB-101","runId":"missing"}"#,
-		))
-		.expect("client should send unknown-run control");
-
-	let unknown_run_ack = read_websocket_json_until(&mut client, &mut frame, |payload| {
-		payload["type"] == "controlAck" && payload["payload"]["requestId"] == "unknown-run"
-	});
-
-	assert_eq!(unknown_run_ack["payload"]["accepted"], false);
-	assert_eq!(unknown_run_ack["payload"]["status"], "failed");
-	assert!(
-		unknown_run_ack["payload"]["message"]
-			.as_str()
-			.expect("interrupt ack message should be text")
-			.contains("not recorded")
+			.is_some(),
+		"unsupported interrupt should not release the queue lease"
 	);
 
 	drop(client);
@@ -1031,21 +920,6 @@ fn websocket_client_text_frame(payload: &str) -> Vec<u8> {
 	frame.extend(payload.iter().enumerate().map(|(index, byte)| byte ^ mask[index % mask.len()]));
 
 	frame
-}
-
-fn dashboard_run_interrupter_calls_for_test() -> &'static Mutex<Vec<u32>> {
-	static CALLS: std::sync::OnceLock<Mutex<Vec<u32>>> = std::sync::OnceLock::new();
-
-	CALLS.get_or_init(|| Mutex::new(Vec::new()))
-}
-
-fn fake_dashboard_run_interrupter(process_id: u32) -> Result<()> {
-	dashboard_run_interrupter_calls_for_test()
-		.lock()
-		.expect("dashboard run interrupter calls should not be poisoned")
-		.push(process_id);
-
-	Ok(())
 }
 
 fn read_websocket_json_until(

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -157,11 +157,11 @@ renders active-lane state, protocol activity, liveness, private-evidence referen
 and local acknowledgement/account controls, but it is not the supported place to author
 steer, retry, task replacement, or lifecycle mutations. CLI/API is the first
 operator-control surface for lane control, governed by
-[`../spec/lane-control.md`](../spec/lane-control.md). Existing low-level WebSocket
-control handlers, including the hard stop fallback, are not the broad lane-control
-contract and must not be expanded into dashboard steer/retry/task controls in this
-rollout. Project watch, project pause/resume buttons, manual retry controls, and active
-lane steer controls are intentionally not shown. `runActivity.activeRunsComplete`
+[`../spec/lane-control.md`](../spec/lane-control.md). The browser UI does not show or
+accept active-lane stop/interrupt controls, project pause/resume controls, manual retry
+controls, or active-lane steer controls. Account-pool selection remains available
+because it changes the global Codex account selector, not an active lane.
+`runActivity.activeRunsComplete`
 marks whether a payload is the complete active-run list; subscription-filtered
 payloads set it to `false`, so consumers must not treat a missing run in that payload
 as ended.
@@ -170,11 +170,7 @@ operator action, snapshots may also include `warning_details` entries with the
 affected `project_id`, `repo_root`, reason, and next action; for example, a stale
 registered project whose repo path is no longer a Git checkout can explain the bad
 project instead of only surfacing `worktree_hygiene_unavailable`.
-The existing hard stop fallback, where available, signals the recorded child process
-for that run, marks the local attempt interrupted, and releases the local queue lease.
-It is an emergency fallback, not the preferred lane-control path. Soft interruption
-through CLI/API `turn/interrupt` should become the preferred active-turn control once
-implemented. `ack` is dashboard-local acknowledgement only. The socket is not a browser
+Dashboard `ack` is dashboard-local acknowledgement only. The socket is not a browser
 connection to Codex app-server, GitHub, or Linear, and it does not make high-frequency
 protocol activity durable outside the local operator surface.
 

--- a/docs/spec/lane-control.md
+++ b/docs/spec/lane-control.md
@@ -34,11 +34,11 @@ agent-facing skills must guide responsible use.
 | Capability | Contract status | Current implementation evidence | Required behavior |
 | --- | --- | --- | --- |
 | Inspect lane state | Supported | `decodex status`, `decodex status --json`, `decodex diagnose --json`, `decodex evidence <ISSUE>`, operator snapshots, and dashboard views | Always inspect before mutating or steering. Inspection must not mutate tracker state, runtime DB rows, worktrees, or app-server turns. |
-| Project dispatch pause | Supported for future dispatch | `decodex project disable <service-id>` and the runtime project enabled flag; dashboard control handlers can also toggle the same flag | Pause prevents new dispatch for the project. It must not kill or rewrite already active lanes. |
-| Project dispatch resume | Supported for future dispatch | `decodex project enable <service-id>` and the runtime project enabled flag; dashboard control handlers can also toggle the same flag | Resume re-enables future dispatch after the operator has inspected blockers, capacity, and queue state. |
+| Project dispatch pause | Supported for future dispatch | `decodex project disable <service-id>` and the runtime project enabled flag | Pause prevents new dispatch for the project. It must not kill or rewrite already active lanes. |
+| Project dispatch resume | Supported for future dispatch | `decodex project enable <service-id>` and the runtime project enabled flag | Resume re-enables future dispatch after the operator has inspected blockers, capacity, and queue state. |
 | Linear scan request | Supported | `POST /api/linear-scan` with optional `projectId` | Queue a scan for the next control-plane tick while respecting tracker backoff. This is an intake/status refresh request, not an execution command. |
 | Soft interrupt | Planned CLI/API control; bottom-layer method allowed | Decodex does not currently send `turn/interrupt` from its app-server client | Prefer soft interrupt before hard interruption when the active turn id is known and the app-server capability is present. Soft interrupt requests a graceful turn stop and must leave classification to the runtime. |
-| Hard interrupt fallback | Emergency fallback only | Current dashboard `interruptRun` signals the recorded process and marks the attempt `interrupted` | Use only when soft interrupt is unavailable, timed out, or impossible because the process or app-server boundary cannot be reached. Preserve retained worktree evidence and runtime classification. |
+| Hard interrupt fallback | Emergency fallback only | No dashboard or CLI/API lane-control path exposes hard interrupt in this rollout; runtime recovery can still classify attempts as `interrupted` | Use only when soft interrupt is unavailable, timed out, or impossible because the process or app-server boundary cannot be reached. Preserve retained worktree evidence and runtime classification. |
 | Steer active lane | Planned CLI/API control; bottom-layer method must stay broad | Decodex does not currently send `turn/steer` from its app-server client | Pass operator-supplied steer text through the CLI/API when available. Do not narrow the protocol to a fixed set of task-content categories. Apply policy, audit, privacy, and lifecycle guardrails above the protocol. |
 | Retained resume/retry | Supported through runtime lifecycle | `decodex run <ISSUE>`, retry scheduling, retained worktree recovery, and `thread/resume` for same-thread app-server continuation | Resume only when retained worktree, issue, branch, PR, and runtime evidence still prove the same lane. Treat ambiguous lineage as manual attention. |
 | Manual attention | Supported terminal control path | `decodex:needs-attention`, `issue_comment(kind = "manual_attention")`, and `issue_terminal_finalize(path = "manual_attention")` | Stop automation when policy requires a human decision. Explain the blocker through structured public fields and keep private evidence local. |
@@ -150,10 +150,11 @@ Linear unless a schema-controlled public projection explicitly allows it.
 ## Implementation Status For This Rollout
 
 This document specifies capabilities that the CLI/API should expose first. Current code
-already supports inspect, project enable/disable, Linear scan requests, retained
+already supports inspect, CLI project enable/disable, Linear scan requests, retained
 resume/retry lifecycle paths, and manual-attention finalization. Current code does not
-yet implement Decodex CLI/API controls that send `turn/interrupt` or `turn/steer`, and
-it does not expose raw `thread/inject_items` as an operator feature.
+expose dashboard lane-mutation controls, does not yet implement Decodex CLI/API
+controls that send `turn/interrupt` or `turn/steer`, and does not expose raw
+`thread/inject_items` as an operator feature.
 
 When implementation work adds the missing CLI/API controls, update this spec,
 [`app-server.md`](./app-server.md), the operator reference, and the Decodex plugin


### PR DESCRIPTION
## Summary
- Remove dashboard active-lane stop/interrupt UI and click dispatch.
- Stop advertising and accepting dashboard WebSocket lane/project mutation actions while preserving subscribe/focus/ack and account selection controls.
- Update focused dashboard tests and operator-control-plane docs for the observe-only active-lane mutation boundary.

## Verification
- cargo make fmt
- cargo make lint-fix
- cargo make test
- git diff --check
- semantic drift audit: pass