### PR TITLE
Persist upstream Radar review artifacts

### DIFF
--- a/artifacts/github/bundles/openai-codex-pr-26409.json
+++ b/artifacts/github/bundles/openai-codex-pr-26409.json
@@ -1,0 +1,101 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "adaley-openai",
+      "committed_at": "2026-06-04T15:46:54Z",
+      "message": "Inject remote plugin identity into install elicitations",
+      "sha": "158fd3ea6eda3a6ee1ba95ad0de76f5cee4f0540",
+      "url": "https://github.com/openai/codex/commit/158fd3ea6eda3a6ee1ba95ad0de76f5cee4f0540"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "--check",
+    "MCP",
+    "REQUEST_PLUGIN_INSTALL_APPROVAL_KIND_VALUE",
+    "REQUEST_PLUGIN_INSTALL_PERSIST_ALWAYS_VALUE"
+  ],
+  "files": [
+    {
+      "additions": 3,
+      "deletions": 0,
+      "patch_excerpt": "@@ -64,6 +64,7 @@ pub struct ToolSuggestPluginDiscoveryInput {\n #[derive(Clone, Debug, PartialEq, Eq)]\n pub struct ToolSuggestDiscoverablePlugin {\n     pub id: String,\n+    pub remote_plugin_id: Option<String>,\n     pub name: String,\n     pub description: Option<String>,\n     pub has_skills: bool,\n@@ -145,6 +146,7 @@ impl PluginsManager {\n \n                         discoverable_plugins.push(ToolSuggestDiscoverablePlugin {\n                             id: plugin.config_name,\n+                            remote_plugin_id: None,\n                             name: plugin.display_name,\n                             description: plugin.description,\n                             has_skills: plugin.has_skills,\n@@ -200,6 +202,7 @@ impl PluginsManager {\n \n                 discoverable_plugins.push(ToolSuggestDiscoverablePlugin {\n                     id: plugin.config_id,\n+                    remote_...",
+      "path": "codex-rs/core-plugins/src/discoverable.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -41,6 +41,7 @@ pub(crate) async fn list_tool_suggest_discoverable_plugins(\n                 .into_iter()\n                 .map(|plugin| DiscoverablePluginInfo {\n                     id: plugin.id,\n+                    remote_plugin_id: plugin.remote_plugin_id,\n                     name: plugin.name,\n                     description: plugin.description,\n                     has_skills: plugin.has_skills,",
+      "path": "codex-rs/core/src/plugins/discoverable.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 0,
+      "patch_excerpt": "@@ -393,6 +393,7 @@ remote_plugin = true\n         remote_plugins,\n         vec![DiscoverablePluginInfo {\n             id: \"github@openai-curated-remote\".to_string(),\n+            remote_plugin_id: Some(\"plugins~Plugin_remote_github\".to_string()),\n             name: \"Remote GitHub\".to_string(),\n             description: Some(\"Remote GitHub short\".to_string()),\n             has_skills: true,\n@@ -680,6 +681,7 @@ async fn list_tool_suggest_discoverable_plugins_normalizes_description() {\n         discoverable_plugins,\n         vec![DiscoverablePluginInfo {\n             id: \"slack@openai-curated\".to_string(),\n+            remote_plugin_id: None,\n             name: \"slack\".to_string(),\n             description: Some(\"Plugin with extra spacing\".to_string()),\n             has_skills: true,\n@@ -816,6 +818,7 @@ discoverables = [{ type = \"plugin\", id = \"sample@openai-curated\" }]\n         discoverabl...",
+      "path": "codex-rs/core/src/plugins/discoverable_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -130,6 +130,7 @@ async fn persist_disabled_install_request_writes_plugin_config() {\n     let codex_home = tempdir().expect(\"tempdir should succeed\");\n     let tool = DiscoverableTool::Plugin(Box::new(DiscoverablePluginInfo {\n         id: \"slack@openai-curated\".to_string(),\n+        remote_plugin_id: None,\n         name: \"Slack\".to_string(),\n         description: None,\n         has_skills: true,",
+      "path": "codex-rs/core/src/tools/handlers/request_plugin_install_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -406,6 +406,7 @@ fn dynamic_tool(namespace: Option<&str>, name: &str, defer_loading: bool) -> Dyn\n fn discoverable_plugin(id: &str, name: &str) -> DiscoverableTool {\n     DiscoverablePluginInfo {\n         id: id.to_string(),\n+        remote_plugin_id: None,\n         name: name.to_string(),\n         description: Some(format!(\"{name} plugin\")),\n         has_skills: false,",
+      "path": "codex-rs/core/src/tools/spec_plan_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 18,
+      "deletions": 11,
+      "patch_excerpt": "@@ -47,6 +47,10 @@ pub struct RequestPluginInstallMeta<'a> {\n     pub tool_name: &'a str,\n     #[serde(skip_serializing_if = \"Option::is_none\")]\n     pub install_url: Option<&'a str>,\n+    #[serde(skip_serializing_if = \"Option::is_none\")]\n+    pub remote_plugin_id: Option<&'a str>,\n+    #[serde(skip_serializing_if = \"Option::is_none\")]\n+    pub app_connector_ids: Option<&'a [String]>,\n }\n \n pub fn build_request_plugin_install_elicitation_request(\n@@ -57,8 +61,6 @@ pub fn build_request_plugin_install_elicitation_request(\n     suggest_reason: &str,\n     tool: &DiscoverableTool,\n ) -> McpServerElicitationRequestParams {\n-    let tool_name = tool.name().to_string();\n-    let install_url = tool.install_url().map(ToString::to_string);\n     let message = suggest_reason.to_string();\n \n     McpServerElicitationRequestParams {\n@@ -70,9 +72,7 @@ pub fn build_request_plugin_install_elicitation_reque...",
+      "path": "codex-rs/tools/src/request_plugin_install.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 29,
+      "deletions": 7,
+      "patch_excerpt": "@@ -57,6 +57,8 @@ fn build_request_plugin_install_elicitation_request_uses_expected_shape() {\n                     install_url: Some(\n                         \"https://chatgpt.com/apps/google-calendar/connector_2128aebfecb84f64a069897515042a44\"\n                     ),\n+                    remote_plugin_id: None,\n+                    app_connector_ids: None,\n                 })),\n                 message: \"Plan and reference events from your calendar\".to_string(),\n                 requested_schema: McpElicitationSchema {\n@@ -71,15 +73,16 @@ fn build_request_plugin_install_elicitation_request_uses_expected_shape() {\n }\n \n #[test]\n-fn build_request_plugin_install_elicitation_request_for_plugin_omits_install_url() {\n+fn build_request_plugin_install_elicitation_request_injects_plugin_metadata() {\n     let args = RequestPluginInstallArgs {\n         tool_type: DiscoverableToolType::Plugin,\n    ...",
+      "path": "codex-rs/tools/src/request_plugin_install_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -93,6 +93,7 @@ pub fn filter_request_plugin_install_discoverable_tools_for_client(\n #[derive(Clone, Debug, PartialEq, Eq)]\n pub struct DiscoverablePluginInfo {\n     pub id: String,\n+    pub remote_plugin_id: Option<String>,\n     pub name: String,\n     pub description: Option<String>,\n     pub has_skills: bool,",
+      "path": "codex-rs/tools/src/tool_discovery.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -37,6 +37,7 @@ fn filter_request_plugin_install_discoverable_tools_for_codex_tui_omits_plugins(\n         })),\n         DiscoverableTool::Plugin(Box::new(DiscoverablePluginInfo {\n             id: \"slack@openai-curated\".to_string(),\n+            remote_plugin_id: None,\n             name: \"Slack\".to_string(),\n             description: Some(\"Search Slack messages\".to_string()),\n             has_skills: true,",
+      "path": "codex-rs/tools/src/tool_discovery_tests.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "Summary\n- Propagate cached remote plugin IDs through Codex plugin discovery.\n- Inject `remote_plugin_id` and connector IDs into `request_plugin_install` elicitation `_meta` from the resolved plugin.\n- Keep the remote plugin ID out of the model-facing tool schema, arguments, and result.\n\nValidation\n- `just test -p codex-tools`\n- `just test -p codex-core-plugins`\n- `just test -p codex-core list_tool_suggest_discoverable_plugins_includes_cached_remote_global_plugins`\n- `just fix -p codex-tools`\n- `just fix -p codex-core-plugins`\n- `just fix -p codex-core`\n- `git diff --check`\n- `just test -p codex-core` was also attempted: 2,581 passed, 55 failed, and 1 timed out across unrelated sandbox/environment-sensitive integration tests.",
+    "labels": [],
+    "merged_at": "2026-06-10T19:01:04Z",
+    "number": 26409,
+    "state": "merged",
+    "title": "[plugins] Inject remote_plugin_id into install elicitations",
+    "url": "https://github.com/openai/codex/pull/26409"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-26859.json
+++ b/artifacts/github/bundles/openai-codex-pr-26859.json
@@ -1,0 +1,157 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "ddr-oai",
+      "committed_at": "2026-06-07T07:23:49Z",
+      "message": "fix: Auto-recover from corrupted sqlite databases",
+      "sha": "57659383ec35538c75d4f35ea8348edd740a0435",
+      "url": "https://github.com/openai/codex/commit/57659383ec35538c75d4f35ea8348edd740a0435"
+    },
+    {
+      "author": "ddr-oai",
+      "committed_at": "2026-06-08T22:02:06Z",
+      "message": "PR feedback",
+      "sha": "bf636e08e83562fce57cdfd0ca64e0ebafec106f",
+      "url": "https://github.com/openai/codex/commit/bf636e08e83562fce57cdfd0ca64e0ebafec106f"
+    },
+    {
+      "author": "ddr-oai",
+      "committed_at": "2026-06-09T20:50:52Z",
+      "message": "pr feedback",
+      "sha": "186490d934d112d51c400dd54b7f5c887023cd0d",
+      "url": "https://github.com/openai/codex/commit/186490d934d112d51c400dd54b7f5c887023cd0d"
+    },
+    {
+      "author": "ddr-oai",
+      "committed_at": "2026-06-10T18:08:56Z",
+      "message": "PR feedback -- fixing auto recovery to ensure it doesn't recover non-hosed dbs",
+      "sha": "bc9a3b9cbc07d1ac22fad1f499c51568301884cd",
+      "url": "https://github.com/openai/codex/commit/bc9a3b9cbc07d1ac22fad1f499c51568301884cd"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "SQL",
+    "CLI",
+    "SQLITE_RECOVERY_CONFIG_WARNING_SUMMARY",
+    "CODEX_HOME",
+    "TUI",
+    "UNIX_EPOCH",
+    "SELECT",
+    "MAX",
+    "FROM",
+    "MEMORIES_DB",
+    "BACKUP_DIR_NAME"
+  ],
+  "files": [
+    {
+      "additions": 128,
+      "deletions": 2,
+      "patch_excerpt": "@@ -74,6 +74,8 @@ use tracing_subscriber::layer::SubscriberExt;\n use tracing_subscriber::registry::Registry;\n use tracing_subscriber::util::SubscriberInitExt;\n \n+const SQLITE_RECOVERY_CONFIG_WARNING_SUMMARY: &str = \"Codex rebuilt its local database.\";\n+\n mod analytics_utils;\n mod app_server_tracing;\n mod attestation;\n@@ -533,15 +535,24 @@ pub async fn run_main_with_transport_options(\n         }\n         _ => None,\n     };\n-    let state_db = match rollout_state_db::try_init(&config).await {\n-        Ok(state_db) => Some(state_db),\n+    let state_db_init = match init_sqlite_state_db_with_fresh_start_on_corruption(&config).await {\n+        Ok(state_db_init) => state_db_init,\n         Err(err) => {\n             return Err(std::io::Error::other(format!(\n                 \"failed to initialize sqlite state runtime under {}: {err}\",\n                 config.sqlite_home.display()\n             )))...",
+      "path": "codex-rs/app-server/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 2,
+      "patch_excerpt": "@@ -2141,8 +2141,9 @@ async fn state_check(config: &Config) -> DoctorCheck {\n     };\n     let mut check = DoctorCheck::new(\"state.paths\", \"state\", status, summary).details(details);\n     if status == CheckStatus::Fail {\n-        check = check\n-            .remediation(\"Back up CODEX_HOME, then remove or repair the affected SQLite database.\");\n+        check = check.remediation(\n+            \"Move the damaged SQLite database aside, then restart the interactive CLI or app server so it can rebuild that runtime database from saved data. Other entry points may not rebuild automatically.\",\n+        );\n     }\n     check\n }",
+      "path": "codex-rs/cli/src/doctor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 9,
+      "deletions": 8,
+      "patch_excerpt": "@@ -38,6 +38,7 @@ use codex_utils_cli::ProfileV2Name;\n use codex_utils_cli::SharedCliOptions;\n use codex_utils_cli::resume_hint;\n use owo_colors::OwoColorize;\n+use std::collections::HashSet;\n use std::io::IsTerminal;\n use std::path::PathBuf;\n use supports_color::Stream;\n@@ -2188,7 +2189,7 @@ async fn run_interactive_tui(\n             remote_endpoint.clone(),\n         )\n     };\n-    let mut attempted_repair = false;\n+    let mut attempted_backups = HashSet::new();\n     loop {\n         let err = match start_tui().await {\n             Ok(exit_info) => return Ok(exit_info),\n@@ -2201,25 +2202,25 @@ async fn run_interactive_tui(\n             local_state_db::print_locked_guidance(startup_error);\n             return Ok(AppExitInfo::fatal(startup_error.to_string()));\n         }\n-        if attempted_repair {\n+        if !local_state_db::is_auto_backup_recoverable(startup_error) {\n             loc...",
+      "path": "codex-rs/cli/src/main.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 84,
+      "deletions": 110,
+      "patch_excerpt": "@@ -1,77 +1,73 @@\n-//! CLI recovery for local state database startup failures.\n+//! CLI handling for local state database startup failures.\n //!\n-//! This keeps user-facing repair and lock-contention handling out of the main\n+//! This keeps user-facing backup and lock-contention handling out of the main\n //! CLI dispatch path while preserving the TUI startup error as the boundary type.\n \n+use codex_state::RuntimeDbBackup;\n use codex_tui::LocalStateDbStartupError;\n-use std::path::PathBuf;\n+use std::io::IsTerminal;\n+use std::path::Path;\n \n pub(crate) fn startup_error(err: &std::io::Error) -> Option<&LocalStateDbStartupError> {\n     err.get_ref()\n         .and_then(|err| err.downcast_ref::<LocalStateDbStartupError>())\n }\n \n pub(crate) fn is_locked(detail: &str) -> bool {\n-    let detail = detail.to_ascii_lowercase();\n-    detail.contains(\"database is locked\") || detail.contains(\"database is...",
+      "path": "codex-rs/cli/src/state_db_recovery.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 9,
+      "deletions": 5,
+      "patch_excerpt": "@@ -5,6 +5,7 @@ use crate::list::SortDirection;\n use crate::list::ThreadSortKey;\n use crate::metadata;\n use crate::sqlite_metrics;\n+use anyhow::Context;\n use chrono::DateTime;\n use chrono::Utc;\n use codex_protocol::ThreadId;\n@@ -50,7 +51,7 @@ pub async fn init(config: &impl RolloutConfigView) -> Option<StateDbHandle> {\n     {\n         Ok(runtime) => Some(runtime),\n         Err(err) => {\n-            emit_startup_warning(&format!(\"failed to initialize state runtime: {err}\"));\n+            emit_startup_warning(&format!(\"failed to initialize state runtime: {err:#}\"));\n             None\n         }\n     }\n@@ -109,9 +110,9 @@ async fn try_init_with_roots_inner(\n     let runtime =\n         codex_state::StateRuntime::init(sqlite_home.clone(), default_model_provider_id.clone())\n             .await\n-            .map_err(|err| {\n-                anyhow::anyhow!(\n-                    \"failed to init...",
+      "path": "codex-rs/rollout/src/state_db.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 6,
+      "deletions": 0,
+      "patch_excerpt": "@@ -57,15 +57,21 @@ pub use runtime::GoalStore;\n pub use runtime::GoalUpdate;\n pub use runtime::MemoryStore;\n pub use runtime::RemoteControlEnrollmentRecord;\n+pub use runtime::RuntimeDbBackup;\n pub use runtime::RuntimeDbPath;\n pub use runtime::ThreadFilterOptions;\n+pub use runtime::backup_runtime_db_for_fresh_start;\n pub use runtime::goals_db_filename;\n pub use runtime::goals_db_path;\n+pub use runtime::is_sqlite_corruption_error;\n pub use runtime::logs_db_filename;\n pub use runtime::logs_db_path;\n pub use runtime::memories_db_filename;\n pub use runtime::memories_db_path;\n+pub use runtime::runtime_db_path_for_corruption_error;\n pub use runtime::runtime_db_paths;\n+pub use runtime::sqlite_error_detail_is_corruption;\n+pub use runtime::sqlite_error_detail_is_lock;\n pub use runtime::sqlite_integrity_check;\n pub use runtime::state_db_filename;\n pub use runtime::state_db_path;",
+      "path": "codex-rs/state/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 53,
+      "deletions": 4,
+      "patch_excerpt": "@@ -62,6 +62,7 @@ mod backfill;\n mod goals;\n mod logs;\n mod memories;\n+mod recovery;\n mod remote_control;\n #[cfg(test)]\n mod test_support;\n@@ -72,6 +73,12 @@ pub use goals::GoalAccountingOutcome;\n pub use goals::GoalStore;\n pub use goals::GoalUpdate;\n pub use memories::MemoryStore;\n+pub use recovery::RuntimeDbBackup;\n+pub use recovery::backup_runtime_db_for_fresh_start;\n+pub use recovery::is_sqlite_corruption_error;\n+pub use recovery::runtime_db_path_for_corruption_error;\n+pub use recovery::sqlite_error_detail_is_corruption;\n+pub use recovery::sqlite_error_detail_is_lock;\n pub use remote_control::RemoteControlEnrollmentRecord;\n pub use threads::ThreadFilterOptions;\n \n@@ -200,6 +207,7 @@ impl StateRuntime {\n             Ok(db) => Arc::new(db),\n             Err(err) => {\n                 warn!(\"failed to open logs db at {}: {err}\", logs_path.display());\n+                close_sqlite_pools(...",
+      "path": "codex-rs/state/src/runtime.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 4,
+      "deletions": 0,
+      "patch_excerpt": "@@ -11,6 +11,10 @@ impl GoalStore {\n     pub(crate) fn new(pool: Arc<SqlitePool>) -> Self {\n         Self { pool }\n     }\n+\n+    pub(crate) async fn close(&self) {\n+        self.pool.close().await;\n+    }\n }\n \n pub struct GoalUpdate {",
+      "path": "codex-rs/state/src/runtime/goals.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 4,
+      "deletions": 0,
+      "patch_excerpt": "@@ -35,6 +35,10 @@ impl MemoryStore {\n         Self { pool, state_pool }\n     }\n \n+    pub(crate) async fn close(&self) {\n+        self.pool.close().await;\n+    }\n+\n     /// Deletes all persisted memory state in one transaction.\n     ///\n     /// This removes every `stage1_outputs` row and all `jobs` rows for the",
+      "path": "codex-rs/state/src/runtime/memories.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 243,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,243 @@\n+//! Backup-and-rebuild support for Codex runtime SQLite databases.\n+//!\n+//! Codex keeps several independent runtime SQLite databases under one SQLite\n+//! home. When SQLite reports that one of them is corrupt, automatic recovery\n+//! moves only that database file and its sidecars into a backup folder so the\n+//! other databases keep their data.\n+\n+use std::borrow::Cow;\n+use std::path::Path;\n+use std::path::PathBuf;\n+\n+const BACKUP_DIR_NAME: &str = \"db-backups\";\n+\n+#[derive(Clone, Debug, Eq, PartialEq)]\n+pub struct RuntimeDbBackup {\n+    /// Path where the runtime database or sidecar lived before it was moved.\n+    pub original_path: PathBuf,\n+    /// Path where the runtime database or sidecar was backed up.\n+    pub backup_path: PathBuf,\n+}\n+\n+#[derive(Debug)]\n+pub(crate) struct RuntimeDbInitError {\n+    label: &'static str,\n+    operation: &'static str,\n+    path: Pa...",
+      "path": "codex-rs/state/src/runtime/recovery.rs",
+      "status": "added"
+    },
+    {
+      "additions": 105,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,105 @@\n+use super::*;\n+use crate::runtime::test_support::unique_temp_dir;\n+use pretty_assertions::assert_eq;\n+\n+#[tokio::test]\n+async fn backup_moves_only_requested_runtime_db_files_to_backup_folder() -> std::io::Result<()> {\n+    let sqlite_home = unique_temp_dir();\n+    tokio::fs::create_dir_all(sqlite_home.as_path()).await?;\n+    let runtime_paths = super::super::runtime_db_paths(sqlite_home.as_path());\n+    let mut expected_paths = Vec::new();\n+    for db_path in runtime_paths.iter().map(|db| db.path.as_path()) {\n+        for path in sqlite_paths(db_path) {\n+            tokio::fs::write(path.as_path(), path.display().to_string()).await?;\n+            expected_paths.push(path);\n+        }\n+    }\n+    let failed_db_path = super::super::logs_db_path(sqlite_home.as_path());\n+    let failed_paths = sqlite_paths(failed_db_path.as_path());\n+\n+    let backups = backup_runtime_db_f...",
+      "path": "codex-rs/state/src/runtime/recovery_tests.rs",
+      "status": "added"
+    },
+    {
+      "additions": 35,
+      "deletions": 2,
+      "patch_excerpt": "@@ -352,9 +352,11 @@ async fn init_state_db_for_app_server_target(\n ) -> std::io::Result<Option<StateDbHandle>> {\n     match app_server_target {\n         AppServerTarget::Embedded => state_db::try_init(config).await.map(Some).map_err(|err| {\n+            let database_path = codex_state::runtime_db_path_for_corruption_error(&err)\n+                .unwrap_or_else(|| codex_state::state_db_path(config.sqlite_home.as_path()));\n             std::io::Error::other(LocalStateDbStartupError::new(\n-                codex_state::state_db_path(config.sqlite_home.as_path()),\n-                err.to_string(),\n+                database_path,\n+                format!(\"{err:#}\"),\n             ))\n         }),\n         AppServerTarget::LocalDaemon { .. } | AppServerTarget::Remote { .. } => {\n@@ -2990,6 +2992,37 @@ mod tests {\n         );\n         Ok(())\n     }\n+\n+    #[tokio::test]\n+    async fn embedded_sta...",
+      "path": "codex-rs/tui/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 10,
+      "deletions": 6,
+      "patch_excerpt": "@@ -3,24 +3,28 @@ use std::path::PathBuf;\n \n #[derive(Debug, thiserror::Error)]\n #[error(\n-    \"failed to initialize sqlite state db at {}: {detail}\",\n-    state_db_path.display()\n+    \"failed to initialize sqlite local db at {}: {detail}\",\n+    database_path.display()\n )]\n pub struct LocalStateDbStartupError {\n-    state_db_path: PathBuf,\n+    database_path: PathBuf,\n     detail: String,\n }\n \n impl LocalStateDbStartupError {\n-    pub fn new(state_db_path: PathBuf, detail: String) -> Self {\n+    pub fn new(database_path: PathBuf, detail: String) -> Self {\n         Self {\n-            state_db_path,\n+            database_path,\n             detail,\n         }\n     }\n \n+    pub fn database_path(&self) -> &Path {\n+        self.database_path.as_path()\n+    }\n+\n     pub fn state_db_path(&self) -> &Path {\n-        self.state_db_path.as_path()\n+        self.database_path()\n     }\n \n     pub fn d...",
+      "path": "codex-rs/tui/src/startup_error.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "Further investigation of the sqlite incidents showed that the problems are due to corruption from the older version of SQLite that we recently upgraded, and that the data is truly corrupted in the root database -- recovery of all data is not possible.  Given that the data is reconstructable from the rollouts on disk, we should just auto-backup the database and let codex rebuild the rollout info from the disk rollouts.\r\n\r\nThe new behavior is that appserver auto-backs-up and rebuilds (with logs reflecting that behavior).  The CLI now pops a message letting you know this happened and the paths of the backed-up corrupt db and the new database.  There is also context added so that the desktop app can read the rebuild info from it and inform the user with it.\r\n",
+    "labels": [],
+    "merged_at": "2026-06-10T18:24:29Z",
+    "number": 26859,
+    "state": "merged",
+    "title": "fix: Auto-recover from corrupted sqlite databases",
+    "url": "https://github.com/openai/codex/pull/26859"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27064.json
+++ b/artifacts/github/bundles/openai-codex-pr-27064.json
@@ -1,0 +1,108 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "stefanstokic-oai",
+      "committed_at": "2026-06-08T18:35:04Z",
+      "message": "tui: remove startup external agent migration",
+      "sha": "d0dcb2a19f0ed125bb8dbdfc61fdadc346667b59",
+      "url": "https://github.com/openai/codex/commit/d0dcb2a19f0ed125bb8dbdfc61fdadc346667b59"
+    },
+    {
+      "author": "stefanstokic-oai",
+      "committed_at": "2026-06-09T15:00:57Z",
+      "message": "Merge main and remove unused migration code",
+      "sha": "c7e1523503f1e1f9f979e686d34fa31133cba194",
+      "url": "https://github.com/openai/codex/commit/c7e1523503f1e1f9f979e686d34fa31133cba194"
+    },
+    {
+      "author": "stefanstokic-oai",
+      "committed_at": "2026-06-09T15:08:36Z",
+      "message": "tui: preserve migration picker for stacked flow",
+      "sha": "52c6ed6ff8e71895aa6fe067bf99521f37265a89",
+      "url": "https://github.com/openai/codex/commit/52c6ed6ff8e71895aa6fe067bf99521f37265a89"
+    },
+    {
+      "author": "stefanstokic-oai",
+      "committed_at": "2026-06-10T17:56:21Z",
+      "message": "Merge main and resolve feature test conflict",
+      "sha": "ac05fffdb3bd224c28cb6819e288ae43b09ac1e5",
+      "url": "https://github.com/openai/codex/commit/ac05fffdb3bd224c28cb6819e288ae43b09ac1e5"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "TUI",
+    "--config",
+    "FEATURES",
+    "UNIX_EPOCH",
+    "EXTERNAL_CONFIG_MIGRATION_PROMPT_COOLDOWN_SECS",
+    "NUX"
+  ],
+  "files": [
+    {
+      "additions": 2,
+      "deletions": 6,
+      "patch_excerpt": "@@ -177,7 +177,7 @@ pub enum Feature {\n     RemotePlugin,\n     /// Enable remote plugin sharing flows.\n     PluginSharing,\n-    /// Show the startup prompt for migrating external agent config into Codex.\n+    /// Removed compatibility flag retained as a no-op.\n     ExternalMigration,\n     /// Allow the model to invoke the built-in image generation tool.\n     ImageGeneration,\n@@ -1071,11 +1071,7 @@ pub const FEATURES: &[FeatureSpec] = &[\n     FeatureSpec {\n         id: Feature::ExternalMigration,\n         key: \"external_migration\",\n-        stage: Stage::Experimental {\n-            name: \"External migration\",\n-            menu_description: \"Show a startup prompt when Codex detects migratable external agent config for this machine or project.\",\n-            announcement: \"\",\n-        },\n+        stage: Stage::Removed,\n         default_enabled: false,\n     },\n     FeatureSpec {",
+      "path": "codex-rs/features/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 10,
+      "deletions": 17,
+      "patch_excerpt": "@@ -83,6 +83,16 @@ fn plugin_hooks_is_removed_and_disabled_by_default() {\n     assert_eq!(feature_for_key(\"plugin_hooks\"), Some(Feature::PluginHooks));\n }\n \n+#[test]\n+fn external_migration_is_removed_and_disabled_by_default() {\n+    assert_eq!(Feature::ExternalMigration.stage(), Stage::Removed);\n+    assert_eq!(Feature::ExternalMigration.default_enabled(), false);\n+    assert_eq!(\n+        feature_for_key(\"external_migration\"),\n+        Some(Feature::ExternalMigration)\n+    );\n+}\n+\n #[test]\n fn removed_apps_mcp_path_override_shapes_are_ignored() {\n     let features = [\n@@ -122,23 +132,6 @@ fn guardian_approval_is_stable_and_enabled_by_default() {\n     assert_eq!(Feature::GuardianApproval.default_enabled(), true);\n }\n \n-#[test]\n-fn external_migration_is_experimental_and_disabled_by_default() {\n-    let spec = Feature::ExternalMigration.info();\n-    let stage = spec.stage;\n-\n-    assert!(m...",
+      "path": "codex-rs/features/src/tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 40,
+      "patch_excerpt": "@@ -37,8 +37,6 @@ use crate::cwd_prompt::CwdPromptAction;\n use crate::diff_render::DiffSummary;\n use crate::exec_command::split_command_string;\n use crate::exec_command::strip_bash_lc_and_escape;\n-use crate::external_agent_config_migration_startup::ExternalAgentConfigMigrationStartupOutcome;\n-use crate::external_agent_config_migration_startup::handle_external_agent_config_migration_prompt_if_needed;\n use crate::external_editor;\n use crate::file_search::FileSearchManager;\n use crate::history_cell;\n@@ -764,7 +762,6 @@ impl App {\n         session_selection: SessionSelection,\n         feedback: codex_feedback::CodexFeedback,\n         is_first_run: bool,\n-        entered_trust_nux: bool,\n         should_prompt_windows_sandbox_nux_at_startup: bool,\n         app_server_target: AppServerTarget,\n         state_db: Option<StateDbHandle>,\n@@ -786,39 +783,6 @@ impl App {\n \n         let harness_overr...",
+      "path": "codex-rs/tui/src/app.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 30,
+      "patch_excerpt": "@@ -22,11 +22,6 @@ use codex_app_server_protocol::AuthMode;\n use codex_app_server_protocol::ClientRequest;\n use codex_app_server_protocol::ConfigBatchWriteParams;\n use codex_app_server_protocol::ConfigWriteResponse;\n-use codex_app_server_protocol::ExternalAgentConfigDetectParams;\n-use codex_app_server_protocol::ExternalAgentConfigDetectResponse;\n-use codex_app_server_protocol::ExternalAgentConfigImportParams;\n-use codex_app_server_protocol::ExternalAgentConfigImportResponse;\n-use codex_app_server_protocol::ExternalAgentConfigMigrationItem;\n use codex_app_server_protocol::GetAccountParams;\n use codex_app_server_protocol::GetAccountRateLimitsResponse;\n use codex_app_server_protocol::GetAccountResponse;\n@@ -349,31 +344,6 @@ impl AppServerSession {\n             .map_err(|err| bootstrap_request_error(\"account/read failed during TUI bootstrap\", err))\n     }\n \n-    pub(crate) async fn external_...",
+      "path": "codex-rs/tui/src/app_server_session.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 570,
+      "patch_excerpt": "@@ -1,570 +0,0 @@\n-use crate::app_server_session::AppServerSession;\n-use crate::external_agent_config_migration::ExternalAgentConfigMigrationOutcome;\n-use crate::external_agent_config_migration::run_external_agent_config_migration_prompt;\n-use crate::legacy_core::config::Config;\n-use crate::legacy_core::config::ConfigBuilder;\n-use crate::legacy_core::config::ConfigOverrides;\n-use crate::legacy_core::config::edit::ConfigEdit;\n-use crate::legacy_core::config::edit::ConfigEditsBuilder;\n-use crate::tui;\n-use codex_app_server_protocol::ExternalAgentConfigDetectParams;\n-use codex_app_server_protocol::ExternalAgentConfigMigrationItem;\n-use codex_config::CloudConfigBundleLoader;\n-use codex_features::Feature;\n-use color_eyre::eyre::Result;\n-use color_eyre::eyre::WrapErr;\n-use std::collections::BTreeSet;\n-use std::path::Path;\n-use std::time::SystemTime;\n-use std::time::UNIX_EPOCH;\n-use toml::Value...",
+      "path": "codex-rs/tui/src/external_agent_config_migration_startup.rs",
+      "status": "removed"
+    },
+    {
+      "additions": 6,
+      "deletions": 19,
+      "patch_excerpt": "@@ -130,8 +130,8 @@ mod diff_model;\n mod diff_render;\n mod exec_cell;\n mod exec_command;\n+#[allow(dead_code)]\n mod external_agent_config_migration;\n-mod external_agent_config_migration_startup;\n mod external_editor;\n mod file_search;\n mod frames;\n@@ -1812,23 +1812,11 @@ async fn run_ratatui_app(\n     let hooks_request_handle = app_server.request_handle();\n     let hooks_cwd = config.cwd.to_path_buf();\n     let startup_prefetch_started_at = Instant::now();\n-    let should_defer_bootstrap =\n-        external_agent_config_migration_startup::should_show_external_agent_config_migration_prompt(\n-            &config,\n-            should_show_trust_screen_flag,\n-        );\n-    let (startup_bootstrap, startup_hooks_entry) = if should_defer_bootstrap {\n-        (\n-            None,\n-            load_startup_hooks_review_entry(hooks_request_handle, hooks_cwd).await,\n-        )\n-    } else {\n-     ...",
+      "path": "codex-rs/tui/src/lib.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#27064",
+    "#27065",
+    "#27070",
+    "#27071"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nExternal-agent import should be initiated deliberately instead of interrupting eligible TUI startups. This cleanup removes the blocking startup flow before the replacement import experience is introduced later in the stack.\n\n## What changed\n\n- remove the startup-blocking external-agent migration prompt\n- remove the now-unused external migration feature gate\n- remove the obsolete TUI app-server migration wrappers\n- retain the dormant picker behind a module-scoped dead-code allowance until the next stack item wires it back in\n- keep normal TUI startup focused on entering Codex immediately\n\n## Validation\n\n- `bazel build --config=clippy //codex-rs/tui:tui //codex-rs/tui:tui-unit-tests-bin`\n- `just test -p codex-tui external_agent_config_migration` (8 passed)\n- `just test -p codex-tui` (2,786 passed, 12 unrelated local environment-sensitive failures, 4 skipped)\n- `just fix -p codex-tui`\n- `just fmt`\n\n## Stack\n\n1. [#27064](https://github.com/openai/codex/pull/27064): remove the startup migration flow\n2. [#27065](https://github.com/openai/codex/pull/27065): extract the picker renderer\n3. [#27070](https://github.com/openai/codex/pull/27070): add the external-agent import picker UX\n4. [#27071](https://github.com/openai/codex/pull/27071): expose the flow through `/import`\n\n**This PR is stack item 1.**",
+    "labels": [],
+    "merged_at": "2026-06-10T18:25:04Z",
+    "number": 27064,
+    "state": "merged",
+    "title": "[codex] remove blocking external agent migration flow",
+    "url": "https://github.com/openai/codex/pull/27064"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27065.json
+++ b/artifacts/github/bundles/openai-codex-pr-27065.json
@@ -1,0 +1,54 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "stefanstokic-oai",
+      "committed_at": "2026-06-10T18:38:11Z",
+      "message": "tui: extract external agent migration renderer",
+      "sha": "78a9d823a89350a2ab49ee0b3ea2e3bf48685ff7",
+      "url": "https://github.com/openai/codex/commit/78a9d823a89350a2ab49ee0b3ea2e3bf48685ff7"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "CONTROL"
+  ],
+  "files": [
+    {
+      "additions": 2,
+      "deletions": 128,
+      "patch_excerpt": "@@ -1,9 +1,5 @@\n use crate::diff_render::display_path_for;\n-use crate::key_hint;\n use crate::line_truncation::truncate_line_with_ellipsis_if_overflow;\n-use crate::render::Insets;\n-use crate::render::RectExt as _;\n-use crate::selection_list::selection_option_row_with_dim;\n use crate::style::accent_style;\n use crate::tui::FrameRequester;\n use crate::tui::Tui;\n@@ -15,18 +11,14 @@ use crossterm::event::KeyEvent;\n use crossterm::event::KeyEventKind;\n use crossterm::event::KeyModifiers;\n use ratatui::buffer::Buffer;\n-use ratatui::layout::Constraint;\n-use ratatui::layout::Layout;\n use ratatui::layout::Rect;\n use ratatui::prelude::Stylize as _;\n use ratatui::text::Line;\n-use ratatui::widgets::Clear;\n-use ratatui::widgets::Paragraph;\n use ratatui::widgets::Widget;\n-use ratatui::widgets::WidgetRef;\n-use ratatui::widgets::Wrap;\n use tokio_stream::StreamExt;\n \n+mod render;\n+\n #[derive(Clone, Debug, ...",
+      "path": "codex-rs/tui/src/external_agent_config_migration.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 137,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,137 @@\n+use super::ActionMenuOption;\n+use super::ExternalAgentConfigMigrationScreen;\n+use super::FocusArea;\n+use crate::key_hint;\n+use crate::render::Insets;\n+use crate::render::RectExt as _;\n+use crate::selection_list::selection_option_row_with_dim;\n+use crossterm::event::KeyCode;\n+use ratatui::buffer::Buffer;\n+use ratatui::layout::Constraint;\n+use ratatui::layout::Layout;\n+use ratatui::layout::Rect;\n+use ratatui::prelude::Stylize as _;\n+use ratatui::text::Line;\n+use ratatui::widgets::Clear;\n+use ratatui::widgets::Paragraph;\n+use ratatui::widgets::Widget;\n+use ratatui::widgets::WidgetRef;\n+use ratatui::widgets::Wrap;\n+\n+impl WidgetRef for &ExternalAgentConfigMigrationScreen {\n+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {\n+        Clear.render(area, buf);\n+\n+        let inner_area = area.inset(Insets::vh(/*v*/ 1, /*h*/ 2));\n+        let error_height = u16::from(sel...",
+      "path": "codex-rs/tui/src/external_agent_config_migration/render.rs",
+      "status": "added"
+    }
+  ],
+  "linked_issues": [
+    "#27064",
+    "#27065",
+    "#27070",
+    "#27071"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nThe external-agent import picker is easier to review when its rendering refactor lands separately from new state and interaction behavior. This layer is intended to be behavior-neutral.\n\n## What changed\n\n- extract external-agent migration rendering into a dedicated `render` module\n- preserve existing behavior while separating presentation from interaction logic\n- establish a smaller foundation for the import picker UX in the next PR\n\n## Validation\n\n- `just test -p codex-tui external_agent_config_migration` (10 passed)\n\n## Stack\n\n1. [#27064](https://github.com/openai/codex/pull/27064): remove the startup migration flow\n2. [#27065](https://github.com/openai/codex/pull/27065): extract the picker renderer\n3. [#27070](https://github.com/openai/codex/pull/27070): add the external-agent import picker UX\n4. [#27071](https://github.com/openai/codex/pull/27071): expose the flow through `/import`\n\n**This PR is stack item 2.** Draft while the lower stack dependency is reviewed.",
+    "labels": [],
+    "merged_at": "2026-06-10T18:48:31Z",
+    "number": 27065,
+    "state": "merged",
+    "title": "[codex] extract external agent import picker renderer",
+    "url": "https://github.com/openai/codex/pull/27065"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/impact/openai-codex-pr-26409.json
+++ b/artifacts/github/impact/openai-codex-pr-26409.json
@@ -1,0 +1,46 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-26409",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[plugins] Inject remote_plugin_id into install elicitations",
+        "url": "https://github.com/openai/codex/pull/26409",
+        "meta": "Merged 2026-06-10T19:01:04Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/26409",
+        "meta": "artifacts/github/reviews/openai-codex-pr-26409.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex now carries optional remote plugin identity through plugin discovery and injects `remote_plugin_id` plus connector IDs into `request_plugin_install` elicitation `_meta` without exposing those identifiers to the model-facing schema, arguments, or tool result.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "The upstream review records `remote_plugin_id` added to discoverable plugin structs and propagated through tool discovery.",
+    "`RequestPluginInstallMeta` gains optional `remote_plugin_id` and `app_connector_ids` fields.",
+    "The PR body states that remote IDs stay out of the model-facing tool schema, arguments, and result.",
+    "Updated request-plugin-install tests assert plugin metadata injection while local plugins keep metadata absent."
+  ],
+  "candidate_followups": [
+    "Preserve `_meta.remote_plugin_id` and `_meta.app_connector_ids` in Decodex plugin-install approval flows.",
+    "Add Decodex fixtures for remote plugin install elicitations that verify backend IDs do not leak into model-visible arguments.",
+    "Audit any Control Plane validators that assumed install elicitation metadata only contained `tool_name` and `install_url`."
+  ],
+  "social_notes": [
+    "Public copy should emphasize exact remote-plugin identity in approval metadata and the model-visible boundary.",
+    "Avoid claiming a new install UI unless a separate client release or changelog confirms it.",
+    "Mention that the metadata fields are optional and additive."
+  ],
+  "caveats": [
+    "The reviewed source confirms metadata propagation, not a specific hosted backend rollout.",
+    "Clients that ignore unknown `_meta` fields should continue to work, but install brokers should preserve them."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-26859.json
+++ b/artifacts/github/impact/openai-codex-pr-26859.json
@@ -1,0 +1,47 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-26859",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "fix: Auto-recover from corrupted sqlite databases",
+        "url": "https://github.com/openai/codex/pull/26859",
+        "meta": "Merged 2026-06-10T18:24:29Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/26859",
+        "meta": "artifacts/github/reviews/openai-codex-pr-26859.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex now treats detected local runtime SQLite corruption as a backup-and-rebuild path for the interactive CLI and app server, moving only the damaged database files aside and surfacing recovery context to the user.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "The upstream review records the new `RuntimeDbBackup` recovery helper and `db-backups` behavior.",
+    "The app-server startup path now uses a corruption-aware fresh-start initializer and warning summary.",
+    "The interactive CLI retry loop backs up recoverable corrupted databases and reports backup/new database paths.",
+    "The doctor remediation text now tells users to restart the interactive CLI or app server so those entry points can rebuild the runtime database."
+  ],
+  "candidate_followups": [
+    "Recognize Codex SQLite recovery warnings in Decodex app-server status and operator snapshots.",
+    "Preserve backup-path evidence when diagnosing apparent state loss after a corrupt database rebuild.",
+    "Update recovery runbooks so operators distinguish recoverable corruption from lock contention or non-corruption startup failures."
+  ],
+  "social_notes": [
+    "Frame this as reliability and recoverability, not as guaranteed preservation of every corrupt database row.",
+    "Mention that recovery is confirmed for interactive CLI and app-server entry points.",
+    "Avoid implying that all entry points rebuild automatically."
+  ],
+  "caveats": [
+    "Recovered runtime state depends on saved rollout files being present.",
+    "Non-corruption startup errors and lock contention remain separate failure paths.",
+    "Other entry points may still require manual recovery."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-27064.json
+++ b/artifacts/github/impact/openai-codex-pr-27064.json
@@ -1,0 +1,45 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27064",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] remove blocking external agent migration flow",
+        "url": "https://github.com/openai/codex/pull/27064",
+        "meta": "Merged 2026-06-10T18:25:04Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27064",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27064.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex removes the startup-blocking external-agent configuration migration prompt, marks the `external_migration` feature as a removed no-op, and keeps the picker code dormant for a later deliberate import flow.",
+  "public_signal_decision": "defer",
+  "control_plane_impact": "watch",
+  "publisher_angle": "watch_note",
+  "confidence": "confirmed",
+  "evidence": [
+    "The upstream review records that PR #27064 is stack item 1 before the new picker and `/import` flow.",
+    "`ExternalMigration` changes from an experimental startup prompt feature to a removed no-op compatibility flag.",
+    "The TUI startup path removes the migration prompt handler and no longer defers bootstrap for that prompt.",
+    "The startup migration module is deleted while the picker module remains dormant for later stack items."
+  ],
+  "candidate_followups": [
+    "Wait for the later `/import` PR before drafting public guidance or a try path.",
+    "Remove any Decodex operator assumption that startup will automatically prompt for external-agent migration.",
+    "Track the complete external-agent import stack as one release-rollup topic if later PRs provide the user-facing flow."
+  ],
+  "social_notes": [
+    "Do not publish this PR as a standalone feature; it intentionally removes an interrupting startup flow before the replacement UX lands.",
+    "A later rollup may explain the move from startup interruption to deliberate `/import` once the stack is complete."
+  ],
+  "caveats": [
+    "The replacement import picker and `/import` command are separate queued PRs.",
+    "This PR confirms reduced startup interruption, not the final import workflow."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-27065.json
+++ b/artifacts/github/impact/openai-codex-pr-27065.json
@@ -1,0 +1,42 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27065",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] extract external agent import picker renderer",
+        "url": "https://github.com/openai/codex/pull/27065",
+        "meta": "Merged 2026-06-10T18:48:31Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27065",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27065.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex moves external-agent migration screen rendering into a dedicated `render` module while preserving the existing picker behavior for later stack items.",
+  "public_signal_decision": "skip",
+  "control_plane_impact": "none",
+  "publisher_angle": "none",
+  "confidence": "confirmed",
+  "evidence": [
+    "The upstream review records PR #27065 as a behavior-neutral refactor.",
+    "`external_agent_config_migration.rs` removes rendering imports and delegates rendering to a new module.",
+    "`external_agent_config_migration/render.rs` contains the extracted widget rendering implementation.",
+    "The PR body reports targeted external-agent migration tests passing."
+  ],
+  "candidate_followups": [
+    "Use this only as background for the later external-agent import stack.",
+    "Do not create a standalone public signal or Publisher candidate from this refactor."
+  ],
+  "social_notes": [
+    "No public candidate should be produced from this PR alone."
+  ],
+  "caveats": [
+    "This artifact intentionally records a no-impact outcome so downstream release and Publisher automation can skip it."
+  ]
+}

--- a/artifacts/github/review-queue/openai-codex-latest.json
+++ b/artifacts/github/review-queue/openai-codex-latest.json
@@ -1,14 +1,14 @@
 {
   "counts": {
-    "critical": 17,
-    "high": 9,
-    "low": 2,
-    "normal": 12,
+    "critical": 19,
+    "high": 8,
+    "low": 0,
+    "normal": 13,
     "published_subjects_seen": 0,
     "recent_commits_scanned": 40,
     "subjects_queued": 40
   },
-  "generated_at": "2026-06-11T02:04:53.013782Z",
+  "generated_at": "2026-06-11T08:06:28.367132Z",
   "repo": "openai/codex",
   "schema": "upstream_review_queue/v1",
   "source": {
@@ -17,322 +17,6 @@
     "signals_dir": "site/src/content/signals"
   },
   "subjects": [
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 27,
-      "commit_shas": [
-        "c86af903969cdfa1fbeba67fbd454710f0d53de2",
-        "fa313ba390f5372cd7dfa2e2a05b890f93b9b3a1",
-        "19a14a08106a029b63c08e0a930c2c3bd769183b",
-        "e7ea9109a9e343fd1cc6a62d4c50d2d7b9cf1660"
-      ],
-      "committed_at": "2026-06-10T10:54:21Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27198,
-      "pr_url": "https://github.com/openai/codex/pull/27198",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server/tests/suite/v2/app_list.rs",
-        "codex-rs/app-server/tests/suite/v2/mcp_resource.rs",
-        "codex-rs/app-server/tests/suite/v2/mcp_server_elicitation.rs",
-        "codex-rs/app-server/tests/suite/v2/plugin_install.rs",
-        "codex-rs/app-server/tests/suite/v2/plugin_read.rs",
-        "codex-rs/codex-mcp/src/lib.rs",
-        "codex-rs/codex-mcp/src/mcp/mod.rs",
-        "codex-rs/codex-mcp/src/mcp/mod_tests.rs",
-        "codex-rs/config/src/schema.rs",
-        "codex-rs/core/config.schema.json",
-        "codex-rs/core/src/config/config_tests.rs",
-        "codex-rs/core/src/config/mod.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27198",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "config_hooks",
-        "mcp_plugins",
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "Use plugin-service MCP as the hosted plugin runtime",
-      "url": "https://github.com/openai/codex/pull/27198"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 21,
-      "commit_shas": [
-        "9c223af9d01e5e895d668d29291c45b794eeda83",
-        "6b0115c1838acfe99839e07a64bcaffbf9bebeb4"
-      ],
-      "committed_at": "2026-06-10T12:31:09Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27383,
-      "pr_url": "https://github.com/openai/codex/pull/27383",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/Cargo.lock",
-        "codex-rs/core/src/session/tests.rs",
-        "codex-rs/core/src/session/turn_tests.rs",
-        "codex-rs/core/src/stream_events_utils_tests.rs",
-        "codex-rs/core/src/thread_manager_tests.rs",
-        "codex-rs/core/src/tools/handlers/extension_tools.rs",
-        "codex-rs/ext/extension-api/Cargo.toml",
-        "codex-rs/ext/extension-api/src/contributors.rs",
-        "codex-rs/ext/extension-api/src/lib.rs",
-        "codex-rs/ext/extension-api/tests/registry.rs",
-        "codex-rs/ext/goal/src/extension.rs",
-        "codex-rs/ext/guardian/Cargo.toml"
-      ],
-      "source_state": "merged",
-      "subject_id": "27383",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "config_hooks",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "Remove async-trait from extension contributors",
-      "url": "https://github.com/openai/codex/pull/27383"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 20,
-      "commit_shas": [
-        "935cbc2e7b35c10516254001991b9a0bf7c2f069",
-        "cc60f5411157f765bb97ece8f79ef25d3795101f",
-        "6adf517d65bfdf08aaac21e35e5dfa7f6ce08b19"
-      ],
-      "committed_at": "2026-06-10T15:33:21Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27259,
-      "pr_url": "https://github.com/openai/codex/pull/27259",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/codex-mcp/src/connection_manager.rs",
-        "codex-rs/codex-mcp/src/connection_manager_tests.rs",
-        "codex-rs/core/src/codex_delegate_tests.rs",
-        "codex-rs/core/src/connectors.rs",
-        "codex-rs/core/src/mcp_tool_call.rs",
-        "codex-rs/core/src/mcp_tool_call_tests.rs",
-        "codex-rs/core/src/session/handlers.rs",
-        "codex-rs/core/src/session/mcp.rs",
-        "codex-rs/core/src/session/mod.rs",
-        "codex-rs/core/src/session/session.rs",
-        "codex-rs/core/src/session/tests.rs",
-        "codex-rs/core/src/session/turn.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27259",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "mcp_plugins",
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "Use latest-wins MCP manager replacement",
-      "url": "https://github.com/openai/codex/pull/27259"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 56,
-      "commit_shas": [
-        "fffd0036afdb23efb940be1527158f985bda5d6e"
-      ],
-      "committed_at": "2026-06-10T17:26:53Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27304,
-      "pr_url": "https://github.com/openai/codex/pull/27304",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/Cargo.lock",
-        "codex-rs/core/src/tools/code_mode/execute_handler.rs",
-        "codex-rs/core/src/tools/code_mode/wait_handler.rs",
-        "codex-rs/core/src/tools/handlers/agent_jobs/report_agent_job_result.rs",
-        "codex-rs/core/src/tools/handlers/agent_jobs/spawn_agents_on_csv.rs",
-        "codex-rs/core/src/tools/handlers/apply_patch.rs",
-        "codex-rs/core/src/tools/handlers/dynamic.rs",
-        "codex-rs/core/src/tools/handlers/extension_tools.rs",
-        "codex-rs/core/src/tools/handlers/list_available_plugins_to_install.rs",
-        "codex-rs/core/src/tools/handlers/mcp.rs",
-        "codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resource_templates.rs",
-        "codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resources.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27304",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "config_hooks",
-        "mcp_plugins",
-        "release_packaging",
-        "sandbox_permissions",
-        "tests_ci"
-      ],
-      "title": "[codex] Remove async_trait from ToolExecutor",
-      "url": "https://github.com/openai/codex/pull/27304"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 16,
-      "commit_shas": [
-        "e4cb80ffaed2e6ad90a42e0993eabd0d00ddcad3",
-        "3a5856f7ed4241b1d78aa834b47cea80b6607770",
-        "353ed1b6bb945a60e859384cf279976e9b280ecf",
-        "0d37f064d817b8f0f3aa63d8b4fc27901f6c0b5b",
-        "b90d036c9c45fad1a7abf3474d0aa600e787f116",
-        "4d1537dba9be19227807e924bb8f551ba2385200",
-        "e0f9c328df1ff2d337d3baeb029884b04fe69b35",
-        "64dc0d2bc88f179dd3d71de57586d2a77bb86ab8",
-        "cce9ca7334ae9bbb5b1086dbcfc136264226b27f",
-        "33a8e24459749ee78aeed292adebc176724b1bcb",
-        "61c5d9c84bdae60c98006a819ec8d601255eb165",
-        "e78df1ea9d485e8b06fff4b4c075591d556be156",
-        "ff2201af2929455c6b826161b4f818663cfe7ebd",
-        "b59232841e28b88559ec0f7d5c7cc602fbd2363a",
-        "b949dc3b1dbe0e25448dfcc4bba207deeb43a72a",
-        "7daf14053e74673697bca70290a4ddcee2d412d9",
-        "dcd1b73bce47bd514839ff4d71a48c12280ae413",
-        "28b3f1ea589a2bc0090577c4a4d309f261318c57",
-        "cac8884c2c0540a586472f35c17dfb1cbe7a2697"
-      ],
-      "committed_at": "2026-06-10T18:18:09Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26041,
-      "pr_url": "https://github.com/openai/codex/pull/26041",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server-protocol/src/export.rs",
-        "codex-rs/app-server-protocol/src/protocol/common.rs",
-        "codex-rs/app-server-protocol/src/protocol/v2/thread.rs",
-        "codex-rs/app-server/README.md",
-        "codex-rs/app-server/src/message_processor.rs",
-        "codex-rs/app-server/src/request_processors.rs",
-        "codex-rs/app-server/src/request_processors/thread_processor.rs",
-        "codex-rs/app-server/src/request_processors/thread_processor_tests.rs",
-        "codex-rs/core/src/codex_thread.rs",
-        "codex-rs/core/src/lib.rs",
-        "codex-rs/core/src/tasks/mod.rs",
-        "codex-rs/core/src/unified_exec/mod.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26041",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "docs_examples",
-        "tests_ci"
-      ],
-      "title": "Add app-server background terminal process APIs",
-      "url": "https://github.com/openai/codex/pull/26041"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 38,
-      "commit_shas": [
-        "6a8eca9c764324003e5244ff1350763b92bfd55c",
-        "2ffeebb96a53d069ec9a4b27ac855399ac2ed5e0",
-        "e3474e6f4e8bb5806b2f4d86057b4af3e6cc89df",
-        "2292718bf4af345f4bb5b5e0f8ff8bfa287c62d8",
-        "2adf4ac97da874f89611fb3b33d8f301e04fbe75",
-        "cb6f55ebed68ab47a383eeb01d7dd8b258c051f4",
-        "b54292ea752847fafacd90568d9585f686bbe6af",
-        "4e4d0b03381e9f8ff1e95428865f28bea4d25280",
-        "e221c3526b18ee401a4b9dfaad6218dc79165c9f",
-        "cba630a49f83b92c89e893f843f0f6f434c616f1",
-        "75e10774593faffca4cb842a934cd357084fd44b",
-        "cc77f6475b243804c31a1530428f9c0e6ef2963d",
-        "d2feb3b324d4a8553f9b60d481869a3e87bcc4ac",
-        "ab817ffd6963c3d74e18e88d3bddb6f61d78ae3d",
-        "c6280684fc1329dcf081a70c19b7e3721bd7e53e",
-        "adf45c442742593ff61765a11e48c572e20a5212",
-        "e31a612db2e4f6e0b9c77c2f5605fc80757c26c5",
-        "14aa743b37972f342d7383ae48d76b410ca48f7e",
-        "879d73a0f5e96407f31875d62c430b47d8add678",
-        "126b310bbef358ecd7a2d25b9cc51e6040eafb95",
-        "2f4f9ed4921ee874dd5c20d09bdd1ba52d66c45d",
-        "71471d9e7917d7815414da4bc49f39441a984267"
-      ],
-      "committed_at": "2026-06-10T18:22:12Z",
-      "next_step": "ai_review_required",
-      "pr_number": 25018,
-      "pr_url": "https://github.com/openai/codex/pull/25018",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
-        "codex-rs/app-server-protocol/schema/json/ServerNotification.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadDeleteParams.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadDeleteResponse.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadDeletedNotification.json",
-        "codex-rs/app-server-protocol/schema/typescript/ClientRequest.ts",
-        "codex-rs/app-server-protocol/schema/typescript/ServerNotification.ts",
-        "codex-rs/app-server-protocol/schema/typescript/v2/ThreadDeleteParams.ts",
-        "codex-rs/app-server-protocol/schema/typescript/v2/ThreadDeleteResponse.ts",
-        "codex-rs/app-server-protocol/schema/typescript/v2/ThreadDeletedNotification.ts"
-      ],
-      "source_state": "merged",
-      "subject_id": "25018",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "docs_examples",
-        "tests_ci"
-      ],
-      "title": "Add app-server `thread/delete` API",
-      "url": "https://github.com/openai/codex/pull/25018"
-    },
     {
       "attention_flags": [
         "auth_account",
@@ -791,208 +475,334 @@
     },
     {
       "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 15,
+      "commit_shas": [
+        "cda812d01363baa1c349ad59ca75006f0a413f2f"
+      ],
+      "committed_at": "2026-06-11T02:21:24Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27247,
+      "pr_url": "https://github.com/openai/codex/pull/27247",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/config.schema.json",
+        "codex-rs/core/src/image_preparation.rs",
+        "codex-rs/core/src/image_preparation_tests.rs",
+        "codex-rs/core/src/lib.rs",
+        "codex-rs/core/src/prompt_debug.rs",
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/session/tests.rs",
+        "codex-rs/core/src/tools/handlers/view_image.rs",
+        "codex-rs/core/tests/suite/code_mode.rs",
+        "codex-rs/core/tests/suite/rmcp_client.rs",
+        "codex-rs/core/tests/suite/view_image.rs",
+        "codex-rs/features/src/lib.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27247",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "config_hooks",
+        "mcp_plugins",
+        "model_provider",
+        "tests_ci"
+      ],
+      "title": "core: resize all history images behind a feature flag",
+      "url": "https://github.com/openai/codex/pull/27247"
+    },
+    {
+      "attention_flags": [
+        "breaking_change",
+        "deprecated_removed",
+        "release_packaging"
+      ],
+      "changed_file_count": 2,
+      "commit_shas": [
+        "346a2833dae23c17095b75daf08fddf8515e2339",
+        "d663d950dba7c0a87d64c450702a0d508270251d",
+        "bdf60ba26131e29c86f98a64e8b6cddd6864a121",
+        "0d45b47959c8630d9c0e53d6635a94b80dbf0f99"
+      ],
+      "committed_at": "2026-06-11T02:50:57Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27487,
+      "pr_url": "https://github.com/openai/codex/pull/27487",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for breaking_change, deprecated_removed, release_packaging.",
+      "sample_paths": [
+        "codex-rs/app-server-client/src/lib.rs",
+        "codex-rs/tui/src/lib.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27487",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui"
+      ],
+      "title": "Trim TUI legacy telemetry and migration dependencies",
+      "url": "https://github.com/openai/codex/pull/27487"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
         "new_feature",
         "protocol_change"
       ],
       "changed_file_count": 4,
       "commit_shas": [
-        "d047caf12e4d0670a3abf28a4f2915fa3f70732d",
-        "f73d37d6769e342190b234e4d84c91e3a5fc8832"
+        "8a34e24ba2eb9415433cfc680d35d35112f403b8"
       ],
