### PR TITLE
Promote MCP remote-control docs gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ for operator-chosen local, tunnel, or relay access. Streamable HTTP validates br
 `Mcp-Session-Id` response headers on `initialize`, requires a known session for later
 requests, returns ordinary JSON-RPC JSON responses, and switches to
 `text/event-stream` framing when the client sends `Accept: text/event-stream`.
+The session header is protocol state, not authorization. `--allow-origin` is CORS
+trust, not authentication. Use Streamable HTTP remote control over loopback or behind
+an operator-owned tunnel, relay, network ACL, or MCP authorization boundary; direct
+non-loopback exposure and elevated `operate`/`admin` profiles are unsupported without
+that external boundary until Decodex implements a protected-resource auth surface.
 The gateway advertises resources, resource templates, prompts, tools, logging
 compatibility, and progress notifications. Resources expose checked-in documentation,
 checked-in Markdown research concepts, runtime Decision Contract readback, local status

--- a/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
+++ b/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
@@ -113,7 +113,11 @@ valid JSON-RPC only. Streamable HTTP is available at `POST /mcp`, binds to loopb
 default, defaults to `observe`, validates browser origins, issues MCP session headers,
 requires a known session after initialization, returns JSON-RPC JSON by default, and
 uses SSE framing for progress or notifications when the client accepts
-`text/event-stream`.
+`text/event-stream`. Loopback `observe` is the safe default. MCP sessions are protocol
+state rather than authorization, and `--allow-origin` is CORS trust rather than an
+authentication boundary. Direct non-loopback operation and elevated Streamable HTTP
+profiles require an operator-owned tunnel, relay, network ACL, or future Decodex
+protected-resource authorization boundary before they are production-safe.
 
 The gateway advertises resources, resource templates, prompts, tools, logging
 compatibility, progress notifications, active capability-profile metadata, and
@@ -229,9 +233,13 @@ Target shape:
   JSON POST, SSE response, origin rejection, session handling, observe-profile access,
   operate/admin profile-refusal coverage, and remote-safe observability template
   coverage for live status, activity tail, current/recent status-window run
-  event/protocol/child/progress readback, lane inspect, and PR/review state. Operate
-  and admin tools should pass inspect-first authority, current run/turn precondition,
-  explicit-authority refusal, and unsupported-shortcut refusal coverage.
+  event/protocol/child/progress readback, lane inspect, and PR/review state. The
+  remaining remote productization gap is process-level Streamable HTTP smoke coverage
+  with a real `decodex mcp serve --transport streamable-http` child process plus a
+  protected-resource or relay-auth boundary before any direct non-loopback or elevated
+  HTTP profile is advertised as production-ready. Operate and admin tools should pass
+  inspect-first authority, current run/turn precondition, explicit-authority refusal,
+  and unsupported-shortcut refusal coverage.
 
 ## Remaining Boundaries
 
@@ -240,7 +248,9 @@ The promoted implementation has the stdio gateway exposed as
 exposed as `decodex mcp serve --transport streamable-http`. It advertises resources,
 resource templates, prompts, and a schema-bound tool catalog while keeping mutating
 planning, operate, and admin behavior behind explicit capability profiles, authority
-fields, inspect-first preconditions, and structured refusal states. Further expansion
-must keep the catalog deliberately small and route new mutating behavior through
-Decodex's existing runtime, tracker, review, landing, and lane-control authority
-surfaces instead of adding one tool per CLI command.
+fields, inspect-first preconditions, and structured refusal states. Remote operation
+beyond loopback still depends on an operator-managed authorization boundary until the
+Decodex listener itself implements a protected-resource auth surface. Further
+expansion must keep the catalog deliberately small and route new mutating behavior
+through Decodex's existing runtime, tracker, review, landing, and lane-control
+authority surfaces instead of adding one tool per CLI command.

--- a/docs/evidence/decodex-plugin-eval.md
+++ b/docs/evidence/decodex-plugin-eval.md
@@ -15,8 +15,8 @@ last_verified: 2026-06-18
 # Decodex Plugin Eval
 
 Purpose: Preserve public-safe evidence that the Decodex plugin, routing reference,
-portable OKF init and skill family, repo-memory skill family, and docs skill family
-passed local plugin evaluation.
+portable OKF init and skill family, repo-memory skill family, docs skill family, and
+research skill family passed local plugin evaluation without failures.
 
 Read this when: You need proof that the OKF init/split, repo-memory skills, docs skill
 split, research skill split, and plugin invocation policy were evaluated before
