### PR TITLE
Preserve live App lane activity without active lease

### DIFF
--- a/apps/decodex/src/orchestrator/operator_http.rs
+++ b/apps/decodex/src/orchestrator/operator_http.rs
@@ -513,18 +513,20 @@ fn build_operator_run_activity_event(
 				continue;
 			},
 		};
-		let (runs, _) = state_store.list_project_runs(project.service_id(), 0)?;
+		let (leased_runs, recent_runs) =
+			state_store.list_project_runs(project.service_id(), DEFAULT_OPERATOR_DASHBOARD_RUN_LIMIT)?;
 		let project_display_name = operator_project_display_name(&project);
-		let mut project_active_runs = Vec::new();
-
-		for run in runs {
-			let run_status =
-				operator_run_status(&project, &project_display_name, run, now_unix_epoch)?;
-
-			if operator_run_counts_as_active(&run_status) {
-				project_active_runs.push(run_status);
-			}
-		}
+		let recent_runs = recent_runs
+			.into_iter()
+			.map(|run| operator_run_status(&project, &project_display_name, run, now_unix_epoch))
+			.collect::<Result<Vec<_>>>()?;
+		let project_active_runs = operator_active_run_statuses(
+			&project,
+			&project_display_name,
+			leased_runs,
+			&recent_runs,
+			now_unix_epoch,
+		)?;
 
 		if project_active_runs.is_empty() {
 			continue;

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -280,29 +280,19 @@ fn build_operator_status_snapshot_with_account_mode(
 	account_activity_mode: AccountActivityMode,
 ) -> crate::prelude::Result<OperatorStatusSnapshot> {
 	let now_unix_epoch = OffsetDateTime::now_utc().unix_timestamp();
-	let (active_runs, recent_runs) = state_store.list_project_runs(project.service_id(), limit)?;
+	let (leased_runs, recent_runs) = state_store.list_project_runs(project.service_id(), limit)?;
 	let project_display_name = operator_project_display_name(project);
 	let recent_runs = recent_runs
 		.into_iter()
 		.map(|run| operator_run_status(project, &project_display_name, run, now_unix_epoch))
 		.collect::<crate::prelude::Result<Vec<_>>>()?;
-	let mut active_runs = active_runs
-		.into_iter()
-		.map(|run| operator_run_status(project, &project_display_name, run, now_unix_epoch))
-		.collect::<crate::prelude::Result<Vec<_>>>()?
-		.into_iter()
-		.filter(operator_run_counts_as_active)
-		.collect::<Vec<_>>();
-	let mut active_run_ids =
-		active_runs.iter().map(|run| run.run_id.clone()).collect::<HashSet<_>>();
-
-	for run in &recent_runs {
-		if !active_run_ids.contains(&run.run_id) && operator_run_has_live_execution(run) {
-			active_run_ids.insert(run.run_id.clone());
-			active_runs.push(run.clone());
-		}
-	}
-
+	let active_runs = operator_active_run_statuses(
+		project,
+		&project_display_name,
+		leased_runs,
+		&recent_runs,
+		now_unix_epoch,
+	)?;
 	let history_lanes = operator_history_lanes(&active_runs, &recent_runs);
 	let (worktrees, mut warnings, warning_details) =
 		operator_status_worktrees(project, state_store)?;
@@ -346,6 +336,33 @@ fn build_operator_status_snapshot_with_account_mode(
 	refresh_operator_project_summary(&mut snapshot);
 
 	Ok(snapshot)
+}
+
+fn operator_active_run_statuses(
+	project: &ServiceConfig,
+	project_display_name: &str,
+	leased_runs: Vec<ProjectRunStatus>,
+	recent_runs: &[OperatorRunStatus],
+	now_unix_epoch: i64,
+) -> crate::prelude::Result<Vec<OperatorRunStatus>> {
+	let mut active_runs = leased_runs
+		.into_iter()
+		.map(|run| operator_run_status(project, project_display_name, run, now_unix_epoch))
+		.collect::<crate::prelude::Result<Vec<_>>>()?
+		.into_iter()
+		.filter(operator_run_counts_as_active)
+		.collect::<Vec<_>>();
+	let mut active_run_ids =
+		active_runs.iter().map(|run| run.run_id.clone()).collect::<HashSet<_>>();
+
+	for run in recent_runs {
+		if !active_run_ids.contains(&run.run_id) && operator_run_has_live_execution(run) {
+			active_run_ids.insert(run.run_id.clone());
+			active_runs.push(run.clone());
+		}
+	}
+
+	Ok(active_runs)
 }
 
 fn global_codex_account_control_status() -> OperatorCodexAccountControlStatus {
@@ -1143,16 +1160,16 @@ fn operator_run_counts_as_active(run: &OperatorRunStatus) -> bool {
 
 fn operator_run_has_live_execution(run: &OperatorRunStatus) -> bool {
 	matches!(run.status.as_str(), "starting" | "running")
-		&& matches!(
+		&& (matches!(
 			run.execution_liveness.as_str(),
 			"process_alive" | "thread_active" | "protocol_observed"
-		)
+		) || operator_run_has_recent_app_server_execution(run))
 }
 
 fn operator_run_counts_as_running(run: &OperatorRunStatus) -> bool {
 	matches!(run.status.as_str(), "starting" | "running")
 		&& run.phase == "executing"
-		&& run.process_alive != Some(false)
+		&& (run.process_alive != Some(false) || operator_run_has_recent_app_server_execution(run))
 		&& !operator_run_needs_attention(run)
 }
 
@@ -1162,7 +1179,17 @@ fn operator_run_needs_attention(run: &OperatorRunStatus) -> bool {
 		|| run.process_alive == Some(false)
 			&& matches!(run.status.as_str(), "starting" | "running")
 			&& run.wait_reason.is_none()
+			&& !operator_run_has_recent_app_server_execution(run)
 		|| operator_run_has_stale_execution_without_known_process(run)
+}
+
+fn operator_run_has_recent_app_server_execution(run: &OperatorRunStatus) -> bool {
+	matches!(run.thread_status.as_deref(), Some("active"))
+		|| !run.thread_active_flags.is_empty()
+		|| run.protocol_idle_for_seconds.is_some_and(|idle_for| {
+			u64::try_from(idle_for)
+				.is_ok_and(|idle_for| idle_for < ACTIVE_RUN_IDLE_TIMEOUT.as_secs())
+		})
 }
 
 fn operator_run_has_stale_execution_without_known_process(run: &OperatorRunStatus) -> bool {
@@ -6162,6 +6189,9 @@ fn operator_run_queue_lease_summary(run: &OperatorRunStatus) -> String {
 		"thread_active" => String::from("not_held (thread_active keeps lane visible)"),
 		"protocol_observed" => String::from("not_held (protocol_observed keeps lane visible)"),
 		"process_stopped" => String::from("not_held (process_stopped needs attention)"),
+		EXECUTION_LIVENESS_PROCESS_IDENTITY_MISMATCH if operator_run_has_recent_app_server_execution(run) => {
+			String::from("not_held (app_server_activity keeps lane visible)")
+		},
 		EXECUTION_LIVENESS_PROCESS_IDENTITY_MISMATCH => {
 			String::from("not_held (process_identity_mismatch needs attention)")
 		},

--- a/apps/decodex/src/orchestrator/tests/operator/status/http.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/http.rs
@@ -1095,6 +1095,80 @@ fn operator_dashboard_run_activity_event_summarizes_active_runs() {
 	assert!(fingerprint["activeRuns"][0].get("protocol_idle_for_seconds").is_none());
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn operator_dashboard_run_activity_event_keeps_unleased_app_server_active_run() {
+	let temp_dir = TempDir::new().expect("temp dir should exist");
+	let _home_guard =
+		TestEnvVarGuard::set("HOME", temp_dir.path().to_str().expect("temp path should be UTF-8"));
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let registration = ProjectRegistration::from_config(
+		config.service_id(),
+		&service_config_path(config.repo_root()),
+		&config,
+		true,
+		"test-fingerprint",
+	);
+	let issue = sample_issue("Todo", &[]);
+	let worktree_path = config.worktree_root().join("PUB-101");
+
+	git_status_success(
+		config.repo_root(),
+		&["remote", "add", "origin", "git@github.com:hack-ink/pubfi-mono-v2.git"],
+	);
+
+	state_store.upsert_project(&registration).expect("project should register");
+	state_store
+		.record_run_attempt("run-1", &issue.id, 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_worktree(
+			config.service_id(),
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	state::write_run_thread_status_marker(
+		&worktree_path,
+		"run-1",
+		1,
+		Some("thread-1"),
+		Some("turn-1"),
+		"active",
+		&[],
+	)
+	.expect("thread status should write");
+
+	rewrite_run_activity_marker_host_boot_id(&worktree_path, "previous-boot");
+
+	let event =
+		orchestrator::build_operator_run_activity_event(&state_store).expect("event should build");
+	let message = orchestrator::dashboard_websocket_message(
+		event.event.event_type,
+		&event.event.payload,
+	)
+	.expect("event should serialize");
+	let (payload, _consumed) = websocket_text_payload(&message).expect("event should be a text frame");
+	let payload: Value = serde_json::from_slice(payload).expect("event data should be json");
+	let data = &payload["payload"];
+	let active_runs = data["activeRuns"].as_array().expect("active runs should list");
+
+	assert_eq!(payload["type"], "runActivity");
+	assert_eq!(data["activeRunsComplete"], true);
+	assert_eq!(active_runs.len(), 1);
+	assert_eq!(active_runs[0]["run_id"], "run-1");
+	assert_eq!(active_runs[0]["project_id"], "pubfi");
+	assert_eq!(active_runs[0]["project_display_name"], "hack-ink/pubfi-mono-v2");
+	assert_eq!(active_runs[0]["active_lease"], false);
+	assert_eq!(active_runs[0]["execution_liveness"], "process_identity_mismatch");
+	assert_eq!(active_runs[0]["process_alive"], false);
+	assert_eq!(active_runs[0]["process_liveness_reason"], "host_boot_id_mismatch");
+	assert_eq!(active_runs[0]["thread_status"], "active");
+}
+
 #[test]
 fn operator_dashboard_run_activity_fingerprint_ignores_volatile_timing_fields() {
 	let mut first = serde_json::json!({

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -1063,6 +1063,60 @@ fn operator_status_snapshot_counts_previous_boot_process_as_attention_not_runnin
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
+fn operator_status_snapshot_keeps_unleased_app_server_active_run_with_stale_process_marker() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue("Todo", &[]);
+	let worktree_path = config.worktree_root().join("PUB-101");
+
+	state_store
+		.record_run_attempt("run-1", &issue.id, 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	state::write_run_thread_status_marker(
+		&worktree_path,
+		"run-1",
+		1,
+		Some("thread-1"),
+		Some("turn-1"),
+		"active",
+		&[],
+	)
+	.expect("thread status should write");
+
+	rewrite_run_activity_marker_host_boot_id(&worktree_path, "previous-boot");
+
+	let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+		.expect("snapshot should build");
+	let run = snapshot.active_runs.first().expect("active run should remain visible");
+	let project = snapshot.projects.first().expect("project summary should exist");
+
+	assert_eq!(snapshot.active_runs.len(), 1);
+	assert_eq!(run.run_id, "run-1");
+	assert_eq!(run.status, "running");
+	assert_eq!(run.phase, "executing");
+	assert!(!run.active_lease);
+	assert_eq!(run.queue_lease_state, "not_held");
+	assert_eq!(run.execution_liveness, "process_identity_mismatch");
+	assert_eq!(run.process_alive, Some(false));
+	assert_eq!(run.process_liveness_reason.as_deref(), Some("host_boot_id_mismatch"));
+	assert_eq!(run.thread_status.as_deref(), Some("active"));
+	assert_eq!(project.active_run_count, 1);
+	assert_eq!(project.running_lane_count, 1);
+	assert_eq!(project.attention_count, 0);
+	assert_eq!(snapshot.worktrees[0].ownership, "active_lane");
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
 fn operator_status_snapshot_counts_reused_pid_as_attention_not_running() {
 	let (_temp_dir, config, _workflow) = temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");


### PR DESCRIPTION
## Summary
- keep unleased App-server-active runs visible in operator status snapshots
- use the same active-run projection for dashboard websocket runActivity events
- cover stale process-marker plus active App server/thread evidence in status and HTTP tests

## Validation
- cargo make fmt
- cargo make lint-fix
- cargo make test
- git diff --check
