### PR TITLE
Persist upstream Radar review artifacts

### DIFF
--- a/artifacts/github/bundles/openai-codex-pr-27461.json
+++ b/artifacts/github/bundles/openai-codex-pr-27461.json
@@ -1,0 +1,99 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "felixxia-oai",
+      "committed_at": "2026-06-11T10:27:17Z",
+      "message": "Skip plugin MCP OAuth when app route is available",
+      "sha": "9d5edd7c670d178062a8bee9f194ba41fc4072be",
+      "url": "https://github.com/openai/codex/commit/9d5edd7c670d178062a8bee9f194ba41fc4072be"
+    },
+    {
+      "author": "felixxia-oai",
+      "committed_at": "2026-06-15T11:23:58Z",
+      "message": "Update constructor name",
+      "sha": "3c9aaf348048ec81f41bdb1d7dcfa8c45aabbe49",
+      "url": "https://github.com/openai/codex/commit/3c9aaf348048ec81f41bdb1d7dcfa8c45aabbe49"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "PR5",
+    "MCP",
+    "PR1",
+    "PR2",
+    "PR3",
+    "PR4",
+    "API",
+    "--all",
+    "--check",
+    "--cached",
+    "DEFAULT_TIMEOUT",
+    "JSONRPCR",
+    "OPENAI_API_KEY",
+    "REMOTE_PLUGIN_ID",
+    "TEST_ALLOW_HTTP_REMOTE_PLUGIN_BUNDLE_DOWNLOADS",
+    "REMOTE_GLOBAL_MARKETPLACE_NAME",
+    "CONFIG_TOML_FILE"
+  ],
+  "files": [
+    {
+      "additions": 10,
+      "deletions": 3,
+      "patch_excerpt": "@@ -1436,7 +1436,11 @@ impl PluginRequestProcessor {\n \n         self.on_effective_plugins_changed();\n \n-        let plugin_mcp_servers = load_plugin_mcp_servers(result.installed_path.as_path()).await;\n+        let plugin_mcp_servers = load_plugin_mcp_servers(\n+            result.installed_path.as_path(),\n+            auth.as_ref().map(CodexAuth::auth_mode),\n+        )\n+        .await;\n         if !plugin_mcp_servers.is_empty() {\n             self.start_plugin_mcp_oauth_logins(&config, plugin_mcp_servers)\n                 .await;\n@@ -1445,7 +1449,6 @@ impl PluginRequestProcessor {\n         let plugin_app_declarations = load_plugin_apps(result.installed_path.as_path()).await;\n         let plugin_apps =\n             codex_plugin::app_connector_ids_from_declarations(&plugin_app_declarations);\n-        let auth = self.auth_manager.auth().await;\n         let apps_needing_auth = self\n          ...",
+      "path": "codex-rs/app-server/src/request_processors/plugins.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 378,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1027,6 +1027,293 @@ async fn plugin_install_returns_apps_needing_auth() -> Result<()> {\n     Ok(())\n }\n \n+#[tokio::test]\n+async fn plugin_install_skips_mcp_oauth_for_chatgpt_dual_surface_plugin() -> Result<()> {\n+    let connectors = vec![AppInfo {\n+        id: \"sample-mcp\".to_string(),\n+        name: \"Sample MCP\".to_string(),\n+        description: Some(\"Sample MCP connector\".to_string()),\n+        logo_url: Some(\"https://example.com/alpha.png\".to_string()),\n+        logo_url_dark: None,\n+        distribution_channel: Some(\"featured\".to_string()),\n+        branding: None,\n+        app_metadata: None,\n+        labels: None,\n+        install_url: None,\n+        is_accessible: false,\n+        is_enabled: true,\n+        plugin_display_names: Vec::new(),\n+    }];\n+    let (apps_server_url, apps_server_handle, _apps_server_control) =\n+        start_apps_server(connectors, Vec::new()).await...",
+      "path": "codex-rs/app-server/tests/suite/v2/plugin_install.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 24,
+      "deletions": 1,
+      "patch_excerpt": "@@ -10,6 +10,7 @@ use crate::remote::REMOTE_GLOBAL_MARKETPLACE_NAME;\n use crate::remote::RemoteInstalledPlugin;\n use crate::store::PluginStore;\n use crate::store::plugin_version_for_source;\n+use codex_app_server_protocol::AuthMode;\n use codex_config::ConfigLayerStack;\n use codex_config::HooksFile;\n use codex_config::types::McpServerConfig;\n@@ -1079,7 +1080,29 @@ pub async fn plugin_telemetry_metadata_from_root(\n     }\n }\n \n-pub async fn load_plugin_mcp_servers(plugin_root: &Path) -> HashMap<String, McpServerConfig> {\n+pub async fn load_plugin_mcp_servers(\n+    plugin_root: &Path,\n+    auth_mode: Option<AuthMode>,\n+) -> HashMap<String, McpServerConfig> {\n+    let mut mcp_servers = load_declared_plugin_mcp_servers(plugin_root).await;\n+    if !auth_mode.is_some_and(AuthMode::uses_codex_backend) || mcp_servers.is_empty() {\n+        return mcp_servers;\n+    }\n+\n+    let app_declarations = loa...",
+      "path": "codex-rs/core-plugins/src/loader.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -1330,7 +1330,7 @@ impl PluginsManager {\n                 app_category_by_id.insert(app.connector_id.0.clone(), category.clone());\n             }\n         }\n-        let mut mcp_server_names = load_plugin_mcp_servers(source_path.as_path())\n+        let mut mcp_server_names = load_plugin_mcp_servers(source_path.as_path(), self.auth_mode())\n             .await\n             .into_keys()\n             .collect::<Vec<_>>();",
+      "path": "codex-rs/core-plugins/src/manager.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 76,
+      "deletions": 0,
+      "patch_excerpt": "@@ -2425,6 +2425,82 @@ enabled = true\n     assert!(matches!(err, MarketplaceError::PluginsDisabled));\n }\n \n+#[tokio::test]\n+async fn read_plugin_for_config_filters_mcp_servers_for_codex_backend_auth() {\n+    let tmp = tempfile::tempdir().unwrap();\n+    let repo_root = tmp.path().join(\"repo\");\n+    fs::create_dir_all(repo_root.join(\".git\")).unwrap();\n+    fs::create_dir_all(repo_root.join(\".agents/plugins\")).unwrap();\n+    write_file(\n+        &repo_root.join(\".agents/plugins/marketplace.json\"),\n+        r#\"{\n+  \"name\": \"debug\",\n+  \"plugins\": [\n+    {\n+      \"name\": \"sample-plugin\",\n+      \"source\": {\n+        \"source\": \"local\",\n+        \"path\": \"./sample-plugin\"\n+      }\n+    }\n+  ]\n+}\"#,\n+    );\n+    write_file(\n+        &repo_root.join(\"sample-plugin/.codex-plugin/plugin.json\"),\n+        r#\"{\"name\":\"sample-plugin\"}\"#,\n+    );\n+    write_file(\n+        &repo_root.join(\"sample-plugin/.ap...",
+      "path": "codex-rs/core-plugins/src/manager_tests.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#27652",
+    "#27459",
+    "#27607",
+    "#27602",
+    "#27461"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Context\r\n\r\nThis is PR5 in the plugin auth-routing stack. Earlier PRs make plugin surface projection auth-aware, narrow App/MCP conflicts by App declaration name, and keep connector listings auth-aware. This PR applies the same name-based App/MCP conflict rule into plugin MCP loading, so install-time MCP OAuth and plugin detail metadata both reflect the MCPs available for the current auth route.\r\n\r\n## Stack\r\n\r\n- PR1: #27652 seed plugin manager auth at construction.\r\n- PR2: #27459 route plugin surfaces by auth mode.\r\n- PR3: #27607 dedupe plugin MCP servers by App declaration name.\r\n- PR4: #27602 preserve plugin Apps in connector listings.\r\n- PR5: #27461 skip install-time plugin MCP OAuth for matching App routes.\r\n\r\n## Summary\r\n\r\n- Make `load_plugin_mcp_servers` auth-aware and let it load App declarations before filtering same-name MCP servers for Codex-backend auth.\r\n- Use that filtered MCP list for both install-time MCP OAuth and marketplace plugin detail metadata.\r\n- Preserve API-key/direct auth behavior so plugin MCP servers remain visible and can still start OAuth.\r\n\r\n## Validation\r\n\r\n```bash\r\ncargo fmt --all\r\ncargo test -p codex-core-plugins read_plugin_for_config_filters_mcp_servers_for_codex_backend_auth\r\ncargo check -p codex-core-plugins -p codex-app-server\r\ngit diff --check\r\ngit diff --cached --check\r\n```\r\n",
+    "labels": [],
+    "merged_at": "2026-06-15T13:04:01Z",
+    "number": 27461,
+    "state": "merged",
+    "title": "[codex] Skip plugin MCP OAuth for matching app routes",
+    "url": "https://github.com/openai/codex/pull/27461"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27602.json
+++ b/artifacts/github/bundles/openai-codex-pr-27602.json
@@ -1,0 +1,116 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "felixxia-oai",
+      "committed_at": "2026-06-11T19:38:54Z",
+      "message": "Preserve plugin apps in connector listings",
+      "sha": "6a3bac99652534ee250536787b3d40061981283a",
+      "url": "https://github.com/openai/codex/commit/6a3bac99652534ee250536787b3d40061981283a"
+    },
+    {
+      "author": "felixxia-oai",
+      "committed_at": "2026-06-12T10:18:45Z",
+      "message": "Inline plugin app lookup in apps list",
+      "sha": "e93643d804ea1f7ed68ca286fbe935e5e32ec3a1",
+      "url": "https://github.com/openai/codex/commit/e93643d804ea1f7ed68ca286fbe935e5e32ec3a1"
+    },
+    {
+      "author": "felixxia-oai",
+      "committed_at": "2026-06-12T10:32:21Z",
+      "message": "Simplify connector listing options",
+      "sha": "6370a49ab0b18daeeaf3b531c4e3b0d1c645c979",
+      "url": "https://github.com/openai/codex/commit/6370a49ab0b18daeeaf3b531c4e3b0d1c645c979"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "PR4",
+    "MCP",
+    "SIWC",
+    "API",
+    "PR1",
+    "PR2",
+    "PR3",
+    "PR5",
+    "--check",
+    "JSONRPCE",
+    "ZERO",
+    "DEFAULT_TIMEOUT",
+    "JSONRPCR"
+  ],
+  "files": [
+    {
+      "additions": 0,
+      "deletions": 1,
+      "patch_excerpt": "@@ -2257,7 +2257,6 @@ dependencies = [\n  \"codex-app-server-protocol\",\n  \"codex-connectors\",\n  \"codex-core\",\n- \"codex-core-plugins\",\n  \"codex-git-utils\",\n  \"codex-login\",\n  \"codex-model-provider\",",
+      "path": "codex-rs/Cargo.lock",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -318,6 +318,7 @@ use codex_core_plugins::PluginInstallError as CorePluginInstallError;\n use codex_core_plugins::PluginInstallRequest;\n use codex_core_plugins::PluginReadRequest;\n use codex_core_plugins::PluginUninstallError as CorePluginUninstallError;\n+use codex_core_plugins::PluginsManager;\n use codex_core_plugins::loader::load_plugin_apps;\n use codex_core_plugins::loader::load_plugin_mcp_servers;\n use codex_core_plugins::loader::plugin_telemetry_metadata_from_root;",
+      "path": "codex-rs/app-server/src/request_processors.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 28,
+      "deletions": 7,
+      "patch_excerpt": "@@ -89,6 +89,7 @@ impl AppsRequestProcessor {\n         let outgoing = Arc::clone(&self.outgoing);\n         let environment_manager = self.thread_manager.environment_manager();\n         let mcp_manager = self.thread_manager.mcp_manager();\n+        let plugins_manager = self.thread_manager.plugins_manager();\n         let shutdown_token = self.shutdown_token.child_token();\n         tokio::spawn(async move {\n             tokio::select! {\n@@ -100,6 +101,7 @@ impl AppsRequestProcessor {\n                     config,\n                     environment_manager,\n                     mcp_manager,\n+                    plugins_manager,\n                 ) => {}\n             }\n         });\n@@ -117,14 +119,22 @@ impl AppsRequestProcessor {\n         config: Config,\n         environment_manager: Arc<EnvironmentManager>,\n         mcp_manager: Arc<McpManager>,\n+        plugins_manager: Arc<PluginsManager>,\n  ...",
+      "path": "codex-rs/app-server/src/request_processors/apps_processor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 18,
+      "deletions": 13,
+      "patch_excerpt": "@@ -1578,7 +1578,7 @@ impl PluginRequestProcessor {\n                     .as_ref()\n                     .map(plugin_app_category_by_id_from_value)\n                     .unwrap_or_default();\n-                let all_connectors = connectors::list_cached_all_connectors(&config)\n+                let all_connectors = connectors::list_cached_all_connectors(&config, &[])\n                     .await\n                     .unwrap_or_default();\n                 connectors::connectors_for_plugin_apps(all_connectors, &plugin_apps)\n@@ -1630,7 +1630,7 @@ impl PluginRequestProcessor {\n \n         let environment_manager = self.thread_manager.environment_manager();\n         let (all_connectors_result, accessible_connectors_result) = tokio::join!(\n-            connectors::list_all_connectors_with_options(config, /*force_refetch*/ false),\n+            connectors::list_all_connectors_with_options(config, /*f...",
+      "path": "codex-rs/app-server/src/request_processors/plugins.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 87,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1,5 +1,6 @@\n use std::borrow::Cow;\n use std::collections::HashMap;\n+use std::path::Path;\n use std::sync::Arc;\n use std::sync::Mutex as StdMutex;\n use std::time::Duration;\n@@ -215,6 +216,50 @@ async fn list_apps_returns_empty_when_workspace_codex_plugins_disabled() -> Resu\n     Ok(())\n }\n \n+#[tokio::test]\n+async fn list_apps_includes_plugin_apps_for_chatgpt_auth() -> Result<()> {\n+    let (server_url, server_handle) =\n+        start_apps_server_with_delays(Vec::new(), Vec::new(), Duration::ZERO, Duration::ZERO)\n+            .await?;\n+\n+    let codex_home = TempDir::new()?;\n+    write_connectors_and_plugins_config(codex_home.path(), &server_url)?;\n+    write_plugin_app_fixture(codex_home.path(), \"sample\", \"connector_sample\")?;\n+    write_chatgpt_auth(\n+        codex_home.path(),\n+        ChatGptAuthFixture::new(\"chatgpt-token\")\n+            .account_id(\"account-123\")\n+            .chat...",
+      "path": "codex-rs/app-server/tests/suite/v2/app_list.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 1,
+      "patch_excerpt": "@@ -13,7 +13,6 @@ clap = { workspace = true, features = [\"derive\"] }\n codex-app-server-protocol = { workspace = true }\n codex-connectors = { workspace = true }\n codex-core = { workspace = true }\n-codex-core-plugins = { workspace = true }\n codex-git-utils = { workspace = true }\n codex-login = { workspace = true }\n codex-model-provider = { workspace = true }",
+      "path": "codex-rs/chatgpt/Cargo.toml",
+      "status": "modified"
+    },
+    {
+      "additions": 19,
+      "deletions": 31,
+      "patch_excerpt": "@@ -19,7 +19,6 @@ pub use codex_core::connectors::list_accessible_connectors_from_mcp_tools_with_o\n pub use codex_core::connectors::list_accessible_connectors_from_mcp_tools_with_options_and_status;\n pub use codex_core::connectors::list_cached_accessible_connectors_from_mcp_tools;\n pub use codex_core::connectors::with_app_enabled_state;\n-use codex_core_plugins::PluginsManager;\n use codex_login::AuthManager;\n use codex_login::CodexAuth;\n use codex_login::default_client::originator;\n@@ -69,33 +68,27 @@ pub async fn list_connectors(config: &Config) -> anyhow::Result<Vec<AppInfo>> {\n }\n \n pub async fn list_all_connectors(config: &Config) -> anyhow::Result<Vec<AppInfo>> {\n-    list_all_connectors_with_options(config, /*force_refetch*/ false).await\n+    list_all_connectors_with_options(config, /*force_refetch*/ false, &[]).await\n }\n \n-pub async fn list_cached_all_connectors(config: &Config) ->...",
+      "path": "codex-rs/chatgpt/src/connectors.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#27652",
+    "#27459",
+    "#27607",
+    "#27602",
+    "#27461"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Context\n\nThis is PR4 in the plugin auth-routing stack. The earlier PRs make plugin surface projection auth-aware and narrow App/MCP conflicts by App declaration name. This PR keeps connector listing paths aligned with that projected plugin App set.\n\nThis means ChatGPT/SIWC users will still see plugin-provided Apps in connector listing surfaces like the Apps/connector picker, while API-key users will not see Apps they cannot use.\n\n## Stack\n\n- PR1: #27652 seed plugin manager auth at construction.\n- PR2: #27459 route plugin surfaces by auth mode.\n- PR3: #27607 dedupe plugin MCP servers by App declaration name.\n- PR4: #27602 preserve plugin Apps in connector listings.\n- PR5: #27461 skip install-time plugin MCP OAuth for matching App routes.\n\n## Summary\n\n- Have app-server compute effective plugin Apps from the existing PluginsManager and pass them into connector listing.\n- Keep plugin Apps visible in Apps/connector listing for ChatGPT/SIWC users.\n- Keep API-key-style auth from surfacing plugin Apps in connector listings.\n\n## Validation\n\n```bash\ncargo test -p codex-chatgpt connectors::tests\ncargo test -p codex-app-server list_apps_includes_plugin_apps_for_chatgpt_auth\ngit diff --check\n```",
+    "labels": [],
+    "merged_at": "2026-06-15T12:50:08Z",
+    "number": 27602,
+    "state": "merged",
+    "title": "[codex] Preserve plugin apps in connector listings",
+    "url": "https://github.com/openai/codex/pull/27602"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-27893.json
+++ b/artifacts/github/bundles/openai-codex-pr-27893.json
@@ -1,0 +1,207 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-12T14:21:48Z",
+      "message": "Resolve selected plugin MCP registrations",
+      "sha": "8489afd8e3f3a547b47d569cfc91a389af125b34",
+      "url": "https://github.com/openai/codex/commit/8489afd8e3f3a547b47d569cfc91a389af125b34"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-12T15:16:17Z",
+      "message": "Use selected MCP winner approval policy",
+      "sha": "a7578adf4ccdae18f4cc9d3085d5aac15a431a3d",
+      "url": "https://github.com/openai/codex/commit/a7578adf4ccdae18f4cc9d3085d5aac15a431a3d"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-12T14:23:19Z",
+      "message": "Discover MCP servers in selected executor plugins",
+      "sha": "8b78cf44bc9452427916b53c2a7c1b99a2b89434",
+      "url": "https://github.com/openai/codex/commit/8b78cf44bc9452427916b53c2a7c1b99a2b89434"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-12T15:18:40Z",
+      "message": "Narrow executor plugin access to its filesystem",
+      "sha": "b7180839381890e258ba75bfbf2b825b5064a41f",
+      "url": "https://github.com/openai/codex/commit/b7180839381890e258ba75bfbf2b825b5064a41f"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-12T15:33:26Z",
+      "message": "Activate selected executor plugin MCPs in app-server",
+      "sha": "06dc0abb32835ccf054f291294a84a63617e31d8",
+      "url": "https://github.com/openai/codex/commit/06dc0abb32835ccf054f291294a84a63617e31d8"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-15T10:02:14Z",
+      "message": "Merge remote-tracking branch 'origin/main' into jif/app-server-executor-plugin-mcp",
+      "sha": "3964452256ff004a84e64a9299c041bce345b78b",
+      "url": "https://github.com/openai/codex/commit/3964452256ff004a84e64a9299c041bce345b78b"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-15T10:21:09Z",
+      "message": "Merge branch 'main' into jif/app-server-executor-plugin-mcp",
+      "sha": "191de6246942e5413e22b5087e4c8be6c185db9f",
+      "url": "https://github.com/openai/codex/commit/191de6246942e5413e22b5087e4c8be6c185db9f"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-15T10:50:27Z",
+      "message": "Enable hosted orchestrator skills",
+      "sha": "fa0e82f1affe6653756a662114361be0f640b634",
+      "url": "https://github.com/openai/codex/commit/fa0e82f1affe6653756a662114361be0f640b634"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-15T11:03:18Z",
+      "message": "Skip executor MCP helpers on Windows CI",
+      "sha": "b62eff83f23faf457c6f5072af70af7446b3bce1",
+      "url": "https://github.com/openai/codex/commit/b62eff83f23faf457c6f5072af70af7446b3bce1"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-15T11:10:45Z",
+      "message": "Revert unsupported Bazel select in app-server BUILD",
+      "sha": "cf3b08f03d6598c0edd7f60403bf5f92f3a0ca4b",
+      "url": "https://github.com/openai/codex/commit/cf3b08f03d6598c0edd7f60403bf5f92f3a0ca4b"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-15T13:01:58Z",
+      "message": "Remove executor MCP app-server E2E test",
+      "sha": "3d139253da3a4725655a0d1641a60f08c7b17903",
+      "url": "https://github.com/openai/codex/commit/3d139253da3a4725655a0d1641a60f08c7b17903"
+    },
+    {
+      "author": "jif-oai",
+      "committed_at": "2026-06-15T13:57:35Z",
+      "message": "Restore executor MCP E2E on non-Windows",
+      "sha": "2d6589027994b9539faa03d958b02a9cff616dd4",
+      "url": "https://github.com/openai/codex/commit/2d6589027994b9539faa03d958b02a9cff616dd4"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [
+    "codex-rs/app-server/README.md"
+  ],
+  "examples_refs": [],
+  "extracted_flags": [
+    "MCP",
+    "E2E",
+    "HTTP",
+    "BUILD",
+    "API",
+    "TODO",
+    "ORCHESTRATOR_SKILLS_ENABLED",
+    "DEFAULT_READ_TIMEOUT",
+    "MCP_SERVER_NAME",
+    "EXECUTOR_ENV_NAME",
+    "MCP_EXECUTOR_MARKER",
+    "EXECUTOR_ENV_VALUE",
+    "EXECUTOR_ID",
+    "REFRESH_PROBE_SERVER_NAME",
+    "TOOL_CALL_ID",
+    "--listen",
+    "ECHOING",
+    "CARGO_BIN_EXE_",
+    "WINDOWS_GNULLVM_INCOMPATIBLE",
+    "--remap-path-prefix",
+    "WINDOWS_RUSTC_LINK_FLAGS",
+    "WINDOWS_GNULLVM_ONLY"
+  ],
+  "files": [
+    {
+      "additions": 4,
+      "deletions": 0,
+      "patch_excerpt": "@@ -6,6 +6,10 @@ codex_rust_crate(\n     extra_binaries = [\n         \"//codex-rs/bwrap:bwrap\",\n     ],\n+    extra_binaries_non_windows = [\n+        \"//codex-rs/cli:codex\",\n+        \"//codex-rs/rmcp-client:test_stdio_server\",\n+    ],\n     integration_test_timeout = \"long\",\n     test_shard_counts = {\n         # Note app-server-all-test has a large number of integration tests, so",
+      "path": "codex-rs/app-server/BUILD.bazel",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 1,
+      "patch_excerpt": "@@ -130,7 +130,7 @@ Example with notification opt-out:\n \n ## API Overview\n \n-- `thread/start` — create a new thread; emits `thread/started` (including the current `thread.status`) and auto-subscribes you to turn/item events for that thread. When the request includes a `cwd` and the resolved sandbox is `workspace-write` or full access, app-server also marks that project as trusted in the user `config.toml`. Pass `sessionStartSource: \"clear\"` when starting a replacement thread after clearing the current session so `SessionStart` hooks receive `source: \"clear\"` instead of the default `\"startup\"`. Experimental `runtimeWorkspaceRoots` replaces the thread-scoped runtime workspace roots used to materialize `:workspace_roots`; paths must be absolute. For permissions, prefer experimental `permissions` profile selection by id; the legacy `sandbox` shorthand is still accepted but cannot be combined...",
+      "path": "codex-rs/app-server/README.md",
+      "status": "modified"
+    },
+    {
+      "additions": 7,
+      "deletions": 8,
+      "patch_excerpt": "@@ -9,6 +9,7 @@ use codex_core::NewThread;\n use codex_core::StartThreadOptions;\n use codex_core::ThreadManager;\n use codex_core::config::Config;\n+use codex_exec_server::EnvironmentManager;\n use codex_extension_api::AgentSpawnFuture;\n use codex_extension_api::AgentSpawner;\n use codex_extension_api::ExtensionEventSink;\n@@ -27,16 +28,14 @@ use crate::outgoing_message::OutgoingMessageSender;\n use crate::thread_state::ThreadListenerCommand;\n use crate::thread_state::ThreadStateManager;\n \n-// TODO(jif): Enable once /ps/mcp serves complete hosted skill packages.\n-const ORCHESTRATOR_SKILLS_ENABLED: bool = false;\n-\n pub(crate) struct ThreadExtensionDependencies {\n     pub(crate) event_sink: Arc<dyn ExtensionEventSink>,\n     pub(crate) auth_manager: Arc<AuthManager>,\n     pub(crate) state_db: Option<StateDbHandle>,\n     pub(crate) analytics_events_client: AnalyticsEventsClient,\n     pub(crate) thr...",
+      "path": "codex-rs/app-server/src/extensions.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -237,6 +237,7 @@ mod tests {\n                         analytics_events_client: codex_analytics::AnalyticsEventsClient::disabled(),\n                         thread_manager: thread_manager.clone(),\n                         goal_service: Arc::new(codex_goal_extension::GoalService::new()),\n+                        environment_manager: Arc::clone(&environment_manager),\n                         executor_skill_provider: Arc::clone(&executor_skill_provider),\n                         thread_store: Arc::clone(&thread_store),\n                     },",
+      "path": "codex-rs/app-server/src/mcp_refresh.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 1,
+      "patch_excerpt": "@@ -329,7 +329,7 @@ impl MessageProcessor {\n         let restriction_product = session_source.restriction_product();\n         let executor_skill_provider: Arc<dyn codex_skills_extension::SkillProvider> = Arc::new(\n             codex_skills_extension::ExecutorSkillProvider::new_with_restriction_product(\n-                environment_manager_for_extensions,\n+                Arc::clone(&environment_manager_for_extensions),\n                 restriction_product,\n             ),\n         );\n@@ -352,6 +352,7 @@ impl MessageProcessor {\n                         analytics_events_client: analytics_events_client.clone(),\n                         thread_manager: thread_manager.clone(),\n                         goal_service: Arc::clone(&goal_service),\n+                        environment_manager: Arc::clone(&environment_manager_for_extensions),\n                         executor_skill_provider: Arc::clo...",
+      "path": "codex-rs/app-server/src/message_processor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1096,6 +1096,7 @@ impl ThreadRequestProcessor {\n         let mut thread_extension_init = ExtensionDataInit::new();\n         if !selected_capability_roots.is_empty() {\n             thread_extension_init.insert(selected_capability_roots);\n+            codex_mcp_extension::initialize_executor_plugin_thread_data(&mut thread_extension_init);\n         }\n         let create_thread_started_at = std::time::Instant::now();\n         let NewThread {",
+      "path": "codex-rs/app-server/src/request_processors/thread_processor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 264,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,264 @@\n+use anyhow::Result;\n+use app_test_support::TestAppServer;\n+use app_test_support::to_response;\n+use app_test_support::write_mock_responses_config_toml;\n+use codex_app_server_protocol::CapabilityRootLocation;\n+use codex_app_server_protocol::ListMcpServerStatusParams;\n+use codex_app_server_protocol::ListMcpServerStatusResponse;\n+use codex_app_server_protocol::McpServerToolCallParams;\n+use codex_app_server_protocol::McpServerToolCallResponse;\n+use codex_app_server_protocol::RequestId;\n+use codex_app_server_protocol::SelectedCapabilityRoot;\n+use codex_app_server_protocol::ThreadStartParams;\n+use codex_app_server_protocol::ThreadStartResponse;\n+use codex_app_server_protocol::TurnStartParams;\n+use codex_app_server_protocol::UserInput;\n+use core_test_support::responses;\n+use core_test_support::stdio_server_bin;\n+use pretty_assertions::assert_eq;\n+use serde_json::json;\n+use std...",
+      "path": "codex-rs/app-server/tests/suite/v2/executor_mcp.rs",
+      "status": "added"
+    },
+    {
+      "additions": 0,
+      "deletions": 1,
+      "patch_excerpt": "@@ -124,7 +124,6 @@ async fn mcp_resource_read_returns_resource_contents() -> Result<()> {\n }\n \n #[tokio::test(flavor = \"multi_thread\", worker_threads = 2)]\n-#[ignore = \"orchestrator skills are disabled until /ps/mcp serves complete skill packages\"]\n async fn orchestrator_skill_can_read_referenced_resource_without_an_executor() -> Result<()> {\n     let responses_server = responses::start_mock_server().await;\n     let (apps_server_url, apps_server_handle) = start_resource_apps_mcp_server().await?;",
+      "path": "codex-rs/app-server/tests/suite/v2/mcp_resource.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -12,6 +12,8 @@ mod connection_handling_websocket;\n #[cfg(unix)]\n mod connection_handling_websocket_unix;\n mod dynamic_tools;\n+#[cfg(not(target_os = \"windows\"))]\n+mod executor_mcp;\n mod executor_skills;\n mod experimental_api;\n mod experimental_feature_list;",
+      "path": "codex-rs/app-server/tests/suite/v2/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 39,
+      "deletions": 9,
+      "patch_excerpt": "@@ -187,7 +187,8 @@ def codex_rust_crate(\n         test_shard_counts = {},\n         test_tags = [],\n         unit_test_timeout = None,\n-        extra_binaries = []):\n+        extra_binaries = [],\n+        extra_binaries_non_windows = []):\n     \"\"\"Defines a Rust crate with library, binaries, and tests wired for Bazel + Cargo parity.\n \n     The macro mirrors Cargo conventions: it builds a library when `src/` exists,\n@@ -232,6 +233,9 @@ def codex_rust_crate(\n             generated from `src/**/*.rs`.\n         extra_binaries: Additional binary labels to surface as test data and\n             `CARGO_BIN_EXE_*` environment variables. These are only needed for binaries from a different crate.\n+        extra_binaries_non_windows: Like `extra_binaries`, but omitted from\n+            Windows test data and environment variables. Tests using these\n+            binaries must be excluded when targeting...",
+      "path": "defs.bzl",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#27870"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\n#27870 teaches the MCP extension how to discover stdio MCP servers declared by a selected executor plugin, but app-server does not yet install that contributor or initialize its per-thread state. As a result, `thread/start.selectedCapabilityRoots` can select the plugin while its MCP servers remain inactive.\n\nThis PR closes that app-server wiring gap:\n\n```text\nthread/start(selectedCapabilityRoots)\n    -> initialize the thread's selected-plugin MCP snapshot\n    -> read the selected plugin's .mcp.json through its environment\n    -> start declared stdio servers in that environment\n    -> expose their tools only on the selected thread\n```\n\n## What changed\n\n- Install the selected-executor-plugin MCP contributor in app-server using the existing shared `EnvironmentManager`.\n- Initialize its frozen thread snapshot when `thread/start` includes selected capability roots.\n- Document that selected plugin stdio MCPs are activated in their owning environment.\n- Add an app-server E2E covering the complete selection-to-tool-call path.\n\nThe E2E verifies that:\n\n- the selected MCP process receives an executor-only environment value, proving the tool runs through the selected environment;\n- the MCP tool is advertised to the model and can be called;\n- a normal MCP config reload does not discard the thread's frozen selected-plugin registration;\n- another thread without the selected root does not see the MCP server.\n\n## Scope\n\n- Existing sessions without `selectedCapabilityRoots` are unchanged.\n- Only stdio MCP declarations are activated. HTTP declarations remain inactive.\n- This does not change selected-root persistence across resume/fork or add hosted-plugin behavior.\n\n## Verification\n\n- Focused app-server E2E: `selected_executor_plugin_exposes_its_stdio_mcp_only_to_that_thread`\n\n## Stack\n\nStacked on #27870.\n",
+    "labels": [],
+    "merged_at": "2026-06-15T14:23:37Z",
+    "number": 27893,
+    "state": "merged",
+    "title": "Activate selected executor plugin MCPs in app-server",
+    "url": "https://github.com/openai/codex/pull/27893"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/impact/openai-codex-pr-27461.json
+++ b/artifacts/github/impact/openai-codex-pr-27461.json
@@ -1,0 +1,46 @@
+{
+  "candidate_followups": [
+    "Model plugin OAuth prompts in Decodex as auth-route dependent rather than a static function of declared MCP servers.",
+    "When summarizing plugin capabilities, distinguish same-name App routes suppressed under Codex-backend auth from MCP servers still available under API-key/direct auth.",
+    "Use PR #27602 and PR #27607 review artifacts alongside this one when explaining the full plugin auth-routing stack."
+  ],
+  "caveats": [
+    "The filter applies when `AuthMode::uses_codex_backend`; direct/API-key-style auth remains MCP-visible.",
+    "The conflict key is the App declaration name matching an MCP server name, not the broader plugin package name."
+  ],
+  "confidence": "confirmed",
+  "control_plane_impact": "compat_risk",
+  "evidence": [
+    "PR #27461 says install-time MCP OAuth and plugin detail metadata should reflect MCP servers available for the current auth route.",
+    "App-server passes the current auth mode into plugin MCP loading before starting install-time MCP OAuth.",
+    "The core plugin loader removes same-name MCP server declarations only for Codex-backend auth after reading plugin App declarations.",
+    "Tests cover both app-server install behavior and plugin manager metadata filtering.",
+    "The source-backed review is recorded at `artifacts/github/reviews/openai-codex-pr-27461.review.json`."
+  ],
+  "observed_change": "Codex plugin MCP loading is now auth-aware: ChatGPT/SIWC auth filters same-name MCP servers when a plugin App route exists, while API-key/direct auth keeps plugin MCP servers visible and OAuth-capable.",
+  "public_signal_decision": "publish",
+  "publisher_angle": "practical_explainer",
+  "repo": "openai/codex",
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27461",
+  "social_notes": [
+    "A public note should emphasize this avoids duplicate OAuth for dual App/MCP plugins under ChatGPT/SIWC.",
+    "Do not claim MCP servers are globally hidden; API-key/direct auth keeps them visible."
+  ],
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "meta": "Merged 2026-06-15T13:04:01Z",
+        "title": "[codex] Skip plugin MCP OAuth for matching app routes",
+        "url": "https://github.com/openai/codex/pull/27461"
+      },
+      {
+        "kind": "pull_request",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27461.review.json",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27461"
+      }
+    ]
+  }
+}

--- a/artifacts/github/impact/openai-codex-pr-27602.json
+++ b/artifacts/github/impact/openai-codex-pr-27602.json
@@ -1,0 +1,46 @@
+{
+  "candidate_followups": [
+    "Audit Decodex app and connector presentation so plugin-provided Apps are included only when Codex auth mode makes those Apps usable.",
+    "Keep plugin App connector ids distinct from ordinary remote directory connectors when building Control Plane capability inventories.",
+    "Use the source-backed review before promoting this into any site signal or implementation issue."
+  ],
+  "caveats": [
+    "The change is auth-route specific; API-key-style auth intentionally does not surface plugin Apps in connector listings.",
+    "This PR is part of a plugin auth-routing stack and should be read with PRs #27607 and #27461 for dual App/MCP behavior."
+  ],
+  "confidence": "confirmed",
+  "control_plane_impact": "compat_risk",
+  "evidence": [
+    "PR #27602 says ChatGPT/SIWC users should see plugin-provided Apps in Apps and connector picker surfaces, while API-key users should not see Apps they cannot use.",
+    "App-server app listing now computes effective plugin Apps from `PluginsManager` and supplies them to connector listing helpers.",
+    "Connector listing helpers now merge caller-supplied plugin App ids into the connector directory result before disallowed-connector filtering.",
+    "The app-server test suite adds ChatGPT-auth coverage for plugin Apps in app listing.",
+    "The source-backed review is recorded at `artifacts/github/reviews/openai-codex-pr-27602.review.json`."
+  ],
+  "observed_change": "Codex app-server now merges effective plugin Apps into Apps and connector listings for ChatGPT/SIWC auth while keeping API-key-style auth from surfacing plugin Apps it cannot use.",
+  "public_signal_decision": "publish",
+  "publisher_angle": "practical_explainer",
+  "repo": "openai/codex",
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27602",
+  "social_notes": [
+    "A public note should frame this as auth-aware plugin App visibility, not a general connector directory change.",
+    "Mention ChatGPT/SIWC and API-key behavior separately to avoid implying all auth modes see the same App set."
+  ],
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "meta": "Merged 2026-06-15T12:50:08Z",
+        "title": "[codex] Preserve plugin apps in connector listings",
+        "url": "https://github.com/openai/codex/pull/27602"
+      },
+      {
+        "kind": "pull_request",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27602.review.json",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27602"
+      }
+    ]
+  }
+}

