### PR TITLE
Persist upstream Radar review artifacts

### DIFF
--- a/artifacts/github/bundles/openai-codex-pr-25147.json
+++ b/artifacts/github/bundles/openai-codex-pr-25147.json
@@ -1,0 +1,259 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-05-29T20:16:10Z",
+      "message": "Retry streamable HTTP initialize failures",
+      "sha": "09ce7e176bb3e35108cce7c74f9fe566125b6c87",
+      "url": "https://github.com/openai/codex/commit/09ce7e176bb3e35108cce7c74f9fe566125b6c87"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-04T00:19:08Z",
+      "message": "Add MCP initialize outcome metric",
+      "sha": "821b679505e5021c4fc20a3c79070d96ff0aaa24",
+      "url": "https://github.com/openai/codex/commit/821b679505e5021c4fc20a3c79070d96ff0aaa24"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-04T23:54:41Z",
+      "message": "Retry remote streamable HTTP no-response failures",
+      "sha": "e992bdf9805440b068ffa2c031dbf3be0e244107",
+      "url": "https://github.com/openai/codex/commit/e992bdf9805440b068ffa2c031dbf3be0e244107"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-05T00:03:49Z",
+      "message": "codex: fix CI fmt-check recipe on PR #25147",
+      "sha": "7c54723762ae9ebb3d2bbb95e71ac5000771c9c9",
+      "url": "https://github.com/openai/codex/commit/7c54723762ae9ebb3d2bbb95e71ac5000771c9c9"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-05T00:36:07Z",
+      "message": "codex: fix CI failures on PR #25147",
+      "sha": "e4dca2440722489eb1d774ba0b273a4260f8d0e8",
+      "url": "https://github.com/openai/codex/commit/e4dca2440722489eb1d774ba0b273a4260f8d0e8"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-05T00:54:13Z",
+      "message": "codex: address PR review feedback (#25147)",
+      "sha": "5f2b14e092e169c3f4c9f4b93c40e2560f95e2ca",
+      "url": "https://github.com/openai/codex/commit/5f2b14e092e169c3f4c9f4b93c40e2560f95e2ca"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-05T01:08:17Z",
+      "message": "codex: address follow-up review feedback (#25147)",
+      "sha": "d4b826175776c26f977b2e10a9dc9bc4a3030e41",
+      "url": "https://github.com/openai/codex/commit/d4b826175776c26f977b2e10a9dc9bc4a3030e41"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-05T01:15:31Z",
+      "message": "codex: fix python SDK signature test (#25147)",
+      "sha": "daf24cccd232bb9cc3035eb9985d2bf3ee24cab5",
+      "url": "https://github.com/openai/codex/commit/daf24cccd232bb9cc3035eb9985d2bf3ee24cab5"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-05T01:30:15Z",
+      "message": "codex: narrow retry PR scope (#25147)",
+      "sha": "b0a300fb9b9d8ee73be8d40f718eb7b9464a28be",
+      "url": "https://github.com/openai/codex/commit/b0a300fb9b9d8ee73be8d40f718eb7b9464a28be"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-05T01:31:21Z",
+      "message": "codex: remove SDK changes from retry PR (#25147)",
+      "sha": "6e4c8dfa31a5fbb6216e8465337d737b7327fb6a",
+      "url": "https://github.com/openai/codex/commit/6e4c8dfa31a5fbb6216e8465337d737b7327fb6a"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-05T01:58:16Z",
+      "message": "codex: address retry review structure feedback (#25147)",
+      "sha": "dee789ab91d6883ca16fbc86aeadbf524d95c1ef",
+      "url": "https://github.com/openai/codex/commit/dee789ab91d6883ca16fbc86aeadbf524d95c1ef"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-05T02:03:37Z",
+      "message": "codex: fix justfile formatting for CI (#25147)",
+      "sha": "08503d6d13e7b7efc817299c30bcf34bd7b5b076",
+      "url": "https://github.com/openai/codex/commit/08503d6d13e7b7efc817299c30bcf34bd7b5b076"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-05T02:16:56Z",
+      "message": "codex: address streamable http retry review feedback (#25147)",
+      "sha": "75e3421f94a530314154b3ff9dd51a1064f861f6",
+      "url": "https://github.com/openai/codex/commit/75e3421f94a530314154b3ff9dd51a1064f861f6"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-05T02:22:37Z",
+      "message": "codex: keep rmcp retry module surgical (#25147)",
+      "sha": "d1596f4595d17a2e2a94a8fc45c7ceb116079868",
+      "url": "https://github.com/openai/codex/commit/d1596f4595d17a2e2a94a8fc45c7ceb116079868"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-05T02:37:57Z",
+      "message": "codex: narrow streamable http initialize retry (#25147)",
+      "sha": "2e23b88414a393e9800c328bded2e6f2bd7ba7a7",
+      "url": "https://github.com/openai/codex/commit/2e23b88414a393e9800c328bded2e6f2bd7ba7a7"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-09T15:01:20Z",
+      "message": "Persist OAuth state before initialize retry",
+      "sha": "b8760d31e0e00e07aa8db22afae4ab3fb9797af4",
+      "url": "https://github.com/openai/codex/commit/b8760d31e0e00e07aa8db22afae4ab3fb9797af4"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-09T15:06:16Z",
+      "message": "Remove python SDK changes from retry PR",
+      "sha": "1f6a75d2ac149df0a0d8f99a531aeb65243c5d1b",
+      "url": "https://github.com/openai/codex/commit/1f6a75d2ac149df0a0d8f99a531aeb65243c5d1b"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-09T15:26:09Z",
+      "message": "Retry streamable HTTP recovery handshakes",
+      "sha": "9dfb4be0ec69162ea9b1b10008c160a333a99df1",
+      "url": "https://github.com/openai/codex/commit/9dfb4be0ec69162ea9b1b10008c160a333a99df1"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-09T15:44:15Z",
+      "message": "Retry tools list transient HTTP failures",
+      "sha": "ce34025915ff7df1c060ff0343c5b42c4f3453f9",
+      "url": "https://github.com/openai/codex/commit/ce34025915ff7df1c060ff0343c5b42c4f3453f9"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-09T16:00:11Z",
+      "message": "Retry initialized notification failures",
+      "sha": "7a381f591d4bd26aabb5312d89b5c5b3d47d5a9d",
+      "url": "https://github.com/openai/codex/commit/7a381f591d4bd26aabb5312d89b5c5b3d47d5a9d"
+    },
+    {
+      "author": "ssetty-oai",
+      "committed_at": "2026-06-09T16:14:51Z",
+      "message": "Cover tools list JSON-RPC retry",
+      "sha": "4f29a9e89e8f39e784336e83bc71dffc270f632d",
+      "url": "https://github.com/openai/codex/commit/4f29a9e89e8f39e784336e83bc71dffc270f632d"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "HTTP",
+    "RMCP",
+    "--package",
+    "--test",
+    "MCP",
+    "SDK",
+    "JSON",
+    "MEMO_URI",
+    "MEMO_CONTENT",
+    "MCP_SESSION_ID_HEADER",
+    "SESSION_POST_FAILURE_CONTROL_PATH",
+    "INITIALIZE_POST_FAILURE_CONTROL_PATH",
+    "INITIALIZED_NOTIFICATION_POST_FAILURE_CONTROL_PATH",
+    "MAX_MCP_POST_BODY_BYTES",
+    "WWW",
+    "MAX_BIND_RETRIES",
+    "BIND_RETRY_DELAY",
+    "MCP_EXPECT_BEARER",
+    "BAD_REQUEST",
+    "NO_CONTENT",
+    "POST",
+    "CONTENT_TYPE",
+    "HEADER_SESSION_ID",
+    "JSON_MIME_TYPE",
+    "EVENT_STREAM_MIME_TYPE",
+    "REQUEST_TIMEOUT",
+    "TOO_MANY_REQUESTS",
+    "INTERNAL_SERVER_ERROR",
+    "BAD_GATEWAY",
+    "SERVICE_UNAVAILABLE",
+    "GATEWAY_TIMEOUT",
+    "STREAMABLE_HTTP_RETRY_DELAYS_MS",
+    "JSON_RPC_INTERNAL_ERROR_CODE",
+    "SIMULATED_NO_RESPONSE_MESSAGE"
+  ],
+  "files": [
+    {
+      "additions": 103,
+      "deletions": 16,
+      "patch_excerpt": "@@ -8,6 +8,7 @@ use std::time::Duration;\n \n use axum::Router;\n use axum::body::Body;\n+use axum::body::to_bytes;\n use axum::extract::Json;\n use axum::extract::State;\n use axum::http::HeaderMap;\n@@ -48,6 +49,7 @@ use rmcp::transport::StreamableHttpServerConfig;\n use rmcp::transport::StreamableHttpService;\n use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;\n use serde::Deserialize;\n+use serde_json::Value;\n use serde_json::json;\n use tokio::sync::Mutex;\n use tokio::task;\n@@ -64,18 +66,32 @@ const MEMO_URI: &str = \"memo://codex/example-note\";\n const MEMO_CONTENT: &str = \"This is a sample MCP resource served by the rmcp test server.\";\n const MCP_SESSION_ID_HEADER: &str = \"mcp-session-id\";\n const SESSION_POST_FAILURE_CONTROL_PATH: &str = \"/test/control/session-post-failure\";\n+const INITIALIZE_POST_FAILURE_CONTROL_PATH: &str = \"/test/control/initialize-post-failure...",
+      "path": "codex-rs/rmcp-client/src/bin/test_streamable_http_server.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 71,
+      "deletions": 1,
+      "patch_excerpt": "@@ -28,6 +28,8 @@ use reqwest::header::CONTENT_TYPE;\n use reqwest::header::HeaderMap;\n use reqwest::header::HeaderName;\n use rmcp::model::ClientJsonRpcMessage;\n+use rmcp::model::ClientNotification;\n+use rmcp::model::ConstString;\n use rmcp::model::JsonRpcMessage;\n use rmcp::model::ServerJsonRpcMessage;\n use rmcp::transport::streamable_http_client::AuthRequiredError;\n@@ -185,6 +187,25 @@ impl StreamableHttpClient for StreamableHttpClientAdapter {\n \n         let content_type = response_header(&response.headers, CONTENT_TYPE);\n         let session_id = response_header(&response.headers, HEADER_SESSION_ID);\n+        if !status_is_success(response.status) {\n+            let body = collect_body(&mut body_stream).await?;\n+            if !retryable_post_response_status(mcp_method.as_deref(), response.status)\n+                && content_type\n+                    .as_deref()\n+                    .i...",
+      "path": "codex-rs/rmcp-client/src/http_client_adapter.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 137,
+      "deletions": 17,
+      "patch_excerpt": "@@ -74,6 +74,13 @@ use crate::utils::apply_default_headers;\n use crate::utils::build_default_headers;\n use codex_config::types::OAuthCredentialsStoreMode;\n \n+#[path = \"streamable_http_retry.rs\"]\n+mod streamable_http_retry;\n+\n+use self::streamable_http_retry::HandshakeError;\n+use self::streamable_http_retry::STREAMABLE_HTTP_RETRY_DELAYS_MS;\n+use self::streamable_http_retry::sleep_with_retry_deadline;\n+\n enum PendingTransport {\n     InProcess {\n         transport: tokio::io::DuplexStream,\n@@ -223,6 +230,25 @@ enum ClientOperationError {\n     Timeout { label: String, duration: Duration },\n }\n \n+fn remaining_operation_timeout(\n+    label: &str,\n+    timeout: Option<Duration>,\n+    deadline: Option<Instant>,\n+) -> std::result::Result<Option<Duration>, ClientOperationError> {\n+    let Some(deadline) = deadline else {\n+        return Ok(None);\n+    };\n+    let remaining = deadline.saturating_du...",
+      "path": "codex-rs/rmcp-client/src/rmcp_client.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 239,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,239 @@\n+use std::sync::Arc;\n+use std::time::Duration;\n+use std::time::Instant;\n+\n+use anyhow::Result;\n+use anyhow::anyhow;\n+use codex_exec_server::ExecServerError;\n+use reqwest::StatusCode;\n+use rmcp::service::RoleClient;\n+use rmcp::service::RunningService;\n+use rmcp::transport::streamable_http_client::StreamableHttpError;\n+use tokio::time;\n+use tracing::warn;\n+\n+use crate::elicitation_client_service::ElicitationClientService;\n+use crate::http_client_adapter::StreamableHttpClientAdapterError;\n+use crate::oauth::OAuthPersistor;\n+\n+use super::PendingTransport;\n+use super::RmcpClient;\n+\n+const JSON_RPC_INTERNAL_ERROR_CODE: i64 = -32603;\n+pub(super) const STREAMABLE_HTTP_RETRY_DELAYS_MS: [u64; 2] = [250, 1_000];\n+\n+impl RmcpClient {\n+    pub(super) async fn connect_pending_transport_with_initialize_retries(\n+        &self,\n+        initial_transport: PendingTransport,\n+        cli...",
+      "path": "codex-rs/rmcp-client/src/streamable_http_retry.rs",
+      "status": "added"
+    },
+    {
+      "additions": 74,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,74 @@\n+use std::any::TypeId;\n+\n+use codex_exec_server::ExecServerError;\n+use pretty_assertions::assert_eq;\n+use rmcp::transport::DynamicTransportError;\n+use rmcp::transport::streamable_http_client::StreamableHttpError;\n+\n+use crate::http_client_adapter::StreamableHttpClientAdapterError;\n+\n+use super::*;\n+\n+#[test]\n+fn retryable_initialize_error_includes_initialized_notification_context() {\n+    let contexts = [\n+        \"send initialize request\",\n+        \"send initialized notification\",\n+        \"receive initialize response\",\n+    ];\n+\n+    assert_eq!(\n+        contexts.map(|context| {\n+            RmcpClient::is_retryable_client_initialize_error(&retryable_initialize_error(context))\n+        }),\n+        [true, true, false],\n+    );\n+}\n+\n+#[test]\n+fn retryable_streamable_http_error_includes_remote_body_stream_failure() {\n+    let errors = [\n+        StreamableHttpError::Clie...",
+      "path": "codex-rs/rmcp-client/src/streamable_http_retry_tests.rs",
+      "status": "added"
+    },
+    {
+      "additions": 247,
+      "deletions": 4,
+      "patch_excerpt": "@@ -1,13 +1,229 @@\n mod streamable_http_test_support;\n \n+use std::sync::Arc;\n+use std::sync::atomic::AtomicUsize;\n+use std::sync::atomic::Ordering;\n+use std::time::Duration;\n+\n+use codex_exec_server::Environment;\n+use codex_exec_server::ExecServerError;\n+use codex_exec_server::HttpClient;\n+use codex_exec_server::HttpRequestParams;\n+use codex_exec_server::HttpRequestResponse;\n+use codex_exec_server::HttpResponseBodyStream;\n+use futures::FutureExt as _;\n+use futures::future::BoxFuture;\n use pretty_assertions::assert_eq;\n+use serde_json::Value;\n \n+use streamable_http_test_support::arm_initialize_post_failure;\n+use streamable_http_test_support::arm_initialize_post_json_rpc_failure;\n+use streamable_http_test_support::arm_initialized_notification_post_json_rpc_failure;\n use streamable_http_test_support::arm_session_post_failure;\n+use streamable_http_test_support::arm_session_post_json_rpc_fail...",
+      "path": "codex-rs/rmcp-client/tests/streamable_http_recovery.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 114,
+      "deletions": 1,
+      "patch_excerpt": "@@ -20,6 +20,7 @@ use anyhow::Context as _;\n use codex_config::types::OAuthCredentialsStoreMode;\n use codex_exec_server::Environment;\n use codex_exec_server::ExecServerClient;\n+use codex_exec_server::HttpClient;\n use codex_exec_server::RemoteExecServerConnectArgs;\n use codex_rmcp_client::ElicitationAction;\n use codex_rmcp_client::ElicitationResponse;\n@@ -44,6 +45,9 @@ use tokio::process::Command;\n use tokio::time::sleep;\n \n const SESSION_POST_FAILURE_CONTROL_PATH: &str = \"/test/control/session-post-failure\";\n+const INITIALIZE_POST_FAILURE_CONTROL_PATH: &str = \"/test/control/initialize-post-failure\";\n+const INITIALIZED_NOTIFICATION_POST_FAILURE_CONTROL_PATH: &str =\n+    \"/test/control/initialized-notification-post-failure\";\n \n fn streamable_http_server_bin() -> Result<PathBuf, CargoBinError> {\n     codex_utils_cargo_bin::cargo_bin(\"test_streamable_http_server\")\n@@ -74,14 +78,22 @@ pub(cra...",
+      "path": "codex-rs/rmcp-client/tests/streamable_http_test_support.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#25147"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Summary\n- Retry transient streamable HTTP failures during RMCP startup when the failure happens while sending the initialize request.\n- Retry transient streamable HTTP failures for tools/list, which is read-only and safe to replay.\n- Cover both retryable HTTP statuses and request-layer failures where no HTTP status is returned.\n- Surface retryable HTTP statuses from the streamable HTTP adapter as typed client errors.\n- Add integration coverage for initialize retry, tools/list retry, no-status request failure retry, and non-retryable initialize status.\n\n## Root cause\nThe observed codex_apps failures can happen before normal tool execution: RMCP startup fails while sending initialize, or the first read-only tools/list fails after startup. Retrying hosted_apps_bridge tools/call would not cover initialize and would risk replaying side-effecting tool calls. This change retries the streamable HTTP handshake itself, recreates the transport between initialize attempts, and retries only tools/list among post-initialize service operations.\n\n## Validation\n- cargo fmt --package codex-rmcp-client\n- cargo test -p codex-rmcp-client --test streamable_http_recovery",
+    "labels": [],
+    "merged_at": "2026-06-09T22:49:49Z",
+    "number": 25147,
+    "state": "merged",
+    "title": "[codex] Retry streamable HTTP initialize failures",
+    "url": "https://github.com/openai/codex/pull/25147"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-26701.json
+++ b/artifacts/github/bundles/openai-codex-pr-26701.json
@@ -1,0 +1,121 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "canvrno-oai",
+      "committed_at": "2026-06-03T18:10:15Z",
+      "message": "init",
+      "sha": "52f9ec871bedbd53a0c0741d0b7bc47e3dae3da9",
+      "url": "https://github.com/openai/codex/commit/52f9ec871bedbd53a0c0741d0b7bc47e3dae3da9"
+    },
+    {
+      "author": "canvrno-oai",
+      "committed_at": "2026-06-03T22:09:21Z",
+      "message": "cleanup",
+      "sha": "4d32a96c7580b022e5d906bcbb2eb283b80338f7",
+      "url": "https://github.com/openai/codex/commit/4d32a96c7580b022e5d906bcbb2eb283b80338f7"
+    },
+    {
+      "author": "canvrno-oai",
+      "committed_at": "2026-06-03T23:18:35Z",
+      "message": "Adjustment for admin-disabled plugins in /plugin menu",
+      "sha": "ddd48cab1b5d617e8a01737c0665f4025b351421",
+      "url": "https://github.com/openai/codex/commit/ddd48cab1b5d617e8a01737c0665f4025b351421"
+    },
+    {
+      "author": "canvrno-oai",
+      "committed_at": "2026-06-04T00:23:54Z",
+      "message": "fix",
+      "sha": "44448048dcad4a75a1d7056f23cc87691438268c",
+      "url": "https://github.com/openai/codex/commit/44448048dcad4a75a1d7056f23cc87691438268c"
+    },
+    {
+      "author": "canvrno-oai",
+      "committed_at": "2026-06-06T00:41:49Z",
+      "message": "tui: update remote plugin detail fixtures",
+      "sha": "ccf0f0d9892fd9b253401466d6dee7a1886ac407",
+      "url": "https://github.com/openai/codex/commit/ccf0f0d9892fd9b253401466d6dee7a1886ac407"
+    },
+    {
+      "author": "canvrno-oai",
+      "committed_at": "2026-06-09T20:54:23Z",
+      "message": "Merge branch 'main' into canvrno/plugin_sharing_tui_stack_pr1_remote_identity",
+      "sha": "9da50461f3d23990d484b3ba29b5cb293269d23f",
+      "url": "https://github.com/openai/codex/commit/9da50461f3d23990d484b3ba29b5cb293269d23f"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "TUI",
+    "OPENAI_CURATED_MARKETPLACE_NAME",
+    "NONE"
+  ],
+  "files": [
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -11,6 +11,7 @@ use crate::app_event::ExitMode;\n use crate::app_event::FeedbackCategory;\n use crate::app_event::HistoryLookupResponse;\n use crate::app_event::PermissionProfileSelection;\n+use crate::app_event::PluginLocation;\n use crate::app_event::RateLimitRefreshOrigin;\n use crate::app_event::RealtimeAudioDeviceKind;\n #[cfg(target_os = \"windows\")]",
+      "path": "codex-rs/tui/src/app.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 28,
+      "deletions": 7,
+      "patch_excerpt": "@@ -241,22 +241,22 @@ impl App {\n         &mut self,\n         app_server: &AppServerSession,\n         cwd: PathBuf,\n-        marketplace_path: AbsolutePathBuf,\n+        location: PluginLocation,\n         plugin_name: String,\n         plugin_display_name: String,\n     ) {\n         let request_handle = app_server.request_handle();\n         let app_event_tx = self.app_event_tx.clone();\n         tokio::spawn(async move {\n             let cwd_for_event = cwd.clone();\n-            let marketplace_path_for_event = marketplace_path.clone();\n+            let location_for_event = location.clone();\n             let plugin_name_for_event = plugin_name.clone();\n-            let result = fetch_plugin_install(request_handle, marketplace_path, plugin_name)\n+            let result = fetch_plugin_install(request_handle, location, plugin_name)\n                 .await\n                 .map_err(|err| format!...",
+      "path": "codex-rs/tui/src/app/background_requests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 8,
+      "deletions": 6,
+      "patch_excerpt": "@@ -573,14 +573,14 @@ impl App {\n             }\n             AppEvent::FetchPluginInstall {\n                 cwd,\n-                marketplace_path,\n+                location,\n                 plugin_name,\n                 plugin_display_name,\n             } => {\n                 self.fetch_plugin_install(\n                     app_server,\n                     cwd,\n-                    marketplace_path,\n+                    location,\n                     plugin_name,\n                     plugin_display_name,\n                 );\n@@ -601,7 +601,7 @@ impl App {\n             }\n             AppEvent::PluginInstallLoaded {\n                 cwd,\n-                marketplace_path,\n+                location,\n                 plugin_name,\n                 plugin_display_name,\n                 result,\n@@ -612,7 +612,7 @@ impl App {\n                 }\n                 let should_refresh_plugin_detail...",
+      "path": "codex-rs/tui/src/app/event_dispatch.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 17,
+      "deletions": 2,
+      "patch_excerpt": "@@ -109,6 +109,21 @@ pub(crate) struct ConnectorsSnapshot {\n     pub(crate) connectors: Vec<AppInfo>,\n }\n \n+#[derive(Debug, Clone, PartialEq, Eq)]\n+pub(crate) enum PluginLocation {\n+    Local { marketplace_path: AbsolutePathBuf },\n+    Remote { marketplace_name: String },\n+}\n+\n+impl PluginLocation {\n+    pub(crate) fn into_request_params(self) -> (Option<AbsolutePathBuf>, Option<String>) {\n+        match self {\n+            PluginLocation::Local { marketplace_path } => (Some(marketplace_path), None),\n+            PluginLocation::Remote { marketplace_name } => (None, Some(marketplace_name)),\n+        }\n+    }\n+}\n+\n /// Distinguishes why a rate-limit refresh was requested so the completion\n /// handler can route the result correctly.\n ///\n@@ -493,15 +508,15 @@ pub(crate) enum AppEvent {\n     /// Install a specific plugin from a marketplace.\n     FetchPluginInstall {\n         cwd: PathBuf,\n...",
+      "path": "codex-rs/tui/src/app_event.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 146,
+      "deletions": 59,
+      "patch_excerpt": "@@ -5,6 +5,7 @@ use std::time::Instant;\n \n use super::ChatWidget;\n use crate::app_event::AppEvent;\n+use crate::app_event::PluginLocation;\n use crate::bottom_pane::ColumnWidthMode;\n use crate::bottom_pane::SelectionAction;\n use crate::bottom_pane::SelectionItem;\n@@ -25,17 +26,18 @@ use crate::tui::FrameRequester;\n use codex_app_server_protocol::MarketplaceAddResponse;\n use codex_app_server_protocol::MarketplaceRemoveResponse;\n use codex_app_server_protocol::MarketplaceUpgradeResponse;\n+use codex_app_server_protocol::PluginAvailability;\n use codex_app_server_protocol::PluginDetail;\n use codex_app_server_protocol::PluginInstallPolicy;\n use codex_app_server_protocol::PluginInstallResponse;\n use codex_app_server_protocol::PluginListResponse;\n use codex_app_server_protocol::PluginMarketplaceEntry;\n use codex_app_server_protocol::PluginReadResponse;\n+use codex_app_server_protocol::PluginSource;...",
+      "path": "codex-rs/tui/src/chatwidget/plugins.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 28,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1337,6 +1337,34 @@ pub(super) fn plugins_test_summary(\n     }\n }\n \n+pub(super) fn plugins_test_remote_summary(\n+    remote_plugin_id: &str,\n+    name: &str,\n+    display_name: Option<&str>,\n+    description: Option<&str>,\n+    installed: bool,\n+) -> PluginSummary {\n+    PluginSummary {\n+        id: remote_plugin_id.to_string(),\n+        remote_plugin_id: Some(remote_plugin_id.to_string()),\n+        local_version: None,\n+        name: name.to_string(),\n+        share_context: None,\n+        source: PluginSource::Remote,\n+        installed,\n+        enabled: true,\n+        install_policy: PluginInstallPolicy::Available,\n+        auth_policy: PluginAuthPolicy::OnInstall,\n+        availability: PluginAvailability::Available,\n+        interface: Some(plugins_test_interface(\n+            display_name,\n+            description,\n+            /*long_description*/ None,\n+        )),\n+        k...",
+      "path": "codex-rs/tui/src/chatwidget/tests/helpers.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 345,
+      "deletions": 0,
+      "patch_excerpt": "@@ -6,6 +6,7 @@ use codex_app_server_protocol::HookErrorInfo;\n use codex_app_server_protocol::HooksListEntry;\n use codex_app_server_protocol::HooksListResponse;\n use codex_app_server_protocol::MarketplaceRemoveResponse;\n+use codex_app_server_protocol::PluginAvailability;\n use codex_features::Stage;\n use pretty_assertions::assert_eq;\n \n@@ -714,6 +715,350 @@ async fn plugin_detail_popup_hides_disclosure_for_installed_plugins() {\n     );\n }\n \n+#[tokio::test]\n+async fn plugins_popup_remote_row_opens_remote_detail() {\n+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;\n+    chat.set_feature_enabled(Feature::Plugins, /*enabled*/ true);\n+\n+    let popup = render_loaded_plugins_popup(\n+        &mut chat,\n+        plugins_test_response(vec![PluginMarketplaceEntry {\n+            name: \"workspace-directory\".to_string(),\n+            path: None,\n+            ...",
+      "path": "codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "This starts the shared-plugin TUI stack by teaching the existing plugin popup flows to address plugins from either a local marketplace path or a remote marketplace name. The visible surface stays intentionally narrow so later catalog work can build on stable remote request identity without adding share-management UI.\r\n\r\n- Adds remote-capable detail/install/uninstall request routing for plugin popup actions.\r\n- Uses remote plugin IDs for remote install and uninstall while preserving local plugin IDs and paths.\r\n- Keeps remote detail views available when a marketplace has no filesystem path.\r\n- Blocks admin-disabled plugin installs and toggle affordances in the existing flows.",
+    "labels": [],
+    "merged_at": "2026-06-09T23:34:39Z",
+    "number": 26701,
+    "state": "merged",
+    "title": "TUI Plugin Sharing 1 - add remote plugin identity",
+    "url": "https://github.com/openai/codex/pull/26701"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-26734.json
+++ b/artifacts/github/bundles/openai-codex-pr-26734.json
@@ -1,0 +1,232 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "pakrym-oai",
+      "committed_at": "2026-06-06T04:05:34Z",
+      "message": "Handle Ctrl-C for non-TTY unified exec",
+      "sha": "b564da44fb798e9e8e5c89ff912ab72a70a2ba9c",
+      "url": "https://github.com/openai/codex/commit/b564da44fb798e9e8e5c89ff912ab72a70a2ba9c"
+    },
+    {
+      "author": "pakrym-oai",
+      "committed_at": "2026-06-08T21:35:29Z",
+      "message": "Report unsupported process interrupts",
+      "sha": "5b5caa9431c818837eadc6d01cdd64e3b597ce9d",
+      "url": "https://github.com/openai/codex/commit/5b5caa9431c818837eadc6d01cdd64e3b597ce9d"
+    },
+    {
+      "author": "pakrym-oai",
+      "committed_at": "2026-06-08T22:00:38Z",
+      "message": "Avoid expect_err in exec server test",
+      "sha": "83c0b87e952501c98f96957c3df2b2efa45352f7",
+      "url": "https://github.com/openai/codex/commit/83c0b87e952501c98f96957c3df2b2efa45352f7"
+    },
+    {
+      "author": "pakrym-oai",
+      "committed_at": "2026-06-09T15:23:10Z",
+      "message": "Report SIGINT exit code for unified exec",
+      "sha": "9ff7581214ba17137fd351893766e6be3612ff05",
+      "url": "https://github.com/openai/codex/commit/9ff7581214ba17137fd351893766e6be3612ff05"
+    },
+    {
+      "author": "pakrym-oai",
+      "committed_at": "2026-06-09T16:59:29Z",
+      "message": "codex: fix CI failure on PR #26734",
+      "sha": "e605b381502ef535c95f6e57798cc78a08703912",
+      "url": "https://github.com/openai/codex/commit/e605b381502ef535c95f6e57798cc78a08703912"
+    },
+    {
+      "author": "pakrym-oai",
+      "committed_at": "2026-06-09T18:53:52Z",
+      "message": "Merge remote-tracking branch 'origin/main' into pakrym/unified-exec-non-tty-interrupt",
+      "sha": "eb4878b26439e36e1446fc72da6a8b25b495bfd1",
+      "url": "https://github.com/openai/codex/commit/eb4878b26439e36e1446fc72da6a8b25b495bfd1"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "SIGINT",
+    "INT",
+    "UNIFIED_EXEC_OUTPUT_MAX_TOKENS",
+    "EARLY_EXIT_GRACE_PERIOD",
+    "UNIFIED_EXEC_ENV",
+    "NETWORK_ACCESS_DENIED_MESSAGE",
+    "LATE_NETWORK_DENIAL_GRACE_PERIOD",
+    "INTERRUPT",
+    "READY",
+    "POST",
+    "NUL",
+    "EXEC_EXITED_METHOD",
+    "EXEC_METHOD",
+    "EXEC_OUTPUT_DELTA_METHOD",
+    "EXEC_READ_METHOD",
+    "EXEC_SIGNAL_METHOD",
+    "EXEC_TERMINATE_METHOD",
+    "EXEC_WRITE_METHOD",
+    "INITIALIZED_METHOD",
+    "JSONRPCE",
+    "MAX",
+    "ENVIRONMENT_INFO_METHOD",
+    "INITIALIZE_METHOD",
+    "CLI",
+    "PTY",
+    "SIGTERM",
+    "ESRCH",
+    "SIGKILL"
+  ],
+  "files": [
+    {
+      "additions": 14,
+      "deletions": 1,
+      "patch_excerpt": "@@ -14,6 +14,7 @@ use tokio_util::sync::CancellationToken;\n \n use crate::exec::is_likely_sandbox_denied;\n use codex_exec_server::ExecProcess;\n+use codex_exec_server::ProcessSignal as ExecServerProcessSignal;\n use codex_exec_server::ReadResponse as ExecReadResponse;\n use codex_exec_server::StartedExecProcess;\n use codex_exec_server::WriteStatus;\n@@ -23,6 +24,7 @@ use codex_protocol::protocol::TruncationPolicy;\n use codex_sandboxing::SandboxType;\n use codex_utils_output_truncation::formatted_truncate_text;\n use codex_utils_pty::ExecCommandSession;\n+use codex_utils_pty::ProcessSignal as PtyProcessSignal;\n use codex_utils_pty::SpawnedPty;\n \n use super::UNIFIED_EXEC_OUTPUT_MAX_TOKENS;\n@@ -31,7 +33,6 @@ use super::head_tail_buffer::HeadTailBuffer;\n use super::process_state::ProcessState;\n \n const EARLY_EXIT_GRACE_PERIOD: Duration = Duration::from_millis(150);\n-\n pub(crate) trait SpawnLifecycle...",
+      "path": "codex-rs/core/src/unified_exec/process.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 23,
+      "deletions": 17,
+      "patch_excerpt": "@@ -72,6 +72,7 @@ const UNIFIED_EXEC_ENV: [(&str, &str); 10] = [\n const NETWORK_ACCESS_DENIED_MESSAGE: &str =\n     \"Network access was denied by the Codex sandbox network proxy.\";\n const LATE_NETWORK_DENIAL_GRACE_PERIOD: Duration = Duration::from_millis(100);\n+const INTERRUPT: &str = \"\\u{3}\";\n \n /// Test-only override for deterministic unified exec process IDs.\n ///\n@@ -617,24 +618,29 @@ impl UnifiedExecProcessManager {\n \n         if !request.input.is_empty() {\n             if !tty {\n-                return Err(UnifiedExecError::StdinClosed);\n-            }\n-            match process.write(request.input.as_bytes()).await {\n-                Ok(()) => {\n-                    // Give the remote process a brief window to react so that we are\n-                    // more likely to capture its output in the poll below.\n-                    tokio::time::sleep(Duration::from_millis(100)).await;\n+...",
+      "path": "codex-rs/core/src/unified_exec/process_manager.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 5,
+      "deletions": 0,
+      "patch_excerpt": "@@ -5,6 +5,7 @@ use codex_exec_server::ExecProcess;\n use codex_exec_server::ExecProcessEventReceiver;\n use codex_exec_server::ExecServerError;\n use codex_exec_server::ProcessId;\n+use codex_exec_server::ProcessSignal;\n use codex_exec_server::ReadResponse;\n use codex_exec_server::StartedExecProcess;\n use codex_exec_server::WriteResponse;\n@@ -63,6 +64,10 @@ impl ExecProcess for MockExecProcess {\n         Ok(self.write_response.clone())\n     }\n \n+    async fn signal(&self, _signal: ProcessSignal) -> Result<(), ExecServerError> {\n+        Ok(())\n+    }\n+\n     async fn terminate(&self) -> Result<(), ExecServerError> {\n         Ok(())\n     }",
+      "path": "codex-rs/core/src/unified_exec/process_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 243,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1995,6 +1995,249 @@ async fn write_stdin_returns_exit_metadata_and_clears_session() -> Result<()> {\n     Ok(())\n }\n \n+#[tokio::test(flavor = \"multi_thread\", worker_threads = 2)]\n+async fn write_stdin_ctrl_c_interrupts_non_tty_session() -> Result<()> {\n+    assert_write_stdin_ctrl_c_interrupts_non_tty_session(\n+        \"trap\",\n+        \"trap 'echo INT-TRAP; exit 42' INT; echo READY; while true; do sleep 30; done\",\n+        /*expected_exit_code*/ 42,\n+        Some(\"INT-TRAP\"),\n+    )\n+    .await\n+}\n+\n+#[tokio::test(flavor = \"multi_thread\", worker_threads = 2)]\n+async fn write_stdin_ctrl_c_default_interrupt_reports_130_for_non_tty_session() -> Result<()> {\n+    assert_write_stdin_ctrl_c_interrupts_non_tty_session(\n+        \"default\",\n+        \"echo READY; exec sleep 30\",\n+        /*expected_exit_code*/ 130,\n+        /*expected_interrupt_output*/ None,\n+    )\n+    .await\n+}\n+\n+async fn a...",
+      "path": "codex-rs/core/tests/suite/unified_exec.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 25,
+      "deletions": 0,
+      "patch_excerpt": "@@ -35,6 +35,7 @@ use crate::protocol::EXEC_EXITED_METHOD;\n use crate::protocol::EXEC_METHOD;\n use crate::protocol::EXEC_OUTPUT_DELTA_METHOD;\n use crate::protocol::EXEC_READ_METHOD;\n+use crate::protocol::EXEC_SIGNAL_METHOD;\n use crate::protocol::EXEC_TERMINATE_METHOD;\n use crate::protocol::EXEC_WRITE_METHOD;\n use crate::protocol::EnvironmentInfo;\n@@ -80,8 +81,11 @@ use crate::protocol::INITIALIZED_METHOD;\n use crate::protocol::InitializeParams;\n use crate::protocol::InitializeResponse;\n use crate::protocol::ProcessOutputChunk;\n+use crate::protocol::ProcessSignal;\n use crate::protocol::ReadParams;\n use crate::protocol::ReadResponse;\n+use crate::protocol::SignalParams;\n+use crate::protocol::SignalResponse;\n use crate::protocol::TerminateParams;\n use crate::protocol::TerminateResponse;\n use crate::protocol::WriteParams;\n@@ -394,6 +398,23 @@ impl ExecServerClient {\n         .await\n     }\n \n+...",
+      "path": "codex-rs/exec-server/src/client.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 0,
+      "patch_excerpt": "@@ -93,9 +93,12 @@ pub use protocol::HttpRequestResponse;\n pub use protocol::InitializeParams;\n pub use protocol::InitializeResponse;\n pub use protocol::ProcessOutputChunk;\n+pub use protocol::ProcessSignal;\n pub use protocol::ReadParams;\n pub use protocol::ReadResponse;\n pub use protocol::ShellInfo;\n+pub use protocol::SignalParams;\n+pub use protocol::SignalResponse;\n pub use protocol::TerminateParams;\n pub use protocol::TerminateResponse;\n pub use protocol::WriteParams;",
+      "path": "codex-rs/exec-server/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 51,
+      "deletions": 3,
+      "patch_excerpt": "@@ -10,6 +10,7 @@ use codex_protocol::config_types::EnvironmentVariablePattern;\n use codex_protocol::config_types::ShellEnvironmentPolicy;\n use codex_protocol::shell_environment;\n use codex_utils_pty::ExecCommandSession;\n+use codex_utils_pty::ProcessSignal as PtyProcessSignal;\n use codex_utils_pty::TerminalSize;\n use tokio::sync::Mutex;\n use tokio::sync::Notify;\n@@ -33,8 +34,11 @@ use crate::protocol::ExecOutputStream;\n use crate::protocol::ExecParams;\n use crate::protocol::ExecResponse;\n use crate::protocol::ProcessOutputChunk;\n+use crate::protocol::ProcessSignal;\n use crate::protocol::ReadParams;\n use crate::protocol::ReadResponse;\n+use crate::protocol::SignalParams;\n+use crate::protocol::SignalResponse;\n use crate::protocol::TerminateParams;\n use crate::protocol::TerminateResponse;\n use crate::protocol::WriteParams;\n@@ -272,7 +276,6 @@ impl LocalProcess {\n         &self,\n         para...",
+      "path": "codex-rs/exec-server/src/local_process.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 0,
+      "patch_excerpt": "@@ -10,6 +10,7 @@ use crate::ExecServerError;\n use crate::ProcessId;\n use crate::protocol::ExecParams;\n use crate::protocol::ProcessOutputChunk;\n+use crate::protocol::ProcessSignal;\n use crate::protocol::ReadResponse;\n use crate::protocol::WriteResponse;\n \n@@ -178,6 +179,8 @@ pub trait ExecProcess: Send + Sync {\n \n     async fn write(&self, chunk: Vec<u8>) -> Result<WriteResponse, ExecServerError>;\n \n+    async fn signal(&self, signal: ProcessSignal) -> Result<(), ExecServerError>;\n+\n     async fn terminate(&self) -> Result<(), ExecServerError>;\n }",
+      "path": "codex-rs/exec-server/src/process.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 18,
+      "deletions": 0,
+      "patch_excerpt": "@@ -15,6 +15,7 @@ pub const INITIALIZED_METHOD: &str = \"initialized\";\n pub const EXEC_METHOD: &str = \"process/start\";\n pub const EXEC_READ_METHOD: &str = \"process/read\";\n pub const EXEC_WRITE_METHOD: &str = \"process/write\";\n+pub const EXEC_SIGNAL_METHOD: &str = \"process/signal\";\n pub const EXEC_TERMINATE_METHOD: &str = \"process/terminate\";\n pub const EXEC_OUTPUT_DELTA_METHOD: &str = \"process/output\";\n pub const EXEC_EXITED_METHOD: &str = \"process/exited\";\n@@ -166,6 +167,23 @@ pub struct WriteResponse {\n     pub status: WriteStatus,\n }\n \n+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]\n+#[serde(rename_all = \"camelCase\")]\n+pub enum ProcessSignal {\n+    Interrupt,\n+}\n+\n+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]\n+#[serde(rename_all = \"camelCase\")]\n+pub struct SignalParams {\n+    pub process_id: ProcessId,\n+    pub signal: ProcessSignal,\n+}\n+\n+#[deriv...",
+      "path": "codex-rs/exec-server/src/protocol.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 6,
+      "deletions": 0,
+      "patch_excerpt": "@@ -12,6 +12,7 @@ use crate::StartedExecProcess;\n use crate::client::LazyRemoteExecServerClient;\n use crate::client::Session;\n use crate::protocol::ExecParams;\n+use crate::protocol::ProcessSignal;\n use crate::protocol::ReadResponse;\n use crate::protocol::WriteResponse;\n \n@@ -76,6 +77,11 @@ impl ExecProcess for RemoteExecProcess {\n         self.session.write(chunk).await\n     }\n \n+    async fn signal(&self, signal: ProcessSignal) -> Result<(), ExecServerError> {\n+        trace!(\"exec process signal\");\n+        self.session.signal(signal).await\n+    }\n+\n     async fn terminate(&self) -> Result<(), ExecServerError> {\n         trace!(\"exec process terminate\");\n         self.session.terminate().await",
+      "path": "codex-rs/exec-server/src/remote_process.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 10,
+      "deletions": 0,
+      "patch_excerpt": "@@ -42,6 +42,8 @@ use crate::protocol::InitializeParams;\n use crate::protocol::InitializeResponse;\n use crate::protocol::ReadParams;\n use crate::protocol::ReadResponse;\n+use crate::protocol::SignalParams;\n+use crate::protocol::SignalResponse;\n use crate::protocol::TerminateParams;\n use crate::protocol::TerminateResponse;\n use crate::protocol::WriteParams;\n@@ -171,6 +173,14 @@ impl ExecServerHandler {\n         session.process().exec_write(params).await\n     }\n \n+    pub(crate) async fn signal(\n+        &self,\n+        params: SignalParams,\n+    ) -> Result<SignalResponse, JSONRPCErrorError> {\n+        let session = self.require_initialized_for(\"exec\")?;\n+        session.process().signal(params).await\n+    }\n+\n     pub(crate) async fn terminate(\n         &self,\n         params: TerminateParams,",
+      "path": "codex-rs/exec-server/src/server/handler.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 9,
+      "deletions": 0,
+      "patch_excerpt": "@@ -5,6 +5,8 @@ use crate::protocol::ExecParams;\n use crate::protocol::ExecResponse;\n use crate::protocol::ReadParams;\n use crate::protocol::ReadResponse;\n+use crate::protocol::SignalParams;\n+use crate::protocol::SignalResponse;\n use crate::protocol::TerminateParams;\n use crate::protocol::TerminateResponse;\n use crate::protocol::WriteParams;\n@@ -49,6 +51,13 @@ impl ProcessHandler {\n         self.process.exec_write(params).await\n     }\n \n+    pub(crate) async fn signal(\n+        &self,\n+        params: SignalParams,\n+    ) -> Result<SignalResponse, JSONRPCErrorError> {\n+        self.process.signal_process(params).await\n+    }\n+\n     pub(crate) async fn terminate(\n         &self,\n         params: TerminateParams,",
+      "path": "codex-rs/exec-server/src/server/process_handler.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 8,
+      "deletions": 0,
+      "patch_excerpt": "@@ -3,6 +3,7 @@ use std::sync::Arc;\n use crate::protocol::ENVIRONMENT_INFO_METHOD;\n use crate::protocol::EXEC_METHOD;\n use crate::protocol::EXEC_READ_METHOD;\n+use crate::protocol::EXEC_SIGNAL_METHOD;\n use crate::protocol::EXEC_TERMINATE_METHOD;\n use crate::protocol::EXEC_WRITE_METHOD;\n use crate::protocol::ExecParams;\n@@ -32,6 +33,7 @@ use crate::protocol::INITIALIZE_METHOD;\n use crate::protocol::INITIALIZED_METHOD;\n use crate::protocol::InitializeParams;\n use crate::protocol::ReadParams;\n+use crate::protocol::SignalParams;\n use crate::protocol::TerminateParams;\n use crate::protocol::WriteParams;\n use crate::rpc::RpcRouter;\n@@ -77,6 +79,12 @@ pub(crate) fn build_router() -> RpcRouter<ExecServerHandler> {\n             handler.exec_write(params).await\n         },\n     );\n+    router.request(\n+        EXEC_SIGNAL_METHOD,\n+        |handler: Arc<ExecServerHandler>, params: SignalParams| async...",
+      "path": "codex-rs/exec-server/src/server/registry.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 123,
+      "deletions": 2,
+      "patch_excerpt": "@@ -1,5 +1,3 @@\n-#![cfg(unix)]\n-\n mod common;\n \n use std::sync::Arc;\n@@ -13,6 +11,7 @@ use codex_exec_server::ExecParams;\n use codex_exec_server::ExecProcess;\n use codex_exec_server::ExecProcessEvent;\n use codex_exec_server::ProcessId;\n+use codex_exec_server::ProcessSignal;\n use codex_exec_server::ReadResponse;\n use codex_exec_server::StartedExecProcess;\n use codex_exec_server::WriteStatus;\n@@ -505,6 +504,98 @@ async fn assert_exec_process_rejects_write_without_pipe_stdin(use_remote: bool)\n     Ok(())\n }\n \n+async fn assert_exec_process_signal_interrupts_process(use_remote: bool) -> Result<()> {\n+    let context = create_process_context(use_remote).await?;\n+    let process_id = \"proc-signal\".to_string();\n+    let session = context\n+        .backend\n+        .start(ExecParams {\n+            process_id: process_id.clone().into(),\n+            argv: vec![\n+                \"/bin/sh\".to_string...",
+      "path": "codex-rs/exec-server/tests/exec_process.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -17,6 +17,8 @@ pub use pipe::spawn_process_no_stdin as spawn_pipe_process_no_stdin;\n pub use process::ProcessDriver;\n /// Handle for interacting with a spawned process (PTY or pipe).\n pub use process::ProcessHandle;\n+/// Process signal supported by spawned-process handles.\n+pub use process::ProcessSignal;\n /// Bundle of process handles plus split output and exit receivers returned by spawn helpers.\n pub use process::SpawnedProcess;\n /// Terminal size in character cells used for PTY spawn and resize operations.",
+      "path": "codex-rs/utils/pty/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 19,
+      "deletions": 1,
+      "patch_excerpt": "@@ -19,7 +19,9 @@ use tokio::task::JoinHandle;\n \n use crate::process::ChildTerminator;\n use crate::process::ProcessHandle;\n+use crate::process::ProcessSignal;\n use crate::process::SpawnedProcess;\n+use crate::process::exit_code_from_status;\n \n #[cfg(target_os = \"linux\")]\n use libc;\n@@ -32,6 +34,22 @@ struct PipeChildTerminator {\n }\n \n impl ChildTerminator for PipeChildTerminator {\n+    fn signal(&mut self, signal: ProcessSignal) -> io::Result<()> {\n+        match signal {\n+            ProcessSignal::Interrupt => {\n+                #[cfg(unix)]\n+                {\n+                    crate::process_group::interrupt_process_group(self.process_group_id)\n+                }\n+\n+                #[cfg(not(unix))]\n+                {\n+                    Err(crate::process::unsupported_signal(signal))\n+                }\n+            }\n+        }\n+    }\n+\n     fn kill(&mut self) -> io::Result<()> {\n...",
+      "path": "codex-rs/utils/pty/src/pipe.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 48,
+      "deletions": 0,
+      "patch_excerpt": "@@ -2,6 +2,7 @@ use core::fmt;\n use std::io;\n #[cfg(unix)]\n use std::os::fd::RawFd;\n+use std::process::ExitStatus;\n use std::sync::Arc;\n use std::sync::Mutex as StdMutex;\n use std::sync::atomic::AtomicBool;\n@@ -17,7 +18,39 @@ use tokio::sync::watch;\n use tokio::task::AbortHandle;\n use tokio::task::JoinHandle;\n \n+#[derive(Clone, Copy, Debug, PartialEq, Eq)]\n+pub enum ProcessSignal {\n+    Interrupt,\n+}\n+\n+pub(crate) fn unsupported_signal(signal: ProcessSignal) -> io::Error {\n+    match signal {\n+        ProcessSignal::Interrupt => io::Error::new(\n+            io::ErrorKind::Unsupported,\n+            \"process interrupt is not supported by this process backend\",\n+        ),\n+    }\n+}\n+\n+pub(crate) fn exit_code_from_status(status: ExitStatus) -> i32 {\n+    if let Some(code) = status.code() {\n+        return code;\n+    }\n+\n+    #[cfg(unix)]\n+    {\n+        use std::os::unix::process::ExitStatu...",
+      "path": "codex-rs/utils/pty/src/process.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 24,
+      "deletions": 19,
+      "patch_excerpt": "@@ -118,15 +118,10 @@ pub fn kill_process_group_by_pid(_pid: u32) -> io::Result<()> {\n }\n \n #[cfg(unix)]\n-/// Send SIGTERM to a specific process group ID (best-effort).\n-///\n-/// Returns `Ok(true)` when SIGTERM was delivered to an existing group and\n-/// `Ok(false)` when the group no longer exists.\n-pub fn terminate_process_group(process_group_id: u32) -> io::Result<bool> {\n+fn signal_process_group_id(pgid: libc::pid_t, signal: libc::c_int) -> io::Result<bool> {\n     use std::io::ErrorKind;\n \n-    let pgid = process_group_id as libc::pid_t;\n-    let result = unsafe { libc::killpg(pgid, libc::SIGTERM) };\n+    let result = unsafe { libc::killpg(pgid, signal) };\n     if result == -1 {\n         let err = io::Error::last_os_error();\n         if err.kind() == ErrorKind::NotFound || err.raw_os_error() == Some(libc::ESRCH) {\n@@ -138,29 +133,39 @@ pub fn terminate_process_group(process_group_id: ...",
+      "path": "codex-rs/utils/pty/src/process_group.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 25,
+      "deletions": 1,
+      "patch_excerpt": "@@ -30,10 +30,13 @@ use tokio::task::JoinHandle;\n \n use crate::process::ChildTerminator;\n use crate::process::ProcessHandle;\n+use crate::process::ProcessSignal;\n use crate::process::PtyHandles;\n use crate::process::PtyMasterHandle;\n use crate::process::SpawnedProcess;\n use crate::process::TerminalSize;\n+#[cfg(unix)]\n+use crate::process::exit_code_from_status;\n \n /// Returns true when ConPTY support is available (Windows only).\n #[cfg(windows)]\n@@ -54,6 +57,19 @@ struct PtyChildTerminator {\n }\n \n impl ChildTerminator for PtyChildTerminator {\n+    fn signal(&mut self, signal: ProcessSignal) -> std::io::Result<()> {\n+        match signal {\n+            ProcessSignal::Interrupt => {\n+                #[cfg(unix)]\n+                if let Some(process_group_id) = self.process_group_id {\n+                    return crate::process_group::interrupt_process_group(process_group_id);\n+               ...",
+      "path": "codex-rs/utils/pty/src/pty.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#26734"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nA long-running unified exec process started with `tty: false` could not be interrupted via `write_stdin`: ordinary non-TTY stdin writes are rejected once stdin is closed, but an exact U+0003 payload should still map to a process interrupt. The interrupt should flow through the same process lifecycle path as a real signal so Codex preserves process-reported output and exit metadata instead of fabricating a Ctrl-C exit code or tearing down the session early.\n\n## What Changed\n\n- Add `process/signal` to exec-server with `ProcessSignal::Interrupt` and an empty response.\n- Add a non-consuming `ProcessHandle::signal` path for spawned processes; on Unix it sends SIGINT to the process group and leaves terminate/hard-kill unchanged.\n- Route non-TTY U+0003 `write_stdin` through `process.signal(...)` instead of `terminate`, then let the normal post-write collection path drain output and observe exit.\n- Add exec-server coverage where a shell `trap INT` handler prints the signal and exits with its own code.\n- Add unified exec coverage where a `tty: false` process traps SIGINT, emits output, and exits with its own code.\n\n## Validation\n\n- `just test -p codex-exec-server exec_process_signal_interrupts_process`\n- `just test -p codex-exec-server`\n- `just test -p codex-core write_stdin_ctrl_c_interrupts_non_tty_session`\n",
+    "labels": [],
+    "merged_at": "2026-06-09T22:10:18Z",
+    "number": 26734,
+    "state": "merged",
+    "title": "[codex] Handle Ctrl-C for non-TTY unified exec",
+    "url": "https://github.com/openai/codex/pull/26734"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27129.json
+++ b/artifacts/github/bundles/openai-codex-pr-27129.json
@@ -1,0 +1,130 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "celia-oai",
+      "committed_at": "2026-06-09T05:12:43Z",
+      "message": "Use provider defaults for memory models",
+      "sha": "00f1e544854c67163899cd0c6c3091c6d4a7694e",
+      "url": "https://github.com/openai/codex/commit/00f1e544854c67163899cd0c6c3091c6d4a7694e"
+    },
+    {
+      "author": "celia-oai",
+      "committed_at": "2026-06-09T19:32:33Z",
+      "message": "comments",
+      "sha": "38b487f2a4eb2291eab6ccea41d24455acfbe9c0",
+      "url": "https://github.com/openai/codex/commit/38b487f2a4eb2291eab6ccea41d24455acfbe9c0"
+    },
+    {
+      "author": "celia-oai",
+      "committed_at": "2026-06-09T21:52:24Z",
+      "message": "changes",
+      "sha": "b3dce407ff660c49d616be8920bc50a74ced8ac1",
+      "url": "https://github.com/openai/codex/commit/b3dce407ff660c49d616be8920bc50a74ced8ac1"
+    },
+    {
+      "author": "celia-oai",
+      "committed_at": "2026-06-09T23:19:12Z",
+      "message": "changes",
+      "sha": "717e4b299bf0815a2fd1bd77d61ed5f3fbc7ae40",
+      "url": "https://github.com/openai/codex/commit/717e4b299bf0815a2fd1bd77d61ed5f3fbc7ae40"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "MODEL",
+    "REASONING_EFFORT",
+    "CONCURRENCY_LIMIT",
+    "JOB_LEASE_SECONDS",
+    "MOCK_PROVIDER_PHASE_ONE_MODEL",
+    "MOCK_PROVIDER_PHASE_TWO_MODEL",
+    "AMAZON_BEDROCK_GPT_5_4_MODEL_ID",
+    "DEFAULT_APPROVAL_REVIEW_PREFERRED_MODEL",
+    "DEFAULT_MEMORY_EXTRACTION_PREFERRED_MODEL",
+    "DEFAULT_MEMORY_CONSOLIDATION_PREFERRED_MODEL"
+  ],
+  "files": [
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -3320,6 +3320,8 @@ dependencies = [\n  \"codex-features\",\n  \"codex-git-utils\",\n  \"codex-login\",\n+ \"codex-model-provider\",\n+ \"codex-model-provider-info\",\n  \"codex-models-manager\",\n  \"codex-otel\",\n  \"codex-protocol\",",
+      "path": "codex-rs/Cargo.lock",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -21,6 +21,7 @@ codex-config = { workspace = true }\n codex-features = { workspace = true }\n codex-git-utils = { workspace = true }\n codex-login = { workspace = true }\n+codex-model-provider = { workspace = true }\n codex-otel = { workspace = true }\n codex-protocol = { workspace = true }\n codex-rollout = { workspace = true }\n@@ -39,6 +40,7 @@ tracing = { workspace = true, features = [\"log\"] }\n uuid = { workspace = true, features = [\"v4\", \"v5\"] }\n \n [dev-dependencies]\n+codex-model-provider-info = { workspace = true }\n codex-models-manager = { workspace = true }\n core_test_support = { workspace = true }\n pretty_assertions = { workspace = true }",
+      "path": "codex-rs/memories/write/Cargo.toml",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 2,
+      "patch_excerpt": "@@ -76,7 +76,6 @@ signal to remove stale memories derived only from those resources.\n }\n \n mod stage_one {\n-    pub(super) const MODEL: &str = \"gpt-5.4-mini\";\n     pub(super) const REASONING_EFFORT: codex_protocol::openai_models::ReasoningEffort =\n         codex_protocol::openai_models::ReasoningEffort::Low;\n     pub(super) const CONCURRENCY_LIMIT: usize = 8;\n@@ -101,7 +100,6 @@ mod stage_one {\n }\n \n mod stage_two {\n-    pub(super) const MODEL: &str = \"gpt-5.4\";\n     pub(super) const REASONING_EFFORT: codex_protocol::openai_models::ReasoningEffort =\n         codex_protocol::openai_models::ReasoningEffort::Medium;\n     pub(super) const JOB_LEASE_SECONDS: i64 = 3_600;",
+      "path": "codex-rs/memories/write/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 6,
+      "deletions": 5,
+      "patch_excerpt": "@@ -190,11 +190,12 @@ async fn build_request_context(\n     context: &MemoryStartupContext,\n     config: &Config,\n ) -> StageOneRequestContext {\n-    let model_name = config\n-        .memories\n-        .extract_model\n-        .clone()\n-        .unwrap_or(crate::stage_one::MODEL.to_string());\n+    let model_name = config.memories.extract_model.clone().unwrap_or_else(|| {\n+        context\n+            .provider()\n+            .memory_extraction_preferred_model()\n+            .to_string()\n+    });\n     context\n         .stage_one_request_context(config, &model_name, crate::stage_one::REASONING_EFFORT)\n         .await",
+      "path": "codex-rs/memories/write/src/phase1.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 4,
+      "deletions": 3,
+      "patch_excerpt": "@@ -16,6 +16,7 @@ use crate::workspace::write_workspace_diff;\n use codex_config::Constrained;\n use codex_core::config::Config;\n use codex_features::Feature;\n+use codex_model_provider::ModelProvider;\n use codex_protocol::ThreadId;\n use codex_protocol::protocol::AgentStatus;\n use codex_protocol::protocol::AskForApproval;\n@@ -76,7 +77,7 @@ pub async fn run(context: Arc<MemoryStartupContext>, config: Arc<Config>) {\n     }\n \n     // 3. Build the locked-down config used by the consolidation agent.\n-    let Some(agent_config) = agent::get_config(config.as_ref()) else {\n+    let Some(agent_config) = agent::get_config(config.as_ref(), context.provider()) else {\n         // If we can't get the config, we can't consolidate.\n         tracing::error!(\"failed to get agent config\");\n         job::failed(\n@@ -297,7 +298,7 @@ mod agent {\n     use super::*;\n     use tracing::warn;\n \n-    pub(super) fn get...",
+      "path": "codex-rs/memories/write/src/phase2.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 54,
+      "deletions": 0,
+      "patch_excerpt": "@@ -13,6 +13,9 @@ use codex_login::AuthManager;\n use codex_login::CodexAuth;\n use codex_login::auth_env_telemetry::collect_auth_env_telemetry;\n use codex_login::default_client::originator;\n+use codex_model_provider::ModelProvider;\n+use codex_model_provider::SharedModelProvider;\n+use codex_model_provider::create_model_provider;\n use codex_otel::SessionTelemetry;\n use codex_otel::TelemetryAuthMode;\n use codex_protocol::SessionId;\n@@ -68,6 +71,7 @@ pub(crate) struct MemoryStartupContext {\n     thread: Arc<CodexThread>,\n     thread_manager: Arc<ThreadManager>,\n     auth_manager: Arc<AuthManager>,\n+    provider: SharedModelProvider,\n     session_telemetry: SessionTelemetry,\n }\n \n@@ -79,6 +83,51 @@ impl MemoryStartupContext {\n         thread: Arc<CodexThread>,\n         config: &Config,\n         source: SessionSource,\n+    ) -> Self {\n+        let provider = create_model_provider(\n+            ...",
+      "path": "codex-rs/memories/write/src/runtime.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 315,
+      "deletions": 3,
+      "patch_excerpt": "@@ -1,12 +1,30 @@\n+use crate::extensions::seed_extension_instructions;\n+use crate::memory_root;\n+use crate::phase1;\n+use crate::phase2;\n+use crate::runtime::MemoryStartupContext;\n use crate::start_memories_startup_task;\n+use codex_config::types::MemoriesConfig;\n use codex_features::Feature;\n use codex_git_utils::diff_since_latest_init;\n use codex_git_utils::reset_git_repository;\n+use codex_login::AuthManager;\n+use codex_login::CodexAuth;\n+use codex_model_provider::ModelProvider;\n+use codex_model_provider::ProviderAccountResult;\n+use codex_model_provider::SharedModelProvider;\n+use codex_model_provider::create_model_provider;\n+use codex_model_provider_info::ModelProviderInfo;\n use codex_protocol::ThreadId;\n use codex_protocol::config_types::ServiceTier;\n+use codex_protocol::models::ContentItem;\n+use codex_protocol::models::ResponseItem;\n+use codex_protocol::openai_models::ModelsResponse;\n ...",
+      "path": "codex-rs/memories/write/src/startup_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 8,
+      "deletions": 0,
+      "patch_excerpt": "@@ -68,6 +68,14 @@ impl ModelProvider for AmazonBedrockModelProvider {\n         AMAZON_BEDROCK_GPT_5_4_MODEL_ID\n     }\n \n+    fn memory_extraction_preferred_model(&self) -> &'static str {\n+        AMAZON_BEDROCK_GPT_5_4_MODEL_ID\n+    }\n+\n+    fn memory_consolidation_preferred_model(&self) -> &'static str {\n+        AMAZON_BEDROCK_GPT_5_4_MODEL_ID\n+    }\n+\n     fn auth_manager(&self) -> Option<Arc<AuthManager>> {\n         None\n     }",
+      "path": "codex-rs/model-provider/src/amazon_bedrock/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 22,
+      "deletions": 0,
+      "patch_excerpt": "@@ -74,6 +74,14 @@ pub type ProviderAccountResult = std::result::Result<ProviderAccountState, Provi\n /// require a backend-specific model ID.\n pub const DEFAULT_APPROVAL_REVIEW_PREFERRED_MODEL: &str = \"codex-auto-review\";\n \n+/// Default model used for memory extraction when a provider does not require a\n+/// backend-specific model ID.\n+pub const DEFAULT_MEMORY_EXTRACTION_PREFERRED_MODEL: &str = \"gpt-5.4-mini\";\n+\n+/// Default model used for memory consolidation when a provider does not require\n+/// a backend-specific model ID.\n+pub const DEFAULT_MEMORY_CONSOLIDATION_PREFERRED_MODEL: &str = \"gpt-5.4\";\n+\n /// Runtime provider abstraction used by model execution.\n ///\n /// Implementations own provider-specific behavior for a model backend. The\n@@ -96,6 +104,20 @@ pub trait ModelProvider: fmt::Debug + Send + Sync {\n         DEFAULT_APPROVAL_REVIEW_PREFERRED_MODEL\n     }\n \n+    /// Returns the...",
+      "path": "codex-rs/model-provider/src/provider.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#26288"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\r\n\r\nMemory startup used hardcoded OpenAI model slugs for extraction and consolidation. That works for the default OpenAI-compatible path, but provider-specific backends can require different model identifiers. In particular, Amazon Bedrock should use its Bedrock model ID for these background memory requests instead of the OpenAI `gpt-5.4-mini` / `gpt-5.4` slugs.\r\n\r\n## What Changed\r\n\r\n- Added provider-owned preferred memory model methods alongside `approval_review_preferred_model`.\r\n- Updated memory extraction and consolidation to resolve their default model through the active `ModelProvider`.\r\n- Added Amazon Bedrock overrides so both memory stages use `openai.gpt-5.4` through Bedrock’s provider-specific model ID.\r\n- Kept explicit `memories.extract_model` and `memories.consolidation_model` config overrides taking precedence.\r\n- Added startup coverage for default OpenAI and Bedrock memory model selection.\r\n\r\n#closes #26288\r\n\r\n",
+    "labels": [],
+    "merged_at": "2026-06-09T23:49:09Z",
+    "number": 27129,
+    "state": "merged",
+    "title": "feat: use provider defaults for memory models",
+    "url": "https://github.com/openai/codex/pull/27129"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/impact/openai-codex-pr-25147.json
+++ b/artifacts/github/impact/openai-codex-pr-25147.json
@@ -1,0 +1,46 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-25147",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Retry streamable HTTP initialize failures",
+        "url": "https://github.com/openai/codex/pull/25147",
+        "meta": "Merged 2026-06-09T22:49:49Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/25147",
+        "meta": "artifacts/github/reviews/openai-codex-pr-25147.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex RMCP streamable HTTP startup now retries transient initialize and initialized-notification failures, recreates the transport between attempts, and retries only the read-only `tools/list` operation after initialization.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "candidate",
+  "publisher_angle": "practical_explainer",
+  "confidence": "confirmed",
+  "evidence": [
+    "The upstream review records retry orchestration for streamable HTTP initialize and initialized-notification failures.",
+    "`tools/list` is the only post-initialize MCP operation identified as retried, preserving the no-replay boundary for side-effecting tool calls.",
+    "The HTTP adapter now turns retryable streamable HTTP POST statuses into typed client errors.",
+    "Integration tests cover initialize, initialized notification, no-status request failure, and `tools/list` retry paths."
+  ],
+  "candidate_followups": [
+    "Compare Decodex MCP readiness probes with Codex's retry-only-startup boundary.",
+    "Avoid retrying mutating MCP calls unless a later upstream contract makes a specific call idempotent.",
+    "Track initialize retry and `tools/list` retry outcomes separately in operator evidence if Decodex adopts similar probes."
+  ],
+  "social_notes": [
+    "Public copy should emphasize reliability for streamable HTTP MCP startup.",
+    "Call out the safety boundary: initialize and read-only `tools/list` are retried, side-effecting tool calls are not.",
+    "Avoid claiming all MCP transport failures are automatically recoverable."
+  ],
+  "caveats": [
+    "Retries remain bounded by operation deadlines and retry classification.",
+    "The PR does not make mutating MCP tool calls replayable."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-26701.json
+++ b/artifacts/github/impact/openai-codex-pr-26701.json
@@ -1,0 +1,46 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-26701",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "TUI Plugin Sharing 1 - add remote plugin identity",
+        "url": "https://github.com/openai/codex/pull/26701",
+        "meta": "Merged 2026-06-09T23:34:39Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/26701",
+        "meta": "artifacts/github/reviews/openai-codex-pr-26701.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex TUI plugin popups now carry a `PluginLocation` that can address either a local marketplace path or a remote marketplace name, letting remote plugin detail, install, and uninstall actions use remote plugin identity while preserving local plugin flows.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "candidate",
+  "publisher_angle": "practical_explainer",
+  "confidence": "confirmed",
+  "evidence": [
+    "The upstream review records `PluginLocation::Local` and `PluginLocation::Remote` as the new TUI plugin identity branch.",
+    "Plugin install background events now pass `PluginLocation` instead of only a local marketplace path.",
+    "Plugin popup handling adds remote source, remote plugin ID, availability, detail, install, and uninstall behavior.",
+    "TUI tests cover remote rows, remote details, remote install/uninstall, and admin-disabled plugin affordances."
+  ],
+  "candidate_followups": [
+    "Represent remote plugin IDs and marketplace names distinctly from local marketplace paths in Decodex operator views.",
+    "Check install/uninstall readback for remote plugins before assuming a path-backed local plugin model.",
+    "Preserve the source caveat that this PR is identity and popup routing, not complete share-management UI."
+  ],
+  "social_notes": [
+    "Public copy should frame this as the first TUI remote-plugin identity path.",
+    "Mention that local plugin paths still work.",
+    "Avoid claiming end-to-end plugin sharing management or account policy controls."
+  ],
+  "caveats": [
+    "The PR intentionally avoids adding share-management UI.",
+    "Remote plugin policy remains constrained by server-side availability and admin-disabled states."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-26734.json
+++ b/artifacts/github/impact/openai-codex-pr-26734.json
@@ -1,0 +1,46 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-26734",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Handle Ctrl-C for non-TTY unified exec",
+        "url": "https://github.com/openai/codex/pull/26734",
+        "meta": "Merged 2026-06-09T22:10:18Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/26734",
+        "meta": "artifacts/github/reviews/openai-codex-pr-26734.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex unified exec now maps a non-TTY `write_stdin` Ctrl-C payload to a real process interrupt through a new exec-server `process/signal` method, then drains process output and exit metadata instead of rejecting stdin as closed.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "The upstream review records a new exec-server `process/signal` method and `ProcessSignal::Interrupt` payload.",
+    "Unified exec non-TTY U+0003 is routed to `process.signal(...)` instead of returning `StdinClosed`.",
+    "PTY and pipe backends now deliver SIGINT to the process group on Unix and report signal-derived exit code 130 for the default path.",
+    "Unified exec tests cover both trap-handled Ctrl-C output and default SIGINT exit metadata."
+  ],
+  "candidate_followups": [
+    "Audit Decodex background-process interrupt controls for graceful interrupt versus terminate versus hard-kill semantics.",
+    "Treat unsupported `process/signal` as a version or backend capability boundary when reading Codex app-server or exec-server state.",
+    "Expose operator evidence that distinguishes a process-observed interrupt from a fabricated cancellation result."
+  ],
+  "social_notes": [
+    "Frame this as real Ctrl-C handling for non-TTY unified exec sessions.",
+    "Mention `process/signal` only as the enabling protocol detail; avoid implying every backend supports interrupts equally.",
+    "Do not present this as a general process-management API beyond `ProcessSignal::Interrupt`."
+  ],
+  "caveats": [
+    "The source confirms Unix SIGINT behavior; non-Unix backends can report unsupported interrupts.",
+    "Consumers need a current exec-server implementation before relying on `process/signal`."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-27129.json
+++ b/artifacts/github/impact/openai-codex-pr-27129.json
@@ -1,0 +1,46 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27129",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "feat: use provider defaults for memory models",
+        "url": "https://github.com/openai/codex/pull/27129",
+        "meta": "Merged 2026-06-09T23:49:09Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27129",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27129.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex memory extraction and consolidation now resolve their default model names through the active `ModelProvider`, with Amazon Bedrock overriding both memory stages to use its provider-specific `openai.gpt-5.4` model ID while explicit memory model config still takes precedence.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "watch",
+  "publisher_angle": "practical_explainer",
+  "confidence": "confirmed",
+  "evidence": [
+    "The upstream review records provider-owned default hooks for memory extraction and consolidation model names.",
+    "Memory phase 1 now falls back to `memory_extraction_preferred_model()` when `memories.extract_model` is unset.",
+    "Memory phase 2 passes the active provider into consolidation agent config selection.",
+    "Amazon Bedrock overrides both memory defaults to use its provider-specific `openai.gpt-5.4` model ID while explicit config overrides remain authoritative."
+  ],
+  "candidate_followups": [
+    "Use provider-owned default hooks for Decodex background tasks that choose model names outside direct user prompts.",
+    "Track Bedrock and other provider-specific model IDs separately from OpenAI-compatible slugs in operator explanations.",
+    "Keep explicit user config overrides higher priority than provider defaults."
+  ],
+  "social_notes": [
+    "Public copy should explain that memory startup defaults are now provider-aware.",
+    "Mention Bedrock as the concrete source-backed example.",
+    "Avoid claiming every provider has a custom memory model override."
+  ],
+  "caveats": [
+    "The PR confirms Bedrock and default OpenAI-compatible hooks only.",
+    "Explicit memory model config remains the highest-priority selection path."
+  ]
+}

--- a/artifacts/github/review-queue/openai-codex-latest.json
+++ b/artifacts/github/review-queue/openai-codex-latest.json
@@ -1,14 +1,14 @@
 {
   "counts": {
-    "critical": 19,
-    "high": 12,
-    "low": 0,
+    "critical": 18,
+    "high": 11,
+    "low": 2,
     "normal": 9,
     "published_subjects_seen": 0,
     "recent_commits_scanned": 40,
     "subjects_queued": 40
   },
-  "generated_at": "2026-06-10T14:13:34.686999Z",
+  "generated_at": "2026-06-10T20:05:18.910141Z",
   "repo": "openai/codex",
   "schema": "upstream_review_queue/v1",
   "source": {
@@ -17,464 +17,6 @@
     "signals_dir": "site/src/content/signals"
   },
   "subjects": [
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 7,
-      "commit_shas": [
-        "2ff3136992b56306ac00b4f9e894102acaa5237f"
-      ],
-      "committed_at": "2026-06-09T08:23:16Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27098,
-      "pr_url": "https://github.com/openai/codex/pull/27098",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server/src/request_processors/plugins.rs",
-        "codex-rs/app-server/tests/suite/v2/plugin_list.rs",
-        "codex-rs/core-plugins/src/discoverable.rs",
-        "codex-rs/core-plugins/src/manager.rs",
-        "codex-rs/core-plugins/src/manager_tests.rs",
-        "codex-rs/core-plugins/src/remote.rs",
-        "codex-rs/core/src/plugins/discoverable_tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27098",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "[codex] Return workspace directory installed plugins",
-      "url": "https://github.com/openai/codex/pull/27098"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 57,
-      "commit_shas": [
-        "6bba7d7f0403b1190af5f6def0d08da41946c516",
-        "f5696a6365d98f2e083a5ca7681c49be08acfd7b",
-        "3b2e64054eb41fe13c3e71e4b914db352212746c",
-        "ba4061d420e62206e42e94d09bba3d05f6063ae6",
-        "87f4b5f9cad0d5941821cc5dfbbf81f0d75e76e1"
-      ],
-      "committed_at": "2026-06-09T10:14:48Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27007,
-      "pr_url": "https://github.com/openai/codex/pull/27007",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/analytics/src/analytics_client_tests.rs",
-        "codex-rs/analytics/src/reducer.rs",
-        "codex-rs/app-server-protocol/schema/json/ServerNotification.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ItemCompletedNotification.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ItemStartedNotification.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ReviewStartResponse.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json"
-      ],
-      "source_state": "merged",
-      "subject_id": "27007",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "docs_examples",
-        "mcp_plugins",
-        "sandbox_permissions",
-        "tests_ci"
-      ],
-      "title": "multi-agent: add path-based v2 activity tracking",
-      "url": "https://github.com/openai/codex/pull/27007"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "protocol_change"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "634643a5e480b62d16468d27ad0b91295b0b74b2",
-        "339810a9339783c34d7b65b293f08f657ba3c93d"
-      ],
-      "committed_at": "2026-06-09T11:27:53Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27166,
-      "pr_url": "https://github.com/openai/codex/pull/27166",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, protocol_change.",
-      "sample_paths": [
-        "codex-rs/app-server/src/bespoke_event_handling.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27166",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol"
-      ],
-      "title": "app-server: clear stale thread watches after v2 agent interruption",
-      "url": "https://github.com/openai/codex/pull/27166"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 7,
-      "commit_shas": [
-        "900347bbffae41f08467ae2ff7552ea3564847fe",
-        "80f3514fe4fa2d0c811797571ac8e813ed28c10d",
-        "95d77fadad869b547af91f67bebdfc40d9927675",
-        "7f8f4e5d1a414d102075fa0fe87acdfff7f12f46",
-        "375aab3440badf14d4f94ce5bb672fa800fea228",
-        "061e1ad76c24a244534a5f27f70ae713b7d610b2",
-        "bbdb159af09fb5fbf4c672c7e9679a41725f6e7c"
-      ],
-      "committed_at": "2026-06-09T16:41:58Z",
-      "next_step": "ai_review_required",
-      "pr_number": 22879,
-      "pr_url": "https://github.com/openai/codex/pull/22879",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/tui/src/app.rs",
-        "codex-rs/tui/src/app/tests.rs",
-        "codex-rs/tui/src/app/thread_routing.rs",
-        "codex-rs/tui/src/app_server_session.rs",
-        "codex-rs/tui/src/chatwidget/interaction.rs",
-        "codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__review_submission_warning_snapshot.snap",
-        "codex-rs/tui/src/chatwidget/tests/review_mode.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "22879",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "tests_ci"
-      ],
-      "title": "fix: Prevent /review crash when entering Esc on steer message",
-      "url": "https://github.com/openai/codex/pull/22879"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 46,
-      "commit_shas": [
-        "5d7823925c88f09568bafda637fccd92b56a9b6a",
-        "0f384f1b4d7e7542f1202fc966b8c6475fa27d0f",
-        "f0df7cb06b999489e989767092ecc767fa7c30cc",
-        "fec64281b4558807c592629485958b02f0869d55",
-        "f607c8696bc512aefbcf3fc038d6c53d77d4663c",
-        "2400fd9198b798764a5090410c8761a69fd61734",
-        "ed85bf407760a9dcc0ebb6971dc0505c1d4f3a1a"
-      ],
-      "committed_at": "2026-06-09T17:51:54Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27184,
-      "pr_url": "https://github.com/openai/codex/pull/27184",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/Cargo.lock",
-        "codex-rs/Cargo.toml",
-        "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json",
-        "codex-rs/app-server-protocol/schema/typescript/v2/CapabilityRootLocation.ts",
-        "codex-rs/app-server-protocol/schema/typescript/v2/SelectedCapabilityRoot.ts",
-        "codex-rs/app-server-protocol/schema/typescript/v2/index.ts",
-        "codex-rs/app-server-protocol/src/protocol/v2/thread.rs",
-        "codex-rs/app-server/Cargo.toml",
-        "codex-rs/app-server/README.md"
-      ],
-      "source_state": "merged",
-      "subject_id": "27184",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "auth_accounts",
-        "cli_tui",
-        "config_hooks",
-        "docs_examples",
-        "mcp_plugins",
-        "model_provider",
-        "tests_ci"
-      ],
-      "title": "Load selected executor skills through extensions",
-      "url": "https://github.com/openai/codex/pull/27184"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 5,
-      "commit_shas": [
-        "4f1183c281d837c81ee3f13f4b9207fc4bbd7115",
-        "4678bad085f9dac6876e0466c5f922635926d7db",
-        "583f8cca1bd6d6a4ea2762ad6ec1e39d646a8d51",
-        "3a804efa84757c84da11729a04e04995d5c04c8c"
-      ],
-      "committed_at": "2026-06-09T18:30:24Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26835,
-      "pr_url": "https://github.com/openai/codex/pull/26835",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/Cargo.lock",
-        "codex-rs/ext/extension-api/Cargo.toml",
-        "codex-rs/ext/extension-api/tests/capabilities.rs",
-        "codex-rs/ext/extension-api/tests/registry.rs",
-        "codex-rs/ext/extension-api/tests/state.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26835",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "config_hooks",
-        "tests_ci"
-      ],
-      "title": "[codex] Test extension API contracts",
-      "url": "https://github.com/openai/codex/pull/26835"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 32,
-      "commit_shas": [
-        "a3c15ecaa97c2ce5624f1a3590ad500c3a5a0052",
-        "41ac94de1c00074094e20bcf17b44027e5be2154"
-      ],
-      "committed_at": "2026-06-09T19:27:10Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27063,
-      "pr_url": "https://github.com/openai/codex/pull/27063",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/analytics/src/analytics_client_tests.rs",
-        "codex-rs/analytics/src/reducer.rs",
-        "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
-        "codex-rs/app-server-protocol/schema/json/ServerNotification.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadForkParams.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json"
-      ],
-      "source_state": "merged",
-      "subject_id": "27063",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "docs_examples",
-        "model_provider",
-        "tests_ci"
-      ],
-      "title": "[codex-analytics] add extensible feature thread sources",
-      "url": "https://github.com/openai/codex/pull/27063"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 2,
-      "commit_shas": [
-        "e1ac564bb27512e94753613903c48977af502139",
-        "3ba65c149377ae8d5e15a0090ba36f80c6fdd1b6",
-        "bfa7824e0e6a74de4d1a8141744bef165622dd9a"
-      ],
-      "committed_at": "2026-06-09T19:48:04Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26479,
-      "pr_url": "https://github.com/openai/codex/pull/26479",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/.config/nextest.toml",
-        "justfile"
-      ],
-      "source_state": "merged",
-      "subject_id": "26479",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "config_hooks",
-        "tests_ci"
-      ],
-      "title": "[codex] Speed up local nextest runs",
-      "url": "https://github.com/openai/codex/pull/26479"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 7,
-      "commit_shas": [
-        "766c4d531e27de9b8ec273e21f5062682fe032d5",
-        "08811b5e35e7d71eba040fde91d99a613bd3ba5a"
-      ],
-      "committed_at": "2026-06-09T20:26:00Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26711,
-      "pr_url": "https://github.com/openai/codex/pull/26711",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server-client/src/lib.rs",
-        "codex-rs/tui/prompt_for_init_command.md",
-        "codex-rs/tui/src/chatwidget.rs",
-        "codex-rs/tui/src/chatwidget/interaction.rs",
-        "codex-rs/tui/src/chatwidget/slash_dispatch.rs",
-        "codex-rs/tui/src/chatwidget/tests/slash_commands.rs",
-        "codex-rs/tui/src/status/helpers.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26711",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "tests_ci"
-      ],
-      "title": "Reduce TUI legacy core dependencies",
-      "url": "https://github.com/openai/codex/pull/26711"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging"
-      ],
-      "changed_file_count": 6,
-      "commit_shas": [
-        "a9941f5173d16907a710e49e2b083650ad78b3e3",
-        "e2477c12533a1f2f8865744a6341e8a939c9adc1"
-      ],
-      "committed_at": "2026-06-09T20:35:29Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27110,
-      "pr_url": "https://github.com/openai/codex/pull/27110",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging.",
-      "sample_paths": [
-        "sdk/python/src/openai_codex/_goal.py",
-        "sdk/python/src/openai_codex/_message_router.py",
-        "sdk/python/src/openai_codex/async_client.py",
-        "sdk/python/src/openai_codex/client.py",
-        "sdk/python/src/openai_codex/models.py",
-        "sdk/python/tests/test_client_rpc_methods.py"
-      ],
-      "source_state": "merged",
-      "subject_id": "27110",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "model_provider",
-        "tests_ci"
-      ],
-      "title": "[1/6] Add Python goal routing foundation",
-      "url": "https://github.com/openai/codex/pull/27110"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 28,
-      "commit_shas": [
-        "04552f5663aa09b2363f8245b8d814d8bdfdc557",
-        "20b507e3783731f6ecda1ea1ed8197e286891158",
-        "648f66285f4ce14fd12e11c53386f19476b0d44b"
-      ],
-      "committed_at": "2026-06-09T20:44:16Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27191,
-      "pr_url": "https://github.com/openai/codex/pull/27191",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/Cargo.lock",
-        "codex-rs/Cargo.toml",
-        "codex-rs/app-server/Cargo.toml",
-        "codex-rs/app-server/src/extensions.rs",
-        "codex-rs/app-server/src/mcp_refresh.rs",
-        "codex-rs/app-server/src/request_processors.rs",
-        "codex-rs/app-server/src/request_processors/apps_processor.rs",
-        "codex-rs/app-server/src/request_processors/mcp_processor.rs",
-        "codex-rs/app-server/src/request_processors/plugins.rs",
-        "codex-rs/chatgpt/src/connectors.rs",
-        "codex-rs/codex-mcp/src/lib.rs",
-        "codex-rs/codex-mcp/src/mcp/mod.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27191",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "config_hooks",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "Route hosted Apps MCP through extensions",
-      "url": "https://github.com/openai/codex/pull/27191"
-    },
     {
       "attention_flags": [
         "auth_account",
@@ -854,164 +396,470 @@
     {
       "attention_flags": [
         "auth_account",
+        "deprecated_removed",
         "new_feature",
-        "protocol_change"
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
       ],
-      "changed_file_count": 3,
+      "changed_file_count": 20,
       "commit_shas": [
-        "df5b449689130d0e0dbd65ab882aa784a9c02028"
+        "935cbc2e7b35c10516254001991b9a0bf7c2f069",
+        "cc60f5411157f765bb97ece8f79ef25d3795101f",
+        "6adf517d65bfdf08aaac21e35e5dfa7f6ce08b19"
       ],
-      "committed_at": "2026-06-09T04:39:35Z",
+      "committed_at": "2026-06-10T15:33:21Z",
       "next_step": "ai_review_required",
-      "pr_number": 27085,
-      "pr_url": "https://github.com/openai/codex/pull/27085",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
+      "pr_number": 27259,
+      "pr_url": "https://github.com/openai/codex/pull/27259",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
       "sample_paths": [
-        "codex-rs/app-server/src/request_processors/plugins.rs",
-        "codex-rs/app-server/tests/suite/v2/plugin_install.rs",
-        "codex-rs/core-plugins/src/remote.rs"
+        "codex-rs/codex-mcp/src/connection_manager.rs",
+        "codex-rs/codex-mcp/src/connection_manager_tests.rs",
+        "codex-rs/core/src/codex_delegate_tests.rs",
+        "codex-rs/core/src/connectors.rs",
+        "codex-rs/core/src/mcp_tool_call.rs",
+        "codex-rs/core/src/mcp_tool_call_tests.rs",
+        "codex-rs/core/src/session/handlers.rs",
+        "codex-rs/core/src/session/mcp.rs",
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/session/session.rs",
+        "codex-rs/core/src/session/tests.rs",
+        "codex-rs/core/src/session/turn.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27085",
+      "subject_id": "27259",
       "subject_kind": "pr",
       "surface_hints": [
-        "app_server_protocol",
+        "cli_tui",
         "mcp_plugins",
         "release_packaging",
         "tests_ci"
       ],
-      "title": "Use server app auth requirements for remote plugin install",
-      "url": "https://github.com/openai/codex/pull/27085"
+      "title": "Use latest-wins MCP manager replacement",
+      "url": "https://github.com/openai/codex/pull/27259"
     },
     {
       "attention_flags": [
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 3,
-      "commit_shas": [
-        "6f3624d244baecbe138a41dc6d7d744daac7ed07",
-        "09439a8433bf575a5e1d4741602378db27bd1357"
-      ],
-      "committed_at": "2026-06-09T16:16:27Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27031,
-      "pr_url": "https://github.com/openai/codex/pull/27031",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/app-server/src/request_processors/thread_processor.rs",
-        "codex-rs/app-server/tests/suite/v2/remote_thread_store.rs",
-        "codex-rs/thread-store/src/in_memory.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27031",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "tests_ci"
-      ],
-      "title": "Avoid rereading rollout history during cold resume",
-      "url": "https://github.com/openai/codex/pull/27031"
-    },
-    {
-      "attention_flags": [
+        "deprecated_removed",
         "new_feature",
         "protocol_change",
-        "release_packaging"
+        "release_packaging",
+        "security_policy"
       ],
-      "changed_file_count": 2,
+      "changed_file_count": 56,
       "commit_shas": [
-        "1b7ca3095c65076bf1b8face4b554b1997f6e984"
+        "fffd0036afdb23efb940be1527158f985bda5d6e"
       ],
-      "committed_at": "2026-06-09T17:40:40Z",
+      "committed_at": "2026-06-10T17:26:53Z",
       "next_step": "ai_review_required",
-      "pr_number": 27173,
-      "pr_url": "https://github.com/openai/codex/pull/27173",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for new_feature, protocol_change, release_packaging.",
+      "pr_number": 27304,
+      "pr_url": "https://github.com/openai/codex/pull/27304",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
       "sample_paths": [
-        "codex-rs/app-server/src/request_processors/turn_processor.rs",
-        "codex-rs/app-server/tests/suite/v2/turn_start.rs"
+        "codex-rs/Cargo.lock",
+        "codex-rs/core/src/tools/code_mode/execute_handler.rs",
+        "codex-rs/core/src/tools/code_mode/wait_handler.rs",
+        "codex-rs/core/src/tools/handlers/agent_jobs/report_agent_job_result.rs",
+        "codex-rs/core/src/tools/handlers/agent_jobs/spawn_agents_on_csv.rs",
+        "codex-rs/core/src/tools/handlers/apply_patch.rs",
+        "codex-rs/core/src/tools/handlers/dynamic.rs",
+        "codex-rs/core/src/tools/handlers/extension_tools.rs",
+        "codex-rs/core/src/tools/handlers/list_available_plugins_to_install.rs",
+        "codex-rs/core/src/tools/handlers/mcp.rs",
+        "codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resource_templates.rs",
+        "codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resources.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27173",
+      "subject_id": "27304",
       "subject_kind": "pr",
       "surface_hints": [
-        "app_server_protocol",
+        "config_hooks",
+        "mcp_plugins",
+        "release_packaging",
+        "sandbox_permissions",
         "tests_ci"
       ],
-      "title": "app-server: reject direct input to multi-agent v2 sub-agents",
-      "url": "https://github.com/openai/codex/pull/27173"
+      "title": "[codex] Remove async_trait from ToolExecutor",
+      "url": "https://github.com/openai/codex/pull/27304"
     },
     {
       "attention_flags": [
         "auth_account",
+        "breaking_change",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 16,
+      "commit_shas": [
+        "e4cb80ffaed2e6ad90a42e0993eabd0d00ddcad3",
+        "3a5856f7ed4241b1d78aa834b47cea80b6607770",
+        "353ed1b6bb945a60e859384cf279976e9b280ecf",
+        "0d37f064d817b8f0f3aa63d8b4fc27901f6c0b5b",
+        "b90d036c9c45fad1a7abf3474d0aa600e787f116",
+        "4d1537dba9be19227807e924bb8f551ba2385200",
+        "e0f9c328df1ff2d337d3baeb029884b04fe69b35",
+        "64dc0d2bc88f179dd3d71de57586d2a77bb86ab8",
+        "cce9ca7334ae9bbb5b1086dbcfc136264226b27f",
+        "33a8e24459749ee78aeed292adebc176724b1bcb",
+        "61c5d9c84bdae60c98006a819ec8d601255eb165",
+        "e78df1ea9d485e8b06fff4b4c075591d556be156",
+        "ff2201af2929455c6b826161b4f818663cfe7ebd",
+        "b59232841e28b88559ec0f7d5c7cc602fbd2363a",
+        "b949dc3b1dbe0e25448dfcc4bba207deeb43a72a",
+        "7daf14053e74673697bca70290a4ddcee2d412d9",
+        "dcd1b73bce47bd514839ff4d71a48c12280ae413",
+        "28b3f1ea589a2bc0090577c4a4d309f261318c57",
+        "cac8884c2c0540a586472f35c17dfb1cbe7a2697"
+      ],
+      "committed_at": "2026-06-10T18:18:09Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26041,
+      "pr_url": "https://github.com/openai/codex/pull/26041",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server-protocol/src/export.rs",
+        "codex-rs/app-server-protocol/src/protocol/common.rs",
+        "codex-rs/app-server-protocol/src/protocol/v2/thread.rs",
+        "codex-rs/app-server/README.md",
+        "codex-rs/app-server/src/message_processor.rs",
+        "codex-rs/app-server/src/request_processors.rs",
+        "codex-rs/app-server/src/request_processors/thread_processor.rs",
+        "codex-rs/app-server/src/request_processors/thread_processor_tests.rs",
+        "codex-rs/core/src/codex_thread.rs",
+        "codex-rs/core/src/lib.rs",
+        "codex-rs/core/src/tasks/mod.rs",
+        "codex-rs/core/src/unified_exec/mod.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26041",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "docs_examples",
+        "tests_ci"
+      ],
+      "title": "Add app-server background terminal process APIs",
+      "url": "https://github.com/openai/codex/pull/26041"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 38,
+      "commit_shas": [
+        "6a8eca9c764324003e5244ff1350763b92bfd55c",
+        "2ffeebb96a53d069ec9a4b27ac855399ac2ed5e0",
+        "e3474e6f4e8bb5806b2f4d86057b4af3e6cc89df",
+        "2292718bf4af345f4bb5b5e0f8ff8bfa287c62d8",
+        "2adf4ac97da874f89611fb3b33d8f301e04fbe75",
+        "cb6f55ebed68ab47a383eeb01d7dd8b258c051f4",
+        "b54292ea752847fafacd90568d9585f686bbe6af",
+        "4e4d0b03381e9f8ff1e95428865f28bea4d25280",
+        "e221c3526b18ee401a4b9dfaad6218dc79165c9f",
+        "cba630a49f83b92c89e893f843f0f6f434c616f1",
+        "75e10774593faffca4cb842a934cd357084fd44b",
+        "cc77f6475b243804c31a1530428f9c0e6ef2963d",
+        "d2feb3b324d4a8553f9b60d481869a3e87bcc4ac",
+        "ab817ffd6963c3d74e18e88d3bddb6f61d78ae3d",
+        "c6280684fc1329dcf081a70c19b7e3721bd7e53e",
+        "adf45c442742593ff61765a11e48c572e20a5212",
+        "e31a612db2e4f6e0b9c77c2f5605fc80757c26c5",
+        "14aa743b37972f342d7383ae48d76b410ca48f7e",
+        "879d73a0f5e96407f31875d62c430b47d8add678",
+        "126b310bbef358ecd7a2d25b9cc51e6040eafb95",
+        "2f4f9ed4921ee874dd5c20d09bdd1ba52d66c45d",
+        "71471d9e7917d7815414da4bc49f39441a984267"
+      ],
+      "committed_at": "2026-06-10T18:22:12Z",
+      "next_step": "ai_review_required",
+      "pr_number": 25018,
+      "pr_url": "https://github.com/openai/codex/pull/25018",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
+        "codex-rs/app-server-protocol/schema/json/ServerNotification.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ThreadDeleteParams.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ThreadDeleteResponse.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ThreadDeletedNotification.json",
+        "codex-rs/app-server-protocol/schema/typescript/ClientRequest.ts",
+        "codex-rs/app-server-protocol/schema/typescript/ServerNotification.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ThreadDeleteParams.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ThreadDeleteResponse.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ThreadDeletedNotification.ts"
+      ],
+      "source_state": "merged",
+      "subject_id": "25018",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "docs_examples",
+        "tests_ci"
+      ],
+      "title": "Add app-server `thread/delete` API",
+      "url": "https://github.com/openai/codex/pull/25018"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 13,
+      "commit_shas": [
+        "57659383ec35538c75d4f35ea8348edd740a0435",
+        "bf636e08e83562fce57cdfd0ca64e0ebafec106f",
+        "186490d934d112d51c400dd54b7f5c887023cd0d",
+        "bc9a3b9cbc07d1ac22fad1f499c51568301884cd"
+      ],
+      "committed_at": "2026-06-10T18:24:29Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26859,
+      "pr_url": "https://github.com/openai/codex/pull/26859",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/app-server/src/lib.rs",
+        "codex-rs/cli/src/doctor.rs",
+        "codex-rs/cli/src/main.rs",
+        "codex-rs/cli/src/state_db_recovery.rs",
+        "codex-rs/rollout/src/state_db.rs",
+        "codex-rs/state/src/lib.rs",
+        "codex-rs/state/src/runtime.rs",
+        "codex-rs/state/src/runtime/goals.rs",
+        "codex-rs/state/src/runtime/memories.rs",
+        "codex-rs/state/src/runtime/recovery.rs",
+        "codex-rs/state/src/runtime/recovery_tests.rs",
+        "codex-rs/tui/src/lib.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26859",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "fix: Auto-recover from corrupted sqlite databases",
+      "url": "https://github.com/openai/codex/pull/26859"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "rate_limit",
+        "security_policy"
+      ],
+      "changed_file_count": 6,
+      "commit_shas": [
+        "d0dcb2a19f0ed125bb8dbdfc61fdadc346667b59",
+        "c7e1523503f1e1f9f979e686d34fa31133cba194",
+        "52c6ed6ff8e71895aa6fe067bf99521f37265a89",
+        "ac05fffdb3bd224c28cb6819e288ae43b09ac1e5"
+      ],
+      "committed_at": "2026-06-10T18:25:04Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27064,
+      "pr_url": "https://github.com/openai/codex/pull/27064",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, rate_limit, security_policy.",
+      "sample_paths": [
+        "codex-rs/features/src/lib.rs",
+        "codex-rs/features/src/tests.rs",
+        "codex-rs/tui/src/app.rs",
+        "codex-rs/tui/src/app_server_session.rs",
+        "codex-rs/tui/src/external_agent_config_migration_startup.rs",
+        "codex-rs/tui/src/lib.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27064",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "config_hooks",
+        "tests_ci"
+      ],
+      "title": "[codex] remove blocking external agent migration flow",
+      "url": "https://github.com/openai/codex/pull/27064"
+    },
+    {
+      "attention_flags": [
+        "breaking_change",
+        "deprecated_removed",
         "new_feature",
         "protocol_change"
       ],
       "changed_file_count": 2,
       "commit_shas": [
-        "f0566d8a72018d542d5cd745825a478d4d21b401"
+        "78a9d823a89350a2ab49ee0b3ea2e3bf48685ff7"
       ],
-      "committed_at": "2026-06-09T19:52:05Z",
+      "committed_at": "2026-06-10T18:48:30Z",
       "next_step": "ai_review_required",
-      "pr_number": 27223,
-      "pr_url": "https://github.com/openai/codex/pull/27223",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
+      "pr_number": 27065,
+      "pr_url": "https://github.com/openai/codex/pull/27065",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/app-server/tests/suite/v2/plugin_uninstall.rs",
-        "codex-rs/core-plugins/src/remote.rs"
+        "codex-rs/tui/src/external_agent_config_migration.rs",
+        "codex-rs/tui/src/external_agent_config_migration/render.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27223",
+      "subject_id": "27065",
       "subject_kind": "pr",
       "surface_hints": [
-        "app_server_protocol",
+        "cli_tui",
+        "config_hooks"
+      ],
+      "title": "[codex] extract external agent import picker renderer",
+      "url": "https://github.com/openai/codex/pull/27065"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 9,
+      "commit_shas": [
+        "158fd3ea6eda3a6ee1ba95ad0de76f5cee4f0540"
+      ],
+      "committed_at": "2026-06-10T19:01:03Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26409,
+      "pr_url": "https://github.com/openai/codex/pull/26409",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for deprecated_removed, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/core-plugins/src/discoverable.rs",
+        "codex-rs/core/src/plugins/discoverable.rs",
+        "codex-rs/core/src/plugins/discoverable_tests.rs",
+        "codex-rs/core/src/tools/handlers/request_plugin_install_tests.rs",
+        "codex-rs/core/src/tools/spec_plan_tests.rs",
+        "codex-rs/tools/src/request_plugin_install.rs",
+        "codex-rs/tools/src/request_plugin_install_tests.rs",
+        "codex-rs/tools/src/tool_discovery.rs",
+        "codex-rs/tools/src/tool_discovery_tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26409",
+      "subject_kind": "pr",
+      "surface_hints": [
         "mcp_plugins",
         "release_packaging",
         "tests_ci"
       ],
-      "title": "fix: use plugin service route for remote uninstall",
-      "url": "https://github.com/openai/codex/pull/27223"
+      "title": "[plugins] Inject remote_plugin_id into install elicitations",
+      "url": "https://github.com/openai/codex/pull/26409"
     },
     {
       "attention_flags": [
+        "breaking_change",
+        "deprecated_removed",
         "new_feature",
-        "protocol_change",
-        "security_policy"
+        "protocol_change"
       ],
-      "changed_file_count": 4,
+      "changed_file_count": 10,
       "commit_shas": [
-        "7d11ccc1219ef6027533969ce67ff5ac77d3efc6",
-        "d042443be940d05b1700260baac565bfe20836b1",
-        "457430a033c5beceb085b5e6ac94841ecc7e8a07",
-        "8812af506c639905875c3c94ef5544e0787d6f4f",
-        "afd2f66864982ad90369bd7ccb084fe2a6630fe8"
+        "48d3cf0497ceb2ce5228d624d782bb11661811ba",
+        "46487bd2cd860ea7a1d3e7c7302f9031ee8f8124",
+        "72c495a73a8eb216b47fdae30a42ca16022835cc"
       ],
-      "committed_at": "2026-06-09T20:08:01Z",
+      "committed_at": "2026-06-10T19:19:37Z",
       "next_step": "ai_review_required",
-      "pr_number": 22685,
-      "pr_url": "https://github.com/openai/codex/pull/22685",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for new_feature, protocol_change, security_policy.",
+      "pr_number": 27070,
+      "pr_url": "https://github.com/openai/codex/pull/27070",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/network-proxy/README.md",
-        "codex-rs/network-proxy/src/config.rs",
-        "codex-rs/network-proxy/src/mitm.rs",
-        "codex-rs/network-proxy/src/socks5.rs"
+        "codex-rs/tui/src/external_agent_config_migration.rs",
+        "codex-rs/tui/src/external_agent_config_migration/render.rs",
+        "codex-rs/tui/src/external_agent_config_migration_model.rs",
+        "codex-rs/tui/src/lib.rs",
+        "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize.snap",
+        "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_action.snap",
+        "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_action_windows.snap",
+        "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_windows.snap",
+        "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_prompt.snap",
+        "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_prompt_windows.snap"
       ],
       "source_state": "merged",
-      "subject_id": "22685",
+      "subject_id": "27070",
       "subject_kind": "pr",
       "surface_hints": [
+        "cli_tui",
         "config_hooks",
-        "docs_examples"
+        "model_provider",
+        "tests_ci"
       ],
-      "title": "Add SOCKS5 TCP MITM coverage",
-      "url": "https://github.com/openai/codex/pull/22685"
+      "title": "[codex] add external agent import picker UX",
+      "url": "https://github.com/openai/codex/pull/27070"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "rate_limit",
+        "security_policy"
+      ],
+      "changed_file_count": 22,
+      "commit_shas": [
+        "ee228545d822de157518dec714dca4f13cbd3374",
+        "15bbbdf663d80d399cdadefd6987bf17999faab6"
+      ],
+      "committed_at": "2026-06-10T19:53:15Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27071,
+      "pr_url": "https://github.com/openai/codex/pull/27071",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, rate_limit, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server-client/src/lib.rs",
+        "codex-rs/app-server/src/in_process.rs",
+        "codex-rs/cli/src/main.rs",
+        "codex-rs/tui/src/app/app_server_events.rs",
+        "codex-rs/tui/src/app/event_dispatch.rs",
+        "codex-rs/tui/src/app_event.rs",
+        "codex-rs/tui/src/app_server_session.rs",
+        "codex-rs/tui/src/chatwidget/slash_dispatch.rs",
+        "codex-rs/tui/src/chatwidget/tests/slash_commands.rs",
+        "codex-rs/tui/src/external_agent_config_migration.rs",
+        "codex-rs/tui/src/external_agent_config_migration/render.rs",
+        "codex-rs/tui/src/external_agent_config_migration_flow.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27071",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "config_hooks",
+        "tests_ci"
+      ],
+      "title": "[codex] add /import for external agents",
+      "url": "https://github.com/openai/codex/pull/27071"
     },
     {
       "attention_flags": [
@@ -1274,218 +1122,143 @@
     {
       "attention_flags": [
         "auth_account",
-        "deprecated_removed",
         "new_feature",
-        "protocol_change",
-        "security_policy"
+        "protocol_change"
       ],
-      "changed_file_count": 5,
+      "changed_file_count": 24,
       "commit_shas": [
-        "c7fdf9c2ce7cc02ccaf21ff8c5eaac2e819be14f",
-        "884a749d4bc85a2e3dadaab442ea77427b6377a0"
+        "f99614b3e1d8f5d6253411b82ab59f42e2650e76",
+        "39d4f7c14dbc35acb220dcb57e3652d6c67aa7f2",
+        "124b7a666573abce87c82a52156a403f1ebd6f69"
       ],
-      "committed_at": "2026-06-09T02:23:35Z",
+      "committed_at": "2026-06-10T15:47:16Z",
       "next_step": "ai_review_required",
-      "pr_number": 27106,
-      "pr_url": "https://github.com/openai/codex/pull/27106",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "pr_number": 27264,
+      "pr_url": "https://github.com/openai/codex/pull/27264",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
       "sample_paths": [
+        "codex-rs/app-server-protocol/src/protocol/thread_history.rs",
+        "codex-rs/core/src/agent/control_tests.rs",
+        "codex-rs/core/src/client.rs",
+        "codex-rs/core/src/client_tests.rs",
+        "codex-rs/core/src/compact.rs",
         "codex-rs/core/src/compact_remote.rs",
         "codex-rs/core/src/compact_remote_v2.rs",
-        "codex-rs/core/src/context_manager/history.rs",
-        "codex-rs/core/src/context_manager/mod.rs",
-        "codex-rs/core/src/session/mod.rs"
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/session/rollout_reconstruction.rs",
+        "codex-rs/core/src/session/rollout_reconstruction_tests.rs",
+        "codex-rs/core/src/session/session.rs",
+        "codex-rs/core/src/session/tests.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27106",
+      "subject_id": "27264",
       "subject_kind": "pr",
       "surface_hints": [
-        "internal_churn"
-      ],
-      "title": "[codex] Remove remote compaction failure log",
-      "url": "https://github.com/openai/codex/pull/27106"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 6,
-      "commit_shas": [
-        "7dbe7f3e920ed08b1f2bab4abae6c09da35c80c6",
-        "80893eea9662598d4f6371df0eb5f4d09f4c0140",
-        "0294cf23c0a03e9c340c13c80c24093d381a46e7",
-        "f0dba2abb15768c83f2ee46976d95b0328cb409e",
-        "89096fe6d91d9570ea8563dae1937147496f1ffa",
-        "6d893fd1ae65b23eb890ff12164c2c368fa52af1",
-        "d2b82c00f03db7dc3b296430dbee944a58c6aec3",
-        "8d74c889a3e294ec4018f6fccb9495f2ad565b78"
-      ],
-      "committed_at": "2026-06-09T04:32:46Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26880,
-      "pr_url": "https://github.com/openai/codex/pull/26880",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/core/src/git_info_tests.rs",
-        "codex-rs/git-utils/src/fsmonitor.rs",
-        "codex-rs/git-utils/src/fsmonitor_tests.rs",
-        "codex-rs/git-utils/src/info.rs",
-        "codex-rs/git-utils/src/lib.rs",
-        "codex-rs/tui/src/get_git_diff.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26880",
-      "subject_kind": "pr",
-      "surface_hints": [
+        "app_server_protocol",
         "cli_tui",
         "tests_ci"
       ],
-      "title": "[codex] preserve fsmonitor for worktree Git reads",
-      "url": "https://github.com/openai/codex/pull/26880"
+      "title": "[codex] Store compact window id in rollout",
+      "url": "https://github.com/openai/codex/pull/27264"
     },
     {
       "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 5,
-      "commit_shas": [
-        "c0585a40a8aca901dea5d4d04c19188fa084a681"
-      ],
-      "committed_at": "2026-06-09T15:29:32Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27080,
-      "pr_url": "https://github.com/openai/codex/pull/27080",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        ".codex/skills/babysit-pr/SKILL.md",
-        ".codex/skills/babysit-pr/agents/openai.yaml",
-        ".codex/skills/babysit-pr/references/github-api-notes.md",
-        ".codex/skills/babysit-pr/scripts/gh_pr_watch.py",
-        ".codex/skills/babysit-pr/scripts/test_gh_pr_watch.py"
-      ],
-      "source_state": "merged",
-      "subject_id": "27080",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "tests_ci"
-      ],
-      "title": "[codex] Ignore pending PR review comments",
-      "url": "https://github.com/openai/codex/pull/27080"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "new_feature"
-      ],
-      "changed_file_count": 2,
-      "commit_shas": [
-        "a1b5b9e05a52a2a13e19a20e39592fe4c1b42ae7",
-        "df9c1d596b469d3be2a38ee36ce3329ad3c952d6"
-      ],
-      "committed_at": "2026-06-09T15:50:13Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26420,
-      "pr_url": "https://github.com/openai/codex/pull/26420",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature.",
-      "sample_paths": [
-        "codex-rs/state/src/runtime.rs",
-        "codex-rs/state/src/runtime/backfill.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26420",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "internal_churn"
-      ],
-      "title": "Avoid no-op backfill state writes",
-      "url": "https://github.com/openai/codex/pull/26420"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "protocol_change"
-      ],
-      "changed_file_count": 4,
-      "commit_shas": [
-        "e334749c069de53b53319622dd9519005812cd4c",
-        "b7b8195697fd4e367bf9bce3d2c9864f51276f8a"
-      ],
-      "committed_at": "2026-06-09T20:23:31Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26681,
-      "pr_url": "https://github.com/openai/codex/pull/26681",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, protocol_change.",
-      "sample_paths": [
-        "codex-rs/ext/goal/src/spec.rs",
-        "codex-rs/ext/goal/src/tool.rs",
-        "codex-rs/ext/goal/tests/goal_extension_backend.rs",
-        "codex-rs/state/src/runtime/goals.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26681",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "tests_ci"
-      ],
-      "title": "Allow creating a new goal after completion",
-      "url": "https://github.com/openai/codex/pull/26681"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
         "new_feature",
         "protocol_change",
         "security_policy"
       ],
