### PR TITLE
XY-994 Implement complete Decodex MCP protocol primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,18 @@ Program, and issue mappings. It never applies or removes service queue labels; r
 mapped nodes are dispatched directly by the Program scheduler instead of being
 converted into queued-label work.
 
-`decodex mcp serve --transport stdio` starts the phase-one read-only MCP gateway for
-local desktop and CLI clients. The gateway exposes checked-in documentation, checked-in
-JSON research reports, runtime Decision Contract readback, local status snapshots, and
-lane-control readback as MCP resources only. It does not expose mutating MCP tools.
-Stdout is reserved for MCP JSON-RPC messages; diagnostics and logs stay off stdout.
+`decodex mcp serve --transport stdio` starts the local MCP gateway for desktop and
+CLI clients. The gateway advertises resources, resource templates, prompts, tools,
+logging compatibility, and progress notifications over stdio. Resources expose
+checked-in documentation, checked-in JSON research reports, runtime Decision Contract
+readback, local status snapshots, and lane-control readback. The initial tool catalog
+is schema-bound and deliberately small. Local stdio defaults to the `admin` capability
+profile and can be narrowed with `--capability-profile observe|plan|operate|admin`;
+`tools/list` filters by the active profile and `tools/call` returns structured
+refusals for tools above it. Observe and plan are read-oriented, while operate/admin
+lane-control entries return structured refusal states until the later lane-control MCP
+work lands. Stdout is reserved for MCP JSON-RPC messages; diagnostics and logs stay
+off stdout.
 
 ### Project contracts
 

--- a/apps/decodex/src/cli.rs
+++ b/apps/decodex/src/cli.rs
@@ -21,7 +21,7 @@ use crate::{
 	docs_okf::{self, DocsCheckScope, OkfCheckProfile, OkfQuery},
 	maintenance::{self, MaintenanceMode, MaintenancePruneRequest, MaintenanceScope},
 	manual::{self, ManualCommitRequest, ManualLandRequest},
-	mcp::{self, McpServeRequest, McpTransport},
+	mcp::{self, McpCapabilityProfile, McpServeRequest, McpTransport},
 	orchestrator::{
 		self, DEFAULT_STEER_RESULT_WAIT_TIMEOUT, DiagnoseRequest, EvidenceRequest,
 		IssueDispatchMode, LaneInspectRequest, LaneInterruptRequest, LaneSteerReport,
@@ -579,12 +579,16 @@ struct McpServeCommand {
 	/// MCP transport.
 	#[arg(long, value_enum, default_value_t = McpTransport::Stdio)]
 	transport: McpTransport,
+	/// Capability profile exposed by the MCP gateway.
+	#[arg(long, value_enum, default_value_t = mcp::McpCapabilityProfile::Admin)]
+	capability_profile: McpCapabilityProfile,
 }
 impl McpServeCommand {
 	fn run(&self) -> Result<()> {
 		mcp::serve(McpServeRequest {
 			transport: self.transport,
 			config_path: self.project_config.as_path(),
+			capability_profile: self.capability_profile,
 		})
 	}
 }
@@ -1435,7 +1439,7 @@ enum Command {
 	Run(RunCommand),
 	/// Run the local multi-project Decodex control plane.
 	Serve(ServeCommand),
-	/// Serve the read-only Decodex MCP gateway.
+	/// Serve the Decodex MCP gateway.
 	Mcp(McpCommand),
 	/// Manage the local Decodex project registry.
 	Project(ProjectCommand),
@@ -1504,7 +1508,7 @@ enum ProjectSubcommand {
 
 #[derive(Debug, Subcommand)]
 enum McpSubcommand {
-	/// Serve read-only Decodex resources over MCP.
+	/// Serve Decodex MCP protocol primitives.
 	Serve(McpServeCommand),
 }
 
@@ -1790,16 +1794,16 @@ mod tests {
 			Command, CommitCommand, DiagnoseCommand, DocsCommand, DocsRouteCommand, DocsSubcommand,
 			EvidenceCommand, IntakeCommand, IntakeGoalCommand, IntakeIssuesCommand,
 			IntakeSubcommand, LandCommand, LaneCommand, LaneInspectCommand, LaneInterruptCommand,
-			LaneSteerCommand, LaneSubcommand, LegacyCloseoutRecoveryCommand, McpCommand,
-			McpServeCommand, McpSubcommand, MergedCloseoutRecoveryCommand, OkfCommand,
-			OkfInitCommand, OkfInitProfileArg, OkfRouteCommand, OkfSubcommand, ProbeCommand,
-			ProjectCommand, ProjectConfigArgs, ProjectSubcommand, RecoverCommand,
-			RecoverSubcommand, ResearchCommand, ResearchCompileCommand, ResearchOutcomeArg,
-			ResearchPromoteCommand, ResearchSubcommand, ReviewHandoffAdoptCommand,
-			ReviewHandoffDiagnoseCommand, ReviewHandoffRebindCommand, ReviewHandoffRecoveryCommand,
-			ReviewHandoffRecoverySubcommand, RunCommand, ServeCommand, StatusCommand,
+			LaneSteerCommand, LaneSubcommand, LegacyCloseoutRecoveryCommand, McpSubcommand,
+			MergedCloseoutRecoveryCommand, OkfCommand, OkfInitCommand, OkfInitProfileArg,
+			OkfRouteCommand, OkfSubcommand, ProbeCommand, ProjectCommand, ProjectConfigArgs,
+			ProjectSubcommand, RecoverCommand, RecoverSubcommand, ResearchCommand,
+			ResearchCompileCommand, ResearchOutcomeArg, ResearchPromoteCommand, ResearchSubcommand,
+			ReviewHandoffAdoptCommand, ReviewHandoffDiagnoseCommand, ReviewHandoffRebindCommand,
+			ReviewHandoffRecoveryCommand, ReviewHandoffRecoverySubcommand, RunCommand,
+			ServeCommand, StatusCommand,
 		},
-		mcp::McpTransport,
+		mcp::{McpCapabilityProfile, McpTransport},
 	};
 
 	#[test]
@@ -2112,16 +2116,14 @@ mod tests {
 			"--transport",
 			"stdio",
 		]);
+		let Command::Mcp(command) = cli.command else {
+			panic!("expected mcp command");
+		};
+		let McpSubcommand::Serve(serve) = command.command;
 
-		assert!(matches!(
-			cli.command,
-			Command::Mcp(McpCommand {
-				command: McpSubcommand::Serve(McpServeCommand {
-					project_config: ProjectConfigArgs { config: Some(config) },
-					transport: McpTransport::Stdio,
-				})
-			}) if config == Path::new("./project.toml")
-		));
+		assert_eq!(serve.project_config.config.as_deref(), Some(Path::new("./project.toml")));
+		assert_eq!(serve.transport, McpTransport::Stdio);
+		assert_eq!(serve.capability_profile, McpCapabilityProfile::Admin);
 	}
 
 	#[test]

--- a/apps/decodex/src/mcp.rs
+++ b/apps/decodex/src/mcp.rs
@@ -27,6 +27,10 @@ const DECISION_CONTRACTS_HOST: &str = "decision-contracts";
 const PROJECTS_HOST: &str = "projects";
 const RESOURCE_NOT_FOUND_CODE: i64 = -32_002;
 const DEFAULT_MCP_STATUS_LIMIT: usize = 10;
+const TOOL_OBSERVE: &str = "decodex_observe";
+const TOOL_PLAN: &str = "decodex_plan";
+const TOOL_LANE_CONTROL: &str = "decodex_lane_control";
+const TOOL_ADMIN: &str = "decodex_admin";
 
 /// MCP transport supported by the native Decodex gateway.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -36,60 +40,137 @@ pub(crate) enum McpTransport {
 	Stdio,
 }
 
+/// Capability profile exposed by the Decodex MCP gateway.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub(crate) enum McpCapabilityProfile {
+	/// Public-safe local observability only.
+	Observe,
+	/// Observe plus planning and workflow prompt helpers.
+	Plan,
+	/// Observe, plan, and guarded lane-control operations.
+	Operate,
+	/// Full local operator profile for supported Decodex MCP tools.
+	Admin,
+}
+impl McpCapabilityProfile {
+	const ALL: [Self; 4] = [Self::Observe, Self::Plan, Self::Operate, Self::Admin];
+
+	fn as_str(self) -> &'static str {
+		match self {
+			Self::Observe => "observe",
+			Self::Plan => "plan",
+			Self::Operate => "operate",
+			Self::Admin => "admin",
+		}
+	}
+
+	fn allows(self, required: Self) -> bool {
+		required <= self
+	}
+}
+
 /// Request to start the native Decodex MCP gateway.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct McpServeRequest<'a> {
 	pub(crate) transport: McpTransport,
 	pub(crate) config_path: Option<&'a Path>,