--- a/artifacts/github/impact/openai-codex-pr-27893.json
+++ b/artifacts/github/impact/openai-codex-pr-27893.json
@@ -1,0 +1,50 @@
+{
+  "candidate_followups": [
+    "Update Decodex Control Plane capability modeling so selected capability roots can contribute thread-scoped MCP tools, not only skills.",
+    "Preserve selected-root MCP provenance as environment-owned and thread-local when displaying MCP status or deciding tool availability.",
+    "Track the secondary hosted orchestrator skill provider enablement separately if Decodex exposes app-server skill inventory details."
+  ],
+  "caveats": [
+    "Only stdio MCP declarations are activated; HTTP MCP declarations remain inactive.",
+    "The PR body says existing sessions without selectedCapabilityRoots are unchanged.",
+    "Selected-root persistence across resume/fork and hosted-plugin behavior are explicitly outside the PR scope.",
+    "The same PR also enables hosted orchestrator skills; this impact record centers on the selected-plugin MCP activation path."
+  ],
+  "confidence": "confirmed",
+  "control_plane_impact": "candidate",
+  "evidence": [
+    "PR #27893 describes the app-server flow from `thread/start(selectedCapabilityRoots)` to selected plugin `.mcp.json` discovery, stdio server startup in the selected environment, and thread-only tool exposure.",
+    "The app-server README now documents selected plugin stdio MCP activation and inactive HTTP declarations.",
+    "App-server extension registration installs the selected executor plugin MCP contributor with the shared `EnvironmentManager`.",
+    "Thread start seeds executor-plugin MCP state when selected capability roots are present.",
+    "The E2E verifies selected-thread MCP visibility, tool call behavior, executor-only environment value propagation, reload isolation, and absence from another thread.",
+    "The source-backed review is recorded at `artifacts/github/reviews/openai-codex-pr-27893.review.json`."
+  ],
+  "observed_change": "Codex app-server now activates stdio MCP servers declared by selected executor plugins when `thread/start` includes `selectedCapabilityRoots`, using the selected environment and exposing those tools only to that thread.",
+  "public_signal_decision": "publish",
+  "publisher_angle": "operator_impact",
+  "repo": "openai/codex",
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27893",
+  "social_notes": [
+    "Public copy should emphasize thread-scoped selected-plugin MCP activation through app-server, not just provider groundwork.",
+    "Include caveats that only stdio declarations are active and HTTP declarations remain inactive.",
+    "Avoid overclaiming resume/fork or hosted-plugin persistence because the PR body excludes those."
+  ],
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "meta": "Merged 2026-06-15T14:23:37Z",
+        "title": "Activate selected executor plugin MCPs in app-server",
+        "url": "https://github.com/openai/codex/pull/27893"
+      },
+      {
+        "kind": "pull_request",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27893.review.json",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27893"
+      }
+    ]
+  }
+}