-      "committed_at": "2026-06-10T04:41:06Z",
+      "committed_at": "2026-06-11T03:37:25Z",
       "next_step": "ai_review_required",
-      "pr_number": 27107,
-      "pr_url": "https://github.com/openai/codex/pull/27107",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for new_feature, protocol_change.",
+      "pr_number": 27526,
+      "pr_url": "https://github.com/openai/codex/pull/27526",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/core/src/hook_runtime.rs",
-        "codex-rs/core/src/mcp_tool_exposure.rs",
-        "codex-rs/core/src/session/mod.rs",
-        "codex-rs/core/src/session/turn.rs"
+        "codex-rs/tools/src/lib.rs",
+        "codex-rs/tools/src/tool_executor.rs",
+        "codex-rs/tools/src/tool_search.rs",
+        "codex-rs/tools/src/tool_search_tests.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27107",
+      "subject_id": "27526",
       "subject_kind": "pr",
       "surface_hints": [
-        "config_hooks",
-        "mcp_plugins"
+        "mcp_plugins",
+        "tests_ci"
       ],
-      "title": "Add spans to run_turn",
-      "url": "https://github.com/openai/codex/pull/27107"
+      "title": "tools: simplify default tool search text",
+      "url": "https://github.com/openai/codex/pull/27526"
     },
     {
       "attention_flags": [
         "auth_account",
+        "breaking_change",
+        "deprecated_removed",
         "new_feature",
         "protocol_change",
         "security_policy"
+      ],
+      "changed_file_count": 10,
+      "commit_shas": [
+        "a19ec71e8d73d4dbd1dfb5b34894744ee8e6ef1a",
+        "67a29aab4885be483dc7ea05ec9bce8fddbfdc00",
+        "9e25474a95a9ceb092c04ac628cbb6985f7f30eb",
+        "812afdf99973b744cc03839a08128a536df58e4c",
+        "57885a18cccf9db57602e1240e553aaf1df92da9"
+      ],
+      "committed_at": "2026-06-11T03:39:07Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27488,
+      "pr_url": "https://github.com/openai/codex/pull/27488",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/session/turn.rs",
+        "codex-rs/core/src/state/auto_compact_window.rs",
+        "codex-rs/core/src/state/session.rs",
+        "codex-rs/core/src/tools/handlers/mod.rs",
+        "codex-rs/core/src/tools/handlers/new_context_window.rs",
+        "codex-rs/core/src/tools/handlers/new_context_window_spec.rs",
+        "codex-rs/core/src/tools/spec_plan.rs",
+        "codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap",
+        "codex-rs/core/tests/suite/token_budget.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27488",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "auth_accounts",
+        "tests_ci"
+      ],
+      "title": "[codex] Add new context window tool",
+      "url": "https://github.com/openai/codex/pull/27488"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 30,
+      "commit_shas": [
+        "104ce325c053cc8373b8f50f88516aaf73be0409",
+        "2aef9c511d253364af98fb4348683fea07aa8eef",
+        "5159b57cb0503bbf547d1a2c972dbe94933f0f01",
+        "1cd7a69b77fc746d10b786dc1640bc6e542b308e"
+      ],
+      "committed_at": "2026-06-11T03:42:38Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27443,
+      "pr_url": "https://github.com/openai/codex/pull/27443",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/app-server-protocol/schema/json/ServerNotification.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/v2/AccountUpdatedNotification.json",
+        "codex-rs/app-server-protocol/schema/typescript/AuthMode.ts",
+        "codex-rs/app-server-protocol/src/protocol/common.rs",
+        "codex-rs/app-server-transport/src/transport/remote_control/tests.rs",
+        "codex-rs/app-server-transport/src/transport/remote_control/websocket.rs",
+        "codex-rs/app-server/tests/common/auth_fixtures.rs",
+        "codex-rs/app-server/tests/suite/v2/app_list.rs",
+        "codex-rs/cli/src/doctor.rs",
+        "codex-rs/cli/src/login.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27443",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "auth_accounts",
+        "cli_tui",
+        "model_provider",
+        "tests_ci"
+      ],
+      "title": "feat: add Bedrock API key as a managed auth mode",
+      "url": "https://github.com/openai/codex/pull/27443"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 4,
+      "commit_shas": [
+        "66d506e86e5da8691b0773563eff7f73ecff20b9"
+      ],
+      "committed_at": "2026-06-11T03:57:35Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27517,
+      "pr_url": "https://github.com/openai/codex/pull/27517",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server/src/request_processors/account_processor.rs",
+        "codex-rs/core-plugins/src/manager.rs",
+        "codex-rs/core-plugins/src/manager_tests.rs",
+        "codex-rs/core/src/thread_manager.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27517",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "auth_accounts",
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "[codex] Pass auth mode to plugin manager",
+      "url": "https://github.com/openai/codex/pull/27517"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 16,
+      "commit_shas": [
+        "9f43ae5740dd7a0864191e7fd9442731955fcd56",
+        "87118974041e386856e6308cb5de4a4efdb38825",
+        "b5336d7c65a855c2be73a5d969f6261cc0a9016e",
+        "d2faba8e737ea11ebb34e67e1153a927367e40c0",
+        "40b684f149d7b9eb861e7e1bdd07ccbc1ea1803e",
+        "3cc928afc04c980727973669c55ef36ac33132a6",
+        "86be3665c548b7d0cfd1d8093d22f0578a53d3e4"
+      ],
+      "committed_at": "2026-06-11T04:11:26Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27520,
+      "pr_url": "https://github.com/openai/codex/pull/27520",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/analytics/src/facts.rs",
+        "codex-rs/core/src/compact_tests.rs",
+        "codex-rs/core/src/context/environment_context_tests.rs",
+        "codex-rs/core/src/context_manager/history_tests.rs",
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/session/review.rs",
+        "codex-rs/core/src/session/rollout_reconstruction.rs",
+        "codex-rs/core/src/session/rollout_reconstruction_tests.rs",
+        "codex-rs/core/src/session/tests.rs",
+        "codex-rs/core/src/session/turn.rs",
+        "codex-rs/core/src/session/turn_context.rs",
+        "codex-rs/core/tests/suite/compact.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27520",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "tests_ci"
+      ],
+      "title": "[codex] Compact when comp_hash changes",
+      "url": "https://github.com/openai/codex/pull/27520"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
       ],
       "changed_file_count": 8,
       "commit_shas": [
-        "c504b328b7d835c0b33fea762d9a3d796ec336dc",
-        "6b4aa397aae0f0283f11b0d8da02da2e2ac88711",
-        "67da7c5e3b76018780d3cbc7ef3119c56ce5e32f",
-        "eb7002afa00aecddc79b7b2b032a15a78e336101",
-        "34ec33192dfec437986360b687d9a0a888ca521d",
-        "41dda768e5f3d9d339982a94b8d6a21399d68c01",
-        "abfe7ab2d0ad692c724a49bddfd64e40c836307b",
-        "e5c5f0dca5345d8c3e611d4fdaeb2de8b6bdd08c",
-        "6385c6b3b2620c233e771995c328a62a4ef5ceb6",
-        "dfca54a28e98ef7df5407e66ef45ec53bf93eff6",
-        "71772262f3766a508575724d94cec2322ca06796",
-        "a4439ecce64c51bd084dca079c150294a2f44394",
-        "cc2754bbba0afeac1bb785bc1577c6349ab38da5",
-        "a48cb410f214216e21c198be03aa601c01ab19c3",
-        "04b6ef2a7812f427e1f88790e3f4dc3a5b24415b",
-        "0588a59e00333db60c45a80602c47061df309690",
-        "4052ad0f2d8095406635faefa30522324067cd14",
-        "c4e6566a709a825200b021c42952decc6a398895",
-        "6fa2495bc95331e9f06340cd2011e8aad794a384"
+        "df09d11e677e0c7a0efd4e0123a4f2e52eff4aee",
+        "78eec65557d4abd99be8fa4d71eef89c52aa716c"
       ],
