### PR TITLE
XY-1051: [DECODEX-P0] Make review handoff lifecycle marker writeback durable

### DIFF
--- a/apps/decodex/src/agent/tracker_tool_bridge/review.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/review.rs
@@ -11,7 +11,7 @@ use crate::{
 		REVIEW_REPAIR_PUBLIC_SUMMARY_FALLBACK, ReviewExecutionMode, ReviewHandoffContext,
 		ReviewHandoffWritebackFailed, ReviewPolicyPhase, ReviewPolicyState, ReviewPolicyStatus,
 		ReviewPolicyStopReason, ReviewPolicyStopRequested, RunCompletionDisposition, ScopeArgs,
-		TrackerToolBridge,
+		TrackerToolBridge, tools::REVIEW_COMPLETION_INTENT_EVENT_TYPE,
 	},
 	prelude::eyre,
 	state::{
@@ -54,6 +54,38 @@ impl<'a> TrackerToolBridge<'a> {
 		})?;
 
 		state_store.upsert_review_handoff_marker(&review_context.service_id, &self.issue.id, marker)
+	}
+
+	fn persist_review_handoff_marker_for_handoff(
+		&self,
+		review_context: &ReviewHandoffContext,
+		marker: &ReviewHandoffMarker,
+	) -> crate::prelude::Result<()> {
+		let state_store = self.state_store.ok_or_else(|| {
+			eyre::eyre!(
+				"Runtime state store is required to persist review handoff for issue `{}`.",
+				self.issue.identifier
+			)
+		})?;
+
+		if let Some(existing) = state_store.review_handoff_marker(
+			&review_context.service_id,
+			&self.issue.id,
+			&review_context.branch_name,
+		)? && !review_handoff_marker_lineage_matches(&existing, marker)
+		{
+			eyre::bail!(
+				"Existing review lifecycle record for issue `{}` branch `{}` points at PR `{}` head `{}`, but the current review handoff intent points at PR `{}` head `{}`. Use explicit review-handoff recovery before rebinding this lane.",
+				self.issue.identifier,
+				review_context.branch_name,
+				existing.pr_url(),
+				existing.pr_head_oid(),
+				marker.pr_url(),
+				marker.pr_head_oid()
+			);
+		}
+
+		self.persist_review_handoff_marker(review_context, marker)
 	}
 
 	fn persist_review_orchestration_marker(
@@ -194,6 +226,12 @@ impl<'a> TrackerToolBridge<'a> {
 				pull_request.head_repository_name,
 				local_repo.repository_owner,
 				local_repo.repository_name
+			));
+		}
+		if pull_request.url != pr_url {
+			return Err(format!(
+				"Pull request readback returned `{}` while validating requested PR `{}`.",
+				pull_request.url, pr_url
 			));
 		}
 		if pull_request.base_ref_name != local_repo.default_branch {
@@ -361,6 +399,99 @@ impl<'a> TrackerToolBridge<'a> {
 			== self.workflow.frontmatter().tracker().in_progress_state()
 	}
 
+	pub(super) fn persist_terminal_review_handoff_marker(
+		&self,
+		review_context: &ReviewHandoffContext,
+	) -> Result<(), String> {
+		let pending_review_handoff = {
+			let pending_review_handoff = self.pending_review_completion.borrow();
+			let Some(PendingReviewCompletion::Handoff(pending_review_handoff)) =
+				pending_review_handoff.as_ref()
+			else {
+				return Err(format!(
+					"`issue_terminal_finalize` cannot persist review handoff lifecycle state for issue `{}` because no PR-backed review handoff is pending.",
+					self.issue.identifier
+				));
+			};
+
+			pending_review_handoff.clone()
+		};
+		let pull_request =
+			self.validate_review_action_pr(review_context, &pending_review_handoff.pr_url)?;
+
+		self.require_matching_review_completion_intent(
+			review_context,
+			RunCompletionDisposition::ReviewHandoff,
+			&pull_request,
+		)?;
+
+		let handoff_marker = review_handoff_marker_from_pull_request(review_context, &pull_request);
+
+		self.persist_review_handoff_marker_for_handoff(review_context, &handoff_marker).map_err(
+			|error| {
+				format!(
+					"Failed to persist durable review handoff lifecycle marker for issue `{}`: {error}",
+					self.issue.identifier
+				)
+			},
+		)
+	}
+
+	fn require_matching_review_completion_intent(
+		&self,
+		review_context: &ReviewHandoffContext,
+		path: RunCompletionDisposition,
+		pull_request: &PullRequestDetails,
+	) -> Result<(), String> {
+		let state_store = self.state_store.ok_or_else(|| {
+			format!(
+				"`{}` requires the Decodex runtime state store for issue `{}`.",
+				self.required_pr_completion_tool_name(),
+				self.issue.identifier
+			)
+		})?;
+		let events = state_store
+			.list_private_execution_events(
+				&review_context.service_id,
+				&self.issue.id,
+				&review_context.run_id,
+				review_context.attempt_number,
+			)
+			.map_err(|error| {
+				format!(
+					"Failed to read private review completion intent for issue `{}`: {error}",
+					self.issue.identifier
+				)
+			})?;
+		let exact_intent_exists = events.iter().rev().any(|event| {
+			let payload = event.payload();
+
+			event.event_type() == REVIEW_COMPLETION_INTENT_EVENT_TYPE
+				&& payload.get("path").and_then(Value::as_str) == Some(path.as_str())
+				&& payload.get("mode").and_then(Value::as_str) == Some(review_context.mode.as_str())
+				&& payload.get("branch").and_then(Value::as_str)
+					== Some(review_context.branch_name.as_str())
+				&& payload.get("worktree_path").and_then(Value::as_str)
+					== Some(review_context.worktree_path.as_str())
+				&& payload.get("pr_url").and_then(Value::as_str) == Some(pull_request.url.as_str())
+				&& payload.get("pr_base_ref").and_then(Value::as_str)
+					== Some(pull_request.base_ref_name.as_str())
+				&& payload.get("pr_head_ref").and_then(Value::as_str)
+					== Some(pull_request.head_ref_name.as_str())
+				&& payload.get("pr_head_oid").and_then(Value::as_str)
+					== Some(pull_request.head_ref_oid.as_str())
+		});
+
+		if exact_intent_exists {
+			return Ok(());
+		}
+
+		Err(format!(
+			"`issue_terminal_finalize` requires an exact private review completion intent for issue `{}` before writing local review handoff lifecycle state.",
+			self.issue.identifier
+		))
+	}
+
 	pub(crate) fn completion_disposition(
 		&self,
 	) -> crate::prelude::Result<RunCompletionDisposition> {
@@ -480,15 +611,7 @@ impl<'a> TrackerToolBridge<'a> {
 			&pull_request,
 			success_state,
 		)?;
-		let handoff_marker = ReviewHandoffMarker::new(
-			review_context.run_id.clone(),
-			review_context.attempt_number,
-			review_context.branch_name.clone(),
-			pull_request.url.clone(),
-			pull_request.base_ref_name.clone(),
-			pull_request.head_ref_name.clone(),
-			pull_request.head_ref_oid.clone(),
-		);
+		let handoff_marker = review_handoff_marker_from_pull_request(review_context, &pull_request);
 		let orchestration_marker = ReviewOrchestrationMarker::new(
 			review_context.run_id.clone(),
 			review_context.attempt_number,
@@ -503,6 +626,9 @@ impl<'a> TrackerToolBridge<'a> {
 			0,
 			None,
 		);
+
+		self.persist_review_handoff_marker_for_handoff(review_context, &handoff_marker)?;
+		self.persist_review_orchestration_marker(review_context, &orchestration_marker)?;
 
 		if let Err(error) = tracker::create_prepared_linear_execution_event_comment(
 			self.tracker,
@@ -519,8 +645,6 @@ impl<'a> TrackerToolBridge<'a> {
 		}
 
 		self.persist_linear_execution_event(&projection.record)?;
-		self.persist_review_handoff_marker(review_context, &handoff_marker)?;
-		self.persist_review_orchestration_marker(review_context, &orchestration_marker)?;
 
 		if let Err(error) = self.tracker.update_issue_state(&self.issue.id, success_state_id) {
 			return Err(Report::new(ReviewHandoffWritebackFailed {
@@ -1090,6 +1214,32 @@ fn review_policy_stop_fingerprint(details_json: &str) -> Option<String> {
 		.get("stop_fingerprint")?
 		.as_str()
 		.map(str::to_owned)
+}
+
+fn review_handoff_marker_from_pull_request(
+	review_context: &ReviewHandoffContext,
+	pull_request: &PullRequestDetails,
+) -> ReviewHandoffMarker {
+	ReviewHandoffMarker::new(
+		review_context.run_id.clone(),
+		review_context.attempt_number,
+		review_context.branch_name.clone(),
+		pull_request.url.clone(),
+		pull_request.base_ref_name.clone(),
+		pull_request.head_ref_name.clone(),
+		pull_request.head_ref_oid.clone(),
+	)
+}
+
+fn review_handoff_marker_lineage_matches(
+	existing: &ReviewHandoffMarker,
+	marker: &ReviewHandoffMarker,
+) -> bool {
+	existing.branch_name() == marker.branch_name()
+		&& existing.pr_url() == marker.pr_url()
+		&& existing.target_base_ref_name() == marker.target_base_ref_name()
+		&& existing.pr_head_ref_name() == marker.pr_head_ref_name()
+		&& existing.pr_head_oid() == marker.pr_head_oid()
 }
 
 fn linear_execution_identity<'a>(

--- a/apps/decodex/src/agent/tracker_tool_bridge/tests/review/handoff.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests/review/handoff.rs
@@ -137,7 +137,7 @@ fn terminal_finalize_accepts_matching_review_handoff_path() {
 	let tracker = FakeTracker::new();
 	let issue = sample_issue();
 	let workflow = sample_workflow();
-	let inspector = FakePullRequestInspector::new(vec![Ok(PullRequestDetails {
+	let pull_request = PullRequestDetails {
 		head_ref_name: String::from("x/decodex-pub-618"),
 		head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
 		head_repository_name: String::from("decodex"),
@@ -146,7 +146,11 @@ fn terminal_finalize_accepts_matching_review_handoff_path() {
 		state: String::from("OPEN"),
 		base_ref_name: String::from("main"),
 		url: String::from("https://github.com/hack-ink/decodex/pull/53"),
-	})]);
+	};
+	let inspector = FakePullRequestInspector::new(vec![
+		Ok(pull_request.clone()),
+		Ok(pull_request.clone()),
+	]);
 	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
 	let review_context = sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
@@ -214,6 +218,103 @@ fn terminal_finalize_accepts_matching_review_handoff_path() {
 		event.event_type() == "terminal_finalize"
 			&& event.payload()["path"] == "review_handoff"
 	}));
+
+	let handoff_marker = persisted_review_handoff_marker(&bridge, &issue, &review_context);
+
+	assert_eq!(handoff_marker.pr_url(), "https://github.com/hack-ink/decodex/pull/53");
+	assert_eq!(
+		handoff_marker.pr_head_oid(),
+		"08a20f7dfb9526e7421a5f095b1c6adec84e52d6"
+	);
+}
+
+#[test]
+fn terminal_finalize_rejects_review_handoff_when_existing_marker_points_at_different_pr() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let tracker = FakeTracker::new();
+	let issue = sample_issue();
+	let workflow = sample_workflow();
+	let pull_request = PullRequestDetails {
+		head_ref_name: String::from("x/decodex-pub-618"),
+		head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
+		head_repository_name: String::from("decodex"),
+		head_repository_owner: String::from("hack-ink"),
+		is_draft: false,
+		state: String::from("OPEN"),
+		base_ref_name: String::from("main"),
+		url: String::from("https://github.com/hack-ink/decodex/pull/53"),
+	};
+	let inspector = FakePullRequestInspector::new(vec![
+		Ok(pull_request.clone()),
+		Ok(pull_request.clone()),
+	]);
+	let local_repo_inspector =
+		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
+	let review_context = sample_review_context_in(temp_dir.path());
+	let bridge = TrackerToolBridge::with_review_handoff_for_test(
+		&tracker,
+		&issue,
+		&workflow,
+		review_context.clone(),
+		&inspector,
+		&local_repo_inspector,
+	);
+
+	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	bridge_state_store(&bridge)
+		.upsert_review_handoff_marker(
+			TEST_SERVICE_ID,
+			&issue.id,
+			&ReviewHandoffMarker::new(
+				"old-run",
+				1,
+				"x/decodex-pub-618",
+				"https://github.com/hack-ink/decodex/pull/99",
+				"main",
+				"x/decodex-pub-618",
+				"08a20f7dfb9526e7421a5f095b1c6adec84e52d6",
+			),
+		)
+		.expect("existing marker should seed");
+
+	let review_response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_REVIEW_HANDOFF_TOOL_NAME,
+		serde_json::json!({
+			"pr_url": "https://github.com/hack-ink/decodex/pull/53",
+			"summary": "Ready for review."
+		}),
+	);
+	let checkpoint_response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_PROGRESS_CHECKPOINT_TOOL_NAME,
+		serde_json::json!({
+			"phase": "ready_for_review",
+			"docs_impact": "none",
+			"focus": "Finalize review handoff.",
+			"next_action": "Record terminal finalize.",
+			"blockers": [],
+			"evidence": ["Review handoff recorded."]
+		}),
+	);
+	let finalize_response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_TERMINAL_FINALIZE_TOOL_NAME,
+		serde_json::json!({ "path": "review_handoff" }),
+	);
+
+	assert!(review_response.success);
+	assert!(checkpoint_response.success);
+	assert!(!finalize_response.success);
+	assert!(matches!(
+		finalize_response.content_items.as_slice(),
+		[DynamicToolContentItem::InputText { text }]
+			if text.contains("Use explicit review-handoff recovery before rebinding this lane.")
+	));
+	assert_eq!(
+		persisted_review_handoff_marker(&bridge, &issue, &review_context).pr_url(),
+		"https://github.com/hack-ink/decodex/pull/99"
+	);
 }
 
 #[test]
@@ -740,9 +841,22 @@ fn reports_review_handoff_writeback_failure_when_tracker_comment_write_fails() {
 			base_ref_name: String::from("main"),
 			url: String::from("https://github.com/hack-ink/decodex/pull/50"),
 		}),
+		Ok(PullRequestDetails {
+			head_ref_name: String::from("x/decodex-pub-618"),
+			head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
+			head_repository_name: String::from("decodex"),
+			head_repository_owner: String::from("hack-ink"),
+			is_draft: false,
+			state: String::from("OPEN"),
+			base_ref_name: String::from("main"),
+			url: String::from("https://github.com/hack-ink/decodex/pull/50"),
+		}),
 	]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(sample_local_repo()),
+		Ok(sample_local_repo()),
+		Ok(sample_local_repo()),
+	]);
 	let review_context = sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
