### PR TITLE
Implement goal intake materialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ cargo run -p decodex --bin decodex -- lane steer <ISSUE> --run-id <RUN_ID> --exp
 cargo run -p decodex --bin decodex -- research compile --intent "research X"
 cargo run -p decodex --bin decodex -- research compile --input research-design-run.json
 cargo run -p decodex --bin decodex -- research promote <CONTRACT_ID>
+cargo run -p decodex --bin decodex -- intake goal --project decodex <CONTRACT_ID> --dry-run
+cargo run -p decodex --bin decodex -- intake goal --project decodex <CONTRACT_ID> --apply
 cargo run -p decodex --bin decodex -- intake issues --project decodex XY-1 XY-2 --dry-run
 cargo run -p decodex --bin decodex -- radar refresh-upstream-queue
 cargo run -p decodex --bin decodex -- radar refresh-release-delta
@@ -154,6 +156,15 @@ outcomes distinguish `decision_ready`, `not_decision_ready`, `blocked`, and
 tracker state, set goals, or authorize implementation. `decodex research promote`
 records explicit acceptance for a stored contract; only promoted contracts may later
 feed issue shaping or internal Execution Program readiness.
+
+`decodex intake goal` materializes a promoted Decision Contract. `--dry-run` prints
+the proposed normal Linear issues, dependencies, conflict domains, and queue plan
+without mutating Linear or local Program Intake rows. `--apply` creates or updates the
+generated normal Linear issue briefs and persists the internal Execution Program plus
+contract/program links in runtime SQLite. Apply does not run implementation or apply
+queue labels; later reconciliation owns queue-label changes. If the contract is still
+latent, needs a decision, or lacks issue-shaping authority, intake stops before
+creating executable work.
 
 ### Install from Source
 

--- a/apps/decodex/src/cli.rs
+++ b/apps/decodex/src/cli.rs
@@ -26,7 +26,7 @@ use crate::{
 		LaneSteerRequest, RunOnceRequest, ServeRequest,
 	},
 	prelude::{Result, eyre},
-	program_intake::{self, IssueBatchIntakeCommandRequest},
+	program_intake::{self, GoalIntakeCommandRequest, IssueBatchIntakeCommandRequest},
 	radar::{
 		self, RadarBackfillReleaseRangeRequest, RadarBundleBuildRequest,
 		RadarBundleValidateRequest, RadarLedgerArtifactLinkRequest, RadarLedgerBootstrapRequest,
@@ -628,8 +628,53 @@ struct IntakeCommand {
 impl IntakeCommand {
 	fn run(&self) -> Result<()> {
 		match &self.command {
+			IntakeSubcommand::Goal(args) => args.run(),
 			IntakeSubcommand::Issues(args) => args.run(),
 		}
+	}
+}
+
+#[derive(Debug, Args)]
+struct IntakeGoalCommand {
+	#[command(flatten)]
+	project_config: ProjectConfigArgs,
+	/// Registered Decodex service id to intake against.
+	#[arg(long, value_name = "SERVICE_ID", conflicts_with = "config")]
+	project: Option<String>,
+	/// Read tracker state and print the deterministic goal-intake report without mutation.
+	#[arg(long, conflicts_with = "apply", required_unless_present = "apply")]
+	dry_run: bool,
+	/// Create or update generated normal Linear issues and persist local Program Intake state.
+	#[arg(long, conflicts_with = "dry_run")]
+	apply: bool,
+	/// Existing Linear issue whose team and startable state should anchor generated issues.
+	#[arg(long, value_name = "ISSUE")]
+	team_issue: Option<String>,
+	/// Emit structured JSON instead of human-readable text.
+	#[arg(long)]
+	json: bool,
+	/// Accepted Decision Contract identifier to materialize.
+	#[arg(value_name = "CONTRACT_ID")]
+	contract_id: String,
+}
+impl IntakeGoalCommand {
+	fn run(&self) -> Result<()> {
+		let report = program_intake::run_goal_intake_command(GoalIntakeCommandRequest {
+			config_path: self.project_config.as_path(),
+			project_id: self.project.as_deref(),
+			contract_id: &self.contract_id,
+			team_issue_identifier: self.team_issue.as_deref(),
+			dry_run: self.dry_run,
+			apply: self.apply,
+		})?;
+
+		if self.json {
+			println!("{}", serde_json::to_string_pretty(&report)?);
+		} else {
+			print!("{}", program_intake::render_goal_intake_report(&report));
+		}
+
+		Ok(())
 	}
 }
 
@@ -1605,6 +1650,8 @@ enum ResearchSubcommand {
 
 #[derive(Debug, Subcommand)]
 enum IntakeSubcommand {
+	/// Dry-run or apply a promoted Decision Contract as normal issue-backed goal intake.
+	Goal(IntakeGoalCommand),
 	/// Dry-run or persist existing Linear issues as an internal program intake batch.
 	Issues(IntakeIssuesCommand),
 }
@@ -1773,12 +1820,12 @@ mod tests {
 
 	use crate::cli::{
 		AccountCommand, AccountSubcommand, AccountUseCommand, AttemptCommand, Cli, Command,
-		CommitCommand, DiagnoseCommand, EvidenceCommand, IntakeCommand, IntakeIssuesCommand,
-		IntakeSubcommand, LandCommand, LaneCommand, LaneInspectCommand, LaneInterruptCommand,
-		LaneSteerCommand, LaneSubcommand, LegacyCloseoutRecoveryCommand, ProbeCommand,
-		ProjectCommand, ProjectConfigArgs, ProjectSubcommand, RadarBackfillReleaseRangeCommand,
-		RadarBundleBuildCommand, RadarBundleCommand, RadarBundleSubcommand,
-		RadarBundleValidateCommand, RadarCommand, RadarLedgerCommand,
+		CommitCommand, DiagnoseCommand, EvidenceCommand, IntakeCommand, IntakeGoalCommand,
+		IntakeIssuesCommand, IntakeSubcommand, LandCommand, LaneCommand, LaneInspectCommand,
+		LaneInterruptCommand, LaneSteerCommand, LaneSubcommand, LegacyCloseoutRecoveryCommand,
+		ProbeCommand, ProjectCommand, ProjectConfigArgs, ProjectSubcommand,
+		RadarBackfillReleaseRangeCommand, RadarBundleBuildCommand, RadarBundleCommand,
+		RadarBundleSubcommand, RadarBundleValidateCommand, RadarCommand, RadarLedgerCommand,
 		RadarLedgerIngestExistingCommand, RadarLedgerSubcommand, RadarLedgerSummaryCommand,
 		RadarRefreshReleaseDeltaCommand, RadarRefreshUpstreamQueueCommand,
 		RadarRenderSignalCommand, RadarSubcommand, RadarValidateCommand, RecoverCommand,
@@ -2563,6 +2610,37 @@ mod tests {
 					..
 				})
 			}) if issues == vec![String::from("XY-1"), String::from("XY-2")]
+		));
+	}
+
+	#[test]
+	fn parses_intake_goal_apply_with_project_and_team_anchor() {
+		let cli = Cli::parse_from([
+			"decodex",
+			"intake",
+			"goal",
+			"--project",
+			"decodex",
+			"goal-intake-contract",
+			"--apply",
+			"--team-issue",
+			"XY-852",
+			"--json",
+		]);
+
+		assert!(matches!(
+			cli.command,
+			Command::Intake(IntakeCommand {
+				command: IntakeSubcommand::Goal(IntakeGoalCommand {
+					project: Some(_),
+					contract_id,
+					dry_run: false,
+					apply: true,
+					team_issue: Some(team_issue),
+					json: true,
+					..
+				})
+			}) if contract_id == "goal-intake-contract" && team_issue == "XY-852"
 		));
 	}
 

--- a/apps/decodex/src/loop_contract.rs
+++ b/apps/decodex/src/loop_contract.rs
@@ -93,6 +93,25 @@ impl DecisionContract {
 		&self.links
 	}
 
