### PR TITLE
XY-1040: [DECODEX-P0] Route review findings before repair to stop review-phase churn

### DIFF
--- a/apps/decodex/src/agent/tracker_tool_bridge.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge.rs
@@ -857,6 +857,8 @@ struct ReviewCheckpointArgs {
 	accepted_findings: Vec<ReviewCheckpointFindingArgs>,
 	#[serde(default)]
 	rejected_findings: Vec<ReviewCheckpointRejectedFindingArgs>,
+	#[serde(default)]
+	finding_routes: Vec<ReviewCheckpointFindingRouteArgs>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -920,6 +922,21 @@ struct ReviewCheckpointRejectedFindingArgs {
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+struct ReviewCheckpointFindingRouteArgs {
+	route: String,
+	severity: String,
+	summary: String,
+	#[serde(default)]
+	evidence: Vec<String>,
+	resolver: String,
+	next_action: String,
+	risk_tier: Option<String>,
+	finding_source: Option<String>,
+	finding_index: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct ReviewCheckpointLineRangeArgs {
 	start: u64,
 	end: u64,
@@ -935,6 +952,8 @@ struct NormalizedReviewCheckpointPayload {
 	evidence: Vec<String>,
 	accepted_findings: Vec<NormalizedReviewCheckpointFinding>,
 	rejected_findings: Vec<NormalizedRejectedReviewCheckpointFinding>,
+	finding_routes: Vec<NormalizedReviewCheckpointFindingRoute>,
+	finding_route_summary: ReviewCheckpointFindingRouteSummary,
 	finding_policy: ReviewFindingPolicyState,
 }
 
@@ -983,6 +1002,33 @@ struct NormalizedRejectedReviewCheckpointFinding {
 	file: Option<String>,
 	line: Option<u64>,
 	line_range: Option<ReviewCheckpointLineRangeArgs>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct NormalizedReviewCheckpointFindingRoute {
+	route: String,
+	severity: String,
+	risk_tier: String,
+	summary: String,
+	#[serde(default)]
+	evidence: Vec<String>,
+	resolver: String,
+	next_action: String,
+	finding_source: String,
+	finding_index: Option<u64>,
+	finding_fingerprint: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct ReviewCheckpointFindingRouteSummary {
+	route_counts: Vec<ReviewCheckpointFindingRouteCount>,
+	next_action: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct ReviewCheckpointFindingRouteCount {
+	route: String,
+	count: usize,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]

--- a/apps/decodex/src/agent/tracker_tool_bridge/tests/review/policy.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests/review/policy.rs
@@ -110,6 +110,18 @@ fn accepted_review_findings_for_status_json(status: &str) -> Value {
 	}
 }
 
+fn route_only_review_route_json(route: &str) -> Value {
+	serde_json::json!([{
+		"route": route,
+		"severity": "medium",
+		"risk_tier": "medium",
+		"summary": "Review signal is routed outside current repair.",
+		"evidence": ["The reviewer signal was checked against the current lane head."],
+		"resolver": "architecture",
+		"next_action": "Record the routed review signal without mutating the current repair."
+	}])
+}
+
 fn sample_dirty_local_repo() -> LocalRepoDetails {
 	let mut local_repo = sample_local_repo();
 
@@ -785,6 +797,9 @@ fn independent_review_checkpoint_clean_persists_structured_payload() {
 	);
 	assert_eq!(details["accepted_findings"].as_array().expect("accepted findings array").len(), 0);
 	assert_eq!(details["rejected_findings"][0]["rejection_reason"], "Not actionable after checking the current diff and docs.");
+	assert_eq!(details["finding_routes"][0]["route"], "reviewer_rubric_gap");
+	assert_eq!(details["finding_route_summary"]["route_counts"][0]["route"], "reviewer_rubric_gap");
+	assert_eq!(details["finding_route_summary"]["route_counts"][0]["count"], 1);
 
 	let events = bridge_state_store(&bridge)
 		.list_private_execution_events_for_run_attempt(
@@ -797,6 +812,7 @@ fn independent_review_checkpoint_clean_persists_structured_payload() {
 	assert_eq!(events.len(), 1);
 	assert_eq!(events[0].event_type(), "review_checkpoint");
 	assert_eq!(events[0].payload()["review"]["reviewer"], "independent_fresh_context");
+	assert_eq!(events[0].payload()["route_counts"][0]["route"], "reviewer_rubric_gap");
 }
 
 #[test]
@@ -909,6 +925,12 @@ fn independent_review_checkpoint_findings_store_accepted_repair_guidance() {
 		details["accepted_findings"][0]["guidance"],
 		"Repair the accepted issue before requesting another review checkpoint."
 	);
+	assert_eq!(details["finding_routes"][0]["route"], "current_blocker");
+	assert_eq!(
+		details["finding_routes"][0]["finding_fingerprint"],
+		details["accepted_findings"][0]["fingerprint"]
+	);
+	assert_eq!(details["finding_route_summary"]["route_counts"][0]["route"], "current_blocker");
 }
 
 #[test]
@@ -964,6 +986,201 @@ fn review_checkpoint_rejected_finding_is_non_actionable_and_can_handoff_cleanly(
 	assert!(handoff_response.success);
 
 	assert_review_policy_checkpoint_cleared(&bridge, &issue, &review_context);
+}
+
+#[test]
+fn clean_review_checkpoint_records_non_current_routes_without_churn() {
+	let tracker = FakeTracker::new();
+	let issue = sample_issue();
+	let workflow = sample_workflow();
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let review_context = sample_review_context_in(temp_dir.path());
+	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
+	let local_repo_inspector =
+		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
+	let bridge = TrackerToolBridge::with_review_handoff_for_test(
+		&tracker,
+		&issue,
+		&workflow,
+		review_context.clone(),
+		&pull_request_inspector,
+		&local_repo_inspector,
+	);
+
+	for _round in 0..2 {
+		let response = DynamicToolHandler::handle_call(
+			&bridge,
+			ISSUE_REVIEW_CHECKPOINT_TOOL_NAME,
+			serde_json::json!({
+				"reviewer": "independent_fresh_context",
+				"status": "clean",
+				"head_sha": sample_local_repo().head_oid,
+				"review_contract": handoff_review_contract_json(),
+				"checks": review_checks_json(),
+				"evidence": ["fresh reviewer found only non-current follow-up work"],
+				"finding_routes": route_only_review_route_json("follow_up")
+			}),
+		);
+
+		assert!(response.success);
+	}
+
+	let checkpoint = persisted_review_policy_checkpoint(&bridge, &issue, &review_context);
+	let details =
+		serde_json::from_str::<Value>(checkpoint.details_json()).expect("details should be json");
+
+	assert_eq!(checkpoint.status(), "clean");
+	assert_eq!(checkpoint.nonclean_rounds(), 0);
+	assert_eq!(
+		details["finding_policy"]["active_fingerprints"]
+			.as_array()
+			.expect("active fingerprints should be an array")
+			.len(),
+		0
+	);
+	assert_eq!(details["finding_route_summary"]["route_counts"][0]["route"], "follow_up");
+}
+
+#[test]
+fn review_checkpoint_rejects_high_risk_invalid_route() {
+	let tracker = FakeTracker::new();
+	let issue = sample_issue();
+	let workflow = sample_workflow();
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let review_context = sample_review_context_in(temp_dir.path());
+	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let bridge = TrackerToolBridge::with_review_handoff_for_test(
+		&tracker,
+		&issue,
+		&workflow,
+		review_context,
+		&pull_request_inspector,
+		&local_repo_inspector,
+	);
+	let response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_REVIEW_CHECKPOINT_TOOL_NAME,
+		serde_json::json!({
+			"reviewer": "independent_fresh_context",
+			"status": "clean",
+			"head_sha": sample_local_repo().head_oid,
+			"review_contract": handoff_review_contract_json(),
+			"checks": review_checks_json(),
+			"evidence": ["fresh reviewer disputed a severe live-mutation risk"],
+			"finding_routes": [{
+				"route": "invalid_or_unsubstantiated",
+				"severity": "high",
+				"risk_tier": "high",
+				"summary": "Reviewer alleged a high-risk live mutation.",
+				"evidence": ["The reviewer did not provide enough source evidence."],
+				"resolver": "agent",
+				"next_action": "Route to needs_evidence with source proof instead of invalidating it."
+			}]
+		}),
+	);
+
+	assert!(!response.success);
+	assert!(matches!(
+		response.content_items.as_slice(),
+		[DynamicToolContentItem::InputText { text }]
+			if text.contains("cannot route high-severity or high-risk")
+	));
+}
+
+#[test]
+fn review_checkpoint_rejects_bound_high_severity_invalid_route() {
+	let tracker = FakeTracker::new();
+	let issue = sample_issue();
+	let workflow = sample_workflow();
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let review_context = sample_review_context_in(temp_dir.path());
+	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let bridge = TrackerToolBridge::with_review_handoff_for_test(
+		&tracker,
+		&issue,
+		&workflow,
+		review_context,
+		&pull_request_inspector,
+		&local_repo_inspector,
+	);
+	let response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_REVIEW_CHECKPOINT_TOOL_NAME,
+		serde_json::json!({
+			"reviewer": "independent_fresh_context",
+			"status": "findings",
+			"head_sha": sample_local_repo().head_oid,
+			"review_contract": handoff_review_contract_json(),
+			"checks": review_checks_json(),
+			"evidence": ["fresh reviewer disputed a severe accepted finding"],
+			"accepted_findings": [{
+				"severity": "high",
+				"summary": "Accepted reviewer finding reports a high severity regression.",
+				"evidence": ["The reviewer evidence points at the current lane head."],
+				"file": "apps/decodex/src/agent/tracker_tool_bridge/tools.rs",
+				"line": 1,
+				"guidance": "Repair the accepted high severity regression."
+			}],
+			"finding_routes": [{
+				"route": "invalid_or_unsubstantiated",
+				"severity": "low",
+				"risk_tier": "low",
+				"summary": "Route tries to downgrade the accepted finding.",
+				"evidence": ["The bound accepted finding is high severity."],
+				"resolver": "agent",
+				"next_action": "Route to needs_evidence or a landing blocker instead.",
+				"finding_source": "accepted_findings",
+				"finding_index": 0
+			}]
+		}),
+	);
+
+	assert!(!response.success);
+	assert!(matches!(
+		response.content_items.as_slice(),
+		[DynamicToolContentItem::InputText { text }]
+			if text.contains("cannot route high-severity or high-risk")
+	));
+}
+
+#[test]
+fn blocked_review_checkpoint_requires_landing_blocking_route() {
+	let tracker = FakeTracker::new();
+	let issue = sample_issue();
+	let workflow = sample_workflow();
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let review_context = sample_review_context_in(temp_dir.path());
+	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let bridge = TrackerToolBridge::with_review_handoff_for_test(
+		&tracker,
+		&issue,
+		&workflow,
+		review_context,
+		&pull_request_inspector,
+		&local_repo_inspector,
+	);
+	let response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_REVIEW_CHECKPOINT_TOOL_NAME,
+		serde_json::json!({
+			"reviewer": "independent_fresh_context",
+			"status": "blocked",
+			"head_sha": sample_local_repo().head_oid,
+			"review_contract": handoff_review_contract_json(),
+			"checks": review_checks_json(),
+			"evidence": ["review cannot continue without external evidence"]
+		}),
+	);
+
+	assert!(!response.success);
+	assert!(matches!(
+		response.content_items.as_slice(),
+		[DynamicToolContentItem::InputText { text }]
+			if text.contains("requires at least one landing-blocking")
+	));
 }
 
 #[test]
@@ -1263,12 +1480,17 @@ fn review_checkpoint_architecture_and_blocked_statuses_stop_immediately() {
 			serde_json::json!({
 				"reviewer": "independent_fresh_context",
 				"status": status,
-				"head_sha": sample_local_repo().head_oid,
-				"review_contract": handoff_review_contract_json(),
-				"checks": review_checks_json(),
-				"evidence": ["requires human follow-up"]
-			}),
-		);
+			"head_sha": sample_local_repo().head_oid,
+			"review_contract": handoff_review_contract_json(),
+			"checks": review_checks_json(),
+			"evidence": ["requires human follow-up"],
+			"finding_routes": route_only_review_route_json(if status == "blocked" {
+				"landing_blocker"
+			} else {
+				"architecture_signal"
+			})
+		}),
+	);
 
 		assert!(response.success);
 

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools.rs
@@ -13,14 +13,16 @@ use crate::{
 		ISSUE_TERMINAL_FINALIZE_TOOL_NAME, ISSUE_TRANSITION_TOOL_NAME, LabelArgs, LocalRepoDetails,
 		NormalizedProgressCheckpoint, NormalizedRejectedReviewCheckpointFinding,
 		NormalizedReviewCheckpointContract, NormalizedReviewCheckpointFinding,
-		NormalizedReviewCheckpointPayload, PendingReviewAction, PendingReviewCompletion,
-		ProgressCheckpointArgs, PullRequestDetails, REVIEW_POLICY_CONVERGENCE_BUDGET,
-		ReviewCheckpointArgs, ReviewCheckpointChecksArgs, ReviewCheckpointContractArgs,
-		ReviewCheckpointFindingArgs, ReviewCheckpointHeadBinding, ReviewCheckpointLineRangeArgs,
-		ReviewCheckpointRejectedFindingArgs, ReviewExecutionMode, ReviewFindingPolicyRecord,
-		ReviewFindingPolicyState, ReviewHandoffArgs, ReviewHandoffContext, ReviewPolicyPhase,
-		ReviewPolicyState, ReviewPolicyStatus, RunCompletionDisposition, TerminalFinalizeArgs,
-		TrackerToolBridge, TransitionArgs,
+		NormalizedReviewCheckpointFindingRoute, NormalizedReviewCheckpointPayload,
+		PendingReviewAction, PendingReviewCompletion, ProgressCheckpointArgs, PullRequestDetails,
+		REVIEW_POLICY_CONVERGENCE_BUDGET, ReviewCheckpointArgs, ReviewCheckpointChecksArgs,
+		ReviewCheckpointContractArgs, ReviewCheckpointFindingArgs,
+		ReviewCheckpointFindingRouteArgs, ReviewCheckpointFindingRouteCount,
+		ReviewCheckpointFindingRouteSummary, ReviewCheckpointHeadBinding,
+		ReviewCheckpointLineRangeArgs, ReviewCheckpointRejectedFindingArgs, ReviewExecutionMode,
+		ReviewFindingPolicyRecord, ReviewFindingPolicyState, ReviewHandoffArgs,
+		ReviewHandoffContext, ReviewPolicyPhase, ReviewPolicyState, ReviewPolicyStatus,
+		RunCompletionDisposition, TerminalFinalizeArgs, TrackerToolBridge, TransitionArgs,
 	},
 	orchestrator::{
 		self, AUTHORITY_BOUNDARY_CHECK_EVENT_TYPE, AuthorityDecisionOption,
@@ -38,6 +40,22 @@ const MANUAL_ATTENTION_TERMINAL_PATH: &str = "manual_attention";
 const INDEPENDENT_FRESH_CONTEXT_REVIEWER: &str = "independent_fresh_context";
 const REVIEW_COMPLETION_INTENT_EVENT_TYPE: &str = "review_completion_intent";
 const TERMINAL_FINALIZE_EVENT_TYPE: &str = "terminal_finalize";
+const REVIEW_ROUTE_CURRENT_BLOCKER: &str = "current_blocker";
+const REVIEW_ROUTE_LANDING_BLOCKER: &str = "landing_blocker";
+const REVIEW_ROUTE_CONTRACT_OR_AUTHORITY_DECISION_REQUIRED: &str =
+	"contract_or_authority_decision_required";
+const REVIEW_ROUTE_NEEDS_EVIDENCE: &str = "needs_evidence";
+const REVIEW_ROUTE_FOLLOW_UP: &str = "follow_up";
+const REVIEW_ROUTE_DETERMINISTIC_GATE_CANDIDATE: &str = "deterministic_gate_candidate";
+const REVIEW_ROUTE_ARCHITECTURE_SIGNAL: &str = "architecture_signal";
+const REVIEW_ROUTE_ISSUE_CONTRACT_GAP: &str = "issue_contract_gap";
+const REVIEW_ROUTE_REVIEWER_RUBRIC_GAP: &str = "reviewer_rubric_gap";
+const REVIEW_ROUTE_RISK_NOTE: &str = "risk_note";
+const REVIEW_ROUTE_INVALID_OR_UNSUBSTANTIATED: &str = "invalid_or_unsubstantiated";
+const REVIEW_ROUTE_SOURCE_ACCEPTED: &str = "accepted_findings";
+const REVIEW_ROUTE_SOURCE_REJECTED: &str = "rejected_findings";
+const REVIEW_ROUTE_SOURCE_ROUTE_ONLY: &str = "route_only";
+const REVIEW_ROUTE_RISK_HIGH: &str = "high";
 
 #[derive(Debug)]
 struct NormalizedManualAttentionComment {
@@ -77,6 +95,8 @@ struct ReviewCheckpointPayloadCounts {
 	evidence: usize,
 	accepted_findings: usize,
 	rejected_findings: usize,
+	finding_routes: usize,
+	current_blockers: usize,
 }
 
 struct ReviewFindingPolicyUpdate {
@@ -372,7 +392,8 @@ impl<'a> TrackerToolBridge<'a> {
 					"checks": review_checkpoint_checks_schema(),
 					"evidence": non_empty_string_array_schema(),
 					"accepted_findings": review_checkpoint_findings_array_schema(false),
-					"rejected_findings": review_checkpoint_findings_array_schema(true)
+					"rejected_findings": review_checkpoint_findings_array_schema(true),
+					"finding_routes": review_checkpoint_finding_routes_schema()
 				},
 				"required": ["reviewer", "status", "head_sha", "review_contract", "checks", "evidence"],
 				"additionalProperties": false
@@ -1296,6 +1317,9 @@ impl<'a> TrackerToolBridge<'a> {
 				evidence: prepared.checkpoint_payload.evidence.len(),
 				accepted_findings: prepared.checkpoint_payload.accepted_findings.len(),
 				rejected_findings: prepared.checkpoint_payload.rejected_findings.len(),
+				finding_routes: prepared.checkpoint_payload.finding_routes.len(),
+				current_blockers: current_review_blocker_findings(&prepared.checkpoint_payload)
+					.count(),
 			},
 		);
 
@@ -1445,8 +1469,12 @@ impl<'a> TrackerToolBridge<'a> {
 		counts: ReviewCheckpointPayloadCounts,
 	) -> String {
 		let evidence_suffix = format!(
-			"{} evidence item(s), {} accepted finding(s), and {} rejected finding(s) recorded",
-			counts.evidence, counts.accepted_findings, counts.rejected_findings,
+			"{} evidence item(s), {} accepted finding(s), {} rejected finding(s), {} route(s), and {} current blocker(s) recorded",
+			counts.evidence,
+			counts.accepted_findings,
+			counts.rejected_findings,
+			counts.finding_routes,
+			counts.current_blockers,
 		);
 
 		match review_policy_status {
@@ -1493,6 +1521,8 @@ impl<'a> TrackerToolBridge<'a> {
 			"nonclean_rounds": nonclean_rounds,
 			"active_fingerprints": &checkpoint_payload.finding_policy.active_fingerprints,
 			"stop_fingerprint": &checkpoint_payload.finding_policy.stop_fingerprint,
+			"route_counts": &checkpoint_payload.finding_route_summary.route_counts,
+			"route_next_action": &checkpoint_payload.finding_route_summary.next_action,
 			"review": checkpoint_payload,
 		});
 
@@ -2158,6 +2188,57 @@ fn review_checkpoint_findings_array_schema(rejected: bool) -> Value {
 	})
 }
 
+fn review_checkpoint_finding_routes_schema() -> Value {
+	serde_json::json!({
+		"type": "array",
+		"items": {
+			"type": "object",
+			"properties": {
+				"route": review_checkpoint_finding_route_schema(),
+				"severity": review_checkpoint_severity_schema(),
+				"risk_tier": {
+					"type": "string",
+					"enum": ["low", "medium", "high"]
+				},
+				"summary": { "type": "string" },
+				"evidence": non_empty_string_array_schema(),
+				"resolver": { "type": "string" },
+				"next_action": { "type": "string" },
+				"finding_source": {
+					"type": "string",
+					"enum": [
+						REVIEW_ROUTE_SOURCE_ACCEPTED,
+						REVIEW_ROUTE_SOURCE_REJECTED,
+						REVIEW_ROUTE_SOURCE_ROUTE_ONLY
+					]
+				},
+				"finding_index": { "type": "integer", "minimum": 0 }
+			},
+			"required": ["route", "severity", "summary", "evidence", "resolver", "next_action"],
+			"additionalProperties": false
+		}
+	})
+}
+
+fn review_checkpoint_finding_route_schema() -> Value {
+	serde_json::json!({
+		"type": "string",
+		"enum": [
+			REVIEW_ROUTE_CURRENT_BLOCKER,
+			REVIEW_ROUTE_LANDING_BLOCKER,
+			REVIEW_ROUTE_CONTRACT_OR_AUTHORITY_DECISION_REQUIRED,
+			REVIEW_ROUTE_NEEDS_EVIDENCE,
+			REVIEW_ROUTE_FOLLOW_UP,
+			REVIEW_ROUTE_DETERMINISTIC_GATE_CANDIDATE,
+			REVIEW_ROUTE_ARCHITECTURE_SIGNAL,
+			REVIEW_ROUTE_ISSUE_CONTRACT_GAP,
+			REVIEW_ROUTE_REVIEWER_RUBRIC_GAP,
+			REVIEW_ROUTE_RISK_NOTE,
+			REVIEW_ROUTE_INVALID_OR_UNSUBSTANTIATED
+		]
+	})
+}
+
 fn review_checkpoint_finding_schema(rejected: bool) -> Value {
 	let mut properties = Map::from_iter([
 		(String::from("severity"), review_checkpoint_severity_schema()),
@@ -2316,15 +2397,40 @@ fn normalize_review_checkpoint_payload(
 		.into_iter()
 		.map(normalize_rejected_review_checkpoint_finding)
 		.collect::<Result<Vec<_>, _>>()?;
+	let finding_routes = normalize_review_checkpoint_finding_routes(
+		parsed.finding_routes,
+		&accepted_findings,
+		&rejected_findings,
+	)?;
+	let finding_route_summary = summarize_review_checkpoint_finding_routes(&finding_routes);
 
-	if status == ReviewPolicyStatus::Findings && accepted_findings.is_empty() {
+	if status == ReviewPolicyStatus::Findings
+		&& !current_review_blocker_routes(&finding_routes).any(|route| {
+			route.finding_source == REVIEW_ROUTE_SOURCE_ACCEPTED
+				&& route.finding_fingerprint.is_some()
+		}) {
 		return Err(String::from(
-			"`issue_review_checkpoint` status `findings` requires at least one accepted finding. Put non-actionable reviewer comments in `rejected_findings` and use `clean` if no accepted repair remains.",
+			"`issue_review_checkpoint` status `findings` requires at least one accepted finding routed as `current_blocker`. Route non-current comments through `finding_routes` and use `clean` when no current repair remains.",
 		));
 	}
 	if status == ReviewPolicyStatus::Clean && !accepted_findings.is_empty() {
 		return Err(String::from(
 			"`issue_review_checkpoint` status `clean` cannot include accepted findings. Reject non-actionable comments explicitly or use status `findings` for accepted repair work.",
+		));
+	}
+	if status == ReviewPolicyStatus::Clean
+		&& finding_routes.iter().any(|route| {
+			route.route == REVIEW_ROUTE_CURRENT_BLOCKER || review_route_blocks_landing(route)
+		}) {
+		return Err(String::from(
+			"`issue_review_checkpoint` status `clean` can record only non-blocking `finding_routes` such as `follow_up`, `risk_note`, `reviewer_rubric_gap`, or `invalid_or_unsubstantiated`.",
+		));
+	}
+	if matches!(status, ReviewPolicyStatus::Blocked | ReviewPolicyStatus::NeedsArchitectureReview)
+		&& !finding_routes.iter().any(review_route_blocks_landing)
+	{
+		return Err(String::from(
+			"`issue_review_checkpoint` status `blocked` or `needs_architecture_review` requires at least one landing-blocking `finding_routes` item with evidence, resolver, and machine-actionable next_action.",
 		));
 	}
 
@@ -2341,6 +2447,8 @@ fn normalize_review_checkpoint_payload(
 		evidence,
 		accepted_findings,
 		rejected_findings,
+		finding_routes,
+		finding_route_summary,
 		finding_policy: empty_review_finding_policy(review_policy_phase, status, head_sha),
 	})
 }
@@ -2561,6 +2669,353 @@ fn normalize_rejected_review_checkpoint_finding(
 	})
 }
 
+fn normalize_review_checkpoint_finding_routes(
+	explicit_routes: Vec<ReviewCheckpointFindingRouteArgs>,
+	accepted_findings: &[NormalizedReviewCheckpointFinding],
+	rejected_findings: &[NormalizedRejectedReviewCheckpointFinding],
+) -> Result<Vec<NormalizedReviewCheckpointFindingRoute>, String> {
+	let mut routes = Vec::new();
+	let mut explicitly_routed_accepted = BTreeSet::new();
+	let mut explicitly_routed_rejected = BTreeSet::new();
+
+	for route in explicit_routes {
+		let route =
+			normalize_review_checkpoint_finding_route(route, accepted_findings, rejected_findings)?;
+
+		if route.finding_source == REVIEW_ROUTE_SOURCE_ACCEPTED
+			&& let Some(index) = route.finding_index
+		{
+			explicitly_routed_accepted.insert(index);
+		} else if route.finding_source == REVIEW_ROUTE_SOURCE_REJECTED
+			&& let Some(index) = route.finding_index
+		{
+			explicitly_routed_rejected.insert(index);
+		}
+
+		routes.push(route);
+	}
+	for (index, finding) in accepted_findings.iter().enumerate() {
+		let index = u64::try_from(index).map_err(|error| {
+			format!("Failed to normalize accepted finding route index: {error}")
+		})?;
+
+		if !explicitly_routed_accepted.contains(&index) {
+			routes.push(default_current_blocker_route(index, finding));
+		}
+	}
+	for (index, finding) in rejected_findings.iter().enumerate() {
+		let index = u64::try_from(index).map_err(|error| {
+			format!("Failed to normalize rejected finding route index: {error}")
+		})?;
+
+		if !explicitly_routed_rejected.contains(&index) {
+			routes.push(default_reviewer_rubric_gap_route(index, finding));
+		}
+	}
+
+	Ok(routes)
+}
+
+fn normalize_review_checkpoint_finding_route(
+	route: ReviewCheckpointFindingRouteArgs,
+	accepted_findings: &[NormalizedReviewCheckpointFinding],
+	rejected_findings: &[NormalizedRejectedReviewCheckpointFinding],
+) -> Result<NormalizedReviewCheckpointFindingRoute, String> {
+	let route_name = normalize_review_finding_route_name(route.route)?;
+	let severity = normalize_review_severity(route.severity, "finding_routes.severity")?;
+	let risk_tier = normalize_review_route_risk_tier(route.risk_tier)?;
+	let summary = normalize_required_review_text(route.summary, "finding_routes.summary")?;
+	let evidence =
+		normalize_required_review_evidence_list(route.evidence, "finding_routes.evidence")?;
+	let resolver = normalize_required_review_text(route.resolver, "finding_routes.resolver")?;
+	let next_action =
+		normalize_required_review_text(route.next_action, "finding_routes.next_action")?;
+	let finding_source = normalize_review_route_source(route.finding_source)?;
+	let (finding_index, finding_fingerprint) = normalize_review_route_binding(
+		&finding_source,
+		route.finding_index,
+		accepted_findings,
+		rejected_findings,
+	)?;
+	let bound_finding_high_severity = review_route_bound_finding_severity(
+		&finding_source,
+		finding_index,
+		accepted_findings,
+		rejected_findings,
+	)
+	.is_some_and(review_severity_blocks_invalid_route);
+
+	if route_name == REVIEW_ROUTE_CURRENT_BLOCKER
+		&& (finding_source != REVIEW_ROUTE_SOURCE_ACCEPTED || finding_fingerprint.is_none())
+	{
+		return Err(String::from(
+			"`finding_routes.route` `current_blocker` must bind to an `accepted_findings` item with `finding_index`.",
+		));
+	}
+	if route_name == REVIEW_ROUTE_INVALID_OR_UNSUBSTANTIATED
+		&& (review_severity_blocks_invalid_route(severity.as_str())
+			|| bound_finding_high_severity
+			|| risk_tier == REVIEW_ROUTE_RISK_HIGH)
+	{
+		return Err(String::from(
+			"`issue_review_checkpoint` cannot route high-severity or high-risk `finding_routes` items to `invalid_or_unsubstantiated`; use `needs_evidence` or a landing-blocking route.",
+		));
+	}
+
+	Ok(NormalizedReviewCheckpointFindingRoute {
+		route: route_name,
+		severity,
+		risk_tier,
+		summary,
+		evidence,
+		resolver,
+		next_action,
+		finding_source,
+		finding_index,
+		finding_fingerprint,
+	})
+}
+
+fn default_current_blocker_route(
+	index: u64,
+	finding: &NormalizedReviewCheckpointFinding,
+) -> NormalizedReviewCheckpointFindingRoute {
+	NormalizedReviewCheckpointFindingRoute {
+		route: String::from(REVIEW_ROUTE_CURRENT_BLOCKER),
+		severity: finding.severity.clone(),
+		risk_tier: String::from("medium"),
+		summary: finding.summary.clone(),
+		evidence: finding.evidence.clone(),
+		resolver: String::from("agent"),
+		next_action: finding.guidance.clone(),
+		finding_source: String::from(REVIEW_ROUTE_SOURCE_ACCEPTED),
+		finding_index: Some(index),
+		finding_fingerprint: Some(finding.fingerprint.clone()),
+	}
+}
+
+fn default_reviewer_rubric_gap_route(
+	index: u64,
+	finding: &NormalizedRejectedReviewCheckpointFinding,
+) -> NormalizedReviewCheckpointFindingRoute {
+	NormalizedReviewCheckpointFindingRoute {
+		route: String::from(REVIEW_ROUTE_REVIEWER_RUBRIC_GAP),
+		severity: finding.severity.clone(),
+		risk_tier: String::from("low"),
+		summary: finding.summary.clone(),
+		evidence: finding.evidence.clone(),
+		resolver: String::from("reviewer"),
+		next_action: finding.rejection_reason.clone(),
+		finding_source: String::from(REVIEW_ROUTE_SOURCE_REJECTED),
+		finding_index: Some(index),
+		finding_fingerprint: None,
+	}
+}
+
+fn normalize_review_finding_route_name(route: String) -> Result<String, String> {
+	let route = route.trim().to_ascii_lowercase().replace([' ', '-'], "_");
+
+	match route.as_str() {
+		REVIEW_ROUTE_CURRENT_BLOCKER
+		| REVIEW_ROUTE_LANDING_BLOCKER
+		| REVIEW_ROUTE_CONTRACT_OR_AUTHORITY_DECISION_REQUIRED
+		| REVIEW_ROUTE_NEEDS_EVIDENCE
+		| REVIEW_ROUTE_FOLLOW_UP
+		| REVIEW_ROUTE_DETERMINISTIC_GATE_CANDIDATE
+		| REVIEW_ROUTE_ARCHITECTURE_SIGNAL
+		| REVIEW_ROUTE_ISSUE_CONTRACT_GAP
+		| REVIEW_ROUTE_REVIEWER_RUBRIC_GAP
+		| REVIEW_ROUTE_RISK_NOTE
+		| REVIEW_ROUTE_INVALID_OR_UNSUBSTANTIATED => Ok(route),
+		other => Err(format!(
+			"`finding_routes.route` must be one of the supported Decodex Review route taxonomy values, not `{other}`."
+		)),
+	}
+}
+
+fn normalize_review_route_risk_tier(risk_tier: Option<String>) -> Result<String, String> {
+	let Some(risk_tier) = tracker_tool_bridge::normalize_optional_progress_field(risk_tier) else {
+		return Ok(String::from("low"));
+	};
+	let risk_tier = risk_tier.to_ascii_lowercase().replace([' ', '-'], "_");
+
+	match risk_tier.as_str() {
+		"low" | "medium" | REVIEW_ROUTE_RISK_HIGH => Ok(risk_tier),
+		other => Err(format!(
+			"`finding_routes.risk_tier` must be `low`, `medium`, or `high`, not `{other}`."
+		)),
+	}
+}
+
+fn normalize_review_route_source(source: Option<String>) -> Result<String, String> {
+	let Some(source) = tracker_tool_bridge::normalize_optional_progress_field(source) else {
+		return Ok(String::from(REVIEW_ROUTE_SOURCE_ROUTE_ONLY));
+	};
+	let source = source.to_ascii_lowercase().replace([' ', '-'], "_");
+
+	match source.as_str() {
+		REVIEW_ROUTE_SOURCE_ACCEPTED
+		| REVIEW_ROUTE_SOURCE_REJECTED
+		| REVIEW_ROUTE_SOURCE_ROUTE_ONLY => Ok(source),
+		other => Err(format!(
+			"`finding_routes.finding_source` must be `accepted_findings`, `rejected_findings`, or `route_only`, not `{other}`."
+		)),
+	}
+}
+
+fn normalize_review_route_binding(
+	source: &str,
+	index: Option<u64>,
+	accepted_findings: &[NormalizedReviewCheckpointFinding],
+	rejected_findings: &[NormalizedRejectedReviewCheckpointFinding],
+) -> Result<(Option<u64>, Option<String>), String> {
+	match source {
+		REVIEW_ROUTE_SOURCE_ACCEPTED => {
+			let index = index.ok_or_else(|| {
+				String::from(
+					"`finding_routes.finding_index` is required when `finding_source` is `accepted_findings`.",
+				)
+			})?;
+			let finding = accepted_findings
+				.get(usize::try_from(index).map_err(|error| {
+					format!("Failed to normalize accepted finding route index: {error}")
+				})?)
+				.ok_or_else(|| {
+					format!(
+						"`finding_routes.finding_index` `{index}` does not match any accepted finding."
+					)
+				})?;
+
+			Ok((Some(index), Some(finding.fingerprint.clone())))
+		},
+		REVIEW_ROUTE_SOURCE_REJECTED => {
+			let index = index.ok_or_else(|| {
+				String::from(
+					"`finding_routes.finding_index` is required when `finding_source` is `rejected_findings`.",
+				)
+			})?;
+
+			rejected_findings
+				.get(usize::try_from(index).map_err(|error| {
+					format!("Failed to normalize rejected finding route index: {error}")
+				})?)
+				.ok_or_else(|| {
+					format!(
+						"`finding_routes.finding_index` `{index}` does not match any rejected finding."
+					)
+				})?;
+
+			Ok((Some(index), None))
+		},
+		REVIEW_ROUTE_SOURCE_ROUTE_ONLY => {
+			if index.is_some() {
+				return Err(String::from(
+					"`finding_routes.finding_index` is only valid with `accepted_findings` or `rejected_findings` sources.",
+				));
+			}
+
+			Ok((None, None))
+		},
+		_ => Err(String::from(
+			"`finding_routes.finding_source` did not normalize to a supported source.",
+		)),
+	}
+}
+
+fn review_route_bound_finding_severity<'a>(
+	source: &str,
+	index: Option<u64>,
+	accepted_findings: &'a [NormalizedReviewCheckpointFinding],
+	rejected_findings: &'a [NormalizedRejectedReviewCheckpointFinding],
+) -> Option<&'a str> {
+	let index = usize::try_from(index?).ok()?;
+
+	match source {
+		REVIEW_ROUTE_SOURCE_ACCEPTED =>
+			accepted_findings.get(index).map(|finding| finding.severity.as_str()),
+		REVIEW_ROUTE_SOURCE_REJECTED =>
+			rejected_findings.get(index).map(|finding| finding.severity.as_str()),
+		_ => None,
+	}
+}
+
+fn review_severity_blocks_invalid_route(severity: &str) -> bool {
+	matches!(severity, "critical" | "high")
+}
+
+fn summarize_review_checkpoint_finding_routes(
+	routes: &[NormalizedReviewCheckpointFindingRoute],
+) -> ReviewCheckpointFindingRouteSummary {
+	let mut counts = BTreeMap::<String, usize>::new();
+
+	for route in routes {
+		*counts.entry(route.route.clone()).or_default() += 1;
+	}
+
+	ReviewCheckpointFindingRouteSummary {
+		route_counts: counts
+			.into_iter()
+			.map(|(route, count)| ReviewCheckpointFindingRouteCount { route, count })
+			.collect(),
+		next_action: review_route_next_action(routes),
+	}
+}
+
+fn review_route_next_action(routes: &[NormalizedReviewCheckpointFindingRoute]) -> Option<String> {
+	routes
+		.iter()
+		.min_by_key(|route| review_route_priority(&route.route))
+		.map(|route| route.next_action.clone())
+}
+
+fn review_route_priority(route: &str) -> u8 {
+	match route {
+		REVIEW_ROUTE_CURRENT_BLOCKER => 0,
+		REVIEW_ROUTE_LANDING_BLOCKER => 1,
+		REVIEW_ROUTE_CONTRACT_OR_AUTHORITY_DECISION_REQUIRED => 2,
+		REVIEW_ROUTE_NEEDS_EVIDENCE => 3,
+		REVIEW_ROUTE_DETERMINISTIC_GATE_CANDIDATE => 4,
+		REVIEW_ROUTE_ARCHITECTURE_SIGNAL => 5,
+		REVIEW_ROUTE_ISSUE_CONTRACT_GAP => 6,
+		REVIEW_ROUTE_FOLLOW_UP => 7,
+		REVIEW_ROUTE_RISK_NOTE => 8,
+		REVIEW_ROUTE_REVIEWER_RUBRIC_GAP => 9,
+		REVIEW_ROUTE_INVALID_OR_UNSUBSTANTIATED => 10,
+		_ => u8::MAX,
+	}
+}
+
+fn current_review_blocker_routes(
+	routes: &[NormalizedReviewCheckpointFindingRoute],
+) -> impl Iterator<Item = &NormalizedReviewCheckpointFindingRoute> {
+	routes.iter().filter(|route| route.route == REVIEW_ROUTE_CURRENT_BLOCKER)
+}
+
+fn current_review_blocker_findings(
+	payload: &NormalizedReviewCheckpointPayload,
+) -> impl Iterator<Item = &NormalizedReviewCheckpointFinding> {
+	let fingerprints = current_review_blocker_routes(&payload.finding_routes)
+		.filter_map(|route| route.finding_fingerprint.clone())
+		.collect::<BTreeSet<_>>();
+
+	payload
+		.accepted_findings
+		.iter()
+		.filter(move |finding| fingerprints.contains(&finding.fingerprint))
+}
+
+fn review_route_blocks_landing(route: &NormalizedReviewCheckpointFindingRoute) -> bool {
+	matches!(
+		route.route.as_str(),
+		REVIEW_ROUTE_LANDING_BLOCKER
+			| REVIEW_ROUTE_CONTRACT_OR_AUTHORITY_DECISION_REQUIRED
+			| REVIEW_ROUTE_NEEDS_EVIDENCE
+			| REVIEW_ROUTE_DETERMINISTIC_GATE_CANDIDATE
+			| REVIEW_ROUTE_ARCHITECTURE_SIGNAL
+			| REVIEW_ROUTE_ISSUE_CONTRACT_GAP
+	)
+}
+
 fn normalize_review_severity(severity: String, field_name: &str) -> Result<String, String> {
 	let severity = severity.trim().to_ascii_lowercase();
 
@@ -2730,8 +3185,12 @@ fn review_finding_policy_update(
 	checkpoint_payload: &NormalizedReviewCheckpointPayload,
 ) -> ReviewFindingPolicyUpdate {
 	let active_fingerprints = checkpoint_payload
-		.accepted_findings
+		.finding_routes
 		.iter()
+		.filter(|route| route.route == REVIEW_ROUTE_CURRENT_BLOCKER)
+		.filter_map(|route| route.finding_fingerprint.clone())
+		.collect::<BTreeSet<_>>();
+	let current_blocker_findings = current_review_blocker_findings(checkpoint_payload)
 		.map(|finding| finding.fingerprint.clone())
 		.collect::<BTreeSet<_>>();
 	let mut records = previous
@@ -2742,7 +3201,7 @@ fn review_finding_policy_update(
 
 	match status {
 		ReviewPolicyStatus::Findings => {
-			for finding in &checkpoint_payload.accepted_findings {
+			for finding in current_review_blocker_findings(checkpoint_payload) {
 				upsert_open_review_finding_record(
 					&mut records,
 					finding,
@@ -2760,7 +3219,7 @@ fn review_finding_policy_update(
 	}
 
 	let nonclean_rounds = if status == ReviewPolicyStatus::Findings {
-		active_fingerprints
+		current_blocker_findings
 			.iter()
 			.filter_map(|fingerprint| records.get(fingerprint))
 			.map(|record| record.repeat_count)
@@ -2769,7 +3228,7 @@ fn review_finding_policy_update(
 	} else {
 		0
 	};
-	let stop_fingerprint = active_fingerprints
+	let stop_fingerprint = current_blocker_findings
 		.iter()
 		.filter_map(|fingerprint| records.get(fingerprint).map(|record| (fingerprint, record)))
 		.filter(|(_fingerprint, record)| record.repeat_count >= REVIEW_POLICY_CONVERGENCE_BUDGET)

--- a/apps/decodex/src/orchestrator/agent_evidence.rs
+++ b/apps/decodex/src/orchestrator/agent_evidence.rs
@@ -295,7 +295,15 @@ struct PrivateEvidenceReviewCheckpointSummary {
 	stop_fingerprint: Option<String>,
 	accepted_finding_count: usize,
 	rejected_finding_count: usize,
+	route_counts: Vec<PrivateEvidenceReviewRouteCount>,
+	route_next_action: Option<String>,
 	next_action: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct PrivateEvidenceReviewRouteCount {
+	route: String,
+	count: usize,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -867,6 +875,7 @@ fn review_checkpoint_from_private_event(
 		.map_or(0, Vec::len);
 	let (active_fingerprints, stop_fingerprint) =
 		review_checkpoint_fingerprint_summary(payload);
+	let (route_counts, route_next_action) = review_checkpoint_route_summary(payload);
 	let next_action = review_checkpoint_next_action(&status);
 
 	Some(PrivateEvidenceReviewCheckpointSummary {
@@ -878,6 +887,8 @@ fn review_checkpoint_from_private_event(
 		stop_fingerprint,
 		accepted_finding_count,
 		rejected_finding_count,
+		route_counts,
+		route_next_action,
 		next_action,
 	})
 }
@@ -903,6 +914,37 @@ fn review_checkpoint_fingerprint_summary(payload: &Value) -> (Vec<String>, Optio
 		.map(str::to_owned);
 
 	(active_fingerprints, stop_fingerprint)
+}
+
+fn review_checkpoint_route_summary(
+	payload: &Value,
+) -> (Vec<PrivateEvidenceReviewRouteCount>, Option<String>) {
+	let review = payload.get("review").unwrap_or(payload);
+	let route_summary = review.get("finding_route_summary");
+	let route_counts = payload
+		.get("route_counts")
+		.or_else(|| route_summary.and_then(|summary| summary.get("route_counts")))
+		.and_then(Value::as_array)
+		.into_iter()
+		.flatten()
+		.filter_map(|count| {
+			Some(PrivateEvidenceReviewRouteCount {
+				route: count.get("route")?.as_str()?.to_owned(),
+				count: usize::try_from(count.get("count")?.as_u64()?).ok()?,
+			})
+		})
+		.collect();
+	let route_next_action = payload
+		.get("route_next_action")
+		.and_then(Value::as_str)
+		.or_else(|| {
+			route_summary
+				.and_then(|summary| summary.get("next_action"))
+				.and_then(Value::as_str)
+		})
+		.map(str::to_owned);
+
+	(route_counts, route_next_action)
 }
 
 fn review_checkpoint_next_action(status: &str) -> String {
@@ -1512,9 +1554,19 @@ fn append_private_evidence_review_checkpoints(
 			} else {
 				checkpoint.active_fingerprints.join(", ")
 			};
+			let route_counts = if checkpoint.route_counts.is_empty() {
+				String::from("none")
+			} else {
+				checkpoint
+					.route_counts
+					.iter()
+					.map(|count| format!("{}={}", count.route, count.count))
+					.collect::<Vec<_>>()
+					.join(", ")
+			};
 
 			output.push_str(&format!(
-				"- phase: {}\n  status: {}\n  head_sha: {}\n  round: {}\n  active_fingerprints: {}\n  stop_fingerprint: {}\n  accepted_findings: {}\n  rejected_findings: {}\n  next_action: {}\n",
+				"- phase: {}\n  status: {}\n  head_sha: {}\n  round: {}\n  active_fingerprints: {}\n  stop_fingerprint: {}\n  accepted_findings: {}\n  rejected_findings: {}\n  route_counts: {}\n  route_next_action: {}\n  next_action: {}\n",
 				checkpoint.phase,
 				checkpoint.status,
 				checkpoint.head_sha.as_deref().unwrap_or("none"),
@@ -1525,6 +1577,8 @@ fn append_private_evidence_review_checkpoints(
 				checkpoint.stop_fingerprint.as_deref().unwrap_or("none"),
 				checkpoint.accepted_finding_count,
 				checkpoint.rejected_finding_count,
+				route_counts,
+				checkpoint.route_next_action.as_deref().unwrap_or("none"),
 				checkpoint.next_action
 			));
 		}

--- a/apps/decodex/src/orchestrator/execution.rs
+++ b/apps/decodex/src/orchestrator/execution.rs
@@ -4195,6 +4195,7 @@ fn architecture_recovery_review_findings(
 		}));
 	};
 	let review = payload.get("review").unwrap_or(payload);
+	let route_summary = review.get("finding_route_summary");
 
 	Ok(json!({
 		"latest_status": payload.get("status").and_then(Value::as_str),
@@ -4206,6 +4207,13 @@ fn architecture_recovery_review_findings(
 			.get("rejected_findings")
 			.and_then(Value::as_array)
 			.map_or(0, Vec::len),
+		"route_counts": route_summary
+			.and_then(|summary| summary.get("route_counts"))
+			.cloned()
+			.unwrap_or_else(|| json!([])),
+		"route_next_action": route_summary
+			.and_then(|summary| summary.get("next_action"))
+			.and_then(Value::as_str),
 		"nonclean_rounds": payload.get("nonclean_rounds").and_then(Value::as_i64).unwrap_or(0),
 	}))
 }

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -316,6 +316,13 @@ struct OperatorExecutionProgramReadback {
 	issue_metadata_unavailable: bool,
 }
 
+struct OperatorReviewCheckpointSummaryFields {
+	active_fingerprints: Vec<String>,
+	stop_fingerprint: Option<String>,
+	route_counts: Vec<OperatorReviewRouteCount>,
+	route_next_action: Option<String>,
+}
+
 pub(crate) fn ensure_project_has_no_merged_worktree_cleanup_debt(
 	project: &ServiceConfig,
 ) -> crate::prelude::Result<()> {
@@ -8155,8 +8162,7 @@ fn operator_review_loop_status(
 
 	if let Some(checkpoint) = latest_checkpoint {
 		let nonclean_rounds = checkpoint.nonclean_rounds();
-		let (active_fingerprints, stop_fingerprint) =
-			operator_review_finding_policy_fields(checkpoint.details_json());
+		let summary = operator_review_checkpoint_summary_fields(checkpoint.details_json());
 
 		return Ok(Some(OperatorReviewLoopStatus {
 			phase: checkpoint.phase().to_owned(),
@@ -8165,8 +8171,10 @@ fn operator_review_loop_status(
 				head_sha: checkpoint.head_sha().to_owned(),
 				round: nonclean_rounds,
 				nonclean_rounds,
-				active_fingerprints,
-				stop_fingerprint,
+				active_fingerprints: summary.active_fingerprints,
+				stop_fingerprint: summary.stop_fingerprint,
+				route_counts: summary.route_counts,
+				route_next_action: summary.route_next_action,
 				updated_at: checkpoint.updated_at().to_owned(),
 			}),
 		}));
@@ -8185,15 +8193,20 @@ fn operator_review_loop_status(
 	Ok(None)
 }
 
-fn operator_review_finding_policy_fields(details_json: &str) -> (Vec<String>, Option<String>) {
+fn operator_review_checkpoint_summary_fields(
+	details_json: &str,
+) -> OperatorReviewCheckpointSummaryFields {
 	let Ok(details) = serde_json::from_str::<Value>(details_json) else {
-		return (Vec::new(), None);
+		return OperatorReviewCheckpointSummaryFields {
+			active_fingerprints: Vec::new(),
+			stop_fingerprint: None,
+			route_counts: Vec::new(),
+			route_next_action: None,
+		};
 	};
-	let Some(policy) = details.get("finding_policy") else {
-		return (Vec::new(), None);
-	};
+	let policy = details.get("finding_policy");
 	let active_fingerprints = policy
-		.get("active_fingerprints")
+		.and_then(|policy| policy.get("active_fingerprints"))
 		.and_then(Value::as_array)
 		.into_iter()
 		.flatten()
@@ -8201,11 +8214,33 @@ fn operator_review_finding_policy_fields(details_json: &str) -> (Vec<String>, Op
 		.map(str::to_owned)
 		.collect();
 	let stop_fingerprint = policy
-		.get("stop_fingerprint")
+		.and_then(|policy| policy.get("stop_fingerprint"))
+		.and_then(Value::as_str)
+		.map(str::to_owned);
+	let route_summary = details.get("finding_route_summary");
+	let route_counts = route_summary
+		.and_then(|summary| summary.get("route_counts"))
+		.and_then(Value::as_array)
+		.into_iter()
+		.flatten()
+		.filter_map(|count| {
+			Some(OperatorReviewRouteCount {
+				route: count.get("route")?.as_str()?.to_owned(),
+				count: usize::try_from(count.get("count")?.as_u64()?).ok()?,
+			})
+		})
+		.collect();
+	let route_next_action = route_summary
+		.and_then(|summary| summary.get("next_action"))
 		.and_then(Value::as_str)
 		.map(str::to_owned);
 
-	(active_fingerprints, stop_fingerprint)
+	OperatorReviewCheckpointSummaryFields {
+		active_fingerprints,
+		stop_fingerprint,
+		route_counts,
+		route_next_action,
+	}
 }
 
 fn operator_architecture_recovery_status_from_event(
@@ -8539,20 +8574,31 @@ fn operator_loop_status_next_action(
 		};
 	}
 
-	review.and_then(|review| match review.status.as_str() {
-		"pending" => Some(String::from(
-			"Record the independent Decodex Review checkpoint for the current lane head.",
-		)),
-		"findings" => Some(String::from(
-			"Repair validated review findings and record a fresh checkpoint.",
-		)),
-		"blocked" => Some(String::from(
-			"Resolve the blocked Decodex Review before continuing.",
-		)),
-		"needs_architecture_review" => Some(String::from(
-			"Get architecture direction before continuing review repair.",
-		)),
-		_ => None,
+	review.and_then(|review| {
+		if review.status != "clean"
+			&& let Some(route_next_action) = review
+				.checkpoint
+				.as_ref()
+				.and_then(|checkpoint| checkpoint.route_next_action.clone())
+		{
+			return Some(route_next_action);
+		}
+
+		match review.status.as_str() {
+			"pending" => Some(String::from(
+				"Record the independent Decodex Review checkpoint for the current lane head.",
+			)),
+			"findings" => Some(String::from(
+				"Repair validated review findings and record a fresh checkpoint.",
+			)),
+			"blocked" => Some(String::from(
+				"Resolve the blocked Decodex Review before continuing.",
+			)),
+			"needs_architecture_review" => Some(String::from(
+				"Get architecture direction before continuing review repair.",
+			)),
+			_ => None,
+		}
 	})
 }
 

--- a/apps/decodex/src/orchestrator/tests/operator/status/agent_evidence.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/agent_evidence.rs
@@ -839,6 +839,10 @@ fn assert_harness_private_readback(readback: &PrivateEvidenceReadback) {
 			&& checkpoint.head_sha.as_deref() == Some("abc123")
 			&& checkpoint.round == Some(1)
 			&& checkpoint.accepted_finding_count == 1
+			&& checkpoint.route_counts.iter().any(|count| {
+				count.route == "current_blocker" && count.count == 1
+			})
+			&& checkpoint.route_next_action.as_deref() == Some("Repair the accepted finding.")
 	}));
 	assert!(readback.phase_acceptance_checks.iter().any(|check| {
 		check.phase == "implement_to_validation_ready"
@@ -856,6 +860,8 @@ fn assert_harness_private_readback(readback: &PrivateEvidenceReadback) {
 	let rendered = orchestrator::render_private_evidence_readback(readback);
 
 	assert!(rendered.contains("Review Checkpoints"));
+	assert!(rendered.contains("route_counts: current_blocker=1"));
+	assert!(rendered.contains("route_next_action: Repair the accepted finding."));
 	assert!(rendered.contains("Phase Acceptance Checks"));
 	assert!(rendered.contains("Architecture Recoveries"));
 	assert!(rendered.contains("Boundary Checks"));
@@ -895,9 +901,15 @@ fn record_harness_signal_fixture_events(state_store: &StateStore) {
 				"status": "findings",
 				"head_sha": "abc123",
 				"nonclean_rounds": 1,
+				"route_counts": [{"route": "current_blocker", "count": 1}],
+				"route_next_action": "Repair the accepted finding.",
 				"review": {
 					"accepted_findings": [{"summary": "cover the missing edge case"}],
-					"rejected_findings": []
+					"rejected_findings": [],
+					"finding_route_summary": {
+						"route_counts": [{"route": "current_blocker", "count": 1}],
+						"next_action": "Repair the accepted finding."
+					}
 				}
 			}),
 		)

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -3819,7 +3819,16 @@ fn operator_status_current_lane_lifecycle_reconstructs_all_issue_attempts() {
 			status: "clean",
 			head_sha: "2222222222222222222222222222222222222222",
 			nonclean_rounds: 0,
-			details_json: "{}",
+			details_json: r#"{
+				"finding_route_summary": {
+					"route_counts": [{"route": "risk_note", "count": 1}],
+					"next_action": "Carry the routed risk note into follow-up planning."
+				},
+				"finding_policy": {
+					"active_fingerprints": [],
+					"stop_fingerprint": null
+				}
+			}"#,
 		})
 		.expect("review checkpoint should record");
 
@@ -3841,6 +3850,20 @@ fn operator_status_current_lane_lifecycle_reconstructs_all_issue_attempts() {
 	assert_eq!(run.lifecycle_metrics.phases[1].phase, "review");
 	assert_eq!(run.lifecycle_metrics.phases[1].attempt_count, 1);
 	assert_eq!(run.lifecycle_metrics.phases[1].wall_seconds, 300);
+
+	let review_checkpoint = run
+		.loop_status
+		.as_ref()
+		.and_then(|loop_status| loop_status.review.as_ref())
+		.and_then(|review| review.checkpoint.as_ref())
+		.expect("review checkpoint should render in loop status");
+
+	assert_eq!(review_checkpoint.route_counts[0].route, "risk_note");
+	assert_eq!(review_checkpoint.route_counts[0].count, 1);
+	assert_eq!(
+		review_checkpoint.route_next_action.as_deref(),
+		Some("Carry the routed risk note into follow-up planning.")
+	);
 }
 
 fn sample_lifecycle_activity(

--- a/apps/decodex/src/orchestrator/types.rs
+++ b/apps/decodex/src/orchestrator/types.rs
@@ -1891,7 +1891,15 @@ struct OperatorReviewCheckpointStatus {
 	nonclean_rounds: i64,
 	active_fingerprints: Vec<String>,
 	stop_fingerprint: Option<String>,
+	route_counts: Vec<OperatorReviewRouteCount>,
+	route_next_action: Option<String>,
 	updated_at: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct OperatorReviewRouteCount {
+	route: String,
+	count: usize,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/docs/spec/agent-evidence.md
+++ b/docs/spec/agent-evidence.md
@@ -6,9 +6,9 @@ status: active
 authority: normative
 owner: runtime
 tags: [spec]
-code_refs: [apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/orchestrator/types.rs]
-drift_watch: [decodex evidence, phase_acceptance_check, authority_boundary_check, architecture_recovery_packet, private_execution_evidence_readback]
-last_verified: 2026-06-17
+code_refs: [apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/types.rs]
+drift_watch: [decodex evidence, issue_review_checkpoint, phase_acceptance_check, authority_boundary_check, architecture_recovery_packet, private_execution_evidence_readback]
+last_verified: 2026-06-21
 ---
 # Agent Evidence
 
@@ -182,9 +182,9 @@ The readback includes:
 - Decodex Review checkpoint summaries when `review_checkpoint` events are present.
   Default readback may expose review phase, normalized status, head SHA, the
   compatibility round field, active/stop finding fingerprints, accepted/rejected
-  finding counts, and compact next action, but not raw reviewer finding bodies or
-  checklist payloads unless `--include-payload` is explicitly requested for local
-  repair.
+  finding counts, route counts, one route-derived next action, and compact next
+  action, but not raw reviewer finding bodies, route summaries, or checklist payloads
+  unless `--include-payload` is explicitly requested for local repair.
 - Phase Acceptance Check summaries when `phase_acceptance_check` events are present.
   Default readback may expose phase, decision, reason code, objective-coverage state,
   effective-delta state, changed surfaces, non-goal result, validation result, and

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -8,7 +8,7 @@ owner: runtime
 tags: [spec]
 code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/mcp.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs]
 drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, protocol_events, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, decodex intake goal, program_issue_mappings]
-last_verified: 2026-06-19
+last_verified: 2026-06-21
 ---
 # Runtime Specification
 
@@ -553,9 +553,9 @@ state for the current phase and current lane head from the owned lane:
 
 - no checkpoint and no terminal path: allow a clean continuation boundary
 - latest checkpoint `clean` and no terminal path: allow continuation so the agent can finish handoff or repair completion
-- latest checkpoint `findings` where every active accepted-finding fingerprint has
+- latest checkpoint `findings` where every active `current_blocker` fingerprint has
   been seen fewer than three times in the same phase: allow continuation
-- latest checkpoint `findings` where any active accepted-finding fingerprint has
+- latest checkpoint `findings` where any active `current_blocker` fingerprint has
   reached three repeats in the same phase: treat this as `review_churn`, stop the
   current repair strategy, and run the architecture recovery boundary check before
   either retrying with a materially different implementation strategy or routing to
@@ -571,16 +571,23 @@ level, and review prompt version. `issue_review_handoff`,
 matching evidence artifact to be `clean`; a missing or mismatched key fails closed.
 The stored checkpoint contains `phase`, `status`, `head_sha`, `nonclean_rounds`, and
 `details_json`.
-`nonclean_rounds` is the current phase's max active accepted-finding repeat count;
-new findings with different fingerprints do not inherit earlier repeats.
+`nonclean_rounds` is the current phase's max active `current_blocker` repeat count;
+new current-blocker findings with different fingerprints do not inherit earlier
+repeats.
 `details_json` holds the structured independent fresh-context review payload,
 including checklist notes, accepted findings, rejected findings, repair guidance,
-and the `finding_policy` fingerprint ledger.
+typed `finding_routes`, a compact `finding_route_summary`, and the `finding_policy`
+fingerprint ledger. Only accepted findings routed as `current_blocker` populate the
+active fingerprint ledger that can trigger review churn. Non-current routes such as
+`follow_up`, `risk_note`, `reviewer_rubric_gap`, and
+`invalid_or_unsubstantiated` remain durable in the checkpoint payload without driving
+repair.
 Each accepted checkpoint also appends a private `review_checkpoint` execution event
-with the same structured payload for local operator and repair readback. Linear
-receives only coarse lifecycle projections; raw reviewer findings stay in local
-runtime evidence unless another allowlisted lifecycle summary renders a public-safe
-summary.
+with the same structured payload for local operator and repair readback. The local
+operator status and private evidence readback may expose route counts and one
+route-derived next action, but not raw reviewer finding bodies. Linear receives only
+coarse lifecycle projections; raw reviewer findings stay in local runtime evidence
+unless another allowlisted lifecycle summary renders a public-safe summary.
 Recording `issue_review_handoff` or `issue_review_repair_complete` clears the current
 When `[codex].review` is `"off"` or `"basic"`, Decodex does not expose
 `issue_review_checkpoint`, does not require a clean checkpoint before review handoff

--- a/docs/spec/tracker-tools.md
+++ b/docs/spec/tracker-tools.md
@@ -8,7 +8,7 @@ owner: runtime
 tags: [spec]
 code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/agent/tracker_tool_bridge/review.rs, apps/decodex/src/orchestrator/execution.rs]
 drift_watch: [issue_progress_checkpoint, issue_review_checkpoint, issue_review_handoff, issue_review_repair_complete, review_contract, phase_acceptance_check, issue_terminal_finalize, docs_impact, private_execution_events, linear_execution_event]
-last_verified: 2026-06-20
+last_verified: 2026-06-21
 ---
 # Tracker Tool Specification
 
@@ -198,23 +198,52 @@ In either invalid case, `decodex` must fail the attempt rather than infer which 
 - Every new checkpoint payload must include checklist notes for intended behavior,
   regression risk, missing tests, docs/config drift, migration fallout,
   operator-facing fallout, and Loop/Decision Contract mismatch.
-- Review payload findings are split into accepted findings and rejected findings.
-  Accepted findings are the only repair input. Rejected findings record the
-  rejection reason for non-actionable, stale, out-of-scope, or unvalidated reviewer
-  comments.
-- A `findings` checkpoint must carry at least one accepted finding. A `clean`
-  checkpoint may carry rejected findings, but must not carry accepted findings.
+- Review payload findings are split into accepted findings, rejected findings, and
+  route evidence. Accepted and rejected finding arrays remain compatible with earlier
+  callers, but new adjudication uses `finding_routes` to decide where each review
+  signal belongs before repair. When `finding_routes` is omitted, accepted findings
+  default to `current_blocker` and rejected findings default to
+  `reviewer_rubric_gap`.
+- `finding_routes.route` supports this taxonomy: `current_blocker`,
+  `landing_blocker`, `contract_or_authority_decision_required`, `needs_evidence`,
+  `follow_up`, `deterministic_gate_candidate`, `architecture_signal`,
+  `issue_contract_gap`, `reviewer_rubric_gap`, `risk_note`, and
+  `invalid_or_unsubstantiated`.
+- Only accepted findings routed as `current_blocker` are current repair input. Only
+  those current-blocker fingerprints drive `repair_accepted_review_findings`,
+  `nonclean_rounds`, and review churn repeat counting. Non-current routes remain
+  durable in local evidence and status readback but must not start repair churn.
+  Rejected findings record the rejection reason for non-actionable, stale,
+  out-of-scope, or unvalidated reviewer comments.
+- A `findings` checkpoint must carry at least one accepted finding routed as
+  `current_blocker`. A `clean` checkpoint may carry rejected findings and
+  non-blocking routes such as
+  `follow_up`, `risk_note`, `reviewer_rubric_gap`, or
+  `invalid_or_unsubstantiated`, but must not carry accepted findings, current
+  blockers, or landing-blocking routes.
 - Top-level checkpoint evidence is required. Accepted findings must include severity,
   non-empty evidence, file and line or line-range references when possible, and
   concrete repair guidance. Rejected findings must include severity, non-empty
   evidence, and the rejection reason. Accepted and rejected findings may include a
   public snake_case `kind`; omitted kinds normalize to `accepted_finding` or
   `rejected_finding`.
+- Each explicit `finding_routes` item must include route, severity, non-empty
+  evidence, resolver, and machine-actionable `next_action`. A route may bind to an
+  accepted or rejected finding by `finding_source` plus zero-based `finding_index`,
+  or stand alone as `route_only`. `current_blocker` must bind to an accepted finding.
+  `blocked` and `needs_architecture_review` checkpoints must include at least one
+  landing-blocking route such as `landing_blocker`,
+  `contract_or_authority_decision_required`, `needs_evidence`,
+  `deterministic_gate_candidate`, `architecture_signal`, or `issue_contract_gap`.
+  High-severity (`critical` or `high`) or explicitly high-risk routes must not use
+  `invalid_or_unsubstantiated`; they must use `needs_evidence` or a
+  landing-blocking route.
 - Each accepted finding is normalized to a stable `review_finding:<sha256>`
   fingerprint from the review phase, finding kind, summary, guidance, file, and
   line range. The persisted review payload includes a `finding_policy` summary with
-  active fingerprints, per-fingerprint repeat counts, and an optional
-  `stop_fingerprint`.
+  active current-blocker fingerprints, per-fingerprint repeat counts, and an
+  optional `stop_fingerprint`. The persisted payload also includes a compact route
+  summary with route counts and one route-derived next action for local readback.
 - When `[codex].review` is `"standard"` or `"strict"`, `decodex` treats
   `issue_review_checkpoint` as the only authoritative structured review-policy
   signal. Skill prose or wrapper-local result words must not replace it.


### PR DESCRIPTION
## Summary
- Add typed issue_review_checkpoint finding_routes normalization and route taxonomy enforcement.
- Scope review repair/churn accounting to accepted findings routed as current_blocker.
- Persist compact route counts and next action in local private evidence/status readback.
- Update Decodex specs for review route policy and evidence boundaries.

## Validation
- cargo make fmt
- cargo make lint-fix
- cargo make test (1362 passed, 1 skipped)
- cargo make check-docs
- git diff --check

## Decodex Review
- Independent fresh-context read-only review checkpoint recorded clean for HEAD c94feefddaccbaa1e40eb03a6461ed68d6591ad5.