### PR TITLE
Dogfood repo memory docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,8 @@ The split below is by question type, not by human-versus-agent audience.
 
 - Read `README.md` first when you need the repository scope, top-level layout, or
   current source-of-truth boundaries.
+- Read `docs/reference/build-test-run.md` when the question is how to set up, build,
+  test, run, or validate this repository.
 - Use `cargo make` whenever an equivalent repo task exists. When task details matter,
   inspect `Makefile.toml` directly or run `cargo make --list-all-steps`.
 - Read `docs/policy.md` for document contracts, placement rules, and naming rules.
@@ -51,6 +53,8 @@ The split below is by question type, not by human-versus-agent audience.
   sequences -> `docs/runbook/`
 - Need current repository layout, ownership boundaries, static-site/runtime split, or
   implementation surface maps -> `docs/reference/`
+- Need repo setup, build, test, run, validation, task names, automation entrypoints, or
+  local source commands -> `docs/reference/build-test-run.md` and `Makefile.toml`
 - Need durable design rationale, packaging choices, or static-site tradeoffs ->
   `docs/decisions/`
 - Need rationale for keeping execution-graph semantics internal behind a
@@ -84,7 +88,8 @@ The split below is by question type, not by human-versus-agent audience.
 - Need reusable agent-facing Decodex usage instructions -> `plugins/decodex/`
 - Need repository execution defaults or tracker-state policy -> registered project
   `WORKFLOW.md`
-- Need repo task names or automation entrypoints -> `Makefile.toml`
+- Need repo task names or automation entrypoints -> `docs/reference/build-test-run.md`
+  and `Makefile.toml`
 
 ## Retrieval rules
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,11 @@
 
 ## 2026-06-17
 
+- Dogfooded the portable `repo-memory-writer` plugin skill on this repository and
+  added `docs/reference/build-test-run.md` as the source-backed build/test/run/setup
+  route that the first routing probes showed was missing.
+- Refreshed the high-level `docs/reference/test-suite.md` snapshot to the current
+  1213 default-runnable `nextest` tests plus the one skipped live app-server test.
 - Added the portable `repo-memory-writer` plugin skill so Codex can bootstrap or
   improve source-backed repository memory through AI authoring plus OKF route, graph,
   and profile validation.

