### PR TITLE
Complete MCP remote-control productization

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,13 @@ for operator-chosen local, tunnel, or relay access. Streamable HTTP validates br
 requests, returns ordinary JSON-RPC JSON responses, and switches to
 `text/event-stream` framing when the client sends `Accept: text/event-stream`.
 The session header is protocol state, not authorization. `--allow-origin` is CORS
-trust, not authentication. Use Streamable HTTP remote control over loopback or behind
-an operator-owned tunnel, relay, network ACL, or MCP authorization boundary; direct
-non-loopback exposure and elevated `operate`/`admin` profiles are unsupported without
-that external boundary until Decodex implements a protected-resource auth surface.
+trust, not authentication. Use `--bearer-token-env <ENV_VAR>` when a Streamable HTTP
+listener is reachable beyond loopback or when exposing any profile above `observe`;
+Decodex validates `Authorization: Bearer <token>` for `POST` and `DELETE` while still
+allowing unauthenticated CORS preflight. Direct non-loopback listeners require both
+`--allow-origin` and `--bearer-token-env`. The built-in bearer guard is Decodex's
+minimum direct-listener boundary, not OAuth Protected Resource Metadata; OAuth or a
+managed relay can still sit in front for broader MCP client interoperability.
 The gateway advertises resources, resource templates, prompts, tools, logging
 compatibility, and progress notifications. Resources expose checked-in documentation,
 checked-in Markdown research concepts, runtime Decision Contract readback, local status

--- a/apps/decodex/src/cli.rs
+++ b/apps/decodex/src/cli.rs
@@ -566,6 +566,9 @@ struct McpServeCommand {
 	/// Trusted browser Origin for Streamable HTTP. Repeat for multiple origins.
 	#[arg(long = "allow-origin", value_name = "ORIGIN")]
 	allowed_origins: Vec<String>,
+	/// Environment variable containing the Streamable HTTP bearer token.
+	#[arg(long = "bearer-token-env", value_name = "ENV_VAR")]
+	bearer_token_env: Option<String>,
 }
 impl McpServeCommand {
 	fn run(&self) -> Result<()> {
@@ -575,6 +578,7 @@ impl McpServeCommand {
 			capability_profile: self.effective_capability_profile(),
 			listen_address: &self.listen_address,
 			allowed_origins: &self.allowed_origins,
+			bearer_token_env: self.bearer_token_env.as_deref(),
 		})
 	}
 
@@ -1847,7 +1851,6 @@ mod tests {
 			"--text",
 			"command design",
 		]);
