### PR TITLE
Persist Codex alpha7 release checkpoint defer

### DIFF
--- a/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-7-needs-upstream-analysis.json
+++ b/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-7-needs-upstream-analysis.json
@@ -1,0 +1,94 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-rust-v0-140-0-alpha-7-needs-upstream-analysis",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "watch_note",
+  "priority": "normal",
+  "audience": "Codex operators tracking prerelease changes before stable",
+  "candidate_text": [
+    "No 0.140.0-alpha.7 post handoff yet.\n\nalpha.4 -> alpha.7 has 14 commits and 17 PR-title refs, but the release body is sparse and all 17 PRs lack checked Decodex review/impact.\n\nSource: https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.7"
+  ],
+  "source_refs": {
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://developers.openai.com/codex/changelog",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.4",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.7",
+      "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.4...rust-v0.140.0-alpha.7",
+      "https://github.com/openai/codex/pull/26091",
+      "https://github.com/openai/codex/pull/26409",
+      "https://github.com/openai/codex/pull/27057",
+      "https://github.com/openai/codex/pull/27058",
+      "https://github.com/openai/codex/pull/27059",
+      "https://github.com/openai/codex/pull/27062",
+      "https://github.com/openai/codex/pull/27064",
+      "https://github.com/openai/codex/pull/27065",
+      "https://github.com/openai/codex/pull/27070",
+      "https://github.com/openai/codex/pull/27071",
+      "https://github.com/openai/codex/pull/27311",
+      "https://github.com/openai/codex/pull/27312",
+      "https://github.com/openai/codex/pull/27319",
+      "https://github.com/openai/codex/pull/27321",
+      "https://github.com/openai/codex/pull/27343",
+      "https://github.com/openai/codex/pull/27414",
+      "https://github.com/openai/codex/pull/27439"
+    ]
+  },
+  "evidence_notes": [
+    "GitHub release metadata shows rust-v0.140.0-alpha.7 was published at 2026-06-10T22:45:37Z with only a sparse release body: Release 0.140.0-alpha.7.",
+    "GitHub release metadata has no release object for rust-v0.140.0-alpha.5 or rust-v0.140.0-alpha.6 in this run's readback, so this record treats rust-v0.140.0-alpha.7 as the next public prerelease release checkpoint after rust-v0.140.0-alpha.4.",
+    "The correct public prerelease comparison for this checkpoint is rust-v0.140.0-alpha.4 -> rust-v0.140.0-alpha.7; GitHub compare metadata reports 14 ahead commits and 17 PR-title references.",
+    "PR-title metadata in the alpha.4 -> alpha.7 compare points to Guardian auto-review retries, external-agent import UX and /import command work, plugin install elicitation metadata, OTEL instrumentation, remote-plugin curated discovery, disabled MCP server overlay preservation, realtime assistant forwarding, release artifact staging, and release/test tooling.",
+    "Checked Radar review/impact artifacts are absent for all 17 PR-title references in the alpha.4 -> alpha.7 compare window in this checkout.",
+    "The refreshed checked release_delta/v1 records stable rust-v0.139.0 -> latest prerelease rust-v0.140.0-alpha.7 with 67 ahead commits and no tracked signal slugs.",
+    "Official Codex changelog readback for this run still shows Codex app 26.608 and ChatGPT for iOS 1.2026.153 on 2026-06-09 as the newest entries; rust-v0.140.0-alpha.7 is a GitHub prerelease checkpoint, not an official changelog entry."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.140.0-alpha.7 is a real OpenAI Codex prerelease checkpoint.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.7",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The correct public prerelease comparison for this checkpoint is rust-v0.140.0-alpha.4 -> rust-v0.140.0-alpha.7.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.4...rust-v0.140.0-alpha.7",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The alpha.7 release body is sparse and does not describe user-facing behavior beyond the version checkpoint.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.7",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "PR-title metadata in the alpha.7 compare points to Guardian, external-agent import, plugin, OTEL, MCP overlay, realtime, release-staging, and test/tooling areas.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.4...rust-v0.140.0-alpha.7",
+      "confidence": "likely"
+    },
+    {
+      "text": "Behavior claims for the alpha.7 window require upstream source review before a publishable Decodex prerelease thread.",
+      "evidence": "artifacts/github/reviews/",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "defer",
+    "reason": "needs_upstream_analysis: the alpha.7 release body is sparse and the adjacent alpha.4 -> alpha.7 compare has unreviewed PR-title gaps.",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-140-0-alpha-7:alpha4-alpha7:defer"
+  },
+  "caveats": [
+    "This is a terminal defer / needs_upstream_analysis checkpoint record, not a publication request.",
+    "No previous live and quote-eligible @decodexspace 0.140 prerelease post exists; alpha.2 and alpha.4 were also recorded as defer / needs_upstream_analysis checkpoints.",
+    "Do not compare later 0.140 prereleases against stable 0.139.0 or alpha.4 if a newer public prerelease checkpoint exists; later 0.140 prereleases should use adjacent prerelease-to-prerelease lineage from alpha.7.",
+    "Exact source-review gap list for alpha.4 -> alpha.7 primary compare PRs: #26091, #26409, #27057, #27058, #27059, #27062, #27064, #27065, #27070, #27071, #27311, #27312, #27319, #27321, #27343, #27414, #27439.",
+    "Media caveat: no generated image is attached by this downstream artifact-consumer run. If this checkpoint later becomes publishable, decodex-x-publisher should generate and verify candidate-specific media only when it adds reader value."
+  ],
+  "next_steps": [
+    "Do not hand this alpha.7 defer record to decodex-x-publisher.",
+    "Route the listed source-review gap PRs to codex-upstream-radar-review / codex-code-analysis before turning alpha.7 into a release_rollup, watch_note, delta_explainer, or operator_impact post.",
+    "Use the refreshed release_delta/v1 only as stable-to-latest-prerelease site metadata; use adjacent prerelease-to-prerelease lineage for future 0.140 prereleases after alpha.7."
+  ]
+}

