### PR TITLE
Publish Codex alpha.6 release checkpoint

### DIFF
--- a/artifacts/github/social-candidates/openai-codex-rust-v0-138-0-alpha-5-release-checkpoint.json
+++ b/artifacts/github/social-candidates/openai-codex-rust-v0-138-0-alpha-5-release-checkpoint.json
@@ -1,0 +1,61 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-rust-v0-138-0-alpha-5-release-checkpoint",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "watch_note",
+  "priority": "low",
+  "audience": "Codex operators tracking prerelease cadence",
+  "candidate_text": [
+    "No alpha.5 post handoff.\n\nOpenAI published rust-v0.138.0-alpha.5 on 2026-06-05, then alpha.6 superseded it on 2026-06-06 before this run. The alpha.4 -> alpha.5 window is recorded as a source-review gap, not a public post."
+  ],
+  "source_refs": {
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.4",
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.5",
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.6",
+      "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.4...rust-v0.138.0-alpha.5"
+    ]
+  },
+  "evidence_notes": [
+    "GitHub release metadata shows rust-v0.138.0-alpha.5 was published at 2026-06-05T23:27:47Z with only a sparse release body.",
+    "GitHub release metadata shows rust-v0.138.0-alpha.6 was published at 2026-06-06T03:23:40Z, superseding alpha.5 before this automation run.",
+    "The adjacent alpha.4 -> alpha.5 compare has 47 commits and 46 PR-numbered commits, but the current checked release_delta/v1 still stops at alpha.4.",
+    "No fresh upstream source or patch analysis was performed by this publisher automation."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.138.0-alpha.5 is a real OpenAI Codex prerelease checkpoint.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.5",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "alpha.5 was superseded by rust-v0.138.0-alpha.6 before this run.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.6",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The alpha.4 -> alpha.5 window needs upstream review before behavior claims are made.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.4...rust-v0.138.0-alpha.5",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "skip",
+    "reason": "alpha.5 was superseded by alpha.6 before this run and the large alpha.4 -> alpha.5 window lacks checked source-backed review coverage.",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-138-0-alpha-5:skip"
+  },
+  "caveats": [
+    "This is a terminal skip/no-op checkpoint record, not a publication request.",
+    "Exact source-review gap list for alpha.4 -> alpha.5: #25000, #25344, #25710, #25955, #26181, #26210, #26215, #26256, #26307, #26317, #26335, #26431, #26433, #26449, #26450, #26453, #26457, #26462, #26465, #26466, #26469, #26471, #26473, #26480, #26482, #26484, #26487, #26499, #26500, #26532, #26537, #26538, #26547, #26548, #26551, #26552, #26553, #26554, #26566, #26599, #26610, #26623, #26625, #26631, #26636, #26669."
+  ],
+  "next_steps": [
+    "Do not hand this alpha.5 record to decodex-x-publisher.",
+    "Use the alpha.5 -> alpha.6 candidate as the current prerelease checkpoint handoff.",
+    "Route alpha.4 -> alpha.5 behavior claims to codex-upstream-radar-review / codex-code-analysis if a later release rollup needs them."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-rust-v0-138-0-alpha-6-prerelease-read.json
+++ b/artifacts/github/social-candidates/openai-codex-rust-v0-138-0-alpha-6-prerelease-read.json
@@ -1,0 +1,81 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-rust-v0-138-0-alpha-6-prerelease-read",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "thread",
+  "priority": "high",
+  "audience": "Codex operators tracking prerelease direction before stable notes",
+  "candidate_text": [
+    "Codex CLI 0.138.0-alpha.6 prerelease read\n\nIncrement: alpha.5 -> alpha.6, 11 commits.\n\nMetadata read: protocol cleanup, Responses Lite transport, goal error handling, auth/PATs, managed permissions, and plugin cleanup.\n\nAlpha caveat: not stable release notes.",
+    "Protocol + Responses Lite:\n\n- submission-side Op serde removed\nhttps://github.com/openai/codex/pull/26674\n\n- standalone tools + transport header\nhttps://github.com/openai/codex/pull/26490\nhttps://github.com/openai/codex/pull/26542",
+    "Auth/permissions watch:\n\n- v2 personal access tokens\nhttps://github.com/openai/codex/pull/25731\n\n- managed permission profile allowlists\nhttps://github.com/openai/codex/pull/24852\n\nPR-title metadata only until Radar reviews source.",
+    "Runtime cleanup:\n\n- active goals block after terminal turn errors\nhttps://github.com/openai/codex/pull/26690\n\n- legacy remote plugin startup sync removed\nhttps://github.com/openai/codex/pull/25936",
+    "Compare + caveat:\n\nhttps://github.com/openai/codex/compare/rust-v0.138.0-alpha.5...rust-v0.138.0-alpha.6\n\nNo quote-eligible Decodex prerelease post exists for alpha.5, so Publisher should post this as a fresh thread, not a quote."
+  ],
+  "source_refs": {
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.5",
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.6",
+      "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.5...rust-v0.138.0-alpha.6",
+      "https://github.com/openai/codex/pull/26674",
+      "https://github.com/openai/codex/pull/26490",
+      "https://github.com/openai/codex/pull/26542",
+      "https://github.com/openai/codex/pull/25731",
+      "https://github.com/openai/codex/pull/24852",
+      "https://github.com/openai/codex/pull/26690",
+      "https://github.com/openai/codex/pull/25936",
+      "https://github.com/openai/codex/pull/26698",
+      "https://github.com/openai/codex/pull/26716"
+    ]
+  },
+  "evidence_notes": [
+    "GitHub release metadata shows rust-v0.138.0-alpha.6 was published at 2026-06-06T03:23:40Z with only a sparse release body.",
+    "The adjacent alpha.5 -> alpha.6 compare has 11 commits and 10 PR-numbered commits.",
+    "The draft copy is limited to release metadata, compare metadata, and PR-title metadata; it does not claim source-reviewed behavior.",
+    "The current checked release_delta/v1 was generated at 2026-06-05T09:07:58.572455Z for stable rust-v0.137.0 -> prerelease rust-v0.138.0-alpha.4, so alpha.6 is newer than the checked release_delta.",
+    "Checked social_post/v1 records show the prior alpha.4 text-only thread was deleted by the operator and the failed media attempt is not quote-eligible; no alpha.5 Decodex post exists to quote."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.138.0-alpha.6 is the current observed OpenAI Codex prerelease checkpoint for this run.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.6",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The correct prerelease lineage comparison is rust-v0.138.0-alpha.5 -> rust-v0.138.0-alpha.6.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.5...rust-v0.138.0-alpha.6",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "PR-title metadata in the alpha.6 window points to protocol cleanup, Responses Lite transport work, auth/PATs, managed permissions, goal terminal behavior, and plugin cleanup.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.5...rust-v0.138.0-alpha.6",
+      "confidence": "likely"
+    },
+    {
+      "text": "No quote-eligible Decodex prerelease post exists for the immediately previous alpha.5 checkpoint.",
+      "evidence": "artifacts/social/x/posts/2026-06-05/openai-codex-rust-v0-138-0-alpha-4-structured-read-text-only.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The adjacent alpha.5 -> alpha.6 compare supports a scan-friendly metadata thread with direct PR URLs and explicit source-review caveats.",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-138-0-alpha-6:alpha5-alpha6:thread"
+  },
+  "caveats": [
+    "Behavior claims for alpha.6 remain upstream-analysis gaps; exact gap list: #24852, #25731, #25936, #26013, #26490, #26542, #26674, #26690, #26698, #26716.",
+    "This candidate is based on public release metadata, compare metadata, and PR-title metadata only; codex-upstream-radar-review / codex-code-analysis should review source before a release_rollup makes stronger claims.",
+    "No previous live and quote-eligible alpha.5 @decodexspace post exists, so this should be published as a fresh thread rather than quoted.",
+    "Media caveat: no generated image is attached by this downstream artifact-consumer run. If media is required, decodex-x-publisher should generate and verify a fresh candidate-specific decodex_signal_card, then fail closed if upload/readback is unreliable."
+  ],
+  "next_steps": [
+    "Hand this publishable candidate to decodex-x-publisher.",
+    "Before posting, verify @decodexspace account state, daily cap, duplicate/idempotency state, and whether candidate-specific media is required.",
+    "If the Publisher needs stronger behavior language than PR-title metadata, pause publication and route the listed gap PRs to codex-upstream-radar-review / codex-code-analysis."
+  ]
+}