+	pub(crate) fn link_generated_execution_surfaces(
+		&mut self,
+		issue_ids: impl IntoIterator<Item = impl Into<String>>,
+		issue_identifiers: impl IntoIterator<Item = impl Into<String>>,
+		node_ids: impl IntoIterator<Item = impl Into<String>>,
+	) -> Result<()> {
+		let mut candidate = self.clone();
+
+		candidate.links.generated_issue_ids = normalized_link_values(issue_ids)?;
+		candidate.links.generated_issue_identifiers = normalized_link_values(issue_identifiers)?;
+		candidate.links.execution_program_node_ids = normalized_link_values(node_ids)?;
+
+		candidate.validate()?;
+
+		*self = candidate;
+
+		Ok(())
+	}
+
 	pub(crate) fn validate(&self) -> Result<()> {
 		validate_required("decision contract schema", &self.schema)?;
 		validate_required("decision contract contract_id", &self.contract_id)?;
@@ -367,6 +386,18 @@ impl DecisionAcceptedAuthority {
 		&self.non_goals
 	}
 
+	pub(crate) fn constraints(&self) -> &[String] {
+		&self.constraints
+	}
+
+	pub(crate) fn assumptions(&self) -> &[String] {
+		&self.assumptions
+	}
+
+	pub(crate) fn objections(&self) -> &[String] {
+		&self.objections
+	}
+
 	pub(crate) fn stop_conditions(&self) -> &[String] {
 		&self.stop_conditions
 	}
@@ -425,6 +456,18 @@ impl DecisionExecutionReadiness {
 
 	pub(crate) fn conflict_domains(&self) -> &[String] {
 		&self.conflict_domains
+	}
+
+	pub(crate) fn validation_expectations(&self) -> &[String] {
+		&self.validation_expectations
+	}
+
+	pub(crate) fn risk_notes(&self) -> &[String] {
+		&self.risk_notes
+	}
+
+	pub(crate) fn queue_intent(&self) -> &[String] {
+		&self.queue_intent
 	}
 
 	fn validate(&self, status: DecisionContractStatus) -> Result<()> {
@@ -690,6 +733,25 @@ fn validate_string_list(name: &str, values: &[String]) -> Result<()> {
 	Ok(())
 }
 
+fn normalized_link_values(
+	values: impl IntoIterator<Item = impl Into<String>>,
+) -> Result<Vec<String>> {
+	let mut normalized = Vec::new();
+
+	for value in values {
+		let value = value.into();
+		let value = value.trim();
+
+		validate_required("decision contract generated link", value)?;
+
+		if !normalized.iter().any(|existing| existing == value) {
+			normalized.push(value.to_owned());
+		}
+	}
+
+	Ok(normalized)
+}
+
 #[cfg(test)]
 mod tests {
 	use crate::loop_contract::{
@@ -823,6 +885,24 @@ mod tests {
 		contract.evidence_boundary.private_evidence_refs[0].record_id = Some(0);
 
 		assert!(contract.validate().is_err());
+	}
+
+	#[test]
+	fn generated_execution_links_are_normalized_and_validated() {
+		let mut contract = latent_research_contract_fixture();
+
+		contract
+			.link_generated_execution_surfaces(
+				[" issue-1 ", "issue-1", "issue-2"],
+				["XY-1", " XY-2 "],
+				["node-1", "node-1"],
+			)
+			.expect("links should attach");
+
+		assert_eq!(contract.links().generated_issue_ids(), &["issue-1", "issue-2"]);
+		assert_eq!(contract.links().generated_issue_identifiers(), &["XY-1", "XY-2"]);
+		assert_eq!(contract.links().execution_program_node_ids(), &["node-1"]);
+		assert!(contract.link_generated_execution_surfaces([" "], ["XY-1"], ["node-1"]).is_err());
 	}
 
 	#[test]

--- a/apps/decodex/src/program_intake.rs
+++ b/apps/decodex/src/program_intake.rs
@@ -14,15 +14,20 @@ use crate::{
 	execution_program::{
 		ExecutionConflictDomain, ExecutionConflictDomainKind, ExecutionDependencySnapshot,
 		ExecutionLinearIssueMapping, ExecutionNodeEvaluation, ExecutionProgram,
-		ExecutionProgramDependency, ExecutionProgramNode, ExecutionProgramNodeLifecycleState,
-		ExecutionProgramNodeStage, ExecutionProgramReadinessContext, ExecutionQueueIntent,
-		ExecutionQueueLabelAction, ExecutionWorkflowPolicy,
+		ExecutionProgramDependency, ExecutionProgramEvaluation, ExecutionProgramNode,
+		ExecutionProgramNodeLifecycleState, ExecutionProgramNodeStage,
+		ExecutionProgramReadinessContext, ExecutionQueueIntent, ExecutionQueueLabelAction,
+		ExecutionWorkflowPolicy,
 	},
+	loop_contract::{DecisionContract, DecisionContractStatus},
 	orchestrator,
 	prelude::{Result, eyre},
 	runtime,
 	state::StateStore,
-	tracker::{self, IssueTracker, TrackerIssue, linear::LinearClient},
+	tracker::{
+		self, IssueTracker, TrackerIssue, TrackerIssueBriefUpdate, TrackerIssueCreate,
+		linear::LinearClient, public_text,
+	},
 	workflow::WorkflowDocument,
 };
 
@@ -33,6 +38,45 @@ pub(crate) struct IssueBatchIntakeCommandRequest<'a> {
 	pub(crate) issue_identifiers: Vec<String>,
 	pub(crate) dry_run: bool,
 	pub(crate) persist: bool,
+}
+
+/// CLI/runtime request for promoted-goal Program Intake.
+pub(crate) struct GoalIntakeCommandRequest<'a> {
+	/// Project config override, if supplied.
+	pub(crate) config_path: Option<&'a Path>,
+	/// Registered service id to intake against.
+	pub(crate) project_id: Option<&'a str>,
+	/// Accepted Decision Contract id to materialize.
+	pub(crate) contract_id: &'a str,
+	/// Optional Linear issue whose team/startable state should anchor generated issues.
+	pub(crate) team_issue_identifier: Option<&'a str>,
+	/// Read and render the proposed materialization without mutating Linear or local intake rows.
+	pub(crate) dry_run: bool,
+	/// Create or update generated Linear issues and persist the Execution Program.
+	pub(crate) apply: bool,
+}
+
+/// In-process request for promoted-goal Program Intake.
+pub(crate) struct GoalIntakeRunRequest<'a, T>
+where
+	T: IssueTracker + ?Sized,
+{
+	/// Runtime state store used for Decision Contract and program persistence.
+	pub(crate) state_store: &'a StateStore,
+	/// Tracker adapter used for Linear reads and apply-mode writes.
+	pub(crate) tracker: &'a T,
+	/// Registered service config that owns this intake.
+	pub(crate) config: &'a ServiceConfig,
+	/// Registered workflow document for queue and startable-state policy.
+	pub(crate) workflow: &'a WorkflowDocument,
+	/// Accepted Decision Contract id to materialize.
+	pub(crate) contract_id: &'a str,
+	/// Optional Linear issue whose team/startable state should anchor generated issues.
+	pub(crate) team_issue_identifier: Option<String>,
+	/// Read and render without mutation.
+	pub(crate) dry_run: bool,
+	/// Create/update Linear issues and persist local intake rows.
+	pub(crate) apply: bool,
 }
 
 /// Deterministic report for one issue-batch Program Intake run.
@@ -92,6 +136,58 @@ pub(crate) struct IssueBatchIntakeIssueReport {
 	pub(crate) conflict_domains: Vec<String>,
 }
 
+/// Deterministic report for one promoted-goal Program Intake run.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct GoalIntakeReport {
+	/// Registered service id that owns this intake.
+	pub(crate) service_id: String,
+	/// Accepted Decision Contract that authorized the materialization.
+	pub(crate) contract_id: String,
+	/// Internal program id derived from the accepted goal.
+	pub(crate) program_id: String,
+	/// Whether this run was explicitly dry-run only.
+	pub(crate) dry_run: bool,
+	/// Whether Linear issues were created or updated.
+	pub(crate) applied: bool,
+	/// Whether local runtime Program Intake records were persisted.
+	pub(crate) persisted: bool,
+	/// Service-scoped queue label later reconciliation may apply.
+	pub(crate) queue_label: String,
+	/// Per-issue materialization rows.
+	pub(crate) issues: Vec<GoalIntakeIssueReport>,
+}
+
+/// Per-issue promoted-goal materialization row.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct GoalIntakeIssueReport {
+	/// Internal Execution Program node id.
+	pub(crate) node_id: String,
+	/// Public issue title.
+	pub(crate) title: String,
+	/// Natural-language objective for this generated issue.
+	pub(crate) objective: String,
+	/// Linear issue id after apply, or the linked id found during dry-run.
+	pub(crate) issue_id: Option<String>,
+	/// Linear issue identifier after apply, or the linked identifier found during dry-run.
+	pub(crate) issue_identifier: Option<String>,
+	/// Whether apply would create/update or did create/update the issue.
+	pub(crate) action: GoalIntakeIssueAction,
+	/// Queue intent stored on the internal program node.
+	pub(crate) queue_intent: String,
+	/// Queue-label action derived for the mapped node, when known.
+	pub(crate) queue_label_action: Option<String>,
+	/// Dependency ids or public issue identifiers required before this node can run.
+	pub(crate) dependencies: Vec<String>,
+	/// Coarse conflict domains retained in the internal program.
+	pub(crate) conflict_domains: Vec<String>,
+	/// Acceptance expectations rendered into the public issue brief.
+	pub(crate) acceptance: Vec<String>,
+	/// Validation expectations rendered into the public issue brief.
+	pub(crate) validation: Vec<String>,
+	/// Deterministic local readback reasons.
+	pub(crate) reasons: Vec<String>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct IssueFacts {
 	has_queue_label: bool,
@@ -102,6 +198,48 @@ struct IssueFacts {
 	has_generic_dispatch_briefing: bool,
 	has_open_blockers: bool,
 	has_human_owned_queue_label: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct GoalIssuePlan {
+	node_id: String,
+	title: String,
+	objective: String,
+	description: String,
+	dependencies: Vec<String>,
+	conflict_domains: Vec<ExecutionConflictDomain>,
+	acceptance: Vec<String>,
+	validation: Vec<String>,
+}
+
+struct GoalIntakeAnchor {
+	team_id: String,
+	state_id: String,
+}
+
+struct GoalIssueBriefInput<'a> {
+	contract: &'a DecisionContract,
+	program_id: &'a str,
+	node_id: &'a str,
+	objective: &'a str,
+	dependencies: &'a [String],
+	conflict_domains: &'a [ExecutionConflictDomain],
+	acceptance: &'a [String],
+	validation: &'a [String],
+}
+
+struct ApplyGoalIssuesInput<'a, T>
+where
+	T: IssueTracker + ?Sized,
+{
+	state_store: &'a StateStore,
+	service_id: &'a str,
+	source_issue_id: Option<&'a str>,
+	tracker: &'a T,
+	contract: &'a DecisionContract,
+	plans: &'a [GoalIssuePlan],
+	linked_issues: &'a [Option<TrackerIssue>],
+	anchor: &'a GoalIntakeAnchor,
 }
 
 /// Normalized issue-batch intake classification.
@@ -127,6 +265,30 @@ impl IssueBatchIntakeClassification {
 			Self::Blocked => "blocked",
 			Self::Stale => "stale",
 			Self::Unmapped => "unmapped",
+		}
+	}
+}
+
+/// Promoted-goal materialization action.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum GoalIntakeIssueAction {
+	/// Dry-run would create a new normal Linear issue.
+	WouldCreate,
+	/// Dry-run would update an already linked normal Linear issue.
+	WouldUpdate,
+	/// Apply created a new normal Linear issue.
+	Created,
+	/// Apply updated an already linked normal Linear issue.
+	Updated,
+}
+impl GoalIntakeIssueAction {
+	fn as_str(self) -> &'static str {
+		match self {
+			Self::WouldCreate => "would_create",
+			Self::WouldUpdate => "would_update",
+			Self::Created => "created",
+			Self::Updated => "updated",
 		}
 	}
 }