--- a/site/src/content/release-deltas/openai-codex-latest.json
+++ b/site/src/content/release-deltas/openai-codex-latest.json
@@ -1,6 +1,6 @@
 {
   "compare": {
-    "ahead_by": 54,
+    "ahead_by": 67,
     "commit_shas": [
       "dffc4bf75dc9eeb0727f668c95bb7bd72315581d",
       "14660c22d14312c28a50c52954dd77dd88f03c26",
@@ -55,7 +55,20 @@
       "3691fe5b76ccfa84835936c63efffb053dc8e6c6",
       "636cc11398b805a9ad89a4ce2b45ded2feb59567",
       "42415443d036c374eb848caec69b5714e9681b35",
-      "ea113fc404c952ee30e3cb791740f676de61e6db"
+      "ccf1a185180428727cffbdd9bd4eaaab2dc218ef",
+      "72667f4f41ec5515096ea5676b09cd3c01e6c866",
+      "020bf49346efa6c781726c86eda2a59ff415a712",
+      "2e377ce5e5bc3da1ca2b133496cbccab3a3d2c01",
+      "13468115fc6443970b8bf521927fceaf58ad35c1",
+      "e3528434cdfb9b822057095c7edbf4c99363f709",
+      "1deae7bd4a1212f94ec5b877fc4c9d7edea644f1",
+      "b4445f275838981bfd22429c5c41f2c5be0bde7a",
+      "7011044c1c0f51185eee007b45f0f42140fa794c",
+      "980f60b6641c5907c16db3c39f36ac113e15c93d",
+      "387adc6c4bc484aefb658a6006ad0a26fc45c79b",
+      "22dd6ebc7d3abe50d8aa40be3025eccd9c166418",
+      "7e5e41daea443bac9df2af36d86a5332efa7b4d7",
+      "90328c9a13b3c399026ca805b9d769d5744464c1"
     ],
     "pr_numbers": [
       22685,
@@ -64,6 +77,7 @@
       25018,
       25147,
       26041,
+      26409,
       26420,
       26479,
       26681,
@@ -77,8 +91,13 @@
       26880,
       27007,
       27031,
+      27057,
+      27062,
       27063,
       27064,
+      27065,
+      27070,
+      27071,
       27078,
       27080,
       27085,
@@ -105,21 +124,28 @@
       27285,
       27299,
       27304,
+      27311,
+      27312,
       27315,
+      27319,
+      27321,
+      27343,
       27375,
       27383,
       27391,
       27407,
-      27421
+      27414,
+      27421,
+      27439
     ],
     "status": "diverged",
-    "total_commits": 54,
-    "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.4"
+    "total_commits": 67,
+    "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.7"
   },
   "comparisons": [
     {
       "compare": {
-        "ahead_by": 54,
+        "ahead_by": 67,
         "commit_shas": [
           "dffc4bf75dc9eeb0727f668c95bb7bd72315581d",
           "14660c22d14312c28a50c52954dd77dd88f03c26",
@@ -174,7 +200,20 @@
           "3691fe5b76ccfa84835936c63efffb053dc8e6c6",
           "636cc11398b805a9ad89a4ce2b45ded2feb59567",
           "42415443d036c374eb848caec69b5714e9681b35",
-          "ea113fc404c952ee30e3cb791740f676de61e6db"
+          "ccf1a185180428727cffbdd9bd4eaaab2dc218ef",
+          "72667f4f41ec5515096ea5676b09cd3c01e6c866",
+          "020bf49346efa6c781726c86eda2a59ff415a712",
+          "2e377ce5e5bc3da1ca2b133496cbccab3a3d2c01",
+          "13468115fc6443970b8bf521927fceaf58ad35c1",
+          "e3528434cdfb9b822057095c7edbf4c99363f709",
+          "1deae7bd4a1212f94ec5b877fc4c9d7edea644f1",
+          "b4445f275838981bfd22429c5c41f2c5be0bde7a",
+          "7011044c1c0f51185eee007b45f0f42140fa794c",
+          "980f60b6641c5907c16db3c39f36ac113e15c93d",
+          "387adc6c4bc484aefb658a6006ad0a26fc45c79b",
+          "22dd6ebc7d3abe50d8aa40be3025eccd9c166418",
+          "7e5e41daea443bac9df2af36d86a5332efa7b4d7",
+          "90328c9a13b3c399026ca805b9d769d5744464c1"
         ],
         "pr_numbers": [
           22685,
@@ -183,6 +222,7 @@
           25018,
           25147,
           26041,
+          26409,
           26420,
           26479,
           26681,
@@ -196,8 +236,13 @@
           26880,
           27007,
           27031,
+          27057,
+          27062,
           27063,
           27064,
+          27065,
+          27070,
+          27071,
           27078,
           27080,
           27085,
@@ -224,18 +269,25 @@
           27285,
           27299,
           27304,
+          27311,
+          27312,
           27315,
+          27319,
+          27321,
+          27343,
           27375,
           27383,
           27391,
           27407,
-          27421
+          27414,
+          27421,
+          27439
         ],
         "status": "diverged",
-        "total_commits": 54,
-        "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.4"
+        "total_commits": 67,
+        "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.7"
       },
-      "prerelease_tag_name": "rust-v0.140.0-alpha.4",
+      "prerelease_tag_name": "rust-v0.140.0-alpha.7",
       "stable_tag_name": "rust-v0.139.0",
       "tracked_signal_slugs": []
     },
@@ -10044,22 +10096,22 @@
       ]
     }
   ],