--- a/artifacts/social/x/posts/2026-06-06/openai-codex-app-26-602.json
+++ b/artifacts/social/x/posts/2026-06-06/openai-codex-app-26-602.json
@@ -18,6 +18,7 @@
       "https://developers.openai.com/codex/changelog",
       "https://x.com/decodexspace/status/2063109099135574379",
       "https://x.com/decodexspace/status/2063109099135574379/photo/1",
+      "https://pbs.twimg.com/media/HKGirQvagAEuudw?format=jpg&name=medium",
       "https://x.com/decodexspace/status/2063198209271554481"
     ]
   },
@@ -27,12 +28,11 @@
     "The changelog says activity insights and share cards were added to the Profile section, with sharing available on consumer ChatGPT plans.",
     "The changelog says Computer Use startup readiness and appshot error reporting improved.",
     "The changelog says browser and review UI issues were fixed and onboarding was expanded with more role choices.",
-    "A post-publication profile timeline audit found an earlier matching @decodexspace post at https://x.com/decodexspace/status/2063109099135574379 with /photo/1 media; this later post is a duplicate publication.",
-    "Asia/Shanghai cap accounting initially found zero checked-in @decodexspace published records for 2026-06-06, but live profile readback proves the correct pre-publish count was at least one.",
-    "X duplicate detection for from:decodexspace with the exact Codex app 26.602 phrase returned no results before composing.",
-    "A post-publication X search repeated the exact phrase and still returned no results even while the profile timeline exposed both matching posts, so X search no-results is not reliable duplicate evidence.",
-    "Chrome account readback showed Decodex @decodexspace before composing.",
-    "The final permalink readback confirmed @decodexspace, @hackink automation attribution, the expected post text, and the official changelog link card."
+    "The canonical publication is the earlier media-attached @decodexspace post at https://x.com/decodexspace/status/2063109099135574379.",
+    "The canonical publication includes a /photo/1 media readback URL and generated media cache evidence from /Users/x/.codex/decodex/social-media/x/2026-06-06/openai-codex-app-26-602/image.png.",
+    "A later text-only duplicate at https://x.com/decodexspace/status/2063198209271554481 was found after publication and is preserved here only as audit evidence.",
+    "The duplicate happened because X search returned no results for the exact phrase even while profile timeline readback later exposed both matching posts.",
+    "Future duplicate detection must prefer checked records, active reservations, open publication PRs, and live profile/timeline readback over X search no-results."
   ],
   "claims": [
     {
@@ -51,13 +51,13 @@
       "confidence": "confirmed"
     },
     {
-      "text": "The published X post is live on @decodexspace and includes the official changelog link card.",
-      "evidence": "https://x.com/decodexspace/status/2063198209271554481",
+      "text": "The canonical published X post is live on @decodexspace and includes the official changelog link.",
+      "evidence": "https://x.com/decodexspace/status/2063109099135574379",
       "confidence": "confirmed"
     },
     {
-      "text": "The published X post duplicates an earlier live @decodexspace Codex app 26.602 post.",
-      "evidence": "https://x.com/decodexspace/status/2063109099135574379",
+      "text": "The canonical published X post includes generated media and a readable /photo/1 media URL.",
+      "evidence": "https://x.com/decodexspace/status/2063109099135574379/photo/1",
       "confidence": "confirmed"
     }
   ],