-      "committed_at": "2026-06-10T07:17:58Z",
+      "committed_at": "2026-06-11T06:07:06Z",
       "next_step": "ai_review_required",
-      "pr_number": 27261,
-      "pr_url": "https://github.com/openai/codex/pull/27261",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
+      "pr_number": 27082,
+      "pr_url": "https://github.com/openai/codex/pull/27082",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/codex-mcp/src/connection_manager.rs",
-        "codex-rs/codex-mcp/src/connection_manager_tests.rs",
-        "codex-rs/codex-mcp/src/mcp/mod.rs",
-        "codex-rs/core/src/connectors.rs",
-        "codex-rs/core/src/mcp_tool_call_tests.rs",
-        "codex-rs/core/src/session/mcp.rs",
-        "codex-rs/core/src/session/session.rs",
-        "codex-rs/core/src/state/service.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27261",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "[codex] Make MCP connection startup fallible",
-      "url": "https://github.com/openai/codex/pull/27261"
-    },
-    {
-      "attention_flags": [
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 2,
-      "commit_shas": [
-        "ec27d8d71b40bd86900682e989e3ea64bcd72f79",
-        "1bfa6cfe558427f95780c9a1ea2c6a00257b8235",
-        "ffedf368162b5ea8b085b5619505a18980a734d8"
-      ],
-      "committed_at": "2026-06-10T09:45:49Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27174,
-      "pr_url": "https://github.com/openai/codex/pull/27174",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/tui/src/chatwidget/protocol.rs",
-        "codex-rs/tui/src/chatwidget/tests/mcp_startup.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27174",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "feat: keep child MCP warnings out of parent transcript",
-      "url": "https://github.com/openai/codex/pull/27174"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 24,
-      "commit_shas": [
-        "f99614b3e1d8f5d6253411b82ab59f42e2650e76",
-        "39d4f7c14dbc35acb220dcb57e3652d6c67aa7f2",
-        "124b7a666573abce87c82a52156a403f1ebd6f69"
-      ],
-      "committed_at": "2026-06-10T15:47:16Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27264,
-      "pr_url": "https://github.com/openai/codex/pull/27264",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/app-server-protocol/src/protocol/thread_history.rs",
-        "codex-rs/core/src/agent/control_tests.rs",
-        "codex-rs/core/src/client.rs",
-        "codex-rs/core/src/client_tests.rs",
+        "codex-rs/analytics/src/analytics_client_tests.rs",
+        "codex-rs/analytics/src/events.rs",
+        "codex-rs/analytics/src/facts.rs",
+        "codex-rs/analytics/src/lib.rs",
         "codex-rs/core/src/compact.rs",
         "codex-rs/core/src/compact_remote.rs",
         "codex-rs/core/src/compact_remote_v2.rs",
-        "codex-rs/core/src/session/mod.rs",
-        "codex-rs/core/src/session/rollout_reconstruction.rs",
-        "codex-rs/core/src/session/rollout_reconstruction_tests.rs",
-        "codex-rs/core/src/session/session.rs",
-        "codex-rs/core/src/session/tests.rs"
+        "codex-rs/core/src/hook_runtime.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27264",
+      "subject_id": "27082",
       "subject_kind": "pr",
       "surface_hints": [
-        "app_server_protocol",
         "cli_tui",
+        "config_hooks",
         "tests_ci"
       ],
-      "title": "[codex] Store compact window id in rollout",
-      "url": "https://github.com/openai/codex/pull/27264"
-    },
-    {
-      "attention_flags": [
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 37,
-      "commit_shas": [
-        "dfb5c0cf7a5f50d8fc30f7ee2546f071f4fe0cfb"
-      ],
-      "committed_at": "2026-06-10T16:40:41Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27299,
-      "pr_url": "https://github.com/openai/codex/pull/27299",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/core/src/tools/code_mode/execute_handler.rs",
-        "codex-rs/core/src/tools/code_mode/wait_handler.rs",
-        "codex-rs/core/src/tools/handlers/agent_jobs/report_agent_job_result.rs",
-        "codex-rs/core/src/tools/handlers/agent_jobs/spawn_agents_on_csv.rs",
-        "codex-rs/core/src/tools/handlers/apply_patch.rs",
-        "codex-rs/core/src/tools/handlers/dynamic.rs",
-        "codex-rs/core/src/tools/handlers/extension_tools.rs",
-        "codex-rs/core/src/tools/handlers/list_available_plugins_to_install.rs",
-        "codex-rs/core/src/tools/handlers/mcp.rs",
-        "codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resource_templates.rs",
-        "codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resources.rs",
-        "codex-rs/core/src/tools/handlers/mcp_resource/read_mcp_resource.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27299",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "mcp_plugins",
-        "release_packaging",
-        "sandbox_permissions",
-        "tests_ci"
-      ],
-      "title": "[codex] Outline ToolExecutor handler bodies",
-      "url": "https://github.com/openai/codex/pull/27299"
+      "title": "[codex-analytics] Emit structured compaction codex errors",
+      "url": "https://github.com/openai/codex/pull/27082"
     },
     {
       "attention_flags": [
@@ -1119,119 +929,166 @@
     },
     {
       "attention_flags": [
-        "release_packaging"
-      ],
-      "changed_file_count": 2,
-      "commit_shas": [
-        "90fc87dd1a1c7449323fcff804c77abfea377a23"
-      ],
-      "committed_at": "2026-06-10T11:06:48Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27375,
-      "pr_url": "https://github.com/openai/codex/pull/27375",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for release_packaging.",
-      "sample_paths": [
-        "codex-rs/core/src/tools/handlers/multi_agents/spawn.rs",
-        "codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27375",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "internal_churn"
-      ],
-      "title": "[codex] Tag multi-agent spawn metrics with version",
-      "url": "https://github.com/openai/codex/pull/27375"
-    },
-    {
-      "attention_flags": [
+        "auth_account",
         "new_feature",
         "protocol_change",
-        "release_packaging"
+        "security_policy"
       ],
-      "changed_file_count": 2,
+      "changed_file_count": 14,
       "commit_shas": [
-        "2545ed23fec98ab5396de7e5156060f78a3ae896"
+        "a19ec71e8d73d4dbd1dfb5b34894744ee8e6ef1a",
+        "67a29aab4885be483dc7ea05ec9bce8fddbfdc00",
+        "9e25474a95a9ceb092c04ac628cbb6985f7f30eb",
+        "1a2c1cd787a7eedd307a761fc2823d6ac65c7e05"
       ],
-      "committed_at": "2026-06-10T15:51:17Z",
+      "committed_at": "2026-06-11T03:07:06Z",
       "next_step": "ai_review_required",
-      "pr_number": 27280,
-      "pr_url": "https://github.com/openai/codex/pull/27280",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature, protocol_change, release_packaging.",
+      "pr_number": 27438,
+      "pr_url": "https://github.com/openai/codex/pull/27438",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/utils/path-uri/src/lib.rs",
-        "codex-rs/utils/path-uri/src/tests.rs"
+        "codex-rs/core/config.schema.json",
+        "codex-rs/core/src/compact.rs",
+        "codex-rs/core/src/compact_remote.rs",
+        "codex-rs/core/src/compact_remote_v2.rs",
+        "codex-rs/core/src/context/mod.rs",
+        "codex-rs/core/src/context/token_budget_context.rs",
+        "codex-rs/core/src/event_mapping.rs",
+        "codex-rs/core/src/event_mapping_tests.rs",
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/session/token_budget.rs",
+        "codex-rs/core/src/session/turn.rs",
+        "codex-rs/core/tests/suite/mod.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27280",
+      "subject_id": "27438",
       "subject_kind": "pr",
       "surface_hints": [
+        "auth_accounts",
+        "config_hooks",
         "tests_ci"
       ],
-      "title": "[codex] add io PathUri native conversion APIs",
-      "url": "https://github.com/openai/codex/pull/27280"
+      "title": "[codex] Add token budget context feature",
+      "url": "https://github.com/openai/codex/pull/27438"
     },
     {
       "attention_flags": [
-        "release_packaging"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "04291f52e1d3efeb4d6266ae183a6ab6fabfff68"
-      ],
-      "committed_at": "2026-06-10T16:18:19Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27315,
-      "pr_url": "https://github.com/openai/codex/pull/27315",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for release_packaging.",
-      "sample_paths": [
-        ".github/workflows/rust-release-windows.yml"
-      ],
-      "source_state": "merged",
-      "subject_id": "27315",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "[codex] link Windows releases with LLD",
-      "url": "https://github.com/openai/codex/pull/27315"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "deprecated_removed",
+        "auth_account",
         "new_feature",
         "protocol_change"
       ],
-      "changed_file_count": 2,
+      "changed_file_count": 13,
       "commit_shas": [
-        "b36053eec1f68a4a9e48aed53ea56810a2003c5f",
-        "9a58bdcec68fa76812192615935890a2e826187f",
-        "4dc3e9cae948d55ec4070f7163f0e99c8ff1b1ce",
-        "3835922698aa996af2bd6e9e371da2cfa768335a"
+        "9f43ae5740dd7a0864191e7fd9442731955fcd56"
       ],
-      "committed_at": "2026-06-10T16:52:17Z",
+      "committed_at": "2026-06-11T03:42:55Z",
       "next_step": "ai_review_required",
-      "pr_number": 27391,
-      "pr_url": "https://github.com/openai/codex/pull/27391",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change.",
+      "pr_number": 27532,
+      "pr_url": "https://github.com/openai/codex/pull/27532",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/state/migrations/0036_threads_visible_sort_indexes.sql",
-        "codex-rs/state/src/runtime/threads.rs"
+        "codex-rs/app-server/tests/common/models_cache.rs",
+        "codex-rs/codex-api/tests/models_integration.rs",
+        "codex-rs/core/tests/suite/auto_review.rs",
+        "codex-rs/core/tests/suite/model_switching.rs",
+        "codex-rs/core/tests/suite/models_cache_ttl.rs",
+        "codex-rs/core/tests/suite/personality.rs",
+        "codex-rs/core/tests/suite/remote_models.rs",
+        "codex-rs/core/tests/suite/rmcp_client.rs",
+        "codex-rs/core/tests/suite/spawn_agent_description.rs",
+        "codex-rs/core/tests/suite/view_image.rs",
+        "codex-rs/models-manager/src/model_info.rs",
+        "codex-rs/protocol/src/openai_models.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27391",
+      "subject_id": "27532",
       "subject_kind": "pr",
       "surface_hints": [
-        "internal_churn"
+        "app_server_protocol",
+        "cli_tui",
+        "config_hooks",
+        "mcp_plugins",
+        "model_provider",
+        "tests_ci"
       ],
-      "title": "Index visible thread list ordering",
-      "url": "https://github.com/openai/codex/pull/27391"
+      "title": "[codex] Add comp_hash to model metadata",
+      "url": "https://github.com/openai/codex/pull/27532"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 6,
+      "commit_shas": [
+        "a19ec71e8d73d4dbd1dfb5b34894744ee8e6ef1a",
+        "67a29aab4885be483dc7ea05ec9bce8fddbfdc00",
+        "9e25474a95a9ceb092c04ac628cbb6985f7f30eb",
+        "812afdf99973b744cc03839a08128a536df58e4c",
+        "7926acc9983d2f91e3a8933f1c0e98c52678e13b",
+        "2f244354b476946dafe292f32368c259fd8ff853",
+        "57885a18cccf9db57602e1240e553aaf1df92da9",
+        "d12b3c17eba6d2c30919ce1083033fca50a4f682",
+        "86e43fe8635b2aded6cfda2011e1328ab5fa94a4"
+      ],
+      "committed_at": "2026-06-11T04:17:10Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27518,
+      "pr_url": "https://github.com/openai/codex/pull/27518",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/src/context/token_budget_context.rs",
+        "codex-rs/core/src/tools/handlers/get_context_remaining.rs",
+        "codex-rs/core/src/tools/handlers/get_context_remaining_spec.rs",
+        "codex-rs/core/src/tools/handlers/mod.rs",
+        "codex-rs/core/src/tools/spec_plan.rs",
+        "codex-rs/core/tests/suite/token_budget.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27518",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "auth_accounts",
+        "tests_ci"
+      ],
+      "title": "[codex] Add context remaining tool",
+      "url": "https://github.com/openai/codex/pull/27518"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "release_packaging"
+      ],
+      "changed_file_count": 3,
+      "commit_shas": [
+        "7a740bc45d7d114d457cf04b1b8a76ba9eab8797",
+        "2141e57b350c9b76a838b238a1a01a312f04f722"
+      ],
+      "committed_at": "2026-06-11T06:42:15Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26513,
+      "pr_url": "https://github.com/openai/codex/pull/26513",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, release_packaging.",
+      "sample_paths": [
+        "codex-rs/cloud-config/src/cache.rs",
+        "codex-rs/cloud-config/src/cache_tests.rs",
+        "codex-rs/cloud-config/src/service.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26513",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "config_hooks",
+        "tests_ci"
+      ],
+      "title": "[codex] Tune cloud config cache intervals",
+      "url": "https://github.com/openai/codex/pull/26513"
     },
     {
       "attention_flags": [
@@ -1496,59 +1353,155 @@
       "url": "https://github.com/openai/codex/pull/27489"
     },
     {
-      "attention_flags": [],
+      "attention_flags": [
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
       "changed_file_count": 1,
       "commit_shas": [
-        "4e74b09a544ca5150d1998c4d647b1b9651e0f63"
+        "454561e86fdc09e92cedbd6648ceb2f1df0acfb3",
+        "e71036adc2ff3109637cb334c051045a2bf8aa16"
       ],
-      "committed_at": "2026-06-10T16:28:12Z",
+      "committed_at": "2026-06-11T03:30:44Z",
       "next_step": "ai_review_required",
-      "pr_number": 27276,
-      "pr_url": "https://github.com/openai/codex/pull/27276",
-      "review_priority": "low",
-      "review_reason": "Needs AI review because every recent upstream commit is tracked, but deterministic hints found only internal churn.",
+      "pr_number": 27501,
+      "pr_url": "https://github.com/openai/codex/pull/27501",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/rollout/src/list.rs"
+        "codex-rs/ext/web-search/web_run_description.md"
       ],
       "source_state": "merged",
-      "subject_id": "27276",
+      "subject_id": "27501",
       "subject_kind": "pr",
       "surface_hints": [
         "internal_churn"
       ],
-      "title": "Reduce archive rollout lookup CPU",
-      "url": "https://github.com/openai/codex/pull/27276"
+      "title": "[codex] Expand hosted web search citation guidance",
+      "url": "https://github.com/openai/codex/pull/27501"
     },
     {
       "attention_flags": [
-        "deprecated_removed"
+        "auth_account",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
       ],
-      "changed_file_count": 3,
+      "changed_file_count": 4,
       "commit_shas": [
-        "049fa8db072a31d059bfb6ecc6b360781492a551",
-        "88ab3ee9d4e0c11c6c6b34e5b1fb26eb5d277c9c",
-        "1c227840af937213b8704aac36f78867d0c8ac09",
-        "b73155ba00ab28ea105617ef39bc881a3eaf715f"
+        "5eb40cb8dfdbf308827d18f4987f43053168e44a"
       ],
-      "committed_at": "2026-06-10T17:23:42Z",
+      "committed_at": "2026-06-11T03:43:03Z",
       "next_step": "ai_review_required",
-      "pr_number": 27407,
-      "pr_url": "https://github.com/openai/codex/pull/27407",
-      "review_priority": "low",
-      "review_reason": "Needs AI review for deprecated_removed.",
+      "pr_number": 27246,
+      "pr_url": "https://github.com/openai/codex/pull/27246",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/rollout/src/compression_tests.rs",
-        "codex-rs/rollout/src/search.rs",
-        "codex-rs/thread-store/src/local/search_threads.rs"
+        "codex-rs/core/src/client.rs",
+        "codex-rs/core/src/client_common.rs",
+        "codex-rs/core/src/client_common_tests.rs",
+        "codex-rs/core/tests/suite/responses_lite.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27407",
+      "subject_id": "27246",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "core: strip image detail from Responses Lite requests",
+      "url": "https://github.com/openai/codex/pull/27246"
+    },
+    {
+      "attention_flags": [
+        "new_feature"
+      ],
+      "changed_file_count": 2,
+      "commit_shas": [
+        "42aa9fe72e94b5aed23350b9431008ab41310f98"
+      ],
+      "committed_at": "2026-06-11T04:17:32Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27266,
+      "pr_url": "https://github.com/openai/codex/pull/27266",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature.",
+      "sample_paths": [
+        "codex-rs/utils/image/src/image_tests.rs",
+        "codex-rs/utils/image/src/lib.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27266",
       "subject_kind": "pr",
       "surface_hints": [
         "tests_ci"
       ],
-      "title": "Fix compressed rollout search path matching",
-      "url": "https://github.com/openai/codex/pull/27407"
+      "title": "image: preserve metadata when resizing prompt images",
+      "url": "https://github.com/openai/codex/pull/27266"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 5,
+      "commit_shas": [
+        "2536d74dce9c36ccde72b57c8571f64b713d4cb3"
+      ],
+      "committed_at": "2026-06-11T05:47:22Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27103,
+      "pr_url": "https://github.com/openai/codex/pull/27103",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/analytics/src/analytics_client_tests.rs",
+        "codex-rs/analytics/src/events.rs",
+        "codex-rs/analytics/src/facts.rs",
+        "codex-rs/core/src/compact.rs",
+        "codex-rs/core/src/compact_remote_v2.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27103",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "[codex-analytics] report cached input tokens for v2 compaction",
+      "url": "https://github.com/openai/codex/pull/27103"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 2,
+      "commit_shas": [
+        "902b3a655c25808562b40d65765c8034d4639fb2"
+      ],
+      "committed_at": "2026-06-11T06:06:34Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27356,
+      "pr_url": "https://github.com/openai/codex/pull/27356",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/core/src/tools/handlers/dynamic.rs",
+        "codex-rs/core/src/tools/handlers/dynamic_tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27356",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "Use generic search metadata for dynamic tools",
+      "url": "https://github.com/openai/codex/pull/27356"
     }
   ]
 }

