### PR TITLE
Use direct Decodex CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,28 +78,28 @@ Public site authority stays in `site/` and the site specs.
 
 ### Runtime CLI
 
-From the workspace root:
+Use:
 
 ```sh
-cargo run -p decodex --bin decodex -- --help
-cargo run -p decodex --bin decodex -- app
-cargo run -p decodex --bin decodex -- probe stdio://
-cargo run -p decodex --bin decodex -- project list
-cargo run -p decodex --bin decodex -- status
-cargo run -p decodex --bin decodex -- status --live
-cargo run -p decodex --bin decodex -- diagnose --json
-cargo run -p decodex --bin decodex -- maintenance prune --dry-run
-cargo run -p decodex --bin decodex -- lane steer <ISSUE> --run-id <RUN_ID> --expected-turn-id <TURN_ID> --message <TEXT>
-cargo run -p decodex --bin decodex -- research compile --intent "research X"
-cargo run -p decodex --bin decodex -- research compile --input research-design-run.json
-cargo run -p decodex --bin decodex -- research promote <CONTRACT_ID>
-cargo run -p decodex --bin decodex -- intake goal --project decodex <CONTRACT_ID> --dry-run
-cargo run -p decodex --bin decodex -- intake goal --project decodex <CONTRACT_ID> --apply
-cargo run -p decodex --bin decodex -- intake issues --project decodex XY-1 XY-2 --dry-run
-cargo run -p decodex --bin decodex -- intake issues --project decodex XY-1 XY-2 --apply
-cargo run -p decodex --bin decodex -- mcp serve --transport stdio
-cargo run -p decodex --bin decodex -- run --dry-run
-cargo run -p decodex --bin decodex -- serve --listen-address 127.0.0.1:8192
+decodex --help
+decodex app
+decodex probe stdio://
+decodex project list
+decodex status
+decodex status --live
+decodex diagnose --json
+decodex maintenance prune --dry-run
+decodex lane steer <ISSUE> --run-id <RUN_ID> --expected-turn-id <TURN_ID> --message <TEXT>
+decodex research compile --intent "research X"
+decodex research compile --input research-design-run.json
+decodex research promote <CONTRACT_ID>
+decodex intake goal --project decodex <CONTRACT_ID> --dry-run
+decodex intake goal --project decodex <CONTRACT_ID> --apply
+decodex intake issues --project decodex XY-1 XY-2 --dry-run
+decodex intake issues --project decodex XY-1 XY-2 --apply
+decodex mcp serve --transport stdio
+decodex run --dry-run
+decodex serve --listen-address 127.0.0.1:8192
 ```
 
 Project-scoped commands accept `--config <PROJECT_DIR>` after the subcommand when the
@@ -159,16 +159,6 @@ local desktop and CLI clients. The gateway exposes checked-in documentation, che
 JSON research reports, runtime Decision Contract readback, local status snapshots, and
 lane-control readback as MCP resources only. It does not expose mutating MCP tools.
 Stdout is reserved for MCP JSON-RPC messages; diagnostics and logs stay off stdout.
-
-### Install from Source
-
-```sh
-git clone https://github.com/hack-ink/decodex
-cd decodex
-
-cargo install --path apps/decodex --force
-decodex --version
-```
 
 ### Project contracts
 
@@ -273,7 +263,7 @@ default `127.0.0.1:8192` runtime.
 
 ```sh
 DECODEX_APP_SERVER_URL=http://127.0.0.1:57399 open -n target/decodex-app/Decodex.app
-DECODEX_APP_SERVER_URL=http://127.0.0.1:57399 cargo run -p decodex --bin decodex -- app \
+DECODEX_APP_SERVER_URL=http://127.0.0.1:57399 decodex app \
   --bundle target/decodex-app/Decodex.app --new
 ```
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -6,6 +6,9 @@
   now retain payload SHA-256 identity so app-server continuation/recovery can replay
   the same event without failing the lane, while conflicting same-sequence events still
   fail closed.
+- Simplified Decodex plugin and docs manual command guidance so agent-facing usage
+  examples call `decodex ...` directly instead of teaching source-run or install
+  variants.
 
 ## 2026-06-17
 

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -175,7 +175,7 @@ Every docs-changing lane follows this loop:
 3. If the change affects behavior, update the owning concept's `code_refs` and
    `drift_watch`, or update/create a linked drift audit.
 4. Update lane indexes and `docs/log.md` when routing changes.