-      "changed_file_count": 2,
+      "changed_file_count": 37,
       "commit_shas": [
-        "f5aceef813187034818cd820bc6dc88eda61a2e0",
-        "31be4bfd9e18c79a72a46bd60414e1ff6d421855",
-        "370ee0584b72143fc47337d21933a41d1b4da7ef",
-        "fc5b45bfc2212b4c34e03ab6e4f826feb09edd90",
-        "4ce0812b02ebf0973901ed19f58bb7852237163a",
-        "98a6caf6a105156a0741c5952bd3350c03333556",
-        "4e2a69b9a3e0cf97209eeab7551a7bb11d5bec01",
-        "01f4a200d4e6eb53d086ec44ebddff9f25b1f8b6",
-        "6c6bc03418b575dba5af860025449bca73ecf1be",
-        "51dd8b35382f6ca994a4bf2e0dbc3ee86f38e413",
-        "42f3de1f1526af2e9f14538a4e63f01789141166",
-        "d2f5bddc9c6f8b8646af0a906e09115b78f28b66",
-        "5111a85c16c9ac17dc3adc5e7b0e1cadfafae93c",
-        "11babeb0901576cdd8f27e9864e1f20cfe22cfd1"
+        "dfb5c0cf7a5f50d8fc30f7ee2546f071f4fe0cfb"
       ],
