### PR TITLE
Centralize operator lane presentation contract

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
@@ -221,15 +221,10 @@ final class AccountStore: ObservableObject {
 			}
 
 			operatorSnapshot = snapshot
-			operatorPresentation = snapshot.visiblePresentation
+			operatorPresentation = snapshot.presentation
 			operatorSnapshotUpdatedAt = payload.snapshotPublishedAt ?? Date()
 		case "runActivity":
-			let presentation: OperatorSnapshotPresentation
-			if let payloadPresentation = payload.presentation {
-				presentation = payloadPresentation
-			} else if let currentLanes = payload.currentLanes {
-				presentation = OperatorSnapshotPresentation(legacyCurrentLanes: currentLanes)
-			} else {
+			guard let presentation = payload.presentation else {
 				return
 			}
 

--- a/apps/decodex-app/Sources/DecodexApp/OperatorSnapshotModels.swift
+++ b/apps/decodex-app/Sources/DecodexApp/OperatorSnapshotModels.swift
@@ -17,10 +17,6 @@ struct OperatorSnapshotResponse: Decodable, Sendable {
 		)
 	}
 
-	var visiblePresentation: OperatorSnapshotPresentation {
-		presentation ?? OperatorSnapshotPresentation(legacyCurrentLanes: currentLanes)
-	}
-
 	var runningLaneCount: Int {
 		max(
 			currentLanes.filter(\.countsAsRunning).count,
@@ -799,7 +795,6 @@ struct OperatorDashboardSocketPayload: Decodable, Sendable {
 	let snapshotPublishedAtUnixEpoch: Int64?
 	let snapshot: OperatorSnapshotResponse?
 	let presentation: OperatorSnapshotPresentation?
-	let currentLanes: [OperatorRunStatus]?
 
 	var emittedAt: Date? {
 		date(fromUnixEpoch: emittedAtUnixEpoch)
@@ -814,7 +809,6 @@ struct OperatorDashboardSocketPayload: Decodable, Sendable {
 		case snapshotPublishedAtUnixEpoch
 		case snapshot
 		case presentation
-		case currentLanes
 	}
 }
 
@@ -985,15 +979,6 @@ struct OperatorSnapshotPresentation: Decodable, Sendable {
 	let schema: String?
 	let currentLaneCards: [OperatorCurrentLaneCard]
 
-	init(schema: String? = nil, currentLaneCards: [OperatorCurrentLaneCard]) {
-		self.schema = schema
-		self.currentLaneCards = currentLaneCards
-	}
-
-	init(legacyCurrentLanes: [OperatorRunStatus]) {
-		self.init(currentLaneCards: legacyCurrentLanes.map(OperatorCurrentLaneCard.init(legacyRun:)))
-	}
-
 	enum CodingKeys: String, CodingKey {
 		case schema
 		case currentLaneCards = "current_lane_cards"
@@ -1026,23 +1011,6 @@ struct OperatorCurrentLaneCard: Decodable, Identifiable, Sendable {
 	let assignedAccountEmails: [String]
 	let run: OperatorRunStatus
 
-	init(legacyRun run: OperatorRunStatus) {
-		self.id = run.runID
-		self.runID = run.runID
-		self.issueID = run.issueID
-		self.issueIdentifier = run.issueIdentifier
-		self.projectID = run.projectID
-		self.title = run.compactTitle
-		self.detail = run.compactDetail
-		self.tone = run.hasAttentionTone ? "attention" : (run.isWaiting ? "waiting" : "running")
-		self.countsAsRunning = run.countsAsRunning
-		self.needsAttention = run.hasAttentionTone
-		self.isWaiting = run.isWaiting
-		self.assignedAccountFingerprints = run.presentationAccountFingerprints
-		self.assignedAccountEmails = run.presentationAccountEmails
-		self.run = run
-	}
-
 	func isAssigned(to account: CodexAccount) -> Bool {
 		if assignedAccountFingerprints.contains(where: { $0 == account.accountFingerprint }) {
 			return true
@@ -1072,66 +1040,6 @@ struct OperatorCurrentLaneCard: Decodable, Identifiable, Sendable {
 		case assignedAccountEmails = "assigned_account_emails"
 		case run
 	}
-
-	init(from decoder: Decoder) throws {
-		let container = try decoder.container(keyedBy: CodingKeys.self)
-
-		run = try container.decode(OperatorRunStatus.self, forKey: .run)
-		runID = try container.decodeIfPresent(String.self, forKey: .runID) ?? run.runID
-		id = try container.decodeIfPresent(String.self, forKey: .id) ?? runID
-		issueID = try container.decodeIfPresent(String.self, forKey: .issueID) ?? run.issueID
-		issueIdentifier = try container.decodeIfPresent(String.self, forKey: .issueIdentifier)
-			?? run.issueIdentifier
-		projectID = try container.decodeIfPresent(String.self, forKey: .projectID) ?? run.projectID
-		title = try container.decodeIfPresent(String.self, forKey: .title) ?? run.compactTitle
-		detail = try container.decodeIfPresent(String.self, forKey: .detail) ?? run.compactDetail
-		tone = try container.decodeIfPresent(String.self, forKey: .tone) ?? "running"
-		countsAsRunning = try container.decodeIfPresent(Bool.self, forKey: .countsAsRunning)
-			?? run.countsAsRunning
-		needsAttention = try container.decodeIfPresent(Bool.self, forKey: .needsAttention)
-			?? run.hasAttentionTone
-		isWaiting = try container.decodeIfPresent(Bool.self, forKey: .isWaiting) ?? run.isWaiting
-		assignedAccountFingerprints = try container.decodeIfPresent(
-			[String].self,
-			forKey: .assignedAccountFingerprints
-		) ?? []
-		assignedAccountEmails = try container.decodeIfPresent(
-			[String].self,
-			forKey: .assignedAccountEmails
-		) ?? []
-	}
-}
-
-private extension OperatorRunStatus {
-	var presentationAccountFingerprints: [String] {
-		var values = Set<String>()
-
-		insertNonEmptyPresentationText(account?.accountFingerprint, into: &values)
-		for account in accounts where account.isSelected {
-			insertNonEmptyPresentationText(account.accountFingerprint, into: &values)
-		}
-
-		return values.sorted()
-	}
-
-	var presentationAccountEmails: [String] {
-		var values = Set<String>()
-
-		insertNonEmptyPresentationText(account?.email, into: &values)
-		for account in accounts where account.isSelected {
-			insertNonEmptyPresentationText(account.email, into: &values)
-		}
-
-		return values.sorted()
-	}
-}
-
-private func insertNonEmptyPresentationText(_ value: String?, into values: inout Set<String>) {
-	guard let value = trimmed(value), value.isEmpty == false else {
-		return
-	}
-
-	values.insert(value)
 }
 
 private func trimmed(_ value: String?) -> String? {

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountModelTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountModelTests.swift
@@ -545,6 +545,8 @@ final class AccountModelTests: XCTestCase {
 				          "counts_as_running": true,
 				          "needs_attention": false,
 				          "is_waiting": false,
+				          "assigned_account_fingerprints": [],
+				          "assigned_account_emails": [],
 				          "run": {
 				            "run_id": "run-new",
 				            "issue_identifier": "XY-672"
@@ -572,6 +574,8 @@ final class AccountModelTests: XCTestCase {
 				        "counts_as_running": true,
 				        "needs_attention": false,
 				        "is_waiting": false,
+				        "assigned_account_fingerprints": [],
+				        "assigned_account_emails": [],
 				        "run": {
 				          "run_id": "run-old",
 				          "issue_identifier": "PUB-1147"
@@ -625,12 +629,7 @@ final class AccountModelTests: XCTestCase {
 	}
 
 	@MainActor
-	func testLegacySnapshotCurrentLanesCreateVisiblePresentation() throws {
-		let account = makeAccount(
-			status: "available",
-			email: "copy@example.com",
-			accountFingerprint: "...123456"
-		)
+	func testSnapshotCurrentLanesWithoutPresentationDoNotCreateVisiblePresentation() throws {
 		let store = AccountStore()
 
 		try store.applyOperatorDashboardEvent(dashboardEvent(
@@ -655,21 +654,12 @@ final class AccountModelTests: XCTestCase {
 			"""
 		))
 
-		let card = try XCTUnwrap(store.operatorPresentation?.currentLaneCards.first)
-
-		XCTAssertEqual(card.runID, "run-live")
-		XCTAssertEqual(card.title, "XY-672")
-		XCTAssertEqual(card.tone, "waiting")
-		XCTAssertTrue(card.isAssigned(to: account))
+		XCTAssertEqual(store.operatorSnapshot?.currentLanes.map(\.runID), ["run-live"])
+		XCTAssertNil(store.operatorPresentation)
 	}
 
 	@MainActor
-	func testLegacyRunActivityCurrentLanesCreateVisiblePresentation() throws {
-		let account = makeAccount(
-			status: "available",
-			email: "copy@example.com",
-			accountFingerprint: "...123456"
-		)
+	func testRunActivityCurrentLanesWithoutPresentationAreIgnored() throws {
 		let store = AccountStore()
 
 		try store.applyOperatorDashboardEvent(dashboardEvent(
@@ -695,12 +685,35 @@ final class AccountModelTests: XCTestCase {
 			"""
 		))
 
-		let card = try XCTUnwrap(store.operatorPresentation?.currentLaneCards.first)
-
 		XCTAssertNil(store.operatorSnapshot)
-		XCTAssertEqual(card.runID, "run-live")
-		XCTAssertEqual(card.detail, "agent_run")
-		XCTAssertTrue(card.isAssigned(to: account))
+		XCTAssertNil(store.operatorPresentation)
+	}
+
+	func testPresentationCardsRequireServerOwnedFields() throws {
+		let payload = """
+		{
+		  "current_lane_cards": [
+		    {
+		      "id": "run-690",
+		      "run_id": "run-690",
+		      "detail": "agent_run",
+		      "tone": "running",
+		      "counts_as_running": true,
+		      "needs_attention": false,
+		      "is_waiting": false,
+		      "assigned_account_fingerprints": ["...123456"],
+		      "assigned_account_emails": ["copy@example.com"],
+		      "run": {
+		        "run_id": "run-690",
+		        "issue_identifier": "XY-690",
+		        "current_operation": "agent_run"
+		      }
+		    }
+		  ]
+		}
+		""".data(using: .utf8)!
+
+		XCTAssertThrowsError(try JSONDecoder().decode(OperatorSnapshotPresentation.self, from: payload))
 	}
 
 	func testPresentationCardsAssignAccountsFromServerFields() throws {
@@ -772,6 +785,8 @@ final class AccountModelTests: XCTestCase {
 				        "counts_as_running": true,
 				        "needs_attention": false,
 				        "is_waiting": false,
+				        "assigned_account_fingerprints": [],
+				        "assigned_account_emails": [],
 				        "run": {
 				          "run_id": "run-live",
 				          "issue_identifier": "XY-672"
@@ -827,6 +842,8 @@ final class AccountModelTests: XCTestCase {
 				          "counts_as_running": true,
 				          "needs_attention": false,
 				          "is_waiting": false,
+				          "assigned_account_fingerprints": [],
+				          "assigned_account_emails": [],
 				          "run": {
 				            "run_id": "run-live",
 				            "issue_identifier": "XY-672"
@@ -881,6 +898,8 @@ final class AccountModelTests: XCTestCase {
 				          "counts_as_running": true,
 				          "needs_attention": false,
 				          "is_waiting": false,
+				          "assigned_account_fingerprints": [],
+				          "assigned_account_emails": [],
 				          "run": {
 				            "run_id": "run-live",
 				            "issue_identifier": "XY-672"
@@ -928,6 +947,8 @@ final class AccountModelTests: XCTestCase {
 				          "counts_as_running": true,
 				          "needs_attention": false,
 				          "is_waiting": false,
+				          "assigned_account_fingerprints": [],
+				          "assigned_account_emails": [],
 				          "run": {
 				            "run_id": "run-returned",
 				            "issue_identifier": "XY-934"

--- a/apps/decodex/src/orchestrator.rs
+++ b/apps/decodex/src/orchestrator.rs
@@ -50,6 +50,8 @@ use harness_improvement::{HarnessOutcomeRecordInput, record_harness_outcome_for_
 
 include!("orchestrator/types.rs");
 
+include!("orchestrator/operator_presentation.rs");
+
 include!("orchestrator/entrypoints.rs");
 
 include!("orchestrator/operator_http.rs");

--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -9067,74 +9067,6 @@
 				`;
 			}
 
-			function currentLaneSummary(run) {
-				if (runTelemetryMissingNeedsAttention(run)) {
-					if (runHasChildAgentActivity(run)) {
-						return `Metadata missing ${formatDuration(run.idle_for_seconds)}.`;
-					}
-					return `Telemetry missing ${formatDuration(run.idle_for_seconds)}.`;
-				}
-				if (runTelemetryMissing(run)) {
-					if (runHasChildAgentActivity(run)) {
-						return "Metadata pending.";
-					}
-					return "Telemetry pending.";
-				}
-				if (runStoppedProcessNeedsAttention(run)) {
-					return "";
-				}
-				if (runProcessStoppedWhileActive(run)) {
-					return `Agent done; finalizing ${displayToken(run.current_operation || run.run_phase || run.phase)}.`;
-				}
-				if (run.suspected_stall) {
-					return `No progress ${formatDuration(run.protocol_idle_for_seconds ?? run.idle_for_seconds)}.`;
-				}
-				if (run.interactive_requested) {
-					return "Operator input needed.";
-				}
-				if (run.continuation_pending) {
-					return "Continuation pending.";
-				}
-				if (runWaitReasonShowsExecutionProgress(run)) {
-					return "";
-				}
-				if (run.wait_reason) {
-					return `Waiting on ${displayToken(run.wait_reason)}.`;
-				}
-				if (!run.run_lease) {
-					return "No queue lease.";
-				}
-				const childCurrent = childAgentCurrentSummary(childAgentActivity(run));
-				if (childCurrent) {
-					return "";
-				}
-				const focus = protocolActivityFocus(run);
-				if (focus === "protocol idleness") {
-					return "Protocol idle.";
-				}
-				return "";
-			}
-
-			function runIssueRecord(run, derived) {
-				const candidates = derived?.queuedCandidates ?? [];
-				return candidates.find((candidate) => candidate.issue_id === run.issue_id);
-			}
-
-			function runIssueTitle(run, derived) {
-				const issueRecord = runIssueRecord(run, derived);
-				const operationFallback = displayToken(run.current_operation || run.run_phase || run.phase);
-				const fallback = issueDisplayKey(run);
-
-				for (const value of [run.title, run.issue_title, issueRecord?.title]) {
-					const title = String(value || "").trim();
-					if (title && !(fallback !== "unknown" && title === operationFallback)) {
-						return title;
-					}
-				}
-
-				return fallback !== "unknown" ? fallback : operationFallback;
-			}
-
 			function runHealthText(run) {
 				if (runTelemetryMissingNeedsAttention(run)) {
 					if (runHasChildAgentActivity(run)) {
@@ -10643,15 +10575,15 @@
 				renderStableList(
 					nodes.currentLanes,
 					cards
-						.map((card) => {
+						.map((card, index) => {
 							const run = card.run || {};
-							const tone = currentLaneCardToneClass(card, run);
+							const tone = currentLaneCardToneClass(card);
 							const statusBits = [statusLabel(runPhaseLabel(run), tone)];
 							const detailKey = runDetailKey(run);
-							const renderKey = card.id || card.run_id || currentLaneRenderKey(run);
-							const issueKey = card.issue_identifier || issueDisplayKey(run);
-							const issueTitle = card.title || runIssueTitle(run, derived);
-							const summary = currentLaneSummary(run) || card.detail || "";
+							const renderKey = card.id || card.run_id || `presentation-card:${index}`;
+							const issueKey = card.issue_identifier || "unknown";
+							const issueTitle = card.title || "Run";
+							const summary = card.detail || "";
 							if (run.ownership_state && run.ownership_state !== "leased_run") {
 								statusBits.push(inlineStatusFact("Owner", displayToken(run.ownership_state)));
 							}
@@ -11213,36 +11145,15 @@
 				);
 			}
 
-				function presentationCurrentLaneCards(presentation) {
-					return Array.isArray(presentation?.current_lane_cards)
-						? presentation.current_lane_cards.filter((card) => card && typeof card === "object")
-						: [];
-				}
+			function presentationCurrentLaneCards(presentation) {
+				return Array.isArray(presentation?.current_lane_cards)
+					? presentation.current_lane_cards.filter((card) => card && typeof card === "object")
+					: [];
+			}
 
 			function snapshotCurrentLaneCards(snapshot) {
-				const cards = presentationCurrentLaneCards(snapshot?.presentation);
-				if (cards.length || snapshot?.presentation) {
-					return cards;
-				}
-
-				return (snapshot?.current_lanes ?? [])
-					.filter((run) => run && typeof run === "object")
-						.map((run) => ({
-							id: run.run_id || issueDisplayKey(run),
-							run_id: run.run_id,
-							issue_id: run.issue_id,
-							issue_identifier: run.issue_identifier,
-							project_id: run.project_id,
-							title: run.issue_identifier || run.title || "Run",
-							detail: run.current_operation || run.run_phase || run.phase || "Active",
-							tone: runNeedsAttention(run)
-								? "attention"
-								: runWaitReasonShowsExecutionProgress(run) || !run.wait_reason
-									? "running"
-									: "waiting",
-							run,
-						}));
-				}
+				return presentationCurrentLaneCards(snapshot?.presentation);
+			}
 
 			function currentLaneRunsFromCards(cards) {
 				return cards
@@ -11254,7 +11165,7 @@
 				return currentLaneRunsFromCards(snapshotCurrentLaneCards(snapshot));
 			}
 
-			function currentLaneCardToneClass(card, run) {
+			function currentLaneCardToneClass(card) {
 				if (card?.tone === "attention") {
 					return "tone-blocked";
 				}
@@ -11262,7 +11173,7 @@
 					return "tone-wait";
 				}
 
-				return toneForRun(run);
+				return "tone-run";
 			}
 
 			function dashboardLiveRunActivityHasOverlay({ includeCompletedEmpty = false } = {}) {

--- a/apps/decodex/src/orchestrator/operator_http.rs
+++ b/apps/decodex/src/orchestrator/operator_http.rs
@@ -19,7 +19,6 @@ const DASHBOARD_RUN_ACTIVITY_FINGERPRINT_VOLATILE_FIELDS: &[&str] = &[
 	"current_elapsed_seconds",
 	"wall_seconds",
 ];
-const OPERATOR_PRESENTATION_SCHEMA: &str = "decodex.operator.presentation/1";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum OperatorRequestRoute {
@@ -610,9 +609,9 @@ fn build_operator_run_activity_event(
 	}
 
 	let fingerprint_payload =
-		dashboard_run_activity_fingerprint_payload(&account_control, &current_lanes);
+		dashboard_run_activity_fingerprint_payload(&account_control, &current_lanes)?;
 	let fingerprint = serde_json::to_vec(&fingerprint_payload)?;
-	let presentation = operator_snapshot_presentation_value(&current_lanes);
+	let presentation = operator_snapshot_presentation_value(&current_lanes)?;
 	let payload = json!({
 		"emittedAtUnixEpoch": now_unix_epoch,
 		"accountControl": &account_control,
@@ -631,18 +630,18 @@ fn build_operator_run_activity_event(
 fn dashboard_run_activity_fingerprint_payload(
 	account_control: &OperatorCodexAccountControlStatus,
 	current_lanes: &[OperatorRunStatus],
-) -> Value {
+) -> Result<Value> {
 	let mut fingerprint_payload = json!({
 		"accountControl": account_control,
 		"currentLanes": current_lanes,
 		"currentLanesComplete": true,
 		"currentLaneScope": "complete",
-		"presentation": operator_snapshot_presentation_value(current_lanes),
+		"presentation": operator_snapshot_presentation_value(current_lanes)?,
 	});
 
 	strip_dashboard_run_activity_volatile_fields(&mut fingerprint_payload);
 
-	fingerprint_payload
+	Ok(fingerprint_payload)
 }
 
 fn strip_dashboard_run_activity_volatile_fields(value: &mut Value) {
@@ -667,7 +666,7 @@ fn strip_dashboard_run_activity_volatile_fields(value: &mut Value) {
 fn operator_snapshot_json_value(snapshot: &OperatorStatusSnapshot) -> Result<Value> {
 	let mut value = serde_json::to_value(snapshot)?;
 
-	attach_operator_snapshot_presentation(&mut value, &snapshot.current_lanes);
+	attach_operator_snapshot_presentation(&mut value, &snapshot.current_lanes)?;
 
 	Ok(value)
 }
@@ -675,134 +674,15 @@ fn operator_snapshot_json_value(snapshot: &OperatorStatusSnapshot) -> Result<Val
 fn attach_operator_snapshot_presentation(
 	snapshot: &mut Value,
 	current_lanes: &[OperatorRunStatus],
-) {
+) -> Result<()> {
 	if let Some(object) = snapshot.as_object_mut() {
 		object.insert(
 			String::from("presentation"),
-			operator_snapshot_presentation_value(current_lanes),
+			operator_snapshot_presentation_value(current_lanes)?,
 		);
 	}
-}
 
-fn operator_snapshot_presentation_value(current_lanes: &[OperatorRunStatus]) -> Value {
-	json!({
-		"schema": OPERATOR_PRESENTATION_SCHEMA,
-		"current_lane_cards": current_lanes
-			.iter()
-			.map(operator_current_lane_card_value)
-			.collect::<Vec<_>>(),
-	})
-}
-
-fn operator_current_lane_card_value(run: &OperatorRunStatus) -> Value {
-	json!({
-		"id": &run.run_id,
-		"run_id": &run.run_id,
-		"project_id": &run.project_id,
-		"issue_id": &run.issue_id,
-		"issue_identifier": &run.issue_identifier,
-		"title": operator_current_lane_card_title(run),
-		"detail": operator_current_lane_card_detail(run),
-		"tone": operator_current_lane_card_tone(run),
-		"counts_as_running": operator_run_counts_as_running(run),
-		"needs_attention": operator_run_counts_as_attention(run),
-		"is_waiting": operator_run_counts_as_waiting(run),
-		"assigned_account_fingerprints": operator_run_assigned_account_fingerprints(run),
-		"assigned_account_emails": operator_run_assigned_account_emails(run),
-		"run": run,
-	})
-}
-
-fn operator_current_lane_card_title(run: &OperatorRunStatus) -> String {
-	trimmed_operator_text(run.issue_identifier.as_deref())
-		.or_else(|| trimmed_operator_text(run.title.as_deref()))
-		.unwrap_or("Run")
-		.to_owned()
-}
-
-fn operator_current_lane_card_detail(run: &OperatorRunStatus) -> String {
-	trimmed_operator_text(
-		run.child_agent_activity
-			.as_ref()
-			.and_then(|activity| activity.current_detail.as_deref()),
-	)
-	.or_else(|| {
-		trimmed_operator_text(
-			run.child_agent_activity
-				.as_ref()
-				.and_then(|activity| activity.current_bucket.as_deref()),
-		)
-	})
-	.or_else(|| trimmed_operator_text(run.wait_reason.as_deref()))
-	.or_else(|| {
-		trimmed_operator_text(Some(run.current_operation.as_str()))
-			.filter(|operation| *operation != RUN_OPERATION_IDLE)
-	})
-	.or_else(|| trimmed_operator_text(Some(run.run_phase.as_str())))
-	.or_else(|| trimmed_operator_text(Some(run.phase.as_str())))
-	.or_else(|| trimmed_operator_text(run.thread_status.as_deref()))
-	.unwrap_or("Active")
-	.to_owned()
-}
-
-fn operator_current_lane_card_tone(run: &OperatorRunStatus) -> &'static str {
-	if operator_run_counts_as_attention(run) {
-		"attention"
-	} else if operator_run_counts_as_waiting(run) {
-		"waiting"
-	} else {
-		"running"
-	}
-}
-
-fn operator_run_assigned_account_fingerprints(run: &OperatorRunStatus) -> Vec<String> {
-	let mut fingerprints = BTreeSet::new();
-
-	if let Some(account) = run.account.as_ref() {
-		insert_non_empty_operator_text(&mut fingerprints, &account.account_fingerprint);
-	}
-
-	for account in run
-		.accounts
-		.iter()
-		.filter(|account| account.status.eq_ignore_ascii_case("selected"))
-	{
-		insert_non_empty_operator_text(&mut fingerprints, &account.account_fingerprint);
-	}
-
-	fingerprints.into_iter().collect()
-}
-
-fn operator_run_assigned_account_emails(run: &OperatorRunStatus) -> Vec<String> {
-	let mut emails = BTreeSet::new();
-
-	if let Some(account) = run.account.as_ref()
-		&& let Some(email) = account.email.as_deref()
-	{
-		insert_non_empty_operator_text(&mut emails, email);
-	}
-
-	for account in run
-		.accounts
-		.iter()
-		.filter(|account| account.status.eq_ignore_ascii_case("selected"))
-	{
-		if let Some(email) = account.email.as_deref() {
-			insert_non_empty_operator_text(&mut emails, email);
-		}
-	}
-
-	emails.into_iter().collect()
-}
-
-fn insert_non_empty_operator_text(values: &mut BTreeSet<String>, value: &str) {
-	if let Some(value) = trimmed_operator_text(Some(value)) {
-		values.insert(value.to_owned());
-	}
-}
-
-fn trimmed_operator_text(value: Option<&str>) -> Option<&str> {
-	value.map(str::trim).filter(|value| !value.is_empty())
+	Ok(())
 }
 
 fn dashboard_current_snapshot_event_payload(

--- a/apps/decodex/src/orchestrator/operator_presentation.rs
+++ b/apps/decodex/src/orchestrator/operator_presentation.rs
@@ -1,0 +1,159 @@
+const OPERATOR_PRESENTATION_SCHEMA: &str = "decodex.operator.presentation/1";
+
+#[derive(Serialize)]
+struct OperatorSnapshotPresentation<'a> {
+	schema: &'static str,
+	#[serde(rename = "current_lane_cards")]
+	current_lane_cards: Vec<OperatorCurrentLaneCard<'a>>,
+}
+
+#[derive(Serialize)]
+struct OperatorCurrentLaneCard<'a> {
+	id: &'a str,
+	#[serde(rename = "run_id")]
+	run_id: &'a str,
+	#[serde(rename = "project_id")]
+	project_id: &'a str,
+	#[serde(rename = "issue_id")]
+	issue_id: &'a str,
+	#[serde(rename = "issue_identifier")]
+	issue_identifier: &'a Option<String>,
+	title: String,
+	detail: String,
+	tone: &'static str,
+	#[serde(rename = "counts_as_running")]
+	counts_as_running: bool,
+	#[serde(rename = "needs_attention")]
+	needs_attention: bool,
+	#[serde(rename = "is_waiting")]
+	is_waiting: bool,
+	#[serde(rename = "assigned_account_fingerprints")]
+	assigned_account_fingerprints: Vec<String>,
+	#[serde(rename = "assigned_account_emails")]
+	assigned_account_emails: Vec<String>,
+	run: &'a OperatorRunStatus,
+}
+
+fn operator_snapshot_presentation_value(current_lanes: &[OperatorRunStatus]) -> Result<Value> {
+	Ok(serde_json::to_value(operator_snapshot_presentation(current_lanes))?)
+}
+
+fn operator_snapshot_presentation(
+	current_lanes: &[OperatorRunStatus],
+) -> OperatorSnapshotPresentation<'_> {
+	OperatorSnapshotPresentation {
+		schema: OPERATOR_PRESENTATION_SCHEMA,
+		current_lane_cards: current_lanes.iter().map(operator_current_lane_card).collect(),
+	}
+}
+
+fn operator_current_lane_card(run: &OperatorRunStatus) -> OperatorCurrentLaneCard<'_> {
+	OperatorCurrentLaneCard {
+		id: run.run_id.as_str(),
+		run_id: run.run_id.as_str(),
+		project_id: run.project_id.as_str(),
+		issue_id: run.issue_id.as_str(),
+		issue_identifier: &run.issue_identifier,
+		title: operator_current_lane_card_title(run),
+		detail: operator_current_lane_card_detail(run),
+		tone: operator_current_lane_card_tone(run),
+		counts_as_running: operator_run_counts_as_running(run),
+		needs_attention: operator_run_counts_as_attention(run),
+		is_waiting: operator_run_counts_as_waiting(run),
+		assigned_account_fingerprints: operator_run_assigned_account_fingerprints(run),
+		assigned_account_emails: operator_run_assigned_account_emails(run),
+		run,
+	}
+}
+
+fn operator_current_lane_card_title(run: &OperatorRunStatus) -> String {
+	trimmed_operator_presentation_text(run.issue_identifier.as_deref())
+		.or_else(|| trimmed_operator_presentation_text(run.title.as_deref()))
+		.unwrap_or("Run")
+		.to_owned()
+}
+
+fn operator_current_lane_card_detail(run: &OperatorRunStatus) -> String {
+	trimmed_operator_presentation_text(
+		run.child_agent_activity.as_ref().and_then(|activity| activity.current_detail.as_deref()),
+	)
+	.or_else(|| {
+		trimmed_operator_presentation_text(
+			run.child_agent_activity
+				.as_ref()
+				.and_then(|activity| activity.current_bucket.as_deref()),
+		)
+	})
+	.or_else(|| trimmed_operator_presentation_text(run.wait_reason.as_deref()))
+	.or_else(|| {
+		trimmed_operator_presentation_text(Some(run.current_operation.as_str()))
+			.filter(|operation| *operation != RUN_OPERATION_IDLE)
+	})
+	.or_else(|| trimmed_operator_presentation_text(Some(run.run_phase.as_str())))
+	.or_else(|| trimmed_operator_presentation_text(Some(run.phase.as_str())))
+	.or_else(|| trimmed_operator_presentation_text(run.thread_status.as_deref()))
+	.unwrap_or("Active")
+	.to_owned()
+}
+
+fn operator_current_lane_card_tone(run: &OperatorRunStatus) -> &'static str {
+	if operator_run_counts_as_attention(run) {
+		"attention"
+	} else if operator_run_counts_as_waiting(run) {
+		"waiting"
+	} else {
+		"running"
+	}
+}
+
+fn operator_run_assigned_account_fingerprints(run: &OperatorRunStatus) -> Vec<String> {
+	let mut fingerprints = BTreeSet::new();
+
+	if let Some(account) = run.account.as_ref() {
+		insert_non_empty_operator_presentation_text(
+			&mut fingerprints,
+			&account.account_fingerprint,
+		);
+	}
+
+	for account in
+		run.accounts.iter().filter(|account| account.status.eq_ignore_ascii_case("selected"))
+	{
+		insert_non_empty_operator_presentation_text(
+			&mut fingerprints,
+			&account.account_fingerprint,
+		);
+	}
+
+	fingerprints.into_iter().collect()
+}
+
+fn operator_run_assigned_account_emails(run: &OperatorRunStatus) -> Vec<String> {
+	let mut emails = BTreeSet::new();
+
+	if let Some(account) = run.account.as_ref()
+		&& let Some(email) = account.email.as_deref()
+	{
+		insert_non_empty_operator_presentation_text(&mut emails, email);
+	}
+
+	for account in
+		run.accounts.iter().filter(|account| account.status.eq_ignore_ascii_case("selected"))
+	{
+		if let Some(email) = account.email.as_deref() {
+			insert_non_empty_operator_presentation_text(&mut emails, email);
+		}
+	}
+
+	emails.into_iter().collect()
+}
+
+fn insert_non_empty_operator_presentation_text(values: &mut BTreeSet<String>, value: &str) {
+	if let Some(value) = trimmed_operator_presentation_text(Some(value)) {
+		values.insert(value.to_owned());
+	}
+}
+
+fn trimmed_operator_presentation_text(value: Option<&str>) -> Option<&str> {
+	value.map(str::trim).filter(|value| !value.is_empty())
+}

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -622,14 +622,16 @@ fn operator_dashboard_current_lane_status_copy_stays_concise() {
 	assert!(
 		response.contains("return run.current_operation || run.run_phase || run.phase || \"process_stopped\";")
 	);
-	assert!(response.contains("Operator input needed."));
-	assert!(response.contains("Protocol idle."));
 	assert!(response.contains("Stopped agent process"));
 	assert!(response.contains("attention stopped"));
 	assert!(response.contains("inlineStatusFact(\"Agent\", \"Done\")"));
 	assert!(response.contains("const waitReason = displayToken(run.wait_reason);"));
 	assert!(response.contains("if (!displayTextRepeats(summary, waitReason))"));
 	assert!(response.contains("displayTextRepeats(summary, \"operator input\")"));
+	assert!(response.contains("const issueTitle = card.title || \"Run\";"));
+	assert!(response.contains("const summary = card.detail || \"\";"));
+	assert!(!response.contains("Operator input needed."));
+	assert!(!response.contains("Protocol idle."));
 	assert!(response.contains("status: \"waiting\","));
 	assert!(!response.contains(
 		"status: run.wait_reason ? `wait ${displayToken(run.wait_reason)}`"
@@ -1869,8 +1871,9 @@ fn operator_dashboard_run_activity_consumes_server_presentation() {
 
 	assert!(response.contains("function presentationCurrentLaneCards(presentation)"));
 	assert!(response.contains("function snapshotCurrentLaneCards(snapshot)"));
+	assert!(response.contains("return presentationCurrentLaneCards(snapshot?.presentation);"));
 	assert!(response.contains("function currentLaneRunsFromCards(cards)"));
-	assert!(response.contains("function currentLaneCardToneClass(card, run)"));
+	assert!(response.contains("function currentLaneCardToneClass(card)"));
 	assert!(response.contains("let dashboardLivePresentation = null;"));
 	assert!(response.contains("let dashboardLiveRunActivitySeen = false;"));
 	assert!(!response.contains("let dashboardLiveAccounts = null;"));
@@ -1902,6 +1905,13 @@ fn operator_dashboard_run_activity_consumes_server_presentation() {
 	assert!(!response.contains("accounts: dashboardLiveAccounts"));
 	assert!(response.contains("current_lanes: liveRuns,"));
 	assert!(response.contains("presentation: dashboardLivePresentation,"));
+	assert!(!response.contains("snapshot?.current_lanes ?? []"));
+	assert!(!response.contains("issueDisplayKey(run),\n\t\t\t\t\t\t\trun_id: run.run_id"));
+	assert!(!response.contains("function currentLaneSummary"));
+	assert!(!response.contains("function runIssueTitle"));
+	assert!(!response.contains("card.title || runIssueTitle"));
+	assert!(!response.contains("currentLaneSummary(run) || card.detail"));
+	assert!(!response.contains("function currentLaneCardToneClass(card, run)"));
 	assert!(!response.contains("function mergeDashboardRunRecord"));
 	assert!(!response.contains("function mergeDashboardCurrentLanes"));
 	assert!(!response.contains("function mergeDashboardRunActivity"));


### PR DESCRIPTION
## Summary
- add a server-owned operator presentation contract for current-lane cards
- make snapshot and runActivity payloads publish that same presentation contract
- remove Web/macOS raw current_lanes presentation fallbacks so both clients consume the same card fields

## Validation
- swift test
- cargo test -p decodex operator_dashboard
- git diff --check

## Operational note
This deliberately does not restart the local Decodex server while an active lane is running. The installed runtime must be restarted after landing to serve the new presentation contract.