### PR TITLE
Reserve Decodex X post for PR 26687

### DIFF
--- a/artifacts/social/x/posts/2026-06-10/openai-codex-pr-26687.json
+++ b/artifacts/social/x/posts/2026-06-10/openai-codex-pr-26687.json
@@ -1,0 +1,104 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-26687",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "published",
+  "audience": "Codex app-server and Control Plane operators",
+  "text": [
+    "Codex now pairs thread cwd with environment selections: turn/start environments can become sticky for later turns while app-server keeps the public cwd shape. Control-plane clients should model them as one setting. PR: https://github.com/openai/codex/pull/26687"
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-26687.json"
+    ],
+    "reservations": [
+      "artifacts/social/x/reservations/2026-06-10/openai-codex-pr-26687.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26687.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26687.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26687",
+      "https://x.com/decodexspace/status/2064468019414552591"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish, priority critical, and mode operator_impact for openai-codex-pr-26687.",
+    "The upstream_review/v1 artifact confirms PR #26687 pairs cwd and environment selections, makes turn/start environments sticky across later turns, and preserves public app-server cwd params through internal translation.",
+    "The upstream_impact/v1 artifact marks the change as public_signal_decision publish, control_plane_impact compat_risk, and publisher_angle operator_impact.",
+    "The x-post-quality-system gate passed because the post states what changed, who needs to act, and the direct source that proves it; it is not a generic watch note or dense release paragraph.",
+    "Checked durable social_post/v1 records contained no published or blocked record for this idempotency key before publication.",
+    "Checked durable social_publish_reservation/v1 records contained no active reservation for this idempotency key before the new reservation was created.",
+    "Open GitHub PR readback with routed hackink credentials showed only PR #265 adding a social/x publication record, for PR27007 daily-cap block; no open publication PR added this PR26687 idempotency key.",
+    "PR #276 made the active reservation visible before X compose.",
+    "Chrome account readback initially showed @hackink active with @decodexspace available; the automation switched to @decodexspace and verified the account menu before reservation and compose.",
+    "Live @decodexspace profile readback before reservation found no PR26687 lead, source URL, thread cwd, or environment-selection match among recent posts.",
+    "X search for PR26687 lead terms from @decodexspace returned no results and was treated as supporting duplicate evidence only.",
+    "Live @decodexspace profile readback after PR-visible reservation and immediately before clicking Post again found no PR26687 lead or source URL match.",
+    "The compose dialog showed @decodexspace and the 261-character posted text before the enabled modal Post button was clicked.",
+    "Home timeline readback immediately after posting showed the new @decodexspace status with the expected PR26687 text and GitHub PR card.",
+    "Permalink readback showed the expected @decodexspace post text, Automated by @hackink attribution, GitHub PR #26687 card, and no attached image media.",
+    "The status ID decodes to 2026-06-09T22:01:46.446Z."
+  ],
+  "claims": [
+    {
+      "text": "Codex pairs cwd and environment selection as a sticky thread setting.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26687.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The public app-server cwd request shape remains translated rather than removed.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26687.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Control-plane clients should model cwd and environment selection together for this app-server execution-context path.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26687.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The PR #26687 operator-impact post is live on @decodexspace.",
+      "evidence": "https://x.com/decodexspace/status/2064468019414552591",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "priority": "critical",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26687:operator_impact",
+    "reason": "The PR changes concrete app-server execution-context semantics used by Control Plane operators.",
+    "daily_limit": 8,
+    "daily_count_before": 0,
+    "daily_count_after": 1,
+    "day": "2026-06-10",
+    "timezone": "Asia/Shanghai"
+  },
+  "publication": {
+    "posted_at": "2026-06-09T22:01:46.446Z",
+    "published_urls": [
+      "https://x.com/decodexspace/status/2064468019414552591"
+    ],
+    "publisher": "chrome",
+    "account_verified": true,
+    "made_with_ai": false
+  },
+  "media_refs": [
+    "media_caveat: no media was attached; this non-release operator_impact post remains valuable text-only because the source-backed app-server execution-context warning and GitHub PR card are the reader value."
+  ],
+  "caveats": [
+    "Keep the claim scoped to app-server execution-context semantics for cwd and environment selections.",
+    "Do not say the public app-server cwd field was removed; the source-backed claim is that it is translated internally.",
+    "No generated image was used because this was a single non-release operator-impact post with sufficient reader value from the text and source card."
+  ],
+  "post_lifecycle": {
+    "current_state": "live",
+    "quote_eligible": false,
+    "reason": "This is a standalone operator-impact post, not a prerelease quote-chain anchor."
+  }
+}

