### PR TITLE
Use inline GitHub credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,14 @@ repair agents.
 
 `decodex maintenance prune` defaults to the same read-only report as
 `decodex maintenance prune --dry-run`. Add `--apply` to rotate
-oversized local logs and agent-evidence event streams, prune old backup files, compact
-old terminal-run protocol events after preserving their summary, and checkpoint the
-SQLite WAL. `decodex serve` also runs the auto-safe subset at startup and periodically
-while it is polling, including 14-day retention for rotated logs and agent-evidence
-event streams plus 14-day protocol-event compaction for terminal unowned runs after
-the compact summary is preserved. If the runtime database is busy or candidate
-detection fails, serve logs a warning and continues polling.
+oversized local logs and agent-evidence event streams, prune old backup files, delete
+legacy Git askpass helper files older than one day from registered project worktree
+roots, compact old terminal-run protocol events after preserving their summary, and
+checkpoint the SQLite WAL. `decodex serve` also runs the auto-safe subset at startup
+and periodically while it is polling, including 14-day retention for rotated logs and
+agent-evidence event streams plus 14-day protocol-event compaction for terminal
+unowned runs after the compact summary is preserved. If the runtime database is busy
+or candidate detection fails, serve logs a warning and continues polling.
 
 ## Static Site
 