-5. Run `cargo run -p decodex --bin decodex -- docs check`.
+5. Run `decodex docs check`.
 6. Treat docs check or drift failure as a completion blocker. Research uncertainty uses
    the research-contract `needs_human_decision` status; implementation-lane blockers
    use the runtime `manual_attention` terminal path.
@@ -215,9 +215,8 @@ Run:
 decodex docs check
 ```
 
-In this repository, `cargo make check` includes the same docs gate through
-`cargo run -p decodex --bin decodex -- docs check`. `decodex docs lint` remains an
-alias for compatibility.
+In this repository, `cargo make check` includes the same docs gate. `decodex docs lint`
+remains an alias for compatibility.
 
 The check fails when:
 

--- a/docs/reference/build-test-run.md
+++ b/docs/reference/build-test-run.md
@@ -1,7 +1,7 @@
 ---
 type: Reference
 title: Build Test Run Entrypoints
-description: Helps a new agent understand repo setup, build, test, run, validation, automation resources, and command entrypoints.
+description: Helps a new agent understand repo setup, build, test, run, validation, automation resources, and Decodex command entrypoints.
 status: active
 authority: current_state
 owner: docs
@@ -10,7 +10,7 @@ source_refs: []
 code_refs: [Makefile.toml, Cargo.toml, apps/decodex/Cargo.toml, site/package.json, apps/decodex-app/Package.swift, README.md]
 related: [./workspace-layout.md, ./test-suite.md, ./docs-knowledge-map.md, ../policy.md, ../runbook/release-readiness.md, ../spec/okf-knowledge-layer.md]
 drift_watch: [Makefile.toml, Cargo.toml, site/package.json, apps/decodex-app/Package.swift, cargo make --list-all-steps, cargo make check, cargo nextest list --workspace --all-targets --all-features]
-last_verified: 2026-06-17
+last_verified: 2026-06-18
 ---
 
 # Build Test Run Entrypoints
@@ -19,9 +19,9 @@ Purpose: Map the current repository commands for setup, building, testing, runni
 and validating Decodex.
 
 Read this when: You need the smallest current entrypoint for repo setup, local
-validation, task-runner automation resources, or invoking the Decodex runtime from
-source. This is the first reference for a new agent that needs to understand how repo
-setup and command entrypoints fit together.
+validation, task-runner automation resources, or Decodex CLI usage. This is the first
+reference for a new agent that needs to understand how repo setup and command
+entrypoints fit together.
 
 Not this document: The full test inventory, repository directory ownership, release
 procedure, or runtime behavior contract.
@@ -55,7 +55,7 @@ explain why a narrower check is sufficient.
 | Task | Command surface | Owns |
 | --- | --- | --- |
 | `cargo make check` | composite root task | Aggregate build, docs, node, Rust, format, lint, and test validation |
-| `cargo make check-docs` | `cargo run -p decodex --bin decodex -- docs lint` | Decodex docs OKF/profile validation |
+| `cargo make check-docs` | `decodex docs check` | Decodex docs OKF/profile validation |
 | `cargo make check-rust` | `cargo check --all-features --all-targets --workspace` | Rust workspace type checking |
 | `cargo make check-node` | `npm run check` in `site/` | Astro and TypeScript site checks |
 | `cargo make fmt-check` | Rust nightly fmt plus Taplo check | Rust and TOML formatting |
@@ -72,9 +72,9 @@ native app surface.
 Use these commands when a change does not need the full aggregate gate:
 
 ```sh
-cargo run -p decodex --bin decodex -- docs check
-cargo run -p decodex --bin decodex -- docs graph
-cargo run -p decodex --bin decodex -- okf route docs "how do I validate this repo"
+decodex docs check
+decodex docs graph
+decodex okf route docs "how do I validate this repo"
 cargo check --all-features --all-targets --workspace
 cargo nextest run --workspace --all-targets --all-features
 cargo test -p decodex <filter>
@@ -82,15 +82,14 @@ npm --prefix site run check
 npm --prefix site run build
 ```
 
-Use these commands when invoking the runtime from source:
+Use these commands when invoking the runtime:
 
 ```sh
