### PR TITLE
Persist upstream Radar review artifacts

### DIFF
--- a/artifacts/github/bundles/openai-codex-pr-27413.json
+++ b/artifacts/github/bundles/openai-codex-pr-27413.json
@@ -1,0 +1,125 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-10T16:23:04Z",
+      "message": "skills: decouple extension from core",
+      "sha": "9ff580bf7e426f19713de20aaa9a0138a4aa389f",
+      "url": "https://github.com/openai/codex/commit/9ff580bf7e426f19713de20aaa9a0138a4aa389f"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-11T11:54:59Z",
+      "message": "Merge remote-tracking branch 'origin/main' into HEAD",
+      "sha": "3eb9c5126d277d5c6e2b92dfb71a3025942a19ef",
+      "url": "https://github.com/openai/codex/commit/3eb9c5126d277d5c6e2b92dfb71a3025942a19ef"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "API",
+    "HEAD",
+    "MAX_SKILL_NAME_BYTES",
+    "SKILLS_INSTRUCTIONS_CLOSE_TAG",
+    "SKILLS_INSTRUCTIONS_OPEN_TAG",
+    "MAX_AVAILABLE_SKILLS_BYTES",
+    "MAX_MAIN_PROMPT_BYTES",
+    "SKILLS_HOW_TO_USE_WITH_ABSOLUTE_PATHS",
+    "SKILLS_INTRO_WITH_ABSOLUTE_PATHS",
+    "NEXT_CODEX_HOME_ID",
+    "DEMO_SKILL_CONTENTS",
+    "SKILL"
+  ],
+  "files": [
+    {
+      "additions": 0,
+      "deletions": 1,
+      "patch_excerpt": "@@ -3815,7 +3815,6 @@ name = \"codex-skills-extension\"\n version = \"0.0.0\"\n dependencies = [\n  \"async-trait\",\n- \"codex-core\",\n  \"codex-core-skills\",\n  \"codex-exec-server\",\n  \"codex-extension-api\",",
+      "path": "codex-rs/Cargo.lock",
+      "status": "modified"
+    },
+    {
+      "additions": 4,
+      "deletions": 0,
+      "patch_excerpt": "@@ -80,6 +80,10 @@ where\n             .with_orchestrator_provider(Arc::new(\n                 codex_skills_extension::OrchestratorSkillProvider::new(),\n             )),\n+        |config: &Config| codex_skills_extension::SkillsExtensionConfig {\n+            include_instructions: config.include_skill_instructions,\n+            bundled_skills_enabled: config.bundled_skills_enabled(),\n+        },\n     );\n     Arc::new(builder.build())\n }",
+      "path": "codex-rs/app-server/src/extensions.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 1,
+      "patch_excerpt": "@@ -14,7 +14,6 @@ doctest = false\n workspace = true\n \n [dependencies]\n-codex-core = { workspace = true }\n codex-core-skills = { workspace = true }\n codex-exec-server = { workspace = true }\n codex-extension-api = { workspace = true }",
+      "path": "codex-rs/ext/skills/Cargo.toml",
+      "status": "modified"
+    },
+    {
+      "additions": 8,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,8 @@\n+/// Host-supplied configuration used by the skills extension.\n+#[derive(Clone, Debug, Eq, PartialEq)]\n+pub struct SkillsExtensionConfig {\n+    /// Whether the available-skills catalog is included in model context.\n+    pub include_instructions: bool,\n+    /// Whether bundled skills are eligible for discovery.\n+    pub bundled_skills_enabled: bool,\n+}",
+      "path": "codex-rs/ext/skills/src/config.rs",
+      "status": "added"
+    },
+    {
+      "additions": 46,
+      "deletions": 26,
+      "patch_excerpt": "@@ -1,10 +1,7 @@\n use std::sync::Arc;\n \n-use codex_core::config::Config;\n use codex_core_skills::HostLoadedSkills;\n-use codex_core_skills::SkillInstructions;\n use codex_core_skills::injection::InjectedHostSkillPrompts;\n-use codex_core_skills::injection::SkillInjection;\n use codex_extension_api::ConfigContributor;\n use codex_extension_api::ContextContributor;\n use codex_extension_api::ContextualUserFragment;\n@@ -26,10 +23,12 @@ use codex_protocol::protocol::Event;\n use codex_protocol::protocol::EventMsg;\n use codex_protocol::protocol::WarningEvent;\n \n+use crate::SkillsExtensionConfig;\n use crate::catalog::SkillCatalog;\n use crate::catalog::SkillCatalogEntry;\n use crate::catalog::SkillReadResult;\n use crate::catalog::SkillSourceKind;\n+use crate::fragments::SkillInstructions;\n use crate::provider::HostSkillProvider;\n use crate::provider::SkillListQuery;\n use crate::provider::SkillReadReques...",
+      "path": "codex-rs/ext/skills/src/extension.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 61,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,61 @@\n+use codex_core_skills::render_available_skills_body;\n+use codex_extension_api::ContextualUserFragment;\n+use codex_protocol::protocol::SKILLS_INSTRUCTIONS_CLOSE_TAG;\n+use codex_protocol::protocol::SKILLS_INSTRUCTIONS_OPEN_TAG;\n+\n+#[derive(Clone, Debug, Eq, PartialEq)]\n+pub(crate) struct AvailableSkillsInstructions {\n+    skill_lines: Vec<String>,\n+}\n+\n+impl AvailableSkillsInstructions {\n+    pub(crate) fn from_skill_lines(skill_lines: Vec<String>) -> Self {\n+        Self { skill_lines }\n+    }\n+}\n+\n+impl ContextualUserFragment for AvailableSkillsInstructions {\n+    fn role(&self) -> &'static str {\n+        \"developer\"\n+    }\n+\n+    fn markers(&self) -> (&'static str, &'static str) {\n+        Self::type_markers()\n+    }\n+\n+    fn type_markers() -> (&'static str, &'static str) {\n+        (SKILLS_INSTRUCTIONS_OPEN_TAG, SKILLS_INSTRUCTIONS_CLOSE_TAG)\n+    }\n+\n+    fn body(&s...",
+      "path": "codex-rs/ext/skills/src/fragments.rs",
+      "status": "added"
+    },
+    {
+      "additions": 3,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1,12 +1,15 @@\n pub mod catalog;\n+mod config;\n mod extension;\n+mod fragments;\n pub mod provider;\n mod render;\n mod selection;\n mod sources;\n mod state;\n mod tools;\n \n+pub use config::SkillsExtensionConfig;\n pub use extension::install;\n pub use extension::install_with_providers;\n pub use provider::ExecutorSkillProvider;",
+      "path": "codex-rs/ext/skills/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -1,9 +1,9 @@\n-use codex_core::context::AvailableSkillsInstructions;\n use codex_utils_string::take_bytes_at_char_boundary;\n \n use crate::catalog::SkillCatalog;\n use crate::catalog::SkillCatalogEntry;\n use crate::catalog::SkillSourceKind;\n+use crate::fragments::AvailableSkillsInstructions;\n \n const MAX_AVAILABLE_SKILLS_BYTES: usize = 8_000;\n const MAX_MAIN_PROMPT_BYTES: usize = 8_000;",
+      "path": "codex-rs/ext/skills/src/render.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 16,
+      "patch_excerpt": "@@ -1,28 +1,13 @@\n-use codex_core::config::Config;\n use codex_protocol::capabilities::SelectedCapabilityRoot;\n use std::future::Future;\n use std::sync::Mutex;\n use tokio::sync::OnceCell;\n \n+use crate::SkillsExtensionConfig;\n use crate::catalog::SkillCatalog;\n use crate::catalog::SkillCatalogEntry;\n use crate::catalog::SkillProviderError;\n \n-#[derive(Clone, Debug, PartialEq, Eq)]\n-pub(crate) struct SkillsExtensionConfig {\n-    pub(crate) include_instructions: bool,\n-    pub(crate) bundled_skills_enabled: bool,\n-}\n-\n-impl SkillsExtensionConfig {\n-    pub(crate) fn from_config(config: &Config) -> Self {\n-        Self {\n-            include_instructions: config.include_skill_instructions,\n-            bundled_skills_enabled: config.bundled_skills_enabled(),\n-        }\n-    }\n-}\n-\n #[derive(Debug)]\n pub(crate) struct SkillsThreadState {\n     config: Mutex<SkillsExtensionConfig>,",
+      "path": "codex-rs/ext/skills/src/state.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 67,
+      "deletions": 58,
+      "patch_excerpt": "@@ -4,11 +4,11 @@ use std::sync::Mutex;\n use std::sync::atomic::AtomicUsize;\n use std::sync::atomic::Ordering;\n \n-use codex_core::config::Config;\n-use codex_core::config::ConfigBuilder;\n use codex_core_skills::HostLoadedSkills;\n-use codex_core_skills::SkillsLoadInput;\n-use codex_core_skills::SkillsManager;\n+use codex_core_skills::SKILLS_HOW_TO_USE_WITH_ABSOLUTE_PATHS;\n+use codex_core_skills::SKILLS_INTRO_WITH_ABSOLUTE_PATHS;\n+use codex_core_skills::SkillLoadOutcome;\n+use codex_core_skills::SkillMetadata;\n use codex_core_skills::injection::InjectedHostSkillPrompts;\n use codex_extension_api::ExtensionData;\n use codex_extension_api::ExtensionEventSink;\n@@ -19,10 +19,13 @@ use codex_protocol::capabilities::CapabilityRootLocation;\n use codex_protocol::capabilities::SelectedCapabilityRoot;\n use codex_protocol::protocol::Event;\n use codex_protocol::protocol::EventMsg;\n+use codex_protocol::proto...",
+      "path": "codex-rs/ext/skills/tests/skills_extension.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#27404"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\n`ext/skills` currently depends on `codex-core` for two host concerns: reading the concrete `Config` type and borrowing core-owned model-context fragment types. That coupling prevents the extension from being assembled independently above core and leaves context that belongs to the skills feature owned by core.\n\nThis stacked PR introduces the host boundary needed for the broader extension migration while intentionally preserving existing skills behavior. It is stacked on #27404.\n\n## What changed\n\n- Adds a small public `SkillsExtensionConfig` view and makes skills installation generic over the host config type.\n- Requires the host to map its config into that view; app-server supplies the current `Config` values.\n- Moves the available-skills and selected-skill context fragment implementations into `ext/skills`, preserving their roles, markers, and rendered bytes.\n- Removes the direct `codex-core` dependency from `codex-skills-extension`.\n- Keeps local discovery, invocation, side effects, and the `codex-core-skills` compatibility types unchanged for later staged PRs.\n\n## Behavior\n\nThis adds no capability and is intended to have no user-visible or model-visible behavior change. The install API and ownership boundary change internally; emitted skills context remains byte-for-byte compatible.\n\n## Validation\n\n- Updates the skills extension integration coverage to use a host-owned test config.\n- Asserts the complete rendered catalog and selected-skill fragments, including their roles and markers.\n- `just bazel-lock-check`\n- Rust tests and Clippy were not run locally per request; CI will run them.\n",
+    "labels": [],
+    "merged_at": "2026-06-11T12:03:53Z",
+    "number": 27413,
+    "state": "merged",
+    "title": "skills: decouple the skills extension from core",
+    "url": "https://github.com/openai/codex/pull/27413"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27569.json
+++ b/artifacts/github/bundles/openai-codex-pr-27569.json
@@ -1,0 +1,106 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-11T09:13:59Z",
+      "message": "feat: update max concurrency message",
+      "sha": "168cddddc1b5c5f4fe64534acc4e31ae69474365",
+      "url": "https://github.com/openai/codex/commit/168cddddc1b5c5f4fe64534acc4e31ae69474365"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-11T09:51:34Z",
+      "message": "fix: preserve rendered usage hints across forks",
+      "sha": "fe04e86efaae705d0b47e3d076e82d54b2e1dca5",
+      "url": "https://github.com/openai/codex/commit/fe04e86efaae705d0b47e3d076e82d54b2e1dca5"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-11T10:01:20Z",
+      "message": "refactor: simplify multi-agent concurrency guidance",
+      "sha": "92644c48f26b1f5d92892c01cd1585b86fc381f1",
+      "url": "https://github.com/openai/codex/commit/92644c48f26b1f5d92892c01cd1585b86fc381f1"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-11T10:23:08Z",
+      "message": "fix: derive usage hints from configured concurrency",
+      "sha": "e13920ef12be52e892db5cbf3e0a3402d5d33f6e",
+      "url": "https://github.com/openai/codex/commit/e13920ef12be52e892db5cbf3e0a3402d5d33f6e"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "DEFAULT_MULTI_AGENT_V2_ROOT_AGENT_USAGE_HINT_TEXT",
+    "DEFAULT_MULTI_AGENT_V2_SUBAGENT_USAGE_HINT_TEXT",
+    "HARD_MIN_MULTI_AGENT_V2_TIMEOUT_MS",
+    "HARD_MAX_MULTI_AGENT_V2_TIMEOUT_MS",
+    "DEFAULT_MULTI_AGENT_V2_MAX_WAIT_TIMEOUT_MS",
+    "DEFAULT_MULTI_AGENT_V2_MAX_CONCURRENT_THREADS_PER_SESSION",
+    "DEFAULT_MULTI_AGENT_V2_MIN_WAIT_TIMEOUT_MS",
+    "DEFAULT_MULTI_AGENT_V2_DEFAULT_WAIT_TIMEOUT_MS",
+    "SPAWN_AGENT_INHERITED_MODEL_GUIDANCE"
+  ],
+  "files": [
+    {
+      "additions": 23,
+      "deletions": 30,
+      "patch_excerpt": "@@ -9831,47 +9831,40 @@ enabled = true\n         .build()\n         .await?;\n \n-    assert_eq!(config.multi_agent_v2.max_concurrent_threads_per_session, 4);\n-    assert_eq!(config.multi_agent_v2.min_wait_timeout_ms, 10_000);\n-    assert_eq!(config.multi_agent_v2.max_wait_timeout_ms, 3_600_000);\n-    assert_eq!(config.multi_agent_v2.default_wait_timeout_ms, 30_000);\n+    assert_eq!(config.multi_agent_v2, MultiAgentV2Config::default());\n     assert_eq!(\n         (\n             config.agent_max_threads,\n             config.effective_agent_max_threads(MultiAgentVersion::V2)\n         ),\n         (None, Some(3))\n     );\n-    assert_eq!(\n-        config.multi_agent_v2.root_agent_usage_hint_text.as_deref(),\n-        Some(DEFAULT_MULTI_AGENT_V2_ROOT_AGENT_USAGE_HINT_TEXT)\n-    );\n-    assert!(\n-        !config\n-            .multi_agent_v2\n-            .root_agent_usage_hint_text\n-            .as_de...",
+      "path": "codex-rs/core/src/config/config_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 29,
+      "deletions": 13,
+      "patch_excerpt": "@@ -233,6 +233,13 @@ Payload:\n ```\n You may also see them addressed as to=/root/..., which indicates your identity is /root/...\n \"#;\n+\n+fn default_multi_agent_v2_usage_hint_text(usage_hint_text: &str, max_concurrency: usize) -> String {\n+    format!(\n+        \"{usage_hint_text}\\nThere are {max_concurrency} available concurrency slots, meaning that up to {max_concurrency} agents can be active at once, including you.\"\n+    )\n+}\n+\n pub(crate) const HARD_MIN_MULTI_AGENT_V2_TIMEOUT_MS: i64 = 0;\n pub(crate) const HARD_MAX_MULTI_AGENT_V2_TIMEOUT_MS: i64 =\n     DEFAULT_MULTI_AGENT_V2_MAX_WAIT_TIMEOUT_MS;\n@@ -1055,29 +1062,38 @@ pub struct MultiAgentV2Config {\n     pub non_code_mode_only: bool,\n }\n \n-impl Default for MultiAgentV2Config {\n-    fn default() -> Self {\n+impl MultiAgentV2Config {\n+    fn defaults_for_max_concurrency(max_concurrent_threads_per_session: usize) -> Self {\n         Self {\n...",
+      "path": "codex-rs/core/src/config/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 12,
+      "patch_excerpt": "@@ -26,7 +26,6 @@ pub struct SpawnAgentToolOptions {\n     pub hide_agent_type_model_reasoning: bool,\n     pub include_usage_hint: bool,\n     pub usage_hint_text: Option<String>,\n-    pub max_concurrent_threads_per_session: Option<usize>,\n }\n \n #[derive(Debug, Clone, Copy, PartialEq, Eq)]\n@@ -102,7 +101,6 @@ pub fn create_spawn_agent_tool_v2(options: SpawnAgentToolOptions) -> ToolSpec {\n             inherited_model_guidance,\n             options.include_usage_hint,\n             options.usage_hint_text,\n-            options.max_concurrent_threads_per_session,\n         ),\n         strict: false,\n         defer_loading: None,\n@@ -722,17 +720,9 @@ fn spawn_agent_tool_description_v2(\n     inherited_model_guidance: Option<&str>,\n     include_usage_hint: bool,\n     usage_hint_text: Option<String>,\n-    max_concurrent_threads_per_session: Option<usize>,\n ) -> String {\n     let agent_role_guidance...",
+      "path": "codex-rs/core/src/tools/handlers/multi_agents_spec.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 5,
+      "patch_excerpt": "@@ -47,7 +47,6 @@ fn spawn_agent_tool_v2_requires_task_name_and_lists_visible_models() {\n         hide_agent_type_model_reasoning: false,\n         include_usage_hint: true,\n         usage_hint_text: None,\n-        max_concurrent_threads_per_session: Some(4),\n     });\n \n     let ToolSpec::Function(ResponsesApiTool {\n@@ -69,7 +68,7 @@ fn spawn_agent_tool_v2_requires_task_name_and_lists_visible_models() {\n         .expect(\"spawn_agent should use object params\");\n     assert!(description.contains(\"Spawns an agent to work on the specified task.\"));\n     assert!(description.contains(\"The spawned agent will have the same tools as you\"));\n-    assert!(description.contains(\"`max_concurrent_threads_per_session = 4`\"));\n+    assert!(!description.contains(\"max_concurrent_threads_per_session\"));\n     assert!(description.contains(SPAWN_AGENT_INHERITED_MODEL_GUIDANCE));\n     assert!(\n         descripti...",
+      "path": "codex-rs/core/src/tools/handlers/multi_agents_spec_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 15,
+      "patch_excerpt": "@@ -386,15 +386,6 @@ fn wait_agent_timeout_options(turn_context: &TurnContext) -> WaitAgentTimeoutOpt\n     }\n }\n \n-fn max_concurrent_threads_per_session(turn_context: &TurnContext) -> Option<usize> {\n-    multi_agent_v2_enabled(turn_context).then_some(\n-        turn_context\n-            .config\n-            .multi_agent_v2\n-            .max_concurrent_threads_per_session,\n-    )\n-}\n-\n fn agent_type_description(\n     turn_context: &TurnContext,\n     default_agent_type_description: &str,\n@@ -722,9 +713,6 @@ fn add_collaboration_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mu\n                             .hide_spawn_agent_metadata,\n                         include_usage_hint: turn_context.config.multi_agent_v2.usage_hint_enabled,\n                         usage_hint_text: turn_context.config.multi_agent_v2.usage_hint_text.clone(),\n-                        max_concurrent_threads_p...",
+      "path": "codex-rs/core/src/tools/spec_plan.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -1015,7 +1015,7 @@ async fn multi_agent_feature_selects_one_agent_tool_family() {\n         ToolSpec::Function(tool) => tool.description.as_str(),\n         other => panic!(\"expected spawn_agent function spec, got {other:?}\"),\n     };\n-    assert!(spawn_agent_description.contains(\"max_concurrent_threads_per_session = 17\"));\n+    assert!(!spawn_agent_description.contains(\"max_concurrent_threads_per_session\"));\n \n     let direct_model_only = probe(|turn| {\n         set_features(",
+      "path": "codex-rs/core/src/tools/spec_plan_tests.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nNative Codex currently teaches multi-agent concurrency through the `spawn_agent` tool description, while bridge-driven evals frame the same limit as a shared pool of active agent slots. That mismatch makes the model-facing story harder to reason about, especially because the tool-level wording does not make it explicit that the limit covers the whole agent team, including the current agent.\n\nThis change gives native Codex the same mental model: tell the root agent and subagents how many active slots exist, and remove the separate `spawn_agent` limit wording.\n\n## What changed\n\n- Extend the built-in `multi_agent_v2` root and subagent usage hints with shared-slot guidance derived from the resolved `max_concurrent_threads_per_session` value.\n- Keep the complete default hints in `MultiAgentV2Config` so initial context and forked histories consume the same canonical strings.\n- Drop the redundant `spawn_agent` description text and remove the now-unused limit plumbing from the tool spec path.\n\n## Testing\n\n- `just test -p codex-core usage_hint`\n- `just test -p codex-core multi_agent_v2_default_session_thread_cap_counts_root`\n- `just test -p codex-core multi_agent_v2_default_usage_hints_use_configured_thread_cap`\n- `just test -p codex-core spawn_agent_tool_v2_requires_task_name_and_lists_visible_models`\n- `just test -p codex-core multi_agent_feature_selects_one_agent_tool_family`\n",
+    "labels": [],
+    "merged_at": "2026-06-11T10:41:44Z",
+    "number": 27569,
+    "state": "merged",
+    "title": "multi-agent: move concurrency guidance into v2 usage hints",
+    "url": "https://github.com/openai/codex/pull/27569"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27573.json
+++ b/artifacts/github/bundles/openai-codex-pr-27573.json
@@ -1,0 +1,108 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-11T09:27:06Z",
+      "message": "chore: compaction v2 default",
+      "sha": "c011f6e6809601b6cc138e055bf1bc57bf5b5d4c",
+      "url": "https://github.com/openai/codex/commit/c011f6e6809601b6cc138e055bf1bc57bf5b5d4c"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-11T09:33:33Z",
+      "message": "Merge branch 'main' into jif/compaction-v2-land",
+      "sha": "571debf6883633a51c69f6654efd10c4e13e7f26",
+      "url": "https://github.com/openai/codex/commit/571debf6883633a51c69f6654efd10c4e13e7f26"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-11T09:56:29Z",
+      "message": "test: update compaction coverage for v2 default",
+      "sha": "0b768f5016684ccf0266aef513ff7f7bdfcc5aa2",
+      "url": "https://github.com/openai/codex/commit/0b768f5016684ccf0266aef513ff7f7bdfcc5aa2"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "OSS",
+    "V2U",
+    "REMOTE_AUTO_COMPACT_LIMIT",
+    "FEATURES"
+  ],
+  "files": [
+    {
+      "additions": 2,
+      "deletions": 1,
+      "patch_excerpt": "@@ -29,6 +29,7 @@ use codex_app_server_protocol::TurnStartParams;\n use codex_app_server_protocol::TurnStartResponse;\n use codex_app_server_protocol::UserInput as V2UserInput;\n use codex_config::types::AuthCredentialsStoreMode;\n+use codex_features::Feature;\n use codex_protocol::models::ContentItem;\n use codex_protocol::models::ResponseItem;\n use core_test_support::responses;\n@@ -150,7 +151,7 @@ async fn auto_compaction_remote_emits_started_and_completed_items() -> Result<()\n     write_mock_responses_config_toml(\n         codex_home.path(),\n         &server.uri(),\n-        &BTreeMap::default(),\n+        &BTreeMap::from([(Feature::RemoteCompactionV2, false)]),\n         REMOTE_AUTO_COMPACT_LIMIT,\n         Some(true),\n         \"mock_provider\",",
+      "path": "codex-rs/app-server/tests/suite/v2/compaction.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 4,
+      "deletions": 0,
+      "patch_excerpt": "@@ -2015,6 +2015,7 @@ async fn auto_compact_runs_after_resume_when_token_usage_is_over_limit() {\n     let mut builder = test_codex().with_config(move |config| {\n         set_test_compact_prompt(config);\n         config.model_auto_compact_token_limit = Some(limit);\n+        let _ = config.features.disable(Feature::RemoteCompactionV2);\n     });\n     let initial = builder.build(&server).await.unwrap();\n     let home = initial.home.clone();\n@@ -2043,6 +2044,7 @@ async fn auto_compact_runs_after_resume_when_token_usage_is_over_limit() {\n     let mut resume_builder = test_codex().with_config(move |config| {\n         set_test_compact_prompt(config);\n         config.model_auto_compact_token_limit = Some(limit);\n+        let _ = config.features.disable(Feature::RemoteCompactionV2);\n     });\n     let resumed = resume_builder\n         .resume(&server, home, rollout_path)\n@@ -4023,6 +4025,7 @@ async...",
+      "path": "codex-rs/core/tests/suite/compact.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 7,
+      "deletions": 1,
+      "patch_excerpt": "@@ -36,7 +36,7 @@ use core_test_support::responses::start_websocket_server;\n use core_test_support::skip_if_no_network;\n use core_test_support::test_codex::TestCodexBuilder;\n use core_test_support::test_codex::TestCodexHarness;\n-use core_test_support::test_codex::test_codex;\n+use core_test_support::test_codex::test_codex as base_test_codex;\n use core_test_support::test_path_buf;\n use core_test_support::wait_for_event;\n use core_test_support::wait_for_event_match;\n@@ -160,6 +160,12 @@ fn compacted_summary_only_output(summary: &str) -> Vec<ResponseItem> {\n     }]\n }\n \n+fn test_codex() -> TestCodexBuilder {\n+    base_test_codex().with_config(|config| {\n+        let _ = config.features.disable(Feature::RemoteCompactionV2);\n+    })\n+}\n+\n fn remote_realtime_test_codex_builder(\n     realtime_server: &responses::WebSocketTestServer,\n ) -> TestCodexBuilder {",
+      "path": "codex-rs/core/tests/suite/compact_remote.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 2,
+      "patch_excerpt": "@@ -529,8 +529,8 @@ async fn build_harness_inner(\n         if hooks {\n             trust_discovered_hooks(config);\n         }\n-        if mode == Mode::V2 {\n-            let _ = config.features.enable(Feature::RemoteCompactionV2);\n+        if mode == Mode::Legacy {\n+            let _ = config.features.disable(Feature::RemoteCompactionV2);\n         }\n     }))\n     .await",
+      "path": "codex-rs/core/tests/suite/compact_remote_parity.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 30,
+      "deletions": 38,
+      "patch_excerpt": "@@ -34,7 +34,6 @@ use core_test_support::responses::ev_function_call;\n use core_test_support::responses::ev_message_item_added;\n use core_test_support::responses::ev_output_text_delta;\n use core_test_support::responses::ev_response_created;\n-use core_test_support::responses::mount_compact_json_once;\n use core_test_support::responses::mount_sse_once;\n use core_test_support::responses::mount_sse_sequence;\n use core_test_support::responses::sse;\n@@ -1441,21 +1440,32 @@ async fn resumed_thread_runs_resume_then_compact_session_start_hooks() -> Result\n     let remote_summary = \"remote compact summary\";\n     let resume_context = \"remember the resumed reef\";\n     let compact_context = \"remember the compacted reef\";\n-    let compacted_history = vec![\n-        ResponseItem::Message {\n-            id: None,\n-            role: \"assistant\".to_string(),\n-            content: vec![ContentItem::OutputTe...",
+      "path": "codex-rs/core/tests/suite/hooks.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 8,
+      "deletions": 4,
+      "patch_excerpt": "@@ -177,10 +177,14 @@ async fn responses_lite_compact_request_uses_lite_transport_contract() -> Result\n     let compact_mock =\n         responses::mount_compact_json_once(&server, serde_json::json!({ \"output\": [] })).await;\n \n-    let mut builder = test_codex().with_model_info_override(\"gpt-5.4\", |model_info| {\n-        model_info.use_responses_lite = true;\n-        model_info.supports_parallel_tool_calls = true;\n-    });\n+    let mut builder = test_codex()\n+        .with_model_info_override(\"gpt-5.4\", |model_info| {\n+            model_info.use_responses_lite = true;\n+            model_info.supports_parallel_tool_calls = true;\n+        })\n+        .with_config(|config| {\n+            let _ = config.features.disable(Feature::RemoteCompactionV2);\n+        });\n     let test = builder.build(&server).await?;\n \n     test.submit_turn(\"Compact this conversation\").await?;",
+      "path": "codex-rs/core/tests/suite/responses_lite.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 2,
+      "patch_excerpt": "@@ -1249,8 +1249,8 @@ pub const FEATURES: &[FeatureSpec] = &[\n     FeatureSpec {\n         id: Feature::RemoteCompactionV2,\n         key: \"remote_compaction_v2\",\n-        stage: Stage::UnderDevelopment,\n-        default_enabled: false,\n+        stage: Stage::Stable,\n+        default_enabled: true,\n     },\n     FeatureSpec {\n         id: Feature::WorkspaceDependencies,",
+      "path": "codex-rs/features/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 10,
+      "patch_excerpt": "@@ -150,16 +150,6 @@ fn request_permissions_tool_is_under_development() {\n     assert_eq!(Feature::RequestPermissionsTool.default_enabled(), false);\n }\n \n-#[test]\n-fn remote_compaction_v2_is_under_development() {\n-    assert_eq!(Feature::RemoteCompactionV2.stage(), Stage::UnderDevelopment);\n-    assert_eq!(Feature::RemoteCompactionV2.default_enabled(), false);\n-    assert_eq!(\n-        feature_for_key(\"remote_compaction_v2\"),\n-        Some(Feature::RemoteCompactionV2)\n-    );\n-}\n-\n #[test]\n fn terminal_resize_reflow_is_experimental_and_enabled_by_default() {\n     assert_eq!(",
+      "path": "codex-rs/features/src/tests.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nRemote compaction v2 is ready to become the default for providers that already support remote compaction. Leaving it behind an under-development opt-in keeps eligible sessions on the legacy remote-compaction path.\n\nThis does not broaden provider eligibility: OpenAI and Azure move to v2, while Bedrock and OSS providers retain their existing local-compaction behavior.\n\n## What changed\n\n- Mark `remote_compaction_v2` stable and enable it by default.\n- Make tests that intentionally cover legacy remote compaction explicitly disable v2.\n- Update parity coverage so v2 exercises the production default and only legacy mode opts out.\n\n## Verification\n\n- `just test -p codex-core auto_compact_runs_after_resume_when_token_usage_is_over_limit auto_compact_counts_encrypted_reasoning_before_last_user auto_compact_runs_when_reasoning_header_clears_between_turns responses_lite_compact_request_uses_lite_transport_contract`\n",
+    "labels": [],
+    "merged_at": "2026-06-11T10:07:20Z",
+    "number": 27573,
+    "state": "merged",
+    "title": "core: enable remote compaction v2 by default",
+    "url": "https://github.com/openai/codex/pull/27573"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27591.json
+++ b/artifacts/github/bundles/openai-codex-pr-27591.json
@@ -1,0 +1,78 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-11T11:37:52Z",
+      "message": "feat: renderer",
+      "sha": "0dd59d361fb64e7cad0641619eae8047f893a8d8",
+      "url": "https://github.com/openai/codex/commit/0dd59d361fb64e7cad0641619eae8047f893a8d8"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "SKILL_NAME",
+    "SKILL_DESCRIPTION",
+    "SKILL_RESOURCE_URI",
+    "SKILL_DESCRIPTION_TRUNCATED_WARNING",
+    "SKILL_DESCRIPTION_TRUNCATED_WARNING_WITH_PERCENT",
+    "SKILL_DESCRIPTIONS_REMOVED_WARNING_PREFIX",
+    "SKILLS_INTRO_WITH_ABSOLUTE_PATHS",
+    "SKILL",
+    "SKILLS_INTRO_WITH_ALIASES",
+    "SKILLS_HOW_TO_USE_WITH_ABSOLUTE_PATHS",
+    "EOF",
+    "MAX_AVAILABLE_SKILLS_BYTES",
+    "MAX_MAIN_PROMPT_BYTES",
+    "SKILLS_INSTRUCTIONS_OPEN_TAG"
+  ],
+  "files": [
+    {
+      "additions": 8,
+      "deletions": 1,
+      "patch_excerpt": "@@ -217,7 +217,9 @@ async fn orchestrator_skill_can_read_referenced_resource_without_an_executor() -\n     assert!(first_request.tool_by_name(\"skills\", \"search\").is_none());\n \n     let developer_messages = first_request.message_input_texts(\"developer\");\n-    let catalog_line = format!(\"- {SKILL_NAME}: {SKILL_DESCRIPTION} (file: {SKILL_RESOURCE_URI})\");\n+    let catalog_line = format!(\n+        \"- {SKILL_NAME}: {SKILL_DESCRIPTION} (orchestrator resource: {SKILL_RESOURCE_URI})\"\n+    );\n     assert_eq!(\n         1,\n         developer_messages\n@@ -230,6 +232,11 @@ async fn orchestrator_skill_can_read_referenced_resource_without_an_executor() -\n             .iter()\n             .all(|text| !text.contains(\"ignored-plugin:ignored\"))\n     );\n+    assert!(\n+        developer_messages\n+            .iter()\n+            .any(|text| text.contains(\"do not treat `skill://` identifiers as filesystem path...",
+      "path": "codex-rs/app-server/tests/suite/v2/mcp_resource.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 8,
+      "deletions": 8,
+      "patch_excerpt": "@@ -22,17 +22,17 @@ pub const SKILL_DESCRIPTION_TRUNCATED_WARNING: &str = \"Skill descriptions were s\n pub const SKILL_DESCRIPTION_TRUNCATED_WARNING_WITH_PERCENT: &str = \"Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter. Disable unused skills or plugins to leave more room for the rest.\";\n pub const SKILL_DESCRIPTIONS_REMOVED_WARNING_PREFIX: &str =\n     \"Exceeded skills context budget. All skill descriptions were removed and\";\n-pub const SKILLS_INTRO_WITH_ABSOLUTE_PATHS: &str = \"A skill is a set of local instructions to follow that is stored in a `SKILL.md` file. Below is the list of skills that can be used. Each entry includes a name, description, and file path so you can open the source for full instructions when using a specific skill.\";\n+pub const SKILLS_INTRO_WITH_ABSOLUTE_PATHS: &str = \"A skill i...",
+      "path": "codex-rs/core-skills/src/render.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 14,
+      "deletions": 4,
+      "patch_excerpt": "@@ -2,6 +2,8 @@ use codex_core::context::AvailableSkillsInstructions;\n use codex_utils_string::take_bytes_at_char_boundary;\n \n use crate::catalog::SkillCatalog;\n+use crate::catalog::SkillCatalogEntry;\n+use crate::catalog::SkillSourceKind;\n \n const MAX_AVAILABLE_SKILLS_BYTES: usize = 8_000;\n const MAX_MAIN_PROMPT_BYTES: usize = 8_000;\n@@ -24,7 +26,7 @@ pub(crate) fn available_skills_fragment(\n             .short_description\n             .as_deref()\n             .unwrap_or(entry.description.as_str());\n-        let line = render_skill_line(entry.name.as_str(), description, entry.rendered_path());\n+        let line = render_skill_line(entry, description);\n         let next_bytes = total_bytes.saturating_add(line.len());\n         if next_bytes > MAX_AVAILABLE_SKILLS_BYTES {\n             omitted = omitted.saturating_add(1);\n@@ -47,11 +49,19 @@ pub(crate) fn available_skills_fragment(\n     Some...",
+      "path": "codex-rs/ext/skills/src/render.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 10,
+      "deletions": 0,
+      "patch_excerpt": "@@ -120,6 +120,11 @@ async fn installed_extension_loads_host_skills_from_legacy_roots() -> TestResult\n     assert_eq!(\"developer\", fragments[0].role());\n     assert!(fragments[0].render().contains(\"demo\"));\n     assert!(fragments[0].render().contains(&skill_prompt_path));\n+    assert!(\n+        fragments[0]\n+            .render()\n+            .contains(&format!(\"(file: {skill_prompt_path})\"))\n+    );\n     assert_eq!(\"user\", fragments[1].role());\n     assert!(fragments[1].render().contains(\"<name>demo</name>\"));\n     assert!(fragments[1].render().contains(\"# Demo\"));\n@@ -187,6 +192,11 @@ async fn selected_executor_catalog_is_context_and_selected_entrypoint_is_turn_in\n             .starts_with(SKILLS_INSTRUCTIONS_OPEN_TAG)\n     );\n     assert!(prompt_fragments[0].text().contains(\"lint-fix\"));\n+    assert!(\n+        prompt_fragments[0]\n+            .text()\n+            .contains(\"(environme...",
+      "path": "codex-rs/ext/skills/tests/skills_extension.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#27388"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nHosted skills introduced by #27388 use opaque `skill://` resource identifiers, but the skills catalog rendered every locator as a `file` and told the model that every skill body lived on disk. That can send the model toward filesystem tools for a resource that must instead be read through its owning authority.\n\nThe catalog should describe how each source is accessed without changing the underlying discovery or invocation behavior.\n\n## What changed\n\n- Render host skills as `file`, executor-owned skills as `environment resource`, orchestrator-owned skills as `orchestrator resource`, and custom-provider skills as `custom resource`.\n- Update the shared no-alias guidance to describe source locators rather than assuming every skill is stored on the host filesystem.\n- Direct orchestrator resources through `skills.list` and `skills.read`, and explicitly tell the model not to treat `skill://` identifiers as filesystem paths.\n- Preserve the existing filesystem and alias behavior for local skills.\n\n## Scope\n\nThis PR changes only model-visible catalog rendering and guidance. It does not change skill discovery, selection, prompt injection, provider routing, catalog caching or refresh behavior, resource validation, or the `skills.*` tool contract.\n\n## Verification\n\n- Extended skills-extension coverage for host-file and executor-resource labels.\n- Extended the no-executor app-server flow to assert orchestrator-resource wording and non-filesystem guidance.\n",
+    "labels": [],
+    "merged_at": "2026-06-11T11:51:04Z",
+    "number": 27591,
+    "state": "merged",
+    "title": "skills: render catalog locators by authority",
+    "url": "https://github.com/openai/codex/pull/27591"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/impact/openai-codex-pr-27413.json
+++ b/artifacts/github/impact/openai-codex-pr-27413.json
@@ -1,0 +1,45 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27413",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "skills: decouple the skills extension from core",
+        "url": "https://github.com/openai/codex/pull/27413",
+        "meta": "Merged 2026-06-11T12:03:53Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27413",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27413.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex decoupled `codex-skills-extension` from `codex-core` by introducing a host-supplied `SkillsExtensionConfig` view and moving skills context fragments into the extension crate.",
+  "public_signal_decision": "skip",
+  "control_plane_impact": "watch",
+  "publisher_angle": "none",
+  "confidence": "confirmed",
+  "evidence": [
+    "`codex-skills-extension` removes its direct `codex-core` dependency.",
+    "`SkillsExtensionConfig` becomes the public host-supplied configuration view for skills installation.",
+    "The app-server maps its `Config` into the skills extension config at install time.",
+    "Available-skills and selected-skill context fragments move into `ext/skills` while tests assert roles, markers, and rendered bytes."
+  ],
+  "candidate_followups": [
+    "Track this as staged migration context for future hosted-skill and extension-boundary PRs.",
+    "Check out-of-tree host integrations for the new config projection if Decodex consumes this crate boundary directly."
+  ],
+  "social_notes": [
+    "Skip standalone social publishing because the PR explicitly preserves user-visible and model-visible behavior.",
+    "Use only as background if a later extension migration PR adds a visible hosted-skill capability."
+  ],
+  "caveats": [
+    "The PR body states this adds no capability.",
+    "Any source-level break is limited to host code that installs the skills extension directly.",
+    "No immediate Decodex runtime action is justified without a later behavior-changing PR."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-27569.json
+++ b/artifacts/github/impact/openai-codex-pr-27569.json
@@ -1,0 +1,45 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27569",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "multi-agent: move concurrency guidance into v2 usage hints",
+        "url": "https://github.com/openai/codex/pull/27569",
+        "meta": "Merged 2026-06-11T10:41:44Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27569",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27569.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex now places multi-agent v2 shared concurrency-slot guidance in the root and subagent usage hints instead of the `spawn_agent` tool description.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "candidate",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "`default_multi_agent_v2_usage_hint_text` appends shared-slot guidance based on configured max concurrency.",
+    "`MultiAgentV2Config` keeps rendered default root and subagent usage hints from the configured thread cap.",
+    "`SpawnAgentToolOptions` no longer carries `max_concurrent_threads_per_session` into the tool description.",
+    "Tests assert the spawn-agent description omits the old setting name and that usage hints carry the configured capacity."
+  ],
+  "candidate_followups": [
+    "Align Decodex multi-agent operator guidance with the shared active-slot wording.",
+    "Avoid writing tests or docs that expect concurrency limits inside the `spawn_agent` description.",
+    "Watch for later PRs that change the scheduler or slot accounting itself."
+  ],
+  "social_notes": [
+    "Useful as an operator note because it explains how the model should reason about shared agent capacity.",
+    "Do not imply that the actual concurrency limit changed."
+  ],
+  "caveats": [
+    "The change is model-facing guidance, not a scheduler change.",
+    "The configured active-agent limit still comes from `max_concurrent_threads_per_session`."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-27573.json
+++ b/artifacts/github/impact/openai-codex-pr-27573.json
@@ -1,0 +1,46 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27573",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "core: enable remote compaction v2 by default",
+        "url": "https://github.com/openai/codex/pull/27573",
+        "meta": "Merged 2026-06-11T10:07:20Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27573",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27573.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex promoted `remote_compaction_v2` from an under-development opt-in to a stable default for providers that already support remote compaction.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "candidate",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "`Feature::RemoteCompactionV2` is now `Stage::Stable` and `default_enabled: true`.",
+    "Legacy remote-compaction tests now explicitly disable the v2 feature.",
+    "Parity tests treat v2 as the production default and legacy mode as the explicit opt-out.",
+    "The PR body limits the default change to providers that already support remote compaction."
+  ],
+  "candidate_followups": [
+    "Audit Decodex retained-lane history and compaction readbacks against the v2 default.",
+    "Keep provider-eligibility claims narrow: OpenAI and Azure move to v2; Bedrock and OSS stay local.",
+    "Use explicit feature-disable coverage when testing legacy remote-compaction assumptions."
+  ],
+  "social_notes": [
+    "Lead with the default flip and the provider caveat.",
+    "Frame it as an operator-impact note for long sessions and compaction, not as new provider support."
+  ],
+  "caveats": [
+    "This PR does not broaden remote-compaction provider eligibility.",
+    "The legacy path remains available through explicit feature disablement.",
+    "No Decodex runtime support claim should be made without a separate Decodex audit."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-27591.json
+++ b/artifacts/github/impact/openai-codex-pr-27591.json
@@ -1,0 +1,46 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27591",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "skills: render catalog locators by authority",
+        "url": "https://github.com/openai/codex/pull/27591",
+        "meta": "Merged 2026-06-11T11:51:04Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27591",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27591.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex now renders skills catalog source locators by owning authority instead of describing every skill as a host filesystem file.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "candidate",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "Available-skills instructions now describe source locators instead of only file paths.",
+    "Skill lines are rendered from `SkillSourceKind`, producing file, environment-resource, orchestrator-resource, or custom-resource labels.",
+    "App-server coverage asserts `skill://` orchestrator resources are not treated as filesystem paths.",
+    "The PR body keeps discovery, provider routing, resource validation, and the `skills.*` tool contract out of scope."
+  ],
+  "candidate_followups": [
+    "Mirror authority-aware locator language in Decodex plugin and skills guidance.",
+    "Check Decodex prompt templates for file-path-only assumptions around available skills.",
+    "Keep hosted-skill claims limited to catalog rendering unless later PRs change the tool contract."
+  ],
+  "social_notes": [
+    "Good operator-impact candidate for explaining how agents should read hosted skill resources.",
+    "Mention `skills.list` and `skills.read` for orchestrator-owned `skill://` resources."
+  ],
+  "caveats": [
+    "No new skill discovery or invocation behavior is introduced.",
+    "Local host skills continue to render as file locators.",
+    "The change is prompt/catalog rendering, not a plugin protocol expansion."
+  ]
+}

--- a/artifacts/github/review-queue/openai-codex-latest.json
+++ b/artifacts/github/review-queue/openai-codex-latest.json
@@ -1,14 +1,14 @@
 {
   "counts": {
     "critical": 17,
-    "high": 7,
+    "high": 11,
     "low": 0,
-    "normal": 16,
+    "normal": 12,
     "published_subjects_seen": 0,
     "recent_commits_scanned": 40,
     "subjects_queued": 40
   },
-  "generated_at": "2026-06-11T20:04:32.657127Z",
+  "generated_at": "2026-06-12T02:04:59.697624Z",
   "repo": "openai/codex",
   "schema": "upstream_review_queue/v1",
   "source": {
@@ -17,257 +17,6 @@
     "signals_dir": "site/src/content/signals"
   },
   "subjects": [
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 4,
-      "commit_shas": [
-        "8a34e24ba2eb9415433cfc680d35d35112f403b8"
-      ],
-      "committed_at": "2026-06-11T03:37:25Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27526,
-      "pr_url": "https://github.com/openai/codex/pull/27526",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/tools/src/lib.rs",
-        "codex-rs/tools/src/tool_executor.rs",
-        "codex-rs/tools/src/tool_search.rs",
-        "codex-rs/tools/src/tool_search_tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27526",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "tools: simplify default tool search text",
-      "url": "https://github.com/openai/codex/pull/27526"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 10,
-      "commit_shas": [
-        "a19ec71e8d73d4dbd1dfb5b34894744ee8e6ef1a",
-        "67a29aab4885be483dc7ea05ec9bce8fddbfdc00",
-        "9e25474a95a9ceb092c04ac628cbb6985f7f30eb",
-        "812afdf99973b744cc03839a08128a536df58e4c",
-        "57885a18cccf9db57602e1240e553aaf1df92da9"
-      ],
-      "committed_at": "2026-06-11T03:39:07Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27488,
-      "pr_url": "https://github.com/openai/codex/pull/27488",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/core/src/session/mod.rs",
-        "codex-rs/core/src/session/turn.rs",
-        "codex-rs/core/src/state/auto_compact_window.rs",
-        "codex-rs/core/src/state/session.rs",
-        "codex-rs/core/src/tools/handlers/mod.rs",
-        "codex-rs/core/src/tools/handlers/new_context_window.rs",
-        "codex-rs/core/src/tools/handlers/new_context_window_spec.rs",
-        "codex-rs/core/src/tools/spec_plan.rs",
-        "codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap",
-        "codex-rs/core/tests/suite/token_budget.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27488",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "auth_accounts",
-        "tests_ci"
-      ],
-      "title": "[codex] Add new context window tool",
-      "url": "https://github.com/openai/codex/pull/27488"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 30,
-      "commit_shas": [
-        "104ce325c053cc8373b8f50f88516aaf73be0409",
-        "2aef9c511d253364af98fb4348683fea07aa8eef",
-        "5159b57cb0503bbf547d1a2c972dbe94933f0f01",
-        "1cd7a69b77fc746d10b786dc1640bc6e542b308e"
-      ],
-      "committed_at": "2026-06-11T03:42:38Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27443,
-      "pr_url": "https://github.com/openai/codex/pull/27443",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/app-server-protocol/schema/json/ServerNotification.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/v2/AccountUpdatedNotification.json",
-        "codex-rs/app-server-protocol/schema/typescript/AuthMode.ts",
-        "codex-rs/app-server-protocol/src/protocol/common.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/tests.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/websocket.rs",
-        "codex-rs/app-server/tests/common/auth_fixtures.rs",
-        "codex-rs/app-server/tests/suite/v2/app_list.rs",
-        "codex-rs/cli/src/doctor.rs",
-        "codex-rs/cli/src/login.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27443",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "auth_accounts",
-        "cli_tui",
-        "model_provider",
-        "tests_ci"
-      ],
-      "title": "feat: add Bedrock API key as a managed auth mode",
-      "url": "https://github.com/openai/codex/pull/27443"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 4,
-      "commit_shas": [
-        "66d506e86e5da8691b0773563eff7f73ecff20b9"
-      ],
-      "committed_at": "2026-06-11T03:57:35Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27517,
-      "pr_url": "https://github.com/openai/codex/pull/27517",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server/src/request_processors/account_processor.rs",
-        "codex-rs/core-plugins/src/manager.rs",
-        "codex-rs/core-plugins/src/manager_tests.rs",
-        "codex-rs/core/src/thread_manager.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27517",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "auth_accounts",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "[codex] Pass auth mode to plugin manager",
-      "url": "https://github.com/openai/codex/pull/27517"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 16,
-      "commit_shas": [
-        "9f43ae5740dd7a0864191e7fd9442731955fcd56",
-        "87118974041e386856e6308cb5de4a4efdb38825",
-        "b5336d7c65a855c2be73a5d969f6261cc0a9016e",
-        "d2faba8e737ea11ebb34e67e1153a927367e40c0",
-        "40b684f149d7b9eb861e7e1bdd07ccbc1ea1803e",
-        "3cc928afc04c980727973669c55ef36ac33132a6",
-        "86be3665c548b7d0cfd1d8093d22f0578a53d3e4"
-      ],
-      "committed_at": "2026-06-11T04:11:26Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27520,
-      "pr_url": "https://github.com/openai/codex/pull/27520",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/analytics/src/facts.rs",
-        "codex-rs/core/src/compact_tests.rs",
-        "codex-rs/core/src/context/environment_context_tests.rs",
-        "codex-rs/core/src/context_manager/history_tests.rs",
-        "codex-rs/core/src/session/mod.rs",
-        "codex-rs/core/src/session/review.rs",
-        "codex-rs/core/src/session/rollout_reconstruction.rs",
-        "codex-rs/core/src/session/rollout_reconstruction_tests.rs",
-        "codex-rs/core/src/session/tests.rs",
-        "codex-rs/core/src/session/turn.rs",
-        "codex-rs/core/src/session/turn_context.rs",
-        "codex-rs/core/tests/suite/compact.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27520",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "tests_ci"
-      ],
-      "title": "[codex] Compact when comp_hash changes",
-      "url": "https://github.com/openai/codex/pull/27520"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 8,
-      "commit_shas": [
-        "df09d11e677e0c7a0efd4e0123a4f2e52eff4aee",
-        "78eec65557d4abd99be8fa4d71eef89c52aa716c"
-      ],
-      "committed_at": "2026-06-11T06:07:06Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27082,
-      "pr_url": "https://github.com/openai/codex/pull/27082",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/analytics/src/analytics_client_tests.rs",
-        "codex-rs/analytics/src/events.rs",
-        "codex-rs/analytics/src/facts.rs",
-        "codex-rs/analytics/src/lib.rs",
-        "codex-rs/core/src/compact.rs",
-        "codex-rs/core/src/compact_remote.rs",
-        "codex-rs/core/src/compact_remote_v2.rs",
-        "codex-rs/core/src/hook_runtime.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27082",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "config_hooks",
-        "tests_ci"
-      ],
-      "title": "[codex-analytics] Emit structured compaction codex errors",
-      "url": "https://github.com/openai/codex/pull/27082"
-    },
     {
       "attention_flags": [
         "auth_account",
@@ -742,160 +491,253 @@
     {
       "attention_flags": [
         "auth_account",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 13,
-      "commit_shas": [
-        "9f43ae5740dd7a0864191e7fd9442731955fcd56"
-      ],
-      "committed_at": "2026-06-11T03:42:55Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27532,
-      "pr_url": "https://github.com/openai/codex/pull/27532",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/app-server/tests/common/models_cache.rs",
-        "codex-rs/codex-api/tests/models_integration.rs",
-        "codex-rs/core/tests/suite/auto_review.rs",
-        "codex-rs/core/tests/suite/model_switching.rs",
-        "codex-rs/core/tests/suite/models_cache_ttl.rs",
-        "codex-rs/core/tests/suite/personality.rs",
-        "codex-rs/core/tests/suite/remote_models.rs",
-        "codex-rs/core/tests/suite/rmcp_client.rs",
-        "codex-rs/core/tests/suite/spawn_agent_description.rs",
-        "codex-rs/core/tests/suite/view_image.rs",
-        "codex-rs/models-manager/src/model_info.rs",
-        "codex-rs/protocol/src/openai_models.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27532",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "mcp_plugins",
-        "model_provider",
-        "tests_ci"
-      ],
-      "title": "[codex] Add comp_hash to model metadata",
-      "url": "https://github.com/openai/codex/pull/27532"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
+        "deprecated_removed",
         "new_feature",
         "protocol_change",
         "security_policy"
       ],
+      "changed_file_count": 27,
+      "commit_shas": [
+        "07499eb7263dc91e44e04ba86a3704c758b80860",
+        "3e9298af57a7c3057ded958ac4d8a630919523ac",
+        "2637659fc3571c1e31136107285db749400a9082"
+      ],
+      "committed_at": "2026-06-11T20:42:09Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27122,
+      "pr_url": "https://github.com/openai/codex/pull/27122",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server-protocol/src/protocol/v2/turn.rs",
+        "codex-rs/app-server/tests/suite/v2/client_metadata.rs",
+        "codex-rs/core/src/client.rs",
+        "codex-rs/core/src/client_tests.rs",
+        "codex-rs/core/src/compact.rs",
+        "codex-rs/core/src/compact_remote.rs",
+        "codex-rs/core/src/compact_remote_v2.rs",
+        "codex-rs/core/src/lib.rs",
+        "codex-rs/core/src/responses_metadata.rs",
+        "codex-rs/core/src/session/review.rs",
+        "codex-rs/core/src/session/session.rs",
+        "codex-rs/core/src/session/tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27122",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "auth_accounts",
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "core: Consolidate Responses API Codex metadata",
+      "url": "https://github.com/openai/codex/pull/27122"
+    },
+    {
+      "attention_flags": [
+        "breaking_change",
+        "deprecated_removed",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 7,
+      "commit_shas": [
+        "15a21e11f315c88a65b197f34ad84eef9475aa9b",
+        "eafb482e8d0e8d723794462bc543798272031b9f",
+        "f69b2d1e2a1e1c6db6e2aaf2a10ed2aca461a289",
+        "9a8ae04cb9831aebe459f0e45b492cd6bbfb9dc9",
+        "8eb6f5af6fcdd069dbb0b31d6fd62f91900d9443"
+      ],
+      "committed_at": "2026-06-11T22:09:12Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27653,
+      "pr_url": "https://github.com/openai/codex/pull/27653",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for breaking_change, deprecated_removed, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/exec-server/README.md",
+        "codex-rs/exec-server/src/fs_helper.rs",
+        "codex-rs/exec-server/src/protocol.rs",
+        "codex-rs/exec-server/src/remote_file_system.rs",
+        "codex-rs/exec-server/src/remote_file_system_path_uri_tests.rs",
+        "codex-rs/exec-server/src/sandboxed_file_system.rs",
+        "codex-rs/exec-server/src/server/file_system_handler.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27653",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "docs_examples",
+        "sandbox_permissions",
+        "tests_ci"
+      ],
+      "title": "[codex] migrate exec-server filesystem protocol to PathUri",
+      "url": "https://github.com/openai/codex/pull/27653"
+    },
+    {
+      "attention_flags": [
+        "breaking_change",
+        "deprecated_removed",
+        "protocol_change"
+      ],
       "changed_file_count": 6,
       "commit_shas": [
-        "a19ec71e8d73d4dbd1dfb5b34894744ee8e6ef1a",
-        "67a29aab4885be483dc7ea05ec9bce8fddbfdc00",
-        "9e25474a95a9ceb092c04ac628cbb6985f7f30eb",
-        "812afdf99973b744cc03839a08128a536df58e4c",
-        "7926acc9983d2f91e3a8933f1c0e98c52678e13b",
-        "2f244354b476946dafe292f32368c259fd8ff853",
-        "57885a18cccf9db57602e1240e553aaf1df92da9",
-        "d12b3c17eba6d2c30919ce1083033fca50a4f682",
-        "86e43fe8635b2aded6cfda2011e1328ab5fa94a4"
+        "fe16ca355a264215ee5b05fa9afc5dd7f5e83c65"
       ],
-      "committed_at": "2026-06-11T04:17:10Z",
+      "committed_at": "2026-06-11T22:48:53Z",
       "next_step": "ai_review_required",
-      "pr_number": 27518,
-      "pr_url": "https://github.com/openai/codex/pull/27518",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
+      "pr_number": 27700,
+      "pr_url": "https://github.com/openai/codex/pull/27700",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for breaking_change, deprecated_removed, protocol_change.",
       "sample_paths": [
-        "codex-rs/core/src/context/token_budget_context.rs",
-        "codex-rs/core/src/tools/handlers/get_context_remaining.rs",
-        "codex-rs/core/src/tools/handlers/get_context_remaining_spec.rs",
-        "codex-rs/core/src/tools/handlers/mod.rs",
-        "codex-rs/core/src/tools/spec_plan.rs",
-        "codex-rs/core/tests/suite/token_budget.rs"
+        "codex-rs/exec-server/src/client.rs",
+        "codex-rs/exec-server/src/lib.rs",
+        "codex-rs/exec-server/src/protocol.rs",
+        "codex-rs/exec-server/src/server/file_system_handler.rs",
+        "codex-rs/exec-server/src/server/handler.rs",
+        "codex-rs/exec-server/src/server/registry.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27518",
+      "subject_id": "27700",
       "subject_kind": "pr",
       "surface_hints": [
-        "auth_accounts",
-        "tests_ci"
+        "app_server_protocol",
+        "cli_tui"
       ],
-      "title": "[codex] Add context remaining tool",
-      "url": "https://github.com/openai/codex/pull/27518"
+      "title": "Remove fs/join and fs/parent from exec-server protocol",
+      "url": "https://github.com/openai/codex/pull/27700"
     },
     {
       "attention_flags": [
-        "auth_account",
-        "release_packaging"
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
       ],
-      "changed_file_count": 3,
+      "changed_file_count": 8,
       "commit_shas": [
-        "7a740bc45d7d114d457cf04b1b8a76ba9eab8797",
-        "2141e57b350c9b76a838b238a1a01a312f04f722"
+        "eafa1fc84190009a6d53378565460290dba3ceb8",
+        "682f2b9c28f8bdc54c8b48e2f1587228b81c90ed",
+        "0b34bb09f82857993b511572569cdcfdaa9430ab",
+        "6b06a574cc1be682580cfce269d755e3140e39f6",
+        "8f878400ea36dbcbc573a2f8d5bfacfe1b8c73b6",
+        "d2132fbc5250d96109f5c30b05a07432afa5afd3"
       ],
-      "committed_at": "2026-06-11T06:42:15Z",
+      "committed_at": "2026-06-11T23:24:12Z",
       "next_step": "ai_review_required",
-      "pr_number": 26513,
-      "pr_url": "https://github.com/openai/codex/pull/26513",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, release_packaging.",
+      "pr_number": 27318,
+      "pr_url": "https://github.com/openai/codex/pull/27318",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/cloud-config/src/cache.rs",
-        "codex-rs/cloud-config/src/cache_tests.rs",
-        "codex-rs/cloud-config/src/service.rs"
+        "codex-rs/app-server-protocol/src/protocol/thread_history.rs",
+        "codex-rs/core/src/session/session.rs",
+        "codex-rs/thread-store/src/in_memory.rs",
+        "codex-rs/thread-store/src/lib.rs",
+        "codex-rs/thread-store/src/live_thread.rs",
+        "codex-rs/thread-store/src/local/live_writer.rs",
+        "codex-rs/thread-store/src/store.rs",
+        "codex-rs/thread-store/src/types.rs"
       ],
       "source_state": "merged",
-      "subject_id": "26513",
+      "subject_id": "27318",
       "subject_kind": "pr",
       "surface_hints": [
-        "config_hooks",
-        "tests_ci"
+        "app_server_protocol"
       ],
-      "title": "[codex] Tune cloud config cache intervals",
-      "url": "https://github.com/openai/codex/pull/26513"
+      "title": "[codex] Move persistence policy application into ThreadStore",
+      "url": "https://github.com/openai/codex/pull/27318"
     },
     {
       "attention_flags": [
         "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 14,
+      "commit_shas": [
+        "27e50cfa078191d4d61f281fcb4307b3fd8d2e97",
+        "526c3e8565b00151ee29f620978650f07610e9ee",
+        "6467362a57ce5befcf5895c4df10d5bae82a92e6",
+        "2feef6f6c77bcd8140bc126377410bcdf3b89915",
+        "18126046137392d29cb21f2f734160b52cfa1ea5",
+        "f8ab6ef5dc39035114a695d5dc5952ff1aad7fa6",
+        "03f5b38cf9b4d10eb8d9f1a94ddd0d503aacd257",
+        "59544fbc520493779b297162c114ee185392c521"
+      ],
+      "committed_at": "2026-06-11T23:32:52Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27498,
+      "pr_url": "https://github.com/openai/codex/pull/27498",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/Cargo.lock",
+        "codex-rs/app-server/tests/suite/v2/imagegen_extension.rs",
+        "codex-rs/core/src/tools/handlers/extension_tools.rs",
+        "codex-rs/core/tests/suite/extension_sandbox.rs",
+        "codex-rs/core/tests/suite/mod.rs",
+        "codex-rs/ext/extension-api/src/lib.rs",
+        "codex-rs/ext/goal/tests/goal_extension_backend.rs",
+        "codex-rs/ext/image-generation/Cargo.toml",
+        "codex-rs/ext/image-generation/src/tests.rs",
+        "codex-rs/ext/image-generation/src/tool.rs",
+        "codex-rs/ext/memories/src/tests.rs",
+        "codex-rs/tools/Cargo.toml"
+      ],
+      "source_state": "merged",
+      "subject_id": "27498",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "config_hooks",
+        "sandbox_permissions",
+        "tests_ci"
+      ],
+      "title": "Route image extension reads through turn environments v2",
+      "url": "https://github.com/openai/codex/pull/27498"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
         "new_feature",
         "protocol_change",
         "release_packaging",
         "security_policy"
       ],
-      "changed_file_count": 26,
+      "changed_file_count": 98,
       "commit_shas": [
-        "f2eb57ab01ec5e7180feaeb0da8be0270a9ce08f",
-        "2adc40863bc3f8deeb51af81e1e7b344211a8d26",
-        "cc06cd29c87eb5d43deff1a4a43109d9c29c1e74",
-        "cde0b1be448e91e3d24764565ba6ff6c37aadd22",
-        "5557f6fdae174275e23870a4be7e1e0dcddce540",
-        "d5fb1fcdb891132261b761f280d3e1c2c1b969de"
+        "9aba4e7c68322efaf4a930336061dc4ddf22eedb",
+        "4df5f02d73bd57c728ec65880b2b702825256edc"
       ],
-      "committed_at": "2026-06-11T09:28:16Z",
+      "committed_at": "2026-06-12T01:16:39Z",
       "next_step": "ai_review_required",
-      "pr_number": 27387,
-      "pr_url": "https://github.com/openai/codex/pull/27387",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, release_packaging, security_policy.",
+      "pr_number": 27475,
+      "pr_url": "https://github.com/openai/codex/pull/27475",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
       "sample_paths": [
+        "MODULE.bazel.lock",
         "codex-rs/Cargo.lock",
-        "codex-rs/app-server/src/extensions.rs",
-        "codex-rs/app-server/tests/suite/v2/mcp_resource.rs",
-        "codex-rs/codex-mcp/Cargo.toml",
-        "codex-rs/codex-mcp/src/connection_manager.rs",
-        "codex-rs/codex-mcp/src/lib.rs",
-        "codex-rs/codex-mcp/src/resource_client.rs",
-        "codex-rs/core/src/context/available_skills_instructions.rs",
-        "codex-rs/core/src/context/mod.rs",
-        "codex-rs/core/src/event_mapping.rs",
-        "codex-rs/core/src/event_mapping_tests.rs",
-        "codex-rs/core/src/session/mod.rs"
+        "codex-rs/Cargo.toml",
+        "codex-rs/agent-graph-store/Cargo.toml",
+        "codex-rs/agent-graph-store/src/local.rs",
+        "codex-rs/agent-graph-store/src/store.rs",
+        "codex-rs/app-server/Cargo.toml",
+        "codex-rs/app-server/src/mcp_refresh.rs",
+        "codex-rs/app-server/src/message_processor.rs",
+        "codex-rs/async-utils/Cargo.toml",
+        "codex-rs/async-utils/src/lib.rs",
+        "codex-rs/cloud-tasks-client/Cargo.toml"
       ],
       "source_state": "merged",
-      "subject_id": "27387",
+      "subject_id": "27475",
       "subject_kind": "pr",
       "surface_hints": [
         "app_server_protocol",
@@ -904,10 +746,11 @@
         "config_hooks",
         "mcp_plugins",
         "model_provider",
+        "sandbox_permissions",
         "tests_ci"
       ],
-      "title": "skills: make backend plugin skills invocable without an executor",
-      "url": "https://github.com/openai/codex/pull/27387"
+      "title": "[codex] Remove async_trait from first-party code",
+      "url": "https://github.com/openai/codex/pull/27475"
     },
     {
       "attention_flags": [
@@ -1013,32 +856,35 @@
     },
     {
       "attention_flags": [
-        "deprecated_removed",
+        "auth_account",
         "new_feature",
         "protocol_change"
       ],
-      "changed_file_count": 1,
+      "changed_file_count": 3,
       "commit_shas": [
-        "454561e86fdc09e92cedbd6648ceb2f1df0acfb3",
-        "e71036adc2ff3109637cb334c051045a2bf8aa16"
+        "e14573d583899a66897d439c1561e655aa1141aa"
       ],
-      "committed_at": "2026-06-11T03:30:44Z",
+      "committed_at": "2026-06-11T21:17:37Z",
       "next_step": "ai_review_required",
-      "pr_number": 27501,
-      "pr_url": "https://github.com/openai/codex/pull/27501",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change.",
+      "pr_number": 27450,
+      "pr_url": "https://github.com/openai/codex/pull/27450",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/ext/web-search/web_run_description.md"
+        "codex-rs/cli/src/login.rs",
+        "codex-rs/login/src/auth/auth_tests.rs",
+        "codex-rs/login/src/auth/manager.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27501",
+      "subject_id": "27450",
       "subject_kind": "pr",
       "surface_hints": [
-        "internal_churn"
+        "auth_accounts",
+        "cli_tui",
+        "tests_ci"
       ],
-      "title": "[codex] Expand hosted web search citation guidance",
-      "url": "https://github.com/openai/codex/pull/27501"
+      "title": "[codex-rs] enforce PAT workspace restrictions",
+      "url": "https://github.com/openai/codex/pull/27450"
     },
     {
       "attention_flags": [
@@ -1047,31 +893,36 @@
         "protocol_change",
         "security_policy"
       ],
-      "changed_file_count": 4,
+      "changed_file_count": 8,
       "commit_shas": [
-        "5eb40cb8dfdbf308827d18f4987f43053168e44a"
+        "24f2071d12595ecdbdb1274e3033e80d1008bae6",
+        "5bcc69e3736702540c73b38112eecbe52daf680c"
       ],
-      "committed_at": "2026-06-11T03:43:03Z",
+      "committed_at": "2026-06-11T22:10:29Z",
       "next_step": "ai_review_required",
-      "pr_number": 27246,
-      "pr_url": "https://github.com/openai/codex/pull/27246",
-      "review_priority": "normal",
+      "pr_number": 27663,
+      "pr_url": "https://github.com/openai/codex/pull/27663",
+      "review_priority": "high",
       "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/core/src/client.rs",
-        "codex-rs/core/src/client_common.rs",
-        "codex-rs/core/src/client_common_tests.rs",
-        "codex-rs/core/tests/suite/responses_lite.rs"
+        "codex-rs/core/src/context/token_budget_context.rs",
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/tools/handlers/get_context_remaining.rs",
+        "codex-rs/core/src/tools/handlers/get_context_remaining_spec.rs",
+        "codex-rs/core/src/tools/spec_plan.rs",
+        "codex-rs/core/tests/suite/code_mode.rs",
+        "codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap",
+        "codex-rs/core/tests/suite/token_budget.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27246",
+      "subject_id": "27663",
       "subject_kind": "pr",
       "surface_hints": [
-        "cli_tui",
+        "auth_accounts",
         "tests_ci"
       ],
-      "title": "core: strip image detail from Responses Lite requests",
-      "url": "https://github.com/openai/codex/pull/27246"
+      "title": "Include thread id in token budget context",
+      "url": "https://github.com/openai/codex/pull/27663"
     },
     {
       "attention_flags": [
@@ -1079,26 +930,28 @@
       ],
       "changed_file_count": 2,
       "commit_shas": [
-        "42aa9fe72e94b5aed23350b9431008ab41310f98"
+        "88334ad08f5aaa25bcccd8383d5b71ab7f94481b",
+        "492b77a792d74008f2de14de1a06053c01672848"
       ],
-      "committed_at": "2026-06-11T04:17:32Z",
+      "committed_at": "2026-06-11T22:25:55Z",
       "next_step": "ai_review_required",
-      "pr_number": 27266,
-      "pr_url": "https://github.com/openai/codex/pull/27266",
-      "review_priority": "normal",
+      "pr_number": 26418,
+      "pr_url": "https://github.com/openai/codex/pull/26418",
+      "review_priority": "high",
       "review_reason": "Needs AI review for new_feature.",
       "sample_paths": [
-        "codex-rs/utils/image/src/image_tests.rs",
-        "codex-rs/utils/image/src/lib.rs"
+        "codex-rs/hooks/src/engine/discovery.rs",
+        "codex-rs/hooks/src/engine/mod_tests.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27266",
+      "subject_id": "26418",
       "subject_kind": "pr",
       "surface_hints": [
+        "config_hooks",
         "tests_ci"
       ],
-      "title": "image: preserve metadata when resizing prompt images",
-      "url": "https://github.com/openai/codex/pull/27266"
+      "title": "[codex] Avoid duplicate hooks.json discovery with profiles",
+      "url": "https://github.com/openai/codex/pull/26418"
     },
     {
       "attention_flags": [
@@ -1106,91 +959,150 @@
         "new_feature",
         "protocol_change"
       ],
-      "changed_file_count": 5,
+      "changed_file_count": 4,
       "commit_shas": [
-        "2536d74dce9c36ccde72b57c8571f64b713d4cb3"
+        "7115762f8f49eb11a5ee4061ddd7b2d7dd9de37f"
       ],
-      "committed_at": "2026-06-11T05:47:22Z",
+      "committed_at": "2026-06-11T22:33:38Z",
       "next_step": "ai_review_required",
-      "pr_number": 27103,
-      "pr_url": "https://github.com/openai/codex/pull/27103",
-      "review_priority": "normal",
+      "pr_number": 27689,
+      "pr_url": "https://github.com/openai/codex/pull/27689",
+      "review_priority": "high",
       "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/analytics/src/analytics_client_tests.rs",
-        "codex-rs/analytics/src/events.rs",
-        "codex-rs/analytics/src/facts.rs",
-        "codex-rs/core/src/compact.rs",
-        "codex-rs/core/src/compact_remote_v2.rs"
+        "codex-rs/model-provider/src/amazon_bedrock/auth.rs",
+        "codex-rs/model-provider/src/amazon_bedrock/mantle.rs",
+        "codex-rs/model-provider/src/amazon_bedrock/mod.rs",
+        "codex-rs/model-provider/src/provider.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27103",
+      "subject_id": "27689",
       "subject_kind": "pr",
       "surface_hints": [
-        "cli_tui",
-        "tests_ci"
+        "auth_accounts",
+        "model_provider"
       ],
-      "title": "[codex-analytics] report cached input tokens for v2 compaction",
-      "url": "https://github.com/openai/codex/pull/27103"
+      "title": "feat: prefer managed Bedrock auth in model provider",
+      "url": "https://github.com/openai/codex/pull/27689"
     },
     {
       "attention_flags": [
-        "deprecated_removed",
         "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 2,
-      "commit_shas": [
-        "902b3a655c25808562b40d65765c8034d4639fb2"
-      ],
-      "committed_at": "2026-06-11T06:06:34Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27356,
-      "pr_url": "https://github.com/openai/codex/pull/27356",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/core/src/tools/handlers/dynamic.rs",
-        "codex-rs/core/src/tools/handlers/dynamic_tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27356",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "tests_ci"
-      ],
-      "title": "Use generic search metadata for dynamic tools",
-      "url": "https://github.com/openai/codex/pull/27356"
-    },
-    {
-      "attention_flags": [
         "protocol_change"
       ],
       "changed_file_count": 3,
       "commit_shas": [
-        "8d5d46c373675f75b214d8e43b11f501f9a8cdb8",
-        "ef726e2478cd1cedda5020530dad5999eb9f24bf",
-        "8c11c0a92c49645e02082e70f5801ef53b3c1d57"
+        "e328232510870ff1b681078f1953e2910e23270c",
+        "00d340119b0ffb310544cc046d366ea101610bcd",
+        "e11078f3a82b0a8eeb0c92453bda658d780d3820"
       ],
-      "committed_at": "2026-06-11T09:46:47Z",
+      "committed_at": "2026-06-11T23:08:07Z",
       "next_step": "ai_review_required",
-      "pr_number": 27403,
-      "pr_url": "https://github.com/openai/codex/pull/27403",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for protocol_change.",
+      "pr_number": 26426,
+      "pr_url": "https://github.com/openai/codex/pull/26426",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/ext/skills/src/extension.rs",
-        "codex-rs/ext/skills/src/state.rs",
-        "codex-rs/ext/skills/tests/skills_extension.rs"
+        "codex-rs/config/src/hook_config.rs",
+        "codex-rs/config/src/hooks_tests.rs",
+        "codex-rs/hooks/src/engine/mod_tests.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27403",
+      "subject_id": "26426",
       "subject_kind": "pr",
       "surface_hints": [
+        "config_hooks",
         "tests_ci"
       ],
-      "title": "skills: cache remote catalog failures per thread",
-      "url": "https://github.com/openai/codex/pull/27403"
+      "title": "Warn when hooks.json has unsupported top-level fields",
+      "url": "https://github.com/openai/codex/pull/26426"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 4,
+      "commit_shas": [
+        "b4ea264a29f466200008303391c2b7f42c8747b1"
+      ],
+      "committed_at": "2026-06-12T00:15:04Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27619,
+      "pr_url": "https://github.com/openai/codex/pull/27619",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/tui/src/chatwidget/hook_lifecycle.rs",
+        "codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__completed_turn_clears_visible_running_hook.snap",
+        "codex-rs/tui/src/chatwidget/tests/status_and_layout.rs",
+        "codex-rs/tui/src/chatwidget/turn_runtime.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27619",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "config_hooks",
+        "tests_ci"
+      ],
+      "title": "tui: clear stale hook row after turn completion",
+      "url": "https://github.com/openai/codex/pull/27619"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 3,
+      "commit_shas": [
+        "0ebb68ad99d0eda8eb00f83d9d2653878875c814"
+      ],
+      "committed_at": "2026-06-12T00:15:19Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27711,
+      "pr_url": "https://github.com/openai/codex/pull/27711",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/Cargo.lock",
+        "codex-rs/ext/image-generation/Cargo.toml",
+        "codex-rs/ext/image-generation/src/tool.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27711",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "config_hooks"
+      ],
+      "title": "Fix image extension PathUri conversion",
+      "url": "https://github.com/openai/codex/pull/27711"
+    },
+    {
+      "attention_flags": [],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "0ca5934aef35c66961dee37b1cf925dfaca9364f"
+      ],
+      "committed_at": "2026-06-12T01:23:16Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27719,
+      "pr_url": "https://github.com/openai/codex/pull/27719",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for surface hints: app_server_protocol.",
+      "sample_paths": [
+        "codex-rs/app-server/src/lib.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27719",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol"
+      ],
+      "title": "fix: Recover from sqlite directory being a file",
+      "url": "https://github.com/openai/codex/pull/27719"
     },
     {
       "attention_flags": [
@@ -1502,6 +1414,70 @@
       ],
       "title": "[codex] Provide ARM64 MinGW powl compatibility support",
       "url": "https://github.com/openai/codex/pull/27323"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 5,
+      "commit_shas": [
+        "585a3fd1e845ac42098ef2caa40cea13b17f0e3a"
+      ],
+      "committed_at": "2026-06-11T23:55:01Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27623,
+      "pr_url": "https://github.com/openai/codex/pull/27623",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/session/turn.rs",
+        "codex-rs/core/src/session_startup_prewarm.rs",
+        "codex-rs/core/src/tasks/mod.rs",
+        "codex-rs/core/src/tasks/regular.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27623",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "internal_churn"
+      ],
+      "title": "Add spans to turn lifecycle gaps",
+      "url": "https://github.com/openai/codex/pull/27623"
+    },
+    {
+      "attention_flags": [
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 3,
+      "commit_shas": [
+        "30c334f609adb05a20c446c0f11e391aa27640f4",
+        "4cb95d86aa8be47c4b5d504b58799382f13e0a11",
+        "cd7264b628cfe8512e03035210c5a7f058112bb9",
+        "58064857225b9649756529974249db82c12ca808"
+      ],
+      "committed_at": "2026-06-12T01:44:42Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27715,
+      "pr_url": "https://github.com/openai/codex/pull/27715",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for release_packaging, security_policy.",
+      "sample_paths": [
+        ".github/scripts/test_v8_canary_changes.py",
+        ".github/scripts/v8_canary_changes.py",
+        ".github/workflows/v8-canary.yml"
+      ],
+      "source_state": "merged",
+      "subject_id": "27715",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "ci(v8): gate Windows source builds on relevant changes",
+      "url": "https://github.com/openai/codex/pull/27715"
     }
   ]
 }