--- a/artifacts/github/review-queue/openai-codex-latest.json
+++ b/artifacts/github/review-queue/openai-codex-latest.json
@@ -1,14 +1,14 @@
 {
   "counts": {
-    "critical": 20,
-    "high": 5,
+    "critical": 13,
+    "high": 9,
     "low": 0,
-    "normal": 15,
+    "normal": 18,
     "published_subjects_seen": 0,
     "recent_commits_scanned": 40,
     "subjects_queued": 40
   },
-  "generated_at": "2026-06-15T12:06:27.560195Z",
+  "generated_at": "2026-06-15T18:05:22.018404Z",
   "repo": "openai/codex",
   "schema": "upstream_review_queue/v1",
   "source": {
@@ -17,574 +17,6 @@
     "signals_dir": "site/src/content/signals"
   },
   "subjects": [
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "new_feature"
-      ],
-      "changed_file_count": 3,
-      "commit_shas": [
-        "cb38dc5b975c922567a770237080cb3c1047e407"
-      ],
-      "committed_at": "2026-06-12T20:31:11Z",
-      "next_step": "ai_review_required",
-      "pr_number": 23254,
-      "pr_url": "https://github.com/openai/codex/pull/23254",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature.",
-      "sample_paths": [
-        "codex-rs/core/src/context/available_plugins_instructions.rs",
-        "codex-rs/core/src/plugins/render_tests.rs",
-        "codex-rs/core/tests/suite/plugins.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "23254",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "fix(plugins) rm plugin descriptions",
-      "url": "https://github.com/openai/codex/pull/23254"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 44,
-      "commit_shas": [
-        "175e330c022da6cb1b49d20351464a8e99b77d29",
-        "dea1baa7a97b7a072a00dadb87d54bce4858dade",
-        "73dde0c84f6cf2da38ec71a094b6c7a6282bf645",
-        "e62505d9da1a30546003ca7af0ca25f67bbf502b",
-        "a1d47af3a817a03973e53d7eed6467660981651a",
-        "3d56c1105db26de4c47d7d0f890ddd6bc97f4f97",
-        "029c6755406e172c41d4eb8456f265054968983a",
-        "9a685d4cabb0fa6370135ef2737ed731d5759033"
-      ],
-      "committed_at": "2026-06-12T20:50:04Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27830,
-      "pr_url": "https://github.com/openai/codex/pull/27830",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/v2/RawResponseItemCompletedNotification.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadResumeParams.json",
-        "codex-rs/app-server-protocol/schema/typescript/AgentMessageInputContent.ts",
-        "codex-rs/app-server-protocol/src/protocol/thread_history.rs",
-        "codex-rs/core/src/agent/control/spawn.rs",
-        "codex-rs/core/src/client_common.rs",
-        "codex-rs/core/src/guardian/prompt.rs",
-        "codex-rs/core/src/hook_runtime.rs",
-        "codex-rs/core/src/prompt_debug.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27830",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "model_provider",
-        "sandbox_permissions",
-        "tests_ci"
-      ],
-      "title": "Support plaintext agent messages",
-      "url": "https://github.com/openai/codex/pull/27830"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "rate_limit",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 37,
-      "commit_shas": [
-        "993987bfebdb801052b5204b7c6dc179345141d2",
-        "9d621c44ee7863a51b55a55d5cd9228c8344ec51",
-        "77fccf78513484a77c322498138121f5755b8d42",
-        "3731b0fad7bccf63361cc1f9f9cb8bde8e9cd7dc",
-        "d7cbab5392bff4ff61c2953b0e79b54520f9c69b",
-        "5381aad53113fd81732460dcce5627877c98e4c0"
-      ],
-      "committed_at": "2026-06-12T21:20:55Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27801,
-      "pr_url": "https://github.com/openai/codex/pull/27801",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change, rate_limit, release_packaging, security_policy.",
-      "sample_paths": [
-        "MODULE.bazel.lock",
-        "codex-rs/Cargo.lock",
-        "codex-rs/Cargo.toml",
-        "codex-rs/tui/Cargo.toml",
-        "codex-rs/tui/src/app.rs",
-        "codex-rs/tui/src/app/event_dispatch.rs",
-        "codex-rs/tui/src/app/thread_routing.rs",
-        "codex-rs/tui/src/app_command.rs",
-        "codex-rs/tui/src/app_event.rs",
-        "codex-rs/tui/src/app_event_sender.rs",
-        "codex-rs/tui/src/app_server_session.rs",
-        "codex-rs/tui/src/audio_device.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27801",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "tests_ci"
-      ],
-      "title": "Remove TUI realtime voice support",
-      "url": "https://github.com/openai/codex/pull/27801"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 37,
-      "commit_shas": [
-        "24a0cd4c2b9a14f672691335af172ce3462aeb79",
-        "77343b8909e8a8ef9c6b65476c547f8681eb1554",
-        "d43079bc45170d8d8abf051718a446a592728416",
-        "0dc3b430c878be6d9d5a7f19e72dd6567adc6933"
-      ],
-      "committed_at": "2026-06-12T21:23:50Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27539,
-      "pr_url": "https://github.com/openai/codex/pull/27539",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/Cargo.lock",
-        "codex-rs/app-server-transport/src/transport/remote_control/tests.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/tests/clients_tests.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/tests/pairing_tests.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/websocket.rs",
-        "codex-rs/app-server/src/request_processors/account_processor.rs",
-        "codex-rs/app-server/tests/common/auth_fixtures.rs",
-        "codex-rs/app-server/tests/suite/v2/account.rs",
-        "codex-rs/app-server/tests/suite/v2/app_list.rs",
-        "codex-rs/cli/src/doctor.rs",
-        "codex-rs/cli/src/login.rs",
-        "codex-rs/cloud-config/src/bundle_loader.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27539",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "auth_accounts",
-        "cli_tui",
-        "config_hooks",
-        "model_provider",
-        "tests_ci"
-      ],
-      "title": "feat: use encrypted local secrets for CLI auth",
-      "url": "https://github.com/openai/codex/pull/27539"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 27,
-      "commit_shas": [
-        "bc08fad8d62d48b248a86b6183ebb1ecc44d786c",
-        "78daf298b0ea9ea7a5fddad51af4545cb05d2236"
-      ],
-      "committed_at": "2026-06-12T22:03:51Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27541,
-      "pr_url": "https://github.com/openai/codex/pull/27541",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/Cargo.lock",
-        "codex-rs/app-server/src/mcp_refresh.rs",
-        "codex-rs/app-server/src/request_processors/mcp_processor.rs",
-        "codex-rs/app-server/src/request_processors/plugins.rs",
-        "codex-rs/cli/src/mcp_cmd.rs",
-        "codex-rs/codex-mcp/src/connection_manager.rs",
-        "codex-rs/codex-mcp/src/connection_manager_tests.rs",
-        "codex-rs/codex-mcp/src/mcp/auth.rs",
-        "codex-rs/codex-mcp/src/mcp/mod.rs",
-        "codex-rs/codex-mcp/src/mcp/mod_tests.rs",
-        "codex-rs/codex-mcp/src/rmcp_client.rs",
-        "codex-rs/core/src/config/mod.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27541",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "auth_accounts",
-        "cli_tui",
-        "config_hooks",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "feat: use encrypted local secrets for MCP OAuth",
-      "url": "https://github.com/openai/codex/pull/27541"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 18,
-      "commit_shas": [
-        "728db43093fb3390778de642164be5520aa9262a"
-      ],
-      "committed_at": "2026-06-12T22:05:37Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27936,
-      "pr_url": "https://github.com/openai/codex/pull/27936",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
-        "codex-rs/app-server-protocol/schema/typescript/ConversationTextRole.ts",
-        "codex-rs/app-server-protocol/schema/typescript/index.ts",
-        "codex-rs/app-server-protocol/src/protocol/v2/realtime.rs",
-        "codex-rs/app-server-protocol/src/protocol/v2/tests.rs",
-        "codex-rs/app-server/README.md",
-        "codex-rs/app-server/src/request_processors/turn_processor.rs",
-        "codex-rs/app-server/tests/suite/v2/realtime_conversation.rs",
-        "codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs",
-        "codex-rs/codex-api/src/endpoint/realtime_websocket/methods_common.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27936",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "docs_examples",
-        "tests_ci"
-      ],
-      "title": "[codex] add roles to realtime append text",
-      "url": "https://github.com/openai/codex/pull/27936"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 8,
-      "commit_shas": [
-        "b9aa83a325087256114abbf696bc4f1e2c48840a",
-        "e1af0c16d05d22b2ab34db103e8e5ab2abd75998",
-        "2a2d9c3bd9a79173ed02659dc2aa218ce10c30cf",
-        "16a8f5916f994ec3ed23290df8a4e54b148e24d1",
-        "5b08f9d725f7a629e9aa047e54e2941b04a44cb2",
-        "de336b350e5817be9a603c36a379977ea740e78e",
-        "c1855cd69674b2d747534dcf6f6d10a606101884"
-      ],
-      "committed_at": "2026-06-12T23:29:40Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27499,
-      "pr_url": "https://github.com/openai/codex/pull/27499",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/features/src/lib.rs",
-        "codex-rs/features/src/tests.rs",
-        "codex-rs/tui/src/bottom_pane/chat_composer.rs",
-        "codex-rs/tui/src/bottom_pane/mentions_v2/mod.rs",
-        "codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__default_unified_mention_popup.snap",
-        "codex-rs/tui/src/chatwidget/skills.rs",
-        "codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__skills_menu_default_mentions_shortcut.snap",
-        "codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27499",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "config_hooks",
-        "tests_ci"
-      ],
-      "title": "Promote TUI unified mentions in composer to default mentions feature",
-      "url": "https://github.com/openai/codex/pull/27499"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 4,
-      "commit_shas": [
-        "bb55610111fe3fdbcbc954cab562a9985ef9f84c"
-      ],
-      "committed_at": "2026-06-12T23:37:14Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27972,
-      "pr_url": "https://github.com/openai/codex/pull/27972",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/core/tests/suite/apply_patch_cli.rs",
-        "codex-rs/core/tests/suite/rmcp_client.rs",
-        "codex-rs/core/tests/suite/unified_exec.rs",
-        "codex-rs/core/tests/suite/view_image.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27972",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "[codex] Let generic test turns inherit their environment",
-      "url": "https://github.com/openai/codex/pull/27972"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 42,
-      "commit_shas": [
-        "5beb1d3bf50105bb17e1046b0a7381bc8f074704",
-        "4b5ca0f8b07f3ea4e1555bf53546e6153ac465e8",
-        "d4554c3a42b08747b29cb52390512ad8ef9ce015"
-      ],
-      "committed_at": "2026-06-12T23:58:42Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27976,
-      "pr_url": "https://github.com/openai/codex/pull/27976",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/Cargo.lock",
-        "codex-rs/app-server/src/request_processors/fs_processor.rs",
-        "codex-rs/apply-patch/src/invocation.rs",
-        "codex-rs/apply-patch/src/lib.rs",
-        "codex-rs/config/src/loader/layer_io.rs",
-        "codex-rs/config/src/loader/mod.rs",
-        "codex-rs/config/src/loader/tests.rs",
-        "codex-rs/core-plugins/src/provider.rs",
-        "codex-rs/core-skills/src/injection.rs",
-        "codex-rs/core-skills/src/loader.rs",
-        "codex-rs/core-skills/src/model.rs",
-        "codex-rs/core/src/agents_md.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27976",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "auth_accounts",
-        "config_hooks",
-        "mcp_plugins",
-        "model_provider",
-        "sandbox_permissions",
-        "tests_ci"
-      ],
-      "title": "[codex] make PathUri::from_abs_path infallible",
-      "url": "https://github.com/openai/codex/pull/27976"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 11,
-      "commit_shas": [
-        "a148a9c44082c55fff64b7d4ef0182dd3d088b3e",
-        "9ebebf0cb0af759667c1bdc5c4aff3df132f890a",
-        "5c33830e5678a7338b3f0782c481ada594d5be2f",
-        "122bcdf2ad64d386aefce7899f4da4ff77bf1ef8",
-        "6eea710f43558b241c3170bf488bb8a2df20cd54"
-      ],
-      "committed_at": "2026-06-13T00:11:32Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27710,
-      "pr_url": "https://github.com/openai/codex/pull/27710",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "AGENTS.md",
-        "codex-rs/app-server/src/config_manager.rs",
-        "codex-rs/app-server/src/request_processors/thread_processor.rs",
-        "codex-rs/core-plugins/src/loader.rs",
-        "codex-rs/core-plugins/src/manager.rs",
-        "codex-rs/core-skills/src/manager.rs",
-        "codex-rs/core/src/connectors.rs",
-        "codex-rs/core/src/plugins/discoverable.rs",
-        "codex-rs/core/src/session/mod.rs",
-        "codex-rs/core/src/session/turn_context.rs",
-        "codex-rs/core/src/thread_manager.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27710",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "config_hooks",
-        "mcp_plugins"
-      ],
-      "title": "[codex] add latency tracing spans",
-      "url": "https://github.com/openai/codex/pull/27710"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "rate_limit",
-        "release_packaging"
-      ],
-      "changed_file_count": 42,
-      "commit_shas": [
-        "40447b66b8534d4046401396da86fbe96af3a4f8"
-      ],
-      "committed_at": "2026-06-13T00:33:43Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27925,
-      "pr_url": "https://github.com/openai/codex/pull/27925",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, rate_limit, release_packaging.",
-      "sample_paths": [
-        "codex-rs/tui/src/app.rs",
-        "codex-rs/tui/src/app/app_server_events.rs",
-        "codex-rs/tui/src/app/background_requests.rs",
-        "codex-rs/tui/src/app/event_dispatch.rs",
-        "codex-rs/tui/src/app/history_ui.rs",
-        "codex-rs/tui/src/app/resize_reflow.rs",
-        "codex-rs/tui/src/app/tests.rs",
-        "codex-rs/tui/src/app_backtrack.rs",
-        "codex-rs/tui/src/app_event.rs",
-        "codex-rs/tui/src/bottom_pane/chat_composer.rs",
-        "codex-rs/tui/src/bottom_pane/chat_composer/slash_input.rs",
-        "codex-rs/tui/src/bottom_pane/command_popup.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27925",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "auth_accounts",
-        "cli_tui",
-        "config_hooks",
-        "tests_ci"
-      ],
-      "title": "feat(tui): reland token activity command",
-      "url": "https://github.com/openai/codex/pull/27925"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 5,
-      "commit_shas": [
-        "5500d7a7c915d55e554d316ff2498a19a8977b55",
-        "13b29654fbdf2b982afff6ee1836c73aed3deba0"
-      ],
-      "committed_at": "2026-06-13T00:51:09Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27988,
-      "pr_url": "https://github.com/openai/codex/pull/27988",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/Cargo.lock",
-        "codex-rs/core-plugins/Cargo.toml",
-        "codex-rs/core-plugins/src/discoverable.rs",
-        "codex-rs/core-plugins/src/discoverable_tests.rs",
-        "codex-rs/core/src/plugins/discoverable_tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27988",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "config_hooks",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "[codex] Limit app-based plugin suggestions to remote catalogs",
-      "url": "https://github.com/openai/codex/pull/27988"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "new_feature",
-        "protocol_change",
-        "release_packaging"
-      ],
-      "changed_file_count": 3,
-      "commit_shas": [
-        "c3166f21172b5254033852ac1f75e03e4823863c",
-        "57bc034fab9dbc29f257be65c5dd84fe44eb4dfa"
-      ],
-      "committed_at": "2026-06-13T01:00:31Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27652,
-      "pr_url": "https://github.com/openai/codex/pull/27652",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, release_packaging.",
-      "sample_paths": [
-        "codex-rs/core-plugins/src/manager.rs",
-        "codex-rs/core-plugins/src/manager_tests.rs",
-        "codex-rs/core/src/thread_manager.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27652",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "[codex] Add auth mode to plugin manager constructor",
-      "url": "https://github.com/openai/codex/pull/27652"
-    },
     {
       "attention_flags": [
         "auth_account",
@@ -939,6 +371,275 @@
     {
       "attention_flags": [
         "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 7,
+      "commit_shas": [
+        "6a3bac99652534ee250536787b3d40061981283a",
+        "e93643d804ea1f7ed68ca286fbe935e5e32ec3a1",
+        "6370a49ab0b18daeeaf3b531c4e3b0d1c645c979"
+      ],
+      "committed_at": "2026-06-15T12:50:08Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27602,
+      "pr_url": "https://github.com/openai/codex/pull/27602",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/Cargo.lock",
+        "codex-rs/app-server/src/request_processors.rs",
+        "codex-rs/app-server/src/request_processors/apps_processor.rs",
+        "codex-rs/app-server/src/request_processors/plugins.rs",
+        "codex-rs/app-server/tests/suite/v2/app_list.rs",
+        "codex-rs/chatgpt/Cargo.toml",
+        "codex-rs/chatgpt/src/connectors.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27602",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "config_hooks",
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "[codex] Preserve plugin apps in connector listings",
+      "url": "https://github.com/openai/codex/pull/27602"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 5,
+      "commit_shas": [
+        "9d5edd7c670d178062a8bee9f194ba41fc4072be",
+        "3c9aaf348048ec81f41bdb1d7dcfa8c45aabbe49"
+      ],
+      "committed_at": "2026-06-15T13:04:01Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27461,
+      "pr_url": "https://github.com/openai/codex/pull/27461",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/app-server/src/request_processors/plugins.rs",
+        "codex-rs/app-server/tests/suite/v2/plugin_install.rs",
+        "codex-rs/core-plugins/src/loader.rs",
+        "codex-rs/core-plugins/src/manager.rs",
+        "codex-rs/core-plugins/src/manager_tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27461",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "mcp_plugins",
+        "release_packaging",
+        "tests_ci"
+      ],
+      "title": "[codex] Skip plugin MCP OAuth for matching app routes",
+      "url": "https://github.com/openai/codex/pull/27461"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 10,
+      "commit_shas": [
+        "8489afd8e3f3a547b47d569cfc91a389af125b34",
+        "a7578adf4ccdae18f4cc9d3085d5aac15a431a3d",
+        "8b78cf44bc9452427916b53c2a7c1b99a2b89434",
+        "b7180839381890e258ba75bfbf2b825b5064a41f",
+        "06dc0abb32835ccf054f291294a84a63617e31d8",
+        "3964452256ff004a84e64a9299c041bce345b78b",
+        "191de6246942e5413e22b5087e4c8be6c185db9f",
+        "fa0e82f1affe6653756a662114361be0f640b634",
+        "b62eff83f23faf457c6f5072af70af7446b3bce1",
+        "cf3b08f03d6598c0edd7f60403bf5f92f3a0ca4b",
+        "3d139253da3a4725655a0d1641a60f08c7b17903",
+        "2d6589027994b9539faa03d958b02a9cff616dd4"
+      ],
+      "committed_at": "2026-06-15T14:23:37Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27893,
+      "pr_url": "https://github.com/openai/codex/pull/27893",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server/BUILD.bazel",
+        "codex-rs/app-server/README.md",
+        "codex-rs/app-server/src/extensions.rs",
+        "codex-rs/app-server/src/mcp_refresh.rs",
+        "codex-rs/app-server/src/message_processor.rs",
+        "codex-rs/app-server/src/request_processors/thread_processor.rs",
+        "codex-rs/app-server/tests/suite/v2/executor_mcp.rs",
+        "codex-rs/app-server/tests/suite/v2/mcp_resource.rs",
+        "codex-rs/app-server/tests/suite/v2/mod.rs",
+        "defs.bzl"
+      ],
+      "source_state": "merged",
+      "subject_id": "27893",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "docs_examples",
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "Activate selected executor plugin MCPs in app-server",
+      "url": "https://github.com/openai/codex/pull/27893"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 20,
+      "commit_shas": [
+        "e401d78a53711d01aff64345a221130be95ba3d1",
+        "8570c09a0307ab72b74e35f2c8f11e73b2855b6c",
+        "c856ed238f1d5fe32717438ebf8a25c164319825",
+        "d4c37e93f76093cdd099b4aa1597bd1f936181c2",
+        "108c7e6ae81cdf469baa1b4608dab0b5aad92027"
+      ],
+      "committed_at": "2026-06-15T15:06:14Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27365,
+      "pr_url": "https://github.com/openai/codex/pull/27365",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server/src/request_processors.rs",
+        "codex-rs/app-server/src/request_processors/thread_processor.rs",
+        "codex-rs/app-server/tests/suite/v2/dynamic_tools.rs",
+        "codex-rs/core-api/src/lib.rs",
+        "codex-rs/core/src/tools/handlers/dynamic.rs",
+        "codex-rs/core/src/tools/handlers/tool_search.rs",
+        "codex-rs/core/src/tools/router_tests.rs",
+        "codex-rs/core/src/tools/spec_plan.rs",
+        "codex-rs/core/src/tools/spec_plan_tests.rs",
+        "codex-rs/core/tests/suite/code_mode.rs",
+        "codex-rs/core/tests/suite/compact_remote.rs",
+        "codex-rs/core/tests/suite/search_tool.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27365",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "Represent dynamic tools with explicit namespaces internally",
+      "url": "https://github.com/openai/codex/pull/27365"
+    },
+    {
+      "attention_flags": [
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 19,
+      "commit_shas": [
+        "54610fec006e76c51d30f2fe5b90001c48632288",
+        "eefdd863d8d8fbb4c3d6bc06f9b4a0b0b296a8e5",
+        "39eabddc46a763edc22f33f1f7013249f01d4a93",
+        "87fa3a6a5bc08f91c630c4990a42869ed064c86a",
+        "11867f161e889c8095d6970f151308263bc2d462",
+        "fe2b08e0b90598c0648ddba0b27e5341a6754212"
+      ],
+      "committed_at": "2026-06-15T15:35:57Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27371,
+      "pr_url": "https://github.com/openai/codex/pull/27371",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json",
+        "codex-rs/app-server-protocol/schema/typescript/v2/DynamicToolFunctionSpec.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/DynamicToolNamespaceSpec.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/DynamicToolNamespaceTool.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/DynamicToolSpec.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/index.ts",
+        "codex-rs/app-server-protocol/src/protocol/v2/tests.rs",
+        "codex-rs/app-server-protocol/src/protocol/v2/thread.rs",
+        "codex-rs/app-server-test-client/src/lib.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27371",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "docs_examples",
+        "tests_ci"
+      ],
+      "title": "Expose explicit dynamic tool namespaces in thread start",
+      "url": "https://github.com/openai/codex/pull/27371"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 8,
+      "commit_shas": [
+        "c0094f38430892282049e36c010d28773d4c5f36",
+        "a9bf199b81de2fcd23577efae2532559d7af5336"
+      ],
+      "committed_at": "2026-06-15T17:56:53Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28257,
+      "pr_url": "https://github.com/openai/codex/pull/28257",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server/src/request_processors.rs",
+        "codex-rs/app-server/src/request_processors/account_processor.rs",
+        "codex-rs/app-server/tests/suite/v2/account.rs",
+        "codex-rs/login/src/auth/manager.rs",
+        "codex-rs/login/src/auth/revoke.rs",
+        "codex-rs/login/src/lib.rs",
+        "codex-rs/login/tests/suite/auth_refresh.rs",
+        "codex-rs/login/tests/suite/logout.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28257",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "auth_accounts",
+        "tests_ci"
+      ],
+      "title": "Support staging OAuth client ID overrides",
+      "url": "https://github.com/openai/codex/pull/28257"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
         "new_feature",
         "protocol_change",
         "security_policy"
@@ -1135,328 +836,148 @@
     },
     {
       "attention_flags": [
-        "new_feature"
-      ],
-      "changed_file_count": 2,
-      "commit_shas": [
-        "7dfb944924fed2e4c5665fdb5f1e68cc61a1d306",
-        "bf304810261929bb4256b3a72018fed46170281c",
-        "b4e5207e35b3c72b4a5fc3fb5638971d0835e619",
-        "add216625ec76a84dbde99cff133cf547d261d02",
-        "4ca37ea9d4fcee4e484090904c8f119fe4bf38e4",
-        "3aa942edbcf0488187c4b0dbfbd9a55bdd30b4af"
-      ],
-      "committed_at": "2026-06-12T21:52:07Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27076,
-      "pr_url": "https://github.com/openai/codex/pull/27076",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature.",
-      "sample_paths": [
-        "codex-rs/features/src/lib.rs",
-        "codex-rs/features/src/tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27076",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "tests_ci"
-      ],
-      "title": "Warn for structured feature toggles",
-      "url": "https://github.com/openai/codex/pull/27076"
-    },
-    {
-      "attention_flags": [
         "auth_account",
-        "deprecated_removed",
-        "new_feature",
         "protocol_change",
         "security_policy"
       ],
-      "changed_file_count": 17,
-      "commit_shas": [
-        "ecb83dc0aedffece5c65b341fe0b073eef92fc3e"
-      ],
-      "committed_at": "2026-06-12T22:34:04Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27509,
-      "pr_url": "https://github.com/openai/codex/pull/27509",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/tui/src/app/event_dispatch.rs",
-        "codex-rs/tui/src/app/tests.rs",
-        "codex-rs/tui/src/app/thread_goal_actions.rs",
-        "codex-rs/tui/src/app_event.rs",
-        "codex-rs/tui/src/bottom_pane/chat_composer.rs",
-        "codex-rs/tui/src/bottom_pane/mod.rs",
-        "codex-rs/tui/src/chatwidget/goal_menu.rs",
-        "codex-rs/tui/src/chatwidget/input_flow.rs",
-        "codex-rs/tui/src/chatwidget/input_restore.rs",
-        "codex-rs/tui/src/chatwidget/interaction.rs",
-        "codex-rs/tui/src/chatwidget/slash_dispatch.rs",
-        "codex-rs/tui/src/chatwidget/tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27509",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "tests_ci"
-      ],
-      "title": "[2 of 3] Support long pasted text in TUI goals",
-      "url": "https://github.com/openai/codex/pull/27509"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 6,
-      "commit_shas": [
-        "834d47cb7dd42d0386620c209f75359fd01fe65b",
-        "573e1cd0f65d65e64487711124b89d22f1a319b4",
-        "1862ba37a36cc0ebcf1b512cf2ecfc74427a1e7d",
-        "671c94b06c9ec655ac6a08a86ad45f345222cfef",
-        "c4e497b38e49fb9eef7be735f1f14776e4635958",
-        "59031001029797ca92be4aadc02057b2a9543d5a"
-      ],
-      "committed_at": "2026-06-12T22:50:30Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27109,
-      "pr_url": "https://github.com/openai/codex/pull/27109",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/analytics/src/analytics_client_tests.rs",
-        "codex-rs/analytics/src/events.rs",
-        "codex-rs/analytics/src/lib.rs",
-        "codex-rs/core/src/guardian/review.rs",
-        "codex-rs/core/src/guardian/review_session.rs",
-        "codex-rs/core/src/guardian/tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27109",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "tests_ci"
-      ],
-      "title": "Add Guardian catalog diagnostics metadata",
-      "url": "https://github.com/openai/codex/pull/27109"
-    },
-    {
-      "attention_flags": [
-        "new_feature",
-        "release_packaging"
-      ],
       "changed_file_count": 1,
       "commit_shas": [
-        "900e4e269085dbe611456d22f9cfd8430913b01b"
+        "01ef282efd1c41f07917b71178192dd10972841b",
+        "932662bcc1a52e17920a43b10c89f35577c9cb63"
       ],
-      "committed_at": "2026-06-12T23:25:58Z",
+      "committed_at": "2026-06-15T14:58:01Z",
       "next_step": "ai_review_required",
-      "pr_number": 27966,
-      "pr_url": "https://github.com/openai/codex/pull/27966",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature, release_packaging.",
+      "pr_number": 28332,
+      "pr_url": "https://github.com/openai/codex/pull/28332",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, protocol_change, security_policy.",
       "sample_paths": [
-        "AGENTS.md"
+        "codex-rs/app-server/src/request_processors/feedback_processor.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27966",
+      "subject_id": "28332",
       "subject_kind": "pr",
       "surface_hints": [
-        "internal_churn"
+        "app_server_protocol"
       ],
-      "title": "Specify platform support in AGENTS.md",
-      "url": "https://github.com/openai/codex/pull/27966"
+      "title": "[codex] Cap feedback upload subtrees",
+      "url": "https://github.com/openai/codex/pull/28332"
     },
     {
       "attention_flags": [
-        "deprecated_removed",
-        "release_packaging"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "b6120fe5778a0a3a2e595941f2d2520d87e25962"
-      ],
-      "committed_at": "2026-06-12T23:26:39Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27855,
-      "pr_url": "https://github.com/openai/codex/pull/27855",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, release_packaging.",
-      "sample_paths": [
-        ".github/workflows/rust-release-windows.yml"
-      ],
-      "source_state": "merged",
-      "subject_id": "27855",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "[codex] parallelize Windows compression",
-      "url": "https://github.com/openai/codex/pull/27855"
-    },
-    {
-      "attention_flags": [
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "4a47b5a20ffe31b27af2870ef0e43ac797d82952"
-      ],
-      "committed_at": "2026-06-12T23:52:23Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27856,
-      "pr_url": "https://github.com/openai/codex/pull/27856",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        ".github/workflows/rust-release-windows.yml"
-      ],
-      "source_state": "merged",
-      "subject_id": "27856",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "[codex] package Windows symbols in parallel",
-      "url": "https://github.com/openai/codex/pull/27856"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "release_packaging"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "cd08ab789367666570e9e93489899319a0ce75ef"
-      ],
-      "committed_at": "2026-06-13T00:00:15Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27854,
-      "pr_url": "https://github.com/openai/codex/pull/27854",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, release_packaging.",
-      "sample_paths": [
-        ".github/workflows/rust-release-windows.yml"
-      ],
-      "source_state": "merged",
-      "subject_id": "27854",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "[codex] parallelize Windows package archives",
-      "url": "https://github.com/openai/codex/pull/27854"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "release_packaging"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "587746d90fd392e8b167de8e51006803266b633a"
-      ],
-      "committed_at": "2026-06-13T00:01:14Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27853,
-      "pr_url": "https://github.com/openai/codex/pull/27853",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, release_packaging.",
-      "sample_paths": [
-        "scripts/stage_npm_packages.py"
-      ],
-      "source_state": "merged",
-      "subject_id": "27853",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "release_packaging"
-      ],
-      "title": "[codex] stage npm packages concurrently",
-      "url": "https://github.com/openai/codex/pull/27853"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
         "new_feature",
         "protocol_change"
       ],
