### PR TITLE
Expose inspect-first MCP operate and admin tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,14 @@ profile and `tools/call` returns structured refusals for tools above it. Observe
 read-only. Plan exposes `research_compile`, `research_promote`, and `intake_goal`:
 dry-run modes validate or preview without tracker or Program Intake mutation, while
 apply/promote modes require explicit authority fields and return structured refusals
-when authority or project context is missing. Operate/admin lane-control entries
-return structured refusal states until later lane-control MCP work delegates through
-existing authority guards. Stdio stdout is reserved for MCP JSON-RPC messages;
-diagnostics and logs stay off stdout.
+when authority or project context is missing. Operate exposes `decodex_lane_control`
+as an inspect-first lane-control facade: `inspect` returns current preconditions,
+`steer` and `interrupt` delegate through existing lane-control guards only with
+current run/turn authority, and `manual_attention` or `retained_resume` refuse back to
+their canonical tracker/runtime paths. Admin exposes `decodex_project_control` for
+project status plus future-dispatch-only pause/resume with explicit authority; `scan`
+refuses to the operator control loop. Stdio stdout is reserved for MCP JSON-RPC
+messages; diagnostics and logs stay off stdout.
 
 ### Project contracts
 

--- a/apps/decodex/src/mcp.rs
+++ b/apps/decodex/src/mcp.rs
@@ -16,25 +16,14 @@ use serde::{Deserialize, Serialize};
 use serde_json::{self, Value};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
-use crate::{
-	config::ServiceConfig,
-	loop_contract::{DecisionPromotion, DecisionPromotionActorKind},
-	orchestrator,
-	prelude::eyre,
-	program_intake::{
+use crate::{config::ServiceConfig, loop_contract::{DecisionPromotion, DecisionPromotionActorKind}, orchestrator::{self, DEFAULT_STEER_RESULT_WAIT_TIMEOUT, McpLaneSteerRequest}, prelude::eyre, program_intake::{
 		self, GoalIntakeCommandRequest, GoalIntakeIssueReport, GoalIntakeReport,
 		GoalIntakeRunRequest,
-	},
-	research_design::{
+	}, research_design::{
 		self, ResearchDesignOutcome, ResearchDesignRunInput, ResearchDesignRunReport,
-	},
-	runtime,
-	state::StateStore,
-	tracker::{
+	}, runtime, state::StateStore, tracker::{
 		IssueTracker, TrackerComment, TrackerIssue, TrackerIssueBriefUpdate, TrackerIssueCreate,
-	},
-	workflow::WorkflowDocument,
-};
+	}, workflow::WorkflowDocument};
 
 /// Safe default listen address for Streamable HTTP MCP.
 pub(crate) const DEFAULT_MCP_HTTP_LISTEN_ADDRESS: &str = "127.0.0.1:8193";
@@ -53,7 +42,7 @@ const TOOL_RESEARCH_COMPILE: &str = "research_compile";
 const TOOL_RESEARCH_PROMOTE: &str = "research_promote";
 const TOOL_INTAKE_GOAL: &str = "intake_goal";
 const TOOL_LANE_CONTROL: &str = "decodex_lane_control";
-const TOOL_ADMIN: &str = "decodex_admin";
+const TOOL_PROJECT_CONTROL: &str = "decodex_project_control";
 const MCP_HTTP_ENDPOINT_PATH: &str = "/mcp";
 const MCP_HTTP_READ_TIMEOUT: Duration = Duration::from_secs(2);
 const MCP_HTTP_MAX_REQUEST_BYTES: usize = 1_024 * 1_024;
@@ -218,7 +207,7 @@ impl McpServer {
 							"sessionHeader": MCP_SESSION_HEADER,
 							"sseResponses": true,
 							"originValidation": true,
-							"operateAdminTools": "deferred_to_XY-998",
+							"operateAdminTools": "inspect_first_guarded",
 							"mutatingToolsRequireAuthority": true,
 							"privateEvidencePayloadsExposed": false
 						}
@@ -441,8 +430,8 @@ impl McpServer {
 			TOOL_RESEARCH_COMPILE => Ok(self.call_research_compile_tool(arguments)),
 			TOOL_RESEARCH_PROMOTE => Ok(self.call_research_promote_tool(arguments)),
 			TOOL_INTAKE_GOAL => Ok(self.call_intake_goal_tool(arguments)),
-			TOOL_LANE_CONTROL => Ok(lane_control_stub_result(arguments, required_profile)),
-			TOOL_ADMIN => Ok(admin_stub_result(arguments, required_profile)),
+			TOOL_LANE_CONTROL => Ok(self.call_lane_control_tool(arguments, required_profile)),
+			TOOL_PROJECT_CONTROL => Ok(self.call_project_control_tool(arguments, required_profile)),
 			_ => Ok(tool_refusal("unknown_tool", "Decodex MCP tool is not registered.")),
 		}
 	}
@@ -764,6 +753,393 @@ impl McpServer {
 				"Goal intake apply was refused by Decodex authority or tracker checks.",
 			),
 		}