-cargo run -p decodex --bin decodex -- --help
-cargo run -p decodex --bin decodex -- status
-cargo run -p decodex --bin decodex -- diagnose --json
-cargo run -p decodex --bin decodex -- mcp serve --transport stdio
-cargo run -p decodex --bin decodex -- serve --listen-address 127.0.0.1:8192
-cargo install --path apps/decodex --force
+decodex --help
+decodex status
+decodex diagnose --json
+decodex mcp serve --transport stdio
+decodex serve --listen-address 127.0.0.1:8192
 ```
 
 `README.md` remains the better source for the broad CLI usage list. This document owns

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -6,7 +6,7 @@ status: active
 authority: current_state
 owner: docs
 tags: [reference]
-last_verified: 2026-06-17
+last_verified: 2026-06-18
 ---
 # Workspace Layout
 
@@ -50,16 +50,17 @@ For build, test, run, setup, validation, and task-runner command entrypoints, re
 The root `Cargo.toml` is a workspace manifest. It does not define a root package.
 
 `apps/decodex/Cargo.toml` is the only checked-in Rust package in this first integrated
-layout. Use package-qualified commands when invoking the runtime from the workspace root:
+layout. Use package-qualified Cargo commands only when validating source changes from
+the workspace root:
 
 ```sh
-cargo run -p decodex --bin decodex -- --help
+cargo check -p decodex --all-features --all-targets
 cargo build -p decodex
-cargo install --path apps/decodex --force
 ```
 
-For the current aggregate validation gates, use [`./build-test-run.md`](./build-test-run.md)
-instead of treating this layout reference as command authority.
+For Decodex CLI usage and the current aggregate validation gates, use
+[`./build-test-run.md`](./build-test-run.md) instead of treating this layout reference
+as command authority.
 
 Do not add new runtime behavior to a root `src/` directory. If Decodex later needs
 shared crates, add them under `packages/` and make the boundary explicit in this

--- a/docs/runbook/linear-archive-hygiene.md
+++ b/docs/runbook/linear-archive-hygiene.md
@@ -45,7 +45,7 @@ Verification:
 Use the dry-run default before demos or large issue seeding:
 
 ```sh
-cargo run -p decodex --bin decodex -- archive-linear --repo-label repo:decodex --older-than-days 30
+decodex archive-linear --repo-label repo:decodex --older-than-days 30
 ```
 
 The command prints the terminal issues that would be archived, using `updatedAt`
@@ -54,7 +54,7 @@ as the age cutoff. It does not mutate Linear unless `--execute` is present.
 For another Decodex-managed repo, run from that registered checkout or pass its centralized config:
 
 ```sh
-cargo run -p decodex --bin decodex -- archive-linear --config ~/.codex/decodex/projects/ashen-vale --repo-label repo:ashen-vale --older-than-days 30
+decodex archive-linear --config ~/.codex/decodex/projects/ashen-vale --repo-label repo:ashen-vale --older-than-days 30
 ```
 
 ## Execute
@@ -63,7 +63,7 @@ After the dry run shows only issues that should leave the active tracker view,
 repeat the command with `--execute`:
 
 ```sh
-cargo run -p decodex --bin decodex -- archive-linear --repo-label repo:decodex --older-than-days 30 --execute
+decodex archive-linear --repo-label repo:decodex --older-than-days 30 --execute
 ```
 
 This archives issues through Linear `issueArchive` with `trash = false`. It does

--- a/docs/runbook/release-readiness.md
+++ b/docs/runbook/release-readiness.md
@@ -88,9 +88,9 @@ Collect evidence in this order:
 8. Verify the current-source CLI path:
 
    ```sh
-   cargo run -p decodex --bin decodex -- probe stdio://
-   cargo run -p decodex --bin decodex -- status --live --json
-   cargo run -p decodex --bin decodex -- run --dry-run
+   decodex probe stdio://
+   decodex status --live --json
+   decodex run --dry-run
    ```
 
 9. Dogfood at least one real Decodex lane with `[codex].review = "standard"`.
@@ -103,7 +103,7 @@ Collect evidence in this order:
 10. Read the dogfood lane private evidence:
 
    ```sh
