### PR TITLE
Standardize OKF prose capitalization

### DIFF
--- a/apps/decodex/src/docs_okf.rs
+++ b/apps/decodex/src/docs_okf.rs
@@ -137,6 +137,7 @@ pub(crate) fn run_docs_check(root: &Path, scope: DocsCheckScope) -> Result<DocsC
 
 	if matches!(scope, DocsCheckScope::All | DocsCheckScope::Index) {
 		check_markdown_only(&files, &mut report);
+		check_acronym_capitalization(&files, &mut report);
 		check_concept_contracts(&files, &mut report);
 	}
 	if matches!(scope, DocsCheckScope::All | DocsCheckScope::Links) {
@@ -250,6 +251,23 @@ fn check_markdown_only(files: &[DocsFile], report: &mut DocsCheckReport) {
 			};
 
 			report.issues.push(issue(Some(file.relative_path.clone()), String::from(message)));
+		}
+	}
+}
+
+fn check_acronym_capitalization(files: &[DocsFile], report: &mut DocsCheckReport) {
+	for file in files.iter().filter(|file| is_markdown(&file.relative_path)) {
+		let Some(content) = file.content.as_deref() else {
+			continue;
+		};
+
+		if content.contains("Okf") {
+			report.issues.push(issue(
+				Some(file.relative_path.clone()),
+				String::from(
+					"use `OKF` in prose; lowercase `okf` is reserved for paths, slugs, tags, and URLs",
+				),
+			));
 		}
 	}
 }
@@ -842,6 +860,23 @@ mod tests {
 
 		assert!(report.has_issues());
 		assert!(report.issues.iter().any(|issue| issue.message.contains("JSON artifacts")));
+	}
+
+	#[test]
+	fn docs_check_rejects_mis_capitalized_okf_acronym() {
+		let temp_dir = TempDir::new().expect("tempdir");
+		let docs = temp_dir.path().join("docs");
+
+		write_minimal_okf_bundle(&docs);
+		write(
+			&docs.join("policy.md"),
+			"---\ntype: Policy\ntitle: Okf policy\ndescription: Test concept.\nstatus: active\nauthority: non_authoritative\nowner: docs\nlast_verified: 2026-06-16\n---\n\n# Purpose\nOkf should be uppercase.\n",
+		);
+
+		let report = docs_okf::run_docs_check(&docs, DocsCheckScope::All).expect("check");
+
+		assert!(report.has_issues());
+		assert!(report.issues.iter().any(|issue| issue.message.contains("use `OKF`")));
 	}
 
 	#[test]

--- a/apps/decodex/src/plugin_surface_tests.rs
+++ b/apps/decodex/src/plugin_surface_tests.rs
@@ -307,6 +307,7 @@ fn packaged_docs_skills_encode_okf_wiki_and_drift_boundaries() {
 	assert_contains(&docs_surface, "one authoritative concept per claim");
 	assert_contains(&docs_surface, "pass`, `fail`, or `needs-human");
 	assert_contains(&docs_surface, "Do not create a parallel `wiki/` or `okf/` root");
+	assert_not_contains(&docs_surface, "Okf");
 }
 
 #[test]

--- a/docs/log.md
+++ b/docs/log.md
@@ -35,3 +35,5 @@
 - Clarified the Program Intake public/private boundary so generated Linear issue
   descriptions omit internal Program and node identifiers while SQLite/operator
   readback keeps private mappings.
+- Standardized `OKF` as the all-caps prose form while preserving lowercase `okf` for
+  filenames, paths, skill IDs, tags, and URLs.

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -38,6 +38,12 @@ or private execution evidence.
 Runtime state may still use internal structured storage. The docs source of truth for
 research, drift audit, decisions, references, runbooks, and specs is Markdown.
 
+## Naming
+
+Write `OKF` as an all-caps acronym in prose, matching the repository convention for
+`CLI`. Lowercase `okf` is allowed only in machine identifiers such as filenames,
+paths, skill IDs, tags, and URLs.
+
 ## Concept Frontmatter
 
 Every concept must start with YAML frontmatter delimited by `---`.

--- a/plugins/decodex/references/docs-okf.md
+++ b/plugins/decodex/references/docs-okf.md
@@ -10,6 +10,7 @@ concepts.
 - `docs/index.md`, `docs/policy.md`, and `docs/log.md` must exist.
 - Non-index, non-log Markdown documents are OKF concepts.
 - Concepts start with YAML frontmatter delimited by `---`.
+- Prose spells the acronym `OKF`; lowercase `okf` is slug-only.
 
 ## Required Frontmatter
 


### PR DESCRIPTION
## Summary
- enforce all-caps OKF in docs lint for prose
- document OKF naming rules in docs policy and plugin OKF reference
- add coverage for packaged docs surfaces

## Verification
- cargo test -p decodex docs_check_rejects_mis_capitalized_okf_acronym
- cargo test -p decodex packaged_docs_skills_encode_okf_wiki_and_drift_boundaries
- cargo run -p decodex --bin decodex -- docs lint
- cargo make docs-check
- rustfmt --check apps/decodex/src/docs_okf.rs apps/decodex/src/plugin_surface_tests.rs
- node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex --format markdown