### PR TITLE
Guard ghost-lane recovery read-only state

### DIFF
--- a/apps/decodex/src/cli.rs
+++ b/apps/decodex/src/cli.rs
@@ -30,8 +30,9 @@ use crate::{
 	prelude::{Result, eyre},
 	program_intake::{self, GoalIntakeCommandRequest, IssueBatchIntakeCommandRequest},
 	recovery::{
-		self, LegacyCloseoutRecoveryRequest, MergedCloseoutRecoveryRequest,
-		ReviewHandoffAdoptRequest, ReviewHandoffDiagnoseRequest, ReviewHandoffRebindRequest,
+		self, GhostLaneCleanupRequest, GhostLaneDiagnoseRequest, LegacyCloseoutRecoveryRequest,
+		MergedCloseoutRecoveryRequest, ReviewHandoffAdoptRequest, ReviewHandoffDiagnoseRequest,
+		ReviewHandoffRebindRequest,
 	},
 	research_design::{
 		self, ResearchDesignCompileRequest, ResearchDesignOutcome, ResearchDesignPromoteRequest,
@@ -1093,6 +1094,7 @@ impl RecoverCommand {
 	fn run(&self) -> Result<()> {
 		match &self.command {
 			RecoverSubcommand::ReviewHandoff(args) => args.run(self.project_config.as_path()),
+			RecoverSubcommand::GhostLane(args) => args.run(self.project_config.as_path()),
 			RecoverSubcommand::LegacyCloseout(args) => recovery::run_legacy_closeout(
 				self.project_config.as_path(),
 				&LegacyCloseoutRecoveryRequest {
@@ -1113,6 +1115,46 @@ impl RecoverCommand {
 			),
 		}
 	}
+}
+
+#[derive(Debug, Args)]
+struct GhostLaneRecoveryCommand {
+	#[command(subcommand)]
+	command: GhostLaneRecoverySubcommand,
+}
+impl GhostLaneRecoveryCommand {
+	fn run(&self, config_path: Option<&Path>) -> Result<()> {
+		match &self.command {
+			GhostLaneRecoverySubcommand::Diagnose(args) => recovery::run_ghost_lane_diagnose(
+				config_path,
+				&GhostLaneDiagnoseRequest { issue: args.issue.clone(), json: args.json },
+			),
+			GhostLaneRecoverySubcommand::Cleanup(args) => recovery::run_ghost_lane_cleanup(
+				config_path,
+				&GhostLaneCleanupRequest { issue: args.issue.clone(), dry_run: args.dry_run },
+			),
+		}
+	}
+}
+
+#[derive(Debug, Args)]
+struct GhostLaneDiagnoseCommand {
+	/// Issue identifier or local issue id to inspect. Omit to inspect leased lanes.
+	#[arg(value_name = "ISSUE")]
+	issue: Option<String>,
+	/// Emit structured JSON instead of human-readable text.
+	#[arg(long)]
+	json: bool,
+}
+
+#[derive(Debug, Args)]
+struct GhostLaneCleanupCommand {
+	/// Issue identifier or local issue id for the ghost lane.
+	#[arg(value_name = "ISSUE")]
+	issue: String,
+	/// Validate only; do not terminalize the run lease or write private audit evidence.
+	#[arg(long)]
+	dry_run: bool,
 }
 
 #[derive(Debug, Args)]
@@ -1579,10 +1621,20 @@ enum ResearchOutcomeArg {
 enum RecoverSubcommand {
 	/// Recover retained review lanes whose lifecycle record is missing.
 	ReviewHandoff(ReviewHandoffRecoveryCommand),
+	/// Diagnose or clear missing-issue ghost lanes after fail-closed safety checks.
+	GhostLane(GhostLaneRecoveryCommand),
 	/// Record an audited fallback closeout for a legacy cleanup-only worktree.
 	LegacyCloseout(LegacyCloseoutRecoveryCommand),
 	/// Reconcile stale retained attention after a PR is already merged and cleaned up.
 	MergedCloseout(MergedCloseoutRecoveryCommand),
+}
+
+#[derive(Debug, Subcommand)]
+enum GhostLaneRecoverySubcommand {
+	/// Read-only diagnosis for local leases whose tracker issue is missing.
+	Diagnose(GhostLaneDiagnoseCommand),
+	/// Terminalize a proven ghost lane and clear its local run lease.
+	Cleanup(GhostLaneCleanupCommand),
 }
 
 #[derive(Debug, Subcommand)]
@@ -1758,9 +1810,10 @@ mod tests {
 		cli::{
 			AccountCommand, AccountSubcommand, AccountUseCommand, AppCommand, AttemptCommand, Cli,
 			Command, CommitCommand, DiagnoseCommand, DocsCommand, DocsSubcommand, EvidenceCommand,
-			IntakeCommand, IntakeGoalCommand, IntakeIssuesCommand, IntakeSubcommand, LandCommand,
-			LaneCommand, LaneInspectCommand, LaneInterruptCommand, LaneSteerCommand,
-			LaneSubcommand, LegacyCloseoutRecoveryCommand, McpSubcommand,
+			GhostLaneCleanupCommand, GhostLaneDiagnoseCommand, GhostLaneRecoveryCommand,
+			GhostLaneRecoverySubcommand, IntakeCommand, IntakeGoalCommand, IntakeIssuesCommand,
+			IntakeSubcommand, LandCommand, LaneCommand, LaneInspectCommand, LaneInterruptCommand,
+			LaneSteerCommand, LaneSubcommand, LegacyCloseoutRecoveryCommand, McpSubcommand,
 			MergedCloseoutRecoveryCommand, OkfCommand, OkfInitCommand, OkfInitProfileArg,
 			OkfSubcommand, ProbeCommand, ProjectCommand, ProjectConfigArgs, ProjectSubcommand,
 			RecoverCommand, RecoverSubcommand, ResearchCommand, ResearchCompileCommand,
@@ -2645,6 +2698,56 @@ mod tests {
 					)
 				})
 			}) if config == Path::new("./project.toml")
+		));
+	}
+
+	#[test]
+	fn parses_ghost_lane_diagnose_with_issue_and_json() {
+		let cli = Cli::parse_from([
+			"decodex",
+			"recover",
+			"--config",
+			"./project.toml",
+			"ghost-lane",
+			"diagnose",
+			"PUBFI-012",
+			"--json",
+		]);
+
+		assert!(matches!(
+			cli.command,
+			Command::Recover(RecoverCommand {
+				project_config: ProjectConfigArgs { config: Some(config) },
+				command: RecoverSubcommand::GhostLane(GhostLaneRecoveryCommand {
+					command: GhostLaneRecoverySubcommand::Diagnose(
+						GhostLaneDiagnoseCommand { issue: Some(_), json: true }
+					)
+				})
+			}) if config == Path::new("./project.toml")
+		));
+	}
+
+	#[test]
+	fn parses_ghost_lane_cleanup_dry_run() {
+		let cli = Cli::parse_from([
+			"decodex",
+			"recover",
+			"ghost-lane",
+			"cleanup",
+			"PUBFI-012",
+			"--dry-run",
+		]);
+
+		assert!(matches!(
+			cli.command,
+			Command::Recover(RecoverCommand {
+				command: RecoverSubcommand::GhostLane(GhostLaneRecoveryCommand {
+					command: GhostLaneRecoverySubcommand::Cleanup(
+						GhostLaneCleanupCommand { issue, dry_run: true }
+					)
+				}),
+				..
+			}) if issue == "PUBFI-012"
 		));
 	}
 

--- a/apps/decodex/src/orchestrator/operator_http.rs
+++ b/apps/decodex/src/orchestrator/operator_http.rs
@@ -1172,12 +1172,12 @@ fn dashboard_event_for_subscription(
 			.cloned()
 			.collect::<Vec<_>>()
 	})?;
-	let mut payload = event.payload.clone();
 	let current_lanes_complete = event
 		.payload
 		.get("currentLanesComplete")
 		.and_then(Value::as_bool)
 		.unwrap_or(true);
+	let mut payload = event.payload.clone();
 
 	payload["currentLanes"] = Value::Array(current_lanes);
 	payload["currentLanesComplete"] = Value::Bool(current_lanes_complete);

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -18,15 +18,21 @@ use state::WORKTREE_PROVENANCE_FILESYSTEM_SCAN;
 use state::WORKTREE_PROVENANCE_GIT_HYGIENE_SCAN;
 use state::WORKTREE_PROVENANCE_LEGACY_UNKNOWN;
 use state::ProjectLoopEvidenceSnapshot;
+use state::ProtocolActivityEventSummary;
 
 use crate::agent::REVIEW_POLICY_CONVERGENCE_BUDGET;
 use crate::pull_request::{self, PullRequestLandingGateView};
+use crate::tracker::public_text;
 use crate::worktree;
 use crate::worktree::MergedWorktreeCleanupDebt;
 
 const QUEUE_REASON_LINEAR_ACTIVE_LABEL_PRESENT: &str = "linear_active_label_present";
 const ATTENTION_ERROR_EVIDENCE_MISSING: &str = "evidence_missing";
 const EXECUTION_LIVENESS_PROCESS_IDENTITY_MISMATCH: &str = "process_identity_mismatch";
