### PR TITLE
Reserve Decodex X release rollup for Codex 0.139.0

### DIFF
--- a/artifacts/social/x/posts/2026-06-11/openai-codex-rust-v0-139-0-release-rollup.json
+++ b/artifacts/social/x/posts/2026-06-11/openai-codex-rust-v0-139-0-release-rollup.json
@@ -1,0 +1,162 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-rust-v0-139-0-release-rollup",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "release_rollup",
+  "status": "published",
+  "audience": "Codex operators tracking stable CLI releases and operator-facing surfaces",
+  "text": [
+    "Codex CLI 0.139.0 stable is out.\n\nTop notes: web search in code mode, richer tool/connector schemas, plugin marketplace provenance/cache work, image-edit path fixes, and sandbox/proxy correctness.\n\nSource: https://github.com/openai/codex/releases/tag/rust-v0.139.0",
+    "Feature picks:\n\n- standalone web search in code mode\nhttps://github.com/openai/codex/pull/26719\n\n- tool schemas preserve oneOf/allOf plus more shallow structure\nhttps://github.com/openai/codex/pull/24118\nhttps://github.com/openai/codex/pull/27084",
+    "Operator/plugin notes:\n\n- marketplace JSON adds marketplaceSource\nhttps://github.com/openai/codex/pull/27009\n\n- plugin lists can use cached catalog before background refresh\nhttps://github.com/openai/codex/pull/26932",
+    "Workflow fixes:\n\n- resume/fork --last parses prompt correctly\nhttps://github.com/openai/codex/pull/26818\n\n- TUI bare URLs with ~ linkify end to end\nhttps://github.com/openai/codex/pull/27088\n\n- thread resets preserve cloud requirements\nhttps://github.com/openai/codex/pull/25177",
+    "Reviewed Decodex-relevant fixes:\n\n- MCP startup status stays scoped to owning thread\nhttps://github.com/openai/codex/pull/26639\n\n- image edits use referenced file paths\nhttps://github.com/openai/codex/pull/26486\n\nBoth have checked Radar review/impact artifacts.",
+    "Sandbox/operator notes:\n\n- approved unified-exec escalation survives zsh-fork/intercepted exec paths\nhttps://github.com/openai/codex/pull/24981\n\n- configured network proxy now enforces proxy-only containment\nhttps://github.com/openai/codex/pull/27035",
+    "Lineage + caveat:\n\nStable compare: rust-v0.138.0 -> rust-v0.139.0\nhttps://github.com/openai/codex/compare/rust-v0.138.0...rust-v0.139.0\n\nRelease notes are source evidence; unreviewed PR details should stay release-note-scoped."
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-rust-v0-139-0-release-rollup.json"
+    ],
+    "reservations": [
+      "artifacts/social/x/reservations/2026-06-11/openai-codex-rust-v0-139-0-release-rollup.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-24981.review.json",
+      "artifacts/github/reviews/openai-codex-pr-26464.review.json",
+      "artifacts/github/reviews/openai-codex-pr-26486.review.json",
+      "artifacts/github/reviews/openai-codex-pr-26639.review.json",
+      "artifacts/github/reviews/openai-codex-pr-27009.review.json",
+      "artifacts/github/reviews/openai-codex-pr-27035.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-24981.json",
+      "artifacts/github/impact/openai-codex-pr-26464.json",
+      "artifacts/github/impact/openai-codex-pr-26486.json",
+      "artifacts/github/impact/openai-codex-pr-26639.json",
+      "artifacts/github/impact/openai-codex-pr-27009.json",
+      "artifacts/github/impact/openai-codex-pr-27035.json"
+    ],
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://developers.openai.com/codex/changelog",
+      "https://github.com/openai/codex/releases/tag/rust-v0.138.0",
+      "https://github.com/openai/codex/releases/tag/rust-v0.139.0",
+      "https://github.com/openai/codex/compare/rust-v0.138.0...rust-v0.139.0",
+      "https://github.com/openai/codex/pull/26719",
+      "https://github.com/openai/codex/pull/24118",
+      "https://github.com/openai/codex/pull/27084",
+      "https://github.com/openai/codex/pull/27009",
+      "https://github.com/openai/codex/pull/26932",
+      "https://github.com/openai/codex/pull/26818",
+      "https://github.com/openai/codex/pull/27088",
+      "https://github.com/openai/codex/pull/25177",
+      "https://github.com/openai/codex/pull/26639",
+      "https://github.com/openai/codex/pull/26486",
+      "https://github.com/openai/codex/pull/24981",
+      "https://github.com/openai/codex/pull/27035",
+      "https://x.com/decodexspace/status/2064831630381027692",
+      "https://x.com/decodexspace/status/2064831633514201293",
+      "https://x.com/decodexspace/status/2064831637221999083",
+      "https://x.com/decodexspace/status/2064831640405463066",
+      "https://x.com/decodexspace/status/2064831644201369963",
+      "https://x.com/decodexspace/status/2064831648504676557",
+      "https://x.com/decodexspace/status/2064831650874503240"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish, priority high, and mode release_rollup for the stable 0.139.0 checkpoint.",
+    "The candidate is source-backed by GitHub release metadata, official Codex changelog readback notes captured in the candidate, stable release compare metadata, direct PR URLs, release_delta/v1 metadata, and checked Radar review/impact artifacts for selected operator claims.",
+    "The x-post-quality-system gate passed because the thread answers what changed, who can act on it, and what source proves it; the copy is scan-friendly and uses direct GitHub PR URLs on first important PR mentions.",
+    "The release publisher gates were applied as stable release channel lineage: stable rust-v0.138.0 -> stable rust-v0.139.0, not prerelease channel lineage.",
+    "Checked durable social_post/v1 records contained no published or blocked record for this idempotency key before publication.",
+    "Checked durable social_publish_reservation/v1 records contained no active reservation for this idempotency key before PR #304 created the active reservation.",
+    "Open GitHub PR readback with routed hackink credentials found PR #298 as one pending 2026-06-11 publication record and no pending social/x record for rust-v0.139.0 before this reservation.",
+    "PR #304 made the active reservation visible before X compose; the reservation diff was limited to artifacts/social/x/reservations/2026-06-11/openai-codex-rust-v0-139-0-release-rollup.json at reservation time.",
+    "Chrome account readback in the X profile and composer showed the account menu as Decodex @decodexspace before publication.",
+    "Live @decodexspace profile readback before reservation and again after PR-visible reservation found no stable 0.139.0 lead, release URL, compare URL, candidate slug, or idempotency-subject duplicate across rendered recent profile posts.",
+    "The profile readback found prior alpha-thread overlap for the generic phrase standalone web search in code mode, so the final thread kept the claim scoped to the stable 0.139.0 release checkpoint rather than presenting it as a first-ever Decodex observation.",
+    "The generated decodex_signal_card media was created fresh for this candidate, stored outside Git at /Users/x/.codex/decodex/social-media/x/2026-06-11/openai-codex-rust-v0-139-0-release-rollup/image.png, and verified locally as 1254x1254 with SHA-256 4b967d8fb372ebc4a470a9a1af278f7753ff0392de8a96fbaedd0e20d8fd09e2.",
+    "X compose readback showed one 1254x1254 blob media attachment in the modal before publication.",
+    "Immediately before clicking Post all, live profile duplicate readback again found no stable 0.139.0 duplicate; composer readback showed Decodex @decodexspace, seven text boxes, one media attachment, and an enabled Post all button.",
+    "Home timeline readback after clicking Post all showed seven new @decodexspace posts with the expected 0.139.0 stable release text.",
+    "Permalink readback for the first status showed @decodexspace, Automated by @hackink, the expected lead text, a GitHub release source card, the uploaded media, and a /photo/1 URL.",
+    "Permalink thread readback showed all seven status URLs and the expected thread text for feature picks, operator/plugin notes, workflow fixes, reviewed Decodex-relevant fixes, sandbox/operator notes, and stable lineage/caveat.",
+    "The first status ID decodes to 2026-06-10T22:06:38.056Z, which is cap day 2026-06-11 in Asia/Shanghai; with pending PR #298 counted as one earlier 2026-06-11 publication, this seven-post thread moves the cap day from 1 to 8 published posts."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.139.0 is the stable OpenAI Codex CLI release checkpoint covered by this post.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.139.0",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The stable release lineage comparison used by this thread is rust-v0.138.0 -> rust-v0.139.0.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.138.0...rust-v0.139.0",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The 0.139.0 release notes highlight web search in code mode, richer tool schemas, plugin marketplace provenance/cache behavior, image edit path routing, and sandbox/proxy correctness.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.139.0",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Checked Radar review/impact artifacts support stronger Decodex-relevant operator claims for marketplace source provenance, image edit path routing, MCP startup scoping, sandbox escalation preservation, and proxy-only containment.",
+      "evidence": "artifacts/github/reviews/",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The 0.139.0 release-rollup thread is live on @decodexspace with generated media attached to the first post.",
+      "evidence": "https://x.com/decodexspace/status/2064831630381027692",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "priority": "high",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-139-0:stable138-stable139:release_rollup",
+    "reason": "The stable 0.139.0 release body provides concrete reader-facing release-note evidence, direct PR links, and enough checked Radar context for operator caveats.",
+    "daily_limit": 8,
+    "daily_count_before": 1,
+    "daily_count_after": 8,
+    "day": "2026-06-11",
+    "timezone": "Asia/Shanghai"
+  },
+  "publication": {
+    "posted_at": "2026-06-10T22:06:38.056Z",
+    "published_urls": [
+      "https://x.com/decodexspace/status/2064831630381027692",
+      "https://x.com/decodexspace/status/2064831633514201293",
+      "https://x.com/decodexspace/status/2064831637221999083",
+      "https://x.com/decodexspace/status/2064831640405463066",
+      "https://x.com/decodexspace/status/2064831644201369963",
+      "https://x.com/decodexspace/status/2064831648504676557",
+      "https://x.com/decodexspace/status/2064831650874503240"
+    ],
+    "publisher": "chrome",
+    "account_verified": true,
+    "made_with_ai": true,
+    "image_template": "decodex_signal_card"
+  },
+  "media_refs": [
+    "local_generated_image: /Users/x/.codex/decodex/social-media/x/2026-06-11/openai-codex-rust-v0-139-0-release-rollup/image.png",
+    "local_generated_sha256: 4b967d8fb372ebc4a470a9a1af278f7753ff0392de8a96fbaedd0e20d8fd09e2",
+    "x_photo_url: https://x.com/decodexspace/status/2064831630381027692/photo/1",
+    "x_media_url: https://pbs.twimg.com/media/HKfBC3vbYAAYbVR?format=jpg&name=medium"
+  ],
+  "caveats": [
+    "This thread is stable 0.139.0 release-scoped; it does not publish or analyze the later rust-v0.140.0-alpha.4 prerelease candidate, which remains deferred for upstream analysis.",
+    "Release-note bullets without checked Radar review in this tree remain release-note-scoped.",
+    "The live profile already contained an older alpha prerelease mention of standalone web search in code mode, so this thread should be read as stable-release coverage rather than first coverage of that individual feature.",
+    "The generated image file remains outside Git by policy; only the X media readback and local cache pointer are recorded here."
+  ],
+  "post_lifecycle": {
+    "current_state": "live",
+    "quote_eligible": false,
+    "reason": "This is a stable release rollup, not a prerelease quote-chain anchor."
+  }
+}

