### PR TITLE
Allow Decodex App fallback server dogfood

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -14,10 +14,12 @@ bundled Rust app helper so account UI stays on the same CLI-owned files even whe
 long-running local `decodex serve` is older than the app bundle. On launch the app also
 connects to an existing `decodex serve` on the default local endpoint when one is
 available; otherwise it starts the bundled Decodex binary as a normal scheduler with
-`decodex serve --listen-address 127.0.0.1:8912`. The CLI owns the default scheduler
-interval, currently 15 seconds. App-started servers load the enabled project registry
-and own the same operator listener as a manually started `decodex serve`. The helper
-owns account operations and interactive login flows that need streamed command output:
+`decodex serve --allow-unverified-codex --listen-address 127.0.0.1:8912`. The override
+only downgrades unverified Codex app-server identity to a warning; other preflight
+blockers remain fail-closed. The CLI owns the default scheduler interval, currently
+15 seconds. App-started servers load the enabled project registry and own the same
+operator listener as a manually started `decodex serve`. The helper owns account
+operations and interactive login flows that need streamed command output:
 
 - list accounts without printing token material
 - pin future Decodex runs to one account
@@ -75,9 +77,10 @@ swift run --package-path apps/decodex-app DecodexApp
 
 Use hidden `decodex serve --dev` only when manually testing local account APIs, the app
 snapshot API, or dashboard routes while deliberately avoiding scheduler activity. The
-normal app fallback is ordinary `decodex serve --listen-address 127.0.0.1:8912`. Do
-not use `--dev` to validate project registration, Linear polling, queue intake, or
-retained-lane execution; use ordinary `decodex serve` for those paths.
+normal app fallback is `decodex serve --allow-unverified-codex --listen-address
+127.0.0.1:8912` so development Codex app-server builds can still run through the local
+operator surface. Do not use `--dev` to validate project registration, Linear polling,
+queue intake, or retained-lane execution; use ordinary `decodex serve` for those paths.
 
 The staging script follows the local Rsnap-style signing path: it writes
 `target/decodex-app/Decodex App.app`, signs the bundle with an Apple Development

--- a/apps/decodex-app/Sources/DecodexApp/DecodexServerBridge.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexServerBridge.swift
@@ -221,10 +221,7 @@ actor DecodexServerBridge {
 		let nullDevice = FileHandle(forWritingAtPath: "/dev/null")
 
 		process.executableURL = try decodexExecutableURL()
-		process.arguments = [
-			"serve",
-			"--listen-address", defaultListenAddress,
-		]
+		process.arguments = Self.bundledServerArguments(listenAddress: defaultListenAddress)
 		process.standardOutput = nullDevice
 		process.standardError = nullDevice
 
@@ -235,6 +232,14 @@ actor DecodexServerBridge {
 		}
 
 		startedProcess = process
+	}
+
+	static func bundledServerArguments(listenAddress: String) -> [String] {
+		[
+			"serve",
+			"--allow-unverified-codex",
+			"--listen-address", listenAddress,
+		]
 	}
 
 	private func decodexExecutableURL() throws -> URL {

--- a/apps/decodex-app/Sources/DecodexApp/Models.swift
+++ b/apps/decodex-app/Sources/DecodexApp/Models.swift
@@ -430,7 +430,7 @@ struct CodexAccount: Decodable, Identifiable, Equatable {
 		if let recoveryAction = AccountRecoveryAction(rawValue: normalized(recoveryAction)) {
 			return recoveryAction
 		}
-		if !refreshTokenPresent {
+		if refreshTokenPresent == false {
 			return .login
 		}
 		if normalized(refreshStatus) == "failed" {

--- a/apps/decodex-app/Tests/DecodexAppTests/DecodexServerBridgeTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/DecodexServerBridgeTests.swift
@@ -1,0 +1,16 @@
+@testable import DecodexApp
+import XCTest
+
+final class DecodexServerBridgeTests: XCTestCase {
+	func testBundledServerArgumentsAllowUnverifiedCodex() {
+		XCTAssertEqual(
+			DecodexServerBridge.bundledServerArguments(listenAddress: "127.0.0.1:8912"),
+			[
+				"serve",
+				"--allow-unverified-codex",
+				"--listen-address",
+				"127.0.0.1:8912",
+			]
+		)
+	}
+}


### PR DESCRIPTION
## Summary
- start the bundled Decodex App fallback server with `--allow-unverified-codex`
- keep the app fallback command documented with the same fail-closed boundary as the CLI override
- add a Swift test that locks the fallback server arguments
- remove one Swift style-gate false-positive by rewriting `!refreshTokenPresent` as `refreshTokenPresent == false`

## Verification
- `swift test --package-path apps/decodex-app`
- `cargo vstyle curate --language swift --workspace`
- `cargo make test-decodex-app-stage`
- `git diff --check`
- semantic drift audit: pass; README fallback command matches `DecodexServerBridge.bundledServerArguments` and the new test