+const GHOST_LANE_CONDITION_TRACKER_ISSUE_MISSING: &str = "tracker_issue_missing";
+const GHOST_LANE_OWNERSHIP_STATE: &str = "ghost_lane";
+const GHOST_LANE_POLICY_STATE: &str = "runtime_recovery_required";
+const GHOST_LANE_NEXT_ACTION: &str = "run_ghost_lane_recovery";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum RetainedCloseoutPrMergeGate {
@@ -65,6 +71,7 @@ struct LiveOperatorStatusSnapshotOptions {
 	hydrate_history_ledger: bool,
 	run_issue_metadata_hydration: RunIssueMetadataHydration,
 	account_activity_mode: AccountActivityMode,
+	configure_dispatch_slots: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -309,6 +316,166 @@ pub(crate) fn ensure_project_has_no_merged_worktree_cleanup_debt(
 		project.service_id(),
 		format_merged_worktree_cleanup_debts(&debts)
 	);
+}
+
+pub(crate) fn ghost_lane_cleanup_status_blockers<T>(
+	tracker: &T,
+	project: &ServiceConfig,
+	_workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	issue_id: &str,
+	run_id: &str,
+) -> crate::prelude::Result<Vec<String>>
+where
+	T: IssueTracker,
+{
+	let Some(mut run) =
+		ghost_lane_cleanup_status_run(project, state_store, issue_id, run_id)?
+	else {
+		return Ok(vec![String::from("status_current_lane_missing")]);
+	};
+
+	if let Some(issue) = ghost_lane_tracker_issue(tracker, &run)? {
+		return Ok(vec![
+			String::from("tracker_issue_present"),
+			format!("issue_state:{}", issue.state.name),
+		]);
+	}
+
+	append_lane_control_condition(&mut run, GHOST_LANE_CONDITION_TRACKER_ISSUE_MISSING);
+	apply_missing_issue_ghost_lane_status_projection(project, state_store, &mut run)?;
+
+	if run.ownership_state == GHOST_LANE_OWNERSHIP_STATE
+		&& run.policy_state == GHOST_LANE_POLICY_STATE
+		&& run.lane_control_next_action == GHOST_LANE_NEXT_ACTION
+	{
+		return Ok(Vec::new());
+	}
+
+	let mut blockers = vec![
+		format!("ownership_state:{}", run.ownership_state),
+		format!("policy_state:{}", run.policy_state),
+		format!("lane_control_next_action:{}", run.lane_control_next_action),
+	];
+
+	blockers.extend(run.lane_control_conditions.iter().cloned());
+	blockers.sort();
+	blockers.dedup();
+
+	Ok(blockers)
+}
+
+fn ghost_lane_cleanup_status_run(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	issue_id: &str,
+	run_id: &str,
+) -> crate::prelude::Result<Option<OperatorRunStatus>> {
+	let (leased_runs, _) = state_store.list_project_runs_read_only(project.service_id(), 0)?;
+	let Some(run) = leased_runs
+		.into_iter()
+		.find(|run| run.issue_id() == issue_id && run.run_id() == run_id)
+	else {
+		return Ok(None);
+	};
+	let loop_evidence = state_store.project_loop_evidence_snapshot(project.service_id())?;
+	let project_display_name = operator_project_display_name(project);
+	let now_unix_epoch = OffsetDateTime::now_utc().unix_timestamp();
+
+	Ok(Some(operator_run_status(
+		project,
+		&loop_evidence,
+		&project_display_name,
+		run,
+		now_unix_epoch,
+	)?))
+}
+
+fn ghost_lane_tracker_issue<T>(
+	tracker: &T,
+	run: &OperatorRunStatus,
+) -> crate::prelude::Result<Option<TrackerIssue>>
+where
+	T: IssueTracker,
+{
+	if !run.issue_id.trim().is_empty() && !run.issue_id.eq_ignore_ascii_case("unknown") {
+		match tracker.refresh_issues(slice::from_ref(&run.issue_id)) {
+			Ok(issues) =>
+				if let Some(issue) = issues.into_iter().next() {
+					return Ok(Some(issue));
+				},
+			Err(error)
+				if tracker::issue_lookup_missing_error_for_candidate(&error, &run.issue_id) => {},
+			Err(error) => return Err(error),
+		}
+	}
+
+	let Some(selector) = operator_run_tracker_issue_identifier_selector(run) else {
+		return Ok(None);
+	};
+
+	match tracker.get_issue_by_identifier(&selector) {
+		Ok(issue) => Ok(issue),
+		Err(error) if tracker::issue_lookup_missing_error_for_candidate(&error, &selector) => {
+			Ok(None)
+		},
+		Err(error) => Err(error),
+	}
+}
+
+fn apply_missing_issue_ghost_lane_status_projection(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	run: &mut OperatorRunStatus,
+) -> crate::prelude::Result<()> {
+	let current_worktree_keys = ghost_lane_current_worktree_keys(project, state_store)?;
+	let (cleanup_safe, conditions) =
+		missing_issue_ghost_lane_local_conditions(project, state_store, run, &current_worktree_keys)?;
+
+	for condition in conditions {
+		append_lane_control_condition(run, &condition);
+	}
+
+	if cleanup_safe {
+		run.ownership_state = String::from(GHOST_LANE_OWNERSHIP_STATE);
+		run.policy_state = String::from(GHOST_LANE_POLICY_STATE);
+		run.lane_control_next_action = String::from(GHOST_LANE_NEXT_ACTION);
+	} else {
+		run.ownership_state = String::from("retained_attention");
+		run.policy_state = String::from("runtime_recovery_blocked");
+		run.lane_control_next_action =
+			String::from("inspect_missing_issue_runtime_recovery_blockers");
+	}
+
+	Ok(())
+}
+
+fn ghost_lane_current_worktree_keys(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+) -> crate::prelude::Result<std::collections::BTreeSet<String>> {
+	let mut keys = std::collections::BTreeSet::new();
+
+	for mapping in state_store.list_worktrees(project.service_id())? {
+		if !mapping.worktree_path().exists() {
+			continue;
+		}
+
+		let issue_identifier = issue_identifier_in_text(mapping.branch_name())
+			.or_else(|| issue_identifier_in_text(&mapping.worktree_path().display().to_string()));
+
+		keys.insert(operator_issue_attention_key(
+			mapping.issue_id(),
+			issue_identifier.as_deref(),
+		));
+	}
+	for issue_identifier in recoverable_worktree_identifiers(project.worktree_root())? {
+		if project.worktree_root().join(&issue_identifier).exists() {
+			keys.insert(operator_issue_attention_key(&issue_identifier, Some(&issue_identifier)));
+		}
+	}
+
+	Ok(keys)
 }
 
 fn build_operator_status_snapshot(
@@ -624,12 +791,13 @@ where
 		workflow,
 		state_store,
 		limit,
-		LiveOperatorStatusSnapshotOptions {
-			hydrate_history_ledger: true,
-			run_issue_metadata_hydration: RunIssueMetadataHydration::AllRows,
-			account_activity_mode: AccountActivityMode::Probe,
-		},
-	)
+			LiveOperatorStatusSnapshotOptions {
+				hydrate_history_ledger: true,
+				run_issue_metadata_hydration: RunIssueMetadataHydration::AllRows,
+				account_activity_mode: AccountActivityMode::Probe,
+				configure_dispatch_slots: true,
+			},
+		)
 }
 
 fn build_status_command_operator_status_snapshot<T>(
@@ -648,12 +816,13 @@ where
 		workflow,
 		state_store,
 		limit,
-		LiveOperatorStatusSnapshotOptions {
-			hydrate_history_ledger: true,
-			run_issue_metadata_hydration: RunIssueMetadataHydration::AllRows,
-			account_activity_mode: AccountActivityMode::Snapshot,
-		},
-	)
+			LiveOperatorStatusSnapshotOptions {
+				hydrate_history_ledger: true,
+				run_issue_metadata_hydration: RunIssueMetadataHydration::AllRows,
+				account_activity_mode: AccountActivityMode::Snapshot,
+				configure_dispatch_slots: true,
+			},
+		)
 }
 
 fn build_control_plane_operator_status_snapshot<T>(
@@ -672,12 +841,13 @@ where
 		workflow,
 		state_store,
 		limit,
-		LiveOperatorStatusSnapshotOptions {
-			hydrate_history_ledger: false,
-			run_issue_metadata_hydration: RunIssueMetadataHydration::CurrentLaneRowsOnly,
-			account_activity_mode: AccountActivityMode::Snapshot,
-		},
-	)
+			LiveOperatorStatusSnapshotOptions {
+				hydrate_history_ledger: false,
+				run_issue_metadata_hydration: RunIssueMetadataHydration::CurrentLaneRowsOnly,
+				account_activity_mode: AccountActivityMode::Snapshot,
+				configure_dispatch_slots: true,
+			},
+		)
 }
 
 fn build_live_operator_status_snapshot_with_history_ledger<T>(
@@ -691,11 +861,13 @@ fn build_live_operator_status_snapshot_with_history_ledger<T>(
 where
 	T: IssueTracker,
 {
-	state_store.configure_dispatch_slot_root(
-		project.service_id(),
-		project.worktree_root(),
-		workflow.frontmatter().execution().max_concurrent_agents(),
-	)?;
+	if options.configure_dispatch_slots {
+		state_store.configure_dispatch_slot_root(
+			project.service_id(),
+			project.worktree_root(),
+			workflow.frontmatter().execution().max_concurrent_agents(),
+		)?;
+	}
 
 	let review_state_inspector = GhPullRequestReviewStateInspector {
 		github_token_env_var: Some(project.github().token_env_var().to_owned()),
@@ -724,6 +896,7 @@ where
 		},
 		&mut snapshot,
 	)?;
+	apply_missing_issue_ghost_lane_projection(project, state_store, &mut snapshot)?;
 
 	let terminal_projection =
 		current_lane_terminal_projection_from_local_ledger(project, state_store, &snapshot)?;
@@ -2455,6 +2628,61 @@ where
 
 			hydrate_operator_snapshot_run_rows(snapshot, &metadata_by_issue_id);
 
+			if let Err(error) = hydrate_missing_current_lane_tracker_metadata(
+				tracker,
+				snapshot,
+				&active_label,
+				&needs_attention_label,
+			) {
+				if let Some(backoff) =
+					tracker_connector_backoff(&error, Instant::now(), "run_issue_identifier_metadata")
+				{
+					return TrackerObserverOutcome::Backoff(backoff);
+				}
+
+				let _ = error;
+
+				tracing::warn!(
+					project_id = project.service_id(),
+					"Skipped missing-issue current lane classification; sensitive tracker details were withheld."
+				);
+
+				return TrackerObserverOutcome::Unavailable;
+			}
+
+			TrackerObserverOutcome::Ok
+		},
+		Err(error)
+			if issue_ids
+				.iter()
+				.any(|issue_id| tracker::issue_lookup_missing_error_for_candidate(&error, issue_id)) =>
+		{
+			let active_label = crate::tracker::automation_active_label(project.service_id());
+			let needs_attention_label =
+				workflow.frontmatter().tracker().needs_attention_label().to_owned();
+
+			if let Err(error) = hydrate_missing_current_lane_tracker_metadata(
+				tracker,
+				snapshot,
+				&active_label,
+				&needs_attention_label,
+			) {
+				if let Some(backoff) =
+					tracker_connector_backoff(&error, Instant::now(), "run_issue_identifier_metadata")
+				{
+					return TrackerObserverOutcome::Backoff(backoff);
+				}
+
+				let _ = error;
+
+				tracing::warn!(
+					project_id = project.service_id(),
+					"Skipped missing-issue current lane classification; sensitive tracker details were withheld."
+				);
+
+				return TrackerObserverOutcome::Unavailable;
+			}
+
 			TrackerObserverOutcome::Ok
 		},
 		Err(error) => {
@@ -2519,6 +2747,428 @@ fn hydrate_operator_snapshot_run_rows(
 	}
 	for lane in &mut snapshot.history_lanes {
 		hydrate_history_lane_from_issue_metadata(lane, metadata_by_issue_id);
+	}
+}
+
+fn hydrate_missing_current_lane_tracker_metadata<T>(
+	tracker: &T,
+	snapshot: &mut OperatorStatusSnapshot,
+	active_label: &str,
+	needs_attention_label: &str,
+) -> crate::prelude::Result<()>
+where
+	T: IssueTracker,
+{
+	let mut metadata_by_issue_id = HashMap::new();
+	let mut missing_rows = Vec::new();
+
+	for run in &snapshot.current_lanes {
+		if run.issue_state.is_some() {
+			continue;
+		}
+
+		let Some(selector) = operator_run_tracker_issue_identifier_selector(run) else {
+			continue;
+		};
+
+		match tracker.get_issue_by_identifier(&selector) {
+			Ok(Some(issue)) => {
+				metadata_by_issue_id.insert(
+					run.issue_id.clone(),
+					operator_issue_display_metadata(&issue, active_label, needs_attention_label),
+				);
+			},
+			Ok(None) => missing_rows.push((run.run_id.clone(), run.issue_id.clone(), selector)),
+			Err(error) if tracker::issue_lookup_missing_error_for_candidate(&error, &selector) => {
+				missing_rows.push((run.run_id.clone(), run.issue_id.clone(), selector));
+			},
+			Err(error) => return Err(error),
+		}
+	}
+
+	if !metadata_by_issue_id.is_empty() {
+		hydrate_operator_snapshot_run_rows(snapshot, &metadata_by_issue_id);
+	}
+
+	for (run_id, issue_id, selector) in missing_rows {
+		mark_operator_run_tracker_issue_missing(snapshot, &run_id, &issue_id, &selector);
+	}
+
+	Ok(())
+}
+
+fn operator_issue_display_metadata(
+	issue: &TrackerIssue,
+	active_label: &str,
+	needs_attention_label: &str,
+) -> OperatorIssueDisplayMetadata {
+	OperatorIssueDisplayMetadata {
+		issue_identifier: issue.identifier.clone(),
+		title: Some(issue.title.clone()),
+		author: issue.author.clone(),
+		issue_state: Some(issue.state.name.clone()),
+		active_label_present: Some(issue.has_label(active_label)),
+		needs_attention_label_present: Some(issue.has_label(needs_attention_label)),
+	}
+}
+
+fn operator_run_tracker_issue_identifier_selector(run: &OperatorRunStatus) -> Option<String> {
+	run.issue_identifier
+		.as_ref()
+		.filter(|identifier| commit_message::looks_like_issue_identifier(identifier))
+		.map(|identifier| identifier.to_ascii_uppercase())
+		.or_else(|| {
+			operator_run_issue_identifier_from_fields(
+				&run.run_id,
+				run.branch_name.as_deref(),
+				run.worktree_path.as_deref(),
+			)
+		})
+		.or_else(|| {
+			commit_message::looks_like_issue_identifier(&run.issue_id)
+				.then(|| run.issue_id.to_ascii_uppercase())
+		})
+}
+
+fn mark_operator_run_tracker_issue_missing(
+	snapshot: &mut OperatorStatusSnapshot,
+	run_id: &str,
+	issue_id: &str,
+	selector: &str,
+) {
+	for run in snapshot.current_lanes.iter_mut().chain(snapshot.recent_runs.iter_mut()) {
+		if run.run_id == run_id || run.issue_id == issue_id {
+			if run.issue_identifier.is_none() {
+				run.issue_identifier = Some(selector.to_owned());
+			}
+
+			append_lane_control_condition(run, GHOST_LANE_CONDITION_TRACKER_ISSUE_MISSING);
+		}
+	}
+}
+
+fn apply_missing_issue_ghost_lane_projection(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	snapshot: &mut OperatorStatusSnapshot,
+) -> crate::prelude::Result<()> {
+	let current_worktree_keys = snapshot
+		.worktrees
+		.iter()
+		.filter(|worktree| operator_worktree_status_path_exists(project, worktree))
+		.map(|worktree| {
+			operator_issue_attention_key(
+				&worktree.issue_id,
+				worktree.issue_identifier.as_deref(),
+			)
+		})
+		.collect::<std::collections::BTreeSet<_>>();
+
+	for run in &mut snapshot.current_lanes {
+		if !run
+			.lane_control_conditions
+			.iter()
+			.any(|condition| condition == GHOST_LANE_CONDITION_TRACKER_ISSUE_MISSING)
+		{
+			continue;
+		}
+
+		let (cleanup_safe, conditions) =
+			missing_issue_ghost_lane_local_conditions(project, state_store, run, &current_worktree_keys)?;
+
+		for condition in conditions {
+			append_lane_control_condition(run, &condition);
+		}
+
+		if cleanup_safe {
+			run.ownership_state = String::from(GHOST_LANE_OWNERSHIP_STATE);
+			run.policy_state = String::from(GHOST_LANE_POLICY_STATE);
+			run.lane_control_next_action = String::from(GHOST_LANE_NEXT_ACTION);
+		} else {
+			run.ownership_state = String::from("retained_attention");
+			run.policy_state = String::from("runtime_recovery_blocked");
+			run.lane_control_next_action =
+				String::from("inspect_missing_issue_runtime_recovery_blockers");
+		}
+
+		if let Some(loop_status) = run.loop_status.as_mut() {
+			loop_status.next_action = Some(run.lane_control_next_action.clone());
+		}
+
+		run.needs_attention = true;
+		run.counts_as_running = false;
+	}
+
+	Ok(())
+}
+
+fn operator_worktree_status_path_exists(
+	project: &ServiceConfig,
+	worktree: &OperatorWorktreeStatus,
+) -> bool {
+	let path = Path::new(&worktree.worktree_path);
+
+	if path.is_absolute() { path.exists() } else { project.repo_root().join(path).exists() }
+}
+
+fn missing_issue_ghost_lane_local_conditions(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	run: &OperatorRunStatus,
+	current_worktree_keys: &std::collections::BTreeSet<String>,
+) -> crate::prelude::Result<(bool, Vec<String>)> {
+	let mut conditions = Vec::new();
+	let mut blockers = Vec::new();
+
+	if !run.run_lease {
+		blockers.push(String::from("run_lease_missing"));
+	}
+
+	inspect_status_ghost_lane_worktree(
+		project,
+		state_store,
+		run,
+		current_worktree_keys,
+		&mut conditions,
+		&mut blockers,
+	)?;
+	inspect_status_ghost_lane_control_channel(run, &mut conditions, &mut blockers);
+	inspect_status_ghost_lane_live_evidence(run, &mut conditions, &mut blockers);
+	inspect_status_ghost_lane_private_evidence(project, state_store, run, &mut conditions, &mut blockers)?;
+	inspect_status_ghost_lane_review_lineage(project, state_store, run, &mut conditions, &mut blockers)?;
+
+	conditions.extend(blockers.iter().cloned());
+
+	Ok((blockers.is_empty(), conditions))
+}
+
+fn inspect_status_ghost_lane_worktree(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	run: &OperatorRunStatus,
+	current_worktree_keys: &std::collections::BTreeSet<String>,
+	conditions: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> crate::prelude::Result<()> {
+	let mut retained_worktree_present = false;
+	let mut mapping_checked = false;
+
+	if let Some(worktree_path) = run.worktree_path.as_ref() {
+		mapping_checked = true;
+
+		if project.repo_root().join(worktree_path).exists() {
+			retained_worktree_present = true;
+		} else {
+			conditions.push(String::from("worktree_mapping_path_missing"));
+		}
+	}
+	if let Some(mapping) = state_store.worktree_for_issue(&run.issue_id)? {
+		mapping_checked = true;
+
+		if mapping.worktree_path().exists() {
+			retained_worktree_present = true;
+		} else {
+			conditions.push(String::from("worktree_mapping_path_missing"));
+		}
+	}
+
+	let selector = operator_run_tracker_issue_identifier_selector(run);
+
+	for candidate in [selector.as_deref(), Some(run.issue_id.as_str())].into_iter().flatten() {
+		if commit_message::looks_like_issue_identifier(candidate)
+			&& project.worktree_root().join(candidate).exists()
+		{
+			retained_worktree_present = true;
+		}
+	}
+
+	let run_issue_key = operator_issue_attention_key(&run.issue_id, run.issue_identifier.as_deref());
+
+	if current_worktree_keys.contains(&run_issue_key) {
+		retained_worktree_present = true;
+	}
+	if retained_worktree_present {
+		blockers.push(String::from("retained_worktree_present"));
+	} else {
+		if !mapping_checked {
+			conditions.push(String::from("worktree_mapping_missing"));
+		}
+
+		conditions.push(String::from("worktree_missing"));
+	}
+
+	Ok(())
+}
+
+fn inspect_status_ghost_lane_control_channel(
+	run: &OperatorRunStatus,
+	conditions: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) {
+	let Some(control_capability) = run.control_capability.as_ref() else {
+		conditions.push(String::from("control_channel_missing"));
+
+		return;
+	};
+
+	if Path::new(&control_capability.channel_path).exists() {
+		conditions.push(String::from("control_channel_file_present"));
+	} else {
+		conditions.push(String::from("control_channel_file_missing"));
+	}
+
+	blockers.push(String::from("control_channel_present"));
+}
+
+fn inspect_status_ghost_lane_live_evidence(
+	run: &OperatorRunStatus,
+	conditions: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) {
+	if run.process_alive == Some(true) {
+		blockers.push(String::from("process_alive"));
+	}
+	if matches!(run.thread_status.as_deref(), Some("active")) || !run.thread_active_flags.is_empty() {
+		blockers.push(String::from("thread_active"));
+	}
+	if operator_run_has_recent_app_server_execution(run) {
+		blockers.push(String::from("protocol_recent"));
+	}
+	if run.event_count > 0 || run.last_event_type.is_some() || run.last_event_at.is_some() {
+		blockers.push(String::from("protocol_event_evidence_present"));
+	}
+	if run.child_agent_activity.is_some() {
+		blockers.push(String::from("child_agent_activity_present"));
+	}
+	if run.protocol_activity.is_some() {
+		blockers.push(String::from("protocol_activity_present"));
+	}
+	if run.thread_id.is_some() || run.turn_id.is_some() {
+		blockers.push(String::from("thread_reference_present"));
+	}
+	if blockers.iter().any(|blocker| {
+		matches!(
+			blocker.as_str(),
+			"process_alive"
+				| "thread_active"
+				| "protocol_recent"
+				| "protocol_event_evidence_present"
+				| "child_agent_activity_present"
+				| "protocol_activity_present"
+				| "thread_reference_present"
+		)
+	}) {
+		return;
+	}
+
+	conditions.push(String::from("no_live_execution_evidence"));
+}
+
+fn inspect_status_ghost_lane_private_evidence(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	run: &OperatorRunStatus,
+	conditions: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> crate::prelude::Result<()> {
+	let events = state_store.list_private_execution_events(
+		project.service_id(),
+		&run.issue_id,
+		&run.run_id,
+		run.attempt_number,
+	)?;
+
+	if events.is_empty() {
+		conditions.push(String::from("private_evidence_missing"));
+	} else {
+		blockers.push(String::from("private_evidence_present"));
+	}
+
+	Ok(())
+}
+
+fn inspect_status_ghost_lane_review_lineage(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	run: &OperatorRunStatus,
+	conditions: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> crate::prelude::Result<()> {
+	if state_store.issue_has_review_lifecycle_record(project.service_id(), &run.issue_id)? {
+		blockers.push(String::from("review_lifecycle_present"));
+
+		return Ok(());
+	}
+	if status_run_has_review_policy_checkpoint(project, state_store, run)? {
+		blockers.push(String::from("review_policy_checkpoint_present"));
+
+		return Ok(());
+	}
+
+	let mut records = state_store.list_linear_execution_events(project.service_id(), &run.issue_id)?;
+
+	if let Some(issue_identifier) = run
+		.issue_identifier
+		.as_deref()
+		.filter(|identifier| !identifier.eq_ignore_ascii_case(&run.issue_id))
+	{
+		records.extend(state_store.list_linear_execution_events(project.service_id(), issue_identifier)?);
+	}
+
+	if records.iter().any(operator_linear_execution_event_has_pr_or_review_lineage) {
+		blockers.push(String::from("pr_or_review_lineage_present"));
+	} else {
+		conditions.push(String::from("review_lineage_missing"));
+	}
+
+	Ok(())
+}
+
+fn status_run_has_review_policy_checkpoint(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	run: &OperatorRunStatus,
+) -> crate::prelude::Result<bool> {
+	for phase in ["handoff", "repair"] {
+		if state_store
+			.review_policy_checkpoint(
+				project.service_id(),
+				&run.issue_id,
+				&run.run_id,
+				run.attempt_number,
+				phase,
+			)?
+			.is_some()
+		{
+			return Ok(true);
+		}
+	}
+
+	Ok(false)
+}
+
+fn operator_linear_execution_event_has_pr_or_review_lineage(
+	record: &LinearExecutionEventRecord,
+) -> bool {
+	record.pr_url.as_ref().is_some_and(|value| !value.trim().is_empty())
+		|| record.pr_head_sha.as_ref().is_some_and(|value| !value.trim().is_empty())
+		|| record.pr_base_ref.as_ref().is_some_and(|value| !value.trim().is_empty())
+		|| matches!(
+			record.event_type.as_str(),
+			"review_handoff"
+				| "review_handoff_rebind"
+				| "review_handoff_adopt"
+				| "review_repair"
+				| "landed"
+				| "closeout"
+				| "cleanup_complete"
+		)
+		|| record.terminal_path.as_deref() == Some("review_handoff")
+}
+
+fn append_lane_control_condition(run: &mut OperatorRunStatus, condition: &str) {
+	if !run.lane_control_conditions.iter().any(|value| value == condition) {
+		run.lane_control_conditions.push(condition.to_owned());
 	}
 }
 
@@ -5471,7 +6121,7 @@ where
 	let mut issues = if issue_ids.is_empty() && recoverable_worktree_skip_cache.is_some() {
 		Vec::new()
 	} else {
-		tracker.refresh_issues(&issue_ids)?
+		refresh_recoverable_runtime_issues(tracker, &issue_ids)?
 	};
 	let mut known_identifiers =
 		issues.iter().map(|issue| issue.identifier.to_ascii_uppercase()).collect::<BTreeSet<_>>();
@@ -5507,6 +6157,37 @@ where
 	recoverable_issues.sort_by(compare_issue_candidates);
 
 	Ok(RecoveredRuntimeState { recoverable_issues })
+}
+
+fn refresh_recoverable_runtime_issues<T>(
+	tracker: &T,
+	issue_ids: &[String],
+) -> crate::prelude::Result<Vec<TrackerIssue>>
+where
+	T: IssueTracker,
+{
+	match tracker.refresh_issues(issue_ids) {
+		Ok(issues) => Ok(issues),
+		Err(error)
+			if issue_ids
+				.iter()
+				.any(|issue_id| tracker::issue_lookup_missing_error_for_candidate(&error, issue_id)) =>
+		{
+			let mut issues = Vec::new();
+
+			for issue_id in issue_ids {
+				match tracker.refresh_issues(slice::from_ref(issue_id)) {
+					Ok(mut refreshed) => issues.append(&mut refreshed),
+					Err(error)
+						if tracker::issue_lookup_missing_error_for_candidate(&error, issue_id) => {},
+					Err(error) => return Err(error),
+				}
+			}
+
+			Ok(issues)
+		},
+		Err(error) => Err(error),
+	}
 }
 
 fn recover_issue_runtime_state<T>(
@@ -5719,7 +6400,13 @@ where
 		return Ok(());
 	}
 
-	let Some(issue) = tracker.get_issue_by_identifier(issue_identifier)? else {
+	let issue = match tracker.get_issue_by_identifier(issue_identifier) {
+		Ok(issue) => issue,
+		Err(error)
+			if tracker::issue_lookup_missing_error_for_candidate(&error, issue_identifier) => None,
+		Err(error) => return Err(error),
+	};
+	let Some(issue) = issue else {
 		if let Some(cache) = recoverable_worktree_skip_cache {
 			cache.remember(&canonical_identifier, now);
 		}
@@ -7769,7 +8456,98 @@ fn operator_run_protocol_activity(
 		return None;
 	}
 
+	sanitize_operator_protocol_activity_summary(&mut summary);
+
 	Some(summary)
+}
+
+fn sanitize_operator_protocol_activity_summary(summary: &mut ProtocolActivitySummary) {
+	for event in &mut summary.recent_events {
+		if let Some(detail) = event.detail.as_deref()
+			&& !operator_protocol_activity_detail_is_public(detail)
+		{
+			event.detail = Some(String::from("redacted_sensitive_detail"));
+		}
+	}
+}
+
+fn operator_protocol_activity_detail_is_public(detail: &str) -> bool {
+	public_text::validate_public_text_field("protocol_activity.detail", detail).is_ok()
+		&& !contains_protocol_activity_host_path_shape(detail)
+		&& !contains_protocol_activity_secret_shape(detail)
+}
+
+fn contains_protocol_activity_host_path_shape(detail: &str) -> bool {
+	let mut previous = None;
+	let mut chars = detail.char_indices().peekable();
+
+	while let Some((index, character)) = chars.next() {
+		if character != '/' {
+			previous = Some(character);
+
+			continue;
+		}
+		if previous == Some(':') || previous == Some('/') {
+			previous = Some(character);
+
+			continue;
+		}
+
+		let path_boundary = index == 0
+			|| previous.is_some_and(|previous| {
+				previous.is_whitespace() || matches!(previous, '"' | '\'' | '`' | '(' | '[' | '{' | '=')
+			});
+		let path_component = chars
+			.peek()
+			.map(|(_, next)| next.is_ascii_alphanumeric() || matches!(next, '.' | '_' | '-'))
+			.unwrap_or(false);
+
+		if path_boundary && path_component {
+			return true;
+		}
+
+		previous = Some(character);
+	}
+
+	false
+}
+
+fn contains_protocol_activity_secret_shape(detail: &str) -> bool {
+	detail.split(protocol_activity_token_separator).any(|token| {
+		let normalized = token.to_ascii_lowercase();
+
+		normalized.starts_with("ghp_")
+			|| normalized.starts_with("github_pat_")
+			|| is_high_entropy_protocol_activity_token(token)
+	})
+}
+
+fn protocol_activity_token_separator(character: char) -> bool {
+	!(character.is_ascii_alphanumeric() || character == '_' || character == '-')
+}
+
+fn is_high_entropy_protocol_activity_token(token: &str) -> bool {
+	if token.len() < 24 {
+		return false;
+	}
+
+	let mut has_uppercase = false;
+	let mut has_lowercase = false;
+	let mut has_digit = false;
+	let mut alphanumeric_count = 0;
+
+	for character in token.chars() {
+		if !character.is_ascii_alphanumeric() {
+			continue;
+		}
+
+		alphanumeric_count += 1;
+		has_uppercase |= character.is_ascii_uppercase();
+		has_lowercase |= character.is_ascii_lowercase();
+		has_digit |= character.is_ascii_digit();
+	}
+
+	alphanumeric_count >= 24 && has_uppercase && has_lowercase && has_digit
 }
 
 fn protocol_wait_reason_from_child_bucket(current_bucket: &str) -> String {
@@ -9124,19 +9902,27 @@ fn render_protocol_activity_summary(summary: Option<&ProtocolActivitySummary>) -
 			.iter()
 			.rev()
 			.take(5)
-			.map(|event| {
-				event
-					.detail
-					.as_ref()
-					.map_or_else(|| event.event_type.clone(), |detail| {
-						format!("{}:{detail}", event.event_type)
-					})
-			})
+			.map(render_protocol_activity_event_summary)
 			.collect::<Vec<_>>()
 			.join(", ")
 	};
 
 	format!("turn={turn}; waiting={wait}; rate_limit={rate_limit}; recent={recent}")
+}
+
+fn render_protocol_activity_event_summary(event: &ProtocolActivityEventSummary) -> String {
+	event.detail.as_ref().map_or_else(
+		|| event.event_type.clone(),
+		|detail| format!("{}:{}", event.event_type, render_protocol_activity_detail(detail)),
+	)
+}
+
+fn render_protocol_activity_detail(detail: &str) -> &str {
+	if operator_protocol_activity_detail_is_public(detail) {
+		detail
+	} else {
+		"redacted_sensitive_detail"
+	}
 }
 
 fn render_loop_status_summary(status: Option<&OperatorLoopStatus>) -> String {

--- a/apps/decodex/src/orchestrator/tests/operator/status/http.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/http.rs
@@ -986,10 +986,55 @@ fn read_websocket_json_until(
 			frame.extend_from_slice(&buffer[..event_bytes]);
 		}
 	}
-}
+	}
 
-#[test]
-fn operator_dashboard_run_activity_event_summarizes_current_lanes() {
+	fn assert_protocol_activity_detail_redacted(protocol_activity: &Value) {
+		assert_eq!(
+			protocol_activity["recent_events"][0]["detail"],
+			"redacted_sensitive_detail"
+		);
+		assert!(!protocol_activity.to_string().contains("path=/srv"));
+	}
+
+	fn assert_run_activity_protocol_activity_redacted(data_lane: &Value, fingerprint_lane: &Value) {
+		assert_eq!(data_lane["protocol_activity"]["waiting_reason"], "model");
+
+		assert_protocol_activity_detail_redacted(&data_lane["protocol_activity"]);
+		assert_protocol_activity_detail_redacted(&fingerprint_lane["protocol_activity"]);
+	}
+
+	fn assert_run_activity_envelope(payload: &Value, data: &Value, fingerprint: &Value) {
+		assert_eq!(payload["type"], "runActivity");
+		assert_eq!(data["accountControl"]["mode"], "balanced");
+		assert_eq!(data["currentLanesComplete"], true);
+		assert_eq!(data["currentLaneScope"], "complete");
+		assert!(data.get("accounts").is_none());
+		assert!(fingerprint.get("emittedAtUnixEpoch").is_none());
+		assert_eq!(fingerprint["accountControl"]["mode"], "balanced");
+		assert_eq!(fingerprint["currentLanesComplete"], true);
+		assert_eq!(fingerprint["currentLaneScope"], "complete");
+		assert!(fingerprint.get("accounts").is_none());
+	}
+
+	fn assert_run_activity_current_lane(data_lane: &Value, fingerprint_lane: &Value) {
+		assert_eq!(fingerprint_lane["run_id"], "run-1");
+		assert_eq!(fingerprint_lane["project_display_name"], "hack-ink/pubfi-mono-v2");
+		assert_eq!(data_lane["run_id"], "run-1");
+		assert_eq!(data_lane["project_id"], "pubfi");
+		assert_eq!(data_lane["project_display_name"], "hack-ink/pubfi-mono-v2");
+
+		assert_run_activity_protocol_activity_redacted(data_lane, fingerprint_lane);
+
+		assert_eq!(data_lane["account"]["account_fingerprint"], "acct-1");
+		assert_eq!(data_lane["accounts"][0]["account_fingerprint"], "acct-1");
+		assert!(data_lane.get("idle_for_seconds").is_some());
+		assert!(data_lane.get("protocol_idle_for_seconds").is_some());
+		assert!(fingerprint_lane.get("idle_for_seconds").is_none());
+		assert!(fingerprint_lane.get("protocol_idle_for_seconds").is_none());
+	}
+
+	#[test]
+	fn operator_dashboard_run_activity_event_summarizes_current_lanes() {
 	let temp_dir = TempDir::new().expect("temp dir should exist");
 	let _home_guard =
 		TestEnvVarGuard::set("HOME", temp_dir.path().to_str().expect("temp path should be UTF-8"));
@@ -1011,7 +1056,7 @@ fn operator_dashboard_run_activity_event_summarizes_current_lanes() {
 		recent_events: vec![state::ProtocolActivityEventSummary {
 			event_type: String::from("item/model/delta"),
 			category: String::from("model"),
-			detail: Some(String::from("received model delta")),
+			detail: Some(String::from("state marker path=/srv/decodex/runtime")),
 		}],
 	};
 	let account = CodexAccountActivitySummary {
@@ -1080,31 +1125,8 @@ fn operator_dashboard_run_activity_event_summarizes_current_lanes() {
 	let fingerprint: Value =
 		serde_json::from_slice(&event.fingerprint).expect("fingerprint should be json");
 
-	assert_eq!(payload["type"], "runActivity");
-	assert_eq!(data["accountControl"]["mode"], "balanced");
-	assert_eq!(data["currentLanesComplete"], true);
-	assert_eq!(data["currentLaneScope"], "complete");
-	assert!(data.get("accounts").is_none());
-	assert!(fingerprint.get("emittedAtUnixEpoch").is_none());
-	assert_eq!(fingerprint["accountControl"]["mode"], "balanced");
-	assert_eq!(fingerprint["currentLanesComplete"], true);
-	assert_eq!(fingerprint["currentLaneScope"], "complete");
-	assert!(fingerprint.get("accounts").is_none());
-	assert_eq!(fingerprint["currentLanes"][0]["run_id"], "run-1");
-	assert_eq!(
-		fingerprint["currentLanes"][0]["project_display_name"],
-		"hack-ink/pubfi-mono-v2"
-	);
-	assert_eq!(data["currentLanes"][0]["run_id"], "run-1");
-	assert_eq!(data["currentLanes"][0]["project_id"], "pubfi");
-	assert_eq!(data["currentLanes"][0]["project_display_name"], "hack-ink/pubfi-mono-v2");
-	assert_eq!(data["currentLanes"][0]["protocol_activity"]["waiting_reason"], "model");
-	assert_eq!(data["currentLanes"][0]["account"]["account_fingerprint"], "acct-1");
-	assert_eq!(data["currentLanes"][0]["accounts"][0]["account_fingerprint"], "acct-1");
-	assert!(data["currentLanes"][0].get("idle_for_seconds").is_some());
-	assert!(data["currentLanes"][0].get("protocol_idle_for_seconds").is_some());
-	assert!(fingerprint["currentLanes"][0].get("idle_for_seconds").is_none());
-	assert!(fingerprint["currentLanes"][0].get("protocol_idle_for_seconds").is_none());
+	assert_run_activity_envelope(&payload, data, &fingerprint);
+	assert_run_activity_current_lane(&data["currentLanes"][0], &fingerprint["currentLanes"][0]);
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -1,3 +1,5 @@
+use records::LinearExecutionEventRecord;
+
 #[test]
 fn failure_comments_use_repo_relative_worktree_paths() {
 	let (_temp_dir, config, _workflow) = temp_project_layout();
@@ -73,6 +75,712 @@ fn operator_status_snapshot_includes_current_lanes_and_repo_relative_paths() {
 	);
 	assert_eq!(project.connector_state, "ok");
 	assert!(project.last_activity_at.is_some());
+}
+
+#[test]
+fn live_operator_status_classifies_missing_issue_ghost_lane_for_runtime_recovery() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::new(Vec::new());
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("ghost current lane should be visible");
+	let rendered = orchestrator::render_operator_status(&snapshot);
+	let project = snapshot.projects.first().expect("project summary should exist");
+
+	assert_eq!(snapshot.current_lanes.len(), 1);
+	assert_eq!(run.run_id, "run-12");
+	assert_eq!(run.issue_id, "PUB-012");
+	assert_eq!(run.issue_identifier.as_deref(), Some("PUB-012"));
+	assert_eq!(run.ownership_state, "ghost_lane");
+	assert_eq!(run.policy_state, "runtime_recovery_required");
+	assert_eq!(run.lane_control_next_action, "run_ghost_lane_recovery");
+	assert!(!run.counts_as_running);
+	assert!(run.needs_attention);
+	assert!(run.lane_control_conditions.contains(&String::from("tracker_issue_missing")));
+	assert!(run.lane_control_conditions.contains(&String::from("worktree_missing")));
+	assert!(run.lane_control_conditions.contains(&String::from("control_channel_missing")));
+	assert!(run.lane_control_conditions.contains(&String::from("private_evidence_missing")));
+	assert!(run.lane_control_conditions.contains(&String::from("review_lineage_missing")));
+	assert_eq!(project.attention_count, 1);
+	assert!(!rendered.contains("Record the independent Decodex Review checkpoint"));
+	assert!(!rendered.contains("review-handoff"));
+}
+
+#[test]
+fn live_operator_status_classifies_invalid_local_issue_id_as_ghost_lane() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::with_refresh_error(
+		Vec::new(),
+		"Linear GraphQL request failed: Argument Validation Error",
+	);
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("ghost current lane should be visible");
+
+	assert_eq!(run.issue_id, "PUB-012");
+	assert_eq!(run.ownership_state, "ghost_lane");
+	assert_eq!(run.policy_state, "runtime_recovery_required");
+	assert_eq!(run.lane_control_next_action, "run_ghost_lane_recovery");
+	assert!(!run.counts_as_running);
+	assert!(run.needs_attention);
+	assert!(run.lane_control_conditions.contains(&String::from("tracker_issue_missing")));
+	assert!(!snapshot.warnings.iter().any(|warning| warning.contains("runtime_recovery_unavailable")));
+}
+
+#[test]
+fn live_operator_status_allows_ghost_recovery_when_worktree_mapping_path_is_missing() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::new(Vec::new());
+	let missing_worktree_path = config.worktree_root().join("PUB-012");
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			"PUB-012",
+			"x/pubfi-pub-012",
+			&missing_worktree_path.display().to_string(),
+		)
+		.expect("stale worktree mapping should record");
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("ghost current lane should be visible");
+
+	assert_eq!(run.ownership_state, "ghost_lane");
+	assert_eq!(run.policy_state, "runtime_recovery_required");
+	assert_eq!(run.lane_control_next_action, "run_ghost_lane_recovery");
+	assert!(run.lane_control_conditions.contains(&String::from("worktree_mapping_path_missing")));
+	assert!(run.lane_control_conditions.contains(&String::from("worktree_missing")));
+	assert!(!run.lane_control_conditions.contains(&String::from("retained_worktree_present")));
+}
+
+#[test]
+fn live_operator_status_blocks_missing_issue_ghost_cleanup_when_retained_worktree_exists() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::new(Vec::new());
+
+	fs::create_dir_all(config.worktree_root().join("PUB-012"))
+		.expect("retained worktree directory should exist");
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("current lane should be visible");
+
+	assert_eq!(run.ownership_state, "retained_attention");
+	assert_eq!(run.policy_state, "runtime_recovery_blocked");
+	assert_eq!(
+		run.lane_control_next_action,
+		"inspect_missing_issue_runtime_recovery_blockers"
+	);
+	assert!(run.needs_attention);
+	assert!(!run.counts_as_running);
+	assert!(run.lane_control_conditions.contains(&String::from("retained_worktree_present")));
+}
+
+#[test]
+fn live_operator_status_blocks_missing_issue_ghost_cleanup_when_control_channel_row_exists() {
+	let (temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::new(Vec::new());
+	let channel_path = temp_dir.path().join("missing-control-channel.json");
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+	state_store
+		.publish_run_control_channel_for_active_attempt(
+			"run-12",
+			1,
+			&channel_path,
+			"local_file",
+		)
+		.expect("control channel row should publish");
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("current lane should be visible");
+
+	assert_eq!(run.ownership_state, "retained_attention");
+	assert_eq!(run.policy_state, "runtime_recovery_blocked");
+	assert_eq!(
+		run.lane_control_next_action,
+		"inspect_missing_issue_runtime_recovery_blockers"
+	);
+	assert!(run.needs_attention);
+	assert!(!run.counts_as_running);
+	assert!(run.lane_control_conditions.contains(&String::from("control_channel_file_missing")));
+	assert!(run.lane_control_conditions.contains(&String::from("control_channel_present")));
+}
+
+#[test]
+fn ghost_lane_cleanup_status_blockers_treat_invalid_local_issue_id_as_missing_issue() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::with_refresh_error(
+		Vec::new(),
+		"Linear GraphQL request failed: Argument Validation Error",
+	);
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+
+	let blockers = orchestrator::ghost_lane_cleanup_status_blockers(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		"PUB-012",
+		"run-12",
+	)
+	.expect("invalid local issue id should be classified as a missing tracker issue");
+
+	assert!(blockers.is_empty(), "missing issue with no live evidence should allow cleanup");
+}
+
+#[test]
+fn ghost_lane_cleanup_status_blockers_preserve_live_blockers_after_invalid_issue_id_lookup() {
+	let (temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::with_refresh_error(
+		Vec::new(),
+		"Linear GraphQL request failed: Argument Validation Error",
+	);
+	let channel_path = temp_dir.path().join("missing-control-channel.json");
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+	state_store
+		.publish_run_control_channel_for_active_attempt(
+			"run-12",
+			1,
+			&channel_path,
+			"local_file",
+		)
+		.expect("control channel row should publish");
+
+	let blockers = orchestrator::ghost_lane_cleanup_status_blockers(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		"PUB-012",
+		"run-12",
+	)
+	.expect("invalid local issue id should still run local safety checks");
+
+	assert!(blockers.contains(&String::from("control_channel_present")));
+	assert!(blockers.contains(&String::from("control_channel_file_missing")));
+}
+
+#[test]
+fn ghost_lane_cleanup_status_blockers_do_not_hide_validation_error_for_server_issue_id() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::with_refresh_error(
+		Vec::new(),
+		"Linear GraphQL request failed: Argument Validation Error",
+	);
+	let issue_id = "00000000-0000-0000-0000-000000000012";
+
+	state_store
+		.record_run_attempt("run-12", issue_id, 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", issue_id, "run-12", "In Progress")
+		.expect("lease should record");
+
+	let error = orchestrator::ghost_lane_cleanup_status_blockers(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		issue_id,
+		"run-12",
+	)
+	.expect_err("server issue id validation errors must remain tracker failures");
+
+	assert!(error.to_string().contains("Argument Validation Error"));
+}
+
+#[test]
+fn ghost_lane_cleanup_status_blockers_reject_live_process_evidence() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::new(Vec::new());
+	let worktree_path = config.worktree_root().join("PUB-012");
+
+	fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			"PUB-012",
+			"x/pubfi-pub-012",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	state::write_run_activity_marker_for_process(&worktree_path, "run-12", 1, process::id())
+		.expect("live process marker should write");
+
+	let blockers = orchestrator::ghost_lane_cleanup_status_blockers(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		"PUB-012",
+		"run-12",
+	)
+	.expect("cleanup status blockers should load");
+
+	assert!(blockers.contains(&String::from("process_alive")));
+	assert!(blockers.contains(&String::from("retained_worktree_present")));
+}
+
+#[test]
+fn ghost_lane_cleanup_status_blockers_reject_active_thread_evidence() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::new(Vec::new());
+	let worktree_path = config.worktree_root().join("PUB-012");
+
+	fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			"PUB-012",
+			"x/pubfi-pub-012",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	state::write_run_thread_status_marker(
+		&worktree_path,
+		"run-12",
+		1,
+		Some("thread-12"),
+		Some("turn-12"),
+		"active",
+		&[String::from("waitingOnApproval")],
+	)
+	.expect("active thread marker should write");
+
+	let blockers = orchestrator::ghost_lane_cleanup_status_blockers(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		"PUB-012",
+		"run-12",
+	)
+	.expect("cleanup status blockers should load");
+
+	assert!(blockers.contains(&String::from("thread_active")));
+	assert!(blockers.contains(&String::from("retained_worktree_present")));
+}
+
+#[test]
+fn ghost_lane_cleanup_status_blockers_do_not_persist_marker_thread_identity() {
+	let (temp_dir, config, workflow) = temp_project_layout();
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+	let state_store = StateStore::open(&state_path).expect("state store should open");
+	let tracker = FakeTracker::new(Vec::new());
+	let worktree_path = config.worktree_root().join("PUB-012");
+
+	fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			"PUB-012",
+			"x/pubfi-pub-012",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	state::write_run_thread_status_marker(
+		&worktree_path,
+		"run-12",
+		1,
+		Some("thread-12"),
+		Some("turn-12"),
+		"active",
+		&[String::from("waitingOnApproval")],
+	)
+	.expect("active thread marker should write");
+
+	let blockers = orchestrator::ghost_lane_cleanup_status_blockers(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		"PUB-012",
+		"run-12",
+	)
+	.expect("cleanup status blockers should load");
+	let connection = Connection::open(&state_path).expect("sqlite should open");
+	let (thread_id, turn_id): (Option<String>, Option<String>) = connection
+		.query_row(
+			"SELECT thread_id, turn_id FROM run_attempts WHERE run_id = 'run-12'",
+			[],
+			|row| Ok((row.get(0)?, row.get(1)?)),
+		)
+		.expect("run attempt should exist");
+
+	assert!(blockers.contains(&String::from("thread_active")));
+	assert_eq!(thread_id, None);
+	assert_eq!(turn_id, None);
+}
+
+#[test]
+fn ghost_lane_cleanup_status_blockers_reject_existing_tracker_issue() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let mut issue = sample_issue("In Progress", &[]);
+
+	issue.id = String::from("PUB-012");
+	issue.identifier = String::from("PUB-012");
+
+	let tracker = FakeTracker::new(vec![issue]);
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+
+	let blockers = orchestrator::ghost_lane_cleanup_status_blockers(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		"PUB-012",
+		"run-12",
+	)
+	.expect("cleanup status blockers should load");
+
+	assert!(blockers.contains(&String::from("tracker_issue_present")));
+	assert!(blockers.contains(&String::from("issue_state:In Progress")));
+}
+
+#[test]
+fn ghost_lane_cleanup_status_blockers_reject_recent_protocol_evidence() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::new(Vec::new());
+	let worktree_path = config.worktree_root().join("PUB-012");
+
+	fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			"PUB-012",
+			"x/pubfi-pub-012",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	state::write_run_protocol_activity_marker(
+		&worktree_path,
+		&ProtocolActivityMarker {
+			run_id: "run-12",
+			attempt_number: 1,
+			thread_id: None,
+			turn_id: None,
+			event_count: 1,
+			last_event_type: "thread/status/changed",
+			child_agent_activity: None,
+			protocol_activity: None,
+		},
+	)
+	.expect("recent protocol marker should write");
+
+	rewrite_run_activity_marker_host_boot_id(&worktree_path, "previous-boot");
+
+	let blockers = orchestrator::ghost_lane_cleanup_status_blockers(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		"PUB-012",
+		"run-12",
+	)
+	.expect("cleanup status blockers should load");
+
+	assert!(blockers.contains(&String::from("protocol_recent")));
+	assert!(blockers.contains(&String::from("retained_worktree_present")));
+}
+
+#[test]
+fn live_operator_status_blocks_missing_issue_ghost_cleanup_when_review_lifecycle_exists() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::new(Vec::new());
+	let marker = ReviewHandoffMarker::new(
+		"run-12",
+		1,
+		"x/pubfi-pub-012",
+		"https://github.com/hack-ink/decodex/pull/12",
+		"main",
+		"x/pubfi-pub-012",
+		"08a20f7dfb9526e7421a5f095b1c6adec84e52d6",
+	);
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+	state_store
+		.upsert_review_handoff_marker(TEST_SERVICE_ID, "PUB-012", &marker)
+		.expect("review lifecycle should record");
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("current lane should be visible");
+
+	assert_eq!(run.ownership_state, "retained_attention");
+	assert_eq!(run.policy_state, "runtime_recovery_blocked");
+	assert!(run.lane_control_conditions.contains(&String::from("review_lifecycle_present")));
+}
+
+#[test]
+fn live_operator_status_blocks_missing_issue_ghost_cleanup_when_private_evidence_exists() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::new(Vec::new());
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+	state_store
+		.append_private_execution_event(
+			"pubfi",
+			"PUB-012",
+			"run-12",
+			1,
+			"diagnostic",
+			serde_json::json!({"schema": "test.private/1"}),
+		)
+		.expect("private evidence should record");
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("current lane should be visible");
+
+	assert_eq!(run.ownership_state, "retained_attention");
+	assert_eq!(run.policy_state, "runtime_recovery_blocked");
+	assert!(run.lane_control_conditions.contains(&String::from("private_evidence_present")));
+}
+
+#[test]
+fn live_operator_status_blocks_missing_issue_ghost_cleanup_when_review_checkpoint_exists() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::new(Vec::new());
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+	state_store
+		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
+			project_id: TEST_SERVICE_ID,
+			issue_id: "PUB-012",
+			run_id: "run-12",
+			attempt_number: 1,
+			phase: "handoff",
+			review_level: config.codex().review_level().as_str(),
+			status: "clean",
+			head_sha: "2222222222222222222222222222222222222222",
+			nonclean_rounds: 0,
+			details_json: "{}",
+		})
+		.expect("review checkpoint should record");
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("current lane should be visible");
+
+	assert_eq!(run.ownership_state, "retained_attention");
+	assert_eq!(run.policy_state, "runtime_recovery_blocked");
+	assert!(
+		run.lane_control_conditions
+			.contains(&String::from("review_policy_checkpoint_present"))
+	);
+}
+
+#[test]
+fn live_operator_status_blocks_missing_issue_ghost_cleanup_when_pr_lineage_exists() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::new(Vec::new());
+	let mut event = LinearExecutionEventRecord::new(
+		LinearExecutionEventIdentity {
+			service_id: "pubfi",
+			issue_id: "PUB-012",
+			issue_identifier: "PUB-012",
+			run_id: "run-12",
+			attempt_number: 1,
+		},
+		"closeout",
+		String::from("2026-06-18T00:00:00Z"),
+		"closeout",
+	);
+
+	event.branch = Some(String::from("x/pubfi-pub-012"));
+	event.pr_url = Some(String::from("https://github.com/hack-ink/decodex/pull/12"));
+	event.pr_head_sha = Some(String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"));
+	event.pr_base_ref = Some(String::from("main"));
+	event.commit_sha = Some(String::from("18a20f7dfb9526e7421a5f095b1c6adec84e52d7"));
+	event.summary = Some(String::from("Recorded retained closeout."));
+
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("lease should record");
+	state_store.record_linear_execution_event(&event).expect("linear event should record");
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("current lane should be visible");
+
+	assert_eq!(run.ownership_state, "retained_attention");
+	assert_eq!(run.policy_state, "runtime_recovery_blocked");
+	assert!(run.lane_control_conditions.contains(&String::from("pr_or_review_lineage_present")));
 }
 
 #[test]
