### PR TITLE
Persist Decodex X post for PR 27488

### DIFF
--- a/artifacts/social/x/posts/2026-06-12/openai-codex-pr-27488.json
+++ b/artifacts/social/x/posts/2026-06-12/openai-codex-pr-27488.json
@@ -1,0 +1,100 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-27488",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "published",
+  "audience": "Codex operators and long-running automation maintainers",
+  "text": [
+    "Codex added a direct-model-only `new_context` tool behind token_budget. It starts the next follow-up in a fresh context window without a compaction summary, so rollout readers should expect no-summary resets. PR: https://github.com/openai/codex/pull/27488"
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27488.json"
+    ],
+    "reservations": [
+      "artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27488.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27488.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27488.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27488",
+      "https://x.com/decodexspace/status/2065192562416353458"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish, priority critical, and mode operator_impact for openai-codex-pr-27488.",
+    "The upstream_review/v1 artifact confirms PR #27488 adds a feature-gated direct-model-only new_context tool that starts a fresh context window without preserving prior request text.",
+    "The upstream_impact/v1 artifact marks the change as public_signal_decision publish, control_plane_impact compat_risk, and publisher_angle operator_impact.",
+    "The x-post-quality-system gate passed because the post states what changed, who can act on it, and the direct source that proves it; the checked copy is 255 characters and includes a direct GitHub PR URL.",
+    "Checked durable social_post/v1 records contained no published or blocked record for this idempotency key before publication.",
+    "Checked durable social_publish_reservation/v1 records contained no active reservation for this idempotency key before the new reservation was created.",
+    "Open GitHub PR readback with routed hackink credentials found pending publication PR #336 for openai-codex-pr-27414, PR #328 for openai-codex-app-26-608, and PR #298 for openai-codex-pr-26486, with no open PR touching openai-codex-pr-27488.",
+    "PR #340 made the active reservation visible before X compose; remote GitHub content readback confirmed artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27488.json with status active and the PR URL.",
+    "Chrome account readback initially showed @hackink active; the automation switched to @decodexspace and verified account menu plus Edit profile owner controls before reservation and compose.",
+    "Bounded @decodexspace profile readback before reservation found no PR 27488, new_context, token_budget, candidate slug, or source URL match.",
+    "Live @decodexspace profile readback after PR-visible reservation and immediately before clicking Post showed owner controls, rendered eight recent articles, and found no PR 27488, new_context, token_budget, candidate slug, or source URL match.",
+    "Focused X search after the PR-visible reservation returned No results with zero result articles for from:decodexspace PR 27488/new_context/token_budget/openai-codex-pr-27488.",
+    "The compose dialog showed @decodexspace and the 255-character checked text before the enabled modal Post button was clicked.",
+    "Home timeline readback immediately after posting showed the new @decodexspace status with the expected PR 27488 new_context text and GitHub source card.",
+    "Permalink readback showed the expected @decodexspace post text, Automated by @hackink attribution, GitHub PR #27488 card, and no attached image media or /photo/N link.",
+    "The status ID decodes to 2026-06-11T22:00:50.959Z, which is 2026-06-12 06:00:50 in Asia/Shanghai."
+  ],
+  "claims": [
+    {
+      "text": "Codex added a feature-gated, direct-model-only `new_context` tool.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27488.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The tool starts the next follow-up in a fresh context window without a compaction summary.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27488.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The PR #27488 operator-impact post is live on @decodexspace.",
+      "evidence": "https://x.com/decodexspace/status/2065192562416353458",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "priority": "critical",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27488:operator_impact",
+    "reason": "The feature changes long-session context and compaction semantics that Codex operators should recognize.",
+    "daily_limit": 8,
+    "daily_count_before": 1,
+    "daily_count_after": 2,
+    "day": "2026-06-12",
+    "timezone": "Asia/Shanghai"
+  },
+  "publication": {
+    "posted_at": "2026-06-11T22:00:50.959Z",
+    "published_urls": [
+      "https://x.com/decodexspace/status/2065192562416353458"
+    ],
+    "publisher": "chrome",
+    "account_verified": true,
+    "made_with_ai": false
+  },
+  "media_refs": [
+    "media_caveat: no generated media was attached; this non-release operator_impact post remains valuable text-only because the source-backed long-session behavior note and GitHub PR card are the reader value."
+  ],
+  "caveats": [
+    "The upstream feature is under development and disabled by default.",
+    "Do not claim Decodex runtime support until Decodex run reconstruction is audited.",
+    "Do not frame it as a normal user-invoked command; it is direct-model-only.",
+    "No generated image was used because this was a single non-release operator-impact post with sufficient reader value from the text and source card."
+  ],
+  "post_lifecycle": {
+    "current_state": "live",
+    "quote_eligible": false,
+    "reason": "This is a standalone operator-impact post, not a prerelease quote-chain anchor."
+  }
+}