@@ -766,6 +880,33 @@ fn reports_review_handoff_writeback_failure_when_tracker_comment_write_fails() {
 
 	assert!(response.success);
 
+	bridge_state_store(&bridge)
+		.append_private_execution_event(
+			TEST_SERVICE_ID,
+			&issue.id,
+			&review_context.run_id,
+			review_context.attempt_number,
+			"progress_checkpoint",
+			serde_json::json!({
+				"phase": "ready_for_review",
+				"docs_impact": "none",
+				"head_sha": sample_local_repo().head_oid,
+				"focus": "Finalize review handoff.",
+				"next_action": "Record terminal finalize.",
+				"blockers": [],
+				"evidence": ["Review handoff recorded."]
+			}),
+		)
+		.expect("private progress checkpoint should seed");
+
+	let finalize_response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_TERMINAL_FINALIZE_TOOL_NAME,
+		serde_json::json!({ "path": "review_handoff" }),
+	);
+
+	assert!(finalize_response.success);
+
 	let error = bridge.apply_review_handoff().expect_err(
 		"comment write failures after state transition must surface as partial writeback",
 	);
@@ -780,11 +921,13 @@ fn reports_review_handoff_writeback_failure_when_tracker_comment_write_fails() {
 	assert!(writeback_error.source.contains("tracker comment write failed"));
 	assert!(tracker.state_updates.borrow().is_empty());
 	assert!(tracker.comments.borrow().is_empty());
-	assert!(
+	assert_eq!(
 		bridge_state_store(&bridge)
 			.review_handoff_marker(TEST_SERVICE_ID, &issue.id, "x/decodex-pub-618")
 			.expect("runtime handoff marker read should succeed")
-			.is_none()
+			.expect("tracker writeback failure should keep durable handoff marker")
+			.pr_url(),
+		"https://github.com/hack-ink/decodex/pull/50"
 	);
 }
 

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools.rs
@@ -36,10 +36,11 @@ use crate::{
 	},
 };
 
