### PR TITLE
XY-1046: [DECODEX-DOGFOOD] Exercise compact review on a tiny low-risk lane

### DIFF
--- a/docs/spec/tracker-tools.md
+++ b/docs/spec/tracker-tools.md
@@ -199,7 +199,9 @@ In either invalid case, `decodex` must fail the attempt rather than infer which 
   (`compact_current_head_review` or `full_current_head_review`), `risk_class`,
   changed-surface count and public-safe summary, high-risk surface summary,
   current-head evidence flag, validation-backed flag, reviewer judgment, and
-  fallback reason for full review. Omitted cost-control metadata normalizes to
+  fallback reason for full review. Compact review checkpoints keep the fallback
+  reason absent, while full-review checkpoints must record the reason compact
+  review was not selected. Omitted cost-control metadata normalizes to
   `full_current_head_review` with fallback reason
   `review_cost_control_not_provided`.
 - `compact_current_head_review` is accepted only for a clean handoff checkpoint with


### PR DESCRIPTION
## Summary
- Clarifies tracker-tool docs for compact-review fallback evidence.
- Keeps the lane docs-only and limited to `docs/spec/tracker-tools.md`.
- Records compact-review eligibility through the Decodex review checkpoint for the current committed head.

## Validation
- `cargo make fmt`
- `cargo make lint-fix`
- `cargo make test` (1370 passed, 1 skipped)

## Decodex Review
- Review checkpoint: clean
- Review class: compact_current_head_review
- Risk class: low
- Accepted findings: 0
- Rejected findings: 0
- Nonclean rounds: 0