### PR TITLE
Add Program Reconciler queue label automation

### DIFF
--- a/apps/decodex/src/execution_program.rs
+++ b/apps/decodex/src/execution_program.rs
@@ -459,6 +459,8 @@ pub(crate) struct ExecutionLinearIssueMapping {
 	has_active_label: bool,
 	has_opt_out_label: bool,
 	has_needs_attention_label: bool,
+	#[serde(default, skip_serializing_if = "is_false")]
+	has_open_tracker_blockers: bool,
 	has_generic_dispatch_briefing: bool,
 }
 impl ExecutionLinearIssueMapping {
@@ -477,6 +479,7 @@ impl ExecutionLinearIssueMapping {
 			has_active_label: false,
 			has_opt_out_label: false,
 			has_needs_attention_label: false,
+			has_open_tracker_blockers: false,
 			has_generic_dispatch_briefing: true,
 		};
 
@@ -517,6 +520,13 @@ impl ExecutionLinearIssueMapping {
 	/// Mark whether the issue currently carries the needs-attention label.
 	pub(crate) fn with_needs_attention_label(mut self, present: bool) -> Self {
 		self.has_needs_attention_label = present;
+
+		self
+	}
+
+	/// Mark whether the mapped issue currently has open tracker dependency blockers.
+	pub(crate) fn with_open_tracker_blockers(mut self, present: bool) -> Self {
+		self.has_open_tracker_blockers = present;
 
 		self
 	}
@@ -566,6 +576,11 @@ impl ExecutionLinearIssueMapping {
 	/// Whether the configured human-attention label is currently present.
 	pub(crate) fn has_needs_attention_label(&self) -> bool {
 		self.has_needs_attention_label
+	}
+
+	/// Whether the mapped issue currently has open dependency blockers in the tracker.
+	pub(crate) fn has_open_tracker_blockers(&self) -> bool {
+		self.has_open_tracker_blockers
 	}
 
 	/// Whether the issue description is usable as a generic dispatch briefing.
@@ -904,6 +919,15 @@ impl ExecutionProgram {
 	/// Program nodes.
 	pub(crate) fn nodes(&self) -> &[ExecutionProgramNode] {
 		&self.nodes
+	}
+
+	/// Replace program nodes after runtime reconciliation refreshes tracker issue facts.
+	pub(crate) fn with_nodes(mut self, nodes: Vec<ExecutionProgramNode>) -> Result<Self> {
+		self.nodes = nodes;
+
+		self.validate()?;
+
+		Ok(self)
 	}
 
 	/// Evaluate every node against the current contract, workflow policy, and runtime context.
@@ -1610,6 +1634,12 @@ fn collect_issue_mapping_reasons(
 			"mapped issue `{}` carries `{}`",
 			issue.issue_identifier(),
 			policy.needs_attention_label
+		));
+	}
+	if issue.has_open_tracker_blockers {
+		reasons.push(format!(
+			"mapped issue `{}` has open tracker dependency blockers",
+			issue.issue_identifier()
 		));
 	}
 	if !issue.has_generic_dispatch_briefing {

--- a/apps/decodex/src/orchestrator.rs
+++ b/apps/decodex/src/orchestrator.rs
@@ -56,6 +56,8 @@ include!("orchestrator/operator_http.rs");
 
 include!("orchestrator/pull_request_review.rs");
 
+include!("orchestrator/program_reconciler.rs");
+
 include!("orchestrator/daemon.rs");
 
 include!("orchestrator/reconciliation.rs");

--- a/apps/decodex/src/orchestrator/daemon.rs
+++ b/apps/decodex/src/orchestrator/daemon.rs
@@ -140,6 +140,24 @@ where
 		context.review_state_inspector,
 	)?;
 
+	let program_reconciliation = reconcile_execution_program_queue_labels(
+		context.tracker,
+		context.project,
+		context.workflow,
+		state_store,
+	)?;
+
+	if program_reconciliation.label_mutation_count() > 0 {
+		tracing::info!(
+			project_id = context.project.service_id(),
+			programs_evaluated = program_reconciliation.programs_evaluated,
+			programs_updated = program_reconciliation.programs_updated,
+			labels_applied = program_reconciliation.labels_applied,
+			labels_removed = program_reconciliation.labels_removed,
+			"Reconciled Execution Program queue labels before normal issue selection."
+		);
+	}
+
 	while context
 		.workflow
 		.frontmatter()

--- a/apps/decodex/src/orchestrator/program_reconciler.rs
+++ b/apps/decodex/src/orchestrator/program_reconciler.rs
@@ -1,0 +1,502 @@
+use crate::execution_program::{
+	ExecutionDependencySnapshot, ExecutionLinearIssueMapping, ExecutionNodeEvaluation,
+	ExecutionProgram, ExecutionQueueLabelAction,
+};
+use crate::execution_program::ExecutionConflictDomain;
+
+#[derive(Clone)]
+struct RefreshedExecutionProgram {
+	record: ExecutionProgramRecord,
+	program: ExecutionProgram,
+	issues_by_node: std::collections::BTreeMap<String, ProgramIssueSnapshot>,
+}
+
+#[derive(Clone)]
+struct ProgramIssueSnapshot {
+	issue: TrackerIssue,
+	has_queue_label: bool,
+	queue_label_owned_by_current_program: bool,
+	has_active_label: bool,
+	has_opt_out_label: bool,
+	has_needs_attention_label: bool,
+	has_open_tracker_blockers: bool,
+	has_generic_dispatch_briefing: bool,
+}
+impl ProgramIssueSnapshot {
+	fn linear_mapping(
+		&self,
+		has_queue_label: bool,
+		queue_label_program_owned: bool,
+	) -> Result<ExecutionLinearIssueMapping> {
+		let mut mapping = ExecutionLinearIssueMapping::new(
+			&self.issue.id,
+			&self.issue.identifier,
+			&self.issue.state.name,
+		)?;
+
+		mapping = if queue_label_program_owned {
+			mapping.with_program_owned_queue_label(true)
+		} else {
+			mapping.with_queue_label(has_queue_label)
+		};
+
+		Ok(mapping
+			.with_active_label(self.has_active_label)
+			.with_opt_out_label(self.has_opt_out_label)
+			.with_needs_attention_label(self.has_needs_attention_label)
+			.with_open_tracker_blockers(self.has_open_tracker_blockers)
+			.with_generic_dispatch_briefing(self.has_generic_dispatch_briefing))
+	}
+}
+
+struct ProgramIssueSnapshotInput<'a, T>
+where
+	T: IssueTracker + ?Sized,
+{
+	tracker: &'a T,
+	service_id: &'a str,
+	workflow: &'a WorkflowDocument,
+	state_store: &'a StateStore,
+	queue_label: &'a str,
+	record: &'a ExecutionProgramRecord,
+	node_id: &'a str,
+	issue: &'a TrackerIssue,
+}
+
+#[derive(Default)]
+struct ProgramReconciliationSummary {
+	programs_evaluated: usize,
+	programs_updated: usize,
+	labels_applied: usize,
+	labels_removed: usize,
+	labels_retained: usize,
+}
+impl ProgramReconciliationSummary {
+	fn label_mutation_count(&self) -> usize {
+		self.labels_applied + self.labels_removed
+	}
+}
+
+struct ProgramQueueLabelState {
+	has_queue_label: bool,
+	program_owned: bool,
+}
+
+fn reconcile_execution_program_queue_labels<T>(
+	tracker: &T,
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+) -> Result<ProgramReconciliationSummary>
+where
+	T: IssueTracker + ?Sized,
+{
+	let records = state_store.list_execution_programs(project.service_id())?;
+
+	if records.is_empty() {
+		return Ok(ProgramReconciliationSummary::default());
+	}
+
+	let policy = ExecutionWorkflowPolicy::from_workflow(project.service_id(), workflow)?;
+	let refreshed_issues = refresh_execution_program_issues(tracker, &records)?;
+	let refreshed_programs = records
+		.into_iter()
+		.map(|record| {
+			refresh_execution_program_tracker_facts(
+				tracker,
+				project.service_id(),
+				workflow,
+				state_store,
+				&policy,
+				record,
+				&refreshed_issues,
+			)
+		})
+		.collect::<Result<Vec<_>>>()?;
+	let context = execution_program_readiness_context(
+		project.service_id(),
+		workflow,
+		state_store,
+		&refreshed_programs,
+	)?;
+	let mut summary = ProgramReconciliationSummary::default();
+
+	for refreshed in refreshed_programs {
+		let evaluation = if let Some(source_contract_id) = refreshed.record.source_contract_id() {
+			let Some(contract) =
+				state_store.decision_contract(project.service_id(), source_contract_id)?
+			else {
+				continue;
+			};
+
+			refreshed.program.evaluate(contract.contract(), &policy, &context)?
+		} else {
+			refreshed.program.evaluate_issue_batch(&policy, &context)?
+		};
+
+		summary.programs_evaluated += 1;
+
+		let final_program = apply_execution_program_queue_actions(
+			tracker,
+			project.service_id(),
+			policy.queue_label(),
+			refreshed.program,
+			&refreshed.issues_by_node,
+			evaluation.nodes(),
+			&mut summary,
+		)?;
+
+		if final_program != *refreshed.record.program() {
+			state_store.upsert_execution_program(project.service_id(), final_program)?;
+
+			summary.programs_updated += 1;
+		}
+	}
+
+	Ok(summary)
+}
+
+fn refresh_execution_program_issues<T>(
+	tracker: &T,
+	records: &[ExecutionProgramRecord],
+) -> Result<std::collections::BTreeMap<String, TrackerIssue>>
+where
+	T: IssueTracker + ?Sized,
+{
+	let issue_ids = records
+		.iter()
+		.flat_map(|record| record.program().nodes())
+		.filter_map(|node| node.linear_issue().map(|issue| issue.issue_id().to_owned()))
+		.collect::<std::collections::BTreeSet<_>>()
+		.into_iter()
+		.collect::<Vec<_>>();
+
+	if issue_ids.is_empty() {
+		return Ok(std::collections::BTreeMap::new());
+	}
+
+	Ok(tracker
+		.refresh_issues(&issue_ids)?
+		.into_iter()
+		.map(|issue| (issue.id.clone(), issue))
+		.collect())
+}
+
+fn refresh_execution_program_tracker_facts<T>(
+	tracker: &T,
+	service_id: &str,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	policy: &ExecutionWorkflowPolicy,
+	record: ExecutionProgramRecord,
+	refreshed_issues: &std::collections::BTreeMap<String, TrackerIssue>,
+) -> Result<RefreshedExecutionProgram>
+where
+	T: IssueTracker + ?Sized,
+{
+	let mut refreshed_nodes = Vec::with_capacity(record.program().nodes().len());
+	let mut issues_by_node = std::collections::BTreeMap::new();
+
+	for node in record.program().nodes() {
+		let Some(mapping) = node.linear_issue() else {
+			refreshed_nodes.push(node.clone());
+
+			continue;
+		};
+		let Some(issue) = refreshed_issues.get(mapping.issue_id()) else {
+			refreshed_nodes.push(node.clone());
+
+			continue;
+		};
+		let snapshot = program_issue_snapshot(ProgramIssueSnapshotInput {
+			tracker,
+			service_id,
+			workflow,
+			state_store,
+			queue_label: policy.queue_label(),
+			record: &record,
+			node_id: node.node_id(),
+			issue,
+		})?;
+		let mapping =
+			snapshot.linear_mapping(snapshot.has_queue_label, snapshot.queue_label_owned_by_current_program)?;
+
+		refreshed_nodes.push(node.clone().with_linear_issue(mapping)?);
+		issues_by_node.insert(node.node_id().to_owned(), snapshot);
+	}
+
+	let program = record.program().clone().with_nodes(refreshed_nodes)?;
+
+	Ok(RefreshedExecutionProgram { record, program, issues_by_node })
+}
+
+fn program_issue_snapshot<T>(input: ProgramIssueSnapshotInput<'_, T>) -> Result<ProgramIssueSnapshot>
+where
+	T: IssueTracker + ?Sized,
+{
+	let ProgramIssueSnapshotInput {
+		tracker,
+		service_id,
+		workflow,
+		state_store,
+		queue_label,
+		record,
+		node_id,
+		issue,
+	} = input;
+	let tracker_policy = workflow.frontmatter().tracker();
+	let has_queue_label =
+		tracker::issue_has_label_with_server_confirmation(tracker, issue, queue_label)?;
+	let ownership = state_store.program_queue_label_ownership_for_issue(
+		service_id,
+		&issue.id,
+		queue_label,
+	)?;
+	let queue_label_owned_by_current_program = has_queue_label
+		&& ownership.iter().any(|recorded| {
+			recorded.service_id() == service_id
+				&& recorded.program_id() == record.program_id()
+				&& recorded.node_id() == node_id
+				&& recorded.issue_id() == issue.id
+				&& recorded.issue_identifier() == issue.identifier
+				&& recorded.label_name() == queue_label
+		});
+	let has_active_label = tracker::issue_has_label_with_server_confirmation(
+		tracker,
+		issue,
+		&tracker::automation_active_label(service_id),
+	)?;
+	let has_opt_out_label =
+		tracker::issue_has_label_with_server_confirmation(tracker, issue, tracker_policy.opt_out_label())?;
+	let has_needs_attention_label = tracker::issue_has_label_with_server_confirmation(
+		tracker,
+		issue,
+		tracker_policy.needs_attention_label(),
+	)?;
+	let has_open_tracker_blockers =
+		issue.blockers.iter().any(|blocker| !state_name_is_terminal(&blocker.state.name, workflow));
+
+	Ok(ProgramIssueSnapshot {
+		issue: issue.clone(),
+		has_queue_label,
+		queue_label_owned_by_current_program,
+		has_active_label,
+		has_opt_out_label,
+		has_needs_attention_label,
+		has_open_tracker_blockers,
+		has_generic_dispatch_briefing: issue_has_generic_dispatch_briefing(issue),
+	})
+}
+
+fn execution_program_readiness_context(
+	service_id: &str,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	programs: &[RefreshedExecutionProgram],
+) -> Result<ExecutionProgramReadinessContext> {
+	let dependency_snapshots = execution_program_dependency_snapshots(programs)?;
+	let occupied_conflict_domains =
+		execution_program_occupied_conflict_domains(service_id, workflow, state_store, programs)?;
+
+	Ok(ExecutionProgramReadinessContext::new()
+		.with_dependency_snapshots(dependency_snapshots)
+		.with_occupied_conflict_domains(occupied_conflict_domains))
+}
+
+fn execution_program_dependency_snapshots(
+	programs: &[RefreshedExecutionProgram],
+) -> Result<Vec<ExecutionDependencySnapshot>> {
+	let mut snapshots = std::collections::BTreeMap::new();
+
+	for refreshed in programs {
+		for node in refreshed.program.nodes() {
+			let Some(snapshot) = refreshed.issues_by_node.get(node.node_id()) else {
+				continue;
+			};
+
+			insert_dependency_snapshot(&mut snapshots, node.node_id(), &snapshot.issue.state.name)?;
+			insert_dependency_snapshot(
+				&mut snapshots,
+				&snapshot.issue.identifier,
+				&snapshot.issue.state.name,
+			)?;
+
+			for blocker in &snapshot.issue.blockers {
+				insert_dependency_snapshot(&mut snapshots, &blocker.identifier, &blocker.state.name)?;
+			}
+		}
+	}
+
+	Ok(snapshots.into_values().collect())
+}
+
+fn insert_dependency_snapshot(
+	snapshots: &mut std::collections::BTreeMap<String, ExecutionDependencySnapshot>,
+	dependency_id: &str,
+	state: &str,
+) -> Result<()> {
+	if snapshots.contains_key(dependency_id) {
+		return Ok(());
+	}
+
+	snapshots.insert(
+		dependency_id.to_owned(),
+		ExecutionDependencySnapshot::tracker_state(dependency_id, state)?,
+	);
+
+	Ok(())
+}
+
+fn execution_program_occupied_conflict_domains(
+	service_id: &str,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	programs: &[RefreshedExecutionProgram],
+) -> Result<Vec<ExecutionConflictDomain>> {
+	let retained_issue_ids = state_store
+		.list_worktrees(service_id)?
+		.into_iter()
+		.map(|worktree| worktree.issue_id().to_owned())
+		.collect::<std::collections::BTreeSet<_>>();
+	let mut occupied = Vec::new();
+	let mut seen = std::collections::BTreeSet::new();
+
+	for refreshed in programs {
+		for node in refreshed.program.nodes() {
+			let Some(snapshot) = refreshed.issues_by_node.get(node.node_id()) else {
+				continue;
+			};
+
+			if !program_issue_occupies_conflict_domain(
+				service_id,
+				workflow,
+				state_store,
+				&retained_issue_ids,
+				snapshot,
+			)? {
+				continue;
+			}
+
+			for domain in node.conflict_domains() {
+				let key = format!("{}:{}", domain.kind().as_str(), domain.key());
+
+				if seen.insert(key) {
+					occupied.push(domain.clone());
+				}
+			}
+		}
+	}
+
+	Ok(occupied)
+}
+
+fn program_issue_occupies_conflict_domain(
+	service_id: &str,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	retained_issue_ids: &std::collections::BTreeSet<String>,
+	snapshot: &ProgramIssueSnapshot,
+) -> Result<bool> {
+	let issue = &snapshot.issue;
+	let retained_nonterminal =
+		retained_issue_ids.contains(&issue.id) && !state_name_is_terminal(&issue.state.name, workflow);
+
+	Ok(snapshot.has_active_label
+		|| snapshot.has_needs_attention_label
+		|| retained_nonterminal
+		|| state_store.issue_has_active_shared_claim(service_id, &issue.id)?)
+}
+
+fn apply_execution_program_queue_actions<T>(
+	tracker: &T,
+	service_id: &str,
+	queue_label: &str,
+	program: ExecutionProgram,
+	issues_by_node: &std::collections::BTreeMap<String, ProgramIssueSnapshot>,
+	evaluations: &[ExecutionNodeEvaluation],
+	summary: &mut ProgramReconciliationSummary,
+) -> Result<ExecutionProgram>
+where
+	T: IssueTracker + ?Sized,
+{
+	let evaluations_by_node = evaluations
+		.iter()
+		.map(|evaluation| (evaluation.node_id().to_owned(), evaluation))
+		.collect::<std::collections::BTreeMap<_, _>>();
+	let mut final_nodes = Vec::with_capacity(program.nodes().len());
+
+	for node in program.nodes() {
+		let (Some(snapshot), Some(evaluation)) = (
+			issues_by_node.get(node.node_id()),
+			evaluations_by_node.get(node.node_id()),
+		) else {
+			final_nodes.push(node.clone());
+
+			continue;
+		};
+		let label_state = apply_execution_program_node_queue_action(
+			tracker,
+			service_id,
+			queue_label,
+			snapshot,
+			evaluation.queue_label_action(),
+			summary,
+		)?;
+		let mapping =
+			snapshot.linear_mapping(label_state.has_queue_label, label_state.program_owned)?;
+
+		final_nodes.push(node.clone().with_linear_issue(mapping)?);
+	}
+
+	program.with_nodes(final_nodes)
+}
+
+fn apply_execution_program_node_queue_action<T>(
+	tracker: &T,
+	service_id: &str,
+	queue_label: &str,
+	snapshot: &ProgramIssueSnapshot,
+	action: Option<ExecutionQueueLabelAction>,
+	summary: &mut ProgramReconciliationSummary,
+) -> Result<ProgramQueueLabelState>
+where
+	T: IssueTracker + ?Sized,
+{
+	match action {
+		Some(ExecutionQueueLabelAction::Apply) => {
+			if tracker::set_issue_label_presence(tracker, &snapshot.issue, queue_label, true)? {
+				summary.labels_applied += 1;
+			}
+
+			Ok(ProgramQueueLabelState { has_queue_label: true, program_owned: true })
+		},
+		Some(ExecutionQueueLabelAction::Retain) => {
+			summary.labels_retained += 1;
+
+			Ok(ProgramQueueLabelState { has_queue_label: true, program_owned: true })
+		},
+		Some(ExecutionQueueLabelAction::Remove) => {
+			if snapshot.queue_label_owned_by_current_program
+				&& tracker::set_issue_label_presence(tracker, &snapshot.issue, queue_label, false)?
+			{
+				summary.labels_removed += 1;
+			}
+
+			Ok(ProgramQueueLabelState { has_queue_label: false, program_owned: false })
+		},
+		None => {
+			if snapshot.has_queue_label && snapshot.queue_label_owned_by_current_program {
+				tracing::debug!(
+					project_id = service_id,
+					issue = snapshot.issue.identifier,
+					"Retained program-owned queue label without a readiness action."
+				);
+			}
+
+			Ok(ProgramQueueLabelState {
+				has_queue_label: snapshot.has_queue_label,
+				program_owned: snapshot.queue_label_owned_by_current_program,
+			})
+		},
+	}
+}

--- a/apps/decodex/src/orchestrator/tests.rs
+++ b/apps/decodex/src/orchestrator/tests.rs
@@ -75,6 +75,8 @@ include!("tests/runtime/failure.rs");
 
 include!("tests/runtime/loop_scenarios.rs");
 
+include!("tests/runtime/program_reconciler.rs");
+
 include!("tests/runtime/thread_archive.rs");
 
 include!("tests/recovery/reconciliation.rs");

--- a/apps/decodex/src/orchestrator/tests/runtime/program_reconciler.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/program_reconciler.rs
@@ -1,0 +1,349 @@
+mod program_reconciler {
+use std::collections::BTreeSet;
+
+use crate::execution_program::{
+	ExecutionConflictDomain, ExecutionConflictDomainKind, ExecutionLinearIssueMapping,
+	ExecutionProgram, ExecutionProgramDependency, ExecutionProgramNode, ExecutionProgramNodeStage,
+	ExecutionQueueIntent,
+};
+use crate::state::StateStore;
+use crate::tracker::{self, TrackerIssue, TrackerLabel};
+use crate::orchestrator;
+
+use crate::orchestrator::tests::{
+	FakeTracker, sample_issue_with_project_slug_and_sort_fields, temp_project_layout,
+};
+
+#[test]
+fn applies_ready_queue_label_and_repeated_reconcile_is_idempotent() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let issue = program_reconciler_issue("issue-ready", "PUB-201", "Todo", &[]);
+	let queued_issue = program_reconciler_issue(
+		"issue-ready",
+		"PUB-201",
+		"Todo",
+		&[program_reconciler_queue_label().as_str()],
+	);
+
+	store
+		.upsert_execution_program(
+			config.service_id(),
+			program_reconciler_program(vec![program_reconciler_node(
+				"node-ready",
+				&issue,
+				ExecutionQueueIntent::ReadyToQueue,
+			)]),
+		)
+		.expect("program should persist");
+
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+	let summary =
+		orchestrator::reconcile_execution_program_queue_labels(&tracker, &config, &workflow, &store)
+			.expect("ready reconcile should succeed");
+
+	assert_eq!(summary.labels_applied, 1);
+	assert_eq!(
+		tracker.label_additions.borrow().as_slice(),
+		&[(issue.id.clone(), vec![String::from("label-queued")])]
+	);
+
+	assert_program_owned_queue_label(&store, config.service_id(), &issue, true);
+
+	let tracker = FakeTracker::new(vec![queued_issue.clone()]);
+	let summary =
+		orchestrator::reconcile_execution_program_queue_labels(&tracker, &config, &workflow, &store)
+			.expect("idempotent reconcile should succeed");
+
+	assert_eq!(summary.labels_applied, 0);
+	assert_eq!(summary.labels_removed, 0);
+	assert_eq!(summary.labels_retained, 1);
+	assert!(tracker.label_additions.borrow().is_empty());
+	assert!(tracker.label_removals.borrow().is_empty());
+
+	assert_program_owned_queue_label(&store, config.service_id(), &queued_issue, true);
+}
+
+#[test]
+fn unlocks_downstream_node_when_dependency_reaches_terminal_state() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let dependency_todo = program_reconciler_issue("issue-dependency", "PUB-202", "Todo", &[]);
+	let dependency_done = program_reconciler_issue("issue-dependency", "PUB-202", "Done", &[]);
+	let dependent = program_reconciler_issue("issue-dependent", "PUB-203", "Todo", &[]);
+	let dependent_node = program_reconciler_node(
+		"node-dependent",
+		&dependent,
+		ExecutionQueueIntent::ReadyToQueue,
+	)
+	.with_dependencies([ExecutionProgramDependency::new("node-dependency")
+		.expect("dependency should build")])
+	.expect("dependency should attach");
+
+	store
+		.upsert_execution_program(
+			config.service_id(),
+			program_reconciler_program(vec![
+				program_reconciler_node(
+					"node-dependency",
+					&dependency_todo,
+					ExecutionQueueIntent::Done,
+				),
+				dependent_node,
+			]),
+		)
+		.expect("program should persist");
+
+	let tracker = FakeTracker::new(vec![dependency_todo, dependent.clone()]);
+	let blocked_summary =
+		orchestrator::reconcile_execution_program_queue_labels(&tracker, &config, &workflow, &store)
+			.expect("blocked reconcile should succeed");
+
+	assert_eq!(blocked_summary.labels_applied, 0);
+	assert!(tracker.label_additions.borrow().is_empty());
+
+	let tracker = FakeTracker::new(vec![dependency_done, dependent.clone()]);
+	let ready_summary =
+		orchestrator::reconcile_execution_program_queue_labels(&tracker, &config, &workflow, &store)
+			.expect("unlock reconcile should succeed");
+
+	assert_eq!(ready_summary.labels_applied, 1);
+	assert_eq!(
+		tracker.label_additions.borrow().as_slice(),
+		&[(dependent.id.clone(), vec![String::from("label-queued")])]
+	);
+}
+
+#[test]
+fn active_conflict_domain_holds_peer_node() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let active_label = tracker::automation_active_label(config.service_id());
+	let active_issue =
+		program_reconciler_issue("issue-active", "PUB-204", "In Progress", &[active_label.as_str()]);
+	let peer_issue = program_reconciler_issue("issue-peer", "PUB-205", "Todo", &[]);
+	let conflict = ExecutionConflictDomain::new(ExecutionConflictDomainKind::Module, "runtime")
+		.expect("conflict should build");
+
+	store
+		.upsert_execution_program(
+			config.service_id(),
+			program_reconciler_program(vec![
+				program_reconciler_node(
+					"node-active",
+					&active_issue,
+					ExecutionQueueIntent::Active,
+				)
+				.with_conflict_domains([conflict.clone()])
+				.expect("active conflict should attach"),
+				program_reconciler_node(
+					"node-peer",
+					&peer_issue,
+					ExecutionQueueIntent::ReadyToQueue,
+				)
+				.with_conflict_domains([conflict])
+				.expect("peer conflict should attach"),
+			]),
+		)
+		.expect("program should persist");
+
+	let tracker = FakeTracker::new(vec![active_issue, peer_issue]);
+	let summary =
+		orchestrator::reconcile_execution_program_queue_labels(&tracker, &config, &workflow, &store)
+			.expect("conflict reconcile should succeed");
+
+	assert_eq!(summary.labels_applied, 0);
+	assert!(tracker.label_additions.borrow().is_empty());
+}
+
+#[test]
+fn needs_attention_removes_only_program_owned_queue_label() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let queue_label = program_reconciler_queue_label();
+	let issue = program_reconciler_issue(
+		"issue-attention",
+		"PUB-206",
+		"Todo",
+		&[queue_label.as_str(), "decodex:needs-attention"],
+	);
+
+	store
+		.upsert_execution_program(
+			config.service_id(),
+			program_reconciler_program(vec![program_reconciler_node_with_mapping(
+				"node-attention",
+				&issue,
+				ExecutionQueueIntent::ReadyToQueue,
+				true,
+			)]),
+		)
+		.expect("program should persist");
+
+	assert_program_owned_queue_label(&store, config.service_id(), &issue, true);
+
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+	let summary =
+		orchestrator::reconcile_execution_program_queue_labels(&tracker, &config, &workflow, &store)
+			.expect("attention reconcile should succeed");
+
+	assert_eq!(summary.labels_removed, 1);
+	assert_eq!(
+		tracker.label_removals.borrow().as_slice(),
+		&[(issue.id.clone(), vec![String::from("label-queued")])]
+	);
+
+	assert_program_owned_queue_label(&store, config.service_id(), &issue, false);
+}
+
+#[test]
+fn human_owned_queue_label_is_not_removed_when_node_blocks() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let queue_label = program_reconciler_queue_label();
+	let issue =
+		program_reconciler_issue("issue-human", "PUB-207", "In Progress", &[queue_label.as_str()]);
+
+	store
+		.upsert_execution_program(
+			config.service_id(),
+			program_reconciler_program(vec![program_reconciler_node_with_mapping(
+				"node-human",
+				&issue,
+				ExecutionQueueIntent::ReadyToQueue,
+				false,
+			)]),
+		)
+		.expect("program should persist");
+
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+	let summary =
+		orchestrator::reconcile_execution_program_queue_labels(&tracker, &config, &workflow, &store)
+			.expect("human-owned reconcile should succeed");
+
+	assert_eq!(summary.labels_removed, 0);
+	assert!(tracker.label_removals.borrow().is_empty());
+
+	assert_program_owned_queue_label(&store, config.service_id(), &issue, false);
+}
+
+fn program_reconciler_program(nodes: Vec<ExecutionProgramNode>) -> ExecutionProgram {
+	ExecutionProgram::from_issue_batch_intake(
+		"program-reconciler",
+		"pubfi",
+		"program-reconciler-fingerprint",
+		"Program reconciler test intake.",
+		nodes,
+	)
+	.expect("program should build")
+}
+
+fn program_reconciler_node(
+	node_id: &str,
+	issue: &TrackerIssue,
+	queue_intent: ExecutionQueueIntent,
+) -> ExecutionProgramNode {
+	program_reconciler_node_with_mapping(node_id, issue, queue_intent, false)
+}
+
+fn program_reconciler_node_with_mapping(
+	node_id: &str,
+	issue: &TrackerIssue,
+	queue_intent: ExecutionQueueIntent,
+	program_owned_queue_label: bool,
+) -> ExecutionProgramNode {
+	let mapping = program_reconciler_mapping(issue, program_owned_queue_label);
+
+	ExecutionProgramNode::new(
+		node_id,
+		ExecutionProgramNodeStage::Runtime,
+		format!("Resolve {}.", issue.identifier),
+		queue_intent,
+	)
+	.expect("node should build")
+	.with_acceptance_expectations([format!("{} is executable.", issue.identifier)])
+	.expect("acceptance should attach")
+	.with_validation_expectations([String::from("Run focused validation.")])
+	.expect("validation should attach")
+	.with_linear_issue(mapping)
+	.expect("issue mapping should attach")
+}
+
+fn program_reconciler_mapping(
+	issue: &TrackerIssue,
+	program_owned_queue_label: bool,
+) -> ExecutionLinearIssueMapping {
+	let mut mapping =
+		ExecutionLinearIssueMapping::new(&issue.id, &issue.identifier, &issue.state.name)
+			.expect("mapping should build");
+
+	mapping = if program_owned_queue_label {
+		mapping.with_program_owned_queue_label(true)
+	} else {
+		mapping.with_queue_label(issue.has_label(&program_reconciler_queue_label()))
+	};
+
+	mapping
+		.with_active_label(issue.has_label(&tracker::automation_active_label("pubfi")))
+		.with_opt_out_label(issue.has_label("decodex:manual-only"))
+		.with_needs_attention_label(issue.has_label("decodex:needs-attention"))
+		.with_open_tracker_blockers(!issue.blockers.is_empty())
+}
+
+fn program_reconciler_issue(
+	id: &str,
+	identifier: &str,
+	state_name: &str,
+	labels: &[&str],
+) -> TrackerIssue {
+	let mut issue = sample_issue_with_project_slug_and_sort_fields(
+		id,
+		identifier,
+		"pubfi",
+		state_name,
+		&[],
+		Some(3),
+		"2026-06-12T00:00:00.000Z",
+	);
+
+	issue.labels = labels
+		.iter()
+		.copied()
+		.collect::<BTreeSet<_>>()
+		.into_iter()
+		.enumerate()
+		.map(|(index, label)| TrackerLabel {
+			id: format!("label-current-{index}"),
+			name: label.to_owned(),
+		})
+		.collect();
+
+	issue
+}
+
+fn program_reconciler_queue_label() -> String {
+	tracker::automation_queue_label("pubfi")
+}
+
+fn assert_program_owned_queue_label(
+	store: &StateStore,
+	service_id: &str,
+	issue: &TrackerIssue,
+	expected_present: bool,
+) {
+	let records = store
+		.program_queue_label_ownership_for_issue(
+			service_id,
+			&issue.id,
+			&program_reconciler_queue_label(),
+		)
+		.expect("ownership records should load");
+
+	assert_eq!(
+		!records.is_empty(),
+		expected_present,
+		"program-owned queue-label evidence mismatch for {}",
+		issue.identifier
+	);
+}
+}

