### PR TITLE
Persist Codex alpha14 checkpoint handoff

### DIFF
--- a/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-14-needs-upstream-analysis.json
+++ b/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-14-needs-upstream-analysis.json
@@ -1,0 +1,81 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-rust-v0-140-0-alpha-14-needs-upstream-analysis",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "watch_note",
+  "priority": "normal",
+  "audience": "Codex operators tracking prerelease changes before stable",
+  "candidate_text": [
+    "0.140.0-alpha.14: defer, no X handoff.\n\nAdjacent compare alpha.13 -> alpha.14 has 5 commits. PR titles point to async_trait removal, SQLite directory recovery, V8 CI gating, and release codegen. Behavior claims need source review."
+  ],
+  "source_refs": {
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://developers.openai.com/codex/changelog",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.13",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.14",
+      "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.13...rust-v0.140.0-alpha.14",
+      "https://github.com/openai/codex/pull/27475",
+      "https://github.com/openai/codex/pull/27719",
+      "https://github.com/openai/codex/pull/27715",
+      "https://github.com/openai/codex/pull/27702"
+    ]
+  },
+  "evidence_notes": [
+    "GitHub release metadata shows rust-v0.140.0-alpha.14 was published at 2026-06-12T03:42:44Z with only a sparse release body: Release 0.140.0-alpha.14.",
+    "The correct public prerelease comparison for this checkpoint is rust-v0.140.0-alpha.13 -> rust-v0.140.0-alpha.14; alpha.14 is not the first prerelease after stable rust-v0.139.0.",
+    "GitHub compare metadata for alpha.13 -> alpha.14 reports status=diverged, 5 ahead commits, and 5 total commits.",
+    "PR-title metadata in the alpha.13 -> alpha.14 compare points to first-party async_trait removal, SQLite directory recovery, Windows V8 CI gating, and release code generation parallelization.",
+    "Checked Decodex review/impact artifacts are absent for all 4 primary PR-title references in the alpha.13 -> alpha.14 compare window in this checkout.",
+    "The refreshed release_delta/v1 records stable rust-v0.139.0 -> latest prerelease rust-v0.140.0-alpha.14 with 134 ahead commits and no tracked signal slugs.",
+    "Official Codex changelog readback for this run shows a 2026-06-11 Codex app update as the newest official app entry; rust-v0.140.0-alpha.14 is a GitHub prerelease checkpoint, not an official changelog entry."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.140.0-alpha.14 is a real OpenAI Codex prerelease checkpoint.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.14",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The correct public prerelease comparison for this checkpoint is rust-v0.140.0-alpha.13 -> rust-v0.140.0-alpha.14.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.13...rust-v0.140.0-alpha.14",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The alpha.14 release body is sparse and does not describe user-facing behavior beyond the version checkpoint.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.14",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "PR-title metadata in the alpha.14 compare points to async_trait removal, SQLite directory recovery, V8 CI gating, and release code generation changes.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.13...rust-v0.140.0-alpha.14",
+      "confidence": "likely"
+    },
+    {
+      "text": "Behavior claims for the alpha.14 window require upstream source review before a publishable Decodex prerelease thread.",
+      "evidence": "artifacts/github/reviews/",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "defer",
+    "reason": "needs_upstream_analysis: the alpha.14 release body is sparse and the adjacent alpha.13 -> alpha.14 compare has unreviewed PR-title gaps.",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-140-0-alpha-14:alpha13-alpha14:defer"
+  },
+  "caveats": [
+    "This is a terminal defer / needs_upstream_analysis checkpoint record, not a publication request.",
+    "No previous live and quote-eligible @decodexspace 0.140 prerelease post exists; earlier 0.140 prereleases in this checkout are recorded as defer / needs_upstream_analysis checkpoints.",
+    "Do not compare alpha.14 against stable 0.139.0 for public prerelease copy; the adjacent prerelease lineage is alpha.13 -> alpha.14 because alpha.14 is not the first prerelease after stable.",
+    "Exact source-review gap list for alpha.13 -> alpha.14 primary compare PRs: #27475, #27719, #27715, #27702.",
+    "Media caveat: no generated image is attached by this downstream artifact-consumer run. If this checkpoint later becomes publishable, decodex-x-publisher should generate and verify candidate-specific media only when it adds reader value."
+  ],
+  "next_steps": [
+    "Do not hand this alpha.14 defer record to decodex-x-publisher.",
+    "Route the listed source-review gap PRs to codex-upstream-radar-review / codex-code-analysis before turning alpha.14 into a release_rollup, watch_note, delta_explainer, or operator_impact post.",
+    "Use adjacent prerelease-to-prerelease lineage for future 0.140 prereleases after alpha.14."
+  ]
+}

