### PR TITLE
XY-995 Add Streamable HTTP transport for remote Decodex MCP control

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ decodex intake goal --project decodex <CONTRACT_ID> --apply
 decodex intake issues --project decodex XY-1 XY-2 --dry-run
 decodex intake issues --project decodex XY-1 XY-2 --apply
 decodex mcp serve --transport stdio
+decodex mcp serve --transport streamable-http --listen-address 127.0.0.1:8193
 decodex run --dry-run
 decodex serve --listen-address 127.0.0.1:8192
 ```
@@ -155,16 +156,24 @@ mapped nodes are dispatched directly by the Program scheduler instead of being
 converted into queued-label work.
 
 `decodex mcp serve --transport stdio` starts the local MCP gateway for desktop and
-CLI clients. The gateway advertises resources, resource templates, prompts, tools,
-logging compatibility, and progress notifications over stdio. Resources expose
-checked-in documentation, checked-in JSON research reports, runtime Decision Contract
-readback, local status snapshots, and lane-control readback. The initial tool catalog
-is schema-bound and deliberately small. Local stdio defaults to the `admin` capability
-profile and can be narrowed with `--capability-profile observe|plan|operate|admin`;
-`tools/list` filters by the active profile and `tools/call` returns structured
-refusals for tools above it. Observe and plan are read-oriented, while operate/admin
-lane-control entries return structured refusal states until the later lane-control MCP
-work lands. Stdout is reserved for MCP JSON-RPC messages; diagnostics and logs stay
+CLI clients. `decodex mcp serve --transport streamable-http` serves the same gateway
+over the Streamable HTTP `POST /mcp` endpoint, bound to `127.0.0.1:8193` by default
+for operator-chosen local, tunnel, or relay access. Streamable HTTP validates browser
+`Origin` headers against loopback or repeated `--allow-origin <ORIGIN>` values, issues
+`Mcp-Session-Id` response headers on `initialize`, requires a known session for later
+requests, returns ordinary JSON-RPC JSON responses, and switches to
+`text/event-stream` framing when the client sends `Accept: text/event-stream`.
+The gateway advertises resources, resource templates, prompts, tools, logging
+compatibility, and progress notifications. Resources expose checked-in documentation,
+checked-in JSON research reports, runtime Decision Contract readback, local status
+snapshots, and lane-control readback. The tool catalog is schema-bound and
+deliberately small. Local stdio defaults to the `admin` capability profile; Streamable
+HTTP defaults to `observe`. Both can be set with
+`--capability-profile observe|plan|operate|admin`; `tools/list` filters by the active
+profile and `tools/call` returns structured refusals for tools above it. Observe and
+plan are read-oriented, while operate/admin lane-control entries return structured
+refusal states until later lane-control MCP work delegates through existing authority
+guards. Stdio stdout is reserved for MCP JSON-RPC messages; diagnostics and logs stay
 off stdout.
 
 ### Project contracts

--- a/apps/decodex/src/cli.rs
+++ b/apps/decodex/src/cli.rs
@@ -579,17 +579,30 @@ struct McpServeCommand {
 	/// MCP transport.
 	#[arg(long, value_enum, default_value_t = McpTransport::Stdio)]
 	transport: McpTransport,
-	/// Capability profile exposed by the MCP gateway.
-	#[arg(long, value_enum, default_value_t = mcp::McpCapabilityProfile::Admin)]
-	capability_profile: McpCapabilityProfile,
+	/// Capability profile exposed by the MCP gateway. Defaults to admin for stdio and observe for
+	/// Streamable HTTP.
+	#[arg(long, value_enum)]
+	capability_profile: Option<McpCapabilityProfile>,
+	/// Streamable HTTP listen address.
+	#[arg(long, value_name = "ADDR", default_value_t = mcp::DEFAULT_MCP_HTTP_LISTEN_ADDRESS.to_owned())]
+	listen_address: String,
+	/// Trusted browser Origin for Streamable HTTP. Repeat for multiple origins.
+	#[arg(long = "allow-origin", value_name = "ORIGIN")]
+	allowed_origins: Vec<String>,
 }
 impl McpServeCommand {
 	fn run(&self) -> Result<()> {
 		mcp::serve(McpServeRequest {
 			transport: self.transport,
 			config_path: self.project_config.as_path(),
-			capability_profile: self.capability_profile,
+			capability_profile: self.effective_capability_profile(),
+			listen_address: &self.listen_address,
+			allowed_origins: &self.allowed_origins,
 		})
+	}
+
+	fn effective_capability_profile(&self) -> McpCapabilityProfile {
+		self.capability_profile.unwrap_or_else(|| self.transport.default_capability_profile())
 	}
 }
 
@@ -1788,8 +1801,8 @@ mod tests {
 
 	use clap::Parser;
 
-	use crate::{
-		cli::{
+	use crate::mcp;
+	use crate::{cli::{
 			AccountCommand, AccountSubcommand, AccountUseCommand, AppCommand, AttemptCommand, Cli,
 			Command, CommitCommand, DiagnoseCommand, DocsCommand, DocsRouteCommand, DocsSubcommand,
 			EvidenceCommand, IntakeCommand, IntakeGoalCommand, IntakeIssuesCommand,
@@ -1802,9 +1815,7 @@ mod tests {
 			ReviewHandoffAdoptCommand, ReviewHandoffDiagnoseCommand, ReviewHandoffRebindCommand,
 			ReviewHandoffRecoveryCommand, ReviewHandoffRecoverySubcommand, RunCommand,
 			ServeCommand, StatusCommand,
-		},
-		mcp::{McpCapabilityProfile, McpTransport},
-	};
+		}, mcp::{McpCapabilityProfile, McpTransport}};
 
 	#[test]
 	fn parses_app_command() {
@@ -2123,7 +2134,33 @@ mod tests {
 
 		assert_eq!(serve.project_config.config.as_deref(), Some(Path::new("./project.toml")));
 		assert_eq!(serve.transport, McpTransport::Stdio);
-		assert_eq!(serve.capability_profile, McpCapabilityProfile::Admin);
+		assert_eq!(serve.effective_capability_profile(), McpCapabilityProfile::Admin);
+		assert_eq!(serve.listen_address, mcp::DEFAULT_MCP_HTTP_LISTEN_ADDRESS);
+		assert!(serve.allowed_origins.is_empty());
+	}
+
+	#[test]
+	fn parses_mcp_streamable_http_serve_with_safe_profile_default() {
+		let cli = Cli::parse_from([
+			"decodex",
+			"mcp",
+			"serve",
+			"--transport",
+			"streamable-http",
+			"--listen-address",
+			"127.0.0.1:8194",
+			"--allow-origin",
+			"http://127.0.0.1:8194",
+		]);
+		let Command::Mcp(command) = cli.command else {
+			panic!("expected mcp command");
+		};
+		let McpSubcommand::Serve(serve) = command.command;
+
+		assert_eq!(serve.transport, McpTransport::StreamableHttp);
+		assert_eq!(serve.effective_capability_profile(), McpCapabilityProfile::Observe);
+		assert_eq!(serve.listen_address, "127.0.0.1:8194");
+		assert_eq!(serve.allowed_origins, vec!["http://127.0.0.1:8194"]);
 	}
 
 	#[test]

--- a/apps/decodex/src/mcp.rs
+++ b/apps/decodex/src/mcp.rs
@@ -1,9 +1,13 @@
 use std::{
+	collections::BTreeSet,
 	env,
 	fmt::Display,
 	fs,
 	io::{self, BufRead as _, BufReader, ErrorKind, Read, Write},
+	net::{IpAddr, TcpListener, TcpStream},
 	path::{Path, PathBuf},
+	str,
+	time::Duration,
 };
 
 use clap::ValueEnum;
@@ -11,13 +15,10 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_json::{self, Value};
 
-use crate::{
-	config::ServiceConfig,
-	orchestrator,
-	prelude::{Result, eyre},
-	runtime,
-	state::StateStore,
-};
+use crate::{config::ServiceConfig, orchestrator, prelude::eyre, runtime, state::StateStore};
+
+/// Safe default listen address for Streamable HTTP MCP.
+pub(crate) const DEFAULT_MCP_HTTP_LISTEN_ADDRESS: &str = "127.0.0.1:8193";
 
 const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
 const SERVER_NAME: &str = "decodex";
@@ -31,6 +32,12 @@ const TOOL_OBSERVE: &str = "decodex_observe";
 const TOOL_PLAN: &str = "decodex_plan";
 const TOOL_LANE_CONTROL: &str = "decodex_lane_control";
 const TOOL_ADMIN: &str = "decodex_admin";
+const MCP_HTTP_ENDPOINT_PATH: &str = "/mcp";
+const MCP_HTTP_READ_TIMEOUT: Duration = Duration::from_secs(2);
+const MCP_HTTP_MAX_REQUEST_BYTES: usize = 1_024 * 1_024;
+const MCP_SESSION_HEADER: &str = "Mcp-Session-Id";
+const MCP_CORS_ALLOW_METHODS: &str = "POST, DELETE, OPTIONS";
+const MCP_CORS_ALLOW_HEADERS: &str = "Content-Type, Accept, Mcp-Session-Id";
 
 /// MCP transport supported by the native Decodex gateway.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -38,6 +45,23 @@ const TOOL_ADMIN: &str = "decodex_admin";
 pub(crate) enum McpTransport {
 	/// JSON-RPC messages over stdin/stdout.
 	Stdio,
+	/// MCP Streamable HTTP endpoint for remote-capable clients.
+	StreamableHttp,
+}
+impl McpTransport {
+	fn as_str(self) -> &'static str {
+		match self {
+			Self::Stdio => "stdio",
+			Self::StreamableHttp => "streamable-http",
+		}
+	}
+
+	pub(crate) fn default_capability_profile(self) -> McpCapabilityProfile {
+		match self {
+			Self::Stdio => McpCapabilityProfile::Admin,
+			Self::StreamableHttp => McpCapabilityProfile::Observe,
+		}
+	}
 }
 
 /// Capability profile exposed by the Decodex MCP gateway.
@@ -76,11 +100,14 @@ pub(crate) struct McpServeRequest<'a> {
 	pub(crate) transport: McpTransport,
 	pub(crate) config_path: Option<&'a Path>,
 	pub(crate) capability_profile: McpCapabilityProfile,
+	pub(crate) listen_address: &'a str,
+	pub(crate) allowed_origins: &'a [String],
 }
 
 struct McpServer {
 	context: McpContext,
 	capability_profile: McpCapabilityProfile,
+	transport: McpTransport,
 }
 impl McpServer {
 	fn handle_line(&self, line: &str, emit_progress: bool) -> Vec<Value> {
@@ -161,10 +188,14 @@ impl McpServer {
 							.into_iter()
 							.map(McpCapabilityProfile::as_str)
 							.collect::<Vec<_>>(),
-						"transport": "stdio",
+						"transport": self.transport.as_str(),
 						"remoteControl": {
 							"safeDefaultProfile": "observe",
-							"httpTransport": "deferred_to_XY-995",
+							"httpTransport": "streamable-http",
+							"httpEndpoint": MCP_HTTP_ENDPOINT_PATH,
+							"sessionHeader": MCP_SESSION_HEADER,
+							"sseResponses": true,
+							"originValidation": true,
 							"operateAdminTools": "deferred_to_XY-998",
 							"mutatingToolsRequireAuthority": true,
 							"privateEvidencePayloadsExposed": false
@@ -179,7 +210,7 @@ impl McpServer {
 		})
 	}
 
-	fn list_resources(&self) -> Result<Value, McpError> {
+	fn list_resources(&self) -> crate::prelude::Result<Value, McpError> {
 		let mut resources = self.context.docs_resources()?;
 
 		resources.extend(self.context.decision_contract_resources()?);
@@ -255,7 +286,7 @@ impl McpServer {
 		})
 	}
 
-	fn read_resource(&self, params: Option<Value>) -> Result<Value, McpError> {
+	fn read_resource(&self, params: Option<Value>) -> crate::prelude::Result<Value, McpError> {
 		let params = params.ok_or_else(McpError::invalid_params)?;
 		let params = serde_json::from_value::<ReadResourceParams>(params)
 			.map_err(|_| McpError::invalid_params())?;
@@ -276,7 +307,7 @@ impl McpServer {
 		serde_json::json!({ "prompts": mcp_prompts() })
 	}
 
-	fn get_prompt(&self, params: Option<Value>) -> Result<Value, McpError> {
+	fn get_prompt(&self, params: Option<Value>) -> crate::prelude::Result<Value, McpError> {
 		let params = params.ok_or_else(McpError::invalid_params)?;
 		let params = serde_json::from_value::<GetPromptParams>(params)
 			.map_err(|_| McpError::invalid_params())?;
@@ -299,7 +330,7 @@ impl McpServer {
 		serde_json::json!({ "tools": tools })
 	}
 
-	fn call_tool(&self, params: Option<Value>) -> Result<Value, McpError> {
+	fn call_tool(&self, params: Option<Value>) -> crate::prelude::Result<Value, McpError> {
 		let params = params.ok_or_else(McpError::invalid_params)?;
 		let params = serde_json::from_value::<CallToolParams>(params)
 			.map_err(|_| McpError::invalid_params())?;
@@ -380,7 +411,7 @@ struct McpContext {
 	state_store: Option<StateStore>,
 }
 impl McpContext {
-	fn for_process(config_path: Option<&Path>) -> Result<Self> {
+	fn for_process(config_path: Option<&Path>) -> crate::prelude::Result<Self> {
 		let state_store = runtime::open_runtime_store_lazy().ok();
 		let config_path = resolve_context_config_path(config_path, state_store.as_ref())?;
 		let config = config_path.as_ref().map(ServiceConfig::from_path).transpose()?;
@@ -402,7 +433,7 @@ impl McpContext {
 		self.project_id.as_deref()
 	}
 
-	fn docs_resources(&self) -> Result<Vec<McpResource>, McpError> {
+	fn docs_resources(&self) -> crate::prelude::Result<Vec<McpResource>, McpError> {
 		let mut resources = Vec::new();
 
 		push_file_resource(
@@ -450,7 +481,7 @@ impl McpContext {
 		Ok(resources)
 	}
 
-	fn decision_contract_resources(&self) -> Result<Vec<McpResource>, McpError> {
+	fn decision_contract_resources(&self) -> crate::prelude::Result<Vec<McpResource>, McpError> {
 		let Some(project_id) = self.project_id.as_deref() else {
 			return Ok(Vec::new());
 		};
@@ -473,7 +504,7 @@ impl McpContext {
 			.collect())
 	}
 
-	fn read_resource(&self, uri: &str) -> Result<ResourceContent, McpError> {
+	fn read_resource(&self, uri: &str) -> crate::prelude::Result<ResourceContent, McpError> {
 		let resource_uri = ResourceUri::parse(uri)?;
 
 		match resource_uri.host.as_str() {
@@ -485,7 +516,10 @@ impl McpContext {
 		}
 	}
 
-	fn read_docs_resource(&self, uri: &ResourceUri) -> Result<ResourceContent, McpError> {
+	fn read_docs_resource(
+		&self,
+		uri: &ResourceUri,
+	) -> crate::prelude::Result<ResourceContent, McpError> {
 		let path = match uri.segments.as_slice() {
 			[segment] if segment == "index" => self.repo_root.join("docs/index.md"),
 			[segment] if segment == "policy" => self.repo_root.join("docs/policy.md"),
@@ -497,7 +531,10 @@ impl McpContext {
 		read_file_resource(&uri.raw, path, "text/markdown")
 	}
 
-	fn read_research_resource(&self, uri: &ResourceUri) -> Result<ResourceContent, McpError> {
+	fn read_research_resource(
+		&self,
+		uri: &ResourceUri,
+	) -> crate::prelude::Result<ResourceContent, McpError> {
 		let [artifact] = uri.segments.as_slice() else {
 			return Err(McpError::resource_not_found());
 		};
@@ -522,7 +559,7 @@ impl McpContext {
 	fn read_decision_contract_resource(
 		&self,
 		uri: &ResourceUri,
-	) -> Result<ResourceContent, McpError> {
+	) -> crate::prelude::Result<ResourceContent, McpError> {
 		let [contract_id] = uri.segments.as_slice() else {
 			return Err(McpError::resource_not_found());
 		};
@@ -542,7 +579,7 @@ impl McpContext {
 		else {
 			return Err(McpError::resource_not_found());
 		};
-		let value = serde_json::json!({
+		let mut value = serde_json::json!({
 			"schema": "decodex.mcp.decision_contract_resource/1",
 			"project_id": record.project_id(),
 			"source_issue_id": record.source_issue_id(),
@@ -552,10 +589,15 @@ impl McpContext {
 			"decision_contract": record.contract()
 		});
 
+		sanitize_mcp_observability_value(&mut value);
+
 		ResourceContent::json(&uri.raw, value)
 	}
 
-	fn read_project_resource(&self, uri: &ResourceUri) -> Result<ResourceContent, McpError> {
+	fn read_project_resource(
+		&self,
+		uri: &ResourceUri,
+	) -> crate::prelude::Result<ResourceContent, McpError> {
 		let [project_id, resource_kind, rest @ ..] = uri.segments.as_slice() else {
 			return Err(McpError::resource_not_found());
 		};
@@ -707,13 +749,16 @@ struct ResourceContent {
 	text: String,
 }
 impl ResourceContent {
-	fn json(uri: &str, value: Value) -> Result<Self, McpError> {
+	fn json(uri: &str, value: Value) -> crate::prelude::Result<Self, McpError> {
 		let text = serde_json::to_string_pretty(&value).map_err(McpError::internal)?;
 
 		Ok(Self { uri: uri.to_owned(), mime_type: String::from("application/json"), text })
 	}
 
-	fn mcp_observability_json(uri: &str, mut value: Value) -> Result<Self, McpError> {
+	fn mcp_observability_json(
+		uri: &str,
+		mut value: Value,
+	) -> crate::prelude::Result<Self, McpError> {
 		sanitize_mcp_observability_value(&mut value);
 
 		Self::json(uri, value)
@@ -727,7 +772,7 @@ struct ResourceUri {
 	segments: Vec<String>,
 }
 impl ResourceUri {
-	fn parse(uri: &str) -> Result<Self, McpError> {
+	fn parse(uri: &str) -> crate::prelude::Result<Self, McpError> {
 		let parsed = Url::parse(uri).map_err(|_| McpError::invalid_params())?;
 
 		if parsed.scheme() != "decodex" {
@@ -774,8 +819,380 @@ impl McpError {
 	}
 }
 
+struct McpHttpHandler {
+	server: McpServer,
+	sessions: McpHttpSessions,
+	allowed_origins: Vec<String>,
+	listen_address: Option<String>,
+}
+impl McpHttpHandler {
+	fn handle_request_bytes(&mut self, request: &[u8]) -> crate::prelude::Result<Vec<u8>> {
+		let request = match McpHttpRequest::parse(request) {
+			Ok(request) => request,
+			Err(response) => return response.into_bytes(),
+		};
+		let response = self.handle_request(request)?;
+
+		response.into_bytes()
+	}
+
+	fn handle_request(
+		&mut self,
+		request: McpHttpRequest,
+	) -> crate::prelude::Result<McpHttpResponse> {
+		let cors_origin = match self.allowed_cors_origin(&request) {
+			Ok(origin) => origin,
+			Err(()) =>
+				return Ok(McpHttpResponse::json_error(
+					"403 Forbidden",
+					json_rpc_error(Value::Null, -32_000, "Forbidden origin"),
+				)),
+		};
+		let mut response = if request.path != MCP_HTTP_ENDPOINT_PATH {
+			McpHttpResponse::empty("404 Not Found")
+		} else {
+			match request.method.as_str() {
+				"OPTIONS" => self.handle_options(&request),
+				"POST" => self.handle_post(request)?,
+				"DELETE" => self.handle_delete(&request),
+				_ => McpHttpResponse::empty("405 Method Not Allowed"),
+			}
+		};
+
+		response.add_cors_headers(cors_origin);
+
+		Ok(response)
+	}
+
+	fn handle_options(&self, request: &McpHttpRequest) -> McpHttpResponse {
+		let Some(method) = request.header("Access-Control-Request-Method") else {
+			return McpHttpResponse::empty("204 No Content");
+		};
+
+		if matches!(method.to_ascii_uppercase().as_str(), "POST" | "DELETE") {
+			McpHttpResponse::empty("204 No Content")
+		} else {
+			McpHttpResponse::empty("405 Method Not Allowed")
+		}
+	}
+
+	fn handle_post(&mut self, request: McpHttpRequest) -> crate::prelude::Result<McpHttpResponse> {
+		if !request.content_type_is_json() {
+			return Ok(McpHttpResponse::json_error(
+				"415 Unsupported Media Type",
+				json_rpc_error(Value::Null, -32_600, "Invalid Request"),
+			));
+		}
+
+		let body = match str::from_utf8(&request.body) {
+			Ok(body) => body,
+			Err(_) =>
+				return Ok(McpHttpResponse::json_error(
+					"400 Bad Request",
+					json_rpc_error(Value::Null, -32_700, "Parse error"),
+				)),
+		};
+		let method = json_rpc_method_name(body);
+		let is_initialize = method.as_deref() == Some("initialize");
+		let session_id = request.header(MCP_SESSION_HEADER).map(str::to_owned);
+
+		if method.is_none() && serde_json::from_str::<Value>(body).is_err() {
+			return McpHttpResponse::json(
+				self.server
+					.handle_line(body, false)
+					.into_iter()
+					.next()
+					.unwrap_or_else(|| json_rpc_error(Value::Null, -32_700, "Parse error")),
+				None,
+			);
+		}
+
+		let wants_sse = request.accepts_sse();
+
+		if is_initialize {
+			let responses = self.server.handle_line(body, wants_sse);
+			let response_session_id =
+				initialize_response_succeeded(&responses).then(|| self.sessions.create());
+
+			return mcp_http_response_for_server_responses(
+				responses,
+				wants_sse,
+				response_session_id,
+			);
+		}
+
+		let Some(session_id) = session_id.as_deref() else {
+			return Ok(McpHttpResponse::json_error(
+				"428 Precondition Required",
+				json_rpc_error(Value::Null, -32_000, "Missing MCP session"),
+			));
+		};
+
+		if !self.sessions.contains(session_id) {
+			return Ok(McpHttpResponse::json_error(
+				"404 Not Found",
+				json_rpc_error(Value::Null, -32_001, "Unknown MCP session"),
+			));
+		}
+
+		let responses = self.server.handle_line(body, wants_sse);
+
+		mcp_http_response_for_server_responses(responses, wants_sse, Some(session_id.to_owned()))
+	}
+
+	fn handle_delete(&mut self, request: &McpHttpRequest) -> McpHttpResponse {
+		let Some(session_id) = request.header(MCP_SESSION_HEADER) else {
+			return McpHttpResponse::json_error(
+				"428 Precondition Required",
+				json_rpc_error(Value::Null, -32_000, "Missing MCP session"),
+			);
+		};
+
+		if !self.sessions.remove(session_id) {
+			return McpHttpResponse::json_error(
+				"404 Not Found",
+				json_rpc_error(Value::Null, -32_001, "Unknown MCP session"),
+			);
+		}
+
+		McpHttpResponse::empty("202 Accepted")
+	}
+
+	fn allowed_cors_origin(
+		&self,
+		request: &McpHttpRequest,
+	) -> std::result::Result<Option<String>, ()> {
+		let Some(origin) = request.header("Origin") else {
+			return Ok(None);
+		};
+
+		if mcp_http_origin_is_allowed(
+			origin,
+			self.listen_address.as_deref(),
+			self.allowed_origins.as_slice(),
+		) {
+			Ok(Some(origin.to_owned()))
+		} else {
+			Err(())
+		}
+	}
+}
+
+#[derive(Default)]
+struct McpHttpSessions {
+	active: BTreeSet<String>,
+	next_id: u64,
+}
+impl McpHttpSessions {
+	fn create(&mut self) -> String {
+		self.next_id = self.next_id.saturating_add(1);
+
+		let session_id = format!("decodex-mcp-session-{:016x}", self.next_id);
+
+		self.active.insert(session_id.clone());
+
+		session_id
+	}
+
+	fn contains(&self, session_id: &str) -> bool {
+		self.active.contains(session_id)
+	}
+
+	fn remove(&mut self, session_id: &str) -> bool {
+		self.active.remove(session_id)
+	}
+}
+
+struct McpHttpRequest {
+	method: String,
+	path: String,
+	headers: Vec<(String, String)>,
+	body: Vec<u8>,
+}
+impl McpHttpRequest {
+	fn parse(request: &[u8]) -> std::result::Result<Self, McpHttpResponse> {
+		let Some(header_end) = http_header_end(request) else {
+			return Err(McpHttpResponse::empty("400 Bad Request"));
+		};
+		let header_text = str::from_utf8(&request[..header_end])
+			.map_err(|_| McpHttpResponse::empty("400 Bad Request"))?;
+		let mut lines = header_text.split("\r\n");
+		let request_line = lines.next().ok_or_else(|| McpHttpResponse::empty("400 Bad Request"))?;
+		let mut request_parts = request_line.split_whitespace();
+		let method = request_parts
+			.next()
+			.ok_or_else(|| McpHttpResponse::empty("400 Bad Request"))?
+			.to_owned();
+		let path = request_parts
+			.next()
+			.ok_or_else(|| McpHttpResponse::empty("400 Bad Request"))?
+			.to_owned();
+		let version =
+			request_parts.next().ok_or_else(|| McpHttpResponse::empty("400 Bad Request"))?;
+
+		if !version.starts_with("HTTP/1.") {
+			return Err(McpHttpResponse::empty("505 HTTP Version Not Supported"));
+		}
+
+		let mut headers = Vec::new();
+
+		for line in lines {
+			if line.is_empty() {
+				continue;
+			}
+
+			let Some((name, value)) = line.split_once(':') else {
+				return Err(McpHttpResponse::empty("400 Bad Request"));
+			};
+
+			headers.push((name.trim().to_owned(), value.trim().to_owned()));
+		}
+
+		let content_length = http_content_length(&request[..header_end])
+			.map_err(|_| McpHttpResponse::empty("400 Bad Request"))?;
+		let body_start = header_end + 4;
+		let body_end = body_start.saturating_add(content_length);
+
+		if request.len() < body_end {
+			return Err(McpHttpResponse::empty("400 Bad Request"));
+		}
+
+		Ok(Self { method, path, headers, body: request[body_start..body_end].to_vec() })
+	}
+
+	fn header(&self, name: &str) -> Option<&str> {
+		self.headers
+			.iter()
+			.find(|(header, _)| header.eq_ignore_ascii_case(name))
+			.map(|(_, value)| value.as_str())
+	}
+
+	fn accepts_sse(&self) -> bool {
+		header_contains(self.header("Accept"), "text/event-stream")
+	}
+
+	fn content_type_is_json(&self) -> bool {
+		header_contains(self.header("Content-Type"), "application/json")
+	}
+}
+
+struct McpHttpResponse {
+	status: &'static str,
+	content_type: Option<&'static str>,
+	headers: Vec<(&'static str, String)>,
+	body: Vec<u8>,
+}
+impl McpHttpResponse {
+	fn empty(status: &'static str) -> Self {
+		Self { status, content_type: None, headers: Vec::new(), body: Vec::new() }
+	}
+
+	fn empty_with_session(status: &'static str, session_id: Option<String>) -> Self {
+		let mut response = Self::empty(status);
+
+		response.add_session_header(session_id);
+
+		response
+	}
+
+	fn json(value: Value, session_id: Option<String>) -> crate::prelude::Result<Self> {
+		let body = serde_json::to_vec(&value)?;
+		let mut response = Self {
+			status: "200 OK",
+			content_type: Some("application/json"),
+			headers: vec![("Cache-Control", String::from("no-store"))],
+			body,
+		};
+
+		response.add_session_header(session_id);
+
+		Ok(response)
+	}
+
+	fn json_error(status: &'static str, value: Value) -> Self {
+		let body =
+			serde_json::to_vec(&value)
+				.unwrap_or_else(|_| {
+					br#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"Internal error"}}"#.to_vec()
+				});
+
+		Self {
+			status,
+			content_type: Some("application/json"),
+			headers: vec![("Cache-Control", String::from("no-store"))],
+			body,
+		}
+	}
+
+	fn sse(responses: Vec<Value>, session_id: Option<String>) -> crate::prelude::Result<Self> {
+		let mut body = Vec::new();
+
+		for response in responses {
+			let line = serde_json::to_string(&response)?;
+
+			body.extend_from_slice(b"event: message\n");
+			body.extend_from_slice(b"data: ");
+			body.extend_from_slice(line.as_bytes());
+			body.extend_from_slice(b"\n\n");
+		}
+
+		let mut response = Self {
+			status: "200 OK",
+			content_type: Some("text/event-stream"),
+			headers: vec![
+				("Cache-Control", String::from("no-store")),
+				("X-Accel-Buffering", String::from("no")),
+			],
+			body,
+		};
+
+		response.add_session_header(session_id);
+
+		Ok(response)
+	}
+
+	fn add_session_header(&mut self, session_id: Option<String>) {
+		if let Some(session_id) = session_id {
+			self.headers.push((MCP_SESSION_HEADER, session_id));
+		}
+	}
+
+	fn add_cors_headers(&mut self, origin: Option<String>) {
+		let Some(origin) = origin else {
+			return;
+		};
+
+		self.headers.push(("Access-Control-Allow-Origin", origin));
+		self.headers.push(("Vary", String::from("Origin")));
+		self.headers.push(("Access-Control-Allow-Methods", String::from(MCP_CORS_ALLOW_METHODS)));
+		self.headers.push(("Access-Control-Allow-Headers", String::from(MCP_CORS_ALLOW_HEADERS)));
+		self.headers.push(("Access-Control-Expose-Headers", String::from(MCP_SESSION_HEADER)));
+	}
+
+	fn into_bytes(self) -> crate::prelude::Result<Vec<u8>> {
+		let mut response = Vec::new();
+
+		response.extend_from_slice(format!("HTTP/1.1 {}\r\n", self.status).as_bytes());
+		response.extend_from_slice(b"Connection: close\r\n");
+		response.extend_from_slice(format!("Content-Length: {}\r\n", self.body.len()).as_bytes());
+
+		if let Some(content_type) = self.content_type {
+			response.extend_from_slice(format!("Content-Type: {content_type}\r\n").as_bytes());
+		}
+
+		for (name, value) in self.headers {
+			response.extend_from_slice(format!("{name}: {value}\r\n").as_bytes());
+		}
+
+		response.extend_from_slice(b"\r\n");
+		response.extend_from_slice(&self.body);
+
+		Ok(response)
+	}
+}
+
 /// Start the Decodex MCP gateway.
-pub(crate) fn serve(request: McpServeRequest<'_>) -> Result<()> {
+pub(crate) fn serve(request: McpServeRequest<'_>) -> crate::prelude::Result<()> {
 	match request.transport {
 		McpTransport::Stdio => {
 			let context = McpContext::for_process(request.config_path)?;
@@ -789,7 +1206,43 @@ pub(crate) fn serve(request: McpServeRequest<'_>) -> Result<()> {
 				request.capability_profile,
 			)
 		},
+		McpTransport::StreamableHttp => {
+			validate_mcp_http_listen_address(request.listen_address, request.allowed_origins)?;
+
+			let context = McpContext::for_process(request.config_path)?;
+			let listener = TcpListener::bind(request.listen_address).map_err(|error| {
+				eyre::eyre!(
+					"Failed to bind Decodex MCP Streamable HTTP endpoint at {}: {error}",
+					request.listen_address
+				)
+			})?;
+
+			serve_streamable_http_with_profile(
+				listener,
+				context,
+				request.capability_profile,
+				request.allowed_origins.to_vec(),
+			)
+		},
 	}
+}
+
+fn mcp_http_response_for_server_responses(
+	responses: Vec<Value>,
+	wants_sse: bool,
+	session_id: Option<String>,
+) -> crate::prelude::Result<McpHttpResponse> {
+	if responses.is_empty() {
+		return Ok(McpHttpResponse::empty_with_session("202 Accepted", session_id));
+	}
+	if wants_sse {
+		return McpHttpResponse::sse(responses, session_id);
+	}
+
+	McpHttpResponse::json(
+		responses.into_iter().next().unwrap_or_else(|| serde_json::json!({})),
+		session_id,
+	)
 }
 
 fn mcp_prompts() -> Vec<Value> {
@@ -1451,7 +1904,7 @@ fn lane_control_stub_result(arguments: Value, profile: McpCapabilityProfile) -> 
 		"schema": "decodex.mcp.lane_control_result/1",
 		"status": "refused",
 		"reason": "deferred_to_XY-998",
-		"message": "MCP lane-control mutation is intentionally deferred; this lane only exposes core stdio protocol primitives.",
+		"message": "MCP lane-control mutation is intentionally deferred; this gateway currently exposes discovery, observability, and structured refusal surfaces.",
 		"capability_profile": profile.as_str(),
 		"action": params.action.as_str(),
 		"preconditions": lane_control_preconditions(&params)
@@ -1500,7 +1953,7 @@ fn admin_stub_result(arguments: Value, profile: McpCapabilityProfile) -> Value {
 		"schema": "decodex.mcp.admin_result/1",
 		"status": "refused",
 		"reason": "deferred_admin_control",
-		"message": "Admin MCP behavior is not implemented in this stdio core-primitives lane.",
+		"message": "Admin MCP behavior is not implemented in this gateway lane.",
 		"capability_profile": profile.as_str(),
 		"action": params.action.as_str(),
 		"supported_admin_actions": []
@@ -1579,12 +2032,12 @@ fn serve_stdio_with_profile<R, W>(
 	mut writer: W,
 	context: McpContext,
 	capability_profile: McpCapabilityProfile,
-) -> Result<()>
+) -> crate::prelude::Result<()>
 where
 	R: Read,
 	W: Write,
 {
-	let server = McpServer { context, capability_profile };
+	let server = McpServer { context, capability_profile, transport: McpTransport::Stdio };
 	let reader = BufReader::new(reader);
 
 	for line in reader.lines() {
@@ -1602,7 +2055,194 @@ where
 	Ok(())
 }
 
-fn write_json_line<W>(writer: &mut W, value: &Value) -> Result<()>
+fn serve_streamable_http_with_profile(
+	listener: TcpListener,
+	context: McpContext,
+	capability_profile: McpCapabilityProfile,
+	allowed_origins: Vec<String>,
+) -> crate::prelude::Result<()> {
+	let mut handler = McpHttpHandler {
+		server: McpServer { context, capability_profile, transport: McpTransport::StreamableHttp },
+		sessions: McpHttpSessions::default(),
+		allowed_origins,
+		listen_address: listener.local_addr().map(|address| address.to_string()).ok(),
+	};
+
+	for stream in listener.incoming() {
+		match stream {
+			Ok(mut stream) =>
+				if let Err(error) = handle_mcp_http_stream(&mut stream, &mut handler) {
+					tracing::warn!(?error, "Decodex MCP Streamable HTTP request failed.");
+				},
+			Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+			Err(error) => return Err(error.into()),
+		}
+	}
+
+	Ok(())
+}
+
+fn handle_mcp_http_stream(
+	stream: &mut TcpStream,
+	handler: &mut McpHttpHandler,
+) -> crate::prelude::Result<()> {
+	stream.set_read_timeout(Some(MCP_HTTP_READ_TIMEOUT))?;
+
+	let request = read_mcp_http_request(stream)?;
+	let response = handler.handle_request_bytes(&request)?;
+
+	stream.write_all(&response)?;
+	stream.flush()?;
+
+	Ok(())
+}
+
+fn read_mcp_http_request(stream: &mut TcpStream) -> crate::prelude::Result<Vec<u8>> {
+	let mut buffer = Vec::new();
+	let mut scratch = [0_u8; 1_024];
+	let mut expected_len = None;
+
+	loop {
+		let read = stream.read(&mut scratch)?;
+
+		if read == 0 {
+			break;
+		}
+
+		buffer.extend_from_slice(&scratch[..read]);
+
+		if buffer.len() > MCP_HTTP_MAX_REQUEST_BYTES {
+			eyre::bail!("MCP HTTP request exceeded {MCP_HTTP_MAX_REQUEST_BYTES} bytes.");
+		}
+		if expected_len.is_none()
+			&& let Some(header_end) = http_header_end(&buffer)
+		{
+			let content_length = http_content_length(&buffer[..header_end])?;
+
+			expected_len = Some(header_end + 4 + content_length);
+		}
+		if expected_len.is_some_and(|length| buffer.len() >= length) {
+			break;
+		}
+	}
+
+	Ok(buffer)
+}
+
+fn validate_mcp_http_listen_address(
+	address: &str,
+	allowed_origins: &[String],
+) -> crate::prelude::Result<()> {
+	if listen_address_host_is_loopback(address) || !allowed_origins.is_empty() {
+		return Ok(());
+	}
+
+	eyre::bail!(
+		"Refusing to bind Decodex MCP Streamable HTTP to `{address}` without --allow-origin; use the loopback default or set explicit trusted origins."
+	)
+}
+
+fn listen_address_host_is_loopback(address: &str) -> bool {
+	let host = listen_address_host(address);
+
+	host.as_deref().is_some_and(host_is_loopback)
+}
+
+fn mcp_http_origin_is_allowed(
+	origin: &str,
+	listen_address: Option<&str>,
+	allowed_origins: &[String],
+) -> bool {
+	if allowed_origins.iter().any(|allowed| allowed == origin) {
+		return true;
+	}
+
+	let Ok(parsed) = Url::parse(origin) else {
+		return false;
+	};
+	let Some(host) = parsed.host_str() else {
+		return false;
+	};
+
+	if !matches!(parsed.scheme(), "http" | "https") || !host_is_loopback(host) {
+		return false;
+	}
+
+	let Some(listen_port) = listen_address.and_then(listen_address_port) else {
+		return true;
+	};
+
+	parsed.port_or_known_default() == Some(listen_port)
+}
+
+fn host_is_loopback(host: &str) -> bool {
+	host.eq_ignore_ascii_case("localhost")
+		|| host
+			.trim_matches(['[', ']'])
+			.parse::<IpAddr>()
+			.is_ok_and(|address| address.is_loopback())
+}
+
+fn listen_address_host(address: &str) -> Option<String> {
+	let (host, _) = address.rsplit_once(':')?;
+
+	Some(host.trim_matches(['[', ']']).to_owned())
+}
+
+fn listen_address_port(address: &str) -> Option<u16> {
+	let (_, port) = address.rsplit_once(':')?;
+
+	port.parse().ok()
+}
+
+fn http_header_end(bytes: &[u8]) -> Option<usize> {
+	bytes.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn http_content_length(header_bytes: &[u8]) -> crate::prelude::Result<usize> {
+	let header_text = str::from_utf8(header_bytes)?;
+
+	for line in header_text.split("\r\n").skip(1) {
+		let Some((name, value)) = line.split_once(':') else {
+			continue;
+		};
+
+		if name.trim().eq_ignore_ascii_case("Content-Length") {
+			return Ok(value.trim().parse()?);
+		}
+	}
+
+	Ok(0)
+}
+
+fn header_contains(header: Option<&str>, value: &str) -> bool {
+	header
+		.map(|header| {
+			header.split(',').any(|item| {
+				item.trim().split(';').next().is_some_and(|item| item.eq_ignore_ascii_case(value))
+			})
+		})
+		.unwrap_or(false)
+}
+
+fn json_rpc_method_name(body: &str) -> Option<String> {
+	serde_json::from_str::<Value>(body)
+		.ok()
+		.and_then(|value| value.get("method").and_then(Value::as_str).map(str::to_owned))
+}
+
+fn initialize_response_succeeded(responses: &[Value]) -> bool {
+	responses.iter().any(|response| {
+		response.get("error").is_none()
+			&& response
+				.get("result")
+				.and_then(|result| result.get("protocolVersion"))
+				.and_then(Value::as_str)
+				== Some(MCP_PROTOCOL_VERSION)
+	})
+}
+
+fn write_json_line<W>(writer: &mut W, value: &Value) -> crate::prelude::Result<()>
 where
 	W: Write,
 {
@@ -1622,7 +2262,7 @@ where
 fn resolve_context_config_path(
 	explicit_path: Option<&Path>,
 	state_store: Option<&StateStore>,
-) -> Result<Option<PathBuf>> {
+) -> crate::prelude::Result<Option<PathBuf>> {
 	if let Some(path) = explicit_path {
 		return Ok(Some(path.to_path_buf()));
 	}
@@ -1634,7 +2274,7 @@ fn resolve_context_config_path(
 	runtime::registered_config_path_for_cwd(state_store, &env::current_dir()?)
 }
 
-fn discover_repo_root_from_current_dir() -> Result<Option<PathBuf>> {
+fn discover_repo_root_from_current_dir() -> crate::prelude::Result<Option<PathBuf>> {
 	let mut candidate = env::current_dir()?;
 
 	loop {
@@ -1714,6 +2354,16 @@ fn sanitize_mcp_observability_value(value: &mut Value) {
 				"private_evidence_ref",
 				"privateEvidenceRefs",
 				"private_evidence_refs",
+				"executionProgramId",
+				"execution_program_id",
+				"executionProgramNodeIds",
+				"execution_program_node_ids",
+				"graphId",
+				"graph_id",
+				"nodeId",
+				"node_id",
+				"programId",
+				"program_id",
 				"readCommand",
 				"read_command",
 				"githubCliAuthority",
@@ -1752,7 +2402,7 @@ fn push_file_resource(
 	}
 }
 
-fn read_sorted_dir(path: &Path) -> Result<Vec<PathBuf>, McpError> {
+fn read_sorted_dir(path: &Path) -> crate::prelude::Result<Vec<PathBuf>, McpError> {
 	let entries = match fs::read_dir(path) {
 		Ok(entries) => entries,
 		Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
@@ -1760,7 +2410,7 @@ fn read_sorted_dir(path: &Path) -> Result<Vec<PathBuf>, McpError> {
 	};
 	let mut paths = entries
 		.map(|entry| entry.map(|entry| entry.path()).map_err(McpError::internal))
-		.collect::<Result<Vec<_>, _>>()?;
+		.collect::<crate::prelude::Result<Vec<_>, _>>()?;
 
 	paths.sort();
 
@@ -1787,7 +2437,7 @@ fn read_file_resource(
 	uri: &str,
 	path: PathBuf,
 	mime_type: &str,
-) -> Result<ResourceContent, McpError> {
+) -> crate::prelude::Result<ResourceContent, McpError> {
 	let text = fs::read_to_string(path).map_err(|error| match error.kind() {
 		ErrorKind::NotFound => McpError::resource_not_found(),
 		_ => McpError::internal(error),
@@ -1823,16 +2473,59 @@ fn safe_runtime_identifier(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-	use std::{fs, io::Cursor, path::Path};
+	use std::{fs, io::Cursor, path::Path, str};
 
 	use serde_json::Value;
 	use tempfile::TempDir;
 
 	use crate::{
 		loop_contract::DecisionContract,
-		mcp::{self, McpCapabilityProfile, McpContext, ResourceContent},
+		mcp::{
+			self, DEFAULT_MCP_HTTP_LISTEN_ADDRESS, McpCapabilityProfile, McpContext,
+			McpHttpHandler, McpHttpSessions, McpServer, McpTransport, ResourceContent,
+		},
 		state::StateStore,
 	};
+
+	struct ParsedHttpResponse {
+		status: String,
+		headers: Vec<(String, String)>,
+		body: Vec<u8>,
+	}
+
+	impl ParsedHttpResponse {
+		fn parse(response: &[u8]) -> Self {
+			let header_end =
+				mcp::http_header_end(response).expect("response should include headers");
+			let headers = str::from_utf8(&response[..header_end]).expect("headers should be utf-8");
+			let mut lines = headers.split("\r\n");
+			let status = lines.next().expect("status line should exist").to_owned();
+			let headers = lines
+				.filter_map(|line| {
+					let (name, value) = line.split_once(':')?;
+
+					Some((name.trim().to_ascii_lowercase(), value.trim().to_owned()))
+				})
+				.collect();
+
+			Self { status, headers, body: response[(header_end + 4)..].to_vec() }
+		}
+
+		fn header(&self, name: &str) -> Option<&str> {
+			self.headers
+				.iter()
+				.find(|(header, _)| header == &name.to_ascii_lowercase())
+				.map(|(_, value)| value.as_str())
+		}
+
+		fn json_body(&self) -> Value {
+			serde_json::from_slice(&self.body).expect("HTTP body should be JSON")
+		}
+
+		fn body_text(&self) -> &str {
+			str::from_utf8(&self.body).expect("HTTP body should be utf-8")
+		}
+	}
 
 	#[test]
 	fn initialize_exposes_protocol_primitive_capabilities() {
@@ -1936,6 +2629,11 @@ mod tests {
 
 		assert_eq!(content["project_id"], "decodex");
 		assert_eq!(content["decision_contract"]["contract_id"], "research-x-loop-contract");
+		assert!(
+			content["decision_contract"]["evidence_boundary"]["private_evidence_refs"].is_null()
+		);
+		assert!(content["decision_contract"]["links"]["execution_program_node_ids"].is_null());
+		assert!(!text.contains("research-x-run"));
 	}
 
 	#[test]
@@ -2133,6 +2831,12 @@ mod tests {
 		assert_eq!(result["isError"], true);
 		assert_eq!(result["structuredContent"]["status"], "refused");
 		assert_eq!(result["structuredContent"]["reason"], "deferred_to_XY-998");
+		assert!(
+			!result["structuredContent"]["message"]
+				.as_str()
+				.expect("message should be text")
+				.contains("stdio")
+		);
 	}
 
 	#[test]
@@ -2163,6 +2867,12 @@ mod tests {
 		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.admin_result/1");
 		assert_eq!(result["structuredContent"]["status"], "refused");
 		assert_eq!(result["structuredContent"]["reason"], "deferred_admin_control");
+		assert!(
+			!result["structuredContent"]["message"]
+				.as_str()
+				.expect("message should be text")
+				.contains("stdio")
+		);
 	}
 
 	#[test]
@@ -2248,6 +2958,348 @@ mod tests {
 		assert_eq!(result["isError"], true);
 		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.refusal/1");
 		assert_eq!(result["structuredContent"]["reason"], "insufficient_capability_profile");
+	}
+
+	#[test]
+	fn streamable_http_json_post_initializes_session() {
+		let repo = test_repo();
+		let mut handler = http_handler(repo.path(), McpCapabilityProfile::Admin);
+		let response = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "http://127.0.0.1:8193"), ("Accept", "application/json")],
+				r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+			),
+		);
+		let body = response.json_body();
+
+		assert_eq!(response.status, "HTTP/1.1 200 OK");
+		assert_eq!(response.header("content-type"), Some("application/json"));
+		assert!(response.header("mcp-session-id").is_some());
+		assert_eq!(response.header("access-control-allow-origin"), Some("http://127.0.0.1:8193"));
+		assert_eq!(response.header("access-control-expose-headers"), Some("Mcp-Session-Id"));
+		assert_eq!(
+			body["result"]["capabilities"]["experimental"]["decodex"]["transport"],
+			"streamable-http"
+		);
+		assert_eq!(
+			body["result"]["capabilities"]["experimental"]["decodex"]["remoteControl"]["httpTransport"],
+			"streamable-http"
+		);
+	}
+
+	#[test]
+	fn streamable_http_allows_cors_preflight_for_trusted_origin() {
+		let repo = test_repo();
+		let mut handler = http_handler(repo.path(), McpCapabilityProfile::Admin);
+		let response = run_http(
+			&mut handler,
+			http_options(
+				"/mcp",
+				[
+					("Origin", "http://127.0.0.1:8193"),
+					("Access-Control-Request-Method", "POST"),
+					("Access-Control-Request-Headers", "Content-Type, Mcp-Session-Id"),
+				],
+			),
+		);
+
+		assert_eq!(response.status, "HTTP/1.1 204 No Content");
+		assert_eq!(response.header("access-control-allow-origin"), Some("http://127.0.0.1:8193"));
+		assert_eq!(response.header("access-control-allow-methods"), Some("POST, DELETE, OPTIONS"));
+		assert_eq!(
+			response.header("access-control-allow-headers"),
+			Some("Content-Type, Accept, Mcp-Session-Id")
+		);
+	}
+
+	#[test]
+	fn streamable_http_allows_configured_origin() {
+		let repo = test_repo();
+		let mut handler = http_handler_with_allowed_origins(
+			repo.path(),
+			McpCapabilityProfile::Admin,
+			vec![String::from("https://relay.example")],
+		);
+		let preflight = run_http(
+			&mut handler,
+			http_options(
+				"/mcp",
+				[("Origin", "https://relay.example"), ("Access-Control-Request-Method", "POST")],
+			),
+		);
+		let initialize = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "https://relay.example")],
+				r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+			),
+		);
+
+		assert_eq!(preflight.status, "HTTP/1.1 204 No Content");
+		assert_eq!(preflight.header("access-control-allow-origin"), Some("https://relay.example"));
+		assert_eq!(initialize.status, "HTTP/1.1 200 OK");
+		assert!(initialize.header("mcp-session-id").is_some());
+		assert_eq!(initialize.header("access-control-allow-origin"), Some("https://relay.example"));
+	}
+
+	#[test]
+	fn streamable_http_sse_response_includes_progress_notification() {
+		let repo = test_repo();
+		let mut handler = http_handler(repo.path(), McpCapabilityProfile::Admin);
+		let initialize = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "http://127.0.0.1:8193")],
+				r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+			),
+		);
+		let session_id = initialize.header("mcp-session-id").expect("session id").to_owned();
+		let response = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[
+					("Origin", "http://127.0.0.1:8193"),
+					("Accept", "text/event-stream"),
+					("Mcp-Session-Id", session_id.as_str()),
+				],
+				r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"_meta":{"progressToken":"progress-1"},"name":"decodex_plan","arguments":{"intent":"validation_ready"}}}"#,
+			),
+		);
+		let body = response.body_text();
+
+		assert_eq!(response.status, "HTTP/1.1 200 OK");
+		assert_eq!(response.header("content-type"), Some("text/event-stream"));
+		assert_eq!(response.header("access-control-allow-origin"), Some("http://127.0.0.1:8193"));
+		assert_eq!(response.header("access-control-expose-headers"), Some("Mcp-Session-Id"));
+		assert!(body.contains("event: message"));
+		assert!(body.contains("\"method\":\"notifications/progress\""));
+		assert!(body.contains("\"id\":2"));
+	}
+
+	#[test]
+	fn streamable_http_initialize_notification_does_not_create_session() {
+		let repo = test_repo();
+		let mut handler = http_handler(repo.path(), McpCapabilityProfile::Admin);
+		let response = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "http://127.0.0.1:8193")],
+				r#"{"jsonrpc":"2.0","method":"initialize","params":{}}"#,
+			),
+		);
+
+		assert_eq!(response.status, "HTTP/1.1 202 Accepted");
+		assert_eq!(response.header("mcp-session-id"), None);
+
+		let response = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[
+					("Origin", "http://127.0.0.1:8193"),
+					("Mcp-Session-Id", "decodex-mcp-session-0000000000000001"),
+				],
+				r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#,
+			),
+		);
+		let body = response.json_body();
+
+		assert_eq!(response.status, "HTTP/1.1 404 Not Found");
+		assert_eq!(body["error"]["message"], "Unknown MCP session");
+	}
+
+	#[test]
+	fn streamable_http_invalid_initialize_does_not_create_session() {
+		let repo = test_repo();
+		let mut handler = http_handler(repo.path(), McpCapabilityProfile::Admin);
+		let response = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "http://127.0.0.1:8193")],
+				r#"{"jsonrpc":"1.0","id":1,"method":"initialize","params":{}}"#,
+			),
+		);
+		let body = response.json_body();
+
+		assert_eq!(response.status, "HTTP/1.1 200 OK");
+		assert_eq!(response.header("mcp-session-id"), None);
+		assert_eq!(body["error"]["message"], "Invalid Request");
+	}
+
+	#[test]
+	fn streamable_http_rejects_disallowed_origin() {
+		let repo = test_repo();
+		let mut handler = http_handler(repo.path(), McpCapabilityProfile::Admin);
+		let response = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "https://example.invalid")],
+				r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+			),
+		);
+		let body = response.json_body();
+
+		assert_eq!(response.status, "HTTP/1.1 403 Forbidden");
+		assert_eq!(body["error"]["message"], "Forbidden origin");
+	}
+
+	#[test]
+	fn streamable_http_delete_invalidates_session() {
+		let repo = test_repo();
+		let mut handler = http_handler(repo.path(), McpCapabilityProfile::Admin);
+		let initialize = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "http://127.0.0.1:8193")],
+				r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+			),
+		);
+		let session_id = initialize.header("mcp-session-id").expect("session id").to_owned();
+		let delete = run_http(
+			&mut handler,
+			http_delete(
+				"/mcp",
+				[("Origin", "http://127.0.0.1:8193"), ("Mcp-Session-Id", session_id.as_str())],
+			),
+		);
+
+		assert_eq!(delete.status, "HTTP/1.1 202 Accepted");
+		assert_eq!(delete.header("access-control-allow-origin"), Some("http://127.0.0.1:8193"));
+
+		let response = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "http://127.0.0.1:8193"), ("Mcp-Session-Id", session_id.as_str())],
+				r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#,
+			),
+		);
+		let body = response.json_body();
+
+		assert_eq!(response.status, "HTTP/1.1 404 Not Found");
+		assert_eq!(body["error"]["message"], "Unknown MCP session");
+	}
+
+	#[test]
+	fn streamable_http_bind_guard_requires_loopback_or_allowed_origin() {
+		assert!(
+			mcp::validate_mcp_http_listen_address(DEFAULT_MCP_HTTP_LISTEN_ADDRESS, &[]).is_ok()
+		);
+		assert!(mcp::validate_mcp_http_listen_address("0.0.0.0:8193", &[]).is_err());
+		assert!(
+			mcp::validate_mcp_http_listen_address(
+				"0.0.0.0:8193",
+				&[String::from("https://relay.example")]
+			)
+			.is_ok()
+		);
+	}
+
+	#[test]
+	fn streamable_http_requires_known_session_after_initialize() {
+		let repo = test_repo();
+		let mut handler = http_handler(repo.path(), McpCapabilityProfile::Admin);
+
+		run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "http://127.0.0.1:8193")],
+				r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+			),
+		);
+
+		let response = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "http://127.0.0.1:8193")],
+				r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#,
+			),
+		);
+		let body = response.json_body();
+
+		assert_eq!(response.status, "HTTP/1.1 428 Precondition Required");
+		assert_eq!(body["error"]["message"], "Missing MCP session");
+	}
+
+	#[test]
+	fn streamable_http_observe_profile_exposes_only_observe_tool() {
+		let repo = test_repo();
+		let mut handler = http_handler(repo.path(), McpCapabilityProfile::Observe);
+		let initialize = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "http://127.0.0.1:8193")],
+				r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+			),
+		);
+		let session_id = initialize.header("mcp-session-id").expect("session id").to_owned();
+		let response = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "http://127.0.0.1:8193"), ("Mcp-Session-Id", session_id.as_str())],
+				r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#,
+			),
+		);
+		let body = response.json_body();
+		let tool_names = body["result"]["tools"]
+			.as_array()
+			.expect("tools array")
+			.iter()
+			.filter_map(|tool| tool.get("name").and_then(Value::as_str))
+			.collect::<Vec<_>>();
+
+		assert_eq!(tool_names, vec!["decodex_observe"]);
+	}
+
+	#[test]
+	fn streamable_http_observe_profile_refuses_operate_and_admin_calls() {
+		let repo = test_repo();
+		let mut handler = http_handler(repo.path(), McpCapabilityProfile::Observe);
+		let initialize = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "http://127.0.0.1:8193")],
+				r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+			),
+		);
+		let session_id = initialize.header("mcp-session-id").expect("session id").to_owned();
+
+		for (tool, required_profile, arguments) in [
+			("decodex_lane_control", "operate", r#"{"action":"inspect"}"#),
+			("decodex_admin", "admin", r#"{"action":"capabilities"}"#),
+		] {
+			let response = run_http(
+				&mut handler,
+				http_post(
+					"/mcp",
+					[("Origin", "http://127.0.0.1:8193"), ("Mcp-Session-Id", session_id.as_str())],
+					&format!(
+						r#"{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"{tool}","arguments":{arguments}}}}}"#
+					),
+				),
+			);
+			let body = response.json_body();
+			let structured = &body["result"]["structuredContent"];
+
+			assert_eq!(structured["schema"], "decodex.mcp.refusal/1");
+			assert_eq!(structured["reason"], "insufficient_capability_profile");
+			assert_eq!(structured["capability_profile"], "observe");
+			assert_eq!(structured["required_capability_profile"], required_profile);
+		}
 	}
 
 	#[test]
@@ -2431,6 +3483,100 @@ mod tests {
 		}
 
 		assert!(serialized.contains("kept"));
+	}
+
+	fn http_handler(repo_root: &Path, capability_profile: McpCapabilityProfile) -> McpHttpHandler {
+		http_handler_with_allowed_origins(repo_root, capability_profile, Vec::new())
+	}
+
+	fn http_handler_with_allowed_origins(
+		repo_root: &Path,
+		capability_profile: McpCapabilityProfile,
+		allowed_origins: Vec<String>,
+	) -> McpHttpHandler {
+		McpHttpHandler {
+			server: McpServer {
+				context: McpContext {
+					repo_root: repo_root.to_path_buf(),
+					config_path: None,
+					project_id: None,
+					state_store: None,
+				},
+				capability_profile,
+				transport: McpTransport::StreamableHttp,
+			},
+			sessions: McpHttpSessions::default(),
+			allowed_origins,
+			listen_address: Some(String::from(DEFAULT_MCP_HTTP_LISTEN_ADDRESS)),
+		}
+	}
+
+	fn run_http(handler: &mut McpHttpHandler, request: Vec<u8>) -> ParsedHttpResponse {
+		let response =
+			handler.handle_request_bytes(&request).expect("HTTP handler should return response");
+
+		ParsedHttpResponse::parse(&response)
+	}
+
+	fn http_post<'a>(
+		path: &str,
+		headers: impl IntoIterator<Item = (&'a str, &'a str)>,
+		body: &str,
+	) -> Vec<u8> {
+		let mut request = format!(
+			"POST {path} HTTP/1.1\r\nHost: 127.0.0.1:8193\r\nContent-Type: application/json\r\nContent-Length: {}\r\n",
+			body.len()
+		);
+
+		for (name, value) in headers {
+			request.push_str(name);
+			request.push_str(": ");
+			request.push_str(value);
+			request.push_str("\r\n");
+		}
+
+		request.push_str("\r\n");
+		request.push_str(body);
+
+		request.into_bytes()
+	}
+
+	fn http_delete<'a>(
+		path: &str,
+		headers: impl IntoIterator<Item = (&'a str, &'a str)>,
+	) -> Vec<u8> {
+		let mut request =
+			format!("DELETE {path} HTTP/1.1\r\nHost: 127.0.0.1:8193\r\nContent-Length: 0\r\n");
+
+		for (name, value) in headers {
+			request.push_str(name);
+			request.push_str(": ");
+			request.push_str(value);
+			request.push_str("\r\n");
+		}
+
+		request.push_str("\r\n");
+
+		request.into_bytes()
+	}
+
+	fn http_options<'a>(
+		path: &str,
+		headers: impl IntoIterator<Item = (&'a str, &'a str)>,
+	) -> Vec<u8> {
+		let mut request =
+			format!("OPTIONS {path} HTTP/1.1\r\nHost: 127.0.0.1:8193\r\nContent-Length: 0\r\n");
+
+		for (name, value) in headers {
+			request.push_str(name);
+			request.push_str(": ");
+			request.push_str(value);
+			request.push_str("\r\n");
+		}
+
+		request.push_str("\r\n");
+
+		request.into_bytes()
 	}
 
 	fn test_repo() -> TempDir {

--- a/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
+++ b/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
@@ -7,7 +7,7 @@ authority: rationale
 owner: docs
 tags: [decision]
 code_refs: [apps/decodex/src/mcp.rs, README.md, docs/spec/runtime.md, docs/reference/operator-control-plane.md]
-drift_watch: [decodex mcp serve --transport stdio, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call]
+drift_watch: [decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call]
 last_verified: 2026-06-18
 ---
 # MCP Capability Gateway And Skill Slimming
@@ -112,9 +112,12 @@ implementation slice, XY-994, owns the stdio primitive gateway: `initialize`,
 `resources/list`, `resources/read`, `resources/templates/list`, `prompts/list`,
 `prompts/get`, `tools/list`, `tools/call`, `logging/setLevel`, progress notifications,
 profile-tagged tool discovery, and structured refusal behavior for deferred
-operate/admin entries. Streamable HTTP, richer observability, live research/intake
-planning tools, live lane-control/admin tools, and skill slimming remain separate
-follow-up lanes from the accepted Decision Contract.
+operate/admin entries. The follow-up transport slice adds Streamable HTTP for the same
+gateway at `POST /mcp`, with loopback default binding, browser-origin validation,
+session headers, JSON responses, SSE framing for progress/notifications, and an
+`observe` default profile for remote-safe access. Richer live research/intake planning
+tools, live lane-control/admin mutation, and skill slimming remain separate follow-up
+lanes from the accepted Decision Contract.
 
 Resources:
 
@@ -193,15 +196,18 @@ Target shape:
 - `git diff --check` should pass.
 - The stdio MCP primitive implementation should pass initialize, resources/list,
   resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, progress
-  notification, and stdout-cleanliness smoke coverage. Streamable HTTP transport and
-  live operate/admin lane-control behavior should remain separate follow-up work.
+  notification, and stdout-cleanliness smoke coverage. Streamable HTTP should pass
+  JSON POST, SSE response, origin rejection, session handling, observe-profile access,
+  and operate/admin profile-refusal coverage. Live operate/admin lane-control behavior
+  should remain separate follow-up work.
 
 ## Open Follow-Up
 
-The first promoted implementation is the stdio gateway exposed as
-`decodex mcp serve --transport stdio`. It advertises resources, resource templates,
-prompts, and a schema-bound tool catalog while keeping mutating operate/admin behavior
-behind structured refusal states. Later promoted work should stay split across
-Streamable HTTP transport, research compile/promote tools, live lane-control tools,
+The promoted implementation now has the stdio gateway exposed as
+`decodex mcp serve --transport stdio` and the remote-capable Streamable HTTP gateway
+exposed as `decodex mcp serve --transport streamable-http`. It advertises resources,
+resource templates, prompts, and a schema-bound tool catalog while keeping mutating
+operate/admin behavior behind structured refusal states. Later promoted work should
+stay split across research compile/promote tools, live lane-control tools,
 skill-slimming eval, and docs/resource validation lanes so mutating MCP tools do not
 bypass Decision Contract or lane-control authority.

--- a/docs/evidence/decodex-plugin-eval.md
+++ b/docs/evidence/decodex-plugin-eval.md
@@ -1,22 +1,22 @@
 ---
 type: Evidence
 title: Decodex Plugin Eval
-description: Records plugin-eval results for the Decodex portable OKF, repo-memory, docs, and research skills.
+description: Records plugin-eval results for the Decodex plugin, routing skill, portable OKF, repo-memory, docs, and research skills.
 status: active
 authority: evidence
 owner: docs
 tags: [plugin-eval, skills, docs, research, okf, repo-memory]
 source_refs: []
-code_refs: [plugins/decodex/.codex-plugin/plugin.json, plugins/decodex/references/okf-layer.md, plugins/decodex/skills/okf/SKILL.md, plugins/decodex/skills/okf-query/SKILL.md, plugins/decodex/skills/okf-maintain/SKILL.md, plugins/decodex/skills/repo-memory-writer/SKILL.md, plugins/decodex/skills/docs/SKILL.md, plugins/decodex/skills/docs-okf/SKILL.md, plugins/decodex/skills/docs-wiki/SKILL.md, plugins/decodex/skills/docs-drift/SKILL.md, plugins/decodex/skills/research/SKILL.md]
+code_refs: [plugins/decodex/.codex-plugin/plugin.json, plugins/decodex/references/routing.md, plugins/decodex/references/okf-layer.md, plugins/decodex/skills/decodex/SKILL.md, plugins/decodex/skills/okf/SKILL.md, plugins/decodex/skills/okf-query/SKILL.md, plugins/decodex/skills/okf-maintain/SKILL.md, plugins/decodex/skills/repo-memory-writer/SKILL.md, plugins/decodex/skills/docs/SKILL.md, plugins/decodex/skills/docs-okf/SKILL.md, plugins/decodex/skills/docs-wiki/SKILL.md, plugins/decodex/skills/docs-drift/SKILL.md, plugins/decodex/skills/research/SKILL.md]
 related: [../policy.md, ./docs-self-iteration.md]
-last_verified: 2026-06-17
+last_verified: 2026-06-18
 ---
 
 # Decodex Plugin Eval
 
-Purpose: Preserve public-safe evidence that the Decodex plugin, portable OKF init and
-skill family, repo-memory writer skill, and docs skill family passed local plugin
-evaluation.
+Purpose: Preserve public-safe evidence that the Decodex plugin, routing skill,
+portable OKF init and skill family, repo-memory writer skill, and docs skill family
+passed local plugin evaluation.
 
 Read this when: You need proof that the OKF init/split, repo-memory writer, docs skill
 split, research skill split, and plugin invocation policy were evaluated before
@@ -29,16 +29,10 @@ Covers: Static plugin-eval commands, score results, and the invocation-policy de
 
 ## Commands
 
+Current full-plugin gate:
+
 ```sh