-      "changed_file_count": 5,
+      "changed_file_count": 7,
       "commit_shas": [
-        "b3f37c48499df0d2b374618991f6ad75f8208d63"
+        "872e4d5152ea4a7e1b71f33bb206b5217f97efc8"
       ],
-      "committed_at": "2026-06-13T00:14:27Z",
+      "committed_at": "2026-06-15T15:15:45Z",
       "next_step": "ai_review_required",
-      "pr_number": 27510,
-      "pr_url": "https://github.com/openai/codex/pull/27510",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change.",
+      "pr_number": 28333,
+      "pr_url": "https://github.com/openai/codex/pull/28333",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/tui/src/app/tests.rs",
-        "codex-rs/tui/src/bottom_pane/mod.rs",
-        "codex-rs/tui/src/chatwidget/slash_dispatch.rs",
-        "codex-rs/tui/src/chatwidget/tests/slash_commands.rs",
-        "codex-rs/tui/src/goal_files.rs"
+        "codex-rs/app-server/tests/suite/v2/mcp_resource.rs",
+        "codex-rs/core/src/session/session.rs",
+        "codex-rs/ext/extension-api/src/contributors/thread_lifecycle.rs",
+        "codex-rs/ext/goal/tests/goal_extension_backend.rs",
+        "codex-rs/ext/skills/src/extension.rs",
+        "codex-rs/ext/skills/src/state.rs",
+        "codex-rs/ext/skills/tests/skills_extension.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27510",
+      "subject_id": "28333",
       "subject_kind": "pr",
       "surface_hints": [
-        "cli_tui",
+        "app_server_protocol",
+        "mcp_plugins",
         "tests_ci"
       ],
