### PR TITLE
XY-1052: [DECODEX-P0] Harden compact review quality gates and readback

### DIFF
--- a/apps/decodex/src/agent/tracker_tool_bridge.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge.rs
@@ -874,6 +874,10 @@ struct ReviewCostControlArgs {
 	high_risk_surfaces: Vec<String>,
 	current_head_evidence: bool,
 	validation_backed: bool,
+	#[serde(default)]
+	validation_current: bool,
+	#[serde(default)]
+	evidence_sufficient: bool,
 	reviewer_judgment: String,
 	fallback_reason: Option<String>,
 }
@@ -998,6 +1002,8 @@ struct NormalizedReviewCostControl {
 	high_risk_surfaces: Vec<String>,
 	current_head_evidence: bool,
 	validation_backed: bool,
+	validation_current: bool,
+	evidence_sufficient: bool,
 	reviewer_judgment: String,
 	fallback_reason: Option<String>,
 }

--- a/apps/decodex/src/agent/tracker_tool_bridge/tests/review/policy.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests/review/policy.rs
@@ -99,6 +99,8 @@ fn compact_review_cost_control_json() -> Value {
 		"high_risk_surfaces": [],
 		"current_head_evidence": true,
 		"validation_backed": true,
+		"validation_current": true,
+		"evidence_sufficient": true,
 		"reviewer_judgment": "The reviewer independently checked intended behavior and adversarial risk and found a low-risk small current-head lane."
 	})
 }
@@ -115,6 +117,8 @@ fn full_review_cost_control_json(fallback_reason: &str) -> Value {
 		"high_risk_surfaces": ["operator-facing runtime review behavior"],
 		"current_head_evidence": true,
 		"validation_backed": true,
+		"validation_current": true,
+		"evidence_sufficient": true,
 		"reviewer_judgment": "The reviewer used full independent review because compact-review guardrails did not all pass.",
 		"fallback_reason": fallback_reason
 	})
