### PR TITLE
Persist Codex alpha.19 checkpoint handoff

### DIFF
--- a/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-19-needs-upstream-analysis.json
+++ b/artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-19-needs-upstream-analysis.json
@@ -1,0 +1,88 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-rust-v0-140-0-alpha-19-needs-upstream-analysis",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "watch_note",
+  "priority": "normal",
+  "audience": "Codex operators tracking prerelease changes before stable",
+  "candidate_text": [
+    "0.140.0-alpha.19: defer, no X handoff.\n\nAdjacent alpha.18 -> alpha.19 has 4 commits. Decodex has source-backed #28032 cwd PathUri compatibility evidence, but #28001 and #27607 still need upstream review before a release-level post."
+  ],
+  "source_refs": {
+    "release_deltas": [
+      "site/src/content/release-deltas/openai-codex-latest.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-28032.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-28032.json"
+    ],
+    "urls": [
+      "https://developers.openai.com/codex/changelog",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.18",
+      "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.19",
+      "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.18...rust-v0.140.0-alpha.19",
+      "https://github.com/openai/codex/pull/28001",
+      "https://github.com/openai/codex/pull/28032",
+      "https://github.com/openai/codex/pull/27607"
+    ]
+  },
+  "evidence_notes": [
+    "GitHub release metadata shows rust-v0.140.0-alpha.19 was published at 2026-06-14T02:03:02Z with only a sparse release body: Release 0.140.0-alpha.19.",
+    "The correct public prerelease comparison for this checkpoint is rust-v0.140.0-alpha.18 -> rust-v0.140.0-alpha.19; alpha.19 is not the first prerelease after stable rust-v0.139.0.",
+    "GitHub compare metadata for alpha.18 -> alpha.19 reports status=diverged, 4 ahead commits, and 4 total commits.",
+    "PR-title metadata in the alpha.18 -> alpha.19 compare points to Windows ARM64 packaging on x64 runners, exec-server cwd as PathUri, and plugin MCP deduping by app declaration name.",
+    "Checked Decodex review and impact artifacts already exist for #28032 and classify exec-server cwd PathUri as a Control Plane compatibility risk.",
+    "Checked Decodex review/impact artifacts are absent for #28001 and #27607 in this checkout, so release-level behavior claims for those PRs require upstream source review.",
+    "The refreshed release_delta/v1 records stable rust-v0.139.0 -> latest prerelease rust-v0.140.0-alpha.19 with 197 ahead commits and no tracked signal slugs.",
+    "Official Codex changelog readback for this run shows a 2026-06-11 Codex app update as the newest official app entry, plus 2026-06-09 entries for ChatGPT for iOS 1.2026.153 and Codex CLI 0.139.0; rust-v0.140.0-alpha.19 is a GitHub prerelease checkpoint, not an official changelog entry."
+  ],
+  "claims": [
+    {
+      "text": "rust-v0.140.0-alpha.19 is a real OpenAI Codex prerelease checkpoint.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.19",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The correct public prerelease comparison for this checkpoint is rust-v0.140.0-alpha.18 -> rust-v0.140.0-alpha.19.",
+      "evidence": "https://github.com/openai/codex/compare/rust-v0.140.0-alpha.18...rust-v0.140.0-alpha.19",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The alpha.19 release body is sparse and does not describe user-facing behavior beyond the version checkpoint.",
+      "evidence": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.19",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The alpha.19 window includes a source-backed exec-server cwd PathUri compatibility finding for #28032.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-28032.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Release-level behavior claims for #28001 and #27607 require upstream source review before a publishable Decodex prerelease thread.",
+      "evidence": "artifacts/github/reviews/",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "defer",
+    "reason": "needs_upstream_analysis: alpha.19 has one source-backed operator-impact PR (#28032), but the adjacent alpha.18 -> alpha.19 window still has unreviewed PR-title gaps #28001 and #27607.",
+    "idempotency_key": "x:decodexspace:openai-codex-rust-v0-140-0-alpha-19:alpha18-alpha19:defer"
+  },
+  "caveats": [
+    "This is a terminal defer / needs_upstream_analysis checkpoint record, not a publication request.",
+    "No previous live and quote-eligible @decodexspace 0.140 prerelease post exists; earlier 0.140 prereleases in this checkout are recorded as defer / needs_upstream_analysis checkpoints.",
+    "Do not compare alpha.19 against stable 0.139.0 for public prerelease copy; the adjacent prerelease lineage is alpha.18 -> alpha.19 because alpha.19 is not the first prerelease after stable.",
+    "Exact source-review gap list for alpha.18 -> alpha.19 primary compare PRs: #28001 and #27607. PR #28032 already has checked Decodex review, impact, and social-candidate artifacts.",
+    "Media caveat: no generated image is attached by this downstream artifact-consumer run. If this checkpoint later becomes publishable, decodex-x-publisher should generate and verify candidate-specific media only when it adds reader value."
+  ],
+  "next_steps": [
+    "Do not hand this alpha.19 defer record to decodex-x-publisher.",
+    "Route #28001 and #27607 to codex-upstream-radar-review / codex-code-analysis before turning alpha.19 into a release_rollup, watch_note, delta_explainer, or operator_impact post.",
+    "Use the existing openai-codex-pr-28032 social candidate separately if Publisher wants to evaluate the source-backed exec-server cwd operator-impact angle.",
+    "Use adjacent prerelease-to-prerelease lineage for future 0.140 prereleases after alpha.19."
+  ]
+}