@@ -37,19 +37,9 @@ node ~/.codex/plugins/cache/openai-curated/plugin-eval/015c0dff/scripts/plugin-e
 
 ## Results
 
-| Target | Score | Grade | Risk | Fix First |
-| --- | --- | --- | --- | --- |
-| `plugins/decodex` | 100 | A | low | none |
-| `plugins/decodex/skills/okf` | 100 | A | low | none |
-| `plugins/decodex/skills/okf-query` | 100 | A | low | none |
-| `plugins/decodex/skills/okf-maintain` | 100 | A | low | none |
-| `plugins/decodex/skills/repo-memory-writer` | 100 | A | low | none |
-| `plugins/decodex/skills/repo-memory-evaluator` | 100 | A | low | none |
-| `plugins/decodex/skills/repo-memory-curator` | 100 | A | low | none |
-| `plugins/decodex/skills/docs` | 100 | A | low | none |
-| `plugins/decodex/skills/docs-okf` | 100 | A | low | none |
-| `plugins/decodex/skills/docs-wiki` | 100 | A | low | none |
-| `plugins/decodex/skills/docs-drift` | 100 | A | low | none |
+| Target | Score | Grade | Risk | Checks | Fix First |
+| --- | ---: | --- | --- | --- | --- |
+| `plugins/decodex` | 95 | A | medium | 0 fail, 1 warn, 2 info | Reduce repeated deferred instruction text when doing a future token-budget pass. |
 
 ## Invocation Policy
 
@@ -91,7 +81,7 @@ Explicit-only skills:
 ## Limits
 
 The evaluation is static plugin analysis, not a measured real-usage benchmark. The
-2026-06-18 full-plugin rerun reported score 100/100, grade A, low risk, zero failing
-checks, zero warnings, and two informational notes. The context-intake update stays
-inside `routing.md` so OKF/LLM Wiki context intake remains Decodex-owned without
-creating a heavy deferred-reference warning.
+2026-06-18 full-plugin rerun reported score 95/100, grade A, medium risk, zero
+failing checks, one warning, and two informational notes. The warning is
+`deferred_cost_tokens-budget-high`, which is a known static token-budget cleanup item
+for a future slimming pass, not a routing, safety, or progressive-disclosure failure.

--- a/docs/evidence/index.md
+++ b/docs/evidence/index.md
@@ -7,6 +7,7 @@ claims without becoming implementation authority by themselves.
 
 - [Decodex Plugin Eval](./decodex-plugin-eval.md)
 - [Docs Self-Iteration](./docs-self-iteration.md)
+- [MCP Remote Control Productization](./mcp-remote-control-productization.md)
 
 ## Maintenance
 

