### PR TITLE
Refresh Execution Program status from live tracker facts

### DIFF
--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -941,8 +941,15 @@ where
 		options.account_activity_mode,
 	)?;
 
-	snapshot.execution_programs =
-		operator_execution_program_statuses(project, workflow, state_store)?;
+	let execution_program_readback =
+		operator_execution_program_statuses(tracker, project, workflow, state_store)?;
+	snapshot.execution_programs = execution_program_readback.statuses;
+	if execution_program_readback.issue_metadata_unavailable {
+		add_operator_snapshot_warning(
+			&mut snapshot,
+			"execution_program_issue_metadata_unavailable",
+		);
+	}
 
 	hydrate_history_lanes_from_local_ledger(project, state_store, &mut snapshot)?;
 	hydrate_live_operator_external_observers(
@@ -981,18 +988,153 @@ where
 	Ok(snapshot)
 }
 
-fn operator_execution_program_statuses(
+struct OperatorExecutionProgramReadback {
+	statuses: Vec<OperatorExecutionProgramStatus>,
+	issue_metadata_unavailable: bool,
+}
+
+fn operator_execution_program_statuses<T>(
+	tracker: &T,
 	project: &ServiceConfig,
 	workflow: &WorkflowDocument,
 	state_store: &StateStore,
+) -> crate::prelude::Result<OperatorExecutionProgramReadback>
+where
+	T: IssueTracker + ?Sized,
+{
+	let records = state_store.list_execution_programs(project.service_id())?;
+
+	if records.is_empty() {
+		return Ok(OperatorExecutionProgramReadback {
+			statuses: Vec::new(),
+			issue_metadata_unavailable: false,
+		});
+	}
+
+	match operator_execution_program_statuses_with_live_tracker(
+		tracker,
+		project,
+		workflow,
+		state_store,
+		&records,
+	) {
+		Ok(statuses) => Ok(OperatorExecutionProgramReadback {
+			statuses,
+			issue_metadata_unavailable: false,
+		}),
+		Err(error) => {
+			let _ = error;
+
+			tracing::warn!(
+				project_id = project.service_id(),
+				"Skipped live tracker metadata hydration for Execution Program status; sensitive tracker details were withheld."
+			);
+
+			Ok(OperatorExecutionProgramReadback {
+				statuses: operator_execution_program_statuses_from_persisted(
+					project,
+					workflow,
+					state_store,
+					&records,
+				)?,
+				issue_metadata_unavailable: true,
+			})
+		},
+	}
+}
+
+fn operator_execution_program_statuses_with_live_tracker<T>(
+	tracker: &T,
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	records: &[ExecutionProgramRecord],
+) -> crate::prelude::Result<Vec<OperatorExecutionProgramStatus>>
+where
+	T: IssueTracker + ?Sized,
+{
+	let policy = ExecutionWorkflowPolicy::from_workflow(project.service_id(), workflow)?;
+	let mapped_issue_ids = operator_execution_program_mapped_issue_ids(records);
+	let refreshed_issues = refresh_execution_program_issues(tracker, records)?;
+	if mapped_issue_ids
+		.iter()
+		.any(|issue_id| !refreshed_issues.contains_key(issue_id))
+	{
+		eyre::bail!("Execution Program tracker metadata was incomplete.");
+	}
+	let refreshed_programs = records
+		.iter()
+		.cloned()
+		.map(|record| {
+			refresh_execution_program_tracker_facts(
+				tracker,
+				state_store,
+				project.service_id(),
+				workflow,
+				record,
+				&refreshed_issues,
+			)
+		})
+		.collect::<Result<Vec<_>>>()?;
+	let context = execution_program_readiness_context(
+		project.service_id(),
+		workflow,
+		state_store,
+		&refreshed_programs,
+	)?;
+	let mut statuses = Vec::new();
+
+	for refreshed in refreshed_programs {
+		let record = &refreshed.record;
+		let program = &refreshed.program;
+		let evaluation = if let Some(source_contract_id) = record.source_contract_id() {
+			let Some(contract) =
+				state_store.decision_contract_for_readback(project.service_id(), source_contract_id)?
+			else {
+				statuses.push(OperatorExecutionProgramStatus::missing_contract(record));
+
+				continue;
+			};
+
+			program.evaluate(contract.contract(), &policy, &context)?
+		} else {
+			program.evaluate_issue_batch(&policy, &context)?
+		};
+
+		statuses.push(OperatorExecutionProgramStatus::from_summary(
+			record,
+			evaluation.operator_summary(),
+			&evaluation,
+		));
+	}
+
+	statuses.sort_by(|left, right| left.program_id.cmp(&right.program_id));
+
+	Ok(statuses)
+}
+
+fn operator_execution_program_mapped_issue_ids(records: &[ExecutionProgramRecord]) -> Vec<String> {
+	records
+		.iter()
+		.flat_map(|record| record.program().nodes())
+		.filter_map(|node| node.linear_issue().map(|issue| issue.issue_id().to_owned()))
+		.collect::<BTreeSet<_>>()
+		.into_iter()
+		.collect()
+}
+
+fn operator_execution_program_statuses_from_persisted(
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	records: &[ExecutionProgramRecord],
 ) -> crate::prelude::Result<Vec<OperatorExecutionProgramStatus>> {
 	let policy = ExecutionWorkflowPolicy::from_workflow(project.service_id(), workflow)?;
-	let records = state_store.list_execution_programs(project.service_id())?;
 	let context = operator_execution_program_readiness_context(
 		project.service_id(),
 		workflow,
 		state_store,
-		&records,
+		records,
 	)?;
 	let mut statuses = Vec::new();
 

--- a/apps/decodex/src/orchestrator/tests/operator/status/text.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/text.rs
@@ -504,6 +504,73 @@ fn operator_status_program_readback_prefers_post_review_owner_over_stale_active_
 	);
 }
 
