### PR TITLE
XY-1016: [DECODEX-P0] Clear stale terminal PubFi records before targeted dispatch refresh

### DIFF
--- a/apps/decodex/src/orchestrator/run_cycle.rs
+++ b/apps/decodex/src/orchestrator/run_cycle.rs
@@ -1,5 +1,6 @@
 use state::IssueLease;
 use state::PreacquiredLeaseGuards;
+use state::WORKTREE_PROVENANCE_RUNTIME_RECORDED;
 
 use crate::commit_message;
 
@@ -31,6 +32,7 @@ impl<T> Clone for PassiveRetainedAttentionRuntime<'_, T> {
 		*self
 	}
 }
+
 impl<T> Copy for PassiveRetainedAttentionRuntime<'_, T> {}
 
 struct ProjectStateReconciliationContext<'a, T> {
@@ -71,6 +73,37 @@ enum RetainedReviewLaneReviewLoad {
 	Skip,
 	Blocked(String),
 	ReviewState(Box<PullRequestReviewState>),
+}
+
+pub(crate) fn worktree_mapping_is_stale_terminal_local_residue(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	mapping: &WorktreeMapping,
+	active_issue_ids: &HashSet<String>,
+) -> Result<bool> {
+	if active_issue_ids.contains(mapping.issue_id())
+		|| !looks_like_tracker_issue_identifier_key(mapping.issue_id())
+		|| mapping.provenance().source() != WORKTREE_PROVENANCE_RUNTIME_RECORDED
+	{
+		return Ok(false);
+	}
+	if state_store.issue_has_active_shared_claim(project.service_id(), mapping.issue_id())? {
+		return Ok(false);
+	}
+	if state_store.issue_has_review_lifecycle_record(project.service_id(), mapping.issue_id())?
+		|| state_store.issue_has_review_policy_checkpoint(project.service_id(), mapping.issue_id())?
+	{
+		return Ok(false);
+	}
+	if mapping.worktree_path().try_exists()? {
+		return Ok(false);
+	}
+
+	let Some(attempt) = state_store.latest_run_attempt_for_issue(mapping.issue_id())? else {
+		return Ok(false);
+	};
+
+	Ok(local_run_attempt_status_is_terminal(attempt.status()))
 }
 
 fn run_configured_cycle(
@@ -198,7 +231,27 @@ where
 	T: IssueTracker,
 	I: PullRequestReviewStateInspector,
 {
-	let worktrees = state_store.list_worktrees(project.service_id())?;
+	let active_issue_ids = state_store
+		.list_active_shared_leases(project.service_id())?
+		.into_iter()
+		.map(|lease| lease.issue_id().to_owned())
+		.collect::<HashSet<_>>();
+	let worktrees = state_store
+		.list_worktrees(project.service_id())?
+		.into_iter()
+		.filter_map(|mapping| {
+			match worktree_mapping_is_stale_terminal_local_residue(
+				project,
+				state_store,
+				&mapping,
+				&active_issue_ids,
+			) {
+				Ok(true) => None,
+				Ok(false) => Some(Ok(mapping)),
+				Err(error) => Some(Err(error)),
+			}
+		})
+		.collect::<Result<Vec<_>>>()?;
 
 	if worktrees.is_empty() {
 		return Ok(());
@@ -2636,7 +2689,13 @@ where
 	T: IssueTracker,
 {
 	let leases = state_store.list_leases(project.service_id())?;
-	let worktrees = state_store.list_worktrees(project.service_id())?;
+	let mut worktrees = state_store.list_worktrees(project.service_id())?;
+
+	if leases.is_empty() && worktrees.is_empty() {
+		return Ok(());
+	}
+
+	clear_stale_terminal_local_worktree_mappings(project, state_store, &leases, &mut worktrees)?;
 
 	if leases.is_empty() && worktrees.is_empty() {
 		return Ok(());
@@ -2694,6 +2753,67 @@ where
 	)?;
 
 	Ok(())
+}
+
+fn clear_stale_terminal_local_worktree_mappings(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	leases: &[IssueLease],
+	worktrees: &mut Vec<WorktreeMapping>,
+) -> Result<()> {
+	let active_issue_ids = leases
+		.iter()
+		.map(|lease| lease.issue_id().to_owned())
+		.collect::<HashSet<_>>();
+	let mut cleared_issue_ids = Vec::new();
+
+	for mapping in worktrees.iter() {
+		if !worktree_mapping_is_stale_terminal_local_residue(
+			project,
+			state_store,
+			mapping,
+			&active_issue_ids,
+		)? {
+			continue;
+		}
+
+		state_store.clear_worktree(mapping.issue_id())?;
+
+		tracing::info!(
+			project_id = project.service_id(),
+			issue_id = mapping.issue_id(),
+			provenance_source = mapping.provenance().source(),
+			"Cleared stale terminal local worktree mapping before tracker refresh."
+		);
+
+		cleared_issue_ids.push(mapping.issue_id().to_owned());
+	}
+
+	if !cleared_issue_ids.is_empty() {
+		worktrees.retain(|mapping| !cleared_issue_ids.iter().any(|issue_id| issue_id == mapping.issue_id()));
+	}
+
+	Ok(())
+}
+
+fn looks_like_tracker_issue_identifier_key(value: &str) -> bool {
+	let Some((prefix, number)) = value.rsplit_once('-') else {
+		return false;
+	};
+
+	!prefix.is_empty()
+		&& !number.is_empty()
+		&& prefix
+			.chars()
+			.all(|character| character.is_ascii_uppercase() || character.is_ascii_digit())
+		&& number.chars().all(|character| character.is_ascii_digit())
+}
+
+fn local_run_attempt_status_is_terminal(status: &str) -> bool {
+	matches!(
+		status,
+		"succeeded" | "failed" | "interrupted" | "terminated" | TERMINAL_GUARDED_RUN_STATUS
+	)
 }
 
 fn reconcile_active_project_leases<T>(

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -1272,6 +1272,8 @@ fn hydrate_live_operator_external_observers<T>(
 where
 	T: IssueTracker,
 {
+	let stale_terminal_local_issue_ids =
+		stale_terminal_local_issue_ids(context.project, context.state_store)?;
 	let mut paused =
 		pause_operator_snapshot_for_stored_tracker_backoff(&context, snapshot)?;
 
@@ -1283,6 +1285,7 @@ where
 				context.workflow,
 				snapshot,
 				context.run_issue_metadata_hydration,
+				&stale_terminal_local_issue_ids,
 			),
 			snapshot,
 			context.state_store,
@@ -1292,7 +1295,12 @@ where
 	}
 	if !paused && context.hydrate_history_ledger {
 		paused = apply_tracker_observer_outcome(
-			hydrate_history_lanes_from_linear_ledger(context.tracker, context.project, snapshot),
+			hydrate_history_lanes_from_linear_ledger(
+				context.tracker,
+				context.project,
+				snapshot,
+				&stale_terminal_local_issue_ids,
+			),
 			snapshot,
 			context.state_store,
 			context.project,
@@ -2499,10 +2507,15 @@ fn operator_status_worktrees(
 	Vec<String>,
 	Vec<OperatorSnapshotWarningDetail>,
 )> {
-	let mut worktrees = state_store
-		.list_worktrees(project.service_id())?
-		.into_iter()
-		.map(|mapping| OperatorWorktreeStatus {
+	let skipped_terminal_local_issue_ids = stale_terminal_local_issue_ids(project, state_store)?;
+	let mut worktrees = Vec::new();
+
+	for mapping in state_store.list_worktrees(project.service_id())? {
+		if skipped_terminal_local_issue_ids.contains(mapping.issue_id()) {
+			continue;
+		}
+
+		worktrees.push(OperatorWorktreeStatus {
 			project_id: project.service_id().to_owned(),
 			issue_id: mapping.issue_id().to_owned(),
 			issue_identifier: issue_identifier_in_text(mapping.branch_name())
@@ -2517,12 +2530,24 @@ fn operator_status_worktrees(
 			provenance: operator_worktree_provenance_from_mapping(&mapping),
 			recovery_next_action: None,
 			hygiene: None,
-		})
-		.collect::<Vec<_>>();
+		});
+	}
+
 	let mut seen_paths =
 		worktrees.iter().map(|worktree| worktree.worktree_path.clone()).collect::<HashSet<_>>();
 	let mut warnings = Vec::new();
 	let mut warning_details = Vec::new();
+	let mut skipped_terminal_local_issue_ids =
+		skipped_terminal_local_issue_ids.into_iter().collect::<Vec<_>>();
+
+	skipped_terminal_local_issue_ids.sort();
+
+	append_stale_terminal_local_mapping_warning(
+		project,
+		&skipped_terminal_local_issue_ids,
+		&mut warnings,
+		&mut warning_details,
+	);
 
 	for issue_identifier in recoverable_worktree_identifiers(project.worktree_root())? {
 		let worktree_path = project.worktree_root().join(&issue_identifier);
@@ -2574,6 +2599,66 @@ fn operator_status_worktrees(
 	});
 
 	Ok((worktrees, warnings, warning_details))
+}
+
+fn active_shared_issue_ids(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+) -> crate::prelude::Result<HashSet<String>> {
+	Ok(state_store
+		.list_active_shared_leases(project.service_id())?
+		.into_iter()
+		.map(|lease| lease.issue_id().to_owned())
+		.collect())
+}
+
+fn stale_terminal_local_issue_ids(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+) -> crate::prelude::Result<HashSet<String>> {
+	let active_issue_ids = active_shared_issue_ids(project, state_store)?;
+	let mut issue_ids = HashSet::new();
+
+	for mapping in state_store.list_worktrees(project.service_id())? {
+		if worktree_mapping_is_stale_terminal_local_residue(
+			project,
+			state_store,
+			&mapping,
+			&active_issue_ids,
+		)? {
+			issue_ids.insert(mapping.issue_id().to_owned());
+		}
+	}
+
+	Ok(issue_ids)
+}
+
+fn append_stale_terminal_local_mapping_warning(
+	project: &ServiceConfig,
+	issue_ids: &[String],
+	warnings: &mut Vec<String>,
+	warning_details: &mut Vec<OperatorSnapshotWarningDetail>,
+) {
+	if issue_ids.is_empty() {
+		return;
+	}
+
+	let warning = String::from("stale_terminal_local_worktree_mapping_ignored");
+
+	warnings.push(warning.clone());
+	warning_details.push(OperatorSnapshotWarningDetail {
+		warning,
+		project_id: Some(project.service_id().to_owned()),
+		repo_root: None,
+		reason: format!(
+			"ignored {} terminal unleased runtime-recorded worktree mapping(s) with identifier-style issue ids and missing paths: {}",
+			issue_ids.len(),
+			issue_ids.join(", ")
+		),
+		next_action: Some(String::from(
+			"no recovery worktree action is required; project reconciliation clears this stale local mapping before tracker refresh",
+		)),
+	});
 }
 
 fn append_merged_worktree_cleanup_debts(
@@ -2797,11 +2882,16 @@ fn hydrate_operator_run_rows_from_tracker<T>(
 	workflow: &WorkflowDocument,
 	snapshot: &mut OperatorStatusSnapshot,
 	hydration: RunIssueMetadataHydration,
+	stale_terminal_local_issue_ids: &HashSet<String>,
 ) -> TrackerObserverOutcome
 where
 	T: IssueTracker,
 {
-	let issue_ids = operator_snapshot_run_issue_ids(snapshot, hydration);
+	let issue_ids = operator_snapshot_run_issue_ids(
+		snapshot,
+		hydration,
+		stale_terminal_local_issue_ids,
+	);
 
 	if issue_ids.is_empty() {
 		return TrackerObserverOutcome::Ok;
@@ -2913,22 +3003,31 @@ where
 fn operator_snapshot_run_issue_ids(
 	snapshot: &OperatorStatusSnapshot,
 	hydration: RunIssueMetadataHydration,
+	stale_terminal_local_issue_ids: &HashSet<String>,
 ) -> Vec<String> {
 	let mut issue_ids = BTreeSet::new();
 
 	for run in &snapshot.current_lanes {
-		append_operator_run_issue_id(&mut issue_ids, run);
+		append_operator_run_issue_id(&mut issue_ids, run, stale_terminal_local_issue_ids);
 	}
 
 	if matches!(hydration, RunIssueMetadataHydration::AllRows) {
 		for run in &snapshot.recent_runs {
-			append_operator_run_issue_id(&mut issue_ids, run);
+			append_operator_run_issue_id(&mut issue_ids, run, stale_terminal_local_issue_ids);
 		}
 		for lane in &snapshot.history_lanes {
-			append_operator_run_issue_id(&mut issue_ids, &lane.latest_run);
+			append_operator_run_issue_id(
+				&mut issue_ids,
+				&lane.latest_run,
+				stale_terminal_local_issue_ids,
+			);
 
 			for attempt in &lane.attempts {
-				append_operator_run_issue_id(&mut issue_ids, attempt);
+				append_operator_run_issue_id(
+					&mut issue_ids,
+					attempt,
+					stale_terminal_local_issue_ids,
+				);
 			}
 		}
 	}
@@ -2936,12 +3035,34 @@ fn operator_snapshot_run_issue_ids(
 	issue_ids.into_iter().collect()
 }
 
-fn append_operator_run_issue_id(issue_ids: &mut BTreeSet<String>, run: &OperatorRunStatus) {
+fn append_operator_run_issue_id(
+	issue_ids: &mut BTreeSet<String>,
+	run: &OperatorRunStatus,
+	stale_terminal_local_issue_ids: &HashSet<String>,
+) {
+	if operator_run_is_stale_terminal_local_residue(run, stale_terminal_local_issue_ids) {
+		return;
+	}
+
 	let issue_id = run.issue_id.trim();
 
 	if !issue_id.is_empty() && !issue_id.eq_ignore_ascii_case("unknown") {
 		issue_ids.insert(issue_id.to_owned());
 	}
+}
+
+fn operator_run_is_terminal_unleased_identifier(run: &OperatorRunStatus) -> bool {
+	!run.run_lease
+		&& looks_like_tracker_issue_identifier_key(&run.issue_id)
+		&& local_run_attempt_status_is_terminal(&run.attempt_status)
+}
+
+fn operator_run_is_stale_terminal_local_residue(
+	run: &OperatorRunStatus,
+	stale_terminal_local_issue_ids: &HashSet<String>,
+) -> bool {
+	operator_run_is_terminal_unleased_identifier(run)
+		&& stale_terminal_local_issue_ids.contains(run.issue_id.trim())
 }
 
 fn hydrate_operator_snapshot_run_rows(
@@ -3755,6 +3876,7 @@ fn hydrate_history_lanes_from_linear_ledger<T>(
 	tracker: &T,
 	project: &ServiceConfig,
 	snapshot: &mut OperatorStatusSnapshot,
+	stale_terminal_local_issue_ids: &HashSet<String>,
 ) -> TrackerObserverOutcome
 where
 	T: IssueTracker,
@@ -3762,6 +3884,15 @@ where
 	let mut unavailable = false;
 
 	for lane in &mut snapshot.history_lanes {
+		if operator_run_is_stale_terminal_local_residue(
+			&lane.latest_run,
+			stale_terminal_local_issue_ids,
+		) {
+			lane.ledger_outcome = stale_terminal_local_history_ledger_outcome();
+
+			continue;
+		}
+
 		match tracker.list_comments(&lane.issue_id) {
 			Ok(comments) => {
 				let records =
@@ -4082,6 +4213,27 @@ fn unavailable_history_ledger_outcome() -> OperatorHistoryLedgerOutcome {
 		final_event_at: None,
 		summary: Some(String::from(
 			"Linear execution ledger records could not be loaded for this issue.",
+		)),
+		pr_url: None,
+		commit_sha: None,
+		branch: None,
+		closeout_status: None,
+		needs_attention_reason: None,
+		lifecycle_started_at: None,
+		lifecycle_finished_at: None,
+		lifecycle_elapsed_seconds: None,
+		record_count: 0,
+	}
+}
+
+fn stale_terminal_local_history_ledger_outcome() -> OperatorHistoryLedgerOutcome {
+	OperatorHistoryLedgerOutcome {
+		ledger_status: String::from("local_terminal_residue"),
+		final_outcome: String::from("local_terminal_residue"),
+		final_event_type: None,
+		final_event_at: None,
+		summary: Some(String::from(
+			"Linear ledger lookup skipped for terminal unleased local residue with an identifier-style issue id.",
 		)),
 		pr_url: None,
 		commit_sha: None,
@@ -4868,7 +5020,23 @@ fn load_post_review_worktree_issues<T>(
 where
 	T: IssueTracker,
 {
-	let worktrees = state_store.list_worktrees(project.service_id())?;
+	let active_issue_ids = active_shared_issue_ids(project, state_store)?;
+	let worktrees = state_store
+		.list_worktrees(project.service_id())?
+		.into_iter()
+		.filter_map(|mapping| {
+			match worktree_mapping_is_stale_terminal_local_residue(
+				project,
+				state_store,
+				&mapping,
+				&active_issue_ids,
+			) {
+				Ok(true) => None,
+				Ok(false) => Some(Ok(mapping)),
+				Err(error) => Some(Err(error)),
+			}
+		})
+		.collect::<crate::prelude::Result<Vec<_>>>()?;
 
 	if worktrees.is_empty() {
 		return Ok(Vec::new());
@@ -6574,12 +6742,21 @@ where
 {
 	let worktree_manager =
 		WorktreeManager::new(project.service_id(), project.repo_root(), project.worktree_root());
-	let mut issue_ids = state_store
-		.list_worktrees(project.service_id())?
-		.into_iter()
-		.map(|mapping| mapping.issue_id().to_owned())
-		.collect::<Vec<_>>();
+	let active_issue_ids = active_shared_issue_ids(project, state_store)?;
+	let mut issue_ids = Vec::new();
 
+	for mapping in state_store.list_worktrees(project.service_id())? {
+		if worktree_mapping_is_stale_terminal_local_residue(
+			project,
+			state_store,
+			&mapping,
+			&active_issue_ids,
+		)? {
+			continue;
+		}
+
+		issue_ids.push(mapping.issue_id().to_owned());
+	}
 	for lease in state_store.list_active_shared_leases(project.service_id())? {
 		if !issue_ids.iter().any(|issue_id| issue_id == lease.issue_id()) {
 			issue_ids.push(lease.issue_id().to_owned());

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -158,6 +158,204 @@ fn live_operator_status_classifies_invalid_local_issue_id_as_ghost_lane() {
 }
 
 #[test]
+fn live_operator_status_ignores_terminal_identifier_worktree_mapping_without_tracker_refresh() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let tracker = FakeTracker::new(Vec::new());
+	let stale_issue_id = "PUB-001";
+	let missing_worktree_path = config.worktree_root().join(stale_issue_id);
+
+	state_store
+		.record_run_attempt("run-01", stale_issue_id, 1, TERMINAL_GUARDED_RUN_STATUS)
+		.expect("terminal run attempt should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			stale_issue_id,
+			"x/pubfi-pub-001",
+			&missing_worktree_path.display().to_string(),
+		)
+		.expect("stale worktree mapping should record");
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let rendered = orchestrator::render_operator_status(&snapshot);
+	let history_lane = snapshot.history_lanes.first().expect("terminal history lane should render");
+
+	assert!(snapshot.worktrees.is_empty());
+	assert!(snapshot.warnings.contains(&String::from(
+		"stale_terminal_local_worktree_mapping_ignored"
+	)));
+	assert_eq!(history_lane.issue_id, stale_issue_id);
+	assert_eq!(history_lane.ledger_outcome.ledger_status, "local_terminal_residue");
+	assert_eq!(history_lane.ledger_outcome.final_outcome, "local_terminal_residue");
+	assert!(
+		tracker
+			.refresh_queries
+			.borrow()
+			.iter()
+			.flatten()
+			.all(|issue_id| issue_id != stale_issue_id),
+		"terminal local identifier id must not be sent to tracker refresh"
+	);
+	assert!(
+		tracker.comment_queries.borrow().iter().all(|issue_id| issue_id != stale_issue_id),
+		"terminal local identifier id must not be used for Linear ledger lookup"
+	);
+	assert!(rendered.contains("Recovery worktrees: 0"));
+	assert!(rendered.contains("stale_terminal_local_worktree_mapping_ignored"));
+	assert!(!rendered.contains("execution_ledger_status_unavailable"));
+}
+
+#[test]
+fn live_operator_status_hydrates_terminal_identifier_history_with_review_checkpoint() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let protected_issue_id = "PUB-001";
+	let issue = sample_issue_with_sort_fields(
+		protected_issue_id,
+		protected_issue_id,
+		"In Review",
+		&[],
+		Some(1),
+		"2026-06-19T00:00:00.000Z",
+	);
+	let tracker = FakeTracker::new(vec![issue]);
+	let missing_worktree_path = config.worktree_root().join(protected_issue_id);
+
+	state_store
+		.record_run_attempt("run-01", protected_issue_id, 1, TERMINAL_GUARDED_RUN_STATUS)
+		.expect("terminal run attempt should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			protected_issue_id,
+			"x/pubfi-pub-001",
+			&missing_worktree_path.display().to_string(),
+		)
+		.expect("worktree mapping should record");
+	state_store
+		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
+			project_id: TEST_SERVICE_ID,
+			issue_id: protected_issue_id,
+			run_id: "run-01",
+			attempt_number: 1,
+			phase: "handoff",
+			review_level: config.codex().review_level().as_str(),
+			status: "clean",
+			head_sha: "2222222222222222222222222222222222222222",
+			nonclean_rounds: 0,
+			details_json: "{}",
+		})
+		.expect("review checkpoint should record");
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let history_lane = snapshot.history_lanes.first().expect("terminal history lane should render");
+
+	assert!(
+		!snapshot
+			.warnings
+			.contains(&String::from("stale_terminal_local_worktree_mapping_ignored")),
+		"review-authority mappings must not be classified as local residue"
+	);
+	assert!(
+		snapshot.worktrees.iter().any(|worktree| worktree.issue_id == protected_issue_id),
+		"review-authority worktree mapping must remain visible"
+	);
+	assert_ne!(history_lane.ledger_outcome.ledger_status, "local_terminal_residue");
+	assert!(
+		tracker
+			.refresh_queries
+			.borrow()
+			.iter()
+			.flatten()
+			.any(|issue_id| issue_id == protected_issue_id),
+		"review-authority terminal identifier id must still be sent to tracker refresh"
+	);
+	assert!(
+		tracker.comment_queries.borrow().iter().any(|issue_id| issue_id == protected_issue_id),
+		"review-authority terminal identifier id must still be used for Linear ledger lookup"
+	);
+}
+
+#[test]
+fn live_operator_status_hydrates_active_terminal_identifier_lane() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let active_issue_id = "PUB-001";
+	let issue = sample_issue_with_sort_fields(
+		active_issue_id,
+		active_issue_id,
+		"In Progress",
+		&[crate::tracker::automation_active_label(config.service_id()).as_str()],
+		Some(1),
+		"2026-06-19T00:00:00.000Z",
+	);
+	let tracker = FakeTracker::new(vec![issue]);
+	let missing_worktree_path = config.worktree_root().join(active_issue_id);
+
+	state_store
+		.record_run_attempt("run-01", active_issue_id, 1, TERMINAL_GUARDED_RUN_STATUS)
+		.expect("terminal run attempt should record");
+	state_store
+		.upsert_lease("pubfi", active_issue_id, "run-01", "In Progress")
+		.expect("active lease should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			active_issue_id,
+			"x/pubfi-pub-001",
+			&missing_worktree_path.display().to_string(),
+		)
+		.expect("active worktree mapping should record");
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let history_lane = snapshot.history_lanes.first().expect("terminal history lane should render");
+
+	assert_eq!(history_lane.issue_id, active_issue_id);
+	assert_ne!(history_lane.ledger_outcome.ledger_status, "local_terminal_residue");
+	assert!(
+		!snapshot
+			.warnings
+			.contains(&String::from("stale_terminal_local_worktree_mapping_ignored")),
+		"active lanes must not be classified as local residue"
+	);
+	assert!(
+		tracker
+			.refresh_queries
+			.borrow()
+			.iter()
+			.flatten()
+			.any(|issue_id| issue_id == active_issue_id),
+		"active terminal identifier id must still be sent to tracker refresh"
+	);
+	assert!(
+		tracker.comment_queries.borrow().iter().any(|issue_id| issue_id == active_issue_id),
+		"active terminal identifier id must still be used for Linear ledger lookup"
+	);
+}
+
+#[test]
 fn live_operator_status_allows_ghost_recovery_when_worktree_mapping_path_is_missing() {
 	let (_temp_dir, config, workflow) = temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");

--- a/apps/decodex/src/orchestrator/tests/recovery/reconciliation.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery/reconciliation.rs
@@ -1744,6 +1744,148 @@ fn project_reconciliation_schedules_retry_for_orphaned_active_worktree_run() {
 }
 
 #[test]
+fn project_reconciliation_clears_terminal_identifier_worktree_before_tracker_refresh() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let tracker = FakeTracker::new(Vec::new());
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let worktree_manager =
+		WorktreeManager::new("pubfi", config.repo_root(), config.worktree_root());
+	let stale_issue_id = "PUB-001";
+	let stale_worktree_path = config.worktree_root().join(stale_issue_id);
+
+	state_store
+		.record_run_attempt("run-01", stale_issue_id, 1, TERMINAL_GUARDED_RUN_STATUS)
+		.expect("terminal run attempt should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			stale_issue_id,
+			"x/pubfi-pub-001",
+			&stale_worktree_path.display().to_string(),
+		)
+		.expect("stale worktree mapping should record");
+
+	orchestrator::reconcile_project_state(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		&worktree_manager,
+	)
+	.expect("project reconciliation should succeed");
+
+	assert!(
+		state_store
+			.worktree_for_issue(stale_issue_id)
+			.expect("worktree lookup should succeed")
+			.is_none(),
+		"terminal unleased identifier mapping should be cleared before tracker refresh"
+	);
+	assert!(
+		tracker
+			.refresh_queries
+			.borrow()
+			.iter()
+			.flatten()
+			.all(|issue_id| issue_id != stale_issue_id),
+		"stale local identifier id must not be sent to tracker refresh"
+	);
+}
+
+#[test]
+fn project_reconciliation_preserves_terminal_identifier_worktree_with_review_authority() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let stale_issue_id = "PUB-001";
+	let branch_name = "x/pubfi-pub-001";
+	let issue = sample_issue_with_sort_fields(
+		stale_issue_id,
+		stale_issue_id,
+		"In Review",
+		&[],
+		Some(1),
+		"2026-06-19T00:00:00.000Z",
+	);
+	let tracker = FakeTracker::new(vec![issue]);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let worktree_manager =
+		WorktreeManager::new("pubfi", config.repo_root(), config.worktree_root());
+	let stale_worktree_path = config.worktree_root().join(stale_issue_id);
+
+	state_store
+		.record_run_attempt("run-01", stale_issue_id, 1, TERMINAL_GUARDED_RUN_STATUS)
+		.expect("terminal run attempt should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			stale_issue_id,
+			branch_name,
+			&stale_worktree_path.display().to_string(),
+		)
+		.expect("stale worktree mapping should record");
+
+	seed_review_handoff_marker(
+		&state_store,
+		config.service_id(),
+		stale_issue_id,
+		branch_name,
+		"https://github.com/example/decodex/pull/1016",
+		"head-oid",
+	);
+
+	state_store
+		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
+			project_id: config.service_id(),
+			issue_id: stale_issue_id,
+			run_id: "run-01",
+			attempt_number: 1,
+			phase: "handoff",
+			review_level: "independent",
+			status: "clean",
+			head_sha: "head-oid",
+			nonclean_rounds: 0,
+			details_json: "{}",
+		})
+		.expect("review checkpoint should record");
+
+	orchestrator::reconcile_project_state(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		&worktree_manager,
+	)
+	.expect("project reconciliation should preserve review authority");
+
+	assert!(
+		state_store
+			.worktree_for_issue(stale_issue_id)
+			.expect("worktree lookup should succeed")
+			.is_some(),
+		"review-owned identifier mapping must not be cleared as stale residue"
+	);
+	assert!(
+		state_store
+			.review_handoff_marker(config.service_id(), stale_issue_id, branch_name)
+			.expect("review handoff lookup should succeed")
+			.is_some(),
+		"review lifecycle authority must be preserved"
+	);
+	assert!(
+		state_store
+			.review_policy_checkpoint(
+				config.service_id(),
+				stale_issue_id,
+				"run-01",
+				1,
+				"handoff",
+			)
+			.expect("review checkpoint lookup should succeed")
+			.is_some(),
+		"review checkpoint authority must be preserved"
+	);
+}
+
+#[test]
 fn project_reconciliation_marks_orphaned_attention_worktree_run_stalled_without_tracker_writes() {
 	let (_temp_dir, config, workflow) = temp_project_layout();
 	let issue = sample_issue("Todo", &["decodex:needs-attention"]);

--- a/apps/decodex/src/orchestrator/tests/review_landing/orchestration.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing/orchestration.rs
@@ -87,6 +87,53 @@ fn reconcile_post_review_orchestration_requests_external_review_without_thumbs_u
 }
 
 #[test]
+fn reconcile_post_review_orchestration_filters_terminal_identifier_worktree_before_tracker_refresh()
+{
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let repo_root = config.repo_root().to_path_buf();
+	let issue = post_review_sample_service_owned_issue("Todo");
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let stale_issue_id = "PUB-001";
+	let stale_worktree_path = config.worktree_root().join(stale_issue_id);
+
+	state_store
+		.record_run_attempt("run-01", stale_issue_id, 1, TERMINAL_GUARDED_RUN_STATUS)
+		.expect("terminal run attempt should record");
+	state_store
+		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
+		.expect("valid worktree should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			stale_issue_id,
+			"x/pubfi-pub-001",
+			&stale_worktree_path.display().to_string(),
+		)
+		.expect("stale worktree mapping should record");
+
+	orchestrator::reconcile_post_review_orchestration_with_inspector(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		&FakePullRequestReviewStateInspector::new(Vec::new()),
+	)
+	.expect("post-review orchestration should ignore stale terminal local residue");
+
+	let refresh_queries = tracker.refresh_queries.borrow();
+
+	assert!(
+		refresh_queries.iter().flatten().any(|issue_id| issue_id == &issue.id),
+		"valid worktree issue id should still be sent to tracker refresh"
+	);
+	assert!(
+		refresh_queries.iter().flatten().all(|issue_id| issue_id != stale_issue_id),
+		"terminal local identifier residue must not be sent to post-review tracker refresh"
+	);
+}
+
+#[test]
 fn reconcile_post_review_orchestration_uses_matching_handoff_record_for_current_branch() {
 	let (temp_dir, config, workflow) = temp_project_layout();
 	let config = service_config_with_github_token_env_var(&config, "PATH");

--- a/apps/decodex/src/recovery.rs
+++ b/apps/decodex/src/recovery.rs
@@ -1,7 +1,7 @@
 //! Explicit operator recovery surfaces for retained Decodex lanes.
 
 use std::{
-	collections::{BTreeSet, HashMap},
+	collections::{BTreeSet, HashMap, HashSet},
 	env, fs,
 	path::{Path, PathBuf},
 	process::Command,
@@ -39,6 +39,7 @@ const REVIEW_HANDOFF_OWNERSHIP_DRIFT_CLASSIFICATION: &str = "review_handoff_owne
 const REVIEW_HANDOFF_REBIND_REQUIRED_CLASSIFICATION: &str = "review_handoff_rebind_required";
 const REVIEW_HANDOFF_UNVERIFIED_CLASSIFICATION: &str = "review_handoff_unverified";
 const REVIEW_HANDOFF_MISMATCH_CLASSIFICATION: &str = "review_handoff_mismatch";
+const REVIEW_HANDOFF_STALE_TERMINAL_RESIDUE_CLASSIFICATION: &str = "stale_terminal_local_residue";
 const REVIEW_HANDOFF_REBIND_EVENT: &str = "review_handoff_rebind";
 const REVIEW_HANDOFF_ADOPT_EVENT: &str = "review_handoff_adopt";
 const LEGACY_MANUAL_CLOSEOUT_EVENT: &str = "closeout";
@@ -914,21 +915,31 @@ fn resolve_recovery_config_path(
 fn diagnose_all_retained_review_worktrees(
 	context: &RecoveryContext,
 ) -> Result<Vec<ReviewHandoffDiagnostic>> {
-	let worktrees = context.state_store.list_worktrees(context.config.service_id())?;
+	diagnose_all_retained_review_worktrees_with_tracker(context, &context.tracker)
+}
 
-	if worktrees.is_empty() {
-		return Ok(Vec::new());
+fn diagnose_all_retained_review_worktrees_with_tracker<T>(
+	context: &RecoveryContext,
+	tracker: &T,
+) -> Result<Vec<ReviewHandoffDiagnostic>>
+where
+	T: IssueTracker,
+{
+	let mut worktrees = Vec::new();
+	let mut diagnostics = Vec::new();
+
+	for worktree in context.state_store.list_worktrees(context.config.service_id())? {
+		if retained_review_worktree_is_stale_terminal_residue(context, &worktree)? {
+			diagnostics.push(stale_terminal_residue_review_handoff_diagnostic(context, &worktree));
+		} else {
+			worktrees.push(worktree);
+		}
 	}
 
-	let issue_ids =
-		worktrees.iter().map(|worktree| worktree.issue_id().to_owned()).collect::<Vec<_>>();
-	let issues = context.tracker.refresh_issues(&issue_ids)?;
-	let issues_by_id =
-		issues.into_iter().map(|issue| (issue.id.clone(), issue)).collect::<HashMap<_, _>>();
+	let issues_by_id = refresh_retained_review_worktree_issues(tracker, &worktrees)?;
 	let tracker_policy = context.workflow.frontmatter().tracker();
 	let success_state = tracker_policy.success_state();
 	let in_progress_state = tracker_policy.in_progress_state();
-	let mut diagnostics = Vec::new();
 
 	for worktree in worktrees {
 		let Some(issue) = issues_by_id.get(worktree.issue_id()).cloned() else {
@@ -945,16 +956,117 @@ fn diagnose_all_retained_review_worktrees(
 	Ok(diagnostics)
 }
 
+fn retained_review_worktree_is_stale_terminal_residue(
+	context: &RecoveryContext,
+	worktree: &WorktreeMapping,
+) -> Result<bool> {
+	let active_issue_ids = context
+		.state_store
+		.list_active_shared_leases(context.config.service_id())?
+		.into_iter()
+		.map(|lease| lease.issue_id().to_owned())
+		.collect::<HashSet<_>>();
+
+	orchestrator::worktree_mapping_is_stale_terminal_local_residue(
+		&context.config,
+		&context.state_store,
+		worktree,
+		&active_issue_ids,
+	)
+}
+
+fn stale_terminal_residue_review_handoff_diagnostic(
+	context: &RecoveryContext,
+	worktree: &WorktreeMapping,
+) -> ReviewHandoffDiagnostic {
+	ReviewHandoffDiagnostic {
+		project_id: context.config.service_id().to_owned(),
+		issue_id: worktree.issue_id().to_owned(),
+		issue_identifier: worktree.issue_id().to_owned(),
+		issue_state: String::from("local_terminal_residue"),
+		classification: String::from(REVIEW_HANDOFF_STALE_TERMINAL_RESIDUE_CLASSIFICATION),
+		reason: String::from(
+			"terminal_unleased_runtime_recorded_identifier_mapping_with_missing_path",
+		),
+		branch_name: worktree.branch_name().to_owned(),
+		worktree_path: worktree.worktree_path().display().to_string(),
+		local_branch_name: None,
+		local_head_oid: None,
+		worktree_clean: None,
+		existing_pr_url: None,
+		existing_lifecycle_handoff_head_oid: None,
+		existing_lifecycle_phase_head_oid: None,
+		pr_base_ref: None,
+		pr_head_oid: None,
+		mismatched_field: None,
+		active_label_present: None,
+		next_action: String::from(
+			"No review-handoff recovery action is required; project reconciliation clears this stale local mapping before tracker refresh.",
+		),
+	}
+}
+
+fn refresh_retained_review_worktree_issues<T>(
+	tracker: &T,
+	worktrees: &[WorktreeMapping],
+) -> Result<HashMap<String, TrackerIssue>>
+where
+	T: IssueTracker,
+{
+	if worktrees.is_empty() {
+		return Ok(HashMap::new());
+	}
+
+	let issue_ids =
+		worktrees.iter().map(|worktree| worktree.issue_id().to_owned()).collect::<Vec<_>>();
+
+	Ok(tracker
+		.refresh_issues(&issue_ids)?
+		.into_iter()
+		.map(|issue| (issue.id.clone(), issue))
+		.collect())
+}
+
 fn diagnose_issue(
 	context: &RecoveryContext,
 	issue_identifier: &str,
 ) -> Result<ReviewHandoffDiagnostic> {
-	let issue = load_issue_by_identifier(&context.tracker, issue_identifier)?;
+	diagnose_issue_with_tracker(context, &context.tracker, issue_identifier)
+}
+
+fn diagnose_issue_with_tracker<T>(
+	context: &RecoveryContext,
+	tracker: &T,
+	issue_identifier: &str,
+) -> Result<ReviewHandoffDiagnostic>
+where
+	T: IssueTracker,
+{
+	if let Some(worktree) = stale_terminal_residue_worktree_for_issue(context, issue_identifier)? {
+		return Ok(stale_terminal_residue_review_handoff_diagnostic(context, &worktree));
+	}
+
+	let issue = load_issue_by_identifier(tracker, issue_identifier)?;
 	let worktree = context.state_store.worktree_for_issue(&issue.id)?.ok_or_else(|| {
 		eyre::eyre!("Issue `{}` has no retained worktree mapping.", issue.identifier)
 	})?;
 
 	diagnose_issue_worktree(context, issue, worktree)
+}
+
+fn stale_terminal_residue_worktree_for_issue(
+	context: &RecoveryContext,
+	issue_identifier: &str,
+) -> Result<Option<WorktreeMapping>> {
+	let Some(worktree) = context.state_store.worktree_for_issue(issue_identifier)? else {
+		return Ok(None);
+	};
+
+	if retained_review_worktree_is_stale_terminal_residue(context, &worktree)? {
+		Ok(Some(worktree))
+	} else {
+		Ok(None)
+	}
 }
 
 fn diagnose_issue_worktree(
@@ -4429,7 +4541,7 @@ fn relative_worktree_path_for_recovery(
 
 #[cfg(test)]
 mod tests {
-	use std::{fs, path::Path};
+	use std::{cell::RefCell, fs, path::Path};
 
 	use tempfile::TempDir;
 
@@ -4460,10 +4572,16 @@ mod tests {
 		issues: Vec<TrackerIssue>,
 		refresh_error: Option<String>,
 		identifier_error: Option<String>,
+		refresh_queries: RefCell<Vec<Vec<String>>>,
 	}
 	impl GhostLaneTestTracker {
 		fn missing() -> Self {
-			Self { issues: Vec::new(), refresh_error: None, identifier_error: None }
+			Self {
+				issues: Vec::new(),
+				refresh_error: None,
+				identifier_error: None,
+				refresh_queries: RefCell::new(Vec::new()),
+			}
 		}
 
 		fn refresh_error(message: &str) -> Self {
@@ -4471,6 +4589,7 @@ mod tests {
 				issues: Vec::new(),
 				refresh_error: Some(message.to_owned()),
 				identifier_error: None,
+				refresh_queries: RefCell::new(Vec::new()),
 			}
 		}
 
@@ -4479,6 +4598,7 @@ mod tests {
 				issues: Vec::new(),
 				refresh_error: None,
 				identifier_error: Some(message.to_owned()),
+				refresh_queries: RefCell::new(Vec::new()),
 			}
 		}
 	}
@@ -4517,6 +4637,8 @@ mod tests {
 			&self,
 			issue_ids: &[String],
 		) -> crate::prelude::Result<Vec<TrackerIssue>> {
+			self.refresh_queries.borrow_mut().push(issue_ids.to_vec());
+
 			if let Some(message) = &self.refresh_error {
 				return Err(crate::prelude::eyre::eyre!(message.clone()));
 			}
@@ -4888,6 +5010,87 @@ token_env_var = "HOME"
 				.expect("backoff should read")
 				.is_none(),
 			"read-only recovery diagnostics must not persist new connector backoff"
+		);
+	}
+
+	#[test]
+	fn review_handoff_diagnose_skips_terminal_identifier_worktree_before_tracker_refresh() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let context =
+			sample_recovery_context(&temp_dir, super::RecoveryRuntimeMutationPolicy::ReadOnly);
+		let tracker = GhostLaneTestTracker::missing();
+		let stale_issue_id = "PUB-001";
+		let stale_worktree_path = context.config.worktree_root().join(stale_issue_id);
+
+		context
+			.state_store
+			.record_run_attempt("run-01", stale_issue_id, 1, super::GHOST_LANE_TERMINAL_STATUS)
+			.expect("terminal attempt should record");
+		context
+			.state_store
+			.upsert_worktree(
+				context.config.service_id(),
+				stale_issue_id,
+				"x/pubfi-pub-001",
+				&stale_worktree_path.display().to_string(),
+			)
+			.expect("stale worktree mapping should record");
+
+		let diagnostics =
+			super::diagnose_all_retained_review_worktrees_with_tracker(&context, &tracker)
+				.expect("retained review diagnostics should build");
+		let diagnostic = diagnostics.first().expect("local residue diagnostic should render");
+
+		assert_eq!(diagnostics.len(), 1);
+		assert_eq!(
+			diagnostic.classification,
+			super::REVIEW_HANDOFF_STALE_TERMINAL_RESIDUE_CLASSIFICATION
+		);
+		assert_eq!(diagnostic.issue_id, stale_issue_id);
+		assert_eq!(diagnostic.issue_state, "local_terminal_residue");
+		assert!(
+			tracker.refresh_queries.borrow().is_empty(),
+			"terminal local identifier residue must not be sent to tracker refresh"
+		);
+	}
+
+	#[test]
+	fn review_handoff_diagnose_targeted_terminal_identifier_worktree_before_tracker_lookup() {
+		let temp_dir = TempDir::new().expect("tempdir should create");
+		let context =
+			sample_recovery_context(&temp_dir, super::RecoveryRuntimeMutationPolicy::ReadOnly);
+		let tracker = GhostLaneTestTracker::identifier_error(
+			"Linear GraphQL request failed: Argument Validation Error",
+		);
+		let stale_issue_id = "PUB-001";
+		let stale_worktree_path = context.config.worktree_root().join(stale_issue_id);
+
+		context
+			.state_store
+			.record_run_attempt("run-01", stale_issue_id, 1, super::GHOST_LANE_TERMINAL_STATUS)
+			.expect("terminal attempt should record");
+		context
+			.state_store
+			.upsert_worktree(
+				context.config.service_id(),
+				stale_issue_id,
+				"x/pubfi-pub-001",
+				&stale_worktree_path.display().to_string(),
+			)
+			.expect("stale worktree mapping should record");
+
+		let diagnostic = super::diagnose_issue_with_tracker(&context, &tracker, stale_issue_id)
+			.expect("targeted retained review diagnostic should classify local residue");
+
+		assert_eq!(
+			diagnostic.classification,
+			super::REVIEW_HANDOFF_STALE_TERMINAL_RESIDUE_CLASSIFICATION
+		);
+		assert_eq!(diagnostic.issue_id, stale_issue_id);
+		assert_eq!(diagnostic.issue_state, "local_terminal_residue");
+		assert!(
+			tracker.refresh_queries.borrow().is_empty(),
+			"targeted terminal local residue must not be sent to tracker refresh"
 		);
 	}
 
@@ -5372,6 +5575,7 @@ token_env_var = "HOME"
 			issues: vec![issue],
 			refresh_error: None,
 			identifier_error: None,
+			refresh_queries: RefCell::new(Vec::new()),
 		};
 
 		store

--- a/apps/decodex/src/state/store.rs
+++ b/apps/decodex/src/state/store.rs
@@ -2957,6 +2957,20 @@ impl StateStore {
 		Ok(state.review_policy_checkpoints.get(&key).map(ReviewPolicyRuntimeRecord::as_public))
 	}
 
+	/// Return whether any bounded-review checkpoint row owns this issue.
+	pub(crate) fn issue_has_review_policy_checkpoint(
+		&self,
+		project_id: &str,
+		issue_id: &str,
+	) -> Result<bool> {
+		let state = self.lock()?;
+
+		Ok(state
+			.review_policy_checkpoints
+			.values()
+			.any(|record| record.project_id == project_id && record.issue_id == issue_id))
+	}
+
 	/// Read the latest review checkpoint by its canonical reusable evidence key.
 	pub(crate) fn review_checkpoint_artifact(
 		&self,

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -384,8 +384,8 @@ protocol activity durable outside the local operator surface.
 | `Program Intake` | Read-only Program Intake and Execution Program progress. It shows each active program's public intake summary, status, mapped issue identifiers, summary counts, dispatchable counts, and sparse node diagnostics for dispatch decisions or held/blocked/stale/attention nodes. It does not expose graph editing, raw node-edge mutation controls, Decision Contract payloads, or private runtime evidence. |
 | `Intake Queue` | Queued tracker issues before execution. Candidates are classified as `ready`, capacity-waiting, claimed without a matching local lane, blocked, or closed/stale. Repeated identical open dependency blockers surface as `dependency_program_stale` after the guardrail threshold so operators can distinguish a stale Execution Program/dependency plan from a newly blocked queue item. A blocked queued candidate can still show an attached `.worktrees/XY-*` path when the queue owns the attention state; if that worktree has tracked changes after stalled reconciliation, failure writeback, or retries, the candidate is partial retained progress and not just a generic stalled or retry-budget hold. If the worktree is clean but stale active ownership remains after failed-start retry accounting, the candidate is failed-start cleanup debt rather than retained partial progress. Human-required authority stops expose their compact decision request fields here: `phase = human_required`, reason, boundary, `decision_request_id`, and `next_action`. When queued attention still maps to a run/attempt, it also carries the same compact loop status used by running lanes. Running lanes are not repeated as normal intake work. |
 | `Review & Landing` | Retained PR lanes after review handoff. This section owns post-review repair, wait-for-review, ready-to-land, closeout, cleanup, and blocked retained-lane visibility. Retained lanes expose compact loop status for their bound handoff run/attempt so operators can see review repair checkpoint state, architecture recovery stops, and boundary/human-required disposition without direct SQLite inspection. |
-| `Recovery Worktrees` | Retained local worktrees that are not currently owned by `Running Lanes`, `Review & Landing`, or queued attention in `Intake Queue`. This is the cleanup or recovery inbox for recovered paths, retained PR leftovers, and cleanup-only local worktrees. Empty is the normal healthy state. |
-| `Run Ledger` | Completed or non-running issue history, grouped by issue/lane. Decodex Linear execution ledger comments provide the durable completed outcome when available. If no `decodex.linear_execution_event` record exists, the row reports `missing` / `execution_ledger_missing`; the control plane does not derive a completed or landed outcome from tracker state, local attempts, or non-ledger comments. Terminal attention rows are history unless a current attention signal still exists. Raw local attempts and heartbeat details stay in debug expansion. |
+| `Recovery Worktrees` | Retained local worktrees that are not currently owned by `Running Lanes`, `Review & Landing`, or queued attention in `Intake Queue`. This is the cleanup or recovery inbox for recovered paths, retained PR leftovers, and cleanup-only local worktrees. Empty is the normal healthy state. Terminal unleased runtime-recorded mappings with identifier-style ids and missing checkout paths are local terminal residue, not recovery worktrees; snapshots omit them from this count and emit `stale_terminal_local_worktree_mapping_ignored` warning detail instead of refreshing those ids through Linear. |
+| `Run Ledger` | Completed or non-running issue history, grouped by issue/lane. Decodex Linear execution ledger comments provide the durable completed outcome when available. If no `decodex.linear_execution_event` record exists, the row reports `missing` / `execution_ledger_missing`; the control plane does not derive a completed or landed outcome from tracker state, local attempts, or non-ledger comments. Terminal unleased local residue with identifier-style ids reports `local_terminal_residue` because Linear ledger lookup is intentionally skipped for ids that are not proven Linear issue ids. Terminal attention rows are history unless a current attention signal still exists. Raw local attempts and heartbeat details stay in debug expansion. |
 
 ## Private Evidence Readback
 
@@ -655,6 +655,18 @@ missing. Filesystem-only scans use scan-specific provenance such as `filesystem_
 or `git_hygiene_scan`. Rows migrated from older runtime stores that had no provenance
 report `provenance.source = "legacy_unknown"` and may set
 `provenance.audit_required = true`.
+
+A runtime-recorded mapping with an identifier-style `issue_id`, no active lease or
+shared claim, no retained review lifecycle or review checkpoint authority, a checkout
+path that is confirmed missing, and a latest terminal run attempt is classified as
+stale terminal local residue. Live status and post-review readback skip Linear refresh
+and ledger calls for that row, omit it from `Recovery Worktrees`, and surface
+`stale_terminal_local_worktree_mapping_ignored`; review-handoff recovery diagnose
+surfaces `stale_terminal_local_residue` for the skipped local row without refreshing
+the identifier through Linear. Project reconciliation clears the mapping before issue
+selection so it cannot poison targeted dispatch. Filesystem uncertainty is not treated
+as a missing checkout path; Decodex fails closed instead of clearing local runtime
+authority.
 
 A `Recovery Worktrees` row tells the operator to inspect the local path and either
 clean it up or recover local-only changes; it is not, by itself, evidence that the

--- a/docs/reference/test-suite.md
+++ b/docs/reference/test-suite.md
@@ -8,7 +8,7 @@ owner: docs
 tags: [reference]
 code_refs: [apps/decodex/src/mcp.rs, apps/decodex/tests/mcp_stdio.rs, apps/decodex/src/orchestrator/tests.rs, apps/decodex/src/agent/app_server/tests.rs, apps/decodex/src/state/tests.rs]
 drift_watch: [cargo nextest list --workspace --all-targets --all-features, mcp::tests]
-last_verified: 2026-06-18
+last_verified: 2026-06-19
 ---
 # Test Suite
 
@@ -26,7 +26,7 @@ standards for keeping, merging, or deleting tests.
 
 ## Current Snapshot
 
-This snapshot groups 1282 runnable `nextest` tests across all targets. One additional
+This snapshot groups 1348 runnable `nextest` tests across all targets. One additional
 skipped live app-server test is listed only with verbose or JSON inventory output.
 Regenerate the runnable inventory with:
 
@@ -57,13 +57,13 @@ cargo nextest list --workspace --all-targets --all-features 2>/dev/null \
 
 | Group | Count | Primary surfaces | Owns |
 | --- | ---: | --- | --- |
-| Orchestrator | 606 | `apps/decodex/src/orchestrator/tests.rs`, `apps/decodex/src/orchestrator/tests/**/*.rs` | Intake, retry, review/landing, runtime cleanup, operator status, repo gates |
+| Orchestrator | 641 | `apps/decodex/src/orchestrator/tests.rs`, `apps/decodex/src/orchestrator/tests/**/*.rs` | Intake, retry, review/landing, runtime cleanup, operator status, repo gates |
 | Tracker tool bridge | 101 | `apps/decodex/src/agent/tracker_tool_bridge/tests.rs`, `apps/decodex/src/agent/tracker_tool_bridge/tests/**/*.rs` | Dynamic tracker tools, continuation guards, review handoff writes, closeout writes |
 | App-server protocol/runtime | 96 | `apps/decodex/src/agent/app_server/tests.rs`, `apps/decodex/src/agent/json_rpc.rs`, app-server protocol tests | JSON-RPC parsing, turn execution, dynamic tools, thread config, transport failures |
-| Runtime state, locks, and maintenance | 89 | `state::tests`, `runtime::tests`, `maintenance::tests` | Persistent local state, lock ownership, runtime database contracts, local retention |
+| Runtime state, locks, and maintenance | 93 | `state::tests`, `runtime::tests`, `maintenance::tests` | Persistent local state, lock ownership, runtime database contracts, local retention |
 | Workflow, config, and docs parsing | 62 | `workflow::tests`, `config::tests`, `codex_config::tests`, `docs_okf::tests` | `WORKFLOW.md`, project config, Codex config edits, removed-field rejection, default policy, OKF docs parsing |
-| Git, worktree, landing, and recovery helpers | 137 | `worktree::tests`, `manual::tests`, `commit_message::tests`, `github::tests`, `default_branch_sync::tests`, `pull_request::tests`, `recovery::tests`, `git_credentials::tests` | Git/worktree behavior, manual landing, GitHub/PR helpers, recovery commands, commit-message policy |
-| Account, CLI, archive, tracker, and MCP integration | 152 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests`, `mcp::tests`, `apps/decodex/tests/mcp_stdio.rs` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter, MCP resources, HTTP transport, bearer auth, schema-bound planning tools, inspect-first operate/admin tools, remote-safe observability templates, process-level MCP smoke, and public-text behavior |
+| Git, worktree, landing, and recovery helpers | 161 | `worktree::tests`, `manual::tests`, `commit_message::tests`, `github::tests`, `default_branch_sync::tests`, `pull_request::tests`, `recovery::tests`, `git_credentials::tests` | Git/worktree behavior, manual landing, GitHub/PR helpers, recovery commands, commit-message policy |
+| Account, CLI, archive, tracker, and MCP integration | 155 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests`, `mcp::tests`, `apps/decodex/tests/mcp_stdio.rs` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter, MCP resources, HTTP transport, bearer auth, schema-bound planning tools, inspect-first operate/admin tools, remote-safe observability templates, process-level MCP smoke, and public-text behavior |
 | Program intake | 10 | `program_intake::tests` | Decision Contract materialization, Linear issue shaping, and internal Execution Program persistence |
 | Loop contract and research surfaces | 29 | `loop_contract::tests`, `execution_program::tests`, `research_design::tests`, `plugin_surface_tests` | Decision Contract schema, Execution Program readiness, research compile/promote, and plugin trigger behavior |
 
@@ -85,7 +85,7 @@ large catch-all test file unless the behavior crosses several of these stages.
 | `apps/decodex/src/orchestrator/tests/runtime/failure.rs` | 38 | Failure comments, runtime credentials, cleanup, lease release |
 | `apps/decodex/src/orchestrator/tests/runtime/loop_scenarios.rs` | 2 | Research-to-execution loop scenarios, Program dispatch readiness, phase-goal validation, review, guardrails, and harness feedback |
 | `apps/decodex/src/orchestrator/tests/runtime/thread_archive.rs` | 1 | Completed-thread archive candidate filtering |
-| `apps/decodex/src/orchestrator/tests/recovery/reconciliation.rs` | 22 | Stale lease, recovery worktree, and reconciliation behavior |
+| `apps/decodex/src/orchestrator/tests/recovery/reconciliation.rs` | 24 | Stale lease, recovery worktree, and reconciliation behavior |
 | `apps/decodex/src/orchestrator/tests/recovery/terminal_support.rs` | 0 | Shared retained recovery and closeout fixtures |
 | `apps/decodex/src/orchestrator/tests/recovery/closeout/dispatch.rs` | 5 | Direct closeout dispatch and PR validation |
 | `apps/decodex/src/orchestrator/tests/recovery/closeout/identity.rs` | 4 | Closeout identity reuse after retained runs |
@@ -94,7 +94,7 @@ large catch-all test file unless the behavior crosses several of these stages.
 | `apps/decodex/src/orchestrator/tests/recovery/runtime_reentry.rs` | 30 | Runtime reentry, recovered worktrees, liveness, and live-run recovery |
 | `apps/decodex/src/orchestrator/tests/operator/status_support.rs` | 0 | Shared operator status fixtures |
 | `apps/decodex/src/orchestrator/tests/operator/status/control_plane.rs` | 10 | Registered project control-plane rows |
-| `apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs` | 34 | Running lanes, stalled lanes, current-lane hydration, and local worktrees |
+| `apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs` | 37 | Running lanes, stalled lanes, current-lane hydration, and local worktrees |
 | `apps/decodex/src/orchestrator/tests/operator/status/history.rs` | 7 | Run ledger and Linear history hydration |
 | `apps/decodex/src/orchestrator/tests/operator/status/text.rs` | 10 | Human-readable operator status text |
 | `apps/decodex/src/orchestrator/tests/operator/status/publishing.rs` | 11 | Snapshot publishing, degraded observers, and tracker backoff |
@@ -104,7 +104,7 @@ large catch-all test file unless the behavior crosses several of these stages.
 | `apps/decodex/src/orchestrator/tests/operator/status/agent_evidence.rs` | 6 | Agent evidence snapshots and private evidence readback |
 | `apps/decodex/src/orchestrator/tests/review_landing/status_support.rs` | 0 | Shared Review & Landing status fixtures |
 | `apps/decodex/src/orchestrator/tests/review_landing/status_rows.rs` | 18 | Review & Landing status rows and handoff lineage |
-| `apps/decodex/src/orchestrator/tests/review_landing/orchestration.rs` | 17 | Review orchestration, admin merge, and repair routing |
+| `apps/decodex/src/orchestrator/tests/review_landing/orchestration.rs` | 18 | Review orchestration, admin merge, and repair routing |
 | `apps/decodex/src/orchestrator/tests/review_landing/status_markers.rs` | 1 | Review lifecycle readback handling and recovered targeted visibility |
 | `apps/decodex/src/orchestrator/tests/review_landing/classification_review.rs` | 12 | Review repair, request-pending, stale handoff, merged PR classification |
 | `apps/decodex/src/orchestrator/tests/review_landing/classification_checks.rs` | 16 | Required checks, GitHub token gates, GraphQL pagination/query shape |

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -941,6 +941,16 @@ After a process restart, recent-run history, run lease ownership, retained post-
   does not occupy Program conflict domains. `legacy_unknown` mappings are excluded
   from this automatic cleanup and remain subject to the explicit legacy closeout audit
   path.
+- Terminal identifier residue: when a runtime-recorded mapping uses an identifier-style
+  issue id such as `PUB-001`, has no active lease or shared claim, has no retained
+  review lifecycle or review checkpoint authority, points at a checkout path that is
+  confirmed missing, and its latest local run attempt is terminal, Decodex must
+  classify it as local terminal residue before any Linear issue refresh. Reconciliation
+  clears the mapping; live status, recovery, post-review readback, and Run Ledger
+  hydration skip Linear refresh/comment calls for that identifier and may surface
+  `stale_terminal_local_worktree_mapping_ignored`, `stale_terminal_local_residue`, or
+  `local_terminal_residue` evidence. Filesystem stat errors are not missing-path
+  evidence and must fail closed rather than clear retained runtime authority.
 - If an issue becomes non-terminal but no longer eligible while `decodex` is still preparing the lane, keep the worktree and skip execution for that pass.
 
 ## Recovery rules


### PR DESCRIPTION
## Summary
- Filter stale terminal runtime-recorded identifier mappings before Linear refresh in reconciliation, status, recovery diagnose, and post-review orchestration paths.
- Preserve active/shared/review lifecycle and review checkpoint authority rows from stale-residue cleanup.
- Document the operator-visible stale terminal local residue path and update test-suite inventory.

## Verification
- cargo make fmt
- cargo make lint-fix
- cargo make test (1348 passed, 1 skipped)
- cargo make check-docs
- git diff --check

## Review
- Independent requirements and adversarial review checkpoints are clean for head 25bbf0a6aa479b9ba646997be8ff669759aa6a66.