### PR TITLE
Persist daily-cap block for 0.138 release thread

### DIFF
--- a/artifacts/social/x/posts/2026-06-09/openai-codex-rust-v0-138-0-release-thread-daily-cap-block.json
+++ b/artifacts/social/x/posts/2026-06-09/openai-codex-rust-v0-138-0-release-thread-daily-cap-block.json
@@ -1,0 +1,105 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-rust-v0-138-0-release-thread-daily-cap-block",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "thread",
+  "status": "blocked",
+  "audience": "Codex operators tracking stable CLI releases and operator-facing surfaces",
+  "text": [
+    "Codex CLI 0.138.0 stable is out.\n\nRelease notes highlight `/app` handoff to Desktop, saved image paths, flexible reasoning effort, app-server token usage/PATs, and plugin JSON/detail upgrades.\n\nSource: https://github.com/openai/codex/releases/tag/rust-v0.138.0",
+    "User-facing picks:\n\n- `/app` can hand off a CLI thread to Codex Desktop\nhttps://github.com/openai/codex/pull/25638\n\n- local images expose saved paths for follow-up edits\nhttps://github.com/openai/codex/pull/25944",
+    "Operator surfaces:\n\n- app-server account token usage\nhttps://github.com/openai/codex/pull/25344\n\n- v2 personal access tokens\nhttps://github.com/openai/codex/pull/25731\n\n- plugin command JSON + richer detail data\nhttps://github.com/openai/codex/pull/26631",
+    "Quality fixes worth noting:\n\n- goal auto-continuation stops after terminal turn failures\nhttps://github.com/openai/codex/pull/26690\n\n- AGENTS.md discovery is more accurate across remote/symlinked workspaces\nhttps://github.com/openai/codex/pull/26205",
+    "Lineage + caveat:\n\nStable compare: rust-v0.137.0 -> rust-v0.138.0\nhttps://github.com/openai/codex/compare/rust-v0.137.0...rust-v0.138.0\n\nRelease notes are source evidence; deeper Decodex adoption claims still need Radar review."
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-rust-v0-138-0-release-thread.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26631.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26631.json"
+    ],
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://developers.openai.com/codex/changelog",
+      "https://github.com/openai/codex/releases/tag/rust-v0.137.0",
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0",
+      "https://github.com/openai/codex/compare/rust-v0.137.0...rust-v0.138.0",
+      "https://github.com/openai/codex/pull/25638",
+      "https://github.com/openai/codex/pull/25944",
+      "https://github.com/openai/codex/pull/25344",
+      "https://github.com/openai/codex/pull/25731",
+      "https://github.com/openai/codex/pull/26631",
+      "https://github.com/openai/codex/pull/26690",
+      "https://github.com/openai/codex/pull/26205"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish and mode thread for the stable rust-v0.138.0 release read.",
+    "The release candidate is source-backed by GitHub release metadata, direct PR URLs, compare metadata, official changelog readback notes captured in the candidate, and checked Radar review/impact context for PR #26631.",
+    "Checked durable social_post/v1 records for 2026-06-09 Asia/Shanghai already contain seven published @decodexspace status URLs from the alpha.7 prerelease thread.",
+    "This stable release candidate contains five thread posts, so publishing it today would require daily cap positions 8 through 12 and would exceed the hard cap of 8 posts.",
+    "Open GitHub PR inspection with routed hackink GitHub credentials found only dependency PRs #249, #232, #213, #198, and #196; no open social publication PR added another 2026-06-09 social_post/v1 record.",
+    "No social_publish_reservation/v1 record was created because the cap check failed before the reservation and Chrome compose gate.",
+    "No Chrome account, duplicate, media upload, or final URL readback was attempted because the candidate was blocked before compose authorization.",
+    "The current checked validator accepts daily_cap_exceeded only when decision.daily_count_before is at least 8, so this record preserves the exact checked-tree count and five-post thread overflow evidence in evidence_notes while using the validator-compatible blocked threshold fields."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.138.0 is the current observed stable OpenAI Codex CLI release checkpoint for this run.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.138.0",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The correct stable release lineage comparison is rust-v0.137.0 -> rust-v0.138.0.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.137.0...rust-v0.138.0",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The stable 0.138.0 release candidate would exceed the 2026-06-09 Asia/Shanghai daily cap if published as its source-backed five-post thread.",
+      "evidence": "artifacts/social/x/posts/2026-06-09/openai-codex-rust-v0-138-0-alpha-7-prerelease-read.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The 0.138.0 release notes highlight `/app` Desktop handoff, image path exposure, reasoning effort selection, app-server token usage and v2 PAT support, and plugin JSON/detail upgrades.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.138.0",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Existing checked Radar review coverage among the highlighted stable bullets is limited to PR #26631.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26631.review.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "block",
+    "priority": "high",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-138-0:stable137-stable138:thread",
+    "reason": "daily_cap_exceeded: the source-backed stable 0.138.0 thread would exceed the 2026-06-09 Asia/Shanghai cap after the already-published alpha.7 thread.",
+    "daily_limit": 8,
+    "daily_count_before": 8,
+    "daily_count_after": 8,
+    "day": "2026-06-09",
+    "timezone": "Asia/Shanghai"
+  },
+  "block": {
+    "reason": "daily_cap_exceeded",
+    "operator_notice": "Blocked before Chrome compose: the checked 2026-06-09 ledger already has seven published @decodexspace status URLs, and this five-post stable 0.138.0 thread would exceed the hard cap of 8 posts."
+  },
+  "media_refs": [
+    "media_caveat: no generated media was created because the run stopped at the daily-cap gate before reservation or compose."
+  ],
+  "caveats": [
+    "No X post was published.",
+    "No Chrome tabs were opened for this blocked outcome.",
+    "Do not treat this blocked record as a prerelease quote target.",
+    "If the operator still wants this stable release thread, schedule it for the next Asia/Shanghai cap day and repeat duplicate, account, reservation, media, and final readback gates before compose."
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a terminal `social_post/v1` blocked record for the publishable stable `rust-v0.138.0` release thread.
- Records `block.reason = daily_cap_exceeded` because the 2026-06-09 Asia/Shanghai ledger already has seven published @decodexspace status URLs and the stable candidate is a five-post thread.
- Stops before reservation, Chrome compose, media generation, or X account checks because the cap gate fails first.

## Validation

- `cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x`

## Publisher Evidence

- Candidate: `artifacts/github/social-candidates/openai-codex-rust-v0-138-0-release-thread.json`
- Decision worthiness: `publish`
- Blocked record: `artifacts/social/x/posts/2026-06-09/openai-codex-rust-v0-138-0-release-thread-daily-cap-block.json`
- Daily cap day: `2026-06-09` Asia/Shanghai
- Existing checked count: seven published status URLs from `openai-codex-rust-v0-138-0-alpha-7-prerelease-read`
- Open PR duplicate/cap readback: dependency PRs only; no pending social publication PR found
- Chrome tabs: none opened for this blocked outcome
