### PR TITLE
Update Decodex plugin manifest direct-dispatch copy

### DIFF
--- a/apps/decodex/src/plugin_surface_tests.rs
+++ b/apps/decodex/src/plugin_surface_tests.rs
@@ -46,8 +46,8 @@ fn packaged_plugin_manifest_routes_natural_language_research_to_decodex() {
 	assert_contains(long_description, "latent Decision Contracts");
 	assert_contains(long_description, "\"arrange this\"");
 	assert_contains(long_description, "\"推进\"");
-	assert_contains(long_description, "queues only ready nodes");
-	assert_contains(long_description, "graph, DAG, goal, and queue mechanics backstage");
+	assert_contains(long_description, "ready mapped nodes dispatch directly");
+	assert_contains(long_description, "graph, DAG, goal, and dispatch mechanics backstage");
 	assert_contains(&default_prompts, "Research how Decodex should handle this.");
 	assert_contains(
 		&default_prompts,

--- a/plugins/decodex/.codex-plugin/plugin.json
+++ b/plugins/decodex/.codex-plugin/plugin.json
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Decodex",
     "shortDescription": "Use Decodex for research/design intake, planning, manual CLI work, or retained-lane automation.",
-    "longDescription": "Routes Codex agents through Decodex natural-language-first research/design intake, such as \"research X\", which produces latent Decision Contracts before execution. Follow-ups such as \"arrange this\" or \"推进\" can promote accepted work into planning that queues only ready nodes, while graph, DAG, goal, and queue mechanics backstage remain hidden from ordinary users.",
+    "longDescription": "Routes Codex agents through Decodex natural-language-first research/design intake, such as \"research X\", which produces latent Decision Contracts before execution. Follow-ups such as \"arrange this\" or \"推进\" can promote accepted work into planning and Program Intake where ready mapped nodes dispatch directly, while graph, DAG, goal, and dispatch mechanics backstage remain hidden from ordinary users.",
     "developerName": "hack-ink",
     "category": "Development",
     "capabilities": [


### PR DESCRIPTION
## Summary
- update the Decodex plugin manifest copy to describe Program Intake direct dispatch
- align packaged plugin surface assertions with the new direct-dispatch wording

## Verification
- cargo test -p decodex --lib plugin_surface_tests -- --nocapture
- cargo make check