### PR TITLE
Reserve Decodex X post for PR 27936

### DIFF
--- a/artifacts/social/x/posts/2026-06-15/openai-codex-pr-27936.json
+++ b/artifacts/social/x/posts/2026-06-15/openai-codex-pr-27936.json
@@ -1,0 +1,100 @@
+{
+  "audience": "App-server integrators and Control Plane operators",
+  "caveats": [
+    "Do not imply older JSON clients break; omitted role defaults to user.",
+    "Do not suggest user-authored text should be sent as developer authority.",
+    "Keep the claim scoped to realtime appendText and app-server protocol clients.",
+    "No generated image was used because this was a single non-release operator-impact post with sufficient reader value from the text and source card."
+  ],
+  "channel": "x",
+  "claims": [
+    {
+      "confidence": "confirmed",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27936.review.json",
+      "text": "`thread/realtime/appendText` now accepts user or developer role text."
+    },
+    {
+      "confidence": "confirmed",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27936.json",
+      "text": "The optional role field is an adoption opportunity for app-server and Control Plane realtime clients."
+    },
+    {
+      "confidence": "confirmed",
+      "evidence": "https://x.com/decodexspace/status/2066417967710212345",
+      "text": "The PR #27936 operator-impact post is live on @decodexspace."
+    }
+  ],
+  "controller_account": "hackink",
+  "decision": {
+    "daily_count_after": 1,
+    "daily_count_before": 0,
+    "daily_limit": 8,
+    "day": "2026-06-15",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27936:operator_impact",
+    "priority": "high",
+    "reason": "The change has a concrete protocol and authority-semantics angle with direct source links.",
+    "timezone": "Asia/Shanghai",
+    "worthiness": "publish"
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish, priority high, and mode operator_impact for openai-codex-pr-27936.",
+    "The upstream_review/v1 artifact confirms `thread/realtime/appendText` adds an optional user/developer role that defaults to user for older JSON clients.",
+    "The upstream_impact/v1 artifact marks the change as public_signal_decision publish, control_plane_impact candidate, and publisher_angle operator_impact.",
+    "The x-post-quality-system gate passed because the post states what changed, who can act on it, and the direct GitHub PR source that proves it; the checked text was 246 characters and fit in X compose.",
+    "The release publisher gates were not applicable because this is a non-release operator_impact candidate.",
+    "Checked durable social_post/v1 records contained no published or blocked record for this slug or idempotency key before publication.",
+    "Checked durable social_publish_reservation/v1 records contained no active reservation for this idempotency key before the new reservation was created.",
+    "Open GitHub PR readback with routed hackink credentials found no open publication PR touching this candidate or social/x records before reservation.",
+    "PR #386 made the active reservation visible before X compose; GitHub PR readback confirmed the PR was open, non-draft, mergeable, targeted main, and contained only the reservation file before compose.",
+    "Chrome account-menu readback initially showed @hackink, then the account switcher exposed an existing @decodexspace session; after switching, Chrome readback showed active account @decodexspace.",
+    "Bounded @decodexspace profile readback and exact X searches before reservation found no 27936, appendText, source URL, or lead-text duplicate.",
+    "Live @decodexspace profile readback after the PR-visible reservation and immediately before clicking Post showed active @decodexspace, eight recent profile statuses, and no candidate text match; exact X search for from:decodexspace 27936 returned no results.",
+    "The compose dialog showed @decodexspace active and the checked PR #27936 text before the enabled X compose button was clicked.",
+    "Home timeline readback immediately after posting showed a new @decodexspace status with the expected appendText role text and GitHub source link.",
+    "Profile readback showed the expected @decodexspace post text, Automated by @hackink attribution, GitHub PR card for openai/codex PR #27936, and no /photo/N media link.",
+    "The status ID decodes to 2026-06-15T07:10:10.348Z, which is 2026-06-15 15:10:10 in Asia/Shanghai."
+  ],
+  "media_refs": [
+    "media_caveat: no generated media was attached; this non-release operator_impact post remains valuable text-only because the source-backed app-server protocol caveat and GitHub PR card are the reader value."
+  ],
+  "mode": "operator_impact",
+  "post_lifecycle": {
+    "current_state": "live",
+    "quote_eligible": false,
+    "reason": "This is a standalone operator-impact post, not a prerelease quote-chain anchor."
+  },
+  "publication": {
+    "account_verified": true,
+    "made_with_ai": false,
+    "posted_at": "2026-06-15T07:10:10.348Z",
+    "published_urls": [
+      "https://x.com/decodexspace/status/2066417967710212345"
+    ],
+    "publisher": "chrome"
+  },
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-27936",
+  "source_refs": {
+    "reservations": [
+      "artifacts/social/x/reservations/2026-06-15/openai-codex-pr-27936.json"
+    ],
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27936.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27936.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27936.review.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27936",
+      "https://x.com/decodexspace/status/2066417967710212345"
+    ]
+  },
+  "status": "published",
+  "target_account": "decodexspace",
+  "text": [
+    "Codex app-server `thread/realtime/appendText` now accepts `role: \"user\" | \"developer\"` and defaults older clients to user. That gives apps a protocol path for developer-authority context like memory. PR: https://github.com/openai/codex/pull/27936"
+  ]
+}

