### PR TITLE
Persist upstream Radar review artifacts

### DIFF
--- a/artifacts/github/bundles/openai-codex-pr-24852.json
+++ b/artifacts/github/bundles/openai-codex-pr-24852.json
@@ -1,0 +1,201 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "viyatb-oai",
+      "committed_at": "2026-05-28T02:18:08Z",
+      "message": "Enforce permission profile defaults and allowlists",
+      "sha": "d4bf7bafbaf7a1ae72427606319afa6b3465c80b",
+      "url": "https://github.com/openai/codex/commit/d4bf7bafbaf7a1ae72427606319afa6b3465c80b"
+    },
+    {
+      "author": "viyatb-oai",
+      "committed_at": "2026-05-28T02:33:10Z",
+      "message": "fix(permissions): preserve implicit sandbox defaults",
+      "sha": "26b0a07d3a66589dbd3595d1eb9cfa1f43dce1cb",
+      "url": "https://github.com/openai/codex/commit/26b0a07d3a66589dbd3595d1eb9cfa1f43dce1cb"
+    },
+    {
+      "author": "viyatb-oai",
+      "committed_at": "2026-06-03T18:25:38Z",
+      "message": "fix(permissions): require managed default profile",
+      "sha": "ec6d5a352a5c71b3eb47bf9dfaa3474a7cd45c38",
+      "url": "https://github.com/openai/codex/commit/ec6d5a352a5c71b3eb47bf9dfaa3474a7cd45c38"
+    },
+    {
+      "author": "viyatb-oai",
+      "committed_at": "2026-06-03T19:03:35Z",
+      "message": "fix(permissions): allow implicit standard default",
+      "sha": "d70eda07414e169b9e93e7787b55bb637168533c",
+      "url": "https://github.com/openai/codex/commit/d70eda07414e169b9e93e7787b55bb637168533c"
+    },
+    {
+      "author": "viyatb-oai",
+      "committed_at": "2026-06-04T00:30:32Z",
+      "message": "fix(permissions): make managed allowlist mergeable",
+      "sha": "4379a32b69fc770f27e0c843ca391e377eb6c198",
+      "url": "https://github.com/openai/codex/commit/4379a32b69fc770f27e0c843ca391e377eb6c198"
+    },
+    {
+      "author": "viyatb-oai",
+      "committed_at": "2026-06-04T01:07:59Z",
+      "message": "fix(permissions): make managed map a strict allowlist",
+      "sha": "511bc0ec1f015e95f4c282815a16d2aad75e6b29",
+      "url": "https://github.com/openai/codex/commit/511bc0ec1f015e95f4c282815a16d2aad75e6b29"
+    },
+    {
+      "author": "viyatb-oai",
+      "committed_at": "2026-06-05T17:57:18Z",
+      "message": "fix(permissions): preserve legacy permission allowlists",
+      "sha": "c330349b3c98b701d7fa60fe1b6c612115ee9db4",
+      "url": "https://github.com/openai/codex/commit/c330349b3c98b701d7fa60fe1b6c612115ee9db4"
+    },
+    {
+      "author": "viyatb-oai",
+      "committed_at": "2026-06-05T22:11:56Z",
+      "message": "fix(permissions): remove legacy permission allowlist",
+      "sha": "bc249ef5b32f3883950892d1ec03fe165a746130",
+      "url": "https://github.com/openai/codex/commit/bc249ef5b32f3883950892d1ec03fe165a746130"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [
+    "codex-rs/app-server/README.md"
+  ],
+  "examples_refs": [],
+  "extracted_flags": [
+    "API",
+    "MDM",
+    "LOCAL_FS",
+    "BUILT_IN_PERMISSION_PROFILE_READ_ONLY",
+    "BUILT_IN_PERMISSION_PROFILE_DANGER_FULL_ACCESS",
+    "BUILT_IN_PERMISSION_PROFILE_WORKSPACE",
+    "CONFIG_TOML_FILE",
+    "BUILT_IN_READ_ONLY_PROFILE",
+    "BUILT_IN_WORKSPACE_PROFILE"
+  ],
+  "files": [
+    {
+      "additions": 10,
+      "deletions": 4,
+      "patch_excerpt": "@@ -8013,12 +8013,12 @@\n               \"null\"\n             ]\n           },\n-          \"allowedPermissions\": {\n-            \"items\": {\n-              \"type\": \"string\"\n+          \"allowedPermissionProfiles\": {\n+            \"additionalProperties\": {\n+              \"type\": \"boolean\"\n             },\n             \"type\": [\n-              \"array\",\n+              \"object\",\n               \"null\"\n             ]\n           },\n@@ -8059,6 +8059,12 @@\n               }\n             ]\n           },\n+          \"defaultPermissions\": {\n+            \"type\": [\n+              \"string\",\n+              \"null\"\n+            ]\n+          },\n           \"enforceResidency\": {\n             \"anyOf\": [\n               {",
+      "path": "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+      "status": "modified"
+    },
+    {
+      "additions": 10,
+      "deletions": 4,
+      "patch_excerpt": "@@ -4355,12 +4355,12 @@\n             \"null\"\n           ]\n         },\n-        \"allowedPermissions\": {\n-          \"items\": {\n-            \"type\": \"string\"\n+        \"allowedPermissionProfiles\": {\n+          \"additionalProperties\": {\n+            \"type\": \"boolean\"\n           },\n           \"type\": [\n-            \"array\",\n+            \"object\",\n             \"null\"\n           ]\n         },\n@@ -4401,6 +4401,12 @@\n             }\n           ]\n         },\n+        \"defaultPermissions\": {\n+          \"type\": [\n+            \"string\",\n+            \"null\"\n+          ]\n+        },\n         \"enforceResidency\": {\n           \"anyOf\": [\n             {",
+      "path": "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+      "status": "modified"
+    },
+    {
+      "additions": 10,
+      "deletions": 4,
+      "patch_excerpt": "@@ -94,12 +94,12 @@\n             \"null\"\n           ]\n         },\n-        \"allowedPermissions\": {\n-          \"items\": {\n-            \"type\": \"string\"\n+        \"allowedPermissionProfiles\": {\n+          \"additionalProperties\": {\n+            \"type\": \"boolean\"\n           },\n           \"type\": [\n-            \"array\",\n+            \"object\",\n             \"null\"\n           ]\n         },\n@@ -140,6 +140,12 @@\n             }\n           ]\n         },\n+        \"defaultPermissions\": {\n+          \"type\": [\n+            \"string\",\n+            \"null\"\n+          ]\n+        },\n         \"enforceResidency\": {\n           \"anyOf\": [\n             {",
+      "path": "codex-rs/app-server-protocol/schema/json/v2/ConfigRequirementsReadResponse.json",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -8,4 +8,4 @@ import type { ResidencyRequirement } from \"./ResidencyRequirement\";\n import type { SandboxMode } from \"./SandboxMode\";\n import type { WindowsSandboxSetupMode } from \"./WindowsSandboxSetupMode\";\n \n-export type ConfigRequirements = {allowedApprovalPolicies: Array<AskForApproval> | null, allowedSandboxModes: Array<SandboxMode> | null, allowedWindowsSandboxImplementations: Array<WindowsSandboxSetupMode> | null, allowedPermissions: Array<string> | null, allowedWebSearchModes: Array<WebSearchMode> | null, allowManagedHooksOnly: boolean | null, allowAppshots: boolean | null, computerUse: ComputerUseRequirements | null, featureRequirements: { [key in string]?: boolean } | null, enforceResidency: ResidencyRequirement | null};\n+export type ConfigRequirements = {allowedApprovalPolicies: Array<AskForApproval> | null, allowedSandboxModes: Array<SandboxMode> | null, allowedWindowsSandb...",
+      "path": "codex-rs/app-server-protocol/schema/typescript/v2/ConfigRequirements.ts",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 1,
+      "patch_excerpt": "@@ -375,7 +375,8 @@ pub struct ConfigRequirements {\n     pub allowed_approvals_reviewers: Option<Vec<ApprovalsReviewer>>,\n     pub allowed_sandbox_modes: Option<Vec<SandboxMode>>,\n     pub allowed_windows_sandbox_implementations: Option<Vec<WindowsSandboxSetupMode>>,\n-    pub allowed_permissions: Option<Vec<String>>,\n+    pub allowed_permission_profiles: Option<BTreeMap<String, bool>>,\n+    pub default_permissions: Option<String>,\n     pub allowed_web_search_modes: Option<Vec<WebSearchMode>>,\n     pub allow_managed_hooks_only: Option<bool>,\n     pub allow_appshots: Option<bool>,",
+      "path": "codex-rs/app-server-protocol/src/protocol/v2/config.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 1,
+      "patch_excerpt": "@@ -1674,7 +1674,8 @@ fn config_requirements_granular_allowed_approval_policy_is_marked_experimental()\n             allowed_approvals_reviewers: None,\n             allowed_sandbox_modes: None,\n             allowed_windows_sandbox_implementations: None,\n-            allowed_permissions: None,\n+            allowed_permission_profiles: None,\n+            default_permissions: None,\n             allowed_web_search_modes: None,\n             allow_managed_hooks_only: None,\n             allow_appshots: None,",
+      "path": "codex-rs/app-server-protocol/src/protocol/v2/tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -231,7 +231,7 @@ Example with notification opt-out:\n - `externalAgentConfig/import` — apply selected external-agent migration items by passing explicit `migrationItems` with `cwd` (`null` for home) and any plugin/session `details` returned by detect. When a request includes migration items, the server emits `externalAgentConfig/import/completed` once after the full import finishes (immediately after the response when everything completed synchronously, or after background imports finish).\n - `config/value/write` — write a single config key/value to the user's config.toml on disk; dotted paths such as `desktop.someKey` use the same generic write surface.\n - `config/batchWrite` — apply multiple config edits atomically to the user's config.toml on disk, with optional `reloadUserConfig: true` to hot-reload loaded threads, including multiple `desktop.*` edits.\n-- `configRequirements/read` ...",
+      "path": "codex-rs/app-server/README.md",
+      "status": "modified"
+    },
+    {
+      "additions": 27,
+      "deletions": 12,
+      "patch_excerpt": "@@ -350,7 +350,8 @@ fn map_requirements_toml_to_api(requirements: ConfigRequirementsToml) -> ConfigR\n                         .collect()\n                 })\n         }),\n-        allowed_permissions: requirements.allowed_permissions,\n+        allowed_permission_profiles: requirements.allowed_permission_profiles,\n+        default_permissions: requirements.default_permissions,\n         allowed_web_search_modes: requirements.allowed_web_search_modes.map(|modes| {\n             let mut normalized = modes\n                 .into_iter()\n@@ -569,29 +570,43 @@ mod tests {\n     use codex_config::ConfigRequirementsToml;\n     use codex_config::WindowsRequirementsToml;\n     use pretty_assertions::assert_eq;\n+    use std::collections::BTreeMap;\n \n     #[test]\n     fn requirements_api_includes_allow_managed_hooks_only() {\n         let mapped = map_requirements_toml_to_api(ConfigRequirementsToml {\n-     ...",
+      "path": "codex-rs/app-server/src/request_processors/config_processor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 44,
+      "deletions": 21,
+      "patch_excerpt": "@@ -822,7 +822,8 @@ pub struct ConfigRequirementsToml {\n     pub allowed_approval_policies: Option<Vec<AskForApproval>>,\n     pub allowed_approvals_reviewers: Option<Vec<ApprovalsReviewer>>,\n     pub allowed_sandbox_modes: Option<Vec<SandboxModeRequirement>>,\n-    pub allowed_permissions: Option<Vec<String>>,\n+    pub allowed_permission_profiles: Option<BTreeMap<String, bool>>,\n+    pub default_permissions: Option<String>,\n     pub remote_sandbox_config: Option<Vec<RemoteSandboxConfigToml>>,\n     pub allowed_web_search_modes: Option<Vec<WebSearchModeRequirement>>,\n     pub allow_managed_hooks_only: Option<bool>,\n@@ -876,7 +877,8 @@ pub struct ConfigRequirementsWithSources {\n     pub allowed_approval_policies: Option<Sourced<Vec<AskForApproval>>>,\n     pub allowed_approvals_reviewers: Option<Sourced<Vec<ApprovalsReviewer>>>,\n     pub allowed_sandbox_modes: Option<Sourced<Vec<SandboxModeRe...",
+      "path": "codex-rs/config/src/config_requirements.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 7,
+      "deletions": 2,
+      "patch_excerpt": "@@ -176,7 +176,8 @@ fn populate_merged_regular_fields_with_sources(\n         allowed_approval_policies,\n         allowed_approvals_reviewers,\n         allowed_sandbox_modes,\n-        allowed_permissions,\n+        allowed_permission_profiles,\n+        default_permissions,\n         remote_sandbox_config: _,\n         allowed_web_search_modes,\n         allow_managed_hooks_only,\n@@ -201,7 +202,11 @@ fn populate_merged_regular_fields_with_sources(\n         &[\"allowed_approvals_reviewers\"]\n     );\n     set_sourced!(allowed_sandbox_modes, &[\"allowed_sandbox_modes\"]);\n-    set_sourced!(allowed_permissions, &[\"allowed_permissions\"]);\n+    set_sourced!(\n+        allowed_permission_profiles,\n+        &[\"allowed_permission_profiles\"]\n+    );\n+    set_sourced!(default_permissions, &[\"default_permissions\"]);\n     set_sourced!(allowed_web_search_modes, &[\"allowed_web_search_modes\"]);\n     set_sourced!(a...",
+      "path": "codex-rs/config/src/requirements_layers/stack.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 16,
+      "deletions": 0,
+      "patch_excerpt": "@@ -62,6 +62,11 @@ fn top_level_values_use_toml_priority() {\n             r#\"\n allowed_approval_policies = [\"on-request\"]\n allowed_sandbox_modes = [\"workspace-write\"]\n+default_permissions = \":workspace\"\n+\n+[allowed_permission_profiles]\n+\":read-only\" = true\n+\":workspace\" = true\n \"#,\n         ),\n         layer(\n@@ -70,6 +75,11 @@ allowed_sandbox_modes = [\"workspace-write\"]\n             r#\"\n allowed_approval_policies = [\"never\"]\n allowed_sandbox_modes = [\"read-only\"]\n+default_permissions = \":read-only\"\n+\n+[allowed_permission_profiles]\n+\":danger-full-access\" = false\n+\":workspace\" = false\n \"#,\n         ),\n     ])\n@@ -82,6 +92,12 @@ allowed_sandbox_modes = [\"read-only\"]\n             r#\"\n allowed_approval_policies = [\"never\"]\n allowed_sandbox_modes = [\"read-only\"]\n+default_permissions = \":read-only\"\n+\n+[allowed_permission_profiles]\n+\":danger-full-access\" = false\n+\":read-only\" = true\n+\":workspac...",
+      "path": "codex-rs/config/src/requirements_layers/stack_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 250,
+      "deletions": 31,
+      "patch_excerpt": "@@ -31,7 +31,7 @@ use codex_config::test_support::CloudConfigBundleFixture;\n use codex_exec_server::LOCAL_FS;\n use codex_protocol::config_types::TrustLevel;\n use codex_protocol::config_types::WebSearchMode;\n-use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_READ_ONLY;\n+use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_DANGER_FULL_ACCESS;\n use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_WORKSPACE;\n use codex_protocol::models::PermissionProfile;\n use codex_protocol::protocol::AskForApproval;\n@@ -1375,7 +1375,10 @@ default_permissions = \"managed-standard\"\n     tokio::fs::write(\n         &requirements_path,\n         r#\"\n-allowed_permissions = [\"managed-standard\"]\n+default_permissions = \"managed-standard\"\n+\n+[allowed_permission_profiles]\n+managed-standard = true\n \n [permissions.managed-standard]\n extends = \":workspace\"\n@@ -1397,8 +1400,8 @@ extends = \":workspace\"\n         ...",
+      "path": "codex-rs/core/src/config/config_loader_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 1,
+      "patch_excerpt": "@@ -8351,7 +8351,8 @@ async fn test_requirements_web_search_mode_allowlist_does_not_warn_when_unset()\n         allowed_approval_policies: None,\n         allowed_approvals_reviewers: None,\n         allowed_sandbox_modes: None,\n-        allowed_permissions: None,\n+        allowed_permission_profiles: None,\n+        default_permissions: None,\n         remote_sandbox_config: None,\n         allowed_web_search_modes: Some(vec![codex_config::WebSearchModeRequirement::Cached]),\n         allow_managed_hooks_only: None,",
+      "path": "codex-rs/core/src/config/config_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 79,
+      "deletions": 31,
+      "patch_excerpt": "@@ -119,6 +119,7 @@ use std::path::Path;\n use std::path::PathBuf;\n use std::sync::Arc;\n \n+use crate::config::permissions::BUILT_IN_READ_ONLY_PROFILE;\n use crate::config::permissions::BUILT_IN_WORKSPACE_PROFILE;\n use crate::config::permissions::apply_network_proxy_feature_config;\n use crate::config::permissions::builtin_permission_profile;\n@@ -3835,7 +3836,9 @@ fn resolve_effective_permission_selection<'a>(\n     Ok(EffectivePermissionSelection {\n         profiles,\n         selected_profile_id,\n-        requirements_force_profile_selection: requirements_toml.allowed_permissions.is_some(),\n+        requirements_force_profile_selection: requirements_toml\n+            .allowed_permission_profiles\n+            .is_some(),\n     })\n }\n \n@@ -3845,28 +3848,36 @@ fn resolve_default_permissions<'a>(\n     requirements_toml: &'a ConfigRequirementsToml,\n     startup_warnings: &mut Vec<String>,\n ) -> st...",
+      "path": "codex-rs/core/src/config/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 4,
+      "deletions": 2,
+      "patch_excerpt": "@@ -702,7 +702,8 @@ mod tests {\n             allowed_approval_policies: Some(vec![AskForApproval::OnRequest.to_core()]),\n             allowed_approvals_reviewers: Some(vec![ApprovalsReviewer::AutoReview]),\n             allowed_sandbox_modes: Some(vec![SandboxModeRequirement::ReadOnly]),\n-            allowed_permissions: None,\n+            allowed_permission_profiles: None,\n+            default_permissions: None,\n             remote_sandbox_config: None,\n             allowed_web_search_modes: Some(vec![WebSearchModeRequirement::Cached]),\n             allow_managed_hooks_only: Some(true),\n@@ -973,7 +974,8 @@ approval_policy = \"never\"\n             allowed_approval_policies: None,\n             allowed_approvals_reviewers: None,\n             allowed_sandbox_modes: None,\n-            allowed_permissions: None,\n+            allowed_permission_profiles: None,\n+            default_permissions: No...",
+      "path": "codex-rs/tui/src/debug_config.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#24620"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nPermission profile allowlists are an enterprise security boundary, but they also need to compose across the managed requirements layers added in #24620.\n\nA map representation lets each requirements layer add, allow, or revoke individual profiles without replacing an entire array.\n\n## Managed Contract\n\nAdministrators configure the mergeable allow map with `allowed_permission_profiles`. A recommended enterprise configuration explicitly lists every built-in and custom profile users should be able to select:\n\n```toml\ndefault_permissions = \"review_only\"\n\n[allowed_permission_profiles]\n\":read-only\" = true\n\":workspace\" = true\nreview_only = true\n# \":danger-full-access\" is intentionally omitted, so it is denied.\n\n[permissions.review_only]\nextends = \":read-only\"\n```\n\n- Profiles whose effective merged value is `true` are allowed.\n- Missing profiles and profiles set to `false` are denied.\n- This is a closed allowlist: built-in profiles and profiles introduced in future versions are denied unless explicitly allowed.\n- Explicitly list each built-in profile the enterprise wants to make available. Omit built-ins such as `:danger-full-access` when they should remain unavailable.\n- Set `default_permissions` explicitly to the allowed profile users should receive when they have no local selection.\n- Higher-precedence layers override only the profile keys they define.\n- `false` is only needed when a higher-precedence layer must revoke a `true` inherited from a lower layer.\n- Explicit keys must refer to known built-in or managed profiles.\n\nA custom or narrowed allowlist requires an allowed `default_permissions`. For compatibility, if both `:workspace` and `:read-only` are explicitly allowed, an omitted default resolves to `:workspace`; customer configurations should still set the intended default explicitly.\n\nWhen `allowed_permission_profiles` is absent, existing implicit permission and legacy `sandbox_mode` behavior is unchanged.\n\n## What Changed\n\n- Add `allowed_permission_profiles` as a `BTreeMap<String, bool>` that merges per profile across requirements layers.\n- Enforce managed defaults, strict denial of omitted profiles, and the explicitly allowed standard-pair fallback.\n- Expose `allowedPermissionProfiles` through `configRequirements/read` and regenerate its schemas.\n- Add regression coverage for map composition and revocation, managed defaults, strict denial of omitted built-ins, and API output.\n\n## Verification\n\n- Focused `codex-config` coverage for layered map composition and revocation\n- Focused `codex-core` coverage for managed defaults, invalid defaults, strict denial of omitted built-ins, and the standard built-in pair\n- Focused `codex-app-server` coverage for requirements API output\n- Scoped Clippy for `codex-config`, `codex-core`, `codex-app-server-protocol`, and `codex-app-server`\n\n## Documentation\n\nThe managed `requirements.toml` documentation should introduce `allowed_permission_profiles` as a closed permission-profile allowlist before this setting is published on developers.openai.com.\n",
+    "labels": [],
+    "merged_at": "2026-06-06T01:06:30Z",
+    "number": 24852,
+    "state": "merged",
+    "title": "permissions: enforce managed permission profile allowlists",
+    "url": "https://github.com/openai/codex/pull/24852"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-25731.json
+++ b/artifacts/github/bundles/openai-codex-pr-25731.json
@@ -1,0 +1,513 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-02T00:42:45Z",
+      "message": "[codex-rs] support v2 personal access tokens [ci changed_files]",
+      "sha": "52e8322d26b0dcab311fc69051d7c65c1c9b0bad",
+      "url": "https://github.com/openai/codex/commit/52e8322d26b0dcab311fc69051d7c65c1c9b0bad"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-02T01:42:40Z",
+      "message": "[codex-rs] preserve PAT app-server compatibility [ci changed_files]",
+      "sha": "102b651347bcc5bab8c141521feb98a86ab0aa60",
+      "url": "https://github.com/openai/codex/commit/102b651347bcc5bab8c141521feb98a86ab0aa60"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-02T02:24:01Z",
+      "message": "[codex-rs] preserve app-server account email compatibility [ci changed_files]",
+      "sha": "4097f5e2f5e16432316bfeef391e8c0c8fe47048",
+      "url": "https://github.com/openai/codex/commit/4097f5e2f5e16432316bfeef391e8c0c8fe47048"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-02T02:41:32Z",
+      "message": "[codex-rs] normalize missing app-server account email [ci changed_files]",
+      "sha": "4e508fdf0ee94f6cdc2d2fe2a8e7730157e964f9",
+      "url": "https://github.com/openai/codex/commit/4e508fdf0ee94f6cdc2d2fe2a8e7730157e964f9"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-02T03:02:26Z",
+      "message": "[codex-rs] complete PAT auth refresh fixtures [ci changed_files]",
+      "sha": "bb3aa3c8c75303e86cf3cd9ef34f74522a0ad600",
+      "url": "https://github.com/openai/codex/commit/bb3aa3c8c75303e86cf3cd9ef34f74522a0ad600"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-02T03:23:51Z",
+      "message": "[codex-rs] handle PAT auth edge cases [ci changed_files]",
+      "sha": "56418b3f60d2cda53f5dddf1dfb1de3ec3aae2fb",
+      "url": "https://github.com/openai/codex/commit/56418b3f60d2cda53f5dddf1dfb1de3ec3aae2fb"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-02T03:55:03Z",
+      "message": "[codex-rs] simplify PAT auth integration [ci changed_files]",
+      "sha": "1e253161298656cd877257c342c66aede39a5f35",
+      "url": "https://github.com/openai/codex/commit/1e253161298656cd877257c342c66aede39a5f35"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-02T17:59:28Z",
+      "message": "[codex-rs] expose personal access token auth mode [ci changed_files]",
+      "sha": "8b4619b3f39c3bc84248a5c2d5068d94b7e04dc5",
+      "url": "https://github.com/openai/codex/commit/8b4619b3f39c3bc84248a5c2d5068d94b7e04dc5"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-02T18:24:01Z",
+      "message": "[codex-rs] align PAT tests with review feedback [ci changed_files]",
+      "sha": "78517260e070b17b17a2612185c8fb3c9c7de944",
+      "url": "https://github.com/openai/codex/commit/78517260e070b17b17a2612185c8fb3c9c7de944"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-02T19:11:07Z",
+      "message": "[codex-rs] add PAT turn integration coverage [ci changed_files]",
+      "sha": "96cb93cf0de4270210f1511e59a7cedc4913ec16",
+      "url": "https://github.com/openai/codex/commit/96cb93cf0de4270210f1511e59a7cedc4913ec16"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-02T19:44:52Z",
+      "message": "[codex-rs] validate PAT workspace before persistence [ci changed_files]",
+      "sha": "691c1eb82b2a743f377df192670f3ed5845e312c",
+      "url": "https://github.com/openai/codex/commit/691c1eb82b2a743f377df192670f3ed5845e312c"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-02T20:18:57Z",
+      "message": "[codex-rs] keep PAT auth mode out of v1 [ci changed_files]",
+      "sha": "de7e938c6d9da77943dcb19c88c4a32d6b677382",
+      "url": "https://github.com/openai/codex/commit/de7e938c6d9da77943dcb19c88c4a32d6b677382"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-02T20:39:33Z",
+      "message": "[codex-rs] preserve PAT account compatibility [ci changed_files]",
+      "sha": "c7d13639a2ab58a67ac608e190602c472eab6b82",
+      "url": "https://github.com/openai/codex/commit/c7d13639a2ab58a67ac608e190602c472eab6b82"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-03T20:07:44Z",
+      "message": "[codex-rs] update PAT cloud bundle test fixture [ci changed_files]",
+      "sha": "d0eacff64b1c1eb61b1c54b782fb0ff9ae5f8bf9",
+      "url": "https://github.com/openai/codex/commit/d0eacff64b1c1eb61b1c54b782fb0ff9ae5f8bf9"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-03T21:49:31Z",
+      "message": "[codex-rs] simplify PAT auth branches [ci changed_files]",
+      "sha": "dd0336b089d4f28af8a2adfea8ffea52a395992a",
+      "url": "https://github.com/openai/codex/commit/dd0336b089d4f28af8a2adfea8ffea52a395992a"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-03T22:04:50Z",
+      "message": "[codex-rs] reject PAT metadata without email [ci changed_files]",
+      "sha": "9f1db458fd1f61f692735a78f6b81f4b36b69ee1",
+      "url": "https://github.com/openai/codex/commit/9f1db458fd1f61f692735a78f6b81f4b36b69ee1"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-03T22:30:38Z",
+      "message": "[codex-rs] use valid PAT metadata test fixtures [ci changed_files]",
+      "sha": "3070fdea6338f7701fcea3f71508779c20c147ac",
+      "url": "https://github.com/openai/codex/commit/3070fdea6338f7701fcea3f71508779c20c147ac"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-05T19:52:35Z",
+      "message": "[codex-rs] align PAT auth modes across app-server APIs [ci changed_files]",
+      "sha": "41c090349d5496ac038a6513474bc50303d9c0c9",
+      "url": "https://github.com/openai/codex/commit/41c090349d5496ac038a6513474bc50303d9c0c9"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-05T20:11:55Z",
+      "message": "[codex-rs] enforce PAT workspace restrictions on load [ci changed_files]",
+      "sha": "086ab2b05d1ae1592ca49594eebb56048cbd6ecf",
+      "url": "https://github.com/openai/codex/commit/086ab2b05d1ae1592ca49594eebb56048cbd6ecf"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-05T20:50:42Z",
+      "message": "[codex-rs] preserve PAT auth rollback compatibility [ci changed_files]",
+      "sha": "8a0e4f3c2abe7099d81a41922972bfcebfecdff7",
+      "url": "https://github.com/openai/codex/commit/8a0e4f3c2abe7099d81a41922972bfcebfecdff7"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-05T23:56:52Z",
+      "message": "[codex-rs] address PAT review feedback [ci changed_files]",
+      "sha": "c4a77fe492b717c4b4c8643cd1811eec41e2dcfe",
+      "url": "https://github.com/openai/codex/commit/c4a77fe492b717c4b4c8643cd1811eec41e2dcfe"
+    },
+    {
+      "author": "cooper-oai",
+      "committed_at": "2026-06-06T00:20:03Z",
+      "message": "[codex-rs] infer PAT auth in doctor [ci changed_files]",
+      "sha": "2008f30c7de3ae4a1a9790cc7acad6f0955b956f",
+      "url": "https://github.com/openai/codex/commit/2008f30c7de3ae4a1a9790cc7acad6f0955b956f"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [
+    "codex-rs/app-server/README.md"
+  ],
+  "examples_refs": [],
+  "extracted_flags": [
+    "--with-access-token",
+    "CODEX_ACCESS_TOKEN",
+    "JWT",
+    "PAT",
+    "API",
+    "CARGO_INCREMENTAL=0",
+    "--check",
+    "IDE",
+    "TUI",
+    "RPC",
+    "GET",
+    "OPENAI_API_KEY",
+    "CODEX_AUTHAPI_BASE_URL",
+    "DEFAULT_READ_TIMEOUT",
+    "JSONRPCR",
+    "CODEX_ACCESS_TOKEN_ENV_VAR",
+    "CODEX_API_KEY_ENV_VAR",
+    "PERSONAL_ACCESS_TOKEN",
+    "PERSONAL_ACCESS_TOKEN_AUTHORIZATION",
+    "PERSONAL_ACCESS_TOKEN_ACCOUNT_ID",
+    "WHOAMI_PATH",
+    "CLOUD_CONFIG_BUNDLE_PATH",
+    "--skip-git-repo-check",
+    "CODEX_HOME",
+    "POST",
+    "CLI",
+    "PERSONAL_ACCESS_TOKEN_PREFIX",
+    "WORKSPACE_ID_ALLOWED",
+    "TEST_AGENT_IDENTITY_RSA_PRIVATE_KEY_PEM",
+    "PRIVATE",
+    "KEY",
+    "MIIE",
+    "DEFAULT_CHATGPT_BACKEND_BASE_URL",
+    "PROD_AUTHAPI_BASE_URL",
+    "CODEX_AUTHAPI_BASE_URL_ENV_VAR",
+    "CHATGPT_CODEX_BASE_URL"
+  ],
+  "files": [
+    {
+      "additions": 7,
+      "deletions": 0,
+      "patch_excerpt": "@@ -525,6 +525,13 @@\n             \"agentIdentity\"\n           ],\n           \"type\": \"string\"\n+        },\n+        {\n+          \"description\": \"Programmatic Codex auth backed by a personal access token.\",\n+          \"enum\": [\n+            \"personalAccessToken\"\n+          ],\n+          \"type\": \"string\"\n         }\n       ]\n     },",
+      "path": "codex-rs/app-server-protocol/schema/json/ServerNotification.json",
+      "status": "modified"
+    },
+    {
+      "additions": 7,
+      "deletions": 0,
+      "patch_excerpt": "@@ -6677,6 +6677,13 @@\n               \"agentIdentity\"\n             ],\n             \"type\": \"string\"\n+          },\n+          {\n+            \"description\": \"Programmatic Codex auth backed by a personal access token.\",\n+            \"enum\": [\n+              \"personalAccessToken\"\n+            ],\n+            \"type\": \"string\"\n           }\n         ]\n       },",
+      "path": "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+      "status": "modified"
+    },
+    {
+      "additions": 7,
+      "deletions": 0,
+      "patch_excerpt": "@@ -999,6 +999,13 @@\n             \"agentIdentity\"\n           ],\n           \"type\": \"string\"\n+        },\n+        {\n+          \"description\": \"Programmatic Codex auth backed by a personal access token.\",\n+          \"enum\": [\n+            \"personalAccessToken\"\n+          ],\n+          \"type\": \"string\"\n         }\n       ]\n     },",
+      "path": "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+      "status": "modified"
+    },
+    {
+      "additions": 7,
+      "deletions": 0,
+      "patch_excerpt": "@@ -31,6 +31,13 @@\n             \"agentIdentity\"\n           ],\n           \"type\": \"string\"\n+        },\n+        {\n+          \"description\": \"Programmatic Codex auth backed by a personal access token.\",\n+          \"enum\": [\n+            \"personalAccessToken\"\n+          ],\n+          \"type\": \"string\"\n         }\n       ]\n     },",
+      "path": "codex-rs/app-server-protocol/schema/json/v2/AccountUpdatedNotification.json",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -5,4 +5,4 @@\n /**\n  * Authentication mode for OpenAI-backed providers.\n  */\n-export type AuthMode = \"apikey\" | \"chatgpt\" | \"chatgptAuthTokens\" | \"agentIdentity\";\n+export type AuthMode = \"apikey\" | \"chatgpt\" | \"chatgptAuthTokens\" | \"agentIdentity\" | \"personalAccessToken\";",
+      "path": "codex-rs/app-server-protocol/schema/typescript/AuthMode.ts",
+      "status": "modified"
+    },
+    {
+      "additions": 15,
+      "deletions": 0,
+      "patch_excerpt": "@@ -36,6 +36,21 @@ pub enum AuthMode {\n     #[ts(rename = \"agentIdentity\")]\n     #[strum(serialize = \"agentIdentity\")]\n     AgentIdentity,\n+    /// Programmatic Codex auth backed by a personal access token.\n+    #[serde(rename = \"personalAccessToken\")]\n+    #[ts(rename = \"personalAccessToken\")]\n+    #[strum(serialize = \"personalAccessToken\")]\n+    PersonalAccessToken,\n+}\n+\n+impl AuthMode {\n+    /// Returns whether this mode represents an authenticated human ChatGPT account.\n+    pub fn has_chatgpt_account(self) -> bool {\n+        match self {\n+            Self::Chatgpt | Self::ChatgptAuthTokens | Self::PersonalAccessToken => true,\n+            Self::ApiKey | Self::AgentIdentity => false,\n+        }\n+    }\n }\n \n macro_rules! experimental_reason_expr {",
+      "path": "codex-rs/app-server-protocol/src/protocol/common.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -115,6 +115,7 @@ fn remote_control_auth_dot_json(account_id: Option<&str>) -> AuthDotJson {\n         }),\n         last_refresh: Some(chrono::Utc::now()),\n         agent_identity: None,\n+        personal_access_token: None,\n     }\n }",
+      "path": "codex-rs/app-server-transport/src/transport/remote_control/tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1769,6 +1769,7 @@ mod tests {\n             }),\n             last_refresh: Some(Utc::now()),\n             agent_identity: None,\n+            personal_access_token: None,\n         }\n     }",
+      "path": "codex-rs/app-server-transport/src/transport/remote_control/websocket.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 1,
+      "patch_excerpt": "@@ -1770,6 +1770,7 @@ Codex supports these authentication modes. The current mode is surfaced in `acco\n \n - **API key (`apiKey`)**: Caller supplies an OpenAI API key via `account/login/start` with `type: \"apiKey\"`. The API key is saved and used for API requests.\n - **ChatGPT managed (`chatgpt`)** (recommended): Codex owns the ChatGPT OAuth flow and refresh tokens. Start via `account/login/start` with `type: \"chatgpt\"` for the browser flow or `type: \"chatgptDeviceCode\"` for device code; Codex persists tokens to disk and refreshes them automatically.\n+- **Personal access token (`personalAccessToken`)**: Codex uses a ChatGPT-backed personal access token loaded outside the app-server login RPCs, such as with `codex login --with-access-token` or `CODEX_ACCESS_TOKEN`.\n \n ### API Overview\n \n@@ -1778,7 +1779,7 @@ Codex supports these authentication modes. The current mode is surfaced in `acco\n -...",
+      "path": "codex-rs/app-server/README.md",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 1,
+      "patch_excerpt": "@@ -359,7 +359,6 @@ use codex_mcp::discover_supported_scopes;\n use codex_mcp::read_mcp_resource as read_mcp_resource_without_thread;\n use codex_mcp::resolve_oauth_scopes;\n use codex_memories_write::clear_memory_roots_contents;\n-use codex_model_provider::ProviderAccountError;\n use codex_model_provider::create_model_provider;\n use codex_models_manager::collaboration_mode_presets::builtin_collaboration_mode_presets;\n use codex_protocol::ThreadId;",
+      "path": "codex-rs/app-server/src/request_processors.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 22,
+      "deletions": 22,
+      "patch_excerpt": "@@ -776,24 +776,28 @@ impl AccountRequestProcessor {\n                     let permanent_refresh_failure =\n                         self.auth_manager.refresh_failure_for_auth(&auth).is_some();\n                     let auth_mode = auth.api_auth_mode();\n-                    let (reported_auth_method, token_opt) =\n-                        if matches!(auth, CodexAuth::AgentIdentity(_))\n-                            || include_token && permanent_refresh_failure\n-                        {\n-                            (Some(auth_mode), None)\n-                        } else {\n-                            match auth.get_token() {\n-                                Ok(token) if !token.is_empty() => {\n-                                    let tok = if include_token { Some(token) } else { None };\n-                                    (Some(auth_mode), tok)\n-                                }\n-             ...",
+      "path": "codex-rs/app-server/src/request_processors/account_processor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -164,6 +164,7 @@ pub fn write_chatgpt_auth(\n         tokens: Some(tokens),\n         last_refresh,\n         agent_identity: None,\n+        personal_access_token: None,\n     };\n \n     save_auth(codex_home, &auth, cli_auth_credentials_store_mode).context(\"write auth.json\")",
+      "path": "codex-rs/app-server/tests/common/auth_fixtures.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 59,
+      "deletions": 0,
+      "patch_excerpt": "@@ -21,6 +21,7 @@ use tokio::time::timeout;\n use wiremock::Mock;\n use wiremock::MockServer;\n use wiremock::ResponseTemplate;\n+use wiremock::matchers::header;\n use wiremock::matchers::method;\n use wiremock::matchers::path;\n \n@@ -160,6 +161,64 @@ async fn get_auth_status_with_api_key() -> Result<()> {\n     Ok(())\n }\n \n+#[tokio::test(flavor = \"multi_thread\", worker_threads = 2)]\n+async fn get_auth_status_with_personal_access_token_omits_token() -> Result<()> {\n+    let codex_home = TempDir::new()?;\n+    create_config_toml(codex_home.path())?;\n+\n+    let server = MockServer::start().await;\n+    Mock::given(method(\"GET\"))\n+        .and(path(\"/v1/user-auth-credential/whoami\"))\n+        .and(header(\"Authorization\", \"Bearer at-test-token\"))\n+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({\n+            \"email\": \"user@example.com\",\n+            \"chatgpt_user_id\":...",
+      "path": "codex-rs/app-server/tests/suite/auth.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -118,6 +118,7 @@ async fn list_apps_returns_empty_with_api_key_auth() -> Result<()> {\n             tokens: None,\n             last_refresh: None,\n             agent_identity: None,\n+            personal_access_token: None,\n         },\n         AuthCredentialsStoreMode::File,\n     )?;",
+      "path": "codex-rs/app-server/tests/suite/v2/app_list.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 4,
+      "deletions": 8,
+      "patch_excerpt": "@@ -3,7 +3,6 @@ use std::sync::RwLock;\n use std::time::Duration;\n use std::time::Instant;\n \n-use anyhow::Context;\n use codex_core::config::Config;\n use codex_login::CodexAuth;\n use serde::Deserialize;\n@@ -93,28 +92,25 @@ pub async fn codex_plugins_enabled_for_workspace(\n         return Ok(true);\n     }\n \n-    let token_data = auth\n-        .get_token_data()\n-        .context(\"ChatGPT token data is not available\")?;\n-    if !token_data.id_token.is_workspace_account() {\n+    if !auth.is_workspace_account() {\n         return Ok(true);\n     }\n \n-    let Some(account_id) = token_data.account_id.as_deref().filter(|id| !id.is_empty()) else {\n+    let Some(account_id) = auth.get_account_id().filter(|id| !id.is_empty()) else {\n         return Ok(true);\n     };\n \n     let cache_key = WorkspaceSettingsCacheKey {\n         chatgpt_base_url: config.chatgpt_base_url.clone(),\n-        account_id: accoun...",
+      "path": "codex-rs/chatgpt/src/workspace_settings.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 40,
+      "deletions": 1,
+      "patch_excerpt": "@@ -1308,6 +1308,7 @@ fn stored_auth_mode(auth: &codex_login::AuthDotJson) -> &'static str {\n         codex_app_server_protocol::AuthMode::Chatgpt => \"chatgpt\",\n         codex_app_server_protocol::AuthMode::ChatgptAuthTokens => \"chatgpt_auth_tokens\",\n         codex_app_server_protocol::AuthMode::AgentIdentity => \"agent_identity\",\n+        codex_app_server_protocol::AuthMode::PersonalAccessToken => \"personal_access_token\",\n     }\n }\n \n@@ -1317,6 +1318,8 @@ fn stored_auth_mode_value(auth: &AuthDotJson) -> codex_app_server_protocol::Auth\n     }\n     if auth.openai_api_key.is_some() {\n         codex_app_server_protocol::AuthMode::ApiKey\n+    } else if auth.personal_access_token.is_some() {\n+        codex_app_server_protocol::AuthMode::PersonalAccessToken\n     } else {\n         codex_app_server_protocol::AuthMode::Chatgpt\n     }\n@@ -1380,6 +1383,15 @@ fn stored_auth_issues(\n                 i...",
+      "path": "codex-rs/cli/src/doctor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 4,
+      "deletions": 0,
+      "patch_excerpt": "@@ -391,6 +391,10 @@ pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {\n                 eprintln!(\"Logged in using access token\");\n                 std::process::exit(0);\n             }\n+            AuthMode::PersonalAccessToken => {\n+                eprintln!(\"Logged in using personal access token\");\n+                std::process::exit(0);\n+            }\n         },\n         Ok(None) => {\n             eprintln!(\"Not logged in\");",
+      "path": "codex-rs/cli/src/login.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 4,
+      "deletions": 3,
+      "patch_excerpt": "@@ -1950,9 +1950,10 @@ impl AuthRequestTelemetryContext {\n         Self {\n             auth_mode: auth_mode.map(|mode| match mode {\n                 AuthMode::ApiKey => \"ApiKey\",\n-                AuthMode::Chatgpt | AuthMode::ChatgptAuthTokens | AuthMode::AgentIdentity => {\n-                    \"Chatgpt\"\n-                }\n+                AuthMode::Chatgpt\n+                | AuthMode::ChatgptAuthTokens\n+                | AuthMode::AgentIdentity\n+                | AuthMode::PersonalAccessToken => \"Chatgpt\",\n             }),\n             auth_header_attached: auth_telemetry.attached,\n             auth_header_name: auth_telemetry.name,",
+      "path": "codex-rs/core/src/client.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 125,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1,14 +1,27 @@\n use assert_cmd::Command as AssertCommand;\n use codex_git_utils::collect_git_info;\n+use codex_login::CODEX_ACCESS_TOKEN_ENV_VAR;\n use codex_login::CODEX_API_KEY_ENV_VAR;\n use codex_protocol::protocol::GitInfo;\n use core_test_support::fs_wait;\n use core_test_support::responses;\n use core_test_support::skip_if_no_network;\n+use pretty_assertions::assert_eq;\n use std::time::Duration;\n use tempfile::TempDir;\n use uuid::Uuid;\n+use wiremock::Mock;\n use wiremock::MockServer;\n+use wiremock::ResponseTemplate;\n+use wiremock::matchers::header;\n+use wiremock::matchers::method;\n+use wiremock::matchers::path;\n+\n+const PERSONAL_ACCESS_TOKEN: &str = \"at-cli-test\";\n+const PERSONAL_ACCESS_TOKEN_AUTHORIZATION: &str = \"Bearer at-cli-test\";\n+const PERSONAL_ACCESS_TOKEN_ACCOUNT_ID: &str = \"account-pat\";\n+const WHOAMI_PATH: &str = \"/v1/user-auth-credential/whoami\";\n+const CLOUD_CONFIG_BUNDLE_P...",
+      "path": "codex-rs/core/tests/suite/cli_stream.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 18,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,18 @@\n+const PERSONAL_ACCESS_TOKEN_PREFIX: &str = \"at-\";\n+\n+pub(super) enum CodexAccessToken<'a> {\n+    PersonalAccessToken(&'a str),\n+    AgentIdentityJwt(&'a str),\n+}\n+\n+pub(super) fn classify_codex_access_token(access_token: &str) -> CodexAccessToken<'_> {\n+    if access_token.starts_with(PERSONAL_ACCESS_TOKEN_PREFIX) {\n+        CodexAccessToken::PersonalAccessToken(access_token)\n+    } else {\n+        CodexAccessToken::AgentIdentityJwt(access_token)\n+    }\n+}\n+\n+#[cfg(test)]\n+#[path = \"access_token_tests.rs\"]\n+mod tests;",
+      "path": "codex-rs/login/src/auth/access_token.rs",
+      "status": "added"
+    },
+    {
+      "additions": 13,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,13 @@\n+use super::*;\n+\n+#[test]\n+fn classifies_personal_access_tokens_by_prefix() {\n+    assert!(matches!(\n+        classify_codex_access_token(\"at-example\"),\n+        CodexAccessToken::PersonalAccessToken(\"at-example\")\n+    ));\n+    assert!(matches!(\n+        classify_codex_access_token(\"header.payload.signature\"),\n+        CodexAccessToken::AgentIdentityJwt(\"header.payload.signature\")\n+    ));\n+}",
+      "path": "codex-rs/login/src/auth/access_token_tests.rs",
+      "status": "added"
+    },
+    {
+      "additions": 184,
+      "deletions": 0,
+      "patch_excerpt": "@@ -19,6 +19,7 @@ use tempfile::tempdir;\n use wiremock::Mock;\n use wiremock::MockServer;\n use wiremock::ResponseTemplate;\n+use wiremock::matchers::header;\n use wiremock::matchers::method;\n use wiremock::matchers::path;\n \n@@ -126,6 +127,84 @@ async fn login_with_access_token_writes_only_token() {\n     server.verify().await;\n }\n \n+#[tokio::test]\n+#[serial(codex_auth_env)]\n+async fn login_with_access_token_writes_only_personal_access_token() {\n+    let dir = tempdir().unwrap();\n+    let auth_path = dir.path().join(\"auth.json\");\n+    let server = MockServer::start().await;\n+    Mock::given(method(\"GET\"))\n+        .and(path(\"/v1/user-auth-credential/whoami\"))\n+        .and(header(\"authorization\", \"Bearer at-login-test\"))\n+        .respond_with(\n+            ResponseTemplate::new(200)\n+                .set_body_json(personal_access_token_whoami(WORKSPACE_ID_ALLOWED)),\n+        )\n+        .expe...",
+      "path": "codex-rs/login/src/auth/auth_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 130,
+      "deletions": 30,
+      "patch_excerpt": "@@ -24,9 +24,12 @@ use codex_app_server_protocol::AuthMode as ApiAuthMode;\n use codex_protocol::config_types::ForcedLoginMethod;\n use codex_protocol::config_types::ModelProviderAuthInfo;\n \n+use super::access_token::CodexAccessToken;\n+use super::access_token::classify_codex_access_token;\n use super::external_bearer::BearerTokenRefresher;\n use super::revoke::revoke_auth_tokens;\n pub use crate::auth::agent_identity::AgentIdentityAuth;\n+pub use crate::auth::personal_access_token::PersonalAccessTokenAuth;\n pub use crate::auth::storage::AgentIdentityAuthRecord;\n pub use crate::auth::storage::AuthDotJson;\n use crate::auth::storage::AuthStorageBackend;\n@@ -53,11 +56,15 @@ pub enum CodexAuth {\n     Chatgpt(ChatgptAuth),\n     ChatgptAuthTokens(ChatgptAuthTokens),\n     AgentIdentity(AgentIdentityAuth),\n+    PersonalAccessToken(PersonalAccessTokenAuth),\n }\n \n impl PartialEq for CodexAuth {\n     fn e...",
+      "path": "codex-rs/login/src/auth/manager.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1,6 +1,8 @@\n+mod access_token;\n mod agent_identity;\n pub mod default_client;\n pub mod error;\n+mod personal_access_token;\n mod storage;\n mod util;",
+      "path": "codex-rs/login/src/auth/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 112,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,112 @@\n+use codex_client::CodexHttpClient;\n+use codex_protocol::account::PlanType as AccountPlanType;\n+use codex_protocol::auth::PlanType as InternalPlanType;\n+use serde::Deserialize;\n+use std::env;\n+use std::fmt;\n+\n+use crate::default_client::create_client;\n+\n+const PROD_AUTHAPI_BASE_URL: &str = \"https://auth.openai.com/api/accounts\";\n+const CODEX_AUTHAPI_BASE_URL_ENV_VAR: &str = \"CODEX_AUTHAPI_BASE_URL\";\n+const WHOAMI_PATH: &str = \"/v1/user-auth-credential/whoami\";\n+\n+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]\n+struct PersonalAccessTokenMetadata {\n+    email: String,\n+    chatgpt_user_id: String,\n+    chatgpt_account_id: String,\n+    chatgpt_plan_type: String,\n+    chatgpt_account_is_fedramp: bool,\n+}\n+\n+#[derive(Clone, PartialEq, Eq)]\n+pub struct PersonalAccessTokenAuth {\n+    access_token: String,\n+    metadata: PersonalAccessTokenMetadata,\n+}\n+\n+impl fmt::Debug f...",
+      "path": "codex-rs/login/src/auth/personal_access_token.rs",
+      "status": "added"
+    },
+    {
+      "additions": 71,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,71 @@\n+use super::*;\n+use pretty_assertions::assert_eq;\n+use serde_json::json;\n+use wiremock::Mock;\n+use wiremock::MockServer;\n+use wiremock::ResponseTemplate;\n+use wiremock::matchers::header;\n+use wiremock::matchers::method;\n+use wiremock::matchers::path;\n+\n+fn response(email: Option<&str>) -> serde_json::Value {\n+    json!({\n+        \"email\": email,\n+        \"chatgpt_user_id\": \"user-123\",\n+        \"chatgpt_account_id\": \"account-123\",\n+        \"chatgpt_plan_type\": \"enterprise\",\n+        \"chatgpt_account_is_fedramp\": true,\n+    })\n+}\n+\n+#[tokio::test]\n+async fn hydrate_sends_bearer_token_and_preserves_metadata() {\n+    let server = MockServer::start().await;\n+    Mock::given(method(\"GET\"))\n+        .and(path(WHOAMI_PATH))\n+        .and(header(\"authorization\", \"Bearer at-example\"))\n+        .respond_with(ResponseTemplate::new(200).set_body_json(response(Some(\"user@example.com\")...",
+      "path": "codex-rs/login/src/auth/personal_access_token_tests.rs",
+      "status": "added"
+    },
+    {
+      "additions": 3,
+      "deletions": 0,
+      "patch_excerpt": "@@ -45,6 +45,9 @@ pub struct AuthDotJson {\n \n     #[serde(default, skip_serializing_if = \"Option::is_none\")]\n     pub agent_identity: Option<String>,\n+\n+    #[serde(default, skip_serializing_if = \"Option::is_none\")]\n+    pub personal_access_token: Option<String>,\n }\n \n #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]",
+      "path": "codex-rs/login/src/auth/storage.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 28,
+      "deletions": 0,
+      "patch_excerpt": "@@ -19,6 +19,7 @@ async fn file_storage_load_returns_auth_dot_json() -> anyhow::Result<()> {\n         tokens: None,\n         last_refresh: Some(Utc::now()),\n         agent_identity: None,\n+        personal_access_token: None,\n     };\n \n     storage\n@@ -40,6 +41,7 @@ async fn file_storage_save_persists_auth_dot_json() -> anyhow::Result<()> {\n         tokens: None,\n         last_refresh: Some(Utc::now()),\n         agent_identity: None,\n+        personal_access_token: None,\n     };\n \n     let file = get_auth_file(codex_home.path());\n@@ -73,6 +75,27 @@ async fn file_storage_round_trips_agent_identity_auth() -> anyhow::Result<()> {\n         tokens: None,\n         last_refresh: None,\n         agent_identity: Some(agent_identity),\n+        personal_access_token: None,\n+    };\n+\n+    storage.save(&auth_dot_json)?;\n+\n+    let loaded = storage.load()?;\n+    assert_eq!(Some(auth_dot_json), loaded);...",
+      "path": "codex-rs/login/src/auth/storage_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 16,
+      "deletions": 0,
+      "patch_excerpt": "@@ -822,6 +822,7 @@ pub(crate) async fn persist_tokens_async(\n             tokens: Some(tokens),\n             last_refresh: Some(Utc::now()),\n             agent_identity: None,\n+            personal_access_token: None,\n         };\n         save_auth(&codex_home, &auth, auth_credentials_store_mode)?;\n         Ok::<_, io::Error>((previous_auth, auth))\n@@ -940,6 +941,20 @@ pub(crate) fn ensure_workspace_allowed(\n         return Err(\"Login is restricted to a specific workspace, but the token did not include an chatgpt_account_id claim.\".to_string());\n     };\n \n+    ensure_workspace_account_allowed(Some(expected), actual)\n+}\n+\n+/// Validates an already known ChatGPT account ID against an optional workspace restriction.\n+///\n+/// PAT login calls this directly because `/whoami` supplies the account ID without an ID token.\n+pub(crate) fn ensure_workspace_account_allowed(\n+    expected: Option<&[...",
+      "path": "codex-rs/login/src/server.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 25,
+      "deletions": 0,
+      "patch_excerpt": "@@ -55,6 +55,7 @@ async fn refresh_token_succeeds_updates_storage() -> Result<()> {\n         tokens: Some(initial_tokens.clone()),\n         last_refresh: Some(initial_last_refresh),\n         agent_identity: None,\n+        personal_access_token: None,\n     };\n     ctx.write_auth(&initial_auth).await?;\n \n@@ -119,6 +120,7 @@ async fn refresh_token_refreshes_when_auth_is_unchanged() -> Result<()> {\n         tokens: Some(initial_tokens.clone()),\n         last_refresh: Some(initial_last_refresh),\n         agent_identity: None,\n+        personal_access_token: None,\n     };\n     ctx.write_auth(&initial_auth).await?;\n \n@@ -184,6 +186,7 @@ async fn auth_refreshes_when_access_token_is_near_expiry() -> Result<()> {\n         tokens: Some(initial_tokens.clone()),\n         last_refresh: Some(initial_last_refresh),\n         agent_identity: None,\n+        personal_access_token: None,\n     };\n     ctx.wri...",
+      "path": "codex-rs/login/tests/suite/auth_refresh.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -195,6 +195,7 @@ fn chatgpt_auth_with_refresh_token(refresh_token: &str) -> AuthDotJson {\n         }),\n         last_refresh: None,\n         agent_identity: None,\n+        personal_access_token: None,\n     }\n }",
+      "path": "codex-rs/login/tests/suite/logout.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 6,
+      "deletions": 1,
+      "patch_excerpt": "@@ -237,7 +237,12 @@ impl ModelProviderInfo {\n     pub fn to_api_provider(&self, auth_mode: Option<AuthMode>) -> CodexResult<ApiProvider> {\n         let default_base_url = if matches!(\n             auth_mode,\n-            Some(AuthMode::Chatgpt | AuthMode::ChatgptAuthTokens | AuthMode::AgentIdentity)\n+            Some(\n+                AuthMode::Chatgpt\n+                    | AuthMode::ChatgptAuthTokens\n+                    | AuthMode::AgentIdentity\n+                    | AuthMode::PersonalAccessToken\n+            )\n         ) {\n             CHATGPT_CODEX_BASE_URL\n         } else {",
+      "path": "codex-rs/model-provider-info/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 9,
+      "deletions": 0,
+      "patch_excerpt": "@@ -139,6 +139,15 @@ fn test_supports_remote_compaction_for_openai() {\n     assert!(provider.supports_remote_compaction());\n }\n \n+#[test]\n+fn test_personal_access_token_uses_chatgpt_codex_base_url() {\n+    let api_provider = ModelProviderInfo::create_openai_provider(/*base_url*/ None)\n+        .to_api_provider(Some(AuthMode::PersonalAccessToken))\n+        .expect(\"OpenAI provider should build API provider\");\n+\n+    assert_eq!(api_provider.base_url, CHATGPT_CODEX_BASE_URL);\n+}\n+\n #[test]\n fn test_supports_remote_compaction_for_azure_name() {\n     let provider = ModelProviderInfo {",
+      "path": "codex-rs/model-provider-info/src/model_provider_info_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 8,
+      "deletions": 7,
+      "patch_excerpt": "@@ -109,13 +109,14 @@ pub fn auth_provider_from_auth(auth: &CodexAuth) -> SharedAuthProvider {\n         CodexAuth::AgentIdentity(auth) => {\n             Arc::new(AgentIdentityAuthProvider { auth: auth.clone() })\n         }\n-        CodexAuth::ApiKey(_) | CodexAuth::Chatgpt(_) | CodexAuth::ChatgptAuthTokens(_) => {\n-            Arc::new(BearerAuthProvider {\n-                token: auth.get_token().ok(),\n-                account_id: auth.get_account_id(),\n-                is_fedramp_account: auth.is_fedramp_account(),\n-            })\n-        }\n+        CodexAuth::ApiKey(_)\n+        | CodexAuth::Chatgpt(_)\n+        | CodexAuth::ChatgptAuthTokens(_)\n+        | CodexAuth::PersonalAccessToken(_) => Arc::new(BearerAuthProvider {\n+            token: auth.get_token().ok(),\n+            account_id: auth.get_account_id(),\n+            is_fedramp_account: auth.is_fedramp_account(),\n+        }),\n   ...",
+      "path": "codex-rs/model-provider/src/auth.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 17,
+      "deletions": 1,
+      "patch_excerpt": "@@ -212,7 +212,8 @@ impl ModelProvider for ConfiguredModelProvider {\n                     CodexAuth::ApiKey(_) => Ok(ProviderAccount::ApiKey),\n                     CodexAuth::Chatgpt(_)\n                     | CodexAuth::ChatgptAuthTokens(_)\n-                    | CodexAuth::AgentIdentity(_) => {\n+                    | CodexAuth::AgentIdentity(_)\n+                    | CodexAuth::PersonalAccessToken(_) => {\n                         let email = auth.get_account_email();\n                         let plan_type = auth.account_plan_type();\n \n@@ -453,6 +454,21 @@ mod tests {\n         );\n     }\n \n+    #[test]\n+    fn openai_provider_rejects_chatgpt_account_state_without_email() {\n+        let provider = create_model_provider(\n+            ModelProviderInfo::create_openai_provider(/*base_url*/ None),\n+            Some(AuthManager::from_auth_for_testing(\n+                CodexAuth::create_dummy_ch...",
+      "path": "codex-rs/model-provider/src/provider.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 4,
+      "patch_excerpt": "@@ -328,10 +328,9 @@ impl OpenAiModelsManager {\n                 .iter()\n                 .any(|model| model.visibility == ModelVisibility::List)\n             && self.auth_manager.as_ref().is_some_and(|auth_manager| {\n-                matches!(\n-                    auth_manager.auth_mode(),\n-                    Some(AuthMode::Chatgpt | AuthMode::ChatgptAuthTokens)\n-                )\n+                auth_manager\n+                    .auth_mode()\n+                    .is_some_and(AuthMode::has_chatgpt_account)\n             });\n         if should_use_remote_models_only {\n             *self.remote_models.write().await = models;",
+      "path": "codex-rs/models-manager/src/manager.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -211,6 +211,7 @@ c2ln\",\n         }),\n         last_refresh: Some(Utc::now()),\n         agent_identity: None,\n+        personal_access_token: None,\n     };\n     std::fs::create_dir_all(codex_home).expect(\"codex home should be created\");\n     std::fs::write(",
+      "path": "codex-rs/models-manager/src/manager_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 1,
+      "patch_excerpt": "@@ -57,7 +57,8 @@ impl From<codex_app_server_protocol::AuthMode> for TelemetryAuthMode {\n             codex_app_server_protocol::AuthMode::ApiKey => Self::ApiKey,\n             codex_app_server_protocol::AuthMode::Chatgpt\n             | codex_app_server_protocol::AuthMode::ChatgptAuthTokens\n-            | codex_app_server_protocol::AuthMode::AgentIdentity => Self::Chatgpt,\n+            | codex_app_server_protocol::AuthMode::AgentIdentity\n+            | codex_app_server_protocol::AuthMode::PersonalAccessToken => Self::Chatgpt,\n         }\n     }\n }",
+      "path": "codex-rs/otel/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 4,
+      "patch_excerpt": "@@ -87,10 +87,9 @@ impl App {\n                         notification.plan_type,\n                     ),\n                     notification.plan_type,\n-                    matches!(\n-                        notification.auth_mode,\n-                        Some(AuthMode::Chatgpt) | Some(AuthMode::ChatgptAuthTokens)\n-                    ),\n+                    notification\n+                        .auth_mode\n+                        .is_some_and(AuthMode::has_chatgpt_account),\n                 );\n                 return;\n             }",
+      "path": "codex-rs/tui/src/app/app_server_events.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 1,
+      "patch_excerpt": "@@ -1191,7 +1191,8 @@ pub(crate) fn status_account_display_from_auth_mode(\n         Some(AuthMode::ApiKey) => Some(StatusAccountDisplay::ApiKey),\n         Some(AuthMode::Chatgpt)\n         | Some(AuthMode::ChatgptAuthTokens)\n-        | Some(AuthMode::AgentIdentity) => Some(StatusAccountDisplay::ChatGpt {\n+        | Some(AuthMode::AgentIdentity)\n+        | Some(AuthMode::PersonalAccessToken) => Some(StatusAccountDisplay::ChatGpt {\n             email: None,\n             plan: plan_type.map(plan_type_display_name),\n         }),",
+      "path": "codex-rs/tui/src/app_server_session.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -109,6 +109,7 @@ mod tests {\n             }),\n             last_refresh: Some(Utc::now()),\n             agent_identity: None,\n+            personal_access_token: None,\n         };\n         save_auth(codex_home, &auth, AuthCredentialsStoreMode::File)\n             .expect(\"chatgpt auth should save\");\n@@ -156,6 +157,7 @@ mod tests {\n                 tokens: None,\n                 last_refresh: None,\n                 agent_identity: None,\n+                personal_access_token: None,\n             },\n             AuthCredentialsStoreMode::File,\n         )",
+      "path": "codex-rs/tui/src/local_chatgpt_auth.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 18,
+      "deletions": 13,
+      "patch_excerpt": "@@ -10,6 +10,7 @@\n use codex_app_server_client::AppServerRequestHandle;\n use codex_app_server_protocol::AccountLoginCompletedNotification;\n use codex_app_server_protocol::AccountUpdatedNotification;\n+#[cfg(test)]\n use codex_app_server_protocol::AuthMode as AppServerAuthMode;\n use codex_app_server_protocol::CancelLoginAccountParams;\n use codex_app_server_protocol::ClientRequest;\n@@ -845,8 +846,7 @@ impl AuthModeWidget {\n     fn handle_existing_chatgpt_login(&mut self) -> bool {\n         if matches!(\n             self.login_status,\n-            LoginStatus::AuthMode(AppServerAuthMode::Chatgpt)\n-                | LoginStatus::AuthMode(AppServerAuthMode::ChatgptAuthTokens)\n+            LoginStatus::AuthMode(auth_mode) if auth_mode.has_chatgpt_account()\n         ) {\n             *self.sign_in_state.write().unwrap() = SignInState::ChatGptSuccess;\n             self.request_frame.schedule_frame(...",
+      "path": "codex-rs/tui/src/onboarding/auth.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Summary\n\n- add v2 personal access token support for `codex login --with-access-token` and `CODEX_ACCESS_TOKEN`\n- classify opaque `at-` tokens separately from legacy Agent Identity JWTs\n- hydrate required ChatGPT account metadata through AuthAPI `/v1/user-auth-credential/whoami`\n- use PATs directly as bearer tokens while preserving existing ChatGPT account surfaces\n- expose PAT-backed auth as the explicit `personalAccessToken` app-server auth mode\n\n## Implementation\n\nPAT auth is intentionally small and stateless. Loading a PAT performs one AuthAPI metadata request, stores the hydrated metadata in the in-memory auth object, and redacts the secret from debug output. Legacy Agent Identity JWT handling remains unchanged. The shared access-token classifier lives in a private neutral module because it dispatches between both credential types.\n\nPAT hydration fails closed when AuthAPI omits any required metadata, including email. Hydrated metadata is intentionally not persisted: startup performs a live `whoami` preflight so revoked tokens or changed account metadata are not accepted from a stale cache.\n\n## Workspace restriction scope\n\nThis change intentionally does **not** apply `forced_chatgpt_workspace_id` to PAT authentication. The setting is a client-side config guardrail, not an authorization boundary, and PAT does not currently require workspace-ID parity. The PAT login and `CODEX_ACCESS_TOKEN` paths therefore validate through AuthAPI without threading workspace-restriction state through access-token loading. Existing workspace checks for non-PAT auth remain on their established paths.\n\n## App-server compatibility\n\nThe public app-server `AuthMode` is shared across v1 and v2, and PAT-backed auth reports `personalAccessToken` through both APIs. Following human review, this intentionally removes the temporary v1 compatibility mapping that reported PATs as `chatgpt`; the deprecated v1 API is kept in parity with v2 rather than maintaining a separate closed enum. Clients with exhaustive auth-mode handling in either API version must add the new case and should generally treat it as ChatGPT-backed unless they need PAT-specific behavior.\n\nThe v1 auth-status response still omits the raw PAT when `includeToken` is requested because that response cannot carry the account metadata needed to reuse the credential safely. Persisted PAT auth also omits the new enum value so older Codex builds can deserialize `auth.json` and infer PAT auth from the credential field after a rollback.\n\n## Validation\n\nLatest review-fix validation:\n\n- `CARGO_INCREMENTAL=0 just test -p codex-login` (126 passed)\n- `CARGO_INCREMENTAL=0 just test -p codex-cli` (263 passed)\n- `CARGO_INCREMENTAL=0 just test -p codex-cli stored_auth_validation_handles_personal_access_token`\n- `CARGO_INCREMENTAL=0 just test -p codex-app-server-protocol` (226 passed)\n- `CARGO_INCREMENTAL=0 just test -p codex-models-manager refresh_available_models_uses_remote_only_catalog_for_chatgpt_auth`\n- `CARGO_INCREMENTAL=0 just test -p codex-tui existing_non_oauth_chatgpt_login_counts_as_signed_in`\n- `CARGO_INCREMENTAL=0 just fix -p codex-login -p codex-app-server-protocol -p codex-models-manager -p codex-tui -p codex-cli`\n- `just fmt`\n- `git diff --check`\n\nThe broader `codex-tui` suite previously compiled and ran 2,834 tests. Three unrelated environment-sensitive guardian/IDE-socket tests failed after retries; the PAT-relevant TUI coverage passed.",
+    "labels": [],
+    "merged_at": "2026-06-06T00:36:19Z",
+    "number": 25731,
+    "state": "merged",
+    "title": "[codex-rs] support v2 personal access tokens",
+    "url": "https://github.com/openai/codex/pull/25731"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-26013.json
+++ b/artifacts/github/bundles/openai-codex-pr-26013.json
@@ -1,0 +1,92 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "vie-oai",
+      "committed_at": "2026-06-04T02:32:04Z",
+      "message": "Gate terminal visualization instructions in TUI",
+      "sha": "a52f7e1e2e945a2facea65781ba429f04524a477",
+      "url": "https://github.com/openai/codex/commit/a52f7e1e2e945a2facea65781ba429f04524a477"
+    },
+    {
+      "author": "vie-oai",
+      "committed_at": "2026-06-04T05:04:09Z",
+      "message": "Fix terminal visualization CI",
+      "sha": "a323a5101b5aa61af6e0c1cecaf5da04391bfa44",
+      "url": "https://github.com/openai/codex/commit/a323a5101b5aa61af6e0c1cecaf5da04391bfa44"
+    },
+    {
+      "author": "vie-oai",
+      "committed_at": "2026-06-05T23:00:19Z",
+      "message": "Merge remote-tracking branch 'origin/main' into codex/terminal-visualization-tui-gate",
+      "sha": "f249259c64745fed22c706240526d7797fdc6691",
+      "url": "https://github.com/openai/codex/commit/f249259c64745fed22c706240526d7797fdc6691"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "TUI",
+    "--lib",
+    "--all",
+    "--check",
+    "GPT",
+    "CLI",
+    "FEATURES",
+    "TERMINAL_VISUALIZATION_INSTRUCTIONS",
+    "ASCII"
+  ],
+  "files": [
+    {
+      "additions": 6,
+      "deletions": 0,
+      "patch_excerpt": "@@ -614,6 +614,9 @@\n             \"terminal_resize_reflow\": {\n               \"type\": \"boolean\"\n             },\n+            \"terminal_visualization_instructions\": {\n+              \"type\": \"boolean\"\n+            },\n             \"tool_call_mcp_elicitation\": {\n               \"type\": \"boolean\"\n             },\n@@ -4737,6 +4740,9 @@\n         \"terminal_resize_reflow\": {\n           \"type\": \"boolean\"\n         },\n+        \"terminal_visualization_instructions\": {\n+          \"type\": \"boolean\"\n+        },\n         \"tool_call_mcp_elicitation\": {\n           \"type\": \"boolean\"\n         },",
+      "path": "codex-rs/core/config.schema.json",
+      "status": "modified"
+    },
+    {
+      "additions": 8,
+      "deletions": 0,
+      "patch_excerpt": "@@ -99,6 +99,8 @@ pub enum Feature {\n     UnifiedExecZshFork,\n     /// Reflow transcript scrollback when the terminal is resized.\n     TerminalResizeReflow,\n+    /// Add terminal-specific visualization guidance to TUI developer instructions.\n+    TerminalVisualizationInstructions,\n     /// Stream structured progress while apply_patch input is being generated.\n     ApplyPatchStreamingEvents,\n     /// Allow exec tools to request additional permissions while staying sandboxed.\n@@ -1118,6 +1120,12 @@ pub const FEATURES: &[FeatureSpec] = &[\n         stage: Stage::UnderDevelopment,\n         default_enabled: false,\n     },\n+    FeatureSpec {\n+        id: Feature::TerminalVisualizationInstructions,\n+        key: \"terminal_visualization_instructions\",\n+        stage: Stage::UnderDevelopment,\n+        default_enabled: false,\n+    },\n     FeatureSpec {\n         id: Feature::GuardianApproval,\n      ...",
+      "path": "codex-rs/features/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 85,
+      "deletions": 1,
+      "patch_excerpt": "@@ -11,6 +11,7 @@ use crate::session_state::MessageHistoryMetadata;\n use crate::session_state::ThreadSessionState;\n use crate::status::StatusAccountDisplay;\n use crate::status::plan_type_display_name;\n+use crate::terminal_visualization_instructions::with_terminal_visualization_instructions;\n use codex_app_server_client::AppServerClient;\n use codex_app_server_client::AppServerEvent;\n use codex_app_server_client::AppServerRequestHandle;\n@@ -1412,6 +1413,9 @@ fn thread_start_params_from_config(\n         ephemeral: Some(config.ephemeral),\n         session_start_source,\n         thread_source: Some(ThreadSource::User),\n+        developer_instructions: with_terminal_visualization_instructions(\n+            config, /*control_instructions*/ None,\n+        ),\n         ..ThreadStartParams::default()\n     }\n }\n@@ -1444,6 +1448,9 @@ fn thread_resume_params_from_config(\n         sandbox,\n         per...",
+      "path": "codex-rs/tui/src/app_server_session.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -188,6 +188,7 @@ mod terminal_hyperlinks;\n mod terminal_palette;\n mod terminal_probe;\n mod terminal_title;\n+mod terminal_visualization_instructions;\n mod text_formatting;\n mod theme_picker;\n mod token_usage;",
+      "path": "codex-rs/tui/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 29,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,29 @@\n+use crate::legacy_core::config::Config;\n+use codex_features::Feature;\n+\n+pub(crate) const TERMINAL_VISUALIZATION_INSTRUCTIONS: &str = \"\\\n+- This surface is a terminal. When the formatting rules require a visual, include one in the final answer using compact ASCII diagrams, trees, timelines, or tables.\n+- Use tables for exact mappings or comparisons rather than collapsing known mappings into prose.\n+- Use trees for hierarchy or one-to-many relationships, and diagrams or timelines for sequence, change, or state transferred between records across event order.\n+- Use only ASCII characters in visuals.\";\n+\n+pub(crate) fn with_terminal_visualization_instructions(\n+    config: &Config,\n+    control_instructions: Option<String>,\n+) -> Option<String> {\n+    if !config\n+        .features\n+        .enabled(Feature::TerminalVisualizationInstructions)\n+    {\n+        return control_i...",
+      "path": "codex-rs/tui/src/terminal_visualization_instructions.rs",
+      "status": "added"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Summary\n- add `Feature::TerminalVisualizationInstructions` as `UnderDevelopment`, disabled by default\n- keep terminal visualization instructions inside the TUI package\n- append them to existing developer instructions for TUI start, resume, and fork flows only when enabled\n- intentionally do not apply them to `codex exec`\n\n## Rollout\nControl behavior is unchanged. TUI dogfooders can enable `terminal_visualization_instructions`; no default user receives the new terminal-specific instructions.\n\nThe shared visualization-selection rule is supplied separately through the `codex_proxy_model_3` Statsig layer for every target Codex model slug in the gated cohort. This TUI feature determines how to render an appropriate visualization on the terminal surface; the model-layer treatment determines when to use one.\n\n## Validation\n- `cargo test -p codex-tui terminal_visualization_instructions_are_gated_for_all_tui_thread_flows --lib`\n- `cargo test -p codex-features --lib`\n- `cargo fmt --all -- --check`\n- `git diff --check`\n- GPT-5.4 and GPT-5.5 real prompt-pipeline smoke tests: both visualized the positive mapping case, abstained on the negative route case, and passed exact prompt-stack verification on CLI and App\n- refreshed onto current `main` with a clean merge and reran the focused validation\n\nThe full 53-probe all-model treatment comparison and requested production coding evals remain rollout gates before broadening beyond the initial employee cohort.\n\nThis PR remains open for normal human review.",
+    "labels": [],
+    "merged_at": "2026-06-06T00:23:46Z",
+    "number": 26013,
+    "state": "merged",
+    "title": "[codex] Gate terminal visualization instructions in TUI",
+    "url": "https://github.com/openai/codex/pull/26013"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-26464.json
+++ b/artifacts/github/bundles/openai-codex-pr-26464.json
@@ -1,0 +1,259 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "cconger",
+      "committed_at": "2026-06-04T20:01:42Z",
+      "message": "build(v8): update rusty_v8 to 149.2.0",
+      "sha": "bab01026e7d4a6329df5513a129ee2c1898d917e",
+      "url": "https://github.com/openai/codex/commit/bab01026e7d4a6329df5513a129ee2c1898d917e"
+    },
+    {
+      "author": "cconger",
+      "committed_at": "2026-06-04T22:14:55Z",
+      "message": "fix(v8): pin artifact target CPU",
+      "sha": "336d10be5c4ec22a11ab0ca5e68dc751876c26ea",
+      "url": "https://github.com/openai/codex/commit/336d10be5c4ec22a11ab0ca5e68dc751876c26ea"
+    },
+    {
+      "author": "cconger",
+      "committed_at": "2026-06-05T19:42:15Z",
+      "message": "build(v8): consume published 149.2.0 artifacts",
+      "sha": "bcff1e61996a1de050a69b576ef0ec5e13430766",
+      "url": "https://github.com/openai/codex/commit/bcff1e61996a1de050a69b576ef0ec5e13430766"
+    },
+    {
+      "author": "cconger",
+      "committed_at": "2026-06-05T21:52:17Z",
+      "message": "ci(v8): publish Windows artifacts from release tags",
+      "sha": "1e1b8ed914d7b4aec4d987ffaf3d1c3e97f3fa4d",
+      "url": "https://github.com/openai/codex/commit/1e1b8ed914d7b4aec4d987ffaf3d1c3e97f3fa4d"
+    },
+    {
+      "author": "cconger",
+      "committed_at": "2026-06-05T23:24:25Z",
+      "message": "fix(v8): keep Bazel consumers on source builds",
+      "sha": "ec64ccb725793f49feb297d7f4ad0f74be0fb32a",
+      "url": "https://github.com/openai/codex/commit/ec64ccb725793f49feb297d7f4ad0f74be0fb32a"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [
+    "third_party/v8/README.md"
+  ],
+  "examples_refs": [],
+  "extracted_flags": [
+    "CPU",
+    "PLATFORM",
+    "SANDBOX",
+    "TARGET",
+    "V8_CPU",
+    "--platforms",
+    "--config",
+    "--build_metadata",
+    "COMMIT_SHA=$(git",
+    "HEAD",
+    "--compilation-mode",
+    "--output-dir",
+    "--bazel-config",
+    "BAZEL_CONFIG",
+    "--sandbox",
+    "--global",
+    "--profile",
+    "--no-self-update",
+    "--toolchain",
+    "--recursive",
+    "SCCACHE_CACHE_SIZE",
+    "SCCACHE_DIR",
+    "SCCACHE_IDLE_TIMEOUT",
+    "--start-server",
+    "GITHUB_PATH",
+    "ARM64",
+    "MSVC",
+    "V8_FROM_SOURCE",
+    "--locked",
+    "--release",
+    "--target",
+    "--features",
+    "--source-root",
+    "RUSTY_V8_ARCHIVE=\"${GITHUB_WORKSPACE}/${archive}\"",
+    "RUSTY_V8_SRC_BINDING_PATH=\"${GITHUB_WORKSPACE}/${binding}\"",
+    "--no-run",
+    "BUILD",
+    "--git",
+    "UNICODE",
+    "V8_TRACE_MAPS",
+    "V8_ENABLE_TURBOFAN",
+    "V8_ENABLE_CHECKS",
+    "BSD",
+    "LICENSE",
+    "HAVE_DLOPEN=0\"",
+    "U_ICUDATAENTRY_IN_COMMON",
+    "CUSTOM_LIBCXX_DEPS",
+    "U_COMMON_IMPLEMENTATION",
+    "MODULE",
+    "--require-hashes",
+    "--index-url",
+    "FP16",
+    "LLVM",
+    "WORKSPACE_ROOT",
+    "COPTS",
+    "HWY_SHARED_DEFINE",
+    "DEFINES",
+    "EXPORT_TEMPLATE_TEST",
+    "DEFAULT",
+    "EXPORT_TEMPLATE_TEST_DEFAULT_DEFAULT",
+    "DCHECK",
+    "V8_CRITICAL_SECTION",
+    "CRT",
+    "STRUNCATE",
+    "DEFINE_LAZY_LEAKY_OBJECT_GETTER",
+    "PASE",
+    "UNREACHABLE",
+    "V8_WEAK",
+    "PKU",
+    "GNU",
+    "ABI",
+    "API",
+    "V8_COPTS",
+    "V8_CUSTOM_LIBCXX_COPTS",
+    "V8_STATIC_LIBRARY_FEATURES",
+    "EOF",
+    "RUSTY_V8_ARCHIVE",
+    "RUSTY_V8_SRC_BINDING_PATH",
+    "CR_LIBCXX_REVISION=7ab65651aed6802d2599dcb7a73b1f82d5179d05\"",
+    "CR_LIBCXX_REVISION=99457fa555797f8c5ac3c076ca288d8481d3b23a\"",
+    "LIBCXX_BUILDING_LIBCXXABI",
+    "LIBC_NAMESPACE=__llvm_libc_cr\"",
+    "LIBCXXABI_SILENT_TERMINATE"
+  ],
+  "files": [
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -214,6 +214,8 @@ common --@v8//:v8_enable_sandbox=True\n # artifact migration ships matching Rust feature selection for Cargo consumers.\n common:v8-release-compat --@v8//:v8_enable_pointer_compression=False\n common:v8-release-compat --@v8//:v8_enable_sandbox=False\n+common:v8-target-x64 --@v8//bazel/config:v8_target_cpu=x64\n+common:v8-target-arm64 --@v8//bazel/config:v8_target_cpu=arm64\n \n # Match rusty_v8's upstream GN release contract for published artifacts: every\n # target object uses Chromium's custom libc++ headers and the archive folds in",
+      "path": ".bazelrc",
+      "status": "modified"
+    },
+    {
+      "additions": 156,
+      "deletions": 0,
+      "patch_excerpt": "@@ -73,72 +73,84 @@ jobs:\n             platform: linux_amd64\n             sandbox: false\n             target: x86_64-unknown-linux-gnu\n+            v8_cpu: x64\n             variant: release\n           - runner: ubuntu-24.04\n             bazel_config: ci-v8\n             platform: linux_amd64\n             sandbox: true\n             target: x86_64-unknown-linux-gnu\n+            v8_cpu: x64\n             variant: ptrcomp-sandbox\n           - runner: ubuntu-24.04-arm\n             bazel_config: ci-v8\n             platform: linux_arm64\n             sandbox: false\n             target: aarch64-unknown-linux-gnu\n+            v8_cpu: arm64\n             variant: release\n           - runner: ubuntu-24.04-arm\n             bazel_config: ci-v8\n             platform: linux_arm64\n             sandbox: true\n             target: aarch64-unknown-linux-gnu\n+            v8_cpu: arm64\n             variant: ptrco...",
+      "path": ".github/workflows/rusty-v8-release.yml",
+      "status": "modified"
+    },
+    {
+      "additions": 16,
+      "deletions": 0,
+      "patch_excerpt": "@@ -89,72 +89,84 @@ jobs:\n             platform: linux_amd64\n             sandbox: false\n             target: x86_64-unknown-linux-gnu\n+            v8_cpu: x64\n             variant: release\n           - runner: ubuntu-24.04\n             bazel_config: ci-v8\n             platform: linux_amd64\n             sandbox: true\n             target: x86_64-unknown-linux-gnu\n+            v8_cpu: x64\n             variant: ptrcomp-sandbox\n           - runner: ubuntu-24.04-arm\n             bazel_config: ci-v8\n             platform: linux_arm64\n             sandbox: false\n             target: aarch64-unknown-linux-gnu\n+            v8_cpu: arm64\n             variant: release\n           - runner: ubuntu-24.04-arm\n             bazel_config: ci-v8\n             platform: linux_arm64\n             sandbox: true\n             target: aarch64-unknown-linux-gnu\n+            v8_cpu: arm64\n             variant: ptrco...",
+      "path": ".github/workflows/v8-canary.yml",
+      "status": "modified"
+    },
+    {
+      "additions": 16,
+      "deletions": 16,
+      "patch_excerpt": "@@ -415,18 +415,18 @@ crate.annotation(\n \n inject_repo(crate, \"alsa_lib\")\n \n-bazel_dep(name = \"v8\", version = \"14.7.173.20\")\n+bazel_dep(name = \"v8\", version = \"14.9.207.2\")\n archive_override(\n     module_name = \"v8\",\n-    integrity = \"sha256-v/x6I4X38a2wckzUIft3Dh0SUdkuOTokwxyF7lzW8Lc=\",\n+    integrity = \"sha256-tflbZE5srqal6leMxJjK/ZQtwpF96OMGJ6avd5lice4=\",\n     patch_strip = 3,\n     patches = [\n         \"//patches:v8_module_deps.patch\",\n         \"//patches:v8_bazel_rules.patch\",\n         \"//patches:v8_source_portability.patch\",\n     ],\n-    strip_prefix = \"v8-14.7.173.20\",\n-    urls = [\"https://github.com/v8/v8/archive/refs/tags/14.7.173.20.tar.gz\"],\n+    strip_prefix = \"v8-14.9.207.2\",\n+    urls = [\"https://github.com/v8/v8/archive/refs/tags/14.9.207.2.tar.gz\"],\n )\n \n http_archive(\n@@ -439,20 +439,20 @@ http_archive(\n )\n \n http_archive(\n-    name = \"v8_crate_147_4_0\",\n+    name = \"v8_...",
+      "path": "MODULE.bazel",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -1704,7 +1704,7 @@\n       \"utf8_iter_1.0.4\": \"{\\\"dependencies\\\":[],\\\"features\\\":{}}\",\n       \"utf8parse_0.2.2\": \"{\\\"dependencies\\\":[],\\\"features\\\":{\\\"default\\\":[],\\\"nightly\\\":[]}}\",\n       \"uuid_1.20.0\": \"{\\\"dependencies\\\":[{\\\"name\\\":\\\"arbitrary\\\",\\\"optional\\\":true,\\\"req\\\":\\\"^1.1.3\\\"},{\\\"default_features\\\":false,\\\"name\\\":\\\"atomic\\\",\\\"optional\\\":true,\\\"req\\\":\\\"^0.6\\\"},{\\\"default_features\\\":false,\\\"name\\\":\\\"borsh\\\",\\\"optional\\\":true,\\\"req\\\":\\\"^1\\\"},{\\\"default_features\\\":false,\\\"name\\\":\\\"borsh-derive\\\",\\\"optional\\\":true,\\\"req\\\":\\\"^1\\\"},{\\\"features\\\":[\\\"derive\\\"],\\\"name\\\":\\\"bytemuck\\\",\\\"optional\\\":true,\\\"req\\\":\\\"^1.20.0\\\"},{\\\"name\\\":\\\"getrandom\\\",\\\"optional\\\":true,\\\"req\\\":\\\"^0.3\\\",\\\"target\\\":\\\"cfg(not(all(target_arch = \\\\\\\"wasm32\\\\\\\", any(target_os = \\\\\\\"unknown\\\\\\\", target_os = \\\\\\\"none\\\\\\\"))))\\\"},{\\\"default_features\\\":false,\\\"name\\\":\\\"js-sys\\\",\\\"optional\\\":true,\\\"req\\\":\\\"^0.3\\\",\\\"target...",
+      "path": "MODULE.bazel.lock",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 2,
+      "patch_excerpt": "@@ -14064,9 +14064,9 @@ dependencies = [\n \n [[package]]\n name = \"v8\"\n-version = \"147.4.0\"\n+version = \"149.2.0\"\n source = \"registry+https://github.com/rust-lang/crates.io-index\"\n-checksum = \"2df8fffd507fb18ed000673a83d937f58e60fb07f3306b2274284125b15137cd\"\n+checksum = \"46dccf61a364b61bbaac70a8ba64a1a1006e87123b7d62eaeec999a3ba31ecdb\"\n dependencies = [\n  \"bindgen\",\n  \"bitflags 2.10.0\",",
+      "path": "codex-rs/Cargo.lock",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -424,7 +424,7 @@ unicode-width = \"0.2\"\n url = \"2\"\n urlencoding = \"2.1\"\n uuid = \"1\"\n-v8 = \"=147.4.0\"\n+v8 = \"=149.2.0\"\n vt100 = \"0.16.2\"\n walkdir = \"2.5.0\"\n webbrowser = \"1.0\"",
+      "path": "codex-rs/Cargo.toml",
+      "status": "modified"
+    },
+    {
+      "additions": 37,
+      "deletions": 38,
+      "patch_excerpt": "@@ -3,11 +3,11 @@\n # Scope: Bazel BUILD/defs/BUILD.icu integration only, including dependency\n # wiring, generated sources, and visibility; no standalone V8 source patching.\n \n-diff --git a/orig/v8-14.6.202.11/bazel/defs.bzl b/mod/v8-14.6.202.11/bazel/defs.bzl\n-index 9648e4a..88efd41 100644\n---- a/orig/v8-14.6.202.11/bazel/defs.bzl\n-+++ b/mod/v8-14.6.202.11/bazel/defs.bzl\n-@@ -33,9 +33,21 @@\n+diff --git a/orig/v8-14.9.207.2/bazel/defs.bzl b/mod/v8-14.9.207.2/bazel/defs.bzl\n+index bbe1495..6673518 100644\n+--- a/orig/v8-14.9.207.2/bazel/defs.bzl\n++++ b/mod/v8-14.9.207.2/bazel/defs.bzl\n+@@ -33,9 +33,21 @@ _create_option_int = rule(\n  )\n  \n  def v8_flag(name, default = False):\n@@ -32,7 +32,7 @@ index 9648e4a..88efd41 100644\n  \n  def v8_string(name, default = \"\"):\n      _create_option_string(name = name, build_setting_default = default)\n-@@ -97,7 +109,13 @@\n+@@ -97,7 +109,13 @@ v8_config = ru...",
+      "path": "patches/v8_bazel_rules.patch",
+      "status": "modified"
+    },
+    {
+      "additions": 82,
+      "deletions": 67,
+      "patch_excerpt": "@@ -3,14 +3,25 @@\n # Scope: upstream MODULE.bazel only; affects external repo resolution and Bazel\n # module wiring, not V8 source files.\n \n-diff --git a/orig/v8-14.6.202.11/MODULE.bazel b/mod/v8-14.6.202.11/MODULE.bazel\n---- a/orig/v8-14.6.202.11/MODULE.bazel\n-+++ b/mod/v8-14.6.202.11/MODULE.bazel\n-@@ -8,7 +8,65 @@\n+diff --git a/orig/v8-14.9.207.2/MODULE.bazel b/mod/v8-14.9.207.2/MODULE.bazel\n+index b8bf8bd..573f463 100644\n+--- a/orig/v8-14.9.207.2/MODULE.bazel\n++++ b/mod/v8-14.9.207.2/MODULE.bazel\n+@@ -8,193 +8,67 @@ bazel_dep(name = \"rules_cc\", version = \"0.2.0\")\n  bazel_dep(name = \"rules_python\", version = \"1.0.0\")\n  bazel_dep(name = \"platforms\", version = \"1.0.0\")\n  bazel_dep(name = \"abseil-cpp\", version = \"20250814.0\")\n -bazel_dep(name = \"highway\", version = \"1.2.0\")\n+-\n+-pip = use_extension(\"@rules_python//python/extensions:pip.bzl\", \"pip\")\n+-pip.parse(\n+-    hub_name = \"v8_python...",
+      "path": "patches/v8_module_deps.patch",
+      "status": "modified"
+    },
+    {
+      "additions": 39,
+      "deletions": 39,
+      "patch_excerpt": "@@ -2,10 +2,10 @@\n # Scope: minimal source-level portability fixes only, such as libexecinfo guards,\n # weak glibc symbol handling, and warning annotations; no dependency\n # include-path rewrites or intentional V8 feature changes.\n-diff --git a/orig/v8-14.6.202.11/src/base/bits.h b/mod/v8-14.6.202.11/src/base/bits.h\n+diff --git a/orig/v8-14.9.207.2/src/base/bits.h b/mod/v8-14.9.207.2/src/base/bits.h\n index 179a10f..4791e96 100644\n---- a/orig/v8-14.6.202.11/src/base/bits.h\n-+++ b/mod/v8-14.6.202.11/src/base/bits.h\n+--- a/orig/v8-14.9.207.2/src/base/bits.h\n++++ b/mod/v8-14.9.207.2/src/base/bits.h\n @@ -270,11 +270,17 @@ inline constexpr uint32_t RoundDownToPowerOfTwo32(uint32_t value) {\n  }\n  \n@@ -24,10 +24,10 @@ index 179a10f..4791e96 100644\n  inline constexpr uint32_t RotateLeft32(uint32_t value, uint32_t shift) {\n    return (value << shift) | (value >> ((32 - shift) & 31));\n  }\n-diff --g...",
+      "path": "patches/v8_source_portability.patch",
+      "status": "modified"
+    },
+    {
+      "additions": 115,
+      "deletions": 115,
+      "patch_excerpt": "@@ -30,26 +30,26 @@ config_setting(\n )\n \n alias(\n-    name = \"v8_147_4_0_x86_64_pc_windows_msvc\",\n-    actual = \"@rusty_v8_147_4_0_x86_64_pc_windows_msvc_archive//file\",\n+    name = \"v8_149_2_0_x86_64_pc_windows_msvc\",\n+    actual = \"@rusty_v8_149_2_0_x86_64_pc_windows_msvc_archive//file\",\n )\n \n alias(\n-    name = \"v8_147_4_0_aarch64_pc_windows_msvc\",\n-    actual = \"@rusty_v8_147_4_0_aarch64_pc_windows_msvc_archive//file\",\n+    name = \"v8_149_2_0_aarch64_pc_windows_msvc\",\n+    actual = \"@rusty_v8_149_2_0_aarch64_pc_windows_msvc_archive//file\",\n )\n \n alias(\n-    name = \"v8_147_4_0_aarch64_pc_windows_gnullvm\",\n+    name = \"v8_149_2_0_aarch64_pc_windows_gnullvm\",\n     # `rusty_v8` only ships prebuilt Windows archives for MSVC. Build the\n     # GNU-flavored archive in-tree so windows-gnullvm consumers can link\n     # against a matching ABI instead of trying to reuse the MSVC release.\n-    ac...",
+      "path": "third_party/v8/BUILD.bazel",
+      "status": "modified"
+    },
+    {
+      "additions": 23,
+      "deletions": 17,
+      "patch_excerpt": "@@ -5,23 +5,21 @@ Bazel consumer builds use:\n \n - upstream `denoland/rusty_v8` release archives on Windows MSVC\n - source-built V8 archives on Darwin, GNU Linux, musl Linux, and Windows GNU\n-- `openai/codex` release assets for published musl release pairs\n \n-Cargo builds still use prebuilt `rusty_v8` archives by default. Only Bazel\n-overrides `RUSTY_V8_ARCHIVE`/`RUSTY_V8_SRC_BINDING_PATH` in `MODULE.bazel` to\n-select source-built local archives for its consumer builds.\n+Local Cargo builds still use upstream prebuilt `rusty_v8` archives by default.\n+Selected Cargo CI, release, and package builds override\n+`RUSTY_V8_ARCHIVE`/`RUSTY_V8_SRC_BINDING_PATH` with Codex release assets. Bazel\n+sets those variables independently in `MODULE.bazel` to select source-built\n+local archives and bindings for its consumer builds.\n \n-Source-built Bazel V8 artifacts enable V8's in-process sandbox by default,...",
+      "path": "third_party/v8/README.md",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 1,
+      "patch_excerpt": "@@ -111,10 +111,11 @@ cc_runtime_stage0_library(\n         \"//conditions:default\": [\"-fPIC\"],\n     }),\n     defines = [\n-        \"CR_LIBCXX_REVISION=7ab65651aed6802d2599dcb7a73b1f82d5179d05\",\n+        \"CR_LIBCXX_REVISION=99457fa555797f8c5ac3c076ca288d8481d3b23a\",\n         \"LIBCXX_BUILDING_LIBCXXABI\",\n         \"LIBC_NAMESPACE=__llvm_libc_cr\",\n         \"_LIBCPP_BUILDING_LIBRARY\",\n+        \"_LIBCPP_CONSTINIT=constinit\",\n         \"_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS\",\n         \"_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE\",\n         \"_LIBCPP_INSTRUMENTED_WITH_ASAN=0\",",
+      "path": "third_party/v8/libcxx.BUILD.bazel",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -65,6 +65,7 @@ cc_runtime_stage0_library(\n     defines = [\n         \"LIBCXXABI_SILENT_TERMINATE\",\n         \"_LIBCPP_BUILDING_LIBRARY\",\n+        \"_LIBCPP_CONSTINIT=constinit\",\n         \"_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS\",\n         \"_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE\",\n         \"_LIBCPP_INSTRUMENTED_WITH_ASAN=0\",",
+      "path": "third_party/v8/libcxxabi.BUILD.bazel",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 2,
+      "patch_excerpt": "@@ -1,2 +0,0 @@\n-1fa3f94d9e09cff1f6bcce94c478e5cb072c0755f6a0357abadb9dd3b48d8127  rusty_v8_release_aarch64-pc-windows-msvc.lib.gz\n-e2827ff98b1a9d4c0343000fc5124ac30dfab3007bc0129c168c9355fc2fcd7c  rusty_v8_release_x86_64-pc-windows-msvc.lib.gz",
+      "path": "third_party/v8/rusty_v8_147_4_0.sha256",
+      "status": "removed"
+    },
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,2 @@\n+923f2b6ccdc14526b814e171e34c9aafd7969f12304948857c6696d022f0fb3c  rusty_v8_release_aarch64-pc-windows-msvc.lib.gz\n+12b5a791b54e92f748738ad8d0d12dad8d281a2d836638ad1aa6678e3b855d9a  rusty_v8_release_x86_64-pc-windows-msvc.lib.gz",
+      "path": "third_party/v8/rusty_v8_149_2_0.sha256",
+      "status": "added"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "",
+    "labels": [],
+    "merged_at": "2026-06-06T21:27:23Z",
+    "number": 26464,
+    "state": "merged",
+    "title": "build(v8): update rusty_v8 to 149.2.0",
+    "url": "https://github.com/openai/codex/pull/26464"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/impact/openai-codex-pr-24852.json
+++ b/artifacts/github/impact/openai-codex-pr-24852.json
@@ -1,0 +1,47 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-24852",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "permissions: enforce managed permission profile allowlists",
+        "url": "https://github.com/openai/codex/pull/24852",
+        "meta": "Merged 2026-06-06T01:06:30Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/24852",
+        "meta": "artifacts/github/reviews/openai-codex-pr-24852.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex replaces managed `allowed_permissions` arrays with mergeable `allowed_permission_profiles` maps plus explicit `default_permissions`, and exposes the new shape through app-server config requirements.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "The PR describes `allowed_permission_profiles` as a closed enterprise allowlist.",
+    "Config TOML and sourced requirements structs now use a `BTreeMap<String, bool>` and `default_permissions`.",
+    "App-server protocol schemas replace `allowedPermissions` with `allowedPermissionProfiles` and add `defaultPermissions`.",
+    "Config-loader tests cover denied omitted profiles, managed defaults, and standard-pair fallback behavior.",
+    "The review artifact records the compatibility risk for clients still expecting `allowedPermissions`."
+  ],
+  "candidate_followups": [
+    "Update any Decodex app-server config requirements parser that expects `allowedPermissions`.",
+    "Represent permission profile allowlists as keyed allow/deny maps in operator readbacks.",
+    "Explain the closed allowlist behavior publicly for enterprise operators."
+  ],
+  "social_notes": [
+    "Lead with the protocol and config-shape migration: list to keyed map plus explicit default.",
+    "Mention that omitted profiles are denied only when the allowlist is present.",
+    "Avoid implying legacy behavior changes when the allowlist is absent."
+  ],
+  "caveats": [
+    "The PR preserves legacy behavior when `allowed_permission_profiles` is absent.",
+    "The standard built-in pair fallback is compatibility behavior, not a recommended substitute for explicit defaults."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-25731.json
+++ b/artifacts/github/impact/openai-codex-pr-25731.json
@@ -1,0 +1,47 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-25731",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex-rs] support v2 personal access tokens",
+        "url": "https://github.com/openai/codex/pull/25731",
+        "meta": "Merged 2026-06-06T00:36:19Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/25731",
+        "meta": "artifacts/github/reviews/openai-codex-pr-25731.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex adds ChatGPT-backed personal access token authentication and exposes it through CLI status, model-provider routing, stored auth, and the app-server `personalAccessToken` auth mode.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "The PR adds PAT login through `codex login --with-access-token` and `CODEX_ACCESS_TOKEN`.",
+    "The app-server protocol schemas and Rust enum include the new `personalAccessToken` auth mode.",
+    "The app-server README says PAT auth is loaded outside app-server login RPCs.",
+    "Model-provider and TUI code paths use `AuthMode::has_chatgpt_account` so PATs are treated as ChatGPT-backed.",
+    "Tests cover PAT whoami hydration, stored auth, app-server auth status, and model-provider behavior."
+  ],
+  "candidate_followups": [
+    "Audit Decodex app-server clients for exhaustive `AuthMode` handling and add `personalAccessToken` where needed.",
+    "Represent PAT-backed ChatGPT auth distinctly in account readbacks while preserving ChatGPT-account capability grouping.",
+    "Use the PR as a public operator-impact explanation for app-server clients and programmatic Codex login."
+  ],
+  "social_notes": [
+    "Lead with the new `at-` token login path and the `personalAccessToken` app-server enum.",
+    "Mention that clients with exhaustive auth-mode handling need to add the case.",
+    "Avoid implying PAT metadata is cached permanently; the PR says startup hydrates through AuthAPI."
+  ],
+  "caveats": [
+    "PAT auth is ChatGPT-backed but not identical to OAuth refresh-token storage.",
+    "The v1 auth-status response still omits the raw PAT when token inclusion is requested."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-26013.json
+++ b/artifacts/github/impact/openai-codex-pr-26013.json
@@ -1,0 +1,45 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-26013",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Gate terminal visualization instructions in TUI",
+        "url": "https://github.com/openai/codex/pull/26013",
+        "meta": "Merged 2026-06-06T00:23:46Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/26013",
+        "meta": "artifacts/github/reviews/openai-codex-pr-26013.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex adds a disabled-by-default TUI feature that appends terminal-specific visualization instructions to TUI thread start, resume, and fork developer instructions.",
+  "public_signal_decision": "defer",
+  "control_plane_impact": "watch",
+  "publisher_angle": "watch_note",
+  "confidence": "confirmed",
+  "evidence": [
+    "The PR body says no default user receives the new terminal-specific instructions.",
+    "The feature catalog marks `TerminalVisualizationInstructions` as `UnderDevelopment` and default disabled.",
+    "The helper text is wired into TUI thread parameter construction rather than `codex exec`.",
+    "The review artifact records the feature gate and rollout caveats."
+  ],
+  "candidate_followups": [
+    "Track whether Codex promotes `terminal_visualization_instructions` beyond the initial cohort.",
+    "Avoid labeling terminal visualization instructions as a general Codex capability in Decodex release summaries.",
+    "If the gate broadens, revisit Decodex terminal-output guidance and public explanation value."
+  ],
+  "social_notes": [
+    "Any public copy must lead with the disabled-by-default and dogfood-gated status.",
+    "Frame this as a watch note, not a try-it-now feature."
+  ],
+  "caveats": [
+    "The behavior is TUI-only and intentionally not applied to `codex exec`.",
+    "The PR references separate model-layer treatment and future eval gates before broadening."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-26464.json
+++ b/artifacts/github/impact/openai-codex-pr-26464.json
@@ -1,0 +1,44 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-26464",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "build(v8): update rusty_v8 to 149.2.0",
+        "url": "https://github.com/openai/codex/pull/26464",
+        "meta": "Merged 2026-06-06T21:27:23Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/26464",
+        "meta": "artifacts/github/reviews/openai-codex-pr-26464.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex updates its V8 and `rusty_v8` build inputs to 149.2.0, refreshes Bazel patches and release workflows, and replaces the checked Windows artifact hashes.",
+  "public_signal_decision": "skip",
+  "control_plane_impact": "watch",
+  "publisher_angle": "none",
+  "confidence": "confirmed",
+  "evidence": [
+    "Cargo pins `v8` to `=149.2.0`.",
+    "MODULE.bazel moves the V8 source archive to 14.9.207.2.",
+    "Release and canary workflows add `v8_cpu` matrix settings.",
+    "The third_party/v8 artifact aliases and sha256 file names move from 147.4.0 to 149.2.0.",
+    "The review artifact limits the claim to build and release packaging because the PR body is empty."
+  ],
+  "candidate_followups": [
+    "Use this as release-rollup background if a Codex release highlights V8 or builder changes.",
+    "Watch for upstream build or runtime regressions that reference the 149.2.0 V8 baseline."
+  ],
+  "social_notes": [
+    "Do not publish this as a standalone post without additional user-facing release evidence."
+  ],
+  "caveats": [
+    "No direct app-server, CLI, or user workflow behavior is established by this PR alone.",
+    "The PR body is empty, so confidence is about the dependency and packaging change, not product behavior."
+  ]
+}

--- a/artifacts/github/review-queue/openai-codex-latest.json
+++ b/artifacts/github/review-queue/openai-codex-latest.json
@@ -1,14 +1,14 @@
 {
   "counts": {
-    "critical": 19,
-    "high": 4,
+    "critical": 20,
+    "high": 6,
     "low": 1,
-    "normal": 16,
+    "normal": 13,
     "published_subjects_seen": 0,
     "recent_commits_scanned": 40,
     "subjects_queued": 40
   },
-  "generated_at": "2026-06-08T14:06:05.15617Z",
+  "generated_at": "2026-06-08T20:05:40.801953Z",
   "repo": "openai/codex",
   "schema": "upstream_review_queue/v1",
   "source": {
@@ -17,124 +17,6 @@
     "signals_dir": "site/src/content/signals"
   },
   "subjects": [
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 6,
-      "commit_shas": [
-        "acf4f7a893034a677d89703bc6236842b923ee23"
-      ],
-      "committed_at": "2026-06-05T17:07:25Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26449,
-      "pr_url": "https://github.com/openai/codex/pull/26449",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/app-server-protocol/src/protocol/v2/remote_control.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/enroll.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/mod.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/protocol.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/tests.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/tests/pairing_tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26449",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "tests_ci"
-      ],
-      "title": "feat(remote-control): add pairing status transport",
-      "url": "https://github.com/openai/codex/pull/26449"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 8,
-      "commit_shas": [
-        "7d3240b290464a9102fd68f4438c1bd7ecb2431d"
-      ],
-      "committed_at": "2026-06-05T17:33:56Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26450,
-      "pr_url": "https://github.com/openai/codex/pull/26450",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server-protocol/src/export.rs",
-        "codex-rs/app-server-protocol/src/protocol/common.rs",
-        "codex-rs/app-server/README.md",
-        "codex-rs/app-server/src/message_processor.rs",
-        "codex-rs/app-server/src/request_processors/remote_control_processor.rs",
-        "codex-rs/app-server/src/request_processors/remote_control_processor/remote_control_processor_tests.rs",
-        "codex-rs/app-server/tests/common/test_app_server.rs",
-        "codex-rs/app-server/tests/suite/v2/remote_control.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26450",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "docs_examples",
-        "tests_ci"
-      ],
-      "title": "feat(app-server): add remote control pairing status RPC",
-      "url": "https://github.com/openai/codex/pull/26450"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 9,
-      "commit_shas": [
-        "1069e2b232186a41062acb09e6a8618bf38f39c0",
-        "e81eeb17681260aa57a674008396a9f28c72b523",
-        "733bce9026a455d58beb3767aa1b776ebefb35b8",
-        "a4ae296709b6b998f5084fdbd977165a59ef1f82",
-        "ec258935d84587f16b1dd7ce7c6dfa986ad9a113",
-        "ca363cb953a62ef24d7b3e0ab845b77d8995c973",
-        "c86ad28615e8eff9a0e7bce6243093e2c645566e"
-      ],
-      "committed_at": "2026-06-05T18:20:52Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26307,
-      "pr_url": "https://github.com/openai/codex/pull/26307",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/core/src/exec_policy.rs",
-        "codex-rs/core/src/exec_policy_tests.rs",
-        "codex-rs/core/src/exec_policy_windows_tests.rs",
-        "codex-rs/core/src/session/tests.rs",
-        "codex-rs/core/src/tools/handlers/shell.rs",
-        "codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs",
-        "codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs",
-        "codex-rs/core/src/unified_exec/process_manager.rs",
-        "codex-rs/core/tests/suite/exec_policy.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26307",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "sandbox_permissions",
-        "tests_ci"
-      ],
-      "title": "[codex] Respect Windows sandbox backend in exec policy",
-      "url": "https://github.com/openai/codex/pull/26307"
-    },
     {
       "attention_flags": [
         "auth_account",
@@ -849,6 +731,163 @@
     },
     {
       "attention_flags": [
+        "deprecated_removed",
+        "new_feature",
+        "release_packaging"
+      ],
+      "changed_file_count": 4,
+      "commit_shas": [
+        "95202ed2120c490f12f954daeb9ca8167f4e6dc8",
+        "c7f7ad74df9090665b12869705c54268794d289d",
+        "69c1858bc0c90ef389b581719229395e42676ed3",
+        "0fd91f10f38d70146f7b1d6ed6a3df34207c97cd",
+        "c7a47e5b23d8f0bf2742a052139eda48ab4982d6"
+      ],
+      "committed_at": "2026-06-08T17:16:36Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26202,
+      "pr_url": "https://github.com/openai/codex/pull/26202",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, release_packaging.",
+      "sample_paths": [
+        ".github/scripts/archive-release-symbols-and-strip-binaries.sh",
+        ".github/workflows/rust-release-windows.yml",
+        ".github/workflows/rust-release.yml",
+        "codex-rs/Cargo.toml"
+      ],
+      "source_state": "merged",
+      "subject_id": "26202",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "config_hooks",
+        "release_packaging",
+        "tests_ci"
+      ],
+      "title": "[codex] Restore release symbol artifacts with line tables",
+      "url": "https://github.com/openai/codex/pull/26202"
+    },
+    {
+      "attention_flags": [
+        "breaking_change",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 10,
+      "commit_shas": [
+        "3a77fbcc7217e2a49e7447017ac4932625e55912",
+        "cbb1d21dfa72d84973bcc8b58a6deaca53808e0f",
+        "2a416e92a12e43d044e4a39096f1825a29b11d3f",
+        "1188ee05a5b82e99bc653820a27c8830d66ab7bf",
+        "fd0f44bb07220d2ae600bca3c38b2af596ae21e1",
+        "583174aca7660c1a872ac7aead5abb335dec1f65"
+      ],
+      "committed_at": "2026-06-08T18:16:32Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26637,
+      "pr_url": "https://github.com/openai/codex/pull/26637",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for breaking_change, new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/app-server/src/message_processor.rs",
+        "codex-rs/app-server/src/request_processors.rs",
+        "codex-rs/app-server/src/request_processors/external_agent_config_processor.rs",
+        "codex-rs/app-server/src/request_processors/external_agent_session_import.rs",
+        "codex-rs/app-server/tests/suite/v2/external_agent_config.rs",
+        "codex-rs/external-agent-sessions/src/export.rs",
+        "codex-rs/external-agent-sessions/src/ledger.rs",
+        "codex-rs/external-agent-sessions/src/ledger_tests.rs",
+        "codex-rs/external-agent-sessions/src/lib.rs",
+        "codex-rs/external-agent-sessions/src/records.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26637",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "config_hooks",
+        "tests_ci"
+      ],
+      "title": "[codex] Speed up external agent session imports",
+      "url": "https://github.com/openai/codex/pull/26637"
+    },
+    {
+      "attention_flags": [
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 3,
+      "commit_shas": [
+        "a4520a312a6ac3509088827dc96bc5c20ec96ef6"
+      ],
+      "committed_at": "2026-06-08T18:37:55Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27009,
+      "pr_url": "https://github.com/openai/codex/pull/27009",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/cli/src/marketplace_cmd.rs",
+        "codex-rs/cli/src/plugin_cmd.rs",
+        "codex-rs/cli/tests/plugin_cli.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27009",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "[plugins] Expose marketplace source in marketplace list JSON",
+      "url": "https://github.com/openai/codex/pull/27009"
+    },
+    {
+      "attention_flags": [
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 8,
+      "commit_shas": [
+        "d6528ccc954f1768a3d7d080bba8162b59d982a1",
+        "bf84a984d0233936cf29c72dd60d704b9182d569",
+        "8e14f2d413ef8a826d45a0602573148c6c7ac358"
+      ],
+      "committed_at": "2026-06-08T18:59:50Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26230,
+      "pr_url": "https://github.com/openai/codex/pull/26230",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server-protocol/src/protocol/v2/shared.rs",
+        "codex-rs/app-server-protocol/src/protocol/v2/tests.rs",
+        "codex-rs/config/src/loader/mod.rs",
+        "codex-rs/core/src/tools/handlers/multi_agents_common.rs",
+        "codex-rs/core/src/tools/handlers/multi_agents_tests.rs",
+        "codex-rs/protocol/src/config_types.rs",
+        "codex-rs/tui/src/app/tests.rs",
+        "codex-rs/tui/src/debug_config.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26230",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "config_hooks",
+        "tests_ci"
+      ],
+      "title": "fix: preserve auto review across config and delegation",
+      "url": "https://github.com/openai/codex/pull/26230"
+    },
+    {
+      "attention_flags": [
         "auth_account",
         "new_feature",
         "protocol_change",
@@ -976,228 +1015,75 @@
     },
     {
       "attention_flags": [
-        "deprecated_removed",
+        "auth_account",
         "new_feature",
         "protocol_change"
       ],
-      "changed_file_count": 2,
+      "changed_file_count": 5,
       "commit_shas": [
-        "64559982ae8bfe5f7b19c26d78f9f9bd31fb7e96"
+        "0fa7186cf9f9db8b60e308d369381ab4f076905b",
+        "42fb873e7ca5bc1d7661414db1299490198d52bd",
+        "6c10ca4be59c4270fcb9f4a03a73baa794b28da2",
+        "0c649e5492e4ee174f5b4942c9a26ee3e561a322"
       ],
-      "committed_at": "2026-06-05T16:38:26Z",
+      "committed_at": "2026-06-08T17:20:54Z",
       "next_step": "ai_review_required",
-      "pr_number": 26538,
-      "pr_url": "https://github.com/openai/codex/pull/26538",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change.",
+      "pr_number": 26852,
+      "pr_url": "https://github.com/openai/codex/pull/26852",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
       "sample_paths": [
-        "AGENTS.md",
-        "codex-rs/shell-command/src/shell_detect.rs"
+        "codex-rs/app-server/src/connection_cleanup.rs",
+        "codex-rs/app-server/src/connection_rpc_gate.rs",
+        "codex-rs/app-server/src/lib.rs",
+        "codex-rs/app-server/src/message_processor.rs",
+        "codex-rs/app-server/src/request_serialization.rs"
       ],
       "source_state": "merged",
-      "subject_id": "26538",
+      "subject_id": "26852",
       "subject_kind": "pr",
       "surface_hints": [
-        "internal_churn"
+        "app_server_protocol"
       ],
-      "title": "[codex] Add /usr/bin/bash shell fallback",
-      "url": "https://github.com/openai/codex/pull/26538"
+      "title": "fix(app-server): avoid blocking connection cleanup",
+      "url": "https://github.com/openai/codex/pull/26852"
     },
     {
       "attention_flags": [
         "auth_account",
-        "deprecated_removed",
         "new_feature",
         "protocol_change",
         "security_policy"
       ],
-      "changed_file_count": 6,
+      "changed_file_count": 5,
       "commit_shas": [
-        "776fcabcb9ff6b9f1303ed190ce6c00b69a52edf",
-        "e0d32deb6daf4a09397d8dee18add6a08311925b",
-        "cca17acda1781cee574cce3d102d81aec6d05f18",
-        "79061c35a6804b4bc8605e40662eb3b6bc6b09d1",
-        "031957bf64fee0de9aa06f686aa0ae02f1542fc4",
-        "99ea17ed6e503ddfc0157f88410f4fa762c852c0",
-        "fd1ff88a0f75d86d34f9e62d6ca39828571fd8ef",
-        "fe84ef98d9f8c09e5b6b25e4ee51dd9b6eddb80e"
+        "c6e9b6f312775a7013c56050f5ecf38a3c4ac476",
+        "bdd975fb8c969040ca1647f23555641ae9b7b76b",
+        "219baef3c22457b3febaeaf3af1bef44fb5f7ef2"
       ],
-      "committed_at": "2026-06-05T17:31:22Z",
+      "committed_at": "2026-06-08T17:49:59Z",
       "next_step": "ai_review_required",
-      "pr_number": 26433,
-      "pr_url": "https://github.com/openai/codex/pull/26433",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "pr_number": 26923,
+      "pr_url": "https://github.com/openai/codex/pull/26923",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/core/src/session/turn.rs",
-        "codex-rs/core/src/tools/events.rs",
-        "codex-rs/core/src/tools/handlers/apply_patch.rs",
-        "codex-rs/core/src/turn_diff_tracker.rs",
-        "codex-rs/core/src/turn_diff_tracker_tests.rs",
-        "codex-rs/core/tests/suite/apply_patch_cli.rs"
+        "codex-rs/core/src/client.rs",
+        "codex-rs/core/tests/responses_headers.rs",
+        "codex-rs/core/tests/suite/compact_remote.rs",
+        "codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_api_auth_prompt_cache_key_request_diff.snap",
+        "codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_chatgpt_auth_service_tier_prompt_cache_key_request_diff.snap"
       ],
       "source_state": "merged",
-      "subject_id": "26433",
+      "subject_id": "26923",
       "subject_kind": "pr",
       "surface_hints": [
+        "auth_accounts",
         "cli_tui",
         "tests_ci"
       ],
-      "title": "Make turn diff tracker multi-env aware",
-      "url": "https://github.com/openai/codex/pull/26433"
-    },
-    {
-      "attention_flags": [
-        "new_feature"
-      ],
-      "changed_file_count": 2,
-      "commit_shas": [
-        "f8a86c88f56348b6bc8205039078d9e85f1f1ea2"
-      ],
-      "committed_at": "2026-06-05T17:33:31Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26636,
-      "pr_url": "https://github.com/openai/codex/pull/26636",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature.",
-      "sample_paths": [
-        "codex-rs/tui/src/history_cell/messages.rs",
-        "codex-rs/tui/src/history_cell/tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26636",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "tests_ci"
-      ],
-      "title": "fix(tui): avoid doubled blank rows while streaming",
-      "url": "https://github.com/openai/codex/pull/26636"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "deprecated_removed",
-        "release_packaging"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "6edb920aa9d5b3d4d34b0cf415528de65fb03c44"
-      ],
-      "committed_at": "2026-06-05T17:36:14Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26335,
-      "pr_url": "https://github.com/openai/codex/pull/26335",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for breaking_change, deprecated_removed, release_packaging.",
-      "sample_paths": [
-        ".github/workflows/rust-release.yml"
-      ],
-      "source_state": "merged",
-      "subject_id": "26335",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "Clean up Rust release workflow",
-      "url": "https://github.com/openai/codex/pull/26335"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 4,
-      "commit_shas": [
-        "919dbbefd1b2a627da577cd7441ce25907d16c73",
-        "22626f84dcd756a47f05cf6dfdd79a88c8e8db48",
-        "1b3099736864afa15768b285925433b47a8127f7",
-        "a0db64911d288a2a27996b1dcc0daa28b7f95d57"
-      ],
-      "committed_at": "2026-06-05T17:37:38Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26547,
-      "pr_url": "https://github.com/openai/codex/pull/26547",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/ext/goal/src/api.rs",
-        "codex-rs/ext/goal/src/lib.rs",
-        "codex-rs/ext/goal/src/runtime.rs",
-        "codex-rs/ext/goal/src/spec.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26547",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "internal_churn"
-      ],
-      "title": "[1 of 2] Align goal extension with core behavior",
-      "url": "https://github.com/openai/codex/pull/26547"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "new_feature"
-      ],
-      "changed_file_count": 3,
-      "commit_shas": [
-        "38efaa1fe374429cb96f6fbcfa07fcce243b4f38",
-        "af05533ba811e4d534cd0e9db82fe24f13db07c2",
-        "29030fdde2b4eae687b3069065b0086756b4fb37",
-        "051fed6668f3797db120bdad8944140b36d39838"
-      ],
-      "committed_at": "2026-06-05T18:05:46Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26181,
-      "pr_url": "https://github.com/openai/codex/pull/26181",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature.",
-      "sample_paths": [
-        "codex-rs/tui/src/terminal_palette.rs",
-        "codex-rs/tui/src/terminal_probe.rs",
-        "codex-rs/tui/src/tui.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26181",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui"
-      ],
-      "title": "fix(tui): Windows composer background",
-      "url": "https://github.com/openai/codex/pull/26181"
-    },
-    {
-      "attention_flags": [
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 3,
-      "commit_shas": [
-        "b7367f965a0c0102bef69d3c02e4a177b5fee615"
-      ],
-      "committed_at": "2026-06-05T18:10:13Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26457,
-      "pr_url": "https://github.com/openai/codex/pull/26457",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/tui/src/bottom_pane/chat_composer.rs",
-        "codex-rs/tui/src/bottom_pane/mod.rs",
-        "codex-rs/tui/src/chatwidget/tests/composer_submission.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26457",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "tests_ci"
-      ],
-      "title": "fix(tui): restore cancelled prompt cursor at end",
-      "url": "https://github.com/openai/codex/pull/26457"
+      "title": "Add HTTP window ID to Responses client metadata",
+      "url": "https://github.com/openai/codex/pull/26923"
     },
     {
       "attention_flags": [
@@ -1513,6 +1399,151 @@
       ],
       "title": "Rename multi-agent v2 close_agent to interrupt_agent",
       "url": "https://github.com/openai/codex/pull/26994"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 4,
+      "commit_shas": [
+        "ab28c845a6a812549468c13e6d0022137c2ec52b",
+        "e61af26e42492f46a5178d5d023e0d6110d3ba0d",
+        "0b007fe89fad0510f6d110dd4e8a5e06d79a7214",
+        "74b3fb4726959890deb0dbe821842dbf9fe578be",
+        "b123fcecff1d293c20af985c9046b7e80ee7fb23",
+        "cd299c10b1200f8ceb0dc87bc40c7670363e96fe",
+        "9bf5709bb08e9448010ea67be362f9eb4cc97f2c",
+        "6bd602db71ecce6f4d549ce823f34668931e7085",
+        "fb4e3d143345e7baa9f8d324bebc130d725550e2"
+      ],
+      "committed_at": "2026-06-08T14:44:50Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26997,
+      "pr_url": "https://github.com/openai/codex/pull/26997",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/core/src/agent/control/residency.rs",
+        "codex-rs/core/src/agent/control/residency_tests.rs",
+        "codex-rs/core/src/agent/control/spawn.rs",
+        "codex-rs/core/src/agent/control_tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26997",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "Avoid reopening v2 descendants on resume",
+      "url": "https://github.com/openai/codex/pull/26997"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 4,
+      "commit_shas": [
+        "f23db2d6caf90384ede49d91ed7c95dbe31f2970",
+        "d9c87f3d713dd5bf146b7194e484e149c1809b0d",
+        "3cfd7f95deed730ac107b61a709300a08842135d",
+        "66dc1f9e1617d1932832c2fa0ee9ddaf51c788ad"
+      ],
+      "committed_at": "2026-06-08T16:53:04Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26821,
+      "pr_url": "https://github.com/openai/codex/pull/26821",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/src/tools/registry.rs",
+        "codex-rs/core/tests/suite/sqlite_state.rs",
+        "codex-rs/ext/web-search/src/output.rs",
+        "codex-rs/tools/src/tool_output.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26821",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "[codex] Exclude external tool output from memories",
+      "url": "https://github.com/openai/codex/pull/26821"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 6,
+      "commit_shas": [
+        "78ec3d1c6525f83653a2d63ccc6e9e4a8fadc664"
+      ],
+      "committed_at": "2026-06-08T17:52:31Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26680,
+      "pr_url": "https://github.com/openai/codex/pull/26680",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/analytics/src/analytics_client_tests.rs",
+        "codex-rs/analytics/src/events.rs",
+        "codex-rs/analytics/src/facts.rs",
+        "codex-rs/core/src/compact.rs",
+        "codex-rs/core/src/compact_remote.rs",
+        "codex-rs/core/src/compact_remote_v2.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26680",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "[codex-analytics] report compaction analytics details",
+      "url": "https://github.com/openai/codex/pull/26680"
+    },
+    {
+      "attention_flags": [
+        "breaking_change",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 7,
+      "commit_shas": [
+        "fe72ccd18a05ea467d8baf65286ca4e6c4156bd1"
+      ],
+      "committed_at": "2026-06-08T18:47:23Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27024,
+      "pr_url": "https://github.com/openai/codex/pull/27024",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for breaking_change, protocol_change, release_packaging.",
+      "sample_paths": [
+        ".github/workflows/bazel.yml",
+        ".github/workflows/rust-ci-full.yml",
+        ".github/workflows/rust-ci.yml",
+        ".github/workflows/rust-release-argument-comment-lint.yml",
+        ".github/workflows/rust-release-windows.yml",
+        ".github/workflows/rust-release.yml",
+        ".github/workflows/sdk.yml"
+      ],
+      "source_state": "merged",
+      "subject_id": "27024",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "release_packaging",
+        "tests_ci"
+      ],
+      "title": "ci: template custom runner names by repo",
+      "url": "https://github.com/openai/codex/pull/27024"
     },
     {
       "attention_flags": [

--- a/artifacts/github/reviews/openai-codex-pr-24852.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-24852.review.json
@@ -1,0 +1,75 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-24852",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "24852",
+    "commit_shas": [
+      "d4bf7bafbaf7a1ae72427606319afa6b3465c80b",
+      "26b0a07d3a66589dbd3595d1eb9cfa1f43dce1cb",
+      "ec6d5a352a5c71b3eb47bf9dfaa3474a7cd45c38",
+      "d70eda07414e169b9e93e7787b55bb637168533c",
+      "4379a32b69fc770f27e0c843ca391e377eb6c198",
+      "511bc0ec1f015e95f4c282815a16d2aad75e6b29",
+      "c330349b3c98b701d7fa60fe1b6c612115ee9db4",
+      "bc249ef5b32f3883950892d1ec03fe165a746130"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "permissions: enforce managed permission profile allowlists",
+        "url": "https://github.com/openai/codex/pull/24852",
+        "meta": "Merged 2026-06-06T01:06:30Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Enforce permission profile defaults and allowlists",
+        "url": "https://github.com/openai/codex/commit/d4bf7bafbaf7a1ae72427606319afa6b3465c80b"
+      },
+      {
+        "kind": "commit",
+        "title": "fix(permissions): make managed map a strict allowlist",
+        "url": "https://github.com/openai/codex/commit/511bc0ec1f015e95f4c282815a16d2aad75e6b29"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-08T20:07:03Z",
+  "observed_change": "Codex replaces managed `allowed_permissions` arrays with mergeable `allowed_permission_profiles` maps plus explicit `default_permissions`, and exposes the new shape through app-server config requirements.",
+  "changed_surfaces": [
+    "managed requirements TOML schema and merge behavior",
+    "permission-profile default selection",
+    "app-server configRequirements/read response schema",
+    "TypeScript app-server protocol types",
+    "config and app-server regression tests"
+  ],
+  "user_visible_path": "Enterprise-managed Codex configurations can define a closed permission-profile allowlist where missing or false profiles are denied and `default_permissions` must resolve to an allowed profile; app-server clients now read `allowedPermissionProfiles` and `defaultPermissions` instead of an `allowedPermissions` list.",
+  "control_plane_relevance": "Decodex must treat managed permission profiles as a keyed allow map and default profile constraint when rendering or enforcing operator permission options.",
+  "compatibility_risk": "App-server clients expecting `allowedPermissions: string[]` can break or silently miss restrictions because the response now uses `allowedPermissionProfiles: object` and `defaultPermissions`.",
+  "adoption_opportunity": "Update Decodex permission/readback models to show denied, allowed, inherited, and default permission profiles from the new map form.",
+  "community_value": "High operator value because the change turns enterprise permission profiles into a closed allowlist and changes the app-server config requirements contract.",
+  "deprecated_or_breaking_notes": "`allowedPermissions` is replaced by `allowedPermissionProfiles`; omitted built-in and future profiles are denied when the allowlist is present, and custom allowlists require an allowed default.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #24852 says `allowed_permission_profiles` is a closed allow map where true allows, false revokes, and missing profiles are denied.",
+    "codex-rs/config/src/config_requirements.rs changes `allowed_permissions` to `allowed_permission_profiles: BTreeMap<String, bool>` and adds `default_permissions`.",
+    "codex-rs/app-server-protocol/src/protocol/v2/config.rs replaces `allowed_permissions` with `allowed_permission_profiles` and `default_permissions`.",
+    "The generated JSON and TypeScript schemas expose `allowedPermissionProfiles` as an object and add `defaultPermissions`.",
+    "codex-rs/app-server/src/request_processors/config_processor.rs maps the new TOML fields into the app-server API.",
+    "codex-rs/core/src/config/config_loader_tests.rs adds coverage for managed defaults, strict denial, and the standard built-in pair.",
+    "The normalized bundle artifacts/github/bundles/openai-codex-pr-24852.json records 15 changed files for the merged PR."
+  ],
+  "caveats": "When `allowed_permission_profiles` is absent, the PR says existing implicit permission and legacy sandbox behavior is unchanged.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The app-server config requirements shape and enterprise permission semantics affect Decodex Control Plane compatibility."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The closed allowlist and API-shape change are concrete operator-facing material for a public explanation."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-25731.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-25731.review.json
@@ -1,0 +1,95 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-25731",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "25731",
+    "commit_shas": [
+      "52e8322d26b0dcab311fc69051d7c65c1c9b0bad",
+      "102b651347bcc5bab8c141521feb98a86ab0aa60",
+      "4097f5e2f5e16432316bfeef391e8c0c8fe47048",
+      "4e508fdf0ee94f6cdc2d2fe2a8e7730157e964f9",
+      "bb3aa3c8c75303e86cf3cd9ef34f74522a0ad600",
+      "56418b3f60d2cda53f5dddf1dfb1de3ec3aae2fb",
+      "1e253161298656cd877257c342c66aede39a5f35",
+      "8b4619b3f39c3bc84248a5c2d5068d94b7e04dc5",
+      "78517260e070b17b17a2612185c8fb3c9c7de944",
+      "96cb93cf0de4270210f1511e59a7cedc4913ec16",
+      "691c1eb82b2a743f377df192670f3ed5845e312c",
+      "de7e938c6d9da77943dcb19c88c4a32d6b677382",
+      "c7d13639a2ab58a67ac608e190602c472eab6b82",
+      "d0eacff64b1c1eb61b1c54b782fb0ff9ae5f8bf9",
+      "dd0336b089d4f28af8a2adfea8ffea52a395992a",
+      "9f1db458fd1f61f692735a78f6b81f4b36b69ee1",
+      "3070fdea6338f7701fcea3f71508779c20c147ac",
+      "41c090349d5496ac038a6513474bc50303d9c0c9",
+      "086ab2b05d1ae1592ca49594eebb56048cbd6ecf",
+      "8a0e4f3c2abe7099d81a41922972bfcebfecdff7",
+      "c4a77fe492b717c4b4c8643cd1811eec41e2dcfe",
+      "2008f30c7de3ae4a1a9790cc7acad6f0955b956f"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex-rs] support v2 personal access tokens",
+        "url": "https://github.com/openai/codex/pull/25731",
+        "meta": "Merged 2026-06-06T00:36:19Z"
+      },
+      {
+        "kind": "commit",
+        "title": "[codex-rs] support v2 personal access tokens",
+        "url": "https://github.com/openai/codex/commit/52e8322d26b0dcab311fc69051d7c65c1c9b0bad"
+      },
+      {
+        "kind": "commit",
+        "title": "[codex-rs] expose personal access token auth mode",
+        "url": "https://github.com/openai/codex/commit/8b4619b3f39c3bc84248a5c2d5068d94b7e04dc5"
+      },
+      {
+        "kind": "commit",
+        "title": "[codex-rs] infer PAT auth in doctor",
+        "url": "https://github.com/openai/codex/commit/2008f30c7de3ae4a1a9790cc7acad6f0955b956f"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-08T20:07:03Z",
+  "observed_change": "Codex adds ChatGPT-backed personal access token authentication and exposes it through CLI status, model-provider routing, stored auth, and the app-server `personalAccessToken` auth mode.",
+  "changed_surfaces": [
+    "login and access-token classification",
+    "AuthDotJson storage and doctor/login status",
+    "app-server protocol AuthMode schema and README",
+    "model provider and models manager ChatGPT-account detection",
+    "TUI account display and onboarding handling"
+  ],
+  "user_visible_path": "Users can supply an `at-` personal access token through `codex login --with-access-token` or `CODEX_ACCESS_TOKEN`; Codex hydrates ChatGPT account metadata through AuthAPI, reports PAT auth in CLI status, and surfaces `personalAccessToken` through app-server auth status.",
+  "control_plane_relevance": "Decodex app-server and account-pool integrations need to recognize `personalAccessToken` as a ChatGPT-backed auth mode and avoid exhaustive enum handling that treats it as unknown.",
+  "compatibility_risk": "Clients that exhaustively handle app-server `AuthMode` values can break or misclassify accounts unless they add `personalAccessToken`; the PR explicitly removed a temporary v1 compatibility mapping.",
+  "adoption_opportunity": "Add PAT-aware account readbacks and Control Plane documentation so Decodex can distinguish PAT-backed ChatGPT auth from OAuth tokens and legacy Agent Identity tokens.",
+  "community_value": "High practical value because it documents a new programmatic login path, live metadata hydration, and an app-server auth-mode change that downstream clients must handle.",
+  "deprecated_or_breaking_notes": "The v1 and v2 app-server auth-mode enums now include `personalAccessToken`; the PR notes exhaustive clients must add the case, while persisted auth omits the enum value for rollback compatibility.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #25731 says Codex supports v2 personal access tokens for `codex login --with-access-token` and `CODEX_ACCESS_TOKEN`.",
+    "codex-rs/login/src/auth/access_token.rs classifies `at-` tokens as personal access tokens instead of Agent Identity JWTs.",
+    "codex-rs/login/src/auth/personal_access_token.rs adds AuthAPI `/v1/user-auth-credential/whoami` hydration and stores metadata in the auth object.",
+    "codex-rs/app-server-protocol/src/protocol/common.rs adds `AuthMode::PersonalAccessToken` and `has_chatgpt_account`.",
+    "codex-rs/app-server/README.md documents `personalAccessToken` as a supported auth mode loaded outside app-server login RPCs.",
+    "codex-rs/cli/src/login.rs and codex-rs/cli/src/doctor.rs add PAT-specific status and stored-auth reporting.",
+    "Model-provider, models-manager, TUI account display, and onboarding paths now treat personal access tokens as ChatGPT-backed account state.",
+    "The normalized bundle artifacts/github/bundles/openai-codex-pr-25731.json records 42 changed files and PAT-focused tests."
+  ],
+  "caveats": "PAT metadata is hydrated live and is not a persisted reusable account cache; forced workspace restrictions and rollback behavior have specific caveats described in the PR.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The new app-server AuthMode and login path affect Decodex Control Plane compatibility."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The PR has a clear public operator-impact angle for PAT login and app-server clients."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-26013.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-26013.review.json
@@ -1,0 +1,68 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-26013",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "26013",
+    "commit_shas": [
+      "a52f7e1e2e945a2facea65781ba429f04524a477",
+      "a323a5101b5aa61af6e0c1cecaf5da04391bfa44",
+      "f249259c64745fed22c706240526d7797fdc6691"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Gate terminal visualization instructions in TUI",
+        "url": "https://github.com/openai/codex/pull/26013",
+        "meta": "Merged 2026-06-06T00:23:46Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Gate terminal visualization instructions in TUI",
+        "url": "https://github.com/openai/codex/commit/a52f7e1e2e945a2facea65781ba429f04524a477"
+      },
+      {
+        "kind": "commit",
+        "title": "Fix terminal visualization CI",
+        "url": "https://github.com/openai/codex/commit/a323a5101b5aa61af6e0c1cecaf5da04391bfa44"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-08T20:07:03Z",
+  "observed_change": "Codex adds a disabled-by-default TUI feature that appends terminal-specific visualization instructions to TUI thread start, resume, and fork developer instructions.",
+  "changed_surfaces": [
+    "feature flag catalog and config schema",
+    "TUI thread start, resume, and fork developer-instruction assembly",
+    "new terminal visualization instruction helper",
+    "TUI-focused validation coverage"
+  ],
+  "user_visible_path": "A TUI user in the gated cohort can enable `terminal_visualization_instructions` and receive terminal-aware ASCII visualization guidance in TUI sessions; default users and `codex exec` do not receive the new instructions.",
+  "control_plane_relevance": "Decodex should treat terminal visualization guidance as a gated TUI-only behavior, not as a default Codex capability or an app-server protocol change.",
+  "compatibility_risk": "Low for current Decodex integrations because the feature is `UnderDevelopment`, default disabled, and intentionally excluded from `codex exec`; risk is mainly over-reporting it as generally available.",
+  "adoption_opportunity": "Track the gate as a possible future terminal-output quality signal once Codex broadens it beyond the initial cohort.",
+  "community_value": "Interesting as a cautious watch note about terminal-specific output shaping, but not ready for a strong public availability claim.",
+  "deprecated_or_breaking_notes": "No default behavior changes; the PR explicitly says control behavior is unchanged and broad rollout remains gated by further evals.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26013 says the feature is `UnderDevelopment`, disabled by default, applies only to TUI start, resume, and fork flows, and intentionally does not apply to `codex exec`.",
+    "codex-rs/features/src/lib.rs adds `Feature::TerminalVisualizationInstructions` with key `terminal_visualization_instructions`, stage `UnderDevelopment`, and `default_enabled: false`.",
+    "codex-rs/core/config.schema.json exposes the new `terminal_visualization_instructions` boolean feature key.",
+    "codex-rs/tui/src/app_server_session.rs injects `with_terminal_visualization_instructions` into TUI thread start, resume, and fork parameter builders.",
+    "codex-rs/tui/src/terminal_visualization_instructions.rs defines compact ASCII diagram, tree, timeline, and table guidance for terminal surfaces.",
+    "The normalized bundle artifacts/github/bundles/openai-codex-pr-26013.json records 5 changed files for the merged PR."
+  ],
+  "caveats": "The PR describes employee-cohort dogfooding and separate model-layer rollout controls; do not present this as broadly shipped behavior.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The gated TUI behavior is useful for Control Plane readiness and release-rollup tracking."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "There is a public watch-note angle, but Publisher should defer until availability is broader or release context makes the caveat useful."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-26464.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-26464.review.json
@@ -1,0 +1,68 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-26464",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "26464",
+    "commit_shas": [
+      "bab01026e7d4a6329df5513a129ee2c1898d917e",
+      "336d10be5c4ec22a11ab0ca5e68dc751876c26ea",
+      "bcff1e61996a1de050a69b576ef0ec5e13430766",
+      "1e1b8ed914d7b4aec4d987ffaf3d1c3e97f3fa4d",
+      "ec64ccb725793f49feb297d7f4ad0f74be0fb32a"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "build(v8): update rusty_v8 to 149.2.0",
+        "url": "https://github.com/openai/codex/pull/26464",
+        "meta": "Merged 2026-06-06T21:27:23Z"
+      },
+      {
+        "kind": "commit",
+        "title": "build(v8): update rusty_v8 to 149.2.0",
+        "url": "https://github.com/openai/codex/commit/bab01026e7d4a6329df5513a129ee2c1898d917e"
+      },
+      {
+        "kind": "commit",
+        "title": "build(v8): consume published 149.2.0 artifacts",
+        "url": "https://github.com/openai/codex/commit/bcff1e61996a1de050a69b576ef0ec5e13430766"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-08T20:07:03Z",
+  "observed_change": "Codex updates its V8 and `rusty_v8` build inputs to 149.2.0, refreshes Bazel patches and release workflows, and replaces the checked Windows artifact hashes.",
+  "changed_surfaces": [
+    "Cargo and Bazel V8 dependency versions",
+    "V8 Bazel patch set",
+    "V8 release and canary workflows",
+    "third_party/v8 release artifact aliases and hashes",
+    "V8 build documentation"
+  ],
+  "user_visible_path": "Normal Codex CLI users should not see a direct feature change, but source builders and release consumers get new V8 14.9.207.2 and `rusty_v8` 149.2.0 artifacts and updated platform release workflows.",
+  "control_plane_relevance": "No immediate Decodex Control Plane protocol change; keep it as release-packaging background for diagnosing upstream Codex build or runtime regressions tied to V8.",
+  "compatibility_risk": "Low for Decodex integrations, but source builds, Bazel consumers, or release artifact consumers can be sensitive to V8 artifact, CPU-target, and patch-set changes.",
+  "adoption_opportunity": "No Decodex adoption action is clear beyond tracking the dependency baseline in release-rollup context.",
+  "community_value": "Limited public value unless a later release note or regression makes the V8 baseline relevant to builders.",
+  "deprecated_or_breaking_notes": "The checked `rusty_v8_147_4_0.sha256` artifact list is removed and replaced by `rusty_v8_149_2_0.sha256`; Bazel module and Cargo versions move to the newer V8 baseline.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26464 is a merged build PR updating `rusty_v8` to 149.2.0.",
+    "codex-rs/Cargo.toml changes the pinned `v8` crate from `=147.4.0` to `=149.2.0`.",
+    "MODULE.bazel changes the V8 archive from 14.7.173.20 to 14.9.207.2 and updates archive integrity.",
+    ".github/workflows/rusty-v8-release.yml and .github/workflows/v8-canary.yml add explicit `v8_cpu` matrix entries.",
+    "third_party/v8/BUILD.bazel renames artifact aliases from 147.4.0 to 149.2.0.",
+    "third_party/v8/rusty_v8_147_4_0.sha256 is removed and third_party/v8/rusty_v8_149_2_0.sha256 is added.",
+    "The normalized bundle artifacts/github/bundles/openai-codex-pr-26464.json records 16 changed files for the merged PR."
+  ],
+  "caveats": "The PR body is empty, so behavior interpretation relies on commit titles and patch evidence; treat it as build/release-packaging evidence, not a user-facing feature.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The V8 baseline change is useful release-rollup and regression-diagnosis context, but it is not a public Publisher candidate by itself."
+    }
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-24852.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-24852.json
@@ -1,0 +1,54 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-24852",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "high",
+  "audience": "Enterprise Codex operators and app-server clients",
+  "candidate_text": [
+    "Codex managed permissions moved to a closed `allowed_permission_profiles` map plus explicit `default_permissions`; app-server configRequirements/read now exposes `allowedPermissionProfiles` and `defaultPermissions`. PR: https://github.com/openai/codex/pull/24852"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-24852.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-24852.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/24852"
+    ]
+  },
+  "evidence_notes": [
+    "PR #24852 defines `allowed_permission_profiles` as a closed allow map.",
+    "The app-server protocol replaces `allowedPermissions` with `allowedPermissionProfiles` and adds `defaultPermissions`.",
+    "Config-loader tests cover strict denial of omitted built-ins and managed defaults.",
+    "The PR says legacy behavior is unchanged when the allowlist is absent."
+  ],
+  "claims": [
+    {
+      "text": "Managed permission profiles are now represented as a closed allow/deny map.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-24852.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "App-server config requirements clients need the `allowedPermissionProfiles` and `defaultPermissions` response shape.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-24852.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR changes enterprise permission semantics and a concrete app-server response contract.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-24852:operator_impact"
+  },
+  "caveats": [
+    "Keep legacy behavior caveat visible when the allowlist is absent.",
+    "Do not frame omitted profiles as denied unless `allowed_permission_profiles` is configured."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this after repository checks pass."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-25731.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-25731.json
@@ -1,0 +1,54 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-25731",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "high",
+  "audience": "Codex app-server and automation operators",
+  "candidate_text": [
+    "Codex now treats `at-` personal access tokens as a first-class ChatGPT-backed auth path and reports app-server auth mode `personalAccessToken`; exhaustive AuthMode clients need the new case. PR: https://github.com/openai/codex/pull/25731"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-25731.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-25731.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/25731"
+    ]
+  },
+  "evidence_notes": [
+    "PR #25731 documents `codex login --with-access-token` and `CODEX_ACCESS_TOKEN` support for PATs.",
+    "The app-server protocol adds `personalAccessToken` to `AuthMode`.",
+    "PAT auth hydrates metadata through AuthAPI whoami and is treated as ChatGPT-backed by provider and TUI paths.",
+    "The PR warns clients with exhaustive auth-mode handling must add the new case."
+  ],
+  "claims": [
+    {
+      "text": "Codex personal access tokens are a first-class ChatGPT-backed auth path.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-25731.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "App-server clients need to handle the new `personalAccessToken` AuthMode case.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-25731.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR changes a concrete login path and app-server protocol enum that external operators can act on.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-25731:operator_impact"
+  },
+  "caveats": [
+    "Do not describe PAT metadata as a persisted reusable cache.",
+    "Keep the app-server login-RPC limitation visible."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this after repository checks pass."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-26013.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-26013.json
@@ -1,0 +1,54 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-26013",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "watch_note",
+  "priority": "normal",
+  "audience": "Codex users watching terminal UX experiments",
+  "candidate_text": [
+    "Codex is dogfooding terminal-specific visualization instructions for the TUI behind the disabled `terminal_visualization_instructions` feature; no default user gets them yet. PR: https://github.com/openai/codex/pull/26013"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26013.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26013.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26013"
+    ]
+  },
+  "evidence_notes": [
+    "PR #26013 says no default user receives the new instructions.",
+    "The feature catalog marks the feature as `UnderDevelopment` and default disabled.",
+    "The helper is wired only into TUI thread start, resume, and fork flows.",
+    "The PR explicitly excludes `codex exec`."
+  ],
+  "claims": [
+    {
+      "text": "Codex added terminal-specific visualization instructions behind a disabled TUI feature gate.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26013.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The feature is not broadly available by default and does not apply to `codex exec`.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26013.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "defer",
+    "reason": "The change is interesting but the PR frames it as gated dogfood rather than broadly available user behavior.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26013:watch_note"
+  },
+  "caveats": [
+    "Do not imply broad availability.",
+    "Keep the TUI-only and dogfood-gated scope visible."
+  ],
+  "next_steps": [
+    "Let Publisher automation skip or hold this until release context makes the caveat useful."
+  ]
+}


### PR DESCRIPTION
## Summary
- refresh the openai/codex upstream review queue
- add source bundles, upstream reviews, and upstream-impact artifacts for PRs 26013, 25731, 24852, and 26464
- add social_candidate/v1 handoffs for PRs 26013 (defer), 25731 (publish), and 24852 (publish)

## Validation
- `cargo run -p decodex --bin decodex -- radar bundle validate artifacts/github/bundles/openai-codex-pr-26013.json artifacts/github/bundles/openai-codex-pr-25731.json artifacts/github/bundles/openai-codex-pr-24852.json artifacts/github/bundles/openai-codex-pr-26464.json`
- `cargo make check-site-content`
- `git diff --cached --check` before commit

## Notes
- no social_post/v1 artifacts were written
- no X publishing was attempted
- labels `codex` and `codex-automation` were not present in the repository label list