### PR TITLE
XY-896: Dogfood standard Decodex Review checkpoint on a tiny docs lane

### DIFF
--- a/docs/runbook/release-readiness.md
+++ b/docs/runbook/release-readiness.md
@@ -80,6 +80,10 @@ Collect evidence in this order:
 9. Dogfood at least one real Decodex lane with `[codex].review = "standard"`.
    The lane must reach PR handoff or another release-safe terminal state, and it must
    leave an inspectable Decodex Review checkpoint.
+   Manual PR review comments or local self-check notes do not replace the runtime
+   checkpoint: `decodex evidence <ISSUE> --json` for the dogfood lane must show a
+   non-empty `review_checkpoints` array. The release remains blocked, even if the
+   implementation PR lands, when that runtime checkpoint is absent.
 10. Read the dogfood lane private evidence:
 
    ```sh


### PR DESCRIPTION
## Summary
- Clarify that valid standard-review dogfood evidence requires runtime issue_review_checkpoint evidence.
- State that manual PR review comments or local self-check notes do not replace a non-empty review_checkpoints array from decodex evidence.
- Note that release readiness remains blocked when the runtime checkpoint is absent, even if the implementation PR lands.

## Validation
- cargo make fmt
- cargo make lint-fix
- cargo make test: 1035 passed, 1 skipped
- git diff --check

## Review Evidence
- Clean independent fresh-context Decodex Review checkpoint recorded for c390fc24f1d93f4f3bc2848067f1021ee5c81cfe.

Linear: XY-896