--- a/artifacts/github/reviews/openai-codex-pr-27413.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27413.review.json
@@ -1,0 +1,60 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27413",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27413",
+    "commit_shas": [
+      "9ff580bf7e426f19713de20aaa9a0138a4aa389f",
+      "3eb9c5126d277d5c6e2b92dfb71a3025942a19ef"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "skills: decouple the skills extension from core",
+        "url": "https://github.com/openai/codex/pull/27413",
+        "meta": "Merged 2026-06-11T12:03:53Z"
+      },
+      {
+        "kind": "commit",
+        "title": "skills: decouple extension from core",
+        "url": "https://github.com/openai/codex/commit/9ff580bf7e426f19713de20aaa9a0138a4aa389f"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-12T02:07:24Z",
+  "observed_change": "Codex decoupled `codex-skills-extension` from `codex-core` by introducing a host-supplied `SkillsExtensionConfig` view and moving skills context fragments into the extension crate.",
+  "changed_surfaces": [
+    "codex-skills-extension crate dependencies",
+    "app-server extension installation boundary",
+    "skills extension host configuration view",
+    "available-skills and selected-skill context fragments",
+    "skills extension integration tests"
+  ],
+  "user_visible_path": "No user-visible or model-visible behavior change is intended; the PR preserves existing skills context roles, markers, and rendered bytes while changing crate ownership boundaries.",
+  "control_plane_relevance": "Moderate for Decodex Control Plane as background for the staged skills-extension migration, but the PR does not add a new hosted-skill capability or protocol method.",
+  "compatibility_risk": "Low for normal Codex users; medium for out-of-tree Rust hosts that install the skills extension because the host now supplies a config mapping into `SkillsExtensionConfig`.",
+  "adoption_opportunity": "Track the new host-owned config boundary for future Decodex plugin and skills-resource integration work, but do not schedule immediate runtime adoption from this PR alone.",
+  "community_value": "Low as a standalone public signal because the PR is intentionally internal and preserves model-visible behavior.",
+  "deprecated_or_breaking_notes": "`codex-skills-extension` removes its direct `codex-core` dependency and exposes `SkillsExtensionConfig`; host install code must provide the config projection.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27413 says the change intentionally preserves skills behavior and moves the host boundary needed for a broader extension migration.",
+    "`codex-rs/ext/skills/Cargo.toml` and `Cargo.lock` remove the direct `codex-core` dependency from `codex-skills-extension`.",
+    "`codex-rs/ext/skills/src/config.rs` adds public `SkillsExtensionConfig` with `include_instructions` and `bundled_skills_enabled` fields.",
+    "`codex-rs/app-server/src/extensions.rs` supplies a mapping from the app-server `Config` into `SkillsExtensionConfig` when installing the extension.",
+    "`codex-rs/ext/skills/src/fragments.rs` moves available-skills and selected-skill context fragment implementations into the extension crate.",
+    "`codex-rs/ext/skills/tests/skills_extension.rs` updates integration coverage to assert complete rendered catalog and selected-skill fragments, including roles and markers.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27413.json` records 10 changed files for the merged PR."
+  ],
+  "caveats": "Do not treat this PR as proof of a new skills UX; the PR body states it adds no capability and preserves emitted skills context.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The host-boundary change is useful Control Plane planning context for future skills-extension migration work."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-27569.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27569.review.json
@@ -1,0 +1,71 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27569",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27569",
+    "commit_shas": [
+      "168cddddc1b5c5f4fe64534acc4e31ae69474365",
+      "fe04e86efaae705d0b47e3d076e82d54b2e1dca5",
+      "92644c48f26b1f5d92892c01cd1585b86fc381f1",
+      "e13920ef12be52e892db5cbf3e0a3402d5d33f6e"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "multi-agent: move concurrency guidance into v2 usage hints",
+        "url": "https://github.com/openai/codex/pull/27569",
+        "meta": "Merged 2026-06-11T10:41:44Z"
+      },
+      {
+        "kind": "commit",
+        "title": "feat: update max concurrency message",
+        "url": "https://github.com/openai/codex/commit/168cddddc1b5c5f4fe64534acc4e31ae69474365"
+      },
+      {
+        "kind": "commit",
+        "title": "fix: derive usage hints from configured concurrency",
+        "url": "https://github.com/openai/codex/commit/e13920ef12be52e892db5cbf3e0a3402d5d33f6e"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-12T02:07:24Z",
+  "observed_change": "Codex now places multi-agent v2 shared concurrency-slot guidance in the root and subagent usage hints instead of the `spawn_agent` tool description.",
+  "changed_surfaces": [
+    "MultiAgentV2Config default usage-hint rendering",
+    "configured max-concurrency handling",
+    "spawn_agent v2 tool description",
+    "tool planning for collaboration tools",
+    "multi-agent configuration and tool-spec tests"
+  ],
+  "user_visible_path": "Root agents and subagents see guidance that the configured active-agent slots include the current agent; the `spawn_agent` description no longer repeats `max_concurrent_threads_per_session` wording.",
+  "control_plane_relevance": "Moderate for Decodex Control Plane because multi-agent orchestration quality depends on the model-visible concurrency contract, but this PR does not change the underlying slot limit or add a new protocol method.",
+  "compatibility_risk": "Low to medium for prompt snapshots, tests, or downstream tool-description checks that expected concurrency text to live inside the `spawn_agent` description.",
+  "adoption_opportunity": "Align Decodex multi-agent operator guidance with the shared active-slot model and avoid duplicating concurrency limits inside individual tool descriptions.",
+  "community_value": "Medium to high for Codex multi-agent users because it clarifies that active-agent capacity is a shared pool across the root agent and spawned agents.",
+  "deprecated_or_breaking_notes": "The redundant `max_concurrent_threads_per_session` text and plumbing are removed from the `spawn_agent` tool-spec path, while the configured concurrency value still feeds usage hints.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27569 says native Codex now tells the root agent and subagents how many active slots exist, including the current agent, and removes separate `spawn_agent` limit wording.",
+    "`codex-rs/core/src/config/mod.rs` adds `default_multi_agent_v2_usage_hint_text` that appends shared-slot guidance using the resolved max concurrency.",
+    "`MultiAgentV2Config::defaults_for_max_concurrency` keeps the complete default root and subagent usage hints in the config.",
+    "`codex-rs/core/src/tools/handlers/multi_agents_spec.rs` removes `max_concurrent_threads_per_session` from `SpawnAgentToolOptions` and the v2 description builder.",
+    "`codex-rs/core/src/tools/spec_plan.rs` removes the helper that threaded max-concurrency text into the spawn-agent tool spec.",
+    "Tests now assert the `spawn_agent` description does not contain `max_concurrent_threads_per_session` and that configured concurrency is reflected through usage hints.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27569.json` records 6 changed files for the merged PR."
+  ],
+  "caveats": "This is a model-facing guidance change, not evidence that Codex changed the actual concurrency limit or scheduling algorithm.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The change affects multi-agent prompt contracts that Decodex operators may need to mirror."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The shared-slot guidance is a useful public operator note for multi-agent users."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-27573.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27573.review.json
@@ -1,0 +1,69 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27573",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27573",
+    "commit_shas": [
+      "c011f6e6809601b6cc138e055bf1bc57bf5b5d4c",
+      "571debf6883633a51c69f6654efd10c4e13e7f26",
+      "0b768f5016684ccf0266aef513ff7f7bdfcc5aa2"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "core: enable remote compaction v2 by default",
+        "url": "https://github.com/openai/codex/pull/27573",
+        "meta": "Merged 2026-06-11T10:07:20Z"
+      },
+      {
+        "kind": "commit",
+        "title": "chore: compaction v2 default",
+        "url": "https://github.com/openai/codex/commit/c011f6e6809601b6cc138e055bf1bc57bf5b5d4c"
+      },
+      {
+        "kind": "commit",
+        "title": "test: update compaction coverage for v2 default",
+        "url": "https://github.com/openai/codex/commit/0b768f5016684ccf0266aef513ff7f7bdfcc5aa2"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-12T02:07:24Z",
+  "observed_change": "Codex promoted `remote_compaction_v2` from an under-development opt-in to a stable default for providers that already support remote compaction.",
+  "changed_surfaces": [
+    "feature registry stage and default for `remote_compaction_v2`",
+    "core remote-compaction test harness defaults",
+    "app-server v2 compaction coverage",
+    "remote compaction parity tests",
+    "resume, hooks, and responses-lite compaction tests"
+  ],
+  "user_visible_path": "Eligible OpenAI and Azure sessions now use remote compaction v2 by default, while Bedrock and OSS providers keep their existing local-compaction behavior.",
+  "control_plane_relevance": "Moderate for Decodex Control Plane because long-running retained lanes depend on Codex compaction behavior when sessions cross token limits or resume from compacted history.",
+  "compatibility_risk": "Medium for automation, tests, or run reconstruction that assumed legacy remote compaction was the production default; provider eligibility is not broadened by this PR.",
+  "adoption_opportunity": "Audit Decodex retained-lane history reconstruction, compaction readbacks, and any remote-compaction test fixtures against the v2 default rather than treating v2 as an opt-in edge case.",
+  "community_value": "High for Codex operators because the PR changes the default compaction path for supported hosted providers and preserves a clear legacy opt-out for parity coverage.",
+  "deprecated_or_breaking_notes": "`remote_compaction_v2` is no longer under development and no longer defaults to disabled; tests that intentionally exercise legacy remote compaction now explicitly disable the feature.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27573 says remote compaction v2 is ready to become the default for providers that already support remote compaction, while Bedrock and OSS providers retain local compaction.",
+    "`codex-rs/features/src/lib.rs` changes `Feature::RemoteCompactionV2` from `Stage::UnderDevelopment` and `default_enabled: false` to `Stage::Stable` and `default_enabled: true`.",
+    "`codex-rs/features/src/tests.rs` removes the test that asserted remote compaction v2 was under development and disabled by default.",
+    "`codex-rs/core/tests/suite/compact_remote_parity.rs` now disables `Feature::RemoteCompactionV2` only for `Mode::Legacy` instead of enabling it only for v2 mode.",
+    "`codex-rs/app-server/tests/suite/v2/compaction.rs`, `compact.rs`, `compact_remote.rs`, and `responses_lite.rs` explicitly disable remote compaction v2 where the test intends legacy behavior.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27573.json` records 8 changed files for the merged PR."
+  ],
+  "caveats": "Do not claim that this PR expands remote-compaction provider support; the PR body explicitly limits the default flip to providers that already support remote compaction.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Default compaction behavior can affect Decodex retained-lane history and operator readbacks."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The default flip is a clear public operator note with an important provider-eligibility caveat."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-27591.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27591.review.json
@@ -1,0 +1,62 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27591",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27591",
+    "commit_shas": [
+      "0dd59d361fb64e7cad0641619eae8047f893a8d8"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "skills: render catalog locators by authority",
+        "url": "https://github.com/openai/codex/pull/27591",
+        "meta": "Merged 2026-06-11T11:51:04Z"
+      },
+      {
+        "kind": "commit",
+        "title": "feat: renderer",
+        "url": "https://github.com/openai/codex/commit/0dd59d361fb64e7cad0641619eae8047f893a8d8"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-12T02:07:24Z",
+  "observed_change": "Codex now renders skills catalog source locators by owning authority instead of describing every skill as a host filesystem file.",
+  "changed_surfaces": [
+    "core skills instructions text",
+    "skills-extension catalog rendering",
+    "orchestrator-resource app-server skill guidance",
+    "host-file and executor-resource skills-extension coverage"
+  ],
+  "user_visible_path": "When model context lists available skills, local skills are still shown as files, but executor, orchestrator, and custom-provider skills are labeled as resources that must be read through the appropriate authority.",
+  "control_plane_relevance": "High for Decodex Control Plane because remote and hosted skill resources must route through `skills.list` and `skills.read` instead of filesystem tools in orchestration prompts.",
+  "compatibility_risk": "Medium for prompt snapshots or agent instructions that assumed every skill entry includes `file: <path>`; the underlying discovery, provider routing, and `skills.*` tool contract are unchanged.",
+  "adoption_opportunity": "Use authority-aware locator language in Decodex skill and plugin guidance so agents do not try to open `skill://` orchestrator resources as local paths.",
+  "community_value": "High for Codex plugin and skill users because the PR fixes model-visible instructions for hosted skills introduced through opaque resource identifiers.",
+  "deprecated_or_breaking_notes": "No runtime skill discovery or invocation behavior is removed. The visible catalog wording changes from file-only paths to `file`, `environment resource`, `orchestrator resource`, or `custom resource` locators.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27591 says hosted skills introduced by PR #27388 use opaque `skill://` resource identifiers and should not send the model toward filesystem tools.",
+    "`codex-rs/core-skills/src/render.rs` changes the available-skills intro and how-to-use guidance from file-path-only wording to source-locator wording.",
+    "`codex-rs/ext/skills/src/render.rs` now renders each skill line from `SkillCatalogEntry` and `SkillSourceKind` rather than `entry.rendered_path()` alone.",
+    "`codex-rs/app-server/tests/suite/v2/mcp_resource.rs` asserts orchestrator skills render as `orchestrator resource: skill://...` and include guidance not to treat `skill://` identifiers as filesystem paths.",
+    "`codex-rs/ext/skills/tests/skills_extension.rs` adds coverage for host skills as `(file: ...)` and executor skills as environment resources.",
+    "The PR body explicitly says the scope is model-visible catalog rendering and guidance, not discovery, selection, provider routing, caching, resource validation, or the `skills.*` tool contract.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27591.json` records 4 changed files for the merged PR."
+  ],
+  "caveats": "Do not claim new skill-provider capabilities from this PR alone; it corrects source-locator rendering and usage guidance for existing provider types.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Authority-aware skill locators affect Decodex prompt and plugin-resource routing."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The change is a clear public operator note for hosted skills and `skill://` resources."
+    }
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27569.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27569.json
@@ -1,0 +1,53 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27569",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "critical",
+  "audience": "Codex operators using multi-agent v2",
+  "candidate_text": [
+    "Codex moved multi-agent v2 concurrency guidance into shared usage hints: root agents and subagents now see that active slots include the current agent, while `spawn_agent` drops separate limit wording. PR: https://github.com/openai/codex/pull/27569"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27569.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27569.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27569"
+    ]
+  },
+  "evidence_notes": [
+    "Usage hints now include shared-slot guidance derived from the configured thread cap.",
+    "`spawn_agent` no longer carries `max_concurrent_threads_per_session` description text.",
+    "Tests assert the configured concurrency appears through usage hints rather than tool-description text."
+  ],
+  "claims": [
+    {
+      "text": "Multi-agent v2 concurrency guidance now lives in root and subagent usage hints.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27569.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The PR changes model-facing guidance, not the scheduler or actual concurrency limit.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27569.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The shared-slot wording is useful for operators interpreting multi-agent capacity.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27569:operator_impact"
+  },
+  "caveats": [
+    "Do not claim a changed concurrency limit or scheduler behavior.",
+    "Keep the note scoped to multi-agent v2 usage hints."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or publish this candidate."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27573.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27573.json
@@ -1,0 +1,54 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27573",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "critical",
+  "audience": "Codex operators running long sessions on hosted providers",
+  "candidate_text": [
+    "Codex made `remote_compaction_v2` the default for providers that already support remote compaction: OpenAI/Azure move to v2, while Bedrock/OSS stay local. Operators should treat legacy remote compaction as explicit opt-out coverage. PR: https://github.com/openai/codex/pull/27573"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27573.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27573.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27573"
+    ]
+  },
+  "evidence_notes": [
+    "`Feature::RemoteCompactionV2` is now stable and enabled by default.",
+    "Tests that need legacy remote compaction now explicitly disable the feature.",
+    "The PR body says OpenAI and Azure move to v2 while Bedrock and OSS keep local compaction."
+  ],
+  "claims": [
+    {
+      "text": "Remote compaction v2 is now the default for providers that already support remote compaction.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27573.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The change does not broaden provider eligibility for remote compaction.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27573.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The default compaction-path change matters to operators of long hosted Codex sessions.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27573:operator_impact"
+  },
+  "caveats": [
+    "Do not frame this as new Bedrock or OSS remote-compaction support.",
+    "Do not claim Decodex retained-lane support changes without a separate Decodex audit."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or publish this candidate.",
+    "Keep the provider caveat in any downstream post."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27591.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27591.json
@@ -1,0 +1,53 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27591",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "critical",
+  "audience": "Codex operators, plugin authors, and skill authors",
+  "candidate_text": [
+    "Codex now labels skill catalog sources by authority: `file`, environment, orchestrator, or custom resource. Hosted `skill://` entries point agents to `skills.list`/`skills.read`, not filesystem tools. PR: https://github.com/openai/codex/pull/27591"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27591.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27591.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27591"
+    ]
+  },
+  "evidence_notes": [
+    "Skill catalog rendering now distinguishes file, environment, orchestrator, and custom resource locators.",
+    "App-server tests assert orchestrator `skill://` resources are not treated as filesystem paths.",
+    "The PR body keeps discovery, provider routing, and the `skills.*` contract unchanged."
+  ],
+  "claims": [
+    {
+      "text": "Codex now renders skill catalog locators according to the skill resource authority.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27591.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Hosted `skill://` resources should be read through `skills.list` and `skills.read`, not filesystem tools.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27591.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "The corrected catalog wording is useful to operators working with hosted skills and orchestrator resources.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27591:operator_impact"
+  },
+  "caveats": [
+    "Do not claim a new skill-provider capability.",
+    "Local host skills still render as file locators."
+  ],
+  "next_steps": [
+    "Let Publisher automation decide whether to reserve or publish this candidate."
+  ]
+}


### PR DESCRIPTION
## Summary
- refreshed the deterministic openai/codex upstream review queue
- added source bundles, upstream reviews, and impact artifacts for PRs 27573, 27569, 27591, and 27413
- added social_candidate/v1 handoffs for PRs 27573, 27569, and 27591 only; no social_post/v1 artifacts were created

## Validation
- decodex radar bundle validate artifacts/github/bundles/openai-codex-pr-27573.json artifacts/github/bundles/openai-codex-pr-27569.json artifacts/github/bundles/openai-codex-pr-27591.json artifacts/github/bundles/openai-codex-pr-27413.json
- decodex radar validate artifacts/github/review-queue artifacts/github/bundles artifacts/github/reviews artifacts/github/impact artifacts/github/social-candidates
- cargo make check-site-content
- cargo make fmt
- cargo make lint-fix
- cargo make test

## Notes
- GitHub labels codex and codex-automation were not present in label readback, so none were applied.