### PR TITLE
XY-1009: [DECODEX-P0] Fix app-server protocol journal conflicts after thread archive

### DIFF
--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -4366,31 +4366,26 @@ fn operator_queued_issue_attention_summary(
 	worktree_has_tracked_changes: bool,
 	attention_error_class: Option<&str>,
 ) -> String {
-	if reason == QUEUE_REASON_LINEAR_ACTIVE_LABEL_PRESENT {
-		if worktree_has_tracked_changes {
-			return String::from(
-				"Linear active ownership is still present with retained worktree changes; inspect the patch and reconcile the lane before dispatch.",
-			);
-		}
-		if attention_error_class == Some(ATTENTION_ERROR_EVIDENCE_MISSING) {
-			return if marker.is_some() {
-				String::from(
-					"Linear active ownership is still present but private execution evidence is missing; inspect the retained marker and reconcile before dispatch.",
-				)
-			} else {
-				String::from(
-					"Linear active ownership is still present but the retained marker or private execution evidence is missing; reconcile before dispatch.",
-				)
-			};
-		}
-		if marker.is_some() {
-			return String::from(
-				"Linear active ownership is still present alongside queue intake; inspect the retained marker before dispatch.",
-			);
-		}
+	if let Some(summary) = operator_active_label_attention_summary(
+		reason,
+		marker,
+		worktree_has_tracked_changes,
+		attention_error_class,
+	) {
+		return summary;
+	}
 
-		return String::from(
-			"Linear active ownership is still present without a matching local run lease; reconcile before dispatch.",
+	if attempt_status == Some("failed")
+		&& marker
+			.and_then(RunActivityMarker::last_event_type)
+			.is_some_and(|event_type| {
+				matches!(event_type, "thread/archive" | "thread/archive/discarded")
+			})
+	{
+		let operation = operator_recovery_operation_label(marker);
+
+		return format!(
+			"Child implementation attempt failed during {operation}; retained status is preserved separately from parent journal or closeout handling."
 		);
 	}
 	if worktree_has_tracked_changes {
@@ -4446,7 +4441,7 @@ fn operator_queued_issue_attention_summary(
 				),
 			"failed" =>
 				return format!(
-					"Previous attempt failed during {operation}; operator recovery required."
+					"Child implementation attempt failed during {operation}; retained status is preserved separately from parent journal or closeout handling."
 				),
 			"terminal_guarded" =>
 				return format!(
@@ -4480,6 +4475,42 @@ fn operator_queued_issue_attention_summary(
 			format!("Stopped during `{operation}`; operator recovery required."),
 		None => String::from("Needs operator recovery; no local run marker was found."),
 	}
+}
+
+fn operator_active_label_attention_summary(
+	reason: &str,
+	marker: Option<&RunActivityMarker>,
+	worktree_has_tracked_changes: bool,
+	attention_error_class: Option<&str>,
+) -> Option<String> {
+	if reason != QUEUE_REASON_LINEAR_ACTIVE_LABEL_PRESENT {
+		return None;
+	}
+	if worktree_has_tracked_changes {
+		return Some(String::from(
+			"Linear active ownership is still present with retained worktree changes; inspect the patch and reconcile the lane before dispatch.",
+		));
+	}
+	if attention_error_class == Some(ATTENTION_ERROR_EVIDENCE_MISSING) {
+		return Some(if marker.is_some() {
+			String::from(
+				"Linear active ownership is still present but private execution evidence is missing; inspect the retained marker and reconcile before dispatch.",
+			)
+		} else {
+			String::from(
+				"Linear active ownership is still present but the retained marker or private execution evidence is missing; reconcile before dispatch.",
+			)
+		});
+	}
+	if marker.is_some() {
+		return Some(String::from(
+			"Linear active ownership is still present alongside queue intake; inspect the retained marker before dispatch.",
+		));
+	}
+
+	Some(String::from(
+		"Linear active ownership is still present without a matching local run lease; reconcile before dispatch.",
+	))
 }
 
 fn operator_recovery_operation_label(marker: Option<&RunActivityMarker>) -> String {

--- a/apps/decodex/src/orchestrator/tests/operator/status/queue.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/queue.rs
@@ -759,6 +759,113 @@ fn live_operator_status_snapshot_explains_needs_attention_before_retry_budget() 
 }
 
 #[test]
+fn live_operator_status_snapshot_surfaces_failed_child_run_after_archive_race() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue_with_sort_fields(
+		"issue-needs-attention",
+		"PUB-109",
+		"Todo",
+		&["decodex:needs-attention"],
+		Some(2),
+		"2026-03-13T09:16:17.133Z",
+	);
+	let worktree_path = config.worktree_root().join(&issue.identifier);
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+	let protocol_activity = ProtocolActivitySummary {
+		turn_status: Some(String::from("completed")),
+		waiting_reason: Some(String::from("turn_completed")),
+		rate_limit_status: None,
+		recent_events: vec![ProtocolActivityEventSummary {
+			event_type: String::from("thread/archive/discarded"),
+			category: String::from("thread"),
+			detail: Some(String::from("discarded")),
+		}],
+	};
+
+	git_status_success(
+		config.repo_root(),
+		&["worktree", "add", "-b", "x/pubfi-pub-109", ".worktrees/PUB-109", "main"],
+	);
+
+	fs::write(worktree_path.join("README.md"), "retained child patch\n")
+		.expect("tracked worktree file should change");
+
+	state_store
+		.record_run_attempt("run-archive-race", &issue.id, 4, "failed")
+		.expect("failed run attempt should record");
+	state_store
+		.upsert_worktree(
+			config.service_id(),
+			&issue.id,
+			"x/pubfi-pub-109",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+	state_store
+		.append_event("run-archive-race", 963, "thread/archive/discarded", "{}")
+		.expect("archive discard should record");
+	state_store
+		.append_event(
+			"run-archive-race",
+			963,
+			"item/commandExecution/outputDelta",
+			r#"{"delta":"late output"}"#,
+		)
+		.expect("late output should be discarded without corrupting status");
+
+	state::write_run_protocol_activity_marker(
+		&worktree_path,
+		&ProtocolActivityMarker {
+			run_id: "run-archive-race",
+			attempt_number: 4,
+			thread_id: Some("thread-1"),
+			turn_id: Some("turn-1"),
+			event_count: 2,
+			last_event_type: "thread/archive/discarded",
+			child_agent_activity: None,
+			protocol_activity: Some(&protocol_activity),
+		},
+	)
+	.expect("protocol marker should write");
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let candidate = snapshot
+		.queued_candidates
+		.iter()
+		.find(|candidate| candidate.issue_identifier == "PUB-109")
+		.expect("needs-attention queued issue should exist");
+	let attention = candidate.attention.as_ref().expect("attention details should render");
+	let worktree = snapshot
+		.worktrees
+		.iter()
+		.find(|worktree| worktree.issue_identifier.as_deref() == Some("PUB-109"))
+		.expect("retained worktree should remain visible with queue ownership");
+
+	assert_eq!(candidate.classification, "blocked");
+	assert_eq!(candidate.reason, "issue_needs_attention");
+	assert_eq!(attention.run_id.as_deref(), Some("run-archive-race"));
+	assert_eq!(attention.attempt_number, Some(4));
+	assert_eq!(attention.attempt_status.as_deref(), Some("failed"));
+	assert_eq!(attention.last_event_type.as_deref(), Some("thread/archive/discarded"));
+	assert_eq!(attention.event_count, 2);
+	assert_eq!(attention.worktree_path.as_deref(), Some(".worktrees/PUB-109"));
+	assert!(attention.worktree_has_tracked_changes);
+	assert!(attention.summary.contains("Child implementation attempt failed"));
+	assert!(attention.summary.contains("parent journal or closeout handling"));
+	assert_eq!(worktree.ownership, "orphaned_live_thread");
+	assert_eq!(worktree.branch_name, "x/pubfi-pub-109");
+	assert_eq!(worktree.worktree_path, ".worktrees/PUB-109");
+}
+
+#[test]
 fn live_operator_status_snapshot_surfaces_needs_attention_event_cause() {
 	let (_temp_dir, config, workflow) = temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");

--- a/apps/decodex/src/state/store.rs
+++ b/apps/decodex/src/state/store.rs
@@ -1,5 +1,12 @@
 use crate::workflow::WorkflowConcurrencyLimit;
 
+const TERMINAL_THREAD_ARCHIVE_EVENT_TYPES: [&str; 2] = [
+	"thread/archive",
+	"thread/archive/discarded",
+];
+const DISCARDED_POST_ARCHIVE_PROTOCOL_EVENT_TYPE: &str =
+	"protocol/post_archive_event/discarded";
+
 /// Input fields for recording a project-scoped external connector backoff.
 pub(crate) struct ConnectorBackoffInput<'a> {
 	pub(crate) project_id: &'a str,
@@ -1697,8 +1704,8 @@ impl StateStore {
 		event_type: &str,
 		payload: &str,
 	) -> Result<()> {
-		let mut state = self.lock_without_refresh()?;
 		let now = timestamp_parts();
+		let mut state = self.lock_without_refresh()?;
 		let event = ProtocolEventRecord {
 			sequence_number,
 			event_type: event_type.to_owned(),
@@ -1706,51 +1713,213 @@ impl StateStore {
 			created_at: now.text,
 			created_at_unix: now.unix,
 		};
-		let (insert_index, cached_existing) = {
-			let events = state.events.entry(run_id.to_owned()).or_default();
-
-			match events.binary_search_by_key(&sequence_number, |event| event.sequence_number) {
-				Ok(index) => (index, Some(events[index].clone())),
-				Err(index) => (index, None),
-			}
+		let Some(mut event) =
+			self.prepare_protocol_event_for_append_locked(&mut state, run_id, event)?
+		else {
+			return Ok(());
 		};
 
-		if let Some(existing) = cached_existing {
-			ensure_protocol_event_replay_matches(run_id, &existing, &event)?;
+		loop {
+			let (insert_index, cached_existing) = {
+				let events = state.events.entry(run_id.to_owned()).or_default();
 
-			self.refresh_protocol_event_summaries_for_runs_locked(&mut state, &[run_id.to_owned()])?;
+				match events.binary_search_by_key(&event.sequence_number, |event| event.sequence_number) {
+					Ok(index) => (index, Some(events[index].clone())),
+					Err(index) => (index, None),
+				}
+			};
+
+			if let Some(existing) = cached_existing {
+				if self.handle_protocol_event_append_conflict_locked(
+					&mut state,
+					run_id,
+					&mut event,
+					&existing,
+				)? {
+					continue;
+				}
+
+				return Ok(());
+			}
+
+			if !self.append_protocol_event_locked(run_id, &event)? {
+				let existing =
+					self.protocol_event_locked(run_id, event.sequence_number)?.ok_or_else(|| {
+						eyre::eyre!(
+							"Protocol event `{run_id}` sequence `{}` already exists in the runtime journal, but the existing row could not be read.",
+							event.sequence_number
+						)
+					})?;
+
+				if self.handle_protocol_event_append_conflict_locked(
+					&mut state,
+					run_id,
+					&mut event,
+					&existing,
+				)? {
+					continue;
+				}
+
+				return Ok(());
+			}
+
+			self.record_inserted_protocol_event_locked(&mut state, run_id, insert_index, event)?;
 
 			return Ok(());
 		}
+	}
 
-		if !self.append_protocol_event_locked(run_id, &event)? {
-			let existing = self.protocol_event_locked(run_id, sequence_number)?.ok_or_else(|| {
-				eyre::eyre!(
-					"Protocol event `{run_id}` sequence `{sequence_number}` already exists in the runtime journal, but the existing row could not be read."
-				)
-			})?;
+	fn prepare_protocol_event_for_append_locked(
+		&self,
+		state: &mut StateData,
+		run_id: &str,
+		event: ProtocolEventRecord,
+	) -> Result<Option<ProtocolEventRecord>> {
+		if !self.protocol_event_should_be_discarded_after_archive_locked(state, run_id, &event)? {
+			return Ok(Some(event));
+		}
+		if self.protocol_event_replay_already_recorded_locked(state, run_id, &event)? {
+			self.refresh_protocol_event_summaries_for_runs_locked(
+				state,
+				&[run_id.to_owned()],
+			)?;
 
-			ensure_protocol_event_replay_matches(run_id, &existing, &event)?;
-
-			self.refresh_protocol_event_summaries_for_runs_locked(&mut state, &[run_id.to_owned()])?;
-
-			return Ok(());
+			return Ok(None);
 		}
 
-		let summary = state.event_summaries.entry(run_id.to_owned()).or_default();
+		Ok(Some(discarded_post_archive_protocol_event_with_log(run_id, event)))
+	}
 
-		if summary
-			.last_sequence_number
-			.is_none_or(|last_sequence_number| sequence_number == last_sequence_number.saturating_add(1))
-		{
-			summary.record_event(&event);
-		} else {
-			self.refresh_protocol_event_summaries_for_runs_locked(&mut state, &[run_id.to_owned()])?;
+	fn handle_protocol_event_append_conflict_locked(
+		&self,
+		state: &mut StateData,
+		run_id: &str,
+		event: &mut ProtocolEventRecord,
+		existing: &ProtocolEventRecord,
+	) -> Result<bool> {
+		if protocol_event_conflict_should_be_discarded_after_archive(existing, event) {
+			*event = discarded_post_archive_protocol_event_with_log(run_id, event.clone());
+
+			return Ok(true);
 		}
+		if protocol_event_is_discarded_post_archive_collision(existing, event) {
+			event.sequence_number =
+				next_discarded_post_archive_sequence_after_collision(event.sequence_number)?;
+
+			return Ok(true);
+		}
+
+		ensure_protocol_event_replay_matches(run_id, existing, event)?;
+
+		self.refresh_protocol_event_summaries_for_runs_locked(state, &[run_id.to_owned()])?;
+
+		Ok(false)
+	}
+
+	fn record_inserted_protocol_event_locked(
+		&self,
+		state: &mut StateData,
+		run_id: &str,
+		insert_index: usize,
+		event: ProtocolEventRecord,
+	) -> Result<()> {
+		let had_cached_summary = state.event_summaries.contains_key(run_id);
+		let inserted_event = event.clone();
 
 		state.events.entry(run_id.to_owned()).or_default().insert(insert_index, event);
 
+		if self.sqlite.is_some() && !had_cached_summary {
+			self.refresh_protocol_event_summaries_for_runs_locked(state, &[run_id.to_owned()])?;
+		} else if self.sqlite.is_some() {
+			let summary = state.event_summaries.entry(run_id.to_owned()).or_default();
+
+			if summary.last_sequence_number.is_none_or(|last_sequence_number| {
+				inserted_event.sequence_number == last_sequence_number.saturating_add(1)
+			}) {
+				summary.record_event(&inserted_event);
+			} else {
+				self.refresh_protocol_event_summaries_for_runs_locked(
+					state,
+					&[run_id.to_owned()],
+				)?;
+			}
+		} else if let Some(events) = state.events.get(run_id) {
+			let summary = protocol_event_summary_from_events(events);
+
+			state.event_summaries.insert(run_id.to_owned(), summary);
+		}
+
 		Ok(())
+	}
+
+	fn protocol_event_should_be_discarded_after_archive_locked(
+		&self,
+		state: &StateData,
+		run_id: &str,
+		event: &ProtocolEventRecord,
+	) -> Result<bool> {
+		if !protocol_event_can_be_discarded_after_archive(event) {
+			return Ok(false);
+		}
+
+		self.run_has_terminal_thread_archive_event_locked(state, run_id)
+	}
+
+	fn run_has_terminal_thread_archive_event_locked(
+		&self,
+		state: &StateData,
+		run_id: &str,
+	) -> Result<bool> {
+		if state.events.get(run_id).is_some_and(|events| {
+			events
+				.iter()
+				.any(|event| protocol_event_is_terminal_thread_archive(&event.event_type))
+		}) {
+			return Ok(true);
+		}
+		if state.event_summaries.get(run_id).is_some_and(|summary| {
+			summary
+				.last_event_type
+				.as_deref()
+				.is_some_and(protocol_event_is_terminal_thread_archive)
+		}) {
+			return Ok(true);
+		}
+
+		let Some(sqlite) = self.sqlite.as_ref() else {
+			return Ok(false);
+		};
+		let sqlite = sqlite
+			.lock()
+			.map_err(|_| eyre::eyre!("StateStore SQLite mutex is poisoned."))?;
+
+		for event_type in TERMINAL_THREAD_ARCHIVE_EVENT_TYPES {
+			if sqlite.run_has_protocol_event(run_id, event_type)? {
+				return Ok(true);
+			}
+		}
+
+		Ok(false)
+	}
+
+	fn protocol_event_replay_already_recorded_locked(
+		&self,
+		state: &StateData,
+		run_id: &str,
+		event: &ProtocolEventRecord,
+	) -> Result<bool> {
+		if let Some(events) = state.events.get(run_id)
+			&& let Ok(index) =
+				events.binary_search_by_key(&event.sequence_number, |event| event.sequence_number)
+		{
+			return Ok(events[index].is_idempotent_replay_of(event));
+		}
+
+		let Some(existing) = self.protocol_event_locked(run_id, event.sequence_number)? else {
+			return Ok(false);
+		};
+
+		Ok(existing.is_idempotent_replay_of(event))
 	}
 
 	pub(crate) fn record_run_activity_summary(
@@ -4568,6 +4737,90 @@ fn protocol_event_payload_sha256(payload: &str) -> String {
 	}
 
 	hash
+}
+
+fn protocol_event_is_terminal_thread_archive(event_type: &str) -> bool {
+	TERMINAL_THREAD_ARCHIVE_EVENT_TYPES.contains(&event_type)
+}
+
+fn protocol_event_can_be_discarded_after_archive(event: &ProtocolEventRecord) -> bool {
+	!protocol_event_is_terminal_thread_archive(&event.event_type)
+		&& event.event_type != DISCARDED_POST_ARCHIVE_PROTOCOL_EVENT_TYPE
+}
+
+fn protocol_event_conflict_should_be_discarded_after_archive(
+	existing: &ProtocolEventRecord,
+	candidate: &ProtocolEventRecord,
+) -> bool {
+	protocol_event_is_terminal_thread_archive(&existing.event_type)
+		&& protocol_event_can_be_discarded_after_archive(candidate)
+}
+
+fn protocol_event_is_discarded_post_archive_collision(
+	existing: &ProtocolEventRecord,
+	candidate: &ProtocolEventRecord,
+) -> bool {
+	existing.event_type == DISCARDED_POST_ARCHIVE_PROTOCOL_EVENT_TYPE
+		&& candidate.event_type == DISCARDED_POST_ARCHIVE_PROTOCOL_EVENT_TYPE
+		&& !existing.is_idempotent_replay_of(candidate)
+}
+
+fn discarded_post_archive_protocol_event(mut event: ProtocolEventRecord) -> ProtocolEventRecord {
+	if event.event_type == DISCARDED_POST_ARCHIVE_PROTOCOL_EVENT_TYPE {
+		return event;
+	}
+
+	event.sequence_number = discarded_post_archive_protocol_sequence(&event);
+	event.event_type = DISCARDED_POST_ARCHIVE_PROTOCOL_EVENT_TYPE.to_owned();
+
+	event
+}
+
+fn discarded_post_archive_protocol_event_with_log(
+	run_id: &str,
+	event: ProtocolEventRecord,
+) -> ProtocolEventRecord {
+	let original_sequence_number = event.sequence_number;
+	let original_event_type = event.event_type.clone();
+	let discarded = discarded_post_archive_protocol_event(event);
+
+	tracing::info!(
+		run_id,
+		original_sequence_number,
+		original_event_type,
+		discarded_sequence_number = discarded.sequence_number,
+		discarded_event_type = discarded.event_type.as_str(),
+		"Discarded late app-server protocol event after terminal thread archive barrier; child protocol activity is isolated from parent journal and closeout state."
+	);
+
+	discarded
+}
+
+fn discarded_post_archive_protocol_sequence(event: &ProtocolEventRecord) -> i64 {
+	let payload = format!(
+		"{}\n{}\n{}",
+		event.sequence_number, event.event_type, event.payload_sha256
+	);
+	let digest = Sha256::digest(payload.as_bytes());
+	let mut bytes = [0_u8; 8];
+
+	bytes.copy_from_slice(&digest[..8]);
+
+	let slot = i64::from_be_bytes(bytes) & i64::MAX;
+
+	if slot == i64::MAX {
+		i64::MIN
+	} else {
+		-1 - slot
+	}
+}
+
+fn next_discarded_post_archive_sequence_after_collision(sequence_number: i64) -> Result<i64> {
+	if sequence_number == i64::MIN {
+		eyre::bail!("Post-archive discarded protocol event sequence space is exhausted.");
+	}
+
+	Ok(sequence_number - 1)
 }
 
 fn ensure_protocol_event_replay_matches(

--- a/apps/decodex/src/state/tests.rs
+++ b/apps/decodex/src/state/tests.rs
@@ -27,9 +27,9 @@ use crate::{
 		LoopGuardrailCheckpointInput, PreacquiredLeaseGuards, ProjectRegistration,
 		ProtocolActivityMarker, ProtocolActivitySummary, RUN_ACTIVITY_MARKER_FILE,
 		RUN_CONTROL_ACTION_COMPLETED, RUN_CONTROL_ACTION_FAILED, RUN_CONTROL_ACTION_FALLBACK,
-		RUN_CONTROL_ACTION_TIMED_OUT, RUN_OPERATION_REPO_GATE, Result,
-		ReviewCheckpointArtifactLookup, ReviewHandoffMarker, ReviewOrchestrationMarker,
-		ReviewPolicyCheckpointInput, RunControlActionRequest, StateStore,
+		RUN_CONTROL_ACTION_TIMED_OUT, RUN_OPERATION_REPO_GATE, ReviewCheckpointArtifactLookup,
+		ReviewHandoffMarker, ReviewOrchestrationMarker, ReviewPolicyCheckpointInput,
+		RunControlActionRequest, StateStore,
 	},
 	tracker::records::{LinearExecutionEventIdentity, LinearExecutionEventRecord},
 };
@@ -1117,6 +1117,117 @@ fn protocol_event_sequence_conflict_rejects_changed_payload() {
 		"unexpected error: {error:?}",
 	);
 	assert_eq!(store.event_count("run-1").expect("event count should load"), 1);
+}
+
+#[test]
+fn late_protocol_events_after_thread_archive_use_discarded_sequence_namespace() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+	let store = StateStore::open(&state_path).expect("state store should open");
+
+	store.record_run_attempt("run-1", "PUB-101", 1, "failed").expect("run attempt should record");
+	store
+		.upsert_worktree("pubfi", "PUB-101", "x/pubfi-pub-101", "/tmp/worktrees/pub-101")
+		.expect("worktree should record");
+	store
+		.append_event("run-1", 32, "thread/archive", r#"{"threadId":"thread-1"}"#)
+		.expect("archive event should append");
+	store
+		.append_event("run-1", 32, "item/started", r#"{"itemId":"item-1"}"#)
+		.expect("late item start should be discarded without conflict");
+	store
+		.append_event("run-1", 33, "item/completed", r#"{"itemId":"item-1"}"#)
+		.expect("later item completion should also be discarded");
+
+	let runs = store.list_recent_runs("pubfi", 10).expect("recent runs should load");
+
+	assert_eq!(runs.len(), 1);
+	assert_eq!(runs[0].event_count(), 3);
+	assert_eq!(runs[0].last_event_type(), Some("thread/archive"));
+	assert_eq!(store.event_count("run-1").expect("event count should load"), 3);
+
+	let connection = Connection::open(&state_path).expect("sqlite should open");
+	let mut statement = connection
+		.prepare(
+			"SELECT sequence_number, event_type FROM protocol_events \
+			 WHERE run_id = 'run-1' ORDER BY sequence_number",
+		)
+		.expect("protocol rows should prepare");
+	let rows = statement
+		.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)))
+		.expect("protocol rows should query")
+		.collect::<rusqlite::Result<Vec<_>>>()
+		.expect("protocol rows should collect");
+	let discarded_rows = rows
+		.iter()
+		.filter(|(_sequence, event_type)| {
+			event_type.as_str() == "protocol/post_archive_event/discarded"
+		})
+		.collect::<Vec<_>>();
+
+	assert!(rows.iter().any(|row| row == &(32, String::from("thread/archive"))));
+	assert_eq!(discarded_rows.len(), 2);
+	assert!(discarded_rows.iter().all(|(sequence, _event_type)| *sequence < 0));
+	assert!(!rows.iter().any(|(_sequence, event_type)| event_type == "item/started"));
+	assert!(!rows.iter().any(|(_sequence, event_type)| event_type == "item/completed"));
+}
+
+#[test]
+fn pre_archive_protocol_replays_remain_idempotent_after_archive() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+	let store = StateStore::open(&state_path).expect("state store should open");
+
+	store.record_run_attempt("run-1", "PUB-101", 1, "failed").expect("run attempt should record");
+	store
+		.upsert_worktree("pubfi", "PUB-101", "x/pubfi-pub-101", "/tmp/worktrees/pub-101")
+		.expect("worktree should record");
+	store
+		.append_event("run-1", 31, "item/started", r#"{"itemId":"item-1"}"#)
+		.expect("pre-archive item start should append");
+	store
+		.append_event("run-1", 32, "thread/archive", r#"{"threadId":"thread-1"}"#)
+		.expect("archive event should append");
+	store
+		.append_event("run-1", 31, "item/started", r#"{"itemId":"item-1"}"#)
+		.expect("pre-archive replay should stay idempotent after archive");
+
+	let runs = store.list_recent_runs("pubfi", 10).expect("recent runs should load");
+
+	assert_eq!(runs.len(), 1);
+	assert_eq!(runs[0].event_count(), 2);
+	assert_eq!(runs[0].last_event_type(), Some("thread/archive"));
+	assert_eq!(store.event_count("run-1").expect("event count should load"), 2);
+}
+
+#[test]
+fn late_protocol_events_after_archive_discard_are_restart_safe() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+	let store = StateStore::open(&state_path).expect("state store should open");
+
+	store.record_run_attempt("run-1", "PUB-101", 1, "failed").expect("run attempt should record");
+	store
+		.upsert_worktree("pubfi", "PUB-101", "x/pubfi-pub-101", "/tmp/worktrees/pub-101")
+		.expect("worktree should record");
+	store
+		.append_event("run-1", 7, "thread/archive/discarded", r#"{"threadId":"thread-1"}"#)
+		.expect("discarded archive event should append");
+
+	drop(store);
+
+	let restarted = StateStore::open_lazy(&state_path).expect("lazy store should open");
+
+	restarted
+		.append_event("run-1", 8, "item/commandExecution/outputDelta", r#"{"delta":"late output"}"#)
+		.expect("late output after restart should be discarded without conflict");
+
+	let runs = restarted.list_recent_runs("pubfi", 10).expect("recent runs should load");
+
+	assert_eq!(runs.len(), 1);
+	assert_eq!(runs[0].event_count(), 2);
+	assert_eq!(runs[0].last_event_type(), Some("thread/archive/discarded"));
+	assert_eq!(restarted.event_count("run-1").expect("event count should load"), 2);
 }
 
 #[test]
@@ -2643,7 +2754,7 @@ fn write_test_protocol_activity_marker(
 	event_count: i64,
 	last_event_type: &str,
 	protocol_activity: Option<&ProtocolActivitySummary>,
-) -> Result<()> {
+) -> crate::state::Result<()> {
 	state::write_run_protocol_activity_marker(
 		worktree_path,
 		&ProtocolActivityMarker {

--- a/docs/evidence/decodex-plugin-eval.md
+++ b/docs/evidence/decodex-plugin-eval.md
@@ -44,7 +44,7 @@ node ~/.codex/plugins/cache/openai-curated-remote/plugin-eval/0.1.2/scripts/plug
 
 Static budget snapshot:
 
-- Active invocation budget: 1013 tokens.
+- Active invocation budget: 1037 tokens.
 - Deferred skill budget: 10844 tokens.
 - Explicit-only invocation budget: 10317 tokens.
 - Plugin skill count: 31 skills, with one implicit router and 30 explicit-only skills.
@@ -95,16 +95,17 @@ Explicit-only skills:
 ## Limits
 
 The evaluation is static plugin analysis, not a measured real-usage benchmark. The
-2026-06-19 full-plugin rerun after skill slimming reported score 95/100, grade A,
-medium risk, zero failing checks, one warning, and two informational notes. Active
-invocation cost dropped to 1013 tokens; deferred skill cost dropped to 10844 tokens.
-The remaining warning is `deferred_cost_tokens-budget-high`, a known static
-token-budget cleanup item after the repo-work migration, not a routing, safety, or
-progressive-disclosure failure. The manifest default prompt count remains within the
-three-prompt Codex limit. Only the top-level `decodex` router remains implicit;
-repo-work, docs, planning, repo-memory, research, and specialist skills are
-explicit-only because the top-level router and host `AGENTS.md` name the narrower
-owner skills directly.
+2026-06-19 full-plugin rerun after the XY-1009 packaged-surface repair reported
+score 95/100, grade A, medium risk, zero failing checks, one warning, and two
+informational notes. Active invocation cost was 1037 tokens; deferred skill cost
+remained 10844 tokens. The remaining warning is
+`deferred_cost_tokens-budget-high`, a known static token-budget cleanup item after
+the repo-work migration, not a routing, safety, or progressive-disclosure failure.
+The manifest default prompt count is 3, which keeps repo-work, docs/OKF, research,
+and debugging starters inside the first-three prompt surface used by Codex. Only the
+top-level `decodex` router remains implicit; repo-work, docs, planning, repo-memory,
+research, and specialist skills are explicit-only because the top-level router and
+host `AGENTS.md` name the narrower owner skills directly.
 
 Directly evaluating the installed cache path
 `~/.codex/plugins/cache/hack-ink/decodex/0.2.0` reports an additional

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,15 @@
 # Documentation Log
 
+## 2026-06-19
+
+- Added the terminal app-server archive barrier contract: late non-terminal protocol
+  events after `thread/archive` or `thread/archive/discarded` are recorded as
+  discarded post-archive diagnostics in a non-conflicting runtime journal namespace,
+  while operator status preserves failed child-run recovery context separately from
+  parent journal or closeout handling.
+- Refreshed Decodex plugin-eval evidence after the packaged plugin manifest prompt
+  surface was consolidated back to the first-three prompt limit.
+
 ## 2026-06-18
 
 - Documented the narrow `mcp_test_fixture_ghost_lane` recovery classification for the

--- a/docs/spec/app-server.md
+++ b/docs/spec/app-server.md
@@ -9,7 +9,7 @@ tags: [spec]
 code_refs: [apps/decodex/src/agent/app_server.rs, apps/decodex/src/agent/app_server/protocol.rs, apps/decodex/src/agent/app_server/tests.rs, apps/decodex/src/agent/tracker_tool_bridge.rs]
 related: [./tracker-tools.md, ./lane-control.md, ./runtime.md]
 drift_watch: ["codex app-server generate-json-schema --experimental", "decodex probe stdio://", ThreadStartParams.dynamicTools, dynamicTools, "type:function", "type:namespace", ClientRequest, ServerRequest, ClientNotification, ServerNotification, "account/rateLimitResetCredit/consume", "externalAgentConfig/import/readHistories", "thread/realtime/appendSpeech", "externalAgentConfig/import/progress"]
-last_verified: 2026-06-18
+last_verified: 2026-06-19
 ---
 # App-Server Specification
 
@@ -178,6 +178,12 @@ To validate an upstream app-server protocol change:
 Additional notifications may be recorded opportunistically for diagnostics.
 `thread/goal/updated` is recorded as local protocol activity and may summarize the
 active phase and status for operator readback. It is not a public tracker signal.
+After `thread/archive` or `thread/archive/discarded` is recorded for a run, Decodex
+treats later non-terminal app-server events for that run as late diagnostics rather
+than authoritative progress. Those events are discarded into the runtime journal's
+post-archive namespace so they cannot collide with the archive sequence, cannot
+replace the archive as the terminal protocol marker, and cannot make parent
+journal/closeout recovery consume the child retry budget.
 
 The follow-up alignment phase should also record tool-related requests and notifications needed for issue-scoped tracker writes.
 

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -8,7 +8,7 @@ owner: runtime
 tags: [spec]
 code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/mcp.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs]
 drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, protocol_events, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, decodex intake goal, program_issue_mappings]
-last_verified: 2026-06-18
+last_verified: 2026-06-19
 ---
 # Runtime Specification
 
@@ -62,6 +62,15 @@ state or this state machine.
   the same event type and digest are idempotent and must not inflate event counts or
   fail a continuation/recovery path. A different event type or different digest at the
   same sequence remains a journal integrity error.
+- `thread/archive` and `thread/archive/discarded` are terminal protocol barriers for
+  one run. After either barrier is recorded, later non-terminal app-server events for
+  the same run must not compete for the normal positive protocol sequence namespace.
+  The runtime records them as `protocol/post_archive_event/discarded` in a negative,
+  replay-stable sequence namespace derived from the original sequence, event type, and
+  payload digest. These discarded rows are local recovery evidence only: they may
+  increase protocol event counts, but they must not replace the terminal archive event
+  as the run's latest event and must not turn a parent journal/closeout race into a
+  child retry failure.
 - Linear remains the team-visible tracker surface for issue lifecycle, queue/active/manual-attention labels, and coarse lifecycle summaries such as start, PR-ready, blocked, failed, landed, and done.
 - Versioned Linear execution event comments use the schema in
   [`linear-execution-ledger.md`](./linear-execution-ledger.md), but fine-grained runtime truth must not be rebuilt from comments every tick.
@@ -778,6 +787,12 @@ or `stalled` while current marker, active thread, or active work-protocol eviden
 still identifies the same `run_id` and `attempt_number` as live, operator status must
 keep the lane visible with the process/protocol liveness details instead of hiding it
 as only terminal history or cleanup work.
+For needs-attention recovery, operator status must preserve failed child-run context
+separately from parent journal or closeout handling. A dirty retained worktree for the
+same issue remains associated with queue-attention or live-thread recovery state when
+the tracker has the configured needs-attention label; it must not collapse into a
+cleanup-only worktree row with no run id, attempt status, branch, or recovery
+explanation.
 Operator status lifecycle reconstruction may use recorded run attempts plus local
 evidence that is already scoped to the same project, issue, run id, and attempt:
 runtime run leases, run-control channels, protocol activity summaries, private

--- a/plugins/decodex/.codex-plugin/plugin.json
+++ b/plugins/decodex/.codex-plugin/plugin.json
@@ -37,8 +37,8 @@
     "termsOfServiceURL": "https://github.com/hack-ink/decodex",
     "defaultPrompt": [
       "Apply Decodex repo-work rules.",
-      "Debug or audit Decodex drift.",
-      "Research this with Decodex."
+      "Maintain Decodex docs. Work with an OKF bundle.",
+      "Research this with Decodex. Debug or audit Decodex drift."
     ],
     "brandColor": "#0F766E"
   }


### PR DESCRIPTION
## Summary
- Add a terminal archive barrier for app-server protocol events so late non-terminal events after thread archive are stored as discarded diagnostics in a non-conflicting namespace.
- Preserve exact protocol replay idempotence and keep archive markers authoritative for recovery/status summaries.
- Surface failed child-run recovery status distinctly from parent journal or closeout failures, with specs and evidence updated.

## Validation
- cargo make fmt
- cargo make lint-fix
- cargo make check-docs
- node plugin-eval analyze for plugins/decodex
- cargo make test (1333 passed, 1 skipped)
- Independent fresh-context review checkpoint clean for HEAD 454c7ffc364d29bc685bd8d72579dd9b505558b7