### PR TITLE
Publish PR 26254 social record

### DIFF
--- a/artifacts/social/x/posts/2026-06-05/openai-codex-pr-26254.json
+++ b/artifacts/social/x/posts/2026-06-05/openai-codex-pr-26254.json
@@ -1,0 +1,86 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-26254",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "practical_explainer",
+  "status": "published",
+  "audience": "Codex MultiAgentV2 operators",
+  "text": [
+    "Codex MultiAgentV2 config nuance: explicit `features.multi_agent_v2` + `agents.max_threads` is still invalid, but catalog-selected v2 models can start while that legacy v1 cap is present.\n\nSource: https://github.com/openai/codex/pull/26254"
+  ],
+  "source_refs": {
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26254.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26254.review.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26254",
+      "https://github.com/openai/codex/commit/c677bf1f9c6b263c185fd65a4fe8da2a1eb8fed1",
+      "https://github.com/openai/codex/commit/a44923c056afdde77ad82f620825d95df392e0f1",
+      "https://x.com/decodexspace/status/2062804093551468805",
+      "https://x.com/decodexspace/status/2062804093551468805/photo/1"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact sets decision.worthiness to publish with high priority for a practical_explainer post.",
+    "The upstream_review/v1 artifact records PR #26254 as a confirmed MultiAgentV2 config change.",
+    "The upstream_impact/v1 artifact classifies PR #26254 as confirmed compat_risk with a practical_explainer Publisher angle.",
+    "Asia/Shanghai cap accounting found zero checked-in @decodexspace published records for 2026-06-05 before posting.",
+    "Current X benchmark readback showed @CodexReleases and @Codex_Changelog covering Codex app 26.602 in release-card and high-density changelog formats; no checked-in release/app/mobile candidate supported duplicating that coverage.",
+    "Chrome account readback showed @hackink initially, then Decodex @decodexspace after account switching before composing.",
+    "Generated decodex_signal_card media was rendered locally at /Users/x/.codex/decodex/social-media/openai-codex-pr-26254-signal-card-2026-06-05.png with SHA-256 d82ea9af8a4df7ad03084bb92df40e461aea84ada235d6b9f212b78549af62e8.",
+    "The X composer showed the expected text plus Edit media and Remove media controls before submit.",
+    "The final permalink readback confirmed @decodexspace, the expected post text, the GitHub source link, and a /photo/1 media link."
+  ],
+  "claims": [
+    {
+      "text": "Explicit features.multi_agent_v2 plus agents.max_threads remains invalid upstream.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26254.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Catalog-selected MultiAgentV2 can start while legacy agents.max_threads is present.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26254.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The published X post includes generated media and a readable /photo/1 media URL.",
+      "evidence": "https://x.com/decodexspace/status/2062804093551468805/photo/1",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "priority": "high",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26254:practical_explainer",
+    "reason": "The change is a clear, source-backed config migration note with practical operator value.",
+    "daily_limit": 8,
+    "daily_count_before": 0,
+    "daily_count_after": 1,
+    "day": "2026-06-05",
+    "timezone": "Asia/Shanghai"
+  },
+  "publication": {
+    "posted_at": "2026-06-05T07:49:00Z",
+    "published_urls": [
+      "https://x.com/decodexspace/status/2062804093551468805"
+    ],
+    "publisher": "chrome",
+    "account_verified": true,
+    "made_with_ai": true,
+    "image_template": "decodex_signal_card"
+  },
+  "media_refs": [
+    "https://x.com/decodexspace/status/2062804093551468805/photo/1"
+  ],
+  "caveats": [
+    "This post does not claim Decodex runtime adoption of upstream model catalog selectors.",
+    "The catalog-selected behavior depends on upstream model metadata selecting MultiAgentV2.",
+    "The generated image binary is intentionally kept outside Git; this record preserves the X media URL and content hash instead.",
+    "X permalink and media readback confirmed the /photo/1 media link, but the page text did not expose a Made with AI label during final readback."
+  ]
+}


### PR DESCRIPTION
## Summary
- records the live @decodexspace publication for openai/codex PR #26254
- preserves the X status URL, /photo/1 media URL, source refs, cap accounting, and generated-card hash

## Verification
- cargo run -p decodex --bin decodex -- radar validate artifacts/social/x

## Published
- https://x.com/decodexspace/status/2062804093551468805
- https://x.com/decodexspace/status/2062804093551468805/photo/1

Labels: codex and codex-automation were not available in this repository.