### PR TITLE
Fix dashboard account pool divider

### DIFF
--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -2125,7 +2125,7 @@
 				cursor: pointer;
 			}
 
-			.account-pool-list > .account-row:last-child {
+			.account-pool-list > .account-row.is-last-account {
 				border-bottom: 0;
 			}
 
@@ -7185,7 +7185,7 @@
 					`;
 				}
 
-				function renderCodexAccountPoolRow(account, snapshot) {
+				function renderCodexAccountPoolRow(account, snapshot, isLastAccount = false) {
 					const weight = codexAccountCapacityLabel(account);
 					const statusTone = codexAccountStatusTone(account);
 					const toneClass = statusTone ? ` is-${statusTone}` : "";
@@ -7207,12 +7207,13 @@
 					const profileExpanded = hasProfileDetails && codexAccountProfileExpanded(account);
 					const profileOpenClass = profileExpanded ? " is-profile-open" : "";
 					const profileToggleableClass = hasProfileDetails ? " is-profile-toggleable" : "";
+					const lastAccountClass = isLastAccount ? " is-last-account" : "";
 					const profileRowToggleAttribute = hasProfileDetails
 						? ` data-account-profile-row-toggle="${escapeHtml(profileKey)}"`
 						: "";
 
 					return `
-							<div class="account-row${selectedClass}${fixedClass}${armedClass}${toneClass}${profileOpenClass}${profileToggleableClass}" data-render-key="account-row:${escapeHtml(profileKey)}"${profileRowToggleAttribute}>
+							<div class="account-row${selectedClass}${fixedClass}${armedClass}${toneClass}${profileOpenClass}${profileToggleableClass}${lastAccountClass}" data-render-key="account-row:${escapeHtml(profileKey)}"${profileRowToggleAttribute}>
 								<div class="account-row-id${identityClass}">
 									${renderCodexAccountNameControl(account, snapshot)}
 									${renderCodexAccountRandomNameButton(account)}
@@ -7446,7 +7447,7 @@
 							<div class="account-pool-guide">
 								${ACCOUNT_POOL_SORT_COLUMNS.map(renderCodexAccountPoolGuideCell).join("")}
 							</div>
-							${accounts.map((account) => renderCodexAccountPoolRow(account, snapshot)).join("")}
+							${accounts.map((account, index) => renderCodexAccountPoolRow(account, snapshot, index === accounts.length - 1)).join("")}
 						</div>
 					`;
 				}

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -467,7 +467,9 @@ fn operator_dashboard_renders_account_usage_controls() {
 	assert!(response.contains("function codexAccountPoolMergeRank(account)"));
 	assert!(response.contains("function renderCodexAccountPool(accounts, snapshot)"));
 	assert!(!response.contains("function renderCodexAccountPoolHeader(accounts)"));
-	assert!(response.contains("function renderCodexAccountPoolRow(account, snapshot)"));
+	assert!(response.contains(
+		"function renderCodexAccountPoolRow(account, snapshot, isLastAccount = false)"
+	));
 	assert!(response.contains("function renderCodexAccountNameControl(account, snapshot)"));
 	assert!(!response.contains("ACCOUNT_SELECTION_CONFIRMATION_MS"));
 	assert!(!response.contains("accountSelectionConfirmationTimer"));
@@ -918,7 +920,12 @@ fn operator_dashboard_accounts_keeps_window_status_and_credit_copy_compact() {
 	assert!(response.contains("min-height: 42px;"));
 	assert!(response.contains("padding: var(--space-account-row-y) 28px var(--space-account-row-y) var(--space-row-indent);"));
 	assert!(response.contains("border-bottom: 1px solid var(--line);"));
-	assert!(response.contains(".account-pool-list > .account-row:last-child"));
+	assert!(response.contains(".account-pool-list > .account-row.is-last-account"));
+	assert!(response.contains("const lastAccountClass = isLastAccount ? \" is-last-account\" : \"\";"));
+	assert!(response.contains(
+		"accounts.map((account, index) => renderCodexAccountPoolRow(account, snapshot, index === accounts.length - 1))"
+	));
+	assert!(!response.contains(".account-pool-list > .account-row:last-child"));
 	assert!(response.contains("account-row-credit"));
 	assert!(response.contains(".account-row-credit {\n\t\t\t\tgrid-area: credit;"));
 	assert!(response.contains(".account-row-credit {\n\t\t\t\tgrid-area: credit;\n\t\t\t\tjustify-self: center;"));


### PR DESCRIPTION
## Summary
- mark the final account-pool row explicitly during dashboard rendering
- update dashboard assertions so the pool no longer depends on `:last-child` for the final-row divider

## Verification
- git diff --check
- cargo make fmt
- cargo make lint-fix
- cargo make test