--- a/artifacts/social/x/reservations/2026-06-10/openai-codex-pr-26687.json
+++ b/artifacts/social/x/reservations/2026-06-10/openai-codex-pr-26687.json
@@ -1,0 +1,46 @@
+{
+  "schema": "social_publish_reservation/v1",
+  "slug": "openai-codex-pr-26687",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "active",
+  "idempotency_key": "x:decodexspace:openai-codex-pr-26687:operator_impact",
+  "reserved_at": "2026-06-09T21:58:30Z",
+  "expires_at": "2026-06-09T23:58:30Z",
+  "day": "2026-06-10",
+  "timezone": "Asia/Shanghai",
+  "candidate_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-26687.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26687.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26687.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26687"
+    ]
+  },
+  "duplicate_keys": [
+    "x:decodexspace:openai-codex-pr-26687:operator_impact",
+    "openai-codex-pr-26687",
+    "https://github.com/openai/codex/pull/26687",
+    "Codex now pairs thread cwd with environment selections"
+  ],
+  "owner": {
+    "automation_id": "decodex-x-publisher",
+    "branch": "codex/x-publisher-pr26687-20260610"
+  },
+  "evidence_notes": [
+    "Checked durable social_post/v1 records: no PR26687 slug, source URL, or idempotency-key match.",
+    "Checked durable social_publish_reservation/v1 records: no PR26687 slug or idempotency-key match.",
+    "Checked open GitHub publication PRs: only PR #265 for PR27007 daily-cap block matched social/x paths.",
+    "Chrome X account readback switched from controller @hackink to target @decodexspace before reservation.",
+    "Live @decodexspace profile readback was readable and showed no PR26687 lead/source match among recent posts.",
+    "X search for PR26687 lead terms from @decodexspace returned no results; treated as supporting evidence only."
+  ]
+}

--- a/artifacts/social/x/reservations/2026-06-10/openai-codex-pr-26687.json
+++ b/artifacts/social/x/reservations/2026-06-10/openai-codex-pr-26687.json
@@ -5,7 +5,7 @@
   "target_account": "decodexspace",
   "controller_account": "hackink",
   "mode": "operator_impact",
-  "status": "active",
+  "status": "consumed",
   "idempotency_key": "x:decodexspace:openai-codex-pr-26687:operator_impact",
   "reserved_at": "2026-06-09T21:58:30Z",
   "expires_at": "2026-06-09T23:58:30Z",
@@ -33,8 +33,10 @@
   ],
   "owner": {
     "automation_id": "decodex-x-publisher",
-    "branch": "codex/x-publisher-pr26687-20260610"
+    "branch": "codex/x-publisher-pr26687-20260610",
+    "pr_url": "https://github.com/hack-ink/decodex/pull/276"
   },
+  "consumed_by_social_post": "artifacts/social/x/posts/2026-06-10/openai-codex-pr-26687.json",
   "evidence_notes": [
     "Checked durable social_post/v1 records: no PR26687 slug, source URL, or idempotency-key match.",
     "Checked durable social_publish_reservation/v1 records: no PR26687 slug or idempotency-key match.",


### PR DESCRIPTION
## Summary
- Add and consume a thin social_publish_reservation/v1 for openai-codex-pr-26687.
- Persist the terminal social_post/v1 publication record for the Decodex X post.

## Publication
- Candidate: openai-codex-pr-26687
- decision.worthiness: publish
- Mode: operator_impact
- Published URL: https://x.com/decodexspace/status/2064468019414552591
- Media: text-only; no generated media attached because this non-release operator-impact post was valuable through source-backed text plus the GitHub PR card.

## Evidence
- Durable social_post/v1 and social_publish_reservation/v1 records had no PR26687 slug/key/source match before reservation.
- Open publication PR scan only found PR #265 for PR27007 daily-cap block.
- Chrome X account readback switched from @hackink to @decodexspace before reservation/compose.
- Live @decodexspace profile readback before reservation and immediately before Post showed no PR26687 lead/source match.
- Home timeline and independent permalink readback confirmed the post, @decodexspace account, Automated by @hackink attribution, GitHub PR #26687 card, and no attached media.

## Validation
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x -> OK (60 Radar artifact JSON files validated)

## Scope
- Diff limited to artifacts/social/x/reservations/ and artifacts/social/x/posts/.
- No generated media committed.