--- a/docs/evidence/mcp-remote-control-productization.md
+++ b/docs/evidence/mcp-remote-control-productization.md
@@ -1,0 +1,92 @@
+---
+type: "Drift Audit"
+title: "MCP Remote Control Productization"
+description: "Audit Streamable HTTP remote-control docs against code, tests, research, and external MCP security guidance."
+status: active
+authority: evidence
+owner: docs
+tags: [mcp, remote-control, semantic-drift, evidence]
+source_refs: [https://modelcontextprotocol.io/specification/2025-11-25/basic/transports, https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization, https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices, https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/, https://www.nsa.gov/Portals/75/documents/Cybersecurity/CSI_MCP_SECURITY.pdf?ver=bmgiSbNQLP6Z_GiWtRt6bg%3D%3D]
+code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/mcp.rs, apps/decodex/tests/mcp_stdio.rs, README.md, docs/spec/runtime.md, docs/runbook/mcp-remote-control.md, docs/reference/operator-control-plane.md, docs/research/mcp-remote-control-productization.md]
+related: [../spec/runtime.md, ../runbook/mcp-remote-control.md, ../reference/operator-control-plane.md, ../decisions/mcp-capability-gateway-and-skill-slimming.md, ../research/mcp-remote-control-productization.md]
+drift_watch: [decodex mcp serve --transport streamable-http, --allow-origin, Mcp-Session-Id, text/event-stream, decodex_observe, decodex_lane_control, decodex_project_control, authorization, protected-resource, process-level smoke]
+last_verified: 2026-06-18
+---
+
+# MCP Remote Control Productization
+
+## Watched Claims
+
+- Streamable HTTP binds to loopback by default and defaults to `observe`.
+- Streamable HTTP validates browser `Origin`, issues `Mcp-Session-Id` on
+  `initialize`, requires known sessions after initialization, and supports JSON or
+  SSE responses under stable MCP `2025-11-25`.
+- `Mcp-Session-Id` and `--allow-origin` are not Decodex authorization boundaries.
+- Direct non-loopback exposure and elevated Streamable HTTP profiles need an
+  operator-managed authorization boundary until Decodex implements an MCP
+  protected-resource auth surface.
+- Public-safe observation excludes hidden reasoning, private evidence payloads, host
+  paths, secret material, raw steer text, and Program graph identifiers.
+- Standalone MCP keeps `scan`, `manual_attention`, and `retained_resume` routed to
+  canonical operator, tracker, or runtime paths instead of adding shortcuts.
+- Process-level Streamable HTTP smoke coverage and protected-resource auth remain
+  productization gaps, not completed implementation evidence.
+
+## Evidence Anchors
+
+- `apps/decodex/src/cli.rs` exposes `--allow-origin`, `--listen-address`,
+  `--transport streamable-http`, and `--capability-profile`; it does not expose a
+  Decodex-owned HTTP bearer or protected-resource auth flag.
+- `apps/decodex/src/mcp.rs` implements Streamable HTTP origin checks, session
+  handling, JSON/SSE framing, capability-profile filtering, observe resources,
+  lane-control refusals, project-control `scan` refusal, and public-text guards.
+- `apps/decodex/tests/mcp_stdio.rs` covers stdio process smoke and in-process
+  Streamable HTTP behavior; a real `decodex mcp serve --transport streamable-http`
+  child-process smoke is still missing.
+- `docs/research/mcp-remote-control-productization.md` records the external evidence
+  and selected staged productization strategy.
+- Official MCP transport and authorization docs, MCP security guidance, the 2026 RC
+  announcement, and the NSA May 2026 guidance all support fail-closed remote access,
+  explicit authorization boundaries, no token passthrough, and a future-compatible
+  protocol seam.
+
+## Reverse Checks
+
+- `rg -n "bearer|Authorization|allow-origin|capability-profile|streamable-http|Mcp-Session-Id|scan|manual_attention|retained_resume" apps/decodex/src apps/decodex/tests README.md docs plugins/decodex`
+  shows current CLI/MCP support and the absence of a Decodex-owned HTTP auth flag.
+- `rg -n "mcp_streamable_http_process|streamable_http_.*process" apps/decodex/tests apps/decodex/src`
+  should stay empty until the process-level HTTP smoke is implemented.
+- `decodex docs check` must pass after this docs promotion.
+
+## Verdict
+
+pass
+
+The promoted docs now distinguish current implementation from remaining productization
+gaps. The gaps are accepted research-backed work items, not current runtime facts.
+
+## Required Updates
+
+- When Decodex implements HTTP protected-resource auth, update README, runtime spec,
+  remote MCP runbook, operator reference, MCP tests, Decodex plugin guidance, and this
+  audit in the same lane.
+- When process-level Streamable HTTP smoke coverage lands, update
+  `docs/reference/test-suite.md` with real test counts and update this audit with the
+  exact passing command.
+- If the final MCP stateless protocol supersedes the stable 2025-11-25 session
+  contract, update runtime session handling, protocol metadata, runbook examples, and
+  all `Mcp-Session-Id` claims together.
+
+## Citations
+
+- [MCP 2025-11-25 Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)
+- [MCP 2025-11-25 authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+- [MCP security best practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices)
+- [MCP 2026-07-28 release candidate announcement](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+- [NSA MCP Security Design Considerations, May 2026](https://www.nsa.gov/Portals/75/documents/Cybersecurity/CSI_MCP_SECURITY.pdf?ver=bmgiSbNQLP6Z_GiWtRt6bg%3D%3D)
+- [`../spec/runtime.md`](../spec/runtime.md)
+- [`../runbook/mcp-remote-control.md`](../runbook/mcp-remote-control.md)
+- [`../reference/operator-control-plane.md`](../reference/operator-control-plane.md)
+- [`../research/mcp-remote-control-productization.md`](../research/mcp-remote-control-productization.md)
+- [`../../apps/decodex/src/mcp.rs`](../../apps/decodex/src/mcp.rs)
+- [`../../apps/decodex/tests/mcp_stdio.rs`](../../apps/decodex/tests/mcp_stdio.rs)

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,12 @@
 
 ## 2026-06-18
 
+- Promoted MCP remote-control docs drift into the runtime spec, operator reference,
+  remote MCP runbook, decision record, evidence index, and Decodex plugin routing;
+  documented that `--allow-origin` is not authentication, loopback `observe` is the
+  safe default, direct remote/elevated Streamable HTTP needs an operator auth
+  boundary, and built-in MCP protected-resource auth plus process-level HTTP smoke
+  remain active research-backed gaps.
 - Added active research for MCP remote-control productization, covering remote
   access docs, authorization or relay boundaries, public-safe observation, process
   smoke coverage, high-risk control refusals, and protocol compatibility.

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -98,7 +98,11 @@ schema-bound tool catalog. The stdio gateway defaults to
 validates browser `Origin` headers against loopback or `--allow-origin`, issues
 `Mcp-Session-Id` on `initialize`, requires a known session after initialization, and
 uses SSE framing for progress or notifications when the client accepts
-`text/event-stream`. Both transports can be narrowed or explicitly elevated with
+`text/event-stream`. The MCP session is not authorization, and `--allow-origin` is
+not authentication. Remote Streamable HTTP beyond loopback, or any Streamable HTTP
+profile above `observe`, must sit behind an operator-owned tunnel, relay, network ACL,
+or future Decodex protected-resource authorization boundary. Both transports can be
+narrowed or explicitly elevated with
 `--capability-profile observe|plan|operate|admin`; `tools/list` filters by the active
 profile and above-profile calls return structured refusals. Observe and plan tools are
 read-oriented. Operate exposes `decodex_lane_control` as an inspect-first facade:

--- a/docs/research/mcp-remote-control-productization.md
+++ b/docs/research/mcp-remote-control-productization.md
@@ -7,8 +7,8 @@ authority: non_authoritative
 owner: research
 tags: [research, mcp, remote-control, security, operator]
 source_refs: [https://modelcontextprotocol.io/specification/2025-11-25/basic/transports, https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization, https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices, https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/, https://www.nsa.gov/Portals/75/documents/Cybersecurity/CSI_MCP_SECURITY.pdf?ver=bmgiSbNQLP6Z_GiWtRt6bg%3D%3D]
-code_refs: [apps/decodex/src/mcp.rs, apps/decodex/tests/mcp_stdio.rs, README.md, docs/spec/runtime.md, docs/reference/operator-control-plane.md, docs/decisions/mcp-capability-gateway-and-skill-slimming.md]
-related: [index.md, ../decisions/mcp-capability-gateway-and-skill-slimming.md, ../reference/operator-control-plane.md, ../spec/runtime.md, ../runbook/index.md, ../evidence/index.md]
+code_refs: [apps/decodex/src/mcp.rs, apps/decodex/tests/mcp_stdio.rs, README.md, docs/spec/runtime.md, docs/reference/operator-control-plane.md, docs/runbook/mcp-remote-control.md, docs/evidence/mcp-remote-control-productization.md, docs/decisions/mcp-capability-gateway-and-skill-slimming.md]
+related: [index.md, ../decisions/mcp-capability-gateway-and-skill-slimming.md, ../reference/operator-control-plane.md, ../spec/runtime.md, ../runbook/mcp-remote-control.md, ../evidence/mcp-remote-control-productization.md]
 promotes_to: [docs/decisions, docs/spec, docs/runbook, docs/reference, docs/evidence]
 last_verified: 2026-06-18
 ---
@@ -63,6 +63,8 @@ Out of scope:
 | E7 | repo_source | `apps/decodex/src/mcp.rs` | Current tools are deliberately small: observe, plan, research compile/promote, intake goal, lane control, and project control. `scan` refuses because standalone MCP serve cannot enqueue the operator loop request. |
 | E8 | repo_source | `apps/decodex/src/mcp.rs`, `apps/decodex/tests/mcp_stdio.rs`, `docs/reference/test-suite.md` | Existing tests cover resources, templates, prompts, tool schemas, profile refusals, Streamable HTTP CORS/session/SSE behavior, lane steer/interrupt preconditions, project pause, scan refusal, and stdio stdout cleanliness. |
 | E9 | inference | E1, E2, E3, E5, E6 | The current loopback Streamable HTTP design is correct for local/tunneled development, but non-loopback remote operation needs an explicit auth/relay design and should avoid entrenching session semantics that the RC may remove. |
+| E10 | repo_source | `apps/decodex/src/cli.rs`, `apps/decodex/tests/mcp_stdio.rs`, `docs/evidence/mcp-remote-control-productization.md` | Current Decodex exposes `--allow-origin` and capability profiles, but no Decodex-owned HTTP protected-resource auth flag; process-level Streamable HTTP child-process smoke coverage is still a gap. |
+| E11 | inference | E1, E2, E3, E4, E10 | The best next implementation should not treat CORS or session ids as auth. It should either rely on an operator-managed relay/auth boundary or implement MCP protected-resource discovery and scoped authorization before direct non-loopback or elevated HTTP profiles are considered complete. |
 
 ## Options
 
@@ -93,18 +95,22 @@ Selected option: Productize remote MCP in stages while keeping the tool catalog 
 
 Recommended sequence:
 
-1. Add a remote MCP runbook.
-   Cover stdio versus Streamable HTTP, loopback default, tunnel/relay assumptions,
-   `--allow-origin`, capability profile selection, expected refusal behavior, and
-   examples for observe, plan, operate inspect, steer, interrupt, project status, and
-   future-dispatch pause/resume.
+1. Promote remote MCP docs first.
+   Keep README, runtime spec, operator reference, decision record, runbook, evidence,
+   research, and plugin routing aligned. The promoted docs must state that
+   `--allow-origin` is CORS trust, not authentication; that `Mcp-Session-Id` is
+   protocol state; and that direct remote/elevated Streamable HTTP requires an
+   operator authorization boundary until Decodex owns protected-resource auth.
 
-2. Add a remote-auth decision/spec before any non-loopback operate/admin guidance.
-   The best default is still loopback plus operator-chosen tunnel/relay. For direct
-   remote serve, require an explicit protected-resource design: bearer token
-   validation, OAuth Protected Resource Metadata or a documented operator-managed
-   relay token boundary, no token passthrough, scoped capabilities, short-lived or
-   revocable credentials, and audit-friendly authority fields.
+2. Add a remote-auth decision/spec before any direct non-loopback or elevated
+   Streamable HTTP guidance.
+   The best default is still loopback plus operator-chosen tunnel, relay, network ACL,
+   or reverse proxy. For direct remote serve, require an explicit protected-resource
+   design: OAuth Protected Resource Metadata or a documented operator-managed relay
+   auth boundary, no token passthrough, scoped capabilities, revocable access, and
+   audit-friendly authority fields. A simple static bearer check can be an MVP guard
+   only if the docs label it as incomplete relative to full MCP authorization
+   discovery.
 
 3. Add process-level Streamable HTTP smoke coverage.
    Mirror the existing stdio smoke with a real `decodex mcp serve --transport
@@ -131,6 +137,16 @@ Recommended sequence:
    Instead, isolate session handling, protocol version negotiation, and capability
    discovery so the future stateless request model can be added without changing
    Decodex authority rules or tool schemas.
+
+Gap status after 2026-06-18 docs promotion:
+
+- Remote runbook, runtime/reference docs, decision rationale, evidence audit, and
+  plugin routing are promoted as documentation authority.
+- Built-in protected-resource auth and process-level Streamable HTTP smoke remain
+  unimplemented gaps.
+- `scan`, `manual_attention`, and `retained_resume` remain intentionally refused in
+  standalone MCP unless a later design proves the same canonical runtime/tracker
+  guarantees.
 
 ## Challenge
 
@@ -167,7 +183,8 @@ Terminal status: `decision_ready`.
 Decision: The next MCP work should be a staged productization plan:
 
 - document remote use first
-- require an auth/relay contract before non-loopback operate/admin recommendations
+- require an auth/relay/protected-resource contract before non-loopback or elevated
+  Streamable HTTP recommendations
 - add process-level Streamable HTTP smoke coverage
 - improve public-safe observation recipes
 - keep high-risk shortcuts refused until they can route through canonical operator,

--- a/docs/runbook/index.md
+++ b/docs/runbook/index.md
@@ -34,6 +34,9 @@ Question this index answers: "which sequence should I execute?"
   inspect, resume, scan, keep or remove queue labels, or route manual attention after
   interrupt, hard fallback, broad steer, task replacement, or ambiguous recovery
   evidence.
+- [`mcp-remote-control.md`](./mcp-remote-control.md) for running Streamable HTTP MCP
+  with loopback defaults, CORS trust, capability profiles, public-safe observation,
+  canonical refusal paths, and the current auth/process-smoke gaps.
 - [`recover-review-handoff.md`](./recover-review-handoff.md) for diagnosing retained
   review lanes, explicitly rebinding missing or stale runtime DB lifecycle records, and
   adopting verified human-owned PRs into the normal Decodex landing lifecycle.

--- a/docs/runbook/mcp-remote-control.md
+++ b/docs/runbook/mcp-remote-control.md
@@ -1,0 +1,125 @@
+---
+type: "Runbook"
+title: "MCP Remote Control"
+description: "Run Decodex MCP over Streamable HTTP with safe defaults, authorization boundaries, public-safe observation, and explicit gap routing."
+status: active
+authority: procedural
+owner: runtime
+tags: [mcp, remote-control, operator, runbook]
+source_refs: [https://modelcontextprotocol.io/specification/2025-11-25/basic/transports, https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization, https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices, https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/]
+code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/mcp.rs, apps/decodex/tests/mcp_stdio.rs]
+related: [../spec/runtime.md, ../reference/operator-control-plane.md, ../decisions/mcp-capability-gateway-and-skill-slimming.md, ../evidence/mcp-remote-control-productization.md, ../research/mcp-remote-control-productization.md]
+drift_watch: [decodex mcp serve --transport streamable-http, --capability-profile, --allow-origin, Mcp-Session-Id, decodex_observe, decodex_lane_control, decodex_project_control]
+last_verified: 2026-06-18
+---
+
+# MCP Remote Control
+
+Purpose: Run Decodex MCP over Streamable HTTP without weakening Decodex runtime,
+tracker, review, landing, or lane-control authority.
+
+Read this when: Connecting a remote MCP client, choosing an MCP capability profile,
+or observing Decodex lane progress through MCP.
+
+Not this document: MCP protocol rationale, private execution evidence inspection, or
+permission to expose Decodex directly to the public internet.
+
+## Safe Default
+
+Start Streamable HTTP on loopback with the default `observe` profile:
+
+```sh
+decodex mcp serve --transport streamable-http \
+  --listen-address 127.0.0.1:8193
+```
+
+The endpoint is `POST /mcp`. Browser clients that run from a different loopback
+origin may add that exact origin:
+
+```sh
+decodex mcp serve --transport streamable-http \
+  --listen-address 127.0.0.1:8193 \
+  --allow-origin http://127.0.0.1:3000
+```
+
+`--allow-origin` is only CORS trust. It does not authenticate the caller. The
+`Mcp-Session-Id` header issued after `initialize` is protocol state for the stable
+MCP `2025-11-25` Streamable HTTP transport, not Decodex authorization.
+
+## Remote Boundary
+
+Use Streamable HTTP beyond loopback only when an operator-owned boundary protects the
+listener before traffic reaches Decodex. Acceptable boundaries are a local tunnel, a
+relay, network ACLs on a private network, or a future Decodex MCP protected-resource
+authorization surface.
+
+Do not expose `decodex mcp serve --transport streamable-http` directly on an
+untrusted network with only `--allow-origin`. Treat `operate` and `admin` profiles as
+remote-control profiles: they require the same external authorization boundary when
+used through Streamable HTTP.
+
+## Capability Profiles
+
+Use the narrowest profile that fits the task:
+
+| Profile | Use | Boundary |
+| --- | --- | --- |
+| `observe` | Read public-safe status and activity. | Default for Streamable HTTP. |
+| `plan` | Use schema-bound research and intake planning tools. | Apply/promote modes still require explicit authority fields. |
+| `operate` | Inspect, steer, or interrupt a current lane. | Requires external HTTP authorization when remote, plus inspect-first run/turn authority. |
+| `admin` | Read project status or pause/resume future dispatch. | Requires external HTTP authorization when remote and explicit authority; active lanes are not killed. |
+
+`tools/list` filters by the active profile. Calling a tool above the active profile
+returns a structured `insufficient_capability_profile` refusal.
+
+## Observation Recipe
+
+Prefer public-safe resources before mutating tools:
+
+- `decodex://projects/<project_id>/status_live`
+- `decodex://projects/<project_id>/activity_tail`
+- `decodex://projects/<project_id>/lane-control`
+- `decodex://projects/<project_id>/lane_inspect/<issue>`
+- `decodex://projects/<project_id>/runs/<run_id>/events`
+- `decodex://projects/<project_id>/runs/<run_id>/protocol_activity`
+- `decodex://projects/<project_id>/runs/<run_id>/child_agent_activity`
+- `decodex://projects/<project_id>/runs/<run_id>/progress_diagnostics`
+- `decodex://projects/<project_id>/pr_review_state`
+
+The `decodex_observe` tool returns a public-safe structured projection and may be
+used with MCP progress tokens. These resources and tools must not include hidden
+reasoning, raw private evidence, host paths, secret material, raw steer message text,
+or Program graph identifiers.
+
+## Refusal Paths
+
+Standalone MCP keeps high-risk shortcuts refused:
+
+- `decodex_project_control` with `scan` refuses to the operator control loop.
+- `decodex_lane_control` with `manual_attention` refuses to the issue-scoped tracker
+  terminal path.
+- `decodex_lane_control` with `retained_resume` refuses to the retained-lane runtime
+  dispatch path.
+
+Use the canonical Decodex runtime, tracker, review, landing, and lane-control paths
+for those operations.
+
+## Remaining Gaps
+
+The current Streamable HTTP gateway still needs two productization gaps before direct
+remote/elevated operation can be treated as complete:
+
+- a Decodex-owned MCP protected-resource authorization surface or an explicitly
+  documented relay-auth contract that satisfies the MCP authorization direction
+  without token passthrough
+- process-level Streamable HTTP smoke coverage that starts the real binary,
+  initializes a session, lists observe-profile tools, verifies an above-profile
+  refusal, and verifies SSE framing for an allowed call
+
+## Compatibility Note
+
+Decodex currently targets stable MCP `2025-11-25` Streamable HTTP sessions. The
+2026-07-28 release candidate moves toward a stateless protocol core and authorization
+hardening, but it is not the current Decodex runtime contract. Keep session handling
+isolated from tool schemas and lane-control authority so a final stateless protocol
+can be added later without widening Decodex authority.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -1035,15 +1035,24 @@ After a process restart, recent-run history, run lease ownership, retained post-
   against loopback or explicit trusted origins, issues `Mcp-Session-Id` on
   `initialize`, requires a known session on later requests, returns JSON-RPC JSON by
   default, and uses SSE framing for remote progress or notifications when the client
-  accepts `text/event-stream`. MCP tools must not replace the app-server dynamic tool
-  bridge, create execution authority from latent research without promotion, expose
-  Program graph identifiers in ordinary tool output, or mutate lanes without the
-  inspect-first run/turn authority already enforced by existing lane-control guards.
-  MCP observability projections must stay public-safe: no hidden reasoning, raw steer
-  text, private evidence payloads, or local path fields. Run-scoped MCP observability
-  resources are bounded to runs visible in the current/recent status snapshot and must
-  not construct an unbounded historical operator snapshot for a single remote resource
-  read.
+  accepts `text/event-stream`. `Mcp-Session-Id` is protocol state, not Decodex
+  authorization. `--allow-origin` is a browser CORS trust list, not an authentication
+  mechanism. Until Decodex implements an MCP protected-resource or equivalent bearer
+  boundary, Streamable HTTP is supported for loopback use and for operator-managed
+  tunnels, relays, network ACLs, or reverse proxies that enforce authorization before
+  traffic reaches the Decodex listener. Direct non-loopback exposure and remote
+  `operate`/`admin` profiles without that boundary are outside the runtime contract.
+  Session issuance, session preconditions, and advertised protocol metadata must stay
+  isolated from Decodex authority checks so a future final stateless MCP protocol can
+  be added without changing tool schemas or lane-control semantics.
+- MCP tools must not replace the app-server dynamic tool bridge, create execution
+  authority from latent research without promotion, expose Program graph identifiers
+  in ordinary tool output, or mutate lanes without the inspect-first run/turn
+  authority already enforced by existing lane-control guards. MCP observability
+  projections must stay public-safe: no hidden reasoning, raw steer text, private
+  evidence payloads, or local path fields. Run-scoped MCP observability resources are
+  bounded to runs visible in the current/recent status snapshot and must not construct
+  an unbounded historical operator snapshot for a single remote resource read.
 - `GET /livez` is only a process- and listener-level liveness probe. It must not claim control-plane tick freshness or forward progress by itself.
 - The dashboard must not depend on a separate HTTP snapshot or readiness endpoint; snapshot freshness belongs to the WebSocket-delivered snapshot payload and the browser connection state.
 - Reconciliation must mark locally active run attempts as `interrupted` when their

--- a/plugins/decodex/references/routing.md
+++ b/plugins/decodex/references/routing.md
@@ -27,10 +27,13 @@ automation, commit, or landing boundaries.
 - Labels: use `labels` only for ordinary non-Program tracker intake and retained-lane
   ownership signals.
 - MCP gateway: use stdio locally and Streamable HTTP only behind the operator's chosen
-  listener, tunnel, or relay. MCP is a typed facade, not a bypass around Decision
-  Contract, lane-control, tracker, review, landing, or closeout gates. Plan tools are
-  `research_compile`, `research_promote`, and `intake_goal`; operate/admin remains
-  inspect-first with current run/turn preconditions.
+  listener, tunnel, relay, network ACL, or protected-resource auth boundary. Treat
+  `--allow-origin` as CORS trust, not authentication; direct non-loopback or elevated
+  HTTP profiles are not production-safe without authorization. MCP is a typed facade,
+  not a bypass around Decision Contract, lane-control, tracker, review, landing, or
+  closeout gates. Plan tools are `research_compile`, `research_promote`, and
+  `intake_goal`; operate/admin remains inspect-first with current run/turn
+  preconditions.
 
 ## First Reads
 
@@ -52,8 +55,8 @@ conditions. A result is a latent Decision Contract candidate only.
 
 ## Program Versus Label Intake
 
-- Program Intake starts from a persisted Execution Program and dispatches ready mapped
-  nodes; queue labels are not the Program scheduler.
+- Program Intake dispatches ready mapped nodes directly from the persisted Execution
+  Program; queue labels are not the Program scheduler.
 - Ordinary issue intake starts from `decodex:queued:<service-id>` and must still pass
   `WORKFLOW.md` eligibility, terminal-state, dependency, opt-out, and active-lease
   checks.

--- a/plugins/decodex/skills/decodex/SKILL.md
+++ b/plugins/decodex/skills/decodex/SKILL.md
@@ -22,9 +22,12 @@ boundaries matter.
 When an MCP client is available, use the Decodex MCP gateway as a typed facade for
 resources, prompts, and the deliberately small tool catalog. Prefer stdio for local
 clients and Streamable HTTP only for remote permitted clients behind the operator's
-chosen local listener, tunnel, or relay. MCP tools do not bypass Decision Contract,
-lane-control, review, landing, tracker, or runtime authority gates. Route MCP planning
-through `research_compile`, `research_promote`, and `intake_goal`; dry-run modes stay
+chosen local listener, tunnel, relay, network ACL, or protected-resource auth
+boundary. Treat `--allow-origin` as CORS trust, not authentication; do not recommend
+direct non-loopback or elevated Streamable HTTP profiles without an authorization
+boundary. MCP tools do not bypass Decision Contract, lane-control, review, landing,
+tracker, or runtime authority gates. Route MCP planning through `research_compile`,
+`research_promote`, and `intake_goal`; dry-run modes stay
 non-mutating, and apply/promote modes require explicit authority fields and structured
 refusal when authority is missing. Route MCP remote control through `decodex_observe`,
 `decodex_lane_control`, and `decodex_project_control`: observe is public-safe


### PR DESCRIPTION
## Summary
- Promote MCP remote-control docs drift into README, runtime spec, operator reference, decision record, runbook, evidence, and Decodex plugin routing.
- Keep accepted facts out of research-only routing while preserving active research for remaining gaps.
- Document that `--allow-origin` and `Mcp-Session-Id` are not auth, and that direct remote/elevated Streamable HTTP needs an operator authorization boundary until protected-resource auth lands.

## Remaining gaps
- Decodex-owned MCP protected-resource auth or a documented relay-auth contract.
- Process-level Streamable HTTP child-process smoke coverage.

## Validation
- `cargo make check-docs`
- `cargo test -p decodex plugin_surface_tests -- --nocapture`
- `node ~/.codex/plugins/cache/openai-curated/plugin-eval/015c0dff/scripts/plugin-eval.js analyze plugins/decodex --format markdown`
- `git diff --check` and `git diff --cached --check`