--- a/artifacts/social/x/reservations/2026-06-11/openai-codex-rust-v0-139-0-release-rollup.json
+++ b/artifacts/social/x/reservations/2026-06-11/openai-codex-rust-v0-139-0-release-rollup.json
@@ -1,0 +1,47 @@
+{
+  "schema": "social_publish_reservation/v1",
+  "slug": "openai-codex-rust-v0-139-0-release-rollup",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "release_rollup",
+  "status": "active",
+  "idempotency_key": "x:decodexspace:openai-codex-rust-v0-139-0:stable138-stable139:release_rollup",
+  "reserved_at": "2026-06-10T21:59:19Z",
+  "expires_at": "2026-06-10T23:59:18Z",
+  "day": "2026-06-11",
+  "timezone": "Asia/Shanghai",
+  "candidate_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-rust-v0-139-0-release-rollup.json"
+    ],
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://developers.openai.com/codex/changelog",
+      "https://github.com/openai/codex/releases/tag/rust-v0.139.0",
+      "https://github.com/openai/codex/compare/rust-v0.138.0...rust-v0.139.0"
+    ]
+  },
+  "duplicate_keys": [
+    "x:decodexspace:openai-codex-rust-v0-139-0:stable138-stable139:release_rollup",
+    "openai-codex-rust-v0-139-0-release-rollup",
+    "Codex CLI 0.139.0",
+    "rust-v0.139.0",
+    "https://github.com/openai/codex/releases/tag/rust-v0.139.0",
+    "https://github.com/openai/codex/compare/rust-v0.138.0...rust-v0.139.0"
+  ],
+  "owner": {
+    "automation_id": "decodex-x-publisher",
+    "branch": "codex/x-publisher-rust-v0-139-0-20260611"
+  },
+  "evidence_notes": [
+    "Checked durable social_post/v1 records contain no published or blocked record for this idempotency key.",
+    "Checked durable social_publish_reservation/v1 records contain no active reservation for this idempotency key before this reservation.",
+    "Open GitHub PR readback found one pending 2026-06-11 publication record for openai-codex-pr-26486 and no pending record for rust-v0.139.0.",
+    "Asia/Shanghai cap day 2026-06-11 has one pending published @decodexspace post from PR #298 before this seven-post release-rollup attempt.",
+    "Live @decodexspace profile readback verified the account menu as @decodexspace and found no stable 0.139.0 lead, release URL, compare URL, candidate slug, or idempotency-subject duplicate across rendered recent profile posts.",
+    "The profile readback did find prior alpha-thread overlap for the generic feature phrase standalone web search in code mode, so final publication evidence must keep this stable release-rollup scoped to the 0.139.0 stable checkpoint."
+  ]
+}

