### PR TITLE
Persist upstream Radar reviews for import and plugin changes

### DIFF
--- a/artifacts/github/bundles/openai-codex-pr-27071.json
+++ b/artifacts/github/bundles/openai-codex-pr-27071.json
@@ -1,0 +1,215 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "stefanstokic-oai",
+      "committed_at": "2026-06-10T19:33:22Z",
+      "message": "tui: add explicit external agent import command",
+      "sha": "ee228545d822de157518dec714dca4f13cbd3374",
+      "url": "https://github.com/openai/codex/commit/ee228545d822de157518dec714dca4f13cbd3374"
+    },
+    {
+      "author": "stefanstokic-oai",
+      "committed_at": "2026-06-10T19:35:59Z",
+      "message": "tui: make external agent import copy generic",
+      "sha": "15bbbdf663d80d399cdadefd6987bf17999faab6",
+      "url": "https://github.com/openai/codex/commit/15bbbdf663d80d399cdadefd6987bf17999faab6"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "PROMPT",
+    "CLI",
+    "TUI",
+    "API",
+    "CODEX_HOME",
+    "JSONRPCE",
+    "EXTERNAL_AGENT_CONFIG_MIGRATION_FINISHED_MESSAGE",
+    "EXTERNAL_AGENT_CONFIG_MIGRATION_NO_ITEMS_MESSAGE",
+    "UUID",
+    "JSONRPC_INVALID_REQUEST",
+    "JSONRPC_METHOD_NOT_FOUND",
+    "EXTERNAL_AGENT_CONFIG_IMPORT_IN_PROGRESS_MESSAGE",
+    "THREAD_SETTINGS_UPDATE_METHOD",
+    "EXTERNAL_AGENT_CONFIG_MIGRATION_REMOTE_UNAVAILABLE_MESSAGE",
+    "EXTERNAL_AGENT_CONFIG_MIGRATION_DAEMON_UNAVAILABLE_MESSAGE"
+  ],
+  "files": [
+    {
+      "additions": 8,
+      "deletions": 0,
+      "patch_excerpt": "@@ -158,6 +158,7 @@ pub(crate) fn server_notification_requires_delivery(notification: &ServerNotific\n         ServerNotification::TurnCompleted(_)\n             | ServerNotification::ThreadSettingsUpdated(_)\n             | ServerNotification::ItemCompleted(_)\n+            | ServerNotification::ExternalAgentConfigImportCompleted(_)\n             | ServerNotification::AgentMessageDelta(_)\n             | ServerNotification::PlanDelta(_)\n             | ServerNotification::ReasoningSummaryTextDelta(_)\n@@ -2139,6 +2140,13 @@ mod tests {\n                 )\n             )\n         ));\n+        assert!(event_requires_delivery(\n+            &InProcessServerEvent::ServerNotification(\n+                codex_app_server_protocol::ServerNotification::ExternalAgentConfigImportCompleted(\n+                    codex_app_server_protocol::ExternalAgentConfigImportCompletedNotification {},\n+                )\n+ ...",
+      "path": "codex-rs/app-server-client/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 9,
+      "deletions": 1,
+      "patch_excerpt": "@@ -104,7 +104,9 @@ type PendingClientRequestResponse = std::result::Result<Result, JSONRPCErrorErro\n fn server_notification_requires_delivery(notification: &ServerNotification) -> bool {\n     matches!(\n         notification,\n-        ServerNotification::TurnCompleted(_) | ServerNotification::ThreadSettingsUpdated(_)\n+        ServerNotification::TurnCompleted(_)\n+            | ServerNotification::ThreadSettingsUpdated(_)\n+            | ServerNotification::ExternalAgentConfigImportCompleted(_)\n     )\n }\n \n@@ -729,6 +731,7 @@ mod tests {\n     use super::*;\n     use codex_app_server_protocol::ClientInfo;\n     use codex_app_server_protocol::ConfigRequirementsReadResponse;\n+    use codex_app_server_protocol::ExternalAgentConfigImportCompletedNotification;\n     use codex_app_server_protocol::SessionSource as ApiSessionSource;\n     use codex_app_server_protocol::ThreadStartParams;\n     use code...",
+      "path": "codex-rs/app-server/src/in_process.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 8,
+      "deletions": 0,
+      "patch_excerpt": "@@ -2600,6 +2600,14 @@ mod tests {\n         );\n     }\n \n+    #[test]\n+    fn import_remains_an_interactive_prompt() {\n+        let cli = MultitoolCli::try_parse_from([\"codex\", \"import\"]).expect(\"parse\");\n+\n+        assert!(cli.subcommand.is_none());\n+        assert_eq!(cli.interactive.prompt.as_deref(), Some(\"import\"));\n+    }\n+\n     #[test]\n     fn profile_v2_rejects_non_plain_names_at_parse_time() {\n         assert!(",
+      "path": "codex-rs/cli/src/main.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 10,
+      "deletions": 1,
+      "patch_excerpt": "@@ -93,16 +93,25 @@ impl App {\n                 return;\n             }\n             ServerNotification::ExternalAgentConfigImportCompleted(_) => {\n-                let cwd = self.chat_widget.config_ref().cwd.to_path_buf();\n+                let should_report_completion =\n+                    app_server_client.consume_external_agent_config_import_completion();\n                 if let Err(err) = self.refresh_in_memory_config_from_disk().await {\n                     tracing::warn!(\n                         error = %err,\n                         \"failed to refresh config after external agent config import\"\n                     );\n                 }\n+                let cwd = self.chat_widget.config_ref().cwd.to_path_buf();\n                 self.chat_widget.refresh_plugin_mentions();\n                 self.chat_widget.submit_op(AppCommand::reload_user_config());\n                 self.fetch_plug...",
+      "path": "codex-rs/tui/src/app/app_server_events.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 26,
+      "deletions": 0,
+      "patch_excerpt": "@@ -6,6 +6,7 @@\n use super::resize_reflow::trailing_run_start;\n use super::*;\n use crate::config_update::format_config_error;\n+use crate::external_agent_config_migration_flow::ExternalAgentConfigMigrationFlowOutcome;\n #[cfg(target_os = \"windows\")]\n use codex_config::types::WindowsSandboxModeToml;\n \n@@ -110,6 +111,31 @@ impl App {\n                 // Leaving alt-screen may blank the inline viewport; force a redraw either way.\n                 tui.frame_requester().schedule_frame();\n             }\n+            AppEvent::OpenExternalAgentConfigMigration => {\n+                match crate::external_agent_config_migration_flow::handle_external_agent_config_migration_prompt(\n+                    tui,\n+                    app_server,\n+                    &self.config,\n+                )\n+                .await\n+                {\n+                    Ok(ExternalAgentConfigMigrationFlowOutcome::St...",
+      "path": "codex-rs/tui/src/app/event_dispatch.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 0,
+      "patch_excerpt": "@@ -221,6 +221,9 @@ pub(crate) enum AppEvent {\n     /// Open the resume picker inside the running TUI session.\n     OpenResumePicker,\n \n+    /// Open the external agent migration picker inside the running TUI session.\n+    OpenExternalAgentConfigMigration,\n+\n     /// Resume a thread by UUID or thread name inside the running TUI session.\n     ResumeSessionByIdOrName(String),",
+      "path": "codex-rs/tui/src/app_event.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 67,
+      "deletions": 0,
+      "patch_excerpt": "@@ -22,6 +22,11 @@ use codex_app_server_protocol::AuthMode;\n use codex_app_server_protocol::ClientRequest;\n use codex_app_server_protocol::ConfigBatchWriteParams;\n use codex_app_server_protocol::ConfigWriteResponse;\n+use codex_app_server_protocol::ExternalAgentConfigDetectParams;\n+use codex_app_server_protocol::ExternalAgentConfigDetectResponse;\n+use codex_app_server_protocol::ExternalAgentConfigImportParams;\n+use codex_app_server_protocol::ExternalAgentConfigImportResponse;\n+use codex_app_server_protocol::ExternalAgentConfigMigrationItem;\n use codex_app_server_protocol::GetAccountParams;\n use codex_app_server_protocol::GetAccountRateLimitsResponse;\n use codex_app_server_protocol::GetAccountResponse;\n@@ -123,12 +128,16 @@ use color_eyre::eyre::Result;\n use color_eyre::eyre::WrapErr;\n use std::collections::HashMap;\n use std::path::PathBuf;\n+use std::sync::atomic::AtomicBool;\n+use std::syn...",
+      "path": "codex-rs/tui/src/app_server_session.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 5,
+      "deletions": 0,
+      "patch_excerpt": "@@ -398,6 +398,10 @@ impl ChatWidget {\n             SlashCommand::Skills => {\n                 self.open_skills_menu();\n             }\n+            SlashCommand::Import => {\n+                self.app_event_tx\n+                    .send(AppEvent::OpenExternalAgentConfigMigration);\n+            }\n             SlashCommand::Hooks => {\n                 self.add_hooks_output();\n             }\n@@ -1010,6 +1014,7 @@ impl ChatWidget {\n             | SlashCommand::Logout\n             | SlashCommand::Mention\n             | SlashCommand::Skills\n+            | SlashCommand::Import\n             | SlashCommand::Hooks\n             | SlashCommand::Title\n             | SlashCommand::Statusline",
+      "path": "codex-rs/tui/src/chatwidget/slash_dispatch.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 12,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1861,6 +1861,18 @@ async fn slash_resume_opens_picker() {\n     assert_matches!(rx.try_recv(), Ok(AppEvent::OpenResumePicker));\n }\n \n+#[tokio::test]\n+async fn slash_import_opens_claude_code_import_picker() {\n+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;\n+\n+    chat.dispatch_command(SlashCommand::Import);\n+\n+    assert_matches!(\n+        rx.try_recv(),\n+        Ok(AppEvent::OpenExternalAgentConfigMigration)\n+    );\n+}\n+\n #[tokio::test]\n async fn slash_archive_confirmation_requests_current_thread_archive() {\n     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;",
+      "path": "codex-rs/tui/src/chatwidget/tests/slash_commands.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -758,7 +758,7 @@ mod tests {\n             },\n             ExternalAgentConfigMigrationItem {\n                 item_type: ExternalAgentConfigMigrationItemType::Sessions,\n-                description: \"Migrate recent Claude Code sessions\".to_string(),\n+                description: \"Migrate recent chat sessions\".to_string(),\n                 cwd: None,\n                 details: Some(codex_app_server_protocol::MigrationDetails {\n                     sessions: vec![SessionMigration {",
+      "path": "codex-rs/tui/src/external_agent_config_migration.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 5,
+      "deletions": 5,
+      "patch_excerpt": "@@ -80,13 +80,13 @@ impl WidgetRef for &ExternalAgentConfigMigrationScreen {\n             MigrationView::Summary => vec![\n                 Line::from(\"Bring over your setup, current project, and recent chats.\"),\n                 Line::from(\"Codex may add files to your current project folder.\"),\n-                Line::from(\"Your existing Claude Code setup will not be changed.\"),\n-                Line::from(\"Standard Claude Chat data cannot be imported.\"),\n+                Line::from(\"Your existing agent setup will not be changed.\"),\n+                Line::from(\"Cloud-hosted chat data cannot be imported.\"),\n             ],\n             MigrationView::Customize => vec![\n-                Line::from(\"Choose the Claude Code items to import.\"),\n+                Line::from(\"Choose the items to import.\"),\n                 Line::from(\"Codex may add files to your current project folder.\"),\n-       ...",
+      "path": "codex-rs/tui/src/external_agent_config_migration/render.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 125,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,125 @@\n+use crate::app_server_session::AppServerSession;\n+use crate::app_server_session::EXTERNAL_AGENT_CONFIG_IMPORT_IN_PROGRESS_MESSAGE;\n+use crate::external_agent_config_migration::ExternalAgentConfigMigrationOutcome;\n+use crate::external_agent_config_migration::run_external_agent_config_migration_prompt;\n+use crate::legacy_core::config::Config;\n+use crate::tui;\n+use codex_app_server_protocol::ExternalAgentConfigDetectParams;\n+\n+pub(crate) const EXTERNAL_AGENT_CONFIG_MIGRATION_FINISHED_MESSAGE: &str =\n+    \"Agent import finished. Run /import again to check for additional items.\";\n+pub(crate) const EXTERNAL_AGENT_CONFIG_MIGRATION_NO_ITEMS_MESSAGE: &str =\n+    \"No supported agent setup was found to import.\";\n+pub(crate) const EXTERNAL_AGENT_CONFIG_MIGRATION_REMOTE_UNAVAILABLE_MESSAGE: &str =\n+    \"Agent import is unavailable in remote sessions. Start Codex locally and run /im...",
+      "path": "codex-rs/tui/src/external_agent_config_migration_flow.rs",
+      "status": "added"
+    },
+    {
+      "additions": 21,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,21 @@\n+use super::*;\n+\n+#[test]\n+fn external_agent_config_migration_messages_snapshot() {\n+    let cases = [0, 1, 2];\n+\n+    let messages = cases\n+        .map(external_agent_config_migration_success_message)\n+        .into_iter()\n+        .chain([\n+            EXTERNAL_AGENT_CONFIG_MIGRATION_FINISHED_MESSAGE.to_string(),\n+            EXTERNAL_AGENT_CONFIG_MIGRATION_NO_ITEMS_MESSAGE.to_string(),\n+            EXTERNAL_AGENT_CONFIG_MIGRATION_REMOTE_UNAVAILABLE_MESSAGE.to_string(),\n+            EXTERNAL_AGENT_CONFIG_MIGRATION_DAEMON_UNAVAILABLE_MESSAGE.to_string(),\n+            EXTERNAL_AGENT_CONFIG_IMPORT_IN_PROGRESS_MESSAGE.to_string(),\n+        ])\n+        .collect::<Vec<_>>()\n+        .join(\"\\n\");\n+\n+    insta::assert_snapshot!(\"external_agent_config_migration_messages\", messages);\n+}",
+      "path": "codex-rs/tui/src/external_agent_config_migration_flow_tests.rs",
+      "status": "added"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -130,8 +130,8 @@ mod diff_model;\n mod diff_render;\n mod exec_cell;\n mod exec_command;\n-#[allow(dead_code)]\n mod external_agent_config_migration;\n+mod external_agent_config_migration_flow;\n mod external_agent_config_migration_model;\n mod external_editor;\n mod file_search;",
+      "path": "codex-rs/tui/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 5,
+      "deletions": 0,
+      "patch_excerpt": "@@ -26,6 +26,7 @@ pub enum SlashCommand {\n     AutoReview,\n     Memories,\n     Skills,\n+    Import,\n     Hooks,\n     Review,\n     Rename,\n@@ -98,6 +99,9 @@ impl SlashCommand {\n             SlashCommand::Diff => \"show git diff (including untracked files)\",\n             SlashCommand::Mention => \"mention a file\",\n             SlashCommand::Skills => \"use skills to improve how Codex performs specific tasks\",\n+            SlashCommand::Import => {\n+                \"import setup, this project, and recent chats from another coding agent\"\n+            }\n             SlashCommand::Hooks => \"view and manage lifecycle hooks\",\n             SlashCommand::Status => \"show current session configuration and token usage\",\n             SlashCommand::DebugConfig => \"show config layers and requirement sources for debugging\",\n@@ -198,6 +202,7 @@ impl SlashCommand {\n             | SlashCommand::SandboxReadRoot...",
+      "path": "codex-rs/tui/src/slash_command.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 3,
+      "patch_excerpt": "@@ -4,14 +4,14 @@ expression: rendered\n ---\n \n   > Choose what to import\n-  Choose the Claude Code items to import.\n+  Choose the items to import.\n   Codex may add files to your current project folder.\n-  Your existing Claude Code setup will not be changed.\n+  Your existing agent setup will not be changed.\n   Home\n   › [x] Settings (settings.json -> config.toml)\n         Import /Users/alex/.claude/settings.json into /Users/alex/.codex/conf…\n     [x] Recent chat sessions\n-        Import recent Claude Code sessions\n+        Import recent chat sessions\n         1 chat session: Investigate migration UX\n \n   Current project: /workspace/project",
+      "path": "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize.snap",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 3,
+      "patch_excerpt": "@@ -4,14 +4,14 @@ expression: rendered\n ---\n \n   > Choose what to import\n-  Choose the Claude Code items to import.\n+  Choose the items to import.\n   Codex may add files to your current project folder.\n-  Your existing Claude Code setup will not be changed.\n+  Your existing agent setup will not be changed.\n   Home\n     [x] Settings (settings.json -> config.toml)\n         Import /Users/alex/.claude/settings.json into /Users/alex/.codex/conf…\n     [x] Recent chat sessions\n-        Import recent Claude Code sessions\n+        Import recent chat sessions\n         1 chat session: Investigate migration UX\n \n   Current project: /workspace/project",
+      "path": "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_action.snap",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 3,
+      "patch_excerpt": "@@ -4,14 +4,14 @@ expression: rendered\n ---\n \n   > Choose what to import\n-  Choose the Claude Code items to import.\n+  Choose the items to import.\n   Codex may add files to your current project folder.\n-  Your existing Claude Code setup will not be changed.\n+  Your existing agent setup will not be changed.\n   Home\n     [x] Settings (settings.json -> config.toml)\n         Import /Users/alex/.claude/settings.json into /Users/alex/.codex/conf…\n     [x] Recent chat sessions\n-        Import recent Claude Code sessions\n+        Import recent chat sessions\n         1 chat session: Investigate migration UX\n \n   Current project: C:\\workspace\\project",
+      "path": "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_action_windows.snap",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 3,
+      "patch_excerpt": "@@ -4,14 +4,14 @@ expression: rendered\n ---\n \n   > Choose what to import\n-  Choose the Claude Code items to import.\n+  Choose the items to import.\n   Codex may add files to your current project folder.\n-  Your existing Claude Code setup will not be changed.\n+  Your existing agent setup will not be changed.\n   Home\n   › [x] Settings (settings.json -> config.toml)\n         Import /Users/alex/.claude/settings.json into /Users/alex/.codex/conf…\n     [x] Recent chat sessions\n-        Import recent Claude Code sessions\n+        Import recent chat sessions\n         1 chat session: Investigate migration UX\n \n   Current project: C:\\workspace\\project",
+      "path": "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_windows.snap",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 3,
+      "patch_excerpt": "@@ -3,11 +3,11 @@ source: tui/src/external_agent_config_migration.rs\n expression: rendered\n ---\n \n-  > Import from Claude Code\n+  > Import from another coding agent\n   Bring over your setup, current project, and recent chats.\n   Codex may add files to your current project folder.\n-  Your existing Claude Code setup will not be changed.\n-  Standard Claude Chat data cannot be imported.\n+  Your existing agent setup will not be changed.\n+  Cloud-hosted chat data cannot be imported.\n     [x] Tools & setup\n         Settings, instructions, integrations, agents, commands, and skills\n     [x] Current project",
+      "path": "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_prompt.snap",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 3,
+      "patch_excerpt": "@@ -3,11 +3,11 @@ source: tui/src/external_agent_config_migration.rs\n expression: rendered\n ---\n \n-  > Import from Claude Code\n+  > Import from another coding agent\n   Bring over your setup, current project, and recent chats.\n   Codex may add files to your current project folder.\n-  Your existing Claude Code setup will not be changed.\n-  Standard Claude Chat data cannot be imported.\n+  Your existing agent setup will not be changed.\n+  Cloud-hosted chat data cannot be imported.\n     [x] Tools & setup\n         Settings, instructions, integrations, agents, commands, and skills\n     [x] Current project",
+      "path": "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_prompt_windows.snap",
+      "status": "modified"
+    },
+    {
+      "additions": 12,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,12 @@\n+---\n+source: tui/src/external_agent_config_migration_flow_tests.rs\n+expression: messages\n+---\n+Agent import started. You can keep working while it finishes. Imported setup will apply to new chats.\n+Agent import started. You can keep working while it finishes. Imported setup will apply to new chats. 1 additional item remains. After it finishes, run /import again to review it.\n+Agent import started. You can keep working while it finishes. Imported setup will apply to new chats. 2 additional items remain. After it finishes, run /import again to review them.\n+Agent import finished. Run /import again to check for additional items.\n+No supported agent setup was found to import.\n+Agent import is unavailable in remote sessions. Start Codex locally and run /import.\n+Agent import is unavailable while Codex is connected to the local app-server daemon. Stop the daemon, restart Code...",
+      "path": "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration_flow__tests__external_agent_config_migration_messages.snap",
+      "status": "added"
+    }
+  ],
+  "linked_issues": [
+    "#27064",
+    "#27065",
+    "#27070",
+    "#27071"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nExternal-agent import should be discoverable and deliberate without blocking startup or claiming the public `codex [PROMPT]` CLI namespace. The slash command keeps the flow local to the interactive TUI and reuses the existing app-server import API.\n\n## What changed\n\n- add the user-facing `/import` slash command\n- detect external-agent importable items only when the command is invoked\n- run imports through the embedded local app-server\n- show start and completion messages, refresh configuration, and block duplicate imports while one is pending\n- reject the flow for unsupported remote and local-daemon sessions\n\n## Validation\n\n- `just test -p codex-tui external_agent_config_migration` (10 passed)\n- manually exercised an isolated TUI fixture with existing external-agent setup and session data using a fresh `CODEX_HOME`\n- verified picker customization, plugin and session detection, import completion, repeated invocation, and imported-session resume context\n- the broader `just test -p codex-tui` run passed 2,805 tests, with 2 unrelated guardian feature-flag failures and 4 skipped tests\n\n## Draft follow-ups\n\n- review whether completion messaging should remain attached to the initiating chat if the user switches chats during an import\n- review shutdown semantics for an in-progress background import\n\n## Stack\n\n1. [#27064](https://github.com/openai/codex/pull/27064): remove the startup migration flow\n2. [#27065](https://github.com/openai/codex/pull/27065): extract the picker renderer\n3. [#27070](https://github.com/openai/codex/pull/27070): add the external-agent import picker UX\n4. [#27071](https://github.com/openai/codex/pull/27071): expose the flow through `/import`\n\n**This PR is stack item 4.** Draft while the lower stack dependencies are reviewed.",
+    "labels": [],
+    "merged_at": "2026-06-10T19:53:16Z",
+    "number": 27071,
+    "state": "merged",
+    "title": "[codex] add /import for external agents",
+    "url": "https://github.com/openai/codex/pull/27071"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27311.json
+++ b/artifacts/github/bundles/openai-codex-pr-27311.json
@@ -1,0 +1,87 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "xl-openai",
+      "committed_at": "2026-06-10T04:41:58Z",
+      "message": "Skip local curated discovery for remote plugins",
+      "sha": "a323ed156e4bf7c1ae57cb0bb2d7f7d0d8a83b75",
+      "url": "https://github.com/openai/codex/commit/a323ed156e4bf7c1ae57cb0bb2d7f7d0d8a83b75"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "CPU",
+    "--check",
+    "OPENAI_CURATED_MARKETPLACE_NAME",
+    "CONFIG_TOML_FILE"
+  ],
+  "files": [
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -1147,7 +1147,7 @@ fn configured_marketplace_plugins(\n ) -> io::Result<BTreeMap<String, HashSet<String>>> {\n     let plugins_input = config.plugins_config_input();\n     let marketplaces = plugins_manager\n-        .list_marketplaces_for_config(&plugins_input, &[])\n+        .list_marketplaces_for_config(&plugins_input, &[], /*include_openai_curated*/ true)\n         .map_err(|err| {\n             invalid_data_error(format!(\"failed to list configured marketplaces: {err}\"))\n         })?;",
+      "path": "codex-rs/app-server/src/config/external_agent_config.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 6,
+      "deletions": 2,
+      "patch_excerpt": "@@ -573,6 +573,7 @@ impl PluginRequestProcessor {\n                     .list_marketplaces_for_config(\n                         &config_for_marketplace_listing,\n                         &roots_for_marketplace_listing,\n+                        /*include_openai_curated*/ true,\n                     )?;\n                 Ok::<\n                     (\n@@ -837,8 +838,11 @@ impl PluginRequestProcessor {\n         let config_for_marketplace_listing = plugins_input.clone();\n         let shared_plugin_ids_by_local_path = load_shared_plugin_ids_by_local_path(config)?;\n         match tokio::task::spawn_blocking(move || {\n-            let outcome = plugins_manager\n-                .list_marketplaces_for_config(&config_for_marketplace_listing, &roots)?;\n+            let outcome = plugins_manager.list_marketplaces_for_config(\n+                &config_for_marketplace_listing,\n+                &roots,\n+     ...",
+      "path": "codex-rs/app-server/src/request_processors/plugins.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 2,
+      "patch_excerpt": "@@ -204,7 +204,7 @@ pub async fn run_plugin_list(\n         ..\n     } = load_plugin_command_context(overrides).await?;\n     let outcome = manager\n-        .list_marketplaces_for_config(&plugins_input, &[])\n+        .list_marketplaces_for_config(&plugins_input, &[], /*include_openai_curated*/ true)\n         .context(\"failed to list marketplace plugins\")?;\n     ensure_configured_marketplace_snapshots_loaded(\n         codex_home.as_path(),\n@@ -609,7 +609,7 @@ fn find_marketplace_for_plugin(\n     plugin_name: &str,\n ) -> Result<ConfiguredMarketplace> {\n     let outcome = manager\n-        .list_marketplaces_for_config(plugins_input, &[])\n+        .list_marketplaces_for_config(plugins_input, &[], /*include_openai_curated*/ true)\n         .context(\"failed to list marketplace plugins\")?;\n     ensure_configured_marketplace_snapshots_loaded(\n         codex_home,",
+      "path": "codex-rs/cli/src/plugin_cmd.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 5,
+      "deletions": 6,
+      "patch_excerpt": "@@ -86,7 +86,11 @@ impl PluginsManager {\n         }\n \n         let marketplaces = self\n-            .list_marketplaces_for_config(&input.plugins, &[])\n+            .list_marketplaces_for_config(\n+                &input.plugins,\n+                &[],\n+                /*include_openai_curated*/ !input.plugins.remote_plugin_enabled,\n+            )\n             .context(\"failed to list plugin marketplaces for tool suggestions\")?\n             .marketplaces;\n         let mut installed_app_connector_ids = self\n@@ -109,11 +113,6 @@ impl PluginsManager {\n         let mut discoverable_plugins = Vec::<ToolSuggestDiscoverablePlugin>::new();\n         for marketplace in marketplaces {\n             let marketplace_name = marketplace.name;\n-            if input.plugins.remote_plugin_enabled\n-                && marketplace_name == OPENAI_CURATED_MARKETPLACE_NAME\n-            {\n-                continue;\n...",
+      "path": "codex-rs/core-plugins/src/discoverable.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 7,
+      "deletions": 2,
+      "patch_excerpt": "@@ -992,14 +992,19 @@ impl PluginsManager {\n         &self,\n         config: &PluginsConfigInput,\n         additional_roots: &[AbsolutePathBuf],\n+        include_openai_curated: bool,\n     ) -> Result<ConfiguredMarketplaceListOutcome, MarketplaceError> {\n         if !config.plugins_enabled {\n             return Ok(ConfiguredMarketplaceListOutcome::default());\n         }\n \n         let (installed_plugins, enabled_plugins) = self.configured_plugin_states(config);\n-        let marketplace_outcome =\n-            self.discover_marketplaces_for_config(config, additional_roots)?;\n+        let mut marketplace_roots = self.marketplace_roots(config, additional_roots);\n+        if !include_openai_curated {\n+            let curated_repo_root = curated_plugins_repo_path(self.codex_home.as_path());\n+            marketplace_roots.retain(|root| root.as_path() != curated_repo_root.as_path());\n+        }\n...",
+      "path": "codex-rs/core-plugins/src/manager.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 61,
+      "deletions": 9,
+      "patch_excerpt": "@@ -1815,7 +1815,11 @@ enabled = false\n \n     let config = load_config(tmp.path(), &repo_root).await;\n     let marketplaces = PluginsManager::new(tmp.path().to_path_buf())\n-        .list_marketplaces_for_config(&config, &[AbsolutePathBuf::try_from(repo_root).unwrap()])\n+        .list_marketplaces_for_config(\n+            &config,\n+            &[AbsolutePathBuf::try_from(repo_root).unwrap()],\n+            /*include_openai_curated*/ true,\n+        )\n         .unwrap()\n         .marketplaces;\n \n@@ -1917,7 +1921,11 @@ enabled = true\n \n     let config = load_config(tmp.path(), &repo_root).await;\n     let marketplaces = PluginsManager::new(tmp.path().to_path_buf())\n-        .list_marketplaces_for_config(&config, &[AbsolutePathBuf::try_from(repo_root).unwrap()])\n+        .list_marketplaces_for_config(\n+            &config,\n+            &[AbsolutePathBuf::try_from(repo_root).unwrap()],\n+        ...",
+      "path": "codex-rs/core-plugins/src/manager_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -358,7 +358,7 @@ fn verified_plugin_install_completed(\n ) -> bool {\n     let plugins_input = config.plugins_config_input();\n     plugins_manager\n-        .list_marketplaces_for_config(&plugins_input, &[])\n+        .list_marketplaces_for_config(&plugins_input, &[], /*include_openai_curated*/ true)\n         .ok()\n         .into_iter()\n         .flat_map(|outcome| outcome.marketplaces)",
+      "path": "codex-rs/core/src/tools/handlers/request_plugin_install.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Summary\n\n- skip the local `openai-curated` marketplace before marketplace loading when tool-suggest discovery uses remote plugins\n- preserve existing marketplace listing behavior for all other callers and when remote plugins are disabled\n- add regression coverage proving the curated marketplace is excluded before its malformed manifest can be read\n\n## Why\n\nTool-suggest discovery previously loaded every local `openai-curated` plugin manifest and only discarded that marketplace afterward when remote plugins were enabled. The remote catalog is used in that mode, so the local scan consumed CPU without contributing discoverable plugins.\n\n## Impact\n\nRemote-plugin tool suggestion discovery no longer reads the local curated marketplace and its plugin manifests. `openai-bundled`, configured marketplaces, normal `plugin/list` behavior, and local curated discovery when remote plugins are disabled are unchanged.\n\n## Validation\n\n- `just test -p codex-core-plugins list_marketplaces_can_skip_openai_curated_before_loading`\n- `just test -p codex-core list_tool_suggest_discoverable_plugins_omits_openai_curated_when_remote_enabled`\n- `just fmt`\n- `git diff --check`",
+    "labels": [],
+    "merged_at": "2026-06-10T20:11:09Z",
+    "number": 27311,
+    "state": "merged",
+    "title": "[codex] Skip local curated discovery for remote plugins",
+    "url": "https://github.com/openai/codex/pull/27311"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27414.json
+++ b/artifacts/github/bundles/openai-codex-pr-27414.json
@@ -1,0 +1,57 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "e-provencher",
+      "committed_at": "2026-06-10T16:23:36Z",
+      "message": "preserve disabled MCP servers across runtime overlays",
+      "sha": "679f3b6b5677d685581358f37e7a3a7ddce2466d",
+      "url": "https://github.com/openai/codex/commit/679f3b6b5677d685581358f37e7a3a7ddce2466d"
+    },
+    {
+      "author": "e-provencher",
+      "committed_at": "2026-06-10T16:36:55Z",
+      "message": "Merge branch 'main' into eprovencher/fix-disabled-mcp-initialization",
+      "sha": "d1db1d33d190781ea06aa44692e9c31c4c45c683",
+      "url": "https://github.com/openai/codex/commit/d1db1d33d190781ea06aa44692e9c31c4c45c683"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "MCP",
+    "CODEX_APPS_MCP_SERVER_NAME"
+  ],
+  "files": [
+    {
+      "additions": 11,
+      "deletions": 0,
+      "patch_excerpt": "@@ -45,6 +45,12 @@ impl McpManager {\n     /// runtime-only extension overlays.\n     pub async fn runtime_config(&self, config: &Config) -> McpConfig {\n         let mut mcp_config = config.to_mcp_config(self.plugins_manager.as_ref()).await;\n+        let disabled_server_names = mcp_config\n+            .configured_mcp_servers\n+            .iter()\n+            .filter(|(_, server)| !server.enabled)\n+            .map(|(name, _)| name.clone())\n+            .collect::<Vec<_>>();\n         if mcp_config.apps_enabled {\n             mcp_config.configured_mcp_servers.insert(\n                 CODEX_APPS_MCP_SERVER_NAME.to_string(),\n@@ -60,6 +66,11 @@ impl McpManager {\n         }\n         let contributions = self.contributions(config).await;\n         Self::apply_to_configured_servers(&contributions, &mut mcp_config.configured_mcp_servers);\n+        for name in disabled_server_names {\n+            if l...",
+      "path": "codex-rs/core/src/mcp.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 28,
+      "deletions": 0,
+      "patch_excerpt": "@@ -42,6 +42,34 @@ async fn contributes_hosted_plugin_runtime_without_an_executor() -> TestResult {\n     Ok(())\n }\n \n+#[tokio::test]\n+async fn runtime_overlay_preserves_disabled_server() -> TestResult {\n+    let codex_home = tempfile::tempdir()?;\n+    let config = ConfigBuilder::default()\n+        .codex_home(codex_home.path().to_path_buf())\n+        .fallback_cwd(Some(codex_home.path().to_path_buf()))\n+        .cli_overrides(vec![\n+            (\"features.apps\".to_string(), true.into()),\n+            (\n+                \"mcp_servers.codex_apps.url\".to_string(),\n+                \"https://example.com/mcp\".into(),\n+            ),\n+            (\"mcp_servers.codex_apps.enabled\".to_string(), false.into()),\n+        ])\n+        .build()\n+        .await?;\n+    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();\n+    let manager = installed_manager(&config);\n+\n+    let servers = manager...",
+      "path": "codex-rs/ext/mcp/tests/hosted_apps_mcp.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nRecent MCP runtime overlay changes replace same-name configured server entries with compatibility or extension-provided configs. Those replacement configs default to enabled, so an MCP server explicitly configured with `enabled = false` could be initialized anyway.\n\nThe connection manager still filters disabled servers correctly, but the configured disabled state was lost before initialization reached that filter.\n\n## What changed\n\n- Remember MCP servers that are disabled in the configured view before applying runtime fallbacks and extension overlays.\n- Restore `enabled = false` for those servers after overlays, while leaving all other overlay fields and `Remove` precedence unchanged.\n- Add focused extension-backed regression coverage for a disabled `codex_apps` server.\n\n## Testing\n\n- `just fmt`\n- `just test -p codex-mcp-extension`\n- `just fix -p codex-core`\n- `just fix -p codex-mcp-extension`\n\nThe full workspace `just test` suite was not run.",
+    "labels": [],
+    "merged_at": "2026-06-10T20:11:20Z",
+    "number": 27414,
+    "state": "merged",
+    "title": "[codex] Preserve disabled MCP servers across runtime overlays",
+    "url": "https://github.com/openai/codex/pull/27414"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27465.json
+++ b/artifacts/github/bundles/openai-codex-pr-27465.json
@@ -1,0 +1,131 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "xl-openai",
+      "committed_at": "2026-06-10T20:57:36Z",
+      "message": "Remove redundant plugin app auth state",
+      "sha": "8e0cb424640c7776a0c6a03f27ff2e5d637d6389",
+      "url": "https://github.com/openai/codex/commit/8e0cb424640c7776a0c6a03f27ff2e5d637d6389"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [
+    "codex-rs/app-server/README.md"
+  ],
+  "examples_refs": [],
+  "extracted_flags": [
+    "MCP",
+    "TUI",
+    "API",
+    "EXPERIMENTAL",
+    "AVAILABLE",
+    "DISABLED_BY_ADMIN",
+    "AUTHORIZATION",
+    "DEFAULT_TIMEOUT",
+    "JSONRPCR",
+    "UNAUTHORIZED",
+    "BAD_REQUEST"
+  ],
+  "files": [
+    {
+      "additions": 1,
+      "deletions": 5,
+      "patch_excerpt": "@@ -6433,15 +6433,11 @@\n           },\n           \"name\": {\n             \"type\": \"string\"\n-          },\n-          \"needsAuth\": {\n-            \"type\": \"boolean\"\n           }\n         },\n         \"required\": [\n           \"id\",\n-          \"name\",\n-          \"needsAuth\"\n+          \"name\"\n         ],\n         \"type\": \"object\"\n       },",
+      "path": "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 5,
+      "patch_excerpt": "@@ -711,15 +711,11 @@\n         },\n         \"name\": {\n           \"type\": \"string\"\n-        },\n-        \"needsAuth\": {\n-          \"type\": \"boolean\"\n         }\n       },\n       \"required\": [\n         \"id\",\n-        \"name\",\n-        \"needsAuth\"\n+        \"name\"\n       ],\n       \"type\": \"object\"\n     },",
+      "path": "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 5,
+      "patch_excerpt": "@@ -21,15 +21,11 @@\n         },\n         \"name\": {\n           \"type\": \"string\"\n-        },\n-        \"needsAuth\": {\n-          \"type\": \"boolean\"\n         }\n       },\n       \"required\": [\n         \"id\",\n-        \"name\",\n-        \"needsAuth\"\n+        \"name\"\n       ],\n       \"type\": \"object\"\n     },",
+      "path": "codex-rs/app-server-protocol/schema/json/v2/PluginInstallResponse.json",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 5,
+      "patch_excerpt": "@@ -25,15 +25,11 @@\n         },\n         \"name\": {\n           \"type\": \"string\"\n-        },\n-        \"needsAuth\": {\n-          \"type\": \"boolean\"\n         }\n       },\n       \"required\": [\n         \"id\",\n-        \"name\",\n-        \"needsAuth\"\n+        \"name\"\n       ],\n       \"type\": \"object\"\n     },",
+      "path": "codex-rs/app-server-protocol/schema/json/v2/PluginReadResponse.json",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -5,4 +5,4 @@\n /**\n  * EXPERIMENTAL - app metadata summary for plugin responses.\n  */\n-export type AppSummary = { id: string, name: string, description: string | null, installUrl: string | null, needsAuth: boolean, };\n+export type AppSummary = { id: string, name: string, description: string | null, installUrl: string | null, };",
+      "path": "codex-rs/app-server-protocol/schema/typescript/v2/AppSummary.ts",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 2,
+      "patch_excerpt": "@@ -111,7 +111,6 @@ pub struct AppSummary {\n     pub name: String,\n     pub description: Option<String>,\n     pub install_url: Option<String>,\n-    pub needs_auth: bool,\n }\n \n impl From<AppInfo> for AppSummary {\n@@ -121,7 +120,6 @@ impl From<AppInfo> for AppSummary {\n             name: value.name,\n             description: value.description,\n             install_url: value.install_url,\n-            needs_auth: false,\n         }\n     }\n }",
+      "path": "codex-rs/app-server-protocol/src/protocol/v2/apps.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -206,7 +206,7 @@ Example with notification opt-out:\n - `marketplace/upgrade` — upgrade all configured Git plugin marketplaces, or one named marketplace when `marketplaceName` is provided. Returns selected marketplace names, upgraded roots, and per-marketplace errors.\n - `plugin/list` — list discovered plugin marketplaces and plugin state, including effective marketplace install/auth policy metadata, plugin `availability` (`AVAILABLE` by default or `DISABLED_BY_ADMIN` for remote plugins blocked upstream), fail-open `marketplaceLoadErrors` entries for marketplace files that could not be parsed or loaded, and best-effort `featuredPluginIds` for the official curated marketplace. `interface.category` uses the marketplace category when present; otherwise it falls back to the plugin manifest category (**under development; do not call from production clients yet**).\n - `plugin/installed` — li...",
+      "path": "codex-rs/app-server/README.md",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 61,
+      "patch_excerpt": "@@ -1035,14 +1035,7 @@ impl PluginRequestProcessor {\n                     }\n                     None => None,\n                 };\n-                let environment_manager = self.thread_manager.environment_manager();\n-                let app_summaries = load_plugin_app_summaries(\n-                    &config,\n-                    &outcome.plugin.apps,\n-                    Arc::clone(&environment_manager),\n-                    self.thread_manager.mcp_manager(),\n-                )\n-                .await;\n+                let app_summaries = load_plugin_app_summaries(&config, &outcome.plugin.apps).await;\n                 let visible_skills = outcome\n                     .plugin\n                     .skills\n@@ -1118,14 +1111,7 @@ impl PluginRequestProcessor {\n                     .cloned()\n                     .map(codex_plugin::AppConnectorId)\n                     .collect::<Vec<_>>();\n-  ...",
+      "path": "codex-rs/app-server/src/request_processors/plugins.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 3,
+      "patch_excerpt": "@@ -327,7 +327,6 @@ async fn plugin_install_uses_remote_apps_needing_auth_response() -> Result<()> {\n                 name: \"alpha\".to_string(),\n                 description: None,\n                 install_url: Some(\"https://chatgpt.com/apps/alpha/alpha\".to_string()),\n-                needs_auth: true,\n             }],\n         }\n     );\n@@ -1001,7 +1000,6 @@ async fn plugin_install_returns_apps_needing_auth() -> Result<()> {\n                 name: \"Alpha\".to_string(),\n                 description: Some(\"Alpha connector\".to_string()),\n                 install_url: Some(\"https://chatgpt.com/apps/alpha/alpha\".to_string()),\n-                needs_auth: true,\n             }],\n         }\n     );\n@@ -1089,7 +1087,6 @@ async fn plugin_install_filters_disallowed_apps_needing_auth() -> Result<()> {\n                 name: \"Alpha\".to_string(),\n                 description: Some(\"Alpha connector\".to...",
+      "path": "codex-rs/app-server/tests/suite/v2/plugin_install.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 263,
+      "patch_excerpt": "@@ -1,22 +1,10 @@\n-use std::borrow::Cow;\n-use std::sync::Arc;\n-use std::sync::Mutex as StdMutex;\n use std::time::Duration;\n \n use anyhow::Result;\n use app_test_support::ChatGptAuthFixture;\n use app_test_support::TestAppServer;\n use app_test_support::to_response;\n use app_test_support::write_chatgpt_auth;\n-use axum::Json;\n-use axum::Router;\n-use axum::extract::State;\n-use axum::http::HeaderMap;\n-use axum::http::StatusCode;\n-use axum::http::Uri;\n-use axum::http::header::AUTHORIZATION;\n-use axum::routing::get;\n-use codex_app_server_protocol::AppInfo;\n use codex_app_server_protocol::AppTemplateSummary;\n use codex_app_server_protocol::AppTemplateUnavailableReason;\n use codex_app_server_protocol::HookEventName;\n@@ -37,21 +25,8 @@ use codex_app_server_protocol::RequestId;\n use codex_config::types::AuthCredentialsStoreMode;\n use codex_utils_absolute_path::AbsolutePathBuf;\n use pretty_assertions:...",
+      "path": "codex-rs/app-server/tests/suite/v2/plugin_read.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 3,
+      "patch_excerpt": "@@ -1414,7 +1414,7 @@ pub(super) fn plugins_test_detail(\n     description: Option<&str>,\n     skills: &[&str],\n     hooks: &[(codex_app_server_protocol::HookEventName, usize)],\n-    apps: &[(&str, bool)],\n+    apps: &[&str],\n     mcp_servers: &[&str],\n ) -> PluginDetail {\n     PluginDetail {\n@@ -1449,12 +1449,11 @@ pub(super) fn plugins_test_detail(\n             .collect(),\n         apps: apps\n             .iter()\n-            .map(|(name, needs_auth)| AppSummary {\n+            .map(|name| AppSummary {\n                 id: format!(\"{name}-id\"),\n                 name: (*name).to_string(),\n                 description: Some(format!(\"{name} app\")),\n                 install_url: Some(format!(\"https://example.test/{name}\")),\n-                needs_auth: *needs_auth,\n             })\n             .collect(),\n         app_templates: Vec::new(),",
+      "path": "codex-rs/tui/src/chatwidget/tests/helpers.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 2,
+      "patch_excerpt": "@@ -654,7 +654,7 @@ async fn plugin_detail_popup_snapshot_shows_install_actions_and_capability_summa\n                     (codex_app_server_protocol::HookEventName::PreToolUse, 1),\n                     (codex_app_server_protocol::HookEventName::Stop, 2),\n                 ],\n-                &[(\"Figma\", true), (\"Slack\", false)],\n+                &[\"Figma\", \"Slack\"],\n                 &[\"figma-mcp\", \"docs-mcp\"],\n             ),\n         }),\n@@ -698,7 +698,7 @@ async fn plugin_detail_popup_hides_disclosure_for_installed_plugins() {\n                     (codex_app_server_protocol::HookEventName::PreToolUse, 1),\n                     (codex_app_server_protocol::HookEventName::Stop, 2),\n                 ],\n-                &[(\"Figma\", true), (\"Slack\", false)],\n+                &[\"Figma\", \"Slack\"],\n                 &[\"figma-mcp\", \"docs-mcp\"],\n             ),\n         }),",
+      "path": "codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Summary\n\n- remove the redundant `needsAuth` field from `AppSummary` and generated app-server schemas\n- stop `plugin/read` from querying Apps MCP solely to hydrate unused connector auth state\n- preserve `plugin/install.appsNeedingAuth` membership and `app/list.isAccessible` as the authentication signals\n\n## Why\n\nCodex App and TUI do not consume `plugin/read.plugin.apps[].needsAuth`. Hydrating it could establish an Apps MCP connection and discover tools on a cold `plugin/read` request, adding avoidable latency. The plugin APIs are still marked under development, so removing this wire field is preferable to retaining a misleading default.\n\n## Verification\n\n- `just write-app-server-schema`\n- `just fmt`\n- `just test -p codex-app-server-protocol`\n- `just test -p codex-app-server plugin_install_uses_remote_apps_needing_auth_response`\n- `just test -p codex-app-server plugin_install_returns_apps_needing_auth`\n- `just test -p codex-app-server plugin_read_returns_plugin_details_with_bundle_contents`\n- `just test -p codex-tui plugin_detail_popup_snapshot_shows_install_actions_and_capability_summaries`\n- `$xin-build` simplify and debug reviews\n",
+    "labels": [],
+    "merged_at": "2026-06-11T00:33:56Z",
+    "number": 27465,
+    "state": "merged",
+    "title": "[codex] Remove redundant plugin app auth state",
+    "url": "https://github.com/openai/codex/pull/27465"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/impact/openai-codex-pr-27071.json
+++ b/artifacts/github/impact/openai-codex-pr-27071.json
@@ -1,0 +1,47 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27071",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] add /import for external agents",
+        "url": "https://github.com/openai/codex/pull/27071",
+        "meta": "Merged 2026-06-10T19:53:16Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27071",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27071.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex added a TUI `/import` slash command that launches the external-agent import picker on demand and routes imports through the local app-server API.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "practical_explainer",
+  "confidence": "confirmed",
+  "evidence": [
+    "`SlashCommand::Import` is added and dispatched to `AppEvent::OpenExternalAgentConfigMigration`.",
+    "The new import flow calls app-server detect/import paths and reports remote or local-daemon unavailability.",
+    "`ExternalAgentConfigImportCompleted` is promoted to a delivered app-server notification in both client and in-process server code.",
+    "`codex import` remains an interactive prompt rather than a new top-level CLI namespace."
+  ],
+  "candidate_followups": [
+    "Audit Decodex docs and operator UI assumptions around local-only imported-session migration.",
+    "Watch for upstream follow-ups on completion messaging when users switch chats during import.",
+    "Avoid automating imports through remote or daemon-backed sessions until upstream supports that path."
+  ],
+  "social_notes": [
+    "Public copy should lead with the `/import` slash command and local TUI scope.",
+    "Include the caveat that it imports from another coding agent and does not claim cloud-hosted chat import.",
+    "Do not imply Decodex has already adopted or automated this workflow."
+  ],
+  "caveats": [
+    "The PR depends on earlier stack items for picker and startup-flow behavior.",
+    "The import flow is unavailable in remote sessions and while connected to the local app-server daemon.",
+    "The command does not reserve `codex import` as a top-level CLI subcommand."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-27311.json
+++ b/artifacts/github/impact/openai-codex-pr-27311.json
@@ -1,0 +1,47 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27311",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Skip local curated discovery for remote plugins",
+        "url": "https://github.com/openai/codex/pull/27311",
+        "meta": "Merged 2026-06-10T20:11:09Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27311",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27311.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex skips the local `openai-curated` marketplace scan when remote-plugin tool-suggestion discovery is enabled, while preserving normal marketplace listing behavior elsewhere.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "watch",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "Tool-suggest discovery passes `include_openai_curated: !remote_plugin_enabled`.",
+    "The marketplace manager now removes the local curated repository root before discovery when the new argument is false.",
+    "Plugin list, CLI marketplace operations, configured external-agent import helpers, and install verification keep `include_openai_curated: true`.",
+    "Regression coverage proves malformed curated manifests are skipped before loading in remote-plugin suggestion mode."
+  ],
+  "candidate_followups": [
+    "Update Decodex plugin preflight troubleshooting to distinguish remote catalog failures from local curated marketplace corruption.",
+    "Watch whether upstream adds more caller-specific marketplace discovery knobs.",
+    "Avoid treating local curated scan diagnostics as blockers for remote-plugin tool suggestions when this upstream behavior is present."
+  ],
+  "social_notes": [
+    "Frame as an operator-impact note for remote plugin suggestions.",
+    "Avoid saying `openai-curated` is removed.",
+    "Mention that normal plugin/list and local curated behavior remain available."
+  ],
+  "caveats": [
+    "The behavior applies to tool-suggest discovery with remote plugins enabled.",
+    "Configured marketplace listing and local curated discovery remain unchanged for other paths.",
+    "The change is more operational than end-user feature oriented."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-27414.json
+++ b/artifacts/github/impact/openai-codex-pr-27414.json
@@ -1,0 +1,47 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27414",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Preserve disabled MCP servers across runtime overlays",
+        "url": "https://github.com/openai/codex/pull/27414",
+        "meta": "Merged 2026-06-10T20:11:20Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27414",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27414.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex preserves configured `enabled = false` MCP servers after runtime fallback and extension overlays are applied.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "Disabled server names are collected before runtime fallback and extension overlay application.",
+    "After overlays, matching servers are forced back to `enabled = false` when still present.",
+    "A hosted Apps MCP regression test covers disabled `codex_apps` server behavior.",
+    "The PR body states replacement overlay configs had defaulted to enabled before this fix."
+  ],
+  "candidate_followups": [
+    "Review Decodex MCP diagnostics for assumptions that runtime overlays can re-enable disabled servers.",
+    "Consider adding version-aware notes when diagnosing unexpected Apps MCP startup.",
+    "Track whether upstream extends this preservation rule to other server removal or overlay precedence cases."
+  ],
+  "social_notes": [
+    "Frame as an operator-safety fix for MCP overlays.",
+    "Avoid implying broader MCP policy changed.",
+    "Mention `codex_apps` only as the regression-covered example."
+  ],
+  "caveats": [
+    "The fix preserves disabled state for servers that remain present after overlays.",
+    "Other overlay fields and Remove precedence are intentionally preserved.",
+    "The PR body says the connection manager filter was already correct; the bug was earlier config-state loss."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-27465.json
+++ b/artifacts/github/impact/openai-codex-pr-27465.json
@@ -1,0 +1,47 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27465",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Remove redundant plugin app auth state",
+        "url": "https://github.com/openai/codex/pull/27465",
+        "meta": "Merged 2026-06-11T00:33:56Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27465",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27465.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex removed the experimental `needsAuth` field from plugin app summaries and stopped `plugin/read` from contacting Apps MCP only to hydrate unused connector auth state.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "`AppSummary.needs_auth` is removed from the Rust protocol type.",
+    "Generated JSON schemas and TypeScript definitions no longer include `needsAuth`.",
+    "`plugin/read` app-summary hydration no longer takes environment manager or MCP manager state.",
+    "Plugin install tests preserve `apps_needing_auth` as the auth signal while app summaries drop `needs_auth`."
+  ],
+  "candidate_followups": [
+    "Search Decodex plugin/app-server clients for `needsAuth` or `needs_auth` assumptions.",
+    "Prefer `plugin/install.appsNeedingAuth` and `app/list.isAccessible` in future auth-state readbacks.",
+    "Update operator docs if they mention `plugin/read.plugin.apps[].needsAuth`."
+  ],
+  "social_notes": [
+    "Frame as an under-development plugin API migration note.",
+    "Explain the replacement auth signals explicitly.",
+    "Mention the latency reason only as source-backed context from the PR body."
+  ],
+  "caveats": [
+    "The upstream PR states plugin APIs are still under development.",
+    "The removal affects plugin app summaries, not plugin install `appsNeedingAuth` membership.",
+    "Do not imply all connector auth state has been removed."
+  ]
+}

--- a/artifacts/github/review-queue/openai-codex-latest.json
+++ b/artifacts/github/review-queue/openai-codex-latest.json
@@ -1,14 +1,14 @@
 {
   "counts": {
-    "critical": 19,
-    "high": 8,
+    "critical": 18,
+    "high": 10,
     "low": 0,
-    "normal": 13,
+    "normal": 12,
     "published_subjects_seen": 0,
     "recent_commits_scanned": 40,
     "subjects_queued": 40
   },
-  "generated_at": "2026-06-11T08:06:28.367132Z",
+  "generated_at": "2026-06-11T14:05:19.394314Z",
   "repo": "openai/codex",
   "schema": "upstream_review_queue/v1",
   "source": {
@@ -17,207 +17,6 @@
     "signals_dir": "site/src/content/signals"
   },
   "subjects": [
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging"
-      ],
-      "changed_file_count": 13,
-      "commit_shas": [
-        "57659383ec35538c75d4f35ea8348edd740a0435",
-        "bf636e08e83562fce57cdfd0ca64e0ebafec106f",
-        "186490d934d112d51c400dd54b7f5c887023cd0d",
-        "bc9a3b9cbc07d1ac22fad1f499c51568301884cd"
-      ],
-      "committed_at": "2026-06-10T18:24:29Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26859,
-      "pr_url": "https://github.com/openai/codex/pull/26859",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging.",
-      "sample_paths": [
-        "codex-rs/app-server/src/lib.rs",
-        "codex-rs/cli/src/doctor.rs",
-        "codex-rs/cli/src/main.rs",
-        "codex-rs/cli/src/state_db_recovery.rs",
-        "codex-rs/rollout/src/state_db.rs",
-        "codex-rs/state/src/lib.rs",
-        "codex-rs/state/src/runtime.rs",
-        "codex-rs/state/src/runtime/goals.rs",
-        "codex-rs/state/src/runtime/memories.rs",
-        "codex-rs/state/src/runtime/recovery.rs",
-        "codex-rs/state/src/runtime/recovery_tests.rs",
-        "codex-rs/tui/src/lib.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26859",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "tests_ci"
-      ],
-      "title": "fix: Auto-recover from corrupted sqlite databases",
-      "url": "https://github.com/openai/codex/pull/26859"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "rate_limit",
-        "security_policy"
-      ],
-      "changed_file_count": 6,
-      "commit_shas": [
-        "d0dcb2a19f0ed125bb8dbdfc61fdadc346667b59",
-        "c7e1523503f1e1f9f979e686d34fa31133cba194",
-        "52c6ed6ff8e71895aa6fe067bf99521f37265a89",
-        "ac05fffdb3bd224c28cb6819e288ae43b09ac1e5"
-      ],
-      "committed_at": "2026-06-10T18:25:04Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27064,
-      "pr_url": "https://github.com/openai/codex/pull/27064",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, rate_limit, security_policy.",
-      "sample_paths": [
-        "codex-rs/features/src/lib.rs",
-        "codex-rs/features/src/tests.rs",
-        "codex-rs/tui/src/app.rs",
-        "codex-rs/tui/src/app_server_session.rs",
-        "codex-rs/tui/src/external_agent_config_migration_startup.rs",
-        "codex-rs/tui/src/lib.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27064",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "tests_ci"
-      ],
-      "title": "[codex] remove blocking external agent migration flow",
-      "url": "https://github.com/openai/codex/pull/27064"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 2,
-      "commit_shas": [
-        "78a9d823a89350a2ab49ee0b3ea2e3bf48685ff7"
-      ],
-      "committed_at": "2026-06-10T18:48:30Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27065,
-      "pr_url": "https://github.com/openai/codex/pull/27065",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/tui/src/external_agent_config_migration.rs",
-        "codex-rs/tui/src/external_agent_config_migration/render.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27065",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "config_hooks"
-      ],
-      "title": "[codex] extract external agent import picker renderer",
-      "url": "https://github.com/openai/codex/pull/27065"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 9,
-      "commit_shas": [
-        "158fd3ea6eda3a6ee1ba95ad0de76f5cee4f0540"
-      ],
-      "committed_at": "2026-06-10T19:01:03Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26409,
-      "pr_url": "https://github.com/openai/codex/pull/26409",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for deprecated_removed, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/core-plugins/src/discoverable.rs",
-        "codex-rs/core/src/plugins/discoverable.rs",
-        "codex-rs/core/src/plugins/discoverable_tests.rs",
-        "codex-rs/core/src/tools/handlers/request_plugin_install_tests.rs",
-        "codex-rs/core/src/tools/spec_plan_tests.rs",
-        "codex-rs/tools/src/request_plugin_install.rs",
-        "codex-rs/tools/src/request_plugin_install_tests.rs",
-        "codex-rs/tools/src/tool_discovery.rs",
-        "codex-rs/tools/src/tool_discovery_tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26409",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "mcp_plugins",
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "[plugins] Inject remote_plugin_id into install elicitations",
-      "url": "https://github.com/openai/codex/pull/26409"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 10,
-      "commit_shas": [
-        "48d3cf0497ceb2ce5228d624d782bb11661811ba",
-        "46487bd2cd860ea7a1d3e7c7302f9031ee8f8124",
-        "72c495a73a8eb216b47fdae30a42ca16022835cc"
-      ],
-      "committed_at": "2026-06-10T19:19:37Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27070,
-      "pr_url": "https://github.com/openai/codex/pull/27070",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/tui/src/external_agent_config_migration.rs",
-        "codex-rs/tui/src/external_agent_config_migration/render.rs",
-        "codex-rs/tui/src/external_agent_config_migration_model.rs",
-        "codex-rs/tui/src/lib.rs",
-        "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize.snap",
-        "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_action.snap",
-        "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_action_windows.snap",
-        "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_windows.snap",
-        "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_prompt.snap",
-        "codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_prompt_windows.snap"
-      ],
-      "source_state": "merged",
-      "subject_id": "27070",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "config_hooks",
-        "model_provider",
-        "tests_ci"
-      ],
-      "title": "[codex] add external agent import picker UX",
-      "url": "https://github.com/openai/codex/pull/27070"
-    },
     {
       "attention_flags": [
         "auth_account",
@@ -806,59 +605,158 @@
     },
     {
       "attention_flags": [
-        "release_packaging"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "64ac1dbd97d2d31fc380e2ae589289a9456bc461"
-      ],
-      "committed_at": "2026-06-10T18:37:14Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27421,
-      "pr_url": "https://github.com/openai/codex/pull/27421",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for release_packaging.",
-      "sample_paths": [
-        "codex-rs/app-server/src/lib.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27421",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol"
-      ],
-      "title": "[codex] Raise app-server recursion limit",
-      "url": "https://github.com/openai/codex/pull/27421"
-    },
-    {
-      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
         "new_feature",
-        "protocol_change"
+        "protocol_change",
+        "security_policy"
       ],
-      "changed_file_count": 3,
+      "changed_file_count": 8,
       "commit_shas": [
-        "8686dc569b56f54c3dda658f1115d686584e561d"
+        "c011f6e6809601b6cc138e055bf1bc57bf5b5d4c",
+        "571debf6883633a51c69f6654efd10c4e13e7f26",
+        "0b768f5016684ccf0266aef513ff7f7bdfcc5aa2"
       ],
-      "committed_at": "2026-06-10T19:17:15Z",
+      "committed_at": "2026-06-11T10:07:19Z",
       "next_step": "ai_review_required",
-      "pr_number": 27439,
-      "pr_url": "https://github.com/openai/codex/pull/27439",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for new_feature, protocol_change.",
+      "pr_number": 27573,
+      "pr_url": "https://github.com/openai/codex/pull/27573",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/app-server/src/extensions.rs",
-        "codex-rs/app-server/src/mcp_refresh.rs",
-        "codex-rs/app-server/src/message_processor.rs"
+        "codex-rs/app-server/tests/suite/v2/compaction.rs",
+        "codex-rs/core/tests/suite/compact.rs",
+        "codex-rs/core/tests/suite/compact_remote.rs",
+        "codex-rs/core/tests/suite/compact_remote_parity.rs",
+        "codex-rs/core/tests/suite/hooks.rs",
+        "codex-rs/core/tests/suite/responses_lite.rs",
+        "codex-rs/features/src/lib.rs",
+        "codex-rs/features/src/tests.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27439",
+      "subject_id": "27573",
       "subject_kind": "pr",
       "surface_hints": [
         "app_server_protocol",
-        "mcp_plugins"
+        "config_hooks",
+        "tests_ci"
       ],
-      "title": "feat: make ThreadStore available on ThreadExtensionDependencies",
-      "url": "https://github.com/openai/codex/pull/27439"
+      "title": "core: enable remote compaction v2 by default",
+      "url": "https://github.com/openai/codex/pull/27573"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 6,
+      "commit_shas": [
+        "168cddddc1b5c5f4fe64534acc4e31ae69474365",
+        "fe04e86efaae705d0b47e3d076e82d54b2e1dca5",
+        "92644c48f26b1f5d92892c01cd1585b86fc381f1",
+        "e13920ef12be52e892db5cbf3e0a3402d5d33f6e"
+      ],
+      "committed_at": "2026-06-11T10:41:44Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27569,
+      "pr_url": "https://github.com/openai/codex/pull/27569",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/core/src/config/config_tests.rs",
+        "codex-rs/core/src/config/mod.rs",
+        "codex-rs/core/src/tools/handlers/multi_agents_spec.rs",
+        "codex-rs/core/src/tools/handlers/multi_agents_spec_tests.rs",
+        "codex-rs/core/src/tools/spec_plan.rs",
+        "codex-rs/core/src/tools/spec_plan_tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27569",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "config_hooks",
+        "tests_ci"
+      ],
+      "title": "multi-agent: move concurrency guidance into v2 usage hints",
+      "url": "https://github.com/openai/codex/pull/27569"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 4,
+      "commit_shas": [
+        "0dd59d361fb64e7cad0641619eae8047f893a8d8"
+      ],
+      "committed_at": "2026-06-11T11:51:04Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27591,
+      "pr_url": "https://github.com/openai/codex/pull/27591",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/app-server/tests/suite/v2/mcp_resource.rs",
+        "codex-rs/core-skills/src/render.rs",
+        "codex-rs/ext/skills/src/render.rs",
+        "codex-rs/ext/skills/tests/skills_extension.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27591",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "skills: render catalog locators by authority",
+      "url": "https://github.com/openai/codex/pull/27591"
+    },
+    {
+      "attention_flags": [
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 10,
+      "commit_shas": [
+        "9ff580bf7e426f19713de20aaa9a0138a4aa389f",
+        "3eb9c5126d277d5c6e2b92dfb71a3025942a19ef"
+      ],
+      "committed_at": "2026-06-11T12:03:53Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27413,
+      "pr_url": "https://github.com/openai/codex/pull/27413",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/Cargo.lock",
+        "codex-rs/app-server/src/extensions.rs",
+        "codex-rs/ext/skills/Cargo.toml",
+        "codex-rs/ext/skills/src/config.rs",
+        "codex-rs/ext/skills/src/extension.rs",
+        "codex-rs/ext/skills/src/fragments.rs",
+        "codex-rs/ext/skills/src/lib.rs",
+        "codex-rs/ext/skills/src/render.rs",
+        "codex-rs/ext/skills/src/state.rs",
+        "codex-rs/ext/skills/tests/skills_extension.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27413",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "config_hooks",
+        "tests_ci"
+      ],
+      "title": "skills: decouple the skills extension from core",
+      "url": "https://github.com/openai/codex/pull/27413"
     },
     {
       "attention_flags": [
@@ -1093,85 +991,156 @@
     {
       "attention_flags": [
         "auth_account",
-        "deprecated_removed",
         "new_feature",
         "protocol_change",
-        "rate_limit",
+        "release_packaging",
         "security_policy"
       ],
-      "changed_file_count": 6,
+      "changed_file_count": 26,
       "commit_shas": [
-        "3ea9606263f279e5c58ab3b843330dd1d462e1c1",
-        "38d1808316c2c991fc98eba55191cfca2408c607",
-        "eeb570f02d3c7a360b121d856df22050f05f9e46",
-        "db3a7af542ea52db61f470bd307122007fc4cd5d",
-        "402ee65adeb169b1e1e3bb59fc5c5bbe9a58e624",
-        "db80b07f2a285de93c3bbc03985f1487e046c895",
-        "f672caed2081663e402f3570eb2ddb12ff42ec01",
-        "1311085aa18dbcc1e3c0913b68d963235a70f462",
-        "91a0b3957e9e0661d928df496ceaa2153b3c62f0",
-        "e26cac911ec689f5438c4cdae06f561f52b5dcb0"
+        "f2eb57ab01ec5e7180feaeb0da8be0270a9ce08f",
+        "2adc40863bc3f8deeb51af81e1e7b344211a8d26",
+        "cc06cd29c87eb5d43deff1a4a43109d9c29c1e74",
+        "cde0b1be448e91e3d24764565ba6ff6c37aadd22",
+        "5557f6fdae174275e23870a4be7e1e0dcddce540",
+        "d5fb1fcdb891132261b761f280d3e1c2c1b969de"
       ],
-      "committed_at": "2026-06-10T18:46:57Z",
+      "committed_at": "2026-06-11T09:28:16Z",
       "next_step": "ai_review_required",
-      "pr_number": 27062,
-      "pr_url": "https://github.com/openai/codex/pull/27062",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, rate_limit, security_policy.",
+      "pr_number": 27387,
+      "pr_url": "https://github.com/openai/codex/pull/27387",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, release_packaging, security_policy.",
       "sample_paths": [
-        "codex-rs/analytics/src/analytics_client_tests.rs",
-        "codex-rs/analytics/src/events.rs",
-        "codex-rs/core/src/guardian/mod.rs",
-        "codex-rs/core/src/guardian/review.rs",
-        "codex-rs/core/src/guardian/review_session.rs",
-        "codex-rs/core/src/guardian/tests.rs"
+        "codex-rs/Cargo.lock",
+        "codex-rs/app-server/src/extensions.rs",
+        "codex-rs/app-server/tests/suite/v2/mcp_resource.rs",
+        "codex-rs/codex-mcp/Cargo.toml",
+        "codex-rs/codex-mcp/src/connection_manager.rs",
+        "codex-rs/codex-mcp/src/lib.rs",
+        "codex-rs/codex-mcp/src/resource_client.rs",
+        "codex-rs/core/src/context/available_skills_instructions.rs",
+        "codex-rs/core/src/context/mod.rs",
+        "codex-rs/core/src/event_mapping.rs",
+        "codex-rs/core/src/event_mapping_tests.rs",
+        "codex-rs/core/src/session/mod.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27062",
+      "subject_id": "27387",
       "subject_kind": "pr",
       "surface_hints": [
+        "app_server_protocol",
+        "auth_accounts",
         "cli_tui",
+        "config_hooks",
+        "mcp_plugins",
+        "model_provider",
         "tests_ci"
       ],
-      "title": "[codex] Retry transient Guardian review failures",
-      "url": "https://github.com/openai/codex/pull/27062"
+      "title": "skills: make backend plugin skills invocable without an executor",
+      "url": "https://github.com/openai/codex/pull/27387"
     },
     {
       "attention_flags": [
         "auth_account",
-        "deprecated_removed",
         "new_feature",
-        "protocol_change",
-        "security_policy"
+        "protocol_change"
+      ],
+      "changed_file_count": 12,
+      "commit_shas": [
+        "74066fb2c10e8e881f43faac5222e023527409d4",
+        "fbdff12dbc44263909c49bbd31cdd4fabc068153"
+      ],
+      "committed_at": "2026-06-11T10:38:04Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27388,
+      "pr_url": "https://github.com/openai/codex/pull/27388",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/Cargo.lock",
+        "codex-rs/app-server/tests/suite/v2/mcp_resource.rs",
+        "codex-rs/ext/skills/Cargo.toml",
+        "codex-rs/ext/skills/src/extension.rs",
+        "codex-rs/ext/skills/src/lib.rs",
+        "codex-rs/ext/skills/src/provider/orchestrator.rs",
+        "codex-rs/ext/skills/src/sources.rs",
+        "codex-rs/ext/skills/src/tools/list.rs",
+        "codex-rs/ext/skills/src/tools/mod.rs",
+        "codex-rs/ext/skills/src/tools/read.rs",
+        "codex-rs/ext/skills/src/tools/schema.rs",
+        "codex-rs/tools/src/tool_output.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27388",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "config_hooks",
+        "mcp_plugins",
+        "model_provider",
+        "tests_ci"
+      ],
+      "title": "skills: expose remote skill resource tools",
+      "url": "https://github.com/openai/codex/pull/27388"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 3,
+      "commit_shas": [
+        "fd1acbdba917067139984c12cb9c4288af38988a"
+      ],
+      "committed_at": "2026-06-11T10:52:46Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27585,
+      "pr_url": "https://github.com/openai/codex/pull/27585",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/Cargo.lock",
+        "codex-rs/ext/skills/Cargo.toml",
+        "codex-rs/ext/skills/src/tools/read.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27585",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "config_hooks"
+      ],
+      "title": "nit: cap error",
+      "url": "https://github.com/openai/codex/pull/27585"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change"
       ],
       "changed_file_count": 1,
       "commit_shas": [
-        "52a69d375c0c454744bb4306e0c667533278f7fd",
-        "df144382160d9b068d3782247671c9df2c6c5e14",
-        "f1446ef23a527c4ced239427eb50130bc618b17e",
-        "edea0dc753dd80ac4739fc8773852bf16baf2b88",
-        "675adb8af60b6be867bcf4dedd1bea2d34877faf",
-        "076f6013f5b3ac992a57e6b2d4152db7ec1840ae",
-        "1d0954270ea22db3c32c786742c430b1bfe47e19"
+        "68dc3b758d207d708025a8cb2df6a9eede57d17f"
       ],
-      "committed_at": "2026-06-10T19:19:26Z",
+      "committed_at": "2026-06-11T10:55:58Z",
       "next_step": "ai_review_required",
-      "pr_number": 27343,
-      "pr_url": "https://github.com/openai/codex/pull/27343",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "pr_number": 27404,
+      "pr_url": "https://github.com/openai/codex/pull/27404",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/core/tests/suite/cli_stream.rs"
+        "codex-rs/app-server/tests/suite/v2/mcp_resource.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27343",
+      "subject_id": "27404",
       "subject_kind": "pr",
       "surface_hints": [
-        "cli_tui",
+        "app_server_protocol",
+        "mcp_plugins",
         "tests_ci"
       ],
-      "title": "Guard core test subprocess cleanup",
-      "url": "https://github.com/openai/codex/pull/27343"
+      "title": "test: cover referenced backend skill reads without an executor",
+      "url": "https://github.com/openai/codex/pull/27404"
     },
     {
       "attention_flags": [
@@ -1502,6 +1471,36 @@
       ],
       "title": "Use generic search metadata for dynamic tools",
       "url": "https://github.com/openai/codex/pull/27356"
+    },
+    {
+      "attention_flags": [
+        "protocol_change"
+      ],
+      "changed_file_count": 3,
+      "commit_shas": [
+        "8d5d46c373675f75b214d8e43b11f501f9a8cdb8",
+        "ef726e2478cd1cedda5020530dad5999eb9f24bf",
+        "8c11c0a92c49645e02082e70f5801ef53b3c1d57"
+      ],
+      "committed_at": "2026-06-11T09:46:47Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27403,
+      "pr_url": "https://github.com/openai/codex/pull/27403",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for protocol_change.",
+      "sample_paths": [
+        "codex-rs/ext/skills/src/extension.rs",
+        "codex-rs/ext/skills/src/state.rs",
+        "codex-rs/ext/skills/tests/skills_extension.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27403",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "skills: cache remote catalog failures per thread",
+      "url": "https://github.com/openai/codex/pull/27403"
     }
   ]
 }

--- a/artifacts/github/reviews/openai-codex-pr-27071.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27071.review.json
@@ -1,0 +1,74 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27071",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27071",
+    "commit_shas": [
+      "ee228545d822de157518dec714dca4f13cbd3374",
+      "15bbbdf663d80d399cdadefd6987bf17999faab6"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] add /import for external agents",
+        "url": "https://github.com/openai/codex/pull/27071",
+        "meta": "Merged 2026-06-10T19:53:16Z"
+      },
+      {
+        "kind": "commit",
+        "title": "tui: add explicit external agent import command",
+        "url": "https://github.com/openai/codex/commit/ee228545d822de157518dec714dca4f13cbd3374"
+      },
+      {
+        "kind": "commit",
+        "title": "tui: make external agent import copy generic",
+        "url": "https://github.com/openai/codex/commit/15bbbdf663d80d399cdadefd6987bf17999faab6"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-11T14:06:31Z",
+  "observed_change": "Codex added a TUI `/import` slash command that launches the external-agent import picker on demand and routes imports through the local app-server API.",
+  "changed_surfaces": [
+    "TUI slash command registry and dispatch",
+    "external-agent import flow and user-facing copy",
+    "app-server client import detect/import wrappers",
+    "app-server completion notification delivery",
+    "CLI parse behavior for `codex import`",
+    "TUI snapshots and import-flow tests"
+  ],
+  "user_visible_path": "In an interactive local Codex TUI session, users can run `/import` to detect and import setup, project items, and recent chats from another coding agent without making `codex import` a top-level CLI subcommand.",
+  "control_plane_relevance": "High for Decodex Control Plane because the import path depends on app-server delivery of `ExternalAgentConfigImportCompleted` and explicitly excludes remote and local-daemon sessions.",
+  "compatibility_risk": "Medium: integrations that mirror slash-command availability or app-server notification delivery need to account for the new import command, completion notification, and unsupported-session messages.",
+  "adoption_opportunity": "Expose the import workflow as a local-session-only operator affordance and monitor app-server completion delivery before suggesting Decodex automation around imported sessions.",
+  "community_value": "High for Codex users migrating from another coding agent because the PR documents a concrete `/import` entrypoint and safe on-demand migration behavior.",
+  "deprecated_or_breaking_notes": "`codex import` remains parsed as an interactive prompt instead of a top-level CLI subcommand; the previous startup migration flow had already been removed lower in the stack.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27071 says `/import` detects external-agent items only when invoked, runs imports through the embedded local app-server, refreshes config, blocks duplicate imports, and rejects unsupported remote and local-daemon sessions.",
+    "`codex-rs/tui/src/slash_command.rs` adds `SlashCommand::Import` with the description for importing setup, project, and recent chats from another coding agent.",
+    "`codex-rs/tui/src/chatwidget/slash_dispatch.rs` dispatches `/import` to `AppEvent::OpenExternalAgentConfigMigration`.",
+    "`codex-rs/tui/src/external_agent_config_migration_flow.rs` adds local, remote-unavailable, daemon-unavailable, no-items, in-progress, and completion messages for the flow.",
+    "`codex-rs/app-server-client/src/lib.rs` and `codex-rs/app-server/src/in_process.rs` mark `ExternalAgentConfigImportCompleted` as requiring delivery.",
+    "`codex-rs/cli/src/main.rs` adds a test proving `codex import` remains an interactive prompt rather than a parsed subcommand.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27071.json` records 18 changed files for the merged PR."
+  ],
+  "caveats": "The PR is the fourth item in an import stack and depends on prior picker and startup-flow changes. The public claim should stay scoped to local interactive TUI sessions.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The new slash command and app-server completion notification affect Decodex operator compatibility and possible migration UX."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The local `/import` entrypoint has a clear user-facing migration story with source-backed caveats."
+    },
+    {
+      "type": "linear_followup",
+      "reason": "Check whether Decodex operator docs or Control Plane status surfaces should mention local-only import availability."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-27311.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27311.review.json
@@ -1,0 +1,63 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27311",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27311",
+    "commit_shas": [
+      "a323ed156e4bf7c1ae57cb0bb2d7f7d0d8a83b75"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Skip local curated discovery for remote plugins",
+        "url": "https://github.com/openai/codex/pull/27311",
+        "meta": "Merged 2026-06-10T20:11:09Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Skip local curated discovery for remote plugins",
+        "url": "https://github.com/openai/codex/commit/a323ed156e4bf7c1ae57cb0bb2d7f7d0d8a83b75"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-11T14:06:31Z",
+  "observed_change": "Codex skips the local `openai-curated` marketplace scan when remote-plugin tool-suggestion discovery is enabled, while preserving normal marketplace listing behavior elsewhere.",
+  "changed_surfaces": [
+    "plugin marketplace discovery manager",
+    "tool-suggest discoverable plugin loading",
+    "app-server plugin request processors",
+    "plugin CLI marketplace calls",
+    "plugin install verification",
+    "core plugin manager regression tests"
+  ],
+  "user_visible_path": "Users with remote plugins enabled should see tool-suggestion discovery avoid reading the local curated marketplace, reducing wasted local scan work and avoiding malformed local curated manifests in that mode.",
+  "control_plane_relevance": "Moderate for Decodex Control Plane because plugin discovery preflights and tool-suggest inventories may become faster and less sensitive to local curated marketplace corruption when remote plugins are active.",
+  "compatibility_risk": "Low: the new `include_openai_curated` argument changes internal marketplace-listing callers, but the PR body says plugin/list behavior and local curated discovery when remote plugins are disabled are unchanged.",
+  "adoption_opportunity": "Prefer remote catalog-backed discovery for remote plugin suggestions and stop treating a bad local `openai-curated` checkout as authoritative in that mode.",
+  "community_value": "Medium for plugin operators because the change explains why remote-plugin suggestions no longer depend on local curated marketplace manifests.",
+  "deprecated_or_breaking_notes": "The local curated marketplace is excluded only before tool-suggest discovery when remote plugins are enabled; configured marketplace listing paths still include it.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27311 says tool-suggest discovery now skips local `openai-curated` marketplace loading when remote plugins are enabled, while plugin/list and other callers are preserved.",
+    "`codex-rs/core-plugins/src/discoverable.rs` calls `list_marketplaces_for_config` with `include_openai_curated` set to the inverse of `remote_plugin_enabled`.",
+    "`codex-rs/core-plugins/src/manager.rs` adds the `include_openai_curated` argument and removes the curated repository root from marketplace roots when false.",
+    "App-server plugin request processors, CLI plugin commands, and install verification pass `include_openai_curated: true` to preserve existing listing behavior.",
+    "`codex-rs/core-plugins/src/manager_tests.rs` adds coverage for skipping `openai-curated` before a malformed manifest can be loaded.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27311.json` records 7 changed files for the merged PR."
+  ],
+  "caveats": "This is a discovery-path optimization and robustness fix; it does not remove local curated marketplace support generally.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Remote plugin discovery behavior affects Decodex plugin inventory and preflight assumptions."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The remote-plugin discovery boundary is useful to plugin operators when explained with caveats."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-27414.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27414.review.json
@@ -1,0 +1,70 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27414",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27414",
+    "commit_shas": [
+      "679f3b6b5677d685581358f37e7a3a7ddce2466d",
+      "d1db1d33d190781ea06aa44692e9c31c4c45c683"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Preserve disabled MCP servers across runtime overlays",
+        "url": "https://github.com/openai/codex/pull/27414",
+        "meta": "Merged 2026-06-10T20:11:20Z"
+      },
+      {
+        "kind": "commit",
+        "title": "preserve disabled MCP servers across runtime overlays",
+        "url": "https://github.com/openai/codex/commit/679f3b6b5677d685581358f37e7a3a7ddce2466d"
+      },
+      {
+        "kind": "commit",
+        "title": "Merge branch 'main' into eprovencher/fix-disabled-mcp-initialization",
+        "url": "https://github.com/openai/codex/commit/d1db1d33d190781ea06aa44692e9c31c4c45c683"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-11T14:06:31Z",
+  "observed_change": "Codex preserves configured `enabled = false` MCP servers after runtime fallback and extension overlays are applied.",
+  "changed_surfaces": [
+    "core MCP runtime configuration assembly",
+    "Apps MCP runtime overlay behavior",
+    "extension-backed MCP regression tests"
+  ],
+  "user_visible_path": "Users who explicitly disable an MCP server, including `codex_apps`, should not have that server re-enabled by compatibility or extension-provided runtime overlays.",
+  "control_plane_relevance": "High for Decodex Control Plane because disabled MCP server intent is a core operator safety and compatibility boundary for plugin/app-server orchestration.",
+  "compatibility_risk": "Medium positive compatibility fix: upstream now preserves disabled server state, so Decodex should stop assuming runtime overlays may override `enabled = false` on same-name servers once this version is present.",
+  "adoption_opportunity": "Use this behavior as evidence that disabled MCP server state survives runtime overlays and simplify Decodex troubleshooting around unexpected `codex_apps` initialization.",
+  "community_value": "High for MCP and app/plugin operators because it prevents explicitly disabled servers from being initialized by overlay defaults.",
+  "deprecated_or_breaking_notes": "No MCP server is removed; the change restores disabled state after overlays while preserving `Remove` precedence and other overlay fields.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27414 says same-name runtime overlays could default replacement MCP configs to enabled and initialize a server explicitly configured with `enabled = false`.",
+    "`codex-rs/core/src/mcp.rs` records disabled server names before adding runtime fallbacks and extension overlays.",
+    "`codex-rs/core/src/mcp.rs` restores `enabled = false` for those names after overlay application when the server remains present.",
+    "`codex-rs/ext/mcp/tests/hosted_apps_mcp.rs` adds `runtime_overlay_preserves_disabled_server` for a disabled `codex_apps` server.",
+    "The PR body says the connection manager already filtered disabled servers, but the configured disabled state was lost before that filter.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27414.json` records 2 changed files for the merged PR."
+  ],
+  "caveats": "The behavior is a targeted MCP runtime-overlay fix. It does not change unrelated MCP connection filtering or remove overlay fields.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Disabled MCP server preservation is directly relevant to Control Plane safety and compatibility."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The fix has a concise operator-facing explanation for MCP users."
+    },
+    {
+      "type": "linear_followup",
+      "reason": "Audit Decodex MCP troubleshooting notes for stale warnings about runtime overlays re-enabling disabled servers."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-27465.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27465.review.json
@@ -1,0 +1,68 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27465",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27465",
+    "commit_shas": [
+      "8e0cb424640c7776a0c6a03f27ff2e5d637d6389"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Remove redundant plugin app auth state",
+        "url": "https://github.com/openai/codex/pull/27465",
+        "meta": "Merged 2026-06-11T00:33:56Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Remove redundant plugin app auth state",
+        "url": "https://github.com/openai/codex/commit/8e0cb424640c7776a0c6a03f27ff2e5d637d6389"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-11T14:06:31Z",
+  "observed_change": "Codex removed the experimental `needsAuth` field from plugin app summaries and stopped `plugin/read` from contacting Apps MCP only to hydrate unused connector auth state.",
+  "changed_surfaces": [
+    "app-server protocol v2 AppSummary schema",
+    "generated JSON and TypeScript app-server schemas",
+    "plugin/read app summary hydration",
+    "plugin install auth-signal tests",
+    "TUI plugin detail test helpers and snapshots",
+    "app-server README plugin API documentation"
+  ],
+  "user_visible_path": "Consumers of experimental plugin app summaries should use `plugin/install.appsNeedingAuth` membership and `app/list.isAccessible` as auth signals instead of reading `plugin/read.plugin.apps[].needsAuth`.",
+  "control_plane_relevance": "High for Decodex Control Plane because plugin/app-server clients that track connector auth must stop relying on the removed `needsAuth` wire field.",
+  "compatibility_risk": "High for clients that consumed `AppSummary.needsAuth`; the field is removed from schemas and generated TypeScript, although the PR body says the plugin APIs are still under development.",
+  "adoption_opportunity": "Update Decodex plugin/app auth readbacks to use `plugin/install.appsNeedingAuth` and `app/list.isAccessible`, avoiding cold `plugin/read` calls that establish Apps MCP connections.",
+  "community_value": "High for Codex plugin API consumers because the PR clarifies the intended auth signals and removes a misleading, latency-inducing field.",
+  "deprecated_or_breaking_notes": "`AppSummary.needsAuth` is removed from generated schemas and Rust/TypeScript types. The PR body scopes this to under-development plugin APIs.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27465 says `needsAuth` is removed from `AppSummary`, `plugin/read` no longer queries Apps MCP only for unused auth state, and `plugin/install.appsNeedingAuth` plus `app/list.isAccessible` remain the auth signals.",
+    "`codex-rs/app-server-protocol/src/protocol/v2/apps.rs` removes `needs_auth` from `AppSummary`.",
+    "Generated JSON schemas and `codex-rs/app-server-protocol/schema/typescript/v2/AppSummary.ts` remove `needsAuth` from `AppSummary`.",
+    "`codex-rs/app-server/src/request_processors/plugins.rs` reduces `load_plugin_app_summaries` to config/plugin metadata and removes environment/MCP manager hydration for `plugin/read`.",
+    "`codex-rs/app-server/tests/suite/v2/plugin_install.rs` keeps `apps_needing_auth` expectations while removing `needs_auth` from app summaries.",
+    "`codex-rs/app-server/README.md` documents app list `isAccessible` and plugin install `appsNeedingAuth` as the remaining auth signals.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27465.json` records 11 changed files for the merged PR."
+  ],
+  "caveats": "The removed field belongs to an under-development plugin API; avoid framing this as a stable public API break without that caveat.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The wire schema removal is a Control Plane compatibility risk for plugin/app-server clients."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "Plugin API consumers need a concise migration note for auth-signal reads."
+    },
+    {
+      "type": "linear_followup",
+      "reason": "Audit Decodex plugin/app auth code and docs for any `needsAuth` assumptions."
+    }
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27071.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27071.json
@@ -1,0 +1,56 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27071",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "practical_explainer",
+  "priority": "critical",
+  "audience": "Codex users migrating from another coding agent",
+  "candidate_text": [
+    "Codex now has a local TUI `/import` flow for bringing over setup, project items, and recent chats from another coding agent. It runs on demand through the app-server import API and keeps `codex import` as an interactive prompt. PR: https://github.com/openai/codex/pull/27071"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27071.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27071.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27071"
+    ]
+  },
+  "evidence_notes": [
+    "`SlashCommand::Import` is added to the TUI and dispatched to the external-agent import event.",
+    "The import flow reports local-only availability and blocks duplicate in-progress imports.",
+    "App-server completion notifications are marked for delivery.",
+    "`codex import` remains an interactive prompt in CLI parse coverage."
+  ],
+  "claims": [
+    {
+      "text": "Codex TUI users can run `/import` to launch the external-agent import flow.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27071.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The import path is scoped to local interactive sessions and rejects unsupported remote or daemon-backed sessions.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27071.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR adds a concrete user-facing migration command with clear source-backed limits.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27071:practical_explainer"
+  },
+  "caveats": [
+    "Keep public copy scoped to local interactive TUI sessions.",
+    "Do not claim cloud-hosted chat import support.",
+    "Do not imply Decodex has automated imports."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or publish this candidate.",
+    "Review upstream follow-ups if completion messaging semantics change."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27311.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27311.json
@@ -1,0 +1,53 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27311",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "high",
+  "audience": "Codex plugin operators",
+  "candidate_text": [
+    "Codex remote-plugin tool suggestions no longer read the local openai-curated marketplace first. That avoids wasted local scans and malformed local manifests in remote-catalog mode, while normal plugin/list behavior stays intact. PR: https://github.com/openai/codex/pull/27311"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27311.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27311.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27311"
+    ]
+  },
+  "evidence_notes": [
+    "Tool-suggest discovery now excludes local `openai-curated` when remote plugins are enabled.",
+    "Other marketplace listing callers still include local curated discovery.",
+    "Regression coverage verifies malformed local curated manifests are not loaded in the remote-plugin suggestion path."
+  ],
+  "claims": [
+    {
+      "text": "Remote-plugin tool-suggestion discovery skips the local curated marketplace scan.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27311.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Normal plugin/list and local curated marketplace behavior are preserved outside that remote-plugin suggestion path.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27311.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The change is operationally useful for plugin operators diagnosing remote plugin discovery behavior.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27311:operator_impact"
+  },
+  "caveats": [
+    "Do not imply `openai-curated` marketplace support was removed.",
+    "Keep the claim scoped to remote-plugin tool suggestions."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether this operator-impact candidate should be posted or deferred."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27414.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27414.json
@@ -1,0 +1,55 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27414",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "critical",
+  "audience": "Codex MCP and app-server operators",
+  "candidate_text": [
+    "Codex now preserves `enabled = false` for MCP servers after runtime and extension overlays. That matters for operators who disable `codex_apps` or same-name MCP servers and expect overlays not to re-enable them. PR: https://github.com/openai/codex/pull/27414"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27414.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27414.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27414"
+    ]
+  },
+  "evidence_notes": [
+    "MCP runtime config now records disabled server names before overlays.",
+    "Disabled state is restored after runtime fallback and extension overlay application.",
+    "Regression coverage exercises a disabled `codex_apps` server.",
+    "The PR body identifies same-name replacement overlays defaulting to enabled as the bug."
+  ],
+  "claims": [
+    {
+      "text": "Configured disabled MCP servers remain disabled after runtime overlays.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27414.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The regression-covered example is a disabled `codex_apps` server.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27414.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The PR fixes an operator-visible MCP safety boundary with clear source evidence.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27414:operator_impact"
+  },
+  "caveats": [
+    "Do not imply all MCP overlay precedence changed.",
+    "Keep `codex_apps` framed as the regression-covered example."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or post this candidate.",
+    "Check Decodex MCP troubleshooting docs before making any Decodex support claim."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27465.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27465.json
@@ -1,0 +1,56 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27465",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "critical",
+  "audience": "Codex plugin API and app-server clients",
+  "candidate_text": [
+    "Codex removed `plugin/read.plugin.apps[].needsAuth` from the experimental plugin API. Auth-aware clients should use `plugin/install.appsNeedingAuth` and `app/list.isAccessible` instead. PR: https://github.com/openai/codex/pull/27465"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27465.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27465.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27465"
+    ]
+  },
+  "evidence_notes": [
+    "`AppSummary.needs_auth` is removed from Rust protocol types.",
+    "Generated JSON schemas and TypeScript definitions remove `needsAuth`.",
+    "`plugin/read` no longer hydrates app auth state by contacting Apps MCP.",
+    "The PR body names `plugin/install.appsNeedingAuth` and `app/list.isAccessible` as the preserved auth signals."
+  ],
+  "claims": [
+    {
+      "text": "`plugin/read.plugin.apps[].needsAuth` was removed from experimental plugin app summaries.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27465.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "`plugin/install.appsNeedingAuth` and `app/list.isAccessible` remain the intended auth signals.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27465.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The wire-field removal is a concrete migration note for plugin API and app-server clients.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27465:operator_impact"
+  },
+  "caveats": [
+    "State that the plugin APIs are still under development.",
+    "Do not imply plugin install auth signals were removed.",
+    "Do not claim Decodex support until Decodex clients are audited."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or publish this candidate.",
+    "Audit Decodex code/docs for `needsAuth` assumptions before making support claims."
+  ]
+}


### PR DESCRIPTION
## Summary

- refresh the deterministic openai/codex upstream review queue
- add GitHub change bundles plus upstream_review/v1 and upstream_impact/v1 artifacts for PRs 27071, 27311, 27414, and 27465
- add social_candidate/v1 handoffs for the selected public Publisher opportunities without writing social_post/v1 records

## Validation

- GH_TOKEN=GITHUB_PAT_Y cargo run -p decodex --bin decodex -- radar refresh-upstream-queue
- cargo run -p decodex --bin decodex -- radar bundle validate artifacts/github/bundles/openai-codex-pr-27071.json artifacts/github/bundles/openai-codex-pr-27311.json artifacts/github/bundles/openai-codex-pr-27414.json artifacts/github/bundles/openai-codex-pr-27465.json
- cargo make check-site-content
- git diff --check
- cargo make fmt
- cargo make lint-fix
- cargo test -p decodex still_active_phase_goal_stops_at_max_turns_without_terminal_signal --all-features -- --test-threads=1
- cargo test -p decodex turn_completion_ignores_orphan_json_rpc_response --all-features -- --test-threads=1
- cargo make test

Note: the first cargo make test run hit two app-server timeout flakes under nextest fail-fast; both focused reruns passed, and the full cargo make test rerun passed 1059 tests with 1 skipped.

## Automation boundary

No social_post/v1 artifacts were written and nothing was published to X.