--- a/artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27488.json
+++ b/artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27488.json
@@ -34,7 +34,8 @@
   ],
   "owner": {
     "automation_id": "decodex-x-publisher",
-    "branch": "codex/x-publisher-pr-27488-20260612"
+    "branch": "codex/x-publisher-pr-27488-20260612",
+    "pr_url": "https://github.com/hack-ink/decodex/pull/340"
   },
   "evidence_notes": [
     "The social_candidate/v1 artifact has decision.worthiness = publish, priority critical, and mode operator_impact for openai-codex-pr-27488.",

--- a/artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27488.json
+++ b/artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27488.json
@@ -1,0 +1,48 @@
+{
+  "schema": "social_publish_reservation/v1",
+  "slug": "openai-codex-pr-27488",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "active",
+  "idempotency_key": "x:decodexspace:openai-codex-pr-27488:operator_impact",
+  "reserved_at": "2026-06-11T21:56:57Z",
+  "expires_at": "2026-06-11T23:56:57Z",
+  "day": "2026-06-12",
+  "timezone": "Asia/Shanghai",
+  "candidate_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27488.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27488.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27488.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27488"
+    ]
+  },
+  "duplicate_keys": [
+    "x:decodexspace:openai-codex-pr-27488:operator_impact",
+    "openai-codex-pr-27488",
+    "https://github.com/openai/codex/pull/27488",
+    "PR 27488",
+    "new_context token_budget fresh context"
+  ],
+  "owner": {
+    "automation_id": "decodex-x-publisher",
+    "branch": "codex/x-publisher-pr-27488-20260612"
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish, priority critical, and mode operator_impact for openai-codex-pr-27488.",
+    "Checked durable social_post/v1 records contained no published or blocked record for this idempotency key before reservation.",
+    "Checked durable social_publish_reservation/v1 records contained no active reservation for this idempotency key before reservation.",
+    "Open GitHub PR readback with routed hackink credentials found pending publication PR #336 for openai-codex-pr-27414, PR #328 for openai-codex-app-26-608, and PR #298 for openai-codex-pr-26486, with no open PR touching openai-codex-pr-27488.",
+    "Cap-day count before this reservation is 1 for 2026-06-12 Asia/Shanghai when combining checked-in records with open publication PR #336.",
+    "Chrome account readback showed @hackink first, then the account switcher exposed @decodexspace; after switching, account menu and profile owner controls verified @decodexspace before reservation.",
+    "Bounded @decodexspace profile readback found no PR 27488, new_context, token_budget, candidate slug, or source URL match before reservation."
+  ]
+}

--- a/artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27488.json
+++ b/artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27488.json
@@ -5,7 +5,7 @@
   "target_account": "decodexspace",
   "controller_account": "hackink",
   "mode": "operator_impact",
-  "status": "active",
+  "status": "consumed",
   "idempotency_key": "x:decodexspace:openai-codex-pr-27488:operator_impact",
   "reserved_at": "2026-06-11T21:56:57Z",
   "expires_at": "2026-06-11T23:56:57Z",
@@ -37,6 +37,7 @@
     "branch": "codex/x-publisher-pr-27488-20260612",
     "pr_url": "https://github.com/hack-ink/decodex/pull/340"
   },
+  "consumed_by_social_post": "artifacts/social/x/posts/2026-06-12/openai-codex-pr-27488.json",
   "evidence_notes": [
     "The social_candidate/v1 artifact has decision.worthiness = publish, priority critical, and mode operator_impact for openai-codex-pr-27488.",
     "Checked durable social_post/v1 records contained no published or blocked record for this idempotency key before reservation.",


### PR DESCRIPTION
## Summary
- consume the PR-visible social_publish_reservation/v1 lease for openai-codex-pr-27488
- add the terminal social_post/v1 record for the live @decodexspace PR 27488 post
- record publication, duplicate, account, cap-day, media-caveat, and permalink readback evidence

## Publication
- https://x.com/decodexspace/status/2065192562416353458

## Validation
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x