### PR TITLE
Persist upstream Radar review artifacts

### DIFF
--- a/artifacts/github/bundles/openai-codex-pr-27443.json
+++ b/artifacts/github/bundles/openai-codex-pr-27443.json
@@ -1,0 +1,271 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "celia-oai",
+      "committed_at": "2026-06-10T19:14:29Z",
+      "message": "changes",
+      "sha": "104ce325c053cc8373b8f50f88516aaf73be0409",
+      "url": "https://github.com/openai/codex/commit/104ce325c053cc8373b8f50f88516aaf73be0409"
+    },
+    {
+      "author": "celia-oai",
+      "committed_at": "2026-06-10T22:02:22Z",
+      "message": "changes",
+      "sha": "2aef9c511d253364af98fb4348683fea07aa8eef",
+      "url": "https://github.com/openai/codex/commit/2aef9c511d253364af98fb4348683fea07aa8eef"
+    },
+    {
+      "author": "celia-oai",
+      "committed_at": "2026-06-10T23:17:54Z",
+      "message": "changes",
+      "sha": "5159b57cb0503bbf547d1a2c972dbe94933f0f01",
+      "url": "https://github.com/openai/codex/commit/5159b57cb0503bbf547d1a2c972dbe94933f0f01"
+    },
+    {
+      "author": "celia-oai",
+      "committed_at": "2026-06-10T23:33:01Z",
+      "message": "changes",
+      "sha": "1cd7a69b77fc746d10b786dc1640bc6e542b308e",
+      "url": "https://github.com/openai/codex/commit/1cd7a69b77fc746d10b786dc1640bc6e542b308e"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "API",
+    "AWS",
+    "CODEX_HOME",
+    "BEDROCK_API_KEY_UNSUPPORTED_MESSAGE"
+  ],
+  "files": [
+    {
+      "additions": 7,
+      "deletions": 0,
+      "patch_excerpt": "@@ -532,6 +532,13 @@\n             \"personalAccessToken\"\n           ],\n           \"type\": \"string\"\n+        },\n+        {\n+          \"description\": \"Amazon Bedrock bearer token managed by Codex.\",\n+          \"enum\": [\n+            \"bedrockApiKey\"\n+          ],\n+          \"type\": \"string\"\n         }\n       ]\n     },",
+      "path": "codex-rs/app-server-protocol/schema/json/ServerNotification.json",
+      "status": "modified"
+    },
+    {
+      "additions": 7,
+      "deletions": 0,
+      "patch_excerpt": "@@ -6728,6 +6728,13 @@\n               \"personalAccessToken\"\n             ],\n             \"type\": \"string\"\n+          },\n+          {\n+            \"description\": \"Amazon Bedrock bearer token managed by Codex.\",\n+            \"enum\": [\n+              \"bedrockApiKey\"\n+            ],\n+            \"type\": \"string\"\n           }\n         ]\n       },",
+      "path": "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+      "status": "modified"
+    },
+    {
+      "additions": 7,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1006,6 +1006,13 @@\n             \"personalAccessToken\"\n           ],\n           \"type\": \"string\"\n+        },\n+        {\n+          \"description\": \"Amazon Bedrock bearer token managed by Codex.\",\n+          \"enum\": [\n+            \"bedrockApiKey\"\n+          ],\n+          \"type\": \"string\"\n         }\n       ]\n     },",
+      "path": "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+      "status": "modified"
+    },
+    {
+      "additions": 7,
+      "deletions": 0,
+      "patch_excerpt": "@@ -38,6 +38,13 @@\n             \"personalAccessToken\"\n           ],\n           \"type\": \"string\"\n+        },\n+        {\n+          \"description\": \"Amazon Bedrock bearer token managed by Codex.\",\n+          \"enum\": [\n+            \"bedrockApiKey\"\n+          ],\n+          \"type\": \"string\"\n         }\n       ]\n     },",
+      "path": "codex-rs/app-server-protocol/schema/json/v2/AccountUpdatedNotification.json",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -5,4 +5,4 @@\n /**\n  * Authentication mode for OpenAI-backed providers.\n  */\n-export type AuthMode = \"apikey\" | \"chatgpt\" | \"chatgptAuthTokens\" | \"agentIdentity\" | \"personalAccessToken\";\n+export type AuthMode = \"apikey\" | \"chatgpt\" | \"chatgptAuthTokens\" | \"agentIdentity\" | \"personalAccessToken\" | \"bedrockApiKey\";",
+      "path": "codex-rs/app-server-protocol/schema/typescript/AuthMode.ts",
+      "status": "modified"
+    },
+    {
+      "additions": 6,
+      "deletions": 1,
+      "patch_excerpt": "@@ -41,14 +41,19 @@ pub enum AuthMode {\n     #[ts(rename = \"personalAccessToken\")]\n     #[strum(serialize = \"personalAccessToken\")]\n     PersonalAccessToken,\n+    /// Amazon Bedrock bearer token managed by Codex.\n+    #[serde(rename = \"bedrockApiKey\")]\n+    #[ts(rename = \"bedrockApiKey\")]\n+    #[strum(serialize = \"bedrockApiKey\")]\n+    BedrockApiKey,\n }\n \n impl AuthMode {\n     /// Returns whether this mode represents an authenticated human ChatGPT account.\n     pub fn has_chatgpt_account(self) -> bool {\n         match self {\n             Self::Chatgpt | Self::ChatgptAuthTokens | Self::PersonalAccessToken => true,\n-            Self::ApiKey | Self::AgentIdentity => false,\n+            Self::ApiKey | Self::AgentIdentity | Self::BedrockApiKey => false,\n         }\n     }\n }",
+      "path": "codex-rs/app-server-protocol/src/protocol/common.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -116,6 +116,7 @@ fn remote_control_auth_dot_json(account_id: Option<&str>) -> AuthDotJson {\n         last_refresh: Some(chrono::Utc::now()),\n         agent_identity: None,\n         personal_access_token: None,\n+        bedrock_api_key: None,\n     }\n }",
+      "path": "codex-rs/app-server-transport/src/transport/remote_control/tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1842,6 +1842,7 @@ mod tests {\n             last_refresh: Some(Utc::now()),\n             agent_identity: None,\n             personal_access_token: None,\n+            bedrock_api_key: None,\n         }\n     }",
+      "path": "codex-rs/app-server-transport/src/transport/remote_control/websocket.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -165,6 +165,7 @@ pub fn write_chatgpt_auth(\n         last_refresh,\n         agent_identity: None,\n         personal_access_token: None,\n+        bedrock_api_key: None,\n     };\n \n     save_auth(codex_home, &auth, cli_auth_credentials_store_mode).context(\"write auth.json\")",
+      "path": "codex-rs/app-server/tests/common/auth_fixtures.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -119,6 +119,7 @@ async fn list_apps_returns_empty_with_api_key_auth() -> Result<()> {\n             last_refresh: None,\n             agent_identity: None,\n             personal_access_token: None,\n+            bedrock_api_key: None,\n         },\n         AuthCredentialsStoreMode::File,\n     )?;",
+      "path": "codex-rs/app-server/tests/suite/v2/app_list.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 20,
+      "deletions": 4,
+      "patch_excerpt": "@@ -1324,17 +1324,20 @@ fn stored_auth_mode(auth: &codex_login::AuthDotJson) -> &'static str {\n         codex_app_server_protocol::AuthMode::ChatgptAuthTokens => \"chatgpt_auth_tokens\",\n         codex_app_server_protocol::AuthMode::AgentIdentity => \"agent_identity\",\n         codex_app_server_protocol::AuthMode::PersonalAccessToken => \"personal_access_token\",\n+        codex_app_server_protocol::AuthMode::BedrockApiKey => \"bedrock_api_key\",\n     }\n }\n \n fn stored_auth_mode_value(auth: &AuthDotJson) -> codex_app_server_protocol::AuthMode {\n     if let Some(mode) = auth.auth_mode {\n         return mode;\n     }\n-    if auth.openai_api_key.is_some() {\n-        codex_app_server_protocol::AuthMode::ApiKey\n-    } else if auth.personal_access_token.is_some() {\n+    if auth.personal_access_token.is_some() {\n         codex_app_server_protocol::AuthMode::PersonalAccessToken\n+    } else if auth.bedrock...",
+      "path": "codex-rs/cli/src/doctor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 4,
+      "deletions": 0,
+      "patch_excerpt": "@@ -395,6 +395,10 @@ pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {\n                 eprintln!(\"Logged in using personal access token\");\n                 std::process::exit(0);\n             }\n+            AuthMode::BedrockApiKey => {\n+                eprintln!(\"Logged in using Amazon Bedrock API key\");\n+                std::process::exit(0);\n+            }\n         },\n         Ok(None) => {\n             eprintln!(\"Not logged in\");",
+      "path": "codex-rs/cli/src/login.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -1985,7 +1985,7 @@ impl AuthRequestTelemetryContext {\n         let auth_telemetry = auth_header_telemetry(api_auth);\n         Self {\n             auth_mode: auth_mode.map(|mode| match mode {\n-                AuthMode::ApiKey => \"ApiKey\",\n+                AuthMode::ApiKey | AuthMode::BedrockApiKey => \"ApiKey\",\n                 AuthMode::Chatgpt\n                 | AuthMode::ChatgptAuthTokens\n                 | AuthMode::AgentIdentity",
+      "path": "codex-rs/core/src/client.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 4,
+      "deletions": 0,
+      "patch_excerpt": "@@ -166,6 +166,7 @@ async fn login_with_access_token_writes_only_personal_access_token() {\n             last_refresh: None,\n             agent_identity: None,\n             personal_access_token: Some(\"at-login-test\".to_string()),\n+            bedrock_api_key: None,\n         }\n     );\n     assert_eq!(auth.resolved_mode(), AuthMode::PersonalAccessToken);\n@@ -325,6 +326,7 @@ async fn pro_account_with_no_api_key_uses_chatgpt_auth() {\n             last_refresh: Some(last_refresh),\n             agent_identity: None,\n             personal_access_token: None,\n+            bedrock_api_key: None,\n         },\n         auth_dot_json\n     );\n@@ -367,6 +369,7 @@ fn logout_removes_auth_file() -> Result<(), std::io::Error> {\n         last_refresh: None,\n         agent_identity: None,\n         personal_access_token: None,\n+        bedrock_api_key: None,\n     };\n     super::save_auth(dir.path(), &auth_dot...",
+      "path": "codex-rs/login/src/auth/auth_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 42,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,42 @@\n+use std::path::Path;\n+\n+use codex_config::types::AuthCredentialsStoreMode;\n+use serde::Deserialize;\n+use serde::Serialize;\n+\n+use super::manager::save_auth;\n+use super::storage::AuthDotJson;\n+use codex_app_server_protocol::AuthMode;\n+\n+/// Managed Amazon Bedrock API key persisted in `auth.json`.\n+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]\n+pub struct BedrockApiKeyAuth {\n+    pub api_key: String,\n+    pub region: String,\n+}\n+\n+/// Writes an `auth.json` that contains only the Amazon Bedrock API key auth.\n+pub fn login_with_bedrock_api_key(\n+    codex_home: &Path,\n+    api_key: &str,\n+    region: &str,\n+    auth_credentials_store_mode: AuthCredentialsStoreMode,\n+) -> std::io::Result<()> {\n+    let auth_dot_json = AuthDotJson {\n+        auth_mode: Some(AuthMode::BedrockApiKey),\n+        openai_api_key: None,\n+        tokens: None,\n+        last_refresh: ...",
+      "path": "codex-rs/login/src/auth/bedrock_api_key.rs",
+      "status": "added"
+    },
+    {
+      "additions": 162,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,162 @@\n+use codex_app_server_protocol::AuthMode;\n+use codex_config::types::AuthCredentialsStoreMode;\n+use pretty_assertions::assert_eq;\n+use tempfile::tempdir;\n+\n+use super::*;\n+use crate::auth::AuthManager;\n+use crate::auth::CodexAuth;\n+use crate::auth::storage::AuthStorageBackend;\n+use crate::auth::storage::FileAuthStorage;\n+\n+fn api_key_auth() -> AuthDotJson {\n+    AuthDotJson {\n+        auth_mode: Some(AuthMode::ApiKey),\n+        openai_api_key: Some(\"sk-test-key\".to_string()),\n+        tokens: None,\n+        last_refresh: None,\n+        agent_identity: None,\n+        personal_access_token: None,\n+        bedrock_api_key: None,\n+    }\n+}\n+\n+fn bedrock_only_auth() -> AuthDotJson {\n+    AuthDotJson {\n+        auth_mode: None,\n+        openai_api_key: None,\n+        tokens: None,\n+        last_refresh: None,\n+        agent_identity: None,\n+        personal_access_token: None,...",
+      "path": "codex-rs/login/src/auth/bedrock_api_key_tests.rs",
+      "status": "added"
+    },
+    {
+      "additions": 42,
+      "deletions": 7,
+      "patch_excerpt": "@@ -29,6 +29,7 @@ use super::access_token::classify_codex_access_token;\n use super::external_bearer::BearerTokenRefresher;\n use super::revoke::revoke_auth_tokens;\n pub use crate::auth::agent_identity::AgentIdentityAuth;\n+pub use crate::auth::bedrock_api_key::BedrockApiKeyAuth;\n pub use crate::auth::personal_access_token::PersonalAccessTokenAuth;\n pub use crate::auth::storage::AgentIdentityAuthRecord;\n pub use crate::auth::storage::AuthDotJson;\n@@ -57,12 +58,14 @@ pub enum CodexAuth {\n     ChatgptAuthTokens(ChatgptAuthTokens),\n     AgentIdentity(AgentIdentityAuth),\n     PersonalAccessToken(PersonalAccessTokenAuth),\n+    BedrockApiKey(BedrockApiKeyAuth),\n }\n \n impl PartialEq for CodexAuth {\n     fn eq(&self, other: &Self) -> bool {\n         match (self, other) {\n             (Self::PersonalAccessToken(a), Self::PersonalAccessToken(b)) => a == b,\n+            (Self::BedrockApiKey(a), Self::...",
+      "path": "codex-rs/login/src/auth/manager.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1,5 +1,6 @@\n mod access_token;\n mod agent_identity;\n+mod bedrock_api_key;\n pub mod default_client;\n pub mod error;\n mod personal_access_token;\n@@ -10,6 +11,8 @@ mod external_bearer;\n mod manager;\n mod revoke;\n \n+pub use bedrock_api_key::BedrockApiKeyAuth;\n+pub use bedrock_api_key::login_with_bedrock_api_key;\n pub use error::RefreshTokenFailedError;\n pub use error::RefreshTokenFailedReason;\n pub use manager::*;",
+      "path": "codex-rs/login/src/auth/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 4,
+      "deletions": 0,
+      "patch_excerpt": "@@ -18,6 +18,7 @@ use std::sync::Arc;\n use std::sync::Mutex;\n use tracing::warn;\n \n+use super::BedrockApiKeyAuth;\n use crate::token_data::TokenData;\n use codex_agent_identity::AgentIdentityJwtClaims;\n use codex_agent_identity::decode_agent_identity_jwt;\n@@ -48,6 +49,9 @@ pub struct AuthDotJson {\n \n     #[serde(default, skip_serializing_if = \"Option::is_none\")]\n     pub personal_access_token: Option<String>,\n+\n+    #[serde(default, skip_serializing_if = \"Option::is_none\")]\n+    pub bedrock_api_key: Option<BedrockApiKeyAuth>,\n }\n \n #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]",
+      "path": "codex-rs/login/src/auth/storage.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 9,
+      "deletions": 0,
+      "patch_excerpt": "@@ -20,6 +20,7 @@ async fn file_storage_load_returns_auth_dot_json() -> anyhow::Result<()> {\n         last_refresh: Some(Utc::now()),\n         agent_identity: None,\n         personal_access_token: None,\n+        bedrock_api_key: None,\n     };\n \n     storage\n@@ -42,6 +43,7 @@ async fn file_storage_save_persists_auth_dot_json() -> anyhow::Result<()> {\n         last_refresh: Some(Utc::now()),\n         agent_identity: None,\n         personal_access_token: None,\n+        bedrock_api_key: None,\n     };\n \n     let file = get_auth_file(codex_home.path());\n@@ -76,6 +78,7 @@ async fn file_storage_round_trips_agent_identity_auth() -> anyhow::Result<()> {\n         last_refresh: None,\n         agent_identity: Some(agent_identity),\n         personal_access_token: None,\n+        bedrock_api_key: None,\n     };\n \n     storage.save(&auth_dot_json)?;\n@@ -96,6 +99,7 @@ async fn file_storage_round_trips_pers...",
+      "path": "codex-rs/login/src/auth/storage_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -40,6 +40,7 @@ pub use auth::enforce_login_restrictions;\n pub use auth::load_auth_dot_json;\n pub use auth::login_with_access_token;\n pub use auth::login_with_api_key;\n+pub use auth::login_with_bedrock_api_key;\n pub use auth::logout;\n pub use auth::logout_with_revoke;\n pub use auth::read_codex_access_token_from_env;",
+      "path": "codex-rs/login/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -823,6 +823,7 @@ pub(crate) async fn persist_tokens_async(\n             last_refresh: Some(Utc::now()),\n             agent_identity: None,\n             personal_access_token: None,\n+            bedrock_api_key: None,\n         };\n         save_auth(&codex_home, &auth, auth_credentials_store_mode)?;\n         Ok::<_, io::Error>((previous_auth, auth))\n@@ -1327,6 +1328,7 @@ mod tests {\n             last_refresh: None,\n             agent_identity: None,\n             personal_access_token: None,\n+            bedrock_api_key: None,\n         }\n     }",
+      "path": "codex-rs/login/src/server.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 25,
+      "deletions": 0,
+      "patch_excerpt": "@@ -56,6 +56,7 @@ async fn refresh_token_succeeds_updates_storage() -> Result<()> {\n         last_refresh: Some(initial_last_refresh),\n         agent_identity: None,\n         personal_access_token: None,\n+        bedrock_api_key: None,\n     };\n     ctx.write_auth(&initial_auth).await?;\n \n@@ -121,6 +122,7 @@ async fn refresh_token_refreshes_when_auth_is_unchanged() -> Result<()> {\n         last_refresh: Some(initial_last_refresh),\n         agent_identity: None,\n         personal_access_token: None,\n+        bedrock_api_key: None,\n     };\n     ctx.write_auth(&initial_auth).await?;\n \n@@ -187,6 +189,7 @@ async fn auth_refreshes_when_access_token_is_near_expiry() -> Result<()> {\n         last_refresh: Some(initial_last_refresh),\n         agent_identity: None,\n         personal_access_token: None,\n+        bedrock_api_key: None,\n     };\n     ctx.write_auth(&initial_auth).await?;\n \n@@ -238,6 +2...",
+      "path": "codex-rs/login/tests/suite/auth_refresh.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -196,6 +196,7 @@ fn chatgpt_auth_with_refresh_token(refresh_token: &str) -> AuthDotJson {\n         last_refresh: None,\n         agent_identity: None,\n         personal_access_token: None,\n+        bedrock_api_key: None,\n     }\n }",
+      "path": "codex-rs/login/tests/suite/logout.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 30,
+      "deletions": 0,
+      "patch_excerpt": "@@ -8,11 +8,15 @@ use codex_api::SharedAuthProvider;\n use codex_login::AuthManager;\n use codex_login::CodexAuth;\n use codex_model_provider_info::ModelProviderInfo;\n+use codex_protocol::error::CodexErr;\n use http::HeaderMap;\n use http::HeaderValue;\n \n use crate::bearer_auth_provider::BearerAuthProvider;\n \n+const BEDROCK_API_KEY_UNSUPPORTED_MESSAGE: &str =\n+    \"Bedrock API key auth is only supported by the Amazon Bedrock model provider\";\n+\n #[derive(Clone, Debug)]\n struct AgentIdentityAuthProvider {\n     auth: codex_login::auth::AgentIdentityAuth,\n@@ -79,6 +83,12 @@ pub(crate) fn resolve_provider_auth(\n     auth: Option<&CodexAuth>,\n     provider: &ModelProviderInfo,\n ) -> codex_protocol::error::Result<SharedAuthProvider> {\n+    if matches!(auth, Some(CodexAuth::BedrockApiKey(_))) {\n+        return Err(CodexErr::UnsupportedOperation(\n+            BEDROCK_API_KEY_UNSUPPORTED_MESSAGE.to_str...",
+      "path": "codex-rs/model-provider/src/auth.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 31,
+      "deletions": 0,
+      "patch_excerpt": "@@ -51,6 +51,7 @@ pub struct ProviderAccountState {\n #[derive(Debug, Clone, Copy, PartialEq, Eq)]\n pub enum ProviderAccountError {\n     MissingChatgptAccountDetails,\n+    UnsupportedBedrockApiKeyAuth,\n }\n \n impl fmt::Display for ProviderAccountError {\n@@ -62,6 +63,12 @@ impl fmt::Display for ProviderAccountError {\n                     \"email and plan type are required for chatgpt authentication\"\n                 )\n             }\n+            Self::UnsupportedBedrockApiKeyAuth => {\n+                write!(\n+                    f,\n+                    \"Bedrock API key auth is only supported by the Amazon Bedrock model provider\"\n+                )\n+            }\n         }\n     }\n }\n@@ -232,6 +239,9 @@ impl ModelProvider for ConfiguredModelProvider {\n                 })\n                 .map(|auth| match &auth {\n                     CodexAuth::ApiKey(_) => Ok(ProviderAccount::ApiKey),\n+    ...",
+      "path": "codex-rs/model-provider/src/provider.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -212,6 +212,7 @@ c2ln\",\n         last_refresh: Some(Utc::now()),\n         agent_identity: None,\n         personal_access_token: None,\n+        bedrock_api_key: None,\n     };\n     std::fs::create_dir_all(codex_home).expect(\"codex home should be created\");\n     std::fs::write(",
+      "path": "codex-rs/models-manager/src/manager_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 1,
+      "patch_excerpt": "@@ -54,7 +54,8 @@ pub enum TelemetryAuthMode {\n impl From<codex_app_server_protocol::AuthMode> for TelemetryAuthMode {\n     fn from(mode: codex_app_server_protocol::AuthMode) -> Self {\n         match mode {\n-            codex_app_server_protocol::AuthMode::ApiKey => Self::ApiKey,\n+            codex_app_server_protocol::AuthMode::ApiKey\n+            | codex_app_server_protocol::AuthMode::BedrockApiKey => Self::ApiKey,\n             codex_app_server_protocol::AuthMode::Chatgpt\n             | codex_app_server_protocol::AuthMode::ChatgptAuthTokens\n             | codex_app_server_protocol::AuthMode::AgentIdentity",
+      "path": "codex-rs/otel/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1169,6 +1169,7 @@ pub(crate) fn status_account_display_from_auth_mode(\n             email: None,\n             plan: plan_type.map(plan_type_display_name),\n         }),\n+        Some(AuthMode::BedrockApiKey) => None,\n         None => None,\n     }\n }",
+      "path": "codex-rs/tui/src/app_server_session.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -110,6 +110,7 @@ mod tests {\n             last_refresh: Some(Utc::now()),\n             agent_identity: None,\n             personal_access_token: None,\n+            bedrock_api_key: None,\n         };\n         save_auth(codex_home, &auth, AuthCredentialsStoreMode::File)\n             .expect(\"chatgpt auth should save\");\n@@ -158,6 +159,7 @@ mod tests {\n                 last_refresh: None,\n                 agent_identity: None,\n                 personal_access_token: None,\n+                bedrock_api_key: None,\n             },\n             AuthCredentialsStoreMode::File,\n         )",
+      "path": "codex-rs/tui/src/local_chatgpt_auth.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\r\n\r\nCodex needs to manage Amazon Bedrock API key credentials through the existing auth lifecycle instead of introducing a separate auth manager or provider-specific credential file. Treating Bedrock API key login as a primary auth mode gives it the same persistence, keyring, reload, and logout behavior as the existing OpenAI API key and ChatGPT modes.\r\n\r\nThe credential is valid only for the `amazon-bedrock` model provider. OpenAI-compatible providers must reject this auth mode rather than treating the Bedrock key as an OpenAI bearer token.\r\n\r\n## What changed\r\n\r\n- Added `bedrockApiKey` as an app-server `AuthMode` and `CodexAuth::BedrockApiKey` as a primary `AuthManager` mode.\r\n- Added `BedrockApiKeyAuth`, containing the API key and AWS region, to the existing `AuthDotJson` payload stored in `$CODEX_HOME/auth.json` or the configured keyring backend.\r\n- Added `login_with_bedrock_api_key(...)`, parallel to `login_with_api_key(...)`, which replaces the current stored login with Bedrock credentials.\r\n- Reused generic auth reload and logout behavior instead of adding a Bedrock-specific auth manager or logout path.\r\n- Updated login restrictions, status reporting, diagnostics, telemetry classification, generated app-server schemas, and auth fixtures for the new mode.\r\n- Added explicit errors when Bedrock API key auth is selected with an OpenAI-compatible model provider.\r\n\r\nThis PR establishes managed storage and auth-mode behavior. Routing the managed key and region into Amazon Bedrock requests will be in follow-up PRs.\r\n",
+    "labels": [
+      "code-reviewed"
+    ],
+    "merged_at": "2026-06-11T03:42:39Z",
+    "number": 27443,
+    "state": "merged",
+    "title": "feat: add Bedrock API key as a managed auth mode",
+    "url": "https://github.com/openai/codex/pull/27443"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27488.json
+++ b/artifacts/github/bundles/openai-codex-pr-27488.json
@@ -1,0 +1,142 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "pakrym-oai",
+      "committed_at": "2026-06-10T18:54:24Z",
+      "message": "Add token budget context feature",
+      "sha": "a19ec71e8d73d4dbd1dfb5b34894744ee8e6ef1a",
+      "url": "https://github.com/openai/codex/commit/a19ec71e8d73d4dbd1dfb5b34894744ee8e6ef1a"
+    },
+    {
+      "author": "pakrym-oai",
+      "committed_at": "2026-06-10T20:33:42Z",
+      "message": "codex: address token budget review feedback (#27438)",
+      "sha": "67a29aab4885be483dc7ea05ec9bce8fddbfdc00",
+      "url": "https://github.com/openai/codex/commit/67a29aab4885be483dc7ea05ec9bce8fddbfdc00"
+    },
+    {
+      "author": "pakrym-oai",
+      "committed_at": "2026-06-10T20:42:56Z",
+      "message": "codex: update token budget context wording",
+      "sha": "9e25474a95a9ceb092c04ac628cbb6985f7f30eb",
+      "url": "https://github.com/openai/codex/commit/9e25474a95a9ceb092c04ac628cbb6985f7f30eb"
+    },
+    {
+      "author": "pakrym-oai",
+      "committed_at": "2026-06-10T22:58:44Z",
+      "message": "codex: add new context window tool",
+      "sha": "812afdf99973b744cc03839a08128a536df58e4c",
+      "url": "https://github.com/openai/codex/commit/812afdf99973b744cc03839a08128a536df58e4c"
+    },
+    {
+      "author": "pakrym-oai",
+      "committed_at": "2026-06-11T03:25:47Z",
+      "message": "Merge remote-tracking branch 'origin/main' into pakrym/token-budget-window-tool",
+      "sha": "57885a18cccf9db57602e1240e553aaf1df92da9",
+      "url": "https://github.com/openai/codex/commit/57885a18cccf9db57602e1240e553aaf1df92da9"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "NEW_CONTEXT_WINDOW_TOOL_NAME",
+    "NEW_CONTEXT_WINDOW_MESSAGE",
+    "PERMISSIONS_INSTRUCTIONS",
+    "SKILLS_INSTRUCTIONS",
+    "ENVIRONMENT_CONTEXT",
+    "CWD",
+    "CONFIGURED_CONTEXT_WINDOW",
+    "EFFECTIVE_CONTEXT_WINDOW"
+  ],
+  "files": [
+    {
+      "additions": 38,
+      "deletions": 0,
+      "patch_excerpt": "@@ -3058,6 +3058,44 @@ impl Session {\n         state.advance_auto_compact_window_id()\n     }\n \n+    pub(crate) async fn request_new_context_window(&self) {\n+        let mut state = self.state.lock().await;\n+        state.request_new_context_window();\n+    }\n+\n+    pub(crate) async fn maybe_start_new_context_window(\n+        &self,\n+        turn_context: &TurnContext,\n+    ) -> Option<u64> {\n+        let window_id = {\n+            let mut state = self.state.lock().await;\n+            state.start_new_context_window_if_requested()\n+        };\n+        let window_id = window_id?;\n+        let context_items = self.build_initial_context(turn_context).await;\n+        let turn_context_item = turn_context.to_turn_context_item();\n+        let replacement_history = context_items;\n+        {\n+            let mut state = self.state.lock().await;\n+            state.replace_history(replacement_history....",
+      "path": "codex-rs/core/src/session/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 9,
+      "deletions": 0,
+      "patch_excerpt": "@@ -285,6 +285,15 @@ pub(crate) async fn run_turn(\n                 )\n                 .await;\n \n+                let started_new_context_window = sess\n+                    .maybe_start_new_context_window(turn_context.as_ref())\n+                    .await\n+                    .is_some();\n+                if started_new_context_window && needs_follow_up {\n+                    can_drain_pending_input = !model_needs_follow_up;\n+                    continue;\n+                }\n+\n                 // as long as compaction works well in getting us way below the token limit, we shouldn't worry about being in an infinite loop.\n                 if token_limit_reached && needs_follow_up {\n                     if let Err(err) = run_auto_compact(",
+      "path": "codex-rs/core/src/session/turn.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 18,
+      "deletions": 0,
+      "patch_excerpt": "@@ -14,6 +14,7 @@ enum AutoCompactWindowPrefill {\n #[derive(Debug, Clone, Copy, PartialEq, Eq)]\n pub(super) struct AutoCompactWindow {\n     window_id: u64,\n+    new_context_window_requested: bool,\n     /// Absolute input-token baseline for the current compaction window.\n     ///\n     /// `body_after_prefix` subtracts this from later active-context usage. It is\n@@ -26,6 +27,7 @@ impl AutoCompactWindow {\n     pub(super) fn new() -> Self {\n         Self {\n             window_id: 0,\n+            new_context_window_requested: false,\n             prefill_input_tokens: None,\n         }\n     }\n@@ -44,9 +46,20 @@ impl AutoCompactWindow {\n \n     pub(super) fn advance_window_id(&mut self) -> u64 {\n         self.window_id = self.window_id.saturating_add(1);\n+        self.new_context_window_requested = false;\n         self.window_id\n     }\n \n+    pub(super) fn request_new_context_window(&mut self) {\n...",
+      "path": "codex-rs/core/src/state/auto_compact_window.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 14,
+      "deletions": 0,
+      "patch_excerpt": "@@ -156,6 +156,20 @@ impl SessionState {\n         self.auto_compact_window.advance_window_id()\n     }\n \n+    pub(crate) fn request_new_context_window(&mut self) {\n+        self.auto_compact_window.request_new_context_window();\n+    }\n+\n+    pub(crate) fn start_new_context_window_if_requested(&mut self) -> Option<u64> {\n+        if !self.auto_compact_window.take_new_context_window_request() {\n+            return None;\n+        }\n+\n+        let window_id = self.auto_compact_window.advance_window_id();\n+        self.auto_compact_window.clear_prefill();\n+        Some(window_id)\n+    }\n+\n     pub(crate) fn token_info(&self) -> Option<TokenUsageInfo> {\n         self.history.token_info()\n     }",
+      "path": "codex-rs/core/src/state/session.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 0,
+      "patch_excerpt": "@@ -13,6 +13,8 @@ pub(crate) mod multi_agents;\n pub(crate) mod multi_agents_common;\n pub(crate) mod multi_agents_spec;\n pub(crate) mod multi_agents_v2;\n+mod new_context_window;\n+pub(crate) mod new_context_window_spec;\n mod plan;\n pub(crate) mod plan_spec;\n mod request_permissions;\n@@ -56,6 +58,7 @@ pub use mcp::McpHandler;\n pub use mcp_resource::ListMcpResourceTemplatesHandler;\n pub use mcp_resource::ListMcpResourcesHandler;\n pub use mcp_resource::ReadMcpResourceHandler;\n+pub use new_context_window::NewContextWindowHandler;\n pub use plan::PlanHandler;\n pub use request_permissions::RequestPermissionsHandler;\n pub use request_plugin_install::RequestPluginInstallHandler;",
+      "path": "codex-rs/core/src/tools/handlers/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 45,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,45 @@\n+use crate::function_tool::FunctionCallError;\n+use crate::tools::context::FunctionToolOutput;\n+use crate::tools::context::ToolInvocation;\n+use crate::tools::context::ToolPayload;\n+use crate::tools::context::boxed_tool_output;\n+use crate::tools::handlers::new_context_window_spec::NEW_CONTEXT_WINDOW_TOOL_NAME;\n+use crate::tools::handlers::new_context_window_spec::create_new_context_window_tool;\n+use crate::tools::registry::CoreToolRuntime;\n+use crate::tools::registry::ToolExecutor;\n+use codex_tools::ToolName;\n+use codex_tools::ToolSpec;\n+\n+pub(crate) const NEW_CONTEXT_WINDOW_MESSAGE: &str =\n+    \"A new context window will start without summarizing conversation history.\";\n+\n+pub struct NewContextWindowHandler;\n+\n+impl ToolExecutor<ToolInvocation> for NewContextWindowHandler {\n+    fn tool_name(&self) -> ToolName {\n+        ToolName::plain(NEW_CONTEXT_WINDOW_TOOL_NAME)\n+    ...",
+      "path": "codex-rs/core/src/tools/handlers/new_context_window.rs",
+      "status": "added"
+    },
+    {
+      "additions": 17,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,17 @@\n+use codex_tools::JsonSchema;\n+use codex_tools::ResponsesApiTool;\n+use codex_tools::ToolSpec;\n+use std::collections::BTreeMap;\n+\n+pub(crate) const NEW_CONTEXT_WINDOW_TOOL_NAME: &str = \"new_context\";\n+\n+pub fn create_new_context_window_tool() -> ToolSpec {\n+    ToolSpec::Function(ResponsesApiTool {\n+        name: NEW_CONTEXT_WINDOW_TOOL_NAME.to_string(),\n+        description: \"Start a new context window.\".to_string(),\n+        strict: false,\n+        defer_loading: None,\n+        parameters: JsonSchema::object(BTreeMap::new(), /*required*/ None, Some(false.into())),\n+        output_schema: None,\n+    })\n+}",
+      "path": "codex-rs/core/src/tools/handlers/new_context_window_spec.rs",
+      "status": "added"
+    },
+    {
+      "additions": 5,
+      "deletions": 0,
+      "patch_excerpt": "@@ -13,6 +13,7 @@ use crate::tools::handlers::ListAvailablePluginsToInstallHandler;\n use crate::tools::handlers::ListMcpResourceTemplatesHandler;\n use crate::tools::handlers::ListMcpResourcesHandler;\n use crate::tools::handlers::McpHandler;\n+use crate::tools::handlers::NewContextWindowHandler;\n use crate::tools::handlers::PlanHandler;\n use crate::tools::handlers::ReadMcpResourceHandler;\n use crate::tools::handlers::RequestPermissionsHandler;\n@@ -659,6 +660,10 @@ fn add_core_utility_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut\n         planned_tools.add(RequestPermissionsHandler);\n     }\n \n+    if features.enabled(Feature::TokenBudget) {\n+        planned_tools.add_with_exposure(NewContextWindowHandler, ToolExposure::DirectModelOnly);\n+    }\n+\n     if tool_suggest_enabled(turn_context)\n         && let Some(discoverable_tools) =\n             context.discoverable_tools.filter...",
+      "path": "codex-rs/core/src/tools/spec_plan.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 15,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,15 @@\n+---\n+source: core/tests/suite/token_budget.rs\n+assertion_line: 300\n+expression: \"context_snapshot::format_labeled_requests_snapshot(\\\"New context window tool installs fresh full context before the next follow-up request.\\\",\\n&[(\\\"Final Follow-Up Request\\\", &requests[2])],\\n&ContextSnapshotOptions::default(),)\"\n+---\n+Scenario: New context window tool installs fresh full context before the next follow-up request.\n+\n+## Final Follow-Up Request\n+00:message/developer[3]:\n+    [01] <PERMISSIONS_INSTRUCTIONS>\n+    [02] <SKILLS_INSTRUCTIONS>\n+    [03] <token_budget>\\nCurrent context window 1.\\nYou have 121600 tokens left in this context window.\\n</token_budget>\n+01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>\n+02:function_call/update_plan\n+03:function_call_output:Plan updated",
+      "path": "codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap",
+      "status": "added"
+    },
+    {
+      "additions": 97,
+      "deletions": 0,
+      "patch_excerpt": "@@ -4,10 +4,13 @@ use codex_model_provider_info::built_in_model_providers;\n use codex_protocol::protocol::EventMsg;\n use codex_protocol::protocol::Op;\n use core_test_support::PathBufExt;\n+use core_test_support::context_snapshot;\n+use core_test_support::context_snapshot::ContextSnapshotOptions;\n use core_test_support::responses::ResponsesRequest;\n use core_test_support::responses::ev_assistant_message;\n use core_test_support::responses::ev_completed;\n use core_test_support::responses::ev_completed_with_tokens;\n+use core_test_support::responses::ev_function_call;\n use core_test_support::responses::ev_response_created;\n use core_test_support::responses::mount_sse_sequence;\n use core_test_support::responses::sse;\n@@ -17,6 +20,8 @@ use core_test_support::test_codex::local;\n use core_test_support::test_codex::test_codex;\n use core_test_support::wait_for_event;\n use pretty_assertions::assert_eq...",
+      "path": "codex-rs/core/tests/suite/token_budget.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#27438"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nThe token budget feature tells the model how much room remains in the current context window. When the model decides the current window is no longer useful, it needs a way to ask Codex to start over with a fresh context window without spending tokens on a compaction summary.\n\nThis PR adds that model-requestable escape hatch on top of #27438.\n\n## What changed\n\n- Added a direct-model-only `new_context` tool behind `Feature::TokenBudget`.\n- Stores the tool request on `AutoCompactWindow` and consumes it after sampling so the next follow-up request in the same turn starts in the new window.\n- Starts the new window as a no-summary compaction checkpoint that contains only fresh initial context, not preserved conversation history.\n- Keeps the new window aligned with token-budget startup context, including the `Current context window Z` message.\n- Added integration coverage and a snapshot showing the same-turn `new_context` flow into a fresh full-context follow-up request.\n\n## Validation\n\n- `just test -p codex-core token_budget`\n",
+    "labels": [],
+    "merged_at": "2026-06-11T03:39:08Z",
+    "number": 27488,
+    "state": "merged",
+    "title": "[codex] Add new context window tool",
+    "url": "https://github.com/openai/codex/pull/27488"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27517.json
+++ b/artifacts/github/bundles/openai-codex-pr-27517.json
@@ -1,0 +1,68 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "xl-openai",
+      "committed_at": "2026-06-11T02:32:54Z",
+      "message": "Pass auth mode to plugin manager",
+      "sha": "66d506e86e5da8691b0773563eff7f73ecff20b9",
+      "url": "https://github.com/openai/codex/commit/66d506e86e5da8691b0773563eff7f73ecff20b9"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "MCP",
+    "API",
+    "CODEX_SANDBOX_NETWORK_DISABLED",
+    "CODEX_SANDBOX",
+    "CONFIG_TOML_FILE",
+    "MAX_CAPABILITY_SUMMARY_DESCRIPTION_LEN"
+  ],
+  "files": [
+    {
+      "additions": 7,
+      "deletions": 0,
+      "patch_excerpt": "@@ -158,6 +158,9 @@ impl AccountRequestProcessor {\n \n     pub(crate) fn clear_external_auth(&self) {\n         self.auth_manager.clear_external_auth();\n+        self.thread_manager\n+            .plugins_manager()\n+            .set_auth_mode(self.auth_manager.get_api_auth_mode());\n     }\n \n     fn current_account_updated_notification(&self) -> AccountUpdatedNotification {\n@@ -173,6 +176,10 @@ impl AccountRequestProcessor {\n         thread_manager: &Arc<ThreadManager>,\n         auth: Option<CodexAuth>,\n     ) {\n+        thread_manager\n+            .plugins_manager()\n+            .set_auth_mode(auth.as_ref().map(CodexAuth::api_auth_mode));\n+\n         match config_manager\n             .load_latest_config(/*fallback_cwd*/ None)\n             .await",
+      "path": "codex-rs/app-server/src/request_processors/account_processor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 39,
+      "deletions": 5,
+      "patch_excerpt": "@@ -48,6 +48,7 @@ use crate::store::PluginInstallResult as StorePluginInstallResult;\n use crate::store::PluginStore;\n use crate::store::PluginStoreError;\n use codex_analytics::AnalyticsEventsClient;\n+use codex_app_server_protocol::AuthMode;\n use codex_config::ConfigLayerStack;\n use codex_config::clear_user_plugin;\n use codex_config::set_user_plugin_enabled;\n@@ -203,6 +204,13 @@ fn featured_plugin_ids_cache_key(\n     }\n }\n \n+fn project_plugin_load_outcome_for_auth(\n+    outcome: PluginLoadOutcome,\n+    _auth_mode: Option<AuthMode>,\n+) -> PluginLoadOutcome {\n+    outcome\n+}\n+\n #[derive(Debug, Clone, PartialEq, Eq)]\n pub struct PluginInstallRequest {\n     pub plugin_name: String,\n@@ -319,6 +327,7 @@ pub struct PluginsManager {\n     remote_installed_plugins_cache_refresh_state: RwLock<RemoteInstalledPluginsCacheRefreshState>,\n     global_remote_catalog_cache_refresh_state: RwLock<GlobalRemot...",
+      "path": "codex-rs/core-plugins/src/manager.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 16,
+      "deletions": 0,
+      "patch_excerpt": "@@ -17,6 +17,7 @@ use crate::test_support::load_plugins_config as load_plugins_config_input;\n use crate::test_support::write_curated_plugin_sha_with as write_curated_plugin_sha;\n use crate::test_support::write_file;\n use crate::test_support::write_openai_curated_marketplace;\n+use codex_app_server_protocol::AuthMode;\n use codex_app_server_protocol::ConfigLayerSource;\n use codex_config::AppToolApproval;\n use codex_config::CONFIG_TOML_FILE;\n@@ -47,6 +48,21 @@ use wiremock::matchers::query_param;\n \n const MAX_CAPABILITY_SUMMARY_DESCRIPTION_LEN: usize = 1024;\n \n+#[test]\n+fn plugins_manager_tracks_auth_mode() {\n+    let tmp = TempDir::new().unwrap();\n+    let manager = PluginsManager::new(tmp.path().to_path_buf());\n+\n+    assert_eq!(manager.auth_mode(), None);\n+    assert!(manager.set_auth_mode(Some(AuthMode::ApiKey)));\n+    assert_eq!(manager.auth_mode(), Some(AuthMode::ApiKey));\n+    assert!...",
+      "path": "codex-rs/core-plugins/src/manager_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -272,6 +272,7 @@ impl ThreadManager {\n             codex_home.to_path_buf(),\n             restriction_product,\n         ));\n+        plugins_manager.set_auth_mode(auth_manager.get_api_auth_mode());\n         let mcp_manager = Arc::new(McpManager::new_with_extensions(\n             Arc::clone(&plugins_manager),\n             Arc::clone(&extensions),\n@@ -365,6 +366,7 @@ impl ThreadManager {\n             codex_home.clone(),\n             restriction_product,\n         ));\n+        plugins_manager.set_auth_mode(auth_manager.get_api_auth_mode());\n         let mcp_manager = Arc::new(McpManager::new(Arc::clone(&plugins_manager)));\n         let skills_manager = Arc::new(SkillsManager::new_with_restriction_product(\n             skills_codex_home,",
+      "path": "codex-rs/core/src/thread_manager.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Summary\n- Add auth mode state to `PluginsManager`.\n- Sync the plugin manager auth mode when `ThreadManager` is created and when account auth changes.\n- Route plugin load outcomes through an auth-aware projection hook so follow-up plugin filtering can stay inside `core-plugins`.\n\n## Motivation\nThis prepares plugin capability loading to be configured by auth mode, such as hiding or exposing app/MCP-backed plugin surfaces based on whether the user is using ChatGPT auth or API-key auth, without leaking those details outside the plugin manager.\n\n## Tests\n- `just fmt`\n- `just test -p codex-core-plugins`\n- `env -u CODEX_SANDBOX_NETWORK_DISABLED -u CODEX_SANDBOX just test -p codex-core thread_manager::tests`\n- `env -u CODEX_SANDBOX_NETWORK_DISABLED -u CODEX_SANDBOX just test -p codex-app-server`",
+    "labels": [],
+    "merged_at": "2026-06-11T03:57:35Z",
+    "number": 27517,
+    "state": "merged",
+    "title": "[codex] Pass auth mode to plugin manager",
+    "url": "https://github.com/openai/codex/pull/27517"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27526.json
+++ b/artifacts/github/bundles/openai-codex-pr-27526.json
@@ -1,0 +1,63 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "sayan-oai",
+      "committed_at": "2026-06-11T03:21:36Z",
+      "message": "tools: simplify default tool search text",
+      "sha": "8a34e24ba2eb9415433cfc680d35d35112f403b8",
+      "url": "https://github.com/openai/codex/commit/8a34e24ba2eb9415433cfc680d35d35112f403b8"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "IANA"
+  ],
+  "files": [
+    {
+      "additions": 0,
+      "deletions": 1,
+      "patch_excerpt": "@@ -100,7 +100,6 @@ pub use tool_output::ToolOutput;\n pub use tool_payload::ToolPayload;\n pub use tool_search::ToolSearchEntry;\n pub use tool_search::ToolSearchInfo;\n-pub use tool_search::default_tool_search_text;\n pub use tool_spec::ResponsesApiWebSearchFilters;\n pub use tool_spec::ResponsesApiWebSearchUserLocation;\n pub use tool_spec::ToolSpec;",
+      "path": "codex-rs/tools/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -58,7 +58,7 @@ pub trait ToolExecutor<Invocation>: Send + Sync {\n \n     fn search_info(&self) -> Option<ToolSearchInfo> {\n         let spec = self.spec();\n-        ToolSearchInfo::from_tool_spec(&self.tool_name(), spec, /*source_info*/ None)\n+        ToolSearchInfo::from_tool_spec(spec, /*source_info*/ None)\n     }\n \n     fn supports_parallel_tool_calls(&self) -> bool {",
+      "path": "codex-rs/tools/src/tool_executor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 6,
+      "deletions": 9,
+      "patch_excerpt": "@@ -2,7 +2,6 @@ use crate::JsonSchema;\n use crate::LoadableToolSpec;\n use crate::ResponsesApiNamespaceTool;\n use crate::ResponsesApiTool;\n-use crate::ToolName;\n use crate::ToolSearchSourceInfo;\n use crate::ToolSpec;\n use crate::default_namespace_description;\n@@ -21,11 +20,10 @@ pub struct ToolSearchInfo {\n \n impl ToolSearchInfo {\n     pub fn from_tool_spec(\n-        tool_name: &ToolName,\n         spec: ToolSpec,\n         source_info: Option<ToolSearchSourceInfo>,\n     ) -> Option<Self> {\n-        let search_text = default_tool_search_text(tool_name, &spec);\n+        let search_text = default_tool_search_text(&spec);\n         Self::from_spec(search_text, spec, source_info)\n     }\n \n@@ -67,13 +65,8 @@ impl ToolSearchInfo {\n     }\n }\n \n-pub fn default_tool_search_text(tool_name: &ToolName, spec: &ToolSpec) -> String {\n+fn default_tool_search_text(spec: &ToolSpec) -> String {\n     let mut pa...",
+      "path": "codex-rs/tools/src/tool_search.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 48,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,48 @@\n+use super::*;\n+use pretty_assertions::assert_eq;\n+use std::collections::BTreeMap;\n+\n+#[test]\n+fn default_search_text_uses_model_visible_namespace_metadata_once() {\n+    let mut schedule_schema = JsonSchema::object(\n+        BTreeMap::from([(\n+            \"timezone\".to_string(),\n+            JsonSchema::string(Some(\"IANA timezone.\".to_string())),\n+        )]),\n+        /*required*/ None,\n+        /*additional_properties*/ None,\n+    );\n+    schedule_schema.description = Some(\"Schedule settings.\".to_string());\n+    let mut parameters = JsonSchema::object(\n+        BTreeMap::from([\n+            (\n+                \"mode\".to_string(),\n+                JsonSchema::string(Some(\"Update mode.\".to_string())),\n+            ),\n+            (\"schedule\".to_string(), schedule_schema),\n+        ]),\n+        /*required*/ None,\n+        /*additional_properties*/ None,\n+    );\n+    parame...",
+      "path": "codex-rs/tools/src/tool_search_tests.rs",
+      "status": "added"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nDefault tool search text currently derives identity from both `ToolName` and `ToolSpec`. For function and namespace specs, this indexes the same names more than once and also adds a flattened `{namespace}{name}` token that is not model-visible.\n\n## What changed\n\n- Derive default search text entirely from `ToolSpec` while preserving names, descriptions, namespace metadata, and recursive schema metadata.\n- Keep the default search-text builder private and remove the unused `ToolName` argument.\n- Add coverage for the exact search text generated for a namespaced tool with nested schema metadata.\n\n## Example\n\nFor the `codex_app` namespace and `automation_update` tool (schema terms omitted):\n\n- Before: `codex_appautomation_update automation update codex_app codex_app Manage Codex automations. automation_update automation update ...`\n- After: `codex_app Manage Codex automations. automation_update automation update ...`\n\n## Testing\n\n- `just test -p codex-tools`\n",
+    "labels": [],
+    "merged_at": "2026-06-11T03:37:26Z",
+    "number": 27526,
+    "state": "merged",
+    "title": "tools: simplify default tool search text",
+    "url": "https://github.com/openai/codex/pull/27526"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/impact/openai-codex-pr-27443.json
+++ b/artifacts/github/impact/openai-codex-pr-27443.json
@@ -1,0 +1,49 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27443",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "feat: add Bedrock API key as a managed auth mode",
+        "url": "https://github.com/openai/codex/pull/27443",
+        "meta": "Merged 2026-06-11T03:42:39Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27443",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27443.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex added `bedrockApiKey` as a managed app-server and login auth mode, persisting Bedrock API key plus region in `auth.json` while rejecting that mode for OpenAI-compatible providers.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "`AuthMode::BedrockApiKey` is added to Rust, JSON schema, and TypeScript app-server protocol surfaces.",
+    "`AuthDotJson` gains a `bedrock_api_key` payload containing API key and region.",
+    "`login_with_bedrock_api_key` writes a Bedrock-only auth record through the existing auth storage path.",
+    "OpenAI-compatible provider resolution returns a Bedrock-specific unsupported-operation error.",
+    "CLI login status reports Amazon Bedrock API key auth as a distinct login mode."
+  ],
+  "candidate_followups": [
+    "Update Decodex account and auth-mode displays to recognize `bedrockApiKey`.",
+    "Check app-server schema consumers for exhaustive `AuthMode` matching.",
+    "Keep Decodex provider routing fail-closed until upstream Bedrock request routing lands.",
+    "Track follow-up PRs that route the managed API key and region into Amazon Bedrock requests."
+  ],
+  "social_notes": [
+    "State that this PR adds managed auth storage and app-server mode reporting.",
+    "Keep the caveat that actual Bedrock request routing is a follow-up.",
+    "Use an operator-impact angle because schema clients must handle a new AuthMode value."
+  ],
+  "caveats": [
+    "This is not proof that Bedrock requests are fully wired yet.",
+    "The new mode is not a ChatGPT account and is rejected by OpenAI-compatible providers.",
+    "Downstream clients must not treat `bedrockApiKey` as an ordinary OpenAI API key."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-27488.json
+++ b/artifacts/github/impact/openai-codex-pr-27488.json
@@ -1,0 +1,47 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27488",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Add new context window tool",
+        "url": "https://github.com/openai/codex/pull/27488",
+        "meta": "Merged 2026-06-11T03:39:08Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27488",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27488.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex added a direct-model-only `new_context` tool behind the under-development `token_budget` feature so a model can request a fresh context window without a compaction summary.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "`Feature::TokenBudget` gates token-budget context and the new `new_context` tool.",
+    "`NewContextWindowHandler` records a request and returns the message that a new context window will start without summarizing conversation history.",
+    "`maybe_start_new_context_window` replaces session history with fresh initial context and persists an empty-message compaction checkpoint with a new window id.",
+    "The integration test confirms the follow-up request no longer contains the prior request text after the tool call."
+  ],
+  "candidate_followups": [
+    "Audit Decodex rollout reconstruction for empty-message `CompactedItem` checkpoints.",
+    "Decide whether retained automation should allow direct-model-only `new_context` when feature-gated Codex builds expose it.",
+    "Add operator-facing diagnostics for no-summary context resets if Decodex starts consuming them."
+  ],
+  "social_notes": [
+    "Frame as under-development and feature-gated.",
+    "Emphasize the distinction from normal summary compaction.",
+    "Useful angle: long-running Codex sessions can ask for a fresh window instead of spending tokens on a summary."
+  ],
+  "caveats": [
+    "The feature is disabled by default in the feature registry.",
+    "The tool is direct-model-only, not an ordinary user command.",
+    "Do not imply Decodex currently supports or exposes the behavior before a Decodex audit."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-27517.json
+++ b/artifacts/github/impact/openai-codex-pr-27517.json
@@ -1,0 +1,46 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27517",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Pass auth mode to plugin manager",
+        "url": "https://github.com/openai/codex/pull/27517",
+        "meta": "Merged 2026-06-11T03:57:35Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27517",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27517.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex now stores the current auth mode on `PluginsManager` and projects plugin load outcomes through an auth-aware hook, preparing plugin capability filtering by login mode.",
+  "public_signal_decision": "defer",
+  "control_plane_impact": "watch",
+  "publisher_angle": "watch_note",
+  "confidence": "confirmed",
+  "evidence": [
+    "`PluginsManager` now stores `Option<AuthMode>` behind an `RwLock` with setter and getter methods.",
+    "ThreadManager initialization and app-server account auth changes synchronize the plugin manager auth mode.",
+    "Cached and freshly loaded plugin outcomes pass through `project_plugins_for_auth`.",
+    "`project_plugin_load_outcome_for_auth` currently returns the unchanged outcome, so visible filtering has not landed yet."
+  ],
+  "candidate_followups": [
+    "Track follow-up PRs that make plugin load outcomes differ by auth mode.",
+    "Prepare Decodex plugin discovery readbacks to include current auth mode when plugin availability differs.",
+    "Avoid publishing this as a standalone user-visible behavior change until the projection hook stops being a no-op."
+  ],
+  "social_notes": [
+    "Use only as background evidence for a later plugin-auth capability story.",
+    "A standalone post would overclaim current user-visible behavior."
+  ],
+  "caveats": [
+    "The current auth-aware projection returns the original plugin load outcome.",
+    "No plugin is hidden or exposed by auth mode in this PR alone.",
+    "Compatibility risk may rise when follow-up filtering lands."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-27526.json
+++ b/artifacts/github/impact/openai-codex-pr-27526.json
@@ -1,0 +1,46 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27526",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "tools: simplify default tool search text",
+        "url": "https://github.com/openai/codex/pull/27526",
+        "meta": "Merged 2026-06-11T03:37:26Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27526",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27526.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex now builds default tool-search text from `ToolSpec` alone, removing duplicated `ToolName` text and the non-model-visible flattened namespace/name token.",
+  "public_signal_decision": "defer",
+  "control_plane_impact": "candidate",
+  "publisher_angle": "watch_note",
+  "confidence": "confirmed",
+  "evidence": [
+    "`default_tool_search_text` is made private and no longer consumes `ToolName`.",
+    "`ToolExecutor::search_info` and `ToolSearchInfo::from_tool_spec` now use only the tool specification.",
+    "The added namespace-tool test verifies search text built from model-visible namespace, function, description, parameter, and nested schema metadata.",
+    "The PR body documents the removed duplicate `codex_appautomation_update`-style flattened token."
+  ],
+  "candidate_followups": [
+    "Check Decodex-authored tool metadata for reliance on synthetic flattened namespace/name tokens.",
+    "Use model-visible names and descriptions when tuning deferred tool-search results.",
+    "Watch for downstream source consumers that imported the now-private helper."
+  ],
+  "social_notes": [
+    "Potential watch-note material if later tool-search changes accumulate into a user-visible discovery improvement.",
+    "Do not publish this as a standalone feature announcement without stronger user-visible evidence."
+  ],
+  "caveats": [
+    "The change is primarily internal search-quality cleanup.",
+    "No new app-server, MCP, or plugin protocol method is introduced by this PR.",
+    "Any source-level break is limited to code calling the removed helper or old method signature."
+  ]
+}

--- a/artifacts/github/review-queue/openai-codex-latest.json
+++ b/artifacts/github/review-queue/openai-codex-latest.json
@@ -1,14 +1,14 @@
 {
   "counts": {
-    "critical": 18,
-    "high": 10,
+    "critical": 17,
+    "high": 7,
     "low": 0,
-    "normal": 12,
+    "normal": 16,
     "published_subjects_seen": 0,
     "recent_commits_scanned": 40,
     "subjects_queued": 40
   },
-  "generated_at": "2026-06-11T14:05:19.394314Z",
+  "generated_at": "2026-06-11T20:04:32.657127Z",
   "repo": "openai/codex",
   "schema": "upstream_review_queue/v1",
   "source": {
@@ -17,341 +17,6 @@
     "signals_dir": "site/src/content/signals"
   },
   "subjects": [
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "rate_limit",
-        "security_policy"
-      ],
-      "changed_file_count": 22,
-      "commit_shas": [
-        "ee228545d822de157518dec714dca4f13cbd3374",
-        "15bbbdf663d80d399cdadefd6987bf17999faab6"
-      ],
-      "committed_at": "2026-06-10T19:53:15Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27071,
-      "pr_url": "https://github.com/openai/codex/pull/27071",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, rate_limit, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server-client/src/lib.rs",
-        "codex-rs/app-server/src/in_process.rs",
-        "codex-rs/cli/src/main.rs",
-        "codex-rs/tui/src/app/app_server_events.rs",
-        "codex-rs/tui/src/app/event_dispatch.rs",
-        "codex-rs/tui/src/app_event.rs",
-        "codex-rs/tui/src/app_server_session.rs",
-        "codex-rs/tui/src/chatwidget/slash_dispatch.rs",
-        "codex-rs/tui/src/chatwidget/tests/slash_commands.rs",
-        "codex-rs/tui/src/external_agent_config_migration.rs",
-        "codex-rs/tui/src/external_agent_config_migration/render.rs",
-        "codex-rs/tui/src/external_agent_config_migration_flow.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27071",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "tests_ci"
-      ],
-      "title": "[codex] add /import for external agents",
-      "url": "https://github.com/openai/codex/pull/27071"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 7,
-      "commit_shas": [
-        "a323ed156e4bf7c1ae57cb0bb2d7f7d0d8a83b75"
-      ],
-      "committed_at": "2026-06-10T20:11:09Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27311,
-      "pr_url": "https://github.com/openai/codex/pull/27311",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/app-server/src/config/external_agent_config.rs",
-        "codex-rs/app-server/src/request_processors/plugins.rs",
-        "codex-rs/cli/src/plugin_cmd.rs",
-        "codex-rs/core-plugins/src/discoverable.rs",
-        "codex-rs/core-plugins/src/manager.rs",
-        "codex-rs/core-plugins/src/manager_tests.rs",
-        "codex-rs/core/src/tools/handlers/request_plugin_install.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27311",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "mcp_plugins",
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "[codex] Skip local curated discovery for remote plugins",
-      "url": "https://github.com/openai/codex/pull/27311"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature"
-      ],
-      "changed_file_count": 2,
-      "commit_shas": [
-        "679f3b6b5677d685581358f37e7a3a7ddce2466d",
-        "d1db1d33d190781ea06aa44692e9c31c4c45c683"
-      ],
-      "committed_at": "2026-06-10T20:11:20Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27414,
-      "pr_url": "https://github.com/openai/codex/pull/27414",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature.",
-      "sample_paths": [
-        "codex-rs/core/src/mcp.rs",
-        "codex-rs/ext/mcp/tests/hosted_apps_mcp.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27414",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "[codex] Preserve disabled MCP servers across runtime overlays",
-      "url": "https://github.com/openai/codex/pull/27414"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 12,
-      "commit_shas": [
-        "8e0cb424640c7776a0c6a03f27ff2e5d637d6389"
-      ],
-      "committed_at": "2026-06-11T00:33:56Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27465,
-      "pr_url": "https://github.com/openai/codex/pull/27465",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/v2/PluginInstallResponse.json",
-        "codex-rs/app-server-protocol/schema/json/v2/PluginReadResponse.json",
-        "codex-rs/app-server-protocol/schema/typescript/v2/AppSummary.ts",
-        "codex-rs/app-server-protocol/src/protocol/v2/apps.rs",
-        "codex-rs/app-server/README.md",
-        "codex-rs/app-server/src/request_processors/plugins.rs",
-        "codex-rs/app-server/tests/suite/v2/plugin_install.rs",
-        "codex-rs/app-server/tests/suite/v2/plugin_read.rs",
-        "codex-rs/tui/src/chatwidget/tests/helpers.rs",
-        "codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27465",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "docs_examples",
-        "mcp_plugins",
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "[codex] Remove redundant plugin app auth state",
-      "url": "https://github.com/openai/codex/pull/27465"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "rate_limit",
-        "security_policy"
-      ],
-      "changed_file_count": 13,
-      "commit_shas": [
-        "96708f40a2274cdaf0e06b54b12fabbd29d70cdf",
-        "ca92a59065f9e9a4e4eae113b4dc0a322c8dee85"
-      ],
-      "committed_at": "2026-06-11T00:55:49Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27484,
-      "pr_url": "https://github.com/openai/codex/pull/27484",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, rate_limit, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server-client/src/lib.rs",
-        "codex-rs/tui/src/app/test_support.rs",
-        "codex-rs/tui/src/app/tests.rs",
-        "codex-rs/tui/src/app/tests/model_catalog.rs",
-        "codex-rs/tui/src/chatwidget.rs",
-        "codex-rs/tui/src/chatwidget/tests.rs",
-        "codex-rs/tui/src/chatwidget/tests/helpers.rs",
-        "codex-rs/tui/src/chatwidget/tests/plan_mode.rs",
-        "codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs",
-        "codex-rs/tui/src/chatwidget/tests/status_and_layout.rs",
-        "codex-rs/tui/src/debug_config.rs",
-        "codex-rs/tui/src/status/tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27484",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "model_provider",
-        "tests_ci"
-      ],
-      "title": "Remove TUI legacy core test_support dependencies",
-      "url": "https://github.com/openai/codex/pull/27484"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 11,
-      "commit_shas": [
-        "02968853641aed4bd153b0bc0fbe102adf8e8ed4",
-        "093f205cd1263db388ec05f101f4f17c98257cdd",
-        "0817892a2a847baeb01ec977ca1988564632e09a"
-      ],
-      "committed_at": "2026-06-11T01:04:02Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27476,
-      "pr_url": "https://github.com/openai/codex/pull/27476",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/cli/src/main.rs",
-        "codex-rs/cli/tests/delete.rs",
-        "codex-rs/tui/src/app/event_dispatch.rs",
-        "codex-rs/tui/src/app_event.rs",
-        "codex-rs/tui/src/app_server_session.rs",
-        "codex-rs/tui/src/chatwidget/slash_dispatch.rs",
-        "codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__slash_delete_confirmation_popup.snap",
-        "codex-rs/tui/src/chatwidget/tests/slash_commands.rs",
-        "codex-rs/tui/src/lib.rs",
-        "codex-rs/tui/src/session_archive_commands.rs",
-        "codex-rs/tui/src/slash_command.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27476",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "tests_ci"
-      ],
-      "title": "Add session delete commands in CLI and TUI",
-      "url": "https://github.com/openai/codex/pull/27476"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 15,
-      "commit_shas": [
-        "cda812d01363baa1c349ad59ca75006f0a413f2f"
-      ],
-      "committed_at": "2026-06-11T02:21:24Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27247,
-      "pr_url": "https://github.com/openai/codex/pull/27247",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/core/config.schema.json",
-        "codex-rs/core/src/image_preparation.rs",
-        "codex-rs/core/src/image_preparation_tests.rs",
-        "codex-rs/core/src/lib.rs",
-        "codex-rs/core/src/prompt_debug.rs",
-        "codex-rs/core/src/session/mod.rs",
-        "codex-rs/core/src/session/tests.rs",
-        "codex-rs/core/src/tools/handlers/view_image.rs",
-        "codex-rs/core/tests/suite/code_mode.rs",
-        "codex-rs/core/tests/suite/rmcp_client.rs",
-        "codex-rs/core/tests/suite/view_image.rs",
-        "codex-rs/features/src/lib.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27247",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "mcp_plugins",
-        "model_provider",
-        "tests_ci"
-      ],
-      "title": "core: resize all history images behind a feature flag",
-      "url": "https://github.com/openai/codex/pull/27247"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "deprecated_removed",
-        "release_packaging"
-      ],
-      "changed_file_count": 2,
-      "commit_shas": [
-        "346a2833dae23c17095b75daf08fddf8515e2339",
-        "d663d950dba7c0a87d64c450702a0d508270251d",
-        "bdf60ba26131e29c86f98a64e8b6cddd6864a121",
-        "0d45b47959c8630d9c0e53d6635a94b80dbf0f99"
-      ],
-      "committed_at": "2026-06-11T02:50:57Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27487,
-      "pr_url": "https://github.com/openai/codex/pull/27487",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for breaking_change, deprecated_removed, release_packaging.",
-      "sample_paths": [
-        "codex-rs/app-server-client/src/lib.rs",
-        "codex-rs/tui/src/lib.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27487",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui"
-      ],
-      "title": "Trim TUI legacy telemetry and migration dependencies",
-      "url": "https://github.com/openai/codex/pull/27487"
-    },
     {
       "attention_flags": [
         "auth_account",
@@ -761,114 +426,318 @@
     {
       "attention_flags": [
         "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "rate_limit",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 13,
+      "commit_shas": [
+        "69b921aa666b1059422309b6ab7f4cd1a03b65c9",
+        "44494bb402287988f3faf7590d0ea284ae234657"
+      ],
+      "committed_at": "2026-06-11T16:23:08Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27490,
+      "pr_url": "https://github.com/openai/codex/pull/27490",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, rate_limit, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server-client/src/lib.rs",
+        "codex-rs/tui/src/app.rs",
+        "codex-rs/tui/src/app/config_persistence.rs",
+        "codex-rs/tui/src/app/event_dispatch.rs",
+        "codex-rs/tui/src/chatwidget.rs",
+        "codex-rs/tui/src/chatwidget/constructor.rs",
+        "codex-rs/tui/src/chatwidget/permission_popups.rs",
+        "codex-rs/tui/src/chatwidget/settings.rs",
+        "codex-rs/tui/src/chatwidget/slash_dispatch.rs",
+        "codex-rs/tui/src/chatwidget/windows_sandbox_prompts.rs",
+        "codex-rs/tui/src/lib.rs",
+        "codex-rs/tui/src/onboarding/onboarding_screen.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27490",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "config_hooks",
+        "sandbox_permissions"
+      ],
+      "title": "Remove TUI legacy Windows sandbox dependency",
+      "url": "https://github.com/openai/codex/pull/27490"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 16,
+      "commit_shas": [
+        "2f6191ea633cd0a58580c484cc37d88191787385"
+      ],
+      "committed_at": "2026-06-11T17:34:41Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27420,
+      "pr_url": "https://github.com/openai/codex/pull/27420",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/v2/PluginInstallResponse.json",
+        "codex-rs/app-server-protocol/schema/json/v2/PluginReadResponse.json",
+        "codex-rs/app-server-protocol/schema/typescript/v2/AppSummary.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/AppTemplateSummary.ts",
+        "codex-rs/app-server-protocol/src/protocol/v2/apps.rs",
+        "codex-rs/app-server-protocol/src/protocol/v2/plugin.rs",
+        "codex-rs/app-server/src/request_processors/plugins.rs",
+        "codex-rs/app-server/tests/suite/v2/plugin_install.rs",
+        "codex-rs/app-server/tests/suite/v2/plugin_read.rs",
+        "codex-rs/core-plugins/src/loader.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27420",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "mcp_plugins",
+        "release_packaging",
+        "tests_ci"
+      ],
+      "title": "[codex] Propagate plugin app categories",
+      "url": "https://github.com/openai/codex/pull/27420"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 2,
+      "commit_shas": [
+        "fef2bbfa4c23e6144afa8c2081ca4a44cca082dc"
+      ],
+      "committed_at": "2026-06-11T18:20:26Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27646,
+      "pr_url": "https://github.com/openai/codex/pull/27646",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/app-server/src/extensions.rs",
+        "codex-rs/app-server/tests/suite/v2/mcp_resource.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27646",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "feat: disable orchestrator skills for now",
+      "url": "https://github.com/openai/codex/pull/27646"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 5,
+      "commit_shas": [
+        "a8e9807f4a94cf84b288c0c9ce2678788c9d3228"
+      ],
+      "committed_at": "2026-06-11T18:26:12Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27433,
+      "pr_url": "https://github.com/openai/codex/pull/27433",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/exec-server/src/environment_path.rs",
+        "codex-rs/exec-server/src/lib.rs",
+        "codex-rs/ext/skills/src/catalog.rs",
+        "codex-rs/ext/skills/src/provider/executor.rs",
+        "codex-rs/ext/skills/tests/executor_file_system_authority.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27433",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "auth_accounts",
+        "model_provider",
+        "tests_ci"
+      ],
+      "title": "[codex] remove EnvironmentPathRef",
+      "url": "https://github.com/openai/codex/pull/27433"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 52,
+      "commit_shas": [
+        "32d2f04abebfd51a0062e3b68710bd60b5a51c98"
+      ],
+      "committed_at": "2026-06-11T18:44:18Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27424,
+      "pr_url": "https://github.com/openai/codex/pull/27424",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/Cargo.lock",
+        "codex-rs/Cargo.toml",
+        "codex-rs/app-server/Cargo.toml",
+        "codex-rs/app-server/src/request_processors/fs_processor.rs",
+        "codex-rs/apply-patch/Cargo.toml",
+        "codex-rs/apply-patch/src/invocation.rs",
+        "codex-rs/apply-patch/src/lib.rs",
+        "codex-rs/config/Cargo.toml",
+        "codex-rs/config/src/loader/layer_io.rs",
+        "codex-rs/config/src/loader/mod.rs",
+        "codex-rs/config/src/loader/tests.rs",
+        "codex-rs/core-skills/Cargo.toml"
+      ],
+      "source_state": "merged",
+      "subject_id": "27424",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "auth_accounts",
+        "cli_tui",
+        "config_hooks",
+        "mcp_plugins",
+        "model_provider",
+        "sandbox_permissions",
+        "tests_ci"
+      ],
+      "title": "[codex] migrate ExecutorFileSystem paths to PathUri",
+      "url": "https://github.com/openai/codex/pull/27424"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
         "new_feature",
         "protocol_change",
         "release_packaging",
         "security_policy"
       ],