+pub(super) const REVIEW_COMPLETION_INTENT_EVENT_TYPE: &str = "review_completion_intent";
+
 const COMMENT_KIND_MANUAL_ATTENTION: &str = "manual_attention";
 const MANUAL_ATTENTION_TERMINAL_PATH: &str = "manual_attention";
 const INDEPENDENT_FRESH_CONTEXT_REVIEWER: &str = "independent_fresh_context";
-const REVIEW_COMPLETION_INTENT_EVENT_TYPE: &str = "review_completion_intent";
 const TERMINAL_FINALIZE_EVENT_TYPE: &str = "terminal_finalize";
 const REVIEW_CLASS_COMPACT_CURRENT_HEAD: &str = "compact_current_head_review";
 const REVIEW_CLASS_FULL_CURRENT_HEAD: &str = "full_current_head_review";
@@ -2111,6 +2112,13 @@ impl<'a> TrackerToolBridge<'a> {
 		if let Err(error) = self.ensure_docs_impact_checkpoint(review_context, actual_path) {
 			return DynamicToolCallResponse::failure(error);
 		}
+
+		if actual_path == RunCompletionDisposition::ReviewHandoff
+			&& let Err(error) = self.persist_terminal_review_handoff_marker(review_context)
+		{
+			return DynamicToolCallResponse::failure(error);
+		}
+
 		if let Err(error) = self.append_terminal_finalize_event(review_context, actual_path) {
 			return DynamicToolCallResponse::failure(error);
 		}

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -8864,7 +8864,11 @@ fn operator_run_terminal_finalize_projection(
 		"review_handoff" => Some(OperatorTerminalFinalizeProjection {
 			status: "review_handoff_pending",
 			phase: "terminal_pending",
-			wait_reason: "review_handoff_writeback",
+			wait_reason: review_handoff_terminal_finalize_wait_reason(
+				loop_evidence,
+				run,
+				events,
+			),
 			current_operation: RUN_OPERATION_REVIEW_WRITEBACK,
 		}),
 		"review_repair" => Some(OperatorTerminalFinalizeProjection {
@@ -8887,6 +8891,34 @@ fn operator_run_terminal_finalize_projection(
 		}),
 		_ => None,
 	}
+}
+
+fn review_handoff_terminal_finalize_wait_reason(
+	loop_evidence: &ProjectLoopEvidenceSnapshot,
+	run: &ProjectRunStatus,
+	events: &[PrivateExecutionEvent],
+) -> &'static str {
+	let Some(intent) = events.iter().rev().find(|event| {
+		let payload = event.payload();
+
+		event.event_type() == "review_completion_intent"
+			&& payload.get("path").and_then(Value::as_str) == Some("review_handoff")
+			&& payload.get("mode").and_then(Value::as_str) == Some("handoff")
+			&& payload.get("pr_url").and_then(Value::as_str).is_some()
+			&& payload.get("pr_head_oid").and_then(Value::as_str).is_some()
+			&& payload.get("worktree_path").and_then(Value::as_str).is_some()
+	}) else {
+		return "review_handoff_writeback";
+	};
+	let Some(branch) = intent.payload().get("branch").and_then(Value::as_str) else {
+		return "review_handoff_writeback";
+	};
+
+	if loop_evidence.review_lifecycle_record(run.issue_id(), branch).is_none() {
+		return "review_handoff_writeback_missing_lifecycle_marker";
+	}
+
+	"review_handoff_writeback"
 }
 
 fn operator_run_continuation_recovery_status(

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -3289,6 +3289,87 @@ fn operator_status_projects_terminal_finalized_run_as_pending_not_active() {
 	child.wait().expect("sleep child should reap");
 }
 
+#[test]
+fn operator_status_projects_terminal_finalized_handoff_missing_lifecycle_marker() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let registration = ProjectRegistration::from_config(
+		config.service_id(),
+		&service_config_path(config.repo_root()),
+		&config,
+		true,
+		"test-fingerprint",
+	);
+	let issue = sample_issue("Todo", &[]);
+	let worktree_path = config.worktree_root().join("PUB-101");
+
+	state_store.upsert_project(&registration).expect("project should register");
+	state_store
+		.record_run_attempt("run-1", &issue.id, 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+	state_store
+		.append_private_execution_event(
+			"pubfi",
+			&issue.id,
+			"run-1",
+			1,
+			"review_completion_intent",
+			serde_json::json!({
+				"path": "review_handoff",
+				"mode": "handoff",
+				"branch": "x/pubfi-pub-101",
+				"worktree_path": worktree_path.display().to_string(),
+				"pr_url": "https://github.com/hack-ink/decodex/pull/101",
+				"pr_base_ref": "main",
+				"pr_head_ref": "x/pubfi-pub-101",
+				"pr_head_oid": "08a20f7dfb9526e7421a5f095b1c6adec84e52d6",
+				"summary": "Ready for review."
+			}),
+		)
+		.expect("handoff intent should record");
+	state_store
+		.append_private_execution_event(
+			"pubfi",
+			&issue.id,
+			"run-1",
+			1,
+			"terminal_finalize",
+			serde_json::json!({
+				"path": "review_handoff",
+				"mode": "handoff",
+				"branch": "x/pubfi-pub-101",
+				"worktree_path": worktree_path.display().to_string(),
+			}),
+		)
+		.expect("terminal finalize event should record");
+
+	fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+
+	let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+		.expect("snapshot should build");
+	let run = snapshot
+		.recent_runs
+		.iter()
+		.find(|run| run.run_id == "run-1")
+		.expect("terminal-pending run should remain inspectable in recent runs");
+
+	assert_eq!(run.status, "review_handoff_pending");
+	assert_eq!(run.phase, "terminal_pending");
+	assert_eq!(
+		run.wait_reason.as_deref(),
+		Some("review_handoff_writeback_missing_lifecycle_marker")
+	);
+	assert_eq!(run.current_operation, state::RUN_OPERATION_REVIEW_WRITEBACK);
+}
+
 fn assert_terminal_pending_status_projection(snapshot: &OperatorStatusSnapshot) {
 	let project = snapshot.projects.first().expect("project summary should exist");
 	let run = snapshot

--- a/docs/spec/post-review-lifecycle.md
+++ b/docs/spec/post-review-lifecycle.md
@@ -6,7 +6,7 @@ status: active
 authority: normative
 owner: runtime
 tags: [spec]
-last_verified: 2026-06-17
+last_verified: 2026-06-22
 ---
 # Post-Review Lifecycle
 
@@ -97,6 +97,14 @@ If these signals disagree and the disagreement cannot be resolved without guessi
 `missing_review_handoff_record` is a fail-closed post-review state. The scheduler must
 not infer a PR lineage from branch names, current heads, PR titles, or Linear comments,
 and `decodex run` must not repair this state automatically.
+
+If operator status sees private `review_completion_intent` plus
+`issue_terminal_finalize(path = "review_handoff")` but no matching
+`review_lifecycle_records` row, it must expose a deterministic pending writeback
+reason such as `review_handoff_writeback_missing_lifecycle_marker`. That readback is
+only a fail-closed recovery contract: recovery may proceed automatically only when the
+exact private intent, PR URL, retained branch, local `HEAD`, and PR head still match.
+Otherwise operators must use explicit diagnose, rebind, or adopt recovery.
 
 Failure writeback must also respect this post-review boundary. If an execution failure
 arrives after a retained review lifecycle record already binds the current issue,

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -8,7 +8,7 @@ owner: runtime
 tags: [spec]
 code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/mcp.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs]
 drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, protocol_events, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, decodex intake goal, program_issue_mappings]
