### PR TITLE
Refresh Codex rate-limit reset status

### DIFF
--- a/site/src/content/reset-status/latest.json
+++ b/site/src/content/reset-status/latest.json
@@ -5,48 +5,60 @@
   "confidence": "likely",
   "observed_for_date": "2026-06-08",
   "timezone": "Asia/Shanghai",
-  "generated_at": "2026-06-07T21:50:13Z",
+  "generated_at": "2026-06-08T08:19:17Z",
   "source_account": "@thsottiaux",
   "source_url": "https://x.com/thsottiaux",
   "search_url": "https://x.com/search?q=from%3Athsottiaux%20since%3A2026-06-07%20until%3A2026-06-09&src=typed_query&f=live",
   "judgment_mode": "ai_semantic_review",
-  "rationale": "Chrome/X was reachable for the 2026-06-08 Asia/Shanghai watch date. Broad X search returned no @thsottiaux results for the local-day coverage window, and refreshed profile plus replies timelines showed the newest visible @thsottiaux items were still June 6 posts about Codex settings, team praise, ChatGPT memory/token utility, and package install wording. An older June 4 usage-limit reset post was visible, but it is outside today's observed date. No visible June 8 post semantically indicated a rate-limit, quota, usage, message-cap, or reset-window recovery signal.",
+  "rationale": "Logged-in Chrome/X profile and broad X search were reachable for the 2026-06-08 Asia/Shanghai watch date. The visible local-day posts included a Codex 10X usage-limit promotion for selected builders, short replies about participation, and unrelated ChatGPT or Codex discussion. The usage-limit promotion is usage-adjacent, but it does not say limits reset, quotas recovered, message caps reset, or users should wait for a reset window. Thread context showed user replies asking about participation or complaining about limits, not a source-account reset signal. An older June 4 usage-limit reset post was visible, but it is outside today's observed date.",
   "evidence_posts": [
     {
-      "published_at_label": "2026-06-08 05:50 +08 observation",
+      "published_at_label": "2026-06-08 16:19 +08 observation",
       "url": "https://x.com/search?q=from%3Athsottiaux%20since%3A2026-06-07%20until%3A2026-06-09&src=typed_query&f=live",
       "relevance": "not_related",
-      "summary": "Logged-in Chrome/X search for @thsottiaux posts across the local-day coverage window returned no results. This is supporting evidence only because search can miss visible timeline items."
+      "summary": "Logged-in Chrome/X search for @thsottiaux posts across the local-day coverage window returned six visible June 8 Asia/Shanghai candidate posts. None semantically announced a reset or recovery window."
     },
     {
-      "published_at_label": "2026-06-06 04:39:31 +08 (outside observed_for_date; X datetime 2026-06-05T20:39:31Z)",
-      "url": "https://x.com/thsottiaux/status/2062997768470474765",
+      "published_at_label": "2026-06-08 06:21 +08 (X datetime 2026-06-07T22:21:38Z)",
+      "url": "https://x.com/thsottiaux/status/2063748242681307611",
       "relevance": "not_related",
-      "summary": "@thsottiaux quoted an OpenAI Developers Codex settings update and commented on Codex papercuts/adoption. It was product-usability context, not a reset-window or quota recovery signal."
+      "summary": "@thsottiaux said Codex would select one person per day for 100 days to receive 10X usage limits for one month. This is usage-limit related, but it is a selective promotion, not a reset, quota recovery, message-cap recovery, or reset-window signal."
     },
     {
-      "published_at_label": "2026-06-06 04:39:57 +08 (outside observed_for_date; X datetime 2026-06-05T20:39:57Z)",
-      "url": "https://x.com/thsottiaux/status/2062997876297609257",
+      "published_at_label": "2026-06-08 11:33 +08 (X datetime 2026-06-08T03:33:50Z)",
+      "url": "https://x.com/thsottiaux/status/2063826811373658213",
       "relevance": "not_related",
-      "summary": "@thsottiaux praised @simpsoka and team. It was one of the newest visible timeline items, but it did not mention resets, quotas, caps, or recovery windows."
+      "summary": "@thsottiaux replied that users should build things when asked how to participate in the 10X usage-limit promotion. Immediate thread context included third-party limit complaints, but the source-account reply did not announce a reset or recovery."
     },
     {
-      "published_at_label": "2026-06-06 02:35:46 +08 (outside observed_for_date; X datetime 2026-06-05T18:35:46Z)",
-      "url": "https://x.com/thsottiaux/status/2062966625733861752",
+      "published_at_label": "2026-06-08 14:14 +08 (X datetime 2026-06-08T06:14:33Z)",
+      "url": "https://x.com/thsottiaux/status/2063867254945767838",
       "relevance": "not_related",
-      "summary": "@thsottiaux said better memory means shorter prompts and more utility per token while quoting a ChatGPT memory rollout. The token wording was usage-adjacent but did not indicate rate-limit reset, quota reset, message-cap recovery, or a reset window."
+      "summary": "@thsottiaux joked in a model-personality thread. It was unrelated to Codex rate limits, quotas, message caps, or reset windows."
     },
     {
-      "published_at_label": "2026-06-06 02:13:48 +08 (outside observed_for_date; X datetime 2026-06-05T18:13:48Z)",
-      "url": "https://x.com/thsottiaux/status/2062961096760447392",
+      "published_at_label": "2026-06-08 07:59 +08 (X datetime 2026-06-07T23:59:43Z)",
+      "url": "https://x.com/thsottiaux/status/2063772925644464276",
       "relevance": "not_related",
-      "summary": "@thsottiaux corrected Codex package install wording to `uv add openai-codex`. This install note was unrelated to rate-limit resets, quota resets, usage resets, message caps, or recovery windows."
+      "summary": "@thsottiaux replied agreement in a thread about ChatGPT's personal-assistant direction. It was product-direction discussion, not a rate-limit reset signal."
     },
     {
-      "published_at_label": "2026-06-04 08:25:58 +08 (outside observed_for_date; X datetime 2026-06-04T00:25:58Z)",
+      "published_at_label": "2026-06-08 07:53 +08 (X datetime 2026-06-07T23:53:47Z)",
+      "url": "https://x.com/thsottiaux/status/2063771435194261915",
+      "relevance": "not_related",
+      "summary": "@thsottiaux replied in a thread about loops and attached media. The reply was not about reset behavior, quotas, usage caps, or recovery windows."
+    },
+    {
+      "published_at_label": "2026-06-08 07:52 +08 (X datetime 2026-06-07T23:52:05Z)",
+      "url": "https://x.com/thsottiaux/status/2063771005332697532",
+      "relevance": "not_related",
+      "summary": "@thsottiaux replied to a coding-agent usage poll with an adoption comment. Third-party replies mentioned rate limits, but the source-account post did not announce a reset or cap recovery."
+    },
+    {
+      "published_at_label": "2026-06-04 08:25 +08 (outside observed_for_date; X datetime 2026-06-04T00:25:58Z)",
       "url": "https://x.com/thsottiaux/status/2062329981548802523",
       "relevance": "not_related",
-      "summary": "An older @thsottiaux post did announce that Codex usage limits had been reset across paid plans. It confirms the kind of semantic signal being watched for, but it is outside the June 8 watch date."
+      "summary": "An older @thsottiaux post did announce that Codex usage limits had been reset across paid plans. It confirms the target semantic pattern, but it is outside the June 8 watch date."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- refresh the homepage reset_status/v1 artifact for 2026-06-08 Asia/Shanghai
- record Chrome/X semantic evidence for visible @thsottiaux posts
- keep the answer at no because the usage-limit promotion is not a reset or recovery signal

## Validation
- cargo make check-site-content
- cargo make check-site-types

## Persistence
- artifact change committed through decodex commit --manual-authority
