### PR TITLE
Persist upstream Radar review artifacts

### DIFF
--- a/artifacts/github/bundles/openai-codex-pr-27371.json
+++ b/artifacts/github/bundles/openai-codex-pr-27371.json
@@ -1,0 +1,223 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "sayan-oai",
+      "committed_at": "2026-06-10T09:48:42Z",
+      "message": "Expose explicit dynamic tool namespaces in thread start",
+      "sha": "54610fec006e76c51d30f2fe5b90001c48632288",
+      "url": "https://github.com/openai/codex/commit/54610fec006e76c51d30f2fe5b90001c48632288"
+    },
+    {
+      "author": "sayan-oai",
+      "committed_at": "2026-06-11T05:13:44Z",
+      "message": "Simplify dynamic tool test fixtures",
+      "sha": "eefdd863d8d8fbb4c3d6bc06f9b4a0b0b296a8e5",
+      "url": "https://github.com/openai/codex/commit/eefdd863d8d8fbb4c3d6bc06f9b4a0b0b296a8e5"
+    },
+    {
+      "author": "sayan-oai",
+      "committed_at": "2026-06-11T05:35:07Z",
+      "message": "Fix dynamic tool argument comments",
+      "sha": "39eabddc46a763edc22f33f1f7013249f01d4a93",
+      "url": "https://github.com/openai/codex/commit/39eabddc46a763edc22f33f1f7013249f01d4a93"
+    },
+    {
+      "author": "sayan-oai",
+      "committed_at": "2026-06-11T08:50:27Z",
+      "message": "Validate dynamic tool namespace inputs",
+      "sha": "87fa3a6a5bc08f91c630c4990a42869ed064c86a",
+      "url": "https://github.com/openai/codex/commit/87fa3a6a5bc08f91c630c4990a42869ed064c86a"
+    },
+    {
+      "author": "sayan-oai",
+      "committed_at": "2026-06-12T08:22:46Z",
+      "message": "Reject invalid dynamic tool namespace formats",
+      "sha": "11867f161e889c8095d6970f151308263bc2d462",
+      "url": "https://github.com/openai/codex/commit/11867f161e889c8095d6970f151308263bc2d462"
+    },
+    {
+      "author": "sayan-oai",
+      "committed_at": "2026-06-12T19:04:44Z",
+      "message": "Cover duplicate dynamic tool namespaces",
+      "sha": "fe2b08e0b90598c0648ddba0b27e5341a6754212",
+      "url": "https://github.com/openai/codex/commit/fe2b08e0b90598c0648ddba0b27e5341a6754212"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [
+    "codex-rs/app-server/README.md"
+  ],
+  "examples_refs": [],
+  "extracted_flags": [
+    "API",
+    "GENERATED",
+    "CODE",
+    "NOT",
+    "MODIFY",
+    "HAND",
+    "V2U",
+    "--dynamic-tools",
+    "JSON",
+    "ABC",
+    "DYNAMIC_TOOL_NAME_MAX_LEN",
+    "DYNAMIC_TOOL_NAMESPACE_MAX_LEN",
+    "DYNAMIC_TOOL_NAMESPACE_DESCRIPTION_MAX_LEN",
+    "DYNAMIC_TOOL_IDENTIFIER_PATTERN",
+    "RESERVED_RESPONSES_NAMESPACES",
+    "DEFAULT_READ_TIMEOUT",
+    "JSONRPCR"
+  ],
+  "files": [
+    {
+      "additions": 93,
+      "deletions": 22,
+      "patch_excerpt": "@@ -635,31 +635,102 @@\n       ],\n       \"type\": \"string\"\n     },\n+    \"DynamicToolNamespaceTool\": {\n+      \"oneOf\": [\n+        {\n+          \"properties\": {\n+            \"deferLoading\": {\n+              \"type\": \"boolean\"\n+            },\n+            \"description\": {\n+              \"type\": \"string\"\n+            },\n+            \"inputSchema\": true,\n+            \"name\": {\n+              \"type\": \"string\"\n+            },\n+            \"type\": {\n+              \"enum\": [\n+                \"function\"\n+              ],\n+              \"title\": \"FunctionDynamicToolNamespaceToolType\",\n+              \"type\": \"string\"\n+            }\n+          },\n+          \"required\": [\n+            \"description\",\n+            \"inputSchema\",\n+            \"name\",\n+            \"type\"\n+          ],\n+          \"title\": \"FunctionDynamicToolNamespaceTool\",\n+          \"type\": \"object\"\n+        }\n+      ]\n+    },\n     \"DynamicT...",
+      "path": "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
+      "status": "modified"
+    },
+    {
+      "additions": 93,
+      "deletions": 22,
+      "patch_excerpt": "@@ -8646,31 +8646,102 @@\n         ],\n         \"type\": \"string\"\n       },\n+      \"DynamicToolNamespaceTool\": {\n+        \"oneOf\": [\n+          {\n+            \"properties\": {\n+              \"deferLoading\": {\n+                \"type\": \"boolean\"\n+              },\n+              \"description\": {\n+                \"type\": \"string\"\n+              },\n+              \"inputSchema\": true,\n+              \"name\": {\n+                \"type\": \"string\"\n+              },\n+              \"type\": {\n+                \"enum\": [\n+                  \"function\"\n+                ],\n+                \"title\": \"FunctionDynamicToolNamespaceToolType\",\n+                \"type\": \"string\"\n+              }\n+            },\n+            \"required\": [\n+              \"description\",\n+              \"inputSchema\",\n+              \"name\",\n+              \"type\"\n+            ],\n+            \"title\": \"FunctionDynamicToolNamespaceTool\",\n+   ...",
+      "path": "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+      "status": "modified"
+    },
+    {
+      "additions": 93,
+      "deletions": 22,
+      "patch_excerpt": "@@ -4959,31 +4959,102 @@\n       ],\n       \"type\": \"string\"\n     },\n+    \"DynamicToolNamespaceTool\": {\n+      \"oneOf\": [\n+        {\n+          \"properties\": {\n+            \"deferLoading\": {\n+              \"type\": \"boolean\"\n+            },\n+            \"description\": {\n+              \"type\": \"string\"\n+            },\n+            \"inputSchema\": true,\n+            \"name\": {\n+              \"type\": \"string\"\n+            },\n+            \"type\": {\n+              \"enum\": [\n+                \"function\"\n+              ],\n+              \"title\": \"FunctionDynamicToolNamespaceToolType\",\n+              \"type\": \"string\"\n+            }\n+          },\n+          \"required\": [\n+            \"description\",\n+            \"inputSchema\",\n+            \"name\",\n+            \"type\"\n+          ],\n+          \"title\": \"FunctionDynamicToolNamespaceTool\",\n+          \"type\": \"object\"\n+        }\n+      ]\n+    },\n     \"Dynami...",
+      "path": "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+      "status": "modified"
+    },
+    {
+      "additions": 93,
+      "deletions": 22,
+      "patch_excerpt": "@@ -94,31 +94,102 @@\n         }\n       ]\n     },\n+    \"DynamicToolNamespaceTool\": {\n+      \"oneOf\": [\n+        {\n+          \"properties\": {\n+            \"deferLoading\": {\n+              \"type\": \"boolean\"\n+            },\n+            \"description\": {\n+              \"type\": \"string\"\n+            },\n+            \"inputSchema\": true,\n+            \"name\": {\n+              \"type\": \"string\"\n+            },\n+            \"type\": {\n+              \"enum\": [\n+                \"function\"\n+              ],\n+              \"title\": \"FunctionDynamicToolNamespaceToolType\",\n+              \"type\": \"string\"\n+            }\n+          },\n+          \"required\": [\n+            \"description\",\n+            \"inputSchema\",\n+            \"name\",\n+            \"type\"\n+          ],\n+          \"title\": \"FunctionDynamicToolNamespaceTool\",\n+          \"type\": \"object\"\n+        }\n+      ]\n+    },\n     \"DynamicToolSpec\": {\n-   ...",
+      "path": "codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json",
+      "status": "modified"
+    },
+    {
+      "additions": 6,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,6 @@\n+// GENERATED CODE! DO NOT MODIFY BY HAND!\n+\n+// This file was generated by [ts-rs](https://github.com/Aleph-Alpha/ts-rs). Do not edit this file manually.\n+import type { JsonValue } from \"../serde_json/JsonValue\";\n+\n+export type DynamicToolFunctionSpec = { name: string, description: string, inputSchema: JsonValue, deferLoading?: boolean, };",
+      "path": "codex-rs/app-server-protocol/schema/typescript/v2/DynamicToolFunctionSpec.ts",
+      "status": "added"
+    },
+    {
+      "additions": 6,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,6 @@\n+// GENERATED CODE! DO NOT MODIFY BY HAND!\n+\n+// This file was generated by [ts-rs](https://github.com/Aleph-Alpha/ts-rs). Do not edit this file manually.\n+import type { DynamicToolNamespaceTool } from \"./DynamicToolNamespaceTool\";\n+\n+export type DynamicToolNamespaceSpec = { name: string, description: string, tools: Array<DynamicToolNamespaceTool>, };",
+      "path": "codex-rs/app-server-protocol/schema/typescript/v2/DynamicToolNamespaceSpec.ts",
+      "status": "added"
+    },
+    {
+      "additions": 6,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,6 @@\n+// GENERATED CODE! DO NOT MODIFY BY HAND!\n+\n+// This file was generated by [ts-rs](https://github.com/Aleph-Alpha/ts-rs). Do not edit this file manually.\n+import type { DynamicToolFunctionSpec } from \"./DynamicToolFunctionSpec\";\n+\n+export type DynamicToolNamespaceTool = { \"type\": \"function\" } & DynamicToolFunctionSpec;",
+      "path": "codex-rs/app-server-protocol/schema/typescript/v2/DynamicToolNamespaceTool.ts",
+      "status": "added"
+    },
+    {
+      "additions": 3,
+      "deletions": 2,
+      "patch_excerpt": "@@ -1,6 +1,7 @@\n // GENERATED CODE! DO NOT MODIFY BY HAND!\n \n // This file was generated by [ts-rs](https://github.com/Aleph-Alpha/ts-rs). Do not edit this file manually.\n-import type { JsonValue } from \"../serde_json/JsonValue\";\n+import type { DynamicToolFunctionSpec } from \"./DynamicToolFunctionSpec\";\n+import type { DynamicToolNamespaceSpec } from \"./DynamicToolNamespaceSpec\";\n \n-export type DynamicToolSpec = { namespace?: string, name: string, description: string, inputSchema: JsonValue, deferLoading?: boolean, };\n+export type DynamicToolSpec = { \"type\": \"function\" } & DynamicToolFunctionSpec | { \"type\": \"namespace\" } & DynamicToolNamespaceSpec;",
+      "path": "codex-rs/app-server-protocol/schema/typescript/v2/DynamicToolSpec.ts",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 0,
+      "patch_excerpt": "@@ -92,6 +92,9 @@ export type { DynamicToolCallOutputContentItem } from \"./DynamicToolCallOutputCo\n export type { DynamicToolCallParams } from \"./DynamicToolCallParams\";\n export type { DynamicToolCallResponse } from \"./DynamicToolCallResponse\";\n export type { DynamicToolCallStatus } from \"./DynamicToolCallStatus\";\n+export type { DynamicToolFunctionSpec } from \"./DynamicToolFunctionSpec\";\n+export type { DynamicToolNamespaceSpec } from \"./DynamicToolNamespaceSpec\";\n+export type { DynamicToolNamespaceTool } from \"./DynamicToolNamespaceTool\";\n export type { DynamicToolSpec } from \"./DynamicToolSpec\";\n export type { ErrorNotification } from \"./ErrorNotification\";\n export type { ExecPolicyAmendment } from \"./ExecPolicyAmendment\";",
+      "path": "codex-rs/app-server-protocol/schema/typescript/v2/index.ts",
+      "status": "modified"
+    },
+    {
+      "additions": 0,
+      "deletions": 50,
+      "patch_excerpt": "@@ -3531,56 +3531,6 @@ fn dynamic_tool_response_serializes_text_and_image_content_items() {\n     );\n }\n \n-#[test]\n-fn dynamic_tool_spec_deserializes_defer_loading() {\n-    let value = json!({\n-        \"name\": \"lookup_ticket\",\n-        \"description\": \"Fetch a ticket\",\n-        \"inputSchema\": {\n-            \"type\": \"object\",\n-            \"properties\": {\n-                \"id\": { \"type\": \"string\" }\n-            }\n-        },\n-        \"deferLoading\": true,\n-    });\n-\n-    let actual: DynamicToolSpec = serde_json::from_value(value).expect(\"deserialize\");\n-\n-    assert_eq!(\n-        actual,\n-        DynamicToolSpec {\n-            namespace: None,\n-            name: \"lookup_ticket\".to_string(),\n-            description: \"Fetch a ticket\".to_string(),\n-            input_schema: json!({\n-                \"type\": \"object\",\n-                \"properties\": {\n-                    \"id\": { \"type\": \"string\"...",
+      "path": "codex-rs/app-server-protocol/src/protocol/v2/tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 8,
+      "deletions": 49,
+      "patch_excerpt": "@@ -16,6 +16,10 @@ pub use codex_protocol::capabilities::SelectedCapabilityRoot;\n use codex_protocol::config_types::CollaborationMode;\n use codex_protocol::config_types::Personality;\n use codex_protocol::config_types::ReasoningSummary;\n+pub use codex_protocol::dynamic_tools::DynamicToolFunctionSpec;\n+pub use codex_protocol::dynamic_tools::DynamicToolNamespaceSpec;\n+pub use codex_protocol::dynamic_tools::DynamicToolNamespaceTool;\n+pub use codex_protocol::dynamic_tools::DynamicToolSpec;\n use codex_protocol::models::ResponseItem;\n use codex_protocol::openai_models::ReasoningEffort;\n use codex_protocol::protocol::ThreadGoalStatus as CoreThreadGoalStatus;\n@@ -38,55 +42,6 @@ pub enum ThreadStartSource {\n     Clear,\n }\n \n-#[derive(Serialize, Debug, Clone, PartialEq, JsonSchema, TS)]\n-#[serde(rename_all = \"camelCase\")]\n-#[ts(export_to = \"v2/\")]\n-pub struct DynamicToolSpec {\n-    #[ts(optional)]\n...",
+      "path": "codex-rs/app-server-protocol/src/protocol/v2/thread.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 6,
+      "deletions": 4,
+      "patch_excerpt": "@@ -70,6 +70,7 @@ use codex_app_server_protocol::UserInput as V2UserInput;\n use codex_core::config::Config;\n use codex_otel::OtelProvider;\n use codex_otel::current_span_w3c_trace_context;\n+use codex_protocol::dynamic_tools::normalize_dynamic_tool_specs;\n use codex_protocol::openai_models::ReasoningEffort;\n use codex_protocol::protocol::W3cTraceContext;\n use codex_utils_cli::CliConfigOverrides;\n@@ -135,7 +136,7 @@ struct Cli {\n     /// Prefix a filename with '@' to read from a file.\n     ///\n     /// Example:\n-    ///   --dynamic-tools '[{\"name\":\"demo\",\"description\":\"Demo\",\"inputSchema\":{\"type\":\"object\"}}]'\n+    ///   --dynamic-tools '[{\"type\":\"function\",\"name\":\"demo\",\"description\":\"Demo\",\"inputSchema\":{\"type\":\"object\"}}]'\n     ///   --dynamic-tools @/path/to/tools.json\n     #[arg(long, value_name = \"json-or-@file\", global = true)]\n     dynamic_tools: Option<String>,\n@@ -1373,11 +1374,12 ...",
+      "path": "codex-rs/app-server-test-client/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 24,
+      "deletions": 14,
+      "patch_excerpt": "@@ -271,16 +271,24 @@ Start a fresh thread when you need a new Codex conversation.\n     // Experimental: requires opt-in\n     \"dynamicTools\": [\n         {\n-            \"name\": \"lookup_ticket\",\n-            \"description\": \"Fetch a ticket by id\",\n-            \"deferLoading\": true,\n-            \"inputSchema\": {\n-                \"type\": \"object\",\n-                \"properties\": {\n-                    \"id\": { \"type\": \"string\" }\n-                },\n-                \"required\": [\"id\"]\n-            }\n+            \"type\": \"namespace\",\n+            \"name\": \"tickets\",\n+            \"description\": \"Ticket management tools\",\n+            \"tools\": [\n+                {\n+                    \"type\": \"function\",\n+                    \"name\": \"lookup_ticket\",\n+                    \"description\": \"Fetch a ticket by id\",\n+                    \"deferLoading\": true,\n+                    \"inputSchema\": {\n+          ...",
+      "path": "codex-rs/app-server/README.md",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 3,
+      "patch_excerpt": "@@ -54,7 +54,9 @@ use codex_app_server_protocol::CommandExecWriteParams;\n use codex_app_server_protocol::ConfigWarningNotification;\n use codex_app_server_protocol::ConversationGitInfo;\n use codex_app_server_protocol::ConversationSummary;\n-use codex_app_server_protocol::DynamicToolSpec as ApiDynamicToolSpec;\n+use codex_app_server_protocol::DynamicToolFunctionSpec;\n+use codex_app_server_protocol::DynamicToolNamespaceTool;\n+use codex_app_server_protocol::DynamicToolSpec;\n use codex_app_server_protocol::EnvironmentAddParams;\n use codex_app_server_protocol::EnvironmentAddResponse;\n use codex_app_server_protocol::ExperimentalFeature as ApiExperimentalFeature;\n@@ -377,8 +379,6 @@ use codex_protocol::config_types::Personality;\n use codex_protocol::config_types::ReasoningSummary;\n use codex_protocol::config_types::TrustLevel;\n use codex_protocol::config_types::WindowsSandboxLevel;\n-use codex_prot...",
+      "path": "codex-rs/app-server/src/request_processors.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 77,
+      "deletions": 59,
+      "patch_excerpt": "@@ -195,9 +195,10 @@ fn has_model_resume_override(\n             .is_some_and(|overrides| overrides.contains_key(\"model_reasoning_effort\"))\n }\n \n-fn validate_dynamic_tools(tools: &[ApiDynamicToolSpec]) -> Result<(), String> {\n+fn validate_dynamic_tools(tools: &[DynamicToolSpec]) -> Result<(), String> {\n     const DYNAMIC_TOOL_NAME_MAX_LEN: usize = 128;\n     const DYNAMIC_TOOL_NAMESPACE_MAX_LEN: usize = 64;\n+    const DYNAMIC_TOOL_NAMESPACE_DESCRIPTION_MAX_LEN: usize = 1024;\n     const DYNAMIC_TOOL_IDENTIFIER_PATTERN: &str = \"^[a-zA-Z0-9_-]+$\";\n     const RESERVED_RESPONSES_NAMESPACES: &[&str] = &[\n         \"api_tool\",\n@@ -243,8 +244,11 @@ fn validate_dynamic_tools(tools: &[ApiDynamicToolSpec]) -> Result<(), String> {\n         Ok(())\n     }\n \n-    let mut seen = HashSet::new();\n-    for tool in tools {\n+    fn validate_dynamic_tool<'a>(\n+        tool: &'a DynamicToolFunctionSpec,\n+        ...",
+      "path": "codex-rs/app-server/src/request_processors/thread_processor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 131,
+      "deletions": 117,
+      "patch_excerpt": "@@ -142,128 +142,143 @@ mod thread_processor_behavior_tests {\n     use codex_utils_absolute_path::test_support::PathBufExt;\n     use codex_utils_absolute_path::test_support::test_path_buf;\n     use pretty_assertions::assert_eq;\n+    use serde_json::Value;\n     use serde_json::json;\n     use std::collections::BTreeMap;\n     use std::path::PathBuf;\n     use std::sync::Arc;\n     use tempfile::TempDir;\n \n+    fn dynamic_tool(\n+        namespace: Option<&str>,\n+        name: impl Into<String>,\n+        input_schema: Value,\n+        defer_loading: bool,\n+    ) -> DynamicToolSpec {\n+        let function = DynamicToolFunctionSpec {\n+            name: name.into(),\n+            description: \"test\".to_string(),\n+            input_schema,\n+            defer_loading,\n+        };\n+        match namespace {\n+            Some(namespace) => {\n+                DynamicToolSpec::Namespace(codex_app_server_p...",
+      "path": "codex-rs/app-server/src/request_processors/thread_processor_tests.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 172,
+      "deletions": 121,
+      "patch_excerpt": "@@ -8,6 +8,9 @@ use codex_app_server_protocol::DynamicToolCallOutputContentItem;\n use codex_app_server_protocol::DynamicToolCallParams;\n use codex_app_server_protocol::DynamicToolCallResponse;\n use codex_app_server_protocol::DynamicToolCallStatus;\n+use codex_app_server_protocol::DynamicToolFunctionSpec;\n+use codex_app_server_protocol::DynamicToolNamespaceSpec;\n+use codex_app_server_protocol::DynamicToolNamespaceTool;\n use codex_app_server_protocol::DynamicToolSpec;\n use codex_app_server_protocol::ItemCompletedNotification;\n use codex_app_server_protocol::ItemStartedNotification;\n@@ -157,80 +160,6 @@ async fn thread_start_normalizes_legacy_dynamic_tools_into_model_request() -> Re\n     Ok(())\n }\n \n-#[tokio::test]\n-async fn thread_start_keeps_hidden_dynamic_tools_out_of_model_requests() -> Result<()> {\n-    let responses = vec![create_final_assistant_message_sse_response(\"Done\")?];\n-    let...",
+      "path": "codex-rs/app-server/tests/suite/v2/dynamic_tools.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 3,
+      "patch_excerpt": "@@ -5,6 +5,7 @@ use app_test_support::to_response;\n use codex_app_server_protocol::DynamicToolCallOutputContentItem;\n use codex_app_server_protocol::DynamicToolCallParams;\n use codex_app_server_protocol::DynamicToolCallResponse;\n+use codex_app_server_protocol::DynamicToolFunctionSpec;\n use codex_app_server_protocol::DynamicToolSpec;\n use codex_app_server_protocol::ItemStartedNotification;\n use codex_app_server_protocol::JSONRPCResponse;\n@@ -126,8 +127,7 @@ async fn thread_unsubscribe_during_turn_keeps_turn_running() -> Result<()> {\n     let thread_req = mcp\n         .send_thread_start_request(ThreadStartParams {\n             model: Some(\"mock-model\".to_string()),\n-            dynamic_tools: Some(vec![DynamicToolSpec {\n-                namespace: None,\n+            dynamic_tools: Some(vec![DynamicToolSpec::Function(DynamicToolFunctionSpec {\n                 name: tool_name.to_string(),\n  ...",
+      "path": "codex-rs/app-server/tests/suite/v2/thread_unsubscribe.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 10,
+      "deletions": 5,
+      "patch_excerpt": "@@ -88,15 +88,20 @@ struct LegacyDynamicToolSpec {\n pub fn normalize_dynamic_tool_specs(\n     values: Vec<JsonValue>,\n ) -> Result<Vec<DynamicToolSpec>, serde_json::Error> {\n-    let has_legacy_format = values.iter().any(|value| {\n+    let has_legacy_fields = |value: &JsonValue| {\n         value.get(\"namespace\").is_some()\n             || value.get(\"exposeToContext\").is_some()\n             || value.get(\"type\").is_none()\n+    };\n+    let has_legacy_format = values.iter().any(|value| {\n+        has_legacy_fields(value)\n+            || value\n+                .get(\"tools\")\n+                .and_then(JsonValue::as_array)\n+                .is_some_and(|tools| tools.iter().any(&has_legacy_fields))\n     });\n-    let has_canonical_namespace = values\n-        .iter()\n-        .any(|value| value.get(\"type\").and_then(JsonValue::as_str) == Some(\"namespace\"));\n-    if has_legacy_format && has_canonical...",
+      "path": "codex-rs/protocol/src/dynamic_tools.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#27365"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "Stacked on #27365.\n\n## Stack note\n\n[#27365](https://github.com/openai/codex/pull/27365) kept `thread/start` unchanged and converted its input in `thread_processor`. This PR updates `thread/start` to accept explicit functions and namespaces directly.\n\nLegacy per-tool arrays are still accepted and converted while reading the request. As a result, `thread_processor` can validate and pass the tools through directly, which is why some code added in #27365 is removed here.\n\n## Why\n\n`thread/start.dynamicTools` still repeats namespace data on each function even though core now stores explicit namespace groups. The request API should use the same shape so each namespace has one description and one member list.\n\n## What changed\n\n- Accept top-level functions and explicit namespace objects in `dynamicTools`.\n- Continue accepting fully legacy flat arrays, including `exposeToContext`.\n- Reject arrays that mix legacy and canonical entries.\n- Reuse the protocol types directly and remove the temporary app-server adapter.\n- Update validation, docs, the test client, and generated schemas.\n\n## Test plan\n\n- `just test -p codex-app-server-protocol`\n- `just test -p codex-app-server dynamic_tool_call_round_trip_sends_text_content_items_to_model`\n- `just test -p codex-app-server thread_start_normalizes_legacy_dynamic_tools_into_model_request`\n- `just test -p codex-app-server thread_start_rejects_mixed_dynamic_tool_formats`\n- `just test -p codex-app-server thread_start_rejects_hidden_dynamic_tools_without_namespace`\n",
+    "labels": [],
+    "merged_at": "2026-06-15T15:35:58Z",
+    "number": 27371,
+    "state": "merged",
+    "title": "Expose explicit dynamic tool namespaces in thread start",
+    "url": "https://github.com/openai/codex/pull/27371"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/bundles/openai-codex-pr-28143.json
+++ b/artifacts/github/bundles/openai-codex-pr-28143.json
@@ -1,0 +1,352 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "jayp-oai",
+      "committed_at": "2026-06-14T00:39:07Z",
+      "message": "feat(app-server): expose rate-limit reset credits",
+      "sha": "713056e48864fd3c8c1ea03f5719182f4f01ffb2",
+      "url": "https://github.com/openai/codex/commit/713056e48864fd3c8c1ea03f5719182f4f01ffb2"
+    },
+    {
+      "author": "jayp-oai",
+      "committed_at": "2026-06-15T00:06:29Z",
+      "message": "fix(app-server): consolidate rate-limit reset reads",
+      "sha": "405f51d5977e3c60a72bd486b664acea430e232f",
+      "url": "https://github.com/openai/codex/commit/405f51d5977e3c60a72bd486b664acea430e232f"
+    },
+    {
+      "author": "jayp-oai",
+      "committed_at": "2026-06-15T01:00:35Z",
+      "message": "fix(app-server): update rate-limit response fixture",
+      "sha": "3f8ed5c89516e23036777fbd7408a19871f1051a",
+      "url": "https://github.com/openai/codex/commit/3f8ed5c89516e23036777fbd7408a19871f1051a"
+    },
+    {
+      "author": "jayp-oai",
+      "committed_at": "2026-06-15T16:53:06Z",
+      "message": "docs(app-server): use redemption request ID terminology",
+      "sha": "c446387416a2d359c152bd66bb9093954017598e",
+      "url": "https://github.com/openai/codex/commit/c446387416a2d359c152bd66bb9093954017598e"
+    },
+    {
+      "author": "jayp-oai",
+      "committed_at": "2026-06-15T16:55:27Z",
+      "message": "docs(backend-client): describe rate-limit reset module",
+      "sha": "a32381a342c5ce30db88a90525b7b85c2335df9d",
+      "url": "https://github.com/openai/codex/commit/a32381a342c5ce30db88a90525b7b85c2335df9d"
+    },
+    {
+      "author": "jayp-oai",
+      "committed_at": "2026-06-15T17:02:54Z",
+      "message": "test(app-server): avoid real reset timeout wait",
+      "sha": "ebf7ec1b75b90609a71296befcb17603438eb230",
+      "url": "https://github.com/openai/codex/commit/ebf7ec1b75b90609a71296befcb17603438eb230"
+    },
+    {
+      "author": "jayp-oai",
+      "committed_at": "2026-06-15T17:23:22Z",
+      "message": "refactor(app-server): name reset idempotency key",
+      "sha": "d461c4b72f7f92480bdebdd515a05a51b0e4c635",
+      "url": "https://github.com/openai/codex/commit/d461c4b72f7f92480bdebdd515a05a51b0e4c635"
+    },
+    {
+      "author": "jayp-oai",
+      "committed_at": "2026-06-15T17:42:57Z",
+      "message": "refactor(app-server): name reset consume outcome",
+      "sha": "4cfa908a023e9e22c57f2066ce25399ebe9bcf0a",
+      "url": "https://github.com/openai/codex/commit/4cfa908a023e9e22c57f2066ce25399ebe9bcf0a"
+    },
+    {
+      "author": "jayp-oai",
+      "committed_at": "2026-06-15T17:56:25Z",
+      "message": "refactor(app-server): simplify reset consume response",
+      "sha": "dad73d1a17d0d99b9881d85158e63aa3864f8d18",
+      "url": "https://github.com/openai/codex/commit/dad73d1a17d0d99b9881d85158e63aa3864f8d18"
+    },
+    {
+      "author": "jayp-oai",
+      "committed_at": "2026-06-15T18:05:14Z",
+      "message": "docs(app-server): explain reset consume outcomes",
+      "sha": "9d82478f61f3d56170b59f1956cdca9a219cf2fa",
+      "url": "https://github.com/openai/codex/commit/9d82478f61f3d56170b59f1956cdca9a219cf2fa"
+    },
+    {
+      "author": "jayp-oai",
+      "committed_at": "2026-06-15T18:59:04Z",
+      "message": "fix(app-server): camel-case reset outcomes",
+      "sha": "73d786196c659d99e1b456da766ec0ebe6b2a129",
+      "url": "https://github.com/openai/codex/commit/73d786196c659d99e1b456da766ec0ebe6b2a129"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [
+    "codex-rs/app-server/README.md"
+  ],
+  "examples_refs": [],
+  "extracted_flags": [
+    "API",
+    "TUI",
+    "UUID",
+    "JSON",
+    "AGENTS",
+    "RPC",
+    "GENERATED",
+    "CODE",
+    "NOT",
+    "MODIFY",
+    "HAND",
+    "LOGIN_CHATGPT_TIMEOUT",
+    "ACCOUNT_TOKEN_USAGE_FETCH_TIMEOUT",
+    "JSONRPCE",
+    "RATE_LIMIT_RESET_REQUEST_TIMEOUT",
+    "RATE_LIMIT_RESET_REQUEST_TIMEOUT_ENV_VAR",
+    "CODEX_TEST_RATE_LIMIT_RESET_REQUEST_TIMEOUT_MS",
+    "JSONRPCR",
+    "DEFAULT_READ_TIMEOUT",
+    "SERVER_TIMEOUT_READ_TIMEOUT",
+    "INVALID_REQUEST_ERROR_CODE",
+    "INTERNAL_ERROR_CODE",
+    "POST",
+    "OPENAI_API_KEY",
+    "GET",
+    "CONTENT_TYPE"
+  ],
+  "files": [
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -261,6 +261,7 @@ These guidelines apply to app-server protocol work in `codex-rs`, especially:\n   `*Params` for request payloads, `*Response` for responses, and `*Notification` for notifications.\n - Expose RPC methods as `<resource>/<method>` and keep `<resource>` singular (for example, `thread/read`, `app/list`).\n - Always expose fields as camelCase on the wire with `#[serde(rename_all = \"camelCase\")]` unless a tagged union or explicit compatibility requirement needs a targeted rename.\n+- Always expose string enum values as camelCase on the wire with matching serde and TS `rename_all = \"camelCase\"` annotations unless an explicit compatibility requirement needs targeted renames.\n - Exception: config RPC payloads are expected to use snake_case to mirror config.toml keys (see the config read/write/list APIs in `app-server-protocol/src/protocol/v2.rs`).\n - Always set `#[ts(export_to = \"v...",
+      "path": "AGENTS.md",
+      "status": "modified"
+    },
+    {
+      "additions": 36,
+      "deletions": 0,
+      "patch_excerpt": "@@ -554,6 +554,18 @@\n       ],\n       \"type\": \"object\"\n     },\n+    \"ConsumeAccountRateLimitResetCreditParams\": {\n+      \"properties\": {\n+        \"idempotencyKey\": {\n+          \"description\": \"Identifies one logical reset attempt. A UUID is recommended; reuse the same value when retrying that attempt.\",\n+          \"type\": \"string\"\n+        }\n+      },\n+      \"required\": [\n+        \"idempotencyKey\"\n+      ],\n+      \"type\": \"object\"\n+    },\n     \"ContentItem\": {\n       \"oneOf\": [\n         {\n@@ -6108,6 +6120,30 @@\n       \"title\": \"Account/rateLimits/readRequest\",\n       \"type\": \"object\"\n     },\n+    {\n+      \"properties\": {\n+        \"id\": {\n+          \"$ref\": \"#/definitions/RequestId\"\n+        },\n+        \"method\": {\n+          \"enum\": [\n+            \"account/rateLimitResetCredit/consume\"\n+          ],\n+          \"title\": \"Account/rateLimitResetCredit/consumeRequestMethod\",\n+          \"type...",
+      "path": "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
+      "status": "modified"
+    },
+    {
+      "additions": 105,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1857,6 +1857,30 @@\n           \"title\": \"Account/rateLimits/readRequest\",\n           \"type\": \"object\"\n         },\n+        {\n+          \"properties\": {\n+            \"id\": {\n+              \"$ref\": \"#/definitions/v2/RequestId\"\n+            },\n+            \"method\": {\n+              \"enum\": [\n+                \"account/rateLimitResetCredit/consume\"\n+              ],\n+              \"title\": \"Account/rateLimitResetCredit/consumeRequestMethod\",\n+              \"type\": \"string\"\n+            },\n+            \"params\": {\n+              \"$ref\": \"#/definitions/v2/ConsumeAccountRateLimitResetCreditParams\"\n+            }\n+          },\n+          \"required\": [\n+            \"id\",\n+            \"method\",\n+            \"params\"\n+          ],\n+          \"title\": \"Account/rateLimitResetCredit/consumeRequest\",\n+          \"type\": \"object\"\n+        },\n         {\n           \"properties\": {\n             \"id\": {\n@...",
+      "path": "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+      "status": "modified"
+    },
+    {
+      "additions": 105,
+      "deletions": 0,
+      "patch_excerpt": "@@ -2841,6 +2841,30 @@\n           \"title\": \"Account/rateLimits/readRequest\",\n           \"type\": \"object\"\n         },\n+        {\n+          \"properties\": {\n+            \"id\": {\n+              \"$ref\": \"#/definitions/RequestId\"\n+            },\n+            \"method\": {\n+              \"enum\": [\n+                \"account/rateLimitResetCredit/consume\"\n+              ],\n+              \"title\": \"Account/rateLimitResetCredit/consumeRequestMethod\",\n+              \"type\": \"string\"\n+            },\n+            \"params\": {\n+              \"$ref\": \"#/definitions/ConsumeAccountRateLimitResetCreditParams\"\n+            }\n+          },\n+          \"required\": [\n+            \"id\",\n+            \"method\",\n+            \"params\"\n+          ],\n+          \"title\": \"Account/rateLimitResetCredit/consumeRequest\",\n+          \"type\": \"object\"\n+        },\n         {\n           \"properties\": {\n             \"id\": {\n@@ -476...",
+      "path": "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+      "status": "modified"
+    },
+    {
+      "additions": 14,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,14 @@\n+{\n+  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n+  \"properties\": {\n+    \"idempotencyKey\": {\n+      \"description\": \"Identifies one logical reset attempt. A UUID is recommended; reuse the same value when retrying that attempt.\",\n+      \"type\": \"string\"\n+    }\n+  },\n+  \"required\": [\n+    \"idempotencyKey\"\n+  ],\n+  \"title\": \"ConsumeAccountRateLimitResetCreditParams\",\n+  \"type\": \"object\"\n+}\n\\ No newline at end of file",
+      "path": "codex-rs/app-server-protocol/schema/json/v2/ConsumeAccountRateLimitResetCreditParams.json",
+      "status": "added"
+    },
+    {
+      "additions": 47,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,47 @@\n+{\n+  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n+  \"definitions\": {\n+    \"ConsumeAccountRateLimitResetCreditOutcome\": {\n+      \"oneOf\": [\n+        {\n+          \"description\": \"A reset credit was consumed and the eligible rate-limit windows were reset.\",\n+          \"enum\": [\n+            \"reset\"\n+          ],\n+          \"type\": \"string\"\n+        },\n+        {\n+          \"description\": \"No current rate-limit window is eligible for a reset.\",\n+          \"enum\": [\n+            \"nothingToReset\"\n+          ],\n+          \"type\": \"string\"\n+        },\n+        {\n+          \"description\": \"The account has no earned reset credits available.\",\n+          \"enum\": [\n+            \"noCredit\"\n+          ],\n+          \"type\": \"string\"\n+        },\n+        {\n+          \"description\": \"The same idempotency key already completed a reset successfully.\",\n+          \"enum\": [\n+     ...",
+      "path": "codex-rs/app-server-protocol/schema/json/v2/ConsumeAccountRateLimitResetCreditResponse.json",
+      "status": "added"
+    },
+    {
+      "additions": 22,
+      "deletions": 0,
+      "patch_excerpt": "@@ -49,6 +49,18 @@\n       ],\n       \"type\": \"string\"\n     },\n+    \"RateLimitResetCreditsSummary\": {\n+      \"properties\": {\n+        \"availableCount\": {\n+          \"format\": \"int64\",\n+          \"type\": \"integer\"\n+        }\n+      },\n+      \"required\": [\n+        \"availableCount\"\n+      ],\n+      \"type\": \"object\"\n+    },\n     \"RateLimitSnapshot\": {\n       \"properties\": {\n         \"credits\": {\n@@ -179,6 +191,16 @@\n     }\n   },\n   \"properties\": {\n+    \"rateLimitResetCredits\": {\n+      \"anyOf\": [\n+        {\n+          \"$ref\": \"#/definitions/RateLimitResetCreditsSummary\"\n+        },\n+        {\n+          \"type\": \"null\"\n+        }\n+      ]\n+    },\n     \"rateLimits\": {\n       \"allOf\": [\n         {",
+      "path": "codex-rs/app-server-protocol/schema/json/v2/GetAccountRateLimitsResponse.json",
+      "status": "modified"
+    },
+    {
+      "additions": 2,
+      "deletions": 1,
+      "patch_excerpt": "@@ -16,6 +16,7 @@ import type { CommandExecWriteParams } from \"./v2/CommandExecWriteParams\";\n import type { ConfigBatchWriteParams } from \"./v2/ConfigBatchWriteParams\";\n import type { ConfigReadParams } from \"./v2/ConfigReadParams\";\n import type { ConfigValueWriteParams } from \"./v2/ConfigValueWriteParams\";\n+import type { ConsumeAccountRateLimitResetCreditParams } from \"./v2/ConsumeAccountRateLimitResetCreditParams\";\n import type { ExperimentalFeatureEnablementSetParams } from \"./v2/ExperimentalFeatureEnablementSetParams\";\n import type { ExperimentalFeatureListParams } from \"./v2/ExperimentalFeatureListParams\";\n import type { ExternalAgentConfigDetectParams } from \"./v2/ExternalAgentConfigDetectParams\";\n@@ -87,4 +88,4 @@ import type { WindowsSandboxSetupStartParams } from \"./v2/WindowsSandboxSetupSta\n /**\n  * Request from the client to the server.\n  */\n-export type ClientRequest ={ \"meth...",
+      "path": "codex-rs/app-server-protocol/schema/typescript/ClientRequest.ts",
+      "status": "modified"
+    },
+    {
+      "additions": 5,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,5 @@\n+// GENERATED CODE! DO NOT MODIFY BY HAND!\n+\n+// This file was generated by [ts-rs](https://github.com/Aleph-Alpha/ts-rs). Do not edit this file manually.\n+\n+export type ConsumeAccountRateLimitResetCreditOutcome = \"reset\" | \"nothingToReset\" | \"noCredit\" | \"alreadyRedeemed\";",
+      "path": "codex-rs/app-server-protocol/schema/typescript/v2/ConsumeAccountRateLimitResetCreditOutcome.ts",
+      "status": "added"
+    },
+    {
+      "additions": 10,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,10 @@\n+// GENERATED CODE! DO NOT MODIFY BY HAND!\n+\n+// This file was generated by [ts-rs](https://github.com/Aleph-Alpha/ts-rs). Do not edit this file manually.\n+\n+export type ConsumeAccountRateLimitResetCreditParams = {\n+/**\n+ * Identifies one logical reset attempt. A UUID is recommended; reuse the same value when\n+ * retrying that attempt.\n+ */\n+idempotencyKey: string, };",
+      "path": "codex-rs/app-server-protocol/schema/typescript/v2/ConsumeAccountRateLimitResetCreditParams.ts",
+      "status": "added"
+    },
+    {
+      "additions": 6,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,6 @@\n+// GENERATED CODE! DO NOT MODIFY BY HAND!\n+\n+// This file was generated by [ts-rs](https://github.com/Aleph-Alpha/ts-rs). Do not edit this file manually.\n+import type { ConsumeAccountRateLimitResetCreditOutcome } from \"./ConsumeAccountRateLimitResetCreditOutcome\";\n+\n+export type ConsumeAccountRateLimitResetCreditResponse = { outcome: ConsumeAccountRateLimitResetCreditOutcome, };",
+      "path": "codex-rs/app-server-protocol/schema/typescript/v2/ConsumeAccountRateLimitResetCreditResponse.ts",
+      "status": "added"
+    },
+    {
+      "additions": 2,
+      "deletions": 1,
+      "patch_excerpt": "@@ -1,6 +1,7 @@\n // GENERATED CODE! DO NOT MODIFY BY HAND!\n \n // This file was generated by [ts-rs](https://github.com/Aleph-Alpha/ts-rs). Do not edit this file manually.\n+import type { RateLimitResetCreditsSummary } from \"./RateLimitResetCreditsSummary\";\n import type { RateLimitSnapshot } from \"./RateLimitSnapshot\";\n \n export type GetAccountRateLimitsResponse = {\n@@ -11,4 +12,4 @@ rateLimits: RateLimitSnapshot,\n /**\n  * Multi-bucket view keyed by metered `limit_id` (for example, `codex`).\n  */\n-rateLimitsByLimitId: { [key in string]?: RateLimitSnapshot } | null, };\n+rateLimitsByLimitId: { [key in string]?: RateLimitSnapshot } | null, rateLimitResetCredits: RateLimitResetCreditsSummary | null, };",
+      "path": "codex-rs/app-server-protocol/schema/typescript/v2/GetAccountRateLimitsResponse.ts",
+      "status": "modified"
+    },
+    {
+      "additions": 5,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,5 @@\n+// GENERATED CODE! DO NOT MODIFY BY HAND!\n+\n+// This file was generated by [ts-rs](https://github.com/Aleph-Alpha/ts-rs). Do not edit this file manually.\n+\n+export type RateLimitResetCreditsSummary = { availableCount: bigint, };",
+      "path": "codex-rs/app-server-protocol/schema/typescript/v2/RateLimitResetCreditsSummary.ts",
+      "status": "added"
+    },
+    {
+      "additions": 4,
+      "deletions": 0,
+      "patch_excerpt": "@@ -85,6 +85,9 @@ export type { ConfigWarningNotification } from \"./ConfigWarningNotification\";\n export type { ConfigWriteResponse } from \"./ConfigWriteResponse\";\n export type { ConfiguredHookHandler } from \"./ConfiguredHookHandler\";\n export type { ConfiguredHookMatcherGroup } from \"./ConfiguredHookMatcherGroup\";\n+export type { ConsumeAccountRateLimitResetCreditOutcome } from \"./ConsumeAccountRateLimitResetCreditOutcome\";\n+export type { ConsumeAccountRateLimitResetCreditParams } from \"./ConsumeAccountRateLimitResetCreditParams\";\n+export type { ConsumeAccountRateLimitResetCreditResponse } from \"./ConsumeAccountRateLimitResetCreditResponse\";\n export type { ContextCompactedNotification } from \"./ContextCompactedNotification\";\n export type { CreditsSnapshot } from \"./CreditsSnapshot\";\n export type { DeprecationNoticeNotification } from \"./DeprecationNoticeNotification\";\n@@ -317,6 +320,7 @@ e...",
+      "path": "codex-rs/app-server-protocol/schema/typescript/v2/index.ts",
+      "status": "modified"
+    },
+    {
+      "additions": 6,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1003,6 +1003,12 @@ client_request_definitions! {\n         response: v2::GetAccountRateLimitsResponse,\n     },\n \n+    ConsumeAccountRateLimitResetCredit => \"account/rateLimitResetCredit/consume\" {\n+        params: v2::ConsumeAccountRateLimitResetCreditParams,\n+        serialization: global(\"account-auth\"),\n+        response: v2::ConsumeAccountRateLimitResetCreditResponse,\n+    },\n+\n     GetAccountTokenUsage => \"account/usage/read\" {\n         params: #[ts(type = \"undefined\")] #[serde(skip_serializing_if = \"Option::is_none\")] Option<()>,\n         serialization: None,",
+      "path": "codex-rs/app-server-protocol/src/protocol/common.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 38,
+      "deletions": 0,
+      "patch_excerpt": "@@ -256,6 +256,44 @@ pub struct GetAccountRateLimitsResponse {\n     pub rate_limits: RateLimitSnapshot,\n     /// Multi-bucket view keyed by metered `limit_id` (for example, `codex`).\n     pub rate_limits_by_limit_id: Option<HashMap<String, RateLimitSnapshot>>,\n+    pub rate_limit_reset_credits: Option<RateLimitResetCreditsSummary>,\n+}\n+\n+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema, TS)]\n+#[serde(rename_all = \"camelCase\")]\n+#[ts(export_to = \"v2/\")]\n+pub struct RateLimitResetCreditsSummary {\n+    pub available_count: i64,\n+}\n+\n+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema, TS)]\n+#[serde(rename_all = \"camelCase\")]\n+#[ts(export_to = \"v2/\")]\n+pub struct ConsumeAccountRateLimitResetCreditParams {\n+    /// Identifies one logical reset attempt. A UUID is recommended; reuse the same value when\n+    /// retrying that attempt.\n+    pub idempo...",
+      "path": "codex-rs/app-server-protocol/src/protocol/v2/account.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 23,
+      "deletions": 5,
+      "patch_excerpt": "@@ -1838,7 +1838,8 @@ Codex supports these authentication modes. The current mode is surfaced in `acco\n - `account/login/cancel` — cancel a pending managed ChatGPT login by `loginId`.\n - `account/logout` — sign out; triggers `account/updated`.\n - `account/updated` (notify) — emitted whenever auth mode changes (`authMode`: `apikey`, `chatgpt`, `personalAccessToken`, or `null`) and includes the current ChatGPT `planType` when available.\n-- `account/rateLimits/read` — fetch ChatGPT rate limits and an optional effective monthly credit limit; updates arrive via `account/rateLimits/updated` (notify).\n+- `account/rateLimits/read` — fetch ChatGPT rate limits, an optional effective monthly credit limit, and the number of earned rate-limit resets currently available. Rate-limit updates arrive via `account/rateLimits/updated` (notify); the reset count is snapshot-only.\n+- `account/rateLimitResetCre...",
+      "path": "codex-rs/app-server/README.md",
+      "status": "modified"
+    },
+    {
+      "additions": 5,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1375,6 +1375,11 @@ impl MessageProcessor {\n             ClientRequest::GetAccountRateLimits { .. } => {\n                 self.account_processor.get_account_rate_limits().await\n             }\n+            ClientRequest::ConsumeAccountRateLimitResetCredit { params, .. } => {\n+                self.account_processor\n+                    .consume_account_rate_limit_reset_credit(params)\n+                    .await\n+            }\n             ClientRequest::GetAccountTokenUsage { .. } => {\n                 self.account_processor.get_account_token_usage().await\n             }",
+      "path": "codex-rs/app-server/src/message_processor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 5,
+      "deletions": 1,
+      "patch_excerpt": "@@ -52,6 +52,9 @@ use codex_app_server_protocol::CommandExecResizeParams;\n use codex_app_server_protocol::CommandExecTerminateParams;\n use codex_app_server_protocol::CommandExecWriteParams;\n use codex_app_server_protocol::ConfigWarningNotification;\n+use codex_app_server_protocol::ConsumeAccountRateLimitResetCreditOutcome;\n+use codex_app_server_protocol::ConsumeAccountRateLimitResetCreditParams;\n+use codex_app_server_protocol::ConsumeAccountRateLimitResetCreditResponse;\n use codex_app_server_protocol::ConversationGitInfo;\n use codex_app_server_protocol::ConversationSummary;\n use codex_app_server_protocol::DynamicToolSpec as ApiDynamicToolSpec;\n@@ -147,6 +150,7 @@ use codex_app_server_protocol::PluginSource;\n use codex_app_server_protocol::PluginSummary;\n use codex_app_server_protocol::PluginUninstallParams;\n use codex_app_server_protocol::PluginUninstallResponse;\n+use codex_app_server_pro...",
+      "path": "codex-rs/app-server/src/request_processors.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 59,
+      "deletions": 67,
+      "patch_excerpt": "@@ -1,5 +1,7 @@\n use super::*;\n \n+mod rate_limit_resets;\n+\n // Duration before a browser ChatGPT login attempt is abandoned.\n const LOGIN_CHATGPT_TIMEOUT: Duration = Duration::from_secs(10 * 60);\n const ACCOUNT_TOKEN_USAGE_FETCH_TIMEOUT: Duration = Duration::from_secs(/*secs*/ 10);\n@@ -851,19 +853,64 @@ impl AccountRequestProcessor {\n     async fn get_account_rate_limits_response(\n         &self,\n     ) -> Result<GetAccountRateLimitsResponse, JSONRPCErrorError> {\n-        self.fetch_account_rate_limits()\n+        let Some(auth) = self.auth_manager.auth().await else {\n+            return Err(invalid_request(\n+                \"codex account authentication required to read rate limits\",\n+            ));\n+        };\n+\n+        if !auth.uses_codex_backend() {\n+            return Err(invalid_request(\n+                \"chatgpt authentication required to read rate limits\",\n+            ));\n+    ...",
+      "path": "codex-rs/app-server/src/request_processors/account_processor.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 66,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,66 @@\n+use super::*;\n+\n+const RATE_LIMIT_RESET_REQUEST_TIMEOUT: Duration = Duration::from_secs(/*secs*/ 10);\n+#[cfg(debug_assertions)]\n+const RATE_LIMIT_RESET_REQUEST_TIMEOUT_ENV_VAR: &str =\n+    \"CODEX_TEST_RATE_LIMIT_RESET_REQUEST_TIMEOUT_MS\";\n+\n+impl AccountRequestProcessor {\n+    pub(crate) async fn consume_account_rate_limit_reset_credit(\n+        &self,\n+        params: ConsumeAccountRateLimitResetCreditParams,\n+    ) -> Result<Option<ClientResponsePayload>, JSONRPCErrorError> {\n+        if params.idempotency_key.is_empty() {\n+            return Err(invalid_request(\"idempotencyKey must not be empty\"));\n+        }\n+\n+        let client = self.rate_limit_reset_backend_client().await?;\n+        let request_timeout = RATE_LIMIT_RESET_REQUEST_TIMEOUT;\n+        #[cfg(debug_assertions)]\n+        let request_timeout = std::env::var(RATE_LIMIT_RESET_REQUEST_TIMEOUT_ENV_VAR)\n+    ...",
+      "path": "codex-rs/app-server/src/request_processors/account_processor/rate_limit_resets.rs",
+      "status": "added"
+    },
+    {
+      "additions": 13,
+      "deletions": 0,
+      "patch_excerpt": "@@ -24,6 +24,7 @@ use codex_app_server_protocol::CommandExecWriteParams;\n use codex_app_server_protocol::ConfigBatchWriteParams;\n use codex_app_server_protocol::ConfigReadParams;\n use codex_app_server_protocol::ConfigValueWriteParams;\n+use codex_app_server_protocol::ConsumeAccountRateLimitResetCreditParams;\n use codex_app_server_protocol::ExperimentalFeatureListParams;\n use codex_app_server_protocol::FeedbackUploadParams;\n use codex_app_server_protocol::FsCopyParams;\n@@ -382,6 +383,18 @@ impl TestAppServer {\n             .await\n     }\n \n+    /// Send an `account/rateLimitResetCredit/consume` JSON-RPC request.\n+    pub async fn send_consume_account_rate_limit_reset_credit_request(\n+        &mut self,\n+        params: ConsumeAccountRateLimitResetCreditParams,\n+    ) -> anyhow::Result<i64> {\n+        self.send_request(\n+            \"account/rateLimitResetCredit/consume\",\n+            Some(s...",
+      "path": "codex-rs/app-server/tests/common/test_app_server.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -39,6 +39,7 @@ mod plugin_read;\n mod plugin_share;\n mod plugin_uninstall;\n mod process_exec;\n+mod rate_limit_reset_credits;\n mod rate_limits;\n mod realtime_conversation;\n mod remote_control;",
+      "path": "codex-rs/app-server/tests/suite/v2/mod.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 288,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,288 @@\n+use std::path::Path;\n+\n+use anyhow::Result;\n+use app_test_support::ChatGptAuthFixture;\n+use app_test_support::TestAppServer;\n+use app_test_support::to_response;\n+use app_test_support::write_chatgpt_auth;\n+use codex_app_server_protocol::ConsumeAccountRateLimitResetCreditOutcome;\n+use codex_app_server_protocol::ConsumeAccountRateLimitResetCreditParams;\n+use codex_app_server_protocol::ConsumeAccountRateLimitResetCreditResponse;\n+use codex_app_server_protocol::GetAccountParams;\n+use codex_app_server_protocol::JSONRPCError;\n+use codex_app_server_protocol::JSONRPCResponse;\n+use codex_app_server_protocol::LoginAccountResponse;\n+use codex_app_server_protocol::RequestId;\n+use codex_config::types::AuthCredentialsStoreMode;\n+use pretty_assertions::assert_eq;\n+use serde::de::DeserializeOwned;\n+use serde_json::json;\n+use tempfile::TempDir;\n+use tokio::time::timeout;\n+use wiremock::...",
+      "path": "codex-rs/app-server/tests/suite/v2/rate_limit_reset_credits.rs",
+      "status": "added"
+    },
+    {
+      "additions": 5,
+      "deletions": 1,
+      "patch_excerpt": "@@ -10,6 +10,7 @@ use codex_app_server_protocol::JSONRPCError;\n use codex_app_server_protocol::JSONRPCResponse;\n use codex_app_server_protocol::LoginAccountResponse;\n use codex_app_server_protocol::RateLimitReachedType;\n+use codex_app_server_protocol::RateLimitResetCreditsSummary;\n use codex_app_server_protocol::RateLimitSnapshot;\n use codex_app_server_protocol::RateLimitWindow;\n use codex_app_server_protocol::RequestId;\n@@ -157,14 +158,16 @@ async fn get_account_rate_limits_returns_snapshot() -> Result<()> {\n                     }\n                 }\n             }\n-        ]\n+        ],\n+        \"rate_limit_reset_credits\": { \"available_count\": 3 }\n     });\n \n     Mock::given(method(\"GET\"))\n         .and(path(\"/api/codex/usage\"))\n         .and(header(\"authorization\", \"Bearer chatgpt-token\"))\n         .and(header(\"chatgpt-account-id\", \"account-123\"))\n         .respond_with(ResponseTemplat...",
+      "path": "codex-rs/app-server/tests/suite/v2/rate_limits.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 3,
+      "deletions": 8,
+      "patch_excerpt": "@@ -28,6 +28,8 @@ use serde::Serialize;\n use serde::de::DeserializeOwned;\n use std::fmt;\n \n+mod rate_limit_resets;\n+\n #[derive(Debug)]\n pub enum RequestError {\n     UnexpectedStatus {\n@@ -294,14 +296,7 @@ impl Client {\n     }\n \n     pub async fn get_rate_limits_many(&self) -> Result<Vec<RateLimitSnapshot>> {\n-        let url = match self.path_style {\n-            PathStyle::CodexApi => format!(\"{}/api/codex/usage\", self.base_url),\n-            PathStyle::ChatGptApi => format!(\"{}/wham/usage\", self.base_url),\n-        };\n-        let req = self.http.get(&url).headers(self.headers());\n-        let (body, ct) = self.exec_request(req, \"GET\", &url).await?;\n-        let payload: RateLimitStatusPayload = self.decode_json(&url, &ct, &body)?;\n-        Ok(Self::rate_limit_snapshots_from_payload(payload))\n+        Ok(self.get_rate_limits_with_reset_credits().await?.rate_limits)\n     }\n \n     pub as...",
+      "path": "codex-rs/backend-client/src/client.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 73,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,73 @@\n+//! Backend client operations for reading available rate-limit reset credits and consuming one.\n+\n+use super::Client;\n+use super::PathStyle;\n+use crate::types::ConsumeRateLimitResetCreditResponse;\n+use crate::types::RateLimitStatusWithResetCredits;\n+use crate::types::RateLimitsWithResetCredits;\n+use anyhow::Result;\n+use reqwest::header::CONTENT_TYPE;\n+use reqwest::header::HeaderValue;\n+use serde::Serialize;\n+\n+#[derive(Serialize)]\n+struct ConsumeRateLimitResetCreditRequest<'a> {\n+    redeem_request_id: &'a str,\n+}\n+\n+impl Client {\n+    pub async fn get_rate_limits_with_reset_credits(&self) -> Result<RateLimitsWithResetCredits> {\n+        let payload = self.get_rate_limit_status().await?;\n+        Ok(RateLimitsWithResetCredits {\n+            rate_limits: Self::rate_limit_snapshots_from_payload(payload.rate_limits),\n+            rate_limit_reset_credits: payload.rate_limi...",
+      "path": "codex-rs/backend-client/src/client/rate_limit_resets.rs",
+      "status": "added"
+    },
+    {
+      "additions": 71,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,71 @@\n+use super::*;\n+use crate::types::ConsumeRateLimitResetCreditCode;\n+use crate::types::RateLimitResetCreditsSummary;\n+use pretty_assertions::assert_eq;\n+\n+#[test]\n+fn rate_limit_reset_contract_uses_expected_paths_and_payloads() {\n+    assert_eq!(\n+        test_client(\"https://example.test\", PathStyle::CodexApi).rate_limit_status_url(),\n+        \"https://example.test/api/codex/usage\"\n+    );\n+    assert_eq!(\n+        test_client(\"https://example.test\", PathStyle::CodexApi)\n+            .consume_rate_limit_reset_credit_url(),\n+        \"https://example.test/api/codex/rate-limit-reset-credits/consume\"\n+    );\n+    assert_eq!(\n+        test_client(\"https://chatgpt.com/backend-api\", PathStyle::ChatGptApi)\n+            .rate_limit_status_url(),\n+        \"https://chatgpt.com/backend-api/wham/usage\"\n+    );\n+    assert_eq!(\n+        test_client(\"https://chatgpt.com/backend-api\", P...",
+      "path": "codex-rs/backend-client/src/client/rate_limit_resets_tests.rs",
+      "status": "added"
+    },
+    {
+      "additions": 4,
+      "deletions": 0,
+      "patch_excerpt": "@@ -9,10 +9,14 @@ pub use types::AccountsCheckResponse;\n pub use types::CodeTaskDetailsResponse;\n pub use types::CodeTaskDetailsResponseExt;\n pub use types::ConfigBundleResponse;\n+pub use types::ConsumeRateLimitResetCreditCode;\n+pub use types::ConsumeRateLimitResetCreditResponse;\n pub use types::DeliveredConfigToml;\n pub use types::DeliveredRequirementsToml;\n pub use types::DeliveredTomlFragment;\n pub use types::PaginatedListTaskListItem;\n+pub use types::RateLimitResetCreditsSummary;\n+pub use types::RateLimitsWithResetCredits;\n pub use types::TaskListItem;\n pub use types::TokenUsageProfile;\n pub use types::TokenUsageProfileDailyBucket;",
+      "path": "codex-rs/backend-client/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 35,
+      "deletions": 0,
+      "patch_excerpt": "@@ -12,11 +12,46 @@ pub use codex_backend_openapi_models::models::RateLimitWindowSnapshot;\n pub use codex_backend_openapi_models::models::SpendControlLimitDetails;\n pub use codex_backend_openapi_models::models::TaskListItem;\n \n+use codex_protocol::protocol::RateLimitSnapshot;\n use serde::Deserialize;\n use serde::de::Deserializer;\n use serde_json::Value;\n use std::collections::HashMap;\n \n+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]\n+pub struct RateLimitResetCreditsSummary {\n+    pub available_count: i64,\n+}\n+\n+#[derive(Clone, Debug, PartialEq)]\n+pub struct RateLimitsWithResetCredits {\n+    pub rate_limits: Vec<RateLimitSnapshot>,\n+    pub rate_limit_reset_credits: Option<RateLimitResetCreditsSummary>,\n+}\n+\n+#[derive(Clone, Debug, Deserialize, PartialEq)]\n+pub(crate) struct RateLimitStatusWithResetCredits {\n+    #[serde(flatten)]\n+    pub rate_limits: RateLimitStatusPayload,\n+    p...",
+      "path": "codex-rs/backend-client/src/types.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 1,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1792,6 +1792,7 @@ mod tests {\n                 (\"codex\".to_string(), rate_limit_snapshot(\"codex\")),\n                 (\"other\".to_string(), rate_limit_snapshot(\"other\")),\n             ])),\n+            rate_limit_reset_credits: None,\n         };\n \n         let snapshots = app_server_rate_limit_snapshots(response);",
+      "path": "codex-rs/tui/src/app_server_session.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [
+    "#28154"
+  ],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints.",
+    "Built during codex-upstream-radar-review automation run on 2026-06-16."
+  ],
+  "primary_pr": {
+    "body": "## Why\n\nCodex users can earn personal rate-limit reset credits, but app-server clients do not currently have an API for reading or redeeming them. This adds the backend and protocol foundation used by the `/usage` TUI flow in #28154.\n\n## What changed\n\n- Extend `account/rateLimits/read` with a nullable `rateLimitResetCredits` summary sourced from the existing usage response.\n- Add backend-client and app-server support for consuming a reset with a caller-generated idempotency key. A UUID is recommended, and clients reuse the same key when retrying the same logical reset.\n- Return only the consume `outcome`; clients refetch `account/rateLimits/read` for updated window state.\n- Document the response field and each consume outcome, and regenerate the JSON and TypeScript schema fixtures.\n- Clarify in `AGENTS.md` that new app-server string enum values use camelCase on the wire.\n- Update the existing TUI response fixture for the expanded protocol shape.\n- Add coverage for authentication, response mapping, backend failures, consume outcomes, and request timeout behavior.\n\n## Validation\n\n- `just test -p codex-app-server-protocol` — 231 passed.\n- `just test -p codex-backend-client` — 14 passed.\n- Focused `codex-app-server` reset-credit tests — 5 passed.\n- Focused `codex-tui` protocol response fixture test — passed.\n- `just fix -p codex-backend-client -p codex-app-server-protocol -p codex-app-server` — passed.\n- `just fmt` — passed.\n",
+    "labels": [],
+    "merged_at": "2026-06-15T21:54:02Z",
+    "number": 28143,
+    "state": "merged",
+    "title": "feat(app-server): expose rate-limit reset credits",
+    "url": "https://github.com/openai/codex/pull/28143"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/impact/openai-codex-pr-27371.json
+++ b/artifacts/github/impact/openai-codex-pr-27371.json
@@ -1,0 +1,48 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27371",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "Expose explicit dynamic tool namespaces in thread start",
+        "url": "https://github.com/openai/codex/pull/27371",
+        "meta": "Merged 2026-06-15T15:35:58Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27371",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27371.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex `thread/start.dynamicTools` now accepts tagged top-level function and namespace objects while normalizing legacy flat arrays and rejecting mixed legacy/canonical formats.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27371 describes the canonical `dynamicTools` API as explicit top-level functions and namespace objects, while preserving fully legacy flat arrays.",
+    "`DynamicToolSpec` is now a tagged function-or-namespace protocol type exported through the app-server v2 schema.",
+    "`ThreadStartParams.dynamic_tools` deserializes through `normalize_dynamic_tool_specs`, which rejects mixed legacy and canonical formats.",
+    "App-server validation now checks namespace names, descriptions, reserved Responses API namespace collisions, duplicate namespaces, empty namespaces, and deferred top-level functions.",
+    "The README example and app-server integration tests cover the canonical namespace request shape and migration-sensitive invalid inputs.",
+    "The source-backed review is recorded at `artifacts/github/reviews/openai-codex-pr-27371.review.json`."
+  ],
+  "candidate_followups": [
+    "Audit Decodex app-server request builders and schemas for flat-only dynamic-tool assumptions.",
+    "Preserve namespace descriptions and nested tool lists in any Control Plane UI or artifact that renders app-server dynamic tools.",
+    "Add preflight validation for mixed legacy/canonical dynamic-tool arrays before Decodex sends `thread/start` requests."
+  ],
+  "social_notes": [
+    "Frame this as the app-server dynamic-tool API gaining an explicit namespace shape, not as removal of legacy flat arrays.",
+    "Mention that legacy flat arrays still normalize when used consistently, but mixed legacy/canonical arrays are rejected."
+  ],
+  "caveats": [
+    "The upstream PR keeps legacy flat arrays accepted for compatibility.",
+    "The feature is still under the experimental `thread/start.dynamicTools` surface.",
+    "Exact Decodex implementation changes require a separate follow-up if local Control Plane code sends or renders dynamic tools."
+  ]
+}

--- a/artifacts/github/impact/openai-codex-pr-28143.json
+++ b/artifacts/github/impact/openai-codex-pr-28143.json
@@ -1,0 +1,49 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-28143",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "feat(app-server): expose rate-limit reset credits",
+        "url": "https://github.com/openai/codex/pull/28143",
+        "meta": "Merged 2026-06-15T21:54:02Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/28143",
+        "meta": "artifacts/github/reviews/openai-codex-pr-28143.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex app-server now reports earned rate-limit reset credits in `account/rateLimits/read` and adds `account/rateLimitResetCredit/consume` with caller-supplied idempotency.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "candidate",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "`GetAccountRateLimitsResponse` now includes nullable `rateLimitResetCredits` with `availableCount`.",
+    "The app-server protocol adds `account/rateLimitResetCredit/consume` with a non-empty `idempotencyKey` request parameter.",
+    "The consume response returns only an `outcome`; upstream docs tell clients to refetch `account/rateLimits/read` for updated window state.",
+    "Consume outcomes are camelCase: `reset`, `nothingToReset`, `noCredit`, and `alreadyRedeemed`.",
+    "The app-server processor requires ChatGPT-backed auth and maps backend reset-credit responses through a bounded timeout.",
+    "The source-backed review is recorded at `artifacts/github/reviews/openai-codex-pr-28143.review.json`."
+  ],
+  "candidate_followups": [
+    "Audit Decodex account and rate-limit read models for the nullable `rateLimitResetCredits` field.",
+    "Consider a guarded Control Plane action for consuming a reset credit with a stable idempotency key per logical user request.",
+    "After any consume action, refetch `account/rateLimits/read` instead of deriving updated windows from the consume response."
+  ],
+  "social_notes": [
+    "Frame this as an app-server account API capability for earned rate-limit reset credits.",
+    "Avoid implying automatic Decodex support until a separate Control Plane adoption issue is implemented.",
+    "Mention idempotency and refetch behavior because they are the operational details client authors need."
+  ],
+  "caveats": [
+    "The feature depends on ChatGPT-backed Codex auth and backend reset-credit availability.",
+    "The reset count is exposed on the read snapshot, not as a pushed notification update.",
+    "The upstream PR is protocol/backend foundation for a TUI `/usage` flow in a separate PR."
+  ]
+}

--- a/artifacts/github/review-queue/openai-codex-latest.json
+++ b/artifacts/github/review-queue/openai-codex-latest.json
@@ -1,14 +1,14 @@
 {
   "counts": {
-    "critical": 13,
+    "critical": 20,
     "high": 9,
     "low": 0,
-    "normal": 18,
+    "normal": 11,
     "published_subjects_seen": 0,
     "recent_commits_scanned": 40,
     "subjects_queued": 40
   },
-  "generated_at": "2026-06-15T18:05:22.018404Z",
+  "generated_at": "2026-06-16T06:05:27.805936Z",
   "repo": "openai/codex",
   "schema": "upstream_review_queue/v1",
   "source": {
@@ -17,586 +17,6 @@
     "signals_dir": "site/src/content/signals"
   },
   "subjects": [
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 29,
-      "commit_shas": [
-        "a1f9d5e195dbf73c5ac756e90224f2e4af3a6adf",
-        "69a4db602847e1c1269016243061b76b0687a6da",
-        "d3918160167a6eaa5a33982ef79d9ccb63636d7b",
-        "f4ef520440ce2a1d6b9ea9dcae6bbc272c2c181c"
-      ],
-      "committed_at": "2026-06-13T03:10:12Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27961,
-      "pr_url": "https://github.com/openai/codex/pull/27961",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ConfigRequirementsReadResponse.json",
-        "codex-rs/app-server-protocol/schema/typescript/v2/ConfigRequirements.ts",
-        "codex-rs/app-server-protocol/src/protocol/v2/config.rs",
-        "codex-rs/app-server-protocol/src/protocol/v2/tests.rs",
-        "codex-rs/app-server-transport/src/lib.rs",
-        "codex-rs/app-server-transport/src/transport/mod.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/desired_state.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/mod.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/tests.rs",
-        "codex-rs/app-server-transport/src/transport/remote_control/tests/clients_tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27961",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "docs_examples",
-        "tests_ci"
-      ],
-      "title": "feat(app-server): enforce managed remote control disable",
-      "url": "https://github.com/openai/codex/pull/27961"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging"
-      ],
-      "changed_file_count": 7,
-      "commit_shas": [
-        "6090e9d2498277d9f8720d860e6e89142d9e45a9",
-        "97a3f22d9eaa499ee384674a4f47788a2c0e219e",
-        "8235bab021b5b77dd1999487ab3082fafca3069a"
-      ],
-      "committed_at": "2026-06-14T00:53:09Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27607,
-      "pr_url": "https://github.com/openai/codex/pull/27607",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging.",
-      "sample_paths": [
-        "codex-rs/app-server/src/request_processors/plugins.rs",
-        "codex-rs/core-plugins/src/loader.rs",
-        "codex-rs/core-plugins/src/manager.rs",
-        "codex-rs/core-plugins/src/manager_tests.rs",
-        "codex-rs/core/tests/suite/plugins.rs",
-        "codex-rs/plugin/src/lib.rs",
-        "codex-rs/plugin/src/load_outcome.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27607",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "[codex] Dedupe plugin MCPs by app declaration name",
-      "url": "https://github.com/openai/codex/pull/27607"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 47,
-      "commit_shas": [
-        "7790dbe973f1b5310c79d90df26a181d0940e8a1",
-        "2a4048370d399c4fd45040f27659dee2bed7f97a",
-        "337e24e0ecc099f24ec63a643bcd2c5d6573e384",
-        "2c976d8ce0bafb0ead74d52eef1ca9bf3aaa6a13",
-        "6ad9c02999081787c4d16e6d3d070aa0133b9bf9"
-      ],
-      "committed_at": "2026-06-14T04:43:39Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28125,
-      "pr_url": "https://github.com/openai/codex/pull/28125",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        ".devcontainer/devcontainer.json",
-        ".devcontainer/devcontainer.secure.json",
-        ".github/workflows/ci.yml",
-        "MODULE.bazel",
-        "codex-rs/app-server-protocol/BUILD.bazel",
-        "codex-rs/app-server/BUILD.bazel",
-        "codex-rs/app-server/tests/common/BUILD.bazel",
-        "codex-rs/backend-client/BUILD.bazel",
-        "codex-rs/bwrap/BUILD.bazel",
-        "codex-rs/codex-client/BUILD.bazel",
-        "codex-rs/collaboration-mode-templates/BUILD.bazel",
-        "codex-rs/core-plugins/BUILD.bazel"
-      ],
-      "source_state": "merged",
-      "subject_id": "28125",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "auth_accounts",
-        "cli_tui",
-        "config_hooks",
-        "docs_examples",
-        "mcp_plugins",
-        "model_provider",
-        "release_packaging",
-        "sandbox_permissions",
-        "tests_ci"
-      ],
-      "title": "build: run buildifier from just fmt",
-      "url": "https://github.com/openai/codex/pull/28125"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 22,
-      "commit_shas": [
-        "a2a917b071ce164777333349163005720c8c5e7f",
-        "019ff65142c38263fd685f9692670aeeb560c5c6",
-        "5bada3f2a4f18a252cd65d89f461d3ff3c9f4b1f",
-        "2a8b87ed44215e4bf0bcce6b778038874c720b51",
-        "310ccf29f684a7a19ae65ea790bd465cfe74cb2a",
-        "763357aaa79a5fb13f84a5013deb2ff284a67bd4",
-        "ce4102787545b9131e32619e43ed89dc0ad13f12",
-        "4f6dd50b0eb01f3548c7b1403017e74c8697ef51",
-        "f4db0780fc9ef2063e29847f851759c5bd97dbe1",
-        "25644e0ec49ebf371ab45c8ae73b3cb8fd78607e",
-        "18004b9322a89dd9efc40aea3f88643cdfc55eed",
-        "716e9e32e934a3f7b868a1bc7a327524594dc81e",
-        "1a7dbd5b4ff43cdf230f8b7062e6c1618ed458dc"
-      ],
-      "committed_at": "2026-06-14T06:07:46Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28122,
-      "pr_url": "https://github.com/openai/codex/pull/28122",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "bazel/rules/testing/wine/src/lib.rs",
-        "bazel/rules/testing/wine/src/lib_tests.rs",
-        "codex-rs/Cargo.lock",
-        "codex-rs/app-server/src/request_processors/thread_processor.rs",
-        "codex-rs/app-server/src/request_processors/turn_processor.rs",
-        "codex-rs/core/src/environment_selection.rs",
-        "codex-rs/core/src/session/mod.rs",
-        "codex-rs/core/src/session/tests.rs",
-        "codex-rs/core/src/session/turn_context.rs",
-        "codex-rs/core/src/thread_manager_tests.rs",
-        "codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs",
-        "codex-rs/core/tests/common/test_codex.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "28122",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "tests_ci"
-      ],
-      "title": "[codex] exec-server honors remote environment cwd and shell",
-      "url": "https://github.com/openai/codex/pull/28122"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 27,
-      "commit_shas": [
-        "68567deb6f6e9227662c9558d37ff3e280a2b377",
-        "724cd58bf6ed04ffaf8ab8520c951a5518f3161a",
-        "c2f877a1d0c5dbab82f5d7fcb4c591b90e9541f8",
-        "e06ed34720737e1657c74fdc466972c5fdda5ac4",
-        "eaeb92854e2d6da708558a8f0b81ff7cacdfd569",
-        "4c1fbf28545273cd4ba9402a4065171b646824f9",
-        "28d35a99eff66cf06742933e4a45fde47fb927d5",
-        "ba23593c751b155e4a86d2e6c24125a4b177a8c6",
-        "95d0018d71d9b15ccac883561abd1d408cf0f875",
-        "688537c78d85337d3bc70e80a7e74fcfe11da6ce"
-      ],
-      "committed_at": "2026-06-14T07:14:26Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26662,
-      "pr_url": "https://github.com/openai/codex/pull/26662",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server-protocol/schema/typescript/v2/ThreadListParams.ts",
-        "codex-rs/app-server-protocol/src/protocol/common.rs",
-        "codex-rs/app-server-protocol/src/protocol/v2/thread.rs",
-        "codex-rs/app-server-test-client/src/lib.rs",
-        "codex-rs/app-server/README.md",
-        "codex-rs/app-server/src/request_processors/thread_processor.rs",
-        "codex-rs/app-server/tests/suite/v2/external_agent_config.rs",
-        "codex-rs/app-server/tests/suite/v2/remote_thread_store.rs",
-        "codex-rs/app-server/tests/suite/v2/thread_fork.rs",
-        "codex-rs/app-server/tests/suite/v2/thread_list.rs",
-        "codex-rs/app-server/tests/suite/v2/thread_read.rs",
-        "codex-rs/core/src/personality_migration.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26662",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "docs_examples",
-        "tests_ci"
-      ],
-      "title": "feat(app-server): filter threads by parent",
-      "url": "https://github.com/openai/codex/pull/26662"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 16,
-      "commit_shas": [
-        "8489afd8e3f3a547b47d569cfc91a389af125b34",
-        "a7578adf4ccdae18f4cc9d3085d5aac15a431a3d",
-        "fa026aaac9fd3a6ed649544c7c22df2fb600f9c4",
-        "947796d1630c443c43a45727dd8b2150b5dc00d6",
-        "e6b462681a96488861b6e2197327a5d0b01cc6f2"
-      ],
-      "committed_at": "2026-06-15T09:10:51Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27884,
-      "pr_url": "https://github.com/openai/codex/pull/27884",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/codex-mcp/src/catalog.rs",
-        "codex-rs/codex-mcp/src/catalog_tests.rs",
-        "codex-rs/codex-mcp/src/connection_manager.rs",
-        "codex-rs/codex-mcp/src/connection_manager_tests.rs",
-        "codex-rs/codex-mcp/src/lib.rs",
-        "codex-rs/codex-mcp/src/mcp/mod.rs",
-        "codex-rs/codex-mcp/src/mcp/mod_tests.rs",
-        "codex-rs/codex-mcp/src/server.rs",
-        "codex-rs/core/src/config/config_tests.rs",
-        "codex-rs/core/src/config/mod.rs",
-        "codex-rs/core/src/mcp.rs",
-        "codex-rs/core/src/mcp_tool_call.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27884",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "config_hooks",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "Add selected-plugin precedence and attribution to the MCP catalog",
-      "url": "https://github.com/openai/codex/pull/27884"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 11,
-      "commit_shas": [
-        "8489afd8e3f3a547b47d569cfc91a389af125b34",
-        "a7578adf4ccdae18f4cc9d3085d5aac15a431a3d",
-        "8b78cf44bc9452427916b53c2a7c1b99a2b89434",
-        "b7180839381890e258ba75bfbf2b825b5064a41f",
-        "a5453ca8f4c3c24b473c031811c1e36c3185efb8"
-      ],
-      "committed_at": "2026-06-15T09:52:05Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27870,
-      "pr_url": "https://github.com/openai/codex/pull/27870",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/Cargo.lock",
-        "codex-rs/core-plugins/src/lib.rs",
-        "codex-rs/core-plugins/src/loader.rs",
-        "codex-rs/core-plugins/src/provider.rs",
-        "codex-rs/ext/mcp/Cargo.toml",
-        "codex-rs/ext/mcp/src/executor_plugin.rs",
-        "codex-rs/ext/mcp/src/executor_plugin/provider.rs",
-        "codex-rs/ext/mcp/src/executor_plugin/provider_tests.rs",
-        "codex-rs/ext/mcp/src/lib.rs",
-        "codex-rs/ext/mcp/tests/executor_plugin_mcp.rs",
-        "codex-rs/plugin/src/manifest.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27870",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "config_hooks",
-        "mcp_plugins",
-        "model_provider",
-        "tests_ci"
-      ],
-      "title": "Discover stdio MCP servers from selected executor plugins",
-      "url": "https://github.com/openai/codex/pull/27870"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 7,
-      "commit_shas": [
-        "6a3bac99652534ee250536787b3d40061981283a",
-        "e93643d804ea1f7ed68ca286fbe935e5e32ec3a1",
-        "6370a49ab0b18daeeaf3b531c4e3b0d1c645c979"
-      ],
-      "committed_at": "2026-06-15T12:50:08Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27602,
-      "pr_url": "https://github.com/openai/codex/pull/27602",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/Cargo.lock",
-        "codex-rs/app-server/src/request_processors.rs",
-        "codex-rs/app-server/src/request_processors/apps_processor.rs",
-        "codex-rs/app-server/src/request_processors/plugins.rs",
-        "codex-rs/app-server/tests/suite/v2/app_list.rs",
-        "codex-rs/chatgpt/Cargo.toml",
-        "codex-rs/chatgpt/src/connectors.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27602",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "config_hooks",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "[codex] Preserve plugin apps in connector listings",
-      "url": "https://github.com/openai/codex/pull/27602"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging"
-      ],
-      "changed_file_count": 5,
-      "commit_shas": [
-        "9d5edd7c670d178062a8bee9f194ba41fc4072be",
-        "3c9aaf348048ec81f41bdb1d7dcfa8c45aabbe49"
-      ],
-      "committed_at": "2026-06-15T13:04:01Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27461,
-      "pr_url": "https://github.com/openai/codex/pull/27461",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging.",
-      "sample_paths": [
-        "codex-rs/app-server/src/request_processors/plugins.rs",
-        "codex-rs/app-server/tests/suite/v2/plugin_install.rs",
-        "codex-rs/core-plugins/src/loader.rs",
-        "codex-rs/core-plugins/src/manager.rs",
-        "codex-rs/core-plugins/src/manager_tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27461",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "mcp_plugins",
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "[codex] Skip plugin MCP OAuth for matching app routes",
-      "url": "https://github.com/openai/codex/pull/27461"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 10,
-      "commit_shas": [
-        "8489afd8e3f3a547b47d569cfc91a389af125b34",
-        "a7578adf4ccdae18f4cc9d3085d5aac15a431a3d",
-        "8b78cf44bc9452427916b53c2a7c1b99a2b89434",
-        "b7180839381890e258ba75bfbf2b825b5064a41f",
-        "06dc0abb32835ccf054f291294a84a63617e31d8",
-        "3964452256ff004a84e64a9299c041bce345b78b",
-        "191de6246942e5413e22b5087e4c8be6c185db9f",
-        "fa0e82f1affe6653756a662114361be0f640b634",
-        "b62eff83f23faf457c6f5072af70af7446b3bce1",
-        "cf3b08f03d6598c0edd7f60403bf5f92f3a0ca4b",
-        "3d139253da3a4725655a0d1641a60f08c7b17903",
-        "2d6589027994b9539faa03d958b02a9cff616dd4"
-      ],
-      "committed_at": "2026-06-15T14:23:37Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27893,
-      "pr_url": "https://github.com/openai/codex/pull/27893",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server/BUILD.bazel",
-        "codex-rs/app-server/README.md",
-        "codex-rs/app-server/src/extensions.rs",
-        "codex-rs/app-server/src/mcp_refresh.rs",
-        "codex-rs/app-server/src/message_processor.rs",
-        "codex-rs/app-server/src/request_processors/thread_processor.rs",
-        "codex-rs/app-server/tests/suite/v2/executor_mcp.rs",
-        "codex-rs/app-server/tests/suite/v2/mcp_resource.rs",
-        "codex-rs/app-server/tests/suite/v2/mod.rs",
-        "defs.bzl"
-      ],
-      "source_state": "merged",
-      "subject_id": "27893",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "docs_examples",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "Activate selected executor plugin MCPs in app-server",
-      "url": "https://github.com/openai/codex/pull/27893"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 20,
-      "commit_shas": [
-        "e401d78a53711d01aff64345a221130be95ba3d1",
-        "8570c09a0307ab72b74e35f2c8f11e73b2855b6c",
-        "c856ed238f1d5fe32717438ebf8a25c164319825",
-        "d4c37e93f76093cdd099b4aa1597bd1f936181c2",
-        "108c7e6ae81cdf469baa1b4608dab0b5aad92027"
-      ],
-      "committed_at": "2026-06-15T15:06:14Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27365,
-      "pr_url": "https://github.com/openai/codex/pull/27365",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server/src/request_processors.rs",
-        "codex-rs/app-server/src/request_processors/thread_processor.rs",
-        "codex-rs/app-server/tests/suite/v2/dynamic_tools.rs",
-        "codex-rs/core-api/src/lib.rs",
-        "codex-rs/core/src/tools/handlers/dynamic.rs",
-        "codex-rs/core/src/tools/handlers/tool_search.rs",
-        "codex-rs/core/src/tools/router_tests.rs",
-        "codex-rs/core/src/tools/spec_plan.rs",
-        "codex-rs/core/src/tools/spec_plan_tests.rs",
-        "codex-rs/core/tests/suite/code_mode.rs",
-        "codex-rs/core/tests/suite/compact_remote.rs",
-        "codex-rs/core/tests/suite/search_tool.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27365",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "Represent dynamic tools with explicit namespaces internally",
-      "url": "https://github.com/openai/codex/pull/27365"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 19,
-      "commit_shas": [
-        "54610fec006e76c51d30f2fe5b90001c48632288",
-        "eefdd863d8d8fbb4c3d6bc06f9b4a0b0b296a8e5",
-        "39eabddc46a763edc22f33f1f7013249f01d4a93",
-        "87fa3a6a5bc08f91c630c4990a42869ed064c86a",
-        "11867f161e889c8095d6970f151308263bc2d462",
-        "fe2b08e0b90598c0648ddba0b27e5341a6754212"
-      ],
-      "committed_at": "2026-06-15T15:35:57Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27371,
-      "pr_url": "https://github.com/openai/codex/pull/27371",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
-        "codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json",
-        "codex-rs/app-server-protocol/schema/typescript/v2/DynamicToolFunctionSpec.ts",
-        "codex-rs/app-server-protocol/schema/typescript/v2/DynamicToolNamespaceSpec.ts",
-        "codex-rs/app-server-protocol/schema/typescript/v2/DynamicToolNamespaceTool.ts",
-        "codex-rs/app-server-protocol/schema/typescript/v2/DynamicToolSpec.ts",
-        "codex-rs/app-server-protocol/schema/typescript/v2/index.ts",
-        "codex-rs/app-server-protocol/src/protocol/v2/tests.rs",
-        "codex-rs/app-server-protocol/src/protocol/v2/thread.rs",
-        "codex-rs/app-server-test-client/src/lib.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27371",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "docs_examples",
-        "tests_ci"
-      ],
-      "title": "Expose explicit dynamic tool namespaces in thread start",
-      "url": "https://github.com/openai/codex/pull/27371"
-    },
     {
       "attention_flags": [
         "auth_account",
@@ -639,43 +59,286 @@
     },
     {
       "attention_flags": [
+        "breaking_change",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 4,
+      "commit_shas": [
+        "4133ae0d19d9bc5f689a28b51e52a5bfc5f8cb86"
+      ],
+      "committed_at": "2026-06-15T18:32:13Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27706,
+      "pr_url": "https://github.com/openai/codex/pull/27706",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for breaking_change, new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/Cargo.toml",
+        "codex-rs/utils/rustls-provider/src/lib.rs",
+        "codex-rs/utils/rustls-provider/tests/preinstalled.rs",
+        "codex-rs/utils/rustls-provider/tests/provider.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27706",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "config_hooks",
+        "model_provider",
+        "release_packaging",
+        "tests_ci"
+      ],
+      "title": "Use aws-lc-rs for rustls crypto provider",
+      "url": "https://github.com/openai/codex/pull/27706"
+    },
+    {
+      "attention_flags": [
         "auth_account",
+        "breaking_change",
         "new_feature",
         "protocol_change",
         "security_policy"
       ],
-      "changed_file_count": 6,
+      "changed_file_count": 21,
       "commit_shas": [
-        "c3f075e16a688d207f4b688c4f40f456a2377f2b"
+        "d5bf231073d01d64201914855ea3ca50473c63da",
+        "ed32eb778b3855e61cb2211ed00ceff5053c384f",
+        "8186f026f23bfc1e48426bdaadc3322e7b9caf8b",
+        "e6de7af1c65f32368d9598a6015a7c66a1490b87",
+        "2b95a53857c11938ed35465e7530d68719047462",
+        "495f01b0d6f99dc6f8b519b708fe36c716bf193b",
+        "47e351f4f8e7861bb9eb9142c730c0959e6b0978",
+        "f89237307418ec70618b2f4ee072fdeb83b409b3"
       ],
-      "committed_at": "2026-06-13T02:42:11Z",
+      "committed_at": "2026-06-15T20:25:42Z",
       "next_step": "ai_review_required",
-      "pr_number": 27459,
-      "pr_url": "https://github.com/openai/codex/pull/27459",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
+      "pr_number": 28008,
+      "pr_url": "https://github.com/openai/codex/pull/28008",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/app-server-protocol/src/protocol/common.rs",
-        "codex-rs/core-plugins/src/manager.rs",
-        "codex-rs/core-plugins/src/manager_tests.rs",
-        "codex-rs/core/src/plugins/discoverable_tests.rs",
-        "codex-rs/core/tests/suite/plugins.rs",
-        "codex-rs/login/src/auth/manager.rs"
+        "codex-rs/app-server-client/src/lib.rs",
+        "codex-rs/app-server-protocol/schema/json/ServerNotification.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ExternalAgentConfigImportCompletedNotification.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ExternalAgentConfigImportResponse.json",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ExternalAgentConfigImportCompletedNotification.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ExternalAgentConfigImportItemTypeFailure.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ExternalAgentConfigImportItemTypeSuccess.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ExternalAgentConfigImportResponse.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ExternalAgentConfigImportTypeResult.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/index.ts"
       ],
       "source_state": "merged",
-      "subject_id": "27459",
+      "subject_id": "28008",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "config_hooks",
+        "docs_examples",
+        "tests_ci"
+      ],
+      "title": "[codex] Add external agent import result accounting",
+      "url": "https://github.com/openai/codex/pull/28008"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 4,
+      "commit_shas": [
+        "35ebd055eecb5842b0c632aadac598035dc75b62"
+      ],
+      "committed_at": "2026-06-15T20:54:24Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27944,
+      "pr_url": "https://github.com/openai/codex/pull/27944",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/windows-sandbox-rs/src/elevated/runner_client.rs",
+        "codex-rs/windows-sandbox-rs/src/elevated_impl.rs",
+        "codex-rs/windows-sandbox-rs/src/identity.rs",
+        "codex-rs/windows-sandbox-rs/src/unified_exec/backends/elevated.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27944",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "sandbox_permissions"
+      ],
+      "title": "recover stale Windows sandbox credentials",
+      "url": "https://github.com/openai/codex/pull/27944"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "rate_limit",
+        "security_policy"
+      ],
+      "changed_file_count": 31,
+      "commit_shas": [
+        "713056e48864fd3c8c1ea03f5719182f4f01ffb2",
+        "405f51d5977e3c60a72bd486b664acea430e232f",
+        "3f8ed5c89516e23036777fbd7408a19871f1051a",
+        "c446387416a2d359c152bd66bb9093954017598e",
+        "a32381a342c5ce30db88a90525b7b85c2335df9d",
+        "ebf7ec1b75b90609a71296befcb17603438eb230",
+        "d461c4b72f7f92480bdebdd515a05a51b0e4c635",
+        "4cfa908a023e9e22c57f2066ce25399ebe9bcf0a",
+        "dad73d1a17d0d99b9881d85158e63aa3864f8d18",
+        "9d82478f61f3d56170b59f1956cdca9a219cf2fa",
+        "73d786196c659d99e1b456da766ec0ebe6b2a129"
+      ],
+      "committed_at": "2026-06-15T21:54:01Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28143,
+      "pr_url": "https://github.com/openai/codex/pull/28143",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, rate_limit, security_policy.",
+      "sample_paths": [
+        "AGENTS.md",
+        "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ConsumeAccountRateLimitResetCreditParams.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ConsumeAccountRateLimitResetCreditResponse.json",
+        "codex-rs/app-server-protocol/schema/json/v2/GetAccountRateLimitsResponse.json",
+        "codex-rs/app-server-protocol/schema/typescript/ClientRequest.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ConsumeAccountRateLimitResetCreditOutcome.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ConsumeAccountRateLimitResetCreditParams.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ConsumeAccountRateLimitResetCreditResponse.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/GetAccountRateLimitsResponse.ts"
+      ],
+      "source_state": "merged",
+      "subject_id": "28143",
       "subject_kind": "pr",
       "surface_hints": [
         "app_server_protocol",
         "auth_accounts",
-        "mcp_plugins",
+        "cli_tui",
+        "docs_examples",
+        "model_provider",
         "tests_ci"
       ],
-      "title": "[codex] Gate plugin MCP servers by auth route",
-      "url": "https://github.com/openai/codex/pull/27459"
+      "title": "feat(app-server): expose rate-limit reset credits",
+      "url": "https://github.com/openai/codex/pull/28143"
     },
     {
       "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 85,
+      "commit_shas": [
+        "e5daf04ee72403d86ca94d70ae5a02943ebbee14",
+        "da05911b406c15334e0c8be90bb1d4018107cc35",
+        "654a768b5d268a9e9f3f3e449db734b2af244885",
+        "e127df9a227a54d797ce377ae077aed41fcb7cab",
+        "0fbfb9eef395c433e4a470cb62df57b334b0af91"
+      ],
+      "committed_at": "2026-06-15T22:05:28Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28355,
+      "pr_url": "https://github.com/openai/codex/pull/28355",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/v2/RawResponseItemCompletedNotification.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ThreadResumeParams.json",
+        "codex-rs/app-server-protocol/schema/typescript/ResponseItem.ts",
+        "codex-rs/app-server-protocol/schema/typescript/ResponseItemMetadata.ts",
+        "codex-rs/app-server-protocol/schema/typescript/index.ts",
+        "codex-rs/app-server-protocol/src/protocol/thread_history.rs",
+        "codex-rs/app-server/tests/suite/v2/compaction.rs",
+        "codex-rs/app-server/tests/suite/v2/thread_inject_items.rs",
+        "codex-rs/app-server/tests/suite/v2/thread_resume.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28355",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "model_provider",
+        "sandbox_permissions",
+        "tests_ci"
+      ],
+      "title": "feat(core): add metadata field to ResponseItem",
+      "url": "https://github.com/openai/codex/pull/28355"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 15,
+      "commit_shas": [
+        "f5c4df12fc81f00d3399e8b1eabb07578d5f53a4",
+        "015c83c692daac61a5ff93e9d02207795bcdf84c",
+        "10ed4c665ba612f8ba30841c86ba3250144b67cb"
+      ],
+      "committed_at": "2026-06-15T22:07:07Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28203,
+      "pr_url": "https://github.com/openai/codex/pull/28203",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/v2/PluginListParams.json",
+        "codex-rs/app-server-protocol/schema/typescript/v2/PluginListMarketplaceKind.ts",
+        "codex-rs/app-server-protocol/src/protocol/v2/plugin.rs",
+        "codex-rs/app-server-protocol/src/protocol/v2/tests.rs",
+        "codex-rs/app-server/README.md",
+        "codex-rs/app-server/src/request_processors/plugins.rs",
+        "codex-rs/app-server/tests/suite/v2/plugin_list.rs",
+        "codex-rs/app-server/tests/suite/v2/skills_list.rs",
+        "codex-rs/core-plugins/src/discoverable_tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28203",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "docs_examples",
+        "mcp_plugins",
+        "release_packaging",
+        "tests_ci"
+      ],
+      "title": "[codex] Add created-by-me remote plugin marketplace",
+      "url": "https://github.com/openai/codex/pull/28203"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
         "new_feature",
         "protocol_change",
         "release_packaging",
@@ -683,872 +346,1130 @@
       ],
       "changed_file_count": 10,
       "commit_shas": [
-        "7ae8a2b96ff40507131cf85220c3e7d0ce8903e2",
-        "9defc3f62bababfd16dfc0c09e42d7a826c5edf8",
-        "fa4da9b809e22a9e0535bf13a69424b1c8e549bf",
-        "573477f944be51be60e7ef6c19630b4d7d1c5d92",
-        "81ce551c37fac7e15b40872f7006d9b0decfbb28",
-        "8f11fbee94dd4381c44a5fec3b3838ae63cb235e",
-        "92f022d5294f79cfafa0eabc9e4e751b2611ee12",
-        "152d97daf01d01dcc41b6a37e7ab2f9f27ca2740"
+        "650a0c6cf4dec2fc7337973b123391e7958891a5",
+        "eb2b7267d4ccc3437723179199796aea0ffb21b9",
+        "fc8e962fba140118d365bb5d1f1c6e324c44387a",
+        "f01df8e06da9083369ed3e1c3caf62fc80200714",
+        "f5cbeddf7e208b356847897aa2446ddc6d1b7e38"
       ],
-      "committed_at": "2026-06-13T03:20:23Z",
+      "committed_at": "2026-06-15T22:24:33Z",
       "next_step": "ai_review_required",
-      "pr_number": 27937,
-      "pr_url": "https://github.com/openai/codex/pull/27937",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "bazel/rules/testing/wine.bzl",
-        "codex-rs/core/Cargo.toml",
-        "codex-rs/core/tests/remote_env_windows/BUILD.bazel",
-        "codex-rs/core/tests/remote_env_windows/README.md",
-        "codex-rs/core/tests/remote_env_windows/remote_env_windows_test.rs",
-        "codex-rs/exec-server/testing/BUILD.bazel",
-        "codex-rs/exec-server/testing/README.md",
-        "codex-rs/exec-server/testing/windows_exec_server.rs",
-        "scripts/list-bazel-release-targets.sh",
-        "tools/argument-comment-lint/list-bazel-targets.sh"
-      ],
-      "source_state": "merged",
-      "subject_id": "27937",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "config_hooks",
-        "docs_examples",
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "[codex] Add hermetic Wine exec-server test",
-      "url": "https://github.com/openai/codex/pull/27937"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 13,
-      "commit_shas": [
-        "362785f70469ae7c968c3ef49aae53772e5b9d9e",
-        "f21ad4deaed11404daa5bdb1ac210ddcb205f73c"
-      ],
-      "committed_at": "2026-06-13T20:56:42Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28032,
-      "pr_url": "https://github.com/openai/codex/pull/28032",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
+      "pr_number": 27813,
+      "pr_url": "https://github.com/openai/codex/pull/27813",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
       "sample_paths": [
         "codex-rs/Cargo.lock",
-        "codex-rs/core/src/unified_exec/process_manager.rs",
-        "codex-rs/core/src/unified_exec/process_manager_tests.rs",
-        "codex-rs/core/tests/remote_env_windows/remote_env_windows_test.rs",
-        "codex-rs/exec-server/README.md",
-        "codex-rs/exec-server/src/environment.rs",
-        "codex-rs/exec-server/src/local_process.rs",
-        "codex-rs/exec-server/src/protocol.rs",
-        "codex-rs/exec-server/src/server/handler/tests.rs",
-        "codex-rs/exec-server/src/server/processor.rs",
-        "codex-rs/exec-server/tests/exec_process.rs",
-        "codex-rs/rmcp-client/Cargo.toml"
+        "codex-rs/connectors/Cargo.toml",
+        "codex-rs/connectors/src/app_tool_policy.rs",
+        "codex-rs/connectors/src/app_tool_policy_tests.rs",
+        "codex-rs/connectors/src/lib.rs",
+        "codex-rs/core/src/connectors.rs",
+        "codex-rs/core/src/connectors_tests.rs",
+        "codex-rs/core/src/mcp_tool_call.rs",
+        "codex-rs/core/src/mcp_tool_exposure.rs",
+        "codex-rs/core/src/mcp_tool_exposure_test.rs"
       ],
       "source_state": "merged",
-      "subject_id": "28032",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "config_hooks",
-        "docs_examples",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "[codex] Carry exec-server cwd as PathUri",
-      "url": "https://github.com/openai/codex/pull/28032"
-    },
-    {
-      "attention_flags": [
-        "new_feature",
-        "protocol_change",
-        "release_packaging"
-      ],
-      "changed_file_count": 5,
-      "commit_shas": [
-        "decac77d8337b827375619f1de4eb14d58cc64ca",
-        "36599cad8adc4f60b5743f85763c6382f248c00e",
-        "624645fffe36882390418ca331b66c3387ce527f",
-        "68b7b0d39ac322dc4d5c3a0a868ccc2244ba5729"
-      ],
-      "committed_at": "2026-06-14T04:28:31Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27992,
-      "pr_url": "https://github.com/openai/codex/pull/27992",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for new_feature, protocol_change, release_packaging.",
-      "sample_paths": [
-        "MODULE.bazel.lock",
-        "codex-rs/Cargo.lock",
-        "codex-rs/Cargo.toml",
-        "codex-rs/state/Cargo.toml",
-        "codex-rs/state/src/lib.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27992",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "config_hooks"
-      ],
-      "title": "[codex] Pin bundled SQLite to fixed WAL-reset version",
-      "url": "https://github.com/openai/codex/pull/27992"
-    },
-    {
-      "attention_flags": [
-        "new_feature"
-      ],
-      "changed_file_count": 4,
-      "commit_shas": [
-        "24984b53cfed8bea45870dc5fe57a5ea6e796c61",
-        "888be7d90b2129e93bf28eb0070660601fa0ce77"
-      ],
-      "committed_at": "2026-06-15T10:21:02Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28283,
-      "pr_url": "https://github.com/openai/codex/pull/28283",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for new_feature.",
-      "sample_paths": [
-        "codex-rs/core/src/config/config_tests.rs",
-        "codex-rs/core/src/config/mod.rs",
-        "codex-rs/core/src/tools/handlers/multi_agents_spec.rs",
-        "codex-rs/core/src/tools/spec_plan_tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "28283",
+      "subject_id": "27813",
       "subject_kind": "pr",
       "surface_hints": [
         "config_hooks",
-        "tests_ci"
-      ],
-      "title": "[codex] update multi-agent v2 prompts",
-      "url": "https://github.com/openai/codex/pull/28283"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "01ef282efd1c41f07917b71178192dd10972841b",
-        "932662bcc1a52e17920a43b10c89f35577c9cb63"
-      ],
-      "committed_at": "2026-06-15T14:58:01Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28332,
-      "pr_url": "https://github.com/openai/codex/pull/28332",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server/src/request_processors/feedback_processor.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "28332",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol"
-      ],
-      "title": "[codex] Cap feedback upload subtrees",
-      "url": "https://github.com/openai/codex/pull/28332"
-    },
-    {
-      "attention_flags": [
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 7,
-      "commit_shas": [
-        "872e4d5152ea4a7e1b71f33bb206b5217f97efc8"
-      ],
-      "committed_at": "2026-06-15T15:15:45Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28333,
-      "pr_url": "https://github.com/openai/codex/pull/28333",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/app-server/tests/suite/v2/mcp_resource.rs",
-        "codex-rs/core/src/session/session.rs",
-        "codex-rs/ext/extension-api/src/contributors/thread_lifecycle.rs",
-        "codex-rs/ext/goal/tests/goal_extension_backend.rs",
-        "codex-rs/ext/skills/src/extension.rs",
-        "codex-rs/ext/skills/src/state.rs",
-        "codex-rs/ext/skills/tests/skills_extension.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "28333",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
         "mcp_plugins",
+        "sandbox_permissions",
         "tests_ci"
       ],
-      "title": "skills: hide orchestrator skills with a local executor",
-      "url": "https://github.com/openai/codex/pull/28333"
+      "title": "[codex] Reuse Apps policy evaluation across MCP tool exposure",
+      "url": "https://github.com/openai/codex/pull/27813"
     },
     {
       "attention_flags": [
-        "auth_account",
-        "protocol_change"
-      ],
-      "changed_file_count": 4,
-      "commit_shas": [
-        "b36c87b2ceb91ea08519c57162dfe2e52a332c4a"
-      ],
-      "committed_at": "2026-06-15T17:17:34Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27995,
-      "pr_url": "https://github.com/openai/codex/pull/27995",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, protocol_change.",
-      "sample_paths": [
-        "codex-rs/app-server/src/request_processors/turn_processor.rs",
-        "codex-rs/app-server/tests/suite/v2/thread_settings_update.rs",
-        "codex-rs/core/src/session/tests.rs",
-        "codex-rs/protocol/src/protocol.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27995",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "config_hooks",
-        "tests_ci"
-      ],
-      "title": "[codex] preserve explicit environment cwd",
-      "url": "https://github.com/openai/codex/pull/27995"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "new_feature",
-        "protocol_change",
-        "rate_limit",
-        "security_policy"
-      ],
-      "changed_file_count": 9,
-      "commit_shas": [
-        "b10549a76402a14d8c7e650f6c5774e96e46be25",
-        "04e1e711d84df0411666203e53b430af662906ed",
-        "5d54c4ea4393631d951e2fff2d797cc9ad563a84",
-        "ee3d532e8f217fde9dcbe3c16b0584fd8b2b4992",
-        "34b933ac26cd90f3ab07f9a05b99c7e92d79defc",
-        "c01b8b9c3ecc5341fae2eb61efae75bffdd594cf",
-        "5b11f61b2be8a96db3fbbc8b8a58db1352740666",
-        "0ccf9cc1bd3a215e373364bcb46aeebef02fb744",
-        "4850301eb2b9f5750e92ef04880111309f16218f"
-      ],
-      "committed_at": "2026-06-15T17:25:37Z",
-      "next_step": "ai_review_required",
-      "pr_number": 26702,
-      "pr_url": "https://github.com/openai/codex/pull/26702",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, rate_limit, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server/src/request_processors/plugins.rs",
-        "codex-rs/app-server/tests/suite/v2/plugin_list.rs",
-        "codex-rs/tui/src/app.rs",
-        "codex-rs/tui/src/app/background_requests.rs",
-        "codex-rs/tui/src/app/event_dispatch.rs",
-        "codex-rs/tui/src/app_event.rs",
-        "codex-rs/tui/src/chatwidget.rs",
-        "codex-rs/tui/src/chatwidget/constructor.rs",
-        "codex-rs/tui/src/chatwidget/plugins.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "26702",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "cli_tui",
-        "mcp_plugins",
-        "tests_ci"
-      ],
-      "title": "TUI Plugin Sharing 2 - add remote plugin section plumbing",
-      "url": "https://github.com/openai/codex/pull/26702"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 5,
-      "commit_shas": [
-        "00c8016dd084973c4fd2844236781872cba16120"
-      ],
-      "committed_at": "2026-06-13T07:44:39Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27996,
-      "pr_url": "https://github.com/openai/codex/pull/27996",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/codex-api/src/endpoint/responses_websocket.rs",
-        "codex-rs/codex-api/src/sse/responses.rs",
-        "codex-rs/core/src/client.rs",
-        "codex-rs/core/src/client_tests.rs",
-        "codex-rs/core/tests/suite/turn_state.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27996",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "tests_ci"
-      ],
-      "title": "[codex] Send request-scoped turn state over WebSocket",
-      "url": "https://github.com/openai/codex/pull/27996"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "new_feature",
-        "protocol_change",
-        "release_packaging",
-        "security_policy"
-      ],
-      "changed_file_count": 5,
-      "commit_shas": [
-        "a568cdbec99e2f66947cc072a8824031eeaa25dd"
-      ],
-      "committed_at": "2026-06-13T08:27:58Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28002,
-      "pr_url": "https://github.com/openai/codex/pull/28002",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, release_packaging, security_policy.",
-      "sample_paths": [
-        "codex-rs/codex-api/src/endpoint/compact.rs",
-        "codex-rs/core/src/client.rs",
-        "codex-rs/core/src/compact_remote.rs",
-        "codex-rs/core/src/session/turn.rs",
-        "codex-rs/core/tests/suite/compact_remote.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "28002",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui",
-        "tests_ci"
-      ],
-      "title": "[codex] Send turn state through compact requests",
-      "url": "https://github.com/openai/codex/pull/28002"
-    },
-    {
-      "attention_flags": [
-        "release_packaging"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "4b3fd5e359221031616a66cad36299c4becd810b"
-      ],
-      "committed_at": "2026-06-13T19:55:53Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28001,
-      "pr_url": "https://github.com/openai/codex/pull/28001",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for release_packaging.",
-      "sample_paths": [
-        ".github/workflows/rust-release-windows.yml"
-      ],
-      "source_state": "merged",
-      "subject_id": "28001",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "[codex] package Windows ARM64 on x64",
-      "url": "https://github.com/openai/codex/pull/28001"
-    },
-    {
-      "attention_flags": [
-        "new_feature",
-        "release_packaging"
-      ],
-      "changed_file_count": 6,
-      "commit_shas": [
-        "db7a2aa50bc789d69b6a36ef0f6ff400d51a12dc",
-        "f57c946c5e0c2d1813a5e7121a3be2b09b2b4748",
-        "b9f330cabd62f9c69f9e7e7f9af87bd447498e20",
-        "00d33a1d0c033aeab91e311c3d47ccd5e1b54304",
-        "e7f67ea405c76d36e2a1d3a0d52d04c24e56be8d",
-        "74595cf140bf78d036a1a6ec6e33d21e2af76ef5",
-        "f549600c77ed3802be97afc670aad3e1e8a5c795",
-        "4dc3408a759fb12caaae3145686fcb6517a1f4c1",
-        "1859f054ada720b3c3b14590ea3517ed1a269642"
-      ],
-      "committed_at": "2026-06-14T04:52:32Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28120,
-      "pr_url": "https://github.com/openai/codex/pull/28120",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature, release_packaging.",
-      "sample_paths": [
-        "bazel/modules/wine.MODULE.bazel",
-        "bazel/rules/testing/wine.bzl",
-        "bazel/rules/testing/wine/BUILD.bazel",
-        "bazel/rules/testing/wine/src/lib.rs",
-        "bazel/rules/testing/wine/src/lib_tests.rs",
-        "third_party/powershell/BUILD.bazel"
-      ],
-      "source_state": "merged",
-      "subject_id": "28120",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "tests_ci"
-      ],
-      "title": "bazel: add PowerShell to Wine test harness",
-      "url": "https://github.com/openai/codex/pull/28120"
-    },
-    {
-      "attention_flags": [
-        "new_feature",
-        "protocol_change",
-        "release_packaging"
-      ],
-      "changed_file_count": 4,
-      "commit_shas": [
-        "377700dd9f2079789f278fdd824ef5edbe81aa3d",
-        "cbe210fec0099907deb586bfab9e096ecaed6d79",
-        "0a168379203140f3cc71317b2a42fb94f8819d51",
-        "feea9f34655b52ab0fe2b6557d906f5f787ddc36",
-        "92dba3d12fc96c20cdb49258954fbe7103e1dd4c",
-        "aa5c37c849ae0dc51572f8d1c0cf6fc3e6ffd720",
-        "73620dc8a5e1dca2a92db78a8e6816a336ef9af7",
-        "2fec80ce01253a6e7414045b2e14bb2018608450",
-        "750ea1b4a976f5e1aaf24646c45371ae608c4519",
-        "c210314e68dcd6be2ca724d7883935dabc12e4fa",
-        "26b531ceb5f1c1351269c25be9c2d522fda99ec0",
-        "12650ca3637c4e8dc15860264baed9645f1a45b7",
-        "2ac53324769ae038aacaec3febd69c968ced5d30",
-        "f2cbe718ae4d9180b4f38672eca2adaf60b4baac",
-        "b19077b4f994b0b789d0f9d1ba0c5c359b0cbc37"
-      ],
-      "committed_at": "2026-06-14T05:26:49Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27819,
-      "pr_url": "https://github.com/openai/codex/pull/27819",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature, protocol_change, release_packaging.",
-      "sample_paths": [
-        "codex-rs/utils/path-uri/src/api_path_string.rs",
-        "codex-rs/utils/path-uri/src/api_path_string_tests.rs",
-        "codex-rs/utils/path-uri/src/lib.rs",
-        "codex-rs/utils/path-uri/src/tests.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27819",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "tests_ci"
-      ],
-      "title": "path-uri: render native paths across platforms",
-      "url": "https://github.com/openai/codex/pull/27819"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
         "deprecated_removed",
         "new_feature",
-        "protocol_change",
-        "security_policy"
+        "protocol_change"
       ],
-      "changed_file_count": 18,
+      "changed_file_count": 2,
       "commit_shas": [
-        "75b42ead5b591cc209cd00c15e5afcadf25156e2",
-        "ddcc446526f6009cf238a9a95f0d1048673a5ec8",
-        "f46f930650b35d98ff364960a34307bc7ecae05f"
+        "a6fcbb16f108a93ac8710414b340b8a347e74a21",
+        "740875681ea2a1aa44cddd5a6e3d090bc3b6f81c"
       ],
-      "committed_at": "2026-06-15T15:18:13Z",
+      "committed_at": "2026-06-15T23:09:43Z",
       "next_step": "ai_review_required",
-      "pr_number": 27756,
-      "pr_url": "https://github.com/openai/codex/pull/27756",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "pr_number": 28395,
+      "pr_url": "https://github.com/openai/codex/pull/28395",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/core/src/agent/control.rs",
-        "codex-rs/core/src/context/environment_context_tests.rs",
-        "codex-rs/core/src/session/mod.rs",
-        "codex-rs/core/src/session/session.rs",
-        "codex-rs/core/src/session/tests.rs",
-        "codex-rs/core/src/shell.rs",
-        "codex-rs/core/src/shell_snapshot.rs",
-        "codex-rs/core/src/shell_snapshot_tests.rs",
-        "codex-rs/core/src/shell_tests.rs",
-        "codex-rs/core/src/state/service.rs",
-        "codex-rs/core/src/tasks/user_shell.rs",
-        "codex-rs/core/src/tasks/user_shell_tests.rs"
+        "codex-rs/core-plugins/src/remote.rs",
+        "codex-rs/core-plugins/src/remote_tests.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27756",
+      "subject_id": "28395",
       "subject_kind": "pr",
       "surface_hints": [
+        "mcp_plugins",
         "tests_ci"
       ],
-      "title": "[codex] simplify shell snapshot ownership",
-      "url": "https://github.com/openai/codex/pull/27756"
+      "title": "[codex] Preserve remote plugin directory order",
+      "url": "https://github.com/openai/codex/pull/28395"
     },
     {
       "attention_flags": [
         "auth_account",
         "breaking_change",
         "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 14,
+      "commit_shas": [
+        "b4e6758e756123a7c2ee52be888ab6e6a544dbff",
+        "f7c8157651ea3a2f589ec17ae4f367af90120b11",
+        "1d4e81968f2b93c3f34ff296f5215bf1e8c7ffac",
+        "987bc42be7d9c8d9c4e1e952f20cf6c8856bcebb",
+        "1a286807a98e081f00c5ba0030c93879dcf31ed0",
+        "4c94d20ae013b408a6f9851fd8741232660f16f1",
+        "c6481cb945ff550d6165890653522ae221b8635a",
+        "7a0b15b72f8e29ce9356712d77cfe5521345a6bc",
+        "56a40eecbb787783970d6dc00c4068f586b17cde",
+        "f4c74a4c46a83ee25016477fe6c85a0f404140cb",
+        "f5ea28cf215802c1050812ad2a9bde791b5f81e0",
+        "b0970f98bd94800cab88d78822d45ba6fd1b3036",
+        "23d04357c7870fea60111700ae4e29b6172c6c49",
+        "ee626108cbb138883ab9390c02f555869f620ed4"
+      ],
+      "committed_at": "2026-06-15T23:15:07Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27955,
+      "pr_url": "https://github.com/openai/codex/pull/27955",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/src/agents_md.rs",
+        "codex-rs/core/src/agents_md_tests.rs",
+        "codex-rs/core/src/codex_delegate.rs",
+        "codex-rs/core/src/environment_selection.rs",
+        "codex-rs/core/src/mcp_tool_call_tests.rs",
+        "codex-rs/core/src/session/mcp.rs",
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/session/session.rs",
+        "codex-rs/core/src/session/tests.rs",
+        "codex-rs/core/src/session/tests/guardian_tests.rs",
+        "codex-rs/core/src/session/turn_context.rs",
+        "codex-rs/core/src/state/service.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27955",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "[codex] retain resolved environments across turns",
+      "url": "https://github.com/openai/codex/pull/27955"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 15,
+      "commit_shas": [
+        "58cec52819abcec54bce14133986a1e4bd4d3a3e",
+        "4c2a85316907f0ee7f6093a1368877cb119e176b",
+        "aa1b854043fcd6fa152b0d2dee3f7edc2268af66",
+        "38a8d2412d2ff035532caba22b7c1a24f6a4bd94",
+        "10f84b4b3ab5bf6474ac5779495d703f94c4ec45",
+        "58474a5868bc36efed6f7352d3fcffd7afafb4dc",
+        "5cfce1b15c55a08b7f1d573a4c4106083658d3f0",
+        "ab5d0d0282817d0353090ec414b2b30ea1498b86",
+        "63c228e9f3b6fb131451e72ab6ba3716ba2bac1e",
+        "ebabc004ff039fb065b0309f3ba30600f12a376f",
+        "47b863388a7b9f17d1c6cad1301ada846b9f8fba",
+        "25cdef98895a025d1e87c771be927e5ca0a82ee7",
+        "6acf653491ae1d21449072be224fc5977730564d"
+      ],
+      "committed_at": "2026-06-15T23:15:58Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27917,
+      "pr_url": "https://github.com/openai/codex/pull/27917",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server-protocol/src/protocol/common.rs",
+        "codex-rs/app-server-protocol/src/protocol/v2/realtime.rs",
+        "codex-rs/app-server/README.md",
+        "codex-rs/app-server/src/message_processor.rs",
+        "codex-rs/app-server/src/request_processors.rs",
+        "codex-rs/app-server/src/request_processors/turn_processor.rs",
+        "codex-rs/app-server/tests/common/test_app_server.rs",
+        "codex-rs/app-server/tests/suite/v2/experimental_api.rs",
+        "codex-rs/app-server/tests/suite/v2/realtime_conversation.rs",
+        "codex-rs/core/src/realtime_conversation.rs",
+        "codex-rs/core/src/realtime_conversation_tests.rs",
+        "codex-rs/core/src/session/handlers.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27917",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "docs_examples",
+        "tests_ci"
+      ],
+      "title": "Add realtime speech append control",
+      "url": "https://github.com/openai/codex/pull/27917"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 17,
+      "commit_shas": [
+        "3fedaaa5e3898a21013d3272f02d41539dbd0bbd",
+        "6af9ab03ab7cce46e239254b3ced77ed69f54d1f",
+        "46ed57871a4736b09d19019ccf182e0da8b3fb2d",
+        "ff6a21888a72916e383484f46ea220d0cdea825e",
+        "6192c19a33400f5981bebd07f6f6b18687770e1f",
+        "912ee19526f5276f99e5dd1ec923a74859ed686e",
+        "6a0a7c1871536eb1dcb533b268aba1386672c78a",
+        "d845eb7a9c1118c7fd000fda150aabea1fd0ae2f",
+        "9ffdc4297acbec6febbfc632256253e3b4cb6fb8",
+        "86c688a448360685723a7fc2879608e7f201ab50",
+        "02e8b09a93c5d92ba2c0d31aec79f483dfca62a5",
+        "c8988353cd96b5f2c9268d29e4c5a7158eda7282",
+        "76e6145a3fbe373b86c227dc78cdb83a28767260",
+        "b4ce8857bcab56cdada4165614e5dadd255aa2a5",
+        "9190977f96beafad10c2c40a95725ef98defefbf",
+        "00f4a7408cf66c1b931b4dac85514c14df14fc6b",
+        "7117c9af9740bbe4774cd98c5ba6a85c1c52947f",
+        "6de8fc4f378fa162942d5a3888f4a606bb55a44e",
+        "82bbcb1454010eb527a4226e84a076d49344fe79",
+        "6483743dce2638a856b410d0fe072961cd0ffd80"
+      ],
+      "committed_at": "2026-06-15T23:55:23Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28165,
+      "pr_url": "https://github.com/openai/codex/pull/28165",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/Cargo.lock",
+        "codex-rs/core/Cargo.toml",
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/session/turn_context.rs",
+        "codex-rs/core/src/tools/runtimes/apply_patch.rs",
+        "codex-rs/core/src/tools/runtimes/apply_patch_tests.rs",
+        "codex-rs/exec-server/src/fs_sandbox.rs",
+        "codex-rs/exec-server/src/protocol.rs",
+        "codex-rs/exec-server/tests/file_system/shared.rs",
+        "codex-rs/ext/image-generation/src/tool.rs",
+        "codex-rs/file-system/Cargo.toml",
+        "codex-rs/file-system/src/lib.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28165",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "config_hooks",
+        "model_provider",
+        "sandbox_permissions",
+        "tests_ci"
+      ],
+      "title": "Use PathUri in filesystem permission paths for exec-server",
+      "url": "https://github.com/openai/codex/pull/28165"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 5,
+      "commit_shas": [
+        "867e7dfb0167f048017a79a8da2ce8e5ecb9b51e",
+        "47889f50220135ea1d170b620ef79aa9e3dd34b2",
+        "17cd2e0d77b51fecfef350a41194cd659c224756"
+      ],
+      "committed_at": "2026-06-16T00:13:27Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27902,
+      "pr_url": "https://github.com/openai/codex/pull/27902",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/core-plugins/src/app_mcp_routing.rs",
+        "codex-rs/core-plugins/src/app_mcp_routing_tests.rs",
+        "codex-rs/core-plugins/src/lib.rs",
+        "codex-rs/core-plugins/src/loader.rs",
+        "codex-rs/core-plugins/src/manager.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27902",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "[codex] Centralize plugin auth capability filtering",
+      "url": "https://github.com/openai/codex/pull/27902"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 12,
+      "commit_shas": [
+        "7c7ddb6734726efdf5b8b5428aa184c096fcafa9",
+        "33e611a206a0afceb08cbb25a8305390535679b8",
+        "5979d2049f94aca849e7af3d30896c138d52d285"
+      ],
+      "committed_at": "2026-06-16T00:14:22Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28405,
+      "pr_url": "https://github.com/openai/codex/pull/28405",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/app-server-protocol/src/protocol/common.rs",
+        "codex-rs/app-server-protocol/src/protocol/v2/realtime.rs",
+        "codex-rs/app-server/README.md",
+        "codex-rs/app-server/src/request_processors/turn_processor.rs",
+        "codex-rs/app-server/tests/suite/v2/experimental_api.rs",
+        "codex-rs/app-server/tests/suite/v2/realtime_conversation.rs",
+        "codex-rs/codex-api/tests/clients.rs",
+        "codex-rs/core/src/guardian/tests.rs",
+        "codex-rs/core/src/realtime_conversation.rs",
+        "codex-rs/core/tests/suite/compact_remote.rs",
+        "codex-rs/core/tests/suite/realtime_conversation.rs",
+        "codex-rs/protocol/src/protocol.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28405",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "docs_examples",
+        "tests_ci"
+      ],
+      "title": "Add a toggle for realtime startup context",
+      "url": "https://github.com/openai/codex/pull/28405"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 28,
+      "commit_shas": [
+        "1fe89de576e2ee6dc341e6f97beca6160ef85a7f"
+      ],
+      "committed_at": "2026-06-16T00:38:41Z",
+      "next_step": "ai_review_required",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        ".codex/skills/remote-tests/SKILL.md",
+        ".github/workflows/rust-ci-full-nextest-platform.yml",
+        "bazel/rules/testing/BUILD.bazel",
+        "bazel/rules/testing/wine/BUILD.bazel",
+        "bazel/rules/testing/wine/wine.bzl",
+        "bazel/rules/testing/wine/wine_runtime.bzl",
+        "codex-rs/core/BUILD.bazel",
+        "codex-rs/core/README.md",
+        "codex-rs/core/tests/common/lib.rs",
+        "codex-rs/core/tests/common/test_codex.rs",
+        "codex-rs/core/tests/common/test_environment.rs",
+        "codex-rs/core/tests/common/test_environment_tests.rs"
+      ],
+      "source_state": "commit_only",
+      "subject_id": "1fe89de576e2ee6dc341e6f97beca6160ef85a7f",
+      "subject_kind": "commit",
+      "surface_hints": [
+        "cli_tui",
+        "docs_examples",
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "Run core integration tests against a Wine-backed Windows executor (#28401)",
+      "url": "https://github.com/openai/codex/commit/1fe89de576e2ee6dc341e6f97beca6160ef85a7f"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 14,
+      "commit_shas": [
+        "df0bd43d1a101b364ab020ef76cf2bb3a58e9e2e",
+        "fd62a249359eaff578aaf7dba7312523f74fdc45",
+        "1ec95939ec4edfdab7fcab8828db3e1d11eb2e25",
+        "29b362f80b16526c2ca80591aa93d4030304c6bf",
+        "5bd27876ee5845b0530cdf2168656cda2df6bf4f",
+        "3088d8f27e8ea50a2bb0b9924d1ced86b3c37a2d",
+        "b227892a4826fc0bab82810e9ee8f47d0999bd52",
+        "02820307b694d14ae81dbc0ff2b1fe527e1a0900",
+        "3471354c8fc7b5f3a0657bf8767fd6b182df19ac",
+        "1489125cb54f33cda0d7733c6f84027b719995f8",
+        "bbdf6db07c6878c45adf8a5395c1c447f95e3250",
+        "fa185c855d8f8bca1813c58a7fccefb7a692214f",
+        "e7ca54923bbb8f7cca92a005cc15302a30a5dae7",
+        "428a3bacce7d634e8c377d7032a76af78f45bd71",
+        "e86ca5de78988cc188171e4a4cadaa754ee9efe0",
+        "bcf6865cd9e48644b24530aa5c20465d0db6457c",
+        "e954b02d42e5f883351ddc78a08b6d3da90f07ba",
+        "028674d832090e87eb5c580e9e7b6c680a6e1f10",
+        "8655d15d8364e83d1639c357fad34ed6447867b3",
+        "0432dde319956a6ce052d43bec5ee2a9277cd249",
+        "5a65a483d0c15250e2a48adf7a502443914d3cad",
+        "ce5c32820193f236189496fe79a0d60ebba83eae",
+        "2920f1697db1f683ac473a9c986a7083e3b2977d",
+        "bf0e32f4dbb2249c1b55bd6732eb87a9903d0665",
+        "a4ff4374dcee30e09cb60047b07d5bf718f16d7d",
+        "03dfa9cb757dbff7c65b534e23b40d22df328bff",
+        "e29f41db0e0928241ab94770088cd228cc7068f5",
+        "e418a236af50876e14976d1876ff9a277e5df0d0",
+        "d0b2e0cfe6a68a0d64e149cc7df44b4cf82a0774",
+        "160e092ceee90fc83390ba23ad76ec6e3929ba4c",
+        "98035668ae85ea783c0f9b126ebee2d9ea408f90",
+        "bbd64c3595cab0388a2639fbeab39bb21d27dd35",
+        "63376d66757a35e3b856932bcd582d61ea2d7628",
+        "faf5a6ea2018e750717902930ff65ef0805dec9c",
+        "aad59de3a7a8ea63fb0434722f35b343946cf6b5",
+        "587b5f0858e2aa9205d73d6d345439c23868e7ae",
+        "73d8c8ab1ad180b4727d76f3cbafe3410ac45cb5",
+        "fa0d65ec9a3da084f43a7bbddfce9c3b6a079aec",
+        "1e8ccc07e29e5c756902ec04fba4848176680713",
+        "b127ad1c2e058b333820faef893fc25372e04dd2",
+        "5896f50c69114793de041360a8eca5ede930c649",
+        "7ebb6705a88dd96407ede0fd349c195af0001be0",
+        "e672196c663ec33ccbe1e98c42a006d3f7274f7e",
+        "2fee5cc2197e19e6d1ee53d1740508e79efd9f10",
+        "8b1f05bf868054083dcad20fb7013a9a4b353551",
+        "5bfdbaa8ea1ecb10b0d76164996627c17830f858",
+        "aff7b52037cc0287c821f05e955aa188df218088",
+        "b6d245874458bc38c183e3594cd80c5b3c69c9ec",
+        "57cd12060d002bafef1bcaffd21f403f3fd944e1",
+        "3324ec61f0174446aa0aa7f30591cf51abcfab8f",
+        "6ec5b8385ac4cc5f9a9223af200bf34633345af2",
+        "2e079eb8290735d1cf9ab288a8b02549d1d9f015",
+        "dbf69d5de0df29f5ab9d72ce239110336590abe0",
+        "854a2a5a6fba911fb411285414ac3aebaadbc036",
+        "e2abc4a03a6f9c181c1609059376a8b98ca06541",
+        "34744f6e9efd581c6b09de4a62407f510c7a974a",
+        "ce76429393b20eaae708a802253b8c8499a90cf6",
+        "718ac397e0a5003a5770ead23aa997218e018a1c",
+        "4c4c1c5082d575306cc1d5d4470eb3b9c376b0a5",
+        "9fd6a713d69e3b9693d20d3ba4daaaf5fb181922",
+        "e523bc81353ab894d67790c4150fdad9ffa4ffe8",
+        "0322f4710e636412da359d452f95199c13ff5523",
+        "7895dec9ac39e106667a35263fffcbf1437615bf",
+        "f01d4cdee2d11cf17b05c9ca7b40f911f7fe8baa",
+        "39409495e9be27cc440cede7f15467d3a71fa63e",
+        "dba754c9585a7167fc4eff0ddcbe764367fa92d9",
+        "3b4c4a8f5638f35c90c621608e296ab4174fd751",
+        "05fbd5f71abcbe491f7a39629eca365851540673",
+        "cb2f2cafb26beb4b6df54999b2fdffe2e7b0c29a",
+        "d598785f97dcc92959d722e07dcd7fd7e0d21080",
+        "9bd7e9e806e1589998db320a69a839e55a0bc094",
+        "8e120cc064dbceb9981c19ea96685cb30692844f",
+        "69f7f9a151a19f6f307b886eb457f797be829734",
+        "ef96b262ae3b06eeab67d940826bbdd4c2332811",
+        "fb051b7ea044e544015e168b29d16c01a028c65f",
+        "56c4fbed1030f8cffaefcc8dd54f45c6cffc805d",
+        "0fa9f534d32d82a21a3b5346ec8fd48c1629870a",
+        "32bc229a919d8fa59417b808e87ece7f008ac776",
+        "7895ef18797c0f0ac97a0abde5479c7f8befb664",
+        "2e437487b0099c0708b1c06ada1aa1a439f58609",
+        "3a4237195abe5a0504226146fd6dcd04b57eb567",
+        "0ec082d602b9c96fbd3e27c57e7236ad03b57e34",
+        "ddb682fb3257aaf398fdf843d275de2f41074308",
+        "eb10e5c8aec12353ee7d98eca615a367c8035353",
+        "71817d1026e36d365845c01aa3e2bc529d5574ff",
+        "c6e20ebac726c4247cc2ce48554a89cd2726a9a7",
+        "6c6ea8db4c1b3f2ecf6ec521c0012b1962412e29",
+        "84222e273133e6c539c38e9788d63912a8b66dc7",
+        "591be53db99fe474ea5c440b551ed696cda4f9cb",
+        "75858fb47b77c2ce969076905dda259c45792de0",
+        "3a8f189042c82b3514f3787eb30b1ff87dfeaf8e",
+        "a1e295805a9a32a7dcf6c1ed6cd1dc19fbf85b52",
+        "e924c6a881a31ef19adc23b1c57dd083d065e698",
+        "f8e2d6af09bcdfd2f0a17df15177b60555107e9b",
+        "ace36bbc18004555fabbab5f13053bcc634bd8ff",
+        "c51c634ba8fb2d0784b077e9efd2206852f11ae8",
+        "a4aed385a5ea6940b018daa9cd9c8b0ac7e8384b",
+        "2d3f9be4d2448004a2832ba28cdc52de46eca9cc",
+        "19b51698409955c4472a6671b1eac8eea22529de",
+        "7987321cebc8802d20f2e7a7c7d42627449d369e",
+        "60d0968361172d8ace2d94a2739a912d8b94ebf1",
+        "6d04a9997039184603c97a9822276b3047701c27",
+        "708c93e5a3c7fcc6a155ef990a738731d87e26c4",
+        "d887e21d4b67e4f6a00ce6c7a78d969fcac3288d",
+        "0dc01ae169e232fff46bb2fd35ceed27f90cc2c7",
+        "b9f2d753e49e4b6dddf6c191bbdd37be74e64591",
+        "59b780c84a232505565fc7de8474432278a78a70",
+        "fa0402a66d2933235b8f4aa805b497ad89e3711b",
+        "c2d72bdec6a3b90605f4cd9f5f6c6534debf338c"
+      ],
+      "committed_at": "2026-06-16T00:39:00Z",
+      "next_step": "ai_review_required",
+      "pr_number": 26245,
+      "pr_url": "https://github.com/openai/codex/pull/26245",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/cli/Cargo.toml",
+        "codex-rs/exec-server/README.md",
+        "codex-rs/exec-server/src/noise_channel.rs",
+        "codex-rs/exec-server/src/noise_channel_tests.rs",
+        "codex-rs/exec-server/src/noise_relay/executor_stream.rs",
+        "codex-rs/exec-server/src/noise_relay/executor_stream_tests.rs",
+        "codex-rs/exec-server/src/noise_relay/harness.rs",
+        "codex-rs/exec-server/src/noise_relay/mod.rs",
+        "codex-rs/exec-server/src/relay.rs",
+        "codex-rs/exec-server/src/relay_noise_tests.rs",
+        "codex-rs/exec-server/src/relay_proto.rs",
+        "codex-rs/exec-server/src/remote.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "26245",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "config_hooks",
+        "docs_examples",
+        "tests_ci"
+      ],
+      "title": "exec-server: default remote transport to Noise",
+      "url": "https://github.com/openai/codex/pull/26245"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 16,
+      "commit_shas": [
+        "37d15663bd55c36814ad8ba6ac64db1ee3603242",
+        "b9f0ed5a632a0a9f83d99c241f10fe07e3d1e7ca",
+        "6a8424dab00418aba044793dfff5ac77593a3e83",
+        "390f97379dd2273bcf57d4b2ba0c7676b4331658",
+        "d3cf5560a8830d2a1c134353412eb85c1fdc032a",
+        "865ba49b7b3919fb94ec9041fdc2915772b2fa7f",
+        "972c747b1ba0d7c7866221e04e153879b80cd023",
+        "d39478b7c2e874c1bf03aad7d324b75ef2baca6a",
+        "8da598789d2a30a871acbc50a8ada6dcd1ac7fcd",
+        "e44498703e96987062d471aeb8fded8f5f383144",
+        "55cc34b6753cf6d04bd366595bf0a8055ccbba33"
+      ],
+      "committed_at": "2026-06-16T01:16:11Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28383,
+      "pr_url": "https://github.com/openai/codex/pull/28383",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/app-server/src/request_processors/plugins.rs",
+        "codex-rs/app-server/tests/suite/v2/plugin_list.rs",
+        "codex-rs/cli/src/marketplace_cmd.rs",
+        "codex-rs/cli/src/plugin_cmd.rs",
+        "codex-rs/core-plugins/src/discoverable.rs",
+        "codex-rs/core-plugins/src/discoverable_tests.rs",
+        "codex-rs/core-plugins/src/lib.rs",
+        "codex-rs/core-plugins/src/loader.rs",
+        "codex-rs/core-plugins/src/manager.rs",
+        "codex-rs/core-plugins/src/manager_tests.rs",
+        "codex-rs/core-plugins/src/marketplace.rs",
+        "codex-rs/core-plugins/src/marketplace_add.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28383",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "[codex] Load API curated marketplace by auth",
+      "url": "https://github.com/openai/codex/pull/28383"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 34,
+      "commit_shas": [
+        "e66c563b90e4bd363b0edf4d5e362b4f88d7c0f5",
+        "81cb2f67922ad4bc8f5d3fc6b8204a80b48680e8",
+        "49719df9c448eb66b9cea800cc60f4fd4e084b11",
+        "9198eb19f60c023b13170d3195ced2a3c3020ca3",
+        "ed9f88b542d22cf919d3dd69133c6346602ca678",
+        "784cb9fed57a53c2e9b9780e5c5a4d8497341221",
+        "37c5cd22e52ee82acf237e36458a4b5ad8c796de",
+        "6a3a776a98c04c220ad66e15951e4cd5953dab4f",
+        "6e999d9a688daaf75fa4f2dc33a9f92a14856c98",
+        "c5baf2fc9abdc5dd6e5e6c137126ce497ec399ef"
+      ],
+      "committed_at": "2026-06-16T02:25:54Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28367,
+      "pr_url": "https://github.com/openai/codex/pull/28367",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/Cargo.lock",
+        "codex-rs/app-server-protocol/Cargo.toml",
+        "codex-rs/app-server-protocol/schema/json/CommandExecutionRequestApprovalParams.json",
+        "codex-rs/app-server-protocol/schema/json/PermissionsRequestApprovalParams.json",
+        "codex-rs/app-server-protocol/schema/json/PermissionsRequestApprovalResponse.json",
+        "codex-rs/app-server-protocol/schema/json/ServerNotification.json",
+        "codex-rs/app-server-protocol/schema/json/ServerRequest.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ItemGuardianApprovalReviewCompletedNotification.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ItemGuardianApprovalReviewStartedNotification.json",
+        "codex-rs/app-server-protocol/schema/typescript/ApiPathString.ts"
+      ],
+      "source_state": "merged",
+      "subject_id": "28367",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "config_hooks",
+        "release_packaging",
+        "sandbox_permissions",
+        "tests_ci"
+      ],
+      "title": "Use ApiPathString in app-server filesystem permission paths",
+      "url": "https://github.com/openai/codex/pull/28367"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 37,
+      "commit_shas": [
+        "a8971a07a3e1b9d96fe4cef65dbcacc9b7ecac70",
+        "b87412eca5243e00f2c01137159093109f658c6c",
+        "d14bb151d77e9dd5a9e07fc42e454e80382e8169",
+        "6df293aa7befe412935890bcb3ce2daa5330863d",
+        "0e0bb90c7769c73cd1d3d149f892111abfed0ecb",
+        "de814e8fcbf2c19136d388b0118e9683b928c3cd",
+        "43401da619e3aba8062a76a609097a0263f78064"
+      ],
+      "committed_at": "2026-06-16T04:39:21Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28429,
+      "pr_url": "https://github.com/openai/codex/pull/28429",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/analytics/src/reducer.rs",
+        "codex-rs/app-server-protocol/schema/json/ServerNotification.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ItemCompletedNotification.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ItemStartedNotification.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ReviewStartResponse.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json"
+      ],
+      "source_state": "merged",
+      "subject_id": "28429",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "config_hooks",
+        "docs_examples",
+        "sandbox_permissions",
+        "tests_ci"
+      ],
+      "title": "[codex] Add interruptible sleep tool",
+      "url": "https://github.com/openai/codex/pull/28429"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 118,
+      "commit_shas": [
+        "4c3bfdc2569adaf00e6ab8a0e31a84ac35ac6bd7",
+        "86c50896240cac47a94c14eac50e7e3ed9a1c589",
+        "78c1abc79d756d91bcadd5c6c5b0caf0a93f6aa0",
+        "c6de69df5afe165dc21705428cfeeb71717fd8e2",
+        "9a94559a3a9ca8d0ee4ec432f4f77250eed98f3a",
+        "71ac5f568d7c3e193e4e87d56c499d296bfb8edc"
+      ],
+      "committed_at": "2026-06-16T04:53:47Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28441,
+      "pr_url": "https://github.com/openai/codex/pull/28441",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server/tests/all.rs",
+        "codex-rs/app-server/tests/common/config.rs",
+        "codex-rs/app-server/tests/common/lib.rs",
+        "codex-rs/app-server/tests/common/mock_model_server.rs",
+        "codex-rs/app-server/tests/suite/v2/client_metadata.rs",
+        "codex-rs/app-server/tests/suite/v2/compaction.rs",
+        "codex-rs/app-server/tests/suite/v2/fs.rs",
+        "codex-rs/app-server/tests/suite/v2/plan_item.rs",
+        "codex-rs/app-server/tests/suite/v2/realtime_conversation.rs",
+        "codex-rs/app-server/tests/suite/v2/thread_shell_command.rs",
+        "codex-rs/app-server/tests/suite/v2/turn_start.rs",
+        "codex-rs/app-server/tests/suite/v2/turn_start_zsh_fork.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28441",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "auth_accounts",
+        "cli_tui",
+        "config_hooks",
+        "mcp_plugins",
+        "model_provider",
+        "release_packaging",
+        "sandbox_permissions",
+        "tests_ci"
+      ],
+      "title": "[codex] Use expect in integration tests",
+      "url": "https://github.com/openai/codex/pull/28441"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 7,
+      "commit_shas": [
+        "6234ef57439eddc22c694c0774151f45ad7f4e43",
+        "9ffb2384372e917be3a353552632918932db6cee",
+        "173510103e72c03477b79a8d5272049d9321c40b"
+      ],
+      "committed_at": "2026-06-15T18:20:19Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28336,
+      "pr_url": "https://github.com/openai/codex/pull/28336",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/app-server/tests/suite/v2/mcp_resource.rs",
+        "codex-rs/codex-mcp/src/lib.rs",
+        "codex-rs/codex-mcp/src/resource_client.rs",
+        "codex-rs/ext/skills/src/extension.rs",
+        "codex-rs/ext/skills/src/state.rs",
+        "codex-rs/ext/skills/src/tools/mod.rs",
+        "codex-rs/ext/skills/src/tools/read.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28336",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "cli_tui",
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "skills: cache orchestrator resources per thread",
+      "url": "https://github.com/openai/codex/pull/28336"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 6,
+      "commit_shas": [
+        "328cff02bf68502c2de666f0f94f6c25b24ae401",
+        "13875519fa99eb18c816c14b3b7237b9507ae9e3"
+      ],
+      "committed_at": "2026-06-15T18:30:48Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28357,
+      "pr_url": "https://github.com/openai/codex/pull/28357",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/cli/src/debug_sandbox.rs",
+        "codex-rs/windows-sandbox-rs/Cargo.toml",
+        "codex-rs/windows-sandbox-rs/src/lib.rs",
+        "codex-rs/windows-sandbox-rs/src/stdio_bridge.rs",
+        "codex-rs/windows-sandbox-rs/src/stdio_bridge_tests.rs",
+        "codex-rs/windows-sandbox-rs/src/unified_exec/mod.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28357",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "config_hooks",
+        "sandbox_permissions",
+        "tests_ci"
+      ],
+      "title": "Extract shared Windows sandbox session runner",
+      "url": "https://github.com/openai/codex/pull/28357"
+    },
+    {
+      "attention_flags": [],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "9c05bee3c603bed6409464dde1fd2aa8b56b78dd"
+      ],
+      "committed_at": "2026-06-15T20:07:01Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28234,
+      "pr_url": "https://github.com/openai/codex/pull/28234",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for surface hints: cli_tui, mcp_plugins.",
+      "sample_paths": [
+        "codex-rs/codex-mcp/src/rmcp_client.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28234",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "mcp_plugins"
+      ],
+      "title": "[mcp] Increase default tool timeout to 300 seconds",
+      "url": "https://github.com/openai/codex/pull/28234"
+    },
+    {
+      "attention_flags": [
         "new_feature",
         "protocol_change",
         "security_policy"
       ],
       "changed_file_count": 11,
       "commit_shas": [
-        "a42dd05a6108e69fc609f65e0d221793b4ec0012"
+        "60d83296f23ed93f314ad93071617a60e6e9e1ab",
+        "4c6293f4c28ff76c4c5e76d923cc79ecc40aef03"
       ],
-      "committed_at": "2026-06-15T15:23:02Z",
+      "committed_at": "2026-06-15T21:30:32Z",
       "next_step": "ai_review_required",
-      "pr_number": 27794,
-      "pr_url": "https://github.com/openai/codex/pull/27794",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "pr_number": 28358,
+      "pr_url": "https://github.com/openai/codex/pull/28358",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/features/src/lib.rs",
-        "codex-rs/features/src/tests.rs",
-        "codex-rs/tui/src/app.rs",
-        "codex-rs/tui/src/app/event_dispatch.rs",
-        "codex-rs/tui/src/app/resize_reflow.rs",
-        "codex-rs/tui/src/app/tests.rs",
-        "codex-rs/tui/src/app/thread_routing.rs",
-        "codex-rs/tui/src/app_backtrack.rs",
-        "codex-rs/tui/src/chatwidget.rs",
-        "codex-rs/tui/src/transcript_reflow.rs",
-        "codex-rs/tui/tests/suite/resize_reflow.rs"
+        "codex-rs/Cargo.lock",
+        "codex-rs/arg0/Cargo.toml",
+        "codex-rs/arg0/src/lib.rs",
+        "codex-rs/cli/src/debug_sandbox.rs",
+        "codex-rs/core/src/unified_exec/process_manager.rs",
+        "codex-rs/windows-sandbox-rs/src/lib.rs",
+        "codex-rs/windows-sandbox-rs/src/spawn_prep.rs",
+        "codex-rs/windows-sandbox-rs/src/unified_exec/backends/elevated.rs",
+        "codex-rs/windows-sandbox-rs/src/unified_exec/mod.rs",
+        "codex-rs/windows-sandbox-rs/src/wrapper.rs",
+        "codex-rs/windows-sandbox-rs/src/wrapper_tests.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27794",
+      "subject_id": "28358",
       "subject_kind": "pr",
       "surface_hints": [
         "cli_tui",
+        "config_hooks",
+        "sandbox_permissions",
         "tests_ci"
       ],
-      "title": "Remove terminal resize reflow flag gates",
-      "url": "https://github.com/openai/codex/pull/27794"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "protocol_change"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "afc5f40dcff3a6183e2105ee677c148b40cdef05",
-        "ebc30a9859152b0cf897abf4645e30bfa1f4378a"
-      ],
-      "committed_at": "2026-06-15T15:24:36Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28286,
-      "pr_url": "https://github.com/openai/codex/pull/28286",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, protocol_change.",
-      "sample_paths": [
-        "codex-rs/exec-server/src/relay.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "28286",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "internal_churn"
-      ],
-      "title": "chore: restore exec-server relay keepalives",
-      "url": "https://github.com/openai/codex/pull/28286"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "protocol_change"
-      ],
-      "changed_file_count": 6,
-      "commit_shas": [
-        "47d6e2f86f9867f8b5089c6aeee0d50942102537",
-        "48bcf9ab3a31d1170d28962088c31021df628b48",
-        "eef4faf488854783efe494edfb8a127e5a2a2f78",
-        "129948e0261d111ac21606e1b0465be19acaa86e",
-        "902bbe6ad5cbba6463ed38382a2bf9c093a5cda6"
-      ],
-      "committed_at": "2026-06-15T15:28:02Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28164,
-      "pr_url": "https://github.com/openai/codex/pull/28164",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, protocol_change.",
-      "sample_paths": [
-        "codex-rs/core/src/memory_usage.rs",
-        "codex-rs/core/src/tools/handlers/unified_exec.rs",
-        "codex-rs/core/src/tools/registry.rs",
-        "codex-rs/memories/read/src/usage.rs",
-        "codex-rs/shell-command/src/bash.rs",
-        "codex-rs/shell-command/src/parse_command.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "28164",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "internal_churn"
-      ],
-      "title": "[codex] simplify memory read metrics",
-      "url": "https://github.com/openai/codex/pull/28164"
+      "title": "Add hidden Windows sandbox wrapper entrypoint",
+      "url": "https://github.com/openai/codex/pull/28358"
     },
     {
       "attention_flags": [
         "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "c52bcb48c0feaaf55d2aa34231c6f0e1c9de73fe",
-        "242c548dfa23123671e50797b73366e3b5184a85"
-      ],
-      "committed_at": "2026-06-15T16:26:34Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28309,
-      "pr_url": "https://github.com/openai/codex/pull/28309",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/core/src/context_manager/normalize.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "28309",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "internal_churn"
-      ],
-      "title": "linearize history output normalization",
-      "url": "https://github.com/openai/codex/pull/28309"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "protocol_change"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "4ae63e1a8bcc1889a9e0b6c640a4ac272647d943",
-        "8e36bb0c7410351b761e9f8a56709098d3b3f2a5"
-      ],
-      "committed_at": "2026-06-15T16:26:44Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28306,
-      "pr_url": "https://github.com/openai/codex/pull/28306",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, protocol_change.",
-      "sample_paths": [
-        "codex-rs/core/src/session/turn.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "28306",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "internal_churn"
-      ],
-      "title": "avoid cloning sampling request input",
-      "url": "https://github.com/openai/codex/pull/28306"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "protocol_change"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "fe58231e02a6507f383bdc4f93b0959afeb414f2"
-      ],
-      "committed_at": "2026-06-15T16:33:35Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28323,
-      "pr_url": "https://github.com/openai/codex/pull/28323",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, protocol_change.",
-      "sample_paths": [
-        "codex-rs/codex-api/src/endpoint/responses_websocket.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "28323",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "internal_churn"
-      ],
-      "title": "serialize websocket requests directly",
-      "url": "https://github.com/openai/codex/pull/28323"
-    },
-    {
-      "attention_flags": [
-        "auth_account",
-        "breaking_change",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "50f08ba5a76b3d8696cb2d79296527e7a7211684",
-        "624a007e974277ec774bde7c242c2c4cdfd35791"
-      ],
-      "committed_at": "2026-06-15T16:48:47Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28313,
-      "pr_url": "https://github.com/openai/codex/pull/28313",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change.",
-      "sample_paths": [
-        "codex-rs/core/src/client.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "28313",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "cli_tui"
-      ],
-      "title": "avoid cloning websocket request history",
-      "url": "https://github.com/openai/codex/pull/28313"
-    },
-    {
-      "attention_flags": [
-        "deprecated_removed",
-        "new_feature",
+        "protocol_change",
         "security_policy"
       ],
-      "changed_file_count": 1,
+      "changed_file_count": 12,
       "commit_shas": [
-        "c7ed068da023d35761bd0aa2cb4a8ad82e38810e"
+        "3280c70b29863e9fa358761c7ba162d7044a2313",
+        "3e503cc125f7f497531b9a8b7e187af7ccca63dc",
+        "ba3ed1c45e6bfc6aba6232726a6b974fbb9680a4"
       ],
-      "committed_at": "2026-06-15T16:56:21Z",
+      "committed_at": "2026-06-15T21:48:30Z",
       "next_step": "ai_review_required",
-      "pr_number": 28344,
-      "pr_url": "https://github.com/openai/codex/pull/28344",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for deprecated_removed, new_feature, security_policy.",
+      "pr_number": 27258,
+      "pr_url": "https://github.com/openai/codex/pull/27258",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/core/src/tools/runtimes/mod_tests.rs"
+        "codex-rs/core/src/session/session.rs",
+        "codex-rs/core/src/session/tests.rs",
+        "codex-rs/core/src/session/turn.rs",
+        "codex-rs/core/src/state/service.rs",
+        "codex-rs/core/src/stream_events_utils_tests.rs",
+        "codex-rs/core/src/tools/handlers/mod.rs",
+        "codex-rs/core/src/tools/handlers/tool_search.rs",
+        "codex-rs/core/src/tools/router.rs",
+        "codex-rs/core/src/tools/router_tests.rs",
+        "codex-rs/core/src/tools/spec_plan.rs",
+        "codex-rs/core/src/tools/spec_plan_tests.rs",
+        "codex-rs/tools/src/tool_search.rs"
       ],
       "source_state": "merged",
-      "subject_id": "28344",
+      "subject_id": "27258",
       "subject_kind": "pr",
       "surface_hints": [
+        "mcp_plugins",
         "tests_ci"
       ],
-      "title": "[codex] remove stale PathExt import",
-      "url": "https://github.com/openai/codex/pull/28344"
+      "title": "core: cache the tool search handler per session",
+      "url": "https://github.com/openai/codex/pull/27258"
     },
     {
       "attention_flags": [
         "new_feature",
-        "protocol_change"
+        "protocol_change",
+        "security_policy"
       ],
-      "changed_file_count": 1,
+      "changed_file_count": 3,
       "commit_shas": [
-        "0a769d94561b48550af4a0bbdeff17bb1991d5d8"
+        "c4d5a4491019b94c98eb3d83019ec4f936b6552c",
+        "df528142cad801a608f7d8abbc66d9f34da95d61",
+        "f31b6d509305d4c2910b49f1e7d2c9502ebea8d7",
+        "6f6a4283dcf85abdbf3bba6d47ba4fea208777e2",
+        "b1d75376be003e5ba3e239ef25845e6119f59458"
       ],
-      "committed_at": "2026-06-15T16:59:26Z",
+      "committed_at": "2026-06-15T22:12:26Z",
       "next_step": "ai_review_required",
-      "pr_number": 27059,
-      "pr_url": "https://github.com/openai/codex/pull/27059",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature, protocol_change.",
+      "pr_number": 28365,
+      "pr_url": "https://github.com/openai/codex/pull/28365",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/otel/tests/suite/otlp_http_loopback.rs"
+        "codex-rs/core/src/tools/registry.rs",
+        "codex-rs/core/tests/suite/hooks.rs",
+        "codex-rs/hooks/src/events/post_tool_use.rs"
       ],
       "source_state": "merged",
-      "subject_id": "27059",
+      "subject_id": "28365",
       "subject_kind": "pr",
       "surface_hints": [
+        "config_hooks",
         "tests_ci"
       ],
-      "title": "[codex] Cover OTLP HTTP log and trace event export",
-      "url": "https://github.com/openai/codex/pull/27059"
+      "title": "Respect blocking PostToolUse hooks in code mode",
+      "url": "https://github.com/openai/codex/pull/28365"
     },
     {
       "attention_flags": [
         "auth_account",
         "new_feature",
         "protocol_change",
-        "release_packaging"
+        "release_packaging",
+        "security_policy"
       ],
-      "changed_file_count": 6,
+      "changed_file_count": 24,
       "commit_shas": [
-        "abe5c00b76d441e1a94bcb98ace2a4d5cf5c3315",
-        "7527b65d6c654a6706437d927dcb07dd425f2c9c"
+        "df0bd43d1a101b364ab020ef76cf2bb3a58e9e2e",
+        "fd62a249359eaff578aaf7dba7312523f74fdc45",
+        "1ec95939ec4edfdab7fcab8828db3e1d11eb2e25",
+        "29b362f80b16526c2ca80591aa93d4030304c6bf",
+        "5bd27876ee5845b0530cdf2168656cda2df6bf4f",
+        "3088d8f27e8ea50a2bb0b9924d1ced86b3c37a2d",
+        "b227892a4826fc0bab82810e9ee8f47d0999bd52",
+        "02820307b694d14ae81dbc0ff2b1fe527e1a0900",
+        "3471354c8fc7b5f3a0657bf8767fd6b182df19ac",
+        "1489125cb54f33cda0d7733c6f84027b719995f8",
+        "bbdf6db07c6878c45adf8a5395c1c447f95e3250",
+        "fa185c855d8f8bca1813c58a7fccefb7a692214f",
+        "e7ca54923bbb8f7cca92a005cc15302a30a5dae7",
+        "428a3bacce7d634e8c377d7032a76af78f45bd71",
+        "e86ca5de78988cc188171e4a4cadaa754ee9efe0",
+        "bcf6865cd9e48644b24530aa5c20465d0db6457c",
+        "e954b02d42e5f883351ddc78a08b6d3da90f07ba",
+        "028674d832090e87eb5c580e9e7b6c680a6e1f10",
+        "8655d15d8364e83d1639c357fad34ed6447867b3",
+        "0432dde319956a6ce052d43bec5ee2a9277cd249",
+        "5a65a483d0c15250e2a48adf7a502443914d3cad",
+        "ce5c32820193f236189496fe79a0d60ebba83eae",
+        "2920f1697db1f683ac473a9c986a7083e3b2977d",
+        "bf0e32f4dbb2249c1b55bd6732eb87a9903d0665",
+        "a4ff4374dcee30e09cb60047b07d5bf718f16d7d",
+        "03dfa9cb757dbff7c65b534e23b40d22df328bff",
+        "e29f41db0e0928241ab94770088cd228cc7068f5",
+        "e418a236af50876e14976d1876ff9a277e5df0d0",
+        "d0b2e0cfe6a68a0d64e149cc7df44b4cf82a0774",
+        "160e092ceee90fc83390ba23ad76ec6e3929ba4c",
+        "98035668ae85ea783c0f9b126ebee2d9ea408f90",
+        "bbd64c3595cab0388a2639fbeab39bb21d27dd35",
+        "63376d66757a35e3b856932bcd582d61ea2d7628",
+        "faf5a6ea2018e750717902930ff65ef0805dec9c",
+        "9bd7e9e806e1589998db320a69a839e55a0bc094",
+        "fb051b7ea044e544015e168b29d16c01a028c65f",
+        "56c4fbed1030f8cffaefcc8dd54f45c6cffc805d",
+        "0fa9f534d32d82a21a3b5346ec8fd48c1629870a",
+        "2e437487b0099c0708b1c06ada1aa1a439f58609",
+        "3a4237195abe5a0504226146fd6dcd04b57eb567",
+        "0ec082d602b9c96fbd3e27c57e7236ad03b57e34",
+        "ddb682fb3257aaf398fdf843d275de2f41074308",
+        "eb10e5c8aec12353ee7d98eca615a367c8035353",
+        "6c6ea8db4c1b3f2ecf6ec521c0012b1962412e29",
+        "75858fb47b77c2ce969076905dda259c45792de0",
+        "a1e295805a9a32a7dcf6c1ed6cd1dc19fbf85b52",
+        "19b51698409955c4472a6671b1eac8eea22529de",
+        "60d0968361172d8ace2d94a2739a912d8b94ebf1",
+        "d887e21d4b67e4f6a00ce6c7a78d969fcac3288d"
       ],
-      "committed_at": "2026-06-15T17:11:26Z",
+      "committed_at": "2026-06-15T23:39:41Z",
       "next_step": "ai_review_required",
-      "pr_number": 28327,
-      "pr_url": "https://github.com/openai/codex/pull/28327",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, release_packaging.",
+      "pr_number": 26242,
+      "pr_url": "https://github.com/openai/codex/pull/26242",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, release_packaging, security_policy.",
       "sample_paths": [
-        "codex-rs/codex-api/src/endpoint/responses.rs",
-        "codex-rs/codex-api/src/endpoint/session.rs",
-        "codex-rs/codex-api/tests/clients.rs",
-        "codex-rs/codex-client/src/lib.rs",
-        "codex-rs/codex-client/src/request.rs",
-        "codex-rs/codex-client/src/transport.rs"
+        "MODULE.bazel.lock",
+        "codex-rs/Cargo.lock",
+        "codex-rs/Cargo.toml",
+        "codex-rs/core-api/src/lib.rs",
+        "codex-rs/exec-server/Cargo.toml",
+        "codex-rs/exec-server/src/client.rs",
+        "codex-rs/exec-server/src/client_api.rs",
+        "codex-rs/exec-server/src/client_transport.rs",
+        "codex-rs/exec-server/src/connection.rs",
+        "codex-rs/exec-server/src/environment.rs",
+        "codex-rs/exec-server/src/environment_toml.rs",
+        "codex-rs/exec-server/src/lib.rs"
       ],
       "source_state": "merged",
-      "subject_id": "28327",
+      "subject_id": "26242",
       "subject_kind": "pr",
       "surface_hints": [
         "cli_tui",
+        "config_hooks",
         "tests_ci"
       ],
-      "title": "reuse encoded Responses request bodies",
-      "url": "https://github.com/openai/codex/pull/28327"
+      "title": "exec-server: add Noise relay transport",
+      "url": "https://github.com/openai/codex/pull/26242"
     },
     {
       "attention_flags": [
         "auth_account",
-        "deprecated_removed",
         "new_feature",
         "protocol_change",
         "security_policy"
       ],
       "changed_file_count": 4,
       "commit_shas": [
-        "4640faa650d8de9e4c22c8629d524749b77851e9"
+        "fac5cc1e1b750fd2d0efea02c89c49d51cbf15ad",
+        "af5d88778c804b0d463a7a9147d58c428a4a44d2"
       ],
-      "committed_at": "2026-06-15T17:24:50Z",
+      "committed_at": "2026-06-16T00:36:21Z",
       "next_step": "ai_review_required",
-      "pr_number": 28285,
-      "pr_url": "https://github.com/openai/codex/pull/28285",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
+      "pr_number": 26434,
+      "pr_url": "https://github.com/openai/codex/pull/26434",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/core/src/guardian/review_session.rs",
-        "codex-rs/core/src/guardian/snapshots/codex_core__guardian__tests__guardian_review_request_layout.snap",
-        "codex-rs/core/src/guardian/tests.rs",
-        "codex-rs/core/src/session/turn.rs"
+        "codex-rs/exec/src/lib.rs",
+        "codex-rs/exec/src/lib_tests.rs",
+        "codex-rs/exec/tests/suite/hooks.rs",
+        "codex-rs/exec/tests/suite/mod.rs"
       ],
       "source_state": "merged",
-      "subject_id": "28285",
+      "subject_id": "26434",
       "subject_kind": "pr",
       "surface_hints": [
+        "config_hooks",
         "tests_ci"
       ],
-      "title": "guardian: isolate review context from skills and memories",
-      "url": "https://github.com/openai/codex/pull/28285"
+      "title": "Preserve hook trust bypass in codex exec threads",
+      "url": "https://github.com/openai/codex/pull/26434"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 5,
+      "commit_shas": [
+        "8986f089ea4a4549a0fadfe1ea38403b143a941c",
+        "2d703077d7f23a0dc52aa8db1e23bcc70a3bd87b",
+        "5b0f9b18c3372ff0bc7fe5240e854d8d5ae940e7",
+        "678b7080c5cf364c4ebab44a87a66e8864c59c01",
+        "a94bf905f377fd6f3de89853b4d89dba68dfefd6",
+        "13084476992d8b6489891871542e63db0ad512c1"
+      ],
+      "committed_at": "2026-06-16T01:25:22Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27958,
+      "pr_url": "https://github.com/openai/codex/pull/27958",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/app-server/src/request_processors/plugins.rs",
+        "codex-rs/app-server/tests/suite/v2/plugin_read.rs",
+        "codex-rs/core-plugins/src/manager.rs",
+        "codex-rs/core-plugins/src/manager_tests.rs",
+        "codex-rs/core-plugins/src/remote.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27958",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "mcp_plugins",
+        "tests_ci"
+      ],
+      "title": "[codex] Make plugin details capability aware",
+      "url": "https://github.com/openai/codex/pull/27958"
     },
     {
       "attention_flags": [
@@ -1579,6 +1500,333 @@
       ],
       "title": "bound prompt image cache retention",
       "url": "https://github.com/openai/codex/pull/28294"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 5,
+      "commit_shas": [
+        "6533d7582da53bb1fd494379cba62469127795ba",
+        "e32b832c924e0a6c2b610e8315fca7c3bea5049e"
+      ],
+      "committed_at": "2026-06-15T18:08:15Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28341,
+      "pr_url": "https://github.com/openai/codex/pull/28341",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/src/session/input_queue.rs",
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/tools/handlers/multi_agents_spec.rs",
+        "codex-rs/core/src/tools/handlers/multi_agents_v2/wait.rs",
+        "codex-rs/core/tests/suite/pending_input.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28341",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "core: let steer interrupt wait_agent",
+      "url": "https://github.com/openai/codex/pull/28341"
+    },
+    {
+      "attention_flags": [
+        "breaking_change",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "f89b1055a97253e928b8975ce4398d473b406d40",
+        "eef164fc47cc62ea0a7d5283dcf3310c54d8045f"
+      ],
+      "committed_at": "2026-06-15T18:48:31Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28347,
+      "pr_url": "https://github.com/openai/codex/pull/28347",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for breaking_change, new_feature, protocol_change.",
+      "sample_paths": [
+        ".codex/skills/path-types/SKILL.md"
+      ],
+      "source_state": "merged",
+      "subject_id": "28347",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "internal_churn"
+      ],
+      "title": "[codex] add path-types skill",
+      "url": "https://github.com/openai/codex/pull/28347"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 5,
+      "commit_shas": [
+        "77c557d67d893481a1654b1b21f93e7d33d56c59",
+        "81fbb5a99b4cc7c54cdfc4b33107699dc38e2ded",
+        "f9b58d56aa4599d83f249469d96dab04688dd928"
+      ],
+      "committed_at": "2026-06-15T18:49:19Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28235,
+      "pr_url": "https://github.com/openai/codex/pull/28235",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/tui/src/bottom_pane/bottom_pane_view.rs",
+        "codex-rs/tui/src/bottom_pane/mod.rs",
+        "codex-rs/tui/src/bottom_pane/request_user_input/mod.rs",
+        "codex-rs/tui/src/bottom_pane/request_user_input/render.rs",
+        "codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_auto_resolution_countdown.snap"
+      ],
+      "source_state": "merged",
+      "subject_id": "28235",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "Add request user input auto-resolution timer",
+      "url": "https://github.com/openai/codex/pull/28235"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 2,
+      "commit_shas": [
+        "c9e3a94cd03417d5434f19e0c5ce7b1070ed22b8"
+      ],
+      "committed_at": "2026-06-15T20:56:18Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27086,
+      "pr_url": "https://github.com/openai/codex/pull/27086",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/core/src/unified_exec/mod.rs",
+        "codex-rs/core/src/unified_exec/process_manager_tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27086",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "Add Windows unified exec yield floor",
+      "url": "https://github.com/openai/codex/pull/27086"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "7b622835b838708f515c42117ea4d294985dfeb1"
+      ],
+      "committed_at": "2026-06-15T22:50:11Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28300,
+      "pr_url": "https://github.com/openai/codex/pull/28300",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/core/tests/suite/realtime_conversation.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28300",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "Deflake realtime handoff steering test",
+      "url": "https://github.com/openai/codex/pull/28300"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 4,
+      "commit_shas": [
+        "5edd6e7d1a6c0eb53e6d632cede1946350c5271e"
+      ],
+      "committed_at": "2026-06-15T23:32:38Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27093,
+      "pr_url": "https://github.com/openai/codex/pull/27093",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/analytics/src/analytics_capture.rs",
+        "codex-rs/analytics/src/client.rs",
+        "codex-rs/analytics/src/client_tests.rs",
+        "codex-rs/analytics/src/lib.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27093",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "[codex-analytics] Analytics Capture to File in Debug Builds",
+      "url": "https://github.com/openai/codex/pull/27093"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 2,
+      "commit_shas": [
+        "e4ca3ffe0d698b0804c7de077656e463c0238d32"
+      ],
+      "committed_at": "2026-06-16T00:08:39Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28415,
+      "pr_url": "https://github.com/openai/codex/pull/28415",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/codex-api/tests/clients.rs",
+        "codex-rs/core/src/guardian/tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28415",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "[codex] Fix missing response item metadata in tests",
+      "url": "https://github.com/openai/codex/pull/28415"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 2,
+      "commit_shas": [
+        "69fda332a3bc7d2340896e39f8f8bb294d24c8f6",
+        "b02145844ad57b6e068c2fd154ebb2856207d44f"
+      ],
+      "committed_at": "2026-06-16T00:10:52Z",
+      "next_step": "ai_review_required",
+      "pr_number": 27058,
+      "pr_url": "https://github.com/openai/codex/pull/27058",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/otel/src/metrics/client.rs",
+        "codex-rs/otel/tests/suite/timing.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "27058",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "cli_tui",
+        "tests_ci"
+      ],
+      "title": "[codex] Add second-based OTEL duration histograms",
+      "url": "https://github.com/openai/codex/pull/27058"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change",
+        "release_packaging",
+        "security_policy"
+      ],
+      "changed_file_count": 28,
+      "commit_shas": [
+        "a6b4a554b75c721c95107d7423b785a79514ffeb",
+        "98d3d0ac128b83be05b198a1112bb5781941ad61",
+        "6577a4e8f61db58b6d275ee9390c65318dfe6f34"
+      ],
+      "committed_at": "2026-06-16T03:10:53Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28421,
+      "pr_url": "https://github.com/openai/codex/pull/28421",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, release_packaging, security_policy.",
+      "sample_paths": [
+        "codex-rs/codex-home/src/instructions/mod.rs",
+        "codex-rs/codex-home/src/instructions/tests.rs",
+        "codex-rs/core/src/agent/control.rs",
+        "codex-rs/core/src/agent/control/residency_tests.rs",
+        "codex-rs/core/src/agent/control/spawn.rs",
+        "codex-rs/core/src/agents_md.rs",
+        "codex-rs/core/src/agents_md_tests.rs",
+        "codex-rs/core/src/codex_delegate.rs",
+        "codex-rs/core/src/environment_selection.rs",
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/session/session.rs",
+        "codex-rs/core/src/session/tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28421",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "[codex] Bind shell snapshots to retained thread environments",
+      "url": "https://github.com/openai/codex/pull/28421"
+    },
+    {
+      "attention_flags": [
+        "new_feature",
+        "protocol_change",
+        "security_policy"
+      ],
+      "changed_file_count": 6,
+      "commit_shas": [
+        "6d25e07c3358f9536d8699c614e0476fac03e8b9",
+        "b6c705baee74467dd0ee4bb09dab189780b95559",
+        "04b8cc6e0fa58a29c51e98876760a02c71224895"
+      ],
+      "committed_at": "2026-06-16T04:55:20Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28163,
+      "pr_url": "https://github.com/openai/codex/pull/28163",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for new_feature, protocol_change, security_policy.",
+      "sample_paths": [
+        "codex-rs/core/src/environment_selection.rs",
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/session/session.rs",
+        "codex-rs/core/src/tasks/user_shell.rs",
+        "codex-rs/core/src/tools/runtimes/unified_exec.rs",
+        "codex-rs/core/tests/suite/user_shell_cmd.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28163",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "[codex] Use local environment for user shell commands",
+      "url": "https://github.com/openai/codex/pull/28163"
     }
   ]
 }

--- a/artifacts/github/reviews/openai-codex-pr-27371.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27371.review.json
@@ -1,0 +1,84 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27371",
+  "repo": "openai/codex",
+  "reviewed_at": "2026-06-16T00:10:52Z",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27371",
+    "commit_shas": [
+      "54610fec006e76c51d30f2fe5b90001c48632288",
+      "eefdd863d8d8fbb4c3d6bc06f9b4a0b0b296a8e5",
+      "39eabddc46a763edc22f33f1f7013249f01d4a93",
+      "87fa3a6a5bc08f91c630c4990a42869ed064c86a",
+      "11867f161e889c8095d6970f151308263bc2d462",
+      "fe2b08e0b90598c0648ddba0b27e5341a6754212"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "Expose explicit dynamic tool namespaces in thread start",
+        "url": "https://github.com/openai/codex/pull/27371",
+        "meta": "Merged 2026-06-15T15:35:58Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Expose explicit dynamic tool namespaces in thread start",
+        "url": "https://github.com/openai/codex/commit/54610fec006e76c51d30f2fe5b90001c48632288"
+      },
+      {
+        "kind": "commit",
+        "title": "Validate dynamic tool namespace inputs",
+        "url": "https://github.com/openai/codex/commit/87fa3a6a5bc08f91c630c4990a42869ed064c86a"
+      },
+      {
+        "kind": "commit",
+        "title": "Reject invalid dynamic tool namespace formats",
+        "url": "https://github.com/openai/codex/commit/11867f161e889c8095d6970f151308263bc2d462"
+      },
+      {
+        "kind": "commit",
+        "title": "Cover duplicate dynamic tool namespaces",
+        "url": "https://github.com/openai/codex/commit/fe2b08e0b90598c0648ddba0b27e5341a6754212"
+      }
+    ]
+  },
+  "observed_change": "Codex `thread/start.dynamicTools` now accepts tagged top-level function and namespace objects while normalizing legacy flat arrays and rejecting mixed legacy/canonical formats.",
+  "changed_surfaces": [
+    "app-server v2 `thread/start` protocol",
+    "dynamic tool Rust protocol types",
+    "generated JSON and TypeScript app-server protocol schemas",
+    "app-server dynamic tool validation",
+    "app-server dynamic tool integration tests",
+    "app-server README and test-client examples"
+  ],
+  "user_visible_path": "Experimental app-server clients can send grouped dynamic tools as `{\"type\":\"namespace\",\"name\":...,\"description\":...,\"tools\":[...]}` objects in `thread/start.dynamicTools`; legacy flat arrays remain accepted when used consistently.",
+  "control_plane_relevance": "High. Decodex Control Plane and app-server clients that expose dynamic tools need to model canonical `function` and `namespace` specs instead of assuming every dynamic tool is one flat function record.",
+  "compatibility_risk": "Moderate for clients or Control Plane code that mix legacy `{namespace,name,...}` records with canonical tagged objects, or that emit hidden/deferred top-level functions without a namespace. Upstream now rejects mixed legacy/canonical arrays and validates namespace names, descriptions, duplicates, reserved Responses API namespaces, and empty namespace groups.",
+  "adoption_opportunity": "Update any Decodex dynamic-tool request builders, schema readers, or UI affordances to preserve namespace descriptions and nested namespace tools, while keeping legacy-flat normalization as a compatibility path.",
+  "community_value": "High for app-server integrators because the API now has a clearer grouped dynamic-tool shape, concrete migration behavior for legacy arrays, and source-backed validation rules that clients can mirror before sending `thread/start`.",
+  "deprecated_or_breaking_notes": "Legacy flat arrays are still accepted and converted when used consistently, including `exposeToContext` mapping to `deferLoading`. Mixed legacy and canonical entries are rejected, and canonical hidden/deferred tools must live inside a namespace.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27371 says `thread/start` now accepts explicit functions and namespace objects in `dynamicTools`, keeps fully legacy flat arrays, and rejects mixed legacy/canonical entries.",
+    "`codex-rs/protocol/src/dynamic_tools.rs` defines tagged `DynamicToolSpec::Function` and `DynamicToolSpec::Namespace` variants, plus `DynamicToolNamespaceSpec` and nested `DynamicToolNamespaceTool` records.",
+    "`normalize_dynamic_tool_specs` detects legacy fields such as `namespace`, missing `type`, or nested legacy fields, rejects mixed legacy/canonical arrays, and groups legacy namespaced tools into namespace specs.",
+    "`ThreadStartParams.dynamic_tools` now deserializes with `codex_protocol::dynamic_tools::deserialize_dynamic_tool_specs` and uses `Vec<DynamicToolSpec>` directly in the app-server protocol.",
+    "`thread_processor.rs` validates namespace names, namespace descriptions, duplicate namespaces, reserved Responses API namespaces, empty namespaces, duplicate tools within namespaces, and deferred top-level tools without namespaces.",
+    "`codex-rs/app-server/README.md` updates the `thread/start.dynamicTools` example to a `type: namespace` object containing `type: function` tools.",
+    "`codex-rs/app-server/tests/suite/v2/dynamic_tools.rs` covers legacy normalization, hidden top-level tool rejection, mixed legacy/canonical rejection, duplicate namespace rejection, and a namespaced dynamic-tool round trip.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27371.json` records 19 changed files for the merged PR."
+  ],
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The app-server protocol shape and validation rules affect Decodex Control Plane dynamic-tool compatibility assumptions."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The change has a concrete public operator angle for app-server clients adopting namespaced dynamic tools."
+    }
+  ]
+}

--- a/artifacts/github/reviews/openai-codex-pr-28143.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-28143.review.json
@@ -1,0 +1,90 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-28143",
+  "repo": "openai/codex",
+  "reviewed_at": "2026-06-16T06:07:27Z",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "28143",
+    "commit_shas": [
+      "713056e48864fd3c8c1ea03f5719182f4f01ffb2",
+      "405f51d5977e3c60a72bd486b664acea430e232f",
+      "3f8ed5c89516e23036777fbd7408a19871f1051a",
+      "c446387416a2d359c152bd66bb9093954017598e",
+      "a32381a342c5ce30db88a90525b7b85c2335df9d",
+      "ebf7ec1b75b90609a71296befcb17603438eb230",
+      "d461c4b72f7f92480bdebdd515a05a51b0e4c635",
+      "4cfa908a023e9e22c57f2066ce25399ebe9bcf0a",
+      "dad73d1a17d0d99b9881d85158e63aa3864f8d18",
+      "9d82478f61f3d56170b59f1956cdca9a219cf2fa",
+      "73d786196c659d99e1b456da766ec0ebe6b2a129"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "feat(app-server): expose rate-limit reset credits",
+        "url": "https://github.com/openai/codex/pull/28143",
+        "meta": "Merged 2026-06-15T21:54:02Z"
+      },
+      {
+        "kind": "commit",
+        "title": "feat(app-server): expose rate-limit reset credits",
+        "url": "https://github.com/openai/codex/commit/713056e48864fd3c8c1ea03f5719182f4f01ffb2"
+      },
+      {
+        "kind": "commit",
+        "title": "fix(app-server): consolidate rate-limit reset reads",
+        "url": "https://github.com/openai/codex/commit/405f51d5977e3c60a72bd486b664acea430e232f"
+      },
+      {
+        "kind": "commit",
+        "title": "refactor(app-server): simplify reset consume response",
+        "url": "https://github.com/openai/codex/commit/dad73d1a17d0d99b9881d85158e63aa3864f8d18"
+      },
+      {
+        "kind": "commit",
+        "title": "fix(app-server): camel-case reset outcomes",
+        "url": "https://github.com/openai/codex/commit/73d786196c659d99e1b456da766ec0ebe6b2a129"
+      }
+    ]
+  },
+  "observed_change": "Codex app-server now reports earned rate-limit reset credits in `account/rateLimits/read` and adds `account/rateLimitResetCredit/consume` with caller-supplied idempotency.",
+  "changed_surfaces": [
+    "app-server v2 account protocol and generated JSON/TypeScript schemas",
+    "ChatGPT account rate-limit read response",
+    "app-server rate-limit reset consume request processor",
+    "backend client rate-limit reset endpoints",
+    "app-server README account API documentation",
+    "TUI app-server response fixture",
+    "app-server and backend-client tests"
+  ],
+  "user_visible_path": "App-server clients can show `rateLimitResetCredits.availableCount` from `account/rateLimits/read`, then send `account/rateLimitResetCredit/consume` with a non-empty `idempotencyKey` and handle `reset`, `nothingToReset`, `noCredit`, or `alreadyRedeemed` outcomes.",
+  "control_plane_relevance": "High. Decodex account, usage, and rate-limit automation can use this app-server surface to display earned reset credits and optionally offer a guarded reset action for ChatGPT-backed accounts.",
+  "compatibility_risk": "Moderate. The change is mostly additive, but strict app-server clients that decode `account/rateLimits/read` with exact response models or assume reset credits are unavailable need to accept the nullable `rateLimitResetCredits` field and the new camelCase consume outcomes.",
+  "adoption_opportunity": "Add Decodex Control Plane support for reading reset-credit availability, preserving consume idempotency keys across retries, and refetching `account/rateLimits/read` after a consume outcome instead of inferring updated windows locally.",
+  "community_value": "High for app-server and TUI client authors because the PR exposes a concrete way to surface earned reset credits and redeem one without scraping ChatGPT UI state.",
+  "deprecated_or_breaking_notes": "No removal is recorded. The new consume response intentionally returns only `outcome`; clients must refetch `account/rateLimits/read` for updated window state.",
+  "caveats": "The consume API requires ChatGPT-backed Codex authentication, rejects an empty idempotency key, maps backend failures to internal errors, and leaves reset-count updates as snapshot-only rather than pushed notifications.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #28143 says `account/rateLimits/read` gains a nullable `rateLimitResetCredits` summary and `account/rateLimitResetCredit/consume` uses a caller-generated idempotency key.",
+    "`codex-rs/app-server-protocol/src/protocol/v2/account.rs` adds `RateLimitResetCreditsSummary`, `ConsumeAccountRateLimitResetCreditParams`, `ConsumeAccountRateLimitResetCreditResponse`, and camelCase consume outcomes.",
+    "`codex-rs/app-server/README.md` documents the `account/rateLimits/read` response with `rateLimitResetCredits.availableCount`, the consume method, idempotency-key reuse, each consume outcome, and the refetch requirement.",
+    "`codex-rs/app-server/src/request_processors/account_processor/rate_limit_resets.rs` requires ChatGPT-backed auth, rejects an empty idempotency key, calls the backend consume endpoint with a timeout, and maps backend reset codes to app-server outcomes.",
+    "`codex-rs/backend-client/src/client/rate_limit_resets.rs` reads reset credits from `/api/codex/usage` or `/wham/usage` and posts consume requests to `/rate-limit-reset-credits/consume` with `redeem_request_id`.",
+    "`codex-rs/app-server/tests/suite/v2/rate_limit_reset_credits.rs` covers ChatGPT auth requirements, outcome mapping, empty-idempotency rejection, backend failure surfacing, and timeout behavior.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-28143.json` records 31 changed files for the merged PR."
+  ],
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The app-server account API change creates a Decodex Control Plane adoption opportunity and a moderate compatibility watchpoint for rate-limit clients."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The change has a concrete public operator angle for app-server clients that show or redeem earned rate-limit reset credits."
+    }
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27371.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27371.json
@@ -1,0 +1,60 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27371",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "high",
+  "audience": "Codex app-server client authors and Control Plane operators",
+  "candidate_text": [
+    "Codex PR #27371 changes thread/start dynamicTools to accept explicit function and namespace objects, while still normalizing legacy flat arrays. Useful for app-server clients that expose grouped tools. https://github.com/openai/codex/pull/27371",
+    "Control-plane takeaway: treat dynamic tools as tagged function/namespace specs. Mixed legacy+canonical arrays are rejected, deferred tools need a namespace, and namespace names are checked against reserved Responses API names."
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27371.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27371.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27371"
+    ]
+  },
+  "evidence_notes": [
+    "PR #27371 states that `thread/start.dynamicTools` accepts explicit functions and namespaces, while fully legacy flat arrays remain accepted.",
+    "`DynamicToolSpec` is now a tagged function-or-namespace protocol type, and app-server v2 schemas include generated namespace and namespace-tool types.",
+    "`normalize_dynamic_tool_specs` rejects arrays that mix legacy and canonical dynamic-tool formats.",
+    "The checked upstream review and impact artifacts classify this as a Decodex app-server Control Plane compatibility-risk item."
+  ],
+  "claims": [
+    {
+      "text": "Codex app-server `thread/start.dynamicTools` now has a canonical function-or-namespace request shape.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27371.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Legacy flat dynamic-tool arrays remain accepted when used consistently.",
+      "evidence": "https://github.com/openai/codex/pull/27371",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Mixed legacy and canonical dynamic-tool arrays are rejected.",
+      "evidence": "artifacts/github/bundles/openai-codex-pr-27371.json",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "Source-backed operator-impact change for app-server clients adopting namespaced dynamic tools.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27371:operator-impact"
+  },
+  "caveats": [
+    "Do not present this as a removal of legacy flat dynamic-tool arrays.",
+    "The upstream surface remains experimental under `thread/start.dynamicTools`."
+  ],
+  "next_steps": [
+    "Let Publisher decide whether to post; this automation must not write social_post/v1 or publish to X."
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-28143.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-28143.json
@@ -1,0 +1,60 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-28143",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "high",
+  "audience": "Codex app-server client authors and Control Plane operators",
+  "candidate_text": [
+    "Codex PR #28143 exposes earned rate-limit reset credits through app-server: `account/rateLimits/read` now returns `rateLimitResetCredits`, and clients can consume one with an idempotency key. https://github.com/openai/codex/pull/28143",
+    "Operator detail: consume returns only an outcome (`reset`, `nothingToReset`, `noCredit`, or `alreadyRedeemed`). Clients should refetch `account/rateLimits/read` instead of inferring updated windows."
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-28143.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-28143.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/28143"
+    ]
+  },
+  "evidence_notes": [
+    "PR #28143 states that app-server clients can read and redeem earned rate-limit reset credits.",
+    "`account/rateLimits/read` now returns nullable `rateLimitResetCredits.availableCount`.",
+    "`account/rateLimitResetCredit/consume` requires a caller-provided idempotency key and returns an outcome only.",
+    "The checked upstream review and impact artifacts classify this as a Decodex Control Plane adoption candidate."
+  ],
+  "claims": [
+    {
+      "text": "Codex app-server can now expose earned rate-limit reset credit availability through `account/rateLimits/read`.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-28143.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The consume API uses an idempotency key and returns a camelCase outcome.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-28143.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Clients should refetch rate limits after consuming a reset credit instead of inferring updated windows locally.",
+      "evidence": "https://github.com/openai/codex/pull/28143",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "Source-backed operator-impact change for app-server clients handling account rate limits and reset credits.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-28143:operator-impact"
+  },
+  "caveats": [
+    "Do not imply Decodex has already implemented a reset-credit UI or consume action.",
+    "Keep the claim scoped to ChatGPT-backed Codex accounts and backend-provided reset credits."
+  ],
+  "next_steps": [
+    "Let Publisher decide whether to post; this automation must not write social_post/v1 or publish to X."
+  ]
+}


### PR DESCRIPTION
## Summary
- refresh the deterministic openai/codex upstream review queue at 2026-06-16T00:07:37Z
- add github_change_bundle/upstream_review/upstream_impact/social_candidate artifacts for openai/codex PR #27371
- classify the dynamicTools namespace protocol change as confirmed Control Plane compat risk with a Publisher handoff candidate

## Validation
- cargo run -p decodex --bin decodex -- radar bundle validate artifacts/github/bundles/openai-codex-pr-27371.json
- cargo run -p decodex --bin decodex -- radar validate
- cargo make check-site-content
- git diff --check