--- a/site/src/content/release-deltas/openai-codex-latest.json
+++ b/site/src/content/release-deltas/openai-codex-latest.json
@@ -1,6 +1,6 @@
 {
   "compare": {
-    "ahead_by": 130,
+    "ahead_by": 134,
     "commit_shas": [
       "dffc4bf75dc9eeb0727f668c95bb7bd72315581d",
       "14660c22d14312c28a50c52954dd77dd88f03c26",
@@ -131,7 +131,11 @@
       "92d90369108daefad443183379a55357e8448b1a",
       "44403dd3ddff55753af49dd9eba1351c28dc256a",
       "1829ed11228d9ffad6bf7d6db615324126065b23",
-      "36f5119afeac503d68272220b6094f540c3c2cea"
+      "5a56caf18cb773b3d1c60e66d594e9512c7f18e7",
+      "69b0f52b2a728d71f4800793c6c069956a91a2f8",
+      "16c7c79540c26e648b1d0ee09b7c6f4f916258a0",
+      "e23d4df4ff5e284cafee734e5dba6b99abec239a",
+      "9a0cdc45db4d7814e4b64b74aa5566686b5629cf"
     ],
     "pr_numbers": [
       22685,
@@ -231,6 +235,7 @@
       27450,
       27454,
       27465,
+      27475,
       27476,
       27483,
       27484,
@@ -262,16 +267,19 @@
       27663,
       27689,
       27700,
-      27711
+      27702,
+      27711,
+      27715,
+      27719
     ],
     "status": "diverged",
-    "total_commits": 130,
-    "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.13"
+    "total_commits": 134,
+    "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.14"
   },
   "comparisons": [
     {
       "compare": {
-        "ahead_by": 130,
+        "ahead_by": 134,
         "commit_shas": [
           "dffc4bf75dc9eeb0727f668c95bb7bd72315581d",
           "14660c22d14312c28a50c52954dd77dd88f03c26",
@@ -402,7 +410,11 @@
           "92d90369108daefad443183379a55357e8448b1a",
           "44403dd3ddff55753af49dd9eba1351c28dc256a",
           "1829ed11228d9ffad6bf7d6db615324126065b23",
-          "36f5119afeac503d68272220b6094f540c3c2cea"
+          "5a56caf18cb773b3d1c60e66d594e9512c7f18e7",
+          "69b0f52b2a728d71f4800793c6c069956a91a2f8",
+          "16c7c79540c26e648b1d0ee09b7c6f4f916258a0",
+          "e23d4df4ff5e284cafee734e5dba6b99abec239a",
+          "9a0cdc45db4d7814e4b64b74aa5566686b5629cf"
         ],
         "pr_numbers": [
           22685,
@@ -502,6 +514,7 @@
           27450,
           27454,
           27465,
+          27475,
           27476,
           27483,
           27484,
@@ -533,13 +546,16 @@
           27663,
           27689,
           27700,
-          27711
+          27702,
+          27711,
+          27715,
+          27719
         ],
         "status": "diverged",
-        "total_commits": 130,
-        "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.13"
+        "total_commits": 134,
+        "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.14"
       },
-      "prerelease_tag_name": "rust-v0.140.0-alpha.13",
+      "prerelease_tag_name": "rust-v0.140.0-alpha.14",
       "stable_tag_name": "rust-v0.139.0",
       "tracked_signal_slugs": []
     },
@@ -10348,22 +10364,22 @@
       ]
     }
   ],
-  "generated_at": "2026-06-12T02:25:51.625137Z",
+  "generated_at": "2026-06-12T08:27:53.918051Z",
   "prerelease": {
-    "name": "0.140.0-alpha.13",
+    "name": "0.140.0-alpha.14",
     "prerelease": true,
-    "published_at": "2026-06-12T01:28:14Z",
-    "tag_name": "rust-v0.140.0-alpha.13",
-    "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.13"
+    "published_at": "2026-06-12T03:42:44Z",
+    "tag_name": "rust-v0.140.0-alpha.14",
+    "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.14"
   },
   "release_options": {
     "preview": [
       {
-        "name": "0.140.0-alpha.13",
+        "name": "0.140.0-alpha.14",
         "prerelease": true,
-        "published_at": "2026-06-12T01:28:14Z",
-        "tag_name": "rust-v0.140.0-alpha.13",
-        "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.13"
+        "published_at": "2026-06-12T03:42:44Z",
+        "tag_name": "rust-v0.140.0-alpha.14",
+        "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.14"
       },
       {
         "name": "0.139.0-alpha.3",


### PR DESCRIPTION
## Summary
- refresh `release_delta/v1` to latest OpenAI Codex prerelease `rust-v0.140.0-alpha.14`
- add a terminal `social_candidate/v1` defer record for alpha.14
- preserve adjacent prerelease lineage `alpha.13 -> alpha.14` with PR-title gap list

## Decision
`decision.worthiness = defer` / `needs_upstream_analysis`. The alpha.14 release body is sparse and behavior claims require upstream source review for PRs #27475, #27719, #27715, and #27702 before any publishable @decodexspace handoff.

## Validation
- `cargo make check-site-content`
