### PR TITLE
Persist failed X publication record for PR 28143

### DIFF
--- a/artifacts/social/x/posts/2026-06-16/openai-codex-pr-28143-chrome-account-verification-blocked.json
+++ b/artifacts/social/x/posts/2026-06-16/openai-codex-pr-28143-chrome-account-verification-blocked.json
@@ -1,0 +1,91 @@
+{
+  "schema": "social_post/v1",
+  "slug": "openai-codex-pr-28143-chrome-account-verification-blocked",
+  "channel": "x",
+  "target_account": "decodexspace",
+  "controller_account": "hackink",
+  "mode": "operator_impact",
+  "status": "failed",
+  "audience": "Codex app-server client authors and Control Plane operators",
+  "text": [
+    "Codex PR #28143 exposes earned rate-limit reset credits through app-server: `account/rateLimits/read` now returns `rateLimitResetCredits`, and clients can consume one with an idempotency key. https://github.com/openai/codex/pull/28143",
+    "Operator detail: consume returns only an outcome (`reset`, `nothingToReset`, `noCredit`, or `alreadyRedeemed`). Clients should refetch `account/rateLimits/read` instead of inferring updated windows."
+  ],
+  "source_refs": {
+    "social_candidates": [
+      "artifacts/github/social-candidates/openai-codex-pr-28143.json"
+    ],
+    "upstream_reviews": [
+      "artifacts/github/reviews/openai-codex-pr-28143.review.json"
+    ],
+    "upstream_impacts": [
+      "artifacts/github/impact/openai-codex-pr-28143.json"
+    ],
+    "urls": [
+      "https://github.com/openai/codex/pull/28143"
+    ]
+  },
+  "evidence_notes": [
+    "The social_candidate/v1 artifact has decision.worthiness = publish, priority high, and mode operator_impact for openai-codex-pr-28143.",
+    "The candidate copy is English-only, under 280 characters per post, and includes a direct GitHub PR URL on the first important PR mention.",
+    "The upstream_review/v1 artifact confirms app-server clients can read rateLimitResetCredits.availableCount from account/rateLimits/read and consume a reset credit with a non-empty idempotencyKey.",
+    "The upstream_impact/v1 artifact marks the change as public_signal_decision publish, control_plane_impact candidate, publisher_angle operator_impact, and confidence confirmed.",
+    "The x-post-quality-system gate passed because the candidate states what changed, who can act on it, and what direct source proves it.",
+    "The release publisher gates were not applicable because this is a non-release operator_impact candidate.",
+    "Checked durable social_post/v1 records contained no published or blocked record for this idempotency key before this failed attempt.",
+    "Checked durable social_publish_reservation/v1 records contained no active reservation for this idempotency key before this failed attempt.",
+    "Open GitHub PR readback with routed hackink credentials found only dependency PRs #394 and #395; no open publication PRs were present for cap or duplicate accounting.",
+    "Asia/Shanghai cap day 2026-06-16 had one checked published @decodexspace record before this failed attempt, so the daily cap was not the blocker.",
+    "Chrome control setup and the one allowed lightweight retry both returned that the extension browser was unavailable, so Publisher could not verify the logged-in @decodexspace account or read the live profile/timeline for duplicates.",
+    "Chrome troubleshooting checks found Google Chrome running, Google Chrome installed, the Codex Chrome Extension installed and enabled in the selected Default profile, and the native host manifest present and correct.",
+    "Because @decodexspace account verification and live duplicate readback were unavailable, Publisher stopped before creating a reservation, opening compose, attaching media, or clicking Post.",
+    "No Chrome tabs were claimed, created, composed, uploaded, or left open by this run because the Chrome control channel was unavailable before tab acquisition."
+  ],
+  "claims": [
+    {
+      "text": "Codex app-server can now expose earned rate-limit reset credit availability through account/rateLimits/read.",
+      "evidence": "artifacts/github/reviews/openai-codex-pr-28143.review.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The consume API uses an idempotency key and returns a camelCase outcome.",
+      "evidence": "artifacts/github/impact/openai-codex-pr-28143.json",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "Clients should refetch rate limits after consuming a reset credit instead of inferring updated windows locally.",
+      "evidence": "https://github.com/openai/codex/pull/28143",
+      "confidence": "confirmed"
+    },
+    {
+      "text": "The PR #28143 operator-impact post was not published because Chrome account verification and live duplicate readback were unavailable.",
+      "evidence": "This social_post/v1 failure record",
+      "confidence": "confirmed"
+    }
+  ],
+  "decision": {
+    "worthiness": "publish",
+    "priority": "high",
+    "idempotency_key": "x:decodexspace:openai-codex-pr-28143:operator-impact",
+    "reason": "Source-backed operator-impact change for app-server clients handling account rate limits and reset credits.",
+    "daily_limit": 8,
+    "daily_count_before": 1,
+    "daily_count_after": 1,
+    "day": "2026-06-16",
+    "timezone": "Asia/Shanghai"
+  },
+  "failure": {
+    "reason": "chrome_account_verification_blocked",
+    "details": "Chrome extension control was unavailable during setup and after the one allowed retry. Publisher could not verify @decodexspace, could not perform live @decodexspace profile or timeline duplicate readback, and stopped before reservation, compose, media upload, or posting."
+  },
+  "media_refs": [
+    "media_caveat: no generated media was created or attached because the run stopped before account verification, reservation, compose, and upload gates."
+  ],
+  "caveats": [
+    "No X post was published.",
+    "No social_publish_reservation/v1 record was created for this attempt.",
+    "Retry publication only after Chrome can reliably verify @decodexspace and read the live @decodexspace profile or timeline.",
+    "Do not imply Decodex has already implemented a reset-credit UI or consume action.",
+    "Keep the claim scoped to ChatGPT-backed Codex accounts and backend-provided reset credits."
+  ]
+}


### PR DESCRIPTION
## Summary
- add a social_post/v1 failed record for openai-codex-pr-28143
- record that the candidate was publish-worthy but Chrome account/profile verification was unavailable
- document that no reservation, compose, media upload, or X post happened

## Validation
- `jq empty artifacts/social/x/posts/2026-06-16/openai-codex-pr-28143-chrome-account-verification-blocked.json`
- `decodex radar validate artifacts/github/social-candidates artifacts/social/x`

## Publisher Evidence
- candidate: `openai-codex-pr-28143`
- decision.worthiness: `publish`
- mode: `operator_impact`
- status: `failed`
- failure: `chrome_account_verification_blocked`
- daily cap: 1/8 before and after for Asia/Shanghai 2026-06-16
- publication URL: none
- media: none; stopped before account verification and compose gates

## Chrome Gate
Chrome was running, the Codex Chrome Extension was installed/enabled, and the native host manifest was correct, but the Chrome control channel was unavailable on setup and retry. Publisher failed closed before reservation or compose.