### PR TITLE
Keep X publish reservations thin

### DIFF
--- a/dev/skills/x-post-publisher/SKILL.md
+++ b/dev/skills/x-post-publisher/SKILL.md
@@ -61,6 +61,13 @@ reservation is PR-visible and immediately before clicking Post, repeat live
 profile/timeline duplicate readback. If a duplicate appears, cancel or expire the
 reservation and do not publish.
 
+Keep the reservation record thin. It should hold only the publish lease, owner,
+candidate/source refs, idempotency key, duplicate keys, cap-day inputs, and concise
+pre-compose duplicate/account-readiness notes. Do not copy final post text, final
+timeline/permalink readback, publication URLs, media readback, claims, caveats, or
+`post_lifecycle` into `social_publish_reservation/v1`; write those to the terminal
+`social_post/v1`.
+
 ## Chrome And Media
 
 Use `@Chrome` only inside this low-frequency Publisher workflow. Before composing,
@@ -93,10 +100,15 @@ Write `artifacts/social/x/posts/<yyyy-mm-dd>/<slug>.json` with:
 - `post_lifecycle` when the record can affect future prerelease quote chains
 - the consumed reservation path under `source_refs.reservations` when the compose gate
   was reached
+- final profile/timeline/permalink readback evidence after the PR-visible reservation
+  gate and after publication, when available
 
 Update `artifacts/social/x/reservations/<yyyy-mm-dd>/<slug>.json` from `active` to
 `consumed`, `canceled`, or `expired` before the run ends. Do not leave an active
-reservation behind unless the thread is explicitly handed off to a human operator.
+reservation behind unless the thread is explicitly handed off to a human operator. When
+marking a reservation `consumed`, add only `consumed_by_social_post` and any minimal
+status/owner update needed; do not backfill final publication evidence into the
+reservation.
 
 Run:
 

--- a/docs/spec/social-publishing.md
+++ b/docs/spec/social-publishing.md
@@ -45,6 +45,13 @@ account state, idempotency, daily cap, media, and final publication.
 create a checked, PR-visible active reservation before opening X compose. A local-only,
 uncommitted, or unpushed reservation does not authorize publication.
 
+Keep reservations thin. A reservation records ownership of the publish attempt,
+idempotency, cap-day accounting inputs, duplicate keys, candidate/source pointers, and
+the minimum duplicate-gate evidence needed to justify opening compose. It must not copy
+the final post text, final publication URL, publication readback, media readback,
+claims, caveats, or `post_lifecycle`; those belong in the terminal `social_post/v1`
+record.
+
 Generated media files are not default Git artifacts. Store successful publication
 facts in Git as small JSON records. Store generated image files in a local persistent
 media cache, or discard them after upload, unless an operator explicitly asks to commit
@@ -187,8 +194,10 @@ Required fields:
 Optional fields:
 
 - `owner`: automation id, run id, branch, and PR URL that own the active reservation.
-- `evidence_notes`: notes about duplicate checks and account/profile readback at
-  reservation time.
+- `evidence_notes`: short notes about duplicate checks, account/profile readiness, and
+  PR-visible reservation state at reservation time. Keep these notes to the pre-compose
+  gate; final timeline/permalink readback and publication evidence belong in
+  `social_post/v1`.
 - `consumed_by_social_post`: required when `status = "consumed"`.
 - `release_reason`: required when `status = "canceled"` or `status = "expired"`.
 
@@ -245,6 +254,11 @@ After the active reservation is PR-visible and immediately before clicking Post,
 Publisher automation must repeat live profile/timeline readback. If a duplicate appears
 at that final gate, cancel or expire the reservation and write a non-published
 `social_post/v1` record only when it adds audit or idempotency value.
+
+The repeated pre-click readback is publication evidence, not reservation evidence. When
+publication proceeds, store that final readback in the terminal `social_post/v1`
+`evidence_notes`; leave the consumed reservation as the compact lease record plus
+`consumed_by_social_post`.
 
 Chrome tabs are temporary execution resources. Publisher automation must close or
 release research, compose, upload, and readback tabs after the `social_post/v1` record


### PR DESCRIPTION
## Summary
- Clarifies that `social_publish_reservation/v1` is a thin pre-compose lease, not a duplicate publication evidence record.
- Moves final timeline/permalink/readback evidence ownership to terminal `social_post/v1` records.
- Updates the X publisher skill so consumed reservations only add `consumed_by_social_post` plus minimal status/owner updates.

## Validation
- `git diff --check`
- `cargo make check-site-content`

## Notes
- No schema removal or validator change; this narrows artifact authoring guidance only.
- Local `decodex-x-publisher` automation prompt was also updated outside this PR to use the same thin-reservation rule.