### PR TITLE
Make protocol journal replays idempotent

### DIFF
--- a/apps/decodex/src/agent/app_server/tests.rs
+++ b/apps/decodex/src/agent/app_server/tests.rs
@@ -2454,6 +2454,24 @@ fn recorder_aggregates_child_agent_activity_breakdown() {
 }
 
 #[test]
+fn recorder_treats_matching_protocol_replay_as_idempotent() {
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let payload = r#"{"threadId":"thread-1","attemptNumber":5}"#;
+	let mut recorder = RunRecorder::new(&state_store, "run-1", 1, None);
+
+	recorder.record("thread/archive", payload).expect("archive event should record");
+
+	recorder.next_sequence = 1;
+
+	recorder
+		.record("thread/archive", payload)
+		.expect("matching protocol replay should not fail the app-server run");
+
+	assert_eq!(state_store.event_count("run-1").expect("event count should load"), 1);
+	assert_eq!(recorder.next_sequence, 2);
+}
+
+#[test]
 fn recorder_summarizes_high_value_protocol_activity() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let state_store = StateStore::open_in_memory().expect("state store should open");

--- a/apps/decodex/src/state.rs
+++ b/apps/decodex/src/state.rs
@@ -18,6 +18,7 @@ use std::{
 use rusqlite::{Connection, OptionalExtension, Transaction, params};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::Value;
+use sha2::{Digest as _, Sha256};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::{

--- a/apps/decodex/src/state/internal.rs
+++ b/apps/decodex/src/state/internal.rs
@@ -413,6 +413,7 @@ CREATE TABLE IF NOT EXISTS protocol_events (
 	run_id TEXT NOT NULL,
 	sequence_number INTEGER NOT NULL,
 	event_type TEXT NOT NULL,
+	payload_sha256 TEXT NOT NULL,
 	created_at TEXT NOT NULL,
 	created_at_unix INTEGER NOT NULL,
 	PRIMARY KEY (run_id, sequence_number)
@@ -1129,18 +1130,35 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 	fn append_protocol_event(&self, run_id: &str, event: &ProtocolEventRecord) -> Result<bool> {
 		let changed = self.connection.execute(
 			"INSERT OR IGNORE INTO protocol_events (
-					run_id, sequence_number, event_type, created_at, created_at_unix
-				) VALUES (?1, ?2, ?3, ?4, ?5)",
+					run_id, sequence_number, event_type, payload_sha256, created_at, created_at_unix
+				) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
 			params![
 				run_id,
 				event.sequence_number,
 				&event.event_type,
+				&event.payload_sha256,
 				&event.created_at,
 				event.created_at_unix,
 			],
 		)?;
 
 		Ok(changed == 1)
+	}
+
+	fn protocol_event(
+		&self,
+		run_id: &str,
+		sequence_number: i64,
+	) -> Result<Option<ProtocolEventRecord>> {
+		Ok(self
+			.connection
+			.query_row(
+				"SELECT sequence_number, event_type, payload_sha256, created_at, created_at_unix \
+				 FROM protocol_events WHERE run_id = ?1 AND sequence_number = ?2",
+				params![run_id, sequence_number],
+				protocol_event_record_from_row,
+			)
+			.optional()?)
 	}
 
 	fn insert_linear_execution_event_if_absent(
@@ -1808,22 +1826,24 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 		run_id: &str,
 	) -> Result<()> {
 		let mut statement = self.connection.prepare(
-			"SELECT sequence_number, event_type, created_at, created_at_unix \
-			 FROM protocol_events \
-			 WHERE run_id = ?1 \
-			 ORDER BY sequence_number DESC \
-			 LIMIT 1",
+			"SELECT totals.event_count, totals.last_sequence_number, last.event_type, \
+			 last.created_at, last.created_at_unix \
+			 FROM (
+			 SELECT COUNT(*) AS event_count, MAX(sequence_number) AS last_sequence_number \
+			 FROM protocol_events WHERE run_id = ?1
+			 ) totals \
+			 JOIN protocol_events last \
+			 ON last.run_id = ?1 \
+			 AND last.sequence_number = totals.last_sequence_number",
 		)?;
 		let summary = statement
 			.query_row(params![run_id], |row| {
-				let last_sequence_number = row.get(0)?;
-
 				Ok(ProtocolEventSummaryRecord {
-					event_count: last_sequence_number,
-					last_sequence_number: Some(last_sequence_number),
-					last_event_type: Some(row.get(1)?),
-					last_event_at: Some(row.get(2)?),
-					last_event_at_unix: Some(row.get(3)?),
+					event_count: row.get(0)?,
+					last_sequence_number: Some(row.get(1)?),
+					last_event_type: Some(row.get(2)?),
+					last_event_at: Some(row.get(3)?),
+					last_event_at_unix: Some(row.get(4)?),
 				})
 			})
 			.optional()?;
@@ -2806,8 +2826,14 @@ impl RunControlChannelRecord {
 struct ProtocolEventRecord {
 	sequence_number: i64,
 	event_type: String,
+	payload_sha256: String,
 	created_at: String,
 	created_at_unix: i64,
+}
+impl ProtocolEventRecord {
+	fn is_idempotent_replay_of(&self, candidate: &Self) -> bool {
+		self.event_type == candidate.event_type && self.payload_sha256 == candidate.payload_sha256
+	}
 }
 
 #[derive(Clone, Debug, Default)]
@@ -4052,12 +4078,14 @@ fn persist_protocol_events(
 		for event in events {
 			transaction.execute(
 				"INSERT OR REPLACE INTO protocol_events (
-						run_id, sequence_number, event_type, created_at, created_at_unix
-					) VALUES (?1, ?2, ?3, ?4, ?5)",
+						run_id, sequence_number, event_type, payload_sha256, created_at,
+						created_at_unix
+					) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
 				params![
 					run_id,
 					event.sequence_number,
 					&event.event_type,
+					&event.payload_sha256,
 					&event.created_at,
 					event.created_at_unix,
 				],
@@ -5124,6 +5152,16 @@ fn protocol_event_summary_from_events(events: &[ProtocolEventRecord]) -> Protoco
 	}
 
 	summary
+}
+
+fn protocol_event_record_from_row(row: &Row<'_>) -> std::result::Result<ProtocolEventRecord, rusqlite::Error> {
+	Ok(ProtocolEventRecord {
+		sequence_number: row.get(0)?,
+		event_type: row.get(1)?,
+		payload_sha256: row.get(2)?,
+		created_at: row.get(3)?,
+		created_at_unix: row.get(4)?,
+	})
 }
 
 fn compare_attempt_records(left: &RunAttemptRecord, right: &RunAttemptRecord) -> cmp::Ordering {

--- a/apps/decodex/src/state/store.rs
+++ b/apps/decodex/src/state/store.rs
@@ -1640,40 +1640,59 @@ impl StateStore {
 		run_id: &str,
 		sequence_number: i64,
 		event_type: &str,
-		_payload: &str,
+		payload: &str,
 	) -> Result<()> {
 		let mut state = self.lock_without_refresh()?;
-		let insert_index = {
-			let events = state.events.entry(run_id.to_owned()).or_default();
-
-			match events.binary_search_by_key(&sequence_number, |event| event.sequence_number) {
-				Ok(_index) => {
-					eyre::bail!(
-						"Protocol event `{run_id}` sequence `{sequence_number}` already exists in the runtime journal."
-					);
-				},
-				Err(index) => index,
-			}
-		};
 		let now = timestamp_parts();
 		let event = ProtocolEventRecord {
 			sequence_number,
 			event_type: event_type.to_owned(),
+			payload_sha256: protocol_event_payload_sha256(payload),
 			created_at: now.text,
 			created_at_unix: now.unix,
 		};
+		let (insert_index, cached_existing) = {
+			let events = state.events.entry(run_id.to_owned()).or_default();
 
-		if !self.append_protocol_event_locked(run_id, &event)? {
-			eyre::bail!(
-				"Protocol event `{run_id}` sequence `{sequence_number}` already exists in the runtime journal."
-			);
+			match events.binary_search_by_key(&sequence_number, |event| event.sequence_number) {
+				Ok(index) => (index, Some(events[index].clone())),
+				Err(index) => (index, None),
+			}
+		};
+
+		if let Some(existing) = cached_existing {
+			ensure_protocol_event_replay_matches(run_id, &existing, &event)?;
+
+			self.refresh_protocol_event_summaries_for_runs_locked(&mut state, &[run_id.to_owned()])?;
+
+			return Ok(());
 		}
 
-		state
-			.event_summaries
-			.entry(run_id.to_owned())
-			.or_default()
-			.record_event(&event);
+		if !self.append_protocol_event_locked(run_id, &event)? {
+			let existing = self.protocol_event_locked(run_id, sequence_number)?.ok_or_else(|| {
+				eyre::eyre!(
+					"Protocol event `{run_id}` sequence `{sequence_number}` already exists in the runtime journal, but the existing row could not be read."
+				)
+			})?;
+
+			ensure_protocol_event_replay_matches(run_id, &existing, &event)?;
+
+			self.refresh_protocol_event_summaries_for_runs_locked(&mut state, &[run_id.to_owned()])?;
+
+			return Ok(());
+		}
+
+		let summary = state.event_summaries.entry(run_id.to_owned()).or_default();
+
+		if summary
+			.last_sequence_number
+			.is_none_or(|last_sequence_number| sequence_number == last_sequence_number.saturating_add(1))
+		{
+			summary.record_event(&event);
+		} else {
+			self.refresh_protocol_event_summaries_for_runs_locked(&mut state, &[run_id.to_owned()])?;
+		}
+
 		state.events.entry(run_id.to_owned()).or_default().insert(insert_index, event);
 
 		Ok(())
@@ -3116,6 +3135,21 @@ impl StateStore {
 		sqlite.append_protocol_event(run_id, event)
 	}
 
+	fn protocol_event_locked(
+		&self,
+		run_id: &str,
+		sequence_number: i64,
+	) -> Result<Option<ProtocolEventRecord>> {
+		let Some(sqlite) = self.sqlite.as_ref() else {
+			return Ok(None);
+		};
+		let sqlite = sqlite
+			.lock()
+			.map_err(|_| eyre::eyre!("StateStore SQLite mutex is poisoned."))?;
+
+		sqlite.protocol_event(run_id, sequence_number)
+	}
+
 	fn insert_linear_execution_event_if_absent_locked(
 		&self,
 		record: &LinearExecutionEventRuntimeRecord,
@@ -4238,6 +4272,38 @@ fn validate_run_control_channel_status(status: &str) -> Result<()> {
 	}
 
 	Ok(())
+}
+
+fn protocol_event_payload_sha256(payload: &str) -> String {
+	let digest = Sha256::digest(payload.as_bytes());
+	let mut hash = String::with_capacity(64);
+
+	for byte in digest {
+		hash.push(char::from(b"0123456789abcdef"[(byte >> 4) as usize]));
+		hash.push(char::from(b"0123456789abcdef"[(byte & 0x0f) as usize]));
+	}
+
+	hash
+}
+
+fn ensure_protocol_event_replay_matches(
+	run_id: &str,
+	existing: &ProtocolEventRecord,
+	candidate: &ProtocolEventRecord,
+) -> Result<()> {
+	if existing.is_idempotent_replay_of(candidate) {
+		return Ok(());
+	}
+
+	eyre::bail!(
+		"Protocol event `{run_id}` sequence `{}` conflicts with an existing runtime journal event: \
+		 existing event_type=`{}` payload_sha256=`{}`, candidate event_type=`{}` payload_sha256=`{}`.",
+		candidate.sequence_number,
+		existing.event_type,
+		existing.payload_sha256,
+		candidate.event_type,
+		candidate.payload_sha256,
+	);
 }
 
 #[cfg_attr(not(test), allow(dead_code))]

--- a/apps/decodex/src/state/tests.rs
+++ b/apps/decodex/src/state/tests.rs
@@ -939,6 +939,82 @@ fn persistent_append_event_does_not_refresh_full_event_journal() {
 }
 
 #[test]
+fn protocol_event_replay_is_idempotent_when_payload_matches() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+	let store = StateStore::open(&state_path).expect("state store should open");
+	let payload = r#"{"threadId":"thread-1","attemptNumber":4}"#;
+
+	store
+		.append_event("run-1", 32, "thread/archive", payload)
+		.expect("first archive event should append");
+	store
+		.append_event("run-1", 32, "thread/archive", payload)
+		.expect("matching archive replay should be idempotent");
+
+	assert_eq!(store.event_count("run-1").expect("event count should load"), 1);
+
+	let connection = Connection::open(&state_path).expect("sqlite should open");
+	let payload_sha256: String = connection
+		.query_row(
+			"SELECT payload_sha256 FROM protocol_events WHERE run_id = 'run-1' AND sequence_number = 32",
+			[],
+			|row| row.get(0),
+		)
+		.expect("payload digest should read");
+
+	assert_eq!(payload_sha256.len(), 64);
+	assert!(payload_sha256.chars().all(|character| character.is_ascii_hexdigit()));
+}
+
+#[test]
+fn sparse_protocol_event_replay_keeps_leased_run_summary_count_exact() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+	let store = StateStore::open(&state_path).expect("state store should open");
+	let payload = r#"{"threadId":"thread-1","attemptNumber":4}"#;
+
+	store.record_run_attempt("run-1", "PUB-101", 1, "running").expect("run attempt should persist");
+	store
+		.upsert_lease("pubfi", "PUB-101", "run-1", IN_PROGRESS_STATE)
+		.expect("lease should persist");
+	store
+		.append_event("run-1", 32, "thread/archive", payload)
+		.expect("first sparse event should append");
+	store
+		.append_event("run-1", 32, "thread/archive", payload)
+		.expect("matching sparse replay should be idempotent");
+
+	let runs = store.list_leased_runs("pubfi").expect("leased runs should load");
+
+	assert_eq!(runs.len(), 1);
+	assert_eq!(runs[0].run_id(), "run-1");
+	assert_eq!(runs[0].event_count(), 1);
+	assert_eq!(runs[0].last_event_type(), Some("thread/archive"));
+}
+
+#[test]
+fn protocol_event_sequence_conflict_rejects_changed_payload() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+	let store = StateStore::open(&state_path).expect("state store should open");
+
+	store
+		.append_event("run-1", 32, "thread/archive", r#"{"threadId":"thread-1"}"#)
+		.expect("first archive event should append");
+
+	let error = store
+		.append_event("run-1", 32, "thread/archive", r#"{"threadId":"thread-2"}"#)
+		.expect_err("changed payload at the same sequence should be rejected");
+
+	assert!(
+		error.to_string().contains("conflicts with an existing runtime journal event"),
+		"unexpected error: {error:?}",
+	);
+	assert_eq!(store.event_count("run-1").expect("event count should load"), 1);
+}
+
+#[test]
 fn persistent_run_attempt_update_does_not_refresh_full_event_journal() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let state_path = temp_dir.path().join("runtime.sqlite3");

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,12 @@
 # Documentation Log
 
+## 2026-06-18
+
+- Added protocol journal replay idempotency to the runtime contract: protocol events
+  now retain payload SHA-256 identity so app-server continuation/recovery can replay
+  the same event without failing the lane, while conflicting same-sequence events still
+  fail closed.
+
 ## 2026-06-17
 
 - Dogfooded the portable `repo-memory-writer` plugin skill on this repository and

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -6,9 +6,9 @@ status: active
 authority: normative
 owner: runtime
 tags: [spec]
-code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs]
-drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, decodex intake goal, program_issue_mappings]
-last_verified: 2026-06-17
+code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs]
+drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, protocol_events, decodex intake goal, program_issue_mappings]
+last_verified: 2026-06-18
 ---
 # Runtime Specification
 