+	}
+
+	fn call_lane_control_tool(&self, arguments: Value, profile: McpCapabilityProfile) -> Value {
+		let params = match serde_json::from_value::<LaneControlToolArgs>(arguments) {
+			Ok(params) => params,
+			Err(_) =>
+				return invalid_tool_arguments(
+					TOOL_LANE_CONTROL,
+					"`action` is required and must be one of inspect, interrupt, steer, manual_attention, or retained_resume.",
+				),
+		};
+
+		if !matches!(
+			params.action.as_str(),
+			"inspect" | "interrupt" | "steer" | "manual_attention" | "retained_resume"
+		) {
+			return invalid_tool_arguments(
+				TOOL_LANE_CONTROL,
+				"`action` must be one of inspect, interrupt, steer, manual_attention, or retained_resume.",
+			);
+		}
+
+		match params.action.as_str() {
+			"inspect" => self.call_lane_control_inspect_tool(&params, profile),
+			"interrupt" => self.call_lane_control_interrupt_tool(&params, profile),
+			"steer" => self.call_lane_control_steer_tool(&params, profile),
+			"manual_attention" => lane_control_refusal_result(
+				&params,
+				profile,
+				"tracker_terminal_path_required",
+				"MCP does not synthesize manual attention. Use the issue-scoped tracker terminal path so Decodex can validate the public blocker and terminal finalize state.",
+			),
+			"retained_resume" => lane_control_refusal_result(
+				&params,
+				profile,
+				"runtime_lifecycle_required",
+				"Retained resume is owned by the Decodex runtime lifecycle. Use the normal retained-lane dispatch path instead of an MCP shortcut.",
+			),
+			_ => unreachable!("lane-control action was validated above"),
+		}
+	}
+
+	fn call_lane_control_inspect_tool(
+		&self,
+		params: &LaneControlToolArgs,
+		profile: McpCapabilityProfile,
+	) -> Value {
+		let Some(issue) = non_empty_string(params.issue.as_deref()) else {
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"issue_required",
+				"`issue` is required for lane-control inspect.",
+			);
+		};
+
+		if let Some(project_id) = non_empty_string(params.project_id.as_deref())
+			&& Some(project_id) != self.context.project_id.as_deref()
+		{
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"project_mismatch",
+				"The requested projectId does not match this MCP gateway context.",
+			);
+		}
+
+		let report = match orchestrator::build_mcp_lane_control_resource(
+			self.context.config_path.as_deref(),
+			Some(issue),
+			params.run_id.as_deref().and_then(|run_id| non_empty_string(Some(run_id))),
+			DEFAULT_MCP_STATUS_LIMIT,
+		) {
+			Ok(report) => report,
+			Err(error) =>
+				return lane_control_refusal_result(
+					params,
+					profile,
+					"lane_inspect_unavailable",
+					format!("Lane inspect failed closed: {error}"),
+				),
+		};
+		let mut result = serde_json::json!({
+			"schema": "decodex.mcp.lane_control_result/1",
+			"status": "ok",
+			"reason": "inspect_complete",
+			"message": "Inspect returned current lane-control preconditions for any later mutating request.",
+			"capability_profile": profile.as_str(),
+			"action": "inspect",
+			"project_id": self.context.project_id.as_deref(),
+			"issue": issue,
+			"run_id": params.run_id.as_deref(),
+			"preconditions": lane_control_preconditions(params),
+			"result": {
+				"inspect": mcp_public_lane_inspect_resource(report.clone()),
+				"mutating_preconditions": lane_control_mutating_preconditions(&report)
+			}
+		});
+
+		sanitize_mcp_observability_value(&mut result);
+
+		tool_success(result)
+	}
+
+	fn call_lane_control_interrupt_tool(
+		&self,
+		params: &LaneControlToolArgs,
+		profile: McpCapabilityProfile,
+	) -> Value {
+		let Some(issue) = non_empty_string(params.issue.as_deref()) else {
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"issue_required",
+				"`issue` is required for lane-control interrupt.",
+			);
+		};
+		let Some(run_id) = non_empty_string(params.run_id.as_deref()) else {
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"inspect_first_precondition_missing",
+				"`runId` from lane-control inspect is required for interrupt.",
+			);
+		};
+		let Some(authority) = lane_control_authority(params) else {
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"authority_required",
+				"Mutating lane-control calls require authority.reason, authority.source, and authority.inspectedRunId.",
+			);
+		};
+
+		if authority.inspected_run_id != run_id {
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"inspect_first_precondition_mismatch",
+				"authority.inspectedRunId must match the requested runId.",
+			);
+		}
+		if params.force.unwrap_or(false) && !authority.allow_hard_fallback {
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"hard_fallback_authority_missing",
+				"Hard interrupt fallback requires force=true and authority.allowHardFallback=true.",
+			);
+		}
+
+		let report = match orchestrator::run_mcp_lane_interrupt(
+			self.context.config_path.as_deref(),
+			issue,
+			run_id,
+			params.force.unwrap_or(false),
+			Some(authority.reason),
+			authority.source,
+		) {
+			Ok(report) => report,
+			Err(error) =>
+				return lane_control_refusal_result(
+					params,
+					profile,
+					"lane_interrupt_unavailable",
+					format!("Lane interrupt failed closed: {error}"),
+				),
+		};
+
+		lane_control_interrupt_result(params, profile, report)
+	}
+
+	fn call_lane_control_steer_tool(
+		&self,
+		params: &LaneControlToolArgs,
+		profile: McpCapabilityProfile,
+	) -> Value {
+		let Some(issue) = non_empty_string(params.issue.as_deref()) else {
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"issue_required",
+				"`issue` is required for lane-control steer.",
+			);
+		};
+		let Some(run_id) = non_empty_string(params.run_id.as_deref()) else {
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"inspect_first_precondition_missing",
+				"`runId` from lane-control inspect is required for steer.",
+			);
+		};
+		let Some(expected_turn_id) = non_empty_string(params.expected_turn_id.as_deref()) else {
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"expected_turn_id_required",
+				"`expectedTurnId` from lane-control inspect is required for steer.",
+			);
+		};
+		let Some(message) = non_empty_string(params.message.as_deref()) else {
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"message_required",
+				"`message` is required for steer and is never echoed in MCP results.",
+			);
+		};
+		let Some(authority) = lane_control_authority(params) else {
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"authority_required",
+				"Mutating lane-control calls require authority.reason, authority.source, and authority.inspectedRunId.",
+			);
+		};
+
+		if authority.inspected_run_id != run_id {
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"inspect_first_precondition_mismatch",
+				"authority.inspectedRunId must match the requested runId.",
+			);
+		}
+		if authority.expected_turn_id != Some(expected_turn_id) {
+			return lane_control_refusal_result(
+				params,
+				profile,
+				"expected_turn_authority_mismatch",
+				"authority.expectedTurnId must match the requested expectedTurnId.",
+			);
+		}
+
+		let report = match orchestrator::run_mcp_lane_steer(McpLaneSteerRequest {
+			config_path: self.context.config_path.as_deref(),
+			project_id: params
+				.project_id
+				.as_deref()
+				.and_then(|project_id| non_empty_string(Some(project_id))),
+			issue,
+			run_id,
+			expected_turn_id,
+			message,
+			source: authority.source,
+			wait_timeout: DEFAULT_STEER_RESULT_WAIT_TIMEOUT,
+		}) {
+			Ok(report) => report,
+			Err(error) =>
+				return lane_control_refusal_result(
+					params,
+					profile,
+					"lane_steer_unavailable",
+					format!("Lane steer failed closed: {error}"),
+				),
+		};
+
+		lane_control_steer_result(params, profile, report)
+	}
+
+	fn call_project_control_tool(&self, arguments: Value, profile: McpCapabilityProfile) -> Value {
+		let params = match serde_json::from_value::<ProjectControlToolArgs>(arguments) {
+			Ok(params) => params,
+			Err(_) =>
+				return invalid_tool_arguments(
+					TOOL_PROJECT_CONTROL,
+					"`action` is required and must be one of status, pause, resume, or scan.",
+				),
+		};
+
+		if !matches!(params.action.as_str(), "status" | "pause" | "resume" | "scan") {
+			return invalid_tool_arguments(
+				TOOL_PROJECT_CONTROL,
+				"`action` must be one of status, pause, resume, or scan.",
+			);
+		}
+
+		let Some(project_id) =
+			non_empty_string(params.project_id.as_deref()).or(self.context.project_id.as_deref())
+		else {
+			return project_control_refusal_result(
+				&params,
+				profile,
+				"project_id_required",
+				"`projectId` is required when the MCP gateway is not bound to one project config.",
+			);
+		};
+
+		if let Some(context_project_id) = self.context.project_id.as_deref()
+			&& context_project_id != project_id
+		{
+			return project_control_refusal_result(
+				&params,
+				profile,
+				"project_mismatch",
+				"The requested projectId does not match this MCP gateway context.",
+			);
+		}
+
+		match params.action.as_str() {
+			"status" => project_control_status_result(&params, profile, project_id),
+			"scan" => project_control_refusal_result(
+				&params,
+				profile,
+				"operator_control_loop_required",
+				"Linear scan requests are queued by the Decodex operator control-plane loop; standalone MCP serve cannot enqueue that in-memory request.",
+			),
+			"pause" | "resume" => self.call_project_enablement_tool(&params, profile, project_id),
+			_ => unreachable!("project-control action was validated above"),
+		}
+	}
+
+	fn call_project_enablement_tool(
+		&self,
+		params: &ProjectControlToolArgs,
+		profile: McpCapabilityProfile,
+		project_id: &str,
+	) -> Value {
+		let Some(authority) = project_control_authority(params) else {
+			return project_control_refusal_result(
+				params,
+				profile,
+				"authority_required",
+				"Project pause/resume requires authority.reason, authority.source, and authority.acknowledgeFutureDispatchOnly=true.",
+			);
+		};
+
+		if !authority.acknowledge_future_dispatch_only {
+			return project_control_refusal_result(
+				params,
+				profile,
+				"future_dispatch_ack_required",
+				"Project control affects future dispatch only and does not kill active lanes.",
+			);
+		}
+
+		let state_store = match runtime::open_runtime_store_lazy() {
+			Ok(state_store) => state_store,
+			Err(error) =>
+				return project_control_refusal_result(
+					params,
+					profile,
+					"project_control_unavailable",
+					format!("Project control failed closed: {error}"),
+				),
+		};
+
+		if let Some(config_path) = self.context.config_path.as_deref()
+			&& let Err(error) = runtime::register_project_config(&state_store, config_path, true)
+		{
+			return project_control_refusal_result(
+				params,
+				profile,
+				"project_registration_unavailable",
+				format!("Project registration refresh failed closed: {error}"),
+			);
+		}
+
+		let enabled = params.action == "resume";
+
+		if let Err(error) = state_store.set_project_enabled(project_id, enabled) {
+			return project_control_refusal_result(
+				params,
+				profile,
+				"project_enablement_unavailable",
+				format!("Project {action} failed closed: {error}", action = params.action),
+			);
+		}
+
+		project_control_success_result(
+			params,
+			profile,
+			project_id,
+			serde_json::json!({
+				"enabled": enabled,
+				"authority_source": authority.source,
+				"authority_reason_present": !authority.reason.is_empty(),
+				"future_dispatch_only": true,
+				"active_lanes_killed": false,
+				"next_action": if enabled {
+					"Future dispatch is enabled. Active lanes were not modified."
+				} else {
+					"Future dispatch is paused. Inspect active lanes separately before taking lane-control action."
+				}
+			}),
+		)
 	}
 }
 