--- a/apps/decodex/src/program_intake.rs
+++ b/apps/decodex/src/program_intake.rs
@@ -487,6 +487,7 @@ fn issue_node(
 		.with_active_label(facts.has_active_label)
 		.with_opt_out_label(facts.has_opt_out_label)
 		.with_needs_attention_label(facts.has_needs_attention_label)
+		.with_open_tracker_blockers(facts.has_open_blockers)
 		.with_generic_dispatch_briefing(facts.has_generic_dispatch_briefing);
 
 	ExecutionProgramNode::new(

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -42,6 +42,11 @@ Decodex currently runs as a local, single-machine control plane:
   active, and superseded counts may appear when the runtime has that detail. Low-level
   node edges, graph operations, and queue-label ownership records remain internal
   runtime state.
+- Persisted Execution Programs are reconciled during normal Linear scan ticks before
+  issue selection. Ready, startable, program-owned mapped nodes can receive the
+  service queue label automatically; blocked, stale, paused, terminal,
+  attention-required, active, or conflict-held nodes stay unqueued. Human-owned or
+  ownership-unknown queue labels are preserved.
 
 Decodex App is a native shell over the same local runtime and account-pool state. On
 launch it connects to an existing default local listener when one is reachable; if
@@ -126,8 +131,9 @@ registered-project table, but a service is only eligible to intake
 Linear issues labeled with its matching `decodex:queued:<service-id>` label. For
 example, a Decodex-only run intakes issues labeled `decodex:queued:decodex`; `rsnap`
 can stay enabled in the full project registry, and issues labeled `decodex:queued:rsnap`
-remain rsnap intake rather than Decodex intake. The pilot runbook owns enqueue and
-run steps.
+remain rsnap intake rather than Decodex intake. Operators may still enqueue normal
+issues manually, but program-owned queue labels are applied and removed by the runtime
+reconciler when persisted Execution Program readiness changes.
 
 When `decodex run --dry-run` or the status output has no eligible intake candidate,
 the operator hint points to the short checklist: `Todo`, the service-scoped

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -70,6 +70,14 @@ state or this state machine.
   `--persist` writes only local runtime Program Intake and Execution Program state;
   queue labels remain untouched until a later reconciliation surface is explicitly
   authorized.
+- On each normal Linear scan tick, the control plane reconciles persisted Execution
+  Programs before normal issue selection. The reconciler refreshes mapped Linear
+  issue state, dependency observations, local active leases, retained review/landing
+  worktrees, needs-attention labels, and occupied conflict domains; then it applies
+  or removes only the service queue label decisions authorized by the Execution
+  Program readiness evaluator. It must not dispatch app-server runs directly. Any
+  newly queued issue still enters execution through the ordinary queue scan,
+  dispatch policy, lease acquisition, and scheduler path.
 
 The evidence boundary is ordered from private runtime authority to public collaboration
 mirror:
@@ -694,6 +702,14 @@ After a process restart, recent-run history, active lease ownership, retained po
 - While the control plane is supervising an active child process, stall detection must consult the child-updated `.decodex-run-activity` marker for the current `run_id` plus `attempt_number` and the persisted runtime event journal. A retained marker only proves a live process when its PID is still alive on the current host boot and the process start identity still matches; after power loss, reboot, or same-boot PID reuse, recovery must clear the reconstructed lease and re-enter the retained lane through retry-style dispatch instead of preserving the old running state.
 - Retry-style recovery prompts must tell the next agent to treat the current worktree, tracker state, runtime-store records, and protocol events as durable truth, use marker files only as diagnostic liveness breadcrumbs, inspect the branch/diff/recent validation evidence first, and continue from partial work rather than assuming prior in-memory model/tool state survived.
 - While the control plane owns a queued retry entry, that queued claim must take priority over normal candidate selection for the affected project.
+- While the control plane evaluates persisted Execution Programs, program-owned ready
+  nodes may receive `decodex:queued:<service-id>` only when their mapped Linear issue
+  is startable, non-terminal, briefed for generic dispatch, free of opt-out and
+  needs-attention labels, not already active, and not blocked by dependency or
+  occupied conflict-domain evidence. Blocked, stale, paused, terminal, active, or
+  attention-required nodes must not receive the label, and the reconciler may remove
+  the service queue label only when matching local ownership evidence identifies the
+  same service, program, node, issue, and label.
 - While the control plane is idle between lanes, it may reload the configured project `WORKFLOW.md` on each tick and immediately apply a newly valid document to future dispatch, retry, post-exit reconciliation, and prompt generation.
 - If that same configured `WORKFLOW.md` path becomes invalid after a successful load, the control plane must log the reload failure and keep the last known good document active instead of dropping the tick or clearing runtime policy.
 - If the leased issue becomes terminal during a control-plane tick, `decodex` must stop the active run, mark the attempt `terminated`, clear the lease, and then retain or clean the worktree according to the retention rules above.

--- a/docs/spec/tracker-tools.md
+++ b/docs/spec/tracker-tools.md
@@ -120,11 +120,15 @@ In either invalid case, `decodex` must fail the attempt rather than infer which 
   issue-description payloads. Queue-label mutations for generated issues must follow
   the Execution Program readiness evaluator: only ready nodes mapped to normal
   startable Linear issues may receive or retain `decodex:queued:<service-id>`.
-  Program reconciliation must record when it applied that label for a specific
-  service, program, node, and issue. It may remove only labels with matching
+  Program reconciliation runs as part of the normal control-plane scan path and must
+  use current tracker issue state, dependency observations, active leases,
+  review/landing ownership, attention labels, and occupied conflict domains before
+  mutating labels. It must record when it applied that label for a specific service,
+  program, node, issue, and label. It may remove only labels with matching
   program-owned evidence. If the same queue label is present without matching
   ownership evidence, the label is human-owned or ownership-unknown and must be left
-  in place.
+  in place. A reconciled label only feeds the existing scheduler queue scan; it must
+  not directly start an app-server run.
 - `decodex intake issues ... --dry-run` may read tracker state for supplied issues
   and render a local ready/held/blocked/stale/unmapped report, but it must not call
   tracker label mutation tools or write Linear comments. `--persist` may write local


### PR DESCRIPTION
## Summary
- add runtime reconciliation for persisted Execution Programs before normal issue selection
- refresh mapped issue state, blockers, attention/active labels, conflict-domain occupancy, and program-owned queue-label state
- apply/remove only program-owned service queue labels and document the control-plane behavior

## Verification
- cargo make fmt
- cargo make lint-fix
- cargo make test (1074 passed, 1 skipped)
- cargo test -p decodex program_reconciler --lib (5 passed)

Retained lane recovery: XY-939 was manually completed from `.worktrees/XY-939` after Decodex marked partial progress retained.