### PR TITLE
Use macOS boot session API for liveness

### DIFF
--- a/apps/decodex/src/state/internal.rs
+++ b/apps/decodex/src/state/internal.rs
@@ -2,6 +2,7 @@
 use std::mem::{self, MaybeUninit};
 use std::sync::atomic::AtomicU64;
 use std::env;
+use std::ptr;
 
 use libc::FD_CLOEXEC;
 use libc::F_GETFD;
@@ -3687,12 +3688,13 @@ fn read_platform_host_boot_id() -> Option<String> {
 	let query_status = unsafe {
 		libc::sysctlbyname(
 			BOOT_SESSION_UUID_SYSCTL.as_ptr().cast::<c_char>(),
-			std::ptr::null_mut(),
+			ptr::null_mut(),
 			&mut size,
-			std::ptr::null_mut(),
+			ptr::null_mut(),
 			0,
 		)
 	};
+
 	if query_status != 0 || size == 0 {
 		return None;
 	}
@@ -3703,15 +3705,17 @@ fn read_platform_host_boot_id() -> Option<String> {
 			BOOT_SESSION_UUID_SYSCTL.as_ptr().cast::<c_char>(),
 			boot_id.as_mut_ptr().cast::<c_void>(),
 			&mut size,
-			std::ptr::null_mut(),
+			ptr::null_mut(),
 			0,
 		)
 	};
+
 	if read_status != 0 || size == 0 {
 		return None;
 	}
 
 	boot_id.truncate(size);
+
 	if boot_id.last() == Some(&0) {
 		boot_id.pop();
 	}

--- a/apps/decodex/src/state/internal.rs
+++ b/apps/decodex/src/state/internal.rs
@@ -8,12 +8,11 @@ use libc::F_GETFD;
 use libc::F_SETFD;
 #[cfg(target_os = "macos")]
 use libc::{
+	c_char,
 	c_void,
 	proc_bsdinfo,
 	PROC_PIDTBSDINFO,
 };
-#[cfg(target_os = "macos")]
-use process::Command;
 use rusqlite::{self, Row, types::Type};
 
 static RUN_ACTIVITY_MARKER_WRITE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
@@ -3682,18 +3681,44 @@ fn read_platform_host_boot_id() -> Option<String> {
 
 #[cfg(target_os = "macos")]
 fn read_platform_host_boot_id() -> Option<String> {
-	let output = Command::new("/usr/sbin/sysctl")
-		.args(["-n", "kern.boottime"])
-		.output()
-		.ok()?;
+	const BOOT_SESSION_UUID_SYSCTL: &[u8] = b"kern.bootsessionuuid\0";
 
-	if !output.status.success() {
+	let mut size = 0_usize;
+	let query_status = unsafe {
+		libc::sysctlbyname(
+			BOOT_SESSION_UUID_SYSCTL.as_ptr().cast::<c_char>(),
+			std::ptr::null_mut(),
+			&mut size,
+			std::ptr::null_mut(),
+			0,
+		)
+	};
+	if query_status != 0 || size == 0 {
 		return None;
 	}
 
-	String::from_utf8(output.stdout)
-		.ok()
-		.map(|boot_id| format!("macos:{boot_id}"))
+	let mut boot_id = vec![0_u8; size];
+	let read_status = unsafe {
+		libc::sysctlbyname(
+			BOOT_SESSION_UUID_SYSCTL.as_ptr().cast::<c_char>(),
+			boot_id.as_mut_ptr().cast::<c_void>(),
+			&mut size,
+			std::ptr::null_mut(),
+			0,
+		)
+	};
+	if read_status != 0 || size == 0 {
+		return None;
+	}
+
+	boot_id.truncate(size);
+	if boot_id.last() == Some(&0) {
+		boot_id.pop();
+	}
+
+	String::from_utf8(boot_id).ok().map(|boot_id| {
+		format!("macos_bootsessionuuid:{boot_id}")
+	})
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]

--- a/apps/decodex/src/state/internal.rs
+++ b/apps/decodex/src/state/internal.rs
@@ -2,6 +2,7 @@
 use std::mem::{self, MaybeUninit};
 use std::sync::atomic::AtomicU64;
 use std::env;
+#[cfg(target_os = "macos")]
 use std::ptr;
 
 use libc::FD_CLOEXEC;

--- a/apps/decodex/src/state/tests.rs
+++ b/apps/decodex/src/state/tests.rs
@@ -1789,6 +1789,21 @@ fn run_activity_marker_round_trips_marker_surfaces() {
 	assert_run_activity_marker_preserves_account_summary_after_stale_rewrite();
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_host_boot_id_uses_boot_session_uuid() {
+	let host_boot_id = state::current_host_boot_id().expect("macOS boot session UUID should read");
+
+	assert!(
+		host_boot_id.starts_with("macos_bootsessionuuid:"),
+		"macOS host boot identity should use boot-session UUID, got {host_boot_id}"
+	);
+	assert!(
+		!host_boot_id.contains("boottime") && !host_boot_id.contains("usec"),
+		"macOS host boot identity should not depend on kern.boottime timeval output"
+	);
+}
+
 fn assert_run_activity_marker_round_trips_clearable_auxiliary_fields() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 


### PR DESCRIPTION
## Summary
- read macOS host boot identity through kern.bootsessionuuid via sysctlbyname
- remove the sysctl subprocess and kern.boottime timeval dependency from liveness markers
- add a regression test for the boot-session UUID marker prefix

## Verification
- cargo test -p decodex macos_host_boot_id_uses_boot_session_uuid
- cargo test -p decodex live_process
- cargo test -p decodex previous_boot
- cargo make fmt-check
- cargo make check-rust