-node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex --format json
-node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/okf --format json
-node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/okf-query --format json
-node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/okf-maintain --format json
-node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/repo-memory-writer --format markdown
-node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/docs --format json
-node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/docs-okf --format json
-node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/docs-wiki --format json
-node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/43313cc9/scripts/plugin-eval.js analyze plugins/decodex/skills/docs-drift --format json
+node ~/.codex/plugins/cache/openai-curated/plugin-eval/015c0dff/scripts/plugin-eval.js analyze plugins/decodex --format markdown
 ```
 
 ## Results
@@ -66,6 +60,7 @@ Implicit skills:
 - `decodex`
 - `docs`
 - `planning`
+- `repo-memory-curator`
 - `research`
 
 Explicit-only skills:
@@ -81,6 +76,7 @@ Explicit-only skills:
 - `okf`
 - `okf-maintain`
 - `okf-query`
+- `repo-memory-evaluator`
 - `repo-memory-writer`
 - `research-challenge`
 - `research-decision`
@@ -92,7 +88,8 @@ Explicit-only skills:
 
 ## Limits
 
-The evaluation is static plugin analysis, not a measured real-usage benchmark. It is
-sufficient for the skill/plugin change gate in this lane because plugin-eval reported
-no warning or failing checks after the OKF split, repo-memory writer addition, and
-invocation-policy adjustment.
+The evaluation is static plugin analysis, not a measured real-usage benchmark. The
+2026-06-18 full-plugin rerun reported score 100/100, grade A, low risk, zero failing
+checks, zero warning checks, and two informational notes. That is sufficient for the
+MCP routing skill change because the remaining notes are coverage and observed-usage
+availability, not safety, routing, authority, or progressive-disclosure failures.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-18
 
+- Added Streamable HTTP to the Decodex MCP gateway: the transport now defaults to
+  loopback binding and the `observe` profile, validates browser origins, issues MCP
+  sessions, supports JSON and SSE responses, and keeps operate/admin calls behind
+  profile-gated structured refusals.
 - Added the stdio Decodex MCP primitive surface: initialize now advertises resources,
   resource templates, prompts, tools, logging, and progress compatibility; stdio smoke
   coverage now exercises resources/templates/list, prompts/list, prompts/get,

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -7,7 +7,7 @@ authority: current_state
 owner: docs
 tags: [reference]
 code_refs: [apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/mcp.rs]
-drift_watch: [decodex serve, decodex status, decodex evidence, decodex mcp serve --transport stdio, phase_acceptance_check, control_plane_snapshot, operator dashboard, runtime.sqlite3, project.toml, WORKFLOW.md]
+drift_watch: [decodex serve, decodex status, decodex evidence, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, phase_acceptance_check, control_plane_snapshot, operator dashboard, runtime.sqlite3, project.toml, WORKFLOW.md]
 last_verified: 2026-06-18
 ---
 # Operator Control Plane
@@ -80,16 +80,23 @@ Use `decodex app` to open the installed macOS app from the CLI; use
 the caller's environment, so `DECODEX_APP_SERVER_URL` remains an explicit App preview
 override when set.
 
-Local MCP hosts can use `decodex mcp serve --transport stdio` for core MCP protocol
-primitives. The stdio gateway lists and reads checked-in docs, checked-in JSON
+Local MCP hosts can use `decodex mcp serve --transport stdio` for local core MCP
+protocol primitives or `decodex mcp serve --transport streamable-http` for remote
+permitted clients that reach the daemon through an operator-chosen local listener,
+tunnel, or relay. Both transports list and read checked-in docs, checked-in JSON
 research reports, Decision Contract readback, status snapshots, and lane-control
-readback; it also advertises resource templates, reusable Decodex prompts, and a small
-schema-bound tool catalog. The stdio gateway defaults to `--capability-profile admin`
-for local clients and can be narrowed to `observe`, `plan`, or `operate`; `tools/list`
-filters by that active profile and above-profile calls return structured refusals.
-Observe and plan tools are read-oriented. Operate/admin lane-control entries return
-structured refusal states in this phase. Streamable HTTP endpoint, session, origin,
-and SSE behavior is deferred to separate transport work.
+readback; both also advertise resource templates, reusable Decodex prompts, and a
+small schema-bound tool catalog. The stdio gateway defaults to
+`--capability-profile admin` for local clients. Streamable HTTP binds to
+`127.0.0.1:8193` and defaults to `observe`; it serves JSON-RPC at `POST /mcp`,
+validates browser `Origin` headers against loopback or `--allow-origin`, issues
+`Mcp-Session-Id` on `initialize`, requires a known session after initialization, and
+uses SSE framing for progress or notifications when the client accepts
+`text/event-stream`. Both transports can be narrowed or explicitly elevated with
+`--capability-profile observe|plan|operate|admin`; `tools/list` filters by the active
+profile and above-profile calls return structured refusals. Observe and plan tools are
+read-oriented. Operate/admin lane-control entries return structured refusal states
+until later MCP lane-control work delegates mutation through existing authority gates.
 
 `decodex serve` has two hardcoded scheduler cadences:
 

--- a/docs/reference/test-suite.md
+++ b/docs/reference/test-suite.md
@@ -26,12 +26,14 @@ standards for keeping, merging, or deleting tests.
 
 ## Current Snapshot
 
-This snapshot lists 1239 default-runnable `nextest` tests. One additional ignored
-live app-server test is listed only with verbose or JSON inventory output. Regenerate
-the runnable inventory with:
+This snapshot groups 1255 runnable `nextest` tests across all targets. The main
+`decodex` binary accounts for 1254 of them; one additional skipped live app-server
+test is listed only with verbose or JSON inventory output. Regenerate the runnable
+inventory with:
 
 ```sh