-      "title": "[3 of 3] Support images in TUI goals",
-      "url": "https://github.com/openai/codex/pull/27510"
+      "title": "skills: hide orchestrator skills with a local executor",
+      "url": "https://github.com/openai/codex/pull/28333"
     },
     {
       "attention_flags": [
-        "new_feature",
-        "release_packaging"
+        "auth_account",
+        "protocol_change"
       ],
-      "changed_file_count": 12,
+      "changed_file_count": 4,
       "commit_shas": [
-        "25d5679c7824871e2a5359e2c9d7e023a0c06ed9",
-        "da01e88dd828082ec82058354cd3df0d3185d74f"
+        "b36c87b2ceb91ea08519c57162dfe2e52a332c4a"
       ],
-      "committed_at": "2026-06-13T01:24:49Z",
+      "committed_at": "2026-06-15T17:17:34Z",
       "next_step": "ai_review_required",
-      "pr_number": 27964,
-      "pr_url": "https://github.com/openai/codex/pull/27964",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature, release_packaging.",
+      "pr_number": 27995,
+      "pr_url": "https://github.com/openai/codex/pull/27995",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, protocol_change.",
       "sample_paths": [
-        "MODULE.bazel",
-        "bazel/modules/BUILD.bazel",
-        "bazel/modules/wine.MODULE.bazel",
-        "bazel/rules/testing/BUILD.bazel",
-        "bazel/rules/testing/foreign_platform_binary.bzl",
-        "bazel/rules/testing/wine.bzl",
-        "bazel/rules/testing/wine/BUILD.bazel",
-        "bazel/rules/testing/wine/fixtures/windows_smoke.rs",
-        "bazel/rules/testing/wine/src/lib.rs",
-        "bazel/rules/testing/wine/src/lib_tests.rs",
-        "defs.bzl",
-        "third_party/wine/BUILD.bazel"
+        "codex-rs/app-server/src/request_processors/turn_processor.rs",
+        "codex-rs/app-server/tests/suite/v2/thread_settings_update.rs",
+        "codex-rs/core/src/session/tests.rs",
+        "codex-rs/protocol/src/protocol.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27964",
+      "subject_id": "27995",
       "subject_kind": "pr",
       "surface_hints": [
+        "app_server_protocol",
+        "config_hooks",
         "tests_ci"
       ],
-      "title": "[codex] Add hermetic Wine test support",
-      "url": "https://github.com/openai/codex/pull/27964"
+      "title": "[codex] preserve explicit environment cwd",
+      "url": "https://github.com/openai/codex/pull/27995"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "new_feature",
+        "protocol_change",
+        "rate_limit",
+        "security_policy"
+      ],
+      "changed_file_count": 9,
+      "commit_shas": [
+        "b10549a76402a14d8c7e650f6c5774e96e46be25",
+        "04e1e711d84df0411666203e53b430af662906ed",
+        "5d54c4ea4393631d951e2fff2d797cc9ad563a84",
+        "ee3d532e8f217fde9dcbe3c16b0584fd8b2b4992",
+        "34b933ac26cd90f3ab07f9a05b99c7e92d79defc",
+        "c01b8b9c3ecc5341fae2eb61efae75bffdd594cf",
+        "5b11f61b2be8a96db3fbbc8b8a58db1352740666",
+        "0ccf9cc1bd3a215e373364bcb46aeebef02fb744",
+        "4850301eb2b9f5750e92ef04880111309f16218f"
+      ],
+      "committed_at": "2026-06-15T17:25:37Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26702,
+      "pr_url": "https://github.com/openai/codex/pull/26702",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, rate_limit, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server/src/request_processors/plugins.rs",
+        "codex-rs/app-server/tests/suite/v2/plugin_list.rs",
+        "codex-rs/tui/src/app.rs",
+        "codex-rs/tui/src/app/background_requests.rs",
+        "codex-rs/tui/src/app/event_dispatch.rs",
+        "codex-rs/tui/src/app_event.rs",
+        "codex-rs/tui/src/chatwidget.rs",
+        "codex-rs/tui/src/chatwidget/constructor.rs",
+        "codex-rs/tui/src/chatwidget/plugins.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26702",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "TUI Plugin Sharing 2 - add remote plugin section plumbing",
+      "url": "https://github.com/openai/codex/pull/26702"
     },
     {
       "attention_flags": [
@@ -1638,6 +1159,426 @@
       ],
       "title": "path-uri: render native paths across platforms",
       "url": "https://github.com/openai/codex/pull/27819"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 18,
+      "commit_shas": [
+        "75b42ead5b591cc209cd00c15e5afcadf25156e2",
+        "ddcc446526f6009cf238a9a95f0d1048673a5ec8",
+        "f46f930650b35d98ff364960a34307bc7ecae05f"
+      ],
+      "committed_at": "2026-06-15T15:18:13Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27756,
+      "pr_url": "https://github.com/openai/codex/pull/27756",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/src/agent/control.rs",
+        "codex-rs/core/src/context/environment_context_tests.rs",
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/session/session.rs",
+        "codex-rs/core/src/session/tests.rs",
+        "codex-rs/core/src/shell.rs",
+        "codex-rs/core/src/shell_snapshot.rs",
+        "codex-rs/core/src/shell_snapshot_tests.rs",
+        "codex-rs/core/src/shell_tests.rs",
+        "codex-rs/core/src/state/service.rs",
+        "codex-rs/core/src/tasks/user_shell.rs",
+        "codex-rs/core/src/tasks/user_shell_tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27756",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "[codex] simplify shell snapshot ownership",
+      "url": "https://github.com/openai/codex/pull/27756"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 11,
+      "commit_shas": [
+        "a42dd05a6108e69fc609f65e0d221793b4ec0012"
+      ],
+      "committed_at": "2026-06-15T15:23:02Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27794,
+      "pr_url": "https://github.com/openai/codex/pull/27794",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/features/src/lib.rs",
+        "codex-rs/features/src/tests.rs",
+        "codex-rs/tui/src/app.rs",
+        "codex-rs/tui/src/app/event_dispatch.rs",
+        "codex-rs/tui/src/app/resize_reflow.rs",
+        "codex-rs/tui/src/app/tests.rs",
+        "codex-rs/tui/src/app/thread_routing.rs",
+        "codex-rs/tui/src/app_backtrack.rs",
+        "codex-rs/tui/src/chatwidget.rs",
+        "codex-rs/tui/src/transcript_reflow.rs",
+        "codex-rs/tui/tests/suite/resize_reflow.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27794",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "Remove terminal resize reflow flag gates",
+      "url": "https://github.com/openai/codex/pull/27794"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed",
+        "protocol_change"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "afc5f40dcff3a6183e2105ee677c148b40cdef05",
+        "ebc30a9859152b0cf897abf4645e30bfa1f4378a"
+      ],
+      "committed_at": "2026-06-15T15:24:36Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28286,
+      "pr_url": "https://github.com/openai/codex/pull/28286",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for deprecated_removed, protocol_change.",
+      "sample_paths": [
+        "codex-rs/exec-server/src/relay.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28286",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "internal_churn"
+      ],
+      "title": "chore: restore exec-server relay keepalives",
+      "url": "https://github.com/openai/codex/pull/28286"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "protocol_change"
+      ],
+      "changed_file_count": 6,
+      "commit_shas": [
+        "47d6e2f86f9867f8b5089c6aeee0d50942102537",
+        "48bcf9ab3a31d1170d28962088c31021df628b48",
+        "eef4faf488854783efe494edfb8a127e5a2a2f78",
+        "129948e0261d111ac21606e1b0465be19acaa86e",
+        "902bbe6ad5cbba6463ed38382a2bf9c093a5cda6"
+      ],
+      "committed_at": "2026-06-15T15:28:02Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28164,
+      "pr_url": "https://github.com/openai/codex/pull/28164",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, protocol_change.",
+      "sample_paths": [
+        "codex-rs/core/src/memory_usage.rs",
+        "codex-rs/core/src/tools/handlers/unified_exec.rs",
+        "codex-rs/core/src/tools/registry.rs",
+        "codex-rs/memories/read/src/usage.rs",
+        "codex-rs/shell-command/src/bash.rs",
+        "codex-rs/shell-command/src/parse_command.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28164",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "internal_churn"
+      ],
+      "title": "[codex] simplify memory read metrics",
+      "url": "https://github.com/openai/codex/pull/28164"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "c52bcb48c0feaaf55d2aa34231c6f0e1c9de73fe",
+        "242c548dfa23123671e50797b73366e3b5184a85"
+      ],
+      "committed_at": "2026-06-15T16:26:34Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28309,
+      "pr_url": "https://github.com/openai/codex/pull/28309",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/core/src/context_manager/normalize.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28309",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "internal_churn"
+      ],
+      "title": "linearize history output normalization",
+      "url": "https://github.com/openai/codex/pull/28309"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "protocol_change"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "4ae63e1a8bcc1889a9e0b6c640a4ac272647d943",
+        "8e36bb0c7410351b761e9f8a56709098d3b3f2a5"
+      ],
+      "committed_at": "2026-06-15T16:26:44Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28306,
+      "pr_url": "https://github.com/openai/codex/pull/28306",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, protocol_change.",
+      "sample_paths": [
+        "codex-rs/core/src/session/turn.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28306",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "internal_churn"
+      ],
+      "title": "avoid cloning sampling request input",
+      "url": "https://github.com/openai/codex/pull/28306"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed",
+        "protocol_change"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "fe58231e02a6507f383bdc4f93b0959afeb414f2"
+      ],
+      "committed_at": "2026-06-15T16:33:35Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28323,
+      "pr_url": "https://github.com/openai/codex/pull/28323",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for deprecated_removed, protocol_change.",
+      "sample_paths": [
+        "codex-rs/codex-api/src/endpoint/responses_websocket.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28323",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "internal_churn"
+      ],
+      "title": "serialize websocket requests directly",
+      "url": "https://github.com/openai/codex/pull/28323"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "50f08ba5a76b3d8696cb2d79296527e7a7211684",
+        "624a007e974277ec774bde7c242c2c4cdfd35791"
+      ],
+      "committed_at": "2026-06-15T16:48:47Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28313,
+      "pr_url": "https://github.com/openai/codex/pull/28313",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/core/src/client.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28313",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui"
+      ],
+      "title": "avoid cloning websocket request history",
+      "url": "https://github.com/openai/codex/pull/28313"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed",
+        "new_feature",
+        "security_policy"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "c7ed068da023d35761bd0aa2cb4a8ad82e38810e"
+      ],
+      "committed_at": "2026-06-15T16:56:21Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28344,
+      "pr_url": "https://github.com/openai/codex/pull/28344",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/src/tools/runtimes/mod_tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28344",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "[codex] remove stale PathExt import",
+      "url": "https://github.com/openai/codex/pull/28344"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "0a769d94561b48550af4a0bbdeff17bb1991d5d8"
+      ],
+      "committed_at": "2026-06-15T16:59:26Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27059,
+      "pr_url": "https://github.com/openai/codex/pull/27059",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/otel/tests/suite/otlp_http_loopback.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27059",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "[codex] Cover OTLP HTTP log and trace event export",
+      "url": "https://github.com/openai/codex/pull/27059"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 6,
+      "commit_shas": [
+        "abe5c00b76d441e1a94bcb98ace2a4d5cf5c3315",
+        "7527b65d6c654a6706437d927dcb07dd425f2c9c"
+      ],
+      "committed_at": "2026-06-15T17:11:26Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28327,
+      "pr_url": "https://github.com/openai/codex/pull/28327",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/codex-api/src/endpoint/responses.rs",
+        "codex-rs/codex-api/src/endpoint/session.rs",
+        "codex-rs/codex-api/tests/clients.rs",
+        "codex-rs/codex-client/src/lib.rs",
+        "codex-rs/codex-client/src/request.rs",
+        "codex-rs/codex-client/src/transport.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28327",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "reuse encoded Responses request bodies",
+      "url": "https://github.com/openai/codex/pull/28327"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 4,
+      "commit_shas": [
+        "4640faa650d8de9e4c22c8629d524749b77851e9"
+      ],
+      "committed_at": "2026-06-15T17:24:50Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28285,
+      "pr_url": "https://github.com/openai/codex/pull/28285",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/src/guardian/review_session.rs",
+        "codex-rs/core/src/guardian/snapshots/codex_core__guardian__tests__guardian_review_request_layout.snap",
+        "codex-rs/core/src/guardian/tests.rs",
+        "codex-rs/core/src/session/turn.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28285",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "guardian: isolate review context from skills and memories",
+      "url": "https://github.com/openai/codex/pull/28285"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 2,
+      "commit_shas": [
+        "c470de7e14af82b4182333e44d51dd5d6dc9724a",
+        "7d4b7e2b9a40e760e82d32591033db9918d9fab9",
+        "0eeef9d02a13a43a698984c12df95ffa9fdc18dc"
+      ],
+      "committed_at": "2026-06-15T17:52:30Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28294,
+      "pr_url": "https://github.com/openai/codex/pull/28294",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/utils/image/src/image_tests.rs",
+        "codex-rs/utils/image/src/lib.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28294",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "bound prompt image cache retention",
+      "url": "https://github.com/openai/codex/pull/28294"
     }
   ]
 }