@@ -158,6 +320,124 @@ pub(crate) fn run_issue_batch_intake_command(
 		request.dry_run,
 		request.persist,
 	)
+}
+
+/// Run promoted-goal intake through the configured Linear tracker.
+pub(crate) fn run_goal_intake_command(
+	request: GoalIntakeCommandRequest<'_>,
+) -> Result<GoalIntakeReport> {
+	if request.dry_run == request.apply {
+		eyre::bail!("Goal intake requires exactly one of --dry-run or --apply.");
+	}
+
+	let state_store = runtime::open_runtime_store()?;
+	let config_path =
+		resolve_intake_project_config_path(request.config_path, request.project_id, &state_store)?;
+	let config = ServiceConfig::from_path(&config_path)?;
+	let workflow = WorkflowDocument::from_path(config.workflow_path())?;
+
+	register_intake_project_config_for_persist(&state_store, &config_path, request.apply)?;
+
+	let tracker = LinearClient::new(config.tracker().resolve_api_key()?)?;
+
+	run_goal_intake(GoalIntakeRunRequest {
+		state_store: &state_store,
+		tracker: &tracker,
+		config: &config,
+		workflow: &workflow,
+		contract_id: request.contract_id,
+		team_issue_identifier: request.team_issue_identifier.map(str::to_owned),
+		dry_run: request.dry_run,
+		apply: request.apply,
+	})
+}
+
+/// Build and optionally apply a promoted-goal materialization plan.
+pub(crate) fn run_goal_intake<T>(request: GoalIntakeRunRequest<'_, T>) -> Result<GoalIntakeReport>
+where
+	T: IssueTracker + ?Sized,
+{
+	let GoalIntakeRunRequest {
+		state_store,
+		tracker,
+		config,
+		workflow,
+		contract_id,
+		team_issue_identifier,
+		dry_run,
+		apply,
+	} = request;
+
+	if dry_run == apply {
+		eyre::bail!("Goal intake requires exactly one of dry_run or apply.");
+	}
+
+	let record = state_store
+		.decision_contract(config.service_id(), contract_id)?
+		.ok_or_else(|| eyre::eyre!("Decision Contract `{contract_id}` does not exist."))?;
+	let contract = record.contract().clone();
+
+	ensure_goal_intake_authority(&contract)?;
+
+	let program_id = goal_program_id(config.service_id(), contract.contract_id());
+	let plans = goal_issue_plans(&contract, &program_id)?;
+	let queue_label = tracker::automation_queue_label(config.service_id());
+	let linked_issues = linked_goal_issues(tracker, &contract, plans.len())?;
+	let (issues, linked_contract) = if apply {
+		let anchor = goal_intake_anchor(
+			tracker,
+			workflow,
+			team_issue_identifier
+				.or_else(|| record.source_issue_id().map(str::to_owned))
+				.or_else(|| contract.source_intent().source_issue_identifier().map(str::to_owned)),
+		)?;
+
+		apply_goal_issues_and_link_contract(ApplyGoalIssuesInput {
+			state_store,
+			service_id: config.service_id(),
+			source_issue_id: record.source_issue_id(),
+			tracker,
+			contract: &contract,
+			plans: &plans,
+			linked_issues: &linked_issues,
+			anchor: &anchor,
+		})?
+	} else {
+		(Vec::new(), contract.clone())
+	};
+	let report_issues = if apply {
+		let program = goal_execution_program(
+			config.service_id(),
+			&program_id,
+			&linked_contract,
+			&plans,
+			&issues,
+			workflow,
+		)?;
+		let evaluation = program.evaluate(
+			&linked_contract,
+			&ExecutionWorkflowPolicy::from_workflow(config.service_id(), workflow)?,
+			&ExecutionProgramReadinessContext::new(),
+		)?;
+		let rows = applied_goal_issue_rows(&plans, &issues, &linked_issues, &evaluation);
+
+		state_store.upsert_execution_program(config.service_id(), program)?;
+
+		rows
+	} else {
+		dry_run_goal_issue_rows(&plans, &linked_issues)
+	};
+
+	Ok(GoalIntakeReport {
+		service_id: config.service_id().to_owned(),
+		contract_id: contract.contract_id().to_owned(),
+		program_id,
+		dry_run,
+		applied: apply,
+		persisted: apply,
+		queue_label,
+		issues: report_issues,
+	})
 }
 
 /// Build and optionally persist a non-mutating issue-batch intake report.
@@ -314,6 +594,613 @@ pub(crate) fn render_issue_batch_intake_report(report: &IssueBatchIntakeReport) 
 	}
 
 	output
