### PR TITLE
XY-1053: [DECODEX-P1] Align Decodex plugin skills with review and handoff runtime authority

### DIFF
--- a/apps/decodex/src/plugin_surface_tests.rs
+++ b/apps/decodex/src/plugin_surface_tests.rs
@@ -36,6 +36,10 @@ const RESEARCH_PROMOTE_SKILL: &str = include_str!(concat!(
 	env!("CARGO_MANIFEST_DIR"),
 	"/../../plugins/decodex/skills/research-promote/SKILL.md"
 ));
+const LAND_SKILL: &str = include_str!(concat!(
+	env!("CARGO_MANIFEST_DIR"),
+	"/../../plugins/decodex/skills/land/SKILL.md"
+));
 const AGENT_CHALLENGE_SKILL: &str = include_str!(concat!(
 	env!("CARGO_MANIFEST_DIR"),
 	"/../../plugins/agent-method/skills/challenge/SKILL.md"
@@ -339,6 +343,44 @@ fn packaged_research_and_challenge_skills_encode_decodex_methodology() {
 	assert_contains(&research_surface, "Program Intake");
 	assert_contains(&research_surface, "missing evidence");
 	assert_contains(&research_surface, "premature success claims");
+}
+
+#[test]
+fn packaged_decodex_skills_route_review_evidence_and_handoff_recovery_to_runtime_authority() {
+	let ops_surface = format!("{DECODEX_OPS_SKILL}\n{ROUTING_REF}");
+	let research_surface = format!("{RESEARCH_SKILL}\n{ROUTING_REF}");
+	let land_surface = format!("{LAND_SKILL}\n{ROUTING_REF}");
+
+	assert_contains(&ops_surface, "missing_review_handoff_record");
+	assert_contains(&ops_surface, "`decodex recover review-handoff diagnose <ISSUE> --json`");
+	assert_contains(
+		&ops_surface,
+		"`decodex recover review-handoff rebind <ISSUE> --pr <URL> --dry-run`",
+	);
+	assert_contains(
+		&ops_surface,
+		"`decodex recover review-handoff adopt <ISSUE> --pr <URL> --dry-run`",
+	);
+	assert_contains(&ops_surface, "Decodex-owned retained lane PR");
+	assert_contains(&ops_surface, "human-owned PR takeover");
+	assert_contains(&ops_surface, "Do not infer PR lineage");
+	assert_contains(
+		&research_surface,
+		"research compact loop is not runtime `compact_current_head_review`",
+	);
+	assert_contains(&research_surface, "issue_review_checkpoint.review_cost_control");
+	assert_contains(&research_surface, "`review_cost_control`");
+	assert_contains(&research_surface, "`decodex evidence`");
+	assert_contains_normalized(&research_surface, "not a skipped-review signal");
+	assert_contains(&land_surface, "`decodex land --authority <ISSUE> --pr <URL> \"<summary>\"`");
+	assert_contains(&land_surface, "Only `decodex land` lands a Decodex-owned PR");
+	assert_contains_normalized(
+		&land_surface,
+		"Rebind restores or refreshes a Decodex-owned retained lane",
+	);
+	assert_contains_normalized(&land_surface, "adopt is for a human-owned PR takeover");
+	assert_contains(&land_surface, "Neither recovery command lands the PR");
+	assert_contains(&land_surface, "Do not use global `AGENTS.md`");
 }
 
 #[test]

--- a/docs/decisions/decodex-plugin-source.md
+++ b/docs/decisions/decodex-plugin-source.md
@@ -6,7 +6,7 @@ status: active
 authority: rationale
 owner: docs
 tags: [decision]
-last_verified: 2026-06-19
+last_verified: 2026-06-22
 ---
 # Decodex Plugin Source
 
@@ -64,6 +64,11 @@ Companion plugins:
 The plugin must route to `apps/decodex/src/`, `docs/spec/`, `docs/runbook/`, `docs/reference/`,
 registered project `WORKFLOW.md`, and registered project `project.toml` instead of
 copying their full contracts.
+
+For review handoff and compact review readback, plugin skills must point operators to
+runtime evidence surfaces such as `issue_review_checkpoint.review_cost_control`,
+`decodex evidence`, and `decodex recover review-handoff` diagnosis. They must not copy
+the review-cost, handoff-recovery, or tracker invariants out of the runtime specs.
 
 ## Consequences
 

--- a/docs/reference/test-suite.md
+++ b/docs/reference/test-suite.md
@@ -26,7 +26,7 @@ standards for keeping, merging, or deleting tests.
 
 ## Current Snapshot
 
-This snapshot groups 1348 runnable `nextest` tests across all targets. One additional
+This snapshot groups 1349 runnable `nextest` tests across all targets. One additional
 skipped live app-server test is listed only with verbose or JSON inventory output.
 Regenerate the runnable inventory with:
 

--- a/docs/reference/test-suite.md
+++ b/docs/reference/test-suite.md
@@ -65,7 +65,7 @@ cargo nextest list --workspace --all-targets --all-features 2>/dev/null \
 | Git, worktree, landing, and recovery helpers | 161 | `worktree::tests`, `manual::tests`, `commit_message::tests`, `github::tests`, `default_branch_sync::tests`, `pull_request::tests`, `recovery::tests`, `git_credentials::tests` | Git/worktree behavior, manual landing, GitHub/PR helpers, recovery commands, commit-message policy |
 | Account, CLI, archive, tracker, and MCP integration | 155 | `accounts::tests`, `agent::codex_accounts::tests`, `agent::decodex_tool_bridge::tests`, `app_bridge::tests`, `cli::tests`, `archive_hygiene::tests`, `tracker::*::tests`, `mcp::tests`, `apps/decodex/tests/mcp_stdio.rs` | User-facing commands, account pools, app bridge parsing, archive hygiene, direct tracker adapter, MCP resources, HTTP transport, bearer auth, schema-bound planning tools, inspect-first operate/admin tools, remote-safe observability templates, process-level MCP smoke, and public-text behavior |
 | Program intake | 10 | `program_intake::tests` | Decision Contract materialization, Linear issue shaping, and internal Execution Program persistence |
-| Loop contract and research surfaces | 29 | `loop_contract::tests`, `execution_program::tests`, `research_design::tests`, `plugin_surface_tests` | Decision Contract schema, Execution Program readiness, research compile/promote, and plugin trigger behavior |
+| Loop contract and research surfaces | 30 | `loop_contract::tests`, `execution_program::tests`, `research_design::tests`, `plugin_surface_tests` | Decision Contract schema, Execution Program readiness, research compile/promote, and plugin trigger behavior |
 
 ## Orchestrator Inventory
 

--- a/plugins/decodex/references/routing.md
+++ b/plugins/decodex/references/routing.md
@@ -25,6 +25,9 @@ generic challenge live in companion plugins.
   when the result becomes a decision-ready comparison.
 - Research/design: use `research`. The compact loop is probe, evidence, options,
   judgment, challenge, decision. Results are latent Decision Contract candidates only.
+  This research compact loop is separate from runtime `compact_current_head_review`;
+  read runtime compact review quality from `issue_review_checkpoint.review_cost_control`
+  and `decodex evidence`, not from research output.
 - Challenge: use `$agent-method:challenge` for generic skeptic review of plans,
   claims, evidence sufficiency, option framing, and ready/decision-ready assertions.
   Challenge does not create execution authority.
@@ -34,7 +37,8 @@ generic challenge live in companion plugins.
   Planning owns issue briefing and Program readiness.
 - Decodex ops: use `decodex-ops` for retained automation, human-driven CLI commands,
   ordinary non-Program tracker intake, service labels, lane control, recovery
-  inspection, and operator readback.
+  inspection, operator readback, and `missing_review_handoff_record` diagnosis before
+  any dry-run rebind or adopt.
 - Commit and land: use `commit` or `land` for human-driven Git history creation or PR
   landing; keep these high-risk authority surfaces narrower than general ops.
 - MCP gateway: use stdio locally and Streamable HTTP only behind the operator's chosen
@@ -86,8 +90,11 @@ non-issue work.
 
 For human-driven PR landing, confirm PR/base/head/mergeability/checks, then use
 `decodex land`; add `--manual-authority --pr <URL>` for non-issue work. If
-issue-authority landing lacks retained handoff state, dry-run
-`decodex recover review-handoff adopt` before any live adopt.
+issue-authority landing lacks retained handoff state, run
+`decodex recover review-handoff diagnose <ISSUE> --json` first. Use dry-run `rebind`
+only for a Decodex-owned retained lane whose PR, retained worktree, branch, and head
+lineage match. Use dry-run `adopt` only for a human-owned PR takeover from the current
+managed worktree. Neither recovery command lands the PR.
 
 ## Hard Boundaries
 

--- a/plugins/decodex/skills/decodex-ops/SKILL.md
+++ b/plugins/decodex/skills/decodex-ops/SKILL.md
@@ -26,6 +26,20 @@ service labels, recovery, or lane-control details matter.
 - Treat `run --dry-run` as planning evidence, not proof of live writes or closeout.
 - Before live `decodex run`, inspect the project `WORKFLOW.md` and runtime state.
 
+## Review-Handoff Recovery
+
+- For `missing_review_handoff_record`, start with
+  `decodex recover review-handoff diagnose <ISSUE> --json`.
+- If diagnosis proves a Decodex-owned retained lane PR and matching retained
+  worktree, branch, and head lineage, dry-run
+  `decodex recover review-handoff rebind <ISSUE> --pr <URL> --dry-run` before any
+  live rebind.
+- If diagnosis shows a human-owned PR takeover from the current managed worktree,
+  dry-run `decodex recover review-handoff adopt <ISSUE> --pr <URL> --dry-run`
+  before any live adopt.
+- Do not infer PR lineage from branch names, PR titles, Linear comments, status
+  summaries, or stale snapshots.
+
 ## Labels
 
 - `decodex:queued:<service-id>`: ordinary issue intake candidate.

--- a/plugins/decodex/skills/land/SKILL.md
+++ b/plugins/decodex/skills/land/SKILL.md
@@ -9,11 +9,16 @@ Land a human-driven PR through `decodex land`. Read `../../references/routing.md
 full landing and recovery boundaries.
 
 1. Confirm PR, base, head, mergeability, and checks.
-2. Run `decodex land "<summary>"`, or
+2. Run `decodex land --authority <ISSUE> --pr <URL> "<summary>"`, or
    `decodex land --manual-authority --pr <URL> "<summary>"` for non-issue work.
-3. Dry-run `decodex recover review-handoff adopt` before any live adopt.
+3. When handoff state is missing, run `decodex recover review-handoff diagnose`
+   first. Rebind restores or refreshes a Decodex-owned retained lane; adopt is for a
+   human-owned PR takeover from a managed worktree. Dry-run either recovery before
+   the live command.
 4. Clean worktrees and branches only after Decodex landing succeeds and default branch
    syncs.
 
 Use this only after explicit landing intent. Do not substitute GitHub UI, `gh pr
 merge`, merge queue, raw Git, or direct API mutation.
+Only `decodex land` lands a Decodex-owned PR; review-handoff rebind and adopt repair
+runtime lifecycle records and do not land the PR.

--- a/plugins/decodex/skills/research/SKILL.md
+++ b/plugins/decodex/skills/research/SKILL.md
@@ -14,6 +14,12 @@ Follow the compact loop: probe, evidence, options, judgment, challenge, decision
 `$agent-method:challenge` for the skeptic pass before `decision_ready` or any
 high-risk recommendation. Use `research-promote` only after explicit acceptance.
 
+- The research compact loop is not runtime `compact_current_head_review`.
+- For runtime compact review quality, read the current `issue_review_checkpoint`
+  `review_cost_control` and `decodex evidence` instead of restating tracker or review
+  policy in research output.
+- Treat compact runtime review as independent current-head review evidence, not a
+  skipped-review signal.
 - Do not route Decodex research through external research skills.
 - Do not write new Decodex research as `docs/research/` event logs or JSON.
 - Use `docs/research/` only for Markdown OKF research concepts or evidence extraction


### PR DESCRIPTION
## Summary
- Align Decodex ops, research, routing, and land skill guidance with runtime authority for review evidence and handoff recovery.
- Add plugin surface assertions for compact review evidence routing and missing handoff diagnose, rebind, and adopt wording.
- Update owned docs references and test-suite inventory for the added plugin surface test.

## Validation
- cargo test -p decodex plugin_surface_tests -- --nocapture
- cargo make fmt
- cargo make lint-fix
- cargo make test
- cargo make check-docs

## Review
- Decodex review checkpoint clean for HEAD 7846076.