--- a/artifacts/social/x/reservations/2026-06-11/openai-codex-rust-v0-139-0-release-rollup.json
+++ b/artifacts/social/x/reservations/2026-06-11/openai-codex-rust-v0-139-0-release-rollup.json
@@ -34,7 +34,8 @@
   ],
   "owner": {
     "automation_id": "decodex-x-publisher",
-    "branch": "codex/x-publisher-rust-v0-139-0-20260611"
+    "branch": "codex/x-publisher-rust-v0-139-0-20260611",
+    "pr_url": "https://github.com/hack-ink/decodex/pull/304"
   },
   "evidence_notes": [
     "Checked durable social_post/v1 records contain no published or blocked record for this idempotency key.",

--- a/artifacts/social/x/reservations/2026-06-11/openai-codex-rust-v0-139-0-release-rollup.json
+++ b/artifacts/social/x/reservations/2026-06-11/openai-codex-rust-v0-139-0-release-rollup.json
@@ -5,7 +5,7 @@
   "target_account": "decodexspace",
   "controller_account": "hackink",
   "mode": "release_rollup",
-  "status": "active",
+  "status": "consumed",
   "idempotency_key": "x:decodexspace:openai-codex-rust-v0-139-0:stable138-stable139:release_rollup",
   "reserved_at": "2026-06-10T21:59:19Z",
   "expires_at": "2026-06-10T23:59:18Z",
@@ -37,6 +37,7 @@
     "branch": "codex/x-publisher-rust-v0-139-0-20260611",
     "pr_url": "https://github.com/hack-ink/decodex/pull/304"
   },
