### PR TITLE
Fix Decodex orchestration convergence drift

### DIFF
--- a/apps/decodex/src/orchestrator/execution.rs
+++ b/apps/decodex/src/orchestrator/execution.rs
@@ -409,9 +409,11 @@ impl RepoGatePhaseGoalController<'_> {
 	) -> Result<PhaseAcceptanceCheck> {
 		let fingerprint = loop_guardrail_worktree_fingerprint(&self.issue_run.worktree.path)?;
 		let head_sha = fingerprint.as_ref().map(|value| value.head_sha.clone());
-		let effective_delta_present =
-			fingerprint.as_ref().is_some_and(|value| value.effective_delta_present);
 		let changed_surfaces = phase_acceptance_changed_surfaces(&self.issue_run.worktree.path);
+		let effective_delta_present = fingerprint
+			.as_ref()
+			.is_some_and(|value| value.effective_delta_present)
+			|| !changed_surfaces.is_empty();
 		let checkpoint = self.latest_progress_checkpoint()?;
 		let checkpoint_payload = checkpoint.as_ref().map(state::PrivateExecutionEvent::payload);
 		let checkpoint_head_sha = checkpoint_payload
@@ -710,6 +712,7 @@ struct LoopGuardrailWorktreeFingerprint {
 	tracked_status_hash: String,
 	tracked_diff_hash: String,
 	effective_status_hash: String,
+	branch_delta_present: bool,
 	effective_delta_present: bool,
 }
 
@@ -3339,8 +3342,7 @@ fn retryable_failure_loop_guardrail_stop(
 		observations.push((
 			LoopGuardrailReason::NoEffectiveDiff,
 			format!(
-				"{}:{}:{}",
-				worktree_fingerprint.head_sha.as_str(),
+				"{}:{}",
 				worktree_fingerprint.effective_status_hash.as_str(),
 				worktree_fingerprint.tracked_diff_hash.as_str()
 			),
@@ -3365,6 +3367,7 @@ fn retryable_failure_loop_guardrail_stop(
 					"tracked_status_hash": worktree_fingerprint.tracked_status_hash.as_str(),
 					"tracked_diff_hash": worktree_fingerprint.tracked_diff_hash.as_str(),
 					"effective_status_hash": worktree_fingerprint.effective_status_hash.as_str(),
+					"branch_delta_present": worktree_fingerprint.branch_delta_present,
 					"effective_delta_present": worktree_fingerprint.effective_delta_present,
 					"threshold": LOOP_GUARDRAIL_CONVERGENCE_BUDGET,
 				})
@@ -3416,13 +3419,17 @@ fn loop_guardrail_worktree_fingerprint(
 		return Ok(None);
 	};
 	let effective_status = loop_guardrail_effective_status(&raw_status);
+	let branch_delta_present =
+		repo_gate_changed_tracked_files(worktree_path).is_ok_and(|changed_files| !changed_files.is_empty());
 
 	Ok(Some(LoopGuardrailWorktreeFingerprint {
 		head_sha,
 		tracked_status_hash: loop_guardrail_text_hash(&tracked_status),
 		tracked_diff_hash: loop_guardrail_text_hash(&tracked_diff),
 		effective_status_hash: loop_guardrail_text_hash(&effective_status),
-		effective_delta_present: !effective_status.trim().is_empty()
+		branch_delta_present,
+		effective_delta_present: branch_delta_present
+			|| !effective_status.trim().is_empty()
 			|| !tracked_diff.trim().is_empty(),
 	}))
 }

--- a/apps/decodex/src/orchestrator/tests/runtime/failure.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/failure.rs
@@ -1654,6 +1654,48 @@ fn loop_guardrail_stops_no_effective_diff_for_retryable_errors_without_delta() {
 }
 
 #[test]
+fn loop_guardrail_does_not_classify_committed_branch_delta_as_no_effective_diff() {
+	let (temp_dir, config, _workflow) = temp_project_layout();
+	let remote_root = temp_dir.path().join("origin.git");
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue("In Progress", &[]);
+
+	add_origin_remote(config.repo_root(), &remote_root);
+	checkout_new_branch(config.repo_root(), "x/pubfi-pub-101");
+	commit_worktree_change(
+		config.repo_root(),
+		"ready.txt",
+		"implementation complete\n",
+		"implement issue scope",
+	);
+	assert_eq!(git_output(config.repo_root(), &["status", "--porcelain"]), "");
+
+	for attempt_number in 1..=3 {
+		let issue_run = loop_guardrail_issue_run(&config, &issue, attempt_number);
+		let error = Report::msg("child exited after committed issue-scoped work");
+		let stop = orchestrator::retryable_failure_loop_guardrail_stop(
+			&config,
+			&state_store,
+			&issue_run,
+			&error,
+		)
+		.expect("guardrail observation should evaluate");
+
+		assert!(
+			stop.is_none(),
+			"committed branch delta must not be reported as no_effective_diff"
+		);
+	}
+
+	assert!(
+		state_store
+			.loop_guardrail_checkpoint(config.service_id(), &issue.id, "no_effective_diff")
+			.expect("checkpoint lookup should succeed")
+			.is_none()
+	);
+}
+
+#[test]
 fn handle_failure_recovers_review_handoff_state_drift_before_no_effective_diff_terminalization() {
 	let (_temp_dir, config, workflow) = temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");

--- a/apps/decodex/src/orchestrator/tests/runtime/repo_gate.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/repo_gate.rs
@@ -211,6 +211,73 @@ fn phase_goal_completion_runs_repo_gate_and_persists_handoff_phase() {
 }
 
 #[test]
+fn phase_goal_acceptance_accepts_committed_branch_delta_with_clean_worktree() {
+	let (temp_dir, config, workflow) = temp_project_layout();
+	let remote_root = temp_dir.path().join("origin.git");
+	let issue = sample_issue("In Progress", &[tracker::automation_active_label(TEST_SERVICE_ID).as_str()]);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue_run = IssueRunPlan {
+		issue: issue.clone(),
+		issue_state: String::from("In Progress"),
+		initial_issue_state: String::from("Todo"),
+		worktree: WorktreeSpec {
+			branch_name: String::from("x/pubfi-pub-101"),
+			issue_identifier: issue.identifier.clone(),
+			path: config.repo_root().to_path_buf(),
+			reused_existing: false,
+		},
+		retry_project_slug: String::from("pubfi"),
+		dispatch_mode: IssueDispatchMode::Normal,
+		attempt_number: 1,
+		run_id: String::from("pub-101-attempt-1"),
+		retry_budget_base: 0,
+	};
+
+	add_origin_remote(config.repo_root(), &remote_root);
+	checkout_new_branch(config.repo_root(), &issue_run.worktree.branch_name);
+	commit_worktree_change(
+		config.repo_root(),
+		"ready.txt",
+		"implementation complete\n",
+		"implement issue scope",
+	);
+	assert_eq!(git_output(config.repo_root(), &["status", "--porcelain"]), "");
+
+	record_phase_acceptance_progress_checkpoint(&config, &state_store, &issue_run, &[]);
+
+	let transition = RepoGatePhaseGoalController {
+		project: &config,
+		workflow: &workflow,
+		state_store: &state_store,
+		issue_run: &issue_run,
+	}
+	.phase_goal_completed(PhaseGoalKind::ImplementToValidationReady)
+	.expect("clean committed branch delta should satisfy phase acceptance");
+	let events = state_store
+		.list_private_execution_events(TEST_SERVICE_ID, &issue.id, &issue_run.run_id, 1)
+		.expect("private phase goal events should load");
+
+	assert!(matches!(
+		transition,
+		PhaseGoalTransition::Continue(PhaseGoalSpec {
+			phase: PhaseGoalKind::HandoffEvidence,
+			..
+		})
+	));
+	assert!(events.iter().any(|event| {
+		event.event_type() == PHASE_ACCEPTANCE_CHECK_EVENT_TYPE
+			&& event.payload()["decision"] == "pass"
+			&& event.payload()["reason_code"] == "accepted"
+			&& event.payload()["effective_delta"]["present"] == true
+			&& event.payload()["effective_delta"]["changed_surfaces"]
+				.as_array()
+				.is_some_and(|surfaces| {
+					surfaces.iter().any(|surface| surface.as_str() == Some("ready.txt"))
+				})
+	}));
+}
+
+#[test]
 fn phase_goal_acceptance_rejects_repo_gate_pass_without_effective_delta() {
 	let (_temp_dir, config, workflow) = temp_project_layout();
 	let issue = sample_issue("In Progress", &[tracker::automation_active_label(TEST_SERVICE_ID).as_str()]);

--- a/apps/decodex/src/state/store.rs
+++ b/apps/decodex/src/state/store.rs
@@ -1006,7 +1006,13 @@ impl StateStore {
 		validate_run_control_action_request(&request)?;
 
 		let resolution = {
-			let state = self.lock()?;
+			let mut state = self.lock_without_refresh()?;
+
+			self.refresh_project_run_metadata_state_locked(&mut state, request.project_id)?;
+			self.refresh_run_attempt_identities_from_worktree_markers_locked(
+				&mut state,
+				request.project_id,
+			)?;
 
 			resolve_run_control_action_locked(&state, &request)
 		};
@@ -1479,6 +1485,10 @@ impl StateStore {
 		let mut state = self.lock_without_refresh()?;
 
 		self.refresh_project_run_metadata_state_locked(&mut state, project_id)?;
+		self.refresh_run_attempt_identities_from_worktree_markers_locked(
+			&mut state,
+			project_id,
+		)?;
 		self.refresh_project_loop_evidence_state_locked(&mut state, project_id)?;
 
 		let lease_run_ids = project_lease_run_ids(&state, project_id, None);
@@ -1569,6 +1579,10 @@ impl StateStore {
 		let mut state = self.lock_without_refresh()?;
 
 		self.refresh_project_run_metadata_state_locked(&mut state, project_id)?;
+		self.refresh_run_attempt_identities_from_worktree_markers_locked(
+			&mut state,
+			project_id,
+		)?;
 		self.refresh_project_loop_evidence_state_locked(&mut state, project_id)?;
 
 		let lease_run_ids = project_lease_run_ids(&state, project_id, Some(issue_id));
@@ -3053,6 +3067,70 @@ impl StateStore {
 			.map_err(|_| eyre::eyre!("StateStore SQLite mutex is poisoned."))?;
 
 		sqlite.load_run_activity_summaries_for_runs(state, run_ids)
+	}
+
+	fn refresh_run_attempt_identities_from_worktree_markers_locked(
+		&self,
+		state: &mut StateData,
+		project_id: &str,
+	) -> Result<()> {
+		let updates = state
+			.worktrees
+			.values()
+			.filter(|mapping| mapping.project_id == project_id)
+			.filter_map(|mapping| {
+				let marker = match read_run_activity_marker_snapshot(&mapping.worktree_path) {
+					Ok(Some(marker)) => marker,
+					Ok(None) => return None,
+					Err(error) => return Some(Err(error)),
+				};
+				let Some(attempt) = state.run_attempts.get(marker.run_id()) else {
+					return None;
+				};
+
+				if attempt.issue_id != mapping.issue_id
+					|| attempt.attempt_number != marker.attempt_number()
+				{
+					return None;
+				}
+
+				let thread_id = marker.thread_id().map(str::to_owned);
+				let turn_id = marker.turn_id().map(str::to_owned);
+
+				if thread_id.is_none() && turn_id.is_none() {
+					return None;
+				}
+
+				Some(Ok((marker.run_id().to_owned(), thread_id, turn_id)))
+			})
+			.collect::<Result<Vec<_>>>()?;
+
+		for (run_id, thread_id, turn_id) in updates {
+			let Some(attempt) = state.run_attempts.get_mut(&run_id) else {
+				continue;
+			};
+			let mut changed = false;
+
+			if attempt.thread_id.is_none()
+				&& let Some(thread_id) = thread_id
+			{
+				attempt.thread_id = Some(thread_id);
+				changed = true;
+			}
+			if attempt.turn_id.is_none()
+				&& let Some(turn_id) = turn_id
+			{
+				attempt.turn_id = Some(turn_id);
+				changed = true;
+			}
+			if changed {
+				let attempt = attempt.clone();
+
+				self.upsert_run_attempt_locked(&attempt)?;
+			}
+		}
+
+		Ok(())
 	}
 
 	fn refresh_project_loop_evidence_state_locked(

--- a/apps/decodex/src/state/tests.rs
+++ b/apps/decodex/src/state/tests.rs
@@ -4182,6 +4182,79 @@ fn run_control_accepts_active_attempt_and_persists_audit() {
 }
 
 #[test]
+fn run_control_accepts_marker_hydrated_active_attempt_identity() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let channel_path = temp_dir.path().join("control.channel");
+	let worktree_path = temp_dir.path().join("worktree");
+	let worktree_path_text = worktree_path.to_string_lossy().to_string();
+
+	fs::create_dir_all(&worktree_path).expect("worktree should create");
+	fs::write(&channel_path, "ready\n").expect("control channel should write");
+
+	let store = StateStore::open_in_memory().expect("state store should open");
+
+	store
+		.upsert_lease("pubfi", "issue-1", "run-1", IN_PROGRESS_STATE)
+		.expect("lease should record");
+	store
+		.upsert_worktree("pubfi", "issue-1", "x/pubfi-issue-1", &worktree_path_text)
+		.expect("worktree should record");
+	store.record_run_attempt("run-1", "issue-1", 1, "running").expect("attempt should record");
+	state::write_run_effective_runtime_marker(
+		&worktree_path,
+		"run-1",
+		1,
+		&EffectiveRuntimeMarker {
+			thread_id: Some("thread-marker"),
+			turn_id: Some("turn-marker"),
+			effective_model: "gpt-5.4",
+			effective_model_provider: "openai",
+			effective_cwd: worktree_path_text.as_str(),
+			effective_approval_policy: "never",
+			effective_approvals_reviewer: "human",
+			effective_sandbox_mode: "dangerFullAccess",
+		},
+	)
+	.expect("runtime marker should write");
+	store
+		.publish_run_control_channel_for_active_attempt("run-1", 1, &channel_path, "local_file")
+		.expect("control channel should publish")
+		.expect("active control channel should exist");
+
+	let receipt = store
+		.resolve_run_control_action(RunControlActionRequest {
+			project_id: "pubfi",
+			issue_id: "issue-1",
+			run_id: "run-1",
+			attempt_number: 1,
+			thread_id: Some("thread-marker"),
+			turn_id: Some("turn-marker"),
+			source: "test_hook",
+			action: "interrupt",
+			timeout_ms: Some(500),
+			metadata: None,
+			context: None,
+		})
+		.expect("marker-hydrated control request should resolve");
+
+	assert_eq!(receipt.outcome(), "accepted");
+	assert_eq!(receipt.reason(), "run_lease_control_channel_resolved");
+	assert_eq!(receipt.current_thread_id(), Some("thread-marker"));
+	assert_eq!(receipt.current_turn_id(), Some("turn-marker"));
+
+	let events = store
+		.list_private_execution_events("pubfi", "issue-1", "run-1", 1)
+		.expect("private control audit should read");
+	let event = events
+		.iter()
+		.find(|event| event.record_id() == receipt.audit_record_id())
+		.expect("control audit event should exist");
+
+	assert_eq!(event.payload()["observed"]["thread_id"].as_str(), Some("thread-marker"));
+	assert_eq!(event.payload()["observed"]["turn_id"].as_str(), Some("turn-marker"));
+}
+
+#[test]
 fn run_control_rejects_stale_turn_and_run_mismatch() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let channel_path = temp_dir.path().join("control.channel");

--- a/docs/spec/lane-control.md
+++ b/docs/spec/lane-control.md
@@ -97,6 +97,13 @@ operator `control_capability` metadata. `decodex status`, JSON operator snapshot
 private evidence readback may show this local capability, but Linear must not receive
 host-local channel paths or raw control payloads.
 
+When a worktree activity marker for the same run id and attempt number carries a
+thread id or turn id missing from the run attempt row, Decodex may hydrate the missing
+attempt identity before resolving local control. Marker identity must not override an
+already recorded attempt thread id or turn id. Inspect/status/control resolution must
+therefore compare against one canonical current-attempt identity instead of letting UI
+readback and control matching use different sources.
+
 A control request is valid only when all of the following hold:
 
 - the requested run exists

--- a/docs/spec/loop-runtime.md
+++ b/docs/spec/loop-runtime.md
@@ -573,6 +573,11 @@ acceptance check may advance to `handoff_evidence`; a failing check keeps the la
 the appropriate repair phase with the reason and next action available in private
 status/evidence readback. Retained phase-goal recovery uses the same repo-gate plus
 acceptance check before scheduling automatic continuation.
+Effective delta is the canonical lane delta, not merely worktree dirtiness. It
+includes issue-branch changes from the repo-gate base merge-base through current
+`HEAD`, plus tracked or non-runtime untracked worktree changes. A clean worktree at
+an issue-branch `HEAD` with committed lane changes is therefore effective progress,
+not `no_effective_delta`.
 When Decodex has already recorded a valid phase-goal continuation or active phase in
 the immediately previous attempt and must create a retry or automatic continuation
 attempt, the new attempt resumes that unterminated phase state instead of restarting
@@ -637,6 +642,11 @@ Stop conditions include:
 - uncovered contract questions that affect accepted direction or acceptance criteria
 - contradictory tracker, PR, branch, or runtime ownership evidence that cannot be
   resolved without guessing
+
+For `no_effective_diff`, the repeated-observation fingerprint must be stable for the
+absence of progress. It may record current `HEAD` in details for forensics, but `HEAD`
+alone must not reset the consecutive counter when the canonical lane delta, validation
+evidence, and decision state did not change.
 
 Stop attribution must preserve the reason instead of collapsing failures into a
 generic retry bucket. Normalized outcomes include:


### PR DESCRIPTION
## Summary
- Treat committed issue-branch deltas as effective phase progress, even when the worktree is clean at HEAD.
- Stop resetting no-effective-diff convergence solely because HEAD changed.
- Hydrate missing run-control thread/turn identity from same-run worktree markers before resolving soft interrupts.
- Document the canonical lane-delta and control-identity contracts in the runtime specs.

## Root Cause
XY-1004 exposed three drifted facts: phase acceptance only looked at worktree dirtiness, loop guardrail fingerprints included HEAD for no-diff loops, and lane-control matching used DB attempt identity while inspect/status could show marker-hydrated identity.

## Validation
- rustup run nightly cargo fmt --all -- --check
- git diff --check
- cargo run -p decodex --bin decodex -- docs lint
- cargo test -p decodex phase_goal_acceptance
- cargo test -p decodex no_effective_diff
- cargo test -p decodex run_control_
- cargo check --all-features --all-targets --workspace
- cargo test -p decodex --lib -- --skip plugin_surface_tests::packaged_plugin_manifest_routes_natural_language_research_to_decodex --skip plugin_surface_tests::packaged_skills_preserve_research_promotion_and_queue_boundaries

## Known Baseline
- cargo test -p decodex --lib still has two existing plugin surface failures on main: missing packaged phrases `ready mapped nodes directly` and `dispatches ready mapped nodes directly`. Both failures reproduce on main without this branch.