### PR TITLE
Stabilize current lane dashboard patching

### DIFF
--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -5381,11 +5381,15 @@
 			}
 
 			function runDetailKey(run) {
-				return `run:${run.run_id}:more-fields`;
+				return `${currentLaneRenderKey(run)}:more-fields`;
 			}
 
 			function currentLaneRenderKey(run) {
-				return `current-lane:${run.run_id || issueDisplayKey(run)}`;
+				const projectKey = run?.project_id || "unknown-project";
+				const issueKey =
+					canonicalIssueIdentityKey(run?.issue_id) ||
+					canonicalIssueIdentityKey(issueDisplayKey(run));
+				return `current-lane:${projectKey}:${issueKey || run?.run_id || "unknown"}`;
 			}
 
 			function detailsOpenAttribute(detailKey) {
@@ -5616,10 +5620,10 @@
 				}
 
 				syncElementAttributes(current, next);
-				patchChildNodes(current, next);
+				patchChildNodes(current, next, false);
 			}
 
-			function patchChildNodes(current, next) {
+			function patchChildNodes(current, next, animateInsertions = false) {
 				const currentChildren = [...current.childNodes];
 				const nextChildren = [...next.childNodes];
 				const keyedCurrent = new Map();
@@ -5656,7 +5660,9 @@
 					} else {
 						const clone = nextChild.cloneNode(true);
 						current.insertBefore(clone, cursor);
-						markStableListEnter(clone);
+						if (animateInsertions) {
+							markStableListEnter(clone);
+						}
 						used.add(clone);
 					}
 				}
@@ -5732,7 +5738,7 @@
 					? 0
 					: container.getBoundingClientRect().height;
 
-				patchChildNodes(container, template.content);
+				patchChildNodes(container, template.content, true);
 				animateStableListSize(container, startHeight);
 			}
 

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -294,10 +294,16 @@ fn operator_dashboard_patches_current_lane_cards_without_replacing_the_list() {
 	assert!(response.contains("function renderStableList(container, html)"));
 	assert!(response.contains("function animateStableListSize(container, startHeight)"));
 	assert!(response.contains("function markStableListEnter(node)"));
-	assert!(response.contains("function patchChildNodes(current, next)"));
+	assert!(response.contains("function patchChildNodes(current, next, animateInsertions = false)"));
 	assert!(response.contains("function currentLaneRenderKey(run)"));
+	assert!(response.contains(
+		"const issueKey =\n\t\t\t\t\tcanonicalIssueIdentityKey(run?.issue_id) ||\n\t\t\t\t\tcanonicalIssueIdentityKey(issueDisplayKey(run));"
+	));
 	assert!(response.contains("data-render-key=\"${escapeHtml(renderKey)}\""));
 	assert!(response.contains("renderStableList(\n\t\t\t\t\tnodes.currentLanes,"));
+	assert!(response.contains("patchChildNodes(container, template.content, true);"));
+	assert!(response.contains("patchChildNodes(current, next, false);"));
+	assert!(response.contains("if (animateInsertions) {\n\t\t\t\t\t\t\tmarkStableListEnter(clone);\n\t\t\t\t\t\t}"));
 	assert!(response.contains("markStableListEnter(clone);"));
 	assert!(response.contains("container.style.height = `${startHeight}px`;"));
 	assert!(response.contains(".is-list-entering"));


### PR DESCRIPTION
## Summary
- keep current-lane dashboard render keys stable across run_id churn by keying on project + canonical issue identity
- avoid applying list-entry animation while patching an existing current-lane card
- keep the detail-row key tied to the stable current-lane render key

## Current-main assessment
This is still useful on top of current `main` (`2e2eb67`). The current dashboard already has stable-list patching, but same-issue current lanes can still be treated as new cards when `run_id` changes, and nested patch insertions still receive entry animation. This branch narrows that behavior without touching Decodex runtime ownership or lane policy.

## Validation
- `git diff --check origin/main...HEAD`
- `cargo make fmt-check`
- `cargo test -p decodex operator_dashboard -- --nocapture`

No docs impact: this is dashboard DOM patching behavior covered by existing operator dashboard tests.