### PR TITLE
Add repo memory evaluator skill

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,9 @@
 
 ## 2026-06-18
 
+- Added `repo-memory-evaluator` so repo-memory OKF/LLM Wiki bundles have a
+  plugin-eval-style quality workflow for static checks, route top-1/top-3 benchmarks,
+  graph health, owner coverage, and before/after curation evidence.
 - Added `repo-memory-curator` so existing OKF/LLM Wiki bundles have a dedicated
   growth and maintenance skill for top-1/top-3 route benchmark misses,
   metadata-only owner tuning, orphan triage, graph repair, and link tuning.

--- a/docs/reference/docs-knowledge-map.md
+++ b/docs/reference/docs-knowledge-map.md
@@ -1,16 +1,16 @@
 ---
 type: Reference
 title: Docs Knowledge Map
-description: Explains how the Decodex docs bundle uses OKF and LLM Wiki routing, and where their value appears in this repository.
+description: Explains Decodex docs OKF/LLM Wiki routing, repo-memory evaluation, route benchmarks, owner coverage, and where their value appears in this repository.
 status: active
 authority: current_state
 owner: docs
-tags: [docs, okf, llm-wiki, repo-memory, reference]
+tags: [docs, okf, llm-wiki, repo-memory, evaluation, route-benchmark, owner-coverage, reference]
 source_refs: [https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md, https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing, https://llmstxt.org/, https://diataxis.fr/, https://developers.openai.com/codex/guides/agents-md, https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions]
-code_refs: [apps/decodex/src/docs_okf.rs, apps/decodex/src/cli.rs, docs/index.md, docs/policy.md, docs/spec/okf-knowledge-layer.md, plugins/decodex/skills/repo-memory-writer/SKILL.md, plugins/decodex/skills/repo-memory-curator/SKILL.md]
+code_refs: [apps/decodex/src/docs_okf.rs, apps/decodex/src/cli.rs, docs/index.md, docs/policy.md, docs/spec/okf-knowledge-layer.md, plugins/decodex/skills/repo-memory-writer/SKILL.md, plugins/decodex/skills/repo-memory-evaluator/SKILL.md, plugins/decodex/skills/repo-memory-curator/SKILL.md]
 related: [../policy.md, ../spec/okf-knowledge-layer.md, ../evidence/docs-self-iteration.md, ./build-test-run.md, ./workspace-layout.md]
 drift_watch: [decodex docs check, decodex okf graph docs, decodex okf route docs, docs index, docs lane index, okf orphan concepts]
-last_verified: 2026-06-17
+last_verified: 2026-06-18
 ---
 
 # Docs Knowledge Map
@@ -119,6 +119,8 @@ The combined value appears when both layers are used together:
 
 - OKF says whether a concept is well shaped.
 - LLM Wiki says whether the concept is discoverable and connected.
+- Repo-memory evaluation says whether real task questions route to the expected owner
+  concepts and what should be fixed first.
 - Drift audit says whether the concept is still true against code and command output.
 
 The remaining maintenance risk is graph decay: a concept can pass shape checks while
@@ -127,11 +129,14 @@ still being hard to discover. Periodic `decodex okf graph docs` and targeted
 
 ## Cross-Repository Use
 
-In another repository, the Decodex plugin can now provide three distinct layers:
+In another repository, the Decodex plugin can now provide distinct layers:
 
 - `decodex okf init <root> --profile repo-memory` creates the portable scaffold.
 - `repo-memory-writer` guides Codex to read repository evidence and write canonical
   concepts instead of generated summaries.
+- `repo-memory-evaluator` guides Codex to score static quality, route benchmark
+  top-1/top-3, graph health, and before/after curation impact. The LLM judges owner
+  correctness; the CLI supplies repeatable check, graph, find, and route evidence.
 - `repo-memory-curator` guides later graph repair, orphan triage, route benchmarks,
   and metadata/link tuning after real usage exposes misses.
 - `decodex okf check/graph/route` verifies shape, graph health, and task routing.

--- a/docs/spec/okf-knowledge-layer.md
+++ b/docs/spec/okf-knowledge-layer.md
@@ -7,10 +7,10 @@ authority: normative
 owner: docs
 tags: [okf, llm-wiki, docs, repo-memory]
 source_refs: [https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md, https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing, https://developers.openai.com/codex/guides/agents-md, https://code.claude.com/docs/en/memory, https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions]
-code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/docs_okf.rs, plugins/decodex/references/okf-layer.md, plugins/decodex/skills/okf/SKILL.md, plugins/decodex/skills/okf-query/SKILL.md, plugins/decodex/skills/okf-maintain/SKILL.md, plugins/decodex/skills/repo-memory-writer/SKILL.md, plugins/decodex/skills/docs/SKILL.md]
+code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/docs_okf.rs, plugins/decodex/references/okf-layer.md, plugins/decodex/skills/okf/SKILL.md, plugins/decodex/skills/okf-query/SKILL.md, plugins/decodex/skills/okf-maintain/SKILL.md, plugins/decodex/skills/repo-memory-writer/SKILL.md, plugins/decodex/skills/repo-memory-evaluator/SKILL.md, plugins/decodex/skills/repo-memory-curator/SKILL.md, plugins/decodex/skills/docs/SKILL.md]
 related: [../policy.md, ../reference/docs-knowledge-map.md, ../reference/research-concepts.md, ../evidence/decodex-plugin-eval.md]
 drift_watch: [decodex okf, decodex docs, docs check, docs lint, okf profile, docs alias, okf skill]
