### PR TITLE
Persist upstream Radar review artifacts

### DIFF
--- a/artifacts/github/bundles/openai-codex-pr-27902.json
+++ b/artifacts/github/bundles/openai-codex-pr-27902.json
@@ -1,0 +1,87 @@
+{
+  "analysis_mode": "pr_first",
+  "commits": [
+    {
+      "author": "felixxia-oai",
+      "committed_at": "2026-06-12T21:51:49Z",
+      "message": "Centralize plugin auth capability filtering",
+      "sha": "867e7dfb0167f048017a79a8da2ce8e5ecb9b51e",
+      "url": "https://github.com/openai/codex/commit/867e7dfb0167f048017a79a8da2ce8e5ecb9b51e"
+    },
+    {
+      "author": "felixxia-oai",
+      "committed_at": "2026-06-15T23:22:24Z",
+      "message": "Simplify plugin auth capability helper",
+      "sha": "47889f50220135ea1d170b620ef79aa9e3dd34b2",
+      "url": "https://github.com/openai/codex/commit/47889f50220135ea1d170b620ef79aa9e3dd34b2"
+    },
+    {
+      "author": "felixxia-oai",
+      "committed_at": "2026-06-15T23:59:29Z",
+      "message": "Rename plugin app MCP routing module",
+      "sha": "17cd2e0d77b51fecfef350a41194cd659c224756",
+      "url": "https://github.com/openai/codex/commit/17cd2e0d77b51fecfef350a41194cd659c224756"
+    }
+  ],
+  "default_branch": "main",
+  "docs_refs": [],
+  "examples_refs": [],
+  "extracted_flags": [
+    "MCP",
+    "API",
+    "OPENAI_BUNDLED_MARKETPLACE_NAME",
+    "OPENAI_CURATED_MARKETPLACE_NAME"
+  ],
+  "files": [
+    {
+      "additions": 32,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,32 @@\n+use codex_app_server_protocol::AuthMode;\n+use codex_plugin::AppDeclaration;\n+use std::collections::HashMap;\n+use std::collections::HashSet;\n+\n+pub fn apps_route_available(auth_mode: Option<AuthMode>) -> bool {\n+    auth_mode.is_some_and(AuthMode::uses_codex_backend)\n+}\n+\n+pub(crate) fn apply_app_mcp_routing_policy<M>(\n+    apps: &mut Vec<AppDeclaration>,\n+    mcp_servers: &mut HashMap<String, M>,\n+    auth_mode: Option<AuthMode>,\n+    plugin_active: bool,\n+) {\n+    if !apps_route_available(auth_mode) {\n+        apps.clear();\n+        return;\n+    }\n+\n+    if plugin_active && !apps.is_empty() {\n+        let app_declaration_names = apps\n+            .iter()\n+            .map(|app| app.name.as_str())\n+            .collect::<HashSet<_>>();\n+        mcp_servers.retain(|name, _| !app_declaration_names.contains(name.as_str()));\n+    }\n+}\n+\n+#[cfg(test)]\n+#[path = \"app_mcp_rout...",
+      "path": "codex-rs/core-plugins/src/app_mcp_routing.rs",
+      "status": "added"
+    },
+    {
+      "additions": 99,
+      "deletions": 0,
+      "patch_excerpt": "@@ -0,0 +1,99 @@\n+use super::*;\n+use codex_plugin::AppConnectorId;\n+use pretty_assertions::assert_eq;\n+use std::collections::HashMap;\n+\n+fn app(name: &str) -> AppDeclaration {\n+    AppDeclaration {\n+        name: name.to_string(),\n+        connector_id: AppConnectorId(format!(\"connector_{name}\")),\n+        category: None,\n+    }\n+}\n+\n+fn mcp_servers(mcp_servers: impl IntoIterator<Item = (&'static str, i32)>) -> HashMap<String, i32> {\n+    mcp_servers\n+        .into_iter()\n+        .map(|(name, value)| (name.to_string(), value))\n+        .collect::<HashMap<_, _>>()\n+}\n+\n+fn sorted_app_names(apps: &[AppDeclaration]) -> Vec<String> {\n+    let mut names = apps.iter().map(|app| app.name.clone()).collect::<Vec<_>>();\n+    names.sort();\n+    names\n+}\n+\n+fn sorted_mcp_server_names(mcp_servers: &HashMap<String, i32>) -> Vec<String> {\n+    let mut names = mcp_servers.keys().cloned().collect::<Vec<...",
+      "path": "codex-rs/core-plugins/src/app_mcp_routing_tests.rs",
+      "status": "added"
+    },
+    {
+      "additions": 2,
+      "deletions": 0,
+      "patch_excerpt": "@@ -1,3 +1,4 @@\n+mod app_mcp_routing;\n mod discoverable;\n pub mod installed_marketplaces;\n pub mod loader;\n@@ -24,6 +25,7 @@ pub const OPENAI_BUNDLED_MARKETPLACE_NAME: &str = \"openai-bundled\";\n pub type LoadedPlugin = codex_plugin::LoadedPlugin<codex_config::McpServerConfig>;\n pub type PluginLoadOutcome = codex_plugin::PluginLoadOutcome<codex_config::McpServerConfig>;\n \n+pub use app_mcp_routing::apps_route_available;\n pub use discoverable::ToolSuggestDiscoverablePlugin;\n pub use discoverable::ToolSuggestPluginDiscoveryInput;\n pub use loader::PluginHookLoadOutcome;",
+      "path": "codex-rs/core-plugins/src/lib.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 10,
+      "deletions": 11,
+      "patch_excerpt": "@@ -1,4 +1,6 @@\n use crate::OPENAI_CURATED_MARKETPLACE_NAME;\n+use crate::app_mcp_routing::apply_app_mcp_routing_policy;\n+use crate::app_mcp_routing::apps_route_available;\n use crate::manifest::PluginManifestHooks;\n use crate::manifest::PluginManifestPaths;\n use crate::manifest::load_plugin_manifest;\n@@ -1085,20 +1087,17 @@ pub async fn load_plugin_mcp_servers(\n     auth_mode: Option<AuthMode>,\n ) -> HashMap<String, McpServerConfig> {\n     let mut mcp_servers = load_declared_plugin_mcp_servers(plugin_root).await;\n-    if !auth_mode.is_some_and(AuthMode::uses_codex_backend) || mcp_servers.is_empty() {\n+    if !apps_route_available(auth_mode) || mcp_servers.is_empty() {\n         return mcp_servers;\n     }\n \n-    let app_declarations = load_plugin_apps(plugin_root).await;\n-    if app_declarations.is_empty() {\n-        return mcp_servers;\n-    }\n-\n-    let app_declaration_names = app_declarat...",
+      "path": "codex-rs/core-plugins/src/loader.rs",
+      "status": "modified"
+    },
+    {
+      "additions": 8,
+      "deletions": 15,
+      "patch_excerpt": "@@ -1,5 +1,6 @@\n use super::PluginLoadOutcome;\n use crate::OPENAI_CURATED_MARKETPLACE_NAME;\n+use crate::app_mcp_routing::apply_app_mcp_routing_policy;\n use crate::installed_marketplaces::installed_marketplace_roots_from_layer_stack;\n use crate::loader::PluginHookLoadOutcome;\n use crate::loader::configured_curated_plugin_ids_from_codex_home;\n@@ -210,23 +211,15 @@ fn project_plugin_load_outcome_for_auth(\n     outcome: PluginLoadOutcome,\n     auth_mode: Option<AuthMode>,\n ) -> PluginLoadOutcome {\n-    let apps_route_available = auth_mode.is_some_and(AuthMode::uses_codex_backend);\n     let mut plugins = outcome.plugins().to_vec();\n     for plugin in &mut plugins {\n-        if apps_route_available {\n-            if plugin.is_active() && !plugin.apps.is_empty() {\n-                let app_declaration_names = plugin\n-                    .apps\n-                    .iter()\n-                    .ma...",
+      "path": "codex-rs/core-plugins/src/manager.rs",
+      "status": "modified"
+    }
+  ],
+  "linked_issues": [],
+  "notes": [
+    "Built from GitHub pull-request, commits, files, and repo endpoints."
+  ],
+  "primary_pr": {
+    "body": "## Summary\r\n\r\nThis is the first step in making plugin auth routing consistent. The rule should not live as one-off checks in every place that loads or displays plugin capabilities.\r\n\r\nThis PR introduces a small resolver for the auth-level policy: given a plugin's declared apps, MCP servers, current auth mode, and active state, return the capabilities that are actually usable in that context.\r\n\r\n## Why\r\n\r\nProduct rule:\r\n- SiWC auth can use app connectors, so app declarations stay available.\r\n- API-key/direct auth cannot use app connectors, so app declarations are removed.\r\n- When an active plugin has both an app and an MCP server with the same name, the app route wins for Codex-backed auth and the conflicting MCP server is hidden.\r\n\r\nPutting that rule in `capabilities.rs` gives the rest of the stack one place to ask instead of duplicating auth checks in loader, manager, marketplace, and details code.\r\n\r\n## Validation\r\n\r\n- `cargo fmt`\r\n- `cargo test -p codex-core-plugins`",
+    "labels": [],
+    "merged_at": "2026-06-16T00:13:28Z",
+    "number": 27902,
+    "state": "merged",
+    "title": "[codex] Centralize plugin auth capability filtering",
+    "url": "https://github.com/openai/codex/pull/27902"
+  },
+  "repo": "openai/codex",
+  "schema": "github_change_bundle/v1"
+}