--- a/site/src/content/release-deltas/openai-codex-latest.json
+++ b/site/src/content/release-deltas/openai-codex-latest.json
@@ -1,6 +1,6 @@
 {
   "compare": {
-    "ahead_by": 194,
+    "ahead_by": 197,
     "commit_shas": [
       "dffc4bf75dc9eeb0727f668c95bb7bd72315581d",
       "14660c22d14312c28a50c52954dd77dd88f03c26",
@@ -195,7 +195,10 @@
       "9d938a46d9119c3aaa4aac056950951027adec34",
       "640d61b121e886682a03374fdf668e8b9b97ecf2",
       "f297b9f07de10c7d8b9ed284b674d06cc5ff7723",
-      "dfd4b2b65869e9dffae24dfeb233a1586ca39d3b"
+      "17586d80ee6e3096f205cb36cc2968ba1a9adc8d",
+      "0fed4497f50ad5f0b2f7972a1bfd14c5a09a85c5",
+      "51316ead4a434e97928d1331e446d4bf274d44a5",
+      "0b146b13919944cdd31c68f196282f7d84c3316d"
     ],
     "pr_numbers": [
       22685,
@@ -335,6 +338,7 @@
       27573,
       27585,
       27591,
+      27607,
       27619,
       27623,
       27634,
@@ -390,16 +394,18 @@
       27976,
       27988,
       27996,
-      28002
+      28001,
+      28002,
+      28032
     ],
     "status": "diverged",
-    "total_commits": 194,
-    "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.18"
+    "total_commits": 197,
+    "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.19"
   },
   "comparisons": [
     {
       "compare": {
-        "ahead_by": 194,
+        "ahead_by": 197,
         "commit_shas": [
           "dffc4bf75dc9eeb0727f668c95bb7bd72315581d",
           "14660c22d14312c28a50c52954dd77dd88f03c26",
@@ -594,7 +600,10 @@
           "9d938a46d9119c3aaa4aac056950951027adec34",
           "640d61b121e886682a03374fdf668e8b9b97ecf2",
           "f297b9f07de10c7d8b9ed284b674d06cc5ff7723",
-          "dfd4b2b65869e9dffae24dfeb233a1586ca39d3b"
+          "17586d80ee6e3096f205cb36cc2968ba1a9adc8d",
+          "0fed4497f50ad5f0b2f7972a1bfd14c5a09a85c5",
+          "51316ead4a434e97928d1331e446d4bf274d44a5",
+          "0b146b13919944cdd31c68f196282f7d84c3316d"
         ],
         "pr_numbers": [
           22685,
@@ -734,6 +743,7 @@
           27573,
           27585,
           27591,
+          27607,
           27619,
           27623,
           27634,
@@ -789,13 +799,15 @@
           27976,
           27988,
           27996,
-          28002
+          28001,
+          28002,
+          28032
         ],
         "status": "diverged",
-        "total_commits": 194,
-        "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.18"
+        "total_commits": 197,
+        "url": "https://github.com/openai/codex/compare/rust-v0.139.0...rust-v0.140.0-alpha.19"
       },
-      "prerelease_tag_name": "rust-v0.140.0-alpha.18",
+      "prerelease_tag_name": "rust-v0.140.0-alpha.19",
       "stable_tag_name": "rust-v0.139.0",
       "tracked_signal_slugs": []
     },
@@ -10604,22 +10616,22 @@
       ]
     }
   ],
-  "generated_at": "2026-06-13T18:27:32.113601Z",
+  "generated_at": "2026-06-14T06:27:54.436377Z",
   "prerelease": {
-    "name": "0.140.0-alpha.18",
+    "name": "0.140.0-alpha.19",
     "prerelease": true,
-    "published_at": "2026-06-13T17:30:26Z",
-    "tag_name": "rust-v0.140.0-alpha.18",
-    "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.18"
+    "published_at": "2026-06-14T02:03:02Z",
+    "tag_name": "rust-v0.140.0-alpha.19",
+    "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.19"
   },
   "release_options": {
     "preview": [
       {
-        "name": "0.140.0-alpha.18",
+        "name": "0.140.0-alpha.19",
         "prerelease": true,
-        "published_at": "2026-06-13T17:30:26Z",
-        "tag_name": "rust-v0.140.0-alpha.18",
-        "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.18"
+        "published_at": "2026-06-14T02:03:02Z",
+        "tag_name": "rust-v0.140.0-alpha.19",
+        "url": "https://github.com/openai/codex/releases/tag/rust-v0.140.0-alpha.19"
       },
       {
         "name": "0.139.0-alpha.3",


### PR DESCRIPTION
## Summary

- refresh `release_delta/v1` to latest OpenAI Codex prerelease `rust-v0.140.0-alpha.19`
- add `social_candidate/v1` checkpoint record for alpha.19 as `watch_note` / `decision.worthiness = defer`
- preserve adjacent prerelease lineage `alpha.18 -> alpha.19`, with upstream-analysis gaps for #28001 and #27607 and existing source-backed #28032 evidence

## Validation

- `cargo run -p decodex --bin decodex -- radar validate site/src/content/release-deltas/openai-codex-latest.json artifacts/github/social-candidates/openai-codex-rust-v0-140-0-alpha-19-needs-upstream-analysis.json`
- `git diff --check`
- `cargo make fmt`
- `cargo make lint-fix`
- `cargo make test` (`1156 passed, 1 skipped`)

## Notes

No X publication is requested. This is a durable release checkpoint defer / needs-upstream-analysis handoff for downstream Radar review.
