### PR TITLE
Persist upstream Radar review artifacts

### DIFF
--- a/artifacts/github/bundles/openai-codex-pr-25936.json
+++ b/artifacts/github/bundles/openai-codex-pr-25936.json
@@ -1,0 +1,112 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "xl-openai",
+      "committed_at": "2026-06-02T20:39:24Z",
+      "message": "Remove legacy remote plugin startup sync",
+      "sha": "a4bd397630c74317c78f3998df30039adc9279d3",
+      "url": "https://github.com/openai/codex/commit/a4bd397630c74317c78f3998df30039adc9279d3"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "API",
+    "--check",
+    "HOME=/private/tmp/codex-xin-build-home",
+    "USERPROFILE=/private/tmp/codex-xin-build-home",
+    "DEFAULT_TIMEOUT",
+    "TEST_CURATED_PLUGIN_SHA",
+    "STARTUP_REMOTE_PLUGIN_SYNC_MARKER_FILE",
+    "TEST_ALLOW_HTTP_REMOTE_PLUGIN_BUNDLE_DOWNLOADS",
+    "CODEX_TEST_ALLOW_HTTP_REMOTE_PLUGIN_BUNDLE_DOWNLOADS",
+    "ALTERNATE_MARKETPLACE_RELATIVE_PATH",
+    "GET",
+    "JSONRPCR",
+    "OPENAI_CURATED_MARKETPLACE_NAME",
+    "CURATED_REPO_SYNC_STARTED",
+    "TODO",
+    "CONFIG_TOML_FILE",
+    "TEST_CURATED_PLUGIN_CACHE_VERSION",
+    "DEFAULT_REMOTE_MARKETPLACE_NAME",
+    "REMOTE_PLUGIN_FETCH_TIMEOUT",
+    "REMOTE_FEATURED_PLUGIN_FETCH_TIMEOUT",
+    "REMOTE_PLUGIN_MUTATION_TIMEOUT",
+    "STARTUP_REMOTE_PLUGIN_SYNC_PREREQUISITE_TIMEOUT"
+  ],
+  "files": [
+    {
+      "additions": 0,
+      "deletions": 89,
+      "patch_excerpt": "@@ -38,7 +38,6 @@ use wiremock::matchers::query_param;\n \n const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);\n const TEST_CURATED_PLUGIN_SHA: &str = \"0123456789abcdef0123456789abcdef01234567\";\n-const STARTUP_REMOTE_PLUGIN_SYNC_MARKER_FILE: &str = \".tmp/app-server-remote-plugin-sync-v1\";\n const TEST_ALLOW_HTTP_REMOTE_PLUGIN_BUNDLE_DOWNLOADS: &str =\n     \"CODEX_TEST_ALLOW_HTTP_REMOTE_PLUGIN_BUNDLE_DOWNLOADS\";\n const ALTERNATE_MARKETPLACE_RELATIVE_PATH: &str = \".claude-plugin/marketplace.json\";\n@@ -1460,94 +1459,6 @@ enabled = true\n     Ok(())\n }\n \n-#[tokio::test]\n-async fn app_server_startup_remote_plugin_sync_runs_once() -> Result<()> {\n-    let codex_home = TempDir::new()?;\n-    let server = MockServer::start().await;\n-    write_plugin_sync_config(codex_home.path(), &format!(\"{}/backend-api/\", server.uri()))?;\n-    write_chatgpt_auth(\n-        codex_home.path(),\n-        ChatGptAu...",
+      "path": "codex-rs/app-server/tests/suite/v2/plugin_list.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 3,
+      "patch_excerpt": "@@ -11,7 +11,6 @@ mod plugin_bundle_archive;\n pub mod remote;\n pub mod remote_bundle;\n pub mod remote_legacy;\n-pub(crate) mod startup_remote_sync;\n pub mod startup_sync;\n pub mod store;\n #[cfg(test)]\n@@ -37,10 +36,8 @@ pub use manager::PluginInstallOutcome;\n pub use manager::PluginInstallRequest;\n pub use manager::PluginReadOutcome;\n pub use manager::PluginReadRequest;\n-pub use manager::PluginRemoteSyncError;\n pub use manager::PluginUninstallError;\n pub use manager::PluginsConfigInput;\n pub use manager::PluginsManager;\n-pub use manager::RemotePluginSyncResult;\n pub use marketplace_upgrade::ConfiguredMarketplaceUpgradeError as PluginMarketplaceUpgradeError;\n pub use marketplace_upgrade::ConfiguredMarketplaceUpgradeOutcome as PluginMarketplaceUpgradeOutcome;",
+      "path": "codex-rs/core-plugins/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 333,
+      "patch_excerpt": "@@ -1,5 +1,4 @@\n use super::PluginLoadOutcome;\n-use super::startup_remote_sync::start_startup_remote_plugin_sync_once;\n use crate::OPENAI_CURATED_MARKETPLACE_NAME;\n use crate::installed_marketplaces::installed_marketplace_roots_from_layer_stack;\n use crate::loader::PluginHookLoadOutcome;\n@@ -32,7 +31,6 @@ use crate::marketplace::ResolvedMarketplacePlugin;\n use crate::marketplace::find_installable_marketplace_plugin;\n use crate::marketplace::find_marketplace_plugin;\n use crate::marketplace::list_marketplaces;\n-use crate::marketplace::load_marketplace;\n use crate::marketplace::plugin_interface_with_marketplace_category;\n use crate::marketplace_upgrade::ConfiguredMarketplaceUpgradeError;\n use crate::marketplace_upgrade::ConfiguredMarketplaceUpgradeOutcome;\n@@ -52,8 +50,6 @@ use crate::store::PluginStore;\n use crate::store::PluginStoreError;\n use codex_analytics::AnalyticsEventsClient;\n use ...",
+      "path": "codex-rs/core-plugins/src/manager.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 444,
+      "patch_excerpt": "@@ -2416,25 +2416,6 @@ enabled = true\n     );\n }\n \n-#[tokio::test]\n-async fn sync_plugins_from_remote_returns_default_when_feature_disabled() {\n-    let tmp = tempfile::tempdir().unwrap();\n-    write_file(\n-        &tmp.path().join(CONFIG_TOML_FILE),\n-        r#\"[features]\n-plugins = false\n-\"#,\n-    );\n-\n-    let config = load_config(tmp.path(), tmp.path()).await;\n-    let outcome = PluginsManager::new(tmp.path().to_path_buf())\n-        .sync_plugins_from_remote(&config, /*auth*/ None, /*additive_only*/ false)\n-        .await\n-        .unwrap();\n-\n-    assert_eq!(outcome, RemotePluginSyncResult::default());\n-}\n-\n #[tokio::test]\n async fn list_marketplaces_includes_curated_repo_marketplace() {\n     let tmp = tempfile::tempdir().unwrap();\n@@ -2925,431 +2906,6 @@ enabled = true\n     );\n }\n \n-#[tokio::test]\n-async fn sync_plugins_from_remote_reconciles_cache_and_config() {\n-    let tmp = tem...",
+      "path": "codex-rs/core-plugins/src/manager_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 66,
+      "patch_excerpt": "@@ -6,19 +6,9 @@ use serde::Deserialize;\n use std::time::Duration;\n use url::Url;\n \n-const DEFAULT_REMOTE_MARKETPLACE_NAME: &str = \"openai-curated\";\n-const REMOTE_PLUGIN_FETCH_TIMEOUT: Duration = Duration::from_secs(30);\n const REMOTE_FEATURED_PLUGIN_FETCH_TIMEOUT: Duration = Duration::from_secs(10);\n const REMOTE_PLUGIN_MUTATION_TIMEOUT: Duration = Duration::from_secs(30);\n \n-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]\n-pub struct RemotePluginStatusSummary {\n-    pub name: String,\n-    #[serde(default = \"default_remote_marketplace_name\")]\n-    pub marketplace_name: String,\n-    pub enabled: bool,\n-}\n-\n #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]\n #[serde(rename_all = \"camelCase\")]\n struct RemotePluginMutationResponse {\n@@ -83,77 +73,28 @@ pub enum RemotePluginMutationError {\n \n #[derive(Debug, thiserror::Error)]\n pub enum RemotePluginFetchError {\n-    #[error(\"chatgpt au...",
+      "path": "codex-rs/core-plugins/src/remote_legacy.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 100,
+      "patch_excerpt": "@@ -1,100 +0,0 @@\n-use std::path::Path;\n-use std::path::PathBuf;\n-use std::sync::Arc;\n-use std::time::Duration;\n-\n-use crate::manager::PluginsConfigInput;\n-use crate::manager::PluginsManager;\n-use crate::startup_sync::has_local_curated_plugins_snapshot;\n-use codex_login::AuthManager;\n-use tracing::info;\n-use tracing::warn;\n-\n-const STARTUP_REMOTE_PLUGIN_SYNC_MARKER_FILE: &str = \".tmp/app-server-remote-plugin-sync-v1\";\n-const STARTUP_REMOTE_PLUGIN_SYNC_PREREQUISITE_TIMEOUT: Duration = Duration::from_secs(10);\n-\n-pub(crate) fn start_startup_remote_plugin_sync_once(\n-    manager: Arc<PluginsManager>,\n-    codex_home: PathBuf,\n-    config: PluginsConfigInput,\n-    auth_manager: Arc<AuthManager>,\n-) {\n-    let marker_path = startup_remote_plugin_sync_marker_path(codex_home.as_path());\n-    if marker_path.is_file() {\n-        return;\n-    }\n-\n-    tokio::spawn(async move {\n-        if marker_p...",
+      "path": "codex-rs/core-plugins/src/startup_remote_sync.rs",
+      "status": "removed"
+    },
+    {
+      "additions": 0,
+      "deletions": 91,
+      "patch_excerpt": "@@ -1,91 +0,0 @@\n-use super::*;\n-use crate::PluginsManager;\n-use crate::startup_sync::curated_plugins_repo_path;\n-use crate::test_support::TEST_CURATED_PLUGIN_CACHE_VERSION;\n-use crate::test_support::load_plugins_config;\n-use crate::test_support::write_curated_plugin_sha;\n-use crate::test_support::write_file;\n-use crate::test_support::write_openai_curated_marketplace;\n-use codex_config::CONFIG_TOML_FILE;\n-use codex_login::AuthManager;\n-use codex_login::CodexAuth;\n-use pretty_assertions::assert_eq;\n-use std::sync::Arc;\n-use std::time::Duration;\n-use tempfile::tempdir;\n-use wiremock::Mock;\n-use wiremock::MockServer;\n-use wiremock::ResponseTemplate;\n-use wiremock::matchers::header;\n-use wiremock::matchers::method;\n-use wiremock::matchers::path;\n-\n-#[tokio::test]\n-async fn startup_remote_plugin_sync_writes_marker_and_reconciles_state() {\n-    let tmp = tempdir().expect(\"tempdir\");\n-    let c...",
+      "path": "codex-rs/core-plugins/src/startup_remote_sync_tests.rs",
+      "status": "removed"
+    },
+    {
+      "additions": 0,
+      "deletions": 4,
+      "patch_excerpt": "@@ -88,10 +88,6 @@ pub(crate) fn write_openai_curated_marketplace(root: &Path, plugin_names: &[&str\n     }\n }\n \n-pub(crate) fn write_curated_plugin_sha(codex_home: &Path) {\n-    write_curated_plugin_sha_with(codex_home, TEST_CURATED_PLUGIN_SHA);\n-}\n-\n pub(crate) fn write_curated_plugin_sha_with(codex_home: &Path, sha: &str) {\n     write_file(&codex_home.join(\".tmp/plugins.sha\"), &format!(\"{sha}\\n\"));\n }",
+      "path": "codex-rs/core-plugins/src/test_support.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Summary\n\n- Remove the legacy startup remote plugin sync path that called `/plugins/list` and reconciled curated plugin cache/config.\n- Remove the `sync_plugins_from_remote` API, its result/error types, startup marker task, and tests that expected the legacy request.\n- Keep the current remote installed bundle sync and remote catalog flows (`/ps/plugins/installed` and `/ps/plugins/list`) intact.\n\n## Validation\n\n- `just fmt`\n- `git diff --check`\n- `env HOME=/private/tmp/codex-xin-build-home USERPROFILE=/private/tmp/codex-xin-build-home just test -p codex-core-plugins`\n- Searched for legacy `/plugins/list` sync references; remaining matches are `/ps/plugins/list` catalog tests/code.\n\n## Notes\n\n- `just test -p codex-app-server plugin_list` is currently blocked before running filtered tests by an unrelated compile error in `app-server/tests/suite/v2/image_generation.rs`: `app_test_support::McpProcess` is not exported.",
+    "labels": [],
+    "merged_at": "2026-06-05T23:33:01Z",
+    "number": 25936,
+    "state": "merged",
+    "title": "[codex] Remove legacy remote plugin startup sync",
+    "url": "https://github.com/openai/codex/pull/25936"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-26490.json
+++ b/artifacts/github/bundles/openai-codex-pr-26490.json
@@ -1,0 +1,157 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "rka-oai",
+      "committed_at": "2026-06-05T01:05:08Z",
+      "message": "Use standalone tools for Responses Lite",
+      "sha": "7ee483d92c3032987ff02381460ea02696336566",
+      "url": "https://github.com/openai/codex/commit/7ee483d92c3032987ff02381460ea02696336566"
+    },
+    {
+      "author": "rka-oai",
+      "committed_at": "2026-06-05T03:15:19Z",
+      "message": "Move Responses Lite coverage to core integration test",
+      "sha": "7c7b49719ff76676df444a084bd51596a6bfe18d",
+      "url": "https://github.com/openai/codex/commit/7c7b49719ff76676df444a084bd51596a6bfe18d"
+    },
+    {
+      "author": "rka-oai",
+      "committed_at": "2026-06-05T03:26:02Z",
+      "message": "Strengthen Responses Lite integration coverage",
+      "sha": "be7d534041a58366edcf5152c1e6de446b2f9d15",
+      "url": "https://github.com/openai/codex/commit/be7d534041a58366edcf5152c1e6de446b2f9d15"
+    },
+    {
+      "author": "rka-oai",
+      "committed_at": "2026-06-05T03:51:52Z",
+      "message": "Cover Responses Lite tool fallback behavior",
+      "sha": "31159463bf179e40aee1812bc68e556ab4c5fef8",
+      "url": "https://github.com/openai/codex/commit/31159463bf179e40aee1812bc68e556ab4c5fef8"
+    },
+    {
+      "author": "rka-oai",
+      "committed_at": "2026-06-05T21:31:27Z",
+      "message": "Clarify web search execution planning",
+      "sha": "b950c637ccd59ae3564df464c07baeff85d20840",
+      "url": "https://github.com/openai/codex/commit/b950c637ccd59ae3564df464c07baeff85d20840"
+    },
+    {
+      "author": "rka-oai",
+      "committed_at": "2026-06-05T23:23:41Z",
+      "message": "Simplify web search tool planning",
+      "sha": "f6d73aba8d25dfd6a357cbb39f730fc439cf9059",
+      "url": "https://github.com/openai/codex/commit/f6d73aba8d25dfd6a357cbb39f730fc439cf9059"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "API",
+    "--lib",
+    "--test",
+    "--all",
+    "--check",
+    "TODO",
+    "TOOL_SEARCH_TOOL_NAME",
+    "IMAGE_GEN_NAMESPACE",
+    "IMAGEGEN_TOOL_NAME"
+  ],
+  "files": [
+    {
+      "additions": 2,
+      "deletions": 2,
+      "patch_excerpt": "@@ -2548,6 +2548,7 @@ dependencies = [\n  \"codex-feedback\",\n  \"codex-git-utils\",\n  \"codex-hooks\",\n+ \"codex-image-generation-extension\",\n  \"codex-install-context\",\n  \"codex-login\",\n  \"codex-mcp\",\n@@ -2583,6 +2584,7 @@ dependencies = [\n  \"codex-utils-pty\",\n  \"codex-utils-stream-parser\",\n  \"codex-utils-string\",\n+ \"codex-web-search-extension\",\n  \"codex-windows-sandbox\",\n  \"core_test_support\",\n  \"csv\",\n@@ -3046,7 +3048,6 @@ dependencies = [\n  \"codex-api\",\n  \"codex-core\",\n  \"codex-extension-api\",\n- \"codex-features\",\n  \"codex-login\",\n  \"codex-model-provider\",\n  \"codex-model-provider-info\",\n@@ -4205,7 +4206,6 @@ dependencies = [\n  \"codex-api\",\n  \"codex-core\",\n  \"codex-extension-api\",\n- \"codex-features\",\n  \"codex-login\",\n  \"codex-model-provider\",\n  \"codex-model-provider-info\",",
+      "path": "codex-rs/Cargo.lock",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -133,9 +133,11 @@ codex-shell-escalation = { workspace = true }\n [dev-dependencies]\n assert_cmd = { workspace = true }\n assert_matches = { workspace = true }\n+codex-image-generation-extension = { workspace = true }\n codex-otel = { workspace = true }\n codex-test-binary-support = { workspace = true }\n codex-utils-cargo-bin = { workspace = true }\n+codex-web-search-extension = { workspace = true }\n core_test_support = { workspace = true }\n ctor = { workspace = true }\n insta = { workspace = true }",
+      "path": "codex-rs/core/Cargo.toml",
+      "status": "modified"
+    },
+    {
+      "additions": 44,
+      "deletions": 20,
+      "patch_excerpt": "@@ -59,6 +59,7 @@ use crate::tools::router::ToolRouterParams;\n use codex_features::Feature;\n use codex_login::AuthManager;\n use codex_mcp::ToolInfo;\n+use codex_protocol::config_types::WebSearchMode;\n use codex_protocol::dynamic_tools::DynamicToolSpec;\n use codex_protocol::openai_models::ConfigShellToolType;\n use codex_protocol::openai_models::InputModality;\n@@ -249,22 +250,31 @@ fn spec_for_model_request(\n \n fn hosted_model_tool_specs(context: &CoreToolPlanContext<'_>) -> Vec<ToolSpec> {\n     let turn_context = context.turn_context;\n+    // Responses Lite accepts schemas for client-executed tools, not hosted Responses tools.\n+    if turn_context.model_info.use_responses_lite {\n+        return Vec::new();\n+    }\n+\n     let mut specs = Vec::new();\n-    let provider_capabilities = turn_context.provider.capabilities();\n-    let web_search_mode = (!standalone_web_run_available(context.extensi...",
+      "path": "codex-rs/core/src/tools/spec_plan.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 30,
+      "deletions": 1,
+      "patch_excerpt": "@@ -23,12 +23,14 @@ use codex_core::thread_store_from_config;\n use codex_exec_server::CreateDirectoryOptions;\n use codex_exec_server::ExecutorFileSystem;\n use codex_exec_server::RemoveOptions;\n+use codex_extension_api::ExtensionRegistry;\n use codex_extension_api::empty_extension_registry;\n use codex_login::CodexAuth;\n use codex_model_provider_info::ModelProviderInfo;\n use codex_model_provider_info::built_in_model_providers;\n use codex_models_manager::bundled_models_response;\n use codex_protocol::models::PermissionProfile;\n+use codex_protocol::openai_models::ModelInfo;\n use codex_protocol::openai_models::ModelsResponse;\n use codex_protocol::protocol::AskForApproval;\n use codex_protocol::protocol::EventMsg;\n@@ -216,6 +218,7 @@ pub struct TestCodexBuilder {\n     cloud_config_bundle: Option<CloudConfigBundleLoader>,\n     user_shell_override: Option<Shell>,\n     exec_server_url: Option<String...",
+      "path": "codex-rs/core/tests/common/test_codex.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 13,
+      "patch_excerpt": "@@ -1894,20 +1894,10 @@ async fn responses_lite_sets_all_turns_context_and_disables_parallel_tool_calls(\n     )\n     .await;\n \n-    let mut model_catalog = bundled_models_response()\n-        .unwrap_or_else(|err| panic!(\"bundled models.json should parse: {err}\"));\n-    let model = model_catalog\n-        .models\n-        .iter_mut()\n-        .find(|model| model.slug == \"gpt-5.4\")\n-        .expect(\"gpt-5.4 exists in bundled models.json\");\n-    model.use_responses_lite = true;\n-    model.supports_parallel_tool_calls = true;\n-\n     let TestCodex { codex, .. } = test_codex()\n-        .with_model(\"gpt-5.4\")\n-        .with_config(move |config| {\n-            config.model_catalog = Some(model_catalog);\n+        .with_model_info_override(\"gpt-5.4\", |model_info| {\n+            model_info.use_responses_lite = true;\n+            model_info.supports_parallel_tool_calls = true;\n         })\n         .b...",
+      "path": "codex-rs/core/tests/suite/client.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -91,6 +91,7 @@ mod request_permissions_tool;\n mod request_plugin_install;\n mod request_user_input;\n mod responses_api_proxy_headers;\n+mod responses_lite;\n mod resume;\n mod resume_warning;\n mod review;",
+      "path": "codex-rs/core/tests/suite/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 167,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,167 @@\n+use std::sync::Arc;\n+\n+use anyhow::Context;\n+use anyhow::Result;\n+use codex_core::config::Config;\n+use codex_extension_api::ExtensionRegistry;\n+use codex_extension_api::ExtensionRegistryBuilder;\n+use codex_features::Feature;\n+use codex_image_generation_extension::install as install_image_generation_extension;\n+use codex_login::CodexAuth;\n+use codex_protocol::config_types::WebSearchMode;\n+use codex_protocol::openai_models::InputModality;\n+use codex_web_search_extension::install as install_web_search_extension;\n+use core_test_support::responses;\n+use core_test_support::skip_if_no_network;\n+use core_test_support::test_codex::test_codex;\n+use serde_json::Value;\n+\n+fn responses_extensions(auth: &CodexAuth) -> Arc<ExtensionRegistry<Config>> {\n+    let auth_manager = codex_core::test_support::auth_manager_from_auth(auth.clone());\n+    let mut extension_builder = ExtensionRegi...",
+      "path": "codex-rs/core/tests/suite/responses_lite.rs",
+      "status": "added"
+    },
+    {
+      "additions": 0,
+      "deletions": 1,
+      "patch_excerpt": "@@ -17,7 +17,6 @@ async-trait = { workspace = true }\n codex-api = { workspace = true }\n codex-core = { workspace = true }\n codex-extension-api = { workspace = true }\n-codex-features = { workspace = true }\n codex-login = { workspace = true }\n codex-model-provider = { workspace = true }\n codex-model-provider-info = { workspace = true }",
+      "path": "codex-rs/ext/image-generation/Cargo.toml",
+      "status": "modified"
+    },
+    {
+      "additions": 5,
+      "deletions": 6,
+      "patch_excerpt": "@@ -9,7 +9,6 @@ use codex_extension_api::ThreadStartInput;\n use codex_extension_api::ToolCall;\n use codex_extension_api::ToolContributor;\n use codex_extension_api::ToolExecutor;\n-use codex_features::Feature;\n use codex_login::AuthManager;\n use codex_model_provider::create_model_provider;\n use codex_model_provider_info::ModelProviderInfo;\n@@ -25,7 +24,7 @@ struct ImageGenerationExtension {\n \n #[derive(Clone)]\n struct ImageGenerationExtensionConfig {\n-    enabled: bool,\n+    available: bool,\n     provider: ModelProviderInfo,\n     codex_home: AbsolutePathBuf,\n }\n@@ -34,8 +33,8 @@ impl From<&Config> for ImageGenerationExtensionConfig {\n     /// Resolves whether standalone image generation should be available for a thread.\n     fn from(config: &Config) -> Self {\n         Self {\n-            enabled: config.features.enabled(Feature::ImageGenExt)\n-                && config.model_provider.is_ope...",
+      "path": "codex-rs/ext/image-generation/src/extension.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 1,
+      "patch_excerpt": "@@ -17,7 +17,6 @@ async-trait = { workspace = true }\n codex-api = { workspace = true }\n codex-core = { workspace = true }\n codex-extension-api = { workspace = true }\n-codex-features = { workspace = true }\n codex-login = { workspace = true }\n codex-model-provider = { workspace = true }\n codex-model-provider-info = { workspace = true }",
+      "path": "codex-rs/ext/web-search/Cargo.toml",
+      "status": "modified"
+    },
+    {
+      "additions": 5,
+      "deletions": 6,
+      "patch_excerpt": "@@ -13,7 +13,6 @@ use codex_extension_api::ExtensionRegistryBuilder;\n use codex_extension_api::ThreadLifecycleContributor;\n use codex_extension_api::ThreadStartInput;\n use codex_extension_api::ToolContributor;\n-use codex_features::Feature;\n use codex_login::AuthManager;\n use codex_model_provider::create_model_provider;\n use codex_model_provider_info::ModelProviderInfo;\n@@ -29,7 +28,7 @@ struct WebSearchExtension {\n \n #[derive(Clone)]\n struct WebSearchExtensionConfig {\n-    enabled: bool,\n+    available: bool,\n     provider: ModelProviderInfo,\n     settings: SearchSettings,\n }\n@@ -38,8 +37,8 @@ impl From<&Config> for WebSearchExtensionConfig {\n     fn from(config: &Config) -> Self {\n         let web_search_mode = config.web_search_mode.value();\n         Self {\n-            enabled: config.features.enabled(Feature::StandaloneWebSearch)\n-                && config.model_provider.is_openai()\n...",
+      "path": "codex-rs/ext/web-search/src/extension.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#26487"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Summary\r\n\r\nResponses Lite does not execute hosted Responses tools, so models using it must route web search and image generation through Codex-owned executors & standalone Response's API endpoints.\r\n\r\nThis PR is stacked on #26487.\r\n\r\n## Validation\r\n\r\n- `cargo test -p codex-core responses_lite_ --lib`\r\n- `cargo test -p codex-core standalone_executors_remain_hidden_without_flags_or_responses_lite --lib`\r\n- `cargo test -p codex-core hosted_tools_follow_provider_auth_model_and_config_gates --lib`\r\n- `cargo test -p codex-web-search-extension -p codex-image-generation-extension`\r\n- `cargo test -p codex-app-server --test all standalone_`\r\n- `cargo fmt --all -- --check`\r\n",
+    "labels": [],
+    "merged_at": "2026-06-06T00:23:40Z",
+    "number": 26490,
+    "state": "merged",
+    "title": "[codex] Use standalone tools for Responses Lite",
+    "url": "https://github.com/openai/codex/pull/26490"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-26548.json
+++ b/artifacts/github/bundles/openai-codex-pr-26548.json
@@ -1,0 +1,306 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "etraut-openai",
+      "committed_at": "2026-06-05T06:19:46Z",
+      "message": "Move goal runtime to extension",
+      "sha": "5622e8abb3ffcb17707ddc796dd32b6abe1d46ae",
+      "url": "https://github.com/openai/codex/commit/5622e8abb3ffcb17707ddc796dd32b6abe1d46ae"
+    },
+    {
+      "author": "etraut-openai",
+      "committed_at": "2026-06-05T18:09:20Z",
+      "message": "Serialize extension goal notifications",
+      "sha": "507e19e199703e9dec844849d145d36ed767fac6",
+      "url": "https://github.com/openai/codex/commit/507e19e199703e9dec844849d145d36ed767fac6"
+    },
+    {
+      "author": "etraut-openai",
+      "committed_at": "2026-06-05T18:20:23Z",
+      "message": "Merge branch 'main' into etraut/goal-stack-2-app-server-switchover-v2",
+      "sha": "12dbf7c6e13665c8f7f2d303cec8213d7b5b715a",
+      "url": "https://github.com/openai/codex/commit/12dbf7c6e13665c8f7f2d303cec8213d7b5b715a"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "FIFO",
+    "TUI",
+    "JSONRPCE",
+    "UPDATE_GOAL_TOOL_NAME",
+    "GOAL_BLOCKED_METRIC",
+    "GOAL_BUDGET_LIMITED_METRIC",
+    "GOAL_COMPLETED_METRIC",
+    "GOAL_CREATED_METRIC",
+    "GOAL_DURATION_SECONDS_METRIC",
+    "GOAL_RESUMED_METRIC",
+    "GOAL_TOKEN_COUNT_METRIC",
+    "GOAL_USAGE_LIMITED_METRIC",
+    "MAX",
+    "API",
+    "TEST_INSTALLATION_ID",
+    "CREATE_GOAL_TOOL_NAME",
+    "GET_GOAL_TOOL_NAME"
+  ],
+  "files": [
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1926,6 +1926,7 @@ dependencies = [\n  \"codex-file-search\",\n  \"codex-file-watcher\",\n  \"codex-git-utils\",\n+ \"codex-goal-extension\",\n  \"codex-guardian\",\n  \"codex-hooks\",\n  \"codex-image-generation-extension\",",
+      "path": "codex-rs/Cargo.lock",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 1,
+      "patch_excerpt": "@@ -483,7 +483,6 @@ unwrap_used = \"deny\"\n [workspace.metadata.cargo-shear]\n ignored = [\n     \"codex-agent-graph-store\",\n-    \"codex-goal-extension\",\n     \"icu_provider\",\n     \"openssl-sys\",\n     \"codex-v8-poc\",",
+      "path": "codex-rs/Cargo.toml",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -41,6 +41,7 @@ codex-extension-api = { workspace = true }\n codex-external-agent-migration = { workspace = true }\n codex-external-agent-sessions = { workspace = true }\n codex-features = { workspace = true }\n+codex-goal-extension = { workspace = true }\n codex-guardian = { workspace = true }\n codex-git-utils = { workspace = true }\n codex-file-watcher = { workspace = true }",
+      "path": "codex-rs/app-server/Cargo.toml",
+      "status": "modified"
+    },
+    {
+      "additions": 101,
+      "deletions": 55,
+      "patch_excerpt": "@@ -2,6 +2,7 @@ use std::sync::Arc;\n use std::sync::Weak;\n \n use codex_app_server_protocol::ServerNotification;\n+use codex_app_server_protocol::ThreadGoal;\n use codex_app_server_protocol::ThreadGoalUpdatedNotification;\n use codex_core::NewThread;\n use codex_core::StartThreadOptions;\n@@ -12,23 +13,40 @@ use codex_extension_api::AgentSpawner;\n use codex_extension_api::ExtensionEventSink;\n use codex_extension_api::ExtensionRegistry;\n use codex_extension_api::ExtensionRegistryBuilder;\n+use codex_goal_extension::GoalService;\n use codex_login::AuthManager;\n use codex_protocol::ThreadId;\n use codex_protocol::error::CodexErr;\n use codex_protocol::protocol::Event;\n use codex_protocol::protocol::EventMsg;\n+use codex_rollout::state_db::StateDbHandle;\n \n use crate::outgoing_message::OutgoingMessageSender;\n+use crate::thread_state::ThreadListenerCommand;\n+use crate::thread_state::ThreadStateManager;\n...",
+      "path": "codex-rs/app-server/src/extensions.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 0,
+      "patch_excerpt": "@@ -191,6 +191,9 @@ mod tests {\n                     guardian_agent_spawner(thread_manager.clone()),\n                     Arc::new(NoopExtensionEventSink),\n                     auth_manager.clone(),\n+                    Some(state_db.clone()),\n+                    thread_manager.clone(),\n+                    Arc::new(codex_goal_extension::GoalService::new()),\n                 ),\n                 /*analytics_events_client*/ None,\n                 Arc::clone(&thread_store),",
+      "path": "codex-rs/app-server/src/mcp_refresh.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 7,
+      "deletions": 1,
+      "patch_excerpt": "@@ -70,6 +70,7 @@ use codex_core::ThreadManager;\n use codex_core::config::Config;\n use codex_exec_server::EnvironmentManager;\n use codex_feedback::CodexFeedback;\n+use codex_goal_extension::GoalService;\n use codex_login::AuthManager;\n use codex_login::auth::ExternalAuth;\n use codex_login::auth::ExternalAuthRefreshContext;\n@@ -305,6 +306,7 @@ impl MessageProcessor {\n         // resumed, or forked threads to a different persistence backend/root.\n         let thread_store = codex_core::thread_store_from_config(config.as_ref(), state_db.clone());\n         let environment_manager_for_requests = Arc::clone(&environment_manager);\n+        let goal_service = Arc::new(GoalService::new());\n         let thread_manager = Arc::new_cyclic(|thread_manager| {\n             ThreadManager::new(\n                 config.as_ref(),\n@@ -313,8 +315,11 @@ impl MessageProcessor {\n                 environment_manage...",
+      "path": "codex-rs/app-server/src/message_processor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 10,
+      "patch_excerpt": "@@ -555,16 +555,6 @@ impl OutgoingMessageSender {\n             .await;\n     }\n \n-    pub(crate) fn try_send_server_notification(&self, notification: ServerNotification) {\n-        tracing::trace!(\"app-server event: {notification}\");\n-        let outgoing_message = OutgoingMessage::AppServerNotification(notification);\n-        if let Err(err) = self.sender.try_send(OutgoingEnvelope::Broadcast {\n-            message: outgoing_message,\n-        }) {\n-            warn!(\"failed to send server notification to client without waiting: {err:?}\");\n-        }\n-    }\n-\n     pub(crate) async fn send_server_notification_to_connections(\n         &self,\n         connection_ids: &[ConnectionId],",
+      "path": "codex-rs/app-server/src/outgoing_message.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 2,
+      "patch_excerpt": "@@ -279,8 +279,6 @@ use codex_config::loader::project_trust_key;\n use codex_config::types::McpServerTransportConfig;\n use codex_core::CodexThread;\n use codex_core::CodexThreadSettingsOverrides;\n-use codex_core::ExternalGoalPreviousStatus;\n-use codex_core::ExternalGoalSet;\n use codex_core::ForkSnapshot;\n use codex_core::NewThread;\n #[cfg(test)]",
+      "path": "codex-rs/app-server/src/request_processors.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 95,
+      "deletions": 206,
+      "patch_excerpt": "@@ -1,5 +1,9 @@\n use super::*;\n-use codex_protocol::protocol::validate_thread_goal_objective;\n+use codex_goal_extension::GoalObjectiveUpdate;\n+use codex_goal_extension::GoalService;\n+use codex_goal_extension::GoalServiceError;\n+use codex_goal_extension::GoalSetRequest;\n+use codex_goal_extension::GoalTokenBudgetUpdate;\n \n #[derive(Clone)]\n pub(crate) struct ThreadGoalRequestProcessor {\n@@ -8,6 +12,7 @@ pub(crate) struct ThreadGoalRequestProcessor {\n     config: Arc<Config>,\n     thread_state_manager: ThreadStateManager,\n     state_db: Option<StateDbHandle>,\n+    goal_service: Arc<GoalService>,\n }\n \n impl ThreadGoalRequestProcessor {\n@@ -17,13 +22,15 @@ impl ThreadGoalRequestProcessor {\n         config: Arc<Config>,\n         thread_state_manager: ThreadStateManager,\n         state_db: Option<StateDbHandle>,\n+        goal_service: Arc<GoalService>,\n     ) -> Self {\n         Self {\n         ...",
+      "path": "codex-rs/app-server/src/request_processors/thread_goal_processor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 18,
+      "deletions": 15,
+      "patch_excerpt": "@@ -244,12 +244,22 @@ pub(super) async fn ensure_listener_task_running(\n         if thread_state.listener_matches(&conversation) {\n             return Ok(());\n         }\n-        thread_state.set_listener(\n+        let (listener_command_rx, listener_generation) = thread_state.set_listener(\n             cancel_tx,\n             &conversation,\n             watch_registration,\n             thread_settings_baseline,\n-        )\n+        );\n+        let Some(listener_command_tx) = thread_state.listener_command_tx() else {\n+            tracing::warn!(\n+                \"thread listener command sender missing immediately after listener registration\"\n+            );\n+            return Ok(());\n+        };\n+        listener_task_context\n+            .thread_state_manager\n+            .register_listener_command_tx(conversation_id, listener_command_tx);\n+        (listener_command_rx, listener_generati...",
+      "path": "codex-rs/app-server/src/request_processors/thread_lifecycle.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 38,
+      "deletions": 1,
+      "patch_excerpt": "@@ -17,6 +17,7 @@ use codex_utils_absolute_path::AbsolutePathBuf;\n use std::collections::HashMap;\n use std::collections::HashSet;\n use std::sync::Arc;\n+use std::sync::Mutex as StdMutex;\n use std::sync::Weak;\n use tokio::sync::Mutex;\n use tokio::sync::mpsc;\n@@ -44,8 +45,9 @@ pub(crate) struct PendingThreadResumeRequest {\n pub(crate) enum ThreadListenerCommand {\n     // SendThreadResumeResponse is used to resume an already running thread by sending the thread's history to the client and atomically subscribing for new updates.\n     SendThreadResumeResponse(Box<PendingThreadResumeRequest>),\n-    // EmitThreadGoalUpdated is used to order app-server goal updates with running-thread resume responses.\n+    // EmitThreadGoalUpdated is used to order goal updates with running-thread resume responses and goal clears.\n     EmitThreadGoalUpdated {\n+        turn_id: Option<String>,\n         goal: Threa...",
+      "path": "codex-rs/app-server/src/thread_state.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 45,
+      "patch_excerpt": "@@ -1,7 +1,5 @@\n use crate::agent::AgentStatus;\n use crate::config::ConstraintResult;\n-use crate::goals::ExternalGoalSet;\n-use crate::goals::GoalRuntimeEvent;\n use crate::session::Codex;\n use crate::session::SessionSettingsUpdate;\n use crate::session::SteerInputError;\n@@ -205,51 +203,11 @@ impl CodexThread {\n         }\n     }\n \n-    pub async fn apply_goal_resume_runtime_effects(&self) -> anyhow::Result<()> {\n+    pub async fn emit_thread_idle_lifecycle_if_idle(&self) {\n         self.codex\n             .session\n-            .goal_runtime_apply(GoalRuntimeEvent::ThreadResumed)\n-            .await\n-    }\n-\n-    pub async fn continue_active_goal_if_idle(&self) -> anyhow::Result<()> {\n-        self.codex\n-            .session\n-            .goal_runtime_apply(GoalRuntimeEvent::MaybeContinueIfIdle)\n-            .await\n-    }\n-\n-    pub async fn prepare_external_goal_mutation(&self) {\n-        ...",
+      "path": "codex-rs/core/src/codex_thread.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 7,
+      "deletions": 7,
+      "patch_excerpt": "@@ -33,14 +33,14 @@ fn detects_subagent_notification_fragment_case_insensitively() {\n #[test]\n fn detects_internal_model_context_fragment() {\n     let text = InternalModelContextFragment::new(\n-        InternalContextSource::from_static(\"goal\"),\n-        \"Continue working toward the active thread goal.\",\n+        InternalContextSource::from_static(\"extension\"),\n+        \"Internal steering.\",\n     )\n     .render();\n \n     assert_eq!(\n         text,\n-        \"<codex_internal_context source=\\\"goal\\\">\\nContinue working toward the active thread goal.\\n</codex_internal_context>\"\n+        \"<codex_internal_context source=\\\"extension\\\">\\nInternal steering.\\n</codex_internal_context>\"\n     );\n     assert!(is_contextual_user_fragment(&ContentItem::InputText {\n         text\n@@ -65,21 +65,21 @@ fn does_not_hide_arbitrary_context_tags() {\n #[test]\n fn rejects_invalid_internal_model_context_source() {\n...",
+      "path": "codex-rs/core/src/context/contextual_user_message_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 2,
+      "patch_excerpt": "@@ -324,8 +324,8 @@ fn internal_model_context_does_not_parse_as_visible_turn_item() {\n         role: \"user\".to_string(),\n         content: vec![ContentItem::InputText {\n             text: InternalModelContextFragment::new(\n-                InternalContextSource::from_static(\"goal\"),\n-                \"Continue working toward the active thread goal.\",\n+                InternalContextSource::from_static(\"extension\"),\n+                \"Internal steering.\",\n             )\n             .render(),\n         }],",
+      "path": "codex-rs/core/src/event_mapping_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 1622,
+      "patch_excerpt": "@@ -1,1622 +0,0 @@\n-//! Core support for persisted thread goals.\n-//!\n-//! This module bridges core sessions and the state-db goal table. It validates\n-//! goal mutations, converts between state and protocol shapes, emits goal-update\n-//! events, and owns helper hooks used by goal lifecycle behavior.\n-\n-use crate::StateDbHandle;\n-use crate::context::ContextualUserFragment;\n-use crate::context::InternalContextSource;\n-use crate::context::InternalModelContextFragment;\n-use crate::session::TurnInput;\n-use crate::session::session::Session;\n-use crate::session::turn_context::TurnContext;\n-use crate::state::ActiveTurn;\n-use crate::state::TurnState;\n-use crate::tasks::RegularTask;\n-use crate::tools::handlers::goal_spec::UPDATE_GOAL_TOOL_NAME;\n-use anyhow::Context;\n-use codex_features::Feature;\n-use codex_otel::GOAL_BLOCKED_METRIC;\n-use codex_otel::GOAL_BUDGET_LIMITED_METRIC;\n-use codex_otel::GO...",
+      "path": "codex-rs/core/src/goals.rs",
+      "status": "removed"
+    },
+    {
+      "additions": 0,
+      "deletions": 3,
+      "patch_excerpt": "@@ -39,9 +39,6 @@ pub mod exec_env;\n mod exec_policy;\n #[cfg(test)]\n mod git_info_tests;\n-mod goals;\n-pub use goals::ExternalGoalPreviousStatus;\n-pub use goals::ExternalGoalSet;\n mod guardian;\n mod hook_runtime;\n mod installation_id;",
+      "path": "codex-rs/core/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 2,
+      "patch_excerpt": "@@ -26,7 +26,6 @@ pub(super) async fn spawn_review_thread(\n     let _ = review_features.disable(Feature::WebSearchCached);\n     let _ = review_features.disable(Feature::Goals);\n     let review_web_search_mode = WebSearchMode::Disabled;\n-    let goal_tools_supported = !config.ephemeral && parent_turn_context.goal_tools_enabled();\n     let available_models = sess\n         .services\n         .models_manager\n@@ -126,7 +125,6 @@ pub(super) async fn spawn_review_thread(\n         environments: parent_turn_context.environments.clone(),\n         available_models,\n         unified_exec_shell_mode,\n-        goal_tools_supported,\n         features: review_features,\n         ghost_snapshot: parent_turn_context.ghost_snapshot.clone(),\n         current_date: parent_turn_context.current_date.clone(),",
+      "path": "codex-rs/core/src/session/review.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 3,
+      "patch_excerpt": "@@ -2,7 +2,6 @@ use super::input_queue::InputQueue;\n use super::*;\n use crate::agents_md::LoadedAgentsMd;\n use crate::config::ConstraintError;\n-use crate::goals::GoalRuntimeState;\n use crate::skills::SkillError;\n use crate::state::ActiveTurn;\n use codex_protocol::SessionId;\n@@ -37,7 +36,6 @@ pub(crate) struct Session {\n     pub(crate) conversation: Arc<RealtimeConversationManager>,\n     pub(crate) active_turn: Mutex<Option<ActiveTurn>>,\n     pub(crate) input_queue: InputQueue,\n-    pub(crate) goal_runtime: GoalRuntimeState,\n     pub(crate) guardian_review_session: GuardianReviewSessionManager,\n     pub(crate) services: SessionServices,\n     pub(super) next_internal_sub_id: AtomicU64,\n@@ -1059,7 +1057,6 @@ impl Session {\n                 conversation: Arc::new(RealtimeConversationManager::new()),\n                 active_turn: Mutex::new(None),\n                 input_queue: InputQueue::new...",
+      "path": "codex-rs/core/src/session/session.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 72,
+      "deletions": 1252,
+      "patch_excerpt": "@@ -57,11 +57,6 @@ use codex_protocol::request_permissions::PermissionGrantScope;\n use codex_protocol::request_permissions::RequestPermissionProfile;\n use tracing::Span;\n \n-use crate::goals::CreateGoalRequest;\n-use crate::goals::ExternalGoalPreviousStatus;\n-use crate::goals::ExternalGoalSet;\n-use crate::goals::GoalRuntimeEvent;\n-use crate::goals::SetGoalRequest;\n use crate::rollout::recorder::RolloutRecorder;\n use crate::state::ActiveTurn;\n use crate::state::TaskKind;\n@@ -72,11 +67,9 @@ use crate::tasks::execute_user_shell_command;\n use crate::tools::ToolRouter;\n use crate::tools::context::ToolInvocation;\n use crate::tools::context::ToolPayload;\n-use crate::tools::handlers::CreateGoalHandler;\n use crate::tools::handlers::ExecCommandHandler;\n use crate::tools::handlers::RequestPermissionsHandler;\n use crate::tools::handlers::ShellCommandHandler;\n-use crate::tools::handlers::UpdateGoalHand...",
+      "path": "codex-rs/core/src/session/tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 30,
+      "patch_excerpt": "@@ -18,7 +18,6 @@ use crate::compact_remote_v2::run_inline_remote_auto_compact_task as run_inline_\n use crate::connectors;\n use crate::context::ContextualUserFragment;\n use crate::feedback_tags;\n-use crate::goals::GoalRuntimeEvent;\n use crate::hook_runtime::inspect_pending_input;\n use crate::hook_runtime::record_additional_contexts;\n use crate::hook_runtime::record_pending_input;\n@@ -151,15 +150,6 @@ pub(crate) async fn run_turn(\n         let error = err.to_codex_protocol_error();\n         sess.emit_turn_error_lifecycle(turn_context.as_ref(), error.clone())\n             .await;\n-        if error == CodexErrorInfo::UsageLimitExceeded\n-            && let Err(err) = sess\n-                .goal_runtime_apply(GoalRuntimeEvent::UsageLimitReached {\n-                    turn_context: turn_context.as_ref(),\n-                })\n-                .await\n-        {\n-            warn!(\"failed to usage...",
+      "path": "codex-rs/core/src/session/turn.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 10,
+      "patch_excerpt": "@@ -91,7 +91,6 @@ pub struct TurnContext {\n     pub(crate) shell_environment_policy: ShellEnvironmentPolicy,\n     pub(crate) available_models: Vec<ModelPreset>,\n     pub(crate) unified_exec_shell_mode: UnifiedExecShellMode,\n-    pub(crate) goal_tools_supported: bool,\n     pub features: ManagedFeatures,\n     pub(crate) ghost_snapshot: GhostSnapshotConfig,\n     pub(crate) final_output_json_schema: Option<Value>,\n@@ -170,10 +169,6 @@ impl TurnContext {\n         ToolEnvironmentMode::from_count(self.environments.turn_environments.len())\n     }\n \n-    pub(crate) fn goal_tools_enabled(&self) -> bool {\n-        self.goal_tools_supported && self.features.get().enabled(Feature::Goals)\n-    }\n-\n     pub(crate) async fn with_model(\n         &self,\n         model: String,\n@@ -264,7 +259,6 @@ impl TurnContext {\n             shell_environment_policy: self.shell_environment_policy.clone(),\n             ...",
+      "path": "codex-rs/core/src/session/turn_context.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 42,
+      "patch_excerpt": "@@ -23,7 +23,6 @@ use tracing::warn;\n \n use crate::config::Config;\n use crate::context::ContextualUserFragment;\n-use crate::goals::GoalRuntimeEvent;\n use crate::hook_runtime::inspect_pending_input;\n use crate::hook_runtime::record_additional_contexts;\n use crate::hook_runtime::record_pending_input;\n@@ -341,15 +340,6 @@ impl Session {\n             .await\n             .clear_turn(&turn_context.sub_id);\n \n-        if let Err(err) = self\n-            .goal_runtime_apply(GoalRuntimeEvent::TurnStarted {\n-                turn_context: turn_context.as_ref(),\n-                token_usage: token_usage_at_turn_start.clone(),\n-            })\n-            .await\n-        {\n-            warn!(\"failed to apply goal runtime turn-start event: {err}\");\n-        }\n         let pending_items = self.input_queue.get_pending_input(&self.active_turn).await;\n         let turn_state = {\n             let mut activ...",
+      "path": "codex-rs/core/src/tasks/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 3,
+      "patch_excerpt": "@@ -1343,9 +1343,6 @@ impl ThreadManagerState {\n             .await?;\n         if is_resumed_thread {\n             new_thread.thread.emit_thread_resume_lifecycle().await;\n-            if let Err(err) = new_thread.thread.apply_goal_resume_runtime_effects().await {\n-                warn!(\"failed to apply goal resume runtime effects: {err}\");\n-            }\n         }\n         Ok(new_thread)\n     }",
+      "path": "codex-rs/core/src/thread_manager.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 101,
+      "patch_excerpt": "@@ -8,7 +8,6 @@ use crate::session::tests::make_session_and_context;\n use crate::tasks::InterruptedTurnHistoryMarker;\n use crate::tasks::interrupted_turn_history_marker;\n use codex_extension_api::empty_extension_registry;\n-use codex_features::Feature;\n use codex_models_manager::manager::RefreshStrategy;\n use codex_protocol::models::ContentItem;\n use codex_protocol::models::ReasoningItemReasoningSummary;\n@@ -1501,103 +1500,3 @@ async fn interrupted_fork_snapshot_uses_persisted_mid_turn_history_without_live_\n         1,\n     );\n }\n-\n-#[tokio::test]\n-async fn resumed_thread_keeps_paused_goal_paused() -> anyhow::Result<()> {\n-    let temp_dir = tempdir().expect(\"tempdir\");\n-    let mut config = test_config().await;\n-    config.codex_home = temp_dir.path().join(\"codex-home\").abs();\n-    config.cwd = config.codex_home.abs();\n-    config\n-        .features\n-        .enable(Feature::Goals)\n-    ...",
+      "path": "codex-rs/core/src/thread_manager_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 158,
+      "patch_excerpt": "@@ -1,158 +0,0 @@\n-//! Built-in model tool handlers for persisted thread goals.\n-//!\n-//! The public tool contract intentionally splits goal creation from stopped\n-//! status updates: `create_goal` starts an active objective, while\n-//! `update_goal` can only mark the existing goal complete or blocked.\n-\n-use crate::function_tool::FunctionCallError;\n-use crate::tools::context::FunctionToolOutput;\n-use codex_protocol::protocol::ThreadGoal;\n-use codex_protocol::protocol::ThreadGoalStatus;\n-use serde::Deserialize;\n-use serde::Serialize;\n-use std::fmt::Write as _;\n-\n-mod create_goal;\n-mod get_goal;\n-mod update_goal;\n-\n-pub use create_goal::CreateGoalHandler;\n-pub use get_goal::GetGoalHandler;\n-pub use update_goal::UpdateGoalHandler;\n-\n-#[derive(Debug, Deserialize)]\n-#[serde(rename_all = \"snake_case\")]\n-struct CreateGoalArgs {\n-    objective: String,\n-    token_budget: Option<i64>,\n-}\n-\n-#[de...",
+      "path": "codex-rs/core/src/tools/handlers/goal.rs",
+      "status": "removed"
+    },
+    {
+      "additions": 0,
+      "deletions": 78,
+      "patch_excerpt": "@@ -1,78 +0,0 @@\n-use crate::function_tool::FunctionCallError;\n-use crate::goals::CreateGoalRequest;\n-use crate::tools::context::ToolInvocation;\n-use crate::tools::context::ToolPayload;\n-use crate::tools::context::boxed_tool_output;\n-use crate::tools::handlers::goal_spec::CREATE_GOAL_TOOL_NAME;\n-use crate::tools::handlers::goal_spec::create_create_goal_tool;\n-use crate::tools::handlers::parse_arguments;\n-use crate::tools::registry::CoreToolRuntime;\n-use crate::tools::registry::ToolExecutor;\n-use codex_tools::ToolName;\n-use codex_tools::ToolSpec;\n-\n-use super::CompletionBudgetReport;\n-use super::CreateGoalArgs;\n-use super::format_goal_error;\n-use super::goal_response;\n-\n-pub struct CreateGoalHandler;\n-\n-#[async_trait::async_trait]\n-impl ToolExecutor<ToolInvocation> for CreateGoalHandler {\n-    fn tool_name(&self) -> ToolName {\n-        ToolName::plain(CREATE_GOAL_TOOL_NAME)\n-    }\n-\n-    ...",
+      "path": "codex-rs/core/src/tools/handlers/goal/create_goal.rs",
+      "status": "removed"
+    },
+    {
+      "additions": 0,
+      "deletions": 51,
+      "patch_excerpt": "@@ -1,51 +0,0 @@\n-use crate::function_tool::FunctionCallError;\n-use crate::tools::context::ToolInvocation;\n-use crate::tools::context::ToolPayload;\n-use crate::tools::context::boxed_tool_output;\n-use crate::tools::handlers::goal_spec::GET_GOAL_TOOL_NAME;\n-use crate::tools::handlers::goal_spec::create_get_goal_tool;\n-use crate::tools::registry::CoreToolRuntime;\n-use crate::tools::registry::ToolExecutor;\n-use codex_tools::ToolName;\n-use codex_tools::ToolSpec;\n-\n-use super::CompletionBudgetReport;\n-use super::format_goal_error;\n-use super::goal_response;\n-\n-pub struct GetGoalHandler;\n-\n-#[async_trait::async_trait]\n-impl ToolExecutor<ToolInvocation> for GetGoalHandler {\n-    fn tool_name(&self) -> ToolName {\n-        ToolName::plain(GET_GOAL_TOOL_NAME)\n-    }\n-\n-    fn spec(&self) -> ToolSpec {\n-        create_get_goal_tool()\n-    }\n-\n-    async fn handle(\n-        &self,\n-        invocation...",
+      "path": "codex-rs/core/src/tools/handlers/goal/get_goal.rs",
+      "status": "removed"
+    },
+    {
+      "additions": 0,
+      "deletions": 89,
+      "patch_excerpt": "@@ -1,89 +0,0 @@\n-use crate::function_tool::FunctionCallError;\n-use crate::goals::GoalRuntimeEvent;\n-use crate::goals::SetGoalRequest;\n-use crate::tools::context::ToolInvocation;\n-use crate::tools::context::ToolPayload;\n-use crate::tools::context::boxed_tool_output;\n-use crate::tools::handlers::goal_spec::UPDATE_GOAL_TOOL_NAME;\n-use crate::tools::handlers::goal_spec::create_update_goal_tool;\n-use crate::tools::handlers::parse_arguments;\n-use crate::tools::registry::CoreToolRuntime;\n-use crate::tools::registry::ToolExecutor;\n-use codex_protocol::protocol::ThreadGoalStatus;\n-use codex_tools::ToolName;\n-use codex_tools::ToolSpec;\n-\n-use super::CompletionBudgetReport;\n-use super::UpdateGoalArgs;\n-use super::format_goal_error;\n-use super::goal_response;\n-\n-pub struct UpdateGoalHandler;\n-\n-#[async_trait::async_trait]\n-impl ToolExecutor<ToolInvocation> for UpdateGoalHandler {\n-    fn tool_name(...",
+      "path": "codex-rs/core/src/tools/handlers/goal/update_goal.rs",
+      "status": "removed"
+    },
+    {
+      "additions": 0,
+      "deletions": 120,
+      "patch_excerpt": "@@ -1,120 +0,0 @@\n-//! Responses API tool definitions for persisted thread goals.\n-//!\n-//! These specs expose goal read/update primitives to the model while keeping\n-//! usage accounting system-managed.\n-\n-use codex_tools::JsonSchema;\n-use codex_tools::ResponsesApiTool;\n-use codex_tools::ToolSpec;\n-use serde_json::json;\n-use std::collections::BTreeMap;\n-\n-pub const GET_GOAL_TOOL_NAME: &str = \"get_goal\";\n-pub const CREATE_GOAL_TOOL_NAME: &str = \"create_goal\";\n-pub const UPDATE_GOAL_TOOL_NAME: &str = \"update_goal\";\n-\n-pub fn create_get_goal_tool() -> ToolSpec {\n-    ToolSpec::Function(ResponsesApiTool {\n-        name: GET_GOAL_TOOL_NAME.to_string(),\n-        description: \"Get the current goal for this thread, including status, budgets, token and elapsed-time usage, and remaining token budget.\"\n-            .to_string(),\n-        strict: false,\n-        defer_loading: None,\n-        parame...",
+      "path": "codex-rs/core/src/tools/handlers/goal_spec.rs",
+      "status": "removed"
+    },
+    {
+      "additions": 0,
+      "deletions": 5,
+      "patch_excerpt": "@@ -4,8 +4,6 @@ pub(crate) mod apply_patch;\n pub(crate) mod apply_patch_spec;\n mod dynamic;\n pub(crate) mod extension_tools;\n-mod goal;\n-pub(crate) mod goal_spec;\n mod list_available_plugins_to_install;\n pub(crate) mod list_available_plugins_to_install_spec;\n mod mcp;\n@@ -53,9 +51,6 @@ pub use apply_patch::ApplyPatchHandler;\n use codex_protocol::models::AdditionalPermissionProfile;\n use codex_protocol::protocol::AskForApproval;\n pub use dynamic::DynamicToolHandler;\n-pub use goal::CreateGoalHandler;\n-pub use goal::GetGoalHandler;\n-pub use goal::UpdateGoalHandler;\n pub use list_available_plugins_to_install::ListAvailablePluginsToInstallHandler;\n pub use mcp::McpHandler;\n pub use mcp_resource::ListMcpResourceTemplatesHandler;",
+      "path": "codex-rs/core/src/tools/handlers/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 15,
+      "patch_excerpt": "@@ -5,7 +5,6 @@ use std::sync::atomic::Ordering;\n use std::time::Duration;\n \n use crate::function_tool::FunctionCallError;\n-use crate::goals::GoalRuntimeEvent;\n use crate::hook_runtime::PreToolUseHookResult;\n use crate::hook_runtime::record_additional_contexts;\n use crate::hook_runtime::run_post_tool_use_hooks;\n@@ -34,7 +33,6 @@ use codex_tools::ToolSearchInfo;\n use codex_tools::ToolSpec;\n use futures::future::BoxFuture;\n use serde_json::Value;\n-use tracing::warn;\n \n pub(crate) type ToolTelemetryTags = Vec<(&'static str, String)>;\n \n@@ -649,25 +647,13 @@ impl ToolRegistry {\n                 handler_executed: true,\n             },\n         };\n-        let finished = notify_tool_finish_if_unclaimed(\n+        notify_tool_finish_if_unclaimed(\n             &invocation,\n             terminal_outcome_reached.as_deref(),\n             lifecycle_outcome,\n         )\n         .await;\n \n-        if f...",
+      "path": "codex-rs/core/src/tools/registry.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 17,
+      "patch_excerpt": "@@ -6,11 +6,9 @@ use crate::tools::context::ToolInvocation;\n use crate::tools::handlers::ApplyPatchHandler;\n use crate::tools::handlers::CodeModeExecuteHandler;\n use crate::tools::handlers::CodeModeWaitHandler;\n-use crate::tools::handlers::CreateGoalHandler;\n use crate::tools::handlers::DynamicToolHandler;\n use crate::tools::handlers::ExecCommandHandler;\n use crate::tools::handlers::ExecCommandHandlerOptions;\n-use crate::tools::handlers::GetGoalHandler;\n use crate::tools::handlers::ListAvailablePluginsToInstallHandler;\n use crate::tools::handlers::ListMcpResourceTemplatesHandler;\n use crate::tools::handlers::ListMcpResourcesHandler;\n@@ -24,7 +22,6 @@ use crate::tools::handlers::ShellCommandHandler;\n use crate::tools::handlers::ShellCommandHandlerOptions;\n use crate::tools::handlers::TestSyncHandler;\n use crate::tools::handlers::ToolSearchHandler;\n-use crate::tools::handlers::UpdateGoalHa...",
+      "path": "codex-rs/core/src/tools/spec_plan.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 30,
+      "patch_excerpt": "@@ -619,36 +619,7 @@ async fn environment_count_controls_environment_backed_tools() {\n }\n \n #[tokio::test]\n-async fn host_context_gates_goal_and_agent_job_tools() {\n-    let feature_disabled = probe(|turn| {\n-        set_feature(turn, Feature::Goals, /*enabled*/ false);\n-        turn.goal_tools_supported = true;\n-    })\n-    .await;\n-    feature_disabled.assert_visible_lacks(&[\"get_goal\", \"create_goal\", \"update_goal\"]);\n-\n-    let host_disabled = probe(|turn| {\n-        set_feature(turn, Feature::Goals, /*enabled*/ true);\n-        turn.goal_tools_supported = false;\n-    })\n-    .await;\n-    host_disabled.assert_visible_lacks(&[\"get_goal\", \"create_goal\", \"update_goal\"]);\n-\n-    let enabled = probe(|turn| {\n-        set_feature(turn, Feature::Goals, /*enabled*/ true);\n-        turn.goal_tools_supported = true;\n-    })\n-    .await;\n-    enabled.assert_visible_contains(&[\"get_goal\", \"create_...",
+      "path": "codex-rs/core/src/tools/spec_plan_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 3,
+      "patch_excerpt": "@@ -188,9 +188,6 @@ async fn prompt_tools_are_consistent_across_requests() -> anyhow::Result<()> {\n     };\n     expected_tools_names.extend([\n         \"update_plan\",\n-        \"get_goal\",\n-        \"create_goal\",\n-        \"update_goal\",\n         \"request_user_input\",\n         \"apply_patch\",\n         \"view_image\",",
+      "path": "codex-rs/core/tests/suite/prompt_caching.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#26547",
+    "#26548"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Stack\r\n\r\n1. [#26547](https://github.com/openai/codex/pull/26547) - [1 of 2] Align goal extension with core behavior\r\n2. [#26548](https://github.com/openai/codex/pull/26548) - [2 of 2] Move goal runtime to extension\r\n\r\n## Why\r\n\r\nThis PR completes the switch of the goal behavior to the extension-backed runtime and removes the old core goal implementation.\r\n\r\n## What Changed\r\n\r\n- Installs the goal extension for app-server `ThreadManager` sessions.\r\n- Routes app-server thread goal `get`, `set`, and `clear` through `GoalService`.\r\n- Uses thread-idle lifecycle emission after goal resume and snapshot ordering so the extension can decide whether to continue the goal.\r\n- Forwards extension goal updates through a FIFO async app-server notification path so backpressure does not drop them or reorder updates.\r\n- Keeps review turns from enabling goal runtime behavior.\r\n- Plans extension tools before dynamic tools so built-in goal tool names keep their old precedence when goals are enabled.\r\n- Removes the old core goal runtime, core goal tool handlers, and core goal tool specs.\r\n- Updates tests that were coupled to the core-owned goal runtime while leaving the legacy `<goal_context>` compatibility path in core for old threads.\r\n- Removes the stale cargo-shear ignore now that `codex-goal-extension` is used by the workspace.\r\n- Keeps realtime event matching exhaustive after removing the old goal-specific realtime text path.\r\n\r\n\r\n## Validation\r\n\r\n- Ran manual `/goal` runs in TUI. Validated time accounting matched wall-clock time and goal lifecycle state transitions.",
+    "labels": [],
+    "merged_at": "2026-06-05T21:17:30Z",
+    "number": 26548,
+    "state": "merged",
+    "title": "[2 of 2] Finish moving goal runtime to extension",
+    "url": "https://github.com/openai/codex/pull/26548"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-26674.json
+++ b/artifacts/github/bundles/openai-codex-pr-26674.json
@@ -1,0 +1,67 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "pakrym-oai",
+      "committed_at": "2026-06-05T20:34:13Z",
+      "message": "protocol: remove submission-side serde from Op",
+      "sha": "045c529265ced1ae8eeeb81f9e3e5186b74109f0",
+      "url": "https://github.com/openai/codex/commit/045c529265ced1ae8eeeb81f9e3e5186b74109f0"
+    },
+    {
+      "author": "pakrym-oai",
+      "committed_at": "2026-06-05T22:13:23Z",
+      "message": "Restore request_user_input response serde",
+      "sha": "6ae6451e144f9f76e1ea34754ba1d4f8204d3d1a",
+      "url": "https://github.com/openai/codex/commit/6ae6451e144f9f76e1ea34754ba1d4f8204d3d1a"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "API",
+    "IPC",
+    "TCP",
+    "HTTP2",
+    "JSON",
+    "REALTIME_CONVERSATION_OPEN_TAG",
+    "REALTIME_CONVERSATION_CLOSE_TAG",
+    "USER_MESSAGE_BEGIN",
+    "W3C",
+    "MCP",
+    "EXPERIMENTAL",
+    "AQID"
+  ],
+  "files": [
+    {
+      "additions": 2,
+      "deletions": 1,
+      "patch_excerpt": "@@ -54,6 +54,7 @@ Since only 1 `Task` can be run at a time, for parallel tasks it is recommended t\n   - These are messages sent on the `SQ` (UI -> `Codex`)\n   - Has an string ID provided by the UI, referred to as `sub_id`\n   - `Op` refers to the enum of all possible `Submission` payloads\n+  - In the current codebase these are primarily in-process Rust types rather than a stable serde wire contract\n     - This enum is `non_exhaustive`; variants can be added at future dates\n - `Event`\n   - These are messages sent on the `EQ` (`Codex` -> UI)\n@@ -103,7 +104,7 @@ The `response_id` returned from each turn matches the OpenAI `response_id` store\n \n Can operate over any transport that supports bi-directional streaming. - cross-thread channels - IPC channels - stdin/stdout - TCP - HTTP2 - gRPC\n \n-Non-framed transports, such as stdin/stdout and TCP, should use newline-delimited JSON in sending mess...",
+      "path": "codex-rs/docs/protocol_v1.md",
+      "status": "modified"
+    },
+    {
+      "additions": 11,
+      "deletions": 311,
+      "patch_excerpt": "@@ -106,7 +106,7 @@ pub const REALTIME_CONVERSATION_OPEN_TAG: &str = \"<realtime_conversation>\";\n pub const REALTIME_CONVERSATION_CLOSE_TAG: &str = \"</realtime_conversation>\";\n pub const USER_MESSAGE_BEGIN: &str = \"## My request for Codex:\";\n \n-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, JsonSchema)]\n+#[derive(Debug, Clone, PartialEq)]\n pub struct TurnEnvironmentSelection {\n     pub environment_id: String,\n     pub cwd: AbsolutePathBuf,\n@@ -124,17 +124,15 @@ impl GitSha {\n }\n \n /// Submission Queue Entry - requests from user\n-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]\n+#[derive(Debug, Clone)]\n pub struct Submission {\n     /// Unique id for this Submission to correlate with Events\n     pub id: String,\n     /// Payload\n     pub op: Op,\n     /// Client-provided id for the user message represented by `Op::UserInput`.\n-    #[serde(default, skip_serializing_if = \"...",
+      "path": "codex-rs/protocol/src/protocol.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nSubmission-side `Op` payloads are now an internal handoff inside the Rust codebase, so keeping a stable serde contract there adds complexity without a real wire consumer.\n\n## What changed\n\n- remove serde/schema annotations from `Submission`, `Op`, and submission-only payload types like thread settings overrides, additional context, realtime conversation params, `TurnEnvironmentSelection`, and `RequestUserInputResponse`\n- delete the `Op` serialization tests and the now-unused double-option prompt serde helper\n- keep event/API-facing serialization where it is still required, and serialize the `request_user_input` tool output from its wire payload instead of the core response struct\n- update `protocol_v1.md` to call out that events remain the serialized transport surface while submission payloads are implementation details\n\n## Testing\n\n- `just test -p codex-protocol`\n- `cargo check -p codex-core -p codex-app-server -p codex-thread-store`\n- `just test -p codex-core request_user_input`\n",
+    "labels": [],
+    "merged_at": "2026-06-05T22:41:14Z",
+    "number": 26674,
+    "state": "merged",
+    "title": "protocol: remove submission-side serde from Op",
+    "url": "https://github.com/openai/codex/pull/26674"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/impact/openai-codex-pr-25936.json
+++ b/artifacts/github/impact/openai-codex-pr-25936.json
@@ -1,0 +1,46 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-25936",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Remove legacy remote plugin startup sync",
+        "url": "https://github.com/openai/codex/pull/25936",
+        "meta": "Merged 2026-06-05T23:33:01Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/25936",
+        "meta": "artifacts/github/reviews/openai-codex-pr-25936.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex removed the legacy startup remote plugin sync path that called /plugins/list while keeping current remote installed-bundle and catalog flows intact.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #25936 says the legacy startup remote plugin sync path that called /plugins/list is removed.",
+    "The PR says current /ps/plugins/installed and /ps/plugins/list flows remain intact.",
+    "core-plugins startup_remote_sync.rs is removed.",
+    "manager.rs removes sync_plugins_from_remote wiring and related startup sync behavior.",
+    "plugin_list.rs removes the startup remote sync app-server test."
+  ],
+  "candidate_followups": [
+    "Remove any Decodex dependency on startup remote plugin sync markers or sync_plugins_from_remote-style side effects.",
+    "Use current installed-bundle and remote catalog APIs for plugin inventory readback.",
+    "When explaining publicly, state clearly that remote plugin support was not removed overall."
+  ],
+  "social_notes": [
+    "The practical public angle is the migration boundary: legacy /plugins/list startup sync is gone, current /ps/plugins/installed and /ps/plugins/list stay.",
+    "Keep the post useful for plugin operators and avoid implying all remote plugin behavior was removed."
+  ],
+  "caveats": [
+    "Current remote installed bundle sync and remote catalog flows remain supported.",
+    "The app-server plugin_list filtered test was blocked in the upstream PR by an unrelated compile error, according to the PR notes."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-26490.json
+++ b/artifacts/github/impact/openai-codex-pr-26490.json
@@ -1,0 +1,46 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-26490",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Use standalone tools for Responses Lite",
+        "url": "https://github.com/openai/codex/pull/26490",
+        "meta": "Merged 2026-06-06T00:23:40Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/26490",
+        "meta": "artifacts/github/reviews/openai-codex-pr-26490.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex routes web search and image generation through standalone Codex-owned executors for Responses Lite models instead of relying on hosted Responses tools.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "practical_explainer",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26490 says Responses Lite does not execute hosted Responses tools and needs Codex-owned standalone executors.",
+    "spec_plan.rs suppresses hosted model tool specs when use_responses_lite is true.",
+    "Responses Lite tests cover standalone fallback behavior.",
+    "Web-search and image-generation extensions now compute standalone availability from provider/config state.",
+    "The PR validation includes core, app-server, web-search extension, and image-generation extension tests."
+  ],
+  "candidate_followups": [
+    "Represent hosted Responses tools and standalone Codex executors as separate Control Plane capabilities.",
+    "Check Decodex readbacks for Responses Lite sessions so tool availability is not inferred solely from hosted tool support.",
+    "Use this PR as public explanation material for why Responses Lite tool execution may look different from hosted Responses tool execution."
+  ],
+  "social_notes": [
+    "Lead with the practical distinction: Responses Lite does not execute hosted Responses tools, so Codex uses standalone executors for web search and image generation.",
+    "Mention that availability still depends on provider, model, config, and extension gates."
+  ],
+  "caveats": [
+    "Standalone tool availability remains provider/config/model gated.",
+    "This does not mean every Responses Lite session always exposes both web search and image generation."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-26548.json
+++ b/artifacts/github/impact/openai-codex-pr-26548.json
@@ -1,0 +1,46 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-26548",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[2 of 2] Finish moving goal runtime to extension",
+        "url": "https://github.com/openai/codex/pull/26548",
+        "meta": "Merged 2026-06-05T21:17:30Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/26548",
+        "meta": "artifacts/github/reviews/openai-codex-pr-26548.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex completed the move of thread goal behavior from core-owned runtime and built-in core tools into the goal extension and app-server GoalService path.",
+  "public_signal_decision": "defer",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26548 says the goal behavior now uses the extension-backed runtime and old core goal implementation is removed.",
+    "The app-server thread goal processor now depends on codex_goal_extension::GoalService and goal request/update types.",
+    "Core goal runtime and built-in goal tool handler/spec files are removed.",
+    "The PR keeps the legacy <goal_context> compatibility path for old threads.",
+    "Extension goal updates are forwarded through FIFO async app-server notification ordering according to the PR body."
+  ],
+  "candidate_followups": [
+    "Audit Decodex assumptions about goal tool ownership before mirroring Codex goal state.",
+    "Treat goal runtime events as extension-owned when interpreting app-server notifications.",
+    "Avoid describing this as removal of all old goal context support because the PR keeps legacy <goal_context> compatibility."
+  ],
+  "social_notes": [
+    "Use an operator-impact framing if Publisher chooses to post: goals moved from core runtime to extension-backed GoalService routing.",
+    "Keep the candidate narrow and avoid implying new user commands."
+  ],
+  "caveats": [
+    "The PR is a runtime ownership migration, not a broad new end-user goal feature.",
+    "Legacy <goal_context> compatibility remains for old threads."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-26674.json
+++ b/artifacts/github/impact/openai-codex-pr-26674.json
@@ -1,0 +1,45 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-26674",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "protocol: remove submission-side serde from Op",
+        "url": "https://github.com/openai/codex/pull/26674",
+        "meta": "Merged 2026-06-05T22:41:14Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/26674",
+        "meta": "artifacts/github/reviews/openai-codex-pr-26674.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex removed serde/schema support from submission-side Op payloads while preserving event/API-facing serialization where wire consumers still exist.",
+  "public_signal_decision": "defer",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "watch_note",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26674 says submission-side Op payloads are internal handoff types rather than a stable serde wire contract.",
+    "codex-rs/protocol/src/protocol.rs removes serde/schema derives from Submission, Op, and submission-only payloads.",
+    "codex-rs/docs/protocol_v1.md documents that Op submissions are primarily in-process Rust types.",
+    "The PR body says event/API-facing serialization remains where required.",
+    "The request_user_input response serde restoration keeps the wire-payload serialization path explicit."
+  ],
+  "candidate_followups": [
+    "Check Decodex app-server and protocol adapters for any direct serialized Op submission dependency.",
+    "Keep Control Plane integrations anchored to explicit app-server APIs and event serialization.",
+    "Use this as release-rollup background rather than a standalone public feature unless a broader protocol migration note is produced."
+  ],
+  "social_notes": [
+    "If this appears publicly, frame it as a cautious protocol boundary note, not a user feature."
+  ],
+  "caveats": [
+    "Event/API-facing serialization is still preserved where required.",
+    "The change affects submission-side Rust types, not every protocol message."
+  ]
+}

--- a/artifacts/github/review-queue/openai-codex-latest.json
+++ b/artifacts/github/review-queue/openai-codex-latest.json
@@ -1,14 +1,14 @@
 {
   "counts": {
     "critical": 19,
-    "high": 5,
-    "low": 2,
-    "normal": 14,
+    "high": 4,
+    "low": 1,
+    "normal": 16,
     "published_subjects_seen": 0,
     "recent_commits_scanned": 40,
     "subjects_queued": 40
   },
-  "generated_at": "2026-06-08T08:04:47.078688Z",
+  "generated_at": "2026-06-08T14:06:05.15617Z",
   "repo": "openai/codex",
   "schema": "upstream_review_queue/v1",
   "source": {
@@ -17,54 +17,6 @@
     "signals_dir": "site/src/content/signals"
   },
   "subjects": [
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 52,
-      "commit_shas": [
-        "7b0e744c2817f02dfb2be7741654b3163cf63640",
-        "581088c7d4effa5370dbfffdd73075c28f0a69a3",
-        "763ee1c0f8a5c0874acb23b2b139b1ef0c65d40b",
-        "69c63117537ebd06a9e553bd78a8224ef472b619"
-      ],
-      "committed_at": "2026-06-05T16:29:15Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26532,
-      "pr_url": "https://github.com/openai/codex/pull/26532",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server/src/request_processors/turn_processor.rs",
-        "codex-rs/core/src/codex_thread.rs",
-        "codex-rs/core/src/guardian/review_session.rs",
-        "codex-rs/core/src/session/mod.rs",
-        "codex-rs/core/src/session/session.rs",
-        "codex-rs/core/src/session/tests.rs",
-        "codex-rs/core/tests/common/test_codex.rs",
-        "codex-rs/core/tests/suite/apply_patch_cli.rs",
-        "codex-rs/core/tests/suite/approvals.rs",
-        "codex-rs/core/tests/suite/auto_review.rs",
-        "codex-rs/core/tests/suite/client.rs",
-        "codex-rs/core/tests/suite/code_mode.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26532",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "mcp_plugins",
-        "model_provider",
-        "sandbox_permissions",
-        "tests_ci"
-      ],
-      "title": "Require absolute cwd in thread settings",
-      "url": "https://github.com/openai/codex/pull/26532"
-    },
     {
       "attention_flags": [
         "auth_account",
@@ -867,33 +819,33 @@
     },
     {
       "attention_flags": [
-        "protocol_change",
+        "deprecated_removed",
+        "new_feature",
+        "release_packaging",
         "security_policy"
       ],
       "changed_file_count": 2,
       "commit_shas": [
-        "ee11c0430c82d9853644a50bc6fdb98aadc7433a",
-        "2a0a59f851fbe4fe4ef4d8fa51ce68f33a33c70f"
+        "d93f759a07dc3c9b685930233f441fe2fbce1c10"
       ],
-      "committed_at": "2026-06-05T16:34:36Z",
+      "committed_at": "2026-06-08T09:39:08Z",
       "next_step": "ai_review_required",
-      "pr_number": 26625,
-      "pr_url": "https://github.com/openai/codex/pull/26625",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for protocol_change, security_policy.",
+      "pr_number": 26974,
+      "pr_url": "https://github.com/openai/codex/pull/26974",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, release_packaging, security_policy.",
       "sample_paths": [
-        "codex-rs/linux-sandbox/src/landlock.rs",
-        "codex-rs/linux-sandbox/tests/suite/managed_proxy.rs"
+        "codex-rs/.cargo/audit.toml",
+        "codex-rs/deny.toml"
       ],
       "source_state": "merged",
-      "subject_id": "26625",
+      "subject_id": "26974",
       "subject_kind": "pr",
       "surface_hints": [
-        "sandbox_permissions",
-        "tests_ci"
+        "config_hooks"
       ],
-      "title": "[codex] Allow socketpair in proxy-routed Linux sandbox",
-      "url": "https://github.com/openai/codex/pull/26625"
+      "title": "Ignore proc-macro-error2 advisory",
+      "url": "https://github.com/openai/codex/pull/26974"
     },
     {
       "attention_flags": [
@@ -1021,42 +973,6 @@
       ],
       "title": "[codex] Enable standalone web search in code mode",
       "url": "https://github.com/openai/codex/pull/26719"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 4,
-      "commit_shas": [
-        "f93d333b914a3b2771ff1e662779eab99761f3a3",
-        "65e4e817cbc4191a851eec095d9aa779ae4314ad",
-        "b1f2e1c1b186bba3186da59a55fa5f8bf1415528",
-        "b16bb70cd5e227939c665153d41cf653aaa47792",
-        "ae13535f00b66c3c3fdcbe66697ce1aedf24d5b5"
-      ],
-      "committed_at": "2026-06-05T16:18:29Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26623,
-      "pr_url": "https://github.com/openai/codex/pull/26623",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/core/src/agent/control/spawn.rs",
-        "codex-rs/core/src/agent/control_tests.rs",
-        "codex-rs/core/src/tools/handlers/multi_agents/send_input.rs",
-        "codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26623",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "tests_ci"
-      ],
-      "title": "feat: reload v2 agents on delivery",
-      "url": "https://github.com/openai/codex/pull/26623"
     },
     {
       "attention_flags": [
@@ -1480,35 +1396,123 @@
       "url": "https://github.com/openai/codex/pull/26818"
     },
     {
-      "attention_flags": [],
-      "changed_file_count": 6,
-      "commit_shas": [
-        "ac1b6e8188f0c709dfadfff215a05fd324c98cf8",
-        "c5335e4fd15f9fa7b4faf55e1fdeff970943e505"
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
       ],
-      "committed_at": "2026-06-05T15:34:34Z",
+      "changed_file_count": 5,
+      "commit_shas": [
+        "46e2da8bc5461a85aff9c060b4213372eb6992b3",
+        "5a56d7ecee1b27a94f1112e1b5e74f45a1f985ea"
+      ],
+      "committed_at": "2026-06-08T08:24:48Z",
       "next_step": "ai_review_required",
-      "pr_number": 26554,
-      "pr_url": "https://github.com/openai/codex/pull/26554",
-      "review_priority": "low",
-      "review_reason": "Needs AI review for surface hints: cli_tui, tests_ci.",
+      "pr_number": 26632,
+      "pr_url": "https://github.com/openai/codex/pull/26632",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging.",
       "sample_paths": [
-        "codex-rs/tui/src/chatwidget/streaming.rs",
-        "codex-rs/tui/src/chatwidget/turn_runtime.rs",
-        "codex-rs/tui/src/git_action_directives.rs",
-        "codex-rs/tui/src/resume_picker.rs",
-        "codex-rs/tui/src/resume_picker/transcript.rs",
-        "codex-rs/tui/src/snapshots/codex_tui__git_action_directives__tests__code_comment_directive_fallback.snap"
+        "codex-rs/core/src/agent/control.rs",
+        "codex-rs/core/src/agent/control/legacy.rs",
+        "codex-rs/core/src/agent/control/residency.rs",
+        "codex-rs/core/src/agent/control/residency_tests.rs",
+        "codex-rs/core/src/agent/control/spawn.rs"
       ],
       "source_state": "merged",
-      "subject_id": "26554",
+      "subject_id": "26632",
       "subject_kind": "pr",
       "surface_hints": [
-        "cli_tui",
         "tests_ci"
       ],
-      "title": "Render code comment directives in TUI replay",
-      "url": "https://github.com/openai/codex/pull/26554"
+      "title": "feat: add v2 agent residency lru",
+      "url": "https://github.com/openai/codex/pull/26632"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 11,
+      "commit_shas": [
+        "a66741fc0468c7ffa97c690a9aa737a75068699d",
+        "d3e65b3c8f142c79be0a510094edc46e6bf17953",
+        "142344dacca9ff1c6d7ceedc89310800946d81dd",
+        "773a29a9f89f9f36ba0bf9700f9ef6e706d189f4",
+        "4fcd8712ac7358e8b9676e9aac9fabb48538260a",
+        "28d5be36730f14ffe5d949384e91d3b993d03fa0",
+        "37a985e98fcef7f8c6166bdef6766d59d490ce39",
+        "36dcfa4bf3030fb93717714712884d7a4ffef55f",
+        "751112ad6f92aee1e7103dc7dc6c8e088f51a622"
+      ],
+      "committed_at": "2026-06-08T12:21:28Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26969,
+      "pr_url": "https://github.com/openai/codex/pull/26969",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/src/agent/control.rs",
+        "codex-rs/core/src/agent/control/execution.rs",
+        "codex-rs/core/src/agent/control/execution_tests.rs",
+        "codex-rs/core/src/agent/control/spawn.rs",
+        "codex-rs/core/src/codex_thread.rs",
+        "codex-rs/core/src/session/session.rs",
+        "codex-rs/core/src/session/tests.rs",
+        "codex-rs/core/src/state/turn.rs",
+        "codex-rs/core/src/tasks/mod.rs",
+        "codex-rs/core/tests/suite/agent_execution.rs",
+        "codex-rs/core/tests/suite/mod.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26969",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "feat: count V2 concurrency by active execution",
+      "url": "https://github.com/openai/codex/pull/26969"
+    },
+    {
+      "attention_flags": [
+        "breaking_change",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 8,
+      "commit_shas": [
+        "2f9beaccb897de72f762966b71307da28298b72b"
+      ],
+      "committed_at": "2026-06-08T12:46:35Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26994,
+      "pr_url": "https://github.com/openai/codex/pull/26994",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for breaking_change, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/core/src/agent/control.rs",
+        "codex-rs/core/src/tools/handlers/multi_agents_spec.rs",
+        "codex-rs/core/src/tools/handlers/multi_agents_tests.rs",
+        "codex-rs/core/src/tools/handlers/multi_agents_v2.rs",
+        "codex-rs/core/src/tools/handlers/multi_agents_v2/interrupt_agent.rs",
+        "codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs",
+        "codex-rs/core/src/tools/spec_plan.rs",
+        "codex-rs/core/src/tools/spec_plan_tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26994",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "Rename multi-agent v2 close_agent to interrupt_agent",
+      "url": "https://github.com/openai/codex/pull/26994"
     },
     {
       "attention_flags": [

--- a/artifacts/github/reviews/openai-codex-pr-25936.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-25936.review.json
@@ -1,0 +1,62 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-25936",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "25936",
+    "commit_shas": [
+      "a4bd397630c74317c78f3998df30039adc9279d3"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Remove legacy remote plugin startup sync",
+        "url": "https://github.com/openai/codex/pull/25936",
+        "meta": "Merged 2026-06-05T23:33:01Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Remove legacy remote plugin startup sync",
+        "url": "https://github.com/openai/codex/commit/a4bd397630c74317c78f3998df30039adc9279d3"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-08T14:08:38Z",
+  "observed_change": "Codex removed the legacy startup remote plugin sync path that called /plugins/list while keeping current remote installed-bundle and catalog flows intact.",
+  "changed_surfaces": [
+    "core plugin manager remote sync API",
+    "app-server startup remote plugin sync marker task",
+    "legacy remote plugin list fetch types",
+    "plugin list tests for startup sync behavior"
+  ],
+  "user_visible_path": "Plugin users should no longer expect Codex startup to reconcile curated plugin cache/config through the old /plugins/list sync path; current /ps/plugins/installed and /ps/plugins/list flows remain the active remote paths.",
+  "control_plane_relevance": "Decodex plugin automation should not rely on legacy startup sync side effects or the removed sync_plugins_from_remote API when checking plugin inventory.",
+  "compatibility_risk": "Automation or tests expecting startup_remote_sync markers, sync_plugins_from_remote results, or /plugins/list reconciliation will break and should move to the current installed-bundle and catalog flows.",
+  "adoption_opportunity": "Treat explicit plugin inventory reads and current remote installed-bundle/catalog APIs as the durable path for Decodex plugin state checks.",
+  "community_value": "This has a narrow but concrete operator-impact angle because it names the removed legacy path and the still-supported replacement surfaces.",
+  "deprecated_or_breaking_notes": "The startup remote sync module, sync_plugins_from_remote API, related result/error types, marker task, and tests were removed.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #25936 says it removes the legacy startup remote plugin sync path that called /plugins/list.",
+    "The PR body says current remote installed bundle sync and remote catalog flows, /ps/plugins/installed and /ps/plugins/list, remain intact.",
+    "codex-rs/core-plugins/src/startup_remote_sync.rs is removed.",
+    "codex-rs/core-plugins/src/manager.rs removes startup_remote_sync wiring and sync_plugins_from_remote support.",
+    "codex-rs/core-plugins/src/lib.rs stops exporting PluginRemoteSyncError and RemotePluginSyncResult.",
+    "codex-rs/app-server/tests/suite/v2/plugin_list.rs removes the app_server_startup_remote_plugin_sync_runs_once test.",
+    "The normalized bundle artifacts/github/bundles/openai-codex-pr-25936.json records 8 changed files for the merged PR."
+  ],
+  "caveats": "The current remote installed bundle sync and remote catalog flows remain in scope; this is not a removal of remote plugin support overall.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Removed startup sync behavior can affect Decodex plugin inventory and compatibility assumptions."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The removed and retained plugin paths create a source-backed operator-impact note."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-26490.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-26490.review.json
@@ -1,0 +1,71 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-26490",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "26490",
+    "commit_shas": [
+      "7ee483d92c3032987ff02381460ea02696336566",
+      "7c7b49719ff76676df444a084bd51596a6bfe18d",
+      "be7d534041a58366edcf5152c1e6de446b2f9d15",
+      "31159463bf179e40aee1812bc68e556ab4c5fef8",
+      "b950c637ccd59ae3564df464c07baeff85d20840",
+      "f6d73aba8d25dfd6a357cbb39f730fc439cf9059"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Use standalone tools for Responses Lite",
+        "url": "https://github.com/openai/codex/pull/26490",
+        "meta": "Merged 2026-06-06T00:23:40Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Use standalone tools for Responses Lite",
+        "url": "https://github.com/openai/codex/commit/7ee483d92c3032987ff02381460ea02696336566"
+      },
+      {
+        "kind": "commit",
+        "title": "Cover Responses Lite tool fallback behavior",
+        "url": "https://github.com/openai/codex/commit/31159463bf179e40aee1812bc68e556ab4c5fef8"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-08T14:08:38Z",
+  "observed_change": "Codex routes web search and image generation through standalone Codex-owned executors for Responses Lite models instead of relying on hosted Responses tools.",
+  "changed_surfaces": [
+    "core tool planning for hosted versus standalone tools",
+    "Responses Lite model behavior",
+    "standalone web-search and image-generation extensions",
+    "core and app-server integration tests for standalone tool fallback"
+  ],
+  "user_visible_path": "When a model uses Responses Lite, Codex can still expose web search and image generation through standalone executors and standalone Responses API endpoints rather than submitting hosted Responses tools that the model will not execute.",
+  "control_plane_relevance": "Decodex should model Responses Lite tool availability separately from hosted Responses tool availability when planning browser, search, image, or extension-backed capabilities.",
+  "compatibility_risk": "Integrations that infer tool availability only from hosted Responses tool support may misclassify Responses Lite sessions; the fallback depends on standalone executors and provider/config gates.",
+  "adoption_opportunity": "Adopt a capability split between hosted tools and client-executed standalone tools in Decodex Control Plane readiness and operator readbacks.",
+  "community_value": "This is a practical public explainer candidate because it clarifies why Responses Lite needs standalone Codex executors for web search and image generation.",
+  "deprecated_or_breaking_notes": "Hosted model tool specs are suppressed for Responses Lite; standalone executors remain hidden without the relevant flags or Responses Lite path.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26490 says Responses Lite does not execute hosted Responses tools and must route web search and image generation through Codex-owned executors and standalone Responses API endpoints.",
+    "codex-rs/core/src/tools/spec_plan.rs returns no hosted model tool specs when turn_context.model_info.use_responses_lite is true.",
+    "codex-rs/core/src/tools/spec_plan.rs adds planning around WebSearchMode and standalone web-run availability.",
+    "codex-rs/core/tests/suite/responses_lite.rs adds integration coverage for Responses Lite standalone fallback behavior.",
+    "codex-rs/ext/web-search/src/extension.rs and codex-rs/ext/image-generation/src/extension.rs change standalone availability checks from feature-enabled wording to availability derived from provider/config state.",
+    "The normalized bundle artifacts/github/bundles/openai-codex-pr-26490.json records 11 changed files for the merged PR."
+  ],
+  "caveats": "The standalone path still depends on provider, model, config, and extension availability; this should not be described as every Responses Lite model always getting every tool.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Responses Lite tool planning affects Control Plane capability modeling and operator readbacks."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The PR has a clear public try-and-explain angle for web search and image generation under Responses Lite."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-26548.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-26548.review.json
@@ -1,0 +1,70 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-26548",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "26548",
+    "commit_shas": [
+      "5622e8abb3ffcb17707ddc796dd32b6abe1d46ae",
+      "507e19e199703e9dec844849d145d36ed767fac6",
+      "12dbf7c6e13665c8f7f2d303cec8213d7b5b715a"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[2 of 2] Finish moving goal runtime to extension",
+        "url": "https://github.com/openai/codex/pull/26548",
+        "meta": "Merged 2026-06-05T21:17:30Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Move goal runtime to extension",
+        "url": "https://github.com/openai/codex/commit/5622e8abb3ffcb17707ddc796dd32b6abe1d46ae"
+      },
+      {
+        "kind": "commit",
+        "title": "Serialize extension goal notifications",
+        "url": "https://github.com/openai/codex/commit/507e19e199703e9dec844849d145d36ed767fac6"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-08T14:08:38Z",
+  "observed_change": "Codex completed the move of thread goal behavior from core-owned runtime and built-in core tools into the goal extension and app-server GoalService path.",
+  "changed_surfaces": [
+    "app-server goal extension installation and ThreadManager session setup",
+    "app-server thread goal get, set, clear, resume, and notification ordering",
+    "core goal runtime state and built-in goal tool handlers",
+    "extension tool planning order and review-thread goal gating",
+    "goal runtime tests and legacy goal-context compatibility coverage"
+  ],
+  "user_visible_path": "Users still interact with goals through the app-server/TUI goal flow, but the runtime ownership is now extension-backed and old core goal tool handlers/specs were removed.",
+  "control_plane_relevance": "Decodex should treat goal behavior as extension-owned when mirroring app-server thread goal state, goal notifications, or model-visible goal tools.",
+  "compatibility_risk": "Integrations that assumed core-owned get_goal, create_goal, or update_goal handlers, or that depended on core goal runtime hooks, need to account for extension registration and GoalService routing instead.",
+  "adoption_opportunity": "Use this as the app-server direction of travel for extension-backed durable runtime features: install the extension, route app-server mutations through the service, and serialize notifications through FIFO app-server delivery.",
+  "community_value": "The public value is mainly an operator-impact note for Codex extension and app-server integrators rather than a broad end-user feature announcement.",
+  "deprecated_or_breaking_notes": "The old core goal runtime, core goal handlers, and core goal tool specs were removed; the PR says the legacy <goal_context> compatibility path remains for old threads.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26548 says it completes the switch of goal behavior to the extension-backed runtime and removes the old core goal implementation.",
+    "codex-rs/app-server/src/extensions.rs adds codex_goal_extension::GoalService and goal-related app-server extension wiring.",
+    "codex-rs/app-server/src/request_processors/thread_goal_processor.rs replaces core goal types with GoalService, GoalSetRequest, and goal update types from codex-goal-extension.",
+    "codex-rs/core/src/goals.rs is removed, and codex-rs/core/src/lib.rs stops exporting ExternalGoalPreviousStatus and ExternalGoalSet.",
+    "codex-rs/core/src/tools/handlers/goal.rs, create_goal.rs, get_goal.rs, update_goal.rs, and goal_spec.rs are removed.",
+    "codex-rs/core/src/session/review.rs keeps review turns from enabling goal runtime behavior by removing goal tool support from review-thread setup.",
+    "The normalized bundle artifacts/github/bundles/openai-codex-pr-26548.json records 34 changed files for the merged PR."
+  ],
+  "caveats": "The PR preserves legacy goal context compatibility for old threads, so the migration should not be described as deleting all historical goal context support.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Goal runtime ownership changed in a way that affects app-server and extension integration assumptions."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "There is a narrow operator-impact public angle for extension-backed goal runtime ownership."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-26674.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-26674.review.json
@@ -1,0 +1,63 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-26674",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "26674",
+    "commit_shas": [
+      "045c529265ced1ae8eeeb81f9e3e5186b74109f0",
+      "6ae6451e144f9f76e1ea34754ba1d4f8204d3d1a"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "protocol: remove submission-side serde from Op",
+        "url": "https://github.com/openai/codex/pull/26674",
+        "meta": "Merged 2026-06-05T22:41:14Z"
+      },
+      {
+        "kind": "commit",
+        "title": "protocol: remove submission-side serde from Op",
+        "url": "https://github.com/openai/codex/commit/045c529265ced1ae8eeeb81f9e3e5186b74109f0"
+      },
+      {
+        "kind": "commit",
+        "title": "Restore request_user_input response serde",
+        "url": "https://github.com/openai/codex/commit/6ae6451e144f9f76e1ea34754ba1d4f8204d3d1a"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-08T14:08:38Z",
+  "observed_change": "Codex removed serde/schema support from submission-side Op payloads while preserving event/API-facing serialization where wire consumers still exist.",
+  "changed_surfaces": [
+    "codex protocol Submission and Op Rust types",
+    "submission-only payload serde/schema annotations",
+    "request_user_input tool output serialization boundary",
+    "protocol v1 documentation"
+  ],
+  "user_visible_path": "Normal Codex users should not see a new command path, but protocol consumers should treat submission payloads as internal Rust handoff types rather than stable serialized wire contracts.",
+  "control_plane_relevance": "Decodex Control Plane code should avoid depending on serialized Submission or Op payloads and should continue treating events and explicit app-server APIs as the transport surface.",
+  "compatibility_risk": "Any downstream adapter that serialized or deserialized core Op submissions directly now has a compatibility risk; event/API serialization remains the supported boundary according to the PR.",
+  "adoption_opportunity": "Audit Decodex protocol assumptions to ensure app-server integrations consume event/API-facing payloads instead of submission-side Op serde.",
+  "community_value": "This is useful as a cautious protocol-watch note for integrators, but it is too internal for a strong public feature post by itself.",
+  "deprecated_or_breaking_notes": "Submission, Op, and several submission-only payload types lost serde/schema annotations; the PR explicitly keeps event/API-facing serialization where still required.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26674 says submission-side Op payloads are now internal handoff types and no longer need a stable serde contract.",
+    "codex-rs/protocol/src/protocol.rs removes Deserialize, Serialize, and JsonSchema derives from Submission, Op, TurnEnvironmentSelection, and related submission-only payloads.",
+    "codex-rs/docs/protocol_v1.md now states Op submissions are primarily in-process Rust types rather than a stable serde wire contract.",
+    "The PR body says event/API-facing serialization remains where required.",
+    "The follow-up commit restores request_user_input response serde by serializing the wire payload rather than relying on the core response struct.",
+    "The normalized bundle artifacts/github/bundles/openai-codex-pr-26674.json records 2 changed files for the merged PR."
+  ],
+  "caveats": "The change is about submission-side payloads, not a blanket removal of protocol event serialization.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Protocol boundary clarification creates a Decodex compatibility watch item for serialized submission assumptions."
+    }
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-25936.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-25936.json
@@ -1,0 +1,53 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-25936",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "high",
+  "audience": "Codex plugin operators and automation authors",
+  "candidate_text": [
+    "Codex removed the legacy startup remote plugin sync that called /plugins/list. Current remote plugin paths stay on /ps/plugins/installed and /ps/plugins/list. PR: https://github.com/openai/codex/pull/25936"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-25936.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-25936.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/25936"
+    ]
+  },
+  "evidence_notes": [
+    "PR #25936 removes the legacy startup remote plugin sync path using /plugins/list.",
+    "The PR says /ps/plugins/installed and /ps/plugins/list remain intact.",
+    "startup_remote_sync.rs and sync_plugins_from_remote-related exports were removed."
+  ],
+  "claims": [
+    {
+      "text": "Legacy startup remote plugin sync through /plugins/list was removed.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-25936.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Current remote installed-bundle and catalog flows remain on /ps/plugins/installed and /ps/plugins/list.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-25936.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR gives plugin operators a concrete removed path and the current replacement paths.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-25936:operator_impact"
+  },
+  "caveats": [
+    "Do not imply remote plugin support was removed overall.",
+    "Keep the removed path scoped to legacy startup sync."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this after repository checks pass."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-26490.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-26490.json
@@ -1,0 +1,54 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-26490",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "practical_explainer",
+  "priority": "high",
+  "audience": "Codex users evaluating Responses Lite tool behavior",
+  "candidate_text": [
+    "Responses Lite does not execute hosted Responses tools, so Codex routes web search and image generation through standalone Codex executors when available. PR: https://github.com/openai/codex/pull/26490"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26490.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26490.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26490"
+    ]
+  },
+  "evidence_notes": [
+    "PR #26490 says Responses Lite does not execute hosted Responses tools.",
+    "spec_plan.rs suppresses hosted tool specs for use_responses_lite models.",
+    "Responses Lite integration tests cover standalone fallback behavior.",
+    "Web-search and image-generation extensions remain provider/config/model gated."
+  ],
+  "claims": [
+    {
+      "text": "Responses Lite does not execute hosted Responses tools in Codex.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26490.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Codex uses standalone executors for web search and image generation when the provider, model, config, and extensions allow them.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26490.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR explains a concrete user-observable difference in tool execution under Responses Lite.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26490:practical_explainer"
+  },
+  "caveats": [
+    "Do not imply every Responses Lite session always has both tools.",
+    "Keep availability scoped to provider, model, config, and extension gates."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this after repository checks pass."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-26548.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-26548.json
@@ -1,0 +1,54 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-26548",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "normal",
+  "audience": "Codex extension and app-server integrators",
+  "candidate_text": [
+    "Codex moved thread goals out of core runtime and into the goal extension path. App-server goal get/set/clear now route through GoalService; legacy <goal_context> compatibility remains. PR: https://github.com/openai/codex/pull/26548"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26548.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26548.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26548"
+    ]
+  },
+  "evidence_notes": [
+    "PR #26548 says the goal behavior switches to the extension-backed runtime.",
+    "The app-server thread goal processor now uses codex_goal_extension::GoalService.",
+    "Core goal runtime and built-in core goal tool handlers/specs were removed.",
+    "The PR states legacy <goal_context> compatibility remains for old threads."
+  ],
+  "claims": [
+    {
+      "text": "Codex goal runtime ownership moved from core to the goal extension path.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26548.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Legacy <goal_context> compatibility remains for old threads.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26548.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "defer",
+    "reason": "The change is important for extension and app-server operators but may work better inside a broader runtime architecture rollup.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26548:operator_impact"
+  },
+  "caveats": [
+    "Do not frame this as a new user-facing goal command.",
+    "Do not imply old goal context support was fully removed."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to use this as a rollup component or leave it deferred."
+  ]
+}


### PR DESCRIPTION
## Summary

- Refreshed the deterministic openai/codex upstream review queue.
- Added GitHub change bundles, upstream reviews, and upstream impact records for PRs 26548, 26674, 25936, and 26490.
- Added social_candidate/v1 handoffs for PRs 26548, 25936, and 26490 only; no social_post/v1 artifacts were written and nothing was published to X.

## Reviewed subjects

- openai/codex#26548: goal runtime moved to extension-backed GoalService path; social candidate is defer/operator-impact.
- openai/codex#26674: submission-side Op serde removed; impact record only.
- openai/codex#25936: legacy remote plugin startup sync removed; social candidate is publish/operator-impact.
- openai/codex#26490: Responses Lite routes web search and image generation through standalone executors; social candidate is publish/practical-explainer.

## Validation

- cargo run -p decodex --bin decodex -- radar bundle validate artifacts/github/bundles/openai-codex-pr-26548.json artifacts/github/bundles/openai-codex-pr-26674.json artifacts/github/bundles/openai-codex-pr-25936.json artifacts/github/bundles/openai-codex-pr-26490.json
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/review-queue artifacts/github/bundles artifacts/github/reviews artifacts/github/impact artifacts/github/social-candidates
- cargo make check-site-content
- cargo make fmt
- cargo make lint-fix
- cargo make test

Note: this repository currently has no codex or codex-automation labels to apply.