### PR TITLE
Fix Decodex retained lane bug boundaries

### DIFF
--- a/apps/decodex/src/manual.rs
+++ b/apps/decodex/src/manual.rs
@@ -19,7 +19,7 @@ use crate::{
 	prelude::{Result, eyre},
 	pull_request::{self, PullRequestLandingState},
 	runtime,
-	state::{self, ReviewHandoffMarker, StateStore},
+	state::{self, ReviewHandoffMarker, StateStore, WorktreeMapping},
 	tracker::{
 		self, IssueTracker, TrackerIssue,
 		linear::LinearClient,
@@ -147,6 +147,13 @@ impl ManualAuthority {
 	}
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ManualCommitActiveLaneBlocker {
+	issue_id: String,
+	branch_name: String,
+	worktree_path: PathBuf,
+}
+
 pub(crate) fn run_commit(config_path: Option<&Path>, request: &ManualCommitRequest) -> Result<()> {
 	let cwd = env::current_dir()?;
 	let worktree_root = current_worktree_root(&cwd)?;
@@ -156,6 +163,9 @@ pub(crate) fn run_commit(config_path: Option<&Path>, request: &ManualCommitReque
 		request.manual_authority,
 		&worktree_root,
 	)?;
+
+	ensure_manual_commit_not_claimed_by_active_lane(config_path, &cwd, &worktree_root)?;
+
 	let message = commit_message::build_commit_message(
 		&request.summary,
 		authority.commit_message_value(),
@@ -705,6 +715,115 @@ fn resolve_authority(
 	)
 }
 
+fn ensure_manual_commit_not_claimed_by_active_lane(
+	config_path: Option<&Path>,
+	cwd: &Path,
+	worktree_root: &Path,
+) -> Result<()> {
+	let Some(blocker) =
+		manual_commit_active_lane_blocker_from_runtime(config_path, cwd, worktree_root)?
+	else {
+		return Ok(());
+	};
+
+	eyre::bail!(
+		"`decodex commit` refused to write inside active Decodex-owned lane worktree `{}` on branch `{}` for issue `{}` because the issue has a live runtime claim. Wait for the lane to finish, steer or interrupt the owning run, or clear retained ownership before using the manual commit helper.",
+		blocker.worktree_path.display(),
+		blocker.branch_name,
+		blocker.issue_id,
+	)
+}
+
+fn manual_commit_active_lane_blocker_from_runtime(
+	config_path: Option<&Path>,
+	cwd: &Path,
+	worktree_root: &Path,
+) -> Result<Option<ManualCommitActiveLaneBlocker>> {
+	let state_store = match runtime::open_runtime_store() {
+		Ok(state_store) => state_store,
+		Err(_error) if config_path.is_none() => return Ok(None),
+		Err(error) => return Err(error),
+	};
+	let Some(config_path) = manual_commit_project_config_path(config_path, cwd, &state_store)?
+	else {
+		return Ok(None);
+	};
+	let config = ServiceConfig::from_path(&config_path)?;
+
+	if !manual_commit_checkout_matches_project(worktree_root, &config)? {
+		return Ok(None);
+	}
+
+	let current_branch = current_branch_name_if_attached(cwd)?;
+
+	manual_commit_active_lane_blocker(
+		&state_store,
+		config.service_id(),
+		worktree_root,
+		current_branch.as_deref(),
+	)
+}
+
+fn manual_commit_project_config_path(
+	config_path: Option<&Path>,
+	cwd: &Path,
+	state_store: &StateStore,
+) -> Result<Option<PathBuf>> {
+	if let Some(config_path) = config_path {
+		return Ok(Some(ServiceConfig::resolve_project_config_path(config_path)?));
+	}
+
+	runtime::registered_config_path_for_cwd(state_store, cwd)
+}
+
+fn manual_commit_checkout_matches_project(
+	worktree_root: &Path,
+	config: &ServiceConfig,
+) -> Result<bool> {
+	Ok(worktree_root == config.repo_root()
+		|| config::checkouts_share_repository(worktree_root, config.repo_root())?)
+}
+
+fn manual_commit_active_lane_blocker(
+	state_store: &StateStore,
+	service_id: &str,
+	worktree_root: &Path,
+	current_branch: Option<&str>,
+) -> Result<Option<ManualCommitActiveLaneBlocker>> {
+	for mapping in state_store.list_worktrees(service_id)? {
+		if !manual_commit_matches_worktree_mapping(&mapping, worktree_root, current_branch) {
+			continue;
+		}
+		if !state_store.issue_has_active_shared_claim(service_id, mapping.issue_id())? {
+			continue;
+		}
+
+		return Ok(Some(ManualCommitActiveLaneBlocker {
+			issue_id: mapping.issue_id().to_owned(),
+			branch_name: mapping.branch_name().to_owned(),
+			worktree_path: mapping.worktree_path().to_path_buf(),
+		}));
+	}
+
+	Ok(None)
+}
+
+fn manual_commit_matches_worktree_mapping(
+	mapping: &WorktreeMapping,
+	worktree_root: &Path,
+	current_branch: Option<&str>,
+) -> bool {
+	paths_match_for_manual_commit_guard(worktree_root, mapping.worktree_path())
+		&& current_branch.is_none_or(|branch| branch == mapping.branch_name())
+}
+
+fn paths_match_for_manual_commit_guard(left: &Path, right: &Path) -> bool {
+	let left = fs::canonicalize(left).unwrap_or_else(|_| left.to_path_buf());
+	let right = fs::canonicalize(right).unwrap_or_else(|_| right.to_path_buf());
+
+	left == right
+}
+
 fn resolve_land_authority(
 	config_path: Option<&Path>,
 	explicit: Option<&str>,
@@ -789,6 +908,12 @@ fn current_branch_name(cwd: &Path) -> Result<String> {
 	}
 
 	Ok(branch)
+}
+
+fn current_branch_name_if_attached(cwd: &Path) -> Result<Option<String>> {
+	let branch = run_git_capture(cwd, &["branch", "--show-current"])?;
+
+	Ok((!branch.is_empty()).then_some(branch))
 }
 
 fn current_head_oid(cwd: &Path) -> Result<String> {
@@ -2662,6 +2787,86 @@ exit 1\n",
 		.expect("manual authority should resolve");
 
 		assert_eq!(authority, ManualAuthority::Manual);
+	}
+
+	#[test]
+	fn manual_commit_blocker_rejects_active_claimed_managed_worktree() {
+		let temp_dir = TempDir::new().expect("temp dir should create");
+		let state_store = state::StateStore::open_in_memory().expect("state store should open");
+		let worktree_path = temp_dir.path().join("XY-225");
+
+		fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+
+		state_store
+			.upsert_worktree(
+				"decodex",
+				"issue-1",
+				"y/decodex-xy-225",
+				&worktree_path.display().to_string(),
+			)
+			.expect("worktree mapping should persist");
+		state_store
+			.upsert_lease("decodex", "issue-1", "run-1", "In Progress")
+			.expect("active lease should persist");
+
+		let blocker = manual::manual_commit_active_lane_blocker(
+			&state_store,
+			"decodex",
+			&worktree_path,
+			Some("y/decodex-xy-225"),
+		)
+		.expect("manual commit blocker should evaluate")
+		.expect("active managed worktree should block");
+
+		assert_eq!(blocker.issue_id, "issue-1");
+		assert_eq!(blocker.branch_name, "y/decodex-xy-225");
+		assert_eq!(blocker.worktree_path, worktree_path);
+	}
+
+	#[test]
+	fn manual_commit_blocker_allows_unclaimed_or_unmapped_worktree() {
+		let temp_dir = TempDir::new().expect("temp dir should create");
+		let state_store = state::StateStore::open_in_memory().expect("state store should open");
+		let worktree_path = temp_dir.path().join("XY-225");
+		let other_path = temp_dir.path().join("XY-226");
+
+		fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+		fs::create_dir_all(&other_path).expect("other worktree path should exist");
+
+		state_store
+			.upsert_worktree(
+				"decodex",
+				"issue-1",
+				"y/decodex-xy-225",
+				&worktree_path.display().to_string(),
+			)
+			.expect("worktree mapping should persist");
+
+		assert!(
+			manual::manual_commit_active_lane_blocker(
+				&state_store,
+				"decodex",
+				&worktree_path,
+				Some("y/decodex-xy-225"),
+			)
+			.expect("unclaimed worktree should evaluate")
+			.is_none()
+		);
+
+		state_store
+			.upsert_lease("decodex", "issue-1", "run-1", "In Progress")
+			.expect("active lease should persist");
+
+		assert!(
+			manual::manual_commit_active_lane_blocker(
+				&state_store,
+				"decodex",
+				&other_path,
+				Some("y/decodex-xy-226"),
+			)
+			.expect("unmapped worktree should evaluate")
+			.is_none()
+		);
 	}
 
 	#[test]

--- a/apps/decodex/src/orchestrator/run_cycle.rs
+++ b/apps/decodex/src/orchestrator/run_cycle.rs
@@ -1818,6 +1818,10 @@ fn post_review_lane_is_closeout_candidate(
 	lane.classification == "continue" && lane.reason == "pull_request_merged_closeout_pending"
 }
 
+fn post_review_lane_is_repair_candidate(lane: &OperatorPostReviewLaneStatus) -> bool {
+	lane.classification == "needs_review_repair"
+}
+
 fn run_target_issue_once<T>(
 	context: TargetIssueRunContext<'_, T>,
 ) -> Result<Option<RunSummary>>
@@ -2003,6 +2007,9 @@ fn run_target_issue_once_with_inferred_dispatch<T>(
 where
 	T: IssueTracker,
 {
+	if target_issue_has_status_visible_review_repair(&context)? {
+		return run_target_status_visible_review_repair_once(context);
+	}
 	if target_issue_has_status_visible_closeout(&context)? {
 		return run_target_status_visible_closeout_once(context);
 	}
@@ -2019,8 +2026,65 @@ where
 	))? {
 		return Ok(Some(summary));
 	}
+	if let Some(summary) = run_target_status_visible_review_repair_once(
+		target_issue_run_context_with_dispatch_mode(&context, IssueDispatchMode::ReviewRepair),
+	)? {
+		return Ok(Some(summary));
+	}
 
 	run_target_status_visible_closeout_once(context)
+}
+
+fn target_issue_has_status_visible_review_repair<T>(
+	context: &TargetIssueRunContext<'_, T>,
+) -> Result<bool>
+where
+	T: IssueTracker,
+{
+	let target_issue_id = resolve_target_issue_id(context.tracker, context.issue_id)?;
+	let review_state_inspector = GhPullRequestReviewStateInspector {
+		github_token_env_var: Some(context.project.github().token_env_var().to_owned()),
+		github_command_path: context.project.github().command_path().map(Path::to_path_buf),
+	};
+
+	Ok(build_post_review_lane_statuses(
+		context.tracker,
+		context.project,
+		context.workflow,
+		context.state_store,
+		&review_state_inspector,
+	)?
+	.into_iter()
+	.any(|lane| lane.issue_id == target_issue_id && post_review_lane_is_repair_candidate(&lane)))
+}
+
+fn run_target_status_visible_review_repair_once<T>(
+	context: TargetIssueRunContext<'_, T>,
+) -> Result<Option<RunSummary>>
+where
+	T: IssueTracker,
+{
+	let target_issue_id = resolve_target_issue_id(context.tracker, context.issue_id)?;
+	let review_state_inspector = GhPullRequestReviewStateInspector {
+		github_token_env_var: Some(context.project.github().token_env_var().to_owned()),
+		github_command_path: context.project.github().command_path().map(Path::to_path_buf),
+	};
+	let Some(_issue) = select_target_post_review_repair_issue_candidate_with_inspector(
+		context.tracker,
+		context.project,
+		context.workflow,
+		context.state_store,
+		&target_issue_id,
+		context.issue_id,
+		&review_state_inspector,
+	)? else {
+		return Ok(None);
+	};
+
+	run_target_issue_once(target_issue_run_context_with_dispatch_mode(
+		&context,
+		IssueDispatchMode::ReviewRepair,
+	))
 }
 
 fn target_issue_has_status_visible_closeout<T>(
@@ -2044,10 +2108,69 @@ where
 		&review_state_inspector,
 	)?
 	.into_iter()
-	.any(|lane| {
-		lane.issue_id == target_issue_id
-			&& post_review_lane_is_closeout_candidate(&lane, completed_state)
-	}))
+		.any(|lane| {
+			lane.issue_id == target_issue_id
+				&& post_review_lane_is_closeout_candidate(&lane, completed_state)
+		}))
+}
+
+fn select_target_post_review_repair_issue_candidate_with_inspector<T, I>(
+	tracker: &T,
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	target_issue_id: &str,
+	target_issue_reference: &str,
+	review_state_inspector: &I,
+) -> Result<Option<TrackerIssue>>
+where
+	T: IssueTracker,
+	I: PullRequestReviewStateInspector,
+{
+	let lanes = build_post_review_lane_statuses(
+		tracker,
+		project,
+		workflow,
+		state_store,
+		review_state_inspector,
+	)?;
+	let repair_lanes = lanes
+		.into_iter()
+		.filter(post_review_lane_is_repair_candidate)
+		.collect::<Vec<_>>();
+
+	if repair_lanes.is_empty() {
+		return Ok(None);
+	}
+
+	let Some(target_lane) = repair_lanes
+		.iter()
+		.find(|lane| lane.issue_id == target_issue_id)
+	else {
+		let visible_lanes = repair_lanes
+			.iter()
+			.map(|lane| lane.issue_identifier.as_str())
+			.collect::<Vec<_>>()
+			.join(", ");
+
+		eyre::bail!(
+			"targeted retained review repair mismatch: requested issue `{}` does not match status-visible retained review repair lane(s) `{}`",
+			target_issue_reference,
+			visible_lanes,
+		);
+	};
+	let issue_ids = [target_lane.issue_id.clone()];
+	let mut issues = tracker.refresh_issues(&issue_ids)?;
+	let Some(issue_index) = issues.iter().position(|issue| issue.id == target_lane.issue_id) else {
+		return Ok(None);
+	};
+	let issue = issues.swap_remove(issue_index);
+
+	if state_store.issue_has_active_shared_claim(project.service_id(), &issue.id)? {
+		return Ok(None);
+	}
+
+	Ok(Some(issue))
 }
 
 fn run_target_status_visible_closeout_once<T>(

--- a/apps/decodex/src/orchestrator/tests/intake/run_and_prompting.rs
+++ b/apps/decodex/src/orchestrator/tests/intake/run_and_prompting.rs
@@ -336,6 +336,83 @@ fn targeted_identifier_dispatch_accepts_status_visible_retained_closeout_lane() 
 }
 
 #[test]