-   cargo run -p decodex --bin decodex -- evidence <ISSUE> --run-id <RUN_ID> --attempt <N> --json
+   decodex evidence <ISSUE> --run-id <RUN_ID> --attempt <N> --json
    ```
 
    The readback must summarize review, recovery, boundary, or harness evidence when

--- a/docs/runbook/self-dogfood-pilot.md
+++ b/docs/runbook/self-dogfood-pilot.md
@@ -14,7 +14,7 @@ Goal: Run the `decodex` MVP against one target repository and a bounded set of q
 Read this when: You are preparing a dry run or live self-dogfood pilot and need the bounded operator procedure for config, target-repo requirements, and expected run behavior.
 Preconditions: `codex app-server` is available locally; `gh` is available locally for live PR-backed handoff validation, merge inspection, and retained branch cleanup; the target repository exists on disk; the project contract exists under `~/.codex/decodex/projects/<service-id>/`; referenced `WORKFLOW.md [context.read_first]` files exist in `[paths].repo_root`; the Linear team exposes the required workflow states; and the tracker and GitHub token env-var names are configured through `tracker.api_key_env_var` and `github.token_env_var` in the centralized project config.
 Depends on: `docs/spec/runtime.md`, `docs/spec/workflow-file.md`, `docs/spec/app-server.md`, the registered project `WORKFLOW.md`, and `Makefile.toml` for repo-native verification tasks.
-Verification: `cargo run -p decodex --bin decodex -- probe`; `cargo run -p decodex --bin decodex -- project add ~/.codex/decodex/projects/decodex`; `cargo run -p decodex --bin decodex -- project list`; `cargo run -p decodex --bin decodex -- run --dry-run`; and, when the environment is ready, `cargo run -p decodex --bin decodex -- run`.
+Verification: `decodex probe`; `decodex project add ~/.codex/decodex/projects/decodex`; `decodex project list`; `decodex run --dry-run`; and, when the environment is ready, `decodex run`.
 
 ## Alignment note
 
@@ -37,7 +37,7 @@ Verification: `cargo run -p decodex --bin decodex -- probe`; `cargo run -p decod
 Recommended first-run check:
 
 ```sh
-cargo run -p decodex --bin decodex -- probe
+decodex probe
 ```
 
 If `decodex probe` does not return `PROBE_OK`, stop there. The orchestrator loop depends on the same direct `app-server` contract.
@@ -200,9 +200,9 @@ Use `decodex` itself as the first target repo and keep intake bounded by applyin
 Use dry run first to validate config loading, issue discovery, and worktree planning without mutating Linear or creating worktree directories.
 
 ```sh
-cargo run -p decodex --bin decodex -- project add ~/.codex/decodex/projects/decodex
-cargo run -p decodex --bin decodex -- project list
-cargo run -p decodex --bin decodex -- run --dry-run
+decodex project add ~/.codex/decodex/projects/decodex
+decodex project list
+decodex run --dry-run
 ```
 
 Expected behavior:
@@ -221,7 +221,7 @@ dry run: no Decodex project config supplied or registered; nothing to execute.
 ### Live run
 
 ```sh
-cargo run -p decodex --bin decodex -- run
+decodex run
 ```
 
 On a normal successful run, `decodex` will:
@@ -306,22 +306,15 @@ is still unmerged, use the normal reviewed lane checkout instead.
 After `probe`, `project add`, `run --dry-run`, and `run` all behave as expected, use `serve` for the long-running pilot loop:
 
 ```sh
-cargo run -p decodex --bin decodex -- serve
+decodex serve
 ```
 
-### Installed-binary observer loop
+### CLI observer loop
 
 Use this path when the demo operator is starting from a clean `decodex` checkout and
 wants to observe the self-bootstrap loop without reading source code.
 
-1. Install or refresh the current checkout as the local `decodex` binary:
-
-   ```sh
-   cargo install --path apps/decodex --locked --force
-   export PATH="$HOME/.cargo/bin:$PATH"
-   ```
-
-2. Before queueing a self-bootstrap batch, confirm the installed binary matches a
+1. Before queueing a self-bootstrap batch, confirm the active `decodex` CLI matches a
    checkout synced to the current landed `main`:
 
    ```sh
@@ -330,17 +323,10 @@ wants to observe the self-bootstrap loop without reading source code.
    ```
 
    If `decodex --version` does not report the same short revision as the current
