### PR TITLE
Remove stale 8912 listener references

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ cargo run -p decodex --bin decodex -- radar refresh-upstream-queue
 cargo run -p decodex --bin decodex -- radar refresh-release-delta
 cargo run -p decodex --bin decodex -- radar validate
 cargo run -p decodex --bin decodex -- run --dry-run
-cargo run -p decodex --bin decodex -- serve --listen-address 127.0.0.1:8912
+cargo run -p decodex --bin decodex -- serve --listen-address 127.0.0.1:8192
 ```
 
 Project-scoped commands accept `--config <PROJECT_DIR>` after the subcommand when the
@@ -261,7 +261,7 @@ node dev/operator-dashboard-mock.mjs --listen-address 127.0.0.1:57399
 node dev/operator-dashboard-mock.mjs --listen-address 127.0.0.1:57399 --use-codex-auth
 ```
 
-Use hidden `decodex serve --dev --listen-address 127.0.0.1:8912` only when
+Use hidden `decodex serve --dev --listen-address <ADDR>` only when
 developing local account/app snapshot APIs against real runtime state while explicitly
 avoiding scheduler activity. Dev mode deliberately does not register projects, poll
 Linear, dispatch work, or accept `--config`. Decodex App's normal

--- a/apps/decodex/src/cli.rs
+++ b/apps/decodex/src/cli.rs
@@ -326,7 +326,7 @@ struct ServeCommand {
 	#[command(flatten)]
 	project_config: ProjectConfigArgs,
 	/// Operator UI listen address.
-	#[arg(long, value_name = "ADDR", default_value = "127.0.0.1:8912")]
+	#[arg(long, value_name = "ADDR", default_value = "127.0.0.1:8192")]
 	listen_address: String,
 	/// Start the local dev endpoint without polling or dispatching projects.
 	#[arg(long, hide = true)]
@@ -1639,6 +1639,20 @@ mod tests {
 
 		assert!(error.to_string().contains("--explain"));
 		assert!(error.to_string().contains("[ISSUE]"));
+	}
+
+	#[test]
+	fn parses_serve_default_listen_address() {
+		let cli = Cli::parse_from(["decodex", "serve"]);
+
+		assert!(matches!(
+			cli.command,
+			Command::Serve(ServeCommand {
+				project_config: ProjectConfigArgs { config: None },
+				listen_address,
+				dev: false,
+			}) if listen_address == "127.0.0.1:8192"
+		));
 	}
 
 	#[test]

--- a/docs/runbook/lane-control-recovery.md
+++ b/docs/runbook/lane-control-recovery.md
@@ -53,7 +53,7 @@ Use the local HTTP API only against the same trusted listener when CLI access is
 the active surface:
 
 ```sh
-curl -sS 'http://127.0.0.1:8912/api/lane/inspect?projectId=<service-id>&issue=<ISSUE>&runId=<RUN_ID>'
+curl -sS 'http://127.0.0.1:8192/api/lane/inspect?projectId=<service-id>&issue=<ISSUE>&runId=<RUN_ID>'
 ```
 
 Before mutating anything, confirm:

--- a/docs/runbook/self-dogfood-pilot.md
+++ b/docs/runbook/self-dogfood-pilot.md
@@ -330,13 +330,13 @@ wants to observe the self-bootstrap loop without reading source code.
    ```sh
    git rev-parse --short HEAD
    decodex --version
-   SERVE_PID=$(lsof -tiTCP:8912 -sTCP:LISTEN)
-   lsof -nP -iTCP:8912 -sTCP:LISTEN
+   SERVE_PID=$(lsof -tiTCP:8192 -sTCP:LISTEN)
+   lsof -nP -iTCP:8192 -sTCP:LISTEN
    ps -p "$SERVE_PID" -o pid,lstart,command
-   curl -fsS http://127.0.0.1:8912/livez
+   curl -fsS http://127.0.0.1:8192/livez
    ```
 
-   Use the port from the active `--listen-address` if it is not `127.0.0.1:8912`.
+   Use the port from the active `--listen-address` if it is not `127.0.0.1:8192`.
    Treat a missing listener, a binary revision that does not match the current landed
    `HEAD`, or a `decodex serve` start time older than the latest runtime or dashboard
    landing as stale evidence. Restart `decodex serve` after reinstalling or after any
@@ -419,7 +419,7 @@ wants to observe the self-bootstrap loop without reading source code.
    ```sh
    decodex project add ~/.codex/decodex/projects/decodex
    decodex project list
-   decodex serve --listen-address 127.0.0.1:8912
+   decodex serve --listen-address 127.0.0.1:8192
    ```
 
    `serve` owns one operator UI and schedules all enabled registered projects from the
@@ -439,7 +439,7 @@ wants to observe the self-bootstrap loop without reading source code.
    issues, trigger the next scan explicitly instead of waiting for that window:
 
    ```sh
-   curl -sS -X POST http://127.0.0.1:8912/api/linear-scan \
+   curl -sS -X POST http://127.0.0.1:8192/api/linear-scan \
      -H 'Content-Type: application/json' \
      -d '{"projectId":"decodex"}'
    ```
@@ -447,7 +447,7 @@ wants to observe the self-bootstrap loop without reading source code.
 5. Open the operator dashboard:
 
    ```text
-   http://127.0.0.1:8912/
+   http://127.0.0.1:8192/
    ```
 
    For dashboard section meanings and local-vs-external state ownership, read
@@ -537,8 +537,8 @@ wants to observe the self-bootstrap loop without reading source code.
      timing when the ledger recorded those fields; raw attempts and heartbeat details
      stay in the expanded debug view.
      To validate rich local closeout persistence after a lane completes, keep
-     `decodex serve --listen-address 127.0.0.1:8912` running and inspect
-     `decodex status --json` or the 8912 dashboard `Run Ledger`, not a replay of Linear
+     `decodex serve --listen-address 127.0.0.1:8192` running and inspect
+     `decodex status --json` or the operator dashboard `Run Ledger`, not a replay of Linear
      comments. The completed row should still expose the local `run_id`, attempt
      number, lifecycle status, PR or landing reference, closeout or attention reason,
      elapsed timing, and debug-only raw attempt or heartbeat details after the lane
@@ -628,7 +628,7 @@ Decodex is intentionally Unix-only, and the control plane relies on Unix file-de
 `decodex serve` owns the local operator console. Use `--listen-address` when you need a non-default bind address:
 
 ```sh
-decodex serve --listen-address 127.0.0.1:8912
+decodex serve --listen-address <ADDR>
 ```
 
 `serve` has no interval override. It publishes local operator snapshots every

--- a/plugins/decodex/skills/automation/SKILL.md
+++ b/plugins/decodex/skills/automation/SKILL.md
@@ -70,7 +70,7 @@ project. After creating or relabeling queued issues, request the next scan inste
 waiting for the 5-minute window:
 
 ```sh
-curl -sS -X POST http://127.0.0.1:8912/api/linear-scan \
+curl -sS -X POST http://127.0.0.1:8192/api/linear-scan \
   -H 'Content-Type: application/json' \
   -d '{"projectId":"<service-id>"}'
 ```

--- a/plugins/decodex/skills/manual-cli/SKILL.md
+++ b/plugins/decodex/skills/manual-cli/SKILL.md
@@ -147,7 +147,7 @@ Manual commit and landing are separate narrow workflows:
   for the 5-minute Linear poll:
 
   ```sh
-  curl -sS -X POST http://127.0.0.1:8912/api/linear-scan \
+  curl -sS -X POST http://127.0.0.1:8192/api/linear-scan \
     -H 'Content-Type: application/json' \
     -d '{"projectId":"<service-id>"}'
   ```


### PR DESCRIPTION
## Summary
- change the CLI default serve listener to 127.0.0.1:8192
- replace stale 8912 examples in README, runbooks, and Decodex plugin skills
- add a CLI parsing regression test for the default serve listener

## Validation
- cargo test -p decodex parses_serve_default_listen_address
- cargo run -p decodex --bin decodex -- serve --help | rg -n "listen|8192|8912"
- rg -n "8912" . /Users/x/.codex/plugins/cache/hack-ink/decodex/0.1.0 returned no matches
- python3 /Users/x/.codex/plugins/cache/hack-ink/playbook/0.3.0/scripts/semantic_drift_audit.py --rev HEAD^
- cargo make check