### PR TITLE
Persist upstream Radar review artifacts

### DIFF
--- a/artifacts/github/bundles/openai-codex-pr-26202.json
+++ b/artifacts/github/bundles/openai-codex-pr-26202.json
@@ -1,0 +1,122 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "nornagon-openai",
+      "committed_at": "2026-06-03T16:50:44Z",
+      "message": "Restore release symbol artifacts with line tables",
+      "sha": "95202ed2120c490f12f954daeb9ca8167f4e6dc8",
+      "url": "https://github.com/openai/codex/commit/95202ed2120c490f12f954daeb9ca8167f4e6dc8"
+    },
+    {
+      "author": "nornagon-openai",
+      "committed_at": "2026-06-04T16:27:04Z",
+      "message": "Merge remote-tracking branch 'origin/main' into nornagon/codex/release-symbol-line-tables",
+      "sha": "c7f7ad74df9090665b12869705c54268794d289d",
+      "url": "https://github.com/openai/codex/commit/c7f7ad74df9090665b12869705c54268794d289d"
+    },
+    {
+      "author": "nornagon-openai",
+      "committed_at": "2026-06-05T03:37:00Z",
+      "message": "Merge remote-tracking branch 'origin/main' into nornagon/codex/release-symbol-line-tables",
+      "sha": "69c1858bc0c90ef389b581719229395e42676ed3",
+      "url": "https://github.com/openai/codex/commit/69c1858bc0c90ef389b581719229395e42676ed3"
+    },
+    {
+      "author": "nornagon-openai",
+      "committed_at": "2026-06-05T17:01:11Z",
+      "message": "Move release symbol profile into Cargo config",
+      "sha": "0fd91f10f38d70146f7b1d6ed6a3df34207c97cd",
+      "url": "https://github.com/openai/codex/commit/0fd91f10f38d70146f7b1d6ed6a3df34207c97cd"
+    },
+    {
+      "author": "nornagon-openai",
+      "committed_at": "2026-06-08T17:10:16Z",
+      "message": "Merge remote-tracking branch 'origin/main' into nornagon/codex/release-symbol-line-tables",
+      "sha": "c7a47e5b23d8f0bf2742a052139eda48ab4982d6",
+      "url": "https://github.com/openai/codex/commit/c7a47e5b23d8f0bf2742a052139eda48ab4982d6"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "PDB",
+    "CARGO_PROFILE_RELEASE_DEBUG=full",
+    "ARM",
+    "YAML",
+    "--check",
+    "EOF",
+    "--target",
+    "--artifact-name",
+    "--release-dir",
+    "--archive-dir",
+    "--binaries",
+    "--help",
+    "RUNNER_TEMP",
+    "OBJCOPY",
+    "STRIP",
+    "--only-keep-debug",
+    "--strip-debug",
+    "--strip-unneeded",
+    "--add-gnu-debuglink",
+    "AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME",
+    "AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME",
+    "GITHUB_WORKSPACE",
+    "WINDOWS_BINARIES",
+    "CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO",
+    "CLI",
+    "DEBIAN_FRONTEND=noninteractive",
+    "--no-install-recommends",
+    "CODEX_BWRAP_SHA256=${digest}\"",
+    "GITHUB_ENV",
+    "--bin",
+    "--release",
+    "--timings"
+  ],
+  "files": [
+    {
+      "additions": 119,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,119 @@\n+#!/usr/bin/env bash\n+set -euo pipefail\n+\n+usage() {\n+  cat <<'EOF'\n+Usage: archive-release-symbols-and-strip-binaries.sh \\\n+  --target <rust-target> \\\n+  --artifact-name <artifact-name> \\\n+  --release-dir <dir> \\\n+  --archive-dir <dir> \\\n+  --binaries \"<space-delimited binary basenames>\"\n+EOF\n+}\n+\n+target=\"\"\n+artifact_name=\"\"\n+release_dir=\"\"\n+archive_dir=\"\"\n+binaries=\"\"\n+\n+while [[ $# -gt 0 ]]; do\n+  case \"$1\" in\n+    --target)\n+      target=\"${2:?--target requires a value}\"\n+      shift 2\n+      ;;\n+    --artifact-name)\n+      artifact_name=\"${2:?--artifact-name requires a value}\"\n+      shift 2\n+      ;;\n+    --release-dir)\n+      release_dir=\"${2:?--release-dir requires a value}\"\n+      shift 2\n+      ;;\n+    --archive-dir)\n+      archive_dir=\"${2:?--archive-dir requires a value}\"\n+      shift 2\n+      ;;\n+    --binaries)\n+      binaries=\"${2:?--binaries requires a ...",
+      "path": ".github/scripts/archive-release-symbols-and-strip-binaries.sh",
+      "status": "added"
+    },
+    {
+      "additions": 31,
+      "deletions": 2,
+      "patch_excerpt": "@@ -112,10 +112,22 @@ jobs:\n       - name: Stage Windows binaries\n         shell: bash\n         run: |\n-          output_dir=\"target/${{ matrix.target }}/release/staged-${{ matrix.bundle }}\"\n+          release_dir=\"target/${{ matrix.target }}/release\"\n+          output_dir=\"$release_dir/staged-${{ matrix.bundle }}\"\n           mkdir -p \"$output_dir\"\n           for binary in ${{ matrix.binaries }}; do\n-            cp \"target/${{ matrix.target }}/release/${binary}.exe\" \"$output_dir/${binary}.exe\"\n+            pdb_name=\"${binary//-/_}\"\n+            pdb_path=\"$release_dir/${pdb_name}.pdb\"\n+            if [[ ! -f \"$pdb_path\" ]]; then\n+              pdb_path=\"$release_dir/${binary}.pdb\"\n+            fi\n+            if [[ ! -f \"$pdb_path\" ]]; then\n+              echo \"PDB for $binary not found at $release_dir/${pdb_name}.pdb or $release_dir/${binary}.pdb\" >&2\n+              exit 1\n+            f...",
+      "path": ".github/workflows/rust-release-windows.yml",
+      "status": "modified"
+    },
+    {
+      "additions": 38,
+      "deletions": 1,
+      "patch_excerpt": "@@ -64,6 +64,8 @@ jobs:\n       run:\n         working-directory: codex-rs\n     env:\n+      # macOS release packages archive packed dSYM bundles before stripping.\n+      CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: ${{ contains(matrix.target, 'apple-darwin') && 'packed' || 'off' }}\n       # Use the git CLI instead of Cargo's libgit2 path for git dependencies.\n       # macOS release runners have intermittently failed to fetch nested\n       # submodules through SecureTransport/libgit2, especially libwebrtc's\n@@ -163,7 +165,7 @@ jobs:\n         run: |\n           set -euo pipefail\n           sudo apt-get update -y\n-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends pkg-config libcap-dev\n+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends binutils pkg-config libcap-dev\n       - uses: dtolnay/rust-toolchain@e081816240890017053e...",
+      "path": ".github/workflows/rust-release.yml",
+      "status": "modified"
+    },
+    {
+      "additions": 4,
+      "deletions": 3,
+      "patch_excerpt": "@@ -501,10 +501,11 @@ strip = \"symbols\"\n \n [profile.release]\n lto = \"thin\"\n+debug = \"line-tables-only\"\n split-debuginfo = \"off\"\n-# Because we bundle some of these executables with the TypeScript CLI, we\n-# remove everything to make the binary as small as possible.\n-strip = \"symbols\"\n+# Keep release binaries symbolicateable until packaging has archived the\n+# sidecar symbols and stripped the binaries.\n+strip = false\n \n # See https://github.com/openai/codex/issues/1411 for details.\n codegen-units = 1",
+      "path": "codex-rs/Cargo.toml",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Summary\n\n- Restore separate release symbol archives for macOS, Linux, and Windows binaries.\n- Build release binaries with `line-tables-only` debuginfo instead of full debuginfo.\n- Strip Unix distribution binaries after extracting symbols, preserve Windows PDBs, and keep symbol archives available to the release job.\n- Strip the packaged Linux `bwrap` binary before hashing it so the embedded digest matches the distributed bytes.\n\n## Root cause\n\nThe first symbol-artifact implementation enabled `CARGO_PROFILE_RELEASE_DEBUG=full`. In the June 2 release runs, macOS ARM primary builds reached the 90-minute timeout while still inside `Cargo build`. After the symbol changes were reverted, the same primary build completed in about 22 minutes. The archive step itself completed in tens of seconds when reached.\n\nRust's `line-tables-only` debuginfo level preserves function names and source locations for symbolication without emitting the heavier variable and type information from full debuginfo.\n\n## Validation\n\n- Ran `just fmt` from `codex-rs`.\n- Ran `just test-github-scripts` from the repository root: 23 tests passed.\n- Ran `bash -n` and `shellcheck` on `.github/scripts/archive-release-symbols-and-strip-binaries.sh`.\n- Parsed both modified workflows as YAML and ran `git diff --check`.\n- Built a macOS release smoke binary with `line-tables-only`, archived its dSYM through the restored script, stripped the production binary, and verified that `atos` resolves `symbol_smoke_function` to `main.rs:2`.\n- Ran Linux archive-script control-flow coverage with stubbed `objcopy` and `strip` commands.\n- Ran Windows PDB archive staging coverage and verified underscore-emitted Rust PDB names are staged under shipped hyphenated binary names.\n\n## Follow-up\n\nThe release workflow only runs for tags or manual dispatches, so CI cannot dry-run the full release matrix on this PR. The next release run will verify runner time and memory behavior under `line-tables-only`.\n",
+    "labels": [],
+    "merged_at": "2026-06-08T17:16:37Z",
+    "number": 26202,
+    "state": "merged",
+    "title": "[codex] Restore release symbol artifacts with line tables",
+    "url": "https://github.com/openai/codex/pull/26202"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-26230.json
+++ b/artifacts/github/bundles/openai-codex-pr-26230.json
@@ -1,0 +1,111 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "viyatb-oai",
+      "committed_at": "2026-06-03T17:31:13Z",
+      "message": "fix: preserve Auto Review across config and tasks",
+      "sha": "d6528ccc954f1768a3d7d080bba8162b59d982a1",
+      "url": "https://github.com/openai/codex/commit/d6528ccc954f1768a3d7d080bba8162b59d982a1"
+    },
+    {
+      "author": "viyatb-oai",
+      "committed_at": "2026-06-05T17:26:03Z",
+      "message": "fix: align app-server auto review serialization",
+      "sha": "bf84a984d0233936cf29c72dd60d704b9182d569",
+      "url": "https://github.com/openai/codex/commit/bf84a984d0233936cf29c72dd60d704b9182d569"
+    },
+    {
+      "author": "saud-oai",
+      "committed_at": "2026-06-08T18:35:16Z",
+      "message": "Merge branch 'main' into codex/viyatb/guardian-auto-review-continuity",
+      "sha": "8e14f2d413ef8a826d45a0602573148c6c7ac358",
+      "url": "https://github.com/openai/codex/commit/8e14f2d413ef8a826d45a0602573148c6c7ac358"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "TUI",
+    "MDM"
+  ],
+  "files": [
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -233,7 +233,7 @@ impl From<CoreAskForApproval> for AskForApproval {\n pub enum ApprovalsReviewer {\n     #[serde(rename = \"user\")]\n     User,\n-    #[serde(rename = \"guardian_subagent\", alias = \"auto_review\")]\n+    #[serde(rename = \"auto_review\", alias = \"guardian_subagent\")]\n     AutoReview,\n }",
+      "path": "codex-rs/app-server-protocol/src/protocol/v2/shared.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -65,7 +65,7 @@ fn approvals_reviewer_serializes_auto_review_and_accepts_legacy_guardian_subagen\n     );\n     assert_eq!(\n         serde_json::to_string(&ApprovalsReviewer::AutoReview).expect(\"serialize reviewer\"),\n-        \"\\\"guardian_subagent\\\"\"\n+        \"\\\"auto_review\\\"\"\n     );\n \n     for value in [\"user\", \"auto_review\", \"guardian_subagent\"] {",
+      "path": "codex-rs/app-server-protocol/src/protocol/v2/tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -1467,7 +1467,7 @@ foo = \"xyzzy\"\n             TomlValue::Table(toml::map::Map::from_iter([(\n                 \"allowed_approvals_reviewers\".to_string(),\n                 TomlValue::Array(vec![\n-                    TomlValue::String(\"guardian_subagent\".to_string()),\n+                    TomlValue::String(\"auto_review\".to_string()),\n                     TomlValue::String(\"user\".to_string()),\n                 ]),\n             )]))",
+      "path": "codex-rs/config/src/loader/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -262,6 +262,7 @@ pub(crate) fn apply_spawn_agent_runtime_overrides(\n         .map_err(|err| {\n             FunctionCallError::RespondToModel(format!(\"approval_policy is invalid: {err}\"))\n         })?;\n+    config.approvals_reviewer = turn.config.approvals_reviewer;\n     config.permissions.shell_environment_policy = turn.shell_environment_policy.clone();\n     config.codex_linux_sandbox_exe = turn.codex_linux_sandbox_exe.clone();\n     #[allow(deprecated)]",
+      "path": "codex-rs/core/src/tools/handlers/multi_agents_common.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 5,
+      "deletions": 0,
+      "patch_excerpt": "@@ -24,6 +24,7 @@ use codex_model_provider::create_model_provider;\n use codex_model_provider_info::built_in_model_providers;\n use codex_protocol::AgentPath;\n use codex_protocol::ThreadId;\n+use codex_protocol::config_types::ApprovalsReviewer;\n use codex_protocol::config_types::ServiceTier;\n use codex_protocol::config_types::ShellEnvironmentPolicy;\n use codex_protocol::models::BaseInstructions;\n@@ -2331,6 +2332,9 @@ async fn spawn_agent_reapplies_runtime_sandbox_after_role_config() {\n     turn.approval_policy\n         .set(AskForApproval::OnRequest)\n         .expect(\"approval policy should be set\");\n+    let mut config = (*turn.config).clone();\n+    config.approvals_reviewer = ApprovalsReviewer::AutoReview;\n+    set_turn_config(&mut turn, config);\n     turn.permission_profile = expected_permission_profile.clone();\n     assert_ne!(\n         expected_permission_profile,\n@@ -2370,6 +2374,7 @@...",
+      "path": "codex-rs/core/src/tools/handlers/multi_agents_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 3,
+      "patch_excerpt": "@@ -166,8 +166,8 @@ pub enum ApprovalsReviewer {\n     #[default]\n     #[serde(rename = \"user\")]\n     User,\n-    #[serde(rename = \"guardian_subagent\", alias = \"auto_review\")]\n-    #[strum(serialize = \"guardian_subagent\")]\n+    #[serde(rename = \"auto_review\", alias = \"guardian_subagent\")]\n+    #[strum(serialize = \"auto_review\")]\n     AutoReview,\n }\n \n@@ -760,7 +760,7 @@ mod tests {\n         );\n         assert_eq!(\n             serde_json::to_string(&ApprovalsReviewer::AutoReview).expect(\"serialize reviewer\"),\n-            \"\\\"guardian_subagent\\\"\"\n+            \"\\\"auto_review\\\"\"\n         );\n \n         for value in [\"user\", \"auto_review\", \"guardian_subagent\"] {",
+      "path": "codex-rs/protocol/src/config_types.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 2,
+      "patch_excerpt": "@@ -1824,7 +1824,7 @@ async fn update_feature_flags_enabling_guardian_selects_auto_review() -> Result<\n \n     let config = std::fs::read_to_string(codex_home.path().join(\"config.toml\"))?;\n     assert!(config.contains(\"guardian_approval = true\"));\n-    assert!(config.contains(\"approvals_reviewer = \\\"guardian_subagent\\\"\"));\n+    assert!(config.contains(\"approvals_reviewer = \\\"auto_review\\\"\"));\n     assert!(config.contains(\"approval_policy = \\\"on-request\\\"\"));\n     assert!(config.contains(\"sandbox_mode = \\\"workspace-write\\\"\"));\n     app_server.shutdown().await?;\n@@ -1988,7 +1988,7 @@ async fn update_feature_flags_enabling_guardian_overrides_explicit_manual_review\n     );\n \n     let config = std::fs::read_to_string(codex_home.path().join(\"config.toml\"))?;\n-    assert!(config.contains(\"approvals_reviewer = \\\"guardian_subagent\\\"\"));\n+    assert!(config.contains(\"approvals_reviewer = \\\"auto_rev...",
+      "path": "codex-rs/tui/src/app/tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 2,
+      "patch_excerpt": "@@ -755,7 +755,7 @@ mod tests {\n             \"allowed_approval_policies: on-request (source: {requirements_source})\"\n         )));\n         assert!(rendered.contains(\n-            \"allowed_approvals_reviewers: guardian_subagent (source: MDM managed_config.toml (legacy))\"\n+            \"allowed_approvals_reviewers: auto_review (source: MDM managed_config.toml (legacy))\"\n         ));\n         assert!(\n             rendered.contains(\n@@ -818,7 +818,7 @@ mod tests {\n \n         let rendered = render_to_text(&render_debug_config_lines(&stack));\n         assert!(rendered.contains(\n-            \"allowed_approvals_reviewers: guardian_subagent (source: MDM managed_config.toml (legacy))\"\n+            \"allowed_approvals_reviewers: auto_review (source: MDM managed_config.toml (legacy))\"\n         ));\n         assert!(!rendered.contains(\"Requirements:\\n  <none>\"));\n     }",
+      "path": "codex-rs/tui/src/debug_config.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#26231",
+    "#26334",
+    "#26333",
+    "#26232"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nAuto Review should remain the effective approval reviewer when settings cross runtime boundaries. A config or app-server round trip must not change the reviewer identity, and delegated work must not silently fall back to user review.\n\nThis requires both a stable canonical serialized value and propagation of the effective setting. `auto_review` is the canonical value across protocol and app-server output, while `guardian_subagent` remains accepted as backward-compatible input.\n\n## What changed\n\n- serialize `ApprovalsReviewer::AutoReview` consistently as `auto_review` across core protocol and app-server v2\n- continue accepting `guardian_subagent` when reading existing config or client requests\n- carry the active turn's approval reviewer into spawned agents\n- update config/debug expectations and add delegated-task regression coverage\n\n## Scope\n\nThis does not change Guardian policy or remove compatibility with existing `guardian_subagent` inputs. It preserves the selected reviewer across serialization, config reloads, app-server settings, and delegated task setup.\n\nRelated Guardian changes are split independently:\n\n- #26231 adds denials and soft denials\n- #26334 retries transient reviewer failures\n- #26333 reuses narrowly scoped low-risk approvals\n- #26232 adds TUI denial recovery\n\n## Validation\n\n- `just test -p codex-app-server-protocol` (224 passed)\n- regression coverage for delegated task reviewer propagation\n- serialization coverage for canonical `auto_review` output and legacy `guardian_subagent` input\n",
+    "labels": [],
+    "merged_at": "2026-06-08T18:59:51Z",
+    "number": 26230,
+    "state": "merged",
+    "title": "fix: preserve auto review across config and delegation",
+    "url": "https://github.com/openai/codex/pull/26230"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-26637.json
+++ b/artifacts/github/bundles/openai-codex-pr-26637.json
@@ -1,0 +1,153 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "stefanstokic-oai",
+      "committed_at": "2026-06-04T21:53:13Z",
+      "message": "Improve external agent import performance",
+      "sha": "3a77fbcc7217e2a49e7447017ac4932625e55912",
+      "url": "https://github.com/openai/codex/commit/3a77fbcc7217e2a49e7447017ac4932625e55912"
+    },
+    {
+      "author": "stefanstokic-oai",
+      "committed_at": "2026-06-05T19:32:19Z",
+      "message": "Merge branch 'main' into codex/external-agent-import-perf",
+      "sha": "cbb1d21dfa72d84973bcc8b58a6deaca53808e0f",
+      "url": "https://github.com/openai/codex/commit/cbb1d21dfa72d84973bcc8b58a6deaca53808e0f"
+    },
+    {
+      "author": "stefanstokic-oai",
+      "committed_at": "2026-06-08T13:36:48Z",
+      "message": "Merge branch 'main' into codex/external-agent-import-perf",
+      "sha": "2a416e92a12e43d044e4a39096f1825a29b11d3f",
+      "url": "https://github.com/openai/codex/commit/2a416e92a12e43d044e4a39096f1825a29b11d3f"
+    },
+    {
+      "author": "stefanstokic-oai",
+      "committed_at": "2026-06-08T15:17:22Z",
+      "message": "Merge branch 'main' into codex/external-agent-import-perf",
+      "sha": "1188ee05a5b82e99bc653820a27c8830d66ab7bf",
+      "url": "https://github.com/openai/codex/commit/1188ee05a5b82e99bc653820a27c8830d66ab7bf"
+    },
+    {
+      "author": "stefanstokic-oai",
+      "committed_at": "2026-06-08T15:19:24Z",
+      "message": "Refine external agent session import pipeline",
+      "sha": "fd0f44bb07220d2ae600bca3c38b2af596ae21e1",
+      "url": "https://github.com/openai/codex/commit/fd0f44bb07220d2ae600bca3c38b2af596ae21e1"
+    },
+    {
+      "author": "stefanstokic-oai",
+      "committed_at": "2026-06-08T17:12:22Z",
+      "message": "Merge branch 'main' into codex/external-agent-import-perf",
+      "sha": "583174aca7660c1a872ac7aead5abb335dec1f65",
+      "url": "https://github.com/openai/codex/commit/583174aca7660c1a872ac7aead5abb335dec1f65"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "MCP",
+    "API",
+    "JSONRPCE",
+    "SESSION_IMPORT_CONCURRENCY",
+    "CARGO_PKG_VERSION",
+    "HOME",
+    "DEFAULT_TIMEOUT",
+    "SESSIONS",
+    "JSONRPCR",
+    "EXTERNAL_SESSION_IMPORTED_MARKER",
+    "EXTERNAL",
+    "SESSION",
+    "IMPORTED",
+    "MAX"
+  ],
+  "files": [
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -474,6 +474,7 @@ impl MessageProcessor {\n         let external_agent_config_processor = ExternalAgentConfigRequestProcessor::new(\n             outgoing.clone(),\n             Arc::clone(&thread_manager),\n+            Arc::clone(&thread_store),\n             config_manager.clone(),\n             config_processor.clone(),\n             arg0_paths,",
+      "path": "codex-rs/app-server/src/message_processor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -461,6 +461,7 @@ mod command_exec_processor;\n mod config_processor;\n mod environment_processor;\n mod external_agent_config_processor;\n+mod external_agent_session_import;\n mod feedback_doctor_report;\n mod feedback_processor;\n mod fs_processor;",
+      "path": "codex-rs/app-server/src/request_processors.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 15,
+      "deletions": 128,
+      "patch_excerpt": "@@ -26,53 +26,47 @@ use codex_app_server_protocol::MigrationDetails;\n use codex_app_server_protocol::PluginsMigration;\n use codex_app_server_protocol::ServerNotification;\n use codex_arg0::Arg0DispatchPaths;\n-use codex_core::StartThreadOptions;\n use codex_core::ThreadManager;\n-use codex_core::config::ConfigOverrides;\n use codex_external_agent_sessions::ExternalAgentSessionMigration as CoreSessionMigration;\n-use codex_external_agent_sessions::ImportedExternalAgentSession;\n-use codex_external_agent_sessions::PendingSessionImport;\n-use codex_external_agent_sessions::prepare_validated_session_imports;\n-use codex_external_agent_sessions::record_imported_session;\n-use codex_protocol::ThreadId;\n-use codex_protocol::protocol::InitialHistory;\n-use codex_thread_store::ThreadMetadataPatch;\n+use codex_thread_store::ThreadStore;\n use std::collections::HashSet;\n use std::path::PathBuf;\n-use tokio::sync...",
+      "path": "codex-rs/app-server/src/request_processors/external_agent_config_processor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 260,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,260 @@\n+use std::path::PathBuf;\n+use std::sync::Arc;\n+\n+use chrono::Utc;\n+use codex_arg0::Arg0DispatchPaths;\n+use codex_core::ThreadManager;\n+use codex_core::config::ConfigOverrides;\n+use codex_external_agent_sessions::CompletedExternalAgentSessionImport;\n+use codex_external_agent_sessions::ExternalAgentSessionMigration;\n+use codex_external_agent_sessions::ImportedExternalAgentSession;\n+use codex_external_agent_sessions::PendingSessionImport;\n+use codex_external_agent_sessions::prepare_validated_session_import;\n+use codex_external_agent_sessions::record_completed_session_imports;\n+use codex_models_manager::manager::RefreshStrategy;\n+use codex_protocol::ThreadId;\n+use codex_protocol::models::BaseInstructions;\n+use codex_protocol::protocol::MultiAgentVersion;\n+use codex_protocol::protocol::ThreadMemoryMode;\n+use codex_rollout::is_persisted_rollout_item;\n+use codex_thread_store::...",
+      "path": "codex-rs/app-server/src/request_processors/external_agent_session_import.rs",
+      "status": "added"
+    },
+    {
+      "additions": 92,
+      "deletions": 0,
+      "patch_excerpt": "@@ -435,6 +435,98 @@ async fn external_agent_config_import_creates_session_rollouts() -> Result<()> {\n     Ok(())\n }\n \n+#[tokio::test]\n+async fn external_agent_config_import_does_not_initialize_required_mcp() -> Result<()> {\n+    let server = create_mock_responses_server_repeating_assistant(\"unused\").await;\n+    let codex_home = TempDir::new()?;\n+    create_config_toml(codex_home.path(), &server.uri())?;\n+    let mut config = std::fs::read_to_string(codex_home.path().join(\"config.toml\"))?;\n+    config.push_str(\n+        r#\"\n+[mcp_servers.required_broken]\n+command = \"this-command-does-not-exist\"\n+required = true\n+\"#,\n+    );\n+    std::fs::write(codex_home.path().join(\"config.toml\"), config)?;\n+    let project_root = codex_home.path().join(\"repo\");\n+    let recent_timestamp = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);\n+    let session_dir = codex_home.path().joi...",
+      "path": "codex-rs/app-server/tests/suite/v2/external_agent_config.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 106,
+      "deletions": 85,
+      "patch_excerpt": "@@ -1,10 +1,7 @@\n use crate::ConversationMessage;\n use crate::ImportedExternalAgentSession;\n use crate::MessageRole;\n-use crate::records::conversation_messages;\n-use crate::records::project_root_from_records;\n-use crate::records::read_records;\n-use crate::records::source_title_from_records;\n+use crate::records::read_session_import;\n use crate::summarize_for_label;\n use codex_protocol::models::ContentItem;\n use codex_protocol::models::ResponseItem;\n@@ -23,44 +20,55 @@ use std::path::Path;\n \n const EXTERNAL_SESSION_IMPORTED_MARKER: &str = \"<EXTERNAL SESSION IMPORTED>\";\n \n-pub fn load_session_for_import(path: &Path) -> io::Result<Option<ImportedExternalAgentSession>> {\n-    let records = read_records(path)?;\n-    let Some(cwd) = project_root_from_records(&records) else {\n+#[cfg(test)]\n+fn load_session_for_import(path: &Path) -> io::Result<Option<ImportedExternalAgentSession>> {\n+    Ok(\n+  ...",
+      "path": "codex-rs/external-agent-sessions/src/export.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 51,
+      "deletions": 16,
+      "patch_excerpt": "@@ -30,6 +30,13 @@ struct ImportedExternalAgentSessionRecord {\n     source_modified_at: Option<i64>,\n }\n \n+#[derive(Debug, PartialEq, Eq)]\n+pub struct CompletedExternalAgentSessionImport {\n+    pub source_path: PathBuf,\n+    pub source_content_sha256: String,\n+    pub imported_thread_id: ThreadId,\n+}\n+\n #[derive(Debug, Clone, Copy)]\n pub(super) struct ImportedSourceState {\n     pub source_modified_at: Option<i64>,\n@@ -43,29 +50,50 @@ pub fn has_current_session_been_imported(\n     load_import_ledger(codex_home)?.contains_current_source(source_path)\n }\n \n-pub fn record_imported_session(\n+#[cfg(test)]\n+pub(crate) fn record_imported_session(\n     codex_home: &Path,\n     source_path: &Path,\n     imported_thread_id: ThreadId,\n ) -> io::Result<()> {\n-    let mut ledger = load_import_ledger(codex_home)?;\n     let source_path = canonical_source_path(source_path)?;\n-    let content_sha256 = sessio...",
+      "path": "codex-rs/external-agent-sessions/src/ledger.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 85,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,85 @@\n+use super::CompletedExternalAgentSessionImport;\n+use super::ImportedExternalAgentSessionLedger;\n+use super::record_completed_session_imports;\n+use codex_protocol::ThreadId;\n+use sha2::Digest;\n+use sha2::Sha256;\n+use tempfile::TempDir;\n+\n+#[test]\n+fn empty_ledger_does_not_read_source() {\n+    let root = TempDir::new().expect(\"tempdir\");\n+    let missing_source = root.path().join(\"missing-session.jsonl\");\n+\n+    assert!(\n+        !ImportedExternalAgentSessionLedger::default()\n+            .contains_current_source(&missing_source)\n+            .expect(\"empty ledger cannot contain sources\")\n+    );\n+}\n+\n+#[test]\n+fn completed_imports_do_not_read_source_files() {\n+    let root = TempDir::new().expect(\"tempdir\");\n+    let codex_home = root.path().join(\"codex-home\");\n+    let source_path = root.path().join(\"session.jsonl\");\n+    let contents = b\"session contents\";\n+    std::fs...",
+      "path": "codex-rs/external-agent-sessions/src/ledger_tests.rs",
+      "status": "added"
+    },
+    {
+      "additions": 68,
+      "deletions": 108,
+      "patch_excerpt": "@@ -6,15 +6,15 @@ mod ledger;\n mod records;\n \n use codex_protocol::protocol::RolloutItem;\n-use std::collections::HashSet;\n use std::io;\n use std::path::Path;\n use std::path::PathBuf;\n \n pub use detect::detect_recent_sessions;\n-pub use export::load_session_for_import;\n+use export::load_session_for_import_with_content_sha256;\n+pub use ledger::CompletedExternalAgentSessionImport;\n pub use ledger::has_current_session_been_imported;\n-pub use ledger::record_imported_session;\n+pub use ledger::record_completed_session_imports;\n pub use records::SessionSummary;\n pub use records::summarize_session;\n \n@@ -31,105 +31,51 @@ pub struct ExternalAgentSessionMigration {\n pub struct ImportedExternalAgentSession {\n     pub cwd: PathBuf,\n     pub title: Option<String>,\n+    pub first_user_message: Option<String>,\n     pub rollout_items: Vec<RolloutItem>,\n }\n \n #[derive(Debug, Clone)]\n pub struct PendingSess...",
+      "path": "codex-rs/external-agent-sessions/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 106,
+      "deletions": 49,
+      "patch_excerpt": "@@ -4,6 +4,8 @@ use crate::MessageRole;\n use crate::summarize_for_label;\n use crate::truncate;\n use serde_json::Value as JsonValue;\n+use sha2::Digest;\n+use sha2::Sha256;\n use std::fs::File;\n use std::io;\n use std::io::BufRead;\n@@ -21,6 +23,13 @@ pub struct SessionSummary {\n     pub migration: ExternalAgentSessionMigration,\n }\n \n+pub(super) struct ParsedSessionImport {\n+    pub cwd: Option<PathBuf>,\n+    pub source_title: Option<String>,\n+    pub messages: Vec<ConversationMessage>,\n+    pub content_sha256: String,\n+}\n+\n pub fn summarize_session(path: &Path) -> io::Result<Option<SessionSummary>> {\n     let file = File::open(path)?;\n     let reader = BufReader::new(file);\n@@ -37,7 +46,7 @@ pub fn summarize_session(path: &Path) -> io::Result<Option<SessionSummary>> {\n         if trimmed.is_empty() {\n             continue;\n         }\n-        let Ok(record) = serde_json::from_str::<JsonValue>...",
+      "path": "codex-rs/external-agent-sessions/src/records.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nImporting large external-agent session histories currently starts a full live Codex thread for every imported session. This initializes unrelated runtime systems and repeats expensive transcript, metadata, hashing, and ledger work.\n\nOn a 50-session, 238 MiB fixture, the existing path took roughly 70 seconds to complete the import and 77 seconds end to end.\n\n## What changed\n\n- Persist imported sessions directly through `ThreadStore` instead of starting full live threads.\n- Process imports through a bounded five-session pipeline.\n- Parse, extract, and hash each source file in one pass.\n- Move blocking source preparation onto the blocking thread pool.\n- Reuse prepared content hashes and update the import ledger once per batch.\n- Avoid metadata readback for newly written rollouts.\n- Preserve imported conversation history and visible thread metadata.\n- Keep the implementation out of `codex-core` and avoid changes to the public `ThreadStore` trait.\n\n## Performance\n\nFor the same 50-session, 238 MiB fixture:\n\n| Path | Import completion | End to end |\n| --- | ---: | ---: |\n| Existing import | 69.61s | 76.62s |\n| This change | 5.95s | 6.58s |\n\nAll 50 sessions imported successfully with no warnings or contention signals.\n\n## Validation\n\n- `just test -p codex-external-agent-sessions`\n- `just test -p codex-app-server external_agent_config_import`\n- Verified imports do not initialize unrelated required MCP servers.\n- Verified previously imported source versions are skipped and changed sources can be imported again.\n- Verified imported rollouts remain readable through thread listing and history APIs.\n",
+    "labels": [],
+    "merged_at": "2026-06-08T18:16:32Z",
+    "number": 26637,
+    "state": "merged",
+    "title": "[codex] Speed up external agent session imports",
+    "url": "https://github.com/openai/codex/pull/26637"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27009.json
+++ b/artifacts/github/bundles/openai-codex-pr-27009.json
@@ -1,0 +1,62 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "mpc-oai",
+      "committed_at": "2026-06-08T15:08:27Z",
+      "message": "Expose configured marketplace source in marketplace list JSON",
+      "sha": "a4520a312a6ac3509088827dc96bc5c20ec96ef6",
+      "url": "https://github.com/openai/codex/commit/a4520a312a6ac3509088827dc96bc5c20ec96ef6"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "--json",
+    "CLI",
+    "JSON",
+    "HOME"
+  ],
+  "files": [
+    {
+      "additions": 49,
+      "deletions": 2,
+      "patch_excerpt": "@@ -5,7 +5,10 @@ use clap::Parser;\n use codex_core::config::Config;\n use codex_core::config::find_codex_home;\n use codex_core_plugins::PluginMarketplaceUpgradeOutcome;\n+use codex_core_plugins::PluginsConfigInput;\n use codex_core_plugins::PluginsManager;\n+use codex_core_plugins::installed_marketplaces::marketplace_install_root;\n+use codex_core_plugins::installed_marketplaces::resolve_configured_marketplace_root;\n use codex_core_plugins::marketplace::marketplace_root_dir;\n use codex_core_plugins::marketplace_add::MarketplaceAddOutcome;\n use codex_core_plugins::marketplace_add::MarketplaceAddRequest;\n@@ -15,9 +18,14 @@ use codex_core_plugins::marketplace_remove::MarketplaceRemoveRequest;\n use codex_core_plugins::marketplace_remove::remove_marketplace;\n use codex_utils_cli::CliConfigOverrides;\n use serde::Serialize;\n+use std::collections::HashMap;\n use std::collections::HashSet;\n+use std::pa...",
+      "path": "codex-rs/cli/src/marketplace_cmd.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 2,
+      "patch_excerpt": "@@ -437,12 +437,12 @@ impl JsonPluginSource {\n \n #[derive(Debug, Clone, Serialize)]\n #[serde(rename_all = \"camelCase\")]\n-struct JsonMarketplaceSource {\n+pub(crate) struct JsonMarketplaceSource {\n     source_type: String,\n     source: String,\n }\n \n-fn configured_marketplace_sources(\n+pub(crate) fn configured_marketplace_sources(\n     plugins_input: &PluginsConfigInput,\n ) -> HashMap<String, JsonMarketplaceSource> {\n     let Some(user_config) = plugins_input.config_layer_stack.effective_user_config() else {",
+      "path": "codex-rs/cli/src/plugin_cmd.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 107,
+      "deletions": 1,
+      "patch_excerpt": "@@ -341,6 +341,7 @@ async fn marketplace_list_shows_configured_marketplace_names() -> Result<()> {\n #[tokio::test]\n async fn marketplace_list_json_prints_configured_marketplaces() -> Result<()> {\n     let (codex_home, source) = setup_local_marketplace()?;\n+    let source_path = source.path().display().to_string();\n \n     let assert = codex_command(codex_home.path())?\n         .args([\"plugin\", \"marketplace\", \"list\", \"--json\"])\n@@ -355,7 +356,112 @@ async fn marketplace_list_json_prints_configured_marketplaces() -> Result<()> {\n             \"marketplaces\": [\n                 {\n                     \"name\": \"debug\",\n-                    \"root\": source.path().display().to_string(),\n+                    \"root\": source_path,\n+                    \"marketplaceSource\": {\n+                        \"sourceType\": \"local\",\n+                        \"source\": source_path,\n+                    },\n+       ...",
+      "path": "codex-rs/cli/tests/plugin_cli.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#26417",
+    "#26631"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Summary\r\n- Follow-up to #26417 and #26631\r\n- Add `marketplaceSource` to `codex plugin marketplace list --json` entries for configured marketplaces\r\n- Reuse the existing `marketplaceSource` shape from `codex plugin list --json`\r\n- Keep human-readable marketplace list output unchanged\r\n- Add CLI coverage for configured local and git marketplace sources\r\n\r\nExample:\r\n\r\n```json\r\n{\r\n  \"marketplaces\": [\r\n    {\r\n      \"name\": \"debug\",\r\n      \"root\": \"/path/to/.codex/.tmp/marketplaces/debug\",\r\n      \"marketplaceSource\": {\r\n        \"sourceType\": \"git\",\r\n        \"source\": \"https://example.com/acme/agent-skills.git\"\r\n      }\r\n    }\r\n  ]\r\n}\r\n```\r\n\r\n## Validation\r\n- `just fmt`\r\n- `just fix -p codex-cli`\r\n- `just test -p codex-cli marketplace_list`\r\n- `just test -p codex-cli`",
+    "labels": [],
+    "merged_at": "2026-06-08T18:37:55Z",
+    "number": 27009,
+    "state": "merged",
+    "title": "[plugins] Expose marketplace source in marketplace list JSON",
+    "url": "https://github.com/openai/codex/pull/27009"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/impact/openai-codex-pr-26202.json
+++ b/artifacts/github/impact/openai-codex-pr-26202.json
@@ -1,0 +1,44 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-26202",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Restore release symbol artifacts with line tables",
+        "url": "https://github.com/openai/codex/pull/26202",
+        "meta": "Merged 2026-06-08T17:16:37Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/26202",
+        "meta": "artifacts/github/reviews/openai-codex-pr-26202.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex restores separate release symbol archives while switching release builds to line-tables-only debuginfo and stripping packaged binaries after symbol capture.",
+  "public_signal_decision": "defer",
+  "control_plane_impact": "watch",
+  "publisher_angle": "watch_note",
+  "confidence": "confirmed",
+  "evidence": [
+    "The PR body describes restored release symbol archives and line-tables-only debuginfo as the fix for prior release-build timeouts.",
+    "The release profile now keeps line tables before packaging and lets the release workflows strip packaged binaries after symbol archive capture.",
+    "The release workflow and archive script cover macOS dSYM archives, Unix binary stripping, Linux bwrap digest consistency, and Windows PDB staging.",
+    "The upstream review records no app-server, CLI, config, or user workflow migration."
+  ],
+  "candidate_followups": [
+    "Treat this as release-rollup context for Codex artifact observability rather than a standalone Decodex Control Plane change.",
+    "If Decodex later consumes upstream release assets, account for sidecar symbol archives when designing crash-diagnostic readback."
+  ],
+  "social_notes": [
+    "A standalone public post is deferred because the value is mainly release-operator/debuggability context.",
+    "If used in a release rollup, phrase it as restored symbolication support with the caveat that full release-matrix timing is proven only by later release runs."
+  ],
+  "caveats": [
+    "The PR cannot dry-run the full tag/manual-dispatch release matrix.",
+    "The change affects artifact packaging and symbolication, not a normal Codex command path."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-26230.json
+++ b/artifacts/github/impact/openai-codex-pr-26230.json
@@ -1,0 +1,45 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-26230",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "fix: preserve auto review across config and delegation",
+        "url": "https://github.com/openai/codex/pull/26230",
+        "meta": "Merged 2026-06-08T18:59:51Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/26230",
+        "meta": "artifacts/github/reviews/openai-codex-pr-26230.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex makes `auto_review` the canonical serialized approval reviewer value while still accepting legacy `guardian_subagent` input and propagating the active reviewer into spawned agents.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "The core protocol and app-server protocol enums serialize Auto Review as `auto_review` and retain `guardian_subagent` as an alias.",
+    "Config loader, TUI, and debug-config tests update expected output to the canonical `auto_review` value.",
+    "The multi-agent spawn path now copies the active turn's `approvals_reviewer` into spawned-agent config overrides.",
+    "The PR body says delegated work must not silently fall back to user review."
+  ],
+  "candidate_followups": [
+    "Update Decodex approval-reviewer schema handling to emit `auto_review` and continue accepting legacy `guardian_subagent`.",
+    "Check delegated-agent launch paths for reviewer preservation so automation does not fall back to user review after config/app-server round trips.",
+    "Update operator debug/readback copy if any Decodex surfaces still display `guardian_subagent` as the canonical value."
+  ],
+  "social_notes": [
+    "Public copy should frame this as a canonical config/protocol value plus delegated-agent continuity.",
+    "Mention backward-compatible input support to avoid overstating it as a hard removal."
+  ],
+  "caveats": [
+    "Adjacent Guardian policy changes are split into separate upstream PRs.",
+    "Legacy `guardian_subagent` input remains accepted."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-26637.json
+++ b/artifacts/github/impact/openai-codex-pr-26637.json
@@ -1,0 +1,45 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-26637",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Speed up external agent session imports",
+        "url": "https://github.com/openai/codex/pull/26637",
+        "meta": "Merged 2026-06-08T18:16:32Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/26637",
+        "meta": "artifacts/github/reviews/openai-codex-pr-26637.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex imports external-agent session histories directly through ThreadStore with a bounded preparation pipeline instead of starting full live threads for every imported session.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "candidate",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "The PR body says imports now persist directly through `ThreadStore` and process through a bounded five-session pipeline.",
+    "The added app-server import module prepares imports, reuses content hashes, and writes stored threads rather than starting unrelated live runtime systems.",
+    "Regression coverage verifies imports do not initialize unrelated required MCP servers.",
+    "The PR reports a large-fixture import speedup from about 70 seconds to about 6 seconds while keeping rollouts readable through thread listing and history APIs."
+  ],
+  "candidate_followups": [
+    "Check whether Decodex external-agent import monitoring should distinguish stored-thread writes from live-thread starts.",
+    "If Decodex exposes bulk external-agent import status, present unchanged-source skips and completed batch ledger updates as import evidence.",
+    "Avoid treating required MCP startup diagnostics as import prerequisites when using this upstream path."
+  ],
+  "social_notes": [
+    "Public copy should focus on faster external-agent history ingestion and the removal of required-MCP startup side effects.",
+    "Use the PR's 50-session fixture numbers as upstream-measured evidence, not a universal benchmark."
+  ],
+  "caveats": [
+    "The change does not alter the public ThreadStore trait according to the PR body.",
+    "Performance may differ outside the upstream 50-session fixture."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-27009.json
+++ b/artifacts/github/impact/openai-codex-pr-27009.json
@@ -1,0 +1,45 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27009",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[plugins] Expose marketplace source in marketplace list JSON",
+        "url": "https://github.com/openai/codex/pull/27009",
+        "meta": "Merged 2026-06-08T18:37:55Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27009",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27009.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex adds `marketplaceSource` provenance to `codex plugin marketplace list --json` entries for configured marketplaces while leaving human-readable output unchanged.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "candidate",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "The PR body includes an example `marketplaceSource` object with `sourceType` and `source` in marketplace-list JSON.",
+    "The CLI marketplace command now reuses configured marketplace source helpers from plugin-list code.",
+    "CLI tests assert local and git marketplace-list JSON output includes `marketplaceSource`.",
+    "The upstream review records no removal of existing fields and no human-readable output change."
+  ],
+  "candidate_followups": [
+    "Use `marketplaceSource` in Decodex plugin catalog diagnostics when showing where a marketplace was configured from.",
+    "Update strict plugin marketplace JSON adapters to tolerate the new additive field.",
+    "Consider this field as provenance evidence when diagnosing stale or pruned marketplace caches."
+  ],
+  "social_notes": [
+    "Public copy should mention the exact CLI path and that the field is JSON-only.",
+    "Avoid implying that Codex verifies remote marketplace freshness during list output."
+  ],
+  "caveats": [
+    "The field is additive and currently scoped to configured marketplaces.",
+    "Human-readable marketplace list output remains unchanged."
+  ]
+}

--- a/artifacts/github/review-queue/openai-codex-latest.json
+++ b/artifacts/github/review-queue/openai-codex-latest.json
@@ -1,14 +1,14 @@
 {
   "counts": {
-    "critical": 14,
-    "high": 8,
+    "critical": 13,
+    "high": 9,
     "low": 2,
     "normal": 16,
     "published_subjects_seen": 0,
     "recent_commits_scanned": 40,
     "subjects_queued": 40
   },
-  "generated_at": "2026-06-09T02:04:16.262124Z",
+  "generated_at": "2026-06-09T08:06:27.782925Z",
   "repo": "openai/codex",
   "schema": "upstream_review_queue/v1",
   "source": {
@@ -17,42 +17,6 @@
     "signals_dir": "site/src/content/signals"
   },
   "subjects": [
-    {
-      "attention_flags": [
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 6,
-      "commit_shas": [
-        "f5fa53ac9c2a7f7955bbff34cb0a5c65450facd7"
-      ],
-      "committed_at": "2026-06-07T18:33:16Z",
-      "next_step": "ai_review_required",
-      "pr_number": 24981,
-      "pr_url": "https://github.com/openai/codex/pull/24981",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs",
-        "codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs",
-        "codex-rs/core/src/tools/runtimes/unified_exec.rs",
-        "codex-rs/core/tests/common/zsh_fork.rs",
-        "codex-rs/core/tests/suite/mod.rs",
-        "codex-rs/core/tests/suite/unified_exec_zsh_fork_approvals.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "24981",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "sandbox_permissions",
-        "tests_ci"
-      ],
-      "title": "fix: preserve approval sandbox decisions in unified exec",
-      "url": "https://github.com/openai/codex/pull/24981"
-    },
     {
       "attention_flags": [
         "auth_account",
@@ -891,67 +855,36 @@
     },
     {
       "attention_flags": [
-        "breaking_change",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
+        "auth_account",
+        "new_feature",
+        "protocol_change"
       ],
-      "changed_file_count": 6,
+      "changed_file_count": 3,
       "commit_shas": [
-        "e2f5c6b3a76ed210213a0b5db0270f8f25a49050"
+        "df5b449689130d0e0dbd65ab882aa784a9c02028"
       ],
-      "committed_at": "2026-06-07T16:24:54Z",
+      "committed_at": "2026-06-09T04:39:35Z",
       "next_step": "ai_review_required",
-      "pr_number": 26895,
-      "pr_url": "https://github.com/openai/codex/pull/26895",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for breaking_change, protocol_change, release_packaging, security_policy.",
+      "pr_number": 27085,
+      "pr_url": "https://github.com/openai/codex/pull/27085",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
       "sample_paths": [
-        ".github/workflows/bazel.yml",
-        ".github/workflows/rust-ci-full.yml",
-        ".github/workflows/rust-ci.yml",
-        ".github/workflows/rusty-v8-release.yml",
-        ".github/workflows/sdk.yml",
-        ".github/workflows/v8-canary.yml"
+        "codex-rs/app-server/src/request_processors/plugins.rs",
+        "codex-rs/app-server/tests/suite/v2/plugin_install.rs",
+        "codex-rs/core-plugins/src/remote.rs"
       ],
       "source_state": "merged",
-      "subject_id": "26895",
+      "subject_id": "27085",
       "subject_kind": "pr",
       "surface_hints": [
+        "app_server_protocol",
+        "mcp_plugins",
         "release_packaging",
         "tests_ci"
       ],
-      "title": "ci: use bazel environment for BuildBuddy secret",
-      "url": "https://github.com/openai/codex/pull/26895"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "b1e12943b72d40437ae60188113ab90f24a2b05c",
-        "cd0612d55a3e7bf522c77c7d210c9009c7d3fcc0"
-      ],
-      "committed_at": "2026-06-07T21:34:35Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26818,
-      "pr_url": "https://github.com/openai/codex/pull/26818",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature.",
-      "sample_paths": [
-        "codex-rs/cli/src/main.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26818",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui"
-      ],
-      "title": "fix(tui): accept prompts with resume and fork",
-      "url": "https://github.com/openai/codex/pull/26818"
+      "title": "Use server app auth requirements for remote plugin install",
+      "url": "https://github.com/openai/codex/pull/27085"
     },
     {
       "attention_flags": [
@@ -1427,6 +1360,84 @@
       ],
       "title": "Update web search citation prompt",
       "url": "https://github.com/openai/codex/pull/27096"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 5,
+      "commit_shas": [
+        "c7fdf9c2ce7cc02ccaf21ff8c5eaac2e819be14f",
+        "884a749d4bc85a2e3dadaab442ea77427b6377a0"
+      ],
+      "committed_at": "2026-06-09T02:23:35Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27106,
+      "pr_url": "https://github.com/openai/codex/pull/27106",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/src/compact_remote.rs",
+        "codex-rs/core/src/compact_remote_v2.rs",
+        "codex-rs/core/src/context_manager/history.rs",
+        "codex-rs/core/src/context_manager/mod.rs",
+        "codex-rs/core/src/session/mod.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27106",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "internal_churn"
+      ],
+      "title": "[codex] Remove remote compaction failure log",
+      "url": "https://github.com/openai/codex/pull/27106"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 6,
+      "commit_shas": [
+        "7dbe7f3e920ed08b1f2bab4abae6c09da35c80c6",
+        "80893eea9662598d4f6371df0eb5f4d09f4c0140",
+        "0294cf23c0a03e9c340c13c80c24093d381a46e7",
+        "f0dba2abb15768c83f2ee46976d95b0328cb409e",
+        "89096fe6d91d9570ea8563dae1937147496f1ffa",
+        "6d893fd1ae65b23eb890ff12164c2c368fa52af1",
+        "d2b82c00f03db7dc3b296430dbee944a58c6aec3",
+        "8d74c889a3e294ec4018f6fccb9495f2ad565b78"
+      ],
+      "committed_at": "2026-06-09T04:32:46Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26880,
+      "pr_url": "https://github.com/openai/codex/pull/26880",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/src/git_info_tests.rs",
+        "codex-rs/git-utils/src/fsmonitor.rs",
+        "codex-rs/git-utils/src/fsmonitor_tests.rs",
+        "codex-rs/git-utils/src/info.rs",
+        "codex-rs/git-utils/src/lib.rs",
+        "codex-rs/tui/src/get_git_diff.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26880",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "[codex] preserve fsmonitor for worktree Git reads",
+      "url": "https://github.com/openai/codex/pull/26880"
     },
     {
       "attention_flags": [

--- a/artifacts/github/reviews/openai-codex-pr-26202.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-26202.review.json
@@ -1,0 +1,68 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-26202",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "26202",
+    "commit_shas": [
+      "95202ed2120c490f12f954daeb9ca8167f4e6dc8",
+      "c7f7ad74df9090665b12869705c54268794d289d",
+      "69c1858bc0c90ef389b581719229395e42676ed3",
+      "0fd91f10f38d70146f7b1d6ed6a3df34207c97cd",
+      "c7a47e5b23d8f0bf2742a052139eda48ab4982d6"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Restore release symbol artifacts with line tables",
+        "url": "https://github.com/openai/codex/pull/26202",
+        "meta": "Merged 2026-06-08T17:16:37Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Restore release symbol artifacts with line tables",
+        "url": "https://github.com/openai/codex/commit/95202ed2120c490f12f954daeb9ca8167f4e6dc8"
+      },
+      {
+        "kind": "commit",
+        "title": "Move release symbol profile into Cargo config",
+        "url": "https://github.com/openai/codex/commit/0fd91f10f38d70146f7b1d6ed6a3df34207c97cd"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-09T08:08:13Z",
+  "observed_change": "Codex restores separate release symbol archives while switching release builds to line-tables-only debuginfo and stripping packaged binaries after symbol capture.",
+  "changed_surfaces": [
+    "release workflow packaging",
+    "release symbol archive script",
+    "Cargo release profile debug and strip settings",
+    "Windows PDB staging",
+    "Linux bwrap stripping and digest behavior"
+  ],
+  "user_visible_path": "Users of release binaries do not get a new CLI path, but release operators and crash triage workflows regain sidecar symbol artifacts that can symbolicate shipped binaries without carrying full debuginfo in the distributed executables.",
+  "control_plane_relevance": "Decodex has no immediate app-server or runtime compatibility change to absorb, but release-monitoring and crash-diagnostics workflows should know that upstream Codex release artifacts can include symbol archives again.",
+  "compatibility_risk": "Low for Decodex runtime integration; the changed surface is release artifact packaging and debug metadata rather than a protocol, CLI flag, or config schema.",
+  "adoption_opportunity": "Track symbol archive availability in release-rollup or diagnostic tooling if Decodex later consumes upstream Codex release assets for crash triage.",
+  "community_value": "Moderate for operators who debug release binaries, because the change restores symbolication support while avoiding the prior full-debuginfo release-build timeout problem.",
+  "deprecated_or_breaking_notes": "The PR changes release artifact contents and packaging flow, but it does not deprecate a Codex user command or require a migration for normal CLI users.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26202 says release symbol archives are restored for macOS, Linux, and Windows binaries.",
+    "codex-rs/Cargo.toml changes the release profile to `debug = \"line-tables-only\"` and `strip = false` before packaging.",
+    ".github/scripts/archive-release-symbols-and-strip-binaries.sh is added to archive symbols and strip Unix release binaries after symbol capture.",
+    ".github/workflows/rust-release.yml installs binutils, configures macOS packed split debuginfo, and invokes the archive-and-strip script before packaging.",
+    ".github/workflows/rust-release-windows.yml stages PDB files alongside Windows release binaries, including underscore-to-hyphen name handling.",
+    "The PR validation notes macOS dSYM symbolication smoke coverage and Linux and Windows archive-script control-flow checks.",
+    "The normalized bundle artifacts/github/bundles/openai-codex-pr-26202.json records 4 changed files for the merged PR."
+  ],
+  "caveats": "The full release matrix only runs for tags or manual dispatches, so the PR's own validation cannot prove future release-run timing across every target.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Release artifact and symbolication behavior is useful release-rollup and diagnostic context, but not an immediate public post."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-26230.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-26230.review.json
@@ -1,0 +1,70 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-26230",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "26230",
+    "commit_shas": [
+      "d6528ccc954f1768a3d7d080bba8162b59d982a1",
+      "bf84a984d0233936cf29c72dd60d704b9182d569",
+      "8e14f2d413ef8a826d45a0602573148c6c7ac358"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "fix: preserve auto review across config and delegation",
+        "url": "https://github.com/openai/codex/pull/26230",
+        "meta": "Merged 2026-06-08T18:59:51Z"
+      },
+      {
+        "kind": "commit",
+        "title": "fix: preserve Auto Review across config and tasks",
+        "url": "https://github.com/openai/codex/commit/d6528ccc954f1768a3d7d080bba8162b59d982a1"
+      },
+      {
+        "kind": "commit",
+        "title": "fix: align app-server auto review serialization",
+        "url": "https://github.com/openai/codex/commit/bf84a984d0233936cf29c72dd60d704b9182d569"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-09T08:08:13Z",
+  "observed_change": "Codex makes `auto_review` the canonical serialized approval reviewer value while still accepting legacy `guardian_subagent` input and propagating the active reviewer into spawned agents.",
+  "changed_surfaces": [
+    "app-server protocol v2 approval reviewer serialization",
+    "core protocol config type serialization",
+    "config/debug output expectations",
+    "multi-agent spawn runtime overrides",
+    "TUI feature-flag config tests"
+  ],
+  "user_visible_path": "Users and managed-config operators should see `approvals_reviewer = \"auto_review\"` in output and config paths, while existing `guardian_subagent` inputs remain accepted; delegated work should preserve Auto Review instead of falling back to user review.",
+  "control_plane_relevance": "Decodex config, app-server protocol, and delegated-agent adapters should treat `auto_review` as the canonical reviewer value and preserve reviewer settings across spawned-agent boundaries.",
+  "compatibility_risk": "High for strict clients or stored expectations that only accepted serialized `guardian_subagent`; lower for readers because upstream keeps `guardian_subagent` as an alias.",
+  "adoption_opportunity": "Update Control Plane schema expectations, debug-config parsing, and delegated-agent setup to use `auto_review` while retaining legacy-input compatibility.",
+  "community_value": "High for operators using Auto Review and delegated work because the change stabilizes reviewer identity across config, app-server round trips, and spawned agents.",
+  "deprecated_or_breaking_notes": "`guardian_subagent` remains accepted as backward-compatible input, but canonical output changes to `auto_review` across core protocol and app-server v2.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26230 states `auto_review` is the canonical value across protocol and app-server output while `guardian_subagent` remains accepted as backward-compatible input.",
+    "codex-rs/app-server-protocol/src/protocol/v2/shared.rs changes `ApprovalsReviewer::AutoReview` serde rename to `auto_review` and keeps `guardian_subagent` as an alias.",
+    "codex-rs/protocol/src/config_types.rs changes both serde rename and strum serialization for `AutoReview` to `auto_review` while preserving the legacy alias.",
+    "codex-rs/core/src/tools/handlers/multi_agents_common.rs copies `turn.config.approvals_reviewer` into spawned-agent config overrides.",
+    "codex-rs/core/src/tools/handlers/multi_agents_tests.rs adds regression coverage for delegated task reviewer propagation.",
+    "TUI and debug-config tests update expected config/debug output from `guardian_subagent` to `auto_review`.",
+    "The normalized bundle artifacts/github/bundles/openai-codex-pr-26230.json records 8 changed files for the merged PR."
+  ],
+  "caveats": "The review covers serialization and propagation behavior; it does not evaluate the broader Guardian policy changes split into adjacent PRs.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Canonical approval-reviewer serialization and delegated-agent propagation are Control Plane compatibility concerns."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The config/protocol migration has a clear operator-facing public angle."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-26637.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-26637.review.json
@@ -1,0 +1,74 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-26637",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "26637",
+    "commit_shas": [
+      "3a77fbcc7217e2a49e7447017ac4932625e55912",
+      "cbb1d21dfa72d84973bcc8b58a6deaca53808e0f",
+      "2a416e92a12e43d044e4a39096f1825a29b11d3f",
+      "1188ee05a5b82e99bc653820a27c8830d66ab7bf",
+      "fd0f44bb07220d2ae600bca3c38b2af596ae21e1",
+      "583174aca7660c1a872ac7aead5abb335dec1f65"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Speed up external agent session imports",
+        "url": "https://github.com/openai/codex/pull/26637",
+        "meta": "Merged 2026-06-08T18:16:32Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Improve external agent import performance",
+        "url": "https://github.com/openai/codex/commit/3a77fbcc7217e2a49e7447017ac4932625e55912"
+      },
+      {
+        "kind": "commit",
+        "title": "Refine external agent session import pipeline",
+        "url": "https://github.com/openai/codex/commit/fd0f44bb07220d2ae600bca3c38b2af596ae21e1"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-09T08:08:13Z",
+  "observed_change": "Codex imports external-agent session histories directly through ThreadStore with a bounded preparation pipeline instead of starting full live threads for every imported session.",
+  "changed_surfaces": [
+    "app-server external agent config import processor",
+    "external agent session import pipeline",
+    "ThreadStore-backed rollout persistence",
+    "external session import ledger hashing",
+    "app-server import regression tests"
+  ],
+  "user_visible_path": "When importing large external-agent session histories, Codex should finish much faster, avoid initializing unrelated required MCP servers, skip unchanged previously imported sources, and keep imported conversations visible through thread listing and history APIs.",
+  "control_plane_relevance": "Decodex Control Plane clients that trigger or observe external-agent imports should treat imports as direct stored-thread writes rather than live-thread starts and should not infer MCP startup from import activity.",
+  "compatibility_risk": "Low to moderate: app-server behavior changes around import side effects and timing, but the PR states the public ThreadStore trait is unchanged and imported histories remain readable through existing thread APIs.",
+  "adoption_opportunity": "Use the faster import path as an operator workflow improvement for bulk external-agent history ingestion and avoid coupling import progress to live-thread or MCP startup diagnostics.",
+  "community_value": "High for teams moving external agent histories into Codex because the PR reports a 50-session fixture dropping from about 70 seconds to about 6 seconds.",
+  "deprecated_or_breaking_notes": "No explicit deprecation is introduced; the meaningful behavior change is removal of full live-thread startup side effects during import.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26637 says external-agent imports previously started full live Codex threads and now persist imported sessions directly through `ThreadStore`.",
+    "codex-rs/app-server/src/message_processor.rs passes `thread_store` into `ExternalAgentConfigRequestProcessor`.",
+    "codex-rs/app-server/src/request_processors/external_agent_session_import.rs is added to prepare, hash, and persist imports through a bounded five-session pipeline.",
+    "codex-rs/external-agent-sessions/src/lib.rs exports `record_completed_session_imports` and uses `load_session_for_import_with_content_sha256` so source parsing and hashing share one pass.",
+    "codex-rs/external-agent-sessions/src/ledger.rs adds `CompletedExternalAgentSessionImport` and batch ledger recording based on prepared content hashes.",
+    "The app-server regression test `external_agent_config_import_does_not_initialize_required_mcp` configures a required broken MCP server and expects import to avoid initializing it.",
+    "The PR body reports a 50-session, 238 MiB fixture improving from 69.61 seconds import completion to 5.95 seconds.",
+    "The normalized bundle artifacts/github/bundles/openai-codex-pr-26637.json records 10 changed files for the merged PR."
+  ],
+  "caveats": "The performance numbers are upstream PR measurements from one large fixture; downstream environments may vary.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The app-server import behavior affects Control Plane interpretation of external-agent import side effects."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The import speedup and no-required-MCP-startup behavior have a concrete operator-facing public angle."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-27009.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27009.review.json
@@ -1,0 +1,61 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27009",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27009",
+    "commit_shas": [
+      "a4520a312a6ac3509088827dc96bc5c20ec96ef6"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[plugins] Expose marketplace source in marketplace list JSON",
+        "url": "https://github.com/openai/codex/pull/27009",
+        "meta": "Merged 2026-06-08T18:37:55Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Expose configured marketplace source in marketplace list JSON",
+        "url": "https://github.com/openai/codex/commit/a4520a312a6ac3509088827dc96bc5c20ec96ef6"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-09T08:08:13Z",
+  "observed_change": "Codex adds `marketplaceSource` provenance to `codex plugin marketplace list --json` entries for configured marketplaces while leaving human-readable output unchanged.",
+  "changed_surfaces": [
+    "plugin marketplace CLI JSON output",
+    "configured marketplace source normalization",
+    "plugin CLI source-provenance helpers",
+    "CLI marketplace-list regression tests"
+  ],
+  "user_visible_path": "Operators running `codex plugin marketplace list --json` can now see whether each configured marketplace came from a local path or git source, with the source value included in the JSON response.",
+  "control_plane_relevance": "Decodex plugin inventory and marketplace tooling can use `marketplaceSource` to preserve configured source provenance instead of inferring it from install roots.",
+  "compatibility_risk": "Low to moderate for strict JSON consumers: this is an additive field, but clients that validate exact marketplace-list object shapes may need to accept `marketplaceSource`.",
+  "adoption_opportunity": "Adopt `marketplaceSource` in Control Plane plugin catalog views or diagnostics when explaining where a configured marketplace came from.",
+  "community_value": "High for plugin operators because it makes marketplace provenance visible through a machine-readable CLI path.",
+  "deprecated_or_breaking_notes": "No old field is removed and human-readable output is unchanged; the migration is to consume the new JSON field when source provenance matters.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27009 says it adds `marketplaceSource` to `codex plugin marketplace list --json` entries for configured marketplaces.",
+    "codex-rs/cli/src/plugin_cmd.rs makes `JsonMarketplaceSource` and `configured_marketplace_sources` reusable by marketplace-list code.",
+    "codex-rs/cli/src/marketplace_cmd.rs imports `PluginsConfigInput`, configured source helpers, and source root resolution to attach source provenance to marketplace JSON.",
+    "codex-rs/cli/tests/plugin_cli.rs extends marketplace-list JSON coverage for local and git marketplace sources.",
+    "The PR body says human-readable marketplace list output remains unchanged.",
+    "The normalized bundle artifacts/github/bundles/openai-codex-pr-27009.json records 3 changed files for the merged PR."
+  ],
+  "caveats": "The new field applies to configured marketplaces represented by the CLI path; it does not imply every marketplace source is live-verified during listing.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Plugin marketplace source provenance is useful Control Plane inventory and diagnostics context."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The JSON provenance field has a clear operator-facing public angle."
+    }
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-26230.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-26230.json
@@ -1,0 +1,59 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-26230",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "high",
+  "audience": "Codex config, app-server, and delegated-agent operators",
+  "candidate_text": [
+    "Codex now serializes Auto Review as `auto_review`, still accepts legacy `guardian_subagent`, and carries the active reviewer into spawned agents. Strict app-server/config clients should update expectations. PR: https://github.com/openai/codex/pull/26230"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26230.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26230.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26230"
+    ]
+  },
+  "evidence_notes": [
+    "The protocol enums now serialize Auto Review as `auto_review` while retaining `guardian_subagent` as an alias.",
+    "Config/debug/TUI tests update canonical output expectations to `auto_review`.",
+    "The multi-agent spawn path copies the active turn's approval reviewer into spawned-agent config.",
+    "The PR body says delegated work must not silently fall back to user review."
+  ],
+  "claims": [
+    {
+      "text": "Auto Review now serializes canonically as `auto_review` across core protocol and app-server output.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26230.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "`guardian_subagent` remains accepted as backward-compatible input.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26230.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Spawned agents inherit the active turn's approval reviewer.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26230.review.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR changes canonical config/protocol output and delegated-agent reviewer continuity with compatibility implications for strict clients.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26230:operator_impact"
+  },
+  "caveats": [
+    "This PR does not cover adjacent Guardian policy changes.",
+    "Legacy `guardian_subagent` input remains accepted."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this candidate."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-26637.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-26637.json
@@ -1,0 +1,54 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-26637",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "high",
+  "audience": "Codex app-server and external-agent import operators",
+  "candidate_text": [
+    "Codex now imports external-agent session histories through ThreadStore instead of spinning up live threads, cutting a 50-session fixture from ~70s to ~6s and avoiding unrelated required MCP startup during import. PR: https://github.com/openai/codex/pull/26637"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26637.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26637.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26637"
+    ]
+  },
+  "evidence_notes": [
+    "The PR says imports persist directly through ThreadStore rather than starting full live Codex threads.",
+    "The added import pipeline prepares, hashes, and persists sessions through a bounded five-session path.",
+    "Regression coverage verifies imports avoid initializing unrelated required MCP servers.",
+    "The PR reports a 50-session fixture improving from about 70 seconds to about 6 seconds."
+  ],
+  "claims": [
+    {
+      "text": "External-agent session imports now persist through ThreadStore instead of starting a full live thread for every session.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26637.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The upstream PR reports a 50-session fixture dropping from about 70 seconds to about 6 seconds.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26637.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR has a concrete app-server operator workflow improvement with source-backed speed and side-effect evidence.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26637:operator_impact"
+  },
+  "caveats": [
+    "The performance numbers are from the upstream PR's fixture and may vary in other environments.",
+    "The PR states the public ThreadStore trait is unchanged."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this candidate."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27009.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27009.json
@@ -1,0 +1,54 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27009",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "high",
+  "audience": "Codex plugin and marketplace operators",
+  "candidate_text": [
+    "Codex `plugin marketplace list --json` now includes `marketplaceSource`, giving operators source provenance for configured local and git marketplaces while leaving human output unchanged. PR: https://github.com/openai/codex/pull/27009"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27009.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27009.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27009"
+    ]
+  },
+  "evidence_notes": [
+    "The PR body says `marketplaceSource` was added to marketplace-list JSON for configured marketplaces.",
+    "The CLI marketplace command reuses configured source helpers from plugin-list code.",
+    "Tests cover local and git marketplace sources in JSON output.",
+    "The PR body says human-readable marketplace-list output remains unchanged."
+  ],
+  "claims": [
+    {
+      "text": "`codex plugin marketplace list --json` now includes configured marketplace source provenance.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27009.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Human-readable marketplace-list output is unchanged.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27009.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR adds a concrete machine-readable plugin provenance field useful to operators.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27009:operator_impact"
+  },
+  "caveats": [
+    "The field is additive and applies to configured marketplace entries.",
+    "Listing provenance does not itself prove remote marketplace freshness."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this candidate."
+  ]
+}


### PR DESCRIPTION
## Summary

- Refreshed the deterministic upstream Radar queue for openai/codex.
- Reviewed unreviewed critical queue subjects PR 26202, PR 26637, PR 27009, and PR 26230 from source-backed GitHub bundles.
- Added upstream_review/v1 and upstream_impact/v1 artifacts for all four subjects.
- Added social_candidate/v1 handoffs for PR 26637, PR 27009, and PR 26230 only; no social_post/v1 artifacts were written.

## Validation

- `decodex radar bundle validate artifacts/github/bundles/openai-codex-pr-26202.json artifacts/github/bundles/openai-codex-pr-26637.json artifacts/github/bundles/openai-codex-pr-27009.json artifacts/github/bundles/openai-codex-pr-26230.json` -> OK (4 bundle files)
- `decodex radar validate artifacts/github/review-queue artifacts/github/bundles artifacts/github/reviews artifacts/github/impact artifacts/github/social-candidates` -> OK (111 Radar artifact JSON files)
- `cargo make check-site-content` -> OK (216 Radar artifact JSON files)
- `cargo make fmt` -> OK
- `cargo make lint-fix` -> OK, 0 vstyle fixes
- `cargo make test` -> 971 passed, 1 skipped