+	pub(crate) capability_profile: McpCapabilityProfile,
 }
 
 struct McpServer {
 	context: McpContext,
+	capability_profile: McpCapabilityProfile,
 }
 impl McpServer {
-	fn handle_line(&self, line: &str) -> Option<Value> {
+	fn handle_line(&self, line: &str, emit_progress: bool) -> Vec<Value> {
 		let parsed = serde_json::from_str::<Value>(line);
 		let value = match parsed {
 			Ok(value) => value,
-			Err(_) => return Some(json_rpc_error(Value::Null, -32_700, "Parse error")),
+			Err(_) => return vec![json_rpc_error(Value::Null, -32_700, "Parse error")],
 		};
 		let request = match serde_json::from_value::<JsonRpcRequest>(value) {
 			Ok(request) => request,
-			Err(_) => return Some(json_rpc_error(Value::Null, -32_600, "Invalid Request")),
+			Err(_) => return vec![json_rpc_error(Value::Null, -32_600, "Invalid Request")],
 		};
 
-		self.handle_request(request)
+		self.handle_request(request, emit_progress)
 	}
 
-	fn handle_request(&self, request: JsonRpcRequest) -> Option<Value> {
-		let id = request.id?;
+	fn handle_request(&self, request: JsonRpcRequest, emit_progress: bool) -> Vec<Value> {
+		let Some(id) = request.id else {
+			return Vec::new();
+		};
 
 		if request.jsonrpc.as_deref() != Some("2.0") {
-			return Some(json_rpc_error(id, -32_600, "Invalid Request"));
+			return vec![json_rpc_error(id, -32_600, "Invalid Request")];
 		}
 
 		let Some(method) = request.method else {
-			return Some(json_rpc_error(id, -32_600, "Invalid Request"));
+			return vec![json_rpc_error(id, -32_600, "Invalid Request")];
 		};
+		let progress_token =
+			emit_progress.then(|| progress_token_from_params(request.params.as_ref())).flatten();
 		let result = match method.as_str() {
 			"initialize" => Ok(self.initialize()),
 			"ping" => Ok(serde_json::json!({})),
+			"logging/setLevel" => Ok(serde_json::json!({})),
 			"resources/list" => self.list_resources(),
 			"resources/read" => self.read_resource(request.params),
+			"resources/templates/list" => Ok(self.list_resource_templates()),
+			"prompts/list" => Ok(self.list_prompts()),
+			"prompts/get" => self.get_prompt(request.params),
+			"tools/list" => Ok(self.list_tools()),
+			"tools/call" => self.call_tool(request.params),
 			_ => Err(McpError::method_not_found()),
 		};
+		let mut responses = Vec::new();
 
-		Some(match result {
+		if method == "tools/call"
+			&& result.as_ref().is_ok_and(tool_call_result_allows_progress)
+			&& let Some(token) = progress_token
+		{
+			responses.push(progress_notification(
+				token,
+				1,
+				Some(2),
+				"Decodex MCP tool request accepted.",
+			));
+		}
+
+		responses.push(match result {
 			Ok(result) => serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result }),
 			Err(error) => json_rpc_error(id, error.code, &error.message),
-		})
+		});
+
+		responses
 	}
 
 	fn initialize(&self) -> Value {
 		serde_json::json!({
 			"protocolVersion": MCP_PROTOCOL_VERSION,
 			"capabilities": {
-				"resources": {}
+				"resources": {},
+				"prompts": {},
+				"tools": {},
+				"logging": {},
+				"experimental": {
+					"decodex": {
+						"capabilityProfile": self.capability_profile.as_str(),
+						"capabilityProfiles": McpCapabilityProfile::ALL
+							.into_iter()
+							.map(McpCapabilityProfile::as_str)
+							.collect::<Vec<_>>(),
+						"transport": "stdio",
+						"remoteControl": {
+							"safeDefaultProfile": "observe",
+							"httpTransport": "deferred_to_XY-995",
+							"operateAdminTools": "deferred_to_XY-998",
+							"mutatingToolsRequireAuthority": true,
+							"privateEvidencePayloadsExposed": false
+						}
+					}
+				}
 			},
 			"serverInfo": {
 				"name": SERVER_NAME,
@@ -119,6 +200,61 @@ impl McpServer {
 		Ok(serde_json::json!({ "resources": resources }))
 	}
 
+	fn list_resource_templates(&self) -> Value {
+		serde_json::json!({
+			"resourceTemplates": [
+				{
+					"uriTemplate": "decodex://docs/spec/{topic}",
+					"name": "Decodex specs",
+					"description": "Checked-in normative Decodex specification concepts.",
+					"mimeType": "text/markdown"
+				},
+				{
+					"uriTemplate": "decodex://docs/runbook/{topic}",
+					"name": "Decodex runbooks",
+					"description": "Checked-in Decodex operator procedures.",
+					"mimeType": "text/markdown"
+				},
+				{
+					"uriTemplate": "decodex://docs/reference/{topic}",
+					"name": "Decodex references",
+					"description": "Checked-in Decodex implementation and current-state references.",
+					"mimeType": "text/markdown"
+				},
+				{
+					"uriTemplate": "decodex://docs/decisions/{topic}",
+					"name": "Decodex decisions",
+					"description": "Checked-in Decodex design-rationale concepts.",
+					"mimeType": "text/markdown"
+				},
+				{
+					"uriTemplate": "decodex://docs/research/{topic}",
+					"name": "Decodex research concepts",
+					"description": "Checked-in latent Markdown research concepts.",
+					"mimeType": "text/markdown"
+				},
+				{
+					"uriTemplate": "decodex://decision-contracts/{contract_id}",
+					"name": "Runtime Decision Contracts",
+					"description": "Local runtime Decision Contract readback by contract id.",
+					"mimeType": "application/json"
+				},
+				{
+					"uriTemplate": "decodex://projects/{project_id}/status",
+					"name": "Project status",
+					"description": "Local runtime project status readback.",
+					"mimeType": "application/json"
+				},
+				{
+					"uriTemplate": "decodex://projects/{project_id}/lane-control/{issue}",
+					"name": "Lane-control readback",
+					"description": "Inspect one local lane before requesting guarded lane-control actions.",
+					"mimeType": "application/json"
+				}
+			]
+		})
+	}
+
 	fn read_resource(&self, params: Option<Value>) -> Result<Value, McpError> {
 		let params = params.ok_or_else(McpError::invalid_params)?;
 		let params = serde_json::from_value::<ReadResourceParams>(params)
@@ -133,6 +269,106 @@ impl McpServer {
 					"text": content.text
 				}
 			]
+		}))
+	}
+
+	fn list_prompts(&self) -> Value {
+		serde_json::json!({ "prompts": mcp_prompts() })
+	}
+
+	fn get_prompt(&self, params: Option<Value>) -> Result<Value, McpError> {
+		let params = params.ok_or_else(McpError::invalid_params)?;
+		let params = serde_json::from_value::<GetPromptParams>(params)
+			.map_err(|_| McpError::invalid_params())?;
+		let arguments = params.arguments.unwrap_or_default();
+
+		if !prompt_required_arguments_are_present(&params.name, &arguments) {
+			return Err(McpError::invalid_params());
+		}
+
+		mcp_prompt_result(&params.name, arguments).ok_or_else(McpError::invalid_params)
+	}
+
+	fn list_tools(&self) -> Value {
+		let tools = mcp_tools()
+			.into_iter()
+			.filter(|tool| self.capability_profile.allows(tool.required_profile))
+			.map(|tool| tool.value)
+			.collect::<Vec<_>>();
+
+		serde_json::json!({ "tools": tools })
+	}
+
+	fn call_tool(&self, params: Option<Value>) -> Result<Value, McpError> {
+		let params = params.ok_or_else(McpError::invalid_params)?;
+		let params = serde_json::from_value::<CallToolParams>(params)
+			.map_err(|_| McpError::invalid_params())?;
+		let arguments = params.arguments.unwrap_or_else(|| serde_json::json!({}));
+		let Some(required_profile) = tool_required_profile(&params.name) else {
+			return Ok(tool_refusal(
+				"unknown_tool",
+				format!("Decodex MCP tool `{}` is not registered.", params.name),
+			));
+		};
+
+		if !self.capability_profile.allows(required_profile) {
+			return Ok(capability_profile_refusal(
+				&params.name,
+				self.capability_profile,
+				required_profile,
+			));
+		}
+
+		match params.name.as_str() {
+			TOOL_OBSERVE => Ok(self.call_observe_tool(arguments)),
+			TOOL_PLAN => Ok(call_plan_tool(arguments)),
+			TOOL_LANE_CONTROL => Ok(lane_control_stub_result(arguments, required_profile)),
+			TOOL_ADMIN => Ok(admin_stub_result(arguments, required_profile)),
+			_ => Ok(tool_refusal("unknown_tool", "Decodex MCP tool is not registered.")),
+		}
+	}
+
+	fn call_observe_tool(&self, arguments: Value) -> Value {
+		let params = match serde_json::from_value::<ObserveToolArgs>(arguments) {
+			Ok(params) => params,
+			Err(_) =>
+				return invalid_tool_arguments(
+					TOOL_OBSERVE,
+					"`issue`, `runId`, and `limit` are the only supported observe arguments.",
+				),
+		};
+		let limit = params.limit.unwrap_or(DEFAULT_MCP_STATUS_LIMIT);
+
+		if limit == 0 {
+			return tool_refusal("invalid_limit", "`limit` must be greater than zero.");
+		}
+
+		let observability_result = if params.issue.as_deref().is_some() {
+			orchestrator::build_mcp_lane_control_resource(
+				self.context.config_path.as_deref(),
+				params.issue.as_deref(),
+				params.run_id.as_deref(),
+				limit,
+			)
+		} else {
+			orchestrator::build_mcp_status_resource(self.context.config_path.as_deref(), limit)
+		};
+		let mut value = match observability_result {
+			Ok(value) => value,
+			Err(_) =>
+				return tool_refusal(
+					"observability_unavailable",
+					"Decodex observability requires a registered project config or --config.",
+				),
+		};
+
+		sanitize_mcp_observability_value(&mut value);
+
+		tool_success(serde_json::json!({
+			"schema": "decodex.mcp.observe_result/1",
+			"status": "ok",
+			"capability_profile": "observe",
+			"observability": value
 		}))
 	}
 }
@@ -156,7 +392,7 @@ impl McpContext {
 				eyre::eyre!(
 					"Failed to find the Decodex repository root for MCP docs resources; start from a checkout or pass --config."
 				)
-			})?;
+		})?;
 		let project_id = config.map(|config| config.service_id().to_owned());
 
 		Ok(Self { repo_root, config_path, project_id, state_store })
@@ -184,7 +420,7 @@ impl McpContext {
 			"Checked-in Decodex documentation policy.",
 		);
 
