### PR TITLE
XY-876 Dogfood and release Decodex v0.2 Loop Engineering candidate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "decodex"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition     = "2024"
 homepage    = "https://decodex.space"
 license     = "GPL-3.0"
 repository  = "https://github.com/hack-ink/decodex"
-version     = "0.1.0"
+version     = "0.2.0"
 
 [workspace.dependencies]
 base64             = { version = "0.22" }

--- a/docs/runbook/index.md
+++ b/docs/runbook/index.md
@@ -48,6 +48,8 @@ Question this index answers: "which sequence should I execute?"
   marker.
 - [`review-config-migration.md`](./review-config-migration.md) for one-time migration
   from historical review config keys to `[codex].review` levels.
+- [`release-readiness.md`](./release-readiness.md) for the v0.2.0 Loop Engineering
+  release-candidate gate, dogfood evidence checklist, tag contract, and release note.
 - [`research-to-execution-loop.md`](./research-to-execution-loop.md) for compiling
   latent research contracts, promoting accepted results, inspecting Execution Program
   queue shaping, and following validation, review, guardrail, and harness feedback.

--- a/docs/runbook/release-readiness.md
+++ b/docs/runbook/release-readiness.md
@@ -1,0 +1,134 @@
+# Release Readiness
+
+Goal: Execute the final Decodex v0.2.0 Loop Engineering release-candidate gate without
+tagging or publishing before real dogfood and validation evidence exists.
+Read this when: You are closing the v0.2.0 release gate, preparing tag readiness, or
+checking whether the Loop Engineering candidate has enough evidence to publish.
+Inputs: Current `main`, registered Decodex project config, registered project
+`WORKFLOW.md`, release workflow, runtime evidence, PR handoff state, and dogfood lane
+run id.
+Depends on: `README.md`, `Makefile.toml`, `.github/workflows/release.yml`,
+`docs/spec/loop-runtime.md`, `docs/spec/review-orchestration.md`,
+`docs/reference/operator-control-plane.md`, and
+`docs/runbook/review-config-migration.md`.
+Outputs: A release-ready evidence packet, tag/version match for `v0.2.0`, and a final
+release note that names shipped capabilities and deferred items.
+
+## Tag Contract
+
+- `Cargo.toml` `[workspace.package].version` must be `0.2.0`.
+- The release workflow accepts only tags shaped as `vX.Y.Z`.
+- The release workflow fails when the pushed tag does not equal
+  `v${workspace.package.version}`.
+- For this candidate, the only valid release tag is `v0.2.0`.
+- Do not tag or publish if the workflow, workspace version, or intended tag disagree.
+
+## Required Evidence
+
+Collect evidence in this order:
+
+1. Confirm the dependency chain is landed and the lane is based on current `main`.
+   Required dependencies are XY-870, XY-871, XY-872, XY-873, XY-874, XY-875,
+   XY-877, XY-878, and XY-890.
+2. Confirm the operator-local self-project config uses:
+
+   ```toml
+   [codex]
+   review = "standard"
+   ```
+
+3. Scan checked-in docs, skills, examples, and config templates for historical review
+   config fields. The literal old field names may appear only in migration history.
+4. Run the registered project gate before any pushed PR head. This mirrors the
+   registered `WORKFLOW.md` order: canonicalize first, then verify.
+
+   ```sh
+   cargo make fmt
+   cargo make lint-fix
+   cargo make test
+   ```
+
+5. Confirm canonicalization did not leave unreviewed changes. If `fmt` or `lint-fix`
+   changed files, inspect the resulting diff before collecting release-gate evidence.
+6. Run the full release gate on the final tree:
+
+   ```sh
+   cargo make check
+   ```
+
+7. Run focused loop, review, config, prompt, dry-run, and recovery checks selected
+   from the landed dependency changes. At minimum include review-level and config
+   coverage:
+
+   ```sh
+   cargo test -p decodex review --all-features -- --test-threads=1
+   cargo test -p decodex config --all-features -- --test-threads=1
+   cargo test -p decodex loop_scenarios --all-features -- --test-threads=1
+   cargo test -p decodex normal_prompts --all-features -- --test-threads=1
+   cargo test -p decodex dry_run --all-features -- --test-threads=1
+   cargo test -p decodex recovery --all-features -- --test-threads=1
+   ```
+
+8. Verify the current-source CLI path:
+
+   ```sh
+   cargo run -p decodex --bin decodex -- probe stdio://
+   cargo run -p decodex --bin decodex -- status --live --json
+   cargo run -p decodex --bin decodex -- run --dry-run
+   ```
+
+9. Dogfood at least one real Decodex lane with `[codex].review = "standard"`.
+   The lane must reach PR handoff or another release-safe terminal state, and it must
+   leave an inspectable Decodex Review checkpoint.
+10. Read the dogfood lane private evidence:
+
+   ```sh
+   cargo run -p decodex --bin decodex -- evidence <ISSUE> --run-id <RUN_ID> --attempt <N> --json
+   ```
+
+   The readback must summarize review, recovery, boundary, or harness evidence when
+   those events exist for the run.
+11. Attach the concrete command outputs, dogfood issue, run id, attempt, PR URL or
+    terminal state, and evidence readback summary to the release gate record before
+    creating the `v0.2.0` tag.
+
+## Release Note
+
+### v0.2.0 Loop Engineering
+
+Decodex v0.2.0 closes the Loop Engineering release candidate. The release moves
+Decodex from isolated retained-lane automation toward an evidence-backed loop that can
+connect research/design, Decision Contracts, issue/program shaping, queued execution,
+review, recovery, PR handoff, and release-readiness verification.
+
+Shipped capabilities:
+
+- Natural-language research and design intake now compiles local Decision Contract
+  candidates and keeps research output latent until explicit promotion.
+- Accepted Decision Contracts can feed internal Execution Program readiness while
+  normal Linear issues remain the executable lane boundary.
+- Phase-scoped Codex goals make implementation, validation repair, review repair, and
+  handoff evidence distinct runtime phases.
+- The review-level config model is consolidated under `[codex].review` with `off`,
+  `basic`, `standard`, and `strict` levels.
+- Standard review requires Self Check plus Decodex Review through structured
+  `issue_review_checkpoint` evidence before PR handoff.
+- Loop guardrails, Architecture Recovery Packets, and Authority Boundary Checks
+  preserve review, recovery, and human-required stop evidence instead of collapsing
+  repeated failures into generic retry state.
+- Operator status and `decodex evidence` can read compact loop status, review
+  checkpoints, recovery summaries, boundary decisions, and harness-improvement
+  candidates from local runtime evidence.
+- The installable Decodex plugin, runbooks, and specs align with the Loop Engineering
+  workflow and the `review = "standard"` dogfood path.
+
+Intentionally deferred items:
+
+- Do not expose Execution Program graph editing, DAG commands, or Codex goal internals
+  as ordinary operator workflow.
+- Do not use GitHub Review unless `[codex].review = "strict"` and the strict adapter
+  signals are satisfied.
+- Do not treat harness-improvement recommendations as automatic authority to edit
+  prompts, validators, issue templates, skills, or policy.
+- Do not tag or publish v0.2.0 until the evidence checklist above includes a real
+  dogfood lane and a successful full release gate.