-
 		let Command::Okf(OkfCommand {
 			command:
 				OkfSubcommand::Find(super::OkfFindCommand {
@@ -2089,6 +2092,7 @@ mod tests {
 		assert_eq!(serve.effective_capability_profile(), McpCapabilityProfile::Admin);
 		assert_eq!(serve.listen_address, crate::mcp::DEFAULT_MCP_HTTP_LISTEN_ADDRESS);
 		assert!(serve.allowed_origins.is_empty());
+		assert_eq!(serve.bearer_token_env, None);
 	}
 
 	#[test]
@@ -2103,6 +2107,8 @@ mod tests {
 			"127.0.0.1:8194",
 			"--allow-origin",
 			"http://127.0.0.1:8194",
+			"--bearer-token-env",
+			"DECODEX_MCP_TOKEN",
 		]);
 		let Command::Mcp(command) = cli.command else {
 			panic!("expected mcp command");
@@ -2113,6 +2119,7 @@ mod tests {
 		assert_eq!(serve.effective_capability_profile(), McpCapabilityProfile::Observe);
 		assert_eq!(serve.listen_address, "127.0.0.1:8194");
 		assert_eq!(serve.allowed_origins, vec!["http://127.0.0.1:8194"]);
+		assert_eq!(serve.bearer_token_env.as_deref(), Some("DECODEX_MCP_TOKEN"));
 	}
 
 	#[test]

--- a/apps/decodex/src/mcp.rs
+++ b/apps/decodex/src/mcp.rs
@@ -59,7 +59,9 @@ const MCP_HTTP_READ_TIMEOUT: Duration = Duration::from_secs(2);
 const MCP_HTTP_MAX_REQUEST_BYTES: usize = 1_024 * 1_024;
 const MCP_SESSION_HEADER: &str = "Mcp-Session-Id";
 const MCP_CORS_ALLOW_METHODS: &str = "POST, DELETE, OPTIONS";
-const MCP_CORS_ALLOW_HEADERS: &str = "Content-Type, Accept, Mcp-Session-Id";
+const MCP_CORS_ALLOW_HEADERS: &str = "Content-Type, Accept, Mcp-Session-Id, Authorization";
+const MCP_AUTHORIZATION_HEADER: &str = "Authorization";
+const MCP_WWW_AUTHENTICATE_HEADER: &str = "Bearer realm=\"decodex-mcp\"";
 
 /// MCP transport supported by the native Decodex gateway.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -124,6 +126,7 @@ pub(crate) struct McpServeRequest<'a> {
 	pub(crate) capability_profile: McpCapabilityProfile,
 	pub(crate) listen_address: &'a str,
 	pub(crate) allowed_origins: &'a [String],
+	pub(crate) bearer_token_env: Option<&'a str>,
 }
 
 struct McpServer {
@@ -1735,11 +1738,74 @@ impl McpError {
 	}
 }
 
+#[derive(Clone, Default)]
+struct McpHttpAuthorization {
+	token: Option<String>,
+}
+impl McpHttpAuthorization {
+	fn disabled() -> Self {
+		Self { token: None }
+	}
+
+	fn from_env_var_name(env_var: Option<&str>) -> crate::prelude::Result<Self> {
+		let Some(env_var) = env_var else {
+			return Ok(Self::disabled());
+		};
+
+		validate_mcp_bearer_token_env_var_name(env_var)?;
+
+		let token = env::var(env_var).map_err(|_| {
+			eyre::eyre!(
+				"Streamable HTTP bearer token env var `{env_var}` is not set; set it or remove --bearer-token-env."
+			)
+		})?;
+
+		validate_mcp_bearer_token(&token, env_var)?;
+
+		Ok(Self { token: Some(token) })
+	}
+
+	fn is_required(&self) -> bool {
+		self.token.is_some()
+	}
+
+	fn request_is_authorized(&self, request: &McpHttpRequest) -> bool {
+		let Some(expected) = self.token.as_deref() else {
+			return true;
+		};
+		let Some(header) = request.header(MCP_AUTHORIZATION_HEADER) else {
+			return false;
+		};
+		let Some((scheme, supplied)) = header.trim().split_once(' ') else {
+			return false;
+		};
+
+		scheme.eq_ignore_ascii_case("Bearer") && supplied == expected
+	}
+
+	fn unauthorized_response() -> McpHttpResponse {
+		let mut response = McpHttpResponse::json_error(
+			"401 Unauthorized",
+			json_rpc_error(Value::Null, -32_000, "Unauthorized"),
+		);
+
+		response.headers.push(("WWW-Authenticate", String::from(MCP_WWW_AUTHENTICATE_HEADER)));
+
+		response
+	}
+
+	#[cfg(test)]
+	fn from_token_for_test(token: &str) -> Self {
+		Self { token: Some(token.to_owned()) }
+	}
+}
+
 struct McpHttpHandler {
 	server: McpServer,
 	sessions: McpHttpSessions,
 	allowed_origins: Vec<String>,
 	listen_address: Option<String>,
+	authorization: McpHttpAuthorization,
 }
 impl McpHttpHandler {
 	fn handle_request_bytes(&mut self, request: &[u8]) -> crate::prelude::Result<Vec<u8>> {
@@ -1766,6 +1832,9 @@ impl McpHttpHandler {
 		};
 		let mut response = if request.path != MCP_HTTP_ENDPOINT_PATH {
 			McpHttpResponse::empty("404 Not Found")
+		} else if request.method != "OPTIONS" && !self.authorization.request_is_authorized(&request)
+		{
+			McpHttpAuthorization::unauthorized_response()
 		} else {
 			match request.method.as_str() {
 				"OPTIONS" => self.handle_options(&request),
@@ -2144,7 +2213,14 @@ pub(crate) fn serve(request: McpServeRequest<'_>) -> crate::prelude::Result<()> 
 			)
 		},
 		McpTransport::StreamableHttp => {
-			validate_mcp_http_listen_address(request.listen_address, request.allowed_origins)?;
+			let authorization = McpHttpAuthorization::from_env_var_name(request.bearer_token_env)?;
+
+			validate_mcp_http_listen_address(
+				request.listen_address,
+				request.allowed_origins,
+				&authorization,
+			)?;
+			validate_mcp_http_capability_profile(request.capability_profile, &authorization)?;
 
 			let context = McpContext::for_process(request.config_path)?;
 			let listener = TcpListener::bind(request.listen_address).map_err(|error| {
@@ -2159,9 +2235,44 @@ pub(crate) fn serve(request: McpServeRequest<'_>) -> crate::prelude::Result<()> 
 				context,
 				request.capability_profile,
 				request.allowed_origins.to_vec(),
+				authorization,
 			)
 		},
 	}
+}
+
+fn validate_mcp_bearer_token_env_var_name(env_var: &str) -> crate::prelude::Result<()> {
+	if env_var.is_empty() || env_var.trim() != env_var {
+		eyre::bail!("--bearer-token-env must name a non-empty environment variable.");
+	}
+
+	let mut chars = env_var.chars();
+	let Some(first) = chars.next() else {
+		eyre::bail!("--bearer-token-env must name a non-empty environment variable.");
+	};
+
+	if !(first.is_ascii_alphabetic() || first == '_')
+		|| !chars.all(|char| char.is_ascii_alphanumeric() || char == '_')
+	{
+		eyre::bail!(
+			"--bearer-token-env must start with an ASCII letter or underscore and contain only ASCII letters, digits, or underscores."
+		);
+	}
+
+	Ok(())
+}
+
+fn validate_mcp_bearer_token(token: &str, env_var: &str) -> crate::prelude::Result<()> {
+	if token.is_empty() || token.trim().is_empty() {
+		eyre::bail!("Streamable HTTP bearer token env var `{env_var}` is empty.");
+	}
+	if token.chars().any(char::is_whitespace) {
+		eyre::bail!(
+			"Streamable HTTP bearer token env var `{env_var}` must not contain whitespace."
+		);
+	}
+
+	Ok(())
 }
 
 fn mcp_http_response_for_server_responses(
@@ -4181,12 +4292,14 @@ fn serve_streamable_http_with_profile(
 	context: McpContext,
 	capability_profile: McpCapabilityProfile,
 	allowed_origins: Vec<String>,
+	authorization: McpHttpAuthorization,
 ) -> crate::prelude::Result<()> {
 	let mut handler = McpHttpHandler {
 		server: McpServer { context, capability_profile, transport: McpTransport::StreamableHttp },
 		sessions: McpHttpSessions::default(),
 		allowed_origins,
 		listen_address: listener.local_addr().map(|address| address.to_string()).ok(),
+		authorization,
 	};
 
 	for stream in listener.incoming() {
@@ -4253,13 +4366,36 @@ fn read_mcp_http_request(stream: &mut TcpStream) -> crate::prelude::Result<Vec<u
 fn validate_mcp_http_listen_address(
 	address: &str,
 	allowed_origins: &[String],
+	authorization: &McpHttpAuthorization,
 ) -> crate::prelude::Result<()> {
-	if listen_address_host_is_loopback(address) || !allowed_origins.is_empty() {
+	if listen_address_host_is_loopback(address) {
+		return Ok(());
+	}
+	if allowed_origins.is_empty() {
+		eyre::bail!(
+			"Refusing to bind Decodex MCP Streamable HTTP to `{address}` without --allow-origin; use the loopback default or set explicit trusted origins."
+		)
+	}
+	if !authorization.is_required() {
+		eyre::bail!(
+			"Refusing to bind Decodex MCP Streamable HTTP to `{address}` without --bearer-token-env; direct non-loopback listeners require bearer authorization."
+		)
+	}
+
+	Ok(())
+}
+
+fn validate_mcp_http_capability_profile(
+	capability_profile: McpCapabilityProfile,
+	authorization: &McpHttpAuthorization,
+) -> crate::prelude::Result<()> {
+	if capability_profile == McpCapabilityProfile::Observe || authorization.is_required() {
 		return Ok(());
 	}
 
 	eyre::bail!(
-		"Refusing to bind Decodex MCP Streamable HTTP to `{address}` without --allow-origin; use the loopback default or set explicit trusted origins."
+		"Refusing to expose Decodex MCP Streamable HTTP profile `{}` without --bearer-token-env; elevated HTTP profiles require bearer authorization.",
+		capability_profile.as_str()
 	)
 }
 
@@ -4733,7 +4869,8 @@ mod tests {
 		loop_contract::{DecisionContract, DecisionPromotion, DecisionPromotionActorKind},
 		mcp::{
 			self, DEFAULT_MCP_HTTP_LISTEN_ADDRESS, McpCapabilityProfile, McpContext,
-			McpHttpHandler, McpHttpSessions, McpServer, McpTransport, ResourceContent,
+			McpHttpAuthorization, McpHttpHandler, McpHttpSessions, McpServer, McpTransport,
+			ResourceContent,
 		},
 		runtime,
 		state::{self, ProtocolActivityEventSummary, ProtocolActivitySummary, StateStore},
@@ -6072,8 +6209,81 @@ mod tests {
 		assert_eq!(response.header("access-control-allow-methods"), Some("POST, DELETE, OPTIONS"));
 		assert_eq!(
 			response.header("access-control-allow-headers"),
-			Some("Content-Type, Accept, Mcp-Session-Id")
+			Some("Content-Type, Accept, Mcp-Session-Id, Authorization")
 		);
+	}
+
+	#[test]
+	fn streamable_http_bearer_auth_challenges_missing_or_invalid_authorization() {
+		let repo = test_repo();
+		let mut handler = http_handler_with_authorization(
+			repo.path(),
+			McpCapabilityProfile::Observe,
+			McpHttpAuthorization::from_token_for_test("secret-token"),
+		);
+
+		for headers in [
+			vec![("Origin", "http://127.0.0.1:8193")],
+			vec![("Origin", "http://127.0.0.1:8193"), ("Authorization", "Bearer wrong-token")],
+		] {
+			let response = run_http(
+				&mut handler,
+				http_post(
+					"/mcp",
+					headers,
+					r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+				),
+			);
+			let body = response.json_body();
+
+			assert_eq!(response.status, "HTTP/1.1 401 Unauthorized");
+			assert_eq!(response.header("www-authenticate"), Some("Bearer realm=\"decodex-mcp\""));
+			assert_eq!(body["error"]["message"], "Unauthorized");
+			assert!(!response.body_text().contains("secret-token"));
+		}
+	}
+
+	#[test]
+	fn streamable_http_bearer_auth_accepts_valid_authorization() {
+		let repo = test_repo();
+		let mut handler = http_handler_with_authorization(
+			repo.path(),
+			McpCapabilityProfile::Observe,
+			McpHttpAuthorization::from_token_for_test("secret-token"),
+		);
+		let preflight = run_http(
+			&mut handler,
+			http_options(
+				"/mcp",
+				[
+					("Origin", "http://127.0.0.1:8193"),
+					("Access-Control-Request-Method", "POST"),
+					("Access-Control-Request-Headers", "Authorization, Content-Type"),
+				],
+			),
+		);
+		let response = run_http(
+			&mut handler,
+			http_post(
+				"/mcp",
+				[("Origin", "http://127.0.0.1:8193"), ("Authorization", "Bearer secret-token")],
+				r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+			),
+		);
+		let body = response.json_body();
+
+		assert_eq!(preflight.status, "HTTP/1.1 204 No Content");
+		assert_eq!(
+			preflight.header("access-control-allow-headers"),
+			Some("Content-Type, Accept, Mcp-Session-Id, Authorization")
+		);
+		assert_eq!(response.status, "HTTP/1.1 200 OK");
+		assert!(response.header("mcp-session-id").is_some());
+		assert_eq!(
+			body["result"]["capabilities"]["experimental"]["decodex"]["capabilityProfile"],
+			"observe"
+		);
+		assert!(!response.body_text().contains("secret-token"));
 	}
 
 	#[test]
@@ -6254,16 +6464,67 @@ mod tests {
 	#[test]
 	fn streamable_http_bind_guard_requires_loopback_or_allowed_origin() {
 		assert!(
-			mcp::validate_mcp_http_listen_address(DEFAULT_MCP_HTTP_LISTEN_ADDRESS, &[]).is_ok()
-		);
-		assert!(mcp::validate_mcp_http_listen_address("0.0.0.0:8193", &[]).is_err());
-		assert!(
 			mcp::validate_mcp_http_listen_address(
-				"0.0.0.0:8193",
-				&[String::from("https://relay.example")]
+				DEFAULT_MCP_HTTP_LISTEN_ADDRESS,
+				&[],
+				&McpHttpAuthorization::disabled()
 			)
 			.is_ok()
 		);
+		assert!(
+			mcp::validate_mcp_http_listen_address(
+				"0.0.0.0:8193",
+				&[],
+				&McpHttpAuthorization::disabled()
+			)
+			.is_err()
+		);
+		assert!(
+			mcp::validate_mcp_http_listen_address(
+				"0.0.0.0:8193",
+				&[String::from("https://relay.example")],
+				&McpHttpAuthorization::disabled()
+			)
+			.is_err()
+		);
+		assert!(
+			mcp::validate_mcp_http_listen_address(
+				"0.0.0.0:8193",
+				&[String::from("https://relay.example")],
+				&McpHttpAuthorization::from_token_for_test("secret-token")
+			)
+			.is_ok()
+		);
+	}
+
+	#[test]
+	fn streamable_http_elevated_profile_requires_bearer_authorization() {
+		assert!(
+			mcp::validate_mcp_http_capability_profile(
+				McpCapabilityProfile::Observe,
+				&McpHttpAuthorization::disabled()
+			)
+			.is_ok()
+		);
+
+		for profile in
+			[McpCapabilityProfile::Plan, McpCapabilityProfile::Operate, McpCapabilityProfile::Admin]
+		{
+			assert!(
+				mcp::validate_mcp_http_capability_profile(
+					profile,
+					&McpHttpAuthorization::disabled()
+				)
+				.is_err()
+			);
+			assert!(
+				mcp::validate_mcp_http_capability_profile(
+					profile,
+					&McpHttpAuthorization::from_token_for_test("secret-token")
+				)
+				.is_ok()
+			);
+		}
 	}
 
 	#[test]
@@ -6804,6 +7065,26 @@ mod tests {
 		http_handler_with_allowed_origins(repo_root, capability_profile, Vec::new())
 	}
 
+	fn http_handler_with_authorization(
+		repo_root: &Path,
+		capability_profile: McpCapabilityProfile,
+		authorization: McpHttpAuthorization,
+	) -> McpHttpHandler {
+		let context = McpContext {
+			repo_root: repo_root.to_path_buf(),
+			config_path: None,
+			project_id: None,
+			state_store: None,
+		};
+
+		http_handler_with_context_and_authorization(
+			context,
+			capability_profile,
+			Vec::new(),
+			authorization,
+		)
+	}
+
 	fn http_handler_with_allowed_origins(
 		repo_root: &Path,
 		capability_profile: McpCapabilityProfile,
@@ -6824,6 +7105,20 @@ mod tests {
 		capability_profile: McpCapabilityProfile,
 		allowed_origins: Vec<String>,
 	) -> McpHttpHandler {
+		http_handler_with_context_and_authorization(
+			context,
+			capability_profile,
+			allowed_origins,
+			McpHttpAuthorization::disabled(),
+		)
+	}
+
+	fn http_handler_with_context_and_authorization(
+		context: McpContext,
+		capability_profile: McpCapabilityProfile,
+		allowed_origins: Vec<String>,
+		authorization: McpHttpAuthorization,
+	) -> McpHttpHandler {
 		McpHttpHandler {
 			server: McpServer {
 				context,
@@ -6833,6 +7128,7 @@ mod tests {
 			sessions: McpHttpSessions::default(),
 			allowed_origins,
 			listen_address: Some(String::from(DEFAULT_MCP_HTTP_LISTEN_ADDRESS)),
+			authorization,
 		}
 	}
 

--- a/apps/decodex/src/orchestrator/tests/runtime/failure.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/failure.rs
@@ -1668,6 +1668,7 @@ fn loop_guardrail_does_not_classify_committed_branch_delta_as_no_effective_diff(
 		"implementation complete\n",
 		"implement issue scope",
 	);
+
 	assert_eq!(git_output(config.repo_root(), &["status", "--porcelain"]), "");
 
 	for attempt_number in 1..=3 {

--- a/apps/decodex/src/orchestrator/tests/runtime/repo_gate.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/repo_gate.rs
@@ -241,6 +241,7 @@ fn phase_goal_acceptance_accepts_committed_branch_delta_with_clean_worktree() {
 		"implementation complete\n",
 		"implement issue scope",
 	);
+
 	assert_eq!(git_output(config.repo_root(), &["status", "--porcelain"]), "");
 
 	record_phase_acceptance_progress_checkpoint(&config, &state_store, &issue_run, &[]);

--- a/apps/decodex/src/state/store.rs
+++ b/apps/decodex/src/state/store.rs
@@ -3084,9 +3084,7 @@ impl StateStore {
 					Ok(None) => return None,
 					Err(error) => return Some(Err(error)),
 				};
-				let Some(attempt) = state.run_attempts.get(marker.run_id()) else {
-					return None;
-				};
+				let attempt = state.run_attempts.get(marker.run_id())?;
 
 				if attempt.issue_id != mapping.issue_id
 					|| attempt.attempt_number != marker.attempt_number()

--- a/apps/decodex/src/state/tests.rs
+++ b/apps/decodex/src/state/tests.rs
@@ -4200,6 +4200,7 @@ fn run_control_accepts_marker_hydrated_active_attempt_identity() {
 		.upsert_worktree("pubfi", "issue-1", "x/pubfi-issue-1", &worktree_path_text)
 		.expect("worktree should record");
 	store.record_run_attempt("run-1", "issue-1", 1, "running").expect("attempt should record");
+
 	state::write_run_effective_runtime_marker(
 		&worktree_path,
 		"run-1",
@@ -4216,6 +4217,7 @@ fn run_control_accepts_marker_hydrated_active_attempt_identity() {
 		},
 	)
 	.expect("runtime marker should write");
+
 	store
 		.publish_run_control_channel_for_active_attempt("run-1", 1, &channel_path, "local_file")
 		.expect("control channel should publish")

--- a/apps/decodex/tests/mcp_stdio.rs
+++ b/apps/decodex/tests/mcp_stdio.rs
@@ -4,13 +4,97 @@
 
 use std::{
 	fs,
-	io::Write as _,
-	path::PathBuf,
-	process::{Command, Stdio},
+	io::{Read as _, Result, Write},
+	net::{Shutdown, TcpListener, TcpStream},
+	path::{Path, PathBuf},
+	process::{Child, Command, ExitStatus, Output, Stdio},
+	str, thread,
+	time::{Duration, Instant},
 };
 
 use serde_json::Value;
 use tempfile::TempDir;
+
+struct TestProject {
+	_home: TempDir,
+	_project: TempDir,
+	repo_path: PathBuf,
+	home_path: PathBuf,
+	config_path: PathBuf,
+}
+
+struct ChildGuard {
+	child: Option<Child>,
+}
+impl ChildGuard {
+	fn new(child: Child) -> Self {
+		Self { child: Some(child) }
+	}
+
+	fn try_wait(&mut self) -> Option<ExitStatus> {
+		self.child.as_mut().and_then(|child| child.try_wait().expect("child wait should run"))
+	}
+
+	fn stop(mut self) -> Output {
+		let mut child = self.child.take().expect("child should exist");
+		let _ = child.kill();
+
+		child.wait_with_output().expect("child output should collect")
+	}
+}
+
+impl Drop for ChildGuard {
+	fn drop(&mut self) {
+		if let Some(child) = self.child.as_mut() {
+			let _ = child.kill();
+			let _ = child.wait();
+		}
+	}
+}
+
+#[derive(Debug)]
+struct ParsedHttpResponse {
+	status: String,
+	headers: Vec<(String, String)>,
+	body: Vec<u8>,
+}
+impl ParsedHttpResponse {
+	fn parse(bytes: Vec<u8>) -> Self {
+		let header_end = bytes
+			.windows(4)
+			.position(|window| window == b"\r\n\r\n")
+			.expect("HTTP response should have headers");
+		let header_text = str::from_utf8(&bytes[..header_end]).expect("headers should be utf-8");
+		let mut lines = header_text.split("\r\n");
+		let status = lines.next().expect("status line should exist").to_owned();
+		let headers = lines
+			.filter_map(|line| {
+				let (name, value) = line.split_once(':')?;
+
+				Some((name.trim().to_ascii_lowercase(), value.trim().to_owned()))
+			})
+			.collect();
+
+		Self { status, headers, body: bytes[header_end + 4..].to_vec() }
+	}
+
+	fn header(&self, name: &str) -> Option<&str> {
+		let lower_name = name.to_ascii_lowercase();
+
+		self.headers
+			.iter()
+			.find(|(header, _)| header == &lower_name)
+			.map(|(_, value)| value.as_str())
+	}
+
+	fn body_text(&self) -> String {
+		String::from_utf8(self.body.clone()).expect("body should be utf-8")
+	}
+
+	fn json_body(&self) -> Value {
+		serde_json::from_slice(&self.body).expect("body should be JSON")
+	}
+}
 
 #[test]
 fn mcp_stdio_process_stdout_contains_only_json_rpc() {
@@ -64,6 +148,107 @@ fn mcp_stdio_process_stdout_contains_only_json_rpc() {
 	}
 }
 
+#[test]
+fn mcp_streamable_http_process_observe_profile_smoke() {
+	let fixture = test_project();
+	let addr = free_loopback_address();
+	let mut child = ChildGuard::new(
+		Command::new(env!("CARGO_BIN_EXE_decodex"))
+			.args([
+				"mcp",
+				"serve",
+				"--config",
+				fixture.config_path.to_str().expect("config path should be utf-8"),
+				"--transport",
+				"streamable-http",
+				"--listen-address",
+				addr.as_str(),
+			])
+			.current_dir(&fixture.repo_path)
+			.env("HOME", fixture.home_path.to_str().expect("home path should be utf-8"))
+			.stdin(Stdio::null())
+			.stdout(Stdio::piped())
+			.stderr(Stdio::piped())
+			.spawn()
+			.expect("decodex mcp HTTP process should spawn"),
+	);
+
+	wait_for_streamable_http(&addr, &mut child);
+
+	let origin = format!("http://{addr}");
+	let initialize = http_post(
+		&addr,
+		&[("Origin", origin.as_str()), ("Accept", "application/json")],
+		r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+	);
+	let session_id = initialize.header("mcp-session-id").expect("session id").to_owned();
+
+	assert_eq!(initialize.status, "HTTP/1.1 200 OK");
+	assert_eq!(initialize.json_body()["result"]["protocolVersion"], "2025-11-25");
+
+	let tools_list = http_post(
+		&addr,
+		&[
+			("Origin", origin.as_str()),
+			("Accept", "application/json"),
+			("Mcp-Session-Id", session_id.as_str()),
+		],
+		r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#,
+	);
+	let tools_list_body = tools_list.json_body();
+	let tool_names = tools_list_body["result"]["tools"]
+		.as_array()
+		.expect("tools array")
+		.iter()
+		.filter_map(|tool| tool.get("name").and_then(Value::as_str))
+		.collect::<Vec<_>>();
+
+	assert_eq!(tool_names, vec!["decodex_observe"]);
+
+	let above_profile = http_post(
+		&addr,
+		&[
+			("Origin", origin.as_str()),
+			("Accept", "application/json"),
+			("Mcp-Session-Id", session_id.as_str()),
+		],
+		r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"decodex_plan","arguments":{"intent":"validation_ready"}}}"#,
+	);
+	let above_profile_body = above_profile.json_body();
+
+	assert_eq!(
+		above_profile_body["result"]["structuredContent"]["reason"],
+		"insufficient_capability_profile"
+	);
+	assert_eq!(above_profile_body["result"]["structuredContent"]["capability_profile"], "observe");
+
+	let observe_sse = http_post(
+		&addr,
+		&[
+			("Origin", origin.as_str()),
+			("Accept", "text/event-stream"),
+			("Mcp-Session-Id", session_id.as_str()),
+		],
+		r#"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"_meta":{"progressToken":"progress-1"},"name":"decodex_observe","arguments":{"limit":1}}}"#,
+	);
+	let observe_sse_body = observe_sse.body_text();
+
+	assert_eq!(observe_sse.status, "HTTP/1.1 200 OK");
+	assert_eq!(observe_sse.header("content-type"), Some("text/event-stream"));
+	assert!(observe_sse_body.contains("event: message"));
+	assert!(observe_sse_body.contains("\"method\":\"notifications/progress\""));
+	assert!(observe_sse_body.contains("\"progressToken\":\"progress-1\""));
+	assert!(observe_sse_body.contains("\"id\":4"));
+
+	let output = child.stop();
+
+	assert!(output.stdout.is_empty(), "HTTP MCP process must not write stdout");
+	assert!(
+		String::from_utf8_lossy(&output.stderr).trim().is_empty(),
+		"HTTP MCP process should not print diagnostics for the smoke path"
+	);
+}
+
 fn test_repo() -> TempDir {
 	let repo = TempDir::new().expect("temp repo should exist");
 
@@ -75,9 +260,178 @@ fn test_repo() -> TempDir {
 	repo
 }
 
+fn test_project() -> TestProject {
+	let home = TempDir::new().expect("temp home should exist");
+	let project = TempDir::new().expect("temp project should exist");
+	let repo_path = project.path().join("repo");
+	let project_config_dir = project.path().join("project");
+	let config_path = project_config_dir.join("project.toml");
+
+	fs::create_dir_all(repo_path.join(".worktrees")).expect("worktree root should exist");
+	fs::create_dir_all(&project_config_dir).expect("project config dir should exist");
+
+	write_file(repo_path.join("README.md"), "test repo\n");
+	write_file(repo_path.join("docs/index.md"), "# Docs\n");
+	write_file(
+		project_config_dir.join("WORKFLOW.md"),
+		r#"+++
+version = 1
+
+[tracker]
+provider = "linear"
+startable_states = ["Todo"]
+terminal_states = ["Done", "Canceled", "Duplicate"]
+in_progress_state = "In Progress"
+success_state = "In Review"
+completed_state = "Done"
+failure_state = "Todo"
+opt_out_label = "decodex:manual-only"
+needs_attention_label = "decodex:needs-attention"
+
+[agent]
+transport = "stdio://"
+
+[execution]
+max_attempts = 3
+max_turns = 1
+max_retry_backoff_ms = 300000
+max_concurrent_agents = 1
+gate_profiles = {}
+canonicalize_commands = []
+verify_commands = []
+
+[execution.workspace_hooks]
+after_create_commands = []
+before_remove_commands = []
+timeout_seconds = 60
+
+[context]
+read_first = []
++++
+
+Read the repo policy first.
+"#,
+	);
+	write_file(
+		config_path.clone(),
+		&format!(
+			r#"service_id = "decodex"
+
+[tracker]
+api_key_env_var = "HOME"
+
+[github]
+token_env_var = "HOME"
+
+[codex]
+review = "standard"
+
+[paths]
+repo_root = "{}"
+worktree_root = ".worktrees"
+"#,
+			repo_path.display()
+		),
+	);
+	git_status_success(&repo_path, &["init", "-b", "main"]);
+	git_status_success(&repo_path, &["config", "user.name", "Decodex Tests"]);
+	git_status_success(&repo_path, &["config", "user.email", "decodex-tests@example.com"]);
+	git_status_success(&repo_path, &["config", "commit.gpgsign", "false"]);
+	git_status_success(&repo_path, &["add", "."]);
+	git_status_success(&repo_path, &["commit", "-m", "bootstrap repo"]);
+
+	TestProject {
+		home_path: home.path().to_path_buf(),
+		repo_path,
+		config_path,
+		_home: home,
+		_project: project,
+	}
+}
+
+fn git_status_success(cwd: &Path, args: &[&str]) {
+	let output =
+		Command::new("git").arg("-C").arg(cwd).args(args).output().expect("git should run");
+
+	assert!(
+		output.status.success(),
+		"git {:?} failed: {}",
+		args,
+		String::from_utf8_lossy(&output.stderr)
+	);
+}
+
 fn write_file(path: PathBuf, contents: &str) {
 	let parent = path.parent().expect("test path should have parent");
 
 	fs::create_dir_all(parent).expect("parent directory should exist");
 	fs::write(path, contents).expect("test file should write");
+}
+
+fn free_loopback_address() -> String {
+	let listener = TcpListener::bind("127.0.0.1:0").expect("free loopback port should bind");
+	let address = listener.local_addr().expect("loopback address should exist");
+
+	address.to_string()
+}
+
+fn wait_for_streamable_http(addr: &str, child: &mut ChildGuard) {
+	let deadline = Instant::now() + Duration::from_secs(10);
+
+	loop {
+		if let Some(status) = child.try_wait() {
+			panic!("HTTP MCP process exited before accepting requests: {status:?}");
+		}
+
+		match http_options(addr) {
+			Ok(response) if response.status == "HTTP/1.1 204 No Content" => return,
+			Ok(response) => panic!("HTTP MCP readiness probe returned {}", response.status),
+			Err(_) if Instant::now() < deadline => thread::sleep(Duration::from_millis(50)),
+			Err(error) => panic!("HTTP MCP process did not listen at {addr}: {error}"),
+		}
+	}
+}
+
+fn http_options(addr: &str) -> Result<ParsedHttpResponse> {
+	let request = format!(
+		"OPTIONS /mcp HTTP/1.1\r\nHost: {addr}\r\nAccess-Control-Request-Method: POST\r\nContent-Length: 0\r\n\r\n"
+	);
+	let mut stream = TcpStream::connect(addr)?;
+	let mut response = Vec::new();
+
+	stream.write_all(request.as_bytes())?;
+	stream.shutdown(Shutdown::Write)?;
+	stream.read_to_end(&mut response)?;
+
+	Ok(ParsedHttpResponse::parse(response))
+}
+
+fn http_post(addr: &str, headers: &[(&str, &str)], body: &str) -> ParsedHttpResponse {
+	let mut request = format!(
+		"POST /mcp HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n",
+		body.len()
+	);
+
+	for (name, value) in headers {
+		request.push_str(name);
+		request.push_str(": ");
+		request.push_str(value);
+		request.push_str("\r\n");
+	}
+
+	request.push_str("\r\n");
+	request.push_str(body);
+
+	http_raw(addr, &request)
+}
+
+fn http_raw(addr: &str, request: &str) -> ParsedHttpResponse {
+	let mut stream = TcpStream::connect(addr).expect("HTTP server should accept TCP");
+	let mut response = Vec::new();
+
+	stream.write_all(request.as_bytes()).expect("HTTP request should write");
+	stream.shutdown(Shutdown::Write).expect("HTTP request should finish");
+	stream.read_to_end(&mut response).expect("HTTP response should read");
+
+	ParsedHttpResponse::parse(response)
 }

--- a/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
+++ b/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
@@ -116,8 +116,11 @@ uses SSE framing for progress or notifications when the client accepts
 `text/event-stream`. Loopback `observe` is the safe default. MCP sessions are protocol
 state rather than authorization, and `--allow-origin` is CORS trust rather than an
 authentication boundary. Direct non-loopback operation and elevated Streamable HTTP
-profiles require an operator-owned tunnel, relay, network ACL, or future Decodex
-protected-resource authorization boundary before they are production-safe.
+profiles require a Decodex bearer boundary with `--bearer-token-env`, or a stronger
+operator-owned tunnel, relay, network ACL, reverse proxy, or OAuth-capable protected
+resource boundary before they are production-safe. The built-in bearer guard protects
+direct Decodex listeners but does not claim OAuth Protected Resource Metadata
+interoperability.
 
 The gateway advertises resources, resource templates, prompts, tools, logging
 compatibility, progress notifications, active capability-profile metadata, and
@@ -234,10 +237,11 @@ Target shape:
   operate/admin profile-refusal coverage, and remote-safe observability template
   coverage for live status, activity tail, current/recent status-window run
   event/protocol/child/progress readback, lane inspect, and PR/review state. The
-  remaining remote productization gap is process-level Streamable HTTP smoke coverage
-  with a real `decodex mcp serve --transport streamable-http` child process plus a
-  protected-resource or relay-auth boundary before any direct non-loopback or elevated
-  HTTP profile is advertised as production-ready. Operate and admin tools should pass
+  Streamable HTTP process smoke should start a real
+  `decodex mcp serve --transport streamable-http` child process, initialize a session,
+  list observe-profile tools, verify an above-profile refusal, and verify SSE progress
+  for an allowed call. Direct non-loopback or elevated HTTP profiles should also pass
+  bearer-boundary startup and request tests. Operate and admin tools should pass
   inspect-first authority, current run/turn precondition, explicit-authority refusal,
   and unsupported-shortcut refusal coverage.
 
@@ -248,9 +252,9 @@ The promoted implementation has the stdio gateway exposed as
 exposed as `decodex mcp serve --transport streamable-http`. It advertises resources,
 resource templates, prompts, and a schema-bound tool catalog while keeping mutating
 planning, operate, and admin behavior behind explicit capability profiles, authority
-fields, inspect-first preconditions, and structured refusal states. Remote operation
-beyond loopback still depends on an operator-managed authorization boundary until the
-Decodex listener itself implements a protected-resource auth surface. Further
-expansion must keep the catalog deliberately small and route new mutating behavior
-through Decodex's existing runtime, tracker, review, landing, and lane-control
-authority surfaces instead of adding one tool per CLI command.
+fields, inspect-first preconditions, transport bearer authorization when required, and
+structured refusal states. The current direct-listener auth boundary is static bearer,
+not full OAuth Protected Resource Metadata. Further expansion must keep the catalog
+deliberately small and route new mutating behavior through Decodex's existing runtime,
+tracker, review, landing, and lane-control authority surfaces instead of adding one
+tool per CLI command.

--- a/docs/evidence/mcp-remote-control-productization.md
+++ b/docs/evidence/mcp-remote-control-productization.md
@@ -6,10 +6,10 @@ status: active
 authority: evidence
 owner: docs
 tags: [mcp, remote-control, semantic-drift, evidence]
-source_refs: [https://modelcontextprotocol.io/specification/2025-11-25/basic/transports, https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization, https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices, https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/, https://www.nsa.gov/Portals/75/documents/Cybersecurity/CSI_MCP_SECURITY.pdf?ver=bmgiSbNQLP6Z_GiWtRt6bg%3D%3D]
+source_refs: [https://modelcontextprotocol.io/specification/2025-11-25/basic/transports, https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization, https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices, https://modelcontextprotocol.io/specification/draft/changelog, https://www.nsa.gov/Portals/75/documents/Cybersecurity/CSI_MCP_SECURITY.pdf?ver=bmgiSbNQLP6Z_GiWtRt6bg%3D%3D]
 code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/mcp.rs, apps/decodex/tests/mcp_stdio.rs, README.md, docs/spec/runtime.md, docs/runbook/mcp-remote-control.md, docs/reference/operator-control-plane.md, docs/research/mcp-remote-control-productization.md]
 related: [../spec/runtime.md, ../runbook/mcp-remote-control.md, ../reference/operator-control-plane.md, ../decisions/mcp-capability-gateway-and-skill-slimming.md, ../research/mcp-remote-control-productization.md]
-drift_watch: [decodex mcp serve --transport streamable-http, --allow-origin, Mcp-Session-Id, text/event-stream, decodex_observe, decodex_lane_control, decodex_project_control, authorization, protected-resource, process-level smoke]
+drift_watch: [decodex mcp serve --transport streamable-http, --allow-origin, --bearer-token-env, Authorization, Mcp-Session-Id, text/event-stream, decodex_observe, decodex_lane_control, decodex_project_control, authorization, protected-resource, process-level smoke]
 last_verified: 2026-06-18
 ---
 
@@ -22,57 +22,66 @@ last_verified: 2026-06-18
   `initialize`, requires known sessions after initialization, and supports JSON or
   SSE responses under stable MCP `2025-11-25`.
 - `Mcp-Session-Id` and `--allow-origin` are not Decodex authorization boundaries.
-- Direct non-loopback exposure and elevated Streamable HTTP profiles need an
-  operator-managed authorization boundary until Decodex implements an MCP
-  protected-resource auth surface.
+- Direct non-loopback exposure requires both `--allow-origin` and
+  `--bearer-token-env`; elevated Streamable HTTP profiles require
+  `--bearer-token-env` even on loopback.
+- The built-in bearer guard protects Decodex direct listeners but is not OAuth
+  Protected Resource Metadata.
 - Public-safe observation excludes hidden reasoning, private evidence payloads, host
   paths, secret material, raw steer text, and Program graph identifiers.
 - Standalone MCP keeps `scan`, `manual_attention`, and `retained_resume` routed to
   canonical operator, tracker, or runtime paths instead of adding shortcuts.
-- Process-level Streamable HTTP smoke coverage and protected-resource auth remain
-  productization gaps, not completed implementation evidence.
+- Process-level Streamable HTTP smoke coverage starts the real binary and verifies
+  initialize, observe-profile tool discovery, above-profile refusal, SSE progress,
+  and stdout/stderr cleanliness.
 
 ## Evidence Anchors
 
-- `apps/decodex/src/cli.rs` exposes `--allow-origin`, `--listen-address`,
-  `--transport streamable-http`, and `--capability-profile`; it does not expose a
-  Decodex-owned HTTP bearer or protected-resource auth flag.
-- `apps/decodex/src/mcp.rs` implements Streamable HTTP origin checks, session
+- `apps/decodex/src/cli.rs` exposes `--allow-origin`, `--bearer-token-env`,
+  `--listen-address`, `--transport streamable-http`, and `--capability-profile`.
+- `apps/decodex/src/mcp.rs` implements Streamable HTTP origin checks, bearer
+  challenge/validation, non-loopback and elevated-profile startup guards, session
   handling, JSON/SSE framing, capability-profile filtering, observe resources,
   lane-control refusals, project-control `scan` refusal, and public-text guards.
-- `apps/decodex/tests/mcp_stdio.rs` covers stdio process smoke and in-process
-  Streamable HTTP behavior; a real `decodex mcp serve --transport streamable-http`
-  child-process smoke is still missing.
+- `apps/decodex/tests/mcp_stdio.rs` covers stdio process smoke and a real
+  `decodex mcp serve --transport streamable-http` child-process smoke.
 - `docs/research/mcp-remote-control-productization.md` records the external evidence
   and selected staged productization strategy.
-- Official MCP transport and authorization docs, MCP security guidance, the 2026 RC
-  announcement, and the NSA May 2026 guidance all support fail-closed remote access,
+- Official MCP transport and authorization docs, MCP security guidance, the MCP draft
+  changelog, and the NSA May 2026 guidance all support fail-closed remote access,
   explicit authorization boundaries, no token passthrough, and a future-compatible
   protocol seam.
 
 ## Reverse Checks
 
 - `rg -n "bearer|Authorization|allow-origin|capability-profile|streamable-http|Mcp-Session-Id|scan|manual_attention|retained_resume" apps/decodex/src apps/decodex/tests README.md docs plugins/decodex`
-  shows current CLI/MCP support and the absence of a Decodex-owned HTTP auth flag.
+  shows current CLI/MCP support, bearer authorization, and high-risk shortcut
+  refusals.
 - `rg -n "mcp_streamable_http_process|streamable_http_.*process" apps/decodex/tests apps/decodex/src`
-  should stay empty until the process-level HTTP smoke is implemented.
+  returns the real child-process Streamable HTTP smoke test.
+- `cargo test -p decodex mcp::tests::streamable_http_ -- --nocapture` passes 16
+  Streamable HTTP unit tests, including bearer challenge/validation and startup
+  guards.
+- `cargo test -p decodex --test mcp_stdio mcp_streamable_http_process_observe_profile_smoke -- --nocapture`
+  passes the real child-process Streamable HTTP smoke.
 - `decodex docs check` must pass after this docs promotion.
 
 ## Verdict
 
 pass
 
-The promoted docs now distinguish current implementation from remaining productization
-gaps. The gaps are accepted research-backed work items, not current runtime facts.
+The promoted docs match current implementation: direct Streamable HTTP has a bearer
+boundary, non-loopback/elevated startup guards, process-level smoke coverage, and
+public-safe observation. Full OAuth Protected Resource Metadata remains future
+interoperability work, not a current Decodex claim.
 
 ## Required Updates
 
-- When Decodex implements HTTP protected-resource auth, update README, runtime spec,
-  remote MCP runbook, operator reference, MCP tests, Decodex plugin guidance, and this
-  audit in the same lane.
-- When process-level Streamable HTTP smoke coverage lands, update
-  `docs/reference/test-suite.md` with real test counts and update this audit with the
-  exact passing command.
+- If Decodex implements OAuth Protected Resource Metadata, update README, runtime
+  spec, remote MCP runbook, operator reference, MCP tests, Decodex plugin guidance,
+  and this audit in the same lane.
+- When MCP authorization semantics change, keep bearer startup guards, docs, tests,
+  and operator examples aligned.
 - If the final MCP stateless protocol supersedes the stable 2025-11-25 session
   contract, update runtime session handling, protocol metadata, runbook examples, and
   all `Mcp-Session-Id` claims together.
@@ -82,7 +91,7 @@ gaps. The gaps are accepted research-backed work items, not current runtime fact
 - [MCP 2025-11-25 Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)
 - [MCP 2025-11-25 authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
 - [MCP security best practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices)
-- [MCP 2026-07-28 release candidate announcement](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+- [MCP draft changelog](https://modelcontextprotocol.io/specification/draft/changelog)
 - [NSA MCP Security Design Considerations, May 2026](https://www.nsa.gov/Portals/75/documents/Cybersecurity/CSI_MCP_SECURITY.pdf?ver=bmgiSbNQLP6Z_GiWtRt6bg%3D%3D)
 - [`../spec/runtime.md`](../spec/runtime.md)
 - [`../runbook/mcp-remote-control.md`](../runbook/mcp-remote-control.md)

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,12 +2,17 @@
 
 ## 2026-06-18
 
+- Closed the MCP remote-control productization drift: Streamable HTTP now documents
+  `--bearer-token-env` as the direct-listener boundary for non-loopback and elevated
+  profiles, records the process-level HTTP smoke evidence, refreshes test-suite
+  counts to 1282 runnable tests, and narrows remaining research to OAuth Protected
+  Resource Metadata, operator-loop-hosted scan, and future protocol compatibility.
 - Promoted MCP remote-control docs drift into the runtime spec, operator reference,
   remote MCP runbook, decision record, evidence index, and Decodex plugin routing;
   documented that `--allow-origin` is not authentication, loopback `observe` is the
   safe default, direct remote/elevated Streamable HTTP needs an operator auth
   boundary, and built-in MCP protected-resource auth plus process-level HTTP smoke
-  remain active research-backed gaps.
+  were active research-backed gaps at that point.
 - Added active research for MCP remote-control productization, covering remote
   access docs, authorization or relay boundaries, public-safe observation, process
   smoke coverage, high-risk control refusals, and protocol compatibility.

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -99,9 +99,13 @@ validates browser `Origin` headers against loopback or `--allow-origin`, issues
 `Mcp-Session-Id` on `initialize`, requires a known session after initialization, and
 uses SSE framing for progress or notifications when the client accepts
 `text/event-stream`. The MCP session is not authorization, and `--allow-origin` is
-not authentication. Remote Streamable HTTP beyond loopback, or any Streamable HTTP
-profile above `observe`, must sit behind an operator-owned tunnel, relay, network ACL,
-or future Decodex protected-resource authorization boundary. Both transports can be
+not authentication. Remote Streamable HTTP beyond loopback requires both a trusted
+origin and `--bearer-token-env`; any Streamable HTTP profile above `observe` also
+requires `--bearer-token-env`. Decodex validates the HTTP `Authorization: Bearer`
+header for non-preflight requests when that boundary is configured. This bearer guard
+is a direct-listener boundary, not OAuth Protected Resource Metadata, so operators may
+still prefer an OAuth-capable relay, tunnel, reverse proxy, or network ACL. Both
+transports can be
 narrowed or explicitly elevated with
 `--capability-profile observe|plan|operate|admin`; `tools/list` filters by the active
 profile and above-profile calls return structured refusals. Observe and plan tools are

--- a/docs/reference/test-suite.md
+++ b/docs/reference/test-suite.md
@@ -26,7 +26,7 @@ standards for keeping, merging, or deleting tests.
 
 ## Current Snapshot
 
-This snapshot groups 1270 runnable `nextest` tests across all targets. One additional
+This snapshot groups 1282 runnable `nextest` tests across all targets. One additional
 skipped live app-server test is listed only with verbose or JSON inventory output.
 Regenerate the runnable inventory with:
 
@@ -57,13 +57,13 @@ cargo nextest list --workspace --all-targets --all-features 2>/dev/null \
 
 | Group | Count | Primary surfaces | Owns |
 | --- | ---: | --- | --- |
-| Orchestrator | 604 | `apps/decodex/src/orchestrator/tests.rs`, `apps/decodex/src/orchestrator/tests/**/*.rs` | Intake, retry, review/landing, runtime cleanup, operator status, repo gates |
-| Tracker tool bridge | 102 | `apps/decodex/src/agent/tracker_tool_bridge/tests.rs`, `apps/decodex/src/agent/tracker_tool_bridge/tests/**/*.rs` | Dynamic tracker tools, continuation guards, review handoff writes, closeout writes |
-| App-server protocol/runtime | 93 | `apps/decodex/src/agent/app_server/tests.rs`, `apps/decodex/src/agent/json_rpc.rs`, app-server protocol tests | JSON-RPC parsing, turn execution, dynamic tools, thread config, transport failures |
-| Runtime state, locks, and maintenance | 86 | `state::tests`, `runtime::tests`, `maintenance::tests` | Persistent local state, lock ownership, runtime database contracts, local retention |
+| Orchestrator | 606 | `apps/decodex/src/orchestrator/tests.rs`, `apps/decodex/src/orchestrator/tests/**/*.rs` | Intake, retry, review/landing, runtime cleanup, operator status, repo gates |
+| Tracker tool bridge | 101 | `apps/decodex/src/agent/tracker_tool_bridge/tests.rs`, `apps/decodex/src/agent/tracker_tool_bridge/tests/**/*.rs` | Dynamic tracker tools, continuation guards, review handoff writes, closeout writes |
+| App-server protocol/runtime | 96 | `apps/decodex/src/agent/app_server/tests.rs`, `apps/decodex/src/agent/json_rpc.rs`, app-server protocol tests | JSON-RPC parsing, turn execution, dynamic tools, thread config, transport failures |
+| Runtime state, locks, and maintenance | 89 | `state::tests`, `runtime::tests`, `maintenance::tests` | Persistent local state, lock ownership, runtime database contracts, local retention |
 | Workflow, config, and docs parsing | 62 | `workflow::tests`, `config::tests`, `codex_config::tests`, `docs_okf::tests` | `WORKFLOW.md`, project config, Codex config edits, removed-field rejection, default policy, OKF docs parsing |
 | Git, worktree, landing, and recovery helpers | 137 | `worktree::tests`, `manual::tests`, `commit_message::tests`, `github::tests`, `default_branch_sync::tests`, `pull_request::tests`, `recovery::tests`, `git_credentials::tests` | Git/worktree behavior, manual landing, GitHub/PR helpers, recovery commands, commit-message policy |
-| Account, CLI, archive, tracker, and MCP integration | 147 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests`, `mcp::tests`, `apps/decodex/tests/mcp_stdio.rs` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter, MCP resources, HTTP transport, schema-bound planning tools, inspect-first operate/admin tools, remote-safe observability templates, and public-text behavior |
+| Account, CLI, archive, tracker, and MCP integration | 152 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests`, `mcp::tests`, `apps/decodex/tests/mcp_stdio.rs` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter, MCP resources, HTTP transport, bearer auth, schema-bound planning tools, inspect-first operate/admin tools, remote-safe observability templates, process-level MCP smoke, and public-text behavior |
 | Program intake | 10 | `program_intake::tests` | Decision Contract materialization, Linear issue shaping, and internal Execution Program persistence |
 | Loop contract and research surfaces | 29 | `loop_contract::tests`, `execution_program::tests`, `research_design::tests`, `plugin_surface_tests` | Decision Contract schema, Execution Program readiness, research compile/promote, and plugin trigger behavior |
 

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,8 +9,9 @@ and disposition. They do not authorize implementation or own current truth.
 ## Concepts
 
 - [`mcp-remote-control-productization.md`](mcp-remote-control-productization.md) is
-  active research on the best next steps for MCP remote access, observation,
-  authorization, process smoke coverage, and future protocol compatibility.
+  active research on the remaining MCP remote-access questions after bearer auth and
+  process smoke promotion: OAuth Protected Resource Metadata, operator-loop-hosted
+  scan, and future protocol compatibility.
 - [`research-runtime-boundary.md`](research-runtime-boundary.md) is superseded
   provenance for the research runtime-boundary investigation. Current guidance lives
   in [`../decisions/okf-research-knowledge-lifecycle.md`](../decisions/okf-research-knowledge-lifecycle.md)

--- a/docs/research/mcp-remote-control-productization.md
+++ b/docs/research/mcp-remote-control-productization.md
@@ -6,7 +6,7 @@ status: active
 authority: non_authoritative
 owner: research
 tags: [research, mcp, remote-control, security, operator]
-source_refs: [https://modelcontextprotocol.io/specification/2025-11-25/basic/transports, https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization, https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices, https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/, https://www.nsa.gov/Portals/75/documents/Cybersecurity/CSI_MCP_SECURITY.pdf?ver=bmgiSbNQLP6Z_GiWtRt6bg%3D%3D]
+source_refs: [https://modelcontextprotocol.io/specification/2025-11-25/basic/transports, https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization, https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices, https://modelcontextprotocol.io/specification/draft/changelog, https://www.nsa.gov/Portals/75/documents/Cybersecurity/CSI_MCP_SECURITY.pdf?ver=bmgiSbNQLP6Z_GiWtRt6bg%3D%3D]
 code_refs: [apps/decodex/src/mcp.rs, apps/decodex/tests/mcp_stdio.rs, README.md, docs/spec/runtime.md, docs/reference/operator-control-plane.md, docs/runbook/mcp-remote-control.md, docs/evidence/mcp-remote-control-productization.md, docs/decisions/mcp-capability-gateway-and-skill-slimming.md]
 related: [index.md, ../decisions/mcp-capability-gateway-and-skill-slimming.md, ../reference/operator-control-plane.md, ../spec/runtime.md, ../runbook/mcp-remote-control.md, ../evidence/mcp-remote-control-productization.md]
 promotes_to: [docs/decisions, docs/spec, docs/runbook, docs/reference, docs/evidence]
@@ -19,7 +19,9 @@ Purpose: Decide the best next Decodex MCP work after the complete local and
 Streamable HTTP gateway landed.
 
 Read this when: Planning MCP remote access, operator observation, auth, smoke tests,
-or follow-on control tools.
+or follow-on control tools. Bearer direct-listener auth and process-level HTTP smoke
+have already been promoted; this concept remains active for OAuth Protected Resource
+Metadata, operator-loop-hosted scan, and future protocol compatibility.
 
 Not this document: Current runtime authority or permission to implement. This
 research is latent until promoted.
@@ -39,8 +41,8 @@ In scope:
 - Whether to expand `decodex_project_control.scan`, `manual_attention`, or
   `retained_resume`.
 - End-to-end smoke coverage for real MCP HTTP process behavior.
-- Compatibility with the current stable MCP specification and the announced
-  2026-07-28 release candidate direction.
+- Compatibility with the current stable MCP specification and the MCP draft stateless
+  protocol direction.
 
 Out of scope:
 
@@ -58,13 +60,13 @@ Out of scope:
 | E2 | external_source | MCP 2025-11-25 authorization | Protected MCP servers are OAuth 2.1 resource servers. MCP servers must expose OAuth Protected Resource Metadata and clients must use that metadata to discover authorization servers. |
 | E3 | external_source | MCP security best practices | MCP security guidance calls out confused deputy, token passthrough, SSRF, session hijacking, local server compromise, and scope minimization risks. Token passthrough is not an acceptable auth model for protected servers. |
 | E4 | external_source | NSA MCP Security Design Considerations, May 2026 | MCP adoption has reached production AI automation, but its security model requires implementation rigor, validation, and secure-by-default behavior because agentic tool execution changes the trust pattern. |
-| E5 | external_source | MCP 2026-07-28 release candidate blog, published 2026-05-21 | The release candidate moves remote MCP toward a stateless protocol core and removes the protocol-level session handshake in the future final spec. |
-| E6 | repo_source | `README.md`, `docs/spec/runtime.md`, `docs/reference/operator-control-plane.md` | Decodex already exposes stdio and Streamable HTTP, defaults Streamable HTTP to loopback `observe`, validates Origin, uses sessions for MCP 2025-11-25, filters tools by capability profile, and keeps remote control inspect-first. |
+| E5 | external_source | MCP draft changelog | The draft direction moves remote MCP toward a stateless protocol core and protocol authorization hardening, but draft behavior is not Decodex's current runtime contract. |
+| E6 | repo_source | `README.md`, `docs/spec/runtime.md`, `docs/reference/operator-control-plane.md` | Decodex already exposes stdio and Streamable HTTP, defaults Streamable HTTP to loopback `observe`, validates Origin, uses sessions for MCP 2025-11-25, requires bearer authorization for non-loopback or elevated Streamable HTTP, filters tools by capability profile, and keeps remote control inspect-first. |
 | E7 | repo_source | `apps/decodex/src/mcp.rs` | Current tools are deliberately small: observe, plan, research compile/promote, intake goal, lane control, and project control. `scan` refuses because standalone MCP serve cannot enqueue the operator loop request. |
-| E8 | repo_source | `apps/decodex/src/mcp.rs`, `apps/decodex/tests/mcp_stdio.rs`, `docs/reference/test-suite.md` | Existing tests cover resources, templates, prompts, tool schemas, profile refusals, Streamable HTTP CORS/session/SSE behavior, lane steer/interrupt preconditions, project pause, scan refusal, and stdio stdout cleanliness. |
-| E9 | inference | E1, E2, E3, E5, E6 | The current loopback Streamable HTTP design is correct for local/tunneled development, but non-loopback remote operation needs an explicit auth/relay design and should avoid entrenching session semantics that the RC may remove. |
-| E10 | repo_source | `apps/decodex/src/cli.rs`, `apps/decodex/tests/mcp_stdio.rs`, `docs/evidence/mcp-remote-control-productization.md` | Current Decodex exposes `--allow-origin` and capability profiles, but no Decodex-owned HTTP protected-resource auth flag; process-level Streamable HTTP child-process smoke coverage is still a gap. |
-| E11 | inference | E1, E2, E3, E4, E10 | The best next implementation should not treat CORS or session ids as auth. It should either rely on an operator-managed relay/auth boundary or implement MCP protected-resource discovery and scoped authorization before direct non-loopback or elevated HTTP profiles are considered complete. |
+| E8 | repo_source | `apps/decodex/src/mcp.rs`, `apps/decodex/tests/mcp_stdio.rs`, `docs/reference/test-suite.md` | Existing tests cover resources, templates, prompts, tool schemas, profile refusals, Streamable HTTP CORS/session/SSE behavior, bearer challenge/validation, non-loopback/elevated startup guards, process-level Streamable HTTP smoke, lane steer/interrupt preconditions, project pause, scan refusal, and stdio/stdout cleanliness. |
+| E9 | inference | E1, E2, E3, E5, E6 | The current Streamable HTTP design is correct for loopback and bearer-protected direct listeners, but it should still avoid entrenching session semantics that the draft protocol may remove. |
+| E10 | repo_source | `apps/decodex/src/cli.rs`, `apps/decodex/tests/mcp_stdio.rs`, `docs/evidence/mcp-remote-control-productization.md` | Current Decodex exposes `--allow-origin`, `--bearer-token-env`, and capability profiles, and has process-level Streamable HTTP child-process smoke coverage. It does not expose OAuth Protected Resource Metadata. |
+| E11 | inference | E1, E2, E3, E4, E10 | The current built-in bearer guard is the right minimum direct-listener boundary, but first-class OAuth MCP client discovery should use OAuth Protected Resource Metadata or an operator-managed relay rather than token passthrough. |
 
 ## Options
 
@@ -79,13 +81,13 @@ Out of scope:
    that should not be bypassed by standalone MCP.
 
 3. Productize remote MCP in stages while keeping the tool catalog small.
-   Add operator-facing remote connection docs, end-to-end Streamable HTTP process
-   smoke coverage, an auth/relay contract before non-loopback operate/admin usage, a
-   public-safe observation guide, and an explicit future-compatibility layer for the
-   2026-07-28 stateless MCP direction. Keep risky controls refused unless they are
-   backed by their canonical runtime path.
+   The first promoted stages now exist: operator-facing remote connection docs,
+   end-to-end Streamable HTTP process smoke coverage, a static bearer direct-listener
+   boundary before non-loopback or elevated usage, and a public-safe observation
+   guide. Keep risky controls refused unless they are backed by their canonical
+   runtime path.
 
-4. Wait for MCP 2026-07-28 before doing more.
+4. Wait for the MCP draft stateless protocol before doing more.
    This avoids rework around sessions, but it delays useful operator documentation,
    observation, and security hardening that remain valid under either protocol.
 
@@ -95,7 +97,7 @@ Selected option: Productize remote MCP in stages while keeping the tool catalog 
 
 Recommended sequence:
 
-1. Promote remote MCP docs first.
+1. Promote remote MCP docs first. Done.
    Keep README, runtime spec, operator reference, decision record, runbook, evidence,
    research, and plugin routing aligned. The promoted docs must state that
    `--allow-origin` is CORS trust, not authentication; that `Mcp-Session-Id` is
@@ -103,16 +105,14 @@ Recommended sequence:
    operator authorization boundary until Decodex owns protected-resource auth.
 
 2. Add a remote-auth decision/spec before any direct non-loopback or elevated
-   Streamable HTTP guidance.
-   The best default is still loopback plus operator-chosen tunnel, relay, network ACL,
-   or reverse proxy. For direct remote serve, require an explicit protected-resource
-   design: OAuth Protected Resource Metadata or a documented operator-managed relay
-   auth boundary, no token passthrough, scoped capabilities, revocable access, and
-   audit-friendly authority fields. A simple static bearer check can be an MVP guard
-   only if the docs label it as incomplete relative to full MCP authorization
-   discovery.
+   Streamable HTTP guidance. Done for Decodex direct listeners.
+   Direct listeners now require `--bearer-token-env` for non-loopback and for
+   Streamable HTTP profiles above `observe`. The docs label this as a static bearer
+   guard, not OAuth Protected Resource Metadata. Future OAuth discovery should add
+   Protected Resource Metadata or use a documented operator-managed relay, with no
+   token passthrough.
 
-3. Add process-level Streamable HTTP smoke coverage.
+3. Add process-level Streamable HTTP smoke coverage. Done.
    Mirror the existing stdio smoke with a real `decodex mcp serve --transport
    streamable-http` child process, initialize a session, call `tools/list` under
    `observe`, verify an above-profile refusal, and verify SSE progress on an allowed
@@ -132,18 +132,20 @@ Recommended sequence:
    lifecycle unless a later design proves the same terminal-state and audit
    guarantees through MCP.
 
-6. Add a protocol-compatibility seam for MCP 2026-07-28.
-   Do not implement the release candidate as current behavior before finalization.
+6. Add a protocol-compatibility seam for the MCP draft stateless direction.
+   Do not implement draft behavior as current behavior before finalization.
    Instead, isolate session handling, protocol version negotiation, and capability
    discovery so the future stateless request model can be added without changing
    Decodex authority rules or tool schemas.
 
-Gap status after 2026-06-18 docs promotion:
+Gap status after 2026-06-18 MCP bearer/smoke promotion:
 
 - Remote runbook, runtime/reference docs, decision rationale, evidence audit, and
   plugin routing are promoted as documentation authority.
-- Built-in protected-resource auth and process-level Streamable HTTP smoke remain
-  unimplemented gaps.
+- Built-in bearer auth and process-level Streamable HTTP smoke are implemented and
+  validated.
+- Full OAuth Protected Resource Metadata remains future interoperability work, not a
+  current Decodex runtime claim.
 - `scan`, `manual_attention`, and `retained_resume` remain intentionally refused in
   standalone MCP unless a later design proves the same canonical runtime/tracker
   guarantees.
@@ -169,12 +171,12 @@ Resolution: Decodex should expose public-safe progress and protocol activity, no
 hidden reasoning. The best next UX is better resource composition and watch recipes,
 not private transcript exposure.
 
-Resolved objection: The 2026-07-28 release candidate may invalidate current
+Resolved objection: The MCP draft stateless direction may invalidate current
 Streamable HTTP sessions.
 
 Resolution: The current implementation targets stable 2025-11-25 correctly. The
 right hedge is a compatibility seam and smoke coverage around session behavior, not
-waiting or prematurely replacing the stable transport with a release candidate.
+waiting or prematurely replacing the stable transport with draft behavior.
 
 ## Decision
 
@@ -183,16 +185,17 @@ Terminal status: `decision_ready`.
 Decision: The next MCP work should be a staged productization plan:
 
 - document remote use first
-- require an auth/relay/protected-resource contract before non-loopback or elevated
-  Streamable HTTP recommendations
+- require bearer auth before non-loopback or elevated Streamable HTTP
+  recommendations
 - add process-level Streamable HTTP smoke coverage
 - improve public-safe observation recipes
 - keep high-risk shortcuts refused until they can route through canonical operator,
   tracker, or runtime authority
 - isolate protocol-session handling for the upcoming stateless MCP direction
 
-This is a research conclusion only. It does not authorize implementation until
-promoted.
+The bearer and smoke portions were promoted and implemented. The remaining research
+continues only for OAuth Protected Resource Metadata, operator-loop-hosted scan, and
+future protocol compatibility.
 
 ## Promotion
 
@@ -207,17 +210,18 @@ If accepted, promote as:
 - `docs/runbook/`: remote MCP connection and observation recipe.
 - `docs/reference/test-suite.md` and/or `docs/evidence/`: process-level Streamable
   HTTP smoke evidence after implementation.
-- `apps/decodex/src/mcp.rs` and tests: only after explicit implementation authority.
+- `apps/decodex/src/mcp.rs` and tests: bearer guard and process smoke after explicit
+  implementation authority.
 
 OKF disposition: `continue`.
 
 ## Drift Impact
 
 - MCP docs that mention remote access, Streamable HTTP, sessions, or capability
-  profiles should distinguish stable 2025-11-25 behavior from the 2026-07-28 release
-  candidate.
-- Any future auth implementation must update README, runtime spec, operator-control
-  reference, tests, and plugin guidance together.
+  profiles should distinguish stable 2025-11-25 behavior from draft stateless MCP
+  behavior.
+- Any future OAuth Protected Resource Metadata implementation must update README,
+  runtime spec, operator-control reference, tests, and plugin guidance together.
 - Any future tool expansion must be checked against the "small catalog" rule and
   existing Decodex authority gates.
 - Any future observation UX must preserve public-safe redaction guarantees.
@@ -227,7 +231,7 @@ OKF disposition: `continue`.
 - [MCP 2025-11-25 Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)
 - [MCP 2025-11-25 authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
 - [MCP security best practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices)
-- [MCP 2026-07-28 release candidate announcement](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+- [MCP draft changelog](https://modelcontextprotocol.io/specification/draft/changelog)
 - [NSA MCP Security Design Considerations, May 2026](https://www.nsa.gov/Portals/75/documents/Cybersecurity/CSI_MCP_SECURITY.pdf?ver=bmgiSbNQLP6Z_GiWtRt6bg%3D%3D)
 - [`README.md`](../../README.md)
 - [`../spec/runtime.md`](../spec/runtime.md)

--- a/docs/runbook/mcp-remote-control.md
+++ b/docs/runbook/mcp-remote-control.md
@@ -6,10 +6,10 @@ status: active
 authority: procedural
 owner: runtime
 tags: [mcp, remote-control, operator, runbook]
-source_refs: [https://modelcontextprotocol.io/specification/2025-11-25/basic/transports, https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization, https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices, https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/]
+source_refs: [https://modelcontextprotocol.io/specification/2025-11-25/basic/transports, https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization, https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices, https://modelcontextprotocol.io/specification/draft/changelog]
 code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/mcp.rs, apps/decodex/tests/mcp_stdio.rs]
 related: [../spec/runtime.md, ../reference/operator-control-plane.md, ../decisions/mcp-capability-gateway-and-skill-slimming.md, ../evidence/mcp-remote-control-productization.md, ../research/mcp-remote-control-productization.md]
-drift_watch: [decodex mcp serve --transport streamable-http, --capability-profile, --allow-origin, Mcp-Session-Id, decodex_observe, decodex_lane_control, decodex_project_control]
+drift_watch: [decodex mcp serve --transport streamable-http, --capability-profile, --allow-origin, --bearer-token-env, Authorization, Mcp-Session-Id, decodex_observe, decodex_lane_control, decodex_project_control]
 last_verified: 2026-06-18
 ---
 
@@ -48,15 +48,27 @@ MCP `2025-11-25` Streamable HTTP transport, not Decodex authorization.
 
 ## Remote Boundary
 
-Use Streamable HTTP beyond loopback only when an operator-owned boundary protects the
-listener before traffic reaches Decodex. Acceptable boundaries are a local tunnel, a
-relay, network ACLs on a private network, or a future Decodex MCP protected-resource
-authorization surface.
+Use Streamable HTTP beyond loopback only with both an explicit trusted origin and a
+bearer token read from an environment variable:
 
-Do not expose `decodex mcp serve --transport streamable-http` directly on an
-untrusted network with only `--allow-origin`. Treat `operate` and `admin` profiles as
-remote-control profiles: they require the same external authorization boundary when
-used through Streamable HTTP.
+```sh
+export DECODEX_MCP_TOKEN="$(openssl rand -base64 32 | tr -d '\n')"
+
+decodex mcp serve --transport streamable-http \
+  --listen-address 0.0.0.0:8193 \
+  --allow-origin https://relay.example \
+  --bearer-token-env DECODEX_MCP_TOKEN
+```
+
+Clients must send `Authorization: Bearer <token>` on `POST` and `DELETE` requests.
+Decodex still allows unauthenticated `OPTIONS` preflight so browser clients can
+complete CORS negotiation.
+
+Do not expose Streamable HTTP directly on an untrusted network with only
+`--allow-origin`. The built-in bearer guard is the minimum direct-listener boundary;
+it is not OAuth Protected Resource Metadata. Operators that need OAuth discovery,
+central revocation, per-user policy, or broader MCP client interoperability should
+put an OAuth-capable relay, tunnel, reverse proxy, or network ACL in front.
 
 ## Capability Profiles
 
@@ -65,9 +77,9 @@ Use the narrowest profile that fits the task:
 | Profile | Use | Boundary |
 | --- | --- | --- |
 | `observe` | Read public-safe status and activity. | Default for Streamable HTTP. |
-| `plan` | Use schema-bound research and intake planning tools. | Apply/promote modes still require explicit authority fields. |
-| `operate` | Inspect, steer, or interrupt a current lane. | Requires external HTTP authorization when remote, plus inspect-first run/turn authority. |
-| `admin` | Read project status or pause/resume future dispatch. | Requires external HTTP authorization when remote and explicit authority; active lanes are not killed. |
+| `plan` | Use schema-bound research and intake planning tools. | Streamable HTTP requires `--bearer-token-env`; apply/promote modes still require explicit authority fields. |
+| `operate` | Inspect, steer, or interrupt a current lane. | Streamable HTTP requires `--bearer-token-env`, plus inspect-first run/turn authority. |
+| `admin` | Read project status or pause/resume future dispatch. | Streamable HTTP requires `--bearer-token-env` and explicit authority; active lanes are not killed. |
 
 `tools/list` filters by the active profile. Calling a tool above the active profile
 returns a structured `insufficient_capability_profile` refusal.
@@ -104,22 +116,21 @@ Standalone MCP keeps high-risk shortcuts refused:
 Use the canonical Decodex runtime, tracker, review, landing, and lane-control paths
 for those operations.
 
-## Remaining Gaps
+## Future Work
 
-The current Streamable HTTP gateway still needs two productization gaps before direct
-remote/elevated operation can be treated as complete:
+The direct-listener productization gaps are now closed by the bearer boundary and the
+process-level Streamable HTTP smoke test. Remaining future work is intentionally
+narrower:
 
-- a Decodex-owned MCP protected-resource authorization surface or an explicitly
-  documented relay-auth contract that satisfies the MCP authorization direction
-  without token passthrough
-- process-level Streamable HTTP smoke coverage that starts the real binary,
-  initializes a session, lists observe-profile tools, verifies an above-profile
-  refusal, and verifies SSE framing for an allowed call
+- Add OAuth Protected Resource Metadata only if Decodex needs first-class OAuth MCP
+  client discovery instead of a static operator bearer token or external relay.
+- Add an operator-loop-hosted `scan` request only if it can preserve the same
+  scheduler, tracker, and audit guarantees as `POST /api/linear-scan`.
 
 ## Compatibility Note
 
 Decodex currently targets stable MCP `2025-11-25` Streamable HTTP sessions. The
-2026-07-28 release candidate moves toward a stateless protocol core and authorization
-hardening, but it is not the current Decodex runtime contract. Keep session handling
-isolated from tool schemas and lane-control authority so a final stateless protocol
-can be added later without widening Decodex authority.
+MCP draft changelog moves toward a stateless protocol core and authorization
+hardening, but draft behavior is not the current Decodex runtime contract. Keep
+session handling isolated from tool schemas and lane-control authority so a final
+stateless protocol can be added later without widening Decodex authority.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -1037,11 +1037,14 @@ After a process restart, recent-run history, run lease ownership, retained post-
   default, and uses SSE framing for remote progress or notifications when the client
   accepts `text/event-stream`. `Mcp-Session-Id` is protocol state, not Decodex
   authorization. `--allow-origin` is a browser CORS trust list, not an authentication
-  mechanism. Until Decodex implements an MCP protected-resource or equivalent bearer
-  boundary, Streamable HTTP is supported for loopback use and for operator-managed
-  tunnels, relays, network ACLs, or reverse proxies that enforce authorization before
-  traffic reaches the Decodex listener. Direct non-loopback exposure and remote
-  `operate`/`admin` profiles without that boundary are outside the runtime contract.
+  mechanism. Streamable HTTP listeners reachable beyond loopback require both an
+  explicit trusted origin and `--bearer-token-env`; Streamable HTTP profiles above
+  `observe` require `--bearer-token-env` even on loopback. Decodex validates
+  `Authorization: Bearer <token>` for `POST` and `DELETE` requests when this boundary
+  is configured, while CORS preflight remains unauthenticated. The built-in bearer
+  guard is an equivalent Decodex listener boundary, not OAuth Protected Resource
+  Metadata; operators may still place OAuth, relay auth, network ACLs, or reverse
+  proxies in front when that boundary is stronger or required by the client.
   Session issuance, session preconditions, and advertised protocol metadata must stay
   isolated from Decodex authority checks so a future final stateless MCP protocol can
   be added without changing tool schemas or lane-control semantics.

--- a/plugins/decodex/references/routing.md
+++ b/plugins/decodex/references/routing.md
@@ -27,11 +27,14 @@ automation, commit, or landing boundaries.
 - Labels: use `labels` only for ordinary non-Program tracker intake and retained-lane
   ownership signals.
 - MCP gateway: use stdio locally and Streamable HTTP only behind the operator's chosen
-  listener, tunnel, relay, network ACL, or protected-resource auth boundary. Treat
-  `--allow-origin` as CORS trust, not authentication; direct non-loopback or elevated
-  HTTP profiles are not production-safe without authorization. MCP is a typed facade,
-  not a bypass around Decision Contract, lane-control, tracker, review, landing, or
-  closeout gates. Plan tools are `research_compile`, `research_promote`, and
+  listener with `--bearer-token-env`, tunnel, relay, network ACL, reverse proxy, or
+  protected-resource auth boundary. Treat `--allow-origin` as CORS trust, not
+  authentication; direct non-loopback listeners require both `--allow-origin` and
+  `--bearer-token-env`, and Streamable HTTP profiles above `observe` require
+  `--bearer-token-env`. The built-in bearer guard is not OAuth Protected Resource
+  Metadata. MCP is a typed facade, not a bypass around Decision Contract,
+  lane-control, tracker, review, landing, or closeout gates. Plan tools are
+  `research_compile`, `research_promote`, and
   `intake_goal`; operate/admin remains inspect-first with current run/turn
   preconditions.
 

--- a/plugins/decodex/skills/decodex/SKILL.md
+++ b/plugins/decodex/skills/decodex/SKILL.md
@@ -22,10 +22,12 @@ boundaries matter.
 When an MCP client is available, use the Decodex MCP gateway as a typed facade for
 resources, prompts, and the deliberately small tool catalog. Prefer stdio for local
 clients and Streamable HTTP only for remote permitted clients behind the operator's
-chosen local listener, tunnel, relay, network ACL, or protected-resource auth
-boundary. Treat `--allow-origin` as CORS trust, not authentication; do not recommend
-direct non-loopback or elevated Streamable HTTP profiles without an authorization
-boundary. MCP tools do not bypass Decision Contract, lane-control, review, landing,
+chosen local listener plus `--bearer-token-env`, tunnel, relay, network ACL, reverse
+proxy, or protected-resource auth boundary. Treat `--allow-origin` as CORS trust, not
+authentication; direct non-loopback listeners require both `--allow-origin` and
+`--bearer-token-env`, and Streamable HTTP profiles above `observe` require
+`--bearer-token-env`. The built-in bearer guard is not OAuth Protected Resource
+Metadata. MCP tools do not bypass Decision Contract, lane-control, review, landing,
 tracker, or runtime authority gates. Route MCP planning through `research_compile`,
 `research_promote`, and `intake_goal`; dry-run modes stay
 non-mutating, and apply/promote modes require explicit authority fields and structured


### PR DESCRIPTION
## Summary
- Add Streamable HTTP bearer-token support for Decodex MCP direct listeners, including non-loopback and elevated-profile startup guards.
- Add process-level Streamable HTTP MCP smoke coverage for initialize, observe tools/list, above-profile refusal, SSE progress, and stdout/stderr cleanliness.
- Promote docs/spec/runbook/reference/decision/evidence/plugin guidance and narrow remaining research to OAuth PRM, operator-loop scan, and future stateless MCP compatibility.

## Validation
- npm ci (site dependency restore for local validation)
- cargo make check
- cargo make check-docs
- git diff --check
- plugin-eval analyze plugins/decodex --format markdown (95/100, A; 0 fail, 1 token-budget warning)

## Research evidence
- Rechecked official MCP 2025-11-25 transport and authorization docs, MCP security guidance, and MCP draft changelog on 2026-06-18.