-last_verified: 2026-06-21
+last_verified: 2026-06-22
 ---
 # Runtime Specification
 
@@ -617,11 +617,24 @@ During the run, the coding agent should prepare a PR-backed handoff by:
 3. calling the dedicated review handoff tool with the PR URL and a short summary
 4. calling `issue_terminal_finalize(path = "review_handoff")`
 
+The handoff tool first records private `review_completion_intent`. Terminal finalize
+for `review_handoff` is the local durability boundary: it must revalidate that the
+private intent, requested PR URL, retained worktree branch, current local `HEAD`, PR
+head ref, PR head OID, and repository/base readback all match, then persist the
+authoritative `review_lifecycle_records` row before the tool can return success. An
+existing lifecycle row for the same issue and branch must not be silently rebound to a
+different PR or head; that requires explicit review-handoff recovery.
+
 After agent execution and post-run validation succeed, `decodex` should:
 
 1. confirm that the recorded PR still belongs to the current repository and branch and that its head commit matches the validated lane HEAD
 2. transition the issue to `In Review`
 3. post the structured completion comment from the recorded handoff
+
+If a public tracker write fails after terminal finalize wrote the local lifecycle row,
+Decodex must leave that row intact for fail-closed recovery and classify the public
+writeback failure without guessing PR lineage from branch names, titles, comments, or
+stale snapshots.
 
 If the `In Review` transition succeeds but the completion comment fails, `decodex` must stop automatic retries for that attempt and converge the lane through the human-required failure path instead of treating it as retryable work.
 