-		for lane in ["spec", "runbook", "reference", "decisions"] {
+		for lane in ["spec", "runbook", "reference", "decisions", "research"] {
 			let docs_dir = self.repo_root.join("docs").join(lane);
 
 			for entry in read_sorted_dir(&docs_dir)? {
@@ -351,7 +587,7 @@ impl McpContext {
 		}
 		.map_err(McpError::internal)?;
 
-		ResourceContent::json(&uri.raw, value)
+		ResourceContent::mcp_observability_json(&uri.raw, value)
 	}
 }
 
@@ -366,6 +602,66 @@ struct JsonRpcRequest {
 #[derive(Deserialize)]
 struct ReadResourceParams {
 	uri: String,
+}
+
+#[derive(Deserialize)]
+struct GetPromptParams {
+	name: String,
+	arguments: Option<Value>,
+}
+
+#[derive(Deserialize)]
+struct CallToolParams {
+	name: String,
+	arguments: Option<Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ObserveToolArgs {
+	issue: Option<String>,
+	run_id: Option<String>,
+	limit: Option<usize>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PlanToolArgs {
+	intent: String,
+	issue: Option<String>,
+	contract_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct LaneControlToolArgs {
+	action: String,
+	issue: Option<String>,
+	run_id: Option<String>,
+	expected_turn_id: Option<String>,
+	message: Option<String>,
+	force: Option<bool>,
+	authority: Option<LaneControlAuthorityArgs>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct LaneControlAuthorityArgs {
+	reason: Option<String>,
+	source: Option<String>,
+	inspected_run_id: Option<String>,
+	expected_turn_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AdminToolArgs {
+	action: String,
+}
+
+struct McpTool {
+	required_profile: McpCapabilityProfile,
+	value: Value,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -415,6 +711,12 @@ impl ResourceContent {
 		let text = serde_json::to_string_pretty(&value).map_err(McpError::internal)?;
 
 		Ok(Self { uri: uri.to_owned(), mime_type: String::from("application/json"), text })
+	}
+
+	fn mcp_observability_json(uri: &str, mut value: Value) -> Result<Self, McpError> {
+		sanitize_mcp_observability_value(&mut value);
+
+		Self::json(uri, value)
 	}
 }
 
@@ -472,7 +774,7 @@ impl McpError {
 	}
 }
 
-/// Start the read-only Decodex MCP gateway.
+/// Start the Decodex MCP gateway.
 pub(crate) fn serve(request: McpServeRequest<'_>) -> Result<()> {
 	match request.transport {
 		McpTransport::Stdio => {
@@ -480,17 +782,809 @@ pub(crate) fn serve(request: McpServeRequest<'_>) -> Result<()> {
 			let stdin = io::stdin();
 			let stdout = io::stdout();
 
-			serve_stdio_with_context(stdin.lock(), stdout.lock(), context)
+			serve_stdio_with_profile(
+				stdin.lock(),
+				stdout.lock(),
+				context,
+				request.capability_profile,
+			)
 		},
 	}
 }
 
-fn serve_stdio_with_context<R, W>(reader: R, mut writer: W, context: McpContext) -> Result<()>
+fn mcp_prompts() -> Vec<Value> {
+	vec![
+		serde_json::json!({
+			"name": "decodex_research",
+			"title": "Decodex Research",
+			"description": "Frame bounded Decodex research as a latent Decision Contract candidate.",
+			"arguments": [
+				{
+					"name": "intent",
+					"description": "Natural-language research question or design uncertainty.",
+					"required": true
+				}
+			]
+		}),
+		serde_json::json!({
+			"name": "decodex_validation_ready",
+			"title": "Decodex Validation Ready",
+			"description": "Drive an implementation or repair lane to local validation-ready evidence.",
+			"arguments": [
+				{
+					"name": "issue",
+					"description": "Linear issue identifier for the lane.",
+					"required": true
+				},
+				{
+					"name": "phase",
+					"description": "Current Decodex phase goal.",
+					"required": false
+				}
+			]
+		}),
+		serde_json::json!({
+			"name": "decodex_handoff",
+			"title": "Decodex Handoff",
+			"description": "Prepare a verified review handoff only after local validation and bounded review.",
+			"arguments": [
+				{
+					"name": "issue",
+					"description": "Linear issue identifier for the lane.",
+					"required": true
+				}
+			]
+		}),
+		serde_json::json!({
+			"name": "decodex_lane_control",
+			"title": "Decodex Lane Control",
+			"description": "Inspect first, then request guarded lane-control actions through existing Decodex authority gates.",
+			"arguments": [
+				{
+					"name": "issue",
+					"description": "Linear issue identifier or local tracker issue id.",
+					"required": true
+				},
+				{
+					"name": "runId",
+					"description": "Current run id observed through lane inspect.",
+					"required": false
+				}
+			]
+		}),
+	]
+}
+
+fn mcp_prompt_result(name: &str, arguments: Value) -> Option<Value> {
+	let text = match name {
+		"decodex_research" => format!(
+			"Use Decodex research routing for this intent, keep the result latent until explicitly promoted, and preserve evidence, options, judgment, challenge, decision, validation expectations, and stop conditions.\n\nIntent: {}",
+			prompt_argument(&arguments, "intent")?
+		),
+		"decodex_validation_ready" => format!(
+			"Work only to Decodex validation-ready state for issue {}. Implement the smallest coherent code and docs change, run targeted validation, record a current-HEAD docs-impact checkpoint, then complete the active phase goal without push or PR handoff.\n\nPhase: {}",
+			prompt_argument(&arguments, "issue")?,
+			prompt_argument(&arguments, "phase").unwrap_or("implement_to_validation_ready")
+		),
+		"decodex_handoff" => format!(
+			"Before handoff for issue {}, re-read the current diff and HEAD, run the repo-native bounded review method, require a clean current-head review checkpoint, then use the normal PR-backed Decodex handoff path.",
+			prompt_argument(&arguments, "issue")?
+		),
+		"decodex_lane_control" => format!(
+			"Inspect issue {} first. Mutating lane-control tool calls must include the observed run id, current turn preconditions when steering, and explicit authority fields; refuse instead of guessing missing authority.",
+			prompt_argument(&arguments, "issue")?
+		),
+		_ => return None,
+	};
+
+	Some(serde_json::json!({
+		"description": prompt_description(name),
+		"messages": [
+			{
+				"role": "user",
+				"content": {
+					"type": "text",
+					"text": text
+				}
+			}
+		]
+	}))
+}
+
+fn prompt_description(name: &str) -> &'static str {
+	match name {
+		"decodex_research" => "Contract-first bounded Decodex research prompt.",
+		"decodex_validation_ready" => "Decodex implementation-phase validation-ready prompt.",
+		"decodex_handoff" => "Decodex verified review-handoff prompt.",
+		"decodex_lane_control" => "Decodex inspect-first lane-control prompt.",
+		_ => "Decodex prompt.",
+	}
+}
+
+fn prompt_argument<'a>(arguments: &'a Value, key: &str) -> Option<&'a str> {
+	arguments.get(key).and_then(Value::as_str).map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn prompt_required_arguments_are_present(name: &str, arguments: &Value) -> bool {
+	let required: &[&str] = match name {
+		"decodex_research" => &["intent"],
+		"decodex_validation_ready" | "decodex_handoff" | "decodex_lane_control" => &["issue"],
+		_ => return true,
+	};
+
+	required.iter().all(|key| prompt_argument(arguments, key).is_some())
+}
+
+fn mcp_tools() -> Vec<McpTool> {
+	vec![
+		McpTool {
+			required_profile: McpCapabilityProfile::Observe,
+			value: mcp_tool_value(
+				TOOL_OBSERVE,
+				"Decodex Observe",
+				"Read public-safe local Decodex runtime observability without private evidence payloads.",
+				McpCapabilityProfile::Observe,
+				observe_tool_input_schema(),
+				observe_tool_output_schema(),
+				true,
+			),
+		},
+		McpTool {
+			required_profile: McpCapabilityProfile::Plan,
+			value: mcp_tool_value(
+				TOOL_PLAN,
+				"Decodex Plan",
+				"Return the Decodex prompt/resource route for a requested workflow intent.",
+				McpCapabilityProfile::Plan,
+				plan_tool_input_schema(),
+				plan_tool_output_schema(),
+				true,
+			),
+		},
+		McpTool {
+			required_profile: McpCapabilityProfile::Operate,
+			value: mcp_tool_value(
+				TOOL_LANE_CONTROL,
+				"Decodex Lane Control",
+				"Inspect a lane or request guarded soft lane-control actions with explicit authority.",
+				McpCapabilityProfile::Operate,
+				lane_control_tool_input_schema(),
+				lane_control_tool_output_schema(),
+				false,
+			),
+		},
+		McpTool {
+			required_profile: McpCapabilityProfile::Admin,
+			value: mcp_tool_value(
+				TOOL_ADMIN,
+				"Decodex Admin",
+				"Read the supported admin MCP policy surface; raw admin mutation is intentionally not exposed.",
+				McpCapabilityProfile::Admin,
+				admin_tool_input_schema(),
+				admin_tool_output_schema(),
+				true,
+			),
+		},
+	]
+}
+
+fn mcp_tool_value(
+	name: &str,
+	title: &str,
+	description: &str,
+	profile: McpCapabilityProfile,
+	input_schema: Value,
+	output_schema: Value,
+	read_only: bool,
+) -> Value {
+	serde_json::json!({
+		"name": name,
+		"title": title,
+		"description": description,
+		"inputSchema": input_schema,
+		"outputSchema": output_schema,
+		"annotations": {
+			"readOnlyHint": read_only,
+			"destructiveHint": false,
+			"idempotentHint": read_only,
+			"openWorldHint": false
+		},
+		"_meta": {
+			"decodex/capabilityProfile": profile.as_str()
+		}
+	})
+}
+
+fn tool_required_profile(name: &str) -> Option<McpCapabilityProfile> {
+	match name {
+		TOOL_OBSERVE => Some(McpCapabilityProfile::Observe),
+		TOOL_PLAN => Some(McpCapabilityProfile::Plan),
+		TOOL_LANE_CONTROL => Some(McpCapabilityProfile::Operate),
+		TOOL_ADMIN => Some(McpCapabilityProfile::Admin),
+		_ => None,
+	}
+}
+
+fn observe_tool_input_schema() -> Value {
+	serde_json::json!({
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"issue": {
+				"type": "string",
+				"description": "Optional issue identifier or tracker id to inspect one lane."
+			},
+			"runId": {
+				"type": "string",
+				"description": "Optional run id used with issue-scoped lane inspection."
+			},
+			"limit": {
+				"type": "integer",
+				"minimum": 1,
+				"description": "Maximum recent run count for project observability."
+			}
+		}
+	})
+}
+
+fn plan_tool_input_schema() -> Value {
+	serde_json::json!({
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"intent": {
+				"type": "string",
+				"enum": ["research", "validation_ready", "handoff", "lane_control"],
+				"description": "Decodex workflow intent to route."
+			},
+			"issue": {
+				"type": "string",
+				"description": "Optional issue identifier for lane-scoped prompts."
+			},
+			"contractId": {
+				"type": "string",
+				"description": "Optional Decision Contract id for research or intake planning."
+			}
+		},
+		"required": ["intent"]
+	})
+}
+
+fn lane_control_tool_input_schema() -> Value {
+	serde_json::json!({
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"action": {
+				"type": "string",
+				"enum": ["inspect", "interrupt", "steer"]
+			},
+			"issue": {
+				"type": "string",
+				"description": "Issue identifier or tracker issue id."
+			},
+			"runId": {
+				"type": "string",
+				"description": "Current run id observed through inspect."
+			},
+			"expectedTurnId": {
+				"type": "string",
+				"description": "Current turn id required for steer."
+			},
+			"message": {
+				"type": "string",
+				"description": "Operator-supplied steer message."
+			},
+			"force": {
+				"type": "boolean",
+				"description": "Hard interrupt fallback is not exposed through MCP and is refused when true."
+			},
+			"authority": {
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"reason": {
+						"type": "string",
+						"description": "Explicit operator reason for a mutating lane-control request."
+					},
+					"source": {
+						"type": "string",
+						"description": "Remote client or operator source identifier."
+					},
+					"inspectedRunId": {
+						"type": "string",
+						"description": "Run id observed through a prior inspect call."
+					},
+					"expectedTurnId": {
+						"type": "string",
+						"description": "Turn id observed through inspect and required for steer."
+					}
+				}
+			}
+		},
+		"required": ["action"]
+	})
+}
+
+fn admin_tool_input_schema() -> Value {
+	serde_json::json!({
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"action": {
+				"type": "string",
+				"enum": ["capabilities"],
+				"description": "Only admin capability readback is exposed by this MCP tool."
+			}
+		},
+		"required": ["action"]
+	})
+}
+
+fn observe_tool_output_schema() -> Value {
+	tool_output_schema(serde_json::json!({
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"schema": {
+				"type": "string",
+				"enum": ["decodex.mcp.observe_result/1"]
+			},
+			"status": {
+				"type": "string",
+				"enum": ["ok"]
+			},
+			"capability_profile": {
+				"type": "string",
+				"enum": ["observe"]
+			},
+			"observability": {
+				"type": "object",
+				"additionalProperties": true
+			}
+		},
+		"required": ["schema", "status", "capability_profile", "observability"]
+	}))
+}
+
+fn plan_tool_output_schema() -> Value {
+	tool_output_schema(serde_json::json!({
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"schema": {
+				"type": "string",
+				"enum": ["decodex.mcp.plan_result/1"]
+			},
+			"status": {
+				"type": "string",
+				"enum": ["ok"]
+			},
+			"intent": {
+				"type": "string",
+				"enum": ["research", "validation_ready", "handoff", "lane_control"]
+			},
+			"prompt": {
+				"type": "string"
+			},
+			"resource": {
+				"type": "string"
+			},
+			"next_action": {
+				"type": "string"
+			},
+			"issue": {
+				"type": ["string", "null"]
+			},
+			"contract_id": {
+				"type": ["string", "null"]
+			}
+		},
+		"required": ["schema", "status", "intent", "prompt", "resource", "next_action"]
+	}))
+}
+
+fn lane_control_tool_output_schema() -> Value {
+	tool_output_schema(serde_json::json!({
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"schema": {
+				"type": "string",
+				"enum": ["decodex.mcp.lane_control_result/1"]
+			},
+			"status": {
+				"type": "string",
+				"enum": ["refused"]
+			},
+			"reason": {
+				"type": "string",
+				"enum": ["deferred_to_XY-998"]
+			},
+			"message": {
+				"type": "string"
+			},
+			"capability_profile": {
+				"type": "string",
+				"enum": ["operate"]
+			},
+			"action": {
+				"type": "string",
+				"enum": ["inspect", "interrupt", "steer"]
+			},
+			"preconditions": {
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"issue_present": { "type": "boolean" },
+					"run_id_present": { "type": "boolean" },
+					"expected_turn_id_present": { "type": "boolean" },
+					"message_present": { "type": "boolean" },
+					"force_requested": { "type": "boolean" },
+					"authority_reason_present": { "type": "boolean" },
+					"authority_source_present": { "type": "boolean" },
+					"authority_inspected_run_id_present": { "type": "boolean" },
+					"authority_expected_turn_id_present": { "type": "boolean" }
+				},
+				"required": [
+					"issue_present",
+					"run_id_present",
+					"expected_turn_id_present",
+					"message_present",
+					"force_requested",
+					"authority_reason_present",
+					"authority_source_present",
+					"authority_inspected_run_id_present",
+					"authority_expected_turn_id_present"
+				]
+			}
+		},
+		"required": [
+			"schema",
+			"status",
+			"reason",
+			"message",
+			"capability_profile",
+			"action",
+			"preconditions"
+		]
+	}))
+}
+
+fn admin_tool_output_schema() -> Value {
+	tool_output_schema(serde_json::json!({
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"schema": {
+				"type": "string",
+				"enum": ["decodex.mcp.admin_result/1"]
+			},
+			"status": {
+				"type": "string",
+				"enum": ["refused"]
+			},
+			"reason": {
+				"type": "string",
+				"enum": ["deferred_admin_control"]
+			},
+			"message": {
+				"type": "string"
+			},
+			"capability_profile": {
+				"type": "string",
+				"enum": ["admin"]
+			},
+			"action": {
+				"type": "string",
+				"enum": ["capabilities"]
+			},
+			"supported_admin_actions": {
+				"type": "array",
+				"items": {
+					"type": "string"
+				}
+			}
+		},
+		"required": [
+			"schema",
+			"status",
+			"reason",
+			"message",
+			"capability_profile",
+			"action",
+			"supported_admin_actions"
+		]
+	}))
+}
+
+fn tool_output_schema(primary_schema: Value) -> Value {
+	serde_json::json!({
+		"oneOf": [
+			primary_schema,
+			tool_refusal_output_schema(),
+			tool_validation_error_output_schema()
+		]
+	})
+}
+
+fn tool_refusal_output_schema() -> Value {
+	serde_json::json!({
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"schema": {
+				"type": "string",
+				"enum": ["decodex.mcp.refusal/1"]
+			},
+			"status": {
+				"type": "string",
+				"enum": ["refused"]
+			},
+			"reason": {
+				"type": "string"
+			},
+			"message": {
+				"type": "string"
+			},
+			"tool": {
+				"type": "string"
+			},
+			"capability_profile": {
+				"type": "string",
+				"enum": ["observe", "plan", "operate", "admin"]
+			},
+			"required_capability_profile": {
+				"type": "string",
+				"enum": ["observe", "plan", "operate", "admin"]
+			}
+		},
+		"required": ["schema", "status", "reason", "message"]
+	})
+}
+
+fn tool_validation_error_output_schema() -> Value {
+	serde_json::json!({
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"schema": {
+				"type": "string",
+				"enum": ["decodex.mcp.tool_validation_error/1"]
+			},
+			"status": {
+				"type": "string",
+				"enum": ["refused"]
+			},
+			"reason": {
+				"type": "string",
+				"enum": ["invalid_arguments"]
+			},
+			"tool": {
+				"type": "string"
+			},
+			"message": {
+				"type": "string"
+			}
+		},
+		"required": ["schema", "status", "reason", "tool", "message"]
+	})
+}
+
+fn call_plan_tool(arguments: Value) -> Value {
+	let params = match serde_json::from_value::<PlanToolArgs>(arguments) {
+		Ok(params) => params,
+		Err(_) =>
+			return invalid_tool_arguments(
+				TOOL_PLAN,
+				"`intent` is required and must be one of research, validation_ready, handoff, or lane_control.",
+			),
+	};
+
+	if !matches!(
+		params.intent.as_str(),
+		"research" | "validation_ready" | "handoff" | "lane_control"
+	) {
+		return invalid_tool_arguments(
+			TOOL_PLAN,
+			"`intent` must be one of research, validation_ready, handoff, or lane_control.",
+		);
+	}
+
+	tool_success(plan_tool_result(&params))
+}
+
+fn plan_tool_result(params: &PlanToolArgs) -> Value {
+	let (prompt, resource_hint, next_action) = match params.intent.as_str() {
+		"research" => (
+			"decodex_research",
+			"decodex://docs/spec/loop-runtime",
+			"Use the research prompt and keep output latent until explicit promotion.",
+		),
+		"handoff" => (
+			"decodex_handoff",
+			"decodex://docs/spec/review-orchestration",
+			"Run bounded review and repo validation before PR-backed handoff.",
+		),
+		"lane_control" => (
+			"decodex_lane_control",
+			"decodex://docs/spec/lane-control",
+			"Inspect first; mutating MCP lane-control remains deferred to XY-998.",
+		),
+		_ => (
+			"decodex_validation_ready",
+			"decodex://docs/reference/build-test-run",
+			"Implement locally, run targeted validation, record docs impact, and complete the phase goal.",
+		),
+	};
+
+	serde_json::json!({
+		"schema": "decodex.mcp.plan_result/1",
+		"status": "ok",
+		"intent": params.intent.as_str(),
+		"prompt": prompt,
+		"resource": resource_hint,
+		"next_action": next_action,
+		"issue": params.issue.as_deref(),
+		"contract_id": params.contract_id.as_deref()
+	})
+}
+
+fn lane_control_stub_result(arguments: Value, profile: McpCapabilityProfile) -> Value {
+	let params = match serde_json::from_value::<LaneControlToolArgs>(arguments) {
+		Ok(params) => params,
+		Err(_) =>
+			return invalid_tool_arguments(
+				TOOL_LANE_CONTROL,
+				"`action` is required and must be one of inspect, interrupt, or steer.",
+			),
+	};
+
+	if !matches!(params.action.as_str(), "inspect" | "interrupt" | "steer") {
+		return invalid_tool_arguments(
+			TOOL_LANE_CONTROL,
+			"`action` must be one of inspect, interrupt, or steer.",
+		);
+	}
+
+	tool_refusal_value(serde_json::json!({
+		"schema": "decodex.mcp.lane_control_result/1",
+		"status": "refused",
+		"reason": "deferred_to_XY-998",
+		"message": "MCP lane-control mutation is intentionally deferred; this lane only exposes core stdio protocol primitives.",
+		"capability_profile": profile.as_str(),
+		"action": params.action.as_str(),
+		"preconditions": lane_control_preconditions(&params)
+	}))
+}
+
+fn lane_control_preconditions(params: &LaneControlToolArgs) -> Value {
+	let authority = params.authority.as_ref();
+
+	serde_json::json!({
+		"issue_present": non_empty_string(params.issue.as_deref()).is_some(),
+		"run_id_present": non_empty_string(params.run_id.as_deref()).is_some(),
+		"expected_turn_id_present": non_empty_string(params.expected_turn_id.as_deref()).is_some(),
+		"message_present": non_empty_string(params.message.as_deref()).is_some(),
+		"force_requested": params.force.unwrap_or(false),
+		"authority_reason_present": authority
+			.and_then(|value| non_empty_string(value.reason.as_deref()))
+			.is_some(),
+		"authority_source_present": authority
+			.and_then(|value| non_empty_string(value.source.as_deref()))
+			.is_some(),
+		"authority_inspected_run_id_present": authority
+			.and_then(|value| non_empty_string(value.inspected_run_id.as_deref()))
+			.is_some(),
+		"authority_expected_turn_id_present": authority
+			.and_then(|value| non_empty_string(value.expected_turn_id.as_deref()))
+			.is_some()
+	})
+}
+
+fn admin_stub_result(arguments: Value, profile: McpCapabilityProfile) -> Value {
+	let params = match serde_json::from_value::<AdminToolArgs>(arguments) {
+		Ok(params) => params,
+		Err(_) =>
+			return invalid_tool_arguments(
+				TOOL_ADMIN,
+				"`action` is required and must be capabilities.",
+			),
+	};
+
+	if params.action != "capabilities" {
+		return invalid_tool_arguments(TOOL_ADMIN, "`action` must be capabilities.");
+	}
+
+	tool_refusal_value(serde_json::json!({
+		"schema": "decodex.mcp.admin_result/1",
+		"status": "refused",
+		"reason": "deferred_admin_control",
+		"message": "Admin MCP behavior is not implemented in this stdio core-primitives lane.",
+		"capability_profile": profile.as_str(),
+		"action": params.action.as_str(),
+		"supported_admin_actions": []
+	}))
+}
+
+fn tool_success(value: Value) -> Value {
+	tool_result(value, false)
+}
+
+fn tool_refusal(reason: &str, message: impl Into<String>) -> Value {
+	tool_refusal_value(serde_json::json!({
+		"schema": "decodex.mcp.refusal/1",
+		"status": "refused",
+		"reason": reason,
+		"message": message.into()
+	}))
+}
+
+fn invalid_tool_arguments(tool: &str, message: &str) -> Value {
+	tool_refusal_value(serde_json::json!({
+		"schema": "decodex.mcp.tool_validation_error/1",
+		"status": "refused",
+		"reason": "invalid_arguments",
+		"tool": tool,
+		"message": message
+	}))
+}
+
+fn capability_profile_refusal(
+	tool: &str,
+	capability_profile: McpCapabilityProfile,
+	required_profile: McpCapabilityProfile,
+) -> Value {
+	tool_refusal_value(serde_json::json!({
+		"schema": "decodex.mcp.refusal/1",
+		"status": "refused",
+		"reason": "insufficient_capability_profile",
+		"tool": tool,
+		"capability_profile": capability_profile.as_str(),
+		"required_capability_profile": required_profile.as_str(),
+		"message": "The active Decodex MCP capability profile does not expose this tool."
+	}))
+}
+
+fn tool_refusal_value(value: Value) -> Value {
+	tool_result(value, true)
+}
+
+fn tool_result(value: Value, is_error: bool) -> Value {
+	let text = serde_json::to_string_pretty(&value)
+		.unwrap_or_else(|_| String::from("{\"status\":\"refused\"}"));
+
+	serde_json::json!({
+		"content": [
+			{
+				"type": "text",
+				"text": text
+			}
+		],
+		"structuredContent": value,
+		"isError": is_error
+	})
+}
+
+fn tool_call_result_allows_progress(result: &Value) -> bool {
+	result.get("isError").and_then(Value::as_bool) == Some(false)
+}
+
+fn non_empty_string(value: Option<&str>) -> Option<&str> {
+	value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn serve_stdio_with_profile<R, W>(
+	reader: R,
+	mut writer: W,
+	context: McpContext,
+	capability_profile: McpCapabilityProfile,
+) -> Result<()>
 where
 	R: Read,
 	W: Write,
 {
-	let server = McpServer { context };
+	let server = McpServer { context, capability_profile };
 	let reader = BufReader::new(reader);
 
 	for line in reader.lines() {
@@ -500,7 +1594,7 @@ where
 			continue;
 		}
 
-		if let Some(response) = server.handle_line(&line) {
+		for response in server.handle_line(&line, true) {
 			write_json_line(&mut writer, &response)?;
 		}
 	}
@@ -564,6 +1658,88 @@ fn json_rpc_error(id: Value, code: i64, message: &str) -> Value {
 	})
 }
 
