### PR TITLE
[codex] Persist Codex alpha.18 release checkpoint handoff

### DIFF
--- a/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-18-needs-upstream-analysis.json
+++ b/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-18-needs-upstream-analysis.json
@@ -1,0 +1,85 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-rust-v0-140-0-alpha-18-needs-upstream-analysis",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "watch_note",
+  "priority": "normal",
+  "audience": "Codex operators tracking prerelease changes before stable",
+  "candidate_text": [
+    "0.140.0-alpha.18: defer, no X handoff.\n\nAdjacent alpha.17 -> alpha.18 has 9 commits. PR titles point to plugin auth/routes, managed remote control, Wine test support, and turn-state plumbing. Behavior claims need source review."
+  ],
+  "source_refs": {
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "urls": [
+      "https://developers.openai.com/codex/changelog",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.17",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.18",
+      "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.17...rust-v0.140.0-alpha.18",
+      "https://github.com/openai/codex/pull/27459",
+      "https://github.com/openai/codex/pull/27652",
+      "https://github.com/openai/codex/pull/27937",
+      "https://github.com/openai/codex/pull/27961",
+      "https://github.com/openai/codex/pull/27964",
+      "https://github.com/openai/codex/pull/27988",
+      "https://github.com/openai/codex/pull/27996",
+      "https://github.com/openai/codex/pull/28002"
+    ]
+  },
+  "evidence_notes": [
+    "GitHub release metadata shows rust-v0.140.0-alpha.18 was published at 2026-06-13T17:30:26Z with only a sparse release body: Release 0.140.0-alpha.18.",
+    "The correct public prerelease comparison for this checkpoint is rust-v0.140.0-alpha.17 -> rust-v0.140.0-alpha.18; alpha.18 is not the first prerelease after stable rust-v0.139.0.",
+    "GitHub compare metadata for alpha.17 -> alpha.18 reports status=diverged, 9 ahead commits, and 9 total commits.",
+    "PR-title metadata in the alpha.17 -> alpha.18 compare points to app-based plugin suggestions limited to remote catalogs, plugin manager auth mode, plugin MCP auth-route gating, managed remote-control disablement, hermetic Wine test support, request-scoped turn state over WebSocket, and turn state through compact requests.",
+    "Checked Decodex review/impact artifacts are absent for #27459, #27652, #27937, #27961, #27964, #27988, #27996, and #28002 in this checkout.",
+    "The refreshed release_delta/v1 records stable rust-v0.139.0 -> latest prerelease rust-v0.140.0-alpha.18 with 194 ahead commits and no tracked signal slugs.",
+    "Official Codex changelog readback for this run shows a 2026-06-11 Codex app update as the newest official app entry, plus 2026-06-09 entries for ChatGPT for iOS 1.2026.153 and Codex CLI 0.139.0; rust-v0.140.0-alpha.18 is a GitHub prerelease checkpoint, not an official changelog entry."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.140.0-alpha.18 is a real OpenAI Codex prerelease checkpoint.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.18",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The correct public prerelease comparison for this checkpoint is rust-v0.140.0-alpha.17 -> rust-v0.140.0-alpha.18.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.17...rust-v0.140.0-alpha.18",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The alpha.18 release body is sparse and does not describe user-facing behavior beyond the version checkpoint.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.18",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "PR-title metadata in the alpha.18 compare points to plugin auth and suggestion paths, managed remote-control policy, Wine test support, and turn-state plumbing.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.17...rust-v0.140.0-alpha.18",
+      "confidence": "likely"
+    },
+    {
+      "text": "Behavior claims for the alpha.18 window require upstream source review before a publishable Decodex prerelease thread.",
+      "evidence": "artifacts/github/reviews/",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "defer",
+    "reason": "needs_upstream_analysis: the alpha.18 release body is sparse and the adjacent alpha.17 -> alpha.18 compare has unreviewed PR-title gaps.",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-140-0-alpha-18:alpha17-alpha18:defer"
+  },
+  "caveats": [
+    "This is a terminal defer / needs_upstream_analysis checkpoint record, not a publication request.",
+    "No previous live and quote-eligible @decodexspace 0.140 prerelease post exists; earlier 0.140 prereleases in this checkout are recorded as defer / needs_upstream_analysis checkpoints.",
+    "Do not compare alpha.18 against stable 0.139.0 for public prerelease copy; the adjacent prerelease lineage is alpha.17 -> alpha.18 because alpha.18 is not the first prerelease after stable.",
+    "Exact source-review gap list for alpha.17 -> alpha.18 primary compare PRs: #27459, #27652, #27937, #27961, #27964, #27988, #27996, #28002.",
+    "Media caveat: no generated image is attached by this downstream artifact-consumer run. If this checkpoint later becomes publishable, decodex-x-publisher should generate and verify candidate-specific media only when it adds reader value."
+  ],
+  "next_steps": [
+    "Do not hand this alpha.18 defer record to decodex-x-publisher.",
+    "Route #27459, #27652, #27937, #27961, #27964, #27988, #27996, and #28002 to codex-upstream-radar-review / codex-code-analysis before turning alpha.18 into a release_rollup, watch_note, delta_explainer, or operator_impact post.",
+    "Use adjacent prerelease-to-prerelease lineage for future 0.140 prereleases after alpha.18."
+  ]
+}