--- a/artifacts/github/reviews/openai-codex-pr-26409.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-26409.review.json
@@ -1,0 +1,68 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-26409",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "26409",
+    "commit_shas": [
+      "158fd3ea6eda3a6ee1ba95ad0de76f5cee4f0540"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[plugins] Inject remote_plugin_id into install elicitations",
+        "url": "https://github.com/openai/codex/pull/26409",
+        "meta": "Merged 2026-06-10T19:01:04Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Inject remote plugin identity into install elicitations",
+        "url": "https://github.com/openai/codex/commit/158fd3ea6eda3a6ee1ba95ad0de76f5cee4f0540"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-11T08:09:15Z",
+  "observed_change": "Codex now carries optional remote plugin identity through plugin discovery and injects `remote_plugin_id` plus connector IDs into `request_plugin_install` elicitation `_meta` without exposing those identifiers to the model-facing schema, arguments, or tool result.",
+  "changed_surfaces": [
+    "core plugin discovery data model",
+    "discoverable plugin information passed into tool search",
+    "`request_plugin_install` MCP elicitation metadata",
+    "plugin-install and tool-discovery tests",
+    "model-facing install tool schema boundary"
+  ],
+  "user_visible_path": "When a user approves installing a remote plugin or app connector, the client-side elicitation metadata can now include the exact remote plugin and connector identifiers while the model still sees the same high-level install request.",
+  "control_plane_relevance": "High for Decodex Control Plane because plugin-install orchestration and connector-aware approval UI can use stable remote plugin identity from `_meta` instead of inferring it from display names or local config IDs.",
+  "compatibility_risk": "Moderate for clients or validators that assumed `request_plugin_install` elicitation `_meta` only contained `tool_name` and `install_url`; the new fields are optional, but remote-plugin installs may now depend on preserving them.",
+  "adoption_opportunity": "Preserve `remote_plugin_id` and `app_connector_ids` when Decodex brokers or audits plugin-install elicitations, and add fixtures that ensure model-facing arguments do not leak those backend identifiers.",
+  "community_value": "High for plugin and connector operators because the approval request can carry exact backend identity while keeping sensitive routing metadata out of model-visible tool arguments.",
+  "deprecated_or_breaking_notes": "No model-facing argument or result field is removed; the compatibility change is additive in elicitation `_meta` and in internal discoverable plugin structs.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26409 states that cached remote plugin IDs propagate through discovery and are injected into `request_plugin_install` elicitation `_meta` while staying out of the model-facing schema, arguments, and result.",
+    "`codex-rs/core-plugins/src/discoverable.rs` adds `remote_plugin_id: Option<String>` to `ToolSuggestDiscoverablePlugin` and carries it for remote discoverable plugins.",
+    "`codex-rs/core/src/plugins/discoverable.rs` passes `remote_plugin_id` into `DiscoverablePluginInfo` for tool discovery.",
+    "`codex-rs/tools/src/request_plugin_install.rs` adds optional `remote_plugin_id` and `app_connector_ids` fields to `RequestPluginInstallMeta`.",
+    "`codex-rs/tools/src/request_plugin_install_tests.rs` renames the plugin test around injected metadata and asserts the expected metadata shape.",
+    "`codex-rs/tools/src/tool_discovery.rs` adds `remote_plugin_id` to `DiscoverablePluginInfo` while related tests keep local plugins at `None`.",
+    "The PR body reports targeted `codex-tools`, `codex-core-plugins`, and `codex-core` discovery tests plus formatting checks.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-26409.json` records 9 changed files for the merged PR."
+  ],
+  "caveats": "The source confirms metadata propagation and boundary tests; it does not prove any particular hosted backend currently requires a specific remote plugin ID value.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Plugin-install elicitation metadata changes are directly relevant to Decodex Control Plane plugin approval flows."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The change has a clear public operator angle around exact remote-plugin identity without model-visible leakage."
+    },
+    {
+      "type": "linear_followup",
+      "reason": "Audit Decodex plugin-install probes and fixtures for preservation of `remote_plugin_id` and connector IDs."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-26859.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-26859.review.json
@@ -1,0 +1,77 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-26859",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "26859",
+    "commit_shas": [
+      "57659383ec35538c75d4f35ea8348edd740a0435",
+      "bf636e08e83562fce57cdfd0ca64e0ebafec106f",
+      "186490d934d112d51c400dd54b7f5c887023cd0d",
+      "bc9a3b9cbc07d1ac22fad1f499c51568301884cd"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "fix: Auto-recover from corrupted sqlite databases",
+        "url": "https://github.com/openai/codex/pull/26859",
+        "meta": "Merged 2026-06-10T18:24:29Z"
+      },
+      {
+        "kind": "commit",
+        "title": "fix: Auto-recover from corrupted sqlite databases",
+        "url": "https://github.com/openai/codex/commit/57659383ec35538c75d4f35ea8348edd740a0435"
+      },
+      {
+        "kind": "commit",
+        "title": "PR feedback -- fixing auto recovery to ensure it doesn't recover non-hosed dbs",
+        "url": "https://github.com/openai/codex/commit/bc9a3b9cbc07d1ac22fad1f499c51568301884cd"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-11T08:09:15Z",
+  "observed_change": "Codex now treats detected local runtime SQLite corruption as a backup-and-rebuild path for the interactive CLI and app server, moving only the damaged database files aside and surfacing recovery context to the user.",
+  "changed_surfaces": [
+    "local SQLite runtime initialization and recovery helpers",
+    "interactive CLI startup retry and user notification flow",
+    "app-server state database startup and config warning context",
+    "doctor remediation text for damaged SQLite databases",
+    "TUI startup error database-path reporting",
+    "runtime recovery unit tests"
+  ],
+  "user_visible_path": "When the interactive CLI or app server encounters recoverable SQLite corruption, Codex backs up the damaged runtime database and sidecars under a backup directory, creates a fresh database that can be rebuilt from saved rollouts, and tells the user which database was backed up and where the new one lives.",
+  "control_plane_relevance": "High for Decodex Control Plane because local app-server startup and state readback can now continue after a corrupt runtime database by emitting recovery context instead of requiring manual database removal.",
+  "compatibility_risk": "Moderate for supervisors that interpreted SQLite corruption as a terminal startup failure; lock contention and non-corruption startup errors still fail closed, but recoverable corruption now produces backup paths and a rebuilt runtime database.",
+  "adoption_opportunity": "Teach Decodex operator recovery and app-server probes to recognize the SQLite recovery warning, preserve backup-path evidence, and avoid treating a rebuilt local database as silent data loss.",
+  "community_value": "High for Codex desktop, CLI, and app-server operators because a class of corrupt local database incidents can recover automatically while preserving the damaged files for inspection.",
+  "deprecated_or_breaking_notes": "The doctor guidance changes from only backing up and manually removing or repairing the affected database to restarting the interactive CLI or app server so those entry points can rebuild automatically.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #26859 says corruption from an older SQLite version cannot fully preserve the root database, but rollout data on disk allows Codex to back up the corrupt database and rebuild runtime state.",
+    "`codex-rs/state/src/runtime/recovery.rs` adds `RuntimeDbBackup` plus backup-and-rebuild helpers that move only the corrupted runtime database and SQLite sidecars under `db-backups`.",
+    "`codex-rs/app-server/src/lib.rs` switches state runtime startup to `init_sqlite_state_db_with_fresh_start_on_corruption` and defines the warning summary `Codex rebuilt its local database.`.",
+    "`codex-rs/cli/src/main.rs` changes interactive startup from one attempted repair flag to a set of attempted database backups and retries only when `is_auto_backup_recoverable` matches the startup error.",
+    "`codex-rs/cli/src/doctor.rs` updates remediation to tell users to move the damaged SQLite database aside and restart the interactive CLI or app server so it can rebuild from saved data.",
+    "`codex-rs/tui/src/lib.rs` and `startup_error.rs` carry the specific database path from corruption errors instead of always reporting the state database path.",
+    "`codex-rs/state/src/runtime/recovery_tests.rs` covers moving only the requested runtime database files to the backup folder.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-26859.json` records 13 changed files for the merged PR."
+  ],
+  "caveats": "The source confirms automatic recovery for interactive CLI and app-server entry points; other entry points may still require manual recovery, and the rebuilt runtime database depends on saved rollout files being available.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The startup recovery behavior changes Decodex app-server failure handling and operator recovery evidence."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "Automatic SQLite backup-and-rebuild is a clear public reliability improvement for Codex operators."
+    },
+    {
+      "type": "linear_followup",
+      "reason": "Decodex should recognize and preserve SQLite recovery warnings in operator readback and recovery runbooks."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-27064.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27064.review.json
@@ -1,0 +1,71 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27064",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27064",
+    "commit_shas": [
+      "d0dcb2a19f0ed125bb8dbdfc61fdadc346667b59",
+      "c7e1523503f1e1f9f979e686d34fa31133cba194",
+      "52c6ed6ff8e71895aa6fe067bf99521f37265a89",
+      "ac05fffdb3bd224c28cb6819e288ae43b09ac1e5"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] remove blocking external agent migration flow",
+        "url": "https://github.com/openai/codex/pull/27064",
+        "meta": "Merged 2026-06-10T18:25:04Z"
+      },
+      {
+        "kind": "commit",
+        "title": "tui: remove startup external agent migration",
+        "url": "https://github.com/openai/codex/commit/d0dcb2a19f0ed125bb8dbdfc61fdadc346667b59"
+      },
+      {
+        "kind": "commit",
+        "title": "tui: preserve migration picker for stacked flow",
+        "url": "https://github.com/openai/codex/commit/52c6ed6ff8e71895aa6fe067bf99521f37265a89"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-11T08:09:15Z",
+  "observed_change": "Codex removes the startup-blocking external-agent configuration migration prompt, marks the `external_migration` feature as a removed no-op, and keeps the picker code dormant for a later deliberate import flow.",
+  "changed_surfaces": [
+    "TUI startup path",
+    "external-agent migration feature flag lifecycle",
+    "TUI app-server migration helper wrappers",
+    "external-agent migration startup module",
+    "startup bootstrap and hook prefetch sequencing"
+  ],
+  "user_visible_path": "Users with migratable external-agent configuration should no longer be interrupted by an automatic startup prompt; normal TUI startup enters Codex immediately until a later `/import` flow is wired in.",
+  "control_plane_relevance": "Moderate for Decodex because external-agent import becomes an explicit user-initiated flow rather than a startup blocker, so automation and operator guidance should not expect the old automatic migration prompt.",
+  "compatibility_risk": "Moderate for integrations or docs that depended on the `external_migration` startup prompt or TUI app-server migration wrappers; the feature key remains present only as `Stage::Removed` compatibility input.",
+  "adoption_opportunity": "Track the follow-up `/import` stack before creating Decodex user guidance, and remove any assumption that Codex startup will automatically detect and offer external-agent migration.",
+  "community_value": "Medium as startup friction reduction, but the PR is stack item 1 and intentionally defers the replacement import experience to later PRs.",
+  "deprecated_or_breaking_notes": "`external_migration` is changed from experimental to removed, `external_agent_config_migration_startup.rs` is deleted, and TUI startup no longer calls external-agent migration detection before bootstrapping.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27064 says external-agent import should be initiated deliberately instead of interrupting eligible TUI startups, and lists this PR as stack item 1 before the new picker and `/import` flow.",
+    "`codex-rs/features/src/lib.rs` changes the `ExternalMigration` feature description to a removed compatibility flag and sets its stage to `Stage::Removed`.",
+    "`codex-rs/tui/src/app.rs` removes the startup migration outcome and handler from app construction.",
+    "`codex-rs/tui/src/app_server_session.rs` removes TUI helper wrappers for external-agent detect and import requests.",
+    "`codex-rs/tui/src/external_agent_config_migration_startup.rs` is deleted, removing the startup prompt implementation.",
+    "`codex-rs/tui/src/lib.rs` no longer defers bootstrap for the migration prompt and keeps `external_agent_config_migration` behind a module-scoped dead-code allowance.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27064.json` records 6 changed files for the merged PR."
+  ],
+  "caveats": "This review covers the removal of the blocking startup flow only; the replacement picker UX and `/import` command are separate queued PRs and should supply the public try path.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The change alters external-agent migration startup assumptions and should be tracked for Control Plane guidance."
+    },
+    {
+      "type": "linear_followup",
+      "reason": "Check Decodex docs and operator prompts for references to automatic startup external-agent migration after the full import stack lands."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-27065.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27065.review.json
@@ -1,0 +1,55 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27065",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27065",
+    "commit_shas": [
+      "78a9d823a89350a2ab49ee0b3ea2e3bf48685ff7"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] extract external agent import picker renderer",
+        "url": "https://github.com/openai/codex/pull/27065",
+        "meta": "Merged 2026-06-10T18:48:31Z"
+      },
+      {
+        "kind": "commit",
+        "title": "tui: extract external agent migration renderer",
+        "url": "https://github.com/openai/codex/commit/78a9d823a89350a2ab49ee0b3ea2e3bf48685ff7"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-11T08:09:15Z",
+  "observed_change": "Codex moves external-agent migration screen rendering into a dedicated `render` module while preserving the existing picker behavior for later stack items.",
+  "changed_surfaces": [
+    "TUI external-agent migration rendering module",
+    "external-agent migration screen widget implementation",
+    "test coverage for external-agent migration rendering"
+  ],
+  "user_visible_path": "No confirmed new user-visible behavior in this PR; it is explicitly described as behavior-neutral preparation for a later external-agent import picker UX.",
+  "control_plane_relevance": "Low for Decodex Control Plane by itself because the PR refactors TUI presentation code without changing import authority, app-server protocol, or runtime behavior.",
+  "compatibility_risk": "Low; source compatibility is limited to upstream TUI internals around the external-agent migration screen.",
+  "adoption_opportunity": "No direct Decodex adoption action from this PR alone; consume it only as background for the later `/import` flow review.",
+  "community_value": "Low as a standalone item because the PR body states the layer is behavior-neutral and intended to make the next picker UX easier to review.",
+  "deprecated_or_breaking_notes": "No deprecated or removed user behavior is introduced by this refactor; earlier removal of the startup prompt belongs to PR #27064.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27065 states that the rendering refactor is intended to be behavior-neutral and is stack item 2 before the new picker UX.",
+    "`codex-rs/tui/src/external_agent_config_migration.rs` removes rendering imports and declares `mod render` while retaining interaction state and event handling.",
+    "`codex-rs/tui/src/external_agent_config_migration/render.rs` is added with the `WidgetRef` implementation for `ExternalAgentConfigMigrationScreen`.",
+    "The PR body reports `just test -p codex-tui external_agent_config_migration` passing 10 tests.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27065.json` records 2 changed files for the merged PR."
+  ],
+  "caveats": "This is a source-organization review, not evidence that the later external-agent import UX has shipped.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Record an explicit skip/none impact so downstream release and Publisher automation do not treat the refactor as a standalone public signal."
+    }
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-26409.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-26409.json
@@ -1,0 +1,56 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-26409",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "critical",
+  "audience": "Codex plugin, connector, and Control Plane operators",
+  "candidate_text": [
+    "Codex plugin install approvals can now carry exact remote-plugin identity in elicitation `_meta` (`remote_plugin_id` and connector IDs) while keeping those backend IDs out of model-facing args/results. PR: https://github.com/openai/codex/pull/26409"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26409.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26409.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26409"
+    ]
+  },
+  "evidence_notes": [
+    "The PR body says `remote_plugin_id` and connector IDs are injected into `request_plugin_install` elicitation `_meta`.",
+    "`DiscoverablePluginInfo` and core plugin discovery now carry optional `remote_plugin_id`.",
+    "`RequestPluginInstallMeta` adds optional `remote_plugin_id` and `app_connector_ids`.",
+    "The PR explicitly keeps remote plugin identity out of model-facing schema, arguments, and results."
+  ],
+  "claims": [
+    {
+      "text": "Remote plugin install elicitations can carry exact remote plugin and connector identifiers in `_meta`.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26409.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Those backend identifiers are not added to model-visible install tool arguments or results.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26409.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR changes plugin-install approval metadata in a way plugin and Control Plane operators can act on.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26409:operator_impact"
+  },
+  "caveats": [
+    "The new metadata fields are optional and additive.",
+    "The source does not prove a specific hosted backend rollout.",
+    "Clients should preserve unknown `_meta` fields even when they do not render them."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this candidate.",
+    "Audit Decodex plugin-install probes for preservation of `remote_plugin_id` and connector IDs."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-26859.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-26859.json
@@ -1,0 +1,56 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-26859",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "critical",
+  "audience": "Codex desktop, CLI, and app-server operators",
+  "candidate_text": [
+    "Codex now auto-recovers from corrupted local SQLite runtime DBs: it backs up the damaged DB and sidecars, rebuilds from saved rollouts, and surfaces the recovery paths to CLI/app users. PR: https://github.com/openai/codex/pull/26859"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-26859.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-26859.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/26859"
+    ]
+  },
+  "evidence_notes": [
+    "The PR body says Codex now auto-backs-up and rebuilds local runtime databases when corruption is recoverable.",
+    "`runtime/recovery.rs` moves only the damaged database files and sidecars into a `db-backups` folder.",
+    "The app-server path emits the warning summary `Codex rebuilt its local database.`.",
+    "The interactive CLI reports the backed-up corrupt database and new database paths."
+  ],
+  "claims": [
+    {
+      "text": "Codex can automatically back up and rebuild a recoverably corrupted local SQLite runtime database in interactive CLI and app-server entry points.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-26859.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The damaged database files are moved aside instead of silently discarded.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-26859.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR gives Codex operators a concrete reliability and recovery behavior with clear source-backed caveats.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-26859:operator_impact"
+  },
+  "caveats": [
+    "Recovered runtime state depends on saved rollout files.",
+    "Other entry points may still require manual recovery.",
+    "Lock contention and non-corruption errors remain separate failure modes."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this candidate.",
+    "Update Decodex recovery guidance if app-server status readback needs to expose SQLite rebuild warnings."
+  ]
+}


### PR DESCRIPTION
## Summary
- refreshed the deterministic openai/codex upstream review queue
- added GitHub change bundles plus source-backed upstream reviews for PRs 26859, 27064, 27065, and 26409
- added upstream impact records for all four subjects
- added social_candidate/v1 handoffs only for PRs 26859 and 26409; no social_post/v1 artifacts or X publishing

## Validation
- `cargo run -p decodex --bin decodex -- radar bundle validate artifacts/github/bundles/openai-codex-pr-26859.json artifacts/github/bundles/openai-codex-pr-27064.json artifacts/github/bundles/openai-codex-pr-27065.json artifacts/github/bundles/openai-codex-pr-26409.json` passed
- `cargo make check-site-content` passed: 356 Radar artifact JSON files validated
- `cargo make fmt` passed
- `cargo make lint-fix` passed and applied 0 fixes
- `cargo make test` passed: 1055 tests passed, 1 skipped