@@ -57,6 +57,11 @@ state or this state machine.
 ## Source of truth boundaries
 
 - The Decodex runtime SQLite database is the single-machine source of truth for run leases, attempts, run-control channels, protocol events, private execution events, harness-outcome telemetry, latent and promoted Decision Contracts, internal Execution Programs, worktree mappings, retained PR state, review-policy checkpoints, loop-guardrail checkpoints, retry state, phase timing, project registration, tracker cache, PR cache, and connector backoff.
+- Protocol events are keyed by `(run_id, sequence_number)` and store a `payload_sha256`
+  digest for replay identity without storing raw protocol payloads. Exact replays of
+  the same event type and digest are idempotent and must not inflate event counts or
+  fail a continuation/recovery path. A different event type or different digest at the
+  same sequence remains a journal integrity error.
 - Linear remains the team-visible tracker surface for issue lifecycle, queue/active/manual-attention labels, and coarse lifecycle summaries such as start, PR-ready, blocked, failed, landed, and done.
 - Versioned Linear execution event comments use the schema in
   [`linear-execution-ledger.md`](./linear-execution-ledger.md), but fine-grained runtime truth must not be rebuilt from comments every tick.


### PR DESCRIPTION
## Summary
- store protocol event payload SHA-256 digests and treat exact same type+digest replays as idempotent
- keep conflicting same-sequence events failing closed
- fix sparse sequence summary counts to use event count, not last sequence
- document the canonical protocol journal contract

## Migration cleanup
- ran the transitional binary against /Users/x/.codex/decodex/runtime.sqlite3 and confirmed protocol_events.payload_sha256 exists
- final code removes the runtime ALTER TABLE migration path and legacy NULL-digest replay acceptance

## Verification
- cargo make check
- cargo test -p decodex protocol_event
- cargo test -p decodex recorder_treats_matching_protocol_replay
- decodex status --json --limit 1 against the real runtime DB after removing migration code
- semantic drift audit: pass