@@ -67,31 +67,35 @@
     "idempotency_key": "x:decodexspace:codex-app-26-602:release_pulse",
     "reason": "The official changelog has concrete user-visible app changes and enough reader value for a source-led release pulse.",
     "daily_limit": 8,
-    "daily_count_before": 1,
-    "daily_count_after": 2,
+    "daily_count_before": 0,
+    "daily_count_after": 1,
     "day": "2026-06-06",
     "timezone": "Asia/Shanghai"
   },
   "publication": {
-    "posted_at": "2026-06-06T09:56:00Z",
+    "posted_at": "2026-06-06T04:01:00Z",
     "published_urls": [
-      "https://x.com/decodexspace/status/2063198209271554481"
+      "https://x.com/decodexspace/status/2063109099135574379"
     ],
     "publisher": "chrome",
     "account_verified": true,
-    "made_with_ai": false
+    "made_with_ai": true,
+    "image_template": "decodex_signal_card"
   },
+  "media_refs": [
+    "https://x.com/decodexspace/status/2063109099135574379/photo/1",
+    "https://pbs.twimg.com/media/HKGirQvagAEuudw?format=jpg&name=medium",
+    "/Users/x/.codex/decodex/social-media/x/2026-06-06/openai-codex-app-26-602/image.png"
+  ],
   "caveats": [
-    "This post is a duplicate of the earlier media-attached live post at https://x.com/decodexspace/status/2063109099135574379.",
+    "A later duplicate text-only post exists at https://x.com/decodexspace/status/2063198209271554481 and must not be reused as canonical publication evidence.",
     "Do not treat X search no-results as sufficient duplicate-detection evidence for future publication decisions.",
-    "The candidate's declared generated-media path /Users/x/.codex/decodex/social-media/codex-app-26-602.png was missing at publication time.",
-    "The post was intentionally published text-only because the official changelog link card and compact release bullets carried the reader value without a generic replacement image.",
-    "Sharing for profile cards is described as available on consumer ChatGPT plans."
+    "Sharing for profile cards is described by the official changelog as available on consumer ChatGPT plans.",
+    "The local media file is outside Git by default; this record keeps the final X status, /photo/1 URL, and media readback URL instead of committing the generated binary."
   ],
   "post_lifecycle": {
-    "current_state": "superseded_published",
+    "current_state": "live",
     "quote_eligible": false,
-    "superseded_by_candidate": "https://x.com/decodexspace/status/2063109099135574379",
-    "reason": "Post-publication profile readback found an earlier matching live Codex app 26.602 post; this later text-only post is a duplicate and must not be reused as future publication evidence."
+    "reason": "The canonical media-attached app update post remains live, but app release-pulse posts are not prerelease quote-chain anchors."
   }
 }