-      "changed_file_count": 4,
+      "changed_file_count": 49,
       "commit_shas": [
-        "f5d7eacdae35f4e764a4e0b4e902dec29434387a",
-        "942e9da661b86172ab6a56b6e0798a7362311ced"
+        "86c3be87bb3b56f7b00b1ad678f7749d5ccf5e0d",
+        "6058bbf755e4b659ad0a45021911e8d6342b1519",
+        "db55f399a2d96fb0afee96daa5cc4a2d86efad8a",
+        "c75787f5e79a31b4f7702e68b34070e1a13c4124",
+        "ae7666463b7c59a22afaa97c38064eea342b4b1f",
+        "9d056247c33e1b4380c768e9b8c7b0cc45355285",
+        "5ab337bd440e284e5caf2cc50760026c98362c06",
+        "991be42cc3bb7ba7a60880c7a6af4d6d55bd3b57",
+        "56e017522bc978db21118184d6217425883f37e9",
+        "802d4ca0df4f6d9124299fae252d6186fef49413",
+        "1ce912ed71c8284c97b01ea7dfcc566ea32b4a36",
+        "02f04f2ad6655e71067b68df88129ee5b20fdf80",
+        "493e0057247fd619b0fabaed742801715fbe9c09",
+        "8aca78feb7f73cb5d55f762ead36060b4020c71b",
+        "922a7f27cccdb0dbfc322179dd51da27a2085e72"
       ],
