### PR TITLE
XY-872: Stabilize Decodex full release gate for v0.2.0

### DIFF
--- a/apps/decodex/src/orchestrator/tests/operator/status/http.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/http.rs
@@ -8,6 +8,8 @@ use process::Child;
 
 use crate::runtime;
 
+const OPERATOR_DASHBOARD_TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
 #[cfg(unix)]
 struct ActiveLeaseMissingControlFixture {
 	issue: TrackerIssue,
@@ -276,7 +278,7 @@ fn operator_dashboard_websocket_pushes_broadcast_events() {
 		}),
 	);
 
-	let deadline = Instant::now() + Duration::from_secs(1);
+	let deadline = Instant::now() + OPERATOR_DASHBOARD_TEST_TIMEOUT;
 	let payload = loop {
 		assert!(Instant::now() < deadline, "websocket should send broadcast events");
 
@@ -889,7 +891,7 @@ fn open_dashboard_websocket_client(address: SocketAddr) -> (TcpStream, String, V
 	let mut buffer = [0_u8; 2_048];
 
 	client
-		.set_read_timeout(Some(Duration::from_secs(1)))
+		.set_read_timeout(Some(OPERATOR_DASHBOARD_TEST_TIMEOUT))
 		.expect("client timeout should configure");
 	client
 		.write_all(
@@ -947,7 +949,7 @@ fn read_websocket_json_until(
 	frame: &mut Vec<u8>,
 	matches: impl Fn(&Value) -> bool,
 ) -> Value {
-	let deadline = Instant::now() + Duration::from_secs(1);
+	let deadline = Instant::now() + OPERATOR_DASHBOARD_TEST_TIMEOUT;
 	let mut buffer = [0_u8; 2_048];
 
 	loop {


### PR DESCRIPTION
## Summary
- Stabilizes the operator dashboard HTTP/WebSocket test harness by replacing duplicated 1s socket/event deadlines with one shared 5s test deadline.
- Keeps all assertions and coverage intact; no tests are skipped and no release-gate command semantics are changed.

## Failing Tests Observed
- Current full-gate reproduction did not emit app-server timeout test names: after restoring checked-in site dependencies, `cargo make check` and `cargo make test` both completed.
- The first baseline run stopped before nextest because the local site dependency executable was missing (`astro: command not found`); `npm ci` in `site/` restored the locked dependency tree and left no tracked-file changes.
- The timeout-sensitive app-server-adjacent surfaces exercised in this lane were the `app_server`, `operator_dashboard_websocket`, and `operator_state_endpoint` nextest filters.

## Root Cause / Stabilization
- The likely remaining full-gate-only flake surface was the operator dashboard HTTP/WebSocket harness using 1s wall-clock read/event deadlines while the full release gate was compiling and running many tests concurrently.
- Focused reruns can pass because they avoid that load; the harness now uses a 5s bounded test deadline, preserving failure behavior for real hangs while reducing false timeouts under release-gate load.

## Validation
- `cargo nextest run -p decodex --all-targets --all-features operator_dashboard_websocket --stress-count 5 --no-fail-fast`
- `cargo nextest run -p decodex --all-targets --all-features operator_state_endpoint --stress-count 5 --no-fail-fast`
- `cargo nextest run -p decodex --all-targets --all-features app_server --stress-count 5 --no-fail-fast`
- `cargo make fmt`
- `cargo make lint-fix`
- `cargo make test`
- `cargo make check`