### PR TITLE
Persist Codex release checkpoint candidates

### DIFF
--- a/artifacts/github/social-candidates/openai-codex-rust-v0-138-0-alpha-8-release-checkpoint.json
+++ b/artifacts/github/social-candidates/openai-codex-rust-v0-138-0-alpha-8-release-checkpoint.json
@@ -1,0 +1,62 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-rust-v0-138-0-alpha-8-release-checkpoint",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "watch_note",
+  "priority": "low",
+  "audience": "Codex operators tracking prerelease cadence",
+  "candidate_text": [
+    "No alpha.8 post handoff.\n\nOpenAI published rust-v0.138.0-alpha.8 at 2026-06-08T21:46:54Z, then stable rust-v0.138.0 at 2026-06-08T23:00:27Z before this run. Record alpha.7 -> alpha.8 as a review gap."
+  ],
+  "source_refs": {
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.7",
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.8",
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0",
+      "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.7...rust-v0.138.0-alpha.8"
+    ]
+  },
+  "evidence_notes": [
+    "GitHub release metadata shows rust-v0.138.0-alpha.8 was published at 2026-06-08T21:46:54Z with only a sparse release body.",
+    "GitHub release metadata shows stable rust-v0.138.0 was published at 2026-06-08T23:00:27Z, superseding alpha.8 before this automation run.",
+    "The adjacent alpha.7 -> alpha.8 compare has 13 ahead commits and 12 PR-numbered commits, but this publisher automation did not perform source or patch analysis.",
+    "The current checked release_delta/v1 was generated at 2026-06-05T09:07:58.572455Z for stable rust-v0.137.0 -> prerelease rust-v0.138.0-alpha.4, so alpha.8 is newer than the checked release_delta."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.138.0-alpha.8 is a real OpenAI Codex prerelease checkpoint.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.138.0-alpha.8",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "alpha.8 was superseded by stable rust-v0.138.0 before this run.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.138.0",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The alpha.7 -> alpha.8 window needs upstream review before behavior claims are made.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.138.0-alpha.7...rust-v0.138.0-alpha.8",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "skip",
+    "reason": "alpha.8 was superseded by stable 0.138.0 before this run and its sparse release body does not add enough standalone reader value.",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-138-0-alpha-8:skip"
+  },
+  "caveats": [
+    "This is a terminal skip checkpoint record, not a publication request.",
+    "Exact source-review gap list for alpha.7 -> alpha.8: #26997, #26821, #26202, #26852, #26923, #26680, #26637, #27009, #26417, #26631, #27024, #26230, #26231, #26334, #26333, #26232, #27038, #27037."
+  ],
+  "next_steps": [
+    "Do not hand this alpha.8 record to decodex-x-publisher.",
+    "Use the stable 0.138.0 candidate as the current higher-value release checkpoint handoff.",
+    "Route alpha.7 -> alpha.8 behavior claims to codex-upstream-radar-review / codex-code-analysis if a later release rollup needs them."
+  ],
+  "media_refs": null
+}