+fn targeted_identifier_dispatch_accepts_status_visible_review_repair_lane() {
+	let (temp_dir, base_config, workflow) = temp_project_layout();
+	let config = service_config_with_github_token_env_var(&base_config, "HOME");
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = run_and_prompting_service_owned_issue("In Review");
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+	let worktree_manager =
+		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
+	let worktree =
+		worktree_manager.ensure_worktree(&issue.identifier, false).expect("worktree should exist");
+	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let pr_url = "https://github.com/hack-ink/decodex/pull/184";
+
+	state_store
+		.upsert_worktree(
+			config.service_id(),
+			&issue.id,
+			&worktree.branch_name,
+			&worktree.path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	seed_review_handoff_marker_for_path(
+		&state_store,
+		config.service_id(),
+		&worktree.path,
+		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+	);
+
+	let _path_guard =
+		install_fake_conflicting_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("status snapshot should build");
+	let lane = snapshot
+		.post_review_lanes
+		.iter()
+		.find(|lane| lane.issue_identifier == issue.identifier)
+		.expect("retained repair lane should appear in status");
+
+	assert_eq!(lane.classification, "needs_review_repair");
+	assert_eq!(lane.reason, "pull_request_merge_conflict");
+
+	let summary = orchestrator::run_target_issue_once_with_inferred_dispatch(
+		TargetIssueRunContext {
+			tracker: &tracker,
+			project: &config,
+			workflow: &workflow,
+			state_store: &state_store,
+			issue_id: &issue.identifier,
+			preferred_issue_state: None,
+			preferred_initial_issue_state: None,
+			dry_run: true,
+			lease_preacquired: false,
+			preferred_issue_claim_fd: None,
+			preferred_dispatch_slot_fd: None,
+			preferred_dispatch_slot_index: None,
+			dispatch_mode: IssueDispatchMode::Normal,
+			preferred_run_identity: None,
+			preferred_retry_budget_base: None,
+		},
+	)
+	.expect("targeted retained repair identifier run should succeed")
+	.expect("status-visible retained repair lane should dispatch by identifier");
+
+	assert_eq!(summary.issue_id, issue.id);
+	assert_eq!(summary.issue_identifier, issue.identifier);
+	assert_eq!(summary.dispatch_mode, IssueDispatchMode::ReviewRepair);
+	assert_eq!(summary.issue_state, "In Review");
+}
+
+#[test]
 fn targeted_identifier_dispatch_accepts_stopped_active_closeout_lease() {
 	let (temp_dir, base_config, workflow) = temp_project_layout();
 	let config = service_config_with_github_token_env_var(&base_config, "HOME");
@@ -542,6 +619,96 @@ fn targeted_identifier_dispatch_rejects_different_status_visible_closeout_lane()
 	assert!(message.contains("targeted retained closeout mismatch"));
 	assert!(message.contains(&requested_issue.identifier));
 	assert!(message.contains(&closeout_issue.identifier));
+}
+
+#[test]
+fn targeted_identifier_dispatch_rejects_different_status_visible_review_repair_lane() {
+	let (temp_dir, base_config, workflow) = temp_project_layout();
+	let config = service_config_with_github_token_env_var(&base_config, "HOME");
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
+	let repair_issue = sample_issue_with_sort_fields(
+		"issue-repair",
+		"PUB-201",
+		"In Review",
+		&[active_label.as_str()],
+		Some(1),
+		"2026-03-13T04:16:17.133Z",
+	);
+	let requested_issue = sample_issue_with_sort_fields(
+		"issue-requested",
+		"PUB-202",
+		"In Review",
+		&[active_label.as_str()],
+		Some(2),
+		"2026-03-13T04:17:17.133Z",
+	);
+	let tracker = FakeTracker::new(vec![repair_issue.clone(), requested_issue.clone()]);
+	let worktree_manager =
+		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
+	let worktree = worktree_manager
+		.ensure_worktree(&repair_issue.identifier, false)
+		.expect("worktree should exist");
+	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let pr_url = "https://github.com/hack-ink/decodex/pull/185";
+
+	state_store
+		.upsert_worktree(
+			config.service_id(),
+			&repair_issue.id,
+			&worktree.branch_name,
+			&worktree.path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	seed_review_handoff_marker_for_path(
+		&state_store,
+		config.service_id(),
+		&worktree.path,
+		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+	);
+
+	let _path_guard =
+		install_fake_conflicting_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("status snapshot should build");
+
+	assert_eq!(snapshot.post_review_lanes.len(), 1);
+	assert_eq!(snapshot.post_review_lanes[0].issue_identifier, repair_issue.identifier);
+	assert_eq!(snapshot.post_review_lanes[0].classification, "needs_review_repair");
+	assert_eq!(snapshot.post_review_lanes[0].reason, "pull_request_merge_conflict");
+
+	let error = orchestrator::run_target_issue_once_with_inferred_dispatch(
+		TargetIssueRunContext {
+			tracker: &tracker,
+			project: &config,
+			workflow: &workflow,
+			state_store: &state_store,
+			issue_id: &requested_issue.identifier,
+			preferred_issue_state: None,
+			preferred_initial_issue_state: None,
+			dry_run: true,
+			lease_preacquired: false,
+			preferred_issue_claim_fd: None,
+			preferred_dispatch_slot_fd: None,
+			preferred_dispatch_slot_index: None,
+			dispatch_mode: IssueDispatchMode::Normal,
+			preferred_run_identity: None,
+			preferred_retry_budget_base: None,
+		},
+	)
+	.expect_err("targeted review repair inference should reject a different visible lane");
+	let message = error.to_string();
+
+	assert!(message.contains("targeted retained review repair mismatch"));
+	assert!(message.contains(&requested_issue.identifier));
+	assert!(message.contains(&repair_issue.identifier));
 }
 
 #[test]

--- a/apps/decodex/src/orchestrator/tests/recovery/terminal_support.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery/terminal_support.rs
@@ -37,6 +37,7 @@ fn install_fake_open_pr_gh_response(
 	let fake_gh_response = serde_json::json!({
 		"data": {
 			"repository": {
+				"mergeCommitAllowed": true,
 				"pullRequest": {
 					"url": pr_url,
 					"state": "OPEN",
@@ -49,6 +50,75 @@ fn install_fake_open_pr_gh_response(
 					"headRefOid": head_oid,
 					"headRepository": { "name": "decodex" },
 					"headRepositoryOwner": { "login": "hack-ink" },
+					"reactionGroups": [],
+					"comments": {
+						"nodes": [],
+						"pageInfo": { "hasNextPage": false, "endCursor": null }
+					},
+					"reviews": { "nodes": [] },
+					"reviewRequests": { "totalCount": 0 },
+					"reviewThreads": {
+						"nodes": [],
+						"pageInfo": { "hasNextPage": false, "endCursor": null }
+					},
+					"commits": {
+						"nodes": [
+							{ "commit": { "statusCheckRollup": { "state": "SUCCESS" } } }
+						]
+					}
+				}
+			}
+		}
+	})
+	.to_string();
+
+	fs::create_dir_all(&fake_gh_dir).expect("fake gh directory should exist");
+	fs::write(&fake_gh_path, format!("#!/bin/sh\nprintf '%s' '{fake_gh_response}'\n"))
+		.expect("fake gh script should write");
+
+	let mut permissions =
+		fs::metadata(&fake_gh_path).expect("fake gh metadata should read").permissions();
+
+	#[cfg(unix)]
+	PermissionsExt::set_mode(&mut permissions, 0o755);
+	fs::set_permissions(&fake_gh_path, permissions)
+		.expect("fake gh script should become executable");
+
+	let path_env = env::var("PATH").unwrap_or_default();
+
+	TestEnvVarGuard::set("PATH", &format!("{}:{path_env}", fake_gh_dir.display()))
+}
+
+fn install_fake_conflicting_pr_gh_response(
+	temp_dir: &TempDir,
+	worktree: &WorktreeSpec,
+	pr_url: &str,
+	head_oid: &str,
+) -> TestEnvVarGuard {
+	let fake_gh_dir = temp_dir.path().join("fake-conflict-bin");
+	let fake_gh_path = fake_gh_dir.join("gh");
+	let fake_gh_response = serde_json::json!({
+		"data": {
+			"repository": {
+				"mergeCommitAllowed": true,
+				"pullRequest": {
+					"url": pr_url,
+					"state": "OPEN",
+					"isDraft": false,
+					"reviewDecision": "REVIEW_REQUIRED",
+					"baseRefName": "main",
+					"mergeable": "CONFLICTING",
+					"mergeStateStatus": "DIRTY",
+					"headRefName": worktree.branch_name.clone(),
+					"headRefOid": head_oid,
+					"headRepository": { "name": "decodex" },
+					"headRepositoryOwner": { "login": "hack-ink" },
+					"reactionGroups": [],
+					"comments": {
+						"nodes": [],
+						"pageInfo": { "hasNextPage": false, "endCursor": null }
+					},
+					"reviews": { "nodes": [] },
 					"reviewRequests": { "totalCount": 0 },
 					"reviewThreads": {
 						"nodes": [],

--- a/docs/runbook/recover-review-handoff.md
+++ b/docs/runbook/recover-review-handoff.md
@@ -103,6 +103,21 @@ The lane should leave `missing_review_handoff_record` and return to the existing
 post-review lifecycle classification such as waiting for review, ready to land, review
 repair required, or blocked for a different concrete reason.
 
+If status reports that same target issue as `needs_review_repair`, including concrete
+reasons such as `pull_request_merge_conflict` or `pull_request_branch_behind_base`, a
+targeted dry run should exercise the retained repair path:
+
+```sh
+decodex run <ISSUE> --dry-run
+```
+
+That command should plan `ReviewRepair` for the retained lane. If it instead reports no
+eligible queued issue while status still shows `needs_review_repair`, treat that as a
+runtime dispatch bug rather than adding queue labels or re-running review-handoff
+recovery. If status shows a retained repair lane for a different issue, a targeted dry
+run for the wrong identifier should fail with a retained review repair mismatch; do not
+use that mismatch as permission to reuse or relabel the retained worktree.
+
 ## Manual PR Takeover
 
 Use `adopt` when a human-owned PR was created from a managed Decodex worktree and the

--- a/docs/spec/commit-messages.md
+++ b/docs/spec/commit-messages.md
@@ -84,3 +84,8 @@ Those values are runtime or integration-event concerns, not tree-change semantic
 - `decodex commit --manual-authority ...` and `decodex land --manual-authority ...` are the only supported ways to produce `authority = "manual"`.
 - `--authority manual` is not a supported synonym; the reserved literal exists so downstream consumers can distinguish an intentional manual lane from a malformed issue identifier.
 - `related` entries remain issue identifiers even when `authority = "manual"`.
+- `decodex commit` is an operator helper, not an active child-run writer. When the
+  current checkout matches a runtime-recorded Decodex lane worktree and that issue has a
+  live runtime claim, the helper must refuse the commit, including
+  `--manual-authority` commits. The operator should steer or interrupt the owning run,
+  wait for it to finish, or clear retained ownership before using the helper.

--- a/docs/spec/post-review-lifecycle.md
+++ b/docs/spec/post-review-lifecycle.md
@@ -309,6 +309,17 @@ at the repaired lane HEAD, and remains open and ready for fresh review.
 
 If the retained lane is missing or no longer provably belongs to the same issue and PR lineage, the runtime must not invent a fresh lane silently. It must require human intervention or a separately defined recovery path.
 
+Targeted issue dispatch must use the same post-review ownership classification as the
+ordinary scheduler. When `decodex run <ISSUE>` resolves to a retained lane currently
+classified as `needs_review_repair`, the runtime should enter retained review repair for
+that issue rather than treating the request as ordinary queued intake or generic retry.
+This targeted path is gated by the status-visible retained lane classification; an
+ordinary `In Review` issue without a `needs_review_repair` post-review lane is not
+promoted into repair only because it is service-owned. If the status-visible retained
+repair lane belongs to a different issue than the targeted identifier, the runtime must
+fail closed with a targeted retained repair mismatch instead of borrowing that lane or
+falling through to generic retry.
+
 ### `ready_to_land`
 
 `ready_to_land` is a decision boundary, not a merge event.


### PR DESCRIPTION
## Summary

This PR resolves the remaining live code gaps from the open `repo:decodex` + `kind:bug` Linear audit and documents the disposition for the stale/historical bug issues.

Code fixes:
- Route targeted `decodex run <ISSUE>` through status-visible retained review repair when the retained post-review lane is classified as `needs_review_repair`.
- Fail closed when a targeted issue does not match the visible retained review repair lane, mirroring retained closeout mismatch behavior.
- Refuse `decodex commit` inside an active Decodex-owned managed lane worktree when the issue has a live runtime claim, including `--manual-authority`.

Issue disposition:
- `XY-570`: fixed by retained post-review repair dispatch for targeted issue runs.
- `XY-921`: fixed by the manual commit active-lane writer guard.
- `XY-893`, `XY-895`, `XY-907`: no live repro found; current main already has status/lifecycle/closeout coverage for stopped processes, merged closeout, and stale active-lane projections.

## Validation

- `cargo test -p decodex targeted_identifier_dispatch -- --nocapture`
- `cargo make fmt && cargo make lint-fix && cargo make test`
  - nextest: 1354 tests run, 1354 passed, 1 skipped
- `cargo make lint-fix`
  - vstyle/clippy stability rerun: 0 fixes
- `git diff --check`
