### PR TITLE
Reserve Decodex X PR27191 publication

### DIFF
--- a/artifacts/social/x/posts/2026-06-10/openai-codex-pr-27191.json
+++ b/artifacts/social/x/posts/2026-06-10/openai-codex-pr-27191.json
@@ -1,0 +1,99 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-27191",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "published",
+  "audience": "Codex MCP, plugin, and app-server operators",
+  "text": [
+    "Codex is routing hosted Apps MCP through extension contributions: app-server installs `codex-mcp-extension`, resolves runtime/effective MCP views, and keeps ChatGPT auth gating for `codex_apps`. PR: https://github.com/openai/codex/pull/27191"
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27191.json"
+    ],
+    "reservations": [
+      "artifacts/social/x/reservations/2026-06-10/openai-codex-pr-27191.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27191.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27191.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27191",
+      "https://x.com/decodexspace/status/2064649385418617112"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish, priority high, and mode operator_impact for openai-codex-pr-27191.",
+    "The upstream_review/v1 artifact confirms PR #27191 adds the McpServerContributor extension path, installs codex_mcp_extension in app-server, and uses runtime/effective MCP views across app-server MCP paths.",
+    "The upstream_impact/v1 artifact marks the change as public_signal_decision publish, control_plane_impact compat_risk, and publisher_angle operator_impact.",
+    "The x-post-quality-system gate passed because the post states what changed, who can act on it, and the direct source that proves it; the copy stays scoped to hosted Apps MCP and app-server runtime/effective MCP views.",
+    "Checked durable social_post/v1 records contained no published or blocked record for this idempotency key before publication.",
+    "Checked durable social_publish_reservation/v1 records contained no active reservation for this idempotency key before the new reservation was created.",
+    "Open GitHub PR readback with routed hackink credentials showed no open PR touching artifacts/social/x before the reservation branch was created.",
+    "PR #290 made the active reservation visible before X compose; the PR diff was limited to artifacts/social/x/reservations/2026-06-10/openai-codex-pr-27191.json at reservation time.",
+    "Chrome account readback initially showed @hackink active with @decodexspace available; the automation switched to @decodexspace and verified the account menu before reservation and compose.",
+    "Live @decodexspace profile readback before reservation was readable and found no PR27191, hosted Apps MCP, effective MCP, or source duplicate across rendered recent profile posts.",
+    "Live @decodexspace profile readback after PR-visible reservation and immediately before clicking Post again found no PR27191, hosted Apps MCP, effective MCP, codex-mcp-extension, or source duplicate.",
+    "The compose dialog showed @decodexspace and the 241-character checked candidate text before the enabled modal Post button was clicked.",
+    "Home timeline readback immediately after posting showed the new @decodexspace status with the expected PR27191 text and GitHub source link.",
+    "Permalink readback showed the expected @decodexspace post text, Automated by @hackink attribution, GitHub PR #27191 card, and no attached image media or /photo/N link.",
+    "The status ID decodes to 2026-06-10T10:02:27.471Z."
+  ],
+  "claims": [
+    {
+      "text": "Hosted Apps MCP is now contributed through the extension model in app-server.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27191.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "App-server MCP APIs now distinguish configured, runtime, and effective server views.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27191.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The PR #27191 operator-impact post is live on @decodexspace.",
+      "evidence": "https://x.com/decodexspace/status/2064649385418617112",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "priority": "high",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27191:operator_impact",
+    "reason": "The PR changes a concrete hosted MCP/app-server operator path and carries Control Plane compatibility risk.",
+    "daily_limit": 8,
+    "daily_count_before": 2,
+    "daily_count_after": 3,
+    "day": "2026-06-10",
+    "timezone": "Asia/Shanghai"
+  },
+  "publication": {
+    "posted_at": "2026-06-10T10:02:27.471Z",
+    "published_urls": [
+      "https://x.com/decodexspace/status/2064649385418617112"
+    ],
+    "publisher": "chrome",
+    "account_verified": true,
+    "made_with_ai": false
+  },
+  "media_refs": [
+    "media_caveat: no generated media was attached; this non-release operator_impact post remains valuable text-only because the source-backed app-server MCP warning and GitHub PR card are the reader value."
+  ],
+  "caveats": [
+    "This PR does not introduce a generic plugin activation framework.",
+    "Generic manifest-declared stdio MCP activation is left to a later vertical.",
+    "Hosted Apps MCP contribution remains gated by Apps and ChatGPT auth.",
+    "No generated image was used because this was a single non-release operator-impact post with sufficient reader value from the text and source card."
+  ],
+  "post_lifecycle": {
+    "current_state": "live",
+    "quote_eligible": false,
+    "reason": "This is a standalone operator-impact post, not a prerelease quote-chain anchor."
+  }
+}

