### PR TITLE
Reserve Decodex X post for PR 26552

### DIFF
--- a/artifacts/social/x/posts/2026-06-08/openai-codex-pr-26552.json
+++ b/artifacts/social/x/posts/2026-06-08/openai-codex-pr-26552.json
@@ -1,0 +1,94 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-26552",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "published",
+  "audience": "Codex app-server integrators",
+  "text": [
+    "Codex now requires app-server runtimeWorkspaceRoots to be absolute in thread/turn requests. If you mirror v2 calls, resolve roots before sending them: https://github.com/openai/codex/pull/26552"
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-26552.json"
+    ],
+    "reservations": [
+      "artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26552.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26552.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26552.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26552",
+      "https://github.com/openai/codex/pull/26532",
+      "https://x.com/decodexspace/status/2064014155208867999"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish and mode operator_impact for openai-codex-pr-26552.",
+    "The upstream_review/v1 artifact confirms that PR #26552 changes app-server runtimeWorkspaceRoots request fields for thread and turn requests to AbsolutePathBuf.",
+    "The upstream_impact/v1 artifact marks the change as public_signal_decision publish, control_plane_impact compat_risk, and publisher_angle operator_impact.",
+    "Checked social_post/v1 records contained no slug, source URL, or idempotency match before publication.",
+    "Checked social_publish_reservation/v1 records contained no active reservation for this candidate or idempotency key before the new reservation was created.",
+    "Open GitHub PR readback showed only dependency PRs before the reservation PR was created; PR #244 then made the active reservation visible before X compose.",
+    "Chrome account readback initially showed @hackink as active and @decodexspace as available; the automation switched to @decodexspace before reservation or compose.",
+    "Chrome compose readback showed @decodexspace before publishing and the compose dialog showed the exact candidate text.",
+    "Live @decodexspace profile readback before reservation found no 26552, runtimeWorkspaceRoots, runtime workspace roots, source URL, or exact subject match.",
+    "Live @decodexspace profile readback after PR-visible reservation and immediately before clicking Post again found no 26552, runtimeWorkspaceRoots, runtime workspace roots, source URL, or exact subject match.",
+    "After clicking Post, X opened a graduated-access informational modal, but live @decodexspace home timeline readback showed the new status URL with the expected text.",
+    "Independent permalink readback showed the expected @decodexspace post text, GitHub PR card, and no image media.",
+    "The status ID decodes to 2026-06-08T15:58:16.787Z."
+  ],
+  "claims": [
+    {
+      "text": "runtimeWorkspaceRoots in app-server thread and turn requests now require absolute roots.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26552.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Integrators mirroring app-server v2 calls should resolve runtime workspace roots before sending them.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26552.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The PR #26552 operator-impact post is live on @decodexspace.",
+      "evidence": "https://x.com/decodexspace/status/2064014155208867999",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "priority": "high",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26552:operator_impact",
+    "reason": "The PR changes a protocol-facing app-server path contract with clear integrator migration value.",
+    "daily_limit": 8,
+    "daily_count_before": 2,
+    "daily_count_after": 3,
+    "day": "2026-06-08",
+    "timezone": "Asia/Shanghai"
+  },
+  "publication": {
+    "posted_at": "2026-06-08T15:58:16.787Z",
+    "published_urls": [
+      "https://x.com/decodexspace/status/2064014155208867999"
+    ],
+    "publisher": "chrome",
+    "account_verified": true,
+    "made_with_ai": false
+  },
+  "caveats": [
+    "No media was attached; this single operator_impact post remains useful text-only because the reader value is the source-backed migration note and direct PR link.",
+    "Keep the claim scoped to app-server runtimeWorkspaceRoots in thread and turn requests.",
+    "Do not imply broad end-user UI behavior or Decodex runtime adoption."
+  ],
+  "post_lifecycle": {
+    "current_state": "live",
+    "quote_eligible": false,
+    "reason": "This is a standalone operator-impact post, not a prerelease quote-chain anchor."
+  }
+}

--- a/artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26552.json
+++ b/artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26552.json
@@ -5,7 +5,7 @@
   "target_account": "decodexspace",
   "controller_account": "hackink",
   "mode": "operator_impact",
-  "status": "active",
+  "status": "consumed",
   "idempotency_key": "x:decodexspace:openai-codex-pr-26552:operator_impact",
   "reserved_at": "2026-06-08T15:54:46Z",
   "expires_at": "2026-06-08T17:54:46Z",
@@ -47,5 +47,6 @@
     "Chrome account readback initially showed @hackink as active and @decodexspace as available; the automation switched to @decodexspace before this reservation was prepared.",
     "Live @decodexspace profile readback found no 26552, runtimeWorkspaceRoots, runtime workspace roots, source URL, or exact subject match.",
     "Checked publication records show daily_count_before = 2 for @decodexspace on 2026-06-08 Asia/Shanghai, so one additional single-post publication would not exceed the cap of 8."
-  ]
+  ],
+  "consumed_by_social_post": "artifacts/social/x/posts/2026-06-08/openai-codex-pr-26552.json"
 }

--- a/artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26552.json
+++ b/artifacts/social/x/reservations/2026-06-08/openai-codex-pr-26552.json
@@ -1,0 +1,51 @@
+{
+  "schema": "social_publish_reservation/v1",
+  "slug": "openai-codex-pr-26552",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "active",
+  "idempotency_key": "x:decodexspace:openai-codex-pr-26552:operator_impact",
+  "reserved_at": "2026-06-08T15:54:46Z",
+  "expires_at": "2026-06-08T17:54:46Z",
+  "day": "2026-06-08",
+  "timezone": "Asia/Shanghai",
+  "candidate_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-26552.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26552.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26552.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26552",
+      "https://github.com/openai/codex/pull/26532"
+    ]
+  },
+  "duplicate_keys": [
+    "openai-codex-pr-26552",
+    "x:decodexspace:openai-codex-pr-26552:operator_impact",
+    "runtimeWorkspaceRoots",
+    "runtime workspace roots",
+    "absolute in thread/turn",
+    "Make runtime workspace roots absolute",
+    "26552",
+    "https://github.com/openai/codex/pull/26552"
+  ],
+  "owner": {
+    "automation_id": "decodex-x-publisher",
+    "branch": "codex-automation/x-publisher-openai-codex-pr-26552"
+  },
+  "evidence_notes": [
+    "Checked social_post/v1 records contain no slug, source URL, or idempotency match for openai-codex-pr-26552.",
+    "Checked social_publish_reservation/v1 records contain no active reservation for this candidate or idempotency key before this reservation.",
+    "Open GitHub PR readback showed only dependency PRs and no pending social publication PR for this candidate.",
+    "Chrome account readback initially showed @hackink as active and @decodexspace as available; the automation switched to @decodexspace before this reservation was prepared.",
+    "Live @decodexspace profile readback found no 26552, runtimeWorkspaceRoots, runtime workspace roots, source URL, or exact subject match.",
+    "Checked publication records show daily_count_before = 2 for @decodexspace on 2026-06-08 Asia/Shanghai, so one additional single-post publication would not exceed the cap of 8."
+  ]
+}


### PR DESCRIPTION
## Summary
- Add the Decodex X publication record for openai-codex-pr-26552.
- Mark the matching thin social_publish_reservation/v1 as consumed.
- Preserve Chrome account, duplicate-readback, permalink, cap, and text-only media evidence.

## Validation
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x

## Publication
- Published URL: https://x.com/decodexspace/status/2064014155208867999
- Media: none; text-only operator-impact post with direct PR link.