--- a/artifacts/github/reviews/openai-codex-pr-27461.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27461.review.json
@@ -1,0 +1,64 @@
+{
+  "adoption_opportunity": "Update Decodex plugin install and capability modeling to treat dual App/MCP plugins as auth-routed surfaces, where ChatGPT/SIWC auth suppresses same-name MCP OAuth but API-key/direct auth preserves MCP visibility.",
+  "changed_surfaces": [
+    "plugin MCP declaration loading",
+    "plugin install-time MCP OAuth startup",
+    "marketplace plugin metadata",
+    "auth-mode-specific App/MCP conflict filtering",
+    "plugin manager detail readback",
+    "plugin install and manager tests"
+  ],
+  "community_value": "High for plugin authors because the change explains why same-name App and MCP routes do not both ask for OAuth under ChatGPT/SIWC auth while direct/API-key auth still exposes MCP servers.",
+  "compatibility_risk": "Moderate to high for Control Plane or plugin tooling that expected plugin MCP OAuth to start for every declared MCP server regardless of auth route or same-name App declarations.",
+  "confidence": "confirmed",
+  "control_plane_relevance": "High. Decodex needs to preserve Codex's auth-mode-specific App/MCP routing so plugin OAuth prompts and capability summaries match the currently usable surface.",
+  "deprecated_or_breaking_notes": "No public schema was removed. The install-time behavior changes for Codex-backend auth: MCP servers with names matching plugin App declarations are filtered before MCP OAuth startup and plugin metadata readback.",
+  "evidence": [
+    "PR #27461 says `load_plugin_mcp_servers` becomes auth-aware and filters same-name MCP servers for Codex-backend auth while preserving API-key/direct auth behavior.",
+    "`codex-rs/app-server/src/request_processors/plugins.rs` passes the current `CodexAuth` auth mode into `load_plugin_mcp_servers` before calling `start_plugin_mcp_oauth_logins`.",
+    "`codex-rs/core-plugins/src/loader.rs` loads plugin App declarations under `AuthMode::uses_codex_backend` and retains only MCP servers whose names do not match App declaration names.",
+    "`codex-rs/core-plugins/src/manager.rs` uses the auth-aware loader for plugin detail metadata and available MCP server names.",
+    "`codex-rs/app-server/tests/suite/v2/plugin_install.rs` adds install coverage for skipping MCP OAuth on a ChatGPT dual-surface plugin.",
+    "`codex-rs/core-plugins/src/manager_tests.rs` adds `read_plugin_for_config_filters_mcp_servers_for_codex_backend_auth` coverage.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27461.json` records 5 changed files for the merged PR."
+  ],
+  "next_actions": [
+    {
+      "reason": "Auth-mode-specific plugin MCP OAuth filtering affects Decodex Control Plane compatibility and plugin capability summaries.",
+      "type": "upstream_impact"
+    },
+    {
+      "reason": "The change has a clear public explanation path for dual App/MCP plugin auth behavior.",
+      "type": "social_candidate"
+    }
+  ],
+  "observed_change": "Codex plugin MCP loading is now auth-aware: ChatGPT/SIWC auth filters same-name MCP servers when a plugin App route exists, while API-key/direct auth keeps plugin MCP servers visible and OAuth-capable.",
+  "repo": "openai/codex",
+  "reviewed_at": "2026-06-15T18:07:41Z",
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27461",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "meta": "Merged 2026-06-15T13:04:01Z",
+        "title": "[codex] Skip plugin MCP OAuth for matching app routes",
+        "url": "https://github.com/openai/codex/pull/27461"
+      },
+      {
+        "kind": "commit",
+        "title": "Skip plugin MCP OAuth when app route is available",
+        "url": "https://github.com/openai/codex/commit/9d5edd7c670d178062a8bee9f194ba41fc4072be"
+      }
+    ]
+  },
+  "subject": {
+    "commit_shas": [
+      "9d5edd7c670d178062a8bee9f194ba41fc4072be",
+      "3c9aaf348048ec81f41bdb1d7dcfa8c45aabbe49"
+    ],
+    "subject_id": "27461",
+    "subject_kind": "pr"
+  },
+  "user_visible_path": "When installing or reading a dual App/MCP plugin, ChatGPT/SIWC auth avoids duplicate MCP OAuth for same-name App routes, while API-key/direct auth still sees and can start plugin MCP servers."
+}