-      "committed_at": "2026-06-10T21:32:29Z",
+      "committed_at": "2026-06-11T19:28:47Z",
       "next_step": "ai_review_required",
-      "pr_number": 27319,
-      "pr_url": "https://github.com/openai/codex/pull/27319",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, release_packaging, security_policy.",
+      "pr_number": 27101,
+      "pr_url": "https://github.com/openai/codex/pull/27101",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
       "sample_paths": [
-        "codex-rs/app-server/tests/suite/v2/realtime_conversation.rs",
-        "codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs",
-        "codex-rs/core/src/realtime_conversation.rs",
-        "codex-rs/core/src/session/mod.rs"
+        "codex-rs/Cargo.lock",
+        "codex-rs/Cargo.toml",
+        "codex-rs/app-server/Cargo.toml",
+        "codex-rs/app-server/src/mcp_refresh.rs",
+        "codex-rs/app-server/src/message_processor.rs",
+        "codex-rs/app-server/tests/suite/v2/thread_start.rs",
+        "codex-rs/cli/Cargo.toml",
+        "codex-rs/cli/src/main.rs",
+        "codex-rs/codex-home/BUILD.bazel",
+        "codex-rs/codex-home/Cargo.toml",
+        "codex-rs/codex-home/src/instructions/mod.rs",
+        "codex-rs/codex-home/src/instructions/tests.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27319",
+      "subject_id": "27101",
       "subject_kind": "pr",
       "surface_hints": [
         "app_server_protocol",
+        "cli_tui",
+        "config_hooks",
+        "mcp_plugins",
         "tests_ci"
       ],
-      "title": "Forward standalone assistant output to realtime",
-      "url": "https://github.com/openai/codex/pull/27319"
-    },
-    {
-      "attention_flags": [
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 4,
-      "commit_shas": [
-        "424af29908b304199dd33c9fa1ca506a70afebe5"
-      ],
-      "committed_at": "2026-06-10T22:27:34Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27245,
-      "pr_url": "https://github.com/openai/codex/pull/27245",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/protocol/src/models.rs",
-        "codex-rs/utils/image/src/error.rs",
-        "codex-rs/utils/image/src/image_tests.rs",
-        "codex-rs/utils/image/src/lib.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27245",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "model_provider",
-        "tests_ci"
-      ],
-      "title": "image: add shared data URL preparation utilities",
-      "url": "https://github.com/openai/codex/pull/27245"
+      "title": "[codex] Load user instructions through an injected provider",
+      "url": "https://github.com/openai/codex/pull/27101"
     },
     {
       "attention_flags": [
         "auth_account",
+        "breaking_change",
+        "deprecated_removed",
         "new_feature",
         "protocol_change",
         "security_policy"
       ],
       "changed_file_count": 14,
       "commit_shas": [
-        "a19ec71e8d73d4dbd1dfb5b34894744ee8e6ef1a",
-        "67a29aab4885be483dc7ea05ec9bce8fddbfdc00",
-        "9e25474a95a9ceb092c04ac628cbb6985f7f30eb",
-        "1a2c1cd787a7eedd307a761fc2823d6ac65c7e05"
+        "a59cb23505a814d56fa756fa1dd62d9141446fe4",
+        "14a0e947fd75a0948baa5e0d10287fdfb1c79265",
+        "a0a3850c9ef28a3417e02d9850d4204a183ec54f"
       ],
-      "committed_at": "2026-06-11T03:07:06Z",
+      "committed_at": "2026-06-11T19:54:52Z",
       "next_step": "ai_review_required",
-      "pr_number": 27438,
-      "pr_url": "https://github.com/openai/codex/pull/27438",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
+      "pr_number": 27634,
+      "pr_url": "https://github.com/openai/codex/pull/27634",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/core/config.schema.json",
-        "codex-rs/core/src/compact.rs",
-        "codex-rs/core/src/compact_remote.rs",
-        "codex-rs/core/src/compact_remote_v2.rs",
-        "codex-rs/core/src/context/mod.rs",
-        "codex-rs/core/src/context/token_budget_context.rs",
-        "codex-rs/core/src/event_mapping.rs",
-        "codex-rs/core/src/event_mapping_tests.rs",
-        "codex-rs/core/src/session/mod.rs",
-        "codex-rs/core/src/session/token_budget.rs",
-        "codex-rs/core/src/session/turn.rs",
-        "codex-rs/core/tests/suite/mod.rs"
+        "codex-rs/codex-mcp/src/catalog.rs",
+        "codex-rs/codex-mcp/src/catalog_tests.rs",
+        "codex-rs/codex-mcp/src/lib.rs",
+        "codex-rs/codex-mcp/src/mcp/mod.rs",
+        "codex-rs/codex-mcp/src/mcp/mod_tests.rs",
+        "codex-rs/core/src/config/config_tests.rs",
+        "codex-rs/core/src/config/mod.rs",
+        "codex-rs/core/src/connectors.rs",
+        "codex-rs/core/src/mcp.rs",
+        "codex-rs/core/src/session/mcp.rs",
+        "codex-rs/core/src/session/session.rs",
+        "codex-rs/ext/extension-api/src/contributors.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27438",
+      "subject_id": "27634",
       "subject_kind": "pr",
       "surface_hints": [
-        "auth_accounts",
         "config_hooks",
+        "mcp_plugins",
         "tests_ci"
       ],
-      "title": "[codex] Add token budget context feature",
-      "url": "https://github.com/openai/codex/pull/27438"
+      "title": "Resolve MCP server registrations through a catalog",
+      "url": "https://github.com/openai/codex/pull/27634"
     },
     {
       "attention_flags": [
@@ -1144,185 +1013,6 @@
     },
     {
       "attention_flags": [
-        "new_feature",
-        "release_packaging"
-      ],
-      "changed_file_count": 4,
-      "commit_shas": [
-        "c90706ebae4ca30e87ccc1f6d53a6fb7cbef55b2"
-      ],
-      "committed_at": "2026-06-10T19:45:29Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27321,
-      "pr_url": "https://github.com/openai/codex/pull/27321",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature, release_packaging.",
-      "sample_paths": [
-        "bazel/platforms/BUILD.bazel",
-        "bazel/platforms/release_binaries.bzl",
-        "codex-rs/cli/BUILD.bazel",
-        "defs.bzl"
-      ],
-      "source_state": "merged",
-      "subject_id": "27321",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "release_packaging"
-      ],
-      "title": "[codex] Move release platform rules into bazel package",
-      "url": "https://github.com/openai/codex/pull/27321"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "protocol_change",
-        "release_packaging"
-      ],
-      "changed_file_count": 2,
-      "commit_shas": [
-        "d3376022f8a0c0b89267e20793ce0046a3ea6355"
-      ],
-      "committed_at": "2026-06-10T20:15:43Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27312,
-      "pr_url": "https://github.com/openai/codex/pull/27312",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, protocol_change, release_packaging.",
-      "sample_paths": [
-        ".github/workflows/rust-release.yml",
-        "scripts/stage_npm_packages.py"
-      ],
-      "source_state": "merged",
-      "subject_id": "27312",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "[codex] reuse release artifacts for npm staging",
-      "url": "https://github.com/openai/codex/pull/27312"
-    },
-    {
-      "attention_flags": [
-        "new_feature"
-      ],
-      "changed_file_count": 3,
-      "commit_shas": [
-        "bf85303072730e20274518f6aab387d2044d3173"
-      ],
-      "committed_at": "2026-06-10T21:36:38Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27057,
-      "pr_url": "https://github.com/openai/codex/pull/27057",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature.",
-      "sample_paths": [
-        "codex-rs/otel/src/metrics/client.rs",
-        "codex-rs/otel/tests/suite/otlp_http_loopback.rs",
-        "codex-rs/otel/tests/suite/send.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27057",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "tests_ci"
-      ],
-      "title": "[codex] Add reusable OTEL gauge instruments",
-      "url": "https://github.com/openai/codex/pull/27057"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "protocol_change"
-      ],
-      "changed_file_count": 2,
-      "commit_shas": [
-        "ac6ad0791d9a0f799a5ac2291905e1143796e7a9"
-      ],
-      "committed_at": "2026-06-10T22:35:41Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27392,
-      "pr_url": "https://github.com/openai/codex/pull/27392",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, protocol_change.",
-      "sample_paths": [
-        "codex-rs/analytics/src/analytics_client_tests.rs",
-        "codex-rs/analytics/src/reducer.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27392",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "tests_ci"
-      ],
-      "title": "[codex-analytics] emit internally started turn events",
-      "url": "https://github.com/openai/codex/pull/27392"
-    },
-    {
-      "attention_flags": [
-        "new_feature",
-        "protocol_change",
-        "release_packaging"
-      ],
-      "changed_file_count": 3,
-      "commit_shas": [
-        "32f4194ba0c9e89962a825376f3eb78c662553bf"
-      ],
-      "committed_at": "2026-06-11T00:08:35Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27322,
-      "pr_url": "https://github.com/openai/codex/pull/27322",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature, protocol_change, release_packaging.",
-      "sample_paths": [
-        "MODULE.bazel",
-        "patches/BUILD.bazel",
-        "patches/rules_rs_build_script_deps_annotation.patch"
-      ],
-      "source_state": "merged",
-      "subject_id": "27322",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "internal_churn"
-      ],
-      "title": "[codex] Preserve build-script dependencies in rules_rs annotations",
-      "url": "https://github.com/openai/codex/pull/27322"
-    },
-    {
-      "attention_flags": [
-        "protocol_change"
-      ],
-      "changed_file_count": 3,
-      "commit_shas": [
-        "b53fd26ab95c4b2cee0740fa7dde899125a55b5f",
-        "56421478f4ad0965e294e9a0a4147f419c0241da",
-        "ce89871d06af8127572a9c237d6678c79f05a2e6"
-      ],
-      "committed_at": "2026-06-11T00:17:44Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27489,
-      "pr_url": "https://github.com/openai/codex/pull/27489",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for protocol_change.",
-      "sample_paths": [
-        "codex-rs/core/src/tools/events.rs",
-        "codex-rs/core/src/turn_diff_tracker.rs",
-        "codex-rs/core/src/turn_diff_tracker_tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27489",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "tests_ci"
-      ],
-      "title": "core: cache turn diff rendering",
-      "url": "https://github.com/openai/codex/pull/27489"
-    },
-    {
-      "attention_flags": [
         "deprecated_removed",
         "new_feature",
         "protocol_change"
@@ -1501,6 +1191,317 @@
       ],
       "title": "skills: cache remote catalog failures per thread",
       "url": "https://github.com/openai/codex/pull/27403"
+    },
+    {
+      "attention_flags": [
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "4f766def20881fa0e6644384dd7336568f704c6d"
+      ],
+      "committed_at": "2026-06-11T14:19:27Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27527,
+      "pr_url": "https://github.com/openai/codex/pull/27527",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for protocol_change, release_packaging.",
+      "sample_paths": [
+        ".github/workflows/rust-release.yml"
+      ],
+      "source_state": "merged",
+      "subject_id": "27527",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "release_packaging",
+        "tests_ci"
+      ],
+      "title": "[codex] publish npm packages concurrently",
+      "url": "https://github.com/openai/codex/pull/27527"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "c07c75ef754355a134c712b18dc470c0e21ce636"
+      ],
+      "committed_at": "2026-06-11T14:23:46Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27528,
+      "pr_url": "https://github.com/openai/codex/pull/27528",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, release_packaging, security_policy.",
+      "sample_paths": [
+        ".github/workflows/rust-release.yml"
+      ],
+      "source_state": "merged",
+      "subject_id": "27528",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "release_packaging",
+        "tests_ci"
+      ],
+      "title": "[codex] publish DotSlash alongside npm",
+      "url": "https://github.com/openai/codex/pull/27528"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "release_packaging"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "d6c71bb414f08f61de227ce8bcfdad70184ae9a2"
+      ],
+      "committed_at": "2026-06-11T14:34:41Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27529,
+      "pr_url": "https://github.com/openai/codex/pull/27529",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, release_packaging.",
+      "sample_paths": [
+        ".github/workflows/rust-release.yml"
+      ],
+      "source_state": "merged",
+      "subject_id": "27529",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "release_packaging",
+        "tests_ci"
+      ],
+      "title": "[codex] download only release artifacts",
+      "url": "https://github.com/openai/codex/pull/27529"
+    },
+    {
+      "attention_flags": [
+        "protocol_change"
+      ],
+      "changed_file_count": 3,
+      "commit_shas": [
+        "44b802dda33f6dd369c1fa3536491302fb74cefd"
+      ],
+      "committed_at": "2026-06-11T16:55:53Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27483,
+      "pr_url": "https://github.com/openai/codex/pull/27483",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for protocol_change.",
+      "sample_paths": [
+        "codex-rs/analytics/src/analytics_client_tests.rs",
+        "codex-rs/analytics/src/events.rs",
+        "codex-rs/analytics/src/reducer.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27483",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "Emit plugin ID on MCP tool call analytics events",
+      "url": "https://github.com/openai/codex/pull/27483"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 5,
+      "commit_shas": [
+        "ca736f650bbf6dbe664bb66f50baab760e7a70a0",
+        "90f100b8e5c09f2e299dbe6419d08c45843d790d",
+        "b522d62effdd8e2f2f3cd755ca9246617b9e85d4",
+        "794f5ad36787366bca6244e5b06eb8d98c36e582",
+        "97f7dbf6bcdcd7cc8c3cb6c28149d0374abe5bce"
+      ],
+      "committed_at": "2026-06-11T16:56:09Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27417,
+      "pr_url": "https://github.com/openai/codex/pull/27417",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/cli/src/main.rs",
+        "codex-rs/tui/src/app.rs",
+        "codex-rs/tui/src/app/startup_prompts.rs",
+        "codex-rs/tui/src/lib.rs",
+        "codex-rs/tui/src/main.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27417",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui"
+      ],
+      "title": "Print TUI session info on fatal exits",
+      "url": "https://github.com/openai/codex/pull/27417"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 8,
+      "commit_shas": [
+        "b73a14d7936a093f28f75a52dd054e5e2b6255c1",
+        "6ec09b71d7ba945822bd08a8ac8409b018d61cdf"
+      ],
+      "committed_at": "2026-06-11T17:24:42Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27507,
+      "pr_url": "https://github.com/openai/codex/pull/27507",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, protocol_change.",
+      "sample_paths": [
+        "AGENTS.md",
+        "tools/argument-comment-lint/README.md",
+        "tools/argument-comment-lint/src/lib.rs",
+        "tools/argument-comment-lint/ui/allow_self_documenting_methods.rs",
+        "tools/argument-comment-lint/ui/comment_mismatch.rs",
+        "tools/argument-comment-lint/ui/comment_mismatch.stderr",
+        "tools/argument-comment-lint/ui/multiple_method_arguments.rs",
+        "tools/argument-comment-lint/ui/multiple_method_arguments.stderr"
+      ],
+      "source_state": "merged",
+      "subject_id": "27507",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "docs_examples"
+      ],
+      "title": "lint: allow self-documenting builder arguments",
+      "url": "https://github.com/openai/codex/pull/27507"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 5,
+      "commit_shas": [
+        "5e772771b5c51f6f15892e47b7eabb0c45b325c9"
+      ],
+      "committed_at": "2026-06-11T17:53:18Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27454,
+      "pr_url": "https://github.com/openai/codex/pull/27454",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/exec-server/tests/file_system.rs",
+        "codex-rs/exec-server/tests/file_system/shared.rs",
+        "codex-rs/exec-server/tests/file_system/support.rs",
+        "codex-rs/exec-server/tests/file_system_unix.rs",
+        "codex-rs/exec-server/tests/file_system_windows.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27454",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "[codex] add cross-platform filesystem adapter coverage",
+      "url": "https://github.com/openai/codex/pull/27454"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 6,
+      "commit_shas": [
+        "af6121ba5beeed92c19a3ef2e4c9fc082be7a1d9"
+      ],
+      "committed_at": "2026-06-11T18:01:16Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27415,
+      "pr_url": "https://github.com/openai/codex/pull/27415",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/exec/src/event_processor_with_human_output.rs",
+        "codex-rs/exec/src/event_processor_with_jsonl_output.rs",
+        "codex-rs/exec/src/event_processor_with_jsonl_output_tests.rs",
+        "codex-rs/exec/src/lib.rs",
+        "codex-rs/exec/src/lib_tests.rs",
+        "codex-rs/exec/tests/suite/agents_md.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27415",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "[codex] Surface runtime warnings in codex exec",
+      "url": "https://github.com/openai/codex/pull/27415"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "f89eb8e014cead41e86d7dddfca4782224975b92"
+      ],
+      "committed_at": "2026-06-11T18:04:24Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27639,
+      "pr_url": "https://github.com/openai/codex/pull/27639",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        ".github/workflows/rust-release.yml"
+      ],
+      "source_state": "merged",
+      "subject_id": "27639",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "release_packaging",
+        "tests_ci"
+      ],
+      "title": "[codex] revert concurrent npm publishing",
+      "url": "https://github.com/openai/codex/pull/27639"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "release_packaging"
+      ],
+      "changed_file_count": 3,
+      "commit_shas": [
+        "21633f6d2301ad1d88db3aabb4629abe71a91b05"
+      ],
+      "committed_at": "2026-06-11T18:21:47Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27323,
+      "pr_url": "https://github.com/openai/codex/pull/27323",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, release_packaging.",
+      "sample_paths": [
+        "MODULE.bazel",
+        "patches/BUILD.bazel",
+        "patches/llvm_windows_arm64_powl.patch"
+      ],
+      "source_state": "merged",
+      "subject_id": "27323",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "internal_churn"
+      ],
+      "title": "[codex] Provide ARM64 MinGW powl compatibility support",
+      "url": "https://github.com/openai/codex/pull/27323"
     }
   ]
 }