--- a/artifacts/github/impact/openai-codex-pr-27902.json
+++ b/artifacts/github/impact/openai-codex-pr-27902.json
@@ -1,0 +1,49 @@
+{
+  "schema": "upstream_impact/v1",
+  "slug": "openai-codex-pr-27902",
+  "repo": "openai/codex",
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Centralize plugin auth capability filtering",
+        "url": "https://github.com/openai/codex/pull/27902",
+        "meta": "Merged 2026-06-16T00:13:28Z"
+      },
+      {
+        "kind": "pull_request",
+        "title": "Source-backed Decodex upstream review",
+        "url": "https://github.com/openai/codex/pull/27902",
+        "meta": "artifacts/github/reviews/openai-codex-pr-27902.review.json"
+      }
+    ]
+  },
+  "observed_change": "Codex core plugin loading now centralizes auth-aware app/MCP routing so effective plugin capabilities depend on auth mode and active plugin state.",
+  "public_signal_decision": "publish",
+  "control_plane_impact": "compat_risk",
+  "publisher_angle": "operator_impact",
+  "confidence": "confirmed",
+  "evidence": [
+    "The upstream PR defines one product rule for app connector availability and same-name app/MCP conflicts.",
+    "`apps_route_available` treats ChatGPT and AgentIdentity as app-route-capable and treats API-key or missing auth as unavailable.",
+    "`apply_app_mcp_routing_policy` clears app declarations when apps are unavailable for the auth mode.",
+    "For active plugins with app declarations, the shared policy removes MCP servers whose names conflict with app declaration names.",
+    "Loader and manager code now use the shared routing helper instead of duplicating auth checks.",
+    "The source-backed review is recorded at `artifacts/github/reviews/openai-codex-pr-27902.review.json`."
+  ],
+  "candidate_followups": [
+    "Audit Decodex plugin discovery and plugin detail views for places that present declared manifest capabilities instead of auth-filtered effective capabilities.",
+    "When Decodex is operating with API-key/direct auth, suppress app connector affordances that upstream would clear from effective plugin capabilities.",
+    "When Codex-backed auth exposes an active app route with the same name as an MCP server, prefer the app route in Control Plane presentation and avoid duplicate routing."
+  ],
+  "social_notes": [
+    "Frame this as the upstream rule behind plugin capabilities changing by auth mode.",
+    "Avoid implying all downstream UI surfaces already consume the new helper; the PR is the core routing foundation.",
+    "The useful public detail is the three-part rule: Codex-backed auth keeps apps, API-key/direct auth drops apps, and active same-name app routes hide MCP servers."
+  ],
+  "caveats": [
+    "The PR consolidates core plugin policy but may be followed by additional marketplace or details changes.",
+    "No manifest schema migration is recorded; the risk is effective capability visibility, not plugin package format.",
+    "The upstream policy uses `AuthMode::uses_codex_backend`, so local integrations should follow that semantic boundary rather than hard-coding auth-mode names."
+  ]
+}

