### PR TITLE
Unify operator current lane presentation

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -279,6 +279,10 @@ struct AccountPanelView: View {
 			header
 			accountSummary
 
+			if operatorCurrentLaneCards.isEmpty == false {
+				operatorCurrentLaneStrip
+			}
+
 			if telemetryMatrixIsVisible {
 				AccountTelemetryMatrixView(
 					aggregate: accountProfileAggregate,
@@ -486,7 +490,7 @@ struct AccountPanelView: View {
 	private var accountRows: some View {
 		VStack(spacing: 0) {
 			ForEach(Array(store.accounts.enumerated()), id: \.element.id) { index, account in
-				let runs = operatorRuns(for: account)
+				let runs = operatorCurrentLaneCards(for: account)
 
 				AccountRowView(
 					account: account,
@@ -596,6 +600,9 @@ struct AccountPanelView: View {
 			+ AccountPanelLayout.accountSummaryHeight
 			+ AccountPanelLayout.sectionSpacing
 
+		if operatorCurrentLaneCards.isEmpty == false {
+			height += AccountPanelLayout.sectionSpacing + AccountPanelLayout.operatorRunStripHeight
+		}
 		if telemetryMatrixIsVisible {
 			height += AccountPanelLayout.sectionSpacing + telemetryMatrixHeight
 		}
@@ -668,8 +675,30 @@ struct AccountPanelView: View {
 		return account.panelDisplayName(emailsHidden: false)
 	}
 
-	private func operatorRuns(for account: CodexAccount) -> [OperatorRunStatus] {
-		store.operatorSnapshot?.currentLanes(for: account) ?? []
+	private var operatorCurrentLaneCards: [OperatorCurrentLaneCard] {
+		store.operatorPresentation?.currentLaneCards
+			?? store.operatorSnapshot?.presentation?.currentLaneCards
+			?? []
+	}
+
+	private var operatorCurrentLaneStrip: some View {
+		HStack(spacing: 7) {
+			Image(systemName: "dot.radiowaves.left.and.right")
+				.font(.system(size: 13, weight: .semibold))
+				.foregroundStyle(PanelPalette.actionBlue(colorScheme))
+				.frame(width: 16, height: AccountRunChipLayout.height)
+				.accessibilityHidden(true)
+
+			AccountRunSummaryView(runs: operatorCurrentLaneCards, currentTime: currentTime)
+		}
+		.padding(.horizontal, 8)
+		.frame(height: AccountPanelLayout.operatorRunStripHeight)
+		.frame(maxWidth: .infinity, alignment: .leading)
+		.modernGlassSurface(cornerRadius: 9, depth: .row)
+	}
+
+	private func operatorCurrentLaneCards(for account: CodexAccount) -> [OperatorCurrentLaneCard] {
+		operatorCurrentLaneCards.filter { $0.isAssigned(to: account) }
 	}
 
 	private func accountRowHeight(for account: CodexAccount) -> CGFloat {
@@ -679,7 +708,7 @@ struct AccountPanelView: View {
 		} else {
 			base = 48
 		}
-		let runSignal: CGFloat = operatorRuns(for: account).isEmpty ? 0 : 22
+		let runSignal: CGFloat = operatorCurrentLaneCards(for: account).isEmpty ? 0 : 22
 		let profileSignal: CGFloat = account.hasProfileSummary
 			? (account.recentProfileDailyUsage.isEmpty ? 19 : 35)
 			: 0
@@ -734,7 +763,7 @@ struct AccountPanelView: View {
 
 struct AccountRowView: View {
 	let account: CodexAccount
-	let runs: [OperatorRunStatus]
+	let runs: [OperatorCurrentLaneCard]
 	let displayName: String
 	let showsDivider: Bool
 	let isLogoutArmed: Bool
@@ -886,7 +915,7 @@ struct AccountRowView: View {
 }
 
 struct AccountRunSummaryView: View {
-	let runs: [OperatorRunStatus]
+	let runs: [OperatorCurrentLaneCard]
 	let currentTime: Date
 	@State private var placementStore = AccountRunStripPlacementStore()
 	@State private var scrollProxy = AccountRunStripScrollProxy()
@@ -916,11 +945,11 @@ struct AccountRunSummaryView: View {
 				}
 			) {
 				HStack(spacing: 5) {
-					ForEach(runs) { run in
-						AccountRunChipView(run: run, currentTime: currentTime)
+					ForEach(runs) { card in
+						AccountRunChipView(card: card, currentTime: currentTime)
 							.modifier(
 								AccountRunChipPlacementReporter(
-									runID: run.id,
+									runID: card.id,
 									placementStore: placementStore
 								)
 							)
@@ -1775,6 +1804,7 @@ private enum AccountPanelLayout {
 	static let sectionSpacing: CGFloat = 6
 	static let headerHeight: CGFloat = 28
 	static let accountSummaryHeight: CGFloat = 31
+	static let operatorRunStripHeight: CGFloat = 29
 	static let telemetryHorizontalPadding: CGFloat = 7
 	static let telemetryTopPadding: CGFloat = 7
 	static let telemetryBottomPadding: CGFloat = 2
@@ -1850,7 +1880,7 @@ private enum AccountRunChipLayout {
 }
 
 struct AccountRunChipView: View {
-	let run: OperatorRunStatus
+	let card: OperatorCurrentLaneCard
 	let currentTime: Date
 	@Environment(\.colorScheme) private var colorScheme
 	@State private var isHovered = false
@@ -1891,7 +1921,7 @@ struct AccountRunChipView: View {
 			cancelPopover()
 		}
 		.popover(isPresented: $showsPopover, arrowEdge: .trailing) {
-			OperatorLanePopoverView(run: run, currentTime: currentTime)
+			OperatorLanePopoverView(run: card.run, currentTime: currentTime)
 				.fixedSize(horizontal: true, vertical: false)
 		}
 	}
@@ -1919,10 +1949,10 @@ struct AccountRunChipView: View {
 	}
 
 	private var symbol: String {
-		if run.hasAttentionTone {
+		if card.needsAttention || card.tone == "attention" {
 			return "exclamationmark.triangle.fill"
 		}
-		if run.isWaiting {
+		if card.isWaiting || card.tone == "waiting" {
 			return "clock"
 		}
 
@@ -1930,14 +1960,14 @@ struct AccountRunChipView: View {
 	}
 
 	private var chipTitle: String {
-		panelTrimmed(run.issueIdentifier) ?? "Run"
+		panelTrimmed(card.title) ?? panelTrimmed(card.issueIdentifier) ?? "Run"
 	}
 
 	private var tint: Color {
-		if run.hasAttentionTone {
+		if card.needsAttention || card.tone == "attention" {
 			return PanelPalette.warning(colorScheme)
 		}
-		if run.isWaiting {
+		if card.isWaiting || card.tone == "waiting" {
 			return PanelPalette.secondaryText(colorScheme)
 		}
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
@@ -12,6 +12,7 @@ final class AccountStore: ObservableObject {
 	@Published private(set) var accountList: AccountListResponse?
 	@Published private(set) var fastMode: CodexFastModeResponse?
 	@Published private(set) var operatorSnapshot: OperatorSnapshotResponse?
+	@Published private(set) var operatorPresentation: OperatorSnapshotPresentation?
 	@Published private(set) var operatorSnapshotUpdatedAt: Date?
 	@Published private(set) var isRefreshing = false
 	@Published private(set) var isLoggingIn = false
@@ -22,7 +23,6 @@ final class AccountStore: ObservableObject {
 	private let bridge = DecodexAppBridge()
 	private var automaticRefreshTask: Task<Void, Never>?
 	private var operatorSnapshotStreamTask: Task<Void, Never>?
-	private var liveRunActivity: OperatorRunActivitySnapshot?
 
 	deinit {
 		automaticRefreshTask?.cancel()
@@ -220,26 +220,16 @@ final class AccountStore: ObservableObject {
 				return
 			}
 
-			liveRunActivity = nil
 			operatorSnapshot = snapshot
+			operatorPresentation = snapshot.presentation
 			operatorSnapshotUpdatedAt = payload.snapshotPublishedAt ?? Date()
 		case "runActivity":
-			guard let currentLanes = payload.currentLanes else {
+			guard let presentation = payload.presentation else {
 				return
 			}
 
-			let activity = OperatorRunActivitySnapshot(
-				currentLanes: currentLanes,
-				currentLanesComplete: payload.currentLanesComplete ?? true,
-				emittedAt: payload.emittedAt ?? Date()
-			)
-			if let operatorSnapshot {
-				self.operatorSnapshot = activity.merging(into: operatorSnapshot)
-			} else {
-				operatorSnapshot = OperatorSnapshotResponse.currentLanesOnly(currentLanes)
-			}
-			liveRunActivity = activity.shouldPersistAsSnapshotOverlay ? activity : nil
-			operatorSnapshotUpdatedAt = activity.emittedAt
+			operatorPresentation = presentation
+			operatorSnapshotUpdatedAt = payload.emittedAt ?? Date()
 		default:
 			break
 		}

--- a/apps/decodex-app/Sources/DecodexApp/OperatorSnapshotModels.swift
+++ b/apps/decodex-app/Sources/DecodexApp/OperatorSnapshotModels.swift
@@ -6,6 +6,7 @@ struct OperatorSnapshotResponse: Decodable, Sendable {
 	let warnings: [String]
 	let projects: [OperatorProjectStatus]
 	let currentLanes: [OperatorRunStatus]
+	let presentation: OperatorSnapshotPresentation?
 	let queuedCandidates: [OperatorQueuedIssueStatus]
 	let postReviewLanes: [OperatorPostReviewLaneStatus]
 
@@ -89,76 +90,18 @@ struct OperatorSnapshotResponse: Decodable, Sendable {
 		currentLanes(for: account).filter(\.countsAsRunning).count
 	}
 
-	func mergingRunActivity(
-		_ activityRuns: [OperatorRunStatus],
-		currentLanesComplete: Bool = true
-	) -> OperatorSnapshotResponse {
-		let activityRunsByID = activityRuns.reduce(into: [String: OperatorRunStatus]()) { runsByID, run in
-			runsByID[run.runID] = run
-		}
-		let snapshotRunsByID = currentLanes.reduce(into: [String: OperatorRunStatus]()) { runsByID, run in
-			runsByID[run.runID] = run
-		}
-		let mergedSnapshotRuns = currentLanes.compactMap { snapshotRun -> OperatorRunStatus? in
-			if let activityRun = activityRunsByID[snapshotRun.runID] {
-				return snapshotRun.mergingActivity(activityRun)
-			}
-			if currentLanesComplete {
-				return nil
-			}
-
-			return snapshotRun.shouldRetainDuringPartialRunActivity ? snapshotRun : nil
-		}
-		let newActivityRuns = activityRuns.filter { activityRun in
-			snapshotRunsByID[activityRun.runID] == nil
-		}
-		let mergedRuns = mergedSnapshotRuns + newActivityRuns
-		let currentLaneCountsByProject = Dictionary(grouping: mergedRuns.compactMap(\.projectID)) { $0 }
-			.mapValues(\.count)
-		let runningCountsByProject = Dictionary(
-			grouping: mergedRuns.filter(\.countsAsRunning).compactMap(\.projectID)
-		) { $0 }
-			.mapValues(\.count)
-		let mergedProjects = projects.map { project in
-			guard let projectID = project.projectID else {
-				return project
-			}
-
-			return project.withRunCounts(
-				currentLanes: currentLaneCountsByProject[projectID] ?? 0,
-				running: runningCountsByProject[projectID] ?? 0
-			)
-		}
-
-		return OperatorSnapshotResponse(
-			warnings: warnings,
-			projects: mergedProjects,
-			currentLanes: mergedRuns,
-			queuedCandidates: queuedCandidates,
-			postReviewLanes: postReviewLanes
-		)
-	}
-
-	static func currentLanesOnly(_ currentLanes: [OperatorRunStatus]) -> OperatorSnapshotResponse {
-		OperatorSnapshotResponse(
-			warnings: [],
-			projects: [],
-			currentLanes: currentLanes,
-			queuedCandidates: [],
-			postReviewLanes: []
-		)
-	}
-
 	private init(
 		warnings: [String],
 		projects: [OperatorProjectStatus],
 		currentLanes: [OperatorRunStatus],
+		presentation: OperatorSnapshotPresentation?,
 		queuedCandidates: [OperatorQueuedIssueStatus],
 		postReviewLanes: [OperatorPostReviewLaneStatus]
 	) {
 		self.warnings = warnings
 		self.projects = projects
 		self.currentLanes = currentLanes
+		self.presentation = presentation
 		self.queuedCandidates = queuedCandidates
 		self.postReviewLanes = postReviewLanes
 	}
@@ -172,6 +115,7 @@ struct OperatorSnapshotResponse: Decodable, Sendable {
 		case warnings
 		case projects
 		case currentLanes = "current_lanes"
+		case presentation
 		case queuedCandidates = "queued_candidates"
 		case postReviewLanes = "post_review_lanes"
 	}
@@ -182,6 +126,7 @@ struct OperatorSnapshotResponse: Decodable, Sendable {
 		warnings = try container.decodeIfPresent([String].self, forKey: .warnings) ?? []
 		projects = try container.decodeIfPresent([OperatorProjectStatus].self, forKey: .projects) ?? []
 		currentLanes = try container.decodeIfPresent([OperatorRunStatus].self, forKey: .currentLanes) ?? []
+		presentation = try container.decodeIfPresent(OperatorSnapshotPresentation.self, forKey: .presentation)
 		queuedCandidates = try container.decodeIfPresent(
 			[OperatorQueuedIssueStatus].self,
 			forKey: .queuedCandidates
@@ -563,14 +508,6 @@ struct OperatorRunStatus: Decodable, Identifiable, Sendable {
 			|| accounts.contains { $0.isSelected && $0.matches(account) }
 	}
 
-	var shouldRetainDuringPartialRunActivity: Bool {
-		runLease == true
-			|| processAlive == true
-			|| hasRecentAppServerExecution
-			|| status == "running"
-			|| phase == "executing"
-	}
-
 	var countsAsRunning: Bool {
 		if let countsAsRunningSnapshot {
 			return countsAsRunningSnapshot
@@ -626,66 +563,6 @@ struct OperatorRunStatus: Decodable, Identifiable, Sendable {
 
 				return idleForSeconds >= 300
 			}
-	}
-
-	func mergingActivity(_ activity: OperatorRunStatus) -> OperatorRunStatus {
-		OperatorRunStatus(
-			projectID: activity.projectID ?? projectID,
-			projectDisplayName: activity.projectDisplayName ?? projectDisplayName,
-			runID: activity.runID,
-			issueID: activity.issueID ?? issueID,
-			issueIdentifier: activity.issueIdentifier ?? issueIdentifier,
-			title: mergedTitle(from: activity),
-			status: activity.status ?? status,
-			attemptStatus: activity.attemptStatus ?? attemptStatus,
-			attemptNumber: activity.attemptNumber ?? attemptNumber,
-			phase: activity.phase ?? phase,
-			runPhase: activity.runPhase ?? runPhase,
-			waitReason: activity.waitReason ?? waitReason,
-			currentOperation: activity.currentOperation ?? currentOperation,
-			activeGoalPhase: activity.activeGoalPhase ?? activeGoalPhase,
-			publicProgressPhase: activity.publicProgressPhase ?? publicProgressPhase,
-			threadStatus: activity.threadStatus ?? threadStatus,
-			threadActiveFlags: activity.threadActiveFlags.isEmpty ? threadActiveFlags : activity.threadActiveFlags,
-			idleForSeconds: activity.idleForSeconds ?? idleForSeconds,
-			protocolIdleForSeconds: activity.protocolIdleForSeconds ?? protocolIdleForSeconds,
-			updatedAt: activity.updatedAt ?? updatedAt,
-			lastProgressAt: activity.lastProgressAt ?? lastProgressAt,
-			nextRetryAt: activity.nextRetryAt ?? nextRetryAt,
-			lastEventType: activity.lastEventType ?? lastEventType,
-			eventCount: activity.eventCount ?? eventCount,
-			executionLiveness: activity.executionLiveness ?? executionLiveness,
-			hasFreshExecutionSnapshot: activity.hasFreshExecutionSnapshot ?? hasFreshExecutionSnapshot,
-			countsAsRunningSnapshot: activity.countsAsRunningSnapshot ?? countsAsRunningSnapshot,
-			needsAttentionSnapshot: activity.needsAttentionSnapshot ?? needsAttentionSnapshot,
-			processAlive: activity.processAlive ?? processAlive,
-			processLivenessReason: activity.processLivenessReason ?? processLivenessReason,
-			runLease: activity.runLease ?? runLease,
-			branchName: activity.branchName ?? branchName,
-			worktreePath: activity.worktreePath ?? worktreePath,
-			suspectedStall: activity.suspectedStall || suspectedStall,
-			childAgentActivity: activity.childAgentActivity ?? childAgentActivity,
-			lifecycleMetrics: activity.lifecycleMetrics ?? lifecycleMetrics,
-			continuationRecovery: activity.continuationRecovery ?? continuationRecovery,
-			account: activity.account ?? account,
-			accounts: activity.accounts.isEmpty ? accounts : activity.accounts
-		)
-	}
-
-	private func mergedTitle(from activity: OperatorRunStatus) -> String? {
-		if let title = activity.title, title.isEmpty == false, activity.titleIsOperationFallback == false {
-			return title
-		}
-
-		return title ?? activity.title
-	}
-
-	private var titleIsOperationFallback: Bool {
-		guard let title, title.isEmpty == false else {
-			return false
-		}
-
-		return title == rawDisplayToken(currentOperation ?? phase ?? "")
 	}
 
 	enum CodingKeys: String, CodingKey {
@@ -917,8 +794,7 @@ struct OperatorDashboardSocketPayload: Decodable, Sendable {
 	let emittedAtUnixEpoch: Int64?
 	let snapshotPublishedAtUnixEpoch: Int64?
 	let snapshot: OperatorSnapshotResponse?
-	let currentLanes: [OperatorRunStatus]?
-	let currentLanesComplete: Bool?
+	let presentation: OperatorSnapshotPresentation?
 
 	var emittedAt: Date? {
 		date(fromUnixEpoch: emittedAtUnixEpoch)
@@ -932,22 +808,7 @@ struct OperatorDashboardSocketPayload: Decodable, Sendable {
 		case emittedAtUnixEpoch
 		case snapshotPublishedAtUnixEpoch
 		case snapshot
-		case currentLanes
-		case currentLanesComplete
-	}
-}
-
-struct OperatorRunActivitySnapshot: Sendable {
-	let currentLanes: [OperatorRunStatus]
-	let currentLanesComplete: Bool
-	let emittedAt: Date
-
-	var shouldPersistAsSnapshotOverlay: Bool {
-		currentLanes.isEmpty == false || currentLanesComplete == false
-	}
-
-	func merging(into snapshot: OperatorSnapshotResponse) -> OperatorSnapshotResponse {
-		snapshot.mergingRunActivity(currentLanes, currentLanesComplete: currentLanesComplete)
+		case presentation
 	}
 }
 
@@ -1111,6 +972,101 @@ struct OperatorRunAccountSummary: Decodable, Sendable {
 		email = try container.decodeIfPresent(String.self, forKey: .email)
 			?? container.decodeIfPresent(String.self, forKey: .accountEmail)
 		status = try container.decodeIfPresent(String.self, forKey: .status)
+	}
+}
+
+struct OperatorSnapshotPresentation: Decodable, Sendable {
+	let schema: String?
+	let currentLaneCards: [OperatorCurrentLaneCard]
+
+	enum CodingKeys: String, CodingKey {
+		case schema
+		case currentLaneCards = "current_lane_cards"
+	}
+
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+
+		schema = try container.decodeIfPresent(String.self, forKey: .schema)
+		currentLaneCards = try container.decodeIfPresent(
+			[OperatorCurrentLaneCard].self,
+			forKey: .currentLaneCards
+		) ?? []
+	}
+}
+
+struct OperatorCurrentLaneCard: Decodable, Identifiable, Sendable {
+	let id: String
+	let runID: String
+	let issueID: String?
+	let issueIdentifier: String?
+	let projectID: String?
+	let title: String
+	let detail: String
+	let tone: String
+	let countsAsRunning: Bool
+	let needsAttention: Bool
+	let isWaiting: Bool
+	let assignedAccountFingerprints: [String]
+	let assignedAccountEmails: [String]
+	let run: OperatorRunStatus
+
+	func isAssigned(to account: CodexAccount) -> Bool {
+		if assignedAccountFingerprints.contains(where: { $0 == account.accountFingerprint }) {
+			return true
+		}
+		guard let accountEmail = account.email else {
+			return false
+		}
+
+		return assignedAccountEmails.contains {
+			$0.caseInsensitiveCompare(accountEmail) == .orderedSame
+		}
+	}
+
+	enum CodingKeys: String, CodingKey {
+		case id
+		case runID = "run_id"
+		case issueID = "issue_id"
+		case issueIdentifier = "issue_identifier"
+		case projectID = "project_id"
+		case title
+		case detail
+		case tone
+		case countsAsRunning = "counts_as_running"
+		case needsAttention = "needs_attention"
+		case isWaiting = "is_waiting"
+		case assignedAccountFingerprints = "assigned_account_fingerprints"
+		case assignedAccountEmails = "assigned_account_emails"
+		case run
+	}
+
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+
+		run = try container.decode(OperatorRunStatus.self, forKey: .run)
+		runID = try container.decodeIfPresent(String.self, forKey: .runID) ?? run.runID
+		id = try container.decodeIfPresent(String.self, forKey: .id) ?? runID
+		issueID = try container.decodeIfPresent(String.self, forKey: .issueID) ?? run.issueID
+		issueIdentifier = try container.decodeIfPresent(String.self, forKey: .issueIdentifier)
+			?? run.issueIdentifier
+		projectID = try container.decodeIfPresent(String.self, forKey: .projectID) ?? run.projectID
+		title = try container.decodeIfPresent(String.self, forKey: .title) ?? run.compactTitle
+		detail = try container.decodeIfPresent(String.self, forKey: .detail) ?? run.compactDetail
+		tone = try container.decodeIfPresent(String.self, forKey: .tone) ?? "running"
+		countsAsRunning = try container.decodeIfPresent(Bool.self, forKey: .countsAsRunning)
+			?? run.countsAsRunning
+		needsAttention = try container.decodeIfPresent(Bool.self, forKey: .needsAttention)
+			?? run.hasAttentionTone
+		isWaiting = try container.decodeIfPresent(Bool.self, forKey: .isWaiting) ?? run.isWaiting
+		assignedAccountFingerprints = try container.decodeIfPresent(
+			[String].self,
+			forKey: .assignedAccountFingerprints
+		) ?? []
+		assignedAccountEmails = try container.decodeIfPresent(
+			[String].self,
+			forKey: .assignedAccountEmails
+		) ?? []
 	}
 }
 

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountModelTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountModelTests.swift
@@ -520,470 +520,348 @@ final class AccountModelTests: XCTestCase {
 
 	@MainActor
 	func testOperatorRunActivityUsesStreamOrderOverSnapshotTimestamp() throws {
-		let account = makeAccount(
-			status: "available",
-			email: "copy@example.com",
-			accountFingerprint: "...123456"
-		)
 		let store = AccountStore()
 
 		try store.applyOperatorDashboardEvent(dashboardEvent(
 			type: "snapshot",
 			payload: """
 			{
-			  "snapshotPublishedAtUnixEpoch": 20,
-			  "snapshot": {
-			    "current_lanes": [
-			      {
-			        "run_id": "run-new",
-			        "issue_identifier": "XY-672",
-			        "account": {
-			          "email": "copy@example.com",
-			          "account_fingerprint": "...123456"
-			        }
-			      }
-			    ]
-			  }
-			}
+				  "snapshotPublishedAtUnixEpoch": 20,
+				  "snapshot": {
+				    "current_lanes": [
+				      {
+				        "run_id": "run-new",
+				        "issue_identifier": "XY-672"
+				      }
+				    ],
+				    "presentation": {
+				      "current_lane_cards": [
+				        {
+				          "id": "run-new",
+				          "run_id": "run-new",
+				          "title": "XY-672",
+				          "detail": "agent_run",
+				          "tone": "running",
+				          "counts_as_running": true,
+				          "needs_attention": false,
+				          "is_waiting": false,
+				          "run": {
+				            "run_id": "run-new",
+				            "issue_identifier": "XY-672"
+				          }
+				        }
+				      ]
+				    }
+				  }
+				}
 			"""
 		))
 		try store.applyOperatorDashboardEvent(dashboardEvent(
 			type: "runActivity",
-			payload: """
-			{
-			  "emittedAtUnixEpoch": 10,
-			  "currentLanesComplete": true,
-			  "currentLanes": [
-			    {
-			      "run_id": "run-old",
-			      "issue_identifier": "PUB-1147",
-			      "account": {
-			        "email": "copy@example.com",
-			        "account_fingerprint": "...123456"
-			      }
-			    }
-			  ]
-			}
+				payload: """
+				{
+				  "emittedAtUnixEpoch": 10,
+				  "presentation": {
+				    "current_lane_cards": [
+				      {
+				        "id": "run-old",
+				        "run_id": "run-old",
+				        "title": "PUB-1147",
+				        "detail": "agent_run",
+				        "tone": "running",
+				        "counts_as_running": true,
+				        "needs_attention": false,
+				        "is_waiting": false,
+				        "run": {
+				          "run_id": "run-old",
+				          "issue_identifier": "PUB-1147"
+				        }
+				      }
+				    ]
+				  }
+				}
 			"""
 		))
 
-		XCTAssertEqual(store.operatorSnapshot?.currentLanes(for: account).map(\.runID), ["run-old"])
+		XCTAssertEqual(store.operatorSnapshot?.currentLanes.map(\.runID), ["run-new"])
+		XCTAssertEqual(store.operatorPresentation?.currentLaneCards.map(\.runID), ["run-old"])
 	}
 
 	@MainActor
-	func testRunActivityBeforeSnapshotCreatesVisibleCurrentLanes() throws {
-		let account = makeAccount(
-			status: "available",
-			email: "copy@example.com",
-			accountFingerprint: "...123456"
-		)
+	func testRunActivityBeforeSnapshotCreatesVisiblePresentation() throws {
 		let store = AccountStore()
 
 		try store.applyOperatorDashboardEvent(dashboardEvent(
 			type: "runActivity",
-			payload: """
-			{
-			  "emittedAtUnixEpoch": 30,
-			  "currentLanesComplete": true,
-			  "currentLanes": [
-			    {
-			      "run_id": "run-live",
-			      "issue_identifier": "XY-672",
-			      "account": {
-			        "email": "copy@example.com",
-			        "account_fingerprint": "...123456"
-			      }
-			    }
-			  ]
-			}
+				payload: """
+				{
+				  "emittedAtUnixEpoch": 30,
+				  "presentation": {
+				    "current_lane_cards": [
+				      {
+				        "id": "run-live",
+				        "run_id": "run-live",
+				        "title": "XY-672",
+				        "detail": "agent_run",
+				        "tone": "running",
+				        "counts_as_running": true,
+				        "needs_attention": false,
+				        "is_waiting": false,
+				        "assigned_account_fingerprints": ["...123456"],
+				        "assigned_account_emails": ["copy@example.com"],
+				        "run": {
+				          "run_id": "run-live",
+				          "issue_identifier": "XY-672"
+				        }
+				      }
+				    ]
+				  }
+				}
 			"""
 		))
 
-		XCTAssertEqual(store.operatorSnapshot?.currentLanes.map(\.runID), ["run-live"])
-		XCTAssertEqual(store.operatorSnapshot?.currentLanes(for: account).map(\.runID), ["run-live"])
+		XCTAssertNil(store.operatorSnapshot)
+		XCTAssertEqual(store.operatorPresentation?.currentLaneCards.map(\.runID), ["run-live"])
 	}
 
-	func testPartialRunActivityPreservesSnapshotCurrentLanes() throws {
+	func testPresentationCardsAssignAccountsFromServerFields() throws {
 		let account = makeAccount(
 			status: "available",
 			email: "copy@example.com",
 			accountFingerprint: "...123456"
 		)
-		let snapshotPayload = """
+		let payload = """
 		{
-		  "current_lanes": [
+		  "current_lane_cards": [
 		    {
-		      "run_id": "run-689",
-		      "issue_identifier": "XY-689",
-		      "run_lease": true,
-		      "account": {
-		        "email": "copy@example.com",
-		        "account_fingerprint": "...123456"
-		      }
-		    },
-		    {
+		      "id": "run-690",
 		      "run_id": "run-690",
-		      "issue_identifier": "XY-690",
-		      "run_lease": true,
-		      "account": {
-		        "email": "copy@example.com",
-		        "account_fingerprint": "...123456"
+		      "title": "XY-690",
+		      "detail": "agent_run",
+		      "tone": "running",
+		      "counts_as_running": true,
+		      "needs_attention": false,
+		      "is_waiting": false,
+		      "assigned_account_fingerprints": ["...123456"],
+		      "assigned_account_emails": ["copy@example.com"],
+		      "run": {
+		        "run_id": "run-690",
+		        "issue_identifier": "XY-690"
 		      }
 		    }
 		  ]
 		}
 		""".data(using: .utf8)!
-		let activityPayload = """
-		{
-		  "currentLanesComplete": false,
-		  "currentLanes": [
-		    {
-		      "run_id": "run-690",
-		      "issue_identifier": "XY-690",
-		      "account": {
-		        "email": "copy@example.com",
-		        "account_fingerprint": "...123456"
-		      }
-		    }
-		  ]
-		}
-		""".data(using: .utf8)!
+		let presentation = try JSONDecoder().decode(OperatorSnapshotPresentation.self, from: payload)
+		let card = try XCTUnwrap(presentation.currentLaneCards.first)
 
-		let snapshot = try JSONDecoder().decode(OperatorSnapshotResponse.self, from: snapshotPayload)
-		let event = try JSONDecoder()
-			.decode(OperatorDashboardSocketPayload.self, from: activityPayload)
-		let overlay = OperatorRunActivitySnapshot(
-			currentLanes: event.currentLanes ?? [],
-			currentLanesComplete: event.currentLanesComplete ?? true,
-			emittedAt: Date(timeIntervalSince1970: 30)
-		)
-		let merged = overlay.merging(into: snapshot)
-
-		XCTAssertEqual(merged.currentLanes.map(\.runID), ["run-689", "run-690"])
-		XCTAssertEqual(merged.currentLanes(for: account).map(\.runID), ["run-689", "run-690"])
-	}
-
-	func testPartialRunActivityRecomputesProjectRunningLaneCounts() throws {
-		let snapshotPayload = """
-		{
-		  "projects": [
-		    {
-		      "project_id": "pubfi-platform",
-		      "current_lane_count": 1,
-		      "running_lane_count": 1
-		    }
-		  ],
-		  "current_lanes": [
-		    {
-		      "run_id": "run-stopped",
-		      "project_id": "pubfi-platform",
-		      "status": "running",
-		      "phase": "executing",
-		      "process_alive": false
-		    }
-		  ]
-		}
-		""".data(using: .utf8)!
-		let snapshot = try JSONDecoder().decode(OperatorSnapshotResponse.self, from: snapshotPayload)
-		let overlay = OperatorRunActivitySnapshot(
-			currentLanes: [],
-			currentLanesComplete: false,
-			emittedAt: Date(timeIntervalSince1970: 30)
-		)
-		let merged = overlay.merging(into: snapshot)
-		let project = try XCTUnwrap(merged.projects.first)
-
-		XCTAssertEqual(merged.currentLanes.map(\.runID), ["run-stopped"])
-		XCTAssertEqual(project.currentLaneCount, 1)
-		XCTAssertEqual(project.runningLaneCount, 0)
-		XCTAssertEqual(merged.currentLaneCount, 1)
-		XCTAssertEqual(merged.runningLaneCount, 0)
-	}
-
-	func testEmptyPartialRunActivityPreservesSnapshotCurrentLanes() throws {
-		let account = makeAccount(
-			status: "available",
-			email: "copy@example.com",
-			accountFingerprint: "...123456"
-		)
-		let snapshotPayload = """
-		{
-		  "current_lanes": [
-		    {
-		      "run_id": "run-689",
-		      "issue_identifier": "XY-689",
-		      "run_lease": true,
-		      "account": {
-		        "email": "copy@example.com",
-		        "account_fingerprint": "...123456"
-		      }
-		    }
-		  ]
-		}
-		""".data(using: .utf8)!
-		let snapshot = try JSONDecoder().decode(OperatorSnapshotResponse.self, from: snapshotPayload)
-		let overlay = OperatorRunActivitySnapshot(
-			currentLanes: [],
-			currentLanesComplete: false,
-			emittedAt: Date(timeIntervalSince1970: 30)
-		)
-		let merged = overlay.merging(into: snapshot)
-
-		XCTAssertEqual(merged.currentLanes.map(\.runID), ["run-689"])
-		XCTAssertEqual(merged.currentLanes(for: account).map(\.runID), ["run-689"])
-	}
-
-	func testCompleteRunActivityReplacesSnapshotCurrentLanes() throws {
-		let account = makeAccount(
-			status: "available",
-			email: "copy@example.com",
-			accountFingerprint: "...123456"
-		)
-		let snapshotPayload = """
-		{
-		  "current_lanes": [
-		    {
-		      "run_id": "run-689",
-		      "issue_identifier": "XY-689",
-		      "run_lease": true,
-		      "account": {
-		        "email": "copy@example.com",
-		        "account_fingerprint": "...123456"
-		      }
-		    },
-		    {
-		      "run_id": "run-690",
-		      "issue_identifier": "XY-690",
-		      "run_lease": true,
-		      "account": {
-		        "email": "copy@example.com",
-		        "account_fingerprint": "...123456"
-		      }
-		    }
-		  ]
-		}
-		""".data(using: .utf8)!
-		let activityPayload = """
-		{
-		  "currentLanesComplete": true,
-		  "currentLanes": [
-		    {
-		      "run_id": "run-690",
-		      "issue_identifier": "XY-690",
-		      "account": {
-		        "email": "copy@example.com",
-		        "account_fingerprint": "...123456"
-		      }
-		    }
-		  ]
-		}
-		""".data(using: .utf8)!
-
-		let snapshot = try JSONDecoder().decode(OperatorSnapshotResponse.self, from: snapshotPayload)
-		let event = try JSONDecoder()
-			.decode(OperatorDashboardSocketPayload.self, from: activityPayload)
-		let overlay = OperatorRunActivitySnapshot(
-			currentLanes: event.currentLanes ?? [],
-			currentLanesComplete: event.currentLanesComplete ?? true,
-			emittedAt: Date(timeIntervalSince1970: 30)
-		)
-		let merged = overlay.merging(into: snapshot)
-
-		XCTAssertEqual(merged.currentLanes.map(\.runID), ["run-690"])
-		XCTAssertEqual(merged.currentLanes(for: account).map(\.runID), ["run-690"])
-	}
-
-	func testNewerEmptyRunActivityClearsSnapshotRuns() throws {
-		let account = makeAccount(
-			status: "available",
-			email: "copy@example.com",
-			accountFingerprint: "...123456"
-		)
-		let snapshotPayload = """
-		{
-		  "current_lanes": [
-		    {
-		      "run_id": "run-old",
-		      "issue_identifier": "XY-672",
-		      "account": {
-		        "email": "copy@example.com",
-		        "account_fingerprint": "...123456"
-		      }
-		    }
-		  ]
-		}
-		""".data(using: .utf8)!
-		let snapshot = try JSONDecoder().decode(OperatorSnapshotResponse.self, from: snapshotPayload)
-		let overlay = OperatorRunActivitySnapshot(
-			currentLanes: [],
-			currentLanesComplete: true,
-			emittedAt: Date(timeIntervalSince1970: 30)
-		)
-		let merged = overlay.merging(into: snapshot)
-
-		XCTAssertTrue(merged.currentLanes(for: account).isEmpty)
+		XCTAssertEqual(card.runID, "run-690")
+		XCTAssertTrue(card.isAssigned(to: account))
 	}
 
 	@MainActor
 	func testFullSnapshotClearsStaleLiveRunActivityOverlay() throws {
-		let account = makeAccount(
-			status: "available",
-			email: "copy@example.com",
-			accountFingerprint: "...123456"
-		)
 		let store = AccountStore()
 
 		try store.applyOperatorDashboardEvent(dashboardEvent(
 			type: "snapshot",
 			payload: """
 			{
-			  "snapshotPublishedAtUnixEpoch": 20,
-			  "snapshot": {
-			    "current_lanes": []
-			  }
-			}
+				  "snapshotPublishedAtUnixEpoch": 20,
+				  "snapshot": {
+				    "current_lanes": [],
+				    "presentation": {
+				      "current_lane_cards": []
+				    }
+				  }
+				}
 			"""
 		))
 		try store.applyOperatorDashboardEvent(dashboardEvent(
 			type: "runActivity",
-			payload: """
-			{
-			  "emittedAtUnixEpoch": 30,
-			  "currentLanesComplete": true,
-			  "currentLanes": [
-			    {
-			      "run_id": "run-live",
-			      "issue_identifier": "XY-672",
-			      "account": {
-			        "email": "copy@example.com",
-			        "account_fingerprint": "...123456"
-			      }
-			    }
-			  ]
-			}
+				payload: """
+				{
+				  "emittedAtUnixEpoch": 30,
+				  "presentation": {
+				    "current_lane_cards": [
+				      {
+				        "id": "run-live",
+				        "run_id": "run-live",
+				        "title": "XY-672",
+				        "detail": "agent_run",
+				        "tone": "running",
+				        "counts_as_running": true,
+				        "needs_attention": false,
+				        "is_waiting": false,
+				        "run": {
+				          "run_id": "run-live",
+				          "issue_identifier": "XY-672"
+				        }
+				      }
+				    ]
+				  }
+				}
 			"""
 		))
 		try store.applyOperatorDashboardEvent(dashboardEvent(
 			type: "snapshot",
 			payload: """
 			{
-			  "snapshotPublishedAtUnixEpoch": 40,
-			  "snapshot": {
-			    "current_lanes": []
-			  }
-			}
+				  "snapshotPublishedAtUnixEpoch": 40,
+				  "snapshot": {
+				    "current_lanes": [],
+				    "presentation": {
+				      "current_lane_cards": []
+				    }
+				  }
+				}
 			"""
 		))
 
-		XCTAssertTrue(store.operatorSnapshot?.currentLanes(for: account).isEmpty ?? false)
+		XCTAssertTrue(store.operatorPresentation?.currentLaneCards.isEmpty ?? false)
 	}
 
 	@MainActor
 	func testCompleteEmptyRunActivityClearsLiveRuns() throws {
-		let account = makeAccount(
-			status: "available",
-			email: "copy@example.com",
-			accountFingerprint: "...123456"
-		)
 		let store = AccountStore()
 
 		try store.applyOperatorDashboardEvent(dashboardEvent(
 			type: "snapshot",
 			payload: """
 			{
-			  "snapshotPublishedAtUnixEpoch": 20,
-			  "snapshot": {
-			    "current_lanes": [
-			      {
-			        "run_id": "run-live",
-			        "issue_identifier": "XY-672",
-			        "account": {
-			          "email": "copy@example.com",
-			          "account_fingerprint": "...123456"
-			        }
-			      }
-			    ]
-			  }
-			}
+				  "snapshotPublishedAtUnixEpoch": 20,
+				  "snapshot": {
+				    "current_lanes": [
+				      {
+				        "run_id": "run-live",
+				        "issue_identifier": "XY-672"
+				      }
+				    ],
+				    "presentation": {
+				      "current_lane_cards": [
+				        {
+				          "id": "run-live",
+				          "run_id": "run-live",
+				          "title": "XY-672",
+				          "detail": "agent_run",
+				          "tone": "running",
+				          "counts_as_running": true,
+				          "needs_attention": false,
+				          "is_waiting": false,
+				          "run": {
+				            "run_id": "run-live",
+				            "issue_identifier": "XY-672"
+				          }
+				        }
+				      ]
+				    }
+				  }
+				}
 			"""
 		))
 		try store.applyOperatorDashboardEvent(dashboardEvent(
 			type: "runActivity",
-			payload: """
-			{
-			  "emittedAtUnixEpoch": 30,
-			  "currentLanesComplete": true,
-			  "currentLanes": []
-			}
+				payload: """
+				{
+				  "emittedAtUnixEpoch": 30,
+				  "presentation": {
+				    "current_lane_cards": []
+				  }
+				}
 			"""
 		))
 
-		XCTAssertTrue(store.operatorSnapshot?.currentLanes(for: account).isEmpty ?? false)
+		XCTAssertEqual(store.operatorSnapshot?.currentLanes.map(\.runID), ["run-live"])
+		XCTAssertTrue(store.operatorPresentation?.currentLaneCards.isEmpty ?? false)
 	}
 
 	@MainActor
 	func testCompleteEmptyRunActivityDoesNotKeepClearingNewSnapshots() throws {
-		let account = makeAccount(
-			status: "available",
-			email: "copy@example.com",
-			accountFingerprint: "...123456"
-		)
 		let store = AccountStore()
 
 		try store.applyOperatorDashboardEvent(dashboardEvent(
 			type: "snapshot",
 			payload: """
 			{
-			  "snapshotPublishedAtUnixEpoch": 20,
-			  "snapshot": {
-			    "current_lanes": [
-			      {
-			        "run_id": "run-live",
-			        "issue_identifier": "XY-672",
-			        "account": {
-			          "email": "copy@example.com",
-			          "account_fingerprint": "...123456"
-			        }
-			      }
-			    ]
-			  }
-			}
+				  "snapshotPublishedAtUnixEpoch": 20,
+				  "snapshot": {
+				    "current_lanes": [
+				      {
+				        "run_id": "run-live",
+				        "issue_identifier": "XY-672"
+				      }
+				    ],
+				    "presentation": {
+				      "current_lane_cards": [
+				        {
+				          "id": "run-live",
+				          "run_id": "run-live",
+				          "title": "XY-672",
+				          "detail": "agent_run",
+				          "tone": "running",
+				          "counts_as_running": true,
+				          "needs_attention": false,
+				          "is_waiting": false,
+				          "run": {
+				            "run_id": "run-live",
+				            "issue_identifier": "XY-672"
+				          }
+				        }
+				      ]
+				    }
+				  }
+				}
 			"""
 		))
 		try store.applyOperatorDashboardEvent(dashboardEvent(
 			type: "runActivity",
-			payload: """
-			{
-			  "emittedAtUnixEpoch": 30,
-			  "currentLanesComplete": true,
-			  "currentLanes": []
-			}
+				payload: """
+				{
+				  "emittedAtUnixEpoch": 30,
+				  "presentation": {
+				    "current_lane_cards": []
+				  }
+				}
 			"""
 		))
-		XCTAssertTrue(store.operatorSnapshot?.currentLanes(for: account).isEmpty ?? false)
+		XCTAssertTrue(store.operatorPresentation?.currentLaneCards.isEmpty ?? false)
 
 		try store.applyOperatorDashboardEvent(dashboardEvent(
 			type: "snapshot",
 			payload: """
 			{
-			  "snapshotPublishedAtUnixEpoch": 40,
-			  "snapshot": {
-			    "current_lanes": [
-			      {
-			        "run_id": "run-returned",
-			        "issue_identifier": "XY-934",
-			        "account": {
-			          "email": "copy@example.com",
-			          "account_fingerprint": "...123456"
-			        }
-			      }
-			    ]
-			  }
-			}
+				  "snapshotPublishedAtUnixEpoch": 40,
+				  "snapshot": {
+				    "current_lanes": [
+				      {
+				        "run_id": "run-returned",
+				        "issue_identifier": "XY-934"
+				      }
+				    ],
+				    "presentation": {
+				      "current_lane_cards": [
+				        {
+				          "id": "run-returned",
+				          "run_id": "run-returned",
+				          "title": "XY-934",
+				          "detail": "agent_run",
+				          "tone": "running",
+				          "counts_as_running": true,
+				          "needs_attention": false,
+				          "is_waiting": false,
+				          "run": {
+				            "run_id": "run-returned",
+				            "issue_identifier": "XY-934"
+				          }
+				        }
+				      ]
+				    }
+				  }
+				}
 			"""
 		))
 
-		XCTAssertEqual(store.operatorSnapshot?.currentLanes(for: account).map(\.runID), ["run-returned"])
+		XCTAssertEqual(store.operatorPresentation?.currentLaneCards.map(\.runID), ["run-returned"])
 	}
 
 	func testOperatorSnapshotWarningSummaryUsesRawWarningToken() throws {

--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -3974,9 +3974,8 @@
 			let dashboardSocket = null;
 			let dashboardSocketReconnectTimer = null;
 			let dashboardLocalClockTimer = null;
-			let dashboardLiveCurrentLanes = [];
+			let dashboardLivePresentation = null;
 			let dashboardLiveRunActivitySeen = false;
-			let dashboardLiveCurrentLanesComplete = true;
 			let dashboardLiveAccountControl = null;
 			let dashboardStreamState = {
 				supported: typeof window.WebSocket === "function",
@@ -5751,8 +5750,9 @@
 			}
 
 			function rawSessionHistoryRuns(snapshot) {
-				const currentLaneIds = new Set((snapshot?.current_lanes ?? []).map((run) => run.run_id));
-				const currentLaneIssueKeys = new Set((snapshot?.current_lanes ?? []).flatMap(issueIdentityKeys));
+				const currentLaneRuns = snapshotCurrentLaneRuns(snapshot);
+				const currentLaneIds = new Set(currentLaneRuns.map((run) => run.run_id));
+				const currentLaneIssueKeys = new Set(currentLaneRuns.flatMap(issueIdentityKeys));
 				return (snapshot?.recent_runs ?? []).filter(
 					(run) => !currentLaneIds.has(run.run_id) && !issueMatchesKeySet(run, currentLaneIssueKeys),
 				);
@@ -9184,7 +9184,7 @@
 				}
 
 				return (
-					(snapshot.current_lanes?.length ?? 0) === 0 &&
+					snapshotCurrentLaneCards(snapshot).length === 0 &&
 					(snapshot.recent_runs?.length ?? 0) === 0 &&
 					(snapshot.worktrees?.length ?? 0) === 0 &&
 					(snapshot.post_review_lanes?.length ?? 0) === 0
@@ -9470,7 +9470,8 @@
 			}
 
 			function buildDerivedState(snapshot) {
-				const currentLanes = snapshot?.current_lanes ?? [];
+				const currentLaneCards = snapshotCurrentLaneCards(snapshot);
+				const currentLanes = currentLaneRunsFromCards(currentLaneCards);
 				const recentRuns = snapshot?.recent_runs ?? [];
 				const historyRuns = sessionHistoryRuns(snapshot);
 				const executionPrograms = snapshot?.execution_programs ?? [];
@@ -9724,6 +9725,7 @@
 
 				return {
 					projects: snapshot?.projects ?? [],
+					currentLaneCards,
 					liveRuns,
 					currentLaneCount: currentLanes.length,
 					liveLeases: currentLanes.filter((run) => run.run_lease).length,
@@ -10301,17 +10303,16 @@
 					return;
 				}
 
-				const currentLaneCount = (snapshot.current_lanes ?? []).length;
 				const retainedCount = (snapshot.post_review_lanes ?? []).length;
 				setFlowCounts(
 					pluralize(derived.queueBacklogCandidates.length, "issue"),
-					pluralize(currentLaneCount, "lane"),
+					pluralize(derived.currentLaneCount, "lane"),
 					pluralize(retainedCount, "PR"),
 					pluralize(derived.readyCount, "PR"),
 				);
 				setFlowActivity({
 					queue: derived.queueBacklogCandidates.length > 0,
-					run: currentLaneCount > 0,
+					run: derived.currentLaneCount > 0,
 					review:
 						derived.reviewBlockerCount > 0 ||
 						derived.reviewWaitingCount > 0 ||
@@ -10627,29 +10628,30 @@
 			}
 
 			function renderCurrentLanes(snapshot, derived) {
-				const runs = snapshot?.current_lanes ?? [];
+				const cards = derived.currentLaneCards ?? snapshotCurrentLaneCards(snapshot);
 				setPanelMeta(
 					nodes.currentLanesMeta,
 					runningLaneMetaText(derived),
 					derived.runningAttentionCount ? "attention" : "",
 				);
 
-				if (!runs.length) {
+				if (!cards.length) {
 					renderRoutineEmptyList(nodes.currentLanes);
 					return;
 				}
 
 				renderStableList(
 					nodes.currentLanes,
-					runs
-						.map((run) => {
-							const tone = toneForRun(run);
+					cards
+						.map((card) => {
+							const run = card.run || {};
+							const tone = currentLaneCardToneClass(card, run);
 							const statusBits = [statusLabel(runPhaseLabel(run), tone)];
 							const detailKey = runDetailKey(run);
-							const renderKey = currentLaneRenderKey(run);
-							const issueKey = issueDisplayKey(run);
-							const issueTitle = runIssueTitle(run, derived);
-							const summary = currentLaneSummary(run);
+							const renderKey = card.id || card.run_id || currentLaneRenderKey(run);
+							const issueKey = card.issue_identifier || issueDisplayKey(run);
+							const issueTitle = card.title || runIssueTitle(run, derived);
+							const summary = currentLaneSummary(run) || card.detail || "";
 							if (run.ownership_state && run.ownership_state !== "leased_run") {
 								statusBits.push(inlineStatusFact("Owner", displayToken(run.ownership_state)));
 							}
@@ -10886,7 +10888,7 @@
 
 			function worktreeRoleMeta(worktree, snapshot) {
 				const hygiene = worktree.hygiene;
-				const currentLaneMatch = (snapshot?.current_lanes ?? []).find(
+				const currentLaneMatch = snapshotCurrentLaneRuns(snapshot).find(
 					(run) =>
 						(run.worktree_path === worktree.worktree_path ||
 							run.branch_name === worktree.branch_name ||
@@ -11211,216 +11213,63 @@
 				);
 			}
 
-			function dashboardRunFieldHasValue(value) {
-				if (Array.isArray(value)) {
-					return value.length > 0;
-				}
-				if (typeof value === "string") {
-					return value.trim() !== "";
-				}
-				if (value && typeof value === "object") {
-					return Object.keys(value).length > 0;
+				function presentationCurrentLaneCards(presentation) {
+					return Array.isArray(presentation?.current_lane_cards)
+						? presentation.current_lane_cards.filter((card) => card && typeof card === "object")
+						: [];
 				}
 
-				return value !== null && value !== undefined;
-			}
-
-			function mergeDashboardRunRecord(snapshotRun, activityRun) {
-				if (!snapshotRun) {
-					return { ...activityRun };
+			function snapshotCurrentLaneCards(snapshot) {
+				const cards = presentationCurrentLaneCards(snapshot?.presentation);
+				if (cards.length || snapshot?.presentation) {
+					return cards;
 				}
 
-				const merged = { ...snapshotRun, ...activityRun };
-
-				for (const key of [
-					"issue_identifier",
-					"title",
-					"account",
-					"accounts",
-					"codex_account",
-					"codex_accounts",
-					"child_agent_activity",
-					"protocol_activity",
-					"branch_name",
-					"worktree_path",
-				]) {
-					if (
-						!dashboardRunFieldHasValue(activityRun[key]) &&
-						dashboardRunFieldHasValue(snapshotRun[key])
-					) {
-						merged[key] = snapshotRun[key];
-					}
-				}
-				if (
-					dashboardRunTitleIsOperationFallback(activityRun) &&
-					dashboardRunFieldHasValue(snapshotRun.title)
-				) {
-					merged.title = snapshotRun.title;
-				}
-
-				return merged;
-			}
-
-			function dashboardRunTitleIsOperationFallback(run) {
-				const title = String(run?.title || "").trim();
-				if (!title || issueDisplayKey(run) === "unknown") {
-					return false;
-				}
-
-				return title === displayToken(run?.current_operation || run?.run_phase || run?.phase);
-			}
-
-			function dashboardRunIdentityKeys(run) {
-				const keys = run?.run_id ? [`run:${run.run_id}`] : [];
-
-				for (const key of issueIdentityKeys(run)) {
-					keys.push(`issue:${key}`);
-				}
-
-				return keys;
-			}
-
-			function dashboardRunLookup(runs) {
-				const lookup = new Map();
-
-				for (const run of runs) {
-					for (const key of dashboardRunIdentityKeys(run)) {
-						if (!lookup.has(key)) {
-							lookup.set(key, run);
-						}
-					}
-				}
-
-				return lookup;
-			}
-
-			function dashboardRunShouldRetainDuringPartialActivity(run) {
-				return (
-					run?.run_lease === true ||
-					run?.process_alive === true ||
-					runHasFreshExecution(run) ||
-					runCountsAsRunning(run)
-				);
-			}
-
-			function mergeDashboardCurrentLanes(snapshot, currentLaneRows, currentLanesComplete = true) {
-				const snapshotCurrentLanes = snapshot.current_lanes || [];
-				const snapshotRunLookup = dashboardRunLookup(snapshotCurrentLanes);
-				const seenSnapshotRuns = new Set();
-				const mergedRuns = [];
-
-				for (const activityRun of currentLaneRows) {
-					const snapshotRun = dashboardRunIdentityKeys(activityRun)
-						.map((key) => snapshotRunLookup.get(key))
-						.find(Boolean);
-
-					if (snapshotRun) {
-						seenSnapshotRuns.add(snapshotRun);
-					}
-
-					mergedRuns.push(mergeDashboardRunRecord(snapshotRun, activityRun));
-				}
-
-				for (const snapshotRun of snapshotCurrentLanes) {
-					if (
-						!currentLanesComplete &&
-						!seenSnapshotRuns.has(snapshotRun) &&
-						dashboardRunShouldRetainDuringPartialActivity(snapshotRun)
-					) {
-						mergedRuns.push(snapshotRun);
-					}
-				}
-
-				return mergedRuns;
-			}
-
-			function mergeDashboardRunActivity(snapshot, currentLanes, activityPayload = {}) {
-				const currentLaneRows = currentLanes
+				return (snapshot?.current_lanes ?? [])
 					.filter((run) => run && typeof run === "object")
-					.map((run) => ({ ...run }));
-				const currentLanesComplete = activityPayload.currentLanesComplete !== false;
-				const mergedCurrentLanes = mergeDashboardCurrentLanes(
-					snapshot,
-					currentLaneRows,
-					currentLanesComplete,
-				);
-				const activeById = new Map(
-					mergedCurrentLanes
-						.filter((run) => run.run_id)
-						.map((run) => [run.run_id, run]),
-				);
-				const seenRecentIds = new Set();
-				const recentRuns = (snapshot.recent_runs || []).map((run) => {
-					if (!run?.run_id) {
-						return run;
-					}
-
-					seenRecentIds.add(run.run_id);
-					const currentLane = activeById.get(run.run_id);
-
-					return currentLane ? mergeDashboardRunRecord(run, currentLane) : run;
-				});
-
-				for (const run of mergedCurrentLanes) {
-					if (run.run_id && !seenRecentIds.has(run.run_id)) {
-						recentRuns.unshift(run);
-						seenRecentIds.add(run.run_id);
-					}
+						.map((run) => ({
+							id: run.run_id || issueDisplayKey(run),
+							run_id: run.run_id,
+							issue_id: run.issue_id,
+							issue_identifier: run.issue_identifier,
+							project_id: run.project_id,
+							title: run.issue_identifier || run.title || "Run",
+							detail: run.current_operation || run.run_phase || run.phase || "Active",
+							tone: runNeedsAttention(run)
+								? "attention"
+								: runWaitReasonShowsExecutionProgress(run) || !run.wait_reason
+									? "running"
+									: "waiting",
+							run,
+						}));
 				}
 
-				const currentLaneCountsByProject = mergedCurrentLanes.reduce((counts, run) => {
-					const projectId = run.project_id || snapshot.project_id;
-					if (!projectId) {
-						return counts;
-					}
+			function currentLaneRunsFromCards(cards) {
+				return cards
+					.map((card) => card?.run)
+					.filter((run) => run && typeof run === "object");
+			}
 
-					counts.set(projectId, (counts.get(projectId) || 0) + 1);
+			function snapshotCurrentLaneRuns(snapshot) {
+				return currentLaneRunsFromCards(snapshotCurrentLaneCards(snapshot));
+			}
 
-					return counts;
-				}, new Map());
-				const runningCountsByProject = mergedCurrentLanes.reduce((counts, run) => {
-					const projectId = run.project_id || snapshot.project_id;
-					if (!projectId || !runCountsAsRunning(run)) {
-						return counts;
-					}
+			function currentLaneCardToneClass(card, run) {
+				if (card?.tone === "attention") {
+					return "tone-blocked";
+				}
+				if (card?.tone === "waiting") {
+					return "tone-wait";
+				}
 
-					counts.set(projectId, (counts.get(projectId) || 0) + 1);
-
-					return counts;
-				}, new Map());
-
-				const projects = Array.isArray(snapshot.projects)
-					? snapshot.projects.map((project) => {
-						if (!project?.project_id) {
-							return project;
-						}
-
-						return {
-							...project,
-							current_lane_count: currentLaneCountsByProject.get(project.project_id) || 0,
-							running_lane_count: runningCountsByProject.get(project.project_id) || 0,
-						};
-					})
-					: snapshot.projects;
-				const accountControl =
-					activityPayload.accountControl && typeof activityPayload.accountControl === "object"
-						? { ...(snapshot.account_control || {}), ...activityPayload.accountControl }
-						: snapshot.account_control;
-
-				return {
-					...snapshot,
-					account_control: accountControl,
-					current_lanes: mergedCurrentLanes,
-					recent_runs: recentRuns,
-					projects,
-				};
+				return toneForRun(run);
 			}
 
 			function dashboardLiveRunActivityHasOverlay({ includeCompletedEmpty = false } = {}) {
 				if (!dashboardLiveRunActivitySeen) {
 					return false;
 				}
-				if (dashboardLiveCurrentLanes.length || !dashboardLiveCurrentLanesComplete) {
+				if (presentationCurrentLaneCards(dashboardLivePresentation).length) {
 					return true;
 				}
 
@@ -11430,20 +11279,17 @@
 			function clearDashboardLiveRunActivityOverlayIfCompleteEmpty() {
 				if (
 					dashboardLiveRunActivitySeen &&
-					dashboardLiveCurrentLanesComplete &&
-					!dashboardLiveCurrentLanes.length
+					!presentationCurrentLaneCards(dashboardLivePresentation).length
 				) {
 					dashboardLiveRunActivitySeen = false;
-					dashboardLiveCurrentLanes = [];
-					dashboardLiveCurrentLanesComplete = true;
+					dashboardLivePresentation = null;
 					dashboardLiveAccountControl = null;
 				}
 			}
 
 			function clearDashboardLiveRunActivityOverlay() {
 				dashboardLiveRunActivitySeen = false;
-				dashboardLiveCurrentLanes = [];
-				dashboardLiveCurrentLanesComplete = true;
+				dashboardLivePresentation = null;
 				dashboardLiveAccountControl = null;
 			}
 
@@ -11456,14 +11302,22 @@
 					return snapshot;
 				}
 
-				return mergeDashboardRunActivity(snapshot, dashboardLiveCurrentLanes, {
-					accountControl: dashboardLiveAccountControl,
-					currentLanesComplete: dashboardLiveCurrentLanesComplete,
-				});
+				const liveRuns = currentLaneRunsFromCards(
+					presentationCurrentLaneCards(dashboardLivePresentation),
+				);
+				return {
+					...snapshot,
+					account_control:
+						dashboardLiveAccountControl && typeof dashboardLiveAccountControl === "object"
+							? { ...(snapshot.account_control || {}), ...dashboardLiveAccountControl }
+							: snapshot.account_control,
+					current_lanes: liveRuns,
+					presentation: dashboardLivePresentation,
+				};
 			}
 
 			function applyDashboardRunActivity(payload) {
-				if (!Array.isArray(payload?.currentLanes)) {
+				if (!payload?.presentation || typeof payload.presentation !== "object") {
 					updateDashboardStreamState({
 						connected: true,
 						error: false,
@@ -11473,11 +11327,11 @@
 					return;
 				}
 
-				dashboardLiveCurrentLanes = payload.currentLanes
-					.filter((run) => run && typeof run === "object")
-					.map((run) => ({ ...run }));
+				dashboardLivePresentation = {
+					...payload.presentation,
+					current_lane_cards: presentationCurrentLaneCards(payload.presentation),
+				};
 				dashboardLiveRunActivitySeen = true;
-				dashboardLiveCurrentLanesComplete = payload.currentLanesComplete !== false;
 				dashboardLiveAccountControl =
 					payload.accountControl && typeof payload.accountControl === "object"
 						? { ...payload.accountControl }
@@ -11637,24 +11491,22 @@
 						error: false,
 					});
 					syncDashboardSubscriptionToSocket();
-				};
-				dashboardSocket.onclose = () => {
-					dashboardLiveCurrentLanes = [];
-					dashboardLiveRunActivitySeen = false;
-					dashboardLiveCurrentLanesComplete = true;
-					dashboardLiveAccountControl = null;
-					updateDashboardStreamState({
+					};
+					dashboardSocket.onclose = () => {
+						dashboardLivePresentation = null;
+						dashboardLiveRunActivitySeen = false;
+						dashboardLiveAccountControl = null;
+						updateDashboardStreamState({
 						connected: false,
 						error: true,
 					});
 					scheduleDashboardSocketReconnect();
-				};
-				dashboardSocket.onerror = () => {
-					dashboardLiveCurrentLanes = [];
-					dashboardLiveRunActivitySeen = false;
-					dashboardLiveCurrentLanesComplete = true;
-					dashboardLiveAccountControl = null;
-					updateDashboardStreamState({
+					};
+					dashboardSocket.onerror = () => {
+						dashboardLivePresentation = null;
+						dashboardLiveRunActivitySeen = false;
+						dashboardLiveAccountControl = null;
+						updateDashboardStreamState({
 						connected: false,
 						error: true,
 					});

--- a/apps/decodex/src/orchestrator/operator_http.rs
+++ b/apps/decodex/src/orchestrator/operator_http.rs
@@ -19,6 +19,7 @@ const DASHBOARD_RUN_ACTIVITY_FINGERPRINT_VOLATILE_FIELDS: &[&str] = &[
 	"current_elapsed_seconds",
 	"wall_seconds",
 ];
+const OPERATOR_PRESENTATION_SCHEMA: &str = "decodex.operator.presentation/1";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum OperatorRequestRoute {
@@ -611,12 +612,14 @@ fn build_operator_run_activity_event(
 	let fingerprint_payload =
 		dashboard_run_activity_fingerprint_payload(&account_control, &current_lanes);
 	let fingerprint = serde_json::to_vec(&fingerprint_payload)?;
+	let presentation = operator_snapshot_presentation_value(&current_lanes);
 	let payload = json!({
 		"emittedAtUnixEpoch": now_unix_epoch,
 		"accountControl": &account_control,
 		"currentLanes": &current_lanes,
 		"currentLanesComplete": true,
 		"currentLaneScope": "complete",
+		"presentation": &presentation,
 	});
 
 	Ok(DashboardRunActivityEvent {
@@ -634,6 +637,7 @@ fn dashboard_run_activity_fingerprint_payload(
 		"currentLanes": current_lanes,
 		"currentLanesComplete": true,
 		"currentLaneScope": "complete",
+		"presentation": operator_snapshot_presentation_value(current_lanes),
 	});
 
 	strip_dashboard_run_activity_volatile_fields(&mut fingerprint_payload);
@@ -658,6 +662,147 @@ fn strip_dashboard_run_activity_volatile_fields(value: &mut Value) {
 		},
 		_ => {},
 	}
+}
+
+fn operator_snapshot_json_value(snapshot: &OperatorStatusSnapshot) -> Result<Value> {
+	let mut value = serde_json::to_value(snapshot)?;
+
+	attach_operator_snapshot_presentation(&mut value, &snapshot.current_lanes);
+
+	Ok(value)
+}
+
+fn attach_operator_snapshot_presentation(
+	snapshot: &mut Value,
+	current_lanes: &[OperatorRunStatus],
+) {
+	if let Some(object) = snapshot.as_object_mut() {
+		object.insert(
+			String::from("presentation"),
+			operator_snapshot_presentation_value(current_lanes),
+		);
+	}
+}
+
+fn operator_snapshot_presentation_value(current_lanes: &[OperatorRunStatus]) -> Value {
+	json!({
+		"schema": OPERATOR_PRESENTATION_SCHEMA,
+		"current_lane_cards": current_lanes
+			.iter()
+			.map(operator_current_lane_card_value)
+			.collect::<Vec<_>>(),
+	})
+}
+
+fn operator_current_lane_card_value(run: &OperatorRunStatus) -> Value {
+	json!({
+		"id": &run.run_id,
+		"run_id": &run.run_id,
+		"project_id": &run.project_id,
+		"issue_id": &run.issue_id,
+		"issue_identifier": &run.issue_identifier,
+		"title": operator_current_lane_card_title(run),
+		"detail": operator_current_lane_card_detail(run),
+		"tone": operator_current_lane_card_tone(run),
+		"counts_as_running": operator_run_counts_as_running(run),
+		"needs_attention": operator_run_counts_as_attention(run),
+		"is_waiting": operator_run_counts_as_waiting(run),
+		"assigned_account_fingerprints": operator_run_assigned_account_fingerprints(run),
+		"assigned_account_emails": operator_run_assigned_account_emails(run),
+		"run": run,
+	})
+}
+
+fn operator_current_lane_card_title(run: &OperatorRunStatus) -> String {
+	trimmed_operator_text(run.issue_identifier.as_deref())
+		.or_else(|| trimmed_operator_text(run.title.as_deref()))
+		.unwrap_or("Run")
+		.to_owned()
+}
+
+fn operator_current_lane_card_detail(run: &OperatorRunStatus) -> String {
+	trimmed_operator_text(
+		run.child_agent_activity
+			.as_ref()
+			.and_then(|activity| activity.current_detail.as_deref()),
+	)
+	.or_else(|| {
+		trimmed_operator_text(
+			run.child_agent_activity
+				.as_ref()
+				.and_then(|activity| activity.current_bucket.as_deref()),
+		)
+	})
+	.or_else(|| trimmed_operator_text(run.wait_reason.as_deref()))
+	.or_else(|| {
+		trimmed_operator_text(Some(run.current_operation.as_str()))
+			.filter(|operation| *operation != RUN_OPERATION_IDLE)
+	})
+	.or_else(|| trimmed_operator_text(Some(run.run_phase.as_str())))
+	.or_else(|| trimmed_operator_text(Some(run.phase.as_str())))
+	.or_else(|| trimmed_operator_text(run.thread_status.as_deref()))
+	.unwrap_or("Active")
+	.to_owned()
+}
+
+fn operator_current_lane_card_tone(run: &OperatorRunStatus) -> &'static str {
+	if operator_run_counts_as_attention(run) {
+		"attention"
+	} else if operator_run_counts_as_waiting(run) {
+		"waiting"
+	} else {
+		"running"
+	}
+}
+
+fn operator_run_assigned_account_fingerprints(run: &OperatorRunStatus) -> Vec<String> {
+	let mut fingerprints = BTreeSet::new();
+
+	if let Some(account) = run.account.as_ref() {
+		insert_non_empty_operator_text(&mut fingerprints, &account.account_fingerprint);
+	}
+
+	for account in run
+		.accounts
+		.iter()
+		.filter(|account| account.status.eq_ignore_ascii_case("selected"))
+	{
+		insert_non_empty_operator_text(&mut fingerprints, &account.account_fingerprint);
+	}
+
+	fingerprints.into_iter().collect()
+}
+
+fn operator_run_assigned_account_emails(run: &OperatorRunStatus) -> Vec<String> {
+	let mut emails = BTreeSet::new();
+
+	if let Some(account) = run.account.as_ref()
+		&& let Some(email) = account.email.as_deref()
+	{
+		insert_non_empty_operator_text(&mut emails, email);
+	}
+
+	for account in run
+		.accounts
+		.iter()
+		.filter(|account| account.status.eq_ignore_ascii_case("selected"))
+	{
+		if let Some(email) = account.email.as_deref() {
+			insert_non_empty_operator_text(&mut emails, email);
+		}
+	}
+
+	emails.into_iter().collect()
+}
+
+fn insert_non_empty_operator_text(values: &mut BTreeSet<String>, value: &str) {
+	if let Some(value) = trimmed_operator_text(Some(value)) {
+		values.insert(value.to_owned());
+	}
+}
+
+fn trimmed_operator_text(value: Option<&str>) -> Option<&str> {
+	value.map(str::trim).filter(|value| !value.is_empty())
 }
 
 fn dashboard_current_snapshot_event_payload(
@@ -1177,11 +1322,33 @@ fn dashboard_event_for_subscription(
 		.get("currentLanesComplete")
 		.and_then(Value::as_bool)
 		.unwrap_or(true);
+	let current_lane_cards = event
+		.payload
+		.get("presentation")
+		.and_then(|presentation| presentation.get("current_lane_cards"))
+		.and_then(Value::as_array)
+		.map(|cards| {
+			cards
+				.iter()
+				.filter(|card| {
+					let run = card.get("run").unwrap_or(card);
+
+					dashboard_run_matches_subscription(run, subscription)
+				})
+				.cloned()
+				.collect::<Vec<_>>()
+		});
 	let mut payload = event.payload.clone();
 
 	payload["currentLanes"] = Value::Array(current_lanes);
 	payload["currentLanesComplete"] = Value::Bool(current_lanes_complete);
 	payload["currentLaneScope"] = Value::String(String::from("filtered"));
+
+	if let Some(current_lane_cards) = current_lane_cards
+		&& let Some(presentation) = payload.get_mut("presentation").and_then(Value::as_object_mut)
+	{
+		presentation.insert(String::from("current_lane_cards"), Value::Array(current_lane_cards));
+	}
 
 	Some(DashboardBroadcastEvent { event_type: event.event_type, payload })
 }

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -1515,7 +1515,8 @@ fn operator_dashboard_projects_show_compact_activity_work_and_location() {
 	assert!(response.contains("`${project.attention_count ?? 0} attention`"));
 	assert!(response.contains("`${cleanup} cleanup`"));
 	assert!(response.contains("run.process_alive !== false"));
-	assert!(response.contains("running_lane_count: runningCountsByProject.get(project.project_id) || 0"));
+	assert!(response.contains("return project.running_lane_count ?? project.current_lane_count ?? 0;"));
+	assert!(response.contains("run: derived.currentLaneCount > 0,"));
 	assert!(!response.contains("const running = project.current_lane_count ?? 0;"));
 	assert!(!response.contains("`${project.current_lane_count ?? 0} running`"));
 	assert!(response.contains("projectNumber(project.cleanup_blocked_count)"));
@@ -1863,22 +1864,15 @@ fn operator_dashboard_uses_shared_protocol_activity_summary() {
 }
 
 #[test]
-fn operator_dashboard_run_activity_preserves_snapshot_detail_fields() {
+fn operator_dashboard_run_activity_consumes_server_presentation() {
 	let response = dashboard_response();
 
-	assert!(response.contains("function mergeDashboardRunRecord(snapshotRun, activityRun)"));
-	assert!(
-		response.contains("function mergeDashboardCurrentLanes(snapshot, currentLaneRows, currentLanesComplete = true)")
-	);
-	assert!(response.contains("function dashboardRunTitleIsOperationFallback(run)"));
-	assert!(
-		response.contains("const operationFallback = displayToken(run.current_operation || run.run_phase || run.phase);")
-	);
-	assert!(response.contains("!(fallback !== \"unknown\" && title === operationFallback)"));
-	assert!(response.contains("return fallback !== \"unknown\" ? fallback : operationFallback;"));
-	assert!(response.contains("let dashboardLiveCurrentLanes = [];"));
+	assert!(response.contains("function presentationCurrentLaneCards(presentation)"));
+	assert!(response.contains("function snapshotCurrentLaneCards(snapshot)"));
+	assert!(response.contains("function currentLaneRunsFromCards(cards)"));
+	assert!(response.contains("function currentLaneCardToneClass(card, run)"));
+	assert!(response.contains("let dashboardLivePresentation = null;"));
 	assert!(response.contains("let dashboardLiveRunActivitySeen = false;"));
-	assert!(response.contains("let dashboardLiveCurrentLanesComplete = true;"));
 	assert!(!response.contains("let dashboardLiveAccounts = null;"));
 	assert!(response.contains("let dashboardLiveAccountControl = null;"));
 	assert!(response
@@ -1888,40 +1882,29 @@ fn operator_dashboard_run_activity_preserves_snapshot_detail_fields() {
 	assert!(response.contains("function clearDashboardLiveRunActivityOverlay()"));
 	assert!(response.contains("function snapshotWithLiveRunActivity(snapshot, options = {})"));
 	assert!(response.contains("if (!dashboardLiveRunActivityHasOverlay(options))"));
-	assert!(response.contains("\"issue_identifier\""));
-	assert!(response.contains("\"title\""));
 	assert!(!response.contains("field(\"Author\","));
 	assert!(!response.contains("\"author\",\n"));
-	assert!(response.contains("activityPayload.accountControl"));
+	assert!(response.contains("payload.accountControl"));
 	assert!(!response.contains("activityPayload.accounts"));
 	assert!(!response.contains("payload.accounts"));
 	assert!(!response.contains("dashboardLiveAccounts"));
 	assert!(response.contains("dashboardLiveAccountControl ="));
-	assert!(response.contains("\"child_agent_activity\""));
-	assert!(response.contains("\"protocol_activity\""));
-	assert!(response.contains("!dashboardRunFieldHasValue(activityRun[key])"));
-	assert!(response.contains("merged[key] = snapshotRun[key];"));
-	assert!(response.contains("dashboardRunTitleIsOperationFallback(activityRun)"));
-	assert!(response.contains("merged.title = snapshotRun.title;"));
-	assert!(
-		response.contains("const currentLanesComplete = activityPayload.currentLanesComplete !== false;")
-	);
-	assert!(
-		response.contains("const mergedCurrentLanes = mergeDashboardCurrentLanes(\n\t\t\t\t\tsnapshot,\n\t\t\t\t\tcurrentLaneRows,\n\t\t\t\t\tcurrentLanesComplete,\n\t\t\t\t);")
-	);
-	assert!(response.contains("dashboardLiveCurrentLanes = payload.currentLanes"));
+	assert!(response.contains("dashboardLivePresentation = {"));
+	assert!(response.contains("current_lane_cards: presentationCurrentLaneCards(payload.presentation),"));
 	assert!(response.contains("dashboardLiveRunActivitySeen = true;"));
-	assert!(response.contains("dashboardLiveCurrentLanesComplete ="));
 	assert!(response.contains("clearDashboardLiveRunActivityOverlay();"));
 	assert!(response.contains("snapshot: payload.snapshot,"));
 	assert!(response.contains(
 		"snapshot: snapshotWithLiveRunActivity(lastDashboardRender.snapshot, {\n\t\t\t\t\t\tincludeCompletedEmpty: true,\n\t\t\t\t\t}),"
 	));
 	assert!(response.contains("clearDashboardLiveRunActivityOverlayIfCompleteEmpty();"));
-	assert!(response.contains("account_control: accountControl,"));
+	assert!(response.contains("account_control:"));
 	assert!(!response.contains("accounts: dashboardLiveAccounts"));
-	assert!(response.contains("current_lanes: mergedCurrentLanes,"));
-	assert!(!response.contains("current_lanes: currentLaneRows,"));
+	assert!(response.contains("current_lanes: liveRuns,"));
+	assert!(response.contains("presentation: dashboardLivePresentation,"));
+	assert!(!response.contains("function mergeDashboardRunRecord"));
+	assert!(!response.contains("function mergeDashboardCurrentLanes"));
+	assert!(!response.contains("function mergeDashboardRunActivity"));
 }
 
 #[test]

--- a/apps/decodex/src/orchestrator/tests/operator/status/http.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/http.rs
@@ -724,17 +724,43 @@ fn operator_dashboard_websocket_filters_run_activity_by_subscription() {
 		payload["type"] == "controlAck" && payload["payload"]["requestId"] == "sub-filter"
 	});
 
-	dashboard_events.broadcast(
-		"runActivity",
-		serde_json::json!({
-			"emittedAtUnixEpoch": 1_774_000_010_i64,
-			"currentLanes": [
-				{ "project_id": "pubfi", "issue_id": "PUB-101", "run_id": "run-1" },
-				{ "project_id": "pubfi", "issue_id": "PUB-102", "run_id": "run-2" },
-				{ "project_id": "rsnap", "issue_id": "RS-1", "run_id": "run-2" }
-			]
-		}),
-	);
+		dashboard_events.broadcast(
+			"runActivity",
+			serde_json::json!({
+				"emittedAtUnixEpoch": 1_774_000_010_i64,
+				"currentLanes": [
+					{ "project_id": "pubfi", "issue_id": "PUB-101", "run_id": "run-1" },
+					{ "project_id": "pubfi", "issue_id": "PUB-102", "run_id": "run-2" },
+					{ "project_id": "rsnap", "issue_id": "RS-1", "run_id": "run-2" }
+				],
+				"presentation": {
+					"schema": "decodex.operator.presentation/1",
+					"current_lane_cards": [
+						{
+							"id": "run-1",
+							"run_id": "run-1",
+							"issue_id": "PUB-101",
+							"project_id": "pubfi",
+							"run": { "project_id": "pubfi", "issue_id": "PUB-101", "run_id": "run-1" }
+						},
+						{
+							"id": "run-2",
+							"run_id": "run-2",
+							"issue_id": "PUB-102",
+							"project_id": "pubfi",
+							"run": { "project_id": "pubfi", "issue_id": "PUB-102", "run_id": "run-2" }
+						},
+						{
+							"id": "run-2-rsnap",
+							"run_id": "run-2",
+							"issue_id": "RS-1",
+							"project_id": "rsnap",
+							"run": { "project_id": "rsnap", "issue_id": "RS-1", "run_id": "run-2" }
+						}
+					]
+				}
+			}),
+		);
 
 	let activity = read_websocket_json_until(&mut client, &mut frame, |payload| {
 		payload["type"] == "runActivity"
@@ -749,6 +775,14 @@ fn operator_dashboard_websocket_filters_run_activity_by_subscription() {
 	assert_eq!(current_lanes[0]["run_id"], "run-2");
 	assert_eq!(activity["payload"]["currentLanesComplete"], true);
 	assert_eq!(activity["payload"]["currentLaneScope"], "filtered");
+
+	let current_lane_cards = activity["payload"]["presentation"]["current_lane_cards"]
+		.as_array()
+		.expect("filtered current lane cards should list");
+
+	assert_eq!(current_lane_cards.len(), 1);
+	assert_eq!(current_lane_cards[0]["issue_id"], "PUB-102");
+	assert_eq!(current_lane_cards[0]["run_id"], "run-2");
 
 	drop(client);
 
@@ -1014,6 +1048,24 @@ fn read_websocket_json_until(
 		assert_eq!(fingerprint["currentLanesComplete"], true);
 		assert_eq!(fingerprint["currentLaneScope"], "complete");
 		assert!(fingerprint.get("accounts").is_none());
+		assert_eq!(
+			data["presentation"]["schema"],
+			"decodex.operator.presentation/1"
+		);
+		assert_eq!(
+			fingerprint["presentation"]["schema"],
+			"decodex.operator.presentation/1"
+		);
+		assert_eq!(
+			data["presentation"]["current_lane_cards"].as_array().map(Vec::len),
+			data["currentLanes"].as_array().map(Vec::len)
+		);
+		assert_eq!(
+			fingerprint["presentation"]["current_lane_cards"]
+				.as_array()
+				.map(Vec::len),
+			fingerprint["currentLanes"].as_array().map(Vec::len)
+		);
 	}
 
 	fn assert_run_activity_current_lane(data_lane: &Value, fingerprint_lane: &Value) {
@@ -1127,6 +1179,20 @@ fn read_websocket_json_until(
 
 	assert_run_activity_envelope(&payload, data, &fingerprint);
 	assert_run_activity_current_lane(&data["currentLanes"][0], &fingerprint["currentLanes"][0]);
+
+	assert_eq!(data["presentation"]["current_lane_cards"][0]["run_id"], "run-1");
+	assert_eq!(
+		data["presentation"]["current_lane_cards"][0]["title"],
+		"PUB-101"
+	);
+	assert_eq!(
+		data["presentation"]["current_lane_cards"][0]["assigned_account_fingerprints"][0],
+		"acct-1"
+	);
+	assert_eq!(
+		fingerprint["presentation"]["current_lane_cards"][0]["run"]["run_id"],
+		"run-1"
+	);
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -1201,6 +1267,15 @@ fn operator_dashboard_run_activity_event_keeps_unleased_app_server_current_lane(
 	assert_eq!(current_lanes[0]["process_alive"], false);
 	assert_eq!(current_lanes[0]["process_liveness_reason"], "host_boot_id_mismatch");
 	assert_eq!(current_lanes[0]["thread_status"], "active");
+	assert_eq!(
+		data["presentation"]["current_lane_cards"].as_array().map(Vec::len),
+		Some(1)
+	);
+	assert_eq!(data["presentation"]["current_lane_cards"][0]["run_id"], "run-1");
+	assert_eq!(
+		data["presentation"]["current_lane_cards"][0]["run"]["thread_status"],
+		"active"
+	);
 }
 
 #[test]
@@ -1276,6 +1351,16 @@ fn operator_dashboard_run_activity_event_demotes_cleanup_complete_unleased_curre
 	assert_eq!(data["currentLaneScope"], "complete");
 	assert_eq!(data["currentLanes"].as_array().map(Vec::len), Some(0));
 	assert_eq!(fingerprint["currentLanes"].as_array().map(Vec::len), Some(0));
+	assert_eq!(
+		data["presentation"]["current_lane_cards"].as_array().map(Vec::len),
+		Some(0)
+	);
+	assert_eq!(
+		fingerprint["presentation"]["current_lane_cards"]
+			.as_array()
+			.map(Vec::len),
+		Some(0)
+	);
 	assert!(!data.to_string().contains("xy-952-attempt-2-1781598614"));
 }
 
@@ -1418,10 +1503,37 @@ fn dashboard_event_hub_caches_and_filters_last_run_activity_event() {
 				"issue_id": "issue-2",
 				"run_id": "run-2",
 			},
-		],
-		"currentLanesComplete": true,
-		"currentLaneScope": "complete",
-	});
+			],
+			"currentLanesComplete": true,
+			"currentLaneScope": "complete",
+			"presentation": {
+				"schema": "decodex.operator.presentation/1",
+				"current_lane_cards": [
+					{
+						"id": "run-1",
+						"run_id": "run-1",
+						"issue_id": "issue-1",
+						"project_id": "decodex",
+						"run": {
+							"project_id": "decodex",
+							"issue_id": "issue-1",
+							"run_id": "run-1"
+						}
+					},
+					{
+						"id": "run-2",
+						"run_id": "run-2",
+						"issue_id": "issue-2",
+						"project_id": "decodex",
+						"run": {
+							"project_id": "decodex",
+							"issue_id": "issue-2",
+							"run_id": "run-2"
+						}
+					}
+				]
+			},
+		});
 	let subscription = DashboardClientSubscription {
 		project_id: Some(String::from("decodex")),
 		issue_id: Some(String::from("issue-1")),
@@ -1443,6 +1555,14 @@ fn dashboard_event_hub_caches_and_filters_last_run_activity_event() {
 	assert_eq!(current_lanes[0]["issue_id"], "issue-1");
 	assert_eq!(event.payload["currentLanesComplete"], true);
 	assert_eq!(event.payload["currentLaneScope"], "filtered");
+
+	let current_lane_cards = event.payload["presentation"]["current_lane_cards"]
+		.as_array()
+		.expect("filtered current lane cards should be an array");
+
+	assert_eq!(current_lane_cards.len(), 1);
+	assert_eq!(current_lane_cards[0]["issue_id"], "issue-1");
+	assert_eq!(current_lane_cards[0]["run"]["run_id"], "run-1");
 }
 
 #[test]
@@ -1455,16 +1575,32 @@ fn dashboard_event_hub_filtered_empty_complete_event_clears_subscribed_overlay()
 			"account_selector": null,
 		},
 		"accounts": [],
-		"currentLanes": [
-			{
-				"project_id": "decodex",
-				"issue_id": "issue-2",
-				"run_id": "run-2",
+			"currentLanes": [
+				{
+					"project_id": "decodex",
+					"issue_id": "issue-2",
+					"run_id": "run-2",
+				},
+			],
+			"currentLanesComplete": true,
+			"currentLaneScope": "complete",
+			"presentation": {
+				"schema": "decodex.operator.presentation/1",
+				"current_lane_cards": [
+					{
+						"id": "run-2",
+						"run_id": "run-2",
+						"issue_id": "issue-2",
+						"project_id": "decodex",
+						"run": {
+							"project_id": "decodex",
+							"issue_id": "issue-2",
+							"run_id": "run-2"
+						}
+					}
+				]
 			},
-		],
-		"currentLanesComplete": true,
-		"currentLaneScope": "complete",
-	});
+		});
 	let subscription = DashboardClientSubscription {
 		project_id: Some(String::from("decodex")),
 		issue_id: Some(String::from("issue-1")),
@@ -1483,6 +1619,12 @@ fn dashboard_event_hub_filtered_empty_complete_event_clears_subscribed_overlay()
 	assert!(current_lanes.is_empty());
 	assert_eq!(event.payload["currentLanesComplete"], true);
 	assert_eq!(event.payload["currentLaneScope"], "filtered");
+	assert!(
+		event.payload["presentation"]["current_lane_cards"]
+			.as_array()
+			.expect("filtered current lane cards should be an array")
+			.is_empty()
+	);
 }
 
 #[test]
@@ -1544,6 +1686,14 @@ fn operator_dashboard_run_activity_event_includes_disabled_project_current_lanes
 	assert_eq!(current_lanes[0]["project_display_name"], "hack-ink/pubfi-mono-v2");
 	assert_eq!(data["currentLanesComplete"], true);
 	assert_eq!(data["currentLaneScope"], "complete");
+	assert_eq!(
+		data["presentation"]["current_lane_cards"].as_array().map(Vec::len),
+		Some(1)
+	);
+	assert_eq!(
+		data["presentation"]["current_lane_cards"][0]["run_id"],
+		"run-disabled-active"
+	);
 }
 
 #[test]

--- a/apps/decodex/src/orchestrator/tests/operator/status/publishing.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/publishing.rs
@@ -517,6 +517,23 @@ fn operator_state_snapshot_publish_still_refreshes_current_lane_metadata() {
 	assert_eq!(snapshot.current_lanes[0].issue_identifier.as_deref(), Some("XY-355"));
 	assert_eq!(snapshot.current_lanes[0].title.as_deref(), Some("Implement orchestration"));
 	assert_eq!(snapshot.current_lanes[0].author.as_deref(), Some("Yvette"));
+
+	let snapshot_json =
+		orchestrator::operator_snapshot_json_value(&snapshot).expect("snapshot should project");
+
+	assert_eq!(snapshot_json["presentation"]["schema"], "decodex.operator.presentation/1");
+	assert_eq!(
+		snapshot_json["presentation"]["current_lane_cards"][0]["run_id"],
+		"xy-355-attempt-1"
+	);
+	assert_eq!(
+		snapshot_json["presentation"]["current_lane_cards"][0]["title"],
+		"XY-355"
+	);
+	assert_eq!(
+		snapshot_json["presentation"]["current_lane_cards"][0]["run"]["title"],
+		"Implement orchestration"
+	);
 }
 
 #[test]

--- a/apps/decodex/src/orchestrator/types.rs
+++ b/apps/decodex/src/orchestrator/types.rs
@@ -1258,8 +1258,8 @@ impl OperatorStateEndpoint {
 	}
 
 	fn publish_snapshot(&self, snapshot: &OperatorStatusSnapshot) -> crate::prelude::Result<()> {
-		let snapshot_json = serde_json::to_vec(snapshot)?;
-		let snapshot_value = serde_json::to_value(snapshot)?;
+		let snapshot_value = operator_snapshot_json_value(snapshot)?;
+		let snapshot_json = serde_json::to_vec(&snapshot_value)?;
 		let last_publish_unix_epoch = OffsetDateTime::now_utc().unix_timestamp();
 		let mut guard = self
 			.snapshot


### PR DESCRIPTION
## Summary
- add a backend-owned operator presentation projection for current lane cards
- have both the Web dashboard and macOS app consume `presentation.current_lane_cards` instead of local merge/retention logic
- keep raw `currentLanes` as compatibility data while filtering presentation cards through the same subscription path

## Validation
- `cargo test -p decodex operator_dashboard`
- `cargo test -p decodex operator_state_snapshot_publish`
- `cargo test -p decodex operator_state_endpoint`
- `swift test` in `apps/decodex-app`
- `cargo check --all-features --all-targets --workspace`
- `cargo clippy --all-features --all-targets --workspace -- -D clippy::all -D clippy::too_many_lines -D clippy::unwrap_used -D clippy::use_self -D clippy::wildcard_imports -D missing-docs -D unused-crate-dependencies -D warnings`
- `cargo vstyle curate --language rust --workspace --all-features`
- `git diff --check`