-  "generated_at": "2026-06-10T20:27:03.122542Z",
+  "generated_at": "2026-06-11T02:27:53.122626Z",
   "prerelease": {
-    "name": "0.140.0-alpha.4",
+    "name": "0.140.0-alpha.7",
     "prerelease": true,
-    "published_at": "2026-06-10T19:46:17Z",
-    "tag_name": "rust-v0.140.0-alpha.4",
-    "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.4"
+    "published_at": "2026-06-10T22:45:37Z",
+    "tag_name": "rust-v0.140.0-alpha.7",
+    "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.7"
   },
   "release_options": {
     "preview": [
       {
-        "name": "0.140.0-alpha.4",
+        "name": "0.140.0-alpha.7",
         "prerelease": true,
-        "published_at": "2026-06-10T19:46:17Z",
-        "tag_name": "rust-v0.140.0-alpha.4",
-        "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.4"
+        "published_at": "2026-06-10T22:45:37Z",
+        "tag_name": "rust-v0.140.0-alpha.7",
+        "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.7"
       },
       {
         "name": "0.139.0-alpha.3",


### PR DESCRIPTION
## Summary
- refresh `release_delta/v1` to the latest observed OpenAI Codex prerelease `rust-v0.140.0-alpha.7`
- add a `social_candidate/v1` defer / needs_upstream_analysis checkpoint for `alpha.7`
- preserve adjacent prerelease lineage as `rust-v0.140.0-alpha.4 -> rust-v0.140.0-alpha.7`

## Decision
- mode: `watch_note`
- worthiness: `defer`
- reason: sparse prerelease body plus unreviewed PR-title gaps in the adjacent compare window

## Evidence
- GitHub release metadata: `rust-v0.140.0-alpha.7`, published `2026-06-10T22:45:37Z`
- adjacent compare: `rust-v0.140.0-alpha.4...rust-v0.140.0-alpha.7`, 14 commits, 17 PR-title refs
- official Codex changelog still tops out at 2026-06-09 app/mobile entries for this run

## Validation
- `cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates site/src/content/release-deltas`
- `cargo make check-site-content`
- `git diff --cached --check`

## Caveat
This is not a publishable X handoff. Route the listed PR gaps to upstream Radar/code analysis before producing a release rollup, delta explainer, or operator-impact post.
