### PR TITLE
Persist Decodex X PR 27961 reservation

### DIFF
--- a/artifacts/social/x/posts/2026-06-16/openai-codex-pr-27961.json
+++ b/artifacts/social/x/posts/2026-06-16/openai-codex-pr-27961.json
@@ -1,0 +1,102 @@
+{
+  "audience": "Control Plane operators managing Codex remote-control policy",
+  "caveats": [
+    "Do not imply remote control was removed.",
+    "Do not imply managed disable deletes a persisted user preference.",
+    "Keep the claim scoped to managed requirements and app-server remote-control policy.",
+    "No generated image was used because this was a single non-release operator-impact post with sufficient reader value from the text and source card."
+  ],
+  "channel": "x",
+  "claims": [
+    {
+      "confidence": "confirmed",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27961.review.json",
+      "text": "Codex exposes managed remote-control allow/deny policy through app-server config requirements."
+    },
+    {
+      "confidence": "confirmed",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27961.json",
+      "text": "Managed remote-control denial is a Control Plane compatibility risk."
+    },
+    {
+      "confidence": "confirmed",
+      "evidence": "https://x.com/decodexspace/status/2066596585094762728",
+      "text": "The PR #27961 operator-impact post is live on @decodexspace."
+    }
+  ],
+  "controller_account": "hackink",
+  "decision": {
+    "daily_count_after": 1,
+    "daily_count_before": 0,
+    "daily_limit": 8,
+    "day": "2026-06-16",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27961:operator_impact",
+    "priority": "critical",
+    "reason": "The change has a concrete managed-deployment Control Plane compatibility angle with direct source links.",
+    "timezone": "Asia/Shanghai",
+    "worthiness": "publish"
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish, priority critical, and mode operator_impact for openai-codex-pr-27961.",
+    "The upstream_review/v1 artifact confirms managed requirements add allowRemoteControl, remote-control startup captures disabled policy, and remoteControl RPCs are rejected under managed disable.",
+    "The upstream_impact/v1 artifact marks the change as public_signal_decision publish, control_plane_impact compat_risk, and publisher_angle operator_impact.",
+    "The x-post-quality-system gate passed because the post states what changed, who can act on it, and the direct GitHub PR source that proves it; the checked text was 275 characters and fit in X compose.",
+    "The release publisher gates were not applicable because this is a non-release operator_impact candidate.",
+    "Official OpenAI Codex changelog readback for this run showed Codex app 26.609 on 2026-06-11 as the newest official app entry; this post is based on checked PR review/impact artifacts, not an app changelog claim.",
+    "Checked durable social_post/v1 records contained no published or blocked record for this slug or idempotency key before publication.",
+    "Checked durable social_publish_reservation/v1 records contained no active reservation for this idempotency key before the new reservation was created.",
+    "Open GitHub PR readback with routed hackink credentials found no open publication PR touching this candidate or social/x records before reservation.",
+    "PR #393 made the active reservation visible before X compose; GitHub PR readback confirmed the PR was open, non-draft, targeted main, and contained the reservation file before compose.",
+    "Chrome account-menu/profile readback initially showed @hackink, then the account switcher exposed an existing @decodexspace session; after switching, Chrome readback showed active account @decodexspace.",
+    "Bounded @decodexspace profile readback and focused X search before reservation found no 27961, allowRemoteControl, allow_remote_control, remoteControl, source URL, or lead-text duplicate.",
+    "Live @decodexspace profile readback after the PR-visible reservation and immediately before clicking Post showed active @decodexspace, recent profile statuses, and no candidate text match; focused X search returned no results for the candidate duplicate keys.",
+    "The compose dialog showed @decodexspace active and the checked PR #27961 text before the enabled X compose button was clicked.",
+    "Home timeline readback immediately after posting showed a new @decodexspace status with the expected managed remote-control policy text and GitHub source card.",
+    "Permalink readback showed the expected @decodexspace post text, Automated by @hackink attribution, GitHub PR card for openai/codex PR #27961, and no uploaded /photo/N media link.",
+    "Profile readback showed the expected @decodexspace post as the newest profile post with the GitHub PR #27961 card and no uploaded /photo/N media link.",
+    "The status ID decodes to 2026-06-15T18:59:56.051Z, which is 2026-06-16 02:59:56 in Asia/Shanghai."
+  ],
+  "media_refs": [
+    "media_caveat: no generated media was attached; this non-release operator_impact post remains valuable text-only because the source-backed remote-control policy caveat and GitHub PR card are the reader value."
+  ],
+  "mode": "operator_impact",
+  "post_lifecycle": {
+    "current_state": "live",
+    "quote_eligible": false,
+    "reason": "This is a standalone operator-impact post, not a prerelease quote-chain anchor."
+  },
+  "publication": {
+    "account_verified": true,
+    "made_with_ai": false,
+    "posted_at": "2026-06-15T18:59:56.051Z",
+    "published_urls": [
+      "https://x.com/decodexspace/status/2066596585094762728"
+    ],
+    "publisher": "chrome"
+  },
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-27961",
+  "source_refs": {
+    "reservations": [
+      "artifacts/social/x/reservations/2026-06-16/openai-codex-pr-27961.json"
+    ],
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27961.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27961.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27961.review.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27961",
+      "https://x.com/decodexspace/status/2066596585094762728"
+    ]
+  },
+  "status": "published",
+  "target_account": "decodexspace",
+  "text": [
+    "Codex now lets managed deployments force remote control off with `allow_remote_control = false`; app-server exposes `allowRemoteControl` and rejects `remoteControl/*` RPCs under policy. Control Plane operators should gate on it. PR: https://github.com/openai/codex/pull/27961"
+  ]
+}

