### PR TITLE
XY-908: Document no-compat release gate for review config

### DIFF
--- a/docs/runbook/release-readiness.md
+++ b/docs/runbook/release-readiness.md
@@ -38,7 +38,9 @@ Collect evidence in this order:
    ```
 
 3. Scan checked-in docs, skills, examples, and config templates for historical review
-   config fields. The literal old field names may appear only in migration history.
+   config fields. The literal old field names `internal_review_mode` and
+   `external_review_enabled` may appear only in migration history, and they must not
+   appear in active project configs, examples, templates, or release procedures.
 4. Run the registered project gate before any pushed PR head. This mirrors the
    registered `WORKFLOW.md` order: canonicalize first, then verify.
 
@@ -58,7 +60,10 @@ Collect evidence in this order:
 
 7. Run focused loop, review, config, prompt, dry-run, and recovery checks selected
    from the landed dependency changes. At minimum include review-level and config
-   coverage:
+   coverage. Text search from step 3 is not sufficient: the release evidence must
+   show the active project config parser rejects `internal_review_mode` and
+   `external_review_enabled`, while the current `[codex].review` model remains
+   covered by review/config tests.
 
    ```sh
    cargo test -p decodex review --all-features -- --test-threads=1

--- a/docs/runbook/release-readiness.md
+++ b/docs/runbook/release-readiness.md
@@ -38,10 +38,10 @@ Collect evidence in this order:
    ```
 
 3. Scan checked-in docs, skills, examples, and config templates for historical review
-   config fields. Because this gate names the removed keys to define the check, allow
-   `internal_review_mode` and `external_review_enabled` here and in migration history
-   only. They must not appear in active project configs, examples, templates, or other
-   release procedures.
+   config fields. Because this bullet names the removed keys to define the check,
+   allow `internal_review_mode` and `external_review_enabled` in this bullet and in
+   migration history only. They must not appear in active project configs, examples,
+   templates, or other release procedures.
 4. Run the registered project gate before any pushed PR head. This mirrors the
    registered `WORKFLOW.md` order: canonicalize first, then verify.
 
@@ -62,9 +62,8 @@ Collect evidence in this order:
 7. Run focused loop, review, config, prompt, dry-run, and recovery checks selected
    from the landed dependency changes. At minimum include review-level and config
    coverage. Text search from step 3 is not sufficient: the release evidence must
-   show the active project config parser rejects `internal_review_mode` and
-   `external_review_enabled`, while the current `[codex].review` model remains
-   covered by review/config tests.
+   show the active project config parser rejects those removed fields, while the
+   current `[codex].review` model remains covered by review/config tests.
 
    ```sh
    cargo test -p decodex review --all-features -- --test-threads=1

--- a/docs/runbook/release-readiness.md
+++ b/docs/runbook/release-readiness.md
@@ -38,9 +38,10 @@ Collect evidence in this order:
    ```
 
 3. Scan checked-in docs, skills, examples, and config templates for historical review
-   config fields. The literal old field names `internal_review_mode` and
-   `external_review_enabled` may appear only in migration history, and they must not
-   appear in active project configs, examples, templates, or release procedures.
+   config fields. Because this gate names the removed keys to define the check, allow
+   `internal_review_mode` and `external_review_enabled` here and in migration history
+   only. They must not appear in active project configs, examples, templates, or other
+   release procedures.
 4. Run the registered project gate before any pushed PR head. This mirrors the
    registered `WORKFLOW.md` order: canonicalize first, then verify.
 


### PR DESCRIPTION
## Summary
- Document the no-compat release gate for removed review config fields in docs/runbook/release-readiness.md.
- Require release evidence to pair text scanning with active parser rejection and config/review test evidence.

## Verification
- cargo test -p decodex config --all-features -- --test-threads=1
- cargo make fmt
- cargo make lint-fix
- cargo make test