@@ -901,6 +905,8 @@ fn compact_review_checkpoint_persists_low_risk_cost_control() {
 	assert_eq!(details["review_cost_control"]["review_class"], "compact_current_head_review");
 	assert_eq!(details["review_cost_control"]["risk_class"], "low");
 	assert_eq!(details["review_cost_control"]["compact_eligible"], true);
+	assert_eq!(details["review_cost_control"]["validation_current"], true);
+	assert_eq!(details["review_cost_control"]["evidence_sufficient"], true);
 	assert!(details["review_cost_control"]["fallback_reason"].is_null());
 
 	let events = bridge_state_store(&bridge)
@@ -962,7 +968,7 @@ fn full_review_checkpoint_persists_cost_control_fallback_reason() {
 }
 
 #[test]
-fn compact_review_checkpoint_fails_closed_without_validation_or_with_high_risk_surface() {
+fn compact_review_checkpoint_fails_closed_without_current_validation_or_with_high_risk_surface() {
 	let tracker = FakeTracker::new();
 	let issue = sample_issue();
 	let workflow = sample_workflow();
@@ -980,9 +986,17 @@ fn compact_review_checkpoint_fails_closed_without_validation_or_with_high_risk_s
 	);
 	let mut cost_control = compact_review_cost_control_json();
 
+	cost_control["current_head_evidence"] = serde_json::json!(false);
 	cost_control["validation_backed"] = serde_json::json!(false);
-	cost_control["high_risk_surfaces"] =
-		serde_json::json!(["security-sensitive runtime configuration"]);
+	cost_control["validation_current"] = serde_json::json!(false);
+	cost_control["evidence_sufficient"] = serde_json::json!(false);
+	cost_control["high_risk_surfaces"] = serde_json::json!([
+		"docs policy surface without matching validation evidence",
+		"configuration surface without matching validation evidence",
+		"public API surface without matching validation evidence",
+		"security surface without matching validation evidence",
+		"data/privacy surface without matching validation evidence"
+	]);
 
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -1004,7 +1018,205 @@ fn compact_review_checkpoint_fails_closed_without_validation_or_with_high_risk_s
 		[DynamicToolContentItem::InputText { text }] => {
 			assert!(text.contains("full review is required"));
 			assert!(text.contains("high_risk_surfaces_present"));
+			assert!(text.contains("missing_current_head_evidence"));
 			assert!(text.contains("missing_validation_evidence"));
+			assert!(text.contains("stale_validation_evidence"));
+			assert!(text.contains("weak_evidence"));
+		},
+		other => panic!("unexpected response content: {other:?}"),
+	}
+}
+
+#[test]
+fn compact_review_checkpoint_fails_closed_with_stale_validation_evidence() {
+	let tracker = FakeTracker::new();
+	let issue = sample_issue();
+	let workflow = sample_workflow();
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let review_context = sample_review_context_in(temp_dir.path());
+	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let bridge = TrackerToolBridge::with_review_handoff_for_test(
+		&tracker,
+		&issue,
+		&workflow,
+		review_context,
+		&pull_request_inspector,
+		&local_repo_inspector,
+	);
+	let mut cost_control = compact_review_cost_control_json();
+
+	cost_control["validation_current"] = serde_json::json!(false);
+
+	let response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_REVIEW_CHECKPOINT_TOOL_NAME,
+		serde_json::json!({
+			"reviewer": "independent_fresh_context",
+			"status": "clean",
+			"head_sha": sample_local_repo().head_oid,
+			"review_contract": low_risk_handoff_review_contract_json(),
+			"review_cost_control": cost_control,
+			"checks": review_checks_json(),
+			"evidence": ["fresh reviewer tried to claim compact review with validation from an older head"]
+		}),
+	);
+
+	assert!(!response.success);
+
+	match &response.content_items[..] {
+		[DynamicToolContentItem::InputText { text }] => {
+			assert!(text.contains("full review is required"));
+			assert!(text.contains("stale_validation_evidence"));
+		},
+		other => panic!("unexpected response content: {other:?}"),
+	}
+}
+
+#[test]
+fn compact_review_checkpoint_fails_closed_with_weak_evidence() {
+	let tracker = FakeTracker::new();
+	let issue = sample_issue();
+	let workflow = sample_workflow();
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let review_context = sample_review_context_in(temp_dir.path());
+	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let bridge = TrackerToolBridge::with_review_handoff_for_test(
+		&tracker,
+		&issue,
+		&workflow,
+		review_context,
+		&pull_request_inspector,
+		&local_repo_inspector,
+	);
+	let mut cost_control = compact_review_cost_control_json();
+
+	cost_control["evidence_sufficient"] = serde_json::json!(false);
+
+	let response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_REVIEW_CHECKPOINT_TOOL_NAME,
+		serde_json::json!({
+			"reviewer": "independent_fresh_context",
+			"status": "clean",
+			"head_sha": sample_local_repo().head_oid,
+			"review_contract": low_risk_handoff_review_contract_json(),
+			"review_cost_control": cost_control,
+			"checks": review_checks_json(),
+			"evidence": ["fresh reviewer tried to claim compact review with weak current-head evidence"]
+		}),
+	);
+
+	assert!(!response.success);
+
+	match &response.content_items[..] {
+		[DynamicToolContentItem::InputText { text }] => {
+			assert!(text.contains("full review is required"));
+			assert!(text.contains("weak_evidence"));
+		},
+		other => panic!("unexpected response content: {other:?}"),
+	}
+}
+
+#[test]
+fn compact_review_checkpoint_fails_closed_for_non_low_risk_classification() {
+	let tracker = FakeTracker::new();
+	let issue = sample_issue();
+	let workflow = sample_workflow();
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let review_context = sample_review_context_in(temp_dir.path());
+	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let bridge = TrackerToolBridge::with_review_handoff_for_test(
+		&tracker,
+		&issue,
+		&workflow,
+		review_context,
+		&pull_request_inspector,
+		&local_repo_inspector,
+	);
+	let mut cost_control = compact_review_cost_control_json();
+
+	cost_control["risk_class"] = serde_json::json!("localized");
+
+	let response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_REVIEW_CHECKPOINT_TOOL_NAME,
+		serde_json::json!({
+			"reviewer": "independent_fresh_context",
+			"status": "clean",
+			"head_sha": sample_local_repo().head_oid,
+			"review_contract": handoff_review_contract_json(),
+			"review_cost_control": cost_control,
+			"checks": review_checks_json(),
+			"evidence": ["fresh reviewer tried to claim compact review for a localized-risk lane"]
+		}),
+	);
+
+	assert!(!response.success);
+
+	match &response.content_items[..] {
+		[DynamicToolContentItem::InputText { text }] => {
+			assert!(text.contains("full review is required"));
+			assert!(text.contains("review_contract_risk_tier_not_low"));
+			assert!(text.contains("review_cost_risk_class_not_low"));
+		},
+		other => panic!("unexpected response content: {other:?}"),
+	}
+}
+
+#[test]
+fn compact_review_checkpoint_fails_closed_for_accepted_findings_and_blocking_routes() {
+	let tracker = FakeTracker::new();
+	let issue = sample_issue();
+	let workflow = sample_workflow();
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let review_context = sample_review_context_in(temp_dir.path());
+	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let bridge = TrackerToolBridge::with_review_handoff_for_test(
+		&tracker,
+		&issue,
+		&workflow,
+		review_context,
+		&pull_request_inspector,
+		&local_repo_inspector,
+	);
+	let response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_REVIEW_CHECKPOINT_TOOL_NAME,
+		serde_json::json!({
+			"reviewer": "independent_fresh_context",
+			"status": "findings",
+			"head_sha": sample_local_repo().head_oid,
+			"review_contract": low_risk_handoff_review_contract_json(),
+			"review_cost_control": compact_review_cost_control_json(),
+			"checks": review_checks_json(),
+			"evidence": ["fresh reviewer tried to keep compact review after accepting a current blocker"],
+			"accepted_findings": accepted_review_findings_json(),
+			"finding_routes": [{
+				"route": "current_blocker",
+				"severity": "medium",
+				"risk_tier": "medium",
+				"summary": "Accepted current repair blocker.",
+				"evidence": ["The accepted finding applies to the current lane head."],
+				"resolver": "agent",
+				"next_action": "Repair the accepted finding before handoff.",
+				"finding_source": "accepted_findings",
+				"finding_index": 0
+			}]
+		}),
+	);
+
+	assert!(!response.success);
+
+	match &response.content_items[..] {
+		[DynamicToolContentItem::InputText { text }] => {
+			assert!(text.contains("full review is required"));
+			assert!(text.contains("accepted_findings_present"));
+			assert!(text.contains("blocking_finding_routes_present"));
+			assert!(text.contains("nonclean_review_status"));
 		},
 		other => panic!("unexpected response content: {other:?}"),
 	}
