### PR TITLE
Fix Decodex runtime config and evidence projection guards

### DIFF
--- a/apps/decodex/src/orchestrator/agent_evidence.rs
+++ b/apps/decodex/src/orchestrator/agent_evidence.rs
@@ -2052,12 +2052,6 @@ fn agent_run_blocker_reason(run: &OperatorRunStatus) -> Option<&'static str> {
 	if operator_run_has_stale_execution_without_known_process(run) {
 		return Some("stale_execution_without_known_process");
 	}
-	if run.wait_reason.is_some() {
-		return Some("run_waiting");
-	}
-	if run.next_retry_at.is_some() {
-		return Some("retry_backoff");
-	}
 
 	None
 }
@@ -2072,9 +2066,6 @@ fn agent_run_next_action(run: &OperatorRunStatus) -> Option<String> {
 			Some(String::from("Inspect the run capsule, retained worktree, protocol activity, and process state before retrying.")),
 		Some("process_exited_without_terminal_status") =>
 			Some(String::from("Inspect the retained worktree and runtime markers; reconcile or retry only after preserving useful local changes.")),
-		Some("run_waiting") =>
-			Some(String::from("Inspect wait_reason, thread status, and protocol activity before deciding whether the agent can continue.")),
-		Some("retry_backoff") => Some(String::from("Wait until next_retry_at or run an explicit operator retry after reviewing the retained state.")),
 		_ => None,
 	}
 }

--- a/apps/decodex/src/orchestrator/daemon.rs
+++ b/apps/decodex/src/orchestrator/daemon.rs
@@ -556,6 +556,8 @@ where
 				ensure_project_has_no_merged_worktree_cleanup_debt(context.project)?;
 			}
 
+			validate_workflow_read_first_files(context.project, context.workflow)?;
+
 			state_store.configure_dispatch_slot_root(
 				context.project.service_id(),
 				context.project.worktree_root(),

--- a/apps/decodex/src/orchestrator/prompting.rs
+++ b/apps/decodex/src/orchestrator/prompting.rs
@@ -166,8 +166,7 @@ where
 	}
 
 	for relative_path in workflow.frontmatter().context().read_first() {
-		let absolute_path = project.repo_root().join(relative_path);
-		let contents = fs::read_to_string(&absolute_path)?;
+		let contents = read_workflow_read_first_file(project, relative_path)?;
 
 		sections.push(format!("File: {relative_path}\n{contents}"));
 	}
@@ -268,6 +267,44 @@ where
 	sections.push(tracker_contract);
 
 	Ok(sections.join("\n\n"))
+}
+
+fn validate_workflow_read_first_files(
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+) -> Result<()> {
+	for relative_path in workflow.frontmatter().context().read_first() {
+		read_workflow_read_first_file(project, relative_path)?;
+	}
+
+	Ok(())
+}
+
+fn read_workflow_read_first_file(
+	project: &ServiceConfig,
+	relative_path: &str,
+) -> Result<String> {
+	let absolute_path = project.repo_root().join(relative_path);
+
+	fs::read_to_string(&absolute_path).map_err(|error| {
+		if error.kind() == ErrorKind::NotFound {
+			return eyre::eyre!(
+				"Project `{}` workflow `{}` references missing `context.read_first` file `{}` at `{}`. Update the path or restore the file before dispatch.",
+				project.service_id(),
+				project.workflow_path().display(),
+				relative_path,
+				absolute_path.display()
+			);
+		}
+
+		eyre::eyre!(
+			"Failed to read project `{}` workflow `{}` `context.read_first` file `{}` at `{}`: {error}",
+			project.service_id(),
+			project.workflow_path().display(),
+			relative_path,
+			absolute_path.display()
+		)
+	})
 }
 
 fn build_user_input<T>(

--- a/apps/decodex/src/orchestrator/run_cycle.rs
+++ b/apps/decodex/src/orchestrator/run_cycle.rs
@@ -2461,6 +2461,8 @@ where
 		context.preferred_issue_state,
 	);
 
