### PR TITLE
Replace Decision Contract issue summaries with structured proposed issues

### DIFF
--- a/apps/decodex/fixtures/decision_contract/research_x_latent_contract.json
+++ b/apps/decodex/fixtures/decision_contract/research_x_latent_contract.json
@@ -66,6 +66,29 @@
     ],
     "risk_notes": [
       "Do not infer execution authority from research provenance alone."
+    ],
+    "proposed_issues": [
+      {
+        "key": "research-x-contract-model",
+        "title": "Define the runtime-facing Decision Contract model.",
+        "objective": "Define the runtime-facing Decision Contract model.",
+        "stage": "schema",
+        "dependencies": [],
+        "conflict_domains": [
+          "module:runtime"
+        ],
+        "acceptance": [
+          "The Decision Contract model preserves accepted objectives, constraints, evidence boundaries, and issue readiness."
+        ],
+        "validation": [
+          "Serialization round-trip passes.",
+          "Promotion transition records acceptance metadata."
+        ],
+        "risk": [
+          "Do not infer execution authority from research provenance alone."
+        ],
+        "queue_intent": "ready_to_queue"
+      }
     ]
   },
   "links": {

--- a/apps/decodex/fixtures/harness_improvement/incomplete_contract_eval.json
+++ b/apps/decodex/fixtures/harness_improvement/incomplete_contract_eval.json
@@ -58,9 +58,9 @@
       "risk_notes": [
         "A future agent could implement from latent evidence if the issue template omits the authority field."
       ],
-      "proposed_issue_summaries": [],
+      "proposed_issues": [],
       "conflict_domains": [],
-      "queue_intent": []
+      "promotion_targets": []
     },
     "links": {
       "generated_issue_ids": [],

--- a/apps/decodex/src/loop_contract.rs
+++ b/apps/decodex/src/loop_contract.rs
@@ -1,5 +1,7 @@
 //! Versioned Loop/Decision Contract model for research-to-execution handoff.
 
+use std::collections::BTreeSet;
+
 use serde::{Deserialize, Serialize};
 
 use crate::prelude::{Result, eyre};
@@ -423,6 +425,7 @@ impl DecisionAcceptedAuthority {
 
 /// Natural-language readiness summary for later issue shaping.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct DecisionExecutionReadiness {
 	summary: String,
 	ready_for_issue_shaping: bool,
@@ -432,14 +435,11 @@ pub(crate) struct DecisionExecutionReadiness {
 	validation_expectations: Vec<String>,
 	#[serde(default)]
 	risk_notes: Vec<String>,
-	#[serde(default)]
-	proposed_issue_summaries: Vec<String>,
+	proposed_issues: Vec<DecisionProposedIssue>,
 	#[serde(default)]
 	promotion_targets: Vec<String>,
 	#[serde(default)]
 	conflict_domains: Vec<String>,
-	#[serde(default)]
-	queue_intent: Vec<String>,
 }
 #[allow(dead_code)]
 impl DecisionExecutionReadiness {
@@ -455,8 +455,8 @@ impl DecisionExecutionReadiness {
 		&self.missing_decisions
 	}
 
-	pub(crate) fn proposed_issue_summaries(&self) -> &[String] {
-		&self.proposed_issue_summaries
+	pub(crate) fn proposed_issues(&self) -> &[DecisionProposedIssue] {
+		&self.proposed_issues
 	}
 
 	pub(crate) fn promotion_targets(&self) -> &[String] {
@@ -475,10 +475,6 @@ impl DecisionExecutionReadiness {
 		&self.risk_notes
 	}
 
-	pub(crate) fn queue_intent(&self) -> &[String] {
-		&self.queue_intent
-	}
-
 	fn validate(&self, status: DecisionContractStatus) -> Result<()> {
 		validate_required("decision contract execution_readiness.summary", &self.summary)?;
 		validate_string_list("decision contract missing_decisions", &self.missing_decisions)?;
@@ -487,18 +483,19 @@ impl DecisionExecutionReadiness {
 			&self.validation_expectations,
 		)?;
 		validate_string_list("decision contract risk_notes", &self.risk_notes)?;
-		validate_string_list(
-			"decision contract proposed_issue_summaries",
-			&self.proposed_issue_summaries,
-		)?;
+		validate_proposed_issues(&self.proposed_issues)?;
 		validate_string_list("decision contract promotion_targets", &self.promotion_targets)?;
 		validate_string_list("decision contract conflict_domains", &self.conflict_domains)?;
-		validate_string_list("decision contract queue_intent", &self.queue_intent)?;
 
 		match status {
 			DecisionContractStatus::AcceptedPromoted => {
 				if !self.ready_for_issue_shaping {
 					eyre::bail!("Accepted decision contracts must be ready for issue shaping.");
+				}
+				if self.proposed_issues.is_empty() {
+					eyre::bail!(
+						"Accepted decision contracts must include structured proposed_issues."
+					);
 				}
 				if !self.missing_decisions.is_empty() {
 					eyre::bail!(
@@ -516,6 +513,97 @@ impl DecisionExecutionReadiness {
 		}
 
 		Ok(())
+	}
+}
+
+/// Structured issue-shaping input retained inside Decision Contract readiness.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DecisionProposedIssue {
+	key: String,
+	title: String,
+	objective: String,
+	stage: String,
+	dependencies: Vec<String>,
+	conflict_domains: Vec<String>,
+	acceptance: Vec<String>,
+	validation: Vec<String>,
+	risk: Vec<String>,
+	queue_intent: String,
+}
+#[allow(dead_code)]
+impl DecisionProposedIssue {
+	pub(crate) fn key(&self) -> &str {
+		&self.key
+	}
+
+	pub(crate) fn title(&self) -> &str {
+		&self.title
+	}
+
+	pub(crate) fn objective(&self) -> &str {
+		&self.objective
+	}
+
+	pub(crate) fn stage(&self) -> &str {
+		&self.stage
+	}
+
+	pub(crate) fn dependencies(&self) -> &[String] {
+		&self.dependencies
+	}
+
+	pub(crate) fn conflict_domains(&self) -> &[String] {
+		&self.conflict_domains
+	}
+
+	pub(crate) fn acceptance(&self) -> &[String] {
+		&self.acceptance
+	}
+
+	pub(crate) fn validation(&self) -> &[String] {
+		&self.validation
+	}
+
+	pub(crate) fn risk(&self) -> &[String] {
+		&self.risk
+	}
+
+	pub(crate) fn queue_intent(&self) -> &str {
+		&self.queue_intent
+	}
+
+	fn validate(&self) -> Result<()> {
+		validate_required("decision contract proposed_issues.key", &self.key)?;
+		validate_required("decision contract proposed_issues.title", &self.title)?;
+		validate_required("decision contract proposed_issues.objective", &self.objective)?;
+		validate_required("decision contract proposed_issues.stage", &self.stage)?;
+		validate_string_list("decision contract proposed_issues.dependencies", &self.dependencies)?;
+		validate_string_list(
+			"decision contract proposed_issues.conflict_domains",
+			&self.conflict_domains,
+		)?;
+		validate_string_list("decision contract proposed_issues.acceptance", &self.acceptance)?;
+		validate_string_list("decision contract proposed_issues.validation", &self.validation)?;
+		validate_string_list("decision contract proposed_issues.risk", &self.risk)?;
+		validate_required("decision contract proposed_issues.queue_intent", &self.queue_intent)?;
+
+		if self.acceptance.is_empty() {
+			eyre::bail!(
+				"Decision Contract proposed issue `{}` must include acceptance criteria.",
+				self.key
+			);
+		}
+		if self.validation.is_empty() {
+			eyre::bail!(
+				"Decision Contract proposed issue `{}` must include validation expectations.",
+				self.key
+			);
+		}
+
+		validate_proposed_issue_stage(&self.key, &self.stage)?;
+
+		validate_proposed_issue_queue_intent(&self.key, &self.queue_intent)
 	}
 }
 
@@ -747,6 +835,39 @@ fn validate_string_list(name: &str, values: &[String]) -> Result<()> {
 	Ok(())
 }
 
+fn validate_proposed_issues(issues: &[DecisionProposedIssue]) -> Result<()> {
+	let mut keys = BTreeSet::new();
+
+	for issue in issues {
+		issue.validate()?;
+
+		if !keys.insert(issue.key()) {
+			eyre::bail!("Decision Contract proposed issue key `{}` is duplicated.", issue.key());
+		}
+	}
+
+	Ok(())
+}
+
+fn validate_proposed_issue_stage(key: &str, stage: &str) -> Result<()> {
+	match stage {
+		"research" | "design" | "spec" | "schema" | "runtime" | "plugin" | "eval" | "handoff" =>
+			Ok(()),
+		_ =>
+			eyre::bail!("Decision Contract proposed issue `{key}` has unsupported stage `{stage}`."),
+	}
+}
+
+fn validate_proposed_issue_queue_intent(key: &str, queue_intent: &str) -> Result<()> {
+	match queue_intent {
+		"not_ready" | "ready_to_queue" | "queued" | "active" | "paused" | "done" | "canceled" =>
+			Ok(()),
+		_ => eyre::bail!(
+			"Decision Contract proposed issue `{key}` has unsupported queue_intent `{queue_intent}`."
+		),
+	}
+}
+
 fn normalized_link_values(
 	values: impl IntoIterator<Item = impl Into<String>>,
 ) -> Result<Vec<String>> {
@@ -869,6 +990,40 @@ mod tests {
 			contract, before_failed_promotion,
 			"failed promotion must not mutate the contract"
 		);
+
+		let mut contract = latent_research_contract_fixture();
+
+		contract.execution_readiness.proposed_issues.clear();
+
+		let before_failed_promotion = contract.clone();
+
+		assert!(contract.promote(sample_promotion()).is_err());
+		assert_eq!(
+			contract, before_failed_promotion,
+			"failed promotion must not mutate the contract"
+		);
+	}
+
+	#[test]
+	fn legacy_flat_proposed_issue_summaries_are_rejected() {
+		let mut payload = serde_json::to_value(latent_research_contract_fixture())
+			.expect("fixture should encode");
+		let readiness = payload
+			.get_mut("execution_readiness")
+			.expect("readiness should exist")
+			.as_object_mut()
+			.expect("readiness should be an object");
+
+		readiness.remove("proposed_issues");
+		readiness.insert(
+			String::from("proposed_issue_summaries"),
+			serde_json::json!(["Legacy flat summary."]),
+		);
+
+		let error = serde_json::from_value::<DecisionContract>(payload)
+			.expect_err("legacy flat summaries must not deserialize");
+
+		assert!(error.to_string().contains("proposed_issue_summaries"));
 	}
 
 	#[test]

--- a/apps/decodex/src/orchestrator/tests/runtime/program_intake_dogfood.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/program_intake_dogfood.rs
@@ -432,7 +432,7 @@ fn goal_intake_rejects_latent_then_apply_direct_dispatch_and_status_readback_is_
 		.selected
 		.expect("one generated issue should be selected for direct dispatch");
 
-	assert_eq!(selection.summary.dispatchable_nodes, 2);
+	assert_eq!(selection.summary.dispatchable_nodes, 1);
 	assert_eq!(selected.dispatch_mode, orchestrator::IssueDispatchMode::Program);
 	assert!(tracker.label_additions().is_empty());
 	assert!(tracker.label_removals().is_empty());
@@ -443,14 +443,21 @@ fn goal_intake_rejects_latent_then_apply_direct_dispatch_and_status_readback_is_
 	let program = snapshot.execution_programs.first().expect("goal program should surface");
 	let rendered_status = orchestrator::render_operator_status(&snapshot);
 
-	assert_eq!(program.status, "ready");
+	assert_eq!(program.status, "blocked");
 	assert_eq!(program.source_contract_id.as_deref(), Some(accepted.contract_id()));
 	assert_eq!(program.intake_kind.as_deref(), Some("goal_intake"));
 	assert_eq!(
 		program.public_summary.as_deref(),
 		Some("Dogfood accepted goal intake through generated issues.")
 	);
-	assert_eq!(program.ready_count, 2);
+	assert_eq!(program.ready_count, 1);
+	assert_eq!(program.blocked_count, 1);
+	assert!(
+		program
+			.node_readbacks
+			.iter()
+			.any(|node| node.reason_codes.contains(&String::from("dependency_not_terminal")))
+	);
 	assert_eq!(program.queued_count, 0);
 	assert!(rendered_status.contains("source_contract_id: dogfood-goal-contract"));
 	assert!(!rendered_status.contains("private_evidence"));
@@ -507,16 +514,53 @@ fn dogfood_goal_contract() -> DecisionContract {
 			"risk_notes": [
 				"Public readback must stay sparse."
 			],
-			"proposed_issue_summaries": [
-				"Dogfood generated runtime issue.",
-				"Dogfood generated status readback issue."
+			"proposed_issues": [
+				{
+					"key": "dogfood-runtime",
+					"title": "Dogfood generated runtime issue.",
+					"objective": "Dogfood generated runtime issue.",
+					"stage": "runtime",
+					"dependencies": [],
+					"conflict_domains": [
+						"module:runtime"
+					],
+					"acceptance": [
+						"Dogfood accepted goal intake through a generated runtime issue."
+					],
+					"validation": [
+						"Run focused Program Intake E2E tests."
+					],
+					"risk": [
+						"Public readback must stay sparse."
+					],
+					"queue_intent": "ready_to_queue"
+				},
+				{
+					"key": "dogfood-status",
+					"title": "Dogfood generated status readback issue.",
+					"objective": "Dogfood generated status readback issue.",
+					"stage": "runtime",
+					"dependencies": [
+						"dogfood-runtime"
+					],
+					"conflict_domains": [
+						"module:status"
+					],
+					"acceptance": [
+						"Dogfood accepted goal intake through a generated status readback issue."
+					],
+					"validation": [
+						"Run focused Program Intake E2E tests."
+					],
+					"risk": [
+						"Public readback must stay sparse."
+					],
+					"queue_intent": "ready_to_queue"
+				}
 			],
 			"conflict_domains": [
 				"module:runtime",
 				"module:status"
-			],
-			"queue_intent": [
-				"ready_to_queue_after_apply"
 			]
 		},
 		"links": {

--- a/apps/decodex/src/program_intake.rs
+++ b/apps/decodex/src/program_intake.rs
@@ -18,7 +18,7 @@ use crate::{
 		ExecutionProgramNode, ExecutionProgramNodeLifecycleState, ExecutionProgramNodeStage,
 		ExecutionProgramReadinessContext, ExecutionQueueIntent, ExecutionWorkflowPolicy,
 	},
-	loop_contract::{DecisionContract, DecisionContractStatus},
+	loop_contract::{DecisionContract, DecisionContractStatus, DecisionProposedIssue},
 	orchestrator,
 	prelude::{Result, eyre},
 	runtime,
@@ -194,14 +194,19 @@ struct IssueFacts {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct GoalIssuePlan {
+	key: String,
 	node_id: String,
 	title: String,
 	objective: String,
+	stage: ExecutionProgramNodeStage,
+	queue_intent: ExecutionQueueIntent,
 	description: String,
 	dependencies: Vec<String>,
+	dependency_node_ids: Vec<String>,
 	conflict_domains: Vec<ExecutionConflictDomain>,
 	acceptance: Vec<String>,
 	validation: Vec<String>,
+	risk: Vec<String>,
 }
 
 struct GoalIntakeAnchor {
@@ -216,6 +221,7 @@ struct GoalIssueBriefInput<'a> {
 	conflict_domains: &'a [ExecutionConflictDomain],
 	acceptance: &'a [String],
 	validation: &'a [String],
+	risk: &'a [String],
 }
 
 struct ApplyGoalIssuesInput<'a, T>
@@ -628,9 +634,9 @@ fn ensure_goal_intake_authority(contract: &DecisionContract) -> Result<()> {
 			contract.contract_id()
 		);
 	}
-	if contract.execution_readiness().proposed_issue_summaries().is_empty() {
+	if contract.execution_readiness().proposed_issues().is_empty() {
 		eyre::bail!(
-			"Decision Contract `{}` has no proposed issue summaries to materialize.",
+			"Decision Contract `{}` has no structured proposed issues to materialize.",
 			contract.contract_id()
 		);
 	}
@@ -639,41 +645,66 @@ fn ensure_goal_intake_authority(contract: &DecisionContract) -> Result<()> {
 }
 
 fn goal_issue_plans(contract: &DecisionContract, program_id: &str) -> Result<Vec<GoalIssuePlan>> {
-	let conflict_domains = goal_conflict_domains(contract)?;
 	let mut plans = Vec::new();
 
-	for (index, objective) in
-		contract.execution_readiness().proposed_issue_summaries().iter().enumerate()
-	{
-		let node_id = goal_node_id(contract.contract_id(), index, objective);
-		let title = goal_issue_title(objective);
-		let acceptance = goal_acceptance(contract, objective);
-		let validation = goal_validation(contract);
-		let dependencies = Vec::new();
+	for (index, issue) in contract.execution_readiness().proposed_issues().iter().enumerate() {
+		let node_id = goal_node_id(contract.contract_id(), index, issue.key());
+		let title = issue.title().to_owned();
+		let objective = issue.objective().to_owned();
+		let acceptance = issue.acceptance().to_vec();
+		let validation = issue.validation().to_vec();
+		let risk = issue.risk().to_vec();
+		let dependencies = issue.dependencies().to_vec();
+		let conflict_domains = goal_proposed_issue_conflict_domains(issue)?;
 		let description = render_goal_issue_brief(GoalIssueBriefInput {
 			contract,
-			objective,
+			objective: &objective,
 			dependencies: &dependencies,
 			conflict_domains: &conflict_domains,
 			acceptance: &acceptance,
 			validation: &validation,
+			risk: &risk,
 		})?;
 
 		validate_generated_issue_text(&title, &description, &[program_id, &node_id])?;
 
 		plans.push(GoalIssuePlan {
+			key: issue.key().to_owned(),
 			node_id,
 			title,
-			objective: objective.clone(),
+			objective,
+			stage: parse_goal_stage(issue.stage())?,
+			queue_intent: parse_goal_queue_intent(issue.queue_intent())?,
 			description,
 			dependencies,
-			conflict_domains: conflict_domains.clone(),
+			dependency_node_ids: Vec::new(),
+			conflict_domains,
 			acceptance,
 			validation,
+			risk,
 		});
 	}
 
+	bind_goal_dependency_node_ids(&mut plans);
+
 	Ok(plans)
+}
+
+fn bind_goal_dependency_node_ids(plans: &mut [GoalIssuePlan]) {
+	let node_ids_by_key = plans
+		.iter()
+		.map(|plan| (plan.key.clone(), plan.node_id.clone()))
+		.collect::<BTreeMap<_, _>>();
+
+	for plan in plans {
+		plan.dependency_node_ids = plan
+			.dependencies
+			.iter()
+			.map(|dependency| {
+				node_ids_by_key.get(dependency).cloned().unwrap_or_else(|| dependency.to_owned())
+			})
+			.collect();
+	}
 }
 
 fn linked_goal_issues<T>(
@@ -855,7 +886,7 @@ fn goal_program_node(
 	workflow: &WorkflowDocument,
 ) -> Result<ExecutionProgramNode> {
 	let dependencies = plan
-		.dependencies
+		.dependency_node_ids
 		.iter()
 		.map(ExecutionProgramDependency::new)
 		.collect::<Result<Vec<_>>>()?;
@@ -863,9 +894,9 @@ fn goal_program_node(
 
 	ExecutionProgramNode::new(
 		plan.node_id.clone(),
-		ExecutionProgramNodeStage::Runtime,
+		plan.stage,
 		plan.objective.clone(),
-		ExecutionQueueIntent::ReadyToQueue,
+		plan.queue_intent,
 	)?
 	.with_objective_lineage(goal_objective_lineage(contract))?
 	.with_dependencies(dependencies)?
@@ -959,7 +990,7 @@ fn goal_issue_report_row(
 		issue_id: issue.map(|issue| issue.id.clone()),
 		issue_identifier: issue.map(|issue| issue.identifier.clone()),
 		action,
-		queue_intent: ExecutionQueueIntent::ReadyToQueue.as_str().to_owned(),
+		queue_intent: plan.queue_intent.as_str().to_owned(),
 		dispatch_action: dispatch_action.map(dispatch_action_name),
 		dependencies: plan.dependencies.clone(),
 		conflict_domains: conflict_domain_labels(&plan.conflict_domains),
@@ -1002,6 +1033,8 @@ fn render_goal_issue_brief(input: GoalIssueBriefInput<'_>) -> Result<String> {
 	append_items(&mut output, input.acceptance);
 	append_heading(&mut output, "Validation");
 	append_items(&mut output, input.validation);
+	append_heading(&mut output, "Risk");
+	append_items_or_none(&mut output, input.risk);
 	append_heading(&mut output, "Stop Conditions");
 	append_items_or_none(&mut output, input.contract.accepted_authority().stop_conditions());
 	validate_public_issue_description(&output)?;
@@ -1086,22 +1119,6 @@ fn ensure_no_generated_issue_private_identifier(
 	Ok(())
 }
 
-fn goal_acceptance(contract: &DecisionContract, objective: &str) -> Vec<String> {
-	let mut acceptance = vec![format!("Deliver this generated issue objective: {objective}")];
-
-	acceptance.extend(contract.accepted_authority().accepted_objectives().iter().cloned());
-
-	acceptance
-}
-
-fn goal_validation(contract: &DecisionContract) -> Vec<String> {
-	if contract.execution_readiness().validation_expectations().is_empty() {
-		return vec![String::from("Run the registered project validation before review handoff.")];
-	}
-
-	contract.execution_readiness().validation_expectations().to_vec()
-}
-
 fn goal_objective_lineage(contract: &DecisionContract) -> Vec<String> {
 	let mut lineage = vec![
 		format!("Accepted Decision Contract `{}`.", contract.contract_id()),
@@ -1113,13 +1130,10 @@ fn goal_objective_lineage(contract: &DecisionContract) -> Vec<String> {
 	lineage
 }
 
-fn goal_conflict_domains(contract: &DecisionContract) -> Result<Vec<ExecutionConflictDomain>> {
-	contract
-		.execution_readiness()
-		.conflict_domains()
-		.iter()
-		.map(|domain| parse_goal_conflict_domain(domain))
-		.collect()
+fn goal_proposed_issue_conflict_domains(
+	issue: &DecisionProposedIssue,
+) -> Result<Vec<ExecutionConflictDomain>> {
+	issue.conflict_domains().iter().map(|domain| parse_goal_conflict_domain(domain)).collect()
 }
 
 fn parse_goal_conflict_domain(domain: &str) -> Result<ExecutionConflictDomain> {
@@ -1136,6 +1150,33 @@ fn parse_goal_conflict_domain(domain: &str) -> Result<ExecutionConflictDomain> {
 	};
 
 	ExecutionConflictDomain::new(kind, key)
+}
+
+fn parse_goal_stage(stage: &str) -> Result<ExecutionProgramNodeStage> {
+	match stage {
+		"research" => Ok(ExecutionProgramNodeStage::Research),
+		"design" => Ok(ExecutionProgramNodeStage::Design),
+		"spec" => Ok(ExecutionProgramNodeStage::Spec),
+		"schema" => Ok(ExecutionProgramNodeStage::Schema),
+		"runtime" => Ok(ExecutionProgramNodeStage::Runtime),
+		"plugin" => Ok(ExecutionProgramNodeStage::Plugin),
+		"eval" => Ok(ExecutionProgramNodeStage::Eval),
+		"handoff" => Ok(ExecutionProgramNodeStage::Handoff),
+		_ => eyre::bail!("Unsupported proposed issue stage `{stage}`."),
+	}
+}
+
+fn parse_goal_queue_intent(queue_intent: &str) -> Result<ExecutionQueueIntent> {
+	match queue_intent {
+		"not_ready" => Ok(ExecutionQueueIntent::NotReady),
+		"ready_to_queue" => Ok(ExecutionQueueIntent::ReadyToQueue),
+		"queued" => Ok(ExecutionQueueIntent::Queued),
+		"active" => Ok(ExecutionQueueIntent::Active),
+		"paused" => Ok(ExecutionQueueIntent::Paused),
+		"done" => Ok(ExecutionQueueIntent::Done),
+		"canceled" => Ok(ExecutionQueueIntent::Canceled),
+		_ => eyre::bail!("Unsupported proposed issue queue_intent `{queue_intent}`."),
+	}
 }
 
 fn conflict_domain_labels(domains: &[ExecutionConflictDomain]) -> Vec<String> {
@@ -1156,20 +1197,6 @@ fn goal_program_id(service_id: &str, contract_id: &str) -> String {
 
 fn goal_node_id(contract_id: &str, index: usize, objective: &str) -> String {
 	format!("goal:{}:{:02}-{}", stable_slug(contract_id, 32), index + 1, stable_slug(objective, 32))
-}
-
-fn goal_issue_title(objective: &str) -> String {
-	let objective = objective.trim();
-
-	if objective.chars().count() <= 120 {
-		return objective.to_owned();
-	}
-
-	let mut title = objective.chars().take(117).collect::<String>();
-
-	title.push_str("...");
-
-	title
 }
 
 fn stable_slug(value: &str, max_len: usize) -> String {
@@ -1969,19 +1996,16 @@ mod tests {
 		assert_eq!(report.issues.len(), 2);
 		assert_eq!(report.issues[0].action, GoalIntakeIssueAction::WouldCreate);
 		assert_eq!(report.issues[0].dependencies, Vec::<String>::new());
-		assert_eq!(
-			report.issues[0].conflict_domains,
-			vec![String::from("file:docs/spec/loop-runtime.md"), String::from("module:runtime"),]
-		);
+		assert_eq!(report.issues[0].conflict_domains, vec![String::from("module:runtime")]);
+		assert_eq!(report.issues[1].dependencies, vec![String::from("goal-intake-runtime")]);
 		assert_eq!(tracker.created_issue_count(), 0);
 		assert!(store.list_execution_programs("decodex").expect("programs").is_empty());
 
 		let rendered = program_intake::render_goal_intake_report(&report);
 
 		assert!(rendered.contains("dependencies=none"));
-		assert!(
-			rendered.contains("conflict_domains=file:docs/spec/loop-runtime.md, module:runtime")
-		);
+		assert!(rendered.contains("conflict_domains=module:runtime"));
+		assert!(rendered.contains("dependencies=goal-intake-runtime"));
 	}
 
 	#[test]
@@ -2071,7 +2095,13 @@ mod tests {
 		assert_eq!(report.issues[0].action, GoalIntakeIssueAction::Updated);
 		assert_eq!(report.issues[1].action, GoalIntakeIssueAction::Created);
 		assert_eq!(report.issues[0].dispatch_action.as_deref(), Some("dispatch"));
-		assert_eq!(report.issues[1].dispatch_action.as_deref(), Some("dispatch"));
+		assert_eq!(report.issues[1].dispatch_action.as_deref(), None);
+		assert!(
+			report.issues[1]
+				.reasons
+				.iter()
+				.any(|reason| reason.contains("has not reached a required terminal state"))
+		);
 
 		let linked_contract = store
 			.decision_contract("decodex", "goal-intake-contract")
@@ -2118,11 +2148,19 @@ mod tests {
 		assert!(updated.description.contains("Source issue: `XY-852`"));
 		assert!(updated.description.contains("## Dependencies"));
 		assert!(updated.description.contains("## Acceptance"));
-		assert!(updated.description.contains(
-			"Deliver this generated issue objective: Implement goal intake CLI/API behavior."
-		));
+		assert!(
+			updated
+				.description
+				.contains("Goal intake dry-run renders generated issue briefs without mutation.")
+		);
 		assert!(updated.description.contains("## Validation"));
 		assert!(updated.description.contains("Run cargo make test before handoff."));
+		assert!(updated.description.contains("## Risk"));
+		assert!(
+			updated
+				.description
+				.contains("Generated issue descriptions must stay natural-language.")
+		);
 		assert!(updated.description.contains("## Stop Conditions"));
 		assert!(
 			updated
@@ -2358,16 +2396,54 @@ mod tests {
 				"risk_notes": [
 					"Generated issue descriptions must stay natural-language."
 				],
-				"proposed_issue_summaries": [
-					"Implement goal intake CLI/API behavior.",
-					"Persist Execution Program links for generated issues."
+				"proposed_issues": [
+					{
+						"key": "goal-intake-runtime",
+						"title": "Implement goal intake CLI/API behavior.",
+						"objective": "Implement goal intake CLI/API behavior.",
+						"stage": "runtime",
+						"dependencies": [],
+						"conflict_domains": [
+							"module:runtime"
+						],
+						"acceptance": [
+							"Goal intake dry-run renders generated issue briefs without mutation."
+						],
+						"validation": [
+							"Run cargo make test before handoff."
+						],
+						"risk": [
+							"Generated issue descriptions must stay natural-language."
+						],
+						"queue_intent": "ready_to_queue"
+					},
+					{
+						"key": "goal-intake-links",
+						"title": "Persist Execution Program links for generated issues.",
+						"objective": "Persist Execution Program links for generated issues.",
+						"stage": "runtime",
+						"dependencies": [
+							"goal-intake-runtime"
+						],
+						"conflict_domains": [
+							"module:runtime",
+							"file:docs/spec/loop-runtime.md"
+						],
+						"acceptance": [
+							"Apply links generated issue identifiers and execution nodes back to the accepted contract."
+						],
+						"validation": [
+							"Run cargo make test before handoff."
+						],
+						"risk": [
+							"Generated issue descriptions must stay natural-language."
+						],
+						"queue_intent": "ready_to_queue"
+					}
 				],
 				"conflict_domains": [
 					"module:runtime",
 					"file:docs/spec/loop-runtime.md"
-				],
-				"queue_intent": [
-					"ready_to_queue_after_apply"
 				]
 			},
 			"links": {

--- a/apps/decodex/src/research_design.rs
+++ b/apps/decodex/src/research_design.rs
@@ -14,6 +14,7 @@ use crate::{
 	config::ServiceConfig,
 	loop_contract::{
 		DecisionContract, DecisionContractStatus, DecisionPromotion, DecisionPromotionActorKind,
+		DecisionProposedIssue,
 	},
 	prelude::{Result, eyre},
 	runtime,
@@ -82,13 +83,11 @@ pub(crate) struct ResearchDesignRunInput {
 	#[serde(default)]
 	risk_notes: Vec<String>,
 	#[serde(default)]
-	proposed_issue_summaries: Vec<String>,
+	proposed_issues: Vec<ResearchProposedIssueInput>,
 	#[serde(default)]
 	promotion_targets: Vec<String>,
 	#[serde(default)]
 	conflict_domains: Vec<String>,
-	#[serde(default)]
-	queue_intent: Vec<String>,
 	#[serde(default)]
 	private_evidence_refs: Vec<ResearchPrivateEvidenceRefInput>,
 	#[serde(default)]
@@ -123,10 +122,9 @@ impl ResearchDesignRunInput {
 			readiness_summary: None,
 			validation_expectations: Vec::new(),
 			risk_notes: Vec::new(),
-			proposed_issue_summaries: Vec::new(),
+			proposed_issues: Vec::new(),
 			promotion_targets: Vec::new(),
 			conflict_domains: Vec::new(),
-			queue_intent: Vec::new(),
 			private_evidence_refs: Vec::new(),
 			public_projection_refs: Vec::new(),
 			public_summary: None,
@@ -233,6 +231,53 @@ impl ResearchSubworkInput {
 	}
 }
 
+/// Structured issue-shaping input emitted into Decision Contract readiness.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ResearchProposedIssueInput {
+	key: String,
+	title: String,
+	objective: String,
+	stage: String,
+	dependencies: Vec<String>,
+	conflict_domains: Vec<String>,
+	acceptance: Vec<String>,
+	validation: Vec<String>,
+	risk: Vec<String>,
+	queue_intent: String,
+}
+impl ResearchProposedIssueInput {
+	fn normalized(self) -> Result<Self> {
+		let issue = Self {
+			key: normalize_required_text("proposed_issues.key", self.key)?,
+			title: normalize_required_text("proposed_issues.title", self.title)?,
+			objective: normalize_required_text("proposed_issues.objective", self.objective)?,
+			stage: normalize_required_text("proposed_issues.stage", self.stage)?,
+			dependencies: normalize_text_list("proposed_issues.dependencies", self.dependencies)?,
+			conflict_domains: normalize_text_list(
+				"proposed_issues.conflict_domains",
+				self.conflict_domains,
+			)?,
+			acceptance: normalize_text_list("proposed_issues.acceptance", self.acceptance)?,
+			validation: normalize_text_list("proposed_issues.validation", self.validation)?,
+			risk: normalize_text_list("proposed_issues.risk", self.risk)?,
+			queue_intent: normalize_required_text(
+				"proposed_issues.queue_intent",
+				self.queue_intent,
+			)?,
+		};
+
+		if issue.acceptance.is_empty() {
+			eyre::bail!("proposed_issues.acceptance must include at least one item.");
+		}
+		if issue.validation.is_empty() {
+			eyre::bail!("proposed_issues.validation must include at least one item.");
+		}
+
+		Ok(issue)
+	}
+}
+
 /// Runtime-private evidence pointer retained inside the Decision Contract boundary.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -313,7 +358,7 @@ pub(crate) struct ResearchDesignRunReport {
 	pub(crate) feedback: String,
 	pub(crate) missing_decisions: Vec<String>,
 	pub(crate) blockers: Vec<String>,
-	pub(crate) proposed_issue_summaries: Vec<String>,
+	pub(crate) proposed_issues: Vec<DecisionProposedIssue>,
 	pub(crate) promotion_targets: Vec<String>,
 	pub(crate) conflict_domains: Vec<String>,
 	pub(crate) private_evidence_ref_count: usize,
@@ -335,10 +380,7 @@ impl ResearchDesignRunReport {
 			feedback: default_feedback(input.outcome).to_owned(),
 			missing_decisions: input.missing_decisions(),
 			blockers: input.blockers.clone(),
-			proposed_issue_summaries: contract
-				.execution_readiness()
-				.proposed_issue_summaries()
-				.to_vec(),
+			proposed_issues: contract.execution_readiness().proposed_issues().to_vec(),
 			promotion_targets: contract.execution_readiness().promotion_targets().to_vec(),
 			conflict_domains: contract.execution_readiness().conflict_domains().to_vec(),
 			private_evidence_ref_count: input.private_evidence_refs.len(),
@@ -392,10 +434,9 @@ struct NormalizedResearchDesignInput {
 	readiness_summary: String,
 	validation_expectations: Vec<String>,
 	risk_notes: Vec<String>,
-	proposed_issue_summaries: Vec<String>,
+	proposed_issues: Vec<ResearchProposedIssueInput>,
 	promotion_targets: Vec<String>,
 	conflict_domains: Vec<String>,
-	queue_intent: Vec<String>,
 	private_evidence_refs: Vec<ResearchPrivateEvidenceRefInput>,
 	public_projection_refs: Vec<ResearchPublicProjectionRefInput>,
 	public_summary: Option<String>,
@@ -457,13 +498,13 @@ impl NormalizedResearchDesignInput {
 				input.validation_expectations,
 			)?,
 			risk_notes: normalize_text_list("risk_notes", input.risk_notes)?,
-			proposed_issue_summaries: normalize_text_list(
-				"proposed_issue_summaries",
-				input.proposed_issue_summaries,
-			)?,
+			proposed_issues: input
+				.proposed_issues
+				.into_iter()
+				.map(ResearchProposedIssueInput::normalized)
+				.collect::<Result<Vec<_>>>()?,
 			promotion_targets: normalize_text_list("promotion_targets", input.promotion_targets)?,
 			conflict_domains: normalize_text_list("conflict_domains", input.conflict_domains)?,
-			queue_intent: normalize_text_list("queue_intent", input.queue_intent)?,
 			private_evidence_refs: input
 				.private_evidence_refs
 				.into_iter()
@@ -508,9 +549,9 @@ impl NormalizedResearchDesignInput {
 		if self.validation_expectations.is_empty() {
 			eyre::bail!("decision-ready research requires validation expectations.");
 		}
-		if self.proposed_issue_summaries.is_empty() {
+		if self.proposed_issues.is_empty() {
 			eyre::bail!(
-				"decision-ready research requires at least one proposed issue summary for downstream shaping."
+				"decision-ready research requires at least one structured proposed issue for downstream shaping."
 			);
 		}
 		if self.promotion_targets.is_empty() {
@@ -662,6 +703,12 @@ fn ensure_contract_authorizes_execution(record: &DecisionContractRecord) -> Resu
 			record.contract_id()
 		);
 	}
+	if record.contract().execution_readiness().proposed_issues().is_empty() {
+		eyre::bail!(
+			"Accepted research/design contract `{}` has no structured proposed issues.",
+			record.contract_id()
+		);
+	}
 
 	Ok(())
 }
@@ -711,10 +758,9 @@ fn build_decision_contract(
 			"missing_decisions": input.missing_decisions(),
 			"validation_expectations": input.validation_expectations,
 			"risk_notes": risk_notes(input),
-			"proposed_issue_summaries": input.proposed_issue_summaries,
+			"proposed_issues": input.proposed_issues,
 			"promotion_targets": input.promotion_targets,
 			"conflict_domains": input.conflict_domains,
-			"queue_intent": queue_intent(input),
 		},
 		"links": {
 			"generated_issue_ids": [],
@@ -865,17 +911,6 @@ fn risk_notes(input: &NormalizedResearchDesignInput) -> Vec<String> {
 	risk_notes
 }
 
-fn queue_intent(input: &NormalizedResearchDesignInput) -> Vec<String> {
-	if !input.queue_intent.is_empty() {
-		return input.queue_intent.clone();
-	}
-	if input.proposed_issue_summaries.is_empty() {
-		return Vec::new();
-	}
-
-	vec![String::from("Shape generated issues only after explicit Decision Contract promotion.")]
-}
-
 fn default_feedback(outcome: ResearchDesignOutcome) -> &'static str {
 	match outcome {
 		ResearchDesignOutcome::DecisionReady =>
@@ -958,8 +993,8 @@ mod tests {
 		loop_contract::{DecisionContractStatus, DecisionPromotion, DecisionPromotionActorKind},
 		research_design::{
 			self, ResearchDesignOutcome, ResearchDesignRunInput, ResearchEvidenceInput,
-			ResearchOptionInput, ResearchPrivateEvidenceRefInput, ResearchProvenanceInput,
-			ResearchPublicProjectionRefInput, ResearchSubworkInput,
+			ResearchOptionInput, ResearchPrivateEvidenceRefInput, ResearchProposedIssueInput,
+			ResearchProvenanceInput, ResearchPublicProjectionRefInput, ResearchSubworkInput,
 		},
 		state::StateStore,
 	};
@@ -979,7 +1014,7 @@ mod tests {
 				kind: String::from("repo_source"),
 				claim: String::from("Decision-ready research can shape downstream issues."),
 				support: String::from(
-					"The compiler carries objectives, validation expectations, and issue summaries.",
+					"The compiler carries objectives, validation expectations, and structured proposed issues.",
 				),
 				source_ref: Some(String::from("docs/spec/loop-runtime.md")),
 			}],
@@ -1013,12 +1048,26 @@ mod tests {
 			)),
 			validation_expectations: vec![String::from("Run the registered Decodex gate.")],
 			risk_notes: vec![String::from("Do not expose internal graph mechanics.")],
-			proposed_issue_summaries: vec![String::from(
-				"Wire natural-language research trigger into Decodex plugin surface.",
-			)],
+			proposed_issues: vec![ResearchProposedIssueInput {
+				key: String::from("research-trigger-plugin"),
+				title: String::from(
+					"Wire natural-language research trigger into Decodex plugin surface.",
+				),
+				objective: String::from(
+					"Wire natural-language research trigger into Decodex plugin surface.",
+				),
+				stage: String::from("plugin"),
+				dependencies: Vec::new(),
+				conflict_domains: vec![String::from("module:runtime")],
+				acceptance: vec![String::from(
+					"Natural-language research requests compile into latent Decision Contracts.",
+				)],
+				validation: vec![String::from("Run the registered Decodex gate.")],
+				risk: vec![String::from("Do not expose internal graph mechanics.")],
+				queue_intent: String::from("ready_to_queue"),
+			}],
 			promotion_targets: vec![String::from("plugins/decodex/skills")],
 			conflict_domains: vec![String::from("runtime")],
-			queue_intent: Vec::new(),
 			private_evidence_refs: vec![ResearchPrivateEvidenceRefInput {
 				project_id: None,
 				issue_id: String::from("XY-860"),
@@ -1139,8 +1188,12 @@ mod tests {
 		assert_eq!(record.status(), DecisionContractStatus::DraftLatent);
 		assert_eq!(record.contract().research_options().len(), 1);
 		assert_eq!(
-			record.contract().execution_readiness().proposed_issue_summaries(),
-			&[String::from("Wire natural-language research trigger into Decodex plugin surface.")]
+			record.contract().execution_readiness().proposed_issues()[0].key(),
+			"research-trigger-plugin"
+		);
+		assert_eq!(
+			report.proposed_issues[0].title(),
+			"Wire natural-language research trigger into Decodex plugin surface."
 		);
 		assert_eq!(
 			record.contract().execution_readiness().promotion_targets(),
@@ -1164,7 +1217,7 @@ mod tests {
 		input.outcome = ResearchDesignOutcome::NotDecisionReady;
 
 		input.objectives.clear();
-		input.proposed_issue_summaries.clear();
+		input.proposed_issues.clear();
 
 		input.unresolved_decisions =
 			vec![String::from("Choose whether runtime or plugin UX owns first exposure.")];
@@ -1193,7 +1246,7 @@ mod tests {
 
 		blocked.objectives.clear();
 		blocked.evidence.clear();
-		blocked.proposed_issue_summaries.clear();
+		blocked.proposed_issues.clear();
 
 		let blocked_report = research_design::persist_research_design_run(
 			&StateStore::open_in_memory().expect("store should open"),
@@ -1214,7 +1267,7 @@ mod tests {
 
 		human.objectives.clear();
 		human.evidence.clear();
-		human.proposed_issue_summaries.clear();
+		human.proposed_issues.clear();
 
 		let human_report = research_design::persist_research_design_run(
 			&StateStore::open_in_memory().expect("store should open"),

--- a/apps/decodex/src/state/internal.rs
+++ b/apps/decodex/src/state/internal.rs
@@ -2166,9 +2166,9 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 		let rows = statement.query_map([], decision_contract_runtime_row_parts)?;
 
 		for row in rows {
-			let record = decision_contract_record_from_row_parts(row?)?;
-
-			state.decision_contracts.insert(record.key(), record);
+			if let Some(record) = maybe_decision_contract_record_from_row_parts(row?)? {
+				state.decision_contracts.insert(record.key(), record);
+			}
 		}
 
 		Ok(())
@@ -2215,7 +2215,9 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 		let mut records = Vec::new();
 
 		for row in rows {
-			records.push(decision_contract_record_from_row_parts(row?)?);
+			if let Some(record) = maybe_decision_contract_record_from_row_parts(row?)? {
+				records.push(record);
+			}
 		}
 
 		Ok(records)
@@ -2236,7 +2238,9 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 		let mut records = Vec::new();
 
 		for row in rows {
-			records.push(decision_contract_record_from_row_parts(row?)?);
+			if let Some(record) = maybe_decision_contract_record_from_row_parts(row?)? {
+				records.push(record);
+			}
 		}
 
 		Ok(records)
@@ -5220,6 +5224,42 @@ fn decision_contract_record_from_row_parts(
 		updated_at: parts.updated_at,
 		updated_at_unix: parts.updated_at_unix,
 	})
+}
+
+fn maybe_decision_contract_record_from_row_parts(
+	parts: DecisionContractRuntimeRowParts,
+) -> Result<Option<DecisionContractRuntimeRecord>> {
+	let has_removed_flat_issue_summaries =
+		decision_contract_payload_has_removed_flat_issue_summaries(&parts.payload_json);
+	let project_id = parts.project_id.clone();
+	let contract_id = parts.contract_id.clone();
+
+	match decision_contract_record_from_row_parts(parts) {
+		Ok(record) => Ok(Some(record)),
+		Err(error) if has_removed_flat_issue_summaries => {
+			tracing::warn!(
+				project_id = %project_id,
+				contract_id = %contract_id,
+				error = %error,
+				"skipping legacy Decision Contract row with removed proposed_issue_summaries field"
+			);
+
+			Ok(None)
+		},
+		Err(error) => Err(error),
+	}
+}
+
+fn decision_contract_payload_has_removed_flat_issue_summaries(payload_json: &str) -> bool {
+	serde_json::from_str::<Value>(payload_json)
+		.ok()
+		.and_then(|payload| {
+			payload
+				.get("execution_readiness")
+				.and_then(|readiness| readiness.get("proposed_issue_summaries"))
+				.map(|_| ())
+		})
+		.is_some()
 }
 
 fn execution_program_runtime_row_parts(

--- a/apps/decodex/src/state/tests.rs
+++ b/apps/decodex/src/state/tests.rs
@@ -3724,6 +3724,73 @@ fn decision_contract_reload_rejects_row_key_payload_mismatch() {
 }
 
 #[test]
+fn decision_contract_reload_skips_legacy_flat_issue_summary_rows() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+	let store = StateStore::open(&state_path).expect("state store should open");
+
+	store
+		.upsert_decision_contract("decodex", Some("XY-852"), latent_decision_contract_fixture())
+		.expect("current decision contract should persist");
+
+	let mut legacy_payload = serde_json::to_value(latent_decision_contract_fixture())
+		.expect("fixture should encode as JSON");
+	legacy_payload["contract_id"] = serde_json::json!("legacy-flat-issue-contract");
+	let readiness = legacy_payload
+		.get_mut("execution_readiness")
+		.expect("readiness should exist")
+		.as_object_mut()
+		.expect("readiness should be an object");
+
+	readiness.remove("proposed_issues");
+	readiness.insert(
+		String::from("proposed_issue_summaries"),
+		serde_json::json!(["Legacy flat summary that must not be compiled."]),
+	);
+
+	let connection = Connection::open(&state_path).expect("sqlite should open");
+
+	connection
+		.execute(
+			"INSERT INTO decision_contracts (
+					project_id, contract_id, source_issue_id, status, payload_json, created_at,
+					created_at_unix, updated_at, updated_at_unix
+				) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+			rusqlite::params![
+				"decodex",
+				"legacy-flat-issue-contract",
+				"XY-OLD",
+				"draft_latent",
+				serde_json::to_string(&legacy_payload).expect("legacy payload should serialize"),
+				"2026-06-17T00:00:00Z",
+				1_i64,
+				"2026-06-17T00:00:00Z",
+				1_i64,
+			],
+		)
+		.expect("legacy decision contract row should insert");
+
+	let reopened = StateStore::open(&state_path)
+		.expect("legacy flat issue summary row should not block state reload");
+	let project_contracts = reopened
+		.list_decision_contracts_for_project("decodex")
+		.expect("project contracts should list");
+
+	assert_eq!(project_contracts.len(), 1);
+	assert_eq!(project_contracts[0].contract_id(), "research-x-loop-contract");
+	assert!(
+		reopened
+			.list_decision_contracts_for_issue("decodex", "XY-OLD")
+			.expect("legacy issue contracts should list as empty")
+			.is_empty()
+	);
+	assert!(
+		reopened.decision_contract("decodex", "legacy-flat-issue-contract").is_err(),
+		"direct legacy contract reads must still fail closed"
+	);
+}
+
+#[test]
 fn state_store_open_refreshes_pubfi_project_registry_across_instances() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let state_path = temp_dir.path().join("runtime.db");

--- a/docs/log.md
+++ b/docs/log.md
@@ -47,5 +47,7 @@
 - Clarified the Program Intake public/private boundary so generated Linear issue
   descriptions omit internal Program and node identifiers while SQLite/operator
   readback keeps private mappings.
+- Replaced Decision Contract flat issue summaries with structured
+  `execution_readiness.proposed_issues[]` as the only issue-shaping input.
 - Standardized `OKF` as the all-caps prose form while preserving lowercase `okf` for
   filenames, paths, skill IDs, tags, and URLs.

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -118,12 +118,12 @@ returns a bounded outcome: `decision_ready`, `not_decision_ready`, `blocked`, or
 `needs_human_decision`. Decodex research first probes the decision, records evidence,
 compares options, forms a challenge-ready judgment, resolves or preserves skeptic
 objections, and only then chooses the outcome. It may retain private evidence
-references, option comparisons, proposed issue summaries, conflict domains, and
+references, option comparisons, structured proposed issues, conflict domains, and
 dispatch intent for later issue shaping, but it does not enqueue issues, mutate Linear
 state, set goals, or start lane execution. `research promote` records the accepted
 boundary for an existing contract; later issue generation or Execution Program
-readiness must consume the promoted contract instead of treating a research summary as
-authority.
+readiness must consume the promoted contract's structured `proposed_issues[]` instead
+of treating a research summary as authority.
 
 Lane inspect and interrupt are local control APIs, not dashboard UI actions:
 

--- a/docs/spec/loop-runtime.md
+++ b/docs/spec/loop-runtime.md
@@ -140,7 +140,7 @@ The payload carries these top-level fields:
 | `research_evidence` | Non-authoritative evidence claims retained for later review and issue shaping. Each item carries `kind`, `claim`, `support`, and optional `source_ref`; `kind` identifies whether the support is an external source, repository source, live readback, inference, or unresolved gap. |
 | `research_options` | Non-authoritative option comparisons retained with tradeoffs, selected decision notes, or rejected-option reasons. |
 | `accepted_authority` | Objectives, non-goals, constraints, assumptions, objections, and stop conditions that become authority only when status is `accepted_promoted`. |
-| `execution_readiness` | Natural-language readiness summary, missing decisions, validation expectations, risk notes, proposed issue summaries, promotion targets, conflict domains, and dispatch intent. It must not expose graph ids or require the user to operate a DAG. Accepted contracts must be ready for issue shaping and must not carry unresolved missing decisions. |
+| `execution_readiness` | Natural-language readiness summary, missing decisions, validation expectations, risk notes, structured `proposed_issues[]`, promotion targets, and conflict domains. It must not expose graph ids or require the user to operate a DAG. Accepted contracts must be ready for issue shaping, include structured proposed issues, and must not carry unresolved missing decisions. |
 | `promotion` | Metadata recording who or what accepted the decision, the acceptance source, and the acceptance time. Required only for `accepted_promoted`. |
 | `links` | Generated Linear issue ids/identifiers or internal Execution Program node ids when those exist. |
 | `evidence_boundary` | Local private evidence references and sparse public projection references. |
@@ -152,8 +152,9 @@ The status is the authority boundary:
 - `accepted_promoted` means the payload's `accepted_authority` fields may be used by
   the loop runtime to shape dispatch intent, generated issues, or internal Execution
   Program nodes. The payload must include promotion metadata, set
-  `execution_readiness.ready_for_issue_shaping = true`, and leave
-  `execution_readiness.missing_decisions` empty.
+  `execution_readiness.ready_for_issue_shaping = true`, include non-empty
+  `execution_readiness.proposed_issues[]`, and leave `execution_readiness.missing_decisions`
+  empty.
 - `rejected_superseded` means the payload is retained for audit/history but must not
   be promoted later.
 - `needs_human_decision` means the package is incomplete or contradictory enough that
@@ -163,6 +164,14 @@ The status is the authority boundary:
 Research provenance and research evidence are not execution authority. They explain
 why the candidate package exists and give future agents enough context to avoid asking
 the user to restate all details after promotion.
+
+`execution_readiness.proposed_issues[]` is the only issue-shaping input for promoted
+Decision Contracts. The former flat `proposed_issue_summaries` field is removed, not
+deprecated, and runtimes must not compile issues from it. Each proposed issue carries
+`key`, `title`, `objective`, `stage`, `dependencies`, `conflict_domains`,
+`acceptance`, `validation`, `risk`, and `queue_intent`. Accepted contracts without at
+least one structured proposed issue fail readiness validation and cannot be
+materialized for goal intake or Program Intake.
 
 Decision Contracts are top-level snapshots. Terminal status, selected option, material
 evidence, unresolved gaps, validation expectations, and promotion target must be
@@ -400,7 +409,7 @@ natural-language issue brief and does not include those internal ids. Apply must
 run implementation inline and
 must not apply or remove `decodex:queued:<service-id>`; the persisted Program is then
 eligible for direct scheduler dispatch. If the contract is latent, rejected, still needs a human
-decision, carries unresolved missing decisions, or lacks proposed issue summaries,
+decision, carries unresolved missing decisions, or lacks structured `proposed_issues`,
 goal intake stops before creating executable work.
 
 The operator CLI surface for existing issues is

--- a/plugins/decodex/references/research-promotion.md
+++ b/plugins/decodex/references/research-promotion.md
@@ -11,7 +11,7 @@ Before promotion:
 
 - identify the accepted contract
 - preserve objectives, non-goals, constraints, assumptions, objections, validation
-  expectations, issue summaries, and stop conditions
+  expectations, structured proposed issues, and stop conditions
 - refuse promotion while unresolved decisions, evidence gaps, or blockers remain
 
 ## Durable Lanes
@@ -36,4 +36,3 @@ companion execution surfaces, not `promotes_to` lanes.
 
 After promotion, route accepted execution work to `planning`. Program Intake may then
 persist Execution Program readiness and dispatch ready mapped nodes directly.
-

--- a/plugins/decodex/references/routing.md
+++ b/plugins/decodex/references/routing.md
@@ -38,7 +38,8 @@ Keep Decodex natural-language-first. Requests such as `research X` route through
 Research never queues work, mutates Linear, starts implementation, creates Codex
 goals, or dispatches Program nodes. Promotion preserves accepted objectives,
 non-goals, constraints, assumptions, objections, validation expectations, proposed
-issue summaries, and stop conditions. Program Intake dispatches ready mapped nodes directly from the persisted DAG; queue labels are not the Program scheduler.
+issues, and stop conditions. Program Intake dispatches ready mapped nodes directly
+from the persisted DAG; queue labels are not the Program scheduler.
 
 ## Program Versus Label Intake
 

--- a/plugins/decodex/skills/research-promote/SKILL.md
+++ b/plugins/decodex/skills/research-promote/SKILL.md
@@ -11,7 +11,7 @@ rules.
 
 - Identify the accepted contract or conversational contract.
 - Preserve objectives, non-goals, constraints, assumptions, objections, validation,
-  issue summaries, and stop conditions.
+  structured proposed issues, and stop conditions.
 - Promote into the correct durable lane: `docs/spec`, `docs/runbook`,
   `docs/reference`, `docs/decisions`, `plugins/decodex/skills`, runtime code, tests,
   or explicit `no_promotion`.


### PR DESCRIPTION
## Summary
- replace Decision Contract `proposed_issue_summaries` with structured `proposed_issues[]`
- fail closed when accepted/promoted contracts lack structured proposed issues
- compile proposed issue stage, dependencies, conflict domains, risk, validation, and queue intent into goal-intake issue plans and Program nodes
- update fixtures, runtime docs, and Decodex plugin research-promotion references

## Validation
- `cargo make fmt`
- `cargo make fmt-check`
- `cargo make lint-fix`
- `cargo make docs-check`
- `cargo make test` (1200 passed, 1 skipped)
- `node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex --format markdown` (95/A, existing deferred token budget warning)

Refs XY-974, XY-975.