### PR TITLE
Reserve X publication for Codex PR 26469

### DIFF
--- a/artifacts/social/x/posts/2026-06-08/openai-codex-pr-26469.json
+++ b/artifacts/social/x/posts/2026-06-08/openai-codex-pr-26469.json
@@ -1,0 +1,93 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-26469",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "practical_explainer",
+  "status": "published",
+  "audience": "Codex TUI users and plugin operators",
+  "text": [
+    "Codex upstream sped up TUI startup by reusing plugin discovery and overlapping bootstrap work. PR #26469 reports median time to editable composer moving from 833ms to 504ms in its sample: https://github.com/openai/codex/pull/26469"
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-26469.json"
+    ],
+    "reservations": [
+      "artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26469.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26469.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26469.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26469",
+      "https://x.com/decodexspace/status/2063833413266845827"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish and mode practical_explainer for openai-codex-pr-26469.",
+    "The upstream_review/v1 artifact confirms that Codex reuses one immutable plugin load outcome across TUI startup consumers and reports the 833ms to 504ms median startup sample.",
+    "The upstream_impact/v1 artifact marks the change as public_signal_decision publish, control_plane_impact candidate, and publisher_angle practical_explainer.",
+    "Checked social_post/v1 records contained no slug, source URL, or idempotency match before publication.",
+    "Checked social_publish_reservation/v1 records contained no active reservation for this candidate or idempotency key before the new reservation was created.",
+    "Open GitHub PR readback showed only Dependabot PRs before the reservation PR was created; PR #236 then made the active reservation visible before X compose.",
+    "Chrome account readback initially showed @hackink as active and @decodexspace as available; the automation switched to @decodexspace before reservation or compose.",
+    "Chrome account readback showed @decodexspace before composing and the compose page showed @decodexspace with the exact candidate text.",
+    "Live @decodexspace profile readback before reservation found no 26469, plugin discovery, 833ms, or 504ms match; focused X search no-results was supporting evidence only.",
+    "Live @decodexspace profile readback after PR-visible reservation and before clicking Post again found no 26469, plugin discovery, 833ms, or 504ms match.",
+    "After publication, the X timeline showed status https://x.com/decodexspace/status/2063833413266845827 with the expected text and account.",
+    "Independent permalink readback showed the expected @decodexspace post text, GitHub PR card, and no image media.",
+    "The status ID decodes to 2026-06-08T04:00:04.550Z."
+  ],
+  "claims": [
+    {
+      "text": "Upstream Codex reused plugin discovery across TUI startup consumers.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26469.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "PR #26469 reports a median startup improvement from 833ms to 504ms in its sample.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26469.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The PR #26469 practical explainer is live on @decodexspace.",
+      "evidence": "https://x.com/decodexspace/status/2063833413266845827",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "priority": "high",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26469:practical_explainer",
+    "reason": "The PR gives a concrete, source-backed TUI startup improvement with a direct user-visible path.",
+    "daily_limit": 8,
+    "daily_count_before": 0,
+    "daily_count_after": 1,
+    "day": "2026-06-08",
+    "timezone": "Asia/Shanghai"
+  },
+  "publication": {
+    "posted_at": "2026-06-08T04:00:04.550Z",
+    "published_urls": [
+      "https://x.com/decodexspace/status/2063833413266845827"
+    ],
+    "publisher": "chrome",
+    "account_verified": true,
+    "made_with_ai": false
+  },
+  "caveats": [
+    "No media was attached; this single practical_explainer remains useful text-only because the reader value is the source-backed startup latency sample and direct PR link.",
+    "Do not generalize PR #26469's 833ms to 504ms local release-build sample to every plugin configuration.",
+    "Do not imply Decodex runtime adoption of the upstream plugin discovery cache."
+  ],
+  "post_lifecycle": {
+    "current_state": "live",
+    "quote_eligible": false,
+    "reason": "This is a standalone practical explainer, not a prerelease quote-chain anchor."
+  }
+}

--- a/artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26469.json
+++ b/artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26469.json
@@ -5,7 +5,7 @@
   "target_account": "decodexspace",
   "controller_account": "hackink",
   "mode": "practical_explainer",
