### PR TITLE
Add docs knowledge map and repo memory writer

### DIFF
--- a/apps/decodex/src/plugin_surface_tests.rs
+++ b/apps/decodex/src/plugin_surface_tests.rs
@@ -66,6 +66,14 @@ const OKF_MAINTAIN_AGENT_POLICY: &str = include_str!(concat!(
 	env!("CARGO_MANIFEST_DIR"),
 	"/../../plugins/decodex/skills/okf-maintain/agents/openai.yaml"
 ));
+const REPO_MEMORY_WRITER_SKILL: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/repo-memory-writer/SKILL.md"
+));
+const REPO_MEMORY_WRITER_AGENT_POLICY: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/repo-memory-writer/agents/openai.yaml"
+));
 const DOCS_SKILL: &str = include_str!(concat!(
 	env!("CARGO_MANIFEST_DIR"),
 	"/../../plugins/decodex/skills/docs/SKILL.md"
@@ -342,11 +350,15 @@ fn packaged_docs_skills_encode_okf_wiki_and_drift_boundaries() {
 
 #[test]
 fn packaged_okf_skills_preserve_portable_profile_boundary() {
-	let okf_surface =
-		format!("{OKF_SKILL}\n{OKF_QUERY_SKILL}\n{OKF_MAINTAIN_SKILL}\n{OKF_LAYER_REF}");
+	let okf_surface = format!(
+		"{OKF_SKILL}\n{OKF_QUERY_SKILL}\n{OKF_MAINTAIN_SKILL}\n{REPO_MEMORY_WRITER_SKILL}\n{OKF_LAYER_REF}"
+	);
 
 	assert_contains(&okf_surface, "portable OKF");
 	assert_contains(&okf_surface, "LLM Wiki");
+	assert_contains(&okf_surface, "repo-memory-writer");
+	assert_contains(&okf_surface, "source-backed repository knowledge");
+	assert_contains(&okf_surface, "The AI writes the concepts");
 	assert_contains(&okf_surface, "decodex okf init");
 	assert_contains(&okf_surface, "decodex okf check");
 	assert_contains(&okf_surface, "decodex okf find");
@@ -376,6 +388,7 @@ fn narrow_lifecycle_and_specialist_skills_are_explicit_only() {
 		OKF_AGENT_POLICY,
 		OKF_QUERY_AGENT_POLICY,
 		OKF_MAINTAIN_AGENT_POLICY,
+		REPO_MEMORY_WRITER_AGENT_POLICY,
 		DOCS_OKF_AGENT_POLICY,
 		DOCS_WIKI_AGENT_POLICY,
 		DOCS_DRIFT_AGENT_POLICY,

--- a/docs/evidence/decodex-plugin-eval.md
+++ b/docs/evidence/decodex-plugin-eval.md
@@ -1,13 +1,13 @@
 ---
 type: Evidence
 title: Decodex Plugin Eval
-description: Records plugin-eval results for the Decodex portable OKF, docs, and research skills.
+description: Records plugin-eval results for the Decodex portable OKF, repo-memory, docs, and research skills.
 status: active
 authority: evidence
 owner: docs
-tags: [plugin-eval, skills, docs, research, okf]
+tags: [plugin-eval, skills, docs, research, okf, repo-memory]
 source_refs: []
-code_refs: [plugins/decodex/.codex-plugin/plugin.json, plugins/decodex/references/okf-layer.md, plugins/decodex/skills/okf/SKILL.md, plugins/decodex/skills/okf-query/SKILL.md, plugins/decodex/skills/okf-maintain/SKILL.md, plugins/decodex/skills/docs/SKILL.md, plugins/decodex/skills/docs-okf/SKILL.md, plugins/decodex/skills/docs-wiki/SKILL.md, plugins/decodex/skills/docs-drift/SKILL.md, plugins/decodex/skills/research/SKILL.md]
+code_refs: [plugins/decodex/.codex-plugin/plugin.json, plugins/decodex/references/okf-layer.md, plugins/decodex/skills/okf/SKILL.md, plugins/decodex/skills/okf-query/SKILL.md, plugins/decodex/skills/okf-maintain/SKILL.md, plugins/decodex/skills/repo-memory-writer/SKILL.md, plugins/decodex/skills/docs/SKILL.md, plugins/decodex/skills/docs-okf/SKILL.md, plugins/decodex/skills/docs-wiki/SKILL.md, plugins/decodex/skills/docs-drift/SKILL.md, plugins/decodex/skills/research/SKILL.md]
 related: [../policy.md, ./docs-self-iteration.md]
 last_verified: 2026-06-17
 ---
@@ -15,10 +15,12 @@ last_verified: 2026-06-17
 # Decodex Plugin Eval
 
 Purpose: Preserve public-safe evidence that the Decodex plugin, portable OKF init and
-skill family, and docs skill family passed local plugin evaluation.
+skill family, repo-memory writer skill, and docs skill family passed local plugin
+evaluation.
 
-Read this when: You need proof that the OKF init/split, docs skill split, research
-skill split, and plugin invocation policy were evaluated before landing.
+Read this when: You need proof that the OKF init/split, repo-memory writer, docs skill
+split, research skill split, and plugin invocation policy were evaluated before
+landing.
 
 Not this document: A runtime benchmark, coverage report, or replacement for
 `plugin-eval` output.
@@ -32,6 +34,7 @@ node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/p
 node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/okf --format json
 node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/okf-query --format json
 node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/okf-maintain --format json
+node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/repo-memory-writer --format markdown
 node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/docs --format json
 node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/docs-okf --format json
 node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/docs-wiki --format json
@@ -46,6 +49,7 @@ node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/p
 | `plugins/decodex/skills/okf` | 100 | A | low | none |
 | `plugins/decodex/skills/okf-query` | 100 | A | low | none |
 | `plugins/decodex/skills/okf-maintain` | 100 | A | low | none |
+| `plugins/decodex/skills/repo-memory-writer` | 100 | A | low | none |
 | `plugins/decodex/skills/docs` | 100 | A | low | none |
 | `plugins/decodex/skills/docs-okf` | 100 | A | low | none |
 | `plugins/decodex/skills/docs-wiki` | 100 | A | low | none |
@@ -77,6 +81,7 @@ Explicit-only skills:
 - `okf`
 - `okf-maintain`
 - `okf-query`
+- `repo-memory-writer`
 - `research-challenge`
 - `research-decision`
 - `research-evidence`
@@ -89,4 +94,5 @@ Explicit-only skills:
 
 The evaluation is static plugin analysis, not a measured real-usage benchmark. It is
 sufficient for the skill/plugin change gate in this lane because plugin-eval reported
-no warning or failing checks after the OKF split and invocation-policy adjustment.
+no warning or failing checks after the OKF split, repo-memory writer addition, and
+invocation-policy adjustment.

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,9 @@ The split below is by question type, not by human-versus-agent audience.
   `plugins/decodex/skills/docs-drift/SKILL.md`
 - Need docs maintenance, OKF concepts, docs impact classification, or drift gate
   handling -> `plugins/decodex/skills/docs/SKILL.md` and `docs/policy.md`
+- Need the current docs knowledge map, OKF/LLM Wiki value evaluation, graph
+  maintenance anchors, or retrieval-quality observations ->
+  `docs/reference/docs-knowledge-map.md`
 - Need OKF concept schema, LLM Wiki routing, or drift audit details ->
   `plugins/decodex/skills/docs-okf/SKILL.md`,
   `plugins/decodex/skills/docs-wiki/SKILL.md`, and

--- a/docs/log.md
+++ b/docs/log.md
@@ -48,7 +48,8 @@
   than a promotion target.
 - Added `docs/evidence/index.md` for reusable public-safe proof concepts and durable
   semantic-drift audit evidence.
-- Recorded plugin-eval evidence for the Decodex plugin and new docs skill family.
+- Recorded plugin-eval evidence for the Decodex plugin, repo-memory writer, and new
+  docs skill family.
 - Clarified the Program Intake public/private boundary so generated Linear issue
   descriptions omit internal Program and node identifiers while SQLite/operator
   readback keeps private mappings.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-17
 
+- Added `docs/reference/docs-knowledge-map.md` to evaluate the practical OKF/LLM Wiki
+  value in this repository and connect specialized concepts back into the docs graph.
 - Added `docs/spec/okf-knowledge-layer.md` to separate portable OKF engine behavior,
   LLM Wiki graph/retrieval behavior, repository-memory anchors, and the strict
   Decodex docs profile.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,9 @@
 
 ## 2026-06-17
 
+- Added the portable `repo-memory-writer` plugin skill so Codex can bootstrap or
+  improve source-backed repository memory through AI authoring plus OKF route, graph,
+  and profile validation.
 - Added `docs/reference/docs-knowledge-map.md` to evaluate the practical OKF/LLM Wiki
   value in this repository and connect specialized concepts back into the docs graph.
 - Added `docs/spec/okf-knowledge-layer.md` to separate portable OKF engine behavior,

--- a/docs/reference/docs-knowledge-map.md
+++ b/docs/reference/docs-knowledge-map.md
@@ -6,8 +6,8 @@ status: active
 authority: current_state
 owner: docs
 tags: [docs, okf, llm-wiki, repo-memory, reference]
-source_refs: [https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md, https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing]
-code_refs: [apps/decodex/src/docs_okf.rs, apps/decodex/src/cli.rs, docs/index.md, docs/policy.md, docs/spec/okf-knowledge-layer.md]
+source_refs: [https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md, https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing, https://llmstxt.org/, https://diataxis.fr/, https://developers.openai.com/codex/guides/agents-md, https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions]
+code_refs: [apps/decodex/src/docs_okf.rs, apps/decodex/src/cli.rs, docs/index.md, docs/policy.md, docs/spec/okf-knowledge-layer.md, plugins/decodex/skills/repo-memory-writer/SKILL.md]
 related: [../policy.md, ../spec/okf-knowledge-layer.md, ../evidence/docs-self-iteration.md, ./workspace-layout.md]
 drift_watch: [decodex docs check, decodex okf graph docs, decodex okf route docs, docs index, docs lane index, okf orphan concepts]
 last_verified: 2026-06-17
@@ -123,3 +123,16 @@ The combined value appears when both layers are used together:
 The remaining maintenance risk is graph decay: a concept can pass shape checks while
 still being hard to discover. Periodic `decodex okf graph docs` and targeted
 `decodex okf route docs "<intent>"` probes catch that class of issue.
+
+## Cross-Repository Use
+
+In another repository, the Decodex plugin can now provide three distinct layers:
+
+- `decodex okf init <root> --profile repo-memory` creates the portable scaffold.
+- `repo-memory-writer` guides Codex to read repository evidence and write canonical
+  concepts instead of generated summaries.
+- `decodex okf check/graph/route` verifies shape, graph health, and task routing.
+
+The expected first useful output is not a complete encyclopedia. It is a small,
+source-backed map of setup, tests, repository layout, automation resources, contracts,
+procedures, decisions, and drift-watch points that future agents can route through.

--- a/docs/reference/docs-knowledge-map.md
+++ b/docs/reference/docs-knowledge-map.md
@@ -1,0 +1,125 @@
+---
+type: Reference
+title: Docs Knowledge Map
+description: Explains how the Decodex docs bundle uses OKF and LLM Wiki routing, and where their value appears in this repository.
+status: active
+authority: current_state
+owner: docs
+tags: [docs, okf, llm-wiki, repo-memory, reference]
+source_refs: [https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md, https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing]
+code_refs: [apps/decodex/src/docs_okf.rs, apps/decodex/src/cli.rs, docs/index.md, docs/policy.md, docs/spec/okf-knowledge-layer.md]
+related: [../policy.md, ../spec/okf-knowledge-layer.md, ../evidence/docs-self-iteration.md, ./workspace-layout.md]
+drift_watch: [decodex docs check, decodex okf graph docs, decodex okf route docs, docs index, docs lane index, okf orphan concepts]
+last_verified: 2026-06-17
+---
+
+# Docs Knowledge Map
+
+Purpose: Explain how the repository docs currently apply OKF and LLM Wiki ideas, and
+where those ideas provide practical value during agent work.
+
+Read this when: You need to evaluate the docs knowledge-base shape, decide where to
+place a new durable docs claim, or understand why `docs/` uses OKF and LLM Wiki
+routing instead of ordinary prose-only documentation.
+
+Not this document: The normative OKF command/profile contract, the full documentation
+policy, or a step-by-step docs migration runbook.
+
+Covers: Current bundle shape, practical OKF value, practical LLM Wiki value, graph
+maintenance anchors, and retrieval-quality observations.
+
+## Current Bundle Shape
+
+`docs/` is one Markdown OKF bundle with a strict Decodex profile:
+
+- [`../index.md`](../index.md) is the progressive-disclosure entrypoint.
+- [`../policy.md`](../policy.md) owns the document contract, lane taxonomy, and
+  docs-impact gate.
+- [`../log.md`](../log.md) records maintenance events.
+- Lane indexes route by question type: spec, runbook, reference, decision, research,
+  and evidence.
+- Non-index, non-log Markdown files are typed concepts with frontmatter.
+
+This keeps repository knowledge inspectable as plain Markdown while still giving agents
+structured fields for routing, graph checks, and drift review.
+
+## OKF Value
+
+OKF provides the data contract for repository knowledge:
+
+- `type`, `description`, `tags`, `source_refs`, `code_refs`, `related`, and
+  `drift_watch` turn prose files into queryable concepts.
+- Profile checks separate portable knowledge-bundle validity from this repository's
+  stricter Decodex workflow policy.
+- `decodex docs check` blocks broken links, malformed references, missing required
+  concept fields, stale drift-audit structure, and non-Markdown docs artifacts.
+- `decodex okf init <root> --profile repo-memory` makes the same framework reusable in
+  another repository without inheriting Decodex-specific lane rules.
+
+The practical value is not that agents read more files. The value is that agents can
+read fewer, better-targeted files and still preserve source, code, and drift evidence
+when they update repository knowledge.
+
+## LLM Wiki Value
+
+The LLM Wiki layer is the retrieval and maintenance behavior on top of OKF:
+
+- `docs/index.md` and lane indexes answer "where should I look first?"
+- Markdown links and `related` frontmatter form a navigable concept graph.
+- `decodex okf route docs "<intent>"` gives a quick routing sanity check before a
+  broad read.
+- Duplicate claims are discouraged because each concept owns one topic and links to
+  neighbors instead of copying their claims.
+- Drift audits connect human-readable claims back to commands, code, and reusable
+  public-safe evidence.
+
+The practical value is reduced semantic drift: when a command, workflow, or docs
+boundary changes, the agent has an explicit owner concept, nearby evidence anchors,
+and a graph path to related concepts that may also need updates.
+
+## Graph Maintenance Anchors
+
+The current graph has some specialized concepts that are valid but easy to miss from a
+plain index scan. This map keeps them connected to the repository-memory graph:
+
+- Static site surface:
+  [`../spec/site-contract.md`](../spec/site-contract.md),
+  [`../decisions/static-public-site.md`](../decisions/static-public-site.md), and
+  [`../runbook/github-pages-deploy.md`](../runbook/github-pages-deploy.md).
+- Release and external maintenance:
+  [`../runbook/release-readiness.md`](../runbook/release-readiness.md),
+  [`../runbook/linear-archive-hygiene.md`](../runbook/linear-archive-hygiene.md), and
+  [`./github-operations.md`](./github-operations.md).
+- Repository quality inventory:
+  [`./test-suite.md`](./test-suite.md).
+- Plugin source ownership:
+  [`../decisions/decodex-plugin-source.md`](../decisions/decodex-plugin-source.md).
+- Local runtime handoff evidence:
+  [`../spec/agent-evidence.md`](../spec/agent-evidence.md).
+
+Those concepts should stay in their owning lanes. This map only provides a retrieval
+edge so graph-based readers can discover them without treating lane indexes as concept
+authority.
+
+Current readback: `decodex okf graph docs` reports 37 concepts, 105 edges, 0 broken
+links, and 0 orphan concepts.
+
+## Evaluation
+
+For this repository, OKF is most valuable as a validation and evidence schema. It makes
+docs changes testable, lets the CLI find malformed references before review, and
+creates a portable profile stack for other repos.
+
+LLM Wiki is most valuable as a routing discipline. It turns a growing docs tree into a
+task-directed graph so agents can start from the smallest relevant concept, follow
+explicit links, and avoid broad context loading.
+
+The combined value appears when both layers are used together:
+
+- OKF says whether a concept is well shaped.
+- LLM Wiki says whether the concept is discoverable and connected.
+- Drift audit says whether the concept is still true against code and command output.
+
+The remaining maintenance risk is graph decay: a concept can pass shape checks while
+still being hard to discover. Periodic `decodex okf graph docs` and targeted
+`decodex okf route docs "<intent>"` probes catch that class of issue.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -19,6 +19,9 @@ Question this index answers: "how is it currently organized or implemented?"
 
 ## Current reference docs
 
+- [`docs-knowledge-map.md`](./docs-knowledge-map.md) for the current OKF/LLM Wiki
+  knowledge-map shape, value evaluation, graph maintenance anchors, and retrieval
+  quality observations.
 - [`operator-control-plane.md`](./operator-control-plane.md) for the current
   single-machine control-plane shape, operator dashboard sections, local-vs-external
   state boundary, and deferred operator directions.

--- a/docs/spec/okf-knowledge-layer.md
+++ b/docs/spec/okf-knowledge-layer.md
@@ -6,8 +6,8 @@ status: active
 authority: normative
 owner: docs
 tags: [okf, llm-wiki, docs, repo-memory]
-source_refs: [https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md, https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing]
-code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/docs_okf.rs, plugins/decodex/references/okf-layer.md, plugins/decodex/skills/okf/SKILL.md, plugins/decodex/skills/okf-query/SKILL.md, plugins/decodex/skills/okf-maintain/SKILL.md, plugins/decodex/skills/docs/SKILL.md]
+source_refs: [https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md, https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing, https://developers.openai.com/codex/guides/agents-md, https://code.claude.com/docs/en/memory, https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions]
+code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/docs_okf.rs, plugins/decodex/references/okf-layer.md, plugins/decodex/skills/okf/SKILL.md, plugins/decodex/skills/okf-query/SKILL.md, plugins/decodex/skills/okf-maintain/SKILL.md, plugins/decodex/skills/repo-memory-writer/SKILL.md, plugins/decodex/skills/docs/SKILL.md]
 related: [../policy.md, ../reference/docs-knowledge-map.md, ../reference/research-concepts.md, ../evidence/decodex-plugin-eval.md]
 drift_watch: [decodex okf, decodex docs, docs check, docs lint, okf profile, docs alias, okf skill]
 last_verified: 2026-06-17
@@ -125,8 +125,10 @@ Portable OKF skills own cross-repository behavior:
 - maintain indexes and logs
 - route a task to the smallest relevant concepts
 
-The Decodex plugin exposes these portable skills as `okf`, `okf-query`, and
-`okf-maintain`.
+The Decodex plugin exposes these portable skills as `okf`, `okf-query`,
+`okf-maintain`, and `repo-memory-writer`. The first three operate the bundle surface;
+`repo-memory-writer` is the AI authoring workflow that reads repository evidence,
+writes canonical concepts, and proves route quality.
 
 Decodex docs skills are wrappers around those behaviors for this repository. They may
 apply Decodex profile constraints, but the portable OKF skill family must not depend

--- a/docs/spec/okf-knowledge-layer.md
+++ b/docs/spec/okf-knowledge-layer.md
@@ -8,7 +8,7 @@ owner: docs
 tags: [okf, llm-wiki, docs, repo-memory]
 source_refs: [https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md, https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing]
 code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/docs_okf.rs, plugins/decodex/references/okf-layer.md, plugins/decodex/skills/okf/SKILL.md, plugins/decodex/skills/okf-query/SKILL.md, plugins/decodex/skills/okf-maintain/SKILL.md, plugins/decodex/skills/docs/SKILL.md]
-related: [../policy.md, ../reference/research-concepts.md, ../evidence/decodex-plugin-eval.md]
+related: [../policy.md, ../reference/docs-knowledge-map.md, ../reference/research-concepts.md, ../evidence/decodex-plugin-eval.md]
 drift_watch: [decodex okf, decodex docs, docs check, docs lint, okf profile, docs alias, okf skill]
 last_verified: 2026-06-17
 ---

--- a/plugins/decodex/.codex-plugin/plugin.json
+++ b/plugins/decodex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "decodex",
   "version": "0.2.0",
-  "description": "Decodex agent workflows for portable OKF bundles, docs, research, issue planning, automation, commit, and landing.",
+  "description": "Decodex agent workflows for portable OKF bundles, repo memory, docs, research, issue planning, automation, commit, and landing.",
   "author": {
     "name": "hack-ink",
     "email": "hi@hack.ink",
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Decodex",
     "shortDescription": "Maintain docs, research, plan, and operate Decodex.",
-    "longDescription": "Routes portable OKF/LLM Wiki bundle work, Decodex OKF docs maintenance, docs drift audits, bounded research, promotion, issue briefing and planning, CLI, labels, commit, landing, and automation.",
+    "longDescription": "Routes portable OKF/LLM Wiki bundle work, source-backed repo-memory writing, Decodex OKF docs maintenance, docs drift audits, bounded research, promotion, issue briefing and planning, CLI, labels, commit, landing, and automation.",
     "developerName": "hack-ink",
     "category": "Development",
     "capabilities": [

--- a/plugins/decodex/references/issue-briefing.md
+++ b/plugins/decodex/references/issue-briefing.md
@@ -1,26 +1,24 @@
 # Decodex Issue Briefing Reference
 
-Use this reference when accepted Decodex work needs normal Linear issue briefs,
-existing issue-batch intake, or Program Intake readiness.
+Use this when accepted Decodex work needs Linear issue briefs, issue-batch intake, or
+Program Intake readiness.
 
 ## Authority
 
-Issue briefing is part of Decodex planning. It starts only after one of these
-authority sources exists:
+Issue briefing is part of planning. It starts only after one authority source exists:
 
 - an accepted and promoted Decision Contract
 - an explicit execution instruction whose scope is already bounded
 - a supplied batch of executable issue briefs for Program Intake
 
-The briefing is not a separate delivery workflow. Do not route Decodex issue
-briefing through an external delivery plugin, delivery handoff, or progress skill.
-Runtime progress, review handoff, landing, closeout, and recovery remain
-Decodex runtime surfaces.
+The briefing is not a delivery workflow. Do not route Decodex issue briefing through
+an external delivery plugin, delivery handoff, or progress skill. Runtime progress,
+review handoff, landing, closeout, and recovery stay Decodex runtime surfaces.
 
 ## Generic Dispatch Briefing
 
 Every Decodex-planned issue must be understandable by a generic implementation lane
-without replaying the originating chat or reading private runtime state.
+without replaying chat or private runtime state.
 
 Include:
 
@@ -35,16 +33,13 @@ Include:
 9. real dependencies, blockers, or conflict domains
 10. dispatch notes needed for a cold-start agent
 
-Use concrete repository paths, commands, specs, runbooks, and project policy only
-when they exist. Do not invent modules, validation flows, tracker state, or runtime
-authority to make an issue sound complete.
+Use real paths, commands, specs, runbooks, and policy. Do not invent modules,
+validation, tracker state, or runtime authority.
 
 ## Splitting Rules
 
-Split accepted work only when one issue would be too broad for one retained lane.
-Split by real ownership boundary, validation surface, dependency, or conflict
-domain. Keep the issue set small enough that each issue can be started, reviewed,
-and validated independently.
+Split accepted work only when one issue is too broad for one lane. Split by real
+ownership boundary, validation surface, dependency, or conflict domain.
 
 Each child issue must carry its own generic dispatch briefing. Name ordering only
 when it is blocking. Do not expose internal graph ids, DAG edge editing, hidden goal
@@ -52,10 +47,9 @@ ids, or Program scheduler mechanics in the issue text.
 
 ## Existing Issue Intake
 
-For `decodex intake issues`, treat the supplied issue descriptions as the public
-briefing surface. If an issue is only a machine-readable block, private pointer, or
-thin title, it is missing the generic dispatch briefing and should remain held until
-the briefing is repaired.
+For `decodex intake issues`, issue descriptions are the public briefing surface. A
+machine-readable block, private pointer, or thin title is missing the generic
+dispatch briefing and should remain held until repaired.
 
 Do not use a progress checkpoint, review summary, PR body, or runtime event as a
 substitute for the issue briefing. Those surfaces can support evidence, but the

--- a/plugins/decodex/references/okf-layer.md
+++ b/plugins/decodex/references/okf-layer.md
@@ -1,6 +1,8 @@
 # Portable OKF Layer
 
 Use this for portable OKF bundles, LLM Wiki retrieval, and cross-repository memory.
+Use `repo-memory-writer` when the task is to create repository knowledge from code
+evidence, not merely maintain an existing bundle.
 
 ## Boundary
 

--- a/plugins/decodex/references/routing.md
+++ b/plugins/decodex/references/routing.md
@@ -1,24 +1,24 @@
 # Decodex Routing Reference
 
-Use this when a Decodex task crosses docs, research, promotion, planning, manual CLI,
-labels, retained automation, commit, or landing boundaries.
+Use this when a Decodex task crosses docs, research, promotion, planning, CLI,
+labels, automation, commit, or landing boundaries.
 
 ## Mode Map
 
-- Docs: use `docs` as the router. Use `docs-okf` for OKF shape, `docs-wiki` for LLM
-  Wiki routing, and `docs-drift` for claim/evidence audits. Docs impact
-  `research_required` switches to `research*`; checked-in `docs/research/` output is
-  latent supporting evidence, not execution authority.
+- Docs: use `docs` as the router. Use `docs-okf`, `docs-wiki`, and `docs-drift`
+  for shape, routing, and audits. Docs impact `research_required` switches to
+  `research*`; checked-in `docs/research/` is latent evidence.
 - Research/design: use `research` and phase skills. The compact loop is probe,
-  evidence, options, judgment, challenge, decision. A result is a latent Decision Contract candidate only.
+  evidence, options, judgment, challenge, decision. Results are latent Decision
+  Contract candidates only.
 - Promotion: use `research-promote` only after explicit acceptance such as "arrange
   this", "push this forward", "推进", or "做".
 - Planning: use `planning` after promotion or another explicit execution instruction.
-  Planning owns Decodex-native issue briefing and Program readiness.
-- Automation: use `automation` for Decodex-owned intake, retained lanes, review
-  handoff, repair, landing, closeout, cleanup, and operator recovery.
+  Planning owns issue briefing and Program readiness.
+- Automation: use `automation` for Decodex-owned intake, lanes, review handoff,
+  repair, landing, closeout, cleanup, and recovery.
 - Manual CLI: use `manual-cli` when a human drives status, registration, dry-run,
-  recovery inspection, commit, or land.
+  recovery inspection, commit, or landing.
 - Labels: use `labels` only for ordinary non-Program tracker intake and retained-lane
   ownership signals.
 
@@ -38,8 +38,9 @@ Keep Decodex natural-language-first. Requests such as `research X` route through
 Research never queues work, mutates Linear, starts implementation, creates Codex
 goals, or dispatches Program nodes. Promotion preserves accepted objectives,
 non-goals, constraints, assumptions, objections, validation expectations, proposed
-issues, and stop conditions. Program Intake dispatches ready mapped nodes directly
-from the persisted DAG; queue labels are not the Program scheduler.
+issues, and stop conditions. A result is a latent Decision Contract
+candidate only. Program Intake dispatches ready mapped nodes directly from the
+persisted DAG; queue labels are not the Program scheduler.
 
 ## Program Versus Label Intake
 
@@ -54,8 +55,8 @@ from the persisted DAG; queue labels are not the Program scheduler.
 
 ## Commit And Land
 
-For human-driven commits, inspect the diff, stage only intended files, run touched
-surface validation, then use `decodex commit "<summary>"` or
+For human-driven commits, inspect the diff, stage intended files, run touched-surface
+validation, then use `decodex commit "<summary>"` or
 `decodex commit --manual-authority "<summary>"` for deliberate non-issue work.
 
 For human-driven PR landing, confirm PR/base/head/mergeability/checks, then use

--- a/plugins/decodex/skills/okf-maintain/SKILL.md
+++ b/plugins/decodex/skills/okf-maintain/SKILL.md
@@ -6,6 +6,8 @@ description: Use when creating or updating OKF/LLM Wiki concepts, indexes, logs,
 # OKF Maintain
 
 Produce and maintain OKF bundles without coupling them to Decodex-specific policy.
+For bootstrapping high-quality repository memory from code evidence, use
+`repo-memory-writer` first.
 
 Read `../../references/okf-layer.md` before creating concepts, moving files, or
 repairing graph quality.

--- a/plugins/decodex/skills/repo-memory-writer/SKILL.md
+++ b/plugins/decodex/skills/repo-memory-writer/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: repo-memory-writer
+description: Use when bootstrapping or improving source-backed repo-memory OKF/LLM Wiki knowledge for a code repository, including create repo knowledge, organize repo docs, make this repo an LLM wiki, or bootstrap OKF for another repo.
+---
+
+# Repo Memory Writer
+
+Build source-backed repository knowledge. The AI writes the concepts; `decodex okf`
+only scaffolds, checks, routes, and graphs them.
+
+Operating rules:
+
+- Treat repository memory like persistent project guidance: concise, specific,
+  broadly reusable, and scoped close to the work.
+- Treat OKF as a portable Markdown/YAML exchange format, not a platform runtime.
+- Treat LLM Wiki routing as progressive disclosure: small entrypoints point to
+  detailed canonical concepts.
+- For this repository's strict `docs/` profile, use the Decodex `docs-*` skills
+  after this skill identifies the repo-memory shape.
+
+Workflow:
+
+1. Identify the target root and profile. For a new portable bundle, run
+   `decodex okf init <root> --profile repo-memory`.
+2. Probe evidence before writing: README, `AGENTS.md` or project instructions,
+   package/build manifests, CI, task runners, entrypoints, config, tests, docs
+   indexes, and recent command output when available.
+3. Write only claims backed by a checked file, command result, external source, or
+   explicit user statement. Put unknowns in the final answer, not durable docs.
+4. Prefer this first-pass concept set: `overview.md`,
+   `reference/workspace-layout.md`, `reference/build-test-run.md`,
+   `reference/automation-resources.md`, focused `spec/` files for real contracts,
+   `runbook/` files for executable procedures, and `decisions/` only for recorded
+   decisions.
+5. Keep each concept one-topic. Add `description`, useful `tags`, `source_refs`,
+   `code_refs`, `related`, and `drift_watch` only when they improve retrieval or
+   maintenance.
+6. Update `index.md` and `log.md`; link neighboring concepts instead of repeating
+   broad summaries.
+7. Validate with:
+
+   ```sh
+   decodex okf check <root> --profile repo-memory
+   decodex okf graph <root>
+   decodex okf route <root> "<representative task>"
+   ```
+
+   Pick route probes from likely user intents and revise until the owning concept is
+   a top result.
+
+Quality bar:
+
+- Good: a new agent can find setup, tests, architecture boundaries, automation
+  resources, and high-risk drift points without broad repo reading.
+- Bad: generated summaries, README duplication, unverified architecture claims,
+  orphan concepts, or knowledge that cannot answer a task intent.

--- a/plugins/decodex/skills/repo-memory-writer/agents/openai.yaml
+++ b/plugins/decodex/skills/repo-memory-writer/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Repo Memory Writer"
+  short_description: "Write source-backed repo-memory OKF"
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## Summary
- Add the explicit-only `repo-memory-writer` Decodex skill for source-backed repository memory authoring.
- Add the docs knowledge map concept and route/index updates for OKF/LLM Wiki maintenance.
- Update plugin eval evidence so the new repo-memory writer skill is covered by the plugin/skill evaluation gate.

## Current-main assessment
- Still useful after the latest main updates: current `main` has the OKF/docs profile and docs checks, but does not expose a focused repo-memory writer skill or durable docs knowledge-map routing surface.
- Rebased onto `main` at `01d3c88`; resolved the routing reference conflict by preserving current structured proposed-issues terminology.

## Validation
- `cargo make fmt-check`
- `cargo run -p decodex --bin decodex -- docs check`
- `cargo run -p decodex --bin decodex -- okf check docs --profile decodex`
- `cargo run -p decodex --bin decodex -- okf graph docs`
- `cargo run -p decodex --bin decodex -- okf route docs "bootstrap source-backed repo memory"`
- `cargo run -p decodex --bin decodex -- okf route docs "where should I update OKF repo memory writer guidance"`
- `cargo test -p decodex plugin_surface -- --nocapture`
- `python3 /Users/x/.codex/plugins/cache/hack-ink/playbook/0.3.0/scripts/semantic_drift_audit.py --repo . --rev main`
- `node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex --format markdown` -> 100/A, low risk, 0 fail/0 warn
- `node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/repo-memory-writer --format markdown` -> 100/A, low risk, 0 fail/0 warn