### PR TITLE
Unify Decodex research method

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,10 @@ dispatches ready DAG nodes with `program` dispatch mode.
 
 `decodex research compile` is the native Decodex research/design entrypoint. It
 accepts minimal natural-language intake or a structured research/design JSON packet,
-then persists a `decodex.decision_contract/1` payload in local runtime SQLite. Compile
-outcomes distinguish `decision_ready`, `not_decision_ready`, `blocked`, and
+then persists a `decodex.decision_contract/1` payload in local runtime SQLite. The
+Decodex research method frames the question first, records evidence, compares
+realistic options, forms a challenge-ready judgment, resolves skeptic objections, and
+then ends as `decision_ready`, `not_decision_ready`, `blocked`, or
 `needs_human_decision`. A compiled contract is latent and cannot queue work, mutate
 tracker state, set goals, or authorize implementation. `decodex research promote`
 records explicit acceptance for a stored contract; only promoted contracts may later
@@ -382,8 +384,8 @@ The tracked workspace currently keeps:
   and content workflow lane
 - `docs/reference/` as the current repository and artifact surface map lane
 - `docs/decisions/` as the durable design-rationale lane
-- `docs/research/` as machine-authored research artifacts used by shipped research
-  tooling
+- `docs/research/` as legacy or supporting machine-authored research artifacts; current
+  Decodex research authority flows through runtime-local Decision Contracts
 - `dev/` as local development helpers outside `dev/skills/`, such as the operator
   dashboard mock server
 - `assets/` as generated Decodex App icon source notes, Icon Composer foreground,

--- a/apps/decodex/src/plugin_surface_tests.rs
+++ b/apps/decodex/src/plugin_surface_tests.rs
@@ -20,6 +20,38 @@ const LABELS_SKILL: &str = include_str!(concat!(
 	env!("CARGO_MANIFEST_DIR"),
 	"/../../plugins/decodex/skills/labels/SKILL.md"
 ));
