### PR TITLE
Fix dashboard run activity overlay completeness

### DIFF
--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -11338,9 +11338,7 @@
 				const currentLaneRows = currentLanes
 					.filter((run) => run && typeof run === "object")
 					.map((run) => ({ ...run }));
-				const currentLanesComplete =
-					activityPayload.currentLanesComplete !== false &&
-					activityPayload.currentLaneScope !== "filtered";
+				const currentLanesComplete = activityPayload.currentLanesComplete !== false;
 				const mergedCurrentLanes = mergeDashboardCurrentLanes(
 					snapshot,
 					currentLaneRows,
@@ -11472,8 +11470,7 @@
 					.filter((run) => run && typeof run === "object")
 					.map((run) => ({ ...run }));
 				dashboardLiveRunActivitySeen = true;
-				dashboardLiveCurrentLanesComplete =
-					payload.currentLanesComplete !== false && payload.currentLaneScope !== "filtered";
+				dashboardLiveCurrentLanesComplete = payload.currentLanesComplete !== false;
 				dashboardLiveAccountControl =
 					payload.accountControl && typeof payload.accountControl === "object"
 						? { ...payload.accountControl }

--- a/apps/decodex/src/orchestrator/operator_http.rs
+++ b/apps/decodex/src/orchestrator/operator_http.rs
@@ -1173,9 +1173,14 @@ fn dashboard_event_for_subscription(
 			.collect::<Vec<_>>()
 	})?;
 	let mut payload = event.payload.clone();
+	let current_lanes_complete = event
+		.payload
+		.get("currentLanesComplete")
+		.and_then(Value::as_bool)
+		.unwrap_or(true);
 
 	payload["currentLanes"] = Value::Array(current_lanes);
-	payload["currentLanesComplete"] = Value::Bool(false);
+	payload["currentLanesComplete"] = Value::Bool(current_lanes_complete);
 	payload["currentLaneScope"] = Value::String(String::from("filtered"));
 
 	Some(DashboardBroadcastEvent { event_type: event.event_type, payload })

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -1903,7 +1903,7 @@ fn operator_dashboard_run_activity_preserves_snapshot_detail_fields() {
 	assert!(response.contains("dashboardRunTitleIsOperationFallback(activityRun)"));
 	assert!(response.contains("merged.title = snapshotRun.title;"));
 	assert!(
-		response.contains("const currentLanesComplete =\n\t\t\t\t\tactivityPayload.currentLanesComplete !== false")
+		response.contains("const currentLanesComplete = activityPayload.currentLanesComplete !== false;")
 	);
 	assert!(
 		response.contains("const mergedCurrentLanes = mergeDashboardCurrentLanes(\n\t\t\t\t\tsnapshot,\n\t\t\t\t\tcurrentLaneRows,\n\t\t\t\t\tcurrentLanesComplete,\n\t\t\t\t);")

--- a/apps/decodex/src/orchestrator/tests/operator/status/http.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/http.rs
@@ -747,7 +747,7 @@ fn operator_dashboard_websocket_filters_run_activity_by_subscription() {
 	assert_eq!(current_lanes[0]["project_id"], "pubfi");
 	assert_eq!(current_lanes[0]["issue_id"], "PUB-102");
 	assert_eq!(current_lanes[0]["run_id"], "run-2");
-	assert_eq!(activity["payload"]["currentLanesComplete"], false);
+	assert_eq!(activity["payload"]["currentLanesComplete"], true);
 	assert_eq!(activity["payload"]["currentLaneScope"], "filtered");
 
 	drop(client);
@@ -1419,7 +1419,47 @@ fn dashboard_event_hub_caches_and_filters_last_run_activity_event() {
 	assert_eq!(event.event_type, "runActivity");
 	assert_eq!(current_lanes.len(), 1);
 	assert_eq!(current_lanes[0]["issue_id"], "issue-1");
-	assert_eq!(event.payload["currentLanesComplete"], false);
+	assert_eq!(event.payload["currentLanesComplete"], true);
+	assert_eq!(event.payload["currentLaneScope"], "filtered");
+}
+
+#[test]
+fn dashboard_event_hub_filtered_empty_complete_event_clears_subscribed_overlay() {
+	let hub = DashboardEventHub::default();
+	let payload = serde_json::json!({
+		"emittedAtUnixEpoch": 1_774_000_000,
+		"accountControl": {
+			"mode": "balanced",
+			"account_selector": null,
+		},
+		"accounts": [],
+		"currentLanes": [
+			{
+				"project_id": "decodex",
+				"issue_id": "issue-2",
+				"run_id": "run-2",
+			},
+		],
+		"currentLanesComplete": true,
+		"currentLaneScope": "complete",
+	});
+	let subscription = DashboardClientSubscription {
+		project_id: Some(String::from("decodex")),
+		issue_id: Some(String::from("issue-1")),
+		run_id: None,
+	};
+
+	hub.broadcast("runActivity", payload);
+
+	let event = hub
+		.cached_run_activity_event(&subscription)
+		.expect("cached run activity should remain available for empty filtered scope");
+	let current_lanes = event.payload["currentLanes"]
+		.as_array()
+		.expect("filtered current lanes should be an array");
+
+	assert!(current_lanes.is_empty());
+	assert_eq!(event.payload["currentLanesComplete"], true);
 	assert_eq!(event.payload["currentLaneScope"], "filtered");
 }
 


### PR DESCRIPTION
## Summary
- preserve runActivity completeness when filtering cached dashboard events by subscription
- let filtered complete empty events clear stale current-lane overlays
- update dashboard run-activity tests for the filtered-complete contract

## Validation
- rustup run nightly cargo fmt --all -- --check
- cargo test -p decodex run_activity
- cargo test -p decodex dashboard_event_hub
- cargo test -p decodex operator_dashboard_websocket_filters_run_activity_by_subscription
- cargo test -p decodex operator_dashboard_run_activity_preserves_snapshot_detail_fields
- cargo check --all-features --all-targets --workspace