--- a/apps/decodex/src/agent/json_rpc.rs
+++ b/apps/decodex/src/agent/json_rpc.rs
@@ -36,13 +36,11 @@ impl AppServerProcessEnv {
 	pub(crate) fn with_github_credentials(
 		github_token_env_var: String,
 		github_token: String,
-		git_askpass_path: PathBuf,
 	) -> Self {
 		Self {
 			git: GitCredentialEnvironment::with_github_credentials(
 				github_token_env_var,
 				github_token,
-				git_askpass_path,
 			),
 			codex_home_policy: AppServerCodexHomePolicy::SharedDefault,
 		}
@@ -51,14 +49,12 @@ impl AppServerProcessEnv {
 	pub(crate) fn with_github_credentials_and_signing_config(
 		github_token_env_var: String,
 		github_token: String,
-		git_askpass_path: PathBuf,
 		signing_config: GitSigningConfig,
 	) -> Self {
 		Self {
 			git: GitCredentialEnvironment::with_github_credentials_and_signing_config(
 				github_token_env_var,
 				github_token,
-				git_askpass_path,
 				signing_config,
 			),
 			codex_home_policy: AppServerCodexHomePolicy::SharedDefault,
@@ -835,7 +831,6 @@ mod tests {
 		let process_env = AppServerProcessEnv::with_github_credentials(
 			String::from("GITHUB_PAT_Y"),
 			String::from("ghp_test_token"),
-			PathBuf::from("/tmp/decodex-askpass.sh"),
 		);
 		let mut command = Command::new("codex");
 
@@ -858,29 +853,35 @@ mod tests {
 		assert_eq!(envs.get("GH_PROMPT_DISABLED").map(String::as_str), Some("1"));
 		assert_eq!(envs.get("GIT_TERMINAL_PROMPT").map(String::as_str), Some("0"));
 		assert_eq!(envs.get("GCM_INTERACTIVE").map(String::as_str), Some("never"));
-		assert_eq!(envs.get("GIT_ASKPASS").map(String::as_str), Some("/tmp/decodex-askpass.sh"));
-		assert_eq!(envs.get("GIT_CONFIG_COUNT").map(String::as_str), Some("10"));
+		assert!(!envs.contains_key("GIT_ASKPASS"));
+		assert_eq!(envs.get("GIT_CONFIG_COUNT").map(String::as_str), Some("11"));
 		assert_eq!(envs.get("GIT_CONFIG_KEY_0").map(String::as_str), Some("credential.helper"));
 		assert_eq!(envs.get("GIT_CONFIG_VALUE_0").map(String::as_str), Some(""));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_1").map(String::as_str), Some("credential.helper"));
+		assert!(
+			envs.get("GIT_CONFIG_VALUE_1").is_some_and(
+				|value| value.contains("github.com") && value.contains("x-access-token")
+			)
+		);
 		assert_eq!(
 			envs.get("GIT_CONFIG_KEY_2").map(String::as_str),
 			Some("url.https://github.com/.insteadOf")
 		);
-		assert_eq!(envs.get("GIT_CONFIG_VALUE_2").map(String::as_str), Some("git@github.com-x:"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_2").map(String::as_str), Some("git@github.com:"));
 		assert_eq!(
-			envs.get("GIT_CONFIG_KEY_6").map(String::as_str),
+			envs.get("GIT_CONFIG_KEY_7").map(String::as_str),
 			Some("url.https://github.com/.insteadOf")
 		);
 		assert_eq!(
-			envs.get("GIT_CONFIG_VALUE_6").map(String::as_str),
+			envs.get("GIT_CONFIG_VALUE_7").map(String::as_str),
 			Some("ssh://git@github.com-y/")
 		);
-		assert_eq!(envs.get("GIT_CONFIG_KEY_7").map(String::as_str), Some("commit.gpgsign"));
-		assert_eq!(envs.get("GIT_CONFIG_VALUE_7").map(String::as_str), Some("false"));
-		assert_eq!(envs.get("GIT_CONFIG_KEY_8").map(String::as_str), Some("tag.gpgsign"));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_8").map(String::as_str), Some("commit.gpgsign"));
 		assert_eq!(envs.get("GIT_CONFIG_VALUE_8").map(String::as_str), Some("false"));
-		assert_eq!(envs.get("GIT_CONFIG_KEY_9").map(String::as_str), Some("user.signingkey"));
-		assert_eq!(envs.get("GIT_CONFIG_VALUE_9").map(String::as_str), Some(""));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_9").map(String::as_str), Some("tag.gpgsign"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_9").map(String::as_str), Some("false"));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_10").map(String::as_str), Some("user.signingkey"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_10").map(String::as_str), Some(""));
 	}
 
 	#[test]

--- a/apps/decodex/src/default_branch_sync.rs
+++ b/apps/decodex/src/default_branch_sync.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeSet, path::Path, process::Command};
 
 use crate::{
-	git_credentials::{GitAskpassGuard, GitCredentialEnvironment, GitCredentialSource},
+	git_credentials::{GitCredentialEnvironment, GitCredentialSource},
 	prelude::{Result, eyre},
 };
 
@@ -10,7 +10,7 @@ pub(crate) fn sync_repo_root_default_branch(
 	default_branch: &str,
 	credentials: Option<GitCredentialSource<'_>>,
 ) -> Result<()> {
-	let (git_env, _askpass_guard) = materialize_git_credentials(credentials)?;
+	let git_env = materialize_git_credentials(credentials);
 
 	preflight_repo_root_default_branch_sync_with_env(repo_root, default_branch, &git_env)?;
 
@@ -22,7 +22,7 @@ pub(crate) fn preflight_repo_root_default_branch_sync(
 	default_branch: &str,
 	credentials: Option<GitCredentialSource<'_>>,
 ) -> Result<()> {
-	let (git_env, _askpass_guard) = materialize_git_credentials(credentials)?;
+	let git_env = materialize_git_credentials(credentials);
 
 	preflight_repo_root_default_branch_sync_with_env(repo_root, default_branch, &git_env)
 }
@@ -234,13 +234,12 @@ fn build_git_command(cwd: &Path, args: &[&str], git_env: &GitCredentialEnvironme
 
 fn materialize_git_credentials(
 	credentials: Option<GitCredentialSource<'_>>,
-) -> Result<(GitCredentialEnvironment, Option<GitAskpassGuard>)> {
+) -> GitCredentialEnvironment {
 	let Some(credentials) = credentials else {
-		return Ok((GitCredentialEnvironment::default(), None));
+		return GitCredentialEnvironment::default();
 	};
-	let (git_env, askpass_guard) = credentials.materialize_github_askpass("default-branch-sync")?;
 
-	Ok((git_env, Some(askpass_guard)))
+	credentials.materialize_github_credentials()
 }
 
 #[cfg(test)]
@@ -346,7 +345,6 @@ mod tests {
 		let git_env = GitCredentialEnvironment::with_github_credentials(
 			String::from("GITHUB_PAT_Y"),
 			String::from("ghp_test_token"),
-			PathBuf::from("/tmp/decodex-default-branch-askpass.sh"),
 		);
 		let command = default_branch_sync::build_git_command(
 			Path::new("/repo"),
@@ -372,24 +370,27 @@ mod tests {
 		assert_eq!(envs.get("GH_PROMPT_DISABLED").map(String::as_str), Some("1"));
 		assert_eq!(envs.get("GIT_TERMINAL_PROMPT").map(String::as_str), Some("0"));
 		assert_eq!(envs.get("GCM_INTERACTIVE").map(String::as_str), Some("never"));
-		assert_eq!(
-			envs.get("GIT_ASKPASS").map(String::as_str),
-			Some("/tmp/decodex-default-branch-askpass.sh")
-		);
-		assert_eq!(envs.get("GIT_CONFIG_COUNT").map(String::as_str), Some("10"));
+		assert!(!envs.contains_key("GIT_ASKPASS"));
+		assert_eq!(envs.get("GIT_CONFIG_COUNT").map(String::as_str), Some("11"));
 		assert_eq!(envs.get("GIT_CONFIG_KEY_0").map(String::as_str), Some("credential.helper"));
 		assert_eq!(envs.get("GIT_CONFIG_VALUE_0").map(String::as_str), Some(""));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_1").map(String::as_str), Some("credential.helper"));
+		assert!(
+			envs.get("GIT_CONFIG_VALUE_1").is_some_and(
+				|value| value.contains("github.com") && value.contains("x-access-token")
+			)
+		);
 		assert_eq!(
-			envs.get("GIT_CONFIG_KEY_1").map(String::as_str),
+			envs.get("GIT_CONFIG_KEY_2").map(String::as_str),
 			Some("url.https://github.com/.insteadOf")
 		);
-		assert_eq!(envs.get("GIT_CONFIG_VALUE_1").map(String::as_str), Some("git@github.com:"));
-		assert_eq!(envs.get("GIT_CONFIG_KEY_7").map(String::as_str), Some("commit.gpgsign"));
-		assert_eq!(envs.get("GIT_CONFIG_VALUE_7").map(String::as_str), Some("false"));
-		assert_eq!(envs.get("GIT_CONFIG_KEY_8").map(String::as_str), Some("tag.gpgsign"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_2").map(String::as_str), Some("git@github.com:"));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_8").map(String::as_str), Some("commit.gpgsign"));
 		assert_eq!(envs.get("GIT_CONFIG_VALUE_8").map(String::as_str), Some("false"));
-		assert_eq!(envs.get("GIT_CONFIG_KEY_9").map(String::as_str), Some("user.signingkey"));
-		assert_eq!(envs.get("GIT_CONFIG_VALUE_9").map(String::as_str), Some(""));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_9").map(String::as_str), Some("tag.gpgsign"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_9").map(String::as_str), Some("false"));
+		assert_eq!(envs.get("GIT_CONFIG_KEY_10").map(String::as_str), Some("user.signingkey"));
+		assert_eq!(envs.get("GIT_CONFIG_VALUE_10").map(String::as_str), Some(""));
 	}
 
 	#[test]

--- a/apps/decodex/src/git_credentials.rs
+++ b/apps/decodex/src/git_credentials.rs
@@ -1,11 +1,4 @@
-#[cfg(unix)] use std::os::unix::fs::PermissionsExt as _;
-use std::{
-	env, fs,
-	io::ErrorKind,
-	path::{Path, PathBuf},
-	process::{self, Command},
-	sync::atomic::{AtomicU64, Ordering},
-};
+use std::{env, path::Path, process::Command};
 
 use crate::prelude::{Result, eyre};
 
@@ -19,33 +12,39 @@ const GITHUB_SSH_URL_PREFIXES: &[&str] = &[
 	"ssh://git@github.com-y/",
 ];
 const GIT_CONFIG_ENV_REMOVE_FLOOR: usize = 64;
-
-static NEXT_ASKPASS_ID: AtomicU64 = AtomicU64::new(0);
+const GITHUB_CREDENTIAL_HELPER: &str = concat!(
+	"!f() { ",
+	"test \"$1\" = get || exit 0; ",
+	"protocol=; host=; ",
+	"while IFS= read -r line; do ",
+	"test -n \"$line\" || break; ",
+	"case \"$line\" in ",
+	"protocol=*) protocol=${line#protocol=} ;; ",
+	"host=*) host=${line#host=} ;; ",
+	"esac; ",
+	"done; ",
+	"test \"$protocol\" = https || exit 0; ",
+	"test \"$host\" = github.com || exit 0; ",
+	"test -n \"$GH_TOKEN\" || exit 0; ",
+	"printf '%s\\n' username=x-access-token password=\"$GH_TOKEN\"; ",
+	"}; f",
+);
 
 #[derive(Clone, Copy)]
 pub(crate) struct GitCredentialSource<'a> {
 	token_env_var: &'a str,
 	token: &'a str,
-	askpass_root: &'a Path,
 }
 impl<'a> GitCredentialSource<'a> {
-	pub(crate) fn new(token_env_var: &'a str, token: &'a str, askpass_root: &'a Path) -> Self {
-		Self { token_env_var, token, askpass_root }
+	pub(crate) fn new(token_env_var: &'a str, token: &'a str) -> Self {
+		Self { token_env_var, token }
 	}
 
-	pub(crate) fn materialize_github_askpass(
-		self,
-		label: &str,
-	) -> Result<(GitCredentialEnvironment, GitAskpassGuard)> {
-		let askpass_path = scoped_github_askpass_path(self.askpass_root, label);
-		let askpass_guard = GitAskpassGuard::create(askpass_path.clone())?;
-		let git_env = GitCredentialEnvironment::with_github_credentials(
+	pub(crate) fn materialize_github_credentials(self) -> GitCredentialEnvironment {
+		GitCredentialEnvironment::with_github_credentials(
 			self.token_env_var.to_owned(),
 			self.token.to_owned(),
-			askpass_path,
-		);
-
-		Ok((git_env, askpass_guard))
+		)
 	}
 }
 
@@ -53,19 +52,16 @@ impl<'a> GitCredentialSource<'a> {
 pub(crate) struct GitCredentialEnvironment {
 	github_token_env_var: Option<String>,
 	github_token: Option<String>,
-	git_askpass_path: Option<PathBuf>,
 	signing_config: GitSigningConfig,
 }
 impl GitCredentialEnvironment {
 	pub(crate) fn with_github_credentials(
 		github_token_env_var: String,
 		github_token: String,
-		git_askpass_path: PathBuf,
 	) -> Self {
 		Self {
 			github_token_env_var: Some(github_token_env_var),
 			github_token: Some(github_token),
-			git_askpass_path: Some(git_askpass_path),
 			signing_config: GitSigningConfig::DisableInherited,
 		}
 	}
@@ -73,13 +69,11 @@ impl GitCredentialEnvironment {
 	pub(crate) fn with_github_credentials_and_signing_config(
 		github_token_env_var: String,
 		github_token: String,
-		git_askpass_path: PathBuf,
 		signing_config: GitSigningConfig,
 	) -> Self {
 		Self {
 			github_token_env_var: Some(github_token_env_var),
 			github_token: Some(github_token),
-			git_askpass_path: Some(git_askpass_path),
 			signing_config,
 		}
 	}
@@ -99,15 +93,16 @@ impl GitCredentialEnvironment {
 				command.env(github_token_env_var, github_token);
 			}
 		}
-		if let Some(git_askpass_path) = self.git_askpass_path.as_deref() {
-			command.env("GIT_ASKPASS", git_askpass_path);
-		}
 
 		let mut git_config_entries = Vec::new();
 
-		if self.github_token.is_some() && self.git_askpass_path.is_some() {
-			// Empty helper resets inherited helpers so routed askpass owns GitHub auth.
+		if self.github_token.is_some() {
+			command.env_remove("GIT_ASKPASS");
+
+			// Empty helper resets inherited helpers so routed credentials own GitHub auth.
 			git_config_entries.push((String::from("credential.helper"), String::new()));
+			git_config_entries
+				.push((String::from("credential.helper"), String::from(GITHUB_CREDENTIAL_HELPER)));
 
 			for ssh_prefix in GITHUB_SSH_URL_PREFIXES {
 				git_config_entries.push((
@@ -138,31 +133,6 @@ impl GitCredentialEnvironment {
 			}
 
 			command.env("GIT_CONFIG_COUNT", git_config_count.to_string());
-		}
-	}
-}
-
-pub(crate) struct GitAskpassGuard {
-	path: PathBuf,
-}
-impl GitAskpassGuard {
-	pub(crate) fn create(path: PathBuf) -> Result<Self> {
-		write_github_askpass_helper(&path)?;
-
-		Ok(Self { path })
-	}
-}
-
-impl Drop for GitAskpassGuard {
-	fn drop(&mut self) {
-		if let Err(error) = fs::remove_file(&self.path)
-			&& error.kind() != ErrorKind::NotFound
-		{
-			tracing::warn!(
-				?error,
-				askpass_path = %self.path.display(),
-				"Failed to remove Git askpass helper."
-			);
 		}
 	}
 }
@@ -220,53 +190,13 @@ pub(crate) fn clear_injected_git_config(command: &mut Command) {
 	}
 }
 
-pub(crate) fn scoped_github_askpass_path(root: &Path, label: &str) -> PathBuf {
-	let safe_label = sanitize_path_component(label);
-	let id = NEXT_ASKPASS_ID.fetch_add(1, Ordering::Relaxed);
-
-	root.join(format!(".decodex-git-askpass-{safe_label}-{}-{id}.sh", process::id()))
-}
-
-pub(crate) fn write_github_askpass_helper(path: &Path) -> Result<()> {
-	if let Some(parent) = path.parent() {
-		fs::create_dir_all(parent)?;
-	}
-
-	fs::write(
-		path,
-		"#!/bin/sh\ncase \"$1\" in\n  *https://github.com:*|*https://github.com/*|*https://github.com\\'*|*https://*@github.com:*|*https://*@github.com/*|*https://*@github.com\\'*) ;;\n  *) exit 1 ;;\nesac\ncase \"$1\" in\n  *Username*|*username*) printf '%s\\n' 'x-access-token' ;;\n  *Password*|*password*) printf '%s\\n' \"$GH_TOKEN\" ;;\n  *) exit 1 ;;\nesac\n",
-	)?;
-
-	#[cfg(unix)]
-	{
-		let mut permissions = fs::metadata(path)?.permissions();
-
-		permissions.set_mode(0o700);
-
-		fs::set_permissions(path, permissions)?;
-	}
-
-	Ok(())
-}
-
-fn sanitize_path_component(value: &str) -> String {
-	let sanitized = value
-		.chars()
-		.map(|character| {
-			if character.is_ascii_alphanumeric() || character == '-' || character == '_' {
-				character
-			} else {
-				'_'
-			}
-		})
-		.collect::<String>();
-
-	if sanitized.is_empty() { String::from("git") } else { sanitized }
-}
-
 #[cfg(test)]
 mod tests {
-	use std::{ffi::OsStr, process::Command};
+	use std::{
+		ffi::OsStr,
+		io::Write as _,
+		process::{Command, Stdio},
+	};
 
 	use crate::git_credentials::GitCredentialEnvironment;
 
@@ -286,6 +216,51 @@ mod tests {
 		assert_env_removed(&command, "GIT_CONFIG_COUNT");
 		assert_env_removed(&command, "GIT_CONFIG_KEY_0");
 		assert_env_removed(&command, "GIT_CONFIG_VALUE_0");
+	}
+
+	#[test]
+	fn inline_github_credentials_supply_only_github_https_credentials() {
+		let github = credential_fill_stdout("github.com")
+			.expect("github credential helper should return credentials");
+
+		assert!(github.contains("username=x-access-token"));
+		assert!(github.contains("password=secret-token-value"));
+
+		let foreign = credential_fill_stdout("github.com.evil")
+			.expect_err("foreign host should not receive credentials");
+
+		assert!(!foreign.contains("secret-token-value"));
+	}
+
+	fn credential_fill_stdout(host: &str) -> std::result::Result<String, String> {
+		let mut command = Command::new("git");
+
+		GitCredentialEnvironment::with_github_credentials(
+			String::from("GITHUB_PAT_Y"),
+			String::from("secret-token-value"),
+		)
+		.apply_to(&mut command);
+
+		let mut child = command
+			.args(["credential", "fill"])
+			.stdin(Stdio::piped())
+			.stdout(Stdio::piped())
+			.stderr(Stdio::piped())
+			.spawn()
+			.expect("git credential fill should spawn");
+
+		child
+			.stdin
+			.as_mut()
+			.expect("stdin should be piped")
+			.write_all(format!("protocol=https\nhost={host}\n\n").as_bytes())
+			.expect("credential input should write");
+
+		let output = child.wait_with_output().expect("credential fill should exit");
+		let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+		let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+		if output.status.success() { Ok(stdout) } else { Err(format!("{stdout}{stderr}")) }
 	}
 
 	fn assert_env_removed(command: &Command, name: &str) {

--- a/apps/decodex/src/maintenance.rs
+++ b/apps/decodex/src/maintenance.rs
@@ -22,8 +22,11 @@ const DEFAULT_LOG_RETENTION_DAYS: u64 = 14;
 const DEFAULT_EVIDENCE_ROTATE_BYTES: u64 = 10 * 1_024 * 1_024;
 const DEFAULT_EVIDENCE_RETENTION_DAYS: u64 = 14;
 const DEFAULT_PROTOCOL_EVENT_RETENTION_DAYS: i64 = 14;
+const DEFAULT_GIT_ASKPASS_HELPER_RETENTION_DAYS: u64 = 1;
 const DEFAULT_BACKUP_KEEP_RECENT: usize = 3;
 const DEFAULT_BACKUP_RETENTION_DAYS: u64 = 7;
+const LEGACY_GIT_ASKPASS_PREFIX: &str = ".decodex-git-askpass-";
+const LEGACY_GIT_ASKPASS_SUFFIX: &str = ".sh";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum MaintenanceMode {
@@ -64,6 +67,7 @@ pub(crate) struct MaintenanceReport {
 	generated_at: String,
 	pub(crate) logs: FileMaintenanceReport,
 	pub(crate) agent_evidence: FileMaintenanceReport,
+	pub(crate) git_askpass_helpers: FileMaintenanceReport,
 	pub(crate) backups: BackupMaintenanceReport,
 	pub(crate) runtime: RuntimeMaintenanceReport,
 	pub(crate) wal_checkpoint: Option<WalCheckpointReport>,
@@ -124,6 +128,7 @@ struct MaintenancePolicy {
 	evidence_rotate_bytes: u64,
 	evidence_retention: Duration,
 	protocol_event_retention_days: i64,
+	git_askpass_helper_retention: Duration,
 	backup_keep_recent: usize,
 	backup_retention: Duration,
 }
@@ -135,6 +140,9 @@ impl MaintenancePolicy {
 			evidence_rotate_bytes: DEFAULT_EVIDENCE_ROTATE_BYTES,
 			evidence_retention: Duration::from_secs(DEFAULT_EVIDENCE_RETENTION_DAYS * 24 * 60 * 60),
 			protocol_event_retention_days: DEFAULT_PROTOCOL_EVENT_RETENTION_DAYS,
+			git_askpass_helper_retention: Duration::from_secs(
+				DEFAULT_GIT_ASKPASS_HELPER_RETENTION_DAYS * 24 * 60 * 60,
+			),
 			backup_keep_recent: DEFAULT_BACKUP_KEEP_RECENT,
 			backup_retention: Duration::from_secs(DEFAULT_BACKUP_RETENTION_DAYS * 24 * 60 * 60),
 		}
@@ -227,6 +235,8 @@ fn run_prune_with_policy(
 	let system_now = SystemTime::now();
 	let logs = maintain_logs(request.mode, policy, system_now, generated_at)?;
 	let agent_evidence = maintain_agent_evidence(request.mode, policy, system_now, generated_at)?;
+	let git_askpass_helpers =
+		maintain_git_askpass_helpers_for_scope(request.mode, request.scope, policy, system_now)?;
 	let backups = maintain_backups(request.mode, policy, system_now)?;
 	let runtime = maintain_runtime(request.mode, request.scope, policy, generated_at)?;
 	let wal_checkpoint = maintain_wal(request.mode, request.scope)?;
@@ -241,6 +251,7 @@ fn run_prune_with_policy(
 		generated_at: generated_at.format(&Rfc3339)?,
 		logs,
 		agent_evidence,
+		git_askpass_helpers,
 		backups,
 		runtime,
 		wal_checkpoint,
@@ -419,6 +430,96 @@ fn maintain_agent_evidence(
 
 					report.deleted_files += 1;
 				}
+			}
+		}
+	}
+
+	Ok(report)
+}
+
+fn maintain_git_askpass_helpers_for_scope(
+	mode: MaintenanceMode,
+	scope: MaintenanceScope,
+	policy: MaintenancePolicy,
+	system_now: SystemTime,
+) -> Result<FileMaintenanceReport> {
+	match maintain_git_askpass_helpers(mode, policy, system_now) {
+		Ok(report) => Ok(report),
+		Err(error) if scope == MaintenanceScope::AutoSafe => {
+			tracing::warn!(
+				?error,
+				"Skipped Decodex auto-safe legacy Git askpass helper cleanup; control-plane maintenance continued."
+			);
+
+			Ok(FileMaintenanceReport {
+				root: runtime::runtime_db_path()?.display().to_string(),
+				..FileMaintenanceReport::default()
+			})
+		},
+		Err(error) => Err(error),
+	}
+}
+
+fn maintain_git_askpass_helpers(
+	mode: MaintenanceMode,
+	policy: MaintenancePolicy,
+	system_now: SystemTime,
+) -> Result<FileMaintenanceReport> {
+	let database_path = runtime::runtime_db_path()?;
+	let mut report = FileMaintenanceReport {
+		root: database_path.display().to_string(),
+		..FileMaintenanceReport::default()
+	};
+
+	if !database_path.exists() {
+		return Ok(report);
+	}
+
+	let connection = Connection::open(database_path)?;
+
+	if !sqlite_table_exists(&connection, "projects")? {
+		return Ok(report);
+	}
+
+	for worktree_root in registered_worktree_roots(&connection)? {
+		if !worktree_root.exists() {
+			continue;
+		}
+
+		for entry in fs::read_dir(&worktree_root)? {
+			let entry = entry?;
+			let path = entry.path();
+			let file_type = entry.file_type()?;
+
+			if !file_type.is_file() || !is_legacy_git_askpass_helper(&path) {
+				continue;
+			}
+
+			let metadata = entry.metadata()?;
+
+			if !file_is_older_than(&metadata, system_now, policy.git_askpass_helper_retention) {
+				continue;
+			}
+
+			let size = metadata.len();
+
+			report.delete_candidates += 1;
+			report.delete_bytes = report.delete_bytes.saturating_add(size);
+
+			report.actions.push(FileMaintenanceAction {
+				action: "delete",
+				path: path.display().to_string(),
+				bytes: size,
+				target: None,
+				reason: format!(
+					"legacy Git askpass helper is older than {DEFAULT_GIT_ASKPASS_HELPER_RETENTION_DAYS} day"
+				),
+			});
+
+			if mode.applies() {
+				fs::remove_file(&path)?;
+
+				report.deleted_files += 1;
 			}
 		}
 	}
@@ -717,6 +818,29 @@ fn runtime_maintenance_warning_for_error(error: &Report) -> RuntimeMaintenanceWa
 	RuntimeMaintenanceWarning { warning: "auto_protocol_event_compaction_skipped", reason }
 }
 
+fn registered_worktree_roots(connection: &Connection) -> Result<Vec<PathBuf>> {
+	let mut statement =
+		connection.prepare("SELECT DISTINCT worktree_root FROM projects ORDER BY worktree_root")?;
+	let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+	let mut roots = Vec::new();
+
+	for row in rows {
+		roots.push(PathBuf::from(row?));
+	}
+
+	Ok(roots)
+}
+
+fn sqlite_table_exists(connection: &Connection, table: &str) -> Result<bool> {
+	let count = connection.query_row(
+		"SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+		rusqlite::params![table],
+		|row| row.get::<_, i64>(0),
+	)?;
+
+	Ok(count > 0)
+}
+
 fn compact_protocol_events(
 	connection: &mut Connection,
 	candidates: &[RuntimeProtocolCandidate],
@@ -823,6 +947,13 @@ fn is_rotated_log_file(path: &Path) -> bool {
 		.is_some_and(|timestamp| timestamp.parse::<i64>().is_ok())
 }
 
+fn is_legacy_git_askpass_helper(path: &Path) -> bool {
+	path.file_name().and_then(|name| name.to_str()).is_some_and(|file_name| {
+		file_name.starts_with(LEGACY_GIT_ASKPASS_PREFIX)
+			&& file_name.ends_with(LEGACY_GIT_ASKPASS_SUFFIX)
+	})
+}
+
 fn collect_backup_candidates(
 	root: &Path,
 	groups: &mut BTreeMap<String, Vec<BackupCandidate>>,
@@ -886,6 +1017,13 @@ fn print_prune_report(report: &MaintenanceReport) -> Result<()> {
 		report.agent_evidence.deleted_files,
 		report.agent_evidence.delete_candidates,
 		report.agent_evidence.delete_bytes
+	)?;
+	writeln!(
+		stdout,
+		"git-askpass: delete {}/{} files ({} bytes)",
+		report.git_askpass_helpers.deleted_files,
+		report.git_askpass_helpers.delete_candidates,
+		report.git_askpass_helpers.delete_bytes
 	)?;
 	writeln!(
 		stdout,
@@ -1295,6 +1433,45 @@ mod tests {
 		assert!(fresh_events_path.exists());
 	}
 
+	#[test]
+	fn prune_deletes_old_legacy_git_askpass_helpers_from_registered_worktree_roots() {
+		let temp_dir = TempDir::new().expect("temp dir should create");
+		let _home_guard =
+			TestEnvVarGuard::set("HOME", temp_dir.path().to_str().expect("home should be utf-8"));
+		let connection = bootstrap_test_runtime_db(&temp_dir);
+		let worktree_root = temp_dir.path().join("repo/.worktrees");
+		let old_helper = worktree_root.join(".decodex-git-askpass-xy-101-attempt-1.sh");
+		let fresh_helper = worktree_root.join(".decodex-git-askpass-xy-102-attempt-1.sh");
+		let unrelated = worktree_root.join("notes.sh");
+		let old_time = SystemTime::now() - Duration::from_secs(2 * 24 * 60 * 60);
+		let fresh_time = SystemTime::now();
+
+		insert_project(&connection, &worktree_root);
+		fs::create_dir_all(&worktree_root).expect("worktree root should create");
+		fs::write(&old_helper, b"#!/bin/sh\n").expect("old helper should write");
+		fs::write(&fresh_helper, b"#!/bin/sh\n").expect("fresh helper should write");
+		fs::write(&unrelated, b"#!/bin/sh\n").expect("unrelated file should write");
+		set_file_modified(&old_helper, old_time);
+		set_file_modified(&fresh_helper, fresh_time);
+		set_file_modified(&unrelated, old_time);
+
+		let report = maintenance::run_prune_with_policy(
+			MaintenancePruneRequest {
+				mode: MaintenanceMode::Apply,
+				scope: MaintenanceScope::AutoSafe,
+				json: false,
+			},
+			MaintenancePolicy::default(),
+		)
+		.expect("maintenance should run");
+
+		assert_eq!(report.git_askpass_helpers.deleted_files, 1);
+		assert_eq!(report.git_askpass_helpers.delete_candidates, 1);
+		assert!(!old_helper.exists());
+		assert!(fresh_helper.exists());
+		assert!(unrelated.exists());
+	}
+
 	fn insert_attempt(connection: &Connection, run_id: &str, issue_id: &str, status: &str) {
 		connection
 			.execute(
@@ -1304,6 +1481,23 @@ mod tests {
 				rusqlite::params![run_id, issue_id, status],
 			)
 			.expect("attempt should insert");
+	}
+
+	fn insert_project(connection: &Connection, worktree_root: &Path) {
+		connection
+			.execute(
+				"INSERT INTO projects (
+					service_id, config_path, repo_root, worktree_root, workflow_path,
+					tracker_api_key_env_var, github_token_env_var, enabled,
+					config_fingerprint, updated_at, updated_at_unix
+				) VALUES (
+					'decodex', '/tmp/project.toml', '/tmp/repo', ?1, '/tmp/WORKFLOW.md',
+					'LINEAR_API_KEY_HACKINK', 'GITHUB_PAT_Y', 1,
+					'fingerprint', '2026-05-01T00:00:00Z', 0
+				)",
+				rusqlite::params![worktree_root.display().to_string()],
+			)
+			.expect("project should insert");
 	}
 
 	fn set_file_modified(path: &Path, modified: SystemTime) {

--- a/apps/decodex/src/manual.rs
+++ b/apps/decodex/src/manual.rs
@@ -86,11 +86,7 @@ struct ManualLandContext {
 }
 impl ManualLandContext {
 	fn default_branch_git_credentials(&self) -> GitCredentialSource<'_> {
-		GitCredentialSource::new(
-			&self.github_token_env_var,
-			&self.github_token,
-			&self.worktree_root,
-		)
+		GitCredentialSource::new(&self.github_token_env_var, &self.github_token)
 	}
 }
 

--- a/apps/decodex/src/orchestrator.rs
+++ b/apps/decodex/src/orchestrator.rs
@@ -92,7 +92,6 @@ pub(crate) const EXTERNAL_REVIEW_MERGE_VISIBILITY_TIMEOUT_SECS: i64 = 15 * 60;
 const CONTINUATION_RETRY_DELAY_MS: u64 = 1_000;
 const FAILURE_RETRY_BASE_DELAY_MS: u64 = 10_000;
 const RECOVERABLE_WORKTREE_SKIP_TTL: Duration = Duration::from_secs(10 * 60);
-const AGENT_GIT_ASKPASS_PREFIX: &str = ".decodex-git-askpass-";
 const CONTINUATION_PENDING_RUN_STATUS: &str = "continuation_pending";
 const TERMINAL_GUARDED_RUN_STATUS: &str = "terminal_guarded";
 const TERMINAL_GUARD_MARKER_FILE: &str = ".decodex-terminal-guarded";

--- a/apps/decodex/src/orchestrator/dispatch_policy.rs
+++ b/apps/decodex/src/orchestrator/dispatch_policy.rs
@@ -735,7 +735,6 @@ fn cleanup_completed_post_review_lane(
 	let git_credentials = GitCredentialSource::new(
 		project.github().token_env_var(),
 		&github_token,
-		project.worktree_root(),
 	);
 
 	default_branch_sync::sync_repo_root_default_branch(

--- a/apps/decodex/src/orchestrator/execution.rs
+++ b/apps/decodex/src/orchestrator/execution.rs
@@ -61,25 +61,10 @@ impl Error for AppServerZeroEvidenceStartFailure {}
 
 struct AgentGitCredentialEnvironment {
 	process_env: AppServerProcessEnv,
-	askpass_path: PathBuf,
 }
 impl AgentGitCredentialEnvironment {
 	fn process_env(&self) -> &AppServerProcessEnv {
 		&self.process_env
-	}
-}
-
-impl Drop for AgentGitCredentialEnvironment {
-	fn drop(&mut self) {
-		if let Err(error) = fs::remove_file(&self.askpass_path)
-			&& error.kind() != ErrorKind::NotFound
-		{
-			tracing::warn!(
-				?error,
-				askpass_path = %self.askpass_path.display(),
-				"Failed to remove agent Git askpass helper."
-			);
-		}
 	}
 }
 
@@ -768,41 +753,15 @@ fn prepare_agent_git_credentials(
 		})
 		.wrap_err(error)
 	})?;
-	let askpass_path = agent_git_askpass_path(project.worktree_root(), run_id);
 	let signing_config = GitSigningConfig::from_local_git_config(worktree_path)?;
-
-	git_credentials::write_github_askpass_helper(&askpass_path)?;
 
 	Ok(AgentGitCredentialEnvironment {
 		process_env: AppServerProcessEnv::with_github_credentials_and_signing_config(
 			project.github().token_env_var().to_owned(),
 			github_token,
-			askpass_path.clone(),
 			signing_config,
 		),
-		askpass_path,
 	})
-}
-
-fn agent_git_askpass_path(worktree_root: &Path, run_id: &str) -> PathBuf {
-	let safe_run_id = sanitize_run_id_for_path(run_id);
-
-	worktree_root.join(format!("{AGENT_GIT_ASKPASS_PREFIX}{safe_run_id}.sh"))
-}
-
-fn sanitize_run_id_for_path(run_id: &str) -> String {
-	let sanitized = run_id
-		.chars()
-		.map(|character| {
-			if character.is_ascii_alphanumeric() || character == '-' || character == '_' {
-				character
-			} else {
-				'_'
-			}
-		})
-		.collect::<String>();
-
-	if sanitized.is_empty() { String::from("run") } else { sanitized }
 }
 
 fn configured_public_projection_privacy_classifier(

--- a/apps/decodex/src/orchestrator/tests/runtime/failure.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/failure.rs
@@ -44,6 +44,21 @@ fn injected_git_config_keys(credentials: &AgentGitCredentialEnvironment) -> Vec<
 		.collect()
 }
 
+fn injected_git_config_values(credentials: &AgentGitCredentialEnvironment) -> Vec<String> {
+	let mut probe = Command::new("git");
+
+	credentials.process_env().apply_to(&mut probe).expect("agent env should apply");
+
+	probe
+		.get_envs()
+		.filter_map(|(key, value)| {
+			Some((key.to_string_lossy().into_owned(), value?.to_string_lossy().into_owned()))
+		})
+		.filter(|(key, _)| key.starts_with("GIT_CONFIG_VALUE_"))
+		.map(|(_, value)| value)
+		.collect()
+}
+
 fn loop_guardrail_issue_run(
 	config: &ServiceConfig,
 	issue: &TrackerIssue,
@@ -2148,16 +2163,17 @@ fn agent_git_credentials_use_runtime_env_without_persisting_the_token() {
 	let env_var = format!("DECODEX_TEST_AGENT_GITHUB_TOKEN_ENV_{}", process::id());
 	let _env_guard = TestEnvVarGuard::set(&env_var, "secret-token-value");
 	let config = service_config_with_github_token_env_var(&config, &env_var);
-	let askpass_path =
-		orchestrator::agent_git_askpass_path(config.worktree_root(), "run/with spaces");
 	let credentials =
 		orchestrator::prepare_agent_git_credentials(&config, "run/with spaces", config.repo_root())
 			.expect("agent Git credentials should prepare");
-	let script = fs::read_to_string(&askpass_path).expect("askpass script should exist");
 
-	assert!(askpass_path.exists());
-	assert!(script.contains("GH_TOKEN"));
-	assert!(!script.contains("secret-token-value"));
+	assert!(
+		fs::read_dir(config.worktree_root())
+			.expect("worktree root should list")
+			.filter_map(std::result::Result::ok)
+			.all(|entry| !entry.file_name().to_string_lossy().starts_with(".decodex-git-askpass-")),
+		"agent Git credentials should not materialize askpass helper files"
+	);
 
 	let inherited_signing_key = git_config_value(config.repo_root(), "user.signingkey", None);
 	let agent_signing_key =
@@ -2187,69 +2203,17 @@ fn agent_git_credentials_use_runtime_env_without_persisting_the_token() {
 		"agent git environment should not mask inherited signing keys"
 	);
 
-	#[cfg(unix)]
-	{
-		assert_eq!(
-			std::os::unix::fs::PermissionsExt::mode(
-				&fs::metadata(&askpass_path).expect("askpass metadata should load").permissions(),
-			) & 0o777,
-			0o700
-		);
-
-		let github_username = Command::new(&askpass_path)
-			.arg("Username for 'https://github.com/hack-ink/decodex.git'")
-			.env("GH_TOKEN", "secret-token-value")
-			.output()
-			.expect("askpass helper should execute");
-
-		assert!(github_username.status.success());
-		assert_eq!(String::from_utf8_lossy(&github_username.stdout).trim(), "x-access-token");
-
-		let github_password = Command::new(&askpass_path)
-			.arg("Password for 'https://x-access-token@github.com/hack-ink/decodex.git'")
-			.env("GH_TOKEN", "secret-token-value")
-			.output()
-			.expect("askpass helper should execute");
-
-		assert!(github_password.status.success());
-		assert_eq!(String::from_utf8_lossy(&github_password.stdout).trim(), "secret-token-value");
-
-		let foreign_password = Command::new(&askpass_path)
-			.arg("Password for 'https://example.com/repo.git'")
-			.env("GH_TOKEN", "secret-token-value")
-			.output()
-			.expect("askpass helper should execute");
-
-		assert!(
-			!foreign_password.status.success(),
-			"askpass helper should reject non-GitHub prompts"
-		);
-		assert!(
-			!String::from_utf8_lossy(&foreign_password.stdout).contains("secret-token-value"),
-			"askpass helper should not leak the GitHub token to non-GitHub prompts"
-		);
-
-		let lookalike_password = Command::new(&askpass_path)
-			.arg("Password for 'https://x-access-token@github.com.evil/repo.git'")
-			.env("GH_TOKEN", "secret-token-value")
-			.output()
-			.expect("askpass helper should execute");
-
-		assert!(
-			!lookalike_password.status.success(),
-			"askpass helper should reject GitHub lookalike hosts"
-		);
-		assert!(
-			!String::from_utf8_lossy(&lookalike_password.stdout).contains("secret-token-value"),
-			"askpass helper should not leak the GitHub token to lookalike hosts"
-		);
-	}
-
-	drop(credentials);
+	let injected_git_config_values = injected_git_config_values(&credentials);
 
 	assert!(
-		!askpass_path.exists(),
-		"runtime askpass helper should be removed after the run environment drops"
+		injected_git_config_values
+			.iter()
+			.any(|value| value.contains("github.com") && value.contains("x-access-token")),
+		"agent git environment should inject an inline GitHub credential helper"
+	);
+	assert!(
+		!injected_git_config_values.iter().any(|value| value.contains("secret-token-value")),
+		"agent git config should not persist the GitHub token"
 	);
 }
 

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -364,7 +364,15 @@ projections.
   path no longer exists and has no active lease, active service label,
   needs-attention label, shared claim, running attempt, or review lifecycle record.
 - Generic live dispatch must not require GitHub CLI authority before the lane actually attempts PR-backed review handoff.
-- Generic live dispatch must resolve `github.token_env_var` before launching the agent app-server so lane-owned `git push` and `gh pr create` commands inherit noninteractive GitHub credentials. Missing or blank GitHub credentials must fail the run through the human-required path instead of retrying or leaving a promptable lane running.
+- Generic live dispatch must resolve `github.token_env_var` before launching the agent
+  app-server so lane-owned `git push` and `gh pr create` commands inherit
+  noninteractive GitHub credentials. Git operations must receive routed credentials
+  through process-local environment and inline `credential.helper` configuration, not
+  per-run askpass helper files under `.worktrees/`. The inline helper must return
+  credentials only for HTTPS `github.com` requests and must read the token from the
+  routed environment rather than embedding it in Git config. Missing or blank GitHub
+  credentials must fail the run through the human-required path instead of retrying or
+  leaving a promptable lane running.
 - Project configs may set `[github].command_path` to make one expected GitHub CLI binary authoritative for project-scoped GitHub operations. When it is configured, review handoff validation, retained review readback, landing inspection, GitHub comments, admin merge, merge readback, and remote branch cleanup must invoke that path instead of silently rediscovering another `gh` binary.
 - The service must fail fast on missing `gh` CLI authority only at the GitHub-dependent review boundary:
   - when a normal lane is about to validate and persist PR-backed review handoff
@@ -836,16 +844,19 @@ After a process restart, recent-run history, run lease ownership, retained post-
   state-aware protocol-event
   compaction, old backup pruning, local log and agent-evidence event-stream rotation,
   deletion of rotated local logs and agent-evidence event streams older than 14 days,
-  and SQLite WAL checkpointing. Operators must not delete `runtime.sqlite3-wal`
-  directly.
+  deletion of legacy `.decodex-git-askpass-*.sh` helper files older than one day from
+  registered project worktree roots, and SQLite WAL checkpointing. Operators must not
+  delete `runtime.sqlite3-wal` directly.
 - `decodex serve` runs the auto-safe maintenance subset at startup and periodically
   while polling. That subset may rotate oversized local files, prune old backups,
   delete rotated local logs and agent-evidence event streams older than 14 days,
-  compact only safe terminal protocol-event rows behind the 14-day boundary, and run
-  a passive WAL checkpoint. Current local log files and current `events.jsonl` streams
-  are rotation inputs, not age-deletion candidates. If SQLite is busy or
-  protocol-event candidate detection fails, the auto-safe path must record a warning
-  and continue without blocking scheduler health.
+  delete legacy Git askpass helpers older than one day from registered project
+  worktree roots, compact only safe terminal protocol-event rows behind the 14-day
+  boundary, and run a passive WAL checkpoint. Current local log files, current
+  `events.jsonl` streams, and newer legacy askpass helpers are inputs or protected
+  candidates, not age-deletion candidates. If SQLite is busy or protocol-event
+  candidate detection fails, the auto-safe path must record a warning and continue
+  without blocking scheduler health.
 - Worktrees: retain while the issue is non-terminal, and also retain terminal owned lanes while authoritative post-merge closeout or deterministic cleanup is still incomplete.
 - Worktree mappings must carry durable local provenance. New runtime-recorded mappings
   use `provenance_source = "runtime_recorded"` with created and updated Unix


### PR DESCRIPTION
## Summary
- Replace per-run Git askpass helper files with an inline GitHub-only credential.helper.
- Stop app-server lanes and default-branch sync from materializing .decodex-git-askpass-*.sh files.
- Add maintenance cleanup for legacy askpass helpers under registered worktree roots and document the behavior.

## Validation
- cargo make fmt-check
- cargo make check-rust
- cargo make lint-rust
- cargo make check-docs
- cargo test -p decodex git_credentials --all-features -- --test-threads=1
- cargo test -p decodex default_branch_git_commands_use_routed_noninteractive_credentials --all-features -- --test-threads=1
- cargo test -p decodex app_server_command_inherits_noninteractive_git_environment --all-features -- --test-threads=1
- cargo test -p decodex maintenance --all-features -- --test-threads=1
- git diff --check