--- a/docs/spec/tracker-tools.md
+++ b/docs/spec/tracker-tools.md
@@ -8,7 +8,7 @@ owner: runtime
 tags: [spec]
 code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/agent/tracker_tool_bridge/review.rs, apps/decodex/src/orchestrator/execution.rs]
 drift_watch: [issue_progress_checkpoint, issue_review_checkpoint, issue_review_handoff, issue_review_repair_complete, review_contract, review_cost_control, phase_acceptance_check, issue_terminal_finalize, docs_impact, private_execution_events, linear_execution_event]
-last_verified: 2026-06-21
+last_verified: 2026-06-22
 ---
 # Tracker Tool Specification
 
@@ -275,9 +275,17 @@ In either invalid case, `decodex` must fail the attempt rather than infer which 
   `issue_review_repair_complete` must not require `issue_review_checkpoint`; they
   still must pass PR validation, branch/head checks, and the configured repository
   validation gate before writeback.
-- `issue_review_handoff` must validate that the supplied PR belongs to the current repository and lane branch, points at the validated lane HEAD, is open, and is ready for review before `decodex` accepts the handoff.
+- `issue_review_handoff` must validate that the supplied PR belongs to the current repository and lane branch, points at the validated lane HEAD, is open, is ready for review, and reads back as the same requested PR URL before `decodex` accepts the handoff.
 - `issue_review_repair_complete` must validate that the supplied PR belongs to the current repository and retained lane branch, points at the validated lane HEAD, is open, and is ready for fresh review before `decodex` accepts retained repair completion.
