### PR TITLE
Promote OKF research lifecycle model

### DIFF
--- a/apps/decodex/src/docs_okf.rs
+++ b/apps/decodex/src/docs_okf.rs
@@ -42,7 +42,7 @@ const ALLOWED_STATUSES: &[&str] = &["draft", "active", "deprecated", "superseded
 const ALLOWED_AUTHORITIES: &[&str] =
 	&["normative", "procedural", "current_state", "rationale", "evidence", "non_authoritative"];
 const ALLOWED_PROMOTION_TARGETS: &[&str] =
-	&["docs/spec", "docs/runbook", "docs/reference", "docs/decisions"];
+	&["docs/spec", "docs/runbook", "docs/reference", "docs/decisions", "docs/evidence"];
 const RESEARCH_CONTRACT_HEADINGS: &[&str] = &[
 	"Question",
 	"Scope",

--- a/apps/decodex/src/plugin_surface_tests.rs
+++ b/apps/decodex/src/plugin_surface_tests.rs
@@ -266,10 +266,10 @@ fn packaged_skills_preserve_research_promotion_and_queue_boundaries() {
 	assert_contains(&skill_surface, "Promotion is a separate authority step");
 	assert_contains(&skill_surface, "after execution authority exists");
 	assert_contains(&skill_surface, "non-research targets");
-	assert_contains_normalized(
-		&skill_surface,
-		"current facts and contracts stand without reading research",
-	);
+	assert_contains(&skill_surface, "OKF owner");
+	assert_contains(&skill_surface, "docs/evidence");
+	assert_contains(&skill_surface, "LLM Wiki indexes");
+	assert_contains_normalized(&skill_surface, "current truth stands without reading research");
 	assert_contains(&skill_surface, "current truth independently");
 	assert_contains_normalized(&skill_surface, "does not queue work, mutate Linear");
 	assert_contains(&skill_surface, "ordinary non-Program issue intake");
@@ -332,10 +332,14 @@ fn packaged_research_skills_encode_decodex_methodology() {
 		&research_surface,
 		"research-only evidence versus durable knowledge candidates",
 	);
+	assert_contains(&research_surface, "OKF disposition");
+	assert_contains(&research_surface, "promote_and_supersede");
+	assert_contains(&research_surface, "promote_and_retire");
+	assert_contains(&research_surface, "reject_or_deprecate");
 	assert_contains(&research_surface, "target repo");
-	assert_contains(&research_surface, "Durable knowledge candidates are accepted facts");
-	assert_contains(&research_surface, "facts, policies, specs, runbooks");
-	assert_contains(&research_surface, "Research is provenance, not source of truth");
+	assert_contains(&research_surface, "docs/decisions");
+	assert_contains(&research_surface, "docs/evidence");
+	assert_contains_normalized(&research_surface, "out-of-band history");
 	assert_contains(&research_surface, "Use `no_promotion` only when");
 	assert_contains(&research_surface, "Program Intake");
 }
@@ -356,6 +360,8 @@ fn packaged_docs_skills_encode_okf_wiki_and_drift_boundaries() {
 	assert_contains(&docs_surface, "docs impact");
 	assert_contains(&docs_surface, "research_required");
 	assert_contains(&docs_surface, "one authoritative concept per claim");
+	assert_contains_normalized(&docs_surface, "superseded research routes as provenance");
+	assert_contains(&docs_surface, "`docs/evidence`");
 	assert_contains(&docs_surface, "pass`, `fail`, or `needs-human");
 	assert_contains(&docs_surface, "Do not create a parallel `wiki/` or `okf/` root");
 	assert_not_contains(&docs_surface, "Okf");

--- a/apps/decodex/src/plugin_surface_tests.rs
+++ b/apps/decodex/src/plugin_surface_tests.rs
@@ -246,7 +246,7 @@ fn packaged_plugin_manifest_routes_natural_language_research_to_decodex() {
 #[test]
 fn packaged_skills_preserve_research_promotion_and_queue_boundaries() {
 	let skill_surface = format!(
-		"{DECODEX_SKILL}\n{PLANNING_SKILL}\n{AUTOMATION_SKILL}\n{LABELS_SKILL}\n{RESEARCH_SKILL}\n{ROUTING_REF}\n{RESEARCH_LIFECYCLE_REF}\n{RESEARCH_PROMOTION_REF}"
+		"{DECODEX_SKILL}\n{PLANNING_SKILL}\n{AUTOMATION_SKILL}\n{LABELS_SKILL}\n{RESEARCH_SKILL}\n{RESEARCH_PROMOTE_SKILL}\n{ROUTING_REF}\n{RESEARCH_LIFECYCLE_REF}\n{RESEARCH_PROMOTION_REF}"
 	);
 	let planning_surface = format!("{PLANNING_SKILL}\n{ISSUE_BRIEFING_REF}\n{ROUTING_REF}");
 
@@ -265,6 +265,12 @@ fn packaged_skills_preserve_research_promotion_and_queue_boundaries() {
 	assert_contains_normalized(&skill_surface, "Program Intake dispatches ready mapped nodes");
 	assert_contains(&skill_surface, "Promotion is a separate authority step");
 	assert_contains(&skill_surface, "after execution authority exists");
+	assert_contains(&skill_surface, "non-research targets");
+	assert_contains_normalized(
+		&skill_surface,
+		"current facts and contracts stand without reading research",
+	);
+	assert_contains(&skill_surface, "current truth independently");
 	assert_contains_normalized(&skill_surface, "does not queue work, mutate Linear");
 	assert_contains(&skill_surface, "ordinary non-Program issue intake");
 	assert_contains(&skill_surface, "not queue-label polling");
@@ -291,13 +297,13 @@ fn packaged_research_skills_encode_decodex_methodology() {
 	assert_contains(&research_surface, "default research surface");
 	assert_contains(&research_surface, "probe, evidence, options, judgment, challenge, decision");
 	assert_contains_normalized(&research_surface, "No evidence, no claim");
-	assert_contains_normalized(&research_surface, "runtime state");
+	assert_contains_normalized(&research_surface, "Runtime state");
 	assert_contains(
 		&research_surface,
 		"Do not route Decodex research through external research skills",
 	);
-	assert_contains(&research_surface, "primary hypothesis");
-	assert_contains(&research_surface, "rival hypotheses");
+	assert_contains_normalized(&research_surface, "primary hypothesis");
+	assert_contains_normalized(&research_surface, "rival hypotheses");
 	assert_contains(&research_surface, "falsifiers");
 	assert_contains(&research_surface, "No evidence, no claim");
 	assert_contains(&research_surface, "observations");
@@ -318,10 +324,19 @@ fn packaged_research_skills_encode_decodex_methodology() {
 		"Unresolved material objections block `decision_ready`",
 	);
 	assert_contains(&research_surface, "Use exactly one");
-	assert_contains(&research_surface, "refuse promotion while unresolved decisions");
+	assert_contains(&research_surface, "refuse unresolved decisions");
 	assert_contains(&research_surface, "Promotion is a separate authority step");
 	assert_contains(&research_surface, "Promotion requires explicit acceptance");
 	assert_contains(&research_surface, "Do not infer acceptance");
+	assert_contains(
+		&research_surface,
+		"research-only evidence versus durable knowledge candidates",
+	);
+	assert_contains(&research_surface, "target repo");
+	assert_contains(&research_surface, "Durable knowledge candidates are accepted facts");
+	assert_contains(&research_surface, "facts, policies, specs, runbooks");
+	assert_contains(&research_surface, "Research is provenance, not source of truth");
+	assert_contains(&research_surface, "Use `no_promotion` only when");
 	assert_contains(&research_surface, "Program Intake");
 }
 

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -29,6 +29,9 @@ Question this index answers: "why was it designed this way?"
 - [`mcp-capability-gateway-and-skill-slimming.md`](./mcp-capability-gateway-and-skill-slimming.md)
   records why Decodex should introduce an MCP capability gateway while slimming
   skills into static routing, authority, and safety entrypoints.
+- [`okf-research-knowledge-lifecycle.md`](./okf-research-knowledge-lifecycle.md)
+  records why research promotion is an OKF knowledge operation and how LLM Wiki
+  hygiene keeps `docs/research/` from competing with authoritative owners.
 - [`static-public-site.md`](./static-public-site.md) records why the public Decodex site
   remains static while runtime/operator behavior stays in the CLI and local control
   plane.

--- a/docs/decisions/okf-research-knowledge-lifecycle.md
+++ b/docs/decisions/okf-research-knowledge-lifecycle.md
@@ -1,0 +1,73 @@
+---
+type: "Decision"
+title: "OKF Research Knowledge Lifecycle"
+description: "Defines how Decodex promotes research into OKF owners while preserving LLM Wiki retrieval quality."
+status: active
+authority: rationale
+owner: docs
+tags: [decision, okf, research, llm-wiki]
+code_refs: [apps/decodex/src/docs_okf.rs, apps/decodex/src/plugin_surface_tests.rs, plugins/decodex/references/research-promotion.md, plugins/decodex/references/docs-wiki.md]
+related: [../policy.md, ../reference/research-concepts.md, ../research/index.md, ../evidence/index.md, ../spec/okf-knowledge-layer.md]
+last_verified: 2026-06-18
+---
+
+# OKF Research Knowledge Lifecycle
+
+Status: accepted
+Date: 2026-06-18
+Question: How should Decodex manage research promotion in an OKF knowledge base that
+is also used as an LLM Wiki?
+
+## Context
+
+`docs/research/` is useful for bounded investigation, but LLM agents route through
+indexes, frontmatter, links, and short descriptions. If accepted research continues to
+carry current facts or rationale, retrieval can surface non-authoritative research
+before the concept that owns the truth.
+
+## Decision
+
+Research promotion is an OKF knowledge operation. Accepted research is split by owner:
+
+- durable rationale, selected tradeoffs, and rejected alternatives move to
+  `docs/decisions/`
+- required behavior, schemas, state, and invariants move to `docs/spec/`
+- current implementation facts and structure move to `docs/reference/`
+- operator procedures move to `docs/runbook/`
+- reusable proof and drift-audit material move to `docs/evidence/`
+- agent-facing workflow rules move to `plugins/decodex/skills/`
+- executable behavior and verification authority move to code and tests
+
+`docs/research/` keeps only active unresolved research or explicitly superseded
+provenance. It is not a facts database, decisions database, evidence database, or
+history fallback.
+
+## Disposition
+
+Every completed research concept receives one knowledge disposition:
+
+- `continue`: unresolved work remains active in `docs/research/`
+- `promote_and_supersede`: durable owners receive the accepted knowledge, while a
+  compact `status: superseded` research concept remains for provenance
+- `promote_and_retire`: durable owners fully absorb the knowledge, and research leaves
+  active LLM Wiki routing
+- `reject_or_deprecate`: rejected or stale research is kept only when it has retrieval
+  value as a decision, evidence concept, or `status: deprecated` research concept
+
+## LLM Wiki Hygiene
+
+Promotion must update lane indexes, `related`, `promotes_to`, descriptions, and
+status fields. Superseded research may point to authoritative owners, but it must not
+repeat current truth or compete with those owners in normal routing.
+
+Knowledge retention must be explicit in OKF concepts and links rather than relying on
+out-of-band history.
+
+## Consequences
+
+- `docs/decisions/` is the durable owner for rationale produced by accepted research.
+- `docs/evidence/` is a valid promotion target when research yields reusable proof.
+- `docs/research/` stays useful for investigation and provenance without becoming a
+  parallel authority lane.
+- Plugin skills must route future agents through owner concepts first and research
+  only when the task asks for latent evidence, unresolved questions, or provenance.

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,8 @@ The split below is by question type, not by human-versus-agent audience.
 - Need rationale for keeping execution-graph semantics internal behind a
   natural-language user surface ->
   `docs/decisions/natural-language-loop-runtime.md`
+- Need rationale for OKF research promotion, research concept disposition, or LLM Wiki
+  retrieval hygiene -> `docs/decisions/okf-research-knowledge-lifecycle.md`
 - Need rationale for Decodex MCP integration, MCP/skills/docs/runtime boundaries, or
   skill slimming -> `docs/decisions/mcp-capability-gateway-and-skill-slimming.md`
 - Need research concepts, supporting research evidence, or the implemented/superseded
@@ -72,7 +74,7 @@ The split below is by question type, not by human-versus-agent audience.
 - Need docs-impact classification `research_required` -> switch from the docs router
   to `plugins/decodex/skills/research*/`; checked-in output under `docs/research/`
   stays latent and non-authoritative until promoted into `spec`, `runbook`,
-  `reference`, or `decisions`
+  `reference`, `decisions`, or `evidence`
 - Need a semantic-drift audit concept, stale-claim evidence, or docs/code alignment
   verdict -> `docs/evidence/index.md` and
   `plugins/decodex/skills/docs-drift/SKILL.md`
@@ -108,5 +110,7 @@ The split below is by question type, not by human-versus-agent audience.
 - Keep links explicit and stable.
 - Treat `docs/research/` as a Markdown OKF research concept lane, not as a primary
   authority lane or JSON event-log write target.
+- Treat promotion as an OKF/LLM Wiki maintenance event: update owner concepts,
+  statuses, indexes, and links so superseded research does not outrank authority.
 - Treat Decodex research output as latent until accepted or promoted through the
   loop-runtime contract in `docs/spec/loop-runtime.md`.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-18
 
+- Added the OKF research knowledge-lifecycle decision and updated research policy,
+  reference, index, checker, and plugin guidance so promotion now routes rationale to
+  decisions, truth to owner lanes, reusable proof to evidence, and superseded
+  research out of active LLM Wiki routing.
 - Updated the MCP decision record, operator-control reference, resource-template
   readback, and Decodex plugin routing so complete remote MCP now points agents toward
   capability-profiled observe/plan/operate/admin resources, prompts, and tools.

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -90,7 +90,7 @@ Recommended keys:
 | `source_refs` | External or public source references. |
 | `code_refs` | Repository-relative code, test, script, or config file paths. |
 | `related` | Related concepts inside the OKF bundle. |
-| `promotes_to` | Target lane when a research concept becomes durable authority. |
+| `promotes_to` | Target lane when a research concept becomes durable knowledge. |
 | `drift_watch` | Commands, paths, labels, statuses, config keys, or schemas watched for semantic drift. |
 
 ## Primary Lanes
@@ -107,7 +107,7 @@ Recommended keys:
 ## Research Contracts
 
 New research output is a Markdown concept under `docs/research/`. A research concept
-is never execution authority by itself.
+is never execution authority or current repository truth by itself.
 
 Research concepts must expose headings with these names. The heading level is not
 semantic; concepts may use a top-level title followed by lower-level contract
@@ -131,12 +131,30 @@ headings.
 - `blocked`
 - `needs_human_decision`
 
-Promotion means updating the target `spec`, `runbook`, `reference`, or `decisions`
-concept and logging the event in `docs/log.md`. When accepted research changes
+Promotion is an OKF knowledge operation. It consumes a research concept by moving
+durable rationale to `docs/decisions/`, normative truth to `docs/spec/`, current
+state to `docs/reference/`, procedures to `docs/runbook/`, and reusable proof or
+drift-audit material to `docs/evidence/`. When accepted research changes
 agent-facing workflow instructions, update the matching `plugins/decodex/skills/`
 surface alongside the selected docs concept; plugin skills are companion execution
-surfaces, not `promotes_to` lanes. Promotion must preserve evidence, constraints,
-rejected alternatives, validation expectations, and drift impacts.
+surfaces, not `promotes_to` lanes.
+
+Each promoted research concept must end with one disposition:
+
+- `continue`: unresolved research remains active.
+- `promote_and_supersede`: durable knowledge moved to owners, but a compact
+  provenance concept remains in `docs/research/` with `status: superseded`.
+- `promote_and_retire`: durable owners fully absorb the knowledge, so the concept is
+  removed from active LLM Wiki routing and indexes.
+- `reject_or_deprecate`: rejected or stale research is represented as a decision,
+  evidence concept, or `status: deprecated` research concept only when it remains
+  useful to retrieval.
+
+Promotion must preserve evidence, constraints, rejected alternatives, validation
+expectations, and drift impacts in the correct OKF owners. Knowledge retention must be
+explicit in OKF concepts, indexes, and links rather than relying on out-of-band
+history. After promotion, `docs/research/` must not compete with the
+authoritative owner in LLM Wiki routing.
 
 ## Semantic Drift
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -35,4 +35,5 @@ Question this index answers: "how is it currently organized or implemented?"
 - [`workspace-layout.md`](./workspace-layout.md) for the repository surface map and
   directory ownership boundaries, including the canonical Decodex plugin source.
 - [`research-concepts.md`](./research-concepts.md) for Markdown OKF research
-  concepts, runtime Decision Contract boundaries, and promotion rules.
+  concepts, runtime Decision Contract boundaries, promotion owners, disposition, and
+  LLM Wiki routing hygiene.

--- a/docs/reference/research-concepts.md
+++ b/docs/reference/research-concepts.md
@@ -1,7 +1,7 @@
 ---
 type: "Reference"
 title: "Research Concepts"
-description: "Explain how Markdown OKF research concepts relate to runtime Decision Contracts and promoted docs authority."
+description: "Explain how Markdown OKF research concepts relate to runtime Decision Contracts, promotion owners, and LLM Wiki routing."
 status: active
 authority: current_state
 owner: docs
@@ -21,8 +21,8 @@ durable docs lane.
 Not this document: The research method itself, the runtime contract, or a durable
 design decision record.
 
-Covers: Concept placement, authority boundaries, required research sections, and
-promotion rules.
+Covers: Concept placement, authority boundaries, required research sections,
+promotion owners, research disposition, and LLM Wiki routing hygiene.
 
 ## Status of `docs/research/`
 
@@ -34,9 +34,9 @@ promotion rules.
 - New Decodex bounded research must not create checked-in JSON event logs.
 - A research concept may contain useful evidence, alternatives, objections, and a
   candidate decision, but it does not by itself define repository truth.
-- A promoted conclusion must update `docs/spec/`, `docs/runbook/`,
-  `docs/reference/`, or `docs/decisions/`; `docs/research/` remains latent and
-  non-authoritative.
+- A promoted conclusion must update the owning concept in `docs/spec/`,
+  `docs/runbook/`, `docs/reference/`, `docs/decisions/`, or `docs/evidence/`;
+  `docs/research/` remains latent or explicitly superseded and non-authoritative.
 - For Decodex-specific loop-runtime work, the Decodex `research*` skills plus
   `decodex research compile` produce a runtime-local `decodex.decision_contract/1`
   candidate. Runtime storage may stay structured for machine use, but checked-in docs
@@ -75,9 +75,32 @@ The `Decision` section must state exactly one terminal status:
   `docs/reference/`.
 - If a research result records a durable tradeoff or design choice, promote the
   conclusion into `docs/decisions/`.
+- If a research result produces reusable proof, public-safe evidence, or drift-audit
+  material, promote that material into `docs/evidence/`.
+- If accepted research changes future agent behavior, update the matching
+  `plugins/decodex/skills/` files alongside the docs owner.
 - If a Decodex-native research/design result should feed issue shaping or unattended
   execution, promote the stored Decision Contract first. Do not infer acceptance from
   a research summary or Markdown concept.
+
+## Research Disposition
+
+- `continue`: unresolved research stays active.
+- `promote_and_supersede`: owner concepts receive the accepted knowledge; a compact
+  `status: superseded` research concept remains only for provenance.
+- `promote_and_retire`: owner concepts fully absorb the knowledge; remove the concept
+  from active LLM Wiki routing and indexes.
+- `reject_or_deprecate`: rejected or stale research remains only when it has retrieval
+  value as a decision, evidence concept, or deprecated research concept.
+
+Research retention is an OKF knowledge decision. Do not rely on out-of-band history
+for knowledge retention.
+
+## LLM Wiki Hygiene
+
+After promotion, update lane indexes, `related`, `promotes_to`, descriptions, and
+status fields so authoritative owners outrank superseded research. A superseded
+research concept may point to owners, but it must not repeat current truth.
 
 ## Practical Reading Rule
 

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -1,22 +1,29 @@
 # Research Index
 
-Purpose: Route agents to Markdown-only research concepts.
+Purpose: Route agents to Markdown-only active or superseded research concepts.
 
 Research output is latent until accepted and promoted. Research concepts preserve
-evidence, options, challenge notes, terminal status, promotion targets, and drift
-impact. They do not authorize implementation by themselves.
+evidence, options, challenge notes, terminal status, promotion targets, drift impact,
+and disposition. They do not authorize implementation or own current truth.
 
 ## Concepts
 
-- [`research-runtime-boundary.md`](research-runtime-boundary.md) defines the current
-  boundary between checked-in Markdown research concepts, runtime Decision Contracts,
-  MCP readback, and future execution research.
+- [`research-runtime-boundary.md`](research-runtime-boundary.md) is superseded
+  provenance for the research runtime-boundary investigation. Current guidance lives
+  in [`../decisions/okf-research-knowledge-lifecycle.md`](../decisions/okf-research-knowledge-lifecycle.md)
+  and [`../reference/research-concepts.md`](../reference/research-concepts.md).
 
 ## Maintenance
 
 - New research concepts must follow [`../policy.md`](../policy.md).
 - Do not add non-Markdown artifacts under `docs/research/`.
-- Promote accepted research into `docs/spec/`, `docs/runbook/`, `docs/reference/`, or
-  `docs/decisions/`, then record the promotion in [`../log.md`](../log.md).
+- Promote accepted research into the correct OKF owners: `docs/decisions/` for
+  rationale, `docs/spec/` for normative truth, `docs/reference/` for current state,
+  `docs/runbook/` for procedures, and `docs/evidence/` for reusable proof.
+- End each completed research concept as `continue`, `promote_and_supersede`,
+  `promote_and_retire`, or `reject_or_deprecate`, then record the maintenance event
+  in [`../log.md`](../log.md).
+- Keep superseded research out of active LLM Wiki routing except as explicit
+  provenance pointing to authoritative owners.
 - When accepted research changes agent-facing workflow instructions, update the
   matching `plugins/decodex/skills/` files alongside the promoted docs concept.

--- a/docs/research/research-runtime-boundary.md
+++ b/docs/research/research-runtime-boundary.md
@@ -1,147 +1,113 @@
 ---
 type: "Research Contract"
 title: "Research Runtime Boundary"
-description: "Defines the current research format boundary between checked-in Markdown research concepts, runtime Decision Contracts, MCP readback, and future execution research."
-status: active
+description: "Superseded provenance for the research runtime-boundary investigation now promoted into OKF owner concepts."
+status: superseded
 authority: non_authoritative
 owner: research
 tags: [research, runtime, mcp, decision-contract, okf]
 code_refs: [apps/decodex/src/docs_okf.rs, apps/decodex/src/mcp.rs, apps/decodex/src/research_design.rs, apps/decodex/src/execution_program.rs, apps/decodex/src/program_intake.rs, docs/spec/loop-runtime.md, docs/spec/runtime.md, docs/reference/research-concepts.md, plugins/decodex/skills/research/SKILL.md, plugins/decodex/references/research-contract.md, plugins/decodex/references/research-lifecycle.md]
-related: [index.md, ../policy.md, ../reference/research-concepts.md, ../spec/loop-runtime.md, ../spec/runtime.md, ../decisions/mcp-capability-gateway-and-skill-slimming.md]
-promotes_to: [docs/spec, docs/reference, docs/decisions]
+related: [index.md, ../policy.md, ../decisions/okf-research-knowledge-lifecycle.md, ../reference/research-concepts.md, ../spec/loop-runtime.md, ../spec/runtime.md, ../decisions/mcp-capability-gateway-and-skill-slimming.md]
+promotes_to: [docs/decisions, docs/reference, docs/spec, docs/evidence]
 last_verified: 2026-06-18
 ---
 
 # Research Runtime Boundary
 
-Purpose: State the current research boundary in the latest Decodex docs format.
+Purpose: Preserve the provenance of the research runtime-boundary investigation after
+its accepted knowledge moved into OKF owner concepts.
 
-Read this when: You need to decide whether research belongs in checked-in docs,
-runtime-local Decision Contracts, MCP resources, or a promoted execution plan.
+Read this when: You need the historical evidence path for why checked-in research is
+Markdown-only and why runtime Decision Contracts remain structured runtime state.
 
-Not this document: A durable specification, operator runbook, or promotion approval.
+Not this document: Current truth. Use
+[`../decisions/okf-research-knowledge-lifecycle.md`](../decisions/okf-research-knowledge-lifecycle.md),
+[`../reference/research-concepts.md`](../reference/research-concepts.md),
+[`../spec/loop-runtime.md`](../spec/loop-runtime.md), and
+[`../spec/runtime.md`](../spec/runtime.md).
+
+Disposition: `promote_and_supersede`.
 
 ## Question
 
-What is the correct current shape for Decodex research so checked-in docs stay
-Markdown-only while runtime and MCP can still expose structured machine-readable
-state?
+What is the correct boundary between checked-in research concepts, runtime-local
+Decision Contracts, MCP readback, and future execution research?
 
 ## Scope
 
-In scope:
+In scope: checked-in research format, runtime-local Decision Contracts, MCP readback,
+and future research triggers.
 
-- Checked-in `docs/research/` format.
-- Runtime-local `decodex.decision_contract/1` research storage.
-- MCP resource exposure for checked-in research and runtime Decision Contracts.
-- Future research triggers that still need fresh evidence before promotion.
-
-Out of scope:
-
-- Importing event-log storage into checked-in docs.
-- Treating a research concept as execution authority.
-- Queueing Linear issues, dispatching Program nodes, or mutating runtime state from
-  checked-in research.
+Out of scope: treating research as execution authority, storing generated runtime
+state in checked-in docs, or using research as a primary facts/rationale/evidence
+owner after promotion.
 
 ## Evidence
 
 | ID | Class | Sources | Supports |
 | --- | --- | --- | --- |
-| E1 | repo_source | `docs/policy.md`, `docs/reference/research-concepts.md`, `plugins/decodex/skills/research/SKILL.md` | Checked-in research belongs in Markdown OKF `Research Contract` concepts under `docs/research/`. |
-| E2 | repo_source | `apps/decodex/src/docs_okf.rs` | The docs checker requires `docs/research/index.md`, validates Research Contract headings, and rejects JSON or generated state anywhere under `docs/`. |
-| E3 | repo_source | `apps/decodex/src/research_design.rs`, `docs/spec/loop-runtime.md` | Decodex research/design produces latent runtime-local Decision Contracts and requires explicit promotion before execution authority exists. |
-| E4 | repo_source | `apps/decodex/src/execution_program.rs`, `apps/decodex/src/program_intake.rs` | Accepted research can become executable only after promotion and Program Intake shaping. |
-| E5 | repo_source | `apps/decodex/src/mcp.rs`, `docs/spec/runtime.md` | MCP exposes checked-in research as Markdown resources and exposes runtime Decision Contracts separately as JSON readback. |
-| E6 | gap | `docs/spec/app-server.md`, `README.md` | Remote execution beyond the current app-server/local-runtime model still needs fresh evidence for status, diff, apply, issue/run/attempt provenance, repo gate, and PR handoff authority. |
+| E1 | repo_source | `docs/policy.md`, `docs/reference/research-concepts.md` | `docs/research/` is a Markdown OKF `Research Contract` lane and is non-authoritative. |
+| E2 | repo_source | `apps/decodex/src/docs_okf.rs` | The docs checker rejects non-Markdown artifacts under `docs/` and validates research headings. |
+| E3 | repo_source | `apps/decodex/src/research_design.rs`, `docs/spec/loop-runtime.md` | Decodex research produces latent runtime-local Decision Contracts that require explicit promotion. |
+| E4 | repo_source | `apps/decodex/src/mcp.rs`, `docs/spec/runtime.md` | MCP exposes checked-in research as Markdown and runtime Decision Contracts as JSON readback. |
+| E5 | repo_source | `docs/decisions/okf-research-knowledge-lifecycle.md` | Accepted research now follows OKF disposition and LLM Wiki hygiene rules. |
 
 ## Options
 
 1. Store checked-in research as JSON.
-   This gives machine structure but violates the current Markdown-only OKF docs
-   contract and blurs docs authority with runtime state.
-
-2. Store all research only in runtime SQLite.
-   This preserves machine authority but loses durable, reviewable, source-controlled
-   research context for agents.
-
+2. Store all research only in runtime state.
 3. Keep checked-in research as Markdown OKF concepts and keep machine structure in
    runtime Decision Contracts.
-   This preserves readable repository knowledge, keeps runtime JSON where it belongs,
-   and gives MCP a clear split between Markdown docs resources and JSON runtime
-   readback.
 
 ## Judgment
 
 Selected option: Keep checked-in research as Markdown OKF concepts and keep machine
 structure in runtime Decision Contracts.
 
-This fits the current Decodex architecture:
-
-- `docs/research/` is a non-authoritative Markdown OKF lane.
-- `decodex research compile` and `decodex research promote` operate on runtime-local
-  Decision Contracts.
-- MCP should expose `decodex://research/{concept}` as Markdown and
-  `decodex://decision-contracts/{contract_id}` as runtime JSON.
-- Promotion, not file presence, grants authority to shape execution work.
+The accepted knowledge is no longer owned here. Current owner concepts now carry the
+OKF lifecycle, runtime, and MCP boundaries.
 
 ## Challenge
 
 Resolved objection: Markdown research is less schema-bound than JSON.
 
-Resolution: The schema-bound surface already exists in runtime Decision Contracts.
-Checked-in docs optimize for reviewability, routing, citations, and semantic drift
-checks. Duplicating machine state into checked-in docs would create two sources of
-truth.
+Resolution: runtime Decision Contracts are the schema-bound machine surface; checked-in
+research is an OKF knowledge concept optimized for routing and review.
 
-Resolved objection: Markdown concepts may lose useful future direction that was
-captured during investigation.
+Resolved objection: useful research history may disappear after promotion.
 
-Resolution: Useful direction should be restated as current research questions,
-validation expectations, and future trigger conditions. Raw run storage should not be
-kept in `docs/`.
+Resolution: useful provenance remains only as a compact `superseded` research concept
+that points to authoritative owners. Knowledge retention is explicit in OKF links and
+indexes.
 
 ## Decision
 
 Terminal status: `decision_ready`.
 
-Decision: Keep `docs/research/` as Markdown-only OKF Research Contract concepts.
-Keep runtime-local `decodex.decision_contract/1` records as the structured research
-machine surface. MCP must preserve that split by exposing checked-in research as
-Markdown and runtime Decision Contracts as JSON.
-
-Future research should start from fresh evidence when:
-
-- Remote execution needs proof for task status, diff/status readback, apply
-  semantics, issue/run/attempt provenance, repo gates, and PR handoff authority.
-- A landing receipt schema is needed beyond `decodex/commit/1` plus GitHub
-  merge/admin-merge readback.
-- A plan/progress adapter needs lifecycle authority beyond current progress memory.
-- MCP clients need more than observe/plan/operate/admin resource and tool surfaces.
+Decision: Keep `docs/research/` as Markdown-only OKF `Research Contract` concepts,
+keep runtime-local `decodex.decision_contract/1` records as structured runtime state,
+and manage accepted research through OKF promotion/disposition.
 
 ## Promotion
 
-Promotion target: no immediate promotion.
+Promoted to:
 
-Promote only a specific accepted conclusion into:
-
-- `docs/spec/` when it defines required runtime or MCP behavior.
-- `docs/reference/` when it records current implemented structure.
-- `docs/decisions/` when it records durable design rationale.
+- [`../decisions/okf-research-knowledge-lifecycle.md`](../decisions/okf-research-knowledge-lifecycle.md)
+- [`../reference/research-concepts.md`](../reference/research-concepts.md)
+- [`../spec/loop-runtime.md`](../spec/loop-runtime.md)
+- [`../spec/runtime.md`](../spec/runtime.md)
+- `plugins/decodex/references/research-promotion.md`
 
 ## Drift Impact
 
-- `docs/research/` must contain Markdown only.
-- `decodex docs check` must reject JSON or generated state under `docs/`.
-- MCP research resources must stay `text/markdown`.
-- Runtime Decision Contract resources may stay `application/json`.
+- `docs/research/` must remain Markdown-only.
+- Superseded research must not outrank owner concepts in normal LLM Wiki routing.
+- Research promotion must update owner concepts, indexes, links, and plugin guidance.
 
 ## Citations
 
 - [`../policy.md`](../policy.md)
+- [`../decisions/okf-research-knowledge-lifecycle.md`](../decisions/okf-research-knowledge-lifecycle.md)
 - [`../reference/research-concepts.md`](../reference/research-concepts.md)
 - [`../spec/loop-runtime.md`](../spec/loop-runtime.md)
 - [`../spec/runtime.md`](../spec/runtime.md)
-- [`../decisions/mcp-capability-gateway-and-skill-slimming.md`](../decisions/mcp-capability-gateway-and-skill-slimming.md)
-- [`../../plugins/decodex/skills/research/SKILL.md`](../../plugins/decodex/skills/research/SKILL.md)
-- [`../../plugins/decodex/references/research-contract.md`](../../plugins/decodex/references/research-contract.md)
-- [`../../plugins/decodex/references/research-lifecycle.md`](../../plugins/decodex/references/research-lifecycle.md)

--- a/plugins/decodex/references/docs-okf.md
+++ b/plugins/decodex/references/docs-okf.md
@@ -23,8 +23,8 @@ Allowed `type`: `Decision`, `Drift Audit`, `Evidence`, `Policy`, `Reference`,
 Recommended structured fields: `tags`, `source_refs`, `code_refs`, `related`,
 `promotes_to`, and `drift_watch`.
 
-`promotes_to` may point only at `docs/spec`, `docs/runbook`, `docs/reference`, or
-`docs/decisions`.
+`promotes_to` may point only at `docs/spec`, `docs/runbook`, `docs/reference`,
+`docs/decisions`, or `docs/evidence`.
 
 ## Required Sections
 

--- a/plugins/decodex/references/docs-wiki.md
+++ b/plugins/decodex/references/docs-wiki.md
@@ -23,6 +23,8 @@ structure, `decisions` for rationale, `research` for latent candidates, and
 - Use `related` when cross-links materially help retrieval.
 - Start each concept with a short routing purpose and boundary.
 - Keep `docs/research/` non-authoritative until promotion.
+- After promotion, update indexes, links, descriptions, and statuses so superseded
+  research routes as provenance instead of competing with owner concepts.
 
 Update `docs/log.md` when routing, promotion, naming, docs policy, or maintenance
 behavior changes.

--- a/plugins/decodex/references/issue-briefing.md
+++ b/plugins/decodex/references/issue-briefing.md
@@ -5,20 +5,20 @@ Program Intake readiness.
 
 ## Authority
 
-Issue briefing is part of planning. It starts only after one authority source exists:
+Issue briefing is planning-only and starts after one authority source:
 
 - an accepted and promoted Decision Contract
 - an explicit execution instruction whose scope is already bounded
 - a supplied batch of executable issue briefs for Program Intake
 
-The briefing is not a delivery workflow. Do not route Decodex issue briefing through
-an external delivery plugin, delivery handoff, or progress skill. Runtime progress,
-review handoff, landing, closeout, and recovery stay Decodex runtime surfaces.
+The briefing is not delivery workflow. Do not route Decodex issue briefing through
+an external delivery plugin, delivery handoff, or progress skill; runtime progress,
+review handoff, landing, closeout, and recovery stay Decodex surfaces.
 
 ## Generic Dispatch Briefing
 
-Every Decodex-planned issue must be understandable by a generic implementation lane
-without replaying chat or private runtime state.
+Every planned issue must work for a generic implementation lane without replaying chat
+or private runtime state.
 
 Include:
 
@@ -38,8 +38,8 @@ validation, tracker state, or runtime authority.
 
 ## Splitting Rules
 
-Split accepted work only when one issue is too broad for one lane. Split by real
-ownership boundary, validation surface, dependency, or conflict domain.
+Split accepted work only when one issue is too broad for one lane, using real
+ownership, validation, dependency, or conflict boundaries.
 
 Each child issue must carry its own generic dispatch briefing. Name ordering only
 when it is blocking. Do not expose internal graph ids, DAG edge editing, hidden goal
@@ -48,12 +48,8 @@ ids, or Program scheduler mechanics in the issue text.
 ## Existing Issue Intake
 
 For `decodex intake issues`, issue descriptions are the public briefing surface. A
-machine-readable block, private pointer, or thin title is missing the generic
+thin title, private pointer, runtime event, PR body, or checkpoint is not a generic
 dispatch briefing and should remain held until repaired.
-
-Do not use a progress checkpoint, review summary, PR body, or runtime event as a
-substitute for the issue briefing. Those surfaces can support evidence, but the
-normal issue remains the executable lane boundary.
 
 ## Non-Goals
 

--- a/plugins/decodex/references/research-contract.md
+++ b/plugins/decodex/references/research-contract.md
@@ -28,6 +28,8 @@ Expose these from the top-level contract or Markdown research concept:
 - validation expectations
 - promotion target
 - docs impact
+- OKF disposition: `continue`, `promote_and_supersede`, `promote_and_retire`, or
+  `reject_or_deprecate`
 - research-only evidence versus durable knowledge candidates
 - unresolved decisions, evidence gaps, or blockers
 
@@ -56,9 +58,11 @@ Do not write JSON research event logs.
 
 ## Research Versus Durable Knowledge
 
-Research keeps evidence, options, objections, falsifiers, and gaps in the target repo
-research lane, normally `docs/research/`.
+Research keeps active evidence, options, objections, falsifiers, and gaps in the
+target repo research lane, normally `docs/research/`.
 
 Durable knowledge candidates are accepted facts, contracts, and workflow
-instructions. They must name non-research targets and move to owning docs, skill,
-code, or tests after acceptance. Research is provenance, not source of truth.
+instructions. They must name OKF owner targets and move to decisions, specs,
+references, runbooks, evidence, skills, code, or tests after acceptance. Research can
+remain only as unresolved inquiry or explicitly superseded non-authoritative
+provenance.

--- a/plugins/decodex/references/research-contract.md
+++ b/plugins/decodex/references/research-contract.md
@@ -28,6 +28,7 @@ Expose these from the top-level contract or Markdown research concept:
 - validation expectations
 - promotion target
 - docs impact
+- research-only evidence versus durable knowledge candidates
 - unresolved decisions, evidence gaps, or blockers
 
 ## Option And Judgment Rules
@@ -52,3 +53,12 @@ material objections block `decision_ready`.
 
 If persisted under `docs/research/`, use a Markdown OKF `Research Contract` concept.
 Do not write JSON research event logs.
+
+## Research Versus Durable Knowledge
+
+Research keeps evidence, options, objections, falsifiers, and gaps in the target repo
+research lane, normally `docs/research/`.
+
+Durable knowledge candidates are accepted facts, contracts, and workflow
+instructions. They must name non-research targets and move to owning docs, skill,
+code, or tests after acceptance. Research is provenance, not source of truth.

--- a/plugins/decodex/references/research-lifecycle.md
+++ b/plugins/decodex/references/research-lifecycle.md
@@ -8,41 +8,22 @@ Decodex is the default research surface for bounded Decodex technical investigat
 Decodex research produces a latent `decodex.decision_contract/1` candidate. It does
 not queue work, mutate Linear, set Codex goals, implement, or dispatch Program nodes.
 
-The phase order is:
+Phase order: `research-probe`, `research-evidence`, `research-options`,
+`research-judgment`, `research-challenge`, `research-decision`; after explicit
+acceptance, `research-promote`.
 
-1. `research-probe`
-2. `research-evidence`
-3. `research-options`
-4. `research-judgment`
-5. `research-challenge`
-6. `research-decision`
-7. `research-promote` after explicit acceptance
-
-The compact loop is: probe, evidence, options, judgment, challenge, decision.
+Compact loop: probe, evidence, options, judgment, challenge, decision.
 
 ## Probe
 
-Record:
-
-- decision question
-- in-scope and out-of-scope surfaces
-- success criteria and acceptance threshold
-- constraints and non-goals
-- stop rule or budget
-- primary hypothesis
-- rival hypotheses
-- falsifiers
-- first evidence plan
-- expected promotion target or `no_promotion`
-
-Do not gather broad evidence until the question and falsifiers can guide collection.
+Record decision question, scope, criteria, constraints, non-goals, stop rule, primary
+hypothesis, rival hypotheses, falsifiers, first evidence plan, and promotion target or
+`no_promotion`. Do not gather broad evidence until falsifiers can guide collection.
 
 ## Authority Boundary
 
 Research remains latent until explicit acceptance such as "arrange this", "push this
 forward", "推进", or "做". Promotion is a separate authority step.
 
-Checked-in research belongs in `docs/research/` only as a Markdown OKF research
-concept. It is supporting knowledge, not implementation authority.
-runtime state may keep structured Decision Contracts for machine use; checked-in
-docs remain Markdown OKF concepts.
+Checked-in research belongs in `docs/research/` only as Markdown OKF research.
+Runtime state may keep structured Decision Contracts; checked-in docs stay Markdown.

--- a/plugins/decodex/references/research-promotion.md
+++ b/plugins/decodex/references/research-promotion.md
@@ -4,15 +4,10 @@ Use this reference when accepted research becomes execution authority.
 
 ## Acceptance
 
-Promotion requires explicit acceptance of a research result. Do not infer acceptance
-from a research request, summary, or old artifact.
-
-Before promotion:
-
-- identify the accepted contract
-- preserve objectives, non-goals, constraints, assumptions, objections, validation
-  expectations, structured proposed issues, and stop conditions
-- refuse promotion while unresolved decisions, evidence gaps, or blockers remain
+Promotion requires explicit acceptance; do not infer it from a request, summary, or old
+artifact. Identify the accepted contract, preserve objectives, non-goals, constraints,
+assumptions, objections, validation expectations, proposed issues, and stop
+conditions, and refuse unresolved decisions, gaps, or blockers.
 
 ## Durable Lanes
 
@@ -24,9 +19,16 @@ Choose the narrowest durable lane:
 | `docs/runbook/` | operator sequence |
 | `docs/reference/` | current implementation or repository structure |
 | `docs/decisions/` | durable rationale, rejected alternatives, tradeoff |
-| runtime code/tests | behavior that cannot be represented by docs or skills alone |
+| runtime code/tests | behavior not representable by docs or skills |
 
 `docs/research/` is not a promotion target. It is the latent research lane.
+
+Promotion splits by authority: research-only evidence and provenance stay in
+research; accepted durable knowledge (facts, policies, specs, runbooks, repository
+structure, workflow instructions, implementation contracts) moves to durable owners.
+Use `no_promotion` only when no durable fact, contract, instruction, code, or test
+expectation changes. Durable owners state current truth independently and may link
+back for rationale.
 
 When accepted research changes agent-facing workflow instructions, update matching
 `plugins/decodex/skills/` files beside the promoted docs concept. Skills are
@@ -34,5 +36,5 @@ companion execution surfaces, not `promotes_to` lanes.
 
 ## Next Step
 
-After promotion, route accepted execution work to `planning`. Program Intake may then
-persist Execution Program readiness and dispatch ready mapped nodes directly.
+After promotion, route execution to `planning`; Program Intake dispatches ready mapped
+nodes.

--- a/plugins/decodex/references/research-promotion.md
+++ b/plugins/decodex/references/research-promotion.md
@@ -19,16 +19,27 @@ Choose the narrowest durable lane:
 | `docs/runbook/` | operator sequence |
 | `docs/reference/` | current implementation or repository structure |
 | `docs/decisions/` | durable rationale, rejected alternatives, tradeoff |
+| `docs/evidence/` | reusable proof, public-safe evidence, or drift audit |
 | runtime code/tests | behavior not representable by docs or skills |
 
 `docs/research/` is not a promotion target. It is the latent research lane.
 
-Promotion splits by authority: research-only evidence and provenance stay in
-research; accepted durable knowledge (facts, policies, specs, runbooks, repository
-structure, workflow instructions, implementation contracts) moves to durable owners.
-Use `no_promotion` only when no durable fact, contract, instruction, code, or test
-expectation changes. Durable owners state current truth independently and may link
-back for rationale.
+Promotion is an OKF knowledge operation:
+
+- move durable rationale to `docs/decisions/`
+- move current truth to `docs/spec/`, `docs/reference/`, `docs/runbook/`, skills,
+  code, or tests
+- move reusable proof to `docs/evidence/`
+- leave only unresolved inquiry or superseded provenance in `docs/research/`
+
+End the research concept as `continue`, `promote_and_supersede`,
+`promote_and_retire`, or `reject_or_deprecate`. Use `no_promotion` only when no
+durable rationale, fact, proof, instruction, code, or test expectation changes.
+Durable owners state current truth independently and may link back for rationale.
+
+Update LLM Wiki indexes, `related`, `promotes_to`, descriptions, and status fields so
+research does not compete with authoritative owners. Do not rely on out-of-band
+history for knowledge retention.
 
 When accepted research changes agent-facing workflow instructions, update matching
 `plugins/decodex/skills/` files beside the promoted docs concept. Skills are

--- a/plugins/decodex/references/routing.md
+++ b/plugins/decodex/references/routing.md
@@ -21,17 +21,15 @@ labels, automation, commit, or landing boundaries.
   recovery inspection, commit, or landing.
 - Labels: use `labels` only for ordinary non-Program tracker intake and retained-lane
   ownership signals.
-- MCP gateway: use `decodex mcp serve --transport stdio` for local MCP clients and
-  `decodex mcp serve --transport streamable-http` only for remote permitted clients
-  behind the operator's chosen local listener, tunnel, or relay. Treat MCP resources,
-  prompts, and tools as a typed facade over existing Decodex docs/runtime authority,
-  not as a replacement for Decision Contract, lane-control, tracker, review, landing,
-  or closeout gates. Planning tools are deliberately small: `research_compile`,
-  `research_promote`, and `intake_goal` expose dry-run/apply boundaries with explicit
-  authority requirements for apply/promote calls. Operate/admin tools stay
-  inspect-first: `decodex_lane_control` requires lane identity plus current run/turn
-  preconditions for steer or interrupt, and `decodex_project_control` limits
-  pause/resume to future dispatch while refusing standalone scan shortcuts.
+- MCP gateway: use `decodex mcp serve --transport stdio` locally and
+  `decodex mcp serve --transport streamable-http` only behind the operator's listener,
+  tunnel, or relay. MCP is a typed facade, not a bypass around Decision Contract,
+  lane-control, tracker, review, landing, or closeout gates. Plan tools are
+  `research_compile`, `research_promote`, and `intake_goal`; dry-run stays
+  non-mutating, while apply/promote requires explicit authority. Operate/admin stays
+  inspect-first: `decodex_lane_control` requires current run/turn preconditions for
+  steer or interrupt, and `decodex_project_control` limits pause/resume to future
+  dispatch while refusing standalone scan shortcuts.
 
 ## First Reads
 
@@ -48,10 +46,10 @@ Keep Decodex natural-language-first. Requests such as `research X` route through
 
 Research never queues work, mutates Linear, starts implementation, creates Codex
 goals, or dispatches Program nodes. Promotion preserves accepted objectives,
-non-goals, constraints, assumptions, objections, validation expectations, proposed
-issues, and stop conditions. A result is a latent Decision Contract
-candidate only. Program Intake dispatches ready mapped nodes directly from the
-persisted DAG; queue labels are not the Program scheduler.
+constraints, objections, validation expectations, proposed issues, non-goals, and
+stop conditions. A result is a latent Decision Contract candidate only. Program
+Intake dispatches ready mapped nodes directly from the persisted DAG; queue labels
+are not the Program scheduler.
 
 ## Program Versus Label Intake
 
@@ -67,13 +65,12 @@ persisted DAG; queue labels are not the Program scheduler.
 ## Commit And Land
 
 For human-driven commits, inspect the diff, stage intended files, run touched-surface
-validation, then use `decodex commit "<summary>"` or
-`decodex commit --manual-authority "<summary>"` for deliberate non-issue work.
+validation, then use `decodex commit "<summary>"` or `decodex commit
+--manual-authority "<summary>"`.
 
 For human-driven PR landing, confirm PR/base/head/mergeability/checks, then use
-`decodex land "<summary>"` or
-`decodex land --manual-authority --pr <URL> "<summary>"` for deliberate non-issue
-work. If issue-authority land reports missing retained handoff state, dry-run
+`decodex land "<summary>"` or `decodex land --manual-authority --pr <URL>
+"<summary>"`. If issue-authority landing lacks retained handoff state, dry-run
 `decodex recover review-handoff adopt` before any live adopt.
 
 ## Hard Boundaries

--- a/plugins/decodex/skills/research-promote/SKILL.md
+++ b/plugins/decodex/skills/research-promote/SKILL.md
@@ -15,6 +15,7 @@ rules.
 - Promote into the correct durable lane: `docs/spec`, `docs/runbook`,
   `docs/reference`, `docs/decisions`, `plugins/decodex/skills`, runtime code, tests,
   or explicit `no_promotion`.
+- Update durable owners so current facts and contracts stand without reading research.
 - Refuse promotion while unresolved decisions, evidence gaps, or blockers remain.
 - Route accepted work to `planning`.
 - Do not infer acceptance from a research question, summary, or old artifact.

--- a/plugins/decodex/skills/research-promote/SKILL.md
+++ b/plugins/decodex/skills/research-promote/SKILL.md
@@ -12,10 +12,12 @@ rules.
 - Identify the accepted contract or conversational contract.
 - Preserve objectives, non-goals, constraints, assumptions, objections, validation,
   structured proposed issues, and stop conditions.
-- Promote into the correct durable lane: `docs/spec`, `docs/runbook`,
-  `docs/reference`, `docs/decisions`, `plugins/decodex/skills`, runtime code, tests,
-  or explicit `no_promotion`.
-- Update durable owners so current facts and contracts stand without reading research.
+- Promote into the correct OKF owner: `docs/decisions` for rationale, `docs/spec` for
+  normative truth, `docs/reference` for current state, `docs/runbook` for procedures,
+  `docs/evidence` for reusable proof, skills/code/tests for behavior, or explicit
+  `no_promotion`.
+- Update owners, indexes, links, descriptions, and status so current truth stands
+  without reading research.
 - Refuse promotion while unresolved decisions, evidence gaps, or blockers remain.
 - Route accepted work to `planning`.
 - Do not infer acceptance from a research question, summary, or old artifact.

--- a/plugins/decodex/skills/research/SKILL.md
+++ b/plugins/decodex/skills/research/SKILL.md
@@ -20,5 +20,7 @@ Follow phase skills in order. Use `research-promote` only after explicit accepta
   target visible from the top-level contract.
 - Split research-only evidence from durable knowledge candidates; accepted facts,
   policy/spec/runbook/structure/workflow instructions need non-research targets.
+- Name the OKF disposition: `continue`, `promote_and_supersede`,
+  `promote_and_retire`, or `reject_or_deprecate`.
 - Do not queue work, mutate Linear, set Codex goals, implement, or dispatch Program
   nodes from research alone.

--- a/plugins/decodex/skills/research/SKILL.md
+++ b/plugins/decodex/skills/research/SKILL.md
@@ -10,9 +10,7 @@ authority. Read `../../references/research-lifecycle.md` first, then load
 `../../references/research-evidence.md`, `../../references/research-contract.md`, or
 `../../references/research-promotion.md` only when the phase needs it.
 
-Use `research-probe`, `research-evidence`, `research-options`, `research-judgment`,
-`research-challenge`, and `research-decision` in order. Use `research-promote` only
-after explicit acceptance.
+Follow phase skills in order. Use `research-promote` only after explicit acceptance.
 
 - Do not route Decodex research through external research skills.
 - Do not write new Decodex research as `docs/research/` event logs or JSON.
@@ -20,5 +18,7 @@ after explicit acceptance.
   that remains non-authoritative until promoted.
 - Do keep terminal status, evidence classes, selected option, gaps, and promotion
   target visible from the top-level contract.
+- Split research-only evidence from durable knowledge candidates; accepted facts,
+  policy/spec/runbook/structure/workflow instructions need non-research targets.
 - Do not queue work, mutate Linear, set Codex goals, implement, or dispatch Program
   nodes from research alone.


### PR DESCRIPTION
## Summary
- add an OKF research knowledge-lifecycle decision for promotion/disposition and LLM Wiki hygiene
- promote accepted research rules into policy, reference, indexes, and plugin research guidance
- mark the old research runtime-boundary concept as superseded provenance instead of current truth
- allow `docs/evidence` as a research promotion target and lock the behavior with surface tests
- slim repeated plugin reference text enough for plugin-eval budget to pass cleanly

## Validation
- cargo make fmt
- git diff --check
- cargo make check-docs
- cargo test -p decodex docs_okf -- --nocapture
- cargo test -p decodex resources_ -- --nocapture
- cargo test -p decodex plugin_surface_tests -- --nocapture
- node /Users/x/.codex/plugins/cache/openai-curated/plugin-eval/015c0dff/scripts/plugin-eval.js analyze plugins/decodex --format markdown -> 100/100, 0 fail, 0 warn