### PR TITLE
Bump Decodex plugin version to 0.2.0

### DIFF
--- a/apps/decodex-app/script/build_and_run.sh
+++ b/apps/decodex-app/script/build_and_run.sh
@@ -72,7 +72,7 @@ if [[ -z "$APP_VERSION" ]]; then
 			"$WORKTREE_ROOT/Cargo.toml" | head -n 1
 	)"
 fi
-APP_VERSION="${APP_VERSION:-0.1.0}"
+APP_VERSION="${APP_VERSION:-0.2.0}"
 
 terminate_running_app() {
 	pkill -x "$EXECUTABLE_NAME" >/dev/null 2>&1 || true

--- a/plugins/decodex/.codex-plugin/plugin.json
+++ b/plugins/decodex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "decodex",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Agent-facing workflows for Decodex research/design intake, planning, manual CLI use, and runtime-owned automation.",
   "author": {
     "name": "hack-ink",


### PR DESCRIPTION
## Summary
- bump the packaged Decodex Codex plugin manifest to 0.2.0
- align the Decodex app staging fallback version with the 0.2.0 release

## Validation
- jq . plugins/decodex/.codex-plugin/plugin.json
- cargo test -p decodex plugin_surface_tests::packaged_skills_preserve_research_promotion_and_queue_boundaries --all-features -- --test-threads=1
- plugin-eval analyze plugins/decodex --format json (91/B, no fail; only aggregate token-budget warnings)
- apps/decodex-app/script/build_and_run.sh stage
- staged app Info.plist CFBundleShortVersionString=0.2.0 and CFBundleVersion=0.2.0
- cargo make test-decodex-app-stage
- cargo make fmt
- git diff --check HEAD~1..HEAD

Landing: use Decodex/admin merge only; do not use merge queue.