-- `issue_review_handoff` records the success metadata during the turn, but `decodex` owns the final completion comment and `In Review` transition after service-side validation succeeds.
+- `issue_review_handoff` records a private `review_completion_intent` during the
+  turn, but `decodex` owns the final completion comment and `In Review` transition
+  after service-side validation succeeds. `issue_terminal_finalize(path =
+  "review_handoff")` must revalidate the pending PR against that exact private
+  intent, the retained worktree branch, the current local HEAD, and the PR head, then
+  write the local `review_lifecycle_records` row before terminal finalize can
+  succeed. If an existing lifecycle row for the lane branch points at a different PR
+  URL, head ref, base ref, or head OID, the tool must fail closed and require explicit
+  review-handoff recovery instead of rebinding implicitly.
 - `issue_review_repair_complete` records retained repair completion metadata during the turn, but `decodex` owns the final completion comment and refreshed retained-lineage marker after service-side validation succeeds.
 - Agent-authored PR lifecycle summaries are public text inputs. If the summary recorded
   by `issue_review_handoff`, `issue_review_repair_complete`, or `issue_closeout_complete`
@@ -377,9 +385,10 @@ In either invalid case, `decodex` must fail the attempt rather than infer which 
 - If PR-backed success writeback partially succeeds, for example the issue reaches `In Review` but the completion comment fails to post, `decodex` must treat the lane as human-required and must not place it back on the automatic retry path.
 - If a remaining public writeback validation failure occurs after successful PR
   validation, Decodex must classify it as `review_handoff_writeback_failed`, preserve
-  the PR URL in the public recovery record when available, and stop in a recoverable
-  human-required state instead of downgrading the completed implementation work to a
-  generic coding failure.
+  the PR URL in the public recovery record when available, keep the already-written
+  local review lifecycle row when terminal finalization succeeded, and stop in a
+  recoverable human-required state instead of downgrading the completed
+  implementation work to a generic coding failure.
 
 ## Future expansion
 


### PR DESCRIPTION
## Summary
- persist review handoff lifecycle markers before public tracker writeback and during terminal finalize
- require exact private intent plus PR/worktree/head lineage before durable handoff marker writeback
- expose fail-closed missing lifecycle marker readback and update runtime/tracker specs

## Validation
- cargo make fmt
- cargo make lint-fix
- cargo make check-docs
- cargo make test

## Review
- Decodex independent fresh-context review checkpoint: clean for HEAD 5c2b90666e69c9fb61452ca59e8e45d093e351e6