--- a/site/src/content/release-deltas/openai-codex-latest.json
+++ b/site/src/content/release-deltas/openai-codex-latest.json
@@ -1,6 +1,6 @@
 {
   "compare": {
-    "ahead_by": 186,
+    "ahead_by": 194,
     "commit_shas": [
       "dffc4bf75dc9eeb0727f668c95bb7bd72315581d",
       "14660c22d14312c28a50c52954dd77dd88f03c26",
@@ -187,7 +187,15 @@
       "bacfc5e4c097894c927b5451d085fe7e489f8510",
       "9e078922534543b3bad2e6b920d398a661f9e40f",
       "c884536d848524d5f481eed6f8c02312de106a7a",
-      "ed327a57daf13bce2d9cbfe77faf36803bdfb241"
+      "044c1420a180207b1bc04fac82963233921ca2dd",
+      "aef40ad91fdb8afed89bc6b2821e58cc6f929608",
+      "5c8136f48a2b2102815918f8c58efa7173de703a",
+      "5d7db08b61555784ce8b08e1a5a308432e9c06a5",
+      "b9dc3b7a8ba24fe2a6ffa33890f35ca1d3e8ecf2",
+      "9d938a46d9119c3aaa4aac056950951027adec34",
+      "640d61b121e886682a03374fdf668e8b9b97ecf2",
+      "f297b9f07de10c7d8b9ed284b674d06cc5ff7723",
+      "dfd4b2b65869e9dffae24dfeb233a1586ca39d3b"
     ],
     "pr_numbers": [
       22685,
@@ -293,6 +301,7 @@
       27445,
       27450,
       27454,
+      27459,
       27465,
       27475,
       27476,
@@ -331,6 +340,7 @@
       27634,
       27639,
       27646,
+      27652,
       27653,
       27663,
       27670,
@@ -371,19 +381,25 @@
       27926,
       27927,
       27936,
+      27937,
       27939,
+      27961,
+      27964,
       27966,
       27972,
-      27976
+      27976,
+      27988,
+      27996,
+      28002
     ],
     "status": "diverged",
-    "total_commits": 186,
-    "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.17"
+    "total_commits": 194,
+    "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.18"
   },
   "comparisons": [
     {
       "compare": {
-        "ahead_by": 186,
+        "ahead_by": 194,
         "commit_shas": [
           "dffc4bf75dc9eeb0727f668c95bb7bd72315581d",
           "14660c22d14312c28a50c52954dd77dd88f03c26",
@@ -570,7 +586,15 @@
           "bacfc5e4c097894c927b5451d085fe7e489f8510",
           "9e078922534543b3bad2e6b920d398a661f9e40f",
           "c884536d848524d5f481eed6f8c02312de106a7a",
-          "ed327a57daf13bce2d9cbfe77faf36803bdfb241"
+          "044c1420a180207b1bc04fac82963233921ca2dd",
+          "aef40ad91fdb8afed89bc6b2821e58cc6f929608",
+          "5c8136f48a2b2102815918f8c58efa7173de703a",
+          "5d7db08b61555784ce8b08e1a5a308432e9c06a5",
+          "b9dc3b7a8ba24fe2a6ffa33890f35ca1d3e8ecf2",
+          "9d938a46d9119c3aaa4aac056950951027adec34",
+          "640d61b121e886682a03374fdf668e8b9b97ecf2",
+          "f297b9f07de10c7d8b9ed284b674d06cc5ff7723",
+          "dfd4b2b65869e9dffae24dfeb233a1586ca39d3b"
         ],
         "pr_numbers": [
           22685,
@@ -676,6 +700,7 @@
           27445,
           27450,
           27454,
+          27459,
           27465,
           27475,
           27476,
@@ -714,6 +739,7 @@
           27634,
           27639,
           27646,
+          27652,
           27653,
           27663,
           27670,
@@ -754,16 +780,22 @@
           27926,
           27927,
           27936,
+          27937,
           27939,
+          27961,
+          27964,
           27966,
           27972,
-          27976
+          27976,
+          27988,
+          27996,
+          28002
         ],
         "status": "diverged",
-        "total_commits": 186,
-        "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.17"
+        "total_commits": 194,
+        "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.18"
       },
-      "prerelease_tag_name": "rust-v0.140.0-alpha.17",
+      "prerelease_tag_name": "rust-v0.140.0-alpha.18",
       "stable_tag_name": "rust-v0.139.0",
       "tracked_signal_slugs": []
     },
@@ -10572,22 +10604,22 @@
       ]
     }
   ],