+const RESEARCH_SKILL: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/research/SKILL.md"
+));
+const RESEARCH_PROBE_SKILL: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/research-probe/SKILL.md"
+));
+const RESEARCH_EVIDENCE_SKILL: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/research-evidence/SKILL.md"
+));
+const RESEARCH_OPTIONS_SKILL: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/research-options/SKILL.md"
+));
+const RESEARCH_JUDGMENT_SKILL: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/research-judgment/SKILL.md"
+));
+const RESEARCH_CHALLENGE_SKILL: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/research-challenge/SKILL.md"
+));
+const RESEARCH_DECISION_SKILL: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/research-decision/SKILL.md"
+));
+const RESEARCH_PROMOTE_SKILL: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/research-promote/SKILL.md"
+));
 
 #[test]
 fn packaged_plugin_manifest_routes_natural_language_research_to_decodex() {
@@ -42,6 +74,11 @@ fn packaged_plugin_manifest_routes_natural_language_research_to_decodex() {
 		.join("\n");
 
 	assert_contains(long_description, "natural-language-first");
+	assert_contains(long_description, "bounded research");
+	assert_contains(
+		long_description,
+		"probe, evidence, options, judgment, challenge, and decision gates",
+	);
 	assert_contains(long_description, "\"research X\"");
 	assert_contains(long_description, "latent Decision Contracts");
 	assert_contains(long_description, "\"arrange this\"");
@@ -59,10 +96,13 @@ fn packaged_plugin_manifest_routes_natural_language_research_to_decodex() {
 fn packaged_skills_preserve_research_promotion_and_queue_boundaries() {
 	assert_contains(DECODEX_SKILL, "## Natural-Language Research Routing");
 	assert_contains(DECODEX_SKILL, "`research X`");
+	assert_contains(DECODEX_SKILL, "`research-probe`");
+	assert_contains(DECODEX_SKILL, "`research-promote`");
+	assert_contains(DECODEX_SKILL, "legacy external `$research`");
 	assert_contains(DECODEX_SKILL, "latent Decision Contract");
 	assert_contains(DECODEX_SKILL, "`arrange this`");
 	assert_contains(DECODEX_SKILL, "`推进`");
-	assert_contains(DECODEX_SKILL, "Do not queue work");
+	assert_contains_normalized(DECODEX_SKILL, "Do not queue work");
 	assert_contains(DECODEX_SKILL, "dispatches ready mapped nodes directly");
 	assert_contains(PLANNING_SKILL, "accepted Decision Contract");
 	assert_contains(PLANNING_SKILL, "Do not use planning to turn a plain `research X`");
@@ -79,6 +119,45 @@ fn packaged_skills_preserve_research_promotion_and_queue_boundaries() {
 	assert_contains_normalized(LABELS_SKILL, "not the user-facing research/design workflow");
 	assert_contains(LABELS_SKILL, "accepted/promoted Decision");
 	assert_contains(LABELS_SKILL, "Do not ask ordinary users to apply queue labels");
+}
+
+#[test]
+fn packaged_research_skills_encode_decodex_methodology() {
+	assert_contains(RESEARCH_SKILL, "default research surface");
+	assert_contains(RESEARCH_SKILL, "probe, evidence, options, judgment, challenge, decision");
+	assert_contains_normalized(RESEARCH_SKILL, "No evidence, no claim");
+	assert_contains(RESEARCH_SKILL, "runtime state");
+	assert_contains(
+		RESEARCH_SKILL,
+		"Do not route Decodex research through the legacy external `$research`",
+	);
+	assert_contains(RESEARCH_PROBE_SKILL, "primary hypothesis");
+	assert_contains(RESEARCH_PROBE_SKILL, "rival hypotheses");
+	assert_contains(RESEARCH_PROBE_SKILL, "falsifiers");
+	assert_contains(RESEARCH_PROBE_SKILL, "`probe_completed`");
+	assert_contains(RESEARCH_EVIDENCE_SKILL, "No evidence, no claim");
+	assert_contains(
+		RESEARCH_EVIDENCE_SKILL,
+		"Separate observation, contradiction, inference, and missing evidence",
+	);
+	assert_contains(RESEARCH_EVIDENCE_SKILL, "`research_evidence`");
+	assert_contains(RESEARCH_OPTIONS_SKILL, "status quo");
+	assert_contains(RESEARCH_OPTIONS_SKILL, "evidence-grounded");
+	assert_contains(RESEARCH_OPTIONS_SKILL, "`research_options`");
+	assert_contains(RESEARCH_JUDGMENT_SKILL, "challenge-ready");
+	assert_contains(RESEARCH_JUDGMENT_SKILL, "stable judgment id or hash");
+	assert_contains(RESEARCH_JUDGMENT_SKILL, "not-decision-ready");
+	assert_contains(
+		RESEARCH_CHALLENGE_SKILL,
+		"Do not finalize `decision_ready` while material objections remain unresolved",
+	);
+	assert_contains(RESEARCH_CHALLENGE_SKILL, "skeptic worker");
+	assert_contains(RESEARCH_DECISION_SKILL, "Use exactly one terminal outcome");
+	assert_contains(RESEARCH_DECISION_SKILL, "No unresolved decisions, evidence gaps, or blockers");
+	assert_contains(RESEARCH_DECISION_SKILL, "Promotion is a separate authority step");
+	assert_contains(RESEARCH_PROMOTE_SKILL, "research-to-planning authority boundary");
+	assert_contains(RESEARCH_PROMOTE_SKILL, "Do not infer acceptance");
+	assert_contains(RESEARCH_PROMOTE_SKILL, "Program Intake");
 }
 
 fn assert_contains(haystack: &str, needle: &str) {

--- a/apps/decodex/src/research_design.rs
+++ b/apps/decodex/src/research_design.rs
@@ -484,6 +484,17 @@ impl NormalizedResearchDesignInput {
 		if self.evidence.is_empty() {
 			eyre::bail!("decision-ready research requires at least one evidence claim.");
 		}
+		if self.options.is_empty() {
+			eyre::bail!("decision-ready research requires at least one option comparison.");
+		}
+		if self.objections.is_empty() {
+			eyre::bail!(
+				"decision-ready research requires at least one recorded challenge objection or objection note."
+			);
+		}
+		if self.validation_expectations.is_empty() {
+			eyre::bail!("decision-ready research requires validation expectations.");
+		}
 		if self.proposed_issue_summaries.is_empty() {
 			eyre::bail!(
 				"decision-ready research requires at least one proposed issue summary for downstream shaping."
@@ -1010,6 +1021,45 @@ mod tests {
 			Some(String::from("User asked to push this forward.")),
 		)
 		.expect("sample promotion should validate")
+	}
+
+	#[test]
+	fn decision_ready_research_requires_method_gates() {
+		let mut missing_options = decision_ready_input();
+
+		missing_options.options.clear();
+
+		let missing_options_error =
+			match research_design::compile_research_design_run(missing_options, "decodex") {
+				Ok(_) => panic!("decision-ready research should require option comparison"),
+				Err(error) => error,
+			};
+
+		assert!(missing_options_error.to_string().contains("at least one option comparison"));
+
+		let mut missing_challenge = decision_ready_input();
+
+		missing_challenge.objections.clear();
+
+		let missing_challenge_error =
+			match research_design::compile_research_design_run(missing_challenge, "decodex") {
+				Ok(_) => panic!("decision-ready research should require a challenge note"),
+				Err(error) => error,
+			};
+
+		assert!(missing_challenge_error.to_string().contains("recorded challenge objection"));
+
+		let mut missing_validation = decision_ready_input();
+
+		missing_validation.validation_expectations.clear();
+
+		let missing_validation_error =
+			match research_design::compile_research_design_run(missing_validation, "decodex") {
+				Ok(_) => panic!("decision-ready research should require validation expectations"),
+				Err(error) => error,
+			};
+
+		assert!(missing_validation_error.to_string().contains("requires validation expectations"));
 	}
 
 	#[test]

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,8 +57,11 @@ The split below is by question type, not by human-versus-agent audience.
   `docs/runbook/radar-artifact-archive.md`
 - Need historical upstream commit trace, skipped-candidate state, or local Radar ledger
   behavior -> `docs/spec/radar-ledger.md`
-- Need the raw machine-authored research run artifacts used by shipped research tooling
-  -> `docs/research/`
+- Need older machine-authored research run artifacts or supporting evidence trails ->
+  `docs/research/`
+- Need new Decodex bounded research, design investigation, or research-to-execution
+  promotion -> `plugins/decodex/skills/research*/` and
+  `docs/spec/loop-runtime.md`
 - Need reusable agent-facing Decodex usage instructions -> `plugins/decodex/`
 - Need repo-local Radar skills for upstream Codex triage, code analysis, release
   analysis, GitHub signal drafting, or X publishing -> `dev/skills/` plus
@@ -90,5 +93,5 @@ The split below is by question type, not by human-versus-agent audience.
   when to read it, and what it does not cover.
 - Keep links explicit and stable.
 - Treat `docs/research/` as supporting evidence, not as a primary authority lane.
-- Treat research output as latent until accepted or promoted through the loop-runtime
-  contract in `docs/spec/loop-runtime.md`.
+- Treat Decodex research output as latent until accepted or promoted through the
+  loop-runtime contract in `docs/spec/loop-runtime.md`.

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -26,15 +26,15 @@ This repository standardizes on four primary documentation lanes:
 - `runbook` defines procedure, not truth, current state, or rationale.
 - `reference` defines current state, not truth, procedure, or rationale.
 - `decisions` defines rationale, not truth, procedure, or current state.
-- `research` is supporting evidence only. It does not own repository truth, procedure,
-  current state, or rationale.
+- `docs/research/` is supporting evidence only. It does not own repository truth,
+  procedure, current state, or rationale.
 - If a document starts answering a second question type, split it and link to the
   authoritative lane instead of stretching one document across lanes.
 
 ## Artifact lanes
 
-- `docs/research/` is allowed for machine-authored research run artifacts produced by the
-  shipped research tooling.
+- `docs/research/` is allowed for legacy or supporting machine-authored research run
+  artifacts.
 - `docs/research/` is not a primary documentation lane and is not authoritative for
   runtime behavior, repository policy, or operator procedures.
 - If a research result becomes durable repository guidance, promote it into `spec`,

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -94,12 +94,15 @@ decodex research promote <CONTRACT_ID>
 
 `research compile` writes a local Decision Contract candidate into runtime SQLite and
 returns a bounded outcome: `decision_ready`, `not_decision_ready`, `blocked`, or
-`needs_human_decision`. It may retain private evidence references, option comparisons,
-proposed issue summaries, conflict domains, and dispatch intent for later issue shaping,
-but it does not enqueue issues, mutate Linear state, set goals, or start lane
-execution. `research promote` records the accepted boundary for an existing contract;
-later issue generation or Execution Program readiness must consume the promoted
-contract instead of treating a research summary as authority.
+`needs_human_decision`. Decodex research first probes the decision, records evidence,
+compares options, forms a challenge-ready judgment, resolves or preserves skeptic
+objections, and only then chooses the outcome. It may retain private evidence
+references, option comparisons, proposed issue summaries, conflict domains, and
+dispatch intent for later issue shaping, but it does not enqueue issues, mutate Linear
+state, set goals, or start lane execution. `research promote` records the accepted
+boundary for an existing contract; later issue generation or Execution Program
+readiness must consume the promoted contract instead of treating a research summary as
+authority.
 
 Lane inspect and interrupt are local control APIs, not dashboard UI actions:
 

--- a/docs/reference/research-runs.md
+++ b/docs/reference/research-runs.md
@@ -15,15 +15,16 @@ results.
 
 ## Status of `docs/research/`
 
-- `docs/research/` is the persistence root for the shipped research tooling.
+- `docs/research/` is the legacy persistence root for the earlier external research
+  tooling and remains a supporting evidence lane.
 - Files in `docs/research/` are machine-authored run artifacts, not primary
   documentation lanes.
 - A research run may contain useful evidence, alternatives, and objections, but it does
   not by itself define repository truth.
-- For Decodex-specific loop-runtime work, `decodex research compile` supersedes this
-  artifact lane as the runtime-owned path. It stores a
-  `decodex.decision_contract/1` payload in local runtime SQLite and leaves the result
-  latent until explicit promotion.
+- For Decodex-specific loop-runtime work, the Decodex `research*` skills plus
+  `decodex research compile` supersede this artifact lane as the runtime-owned path.
+  They store a `decodex.decision_contract/1` payload in local runtime SQLite and leave
+  the result latent until explicit promotion.
 
 ## Promotion rules
 
@@ -41,6 +42,8 @@ results.
 
 ## Practical reading rule
 
-- Read `docs/research/` when you need the original evidence trail.
+- Read `docs/research/` when you need an older evidence trail.
 - Read one of the four primary documentation lanes when you need current repository
   guidance.
+- Use Decodex `research*` skills and Decision Contracts for new bounded Decodex
+  research.

--- a/docs/reference/test-suite.md
+++ b/docs/reference/test-suite.md
@@ -53,7 +53,7 @@ cargo nextest list --workspace --all-targets --all-features 2>/dev/null \
 | Git, worktree, landing, and recovery helpers | 120 | `worktree::tests`, `manual::tests`, `commit_message::tests`, `github::tests`, `default_branch_sync::tests`, `pull_request::tests`, `recovery::tests`, `git_credentials::tests` | Git/worktree behavior, manual landing, GitHub/PR helpers, recovery commands, commit-message policy |
 | Radar content validation | 33 | `radar::tests` | Upstream Radar schemas, bundles, signal rendering, social publication ledgers |
 | Account, CLI, archive, and tracker integration | 84 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter and public-text behavior |
-| Loop contract and research surfaces | 21 | `loop_contract::tests`, `execution_program::tests`, `research_design::tests`, `plugin_surface_tests` | Decision Contract schema, Execution Program readiness, research compile/promote, and plugin trigger behavior |
+| Loop contract and research surfaces | 25 | `loop_contract::tests`, `execution_program::tests`, `research_design::tests`, `plugin_surface_tests` | Decision Contract schema, Execution Program readiness, research compile/promote, and plugin trigger behavior |
 
 ## Orchestrator Inventory
 

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -30,7 +30,7 @@ should not be treated as repository source.
 | `docs/runbook/` | Operator procedures, validation sequences, deployment steps, and content workflows. |
 | `docs/reference/` | Current repository and artifact surface maps. |
 | `docs/decisions/` | Durable rationale for repository-level design choices. |
-| `docs/research/` | Machine-authored research run artifacts used by shipped research tooling. |
+| `docs/research/` | Legacy or supporting machine-authored research run artifacts; current Decodex research authority is runtime-local Decision Contracts. |
 | `dev/` | Local development helpers outside `dev/skills/`, such as the operator dashboard mock server. |
 | `assets/` | Shared static assets that are not owned by the Astro app's generated output. Decodex App icons live under `assets/app-icon/{source,composer,generated}/`; menu bar template assets live under `assets/tray-icon/{source,generated}/`; `scripts/assets/render_decodex_app_icons.swift` regenerates the icon set. |
 | `.github/` | CI, release, Pages deployment, and content-refresh workflows. |

--- a/docs/spec/loop-runtime.md
+++ b/docs/spec/loop-runtime.md
@@ -3,16 +3,16 @@
 Purpose: Define the natural-language-first Decodex loop-runtime contract that sits
 above individual issue lanes.
 Status: normative
-Read this when: You are implementing or reviewing Decodex-native research,
-decision promotion, internal execution planning, phase-scoped Codex goals, unattended
-loop behavior, or loop guardrails.
+Read this when: You are implementing or reviewing Decodex-native research method
+gates, decision promotion, internal execution planning, phase-scoped Codex goals,
+unattended loop behavior, or loop guardrails.
 Not this document: The issue-lane state machine, low-level `app-server` protocol,
 post-`In Review` phases, operator lane-control commands, or the concrete research
-method.
+run artifact format.
 Defines: The user surface, Research/Decision stage, latent Loop/Decision Contract,
-internal Execution Program, promotion boundary, phase-scoped goal rules, validation
-and review boundary, unattended execution behavior, loop stop conditions, and harness
-improvement loop.
+research method gates, internal Execution Program, promotion boundary, phase-scoped
+goal rules, validation and review boundary, unattended execution behavior, loop stop
+conditions, and harness improvement loop.
 
 ## Scope
 
@@ -57,9 +57,26 @@ through the lane runtime contract.
 Decodex owns a native Research/Decision compiler for Decodex work. That stage accepts
 natural-language intent such as `research X` plus bounded research/design evidence
 when available, then stores a local Decision Contract candidate. It supersedes the
-external research skill for Decodex runtime authority: the old external
-`docs/research/` artifact lane remains supporting evidence and inspiration for method,
-but it is not the authority surface for Decodex loop state.
+external research skill for Decodex runtime authority: Decodex plugin `research*`
+skills are the current agent-facing method, and the old external `docs/research/`
+artifact lane remains legacy or supporting evidence that can be imported into a
+Decision Contract. It is not the authority surface for Decodex loop state.
+
+The native research method has these ordered gates:
+
+1. Probe frames the decision question, scope, success criteria, constraints, stop rule,
+   primary hypothesis, rival hypotheses, and falsifiers before broad evidence
+   collection.
+2. Evidence records an auditable ledger of observations, source references,
+   contradictions, inferences, and missing evidence. No evidence, no claim.
+3. Options compare realistic choices, including status quo or explicit no-go when
+   relevant, with evidence-grounded tradeoffs.
+4. Judgment creates a challenge-ready recommendation or explicitly states that the run
+   is not decision-ready.
+5. Challenge attacks the judgment with skeptic objections. Material unresolved
+   objections become missing decisions, evidence gaps, risk notes, or blockers.
+6. Decision ends the run with exactly one outcome and preserves the latent promotion
+   boundary.
 
 A Research/Decision stage may produce a latent Loop/Decision Contract with:
 
@@ -81,7 +98,7 @@ Native research/design compiler outcomes are:
 
 | Outcome | Contract status | Meaning |
 | --- | --- | --- |
-| `decision_ready` | `draft_latent` | Bounded evidence, option comparison, assumptions, objections, and proposed issue-readiness data are sufficient for downstream issue shaping after promotion. It is still not execution authority while latent. |
+| `decision_ready` | `draft_latent` | Bounded evidence, option comparison, challenge/objection records, validation expectations, assumptions, and proposed issue-readiness data are sufficient for downstream issue shaping after promotion. It is still not execution authority while latent. |
 | `not_decision_ready` | `draft_latent` | The run preserved useful evidence or objections, but missing evidence or unresolved direction means it must not become implementation work. |
 | `blocked` | `draft_latent` | The run cannot finish its bounded research/design pass because a non-decision blocker must be resolved first. |
 | `needs_human_decision` | `needs_human_decision` | The package needs explicit human direction before promotion or execution can be considered. |

--- a/docs/spec/review-orchestration.md
+++ b/docs/spec/review-orchestration.md
@@ -70,7 +70,7 @@ After any review arrives:
   the explicit independent reviewer source, checklist notes, accepted findings,
   rejected findings, non-empty evidence, and repair guidance
 
-The current repository's bounded review method is defined in the registered project `WORKFLOW.md`. This spec does not replace that method; it defines how review requests and review outcomes are orchestrated around it.
+The current repository's bounded review method is defined in the registered project `WORKFLOW.md`. This spec does not replace that method; it defines how review requests and review outcomes are orchestrated around it. When review reveals missing direction rather than a repairable finding, route the gap through Decodex-native research and Decision Contract update, not the legacy external research artifact lane.
 
 ## Review round accounting
 

--- a/plugins/decodex/.codex-plugin/plugin.json
+++ b/plugins/decodex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "decodex",
   "version": "0.2.0",
-  "description": "Agent-facing workflows for Decodex research/design intake, planning, manual CLI use, and runtime-owned automation.",
+  "description": "Agent-facing workflows for Decodex bounded research, Decision Contract promotion, planning, manual CLI use, and runtime-owned automation.",
   "author": {
     "name": "hack-ink",
     "email": "hi@hack.ink",
@@ -20,8 +20,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Decodex",
-    "shortDescription": "Use Decodex for research/design intake, planning, manual CLI work, or retained-lane automation.",
-    "longDescription": "Routes Codex agents through Decodex natural-language-first research/design intake, such as \"research X\", which produces latent Decision Contracts before execution. Follow-ups such as \"arrange this\" or \"推进\" can promote accepted work into planning and Program Intake where ready mapped nodes dispatch directly, while graph, DAG, goal, and dispatch mechanics backstage remain hidden from ordinary users.",
+    "shortDescription": "Use Decodex for bounded research, Decision Contract promotion, planning, manual CLI work, or retained-lane automation.",
+    "longDescription": "Routes Codex agents through Decodex natural-language-first bounded research, such as \"research X\", with probe, evidence, options, judgment, challenge, and decision gates that produce latent Decision Contracts before execution. Follow-ups such as \"arrange this\" or \"推进\" can promote accepted work into planning and Program Intake where ready mapped nodes dispatch directly, while graph, DAG, goal, and dispatch mechanics backstage remain hidden from ordinary users.",
     "developerName": "hack-ink",
     "category": "Development",
     "capabilities": [

--- a/plugins/decodex/skills/decodex/SKILL.md
+++ b/plugins/decodex/skills/decodex/SKILL.md
@@ -11,8 +11,9 @@ Route agent work through the right Decodex surface without duplicating the runti
 specs. Decodex has these supported use modes:
 
 - Research/design mode: natural-language requests such as `research X` enter the
-  Decodex-native Research/Decision path. The result is a latent Decision Contract,
-  not execution authority.
+  Decodex-native bounded research method. Probe, evidence, options, judgment,
+  challenge, and final decision all feed a latent Decision Contract, not execution
+  authority.
 - Manual CLI mode: a human is driving local development, commits, PR preparation,
   landing, status inspection, project registration, account selection, or dry-run
   checks.
@@ -33,16 +34,17 @@ commands.
 Route by intent:
 
 1. If the user says `research X`, asks for a design investigation, or asks Decodex to
-   figure out what should be done before implementation, treat it as research/design
-   intake. Produce or update a latent Decision Contract with evidence, assumptions,
-   options, objections, non-goals, acceptance criteria, stop conditions, readiness,
-   and open decisions. Do not queue work, create execution authority, mutate tracker
-   state, or start implementation from the research request alone.
+   figure out what should be done before implementation, use `research` plus its phase
+   skills: `research-probe`, `research-evidence`, `research-options`,
+   `research-judgment`, `research-challenge`, and `research-decision`. Produce or
+   update a latent Decision Contract with evidence, assumptions, options, objections,
+   non-goals, acceptance criteria, stop conditions, readiness, and open decisions. Do
+   not queue work, create execution authority, mutate tracker state, or start
+   implementation from the research request alone.
 2. If the user later says `arrange this`, `push this forward`, `推进`, `做`, or an
-   equivalent follow-up that clearly accepts or promotes the prior contract, treat that
-   as promotion to execution authority. Preserve the accepted contract boundary; if
-   direction is still missing or contradictory, ask for the missing decision instead
-   of starting work.
+   equivalent follow-up that clearly accepts or promotes the prior contract, use
+   `research-promote`. Preserve the accepted contract boundary; if direction is still
+   missing or contradictory, ask for the missing decision instead of starting work.
 3. After promotion, use `planning` to convert the accepted contract into normal
    Linear issues with clear natural-language briefs, dependencies, acceptance, and
    validation, then persist an Execution Program for direct scheduler dispatch. Keep
@@ -63,6 +65,14 @@ Route by intent:
    `WORKFLOW.md` under `~/.codex/decodex/projects/<service-id>/` or the project
    directory supplied through a project-scoped command's `--config`.
 5. Use the narrow skill for the current action:
+   - `research` for bounded Decodex research/design intake.
+   - `research-probe` for framing decisions, hypotheses, falsifiers, and stop rules.
+   - `research-evidence` for auditable evidence ledgers and missing-evidence tracking.
+   - `research-options` for evidence-grounded option comparison.
+   - `research-judgment` for challenge-ready recommendations.
+   - `research-challenge` for skeptic objections before finalization.
+   - `research-decision` for the terminal decision-ready/not-ready/blocked/human gate.
+   - `research-promote` for accepted research-to-execution authority.
    - `manual-cli` for normal operator CLI use.
    - `planning` for Decodex-friendly issue splitting, dispatch readiness, and concurrency.
    - `automation` for retained-lane control-plane use.
@@ -79,8 +89,10 @@ boundary without making the user learn the commands.
 
 - Runtime behavior belongs to `apps/decodex/src/` and `docs/spec/`.
 - Decodex-native research/design behavior belongs to `apps/decodex/src/research_design.rs`
-  and `docs/spec/loop-runtime.md`; external research artifacts are supporting
-  evidence only for Decodex runtime semantics.
+  and `docs/spec/loop-runtime.md`. The Decodex plugin's `research*` skills are the
+  default agent-facing method for bounded research. The legacy external `$research`
+  skill and `docs/research/` artifacts are supporting evidence or import material only
+  for Decodex runtime semantics.
 - Harness-improvement recommendations from `decodex evidence` are advisory runtime
   feedback. Treat them as candidates for an explicit accepted improvement path; do not
   auto-edit prompts, skills, validators, issue templates, or loop policies solely

--- a/plugins/decodex/skills/research-challenge/SKILL.md
+++ b/plugins/decodex/skills/research-challenge/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: research-challenge
+description: Use before finalizing Decodex research to run skeptic objections against the current judgment. Unresolved objections block decision-ready status.
+---
+
+# Decodex Research Challenge
+
+## Goal
+
+Make the recommendation survive adversarial review before it can become
+decision-ready.
+
+## Challenge Pass
+
+Challenge the current judgment against:
+
+- missing evidence
+- contradictory evidence
+- unexamined alternatives
+- scope creep
+- hidden operational cost
+- compatibility or migration risk
+- security, privacy, data, billing, or destructive-action risk
+- authority mismatch with the user's request or accepted Decision Contract
+- validation gaps
+
+Record each objection as resolved, unresolved, or out of scope. Resolved objections
+should explain what evidence or constraint resolves them. Unresolved objections become
+`unresolved_decisions`, `evidence_gaps`, `risk_notes`, or `blockers`.
+
+## Worker Use
+
+Use a bounded skeptic worker only when it materially improves independence. The skeptic
+must not edit files, mutate tracker state, promote contracts, dispatch work, or recurse
+into further workers.
+
+## Boundaries
+
+- Do not finalize `decision_ready` while material objections remain unresolved.
+- Do not downgrade real blockers into cosmetic risk notes.
+- Do not let challenge create execution authority; it only decides whether the latent
+  contract can be safely promoted later.

--- a/plugins/decodex/skills/research-decision/SKILL.md
+++ b/plugins/decodex/skills/research-decision/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: research-decision
+description: Use to finalize a Decodex research run as decision_ready, not_decision_ready, blocked, or needs_human_decision and prepare the latent Decision Contract boundary.
+---
+
+# Decodex Research Decision
+
+## Goal
+
+End every bounded Decodex research run with one clear status. The result is a latent
+Decision Contract candidate unless and until promotion occurs.
+
+## Outcome Gate
+
+Use exactly one terminal outcome:
+
+- `decision_ready`: evidence, option comparison, resolved challenge, accepted
+  objectives, validation expectations, and proposed issue summaries are sufficient for
+  issue shaping after promotion. No unresolved decisions, evidence gaps, or blockers
+  remain.
+- `not_decision_ready`: useful evidence exists, but the decision would be unsafe or
+  under-supported. Preserve missing evidence and next research needed.
+- `blocked`: the research pass cannot proceed until a non-decision blocker is removed.
+- `needs_human_decision`: the remaining uncertainty is a human/product/authority choice
+  rather than a research gap.
+
+## Decision Contract Checklist
+
+Before `decision_ready`, verify:
+
+- the decision question and falsifiers were framed
+- every material claim has evidence
+- realistic options were compared
+- skeptic objections were addressed or classified
+- the chosen boundary preserves user intent and Decodex authority rules
+- validation expectations are concrete
+- proposed issue summaries are scoped and non-overlapping
+- the output is still latent and does not execute by itself
+
+## Boundaries
+
+- Do not produce multiple terminal statuses.
+- Do not choose `decision_ready` because the budget ended. Use
+  `not_decision_ready`, `blocked`, or `needs_human_decision` when the gate is not met.
+- Do not promote the contract in this skill. Promotion is a separate authority step.

--- a/plugins/decodex/skills/research-evidence/SKILL.md
+++ b/plugins/decodex/skills/research-evidence/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: research-evidence
+description: Use during Decodex research evidence collection. Builds an auditable ledger of observations, sources, contradictions, inferences, missing evidence, and source-family coverage.
+---
+
+# Decodex Research Evidence
+
+## Goal
+
+Make every research claim traceable. Evidence is retained as context for a latent
+Decision Contract, not as execution authority by itself.
+
+## Evidence Rules
+
+- No evidence, no claim.
+- Give evidence items stable ids when the run is more than a short chat answer.
+- Record source or code references close to the claim.
+- Separate observation, contradiction, inference, and missing evidence.
+- For external research, record source family or perspective when coverage breadth
+  matters.
+- Prefer primary sources for code, APIs, specifications, policies, and live project
+  state.
+- When evidence conflicts, preserve the contradiction and decide what would resolve it.
+
+## Decodex Mapping
+
+Map evidence into the Decision Contract as:
+
+- `research_provenance` for source families, inspected files, commands, run outputs, or
+  prior artifacts
+- `research_evidence` for supported claims
+- `evidence_gaps` for missing proof that blocks decision-ready status
+- `private_evidence_refs` when the proof is local, sensitive, or runtime-private
+- `public_projection_refs` only for sparse public-safe references
+
+## Boundaries
+
+- Do not use a research summary as authority to execute. It remains latent until
+  promotion.
+- Do not mirror private runtime payloads into public issue text.
+- Do not flatten contradictions into a single confident claim unless the resolution is
+  explicitly evidenced.

--- a/plugins/decodex/skills/research-judgment/SKILL.md
+++ b/plugins/decodex/skills/research-judgment/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: research-judgment
+description: Use after Decodex evidence and option comparison to form a challenge-ready recommendation or an explicit not-decision-ready conclusion.
+---
+
+# Decodex Research Judgment
+
+## Goal
+
+Turn evidence and options into a testable conclusion without skipping unresolved
+uncertainty.
+
+## Judgment Shape
+
+A challenge-ready judgment must include:
+
+- recommended option or explicit non-decision outcome
+- why this option best satisfies the decision criteria
+- evidence ids, source references, or code references that support it
+- important assumptions and constraints
+- rejected alternatives and why they lost
+- unresolved evidence gaps, if any
+- expected validation if promoted into execution
+
+For machine-authored runs that need replayability, assign a stable judgment id or hash
+over the normalized conclusion and cited evidence. The Decision Contract remains the
+Decodex authority boundary.
+
+## Boundaries
+
+- Do not call a judgment final before skeptic challenge.
+- Do not hide weak evidence behind confident language.
+- Do not mark the result `decision_ready` if the judgment depends on unresolved human
+  direction, unavailable evidence, or untested assumptions that materially affect the
+  chosen option.

--- a/plugins/decodex/skills/research-options/SKILL.md
+++ b/plugins/decodex/skills/research-options/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: research-options
+description: Use after Decodex research evidence collection to compare realistic implementation, architecture, or policy options with evidence-grounded tradeoffs before judgment.
+---
+
+# Decodex Research Options
+
+## Goal
+
+Force a real choice. A Decodex research answer is not decision-ready merely because one
+plan sounds plausible.
+
+## Option Comparison
+
+Include realistic options such as:
+
+- keep current behavior or status quo
+- minimal patch
+- architecture-level redesign
+- staged migration
+- explicit no-go or defer outcome
+
+For each option, record:
+
+- what changes
+- evidence supporting it
+- tradeoffs and risks
+- what it would make easier
+- what it would make harder
+- why it is selected or rejected
+
+## Decision Contract Mapping
+
+Use `research_options` for option records. A `decision_ready` result must have at least
+one realistic option comparison and should preserve rejected alternatives when they
+would otherwise be rediscovered later.
+
+## Boundaries
+
+- Do not compare straw-man options.
+- Do not select an option without tying the decision to evidence or explicit
+  assumptions.
+- Do not expand into executable issue briefs until the selected option survives
+  judgment and challenge.

--- a/plugins/decodex/skills/research-probe/SKILL.md
+++ b/plugins/decodex/skills/research-probe/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: research-probe
+description: Use at the start of a Decodex research run to frame the decision, scope, success criteria, hypotheses, falsifiers, constraints, and stop rule before broad evidence collection.
+---
+
+# Decodex Research Probe
+
+## Goal
+
+Prevent vague research from becoming vague execution. Start every Decodex research run
+by defining what decision is being made and what would prove the answer wrong.
+
+## Required Probe
+
+Record these before broad search or implementation:
+
+- decision question
+- in-scope and out-of-scope surfaces
+- success criteria and acceptance threshold
+- constraints and non-goals
+- stop rule or budget
+- primary hypothesis
+- realistic rival hypotheses
+- falsifiers for the primary hypothesis
+- initial evidence plan
+
+The first durable research event for a machine-authored run should be
+`probe_completed`. In normal chat, the same information can be a concise section in
+the research answer or Decision Contract candidate.
+
+## Boundaries
+
+- Do not gather broad evidence until the question, success criteria, and falsifiers
+  are clear enough to guide collection.
+- Do not skip rival hypotheses for architecture choices. A plan is not decision-ready
+  until serious alternatives have been named and compared.
+- Do not turn the probe into issue writing or execution planning. Proposed issues come
+  only after evidence, options, and challenge.

--- a/plugins/decodex/skills/research-promote/SKILL.md
+++ b/plugins/decodex/skills/research-promote/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: research-promote
+description: Use when a user explicitly accepts a Decodex research result or asks to arrange, push forward, implement, or turn it into executable work. Owns the research-to-planning authority boundary.
+---
+
+# Decodex Research Promote
+
+## Goal
+
+Convert an accepted latent Decision Contract into execution authority without changing
+what was researched or approved.
+
+Use this only after explicit acceptance or an equivalent follow-up such as `arrange
+this`, `push this forward`, `推进`, or `做`.
+
+## Promotion Rules
+
+1. Identify the latent Decision Contract or conversational contract being accepted.
+2. Confirm the accepted boundary: objectives, non-goals, constraints, assumptions,
+   objections, validation expectations, proposed issue summaries, and stop conditions.
+3. If unresolved decisions, evidence gaps, or blockers remain, do not promote. Ask for
+   the missing human decision or return to research.
+4. If the operator is using the manual CLI surface, use `decodex research promote
+   <CONTRACT_ID>` to record acceptance in local runtime state.
+5. After promotion, route issue shaping through `planning`.
+6. Let Program Intake persist the internal Execution Program and dispatch ready mapped
+   nodes directly. Do not use queue labels as the Program scheduler.
+
+## Boundaries
+
+- Do not infer acceptance from a research summary, old `docs/research/` artifact, or
+  merely because the user asked a research question.
+- Do not silently expand scope while promoting. New product behavior, public API,
+  config, workflow, security, privacy, data, billing, validation, or authority changes
+  require explicit acceptance.
+- Do not bypass planning or Program Intake by manually creating queue-label work from a
+  research result.

--- a/plugins/decodex/skills/research/SKILL.md
+++ b/plugins/decodex/skills/research/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: research
+description: Use when Decodex should run bounded evidence-based research or design investigation before execution. Owns the Decodex-native probe, evidence, options, judgment, challenge, decision, and promotion method through latent Decision Contracts.
+---
+
+# Decodex Research
+
+## Goal
+
+Make Decodex the default research surface for bounded technical investigation. A
+research request produces a latent Decision Contract candidate. It does not create
+execution authority until the user or accepted runtime policy promotes it.
+
+Use this skill when the user says `research X`, asks for a design investigation, asks
+whether a plan is the best architecture, or wants a decision-ready answer before
+implementation.
+
+## Method
+
+Run the same decision-quality loop every time:
+
+1. Use `research-probe` to frame the decision, scope, success criteria, constraints,
+   stop rule, primary hypotheses, rival hypotheses, and falsifiers before broad
+   evidence collection.
+2. Use `research-evidence` to collect an auditable evidence ledger. No evidence, no
+   claim. Separate observations, contradictions, inferences, and missing evidence.
+3. Use `research-options` to compare realistic options, including the status quo when
+   relevant. Tie tradeoffs back to evidence ids or explicit assumptions.
+4. Use `research-judgment` to form one challenge-ready recommendation or to state why
+   the run is not decision-ready.
+5. Use `research-challenge` to attack the judgment with skeptic objections. Unresolved
+   objections block `decision_ready`.
+6. Use `research-decision` to finish as `decision_ready`, `not_decision_ready`,
+   `blocked`, or `needs_human_decision`.
+7. Use `research-promote` only after explicit acceptance or an equivalent follow-up
+   such as `arrange this`, `push this forward`, `推进`, or `做`.
+
+## Decision Contract Output
+
+The durable Decodex output is a `decodex.decision_contract/1` payload retained in
+runtime state. In chat, present the same shape plainly:
+
+- source intent and decision question
+- evidence and provenance
+- realistic options and tradeoffs
+- selected decision or why no safe decision exists
+- assumptions, constraints, non-goals, objections, and stop conditions
+- validation expectations
+- proposed issue summaries only when downstream work is appropriate
+- unresolved decisions, evidence gaps, or blockers
+
+`decision_ready` is allowed only when the result has enough evidence, option
+comparison, resolved challenge, accepted objective, validation expectations, and
+proposed issue summaries for downstream issue shaping after promotion. It is still
+latent until promoted.
+
+## Boundaries
+
+- Do not route Decodex research through the legacy external `$research` skill as the
+  primary method.
+- Do not treat `docs/research/` artifacts as current authority. They are legacy or
+  supporting evidence that can be cited or imported into a Decision Contract.
+- Do not queue work, mutate Linear, set Codex goals, start implementation, or dispatch
+  Program nodes from research alone.
+- Do not hide missing evidence. Return `not_decision_ready`, `blocked`, or
+  `needs_human_decision` instead of forcing a recommendation.
+- Use subagents only for bounded scout, analyst, or skeptic support. The main agent
+  owns the coherent Decision Contract and final decision status.


### PR DESCRIPTION
## Summary
- add Decodex-owned bounded research phase skills for probe, evidence, options, judgment, challenge, decision, and promotion
- route plugin/docs away from the legacy external research default and toward runtime-local Decision Contracts
- tighten decision_ready compiler validation so options, challenge notes, and validation expectations are required

## Verification
- cargo test -p decodex --lib plugin_surface_tests -- --nocapture
- cargo test -p decodex --lib research_design -- --nocapture
- decodex research compile forward-test: draft_latent, authority=false
- decodex intake goal forward-test before promote: rejected draft_latent
- decodex research promote forward-test: accepted_promoted, authority=true
- decodex intake goal --dry-run forward-test after promote: applied=false, persisted=false
- cargo make check
