### PR TITLE
Record PR 27445 X publish failure

### DIFF
--- a/artifacts/social/x/posts/2026-06-13/openai-codex-pr-27445-chrome-account-verification-blocked.json
+++ b/artifacts/social/x/posts/2026-06-13/openai-codex-pr-27445-chrome-account-verification-blocked.json
@@ -1,0 +1,83 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-27445-chrome-account-verification-blocked",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "failed",
+  "audience": "Codex app-server and Control Plane operators",
+  "text": [
+    "Codex remoteControl/enable and disable are now durable by default, with `ephemeral: true` for runtime-only callers. Control-plane clients should recheck persistence assumptions. PR: https://github.com/openai/codex/pull/27445"
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27445.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27445.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27445.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27445"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish, priority critical, and mode operator_impact for openai-codex-pr-27445.",
+    "The upstream_review/v1 artifact confirms remoteControl/enable and remoteControl/disable now accept nullable params with optional `ephemeral`, and ordinary enable/disable requests persist desired state by default.",
+    "The upstream_impact/v1 artifact marks the change as public_signal_decision publish, control_plane_impact compat_risk, and publisher_angle operator_impact.",
+    "The x-post-quality-system gate passed because the post states what changed, who can act on it, and the direct source that proves it; the checked copy is 224 characters and includes a direct GitHub PR URL.",
+    "The release publisher gates were not applicable because this is a non-release operator_impact candidate.",
+    "Checked durable social_post/v1 records contained no published or blocked record for this idempotency key before this failed attempt.",
+    "Checked durable social_publish_reservation/v1 records contained no active reservation for this idempotency key before this failed attempt.",
+    "Open GitHub PR readback with routed hackink credentials found pending publication PR #328 for openai-codex-app-26-608 and PR #298 for openai-codex-pr-26486, and no open PR touching openai-codex-pr-27445.",
+    "Asia/Shanghai cap day 2026-06-13 had zero checked published @decodexspace records before this failed attempt.",
+    "Chrome opened X home, but page readback for the agent-created X tab reported that another extension UI was open, so the page could not be inspected reliably.",
+    "A single recovery attempt claimed an already-open X tab, but that tab hit the same extension-UI block before account or profile readback could be trusted.",
+    "Because @decodexspace account verification and live duplicate readback were unreliable, Publisher stopped before creating a reservation, opening compose, attaching media, or clicking Post.",
+    "Scoped Chrome tabs were finalized after the failure; the agent-created X tab was omitted and claimed/user tabs were released or left untouched by browser ownership rules."
+  ],
+  "claims": [
+    {
+      "text": "remoteControl enable and disable now have nullable params with optional `ephemeral`.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27445.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Ordinary remoteControl enable and disable requests now affect durable desired state by default.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27445.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The PR #27445 operator-impact post was not published because Chrome account and profile readback were unreliable.",
+      "evidence": "This social_post/v1 failure record",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "priority": "critical",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27445:operator_impact",
+    "reason": "The change is a concrete app-server Control Plane compatibility note with an operator action.",
+    "daily_limit": 8,
+    "daily_count_before": 0,
+    "daily_count_after": 0,
+    "day": "2026-06-13",
+    "timezone": "Asia/Shanghai"
+  },
+  "failure": {
+    "reason": "chrome_account_verification_blocked",
+    "details": "Chrome page readback for X reported that another extension UI was open on both the agent-created X tab and a claimed existing X tab. Publisher could not verify @decodexspace, could not perform live profile duplicate readback, and stopped before reservation or compose."
+  },
+  "media_refs": [
+    "media_caveat: no generated media was created or attached because the run stopped before account verification, reservation, compose, and upload gates."
+  ],
+  "caveats": [
+    "No X post was published.",
+    "No social_publish_reservation/v1 record was created for this attempt.",
+    "Retry publication only after Chrome can reliably verify @decodexspace and read the live @decodexspace profile or timeline.",
+    "The remote-control methods remain experimental upstream; do not imply Decodex has already adopted the new semantics."
+  ]
+}


### PR DESCRIPTION
## Summary
- records a failed `social_post/v1` publication attempt for `openai-codex-pr-27445`
- preserves why the publishable operator-impact candidate stopped before reservation or compose
- documents that Chrome could not reliably verify `@decodexspace` or live profile duplicate readback because an extension UI blocked X page inspection

## Validation
- `decodex radar validate artifacts/github/social-candidates artifacts/social/x`
- `cargo make fmt`
- `cargo make lint-fix`
- `cargo make test`

## Notes
- no X post was published
- no `social_publish_reservation/v1` was created
- retry only after Chrome can verify `@decodexspace` and read the live profile/timeline
- repo labels `codex` and `codex-automation` are not available in this repository
