### PR TITLE
Add macOS app fallback for legacy lane payloads

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
@@ -221,10 +221,15 @@ final class AccountStore: ObservableObject {
 			}
 
 			operatorSnapshot = snapshot
-			operatorPresentation = snapshot.presentation
+			operatorPresentation = snapshot.visiblePresentation
 			operatorSnapshotUpdatedAt = payload.snapshotPublishedAt ?? Date()
 		case "runActivity":
-			guard let presentation = payload.presentation else {
+			let presentation: OperatorSnapshotPresentation
+			if let payloadPresentation = payload.presentation {
+				presentation = payloadPresentation
+			} else if let currentLanes = payload.currentLanes {
+				presentation = OperatorSnapshotPresentation(legacyCurrentLanes: currentLanes)
+			} else {
 				return
 			}
 

--- a/apps/decodex-app/Sources/DecodexApp/OperatorSnapshotModels.swift
+++ b/apps/decodex-app/Sources/DecodexApp/OperatorSnapshotModels.swift
@@ -17,6 +17,10 @@ struct OperatorSnapshotResponse: Decodable, Sendable {
 		)
 	}
 
+	var visiblePresentation: OperatorSnapshotPresentation {
+		presentation ?? OperatorSnapshotPresentation(legacyCurrentLanes: currentLanes)
+	}
+
 	var runningLaneCount: Int {
 		max(
 			currentLanes.filter(\.countsAsRunning).count,
@@ -795,6 +799,7 @@ struct OperatorDashboardSocketPayload: Decodable, Sendable {
 	let snapshotPublishedAtUnixEpoch: Int64?
 	let snapshot: OperatorSnapshotResponse?
 	let presentation: OperatorSnapshotPresentation?
+	let currentLanes: [OperatorRunStatus]?
 
 	var emittedAt: Date? {
 		date(fromUnixEpoch: emittedAtUnixEpoch)
@@ -809,6 +814,7 @@ struct OperatorDashboardSocketPayload: Decodable, Sendable {
 		case snapshotPublishedAtUnixEpoch
 		case snapshot
 		case presentation
+		case currentLanes
 	}
 }
 
@@ -979,6 +985,15 @@ struct OperatorSnapshotPresentation: Decodable, Sendable {
 	let schema: String?
 	let currentLaneCards: [OperatorCurrentLaneCard]
 
+	init(schema: String? = nil, currentLaneCards: [OperatorCurrentLaneCard]) {
+		self.schema = schema
+		self.currentLaneCards = currentLaneCards
+	}
+
+	init(legacyCurrentLanes: [OperatorRunStatus]) {
+		self.init(currentLaneCards: legacyCurrentLanes.map(OperatorCurrentLaneCard.init(legacyRun:)))
+	}
+
 	enum CodingKeys: String, CodingKey {
 		case schema
 		case currentLaneCards = "current_lane_cards"
@@ -1010,6 +1025,23 @@ struct OperatorCurrentLaneCard: Decodable, Identifiable, Sendable {
 	let assignedAccountFingerprints: [String]
 	let assignedAccountEmails: [String]
 	let run: OperatorRunStatus
+
+	init(legacyRun run: OperatorRunStatus) {
+		self.id = run.runID
+		self.runID = run.runID
+		self.issueID = run.issueID
+		self.issueIdentifier = run.issueIdentifier
+		self.projectID = run.projectID
+		self.title = run.compactTitle
+		self.detail = run.compactDetail
+		self.tone = run.hasAttentionTone ? "attention" : (run.isWaiting ? "waiting" : "running")
+		self.countsAsRunning = run.countsAsRunning
+		self.needsAttention = run.hasAttentionTone
+		self.isWaiting = run.isWaiting
+		self.assignedAccountFingerprints = run.presentationAccountFingerprints
+		self.assignedAccountEmails = run.presentationAccountEmails
+		self.run = run
+	}
 
 	func isAssigned(to account: CodexAccount) -> Bool {
 		if assignedAccountFingerprints.contains(where: { $0 == account.accountFingerprint }) {
@@ -1068,6 +1100,38 @@ struct OperatorCurrentLaneCard: Decodable, Identifiable, Sendable {
 			forKey: .assignedAccountEmails
 		) ?? []
 	}
+}
+
+private extension OperatorRunStatus {
+	var presentationAccountFingerprints: [String] {
+		var values = Set<String>()
+
+		insertNonEmptyPresentationText(account?.accountFingerprint, into: &values)
+		for account in accounts where account.isSelected {
+			insertNonEmptyPresentationText(account.accountFingerprint, into: &values)
+		}
+
+		return values.sorted()
+	}
+
+	var presentationAccountEmails: [String] {
+		var values = Set<String>()
+
+		insertNonEmptyPresentationText(account?.email, into: &values)
+		for account in accounts where account.isSelected {
+			insertNonEmptyPresentationText(account.email, into: &values)
+		}
+
+		return values.sorted()
+	}
+}
+
+private func insertNonEmptyPresentationText(_ value: String?, into values: inout Set<String>) {
+	guard let value = trimmed(value), value.isEmpty == false else {
+		return
+	}
+
+	values.insert(value)
 }
 
 private func trimmed(_ value: String?) -> String? {

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountModelTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountModelTests.swift
@@ -624,6 +624,85 @@ final class AccountModelTests: XCTestCase {
 		XCTAssertEqual(store.operatorPresentation?.currentLaneCards.map(\.runID), ["run-live"])
 	}
 
+	@MainActor
+	func testLegacySnapshotCurrentLanesCreateVisiblePresentation() throws {
+		let account = makeAccount(
+			status: "available",
+			email: "copy@example.com",
+			accountFingerprint: "...123456"
+		)
+		let store = AccountStore()
+
+		try store.applyOperatorDashboardEvent(dashboardEvent(
+			type: "snapshot",
+			payload: """
+			{
+			  "snapshotPublishedAtUnixEpoch": 20,
+			  "snapshot": {
+			    "current_lanes": [
+			      {
+			        "run_id": "run-live",
+			        "issue_identifier": "XY-672",
+			        "wait_reason": "model_execution",
+			        "account": {
+			          "email": "copy@example.com",
+			          "account_fingerprint": "...123456"
+			        }
+			      }
+			    ]
+			  }
+			}
+			"""
+		))
+
+		let card = try XCTUnwrap(store.operatorPresentation?.currentLaneCards.first)
+
+		XCTAssertEqual(card.runID, "run-live")
+		XCTAssertEqual(card.title, "XY-672")
+		XCTAssertEqual(card.tone, "waiting")
+		XCTAssertTrue(card.isAssigned(to: account))
+	}
+
+	@MainActor
+	func testLegacyRunActivityCurrentLanesCreateVisiblePresentation() throws {
+		let account = makeAccount(
+			status: "available",
+			email: "copy@example.com",
+			accountFingerprint: "...123456"
+		)
+		let store = AccountStore()
+
+		try store.applyOperatorDashboardEvent(dashboardEvent(
+			type: "runActivity",
+			payload: """
+			{
+			  "emittedAtUnixEpoch": 30,
+			  "currentLanes": [
+			    {
+			      "run_id": "run-live",
+			      "issue_identifier": "XY-672",
+			      "current_operation": "agent_run",
+			      "accounts": [
+			        {
+			          "email": "copy@example.com",
+			          "account_fingerprint": "...123456",
+			          "status": "selected"
+			        }
+			      ]
+			    }
+			  ]
+			}
+			"""
+		))
+
+		let card = try XCTUnwrap(store.operatorPresentation?.currentLaneCards.first)
+
+		XCTAssertNil(store.operatorSnapshot)
+		XCTAssertEqual(card.runID, "run-live")
+		XCTAssertEqual(card.detail, "agent_run")
+		XCTAssertTrue(card.isAssigned(to: account))
+	}
+
 	func testPresentationCardsAssignAccountsFromServerFields() throws {
 		let account = makeAccount(
 			status: "available",


### PR DESCRIPTION
## Summary
- keep server `presentation.current_lane_cards` as the preferred visible lane authority
- add a macOS app fallback for older running servers that still emit raw `current_lanes` / `currentLanes` without `presentation`
- preserve account assignment on fallback cards so the menubar app does not go blank before the server is restarted

## Validation
- `swift test` in `apps/decodex-app`
- `git diff --check`