-  "status": "active",
+  "status": "consumed",
   "idempotency_key": "x:decodexspace:openai-codex-pr-26469:practical_explainer",
   "reserved_at": "2026-06-08T03:56:50Z",
   "expires_at": "2026-06-08T05:56:50Z",
@@ -43,10 +43,12 @@
     "Checked social_post/v1 records contain no slug, source URL, or idempotency match for openai-codex-pr-26469.",
     "Checked social_publish_reservation/v1 records contain no active reservation for this candidate or idempotency key before this reservation.",
     "Open GitHub PR readback showed only Dependabot PRs and no pending social publication PR for this candidate.",
+    "PR #236 made this active reservation visible before X compose was opened.",
     "Chrome account readback initially showed @hackink as the active X account and @decodexspace as an available account; the automation switched to @decodexspace before reservation.",
     "Chrome account readback then confirmed the active X account menu showed @decodexspace before this reservation was prepared.",
     "Live @decodexspace profile readback found no 26469, plugin discovery, 833ms, or 504ms match.",
     "Focused X search for from:decodexspace \"26469\" returned no results; this is supporting evidence only, not the primary duplicate gate.",
     "Checked publication records show daily_count_before = 0 for @decodexspace on 2026-06-08 Asia/Shanghai, so one additional single-post publication would not exceed the cap of 8."
-  ]
+  ],
+  "consumed_by_social_post": "artifacts/social/x/posts/2026-06-08/openai-codex-pr-26469.json"
 }

--- a/artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26469.json
+++ b/artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26469.json
@@ -1,0 +1,52 @@
+{
+  "schema": "social_publish_reservation/v1",
+  "slug": "openai-codex-pr-26469",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "practical_explainer",
+  "status": "active",
+  "idempotency_key": "x:decodexspace:openai-codex-pr-26469:practical_explainer",
+  "reserved_at": "2026-06-08T03:56:50Z",
+  "expires_at": "2026-06-08T05:56:50Z",
+  "day": "2026-06-08",
+  "timezone": "Asia/Shanghai",
+  "candidate_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-26469.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26469.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26469.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26469"
+    ]
+  },
+  "duplicate_keys": [
+    "openai-codex-pr-26469",
+    "x:decodexspace:openai-codex-pr-26469:practical_explainer",
+    "Codex upstream sped up TUI startup",
+    "plugin discovery",
+    "26469",
+    "833ms",
+    "504ms",
+    "https://github.com/openai/codex/pull/26469"
+  ],
+  "owner": {
+    "automation_id": "decodex-x-publisher",
+    "branch": "codex-automation/x-publisher-openai-codex-pr-26469"
+  },
+  "evidence_notes": [
+    "Checked social_post/v1 records contain no slug, source URL, or idempotency match for openai-codex-pr-26469.",
+    "Checked social_publish_reservation/v1 records contain no active reservation for this candidate or idempotency key before this reservation.",
+    "Open GitHub PR readback showed only Dependabot PRs and no pending social publication PR for this candidate.",
+    "Chrome account readback initially showed @hackink as the active X account and @decodexspace as an available account; the automation switched to @decodexspace before reservation.",
+    "Chrome account readback then confirmed the active X account menu showed @decodexspace before this reservation was prepared.",
+    "Live @decodexspace profile readback found no 26469, plugin discovery, 833ms, or 504ms match.",
+    "Focused X search for from:decodexspace \"26469\" returned no results; this is supporting evidence only, not the primary duplicate gate.",
+    "Checked publication records show daily_count_before = 0 for @decodexspace on 2026-06-08 Asia/Shanghai, so one additional single-post publication would not exceed the cap of 8."
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds and consumes a PR-visible X publish reservation for the checked social_candidate/v1 openai-codex-pr-26469.
- Adds the published social_post/v1 record for the live @decodexspace post.
- Records checked-record, open-PR, account, profile/timeline, search-supporting, daily-cap, timeline, and permalink evidence.

## Publication
- https://x.com/decodexspace/status/2063833413266845827
- Text-only practical_explainer; no media attached because the source-backed startup latency sample and direct PR link carry the reader value.

## Validation
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x

## Notes
- Repository labels codex and codex-automation are not present; applied kind:chore.