### PR TITLE
Add repo memory curator skill

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,9 @@
 
 ## 2026-06-18
 
+- Added `repo-memory-curator` so existing OKF/LLM Wiki bundles have a dedicated
+  growth and maintenance skill for top-1/top-3 route benchmark misses,
+  metadata-only owner tuning, orphan triage, graph repair, and link tuning.
 - Added protocol journal replay idempotency to the runtime contract: protocol events
   now retain payload SHA-256 identity so app-server continuation/recovery can replay
   the same event without failing the lane, while conflicting same-sequence events still

--- a/docs/reference/docs-knowledge-map.md
+++ b/docs/reference/docs-knowledge-map.md
@@ -7,7 +7,7 @@ authority: current_state
 owner: docs
 tags: [docs, okf, llm-wiki, repo-memory, reference]
 source_refs: [https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md, https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing, https://llmstxt.org/, https://diataxis.fr/, https://developers.openai.com/codex/guides/agents-md, https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions]
-code_refs: [apps/decodex/src/docs_okf.rs, apps/decodex/src/cli.rs, docs/index.md, docs/policy.md, docs/spec/okf-knowledge-layer.md, plugins/decodex/skills/repo-memory-writer/SKILL.md]
+code_refs: [apps/decodex/src/docs_okf.rs, apps/decodex/src/cli.rs, docs/index.md, docs/policy.md, docs/spec/okf-knowledge-layer.md, plugins/decodex/skills/repo-memory-writer/SKILL.md, plugins/decodex/skills/repo-memory-curator/SKILL.md]
 related: [../policy.md, ../spec/okf-knowledge-layer.md, ../evidence/docs-self-iteration.md, ./build-test-run.md, ./workspace-layout.md]
 drift_watch: [decodex docs check, decodex okf graph docs, decodex okf route docs, docs index, docs lane index, okf orphan concepts]
 last_verified: 2026-06-17
@@ -132,6 +132,8 @@ In another repository, the Decodex plugin can now provide three distinct layers:
 - `decodex okf init <root> --profile repo-memory` creates the portable scaffold.
 - `repo-memory-writer` guides Codex to read repository evidence and write canonical
   concepts instead of generated summaries.
+- `repo-memory-curator` guides later graph repair, orphan triage, route benchmarks,
+  and metadata/link tuning after real usage exposes misses.
 - `decodex okf check/graph/route` verifies shape, graph health, and task routing.
 
 The expected first useful output is not a complete encyclopedia. It is a small,

--- a/plugins/decodex/.codex-plugin/plugin.json
+++ b/plugins/decodex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "decodex",
   "version": "0.2.0",
-  "description": "Decodex agent workflows for portable OKF bundles, repo memory, docs, research, issue planning, automation, commit, and landing.",
+  "description": "Decodex agent workflows for portable OKF bundles, repo memory writing and curation, docs, research, issue planning, automation, commit, and landing.",
   "author": {
     "name": "hack-ink",
     "email": "hi@hack.ink",
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Decodex",
     "shortDescription": "Maintain docs, research, plan, and operate Decodex.",
-    "longDescription": "Routes portable OKF/LLM Wiki bundle work, source-backed repo-memory writing, Decodex OKF docs maintenance, docs drift audits, bounded research, promotion, issue briefing and planning, CLI, labels, commit, landing, and automation.",
+    "longDescription": "Routes portable OKF/LLM Wiki bundle work, source-backed repo-memory writing and curation, Decodex OKF docs maintenance, docs drift audits, bounded research, promotion, issue briefing and planning, CLI, labels, commit, landing, and automation.",
     "developerName": "hack-ink",
     "category": "Development",
     "capabilities": [
@@ -32,7 +32,7 @@
     "privacyPolicyURL": "https://github.com/hack-ink/decodex",
     "termsOfServiceURL": "https://github.com/hack-ink/decodex",
     "defaultPrompt": [
-      "Work with an OKF bundle.",
+      "Curate a repo-memory OKF bundle.",
       "Maintain Decodex docs.",
       "Research this with Decodex."
     ],

--- a/plugins/decodex/references/okf-layer.md
+++ b/plugins/decodex/references/okf-layer.md
@@ -1,8 +1,8 @@
 # Portable OKF Layer
 
 Use this for portable OKF bundles, LLM Wiki retrieval, and cross-repository memory.
-Use `repo-memory-writer` when the task is to create repository knowledge from code
-evidence, not merely maintain an existing bundle.
+Use `repo-memory-writer` for first-pass repo knowledge and `repo-memory-curator` for
+route misses, orphans, noisy top results, duplicate claims, or graph decay.
 
 ## Boundary
 
@@ -32,10 +32,12 @@ overwrites, and validates. `decodex docs` defaults to root `docs/` and profile
 
 ## Rules
 
-Producers pick a profile first, keep concepts one-topic, use frontmatter for
-routing, link real relationships, update `index.md` or `log.md` for navigation
-changes, and preserve unknown fields.
+Producers pick a profile first, keep concepts one-topic, use frontmatter for routing,
+link real relationships, update indexes/logs, and preserve unknown fields.
 
 Consumers start with `decodex okf route` or `decodex okf find`, use graph output for
 relationships, tolerate unknown `type` values, and use Decodex `docs-*` skills only
 for this repository's strict `docs/` profile.
+
+Maintainers use route benchmarks and graph/orphan triage; shape checks prove only
+conformance.

--- a/plugins/decodex/skills/okf-maintain/SKILL.md
+++ b/plugins/decodex/skills/okf-maintain/SKILL.md
@@ -7,7 +7,8 @@ description: Use when creating or updating OKF/LLM Wiki concepts, indexes, logs,
 
 Produce and maintain OKF bundles without coupling them to Decodex-specific policy.
 For bootstrapping high-quality repository memory from code evidence, use
-`repo-memory-writer` first.
+`repo-memory-writer` first. For route benchmark misses, orphan triage, noisy top
+results, or graph repair, use `repo-memory-curator`.
 
 Read `../../references/okf-layer.md` before creating concepts, moving files, or
 repairing graph quality.

--- a/plugins/decodex/skills/okf-query/SKILL.md
+++ b/plugins/decodex/skills/okf-query/SKILL.md
@@ -16,4 +16,6 @@ bundle graph findings.
 - Use `decodex okf graph <root> --json` when relationship shape, orphans, or broken
   bundle-internal links matter.
 - Return the smallest concept set that can answer the task.
+- If query evidence shows repeated misses, noisy top results, or unexplained orphans,
+  switch to `repo-memory-curator` before editing the bundle.
 - Do not require Decodex lanes or Linear workflow for portable OKF consumption.

--- a/plugins/decodex/skills/repo-memory-curator/SKILL.md
+++ b/plugins/decodex/skills/repo-memory-curator/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: repo-memory-curator
+description: Use when improving an existing repo-memory OKF/LLM Wiki bundle after route misses, noisy top results, orphan concepts, duplicate claims, stale links, or graph decay.
+---
+
+# Repo Memory Curator
+
+Maintain repository memory as a living, source-backed wiki after the first writer pass.
+
+Basis: OKF is Markdown plus YAML frontmatter, not a required query runtime. LLM Wiki is
+the method on top: maintain an interlinked Markdown artifact through ingest, query, and
+lint. llms.txt reinforces concise Markdown navigation, clear link descriptions, fixed
+processing where possible, and test questions.
+
+- Use `repo-memory-writer` for first-pass creation; use this skill for growth and
+  repair after real usage exposes misses.
+- Treat `docs check` or `okf check` as shape validation only. Prove usefulness with
+  `graph`, `find`, and representative `route` probes.
+- Prefer metadata and link repairs before creating new concepts.
+- Improve top-result quality by editing the owner concept's `title`, `description`,
+  `tags`, routing header, and links; do not pad unrelated concepts.
+- Treat a metadata-only repair as successful when the same real question moves to the
+  expected owner without increasing noise elsewhere.
+- Triage orphans as missing edge, intentional leaf, duplicate, stale concept, or
+  low-value generated summary before editing.
+- Keep one owner concept per durable claim; link instead of copying.
+- Record benchmark evidence and remaining misses in the bundle log or final answer.
+
+Growth loop:
+
+1. Capture a real usage signal: failed route, noisy top result, orphan report,
+   duplicate claim, stale command, or user confusion.
+2. Identify the owner concept. If none exists, create the smallest source-backed
+   concept that can own the claim.
+3. Repair in this order: owner `description`, `tags`, routing header, "Not this"
+   boundary, Markdown links/`related`, lane index. Split, merge, or delete only after
+   ownership is proven wrong.
+4. Re-run the failing probe plus a small regression set.
+5. Record material navigation changes in `log.md`.
+
+Route benchmark rules:
+
+- Use representative task questions, not keyword lists.
+- Map each question to one or more acceptable owner concepts.
+- Top-3 is the minimum practical bar; top-1 matters for common operational questions.
+- If top-3 passes but top-1 is noisy, strengthen the expected owner metadata first.
+- If a noisy result overclaims scope, narrow that concept's description or boundary.
+- Preserve before/after counts for real question sets, especially top-1 and top-3.
+
+Orphan triage:
+
+- Treat orphan count as a maintenance queue, not a vanity metric; prioritize concepts
+  tied to common workflows, failed route probes, or stale ownership claims.
+- Missing edge: add a real Markdown link or `related` edge.
+- Intentional leaf: keep if `find` or route can discover it and it has a narrow role.
+- Duplicate: merge into the canonical owner.
+- Stale concept: delete or mark superseded according to bundle policy.
+- Generated summary: remove unless it owns a durable sourced claim.
+
+Metadata rules:
+
+- `description` is the strongest routing sentence; include natural task language.
+- `tags` carry cross-cutting lookup terms and common synonyms.
+- `source_refs` cite external evidence; `code_refs` point at driftable repo files.
+- `related` should help a future task, not decorate the graph.
+- `drift_watch` names concrete files, commands, or evidence checks.
+
+Done evidence: report check result, graph counts, top-1/top-3 benchmark results,
+metadata/find probes when relevant, and any remaining orphan or route noise.

--- a/plugins/decodex/skills/repo-memory-writer/SKILL.md
+++ b/plugins/decodex/skills/repo-memory-writer/SKILL.md
@@ -6,7 +6,8 @@ description: Use when bootstrapping or improving source-backed repo-memory OKF/L
 # Repo Memory Writer
 
 Build source-backed repository knowledge. The AI writes the concepts; `decodex okf`
-only scaffolds, checks, routes, and graphs them.
+only scaffolds, checks, routes, and graphs them. Use `repo-memory-curator` after
+real route, graph, or orphan evidence shows an existing bundle needs repair.
 
 Operating rules:
 
@@ -34,7 +35,7 @@ Workflow:
    decisions.
 5. Keep each concept one-topic. Add `description`, useful `tags`, `source_refs`,
    `code_refs`, `related`, and `drift_watch` only when they improve retrieval or
-   maintenance.
+   maintenance; leave later graph/route tuning to `repo-memory-curator`.
 6. Update `index.md` and `log.md`; link neighboring concepts instead of repeating
    broad summaries.
 7. Validate with:


### PR DESCRIPTION
Summary:
- add repo-memory-curator skill for OKF/LLM Wiki bundle maintenance
- route repo-memory writer/query/maintain guidance to curator for route misses, orphan triage, graph repair, and metadata tuning
- update docs knowledge map and plugin manifest copy

Validation:
- decodex docs check
- decodex docs graph
- decodex okf route docs "how do I maintain repo memory orphan concepts and route benchmarks"
- semantic_drift_audit.py --repo . --json
- plugin-eval analyze plugins/decodex
- git diff --check