### PR TITLE
Sync complete remote MCP docs and skills

### DIFF
--- a/apps/decodex/src/agent/app_server.rs
+++ b/apps/decodex/src/agent/app_server.rs
@@ -35,7 +35,6 @@ use self::protocol::{
 	ThreadResumeRequest, ThreadSessionResponse, ThreadStartRequest,
 	ThreadStatusChangedNotification, ToolRequestUserInputResponse, TurnCompletedNotification,
 	TurnError, TurnInterruptRequest, TurnStartRequest, TurnSteerRequest, UserInput,
-	app_server_dynamic_tool_specs,
 };
 use crate::{
 	agent::{
@@ -3300,11 +3299,11 @@ fn validate_generated_method_union(
 	let missing_or_mismatched = required_methods
 		.iter()
 		.filter_map(|(method, expected_ref)| match method_refs.get(*method) {
-			Some(actual_ref) if actual_ref.as_deref() == expected_ref_to_option(*expected_ref) =>
+			Some(actual_ref) if actual_ref.as_deref() == expected_ref_to_option(expected_ref) =>
 				None,
 			Some(actual_ref) => Some(format!(
 				"{method} expected {} got {}",
-				expected_ref_display(*expected_ref),
+				expected_ref_display(expected_ref),
 				actual_ref.as_deref().unwrap_or("<no params>")
 			)),
 			None => Some(format!("{method} missing")),
@@ -3410,7 +3409,6 @@ fn validate_generated_dynamic_tool_schema(out_dir: &Path) -> crate::prelude::Res
 			"Generated app-server schema was missing ThreadStartParams dynamicTools schema."
 		);
 	}
-
 	if !found_supported_dynamic_tool_schema {
 		eyre::bail!(
 			"Generated app-server schema does not expose the Decodex-supported 0.141 dynamicTools tagged union."
@@ -4237,7 +4235,7 @@ fn build_thread_start_request(
 		.dynamic_tool_handler
 		.map(validated_dynamic_tool_specs)
 		.transpose()?
-		.map(|tool_specs| app_server_dynamic_tool_specs(&tool_specs));
+		.map(|tool_specs| self::protocol::app_server_dynamic_tool_specs(&tool_specs));
 
 	Ok(ThreadStartRequest {
 		cwd: Some(request.cwd.clone()),

--- a/apps/decodex/src/agent/app_server/protocol.rs
+++ b/apps/decodex/src/agent/app_server/protocol.rs
@@ -359,22 +359,6 @@ pub(super) struct InitializeResponse {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-#[serde(tag = "type")]
-pub(super) enum AppServerDynamicToolSpec {
-	#[serde(rename = "function")]
-	Function {
-		description: String,
-		#[serde(rename = "deferLoading", default, skip_serializing_if = "std::ops::Not::not")]
-		defer_loading: bool,
-		#[serde(rename = "inputSchema")]
-		input_schema: Value,
-		name: String,
-	},
-	#[serde(rename = "namespace")]
-	Namespace { description: String, name: String, tools: Vec<AppServerDynamicToolNamespaceTool> },
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub(super) struct AppServerDynamicToolNamespaceTool {
 	#[serde(rename = "type")]
 	kind: &'static str,
@@ -385,18 +369,6 @@ pub(super) struct AppServerDynamicToolNamespaceTool {
 	input_schema: Value,
 	name: String,
 }
-
-impl AppServerDynamicToolSpec {
-	fn function_from_spec(spec: &DynamicToolSpec) -> Self {
-		Self::Function {
-			description: spec.description.clone(),
-			defer_loading: spec.defer_loading,
-			input_schema: spec.input_schema.clone(),
-			name: spec.name.clone(),
-		}
-	}
-}
-
 impl AppServerDynamicToolNamespaceTool {
 	fn from_spec(spec: &DynamicToolSpec) -> Self {
 		Self {
@@ -407,34 +379,6 @@ impl AppServerDynamicToolNamespaceTool {
 			name: spec.name.clone(),
 		}
 	}
-}
-
-pub(super) fn app_server_dynamic_tool_specs(
-	tool_specs: &[DynamicToolSpec],
-) -> Vec<AppServerDynamicToolSpec> {
-	let mut app_server_specs = Vec::new();
-	let mut namespace_tools = BTreeMap::<String, Vec<AppServerDynamicToolNamespaceTool>>::new();
-
-	for spec in tool_specs {
-		if let Some(namespace) = spec.namespace.as_deref() {
-			namespace_tools
-				.entry(namespace.to_owned())
-				.or_default()
-				.push(AppServerDynamicToolNamespaceTool::from_spec(spec));
-		} else {
-			app_server_specs.push(AppServerDynamicToolSpec::function_from_spec(spec));
-		}
-	}
-
-	for (namespace, tools) in namespace_tools {
-		app_server_specs.push(AppServerDynamicToolSpec::Namespace {
-			description: format!("Dynamic tools in the {namespace} namespace."),
-			name: namespace,
-			tools,
-		});
-	}
-
-	app_server_specs
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -489,29 +433,6 @@ pub(super) struct ThreadArchiveRequest {
 
 #[derive(Debug, Deserialize)]
 pub(super) struct ThreadArchiveResponse {}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(super) enum ThreadGoalStatus {
-	Active,
-	Paused,
-	Blocked,
-	UsageLimited,
-	BudgetLimited,
-	Complete,
-}
-impl ThreadGoalStatus {
-	pub(super) const fn as_str(self) -> &'static str {
-		match self {
-			Self::Active => "active",
-			Self::Paused => "paused",
-			Self::Blocked => "blocked",
-			Self::UsageLimited => "usageLimited",
-			Self::BudgetLimited => "budgetLimited",
-			Self::Complete => "complete",
-		}
-	}
-}
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1070,6 +991,55 @@ impl DynamicToolHandler for ProbeDynamicToolHandler {
 	}
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(tag = "type")]
+pub(super) enum AppServerDynamicToolSpec {
+	#[serde(rename = "function")]
+	Function {
+		description: String,
+		#[serde(rename = "deferLoading", default, skip_serializing_if = "std::ops::Not::not")]
+		defer_loading: bool,
+		#[serde(rename = "inputSchema")]
+		input_schema: Value,
+		name: String,
+	},
+	#[serde(rename = "namespace")]
+	Namespace { description: String, name: String, tools: Vec<AppServerDynamicToolNamespaceTool> },
+}
+impl AppServerDynamicToolSpec {
+	fn function_from_spec(spec: &DynamicToolSpec) -> Self {
+		Self::Function {
+			description: spec.description.clone(),
+			defer_loading: spec.defer_loading,
+			input_schema: spec.input_schema.clone(),
+			name: spec.name.clone(),
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) enum ThreadGoalStatus {
+	Active,
+	Paused,
+	Blocked,
+	UsageLimited,
+	BudgetLimited,
+	Complete,
+}
+impl ThreadGoalStatus {
+	pub(super) const fn as_str(self) -> &'static str {
+		match self {
+			Self::Active => "active",
+			Self::Paused => "paused",
+			Self::Blocked => "blocked",
+			Self::UsageLimited => "usageLimited",
+			Self::BudgetLimited => "budgetLimited",
+			Self::Complete => "complete",
+		}
+	}
+}
+
 #[derive(Serialize)]
 #[serde(tag = "type")]
 pub(super) enum LoginAccountParams {
@@ -1119,6 +1089,33 @@ pub(super) enum PermissionGrantScope {
 pub(super) enum UserInput {
 	#[serde(rename = "text")]
 	Text { text: String },
+}
+
+pub(super) fn app_server_dynamic_tool_specs(
+	tool_specs: &[DynamicToolSpec],
+) -> Vec<AppServerDynamicToolSpec> {
+	let mut app_server_specs = Vec::new();
+	let mut namespace_tools = BTreeMap::<String, Vec<AppServerDynamicToolNamespaceTool>>::new();
+
+	for spec in tool_specs {
+		if let Some(namespace) = spec.namespace.as_deref() {
+			namespace_tools
+				.entry(namespace.to_owned())
+				.or_default()
+				.push(AppServerDynamicToolNamespaceTool::from_spec(spec));
+		} else {
+			app_server_specs.push(AppServerDynamicToolSpec::function_from_spec(spec));
+		}
+	}
+	for (namespace, tools) in namespace_tools {
+		app_server_specs.push(AppServerDynamicToolSpec::Namespace {
+			description: format!("Dynamic tools in the {namespace} namespace."),
+			name: namespace,
+			tools,
+		});
+	}
+
+	app_server_specs
 }
 
 fn string_like_json_value(value: &Value) -> Option<String> {

--- a/apps/decodex/src/agent/app_server/tests.rs
+++ b/apps/decodex/src/agent/app_server/tests.rs
@@ -14,6 +14,8 @@ use tempfile::TempDir;
 use crate::{
 	agent::{
 		app_server::{
+			APP_SERVER_REQUIRED_CLIENT_NOTIFICATIONS, APP_SERVER_REQUIRED_CLIENT_REQUESTS,
+			APP_SERVER_REQUIRED_SERVER_NOTIFICATIONS, APP_SERVER_REQUIRED_SERVER_REQUESTS,
 			APP_SERVER_SCHEMA_REQUIRED_MARKERS, AppServerCapabilityPreflightFailure,
 			AppServerCapabilityPreflightReport, AppServerDynamicToolFailure,
 			AppServerPhaseGoalFailure, AppServerRunResult, AppServerThreadArchiveOutcome,
@@ -596,6 +598,7 @@ fn generated_schema_marker_validation_accepts_required_markers() {
 		.to_string(),
 	)
 	.expect("schema fixture should write");
+
 	write_app_server_method_union_fixtures(temp_dir.path(), None);
 
 	super::validate_generated_app_server_schema(temp_dir.path())
@@ -604,10 +607,10 @@ fn generated_schema_marker_validation_accepts_required_markers() {
 
 fn write_app_server_method_union_fixtures(root: &Path, omitted: Option<(&str, &str)>) {
 	for (title, required_methods) in [
-		("ClientRequest", super::APP_SERVER_REQUIRED_CLIENT_REQUESTS),
-		("ServerRequest", super::APP_SERVER_REQUIRED_SERVER_REQUESTS),
-		("ClientNotification", super::APP_SERVER_REQUIRED_CLIENT_NOTIFICATIONS),
-		("ServerNotification", super::APP_SERVER_REQUIRED_SERVER_NOTIFICATIONS),
+		("ClientRequest", APP_SERVER_REQUIRED_CLIENT_REQUESTS),
+		("ServerRequest", APP_SERVER_REQUIRED_SERVER_REQUESTS),
+		("ClientNotification", APP_SERVER_REQUIRED_CLIENT_NOTIFICATIONS),
+		("ServerNotification", APP_SERVER_REQUIRED_SERVER_NOTIFICATIONS),
 	] {
 		let branches = required_methods
 			.iter()
@@ -750,6 +753,7 @@ fn generated_schema_marker_validation_rejects_missing_owned_method() {
 		.to_string(),
 	)
 	.expect("schema fixture should write");
+
 	write_app_server_method_union_fixtures(temp_dir.path(), Some(("ClientRequest", "turn/start")));
 
 	let error = super::validate_generated_app_server_schema(temp_dir.path())
@@ -864,6 +868,7 @@ fn thread_start_and_resume_requests_inherit_runtime_config() {
 #[test]
 fn thread_start_serializes_dynamic_tools_with_app_server_141_shape() {
 	struct MixedDynamicToolHandler;
+
 	impl DynamicToolHandler for MixedDynamicToolHandler {
 		fn tool_specs(&self) -> Vec<DynamicToolSpec> {
 			let local_tool = DynamicToolSpec::new(
@@ -909,7 +914,6 @@ fn thread_start_serializes_dynamic_tools_with_app_server_141_shape() {
 	assert_eq!(dynamic_tools[0]["name"], "local_tool");
 	assert_eq!(dynamic_tools[0]["description"], "Test local tool.");
 	assert!(dynamic_tools[0].get("namespace").is_none());
-
 	assert_eq!(dynamic_tools[1]["type"], "namespace");
 	assert_eq!(dynamic_tools[1]["name"], "tracker");
 	assert_eq!(dynamic_tools[1]["description"], "Dynamic tools in the tracker namespace.");

--- a/apps/decodex/src/cli.rs
+++ b/apps/decodex/src/cli.rs
@@ -1801,8 +1801,8 @@ mod tests {
 
 	use clap::Parser;
 
-	use crate::mcp;
-	use crate::{cli::{
+	use crate::{
+		cli::{
 			AccountCommand, AccountSubcommand, AccountUseCommand, AppCommand, AttemptCommand, Cli,
 			Command, CommitCommand, DiagnoseCommand, DocsCommand, DocsRouteCommand, DocsSubcommand,
 			EvidenceCommand, IntakeCommand, IntakeGoalCommand, IntakeIssuesCommand,
@@ -1815,7 +1815,10 @@ mod tests {
 			ReviewHandoffAdoptCommand, ReviewHandoffDiagnoseCommand, ReviewHandoffRebindCommand,
 			ReviewHandoffRecoveryCommand, ReviewHandoffRecoverySubcommand, RunCommand,
 			ServeCommand, StatusCommand,
-		}, mcp::{McpCapabilityProfile, McpTransport}};
+		},
+		mcp,
+		mcp::{McpCapabilityProfile, McpTransport},
+	};
 
 	#[test]
 	fn parses_app_command() {

--- a/apps/decodex/src/mcp.rs
+++ b/apps/decodex/src/mcp.rs
@@ -16,14 +16,25 @@ use serde::{Deserialize, Serialize};
 use serde_json::{self, Value};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
-use crate::{config::ServiceConfig, loop_contract::{DecisionPromotion, DecisionPromotionActorKind}, orchestrator::{self, DEFAULT_STEER_RESULT_WAIT_TIMEOUT, McpLaneSteerRequest}, prelude::eyre, program_intake::{
+use crate::{
+	config::ServiceConfig,
+	loop_contract::{DecisionPromotion, DecisionPromotionActorKind},
+	orchestrator::{self, DEFAULT_STEER_RESULT_WAIT_TIMEOUT, McpLaneSteerRequest},
+	prelude::eyre,
+	program_intake::{
 		self, GoalIntakeCommandRequest, GoalIntakeIssueReport, GoalIntakeReport,
 		GoalIntakeRunRequest,
-	}, research_design::{
+	},
+	research_design::{
 		self, ResearchDesignOutcome, ResearchDesignRunInput, ResearchDesignRunReport,
-	}, runtime, state::StateStore, tracker::{
+	},
+	runtime,
+	state::StateStore,
+	tracker::{
 		IssueTracker, TrackerComment, TrackerIssue, TrackerIssueBriefUpdate, TrackerIssueCreate,
-	}, workflow::WorkflowDocument};
+	},
+	workflow::WorkflowDocument,
+};
 
 /// Safe default listen address for Streamable HTTP MCP.
 pub(crate) const DEFAULT_MCP_HTTP_LISTEN_ADDRESS: &str = "127.0.0.1:8193";
@@ -285,10 +296,10 @@ impl McpServer {
 					"mimeType": "text/markdown"
 				},
 				{
-					"uriTemplate": "decodex://docs/research/{topic}",
-					"name": "Decodex research concepts",
-					"description": "Checked-in latent Markdown research concepts.",
-					"mimeType": "text/markdown"
+					"uriTemplate": "decodex://research/{artifact}",
+					"name": "Decodex research reports",
+					"description": "Checked-in JSON research reports.",
+					"mimeType": "application/json"
 				},
 				{
 					"uriTemplate": "decodex://decision-contracts/{contract_id}",
@@ -4953,6 +4964,7 @@ mod tests {
 			.collect::<Vec<_>>();
 
 		assert!(uri_templates.contains(&"decodex://docs/spec/{topic}"));
+		assert!(uri_templates.contains(&"decodex://research/{artifact}"));
 		assert!(uri_templates.contains(&"decodex://projects/{project_id}/lane-control/{issue}"));
 		assert!(uri_templates.contains(&"decodex://projects/{project_id}/status_live"));
 		assert!(uri_templates.contains(&"decodex://projects/{project_id}/activity_tail"));

--- a/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
+++ b/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
@@ -74,7 +74,7 @@ Non-goals:
 | Keep skills-only architecture | Rejected | Skills are good at static routing but poor at fresh state, structured readback, typed mutation, and external source freshness. Large skills also increase token load and drift. |
 | Replace skills with MCP-only architecture | Rejected | MCP can expose capabilities, but it does not by itself teach the agent when a Decodex authority boundary applies. A small skill layer is still the right installable policy surface. |
 | Build a hybrid MCP gateway and slim skills | Selected | MCP owns dynamic resources, prompts, and tools; skills own trigger routing, safety boundaries, and progressive disclosure. This uses each surface for the behavior it is best at. |
-| Remote HTTP MCP first | Deferred | Streamable HTTP is useful for app/server integration, but local stdio is simpler for first implementation and avoids premature auth and multi-client complexity. |
+| Remote HTTP MCP first | Rejected for the first slice; implemented as follow-up transport | Local stdio was simpler for the core protocol slice. Streamable HTTP is now the remote-control-capable transport, with loopback binding, origin validation, session handling, SSE framing, and an `observe` default profile. |
 
 ## Architecture
 
@@ -106,18 +106,22 @@ Layer responsibilities:
 
 ## MCP Surface Target
 
-This section describes the complete promoted MCP direction across the generated issue
-set, not the surface delivered by the first core-protocol lane alone. The first
-implementation slice, XY-994, owns the stdio primitive gateway: `initialize`,
-`resources/list`, `resources/read`, `resources/templates/list`, `prompts/list`,
-`prompts/get`, `tools/list`, `tools/call`, `logging/setLevel`, progress notifications,
-profile-tagged tool discovery, and structured refusal behavior for deferred
-operate/admin entries. The follow-up transport slice adds Streamable HTTP for the same
-gateway at `POST /mcp`, with loopback default binding, browser-origin validation,
-session headers, JSON responses, SSE framing for progress/notifications, and an
-`observe` default profile for remote-safe access. Richer live research/intake planning
-tools, live lane-control/admin mutation, and skill slimming remain separate follow-up
-lanes from the accepted Decision Contract.
+This section describes the promoted complete MCP gateway. Decodex serves the same
+gateway through local stdio and remote-control-capable Streamable HTTP. Stdio is for
+desktop and CLI clients, defaults to the `admin` capability profile, and keeps stdout
+valid JSON-RPC only. Streamable HTTP is available at `POST /mcp`, binds to loopback by
+default, defaults to `observe`, validates browser origins, issues MCP session headers,
+requires a known session after initialization, returns JSON-RPC JSON by default, and
+uses SSE framing for progress or notifications when the client accepts
+`text/event-stream`.
+
+The gateway advertises resources, resource templates, prompts, tools, logging
+compatibility, progress notifications, active capability-profile metadata, and
+structured refusal behavior. Remote control means a permitted MCP client can observe
+and request lane-control or project-control actions against this Decodex server through
+capability profiles and Decodex authority checks. It does not mean arbitrary public
+internet clients can reach the daemon or that MCP tools can bypass Decision Contract,
+lane-control, review, landing, tracker, or runtime semantics.
 
 Resources:
 
@@ -126,10 +130,18 @@ Resources:
 - `decodex://docs/runbook/{topic}`
 - `decodex://docs/reference/{topic}`
 - `decodex://docs/decisions/{topic}`
-- `decodex://skills/{skill_name}`
+- `decodex://research/{artifact}`
 - `decodex://decision-contracts/{contract_id}`
 - `decodex://projects/{service_id}/status`
-- `decodex://projects/{service_id}/agent-evidence/{issue_id}`
+- `decodex://projects/{service_id}/status_live`
+- `decodex://projects/{service_id}/activity_tail`
+- `decodex://projects/{service_id}/lane-control`
+- `decodex://projects/{service_id}/lane_inspect/{issue}`
+- `decodex://projects/{service_id}/runs/{run_id}/events`
+- `decodex://projects/{service_id}/runs/{run_id}/protocol_activity`
+- `decodex://projects/{service_id}/runs/{run_id}/child_agent_activity`
+- `decodex://projects/{service_id}/runs/{run_id}/progress_diagnostics`
+- `decodex://projects/{service_id}/pr_review_state`
 
 Prompts:
 
@@ -170,6 +182,9 @@ Tool rules:
 
 - Read-only tools may run without promotion when they only expose public-safe state.
 - Mutating tools must require explicit authority and return structured results.
+- Mutating tools are inspect-first and must require current-lane preconditions such as
+  run id, inspected run id, and expected turn id when the requested action depends on
+  a live turn.
 - Tools must not expose raw private evidence, credentials, transcript text, hidden
   graph ids, or local paths unless the governing Decodex surface allows it.
 - Every mutating result should include `status`, `authority_source`, `changed_surfaces`,
@@ -203,10 +218,10 @@ Target shape:
 
 ## Validation Expectations
 
-- `plugin-eval analyze` on changed research skills should find no critical routing,
-  safety, or progressive-disclosure issue.
-- `cargo test -p decodex plugin_surface_tests research_design` should pass after
-  schema and packaged-skill changes.
+- `plugin-eval analyze` on changed Decodex plugin skills should find no critical
+  routing, safety, or progressive-disclosure issue.
+- `cargo test -p decodex plugin_surface_tests -- --nocapture` should pass after
+  packaged-skill changes.
 - `git diff --check` should pass.
 - The stdio MCP primitive implementation should pass initialize, resources/list,
   resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, progress
@@ -214,18 +229,18 @@ Target shape:
   JSON POST, SSE response, origin rejection, session handling, observe-profile access,
   operate/admin profile-refusal coverage, and remote-safe observability template
   coverage for live status, activity tail, current/recent status-window run
-  event/protocol/child/progress readback, lane inspect, and PR/review state. Live
-  operate/admin lane-control behavior should remain separate follow-up work.
+  event/protocol/child/progress readback, lane inspect, and PR/review state. Operate
+  and admin tools should pass inspect-first authority, current run/turn precondition,
+  explicit-authority refusal, and unsupported-shortcut refusal coverage.
 
-## Open Follow-Up
+## Remaining Boundaries
 
-The promoted implementation now has the stdio gateway exposed as
+The promoted implementation has the stdio gateway exposed as
 `decodex mcp serve --transport stdio` and the remote-capable Streamable HTTP gateway
 exposed as `decodex mcp serve --transport streamable-http`. It advertises resources,
 resource templates, prompts, and a schema-bound tool catalog while keeping mutating
-operate/admin behavior behind inspect-first authority checks and structured refusal
-states. XY-996 adds the remote-safe observability templates and projections on top of
-that transport; promoted work keeps the schema-bound `research_compile`,
-`research_promote`, and `intake_goal` planning tools separate from live
-lane-control/project-control tools, skill-slimming eval, and docs/resource validation
-lanes so mutating MCP tools do not bypass Decision Contract or lane-control authority.
+planning, operate, and admin behavior behind explicit capability profiles, authority
+fields, inspect-first preconditions, and structured refusal states. Further expansion
+must keep the catalog deliberately small and route new mutating behavior through
+Decodex's existing runtime, tracker, review, landing, and lane-control authority
+surfaces instead of adding one tool per CLI command.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,12 @@
 
 ## 2026-06-18
 
+- Updated the MCP decision record, operator-control reference, resource-template
+  readback, and Decodex plugin routing so complete remote MCP now points agents toward
+  capability-profiled observe/plan/operate/admin resources, prompts, and tools.
+- Preserved the existing `decodex://research/{artifact}` checked-in JSON research
+  report resource contract for MCP while leaving the known docs/research format policy
+  conflict for a separate accepted decision.
 - Promoted MCP operate/admin docs from deferred stubs to the implemented
   inspect-first `decodex_lane_control` and future-dispatch-only
   `decodex_project_control` authority model.
@@ -27,7 +33,8 @@
   resource templates, prompts, tools, logging, and progress compatibility; stdio smoke
   coverage now exercises resources/templates/list, prompts/list, prompts/get,
   tools/list, tools/call, active capability-profile filtering, and stdout cleanliness
-  while Streamable HTTP and live operate/admin lane-control remain deferred.
+  as the first MCP slice before the later Streamable HTTP and operate/admin
+  promotions.
 - Added `repo-memory-evaluator` so repo-memory OKF/LLM Wiki bundles have a
   plugin-eval-style quality workflow for static checks, route top-1/top-3 benchmarks,
   graph health, owner coverage, and before/after curation evidence.

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -353,10 +353,12 @@ command surface.
 After a steer request is handled, current lane protocol activity may show a compact
 `turn/steer` entry with outcome, failure class, and response turn id. It does not
 include the operator message.
-MCP lane-control resources are readback only and mirror the local status/inspect
-projection. Operators must still use `decodex lane inspect`, `decodex lane interrupt`,
-`decodex lane steer`, or the local `/api/lane/*` endpoints for supported CLI/API
-controls.
+MCP lane-control resources remain readback only and mirror the local status/inspect
+projection. Remote-control-capable MCP clients request lane-control actions through the
+profile-gated `decodex_lane_control` tool, which uses the same inspect-first
+preconditions, run/turn authority, local audit records, and structured refusals as the
+supported `decodex lane inspect`, `decodex lane interrupt`, `decodex lane steer`, and
+local `/api/lane/*` endpoints.
 Snapshot `warnings` remain stable machine-readable tokens. When a warning needs
 operator action, snapshots may also include `warning_details` entries with the
 affected `project_id`, `repo_root`, reason, and next action; for example, a stale

--- a/plugins/decodex/references/routing.md
+++ b/plugins/decodex/references/routing.md
@@ -28,7 +28,10 @@ labels, automation, commit, or landing boundaries.
   not as a replacement for Decision Contract, lane-control, tracker, review, landing,
   or closeout gates. Planning tools are deliberately small: `research_compile`,
   `research_promote`, and `intake_goal` expose dry-run/apply boundaries with explicit
-  authority requirements for apply/promote calls.
+  authority requirements for apply/promote calls. Operate/admin tools stay
+  inspect-first: `decodex_lane_control` requires lane identity plus current run/turn
+  preconditions for steer or interrupt, and `decodex_project_control` limits
+  pause/resume to future dispatch while refusing standalone scan shortcuts.
 
 ## First Reads
 

--- a/plugins/decodex/skills/automation/SKILL.md
+++ b/plugins/decodex/skills/automation/SKILL.md
@@ -11,6 +11,9 @@ details.
 
 - Confirm authority before tracker or runtime mutation.
 - Inspect `decodex status` or `decodex lane inspect <ISSUE>` first.
+- When an MCP client is available, use `decodex_observe` and remote-safe resources for
+  readback, `decodex_lane_control` for inspect-first steer/interrupt requests, and
+  `decodex_project_control` only for project status or future-dispatch pause/resume.
 - Use Program Intake for accepted Program work.
 - Use `labels` only for ordinary non-Program issue intake.
 - Treat `decodex:needs-attention` and `terminal_pending` as stop signals.

--- a/plugins/decodex/skills/decodex/SKILL.md
+++ b/plugins/decodex/skills/decodex/SKILL.md
@@ -25,7 +25,10 @@ chosen local listener, tunnel, or relay. MCP tools do not bypass Decision Contra
 lane-control, review, landing, tracker, or runtime authority gates. Route MCP planning
 through `research_compile`, `research_promote`, and `intake_goal`; dry-run modes stay
 non-mutating, and apply/promote modes require explicit authority fields and structured
-refusal when authority is missing.
+refusal when authority is missing. Route MCP remote control through `decodex_observe`,
+`decodex_lane_control`, and `decodex_project_control`: observe is public-safe
+readback, lane control is inspect-first with current run/turn preconditions, and
+project control is future-dispatch-only for pause/resume.
 
 Research is latent until promoted. Program Intake is not queue-label polling.
 Decodex-owned landing uses `decodex land`, not raw GitHub merge paths.

--- a/plugins/decodex/skills/planning/SKILL.md
+++ b/plugins/decodex/skills/planning/SKILL.md
@@ -22,4 +22,7 @@ quality.
 - For existing issue-batch intake, hold issues that lack a generic dispatch briefing
   instead of treating machine-only blocks, private pointers, progress checkpoints, or
   review summaries as executable issue text.
+- When an MCP client is available, prefer `research_promote` and `intake_goal` for
+  typed readiness/apply boundaries; dry-run stays non-mutating and apply requires
+  explicit authority.
 - Do not replace `WORKFLOW.md`, mutate active state, or queue latent research.


### PR DESCRIPTION
## Summary
- update the MCP decision and operator-control docs to reflect complete stdio + Streamable HTTP gateway behavior, capability profiles, and inspect-first lane/project control tools
- point Decodex skills/routing at the small MCP observe/plan/operate/admin facade without bypassing Decodex authority gates
- preserve the existing `decodex://research/{artifact}` JSON research resource contract and record the broader docs/research policy conflict as separate decision work
- include repo-gate style/canonicalization fixes in app-server/CLI surfaces left by the retained lane

## Validation
- `git diff --check`
- `cargo make fmt-check`
- `cargo make check-docs`
- `cargo test -p decodex plugin_surface_tests -- --nocapture`
- `cargo test -p decodex mcp::tests -- --nocapture`
- `cargo test -p decodex app_server -- --nocapture`
- `cargo test -p decodex mcp::tests::streamable_http_resources_read_exposes_observability_resources -- --nocapture` after one full-suite flaky failure
- `cargo make test` passed on rerun: 1273 passed, 1 skipped

Related: XY-999