@@ -1082,6 +1294,7 @@ fn review_checkpoint_rejects_review_blocking_local_changes() {
 			"status": "clean",
 			"head_sha": sample_local_repo().head_oid,
 			"review_contract": handoff_review_contract_json(),
+			"review_cost_control": compact_review_cost_control_json(),
 			"checks": review_checks_json(),
 			"evidence": ["review tried to bind a dirty worktree"]
 		}),

--- a/apps/decodex/src/agent/tracker_tool_bridge/tests/review/policy.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests/review/policy.rs
@@ -1270,6 +1270,59 @@ fn compact_review_checkpoint_fails_closed_after_prior_nonclean_round() {
 }
 
 #[test]
+fn compact_review_checkpoint_fails_closed_after_prior_nonclean_round_on_repaired_head() {
+	let tracker = FakeTracker::new();
+	let issue = sample_issue();
+	let workflow = sample_workflow();
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let review_context = sample_review_context_in(temp_dir.path());
+	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
+	let mut repaired_local_repo = sample_local_repo();
+
+	repaired_local_repo.head_oid = String::from("18a20f7dfb9526e7421a5f095b1c6adec84e52d6");
+	repaired_local_repo.head_tree_oid = String::from("28a20f7dfb9526e7421a5f095b1c6adec84e52d6");
+
+	let repaired_head = repaired_local_repo.head_oid.clone();
+	let local_repo_inspector =
+		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(repaired_local_repo)]);
+	let bridge = TrackerToolBridge::with_review_handoff_for_test(
+		&tracker,
+		&issue,
+		&workflow,
+		review_context,
+		&pull_request_inspector,
+		&local_repo_inspector,
+	);
+	let findings_response =
+		submit_findings_review_checkpoint(&bridge, "first full review found a current blocker");
+
+	assert!(findings_response.success);
+
+	let response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_REVIEW_CHECKPOINT_TOOL_NAME,
+		serde_json::json!({
+			"reviewer": "independent_fresh_context",
+			"status": "clean",
+			"head_sha": repaired_head,
+			"review_contract": low_risk_handoff_review_contract_json(),
+			"review_cost_control": compact_review_cost_control_json(),
+			"checks": review_checks_json(),
+			"evidence": ["fresh reviewer confirmed the accepted finding was repaired on a new head"]
+		}),
+	);
+
+	assert!(!response.success);
+
+	match &response.content_items[..] {
+		[DynamicToolContentItem::InputText { text }] => {
+			assert!(text.contains("prior_nonclean_review_rounds_present"));
+		},
+		other => panic!("unexpected response content: {other:?}"),
+	}
+}
+
+#[test]
 fn review_checkpoint_rejects_review_blocking_local_changes() {
 	let tracker = FakeTracker::new();
 	let issue = sample_issue();

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools.rs
@@ -2208,6 +2208,8 @@ fn review_cost_control_schema() -> Value {
 			},
 			"current_head_evidence": { "type": "boolean" },
 			"validation_backed": { "type": "boolean" },
+			"validation_current": { "type": "boolean" },
+			"evidence_sufficient": { "type": "boolean" },
 			"reviewer_judgment": { "type": "string" },
 			"fallback_reason": { "type": "string" }
 		},
