### PR TITLE
Dogfood Program Intake end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ cargo run -p decodex --bin decodex -- research promote <CONTRACT_ID>
 cargo run -p decodex --bin decodex -- intake goal --project decodex <CONTRACT_ID> --dry-run
 cargo run -p decodex --bin decodex -- intake goal --project decodex <CONTRACT_ID> --apply
 cargo run -p decodex --bin decodex -- intake issues --project decodex XY-1 XY-2 --dry-run
+cargo run -p decodex --bin decodex -- intake issues --project decodex XY-1 XY-2 --apply
 cargo run -p decodex --bin decodex -- radar refresh-upstream-queue
 cargo run -p decodex --bin decodex -- radar refresh-release-delta
 cargo run -p decodex --bin decodex -- radar validate
@@ -165,6 +166,14 @@ contract/program links in runtime SQLite. Apply does not run implementation or a
 queue labels; later reconciliation owns queue-label changes. If the contract is still
 latent, needs a decision, or lacks issue-shaping authority, intake stops before
 creating executable work.
+
+`decodex intake issues` materializes a supplied batch of existing Linear issues into
+local Program Intake state. `--dry-run` prints the deterministic ready/held/blocked
+report without mutation. `--apply` persists the local Program Intake Plan, Execution
+Program, issue mappings, and queue-label ownership evidence when already proven, but
+it still never applies or removes service queue labels directly. Program
+reconciliation owns those label changes on a later scan. `--persist` remains a legacy
+alias for `--apply`.
 
 ### Install from Source
 

--- a/apps/decodex/src/cli.rs
+++ b/apps/decodex/src/cli.rs
@@ -686,11 +686,11 @@ struct IntakeIssuesCommand {
 	#[arg(long, value_name = "SERVICE_ID", conflicts_with = "config")]
 	project: Option<String>,
 	/// Read tracker state and print the deterministic intake report without local persistence.
-	#[arg(long, conflicts_with = "persist", required_unless_present = "persist")]
+	#[arg(long, conflicts_with = "apply", required_unless_present = "apply")]
 	dry_run: bool,
-	/// Persist only local runtime Program Intake records; never mutates Linear queue labels.
-	#[arg(long, conflicts_with = "dry_run")]
-	persist: bool,
+	/// Persist local runtime Program Intake records; never mutates Linear queue labels.
+	#[arg(long, visible_alias = "persist", conflicts_with = "dry_run")]
+	apply: bool,
 	/// Emit structured JSON instead of human-readable text.
 	#[arg(long)]
 	json: bool,
@@ -707,7 +707,7 @@ impl IntakeIssuesCommand {
 				project_id: self.project.as_deref(),
 				issue_identifiers: self.issues.clone(),
 				dry_run: self.dry_run,
-				persist: self.persist,
+				persist: self.apply,
 			})?;
 
 		if self.json {
@@ -2627,12 +2627,67 @@ mod tests {
 				command: IntakeSubcommand::Issues(IntakeIssuesCommand {
 					project: Some(_),
 					dry_run: true,
-					persist: false,
+					apply: false,
 					json: true,
 					issues,
 					..
 				})
 			}) if issues == vec![String::from("XY-1"), String::from("XY-2")]
+		));
+	}
+
+	#[test]
+	fn parses_intake_issues_apply_with_project() {
+		let cli = Cli::parse_from([
+			"decodex",
+			"intake",
+			"issues",
+			"--project",
+			"decodex",
+			"XY-1",
+			"XY-2",
+			"--apply",
+			"--json",
+		]);
+
+		assert!(matches!(
+			cli.command,
+			Command::Intake(IntakeCommand {
+				command: IntakeSubcommand::Issues(IntakeIssuesCommand {
+					project: Some(_),
+					dry_run: false,
+					apply: true,
+					json: true,
+					issues,
+					..
+				})
+			}) if issues == vec![String::from("XY-1"), String::from("XY-2")]
+		));
+	}
+
+	#[test]
+	fn parses_intake_issues_legacy_persist_alias() {
+		let cli = Cli::parse_from([
+			"decodex",
+			"intake",
+			"issues",
+			"--project",
+			"decodex",
+			"XY-1",
+			"--persist",
+		]);
+
+		assert!(matches!(
+			cli.command,
+			Command::Intake(IntakeCommand {
+				command: IntakeSubcommand::Issues(IntakeIssuesCommand {
+					project: Some(_),
+					dry_run: false,
+					apply: true,
+					issues,
+					..
+				})
+			}) if issues == vec![String::from("XY-1")]
 		));
 	}
 