--- a/docs/runbook/review-config-migration.md
+++ b/docs/runbook/review-config-migration.md
@@ -67,9 +67,9 @@ belongs to the operator environment, not this source-lane migration.
 After code or checked-in docs change, run:
 
 ```sh
-cargo test -p decodex review --all-features
-cargo test -p decodex config --all-features
-cargo test -p decodex run_and_prompting --all-features
+cargo test -p decodex review --all-features -- --test-threads=1
+cargo test -p decodex config --all-features -- --test-threads=1
+cargo test -p decodex normal_prompts --all-features -- --test-threads=1
 cargo make fmt
 cargo make lint-fix
 cargo make test


### PR DESCRIPTION
## Summary
- Bump Decodex workspace version and lockfile from 0.1.0 to 0.2.0.
- Add the v0.2.0 Loop Engineering release-readiness runbook and index entry.
- Correct migration-guide focused test commands to current targeted filters.

## Validation
- cargo make fmt
- cargo make lint-fix
- cargo make test: 1035 passed, 1 skipped
- cargo make check: 1035 passed, 1 skipped
- cargo test -p decodex review --all-features -- --test-threads=1: 166 passed
- cargo test -p decodex config --all-features -- --test-threads=1: 60 passed
- cargo test -p decodex loop_scenarios --all-features -- --test-threads=1: 2 passed
- cargo test -p decodex normal_prompts --all-features -- --test-threads=1: 2 passed
- cargo test -p decodex dry_run --all-features -- --test-threads=1: 11 passed
- cargo test -p decodex recovery --all-features -- --test-threads=1: 33 passed
- cargo run -p decodex --bin decodex -- probe stdio://: PROBE_OK
- cargo run -p decodex --bin decodex -- status --live --json: XY-876 retained attention, review checkpoint pending
- cargo run -p decodex --bin decodex -- run --dry-run: planned XY-876 attempt 2 on the retained worktree
- git diff --check

## Review
- Independent read-only review found XY876-RR-001: release checklist ran check before canonicalization.
- Fixed by ordering the runbook gate as WORKFLOW.md canonicalize commands first, then verify, then final cargo make check on the final tree.
- Re-ran cargo make check after the fix: 1035 passed, 1 skipped.

## Release note
This PR prepares the v0.2.0 tag contract and release-readiness evidence checklist. It does not publish or tag v0.2.0. The runbook still requires a real standard-review dogfood lane with inspectable Decodex Review checkpoint before tagging.