-last_verified: 2026-06-17
+last_verified: 2026-06-18
 ---
 
 # OKF Knowledge Layer
@@ -126,9 +126,17 @@ Portable OKF skills own cross-repository behavior:
 - route a task to the smallest relevant concepts
 
 The Decodex plugin exposes these portable skills as `okf`, `okf-query`,
-`okf-maintain`, and `repo-memory-writer`. The first three operate the bundle surface;
-`repo-memory-writer` is the AI authoring workflow that reads repository evidence,
-writes canonical concepts, and proves route quality.
+`okf-maintain`, `repo-memory-writer`, `repo-memory-evaluator`, and
+`repo-memory-curator`. The first three operate the bundle surface;
+`repo-memory-writer` is the AI authoring workflow that reads repository evidence and
+writes canonical concepts. `repo-memory-evaluator` turns static checks, graph output,
+and route probes into a quality report. `repo-memory-curator` uses that evidence to
+repair misses, noisy owners, orphan concepts, duplicate claims, and graph decay.
+
+The CLI does not independently generate high-quality repository knowledge. Agents or
+humans still judge owner correctness, classify misses, and author durable claims. OKF
+commands make those judgments repeatable by supplying profile checks, graph counts,
+query output, and routing evidence.
 
 Decodex docs skills are wrappers around those behaviors for this repository. They may
 apply Decodex profile constraints, but the portable OKF skill family must not depend

--- a/plugins/decodex/.codex-plugin/plugin.json
+++ b/plugins/decodex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "decodex",
   "version": "0.2.0",
