### PR TITLE
Prevent stale current-lane attempt rebound

### DIFF
--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -478,17 +478,19 @@ fn operator_current_lane_statuses(
 		.into_iter()
 		.filter(operator_run_counts_as_current_lane)
 		.collect::<Vec<_>>();
+	let latest_attempt_by_issue_key =
+		operator_latest_attempt_by_issue_key(current_lanes.iter().chain(recent_runs.iter()));
+
+	current_lanes.retain(|run| {
+		!operator_run_is_superseded_by_newer_attempt(run, &latest_attempt_by_issue_key)
+	});
+
 	let mut current_lane_run_ids =
 		current_lanes.iter().map(|run| run.run_id.clone()).collect::<HashSet<_>>();
-	let current_lane_shadow_keys = current_lanes
-		.iter()
-		.filter(|run| run.run_lease)
-		.map(operator_run_group_key)
-		.collect::<HashSet<_>>();
 
 	for run in recent_runs {
 		if current_lane_run_ids.contains(&run.run_id)
-			|| current_lane_shadow_keys.contains(&operator_run_group_key(run))
+			|| operator_run_is_superseded_by_newer_attempt(run, &latest_attempt_by_issue_key)
 			|| !operator_run_has_live_execution(run)
 		{
 			continue;
@@ -501,6 +503,30 @@ fn operator_current_lane_statuses(
 	hydrate_current_lane_lifecycle_metrics(&mut current_lanes, recent_runs);
 
 	Ok(current_lanes)
+}
+
+fn operator_latest_attempt_by_issue_key<'a>(
+	runs: impl Iterator<Item = &'a OperatorRunStatus>,
+) -> HashMap<String, i64> {
+	let mut latest_attempt_by_issue_key = HashMap::new();
+
+	for run in runs {
+		let issue_key = operator_run_group_key(run);
+		let latest_attempt = latest_attempt_by_issue_key.entry(issue_key).or_insert(run.attempt_number);
+
+		*latest_attempt = (*latest_attempt).max(run.attempt_number);
+	}
+
+	latest_attempt_by_issue_key
+}
+
+fn operator_run_is_superseded_by_newer_attempt(
+	run: &OperatorRunStatus,
+	latest_attempt_by_issue_key: &HashMap<String, i64>,
+) -> bool {
+	latest_attempt_by_issue_key
+		.get(&operator_run_group_key(run))
+		.is_some_and(|latest_attempt| run.attempt_number < *latest_attempt)
 }
 
 fn global_codex_account_control_status() -> OperatorCodexAccountControlStatus {

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -2182,6 +2182,53 @@ fn operator_status_snapshot_shadows_stale_attempt_when_newer_leased_attempt_exis
 }
 
 #[test]
+fn operator_status_snapshot_shadows_stale_attempt_when_newer_attempt_has_released_lease() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue("Todo", &[]);
+	let worktree_path = config.worktree_root().join("PUB-101");
+	let stale_activity =
+		OffsetDateTime::now_utc().unix_timestamp() - RUN_LEASE_IDLE_TIMEOUT.as_secs() as i64 - 30;
+	let stale_run_id = "pub-101-attempt-2-1781621836";
+	let newer_run_id = "pub-101-attempt-3-1781623863";
+
+	state_store
+		.record_run_attempt(stale_run_id, &issue.id, 2, "running")
+		.expect("stale run attempt should record");
+	state_store
+		.record_run_attempt(newer_run_id, &issue.id, 3, "succeeded")
+		.expect("newer run attempt should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+	fs::write(
+		worktree_path.join(RUN_ACTIVITY_MARKER_FILE),
+		format!(
+			"run_id={stale_run_id}\nattempt_number=2\nlast_activity_unix_epoch={stale_activity}\nlast_protocol_activity_unix_epoch={stale_activity}\nevent_count=1\nlast_event_type=skills/changed\n"
+		),
+	)
+	.expect("stale protocol marker should write");
+
+	let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+		.expect("snapshot should build");
+	let project = snapshot.projects.first().expect("project summary should exist");
+
+	assert!(snapshot.current_lanes.is_empty());
+	assert!(snapshot.recent_runs.iter().any(|run| run.run_id == stale_run_id));
+	assert!(snapshot.recent_runs.iter().any(|run| run.run_id == newer_run_id));
+	assert_eq!(project.current_lane_count, 0);
+	assert_eq!(project.running_lane_count, 0);
+	assert_eq!(project.attention_count, 0);
+}
+
+#[test]
 fn operator_status_snapshot_excludes_completed_lingering_lease_from_current_lanes() {
 	let (_temp_dir, config, _workflow) = temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -409,9 +409,10 @@ Worktree visibility follows the owning dashboard section:
   when `process_alive` is false.
   `run_lease` is queue lease ownership only; `execution_liveness` explains why
   the lane is still visible when the queue lease is not held.
-  If a newer attempt for the same issue holds the run lease, older unleased attempts
-  with stale protocol/process evidence are shadowed out of `Running Lanes` and
-  current-attention counts so one issue does not appear as simultaneous current work.
+  If a newer visible attempt for the same issue exists, older attempts with stale
+  protocol/process evidence are shadowed out of `Running Lanes` and current-attention
+  counts so one issue does not appear as simultaneous current work or rebound after
+  the newer attempt releases its lease.
   Retry attempts also read the immediately previous attempt's unterminated phase-goal
   state, so a lane already in `handoff_evidence` resumes handoff instead of repeating
   implementation just because the attempt identity changed.

--- a/docs/spec/lane-control-state.md
+++ b/docs/spec/lane-control-state.md
@@ -77,9 +77,10 @@ from protocol activity.
 - A lane counts as a running lane only when `ownership_state` is `leased_run`.
 - Liveness evidence may update `liveness_state`, but it must not create or restore
   `leased_run` ownership.
-- When a newer attempt for the same issue has `ownership_state=leased_run`, older
-  unleased attempts with stale or protocol-only liveness evidence stay out of
-  current-lane projection and current-attention counts.
+- When a newer visible attempt for the same issue exists, older attempts with stale
+  or protocol-only liveness evidence stay out of current-lane projection and
+  current-attention counts. The older attempts remain available as recent/history
+  evidence, but only the newest attempt in that issue lineage may become current.
 - A retry or automatic continuation for the same issue must resume the latest
   unterminated phase-goal state from the immediately previous attempt. A validated
   or active `handoff_evidence` phase must not be reset to


### PR DESCRIPTION
## Summary
- Treat the newest visible attempt per issue as the only current-lane candidate.
- Keep superseded stale attempts in recent/history evidence while preventing them from driving Current Lanes or current attention counts.
- Update operator/lane-control docs for the stronger supersession invariant.

## Verification
- cargo make fmt-check
- git diff --check
- cargo make lint-fix
- cargo make check-rust
- cargo test -p decodex operator_status_snapshot
- cargo make test: 1199 passed, 1 skipped
- patched live status: XY-970 current_lanes=[]
