### PR TITLE
Roll dependency updates

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -44,12 +44,12 @@ jobs:
         run: rustup toolchain install nightly --component rustfmt
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
         with:
           tool: cargo-make
 
       - name: Install nextest
-        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
         with:
           tool: nextest
 
@@ -85,7 +85,7 @@ jobs:
           cache-dependency-path: site/package-lock.json
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
         with:
           tool: cargo-make
 
@@ -110,12 +110,12 @@ jobs:
           rustflags: ''
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
         with:
           tool: cargo-make
 
       - name: Install taplo
-        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
         with:
           tool: taplo
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.2"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f04f6fef12d70d42a77b1433c9e0f065238479a6cefc4f5bab105e9873a3c3"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.9.2"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0bd4c2f75335ad98052a37efb54f428b492f64340257143b3429c8a508fa7b"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
  "darling",
  "ident_case",

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@astrojs/check": "^0.9.9",
         "@tailwindcss/vite": "4.3.1",
-        "astro": "^6.4.2",
-        "marked": "^18.0.4",
+        "astro": "^6.4.7",
+        "marked": "^18.0.5",
         "tailwindcss": "4.3.1",
         "three": "^0.184.0",
         "typescript": "^6.0.3"
@@ -2324,9 +2324,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.6.tgz",
-      "integrity": "sha512-48OBTBKR9ctbf+DQxpOuxGl8ebfn59zTuNQMBzptmG/Mi/H8IdfMSbJgGuX1I/4U6g9yazG1p4BHlf4+2hWU4Q==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.7.tgz",
+      "integrity": "sha512-5vsXx0H52u23Jpshs9tM81D03Tb3Oh2Vt2Zo0bpqjXN+njkAWjFyGjTfmWJLAcrCQd9Q+iWB1eqfhR1sZJEaUA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",

--- a/site/package.json
+++ b/site/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "@astrojs/check": "^0.9.9",
     "@tailwindcss/vite": "4.3.1",
-    "astro": "^6.4.2",
-    "marked": "^18.0.4",
+    "astro": "^6.4.7",
+    "marked": "^18.0.5",
     "tailwindcss": "4.3.1",
     "three": "^0.184.0",
     "typescript": "^6.0.3"


### PR DESCRIPTION
## Summary
- roll site dependencies: astro to ^6.4.7 and marked to ^18.0.5
- refresh Cargo.lock transitive Rust deps: bon/bon-macros 3.9.3
- roll taiki-e/install-action to v2.81.11 and keep external action refs full-SHA pinned

## Verification
- npm outdated --json -> {}
- cargo update --dry-run -> 0 packages to update
- actionlint .github/workflows/language.yml
- cargo make check

## Dependency provenance
- taiki-e/install-action v2.81.11 -> 15449e3094499af05d8d964a1c884208e4b8b595