### PR TITLE
Persist Codex alpha9 release checkpoint defer

### DIFF
--- a/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-9-needs-upstream-analysis.json
+++ b/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-9-needs-upstream-analysis.json
@@ -1,0 +1,95 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-rust-v0-140-0-alpha-9-needs-upstream-analysis",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "watch_note",
+  "priority": "normal",
+  "audience": "Codex operators tracking prerelease changes before stable",
+  "candidate_text": [
+    "No 0.140.0-alpha.9 post handoff yet.\n\nalpha.8 -> alpha.9 has 12 ahead commits and 11 primary PR-title refs, but the release body is sparse and those primary PRs lack checked Decodex review/impact.\n\nSource: https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.9"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27198.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27198.json"
+    ],
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://developers.openai.com/codex/changelog",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.8",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.9",
+      "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.8...rust-v0.140.0-alpha.9",
+      "https://github.com/openai/codex/pull/26513",
+      "https://github.com/openai/codex/pull/27082",
+      "https://github.com/openai/codex/pull/27103",
+      "https://github.com/openai/codex/pull/27198",
+      "https://github.com/openai/codex/pull/27356",
+      "https://github.com/openai/codex/pull/27387",
+      "https://github.com/openai/codex/pull/27388",
+      "https://github.com/openai/codex/pull/27403",
+      "https://github.com/openai/codex/pull/27404",
+      "https://github.com/openai/codex/pull/27569",
+      "https://github.com/openai/codex/pull/27573",
+      "https://github.com/openai/codex/pull/27585"
+    ]
+  },
+  "evidence_notes": [
+    "GitHub release metadata shows rust-v0.140.0-alpha.9 was published at 2026-06-11T12:59:01Z with only a sparse release body: Release 0.140.0-alpha.9.",
+    "The correct public prerelease comparison for this checkpoint is rust-v0.140.0-alpha.8 -> rust-v0.140.0-alpha.9; GitHub compare metadata reports status=diverged, 12 ahead commits, and 12 total commits.",
+    "Primary PR-title metadata in the alpha.8 -> alpha.9 compare points to compaction analytics and error shaping, dynamic tool search metadata, cloud config cache timing, backend plugin skills, remote skill resource tools, remote catalog failure caching, remote compaction v2 defaults, multi-agent v2 usage hints, and test or cleanup work.",
+    "Checked Radar review/impact artifacts are absent for all 11 primary PR-title references in the alpha.8 -> alpha.9 compare window in this checkout.",
+    "The compare commit text also references PR #27198 as the reviewed hosted-plugin-runtime dependency behind the backend skill work; that context is useful, but it does not source-review the alpha.9 PRs themselves.",
+    "The refreshed checked release_delta/v1 records stable rust-v0.139.0 -> latest prerelease rust-v0.140.0-alpha.9 with 98 ahead commits and no tracked signal slugs.",
+    "Official Codex changelog readback for this run still shows Codex app 26.608, ChatGPT for iOS 1.2026.153, and Codex CLI 0.139.0 on 2026-06-09 as the newest entries; rust-v0.140.0-alpha.9 is a GitHub prerelease checkpoint, not an official changelog entry."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.140.0-alpha.9 is a real OpenAI Codex prerelease checkpoint.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.9",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The correct public prerelease comparison for this checkpoint is rust-v0.140.0-alpha.8 -> rust-v0.140.0-alpha.9.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.8...rust-v0.140.0-alpha.9",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The alpha.9 release body is sparse and does not describe user-facing behavior beyond the version checkpoint.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.9",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "PR-title metadata in the alpha.9 compare points to compaction analytics, dynamic tool search metadata, cloud config cache timing, backend plugin skills, remote skill tools, remote compaction v2, and multi-agent v2 usage hints.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.8...rust-v0.140.0-alpha.9",
+      "confidence": "likely"
+    },
+    {
+      "text": "Behavior claims for the alpha.9 window require upstream source review before a publishable Decodex prerelease thread.",
+      "evidence": "artifacts/github/reviews/",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "defer",
+    "reason": "needs_upstream_analysis: the alpha.9 release body is sparse and the adjacent alpha.8 -> alpha.9 compare has unreviewed primary PR-title gaps.",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-140-0-alpha-9:alpha8-alpha9:defer"
+  },
+  "caveats": [
+    "This is a terminal defer / needs_upstream_analysis checkpoint record, not a publication request.",
+    "No previous live and quote-eligible @decodexspace 0.140 prerelease post exists; alpha.2, alpha.4, alpha.7, and alpha.8 were also recorded as defer / needs_upstream_analysis checkpoints.",
+    "Do not compare later 0.140 prereleases against stable 0.139.0 or alpha.8 if a newer public prerelease checkpoint exists; later 0.140 prereleases should use adjacent prerelease-to-prerelease lineage from alpha.9.",
+    "Exact source-review gap list for alpha.8 -> alpha.9 primary compare PRs: #26513, #27082, #27103, #27356, #27387, #27388, #27403, #27404, #27569, #27573, #27585.",
+    "Media caveat: no generated image is attached by this downstream artifact-consumer run. If this checkpoint later becomes publishable, decodex-x-publisher should generate and verify candidate-specific media only when it adds reader value."
+  ],
+  "next_steps": [
+    "Do not hand this alpha.9 defer record to decodex-x-publisher.",
+    "Route the listed source-review gap PRs to codex-upstream-radar-review / codex-code-analysis before turning alpha.9 into a release_rollup, watch_note, delta_explainer, or operator_impact post.",
+    "Use the refreshed release_delta/v1 only as stable-to-latest-prerelease site metadata; use adjacent prerelease-to-prerelease lineage for future 0.140 prereleases after alpha.9."
+  ]
+}