-      "committed_at": "2026-06-09T20:51:57Z",
+      "committed_at": "2026-06-10T16:40:41Z",
       "next_step": "ai_review_required",
-      "pr_number": 26830,
-      "pr_url": "https://github.com/openai/codex/pull/26830",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for breaking_change, new_feature, protocol_change, security_policy.",
+      "pr_number": 27299,
+      "pr_url": "https://github.com/openai/codex/pull/27299",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/core/tests/suite/agents_md.rs",
-        "codex-rs/core/tests/suite/compact.rs"
+        "codex-rs/core/src/tools/code_mode/execute_handler.rs",
+        "codex-rs/core/src/tools/code_mode/wait_handler.rs",
+        "codex-rs/core/src/tools/handlers/agent_jobs/report_agent_job_result.rs",
+        "codex-rs/core/src/tools/handlers/agent_jobs/spawn_agents_on_csv.rs",
+        "codex-rs/core/src/tools/handlers/apply_patch.rs",
+        "codex-rs/core/src/tools/handlers/dynamic.rs",
+        "codex-rs/core/src/tools/handlers/extension_tools.rs",
+        "codex-rs/core/src/tools/handlers/list_available_plugins_to_install.rs",
+        "codex-rs/core/src/tools/handlers/mcp.rs",
+        "codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resource_templates.rs",
+        "codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resources.rs",
+        "codex-rs/core/src/tools/handlers/mcp_resource/read_mcp_resource.rs"
       ],
       "source_state": "merged",