--- a/artifacts/social/x/reservations/2026-06-15/openai-codex-pr-27936.json
+++ b/artifacts/social/x/reservations/2026-06-15/openai-codex-pr-27936.json
@@ -15,6 +15,7 @@
   },
   "channel": "x",
   "controller_account": "hackink",
+  "consumed_by_social_post": "artifacts/social/x/posts/2026-06-15/openai-codex-pr-27936.json",
   "day": "2026-06-15",
   "duplicate_keys": [
     "x:decodexspace:openai-codex-pr-27936:operator_impact",
@@ -42,7 +43,7 @@
   "reserved_at": "2026-06-15T07:04:54Z",
   "schema": "social_publish_reservation/v1",
   "slug": "openai-codex-pr-27936",
-  "status": "active",
+  "status": "consumed",
   "target_account": "decodexspace",
   "timezone": "Asia/Shanghai"
 }

--- a/artifacts/social/x/reservations/2026-06-15/openai-codex-pr-27936.json
+++ b/artifacts/social/x/reservations/2026-06-15/openai-codex-pr-27936.json
@@ -1,0 +1,47 @@
+{
+  "candidate_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27936.json"
+    ],
+    "source_urls": [
+      "https://github.com/openai/codex/pull/27936"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27936.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27936.review.json"
+    ]
+  },
+  "channel": "x",
+  "controller_account": "hackink",
+  "day": "2026-06-15",
+  "duplicate_keys": [
+    "x:decodexspace:openai-codex-pr-27936:operator_impact",
+    "openai-codex-pr-27936",
+    "https://github.com/openai/codex/pull/27936",
+    "thread/realtime/appendText",
+    "role: \"user\" | \"developer\""
+  ],
+  "evidence_notes": [
+    "Checked social_post/v1 records contain no published or blocked record for the idempotency key.",
+    "Checked social_publish_reservation/v1 records contain no active reservation for the idempotency key.",
+    "Open GitHub PR scan found no publication PR touching this candidate or social/x records.",
+    "Chrome readback showed active account @decodexspace before reservation.",
+    "Chrome profile scan and exact X searches for 27936 and appendText found no duplicate post."
+  ],
+  "expires_at": "2026-06-15T09:04:54Z",
+  "idempotency_key": "x:decodexspace:openai-codex-pr-27936:operator_impact",
+  "mode": "operator_impact",
+  "owner": {
+    "automation_id": "decodex-x-publisher",
+    "branch": "automation/x-publisher-20260615-pr27936",
+    "run_started_at": "2026-06-15T07:04:54Z"
+  },
+  "reserved_at": "2026-06-15T07:04:54Z",
+  "schema": "social_publish_reservation/v1",
+  "slug": "openai-codex-pr-27936",
+  "status": "active",
+  "target_account": "decodexspace",
+  "timezone": "Asia/Shanghai"
+}

--- a/artifacts/social/x/reservations/2026-06-15/openai-codex-pr-27936.json
+++ b/artifacts/social/x/reservations/2026-06-15/openai-codex-pr-27936.json
@@ -36,6 +36,7 @@
   "owner": {
     "automation_id": "decodex-x-publisher",
     "branch": "automation/x-publisher-20260615-pr27936",
+    "pr_url": "https://github.com/hack-ink/decodex/pull/386",
     "run_started_at": "2026-06-15T07:04:54Z"
   },
   "reserved_at": "2026-06-15T07:04:54Z",


### PR DESCRIPTION
## Summary

- Add a thin social_publish_reservation/v1 lease for openai-codex-pr-27936.
- Keep the reservation scoped to candidate/source refs, duplicate keys, cap day, and pre-compose duplicate/account-readiness notes.

## Validation

- cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x

## Publisher state

- Candidate: artifacts/github/social-candidates/openai-codex-pr-27936.json
- Decision: decision.worthiness = publish
- Target account readback: Chrome active account @decodexspace
- Duplicate readback: checked records, open PR scan, profile scan, and exact X searches found no duplicate for PR 27936 / appendText.

This PR is the PR-visible reservation required before any X compose step.