### PR TITLE
XY-946: Clarify phase goal completion contract

### DIFF
--- a/apps/decodex/src/orchestrator/execution.rs
+++ b/apps/decodex/src/orchestrator/execution.rs
@@ -279,20 +279,21 @@ impl RepoGatePhaseGoalController<'_> {
 		phase: PhaseGoalKind,
 		detail: Option<&str>,
 	) -> PhaseGoalSpec {
+		let phase_exit_contract = "Phase exit contract: when this phase objective is satisfied, explicitly mark the active phase goal complete with the Codex goal completion mechanism so Decodex can run its repo gate and select the next phase. Do not end with only an `issue_progress_checkpoint`, final text, or an \"await next phase\" statement while the phase goal is still active.";
 		let objective = match phase {
 			PhaseGoalKind::ImplementToValidationReady => format!(
-				"Decodex phase: {}\nProduce the smallest coherent implementation and documentation change for {} that is ready for the registered Decodex repo gate. Do not push, request review, or treat goal completion as issue completion.",
+				"Decodex phase: {}\nProduce the smallest coherent implementation and documentation change for {} that is ready for the registered Decodex repo gate. Do not push, request review, or treat goal completion as issue completion. {phase_exit_contract}",
 				phase.as_str(),
 				self.issue_run.issue.identifier
 			),
 			PhaseGoalKind::RepairValidationFailures => format!(
-				"Decodex phase: {}\nRepair repo-gate failures for {} in the current worktree without widening issue scope. {}",
+				"Decodex phase: {}\nRepair repo-gate failures for {} in the current worktree without widening issue scope. {} {phase_exit_contract}",
 				phase.as_str(),
 				self.issue_run.issue.identifier,
 				detail.unwrap_or("Run the registered canonicalize and verify commands before completing this phase.")
 			),
 			PhaseGoalKind::RepairAcceptedReviewFindings => format!(
-				"Decodex phase: {}\nRepair accepted review findings for {} on the retained PR head without widening issue scope. Do not request GitHub Review before Decodex validation.",
+				"Decodex phase: {}\nRepair accepted review findings for {} on the retained PR head without widening issue scope. Do not request GitHub Review before Decodex validation. {phase_exit_contract}",
 				phase.as_str(),
 				self.issue_run.issue.identifier
 			),

--- a/apps/decodex/src/orchestrator/prompting.rs
+++ b/apps/decodex/src/orchestrator/prompting.rs
@@ -4,6 +4,14 @@ pub(crate) const TRACKER_PUBLIC_TEXT_BOUNDARY_INSTRUCTION: &str =
 const SELF_CHECK_INSTRUCTION: &str =
 	"Review your work repeatedly and fix any logic bugs until no new issues are found.";
 
+fn build_phase_goal_runtime_contract() -> String {
+	format!(
+		"Phase goal runtime contract\n- Decodex may set an active phase goal that narrows the immediate turn below the full issue lifecycle checklist.\n- Treat the active phase goal as the authoritative current contract. For `implement_to_validation_ready`, `repair_validation_failures`, and `repair_accepted_review_findings`, stop at validated local work, then explicitly complete the active phase goal with the Codex goal completion mechanism so Decodex can run its repo gate and select the next phase.\n- Do not use `{progress_checkpoint_tool}`, final chat text, or an \"await next phase\" statement as a substitute for completing a satisfied phase goal.\n- Only the later `handoff_evidence` phase should create/update the PR and record the terminal handoff path; that phase still requires the normal review handoff plus `{terminal_finalize_tool}`.",
+		progress_checkpoint_tool = ISSUE_PROGRESS_CHECKPOINT_TOOL_NAME,
+		terminal_finalize_tool = ISSUE_TERMINAL_FINALIZE_TOOL_NAME,
+	)
+}
+
 fn build_retry_recovery_context(dispatch_mode: IssueDispatchMode) -> Option<String> {
 	(dispatch_mode == IssueDispatchMode::Retry).then(|| {
 		String::from(
@@ -123,6 +131,7 @@ where
 	sections.push(String::from(
 		"Commit contract\n- When you create a local commit for this lane, use a single-line `decodex/commit/1` JSON commit message.\n- Required fields: `schema`, `summary`, and `authority`.\n- `authority` must be the authoritative Linear issue identifier for this lane.\n- Optional fields: `related` and `breaking`.\n- Do not encode landing mode, CI status, closeout state, or other process-state fields in the commit message.",
 	));
+	sections.push(build_phase_goal_runtime_contract());
 	sections.push(String::from(TRACKER_PUBLIC_TEXT_BOUNDARY_INSTRUCTION));
 
 	if let Some(recovery_context) = build_retry_recovery_context(issue_run.dispatch_mode) {

--- a/apps/decodex/src/orchestrator/tests/intake/run_and_prompting.rs
+++ b/apps/decodex/src/orchestrator/tests/intake/run_and_prompting.rs
@@ -683,6 +683,14 @@ fn developer_instructions_trim_workflow_body_and_preserve_required_guidance() {
 	assert!(instructions.contains(ISSUE_REVIEW_CHECKPOINT_TOOL_NAME));
 	assert!(instructions.contains(ISSUE_REVIEW_HANDOFF_TOOL_NAME));
 	assert!(instructions.contains(ISSUE_TERMINAL_FINALIZE_TOOL_NAME));
+	assert!(instructions.contains("Phase goal runtime contract"));
+	assert!(instructions.contains("Treat the active phase goal as the authoritative current contract"));
+	assert!(instructions.contains("explicitly complete the active phase goal with the Codex goal completion mechanism"));
+	assert!(
+		instructions.contains(
+			"Do not use `issue_progress_checkpoint`, final chat text, or an \"await next phase\" statement as a substitute"
+		)
+	);
 	assert!(instructions.contains("treat `issue_progress_checkpoint` as terminal completion"));
 	assert!(!instructions.contains("you may end the turn without"));
 	assert!(!instructions.contains("WORKFLOW.md\n"));

--- a/apps/decodex/src/orchestrator/tests/intake/workflow_reload.rs
+++ b/apps/decodex/src/orchestrator/tests/intake/workflow_reload.rs
@@ -174,6 +174,9 @@ fn expected_developer_instructions(
 		"Commit contract\n- When you create a local commit for this lane, use a single-line `decodex/commit/1` JSON commit message.\n- Required fields: `schema`, `summary`, and `authority`.\n- `authority` must be the authoritative Linear issue identifier for this lane.\n- Optional fields: `related` and `breaking`.\n- Do not encode landing mode, CI status, closeout state, or other process-state fields in the commit message.",
 	));
 	sections.push(String::from(
+		"Phase goal runtime contract\n- Decodex may set an active phase goal that narrows the immediate turn below the full issue lifecycle checklist.\n- Treat the active phase goal as the authoritative current contract. For `implement_to_validation_ready`, `repair_validation_failures`, and `repair_accepted_review_findings`, stop at validated local work, then explicitly complete the active phase goal with the Codex goal completion mechanism so Decodex can run its repo gate and select the next phase.\n- Do not use `issue_progress_checkpoint`, final chat text, or an \"await next phase\" statement as a substitute for completing a satisfied phase goal.\n- Only the later `handoff_evidence` phase should create/update the PR and record the terminal handoff path; that phase still requires the normal review handoff plus `issue_terminal_finalize`.",
+	));
+	sections.push(String::from(
 		TRACKER_PUBLIC_TEXT_BOUNDARY_INSTRUCTION,
 	));
 

--- a/apps/decodex/src/orchestrator/tests/runtime/repo_gate.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/repo_gate.rs
@@ -187,6 +187,48 @@ fn phase_goal_completion_runs_repo_gate_and_persists_handoff_phase() {
 }
 
 #[test]
+fn implementation_phase_goal_contract_requires_explicit_goal_completion() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let issue = sample_issue("In Progress", &[tracker::automation_active_label(TEST_SERVICE_ID).as_str()]);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue_run = IssueRunPlan {
+		issue: issue.clone(),
+		issue_state: String::from("In Progress"),
+		initial_issue_state: String::from("Todo"),
+		worktree: WorktreeSpec {
+			branch_name: String::from("x/pubfi-pub-101"),
+			issue_identifier: issue.identifier.clone(),
+			path: config.repo_root().to_path_buf(),
+			reused_existing: false,
+		},
+		retry_project_slug: String::from("pubfi"),
+		dispatch_mode: IssueDispatchMode::Normal,
+		attempt_number: 1,
+		run_id: String::from("pub-101-attempt-1"),
+		retry_budget_base: 0,
+	};
+	let controller = RepoGatePhaseGoalController {
+		project: &config,
+		workflow: &workflow,
+		state_store: &state_store,
+		issue_run: &issue_run,
+	};
+	let goal = controller
+		.initial_phase_goal()
+		.expect("phase goal should build")
+		.expect("normal dispatch should set an implementation phase goal");
+
+	assert_eq!(goal.phase, PhaseGoalKind::ImplementToValidationReady);
+	assert!(
+		goal.objective
+			.contains("explicitly mark the active phase goal complete with the Codex goal completion mechanism")
+	);
+	assert!(goal.objective.contains("Decodex can run its repo gate and select the next phase"));
+	assert!(goal.objective.contains("Do not end with only an `issue_progress_checkpoint`"));
+	assert!(goal.objective.contains("while the phase goal is still active"));
+}
+
+#[test]
 fn repo_gate_shell_falls_back_to_non_login_posix_sh_for_missing_absolute_shell() {
 	let (shell, shell_flag) = orchestrator::repo_gate_shell_from_env(Some(OsString::from(
 		"/definitely-missing-shell-for-tests",

--- a/docs/spec/app-server.md
+++ b/docs/spec/app-server.md
@@ -74,6 +74,10 @@ required goal methods work.
 
 Goal events are phase signals only. A `complete` goal status triggers Decodex-owned
 validation or handoff policy; it never satisfies terminal issue completion by itself.
+For implementation and repair phases, agents must complete the active phase goal
+when the local validation-ready objective is satisfied. Progress checkpoints and final
+text such as "await next phase" remain evidence only; Decodex advances to repo-gate
+validation and the next phase only from the explicit goal-complete signal.
 
 To validate an upstream app-server protocol change:
 

--- a/docs/spec/loop-runtime.md
+++ b/docs/spec/loop-runtime.md
@@ -482,6 +482,11 @@ Goal completion is a trigger for the next validation or review step. It is not p
 that the lane is complete, reviewed, merged, landed, or closed. Lane completion still
 requires the deterministic validation, review, PR handoff, manual-attention, landing,
 closeout, and terminal-finalization contracts owned by the lower-level specs.
+For `implement_to_validation_ready` and repair phases, completing the scoped goal is
+the only valid way to exit a satisfied phase and hand control back to Decodex's
+repo-gate transition. A progress checkpoint or final message that says the lane is
+validation-ready and waiting for the next phase is only evidence; it must not replace
+the Codex goal-complete signal.
 
 ## Validation And Review
 

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -284,6 +284,13 @@ uses it only as a phase signal:
   `issue_terminal_finalize(path = "review_handoff")`, or the manual-attention pair,
   the turn is invalid and must fail rather than treating goal completion as success.
 
+The active phase goal is the authoritative current contract. When an implementation
+or repair phase has satisfied its local validation-ready objective, the agent must
+complete that phase goal with the Codex goal completion mechanism so Decodex can run
+the repo gate and select the next phase. An `issue_progress_checkpoint`, final chat
+text, or "await next phase" statement is evidence only; it is not a phase exit and
+must not be treated as a substitute for goal completion.
+
 Phase-goal telemetry is local runtime evidence. It must distinguish
 `goal_complete`, `validation_pass`, `validation_fail`, review `clean`, review
 `findings`, terminal `review_handoff`, and terminal `manual_attention`. These signals


### PR DESCRIPTION
## Summary
- add a phase-goal runtime contract to Decodex run prompts so validation-ready and repair phases must complete the active Codex goal before Decodex advances phases
- include the same exit contract in implementation/repair phase goal objectives
- document that checkpoints/final text such as "await next phase" are evidence only, not a phase exit

## Validation
- cargo make fmt
- cargo make lint-fix
- cargo test -p decodex implementation_phase_goal_contract_requires_explicit_goal_completion
- cargo test -p decodex phase_goal_completion_runs_repo_gate_and_persists_handoff_phase
- cargo test -p decodex developer_instructions_trim_workflow_body_and_preserve_required_guidance
- cargo test -p decodex developer_instructions_match_trimmed_prompt_shape
- cargo make test
- git diff --check