--- a/artifacts/social/x/posts/2026-06-06/openai-codex-rust-v0-138-0-alpha-6-prerelease-read.json
+++ b/artifacts/social/x/posts/2026-06-06/openai-codex-rust-v0-138-0-alpha-6-prerelease-read.json
@@ -1,0 +1,144 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-rust-v0-138-0-alpha-6-prerelease-read",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "thread",
+  "status": "published",
+  "audience": "Codex operators tracking prerelease direction before stable notes",
+  "text": [
+    "Codex CLI 0.138.0-alpha.6 prerelease read\n\nIncrement: alpha.5 -> alpha.6, 11 commits.\n\nMetadata read: protocol cleanup, Responses Lite transport, goal error handling, auth/PATs, managed permissions, and plugin cleanup.\n\nAlpha caveat: not stable release notes.",
+    "Protocol + Responses Lite:\n\n- submission-side Op serde removed\nhttps://github.com/openai/codex/pull/26674\n\n- standalone tools + transport header\nhttps://github.com/openai/codex/pull/26490\nhttps://github.com/openai/codex/pull/26542",
+    "Auth/permissions watch:\n\n- v2 personal access tokens\nhttps://github.com/openai/codex/pull/25731\n\n- managed permission profile allowlists\nhttps://github.com/openai/codex/pull/24852\n\nPR-title metadata only until Radar reviews source.",
+    "Runtime cleanup:\n\n- active goals block after terminal turn errors\nhttps://github.com/openai/codex/pull/26690\n\n- legacy remote plugin startup sync removed\nhttps://github.com/openai/codex/pull/25936",
+    "Compare + caveat:\n\nhttps://github.com/openai/codex/compare/rust-v0.138.0-alpha.5...rust-v0.138.0-alpha.6\n\nNo quote-eligible Decodex prerelease post exists for alpha.5, so Publisher should post this as a fresh thread, not a quote."
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-rust-v0-138-0-alpha-6-prerelease-read.json"
+    ],
+    "reservations": [
+      "artifacts/social/x/reservations/2026-06-06/openai-codex-rust-v0-138-0-alpha-6-prerelease-read.json"
+    ],
+    "media_manifests": [
+      "/Users/x/.codex/decodex/social-media/x/2026-06-06/openai-codex-rust-v0-138-0-alpha-6-prerelease-read/manifest.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.5",
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.6",
+      "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.5...rust-v0.138.0-alpha.6",
+      "https://github.com/openai/codex/pull/26674",
+      "https://github.com/openai/codex/pull/26490",
+      "https://github.com/openai/codex/pull/26542",
+      "https://github.com/openai/codex/pull/25731",
+      "https://github.com/openai/codex/pull/24852",
+      "https://github.com/openai/codex/pull/26690",
+      "https://github.com/openai/codex/pull/25936",
+      "https://x.com/decodexspace/status/2063279620129247678",
+      "https://x.com/decodexspace/status/2063279622410870898",
+      "https://x.com/decodexspace/status/2063279624575205432",
+      "https://x.com/decodexspace/status/2063279626819141750",
+      "https://x.com/decodexspace/status/2063279628933042178",
+      "https://x.com/decodexspace/status/2063279620129247678/photo/1",
+      "https://pbs.twimg.com/media/HKI9se-bgAIprIe?format=jpg&name=medium"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish and mode thread for the alpha.5 -> alpha.6 prerelease read.",
+    "The active reservation was committed and pushed to PR #226 before X compose was opened, with idempotency key x:decodexspace:openai-codex-rust-v0-138-0-alpha-6:alpha5-alpha6:thread.",
+    "Pre-publication duplicate checks found no terminal alpha.6 social_post/v1 record and X search returned no results for from:decodexspace \"rust-v0.138.0-alpha.6\".",
+    "The checked PR surfaces before publication showed #225 only contained the stale app 26.602 post record, while #226 contained the alpha.6 candidate and active reservation.",
+    "Chrome account readback confirmed the active X account was @decodexspace before compose.",
+    "The first composer post had generated media attached before publication; X showed the media preview group and enabled Post all.",
+    "After publication, the home timeline readback showed all five @decodexspace posts and the first post's /photo/1 image link.",
+    "The first permalink readback showed all five expected status URLs in one conversation and all five expected thread lead phrases.",
+    "The first permalink readback exposed the uploaded media as https://pbs.twimg.com/media/HKI9se-bgAIprIe?format=jpg&name=medium.",
+    "The five status IDs decode to 2026-06-06T15:19:29.977Z through 2026-06-06T15:19:32.076Z."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.138.0-alpha.6 is the observed OpenAI Codex prerelease checkpoint for this publication run.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.6",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The published prerelease lineage comparison is rust-v0.138.0-alpha.5 -> rust-v0.138.0-alpha.6.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.5...rust-v0.138.0-alpha.6",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The alpha.6 window contains 11 commits and PR-title metadata for protocol cleanup, Responses Lite transport, auth/PATs, managed permissions, terminal goal error handling, and plugin cleanup.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.5...rust-v0.138.0-alpha.6",
+      "confidence": "likely"
+    },
+    {
+      "text": "No quote-eligible Decodex prerelease post exists for the immediately previous alpha.5 checkpoint.",
+      "evidence": "artifacts/social/x/posts/2026-06-05/openai-codex-rust-v0-138-0-alpha-4-structured-read-text-only.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The alpha.6 X thread is live on @decodexspace with five status URLs.",
+      "evidence": "https://x.com/decodexspace/status/2063279620129247678",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The first alpha.6 X thread post includes generated media and a readable /photo/1 media URL.",
+      "evidence": "https://x.com/decodexspace/status/2063279620129247678/photo/1",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "priority": "high",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-138-0-alpha-6:alpha5-alpha6:thread",
+    "reason": "The adjacent alpha.5 -> alpha.6 compare supports a scan-friendly metadata thread with direct PR URLs and explicit source-review caveats.",
+    "daily_limit": 8,
+    "daily_count_before": 2,
+    "daily_count_after": 7,
+    "day": "2026-06-06",
+    "timezone": "Asia/Shanghai"
+  },
+  "publication": {
+    "posted_at": "2026-06-06T15:19:29.977Z",
+    "posted_at_last": "2026-06-06T15:19:32.076Z",
+    "published_urls": [
+      "https://x.com/decodexspace/status/2063279620129247678",
+      "https://x.com/decodexspace/status/2063279622410870898",
+      "https://x.com/decodexspace/status/2063279624575205432",
+      "https://x.com/decodexspace/status/2063279626819141750",
+      "https://x.com/decodexspace/status/2063279628933042178"
+    ],
+    "publisher": "chrome",
+    "account_verified": true,
+    "made_with_ai": true,
+    "image_template": "decodex_signal_card"
+  },
+  "media_refs": [
+    "https://x.com/decodexspace/status/2063279620129247678/photo/1",
+    "https://pbs.twimg.com/media/HKI9se-bgAIprIe?format=jpg&name=medium",
+    "/Users/x/.codex/decodex/social-media/x/2026-06-06/openai-codex-rust-v0-138-0-alpha-6-prerelease-read/image.png"
+  ],
+  "generated_media": {
+    "local_png": "/Users/x/.codex/decodex/social-media/x/2026-06-06/openai-codex-rust-v0-138-0-alpha-6-prerelease-read/image.png",
+    "local_svg": "/Users/x/.codex/decodex/social-media/x/2026-06-06/openai-codex-rust-v0-138-0-alpha-6-prerelease-read/image.svg",
+    "png_sha256": "7478ca5b47370a2075a21a7c5458e5b7ec7b6da7781e3b8de2ed106a4702dbe2",
+    "svg_sha256": "eee7189b83c1ffca799d1ce50e817ff71489d4ae0812bc1aedb73496f1f73b1f",
+    "dimensions": {
+      "width": 1200,
+      "height": 1200
+    }
+  },
+  "caveats": [
+    "Behavior claims for alpha.6 remain upstream-analysis gaps; exact gap list: #24852, #25731, #25936, #26013, #26490, #26542, #26674, #26690, #26698, #26716.",
+    "This post is based on public release metadata, compare metadata, and PR-title metadata only; codex-upstream-radar-review / codex-code-analysis should review source before a release_rollup makes stronger claims.",
+    "No previous live and quote-eligible alpha.5 @decodexspace post existed, so this was published as a fresh thread rather than quoted.",
+    "The local media file is outside Git by default; this record keeps the final X status, /photo/1 URL, pbs media readback URL, and SHA-256 metadata instead of committing the generated binary.",
+    "X also generated link preview cards for some GitHub URLs during compose."
+  ],
+  "post_lifecycle": {
+    "current_state": "live",
+    "quote_eligible": true,
+    "reason": "This is the live alpha.6 prerelease thread and may be quoted by the next prerelease checkpoint if it remains live."
+  }
+}