@@ -1132,6 +1508,7 @@ struct PlanningAuthorityArgs {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct LaneControlToolArgs {
 	action: String,
+	project_id: Option<String>,
 	issue: Option<String>,
 	run_id: Option<String>,
 	expected_turn_id: Option<String>,
@@ -1147,12 +1524,23 @@ struct LaneControlAuthorityArgs {
 	source: Option<String>,
 	inspected_run_id: Option<String>,
 	expected_turn_id: Option<String>,
+	allow_hard_fallback: Option<bool>,
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct AdminToolArgs {
+struct ProjectControlToolArgs {
 	action: String,
+	project_id: Option<String>,
+	authority: Option<ProjectControlAuthorityArgs>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ProjectControlAuthorityArgs {
+	reason: Option<String>,
+	source: Option<String>,
+	acknowledge_future_dispatch_only: Option<bool>,
 }
 
 struct McpTool {
@@ -1721,6 +2109,20 @@ struct PromotionAuthority<'a> {
 	reason: Option<&'a String>,
 }
 
+struct LaneControlAuthority<'a> {
+	reason: &'a str,
+	source: &'a str,
+	inspected_run_id: &'a str,
+	expected_turn_id: Option<&'a str>,
+	allow_hard_fallback: bool,
+}
+
+struct ProjectControlAuthority<'a> {
+	reason: &'a str,
+	source: &'a str,
+	acknowledge_future_dispatch_only: bool,
+}
+
 /// Start the Decodex MCP gateway.
 pub(crate) fn serve(request: McpServeRequest<'_>) -> crate::prelude::Result<()> {
 	match request.transport {
@@ -1975,13 +2377,13 @@ fn mcp_tools() -> Vec<McpTool> {
 		McpTool {
 			required_profile: McpCapabilityProfile::Admin,
 			value: mcp_tool_value(
-				TOOL_ADMIN,
-				"Decodex Admin",
-				"Read the supported admin MCP policy surface; raw admin mutation is intentionally not exposed.",
+				TOOL_PROJECT_CONTROL,
+				"Decodex Project Control",
+				"Pause or resume future project dispatch through the registered project enablement guard.",
 				McpCapabilityProfile::Admin,
-				admin_tool_input_schema(),
-				admin_tool_output_schema(),
-				true,
+				project_control_tool_input_schema(),
+				project_control_tool_output_schema(),
+				false,
 			),
 		},
 	]
@@ -2021,7 +2423,7 @@ fn tool_required_profile(name: &str) -> Option<McpCapabilityProfile> {
 		TOOL_RESEARCH_COMPILE | TOOL_RESEARCH_PROMOTE | TOOL_INTAKE_GOAL =>
 			Some(McpCapabilityProfile::Plan),
 		TOOL_LANE_CONTROL => Some(McpCapabilityProfile::Operate),
-		TOOL_ADMIN => Some(McpCapabilityProfile::Admin),
+		TOOL_PROJECT_CONTROL => Some(McpCapabilityProfile::Admin),
 		_ => None,
 	}
 }
@@ -2199,7 +2601,11 @@ fn lane_control_tool_input_schema() -> Value {
 		"properties": {
 			"action": {
 				"type": "string",
-				"enum": ["inspect", "interrupt", "steer"]
+				"enum": ["inspect", "interrupt", "steer", "manual_attention", "retained_resume"]
+			},
+			"projectId": {
+				"type": "string",
+				"description": "Optional project id precondition. When supplied, it must match the MCP gateway project context."
 			},
 			"issue": {
 				"type": "string",
@@ -2240,6 +2646,10 @@ fn lane_control_tool_input_schema() -> Value {
 					"expectedTurnId": {
 						"type": "string",
 						"description": "Turn id observed through inspect and required for steer."
+					},
+					"allowHardFallback": {
+						"type": "boolean",
+						"description": "Explicit acknowledgement required with force=true before hard interrupt fallback can run."
 					}
 				}
 			}
@@ -2248,15 +2658,37 @@ fn lane_control_tool_input_schema() -> Value {
 	})
 }
 
-fn admin_tool_input_schema() -> Value {
+fn project_control_tool_input_schema() -> Value {
 	serde_json::json!({
 		"type": "object",
 		"additionalProperties": false,
 		"properties": {
 			"action": {
 				"type": "string",
-				"enum": ["capabilities"],
-				"description": "Only admin capability readback is exposed by this MCP tool."
+				"enum": ["status", "pause", "resume", "scan"],
+				"description": "Project-control action. Pause/resume only affect future dispatch."
+			},
+			"projectId": {
+				"type": "string",
+				"description": "Registered Decodex project id. Optional only when the gateway was started with a project config."
+			},
+			"authority": {
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"reason": {
+						"type": "string",
+						"description": "Explicit operator reason for pause or resume."
+					},
+					"source": {
+						"type": "string",
+						"description": "Remote client or operator source identifier."
+					},
+					"acknowledgeFutureDispatchOnly": {
+						"type": "boolean",
+						"description": "Must be true for pause/resume; active lanes are not killed."
+					}
+				}
 			}
 		},
 		"required": ["action"]
@@ -2470,11 +2902,10 @@ fn lane_control_tool_output_schema() -> Value {
 			},
 			"status": {
 				"type": "string",
-				"enum": ["refused"]
+				"enum": ["ok", "queued", "refused"]
 			},
 			"reason": {
-				"type": "string",
-				"enum": ["deferred_to_XY-998"]
+				"type": "string"
 			},
 			"message": {
 				"type": "string"
@@ -2485,12 +2916,22 @@ fn lane_control_tool_output_schema() -> Value {
 			},
 			"action": {
 				"type": "string",
-				"enum": ["inspect", "interrupt", "steer"]
+				"enum": ["inspect", "interrupt", "steer", "manual_attention", "retained_resume"]
+			},
+			"project_id": {
+				"type": ["string", "null"]
+			},
+			"issue": {
+				"type": ["string", "null"]
+			},
+			"run_id": {
+				"type": ["string", "null"]
 			},
 			"preconditions": {
 				"type": "object",
 				"additionalProperties": false,
 				"properties": {
+					"project_id_present": { "type": "boolean" },
 					"issue_present": { "type": "boolean" },
 					"run_id_present": { "type": "boolean" },
 					"expected_turn_id_present": { "type": "boolean" },
@@ -2499,9 +2940,11 @@ fn lane_control_tool_output_schema() -> Value {
 					"authority_reason_present": { "type": "boolean" },
 					"authority_source_present": { "type": "boolean" },
 					"authority_inspected_run_id_present": { "type": "boolean" },
-					"authority_expected_turn_id_present": { "type": "boolean" }
+					"authority_expected_turn_id_present": { "type": "boolean" },
+					"authority_allow_hard_fallback": { "type": "boolean" }
 				},
 				"required": [
+					"project_id_present",
 					"issue_present",
 					"run_id_present",
 					"expected_turn_id_present",
@@ -2510,8 +2953,13 @@ fn lane_control_tool_output_schema() -> Value {
 					"authority_reason_present",
 					"authority_source_present",
 					"authority_inspected_run_id_present",
-					"authority_expected_turn_id_present"
+					"authority_expected_turn_id_present",
+					"authority_allow_hard_fallback"
 				]
+			},
+			"result": {
+				"type": "object",
+				"additionalProperties": true
 			}
 		},
 		"required": [
@@ -2521,27 +2969,27 @@ fn lane_control_tool_output_schema() -> Value {
 			"message",
 			"capability_profile",
 			"action",
-			"preconditions"
+			"preconditions",
+			"result"
 		]
 	}))
 }
 
-fn admin_tool_output_schema() -> Value {
+fn project_control_tool_output_schema() -> Value {
 	tool_output_schema(serde_json::json!({
 		"type": "object",
 		"additionalProperties": false,
 		"properties": {
 			"schema": {
 				"type": "string",
-				"enum": ["decodex.mcp.admin_result/1"]
+				"enum": ["decodex.mcp.project_control_result/1"]
 			},
 			"status": {
 				"type": "string",
-				"enum": ["refused"]
+				"enum": ["ok", "refused"]
 			},
 			"reason": {
-				"type": "string",
-				"enum": ["deferred_admin_control"]
+				"type": "string"
 			},
 			"message": {
 				"type": "string"
@@ -2552,13 +3000,17 @@ fn admin_tool_output_schema() -> Value {
 			},
 			"action": {
 				"type": "string",
-				"enum": ["capabilities"]
+				"enum": ["status", "pause", "resume", "scan"]
 			},
-			"supported_admin_actions": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				}
+			"project_id": {
+				"type": ["string", "null"]
+			},
+			"future_dispatch_only": {
+				"type": "boolean"
+			},
+			"result": {
+				"type": "object",
+				"additionalProperties": true
 			}
 		},
 		"required": [
@@ -2568,7 +3020,8 @@ fn admin_tool_output_schema() -> Value {
 			"message",
 			"capability_profile",
 			"action",
-			"supported_admin_actions"
+			"future_dispatch_only",
+			"result"
 		]
 	}))
 }
@@ -2684,7 +3137,7 @@ fn plan_tool_result(params: &PlanToolArgs) -> Value {
 		"lane_control" => (
 			"decodex_lane_control",
 			"decodex://docs/spec/lane-control",
-			"Inspect first; mutating MCP lane-control remains deferred to XY-998.",
+			"Inspect first; then call guarded MCP lane-control with explicit authority and current run/turn preconditions.",
 		),
 		_ => (
 			"decodex_validation_ready",
@@ -2929,9 +3382,14 @@ fn mcp_status_live_resource(snapshot: Value) -> Value {
 }
 
 fn mcp_activity_tail_resource(snapshot: Value) -> Value {
+	let limit = snapshot
+		.get("run_limit")
+		.and_then(Value::as_u64)
+		.and_then(|limit| usize::try_from(limit).ok())
+		.unwrap_or(DEFAULT_MCP_STATUS_LIMIT);
 	let mut activity = Vec::new();
 
-	for run in mcp_all_runs(&snapshot) {
+	for run in mcp_all_runs(&snapshot).into_iter().take(limit) {
 		activity.push(mcp_run_activity_summary(run));
 	}
 
@@ -3257,38 +3715,11 @@ fn redact_reasoning_protocol_activity(value: &mut Value) {
 	}
 }
 
-fn lane_control_stub_result(arguments: Value, profile: McpCapabilityProfile) -> Value {
-	let params = match serde_json::from_value::<LaneControlToolArgs>(arguments) {
-		Ok(params) => params,
-		Err(_) =>
-			return invalid_tool_arguments(
-				TOOL_LANE_CONTROL,
-				"`action` is required and must be one of inspect, interrupt, or steer.",
-			),
-	};
-
-	if !matches!(params.action.as_str(), "inspect" | "interrupt" | "steer") {
-		return invalid_tool_arguments(
-			TOOL_LANE_CONTROL,
-			"`action` must be one of inspect, interrupt, or steer.",
-		);
-	}
-
-	tool_refusal_value(serde_json::json!({
-		"schema": "decodex.mcp.lane_control_result/1",
-		"status": "refused",
-		"reason": "deferred_to_XY-998",
-		"message": "MCP lane-control mutation is intentionally deferred; this gateway currently exposes discovery, observability, and structured refusal surfaces.",
-		"capability_profile": profile.as_str(),
-		"action": params.action.as_str(),
-		"preconditions": lane_control_preconditions(&params)
-	}))
-}
-
 fn lane_control_preconditions(params: &LaneControlToolArgs) -> Value {
 	let authority = params.authority.as_ref();
 
 	serde_json::json!({
+		"project_id_present": non_empty_string(params.project_id.as_deref()).is_some(),
 		"issue_present": non_empty_string(params.issue.as_deref()).is_some(),
 		"run_id_present": non_empty_string(params.run_id.as_deref()).is_some(),
 		"expected_turn_id_present": non_empty_string(params.expected_turn_id.as_deref()).is_some(),
@@ -3305,33 +3736,344 @@ fn lane_control_preconditions(params: &LaneControlToolArgs) -> Value {
 			.is_some(),
 		"authority_expected_turn_id_present": authority
 			.and_then(|value| non_empty_string(value.expected_turn_id.as_deref()))
-			.is_some()
+			.is_some(),
+		"authority_allow_hard_fallback": authority
+			.and_then(|value| value.allow_hard_fallback)
+			.unwrap_or(false)
 	})
 }
 
-fn admin_stub_result(arguments: Value, profile: McpCapabilityProfile) -> Value {
-	let params = match serde_json::from_value::<AdminToolArgs>(arguments) {
-		Ok(params) => params,
-		Err(_) =>
-			return invalid_tool_arguments(
-				TOOL_ADMIN,
-				"`action` is required and must be capabilities.",
-			),
+fn lane_control_authority(params: &LaneControlToolArgs) -> Option<LaneControlAuthority<'_>> {
+	let authority = params.authority.as_ref()?;
+
+	Some(LaneControlAuthority {
+		reason: non_empty_string(authority.reason.as_deref())?,
+		source: non_empty_string(authority.source.as_deref())?,
+		inspected_run_id: non_empty_string(authority.inspected_run_id.as_deref())?,
+		expected_turn_id: non_empty_string(authority.expected_turn_id.as_deref()),
+		allow_hard_fallback: authority.allow_hard_fallback.unwrap_or(false),
+	})
+}
+
+fn lane_control_mutating_preconditions(report: &Value) -> Vec<Value> {
+	report
+		.get("runs")
+		.and_then(Value::as_array)
+		.into_iter()
+		.flatten()
+		.map(|run| {
+			serde_json::json!({
+				"projectId": run.get("projectId").cloned().unwrap_or(Value::Null),
+				"issueId": run.get("issueId").cloned().unwrap_or(Value::Null),
+				"issueIdentifier": run.get("issueIdentifier").cloned().unwrap_or(Value::Null),
+				"runId": run.get("runId").cloned().unwrap_or(Value::Null),
+				"attemptNumber": run.get("attemptNumber").cloned().unwrap_or(Value::Null),
+				"currentTurnId": run.get("turnId").cloned().unwrap_or(Value::Null),
+				"laneControlNextAction": run
+					.get("laneControlNextAction")
+					.cloned()
+					.unwrap_or(Value::Null),
+				"softInterruptAvailable": run
+					.get("softInterruptAvailable")
+					.cloned()
+					.unwrap_or(Value::Null),
+				"hardInterruptAvailable": run
+					.get("hardInterruptAvailable")
+					.cloned()
+					.unwrap_or(Value::Null),
+				"hardInterruptRequiresForce": run
+					.get("hardInterruptRequiresForce")
+					.cloned()
+					.unwrap_or(Value::Bool(true)),
+				"authority": {
+					"inspectedRunId": run.get("runId").cloned().unwrap_or(Value::Null),
+					"expectedTurnId": run.get("turnId").cloned().unwrap_or(Value::Null)
+				}
+			})
+		})
+		.collect()
+}
+
+fn lane_control_refusal_result(
+	params: &LaneControlToolArgs,
+	profile: McpCapabilityProfile,
+	reason: &str,
+	message: impl Into<String>,
+) -> Value {
+	tool_refusal_value(lane_control_result_value(
+		params,
+		profile,
+		"refused",
+		reason,
+		message,
+		serde_json::json!({}),
+	))
+}
+
+fn lane_control_interrupt_result(
+	params: &LaneControlToolArgs,
+	profile: McpCapabilityProfile,
+	report: Value,
+) -> Value {
+	let soft = report.get("softInterrupt").unwrap_or(&Value::Null);
+	let hard = report.get("hardInterrupt").unwrap_or(&Value::Null);
+	let status =
+		if hard.is_object() && hard.get("status").and_then(Value::as_str) != Some("unavailable") {
+			"ok"
+		} else {
+			match soft.get("status").and_then(Value::as_str) {
+				Some("delivered") => "ok",
+				Some("pending") => "queued",
+				_ => "refused",
+			}
+		};
+	let reason =
+		report.get("classification").and_then(Value::as_str).unwrap_or("lane_interrupt_result");
+	let result = serde_json::json!({
+		"projectId": report.get("projectId").cloned().unwrap_or(Value::Null),
+		"issue": report.get("issue").cloned().unwrap_or(Value::Null),
+		"issueId": report.get("issueId").cloned().unwrap_or(Value::Null),
+		"issueIdentifier": report.get("issueIdentifier").cloned().unwrap_or(Value::Null),
+		"runId": report.get("runId").cloned().unwrap_or(Value::Null),
+		"attemptNumber": report.get("attemptNumber").cloned().unwrap_or(Value::Null),
+		"force": report.get("force").cloned().unwrap_or(Value::Bool(false)),
+		"classification": report.get("classification").cloned().unwrap_or(Value::Null),
+		"softInterrupt": {
+			"attempted": soft.get("attempted").cloned().unwrap_or(Value::Bool(false)),
+			"available": soft.get("available").cloned().unwrap_or(Value::Bool(false)),
+			"status": soft.get("status").cloned().unwrap_or(Value::Null),
+			"classification": soft.get("classification").cloned().unwrap_or(Value::Null),
+			"method": soft.get("method").cloned().unwrap_or(Value::Null),
+			"requestId": soft.get("requestId").cloned().unwrap_or(Value::Null),
+			"message": soft.get("message").cloned().unwrap_or(Value::Null),
+			"errorClass": soft.get("errorClass").cloned().unwrap_or(Value::Null)
+		},
+		"hardInterrupt": if hard.is_object() {
+			serde_json::json!({
+				"attempted": hard.get("attempted").cloned().unwrap_or(Value::Bool(false)),
+				"status": hard.get("status").cloned().unwrap_or(Value::Null),
+				"classification": hard.get("classification").cloned().unwrap_or(Value::Null),
+				"signals": hard.get("signals").cloned().unwrap_or_else(|| serde_json::json!([])),
+				"message": hard.get("message").cloned().unwrap_or(Value::Null),
+				"errorClass": hard.get("errorClass").cloned().unwrap_or(Value::Null)
+			})
+		} else {
+			Value::Null
+		},
+		"nextAction": report.get("nextAction").cloned().unwrap_or(Value::Null)
+	});
+	let value = lane_control_result_value(
+		params,
+		profile,
+		status,
+		reason,
+		"Lane interrupt completed through the existing lane-control guard path.",
+		result,
+	);
+
+	if status == "refused" { tool_refusal_value(value) } else { tool_success(value) }
+}
+
+fn lane_control_steer_result(
+	params: &LaneControlToolArgs,
+	profile: McpCapabilityProfile,
+	report: Value,
+) -> Value {
+	let outcome = report.get("outcome").and_then(Value::as_str).unwrap_or("unknown");
+	let delivery_status = report.get("deliveryStatus").and_then(Value::as_str).unwrap_or("unknown");
+	let failure_class = report.get("failureClass").and_then(Value::as_str);
+	let status = if delivery_status == "queued" {
+		"queued"
+	} else if matches!(outcome, "rejected" | "failed" | "timed_out" | "fallback") {
+		"refused"
+	} else {
+		"ok"
 	};
+	let reason = failure_class
+		.or_else(|| report.get("reason").and_then(Value::as_str))
+		.unwrap_or("lane_steer_result");
+	let result = serde_json::json!({
+		"projectId": report.get("projectId").cloned().unwrap_or(Value::Null),
+		"issueId": report.get("issueId").cloned().unwrap_or(Value::Null),
+		"issueIdentifier": report.get("issueIdentifier").cloned().unwrap_or(Value::Null),
+		"runId": report.get("runId").cloned().unwrap_or(Value::Null),
+		"attemptNumber": report.get("attemptNumber").cloned().unwrap_or(Value::Null),
+		"expectedTurnId": report.get("expectedTurnId").cloned().unwrap_or(Value::Null),
+		"currentTurnId": report.get("currentTurnId").cloned().unwrap_or(Value::Null),
+		"responseTurnId": report.get("responseTurnId").cloned().unwrap_or(Value::Null),
+		"auditRecordId": report.get("auditRecordId").cloned().unwrap_or(Value::Null),
+		"requestId": report.get("requestId").cloned().unwrap_or(Value::Null),
+		"outcome": report.get("outcome").cloned().unwrap_or(Value::Null),
+		"reason": report.get("reason").cloned().unwrap_or(Value::Null),
+		"failureClass": report.get("failureClass").cloned().unwrap_or(Value::Null),
+		"deliveryStatus": report.get("deliveryStatus").cloned().unwrap_or(Value::Null),
+		"messageByteCount": report.get("messageByteCount").cloned().unwrap_or(Value::Null),
+		"messageLineCount": report.get("messageLineCount").cloned().unwrap_or(Value::Null)
+	});
+	let value = lane_control_result_value(
+		params,
+		profile,
+		status,
+		reason,
+		"Lane steer returned without exposing the original steer message.",
+		result,
+	);
 
-	if params.action != "capabilities" {
-		return invalid_tool_arguments(TOOL_ADMIN, "`action` must be capabilities.");
-	}
+	if status == "refused" { tool_refusal_value(value) } else { tool_success(value) }
+}
 
-	tool_refusal_value(serde_json::json!({
-		"schema": "decodex.mcp.admin_result/1",
-		"status": "refused",
-		"reason": "deferred_admin_control",
-		"message": "Admin MCP behavior is not implemented in this gateway lane.",
+fn lane_control_result_value(
+	params: &LaneControlToolArgs,
+	profile: McpCapabilityProfile,
+	status: &str,
+	reason: &str,
+	message: impl Into<String>,
+	result: Value,
+) -> Value {
+	let mut value = serde_json::json!({
+		"schema": "decodex.mcp.lane_control_result/1",
+		"status": status,
+		"reason": reason,
+		"message": message.into(),
 		"capability_profile": profile.as_str(),
 		"action": params.action.as_str(),
-		"supported_admin_actions": []
-	}))
+		"project_id": params.project_id.as_deref(),
+		"issue": params.issue.as_deref(),
+		"run_id": params.run_id.as_deref(),
+		"preconditions": lane_control_preconditions(params),
+		"result": result
+	});
+
+	sanitize_mcp_observability_value(&mut value);
+
+	value
+}
+
+fn project_control_authority(
+	params: &ProjectControlToolArgs,
+) -> Option<ProjectControlAuthority<'_>> {
+	let authority = params.authority.as_ref()?;
+
+	Some(ProjectControlAuthority {
+		reason: non_empty_string(authority.reason.as_deref())?,
+		source: non_empty_string(authority.source.as_deref())?,
+		acknowledge_future_dispatch_only: authority
+			.acknowledge_future_dispatch_only
+			.unwrap_or(false),
+	})
+}
+
+fn project_control_status_result(
+	params: &ProjectControlToolArgs,
+	profile: McpCapabilityProfile,
+	project_id: &str,
+) -> Value {
+	let state_store = match runtime::open_runtime_store_lazy() {
+		Ok(state_store) => state_store,
+		Err(error) =>
+			return project_control_refusal_result(
+				params,
+				profile,
+				"project_control_unavailable",
+				format!("Project status failed closed: {error}"),
+			),
+	};
+	let projects = match state_store.list_projects() {
+		Ok(projects) => projects,
+		Err(error) =>
+			return project_control_refusal_result(
+				params,
+				profile,
+				"project_registry_unavailable",
+				format!("Project registry read failed closed: {error}"),
+			),
+	};
+	let Some(project) = projects.iter().find(|project| project.service_id() == project_id) else {
+		return project_control_refusal_result(
+			params,
+			profile,
+			"project_not_registered",
+			"Project control requires a registered Decodex project.",
+		);
+	};
+
+	project_control_success_result(
+		params,
+		profile,
+		project_id,
+		serde_json::json!({
+			"enabled": project.enabled(),
+			"future_dispatch_only": true,
+			"active_lanes_killed": false,
+			"next_action": if project.enabled() {
+				"Project is enabled for future dispatch."
+			} else {
+				"Project is paused for future dispatch. Existing lanes remain visible."
+			}
+		}),
+	)
+}
+
+fn project_control_success_result(
+	params: &ProjectControlToolArgs,
+	profile: McpCapabilityProfile,
+	project_id: &str,
+	result: Value,
+) -> Value {
+	tool_success(project_control_result_value(
+		params,
+		profile,
+		project_id,
+		"ok",
+		params.action.as_str(),
+		"Project control completed through the registered project enablement guard.",
+		result,
+	))
+}
+
+fn project_control_refusal_result(
+	params: &ProjectControlToolArgs,
+	profile: McpCapabilityProfile,
+	reason: &str,
+	message: impl Into<String>,
+) -> Value {
+	let project_id = params.project_id.as_deref().unwrap_or("");
+
+	tool_refusal_value(project_control_result_value(
+		params,
+		profile,
+		project_id,
+		"refused",
+		reason,
+		message,
+		serde_json::json!({}),
+	))
+}
+
+fn project_control_result_value(
+	params: &ProjectControlToolArgs,
+	profile: McpCapabilityProfile,
+	project_id: &str,
+	status: &str,
+	reason: &str,
+	message: impl Into<String>,
+	result: Value,
+) -> Value {
+	let mut value = serde_json::json!({
+		"schema": "decodex.mcp.project_control_result/1",
+		"status": status,
+		"reason": reason,
+		"message": message.into(),
+		"capability_profile": profile.as_str(),
+		"action": params.action.as_str(),
+		"project_id": non_empty_string(Some(project_id)),
+		"future_dispatch_only": true,
+		"result": result
+	});
+
+	sanitize_mcp_observability_value(&mut value);
+
+	value
 }
 
 fn tool_success(value: Value) -> Value {
@@ -4430,10 +5172,13 @@ mod tests {
 		assert_public_lane_control_readback(&lane_control);
 
 		assert_eq!(pr_review_state["schema"], "decodex.mcp.pr_review_state/1");
-		assert_eq!(
-			pr_review_state["current_lane_reviews"].as_array().expect("review array").len(),
-			0
-		);
+
+		let current_lane_reviews =
+			pr_review_state["current_lane_reviews"].as_array().expect("review array");
+
+		assert_eq!(current_lane_reviews.len(), 1);
+		assert_eq!(current_lane_reviews[0]["run_id"], "run-12");
+		assert_eq!(current_lane_reviews[0]["review"]["status"], "pending");
 		assert_eq!(protocol_activity["schema"], "decodex.mcp.protocol_activity/1");
 		assert_eq!(protocol_activity["run_id"], "run-12");
 		assert!(
@@ -4541,6 +5286,13 @@ mod tests {
 		assert_public_lane_control_readback(&lane_control);
 
 		assert_eq!(protocol_activity["schema"], "decodex.mcp.protocol_activity/1");
+
+		let current_lane_reviews =
+			pr_review_state["current_lane_reviews"].as_array().expect("review array");
+
+		assert_eq!(current_lane_reviews.len(), 1);
+		assert_eq!(current_lane_reviews[0]["run_id"], "run-12");
+		assert_eq!(current_lane_reviews[0]["review"]["status"], "pending");
 		assert!(
 			serde_json::to_string(&protocol_activity)
 				.expect("protocol activity should serialize")
@@ -4961,7 +5713,41 @@ mod tests {
 	}
 
 	#[test]
-	fn tools_call_refuses_deferred_lane_control_mutation() {
+	fn tools_call_lane_control_inspect_returns_mutating_preconditions() {
+		let repo = test_repo();
+		let codex_home = repo.path().join("codex-home");
+		let codex_home = codex_home.to_string_lossy().into_owned();
+		let _codex_home_guard = TestEnvVarGuard::set("CODEX_HOME", &codex_home);
+		let config_path = repo.path().join("project.toml");
+
+		seed_project_runtime_for_mcp_resources(repo.path(), &config_path);
+
+		let responses = run_stdio_with_context(
+			project_mcp_context(repo.path(), &config_path),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_lane_control","arguments":{"action":"inspect","issue":"PUB-012"}}}"#,
+		);
+		let result = &response_at(&responses, 0)["result"];
+		let structured = &result["structuredContent"];
+
+		assert_eq!(result["isError"], false);
+		assert_eq!(structured["schema"], "decodex.mcp.lane_control_result/1");
+		assert_eq!(structured["status"], "ok");
+		assert_eq!(structured["reason"], "inspect_complete");
+		assert_eq!(structured["result"]["inspect"]["schema"], "decodex.mcp.lane_inspect/1");
+		assert_eq!(
+			structured["result"]["mutating_preconditions"][0]["authority"]["inspectedRunId"],
+			"run-12"
+		);
+		assert_eq!(
+			structured["result"]["mutating_preconditions"][0]["authority"]["expectedTurnId"],
+			"turn-12"
+		);
+
+		assert_no_sensitive_observability_content(structured);
+	}
+
+	#[test]
+	fn tools_call_refuses_lane_control_mutation_without_inspect_precondition() {
 		let repo = test_repo();
 		let responses = run_stdio(
 			repo.path(),
@@ -4970,14 +5756,9 @@ mod tests {
 		let result = &response_at(&responses, 0)["result"];
 
 		assert_eq!(result["isError"], true);
+		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.lane_control_result/1");
 		assert_eq!(result["structuredContent"]["status"], "refused");
-		assert_eq!(result["structuredContent"]["reason"], "deferred_to_XY-998");
-		assert!(
-			!result["structuredContent"]["message"]
-				.as_str()
-				.expect("message should be text")
-				.contains("stdio")
-		);
+		assert_eq!(result["structuredContent"]["reason"], "authority_required");
 	}
 
 	#[test]
@@ -4996,39 +5777,174 @@ mod tests {
 	}
 
 	#[test]
-	fn tools_call_refuses_deferred_admin_operation() {
+	fn tools_call_lane_control_refuses_stale_expected_turn_id() {
 		let repo = test_repo();
-		let responses = run_stdio(
-			repo.path(),
-			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_admin","arguments":{"action":"capabilities"}}}"#,
+		let codex_home = repo.path().join("codex-home");
+		let codex_home = codex_home.to_string_lossy().into_owned();
+		let _codex_home_guard = TestEnvVarGuard::set("CODEX_HOME", &codex_home);
+		let config_path = repo.path().join("project.toml");
+
+		seed_project_runtime_for_mcp_resources(repo.path(), &config_path);
+
+		let responses = run_stdio_with_context(
+			project_mcp_context(repo.path(), &config_path),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_lane_control","arguments":{"action":"steer","projectId":"pubfi","issue":"PUB-012","runId":"run-12","expectedTurnId":"turn-old","message":"Please stop after the current safe point.","authority":{"reason":"operator requested steer","source":"mcp-test","inspectedRunId":"run-12","expectedTurnId":"turn-old"}}}}"#,
+		);
+		let result = &response_at(&responses, 0)["result"];
+		let structured = &result["structuredContent"];
+
+		assert_eq!(result["isError"], true);
+		assert_eq!(structured["status"], "refused");
+		assert_eq!(structured["reason"], "stale_expected_turn_id");
+		assert_eq!(structured["result"]["failureClass"], "stale_expected_turn_id");
+		assert_eq!(structured["result"]["currentTurnId"], "turn-12");
+
+		assert_no_sensitive_observability_content(structured);
+	}
+
+	#[test]
+	fn tools_call_lane_control_steer_audits_and_queues_without_raw_message() {
+		let repo = test_repo();
+		let codex_home = repo.path().join("codex-home");
+		let codex_home = codex_home.to_string_lossy().into_owned();
+		let _codex_home_guard = TestEnvVarGuard::set("CODEX_HOME", &codex_home);
+		let config_path = repo.path().join("project.toml");
+
+		seed_project_runtime_for_mcp_resources(repo.path(), &config_path);
+
+		let responses = run_stdio_with_context(
+			project_mcp_context(repo.path(), &config_path),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_lane_control","arguments":{"action":"steer","projectId":"pubfi","issue":"PUB-012","runId":"run-12","expectedTurnId":"turn-12","message":"Please stop after the current safe point.","authority":{"reason":"operator requested steer","source":"mcp-test","inspectedRunId":"run-12","expectedTurnId":"turn-12"}}}}"#,
+		);
+		let result = &response_at(&responses, 0)["result"];
+		let structured = &result["structuredContent"];
+		let serialized = serde_json::to_string(structured).expect("structured should serialize");
+
+		assert_eq!(result["isError"], false);
+		assert_eq!(structured["status"], "queued");
+		assert_eq!(structured["result"]["deliveryStatus"], "queued");
+		assert_eq!(structured["result"]["messageLineCount"], 1);
+		assert!(!serialized.contains("Please stop after the current safe point."));
+
+		assert_no_sensitive_observability_content(structured);
+
+		let state_store = runtime::open_runtime_store().expect("runtime store should open");
+		let events = state_store
+			.list_private_execution_events("pubfi", "PUB-012", "run-12", 1)
+			.expect("private events should read");
+
+		assert!(events.iter().any(|event| event.event_type() == "control_action"));
+		assert!(events.iter().any(|event| event.event_type() == "lane_control/steer/requested"));
+	}
+
+	#[test]
+	fn tools_call_lane_control_soft_interrupt_accepts_and_force_requires_ack() {
+		let repo = test_repo();
+		let codex_home = repo.path().join("codex-home");
+		let codex_home = codex_home.to_string_lossy().into_owned();
+		let _codex_home_guard = TestEnvVarGuard::set("CODEX_HOME", &codex_home);
+		let config_path = repo.path().join("project.toml");
+
+		seed_project_runtime_for_mcp_resources(repo.path(), &config_path);
+
+		let force_refusal = run_stdio_with_context(
+			project_mcp_context(repo.path(), &config_path),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_lane_control","arguments":{"action":"interrupt","projectId":"pubfi","issue":"PUB-012","runId":"run-12","force":true,"authority":{"reason":"operator requested hard fallback","source":"mcp-test","inspectedRunId":"run-12"}}}}"#,
+		);
+		let force_structured = &response_at(&force_refusal, 0)["result"]["structuredContent"];
+
+		assert_eq!(force_structured["status"], "refused");
+		assert_eq!(force_structured["reason"], "hard_fallback_authority_missing");
+
+		let soft_acceptance = run_stdio_with_context(
+			project_mcp_context(repo.path(), &config_path),
+			r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"decodex_lane_control","arguments":{"action":"interrupt","projectId":"pubfi","issue":"PUB-012","runId":"run-12","authority":{"reason":"operator requested soft interrupt","source":"mcp-test","inspectedRunId":"run-12"}}}}"#,
+		);
+		let soft_result = &response_at(&soft_acceptance, 0)["result"];
+		let soft_structured = &soft_result["structuredContent"];
+
+		assert_eq!(soft_result["isError"], false);
+		assert_eq!(soft_structured["status"], "queued");
+		assert_eq!(
+			soft_structured["result"]["softInterrupt"]["classification"],
+			"soft_interrupt_pending"
+		);
+		assert_eq!(soft_structured["result"]["hardInterrupt"], Value::Null);
+
+		assert_no_sensitive_observability_content(soft_structured);
+	}
+
+	#[test]
+	fn tools_call_project_control_pauses_future_dispatch_only() {
+		let repo = test_repo();
+		let codex_home = repo.path().join("codex-home");
+		let codex_home = codex_home.to_string_lossy().into_owned();
+		let _codex_home_guard = TestEnvVarGuard::set("CODEX_HOME", &codex_home);
+		let config_path = repo.path().join("project.toml");
+
+		seed_project_runtime_for_mcp_resources(repo.path(), &config_path);
+
+		let responses = run_stdio_with_context(
+			project_mcp_context(repo.path(), &config_path),
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_project_control","arguments":{"action":"pause","projectId":"pubfi","authority":{"reason":"operator pause","source":"mcp-test","acknowledgeFutureDispatchOnly":true}}}}"#,
+		);
+		let result = &response_at(&responses, 0)["result"];
+		let structured = &result["structuredContent"];
+
+		assert_eq!(result["isError"], false);
+		assert_eq!(structured["schema"], "decodex.mcp.project_control_result/1");
+		assert_eq!(structured["status"], "ok");
+		assert_eq!(structured["project_id"], "pubfi");
+		assert_eq!(structured["future_dispatch_only"], true);
+		assert_eq!(structured["result"]["enabled"], false);
+		assert_eq!(structured["result"]["active_lanes_killed"], false);
+
+		let state_store = runtime::open_runtime_store().expect("runtime store should open");
+		let projects = state_store.list_projects().expect("projects should list");
+		let project = projects
+			.iter()
+			.find(|project| project.service_id() == "pubfi")
+			.expect("pubfi should remain registered");
+		let events = state_store
+			.list_private_execution_events("pubfi", "PUB-012", "run-12", 1)
+			.expect("private events should read");
+
+		assert!(!project.enabled());
+		assert!(!events.is_empty(), "pause should not remove active lane evidence");
+	}
+
+	#[test]
+	fn tools_call_project_control_scan_refuses_without_operator_loop() {
+		let repo = test_repo();
+		let responses = run_stdio_with_context(
+			McpContext {
+				repo_root: repo.path().to_path_buf(),
+				config_path: None,
+				project_id: Some(String::from("pubfi")),
+				state_store: None,
+			},
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_project_control","arguments":{"action":"scan","projectId":"pubfi"}}}"#,
 		);
 		let result = &response_at(&responses, 0)["result"];
 
 		assert_eq!(result["isError"], true);
-		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.admin_result/1");
-		assert_eq!(result["structuredContent"]["status"], "refused");
-		assert_eq!(result["structuredContent"]["reason"], "deferred_admin_control");
-		assert!(
-			!result["structuredContent"]["message"]
-				.as_str()
-				.expect("message should be text")
-				.contains("stdio")
-		);
+		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.project_control_result/1");
+		assert_eq!(result["structuredContent"]["reason"], "operator_control_loop_required");
 	}
 
 	#[test]
-	fn tools_call_refuses_missing_admin_action() {
+	fn tools_call_refuses_missing_project_control_action() {
 		let repo = test_repo();
 		let responses = run_stdio(
 			repo.path(),
-			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_admin","arguments":{}}}"#,
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"decodex_project_control","arguments":{}}}"#,
 		);
 		let result = &response_at(&responses, 0)["result"];
 
 		assert_eq!(result["isError"], true);
 		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.tool_validation_error/1");
 		assert_eq!(result["structuredContent"]["reason"], "invalid_arguments");
-		assert_eq!(result["structuredContent"]["tool"], "decodex_admin");
+		assert_eq!(result["structuredContent"]["tool"], "decodex_project_control");
 	}
 
 	#[test]
@@ -5421,7 +6337,7 @@ mod tests {
 
 		for (tool, required_profile, arguments) in [
 			("decodex_lane_control", "operate", r#"{"action":"inspect"}"#),
-			("decodex_admin", "admin", r#"{"action":"capabilities"}"#),
+			("decodex_project_control", "admin", r#"{"action":"status","projectId":"pubfi"}"#),
 		] {
 			let response = run_http(
 				&mut handler,
@@ -5511,6 +6427,15 @@ mod tests {
 			.lines()
 			.map(|line| serde_json::from_str::<Value>(line).expect("response should be JSON"))
 			.collect()
+	}
+
+	fn project_mcp_context(repo_root: &Path, config_path: &Path) -> McpContext {
+		McpContext {
+			repo_root: repo_root.to_path_buf(),
+			config_path: Some(config_path.to_path_buf()),
+			project_id: Some(String::from("pubfi")),
+			state_store: None,
+		}
 	}
 
 	fn run_stdio_raw(repo_root: &Path, input: &str) -> String {
@@ -6039,6 +6964,7 @@ mod tests {
 			let issue_id = format!("PUB-{index:03}");
 			let run_id = format!("run-{index:02}");
 			let worktree_path = repo_root.join(format!("worktrees/{issue_id}"));
+			let attempt_status = if index == 12 { "running" } else { "succeeded" };
 
 			state_store
 				.upsert_worktree(
@@ -6049,7 +6975,7 @@ mod tests {
 				)
 				.expect("worktree should record");
 			state_store
-				.record_run_attempt(&run_id, &issue_id, 1, "succeeded")
+				.record_run_attempt(&run_id, &issue_id, 1, attempt_status)
 				.expect("run attempt should record");
 			state_store
 				.append_event(&run_id, 1, "turn/completed", r#"{"status":"completed"}"#)
@@ -6057,101 +6983,115 @@ mod tests {
 
 			if index == 12 {
 				seed_mcp_lane_runtime_markers(&state_store, &worktree_path, &run_id);
-
-				state_store
-					.append_event(
-						&run_id,
-						2,
-						"configWarning",
-						r#"{"summary":"config at /private/worktree using GITHUB_PAT_Y"}"#,
-					)
-					.expect("warning event should record");
-				state_store
-					.append_event(
-						&run_id,
-						3,
-						"error",
-						r#"{"error":{"codexErrorInfo":"failed under /Users/x/worktree with LINEAR_API_KEY_HACKINK"}}"#,
-					)
-					.expect("error event should record");
-				state_store
-					.append_event(
-						&run_id,
-						4,
-						"configWarning",
-						r#"{"summary":"state marker under /srv/decodex/runtime"}"#,
-					)
-					.expect("generic path warning event should record");
-				state_store
-					.append_event(
-						&run_id,
-						5,
-						"error",
-						r#"{"error":{"codexErrorInfo":"upstream auth failed for ghp_abcdefghijklmnopqrstuvwxyz123456"}}"#,
-					)
-					.expect("token-shaped error event should record");
-				state_store
-					.append_event(
-						&run_id,
-						6,
-						"error",
-						r#"{"error":{"codexErrorInfo":"upstream auth failed for 8Nf4Qz7Lb2Rc9Vx5Tm3Pq6Wy1Hs8Ka0U"}}"#,
-					)
-					.expect("bare token-shaped error event should record");
-
-				let protocol_activity = ProtocolActivitySummary {
-					turn_status: Some(String::from("completed")),
-					waiting_reason: Some(String::from("turn_completed")),
-					rate_limit_status: None,
-					recent_events: vec![
-						ProtocolActivityEventSummary {
-							event_type: String::from("configWarning"),
-							category: String::from("warning"),
-							detail: Some(String::from(
-								"config at /private/worktree using GITHUB_PAT_Y",
-							)),
-						},
-						ProtocolActivityEventSummary {
-							event_type: String::from("error"),
-							category: String::from("protocol_error"),
-							detail: Some(String::from(
-								"failed under /Users/x/worktree with LINEAR_API_KEY_HACKINK",
-							)),
-						},
-						ProtocolActivityEventSummary {
-							event_type: String::from("configWarning"),
-							category: String::from("warning"),
-							detail: Some(String::from("state marker under /srv/decodex/runtime")),
-						},
-						ProtocolActivityEventSummary {
-							event_type: String::from("error"),
-							category: String::from("protocol_error"),
-							detail: Some(String::from(
-								"upstream auth failed for ghp_abcdefghijklmnopqrstuvwxyz123456",
-							)),
-						},
-						ProtocolActivityEventSummary {
-							event_type: String::from("error"),
-							category: String::from("protocol_error"),
-							detail: Some(String::from(
-								"upstream auth failed for 8Nf4Qz7Lb2Rc9Vx5Tm3Pq6Wy1Hs8Ka0U",
-							)),
-						},
-					],
-				};
-
-				state_store
-					.record_run_activity_summary(&run_id, 1, None, Some(&protocol_activity))
-					.expect("activity summary should record");
+				seed_mcp_lane_runtime_activity(&state_store, &run_id);
 			}
 		}
+	}
+
+	fn seed_mcp_lane_runtime_activity(state_store: &StateStore, run_id: &str) {
+		state_store
+			.append_event(
+				run_id,
+				2,
+				"configWarning",
+				r#"{"summary":"config at /private/worktree using GITHUB_PAT_Y"}"#,
+			)
+			.expect("warning event should record");
+		state_store
+			.append_event(
+				run_id,
+				3,
+				"error",
+				r#"{"error":{"codexErrorInfo":"failed under /Users/x/worktree with LINEAR_API_KEY_HACKINK"}}"#,
+			)
+			.expect("error event should record");
+		state_store
+			.append_event(
+				run_id,
+				4,
+				"configWarning",
+				r#"{"summary":"state marker under /srv/decodex/runtime"}"#,
+			)
+			.expect("generic path warning event should record");
+		state_store
+				.append_event(
+					run_id,
+					5,
+					"error",
+					r#"{"error":{"codexErrorInfo":"upstream auth failed for ghp_abcdefghijklmnopqrstuvwxyz123456"}}"#,
+				)
+				.expect("token-shaped error event should record");
+		state_store
+			.append_event(
+				run_id,
+				6,
+				"error",
+				r#"{"error":{"codexErrorInfo":"upstream auth failed for 8Nf4Qz7Lb2Rc9Vx5Tm3Pq6Wy1Hs8Ka0U"}}"#,
+			)
+			.expect("bare token-shaped error event should record");
+
+		let protocol_activity = ProtocolActivitySummary {
+			turn_status: Some(String::from("completed")),
+			waiting_reason: Some(String::from("turn_completed")),
+			rate_limit_status: None,
+			recent_events: vec![
+				ProtocolActivityEventSummary {
+					event_type: String::from("configWarning"),
+					category: String::from("warning"),
+					detail: Some(String::from("config at /private/worktree using GITHUB_PAT_Y")),
+				},
+				ProtocolActivityEventSummary {
+					event_type: String::from("error"),
+					category: String::from("protocol_error"),
+					detail: Some(String::from(
+						"failed under /Users/x/worktree with LINEAR_API_KEY_HACKINK",
+					)),
+				},
+				ProtocolActivityEventSummary {
+					event_type: String::from("configWarning"),
+					category: String::from("warning"),
+					detail: Some(String::from("state marker under /srv/decodex/runtime")),
+				},
+				ProtocolActivityEventSummary {
+					event_type: String::from("error"),
+					category: String::from("protocol_error"),
+					detail: Some(String::from(
+						"upstream auth failed for ghp_abcdefghijklmnopqrstuvwxyz123456",
+					)),
+				},
+				ProtocolActivityEventSummary {
+					event_type: String::from("error"),
+					category: String::from("protocol_error"),
+					detail: Some(String::from(
+						"upstream auth failed for 8Nf4Qz7Lb2Rc9Vx5Tm3Pq6Wy1Hs8Ka0U",
+					)),
+				},
+			],
+		};
+
+		state_store
+			.record_run_activity_summary(run_id, 1, None, Some(&protocol_activity))
+			.expect("activity summary should record");
 	}
 
 	fn seed_mcp_lane_runtime_markers(state_store: &StateStore, worktree_path: &Path, run_id: &str) {
 		fs::create_dir_all(worktree_path).expect("worktree path should exist");
 
+		let control_dir = worktree_path.join(".decodex-run-control");
+		let channel_path = control_dir.join("run-12-1.channel");
+
+		fs::create_dir_all(&control_dir).expect("run-control channel dir should exist");
+		fs::write(&channel_path, "ready\n").expect("run-control channel should write");
+
+		state_store
+			.upsert_lease("pubfi", "PUB-012", run_id, "In Progress")
+			.expect("lease should record");
 		state_store.update_run_thread(run_id, "thread-12").expect("thread should record");
 		state_store.update_run_turn(run_id, "turn-12").expect("turn should record");
+		state_store
+			.publish_run_control_channel_for_active_attempt(run_id, 1, &channel_path, "local_file")
+			.expect("control channel should publish")
+			.expect("active control channel should exist");
 
 		state::write_run_activity_marker_for_process(worktree_path, run_id, 1, process::id())
 			.expect("activity marker should record process");

--- a/apps/decodex/src/orchestrator/entrypoints.rs
+++ b/apps/decodex/src/orchestrator/entrypoints.rs
@@ -6,6 +6,17 @@ use crate::runtime;
 
 const CONTROL_PLANE_TICK_CONTEXT_FAILED_WARNING: &str = "control_plane_tick_context_failed";
 
+pub(crate) struct McpLaneSteerRequest<'a> {
+	pub(crate) config_path: Option<&'a Path>,
+	pub(crate) project_id: Option<&'a str>,
+	pub(crate) issue: &'a str,
+	pub(crate) run_id: &'a str,
+	pub(crate) expected_turn_id: &'a str,
+	pub(crate) message: &'a str,
+	pub(crate) source: &'a str,
+	pub(crate) wait_timeout: Duration,
+}
+
 struct ControlPlaneProjectTick {
 	snapshot: Option<OperatorStatusSnapshot>,
 	project_status: Option<OperatorProjectStatus>,
@@ -373,6 +384,57 @@ pub(crate) fn build_mcp_lane_control_resource(
 		"recent_runs": snapshot.recent_runs,
 		"post_review_lanes": snapshot.post_review_lanes
 	}))
+}
+
+pub(crate) fn run_mcp_lane_interrupt(
+	config_path: Option<&Path>,
+	issue: &str,
+	run_id: &str,
+	force: bool,
+	reason: Option<&str>,
+	source: &str,
+) -> Result<Value> {
+	let state_store = runtime::open_runtime_store_lazy()?;
+	let Some(config_path) = resolve_config_path(config_path, &state_store)? else {
+		eyre::bail!(
+			"No Decodex project config found. Start MCP from a registered checkout or pass --config."
+		);
+	};
+	let config = ServiceConfig::from_path(&config_path)?;
+	let report = lane_control::interrupt_lane_with_state(
+		&state_store,
+		&config,
+		issue,
+		run_id,
+		force,
+		reason,
+		source,
+	)?;
+
+	serde_json::to_value(report).map_err(Into::into)
+}
+
+pub(crate) fn run_mcp_lane_steer(request: McpLaneSteerRequest<'_>) -> Result<Value> {
+	let state_store = runtime::open_runtime_store_lazy()?;
+	let Some(config_path) = resolve_config_path(request.config_path, &state_store)? else {
+		eyre::bail!(
+			"No Decodex project config found. Start MCP from a registered checkout or pass --config."
+		);
+	};
+	let config = ServiceConfig::from_path(&config_path)?;
+	let lane_request = LaneSteerRequest {
+		config_path: Some(&config_path),
+		project_id: request.project_id,
+		issue: request.issue,
+		run_id: request.run_id,
+		expected_turn_id: request.expected_turn_id,
+		message: request.message,
+		source: request.source,
+		wait_timeout: request.wait_timeout,
+	};
+	let report = lane_control::steer_lane_with_state(&state_store, &config, &lane_request)?;
+
+	serde_json::to_value(report).map_err(Into::into)
 }
 
 pub(crate) fn run_diagnose(request: DiagnoseRequest<'_>) -> Result<()> {

--- a/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
+++ b/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
@@ -157,10 +157,14 @@ Tools:
   generated issue rows without tracker or Program Intake mutation; `apply` mutates
   only after accepted contract authority and explicit MCP authority exist.
 - `decodex_lane_control(action, issue, runId, expectedTurnId, authority)`: advertises
-  the operate-profile lane-control surface and returns structured refusal states until
-  later lane-control MCP work delegates through existing policy.
-- `decodex_admin(action)`: advertises the admin-profile policy surface without
-  exposing raw tracker, hosting-service, process, or runtime mutation.
+  the operate-profile lane-control surface. `inspect` returns public-safe
+  preconditions, `steer` and `interrupt` delegate through existing lane-control guards
+  only with current inspected run/turn authority, and unsupported shortcut paths
+  return structured refusals.
+- `decodex_project_control(action, projectId, authority)`: advertises the
+  admin-profile project-control surface. `status` reads project enablement,
+  `pause`/`resume` affect future dispatch only with explicit authority, and `scan`
+  refuses to the operator control loop instead of enqueueing from standalone MCP.
 
 Tool rules:
 
@@ -219,9 +223,9 @@ The promoted implementation now has the stdio gateway exposed as
 `decodex mcp serve --transport stdio` and the remote-capable Streamable HTTP gateway
 exposed as `decodex mcp serve --transport streamable-http`. It advertises resources,
 resource templates, prompts, and a schema-bound tool catalog while keeping mutating
-operate/admin behavior behind structured refusal states. XY-996 adds the
-remote-safe observability templates and projections on top of that transport; later
-promoted work should keep the schema-bound `research_compile`, `research_promote`,
-and `intake_goal` planning tools separate from live lane-control tools,
-skill-slimming eval, and docs/resource validation lanes so mutating MCP tools do not
-bypass Decision Contract or lane-control authority.
+operate/admin behavior behind inspect-first authority checks and structured refusal
+states. XY-996 adds the remote-safe observability templates and projections on top of
+that transport; promoted work keeps the schema-bound `research_compile`,
+`research_promote`, and `intake_goal` planning tools separate from live
+lane-control/project-control tools, skill-slimming eval, and docs/resource validation
+lanes so mutating MCP tools do not bypass Decision Contract or lane-control authority.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,11 @@
 
 ## 2026-06-18
 
+- Promoted MCP operate/admin docs from deferred stubs to the implemented
+  inspect-first `decodex_lane_control` and future-dispatch-only
+  `decodex_project_control` authority model.
+- Refreshed the test-suite inventory to 1270 runnable `nextest` tests after adding
+  MCP operate/admin coverage.
 - Added schema-bound MCP planning tools for `research_compile`, `research_promote`,
   and `intake_goal`; dry-run paths stay read-only while apply/promote paths require
   explicit authority and return structured refusals when authority is missing.

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -101,8 +101,12 @@ uses SSE framing for progress or notifications when the client accepts
 `text/event-stream`. Both transports can be narrowed or explicitly elevated with
 `--capability-profile observe|plan|operate|admin`; `tools/list` filters by the active
 profile and above-profile calls return structured refusals. Observe and plan tools are
-read-oriented. Operate/admin lane-control entries return structured refusal states
-until later MCP lane-control work delegates mutation through existing authority gates.
+read-oriented. Operate exposes `decodex_lane_control` as an inspect-first facade:
+`inspect` returns current lane-control preconditions, `steer` and `interrupt` require
+matching inspected run/turn authority, and unsupported shortcut paths refuse to the
+canonical tracker/runtime lifecycle. Admin exposes `decodex_project_control` for
+project status plus future-dispatch-only pause/resume with explicit authority; scan
+requests refuse to the operator control loop.
 
 `decodex serve` has two hardcoded scheduler cadences:
 

--- a/docs/reference/test-suite.md
+++ b/docs/reference/test-suite.md
@@ -26,7 +26,7 @@ standards for keeping, merging, or deleting tests.
 
 ## Current Snapshot
 
-This snapshot groups 1265 runnable `nextest` tests across all targets. One additional
+This snapshot groups 1270 runnable `nextest` tests across all targets. One additional
 skipped live app-server test is listed only with verbose or JSON inventory output.
 Regenerate the runnable inventory with:
 
@@ -63,7 +63,7 @@ cargo nextest list --workspace --all-targets --all-features 2>/dev/null \
 | Runtime state, locks, and maintenance | 86 | `state::tests`, `runtime::tests`, `maintenance::tests` | Persistent local state, lock ownership, runtime database contracts, local retention |
 | Workflow, config, and docs parsing | 62 | `workflow::tests`, `config::tests`, `codex_config::tests`, `docs_okf::tests` | `WORKFLOW.md`, project config, Codex config edits, removed-field rejection, default policy, OKF docs parsing |
 | Git, worktree, landing, and recovery helpers | 137 | `worktree::tests`, `manual::tests`, `commit_message::tests`, `github::tests`, `default_branch_sync::tests`, `pull_request::tests`, `recovery::tests`, `git_credentials::tests` | Git/worktree behavior, manual landing, GitHub/PR helpers, recovery commands, commit-message policy |
-| Account, CLI, archive, tracker, and MCP integration | 142 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests`, `mcp::tests`, `apps/decodex/tests/mcp_stdio.rs` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter, MCP resources, HTTP transport, schema-bound planning tools, remote-safe observability templates, and public-text behavior |
+| Account, CLI, archive, tracker, and MCP integration | 147 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests`, `mcp::tests`, `apps/decodex/tests/mcp_stdio.rs` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter, MCP resources, HTTP transport, schema-bound planning tools, inspect-first operate/admin tools, remote-safe observability templates, and public-text behavior |
 | Program intake | 10 | `program_intake::tests` | Decision Contract materialization, Linear issue shaping, and internal Execution Program persistence |
 | Loop contract and research surfaces | 29 | `loop_contract::tests`, `execution_program::tests`, `research_design::tests`, `plugin_surface_tests` | Decision Contract schema, Execution Program readiness, research compile/promote, and plugin trigger behavior |
 

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -93,9 +93,13 @@ state or this state machine.
   promotion, and Program Intake authority checks. Dry-run planning calls do not mutate
   tracker state or Program Intake rows. Apply/promote calls require explicit authority
   fields and return structured refusals when authority or project context is missing.
-  Operate/admin lane-control entries return structured refusal states until the
-  dedicated lane-control MCP work delegates through existing authority gates. Local stdio
-  defaults to the `admin` capability profile and can be narrowed with
+  Operate exposes `decodex_lane_control` as an inspect-first facade over existing
+  lane-control authority: `inspect` returns current preconditions, mutating `steer`
+  and `interrupt` require matching inspected run/turn authority, and unsupported
+  shortcut paths refuse to the canonical tracker or runtime lifecycle. Admin exposes
+  `decodex_project_control` for project status and future-dispatch-only pause/resume;
+  standalone scan requests refuse to the operator control loop. Local stdio defaults
+  to the `admin` capability profile and can be narrowed with
   `--capability-profile observe|plan|operate|admin`; tool discovery is filtered by the
   active profile and above-profile calls return structured refusals. Stdout must
   contain only valid MCP JSON-RPC messages.
@@ -1029,8 +1033,8 @@ After a process restart, recent-run history, run lease ownership, retained post-
   default, and uses SSE framing for remote progress or notifications when the client
   accepts `text/event-stream`. MCP tools must not replace the app-server dynamic tool
   bridge, create execution authority from latent research without promotion, expose
-  Program graph identifiers in ordinary tool output, or become a lane-control mutation
-  path before a later authority design delegates through existing lane-control guards.
+  Program graph identifiers in ordinary tool output, or mutate lanes without the
+  inspect-first run/turn authority already enforced by existing lane-control guards.
   MCP observability projections must stay public-safe: no hidden reasoning, raw steer
   text, private evidence payloads, or local path fields. Run-scoped MCP observability
   resources are bounded to runs visible in the current/recent status snapshot and must


### PR DESCRIPTION
## Summary
- Expose `decodex_lane_control` as an inspect-first MCP operate tool for inspect, steer, interrupt, and canonical refusal paths.
- Expose `decodex_project_control` as an admin tool for project status and future-dispatch-only pause/resume.
- Keep XY-997 planning tools intact and update docs/test-suite inventory for the final MCP gateway behavior.

## Verification
- `cargo make fmt`
- `cargo make lint-fix`
- `cargo test -p decodex mcp::tests -- --nocapture`
- `cargo make check-docs`
- `cargo make test` (first run hit a transient `streamable_http_resources_read_exposes_observability_resources` nextest failure; exact nextest rerun passed; full rerun passed: 1270 passed, 1 skipped)
- `git diff --check`