@@ -948,6 +1656,64 @@ fn runtime_recovery_records_recovered_provenance_for_fresh_active_worktree() {
 	assert_eq!(mapping.provenance().created_at_unix(), Some(observed_at_unix));
 	assert_eq!(mapping.provenance().updated_at_unix(), Some(observed_at_unix));
 	assert_eq!(lease.run_id(), "run-1");
+}
+
+#[test]
+fn runtime_recovery_splits_invalid_local_id_batch_without_losing_valid_issue() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let mut issue = sample_active_issue("In Progress");
+
+	issue.id = String::from("00000000-0000-0000-0000-000000000101");
+
+	let tracker = FakeTracker::with_refresh_error(
+		vec![issue.clone()],
+		"Linear GraphQL request failed: Argument Validation Error",
+	);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let worktree_path = config.worktree_root().join(&issue.identifier);
+
+	fs::create_dir_all(&worktree_path).expect("active worktree path should exist");
+	state::write_run_activity_marker(&worktree_path, "run-101", 1)
+		.expect("activity marker should write");
+
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("valid worktree mapping should record");
+	state_store
+		.record_run_attempt("run-12", "PUB-012", 1, "running")
+		.expect("invalid local run attempt should record");
+	state_store
+		.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+		.expect("invalid local lease should record");
+
+	let recovered_state = orchestrator::recover_runtime_state_from_tracker_and_worktrees(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+	)
+	.expect("runtime recovery should split invalid local ids from valid server ids");
+	let recovered_mapping = state_store
+		.worktree_for_issue(&issue.id)
+		.expect("mapping lookup should succeed")
+		.expect("valid issue mapping should remain");
+	let lease = state_store
+		.lease_for_issue(&issue.id)
+		.expect("lease lookup should succeed")
+		.expect("valid issue lease should recover");
+
+	assert!(
+		recovered_state.recoverable_issues.is_empty(),
+		"fresh valid issue should recover as active lease rather than disappear"
+	);
+	assert_eq!(recovered_mapping.issue_id(), issue.id);
+	assert_eq!(lease.issue_id(), issue.id);
+	assert_eq!(lease.run_id(), "run-101");
 }
 
 #[test]