+}
+
+/// Render a compact human-readable promoted-goal intake report.
+pub(crate) fn render_goal_intake_report(report: &GoalIntakeReport) -> String {
+	let mode = if report.applied { "apply" } else { "dry-run" };
+	let mut output = format!(
+		"goal intake {mode}: service={} contract={} program={} queue_label={} issues={} persisted={}\n",
+		report.service_id,
+		report.contract_id,
+		report.program_id,
+		report.queue_label,
+		report.issues.len(),
+		report.persisted,
+	);
+
+	for row in &report.issues {
+		let issue = row.issue_identifier.as_deref().unwrap_or("new");
+		let queue_action = row.queue_label_action.as_deref().unwrap_or("none");
+		let dependencies = list_or_none(&row.dependencies);
+		let conflicts = list_or_none(&row.conflict_domains);
+		let reasons = list_or_none(&row.reasons);
+
+		output.push_str(&format!(
+			"- {} action={} issue={} queue_intent={} queue_action={} dependencies={} conflict_domains={} reasons={}\n",
+			row.node_id,
+			row.action.as_str(),
+			issue,
+			row.queue_intent,
+			queue_action,
+			dependencies,
+			conflicts,
+			reasons,
+		));
+	}
+
+	output
+}
+
+fn ensure_goal_intake_authority(contract: &DecisionContract) -> Result<()> {
+	if contract.status() != DecisionContractStatus::AcceptedPromoted {
+		eyre::bail!(
+			"Decision Contract `{}` is `{}`; goal intake requires accepted execution authority.",
+			contract.contract_id(),
+			contract.status().as_str()
+		);
+	}
+	if !contract.execution_readiness().ready_for_issue_shaping() {
+		eyre::bail!(
+			"Decision Contract `{}` is not ready for issue shaping.",
+			contract.contract_id()
+		);
+	}
+	if !contract.execution_readiness().missing_decisions().is_empty() {
+		eyre::bail!(
+			"Decision Contract `{}` still has unresolved decisions.",
+			contract.contract_id()
+		);
+	}
+	if contract.execution_readiness().proposed_issue_summaries().is_empty() {
+		eyre::bail!(
+			"Decision Contract `{}` has no proposed issue summaries to materialize.",
+			contract.contract_id()
+		);
+	}
+
+	Ok(())
+}
+
+fn goal_issue_plans(contract: &DecisionContract, program_id: &str) -> Result<Vec<GoalIssuePlan>> {
+	let conflict_domains = goal_conflict_domains(contract)?;
+	let mut plans = Vec::new();
+
+	for (index, objective) in
+		contract.execution_readiness().proposed_issue_summaries().iter().enumerate()
+	{
+		let node_id = goal_node_id(contract.contract_id(), index, objective);
+		let title = goal_issue_title(objective);
+		let acceptance = goal_acceptance(contract, objective);
+		let validation = goal_validation(contract);
+		let dependencies = Vec::new();
+		let description = render_goal_issue_brief(GoalIssueBriefInput {
+			contract,
+			program_id,
+			node_id: &node_id,
+			objective,
+			dependencies: &dependencies,
+			conflict_domains: &conflict_domains,
+			acceptance: &acceptance,
+			validation: &validation,
+		})?;
+
+		validate_generated_issue_text(&title, &description)?;
+
+		plans.push(GoalIssuePlan {
+			node_id,
+			title,
+			objective: objective.clone(),
+			description,
+			dependencies,
+			conflict_domains: conflict_domains.clone(),
+			acceptance,
+			validation,
+		});
+	}
+
+	Ok(plans)
+}
+
+fn linked_goal_issues<T>(
+	tracker: &T,
+	contract: &DecisionContract,
+	plan_count: usize,
+) -> Result<Vec<Option<TrackerIssue>>>
+where
+	T: IssueTracker + ?Sized,
+{
+	let mut linked = Vec::with_capacity(plan_count);
+
+	for index in 0..plan_count {
+		let issue = match contract.links().generated_issue_identifiers().get(index) {
+			Some(identifier) =>
+				Some(tracker.get_issue_by_identifier(identifier)?.ok_or_else(|| {
+					eyre::eyre!(
+						"Generated issue link `{identifier}` for Decision Contract `{}` did not resolve.",
+						contract.contract_id()
+					)
+				})?),
+			None => None,
+		};
+
+		linked.push(issue);
+	}
+
+	Ok(linked)
+}
+
+fn goal_intake_anchor<T>(
+	tracker: &T,
+	workflow: &WorkflowDocument,
+	team_issue_identifier: Option<String>,
+) -> Result<GoalIntakeAnchor>
+where
+	T: IssueTracker + ?Sized,
+{
+	let identifier = team_issue_identifier.ok_or_else(|| {
+		eyre::eyre!(
+			"Goal intake apply requires a source issue on the Decision Contract or --team-issue <ISSUE>."
+		)
+	})?;
+	let issue = tracker
+		.get_issue_by_identifier(&identifier)?
+		.ok_or_else(|| eyre::eyre!("Team anchor issue `{identifier}` did not resolve."))?;
+	let (state_id, _state_name) = workflow
+		.frontmatter()
+		.tracker()
+		.startable_states()
+		.iter()
+		.find_map(|state_name| {
+			issue
+				.state_id_for_name(state_name)
+				.map(|state_id| (state_id.to_owned(), state_name.as_str()))
+		})
+		.ok_or_else(|| {
+			eyre::eyre!(
+				"Team anchor issue `{}` does not expose any configured startable state.",
+				issue.identifier
+			)
+		})?;
+
+	Ok(GoalIntakeAnchor { team_id: issue.team.id, state_id })
+}
+
+fn apply_goal_issues_and_link_contract<T>(
+	input: ApplyGoalIssuesInput<'_, T>,
+) -> Result<(Vec<TrackerIssue>, DecisionContract)>
+where
+	T: IssueTracker + ?Sized,
+{
+	let ApplyGoalIssuesInput {
+		state_store,
+		service_id,
+		source_issue_id,
+		tracker,
+		contract,
+		plans,
+		linked_issues,
+		anchor,
+	} = input;
+	let mut issues = Vec::with_capacity(plans.len());
+	let mut linked_contract = contract.clone();
+
+	for (plan, linked_issue) in plans.iter().zip(linked_issues) {
+		let issue = match linked_issue {
+			Some(issue) => tracker.update_issue_brief(
+				&issue.id,
+				&TrackerIssueBriefUpdate {
+					title: plan.title.clone(),
+					description: plan.description.clone(),
+				},
+			)?,
+			None => tracker.create_issue(&TrackerIssueCreate {
+				team_id: anchor.team_id.clone(),
+				title: plan.title.clone(),
+				description: plan.description.clone(),
+				state_id: Some(anchor.state_id.clone()),
+			})?,
+		};
+
+		issues.push(issue);
+
+		linked_contract =
+			linked_goal_contract_for_apply_progress(contract, plans, linked_issues, &issues)?;
+
+		state_store.upsert_decision_contract(
+			service_id,
+			source_issue_id,
+			linked_contract.clone(),
+		)?;
+	}
+
+	Ok((issues, linked_contract))
+}
+
+fn linked_goal_contract_for_apply_progress(
+	contract: &DecisionContract,
+	plans: &[GoalIssuePlan],
+	linked_issues: &[Option<TrackerIssue>],
+	applied_issues: &[TrackerIssue],
+) -> Result<DecisionContract> {
+	let mut linked_contract = contract.clone();
+	let mut issue_ids = Vec::new();
+	let mut issue_identifiers = Vec::new();
+	let mut node_ids = Vec::new();
+
+	for (index, plan) in plans.iter().enumerate() {
+		let issue =
+			applied_issues.get(index).or_else(|| linked_issues.get(index).and_then(Option::as_ref));
+
+		if let Some(issue) = issue {
+			issue_ids.push(issue.id.clone());
+			issue_identifiers.push(issue.identifier.clone());
+
+			let node_id = if applied_issues.get(index).is_some() {
+				plan.node_id.clone()
+			} else {
+				contract
+					.links()
+					.execution_program_node_ids()
+					.get(index)
+					.cloned()
+					.unwrap_or_else(|| plan.node_id.clone())
+			};
+
+			node_ids.push(node_id);
+		}
+	}
+
+	linked_contract.link_generated_execution_surfaces(issue_ids, issue_identifiers, node_ids)?;
+
+	Ok(linked_contract)
+}
+
+fn goal_execution_program(
+	service_id: &str,
+	program_id: &str,
+	contract: &DecisionContract,
+	plans: &[GoalIssuePlan],
+	issues: &[TrackerIssue],
+	workflow: &WorkflowDocument,
+) -> Result<ExecutionProgram> {
+	let nodes = plans
+		.iter()
+		.zip(issues)
+		.map(|(plan, issue)| goal_program_node(service_id, contract, plan, issue, workflow))
+		.collect::<Result<Vec<_>>>()?;
+
+	ExecutionProgram::from_accepted_contract(program_id, service_id, contract, nodes)
+}
+
+fn goal_program_node(
+	service_id: &str,
+	contract: &DecisionContract,
+	plan: &GoalIssuePlan,
+	issue: &TrackerIssue,
+	workflow: &WorkflowDocument,
+) -> Result<ExecutionProgramNode> {
+	let dependencies = plan
+		.dependencies
+		.iter()
+		.map(ExecutionProgramDependency::new)
+		.collect::<Result<Vec<_>>>()?;
+	let mapping = goal_issue_mapping(service_id, issue, workflow)?;
+
+	ExecutionProgramNode::new(
+		plan.node_id.clone(),
+		ExecutionProgramNodeStage::Runtime,
+		plan.objective.clone(),
+		ExecutionQueueIntent::ReadyToQueue,
+	)?
+	.with_objective_lineage(goal_objective_lineage(contract))?
+	.with_dependencies(dependencies)?
+	.with_conflict_domains(plan.conflict_domains.clone())?
+	.with_acceptance_expectations(plan.acceptance.clone())?
+	.with_validation_expectations(plan.validation.clone())?
+	.with_linear_issue(mapping)
+}
+
+fn goal_issue_mapping(
+	service_id: &str,
+	issue: &TrackerIssue,
+	workflow: &WorkflowDocument,
+) -> Result<ExecutionLinearIssueMapping> {
+	let queue_label = tracker::automation_queue_label(service_id);
+	let active_label = tracker::automation_active_label(service_id);
+	let tracker_policy = workflow.frontmatter().tracker();
+
+	Ok(ExecutionLinearIssueMapping::new(&issue.id, &issue.identifier, &issue.state.name)?
+		.with_queue_label(issue.has_label(&queue_label))
+		.with_active_label(issue.has_label(&active_label))
+		.with_opt_out_label(issue.has_label(tracker_policy.opt_out_label()))
+		.with_needs_attention_label(issue.has_label(tracker_policy.needs_attention_label()))
+		.with_generic_dispatch_briefing(issue_has_generic_dispatch_briefing(issue)))
+}
+
+fn applied_goal_issue_rows(
+	plans: &[GoalIssuePlan],
+	issues: &[TrackerIssue],
+	linked_issues: &[Option<TrackerIssue>],
+	evaluation: &ExecutionProgramEvaluation,
+) -> Vec<GoalIntakeIssueReport> {
+	plans
+		.iter()
+		.zip(issues)
+		.zip(linked_issues)
+		.map(|((plan, issue), linked)| {
+			let evaluation = evaluation.nodes().iter().find(|node| node.node_id() == plan.node_id);
+
+			goal_issue_report_row(
+				plan,
+				Some(issue),
+				if linked.is_some() {
+					GoalIntakeIssueAction::Updated
+				} else {
+					GoalIntakeIssueAction::Created
+				},
+				evaluation.and_then(ExecutionNodeEvaluation::queue_label_action),
+				evaluation.map_or_else(Vec::new, |node| node.reasons().to_vec()),
+			)
+		})
+		.collect()
+}
+
+fn dry_run_goal_issue_rows(
+	plans: &[GoalIssuePlan],
+	linked_issues: &[Option<TrackerIssue>],
+) -> Vec<GoalIntakeIssueReport> {
+	plans
+		.iter()
+		.zip(linked_issues)
+		.map(|(plan, linked)| {
+			let action = if linked.is_some() {
+				GoalIntakeIssueAction::WouldUpdate
+			} else {
+				GoalIntakeIssueAction::WouldCreate
+			};
+			let reason = match action {
+				GoalIntakeIssueAction::WouldCreate =>
+					"apply will create a normal Linear issue and persist a mapped program node",
+				GoalIntakeIssueAction::WouldUpdate =>
+					"apply will update the linked normal Linear issue and persist a mapped program node",
+				GoalIntakeIssueAction::Created | GoalIntakeIssueAction::Updated =>
+					"apply already materialized this issue",
+			};
+
+			goal_issue_report_row(plan, linked.as_ref(), action, None, vec![reason.to_owned()])
+		})
+		.collect()
+}
+
+fn goal_issue_report_row(
+	plan: &GoalIssuePlan,
+	issue: Option<&TrackerIssue>,
+	action: GoalIntakeIssueAction,
+	queue_label_action: Option<ExecutionQueueLabelAction>,
+	reasons: Vec<String>,
+) -> GoalIntakeIssueReport {
+	GoalIntakeIssueReport {
+		node_id: plan.node_id.clone(),
+		title: plan.title.clone(),
+		objective: plan.objective.clone(),
+		issue_id: issue.map(|issue| issue.id.clone()),
+		issue_identifier: issue.map(|issue| issue.identifier.clone()),
+		action,
+		queue_intent: ExecutionQueueIntent::ReadyToQueue.as_str().to_owned(),
+		queue_label_action: queue_label_action.map(queue_label_action_name),
+		dependencies: plan.dependencies.clone(),
+		conflict_domains: conflict_domain_labels(&plan.conflict_domains),
+		acceptance: plan.acceptance.clone(),
+		validation: plan.validation.clone(),
+		reasons,
+	}
+}
+
+fn render_goal_issue_brief(input: GoalIssueBriefInput<'_>) -> Result<String> {
+	let mut output = String::new();
+
+	append_heading(&mut output, "Objective");
+
+	output.push_str(input.objective.trim());
+	output.push('\n');
+
+	append_heading(&mut output, "Authority");
+	append_item(
+		&mut output,
+		&format!("Accepted Decision Contract: `{}`", input.contract.contract_id()),
+	);
+	append_item(&mut output, &format!("Execution Program: `{}`", input.program_id));
+	append_item(&mut output, &format!("Execution Program node: `{}`", input.node_id));
+	append_optional_item(
+		&mut output,
+		"Source issue",
+		input.contract.source_intent().source_issue_identifier(),
+	);
+	append_heading(&mut output, "Scope");
+	append_item(&mut output, input.objective.trim());
+	append_items(&mut output, input.contract.accepted_authority().accepted_objectives());
+	append_items(&mut output, input.contract.accepted_authority().constraints());
+	append_items(&mut output, input.contract.accepted_authority().assumptions());
+	append_heading(&mut output, "Non-goals");
+	append_items_or_none(&mut output, input.contract.accepted_authority().non_goals());
+	append_heading(&mut output, "Dependencies");
+	append_items_or_none(&mut output, input.dependencies);
+	append_heading(&mut output, "Conflict Domains");
+	append_items_or_none(&mut output, &conflict_domain_labels(input.conflict_domains));
+	append_heading(&mut output, "Acceptance");
+	append_items(&mut output, input.acceptance);
+	append_heading(&mut output, "Validation");
+	append_items(&mut output, input.validation);
+	append_heading(&mut output, "Stop Conditions");
+	append_items_or_none(&mut output, input.contract.accepted_authority().stop_conditions());
+	validate_public_issue_description(&output)?;
+
+	Ok(output)
+}
+
+fn append_heading(output: &mut String, heading: &str) {
+	if !output.is_empty() {
+		output.push('\n');
+	}
+
+	output.push_str("## ");
+	output.push_str(heading);
+	output.push('\n');
+}
+
+fn append_item(output: &mut String, item: &str) {
+	output.push_str("- ");
+	output.push_str(item);
+	output.push('\n');
+}
+
+fn append_optional_item(output: &mut String, label: &str, value: Option<&str>) {
+	if let Some(value) = value {
+		append_item(output, &format!("{label}: `{value}`"));
+	}
+}
+
+fn append_items(output: &mut String, items: &[String]) {
+	for item in items {
+		append_item(output, item);
+	}
+}
+
+fn append_items_or_none(output: &mut String, items: &[String]) {
+	if items.is_empty() {
+		append_item(output, "None declared by the accepted Decision Contract.");
+	} else {
+		append_items(output, items);
+	}
+}
+
+fn validate_generated_issue_text(title: &str, description: &str) -> Result<()> {
+	public_text::validate_public_text_field("generated issue title", title)
+		.map_err(|error| eyre::eyre!(error))?;
+
+	validate_public_issue_description(description)
+}
+
+fn validate_public_issue_description(description: &str) -> Result<()> {
+	public_text::validate_public_text_field("generated issue description", description)
+		.map_err(|error| eyre::eyre!(error))
+}
+
+fn goal_acceptance(contract: &DecisionContract, objective: &str) -> Vec<String> {
+	let mut acceptance = vec![format!("Deliver this generated issue objective: {objective}")];
+
+	acceptance.extend(contract.accepted_authority().accepted_objectives().iter().cloned());
+
+	acceptance
+}
+
+fn goal_validation(contract: &DecisionContract) -> Vec<String> {
+	if contract.execution_readiness().validation_expectations().is_empty() {
+		return vec![String::from("Run the registered project validation before review handoff.")];
+	}
+
+	contract.execution_readiness().validation_expectations().to_vec()
+}
+
+fn goal_objective_lineage(contract: &DecisionContract) -> Vec<String> {
+	let mut lineage = vec![
+		format!("Accepted Decision Contract `{}`.", contract.contract_id()),
+		format!("Source intent: {}", contract.source_intent().summary()),
+	];
+
+	lineage.extend(contract.accepted_authority().accepted_objectives().iter().cloned());
+
+	lineage
+}
+
+fn goal_conflict_domains(contract: &DecisionContract) -> Result<Vec<ExecutionConflictDomain>> {
+	contract
+		.execution_readiness()
+		.conflict_domains()
+		.iter()
+		.map(|domain| parse_goal_conflict_domain(domain))
+		.collect()
+}
+
+fn parse_goal_conflict_domain(domain: &str) -> Result<ExecutionConflictDomain> {
+	let domain = domain.trim();
+	let (kind, key) = domain.split_once(':').unwrap_or(("module", domain));
+	let kind = match kind {
+		"file" => ExecutionConflictDomainKind::File,
+		"module" => ExecutionConflictDomainKind::Module,
+		"state" => ExecutionConflictDomainKind::State,
+		"credentials" => ExecutionConflictDomainKind::Credentials,
+		"tracker_ownership" => ExecutionConflictDomainKind::TrackerOwnership,
+		"review_surface" => ExecutionConflictDomainKind::ReviewSurface,
+		_ => return ExecutionConflictDomain::new(ExecutionConflictDomainKind::Module, domain),
+	};
+
+	ExecutionConflictDomain::new(kind, key)
+}
+
+fn conflict_domain_labels(domains: &[ExecutionConflictDomain]) -> Vec<String> {
+	let mut labels = domains
+		.iter()
+		.map(|domain| format!("{}:{}", domain.kind().as_str(), domain.key()))
+		.collect::<Vec<_>>();
+
+	labels.sort();
+	labels.dedup();
+
+	labels
+}
+
+fn goal_program_id(service_id: &str, contract_id: &str) -> String {
+	format!("goal-{service_id}-{}", stable_slug(contract_id, 48))
+}
+
+fn goal_node_id(contract_id: &str, index: usize, objective: &str) -> String {
+	format!("goal:{}:{:02}-{}", stable_slug(contract_id, 32), index + 1, stable_slug(objective, 32))
+}
+
+fn goal_issue_title(objective: &str) -> String {
+	let objective = objective.trim();
+
+	if objective.chars().count() <= 120 {
+		return objective.to_owned();
+	}
+
+	let mut title = objective.chars().take(117).collect::<String>();
+
+	title.push_str("...");
+
+	title
+}
+
+fn stable_slug(value: &str, max_len: usize) -> String {
+	let mut slug = String::new();
+	let mut previous_dash = false;
+
+	for character in value.chars() {
+		if character.is_ascii_alphanumeric() {
+			slug.push(character.to_ascii_lowercase());
+
+			previous_dash = false;
+		} else if !previous_dash && !slug.is_empty() {
+			slug.push('-');
+
+			previous_dash = true;
+		}
+		if slug.len() >= max_len {
+			break;
+		}
+	}
+
+	while slug.ends_with('-') {
+		slug.pop();
+	}
+
+	if slug.is_empty() { String::from("goal") } else { slug }
+}
+
+fn list_or_none(values: &[String]) -> String {
+	if values.is_empty() { String::from("none") } else { values.join(", ") }
 }
 
 fn resolve_intake_project_config_path(
@@ -742,16 +1629,20 @@ fn issue_has_generic_dispatch_briefing(issue: &TrackerIssue) -> bool {
 
 #[cfg(test)]
 mod tests {
-	use std::{collections::HashMap, fs, path::Path};
+	use std::{cell::RefCell, collections::HashMap, fs, path::Path};
 
 	use tempfile::TempDir;
 
 	use crate::{
-		program_intake::{self, IssueBatchIntakeClassification},
+		loop_contract::{DecisionContract, DecisionPromotion, DecisionPromotionActorKind},
+		prelude::eyre,
+		program_intake::{
+			self, GoalIntakeIssueAction, GoalIntakeRunRequest, IssueBatchIntakeClassification,
+		},
 		state::StateStore,
 		tracker::{
-			IssueTracker, TrackerComment, TrackerIssue, TrackerIssueBlocker, TrackerLabel,
-			TrackerState, TrackerTeam,
+			IssueTracker, TrackerComment, TrackerIssue, TrackerIssueBlocker,
+			TrackerIssueBriefUpdate, TrackerIssueCreate, TrackerLabel, TrackerState, TrackerTeam,
 		},
 		workflow::WorkflowDocument,
 	};
@@ -763,16 +1654,45 @@ mod tests {
 
 	#[derive(Default)]
 	struct FakeTracker {
-		issues: HashMap<String, TrackerIssue>,
+		issues: RefCell<HashMap<String, TrackerIssue>>,
+		next_issue_number: RefCell<usize>,
+		created_issues: RefCell<Vec<TrackerIssue>>,
+		updated_issues: RefCell<Vec<TrackerIssue>>,
+		fail_create_after_successes: RefCell<Option<usize>>,
+		fail_update_after_successes: RefCell<Option<usize>>,
 	}
 
 	impl FakeTracker {
-		fn with_issues(mut self, issues: impl IntoIterator<Item = TrackerIssue>) -> Self {
+		fn with_issues(self, issues: impl IntoIterator<Item = TrackerIssue>) -> Self {
 			for issue in issues {
-				self.issues.insert(issue.identifier.clone(), issue);
+				self.issues.borrow_mut().insert(issue.identifier.clone(), issue);
 			}
 
 			self
+		}
+
+		fn with_create_failure_after_successes(self, successes: usize) -> Self {
+			*self.fail_create_after_successes.borrow_mut() = Some(successes);
+
+			self
+		}
+
+		fn with_update_failure_after_successes(self, successes: usize) -> Self {
+			*self.fail_update_after_successes.borrow_mut() = Some(successes);
+
+			self
+		}
+
+		fn created_issue_count(&self) -> usize {
+			self.created_issues.borrow().len()
+		}
+
+		fn updated_issue_count(&self) -> usize {
+			self.updated_issues.borrow().len()
+		}
+
+		fn generated_issue_identifier(&self, index: usize) -> String {
+			format!("XY-G{}", index + 1)
 		}
 	}
 
@@ -781,7 +1701,13 @@ mod tests {
 			&self,
 			label_name: &str,
 		) -> crate::prelude::Result<Vec<TrackerIssue>> {
-			Ok(self.issues.values().filter(|issue| issue.has_label(label_name)).cloned().collect())
+			Ok(self
+				.issues
+				.borrow()
+				.values()
+				.filter(|issue| issue.has_label(label_name))
+				.cloned()
+				.collect())
 		}
 
 		fn find_team_label_id(
@@ -796,7 +1722,7 @@ mod tests {
 			&self,
 			issue_identifier: &str,
 		) -> crate::prelude::Result<Option<TrackerIssue>> {
-			Ok(self.issues.get(issue_identifier).cloned())
+			Ok(self.issues.borrow().get(issue_identifier).cloned())
 		}
 
 		fn refresh_issues(
@@ -836,6 +1762,72 @@ mod tests {
 
 		fn create_comment(&self, _issue_id: &str, _body: &str) -> crate::prelude::Result<()> {
 			Ok(())
+		}
+
+		fn create_issue(
+			&self,
+			request: &TrackerIssueCreate,
+		) -> crate::prelude::Result<TrackerIssue> {
+			if let Some(success_limit) = *self.fail_create_after_successes.borrow()
+				&& self.created_issues.borrow().len() >= success_limit
+			{
+				eyre::bail!("injected create failure after {success_limit} successes");
+			}
+
+			let identifier = loop {
+				let mut next_issue_number = self.next_issue_number.borrow_mut();
+
+				*next_issue_number += 1;
+
+				let candidate = self.generated_issue_identifier(*next_issue_number - 1);
+
+				if !self.issues.borrow().contains_key(&candidate) {
+					break candidate;
+				}
+			};
+			let state_name = request
+				.state_id
+				.as_deref()
+				.and_then(|state_id| state_id.strip_prefix("state-"))
+				.unwrap_or("Todo");
+			let mut issue = issue(&identifier, state_name);
+
+			issue.id = format!("id-{identifier}");
+
+			issue.title.clone_from(&request.title);
+			issue.description.clone_from(&request.description);
+			issue.team.id.clone_from(&request.team_id);
+			self.issues.borrow_mut().insert(identifier, issue.clone());
+			self.created_issues.borrow_mut().push(issue.clone());
+
+			Ok(issue)
+		}
+
+		fn update_issue_brief(
+			&self,
+			issue_id: &str,
+			request: &TrackerIssueBriefUpdate,
+		) -> crate::prelude::Result<TrackerIssue> {
+			if let Some(success_limit) = *self.fail_update_after_successes.borrow()
+				&& self.updated_issues.borrow().len() >= success_limit
+			{
+				eyre::bail!("injected update failure after {success_limit} successes");
+			}
+
+			let mut issues = self.issues.borrow_mut();
+			let issue = issues
+				.values_mut()
+				.find(|issue| issue.id == issue_id)
+				.ok_or_else(|| eyre::eyre!("issue `{issue_id}` not found"))?;
+
+			issue.title.clone_from(&request.title);
+			issue.description.clone_from(&request.description);
+
+			let issue = issue.clone();
+
+			self.updated_issues.borrow_mut().push(issue.clone());
+
+			Ok(issue)
 		}
 	}
 
@@ -971,8 +1963,417 @@ mod tests {
 		);
 	}
 
+	#[test]
+	fn goal_intake_dry_run_shows_issue_split_without_mutation() {
+		let store = StateStore::open_in_memory().expect("store should open");
+		let contract = accepted_goal_contract();
+
+		store
+			.upsert_decision_contract("decodex", Some("XY-852"), contract)
+			.expect("contract should persist");
+
+		let tracker = FakeTracker::default().with_issues([issue("XY-852", "Todo")]);
+		let config = test_config();
+		let workflow = workflow();
+		let report = program_intake::run_goal_intake(GoalIntakeRunRequest {
+			state_store: &store,
+			tracker: &tracker,
+			config: &config,
+			workflow: &workflow,
+			contract_id: "goal-intake-contract",
+			team_issue_identifier: None,
+			dry_run: true,
+			apply: false,
+		})
+		.expect("dry-run should produce materialization plan");
+
+		assert!(report.dry_run);
+		assert!(!report.persisted);
+		assert_eq!(report.issues.len(), 2);
+		assert_eq!(report.issues[0].action, GoalIntakeIssueAction::WouldCreate);
+		assert_eq!(report.issues[0].dependencies, Vec::<String>::new());
+		assert_eq!(
+			report.issues[0].conflict_domains,
+			vec![String::from("file:docs/spec/loop-runtime.md"), String::from("module:runtime"),]
+		);
+		assert_eq!(tracker.created_issue_count(), 0);
+		assert!(store.list_execution_programs("decodex").expect("programs").is_empty());
+
+		let rendered = program_intake::render_goal_intake_report(&report);
+
+		assert!(rendered.contains("dependencies=none"));
+		assert!(
+			rendered.contains("conflict_domains=file:docs/spec/loop-runtime.md, module:runtime")
+		);
+	}
+
+	#[test]
+	fn goal_intake_refuses_latent_or_missing_decision_authority() {
+		let store = StateStore::open_in_memory().expect("store should open");
+		let tracker = FakeTracker::default().with_issues([issue("XY-852", "Todo")]);
+		let latent = latent_goal_contract();
+
+		store
+			.upsert_decision_contract("decodex", Some("XY-852"), latent)
+			.expect("latent contract should persist");
+
+		let config = test_config();
+		let workflow = workflow();
+		let latent_error = program_intake::run_goal_intake(GoalIntakeRunRequest {
+			state_store: &store,
+			tracker: &tracker,
+			config: &config,
+			workflow: &workflow,
+			contract_id: "goal-intake-contract",
+			team_issue_identifier: None,
+			dry_run: false,
+			apply: true,
+		})
+		.expect_err("latent contract must not materialize");
+
+		assert!(latent_error.to_string().contains("requires accepted execution authority"));
+
+		let mut needs_decision = latent_goal_contract();
+
+		needs_decision
+			.require_human_decision("Choose the public issue split before apply.")
+			.expect("contract should record missing decision");
+		store
+			.upsert_decision_contract("decodex", Some("XY-852"), needs_decision)
+			.expect("needs-decision contract should persist");
+
+		let missing_decision_error = program_intake::run_goal_intake(GoalIntakeRunRequest {
+			state_store: &store,
+			tracker: &tracker,
+			config: &config,
+			workflow: &workflow,
+			contract_id: "goal-intake-contract",
+			team_issue_identifier: None,
+			dry_run: false,
+			apply: true,
+		})
+		.expect_err("missing decision must stop apply");
+
+		assert!(missing_decision_error.to_string().contains("needs_human_decision"));
+		assert_eq!(tracker.created_issue_count(), 0);
+		assert!(store.list_execution_programs("decodex").expect("programs").is_empty());
+	}
+
+	#[test]
+	fn goal_intake_apply_creates_updates_and_persists_links() {
+		let store = StateStore::open_in_memory().expect("store should open");
+		let mut contract = accepted_goal_contract();
+
+		contract
+			.link_generated_execution_surfaces(["id-XY-G1"], ["XY-G1"], ["old-node"])
+			.expect("existing generated link should attach");
+		store
+			.upsert_decision_contract("decodex", Some("XY-852"), contract)
+			.expect("contract should persist");
+
+		let tracker =
+			FakeTracker::default().with_issues([issue("XY-852", "Todo"), issue("XY-G1", "Todo")]);
+		let config = test_config();
+		let workflow = workflow();
+		let report = program_intake::run_goal_intake(GoalIntakeRunRequest {
+			state_store: &store,
+			tracker: &tracker,
+			config: &config,
+			workflow: &workflow,
+			contract_id: "goal-intake-contract",
+			team_issue_identifier: None,
+			dry_run: false,
+			apply: true,
+		})
+		.expect("apply should materialize issues and program");
+
+		assert!(report.applied);
+		assert!(report.persisted);
+		assert_eq!(tracker.updated_issue_count(), 1);
+		assert_eq!(tracker.created_issue_count(), 1);
+		assert_eq!(report.issues[0].action, GoalIntakeIssueAction::Updated);
+		assert_eq!(report.issues[1].action, GoalIntakeIssueAction::Created);
+		assert_eq!(report.issues[0].queue_label_action.as_deref(), Some("apply"));
+		assert_eq!(report.issues[1].queue_label_action.as_deref(), Some("apply"));
+
+		let linked_contract = store
+			.decision_contract("decodex", "goal-intake-contract")
+			.expect("contract lookup should read")
+			.expect("contract should exist");
+
+		assert_eq!(
+			linked_contract.contract().links().generated_issue_identifiers(),
+			&[String::from("XY-G1"), String::from("XY-G2")]
+		);
+		assert_eq!(
+			linked_contract.contract().links().execution_program_node_ids(),
+			&report.issues.iter().map(|issue| issue.node_id.clone()).collect::<Vec<_>>()
+		);
+
+		let programs = store
+			.list_execution_programs_for_contract("decodex", "goal-intake-contract")
+			.expect("programs should list");
+
+		assert_eq!(programs.len(), 1);
+		assert_eq!(programs[0].program_id(), report.program_id);
+
+		let intake_plans =
+			store.list_program_intake_plans("decodex").expect("intake plans should list");
+
+		assert_eq!(intake_plans.len(), 1);
+		assert_eq!(intake_plans[0].intake_kind(), "goal_intake");
+		assert_eq!(intake_plans[0].source_contract_id(), Some("goal-intake-contract"));
+
+		let mappings = store
+			.list_program_issue_mappings("decodex", &report.program_id)
+			.expect("mappings should list");
+
+		assert_eq!(mappings.len(), 2);
+
+		let updated = tracker
+			.get_issue_by_identifier("XY-G1")
+			.expect("issue lookup should work")
+			.expect("updated issue should exist");
+
+		assert!(updated.description.contains("## Objective"));
+		assert!(updated.description.contains("Accepted Decision Contract: `goal-intake-contract`"));
+		assert!(updated.description.contains("Execution Program node:"));
+		assert!(updated.description.contains("## Dependencies"));
+		assert!(!updated.description.contains("```"));
+		assert!(!updated.description.contains("private_evidence_refs"));
+	}
+
+	#[test]
+	fn goal_intake_apply_persists_links_after_each_successful_issue_mutation() {
+		let store = StateStore::open_in_memory().expect("store should open");
+		let contract = accepted_goal_contract();
+
+		store
+			.upsert_decision_contract("decodex", Some("XY-852"), contract)
+			.expect("contract should persist");
+
+		let tracker = FakeTracker::default()
+			.with_issues([issue("XY-852", "Todo")])
+			.with_create_failure_after_successes(1);
+		let config = test_config();
+		let workflow = workflow();
+		let error = program_intake::run_goal_intake(GoalIntakeRunRequest {
+			state_store: &store,
+			tracker: &tracker,
+			config: &config,
+			workflow: &workflow,
+			contract_id: "goal-intake-contract",
+			team_issue_identifier: None,
+			dry_run: false,
+			apply: true,
+		})
+		.expect_err("second issue create should fail");
+
+		assert!(error.to_string().contains("injected create failure"));
+		assert_eq!(tracker.created_issue_count(), 1);
+
+		let linked_contract = store
+			.decision_contract("decodex", "goal-intake-contract")
+			.expect("contract lookup should read")
+			.expect("contract should exist");
+
+		assert_eq!(
+			linked_contract.contract().links().generated_issue_identifiers(),
+			&[String::from("XY-G1")]
+		);
+		assert_eq!(linked_contract.contract().links().generated_issue_ids().len(), 1);
+		assert_eq!(linked_contract.contract().links().execution_program_node_ids().len(), 1);
+		assert!(store.list_execution_programs("decodex").expect("programs").is_empty());
+	}
+
+	#[test]
+	fn goal_intake_apply_preserves_later_existing_links_after_update_failure() {
+		let store = StateStore::open_in_memory().expect("store should open");
+		let mut contract = accepted_goal_contract();
+
+		contract
+			.link_generated_execution_surfaces(
+				["id-XY-G1", "id-XY-G2"],
+				["XY-G1", "XY-G2"],
+				["old-node-1", "old-node-2"],
+			)
+			.expect("existing generated links should attach");
+		store
+			.upsert_decision_contract("decodex", Some("XY-852"), contract)
+			.expect("contract should persist");
+
+		let tracker = FakeTracker::default()
+			.with_issues([issue("XY-852", "Todo"), issue("XY-G1", "Todo"), issue("XY-G2", "Todo")])
+			.with_update_failure_after_successes(1);
+		let config = test_config();
+		let workflow = workflow();
+		let error = program_intake::run_goal_intake(GoalIntakeRunRequest {
+			state_store: &store,
+			tracker: &tracker,
+			config: &config,
+			workflow: &workflow,
+			contract_id: "goal-intake-contract",
+			team_issue_identifier: None,
+			dry_run: false,
+			apply: true,
+		})
+		.expect_err("second issue update should fail");
+
+		assert!(error.to_string().contains("injected update failure"));
+		assert_eq!(tracker.updated_issue_count(), 1);
+
+		let linked_contract = store
+			.decision_contract("decodex", "goal-intake-contract")
+			.expect("contract lookup should read")
+			.expect("contract should exist");
+
+		assert_eq!(
+			linked_contract.contract().links().generated_issue_identifiers(),
+			&[String::from("XY-G1"), String::from("XY-G2")]
+		);
+		assert_eq!(linked_contract.contract().links().execution_program_node_ids().len(), 2);
+		assert_eq!(
+			linked_contract.contract().links().execution_program_node_ids()[1],
+			"old-node-2"
+		);
+		assert!(store.list_execution_programs("decodex").expect("programs").is_empty());
+	}
+
+	#[test]
+	fn goal_intake_apply_fails_closed_when_existing_generated_link_is_missing() {
+		let store = StateStore::open_in_memory().expect("store should open");
+		let mut contract = accepted_goal_contract();
+
+		contract
+			.link_generated_execution_surfaces(["id-XY-G1"], ["XY-G1"], ["old-node"])
+			.expect("existing generated link should attach");
+		store
+			.upsert_decision_contract("decodex", Some("XY-852"), contract)
+			.expect("contract should persist");
+
+		let tracker = FakeTracker::default().with_issues([issue("XY-852", "Todo")]);
+		let config = test_config();
+		let workflow = workflow();
+		let error = program_intake::run_goal_intake(GoalIntakeRunRequest {
+			state_store: &store,
+			tracker: &tracker,
+			config: &config,
+			workflow: &workflow,
+			contract_id: "goal-intake-contract",
+			team_issue_identifier: None,
+			dry_run: false,
+			apply: true,
+		})
+		.expect_err("missing generated issue link should block apply");
+
+		assert!(error.to_string().contains("Generated issue link `XY-G1`"));
+		assert_eq!(tracker.created_issue_count(), 0);
+		assert_eq!(tracker.updated_issue_count(), 0);
+		assert!(store.list_execution_programs("decodex").expect("programs").is_empty());
+	}
+
 	fn workflow() -> WorkflowDocument {
 		WorkflowDocument::parse_markdown(workflow_markdown()).expect("workflow should parse")
+	}
+
+	fn latent_goal_contract() -> DecisionContract {
+		serde_json::from_value(serde_json::json!({
+			"schema": crate::loop_contract::DECISION_CONTRACT_SCHEMA,
+			"record_version": crate::loop_contract::DECISION_CONTRACT_RECORD_VERSION,
+			"contract_id": "goal-intake-contract",
+			"status": "draft_latent",
+			"source_intent": {
+				"summary": "Ship promoted goal intake.",
+				"user_utterance": "arrange this goal",
+				"source_issue_identifier": "XY-852",
+			},
+			"research_provenance": [
+				{
+					"kind": "spec",
+					"reference": "docs/spec/loop-runtime.md",
+					"summary": "Promoted contracts can shape normal Linear issues."
+				}
+			],
+			"research_evidence": [
+				{
+					"claim": "Goal intake needs generated issues and an internal program.",
+					"support": "The loop-runtime spec defines Program Intake and Execution Program records.",
+					"source_ref": "docs/spec/loop-runtime.md"
+				}
+			],
+			"research_options": [],
+			"accepted_authority": {
+				"accepted_objectives": [
+					"Materialize accepted goal intake into normal Linear issues.",
+					"Persist the internal Execution Program without exposing graph mechanics."
+				],
+				"non_goals": [
+					"Do not run implementation from goal intake."
+				],
+				"constraints": [
+					"Linear receives only public-safe issue briefs and sparse links."
+				],
+				"assumptions": [
+					"The source issue anchors the generated issue team."
+				],
+				"objections": [],
+				"stop_conditions": [
+					"Stop when promotion authority or required decisions are missing."
+				]
+			},
+			"execution_readiness": {
+				"summary": "Ready for issue shaping after promotion.",
+				"ready_for_issue_shaping": true,
+				"missing_decisions": [],
+				"validation_expectations": [
+					"Run cargo make test before handoff."
+				],
+				"risk_notes": [
+					"Generated issue descriptions must stay natural-language."
+				],
+				"proposed_issue_summaries": [
+					"Implement goal intake CLI/API behavior.",
+					"Persist Execution Program links for generated issues."
+				],
+				"conflict_domains": [
+					"module:runtime",
+					"file:docs/spec/loop-runtime.md"
+				],
+				"queue_intent": [
+					"ready_to_queue_after_apply"
+				]
+			},
+			"links": {
+				"generated_issue_ids": [],
+				"generated_issue_identifiers": [],
+				"execution_program_node_ids": []
+			},
+			"evidence_boundary": {
+				"private_evidence_refs": [],
+				"public_projection_refs": [],
+				"public_summary": "Goal intake contract ready for issue shaping."
+			}
+		}))
+		.expect("goal contract should deserialize")
+	}
+
+	fn accepted_goal_contract() -> DecisionContract {
+		let mut contract = latent_goal_contract();
+
+		contract
+			.promote(
+				DecisionPromotion::new(
+					"operator",
+					DecisionPromotionActorKind::User,
+					"2026-06-10T00:00:00Z",
+					"conversation",
+					Some(String::from("User asked Decodex to arrange this goal.")),
+				)
+				.expect("promotion should build"),
+			)
+			.expect("contract should promote");
+
+		contract
 	}
 
 	fn workflow_markdown() -> &'static str {
@@ -1064,7 +2465,14 @@ worktree_root = ".worktrees"
 			team: TrackerTeam {
 				id: String::from("team"),
 				name: String::from("Team"),
-				states: Vec::new(),
+				states: vec![
+					TrackerState { id: String::from("state-Todo"), name: String::from("Todo") },
+					TrackerState {
+						id: String::from("state-In Progress"),
+						name: String::from("In Progress"),
+					},
+					TrackerState { id: String::from("state-Done"), name: String::from("Done") },
+				],
 				labels: Vec::new(),
 			},
 			labels_complete: true,

--- a/apps/decodex/src/tracker.rs
+++ b/apps/decodex/src/tracker.rs
@@ -21,6 +21,42 @@ pub(crate) trait IssueTracker {
 	fn add_issue_labels(&self, issue_id: &str, label_ids: &[String]) -> Result<()>;
 	fn remove_issue_labels(&self, issue_id: &str, label_ids: &[String]) -> Result<()>;
 	fn create_comment(&self, issue_id: &str, body: &str) -> Result<()>;
+	fn create_issue(&self, request: &TrackerIssueCreate) -> Result<TrackerIssue> {
+		let _ = request;
+
+		eyre::bail!("Issue tracker does not support creating issues.")
+	}
+	fn update_issue_brief(
+		&self,
+		issue_id: &str,
+		request: &TrackerIssueBriefUpdate,
+	) -> Result<TrackerIssue> {
+		let _ = (issue_id, request);
+
+		eyre::bail!("Issue tracker does not support updating issue briefs.")
+	}
+}
+
+/// Public-safe normal issue creation request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct TrackerIssueCreate {
+	/// Linear team id that will own the issue.
+	pub(crate) team_id: String,
+	/// Public issue title.
+	pub(crate) title: String,
+	/// Natural-language public issue brief.
+	pub(crate) description: String,
+	/// Optional initial tracker state id.
+	pub(crate) state_id: Option<String>,
+}
+
+/// Public-safe normal issue brief update request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct TrackerIssueBriefUpdate {
+	/// Replacement public issue title.
+	pub(crate) title: String,
+	/// Replacement natural-language public issue brief.
+	pub(crate) description: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/apps/decodex/src/tracker/linear.rs
+++ b/apps/decodex/src/tracker/linear.rs
@@ -7,8 +7,8 @@ use serde_json::Value;
 use crate::{
 	prelude::{Result, eyre},
 	tracker::{
-		IssueTracker, TrackerComment, TrackerIssue, TrackerIssueBlocker, TrackerLabel,
-		TrackerState, TrackerTeam,
+		IssueTracker, TrackerComment, TrackerIssue, TrackerIssueBlocker, TrackerIssueBriefUpdate,
+		TrackerIssueCreate, TrackerLabel, TrackerState, TrackerTeam,
 	},
 };
 
@@ -265,6 +265,142 @@ const ISSUE_UPDATE_MUTATION: &str = r#"
 mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
   issueUpdate(id: $id, input: $input) {
     success
+  }
+}
+"#;
+const ISSUE_UPDATE_BRIEF_MUTATION: &str = r#"
+mutation UpdateIssueBrief($id: String!, $input: IssueUpdateInput!) {
+  issueUpdate(id: $id, input: $input) {
+    success
+    issue {
+      id
+      identifier
+      title
+      creator {
+        displayName
+        name
+        email
+      }
+      description
+      priority
+      createdAt
+      updatedAt
+      state {
+        id
+        name
+      }
+      team {
+        id
+        name
+        states(first: 50) {
+          nodes {
+            id
+            name
+          }
+        }
+        labels(first: 100) {
+          nodes {
+            id
+            name
+          }
+        }
+      }
+      labels(first: 50) {
+        nodes {
+          id
+          name
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+      inverseRelations(first: 50) {
+        nodes {
+          type
+          issue {
+            id
+            identifier
+            state {
+              id
+              name
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+"#;
+const ISSUE_CREATE_MUTATION: &str = r#"
+mutation CreateIssue($input: IssueCreateInput!) {
+  issueCreate(input: $input) {
+    success
+    issue {
+      id
+      identifier
+      title
+      creator {
+        displayName
+        name
+        email
+      }
+      description
+      priority
+      createdAt
+      updatedAt
+      state {
+        id
+        name
+      }
+      team {
+        id
+        name
+        states(first: 50) {
+          nodes {
+            id
+            name
+          }
+        }
+        labels(first: 100) {
+          nodes {
+            id
+            name
+          }
+        }
+      }
+      labels(first: 50) {
+        nodes {
+          id
+          name
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+      inverseRelations(first: 50) {
+        nodes {
+          type
+          issue {
+            id
+            identifier
+            state {
+              id
+              name
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
   }
 }
 "#;
@@ -527,6 +663,8 @@ impl IssueTracker for LinearClient {
 			&IssueUpdateVariables {
 				id: issue_id,
 				input: IssueUpdateInput {
+					title: None,
+					description: None,
 					state_id: Some(state_id.to_owned()),
 					label_ids: None,
 					added_label_ids: None,
@@ -548,6 +686,8 @@ impl IssueTracker for LinearClient {
 			&IssueUpdateVariables {
 				id: issue_id,
 				input: IssueUpdateInput {
+					title: None,
+					description: None,
 					state_id: None,
 					label_ids: None,
 					added_label_ids: Some(label_ids.to_vec()),
@@ -569,6 +709,8 @@ impl IssueTracker for LinearClient {
 			&IssueUpdateVariables {
 				id: issue_id,
 				input: IssueUpdateInput {
+					title: None,
+					description: None,
 					state_id: None,
 					label_ids: None,
 					added_label_ids: None,
@@ -582,6 +724,65 @@ impl IssueTracker for LinearClient {
 		}
 
 		Ok(())
+	}
+
+	fn create_issue(&self, request: &TrackerIssueCreate) -> Result<TrackerIssue> {
+		let data = self.post::<_, IssueCreateData>(
+			ISSUE_CREATE_MUTATION,
+			&IssueCreateVariables {
+				input: IssueCreateInput {
+					team_id: request.team_id.clone(),
+					title: request.title.clone(),
+					description: request.description.clone(),
+					state_id: request.state_id.clone(),
+				},
+			},
+		)?;
+
+		if !data.issue_create.success {
+			eyre::bail!("Linear did not confirm the issue creation.");
+		}
+
+		let issue = data
+			.issue_create
+			.issue
+			.ok_or_else(|| eyre::eyre!("Linear issue creation response did not include issue."))?;
+		let blockers = self.resolve_issue_blockers(&issue)?;
+
+		Ok(map_issue(issue, blockers))
+	}
+
+	fn update_issue_brief(
+		&self,
+		issue_id: &str,
+		request: &TrackerIssueBriefUpdate,
+	) -> Result<TrackerIssue> {
+		let data = self.post::<_, IssueUpdateWithIssueData>(
+			ISSUE_UPDATE_BRIEF_MUTATION,
+			&IssueUpdateVariables {
+				id: issue_id,
+				input: IssueUpdateInput {
+					title: Some(request.title.clone()),
+					description: Some(request.description.clone()),
+					state_id: None,
+					label_ids: None,
+					added_label_ids: None,
+					removed_label_ids: None,
+				},
+			},
+		)?;
+
+		if !data.issue_update.success {
+			eyre::bail!("Linear did not confirm the issue brief update.");
+		}
+
+		let issue = data
+			.issue_update
+			.issue
+			.ok_or_else(|| eyre::eyre!("Linear issue update response did not include issue."))?;
+		let blockers = self.resolve_issue_blockers(&issue)?;
+
+		Ok(map_issue(issue, blockers))
 	}
 
 	fn create_comment(&self, issue_id: &str, body: &str) -> Result<()> {
@@ -809,6 +1010,10 @@ struct IssueUpdateVariables<'a> {
 
 #[derive(Serialize)]
 struct IssueUpdateInput {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	title: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	description: Option<String>,
 	#[serde(rename = "stateId", skip_serializing_if = "Option::is_none")]
 	state_id: Option<String>,
 	#[serde(rename = "labelIds", skip_serializing_if = "Option::is_none")]
@@ -823,6 +1028,39 @@ struct IssueUpdateInput {
 struct IssueUpdateData {
 	#[serde(rename = "issueUpdate")]
 	issue_update: MutationSuccess,
+}
+
+#[derive(Deserialize)]
+struct IssueUpdateWithIssueData {
+	#[serde(rename = "issueUpdate")]
+	issue_update: IssueMutationWithIssue,
+}
+
+#[derive(Serialize)]
+struct IssueCreateVariables {
+	input: IssueCreateInput,
+}
+
+#[derive(Serialize)]
+struct IssueCreateInput {
+	#[serde(rename = "teamId")]
+	team_id: String,
+	title: String,
+	description: String,
+	#[serde(rename = "stateId", skip_serializing_if = "Option::is_none")]
+	state_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct IssueCreateData {
+	#[serde(rename = "issueCreate")]
+	issue_create: IssueMutationWithIssue,
+}
+
+#[derive(Deserialize)]
+struct IssueMutationWithIssue {
+	success: bool,
+	issue: Option<LinearIssue>,
 }
 
 #[derive(Serialize)]

--- a/docs/spec/loop-runtime.md
+++ b/docs/spec/loop-runtime.md
@@ -333,7 +333,21 @@ be represented internally as a DAG, but executable work still enters Decodex as
 ordinary Linear issue lanes with generic natural-language descriptions, tracker
 states, validation expectations, and Decodex lifecycle writeback.
 
-The first operator CLI surface for existing issues is
+The operator CLI surface for promoted goals is
+`decodex intake goal --project <service-id> <CONTRACT_ID> --dry-run`, or the same
+command with `--config <PROJECT_DIR>`. Dry-run reads the promoted Decision Contract
+and existing generated-issue links, then prints the proposed normal issue briefs,
+dependencies, conflict domains, and queue plan without mutating Linear and without
+persisting local runtime rows. `--apply` is the explicit mutation boundary: it creates
+or updates generated normal Linear issue descriptions, links generated issue ids and
+node ids back to the Decision Contract, and stores the paired Program Intake Plan and
+Execution Program in runtime SQLite. Apply must not run implementation directly and
+must not apply or remove `decodex:queued:<service-id>`; later program reconciliation
+owns queue-label changes. If the contract is latent, rejected, still needs a human
+decision, carries unresolved missing decisions, or lacks proposed issue summaries,
+goal intake stops before creating executable work.
+
+The operator CLI surface for existing issues is
 `decodex intake issues --project <service-id> <ISSUE>... --dry-run`, or the same
 command with `--config <PROJECT_DIR>`. Dry-run reads tracker state and prints a
 deterministic ready/held/blocked/stale/unmapped report without mutating Linear and

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -63,6 +63,14 @@ state or this state machine.
 - `decodex research compile` and `decodex research promote` are runtime-local
   Decision Contract writes. They update the SQLite `decision_contracts` surface and do
   not by themselves create Linear issues, queue intent, goals, or executable lanes.
+- `decodex intake goal <CONTRACT_ID> --dry-run` is a tracker-read-only and
+  runtime-read-only operator surface for promoted Decision Contracts. It renders the
+  proposed normal Linear issue split, dependencies, conflict domains, and queue plan
+  without mutating Linear or persisting Program Intake rows. `--apply` creates or
+  updates generated normal Linear issue briefs, links generated issue ids and internal
+  node ids back into the Decision Contract and Execution Program records, and persists
+  the local Program Intake Plan plus Execution Program state. It must not start
+  implementation directly and must not apply queue labels.
 - `decodex intake issues <ISSUE>... --dry-run` is a tracker-read-only operator
   surface for existing Linear issues. It classifies the supplied batch as ready,
   held, blocked, stale, or unmapped and builds the same internal program model used


### PR DESCRIPTION
## Summary
- add `decodex intake goal` for promoted Decision Contract materialization
- create/update generated Linear issue briefs, persist Decision Contract links after each successful mutation, and store the resulting Execution Program
- add tracker create/update support plus docs/readme coverage for goal and issue-batch intake boundaries

## Review notes
- fixes the retained review blocker by persisting generated issue links after every successful Linear create/update
- fails closed when an existing generated issue link no longer resolves
- preserves later existing node links when a later issue update fails

## Verification
- `cargo make fmt`
- `cargo make lint-fix`
- `cargo make test` (1077 passed, 1 skipped)
- `cargo test -p decodex program_intake --lib`
- `cargo run -p decodex --bin decodex -- intake goal --help`
- `cargo run -p decodex --bin decodex -- intake issues --help`
- `git diff --check`