--- a/artifacts/github/social-candidates/openai-codex-rust-v0-138-0-release-thread.json
+++ b/artifacts/github/social-candidates/openai-codex-rust-v0-138-0-release-thread.json
@@ -1,0 +1,102 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-rust-v0-138-0-release-thread",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "thread",
+  "priority": "high",
+  "audience": "Codex operators tracking stable CLI releases and operator-facing surfaces",
+  "candidate_text": [
+    "Codex CLI 0.138.0 stable is out.\n\nRelease notes highlight `/app` handoff to Desktop, saved image paths, flexible reasoning effort, app-server token usage/PATs, and plugin JSON/detail upgrades.\n\nSource: https://github.com/openai/codex/releases/tag/rust-v0.138.0",
+    "User-facing picks:\n\n- `/app` can hand off a CLI thread to Codex Desktop\nhttps://github.com/openai/codex/pull/25638\n\n- local images expose saved paths for follow-up edits\nhttps://github.com/openai/codex/pull/25944",
+    "Operator surfaces:\n\n- app-server account token usage\nhttps://github.com/openai/codex/pull/25344\n\n- v2 personal access tokens\nhttps://github.com/openai/codex/pull/25731\n\n- plugin command JSON + richer detail data\nhttps://github.com/openai/codex/pull/26631",
+    "Quality fixes worth noting:\n\n- goal auto-continuation stops after terminal turn failures\nhttps://github.com/openai/codex/pull/26690\n\n- AGENTS.md discovery is more accurate across remote/symlinked workspaces\nhttps://github.com/openai/codex/pull/26205",
+    "Lineage + caveat:\n\nStable compare: rust-v0.137.0 -> rust-v0.138.0\nhttps://github.com/openai/codex/compare/rust-v0.137.0...rust-v0.138.0\n\nRelease notes are source evidence; deeper Decodex adoption claims still need Radar review."
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26631.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26631.json"
+    ],
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://developers.openai.com/codex/changelog",
+      "https://github.com/openai/codex/releases/tag/rust-v0.137.0",
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0",
+      "https://github.com/openai/codex/compare/rust-v0.137.0...rust-v0.138.0",
+      "https://github.com/openai/codex/pull/25638",
+      "https://github.com/openai/codex/pull/26500",
+      "https://github.com/openai/codex/pull/25944",
+      "https://github.com/openai/codex/pull/25947",
+      "https://github.com/openai/codex/pull/25623",
+      "https://github.com/openai/codex/pull/26444",
+      "https://github.com/openai/codex/pull/26446",
+      "https://github.com/openai/codex/pull/25344",
+      "https://github.com/openai/codex/pull/25731",
+      "https://github.com/openai/codex/pull/26631",
+      "https://github.com/openai/codex/pull/26047",
+      "https://github.com/openai/codex/pull/26147",
+      "https://github.com/openai/codex/pull/26690",
+      "https://github.com/openai/codex/pull/26205",
+      "https://github.com/openai/codex/pull/26465"
+    ]
+  },
+  "evidence_notes": [
+    "GitHub release metadata shows stable rust-v0.138.0 was published at 2026-06-08T23:00:27Z with a detailed release body.",
+    "The release body highlights new features for `/app` Desktop handoff, local image path exposure, reasoning effort selection, app-server token usage, v2 PAT support, and plugin structured output/detail data.",
+    "The release body also highlights goal workflow fixes, fork/title fixes, TUI edit/display fixes, startup resilience, and AGENTS.md discovery accuracy.",
+    "The stable release compare is rust-v0.137.0 -> rust-v0.138.0 with 101 ahead commits in GitHub compare metadata.",
+    "Official Codex changelog readback for this run still has the latest June entries on 2026-06-04 for Codex app 26.602 and 2026-06-02 for ChatGPT iOS 1.2026.146, so this is a GitHub release checkpoint rather than an official Codex changelog entry.",
+    "The current checked release_delta/v1 was generated at 2026-06-05T09:07:58.572455Z for stable rust-v0.137.0 -> prerelease rust-v0.138.0-alpha.4, so stable 0.138.0 is newer than the checked release_delta.",
+    "Checked Radar source-reviewed coverage among the highlighted stable bullets is limited to PR #26631; all other highlighted bullets are release-note and PR-link evidence only."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.138.0 is the current observed stable OpenAI Codex CLI release checkpoint for this run.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.138.0",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The correct stable release lineage comparison is rust-v0.137.0 -> rust-v0.138.0.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.137.0...rust-v0.138.0",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The 0.138.0 release notes highlight `/app` Desktop handoff, image path exposure, reasoning effort selection, app-server token usage and v2 PAT support, and plugin JSON/detail upgrades.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.138.0",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The 0.138.0 release notes highlight goal workflow fixes and more accurate AGENTS.md discovery across remote and symlinked workspaces.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.138.0",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Existing checked Radar review coverage among the highlighted stable bullets is limited to PR #26631.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26631.review.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The stable 0.138.0 release body provides concrete reader-facing release-note evidence and direct PR links for a scan-friendly thread.",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-138-0:stable137-stable138:thread"
+  },
+  "caveats": [
+    "This candidate is based on public GitHub release metadata, release-body text, compare metadata, direct PR URLs, and existing checked review/impact context for #26631 only.",
+    "Do not imply Decodex has adopted or verified every 0.138.0 behavior; route deeper behavior or compatibility claims to codex-upstream-radar-review / codex-code-analysis.",
+    "The current cap day already has the alpha.7 published thread in checked records; decodex-x-publisher must verify daily cap, duplicate/idempotency state, and live @decodexspace profile state before composing.",
+    "Media caveat: no generated image is attached by this downstream artifact-consumer run. If media is required, decodex-x-publisher should generate and verify a fresh candidate-specific decodex_signal_card, then fail closed if upload/readback is unreliable."
+  ],
+  "next_steps": [
+    "Hand this publishable candidate to decodex-x-publisher.",
+    "Before posting, verify @decodexspace account state, daily cap, duplicate/idempotency state, and whether candidate-specific media is required.",
+    "If the Publisher needs stronger behavior language than release notes and PR-title metadata, pause publication and route the relevant PRs to codex-upstream-radar-review / codex-code-analysis."
+  ],
+  "media_refs": null
+}