-      "subject_id": "26830",
+      "subject_id": "27299",
       "subject_kind": "pr",
       "surface_hints": [
+        "mcp_plugins",
+        "release_packaging",
+        "sandbox_permissions",
         "tests_ci"
       ],
-      "title": "[codex] Characterize global instruction lifecycle",
-      "url": "https://github.com/openai/codex/pull/26830"
+      "title": "[codex] Outline ToolExecutor handler bodies",
+      "url": "https://github.com/openai/codex/pull/27299"
+    },
+    {
+      "attention_flags": [
+        "release_packaging"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "64ac1dbd97d2d31fc380e2ae589289a9456bc461"
+      ],
+      "committed_at": "2026-06-10T18:37:14Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27421,
+      "pr_url": "https://github.com/openai/codex/pull/27421",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for release_packaging.",
+      "sample_paths": [
+        "codex-rs/app-server/src/lib.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27421",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol"
+      ],
+      "title": "[codex] Raise app-server recursion limit",
+      "url": "https://github.com/openai/codex/pull/27421"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 3,
+      "commit_shas": [
+        "8686dc569b56f54c3dda658f1115d686584e561d"
+      ],
+      "committed_at": "2026-06-10T19:17:15Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27439,
+      "pr_url": "https://github.com/openai/codex/pull/27439",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/app-server/src/extensions.rs",
+        "codex-rs/app-server/src/mcp_refresh.rs",
+        "codex-rs/app-server/src/message_processor.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27439",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "mcp_plugins"
+      ],
+      "title": "feat: make ThreadStore available on ThreadExtensionDependencies",
+      "url": "https://github.com/openai/codex/pull/27439"
     },
     {
       "attention_flags": [
@@ -1576,6 +1349,264 @@
       ],
       "title": "[codex] Tag multi-agent spawn metrics with version",
       "url": "https://github.com/openai/codex/pull/27375"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 2,
+      "commit_shas": [
+        "2545ed23fec98ab5396de7e5156060f78a3ae896"
+      ],
+      "committed_at": "2026-06-10T15:51:17Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27280,
+      "pr_url": "https://github.com/openai/codex/pull/27280",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/utils/path-uri/src/lib.rs",
+        "codex-rs/utils/path-uri/src/tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27280",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "[codex] add io PathUri native conversion APIs",
+      "url": "https://github.com/openai/codex/pull/27280"
+    },
+    {
+      "attention_flags": [
+        "release_packaging"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "04291f52e1d3efeb4d6266ae183a6ab6fabfff68"
+      ],
+      "committed_at": "2026-06-10T16:18:19Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27315,
+      "pr_url": "https://github.com/openai/codex/pull/27315",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for release_packaging.",
+      "sample_paths": [
+        ".github/workflows/rust-release-windows.yml"
+      ],
+      "source_state": "merged",
+      "subject_id": "27315",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "release_packaging",
+        "tests_ci"
+      ],
+      "title": "[codex] link Windows releases with LLD",
+      "url": "https://github.com/openai/codex/pull/27315"
+    },
+    {
+      "attention_flags": [
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 2,
+      "commit_shas": [
+        "b36053eec1f68a4a9e48aed53ea56810a2003c5f",
+        "9a58bdcec68fa76812192615935890a2e826187f",
+        "4dc3e9cae948d55ec4070f7163f0e99c8ff1b1ce",
+        "3835922698aa996af2bd6e9e371da2cfa768335a"
+      ],
+      "committed_at": "2026-06-10T16:52:17Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27391,
+      "pr_url": "https://github.com/openai/codex/pull/27391",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/state/migrations/0036_threads_visible_sort_indexes.sql",
+        "codex-rs/state/src/runtime/threads.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27391",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "internal_churn"
+      ],
+      "title": "Index visible thread list ordering",
+      "url": "https://github.com/openai/codex/pull/27391"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "rate_limit",
+        "security_policy"
+      ],
+      "changed_file_count": 6,
+      "commit_shas": [
+        "3ea9606263f279e5c58ab3b843330dd1d462e1c1",
+        "38d1808316c2c991fc98eba55191cfca2408c607",
+        "eeb570f02d3c7a360b121d856df22050f05f9e46",
+        "db3a7af542ea52db61f470bd307122007fc4cd5d",
+        "402ee65adeb169b1e1e3bb59fc5c5bbe9a58e624",
+        "db80b07f2a285de93c3bbc03985f1487e046c895",
+        "f672caed2081663e402f3570eb2ddb12ff42ec01",
+        "1311085aa18dbcc1e3c0913b68d963235a70f462",
+        "91a0b3957e9e0661d928df496ceaa2153b3c62f0",
+        "e26cac911ec689f5438c4cdae06f561f52b5dcb0"
+      ],
+      "committed_at": "2026-06-10T18:46:57Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27062,
+      "pr_url": "https://github.com/openai/codex/pull/27062",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, rate_limit, security_policy.",
+      "sample_paths": [
+        "codex-rs/analytics/src/analytics_client_tests.rs",
+        "codex-rs/analytics/src/events.rs",
+        "codex-rs/core/src/guardian/mod.rs",
+        "codex-rs/core/src/guardian/review.rs",
+        "codex-rs/core/src/guardian/review_session.rs",
+        "codex-rs/core/src/guardian/tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27062",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "[codex] Retry transient Guardian review failures",
+      "url": "https://github.com/openai/codex/pull/27062"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "52a69d375c0c454744bb4306e0c667533278f7fd",
+        "df144382160d9b068d3782247671c9df2c6c5e14",
+        "f1446ef23a527c4ced239427eb50130bc618b17e",
+        "edea0dc753dd80ac4739fc8773852bf16baf2b88",
+        "675adb8af60b6be867bcf4dedd1bea2d34877faf",
+        "076f6013f5b3ac992a57e6b2d4152db7ec1840ae",
+        "1d0954270ea22db3c32c786742c430b1bfe47e19"
+      ],
+      "committed_at": "2026-06-10T19:19:26Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27343,
+      "pr_url": "https://github.com/openai/codex/pull/27343",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/tests/suite/cli_stream.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27343",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "Guard core test subprocess cleanup",
+      "url": "https://github.com/openai/codex/pull/27343"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "release_packaging"
+      ],
+      "changed_file_count": 4,
+      "commit_shas": [
+        "c90706ebae4ca30e87ccc1f6d53a6fb7cbef55b2"
+      ],
+      "committed_at": "2026-06-10T19:45:29Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27321,
+      "pr_url": "https://github.com/openai/codex/pull/27321",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, release_packaging.",
+      "sample_paths": [
+        "bazel/platforms/BUILD.bazel",
+        "bazel/platforms/release_binaries.bzl",
+        "codex-rs/cli/BUILD.bazel",
+        "defs.bzl"
+      ],
+      "source_state": "merged",
+      "subject_id": "27321",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "release_packaging"
+      ],
+      "title": "[codex] Move release platform rules into bazel package",
+      "url": "https://github.com/openai/codex/pull/27321"
+    },
+    {
+      "attention_flags": [],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "4e74b09a544ca5150d1998c4d647b1b9651e0f63"
+      ],
+      "committed_at": "2026-06-10T16:28:12Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27276,
+      "pr_url": "https://github.com/openai/codex/pull/27276",
+      "review_priority": "low",
+      "review_reason": "Needs AI review because every recent upstream commit is tracked, but deterministic hints found only internal churn.",
+      "sample_paths": [
+        "codex-rs/rollout/src/list.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27276",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "internal_churn"
+      ],
+      "title": "Reduce archive rollout lookup CPU",
+      "url": "https://github.com/openai/codex/pull/27276"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed"
+      ],
+      "changed_file_count": 3,
+      "commit_shas": [
+        "049fa8db072a31d059bfb6ecc6b360781492a551",
+        "88ab3ee9d4e0c11c6c6b34e5b1fb26eb5d277c9c",
+        "1c227840af937213b8704aac36f78867d0c8ac09",
+        "b73155ba00ab28ea105617ef39bc881a3eaf715f"
+      ],
+      "committed_at": "2026-06-10T17:23:42Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27407,
+      "pr_url": "https://github.com/openai/codex/pull/27407",
+      "review_priority": "low",
+      "review_reason": "Needs AI review for deprecated_removed.",
+      "sample_paths": [
+        "codex-rs/rollout/src/compression_tests.rs",
+        "codex-rs/rollout/src/search.rs",
+        "codex-rs/thread-store/src/local/search_threads.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27407",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "Fix compressed rollout search path matching",
+      "url": "https://github.com/openai/codex/pull/27407"
     }
   ]
 }