--- a/artifacts/social/x/reservations/2026-06-06/openai-codex-rust-v0-138-0-alpha-6-prerelease-read.json
+++ b/artifacts/social/x/reservations/2026-06-06/openai-codex-rust-v0-138-0-alpha-6-prerelease-read.json
@@ -1,0 +1,42 @@
+{
+  "schema": "social_publish_reservation/v1",
+  "slug": "openai-codex-rust-v0-138-0-alpha-6-prerelease-read",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "thread",
+  "status": "active",
+  "idempotency_key": "x:decodexspace:openai-codex-rust-v0-138-0-alpha-6:alpha5-alpha6:thread",
+  "reserved_at": "2026-06-06T15:05:55Z",
+  "expires_at": "2026-06-06T19:05:55Z",
+  "day": "2026-06-06",
+  "timezone": "Asia/Shanghai",
+  "candidate_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-rust-v0-138-0-alpha-6-prerelease-read.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.6",
+      "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.5...rust-v0.138.0-alpha.6"
+    ]
+  },
+  "duplicate_keys": [
+    "x:decodexspace:openai-codex-rust-v0-138-0-alpha-6:alpha5-alpha6:thread",
+    "openai-codex-rust-v0-138-0-alpha-6-prerelease-read",
+    "rust-v0.138.0-alpha.6",
+    "Codex CLI 0.138.0-alpha.6 prerelease read",
+    "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.5...rust-v0.138.0-alpha.6",
+    "alpha.5 -> alpha.6"
+  ],
+  "owner": {
+    "automation_id": "manual-publisher-rescue",
+    "run_id": "pr-226-alpha6-publisher-2026-06-06T150555Z",
+    "branch": "codex-release-checkpoint-0.138.0-alpha.6",
+    "pr_url": "https://github.com/hack-ink/decodex/pull/226"
+  },
+  "evidence_notes": [
+    "PR #226 contains a social_candidate/v1 with decision.worthiness = publish for the alpha.5 -> alpha.6 prerelease thread.",
+    "This active reservation is committed and pushed before opening X compose so duplicate publisher runs can fail closed.",
+    "Duplicate detection must check the candidate slug, idempotency key, exact lead text, rust-v0.138.0-alpha.6 tag, and compare URL against checked records, open PRs, active reservations, and live @decodexspace profile/timeline readback."
+  ]
+}

