### PR TITLE
Persist Decodex X post for PR 27591

### DIFF
--- a/artifacts/social/x/posts/2026-06-12/openai-codex-pr-27591.json
+++ b/artifacts/social/x/posts/2026-06-12/openai-codex-pr-27591.json
@@ -1,0 +1,102 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-27591",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "published",
+  "audience": "Codex operators, plugin authors, and skill authors",
+  "text": [
+    "Codex now labels skill catalog sources by authority: `file`, environment, orchestrator, or custom resource. Hosted `skill://` entries point agents to `skills.list`/`skills.read`, not filesystem tools. PR: https://github.com/openai/codex/pull/27591"
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27591.json"
+    ],
+    "reservations": [
+      "artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27591.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27591.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27591.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27591",
+      "https://x.com/decodexspace/status/2065373771834478939"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish, priority critical, and mode operator_impact for openai-codex-pr-27591.",
+    "The upstream_review/v1 artifact confirms PR #27591 renders skill catalog source locators by owning authority rather than treating every skill as a host filesystem file.",
+    "The upstream_impact/v1 artifact marks the change as public_signal_decision publish, control_plane_impact candidate, and publisher_angle operator_impact.",
+    "The x-post-quality-system gate passed because the post states what changed, who can act on it, and the direct GitHub PR source that proves it; the checked text fit in X compose with the modal Post button enabled.",
+    "Checked durable social_post/v1 records contained no published or blocked record for this slug or idempotency key before publication.",
+    "Checked durable social_publish_reservation/v1 records contained no active reservation for this idempotency key before the new reservation was created.",
+    "Open GitHub PR readback with routed hackink credentials found pending publication PR #328 for openai-codex-app-26-608 and PR #298 for openai-codex-pr-26486, with no open PR touching openai-codex-pr-27591.",
+    "PR #358 made the active reservation visible before X compose; remote GitHub content readback confirmed artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27591.json with status active and the PR URL.",
+    "Chrome profile readback verified @decodexspace owner controls through the account menu and Edit profile before reservation.",
+    "Bounded @decodexspace profile readback and focused X search before reservation found no PR 27591, candidate slug, or source URL match.",
+    "Live @decodexspace profile readback after PR-visible reservation and immediately before clicking Post showed owner controls, rendered nine recent articles, and found no PR 27591, candidate slug, source URL, or lead-text match.",
+    "The compose dialog showed @decodexspace active and the checked PR #27591 text before the enabled modal Post button was clicked.",
+    "Home timeline readback immediately after posting showed the new @decodexspace status with the expected skill-catalog source-locator text and GitHub source link.",
+    "Permalink readback showed the expected @decodexspace post text, Automated by @hackink attribution, no attached image media, and no /photo/N link.",
+    "The t.co source link in final readback expands to https://github.com/openai/codex/pull/27591.",
+    "Final readback showed X auto-linked the dotted tool name `skills.read` to https://skills.read/ even though the visible text remains `skills.read`; treat that as a rendering caveat, not a source claim.",
+    "The status ID decodes to 2026-06-12T10:00:54.651Z, which is 2026-06-12 18:00:54 in Asia/Shanghai."
+  ],
+  "claims": [
+    {
+      "text": "Codex now renders skill catalog locators according to the skill resource authority.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27591.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Hosted `skill://` resources should be read through `skills.list` and `skills.read`, not filesystem tools.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27591.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The PR #27591 operator-impact post is live on @decodexspace.",
+      "evidence": "https://x.com/decodexspace/status/2065373771834478939",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "priority": "critical",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27591:operator_impact",
+    "reason": "The corrected catalog wording is useful to operators working with hosted skills and orchestrator resources.",
+    "daily_limit": 8,
+    "daily_count_before": 3,
+    "daily_count_after": 4,
+    "day": "2026-06-12",
+    "timezone": "Asia/Shanghai"
+  },
+  "publication": {
+    "posted_at": "2026-06-12T10:00:54.651Z",
+    "published_urls": [
+      "https://x.com/decodexspace/status/2065373771834478939"
+    ],
+    "publisher": "chrome",
+    "account_verified": true,
+    "made_with_ai": false
+  },
+  "media_refs": [
+    "media_caveat: no generated media was attached; this non-release operator_impact post remains valuable text-only because the source-backed skill-resource routing caveat and GitHub PR card are the reader value."
+  ],
+  "caveats": [
+    "Do not claim a new skill-provider capability from PR #27591.",
+    "Local host skills still render as file locators.",
+    "The change is prompt/catalog rendering, not a plugin protocol expansion.",
+    "X auto-linked the dotted `skills.read` tool name to https://skills.read/ in final readback; the visible text still communicates the intended tool name and the source link expands to PR #27591.",
+    "No generated image was used because this was a single non-release operator-impact post with sufficient reader value from the text and source card."
+  ],
+  "post_lifecycle": {
+    "current_state": "live",
+    "quote_eligible": false,
+    "reason": "This is a standalone operator-impact post, not a prerelease quote-chain anchor."
+  }
+}