--- a/site/src/content/release-deltas/openai-codex-latest.json
+++ b/site/src/content/release-deltas/openai-codex-latest.json
@@ -1,6 +1,6 @@
 {
   "compare": {
-    "ahead_by": 87,
+    "ahead_by": 98,
     "commit_shas": [
       "dffc4bf75dc9eeb0727f668c95bb7bd72315581d",
       "14660c22d14312c28a50c52954dd77dd88f03c26",
@@ -88,7 +88,18 @@
       "ba4925b3c2240718888989664097f503ed062f80",
       "dac5f07403e048544cad6e9f9fbd52b91cb47a15",
       "598125109dd2e098486884d8fb563ebe90bc24da",
-      "ef7d9c2685a6eebb799f3eff7f5a75d459632c11"
+      "383708e74e42ac09b473633019d5f1498c18fbea",
+      "b5a718ef6742af051857ab5d3e20920dfbe66af3",
+      "8d9f33c87ca2e7cb89490703fb03f74c9a26578b",
+      "53b501974545547b26680b40ba2bb03903b2da44",
+      "a287c5dffdc96855e61a75526e86428fee6663e4",
+      "6754e77792e5cb788a8ef2b4f3c3b51d0324482a",
+      "273a4aa4f2474b9d27a2654f5803d51f65ce3f43",
+      "7b3eb8e4bcacc55cda6d5fb4d31a06b36351749b",
+      "087035224123977defc7fda6e684088395b1d0a0",
+      "e6757bba91f5cfb6c19c7e8ee383bea950d661f0",
+      "dd46ef1aac689d6ab6aa6a73c4358bff07d70a87",
+      "4a5e5db45e60208ce1e9e097a2ccda5eb9562e45"
     ],
     "pr_numbers": [
       22685,
@@ -100,6 +111,7 @@
       26409,
       26420,
       26479,
+      26513,
       26681,
       26701,
       26711,
@@ -120,9 +132,11 @@
       27071,
       27078,
       27080,
+      27082,
       27085,
       27094,
       27098,
+      27103,
       27107,
       27110,
       27111,
@@ -155,10 +169,15 @@
       27321,
       27322,
       27343,
+      27356,
       27375,
       27383,
+      27387,
+      27388,
       27391,
       27392,
+      27403,
+      27404,
       27407,
       27414,
       27421,
@@ -176,16 +195,19 @@
       27518,
       27520,
       27526,
-      27532
+      27532,
+      27569,
+      27573,
+      27585
     ],
     "status": "diverged",
-    "total_commits": 87,
-    "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.8"
+    "total_commits": 98,
+    "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.9"
   },
   "comparisons": [
     {
       "compare": {
-        "ahead_by": 87,
+        "ahead_by": 98,
         "commit_shas": [
           "dffc4bf75dc9eeb0727f668c95bb7bd72315581d",
           "14660c22d14312c28a50c52954dd77dd88f03c26",
@@ -273,7 +295,18 @@
           "ba4925b3c2240718888989664097f503ed062f80",
           "dac5f07403e048544cad6e9f9fbd52b91cb47a15",
           "598125109dd2e098486884d8fb563ebe90bc24da",
-          "ef7d9c2685a6eebb799f3eff7f5a75d459632c11"
+          "383708e74e42ac09b473633019d5f1498c18fbea",
+          "b5a718ef6742af051857ab5d3e20920dfbe66af3",
+          "8d9f33c87ca2e7cb89490703fb03f74c9a26578b",
+          "53b501974545547b26680b40ba2bb03903b2da44",
+          "a287c5dffdc96855e61a75526e86428fee6663e4",
+          "6754e77792e5cb788a8ef2b4f3c3b51d0324482a",
+          "273a4aa4f2474b9d27a2654f5803d51f65ce3f43",
+          "7b3eb8e4bcacc55cda6d5fb4d31a06b36351749b",
+          "087035224123977defc7fda6e684088395b1d0a0",
+          "e6757bba91f5cfb6c19c7e8ee383bea950d661f0",
+          "dd46ef1aac689d6ab6aa6a73c4358bff07d70a87",
+          "4a5e5db45e60208ce1e9e097a2ccda5eb9562e45"
         ],
         "pr_numbers": [
           22685,
@@ -285,6 +318,7 @@
           26409,
           26420,
           26479,
+          26513,
           26681,
           26701,
           26711,
@@ -305,9 +339,11 @@
           27071,
           27078,
           27080,
+          27082,
           27085,
           27094,
           27098,
+          27103,
           27107,
           27110,
           27111,
@@ -340,10 +376,15 @@
           27321,
           27322,
           27343,
+          27356,
           27375,
           27383,
+          27387,
+          27388,
           27391,
           27392,
+          27403,
+          27404,
           27407,
           27414,
           27421,
@@ -361,13 +402,16 @@
           27518,
           27520,
           27526,
-          27532
+          27532,
+          27569,
+          27573,
+          27585
         ],
         "status": "diverged",
-        "total_commits": 87,
-        "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.8"
+        "total_commits": 98,
+        "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.9"
       },
-      "prerelease_tag_name": "rust-v0.140.0-alpha.8",
+      "prerelease_tag_name": "rust-v0.140.0-alpha.9",
       "stable_tag_name": "rust-v0.139.0",
       "tracked_signal_slugs": []
     },
@@ -10176,22 +10220,22 @@
       ]
     }
   ],