--- a/docs/reference/build-test-run.md
+++ b/docs/reference/build-test-run.md
@@ -1,0 +1,135 @@
+---
+type: Reference
+title: Build Test Run Entrypoints
+description: Helps a new agent understand repo setup, build, test, run, validation, automation resources, and command entrypoints.
+status: active
+authority: current_state
+owner: docs
+tags: [reference, build, test, run, validation, setup, automation, resources, entrypoints, agent, repo-memory]
+source_refs: []
+code_refs: [Makefile.toml, Cargo.toml, apps/decodex/Cargo.toml, site/package.json, apps/decodex-app/Package.swift, README.md]
+related: [./workspace-layout.md, ./test-suite.md, ./docs-knowledge-map.md, ../policy.md, ../runbook/release-readiness.md, ../spec/okf-knowledge-layer.md]
+drift_watch: [Makefile.toml, Cargo.toml, site/package.json, apps/decodex-app/Package.swift, cargo make --list-all-steps, cargo make check, cargo nextest list --workspace --all-targets --all-features]
+last_verified: 2026-06-17
+---
+
+# Build Test Run Entrypoints
+
+Purpose: Map the current repository commands for setup, building, testing, running,
+and validating Decodex.
+
+Read this when: You need the smallest current entrypoint for repo setup, local
+validation, task-runner automation resources, or invoking the Decodex runtime from
+source. This is the first reference for a new agent that needs to understand how repo
+setup and command entrypoints fit together.
+
+Not this document: The full test inventory, repository directory ownership, release
+procedure, or runtime behavior contract.
+
+Covers: Task-runner authority, primary validation gates, targeted command entrypoints,
+source entrypoints, local prerequisites, and route-quality boundaries.
+
+## Task Runner Authority
+
+`Makefile.toml` owns repo-native task names. Use `cargo make` when an equivalent task
+exists, and inspect `Makefile.toml` or run `cargo make --list-all-steps` when the exact
+subcommands matter.
+
+The root `check` task is the aggregate repository gate. It currently depends on:
+
+- `build`
+- `check-docs`
+- `check-node`
+- `check-rust`
+- `fmt-check`
+- `lint`
+- `test`
+
+This makes `cargo make check` the first command to reach for before claiming a broad
+repository change is ready. For narrow documentation-only edits, `check-docs` is the
+focused gate, but a broad ready/land claim should still consider the aggregate gate or
+explain why a narrower check is sufficient.
+
+## Primary Validation Gates
+
+| Task | Command surface | Owns |
+| --- | --- | --- |
+| `cargo make check` | composite root task | Aggregate build, docs, node, Rust, format, lint, and test validation |
+| `cargo make check-docs` | `cargo run -p decodex --bin decodex -- docs lint` | Decodex docs OKF/profile validation |
+| `cargo make check-rust` | `cargo check --all-features --all-targets --workspace` | Rust workspace type checking |
+| `cargo make check-node` | `npm run check` in `site/` | Astro and TypeScript site checks |
+| `cargo make fmt-check` | Rust nightly fmt plus Taplo check | Rust and TOML formatting |
+| `cargo make lint` | Clippy plus `cargo vstyle curate` | Rust lint and vibe-style curation |
+| `cargo make test` | `cargo nextest run --workspace --all-targets --all-features` | Default Rust test gate |
+| `cargo make build` | `npm run build` in `site/` | Static site production build |
+
+The SwiftPM macOS app under `apps/decodex-app/` is excluded from the root Cargo
+workspace. Validate it with SwiftPM from that directory when a change touches the
+native app surface.
+
+## Targeted Commands
+
+Use these commands when a change does not need the full aggregate gate:
+
+```sh
+cargo run -p decodex --bin decodex -- docs check
+cargo run -p decodex --bin decodex -- docs graph
+cargo run -p decodex --bin decodex -- okf route docs "how do I validate this repo"
+cargo check --all-features --all-targets --workspace
+cargo nextest run --workspace --all-targets --all-features
+cargo test -p decodex <filter>
+npm --prefix site run check
+npm --prefix site run build
+```
+
+Use these commands when invoking the runtime from source:
+
+```sh
+cargo run -p decodex --bin decodex -- --help
+cargo run -p decodex --bin decodex -- status
+cargo run -p decodex --bin decodex -- diagnose --json
+cargo run -p decodex --bin decodex -- mcp serve --transport stdio
+cargo run -p decodex --bin decodex -- serve --listen-address 127.0.0.1:8192
+cargo install --path apps/decodex --force
+```
+
+`README.md` remains the better source for the broad CLI usage list. This document owns
+the repository-memory route for validation and entrypoint selection.
+
+## Source Entrypoints
+
+| Surface | Entrypoint |
+| --- | --- |
+| Runtime CLI | `apps/decodex/src/main.rs`, `apps/decodex/src/cli.rs`, `apps/decodex/src/lib.rs` |
+| App helper binary | `apps/decodex/src/bin/decodex-app-helper.rs` |
+| OKF/docs command behavior | `apps/decodex/src/docs_okf.rs`, `apps/decodex/src/cli.rs` |
+| Rust package manifest | `apps/decodex/Cargo.toml` |
+| Root workspace manifest | `Cargo.toml` |
+| Static site scripts | `site/package.json` |
+| Native macOS app package | `apps/decodex-app/Package.swift` |
+
+## Local Prerequisites And Generated State
+
+`site/node_modules/` must exist for the site `npm` tasks, but it is local dependency
+state and is not tracked. Run `npm install` or `npm ci` in `site/` when a fresh
+worktree lacks dependencies.
+
+The following paths are generated or local-only and are not source entrypoints:
+
+- `target/`
+- `site/dist/`
+- `site/.astro/`
+- `.worktrees/`
+- `.decodex/`
+
+## Route Quality Boundary
+
+This concept owns build, test, run, validation, setup, automation resources, and
+automation entrypoints questions. Use [`./test-suite.md`](./test-suite.md) for test
+inventory and placement standards, and [`./workspace-layout.md`](./workspace-layout.md)
+for directory ownership boundaries.
+
+When `decodex okf route docs "<intent>"` sends validation or setup questions to a
+generic map instead of this concept, treat that as a retrieval-quality issue and add a
+more specific routing phrase or link rather than duplicating this command list in
+another document.

