### PR TITLE
Persist upstream Radar review for PR 27504

### DIFF
--- a/artifacts/github/bundles/openai-codex-pr-27504.json
+++ b/artifacts/github/bundles/openai-codex-pr-27504.json
@@ -1,0 +1,105 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "celia-oai",
+      "committed_at": "2026-06-11T00:56:21Z",
+      "message": "Add secret auth storage config",
+      "sha": "07d66eccd904cd15cd754c43d3f74a72d63a1980",
+      "url": "https://github.com/openai/codex/commit/07d66eccd904cd15cd754c43d3f74a72d63a1980"
+    },
+    {
+      "author": "celia-oai",
+      "committed_at": "2026-06-12T18:51:10Z",
+      "message": "refactor",
+      "sha": "3e3379b56006b9e877f5db4ba65009b4ad41c49c",
+      "url": "https://github.com/openai/codex/commit/3e3379b56006b9e877f5db4ba65009b4ad41c49c"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "MCP",
+    "CLI",
+    "TUI",
+    "CONFIG_TOML_FILE",
+    "LOCAL_FS",
+    "FEATURES"
+  ],
+  "files": [
+    {
+      "additions": 20,
+      "deletions": 0,
+      "patch_excerpt": "@@ -113,6 +113,26 @@ pub enum OAuthCredentialsStoreMode {\n     Keyring,\n }\n \n+/// Determine how auth credentials should use keyring-backed storage.\n+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]\n+#[serde(rename_all = \"lowercase\")]\n+pub enum AuthKeyringBackendKind {\n+    /// Store the serialized auth payload directly in the OS keyring.\n+    Direct,\n+    /// Store auth payloads in the local encrypted secrets file, with the file key in the OS keyring.\n+    Secrets,\n+}\n+\n+impl Default for AuthKeyringBackendKind {\n+    fn default() -> Self {\n+        if cfg!(windows) {\n+            Self::Secrets\n+        } else {\n+            Self::Direct\n+        }\n+    }\n+}\n+\n #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]\n #[serde(rename_all = \"kebab-case\")]\n pub enum WindowsSandboxModeToml {",
+      "path": "codex-rs/config/src/types.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 6,
+      "deletions": 0,
+      "patch_excerpt": "@@ -599,6 +599,9 @@\n             \"search_tool\": {\n               \"type\": \"boolean\"\n             },\n+            \"secret_auth_storage\": {\n+              \"type\": \"boolean\"\n+            },\n             \"shell_snapshot\": {\n               \"type\": \"boolean\"\n             },\n@@ -4751,6 +4754,9 @@\n         \"search_tool\": {\n           \"type\": \"boolean\"\n         },\n+        \"secret_auth_storage\": {\n+          \"type\": \"boolean\"\n+        },\n         \"shell_snapshot\": {\n           \"type\": \"boolean\"\n         },",
+      "path": "codex-rs/core/config.schema.json",
+      "status": "modified"
+    },
+    {
+      "additions": 59,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,59 @@\n+use super::Config;\n+use super::ConfigTomlLoadResult;\n+use super::ManagedFeatures;\n+use codex_config::types::AuthKeyringBackendKind;\n+use codex_features::Feature;\n+use codex_features::FeatureConfigSource;\n+use codex_features::FeatureOverrides;\n+use codex_features::Features;\n+\n+impl Config {\n+    pub fn auth_keyring_backend_kind(&self) -> AuthKeyringBackendKind {\n+        auth_keyring_backend_kind_from_secret_auth_storage(\n+            self.features.enabled(Feature::SecretAuthStorage),\n+        )\n+    }\n+}\n+\n+/// Resolve the auth keyring backend from a partially loaded bootstrap config.\n+///\n+/// This is intended for startup paths that must read auth before managed cloud\n+/// requirements can be loaded and before a full [`Config`] exists.\n+pub fn resolve_bootstrap_auth_keyring_backend_kind(\n+    bootstrap_config: &ConfigTomlLoadResult,\n+) -> std::io::Result<AuthKeyringBac...",
+      "path": "codex-rs/core/src/config/auth_keyring.rs",
+      "status": "added"
+    },
+    {
+      "additions": 79,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,79 @@\n+use super::*;\n+use codex_config::ConfigLayerStack;\n+use codex_config::ConfigRequirements;\n+use codex_config::ConfigRequirementsToml;\n+use codex_config::FeatureRequirementsToml;\n+use codex_config::RequirementSource;\n+use codex_config::Sourced;\n+use codex_config::config_toml::ConfigToml;\n+use codex_features::FeaturesToml;\n+use pretty_assertions::assert_eq;\n+use std::collections::BTreeMap;\n+\n+#[test]\n+fn resolve_bootstrap_auth_keyring_backend_kind_uses_secret_auth_storage_feature()\n+-> std::io::Result<()> {\n+    let config_toml = ConfigToml {\n+        features: Some(FeaturesToml::from(BTreeMap::from([(\n+            \"secret_auth_storage\".to_string(),\n+            true,\n+        )]))),\n+        ..Default::default()\n+    };\n+    assert_eq!(\n+        resolve_bootstrap_auth_keyring_backend_kind(&config_toml_load_result(\n+            config_toml,\n+            /*feature_requireme...",
+      "path": "codex-rs/core/src/config/auth_keyring_tests.rs",
+      "status": "added"
+    },
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -4,8 +4,10 @@ use crate::config::edit::apply_blocking;\n use assert_matches::assert_matches;\n use codex_config::CONFIG_TOML_FILE;\n use codex_config::ConfigLayerEntry;\n+use codex_config::ConfigLayerStack;\n use codex_config::ProfileV2Name;\n use codex_config::RequirementSource;\n+use codex_config::Sourced;\n use codex_config::config_toml::AgentRoleToml;\n use codex_config::config_toml::AgentsToml;\n use codex_config::config_toml::AutoReviewToml;",
+      "path": "codex-rs/core/src/config/config_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 29,
+      "deletions": 1,
+      "patch_excerpt": "@@ -137,6 +137,7 @@ use toml::Value as TomlValue;\n use toml_edit::DocumentMut;\n \n pub(crate) mod agent_roles;\n+mod auth_keyring;\n pub mod edit;\n mod managed_features;\n mod network_proxy_spec;\n@@ -145,6 +146,7 @@ mod permissions;\n mod resolved_permission_profile;\n #[cfg(test)]\n mod schema;\n+pub use auth_keyring::resolve_bootstrap_auth_keyring_backend_kind;\n pub use codex_config::ConfigLoadOptions;\n pub use codex_config::Constrained;\n pub use codex_config::ConstraintError;\n@@ -1647,6 +1649,29 @@ pub async fn load_config_as_toml_with_cli_and_load_options(\n     cli_overrides: Vec<(String, TomlValue)>,\n     options: impl Into<ConfigLoadOptions>,\n ) -> std::io::Result<ConfigToml> {\n+    load_config_toml_with_layer_stack(codex_home, cwd, cli_overrides, options)\n+        .await\n+        .map(|result| result.config_toml)\n+}\n+\n+/// Partially loaded config plus the layer stack used to derive it.\n+/...",
+      "path": "codex-rs/core/src/config/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 8,
+      "deletions": 0,
+      "patch_excerpt": "@@ -81,6 +81,8 @@ pub enum Feature {\n     ShellTool,\n     /// Enable Claude-style lifecycle hooks loaded from hooks.json files.\n     CodexHooks,\n+    /// Store CLI auth in the encrypted local secrets backend when keyring storage is selected.\n+    SecretAuthStorage,\n \n     // Experimental\n     /// Enable JavaScript code mode backed by the in-process V8 runtime.\n@@ -748,6 +750,12 @@ pub const FEATURES: &[FeatureSpec] = &[\n         stage: Stage::Stable,\n         default_enabled: true,\n     },\n+    FeatureSpec {\n+        id: Feature::SecretAuthStorage,\n+        key: \"secret_auth_storage\",\n+        stage: Stage::Stable,\n+        default_enabled: cfg!(windows),\n+    },\n     FeatureSpec {\n         id: Feature::UnifiedExec,\n         key: \"unified_exec\",",
+      "path": "codex-rs/features/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 10,
+      "deletions": 0,
+      "patch_excerpt": "@@ -189,6 +189,16 @@ fn tool_search_is_removed_and_disabled_by_default() {\n     assert_eq!(feature_for_key(\"tool_search\"), Some(Feature::ToolSearch));\n }\n \n+#[test]\n+fn secret_auth_storage_defaults_to_windows_only() {\n+    assert_eq!(Feature::SecretAuthStorage.stage(), Stage::Stable);\n+    assert_eq!(Feature::SecretAuthStorage.default_enabled(), cfg!(windows));\n+    assert_eq!(\n+        feature_for_key(\"secret_auth_storage\"),\n+        Some(Feature::SecretAuthStorage)\n+    );\n+}\n+\n #[test]\n fn browser_controls_are_stable_and_enabled_by_default() {\n     assert_eq!(Feature::InAppBrowser.stage(), Stage::Stable);",
+      "path": "codex-rs/features/src/tests.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#17931"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nWindows Credential Manager limits generic credential blobs to 2,560 bytes. The encrypted local secrets backend avoids storing large serialized auth payloads directly in the OS keyring, but selecting that backend needs an independently reviewable feature/config layer before the auth and secrets implementation is wired in.\n\n## What Changed\n\n- Added the stable `secret_auth_storage` feature, enabled by default on Windows and disabled by default elsewhere.\n- Added `AuthKeyringBackendKind` and config resolution for full and bootstrap config loading.\n- Applied managed feature requirements when resolving the bootstrap auth backend.\n- Updated the generated config schema and added focused tests.\n\nThis is the base PR for #17931. The auth, secrets, MCP, CLI, TUI, and app-server implementation remains in that follow-up PR.\n\n## Validation\n\n- `just test -p codex-features`\n- `just test -p codex-config`\n- `just test -p codex-core resolve_bootstrap_auth_keyring_backend_kind_uses_secret_auth_storage_feature`\n- `just write-config-schema`\n- `just fix -p codex-core`\n\nThe full `just test -p codex-core` run compiled successfully and ran 2,690 tests; 2,589 passed, one was flaky, and 101 environment-sensitive tests failed because this shell injects a `pyenv` rehash warning into command output or because sandboxed subprocesses timed out.\n",
+    "labels": [],
+    "merged_at": "2026-06-12T19:15:22Z",
+    "number": 27504,
+    "state": "merged",
+    "title": "feat: add secret auth storage configuration",
+    "url": "https://github.com/openai/codex/pull/27504"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/impact/openai-codex-pr-27504.json
+++ b/artifacts/github/impact/openai-codex-pr-27504.json
@@ -1,0 +1,47 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27504",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "feat: add secret auth storage configuration",
+        "url": "https://github.com/openai/codex/pull/27504",
+        "meta": "Merged 2026-06-12T19:15:22Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27504",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27504.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex adds a stable `secret_auth_storage` feature and `AuthKeyringBackendKind` config resolution so auth credential storage can select direct keyring or encrypted-local secrets backends, with Windows defaulting to secrets.",
+  "public_signal_decision": "defer",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "watch_note",
+  "confidence": "confirmed",
+  "evidence": [
+    "The upstream review records `secret_auth_storage`, `AuthKeyringBackendKind`, bootstrap resolution, managed feature requirements, schema updates, and tests.",
+    "The PR body says this is the independently reviewable configuration layer before auth and secrets implementation follow-ups.",
+    "The feature is stable, defaults on for Windows, and maps to the encrypted-local secrets backend when enabled.",
+    "Bootstrap auth backend resolution applies managed feature requirements before a full Config exists.",
+    "The source-backed review is recorded at `artifacts/github/reviews/openai-codex-pr-27504.review.json`."
+  ],
+  "candidate_followups": [
+    "Audit Decodex managed config and auth-inspection paths for assumptions that Codex auth always uses direct OS keyring storage.",
+    "Preserve `secret_auth_storage` when reading or writing Codex feature configuration, especially for Windows and managed-requirement contexts.",
+    "Evaluate the auth-storage stack as a whole with PRs #27535, #27539, and #27541 before filing implementation work."
+  ],
+  "social_notes": [
+    "Use deferred watch-note framing because PR #27504 is only the configuration layer.",
+    "Do not imply CLI auth, MCP OAuth, TUI, or app-server secret storage behavior shipped in this PR alone.",
+    "Combine with later source-backed auth-storage reviews for any stronger public explanation."
+  ],
+  "caveats": [
+    "The PR explicitly says auth, secrets, MCP, CLI, TUI, and app-server implementation remains in follow-ups.",
+    "The compatibility risk becomes concrete when downstream code consumes the follow-up auth-storage implementation."
+  ]
+}