--- a/artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27591.json
+++ b/artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27591.json
@@ -5,7 +5,7 @@
   "target_account": "decodexspace",
   "controller_account": "hackink",
   "mode": "operator_impact",
-  "status": "active",
+  "status": "consumed",
   "idempotency_key": "x:decodexspace:openai-codex-pr-27591:operator_impact",
   "reserved_at": "2026-06-12T09:56:30Z",
   "expires_at": "2026-06-12T11:56:30Z",
@@ -38,6 +38,7 @@
     "branch": "codex/x-publisher-pr-27591-20260612",
     "pr_url": "https://github.com/hack-ink/decodex/pull/358"
   },
+  "consumed_by_social_post": "artifacts/social/x/posts/2026-06-12/openai-codex-pr-27591.json",
   "evidence_notes": [
     "The social_candidate/v1 artifact has decision.worthiness = publish, priority critical, and mode operator_impact for openai-codex-pr-27591.",
     "The x-post-quality-system gate passed before reservation because the candidate states what changed, who can act on it, and the direct GitHub PR source that proves it.",

--- a/artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27591.json
+++ b/artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27591.json
@@ -35,7 +35,8 @@
   ],
   "owner": {
     "automation_id": "decodex-x-publisher",
-    "branch": "codex/x-publisher-pr-27591-20260612"
+    "branch": "codex/x-publisher-pr-27591-20260612",
+    "pr_url": "https://github.com/hack-ink/decodex/pull/358"
   },
   "evidence_notes": [
     "The social_candidate/v1 artifact has decision.worthiness = publish, priority critical, and mode operator_impact for openai-codex-pr-27591.",

--- a/artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27591.json
+++ b/artifacts/social/x/reservations/2026-06-12/openai-codex-pr-27591.json
@@ -1,0 +1,50 @@
+{
+  "schema": "social_publish_reservation/v1",
+  "slug": "openai-codex-pr-27591",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "active",
+  "idempotency_key": "x:decodexspace:openai-codex-pr-27591:operator_impact",
+  "reserved_at": "2026-06-12T09:56:30Z",
+  "expires_at": "2026-06-12T11:56:30Z",
+  "day": "2026-06-12",
+  "timezone": "Asia/Shanghai",
+  "candidate_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27591.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27591.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27591.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27591"
+    ]
+  },
+  "duplicate_keys": [
+    "x:decodexspace:openai-codex-pr-27591:operator_impact",
+    "openai-codex-pr-27591",
+    "https://github.com/openai/codex/pull/27591",
+    "PR 27591",
+    "skill catalog sources by authority",
+    "hosted skill:// resources"
+  ],
+  "owner": {
+    "automation_id": "decodex-x-publisher",
+    "branch": "codex/x-publisher-pr-27591-20260612"
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish, priority critical, and mode operator_impact for openai-codex-pr-27591.",
+    "The x-post-quality-system gate passed before reservation because the candidate states what changed, who can act on it, and the direct GitHub PR source that proves it.",
+    "Checked durable social_post/v1 records contained no published or blocked record for this slug or idempotency key before reservation.",
+    "Checked durable social_publish_reservation/v1 records contained no active reservation for this idempotency key before reservation.",
+    "Open GitHub PR readback with routed hackink credentials found pending publication PR #328 for openai-codex-app-26-608 and PR #298 for openai-codex-pr-26486, with no open PR touching openai-codex-pr-27591.",
+    "Cap-day count before this reservation is 3 for 2026-06-12 Asia/Shanghai from checked-in @decodexspace social_post/v1 records.",
+    "Chrome profile readback verified @decodexspace owner controls through the account menu and Edit profile before reservation.",
+    "Bounded @decodexspace profile readback and focused X search found no PR 27591, candidate slug, or source URL match before reservation."
+  ]
+}


### PR DESCRIPTION
## Summary
- Add the PR 27591 social_post/v1 publication record for @decodexspace.
- Mark the matching social_publish_reservation/v1 record consumed.
- Record the live X URL, no-media caveat, duplicate checks, cap accounting, and final readback caveat.

## Publication
- Candidate: openai-codex-pr-27591
- decision.worthiness: publish
- Mode: operator_impact
- X URL: https://x.com/decodexspace/status/2065373771834478939

## Validation
- jq -e reservation/post schema and status checks
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x

## Caveat
- X final readback auto-linked the dotted tool name `skills.read`; the artifact records this rendering caveat and the source link expands to the intended GitHub PR.