-cargo nextest list --workspace --all-targets --all-features
+cargo nextest list --workspace --all-targets --all-features --verbose \
+  | rg -v "\\(skipped\\)"
 ```
 
 Regenerate the ignored/live-test inventory with:
@@ -62,7 +64,7 @@ cargo nextest list --workspace --all-targets --all-features 2>/dev/null \
 | Runtime state, locks, and maintenance | 86 | `state::tests`, `runtime::tests`, `maintenance::tests` | Persistent local state, lock ownership, runtime database contracts, local retention |
 | Workflow, config, and docs parsing | 62 | `workflow::tests`, `config::tests`, `codex_config::tests`, `docs_okf::tests` | `WORKFLOW.md`, project config, Codex config edits, removed-field rejection, default policy, OKF docs parsing |
 | Git, worktree, landing, and recovery helpers | 137 | `worktree::tests`, `manual::tests`, `commit_message::tests`, `github::tests`, `default_branch_sync::tests`, `pull_request::tests`, `recovery::tests`, `git_credentials::tests` | Git/worktree behavior, manual landing, GitHub/PR helpers, recovery commands, commit-message policy |
-| Account, CLI, archive, tracker, and MCP integration | 116 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests`, `mcp::tests`, `apps/decodex/tests/mcp_stdio.rs` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter, MCP resources, and public-text behavior |
+| Account, CLI, archive, tracker, and MCP integration | 132 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests`, `mcp::tests`, `apps/decodex/tests/mcp_stdio.rs` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter, MCP resources, HTTP transport, and public-text behavior |
 | Program intake | 10 | `program_intake::tests` | Decision Contract materialization, Linear issue shaping, and internal Execution Program persistence |
 | Loop contract and research surfaces | 29 | `loop_contract::tests`, `execution_program::tests`, `research_design::tests`, `plugin_surface_tests` | Decision Contract schema, Execution Program readiness, research compile/promote, and plugin trigger behavior |
 

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -7,7 +7,7 @@ authority: normative
 owner: runtime
 tags: [spec]
 code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/mcp.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs]
-drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, protocol_events, decodex mcp serve --transport stdio, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, decodex intake goal, program_issue_mappings]
+drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, protocol_events, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, decodex intake goal, program_issue_mappings]
 last_verified: 2026-06-18
 ---
 # Runtime Specification
@@ -1010,13 +1010,19 @@ After a process restart, recent-run history, run lease ownership, retained post-
 - `thread_id = null` is expected only before the worker creates the Codex thread for the current run. `event_count = 0`, `last_event_type = null`, and `last_event_at = null` are expected only before the first protocol event for that same run. After the thread exists and protocol activity has started, those empty values indicate missing hydration rather than normal progress.
 - Operator snapshots may expose an additive `protocol_activity` object derived from app-server structured messages for the current run. The object stays local/operator-only and should summarize turn status, waiting reason, rate-limit status, and a compact recent event list for high-value app-server activity such as `turn/started`, `turn/completed`, plan updates, diff updates, item start/completion, command output deltas, server request responses, account updates, and rate-limit updates. Missing `protocol_activity` means no structured summary was captured yet; consumers must continue to rely on the older `event_count`, `last_event_type`, `last_event_at`, thread fields, and `child_agent_activity` fields when it is absent. Presence in `protocol_activity` is not by itself meaningful progress; non-work account, rate-limit, phase-goal, passive status, warning, model-routing, and token-usage events must remain distinguishable from work-progress events through `last_progress_at` and `progress_diagnostic`.
 - The operator snapshot transport must stay local/operator-only. `decodex serve` exposes the human-facing operator console from the canonical HTTP `GET /` and `GET /dashboard` routes, serves only the necessary dashboard assets, `GET /livez` liveness probe, and local account-control API over HTTP, and delivers published snapshots, current-lane activity, and dashboard control acknowledgements through the local `GET /dashboard/control` WebSocket upgrade.
-- The MCP stdio transport is separate from the operator HTTP/WebSocket transport. It is
-  local-client integration for core MCP primitives over stdio only: resources,
-  templates, prompts, schema-bound tools, logging compatibility, progress
-  notifications, and stdio capability-profile filtering. Streamable HTTP endpoint,
-  session, origin, and SSE behavior belongs to later MCP transport work. MCP tools must
-  not replace the app-server dynamic tool bridge or become a lane-control mutation path
-  before a later authority design delegates through existing lane-control guards.
+- The MCP stdio and Streamable HTTP transports are separate from the operator
+  HTTP/WebSocket transport. They expose the same MCP gateway: resources, templates,
+  prompts, schema-bound tools, logging compatibility, progress notifications, and
+  capability-profile filtering. Stdio is for local clients, defaults to the `admin`
+  capability profile, and must keep stdout valid JSON-RPC only. Streamable HTTP is the
+  remote-control-capable transport at `POST /mcp`; it binds to `127.0.0.1:8193` by
+  default, defaults to the `observe` profile, validates browser `Origin` headers
+  against loopback or explicit trusted origins, issues `Mcp-Session-Id` on
+  `initialize`, requires a known session on later requests, returns JSON-RPC JSON by
+  default, and uses SSE framing for remote progress or notifications when the client
+  accepts `text/event-stream`. MCP tools must not replace the app-server dynamic tool
+  bridge or become a lane-control mutation path before a later authority design
+  delegates through existing lane-control guards.
 - `GET /livez` is only a process- and listener-level liveness probe. It must not claim control-plane tick freshness or forward progress by itself.
 - The dashboard must not depend on a separate HTTP snapshot or readiness endpoint; snapshot freshness belongs to the WebSocket-delivered snapshot payload and the browser connection state.
 - Reconciliation must mark locally active run attempts as `interrupted` when their

--- a/plugins/decodex/references/routing.md
+++ b/plugins/decodex/references/routing.md
@@ -21,6 +21,12 @@ labels, automation, commit, or landing boundaries.
   recovery inspection, commit, or landing.
 - Labels: use `labels` only for ordinary non-Program tracker intake and retained-lane
   ownership signals.
+- MCP gateway: use `decodex mcp serve --transport stdio` for local MCP clients and
+  `decodex mcp serve --transport streamable-http` only for remote permitted clients
+  behind the operator's chosen local listener, tunnel, or relay. Treat MCP resources,
+  prompts, and tools as a typed facade over existing Decodex docs/runtime authority,
+  not as a replacement for Decision Contract, lane-control, tracker, review, landing,
+  or closeout gates.
 
 ## First Reads
 
@@ -73,6 +79,9 @@ work. If issue-authority land reports missing retained handoff state, dry-run
   owns Decodex issue shaping after execution authority exists.
 - Do not hand-edit runtime DB rows, kill hidden `_attempt` children, or mutate Linear
   state to simulate lane controls.
+- Do not use MCP tools to bypass Decision Contract promotion, lane-control
+  preconditions, tracker-tool boundaries, review handoff, landing, closeout, or
+  existing runtime authority.
 - Do not substitute raw GitHub merge, merge queue, `gh pr merge`, direct API mutation,
   or hand-assembled merge commits for `decodex land` when Decodex owns landing.
 - Do not expose graph ids, DAG edge editing, hidden goal ids, or Program dispatch

--- a/plugins/decodex/skills/decodex/SKILL.md
+++ b/plugins/decodex/skills/decodex/SKILL.md
@@ -18,5 +18,11 @@ research, promotion, planning, labels, runtime, commit, or landing boundaries ma
 - `automation`: retained lanes, Program Intake, recovery, closeout.
 - `labels`, `commit`, `land`: only their narrow surfaces.
 
+When an MCP client is available, use the Decodex MCP gateway as a typed facade for
+resources, prompts, and the deliberately small tool catalog. Prefer stdio for local
+clients and Streamable HTTP only for remote permitted clients behind the operator's
+chosen local listener, tunnel, or relay. MCP tools do not bypass Decision Contract,
+lane-control, review, landing, tracker, or runtime authority gates.
+
 Research is latent until promoted. Program Intake is not queue-label polling.
 Decodex-owned landing uses `decodex land`, not raw GitHub merge paths.


### PR DESCRIPTION
## Summary
- Add Streamable HTTP MCP serving for remote-capable clients at `/mcp` with JSON and SSE responses.
- Add CORS origin validation, session creation on successful initialize, known-session enforcement, and DELETE teardown.
- Keep Streamable HTTP on the safe `observe` capability profile by default while retaining stdio `admin` behavior.
- Sanitize Decision Contract MCP resources so observe readback does not expose private evidence refs or internal graph/program/node ids.
- Update runtime/operator docs, test-suite evidence, MCP decision notes, and Decodex plugin routing guidance.

## Validation
- `cargo make fmt`
- `cargo make lint-fix`
- `cargo make test` (1255 passed, 1 skipped)
- `cargo make check-docs`
- `node ~/.codex/plugins/cache/openai-curated/plugin-eval/015c0dff/scripts/plugin-eval.js analyze plugins/decodex --format markdown` (100/100, A, low risk; 0 fail, 0 warn)