+	validate_workflow_read_first_files(context.project, context.workflow)?;
+
 	if !context.dry_run
 		&& !context.lease_preacquired
 		&& !context.state_store.try_acquire_lease(

--- a/apps/decodex/src/orchestrator/tests/intake/prepare_issue_run.rs
+++ b/apps/decodex/src/orchestrator/tests/intake/prepare_issue_run.rs
@@ -63,6 +63,69 @@ fn prepare_issue_run_records_starting_attempt_before_execute() {
 }
 
 #[test]
+fn prepare_issue_run_rejects_missing_read_first_before_lease_or_attempt() {
+	let workflow_markdown = sample_workflow_markdown(
+		"pubfi",
+		&["docs/guide/getting_started.md"],
+		"Follow the repository policy.\n",
+		1,
+	);
+	let (_temp_dir, base_config, workflow) =
+		temp_project_layout_with_workflow_markdown(&workflow_markdown);
+	let config = service_config_with_github_token_env_var(&base_config, "HOME");
+	let issue = sample_issue("Todo", &[]);
+	let tracker =
+		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let worktree_manager =
+		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
+	let error = orchestrator::prepare_issue_run(
+		PrepareIssueRunContext {
+			tracker: &tracker,
+			project: &config,
+			workflow: &workflow,
+			state_store: &state_store,
+			worktree_manager: &worktree_manager,
+			dry_run: false,
+			lease_preacquired: false,
+			dispatch_mode: IssueDispatchMode::Normal,
+			preferred_issue_state: None,
+			preferred_initial_issue_state: None,
+			preferred_run_identity: None,
+			preferred_retry_budget_base: None,
+		},
+		issue.clone(),
+	)
+	.expect_err("missing read_first file should reject dispatch");
+	let message = format!("{error:#}");
+
+	assert!(message.contains("context.read_first"));
+	assert!(message.contains("docs/guide/getting_started.md"));
+	assert!(message.contains(config.workflow_path().to_str().expect("workflow path should be utf-8")));
+	assert!(
+		state_store
+			.lease_for_issue(&issue.id)
+			.expect("lease lookup should succeed")
+			.is_none(),
+		"read_first preflight must reject before acquiring a lease"
+	);
+	assert!(
+		state_store
+			.list_run_attempts_for_issue(&issue.id)
+			.expect("attempt lookup should succeed")
+			.is_empty(),
+		"read_first preflight must reject before recording an attempt"
+	);
+	assert!(
+		state_store
+			.worktree_for_issue(&issue.id)
+			.expect("worktree lookup should succeed")
+			.is_none(),
+		"read_first preflight must reject before recording worktree ownership"
+	);
+}
+
+#[test]
 fn prepare_issue_run_runs_after_create_workspace_hook() {
 	let workflow_markdown = r#"
 +++

--- a/apps/decodex/src/orchestrator/tests/operator/status/agent_evidence.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/agent_evidence.rs
@@ -116,6 +116,72 @@ fn agent_evidence_snapshot_writes_index_blockers_capsules_and_event_stream() {
 	assert_eq!(event_json["blocker_count"], 3);
 }
 
+#[test]
+fn agent_evidence_snapshot_does_not_turn_waiting_running_lane_into_attention_blocker() {
+	let temp_dir = TempDir::new().expect("temp dir should create");
+	let _home_guard = TestEnvVarGuard::set("HOME", temp_dir.path().to_str().expect("temp path should be utf-8"));
+	let mut current_lane = operator_status_text_current_lane();
+
+	current_lane.wait_reason = Some(String::from("tool_execution"));
+	current_lane.lane_control_next_action = String::from("continue_owned_attempt");
+	current_lane.counts_as_running = true;
+	current_lane.needs_attention = false;
+	current_lane.suspected_stall = false;
+
+	let snapshot = OperatorStatusSnapshot {
+		project_id: String::from(TEST_SERVICE_ID),
+		run_limit: 10,
+		status_source: None,
+		snapshot_age_seconds: None,
+		warnings: Vec::new(),
+		warning_details: Vec::new(),
+		connector_backoffs: Vec::new(),
+		projects: vec![agent_evidence_project_status_with_configured_gh()],
+		account_control: OperatorCodexAccountControlStatus {
+			mode: String::from("balanced"),
+			account_selector: None,
+		},
+		accounts: Vec::new(),
+		current_lanes: vec![current_lane.clone()],
+		recent_runs: vec![current_lane],
+		history_lanes: Vec::new(),
+		execution_programs: Vec::new(),
+		queued_candidates: Vec::new(),
+		worktrees: operator_status_text_worktrees(),
+		post_review_lanes: Vec::new(),
+	};
+	let results = orchestrator::write_agent_evidence_snapshot(
+		&snapshot,
+		AgentEvidenceSource::ServeTick,
+	)
+	.expect("agent evidence should write");
+	let result = results.first().expect("project evidence should exist");
+	let index_path = temp_dir
+		.path()
+		.join(".codex/decodex/agent-evidence/pubfi/handoff-index.json");
+	let index_json = read_json_file(&index_path);
+
+	assert_eq!(result.handoff_index.summary.blocker_count, 0);
+	assert_eq!(index_json["summary"]["blocker_count"], 0);
+	assert_eq!(index_json["blockers"].as_array().expect("blockers should be array").len(), 0);
+
+	let capsule_path = index_json["run_capsules"][0]["path"]
+		.as_str()
+		.expect("run capsule path should be a string");
+	let capsule_json = read_json_file(Path::new(capsule_path));
+
+	assert_eq!(capsule_json["wait_reason"], "tool_execution");
+	assert_eq!(capsule_json["diagnosis"]["attention_required"], false);
+	assert!(capsule_json["diagnosis"]["reason_code"].is_null());
+	assert!(
+		!temp_dir
+			.path()
+			.join(".codex/decodex/agent-evidence/pubfi/blockers/pub-101.json")
+			.exists(),
+		"ordinary wait_reason must not create a stale attention blocker file"
+	);
+}
+
 fn assert_agent_evidence_github_cli_authority(index_json: &Value) {
 	assert_eq!(index_json["github_cli_authority"]["discovery_tier"], "configured");
 	assert_eq!(index_json["github_cli_authority"]["command_path"], "/opt/homebrew/bin/gh");

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,9 @@
 
 ## 2026-06-22
 
+- Added the workflow `context.read_first` dispatch preflight and agent-evidence
+  live-wait projection boundary so stale workflow paths fail before lease/attempt
+  ownership while normal running waits remain run capsules instead of blockers.
 - Documented the ordinary dispatch guard for retained review handoff lanes:
   matching retained worktree plus review lifecycle record blocks normal, Program, and
   retry intake with `review_handoff_state_transition_pending` while post-review

--- a/docs/spec/agent-evidence.md
+++ b/docs/spec/agent-evidence.md
@@ -8,7 +8,7 @@ owner: runtime
 tags: [spec]
 code_refs: [apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/types.rs]
 drift_watch: [decodex evidence, issue_review_checkpoint, review_cost_control, phase_acceptance_check, authority_boundary_check, architecture_recovery_packet, private_execution_evidence_readback]
-last_verified: 2026-06-21
+last_verified: 2026-06-22
 ---
 # Agent Evidence
 
@@ -134,6 +134,10 @@ Each blocker carries:
 - `next_action`: a short agent-facing recovery hint
 - `related_run_capsule_path`: the run capsule path when the blocker belongs to a
   known run
+
+Running lanes that are leased, count as running, and do not require attention remain
+run capsules only, even when their `wait_reason` or retry metadata is populated.
+Agent evidence must not turn normal live execution waits into blocker snapshots.
 
 For `missing_review_handoff_record`, the recovery contract must point agents to
 `decodex recover review-handoff diagnose <ISSUE> --json`. Rebind remains an explicit

--- a/docs/spec/workflow-file.md
+++ b/docs/spec/workflow-file.md
@@ -353,4 +353,5 @@ Use the issue-scoped tracker tools autonomously when tracker updates are require
 - The body should contain durable repo rules, not ephemeral run notes.
 - The body should instruct the coding agent to use the issue-scoped tracker tools autonomously when tracker writes are part of the repo workflow.
 - Use `context.read_first = []` when the repository has no extra context files beyond the primary `WORKFLOW.md` body.
+- Decodex must verify every configured `context.read_first` file exists and is readable before dispatch acquires a lane lease or records a run attempt. Prompt construction uses the same read path so stale paths report the project, workflow path, relative file path, and absolute file path instead of a generic filesystem error.
 - If the repository expects PR-backed review handoff, the body should state that the lane must produce a reviewable PR before the success state can be reached.


### PR DESCRIPTION
## Summary

- Validate `WORKFLOW.md` `context.read_first` files before dispatch acquires leases or records attempts, and report project/workflow/relative/absolute path context on failures.
- Keep active leased lanes with normal `wait_reason`/retry metadata as run capsules instead of agent-evidence blocker snapshots.
- Document the runtime contract changes and add regression coverage for stale read-first paths and live-wait evidence projection.

## Validation

- `cargo make fmt`
- `cargo test -p decodex prepare_issue_run_rejects_missing_read_first_before_lease_or_attempt`
- `cargo test -p decodex agent_evidence_snapshot_does_not_turn_waiting_running_lane_into_attention_blocker`
- `cargo test -p decodex agent_evidence`
- `cargo test -p decodex prepare_issue_run`
- `cargo make check` (1383 passed, 1 skipped)
