### PR TITLE
Persist Codex alpha.7 checkpoint candidate

### DIFF
--- a/artifacts/github/social-candidates/openai-codex-rust-v0-138-0-alpha-7-prerelease-read.json
+++ b/artifacts/github/social-candidates/openai-codex-rust-v0-138-0-alpha-7-prerelease-read.json
@@ -1,0 +1,101 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-rust-v0-138-0-alpha-7-prerelease-read",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "thread",
+  "priority": "high",
+  "audience": "Codex operators tracking prerelease direction before stable notes",
+  "candidate_text": [
+    "Codex CLI 0.138.0-alpha.7 prerelease read\n\nIncrement: alpha.6 -> alpha.7, 14 commits.\n\nMetadata read: remote-control/plugin identity, approval + MCP status fixes, standalone web search in code mode, and multi-agent v2 lifecycle/concurrency work.\n\nAlpha caveat: not stable notes.",
+    "Operator surfaces:\n\n- remote-control preserves enrollment on generic websocket 404s\nhttps://github.com/openai/codex/pull/26741\n\n- plugin service gets Codex product SKU\nhttps://github.com/openai/codex/pull/26804",
+    "Approval + MCP watch:\n\n- approval sandbox decisions preserved in unified exec\nhttps://github.com/openai/codex/pull/24981\n\n- MCP startup status scoped by thread\nhttps://github.com/openai/codex/pull/26639\n\nPR-title metadata only until Radar reviews source.",
+    "Workflow/runtime direction:\n\n- standalone web search enabled in code mode\nhttps://github.com/openai/codex/pull/26719\n\n- TUI accepts prompts with resume and fork\nhttps://github.com/openai/codex/pull/26818",
+    "Multi-agent v2 thread:\n\n- agent residency LRU\nhttps://github.com/openai/codex/pull/26632\n\n- concurrency counted by active execution\nhttps://github.com/openai/codex/pull/26969\n\n- close_agent renamed to interrupt_agent\nhttps://github.com/openai/codex/pull/26994",
+    "Release/build background:\n\n- V8/rusty_v8 149.2.0 is checked review context, not standalone social value\nhttps://github.com/openai/codex/pull/26464\n\nOther PR-title gaps: BuildBuddy secret, starlark 0.14.2, proc-macro advisory.",
+    "Lineage + quote:\n\nCompare: https://github.com/openai/codex/compare/rust-v0.138.0-alpha.6...rust-v0.138.0-alpha.7\n\nPrevious quote-eligible Decodex prerelease post: https://x.com/decodexspace/status/2063279620129247678"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26464.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26464.json"
+    ],
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://developers.openai.com/codex/changelog",
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.6",
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.7",
+      "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.6...rust-v0.138.0-alpha.7",
+      "https://github.com/openai/codex/pull/26741",
+      "https://github.com/openai/codex/pull/26804",
+      "https://github.com/openai/codex/pull/24981",
+      "https://github.com/openai/codex/pull/26818",
+      "https://github.com/openai/codex/pull/26639",
+      "https://github.com/openai/codex/pull/26719",
+      "https://github.com/openai/codex/pull/26632",
+      "https://github.com/openai/codex/pull/26969",
+      "https://github.com/openai/codex/pull/26994",
+      "https://github.com/openai/codex/pull/26464",
+      "https://github.com/openai/codex/pull/26895",
+      "https://github.com/openai/codex/pull/24820",
+      "https://github.com/openai/codex/pull/26974",
+      "https://x.com/decodexspace/status/2063279620129247678"
+    ]
+  },
+  "evidence_notes": [
+    "GitHub release metadata shows rust-v0.138.0-alpha.7 was published at 2026-06-08T14:47:43Z with only a sparse release body.",
+    "The adjacent alpha.6 -> alpha.7 compare has 14 commits: 13 PR-numbered commits plus the release commit.",
+    "Official Codex changelog readback for this run still has the latest June entries on 2026-06-04 for Codex app 26.602 and Codex CLI 0.137.0, so alpha.7 is a GitHub prerelease checkpoint rather than an official changelog entry.",
+    "The draft copy is limited to release metadata, compare metadata, PR-title metadata, and the existing checked review/impact context for PR #26464; it does not claim source-reviewed behavior for the other PRs.",
+    "The current checked release_delta/v1 was generated at 2026-06-05T09:07:58.572455Z for stable rust-v0.137.0 -> prerelease rust-v0.138.0-alpha.4, so alpha.7 is newer than the checked release_delta.",
+    "Checked social_post/v1 records show the immediately previous alpha.6 prerelease post is live and quote-eligible at https://x.com/decodexspace/status/2063279620129247678; Publisher must still verify live profile state before quoting it."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.138.0-alpha.7 is the current observed OpenAI Codex prerelease checkpoint for this run.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.7",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The correct prerelease lineage comparison is rust-v0.138.0-alpha.6 -> rust-v0.138.0-alpha.7.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.6...rust-v0.138.0-alpha.7",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "PR-title metadata in the alpha.7 window points to remote-control and plugin-service identity fixes, approval and MCP status cleanup, standalone web search in code mode, and multi-agent v2 lifecycle and concurrency work.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.6...rust-v0.138.0-alpha.7",
+      "confidence": "likely"
+    },
+    {
+      "text": "Existing checked Radar review coverage in this compare window is limited to PR #26464, and that review treats the V8/rusty_v8 update as release-packaging background rather than standalone social value.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26464.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The immediately previous alpha.6 Decodex prerelease post is checked as live and quote-eligible.",
+      "evidence": "artifacts/social/x/posts/2026-06-06/openai-codex-rust-v0-138-0-alpha-6-prerelease-read.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The adjacent alpha.6 -> alpha.7 compare supports a scan-friendly metadata thread with direct PR URLs, prior quote lineage, and explicit source-review caveats.",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-138-0-alpha-7:alpha6-alpha7:thread"
+  },
+  "caveats": [
+    "Behavior claims for alpha.7 remain upstream-analysis gaps; exact gap list: #26741, #26804, #24981, #26818, #26639, #26719, #26632, #26969, #26994, #26895, #24820, #26974.",
+    "This candidate is based on public release metadata, compare metadata, PR-title metadata, and existing checked review/impact context for #26464 only; codex-upstream-radar-review / codex-code-analysis should review source before a release_rollup makes stronger claims.",
+    "The previous alpha.6 post is quote-eligible in checked records, but decodex-x-publisher must verify it remains live and quote-eligible on the @decodexspace profile before composing a quote post.",
+    "Media caveat: no generated image is attached by this downstream artifact-consumer run. If media is required, decodex-x-publisher should generate and verify a fresh candidate-specific decodex_signal_card, then fail closed if upload/readback is unreliable."
+  ],
+  "next_steps": [
+    "Hand this publishable candidate to decodex-x-publisher.",
+    "Before posting, verify @decodexspace account state, daily cap, duplicate/idempotency state, prior alpha.6 quote eligibility, and whether candidate-specific media is required.",
+    "If the Publisher needs stronger behavior language than PR-title metadata, pause publication and route the listed gap PRs to codex-upstream-radar-review / codex-code-analysis."
+  ]
+}


### PR DESCRIPTION
## Summary
- add a publishable social_candidate/v1 handoff for openai/codex rust-v0.138.0-alpha.7
- preserve alpha.6 -> alpha.7 adjacent lineage, prior alpha.6 quote URL, direct PR URLs, and upstream-analysis gaps
- keep the candidate scoped to release/compare/PR-title metadata plus existing checked #26464 review context

## Validation
- jq candidate text/idempotency check passed
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x

## Caveats
- no X publishing was performed
- decodex-x-publisher must verify live @decodexspace duplicate state, daily cap, media need, and alpha.6 quote eligibility before compose
