### PR TITLE
Separate read-only and fixing repo tasks

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -4,26 +4,25 @@
 # | task              | type      | cwd  |
 # | ----------------- | --------- | ---- |
 # | check             | composite |      |
+# | check-docs        | command   |      |
 # | check-node        | composite |      |
-# | check-node-build  | command   | site |
 # | check-node-types  | command   | site |
 # | check-rust        | command   |      |
-# | check-vstyle      | composite |      |
-# | check-vstyle-rust | command   |      |
 
 [tasks.check]
 clear = true
 workspace = false
 dependencies = [
-	"fmt-check",
-	"docs-check",
-	"check-rust",
+	"build",
+	"check-docs",
 	"check-node",
-	"check-vstyle",
+	"check-rust",
+	"fmt-check",
+	"lint",
 	"test",
 ]
 
-[tasks.docs-check]
+[tasks.check-docs]
 workspace = false
 command = "cargo"
 args = [
@@ -37,47 +36,10 @@ args = [
 	"lint",
 ]
 
-[tasks.check-rust]
-workspace = false
-command = "cargo"
-args = [
-	"clippy",
-	"--all-features",
-	"--all-targets",
-	"--workspace",
-	"--",
-	"-D",
-	"clippy::all",
-	"-D",
-	"clippy::too_many_lines",
-	"-D",
-	"clippy::unwrap_used",
-	"-D",
-	"clippy::use_self",
-	"-D",
-	"clippy::wildcard_imports",
-	"-D",
-	"missing-docs",
-	"-D",
-	"unused-crate-dependencies",
-	"-D",
-	"warnings",
-]
-
 [tasks.check-node]
 workspace = false
 dependencies = [
-	"check-node-build",
 	"check-node-types",
-]
-
-[tasks.check-node-build]
-workspace = false
-cwd = "site"
-command = "npm"
-args = [
-	"run",
-	"build",
 ]
 
 [tasks.check-node-types]
@@ -89,22 +51,36 @@ args = [
 	"check",
 ]
 
-[tasks.check-vstyle]
-workspace = false
-dependencies = [
-	"check-vstyle-rust",
-]
-
-[tasks.check-vstyle-rust]
+[tasks.check-rust]
 workspace = false
 command = "cargo"
 args = [
-	"vstyle",
-	"curate",
-	"--language",
-	"rust",
-	"--workspace",
+	"check",
 	"--all-features",
+	"--all-targets",
+	"--workspace",
+]
+
+# Build
+# | task       | type      | cwd  |
+# | ---------- | --------- | ---- |
+# | build      | composite |      |
+# | build-node | command   | site |
+
+[tasks.build]
+clear = true
+workspace = false
+dependencies = [
+	"build-node",
+]
+
+[tasks.build-node]
+workspace = false
+cwd = "site"
+command = "npm"
+args = [
+	"run",
+	"build",
 ]
 
 # Format
@@ -169,25 +145,73 @@ args = [
 ]
 
 # Lint
-# | task             | type      | cwd |
-# | ---------------- | --------- | --- |
-# | lint             | composite |     |
-# | lint-fix         | extend    |     |
-# | lint-rust        | command   |     |
-# | lint-vstyle      | composite |     |
-# | lint-vstyle-rust | command   |     |
+# | task              | type      | cwd |
+# | ----------------- | --------- | --- |
+# | lint              | composite |     |
+# | lint-rust         | command   |     |
+# | lint-vstyle-rust  | command   |     |
 
 [tasks.lint]
 workspace = false
 dependencies = [
 	"lint-rust",
-	"lint-vstyle",
+	"lint-vstyle-rust",
 ]
 
-[tasks.lint-fix]
-extend = "lint"
-
 [tasks.lint-rust]
+workspace = false
+command = "cargo"
+args = [
+	"clippy",
+	"--all-features",
+	"--all-targets",
+	"--workspace",
+	"--",
+	"-D",
+	"clippy::all",
+	"-D",
+	"clippy::too_many_lines",
+	"-D",
+	"clippy::unwrap_used",
+	"-D",
+	"clippy::use_self",
+	"-D",
+	"clippy::wildcard_imports",
+	"-D",
+	"missing-docs",
+	"-D",
+	"unused-crate-dependencies",
+	"-D",
+	"warnings",
+]
+
+[tasks.lint-vstyle-rust]
+workspace = false
+command = "cargo"
+args = [
+	"vstyle",
+	"curate",
+	"--language",
+	"rust",
+	"--workspace",
+	"--all-features",
+]
+
+# Fix
+# | task             | type      | cwd |
+# | ---------------- | --------- | --- |
+# | lint-fix         | composite |     |
+# | lint-rust-fix    | command   |     |
+# | lint-vstyle-fix  | command   |     |
+
+[tasks.lint-fix]
+workspace = false
+dependencies = [
+	"lint-rust-fix",
+	"lint-vstyle-fix",
+]
+
+[tasks.lint-rust-fix]
 workspace = false
 command = "cargo"
 args = [
@@ -216,13 +240,7 @@ args = [
 	"warnings",
 ]
 
-[tasks.lint-vstyle]
-workspace = false
-dependencies = [
-	"lint-vstyle-rust",
-]
-
-[tasks.lint-vstyle-rust]
+[tasks.lint-vstyle-fix]
 workspace = false
 command = "cargo"
 args = [

--- a/README.md
+++ b/README.md
@@ -302,13 +302,18 @@ Runtime checks follow the Decodex task structure:
 cargo make check
 cargo make fmt
 cargo make lint
+cargo make lint-fix
 cargo make test
 ```
 
-Node package checks are available separately:
+Use `lint` for the read-only lint gate and `lint-fix` for the canonicalizing lint
+path used by registered Decodex workflow gates.
+
+Node package type checks and builds are available separately:
 
 ```sh
 cargo make check-node
+cargo make build-node
 ```
 
 ## Workspace Layout

--- a/apps/decodex/src/orchestrator/tests.rs
+++ b/apps/decodex/src/orchestrator/tests.rs
@@ -16,6 +16,7 @@ use std::{
 };
 
 use color_eyre::{Report, eyre};
+use rusqlite::Connection;
 use tempfile::TempDir;
 use time::OffsetDateTime;
 
@@ -1339,7 +1340,7 @@ max_attempts = 3
 max_turns = 1
 max_retry_backoff_ms = 300000
 max_concurrent_agents = 1
-canonicalize_commands = ["cargo make fmt", "cargo make lint"]
+canonicalize_commands = ["cargo make fmt", "cargo make lint-fix"]
 verify_commands = ["cargo make check"]
 
 [execution.gate_profiles.config_subset]

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -1,5 +1,3 @@
-use rusqlite::Connection;
-
 #[test]
 fn failure_comments_use_repo_relative_worktree_paths() {
 	let (_temp_dir, config, _workflow) = temp_project_layout();

--- a/apps/decodex/src/orchestrator/tests/operator/status/text.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/text.rs
@@ -691,7 +691,7 @@ fn operator_status_readback_quarantines_legacy_flat_decision_contracts() {
 	);
 
 	{
-		let connection = rusqlite::Connection::open(&state_path).expect("sqlite should open");
+		let connection = Connection::open(&state_path).expect("sqlite should open");
 
 		connection
 			.execute(

--- a/apps/decodex/src/orchestrator/tests/runtime/repo_gate.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/repo_gate.rs
@@ -131,7 +131,7 @@ fn repo_gate_falls_back_to_full_gate_when_changed_file_classification_is_unavail
 		orchestrator::select_repo_gate_for_worktree(workflow.frontmatter().execution(), repo_root);
 
 	assert_eq!(selection.profile_name(), None);
-	assert_eq!(selection.canonicalize_commands(), ["cargo make fmt", "cargo make lint"]);
+	assert_eq!(selection.canonicalize_commands(), ["cargo make fmt", "cargo make lint-fix"]);
 	assert_eq!(selection.verify_commands(), ["cargo make check"]);
 }
 

--- a/apps/decodex/src/state/tests.rs
+++ b/apps/decodex/src/state/tests.rs
@@ -3735,7 +3735,9 @@ fn decision_contract_reload_skips_legacy_flat_issue_summary_rows() {
 
 	let mut legacy_payload = serde_json::to_value(latent_decision_contract_fixture())
 		.expect("fixture should encode as JSON");
+
 	legacy_payload["contract_id"] = serde_json::json!("legacy-flat-issue-contract");
+
 	let readiness = legacy_payload
 		.get_mut("execution_readiness")
 		.expect("readiness should exist")

--- a/docs/runbook/github-pages-deploy.md
+++ b/docs/runbook/github-pages-deploy.md
@@ -59,6 +59,7 @@ Before publication, validate the site from the repository root:
 
 ```bash
 cargo make check-node
+cargo make build-node
 ```
 
 The external Codex automation under `/Users/x/Documents/automations/decodex` owns

--- a/docs/runbook/self-dogfood-pilot.md
+++ b/docs/runbook/self-dogfood-pilot.md
@@ -845,6 +845,6 @@ cargo run -p decodex --bin decodex -- probe
 cargo run -p decodex --bin decodex -- project add ~/.codex/decodex/projects/decodex
 cargo run -p decodex --bin decodex -- run --dry-run
 cargo make fmt
-cargo make lint
+cargo make lint-fix
 cargo make check
 ```

--- a/docs/spec/workflow-file.md
+++ b/docs/spec/workflow-file.md
@@ -327,7 +327,7 @@ max_retry_backoff_ms = 300000
 max_concurrent_agents = 0
 canonicalize_commands = [
   "cargo make fmt",
-  "cargo make lint",
+  "cargo make lint-fix",
 ]
 verify_commands = [
   "cargo make check",


### PR DESCRIPTION
## Summary
- reorganize cargo-make tasks by Playbook action families
- separate Node build from Node type checks and Rust check from lint/fix behavior
- update docs and Decodex workflow fixtures to use lint-fix for canonicalization

## Verification
- cargo make check
- cargo make lint-fix
- git diff --check
- semantic drift audit