### PR TITLE
Record skipped X Publisher candidate for PR 25636

### DIFF
--- a/artifacts/social/x/posts/2026-06-03/openai-codex-pr-25636.json
+++ b/artifacts/social/x/posts/2026-06-03/openai-codex-pr-25636.json
@@ -1,0 +1,68 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-25636",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "skipped",
+  "audience": "Codex operators and Decodex Control Plane builders",
+  "text": [
+    "Codex MultiAgentV2 renamed its trigger-turn tool: assign_task is now followup_task. Legacy rollout traces still classify assign_task, so old traces reduce correctly. Source: https://github.com/openai/codex/pull/25636"
+  ],
+  "source_refs": {
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-25636.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-25636.review.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/25636",
+      "https://github.com/openai/codex/commit/c9bdb5255b2b4b5d365a1be3ec3a94e34a4e0af0"
+    ]
+  },
+  "evidence_notes": [
+    "The upstream review and impact artifacts classify PR #25636 as a confirmed MultiAgentV2 rename with a Decodex compatibility risk and operator_impact Publisher angle.",
+    "Automation memory from 2026-06-03T07:01:10Z and 2026-06-03T07:08:30Z records operator feedback that this exact candidate was not clearly valuable, the previous post was deleted, and future runs must not publish small upstream naming or compatibility notes unless they map to a concrete user workflow, release decision, or broader externally legible impact.",
+    "A stale worktree without the newer x-post-quality-system skill caused this run to initially miss the prior quality decision.",
+    "The run accidentally published https://x.com/decodexspace/status/2062154673403162779, then deleted it after reading the automation memory; direct permalink reload showed the page no longer existed and no candidate text remained visible.",
+    "Chrome account state was restored to @hackink and scoped Chrome tabs were finalized after the deletion readback."
+  ],
+  "claims": [
+    {
+      "text": "Codex MultiAgentV2 renamed the trigger-turn tool from assign_task to followup_task.",
+      "evidence": "https://github.com/openai/codex/pull/25636",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Legacy rollout traces still classify assign_task as an agent-task dispatch.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-25636.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "This candidate should not remain published from @decodexspace because prior operator feedback rejected this exact low-context rename post as not valuable.",
+      "evidence": "/Users/x/.codex/automations/decodex-x-publisher/memory.md",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "skip",
+    "priority": "low",
+    "idempotency_key": "x:decodexspace:operator_impact:openai-codex-pr-25636",
+    "reason": "Prior automation memory and operator feedback already rejected this exact PR #25636 rename as low-value social content; no live publication should remain.",
+    "daily_limit": 8,
+    "daily_count_before": 0,
+    "daily_count_after": 0,
+    "day": "2026-06-03",
+    "timezone": "Asia/Shanghai"
+  },
+  "skip": {
+    "reason": "prior_quality_decision_rejected_candidate"
+  },
+  "caveats": [
+    "The accidental X permalink https://x.com/decodexspace/status/2062154673403162779 was live briefly during this run, then deleted.",
+    "No live @decodexspace publication remains for this candidate from this run.",
+    "The checked-out worktree did not include the newer x-post-quality-system skill from PR 194, so future runs should ensure the quality skill is present before judging publish worthiness."
+  ]
+}


### PR DESCRIPTION
## Summary
- record the June 3 X Publisher run for openai/codex PR #25636 as skipped
- preserve why the candidate is not publishable: prior automation memory recorded operator feedback rejecting this exact low-context rename post
- note the corrective deletion of the accidental X post from this run

## Outcome
- Terminal state: skipped
- No live @decodexspace publication remains for this candidate from this run
- Accidental permalink deleted: https://x.com/decodexspace/status/2062154673403162779 now reads as unavailable in Chrome permalink readback
- Daily cap day: 2026-06-03 Asia/Shanghai, count remains 0 -> 0

## Verification
- cargo run -p decodex --bin decodex -- radar validate artifacts/social/x
- Chrome deletion readback: direct permalink reload showed the page no longer existed and no candidate text remained visible
- Chrome account state restored to @hackink and scoped tabs finalized

## Labels
- codex and codex-automation labels were not present in the repo label list, so no labels were applied.