--- a/artifacts/github/reviews/openai-codex-pr-25147.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-25147.review.json
@@ -1,0 +1,97 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-25147",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "25147",
+    "commit_shas": [
+      "09ce7e176bb3e35108cce7c74f9fe566125b6c87",
+      "821b679505e5021c4fc20a3c79070d96ff0aaa24",
+      "e992bdf9805440b068ffa2c031dbf3be0e244107",
+      "7c54723762ae9ebb3d2bbb95e71ac5000771c9c9",
+      "e4dca2440722489eb1d774ba0b273a4260f8d0e8",
+      "5f2b14e092e169c3f4c9f4b93c40e2560f95e2ca",
+      "d4b826175776c26f977b2e10a9dc9bc4a3030e41",
+      "daf24cccd232bb9cc3035eb9985d2bf3ee24cab5",
+      "b0a300fb9b9d8ee73be8d40f718eb7b9464a28be",
+      "6e4c8dfa31a5fbb6216e8465337d737b7327fb6a",
+      "dee789ab91d6883ca16fbc86aeadbf524d95c1ef",
+      "08503d6d13e7b7efc817299c30bcf34bd7b5b076",
+      "75e3421f94a530314154b3ff9dd51a1064f861f6",
+      "d1596f4595d17a2e2a94a8fc45c7ceb116079868",
+      "2e23b88414a393e9800c328bded2e6f2bd7ba7a7",
+      "b8760d31e0e00e07aa8db22afae4ab3fb9797af4",
+      "1f6a75d2ac149df0a0d8f99a531aeb65243c5d1b",
+      "9dfb4be0ec69162ea9b1b10008c160a333a99df1",
+      "ce34025915ff7df1c060ff0343c5b42c4f3453f9",
+      "7a381f591d4bd26aabb5312d89b5c5b3d47d5a9d",
+      "4f29a9e89e8f39e784336e83bc71dffc270f632d"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Retry streamable HTTP initialize failures",
+        "url": "https://github.com/openai/codex/pull/25147",
+        "meta": "Merged 2026-06-09T22:49:49Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Retry streamable HTTP initialize failures",
+        "url": "https://github.com/openai/codex/commit/09ce7e176bb3e35108cce7c74f9fe566125b6c87"
+      },
+      {
+        "kind": "commit",
+        "title": "Retry streamable HTTP recovery handshakes",
+        "url": "https://github.com/openai/codex/commit/9dfb4be0ec69162ea9b1b10008c160a333a99df1"
+      },
+      {
+        "kind": "commit",
+        "title": "Retry tools list transient HTTP failures",
+        "url": "https://github.com/openai/codex/commit/ce34025915ff7df1c060ff0343c5b42c4f3453f9"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-10T20:07:16Z",
+  "observed_change": "Codex RMCP streamable HTTP startup now retries transient initialize and initialized-notification failures, recreates the transport between attempts, and retries only the read-only `tools/list` operation after initialization.",
+  "changed_surfaces": [
+    "RMCP streamable HTTP startup handshake",
+    "retry classification for request-layer, HTTP-status, and JSON-RPC failures",
+    "typed streamable HTTP adapter errors for retryable statuses",
+    "read-only `tools/list` retry behavior",
+    "OAuth state persistence before initialize retry",
+    "streamable HTTP recovery integration tests"
+  ],
+  "user_visible_path": "Codex users connecting to hosted or remote MCP services, including `codex_apps`, should see fewer startup failures when initialize, initialized notification, or the first read-only `tools/list` request hits a transient HTTP or request-layer failure.",
+  "control_plane_relevance": "High for Decodex Control Plane because hosted plugin and remote MCP readiness probes depend on streamable HTTP startup stability and on not replaying side-effecting tool calls.",
+  "compatibility_risk": "Low; the PR deliberately limits retries to startup handshake paths and read-only `tools/list`, preserving side-effecting `tools/call` behavior while changing transient startup failures into delayed success when retries work.",
+  "adoption_opportunity": "Mirror the retry distinction in Decodex MCP health checks: retry initialize and read-only capability discovery, but keep tool-call replay fail-closed unless a future source-backed contract says otherwise.",
+  "community_value": "High for MCP plugin operators because it makes temporary streamable HTTP failures less likely to break startup without broad replay of mutating operations.",
+  "deprecated_or_breaking_notes": "No removal is visible; the meaningful behavior change is that selected transient startup and read-only discovery failures are retried within the operation deadline.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #25147 says initialize failures and read-only `tools/list` failures are retried while side-effecting tool calls are intentionally not replayed.",
+    "`codex-rs/rmcp-client/src/streamable_http_retry.rs` adds retry delays, initialize retry orchestration, retryable error classification, and deadline-aware sleeps.",
+    "`codex-rs/rmcp-client/src/http_client_adapter.rs` surfaces retryable streamable HTTP POST statuses as typed client errors.",
+    "`codex-rs/rmcp-client/src/rmcp_client.rs` wires the retry path into pending transport connection and client operations.",
+    "`codex-rs/rmcp-client/tests/streamable_http_recovery.rs` covers initialize retry, initialized-notification retry, no-status request failure retry, and `tools/list` retry.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-25147.json` records 7 changed files for the merged PR."
+  ],
+  "caveats": "The review confirms retry behavior for selected streamable HTTP startup and discovery paths only; it does not justify retrying mutating MCP tool calls or treating all HTTP errors as recoverable.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "MCP startup retry semantics affect Control Plane readiness, hosted plugin probes, and reliability expectations."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The retry boundary is useful public guidance for remote MCP and plugin operators."
+    },
+    {
+      "type": "linear_followup",
+      "reason": "Decodex should compare its MCP readiness probes with Codex's retry-only-startup boundary."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-26701.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-26701.review.json
@@ -1,0 +1,76 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-26701",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "26701",
+    "commit_shas": [
+      "52f9ec871bedbd53a0c0741d0b7bc47e3dae3da9",
+      "4d32a96c7580b022e5d906bcbb2eb283b80338f7",
+      "ddd48cab1b5d617e8a01737c0665f4025b351421",
+      "44448048dcad4a75a1d7056f23cc87691438268c",
+      "ccf0f0d9892fd9b253401466d6dee7a1886ac407",
+      "9da50461f3d23990d484b3ba29b5cb293269d23f"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "TUI Plugin Sharing 1 - add remote plugin identity",
+        "url": "https://github.com/openai/codex/pull/26701",
+        "meta": "Merged 2026-06-09T23:34:39Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Adjustment for admin-disabled plugins in /plugin menu",
+        "url": "https://github.com/openai/codex/commit/ddd48cab1b5d617e8a01737c0665f4025b351421"
+      },
+      {
+        "kind": "commit",
+        "title": "tui: update remote plugin detail fixtures",
+        "url": "https://github.com/openai/codex/commit/ccf0f0d9892fd9b253401466d6dee7a1886ac407"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-10T20:07:16Z",
+  "observed_change": "Codex TUI plugin popups now carry a `PluginLocation` that can address either a local marketplace path or a remote marketplace name, letting remote plugin detail, install, and uninstall actions use remote plugin identity while preserving local plugin flows.",
+  "changed_surfaces": [
+    "TUI plugin popup request routing",
+    "`PluginLocation` local-versus-remote identity model",
+    "remote plugin detail, install, and uninstall request parameters",
+    "admin-disabled plugin install and toggle affordances",
+    "plugin popup tests and remote fixtures"
+  ],
+  "user_visible_path": "A Codex TUI user opening the plugin menu can inspect remote marketplace plugins without a local filesystem path and route install or uninstall actions by remote plugin ID; admin-disabled plugins remain blocked in the existing popup flow.",
+  "control_plane_relevance": "Medium for Decodex Control Plane because plugin inventory and install surfaces now need to preserve remote plugin IDs and marketplace names separately from local marketplace paths.",
+  "compatibility_risk": "Medium for local plugin tooling or UI assumptions that treat marketplace path as required identity; the PR keeps local IDs and paths intact but adds remote identity as a first-class branch.",
+  "adoption_opportunity": "Update Decodex plugin readback and operator UI models to distinguish local marketplace path, remote marketplace name, plugin ID, and remote plugin ID before presenting install or uninstall actions.",
+  "community_value": "High for Codex plugin users because it is an early visible step toward shared or remote plugins in the TUI without adding broad share-management UI yet.",
+  "deprecated_or_breaking_notes": "No local plugin behavior is removed; the PR intentionally keeps share-management UI out of scope and only adds remote-capable identity routing for existing plugin popup flows.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26701 states that plugin popup flows now address plugins from either a local marketplace path or a remote marketplace name.",
+    "`codex-rs/tui/src/app_event.rs` adds `PluginLocation::Local` and `PluginLocation::Remote` plus request-parameter conversion.",
+    "`codex-rs/tui/src/app/background_requests.rs` and `event_dispatch.rs` change plugin install request events from marketplace paths to `PluginLocation`.",
+    "`codex-rs/tui/src/chatwidget/plugins.rs` adds remote-aware plugin source, availability, detail, install, and uninstall handling.",
+    "`codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs` adds coverage for remote rows, remote detail, remote install/uninstall actions, and admin-disabled plugin states.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-26701.json` records 7 changed files for the merged PR."
+  ],
+  "caveats": "The source review confirms TUI identity and action routing only; it does not claim a complete remote plugin sharing management UI or account-side sharing policy.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Remote plugin identity changes Control Plane plugin inventory and install assumptions."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The TUI remote plugin identity path has a clear public plugin-operator angle."
+    },
+    {
+      "type": "linear_followup",
+      "reason": "Decodex should verify plugin inventory and install readback can represent remote marketplace identity without requiring local paths."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-26734.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-26734.review.json
@@ -1,0 +1,76 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-26734",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "26734",
+    "commit_shas": [
+      "b564da44fb798e9e8e5c89ff912ab72a70a2ba9c",
+      "5b5caa9431c818837eadc6d01cdd64e3b597ce9d",
+      "83c0b87e952501c98f96957c3df2b2efa45352f7",
+      "9ff7581214ba17137fd351893766e6be3612ff05",
+      "e605b381502ef535c95f6e57798cc78a08703912",
+      "eb4878b26439e36e1446fc72da6a8b25b495bfd1"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Handle Ctrl-C for non-TTY unified exec",
+        "url": "https://github.com/openai/codex/pull/26734",
+        "meta": "Merged 2026-06-09T22:10:18Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Handle Ctrl-C for non-TTY unified exec",
+        "url": "https://github.com/openai/codex/commit/b564da44fb798e9e8e5c89ff912ab72a70a2ba9c"
+      },
+      {
+        "kind": "commit",
+        "title": "Report SIGINT exit code for unified exec",
+        "url": "https://github.com/openai/codex/commit/9ff7581214ba17137fd351893766e6be3612ff05"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-10T20:07:16Z",
+  "observed_change": "Codex unified exec now maps a non-TTY `write_stdin` Ctrl-C payload to a real process interrupt through a new exec-server `process/signal` method, then drains process output and exit metadata instead of rejecting stdin as closed.",
+  "changed_surfaces": [
+    "unified exec `write_stdin` handling for non-TTY sessions",
+    "exec-server `process/signal` JSON-RPC protocol and `ProcessSignal::Interrupt` type",
+    "local and remote exec process signal dispatch",
+    "Unix process-group SIGINT support and signal-derived exit-code reporting",
+    "exec-server and unified-exec interrupt tests"
+  ],
+  "user_visible_path": "Codex clients that keep a long-running non-TTY unified exec session can send U+0003 through `write_stdin` to interrupt the process and still receive process-produced output plus the observed exit code, including 130 for the default SIGINT path or a trap-defined exit.",
+  "control_plane_relevance": "High for Decodex Control Plane and any app-server or exec-server adapter that models process interruption, because non-TTY Ctrl-C now depends on a protocol-level signal path rather than a stdin write or hard termination fallback.",
+  "compatibility_risk": "Medium for mixed-version or third-party exec-server implementations that do not implement `process/signal`; those hosts may report unsupported interrupts instead of delivering SIGINT, and non-TTY Ctrl-C semantics change from `StdinClosed` or termination to process-observed interruption.",
+  "adoption_opportunity": "Teach Decodex process-control probes and operator UI to distinguish graceful interrupt, unsupported interrupt, terminate, and hard-kill paths for non-TTY background commands.",
+  "community_value": "High for Codex users running long-lived non-TTY commands because Ctrl-C can now behave like an actual process interrupt while preserving output and exit metadata.",
+  "deprecated_or_breaking_notes": "No API removal is visible, but `process/signal` is a new exec-server method and non-TTY U+0003 no longer follows the old closed-stdin behavior.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26734 states that non-TTY U+0003 `write_stdin` should route through `process.signal(...)` and then let normal collection drain output and observe process exit.",
+    "`codex-rs/exec-server/src/protocol.rs` adds the `process/signal` method, `ProcessSignal::Interrupt`, `SignalParams`, and `SignalResponse`.",
+    "`codex-rs/exec-server/src/process.rs`, `local_process.rs`, and `remote_process.rs` add signal dispatch to the exec-process abstraction.",
+    "`codex-rs/utils/pty/src/process_group.rs`, `pipe.rs`, and `pty.rs` add process-group SIGINT support and signal-derived exit-code handling.",
+    "`codex-rs/core/tests/suite/unified_exec.rs` adds coverage for trap-handled Ctrl-C exit 42 and default SIGINT exit 130 in non-TTY sessions.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-26734.json` records 19 changed files for the merged PR."
+  ],
+  "caveats": "The bundle confirms Unix process-group interrupt support and unsupported-signal reporting for other backends; downstream clients still need current exec-server support before relying on `process/signal`.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The new signal protocol and non-TTY interrupt semantics affect Control Plane process-control assumptions."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The change has a clear public operator angle for long-running command interruption."
+    },
+    {
+      "type": "linear_followup",
+      "reason": "Decodex should audit non-TTY interrupt, unsupported interrupt, terminate, and hard-kill handling against the new Codex behavior."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-27129.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27129.review.json
@@ -1,0 +1,67 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27129",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27129",
+    "commit_shas": [
+      "00f1e544854c67163899cd0c6c3091c6d4a7694e",
+      "38b487f2a4eb2291eab6ccea41d24455acfbe9c0",
+      "b3dce407ff660c49d616be8920bc50a74ced8ac1",
+      "717e4b299bf0815a2fd1bd77d61ed5f3fbc7ae40"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "feat: use provider defaults for memory models",
+        "url": "https://github.com/openai/codex/pull/27129",
+        "meta": "Merged 2026-06-09T23:49:09Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Use provider defaults for memory models",
+        "url": "https://github.com/openai/codex/commit/00f1e544854c67163899cd0c6c3091c6d4a7694e"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-10T20:07:16Z",
+  "observed_change": "Codex memory extraction and consolidation now resolve their default model names through the active `ModelProvider`, with Amazon Bedrock overriding both memory stages to use its provider-specific `openai.gpt-5.4` model ID while explicit memory model config still takes precedence.",
+  "changed_surfaces": [
+    "memory startup extraction model selection",
+    "memory consolidation agent model selection",
+    "`MemoryStartupContext` provider ownership",
+    "`ModelProvider` preferred memory model hooks",
+    "Amazon Bedrock model-provider defaults",
+    "startup tests for OpenAI and Bedrock memory model selection"
+  ],
+  "user_visible_path": "Codex users running memory startup on non-default providers such as Amazon Bedrock no longer depend on OpenAI-style `gpt-5.4-mini` or `gpt-5.4` slugs unless they explicitly configure `memories.extract_model` or `memories.consolidation_model`.",
+  "control_plane_relevance": "Medium for Decodex Control Plane where provider-specific background tasks, account routing, or model defaults must avoid assuming OpenAI model slugs across providers.",
+  "compatibility_risk": "Low; the provider trait supplies default OpenAI-compatible memory model hooks, explicit config overrides continue to win, and the concrete behavior change is targeted at provider-specific defaults.",
+  "adoption_opportunity": "Use provider-owned default hooks for Decodex background or memory-like tasks rather than baking OpenAI model slugs into provider-neutral workflows.",
+  "community_value": "Medium for Codex users and operators using Bedrock or other provider backends because memory startup becomes provider-aware without requiring per-user memory model overrides.",
+  "deprecated_or_breaking_notes": "The hardcoded memory-stage default constants are removed from the memory writer path, but user-facing memory model override keys remain in force.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27129 states that memory extraction and consolidation now resolve defaults through the active `ModelProvider` while preserving explicit memory config overrides.",
+    "`codex-rs/memories/write/src/phase1.rs` replaces the hardcoded extraction model with `context.provider().memory_extraction_preferred_model()` when no override is set.",
+    "`codex-rs/memories/write/src/phase2.rs` passes the provider into consolidation agent config selection.",
+    "`codex-rs/memories/write/src/runtime.rs` creates and stores a shared model provider in `MemoryStartupContext`.",
+    "`codex-rs/model-provider/src/provider.rs` adds default preferred memory model hooks, and `amazon_bedrock/mod.rs` overrides both memory stages with the Bedrock model ID.",
+    "`codex-rs/memories/write/src/startup_tests.rs` adds startup coverage for default OpenAI and Bedrock memory model selection.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27129.json` records 9 changed files for the merged PR."
+  ],
+  "caveats": "The review confirms memory startup model selection only; it does not prove behavior for every provider implementation beyond the default trait hooks and the Bedrock override included in this PR.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Provider-owned defaults affect how Decodex should reason about provider-neutral background model selection."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The Bedrock memory-model default has a concrete public operator note for non-OpenAI provider users."
+    }
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-25147.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-25147.json
@@ -1,0 +1,54 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-25147",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "practical_explainer",
+  "priority": "critical",
+  "audience": "Codex MCP, hosted plugin, and streamable HTTP operators",
+  "candidate_text": [
+    "Codex now retries streamable HTTP MCP initialize failures and read-only `tools/list` calls, rebuilding the transport without replaying side-effecting tool calls. PR: https://github.com/openai/codex/pull/25147"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-25147.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-25147.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/25147"
+    ]
+  },
+  "evidence_notes": [
+    "The upstream review records retry orchestration for initialize and initialized-notification failures.",
+    "`tools/list` is retried as a read-only post-initialize discovery operation.",
+    "Side-effecting MCP tool calls are intentionally outside the retry boundary."
+  ],
+  "claims": [
+    {
+      "text": "Streamable HTTP MCP initialize and initialized-notification failures can be retried.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-25147.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Codex limits post-initialize retry to read-only `tools/list` rather than replaying mutating tool calls.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-25147.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR gives MCP operators a practical reliability boundary for startup retries.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-25147:practical_explainer"
+  },
+  "caveats": [
+    "Retries are bounded by operation deadlines and retry classification.",
+    "The PR does not authorize replaying side-effecting MCP tool calls."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this candidate.",
+    "Compare Decodex MCP readiness probes with the retry-only-startup boundary."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-26701.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-26701.json
@@ -1,0 +1,54 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-26701",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "practical_explainer",
+  "priority": "critical",
+  "audience": "Codex TUI plugin users and plugin operators",
+  "candidate_text": [
+    "Codex's TUI plugin menu now has a remote plugin identity path: remote marketplace rows can open details and route install/uninstall by remote plugin ID, while local plugin paths still work. PR: https://github.com/openai/codex/pull/26701"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26701.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26701.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26701"
+    ]
+  },
+  "evidence_notes": [
+    "The upstream review records `PluginLocation::Local` and `PluginLocation::Remote` as the TUI identity split.",
+    "Plugin install and uninstall events now carry remote marketplace identity where needed.",
+    "Tests cover remote plugin rows, details, install/uninstall actions, and admin-disabled states."
+  ],
+  "claims": [
+    {
+      "text": "The Codex TUI plugin menu can route remote plugin detail, install, and uninstall actions by remote identity.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26701.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Local plugin path behavior remains supported alongside remote plugin identity.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26701.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR adds a visible remote-plugin identity path that plugin operators can understand without overclaiming full sharing UI.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26701:practical_explainer"
+  },
+  "caveats": [
+    "The PR does not add complete share-management UI.",
+    "Remote availability and admin-disabled state still constrain install affordances."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this candidate.",
+    "Audit Decodex plugin readback for remote IDs and marketplace names."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-26734.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-26734.json
@@ -1,0 +1,54 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-26734",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "critical",
+  "audience": "Codex exec-server, app-server, and automation operators",
+  "candidate_text": [
+    "Codex unified exec learned a real Ctrl-C path for non-TTY sessions: `write_stdin` with U+0003 now calls `process/signal`/SIGINT, drains output, and preserves process exit metadata. PR: https://github.com/openai/codex/pull/26734"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26734.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26734.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26734"
+    ]
+  },
+  "evidence_notes": [
+    "The upstream review records a new exec-server `process/signal` method and `ProcessSignal::Interrupt` payload.",
+    "Non-TTY U+0003 now routes to process signal handling instead of the old closed-stdin path.",
+    "Unified exec tests cover trap-handled output and default SIGINT exit metadata."
+  ],
+  "claims": [
+    {
+      "text": "Non-TTY unified exec Ctrl-C now uses a real process-signal path.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26734.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Codex preserves process output and exit metadata after the interrupt path.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26734.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR changes command-interruption semantics in a concrete way operators can understand and test.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26734:operator_impact"
+  },
+  "caveats": [
+    "Non-Unix or unsupported backends may report unsupported interrupts.",
+    "Consumers need current exec-server support for `process/signal`."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this candidate.",
+    "Audit Decodex process-control handling against the new interrupt distinction."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27129.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27129.json
@@ -1,0 +1,54 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27129",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "practical_explainer",
+  "priority": "high",
+  "audience": "Codex model-provider and memory-feature operators",
+  "candidate_text": [
+    "Codex memory startup now asks the active model provider for default extraction and consolidation models. Bedrock gets provider-specific defaults, while explicit memory model config still wins. PR: https://github.com/openai/codex/pull/27129"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27129.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27129.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27129"
+    ]
+  },
+  "evidence_notes": [
+    "The upstream review records provider-owned defaults for memory extraction and consolidation model selection.",
+    "Amazon Bedrock overrides both memory defaults to its provider-specific `openai.gpt-5.4` model ID.",
+    "Explicit `memories.extract_model` and `memories.consolidation_model` config overrides remain highest priority."
+  ],
+  "claims": [
+    {
+      "text": "Codex memory extraction and consolidation defaults are now provider-aware.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27129.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Explicit memory model config overrides still take precedence over provider defaults.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27129.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR gives non-OpenAI provider users a concrete memory-model default change with a clear Bedrock example.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27129:practical_explainer"
+  },
+  "caveats": [
+    "The source-backed custom provider example is Bedrock.",
+    "The PR does not remove explicit memory model override keys."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this candidate.",
+    "Use provider-owned defaults in Decodex provider-neutral background task design."
+  ]
+}


### PR DESCRIPTION
## Summary
- refresh the openai/codex upstream review queue at 2026-06-10T20:05:18Z
- add GitHub bundles, upstream reviews, upstream impacts, and social candidates for PRs 26734, 25147, 26701, and 27129
- keep the run scoped to source-analysis artifacts only; no social_post/v1 records or X publication

## Validation
- target/debug/decodex radar bundle validate artifacts/github/bundles/openai-codex-pr-26734.json artifacts/github/bundles/openai-codex-pr-25147.json artifacts/github/bundles/openai-codex-pr-26701.json artifacts/github/bundles/openai-codex-pr-27129.json
- target/debug/decodex radar validate
- cargo make check-site-content
- git diff --check
- git diff --cached --check