--- a/artifacts/github/reviews/openai-codex-pr-27602.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27602.review.json
@@ -1,0 +1,68 @@
+{
+  "adoption_opportunity": "Teach Decodex Control Plane app and connector views to include auth-aware effective plugin Apps from the plugin manager instead of treating the remote connector directory as the only Apps source.",
+  "changed_surfaces": [
+    "app-server Apps list request processing",
+    "plugin App projection from PluginsManager",
+    "ChatGPT connector directory merge path",
+    "plugin Apps metadata lookup",
+    "auth-aware app listing tests"
+  ],
+  "community_value": "High for plugin authors and operator tooling because plugin-provided Apps remain visible in connector picker surfaces for ChatGPT/SIWC auth while API-key-style auth avoids Apps it cannot use.",
+  "compatibility_risk": "Moderate for app-server clients or Control Plane code that assumes app listings come only from the remote connector directory or ignores auth-specific plugin App projection.",
+  "confidence": "confirmed",
+  "control_plane_relevance": "High. Decodex needs auth-aware plugin App availability when presenting or reasoning about Codex connector, App, and plugin surfaces.",
+  "deprecated_or_breaking_notes": "No removed API was found. The behavior narrows connector listing output by auth route: ChatGPT/SIWC can surface plugin Apps, while API-key-style auth should not surface unusable plugin App routes.",
+  "evidence": [
+    "PR #27602 says connector listing paths should use the projected plugin App set so ChatGPT/SIWC users see plugin-provided Apps and API-key users do not see Apps they cannot use.",
+    "`codex-rs/app-server/src/request_processors/apps_processor.rs` obtains the thread `PluginsManager`, computes `.effective_apps()`, and passes those plugin App ids into cached and fetched connector listing calls.",
+    "`codex-rs/chatgpt/src/connectors.rs` changes connector listing helpers to merge and filter remote directory connectors with caller-supplied plugin App ids.",
+    "`codex-rs/app-server/src/request_processors/plugins.rs` keeps plugin detail metadata paths from injecting plugin Apps into generic connector listing by passing an empty plugin App list there.",
+    "`codex-rs/app-server/tests/suite/v2/app_list.rs` adds `list_apps_includes_plugin_apps_for_chatgpt_auth` coverage for plugin Apps in app-server app listing.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27602.json` records 7 changed files for the merged PR."
+  ],
+  "next_actions": [
+    {
+      "reason": "Auth-aware plugin App listing affects Decodex Control Plane compatibility assumptions for App and connector visibility.",
+      "type": "upstream_impact"
+    },
+    {
+      "reason": "The change has a concrete public operator angle for plugin-provided Apps under ChatGPT/SIWC auth.",
+      "type": "social_candidate"
+    }
+  ],
+  "observed_change": "Codex app-server now merges effective plugin Apps into Apps and connector listings for ChatGPT/SIWC auth while keeping API-key-style auth from surfacing plugin Apps it cannot use.",
+  "repo": "openai/codex",
+  "reviewed_at": "2026-06-15T18:07:41Z",
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27602",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "meta": "Merged 2026-06-15T12:50:08Z",
+        "title": "[codex] Preserve plugin apps in connector listings",
+        "url": "https://github.com/openai/codex/pull/27602"
+      },
+      {
+        "kind": "commit",
+        "title": "Preserve plugin apps in connector listings",
+        "url": "https://github.com/openai/codex/commit/6a3bac99652534ee250536787b3d40061981283a"
+      },
+      {
+        "kind": "commit",
+        "title": "Inline plugin app lookup in apps list",
+        "url": "https://github.com/openai/codex/commit/e93643d804ea1f7ed68ca286fbe935e5e32ec3a1"
+      }
+    ]
+  },
+  "subject": {
+    "commit_shas": [
+      "6a3bac99652534ee250536787b3d40061981283a",
+      "e93643d804ea1f7ed68ca286fbe935e5e32ec3a1",
+      "6370a49ab0b18daeeaf3b531c4e3b0d1c645c979"
+    ],
+    "subject_id": "27602",
+    "subject_kind": "pr"
+  },
+  "user_visible_path": "In app-server Apps or connector picker listings, ChatGPT/SIWC-authenticated users can see plugin-provided Apps from effective plugin configuration; API-key-style auth does not surface those plugin Apps."
+}