-  "generated_at": "2026-06-11T08:42:01.181164Z",
+  "generated_at": "2026-06-11T14:34:04.510866Z",
   "prerelease": {
-    "name": "0.140.0-alpha.8",
+    "name": "0.140.0-alpha.9",
     "prerelease": true,
-    "published_at": "2026-06-11T06:12:14Z",
-    "tag_name": "rust-v0.140.0-alpha.8",
-    "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.8"
+    "published_at": "2026-06-11T12:59:01Z",
+    "tag_name": "rust-v0.140.0-alpha.9",
+    "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.9"
   },
   "release_options": {
     "preview": [
       {
-        "name": "0.140.0-alpha.8",
+        "name": "0.140.0-alpha.9",
         "prerelease": true,
-        "published_at": "2026-06-11T06:12:14Z",
-        "tag_name": "rust-v0.140.0-alpha.8",
-        "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.8"
+        "published_at": "2026-06-11T12:59:01Z",
+        "tag_name": "rust-v0.140.0-alpha.9",
+        "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.9"
       },
       {
         "name": "0.139.0-alpha.3",


### PR DESCRIPTION
## Summary
- refresh the Codex release_delta/v1 artifact from rust-v0.140.0-alpha.8 to rust-v0.140.0-alpha.9
- add a social_candidate/v1 defer / needs_upstream_analysis record for the alpha.9 checkpoint
- record the adjacent alpha.8 -> alpha.9 compare gap list for upstream review

## Decision
- mode: watch_note
- worthiness: defer
- reason: alpha.9 has a sparse release body and the adjacent compare has unreviewed primary PR-title gaps
- not a publisher handoff; do not send to decodex-x-publisher until upstream review covers the gap list

## Evidence
- official Codex changelog latest entries remain 2026-06-09 Codex app 26.608, iOS 1.2026.153, and Codex CLI 0.139.0
- GitHub release metadata shows rust-v0.140.0-alpha.9 published 2026-06-11T12:59:01Z
- GitHub compare rust-v0.140.0-alpha.8...rust-v0.140.0-alpha.9 reports 12 ahead commits and 11 primary PR-title refs without checked review/impact artifacts

## Validation
- jq empty on changed JSON artifacts
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates site/src/content/release-deltas: OK, 66 Radar artifact JSON files validated
- cargo make check-site-content: OK, 374 Radar artifact JSON files validated
- cargo make fmt: passed
- cargo make lint-fix: passed, vstyle applied 0 fixes
- cargo make test: 1059 passed, 1 skipped

## Label note
- repo has no codex or codex-automation labels available via gh label list, so no automation label was applied