+#[test]
+fn operator_status_program_readback_refreshes_live_tracker_issue_mapping() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let stale_mapping = status_program_issue_mapping("issue-live-refresh", "PUB-1597", "Todo")
+		.with_needs_attention_label(true);
+	let node = ExecutionProgramNode::new(
+		"node-live-refresh",
+		ExecutionProgramNodeStage::Runtime,
+		"Close stale Program attention after the mapped issue is terminal.",
+		ExecutionQueueIntent::ReadyToQueue,
+	)
+	.expect("node should build")
+	.with_acceptance_expectations(["The mapped issue reflects live tracker state."])
+	.expect("acceptance should attach")
+	.with_validation_expectations(["Build operator status."])
+	.expect("validation should attach")
+	.with_linear_issue(stale_mapping)
+	.expect("stale mapping should attach");
+	let program = ExecutionProgram::from_issue_batch_intake(
+		"program-live-refresh",
+		config.service_id(),
+		"program-live-refresh-fingerprint",
+		"Refresh live Program issue metadata.",
+		vec![node],
+	)
+	.expect("program should build");
+
+	state_store
+		.upsert_execution_program(config.service_id(), program)
+		.expect("program should persist");
+
+	let live_issue = sample_issue_with_sort_fields(
+		"issue-live-refresh",
+		"PUB-1597",
+		"Done",
+		&[],
+		Some(1),
+		"2026-06-19T00:00:00.000Z",
+	);
+	let tracker = FakeTracker::new(vec![live_issue]);
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("status snapshot should build");
+	let program = snapshot.execution_programs.first().expect("program should surface");
+
+	assert_eq!(program.status, "completed");
+	assert_eq!(program.completed_count, 1);
+	assert_eq!(program.needs_attention_count, 0);
+	assert_eq!(program.blocked_count, 0);
+	assert_eq!(program.dispatchable_count, 0);
+	assert!(
+		program.node_readbacks.is_empty(),
+		"terminal refreshed Program nodes should not render stale attention readbacks"
+	);
+	assert_eq!(tracker.refresh_queries.borrow().len(), 1);
+	assert_eq!(
+		tracker.refresh_queries.borrow()[0],
+		vec![String::from("issue-live-refresh")]
+	);
+}
+
 fn seed_program_readback_status(state_store: &StateStore, config: &ServiceConfig) {
 	let program = ExecutionProgram::from_issue_batch_intake(
 		"program-status-readback",


### PR DESCRIPTION
## Summary
- refresh Execution Program status readback from live tracker issue metadata before evaluating readiness
- fall back to persisted Program metadata with a warning when live issue metadata is incomplete or unavailable
- add a regression test for stale needs-attention mappings becoming terminal in live tracker state

## Verification
- rustup run nightly cargo fmt --all -- --check
- cargo check -p decodex --lib
- cargo test -p decodex operator_status_program
- cargo test -p decodex operator_status_snapshot_surfaces_program_intake_and_node_readbacks
- cargo run -p decodex --bin decodex -- status --live --config /Users/x/.codex/decodex/projects/pubfi-mono/project.toml | rg -n "PUB-1597|Execution Programs|program_id:|attention=" -C 2

Note: focused cargo test commands required temporary empty include_str fixture files because the current worktree is missing several plugin_surface_tests fixture paths; those files were removed after each run and are not part of this PR.