### PR TITLE
Fix dashboard stale pending lane UI

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -279,10 +279,6 @@ struct AccountPanelView: View {
 			header
 			accountSummary
 
-			if operatorCurrentLaneCards.isEmpty == false {
-				operatorCurrentLaneStrip
-			}
-
 			if telemetryMatrixIsVisible {
 				AccountTelemetryMatrixView(
 					aggregate: accountProfileAggregate,
@@ -600,9 +596,6 @@ struct AccountPanelView: View {
 			+ AccountPanelLayout.accountSummaryHeight
 			+ AccountPanelLayout.sectionSpacing
 
-		if operatorCurrentLaneCards.isEmpty == false {
-			height += AccountPanelLayout.sectionSpacing + AccountPanelLayout.operatorRunStripHeight
-		}
 		if telemetryMatrixIsVisible {
 			height += AccountPanelLayout.sectionSpacing + telemetryMatrixHeight
 		}
@@ -679,22 +672,6 @@ struct AccountPanelView: View {
 		store.operatorPresentation?.currentLaneCards
 			?? store.operatorSnapshot?.presentation?.currentLaneCards
 			?? []
-	}
-
-	private var operatorCurrentLaneStrip: some View {
-		HStack(spacing: 7) {
-			Image(systemName: "dot.radiowaves.left.and.right")
-				.font(.system(size: 13, weight: .semibold))
-				.foregroundStyle(PanelPalette.actionBlue(colorScheme))
-				.frame(width: 16, height: AccountRunChipLayout.height)
-				.accessibilityHidden(true)
-
-			AccountRunSummaryView(runs: operatorCurrentLaneCards, currentTime: currentTime)
-		}
-		.padding(.horizontal, 8)
-		.frame(height: AccountPanelLayout.operatorRunStripHeight)
-		.frame(maxWidth: .infinity, alignment: .leading)
-		.modernGlassSurface(cornerRadius: 9, depth: .row)
 	}
 
 	private func operatorCurrentLaneCards(for account: CodexAccount) -> [OperatorCurrentLaneCard] {
@@ -1804,7 +1781,6 @@ private enum AccountPanelLayout {
 	static let sectionSpacing: CGFloat = 6
 	static let headerHeight: CGFloat = 28
 	static let accountSummaryHeight: CGFloat = 31
-	static let operatorRunStripHeight: CGFloat = 29
 	static let telemetryHorizontalPadding: CGFloat = 7
 	static let telemetryTopPadding: CGFloat = 7
 	static let telemetryBottomPadding: CGFloat = 2

--- a/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
@@ -23,6 +23,7 @@ final class AccountStore: ObservableObject {
 	private let bridge = DecodexAppBridge()
 	private var automaticRefreshTask: Task<Void, Never>?
 	private var operatorSnapshotStreamTask: Task<Void, Never>?
+	private var operatorSnapshotPublishedAtUnixEpoch: Int64?
 
 	deinit {
 		automaticRefreshTask?.cancel()
@@ -222,9 +223,13 @@ final class AccountStore: ObservableObject {
 
 			operatorSnapshot = snapshot
 			operatorPresentation = snapshot.presentation
+			operatorSnapshotPublishedAtUnixEpoch = payload.snapshotPublishedAtUnixEpoch
 			operatorSnapshotUpdatedAt = payload.snapshotPublishedAt ?? Date()
 		case "runActivity":
 			guard let presentation = payload.presentation else {
+				return
+			}
+			guard isStaleRunActivity(payload) == false else {
 				return
 			}
 
@@ -233,6 +238,16 @@ final class AccountStore: ObservableObject {
 		default:
 			break
 		}
+	}
+
+	private func isStaleRunActivity(_ payload: OperatorDashboardSocketPayload) -> Bool {
+		guard let emittedAtUnixEpoch = payload.emittedAtUnixEpoch,
+			let snapshotPublishedAtUnixEpoch = operatorSnapshotPublishedAtUnixEpoch
+		else {
+			return false
+		}
+
+		return emittedAtUnixEpoch < snapshotPublishedAtUnixEpoch
 	}
 
 	func useInCodex(_ account: CodexAccount) async {

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountModelTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountModelTests.swift
@@ -519,7 +519,7 @@ final class AccountModelTests: XCTestCase {
 	}
 
 	@MainActor
-	func testOperatorRunActivityUsesStreamOrderOverSnapshotTimestamp() throws {
+	func testOlderRunActivityDoesNotOverrideNewerSnapshotPresentation() throws {
 		let store = AccountStore()
 
 		try store.applyOperatorDashboardEvent(dashboardEvent(
@@ -588,7 +588,81 @@ final class AccountModelTests: XCTestCase {
 		))
 
 		XCTAssertEqual(store.operatorSnapshot?.currentLanes.map(\.runID), ["run-new"])
-		XCTAssertEqual(store.operatorPresentation?.currentLaneCards.map(\.runID), ["run-old"])
+		XCTAssertEqual(store.operatorPresentation?.currentLaneCards.map(\.runID), ["run-new"])
+	}
+
+	@MainActor
+	func testNewerRunActivityOverridesSnapshotPresentation() throws {
+		let store = AccountStore()
+
+		try store.applyOperatorDashboardEvent(dashboardEvent(
+			type: "snapshot",
+			payload: """
+			{
+				  "snapshotPublishedAtUnixEpoch": 20,
+				  "snapshot": {
+				    "current_lanes": [
+				      {
+				        "run_id": "run-old",
+				        "issue_identifier": "XY-672"
+				      }
+				    ],
+				    "presentation": {
+				      "current_lane_cards": [
+				        {
+				          "id": "run-old",
+				          "run_id": "run-old",
+				          "title": "XY-672",
+				          "detail": "agent_run",
+				          "tone": "running",
+				          "counts_as_running": true,
+				          "needs_attention": false,
+				          "is_waiting": false,
+				          "assigned_account_fingerprints": [],
+				          "assigned_account_emails": [],
+				          "run": {
+				            "run_id": "run-old",
+				            "issue_identifier": "XY-672"
+				          }
+				        }
+				      ]
+				    }
+				  }
+				}
+			"""
+		))
+		try store.applyOperatorDashboardEvent(dashboardEvent(
+			type: "runActivity",
+				payload: """
+				{
+				  "emittedAtUnixEpoch": 30,
+				  "presentation": {
+				    "current_lane_cards": [
+				      {
+				        "id": "run-live",
+				        "run_id": "run-live",
+				        "title": "PUB-1147",
+				        "detail": "agent_run",
+				        "tone": "waiting",
+				        "counts_as_running": true,
+				        "needs_attention": false,
+				        "is_waiting": true,
+				        "assigned_account_fingerprints": [],
+				        "assigned_account_emails": [],
+				        "run": {
+				          "run_id": "run-live",
+				          "issue_identifier": "PUB-1147",
+				          "wait_reason": "model_execution"
+				        }
+				      }
+				    ]
+				  }
+				}
+			"""
+		))
+
+		XCTAssertEqual(store.operatorSnapshot?.currentLanes.map(\.runID), ["run-old"])
+		XCTAssertEqual(store.operatorPresentation?.currentLaneCards.map(\.runID), ["run-live"])
 	}
 
 	@MainActor

--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -11081,18 +11081,36 @@
 					.join("");
 			}
 
-			function unixEpochSecondsToIso(value) {
+			function unixEpochSeconds(value) {
 				const unixEpochSeconds = Number(value);
 				if (!Number.isFinite(unixEpochSeconds)) {
 					return null;
 				}
 
-				const parsed = new Date(unixEpochSeconds * 1000);
+				return unixEpochSeconds;
+			}
+
+			function unixEpochSecondsToIso(value) {
+				const seconds = unixEpochSeconds(value);
+				if (seconds == null) {
+					return null;
+				}
+
+				const parsed = new Date(seconds * 1000);
 				if (Number.isNaN(parsed.getTime())) {
 					return null;
 				}
 
 				return parsed.toISOString();
+			}
+
+			function isoTimestampUnixEpoch(value) {
+				const timestamp = Date.parse(value || "");
+				if (!Number.isFinite(timestamp)) {
+					return null;
+				}
+
+				return Math.floor(timestamp / 1000);
 			}
 
 			function parseDashboardSocketMessage(message) {
@@ -11166,14 +11184,25 @@
 			}
 
 			function currentLaneCardToneClass(card) {
-				if (card?.tone === "attention") {
+				const run = card?.run || {};
+				if (card?.needs_attention === true || card?.tone === "attention") {
 					return "tone-blocked";
 				}
-				if (card?.tone === "waiting") {
+				if (card?.is_waiting === true || card?.tone === "waiting") {
 					return "tone-wait";
+				}
+				if (card?.counts_as_running === true || runCountsAsRunning(run)) {
+					return "tone-run";
 				}
 
 				return "tone-run";
+			}
+
+			function dashboardRunActivityIsStale(payload) {
+				const emittedAt = unixEpochSeconds(payload?.emittedAtUnixEpoch);
+				const snapshotPublishedAt = isoTimestampUnixEpoch(lastDashboardRender?.snapshotPublishedAt);
+
+				return emittedAt != null && snapshotPublishedAt != null && emittedAt < snapshotPublishedAt;
 			}
 
 			function dashboardLiveRunActivityHasOverlay({ includeCompletedEmpty = false } = {}) {
@@ -11235,6 +11264,20 @@
 						lastEventAt: new Date().toISOString(),
 					});
 
+					return;
+				}
+
+				if (dashboardRunActivityIsStale(payload)) {
+					updateDashboardStreamState(
+						{
+							connected: true,
+							error: false,
+							lastEventAt:
+								unixEpochSecondsToIso(payload.emittedAtUnixEpoch) ||
+								new Date().toISOString(),
+						},
+						false,
+					);
 					return;
 				}
 

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -1874,6 +1874,11 @@ fn operator_dashboard_run_activity_consumes_server_presentation() {
 	assert!(response.contains("return presentationCurrentLaneCards(snapshot?.presentation);"));
 	assert!(response.contains("function currentLaneRunsFromCards(cards)"));
 	assert!(response.contains("function currentLaneCardToneClass(card)"));
+	assert!(response.contains("if (card?.is_waiting === true || card?.tone === \"waiting\")"));
+	assert!(response.contains("if (card?.counts_as_running === true || runCountsAsRunning(run))"));
+	assert!(response.contains("function dashboardRunActivityIsStale(payload)"));
+	assert!(response.contains("emittedAt < snapshotPublishedAt"));
+	assert!(response.contains("if (dashboardRunActivityIsStale(payload))"));
 	assert!(response.contains("let dashboardLivePresentation = null;"));
 	assert!(response.contains("let dashboardLiveRunActivitySeen = false;"));
 	assert!(!response.contains("let dashboardLiveAccounts = null;"));

--- a/apps/decodex/src/orchestrator/tests/operator/status/http.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/http.rs
@@ -1190,6 +1190,18 @@ fn read_websocket_json_until(
 		"acct-1"
 	);
 	assert_eq!(
+		data["presentation"]["current_lane_cards"][0]["tone"],
+		"waiting"
+	);
+	assert_eq!(
+		data["presentation"]["current_lane_cards"][0]["counts_as_running"],
+		true
+	);
+	assert_eq!(
+		data["presentation"]["current_lane_cards"][0]["is_waiting"],
+		true
+	);
+	assert_eq!(
 		fingerprint["presentation"]["current_lane_cards"][0]["run"]["run_id"],
 		"run-1"
 	);


### PR DESCRIPTION
## Summary
- remove the native app top current-lane strip
- keep pending lanes yellow while preventing stale runActivity events from overriding newer snapshots
- cover the App and WebUI presentation ordering with tests

## Validation
- cargo make fmt
- cargo make lint-fix
- cargo make test
- swift test --package-path apps/decodex-app
- git diff --check

## Local install
- installed CLI and /Applications/Decodex.app at decodex 0.2.0-234aa2b4-aarch64-apple-darwin
- restarted service and app; /livez returns ok