--- a/artifacts/github/review-queue/openai-codex-latest.json
+++ b/artifacts/github/review-queue/openai-codex-latest.json
@@ -1,14 +1,14 @@
 {
   "counts": {
-    "critical": 20,
+    "critical": 21,
     "high": 9,
     "low": 0,
-    "normal": 11,
+    "normal": 10,
     "published_subjects_seen": 0,
     "recent_commits_scanned": 40,
     "subjects_queued": 40
   },
-  "generated_at": "2026-06-16T06:05:27.805936Z",
+  "generated_at": "2026-06-16T12:38:20.227789Z",
   "repo": "openai/codex",
   "schema": "upstream_review_queue/v1",
   "source": {
@@ -17,81 +17,6 @@
     "signals_dir": "site/src/content/signals"
   },
   "subjects": [
-    {
-      "attention_flags": [
-        "auth_account",
-        "deprecated_removed",
-        "new_feature",
-        "protocol_change",
-        "security_policy"
-      ],
-      "changed_file_count": 8,
-      "commit_shas": [
-        "c0094f38430892282049e36c010d28773d4c5f36",
-        "a9bf199b81de2fcd23577efae2532559d7af5336"
-      ],
-      "committed_at": "2026-06-15T17:56:53Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28257,
-      "pr_url": "https://github.com/openai/codex/pull/28257",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change, security_policy.",
-      "sample_paths": [
-        "codex-rs/app-server/src/request_processors.rs",
-        "codex-rs/app-server/src/request_processors/account_processor.rs",
-        "codex-rs/app-server/tests/suite/v2/account.rs",
-        "codex-rs/login/src/auth/manager.rs",
-        "codex-rs/login/src/auth/revoke.rs",
-        "codex-rs/login/src/lib.rs",
-        "codex-rs/login/tests/suite/auth_refresh.rs",
-        "codex-rs/login/tests/suite/logout.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "28257",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "app_server_protocol",
-        "auth_accounts",
-        "tests_ci"
-      ],
-      "title": "Support staging OAuth client ID overrides",
-      "url": "https://github.com/openai/codex/pull/28257"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "new_feature",
-        "protocol_change",
-        "release_packaging"
-      ],
-      "changed_file_count": 4,
-      "commit_shas": [
-        "4133ae0d19d9bc5f689a28b51e52a5bfc5f8cb86"
-      ],
-      "committed_at": "2026-06-15T18:32:13Z",
-      "next_step": "ai_review_required",
-      "pr_number": 27706,
-      "pr_url": "https://github.com/openai/codex/pull/27706",
-      "review_priority": "critical",
-      "review_reason": "Needs AI review for breaking_change, new_feature, protocol_change, release_packaging.",
-      "sample_paths": [
-        "codex-rs/Cargo.toml",
-        "codex-rs/utils/rustls-provider/src/lib.rs",
-        "codex-rs/utils/rustls-provider/tests/preinstalled.rs",
-        "codex-rs/utils/rustls-provider/tests/provider.rs"
-      ],
-      "source_state": "merged",
-      "subject_id": "27706",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "config_hooks",
-        "model_provider",
-        "release_packaging",
-        "tests_ci"
-      ],
-      "title": "Use aws-lc-rs for rustls crypto provider",
-      "url": "https://github.com/openai/codex/pull/27706"
-    },
     {
       "attention_flags": [
         "auth_account",
@@ -1087,81 +1012,144 @@
     {
       "attention_flags": [
         "auth_account",
+        "breaking_change",
+        "deprecated_removed",
         "new_feature",
         "protocol_change",
+        "rate_limit",
         "security_policy"
       ],
-      "changed_file_count": 7,
+      "changed_file_count": 30,
       "commit_shas": [
-        "6234ef57439eddc22c694c0774151f45ad7f4e43",
-        "9ffb2384372e917be3a353552632918932db6cee",
-        "173510103e72c03477b79a8d5272049d9321c40b"
+        "f30b49fbb337e2f513b4f41452533f61a57ff8de",
+        "6a519b2c2c2bb8bba0a9cd56f1ab481c5728bb9e",
+        "5b76cae31a8ba52cf7ab8e0c6747ad45262cb395",
+        "668c0df73f5464f7e53bfa0d4ec617eb92f69967",
+        "3804b82179c3388e7116983c1eb9c287a2c1069b"
       ],
-      "committed_at": "2026-06-15T18:20:19Z",
+      "committed_at": "2026-06-16T06:17:24Z",
       "next_step": "ai_review_required",
-      "pr_number": 28336,
-      "pr_url": "https://github.com/openai/codex/pull/28336",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
+      "pr_number": 28396,
+      "pr_url": "https://github.com/openai/codex/pull/28396",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, deprecated_removed, new_feature, protocol_change, rate_limit, security_policy.",
       "sample_paths": [
-        "codex-rs/app-server/tests/suite/v2/mcp_resource.rs",
-        "codex-rs/codex-mcp/src/lib.rs",
-        "codex-rs/codex-mcp/src/resource_client.rs",
-        "codex-rs/ext/skills/src/extension.rs",
-        "codex-rs/ext/skills/src/state.rs",
-        "codex-rs/ext/skills/src/tools/mod.rs",
-        "codex-rs/ext/skills/src/tools/read.rs"
+        "codex-rs/app-server-protocol/schema/json/ClientRequest.json",
+        "codex-rs/app-server-protocol/schema/json/ServerNotification.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ExternalAgentConfigImportCompletedNotification.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ExternalAgentConfigImportHistoriesReadResponse.json",
+        "codex-rs/app-server-protocol/schema/json/v2/ExternalAgentConfigImportProgressNotification.json",
+        "codex-rs/app-server-protocol/schema/typescript/ClientRequest.ts",
+        "codex-rs/app-server-protocol/schema/typescript/ServerNotification.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ExternalAgentConfigImportHistoriesReadResponse.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ExternalAgentConfigImportHistory.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/ExternalAgentConfigImportItemTypeFailure.ts"
       ],
       "source_state": "merged",
-      "subject_id": "28336",
+      "subject_id": "28396",
       "subject_kind": "pr",
       "surface_hints": [
         "app_server_protocol",
         "cli_tui",
-        "mcp_plugins",
+        "config_hooks",
         "tests_ci"
       ],
-      "title": "skills: cache orchestrator resources per thread",
-      "url": "https://github.com/openai/codex/pull/28336"
+      "title": "[codex] Record external agent import results",
+      "url": "https://github.com/openai/codex/pull/28396"
     },
     {
       "attention_flags": [
         "auth_account",
+        "breaking_change",
         "new_feature",
         "protocol_change",
-        "release_packaging",
         "security_policy"
       ],
-      "changed_file_count": 6,
+      "changed_file_count": 15,
       "commit_shas": [
-        "328cff02bf68502c2de666f0f94f6c25b24ae401",
-        "13875519fa99eb18c816c14b3b7237b9507ae9e3"
+        "33da9da1175ddbbbf73832adf2b4c0c7a77455e3",
+        "e0a2c1ea75054ee8c508b25193ef7475a76ec7ee"
       ],
-      "committed_at": "2026-06-15T18:30:48Z",
+      "committed_at": "2026-06-16T07:14:53Z",
       "next_step": "ai_review_required",
-      "pr_number": 28357,
-      "pr_url": "https://github.com/openai/codex/pull/28357",
-      "review_priority": "high",
-      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, release_packaging, security_policy.",
+      "pr_number": 27751,
+      "pr_url": "https://github.com/openai/codex/pull/27751",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/cli/src/debug_sandbox.rs",
-        "codex-rs/windows-sandbox-rs/Cargo.toml",
-        "codex-rs/windows-sandbox-rs/src/lib.rs",
-        "codex-rs/windows-sandbox-rs/src/stdio_bridge.rs",
-        "codex-rs/windows-sandbox-rs/src/stdio_bridge_tests.rs",
-        "codex-rs/windows-sandbox-rs/src/unified_exec/mod.rs"
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json",
+        "codex-rs/app-server-protocol/schema/json/v2/GetAccountResponse.json",
+        "codex-rs/app-server-protocol/schema/typescript/AmazonBedrockCredentialSource.ts",
+        "codex-rs/app-server-protocol/schema/typescript/index.ts",
+        "codex-rs/app-server-protocol/schema/typescript/v2/Account.ts",
+        "codex-rs/app-server-protocol/src/protocol/common.rs",
+        "codex-rs/app-server-protocol/src/protocol/v2/account.rs",
+        "codex-rs/app-server/README.md",
+        "codex-rs/app-server/tests/suite/v2/account.rs",
+        "codex-rs/model-provider/src/amazon_bedrock/mod.rs",
+        "codex-rs/model-provider/src/provider.rs"
       ],
       "source_state": "merged",
-      "subject_id": "28357",
+      "subject_id": "27751",
       "subject_kind": "pr",
       "surface_hints": [
+        "app_server_protocol",
+        "auth_accounts",
         "cli_tui",
-        "config_hooks",
-        "sandbox_permissions",
+        "docs_examples",
+        "model_provider",
         "tests_ci"
       ],
-      "title": "Extract shared Windows sandbox session runner",
-      "url": "https://github.com/openai/codex/pull/28357"
+      "title": "[codex] expose Bedrock credential source in account/read",
+      "url": "https://github.com/openai/codex/pull/27751"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "breaking_change",
+        "new_feature",
+        "protocol_change",
+        "release_packaging"
+      ],
+      "changed_file_count": 16,
+      "commit_shas": [
+        "a0e1e3ca2baaf6092c773777e769e940ccdbf6c3",
+        "00a35531dcffc456dab638c544571eb19894f4b4"
+      ],
+      "committed_at": "2026-06-16T09:46:59Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28368,
+      "pr_url": "https://github.com/openai/codex/pull/28368",
+      "review_priority": "critical",
+      "review_reason": "Needs AI review for auth_account, breaking_change, new_feature, protocol_change, release_packaging.",
+      "sample_paths": [
+        "codex-rs/core/src/agent/control.rs",
+        "codex-rs/core/src/agent/control_tests.rs",
+        "codex-rs/core/src/config/mod.rs",
+        "codex-rs/core/src/context/inter_agent_completion_message.rs",
+        "codex-rs/core/src/context/mod.rs",
+        "codex-rs/core/src/guardian/prompt.rs",
+        "codex-rs/core/src/realtime_context.rs",
+        "codex-rs/core/src/session/mod.rs",
+        "codex-rs/core/src/session_prefix.rs",
+        "codex-rs/core/src/tools/handlers/multi_agents_tests.rs",
+        "codex-rs/core/tests/suite/subagent_notifications.rs",
+        "codex-rs/ext/web-search/src/history.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28368",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "app_server_protocol",
+        "config_hooks",
+        "model_provider",
+        "tests_ci"
+      ],
+      "title": "feat: render typed envelopes for multi-agent v2 messages",
+      "url": "https://github.com/openai/codex/pull/28368"
     },
     {
       "attention_flags": [],
@@ -1473,95 +1461,78 @@
     },
     {
       "attention_flags": [
+        "auth_account",
         "new_feature",
         "protocol_change"
       ],
-      "changed_file_count": 2,
+      "changed_file_count": 5,
       "commit_shas": [
-        "c470de7e14af82b4182333e44d51dd5d6dc9724a",
-        "7d4b7e2b9a40e760e82d32591033db9918d9fab9",
-        "0eeef9d02a13a43a698984c12df95ffa9fdc18dc"
+        "c86d41dda671caec19c05f2d195a6de2a21a3c3e"
       ],
-      "committed_at": "2026-06-15T17:52:30Z",
+      "committed_at": "2026-06-16T11:57:21Z",
       "next_step": "ai_review_required",
-      "pr_number": 28294,
-      "pr_url": "https://github.com/openai/codex/pull/28294",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature, protocol_change.",
+      "pr_number": 28472,
+      "pr_url": "https://github.com/openai/codex/pull/28472",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change.",
       "sample_paths": [
-        "codex-rs/utils/image/src/image_tests.rs",
-        "codex-rs/utils/image/src/lib.rs"
+        "codex-rs/core-plugins/src/loader.rs",
+        "codex-rs/core-plugins/src/loader_tests.rs",
+        "codex-rs/core-plugins/src/manager.rs",
+        "codex-rs/core-plugins/src/manager_tests.rs",
+        "codex-rs/plugin/src/load_outcome.rs"
       ],
       "source_state": "merged",
-      "subject_id": "28294",
+      "subject_id": "28472",
       "subject_kind": "pr",
       "surface_hints": [
+        "mcp_plugins",
         "tests_ci"
       ],
-      "title": "bound prompt image cache retention",
-      "url": "https://github.com/openai/codex/pull/28294"
+      "title": "[codex] Clarify plugin load and runtime capability stages",
+      "url": "https://github.com/openai/codex/pull/28472"
     },
     {
       "attention_flags": [
+        "auth_account",
         "new_feature",
         "protocol_change",
         "security_policy"
       ],
-      "changed_file_count": 5,
+      "changed_file_count": 7,
       "commit_shas": [
-        "6533d7582da53bb1fd494379cba62469127795ba",
-        "e32b832c924e0a6c2b610e8315fca7c3bea5049e"
+        "e95fcfe2bb6a02f1a75650afa20048859f556511",
+        "762a053d02c261a6d4545baa154521eb75bccdd2",
+        "d7b5bc3294804f257c683b767f84a55b3c081783",
+        "4f617f452c7750be15ebcea6ef84852b4757a558",
+        "51bb6b27242d459a122fc26d668b01f94fea8113",
+        "761447dde7bf18b7dc5cf536165e8d95272320aa",
+        "012c0600b1c71ffa15a1173ef8f67d8dfcbd0008"
       ],
-      "committed_at": "2026-06-15T18:08:15Z",
+      "committed_at": "2026-06-16T12:34:54Z",
       "next_step": "ai_review_required",
-      "pr_number": 28341,
-      "pr_url": "https://github.com/openai/codex/pull/28341",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for new_feature, protocol_change, security_policy.",
+      "pr_number": 28375,
+      "pr_url": "https://github.com/openai/codex/pull/28375",
+      "review_priority": "high",
+      "review_reason": "Needs AI review for auth_account, new_feature, protocol_change, security_policy.",
       "sample_paths": [
-        "codex-rs/core/src/session/input_queue.rs",
+        "codex-rs/core/src/hook_runtime.rs",
         "codex-rs/core/src/session/mod.rs",
-        "codex-rs/core/src/tools/handlers/multi_agents_spec.rs",
-        "codex-rs/core/src/tools/handlers/multi_agents_v2/wait.rs",
-        "codex-rs/core/tests/suite/pending_input.rs"
+        "codex-rs/core/src/session/review.rs",
+        "codex-rs/core/src/session/turn_context.rs",
+        "codex-rs/core/src/session_prefix.rs",
+        "codex-rs/core/src/session_prefix_tests.rs",
+        "codex-rs/core/tests/suite/subagent_notifications.rs"
       ],
       "source_state": "merged",
-      "subject_id": "28341",
+      "subject_id": "28375",
       "subject_kind": "pr",
       "surface_hints": [
+        "config_hooks",
         "tests_ci"
       ],
-      "title": "core: let steer interrupt wait_agent",
-      "url": "https://github.com/openai/codex/pull/28341"
-    },
-    {
-      "attention_flags": [
-        "breaking_change",
-        "new_feature",
-        "protocol_change"
-      ],
-      "changed_file_count": 1,
-      "commit_shas": [
-        "f89b1055a97253e928b8975ce4398d473b406d40",
-        "eef164fc47cc62ea0a7d5283dcf3310c54d8045f"
-      ],
-      "committed_at": "2026-06-15T18:48:31Z",
-      "next_step": "ai_review_required",
-      "pr_number": 28347,
-      "pr_url": "https://github.com/openai/codex/pull/28347",
-      "review_priority": "normal",
-      "review_reason": "Needs AI review for breaking_change, new_feature, protocol_change.",
-      "sample_paths": [
-        ".codex/skills/path-types/SKILL.md"
-      ],
-      "source_state": "merged",
-      "subject_id": "28347",
-      "subject_kind": "pr",
-      "surface_hints": [
-        "internal_churn"
-      ],
-      "title": "[codex] add path-types skill",
-      "url": "https://github.com/openai/codex/pull/28347"
+      "title": "core: surface terminal subagent errors to parent agents",
+      "url": "https://github.com/openai/codex/pull/28375"
     },
     {
       "attention_flags": [
@@ -1827,6 +1798,66 @@
       ],
       "title": "[codex] Use local environment for user shell commands",
       "url": "https://github.com/openai/codex/pull/28163"
+    },
+    {
+      "attention_flags": [
+        "deprecated_removed",
+        "new_feature"
+      ],
+      "changed_file_count": 2,
+      "commit_shas": [
+        "7b84fe292534270e822ffd6b85bfabc5dc90efb6",
+        "c1902dc239162b8d68240ea859f693fbc159b4af",
+        "74e8bc896f22916cc04fa4e059803ff0fe7e248f"
+      ],
+      "committed_at": "2026-06-16T08:52:21Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28338,
+      "pr_url": "https://github.com/openai/codex/pull/28338",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for deprecated_removed, new_feature.",
+      "sample_paths": [
+        "codex-rs/rollout/src/compression.rs",
+        "codex-rs/rollout/src/compression_tests.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28338",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "[codex] Compress cold active rollouts",
+      "url": "https://github.com/openai/codex/pull/28338"
+    },
+    {
+      "attention_flags": [
+        "auth_account",
+        "deprecated_removed",
+        "new_feature",
+        "protocol_change"
+      ],
+      "changed_file_count": 1,
+      "commit_shas": [
+        "ab4c6fee1e6ee97023effa17b4f8c5f4ce36e0f2",
+        "5fc8ab4e8fe4ffd33310ee4626981cba9bfe4ff6"
+      ],
+      "committed_at": "2026-06-16T11:07:43Z",
+      "next_step": "ai_review_required",
+      "pr_number": 28508,
+      "pr_url": "https://github.com/openai/codex/pull/28508",
+      "review_priority": "normal",
+      "review_reason": "Needs AI review for auth_account, deprecated_removed, new_feature, protocol_change.",
+      "sample_paths": [
+        "codex-rs/core/tests/common/test_codex.rs"
+      ],
+      "source_state": "merged",
+      "subject_id": "28508",
+      "subject_kind": "pr",
+      "surface_hints": [
+        "tests_ci"
+      ],
+      "title": "[tests] Keep Apps out of generic core test harness",
+      "url": "https://github.com/openai/codex/pull/28508"
     }
   ]
 }

