### PR TITLE
Persist Decodex X publication for PR 26631

### DIFF
--- a/artifacts/social/x/posts/2026-06-08/openai-codex-pr-26631.json
+++ b/artifacts/social/x/posts/2026-06-08/openai-codex-pr-26631.json
@@ -1,0 +1,93 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-26631",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "practical_explainer",
+  "status": "published",
+  "audience": "Codex plugin operators and automation authors",
+  "text": [
+    "Codex plugin commands now have --json for successful stdout on add/remove and marketplace add/list/upgrade/remove. Human output stays unchanged. PR: https://github.com/openai/codex/pull/26631"
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-26631.json"
+    ],
+    "reservations": [
+      "artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26631.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26631.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26631.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26631",
+      "https://x.com/decodexspace/status/2063923477699313782"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish and mode practical_explainer for openai-codex-pr-26631.",
+    "The upstream_review/v1 artifact confirms that PR #26631 adds --json output for plugin add/remove and plugin marketplace add/list/upgrade/remove while preserving human-readable output and error behavior.",
+    "The upstream_impact/v1 artifact marks the change as public_signal_decision publish, control_plane_impact candidate, and publisher_angle practical_explainer.",
+    "Checked social_post/v1 records contained no slug, source URL, or idempotency match before publication.",
+    "Checked social_publish_reservation/v1 records contained no active reservation for this candidate or idempotency key before the new reservation was created.",
+    "Open GitHub PR readback showed only dependency PRs before the reservation PR was created; PR #242 then made the active reservation visible before X compose.",
+    "Chrome account readback initially showed @hackink as active and @decodexspace as available; the automation switched to @decodexspace before reservation or compose.",
+    "Chrome account menu readback showed @decodexspace before composing and the compose dialog showed the exact candidate text.",
+    "Live @decodexspace profile readback before reservation found no 26631, plugin add --json, plugin marketplace, source URL, or exact lead-text match.",
+    "Live @decodexspace profile readback after PR-visible reservation and immediately before clicking Post again found no 26631, plugin add --json, plugin marketplace, source URL, or exact lead-text match.",
+    "After clicking Post, X opened a graduated-access informational modal, but live @decodexspace profile readback showed the new status URL with the expected text.",
+    "Independent permalink readback showed the expected @decodexspace post text, GitHub PR card, and no image media.",
+    "The status ID decodes to 2026-06-08T09:57:57.584Z."
+  ],
+  "claims": [
+    {
+      "text": "Supported Codex plugin and marketplace commands now have successful stdout JSON output.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26631.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Human-readable output and failure stderr behavior are unchanged unless --json is used for a success path.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26631.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The PR #26631 practical explainer is live on @decodexspace.",
+      "evidence": "https://x.com/decodexspace/status/2063923477699313782",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "priority": "high",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26631:practical_explainer",
+    "reason": "The PR gives plugin operators a concrete machine-readable CLI workflow.",
+    "daily_limit": 8,
+    "daily_count_before": 1,
+    "daily_count_after": 2,
+    "day": "2026-06-08",
+    "timezone": "Asia/Shanghai"
+  },
+  "publication": {
+    "posted_at": "2026-06-08T09:57:57.584Z",
+    "published_urls": [
+      "https://x.com/decodexspace/status/2063923477699313782"
+    ],
+    "publisher": "chrome",
+    "account_verified": true,
+    "made_with_ai": false
+  },
+  "caveats": [
+    "No media was attached; this single practical_explainer remains useful text-only because the reader value is the source-backed CLI automation flag and direct PR link.",
+    "Keep the claim scoped to successful stdout JSON output.",
+    "Do not imply plugin runtime behavior changed."
+  ],
+  "post_lifecycle": {
+    "current_state": "live",
+    "quote_eligible": false,
+    "reason": "This is a standalone practical explainer, not a prerelease quote-chain anchor."
+  }
+}