+fn progress_token_from_params(params: Option<&Value>) -> Option<Value> {
+	let token = params?.get("_meta")?.get("progressToken")?;
+
+	if token.is_string() || token.is_i64() || token.is_u64() {
+		return Some(token.clone());
+	}
+
+	None
+}
+
+fn progress_notification(
+	progress_token: Value,
+	progress: u64,
+	total: Option<u64>,
+	message: &str,
+) -> Value {
+	let mut params = serde_json::json!({
+		"progressToken": progress_token,
+		"progress": progress,
+		"message": message
+	});
+
+	if let Some(total) = total {
+		params["total"] = serde_json::json!(total);
+	}
+
+	serde_json::json!({
+		"jsonrpc": "2.0",
+		"method": "notifications/progress",
+		"params": params
+	})
+}
+
+fn sanitize_mcp_observability_value(value: &mut Value) {
+	match value {
+		Value::Object(object) => {
+			for key in [
+				"worktreePath",
+				"worktree_path",
+				"channelPath",
+				"channel_path",
+				"requestPath",
+				"request_path",
+				"configPath",
+				"config_path",
+				"repoRoot",
+				"repo_root",
+				"effectiveCwd",
+				"effective_cwd",
+				"cwd",
+				"privateEvidence",
+				"private_evidence",
+				"privateEvidenceRef",
+				"private_evidence_ref",
+				"privateEvidenceRefs",
+				"private_evidence_refs",
+				"readCommand",
+				"read_command",
+				"githubCliAuthority",
+				"github_cli_authority",
+				"githubCommandPath",
+				"github_command_path",
+				"ghCommandPath",
+				"gh_command_path",
+				"githubTokenEnvVar",
+				"github_token_env_var",
+				"path",
+			] {
+				object.remove(key);
+			}
+			for child in object.values_mut() {
+				sanitize_mcp_observability_value(child);
+			}
+		},
+		Value::Array(items) =>
+			for item in items {
+				sanitize_mcp_observability_value(item);
+			},
+		_ => {},
+	}
+}
+
 fn push_file_resource(
 	resources: &mut Vec<McpResource>,
 	path: PathBuf,
@@ -621,7 +1797,7 @@ fn read_file_resource(
 }
 
 fn docs_lane_allowed(lane: &str) -> bool {
-	matches!(lane, "spec" | "runbook" | "reference" | "decisions")
+	matches!(lane, "spec" | "runbook" | "reference" | "decisions" | "research")
 }
 
 fn safe_resource_stem(value: &str) -> bool {
@@ -654,12 +1830,12 @@ mod tests {
 
 	use crate::{
 		loop_contract::DecisionContract,
-		mcp::{self, McpContext},
+		mcp::{self, McpCapabilityProfile, McpContext, ResourceContent},
 		state::StateStore,
 	};
 
 	#[test]
-	fn initialize_exposes_read_only_resource_capability() {
+	fn initialize_exposes_protocol_primitive_capabilities() {
 		let repo = test_repo();
 		let responses =
 			run_stdio(repo.path(), r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#);
@@ -669,7 +1845,22 @@ mod tests {
 			result.get("capabilities").and_then(Value::as_object).expect("capabilities object");
 
 		assert!(capabilities.contains_key("resources"));
-		assert!(!capabilities.contains_key("tools"));
+		assert!(capabilities.contains_key("prompts"));
+		assert!(capabilities.contains_key("tools"));
+		assert!(capabilities.contains_key("logging"));
+		assert_eq!(capabilities["experimental"]["decodex"]["capabilityProfile"], "admin");
+	}
+
+	#[test]
+	fn logging_set_level_is_stdio_compatible() {
+		let repo = test_repo();
+		let responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"logging/setLevel","params":{"level":"debug"}}"#,
+		);
+		let result = response_at(&responses, 0)["result"].as_object().expect("result object");
+
+		assert!(result.is_empty());
 	}
 
 	#[test]
@@ -762,6 +1953,304 @@ mod tests {
 	}
 
 	#[test]
+	fn observability_sanitizer_strips_private_operator_fields() {
+		let mut value = sensitive_observability_fixture();
+
+		mcp::sanitize_mcp_observability_value(&mut value);
+
+		assert_observability_is_sanitized(&value);
+	}
+
+	#[test]
+	fn observability_resource_content_strips_private_operator_fields() {
+		let content = ResourceContent::mcp_observability_json(
+			"decodex://projects/decodex/status",
+			sensitive_observability_fixture(),
+		)
+		.expect("observability content should serialize");
+		let value: Value = serde_json::from_str(&content.text).expect("content should be json");
+
+		assert_eq!(content.mime_type, "application/json");
+
+		assert_observability_is_sanitized(&value);
+	}
+
+	#[test]
+	fn resources_templates_list_exposes_parameterized_resources() {
+		let repo = test_repo();
+		let responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"resources/templates/list","params":{}}"#,
+		);
+		let templates = response_at(&responses, 0)["result"]["resourceTemplates"]
+			.as_array()
+			.expect("resource templates array");
+		let uri_templates = templates
+			.iter()
+			.filter_map(|template| template.get("uriTemplate").and_then(Value::as_str))
+			.collect::<Vec<_>>();
+
+		assert!(uri_templates.contains(&"decodex://docs/spec/{topic}"));
+		assert!(uri_templates.contains(&"decodex://projects/{project_id}/lane-control/{issue}"));
+	}
+
+	#[test]
+	fn prompts_list_and_get_return_prompt_messages() {
+		let repo = test_repo();
+		let list_responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"prompts/list","params":{}}"#,
+		);
+		let prompts =
+			response_at(&list_responses, 0)["result"]["prompts"].as_array().expect("prompts array");
+		let prompt_names = prompts
+			.iter()
+			.filter_map(|prompt| prompt.get("name").and_then(Value::as_str))
+			.collect::<Vec<_>>();
+
+		assert!(prompt_names.contains(&"decodex_validation_ready"));
+
+		let get_responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"decodex_validation_ready","arguments":{"issue":"XY-994"}}}"#,
+		);
+		let messages = response_at(&get_responses, 0)["result"]["messages"]
+			.as_array()
+			.expect("messages array");
+		let text = messages[0]["content"]["text"].as_str().expect("prompt text");
+
+		assert!(text.contains("XY-994"));
+		assert!(text.contains("validation-ready"));
+	}
+
+	#[test]
+	fn prompts_get_rejects_missing_required_arguments() {
+		let repo = test_repo();
+		let responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"decodex_validation_ready","arguments":{}}}"#,
+		);
+		let error = response_at(&responses, 0).get("error").expect("error response");
+
+		assert_eq!(error["code"], -32_602);
+	}
+
+	#[test]
+	fn tools_list_exposes_schema_bound_tools() {
+		let repo = test_repo();
+		let responses =
+			run_stdio(repo.path(), r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}"#);
+		let tools = response_at(&responses, 0)["result"]["tools"].as_array().expect("tools array");
+		let plan = tools
+			.iter()
+			.find(|tool| tool.get("name").and_then(Value::as_str) == Some("decodex_plan"))
+			.expect("plan tool should be listed");
+
+		assert!(plan.get("inputSchema").is_some());
+		assert!(plan.get("outputSchema").is_some());
+		assert_eq!(plan["_meta"]["decodex/capabilityProfile"], "plan");
+
+		assert_tool_output_schema_variant(plan, "decodex.mcp.plan_result/1", Some("next_action"));
+		assert_tool_output_schema_variant(plan, "decodex.mcp.refusal/1", Some("reason"));
+		assert_tool_output_schema_variant(
+			plan,
+			"decodex.mcp.tool_validation_error/1",
+			Some("tool"),
+		);
+	}
+
+	#[test]
+	fn tools_list_filters_by_active_capability_profile() {
+		let repo = test_repo();
+		let responses = run_stdio_with_profile(
+			repo.path(),
+			McpCapabilityProfile::Observe,
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}"#,
+		);
+		let tools = response_at(&responses, 0)["result"]["tools"].as_array().expect("tools array");
+		let tool_names = tools
+			.iter()
+			.filter_map(|tool| tool.get("name").and_then(Value::as_str))
+			.collect::<Vec<_>>();
+
+		assert_eq!(tool_names, vec!["decodex_observe"]);
+	}
+
+	#[test]
+	fn tools_call_refuses_tools_above_active_capability_profile() {
+		let repo = test_repo();
+		let responses = run_stdio_with_profile(
+			repo.path(),
+			McpCapabilityProfile::Observe,
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_plan","arguments":{"intent":"validation_ready"}}}"#,
+		);
+		let structured = &response_at(&responses, 0)["result"]["structuredContent"];
+
+		assert_eq!(structured["schema"], "decodex.mcp.refusal/1");
+		assert_eq!(structured["reason"], "insufficient_capability_profile");
+		assert_eq!(structured["capability_profile"], "observe");
+		assert_eq!(structured["required_capability_profile"], "plan");
+	}
+
+	#[test]
+	fn tools_call_returns_structured_content() {
+		let repo = test_repo();
+		let responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_plan","arguments":{"intent":"validation_ready","issue":"XY-994"}}}"#,
+		);
+		let structured = &response_at(&responses, 0)["result"]["structuredContent"];
+
+		assert_eq!(structured["schema"], "decodex.mcp.plan_result/1");
+		assert_eq!(structured["status"], "ok");
+		assert_eq!(structured["issue"], "XY-994");
+	}
+
+	#[test]
+	fn tools_call_refuses_missing_plan_intent() {
+		let repo = test_repo();
+		let responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_plan","arguments":{}}}"#,
+		);
+		let result = &response_at(&responses, 0)["result"];
+
+		assert_eq!(result["isError"], true);
+		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.tool_validation_error/1");
+		assert_eq!(result["structuredContent"]["reason"], "invalid_arguments");
+		assert_eq!(result["structuredContent"]["tool"], "decodex_plan");
+	}
+
+	#[test]
+	fn tools_call_refuses_deferred_lane_control_mutation() {
+		let repo = test_repo();
+		let responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_lane_control","arguments":{"action":"interrupt","issue":"XY-994","runId":"run-1"}}}"#,
+		);
+		let result = &response_at(&responses, 0)["result"];
+
+		assert_eq!(result["isError"], true);
+		assert_eq!(result["structuredContent"]["status"], "refused");
+		assert_eq!(result["structuredContent"]["reason"], "deferred_to_XY-998");
+	}
+
+	#[test]
+	fn tools_call_refuses_missing_lane_control_action() {
+		let repo = test_repo();
+		let responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_lane_control","arguments":{"issue":"XY-994"}}}"#,
+		);
+		let result = &response_at(&responses, 0)["result"];
+
+		assert_eq!(result["isError"], true);
+		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.tool_validation_error/1");
+		assert_eq!(result["structuredContent"]["reason"], "invalid_arguments");
+		assert_eq!(result["structuredContent"]["tool"], "decodex_lane_control");
+	}
+
+	#[test]
+	fn tools_call_refuses_deferred_admin_operation() {
+		let repo = test_repo();
+		let responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_admin","arguments":{"action":"capabilities"}}}"#,
+		);
+		let result = &response_at(&responses, 0)["result"];
+
+		assert_eq!(result["isError"], true);
+		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.admin_result/1");
+		assert_eq!(result["structuredContent"]["status"], "refused");
+		assert_eq!(result["structuredContent"]["reason"], "deferred_admin_control");
+	}
+
+	#[test]
+	fn tools_call_refuses_missing_admin_action() {
+		let repo = test_repo();
+		let responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_admin","arguments":{}}}"#,
+		);
+		let result = &response_at(&responses, 0)["result"];
+
+		assert_eq!(result["isError"], true);
+		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.tool_validation_error/1");
+		assert_eq!(result["structuredContent"]["reason"], "invalid_arguments");
+		assert_eq!(result["structuredContent"]["tool"], "decodex_admin");
+	}
+
+	#[test]
+	fn tools_call_returns_structured_refusal_for_invalid_observe_arguments() {
+		let repo = test_repo();
+		let responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_observe","arguments":{"limit":0}}}"#,
+		);
+		let result = &response_at(&responses, 0)["result"];
+
+		assert_eq!(result["isError"], true);
+		assert_eq!(result["structuredContent"]["status"], "refused");
+		assert_eq!(result["structuredContent"]["reason"], "invalid_limit");
+	}
+
+	#[test]
+	fn tools_call_emits_json_rpc_progress_notification_when_requested() {
+		let repo = test_repo();
+		let responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"_meta":{"progressToken":"progress-1"},"name":"decodex_plan","arguments":{"intent":"validation_ready"}}}"#,
+		);
+
+		assert_eq!(responses[0]["method"], "notifications/progress");
+		assert_eq!(responses[0]["params"]["progressToken"], "progress-1");
+		assert_eq!(responses[1]["result"]["structuredContent"]["status"], "ok");
+	}
+
+	#[test]
+	fn tools_call_does_not_emit_progress_for_invalid_params() {
+		let repo = test_repo();
+		let responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"_meta":{"progressToken":"progress-1"}}}"#,
+		);
+
+		assert_eq!(responses.len(), 1);
+		assert_eq!(responses[0]["id"], 1);
+		assert_eq!(responses[0]["error"]["code"], -32_602);
+	}
+
+	#[test]
+	fn tools_call_does_not_emit_progress_for_structured_validation_error() {
+		let repo = test_repo();
+		let responses = run_stdio(
+			repo.path(),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"_meta":{"progressToken":"progress-1"},"name":"decodex_plan","arguments":{}}}"#,
+		);
+		let result = &response_at(&responses, 0)["result"];
+
+		assert_eq!(responses.len(), 1);
+		assert_eq!(result["isError"], true);
+		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.tool_validation_error/1");
+	}
+
+	#[test]
+	fn tools_call_does_not_emit_progress_for_structured_refusal() {
+		let repo = test_repo();
+		let responses = run_stdio_with_profile(
+			repo.path(),
+			McpCapabilityProfile::Observe,
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"_meta":{"progressToken":"progress-1"},"name":"decodex_plan","arguments":{"intent":"validation_ready"}}}"#,
+		);
+		let result = &response_at(&responses, 0)["result"];
+
+		assert_eq!(responses.len(), 1);
+		assert_eq!(result["isError"], true);
+		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.refusal/1");
+		assert_eq!(result["structuredContent"]["reason"], "insufficient_capability_profile");
+	}
+
+	#[test]
 	fn resources_read_rejects_invalid_resource_uri() {
 		let repo = test_repo();
 		let responses = run_stdio(
@@ -780,12 +2269,17 @@ mod tests {
 			r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
 			r#"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#,
 			r#"{"jsonrpc":"2.0","id":2,"method":"resources/list","params":{}}"#,
+			r#"{"jsonrpc":"2.0","id":3,"method":"resources/templates/list","params":{}}"#,
+			r#"{"jsonrpc":"2.0","id":4,"method":"prompts/list","params":{}}"#,
+			r#"{"jsonrpc":"2.0","id":5,"method":"prompts/get","params":{"name":"decodex_validation_ready","arguments":{"issue":"XY-994"}}}"#,
+			r#"{"jsonrpc":"2.0","id":6,"method":"tools/list","params":{}}"#,
+			r#"{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"decodex_plan","arguments":{"intent":"validation_ready"}}}"#,
 		]
 		.join("\n");
 		let output = run_stdio_raw(repo.path(), &input);
 		let lines = output.lines().collect::<Vec<_>>();
 
-		assert_eq!(lines.len(), 2);
+		assert_eq!(lines.len(), 7);
 
 		for line in lines {
 			let value = serde_json::from_str::<Value>(line).expect("stdout line should be JSON");
@@ -808,6 +2302,24 @@ mod tests {
 			.collect()
 	}
 
+	fn run_stdio_with_profile(
+		repo_root: &Path,
+		capability_profile: McpCapabilityProfile,
+		input: &str,
+	) -> Vec<Value> {
+		let context = McpContext {
+			repo_root: repo_root.to_path_buf(),
+			config_path: None,
+			project_id: None,
+			state_store: None,
+		};
+
+		run_stdio_raw_with_profile(context, capability_profile, input)
+			.lines()
+			.map(|line| serde_json::from_str::<Value>(line).expect("response should be JSON"))
+			.collect()
+	}
+
 	fn run_stdio_raw(repo_root: &Path, input: &str) -> String {
 		let context = McpContext {
 			repo_root: repo_root.to_path_buf(),
@@ -820,16 +2332,105 @@ mod tests {
 	}
 
 	fn run_stdio_raw_with_context(context: McpContext, input: &str) -> String {
+		run_stdio_raw_with_profile(context, McpCapabilityProfile::Admin, input)
+	}
+
+	fn run_stdio_raw_with_profile(
+		context: McpContext,
+		capability_profile: McpCapabilityProfile,
+		input: &str,
+	) -> String {
 		let mut output = Vec::new();
 
-		mcp::serve_stdio_with_context(Cursor::new(format!("{input}\n")), &mut output, context)
-			.expect("stdio server should run");
+		mcp::serve_stdio_with_profile(
+			Cursor::new(format!("{input}\n")),
+			&mut output,
+			context,
+			capability_profile,
+		)
+		.expect("stdio server should run");
 
 		String::from_utf8(output).expect("stdout should be utf-8")
 	}
 
 	fn response_at(responses: &[Value], index: usize) -> &Value {
 		responses.get(index).expect("response should exist")
+	}
+
+	fn assert_tool_output_schema_variant(tool: &Value, schema: &str, required_field: Option<&str>) {
+		let variants = tool["outputSchema"]["oneOf"].as_array().expect("oneOf variants");
+		let variant = variants
+			.iter()
+			.find(|variant| {
+				variant["properties"]["schema"]["enum"]
+					.as_array()
+					.expect("schema enum")
+					.iter()
+					.any(|value| value.as_str() == Some(schema))
+			})
+			.expect("schema variant should exist");
+
+		if let Some(required_field) = required_field {
+			assert!(
+				variant["required"]
+					.as_array()
+					.expect("required array")
+					.iter()
+					.any(|value| value.as_str() == Some(required_field))
+			);
+		}
+	}
+
+	fn sensitive_observability_fixture() -> Value {
+		serde_json::json!({
+			"schema": "decodex.operator.snapshot/1",
+			"project": {
+				"repoRoot": "/private/repo",
+				"config_path": "/private/project.toml",
+				"visible": "kept"
+			},
+			"runs": [
+				{
+					"issue": "XY-994",
+					"effective_cwd": "/private/worktree",
+					"private_evidence": {
+						"read_command": "decodex evidence --config /private/project.toml --issue XY-994"
+					},
+					"github_cli_authority": {
+						"github_command_path": "/private/bin/gh",
+						"github_token_env_var": "GITHUB_PAT_Y"
+					},
+					"nested": {
+						"readCommand": "decodex evidence --config /private/project.toml",
+						"privateEvidenceRef": "private-ref",
+						"safe": "kept"
+					}
+				}
+			]
+		})
+	}
+
+	fn assert_observability_is_sanitized(value: &Value) {
+		let serialized = serde_json::to_string(value).expect("value should serialize");
+
+		for sensitive in [
+			"repoRoot",
+			"config_path",
+			"effective_cwd",
+			"private_evidence",
+			"privateEvidenceRef",
+			"read_command",
+			"readCommand",
+			"github_cli_authority",
+			"github_command_path",
+			"github_token_env_var",
+			"/private",
+			"GITHUB_PAT_Y",
+		] {
+			assert!(!serialized.contains(sensitive), "sanitized value leaked {sensitive}");
+		}
+
+		assert!(serialized.contains("kept"));
 	}
 
 	fn test_repo() -> TempDir {

--- a/apps/decodex/tests/mcp_stdio.rs
+++ b/apps/decodex/tests/mcp_stdio.rs
@@ -1,0 +1,83 @@
+//! Process-level smoke tests for the Decodex MCP stdio gateway.
+
+#![allow(unused_crate_dependencies)]
+
+use std::{
+	fs,
+	io::Write as _,
+	path::PathBuf,
+	process::{Command, Stdio},
+};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+#[test]
+fn mcp_stdio_process_stdout_contains_only_json_rpc() {
+	let repo = test_repo();
+	let mut child = Command::new(env!("CARGO_BIN_EXE_decodex"))
+		.args(["mcp", "serve", "--transport", "stdio"])
+		.current_dir(repo.path())
+		.stdin(Stdio::piped())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped())
+		.spawn()
+		.expect("decodex mcp process should spawn");
+
+	{
+		let stdin = child.stdin.as_mut().expect("child stdin should be open");
+
+		stdin
+			.write_all(
+				br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
+{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
+{"jsonrpc":"2.0","id":2,"method":"resources/list","params":{}}
+{"jsonrpc":"2.0","id":3,"method":"resources/templates/list","params":{}}
+{"jsonrpc":"2.0","id":4,"method":"prompts/list","params":{}}
+{"jsonrpc":"2.0","id":5,"method":"prompts/get","params":{"name":"decodex_validation_ready","arguments":{"issue":"XY-994"}}}
+{"jsonrpc":"2.0","id":6,"method":"tools/list","params":{}}
+{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"decodex_plan","arguments":{"intent":"validation_ready"}}}
+"#,
+			)
+			.expect("stdio request should write");
+	}
+
+	drop(child.stdin.take());
+
+	let output = child.wait_with_output().expect("child should exit");
+
+	assert!(output.status.success(), "mcp process failed: {:?}", output.status);
+	assert!(
+		String::from_utf8_lossy(&output.stderr).trim().is_empty(),
+		"mcp process should not print diagnostics for the smoke path"
+	);
+
+	let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
+	let lines = stdout.lines().collect::<Vec<_>>();
+
+	assert_eq!(lines.len(), 7);
+
+	for line in lines {
+		let value = serde_json::from_str::<Value>(line).expect("stdout line should be JSON");
+
+		assert_eq!(value["jsonrpc"], "2.0");
+	}
+}
+
+fn test_repo() -> TempDir {
+	let repo = TempDir::new().expect("temp repo should exist");
+
+	write_file(repo.path().join("Cargo.toml"), "[workspace]\n");
+	write_file(repo.path().join("docs/index.md"), "# Docs\n");
+	write_file(repo.path().join("docs/policy.md"), "# Policy\n");
+	write_file(repo.path().join("docs/spec/runtime.md"), "# Runtime\n");
+
+	repo
+}
+
+fn write_file(path: PathBuf, contents: &str) {
+	let parent = path.parent().expect("test path should have parent");
+
+	fs::create_dir_all(parent).expect("parent directory should exist");
+	fs::write(path, contents).expect("test file should write");
+}

--- a/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
+++ b/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
@@ -6,7 +6,9 @@ status: active
 authority: rationale
 owner: docs
 tags: [decision]
-last_verified: 2026-06-16
+code_refs: [apps/decodex/src/mcp.rs, README.md, docs/spec/runtime.md, docs/reference/operator-control-plane.md]
+drift_watch: [decodex mcp serve --transport stdio, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call]
+last_verified: 2026-06-18
 ---
 # MCP Capability Gateway And Skill Slimming
 
@@ -102,7 +104,17 @@ Layer responsibilities:
 - Eval/harness gates verify that skill slimming did not remove required routing,
   safety, or evidence behavior.
 
-## MCP Surface
+## MCP Surface Target
+
+This section describes the complete promoted MCP direction across the generated issue
+set, not the surface delivered by the first core-protocol lane alone. The first
+implementation slice, XY-994, owns the stdio primitive gateway: `initialize`,
+`resources/list`, `resources/read`, `resources/templates/list`, `prompts/list`,
+`prompts/get`, `tools/list`, `tools/call`, `logging/setLevel`, progress notifications,
+profile-tagged tool discovery, and structured refusal behavior for deferred
+operate/admin entries. Streamable HTTP, richer observability, live research/intake
+planning tools, live lane-control/admin tools, and skill slimming remain separate
+follow-up lanes from the accepted Decision Contract.
 
 Resources:
 
@@ -179,12 +191,17 @@ Target shape:
 - `cargo test -p decodex plugin_surface_tests research_design` should pass after
   schema and packaged-skill changes.
 - `git diff --check` should pass.
-- Future MCP implementation should start read-only: resources plus status readback,
-  then add `research_compile`, then add mutating promotion/intake controls.
+- The stdio MCP primitive implementation should pass initialize, resources/list,
+  resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, progress
+  notification, and stdout-cleanliness smoke coverage. Streamable HTTP transport and
+  live operate/admin lane-control behavior should remain separate follow-up work.
 
 ## Open Follow-Up
 
-The first promoted implementation is the read-only stdio gateway exposed as
-`decodex mcp serve --transport stdio`. Later promoted work should stay split across
-research compile/promote tools, skill-slimming eval, and docs/resource validation
-lanes so mutating MCP tools do not bypass Decision Contract or lane-control authority.
+The first promoted implementation is the stdio gateway exposed as
+`decodex mcp serve --transport stdio`. It advertises resources, resource templates,
+prompts, and a schema-bound tool catalog while keeping mutating operate/admin behavior
+behind structured refusal states. Later promoted work should stay split across
+Streamable HTTP transport, research compile/promote tools, live lane-control tools,
+skill-slimming eval, and docs/resource validation lanes so mutating MCP tools do not
+bypass Decision Contract or lane-control authority.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,11 @@
 
 ## 2026-06-18
 
+- Added the stdio Decodex MCP primitive surface: initialize now advertises resources,
+  resource templates, prompts, tools, logging, and progress compatibility; stdio smoke
+  coverage now exercises resources/templates/list, prompts/list, prompts/get,
+  tools/list, tools/call, active capability-profile filtering, and stdout cleanliness
+  while Streamable HTTP and live operate/admin lane-control remain deferred.
 - Added `repo-memory-evaluator` so repo-memory OKF/LLM Wiki bundles have a
   plugin-eval-style quality workflow for static checks, route top-1/top-3 benchmarks,
   graph health, owner coverage, and before/after curation evidence.

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -6,9 +6,9 @@ status: active
 authority: current_state
 owner: docs
 tags: [reference]
-code_refs: [apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs]
-drift_watch: [decodex serve, decodex status, decodex evidence, phase_acceptance_check, control_plane_snapshot, operator dashboard, runtime.sqlite3, project.toml, WORKFLOW.md]
-last_verified: 2026-06-17
+code_refs: [apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/mcp.rs]
+drift_watch: [decodex serve, decodex status, decodex evidence, decodex mcp serve --transport stdio, phase_acceptance_check, control_plane_snapshot, operator dashboard, runtime.sqlite3, project.toml, WORKFLOW.md]
+last_verified: 2026-06-18
 ---
 # Operator Control Plane
 
@@ -80,10 +80,16 @@ Use `decodex app` to open the installed macOS app from the CLI; use
 the caller's environment, so `DECODEX_APP_SERVER_URL` remains an explicit App preview
 override when set.
 
-Local MCP hosts can use `decodex mcp serve --transport stdio` for read-only resource
-access. The stdio gateway lists and reads checked-in docs, checked-in JSON research
-reports, Decision Contract readback, status snapshots, and lane-control readback. It
-does not serve Streamable HTTP and does not expose mutating MCP tools in this phase.
+Local MCP hosts can use `decodex mcp serve --transport stdio` for core MCP protocol
+primitives. The stdio gateway lists and reads checked-in docs, checked-in JSON
+research reports, Decision Contract readback, status snapshots, and lane-control
+readback; it also advertises resource templates, reusable Decodex prompts, and a small
+schema-bound tool catalog. The stdio gateway defaults to `--capability-profile admin`
+for local clients and can be narrowed to `observe`, `plan`, or `operate`; `tools/list`
+filters by that active profile and above-profile calls return structured refusals.
+Observe and plan tools are read-oriented. Operate/admin lane-control entries return
+structured refusal states in this phase. Streamable HTTP endpoint, session, origin,
+and SSE behavior is deferred to separate transport work.
 
 `decodex serve` has two hardcoded scheduler cadences:
 

--- a/docs/reference/test-suite.md
+++ b/docs/reference/test-suite.md
@@ -6,7 +6,9 @@ status: active
 authority: current_state
 owner: docs
 tags: [reference]
-last_verified: 2026-06-17
+code_refs: [apps/decodex/src/mcp.rs, apps/decodex/tests/mcp_stdio.rs, apps/decodex/src/orchestrator/tests.rs, apps/decodex/src/agent/app_server/tests.rs, apps/decodex/src/state/tests.rs]
+drift_watch: [cargo nextest list --workspace --all-targets --all-features, mcp::tests]
+last_verified: 2026-06-18
 ---
 # Test Suite
 
@@ -24,7 +26,7 @@ standards for keeping, merging, or deleting tests.
 
 ## Current Snapshot
 
-This snapshot lists 1213 default-runnable `nextest` tests. One additional ignored
+This snapshot lists 1239 default-runnable `nextest` tests. One additional ignored
 live app-server test is listed only with verbose or JSON inventory output. Regenerate
 the runnable inventory with:
 
@@ -54,13 +56,13 @@ cargo nextest list --workspace --all-targets --all-features 2>/dev/null \
 
 | Group | Count | Primary surfaces | Owns |
 | --- | ---: | --- | --- |
-| Orchestrator | 600 | `apps/decodex/src/orchestrator/tests.rs`, `apps/decodex/src/orchestrator/tests/**/*.rs` | Intake, retry, review/landing, runtime cleanup, operator status, repo gates |
+| Orchestrator | 604 | `apps/decodex/src/orchestrator/tests.rs`, `apps/decodex/src/orchestrator/tests/**/*.rs` | Intake, retry, review/landing, runtime cleanup, operator status, repo gates |
 | Tracker tool bridge | 102 | `apps/decodex/src/agent/tracker_tool_bridge/tests.rs`, `apps/decodex/src/agent/tracker_tool_bridge/tests/**/*.rs` | Dynamic tracker tools, continuation guards, review handoff writes, closeout writes |
-| App-server protocol/runtime | 92 | `apps/decodex/src/agent/app_server/tests.rs`, `apps/decodex/src/agent/json_rpc.rs`, app-server protocol tests | JSON-RPC parsing, turn execution, dynamic tools, thread config, transport failures |
-| Runtime state, locks, and maintenance | 83 | `state::tests`, `runtime::tests`, `maintenance::tests` | Persistent local state, lock ownership, runtime database contracts, local retention |
+| App-server protocol/runtime | 93 | `apps/decodex/src/agent/app_server/tests.rs`, `apps/decodex/src/agent/json_rpc.rs`, app-server protocol tests | JSON-RPC parsing, turn execution, dynamic tools, thread config, transport failures |
+| Runtime state, locks, and maintenance | 86 | `state::tests`, `runtime::tests`, `maintenance::tests` | Persistent local state, lock ownership, runtime database contracts, local retention |
 | Workflow, config, and docs parsing | 62 | `workflow::tests`, `config::tests`, `codex_config::tests`, `docs_okf::tests` | `WORKFLOW.md`, project config, Codex config edits, removed-field rejection, default policy, OKF docs parsing |
 | Git, worktree, landing, and recovery helpers | 137 | `worktree::tests`, `manual::tests`, `commit_message::tests`, `github::tests`, `default_branch_sync::tests`, `pull_request::tests`, `recovery::tests`, `git_credentials::tests` | Git/worktree behavior, manual landing, GitHub/PR helpers, recovery commands, commit-message policy |
-| Account, CLI, archive, tracker, and MCP integration | 98 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests`, `mcp::tests` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter, MCP resources, and public-text behavior |
+| Account, CLI, archive, tracker, and MCP integration | 116 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests`, `mcp::tests`, `apps/decodex/tests/mcp_stdio.rs` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter, MCP resources, and public-text behavior |
 | Program intake | 10 | `program_intake::tests` | Decision Contract materialization, Linear issue shaping, and internal Execution Program persistence |
 | Loop contract and research surfaces | 29 | `loop_contract::tests`, `execution_program::tests`, `research_design::tests`, `plugin_surface_tests` | Decision Contract schema, Execution Program readiness, research compile/promote, and plugin trigger behavior |
 

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -6,8 +6,8 @@ status: active
 authority: normative
 owner: runtime
 tags: [spec]
-code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs]
-drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, protocol_events, decodex intake goal, program_issue_mappings]
+code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/mcp.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs]
+drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, protocol_events, decodex mcp serve --transport stdio, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, decodex intake goal, program_issue_mappings]
 last_verified: 2026-06-18
 ---
 # Runtime Specification
@@ -80,11 +80,18 @@ state or this state machine.
 - `decodex research compile` and `decodex research promote` are runtime-local
   Decision Contract writes. They update the SQLite `decision_contracts` surface and do
   not by themselves create Linear issues, queue intent, goals, or executable lanes.
-- `decodex mcp serve --transport stdio` is the local read-only MCP gateway. Phase one
-  exposes MCP resources that read checked-in docs, checked-in JSON research reports,
-  runtime Decision Contracts, local status snapshots, and lane-control readback. It
-  must not expose mutating MCP tools, and stdout must contain only valid MCP JSON-RPC
-  messages.
+- `decodex mcp serve --transport stdio` is the local MCP gateway for desktop and CLI
+  clients. The stdio gateway advertises resources, resource templates, prompts, tools,
+  logging compatibility, and progress notifications. Resources read checked-in docs,
+  checked-in JSON research reports, runtime Decision Contracts, local status
+  snapshots, and lane-control readback. Tools are schema-bound and deliberately small:
+  observe and plan provide read-oriented structured results, while operate/admin
+  lane-control entries return structured refusal states until the dedicated
+  lane-control MCP work delegates through existing authority gates. Local stdio
+  defaults to the `admin` capability profile and can be narrowed with
+  `--capability-profile observe|plan|operate|admin`; tool discovery is filtered by the
+  active profile and above-profile calls return structured refusals. Stdout must
+  contain only valid MCP JSON-RPC messages.
 - `decodex intake goal <CONTRACT_ID> --dry-run` is a tracker-read-only and
   runtime-read-only operator surface for promoted Decision Contracts. It renders the
   proposed normal Linear issue split, dependencies, conflict domains, and dispatch plan
@@ -1004,9 +1011,12 @@ After a process restart, recent-run history, run lease ownership, retained post-
 - Operator snapshots may expose an additive `protocol_activity` object derived from app-server structured messages for the current run. The object stays local/operator-only and should summarize turn status, waiting reason, rate-limit status, and a compact recent event list for high-value app-server activity such as `turn/started`, `turn/completed`, plan updates, diff updates, item start/completion, command output deltas, server request responses, account updates, and rate-limit updates. Missing `protocol_activity` means no structured summary was captured yet; consumers must continue to rely on the older `event_count`, `last_event_type`, `last_event_at`, thread fields, and `child_agent_activity` fields when it is absent. Presence in `protocol_activity` is not by itself meaningful progress; non-work account, rate-limit, phase-goal, passive status, warning, model-routing, and token-usage events must remain distinguishable from work-progress events through `last_progress_at` and `progress_diagnostic`.
 - The operator snapshot transport must stay local/operator-only. `decodex serve` exposes the human-facing operator console from the canonical HTTP `GET /` and `GET /dashboard` routes, serves only the necessary dashboard assets, `GET /livez` liveness probe, and local account-control API over HTTP, and delivers published snapshots, current-lane activity, and dashboard control acknowledgements through the local `GET /dashboard/control` WebSocket upgrade.
 - The MCP stdio transport is separate from the operator HTTP/WebSocket transport. It is
-  local-client integration for resource readback only; it must not replace the app-server
-  dynamic tool bridge or become a lane-control mutation path before a later authority
-  design delegates through existing lane-control guards.
+  local-client integration for core MCP primitives over stdio only: resources,
+  templates, prompts, schema-bound tools, logging compatibility, progress
+  notifications, and stdio capability-profile filtering. Streamable HTTP endpoint,
+  session, origin, and SSE behavior belongs to later MCP transport work. MCP tools must
+  not replace the app-server dynamic tool bridge or become a lane-control mutation path
+  before a later authority design delegates through existing lane-control guards.
 - `GET /livez` is only a process- and listener-level liveness probe. It must not claim control-plane tick freshness or forward progress by itself.
 - The dashboard must not depend on a separate HTTP snapshot or readiness endpoint; snapshot freshness belongs to the WebSocket-delivered snapshot payload and the browser connection state.
 - Reconciliation must mark locally active run attempts as `interrupted` when their

--- a/plugins/decodex/.codex-plugin/plugin.json
+++ b/plugins/decodex/.codex-plugin/plugin.json
@@ -32,7 +32,7 @@
     "privacyPolicyURL": "https://github.com/hack-ink/decodex",
     "termsOfServiceURL": "https://github.com/hack-ink/decodex",
     "defaultPrompt": [
-      "Evaluate or curate a repo-memory OKF bundle.",
+      "Work with an OKF bundle.",
       "Maintain Decodex docs.",
       "Research this with Decodex."
     ],


### PR DESCRIPTION
## Summary
- Implement core Decodex MCP stdio primitives for resources, resource templates, prompts, tools, logging compatibility, progress notifications, and capability-profile filtering.
- Keep Streamable HTTP and live operate/admin lane-control mutation deferred to follow-up issues.
- Repair review findings around prompt validation, tool output schemas, stdout cleanliness, and progress notification emission for structured tool errors.

## Verification
- cargo test -p decodex tools_call_does_not_emit_progress -- --nocapture
- cargo test -p decodex mcp::tests -- --nocapture
- cargo make fmt
- cargo make lint-fix
- cargo make test