--- a/artifacts/github/reviews/openai-codex-pr-27443.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27443.review.json
@@ -1,0 +1,74 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27443",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27443",
+    "commit_shas": [
+      "104ce325c053cc8373b8f50f88516aaf73be0409",
+      "2aef9c511d253364af98fb4348683fea07aa8eef",
+      "5159b57cb0503bbf547d1a2c972dbe94933f0f01",
+      "1cd7a69b77fc746d10b786dc1640bc6e542b308e"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "feat: add Bedrock API key as a managed auth mode",
+        "url": "https://github.com/openai/codex/pull/27443",
+        "meta": "Merged 2026-06-11T03:42:39Z"
+      },
+      {
+        "kind": "commit",
+        "title": "changes",
+        "url": "https://github.com/openai/codex/commit/1cd7a69b77fc746d10b786dc1640bc6e542b308e"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-11T20:07:07Z",
+  "observed_change": "Codex added `bedrockApiKey` as a managed app-server and login auth mode, persisting Bedrock API key plus region in `auth.json` while rejecting that mode for OpenAI-compatible providers.",
+  "changed_surfaces": [
+    "app-server protocol AuthMode enum and generated schemas",
+    "TypeScript app-server AuthMode schema",
+    "login auth storage and `AuthDotJson` shape",
+    "Bedrock API key login helper and tests",
+    "CLI login status and doctor diagnostics",
+    "model-provider auth resolution and account-state errors",
+    "telemetry auth-mode classification",
+    "TUI account display"
+  ],
+  "user_visible_path": "Codex can now store a managed Amazon Bedrock API key login in the normal auth store and report it as `bedrockApiKey`; OpenAI-compatible providers return an explicit unsupported-operation error for that auth mode.",
+  "control_plane_relevance": "High for Decodex Control Plane because app-server account notifications and generated schemas now have a new `AuthMode` variant that account panels, schema clients, provider routing, and auth-state logic must handle explicitly.",
+  "compatibility_risk": "High for clients that exhaustively match app-server `AuthMode` values or assume API-key-like auth always targets OpenAI-compatible providers.",
+  "adoption_opportunity": "Add `bedrockApiKey` handling to Decodex account readback and auth displays, and keep provider routing conservative until the upstream follow-up wires the managed key into Amazon Bedrock requests.",
+  "community_value": "High for Codex users evaluating non-OpenAI providers because the PR establishes first-class auth storage and diagnostics for Amazon Bedrock credentials.",
+  "deprecated_or_breaking_notes": "The app-server `AuthMode` enum gains `bedrockApiKey`; downstream exhaustive enum consumers need an update. The PR body says actual Bedrock request routing will come in follow-up PRs.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27443 says Bedrock API key login becomes a primary auth mode with the same persistence, reload, and logout lifecycle as existing auth modes, while OpenAI-compatible providers must reject it.",
+    "`codex-rs/app-server-protocol/src/protocol/common.rs` adds `AuthMode::BedrockApiKey` with serde, TypeScript, and strum value `bedrockApiKey`, and marks it as not a ChatGPT account.",
+    "Generated app-server JSON schemas and `schema/typescript/AuthMode.ts` add the `bedrockApiKey` wire value.",
+    "`codex-rs/login/src/auth/storage.rs` adds `bedrock_api_key` to `AuthDotJson`; `bedrock_api_key.rs` writes auth with `api_key` and `region` under `AuthMode::BedrockApiKey`.",
+    "`codex-rs/cli/src/login.rs` reports `Logged in using Amazon Bedrock API key` for the new mode.",
+    "`codex-rs/model-provider/src/auth.rs` and `provider.rs` add explicit unsupported errors when Bedrock API key auth is used with unsupported providers.",
+    "Tests cover Bedrock login replacing OpenAI auth, logout removal, primary-auth creation, OpenAI provider rejection, and provider account-state handling.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27443.json` records 30 changed files for the merged PR."
+  ],
+  "caveats": "The upstream PR establishes managed auth storage and mode reporting only; it explicitly leaves routing the managed key and region into Amazon Bedrock requests to follow-up PRs.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The new app-server auth-mode variant is a Control Plane compatibility and adoption issue."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The managed Bedrock auth mode is a clear public operator note with an important follow-up-routing caveat."
+    },
+    {
+      "type": "linear_followup",
+      "reason": "Audit Decodex account panels, auth-mode displays, schema clients, and provider routing for `bedrockApiKey` handling."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-27488.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27488.review.json
@@ -1,0 +1,73 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27488",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27488",
+    "commit_shas": [
+      "a19ec71e8d73d4dbd1dfb5b34894744ee8e6ef1a",
+      "67a29aab4885be483dc7ea05ec9bce8fddbfdc00",
+      "9e25474a95a9ceb092c04ac628cbb6985f7f30eb",
+      "812afdf99973b744cc03839a08128a536df58e4c",
+      "57885a18cccf9db57602e1240e553aaf1df92da9"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Add new context window tool",
+        "url": "https://github.com/openai/codex/pull/27488",
+        "meta": "Merged 2026-06-11T03:39:08Z"
+      },
+      {
+        "kind": "commit",
+        "title": "codex: add new context window tool",
+        "url": "https://github.com/openai/codex/commit/812afdf99973b744cc03839a08128a536df58e4c"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-11T20:07:07Z",
+  "observed_change": "Codex added a direct-model-only `new_context` tool behind the under-development `token_budget` feature so a model can request a fresh context window without a compaction summary.",
+  "changed_surfaces": [
+    "token_budget feature flag and config schema",
+    "model-visible token budget context",
+    "core tool registry and direct-model-only tool exposure",
+    "new_context tool handler and tool spec",
+    "auto-compact window state",
+    "session history replacement and rollout persistence",
+    "token-budget integration tests and snapshots"
+  ],
+  "user_visible_path": "When `features.token_budget` is enabled, the model sees context-window budget metadata and can call `new_context`; Codex then starts the next same-turn follow-up with fresh initial context and no preserved conversation history.",
+  "control_plane_relevance": "High for Decodex Control Plane because retained-lane history readers, recovery logic, and context-window accounting may need to distinguish ordinary summary compaction from a no-summary context reset requested by the model.",
+  "compatibility_risk": "Medium under the `token_budget` feature: consumers that assume every compaction-like checkpoint carries a non-empty summary or preserved conversation history may misread `new_context` resets.",
+  "adoption_opportunity": "Teach Decodex diagnostics and run reconstruction to recognize no-summary `CompactedItem` checkpoints with a new window id, then decide whether retained lanes should expose or suppress `new_context` during long-running automation.",
+  "community_value": "High for Codex operators because the feature gives the model a source-backed escape hatch when the current context window is no longer useful and a summary would waste budget.",
+  "deprecated_or_breaking_notes": "The tool is gated by the under-development `token_budget` feature and exposed as direct-model-only. It intentionally drops prior window history for the follow-up request.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27488 says `new_context` is direct-model-only, gated by `Feature::TokenBudget`, and starts a no-summary compaction checkpoint containing only fresh initial context.",
+    "`codex-rs/features/src/lib.rs` adds the under-development `token_budget` feature flag with default disabled.",
+    "`codex-rs/core/src/tools/handlers/new_context_window_spec.rs` defines the `new_context` function tool with description `Start a new context window.`",
+    "`codex-rs/core/src/tools/spec_plan.rs` adds `NewContextWindowHandler` with `ToolExposure::DirectModelOnly` only when `Feature::TokenBudget` is enabled.",
+    "`Session::maybe_start_new_context_window` builds fresh initial context, replaces history, persists a `CompactedItem` with an empty message and a new window id, queues a compact session-start source, and recomputes token usage.",
+    "`codex-rs/core/tests/suite/token_budget.rs` asserts that `new_context` is exposed, the final follow-up request uses context window 1, and prior request text is absent.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27488.json` records 10 changed files for the merged PR."
+  ],
+  "caveats": "The feature is under development and disabled by default; do not claim general availability for all Codex sessions.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The no-summary context reset changes history and compaction assumptions relevant to Decodex retained-lane reconstruction."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "Operators need a concise explanation of what the `new_context` tool changes and why it matters for long sessions."
+    },
+    {
+      "type": "linear_followup",
+      "reason": "Audit Decodex run reconstruction and context diagnostics for assumptions about non-empty compaction summaries."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-27517.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27517.review.json
@@ -1,0 +1,63 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27517",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27517",
+    "commit_shas": [
+      "66d506e86e5da8691b0773563eff7f73ecff20b9"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Pass auth mode to plugin manager",
+        "url": "https://github.com/openai/codex/pull/27517",
+        "meta": "Merged 2026-06-11T03:57:35Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Pass auth mode to plugin manager",
+        "url": "https://github.com/openai/codex/commit/66d506e86e5da8691b0773563eff7f73ecff20b9"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-11T20:07:07Z",
+  "observed_change": "Codex now stores the current auth mode on `PluginsManager` and projects plugin load outcomes through an auth-aware hook, preparing plugin capability filtering by login mode.",
+  "changed_surfaces": [
+    "app-server account auth update processing",
+    "core plugin manager state and cache projection",
+    "plugin manager auth-mode tests",
+    "ThreadManager initialization for extension and non-extension paths"
+  ],
+  "user_visible_path": "No new user-facing plugin filtering ships in this PR; it prepares plugin load results to vary by auth mode after ThreadManager creation and account auth changes.",
+  "control_plane_relevance": "High for Decodex Control Plane because future app/MCP-backed plugin surfaces may become conditional on ChatGPT, API-key, Bedrock, or other auth modes inside the plugin manager.",
+  "compatibility_risk": "Low in this PR because the projection hook currently returns the original plugin load outcome, but follow-up filtering could change which tools or plugin capabilities are visible under each auth mode.",
+  "adoption_opportunity": "Track follow-up plugin filtering changes and ensure Decodex plugin discovery, account panels, and automation assumptions include the current Codex auth mode.",
+  "community_value": "Medium as roadmap context for plugin authors, but the current PR is mostly plumbing and should not be announced as a behavior change by itself.",
+  "deprecated_or_breaking_notes": "No deprecated public field or command is removed here. The important change is the new auth-mode state boundary in the plugin manager.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27517 says it adds auth mode state to `PluginsManager`, syncs it from `ThreadManager` and account auth changes, and routes plugin load outcomes through an auth-aware projection hook.",
+    "`account_processor.rs` updates `thread_manager.plugins_manager().set_auth_mode(...)` when external auth is cleared or account auth is updated.",
+    "`core-plugins/src/manager.rs` adds an `auth_mode: RwLock<Option<AuthMode>>`, `set_auth_mode`, `auth_mode`, and `project_plugins_for_auth`.",
+    "`project_plugin_load_outcome_for_auth` currently returns the original `PluginLoadOutcome`, showing this is preparation rather than active filtering.",
+    "Plugin loading paths now project cached and freshly loaded outcomes through `project_plugins_for_auth`.",
+    "`ThreadManager` initialization sets the plugin manager auth mode from `auth_manager.get_api_auth_mode()` in both construction paths.",
+    "`core-plugins/src/manager_tests.rs` adds coverage for changing and clearing the stored auth mode.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27517.json` records 4 changed files for the merged PR."
+  ],
+  "caveats": "Current behavior is intentionally a no-op projection; wait for follow-up filtering before claiming visible plugin availability differences.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The auth-mode boundary is important Control Plane groundwork for future plugin capability filtering."
+    },
+    {
+      "type": "linear_followup",
+      "reason": "Track follow-up plugin filtering and audit Decodex assumptions about auth-mode-specific plugin capability visibility."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-27526.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27526.review.json
@@ -1,0 +1,58 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27526",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27526",
+    "commit_shas": [
+      "8a34e24ba2eb9415433cfc680d35d35112f403b8"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "tools: simplify default tool search text",
+        "url": "https://github.com/openai/codex/pull/27526",
+        "meta": "Merged 2026-06-11T03:37:26Z"
+      },
+      {
+        "kind": "commit",
+        "title": "tools: simplify default tool search text",
+        "url": "https://github.com/openai/codex/commit/8a34e24ba2eb9415433cfc680d35d35112f403b8"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-11T20:07:07Z",
+  "observed_change": "Codex now builds default tool-search text from `ToolSpec` alone, removing duplicated `ToolName` text and the non-model-visible flattened namespace/name token.",
+  "changed_surfaces": [
+    "codex-tools default search-text construction",
+    "ToolExecutor::search_info default implementation",
+    "ToolSearchInfo::from_tool_spec API shape",
+    "codex-tools public reexports",
+    "tool-search unit coverage for namespace metadata"
+  ],
+  "user_visible_path": "Models using Codex tool search should see cleaner default search text for namespace tools because namespace names, tool names, descriptions, and schema metadata remain while duplicate identity tokens are removed.",
+  "control_plane_relevance": "Moderate for Decodex Control Plane because tool-search quality affects which deferred or namespaced tools are surfaced to agents, but the change does not add a new app-server method or plugin protocol.",
+  "compatibility_risk": "Low to medium for out-of-tree Rust code that imported `default_tool_search_text` or called `ToolSearchInfo::from_tool_spec` with a `ToolName`; the helper is now private and the method no longer accepts the name argument.",
+  "adoption_opportunity": "Review Decodex tool-search expectations for namespace tools and avoid relying on flattened namespace/name tokens when authoring tool metadata.",
+  "community_value": "Medium for Codex tool authors and plugin authors because the PR explains why default search text should match model-visible metadata instead of synthetic duplicate names.",
+  "deprecated_or_breaking_notes": "`default_tool_search_text` is no longer reexported from `codex-tools`, and `ToolSearchInfo::from_tool_spec` drops the `ToolName` argument.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27526 states that default search text now derives entirely from `ToolSpec` while preserving names, descriptions, namespace metadata, and recursive schema metadata.",
+    "`codex-rs/tools/src/lib.rs` removes the public reexport of `default_tool_search_text`.",
+    "`ToolExecutor::search_info` now calls `ToolSearchInfo::from_tool_spec(spec, None)` without passing `self.tool_name()`.",
+    "`codex-rs/tools/src/tool_search.rs` removes `ToolName` from `from_tool_spec` and from `default_tool_search_text` input, then makes `default_tool_search_text` private.",
+    "`codex-rs/tools/src/tool_search_tests.rs` asserts that a namespaced `codex_app` automation tool indexes model-visible namespace, function, description, parameter, and nested schema metadata exactly once.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27526.json` records 4 changed files for the merged PR."
+  ],
+  "caveats": "This is a search-quality and source-API cleanup. Do not claim a new user-facing tool or protocol capability from this PR alone.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Decodex should track possible tool-search quality and source-API implications for deferred or namespaced tool discovery."
+    }
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27443.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27443.json
@@ -1,0 +1,56 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27443",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "critical",
+  "audience": "Codex auth, provider, and app-server clients",
+  "candidate_text": [
+    "Codex added `bedrockApiKey` as a managed auth mode with API key + region stored in auth.json and surfaced through app-server AuthMode. OpenAI-compatible providers reject it; Bedrock routing follows later. PR: https://github.com/openai/codex/pull/27443"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27443.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27443.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27443"
+    ]
+  },
+  "evidence_notes": [
+    "`AuthMode::BedrockApiKey` is added to Rust, JSON schema, and TypeScript app-server protocol surfaces.",
+    "`AuthDotJson` stores a Bedrock API key payload with API key and region.",
+    "CLI login status prints a distinct Amazon Bedrock API key login message.",
+    "Model-provider code rejects Bedrock API key auth for OpenAI-compatible providers."
+  ],
+  "claims": [
+    {
+      "text": "Codex added `bedrockApiKey` as a managed auth mode.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27443.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The PR establishes storage and app-server reporting, while Bedrock request routing is still a follow-up.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27443.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The new auth-mode variant is a concrete migration and watch item for app-server and provider clients.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27443:operator_impact"
+  },
+  "caveats": [
+    "Do not imply full Bedrock request routing is shipped in this PR.",
+    "Do not treat `bedrockApiKey` as a ChatGPT account or OpenAI API key.",
+    "Do not claim Decodex support until Decodex account surfaces are audited."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or publish this candidate.",
+    "Track the follow-up PR that wires Bedrock credentials into request routing."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27488.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27488.json
@@ -1,0 +1,56 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27488",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "critical",
+  "audience": "Codex operators and long-running automation maintainers",
+  "candidate_text": [
+    "Codex added a direct-model-only `new_context` tool behind token_budget. It starts the next follow-up in a fresh context window without a compaction summary, so rollout readers should expect no-summary resets. PR: https://github.com/openai/codex/pull/27488"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27488.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27488.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27488"
+    ]
+  },
+  "evidence_notes": [
+    "`new_context` is exposed only when `Feature::TokenBudget` is enabled.",
+    "The handler records a new context request and tells the model no summary will be produced.",
+    "Session code replaces history with fresh initial context and persists an empty compaction checkpoint.",
+    "Integration coverage asserts prior request text is absent in the final follow-up request."
+  ],
+  "claims": [
+    {
+      "text": "Codex added a feature-gated, direct-model-only `new_context` tool.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27488.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The tool starts a fresh context window without preserving conversation history through a compaction summary.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27488.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The feature changes long-session context and compaction semantics that Codex operators should recognize.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27488:operator_impact"
+  },
+  "caveats": [
+    "The upstream feature is under development and disabled by default.",
+    "Do not claim Decodex runtime support until Decodex run reconstruction is audited.",
+    "Do not frame it as a normal user-invoked command; it is direct-model-only."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or publish this candidate.",
+    "Audit Decodex rollout reconstruction before making Decodex support claims."
+  ]
+}


### PR DESCRIPTION
## Summary
- refreshed the deterministic openai/codex upstream review queue
- added source-backed bundles, upstream reviews, and upstream impacts for PRs 27526, 27488, 27443, and 27517
- added social_candidate/v1 handoffs for PRs 27488 and 27443 only; no social_post/v1 artifacts were written

## Validation
- cargo run -p decodex --bin decodex -- radar bundle validate artifacts/github/bundles/openai-codex-pr-27526.json artifacts/github/bundles/openai-codex-pr-27488.json artifacts/github/bundles/openai-codex-pr-27443.json artifacts/github/bundles/openai-codex-pr-27517.json
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/review-queue artifacts/github/bundles artifacts/github/reviews artifacts/github/impact artifacts/github/social-candidates
- cargo make check-site-content
- cargo make fmt
- cargo make lint-fix
- cargo make test