-  "description": "Decodex agent workflows for portable OKF bundles, repo memory writing and curation, docs, research, issue planning, automation, commit, and landing.",
+  "description": "Decodex agent workflows for portable OKF bundles, repo memory writing, evaluation, and curation, docs, research, issue planning, automation, commit, and landing.",
   "author": {
     "name": "hack-ink",
     "email": "hi@hack.ink",
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Decodex",
     "shortDescription": "Maintain docs, research, plan, and operate Decodex.",
-    "longDescription": "Routes portable OKF/LLM Wiki bundle work, source-backed repo-memory writing and curation, Decodex OKF docs maintenance, docs drift audits, bounded research, promotion, issue briefing and planning, CLI, labels, commit, landing, and automation.",
+    "longDescription": "Routes portable OKF/LLM Wiki bundle work, source-backed repo-memory writing, evaluation, and curation, Decodex OKF docs maintenance, docs drift audits, bounded research, promotion, issue briefing and planning, CLI, labels, commit, landing, and automation.",
     "developerName": "hack-ink",
     "category": "Development",
     "capabilities": [
@@ -32,7 +32,7 @@
     "privacyPolicyURL": "https://github.com/hack-ink/decodex",
     "termsOfServiceURL": "https://github.com/hack-ink/decodex",
     "defaultPrompt": [
-      "Curate a repo-memory OKF bundle.",
+      "Evaluate or curate a repo-memory OKF bundle.",
       "Maintain Decodex docs.",
       "Research this with Decodex."
     ],

--- a/plugins/decodex/references/okf-layer.md
+++ b/plugins/decodex/references/okf-layer.md
@@ -1,43 +1,31 @@
 # Portable OKF Layer
 
 Use this for portable OKF bundles, LLM Wiki retrieval, and cross-repository memory.
-Use `repo-memory-writer` for first-pass repo knowledge and `repo-memory-curator` for
-route misses, orphans, noisy top results, duplicate claims, or graph decay.
 
-## Boundary
+Route by task:
 
-OKF is the portable bundle format: Markdown, YAML frontmatter, required `type`, and
-ordinary links. LLM Wiki is the agent method on top: route small context, maintain
-links/indexes/logs, and preserve producer fields.
+- `repo-memory-writer`: first-pass source-backed repo concepts.
+- `repo-memory-evaluator`: quality report, route benchmark, owner coverage.
+- `repo-memory-curator`: route misses, orphans, noisy owners, duplicates, graph decay.
 
-Decodex docs are only one strict profile. Other repositories do not inherit Decodex
-lanes, Linear workflow, research promotion, docs-impact checkpoints, or landing
-policy.
+OKF is Markdown plus YAML frontmatter and ordinary links. LLM Wiki is the agent method
+on top: route small context, maintain links/indexes/logs, and preserve producer fields.
+Decodex docs are only one strict profile; other repos do not inherit Decodex lanes,
+Linear workflow, research promotion, docs-impact checkpoints, or landing policy.
 
-## Profiles
+Profiles: `core` validates portable OKF; `wiki` adds graph hygiene; `repo-memory` adds
+repository anchors such as `source_refs`, `code_refs`, `related`, and `drift_watch`;
+`decodex` adds this repo's lanes, authority, research, and drift gates. Use the lowest
+profile that proves the claim.
 
-- `core`: portable OKF conformance.
-- `wiki`: core plus indexes, retrieval fields, and graph hygiene.
-- `repo-memory`: wiki plus `source_refs`, `code_refs`, `related`, and `drift_watch`.
-- `decodex`: repo-memory plus Decodex lanes, authority, research, and drift gates.
+Use `decodex okf init/check/find/graph/route` for portable bundles. `decodex docs`
+defaults to root `docs/` and profile `decodex`. Do not create or recommend
+`decodex docs okf ...`.
 
-Use the lowest profile that proves the claim.
+The CLI does not replace the LLM: agents judge owners, write concepts, and classify
+misses; CLI commands supply repeatable check, graph, find, and route evidence.
 
-## Commands
-
-Use `decodex okf init/check/find/graph/route` for portable bundles. `init` writes
-`index.md`, `log.md`, and `overview.md` for `core`, `wiki`, or `repo-memory`, refuses
-overwrites, and validates. `decodex docs` defaults to root `docs/` and profile
-`decodex`. Do not create or recommend `decodex docs okf ...`.
-
-## Rules
-
-Producers pick a profile first, keep concepts one-topic, use frontmatter for routing,
-link real relationships, update indexes/logs, and preserve unknown fields.
-
-Consumers start with `decodex okf route` or `decodex okf find`, use graph output for
-relationships, tolerate unknown `type` values, and use Decodex `docs-*` skills only
-for this repository's strict `docs/` profile.
-
-Maintainers use route benchmarks and graph/orphan triage; shape checks prove only
-conformance.
+Producers keep concepts one-topic, use frontmatter for routing, link real
+relationships, update indexes/logs, and preserve unknown fields. Consumers start with
+route/find and use graph output for relationships. Shape checks prove conformance;
+route benchmarks and graph/orphan triage prove usefulness.

--- a/plugins/decodex/skills/decodex/SKILL.md
+++ b/plugins/decodex/skills/decodex/SKILL.md
@@ -9,6 +9,9 @@ Route Decodex work to the narrowest surface. Read `../../references/routing.md` 
 research, promotion, planning, labels, runtime, commit, or landing boundaries matter.
 
 - `research`: bounded investigation before execution.
+- `okf`, `okf-query`, `okf-maintain`, `repo-memory-writer`,
+  `repo-memory-evaluator`, `repo-memory-curator`: portable OKF/LLM Wiki and
+  repo-memory work.
 - `research-promote`: explicit acceptance of latent research.
 - `planning`: accepted work needs issues or Program readiness.
 - `manual-cli`: a human drives local commands.

--- a/plugins/decodex/skills/okf-maintain/SKILL.md
+++ b/plugins/decodex/skills/okf-maintain/SKILL.md
@@ -7,8 +7,9 @@ description: Use when creating or updating OKF/LLM Wiki concepts, indexes, logs,
 
 Produce and maintain OKF bundles without coupling them to Decodex-specific policy.
 For bootstrapping high-quality repository memory from code evidence, use
-`repo-memory-writer` first. For route benchmark misses, orphan triage, noisy top
-results, or graph repair, use `repo-memory-curator`.
+`repo-memory-writer` first. For route benchmark reports, owner-coverage scoring, or
+before/after quality comparisons, use `repo-memory-evaluator`. For route benchmark
+misses, orphan triage, noisy top results, or graph repair, use `repo-memory-curator`.
 
 Read `../../references/okf-layer.md` before creating concepts, moving files, or
 repairing graph quality.

--- a/plugins/decodex/skills/okf-query/SKILL.md
+++ b/plugins/decodex/skills/okf-query/SKILL.md
@@ -16,6 +16,8 @@ bundle graph findings.
 - Use `decodex okf graph <root> --json` when relationship shape, orphans, or broken
   bundle-internal links matter.
 - Return the smallest concept set that can answer the task.
+- If the user asks whether a bundle is good, useful, production-ready, or improving,
+  switch to `repo-memory-evaluator` instead of only returning query hits.
 - If query evidence shows repeated misses, noisy top results, or unexplained orphans,
   switch to `repo-memory-curator` before editing the bundle.
 - Do not require Decodex lanes or Linear workflow for portable OKF consumption.

--- a/plugins/decodex/skills/repo-memory-curator/SKILL.md
+++ b/plugins/decodex/skills/repo-memory-curator/SKILL.md
@@ -14,6 +14,8 @@ processing where possible, and test questions.
 
 - Use `repo-memory-writer` for first-pass creation; use this skill for growth and
   repair after real usage exposes misses.
+- Use `repo-memory-evaluator` first when the task is to judge bundle quality, produce
+  a route benchmark report, or compare before/after curation.
 - Treat `docs check` or `okf check` as shape validation only. Prove usefulness with
   `graph`, `find`, and representative `route` probes.
 - Prefer metadata and link repairs before creating new concepts.
@@ -35,7 +37,8 @@ Growth loop:
 3. Repair in this order: owner `description`, `tags`, routing header, "Not this"
    boundary, Markdown links/`related`, lane index. Split, merge, or delete only after
    ownership is proven wrong.
-4. Re-run the failing probe plus a small regression set.
+4. Re-run the failing probe plus a small regression set. If the set is not already
+   defined, use `repo-memory-evaluator` to create one.
 5. Record material navigation changes in `log.md`.
 
 Route benchmark rules:

--- a/plugins/decodex/skills/repo-memory-evaluator/SKILL.md
+++ b/plugins/decodex/skills/repo-memory-evaluator/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: repo-memory-evaluator
+description: Use when evaluating repo-memory OKF/LLM Wiki quality, route benchmarks, graph health, owner coverage, or curation impact.
+---
+
+# Repo Memory Evaluator
+
+Evaluate whether a repo-memory OKF/LLM Wiki bundle is useful for real agent tasks.
+The LLM designs benchmarks and judges owners; `decodex okf` only supplies evidence.
+
+Use `repo-memory-writer` to create first-pass concepts, this skill to evaluate the
+bundle, and `repo-memory-curator` to repair misses or graph decay.
+
+Evaluate three layers:
+
+- Static quality: check result, graph counts, broken links, orphans, duplicate owners.
+- Retrieval benchmark: real task questions, expected owners, top-1/top-3 route hits.
+- Usage outcome: fewer wrong reads, fewer duplicate claims, preserved evidence.
+
+Workflow:
+
+1. Resolve root/profile. Run `decodex okf check <root> --profile <profile>` and
+   `decodex okf graph <root>`.
+2. Build a benchmark from representative task questions, not keyword searches.
+3. For each question, write the expected owner concept or acceptable owner set before
+   looking at route output.
+4. Run `decodex okf route <root> "<question>" --limit 5` for every question.
+5. Score top-1/top-3. Classify misses as missing concept, weak metadata, noisy owner,
+   missing link/index, duplicate owner, stale claim, or acceptable leaf.
+6. Report `At a Glance`, `Why It Matters`, `Fix First`, benchmark table, graph health,
+   and recommended next step.
+7. If repairs are needed, switch to `repo-memory-curator` and rerun the same questions.
+
+Benchmark table:
+
+| Question | Expected owner | Top-1 | Top-3 hit | Classification | Fix first |
+| --- | --- | --- | --- | --- | --- |
+
+Quality bars:
+
+- Minimum useful: checks pass, no broken links, common-task top-3 is reliable, and
+  misses have clear fix categories.
+- Good: common operational questions are top-1, specialized questions are top-3,
+  orphans are intentional or queued, and metadata-only repairs improve route results
+  without adding unrelated concepts.
+- Not ready: generated summaries dominate, owners are unclear, route misses cannot be
+  explained, graph links are decorative, or claims lack source/code/drift evidence.
+
+Report remaining uncertainty honestly. Static checks prove shape, not usefulness.

--- a/plugins/decodex/skills/repo-memory-evaluator/agents/openai.yaml
+++ b/plugins/decodex/skills/repo-memory-evaluator/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Repo Memory Evaluator"
+  short_description: "Evaluate OKF repo-memory quality"
+policy:
+  allow_implicit_invocation: false

--- a/plugins/decodex/skills/repo-memory-writer/SKILL.md
+++ b/plugins/decodex/skills/repo-memory-writer/SKILL.md
@@ -7,7 +7,8 @@ description: Use when bootstrapping or improving source-backed repo-memory OKF/L
 
 Build source-backed repository knowledge. The AI writes the concepts; `decodex okf`
 only scaffolds, checks, routes, and graphs them. Use `repo-memory-curator` after
-real route, graph, or orphan evidence shows an existing bundle needs repair.
+real route, graph, or orphan evidence shows an existing bundle needs repair. Use
+`repo-memory-evaluator` when the question is whether the bundle is useful enough.
 
 Operating rules:
 
@@ -47,7 +48,7 @@ Workflow:
    ```
 
    Pick route probes from likely user intents and revise until the owning concept is
-   a top result.
+   a top result. For a fuller quality report, switch to `repo-memory-evaluator`.
 
 Quality bar:
 


### PR DESCRIPTION
Summary:
- add repo-memory-evaluator as the explicit eval workflow for OKF/LLM Wiki repo-memory bundles
- route writer/query/maintain/curator guidance through evaluator for quality reports and top-1/top-3 benchmarks
- document the LLM-vs-CLI boundary: LLM judges owners and writes knowledge; CLI supplies check/graph/find/route evidence

Validation:
- decodex docs check
- decodex docs graph
- decodex okf route docs "evaluate repo memory quality top-1 top-3 route benchmark owner coverage"
- plugin-eval analyze plugins/decodex
- semantic_drift_audit.py --repo . --json
- git diff --check