@@ -2736,6 +3502,77 @@ fn operator_status_snapshot_uses_structured_protocol_activity_summary() {
 	assert_eq!(run.wait_reason.as_deref(), Some("approval_or_user_input"));
 	assert_eq!(run.protocol_activity.as_ref(), Some(&protocol_activity));
 	assert!(rendered.contains("protocol_activity: turn=running; waiting=approval_or_user_input; rate_limit=primary; recent=item/tool/requestUserInput, plan/update:verify"));
+}
+
+#[test]
+fn operator_status_snapshot_sanitizes_private_protocol_activity_details() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue("Todo", &[]);
+	let worktree_path = config.worktree_root().join("PUB-101");
+	let protocol_activity = ProtocolActivitySummary {
+		turn_status: Some(String::from("running")),
+		waiting_reason: Some(String::from("tool_execution")),
+		rate_limit_status: None,
+		recent_events: vec![
+			state::ProtocolActivityEventSummary {
+				event_type: String::from("configWarning"),
+				category: String::from("warning"),
+				detail: Some(String::from("state marker path=/srv/decodex/runtime")),
+			},
+			state::ProtocolActivityEventSummary {
+				event_type: String::from("configWarning"),
+				category: String::from("warning"),
+				detail: Some(String::from("state marker (/srv/decodex/runtime)")),
+			},
+		],
+	};
+
+	state_store
+		.record_run_attempt("run-1", &issue.id, 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", &issue.id, "run-1", "In Progress")
+		.expect("lease should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	state::write_run_protocol_activity_marker(
+		&worktree_path,
+		&ProtocolActivityMarker {
+			run_id: "run-1",
+			attempt_number: 1,
+			thread_id: Some("thread-1"),
+			turn_id: Some("turn-1"),
+			event_count: 2,
+			last_event_type: "configWarning",
+			child_agent_activity: None,
+			protocol_activity: Some(&protocol_activity),
+		},
+	)
+	.expect("protocol activity marker should write");
+
+	let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+		.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("current lane should exist");
+	let rendered = orchestrator::render_operator_status(&snapshot);
+	let summary = run.protocol_activity.as_ref().expect("protocol summary should render");
+
+	assert!(
+		summary
+			.recent_events
+			.iter()
+			.all(|event| event.detail.as_deref() == Some("redacted_sensitive_detail"))
+	);
+	assert!(rendered.contains("configWarning:redacted_sensitive_detail"));
+	assert!(!rendered.contains("path=/srv"));
+	assert!(!rendered.contains("(/srv"));
 }
 
 #[test]

--- a/apps/decodex/src/orchestrator/tests/operator/status/text.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/text.rs
@@ -216,6 +216,80 @@ fn operator_status_text_renders_human_readable_sections() {
 }
 
 #[test]