-   landed `HEAD`, or after landing Decodex runtime changes, reinstall before starting
-   the next batch:
-
-   ```sh
-   cargo install --path apps/decodex --force
-   decodex --version
-   ```
-
-   Stale installed binaries keep running pre-fix runtime behavior against new
-   self-bootstrap issues, which can make dashboard or Linear evidence look like a new
-   runtime regression.
+   landed `HEAD`, or after landing Decodex runtime changes, refresh the active CLI
+   through the normal release path before starting the next batch. Stale CLI processes
+   keep running pre-fix runtime behavior against new self-bootstrap issues, which can
+   make dashboard or Linear evidence look like a new runtime regression.
 
    Before-batch stale-process check, after starting or restarting `decodex serve`:
 
@@ -356,17 +342,17 @@ wants to observe the self-bootstrap loop without reading source code.
    Use the port from the active `--listen-address` if it is not `127.0.0.1:8192`.
    Treat a missing listener, a binary revision that does not match the current landed
    `HEAD`, or a `decodex serve` start time older than the latest runtime or dashboard
-   landing as stale evidence. Restart `decodex serve` after reinstalling or after any
-   runtime/UI land, then rerun `/livez` on the same port and reload the dashboard
-   before applying new queue labels. A browser tab left open on an old port is not
-   evidence for the current serve process.
+   landing as stale evidence. Restart `decodex serve` after refreshing the CLI or
+   after any runtime/UI land, then rerun `/livez` on the same port and reload the
+   dashboard before applying new queue labels. A browser tab left open on an old port
+   is not evidence for the current serve process.
 
-   Installed-dashboard smoke checklist: after `decodex --version` matches the short
-   `HEAD`, restart `decodex serve` from that installed binary. Verify `GET /livez`
-   passes, then confirm `decodex status --json` and the browser dashboard agree on
-   project registration and visible lane counts before queueing work.
+   Dashboard smoke checklist: after `decodex --version` matches the short `HEAD`,
+   restart `decodex serve`. Verify `GET /livez` passes, then confirm
+   `decodex status --json` and the browser dashboard agree on project registration and
+   visible lane counts before queueing work.
 
-3. Confirm the installed binary can reach the Codex app-server boundary:
+2. Confirm the active CLI can reach the Codex app-server boundary:
 
    ```sh
    decodex probe
@@ -662,7 +648,7 @@ ordinary `decodex serve` and leaves scheduler cadence to CLI-owned defaults. Dev
 not a scheduler and must not be used for this runbook's automation, queue intake,
 project registration, or retained-lane recovery steps.
 
-The listener serves the operator console from the canonical `GET /` and `GET /dashboard` routes, the same JSON operator snapshot used by `cargo run -p decodex --bin decodex -- status --json` through the `/dashboard/control` WebSocket, and the minimal `GET /livez` liveness probe on the same listener. The single console keeps `Projects`, `Running Lanes`, `Intake Queue`, `Review & Landing`, `Recovery Worktrees`, and `Run Ledger` visible together. Intake candidates that are already claimed by a running lane are shown as claimed queue echoes, capacity-bound candidates are shown as waiting rather than blocked, running lane worktrees stay with their owning lane, and retained/recovery worktrees remain folded until diagnostics are needed:
+The listener serves the operator console from the canonical `GET /` and `GET /dashboard` routes, the same JSON operator snapshot used by `decodex status --json` through the `/dashboard/control` WebSocket, and the minimal `GET /livez` liveness probe on the same listener. The single console keeps `Projects`, `Running Lanes`, `Intake Queue`, `Review & Landing`, `Recovery Worktrees`, and `Run Ledger` visible together. Intake candidates that are already claimed by a running lane are shown as claimed queue echoes, capacity-bound candidates are shown as waiting rather than blocked, running lane worktrees stay with their owning lane, and retained/recovery worktrees remain folded until diagnostics are needed:
 
 - `GET /` or `GET /dashboard`: the same single-page operator console
 - `GET /dashboard/control`: WebSocket transport for snapshots, live run activity, and local dashboard control acknowledgements
@@ -710,8 +696,8 @@ After running manual commands from a lane, check `decodex project list` or the o
 Start with local runtime readback:
 
 ```sh
-cargo run -p decodex --bin decodex -- status
-cargo run -p decodex --bin decodex -- status --json
+decodex status
+decodex status --json
 ```
 
 Use the human-readable view when you need the current leased run, lane worktree
@@ -723,7 +709,7 @@ If the status row or run capsule points to private evidence, inspect it before t
 the Linear summary as complete:
 
 ```sh
