### PR TITLE
Fix operator dashboard layout order

### DIFF
--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -4006,12 +4006,12 @@
 			const detailAnimationTimers = new WeakMap();
 
 			const DASHBOARD_LAYOUT = {
-				primary: ["accountPool", "projects", "active", "programs", "queue", "review", "worktrees", "recent"],
+				primary: ["accountPool", "projects", "currentLanes", "programs", "queue", "review", "worktrees", "recent"],
 			};
 			const DASHBOARD_SECTION_GROUPS = [
 				{ marker: "control", panels: ["accountPool"] },
 				{ marker: "projects", panels: ["projects"] },
-				{ marker: "execution", panels: ["active", "programs", "queue"] },
+				{ marker: "execution", panels: ["currentLanes", "programs", "queue"] },
 				{ marker: "aftercare", panels: ["review", "worktrees", "recent"] },
 			];
 			const COPY = {

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -60,8 +60,8 @@ fn operator_dashboard_surfaces_program_intake_panel() {
 	assert!(response.contains("program.dispatchable_count"));
 	assert!(response.contains("node.dispatch_action"));
 	assert!(response.contains("renderExecutionPrograms(snapshot, derived);"));
-	assert!(response.contains("primary: [\"accountPool\", \"projects\", \"active\", \"programs\", \"queue\", \"review\", \"worktrees\", \"recent\"]"));
-	assert!(response.contains("{ marker: \"execution\", panels: [\"active\", \"programs\", \"queue\"] }"));
+	assert!(response.contains("primary: [\"accountPool\", \"projects\", \"currentLanes\", \"programs\", \"queue\", \"review\", \"worktrees\", \"recent\"]"));
+	assert!(response.contains("{ marker: \"execution\", panels: [\"currentLanes\", \"programs\", \"queue\"] }"));
 	assert!(!response.contains("data-program-edit"));
 	assert!(!response.contains("data-program-mutate"));
 }
@@ -733,7 +733,7 @@ fn operator_dashboard_renders_account_usage_controls() {
 	assert!(!response.contains("queue-group-count"));
 	assert!(response.contains("nodes.projectTitle.textContent = \"Decodex\""));
 	assert!(!response.contains("Decodex Operator"));
-	assert!(response.contains("primary: [\"accountPool\", \"projects\", \"active\", \"programs\", \"queue\", \"review\", \"worktrees\", \"recent\"]"));
+	assert!(response.contains("primary: [\"accountPool\", \"projects\", \"currentLanes\", \"programs\", \"queue\", \"review\", \"worktrees\", \"recent\"]"));
 	assert!(!response.contains("#account-pool-panel {"));
 	assert!(!response.contains("No accounts"));
 	assert!(response.contains("#current-lanes-panel {\n\t\t\t\tbackground: transparent;"));


### PR DESCRIPTION
## Summary
- keep Accounts and Projects ahead of Execution in the operator dashboard layout
- update dashboard layout assertions for the currentLanes panel key

## Verification
- cargo test -p decodex operator_dashboard --lib