--- a/artifacts/github/social-candidates/openai-codex-rust-v0-139-0-alpha-1-needs-upstream-analysis.json
+++ b/artifacts/github/social-candidates/openai-codex-rust-v0-139-0-alpha-1-needs-upstream-analysis.json
@@ -1,0 +1,75 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-rust-v0-139-0-alpha-1-needs-upstream-analysis",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "watch_note",
+  "priority": "normal",
+  "audience": "Codex operators tracking prerelease direction before stable notes",
+  "candidate_text": [
+    "No 0.139.0-alpha.1 post handoff yet.\n\nThis is the first prerelease after stable 0.138.0. The stable -> alpha.1 compare has 38 commits, but the body is sparse and behavior claims need Radar review.\n\nSource: https://github.com/openai/codex/releases/tag/rust-v0.139.0-alpha.1"
+  ],
+  "source_refs": {
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0",
+      "https://github.com/openai/codex/releases/tag/rust-v0.139.0-alpha.1",
+      "https://github.com/openai/codex/compare/rust-v0.138.0...rust-v0.139.0-alpha.1",
+      "https://github.com/openai/codex/pull/27054",
+      "https://github.com/openai/codex/pull/27035",
+      "https://github.com/openai/codex/pull/26486",
+      "https://github.com/openai/codex/pull/24118",
+      "https://github.com/openai/codex/pull/26934",
+      "https://github.com/openai/codex/pull/26932",
+      "https://github.com/openai/codex/pull/27081"
+    ]
+  },
+  "evidence_notes": [
+    "GitHub release metadata shows rust-v0.139.0-alpha.1 was published at 2026-06-09T00:12:33Z with only a sparse release body.",
+    "Per the prerelease lineage gate, this first prerelease after stable rust-v0.138.0 compares stable rust-v0.138.0 -> rust-v0.139.0-alpha.1 and must not quote the previous 0.138 alpha thread.",
+    "The stable -> alpha.1 compare has 38 ahead commits and 1 behind commit in GitHub compare metadata, so the window needs de-duplication against the just-published stable release before a public thread.",
+    "PR-title metadata in the alpha.1 compare points to sandbox permission aliasing, network proxy enforcement, image edits through referenced paths, tool schema support, plugin cache work, and doctor environment reporting, but these behavior claims are unreviewed by this publisher automation.",
+    "The current checked release_delta/v1 was generated at 2026-06-05T09:07:58.572455Z for stable rust-v0.137.0 -> prerelease rust-v0.138.0-alpha.4, so alpha.1 is newer than the checked release_delta."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.139.0-alpha.1 is a real OpenAI Codex prerelease checkpoint.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.139.0-alpha.1",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The correct first-prerelease-after-stable comparison is rust-v0.138.0 -> rust-v0.139.0-alpha.1.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.138.0...rust-v0.139.0-alpha.1",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "PR-title metadata in the alpha.1 compare points to sandbox permission aliasing, network proxy enforcement, image edit routing, tool schema support, plugin cache work, and doctor environment reporting.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.138.0...rust-v0.139.0-alpha.1",
+      "confidence": "likely"
+    },
+    {
+      "text": "Behavior claims for the alpha.1 window require upstream source review before a publishable Decodex thread.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.138.0...rust-v0.139.0-alpha.1",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "defer",
+    "reason": "needs_upstream_analysis: the first 0.139 prerelease body is sparse and the stable -> alpha.1 compare needs source review and de-duplication before public copy.",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-139-0-alpha-1:stable138-alpha1:defer"
+  },
+  "caveats": [
+    "This is a terminal defer / needs_upstream_analysis checkpoint record, not a publication request.",
+    "Do not compare a later 0.139 prerelease against stable 0.138.0 unless it is still the first prerelease after stable; future 0.139 prereleases should use adjacent prerelease-to-prerelease lineage.",
+    "Exact source-review gap list for stable 0.138.0 -> 0.139.0-alpha.1: #26741, #26804, #26464, #26895, #24981, #26818, #24820, #26639, #26719, #26632, #26623, #26974, #26969, #26994, #26997, #26821, #26202, #26852, #26923, #26680, #26637, #27009, #26417, #26631, #27024, #26230, #26231, #26334, #26333, #26232, #27038, #27037, #26687, #27054, #27035, #26486, #27060, #27044, #24118, #26934, #26932, #26091, #27057, #27058, #27059, #27081, #26858, #27084."
+  ],
+  "next_steps": [
+    "Do not hand this alpha.1 defer record to decodex-x-publisher.",
+    "Route the listed gap PRs to codex-upstream-radar-review / codex-code-analysis before turning alpha.1 into a release_rollup or operator_impact post.",
+    "Use stable 0.138.0 as the publishable checkpoint from this run."
+  ],
+  "media_refs": null
+}


### PR DESCRIPTION
## Summary
- Add terminal skip candidate for rust-v0.138.0-alpha.8, superseded by stable 0.138.0 before this run.
- Add publishable thread candidate for stable rust-v0.138.0 using release-note, compare, and direct PR-link evidence.
- Add defer / needs_upstream_analysis candidate for first rust-v0.139.0-alpha.1 prerelease.

## Validation
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates
- cargo make fmt
- cargo make lint-fix
- cargo make test

## Notes
- No upstream source or patch analysis performed.
- Official Codex changelog was checked; latest visible June entries remain Codex app 26.602 and ChatGPT iOS 1.2026.146.