### PR TITLE
Persist Codex alpha10 alpha11 checkpoint handoffs

### DIFF
--- a/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-10-needs-upstream-analysis.json
+++ b/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-10-needs-upstream-analysis.json
@@ -1,0 +1,69 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-rust-v0-140-0-alpha-10-needs-upstream-analysis",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "watch_note",
+  "priority": "normal",
+  "audience": "Codex operators tracking prerelease changes",
+  "candidate_text": [
+    "No 0.140.0-alpha.10 post handoff yet.\n\nalpha.9 -> alpha.10 has 6 ahead commits and 5 primary PR-title refs, but the release body is sparse and those PRs lack checked Decodex review/impact.\n\nSource: https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.10"
+  ],
+  "source_refs": {
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://developers.openai.com/codex/changelog",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.9",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.10",
+      "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.9...rust-v0.140.0-alpha.10",
+      "https://github.com/openai/codex/pull/27388",
+      "https://github.com/openai/codex/pull/27404",
+      "https://github.com/openai/codex/pull/27413",
+      "https://github.com/openai/codex/pull/27527",
+      "https://github.com/openai/codex/pull/27528",
+      "https://github.com/openai/codex/pull/27529",
+      "https://github.com/openai/codex/pull/27591"
+    ]
+  },
+  "evidence_notes": [
+    "GitHub release metadata shows rust-v0.140.0-alpha.10 was published at 2026-06-11T16:48:23Z with only a sparse release body: Release 0.140.0-alpha.10.",
+    "The correct public prerelease comparison for this checkpoint is rust-v0.140.0-alpha.9 -> rust-v0.140.0-alpha.10; GitHub compare metadata reports status=diverged, 6 ahead commits, 1 behind commit, and 6 total commits.",
+    "Primary PR-title metadata in the alpha.9 -> alpha.10 compare points to skills catalog locator authority, skills-extension decoupling, npm package publication concurrency, DotSlash publication, and release artifact download selection.",
+    "The compare commit text also references PR #27388 and PR #27404 as context behind the skills work; those context PRs are useful release-window gaps but do not source-review the alpha.10 PRs themselves.",
+    "Checked Radar review/impact artifacts are absent for all 5 primary PR-title references in the alpha.9 -> alpha.10 compare window and for the 2 context PR references in this checkout.",
+    "The checked release_delta/v1 still records stable rust-v0.139.0 -> prerelease rust-v0.140.0-alpha.9 with no tracked signal slugs; a deterministic refresh during this run returned changed=false and prerelease_tag_name=rust-v0.140.0-alpha.9 despite GitHub release metadata showing alpha.10 as newer.",
+    "Official Codex changelog readback for this run still shows Codex app 26.608, ChatGPT for iOS 1.2026.153, and Codex CLI 0.139.0 on 2026-06-09 as the newest entries; rust-v0.140.0-alpha.10 is a GitHub prerelease checkpoint, not an official changelog entry."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.140.0-alpha.10 is a sparse GitHub prerelease checkpoint after alpha.9.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.10",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The alpha.9 -> alpha.10 compare window has unreviewed primary PR-title gaps before Decodex can make behavior claims.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.9...rust-v0.140.0-alpha.10",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "defer",
+    "reason": "needs_upstream_analysis: the alpha.10 release body is sparse and the adjacent alpha.9 -> alpha.10 compare has unreviewed primary PR-title gaps.",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-140-0-alpha-10:alpha9-alpha10:defer"
+  },
+  "caveats": [
+    "This is a terminal defer / needs_upstream_analysis checkpoint record, not a publication request.",
+    "No previous live and quote-eligible @decodexspace 0.140 prerelease post exists; alpha.2, alpha.4, alpha.7, alpha.8, and alpha.9 were also recorded as defer / needs_upstream_analysis checkpoints.",
+    "rust-v0.140.0-alpha.11 also exists as a newer public prerelease checkpoint in this run; alpha.11 should use adjacent alpha.10 -> alpha.11 lineage rather than stable-to-prerelease comparison.",
+    "Exact source-review gap list for alpha.9 -> alpha.10 primary compare PRs: #27413, #27527, #27528, #27529, #27591. Context PRs referenced by compare text and also missing checked review/impact: #27388, #27404.",
+    "Media caveat: no generated image is attached by this downstream artifact-consumer run. If this checkpoint later becomes publishable, decodex-x-publisher should generate and verify candidate-specific media only when it adds reader value."
+  ],
+  "next_steps": [
+    "Do not hand this alpha.10 defer record to decodex-x-publisher.",
+    "Route the listed source-review gap PRs to codex-upstream-radar-review / codex-code-analysis before turning alpha.10 into a release_rollup, watch_note, delta_explainer, or operator_impact post.",
+    "Investigate why the deterministic release-delta refresh still selects rust-v0.140.0-alpha.9 even though GitHub release metadata lists alpha.10 and alpha.11 as newer public prereleases."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-11-needs-upstream-analysis.json
+++ b/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-11-needs-upstream-analysis.json
@@ -1,0 +1,69 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-rust-v0-140-0-alpha-11-needs-upstream-analysis",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "watch_note",
+  "priority": "normal",
+  "audience": "Codex operators tracking prerelease changes",
+  "candidate_text": [
+    "No 0.140.0-alpha.11 post handoff yet.\n\nalpha.10 -> alpha.11 has 9 ahead commits and 8 primary PR-title refs, but the release body is sparse and those PRs lack checked Decodex review/impact.\n\nSource: https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.11"
+  ],
+  "source_refs": {
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://developers.openai.com/codex/changelog",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.10",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.11",
+      "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.10...rust-v0.140.0-alpha.11",
+      "https://github.com/openai/codex/pull/27415",
+      "https://github.com/openai/codex/pull/27417",
+      "https://github.com/openai/codex/pull/27420",
+      "https://github.com/openai/codex/pull/27454",
+      "https://github.com/openai/codex/pull/27483",
+      "https://github.com/openai/codex/pull/27490",
+      "https://github.com/openai/codex/pull/27507",
+      "https://github.com/openai/codex/pull/27639"
+    ]
+  },
+  "evidence_notes": [
+    "GitHub release metadata shows rust-v0.140.0-alpha.11 was published at 2026-06-11T19:12:40Z with only a sparse release body: Release 0.140.0-alpha.11.",
+    "The correct public prerelease comparison for this checkpoint is rust-v0.140.0-alpha.10 -> rust-v0.140.0-alpha.11; GitHub compare metadata reports status=diverged, 9 ahead commits, 1 behind commit, and 9 total commits.",
+    "Primary PR-title metadata in the alpha.10 -> alpha.11 compare points to removing a legacy Windows sandbox dependency from TUI, plugin ID analytics, fatal-exit session info, a builder-argument lint exception, plugin app categories, cross-platform filesystem adapter coverage, codex exec runtime warnings, and a release-publishing revert.",
+    "Checked Radar review/impact artifacts are absent for all 8 primary PR-title references in the alpha.10 -> alpha.11 compare window in this checkout.",
+    "The checked release_delta/v1 still records stable rust-v0.139.0 -> prerelease rust-v0.140.0-alpha.9 with no tracked signal slugs; a deterministic refresh during this run returned changed=false and prerelease_tag_name=rust-v0.140.0-alpha.9 despite GitHub release metadata showing alpha.11 as newer.",
+    "Official Codex changelog readback for this run still shows Codex app 26.608, ChatGPT for iOS 1.2026.153, and Codex CLI 0.139.0 on 2026-06-09 as the newest entries; rust-v0.140.0-alpha.11 is a GitHub prerelease checkpoint, not an official changelog entry."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.140.0-alpha.11 is the newest public GitHub prerelease checkpoint observed in this run.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.11",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The alpha.10 -> alpha.11 compare window has unreviewed primary PR-title gaps before Decodex can make behavior claims.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.10...rust-v0.140.0-alpha.11",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "defer",
+    "reason": "needs_upstream_analysis: the alpha.11 release body is sparse and the adjacent alpha.10 -> alpha.11 compare has unreviewed primary PR-title gaps.",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-140-0-alpha-11:alpha10-alpha11:defer"
+  },
+  "caveats": [
+    "This is a terminal defer / needs_upstream_analysis checkpoint record, not a publication request.",
+    "No previous live and quote-eligible @decodexspace 0.140 prerelease post exists; alpha.2, alpha.4, alpha.7, alpha.8, alpha.9, and alpha.10 were also recorded as defer / needs_upstream_analysis checkpoints.",
+    "Do not compare later 0.140 prereleases against stable 0.139.0 or alpha.9 if a newer public prerelease checkpoint exists; later 0.140 prereleases should use adjacent prerelease-to-prerelease lineage from alpha.11.",
+    "Exact source-review gap list for alpha.10 -> alpha.11 primary compare PRs: #27415, #27417, #27420, #27454, #27483, #27490, #27507, #27639.",
+    "Media caveat: no generated image is attached by this downstream artifact-consumer run. If this checkpoint later becomes publishable, decodex-x-publisher should generate and verify candidate-specific media only when it adds reader value."
+  ],
+  "next_steps": [
+    "Do not hand this alpha.11 defer record to decodex-x-publisher.",
+    "Route the listed source-review gap PRs to codex-upstream-radar-review / codex-code-analysis before turning alpha.11 into a release_rollup, watch_note, delta_explainer, or operator_impact post.",
+    "Investigate why the deterministic release-delta refresh still selects rust-v0.140.0-alpha.9 even though GitHub release metadata lists alpha.10 and alpha.11 as newer public prereleases."
+  ]
+}


### PR DESCRIPTION
## Summary
- Add terminal `defer` / `needs_upstream_analysis` social_candidate/v1 records for `rust-v0.140.0-alpha.10` and `rust-v0.140.0-alpha.11`.
- Preserve adjacent prerelease lineage, compare URLs, PR-title gap lists, and media caveats.
- Record that deterministic release-delta refresh still selected `rust-v0.140.0-alpha.9` despite GitHub release metadata showing alpha10/alpha11 as newer public prereleases.

## Validation
- `decodex radar validate artifacts/github/social-candidates artifacts/social/x`
- `cargo make fmt`
- `cargo make lint-fix`
- `cargo make test`

## Notes
- No X publication was attempted.
- Both candidates are terminal defer records and should not be handed to `decodex-x-publisher` until upstream source review fills the named gaps.