### PR TITLE
Separate portable OKF layer from Decodex docs profile

### DIFF
--- a/apps/decodex/src/cli.rs
+++ b/apps/decodex/src/cli.rs
@@ -216,7 +216,7 @@ struct OkfGraphCommand {
 #[derive(Debug, Args)]
 struct OkfRouteCommand {
 	/// OKF bundle root.
-	#[arg(value_name = "ROOT", default_value = "docs")]
+	#[arg(value_name = "ROOT")]
 	root: PathBuf,
 	/// Task or question to route into the bundle.
 	intent: String,
@@ -1737,11 +1737,12 @@ mod tests {
 	use crate::{
 		cli::{
 			AccountCommand, AccountSubcommand, AccountUseCommand, AppCommand, AttemptCommand, Cli,
-			Command, CommitCommand, DiagnoseCommand, EvidenceCommand, IntakeCommand,
-			IntakeGoalCommand, IntakeIssuesCommand, IntakeSubcommand, LandCommand, LaneCommand,
-			LaneInspectCommand, LaneInterruptCommand, LaneSteerCommand, LaneSubcommand,
-			LegacyCloseoutRecoveryCommand, McpCommand, McpServeCommand, McpSubcommand,
-			MergedCloseoutRecoveryCommand, ProbeCommand, ProjectCommand, ProjectConfigArgs,
+			Command, CommitCommand, DiagnoseCommand, DocsCommand, DocsRouteCommand, DocsSubcommand,
+			EvidenceCommand, IntakeCommand, IntakeGoalCommand, IntakeIssuesCommand,
+			IntakeSubcommand, LandCommand, LaneCommand, LaneInspectCommand, LaneInterruptCommand,
+			LaneSteerCommand, LaneSubcommand, LegacyCloseoutRecoveryCommand, McpCommand,
+			McpServeCommand, McpSubcommand, MergedCloseoutRecoveryCommand, OkfCommand,
+			OkfRouteCommand, OkfSubcommand, ProbeCommand, ProjectCommand, ProjectConfigArgs,
 			ProjectSubcommand, RecoverCommand, RecoverSubcommand, ResearchCommand,
 			ResearchCompileCommand, ResearchOutcomeArg, ResearchPromoteCommand, ResearchSubcommand,
 			ReviewHandoffAdoptCommand, ReviewHandoffDiagnoseCommand, ReviewHandoffRebindCommand,
@@ -1815,6 +1816,46 @@ mod tests {
 				breaking: true,
 				..
 			})
+		));
+	}
+
+	#[test]
+	fn parses_okf_and_docs_route_commands() {
+		let okf_cli = Cli::parse_from([
+			"decodex",
+			"okf",
+			"route",
+			"docs",
+			"change okf docs command design",
+			"--limit",
+			"3",
+		]);
+
+		assert!(matches!(
+			okf_cli.command,
+			Command::Okf(OkfCommand {
+				command: OkfSubcommand::Route(OkfRouteCommand {
+					root,
+					intent,
+					limit: 3,
+				}),
+			}) if root == Path::new("docs")
+				&& intent == "change okf docs command design"
+		));
+
+		let docs_cli =
+			Cli::parse_from(["decodex", "docs", "route", "change okf docs command design"]);
+
+		assert!(matches!(
+			docs_cli.command,
+			Command::Docs(DocsCommand {
+				root,
+				command: DocsSubcommand::Route(DocsRouteCommand {
+					intent,
+					limit: 5,
+				}),
+			}) if root == Path::new("docs")
+				&& intent == "change okf docs command design"
 		));
 	}
 

--- a/apps/decodex/src/cli.rs
+++ b/apps/decodex/src/cli.rs
@@ -18,7 +18,7 @@ use crate::{
 	accounts::{self, AccountImportRequest, AccountLoginRequest, AccountUseRequest},
 	agent,
 	archive_hygiene::{self, ArchiveHygieneRequest},
-	docs_okf::{self, DocsCheckScope},
+	docs_okf::{self, DocsCheckScope, OkfCheckProfile, OkfQuery},
 	maintenance::{self, MaintenanceMode, MaintenancePruneRequest, MaintenanceScope},
 	manual::{self, ManualCommitRequest, ManualLandRequest},
 	mcp::{self, McpServeRequest, McpTransport},
@@ -75,6 +75,7 @@ impl Cli {
 			Command::Diagnose(args) => args.run(),
 			Command::Evidence(args) => args.run(),
 			Command::Docs(args) => args.run(),
+			Command::Okf(args) => args.run(),
 			Command::Research(args) => args.run(),
 			Command::Intake(args) => args.run(),
 			Command::Recover(args) => args.run(),
@@ -129,12 +130,18 @@ struct DocsCommand {
 }
 impl DocsCommand {
 	fn run(&self) -> Result<()> {
-		let scope = match self.command {
-			DocsSubcommand::Lint => DocsCheckScope::All,
-			DocsSubcommand::Index => DocsCheckScope::Index,
-			DocsSubcommand::Links => DocsCheckScope::Links,
-			DocsSubcommand::Drift => DocsCheckScope::Drift,
-		};
+		match &self.command {
+			DocsSubcommand::Check => self.run_check(DocsCheckScope::All),
+			DocsSubcommand::Index => self.run_check(DocsCheckScope::Index),
+			DocsSubcommand::Links => self.run_check(DocsCheckScope::Links),
+			DocsSubcommand::Drift => self.run_check(DocsCheckScope::Drift),
+			DocsSubcommand::Find(args) => run_okf_find(&self.root, &args.filters),
+			DocsSubcommand::Graph(args) => run_okf_graph(&self.root, args.json),
+			DocsSubcommand::Route(args) => run_okf_route(&self.root, &args.intent, args.limit),
+		}
+	}
+
+	fn run_check(&self, scope: DocsCheckScope) -> Result<()> {
 		let report = docs_okf::run_docs_check(&self.root, scope)?;
 
 		print!("{}", docs_okf::render_docs_check_report(&report));
@@ -144,6 +151,137 @@ impl DocsCommand {
 		}
 
 		Ok(())
+	}
+}
+
+#[derive(Debug, Args)]
+struct OkfCommand {
+	#[command(subcommand)]
+	command: OkfSubcommand,
+}
+impl OkfCommand {
+	fn run(&self) -> Result<()> {
+		match &self.command {
+			OkfSubcommand::Check(args) => args.run(),
+			OkfSubcommand::Find(args) => run_okf_find(&args.root, &args.filters),
+			OkfSubcommand::Graph(args) => run_okf_graph(&args.root, args.json),
+			OkfSubcommand::Route(args) => run_okf_route(&args.root, &args.intent, args.limit),
+		}
+	}
+}
+
+#[derive(Debug, Args)]
+struct OkfCheckCommand {
+	/// OKF bundle root.
+	#[arg(value_name = "ROOT", default_value = "docs")]
+	root: PathBuf,
+	/// Validation profile to apply.
+	#[arg(long, value_enum, default_value_t = OkfProfileArg::Core)]
+	profile: OkfProfileArg,
+}
+impl OkfCheckCommand {
+	fn run(&self) -> Result<()> {
+		let profile = OkfCheckProfile::from(self.profile);
+		let report = docs_okf::run_okf_check(&self.root, profile)?;
+
+		print!("{}", docs_okf::render_okf_check_report(&report));
+
+		if report.has_issues() {
+			eyre::bail!("okf {} check failed.", report.profile().as_str());
+		}
+
+		Ok(())
+	}
+}
+
+#[derive(Debug, Args)]
+struct OkfFindCommand {
+	/// OKF bundle root.
+	#[arg(value_name = "ROOT", default_value = "docs")]
+	root: PathBuf,
+	#[command(flatten)]
+	filters: OkfFindFilters,
+}
+
+#[derive(Debug, Args)]
+struct OkfGraphCommand {
+	/// OKF bundle root.
+	#[arg(value_name = "ROOT", default_value = "docs")]
+	root: PathBuf,
+	/// Emit graph JSON instead of a text summary.
+	#[arg(long)]
+	json: bool,
+}
+
+#[derive(Debug, Args)]
+struct OkfRouteCommand {
+	/// OKF bundle root.
+	#[arg(value_name = "ROOT", default_value = "docs")]
+	root: PathBuf,
+	/// Task or question to route into the bundle.
+	intent: String,
+	/// Maximum number of concepts to print.
+	#[arg(long, default_value_t = 5)]
+	limit: usize,
+}
+
+#[derive(Debug, Args)]
+struct DocsFindCommand {
+	#[command(flatten)]
+	filters: OkfFindFilters,
+}
+
+#[derive(Debug, Args)]
+struct DocsGraphCommand {
+	/// Emit graph JSON instead of a text summary.
+	#[arg(long)]
+	json: bool,
+}
+
+#[derive(Debug, Args)]
+struct DocsRouteCommand {
+	/// Task or question to route into the bundle.
+	intent: String,
+	/// Maximum number of concepts to print.
+	#[arg(long, default_value_t = 5)]
+	limit: usize,
+}
+
+#[derive(Debug, Args)]
+struct OkfFindFilters {
+	/// Match concept type.
+	#[arg(long = "type")]
+	concept_type: Option<String>,
+	/// Match exact tag. May be repeated.
+	#[arg(long)]
+	tag: Vec<String>,
+	/// Match resource URI substring.
+	#[arg(long)]
+	resource: Option<String>,
+	/// Match source_refs substring.
+	#[arg(long)]
+	source_ref: Option<String>,
+	/// Match code_refs substring.
+	#[arg(long)]
+	code_ref: Option<String>,
+	/// Match related refs substring.
+	#[arg(long)]
+	related: Option<String>,
+	/// Match path, title, or description substring.
+	#[arg(long)]
+	text: Option<String>,
+}
+impl From<&OkfFindFilters> for OkfQuery {
+	fn from(value: &OkfFindFilters) -> Self {
+		Self {
+			concept_type: value.concept_type.clone(),
+			tags: value.tag.clone(),
+			resource: value.resource.clone(),
+			source_ref: value.source_ref.clone(),
+			code_ref: value.code_ref.clone(),
+			related: value.related.clone(),
+			text: value.text.clone(),
+		}
 	}
 }
 
@@ -1224,14 +1362,33 @@ impl From<IssueDispatchMode> for AttemptDispatchMode {
 
 #[derive(Debug, Subcommand)]
 enum DocsSubcommand {
-	/// Validate the complete Markdown-only OKF docs bundle.
-	Lint,
+	/// Validate the complete Markdown-only Decodex docs bundle.
+	#[command(alias = "lint")]
+	Check,
 	/// Validate OKF routing files and concept frontmatter.
 	Index,
 	/// Validate local Markdown links.
 	Links,
 	/// Validate semantic-drift audit routing.
 	Drift,
+	/// Find concepts in the default docs bundle.
+	Find(DocsFindCommand),
+	/// Print the default docs bundle graph.
+	Graph(DocsGraphCommand),
+	/// Route a task to relevant docs concepts.
+	Route(DocsRouteCommand),
+}
+
+#[derive(Debug, Subcommand)]
+enum OkfSubcommand {
+	/// Validate an OKF bundle with a selected profile.
+	Check(OkfCheckCommand),
+	/// Find concepts by frontmatter fields.
+	Find(OkfFindCommand),
+	/// Print an OKF concept graph.
+	Graph(OkfGraphCommand),
+	/// Route a task to relevant concepts.
+	Route(OkfRouteCommand),
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -1261,6 +1418,8 @@ enum Command {
 	Evidence(EvidenceCommand),
 	/// Validate the repo docs as a Markdown-only OKF knowledge bundle.
 	Docs(DocsCommand),
+	/// Inspect portable OKF bundles.
+	Okf(OkfCommand),
 	/// Compile or promote Decodex-native research/design contracts.
 	Research(ResearchCommand),
 	/// Operator issue-batch intake into internal Execution Programs, not a graph editor.
@@ -1346,6 +1505,25 @@ enum IntakeSubcommand {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
+enum OkfProfileArg {
+	Core,
+	Wiki,
+	RepoMemory,
+	Decodex,
+}
+impl From<OkfProfileArg> for OkfCheckProfile {
+	fn from(value: OkfProfileArg) -> Self {
+		match value {
+			OkfProfileArg::Core => Self::Core,
+			OkfProfileArg::Wiki => Self::Wiki,
+			OkfProfileArg::RepoMemory => Self::RepoMemory,
+			OkfProfileArg::Decodex => Self::Decodex,
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
 enum ResearchOutcomeArg {
 	DecisionReady,
 	NotDecisionReady,
@@ -1381,6 +1559,64 @@ enum MaintenanceSubcommand {
 
 fn default_lane_steer_wait_timeout_ms() -> u64 {
 	u64::try_from(DEFAULT_STEER_RESULT_WAIT_TIMEOUT.as_millis()).unwrap_or(10_000)
+}
+
+fn run_okf_find(root: &Path, filters: &OkfFindFilters) -> Result<()> {
+	let query = OkfQuery::from(filters);
+	let concepts = docs_okf::query_okf_bundle(root, &query)?;
+
+	println!("okf find: concepts={} root={}", concepts.len(), root.display());
+
+	for concept in concepts {
+		println!(
+			"{} | {} | {}{}",
+			concept.path,
+			concept.concept_type,
+			concept.title,
+			concept
+				.description
+				.as_deref()
+				.map_or(String::new(), |description| format!(" | {description}"))
+		);
+	}
+
+	Ok(())
+}
+
+fn run_okf_graph(root: &Path, json: bool) -> Result<()> {
+	let graph = docs_okf::build_okf_graph(root)?;
+
+	if json {
+		print!("{}", docs_okf::render_okf_graph_json(&graph)?);
+	} else {
+		print!("{}", docs_okf::render_okf_graph_summary(root, &graph));
+	}
+
+	Ok(())
+}
+
+fn run_okf_route(root: &Path, intent: &str, limit: usize) -> Result<()> {
+	let matches = docs_okf::route_okf_bundle(root, intent, limit)?;
+
+	println!(
+		"okf route: matches={} limit={} root={} intent={}",
+		matches.len(),
+		limit,
+		root.display(),
+		intent
+	);
+
+	for route_match in matches {
+		println!(
+			"{} | score={} | {} | {}",
+			route_match.concept.path,
+			route_match.score,
+			route_match.concept.concept_type,
+			route_match.concept.title
+		);
+	}
+
+	Ok(())
 }
 
 fn lane_steer_report_is_failure(report: &LaneSteerReport) -> bool {

--- a/apps/decodex/src/docs_okf.rs
+++ b/apps/decodex/src/docs_okf.rs
@@ -8,6 +8,7 @@ use std::{
 
 use regex::Regex;
 use reqwest::Url;
+use serde::Serialize;
 use serde_yaml::{Mapping, Value};
 use time::{Date, Month};
 
@@ -85,6 +86,29 @@ impl DocsCheckScope {
 	}
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum OkfCheckProfile {
+	/// Validate only the portable OKF v0.1 conformance surface.
+	Core,
+	/// Validate OKF plus agent navigation and graph quality.
+	Wiki,
+	/// Validate wiki quality plus repository-memory anchors.
+	RepoMemory,
+	/// Validate the strict Decodex docs profile.
+	Decodex,
+}
+impl OkfCheckProfile {
+	/// Return the CLI/report label for this profile.
+	pub(crate) fn as_str(self) -> &'static str {
+		match self {
+			Self::Core => "core",
+			Self::Wiki => "wiki",
+			Self::RepoMemory => "repo-memory",
+			Self::Decodex => "decodex",
+		}
+	}
+}
+
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct DocsCheckReport {
 	scope: DocsCheckScope,
@@ -98,6 +122,108 @@ impl DocsCheckReport {
 	pub(crate) fn has_issues(&self) -> bool {
 		!self.issues.is_empty()
 	}
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct OkfCheckReport {
+	profile: OkfCheckProfile,
+	bundle_root: PathBuf,
+	concept_count: usize,
+	link_count: usize,
+	issues: Vec<DocsCheckIssue>,
+}
+impl OkfCheckReport {
+	/// Return whether the check found at least one OKF issue.
+	pub(crate) fn has_issues(&self) -> bool {
+		!self.issues.is_empty()
+	}
+
+	/// Return the profile used for this OKF check.
+	pub(crate) fn profile(&self) -> OkfCheckProfile {
+		self.profile
+	}
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct OkfQuery {
+	/// Match a concept `type` value.
+	pub(crate) concept_type: Option<String>,
+	/// Match one or more exact tag values.
+	pub(crate) tags: Vec<String>,
+	/// Match a substring in the `resource` field.
+	pub(crate) resource: Option<String>,
+	/// Match a substring in `source_refs`.
+	pub(crate) source_ref: Option<String>,
+	/// Match a substring in `code_refs`.
+	pub(crate) code_ref: Option<String>,
+	/// Match a substring in `related`.
+	pub(crate) related: Option<String>,
+	/// Match a substring in concept path, title, or description.
+	pub(crate) text: Option<String>,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct OkfConceptSummary {
+	/// Concept id, derived from the bundle-relative file path without `.md`.
+	pub(crate) id: String,
+	/// Bundle-relative Markdown file path.
+	pub(crate) path: String,
+	/// Concept type from frontmatter.
+	pub(crate) concept_type: String,
+	/// Human-readable title, derived from frontmatter or path.
+	pub(crate) title: String,
+	/// Retrieval summary from frontmatter.
+	pub(crate) description: Option<String>,
+	/// Resource URI from frontmatter.
+	pub(crate) resource: Option<String>,
+	/// Tags from frontmatter.
+	pub(crate) tags: Vec<String>,
+	/// External source references from frontmatter.
+	pub(crate) source_refs: Vec<String>,
+	/// Repository file references from frontmatter.
+	pub(crate) code_refs: Vec<String>,
+	/// Related concept references from frontmatter.
+	pub(crate) related: Vec<String>,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct OkfGraphEdge {
+	/// Source concept id.
+	pub(crate) source: String,
+	/// Target concept id.
+	pub(crate) target: String,
+	/// Relationship source, such as `markdown` or `related`.
+	pub(crate) kind: String,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct OkfBrokenLink {
+	/// Source concept id.
+	pub(crate) source: String,
+	/// Unresolved link target.
+	pub(crate) target: String,
+	/// Relationship source, such as `markdown` or `related`.
+	pub(crate) kind: String,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct OkfGraph {
+	/// Concepts in the bundle.
+	pub(crate) concepts: Vec<OkfConceptSummary>,
+	/// Resolved graph edges between concepts.
+	pub(crate) edges: Vec<OkfGraphEdge>,
+	/// Unresolved graph edges.
+	pub(crate) broken_links: Vec<OkfBrokenLink>,
+	/// Concepts with no inbound or outbound resolved edges.
+	pub(crate) orphan_concepts: Vec<String>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct OkfRouteMatch {
+	/// Matching concept summary.
+	pub(crate) concept: OkfConceptSummary,
+	/// Simple lexical relevance score.
+	pub(crate) score: usize,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -180,6 +306,190 @@ pub(crate) fn render_docs_check_report(report: &DocsCheckReport) -> String {
 	output
 }
 
+/// Validate any OKF bundle with the selected profile.
+pub(crate) fn run_okf_check(root: &Path, profile: OkfCheckProfile) -> Result<OkfCheckReport> {
+	if profile == OkfCheckProfile::Decodex {
+		return Ok(decodex_docs_report_as_okf(run_docs_check(root, DocsCheckScope::All)?));
+	}
+
+	let bundle_root = root.to_path_buf();
+
+	if !bundle_root.is_dir() {
+		color_eyre::eyre::bail!("OKF bundle root `{}` does not exist.", bundle_root.display());
+	}
+
+	let mut files = Vec::new();
+
+	collect_files(&bundle_root, &bundle_root, &mut files)?;
+
+	let mut report = OkfCheckReport {
+		profile,
+		bundle_root,
+		concept_count: 0,
+		link_count: 0,
+		issues: Vec::new(),
+	};
+
+	check_okf_markdown_readability(&files, &mut report);
+	check_okf_core_concepts(&files, &mut report);
+
+	if matches!(profile, OkfCheckProfile::Wiki | OkfCheckProfile::RepoMemory) {
+		check_okf_wiki_surface(&files, &mut report)?;
+	}
+	if profile == OkfCheckProfile::RepoMemory {
+		check_okf_repo_memory_surface(&files, &mut report);
+	}
+
+	Ok(report)
+}
+
+/// Render a stable human-readable OKF check report.
+pub(crate) fn render_okf_check_report(report: &OkfCheckReport) -> String {
+	let mut output = String::new();
+
+	output.push_str(&format!(
+		"okf {} check: concepts={} links={} root={}\n",
+		report.profile.as_str(),
+		report.concept_count,
+		report.link_count,
+		report.bundle_root.display()
+	));
+
+	if report.issues.is_empty() {
+		output.push_str("status: pass\n");
+
+		return output;
+	}
+
+	output.push_str("status: fail\n");
+
+	for issue in &report.issues {
+		match &issue.path {
+			Some(path) => output.push_str(&format!("- {}: {}\n", path.display(), issue.message)),
+			None => output.push_str(&format!("- {}\n", issue.message)),
+		}
+	}
+
+	output
+}
+
+/// Return the concept summaries matching an OKF query.
+pub(crate) fn query_okf_bundle(root: &Path, query: &OkfQuery) -> Result<Vec<OkfConceptSummary>> {
+	let files = read_okf_files(root)?;
+	let mut concepts = Vec::new();
+
+	for file in files.iter().filter(|file| is_concept_markdown(&file.relative_path)) {
+		let Some(concept) = concept_summary(file) else {
+			continue;
+		};
+
+		if okf_query_matches(&concept, query) {
+			concepts.push(concept);
+		}
+	}
+
+	concepts.sort_by(|left, right| left.path.cmp(&right.path));
+
+	Ok(concepts)
+}
+
+/// Build an OKF concept graph from Markdown links and `related` frontmatter.
+pub(crate) fn build_okf_graph(root: &Path) -> Result<OkfGraph> {
+	let files = read_okf_files(root)?;
+	let concept_paths = okf_concept_path_set(&files);
+	let mut concepts = Vec::new();
+	let mut edges = Vec::new();
+	let mut broken_links = Vec::new();
+
+	for file in files.iter().filter(|file| is_concept_markdown(&file.relative_path)) {
+		let Some(concept) = concept_summary(file) else {
+			continue;
+		};
+		let source = concept.id.clone();
+
+		collect_markdown_graph_edges(
+			file,
+			root,
+			&concept_paths,
+			&source,
+			&mut edges,
+			&mut broken_links,
+		)?;
+		collect_related_graph_edges(
+			file,
+			root,
+			&concept_paths,
+			&source,
+			&mut edges,
+			&mut broken_links,
+		);
+
+		concepts.push(concept);
+	}
+
+	let orphan_concepts = okf_orphan_concepts(&concepts, &edges);
+
+	concepts.sort_by(|left, right| left.id.cmp(&right.id));
+	edges.sort_by(|left, right| {
+		(&left.source, &left.target, &left.kind).cmp(&(&right.source, &right.target, &right.kind))
+	});
+	broken_links.sort_by(|left, right| {
+		(&left.source, &left.target, &left.kind).cmp(&(&right.source, &right.target, &right.kind))
+	});
+
+	Ok(OkfGraph { concepts, edges, broken_links, orphan_concepts })
+}
+
+/// Render an OKF graph as JSON.
+pub(crate) fn render_okf_graph_json(graph: &OkfGraph) -> Result<String> {
+	Ok(format!("{}\n", serde_json::to_string_pretty(graph)?))
+}
+
+/// Render a compact text graph summary.
+pub(crate) fn render_okf_graph_summary(root: &Path, graph: &OkfGraph) -> String {
+	format!(
+		"okf graph: concepts={} edges={} broken_links={} orphans={} root={}\n",
+		graph.concepts.len(),
+		graph.edges.len(),
+		graph.broken_links.len(),
+		graph.orphan_concepts.len(),
+		root.display()
+	)
+}
+
+/// Route an intent to the highest scoring OKF concepts.
+pub(crate) fn route_okf_bundle(
+	root: &Path,
+	intent: &str,
+	limit: usize,
+) -> Result<Vec<OkfRouteMatch>> {
+	let files = read_okf_files(root)?;
+	let tokens = route_tokens(intent);
+	let mut matches = Vec::new();
+
+	if tokens.is_empty() {
+		return Ok(matches);
+	}
+
+	for file in files.iter().filter(|file| is_concept_markdown(&file.relative_path)) {
+		let Some(concept) = concept_summary(file) else {
+			continue;
+		};
+		let score = route_score(file, &concept, &tokens);
+
+		if score > 0 {
+			matches.push(OkfRouteMatch { concept, score });
+		}
+	}
+
+	matches.sort_by(|left, right| {
+		right.score.cmp(&left.score).then_with(|| left.concept.path.cmp(&right.concept.path))
+	});
+	matches.truncate(limit);
+
+	Ok(matches)
+}
+
 fn collect_files(root: &Path, dir: &Path, files: &mut Vec<DocsFile>) -> Result<()> {
 	for entry in fs::read_dir(dir)? {
 		let entry = entry?;
@@ -205,6 +515,154 @@ fn collect_files(root: &Path, dir: &Path, files: &mut Vec<DocsFile>) -> Result<(
 	}
 
 	Ok(())
+}
+
+fn read_okf_files(root: &Path) -> Result<Vec<DocsFile>> {
+	if !root.is_dir() {
+		color_eyre::eyre::bail!("OKF bundle root `{}` does not exist.", root.display());
+	}
+
+	let mut files = Vec::new();
+
+	collect_files(root, root, &mut files)?;
+
+	Ok(files)
+}
+
+fn decodex_docs_report_as_okf(report: DocsCheckReport) -> OkfCheckReport {
+	OkfCheckReport {
+		profile: OkfCheckProfile::Decodex,
+		bundle_root: report.docs_root,
+		concept_count: report.concept_count,
+		link_count: report.link_count,
+		issues: report.issues,
+	}
+}
+
+fn check_okf_markdown_readability(files: &[DocsFile], report: &mut OkfCheckReport) {
+	for file in files {
+		if let Some(read_error) = &file.read_error {
+			report.issues.push(issue(
+				Some(file.relative_path.clone()),
+				format!("Markdown file must be UTF-8 readable: {read_error}"),
+			));
+		}
+	}
+}
+
+fn check_okf_core_concepts(files: &[DocsFile], report: &mut OkfCheckReport) {
+	for file in files.iter().filter(|file| is_concept_markdown(&file.relative_path)) {
+		report.concept_count += 1;
+
+		let Some(content) = file.content.as_deref() else {
+			continue;
+		};
+		let Some((frontmatter, _)) = split_yaml_frontmatter(content) else {
+			report.issues.push(issue(
+				Some(file.relative_path.clone()),
+				String::from("concept must start with YAML frontmatter delimited by ---"),
+			));
+
+			continue;
+		};
+		let Some(fields) = parse_okf_frontmatter_mapping(frontmatter, &file.relative_path, report)
+		else {
+			continue;
+		};
+
+		read_required_okf_frontmatter_string(&fields, "type", &file.relative_path, report);
+	}
+}
+
+fn check_okf_wiki_surface(files: &[DocsFile], report: &mut OkfCheckReport) -> Result<()> {
+	check_okf_indexes(files, report);
+	check_okf_wiki_frontmatter(files, report);
+	check_okf_links(files, report)?;
+
+	Ok(())
+}
+
+fn check_okf_indexes(files: &[DocsFile], report: &mut OkfCheckReport) {
+	let paths = file_path_set(files);
+
+	if !paths.contains(Path::new("index.md")) {
+		report.issues.push(issue(
+			Some(PathBuf::from("index.md")),
+			String::from("wiki profile expects a root progressive-disclosure index.md"),
+		));
+	}
+
+	for dir in docs_dirs_with_content(files) {
+		let index_path = dir.join("index.md");
+
+		if !paths.contains(&index_path) {
+			report.issues.push(issue(
+				Some(index_path),
+				String::from("wiki profile expects each populated directory to have index.md"),
+			));
+		}
+	}
+}
+
+fn check_okf_wiki_frontmatter(files: &[DocsFile], report: &mut OkfCheckReport) {
+	for file in files.iter().filter(|file| is_concept_markdown(&file.relative_path)) {
+		let Some(fields) = okf_frontmatter_fields(file, report) else {
+			continue;
+		};
+
+		read_required_okf_frontmatter_string(&fields, "title", &file.relative_path, report);
+		read_required_okf_frontmatter_string(&fields, "description", &file.relative_path, report);
+		okf_frontmatter_string_list(&fields, "tags", &file.relative_path, report);
+	}
+}
+
+fn check_okf_links(files: &[DocsFile], report: &mut OkfCheckReport) -> Result<()> {
+	let link_pattern = Regex::new(r"!?\[[^\]]*\]\(([^)\s]+)(?:\s+[^)]*)?\)")?;
+
+	for file in files.iter().filter(|file| is_markdown(&file.relative_path)) {
+		let Some(content) = file.content.as_deref() else {
+			continue;
+		};
+
+		for captures in link_pattern.captures_iter(content) {
+			let Some(target_match) = captures.get(1) else {
+				continue;
+			};
+			let target = target_match.as_str();
+
+			if should_skip_link_target(target) {
+				continue;
+			}
+
+			report.link_count += 1;
+
+			if let Some(link_path) = resolve_link_target(&file.path, &report.bundle_root, target)
+				&& !link_path.exists()
+			{
+				report.issues.push(issue(
+					Some(file.relative_path.clone()),
+					format!("link target `{target}` does not exist"),
+				));
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn check_okf_repo_memory_surface(files: &[DocsFile], report: &mut OkfCheckReport) {
+	for file in files.iter().filter(|file| is_concept_markdown(&file.relative_path)) {
+		let Some(fields) = okf_frontmatter_fields(file, report) else {
+			continue;
+		};
+
+		validate_repo_memory_frontmatter_fields(
+			&fields,
+			&file.relative_path,
+			&report.bundle_root.clone(),
+			report,
+		);
+	}
 }
 
 fn check_required_docs_layout(files: &[DocsFile], report: &mut DocsCheckReport) {
@@ -451,6 +909,105 @@ fn parse_frontmatter_mapping(
 	}
 }
 
+fn okf_frontmatter_fields(file: &DocsFile, report: &mut OkfCheckReport) -> Option<Mapping> {
+	let content = file.content.as_deref()?;
+	let Some((frontmatter, _)) = split_yaml_frontmatter(content) else {
+		report.issues.push(issue(
+			Some(file.relative_path.clone()),
+			String::from("concept must start with YAML frontmatter delimited by ---"),
+		));
+
+		return None;
+	};
+
+	parse_okf_frontmatter_mapping(frontmatter, &file.relative_path, report)
+}
+
+fn parse_okf_frontmatter_mapping(
+	frontmatter: &str,
+	path: &Path,
+	report: &mut OkfCheckReport,
+) -> Option<Mapping> {
+	match serde_yaml::from_str::<Value>(frontmatter) {
+		Ok(Value::Mapping(mapping)) => Some(mapping),
+		Ok(_) => {
+			report.issues.push(issue(
+				Some(path.to_path_buf()),
+				String::from("frontmatter must be a YAML mapping"),
+			));
+
+			None
+		},
+		Err(error) => {
+			report.issues.push(issue(
+				Some(path.to_path_buf()),
+				format!("frontmatter must parse as YAML: {error}"),
+			));
+
+			None
+		},
+	}
+}
+
+fn read_required_okf_frontmatter_string(
+	fields: &Mapping,
+	key: &str,
+	path: &Path,
+	report: &mut OkfCheckReport,
+) {
+	match frontmatter_value(fields, key) {
+		Some(Value::String(value)) if !value.trim().is_empty() => {},
+		Some(Value::String(_)) | None => report.issues.push(issue(
+			Some(path.to_path_buf()),
+			format!("frontmatter key `{key}` is required and must be non-empty"),
+		)),
+		Some(_) => report.issues.push(issue(
+			Some(path.to_path_buf()),
+			format!("frontmatter key `{key}` must be a string"),
+		)),
+	}
+}
+
+fn okf_frontmatter_string_list(
+	fields: &Mapping,
+	key: &str,
+	path: &Path,
+	report: &mut OkfCheckReport,
+) -> Option<Vec<String>> {
+	match frontmatter_value(fields, key) {
+		None => None,
+		Some(Value::Sequence(items)) => {
+			let mut values = Vec::new();
+
+			for item in items {
+				match item {
+					Value::String(value) if !value.trim().is_empty() => {
+						values.push(value.trim().to_owned());
+					},
+					Value::String(_) => report.issues.push(issue(
+						Some(path.to_path_buf()),
+						format!("frontmatter list `{key}` must not contain empty strings"),
+					)),
+					_ => report.issues.push(issue(
+						Some(path.to_path_buf()),
+						format!("frontmatter list `{key}` must contain only strings"),
+					)),
+				}
+			}
+
+			Some(values)
+		},
+		Some(_) => {
+			report.issues.push(issue(
+				Some(path.to_path_buf()),
+				format!("frontmatter key `{key}` must be a list of strings"),
+			));
+
+			None
+		},
+	}
+}
+
 fn frontmatter_value<'a>(fields: &'a Mapping, key: &str) -> Option<&'a Value> {
 	fields.get(Value::String(key.to_owned()))
 }
@@ -567,6 +1124,159 @@ fn validate_structured_frontmatter_fields(
 	validate_code_refs(fields, path, docs_root, report);
 	validate_related_refs(fields, path, docs_root, report);
 	validate_promotes_to(fields, path, report);
+}
+
+fn validate_repo_memory_frontmatter_fields(
+	fields: &Mapping,
+	path: &Path,
+	bundle_root: &Path,
+	report: &mut OkfCheckReport,
+) {
+	for key in ["tags", "drift_watch"] {
+		okf_frontmatter_string_list(fields, key, path, report);
+	}
+
+	validate_okf_source_refs(fields, path, report);
+	validate_okf_code_refs(fields, path, bundle_root, report);
+	validate_okf_related_refs(fields, path, bundle_root, report);
+}
+
+fn validate_okf_source_refs(fields: &Mapping, path: &Path, report: &mut OkfCheckReport) {
+	let Some(values) = okf_frontmatter_string_list(fields, "source_refs", path, report) else {
+		return;
+	};
+
+	for value in values {
+		if !is_http_url(&value) {
+			report.issues.push(issue(
+				Some(path.to_path_buf()),
+				format!("source_refs entry `{value}` must be an http(s) URL"),
+			));
+		}
+	}
+}
+
+fn validate_okf_code_refs(
+	fields: &Mapping,
+	path: &Path,
+	bundle_root: &Path,
+	report: &mut OkfCheckReport,
+) {
+	let Some(values) = okf_frontmatter_string_list(fields, "code_refs", path, report) else {
+		return;
+	};
+	let repo_root = bundle_root.parent().unwrap_or(bundle_root);
+
+	for value in values {
+		validate_okf_code_ref_value(path, repo_root, &value, report);
+	}
+}
+
+fn validate_okf_code_ref_value(
+	path: &Path,
+	repo_root: &Path,
+	value: &str,
+	report: &mut OkfCheckReport,
+) {
+	let value_path = Path::new(value);
+
+	if value.contains('#') || value.contains('?') {
+		report.issues.push(issue(
+			Some(path.to_path_buf()),
+			format!("code_refs entry `{value}` must be a file path without fragments"),
+		));
+
+		return;
+	}
+	if !is_normalized_relative_path(value_path) {
+		report.issues.push(issue(
+			Some(path.to_path_buf()),
+			format!("code_refs entry `{value}` must be a normalized repository-relative file path"),
+		));
+
+		return;
+	}
+
+	let target_path = normalize_path(&repo_root.join(value_path));
+
+	if !target_path.exists() {
+		report.issues.push(issue(
+			Some(path.to_path_buf()),
+			format!("code_refs entry `{value}` does not exist"),
+		));
+	} else if !target_path.is_file() {
+		report.issues.push(issue(
+			Some(path.to_path_buf()),
+			format!("code_refs entry `{value}` must reference a file"),
+		));
+	}
+}
+
+fn validate_okf_related_refs(
+	fields: &Mapping,
+	path: &Path,
+	bundle_root: &Path,
+	report: &mut OkfCheckReport,
+) {
+	let Some(values) = okf_frontmatter_string_list(fields, "related", path, report) else {
+		return;
+	};
+
+	for value in values {
+		validate_okf_related_ref_value(path, bundle_root, &value, report);
+	}
+}
+
+fn validate_okf_related_ref_value(
+	path: &Path,
+	bundle_root: &Path,
+	value: &str,
+	report: &mut OkfCheckReport,
+) {
+	let target = strip_fragment(value);
+
+	if target.is_empty() {
+		report.issues.push(issue(
+			Some(path.to_path_buf()),
+			format!("related entry `{value}` must include a bundle file path"),
+		));
+
+		return;
+	}
+
+	let target_value_path = Path::new(target);
+
+	if target_value_path.is_absolute() {
+		report.issues.push(issue(
+			Some(path.to_path_buf()),
+			format!("related entry `{value}` must be a bundle-relative file path"),
+		));
+
+		return;
+	}
+
+	let parent = path.parent().unwrap_or_else(|| Path::new(""));
+	let target_path = normalize_path(&bundle_root.join(parent).join(target_value_path));
+
+	if !target_path.starts_with(bundle_root) {
+		report.issues.push(issue(
+			Some(path.to_path_buf()),
+			format!("related entry `{value}` must stay under the OKF bundle"),
+		));
+
+		return;
+	}
+	if !target_path.exists() {
+		report.issues.push(issue(
+			Some(path.to_path_buf()),
+			format!("related entry `{value}` does not exist"),
+		));
+	} else if !target_path.is_file() || !is_markdown(&target_path) {
+		report.issues.push(issue(
+			Some(path.to_path_buf()),
+			format!("related entry `{value}` must reference a Markdown file"),
+		));
+	}
 }
 
 fn validate_source_refs(fields: &Mapping, path: &Path, report: &mut DocsCheckReport) {
@@ -795,6 +1505,252 @@ fn markdown_heading_texts(body: &str) -> BTreeSet<String> {
 		.collect()
 }
 
+fn concept_summary(file: &DocsFile) -> Option<OkfConceptSummary> {
+	let content = file.content.as_deref()?;
+	let (frontmatter, _) = split_yaml_frontmatter(content)?;
+	let Value::Mapping(fields) = serde_yaml::from_str::<Value>(frontmatter).ok()? else {
+		return None;
+	};
+	let concept_type = frontmatter_string(&fields, "type")?.to_owned();
+	let path = path_to_string(&file.relative_path);
+	let title = frontmatter_string(&fields, "title")
+		.filter(|title| !title.is_empty())
+		.map_or_else(|| concept_id(&file.relative_path), str::to_owned);
+	let description = frontmatter_string(&fields, "description")
+		.filter(|description| !description.is_empty())
+		.map(str::to_owned);
+	let resource = frontmatter_string(&fields, "resource")
+		.filter(|resource| !resource.is_empty())
+		.map(str::to_owned);
+	let tags = frontmatter_string_list_lossy(&fields, "tags");
+	let source_refs = frontmatter_string_list_lossy(&fields, "source_refs");
+	let code_refs = frontmatter_string_list_lossy(&fields, "code_refs");
+	let related = frontmatter_string_list_lossy(&fields, "related");
+
+	Some(OkfConceptSummary {
+		id: concept_id(&file.relative_path),
+		path,
+		concept_type,
+		title,
+		description,
+		resource,
+		tags,
+		source_refs,
+		code_refs,
+		related,
+	})
+}
+
+fn concept_id(path: &Path) -> String {
+	let mut id = path.to_path_buf();
+
+	id.set_extension("");
+
+	path_to_string(&id)
+}
+
+fn path_to_string(path: &Path) -> String {
+	path.to_string_lossy().replace('\\', "/")
+}
+
+fn frontmatter_string_list_lossy(fields: &Mapping, key: &str) -> Vec<String> {
+	match frontmatter_value(fields, key) {
+		Some(Value::Sequence(items)) => items
+			.iter()
+			.filter_map(|item| match item {
+				Value::String(value) if !value.trim().is_empty() => Some(value.trim().to_owned()),
+				_ => None,
+			})
+			.collect(),
+		_ => Vec::new(),
+	}
+}
+
+fn okf_query_matches(concept: &OkfConceptSummary, query: &OkfQuery) -> bool {
+	query
+		.concept_type
+		.as_deref()
+		.is_none_or(|value| concept.concept_type.eq_ignore_ascii_case(value))
+		&& query
+			.tags
+			.iter()
+			.all(|tag| concept.tags.iter().any(|candidate| candidate.eq_ignore_ascii_case(tag)))
+		&& query.resource.as_deref().is_none_or(|value| {
+			concept.resource.as_deref().is_some_and(|resource| contains_ci(resource, value))
+		}) && query.source_ref.as_deref().is_none_or(|value| {
+		concept.source_refs.iter().any(|source_ref| contains_ci(source_ref, value))
+	}) && query
+		.code_ref
+		.as_deref()
+		.is_none_or(|value| concept.code_refs.iter().any(|code_ref| contains_ci(code_ref, value)))
+		&& query
+			.related
+			.as_deref()
+			.is_none_or(|value| concept.related.iter().any(|related| contains_ci(related, value)))
+		&& query.text.as_deref().is_none_or(|value| concept_text_matches(concept, value))
+}
+
+fn concept_text_matches(concept: &OkfConceptSummary, value: &str) -> bool {
+	contains_ci(&concept.path, value)
+		|| contains_ci(&concept.title, value)
+		|| concept.description.as_deref().is_some_and(|description| contains_ci(description, value))
+}
+
+fn contains_ci(haystack: &str, needle: &str) -> bool {
+	haystack.to_lowercase().contains(&needle.to_lowercase())
+}
+
+fn okf_concept_path_set(files: &[DocsFile]) -> BTreeSet<PathBuf> {
+	files
+		.iter()
+		.filter(|file| is_concept_markdown(&file.relative_path))
+		.map(|file| file.relative_path.clone())
+		.collect()
+}
+
+fn collect_markdown_graph_edges(
+	file: &DocsFile,
+	bundle_root: &Path,
+	concept_paths: &BTreeSet<PathBuf>,
+	source: &str,
+	edges: &mut Vec<OkfGraphEdge>,
+	broken_links: &mut Vec<OkfBrokenLink>,
+) -> Result<()> {
+	let Some(content) = file.content.as_deref() else {
+		return Ok(());
+	};
+	let link_pattern = Regex::new(r"!?\[[^\]]*\]\(([^)\s]+)(?:\s+[^)]*)?\)")?;
+
+	for captures in link_pattern.captures_iter(content) {
+		let Some(target_match) = captures.get(1) else {
+			continue;
+		};
+		let target = target_match.as_str();
+
+		if should_skip_link_target(target) {
+			continue;
+		}
+
+		push_graph_target(
+			file,
+			bundle_root,
+			concept_paths,
+			source,
+			target,
+			"markdown",
+			edges,
+			broken_links,
+		);
+	}
+
+	Ok(())
+}
+
+fn collect_related_graph_edges(
+	file: &DocsFile,
+	bundle_root: &Path,
+	concept_paths: &BTreeSet<PathBuf>,
+	source: &str,
+	edges: &mut Vec<OkfGraphEdge>,
+	broken_links: &mut Vec<OkfBrokenLink>,
+) {
+	let Some(content) = file.content.as_deref() else {
+		return;
+	};
+	let Some((frontmatter, _)) = split_yaml_frontmatter(content) else {
+		return;
+	};
+	let Ok(Value::Mapping(fields)) = serde_yaml::from_str::<Value>(frontmatter) else {
+		return;
+	};
+
+	for target in frontmatter_string_list_lossy(&fields, "related") {
+		push_graph_target(
+			file,
+			bundle_root,
+			concept_paths,
+			source,
+			&target,
+			"related",
+			edges,
+			broken_links,
+		);
+	}
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_graph_target(
+	file: &DocsFile,
+	bundle_root: &Path,
+	concept_paths: &BTreeSet<PathBuf>,
+	source: &str,
+	target: &str,
+	kind: &str,
+	edges: &mut Vec<OkfGraphEdge>,
+	broken_links: &mut Vec<OkfBrokenLink>,
+) {
+	let Some(target_path) = resolve_link_target(&file.path, bundle_root, target) else {
+		return;
+	};
+	let Ok(relative_target) = target_path.strip_prefix(bundle_root) else {
+		return;
+	};
+	let relative_target = relative_target.to_path_buf();
+
+	if concept_paths.contains(&relative_target) {
+		edges.push(OkfGraphEdge {
+			source: source.to_owned(),
+			target: concept_id(&relative_target),
+			kind: kind.to_owned(),
+		});
+	} else if !target_path.exists() {
+		broken_links.push(broken_link(source, target, kind));
+	}
+}
+
+fn broken_link(source: &str, target: &str, kind: &str) -> OkfBrokenLink {
+	OkfBrokenLink { source: source.to_owned(), target: target.to_owned(), kind: kind.to_owned() }
+}
+
+fn okf_orphan_concepts(concepts: &[OkfConceptSummary], edges: &[OkfGraphEdge]) -> Vec<String> {
+	let connected: BTreeSet<&str> =
+		edges.iter().flat_map(|edge| [edge.source.as_str(), edge.target.as_str()]).collect();
+
+	concepts
+		.iter()
+		.filter(|concept| !connected.contains(concept.id.as_str()))
+		.map(|concept| concept.id.clone())
+		.collect()
+}
+
+fn route_tokens(intent: &str) -> Vec<String> {
+	intent
+		.split(|character: char| !character.is_alphanumeric())
+		.map(str::trim)
+		.filter(|token| token.chars().count() >= 3)
+		.map(str::to_lowercase)
+		.collect()
+}
+
+fn route_score(file: &DocsFile, concept: &OkfConceptSummary, tokens: &[String]) -> usize {
+	let strong_text = format!(
+		"{} {} {} {}",
+		concept.path,
+		concept.title,
+		concept.description.as_deref().unwrap_or_default(),
+		concept.tags.join(" ")
+	)
+	.to_lowercase();
+	let body = file.content.as_deref().unwrap_or_default().to_lowercase();
+
+	tokens
+		.iter()
+		.map(|token| {
+			usize::from(strong_text.contains(token)) * 3 + usize::from(body.contains(token))
+		})
+		.sum()
+}
+
 fn should_skip_link_target(target: &str) -> bool {
 	target.starts_with('#')
 		|| target.starts_with("http://")
@@ -846,7 +1802,7 @@ mod tests {
 
 	use tempfile::TempDir;
 
-	use crate::docs_okf::{self, DocsCheckScope};
+	use crate::docs_okf::{self, DocsCheckScope, OkfCheckProfile, OkfQuery};
 
 	#[test]
 	fn docs_check_rejects_json_artifacts() {
@@ -942,6 +1898,96 @@ mod tests {
 		assert!(report.issues.iter().any(|issue| issue.message.contains("related entry")));
 		assert!(report.issues.iter().any(|issue| issue.message.contains("promotes_to entry")));
 		assert!(report.issues.iter().any(|issue| issue.message.contains("drift_watch")));
+	}
+
+	#[test]
+	fn okf_core_check_allows_unknown_types_and_missing_decodex_fields() {
+		let temp_dir = TempDir::new().expect("tempdir");
+		let bundle = temp_dir.path().join("bundle");
+
+		fs::create_dir_all(&bundle).expect("bundle");
+		write(&bundle.join("index.md"), "# Bundle\n");
+		write(
+			&bundle.join("metric.md"),
+			"---\ntype: Business Metric\n---\n\nWeekly active users.\n",
+		);
+
+		let report = docs_okf::run_okf_check(&bundle, OkfCheckProfile::Core).expect("core check");
+
+		assert!(!report.has_issues(), "{report:#?}");
+	}
+
+	#[test]
+	fn okf_graph_skips_links_outside_the_bundle() {
+		let temp_dir = TempDir::new().expect("tempdir");
+		let bundle = temp_dir.path().join("bundle");
+
+		fs::create_dir_all(&bundle).expect("bundle");
+		write(&temp_dir.path().join("README.md"), "# External repo doc\n");
+		write(&bundle.join("index.md"), "# Bundle\n");
+		write(
+			&bundle.join("alpha.md"),
+			"---\ntype: Concept\ntitle: Alpha\ndescription: Alpha concept.\n---\n\nSee [Beta](beta.md) and [repo readme](../README.md).\n",
+		);
+		write(
+			&bundle.join("beta.md"),
+			"---\ntype: Concept\ntitle: Beta\ndescription: Beta concept.\n---\n\nBeta.\n",
+		);
+
+		let graph = docs_okf::build_okf_graph(&bundle).expect("graph");
+
+		assert_eq!(graph.broken_links, Vec::new());
+		assert_eq!(graph.edges.len(), 1);
+		assert_eq!(graph.edges[0].target, "beta");
+	}
+
+	#[test]
+	fn okf_query_matches_structured_frontmatter_refs() {
+		let temp_dir = TempDir::new().expect("tempdir");
+		let bundle = temp_dir.path().join("docs");
+
+		fs::create_dir_all(&bundle).expect("bundle");
+		write(&temp_dir.path().join("src.rs"), "fn main() {}\n");
+		write(&bundle.join("index.md"), "# Bundle\n");
+		write(
+			&bundle.join("alpha.md"),
+			"---\ntype: Concept\ntitle: Alpha\ndescription: Alpha concept.\ntags: [runtime]\nsource_refs: [https://example.com/spec]\ncode_refs: [src.rs]\nrelated: [beta.md]\n---\n\nAlpha.\n",
+		);
+		write(
+			&bundle.join("beta.md"),
+			"---\ntype: Concept\ntitle: Beta\ndescription: Beta concept.\n---\n\nBeta.\n",
+		);
+
+		let query = OkfQuery {
+			code_ref: Some(String::from("src.rs")),
+			tags: Vec::new(),
+			..OkfQuery::default()
+		};
+		let matches = docs_okf::query_okf_bundle(&bundle, &query).expect("query");
+
+		assert_eq!(matches.len(), 1);
+		assert_eq!(matches[0].id, "alpha");
+	}
+
+	#[test]
+	fn okf_route_prefers_matching_concepts() {
+		let temp_dir = TempDir::new().expect("tempdir");
+		let bundle = temp_dir.path().join("bundle");
+
+		fs::create_dir_all(&bundle).expect("bundle");
+		write(&bundle.join("index.md"), "# Bundle\n");
+		write(
+			&bundle.join("okf.md"),
+			"---\ntype: Spec\ntitle: OKF Knowledge Layer\ndescription: Command design for portable OKF bundles.\ntags: [okf]\n---\n\nOKF command design.\n",
+		);
+		write(
+			&bundle.join("runtime.md"),
+			"---\ntype: Spec\ntitle: Runtime\ndescription: Runtime scheduler.\n---\n\nScheduler.\n",
+		);
+
+		let matches = docs_okf::route_okf_bundle(&bundle, "okf command design", 2).expect("route");
+
+		assert_eq!(matches.first().map(|matched| matched.concept.id.as_str()), Some("okf"));
 	}
 
 	fn write_minimal_okf_bundle(docs: &std::path::Path) {

--- a/apps/decodex/src/docs_okf.rs
+++ b/apps/decodex/src/docs_okf.rs
@@ -1906,6 +1906,7 @@ mod tests {
 		let bundle = temp_dir.path().join("bundle");
 
 		fs::create_dir_all(&bundle).expect("bundle");
+
 		write(&bundle.join("index.md"), "# Bundle\n");
 		write(
 			&bundle.join("metric.md"),
@@ -1923,6 +1924,7 @@ mod tests {
 		let bundle = temp_dir.path().join("bundle");
 
 		fs::create_dir_all(&bundle).expect("bundle");
+
 		write(&temp_dir.path().join("README.md"), "# External repo doc\n");
 		write(&bundle.join("index.md"), "# Bundle\n");
 		write(
@@ -1947,6 +1949,7 @@ mod tests {
 		let bundle = temp_dir.path().join("docs");
 
 		fs::create_dir_all(&bundle).expect("bundle");
+
 		write(&temp_dir.path().join("src.rs"), "fn main() {}\n");
 		write(&bundle.join("index.md"), "# Bundle\n");
 		write(
@@ -1975,6 +1978,7 @@ mod tests {
 		let bundle = temp_dir.path().join("bundle");
 
 		fs::create_dir_all(&bundle).expect("bundle");
+
 		write(&bundle.join("index.md"), "# Bundle\n");
 		write(
 			&bundle.join("okf.md"),

--- a/apps/decodex/src/plugin_surface_tests.rs
+++ b/apps/decodex/src/plugin_surface_tests.rs
@@ -44,6 +44,28 @@ const RESEARCH_SKILL: &str = include_str!(concat!(
 	env!("CARGO_MANIFEST_DIR"),
 	"/../../plugins/decodex/skills/research/SKILL.md"
 ));
+const OKF_SKILL: &str =
+	include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../plugins/decodex/skills/okf/SKILL.md"));
+const OKF_AGENT_POLICY: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/okf/agents/openai.yaml"
+));
+const OKF_QUERY_SKILL: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/okf-query/SKILL.md"
+));
+const OKF_QUERY_AGENT_POLICY: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/okf-query/agents/openai.yaml"
+));
+const OKF_MAINTAIN_SKILL: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/okf-maintain/SKILL.md"
+));
+const OKF_MAINTAIN_AGENT_POLICY: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/okf-maintain/agents/openai.yaml"
+));
 const DOCS_SKILL: &str = include_str!(concat!(
 	env!("CARGO_MANIFEST_DIR"),
 	"/../../plugins/decodex/skills/docs/SKILL.md"
@@ -152,6 +174,10 @@ const DOCS_DRIFT_REF: &str = include_str!(concat!(
 	env!("CARGO_MANIFEST_DIR"),
 	"/../../plugins/decodex/references/docs-drift.md"
 ));
+const OKF_LAYER_REF: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/references/okf-layer.md"
+));
 const RESEARCH_LIFECYCLE_REF: &str = include_str!(concat!(
 	env!("CARGO_MANIFEST_DIR"),
 	"/../../plugins/decodex/references/research-lifecycle.md"
@@ -193,6 +219,7 @@ fn packaged_plugin_manifest_routes_natural_language_research_to_decodex() {
 	);
 
 	assert_contains(&manifest_surface, "natural-language-first");
+	assert_contains(&manifest_surface, "portable OKF");
 	assert_contains(&manifest_surface, "OKF docs");
 	assert_contains(&manifest_surface, "bounded research");
 	assert_contains(&manifest_surface, "probe, evidence, options, judgment, challenge, decision");
@@ -204,8 +231,8 @@ fn packaged_plugin_manifest_routes_natural_language_research_to_decodex() {
 	assert_contains(&manifest_surface, "DAG");
 	assert_contains(&manifest_surface, "issue briefing");
 	assert_contains(&default_prompts, "Maintain Decodex docs.");
+	assert_contains(&default_prompts, "Work with an OKF bundle.");
 	assert_contains(&default_prompts, "Research this with Decodex.");
-	assert_contains(&default_prompts, "Arrange accepted Decodex work.");
 }
 
 #[test]
@@ -298,6 +325,7 @@ fn packaged_docs_skills_encode_okf_wiki_and_drift_boundaries() {
 
 	assert_contains(&docs_surface, "OKF");
 	assert_contains(&docs_surface, "LLM Wiki");
+	assert_contains(&docs_surface, "docs check");
 	assert_contains(&docs_surface, "docs lint");
 	assert_contains(&docs_surface, "Markdown-only");
 	assert_contains(&docs_surface, "Research Contract");
@@ -308,6 +336,32 @@ fn packaged_docs_skills_encode_okf_wiki_and_drift_boundaries() {
 	assert_contains(&docs_surface, "pass`, `fail`, or `needs-human");
 	assert_contains(&docs_surface, "Do not create a parallel `wiki/` or `okf/` root");
 	assert_not_contains(&docs_surface, "Okf");
+	assert_contains(&docs_surface, "portable OKF");
+	assert_contains(&docs_surface, "Decodex profile");
+}
+
+#[test]
+fn packaged_okf_skills_preserve_portable_profile_boundary() {
+	let okf_surface =
+		format!("{OKF_SKILL}\n{OKF_QUERY_SKILL}\n{OKF_MAINTAIN_SKILL}\n{OKF_LAYER_REF}");
+
+	assert_contains(&okf_surface, "portable OKF");
+	assert_contains(&okf_surface, "LLM Wiki");
+	assert_contains(&okf_surface, "decodex okf check");
+	assert_contains(&okf_surface, "decodex okf find");
+	assert_contains(&okf_surface, "decodex okf graph");
+	assert_contains(&okf_surface, "decodex okf route");
+	assert_contains(&okf_surface, "core");
+	assert_contains(&okf_surface, "wiki");
+	assert_contains(&okf_surface, "repo-memory");
+	assert_contains(&okf_surface, "decodex");
+	assert_contains(&okf_surface, "source_refs");
+	assert_contains(&okf_surface, "code_refs");
+	assert_contains(&okf_surface, "related");
+	assert_contains(&okf_surface, "drift_watch");
+	assert_contains_normalized(&okf_surface, "Do not create or recommend `decodex docs okf ...`");
+	assert_contains_normalized(&okf_surface, "do not inherit Decodex lanes");
+	assert_contains(&okf_surface, "Do not require Decodex lanes or Linear workflow");
 }
 
 #[test]
@@ -318,6 +372,9 @@ fn narrow_lifecycle_and_specialist_skills_are_explicit_only() {
 		LABELS_AGENT_POLICY,
 		LAND_AGENT_POLICY,
 		MANUAL_CLI_AGENT_POLICY,
+		OKF_AGENT_POLICY,
+		OKF_QUERY_AGENT_POLICY,
+		OKF_MAINTAIN_AGENT_POLICY,
 		DOCS_OKF_AGENT_POLICY,
 		DOCS_WIKI_AGENT_POLICY,
 		DOCS_DRIFT_AGENT_POLICY,

--- a/docs/evidence/decodex-plugin-eval.md
+++ b/docs/evidence/decodex-plugin-eval.md
@@ -1,24 +1,24 @@
 ---
 type: Evidence
 title: Decodex Plugin Eval
-description: Records plugin-eval results for the Decodex OKF docs and research skill migration.
+description: Records plugin-eval results for the Decodex portable OKF, docs, and research skills.
 status: active
 authority: evidence
 owner: docs
-tags: [plugin-eval, skills, docs, research]
+tags: [plugin-eval, skills, docs, research, okf]
 source_refs: []
-code_refs: [plugins/decodex/.codex-plugin/plugin.json, plugins/decodex/skills/docs/SKILL.md, plugins/decodex/skills/docs-okf/SKILL.md, plugins/decodex/skills/docs-wiki/SKILL.md, plugins/decodex/skills/docs-drift/SKILL.md, plugins/decodex/skills/research/SKILL.md]
+code_refs: [plugins/decodex/.codex-plugin/plugin.json, plugins/decodex/references/okf-layer.md, plugins/decodex/skills/okf/SKILL.md, plugins/decodex/skills/okf-query/SKILL.md, plugins/decodex/skills/okf-maintain/SKILL.md, plugins/decodex/skills/docs/SKILL.md, plugins/decodex/skills/docs-okf/SKILL.md, plugins/decodex/skills/docs-wiki/SKILL.md, plugins/decodex/skills/docs-drift/SKILL.md, plugins/decodex/skills/research/SKILL.md]
 related: [../policy.md, ./docs-self-iteration.md]
 last_verified: 2026-06-17
 ---
 
 # Decodex Plugin Eval
 
-Purpose: Preserve public-safe evidence that the Decodex plugin and the new docs skill
-family passed local plugin evaluation after the OKF docs migration.
+Purpose: Preserve public-safe evidence that the Decodex plugin, portable OKF skill
+family, and docs skill family passed local plugin evaluation.
 
-Read this when: You need proof that the docs skill split, research skill split, and
-plugin invocation policy were evaluated before landing.
+Read this when: You need proof that the OKF split, docs skill split, research skill
+split, and plugin invocation policy were evaluated before landing.
 
 Not this document: A runtime benchmark, coverage report, or replacement for
 `plugin-eval` output.
@@ -28,11 +28,14 @@ Covers: Static plugin-eval commands, score results, and the invocation-policy de
 ## Commands
 
 ```sh
-node /Users/x/.codex/plugins/cache/openai-curated-remote/plugin-eval/0.1.2/scripts/plugin-eval.js analyze plugins/decodex --format json
-node /Users/x/.codex/plugins/cache/openai-curated-remote/plugin-eval/0.1.2/scripts/plugin-eval.js analyze plugins/decodex/skills/docs --format json
-node /Users/x/.codex/plugins/cache/openai-curated-remote/plugin-eval/0.1.2/scripts/plugin-eval.js analyze plugins/decodex/skills/docs-okf --format json
-node /Users/x/.codex/plugins/cache/openai-curated-remote/plugin-eval/0.1.2/scripts/plugin-eval.js analyze plugins/decodex/skills/docs-wiki --format json
-node /Users/x/.codex/plugins/cache/openai-curated-remote/plugin-eval/0.1.2/scripts/plugin-eval.js analyze plugins/decodex/skills/docs-drift --format json
+node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex --format json
+node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/okf --format json
+node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/okf-query --format json
+node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/okf-maintain --format json
+node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/docs --format json
+node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/docs-okf --format json
+node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/docs-wiki --format json
+node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/docs-drift --format json
 ```
 
 ## Results
@@ -40,6 +43,9 @@ node /Users/x/.codex/plugins/cache/openai-curated-remote/plugin-eval/0.1.2/scrip
 | Target | Score | Grade | Risk | Fix First |
 | --- | --- | --- | --- | --- |
 | `plugins/decodex` | 100 | A | low | none |
+| `plugins/decodex/skills/okf` | 100 | A | low | none |
+| `plugins/decodex/skills/okf-query` | 100 | A | low | none |
+| `plugins/decodex/skills/okf-maintain` | 100 | A | low | none |
 | `plugins/decodex/skills/docs` | 100 | A | low | none |
 | `plugins/decodex/skills/docs-okf` | 100 | A | low | none |
 | `plugins/decodex/skills/docs-wiki` | 100 | A | low | none |
@@ -68,6 +74,9 @@ Explicit-only skills:
 - `labels`
 - `land`
 - `manual-cli`
+- `okf`
+- `okf-maintain`
+- `okf-query`
 - `research-challenge`
 - `research-decision`
 - `research-evidence`
@@ -80,4 +89,4 @@ Explicit-only skills:
 
 The evaluation is static plugin analysis, not a measured real-usage benchmark. It is
 sufficient for the skill/plugin change gate in this lane because plugin-eval reported
-no warning or failing checks after the invocation-policy adjustment.
+no warning or failing checks after the OKF split and invocation-policy adjustment.

--- a/docs/evidence/docs-self-iteration.md
+++ b/docs/evidence/docs-self-iteration.md
@@ -9,7 +9,7 @@ tags: [semantic-drift, docs, okf]
 source_refs: []
 code_refs: [apps/decodex/src/docs_okf.rs, apps/decodex/src/cli.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/orchestrator/prompting.rs, apps/decodex/src/orchestrator/execution.rs, Makefile.toml]
 related: [../policy.md, ../log.md]
-drift_watch: [decodex docs lint, issue_progress_checkpoint, issue_terminal_finalize, docs_impact, code_refs, related, promotes_to, drift_watch]
+drift_watch: [decodex docs check, decodex docs lint, decodex okf check, issue_progress_checkpoint, issue_terminal_finalize, docs_impact, code_refs, related, promotes_to, drift_watch]
 last_verified: 2026-06-17
 ---
 
@@ -18,9 +18,12 @@ last_verified: 2026-06-17
 ## Watched Claims
 
 - `docs/` is a Markdown-only OKF bundle.
-- `decodex docs lint` validates required routing files, Markdown-only artifacts,
+- `decodex docs check` validates required routing files, Markdown-only artifacts,
   typed concept frontmatter, required research/drift headings, local Markdown links,
   structured frontmatter refs, and at least one drift audit evidence anchor.
+- `decodex docs lint` remains a compatibility alias for `decodex docs check`.
+- `decodex okf check` validates portable bundles by profile: `core`, `wiki`,
+  `repo-memory`, or `decodex`.
 - Structured OKF frontmatter refs are checked when present: `source_refs`,
   `code_refs`, `related`, `promotes_to`, `drift_watch`, and `tags`.
 - Decodex records docs impact as private `docs_impact` evidence on
@@ -40,7 +43,7 @@ last_verified: 2026-06-17
 
 - Search for non-Markdown artifacts under `docs/`.
 - Search for stale references to JSON-only research docs.
-- Run `decodex docs lint`.
+- Run `decodex docs check`.
 - Verify terminal finalize rejects terminal paths without a current-HEAD docs-impact
   checkpoint.
 
@@ -50,8 +53,9 @@ pass
 
 The OKF gate exists, all checked-in docs concepts have typed frontmatter and required
 contract headings, stale JSON-only research docs claims have been replaced with
-Markdown OKF research concept rules, `decodex docs lint` passes for the repository
-docs bundle, structured frontmatter refs are validated when present, and Decodex
+Markdown OKF research concept rules, `decodex docs check` passes for the repository
+docs bundle, structured frontmatter refs are validated when present, portable
+`decodex okf check` profiles are available for non-Decodex bundles, and Decodex
 terminal paths require the latest private docs-impact checkpoint to match the current
 lane `HEAD`.
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -8,6 +8,8 @@
 - Clarified that `decodex okf` is the cross-repository command surface while
   `decodex docs` is the local `docs/` alias, and that `docs okf` command nesting is
   not part of the user-facing model.
+- Added `decodex okf check/find/graph/route` and `decodex docs check/find/graph/route`
+  command surfaces; `decodex docs lint` remains a compatibility alias.
 - Adopted Docs-as-OKF as the Decodex repo-development documentation knowledge
   standard.
 - Defined `docs/` as a Markdown-only OKF bundle with no non-Markdown documentation

--- a/docs/log.md
+++ b/docs/log.md
@@ -10,6 +10,8 @@
   not part of the user-facing model.
 - Added `decodex okf check/find/graph/route` and `decodex docs check/find/graph/route`
   command surfaces; `decodex docs lint` remains a compatibility alias.
+- Added portable `okf`, `okf-query`, and `okf-maintain` plugin skills and clarified
+  that existing `docs-*` skills are Decodex profile wrappers.
 - Adopted Docs-as-OKF as the Decodex repo-development documentation knowledge
   standard.
 - Defined `docs/` as a Markdown-only OKF bundle with no non-Markdown documentation

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,12 @@
 
 ## 2026-06-17
 
+- Added `docs/spec/okf-knowledge-layer.md` to separate portable OKF engine behavior,
+  LLM Wiki graph/retrieval behavior, repository-memory anchors, and the strict
+  Decodex docs profile.
+- Clarified that `decodex okf` is the cross-repository command surface while
+  `decodex docs` is the local `docs/` alias, and that `docs okf` command nesting is
+  not part of the user-facing model.
 - Adopted Docs-as-OKF as the Decodex repo-development documentation knowledge
   standard.
 - Defined `docs/` as a Markdown-only OKF bundle with no non-Markdown documentation

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -174,8 +174,8 @@ Every docs-changing lane follows this loop:
 3. If the change affects behavior, update the owning concept's `code_refs` and
    `drift_watch`, or update/create a linked drift audit.
 4. Update lane indexes and `docs/log.md` when routing changes.
-5. Run `cargo run -p decodex --bin decodex -- docs lint`.
-6. Treat docs lint or drift failure as a completion blocker. Research uncertainty uses
+5. Run `cargo run -p decodex --bin decodex -- docs check`.
+6. Treat docs check or drift failure as a completion blocker. Research uncertainty uses
    the research-contract `needs_human_decision` status; implementation-lane blockers
    use the runtime `manual_attention` terminal path.
 
@@ -211,11 +211,12 @@ gate fails for touched documentation or touched behavior with docs impact.
 Run:
 
 ```sh
-decodex docs lint
+decodex docs check
 ```
 
 In this repository, `cargo make check` includes the same docs gate through
-`cargo run -p decodex --bin decodex -- docs lint`.
+`cargo run -p decodex --bin decodex -- docs check`. `decodex docs lint` remains an
+alias for compatibility.
 
 The check fails when:
 

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -7,8 +7,8 @@ authority: normative
 owner: docs
 tags: [docs, okf, llm-wiki, semantic-drift]
 source_refs: [https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md]
-code_refs: [apps/decodex/src/docs_okf.rs]
-related: [index.md, log.md, evidence/docs-self-iteration.md]
+code_refs: [apps/decodex/src/docs_okf.rs, apps/decodex/src/cli.rs]
+related: [index.md, log.md, spec/okf-knowledge-layer.md, evidence/docs-self-iteration.md]
 last_verified: 2026-06-17
 ---
 
@@ -18,11 +18,14 @@ last_verified: 2026-06-17
 
 `docs/` is the Decodex repo-development knowledge base. It uses a Markdown-only
 Open Knowledge Format profile so agents can route, read, update, verify, and improve
-repository knowledge during normal lane execution.
+repository knowledge during normal lane execution. OKF itself is the portable
+knowledge-bundle protocol; `docs/` is this repository's default bundle location and
+`decodex docs` is the local convenience surface for that bundle.
 
 This policy owns the docs taxonomy, OKF concept shape, promotion rules, and
 self-iteration loop for documentation. It does not own runtime state, tracker state,
-or private execution evidence.
+private execution evidence, or the portable OKF core contract. The portable command
+and profile boundary is defined by [`spec/okf-knowledge-layer.md`](spec/okf-knowledge-layer.md).
 
 ## Authority
 
@@ -43,6 +46,24 @@ research, drift audit, decisions, references, runbooks, and specs is Markdown.
 Write `OKF` as an all-caps acronym in prose, matching the repository convention for
 `CLI`. Lowercase `okf` is allowed only in machine identifiers such as filenames,
 paths, skill IDs, tags, and URLs.
+
+## Command Boundary
+
+Use `decodex okf` for portable OKF operations against any bundle path. Use
+`decodex docs` for this repository's default `docs/` bundle with the strict Decodex
+profile.
+
+Do not add `decodex docs okf ...` command nesting. OKF is not a docs subfeature;
+`docs/` is one bundle location that happens to use OKF.
+
+Profile ownership:
+
+- `core` follows the portable OKF conformance surface.
+- `wiki` adds graph and agent-retrieval quality checks.
+- `repo-memory` adds repository anchors such as `code_refs`, `source_refs`, and
+  drift hints.
+- `decodex` adds this repository's lanes, authority enums, research contracts, drift
+  audits, and completion gates.
 
 ## Concept Frontmatter
 

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -91,3 +91,5 @@ Then keep the body explicit:
   contract.
 - [`workflow-file.md`](./workflow-file.md) defines registered project `WORKFLOW.md`
   configuration semantics and required fields.
+- [`okf-knowledge-layer.md`](./okf-knowledge-layer.md) defines the portable OKF
+  engine, LLM Wiki profile stack, Decodex docs alias, and profile boundary.

--- a/docs/spec/okf-knowledge-layer.md
+++ b/docs/spec/okf-knowledge-layer.md
@@ -1,0 +1,123 @@
+---
+type: Spec
+title: OKF Knowledge Layer
+description: Defines the portable OKF engine, LLM Wiki profile, Decodex docs alias, and profile boundary.
+status: active
+authority: normative
+owner: docs
+tags: [okf, llm-wiki, docs, repo-memory]
+source_refs: [https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md, https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing]
+code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/docs_okf.rs, plugins/decodex/skills/docs/SKILL.md]
+related: [../policy.md, ../reference/research-concepts.md]
+drift_watch: [decodex okf, decodex docs, docs lint, okf profile, docs alias]
+last_verified: 2026-06-17
+---
+
+# OKF Knowledge Layer
+
+Purpose: Define how Decodex separates portable OKF knowledge-bundle behavior from the
+Decodex repository's strict documentation profile.
+
+Status: normative
+
+Read this when: You are designing OKF/LLM Wiki commands, skills, plugin surfaces, or
+documentation policy that should work beyond this repository.
+
+Not this document: The detailed Decodex lane taxonomy, research promotion contract,
+or runtime docs-impact checkpoint schema.
+
+Defines: The command naming model, profile stack, and boundary between `okf`,
+`docs`, LLM Wiki behavior, and Decodex-specific policy.
+
+## Concepts
+
+`okf` is the portable knowledge-bundle engine. It reads, validates, queries, and
+renders Open Knowledge Format bundles regardless of whether the bundle lives under
+`docs/`, `wiki/`, a generated catalog export, or another repository path.
+
+`llm-wiki` is the agent retrieval and maintenance method layered on top of OKF. It
+uses progressive indexes, Markdown links, backlinks, tags, source references, code
+references, and update logs so agents can find the smallest relevant concept and keep
+the graph current.
+
+`docs` is this repository's default OKF bundle location and convenience command
+surface. In this repository, `decodex docs` is an alias for operating on `docs/` with
+the Decodex profile.
+
+`decodex` is the strict profile for this repository. It adds lane taxonomy,
+authority classes, research-promotion rules, drift gates, and docs-impact integration.
+Those constraints must not be treated as the OKF core contract.
+
+## Command Model
+
+Portable commands use the `okf` noun:
+
+```sh
+decodex okf check docs/ --profile core
+decodex okf graph docs/ --json
+decodex okf find docs/ --tag runtime
+decodex okf route docs/ "change lane control behavior"
+```
+
+Repository-local convenience commands use the `docs` noun:
+
+```sh
+decodex docs check
+decodex docs graph
+decodex docs find --tag runtime
+decodex docs route "change lane control behavior"
+```
+
+The `docs` commands default to:
+
+- bundle root: `docs/`
+- profile: `decodex`
+
+Do not introduce `decodex docs okf ...`, `decodex docs wiki ...`, or
+`decodex docs llm-wiki ...` command nesting. That shape leaks implementation taxonomy
+into the daily user surface and makes OKF look like a child feature of docs. OKF is
+the portable engine; docs is only one bundle location.
+
+## Profiles
+
+Profiles are additive. A stricter profile may reject a bundle that a lower profile
+can consume.
+
+| Profile | Scope | Purpose |
+| --- | --- | --- |
+| `core` | OKF v0.1 conformance | Verify portable Markdown/frontmatter interoperability. |
+| `wiki` | Core plus graph hygiene | Verify agent navigation, indexes, links, backlinks, logs, and retrieval fields. |
+| `repo-memory` | Wiki plus repository anchors | Verify code references, source references, task routing hints, and drift watch fields without Decodex lane semantics. |
+| `decodex` | Repo memory plus Decodex docs policy | Verify Decodex lanes, authority enums, research contracts, drift audits, docs impact, and completion gates. |
+
+Core OKF consumption must remain permissive. Unknown concept types, unknown
+frontmatter keys, missing recommended fields, missing indexes, and broken cross-links
+do not make a bundle non-consumable at the core profile.
+
+Decodex profile checks may be strict because they enforce this repository's
+self-maintaining docs contract. Those checks are not a portable OKF requirement.
+
+## Producer And Consumer Boundary
+
+Producer behavior writes or updates concepts. It should preserve unknown frontmatter
+keys, ordinary Markdown body content, and existing links unless the task explicitly
+changes them.
+
+Consumer behavior reads concepts. It should tolerate unknown concept types and
+producer-specific fields. Query, graph, and route commands must return useful partial
+results even when a bundle is not clean enough to pass the strictest profile.
+
+## Skill Boundary
+
+Portable OKF skills own cross-repository behavior:
+
+- initialize a bundle
+- check profile conformance
+- query frontmatter and Markdown links
+- build graph/backlink views
+- maintain indexes and logs
+- route a task to the smallest relevant concepts
+
+Decodex docs skills are wrappers around those behaviors for this repository. They may
+apply Decodex profile constraints, but the portable OKF skill family must not depend
+on Linear, Decodex runtime state, research promotion, or landing policy.

--- a/docs/spec/okf-knowledge-layer.md
+++ b/docs/spec/okf-knowledge-layer.md
@@ -7,9 +7,9 @@ authority: normative
 owner: docs
 tags: [okf, llm-wiki, docs, repo-memory]
 source_refs: [https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md, https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing]
-code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/docs_okf.rs, plugins/decodex/skills/docs/SKILL.md]
-related: [../policy.md, ../reference/research-concepts.md]
-drift_watch: [decodex okf, decodex docs, docs lint, okf profile, docs alias]
+code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/docs_okf.rs, plugins/decodex/references/okf-layer.md, plugins/decodex/skills/okf/SKILL.md, plugins/decodex/skills/okf-query/SKILL.md, plugins/decodex/skills/okf-maintain/SKILL.md, plugins/decodex/skills/docs/SKILL.md]
+related: [../policy.md, ../reference/research-concepts.md, ../evidence/decodex-plugin-eval.md]
+drift_watch: [decodex okf, decodex docs, docs check, docs lint, okf profile, docs alias, okf skill]
 last_verified: 2026-06-17
 ---
 
@@ -117,6 +117,9 @@ Portable OKF skills own cross-repository behavior:
 - build graph/backlink views
 - maintain indexes and logs
 - route a task to the smallest relevant concepts
+
+The Decodex plugin exposes these portable skills as `okf`, `okf-query`, and
+`okf-maintain`.
 
 Decodex docs skills are wrappers around those behaviors for this repository. They may
 apply Decodex profile constraints, but the portable OKF skill family must not depend

--- a/plugins/decodex/.codex-plugin/plugin.json
+++ b/plugins/decodex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "decodex",
   "version": "0.2.0",
-  "description": "Decodex agent workflows for docs, research, issue planning, automation, commit, and landing.",
+  "description": "Decodex agent workflows for portable OKF bundles, docs, research, issue planning, automation, commit, and landing.",
   "author": {
     "name": "hack-ink",
     "email": "hi@hack.ink",
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Decodex",
     "shortDescription": "Maintain docs, research, plan, and operate Decodex.",
-    "longDescription": "Routes Decodex OKF docs maintenance, docs drift audits, bounded research, promotion, issue briefing and planning, CLI, labels, commit, landing, and automation.",
+    "longDescription": "Routes portable OKF/LLM Wiki bundle work, Decodex OKF docs maintenance, docs drift audits, bounded research, promotion, issue briefing and planning, CLI, labels, commit, landing, and automation.",
     "developerName": "hack-ink",
     "category": "Development",
     "capabilities": [
@@ -32,9 +32,9 @@
     "privacyPolicyURL": "https://github.com/hack-ink/decodex",
     "termsOfServiceURL": "https://github.com/hack-ink/decodex",
     "defaultPrompt": [
+      "Work with an OKF bundle.",
       "Maintain Decodex docs.",
-      "Research this with Decodex.",
-      "Arrange accepted Decodex work."
+      "Research this with Decodex."
     ],
     "brandColor": "#0F766E"
   }

--- a/plugins/decodex/references/docs-drift.md
+++ b/plugins/decodex/references/docs-drift.md
@@ -1,41 +1,24 @@
 # Decodex Docs Drift Reference
 
-Use this reference when docs claims may diverge from code, commands, config, runtime
-state, tracker behavior, validation, or evidence.
+Use this when Decodex docs claims may diverge from code, commands, config, runtime
+state, tracker behavior, validation, or evidence. Portable OKF graph and frontmatter
+quality checks use `okf-layer.md` and `decodex okf`.
 
 ## Trigger
 
-Run a drift audit when a lane changes or relies on claims about:
-
-- commands or flags
-- schemas or payload fields
-- status names or lifecycle states
-- config keys
-- tracker labels or terminal paths
-- validation gates
-- prompts or skills
-- generated artifacts
-- runtime behavior
-- research conclusions or promoted decisions
+Audit claims about commands, flags, schemas, statuses, config keys, tracker labels,
+terminal paths, validation gates, prompts, skills, generated artifacts, runtime
+behavior, or promoted research.
 
 ## Audit
 
 1. Scope changed docs and executable surfaces.
 2. Extract material claims.
-3. Map each claim to direct evidence anchors: source files, tests, CLI output,
-   checked-in config, smoke output, or runtime readback.
+3. Map each claim to source evidence: code, tests, config, CLI output, or runtime
+   readback.
 4. Reverse-check deleted or renamed terms.
-5. Decide one verdict: `pass`, `fail`, or `needs-human`.
-6. Update the owning concept's `code_refs` and `drift_watch`, or create/update a
-   linked `docs/evidence/` drift audit concept.
-
-## Blocking Rule
+5. Record `pass`, `fail`, or `needs-human`.
+6. Update `code_refs`, `drift_watch`, or a linked `docs/evidence/` drift audit.
 
 `fail` blocks ready/review handoff. `needs-human` blocks unless the lane records a
-public-safe manual-attention path with the unresolved authority choice.
-
-## Evidence Shape
-
-Use a `type: Drift Audit` evidence concept when the audit needs durable reuse. Keep
-private runtime proof in Decodex runtime storage and cite only public-safe summaries
-in `docs/`.
+public-safe manual-attention path.

--- a/plugins/decodex/references/docs-method.md
+++ b/plugins/decodex/references/docs-method.md
@@ -1,53 +1,38 @@
 # Decodex Docs Method
 
-Use this reference when a Decodex task changes repository documentation, behavior
-that documentation describes, or the agent-facing docs workflow.
+Use this when Decodex work changes repository documentation, documented behavior, or
+agent-facing docs workflow.
 
 ## Contract
 
-`docs/` is the Decodex repo-development knowledge base:
+`docs/` is this repository's Decodex profile OKF bundle. `docs/index.md` routes,
+`docs/policy.md` owns shape/lanes/gates, `docs/log.md` records maintenance, and
+non-index, non-log Markdown files are typed concepts. Research is latent until
+promoted; drift audits can block completion.
 
-- `docs/index.md` is the routing entrypoint.
-- `docs/policy.md` owns OKF shape, lane authority, and completion gates.
-- `docs/log.md` records docs maintenance events.
-- All durable docs artifacts are Markdown.
-- Non-index, non-log Markdown files are OKF concepts with typed frontmatter.
-- Research concepts are latent until promoted.
-- Drift audits are evidence concepts that can block completion.
-
-Do not create a parallel `wiki/` or `okf/` root. OKF is the `docs/` protocol. LLM
-Wiki is the authoring and retrieval style.
+Do not create a parallel `wiki/` or `okf/` root for this repo. Portable OKF bundles
+use `decodex okf` and the `okf*` skills; they do not inherit Decodex lanes, Linear
+workflow, or docs-impact gates.
 
 ## Lifecycle
 
-1. Read `docs/index.md` and `docs/policy.md`.
-2. Identify the smallest owning concept for the changed claim.
-3. Update that concept instead of duplicating the claim.
-4. Add or update frontmatter evidence fields when behavior, commands, schema,
-   status, config, validation, tracker labels, or runtime semantics changed.
-5. Update lane indexes and `docs/log.md` when routing, names, promotion, or
-   maintenance state changes.
-6. Run `cargo run -p decodex --bin decodex -- docs lint`.
-7. Treat lint or drift failure as a completion blocker.
+1. Read `docs/index.md`, `docs/policy.md`, and the owning concept.
+2. Update the owner; do not duplicate claims.
+3. Add `code_refs`, `drift_watch`, or drift audit evidence for behavior changes.
+4. Update indexes and `docs/log.md` for routing, naming, or promotion changes.
+5. Run `cargo run -p decodex --bin decodex -- docs check`.
 
 ## Docs Impact
 
-Every lane must classify docs impact before completion:
+- `none`: no docs, command, behavior, config, status, or workflow claim changed.
+- `update_required`: update a durable concept in the lane.
+- `research_required`: switch to Decodex research.
+- `drift_required`: create or update drift audit evidence.
 
-| Value | Meaning |
-| --- | --- |
-| `none` | No docs, command, behavior, config, status, or workflow claim changed. |
-| `update_required` | A durable docs concept must be updated in the lane. |
-| `research_required` | Missing or contradictory authority needs Decodex research. |
-| `drift_required` | A changed claim needs a drift audit before completion. |
-
-`validation-ready` includes docs readiness. Do not claim ready while a required docs
-update, research result, or drift audit is missing.
+`validation-ready` includes docs readiness.
 
 ## Routing
 
-- Use `docs-okf.md` for concept layout, frontmatter, and Markdown-only checks.
-- Use `docs-wiki.md` for placement, indexing, linking, and deduplication.
-- Use `docs-drift.md` for claim/evidence audits.
-- Use the research skill family when impact is `research_required`.
-
+- `docs-okf.md`: Decodex frontmatter/Markdown checks.
+- `docs-wiki.md`: placement, indexes, links, deduplication.
+- `docs-drift.md`: docs/code/evidence audits.

--- a/plugins/decodex/references/docs-okf.md
+++ b/plugins/decodex/references/docs-okf.md
@@ -1,12 +1,12 @@
 # Decodex Docs OKF Reference
 
-Use this reference when creating, migrating, validating, or repairing `docs/`
-concepts.
+Use this for this repository's strict Decodex profile `docs/` concepts. Use
+`okf-layer.md` for portable OKF bundles.
 
 ## Bundle Rules
 
-- `docs/` is Markdown-only. JSON and other non-Markdown docs artifacts are invalid.
-- Each directory with content has an `index.md`.
+- `docs/` is Markdown-only; JSON and other docs artifacts are invalid.
+- Every populated directory has `index.md`.
 - `docs/index.md`, `docs/policy.md`, and `docs/log.md` must exist.
 - Non-index, non-log Markdown documents are OKF concepts.
 - Concepts start with YAML frontmatter delimited by `---`.
@@ -14,66 +14,29 @@ concepts.
 
 ## Required Frontmatter
 
-Every concept requires:
+Every concept requires `type`, `title`, `description`, `status`, `authority`,
+`owner`, and `last_verified`.
 
-| Key | Rule |
-| --- | --- |
-| `type` | One of `Decision`, `Drift Audit`, `Evidence`, `Policy`, `Reference`, `Research Contract`, `Runbook`, `Spec`. |
-| `title` | Non-empty string. |
-| `description` | One-sentence retrieval summary. |
-| `status` | `draft`, `active`, `deprecated`, or `superseded`. |
-| `authority` | `normative`, `procedural`, `current_state`, `rationale`, `evidence`, or `non_authoritative`. |
-| `owner` | Owning surface such as `docs`, `runtime`, `research`, `automation`, or `site`. |
-| `last_verified` | ISO date. |
+Allowed `type`: `Decision`, `Drift Audit`, `Evidence`, `Policy`, `Reference`,
+`Research Contract`, `Runbook`, or `Spec`.
 
-Recommended structured fields:
-
-- `tags`
-- `source_refs`
-- `code_refs`
-- `related`
-- `promotes_to`
-- `drift_watch`
+Recommended structured fields: `tags`, `source_refs`, `code_refs`, `related`,
+`promotes_to`, and `drift_watch`.
 
 `promotes_to` may point only at `docs/spec`, `docs/runbook`, `docs/reference`, or
 `docs/decisions`.
 
-## Research Concepts
+## Required Sections
 
-`type: Research Contract` concepts include:
+`Research Contract` concepts include `Question`, `Scope`, `Evidence`, `Options`,
+`Judgment`, `Challenge`, `Decision`, `Promotion`, `Drift Impact`, and `Citations`.
 
-- `Question`
-- `Scope`
-- `Evidence`
-- `Options`
-- `Judgment`
-- `Challenge`
-- `Decision`
-- `Promotion`
-- `Drift Impact`
-- `Citations`
-
-The `Decision` section uses exactly one terminal status: `decision_ready`,
-`not_decision_ready`, `blocked`, or `needs_human_decision`.
-
-## Drift Audit Evidence
-
-`type: Drift Audit` concepts live under `docs/evidence/` when the audit needs a
-durable public-safe anchor. They include:
-
-- `Watched Claims`
-- `Evidence Anchors`
-- `Reverse Checks`
-- `Verdict`
-- `Required Updates`
-- `Citations`
-
-The `Verdict` section uses `pass`, `fail`, or `needs-human`.
+`Drift Audit` concepts include `Watched Claims`, `Evidence Anchors`,
+`Reverse Checks`, `Verdict`, `Required Updates`, and `Citations`. `Verdict` is
+`pass`, `fail`, or `needs-human`.
 
 ## Validation
 
-Run:
+Run `cargo run -p decodex --bin decodex -- docs check`.
 
-```sh
-cargo run -p decodex --bin decodex -- docs lint
-```
+`cargo run -p decodex --bin decodex -- docs lint` remains a compatibility alias.

--- a/plugins/decodex/references/docs-wiki.md
+++ b/plugins/decodex/references/docs-wiki.md
@@ -1,27 +1,18 @@
 # Decodex Docs Wiki Reference
 
-Use this reference when routing, indexing, linking, or deduplicating repository
-knowledge.
+Use this for Decodex `docs/` routing, indexing, linking, and deduplication. Use
+`okf-layer.md` for portable OKF/LLM Wiki bundles.
 
 ## Reading Order
 
-1. `README.md`
-2. `docs/index.md`
-3. `docs/policy.md`
-4. The smallest lane index and owning concept for the task
-
-Do not read a broad docs lane when one concept owns the changed claim.
+Read `README.md`, `docs/index.md`, `docs/policy.md`, then the smallest lane index and
+owning concept. Do not read a broad lane when one concept owns the changed claim.
 
 ## Lane Ownership
 
-| Lane | Owns |
-| --- | --- |
-| `docs/spec/` | Required behavior, schemas, invariants, states, validation contracts. |
-| `docs/runbook/` | Operator procedures and execution sequences. |
-| `docs/reference/` | Current structure, implementation maps, concept explanations. |
-| `docs/decisions/` | Durable rationale, rejected alternatives, tradeoffs. |
-| `docs/research/` | Latent research concepts and supporting evidence candidates. |
-| `docs/evidence/` | Reusable public-safe proof concepts, including durable drift audits. |
+Use `spec` for requirements, `runbook` for procedures, `reference` for current
+structure, `decisions` for rationale, `research` for latent candidates, and
+`evidence` for public-safe proof or drift audits.
 
 ## Authoring Rules
 
@@ -29,13 +20,9 @@ Do not read a broad docs lane when one concept owns the changed claim.
 - Link instead of copying repeated claims.
 - Update lane indexes when concepts are added, renamed, moved, deprecated, or
   superseded.
-- Use `related` frontmatter when cross-links materially help retrieval.
+- Use `related` when cross-links materially help retrieval.
 - Start each concept with a short routing purpose and boundary.
-- Put implementation truth in `docs/spec/` or code references, not in narrative
-  summaries.
 - Keep `docs/research/` non-authoritative until promotion.
 
-## Maintenance Log
-
-Update `docs/log.md` when a lane changes routing, promotion, naming, docs policy, or
-knowledge maintenance behavior.
+Update `docs/log.md` when routing, promotion, naming, docs policy, or maintenance
+behavior changes.

--- a/plugins/decodex/references/okf-layer.md
+++ b/plugins/decodex/references/okf-layer.md
@@ -1,0 +1,40 @@
+# Portable OKF Layer
+
+Use this for Open Knowledge Format bundles, LLM Wiki retrieval, and
+cross-repository knowledge-base maintenance.
+
+## Boundary
+
+OKF is the portable bundle format: Markdown files, YAML frontmatter, required
+`type`, and ordinary Markdown links. LLM Wiki is the agent method on top: route to
+small context, maintain links/indexes/logs, and keep producer-specific fields intact.
+
+Decodex docs are only one strict profile. Other repositories do not inherit Decodex
+lanes, Linear workflow, research promotion, docs-impact checkpoints, or landing
+policy.
+
+## Profiles
+
+- `core`: portable OKF v0.1 conformance.
+- `wiki`: core plus indexes, retrieval fields, and graph hygiene.
+- `repo-memory`: wiki plus `source_refs`, `code_refs`, `related`, and `drift_watch`.
+- `decodex`: repo-memory plus Decodex lanes, authority, research, and drift gates.
+
+Use the lowest profile that proves the claim. Consumers should still return partial
+results when a stricter profile fails.
+
+## Commands
+
+Use `decodex okf check/find/graph/route <root>` for portable bundles.
+`decodex docs` defaults to root `docs/` and profile `decodex`. Do not create or
+recommend `decodex docs okf ...`; OKF is the engine, not a docs subcommand.
+
+## Rules
+
+Producers pick a profile first, keep concepts one-topic, use frontmatter for routing,
+link real relationships, update `index.md` or `log.md` when navigation changes, and
+preserve unknown fields.
+
+Consumers start with `decodex okf route` or `decodex okf find`, use
+`decodex okf graph` for relationships, tolerate unknown `type` values, and use
+Decodex `docs-*` skills only for this repository's strict `docs/` profile.

--- a/plugins/decodex/references/okf-layer.md
+++ b/plugins/decodex/references/okf-layer.md
@@ -1,13 +1,12 @@
 # Portable OKF Layer
 
-Use this for Open Knowledge Format bundles, LLM Wiki retrieval, and
-cross-repository knowledge-base maintenance.
+Use this for portable OKF bundles, LLM Wiki retrieval, and cross-repository memory.
 
 ## Boundary
 
-OKF is the portable bundle format: Markdown files, YAML frontmatter, required
-`type`, and ordinary Markdown links. LLM Wiki is the agent method on top: route to
-small context, maintain links/indexes/logs, and keep producer-specific fields intact.
+OKF is the portable bundle format: Markdown, YAML frontmatter, required `type`, and
+ordinary links. LLM Wiki is the agent method on top: route small context, maintain
+links/indexes/logs, and preserve producer fields.
 
 Decodex docs are only one strict profile. Other repositories do not inherit Decodex
 lanes, Linear workflow, research promotion, docs-impact checkpoints, or landing
@@ -15,26 +14,26 @@ policy.
 
 ## Profiles
 
-- `core`: portable OKF v0.1 conformance.
+- `core`: portable OKF conformance.
 - `wiki`: core plus indexes, retrieval fields, and graph hygiene.
 - `repo-memory`: wiki plus `source_refs`, `code_refs`, `related`, and `drift_watch`.
 - `decodex`: repo-memory plus Decodex lanes, authority, research, and drift gates.
 
-Use the lowest profile that proves the claim. Consumers should still return partial
-results when a stricter profile fails.
+Use the lowest profile that proves the claim.
 
 ## Commands
 
-Use `decodex okf check/find/graph/route <root>` for portable bundles.
-`decodex docs` defaults to root `docs/` and profile `decodex`. Do not create or
-recommend `decodex docs okf ...`; OKF is the engine, not a docs subcommand.
+Use `decodex okf check`, `decodex okf find`, `decodex okf graph`, and
+`decodex okf route` for portable bundles. `decodex docs` defaults to root `docs/`
+and profile `decodex`. Do not create or recommend `decodex docs okf ...`; OKF is
+the engine, not a docs subcommand.
 
 ## Rules
 
-Producers pick a profile first, keep concepts one-topic, use frontmatter for routing,
-link real relationships, update `index.md` or `log.md` when navigation changes, and
-preserve unknown fields.
+Producers pick a profile first, keep concepts one-topic, use frontmatter for
+routing, link real relationships, update `index.md` or `log.md` for navigation
+changes, and preserve unknown fields.
 
-Consumers start with `decodex okf route` or `decodex okf find`, use
-`decodex okf graph` for relationships, tolerate unknown `type` values, and use
-Decodex `docs-*` skills only for this repository's strict `docs/` profile.
+Consumers start with `decodex okf route` or `decodex okf find`, use graph output for
+relationships, tolerate unknown `type` values, and use Decodex `docs-*` skills only
+for this repository's strict `docs/` profile.

--- a/plugins/decodex/skills/docs-drift/SKILL.md
+++ b/plugins/decodex/skills/docs-drift/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: docs-drift
-description: Use when auditing docs claims against code, evidence, and runtime behavior.
+description: Use when auditing this repository's docs claims against code, evidence, and runtime behavior.
 ---
 
 # Decodex Docs Drift
 
-Audit docs claims against source evidence.
+Audit Decodex docs claims against source evidence. For portable OKF graph or
+frontmatter quality checks, use `okf` or `okf-query`; this skill owns Decodex
+semantic drift and completion blocking.
 
 Read `../../references/docs-drift.md` before judging docs/code alignment.
 

--- a/plugins/decodex/skills/docs-okf/SKILL.md
+++ b/plugins/decodex/skills/docs-okf/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: docs-okf
-description: Use when creating or migrating docs/ to the Decodex OKF layout.
+description: Use when creating or migrating docs/ to the strict Decodex OKF profile.
 ---
 
 # Decodex Docs OKF
 
-Maintain the `docs/` bundle as Markdown-only OKF concepts.
+Maintain this repository's `docs/` bundle as Markdown-only Decodex profile concepts.
+For portable OKF bundles, use `okf-maintain`.
 
 Read `../../references/docs-okf.md` before creating, moving, or repairing concepts.
 
 - Keep durable docs artifacts Markdown-only.
-- Use typed OKF frontmatter from `docs/policy.md`.
+- Use typed Decodex profile frontmatter from `docs/policy.md`.
 - Keep research contracts and drift audit evidence concepts in their required section
   shape.
 - Do not add JSON or generated state under `docs/`.
-- Run `cargo run -p decodex --bin decodex -- docs lint` before claiming docs
+- Run `cargo run -p decodex --bin decodex -- docs check` before claiming docs
   readiness.

--- a/plugins/decodex/skills/docs-wiki/SKILL.md
+++ b/plugins/decodex/skills/docs-wiki/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: docs-wiki
-description: Use when turning repo docs into agent-readable LLM Wiki knowledge pages.
+description: Use when maintaining this repository's docs/ lane indexes, links, and Decodex LLM Wiki routing.
 ---
 
 # Decodex Docs Wiki
 
-Maintain `docs/` as an agent-readable LLM Wiki.
+Maintain this repository's `docs/` as an agent-readable LLM Wiki under the Decodex
+profile. For portable OKF bundle lookup, use `okf-query`; for portable maintenance,
+use `okf-maintain`.
 
 Read `../../references/docs-wiki.md` for lane ownership, authoring, and indexing
 rules.

--- a/plugins/decodex/skills/docs/SKILL.md
+++ b/plugins/decodex/skills/docs/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: docs
-description: Use when Decodex work touches docs/ OKF structure, LLM Wiki routing, or drift audits.
+description: Use when Decodex work touches this repository's docs/ OKF profile, LLM Wiki routing, or drift audits.
 ---
 
 # Decodex Docs
 
-Route Decodex work through the repo-development OKF/LLM Wiki knowledge base.
+Route Decodex work through this repository's strict `docs/` OKF/LLM Wiki profile.
+For portable OKF bundles in other repositories, use `okf`, `okf-query`, or
+`okf-maintain` instead.
 
 Read `../../references/docs-method.md`, `docs/index.md`, `docs/policy.md`, and the
 smallest owning concepts before changing behavior, workflow, CLI, status, config,
 research, or documentation.
 
-- Use `docs-okf` for OKF concept shape.
+- Use `docs-okf` for Decodex profile concept shape.
 - Use `docs-wiki` for placement, indexes, links, and duplicate claims.
 - Use `docs-drift` for docs/code/evidence alignment.
 - Classify docs impact before completion: `none`, `update_required`,
@@ -19,6 +21,6 @@ research, or documentation.
 - If docs impact is `research_required`, switch to the Decodex `research*` skill
   family.
 - Record routing, promotion, rename, or maintenance changes in `docs/log.md`.
-- Run `cargo run -p decodex --bin decodex -- docs lint` before claiming docs
+- Run `cargo run -p decodex --bin decodex -- docs check` before claiming docs
   readiness.
-- Treat docs lint or drift failure as a completion blocker.
+- Treat docs check or drift failure as a completion blocker.

--- a/plugins/decodex/skills/okf-maintain/SKILL.md
+++ b/plugins/decodex/skills/okf-maintain/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: okf-maintain
+description: Use when creating or updating OKF/LLM Wiki concepts, indexes, logs, links, frontmatter fields, or repo-memory anchors in any repository.
+---
+
+# OKF Maintain
+
+Produce and maintain OKF bundles without coupling them to Decodex-specific policy.
+
+Read `../../references/okf-layer.md` before creating concepts, moving files, or
+repairing graph quality.
+
+- Choose the target profile first: `core`, `wiki`, `repo-memory`, or `decodex`.
+- Keep each concept focused on one topic and give it a useful `type`.
+- Add `title`, `description`, `resource`, `tags`, and `timestamp` when they help
+  retrieval.
+- For repository memory, add `source_refs`, `code_refs`, `related`, and `drift_watch`
+  only when they carry real retrieval or maintenance value.
+- Update `index.md` and `log.md` when navigation or maintenance history changes.
+- Run the matching `decodex okf check <root> --profile <profile>` before claiming the
+  bundle is ready.

--- a/plugins/decodex/skills/okf-maintain/agents/openai.yaml
+++ b/plugins/decodex/skills/okf-maintain/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "OKF Maintain"
+  short_description: "Maintain OKF bundle memory"
+policy:
+  allow_implicit_invocation: false

--- a/plugins/decodex/skills/okf-query/SKILL.md
+++ b/plugins/decodex/skills/okf-query/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: okf-query
+description: Use when locating context in an OKF/LLM Wiki bundle by profile fields, graph links, backlinks, tags, code refs, source refs, or task intent.
+---
+
+# OKF Query
+
+Consume an OKF bundle as agent-readable repository memory.
+
+Read `../../references/okf-layer.md` before choosing query commands or reporting
+bundle graph findings.
+
+- Start with `decodex okf route <root> "<task intent>"` when the user has a task.
+- Use `decodex okf find <root>` with `--type`, `--tag`, `--resource`,
+  `--source-ref`, `--code-ref`, `--related`, or `--text` for precise lookup.
+- Use `decodex okf graph <root> --json` when relationship shape, orphans, or broken
+  bundle-internal links matter.
+- Return the smallest concept set that can answer the task.
+- Do not require Decodex lanes or Linear workflow for portable OKF consumption.

--- a/plugins/decodex/skills/okf-query/agents/openai.yaml
+++ b/plugins/decodex/skills/okf-query/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "OKF Query"
+  short_description: "Find OKF bundle context"
+policy:
+  allow_implicit_invocation: false

--- a/plugins/decodex/skills/okf/SKILL.md
+++ b/plugins/decodex/skills/okf/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: okf
+description: Use when creating, checking, querying, graphing, routing, or maintaining portable OKF/LLM Wiki bundles across repositories.
+---
+
+# Portable OKF
+
+Route portable OKF and LLM Wiki work without assuming the Decodex docs profile.
+
+Read `../../references/okf-layer.md` before changing a bundle, recommending a
+profile, or using OKF commands.
+
+- Use `decodex okf check <root> --profile core|wiki|repo-memory|decodex` for bundle
+  validation.
+- Use `decodex okf find`, `decodex okf graph`, and `decodex okf route` for consumer
+  workflows.
+- Pick the lowest profile that proves the current claim.
+- Preserve producer-specific fields and unknown concept types.
+- Use Decodex `docs-*` skills only for this repository's strict `docs/` profile.

--- a/plugins/decodex/skills/okf/agents/openai.yaml
+++ b/plugins/decodex/skills/okf/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Portable OKF"
+  short_description: "Work with portable OKF bundles"
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
Linear: XY-989

## Summary

- Define the portable OKF/LLM Wiki layer and separate it from the strict Decodex docs profile.
- Add `decodex okf check/find/graph/route` plus `decodex docs find/graph/route` as the repo-local docs alias surface.
- Split portable OKF plugin skills/references from Decodex docs wrapper skills and keep the narrow lifecycle skills explicit-only.
- Repair route parsing after self-review found `decodex okf route docs "..."` could hit a Clap debug assertion.

## Verification

- `cargo run -p decodex --bin decodex -- okf route docs "change okf docs command design"`
- `cargo run -p decodex --bin decodex -- docs route "change okf docs command design"`
- `cargo run -p decodex --bin decodex -- okf check docs --profile repo-memory`
- `node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex --format json` -> `100/A/low`, deferred `5090`
- plugin-eval for `okf`, `okf-query`, `okf-maintain`, `docs`, `docs-okf`, `docs-wiki`, and `docs-drift` -> all `100/A/low`, no fail/warn/error
- `git diff --check origin/main...HEAD`
- `cargo make check` -> `1193 tests run: 1193 passed, 1 skipped`

## Review Note

Subagent review was attempted after disabling multi-agent v2. The previous replay error stopped, but review agents started and then hung without returning findings. Main-thread fallback review inspected the final diff, CLI parsing, OKF profile boundaries, plugin skills/references, docs policy/spec consistency, and command-surface grep; no concrete findings.