+  "consumed_by_social_post": "artifacts/social/x/posts/2026-06-11/openai-codex-rust-v0-139-0-release-rollup.json",
   "evidence_notes": [
     "Checked durable social_post/v1 records contain no published or blocked record for this idempotency key.",
     "Checked durable social_publish_reservation/v1 records contain no active reservation for this idempotency key before this reservation.",


### PR DESCRIPTION
## Summary
- add a thin social_publish_reservation/v1 for the Codex CLI 0.139.0 stable release rollup candidate
- publish the seven-post @decodexspace release_rollup thread with generated decodex_signal_card media
- consume the reservation and persist the terminal social_post/v1 record

## Publication
- lead URL: https://x.com/decodexspace/status/2064831630381027692
- thread URLs:
  - https://x.com/decodexspace/status/2064831630381027692
  - https://x.com/decodexspace/status/2064831633514201293
  - https://x.com/decodexspace/status/2064831637221999083
  - https://x.com/decodexspace/status/2064831640405463066
  - https://x.com/decodexspace/status/2064831644201369963
  - https://x.com/decodexspace/status/2064831648504676557
  - https://x.com/decodexspace/status/2064831650874503240
- media readback: https://x.com/decodexspace/status/2064831630381027692/photo/1
- local media cache: /Users/x/.codex/decodex/social-media/x/2026-06-11/openai-codex-rust-v0-139-0-release-rollup/image.png
- media sha256: 4b967d8fb372ebc4a470a9a1af278f7753ff0392de8a96fbaedd0e20d8fd09e2

## Validation
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x -> OK (83 Radar artifact JSON files validated)

## Notes
- Pending PR #298 counts as one 2026-06-11 Asia/Shanghai publication for cap accounting; this seven-post thread moves the day to 8/8.
- Live @decodexspace duplicate readbacks found no stable 0.139.0 release duplicate before publication.
- No codex or codex-automation labels exist in this repository, so no automation labels were applied.