--- a/artifacts/github/reviews/openai-codex-pr-27902.review.json
+++ b/artifacts/github/reviews/openai-codex-pr-27902.review.json
@@ -1,0 +1,75 @@
+{
+  "schema": "upstream_review/v1",
+  "slug": "openai-codex-pr-27902",
+  "repo": "openai/codex",
+  "reviewed_at": "2026-06-16T12:41:03Z",
+  "subject": {
+    "subject_kind": "pr",
+    "subject_id": "27902",
+    "commit_shas": [
+      "867e7dfb0167f048017a79a8da2ce8e5ecb9b51e",
+      "47889f50220135ea1d170b620ef79aa9e3dd34b2",
+      "17cd2e0d77b51fecfef350a41194cd659c224756"
+    ]
+  },
+  "source_refs": {
+    "items": [
+      {
+        "kind": "pull_request",
+        "title": "[codex] Centralize plugin auth capability filtering",
+        "url": "https://github.com/openai/codex/pull/27902",
+        "meta": "Merged 2026-06-16T00:13:28Z"
+      },
+      {
+        "kind": "commit",
+        "title": "Centralize plugin auth capability filtering",
+        "url": "https://github.com/openai/codex/commit/867e7dfb0167f048017a79a8da2ce8e5ecb9b51e"
+      },
+      {
+        "kind": "commit",
+        "title": "Simplify plugin auth capability helper",
+        "url": "https://github.com/openai/codex/commit/47889f50220135ea1d170b620ef79aa9e3dd34b2"
+      },
+      {
+        "kind": "commit",
+        "title": "Rename plugin app MCP routing module",
+        "url": "https://github.com/openai/codex/commit/17cd2e0d77b51fecfef350a41194cd659c224756"
+      }
+    ]
+  },
+  "observed_change": "Codex core plugin loading now centralizes auth-aware app/MCP routing so effective plugin capabilities depend on auth mode and active plugin state.",
+  "changed_surfaces": [
+    "core plugin app/MCP routing helper",
+    "plugin MCP server loader",
+    "project plugin load outcome projection",
+    "core plugin public helper export",
+    "auth-routing unit tests"
+  ],
+  "user_visible_path": "Plugin consumers that display or load effective capabilities can now see app declarations only when the auth mode uses the Codex backend; when an active plugin has app and MCP declarations with the same name, the app route wins and the conflicting MCP server is hidden.",
+  "control_plane_relevance": "High. Decodex plugin discovery, marketplace, and Control Plane plugin views need to distinguish declared manifest capabilities from the effective app/MCP capabilities allowed by the operator's current auth mode.",
+  "compatibility_risk": "Moderate. The change is centralized and mostly consolidates existing policy, but clients that assumed manifests expose every app or MCP declaration may now observe app declarations cleared for API-key/direct auth or same-name MCP servers removed for active Codex-backed app routes.",
+  "adoption_opportunity": "Use the upstream effective-capability rule when Decodex reads plugin load outcomes, imports marketplace entries, or presents plugin details so API-key users are not offered unusable app connectors and Codex-backed users do not see duplicate app/MCP routes.",
+  "community_value": "High for plugin authors and operators because the PR documents and enforces one concrete auth policy: app connectors require Codex-backed auth, while same-name app routes take precedence over MCP servers for active plugins.",
+  "deprecated_or_breaking_notes": "No schema or manifest format removal is recorded. The effective capability surface changes by auth mode: API-key/direct auth removes app declarations, and active Codex-backed plugins hide same-name MCP server entries when an app declaration exists.",
+  "caveats": "This PR is a core plugin routing foundation. It does not by itself prove every marketplace, app-server, or UI consumer has switched to the shared resolver; later PRs may extend the same policy into those surfaces.",
+  "confidence": "confirmed",
+  "evidence": [
+    "PR #27902 states that SiWC/Codex-backed auth can use app connectors, API-key/direct auth cannot, and active same-name app/MCP declarations should prefer the app route.",
+    "`codex-rs/core-plugins/src/app_mcp_routing.rs` adds `apps_route_available` and `apply_app_mcp_routing_policy`, clearing apps when `AuthMode::uses_codex_backend` is false and removing same-name MCP servers when a plugin is active and apps remain.",
+    "`codex-rs/core-plugins/src/loader.rs` now uses `apps_route_available` and `apply_app_mcp_routing_policy` when loading plugin MCP servers.",
+    "`codex-rs/core-plugins/src/manager.rs` now applies the same routing policy while projecting plugin load outcomes for an auth mode.",
+    "`codex-rs/core-plugins/src/app_mcp_routing_tests.rs` covers ChatGPT and AgentIdentity as app-route-capable, API-key and missing auth as unavailable, active-plugin same-name app/MCP conflict removal, and inactive-plugin conflict preservation.",
+    "`codex-rs/core-plugins/src/lib.rs` exports `apps_route_available` for shared consumers.",
+    "The normalized bundle `artifacts/github/bundles/openai-codex-pr-27902.json` records five changed files for the merged PR."
+  ],
+  "next_actions": [
+    {
+      "type": "upstream_impact",
+      "reason": "The auth-dependent plugin capability rule is a Decodex Control Plane compatibility watchpoint and adoption candidate."
+    },
+    {
+      "type": "social_candidate",
+      "reason": "The change has a clear public operator angle for plugin authors and clients that need to explain why app connectors or MCP servers appear or disappear by auth mode."
+    }
+  ]
+}