--- a/artifacts/social/x/reservations/2026-06-06/openai-codex-rust-v0-138-0-alpha-6-prerelease-read.json
+++ b/artifacts/social/x/reservations/2026-06-06/openai-codex-rust-v0-138-0-alpha-6-prerelease-read.json
@@ -5,10 +5,19 @@
   "target_account": "decodexspace",
   "controller_account": "hackink",
   "mode": "thread",
-  "status": "active",
+  "status": "consumed",
   "idempotency_key": "x:decodexspace:openai-codex-rust-v0-138-0-alpha-6:alpha5-alpha6:thread",
   "reserved_at": "2026-06-06T15:05:55Z",
   "expires_at": "2026-06-06T19:05:55Z",
+  "consumed_at": "2026-06-06T15:19:32Z",
+  "consumed_by_social_post": "artifacts/social/x/posts/2026-06-06/openai-codex-rust-v0-138-0-alpha-6-prerelease-read.json",
+  "published_urls": [
+    "https://x.com/decodexspace/status/2063279620129247678",
+    "https://x.com/decodexspace/status/2063279622410870898",
+    "https://x.com/decodexspace/status/2063279624575205432",
+    "https://x.com/decodexspace/status/2063279626819141750",
+    "https://x.com/decodexspace/status/2063279628933042178"
+  ],
   "day": "2026-06-06",
   "timezone": "Asia/Shanghai",
   "candidate_refs": {
@@ -37,6 +46,7 @@
   "evidence_notes": [
     "PR #226 contains a social_candidate/v1 with decision.worthiness = publish for the alpha.5 -> alpha.6 prerelease thread.",
     "This active reservation is committed and pushed before opening X compose so duplicate publisher runs can fail closed.",
-    "Duplicate detection must check the candidate slug, idempotency key, exact lead text, rust-v0.138.0-alpha.6 tag, and compare URL against checked records, open PRs, active reservations, and live @decodexspace profile/timeline readback."
+    "Duplicate detection must check the candidate slug, idempotency key, exact lead text, rust-v0.138.0-alpha.6 tag, and compare URL against checked records, open PRs, active reservations, and live @decodexspace profile/timeline readback.",
+    "The reservation was consumed by a Chrome-published @decodexspace thread whose first permalink snowflake decodes to 2026-06-06T15:19:29.977Z."
   ]
 }


### PR DESCRIPTION
## Summary
- Records the alpha.6 prerelease candidate and terminal @decodexspace X thread.
- Consumes the alpha.6 social publish reservation after live Chrome publication.
- Normalizes the Codex app 26.602 publication record to the canonical media-attached post and keeps the later text-only duplicate only as audit evidence.

## Publication
- https://x.com/decodexspace/status/2063279620129247678
- https://x.com/decodexspace/status/2063279622410870898
- https://x.com/decodexspace/status/2063279624575205432
- https://x.com/decodexspace/status/2063279626819141750
- https://x.com/decodexspace/status/2063279628933042178
- Media readback: https://x.com/decodexspace/status/2063279620129247678/photo/1

## Validation
- jq empty on the new alpha.6 post and consumed reservation
- git diff --check
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x
- cargo make check-site-content

## Notes
- #225 is superseded by this branch because main already had the same app 26.602 post path, creating an add/add conflict. This PR carries the canonicalized app record plus the completed alpha.6 publication.