### PR TITLE
Persist PR 27184 Decodex X post

### DIFF
--- a/artifacts/social/x/posts/2026-06-10/openai-codex-pr-27184.json
+++ b/artifacts/social/x/posts/2026-06-10/openai-codex-pr-27184.json
@@ -1,0 +1,99 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-27184",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "published",
+  "audience": "Codex app-server, plugin, and executor-runtime operators",
+  "text": [
+    "Codex `thread/start` now has experimental `selectedCapabilityRoots` so an executor-owned plugin root can expose skills without app-server reading the orchestrator filesystem. PR: https://github.com/openai/codex/pull/27184"
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27184.json"
+    ],
+    "reservations": [
+      "artifacts/social/x/reservations/2026-06-10/openai-codex-pr-27184.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27184.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27184.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27184",
+      "https://x.com/decodexspace/status/2064559366225965128"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish, priority critical, and mode operator_impact for openai-codex-pr-27184.",
+    "The upstream_review/v1 artifact confirms PR #27184 adds experimental thread/start selectedCapabilityRoots, converts selected roots into extension initialization, and loads executor-selected skills through the environment filesystem.",
+    "The upstream_impact/v1 artifact marks the change as public_signal_decision publish, control_plane_impact candidate, and publisher_angle operator_impact.",
+    "The x-post-quality-system gate passed because the post states what changed, who can act on it, and the direct source that proves it; the copy stays scoped to executor-owned skills and calls the field experimental.",
+    "Checked durable social_post/v1 records contained no published or blocked record for this idempotency key before publication.",
+    "Checked durable social_publish_reservation/v1 records contained no active reservation for this idempotency key before the new reservation was created.",
+    "Open GitHub PR readback with routed hackink credentials showed only PR #265 adding a social/x publication record, for PR27007 daily-cap block; no open publication PR added this PR27184 idempotency key.",
+    "PR #281 made the active reservation visible before X compose.",
+    "Chrome account readback initially showed @hackink active with @decodexspace available; the automation switched to @decodexspace and verified the account menu before reservation and compose.",
+    "Live @decodexspace profile readback before reservation loaded ten recent Automated by @hackink posts and found no PR27184 lead, source URL, selectedCapabilityRoots, or title match.",
+    "Live @decodexspace profile readback after PR-visible reservation and immediately before compose again loaded ten recent Automated by @hackink posts and found no PR27184 lead, source URL, selectedCapabilityRoots, or title match.",
+    "The compose dialog showed @decodexspace and the 221-character posted text before the enabled modal Post button was clicked.",
+    "Profile readback immediately after posting showed the new @decodexspace status with the expected PR27184 text and GitHub PR card.",
+    "Permalink readback showed the expected @decodexspace post text, Automated by @hackink attribution, GitHub PR #27184 card, and no attached image media or /photo/N link.",
+    "The status ID decodes to 2026-06-10T04:04:45.223Z."
+  ],
+  "claims": [
+    {
+      "text": "Codex thread/start now accepts experimental selectedCapabilityRoots.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27184.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Executor-owned skill roots are loaded through the selected environment rather than the orchestrator filesystem.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27184.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The PR #27184 operator-impact post is live on @decodexspace.",
+      "evidence": "https://x.com/decodexspace/status/2064559366225965128",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "priority": "critical",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27184:operator_impact",
+    "reason": "The PR creates a concrete split-runtime app-server capability-selection path for executor-owned skills.",
+    "daily_limit": 8,
+    "daily_count_before": 1,
+    "daily_count_after": 2,
+    "day": "2026-06-10",
+    "timezone": "Asia/Shanghai"
+  },
+  "publication": {
+    "posted_at": "2026-06-10T04:04:45.223Z",
+    "published_urls": [
+      "https://x.com/decodexspace/status/2064559366225965128"
+    ],
+    "publisher": "chrome",
+    "account_verified": true,
+    "made_with_ai": false
+  },
+  "media_refs": [
+    "media_caveat: no generated media was attached; this non-release operator_impact post remains valuable text-only because the source-backed app-server capability-selection warning and GitHub PR card are the reader value."
+  ],
+  "caveats": [
+    "The selectedCapabilityRoots field is experimental.",
+    "This PR covers executor-owned skills; MCP, connectors, hooks, persistence, resume, fork, and subagent inheritance remain follow-ups.",
+    "Unavailable environments or invalid roots warn rather than falling back to local filesystem reads.",
+    "No generated image was used because this was a single non-release operator-impact post with sufficient reader value from the text and source card."
+  ],
+  "post_lifecycle": {
+    "current_state": "live",
+    "quote_eligible": false,
+    "reason": "This is a standalone operator-impact post, not a prerelease quote-chain anchor."
+  }
+}

