### PR TITLE
[codex] Sync app-server 0.141 dynamic tool protocol

### DIFF
--- a/apps/decodex/src/agent/app_server.rs
+++ b/apps/decodex/src/agent/app_server.rs
@@ -35,6 +35,7 @@ use self::protocol::{
 	ThreadResumeRequest, ThreadSessionResponse, ThreadStartRequest,
 	ThreadStatusChangedNotification, ToolRequestUserInputResponse, TurnCompletedNotification,
 	TurnError, TurnInterruptRequest, TurnStartRequest, TurnSteerRequest, UserInput,
+	app_server_dynamic_tool_specs,
 };
 use crate::{
 	agent::{
@@ -118,10 +119,61 @@ const APP_SERVER_SCHEMA_REQUIRED_MARKERS: &[&str] = &[
 	"thread/status/changed",
 	"turn/completed",
 	"dynamicTools",
+	"function",
 	"namespace",
+	"tools",
+	"type",
 	"deferLoading",
 	"inputText",
 	"marketplaceKinds",
+];
+const APP_SERVER_REQUIRED_CLIENT_REQUESTS: &[(&str, &str)] = &[
+	("initialize", "InitializeParams"),
+	("account/login/start", "LoginAccountParams"),
+	("thread/start", "ThreadStartParams"),
+	("thread/resume", "ThreadResumeParams"),
+	("thread/archive", "ThreadArchiveParams"),
+	("thread/goal/set", "ThreadGoalSetParams"),
+	("thread/goal/get", "ThreadGoalGetParams"),
+	("thread/goal/clear", "ThreadGoalClearParams"),
+	("turn/start", "TurnStartParams"),
+	("turn/interrupt", "TurnInterruptParams"),
+	("turn/steer", "TurnSteerParams"),
+	("command/exec", "CommandExecParams"),
+	("config/read", "ConfigReadParams"),
+	("model/list", "ModelListParams"),
+	("modelProvider/capabilities/read", "ModelProviderCapabilitiesReadParams"),
+	("skills/list", "SkillsListParams"),
+	("plugin/list", "PluginListParams"),
+	("mcpServerStatus/list", "ListMcpServerStatusParams"),
+];
+const APP_SERVER_REQUIRED_SERVER_REQUESTS: &[(&str, &str)] = &[
+	("item/commandExecution/requestApproval", "CommandExecutionRequestApprovalParams"),
+	("item/fileChange/requestApproval", "FileChangeRequestApprovalParams"),
+	("item/tool/requestUserInput", "ToolRequestUserInputParams"),
+	("mcpServer/elicitation/request", "McpServerElicitationRequestParams"),
+	("item/permissions/requestApproval", "PermissionsRequestApprovalParams"),
+	("item/tool/call", "DynamicToolCallParams"),
+	("account/chatgptAuthTokens/refresh", "ChatgptAuthTokensRefreshParams"),
+];
+const APP_SERVER_REQUIRED_CLIENT_NOTIFICATIONS: &[(&str, &str)] = &[("initialized", "")];
+const APP_SERVER_REQUIRED_SERVER_NOTIFICATIONS: &[(&str, &str)] = &[
+	("error", "ErrorNotification"),
+	("thread/started", "ThreadStartedNotification"),
+	("thread/status/changed", "ThreadStatusChangedNotification"),
+	("thread/archived", "ThreadArchivedNotification"),
+	("thread/goal/updated", "ThreadGoalUpdatedNotification"),
+	("thread/goal/cleared", "ThreadGoalClearedNotification"),
+	("thread/tokenUsage/updated", "ThreadTokenUsageUpdatedNotification"),
+	("turn/started", "TurnStartedNotification"),
+	("turn/completed", "TurnCompletedNotification"),
+	("item/started", "ItemStartedNotification"),
+	("item/completed", "ItemCompletedNotification"),
+	("item/agentMessage/delta", "AgentMessageDeltaNotification"),
+	("account/updated", "AccountUpdatedNotification"),
+	("account/rateLimits/updated", "AccountRateLimitsUpdatedNotification"),
+	("model/rerouted", "ModelReroutedNotification"),
+	("model/verification", "ModelVerificationNotification"),
 ];
 const APP_SERVER_SCHEMA_PROSE_KEYS: &[&str] =
 	&["$comment", "comment", "description", "examples", "markdownDescription", "title"];
@@ -3213,7 +3265,252 @@ fn validate_generated_app_server_schema(out_dir: &Path) -> crate::prelude::Resul
 		);
 	}
 
+	validate_generated_dynamic_tool_schema(out_dir)?;
+	validate_generated_app_server_method_unions(out_dir)?;
+
 	Ok(())