-  "generated_at": "2026-06-13T02:27:22.267611Z",
+  "generated_at": "2026-06-13T18:27:32.113601Z",
   "prerelease": {
-    "name": "0.140.0-alpha.17",
+    "name": "0.140.0-alpha.18",
     "prerelease": true,
-    "published_at": "2026-06-13T01:20:26Z",
-    "tag_name": "rust-v0.140.0-alpha.17",
-    "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.17"
+    "published_at": "2026-06-13T17:30:26Z",
+    "tag_name": "rust-v0.140.0-alpha.18",
+    "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.18"
   },
   "release_options": {
     "preview": [
       {
-        "name": "0.140.0-alpha.17",
+        "name": "0.140.0-alpha.18",
         "prerelease": true,
-        "published_at": "2026-06-13T01:20:26Z",
-        "tag_name": "rust-v0.140.0-alpha.17",
-        "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.17"
+        "published_at": "2026-06-13T17:30:26Z",
+        "tag_name": "rust-v0.140.0-alpha.18",
+        "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.18"
       },
       {
         "name": "0.139.0-alpha.3",


### PR DESCRIPTION
## Summary

- Refresh `release_delta/v1` for `openai/codex` from `rust-v0.140.0-alpha.17` to `rust-v0.140.0-alpha.18`.
- Add a terminal `social_candidate/v1` defer record for the new alpha.18 prerelease checkpoint.
- Record the adjacent `alpha.17 -> alpha.18` PR-title gap list for upstream review before any publishable @decodexspace handoff.

## Decision

`decision.worthiness = defer` / `needs_upstream_analysis`. The alpha.18 release body is sparse and behavior claims would require source review for #27459, #27652, #27937, #27961, #27964, #27988, #27996, and #28002.

## Validation

- `cargo run -p decodex --bin decodex -- radar validate site/src/content/release-deltas/openai-codex-latest.json artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-18-needs-upstream-analysis.json`
- `cargo run -p decodex --bin decodex -- radar validate site/src/content/release-deltas/openai-codex-latest.json artifacts/github/social-candidates`
- `cargo make fmt`
- `cargo make lint-fix`
- `cargo make test`