--- a/artifacts/social/x/reservations/2026-06-10/openai-codex-pr-27184.json
+++ b/artifacts/social/x/reservations/2026-06-10/openai-codex-pr-27184.json
@@ -1,0 +1,47 @@
+{
+  "schema": "social_publish_reservation/v1",
+  "slug": "openai-codex-pr-27184",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "active",
+  "idempotency_key": "x:decodexspace:openai-codex-pr-27184:operator_impact",
+  "reserved_at": "2026-06-10T04:00:00Z",
+  "expires_at": "2026-06-10T06:00:00Z",
+  "day": "2026-06-10",
+  "timezone": "Asia/Shanghai",
+  "candidate_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27184.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27184.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27184.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27184"
+    ]
+  },
+  "duplicate_keys": [
+    "x:decodexspace:openai-codex-pr-27184:operator_impact",
+    "openai-codex-pr-27184",
+    "https://github.com/openai/codex/pull/27184",
+    "Codex `thread/start` now has experimental `selectedCapabilityRoots`",
+    "selectedCapabilityRoots",
+    "Load selected executor skills through extensions"
+  ],
+  "owner": {
+    "automation_id": "decodex-x-publisher",
+    "branch": "codex/x-publisher-pr27184-20260610"
+  },
+  "evidence_notes": [
+    "Checked durable social_post/v1 records: no PR27184 slug, source URL, or idempotency-key match.",
+    "Checked durable social_publish_reservation/v1 records: no PR27184 slug or idempotency-key match.",
+    "Checked open GitHub publication PRs with routed hackink credentials: only PR #265 for PR27007 daily-cap block matched social/x paths.",
+    "Chrome X account readback switched from controller @hackink to target @decodexspace before reservation.",
+    "Live @decodexspace profile readback was readable after loading ten recent Automated by @hackink posts and showed no PR27184 lead, source, or selectedCapabilityRoots match."
+  ]
+}

--- a/artifacts/social/x/reservations/2026-06-10/openai-codex-pr-27184.json
+++ b/artifacts/social/x/reservations/2026-06-10/openai-codex-pr-27184.json
@@ -5,7 +5,7 @@
   "target_account": "decodexspace",
   "controller_account": "hackink",
   "mode": "operator_impact",
-  "status": "active",
+  "status": "consumed",
   "idempotency_key": "x:decodexspace:openai-codex-pr-27184:operator_impact",
   "reserved_at": "2026-06-10T04:00:00Z",
   "expires_at": "2026-06-10T06:00:00Z",
@@ -35,8 +35,10 @@
   ],
   "owner": {
     "automation_id": "decodex-x-publisher",
-    "branch": "codex/x-publisher-pr27184-20260610"
+    "branch": "codex/x-publisher-pr27184-20260610",
+    "pr_url": "https://github.com/hack-ink/decodex/pull/281"
   },
+  "consumed_by_social_post": "artifacts/social/x/posts/2026-06-10/openai-codex-pr-27184.json",
   "evidence_notes": [
     "Checked durable social_post/v1 records: no PR27184 slug, source URL, or idempotency-key match.",
     "Checked durable social_publish_reservation/v1 records: no PR27184 slug or idempotency-key match.",


### PR DESCRIPTION
## Summary
- add and consume social_publish_reservation/v1 for openai-codex-pr-27184
- persist published social_post/v1 for the live @decodexspace PR27184 post

## Publication
- URL: https://x.com/decodexspace/status/2064559366225965128
- target account verified in Chrome as @decodexspace after switching from @hackink
- permalink readback confirmed expected text, Automated by @hackink attribution, GitHub PR #27184 card, and no /photo/N media link
- media caveat: text-only non-release operator-impact post; GitHub PR card carries the reader value

## Validation
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x
- cargo make fmt
- cargo make lint-fix
- cargo make test