--- a/docs/reference/docs-knowledge-map.md
+++ b/docs/reference/docs-knowledge-map.md
@@ -8,7 +8,7 @@ owner: docs
 tags: [docs, okf, llm-wiki, repo-memory, reference]
 source_refs: [https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md, https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing, https://llmstxt.org/, https://diataxis.fr/, https://developers.openai.com/codex/guides/agents-md, https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions]
 code_refs: [apps/decodex/src/docs_okf.rs, apps/decodex/src/cli.rs, docs/index.md, docs/policy.md, docs/spec/okf-knowledge-layer.md, plugins/decodex/skills/repo-memory-writer/SKILL.md]
-related: [../policy.md, ../spec/okf-knowledge-layer.md, ../evidence/docs-self-iteration.md, ./workspace-layout.md]
+related: [../policy.md, ../spec/okf-knowledge-layer.md, ../evidence/docs-self-iteration.md, ./build-test-run.md, ./workspace-layout.md]
 drift_watch: [decodex docs check, decodex okf graph docs, decodex okf route docs, docs index, docs lane index, okf orphan concepts]
 last_verified: 2026-06-17
 ---
@@ -91,6 +91,7 @@ plain index scan. This map keeps them connected to the repository-memory graph:
   [`../runbook/linear-archive-hygiene.md`](../runbook/linear-archive-hygiene.md), and
   [`./github-operations.md`](./github-operations.md).
 - Repository quality inventory:
+  [`./build-test-run.md`](./build-test-run.md) and
   [`./test-suite.md`](./test-suite.md).
 - Plugin source ownership:
   [`../decisions/decodex-plugin-source.md`](../decisions/decodex-plugin-source.md).
@@ -101,7 +102,7 @@ Those concepts should stay in their owning lanes. This map only provides a retri
 edge so graph-based readers can discover them without treating lane indexes as concept
 authority.
 
-Current readback: `decodex okf graph docs` reports 37 concepts, 105 edges, 0 broken
+Current readback: `decodex okf graph docs` reports 38 concepts, 117 edges, 0 broken
 links, and 0 orphan concepts.
 
 ## Evaluation

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -19,6 +19,8 @@ Question this index answers: "how is it currently organized or implemented?"
 
 ## Current reference docs
 
+- [`build-test-run.md`](./build-test-run.md) for repo-native setup, build, test, run,
+  validation, task-runner automation, and source-entrypoint commands.
 - [`docs-knowledge-map.md`](./docs-knowledge-map.md) for the current OKF/LLM Wiki
   knowledge-map shape, value evaluation, graph maintenance anchors, and retrieval
   quality observations.

--- a/docs/reference/test-suite.md
+++ b/docs/reference/test-suite.md
@@ -24,7 +24,7 @@ standards for keeping, merging, or deleting tests.
 
 ## Current Snapshot
 
-This snapshot lists 1138 default-runnable `nextest` tests. One additional ignored
+This snapshot lists 1213 default-runnable `nextest` tests. One additional ignored
 live app-server test is listed only with verbose or JSON inventory output. Regenerate
 the runnable inventory with:
 
@@ -54,15 +54,15 @@ cargo nextest list --workspace --all-targets --all-features 2>/dev/null \
 
 | Group | Count | Primary surfaces | Owns |
 | --- | ---: | --- | --- |
-| Orchestrator | 570 | `apps/decodex/src/orchestrator/tests.rs`, `apps/decodex/src/orchestrator/tests/**/*.rs` | Intake, retry, review/landing, runtime cleanup, operator status, repo gates |
-| Tracker tool bridge | 99 | `apps/decodex/src/agent/tracker_tool_bridge/tests.rs`, `apps/decodex/src/agent/tracker_tool_bridge/tests/**/*.rs` | Dynamic tracker tools, continuation guards, review handoff writes, closeout writes |
-| App-server protocol/runtime | 91 | `apps/decodex/src/agent/app_server/tests.rs`, `apps/decodex/src/agent/json_rpc.rs`, app-server protocol tests | JSON-RPC parsing, turn execution, dynamic tools, thread config, transport failures |
-| Runtime state, locks, and maintenance | 76 | `state::tests`, `runtime::tests`, `maintenance::tests` | Persistent local state, lock ownership, runtime database contracts, local retention |
-| Workflow and config parsing | 47 | `workflow::tests`, `config::tests`, `codex_config::tests` | `WORKFLOW.md`, project config, Codex config edits, removed-field rejection, default policy |
-| Git, worktree, landing, and recovery helpers | 134 | `worktree::tests`, `manual::tests`, `commit_message::tests`, `github::tests`, `default_branch_sync::tests`, `pull_request::tests`, `recovery::tests`, `git_credentials::tests` | Git/worktree behavior, manual landing, GitHub/PR helpers, recovery commands, commit-message policy |
-| Account, CLI, archive, and tracker integration | 87 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter and public-text behavior |
-| Program intake | 9 | `program_intake::tests` | Decision Contract materialization, Linear issue shaping, and internal Execution Program persistence |
-| Loop contract and research surfaces | 25 | `loop_contract::tests`, `execution_program::tests`, `research_design::tests`, `plugin_surface_tests` | Decision Contract schema, Execution Program readiness, research compile/promote, and plugin trigger behavior |
+| Orchestrator | 600 | `apps/decodex/src/orchestrator/tests.rs`, `apps/decodex/src/orchestrator/tests/**/*.rs` | Intake, retry, review/landing, runtime cleanup, operator status, repo gates |
+| Tracker tool bridge | 102 | `apps/decodex/src/agent/tracker_tool_bridge/tests.rs`, `apps/decodex/src/agent/tracker_tool_bridge/tests/**/*.rs` | Dynamic tracker tools, continuation guards, review handoff writes, closeout writes |
+| App-server protocol/runtime | 92 | `apps/decodex/src/agent/app_server/tests.rs`, `apps/decodex/src/agent/json_rpc.rs`, app-server protocol tests | JSON-RPC parsing, turn execution, dynamic tools, thread config, transport failures |
+| Runtime state, locks, and maintenance | 83 | `state::tests`, `runtime::tests`, `maintenance::tests` | Persistent local state, lock ownership, runtime database contracts, local retention |
+| Workflow, config, and docs parsing | 62 | `workflow::tests`, `config::tests`, `codex_config::tests`, `docs_okf::tests` | `WORKFLOW.md`, project config, Codex config edits, removed-field rejection, default policy, OKF docs parsing |
+| Git, worktree, landing, and recovery helpers | 137 | `worktree::tests`, `manual::tests`, `commit_message::tests`, `github::tests`, `default_branch_sync::tests`, `pull_request::tests`, `recovery::tests`, `git_credentials::tests` | Git/worktree behavior, manual landing, GitHub/PR helpers, recovery commands, commit-message policy |
+| Account, CLI, archive, tracker, and MCP integration | 98 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests`, `mcp::tests` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter, MCP resources, and public-text behavior |
+| Program intake | 10 | `program_intake::tests` | Decision Contract materialization, Linear issue shaping, and internal Execution Program persistence |
+| Loop contract and research surfaces | 29 | `loop_contract::tests`, `execution_program::tests`, `research_design::tests`, `plugin_surface_tests` | Decision Contract schema, Execution Program readiness, research compile/promote, and plugin trigger behavior |
 
 ## Orchestrator Inventory
 

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -6,7 +6,7 @@ status: active
 authority: current_state
 owner: docs
 tags: [reference]
-last_verified: 2026-06-16
+last_verified: 2026-06-17
 ---
 # Workspace Layout
 
@@ -21,6 +21,9 @@ design rationale.
 
 Covers: The repository surface map, ownership boundaries, and local directories that
 should not be treated as repository source.
+
+For build, test, run, setup, validation, and task-runner command entrypoints, read
+[`./build-test-run.md`](./build-test-run.md).
 
 ## Top-level surfaces
 
@@ -54,6 +57,9 @@ cargo run -p decodex --bin decodex -- --help
 cargo build -p decodex
 cargo install --path apps/decodex --force
 ```
+
+For the current aggregate validation gates, use [`./build-test-run.md`](./build-test-run.md)
+instead of treating this layout reference as command authority.
 
 Do not add new runtime behavior to a root `src/` directory. If Decodex later needs
 shared crates, add them under `packages/` and make the boundary explicit in this


### PR DESCRIPTION
## Summary
- add a source-backed build/test/run/setup repo-memory concept
- wire the concept into docs indexes, the knowledge map, and workspace layout
- refresh the high-level nextest snapshot after dogfooding the repo-memory writer

## Verification
- cargo make check-docs
- decodex docs check
- decodex docs graph
- decodex okf route docs "how do I build test and validate this repo"
- decodex okf route docs "where are automation resources and entrypoints"
- decodex okf route docs "how should a new agent understand repo setup"
- cargo nextest list --workspace --all-targets --all-features