--- a/artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26631.json
+++ b/artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26631.json
@@ -1,0 +1,50 @@
+{
+  "schema": "social_publish_reservation/v1",
+  "slug": "openai-codex-pr-26631",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "practical_explainer",
+  "status": "active",
+  "idempotency_key": "x:decodexspace:openai-codex-pr-26631:practical_explainer",
+  "reserved_at": "2026-06-08T09:54:38Z",
+  "expires_at": "2026-06-08T11:54:38Z",
+  "day": "2026-06-08",
+  "timezone": "Asia/Shanghai",
+  "candidate_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-26631.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26631.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26631.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26631"
+    ]
+  },
+  "duplicate_keys": [
+    "openai-codex-pr-26631",
+    "x:decodexspace:openai-codex-pr-26631:practical_explainer",
+    "Codex plugin commands now have --json",
+    "plugin add --json",
+    "plugin remove --json",
+    "plugin marketplace",
+    "26631",
+    "https://github.com/openai/codex/pull/26631"
+  ],
+  "owner": {
+    "automation_id": "decodex-x-publisher",
+    "branch": "codex-automation/x-publisher-openai-codex-pr-26631"
+  },
+  "evidence_notes": [
+    "Checked social_post/v1 records contain no slug, source URL, or idempotency match for openai-codex-pr-26631.",
+    "Checked social_publish_reservation/v1 records contain no active reservation for this candidate or idempotency key before this reservation.",
+    "Open GitHub PR readback showed only dependency PRs and no pending social publication PR for this candidate.",
+    "Chrome account switcher exposed @decodexspace, and account menu readback confirmed @decodexspace before this reservation was prepared.",
+    "Live @decodexspace profile readback found no 26631, plugin add --json, plugin marketplace, source URL, or exact lead-text match.",
+    "Checked publication records show daily_count_before = 1 for @decodexspace on 2026-06-08 Asia/Shanghai, so one additional single-post publication would not exceed the cap of 8."
+  ]
+}

--- a/artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26631.json
+++ b/artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26631.json
@@ -5,7 +5,7 @@
   "target_account": "decodexspace",
   "controller_account": "hackink",
   "mode": "practical_explainer",
-  "status": "active",
+  "status": "consumed",
   "idempotency_key": "x:decodexspace:openai-codex-pr-26631:practical_explainer",
   "reserved_at": "2026-06-08T09:54:38Z",
   "expires_at": "2026-06-08T11:54:38Z",
@@ -46,5 +46,6 @@
     "Chrome account switcher exposed @decodexspace, and account menu readback confirmed @decodexspace before this reservation was prepared.",
     "Live @decodexspace profile readback found no 26631, plugin add --json, plugin marketplace, source URL, or exact lead-text match.",
     "Checked publication records show daily_count_before = 1 for @decodexspace on 2026-06-08 Asia/Shanghai, so one additional single-post publication would not exceed the cap of 8."
-  ]
+  ],
+  "consumed_by_social_post": "artifacts/social/x/posts/2026-06-08/openai-codex-pr-26631.json"
 }


### PR DESCRIPTION
## Summary
- Add and consume a thin social_publish_reservation/v1 lease for the openai-codex-pr-26631 X Publisher candidate.
- Add the terminal social_post/v1 record for the live @decodexspace publication.

## Publication
- Candidate: artifacts/github/social-candidates/openai-codex-pr-26631.json
- decision.worthiness: publish
- Mode: practical_explainer
- Published URL: https://x.com/decodexspace/status/2063923477699313782
- Media: none; text-only with GitHub PR card
- Cap day: 2026-06-08 Asia/Shanghai
- daily_count_before: 1
- daily_count_after: 2

## Validation
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x

## Evidence
- Chrome account/profile readback confirmed @decodexspace before reservation and compose.
- Live profile duplicate readback found no PR 26631 match before compose or immediately before click.
- Direct permalink readback showed the expected @decodexspace post text, GitHub PR card, and no image media.