@@ -2670,9 +2725,9 @@ mod tests {
 	#[test]
 	fn rejects_intake_issues_without_explicit_mode() {
 		let error = Cli::try_parse_from(["decodex", "intake", "issues", "XY-1"])
-			.expect_err("intake issues requires dry-run or persist");
+			.expect_err("intake issues requires dry-run or apply");
 
-		assert!(error.to_string().contains("--dry-run") || error.to_string().contains("--persist"));
+		assert!(error.to_string().contains("--dry-run") || error.to_string().contains("--apply"));
 	}
 
 	#[test]

--- a/apps/decodex/src/execution_program.rs
+++ b/apps/decodex/src/execution_program.rs
@@ -1511,6 +1511,17 @@ fn evaluate_node(input: EvaluateNodeInput<'_>) -> Result<ExecutionNodeEvaluation
 		);
 
 		reasons.push(String::from("node no longer matches the accepted Decision Contract"));
+	} else if let Some(issue) = node.linear_issue()
+		&& policy.issue_is_terminal(issue)
+	{
+		state = ExecutionReadinessState::Completed;
+		lifecycle_state = Some(ExecutionProgramNodeLifecycleState::Completed);
+
+		reasons.push(format!(
+			"mapped issue `{}` is already terminal in `{}`",
+			issue.issue_identifier(),
+			issue.issue_state()
+		));
 	} else {
 		match node.queue_intent {
 			ExecutionQueueIntent::NotReady => {

--- a/apps/decodex/src/orchestrator/tests.rs
+++ b/apps/decodex/src/orchestrator/tests.rs
@@ -78,6 +78,8 @@ include!("tests/runtime/loop_scenarios.rs");
 
 include!("tests/runtime/program_reconciler.rs");
 
+include!("tests/runtime/program_intake_dogfood.rs");
+
 include!("tests/runtime/thread_archive.rs");
 
 include!("tests/recovery/reconciliation.rs");

--- a/apps/decodex/src/orchestrator/tests/runtime/program_intake_dogfood.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/program_intake_dogfood.rs
@@ -1,0 +1,598 @@
+mod program_intake_dogfood {
+use std::{cell::RefCell, collections::BTreeMap};
+
+use crate::{
+	config::ServiceConfig,
+	loop_contract::{DecisionContract, DecisionPromotion, DecisionPromotionActorKind},
+	orchestrator,
+	prelude::Result,
+	program_intake::{self, GoalIntakeRunRequest},
+	state::StateStore,
+	tracker::{
+		self, IssueTracker, TrackerComment, TrackerIssue, TrackerIssueBlocker,
+		TrackerIssueBriefUpdate, TrackerIssueCreate, TrackerLabel, TrackerState, TrackerTeam,
+	},
+	workflow::WorkflowDocument,
+};
+
+#[derive(Default)]
+struct DogfoodTracker {
+	issues: RefCell<BTreeMap<String, TrackerIssue>>,
+	label_additions: RefCell<Vec<(String, Vec<String>)>>,
+	label_removals: RefCell<Vec<(String, Vec<String>)>>,
+	next_goal_issue_number: RefCell<usize>,
+}
+impl DogfoodTracker {
+	fn with_issues(self, issues: impl IntoIterator<Item = TrackerIssue>) -> Self {
+		for issue in issues {
+			self.issues.borrow_mut().insert(issue.identifier.clone(), issue);
+		}
+
+		self
+	}
+
+	fn upsert_issue(&self, issue: TrackerIssue) {
+		self.issues.borrow_mut().insert(issue.identifier.clone(), issue);
+	}
+
+	fn label_additions(&self) -> Vec<(String, Vec<String>)> {
+		self.label_additions.borrow().clone()
+	}
+
+	fn label_removals(&self) -> Vec<(String, Vec<String>)> {
+		self.label_removals.borrow().clone()
+	}
+}
+
+impl IssueTracker for DogfoodTracker {
+	fn list_issues_with_label(&self, label_name: &str) -> Result<Vec<TrackerIssue>> {
+		Ok(self
+			.issues
+			.borrow()
+			.values()
+			.filter(|issue| issue.has_label(label_name))
+			.cloned()
+			.collect())
+	}
+
+	fn find_team_label_id(
+		&self,
+		_team_id: &str,
+		label_name: &str,
+	) -> Result<Option<String>> {
+		Ok(Some(format!("label-{label_name}")))
+	}
+
+	fn get_issue_by_identifier(
+		&self,
+		issue_identifier: &str,
+	) -> Result<Option<TrackerIssue>> {
+		Ok(self.issues.borrow().get(issue_identifier).cloned())
+	}
+
+	fn refresh_issues(&self, issue_ids: &[String]) -> Result<Vec<TrackerIssue>> {
+		Ok(self
+			.issues
+			.borrow()
+			.values()
+			.filter(|issue| issue_ids.iter().any(|issue_id| issue_id == &issue.id))
+			.cloned()
+			.collect())
+	}
+
+	fn list_comments(&self, _issue_id: &str) -> Result<Vec<TrackerComment>> {
+		Ok(Vec::new())
+	}
+
+	fn update_issue_state(
+		&self,
+		_issue_id: &str,
+		_state_id: &str,
+	) -> Result<()> {
+		Ok(())
+	}
+
+	fn add_issue_labels(
+		&self,
+		issue_id: &str,
+		label_ids: &[String],
+	) -> Result<()> {
+		self.label_additions
+			.borrow_mut()
+			.push((issue_id.to_owned(), label_ids.to_vec()));
+
+		self.update_issue_labels(issue_id, label_ids, true)
+	}
+
+	fn remove_issue_labels(
+		&self,
+		issue_id: &str,
+		label_ids: &[String],
+	) -> Result<()> {
+		self.label_removals
+			.borrow_mut()
+			.push((issue_id.to_owned(), label_ids.to_vec()));
+
+		self.update_issue_labels(issue_id, label_ids, false)
+	}
+
+	fn create_comment(&self, _issue_id: &str, _body: &str) -> Result<()> {
+		Ok(())
+	}
+
+	fn create_issue(&self, request: &TrackerIssueCreate) -> Result<TrackerIssue> {
+		let identifier = {
+			let mut next = self.next_goal_issue_number.borrow_mut();
+
+			*next += 1;
+
+			format!("PUB-G{}", next)
+		};
+		let state_name = request
+			.state_id
+			.as_deref()
+			.and_then(|state_id| state_id.strip_prefix("state-"))
+			.unwrap_or("Todo");
+		let mut issue = dogfood_issue("pubfi", &format!("issue-{identifier}"), &identifier, state_name, &[]);
+
+		issue.team.id.clone_from(&request.team_id);
+		issue.title.clone_from(&request.title);
+		issue.description.clone_from(&request.description);
+		self.upsert_issue(issue.clone());
+
+		Ok(issue)
+	}
+
+	fn update_issue_brief(
+		&self,
+		issue_id: &str,
+		request: &TrackerIssueBriefUpdate,
+	) -> Result<TrackerIssue> {
+		let mut issues = self.issues.borrow_mut();
+		let issue = issues
+			.values_mut()
+			.find(|issue| issue.id == issue_id)
+			.unwrap_or_else(|| panic!("issue `{issue_id}` should exist"));
+
+		issue.title.clone_from(&request.title);
+		issue.description.clone_from(&request.description);
+
+		Ok(issue.clone())
+	}
+}
+impl DogfoodTracker {
+	fn update_issue_labels(
+		&self,
+		issue_id: &str,
+		label_ids: &[String],
+		present: bool,
+	) -> Result<()> {
+		let mut issues = self.issues.borrow_mut();
+		let issue = issues
+			.values_mut()
+			.find(|issue| issue.id == issue_id)
+			.unwrap_or_else(|| panic!("issue `{issue_id}` should exist"));
+		let labels = label_ids
+			.iter()
+			.map(|label_id| {
+				issue
+					.team
+					.labels
+					.iter()
+					.find(|label| label.id == *label_id)
+					.cloned()
+					.unwrap_or_else(|| TrackerLabel {
+						id: label_id.clone(),
+						name: label_id.strip_prefix("label-").unwrap_or(label_id).to_owned(),
+					})
+			})
+			.collect::<Vec<_>>();
+
+		for label in labels {
+			if present {
+				if !issue.labels.iter().any(|existing| existing.name == label.name) {
+					issue.labels.push(label);
+				}
+			} else {
+				issue.labels.retain(|existing| existing.name != label.name);
+			}
+		}
+
+		Ok(())
+	}
+}
+
+#[test]
+fn issue_batch_intake_apply_reconcile_unlock_and_status_readback_is_end_to_end() {
+	let (_temp_dir, config, workflow) = super::temp_project_layout();
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let queue_label = tracker::automation_queue_label(config.service_id());
+	let dependency_todo = dogfood_issue(config.service_id(), "issue-dependency", "PUB-942A", "Todo", &[]);
+	let dependent_todo = with_blocker(
+		dogfood_issue(config.service_id(), "issue-dependent", "PUB-942B", "Todo", &[]),
+		"PUB-942A",
+		"Todo",
+	);
+	let tracker =
+		DogfoodTracker::default().with_issues([dependency_todo.clone(), dependent_todo.clone()]);
+	let dry_run_report = program_intake::run_issue_batch_intake(
+		&store,
+		&tracker,
+		&config,
+		&workflow,
+		vec![String::from("PUB-942B"), String::from("PUB-942A")],
+		true,
+		false,
+	)
+	.expect("issue-batch dry-run should classify controlled fixtures");
+
+	assert!(dry_run_report.dry_run);
+	assert!(!dry_run_report.persisted);
+	assert_eq!(dry_run_report.counts.ready, 1);
+	assert_eq!(dry_run_report.counts.blocked, 1);
+	assert!(store.list_execution_programs(config.service_id()).expect("programs").is_empty());
+
+	let apply_report = program_intake::run_issue_batch_intake(
+		&store,
+		&tracker,
+		&config,
+		&workflow,
+		vec![String::from("PUB-942B"), String::from("PUB-942A")],
+		false,
+		true,
+	)
+	.expect("issue-batch apply should persist the internal program");
+
+	assert!(apply_report.persisted);
+	assert!(tracker.label_additions().is_empty());
+	assert_eq!(
+		store
+			.list_program_issue_mappings(config.service_id(), &apply_report.program_id)
+			.expect("program issue mappings should list")
+			.len(),
+		2
+	);
+
+	assert_initial_issue_batch_scan(&tracker, &config, &workflow, &store, &dependency_todo);
+
+	let mut dependency_done =
+		dogfood_issue(config.service_id(), "issue-dependency", "PUB-942A", "Done", &[queue_label.as_str()]);
+
+	dependency_done.id.clone_from(&dependency_todo.id);
+	tracker.upsert_issue(dependency_done);
+
+	let mut dependent_unblocked = with_blocker(
+		dogfood_issue(config.service_id(), "issue-dependent", "PUB-942B", "Todo", &[]),
+		"PUB-942A",
+		"Done",
+	);
+
+	dependent_unblocked.id.clone_from(&dependent_todo.id);
+	tracker.upsert_issue(dependent_unblocked);
+
+	assert_unlocked_issue_batch_scan(&tracker, &config, &workflow, &store, &dependency_todo, &dependent_todo);
+}
+
+fn assert_initial_issue_batch_scan(
+	tracker: &DogfoodTracker,
+	config: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	store: &StateStore,
+	dependency_todo: &TrackerIssue,
+) {
+	let first_scan =
+		orchestrator::reconcile_execution_program_queue_labels(tracker, config, workflow, store)
+			.expect("first program reconciliation should queue only the ready node");
+
+	assert_eq!(first_scan.labels_applied, 1);
+	assert_eq!(
+		tracker.label_additions(),
+		vec![(dependency_todo.id.clone(), vec![String::from("label-queued")])]
+	);
+
+	let first_snapshot =
+		orchestrator::build_live_operator_status_snapshot(tracker, config, workflow, store, 10)
+			.expect("first status snapshot should build");
+	let first_program =
+		first_snapshot.execution_programs.first().expect("program status should surface");
+
+	assert_eq!(first_program.status, "blocked");
+	assert_eq!(first_program.intake_kind.as_deref(), Some("issue_batch_intake"));
+	assert_eq!(first_program.queued_count, 1);
+	assert_eq!(first_program.blocked_count, 1);
+	assert!(
+		first_program
+			.node_readbacks
+			.iter()
+			.any(|node| node.reason_codes.contains(&String::from("dependency_not_terminal")))
+	);
+}
+
+fn assert_unlocked_issue_batch_scan(
+	tracker: &DogfoodTracker,
+	config: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	store: &StateStore,
+	dependency_todo: &TrackerIssue,
+	dependent_todo: &TrackerIssue,
+) {
+	let second_scan =
+		orchestrator::reconcile_execution_program_queue_labels(tracker, config, workflow, store)
+			.expect("second program reconciliation should unlock the downstream node");
+
+	assert_eq!(second_scan.labels_applied, 1);
+	assert_eq!(second_scan.labels_removed, 1);
+	assert!(tracker.label_additions().contains(&(
+		dependent_todo.id.clone(),
+		vec![String::from("label-queued")]
+	)));
+	assert_eq!(
+		tracker.label_removals(),
+		vec![(dependency_todo.id.clone(), vec![String::from("label-queued")])]
+	);
+
+	let second_snapshot =
+		orchestrator::build_live_operator_status_snapshot(tracker, config, workflow, store, 10)
+			.expect("second status snapshot should build");
+	let second_program =
+		second_snapshot.execution_programs.first().expect("program status should remain visible");
+	let rendered_status = orchestrator::render_operator_status(&second_snapshot);
+
+	assert_eq!(second_program.status, "queued", "{rendered_status}");
+	assert_eq!(second_program.completed_count, 1);
+	assert_eq!(second_program.queued_count, 1);
+	assert_eq!(second_program.blocked_count, 0);
+	assert!(rendered_status.contains("Execution Programs"));
+	assert!(rendered_status.contains("mapped_issues=PUB-942A, PUB-942B"));
+	assert!(!rendered_status.contains("private_evidence"));
+}
+
+#[test]
+fn goal_intake_rejects_latent_then_apply_reconcile_and_status_readback_is_end_to_end() {
+	let (_temp_dir, config, workflow) = super::temp_project_layout();
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let source_issue = dogfood_issue(config.service_id(), "issue-source", "PUB-940A", "Todo", &[]);
+	let tracker = DogfoodTracker::default().with_issues([source_issue]);
+	let latent = dogfood_goal_contract();
+
+	store
+		.upsert_decision_contract(config.service_id(), Some("PUB-940A"), latent.clone())
+		.expect("latent contract should persist");
+
+	let latent_error = program_intake::run_goal_intake(GoalIntakeRunRequest {
+		state_store: &store,
+		tracker: &tracker,
+		config: &config,
+		workflow: &workflow,
+		contract_id: latent.contract_id(),
+		team_issue_identifier: None,
+		dry_run: false,
+		apply: true,
+	})
+	.expect_err("latent contract must not materialize");
+
+	assert!(latent_error.to_string().contains("requires accepted execution authority"));
+	assert!(store.list_execution_programs(config.service_id()).expect("programs").is_empty());
+
+	let mut accepted = latent.clone();
+
+	accepted
+		.promote(
+			DecisionPromotion::new(
+				"operator",
+				DecisionPromotionActorKind::User,
+				"2026-06-12T00:00:00Z",
+				"controlled_fixture",
+				Some(String::from("XY-942 controlled dogfood accepted authority.")),
+			)
+			.expect("promotion should build"),
+		)
+		.expect("contract should promote");
+	store
+		.upsert_decision_contract(config.service_id(), Some("PUB-940A"), accepted.clone())
+		.expect("accepted contract should persist");
+
+	let apply_report = program_intake::run_goal_intake(GoalIntakeRunRequest {
+		state_store: &store,
+		tracker: &tracker,
+		config: &config,
+		workflow: &workflow,
+		contract_id: accepted.contract_id(),
+		team_issue_identifier: None,
+		dry_run: false,
+		apply: true,
+	})
+	.expect("accepted contract should materialize issues and program");
+
+	assert!(apply_report.applied);
+	assert!(apply_report.persisted);
+	assert_eq!(apply_report.issues.len(), 2);
+	assert!(tracker.label_additions().is_empty());
+
+	let scan =
+		orchestrator::reconcile_execution_program_queue_labels(&tracker, &config, &workflow, &store)
+			.expect("goal-intake program reconciliation should queue generated ready nodes");
+
+	assert_eq!(scan.labels_applied, 2);
+
+	let snapshot =
+		orchestrator::build_live_operator_status_snapshot(&tracker, &config, &workflow, &store, 10)
+			.expect("goal-intake status snapshot should build");
+	let program = snapshot.execution_programs.first().expect("goal program should surface");
+	let rendered_status = orchestrator::render_operator_status(&snapshot);
+
+	assert_eq!(program.status, "queued");
+	assert_eq!(program.source_contract_id.as_deref(), Some(accepted.contract_id()));
+	assert_eq!(program.intake_kind.as_deref(), Some("goal_intake"));
+	assert_eq!(
+		program.public_summary.as_deref(),
+		Some("Dogfood accepted goal intake through generated issues.")
+	);
+	assert_eq!(program.queued_count, 2);
+	assert_eq!(program.queue_label_retain_count, 2);
+	assert!(rendered_status.contains("source_contract_id: dogfood-goal-contract"));
+	assert!(!rendered_status.contains("private_evidence"));
+	assert!(!rendered_status.contains("research_evidence"));
+}
+
+fn dogfood_goal_contract() -> DecisionContract {
+	serde_json::from_value(serde_json::json!({
+		"schema": crate::loop_contract::DECISION_CONTRACT_SCHEMA,
+		"record_version": crate::loop_contract::DECISION_CONTRACT_RECORD_VERSION,
+		"contract_id": "dogfood-goal-contract",
+		"status": "draft_latent",
+		"source_intent": {
+			"summary": "Dogfood Program Intake.",
+			"user_utterance": "arrange this controlled Program Intake fixture",
+			"source_issue_identifier": "PUB-940A"
+		},
+		"research_provenance": [{
+			"kind": "spec",
+			"reference": "docs/spec/loop-runtime.md",
+			"summary": "Program Intake materializes accepted contracts."
+		}],
+		"research_evidence": [{
+			"claim": "Goal intake can create normal issues and persist an Execution Program.",
+			"support": "Controlled fixture for XY-942.",
+			"source_ref": "XY-942"
+		}],
+		"research_options": [],
+		"accepted_authority": {
+			"accepted_objectives": [
+				"Dogfood accepted goal intake through generated issues."
+			],
+			"non_goals": [
+				"Do not mutate live production queue labels during this fixture."
+			],
+			"constraints": [
+				"Generated issues remain natural-language Linear briefs."
+			],
+			"assumptions": [
+				"The source issue anchors the generated issue team and state."
+			],
+			"objections": [],
+			"stop_conditions": [
+				"Stop if the contract is latent or needs a human decision."
+			]
+		},
+		"execution_readiness": {
+			"summary": "Ready for controlled issue shaping.",
+			"ready_for_issue_shaping": true,
+			"missing_decisions": [],
+			"validation_expectations": [
+				"Run focused Program Intake E2E tests."
+			],
+			"risk_notes": [
+				"Public readback must stay sparse."
+			],
+			"proposed_issue_summaries": [
+				"Dogfood generated runtime issue.",
+				"Dogfood generated status readback issue."
+			],
+			"conflict_domains": [
+				"module:runtime",
+				"module:status"
+			],
+			"queue_intent": [
+				"ready_to_queue_after_apply"
+			]
+		},
+		"links": {
+			"generated_issue_ids": [],
+			"generated_issue_identifiers": [],
+			"execution_program_node_ids": []
+		},
+		"evidence_boundary": {
+			"private_evidence_refs": [],
+			"public_projection_refs": [],
+			"public_summary": "Controlled dogfood goal intake fixture."
+		}
+	}))
+	.expect("dogfood goal contract should deserialize")
+}
+
+fn dogfood_issue(
+	service_id: &str,
+	issue_id: &str,
+	identifier: &str,
+	state_name: &str,
+	labels: &[&str],
+) -> TrackerIssue {
+	let team_labels = vec![
+		TrackerLabel {
+			id: String::from("label-queued"),
+			name: crate::tracker::automation_queue_label(service_id),
+		},
+		TrackerLabel {
+			id: String::from("label-active"),
+			name: crate::tracker::automation_active_label(service_id),
+		},
+		TrackerLabel {
+			id: String::from("label-manual"),
+			name: String::from("decodex:manual-only"),
+		},
+		TrackerLabel {
+			id: String::from("label-needs-attention"),
+			name: String::from("decodex:needs-attention"),
+		},
+	];
+	let issue_labels = labels
+		.iter()
+		.map(|name| {
+			team_labels
+				.iter()
+				.find(|label| label.name == *name)
+				.cloned()
+				.unwrap_or_else(|| TrackerLabel {
+					id: format!("label-{name}"),
+					name: (*name).to_owned(),
+				})
+		})
+		.collect::<Vec<_>>();
+
+	TrackerIssue {
+		id: issue_id.to_owned(),
+		identifier: identifier.to_owned(),
+		project_slug: Some(service_id.to_owned()),
+		title: format!("Resolve {identifier}"),
+		author: Some(String::from("Decodex")),
+		description: format!("Implement controlled Program Intake fixture for {identifier}."),
+		priority: None,
+		created_at: String::from("2026-06-12T00:00:00Z"),
+		updated_at: String::from("2026-06-12T00:00:00Z"),
+		state: TrackerState { id: format!("state-{state_name}"), name: state_name.to_owned() },
+		team: TrackerTeam {
+			id: String::from("team-dogfood"),
+			name: String::from("Dogfood"),
+			states: vec![
+				TrackerState { id: String::from("state-Todo"), name: String::from("Todo") },
+				TrackerState {
+					id: String::from("state-In Progress"),
+					name: String::from("In Progress"),
+				},
+				TrackerState { id: String::from("state-In Review"), name: String::from("In Review") },
+				TrackerState { id: String::from("state-Done"), name: String::from("Done") },
+				TrackerState { id: String::from("state-Canceled"), name: String::from("Canceled") },
+				TrackerState { id: String::from("state-Duplicate"), name: String::from("Duplicate") },
+			],
+			labels: team_labels,
+		},
+		labels_complete: true,
+		labels: issue_labels,
+		blockers: Vec::new(),
+	}
+}
+
+fn with_blocker(mut issue: TrackerIssue, identifier: &str, state_name: &str) -> TrackerIssue {
+	issue.blockers.push(TrackerIssueBlocker {
+		id: format!("issue-blocker-{identifier}"),
+		identifier: identifier.to_owned(),
+		state: TrackerState {
+			id: format!("state-blocker-{state_name}"),
+			name: state_name.to_owned(),
+		},
+	});
+
+	issue
+}
+}

--- a/apps/decodex/src/program_intake.rs
+++ b/apps/decodex/src/program_intake.rs
@@ -298,7 +298,7 @@ pub(crate) fn run_issue_batch_intake_command(
 	request: IssueBatchIntakeCommandRequest<'_>,
 ) -> Result<IssueBatchIntakeReport> {
 	if request.dry_run == request.persist {
-		eyre::bail!("Issue-batch intake requires exactly one of --dry-run or --persist.");
+		eyre::bail!("Issue-batch intake requires exactly one of --dry-run or --apply.");
 	}
 
 	let state_store = runtime::open_runtime_store()?;
@@ -564,7 +564,7 @@ where
 
 /// Render a compact human-readable intake report.
 pub(crate) fn render_issue_batch_intake_report(report: &IssueBatchIntakeReport) -> String {
-	let mode = if report.persisted { "persist" } else { "dry-run" };
+	let mode = if report.persisted { "apply" } else { "dry-run" };
 	let mut output = format!(
 		"program intake {mode}: service={} program={} queue_label={} ready={} held={} blocked={} stale={} unmapped={}\n",
 		report.service_id,

--- a/docs/spec/loop-runtime.md
+++ b/docs/spec/loop-runtime.md
@@ -351,10 +351,10 @@ The operator CLI surface for existing issues is
 `decodex intake issues --project <service-id> <ISSUE>... --dry-run`, or the same
 command with `--config <PROJECT_DIR>`. Dry-run reads tracker state and prints a
 deterministic ready/held/blocked/stale/unmapped report without mutating Linear and
-without persisting local runtime rows. `--persist` is an explicit local-runtime write:
+without persisting local runtime rows. `--apply` is an explicit local-runtime write:
 it stores the Program Intake Plan, Execution Program payload, issue mappings, and any
 already-proven program-owned queue-label evidence, but it still must not apply or
-remove `decodex:queued:<service-id>`.
+remove `decodex:queued:<service-id>`. `--persist` is a legacy alias for `--apply`.
 
 ## Internal Execution Program
 

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -75,9 +75,9 @@ state or this state machine.
   surface for existing Linear issues. It classifies the supplied batch as ready,
   held, blocked, stale, or unmapped and builds the same internal program model used
   by later persistence, but it must not mutate Linear or write local runtime rows.
-  `--persist` writes only local runtime Program Intake and Execution Program state;
+  `--apply` writes only local runtime Program Intake and Execution Program state;
   queue labels remain untouched until a later reconciliation surface is explicitly
-  authorized.
+  authorized. `--persist` is a legacy alias for `--apply`.
 - On each normal Linear scan tick, the control plane reconciles persisted Execution
   Programs before normal issue selection. The reconciler refreshes mapped Linear
   issue state, dependency observations, local active leases, retained review/landing

--- a/docs/spec/tracker-tools.md
+++ b/docs/spec/tracker-tools.md
@@ -131,9 +131,10 @@ In either invalid case, `decodex` must fail the attempt rather than infer which 
   not directly start an app-server run.
 - `decodex intake issues ... --dry-run` may read tracker state for supplied issues
   and render a local ready/held/blocked/stale/unmapped report, but it must not call
-  tracker label mutation tools or write Linear comments. `--persist` may write local
+  tracker label mutation tools or write Linear comments. `--apply` may write local
   runtime Program Intake records and issue mappings, but it still must not apply or
-  remove `decodex:queued:<service-id>`.
+  remove `decodex:queued:<service-id>`. `--persist` remains a legacy alias for
+  `--apply`.
 - `issue_progress_checkpoint` must accept only the normalized execution phases `probing`, `implementing`, `verifying`, `blocked`, `ready_for_review`, `review_repair`, `ready_to_land`, and `closeout`.
 - `issue_progress_checkpoint` must not replace `issue_review_checkpoint`, `issue_review_handoff`, `issue_review_repair_complete`, `issue_closeout_complete`, or `issue_terminal_finalize`.
 - `decodex` treats `issue_progress_checkpoint` as execution memory only. Checkpoint phase, focus, next action, blockers, or evidence do not by themselves authorize review handoff, repair completion, merge, closeout, or terminal success.


### PR DESCRIPTION
## Summary

- Promote `decodex intake issues ... --apply` as the issue-batch persistence mode while keeping `--persist` as a legacy alias.
- Treat mapped terminal issues as completed in Execution Program readiness so issue-batch DAGs unlock downstream nodes after upstream completion.
- Add controlled Program Intake dogfood E2E coverage for issue-batch apply/reconcile/status readback and goal-intake latent rejection/apply/reconcile/status readback.
- Update README and specs to align the CLI surface and queue-label ownership boundaries.

## Verification

- `npm ci` in `site/`
- `cargo test -p decodex program_intake_dogfood -- --nocapture`
- `cargo test -p decodex intake_issues -- --nocapture`
- `cargo vstyle curate --language rust --workspace --all-features`
- `cargo make check`
- `git diff --check`
- Semantic drift audit: pass by manual review; docs claims match CLI/parser, intake persistence behavior, reconciler behavior, and E2E readback tests.