--- a/artifacts/github/review-queue/openai-codex-latest.json
+++ b/artifacts/github/review-queue/openai-codex-latest.json
@@ -1,14 +1,14 @@
 {
   "counts": {
-    "critical": 20,
+    "critical": 19,
     "high": 5,
     "low": 0,
-    "normal": 15,
+    "normal": 16,
     "published_subjects_seen": 0,
     "recent_commits_scanned": 40,
     "subjects_queued": 40
   },
-  "generated_at": "2026-06-14T00:05:30.172833Z",
+  "generated_at": "2026-06-14T06:06:44.836542Z",
   "repo": "openai/codex",
   "schema": "upstream_review_queue/v1",
   "source": {
@@ -17,147 +17,6 @@
     "signals_dir": "site/src/content/signals"
   },
   "subjects": [
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 40,
-      "commit_shas": [
-        "69a5b897facddfdb48dc4cccb173541f5349aa6f",
-        "db68524fe5280a98ae8a500448d2c7eb46b33164",
-        "a57dab38147d453e05cd391eed4a3ab83a251f71"
-      ],
-      "committed_at": "2026-06-12T18:38:01Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27816,
-      "pr_url": "https://github.com/openai/codex/pull/27816",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/Cargo.lock",
-        "codex-rs/core/src/agents_md.rs",
-        "codex-rs/core/src/agents_md_tests.rs",
-        "codex-rs/core/src/context/environment_context.rs",
-        "codex-rs/core/src/environment_selection.rs",
-        "codex-rs/core/src/exec.rs",
-        "codex-rs/core/src/guardian/review_session.rs",
-        "codex-rs/core/src/sandboxing/mod.rs",
-        "codex-rs/core/src/session/mcp.rs",
-        "codex-rs/core/src/session/session.rs",
-        "codex-rs/core/src/session/tests.rs",
-        "codex-rs/core/src/session/turn.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27816",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "config_hooks",
-        "mcp_plugins",
-        "sandbox_permissions",
-        "tests_ci"
-      ],
-      "title": "sandboxing: migrate cwd inputs to PathUri",
-      "url": "https://github.com/openai/codex/pull/27816"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging"
-      ],
-      "changed_file_count": 11,
-      "commit_shas": [
-        "79e6ea4a8182b747e0329082a2b70215a70253b3",
-        "f63cf1908952d8daed71bcdb63efda76bfa15ef2"
-      ],
-      "committed_at": "2026-06-12T18:53:55Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27890,
-      "pr_url": "https://github.com/openai/codex/pull/27890",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging.",
-      "sample_paths": [
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/v2/PluginReadResponse.json",
-        "codex-rs/app-server-protocol/schema/typescript/v2/PluginDetail.ts",
-        "codex-rs/app-server-protocol/src/protocol/v2/plugin.rs",
-        "codex-rs/app-server/README.md",
-        "codex-rs/app-server/src/request_processors/plugins.rs",
-        "codex-rs/app-server/tests/suite/v2/plugin_read.rs",
-        "codex-rs/core-plugins/src/remote.rs",
-        "codex-rs/tui/src/chatwidget/tests/helpers.rs",
-        "codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27890",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "docs_examples",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "[codex] expose remote plugin share URL",
-      "url": "https://github.com/openai/codex/pull/27890"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 11,
-      "commit_shas": [
-        "138e4eeeeaaeed2d04a74283e13e30124a75bcd1",
-        "d4e267882417929bfa34d49398f7043f95cddc3c"
-      ],
-      "committed_at": "2026-06-12T19:12:08Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27927,
-      "pr_url": "https://github.com/openai/codex/pull/27927",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/core-plugins/src/provider_tests.rs",
-        "codex-rs/exec-server/src/fs_helper.rs",
-        "codex-rs/exec-server/src/local_file_system.rs",
-        "codex-rs/exec-server/src/protocol.rs",
-        "codex-rs/exec-server/src/remote_file_system.rs",
-        "codex-rs/exec-server/src/sandboxed_file_system.rs",
-        "codex-rs/exec-server/src/server/file_system_handler.rs",
-        "codex-rs/exec-server/tests/file_system/shared.rs",
-        "codex-rs/exec-server/tests/file_system_unix.rs",
-        "codex-rs/ext/skills/tests/executor_file_system_authority.rs",
-        "codex-rs/file-system/src/lib.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27927",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "auth_accounts",
-        "mcp_plugins",
-        "model_provider",
-        "sandbox_permissions",
-        "tests_ci"
-      ],
-      "title": "[codex] Add size to internal filesystem metadata",
-      "url": "https://github.com/openai/codex/pull/27927"
-    },
     {
       "attention_flags": [
         "auth_account",
@@ -909,42 +768,98 @@
     },
     {
       "attention_flags": [
-        "protocol_change"
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
       ],
-      "changed_file_count": 10,
+      "changed_file_count": 7,
       "commit_shas": [
-        "edc3e87b3d2f5db1c3b79ac348bd91f7ea5dd85a",
-        "0ca854c673e53ff602a98fff87e4e3f146a94c1b",
-        "df3603dd3107c78f8a40388990a8f667bc688dfa"
+        "6090e9d2498277d9f8720d860e6e89142d9e45a9",
+        "97a3f22d9eaa499ee384674a4f47788a2c0e219e",
+        "8235bab021b5b77dd1999487ab3082fafca3069a"
       ],
-      "committed_at": "2026-06-12T18:57:22Z",
+      "committed_at": "2026-06-14T00:53:09Z",
       "next_step": "ai_review_required",
-      "pr_number": 27920,
-      "pr_url": "https://github.com/openai/codex/pull/27920",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for protocol_change.",
+      "pr_number": 27607,
+      "pr_url": "https://github.com/openai/codex/pull/27607",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging.",
       "sample_paths": [
-        "codex-rs/app-server/tests/suite/v2/imagegen_extension.rs",
-        "codex-rs/core/src/stream_events_utils.rs",
-        "codex-rs/ext/image-generation/src/tool.rs",
-        "codex-rs/tui/src/chatwidget/replay.rs",
-        "codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__failed_image_generation_call_history_snapshot.snap",
-        "codex-rs/tui/src/chatwidget/tests/exec_flow.rs",
-        "codex-rs/tui/src/chatwidget/tests/helpers.rs",
-        "codex-rs/tui/src/chatwidget/tool_lifecycle.rs",
-        "codex-rs/tui/src/history_cell/patches.rs",
-        "codex-rs/tui/src/history_cell/tests.rs"
+        "codex-rs/app-server/src/request_processors/plugins.rs",
+        "codex-rs/core-plugins/src/loader.rs",
+        "codex-rs/core-plugins/src/manager.rs",
+        "codex-rs/core-plugins/src/manager_tests.rs",
+        "codex-rs/core/tests/suite/plugins.rs",
+        "codex-rs/plugin/src/lib.rs",
+        "codex-rs/plugin/src/load_outcome.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27920",
+      "subject_id": "27607",
       "subject_kind": "pr",
       "surface_hints": [
         "app_server_protocol",
-        "cli_tui",
+        "mcp_plugins",
         "tests_ci"
       ],
-      "title": "Handle standalone image generation failures as terminal items",
-      "url": "https://github.com/openai/codex/pull/27920"
+      "title": "[codex] Dedupe plugin MCPs by app declaration name",
+      "url": "https://github.com/openai/codex/pull/27607"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 47,
+      "commit_shas": [
+        "7790dbe973f1b5310c79d90df26a181d0940e8a1",
+        "2a4048370d399c4fd45040f27659dee2bed7f97a",
+        "337e24e0ecc099f24ec63a643bcd2c5d6573e384",
+        "2c976d8ce0bafb0ead74d52eef1ca9bf3aaa6a13",
+        "6ad9c02999081787c4d16e6d3d070aa0133b9bf9"
+      ],
+      "committed_at": "2026-06-14T04:43:39Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28125,
+      "pr_url": "https://github.com/openai/codex/pull/28125",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        ".devcontainer/devcontainer.json",
+        ".devcontainer/devcontainer.secure.json",
+        ".github/workflows/ci.yml",
+        "MODULE.bazel",
+        "codex-rs/app-server-protocol/BUILD.bazel",
+        "codex-rs/app-server/BUILD.bazel",
+        "codex-rs/app-server/tests/common/BUILD.bazel",
+        "codex-rs/backend-client/BUILD.bazel",
+        "codex-rs/bwrap/BUILD.bazel",
+        "codex-rs/codex-client/BUILD.bazel",
+        "codex-rs/collaboration-mode-templates/BUILD.bazel",
+        "codex-rs/core-plugins/BUILD.bazel"
+      ],
+      "source_state": "merged",
+      "subject_id": "28125",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "auth_accounts",
+        "cli_tui",
+        "config_hooks",
+        "docs_examples",
+        "mcp_plugins",
+        "model_provider",
+        "release_packaging",
+        "sandbox_permissions",
+        "tests_ci"
+      ],
+      "title": "build: run buildifier from just fmt",
+      "url": "https://github.com/openai/codex/pull/28125"
     },
     {
       "attention_flags": [
@@ -1112,35 +1027,38 @@
     },
     {
       "attention_flags": [
-        "deprecated_removed",
         "new_feature",
-        "protocol_change"
+        "protocol_change",
+        "release_packaging"
       ],
-      "changed_file_count": 2,
+      "changed_file_count": 5,
       "commit_shas": [
-        "6b2c572c7a2e3cd662afaf7ee62c8a202e32ae53",
-        "e263eedd3acbd3852ae139e88b82893dc8e6b46b",
-        "312807de7287117c496988a4fac00e976c0bd3c9",
-        "4dbf491551b67756e6657fe0145b384ebef71ade"
+        "decac77d8337b827375619f1de4eb14d58cc64ca",
+        "36599cad8adc4f60b5743f85763c6382f248c00e",
+        "624645fffe36882390418ca331b66c3387ce527f",
+        "68b7b0d39ac322dc4d5c3a0a868ccc2244ba5729"
       ],
-      "committed_at": "2026-06-12T18:54:28Z",
+      "committed_at": "2026-06-14T04:28:31Z",
       "next_step": "ai_review_required",
-      "pr_number": 27913,
-      "pr_url": "https://github.com/openai/codex/pull/27913",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change.",
+      "pr_number": 27992,
+      "pr_url": "https://github.com/openai/codex/pull/27992",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for new_feature, protocol_change, release_packaging.",
       "sample_paths": [
-        "codex-rs/apply-patch/src/parser.rs",
-        "codex-rs/apply-patch/src/streaming_parser.rs"
+        "MODULE.bazel.lock",
+        "codex-rs/Cargo.lock",
+        "codex-rs/Cargo.toml",
+        "codex-rs/state/Cargo.toml",
+        "codex-rs/state/src/lib.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27913",
+      "subject_id": "27992",
       "subject_kind": "pr",
       "surface_hints": [
-        "internal_churn"
+        "config_hooks"
       ],
-      "title": "[codex] unify apply patch parsing",
-      "url": "https://github.com/openai/codex/pull/27913"
+      "title": "[codex] Pin bundled SQLite to fixed WAL-reset version",
+      "url": "https://github.com/openai/codex/pull/27992"
     },
     {
       "attention_flags": [
@@ -1589,6 +1507,91 @@
       ],
       "title": "[codex] package Windows ARM64 on x64",
       "url": "https://github.com/openai/codex/pull/28001"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "release_packaging"
+      ],
+      "changed_file_count": 6,
+      "commit_shas": [
+        "db7a2aa50bc789d69b6a36ef0f6ff400d51a12dc",
+        "f57c946c5e0c2d1813a5e7121a3be2b09b2b4748",
+        "b9f330cabd62f9c69f9e7e7f9af87bd447498e20",
+        "00d33a1d0c033aeab91e311c3d47ccd5e1b54304",
+        "e7f67ea405c76d36e2a1d3a0d52d04c24e56be8d",
+        "74595cf140bf78d036a1a6ec6e33d21e2af76ef5",
+        "f549600c77ed3802be97afc670aad3e1e8a5c795",
+        "4dc3408a759fb12caaae3145686fcb6517a1f4c1",
+        "1859f054ada720b3c3b14590ea3517ed1a269642"
+      ],
+      "committed_at": "2026-06-14T04:52:32Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28120,
+      "pr_url": "https://github.com/openai/codex/pull/28120",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, release_packaging.",
+      "sample_paths": [
+        "bazel/modules/wine.MODULE.bazel",
+        "bazel/rules/testing/wine.bzl",
+        "bazel/rules/testing/wine/BUILD.bazel",
+        "bazel/rules/testing/wine/src/lib.rs",
+        "bazel/rules/testing/wine/src/lib_tests.rs",
+        "third_party/powershell/BUILD.bazel"
+      ],
+      "source_state": "merged",
+      "subject_id": "28120",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "bazel: add PowerShell to Wine test harness",
+      "url": "https://github.com/openai/codex/pull/28120"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 4,
+      "commit_shas": [
+        "377700dd9f2079789f278fdd824ef5edbe81aa3d",
+        "cbe210fec0099907deb586bfab9e096ecaed6d79",
+        "0a168379203140f3cc71317b2a42fb94f8819d51",
+        "feea9f34655b52ab0fe2b6557d906f5f787ddc36",
+        "92dba3d12fc96c20cdb49258954fbe7103e1dd4c",
+        "aa5c37c849ae0dc51572f8d1c0cf6fc3e6ffd720",
+        "73620dc8a5e1dca2a92db78a8e6816a336ef9af7",
+        "2fec80ce01253a6e7414045b2e14bb2018608450",
+        "750ea1b4a976f5e1aaf24646c45371ae608c4519",
+        "c210314e68dcd6be2ca724d7883935dabc12e4fa",
+        "26b531ceb5f1c1351269c25be9c2d522fda99ec0",
+        "12650ca3637c4e8dc15860264baed9645f1a45b7",
+        "2ac53324769ae038aacaec3febd69c968ced5d30",
+        "f2cbe718ae4d9180b4f38672eca2adaf60b4baac",
+        "b19077b4f994b0b789d0f9d1ba0c5c359b0cbc37"
+      ],
+      "committed_at": "2026-06-14T05:26:49Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27819,
+      "pr_url": "https://github.com/openai/codex/pull/27819",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/utils/path-uri/src/api_path_string.rs",
+        "codex-rs/utils/path-uri/src/api_path_string_tests.rs",
+        "codex-rs/utils/path-uri/src/lib.rs",
+        "codex-rs/utils/path-uri/src/tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27819",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "path-uri: render native paths across platforms",
+      "url": "https://github.com/openai/codex/pull/27819"
     }
   ]
 }

