### PR TITLE
Fix MCP research docs drift

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-18
 
+- Corrected MCP operator-control docs to describe checked-in research as Markdown
+  research concepts, matching the current OKF research contract.
 - Added the OKF research knowledge-lifecycle decision and updated research policy,
   reference, index, checker, and plugin guidance so promotion now routes rationale to
   decisions, truth to owner lanes, reusable proof to evidence, and superseded

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,7 +9,7 @@ Question this index answers: "how is it currently organized or implemented?"
 
 - You need the current repository layout, ownership boundaries, or where a topic lives.
 - You need to know which directory or file surface is authoritative for a class of work.
-- You need to understand where research reports and supporting evidence fit.
+- You need to understand where research concepts and supporting evidence fit.
 
 ## Do not use this index when
 

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -83,8 +83,8 @@ override when set.
 Local MCP hosts can use `decodex mcp serve --transport stdio` for local core MCP
 protocol primitives or `decodex mcp serve --transport streamable-http` for remote
 permitted clients that reach the daemon through an operator-chosen local listener,
-tunnel, or relay. Both transports list and read checked-in docs, checked-in JSON
-research reports, Decision Contract readback, status snapshots, and lane-control
+tunnel, or relay. Both transports list and read checked-in docs, checked-in Markdown
+research concepts, Decision Contract readback, status snapshots, and lane-control
 readback; both also advertise resource templates for `status_live`, `activity_tail`,
 `lane_inspect`, current/recent status-window run events, protocol activity,
 child-agent activity, progress diagnostics, and PR/review state. These projections


### PR DESCRIPTION
## Summary
- correct MCP operator-control docs to describe checked-in research as Markdown research concepts
- update the reference index language from research reports to research concepts
- record the drift repair in docs/log.md

## Validation
- git diff --check
- cargo make check-docs
- cargo test -p decodex resources_ -- --nocapture