-cargo run -p decodex --bin decodex -- evidence XY-123 --run-id <RUN_ID> --attempt <N> --json
+decodex evidence XY-123 --run-id <RUN_ID> --attempt <N> --json
 ```
 
 Then inspect Linear for the public collaboration state:
@@ -841,9 +827,9 @@ repo gate commands. Linear should carry only the coarse team-visible failure sum
 When changing `decodex` itself, keep the pilot path healthy with:
 
 ```sh
-cargo run -p decodex --bin decodex -- probe
-cargo run -p decodex --bin decodex -- project add ~/.codex/decodex/projects/decodex
-cargo run -p decodex --bin decodex -- run --dry-run
+decodex probe
+decodex project add ~/.codex/decodex/projects/decodex
+decodex run --dry-run
 cargo make fmt
 cargo make lint-fix
 cargo make check

--- a/plugins/decodex/references/docs-method.md
+++ b/plugins/decodex/references/docs-method.md
@@ -20,7 +20,7 @@ workflow, or docs-impact gates.
 2. Update the owner; do not duplicate claims.
 3. Add `code_refs`, `drift_watch`, or drift audit evidence for behavior changes.
 4. Update indexes and `docs/log.md` for routing, naming, or promotion changes.
-5. Run `cargo run -p decodex --bin decodex -- docs check`.
+5. Run `decodex docs check`.
 
 ## Docs Impact
 

--- a/plugins/decodex/references/docs-okf.md
+++ b/plugins/decodex/references/docs-okf.md
@@ -37,6 +37,6 @@ Recommended structured fields: `tags`, `source_refs`, `code_refs`, `related`,
 
 ## Validation
 
-Run `cargo run -p decodex --bin decodex -- docs check`.
+Run `decodex docs check`.
 
-`cargo run -p decodex --bin decodex -- docs lint` remains a compatibility alias.
+`decodex docs lint` remains a compatibility alias.

--- a/plugins/decodex/skills/docs-okf/SKILL.md
+++ b/plugins/decodex/skills/docs-okf/SKILL.md
@@ -15,5 +15,4 @@ Read `../../references/docs-okf.md` before creating, moving, or repairing concep
 - Keep research contracts and drift audit evidence concepts in their required section
   shape.
 - Do not add JSON or generated state under `docs/`.
-- Run `cargo run -p decodex --bin decodex -- docs check` before claiming docs
-  readiness.
+- Run `decodex docs check` before claiming docs readiness.

--- a/plugins/decodex/skills/docs/SKILL.md
+++ b/plugins/decodex/skills/docs/SKILL.md
@@ -21,6 +21,5 @@ research, or documentation.
 - If docs impact is `research_required`, switch to the Decodex `research*` skill
   family.
 - Record routing, promotion, rename, or maintenance changes in `docs/log.md`.
-- Run `cargo run -p decodex --bin decodex -- docs check` before claiming docs
-  readiness.
+- Run `decodex docs check` before claiming docs readiness.
 - Treat docs check or drift failure as a completion blocker.

--- a/plugins/decodex/skills/manual-cli/SKILL.md
+++ b/plugins/decodex/skills/manual-cli/SKILL.md
@@ -8,8 +8,7 @@ description: Use when a human drives Decodex CLI.
 Assist human-driven Decodex CLI work without taking over retained automation. Read
 `../../references/routing.md` for commands and recovery boundaries.
 
-- Use installed `decodex` for installed runtime work.
-- Use `cargo run -p decodex --bin decodex -- ...` in this repository.
+- Use `decodex ...` for CLI commands.
 - Treat `run --dry-run` as planning evidence, not proof of live writes or closeout.
 - Before live `decodex run`, read `automation` and project `WORKFLOW.md`.
 - Do not hand-edit runtime DB state or clean retained worktrees from the side.


### PR DESCRIPTION
## Summary
- make agent-facing Decodex guidance use direct `decodex ...` commands
- remove source-run/install wording from README, docs policy, runbooks, and Decodex plugin skills
- keep source validation commands scoped to actual development checks

## Verification
- decodex docs check
- decodex docs graph
- git diff --check
- residual command/install wording scan
- plugin-eval analyze plugins/decodex --format markdown