+fn operator_status_text_sanitizes_private_protocol_activity_details() {
+	let mut current_lane = operator_status_text_current_lane();
+
+	current_lane.protocol_activity = Some(ProtocolActivitySummary {
+		turn_status: Some(String::from("completed")),
+		waiting_reason: Some(String::from("turn_completed")),
+		rate_limit_status: None,
+		recent_events: vec![
+			state::ProtocolActivityEventSummary {
+				event_type: String::from("error"),
+				category: String::from("protocol_error"),
+				detail: Some(String::from(
+					"upstream auth failed for ghp_abcdefghijklmnopqrstuvwxyz123456",
+				)),
+			},
+			state::ProtocolActivityEventSummary {
+				event_type: String::from("configWarning"),
+				category: String::from("warning"),
+				detail: Some(String::from("config at /private/worktree using GITHUB_PAT_Y")),
+			},
+			state::ProtocolActivityEventSummary {
+				event_type: String::from("configWarning"),
+				category: String::from("warning"),
+				detail: Some(String::from("state marker under /srv/decodex/runtime")),
+			},
+			state::ProtocolActivityEventSummary {
+				event_type: String::from("configWarning"),
+				category: String::from("warning"),
+				detail: Some(String::from("state marker path=/srv/decodex/runtime")),
+			},
+			state::ProtocolActivityEventSummary {
+				event_type: String::from("configWarning"),
+				category: String::from("warning"),
+				detail: Some(String::from("state marker (/srv/decodex/runtime)")),
+			},
+		],
+	});
+
+	let snapshot = OperatorStatusSnapshot {
+		project_id: String::from("pubfi"),
+		run_limit: 10,
+		status_source: None,
+		snapshot_age_seconds: None,
+		warnings: Vec::new(),
+		warning_details: Vec::new(),
+		connector_backoffs: Vec::new(),
+		projects: Vec::new(),
+		account_control: OperatorCodexAccountControlStatus {
+			mode: String::from("balanced"),
+			account_selector: None,
+		},
+		accounts: Vec::new(),
+		current_lanes: vec![current_lane],
+		queued_candidates: Vec::new(),
+		recent_runs: Vec::new(),
+		history_lanes: Vec::new(),
+		execution_programs: Vec::new(),
+		worktrees: Vec::new(),
+		post_review_lanes: Vec::new(),
+	};
+	let rendered = orchestrator::render_operator_status(&snapshot);
+
+	assert!(rendered.contains(
+		"protocol_activity: turn=completed; waiting=turn_completed; rate_limit=none; recent=configWarning:redacted_sensitive_detail, configWarning:redacted_sensitive_detail, configWarning:redacted_sensitive_detail, configWarning:redacted_sensitive_detail, error:redacted_sensitive_detail"
+	));
+	assert!(!rendered.contains("GITHUB_PAT_Y"));
+	assert!(!rendered.contains("ghp_"));
+	assert!(!rendered.contains("/private/worktree"));
+	assert!(!rendered.contains("/srv/decodex/runtime"));
+	assert!(!rendered.contains("path=/srv"));
+	assert!(!rendered.contains("(/srv"));
+}
+
+#[test]
 fn operator_status_text_surfaces_execution_program_summary() {
 	let snapshot = OperatorStatusSnapshot {
 		project_id: String::from("decodex"),

--- a/apps/decodex/src/recovery.rs
+++ b/apps/decodex/src/recovery.rs
@@ -1,7 +1,7 @@
 //! Explicit operator recovery surfaces for retained Decodex lanes.
 
 use std::{
-	collections::HashMap,
+	collections::{BTreeSet, HashMap},
 	env, fs,
 	path::{Path, PathBuf},
 	process::Command,
@@ -12,14 +12,15 @@ use serde::Serialize;
 use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::{
+	commit_message,
 	config::ServiceConfig,
-	github,
+	github, orchestrator,
 	prelude::{Result, eyre},
 	pull_request::{self, PullRequestLandingState},
 	runtime,
 	state::{
-		self, ConnectorBackoffInput, ReviewHandoffMarker, ReviewOrchestrationMarker, StateStore,
-		WorktreeMapping,
+		self, ConnectorBackoffInput, ProjectRunStatus, RUN_CONTROL_CHANNEL_STATUS_FAILED,
+		ReviewHandoffMarker, ReviewOrchestrationMarker, StateStore, WorktreeMapping,
 	},
 	tracker::{
 		self, IssueTracker, TrackerIssue,
@@ -43,6 +44,10 @@ const LEGACY_MANUAL_CLOSEOUT_EVENT: &str = "closeout";
 const LEGACY_MANUAL_CLOSEOUT_ANCHOR: &str = "legacy_manual_closeout";
 const MERGED_CLOSEOUT_CLOSEOUT_ANCHOR: &str = "merged_closeout";
 const MERGED_CLOSEOUT_CLEANUP_ANCHOR: &str = "merged_closeout_cleanup";
+const GHOST_LANE_CLASSIFICATION: &str = "missing_issue_ghost_lane";
+const GHOST_LANE_BLOCKED_CLASSIFICATION: &str = "ghost_lane_recovery_blocked";
+const GHOST_LANE_CLEANUP_EVENT: &str = "ghost_lane_cleanup";
+const GHOST_LANE_TERMINAL_STATUS: &str = "terminal_guarded";
 const REBOUND_ORCHESTRATION_PHASE: &str = "request_pending";
 const LINEAR_RATE_LIMIT_BACKOFF_WARNING: &str = "tracker_rate_limited";
 const LINEAR_RATE_LIMIT_BACKOFF_SECS: i64 = 15 * 60;
@@ -77,6 +82,24 @@ pub(crate) struct ReviewHandoffAdoptRequest {
 	/// Pull request URL to adopt.
 	pub(crate) pr_url: String,
 	/// Validate without writing runtime lifecycle state or tracker audit comments.
+	pub(crate) dry_run: bool,
+}
+
+/// Read-only ghost-lane diagnostic request.
+#[derive(Debug)]
+pub(crate) struct GhostLaneDiagnoseRequest {
+	/// Optional issue identifier or local issue id to inspect.
+	pub(crate) issue: Option<String>,
+	/// Emit JSON instead of text.
+	pub(crate) json: bool,
+}
+
+/// Explicit missing-issue ghost-lane cleanup request.
+#[derive(Debug)]
+pub(crate) struct GhostLaneCleanupRequest {
+	/// Issue identifier or local issue id to terminalize.
+	pub(crate) issue: String,
+	/// Validate without writing runtime state.
 	pub(crate) dry_run: bool,
 }
 
@@ -135,6 +158,34 @@ struct ReviewHandoffDiagnostic {
 	next_action: String,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct GhostLaneRecoveryReport {
+	project_id: String,
+	diagnostics: Vec<GhostLaneDiagnostic>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct GhostLaneDiagnostic {
+	project_id: String,
+	issue_id: String,
+	issue_identifier: Option<String>,
+	run_id: String,
+	attempt_number: i64,
+	attempt_status: String,
+	classification: String,
+	reason: String,
+	run_lease: bool,
+	control_channel: String,
+	evidence: Vec<String>,
+	blockers: Vec<String>,
+	next_action: String,
+}
+impl GhostLaneDiagnostic {
+	fn recoverable(&self) -> bool {
+		self.classification == GHOST_LANE_CLASSIFICATION && self.blockers.is_empty()
+	}
+}
+
 struct HandoffBindingDiagnostic {
 	classification: String,
 	reason: String,
@@ -175,6 +226,18 @@ struct RecoveryContext {
 	workflow: WorkflowDocument,
 	state_store: StateStore,
 	tracker: LinearClient,
+	runtime_mutation_policy: RecoveryRuntimeMutationPolicy,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RecoveryRuntimeMutationPolicy {
+	AllowRuntimeWrites,
+	ReadOnly,
+}
+impl RecoveryRuntimeMutationPolicy {
+	const fn allows_runtime_writes(self) -> bool {
+		matches!(self, Self::AllowRuntimeWrites)
+	}
 }
 
 struct RebindValidation {
@@ -299,7 +362,7 @@ pub(crate) fn run_review_handoff_diagnose(
 	config_path: Option<&Path>,
 	request: &ReviewHandoffDiagnoseRequest,
 ) -> Result<()> {
-	let context = load_recovery_context(config_path)?;
+	let context = load_recovery_context_read_only(config_path)?;
 
 	if let Some(message) = active_recovery_tracker_backoff_message(&context)? {
 		println!("{message}");
@@ -346,7 +409,7 @@ pub(crate) fn run_review_handoff_rebind(
 	config_path: Option<&Path>,
 	request: &ReviewHandoffRebindRequest,
 ) -> Result<()> {
-	let context = load_recovery_context(config_path)?;
+	let context = load_recovery_context_for_dry_run(config_path, request.dry_run)?;
 	let validation = validate_rebind_request(&context, request)?;
 
 	if request.dry_run {
@@ -390,7 +453,7 @@ pub(crate) fn run_review_handoff_adopt(
 	config_path: Option<&Path>,
 	request: &ReviewHandoffAdoptRequest,
 ) -> Result<()> {
-	let context = load_recovery_context(config_path)?;
+	let context = load_recovery_context_for_dry_run(config_path, request.dry_run)?;
 	let validation = validate_adopt_request(&context, request)?;
 
 	if request.dry_run {
@@ -434,12 +497,164 @@ pub(crate) fn run_review_handoff_adopt(
 	Ok(())
 }
 
+/// Run a read-only missing-issue ghost-lane diagnostic.
+pub(crate) fn run_ghost_lane_diagnose(
+	config_path: Option<&Path>,
+	request: &GhostLaneDiagnoseRequest,
+) -> Result<()> {
+	let context = load_recovery_context_read_only(config_path)?;
+
+	if let Some(message) = active_recovery_tracker_backoff_message(&context)? {
+		println!("{message}");
+
+		return Ok(());
+	}
+
+	let mut diagnostics = match diagnose_ghost_lanes_read_only(
+		context.config.service_id(),
+		context.config.worktree_root(),
+		&context.state_store,
+		&context.tracker,
+		request.issue.as_deref(),
+	) {
+		Ok(diagnostics) => diagnostics,
+		Err(error) => {
+			if let Some(message) =
+				remember_recovery_tracker_backoff_message(&context, &error, "ghost_lane_recovery")
+			{
+				println!("{message}");
+
+				return Ok(());
+			}
+
+			return Err(error);
+		},
+	};
+
+	if let Err(error) = apply_ghost_lane_live_status_blockers(&context, &mut diagnostics) {
+		if let Some(message) =
+			remember_recovery_tracker_backoff_message(&context, &error, "ghost_lane_recovery")
+		{
+			println!("{message}");
+
+			return Ok(());
+		}
+
+		return Err(error);
+	}
+
+	let report =
+		GhostLaneRecoveryReport { project_id: context.config.service_id().to_owned(), diagnostics };
+
+	if request.json {
+		println!("{}", serde_json::to_string_pretty(&report)?);
+	} else {
+		print!("{}", render_ghost_lane_recovery_report(&report));
+	}
+
+	Ok(())
+}
+
+/// Terminalize a proven missing-issue ghost lane and clear its local run lease.
+pub(crate) fn run_ghost_lane_cleanup(
+	config_path: Option<&Path>,
+	request: &GhostLaneCleanupRequest,
+) -> Result<()> {
+	let context = load_recovery_context_for_dry_run(config_path, request.dry_run)?;
+
+	if let Some(message) = active_recovery_tracker_backoff_message(&context)? {
+		println!("{message}");
+
+		return Ok(());
+	}
+
+	let mut diagnostics = match if context.runtime_mutation_policy.allows_runtime_writes() {
+		diagnose_ghost_lanes(
+			context.config.service_id(),
+			context.config.worktree_root(),
+			&context.state_store,
+			&context.tracker,
+			Some(&request.issue),
+		)
+	} else {
+		diagnose_ghost_lanes_read_only(
+			context.config.service_id(),
+			context.config.worktree_root(),
+			&context.state_store,
+			&context.tracker,
+			Some(&request.issue),
+		)
+	} {
+		Ok(diagnostics) => diagnostics,
+		Err(error) => {
+			if let Some(message) =
+				remember_recovery_tracker_backoff_message(&context, &error, "ghost_lane_recovery")
+			{
+				println!("{message}");
+
+				return Ok(());
+			}
+
+			return Err(error);
+		},
+	};
+	let diagnostic = diagnostics
+		.pop()
+		.ok_or_else(|| eyre::eyre!("No leased lane matched `{}`.", request.issue))?;
+
+	if !diagnostic.recoverable() {
+		eyre::bail!(
+			"`recover ghost-lane cleanup` refused `{}` because safety inspection reported blockers: {}",
+			request.issue,
+			diagnostic.blockers.join(", ")
+		);
+	}
+
+	if let Err(error) = ensure_ghost_lane_live_status_allows_cleanup(&context, &diagnostic) {
+		if let Some(message) =
+			remember_recovery_tracker_backoff_message(&context, &error, "ghost_lane_recovery")
+		{
+			println!("{message}");
+
+			return Ok(());
+		}
+
+		return Err(error);
+	}
+
+	if request.dry_run {
+		println!(
+			"dry run: ghost lane cleanup validated for project={} issue={} run_id={} attempt={} classification={}",
+			diagnostic.project_id,
+			render_ghost_lane_issue(&diagnostic),
+			diagnostic.run_id,
+			diagnostic.attempt_number,
+			diagnostic.classification
+		);
+
+		return Ok(());
+	}
+
+	apply_ghost_lane_cleanup(&context.state_store, &diagnostic)?;
+
+	println!(
+		"ghost lane cleanup ok: project={} issue={} run_id={} attempt={} status={} lease_cleared=yes",
+		diagnostic.project_id,
+		render_ghost_lane_issue(&diagnostic),
+		diagnostic.run_id,
+		diagnostic.attempt_number,
+		GHOST_LANE_TERMINAL_STATUS
+	);
+
+	Ok(())
+}
+
 /// Run an explicit audited legacy closeout fallback.
 pub(crate) fn run_legacy_closeout(
 	config_path: Option<&Path>,
 	request: &LegacyCloseoutRecoveryRequest,
 ) -> Result<()> {
-	let context = load_recovery_context(config_path)?;
+	let context = load_recovery_context_for_dry_run(config_path, request.dry_run)?;
 	let validation = validate_legacy_closeout_request(&context, request)?;
 
 	if request.dry_run {
@@ -483,7 +698,7 @@ pub(crate) fn run_merged_closeout(
 	config_path: Option<&Path>,
 	request: &MergedCloseoutRecoveryRequest,
 ) -> Result<()> {
-	let context = load_recovery_context(config_path)?;
+	let context = load_recovery_context_for_dry_run(config_path, request.dry_run)?;
 	let validation = validate_merged_closeout_request(&context, request)?;
 
 	if request.dry_run {
@@ -527,16 +742,38 @@ pub(crate) fn run_merged_closeout(
 	Ok(())
 }
 
-fn load_recovery_context(config_path: Option<&Path>) -> Result<RecoveryContext> {
+fn load_recovery_context_read_only(config_path: Option<&Path>) -> Result<RecoveryContext> {
+	load_recovery_context_with_policy(config_path, RecoveryRuntimeMutationPolicy::ReadOnly)
+}
+
+fn load_recovery_context_for_dry_run(
+	config_path: Option<&Path>,
+	dry_run: bool,
+) -> Result<RecoveryContext> {
+	let runtime_mutation_policy = if dry_run {
+		RecoveryRuntimeMutationPolicy::ReadOnly
+	} else {
+		RecoveryRuntimeMutationPolicy::AllowRuntimeWrites
+	};
+
+	load_recovery_context_with_policy(config_path, runtime_mutation_policy)
+}
+
+fn load_recovery_context_with_policy(
+	config_path: Option<&Path>,
+	runtime_mutation_policy: RecoveryRuntimeMutationPolicy,
+) -> Result<RecoveryContext> {
 	let state_store = runtime::open_runtime_store()?;
 	let config_path = resolve_recovery_config_path(config_path, &state_store)?;
 	let config = ServiceConfig::from_path(&config_path)?;
 	let workflow = WorkflowDocument::from_path(config.workflow_path())?;
 	let tracker = LinearClient::new(config.tracker().resolve_api_key()?)?;
 
-	runtime::register_project_config(&state_store, &config_path, true)?;
+	if runtime_mutation_policy.allows_runtime_writes() {
+		runtime::register_project_config(&state_store, &config_path, true)?;
+	}
 
-	Ok(RecoveryContext { config, workflow, state_store, tracker })
+	Ok(RecoveryContext { config, workflow, state_store, tracker, runtime_mutation_policy })
 }
 
 fn active_recovery_tracker_backoff_message(context: &RecoveryContext) -> Result<Option<String>> {
@@ -548,7 +785,9 @@ fn active_recovery_tracker_backoff_message(context: &RecoveryContext) -> Result<
 	let now_unix_epoch = OffsetDateTime::now_utc().unix_timestamp();
 
 	if backoff.reset_unix_epoch() <= now_unix_epoch {
-		context.state_store.clear_connector_backoff(context.config.service_id(), "linear")?;
+		if context.runtime_mutation_policy.allows_runtime_writes() {
+			context.state_store.clear_connector_backoff(context.config.service_id(), "linear")?;
+		}
 
 		return Ok(None);
 	}
@@ -594,6 +833,15 @@ fn remember_recovery_tracker_backoff_message(
 	} else {
 		return None;
 	};
+
+	if !context.runtime_mutation_policy.allows_runtime_writes() {
+		return Some(recovery_tracker_backoff_message(
+			context.config.service_id(),
+			sync_phase,
+			reset_unix_epoch,
+			reset_unix_epoch.saturating_sub(now_unix_epoch),
+		));
+	}
 
 	if let Err(store_error) = context.state_store.upsert_connector_backoff(ConnectorBackoffInput {
 		project_id: context.config.service_id(),
@@ -1132,6 +1380,772 @@ fn render_review_handoff_recovery_report(report: &ReviewHandoffRecoveryReport) -
 
 fn optional_text(value: Option<&str>) -> &str {
 	value.unwrap_or("none")
+}
+
+fn diagnose_ghost_lanes<T>(
+	project_id: &str,
+	worktree_root: &Path,
+	state_store: &StateStore,
+	tracker: &T,
+	selector: Option<&str>,
+) -> Result<Vec<GhostLaneDiagnostic>>
+where
+	T: IssueTracker + ?Sized,
+{
+	diagnose_ghost_lanes_with_listing_mode(
+		project_id,
+		worktree_root,
+		state_store,
+		tracker,
+		selector,
+		RecoveryRuntimeMutationPolicy::AllowRuntimeWrites,
+	)
+}
+
+fn diagnose_ghost_lanes_read_only<T>(
+	project_id: &str,
+	worktree_root: &Path,
+	state_store: &StateStore,
+	tracker: &T,
+	selector: Option<&str>,
+) -> Result<Vec<GhostLaneDiagnostic>>
+where
+	T: IssueTracker + ?Sized,
+{
+	diagnose_ghost_lanes_with_listing_mode(
+		project_id,
+		worktree_root,
+		state_store,
+		tracker,
+		selector,
+		RecoveryRuntimeMutationPolicy::ReadOnly,
+	)
+}
+
+fn diagnose_ghost_lanes_with_listing_mode<T>(
+	project_id: &str,
+	worktree_root: &Path,
+	state_store: &StateStore,
+	tracker: &T,
+	selector: Option<&str>,
+	listing_mode: RecoveryRuntimeMutationPolicy,
+) -> Result<Vec<GhostLaneDiagnostic>>
+where
+	T: IssueTracker + ?Sized,
+{
+	let (mut runs, _) = if listing_mode.allows_runtime_writes() {
+		state_store.list_project_runs(project_id, 0)?
+	} else {
+		state_store.list_project_runs_read_only(project_id, 0)?
+	};
+
+	if let Some(selector) = selector {
+		let selector = selector.trim();
+
+		runs.retain(|run| ghost_lane_run_matches_selector(run, selector));
+
+		if runs.is_empty() {
+			eyre::bail!("No leased lane matched `{selector}`.");
+		}
+		if runs.len() > 1 {
+			eyre::bail!(
+				"`{selector}` matched multiple leased lanes; pass the exact local issue id."
+			);
+		}
+	}
+
+	runs.into_iter()
+		.map(|run| {
+			inspect_ghost_lane(project_id, worktree_root, state_store, tracker, &run, selector)
+		})
+		.collect()
+}
+
+fn inspect_ghost_lane<T>(
+	project_id: &str,
+	worktree_root: &Path,
+	state_store: &StateStore,
+	tracker: &T,
+	run: &ProjectRunStatus,
+	requested_selector: Option<&str>,
+) -> Result<GhostLaneDiagnostic>
+where
+	T: IssueTracker + ?Sized,
+{
+	let issue_identifier = ghost_lane_issue_identifier(run, requested_selector);
+	let mut evidence = Vec::new();
+	let mut blockers = Vec::new();
+
+	if run.run_lease() {
+		evidence.push(String::from("run_lease_present"));
+	} else {
+		blockers.push(String::from("run_lease_missing"));
+	}
+
+	inspect_ghost_lane_tracker_issue(
+		tracker,
+		run,
+		issue_identifier.as_deref(),
+		requested_selector,
+		&mut evidence,
+		&mut blockers,
+	)?;
+	inspect_ghost_lane_worktree(
+		worktree_root,
+		state_store,
+		run,
+		issue_identifier.as_deref(),
+		requested_selector,
+		&mut evidence,
+		&mut blockers,
+	)?;
+
+	let control_channel = inspect_ghost_lane_control_channel(run, &mut evidence, &mut blockers);
+
+	inspect_ghost_lane_live_evidence(run, &mut evidence, &mut blockers);
+	inspect_ghost_lane_private_evidence(
+		project_id,
+		state_store,
+		run,
+		&mut evidence,
+		&mut blockers,
+	)?;
+	inspect_ghost_lane_review_lineage(
+		project_id,
+		state_store,
+		run,
+		issue_identifier.as_deref(),
+		&mut evidence,
+		&mut blockers,
+	)?;
+
+	let (classification, reason, next_action) = if blockers.is_empty() {
+		(
+			String::from(GHOST_LANE_CLASSIFICATION),
+			String::from("tracker_issue_missing_and_no_live_or_retained_lane_evidence"),
+			format!(
+				"Run `decodex recover ghost-lane cleanup {} --dry-run`, then rerun without `--dry-run` if the report stays safe.",
+				issue_identifier.as_deref().unwrap_or(run.issue_id())
+			),
+		)
+	} else {
+		(
+			String::from(GHOST_LANE_BLOCKED_CLASSIFICATION),
+			String::from("safety_check_blocked"),
+			String::from(
+				"Preserve attention and inspect the listed blockers before using a recovery command.",
+			),
+		)
+	};
+
+	Ok(GhostLaneDiagnostic {
+		project_id: project_id.to_owned(),
+		issue_id: run.issue_id().to_owned(),
+		issue_identifier,
+		run_id: run.run_id().to_owned(),
+		attempt_number: run.attempt_number(),
+		attempt_status: run.status().to_owned(),
+		classification,
+		reason,
+		run_lease: run.run_lease(),
+		control_channel,
+		evidence: sorted_unique(evidence),
+		blockers: sorted_unique(blockers),
+		next_action,
+	})
+}
+
+fn inspect_ghost_lane_tracker_issue<T>(
+	tracker: &T,
+	run: &ProjectRunStatus,
+	issue_identifier: Option<&str>,
+	requested_selector: Option<&str>,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Result<()>
+where
+	T: IssueTracker + ?Sized,
+{
+	let refreshed = match tracker.refresh_issues(&[run.issue_id().to_owned()]) {
+		Ok(refreshed) => refreshed,
+		Err(error) if tracker::issue_lookup_missing_error_for_candidate(&error, run.issue_id()) =>
+			Vec::new(),
+		Err(error) => return Err(error),
+	};
+
+	if !refreshed.is_empty() {
+		blockers.push(String::from("tracker_issue_present"));
+
+		return Ok(());
+	}
+
+	for selector in ghost_lane_tracker_issue_selectors(run, issue_identifier, requested_selector) {
+		match tracker.get_issue_by_identifier(&selector) {
+			Ok(Some(_)) => {
+				blockers.push(String::from("tracker_issue_present"));
+
+				return Ok(());
+			},
+			Ok(None) => {},
+			Err(error) if tracker::issue_lookup_missing_error_for_candidate(&error, &selector) => {
+			},
+			Err(error) => return Err(error),
+		}
+	}
+
+	evidence.push(String::from("tracker_issue_missing"));
+
+	Ok(())
+}
+
+fn inspect_ghost_lane_worktree(
+	worktree_root: &Path,
+	state_store: &StateStore,
+	run: &ProjectRunStatus,
+	issue_identifier: Option<&str>,
+	requested_selector: Option<&str>,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Result<()> {
+	let mut retained_worktree_present = false;
+	let mut mapping_checked = false;
+
+	if let Some(worktree_path) = run.worktree_path() {
+		mapping_checked = true;
+
+		if worktree_path.exists() {
+			retained_worktree_present = true;
+		} else {
+			evidence.push(String::from("worktree_mapping_path_missing"));
+		}
+	}
+	if let Some(mapping) = state_store.worktree_for_issue(run.issue_id())? {
+		mapping_checked = true;
+
+		if mapping.worktree_path().exists() {
+			retained_worktree_present = true;
+		} else {
+			evidence.push(String::from("worktree_mapping_path_missing"));
+		}
+	}
+
+	for selector in ghost_lane_worktree_selectors(run, issue_identifier, requested_selector) {
+		if worktree_root.join(&selector).exists() {
+			retained_worktree_present = true;
+		}
+	}
+
+	if retained_worktree_present {
+		blockers.push(String::from("retained_worktree_present"));
+	} else {
+		if !mapping_checked {
+			evidence.push(String::from("worktree_mapping_missing"));
+		}
+
+		evidence.push(String::from("worktree_missing"));
+	}
+
+	Ok(())
+}
+
+fn inspect_ghost_lane_control_channel(
+	run: &ProjectRunStatus,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> String {
+	let Some(channel) = run.control_channel() else {
+		evidence.push(String::from("control_channel_missing"));
+
+		return String::from("missing");
+	};
+
+	if channel.channel_path().exists() {
+		evidence.push(String::from("control_channel_file_present"));
+	} else {
+		evidence.push(String::from("control_channel_file_missing"));
+	}
+
+	blockers.push(String::from("control_channel_present"));
+
+	format!("{}:present", channel.status())
+}
+
+fn inspect_ghost_lane_live_evidence(
+	run: &ProjectRunStatus,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) {
+	if run.event_count() > 0 || run.last_event_type().is_some() || run.last_event_at().is_some() {
+		blockers.push(String::from("protocol_event_evidence_present"));
+	}
+	if run.child_agent_activity().is_some() {
+		blockers.push(String::from("child_agent_activity_present"));
+	}
+	if run.protocol_activity().is_some() {
+		blockers.push(String::from("protocol_activity_present"));
+	}
+	if run.thread_id().is_some() || run.turn_id().is_some() {
+		blockers.push(String::from("thread_reference_present"));
+	}
+	if blockers.iter().any(|blocker| {
+		matches!(
+			blocker.as_str(),
+			"protocol_event_evidence_present"
+				| "child_agent_activity_present"
+				| "protocol_activity_present"
+				| "thread_reference_present"
+		)
+	}) {
+		return;
+	}
+
+	evidence.push(String::from("no_live_execution_evidence"));
+}
+
+fn inspect_ghost_lane_private_evidence(
+	project_id: &str,
+	state_store: &StateStore,
+	run: &ProjectRunStatus,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Result<()> {
+	let events = state_store.list_private_execution_events(
+		project_id,
+		run.issue_id(),
+		run.run_id(),
+		run.attempt_number(),
+	)?;
+
+	if events.is_empty() {
+		evidence.push(String::from("private_evidence_missing"));
+	} else {
+		blockers.push(String::from("private_evidence_present"));
+	}
+
+	Ok(())
+}
+
+fn inspect_ghost_lane_review_lineage(
+	project_id: &str,
+	state_store: &StateStore,
+	run: &ProjectRunStatus,
+	issue_identifier: Option<&str>,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Result<()> {
+	if state_store.issue_has_review_lifecycle_record(project_id, run.issue_id())? {
+		blockers.push(String::from("review_lifecycle_present"));
+
+		return Ok(());
+	}
+	if ghost_lane_run_has_review_policy_checkpoint(project_id, state_store, run)? {
+		blockers.push(String::from("review_policy_checkpoint_present"));
+
+		return Ok(());
+	}
+
+	let mut records = state_store.list_linear_execution_events(project_id, run.issue_id())?;
+
+	if let Some(issue_identifier) = issue_identifier
+		.filter(|issue_identifier| !issue_identifier.eq_ignore_ascii_case(run.issue_id()))
+	{
+		records.extend(state_store.list_linear_execution_events(project_id, issue_identifier)?);
+	}
+
+	if records.iter().any(ghost_lane_record_has_pr_or_review_lineage) {
+		blockers.push(String::from("pr_or_review_lineage_present"));
+	} else {
+		evidence.push(String::from("review_lineage_missing"));
+	}
+
+	Ok(())
+}
+
+fn ghost_lane_run_has_review_policy_checkpoint(
+	project_id: &str,
+	state_store: &StateStore,
+	run: &ProjectRunStatus,
+) -> Result<bool> {
+	for phase in ["handoff", "repair"] {
+		if state_store
+			.review_policy_checkpoint(
+				project_id,
+				run.issue_id(),
+				run.run_id(),
+				run.attempt_number(),
+				phase,
+			)?
+			.is_some()
+		{
+			return Ok(true);
+		}
+	}
+
+	Ok(false)
+}
+
+fn ghost_lane_record_has_pr_or_review_lineage(record: &LinearExecutionEventRecord) -> bool {
+	record.pr_url.as_ref().is_some_and(|value| !value.trim().is_empty())
+		|| record.pr_head_sha.as_ref().is_some_and(|value| !value.trim().is_empty())
+		|| record.pr_base_ref.as_ref().is_some_and(|value| !value.trim().is_empty())
+		|| matches!(
+			record.event_type.as_str(),
+			"review_handoff"
+				| "review_handoff_rebind"
+				| "review_handoff_adopt"
+				| "review_repair"
+				| "landed" | "closeout"
+				| "cleanup_complete"
+		) || record.terminal_path.as_deref() == Some("review_handoff")
+}
+
+fn apply_ghost_lane_cleanup(
+	state_store: &StateStore,
+	diagnostic: &GhostLaneDiagnostic,
+) -> Result<()> {
+	state_store
+		.append_private_execution_event(
+			&diagnostic.project_id,
+			&diagnostic.issue_id,
+			&diagnostic.run_id,
+			diagnostic.attempt_number,
+			GHOST_LANE_CLEANUP_EVENT,
+			serde_json::json!({
+				"schema": "decodex.ghost_lane_recovery_private_event/1",
+				"event": GHOST_LANE_CLEANUP_EVENT,
+				"classification": &diagnostic.classification,
+				"reason": &diagnostic.reason,
+				"issue_identifier": &diagnostic.issue_identifier,
+				"terminal_status": GHOST_LANE_TERMINAL_STATUS,
+				"cleared_run_lease": true,
+				"evidence": &diagnostic.evidence,
+				"blockers": &diagnostic.blockers,
+				"next_action": "ordinary automation may continue after status readback confirms no current attention lane",
+			}),
+		)
+		.map(|_| ())?;
+	state_store.update_run_status(&diagnostic.run_id, GHOST_LANE_TERMINAL_STATUS)?;
+	state_store.retire_run_control_channel_for_attempt(
+		&diagnostic.run_id,
+		diagnostic.attempt_number,
+		RUN_CONTROL_CHANNEL_STATUS_FAILED,
+	)?;
+
+	if let Some(mapping) = state_store.worktree_for_issue(&diagnostic.issue_id)?
+		&& !mapping.worktree_path().exists()
+	{
+		state_store.clear_worktree(&diagnostic.issue_id)?;
+	}
+
+	state_store.clear_lease(&diagnostic.issue_id)
+}
+
+fn ensure_ghost_lane_live_status_allows_cleanup(
+	context: &RecoveryContext,
+	diagnostic: &GhostLaneDiagnostic,
+) -> Result<()> {
+	ensure_ghost_lane_live_status_allows_cleanup_with_tracker(
+		&context.tracker,
+		&context.config,
+		&context.workflow,
+		&context.state_store,
+		diagnostic,
+	)
+}
+
+fn ensure_ghost_lane_live_status_allows_cleanup_with_tracker<T>(
+	tracker: &T,
+	config: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	diagnostic: &GhostLaneDiagnostic,
+) -> Result<()>
+where
+	T: IssueTracker,
+{
+	let blockers = orchestrator::ghost_lane_cleanup_status_blockers(
+		tracker,
+		config,
+		workflow,
+		state_store,
+		&diagnostic.issue_id,
+		&diagnostic.run_id,
+	)?;
+
+	if blockers.is_empty() {
+		return Ok(());
+	}
+
+	eyre::bail!(
+		"`recover ghost-lane cleanup` refused `{}` because live status reported blockers: {}",
+		render_ghost_lane_issue(diagnostic),
+		blockers.join(", ")
+	)
+}
+
+fn apply_ghost_lane_live_status_blockers(
+	context: &RecoveryContext,
+	diagnostics: &mut [GhostLaneDiagnostic],
+) -> Result<()> {
+	apply_ghost_lane_live_status_blockers_with_tracker(
+		&context.tracker,
+		&context.config,
+		&context.workflow,
+		&context.state_store,
+		diagnostics,
+	)
+}
+
+fn apply_ghost_lane_live_status_blockers_with_tracker<T>(
+	tracker: &T,
+	config: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	diagnostics: &mut [GhostLaneDiagnostic],
+) -> Result<()>
+where
+	T: IssueTracker,
+{
+	for diagnostic in diagnostics {
+		let blockers = orchestrator::ghost_lane_cleanup_status_blockers(
+			tracker,
+			config,
+			workflow,
+			state_store,
+			&diagnostic.issue_id,
+			&diagnostic.run_id,
+		)?;
+
+		if blockers.is_empty() {
+			continue;
+		}
+
+		diagnostic.classification = String::from(GHOST_LANE_BLOCKED_CLASSIFICATION);
+		diagnostic.reason = String::from("status_safety_check_blocked");
+		diagnostic.next_action = String::from(
+			"Preserve attention and inspect the listed blockers before using a recovery command.",
+		);
+		diagnostic.blockers = sorted_unique(
+			diagnostic
+				.blockers
+				.iter()
+				.cloned()
+				.chain(blockers.into_iter().map(|blocker| format!("status:{blocker}")))
+				.collect(),
+		);
+	}
+
+	Ok(())
+}
+
+fn render_ghost_lane_recovery_report(report: &GhostLaneRecoveryReport) -> String {
+	let mut output = format!("Ghost lane recovery diagnostics for project {}\n", report.project_id);
+
+	if report.diagnostics.is_empty() {
+		output.push_str("- none\n");
+
+		return output;
+	}
+
+	for diagnostic in &report.diagnostics {
+		output.push_str(&format!(
+			"- issue: {}\n  local_issue_id: {}\n  run_id: {}\n  attempt: {}\n  attempt_status: {}\n  classification: {}\n  reason: {}\n  run_lease: {}\n  control_channel: {}\n  evidence: {}\n  blockers: {}\n  next_action: {}\n",
+			render_ghost_lane_issue(diagnostic),
+			diagnostic.issue_id,
+			diagnostic.run_id,
+			diagnostic.attempt_number,
+			diagnostic.attempt_status,
+			diagnostic.classification,
+			diagnostic.reason,
+			diagnostic.run_lease,
+			diagnostic.control_channel,
+			render_string_list(&diagnostic.evidence),
+			render_string_list(&diagnostic.blockers),
+			diagnostic.next_action,
+		));
+	}
+
+	output
+}
+
+fn render_ghost_lane_issue(diagnostic: &GhostLaneDiagnostic) -> &str {
+	diagnostic.issue_identifier.as_deref().unwrap_or(diagnostic.issue_id.as_str())
+}
+
+fn render_string_list(values: &[String]) -> String {
+	if values.is_empty() { String::from("none") } else { values.join(",") }
+}
+
+fn ghost_lane_issue_identifier(
+	run: &ProjectRunStatus,
+	requested_selector: Option<&str>,
+) -> Option<String> {
+	requested_selector
+		.filter(|selector| commit_message::looks_like_issue_identifier(selector))
+		.map(str::to_ascii_uppercase)
+		.or_else(|| ghost_lane_issue_identifier_from_run_id(run.run_id()))
+		.or_else(|| run.branch_name().and_then(ghost_lane_issue_identifier_in_text))
+		.or_else(|| {
+			run.worktree_path()
+				.and_then(|path| ghost_lane_issue_identifier_in_text(&path.display().to_string()))
+		})
+		.or_else(|| {
+			commit_message::looks_like_issue_identifier(run.issue_id())
+				.then(|| run.issue_id().to_ascii_uppercase())
+		})
+}
+
+fn ghost_lane_inferred_issue_identifier(run: &ProjectRunStatus) -> Option<String> {
+	ghost_lane_issue_identifier_from_run_id(run.run_id())
+		.or_else(|| run.branch_name().and_then(ghost_lane_issue_identifier_in_text))
+		.or_else(|| {
+			run.worktree_path()
+				.and_then(|path| ghost_lane_issue_identifier_in_text(&path.display().to_string()))
+		})
+		.or_else(|| {
+			commit_message::looks_like_issue_identifier(run.issue_id())
+				.then(|| run.issue_id().to_ascii_uppercase())
+		})
+}
+
+fn ghost_lane_issue_identifier_from_run_id(run_id: &str) -> Option<String> {
+	if let Some((candidate, _attempt_suffix)) = run_id.split_once("-attempt-") {
+		return ghost_lane_issue_identifier_in_text(candidate);
+	}
+	if let Some(candidate) = run_id.strip_prefix("recovered-") {
+		return ghost_lane_issue_identifier_in_text(candidate);
+	}
+
+	None
+}
+
+fn ghost_lane_issue_identifier_in_text(value: &str) -> Option<String> {
+	let bytes = value.as_bytes();
+
+	for index in 0..bytes.len() {
+		if !bytes[index].is_ascii_alphabetic() {
+			continue;
+		}
+
+		let mut prefix_end = index + 1;
+
+		while prefix_end < bytes.len() && bytes[prefix_end].is_ascii_alphanumeric() {
+			prefix_end += 1;
+		}
+
+		if prefix_end >= bytes.len() || bytes[prefix_end] != b'-' {
+			continue;
+		}
+
+		let mut digit_end = prefix_end + 1;
+
+		while digit_end < bytes.len() && bytes[digit_end].is_ascii_digit() {
+			digit_end += 1;
+		}
+
+		if digit_end > prefix_end + 1 {
+			return Some(value[index..digit_end].to_ascii_uppercase());
+		}
+	}
+
+	None
+}
+
+fn ghost_lane_tracker_issue_selectors(
+	run: &ProjectRunStatus,
+	issue_identifier: Option<&str>,
+	requested_selector: Option<&str>,
+) -> Vec<String> {
+	let mut selectors = Vec::new();
+
+	if let Some(selector) =
+		requested_selector.filter(|selector| commit_message::looks_like_issue_identifier(selector))
+	{
+		selectors.push(selector.to_ascii_uppercase());
+	}
+	if let Some(issue_identifier) = issue_identifier {
+		selectors.push(issue_identifier.to_ascii_uppercase());
+	}
+	if let Some(inferred) = ghost_lane_inferred_issue_identifier(run) {
+		selectors.push(inferred);
+	}
+
+	if commit_message::looks_like_issue_identifier(run.issue_id()) {
+		selectors.push(run.issue_id().to_ascii_uppercase());
+	}
+
+	sorted_unique(selectors)
+}
+
+fn ghost_lane_worktree_selectors(
+	run: &ProjectRunStatus,
+	issue_identifier: Option<&str>,
+	requested_selector: Option<&str>,
+) -> Vec<String> {
+	let mut selectors = Vec::new();
+
+	if let Some(selector) =
+		requested_selector.filter(|selector| commit_message::looks_like_issue_identifier(selector))
+	{
+		selectors.push(selector.to_ascii_uppercase());
+	}
+	if let Some(issue_identifier) = issue_identifier {
+		selectors.push(issue_identifier.to_ascii_uppercase());
+	}
+	if let Some(inferred) = ghost_lane_inferred_issue_identifier(run) {
+		selectors.push(inferred);
+	}
+
+	if commit_message::looks_like_issue_identifier(run.issue_id()) {
+		selectors.push(run.issue_id().to_ascii_uppercase());
+	}
+
+	sorted_unique(selectors)
+}
+
+fn ghost_lane_run_matches_selector(run: &ProjectRunStatus, selector: &str) -> bool {
+	if selector.eq_ignore_ascii_case(run.issue_id()) || selector.eq_ignore_ascii_case(run.run_id())
+	{
+		return true;
+	}
+
+	ghost_lane_worktree_selectors(run, ghost_lane_inferred_issue_identifier(run).as_deref(), None)
+		.iter()
+		.any(|candidate| {
+			selector.eq_ignore_ascii_case(candidate)
+				|| ghost_lane_identifier_suffix_matches(selector, candidate)
+		})
+}
+
+fn ghost_lane_identifier_suffix_matches(left: &str, right: &str) -> bool {
+	let Some((left_prefix, left_suffix)) = ghost_lane_identifier_parts(left) else {
+		return false;
+	};
+	let Some((right_prefix, right_suffix)) = ghost_lane_identifier_parts(right) else {
+		return false;
+	};
+
+	left_suffix == right_suffix
+		&& (left_prefix.eq_ignore_ascii_case(right_prefix)
+			|| left_prefix.to_ascii_uppercase().starts_with(&right_prefix.to_ascii_uppercase())
+			|| right_prefix.to_ascii_uppercase().starts_with(&left_prefix.to_ascii_uppercase()))
+}
+
+fn ghost_lane_identifier_parts(value: &str) -> Option<(&str, &str)> {
+	let (prefix, suffix) = value.rsplit_once('-')?;
+
+	(!prefix.is_empty() && suffix.chars().all(|character| character.is_ascii_digit()))
+		.then_some((prefix, suffix))
+}
+
+fn sorted_unique(values: Vec<String>) -> Vec<String> {
+	let mut set = BTreeSet::new();
+
+	for value in values {
+		set.insert(value);
+	}
+
+	set.into_iter().collect()
 }
 
 fn validate_rebind_request(
@@ -3230,19 +4244,131 @@ mod tests {
 	use tempfile::TempDir;
 
 	use crate::{
+		config::ServiceConfig,
 		pull_request::PullRequestLandingState,
 		recovery::{
-			REVIEW_HANDOFF_ADOPT_EVENT, REVIEW_HANDOFF_BOUND_CLASSIFICATION,
-			REVIEW_HANDOFF_OWNERSHIP_DRIFT_CLASSIFICATION, REVIEW_HANDOFF_REBIND_EVENT,
-			REVIEW_HANDOFF_REBIND_REQUIRED_CLASSIFICATION,
+			GHOST_LANE_BLOCKED_CLASSIFICATION, GHOST_LANE_CLASSIFICATION, GHOST_LANE_CLEANUP_EVENT,
+			GHOST_LANE_TERMINAL_STATUS, REVIEW_HANDOFF_ADOPT_EVENT,
+			REVIEW_HANDOFF_BOUND_CLASSIFICATION, REVIEW_HANDOFF_OWNERSHIP_DRIFT_CLASSIFICATION,
+			REVIEW_HANDOFF_REBIND_EVENT, REVIEW_HANDOFF_REBIND_REQUIRED_CLASSIFICATION,
 		},
-		state::{ReviewHandoffMarker, ReviewOrchestrationMarker, StateStore, WorktreeMapping},
+		state::{
+			self, ChildAgentActivitySummary, ConnectorBackoffInput, ReviewHandoffMarker,
+			ReviewOrchestrationMarker, ReviewPolicyCheckpointInput, StateStore, WorktreeMapping,
+		},
 		tracker::{
-			TrackerIssue, TrackerState, TrackerTeam,
+			IssueTracker, TrackerComment, TrackerIssue, TrackerState, TrackerTeam,
+			linear::LinearClient,
 			records::{self, LinearExecutionEventIdentity, LinearExecutionEventRecord},
 		},
 		workflow::WorkflowDocument,
 	};
+
+	struct GhostLaneTestTracker {
+		issues: Vec<TrackerIssue>,
+		refresh_error: Option<String>,
+		identifier_error: Option<String>,
+	}
+	impl GhostLaneTestTracker {
+		fn missing() -> Self {
+			Self { issues: Vec::new(), refresh_error: None, identifier_error: None }
+		}
+
+		fn refresh_error(message: &str) -> Self {
+			Self {
+				issues: Vec::new(),
+				refresh_error: Some(message.to_owned()),
+				identifier_error: None,
+			}
+		}
+
+		fn identifier_error(message: &str) -> Self {
+			Self {
+				issues: Vec::new(),
+				refresh_error: None,
+				identifier_error: Some(message.to_owned()),
+			}
+		}
+	}
+	impl IssueTracker for GhostLaneTestTracker {
+		fn list_issues_with_label(
+			&self,
+			_label_name: &str,
+		) -> crate::prelude::Result<Vec<TrackerIssue>> {
+			Ok(Vec::new())
+		}
+
+		fn find_team_label_id(
+			&self,
+			_team_id: &str,
+			_label_name: &str,
+		) -> crate::prelude::Result<Option<String>> {
+			Ok(None)
+		}
+
+		fn get_issue_by_identifier(
+			&self,
+			issue_identifier: &str,
+		) -> crate::prelude::Result<Option<TrackerIssue>> {
+			if let Some(message) = &self.identifier_error {
+				return Err(crate::prelude::eyre::eyre!(message.clone()));
+			}
+
+			Ok(self
+				.issues
+				.iter()
+				.find(|issue| issue.identifier.eq_ignore_ascii_case(issue_identifier))
+				.cloned())
+		}
+
+		fn refresh_issues(
+			&self,
+			issue_ids: &[String],
+		) -> crate::prelude::Result<Vec<TrackerIssue>> {
+			if let Some(message) = &self.refresh_error {
+				return Err(crate::prelude::eyre::eyre!(message.clone()));
+			}
+
+			Ok(self
+				.issues
+				.iter()
+				.filter(|issue| issue_ids.iter().any(|issue_id| issue_id == &issue.id))
+				.cloned()
+				.collect())
+		}
+
+		fn list_comments(&self, _issue_id: &str) -> crate::prelude::Result<Vec<TrackerComment>> {
+			Ok(Vec::new())
+		}
+
+		fn update_issue_state(
+			&self,
+			_issue_id: &str,
+			_state_id: &str,
+		) -> crate::prelude::Result<()> {
+			Ok(())
+		}
+
+		fn add_issue_labels(
+			&self,
+			_issue_id: &str,
+			_label_ids: &[String],
+		) -> crate::prelude::Result<()> {
+			Ok(())
+		}
+
+		fn remove_issue_labels(
+			&self,
+			_issue_id: &str,
+			_label_ids: &[String],
+		) -> crate::prelude::Result<()> {
+			Ok(())
+		}
+
+		fn create_comment(&self, _issue_id: &str, _body: &str) -> crate::prelude::Result<()> {
+			Ok(())
+		}
+	}
 
 	fn sample_worktree(branch_name: &str) -> WorktreeMapping {
 		sample_worktree_at(branch_name, Path::new("/tmp/PUB-718"))
@@ -3327,6 +4453,41 @@ Test workflow.
 		.expect("sample workflow should parse")
 	}
 
+	fn sample_recovery_context(
+		temp_dir: &TempDir,
+		runtime_mutation_policy: super::RecoveryRuntimeMutationPolicy,
+	) -> super::RecoveryContext {
+		let repo_root = temp_dir.path().join("repo");
+		let config_path = temp_dir.path().join("project.toml");
+
+		fs::create_dir_all(&repo_root).expect("repo root should exist");
+		fs::write(
+			&config_path,
+			r#"
+service_id = "pubfi"
+
+[paths]
+repo_root = "repo"
+
+[tracker]
+api_key_env_var = "HOME"
+
+[github]
+token_env_var = "HOME"
+"#,
+		)
+		.expect("config should write");
+
+		super::RecoveryContext {
+			config: ServiceConfig::from_path(&config_path).expect("config should load"),
+			workflow: sample_workflow(),
+			state_store: StateStore::open_in_memory().expect("state store should open"),
+			tracker: LinearClient::new(String::from("test-token"))
+				.expect("linear client should build"),
+			runtime_mutation_policy,
+		}
+	}
+
 	fn sample_issue(state_name: &str) -> TrackerIssue {
 		let states = vec![
 			TrackerState { id: String::from("state-todo"), name: String::from("Todo") },
@@ -3362,6 +4523,838 @@ Test workflow.
 			labels: Vec::new(),
 			blockers: Vec::new(),
 		}
+	}
+
+	#[test]
+	fn recovery_read_only_backoff_observer_does_not_clear_expired_backoff() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let context =
+			sample_recovery_context(&temp_dir, super::RecoveryRuntimeMutationPolicy::ReadOnly);
+		let expired_unix_epoch = time::OffsetDateTime::now_utc().unix_timestamp() - 1;
+
+		context
+			.state_store
+			.upsert_connector_backoff(ConnectorBackoffInput {
+				project_id: context.config.service_id(),
+				connector: "linear",
+				sync_phase: "ghost_lane_recovery",
+				quota_class: "linear_graphql_rate_limit",
+				reset_unix_epoch: expired_unix_epoch,
+				reset_source: "test",
+				warning: super::LINEAR_RATE_LIMIT_BACKOFF_WARNING,
+			})
+			.expect("backoff should persist");
+
+		let message = super::active_recovery_tracker_backoff_message(&context)
+			.expect("backoff observer should run");
+
+		assert_eq!(message, None);
+		assert!(
+			context
+				.state_store
+				.connector_backoff(context.config.service_id(), "linear")
+				.expect("backoff should read")
+				.is_some(),
+			"read-only recovery diagnostics must not clear stored connector backoff"
+		);
+	}
+
+	#[test]
+	fn recovery_read_only_backoff_recorder_does_not_persist_new_backoff() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let context =
+			sample_recovery_context(&temp_dir, super::RecoveryRuntimeMutationPolicy::ReadOnly);
+		let error = crate::prelude::eyre::eyre!("Linear connector timed out while testing");
+		let message = super::remember_recovery_tracker_backoff_message(
+			&context,
+			&error,
+			"ghost_lane_recovery",
+		)
+		.expect("timeout should produce backoff message");
+
+		assert!(message.contains("Linear connector is in backoff"));
+		assert!(
+			context
+				.state_store
+				.connector_backoff(context.config.service_id(), "linear")
+				.expect("backoff should read")
+				.is_none(),
+			"read-only recovery diagnostics must not persist new connector backoff"
+		);
+	}
+
+	#[test]
+	fn ghost_lane_live_status_overlay_tracker_backoff_stays_read_only() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let context =
+			sample_recovery_context(&temp_dir, super::RecoveryRuntimeMutationPolicy::ReadOnly);
+		let missing_tracker = GhostLaneTestTracker::missing();
+		let error_tracker =
+			GhostLaneTestTracker::refresh_error("Linear connector timed out while testing");
+
+		context
+			.state_store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		context
+			.state_store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+
+		let mut diagnostics = super::diagnose_ghost_lanes_read_only(
+			context.config.service_id(),
+			context.config.worktree_root(),
+			&context.state_store,
+			&missing_tracker,
+			Some("PUB-012"),
+		)
+		.expect("ghost lane diagnostic should run");
+		let error = super::apply_ghost_lane_live_status_blockers_with_tracker(
+			&error_tracker,
+			&context.config,
+			&context.workflow,
+			&context.state_store,
+			&mut diagnostics,
+		)
+		.expect_err("overlay tracker error should surface for recovery backoff wrapping");
+		let message = super::remember_recovery_tracker_backoff_message(
+			&context,
+			&error,
+			"ghost_lane_recovery",
+		)
+		.expect("timeout should become a recovery backoff message");
+
+		assert!(message.contains("ghost_lane_recovery"));
+		assert!(
+			context
+				.state_store
+				.connector_backoff(context.config.service_id(), "linear")
+				.expect("backoff should read")
+				.is_none(),
+			"read-only live-status overlay must not persist connector backoff"
+		);
+	}
+
+	#[test]
+	fn ghost_lane_diagnose_live_status_overlay_blocks_active_thread_marker() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let context =
+			sample_recovery_context(&temp_dir, super::RecoveryRuntimeMutationPolicy::ReadOnly);
+		let tracker = GhostLaneTestTracker::missing();
+		let worktree_path = context.config.worktree_root().join("PUB-012");
+		let mut diagnostics = vec![super::GhostLaneDiagnostic {
+			project_id: String::from("pubfi"),
+			issue_id: String::from("PUB-012"),
+			issue_identifier: Some(String::from("PUBFI-012")),
+			run_id: String::from("run-12"),
+			attempt_number: 1,
+			attempt_status: String::from("running"),
+			classification: String::from(GHOST_LANE_CLASSIFICATION),
+			reason: String::from("test"),
+			run_lease: true,
+			control_channel: String::from("missing"),
+			evidence: Vec::new(),
+			blockers: Vec::new(),
+			next_action: String::from("test"),
+		}];
+
+		fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+
+		context
+			.state_store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		context
+			.state_store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+		context
+			.state_store
+			.upsert_worktree(
+				"pubfi",
+				"PUB-012",
+				"x/pubfi-pub-012",
+				&worktree_path.display().to_string(),
+			)
+			.expect("worktree should record");
+
+		state::write_run_thread_status_marker(
+			&worktree_path,
+			"run-12",
+			1,
+			Some("thread-12"),
+			Some("turn-12"),
+			"active",
+			&[String::from("waitingOnApproval")],
+		)
+		.expect("active thread marker should write");
+		super::apply_ghost_lane_live_status_blockers_with_tracker(
+			&tracker,
+			&context.config,
+			&context.workflow,
+			&context.state_store,
+			&mut diagnostics,
+		)
+		.expect("status overlay should run");
+
+		let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+		assert_eq!(diagnostic.classification, GHOST_LANE_BLOCKED_CLASSIFICATION);
+		assert!(diagnostic.blockers.contains(&String::from("status:thread_active")));
+		assert!(diagnostic.blockers.contains(&String::from("status:retained_worktree_present")));
+	}
+
+	#[test]
+	fn ghost_lane_cleanup_live_status_gate_rejects_active_thread_marker() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let context =
+			sample_recovery_context(&temp_dir, super::RecoveryRuntimeMutationPolicy::ReadOnly);
+		let tracker = GhostLaneTestTracker::missing();
+		let worktree_path = context.config.worktree_root().join("PUB-012");
+		let diagnostic = super::GhostLaneDiagnostic {
+			project_id: String::from("pubfi"),
+			issue_id: String::from("PUB-012"),
+			issue_identifier: Some(String::from("PUBFI-012")),
+			run_id: String::from("run-12"),
+			attempt_number: 1,
+			attempt_status: String::from("running"),
+			classification: String::from(GHOST_LANE_CLASSIFICATION),
+			reason: String::from("test"),
+			run_lease: true,
+			control_channel: String::from("missing"),
+			evidence: Vec::new(),
+			blockers: Vec::new(),
+			next_action: String::from("test"),
+		};
+
+		fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+
+		context
+			.state_store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		context
+			.state_store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+		context
+			.state_store
+			.upsert_worktree(
+				"pubfi",
+				"PUB-012",
+				"x/pubfi-pub-012",
+				&worktree_path.display().to_string(),
+			)
+			.expect("worktree should record");
+
+		state::write_run_thread_status_marker(
+			&worktree_path,
+			"run-12",
+			1,
+			Some("thread-12"),
+			Some("turn-12"),
+			"active",
+			&[String::from("waitingOnApproval")],
+		)
+		.expect("active thread marker should write");
+
+		let error = super::ensure_ghost_lane_live_status_allows_cleanup_with_tracker(
+			&tracker,
+			&context.config,
+			&context.workflow,
+			&context.state_store,
+			&diagnostic,
+		)
+		.expect_err("live status should reject cleanup");
+		let message = format!("{error:#}");
+
+		assert!(message.contains("live status reported blockers"));
+		assert!(message.contains("thread_active"));
+		assert!(message.contains("retained_worktree_present"));
+	}
+
+	#[test]
+	fn ghost_lane_cleanup_terminalizes_missing_issue_lease_and_records_private_audit() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let store = StateStore::open_in_memory().expect("state store should open");
+		let tracker = GhostLaneTestTracker::missing();
+
+		store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+
+		let mut diagnostics = super::diagnose_ghost_lanes(
+			"pubfi",
+			temp_dir.path(),
+			&store,
+			&tracker,
+			Some("PUBFI-012"),
+		)
+		.expect("ghost lane diagnostic should run");
+		let diagnostic = diagnostics.pop().expect("diagnostic should exist");
+
+		assert_eq!(diagnostic.classification, GHOST_LANE_CLASSIFICATION);
+		assert!(diagnostic.recoverable());
+		assert_eq!(diagnostic.issue_id, "PUB-012");
+		assert_eq!(diagnostic.issue_identifier.as_deref(), Some("PUBFI-012"));
+		assert!(diagnostic.evidence.contains(&String::from("tracker_issue_missing")));
+		assert!(diagnostic.evidence.contains(&String::from("worktree_missing")));
+		assert!(diagnostic.evidence.contains(&String::from("control_channel_missing")));
+		assert!(diagnostic.evidence.contains(&String::from("private_evidence_missing")));
+		assert!(diagnostic.evidence.contains(&String::from("review_lineage_missing")));
+
+		super::apply_ghost_lane_cleanup(&store, &diagnostic).expect("cleanup should apply");
+
+		assert!(
+			store.list_leased_runs("pubfi").expect("leased runs should load").is_empty(),
+			"cleanup should clear the local run lease"
+		);
+
+		let runs =
+			store.list_project_issue_runs("pubfi", "PUB-012").expect("issue runs should load");
+
+		assert_eq!(runs.len(), 1);
+		assert_eq!(runs[0].status(), GHOST_LANE_TERMINAL_STATUS);
+
+		let events = store
+			.list_private_execution_events("pubfi", "PUB-012", "run-12", 1)
+			.expect("private events should load");
+
+		assert_eq!(events.len(), 1);
+		assert_eq!(events[0].event_type(), GHOST_LANE_CLEANUP_EVENT);
+		assert_eq!(
+			events[0].payload()["schema"].as_str(),
+			Some("decodex.ghost_lane_recovery_private_event/1")
+		);
+		assert_eq!(events[0].payload()["cleared_run_lease"].as_bool(), Some(true));
+	}
+
+	#[test]
+	fn ghost_lane_cleanup_dry_run_validation_keeps_runtime_state_untouched() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let context =
+			sample_recovery_context(&temp_dir, super::RecoveryRuntimeMutationPolicy::ReadOnly);
+		let tracker = GhostLaneTestTracker::missing();
+
+		context
+			.state_store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		context
+			.state_store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+
+		let diagnostics = super::diagnose_ghost_lanes_read_only(
+			context.config.service_id(),
+			context.config.worktree_root(),
+			&context.state_store,
+			&tracker,
+			Some("PUB-012"),
+		)
+		.expect("ghost lane diagnostic should run");
+		let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+		assert!(diagnostic.recoverable());
+
+		super::ensure_ghost_lane_live_status_allows_cleanup_with_tracker(
+			&tracker,
+			&context.config,
+			&context.workflow,
+			&context.state_store,
+			diagnostic,
+		)
+		.expect("dry-run validation should allow cleanup");
+
+		let runs = context
+			.state_store
+			.list_project_issue_runs("pubfi", "PUB-012")
+			.expect("issue runs should load");
+		let events = context
+			.state_store
+			.list_private_execution_events("pubfi", "PUB-012", "run-12", 1)
+			.expect("private events should load");
+
+		assert_eq!(runs.len(), 1);
+		assert_eq!(runs[0].status(), "running");
+		assert!(
+			!context
+				.state_store
+				.list_leased_runs("pubfi")
+				.expect("leased runs should load")
+				.is_empty(),
+			"dry-run validation must not clear the run lease"
+		);
+		assert!(events.is_empty(), "dry-run validation must not write cleanup audit events");
+	}
+
+	#[test]
+	fn ghost_lane_diagnostic_treats_invalid_local_issue_id_refresh_as_missing_issue() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let store = StateStore::open_in_memory().expect("state store should open");
+		let tracker = GhostLaneTestTracker::refresh_error(
+			"Linear GraphQL request failed: Argument Validation Error",
+		);
+
+		store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+
+		let diagnostics = super::diagnose_ghost_lanes_read_only(
+			"pubfi",
+			temp_dir.path(),
+			&store,
+			&tracker,
+			Some("PUB-012"),
+		)
+		.expect("missing local issue id should not abort ghost-lane diagnosis");
+		let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+		assert_eq!(diagnostic.classification, GHOST_LANE_CLASSIFICATION);
+		assert!(diagnostic.recoverable());
+		assert!(diagnostic.evidence.contains(&String::from("tracker_issue_missing")));
+	}
+
+	#[test]
+	fn ghost_lane_diagnostic_treats_missing_identifier_lookup_as_missing_issue() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let store = StateStore::open_in_memory().expect("state store should open");
+		let tracker = GhostLaneTestTracker::identifier_error(
+			"Linear GraphQL request failed: Entity not found: Issue",
+		);
+
+		store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+
+		let diagnostics = super::diagnose_ghost_lanes_read_only(
+			"pubfi",
+			temp_dir.path(),
+			&store,
+			&tracker,
+			Some("PUB-012"),
+		)
+		.expect("missing issue identifier should not abort ghost-lane diagnosis");
+		let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+		assert_eq!(diagnostic.classification, GHOST_LANE_CLASSIFICATION);
+		assert!(diagnostic.recoverable());
+		assert!(diagnostic.evidence.contains(&String::from("tracker_issue_missing")));
+	}
+
+	#[test]
+	fn ghost_lane_diagnostic_fails_closed_when_requested_issue_identifier_exists() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let store = StateStore::open_in_memory().expect("state store should open");
+		let mut issue = sample_issue("In Progress");
+
+		issue.id = String::from("linear-pubfi-012");
+		issue.identifier = String::from("PUBFI-012");
+
+		let tracker = GhostLaneTestTracker {
+			issues: vec![issue],
+			refresh_error: None,
+			identifier_error: None,
+		};
+
+		store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+
+		let diagnostics = super::diagnose_ghost_lanes(
+			"pubfi",
+			temp_dir.path(),
+			&store,
+			&tracker,
+			Some("PUBFI-012"),
+		)
+		.expect("ghost lane diagnostic should run");
+		let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+		assert_eq!(diagnostic.classification, GHOST_LANE_BLOCKED_CLASSIFICATION);
+		assert!(!diagnostic.recoverable());
+		assert_eq!(diagnostic.issue_identifier.as_deref(), Some("PUBFI-012"));
+		assert!(diagnostic.blockers.contains(&String::from("tracker_issue_present")));
+		assert!(
+			store.list_leased_runs("pubfi").expect("leased runs should load").len() == 1,
+			"fail-closed diagnostics must preserve attention"
+		);
+	}
+
+	#[test]
+	fn ghost_lane_diagnostic_rejects_unrelated_requested_identifier() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let store = StateStore::open_in_memory().expect("state store should open");
+		let tracker = GhostLaneTestTracker::missing();
+
+		store
+			.record_run_attempt("run-12", "ABC-012", 1, "running")
+			.expect("run attempt should record");
+		store
+			.upsert_lease("pubfi", "ABC-012", "run-12", "In Progress")
+			.expect("lease should record");
+
+		let error = super::diagnose_ghost_lanes(
+			"pubfi",
+			temp_dir.path(),
+			&store,
+			&tracker,
+			Some("PUBFI-012"),
+		)
+		.expect_err("unrelated issue prefixes should not match by numeric suffix alone");
+
+		assert!(
+			format!("{error:#}").contains("No leased lane matched"),
+			"unexpected error: {error:#}"
+		);
+		assert!(
+			store.list_leased_runs("pubfi").expect("leased runs should load").len() == 1,
+			"failed selector matches must preserve attention"
+		);
+	}
+
+	#[test]
+	fn ghost_lane_diagnostic_fails_closed_when_requested_worktree_exists() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let store = StateStore::open_in_memory().expect("state store should open");
+		let tracker = GhostLaneTestTracker::missing();
+		let worktree_path = temp_dir.path().join("PUBFI-012");
+
+		fs::create_dir_all(&worktree_path).expect("retained worktree should exist");
+
+		store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+
+		let diagnostics = super::diagnose_ghost_lanes(
+			"pubfi",
+			temp_dir.path(),
+			&store,
+			&tracker,
+			Some("PUBFI-012"),
+		)
+		.expect("ghost lane diagnostic should run");
+		let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+		assert_eq!(diagnostic.classification, GHOST_LANE_BLOCKED_CLASSIFICATION);
+		assert!(!diagnostic.recoverable());
+		assert!(diagnostic.blockers.contains(&String::from("retained_worktree_present")));
+		assert!(
+			store.list_leased_runs("pubfi").expect("leased runs should load").len() == 1,
+			"fail-closed diagnostics must preserve attention"
+		);
+	}
+
+	#[test]
+	fn ghost_lane_diagnostic_fails_closed_when_control_channel_row_exists() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let store = StateStore::open_in_memory().expect("state store should open");
+		let tracker = GhostLaneTestTracker::missing();
+		let channel_path = temp_dir.path().join("missing-control-channel.json");
+
+		store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+		store
+			.publish_run_control_channel_for_active_attempt(
+				"run-12",
+				1,
+				&channel_path,
+				"local_file",
+			)
+			.expect("control channel row should publish");
+
+		let diagnostics = super::diagnose_ghost_lanes(
+			"pubfi",
+			temp_dir.path(),
+			&store,
+			&tracker,
+			Some("PUB-012"),
+		)
+		.expect("ghost lane diagnostic should run");
+		let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+		assert_eq!(diagnostic.classification, GHOST_LANE_BLOCKED_CLASSIFICATION);
+		assert!(!diagnostic.recoverable());
+		assert!(diagnostic.evidence.contains(&String::from("control_channel_file_missing")));
+		assert!(diagnostic.blockers.contains(&String::from("control_channel_present")));
+		assert!(
+			store.list_leased_runs("pubfi").expect("leased runs should load").len() == 1,
+			"fail-closed diagnostics must preserve attention"
+		);
+	}
+
+	#[test]
+	fn ghost_lane_diagnostic_fails_closed_when_private_evidence_exists() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let store = StateStore::open_in_memory().expect("state store should open");
+		let tracker = GhostLaneTestTracker::missing();
+
+		store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+		store
+			.append_private_execution_event(
+				"pubfi",
+				"PUB-012",
+				"run-12",
+				1,
+				"diagnostic",
+				serde_json::json!({"schema": "test.private/1"}),
+			)
+			.expect("private evidence should record");
+
+		let diagnostics = super::diagnose_ghost_lanes(
+			"pubfi",
+			temp_dir.path(),
+			&store,
+			&tracker,
+			Some("PUB-012"),
+		)
+		.expect("ghost lane diagnostic should run");
+		let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+		assert_eq!(diagnostic.classification, GHOST_LANE_BLOCKED_CLASSIFICATION);
+		assert!(!diagnostic.recoverable());
+		assert!(diagnostic.blockers.contains(&String::from("private_evidence_present")));
+		assert!(
+			store.list_leased_runs("pubfi").expect("leased runs should load").len() == 1,
+			"fail-closed diagnostics must preserve attention"
+		);
+	}
+
+	#[test]
+	fn ghost_lane_diagnostic_fails_closed_when_review_lifecycle_exists() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let store = StateStore::open_in_memory().expect("state store should open");
+		let tracker = GhostLaneTestTracker::missing();
+		let marker = ReviewHandoffMarker::new(
+			"run-12",
+			1,
+			"x/pubfi-pub-012",
+			"https://github.com/hack-ink/decodex/pull/12",
+			"main",
+			"x/pubfi-pub-012",
+			"08a20f7dfb9526e7421a5f095b1c6adec84e52d6",
+		);
+
+		store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+		store
+			.upsert_review_handoff_marker("pubfi", "PUB-012", &marker)
+			.expect("review lifecycle should record");
+
+		let diagnostics = super::diagnose_ghost_lanes(
+			"pubfi",
+			temp_dir.path(),
+			&store,
+			&tracker,
+			Some("PUB-012"),
+		)
+		.expect("ghost lane diagnostic should run");
+		let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+		assert_eq!(diagnostic.classification, GHOST_LANE_BLOCKED_CLASSIFICATION);
+		assert!(!diagnostic.recoverable());
+		assert!(diagnostic.blockers.contains(&String::from("review_lifecycle_present")));
+		assert!(
+			store.list_leased_runs("pubfi").expect("leased runs should load").len() == 1,
+			"fail-closed diagnostics must preserve attention"
+		);
+	}
+
+	#[test]
+	fn ghost_lane_diagnostic_fails_closed_when_review_checkpoint_exists() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let store = StateStore::open_in_memory().expect("state store should open");
+		let tracker = GhostLaneTestTracker::missing();
+
+		store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+		store
+			.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
+				project_id: "pubfi",
+				issue_id: "PUB-012",
+				run_id: "run-12",
+				attempt_number: 1,
+				phase: "handoff",
+				review_level: "standard",
+				status: "clean",
+				head_sha: "2222222222222222222222222222222222222222",
+				nonclean_rounds: 0,
+				details_json: "{}",
+			})
+			.expect("review checkpoint should record");
+
+		let diagnostics = super::diagnose_ghost_lanes(
+			"pubfi",
+			temp_dir.path(),
+			&store,
+			&tracker,
+			Some("PUB-012"),
+		)
+		.expect("ghost lane diagnostic should run");
+		let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+		assert_eq!(diagnostic.classification, GHOST_LANE_BLOCKED_CLASSIFICATION);
+		assert!(!diagnostic.recoverable());
+		assert!(diagnostic.blockers.contains(&String::from("review_policy_checkpoint_present")));
+		assert!(
+			store.list_leased_runs("pubfi").expect("leased runs should load").len() == 1,
+			"fail-closed diagnostics must preserve attention"
+		);
+	}
+
+	#[test]
+	fn ghost_lane_diagnostic_fails_closed_when_pr_lineage_exists() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let store = StateStore::open_in_memory().expect("state store should open");
+		let tracker = GhostLaneTestTracker::missing();
+		let mut event = LinearExecutionEventRecord::new(
+			LinearExecutionEventIdentity {
+				service_id: "pubfi",
+				issue_id: "PUB-012",
+				issue_identifier: "PUB-012",
+				run_id: "run-12",
+				attempt_number: 1,
+			},
+			"closeout",
+			String::from("2026-06-18T00:00:00Z"),
+			"closeout",
+		);
+
+		event.branch = Some(String::from("x/pubfi-pub-012"));
+		event.pr_url = Some(String::from("https://github.com/hack-ink/decodex/pull/12"));
+		event.pr_head_sha = Some(String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"));
+		event.pr_base_ref = Some(String::from("main"));
+		event.commit_sha = Some(String::from("18a20f7dfb9526e7421a5f095b1c6adec84e52d7"));
+		event.summary = Some(String::from("Recorded retained closeout."));
+
+		store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+		store.record_linear_execution_event(&event).expect("linear event should record");
+
+		let diagnostics = super::diagnose_ghost_lanes(
+			"pubfi",
+			temp_dir.path(),
+			&store,
+			&tracker,
+			Some("PUB-012"),
+		)
+		.expect("ghost lane diagnostic should run");
+		let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+		assert_eq!(diagnostic.classification, GHOST_LANE_BLOCKED_CLASSIFICATION);
+		assert!(!diagnostic.recoverable());
+		assert!(diagnostic.blockers.contains(&String::from("pr_or_review_lineage_present")));
+		assert!(
+			store.list_leased_runs("pubfi").expect("leased runs should load").len() == 1,
+			"fail-closed diagnostics must preserve attention"
+		);
+	}
+
+	#[test]
+	fn ghost_lane_diagnostic_fails_closed_when_retained_worktree_exists() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let store = StateStore::open_in_memory().expect("state store should open");
+		let tracker = GhostLaneTestTracker::missing();
+		let worktree_path = temp_dir.path().join("PUB-012");
+
+		fs::create_dir_all(&worktree_path).expect("retained worktree should exist");
+
+		store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+
+		let diagnostics = super::diagnose_ghost_lanes(
+			"pubfi",
+			temp_dir.path(),
+			&store,
+			&tracker,
+			Some("PUB-012"),
+		)
+		.expect("ghost lane diagnostic should run");
+		let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+		assert_eq!(diagnostic.classification, GHOST_LANE_BLOCKED_CLASSIFICATION);
+		assert!(!diagnostic.recoverable());
+		assert!(diagnostic.blockers.contains(&String::from("retained_worktree_present")));
+		assert!(
+			store.list_leased_runs("pubfi").expect("leased runs should load").len() == 1,
+			"fail-closed diagnostics must preserve attention"
+		);
+	}
+
+	#[test]
+	fn ghost_lane_diagnostic_fails_closed_when_activity_summary_exists() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let store = StateStore::open_in_memory().expect("state store should open");
+		let tracker = GhostLaneTestTracker::missing();
+		let activity = ChildAgentActivitySummary { event_count: 1, ..Default::default() };
+
+		store
+			.record_run_attempt("run-12", "PUB-012", 1, "running")
+			.expect("run attempt should record");
+		store
+			.record_run_activity_summary("run-12", 1, Some(&activity), None)
+			.expect("activity summary should record");
+		store
+			.upsert_lease("pubfi", "PUB-012", "run-12", "In Progress")
+			.expect("lease should record");
+
+		let diagnostics = super::diagnose_ghost_lanes(
+			"pubfi",
+			temp_dir.path(),
+			&store,
+			&tracker,
+			Some("PUB-012"),
+		)
+		.expect("ghost lane diagnostic should run");
+		let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+		assert_eq!(diagnostic.classification, GHOST_LANE_BLOCKED_CLASSIFICATION);
+		assert!(!diagnostic.recoverable());
+		assert!(diagnostic.blockers.contains(&String::from("child_agent_activity_present")));
+		assert!(
+			store.list_leased_runs("pubfi").expect("leased runs should load").len() == 1,
+			"fail-closed diagnostics must preserve attention"
+		);
 	}
 
 	fn run_git(repo: &Path, args: &[&str]) -> String {

--- a/apps/decodex/src/state/store.rs
+++ b/apps/decodex/src/state/store.rs
@@ -1482,13 +1482,39 @@ impl StateStore {
 		project_id: &str,
 		base_recent_limit: usize,
 	) -> Result<(Vec<ProjectRunStatus>, Vec<ProjectRunStatus>)> {
+		self.list_project_runs_with_mode(
+			project_id,
+			base_recent_limit,
+			ProjectRunListingMode::AllowMarkerIdentityPersistence,
+		)
+	}
+
+	/// List active and recent project runs without persisting marker-derived identities.
+	pub(crate) fn list_project_runs_read_only(
+		&self,
+		project_id: &str,
+		base_recent_limit: usize,
+	) -> Result<(Vec<ProjectRunStatus>, Vec<ProjectRunStatus>)> {
+		self.list_project_runs_with_mode(project_id, base_recent_limit, ProjectRunListingMode::ReadOnly)
+	}
+
+	fn list_project_runs_with_mode(
+		&self,
+		project_id: &str,
+		base_recent_limit: usize,
+		mode: ProjectRunListingMode,
+	) -> Result<(Vec<ProjectRunStatus>, Vec<ProjectRunStatus>)> {
 		let mut state = self.lock_without_refresh()?;
 
 		self.refresh_project_run_metadata_state_locked(&mut state, project_id)?;
-		self.refresh_run_attempt_identities_from_worktree_markers_locked(
-			&mut state,
-			project_id,
-		)?;
+
+		if matches!(mode, ProjectRunListingMode::AllowMarkerIdentityPersistence) {
+			self.refresh_run_attempt_identities_from_worktree_markers_locked(
+				&mut state,
+				project_id,
+			)?;
+		}
+
 		self.refresh_project_loop_evidence_state_locked(&mut state, project_id)?;
 
 		let lease_run_ids = project_lease_run_ids(&state, project_id, None);
@@ -3654,6 +3680,12 @@ impl From<WorkflowConcurrencyLimit> for DispatchSlotLimit {
 	fn from(value: WorkflowConcurrencyLimit) -> Self {
 		Self::from(value.dispatch_slot_limit())
 	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProjectRunListingMode {
+	AllowMarkerIdentityPersistence,
+	ReadOnly,
 }
 
 fn project_run_recovery_status_rank(status: &str) -> u8 {

--- a/apps/decodex/src/state/tests.rs
+++ b/apps/decodex/src/state/tests.rs
@@ -3216,6 +3216,65 @@ fn lists_recent_project_runs_with_protocol_summary() {
 }
 
 #[test]
+fn read_only_project_run_listing_does_not_persist_marker_identities() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+	let worktree_path = temp_dir.path().join("worktrees/PUB-101");
+	let store = StateStore::open(&state_path).expect("state store should open");
+
+	fs::create_dir_all(&worktree_path).expect("worktree should exist");
+
+	store.record_run_attempt("run-1", "PUB-101", 1, "running").expect("run attempt should persist");
+	store
+		.upsert_lease("pubfi", "PUB-101", "run-1", IN_PROGRESS_STATE)
+		.expect("lease should persist");
+	store
+		.upsert_worktree(
+			"pubfi",
+			"PUB-101",
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should persist");
+
+	state::write_run_thread_marker(&worktree_path, "run-1", 1, "thread-marker")
+		.expect("thread marker should write");
+	state::write_run_turn_marker(&worktree_path, "run-1", 1, "turn-marker")
+		.expect("turn marker should write");
+
+	let (leased_runs, _) =
+		store.list_project_runs_read_only("pubfi", 0).expect("read-only runs should load");
+
+	assert_eq!(leased_runs.len(), 1);
+	assert_eq!(leased_runs[0].thread_id(), None);
+	assert_eq!(leased_runs[0].turn_id(), None);
+
+	assert_sqlite_run_attempt_identity(&state_path, None, None);
+
+	store.list_project_runs("pubfi", 0).expect("ordinary runs should load");
+
+	assert_sqlite_run_attempt_identity(&state_path, Some("thread-marker"), Some("turn-marker"));
+}
+
+fn assert_sqlite_run_attempt_identity(
+	state_path: &Path,
+	expected_thread_id: Option<&str>,
+	expected_turn_id: Option<&str>,
+) {
+	let connection = Connection::open(state_path).expect("sqlite should open");
+	let (thread_id, turn_id): (Option<String>, Option<String>) = connection
+		.query_row(
+			"SELECT thread_id, turn_id FROM run_attempts WHERE run_id = 'run-1'",
+			[],
+			|row| Ok((row.get(0)?, row.get(1)?)),
+		)
+		.expect("run attempt row should exist");
+
+	assert_eq!(thread_id.as_deref(), expected_thread_id);
+	assert_eq!(turn_id.as_deref(), expected_turn_id);
+}
+
+#[test]
 fn lists_project_issue_runs_recovered_from_local_evidence() {
 	let store = StateStore::open_in_memory().expect("in-memory state store should open");
 	let activity = ChildAgentActivitySummary {

--- a/apps/decodex/src/tracker.rs
+++ b/apps/decodex/src/tracker.rs
@@ -132,6 +132,14 @@ pub(crate) struct TrackerTeam {
 	pub(crate) labels: Vec<TrackerLabel>,
 }
 
+pub(crate) fn issue_lookup_missing_error_for_candidate(error: &Report, candidate: &str) -> bool {
+	let message = error.to_string();
+
+	message.contains("Linear GraphQL request failed: Entity not found: Issue")
+		|| (message.contains("Linear GraphQL request failed: Argument Validation Error")
+			&& !looks_like_linear_server_issue_id(candidate))
+}
+
 pub(crate) fn automation_queue_label(service_id: &str) -> String {
 	format!("decodex:queued:{service_id}")
 }
@@ -326,6 +334,18 @@ where
 		records::append_structured_comment_record(&projection.body, &projection.record)?;
 
 	tracker.create_comment(issue_id, &comment_body)
+}
+
+fn looks_like_linear_server_issue_id(candidate: &str) -> bool {
+	let candidate = candidate.trim();
+	let bytes = candidate.as_bytes();
+
+	bytes.len() == 36
+		&& [8, 13, 18, 23].into_iter().all(|index| bytes[index] == b'-')
+		&& bytes
+			.iter()
+			.enumerate()
+			.all(|(index, byte)| [8, 13, 18, 23].contains(&index) || byte.is_ascii_hexdigit())
 }
 
 fn log_privacy_classifier_withheld_projection(projection: &LinearExecutionEventPublicProjection) {

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-18
 
+- Added missing-issue ghost-lane recovery docs for `decodex recover ghost-lane`,
+  including the live/cached status readback states `ghost_lane`,
+  `runtime_recovery_required`, and `runtime_recovery_blocked`, plus the fail-closed
+  cleanup boundary.
 - Closed the MCP remote-control productization drift: Streamable HTTP now documents
   `--bearer-token-env` as the direct-listener boundary for non-loopback and elevated
   profiles, records the process-level HTTP smoke evidence, refreshes test-suite

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -6,8 +6,8 @@ status: active
 authority: current_state
 owner: docs
 tags: [reference]
-code_refs: [apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/mcp.rs]
-drift_watch: [decodex serve, decodex status, decodex evidence, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, phase_acceptance_check, control_plane_snapshot, operator dashboard, runtime.sqlite3, project.toml, WORKFLOW.md]
+code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/recovery.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/mcp.rs]
+drift_watch: [decodex serve, decodex status, decodex recover ghost-lane, decodex evidence, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, phase_acceptance_check, control_plane_snapshot, operator dashboard, runtime.sqlite3, project.toml, WORKFLOW.md]
 last_verified: 2026-06-18
 ---
 # Operator Control Plane
@@ -545,6 +545,26 @@ Worktree visibility follows the owning dashboard section:
   identify the lifecycle record, and `decodex recover review-handoff diagnose <ISSUE>`
   reports the stored handoff head, phase head, PR head, and mismatched field before
   any explicit rebind refresh.
+- `ownership_state = ghost_lane` with
+  `policy_state = runtime_recovery_required` in live observer status or a fresh
+  daemon-cached status means a local current lane still has a run lease, but tracker
+  readback proves the issue entity is missing and local inspection found no retained
+  worktree, control-channel row or file, private evidence, live
+  process/thread/protocol signal, PR lineage, or review lifecycle row. The supported
+  next action is `decodex recover ghost-lane diagnose <ISSUE> --json`, followed by
+  `decodex recover ghost-lane cleanup <ISSUE> --dry-run` and then the non-dry-run
+  cleanup only if the diagnostic remains safe. This path writes local private audit
+  evidence, marks the attempt `terminal_guarded`, and clears the local lease; it does
+  not mutate Linear when the issue is missing. The no-cache local-runtime status
+  fallback does not prove tracker absence by itself; use `--live` or the recovery
+  diagnostic when that proof matters.
+- `policy_state = runtime_recovery_blocked` on the same tracker-backed status surfaces
+  means the issue is missing from tracker readback but at least one fail-closed
+  blocker exists, such as retained worktree, control-channel row or file, live
+  execution evidence, private evidence, PR lineage, or review lifecycle state.
+  Preserve attention and inspect the named blocker. Do not use review-handoff
+  recovery, review-checkpoint writeback, label cleanup, or raw SQLite edits for this
+  state.
 - `pull_request_state_read_failed` in `Review & Landing` is a degraded PR readback
   warning when the retained review lifecycle record still exists. `decodex status`
   must keep the issue identifier, branch, lifecycle PR URL, and lifecycle PR head SHA

--- a/docs/runbook/lane-control-recovery.md
+++ b/docs/runbook/lane-control-recovery.md
@@ -6,9 +6,9 @@ status: active
 authority: procedural
 owner: automation
 tags: [runbook]
-code_refs: [apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/status.rs]
-drift_watch: [authority_boundary_check, architecture_recovery_packet, architecture_recovery_started, architecture_recovery_terminal, loop_status]
-last_verified: 2026-06-17
+code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/recovery.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/status.rs]
+drift_watch: [decodex recover ghost-lane, runtime_recovery_required, runtime_recovery_blocked, authority_boundary_check, architecture_recovery_packet, architecture_recovery_started, architecture_recovery_terminal, loop_status]
+last_verified: 2026-06-18
 ---
 # Lane-Control Recovery
 
@@ -97,6 +97,8 @@ or clean labels.
 | Soft control was rejected with `run_lease_missing`, but inspect/status still shows the same run id, attempt, branch, active channel, and live child process or protocol activity. | Treat the lane as degraded active execution, not cleanup-only state. | Re-inspect with `decodex lane inspect` or use `decodex lane interrupt <ISSUE> --run-id <RUN_ID> --force` only when the operator explicitly wants hard process fallback. |
 | Forced interrupt after `run_lease_missing` reports no signalable process. | Treat force as non-mutating for the child process. | Inspect retained worktree and private evidence; do not claim the interrupt succeeded or clear attention labels. |
 | Hard fallback reports `hard_interrupt_fallback`. | Treat it as an interrupted runtime event, not a graceful completion. | Inspect retained worktree and evidence; resume only if lineage is exact. |
+| Live or fresh cached status shows `ownership_state = ghost_lane`, `policy_state = runtime_recovery_required`, and `lane_control_next_action = run_ghost_lane_recovery`. | Treat it as a missing-issue local runtime ghost, not review-handoff recovery. | Run `decodex recover ghost-lane diagnose <ISSUE> --json`; if it still proves missing tracker issue, missing worktree, no control-channel row or file, no private evidence, no live execution, and no PR/review lineage, run `decodex recover ghost-lane cleanup <ISSUE> --dry-run`, then rerun without `--dry-run`. |
+| Live or fresh cached status shows `runtime_recovery_blocked`, or `recover ghost-lane` reports blockers. | Preserve attention. | Inspect the blocker named by status or diagnose output; do not hand-edit runtime SQLite rows or clear the lane while a tracker issue, retained worktree, control-channel row or file, live execution signal, private evidence, PR lineage, or review lifecycle record exists. |
 | Retained worktree has useful local changes and lineage matches issue, branch, runtime evidence, and PR when present. | Resume or repair the same lane. | Use `decodex run <ISSUE>` when the registered workflow makes it eligible, or use the specific retained recovery runbook. |
 | Review lifecycle record is missing or stale but the retained PR lane appears recoverable. | Diagnose before rebind. | Run `decodex recover review-handoff diagnose <ISSUE>` and follow [`recover-review-handoff.md`](./recover-review-handoff.md). |
 | Queue label or tracker state was changed and the scheduler should observe it before the next poll. | Request a refresh, not a retry. | `POST /api/linear-scan` with `projectId`, or no body for all enabled projects. |

--- a/docs/spec/lane-control.md
+++ b/docs/spec/lane-control.md
@@ -6,7 +6,9 @@ status: active
 authority: normative
 owner: runtime
 tags: [spec]
-last_verified: 2026-06-17
+code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/recovery.rs, apps/decodex/src/orchestrator/status.rs]
+drift_watch: [decodex recover ghost-lane, runtime_recovery_required, runtime_recovery_blocked, run_control_channels]
+last_verified: 2026-06-18
 ---
 # Lane-Control Specification
 
@@ -60,6 +62,7 @@ agent-facing skills must guide responsible use.
 | Hard interrupt fallback | Explicit fallback only | `decodex lane interrupt <ISSUE> --run-id <RUN_ID> --force` and `POST /api/lane/interrupt` with `"force": true` classify process signaling as `hard_interrupt_fallback` | Use only when soft interrupt is unavailable, timed out, or impossible because the process, app-server boundary, or run lease cannot be reached. A forced interrupt may signal the recorded child process after `run_lease_missing` only when inspection still identifies the same issue, run id, attempt, channel, and live process. Preserve retained worktree evidence and runtime classification. |
 | Steer active lane | Supported CLI/API control; bottom-layer method stays broad | `decodex lane steer <ISSUE> --run-id <RUN_ID> --expected-turn-id <TURN_ID> --message <TEXT>`, canonical `POST /api/lane/steer`, legacy alias `POST /api/lane-steer`, local run-control steer request/response files, app-server `turn/steer`, private `control_action` audit events, and protocol activity `turn/steer` summaries | Pass operator-supplied steer text through CLI/API to the current active turn. Require `expectedTurnId`; stale turn ids fail closed. Do not narrow the protocol to a fixed set of task-content categories. Apply policy, audit, privacy, and lifecycle guardrails above the protocol. |
 | Retained resume/retry | Supported through runtime lifecycle | `decodex run <ISSUE>`, retry scheduling, retained worktree recovery, and `thread/resume` for same-thread app-server continuation | Resume only when retained worktree, issue, branch, PR, and runtime evidence still prove the same lane. Treat ambiguous lineage as manual attention. |
+| Missing-issue ghost-lane recovery | Supported explicit recovery | `decodex status --live` and fresh daemon-cached `decodex status` project `ownership_state = ghost_lane`, `policy_state = runtime_recovery_required`, and `lane_control_next_action = run_ghost_lane_recovery`; `decodex recover ghost-lane diagnose [ISSUE]` and `decodex recover ghost-lane cleanup <ISSUE>` perform the read-only and mutating recovery paths | Only terminalize and clear a local run lease when tracker issue lookup proves the issue is missing and local inspection proves no worktree, control-channel row or file, live process/thread/protocol evidence, private evidence payload, PR lineage, or review lifecycle record. Any live, retained, tracker, PR, control-channel, or ambiguous evidence must fail closed and preserve attention. |
 | Manual attention | Supported terminal control path | `issue_label_add` intent for `decodex:needs-attention`, `issue_comment(kind = "manual_attention")`, and `issue_terminal_finalize(path = "manual_attention")` | Stop automation when policy requires a human decision. Explain the blocker through structured public fields and keep private evidence local. |
 | Task replacement | Deferred lifecycle work | No supported active-lane replacement command | Do not use steer or raw injection to replace the task silently. Treat replacement as explicit lifecycle work: pause/stop if needed, update or requeue the issue, or create a new issue/lane. |
 | Raw thread item injection | Unsupported as an operator feature | No Decodex operator path for `thread/inject_items` | Do not expose raw `thread/inject_items` to operators in this rollout. Use `turn/steer` for operator steer. |
@@ -222,6 +225,31 @@ Supported retained controls include:
 Unsupported retained controls include guessing a worktree from a branch name, clearing
 runtime DB rows by hand, or changing tracker state to force dispatch when ownership
 signals disagree.
+
+## Missing-Issue Ghost Lanes
+
+A missing-issue ghost lane is a local runtime lease that still appears in current
+live or fresh daemon-cached status but no longer has a tracker issue entity,
+retained worktree, control-channel row or file, private evidence payload, live
+process/thread/protocol evidence, or PR/review lineage. Tracker-backed status must
+not point this class at review-checkpoint recording or review-handoff rebind,
+because those paths require a tracker issue or retained PR lane. The no-cache
+local-runtime status fallback is intentionally not tracker-backed and does not prove
+issue absence by itself.
+
+`decodex recover ghost-lane diagnose [ISSUE]` is read-only. It reports public-safe
+condition names such as `tracker_issue_missing`, `worktree_missing`,
+`control_channel_missing`, `private_evidence_missing`, and
+`review_lineage_missing`. `cleanup` is the explicit mutating path and should be run
+with `--dry-run` first. Cleanup writes local private audit evidence, marks the run
+attempt `terminal_guarded`, removes only an already-missing worktree mapping, and
+clears the local lease. It must not mutate Linear when the tracker issue is missing.
+
+If inspection finds a tracker issue, retained worktree, live execution signal,
+control-channel row or file, private evidence, review lifecycle row, or PR lineage,
+tracker-backed status uses `policy_state = runtime_recovery_blocked` and the recovery
+command refuses to clean the lane. Operators then inspect the blocker instead of
+deleting runtime rows.
 
 ## Manual Attention
 


### PR DESCRIPTION
## Summary
- add explicit missing-issue ghost-lane diagnose/cleanup behavior and fail-closed local evidence checks
- keep diagnose and cleanup dry-run read-only for marker-derived thread/turn identities and live-status blocker inspection
- document live/fresh-cache ghost-lane status semantics and local-runtime fallback boundaries

## Validation
- `cargo make fmt`
- `cargo make lint-fix`
- `cargo test -p decodex --all-features ghost_lane -- --test-threads=1`
- `cargo test -p decodex --all-features read_only_project_run_listing -- --test-threads=1`
- `cargo make lint`
- `cargo make test` (`1315 passed`, `1 skipped`)
- `cargo make fmt-check`
- `cargo make check-docs`
- `git diff --check`

## Review
- subagent skeptic review initially found status/docs semantic drift around no-cache local-runtime fallback
- fixed docs to scope ghost-lane status projection to `decodex status --live` or fresh daemon-cached tracker-backed status
- follow-up subagent review reported no blocking findings

## Safety
- no Linear issue deletion or external tracker mutation is performed for missing tracker issues
- no raw SQLite edit path is introduced
- recovery remains explicit and fail-closed when worktree, control channel, live execution, private evidence, PR lineage, or review lifecycle evidence exists