+}
+
+fn validate_generated_app_server_method_unions(out_dir: &Path) -> crate::prelude::Result<()> {
+	validate_generated_method_union(out_dir, "ClientRequest", APP_SERVER_REQUIRED_CLIENT_REQUESTS)?;
+	validate_generated_method_union(out_dir, "ServerRequest", APP_SERVER_REQUIRED_SERVER_REQUESTS)?;
+	validate_generated_method_union(
+		out_dir,
+		"ClientNotification",
+		APP_SERVER_REQUIRED_CLIENT_NOTIFICATIONS,
+	)?;
+	validate_generated_method_union(
+		out_dir,
+		"ServerNotification",
+		APP_SERVER_REQUIRED_SERVER_NOTIFICATIONS,
+	)?;
+
+	Ok(())
+}
+
+fn validate_generated_method_union(
+	out_dir: &Path,
+	title: &'static str,
+	required_methods: &[(&'static str, &'static str)],
+) -> crate::prelude::Result<()> {
+	let Some(schema) = find_schema_by_title(out_dir, title)? else {
+		eyre::bail!("Generated app-server schema was missing `{title}` method union.");
+	};
+	let method_refs = method_schema_refs(&schema);
+	let missing_or_mismatched = required_methods
+		.iter()
+		.filter_map(|(method, expected_ref)| match method_refs.get(*method) {
+			Some(actual_ref) if actual_ref.as_deref() == expected_ref_to_option(*expected_ref) =>
+				None,
+			Some(actual_ref) => Some(format!(
+				"{method} expected {} got {}",
+				expected_ref_display(*expected_ref),
+				actual_ref.as_deref().unwrap_or("<no params>")
+			)),
+			None => Some(format!("{method} missing")),
+		})
+		.collect::<Vec<_>>();
+
+	if !missing_or_mismatched.is_empty() {
+		eyre::bail!(
+			"Generated app-server `{title}` schema was missing or changed Decodex-owned methods: {}",
+			missing_or_mismatched.join(", ")
+		);
+	}
+
+	Ok(())
+}
+
+fn find_schema_by_title(out_dir: &Path, title: &str) -> crate::prelude::Result<Option<Value>> {
+	let direct_path = out_dir.join(format!("{title}.json"));
+
+	if direct_path.is_file() {
+		let schema = fs::read_to_string(&direct_path)?;
+
+		return Ok(Some(serde_json::from_str(&schema)?));
+	}
+
+	let mut schema = None;
+
+	collect_schema_by_title(out_dir, title, &mut schema)?;
+
+	Ok(schema)
+}
+
+fn collect_schema_by_title(
+	path: &Path,
+	title: &str,
+	matching_schema: &mut Option<Value>,
+) -> crate::prelude::Result<()> {
+	for entry in fs::read_dir(path)? {
+		let entry = entry?;
+		let path = entry.path();
+
+		if path.is_dir() {
+			collect_schema_by_title(&path, title, matching_schema)?;
+		} else if path.extension().and_then(|extension| extension.to_str()) == Some("json") {
+			let schema = fs::read_to_string(&path)?;
+			let value: Value = serde_json::from_str(&schema)?;
+
+			if value.get("title").and_then(Value::as_str) == Some(title) {
+				*matching_schema = Some(value);
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn method_schema_refs(schema: &Value) -> BTreeMap<String, Option<String>> {
+	let Some(branches) = schema.get("oneOf").and_then(Value::as_array) else {
+		return BTreeMap::new();
+	};
+
+	branches
+		.iter()
+		.filter_map(|branch| {
+			let properties = branch.get("properties")?.as_object()?;
+			let method =
+				properties.get("method")?.get("enum")?.as_array()?.first()?.as_str()?.to_owned();
+			let params_ref = properties
+				.get("params")
+				.and_then(|params| params.get("$ref"))
+				.and_then(Value::as_str)
+				.map(schema_ref_title);
+
+			Some((method, params_ref))
+		})
+		.collect()
+}
+
+fn schema_ref_title(schema_ref: &str) -> String {
+	schema_ref.rsplit('/').next().unwrap_or(schema_ref).to_owned()
+}
+
+fn expected_ref_to_option(expected_ref: &str) -> Option<&str> {
+	(!expected_ref.is_empty()).then_some(expected_ref)
+}
+
+fn expected_ref_display(expected_ref: &str) -> &str {
+	expected_ref_to_option(expected_ref).unwrap_or("<no params>")
+}
+
+fn validate_generated_dynamic_tool_schema(out_dir: &Path) -> crate::prelude::Result<()> {
+	let mut found_thread_start_schema = false;
+	let mut found_supported_dynamic_tool_schema = false;
+
+	collect_dynamic_tool_schema_state(
+		out_dir,
+		&mut found_thread_start_schema,
+		&mut found_supported_dynamic_tool_schema,
+	)?;
+
+	if !found_thread_start_schema {
+		eyre::bail!(
+			"Generated app-server schema was missing ThreadStartParams dynamicTools schema."
+		);
+	}
+
+	if !found_supported_dynamic_tool_schema {
+		eyre::bail!(
+			"Generated app-server schema does not expose the Decodex-supported 0.141 dynamicTools tagged union."
+		);
+	}
+
+	Ok(())
+}
+
+fn collect_dynamic_tool_schema_state(
+	path: &Path,
+	found_thread_start_schema: &mut bool,
+	found_supported_dynamic_tool_schema: &mut bool,
+) -> crate::prelude::Result<()> {
+	for entry in fs::read_dir(path)? {
+		let entry = entry?;
+		let path = entry.path();
+
+		if path.is_dir() {
+			collect_dynamic_tool_schema_state(
+				&path,
+				found_thread_start_schema,
+				found_supported_dynamic_tool_schema,
+			)?;
+		} else if path.extension().and_then(|extension| extension.to_str()) == Some("json") {
+			let schema = fs::read_to_string(&path)?;
+			let value: Value = serde_json::from_str(&schema)?;
+
+			if value.get("title").and_then(Value::as_str) == Some("ThreadStartParams")
+				&& value.pointer("/properties/dynamicTools").is_some()
+			{
+				*found_thread_start_schema = true;
+				*found_supported_dynamic_tool_schema |=
+					thread_start_schema_has_app_server_dynamic_tool_union(&value);
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn thread_start_schema_has_app_server_dynamic_tool_union(schema: &Value) -> bool {
+	let Some(definitions) = schema.get("definitions").and_then(Value::as_object) else {
+		return false;
+	};
+	let Some(dynamic_tool_spec) = definitions.get("DynamicToolSpec") else {
+		return false;
+	};
+	let Some(namespace_tool) = definitions.get("DynamicToolNamespaceTool") else {
+		return false;
+	};
+	let Some(function_branch) =
+		one_of_branch_with_title(dynamic_tool_spec, "FunctionDynamicToolSpec")
+	else {
+		return false;
+	};
+	let Some(namespace_branch) =
+		one_of_branch_with_title(dynamic_tool_spec, "NamespaceDynamicToolSpec")
+	else {
+		return false;
+	};
+	let Some(namespace_tool_branch) =
+		one_of_branch_with_title(namespace_tool, "FunctionDynamicToolNamespaceTool")
+	else {
+		return false;
+	};
+
+	schema_required_contains_all(function_branch, &["description", "inputSchema", "name", "type"])
+		&& schema_type_enum_contains(function_branch, "function")
+		&& schema_required_contains_all(namespace_branch, &["description", "name", "tools", "type"])
+		&& schema_type_enum_contains(namespace_branch, "namespace")
+		&& schema_required_contains_all(
+			namespace_tool_branch,
+			&["description", "inputSchema", "name", "type"],
+		) && schema_type_enum_contains(namespace_tool_branch, "function")
+}
+
+fn one_of_branch_with_title<'a>(schema: &'a Value, title: &str) -> Option<&'a Value> {
+	schema
+		.get("oneOf")?
+		.as_array()?
+		.iter()
+		.find(|branch| branch.get("title").and_then(Value::as_str) == Some(title))
+}
+
+fn schema_required_contains_all(schema: &Value, names: &[&str]) -> bool {
+	let Some(required) = schema.get("required").and_then(Value::as_array) else {
+		return false;
+	};
+
+	names.iter().all(|name| required.iter().any(|value| value.as_str() == Some(*name)))
+}
+
+fn schema_type_enum_contains(schema: &Value, type_value: &str) -> bool {
+	let Some(enum_values) = schema.pointer("/properties/type/enum").and_then(Value::as_array)
+	else {
+		return false;
+	};
+
+	enum_values.iter().any(|value| value.as_str() == Some(type_value))
 }
 
 fn collect_schema_markers(
@@ -3936,8 +4233,11 @@ fn app_server_method_not_found(error: &Report) -> bool {
 fn build_thread_start_request(
 	request: &AppServerRunRequest<'_>,
 ) -> crate::prelude::Result<ThreadStartRequest> {
-	let dynamic_tools =
-		request.dynamic_tool_handler.map(validated_dynamic_tool_specs).transpose()?;
+	let dynamic_tools = request
+		.dynamic_tool_handler
+		.map(validated_dynamic_tool_specs)
+		.transpose()?
+		.map(|tool_specs| app_server_dynamic_tool_specs(&tool_specs));
 
 	Ok(ThreadStartRequest {
 		cwd: Some(request.cwd.clone()),

--- a/apps/decodex/src/agent/app_server/protocol.rs
+++ b/apps/decodex/src/agent/app_server/protocol.rs
@@ -358,6 +358,85 @@ pub(super) struct InitializeResponse {
 	pub(super) platform_os: String,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(tag = "type")]
+pub(super) enum AppServerDynamicToolSpec {
+	#[serde(rename = "function")]
+	Function {
+		description: String,
+		#[serde(rename = "deferLoading", default, skip_serializing_if = "std::ops::Not::not")]
+		defer_loading: bool,
+		#[serde(rename = "inputSchema")]
+		input_schema: Value,
+		name: String,
+	},
+	#[serde(rename = "namespace")]
+	Namespace { description: String, name: String, tools: Vec<AppServerDynamicToolNamespaceTool> },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(super) struct AppServerDynamicToolNamespaceTool {
+	#[serde(rename = "type")]
+	kind: &'static str,
+	description: String,
+	#[serde(rename = "deferLoading", default, skip_serializing_if = "std::ops::Not::not")]
+	defer_loading: bool,
+	#[serde(rename = "inputSchema")]
+	input_schema: Value,
+	name: String,
+}
+
+impl AppServerDynamicToolSpec {
+	fn function_from_spec(spec: &DynamicToolSpec) -> Self {
+		Self::Function {
+			description: spec.description.clone(),
+			defer_loading: spec.defer_loading,
+			input_schema: spec.input_schema.clone(),
+			name: spec.name.clone(),
+		}
+	}
+}
+
+impl AppServerDynamicToolNamespaceTool {
+	fn from_spec(spec: &DynamicToolSpec) -> Self {
+		Self {
+			kind: "function",
+			description: spec.description.clone(),
+			defer_loading: spec.defer_loading,
+			input_schema: spec.input_schema.clone(),
+			name: spec.name.clone(),
+		}
+	}
+}
+
+pub(super) fn app_server_dynamic_tool_specs(
+	tool_specs: &[DynamicToolSpec],
+) -> Vec<AppServerDynamicToolSpec> {
+	let mut app_server_specs = Vec::new();
+	let mut namespace_tools = BTreeMap::<String, Vec<AppServerDynamicToolNamespaceTool>>::new();
+
+	for spec in tool_specs {
+		if let Some(namespace) = spec.namespace.as_deref() {
+			namespace_tools
+				.entry(namespace.to_owned())
+				.or_default()
+				.push(AppServerDynamicToolNamespaceTool::from_spec(spec));
+		} else {
+			app_server_specs.push(AppServerDynamicToolSpec::function_from_spec(spec));
+		}
+	}
+
+	for (namespace, tools) in namespace_tools {
+		app_server_specs.push(AppServerDynamicToolSpec::Namespace {
+			description: format!("Dynamic tools in the {namespace} namespace."),
+			name: namespace,
+			tools,
+		});
+	}
+
+	app_server_specs
+}
+
 #[derive(Debug, Default, Serialize)]
 pub(super) struct ThreadStartRequest {
 	#[serde(rename = "baseInstructions", skip_serializing_if = "Option::is_none")]
@@ -367,7 +446,7 @@ pub(super) struct ThreadStartRequest {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub(super) cwd: Option<String>,
 	#[serde(rename = "dynamicTools", skip_serializing_if = "Option::is_none")]
-	pub(super) dynamic_tools: Option<Vec<DynamicToolSpec>>,
+	pub(super) dynamic_tools: Option<Vec<AppServerDynamicToolSpec>>,
 	#[serde(rename = "developerInstructions", skip_serializing_if = "Option::is_none")]
 	pub(super) developer_instructions: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]

--- a/apps/decodex/src/agent/app_server/tests.rs
+++ b/apps/decodex/src/agent/app_server/tests.rs
@@ -3,7 +3,7 @@ use std::{
 	collections::BTreeMap,
 	env, fs,
 	os::unix::fs::PermissionsExt,
-	path::PathBuf,
+	path::{Path, PathBuf},
 	time::{Duration, Instant},
 };
 
@@ -538,22 +538,225 @@ fn generated_schema_marker_validation_accepts_required_markers() {
 		serde_json::json!({
 			"description": "Decodex app-server compatibility fixture.",
 			"requiredMarkers": super::APP_SERVER_SCHEMA_REQUIRED_MARKERS,
+			"title": "ThreadStartParams",
 			"properties": {
 				"dynamicTools": {
-					"properties": {
-						"namespace": { "type": "string" },
-						"deferLoading": { "type": "boolean" }
+					"items": {
+						"$ref": "#/definitions/DynamicToolSpec"
 					}
 				},
 				"marketplaceKinds": { "type": "array" },
 				"type": { "const": "inputText" }
+			},
+			"definitions": {
+				"DynamicToolNamespaceTool": {
+					"oneOf": [{
+						"title": "FunctionDynamicToolNamespaceTool",
+						"required": ["description", "inputSchema", "name", "type"],
+						"properties": {
+							"deferLoading": { "type": "boolean" },
+							"description": { "type": "string" },
+							"inputSchema": true,
+							"name": { "type": "string" },
+							"type": { "enum": ["function"] }
+						}
+					}]
+				},
+				"DynamicToolSpec": {
+					"oneOf": [
+						{
+							"title": "FunctionDynamicToolSpec",
+							"required": ["description", "inputSchema", "name", "type"],
+							"properties": {
+								"deferLoading": { "type": "boolean" },
+								"description": { "type": "string" },
+								"inputSchema": true,
+								"name": { "type": "string" },
+								"type": { "enum": ["function"] }
+							}
+						},
+						{
+							"title": "NamespaceDynamicToolSpec",
+							"required": ["description", "name", "tools", "type"],
+							"properties": {
+								"description": { "type": "string" },
+								"name": { "type": "string" },
+								"tools": {
+									"items": {
+										"$ref": "#/definitions/DynamicToolNamespaceTool"
+									}
+								},
+								"type": { "enum": ["namespace"] }
+							}
+						}
+					]
+				}
 			}
 		})
 		.to_string(),
 	)
 	.expect("schema fixture should write");
+	write_app_server_method_union_fixtures(temp_dir.path(), None);
+
 	super::validate_generated_app_server_schema(temp_dir.path())
 		.expect("required markers should pass schema validation");
+}
+
+fn write_app_server_method_union_fixtures(root: &Path, omitted: Option<(&str, &str)>) {
+	for (title, required_methods) in [
+		("ClientRequest", super::APP_SERVER_REQUIRED_CLIENT_REQUESTS),
+		("ServerRequest", super::APP_SERVER_REQUIRED_SERVER_REQUESTS),
+		("ClientNotification", super::APP_SERVER_REQUIRED_CLIENT_NOTIFICATIONS),
+		("ServerNotification", super::APP_SERVER_REQUIRED_SERVER_NOTIFICATIONS),
+	] {
+		let branches = required_methods
+			.iter()
+			.filter(|(method, _schema)| omitted != Some((title, *method)))
+			.map(|(method, schema)| {
+				let mut properties = serde_json::json!({
+					"method": {
+						"type": "string",
+						"enum": [method]
+					}
+				});
+
+				if !schema.is_empty() {
+					properties["params"] = serde_json::json!({
+						"$ref": format!("#/definitions/{schema}")
+					});
+				}
+
+				serde_json::json!({
+					"title": format!("{method}Fixture"),
+					"type": "object",
+					"properties": properties
+				})
+			})
+			.collect::<Vec<_>>();
+
+		fs::write(
+			root.join(format!("{title}.json")),
+			serde_json::json!({
+				"title": title,
+				"oneOf": branches
+			})
+			.to_string(),
+		)
+		.expect("schema union fixture should write");
+	}
+}
+
+#[test]
+fn generated_schema_marker_validation_rejects_legacy_flat_dynamic_tools() {
+	let temp_dir = TempDir::new().expect("temp dir should create");
+	let schema_path = temp_dir.path().join("app-server.schema.json");
+
+	fs::write(
+		&schema_path,
+		serde_json::json!({
+			"requiredMarkers": super::APP_SERVER_SCHEMA_REQUIRED_MARKERS,
+			"title": "ThreadStartParams",
+			"properties": {
+				"dynamicTools": {
+					"items": {
+						"$ref": "#/definitions/DynamicToolSpec"
+					}
+				}
+			},
+			"definitions": {
+				"DynamicToolSpec": {
+					"type": "object",
+					"required": ["description", "inputSchema", "name"],
+					"properties": {
+						"deferLoading": { "type": "boolean" },
+						"description": { "type": "string" },
+						"inputSchema": true,
+						"name": { "type": "string" },
+						"namespace": { "type": ["string", "null"] }
+					}
+				}
+			}
+		})
+		.to_string(),
+	)
+	.expect("schema fixture should write");
+
+	let error = super::validate_generated_app_server_schema(temp_dir.path())
+		.expect_err("legacy flat dynamicTools should fail schema validation");
+
+	assert!(error.to_string().contains("0.141 dynamicTools tagged union"));
+}
+
+#[test]
+fn generated_schema_marker_validation_rejects_missing_owned_method() {
+	let temp_dir = TempDir::new().expect("temp dir should create");
+	let schema_path = temp_dir.path().join("app-server.schema.json");
+
+	fs::write(
+		&schema_path,
+		serde_json::json!({
+			"requiredMarkers": super::APP_SERVER_SCHEMA_REQUIRED_MARKERS,
+			"title": "ThreadStartParams",
+			"properties": {
+				"dynamicTools": {
+					"items": {
+						"$ref": "#/definitions/DynamicToolSpec"
+					}
+				}
+			},
+			"definitions": {
+				"DynamicToolNamespaceTool": {
+					"oneOf": [{
+						"title": "FunctionDynamicToolNamespaceTool",
+						"required": ["description", "inputSchema", "name", "type"],
+						"properties": {
+							"description": { "type": "string" },
+							"inputSchema": true,
+							"name": { "type": "string" },
+							"type": { "enum": ["function"] }
+						}
+					}]
+				},
+				"DynamicToolSpec": {
+					"oneOf": [
+						{
+							"title": "FunctionDynamicToolSpec",
+							"required": ["description", "inputSchema", "name", "type"],
+							"properties": {
+								"description": { "type": "string" },
+								"inputSchema": true,
+								"name": { "type": "string" },
+								"type": { "enum": ["function"] }
+							}
+						},
+						{
+							"title": "NamespaceDynamicToolSpec",
+							"required": ["description", "name", "tools", "type"],
+							"properties": {
+								"description": { "type": "string" },
+								"name": { "type": "string" },
+								"tools": {
+									"items": {
+										"$ref": "#/definitions/DynamicToolNamespaceTool"
+									}
+								},
+								"type": { "enum": ["namespace"] }
+							}
+						}
+					]
+				}
+			}
+		})
+		.to_string(),
+	)
+	.expect("schema fixture should write");
+	write_app_server_method_union_fixtures(temp_dir.path(), Some(("ClientRequest", "turn/start")));
+
+	let error = super::validate_generated_app_server_schema(temp_dir.path())
+		.expect_err("missing Decodex-owned method should fail schema validation");
+
+	assert!(error.to_string().contains("ClientRequest"));
+	assert!(error.to_string().contains("turn/start missing"));
 }
 
 #[test]
@@ -656,6 +859,72 @@ fn thread_start_and_resume_requests_inherit_runtime_config() {
 	assert_runtime_config(&resume_value);
 
 	assert_eq!(resume_value["threadId"], "thread-1");
+}
+
+#[test]
+fn thread_start_serializes_dynamic_tools_with_app_server_141_shape() {
+	struct MixedDynamicToolHandler;
+	impl DynamicToolHandler for MixedDynamicToolHandler {
+		fn tool_specs(&self) -> Vec<DynamicToolSpec> {
+			let local_tool = DynamicToolSpec::new(
+				"local_tool",
+				"Test local tool.",
+				serde_json::json!({
+					"type": "object",
+					"additionalProperties": false
+				}),
+			);
+			let mut tracker_tool = DynamicToolSpec::new(
+				"tracker_tool",
+				"Test namespaced tool.",
+				serde_json::json!({
+					"type": "object",
+					"additionalProperties": false
+				}),
+			)
+			.deferred();
+
+			tracker_tool.namespace = Some(String::from("tracker"));
+
+			vec![local_tool, tracker_tool]
+		}
+
+		fn handle_call(&self, _tool_name: &str, _arguments: Value) -> DynamicToolCallResponse {
+			DynamicToolCallResponse::success(String::from("unused"))
+		}
+	}
+
+	let handler = MixedDynamicToolHandler;
+	let mut request = minimal_run_request();
+
+	request.dynamic_tool_handler = Some(&handler);
+
+	let start = super::build_thread_start_request(&request).expect("request should build");
+	let start_value = serde_json::to_value(&start).expect("thread start request should serialize");
+	let dynamic_tools =
+		start_value["dynamicTools"].as_array().expect("dynamicTools should serialize as an array");
+
+	assert_eq!(dynamic_tools.len(), 2);
+	assert_eq!(dynamic_tools[0]["type"], "function");
+	assert_eq!(dynamic_tools[0]["name"], "local_tool");
+	assert_eq!(dynamic_tools[0]["description"], "Test local tool.");
+	assert!(dynamic_tools[0].get("namespace").is_none());
+
+	assert_eq!(dynamic_tools[1]["type"], "namespace");
+	assert_eq!(dynamic_tools[1]["name"], "tracker");
+	assert_eq!(dynamic_tools[1]["description"], "Dynamic tools in the tracker namespace.");
+	assert!(dynamic_tools[1].get("inputSchema").is_none());
+	assert!(dynamic_tools[1].get("namespace").is_none());
+
+	let namespace_tools =
+		dynamic_tools[1]["tools"].as_array().expect("namespace tool should contain tools array");
+
+	assert_eq!(namespace_tools.len(), 1);
+	assert_eq!(namespace_tools[0]["type"], "function");
+	assert_eq!(namespace_tools[0]["name"], "tracker_tool");
+	assert_eq!(namespace_tools[0]["description"], "Test namespaced tool.");
+	assert_eq!(namespace_tools[0]["deferLoading"], true);
+	assert!(namespace_tools[0].get("namespace").is_none());
 }
 
 #[test]

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,12 @@
 - Added schema-bound MCP planning tools for `research_compile`, `research_promote`,
   and `intake_goal`; dry-run paths stay read-only while apply/promote paths require
   explicit authority and return structured refusals when authority is missing.
+- Added structured app-server schema drift checks for Decodex-owned
+  `ClientRequest`, `ServerRequest`, `ClientNotification`, and `ServerNotification`
+  method unions so protocol probes catch owned-method removal or params-schema drift.
+- Synced Decodex's app-server dynamic tool contract to the Codex 0.141 preview
+  schema by documenting tagged `type:function` and `type:namespace` declarations
+  instead of the legacy flat `dynamicTools[].namespace` shape.
 - Added remote-safe MCP observability projections for live status, activity tail, run
   events, protocol activity, child-agent activity, progress diagnostics, lane inspect,
   and PR/review state without exposing private evidence or raw steer text.

--- a/docs/spec/app-server.md
+++ b/docs/spec/app-server.md
@@ -6,7 +6,10 @@ status: active
 authority: normative
 owner: runtime
 tags: [spec]
-last_verified: 2026-06-16
+code_refs: [apps/decodex/src/agent/app_server.rs, apps/decodex/src/agent/app_server/protocol.rs, apps/decodex/src/agent/app_server/tests.rs, apps/decodex/src/agent/tracker_tool_bridge.rs]
+related: [./tracker-tools.md, ./lane-control.md, ./runtime.md]
+drift_watch: ["codex app-server generate-json-schema --experimental", "decodex probe stdio://", ThreadStartParams.dynamicTools, dynamicTools, "type:function", "type:namespace", ClientRequest, ServerRequest, ClientNotification, ServerNotification, "account/rateLimitResetCredit/consume", "externalAgentConfig/import/readHistories", "thread/realtime/appendSpeech", "externalAgentConfig/import/progress"]
+last_verified: 2026-06-18
 ---
 # App-Server Specification
 
@@ -55,8 +58,9 @@ are true:
 - The generated schema contains the Decodex-owned request and notification contract in
   this spec, including `initialize`, `thread/start`, `thread/resume`, `turn/start`,
   `thread/archive`, `command/exec`, the bounded preflight methods, `item/tool/call`,
-  dynamic tool `namespace`, dynamic tool `deferLoading`, `inputText` tool responses,
-  and `PluginListParams.marketplaceKinds`.
+  dynamic tool `type:function`, dynamic tool `type:namespace`, namespace
+  `tools[]`, dynamic tool `deferLoading`, `inputText` tool responses, and
+  `PluginListParams.marketplaceKinds`.
 - `decodex probe stdio://` completes the app-server capability preflight,
   standalone `command/exec` health check, and dynamic-tool round trip with
   `PROBE_OK`.
@@ -68,11 +72,34 @@ Support evidence has two distinct layers:
   Any required capability failure is a pre-dispatch app-server preflight blocker
   rather than a promptable agent turn.
 - Schema evidence: `decodex probe stdio://` regenerates the local schema cache and
-  checks the required markers in this spec before completing the dynamic-tool round
-  trip. Normal retained dispatch does not regenerate the schema cache.
+  checks the required markers, the Decodex-owned JSON-RPC method unions, and the
+  dynamic-tool declaration shape in this spec before completing the dynamic-tool
+  round trip. Normal retained dispatch does not regenerate the schema cache.
 
 `decodex probe stdio://` reports the probe result with `preflight_checks`, `thread`,
 `turn`, `events`, and `output`. A passing probe must include `output=PROBE_OK`.
+
+### 0.141 preview drift audit
+
+The 2026-06-18 audit compared Codex app-server `0.140.0` with
+`0.141.0-alpha.7`.
+
+- No JSON-RPC method was removed.
+- Added client requests were `account/rateLimitResetCredit/consume`,
+  `externalAgentConfig/import/readHistories`, and
+  `thread/realtime/appendSpeech`.
+- Added server notification was `externalAgentConfig/import/progress`.
+- Decodex's owned orchestration schemas kept the same top-level required fields.
+- `ThreadStartParams.dynamicTools` changed from the legacy flat
+  `dynamicTools[].namespace` shape to the tagged `type:function` /
+  `type:namespace` union below. That shape is Decodex-owned because retained runs
+  expose issue-scoped dynamic tools.
+
+The newly added account-credit, external-import, and realtime-speech surfaces are
+Codex product APIs, not Decodex retained-run orchestration APIs. Decodex must not
+add no-op wrappers for them merely to mirror the full app-server surface. If a
+future Decodex feature depends on one, promote it into the owned-method union and
+add an explicit runtime preflight or live probe for that feature.
 
 Phase-scoped goal support is mandatory and capability-gated for retained lane
 execution. App-server surfaces must expose `thread/goal/set`, `thread/goal/get`,
@@ -98,10 +125,14 @@ To validate an upstream app-server protocol change:
    `initialize`, `thread/start`, `thread/resume`, `turn/start`, `thread/archive`,
    `thread/goal/set`, `thread/goal/get`, `thread/goal/clear`,
    `thread/goal/updated`, `command/exec`, bounded preflight methods,
-   `item/tool/call`, dynamic tool `namespace`, dynamic tool `deferLoading`, `inputText`, and
+   `item/tool/call`, dynamic tool `type:function`, dynamic tool `type:namespace`,
+   namespace `tools[]`, dynamic tool `deferLoading`, `inputText`, and
    `PluginListParams.marketplaceKinds`.
-4. Run `decodex probe stdio://` and require `PROBE_OK`.
-5. Update this spec or the runtime preflight only when the protocol shape or required
+4. Confirm the generated `ClientRequest`, `ServerRequest`, `ClientNotification`, and
+   `ServerNotification` method unions still contain Decodex-owned methods with their
+   expected params schema names.
+5. Run `decodex probe stdio://` and require `PROBE_OK`.
+6. Update this spec or the runtime preflight only when the protocol shape or required
    capability set changes.
 
 ## Implementation guidance
@@ -225,10 +256,14 @@ implementation failure.
 
 When dynamic tools are enabled, `decodex` must also:
 
-1. Register the tool surface in `thread/start.dynamicTools`.
+1. Register the tool surface in `thread/start.dynamicTools` using the 0.141 tagged
+   schema: unnamespaced tools are `type:function` specs, and Decodex namespaced
+   tools are grouped into `type:namespace` specs whose `tools[]` entries are
+   nested `type:function` specs.
 2. Answer `item/tool/call` requests with `DynamicToolCallResponse`.
 3. Serialize dynamic tool output items with schema-approved `type` values such as `inputText`.
-4. Keep every `dynamicTools[].name` and populated `dynamicTools[].namespace` within the app-server identifier pattern `^[a-zA-Z0-9_-]+$`.
+4. Keep every dynamic tool name and namespace name within the app-server identifier
+   pattern `^[a-zA-Z0-9_-]+$`.
 5. Validate incoming `item/tool/call` thread, tool-name, namespace, and response shape before treating the request as handled. Dynamic tool request `turnId` is diagnostic context only: the app-server may emit a request-scoped turn id that differs from the active `turn/start` id, so Decodex records mismatches but keeps the authorization boundary on the active thread and declared tool surface.
 
 The client-side dynamic bridge may expose narrow Decodex-owned tools that are local to one run attempt, such as the deferred `decodex.decodex_run_context` tool. These tools must stay small and side-effect-bounded so they can move to a process-local MCP server if the surface expands. Broader stateful or cross-service tool families remain MCP candidates rather than reasons to grow the client bridge indefinitely.
@@ -310,6 +345,15 @@ The MVP thread start request owns these fields:
 - `dynamicTools` when the run exposes issue-scoped tracker tools
 - `developerInstructions`
 - `ephemeral` only for synthetic Decodex probe threads
+
+For app-server 0.141 and newer, `dynamicTools` is a tagged union. Decodex keeps its
+internal logical tool declaration flat so callback authorization can still match
+`item/tool/call.namespace`, but the request wire shape is:
+
+- unnamespaced tool: `{ "type": "function", "name": ..., "description": ..., "inputSchema": ... }`
+- namespaced tools: `{ "type": "namespace", "name": ..., "description": ..., "tools": [...] }`,
+  where each nested tool is a `type:function` entry with its own description and
+  input schema.
 
 Decodex must not inject project-owned config, model, personality, service-tier, sandbox, or approval-policy overrides into `thread/start`. Child runs inherit runtime defaults from the active Codex runtime.
 


### PR DESCRIPTION
## Summary

- Adapt Decodex thread/start dynamicTools serialization to the Codex app-server 0.141 tagged union.
- Keep the internal Decodex dynamic tool model flat, and isolate the 0.141 wire shape inside the app-server protocol boundary.
- Strengthen schema preflight coverage for Decodex-owned app-server method unions and dynamic tool schema drift.
- Document the 0.141 preview drift audit and add OKF drift anchors.

## Validation

- `cargo test -p decodex app_server -- --nocapture`
- `cargo run -p decodex --bin decodex -- docs check`
- `cargo run -p decodex --bin decodex -- probe stdio://`
- `python3 /Users/x/.codex/plugins/cache/hack-ink/playbook/0.3.0/scripts/semantic_drift_audit.py`
- `git diff --check`