--- a/artifacts/social/x/reservations/2026-06-10/openai-codex-pr-27191.json
+++ b/artifacts/social/x/reservations/2026-06-10/openai-codex-pr-27191.json
@@ -5,7 +5,7 @@
   "target_account": "decodexspace",
   "controller_account": "hackink",
   "mode": "operator_impact",
-  "status": "active",
+  "status": "consumed",
   "idempotency_key": "x:decodexspace:openai-codex-pr-27191:operator_impact",
   "reserved_at": "2026-06-10T09:56:46Z",
   "expires_at": "2026-06-10T11:56:46Z",
@@ -36,8 +36,10 @@
   ],
   "owner": {
     "automation_id": "decodex-x-publisher",
-    "branch": "codex/x-publisher-pr27191-20260610"
+    "branch": "codex/x-publisher-pr27191-20260610",
+    "pr_url": "https://github.com/hack-ink/decodex/pull/290"
   },
+  "consumed_by_social_post": "artifacts/social/x/posts/2026-06-10/openai-codex-pr-27191.json",
   "evidence_notes": [
     "Checked durable social_post/v1 records: no PR27191 slug, source URL, or idempotency-key match.",
     "Checked durable social_publish_reservation/v1 records: no PR27191 slug or idempotency-key match.",

--- a/artifacts/social/x/reservations/2026-06-10/openai-codex-pr-27191.json
+++ b/artifacts/social/x/reservations/2026-06-10/openai-codex-pr-27191.json
@@ -1,0 +1,49 @@
+{
+  "schema": "social_publish_reservation/v1",
+  "slug": "openai-codex-pr-27191",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "active",
+  "idempotency_key": "x:decodexspace:openai-codex-pr-27191:operator_impact",
+  "reserved_at": "2026-06-10T09:56:46Z",
+  "expires_at": "2026-06-10T11:56:46Z",
+  "day": "2026-06-10",
+  "timezone": "Asia/Shanghai",
+  "candidate_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27191.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27191.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27191.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27191"
+    ]
+  },
+  "duplicate_keys": [
+    "x:decodexspace:openai-codex-pr-27191:operator_impact",
+    "openai-codex-pr-27191",
+    "https://github.com/openai/codex/pull/27191",
+    "Pull Request #27191",
+    "Route hosted Apps MCP through extensions",
+    "hosted Apps MCP",
+    "effective MCP"
+  ],
+  "owner": {
+    "automation_id": "decodex-x-publisher",
+    "branch": "codex/x-publisher-pr27191-20260610"
+  },
+  "evidence_notes": [
+    "Checked durable social_post/v1 records: no PR27191 slug, source URL, or idempotency-key match.",
+    "Checked durable social_publish_reservation/v1 records: no PR27191 slug or idempotency-key match.",
+    "Checked open GitHub PRs with routed hackink credentials at 2026-06-10T09:53:45Z: no open PR touched artifacts/social/x.",
+    "Asia/Shanghai cap day 2026-06-10 had two checked published @decodexspace status URLs before reservation; this one-post candidate would keep the day within the limit of eight.",
+    "Chrome X account readback switched from controller @hackink to target @decodexspace before reservation.",
+    "Live @decodexspace profile readback was readable and showed no PR27191, hosted Apps MCP, effective MCP, or source duplicate across the rendered recent profile posts."
+  ]
+}


### PR DESCRIPTION
## Summary
- Published openai-codex-pr-27191 to @decodexspace via Chrome.
- Consumes the PR-visible social_publish_reservation/v1 lease.
- Adds the terminal social_post/v1 record with permalink/readback evidence and media caveat.

## Published URL
- https://x.com/decodexspace/status/2064649385418617112

## Validation
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x
- cargo make fmt
- cargo make lint-fix
- cargo make test