--- a/artifacts/github/reviews/openai-codex-pr-27893.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27893.review.json
@@ -1,0 +1,88 @@
+{
+  "adoption_opportunity": "Treat `thread/start.selectedCapabilityRoots` as able to activate thread-scoped stdio MCP servers from selected executor plugins, and update Decodex Control Plane modeling so selected-root MCP tools are environment-owned and thread-local.",
+  "caveats": "HTTP MCP declarations remain inactive; existing sessions without selected capability roots are unchanged; selected-root persistence across resume/fork and hosted-plugin behavior remain out of scope for this PR.",
+  "changed_surfaces": [
+    "app-server extension registry",
+    "selected executor plugin MCP contributor installation",
+    "thread/start selectedCapabilityRoots initialization",
+    "thread-scoped selected plugin MCP snapshot",
+    "executor-owned stdio MCP startup",
+    "MCP status and tool-call behavior",
+    "hosted orchestrator skill provider enablement",
+    "app-server README",
+    "app-server selected executor MCP E2E tests"
+  ],
+  "community_value": "High for app-server, plugin, and MCP operators because selected capability roots now activate selected plugin stdio MCP tools in the owning environment and only for the selected thread.",
+  "compatibility_risk": "Medium for app-server clients and Control Plane tooling that assumed selected capability roots only exposed skills, or that MCP status/tool listings are independent of selected roots and owning environments.",
+  "confidence": "confirmed",
+  "control_plane_relevance": "High. Decodex Control Plane needs to recognize selected-root MCP activation, thread scoping, environment-owned filesystem and environment variable authority, and normal MCP reload behavior that must not discard frozen selected-plugin registrations.",
+  "deprecated_or_breaking_notes": "No removed public schema was found. The README now changes selectedCapabilityRoots semantics from skills-only to also starting selected plugin stdio MCP servers in the owning environment; HTTP MCP declarations stay inactive.",
+  "evidence": [
+    "PR #27893 says it closes the app-server wiring gap left by #27870 by initializing selected-plugin MCP state during `thread/start(selectedCapabilityRoots)` and exposing tools only on the selected thread.",
+    "`codex-rs/app-server/README.md` now states that selected plugin stdio MCP servers are started in the selected environment and HTTP MCP declarations remain inactive.",
+    "`codex-rs/app-server/src/extensions.rs` passes the shared `EnvironmentManager` into app-server extensions and installs `codex_mcp_extension::install_executor_plugins`.",
+    "`codex-rs/app-server/src/request_processors/thread_processor.rs` seeds executor-plugin MCP thread data whenever selected capability roots are present.",
+    "`codex-rs/app-server/tests/suite/v2/executor_mcp.rs` adds `selected_executor_plugin_exposes_its_stdio_mcp_only_to_that_thread`, covering environment-only values, model tool advertisement, direct tool call, normal MCP reload isolation, and absence from another thread.",
+    "`codex-rs/app-server/src/extensions.rs` also removes the disabled `ORCHESTRATOR_SKILLS_ENABLED` gate and installs the orchestrator skill provider; this is a secondary changed surface separate from the selected-plugin MCP public angle.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27893.json` records 10 changed files for the merged PR."
+  ],
+  "next_actions": [
+    {
+      "reason": "Selected-root MCP activation changes Decodex Control Plane capability and MCP-status assumptions.",
+      "type": "upstream_impact"
+    },
+    {
+      "reason": "The change has a clear operator-facing public angle around thread-scoped selected plugin MCP tools.",
+      "type": "social_candidate"
+    }
+  ],
+  "observed_change": "Codex app-server now activates stdio MCP servers declared by selected executor plugins when `thread/start` includes `selectedCapabilityRoots`, using the selected environment and exposing those tools only to that thread.",
+  "repo": "openai/codex",
+  "reviewed_at": "2026-06-15T18:07:41Z",
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27893",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "meta": "Merged 2026-06-15T14:23:37Z",
+        "title": "Activate selected executor plugin MCPs in app-server",
+        "url": "https://github.com/openai/codex/pull/27893"
+      },
+      {
+        "kind": "commit",
+        "title": "Activate selected executor plugin MCPs in app-server",
+        "url": "https://github.com/openai/codex/commit/06dc0abb32835ccf054f291294a84a63617e31d8"
+      },
+      {
+        "kind": "commit",
+        "title": "Restore executor MCP E2E on non-Windows",
+        "url": "https://github.com/openai/codex/commit/2d6589027994b9539faa03d958b02a9cff616dd4"
+      },
+      {
+        "kind": "commit",
+        "title": "Enable hosted orchestrator skills",
+        "url": "https://github.com/openai/codex/commit/fa0e82f1affe6653756a662114361be0f640b634"
+      }
+    ]
+  },
+  "subject": {
+    "commit_shas": [
+      "8489afd8e3f3a547b47d569cfc91a389af125b34",
+      "a7578adf4ccdae18f4cc9d3085d5aac15a431a3d",
+      "8b78cf44bc9452427916b53c2a7c1b99a2b89434",
+      "b7180839381890e258ba75bfbf2b825b5064a41f",
+      "06dc0abb32835ccf054f291294a84a63617e31d8",
+      "3964452256ff004a84e64a9299c041bce345b78b",
+      "191de6246942e5413e22b5087e4c8be6c185db9f",
+      "fa0e82f1affe6653756a662114361be0f640b634",
+      "b62eff83f23faf457c6f5072af70af7446b3bce1",
+      "cf3b08f03d6598c0edd7f60403bf5f92f3a0ca4b",
+      "3d139253da3a4725655a0d1641a60f08c7b17903",
+      "2d6589027994b9539faa03d958b02a9cff616dd4"
+    ],
+    "subject_id": "27893",
+    "subject_kind": "pr"
+  },
+  "user_visible_path": "An app-server client can start a thread with selected capability roots; selected plugin stdio MCP servers are started in the owning environment, listed for that thread, and callable as MCP tools, while another thread without the selected root does not see them."
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27461.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27461.json
@@ -1,0 +1,51 @@
+{
+  "audience": "Codex plugin authors and operators evaluating dual App/MCP auth behavior",
+  "candidate_text": [
+    "Codex PR #27461 makes plugin MCP loading auth-aware: ChatGPT/SIWC auth suppresses same-name App-route MCP OAuth, while API-key/direct auth keeps MCP servers visible. https://github.com/openai/codex/pull/27461"
+  ],
+  "channel": "x",
+  "claims": [
+    {
+      "confidence": "confirmed",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27461.review.json",
+      "text": "Codex filters same-name plugin MCP servers for ChatGPT/SIWC auth when a plugin App route exists."
+    },
+    {
+      "confidence": "confirmed",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27461.json",
+      "text": "API-key/direct auth preserves plugin MCP server visibility and OAuth behavior."
+    },
+    {
+      "confidence": "confirmed",
+      "evidence": "artifacts/github/bundles/openai-codex-pr-27461.json",
+      "text": "The app-server install path passes auth mode into the plugin MCP loader before MCP OAuth startup."
+    }
+  ],
+  "decision": {
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27461:practical-explainer:publish",
+    "reason": "The source-backed auth-routing behavior has concrete value for dual App/MCP plugin authors.",
+    "worthiness": "publish"
+  },
+  "evidence_notes": [
+    "PR #27461 says plugin MCP loading should reflect the MCPs available for the current auth route.",
+    "The source review records the loader and app-server install path that enforce same-name filtering.",
+    "The impact artifact classifies this as a Control Plane compatibility risk with a practical public angle."
+  ],
+  "mode": "practical_explainer",
+  "priority": "high",
+  "repo": "openai/codex",
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27461",
+  "source_refs": {
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27461.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27461.review.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27461"
+    ]
+  },
+  "target_account": "decodexspace"
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27602.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27602.json
@@ -1,0 +1,51 @@
+{
+  "audience": "Codex plugin authors and operators tracking auth-aware App listings",
+  "candidate_text": [
+    "Codex PR #27602 keeps plugin-provided Apps visible in app and connector listings for ChatGPT/SIWC auth, while API-key auth avoids Apps it cannot use. https://github.com/openai/codex/pull/27602"
+  ],
+  "channel": "x",
+  "claims": [
+    {
+      "confidence": "confirmed",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27602.review.json",
+      "text": "Codex app-server now includes effective plugin Apps in app and connector listing paths for ChatGPT/SIWC auth."
+    },
+    {
+      "confidence": "confirmed",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27602.json",
+      "text": "API-key-style auth does not surface plugin Apps that route through ChatGPT/SIWC."
+    },
+    {
+      "confidence": "confirmed",
+      "evidence": "artifacts/github/bundles/openai-codex-pr-27602.json",
+      "text": "The behavior is backed by app-server app-list and connector-listing source changes."
+    }
+  ],
+  "decision": {
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27602:practical-explainer:publish",
+    "reason": "Source-backed auth-aware plugin App listing is useful to plugin authors and app-server operators.",
+    "worthiness": "publish"
+  },
+  "evidence_notes": [
+    "PR #27602 states ChatGPT/SIWC users should still see plugin-provided Apps in Apps and connector picker surfaces.",
+    "The source review records the app-server path that passes effective plugin Apps into connector listing.",
+    "The impact artifact classifies this as a Control Plane compatibility risk with a practical public angle."
+  ],
+  "mode": "practical_explainer",
+  "priority": "high",
+  "repo": "openai/codex",
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27602",
+  "source_refs": {
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27602.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27602.review.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27602"
+    ]
+  },
+  "target_account": "decodexspace"
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27893.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27893.json
@@ -1,0 +1,55 @@
+{
+  "audience": "Codex app-server, plugin, and MCP operators",
+  "candidate_text": [
+    "Codex PR #27893 makes selected capability roots activate thread-scoped stdio MCP servers from selected executor plugins through app-server. HTTP MCP declarations stay inactive. https://github.com/openai/codex/pull/27893"
+  ],
+  "caveats": [
+    "Only stdio MCP declarations are active in this PR.",
+    "Do not claim resume/fork persistence or hosted-plugin behavior changed beyond the source-backed review."
+  ],
+  "channel": "x",
+  "claims": [
+    {
+      "confidence": "confirmed",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27893.review.json",
+      "text": "Selected capability roots can now activate selected plugin stdio MCP servers through app-server."
+    },
+    {
+      "confidence": "confirmed",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27893.json",
+      "text": "Selected plugin MCP tools are scoped to the selected thread and owning environment."
+    },
+    {
+      "confidence": "confirmed",
+      "evidence": "artifacts/github/bundles/openai-codex-pr-27893.json",
+      "text": "HTTP MCP declarations remain inactive for selected plugin activation in this PR."
+    }
+  ],
+  "decision": {
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27893:operator-impact:publish",
+    "reason": "The merged app-server behavior has clear operator value and source-backed tests.",
+    "worthiness": "publish"
+  },
+  "evidence_notes": [
+    "PR #27893 states selected plugin stdio MCP servers start in the selected environment and are exposed only on the selected thread.",
+    "The source review records README, extension registration, thread initialization, and E2E evidence.",
+    "The impact artifact classifies this as a Control Plane candidate with an operator-impact public angle."
+  ],
+  "mode": "operator_impact",
+  "priority": "critical",
+  "repo": "openai/codex",
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27893",
+  "source_refs": {
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27893.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27893.review.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27893"
+    ]
+  },
+  "target_account": "decodexspace"
+}


### PR DESCRIPTION
## Summary

- Refreshed `artifacts/github/review-queue/openai-codex-latest.json` from the deterministic upstream review queue.
- Added GitHub change bundles, source-backed `upstream_review/v1`, `upstream_impact/v1`, and `social_candidate/v1` artifacts for openai/codex PRs 27602, 27461, and 27893.
- Wrote only Publisher handoff candidates; no `social_post/v1` records were written and nothing was published to X.

## Reviewed subjects

- openai/codex#27602: auth-aware plugin App visibility in app/connector listings.
- openai/codex#27461: auth-aware dual App/MCP plugin MCP OAuth filtering.
- openai/codex#27893: selected executor plugin stdio MCP activation through app-server `selectedCapabilityRoots`.

## Validation

- `cargo run -p decodex --bin decodex -- radar validate` -> `OK (539 Radar artifact JSON files validated)`
- `jq empty` on the changed queue, bundle, review, impact, and social-candidate JSON artifacts.
- Candidate text lengths checked at 219, 192, and 208 characters.

## Notes

The diff is limited to allowed Radar artifact paths under `artifacts/github/review-queue/`, `artifacts/github/bundles/`, `artifacts/github/reviews/`, `artifacts/github/impact/`, and `artifacts/github/social-candidates/`.