@@ -2655,6 +2657,8 @@ fn normalize_review_cost_control(
 			high_risk_surfaces: Vec::new(),
 			current_head_evidence: false,
 			validation_backed: false,
+			validation_current: false,
+			evidence_sufficient: false,
 			reviewer_judgment: String::from(
 				"No compact-review judgment was recorded; defaulting to full independent review.",
 			),
@@ -2698,6 +2702,8 @@ fn normalize_review_cost_control(
 		high_risk_surfaces,
 		current_head_evidence: cost_control.current_head_evidence,
 		validation_backed: cost_control.validation_backed,
+		validation_current: cost_control.validation_current,
+		evidence_sufficient: cost_control.evidence_sufficient,
 		reviewer_judgment,
 		fallback_reason,
 	})
@@ -2831,6 +2837,12 @@ fn compact_review_forced_full_reasons(
 	}
 	if !cost_control.validation_backed {
 		reasons.push("missing_validation_evidence");
+	}
+	if !cost_control.validation_current {
+		reasons.push("stale_validation_evidence");
+	}
+	if !cost_control.evidence_sufficient {
+		reasons.push("weak_evidence");
 	}
 	if !accepted_findings.is_empty() {
 		reasons.push("accepted_findings_present");

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools.rs
@@ -1453,6 +1453,23 @@ impl<'a> TrackerToolBridge<'a> {
 			.as_ref()
 			.filter(|previous_state| previous_state.phase == review_policy_phase)
 			.map_or(0, |previous_state| previous_state.nonclean_rounds);
+		let prior_nonclean_rounds_present = self
+			.state_store
+			.map(|state_store| {
+				state_store.has_nonclean_review_checkpoint_artifact(
+					&review_context.service_id,
+					&self.issue.id,
+					review_policy_phase.as_str(),
+				)
+			})
+			.transpose()
+			.map_err(|error| error.to_string())?
+			.unwrap_or(false);
+		let previous_nonclean_rounds = if prior_nonclean_rounds_present {
+			previous_nonclean_rounds.max(1)
+		} else {
+			previous_nonclean_rounds
+		};
 		let previous_threshold_exceeded = previous_state.as_ref().is_some_and(|previous_state| {
 			previous_state.phase == review_policy_phase
 				&& previous_state.status == ReviewPolicyStatus::Findings

--- a/docs/spec/review-orchestration.md
+++ b/docs/spec/review-orchestration.md
@@ -174,13 +174,15 @@ Rules:
   binds the committed current `HEAD`, and the reviewer must still perform both the
   intended-behavior and adversarial checks from the registered workflow policy.
   Compact review is valid only for a low-risk, small, validation-backed, clean
-  pre-handoff lane with current-head evidence, no high-risk surfaces, no accepted
-  findings, no blocking routes, and no prior non-clean review-policy state.
-  Full review is forced for repair verification, accepted findings, non-clean rounds,
-  missing or stale validation, weak evidence, architecture risk, high-risk changed
-  surfaces, or docs/config/API/security/data/privacy changes without sufficient
-  evidence. The classification combines structured signals with reviewer judgment;
-  changed-surface count alone is never sufficient.
+  pre-handoff lane with current-head evidence, validation evidence that is current
+  for the reviewed `HEAD`, sufficient current-head evidence quality, no high-risk
+  surfaces, no accepted findings, no blocking routes, and no prior non-clean
+  review-policy state. Full review is forced for repair verification, accepted
+  findings, non-clean rounds, missing or stale validation, weak evidence,
+  architecture risk, high-risk changed surfaces, or docs/config/API/security/data/
+  privacy changes without sufficient evidence. The classification combines
+  structured signals with reviewer judgment; changed-surface count alone is never
+  sufficient.
 - In `"standard"` and `"strict"` levels, a Decodex Review checkpoint is persisted as
   an evidence-keyed artifact. The key must include artifact kind
   `issue_review_checkpoint`, review phase, current `HEAD`, review level, and review

--- a/docs/spec/tracker-tools.md
+++ b/docs/spec/tracker-tools.md
@@ -198,21 +198,23 @@ In either invalid case, `decodex` must fail the attempt rather than infer which 
 - A checkpoint may include `review_cost_control` with `review_class`
   (`compact_current_head_review` or `full_current_head_review`), `risk_class`,
   changed-surface count and public-safe summary, high-risk surface summary,
-  current-head evidence flag, validation-backed flag, reviewer judgment, and
-  fallback reason for full review. Compact review checkpoints keep the fallback
-  reason absent, while full-review checkpoints must record the reason compact
-  review was not selected. Omitted cost-control metadata normalizes to
+  current-head evidence flag, validation-backed flag, validation-current flag,
+  evidence-sufficient flag, reviewer judgment, and fallback reason for full review.
+  Compact review checkpoints keep the fallback reason absent, while full-review
+  checkpoints must record the reason compact review was not selected. Omitted
+  cost-control metadata normalizes to
   `full_current_head_review` with fallback reason
   `review_cost_control_not_provided`.
 - `compact_current_head_review` is accepted only for a clean handoff checkpoint with
   `risk_tier = "low"`, `risk_class = "low"`, current-head evidence, validation
-  evidence, a small changed-surface count, no high-risk surfaces, no accepted
-  findings, no current or landing-blocking routes, and no prior non-clean checkpoint
-  state for the same review phase. It is a compact independent review path, not a
-  skipped-review path. Full review is required for repair verification, accepted
-  findings, non-clean rounds, missing/stale validation, docs/config/API/security/
-  data/privacy surfaces without sufficient evidence, weak evidence, or architecture
-  risk.
+  evidence that is current for the reviewed `HEAD`, sufficient current-head
+  evidence quality, a small changed-surface count, no high-risk surfaces, no
+  accepted findings, no current or landing-blocking routes, and no prior non-clean
+  checkpoint state for the same review phase. It is a compact independent review
+  path, not a skipped-review path. Full review is required for repair verification,
+  accepted findings, non-clean rounds, missing/stale validation, docs/config/API/
+  security/data/privacy surfaces without sufficient evidence, weak evidence, or
+  architecture risk.
 - Every new checkpoint payload must include checklist notes for intended behavior,
   regression risk, missing tests, docs/config drift, migration fallout,
   operator-facing fallout, and Loop/Decision Contract mismatch.


### PR DESCRIPTION
## Summary
- harden compact review cost-control metadata and fail-closed fallback reasons
- reject compact review after prior non-clean review rounds, including repaired-head cases
- update review policy specs and focused tests

## Validation
- cargo make fmt
- cargo make lint-fix
- cargo make test
- cargo make check-docs

## Review
- Independent fresh-context review checkpoint recorded clean for HEAD 0c7a1f2ed2cf6e6109afecebe57e8c5455b91977.