### PR TITLE
Align Decodex status ledger skill guidance

### DIFF
--- a/plugins/decodex/skills/automation/SKILL.md
+++ b/plugins/decodex/skills/automation/SKILL.md
@@ -103,6 +103,12 @@ terminal automation signal.
   wait, retained repair, closeout, recovery worktrees, and cleanup debt.
 - Treat runtime DB rows, app-server protocol activity, and Linear execution-ledger
   comments as different evidence surfaces.
+- When interpreting history, prefer terminal Run Ledger outcomes and the projected
+  issue-level `latest_run` status over raw historical attempt rows. A failed raw
+  attempt that remains in an issue's attempt timeline is diagnostic history, not proof
+  that the lane is currently blocked, when the Run Ledger shows terminal closeout,
+  cleanup, or landed completion and the active/backlog/recovery/post-review sections
+  are empty.
 - When app-server preflight mentions `skills/list`, distinguish non-blocking scan
   diagnostics from real blockers. If the run cwd is present and at least one skill is
   enabled, preserve `error_count`, `first_error_path`, and `first_error` as evidence

--- a/plugins/decodex/skills/manual-cli/SKILL.md
+++ b/plugins/decodex/skills/manual-cli/SKILL.md
@@ -131,6 +131,11 @@ Manual commit and landing are separate narrow workflows:
 - Use `status` to inspect the local runtime snapshot for active lanes, retained local
   state, recovery worktrees, account-pool configuration, and the run ledger without
   refreshing live tracker, pull-request, or ChatGPT account usage observers.
+- For completed issue history, treat the Run Ledger outcome and projected
+  `history_lanes[].latest_run.status` as the primary issue-level result. Raw failed
+  attempts under `history_lanes[].attempts` are retained for diagnosis and should not
+  be read as current lane failure when the primary sections show no active, queued,
+  recovery, or post-review work for that issue.
 - Use `status --live` when the operator needs fresh Linear/GitHub observer readback
   before acting. Use `/api/accounts?refresh=1` for fresh ChatGPT account usage probes.
 - Use `run --dry-run` before live automation to validate project loading, issue


### PR DESCRIPTION
## Summary
- Clarify Decodex automation/manual CLI skill guidance for status history interpretation
- Tell agents/operators to prefer terminal Run Ledger outcomes and projected history latest_run status over raw failed attempt rows
- Keep raw failed attempts framed as diagnostic history, not current lane blockage

## Verification
- python3 /Users/x/.codex/plugins/cache/hack-ink/playbook/0.3.0/scripts/semantic_drift_audit.py
- git diff --check
- cargo make fmt-check