--- a/artifacts/github/reviews/openai-codex-pr-27504.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27504.review.json
@@ -1,0 +1,72 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27504",
+  "repo": "openai/codex",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27504",
+    "commit_shas": [
+      "07d66eccd904cd15cd754c43d3f74a72d63a1980",
+      "3e3379b56006b9e877f5db4ba65009b4ad41c49c"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "feat: add secret auth storage configuration",
+        "url": "https://github.com/openai/codex/pull/27504",
+        "meta": "Merged 2026-06-12T19:15:22Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Add secret auth storage config",
+        "url": "https://github.com/openai/codex/commit/07d66eccd904cd15cd754c43d3f74a72d63a1980"
+      },
+      {
+        "kind": "commit",
+        "title": "refactor",
+        "url": "https://github.com/openai/codex/commit/3e3379b56006b9e877f5db4ba65009b4ad41c49c"
+      }
+    ]
+  },
+  "reviewed_at": "2026-06-14T06:08:00Z",
+  "observed_change": "Codex adds a stable `secret_auth_storage` feature and `AuthKeyringBackendKind` config resolution so auth credential storage can select direct keyring or encrypted-local secrets backends, with Windows defaulting to secrets.",
+  "changed_surfaces": [
+    "stable `secret_auth_storage` feature flag",
+    "`AuthKeyringBackendKind` config type",
+    "full Config auth keyring backend resolution",
+    "bootstrap config auth keyring backend resolution",
+    "managed feature requirements for bootstrap auth resolution",
+    "generated config schema",
+    "feature and config tests"
+  ],
+  "user_visible_path": "Advanced users and managed configuration can set the stable `secret_auth_storage` feature; Windows defaults the auth keyring backend to encrypted-local secrets while other platforms default to direct OS keyring storage.",
+  "control_plane_relevance": "High. Decodex Control Plane and managed configuration flows that inspect or set Codex auth behavior need to preserve `secret_auth_storage`, account for Windows defaults, and apply managed feature requirements before auth bootstrap reads.",
+  "compatibility_risk": "Medium. This PR is a configuration base rather than the auth implementation, but config writers or auth inspectors that assume a single keyring backend may choose the wrong backend once the follow-up auth storage stack is consumed.",
+  "adoption_opportunity": "Track `secret_auth_storage` as the stack-level switch for Codex auth credential backend selection, and make Decodex auth/config tooling treat bootstrap auth backend resolution as managed-feature-aware.",
+  "community_value": "Medium as a watch item for Codex operators because it explains why Windows auth storage is moving toward encrypted local secrets, but standalone public publishing should defer until the implementation PRs are considered together.",
+  "deprecated_or_breaking_notes": "No user command or existing config key is removed. The PR adds `secret_auth_storage`, defaults it on for Windows only, and explicitly says the auth, secrets, MCP, CLI, TUI, and app-server implementation remains in follow-up PRs.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27504 says Windows Credential Manager limits generic credential blobs to 2,560 bytes and this PR adds the independently reviewable feature/config layer for encrypted local secrets.",
+    "`codex-rs/features/src/lib.rs` adds stable `Feature::SecretAuthStorage` with key `secret_auth_storage` and `default_enabled: cfg!(windows)`.",
+    "`codex-rs/config/src/types.rs` adds `AuthKeyringBackendKind::{Direct, Secrets}` and defaults it to `Secrets` on Windows and `Direct` elsewhere.",
+    "`codex-rs/core/src/config/auth_keyring.rs` maps full `Config` and bootstrap `ConfigTomlLoadResult` through managed feature resolution before returning the auth backend kind.",
+    "`codex-rs/core/config.schema.json` adds `secret_auth_storage` to the generated feature schema.",
+    "`codex-rs/core/src/config/auth_keyring_tests.rs` covers explicit true, explicit false, and managed feature requirement override cases for bootstrap auth backend resolution.",
+    "`codex-rs/features/src/tests.rs` verifies the feature key, stable stage, and Windows-only default.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27504.json` records 8 changed files for the merged PR."
+  ],
+  "caveats": "This is the base PR for the auth-storage stack. It does not by itself wire the CLI auth, secrets, MCP, TUI, or app-server implementation paths.",
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "Auth backend configuration affects Decodex managed config and future Control Plane auth compatibility."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "A deferred watch-note handoff can preserve the Windows auth-storage migration signal without overclaiming shipped implementation."
+    }
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27504.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27504.json
@@ -1,0 +1,55 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27504",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "watch_note",
+  "priority": "critical",
+  "audience": "Codex operators, Windows users, and Control Plane integrators",
+  "candidate_text": [
+    "Codex added a stable secret_auth_storage feature that selects encrypted local auth-secret storage on Windows and supports managed requirements, but PR #27504 is only the config layer; implementation lands in follow-ups. https://github.com/openai/codex/pull/27504"
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27504.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27504.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27504"
+    ]
+  },
+  "evidence_notes": [
+    "`secret_auth_storage` is a stable feature and defaults on for Windows.",
+    "`AuthKeyringBackendKind` selects direct keyring or encrypted-local secrets.",
+    "Bootstrap auth backend resolution applies managed feature requirements.",
+    "The upstream PR says implementation paths remain in follow-ups."
+  ],
+  "claims": [
+    {
+      "text": "Codex added a stable `secret_auth_storage` feature for auth backend selection.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27504.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The PR is a configuration layer and should not be framed as the full auth-storage implementation.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27504.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "defer",
+    "reason": "watch_note_only: the source-backed config signal is useful, but public explanation should wait for the auth-storage stack to be reviewed together.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27504:watch_note:defer"
+  },
+  "caveats": [
+    "This is not a publication request.",
+    "Do not claim CLI auth, MCP OAuth, TUI, or app-server secret storage behavior from this PR alone."
+  ],
+  "next_steps": [
+    "Do not hand this defer candidate directly to Publisher for posting.",
+    "Use it as stack context after follow-up auth-storage PRs receive source-backed reviews."
+  ]
+}


### PR DESCRIPTION
## Summary

- refreshed the deterministic upstream Radar queue for openai/codex
- added a GitHub change bundle for openai/codex PR #27504
- added source-backed upstream_review/v1, upstream_impact/v1, and deferred social_candidate/v1 artifacts for PR #27504

## Validation

- `cargo run -p decodex --bin decodex -- radar validate artifacts/github/review-queue artifacts/github/bundles artifacts/github/reviews artifacts/github/impact artifacts/github/social-candidates`
- `cargo make fmt`
- `cargo make lint-fix`
- `cargo make test`

## Notes

- Social handoff is `decision.worthiness = "defer"`; this source review treats PR #27504 as the config layer for the auth-storage stack, not as a standalone publication-ready implementation claim.
- Diff is limited to `artifacts/github/review-queue/`, `artifacts/github/bundles/`, `artifacts/github/reviews/`, `artifacts/github/impact/`, and `artifacts/github/social-candidates/`.
