### PR TITLE
Remove fixed route header icon

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -374,21 +374,6 @@ struct AccountPanelView: View {
 					help: "Open Decodex WebUI"
 				)
 
-				if hasFixedSelection {
-					PanelIconButtonView(
-						symbol: "shuffle",
-						tint: PanelPalette.actionBlue(colorScheme),
-						isActive: false,
-						action: {
-							Task {
-								await store.clearSelection()
-							}
-						},
-						help: "Restore balanced run routing"
-					)
-					.transition(.opacity.combined(with: .scale(scale: 0.96)))
-				}
-
 				PanelIconButtonView(
 					symbol: "plus",
 					tint: PanelPalette.actionBlue(colorScheme),


### PR DESCRIPTION
## Summary
- remove the extra header shuffle icon shown when Decodex runs are pinned to one account
- keep the per-account route button selected state as the routing indicator and reset affordance

## Verification
- git diff --check
- swift test --package-path apps/decodex-app
- apps/decodex-app/script/build_and_run.sh stage
- cargo make test-decodex-app-stage