### PR TITLE
Keep status readback from failing on legacy Decision Contracts

### DIFF
--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -780,7 +780,8 @@ fn operator_execution_program_statuses(
 
 		let program = record.program().clone().with_nodes(nodes)?;
 		let evaluation = if let Some(source_contract_id) = record.source_contract_id() {
-			let Some(contract) = state_store.decision_contract(project.service_id(), source_contract_id)?
+			let Some(contract) =
+				state_store.decision_contract_for_readback(project.service_id(), source_contract_id)?
 			else {
 				statuses.push(OperatorExecutionProgramStatus::missing_contract(&record));
 

--- a/apps/decodex/src/orchestrator/tests/operator/status/text.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/text.rs
@@ -653,6 +653,84 @@ fn operator_status_json_surfaces_missing_contract_program_recovery() {
 	assert!(program_json.get("decision_contract").is_none());
 }
 
+#[test]
+fn operator_status_readback_quarantines_legacy_flat_decision_contracts() {
+	let (temp_dir, config, workflow) = temp_project_layout();
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+	let state_store = StateStore::open(&state_path).expect("state store should open");
+	let contract = accepted_status_decision_contract_fixture();
+	let program = ExecutionProgram::from_accepted_contract(
+		"program-legacy-flat-contract",
+		config.service_id(),
+		&contract,
+		vec![status_program_node(
+			"node-legacy-flat",
+			"issue-legacy-flat",
+			"PUB-947",
+			"Todo",
+			ExecutionQueueIntent::ReadyToQueue,
+		)],
+	)
+	.expect("program should build");
+
+	state_store
+		.upsert_execution_program(config.service_id(), program)
+		.expect("program should persist");
+
+	let mut legacy_payload = serde_json::to_value(&contract).expect("contract should encode as JSON");
+	let readiness = legacy_payload
+		.get_mut("execution_readiness")
+		.expect("readiness should exist")
+		.as_object_mut()
+		.expect("readiness should be an object");
+
+	readiness.remove("proposed_issues");
+	readiness.insert(
+		String::from("proposed_issue_summaries"),
+		serde_json::json!(["Legacy flat summary that must not be re-admitted."]),
+	);
+
+	{
+		let connection = rusqlite::Connection::open(&state_path).expect("sqlite should open");
+
+		connection
+			.execute(
+				"INSERT INTO decision_contracts (
+						project_id, contract_id, source_issue_id, status, payload_json, created_at,
+						created_at_unix, updated_at, updated_at_unix
+					) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+				rusqlite::params![
+					config.service_id(),
+					contract.contract_id(),
+					"PUB-947",
+					contract.status().as_str(),
+					serde_json::to_string(&legacy_payload).expect("legacy payload should serialize"),
+					"2026-06-17T00:00:00Z",
+					1_i64,
+					"2026-06-17T00:00:00Z",
+					1_i64,
+				],
+			)
+			.expect("legacy decision contract row should insert");
+	}
+
+	assert!(
+		state_store
+			.decision_contract(config.service_id(), contract.contract_id())
+			.is_err(),
+		"execution-facing legacy contract reads must still fail closed"
+	);
+
+	let snapshot = build_program_readback_snapshot(&config, &workflow, &state_store);
+	let program = snapshot.execution_programs.first().expect("program should surface");
+
+	assert_eq!(program.program_id, "program-legacy-flat-contract");
+	assert_eq!(program.status, "stale");
+	assert_eq!(program.readback_warning.as_deref(), Some("source_decision_contract_missing"));
+	assert_eq!(program.stale_count, 1);
+	assert_eq!(program.mapped_issue_identifiers, vec![String::from("PUB-947")]);
+}
+
 fn status_program_node(
 	node_id: &str,
 	issue_id: &str,

--- a/apps/decodex/src/state/internal.rs
+++ b/apps/decodex/src/state/internal.rs
@@ -2196,6 +2196,30 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 			.transpose()
 	}
 
+	fn decision_contract_for_readback(
+		&self,
+		project_id: &str,
+		contract_id: &str,
+	) -> Result<Option<DecisionContractRuntimeRecord>> {
+		let mut statement = self.connection.prepare(
+			"SELECT project_id, contract_id, source_issue_id, status, payload_json, created_at, \
+			 created_at_unix, updated_at, updated_at_unix \
+			 FROM decision_contracts \
+			 WHERE project_id = ?1 AND contract_id = ?2 \
+			 LIMIT 1",
+		)?;
+		let mut rows = statement.query(params![project_id, contract_id])?;
+		let Some(parts) = rows
+			.next()?
+			.map(decision_contract_runtime_row_parts)
+			.transpose()?
+		else {
+			return Ok(None);
+		};
+
+		maybe_decision_contract_record_from_row_parts(parts)
+	}
+
 	fn list_decision_contracts_for_issue(
 		&self,
 		project_id: &str,

--- a/apps/decodex/src/state/store.rs
+++ b/apps/decodex/src/state/store.rs
@@ -1977,6 +1977,34 @@ impl StateStore {
 			.map(DecisionContractRuntimeRecord::as_public))
 	}
 
+	/// Read one local Loop/Decision Contract for operator readback only.
+	///
+	/// Readback treats quarantined legacy contract payloads as absent so status surfaces can
+	/// report stale Program recovery without re-admitting removed contract shapes into execution.
+	pub(crate) fn decision_contract_for_readback(
+		&self,
+		project_id: &str,
+		contract_id: &str,
+	) -> Result<Option<DecisionContractRecord>> {
+		validate_required_decision_contract_field("project_id", project_id)?;
+		validate_required_decision_contract_field("contract_id", contract_id)?;
+
+		if let Some(sqlite) = &self.sqlite {
+			let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
+
+			return sqlite
+				.decision_contract_for_readback(project_id, contract_id)
+				.map(|record| record.map(|record| record.as_public()));
+		}
+
+		let state = self.lock()?;
+
+		Ok(state
+			.decision_contracts
+			.get(&DecisionContractKey::new(project_id, contract_id))
+			.map(DecisionContractRuntimeRecord::as_public))
+	}
+
 	/// List local Loop/Decision Contracts sourced from one tracker issue.
 	#[allow(dead_code)]
 	pub(crate) fn list_decision_contracts_for_issue(


### PR DESCRIPTION
## Summary
- Add a status-readback-only Decision Contract lookup that quarantines legacy flat proposed_issue_summaries payloads as missing
- Keep execution-facing Decision Contract reads fail-closed
- Cover status readback for legacy flat contracts with a SQLite regression test

## Verification
- cargo make fmt-check
- cargo test -p decodex operator_status_readback_quarantines_legacy_flat_decision_contracts -- --nocapture
- cargo test -p decodex state::tests::decision_contract_reload_skips_legacy_flat_issue_summary_rows -- --nocapture
- cargo run -p decodex --bin decodex -- status --live --limit 20
- cargo make test