### PR TITLE
Persist PR 27007 daily-cap social block

### DIFF
--- a/artifacts/social/x/posts/2026-06-09/openai-codex-pr-27007-daily-cap-block.json
+++ b/artifacts/social/x/posts/2026-06-09/openai-codex-pr-27007-daily-cap-block.json
@@ -1,0 +1,79 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-27007-daily-cap-block",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "blocked",
+  "audience": "Codex app-server and multi-agent operators",
+  "text": [
+    "Codex multi-agent v2 now emits completion-only `subAgentActivity` thread items with canonical agent paths, and v2 clients must stop assuming legacy collab begin/end pairs for those tools. PR: https://github.com/openai/codex/pull/27007"
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27007.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27007.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27007.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27007"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish, priority critical, and mode operator_impact for PR #27007.",
+    "The x-post-quality-system editorial gate passes this candidate: it says what changed, who must act on it, and the GitHub PR / upstream review / upstream impact evidence that proves it.",
+    "The upstream review records a schema-backed completion-only `subAgentActivity` thread item with `agentPath`, `agentThreadId`, and activity kind.",
+    "The upstream impact record classifies the change as confirmed compat_risk with publisher_angle operator_impact for app-server v2 clients.",
+    "Checked durable social_post/v1 records for 2026-06-09 Asia/Shanghai already contain eight published @decodexspace status URLs: seven from the alpha.7 prerelease thread and one from PR #26639.",
+    "Open GitHub PR inspection with routed hackink GitHub credentials found no open social publication PR adding another 2026-06-09 social_post/v1 or reservation record.",
+    "This candidate is a one-post operator-impact candidate, so publishing it today would require daily cap position 9 and would exceed the hard cap of 8 posts.",
+    "No social_publish_reservation/v1 record was created because the cap check failed before the reservation and Chrome compose gate.",
+    "No Chrome account, duplicate, media upload, final URL readback, or account/media readback was attempted because the candidate was blocked before compose authorization."
+  ],
+  "claims": [
+    {
+      "text": "Codex PR #27007 changes the app-server v2 multi-agent protocol by exposing completion-only `subAgentActivity` thread items.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27007.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "App-server v2 clients that consumed legacy collaboration begin/end pairs for these multi-agent tools must handle the new item shape.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27007.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Publishing this one-post candidate on 2026-06-09 Asia/Shanghai would exceed the @decodexspace daily cap.",
+      "evidence": "artifacts/social/x/posts/2026-06-09/openai-codex-rust-v0-138-0-alpha-7-prerelease-read.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "block",
+    "priority": "critical",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27007:operator_impact",
+    "reason": "daily_cap_exceeded: the checked 2026-06-09 Asia/Shanghai ledger already contains eight published @decodexspace status URLs, so this one-post operator-impact candidate would exceed the hard cap.",
+    "daily_limit": 8,
+    "daily_count_before": 8,
+    "daily_count_after": 8,
+    "day": "2026-06-09",
+    "timezone": "Asia/Shanghai"
+  },
+  "block": {
+    "reason": "daily_cap_exceeded",
+    "operator_notice": "Blocked before reservation or Chrome compose: the checked 2026-06-09 ledger already has eight published @decodexspace status URLs, and this critical one-post PR #27007 candidate would be the ninth post."
+  },
+  "media_refs": [
+    "media_caveat: no generated media was created because the run stopped at the daily-cap gate before reservation or compose."
+  ],
+  "caveats": [
+    "No X post was published.",
+    "No Chrome tabs were opened for this blocked outcome.",
+    "Do not treat this blocked record as a prerelease quote target.",
+    "Lower-priority publishable candidates discovered in the same current artifact set were not composed because the hard cap was already exhausted."
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a terminal `social_post/v1` blocked record for `openai-codex-pr-27007`
- Record `daily_cap_exceeded` because 2026-06-09 Asia/Shanghai already has eight published @decodexspace status URLs
- Stop before reservation, Chrome compose, duplicate readback, or media generation because the cap gate fails first

## Evidence
- Candidate: `artifacts/github/social-candidates/openai-codex-pr-27007.json` has `decision.worthiness = publish`, `priority = critical`, and `mode = operator_impact`
- Cap: checked `social_post/v1` records for 2026-06-09 sum to eight published X URLs
- Open PR readback: no open social publication PRs were present when checked with routed hackink GitHub credentials
- Chrome/media: not attempted; no tabs opened and no media generated

## Validation
- `cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x` -> OK (55 Radar artifact JSON files validated)