--- a/artifacts/github/social-candidates/openai-codex-pr-27902.json
+++ b/artifacts/github/social-candidates/openai-codex-pr-27902.json
@@ -1,0 +1,60 @@
+{
+  "schema": "social_candidate/v1",
+  "slug": "openai-codex-pr-27902",
+  "repo": "openai/codex",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "mode": "operator_impact",
+  "priority": "high",
+  "audience": "Codex plugin authors and Control Plane operators",
+  "candidate_text": [
+    "Codex PR #27902 centralizes plugin app/MCP auth routing: Codex-backed auth keeps app connectors, API-key/direct auth drops app declarations, and active app routes hide same-name MCP servers. https://github.com/openai/codex/pull/27902",
+    "Operator angle: plugin lists and details should consume effective capabilities, not raw manifests, or users may see unusable app connectors under API-key auth or duplicate app/MCP routes under Codex-backed auth."
+  ],
+  "source_refs": {
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-27902.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-27902.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/27902"
+    ]
+  },
+  "evidence_notes": [
+    "PR #27902 states the product rule for app connector availability and same-name app/MCP conflicts.",
+    "`apps_route_available` gates app declarations on Codex-backed auth modes.",
+    "`apply_app_mcp_routing_policy` clears apps for API-key/direct auth and removes conflicting MCP servers for active app-capable plugins.",
+    "The checked upstream review and impact artifacts classify the change as a Decodex Control Plane compatibility risk."
+  ],
+  "claims": [
+    {
+      "text": "Codex plugin app declarations are effective only when the auth mode can use the Codex backend.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-27902.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "For active plugins, same-name app declarations take precedence over MCP server declarations under Codex-backed auth.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-27902.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Operators should present effective auth-filtered plugin capabilities rather than raw manifest declarations.",
+      "evidence": "https://github.com/openai/codex/pull/27902",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "reason": "Source-backed operator-impact change for plugin auth routing and effective capability presentation.",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-27902:operator-impact"
+  },
+  "caveats": [
+    "Do not imply Decodex has already adopted this routing rule in every plugin UI.",
+    "Keep claims scoped to effective capability filtering; this PR does not remove the plugin manifest format."
+  ],
+  "next_steps": [
+    "Let Publisher decide whether to post; this automation must not write social_post/v1 or publish to X."
+  ]
+}


### PR DESCRIPTION
## Summary
- refreshed the openai/codex upstream review queue at 2026-06-16T12:38:20Z with search_limit 40
- added github_change_bundle/v1, upstream_review/v1, upstream_impact/v1, and social_candidate/v1 artifacts for openai/codex PR #27902
- no social_post/v1 records were written and nothing was published to X

## Validation
- cargo run -p decodex --bin decodex -- radar bundle validate artifacts/github/bundles/openai-codex-pr-27902.json
- cargo run -p decodex --bin decodex -- radar validate artifacts/github/review-queue artifacts/github/reviews artifacts/github/impact artifacts/github/social-candidates artifacts/github/bundles
- git diff --check
- cargo make check-site-content

## Notes
- selected PR #27902 from the deterministic queue because it had no matching source-backed upstream_review/v1 artifact and touches auth-dependent plugin app/MCP routing
- downstream Publisher automation should consume the social_candidate/v1 artifact; this PR does not publish