--- a/artifacts/social/x/reservations/2026-06-16/openai-codex-pr-27961.json
+++ b/artifacts/social/x/reservations/2026-06-16/openai-codex-pr-27961.json
@@ -30,7 +30,8 @@
     "Checked social_publish_reservation/v1 records contain no active reservation for the idempotency key.",
     "Open GitHub PR scan found no publication PR touching this candidate or social/x records.",
     "Chrome readback showed active account @decodexspace before reservation.",
-    "Chrome profile scan and focused X search for 27961, allowRemoteControl, allow_remote_control, and remoteControl found no duplicate post."
+    "Chrome profile scan and focused X search for 27961, allowRemoteControl, allow_remote_control, and remoteControl found no duplicate post.",
+    "PR #393 made this active reservation visible before X compose."
   ],
   "expires_at": "2026-06-15T20:56:31Z",
   "idempotency_key": "x:decodexspace:openai-codex-pr-27961:operator_impact",
@@ -38,6 +39,7 @@
   "owner": {
     "automation_id": "decodex-x-publisher",
     "branch": "automation/x-publisher-pr27961-20260616",
+    "pr_url": "https://github.com/hack-ink/decodex/pull/393",
     "run_started_at": "2026-06-15T18:56:31Z"
   },
   "reserved_at": "2026-06-15T18:56:31Z",

--- a/artifacts/social/x/reservations/2026-06-16/openai-codex-pr-27961.json
+++ b/artifacts/social/x/reservations/2026-06-16/openai-codex-pr-27961.json
@@ -15,6 +15,7 @@
   },
   "channel": "x",
   "controller_account": "hackink",
+  "consumed_by_social_post": "artifacts/social/x/posts/2026-06-16/openai-codex-pr-27961.json",
   "day": "2026-06-16",
   "duplicate_keys": [
     "x:decodexspace:openai-codex-pr-27961:operator_impact",
@@ -45,7 +46,7 @@
   "reserved_at": "2026-06-15T18:56:31Z",
   "schema": "social_publish_reservation/v1",
   "slug": "openai-codex-pr-27961",
-  "status": "active",
+  "status": "consumed",
   "target_account": "decodexspace",
   "timezone": "Asia/Shanghai"
 }

--- a/artifacts/social/x/reservations/2026-06-16/openai-codex-pr-27961.json
+++ b/artifacts/social/x/reservations/2026-06-16/openai-codex-pr-27961.json
@@ -1,0 +1,49 @@
+{
+  "candidate_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-27961.json"
+    ],
+    "source_urls": [
+      "https://github.com/openai/codex/pull/27961"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27961.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27961.review.json"
+    ]
+  },
+  "channel": "x",
+  "controller_account": "hackink",
+  "day": "2026-06-16",
+  "duplicate_keys": [
+    "x:decodexspace:openai-codex-pr-27961:operator_impact",
+    "openai-codex-pr-27961",
+    "https://github.com/openai/codex/pull/27961",
+    "27961",
+    "allowRemoteControl",
+    "allow_remote_control",
+    "remoteControl/*"
+  ],
+  "evidence_notes": [
+    "Checked social_post/v1 records contain no published or blocked record for the idempotency key.",
+    "Checked social_publish_reservation/v1 records contain no active reservation for the idempotency key.",
+    "Open GitHub PR scan found no publication PR touching this candidate or social/x records.",
+    "Chrome readback showed active account @decodexspace before reservation.",
+    "Chrome profile scan and focused X search for 27961, allowRemoteControl, allow_remote_control, and remoteControl found no duplicate post."
+  ],
+  "expires_at": "2026-06-15T20:56:31Z",
+  "idempotency_key": "x:decodexspace:openai-codex-pr-27961:operator_impact",
+  "mode": "operator_impact",
+  "owner": {
+    "automation_id": "decodex-x-publisher",
+    "branch": "automation/x-publisher-pr27961-20260616",
+    "run_started_at": "2026-06-15T18:56:31Z"
+  },
+  "reserved_at": "2026-06-15T18:56:31Z",
+  "schema": "social_publish_reservation/v1",
+  "slug": "openai-codex-pr-27961",
+  "status": "active",
+  "target_account": "decodexspace",
+  "timezone": "Asia/Shanghai"
+}


### PR DESCRIPTION
## Summary
- add the PR 27961 Decodex X publication reservation for the 2026-06-16 Asia/Shanghai cap day
- keep the reservation thin: lease, source refs, duplicate keys, owner metadata, and pre-compose evidence only

## Validation
- `cargo run -p decodex --bin decodex -- radar validate artifacts/github/social-candidates artifacts/social/x`

## Publication gate
- candidate: `artifacts/github/social-candidates/openai-codex-pr-27961.json`
- decision.worthiness: `publish`
- target account readback: Chrome active account showed `Decodex @decodexspace` before reservation
- duplicate gate: checked records/open PRs/profile/X search had no 27961 or remote-control policy duplicate
- media: no generated media planned; non-release operator-impact post remains valuable text-only with the GitHub PR card
