### PR TITLE
XY-1085: [Autonomy P2] Persist read-only autonomy signal ledger

### DIFF
--- a/apps/decodex/src/autonomy_signal.rs
+++ b/apps/decodex/src/autonomy_signal.rs
@@ -1,0 +1,896 @@
+//! Versioned read-only autonomy signal evidence.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::prelude::{Result, eyre};
+
+pub(crate) const AUTONOMY_SIGNAL_SCHEMA: &str = "decodex.autonomy_signal/1";
+
+const AUTONOMY_SIGNAL_RECORD_VERSION: u16 = 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AutonomySignalKind {
+	RuntimeHealth,
+	ValidationRegression,
+	ReviewFeedbackCluster,
+	UserFeedbackCluster,
+	SpecDrift,
+	ProtocolDrift,
+	MetricRegression,
+	ExecutionFriction,
+	DocsSkillDrift,
+}
+impl AutonomySignalKind {
+	pub(crate) fn as_str(self) -> &'static str {
+		match self {
+			Self::RuntimeHealth => "runtime_health",
+			Self::ValidationRegression => "validation_regression",
+			Self::ReviewFeedbackCluster => "review_feedback_cluster",
+			Self::UserFeedbackCluster => "user_feedback_cluster",
+			Self::SpecDrift => "spec_drift",
+			Self::ProtocolDrift => "protocol_drift",
+			Self::MetricRegression => "metric_regression",
+			Self::ExecutionFriction => "execution_friction",
+			Self::DocsSkillDrift => "docs_skill_drift",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AutonomySignalSourceType {
+	User,
+	Review,
+	Ci,
+	Telemetry,
+	Runtime,
+	Docs,
+	Protocol,
+	Agent,
+	Tracker,
+	Memory,
+	Report,
+}
+impl AutonomySignalSourceType {
+	fn as_str(self) -> &'static str {
+		match self {
+			Self::User => "user",
+			Self::Review => "review",
+			Self::Ci => "ci",
+			Self::Telemetry => "telemetry",
+			Self::Runtime => "runtime",
+			Self::Docs => "docs",
+			Self::Protocol => "protocol",
+			Self::Agent => "agent",
+			Self::Tracker => "tracker",
+			Self::Memory => "memory",
+			Self::Report => "report",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AutonomySignalFreshness {
+	Fresh,
+	Stale,
+	Unknown,
+}
+impl AutonomySignalFreshness {
+	pub(crate) fn as_str(self) -> &'static str {
+		match self {
+			Self::Fresh => "fresh",
+			Self::Stale => "stale",
+			Self::Unknown => "unknown",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AutonomySignalEvidenceClass {
+	ExternalSource,
+	RepoSource,
+	LiveReadback,
+	Inference,
+	Gap,
+}
+impl AutonomySignalEvidenceClass {
+	pub(crate) fn as_str(self) -> &'static str {
+		match self {
+			Self::ExternalSource => "external_source",
+			Self::RepoSource => "repo_source",
+			Self::LiveReadback => "live_readback",
+			Self::Inference => "inference",
+			Self::Gap => "gap",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AutonomySignalConfidence {
+	High,
+	Medium,
+	Low,
+	Unknown,
+}
+impl AutonomySignalConfidence {
+	pub(crate) fn as_str(self) -> &'static str {
+		match self {
+			Self::High => "high",
+			Self::Medium => "medium",
+			Self::Low => "low",
+			Self::Unknown => "unknown",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AutonomySignalPrivacy {
+	Public,
+	Team,
+	LocalPrivate,
+}
+impl AutonomySignalPrivacy {
+	pub(crate) fn as_str(self) -> &'static str {
+		match self {
+			Self::Public => "public",
+			Self::Team => "team",
+			Self::LocalPrivate => "local_private",
+		}
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AutonomySignalReviewRoute {
+	pub(crate) route: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub(crate) finding_source: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub(crate) finding_index: Option<u64>,
+	pub(crate) summary: String,
+	#[serde(default)]
+	pub(crate) evidence_refs: Vec<String>,
+}
+impl AutonomySignalReviewRoute {
+	fn validate(&self) -> Result<()> {
+		validate_required("autonomy signal review route.route", &self.route)?;
+		validate_required("autonomy signal review route.summary", &self.summary)?;
+		validate_optional_required(
+			"autonomy signal review route.finding_source",
+			self.finding_source.as_deref(),
+		)?;
+
+		validate_string_list("autonomy signal review route.evidence_refs", &self.evidence_refs)
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AutonomySignalReviewEvidence {
+	pub(crate) review_phase: String,
+	pub(crate) review_status: String,
+	pub(crate) head_sha: String,
+	#[serde(default)]
+	pub(crate) checkpoint_refs: Vec<String>,
+	#[serde(default)]
+	pub(crate) finding_routes: Vec<AutonomySignalReviewRoute>,
+}
+impl AutonomySignalReviewEvidence {
+	fn validate(&self) -> Result<()> {
+		validate_required("autonomy signal review evidence.review_phase", &self.review_phase)?;
+		validate_required("autonomy signal review evidence.review_status", &self.review_status)?;
+		validate_required("autonomy signal review evidence.head_sha", &self.head_sha)?;
+		validate_nonempty_list(
+			"autonomy signal review evidence.checkpoint_refs",
+			&self.checkpoint_refs,
+		)?;
+
+		if self.finding_routes.is_empty() {
+			eyre::bail!("Review-derived autonomy signals require finding_routes.");
+		}
+
+		for route in &self.finding_routes {
+			route.validate()?;
+		}
+
+		Ok(())
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct AutonomySignalInput {
+	pub(crate) project_id: String,
+	pub(crate) objective_id: String,
+	pub(crate) objective_version: u64,
+	pub(crate) source_type: AutonomySignalSourceType,
+	pub(crate) source_refs: Vec<String>,
+	pub(crate) primary_source_refs: Vec<String>,
+	pub(crate) issue_id: Option<String>,
+	pub(crate) run_id: Option<String>,
+	pub(crate) attempt_id: Option<String>,
+	pub(crate) head_sha: Option<String>,
+	pub(crate) captured_at: String,
+	pub(crate) freshness: AutonomySignalFreshness,
+	pub(crate) summary: String,
+	pub(crate) evidence: Vec<String>,
+	pub(crate) evidence_class: AutonomySignalEvidenceClass,
+	pub(crate) contradictions: Vec<String>,
+	pub(crate) gaps: Vec<String>,
+	pub(crate) confidence: AutonomySignalConfidence,
+	pub(crate) privacy: AutonomySignalPrivacy,
+	pub(crate) observed_counts: BTreeMap<String, u64>,
+	pub(crate) review_evidence: Option<AutonomySignalReviewEvidence>,
+	pub(crate) proposal_only: bool,
+	pub(crate) created_at: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AutonomySignal {
+	#[serde(default = "autonomy_signal_schema")]
+	schema: String,
+	#[serde(default = "autonomy_signal_record_version")]
+	record_version: u16,
+	id: String,
+	fingerprint: String,
+	project_id: String,
+	objective_id: String,
+	objective_version: u64,
+	kind: AutonomySignalKind,
+	source_type: AutonomySignalSourceType,
+	source_refs: Vec<String>,
+	#[serde(default)]
+	primary_source_refs: Vec<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	issue_id: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	run_id: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	attempt_id: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	head_sha: Option<String>,
+	captured_at: String,
+	freshness: AutonomySignalFreshness,
+	summary: String,
+	evidence: Vec<String>,
+	evidence_class: AutonomySignalEvidenceClass,
+	#[serde(default)]
+	contradictions: Vec<String>,
+	#[serde(default)]
+	gaps: Vec<String>,
+	confidence: AutonomySignalConfidence,
+	privacy: AutonomySignalPrivacy,
+	#[serde(default)]
+	observed_counts: BTreeMap<String, u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	review_evidence: Option<AutonomySignalReviewEvidence>,
+	proposal_only: bool,
+	created_at: String,
+}
+#[allow(dead_code)]
+impl AutonomySignal {
+	pub(crate) fn runtime_health(input: AutonomySignalInput) -> Result<Self> {
+		Self::from_input(AutonomySignalKind::RuntimeHealth, input)
+	}
+
+	pub(crate) fn validation_regression(input: AutonomySignalInput) -> Result<Self> {
+		Self::from_input(AutonomySignalKind::ValidationRegression, input)
+	}
+
+	pub(crate) fn review_feedback_cluster(input: AutonomySignalInput) -> Result<Self> {
+		Self::from_input(AutonomySignalKind::ReviewFeedbackCluster, input)
+	}
+
+	pub(crate) fn user_feedback_cluster(input: AutonomySignalInput) -> Result<Self> {
+		Self::from_input(AutonomySignalKind::UserFeedbackCluster, input)
+	}
+
+	pub(crate) fn spec_drift(input: AutonomySignalInput) -> Result<Self> {
+		Self::from_input(AutonomySignalKind::SpecDrift, input)
+	}
+
+	pub(crate) fn protocol_drift(input: AutonomySignalInput) -> Result<Self> {
+		Self::from_input(AutonomySignalKind::ProtocolDrift, input)
+	}
+
+	#[allow(dead_code)]
+	pub(crate) fn metric_regression(input: AutonomySignalInput) -> Result<Self> {
+		Self::from_input(AutonomySignalKind::MetricRegression, input)
+	}
+
+	pub(crate) fn execution_friction(input: AutonomySignalInput) -> Result<Self> {
+		Self::from_input(AutonomySignalKind::ExecutionFriction, input)
+	}
+
+	pub(crate) fn docs_skill_drift(input: AutonomySignalInput) -> Result<Self> {
+		Self::from_input(AutonomySignalKind::DocsSkillDrift, input)
+	}
+
+	pub(crate) fn id(&self) -> &str {
+		&self.id
+	}
+
+	pub(crate) fn fingerprint(&self) -> &str {
+		&self.fingerprint
+	}
+
+	pub(crate) fn project_id(&self) -> &str {
+		&self.project_id
+	}
+
+	pub(crate) fn objective_id(&self) -> &str {
+		&self.objective_id
+	}
+
+	pub(crate) fn objective_version(&self) -> u64 {
+		self.objective_version
+	}
+
+	pub(crate) fn kind(&self) -> AutonomySignalKind {
+		self.kind
+	}
+
+	pub(crate) fn freshness(&self) -> AutonomySignalFreshness {
+		self.freshness
+	}
+
+	pub(crate) fn evidence_class(&self) -> AutonomySignalEvidenceClass {
+		self.evidence_class
+	}
+
+	pub(crate) fn confidence(&self) -> AutonomySignalConfidence {
+		self.confidence
+	}
+
+	pub(crate) fn privacy(&self) -> AutonomySignalPrivacy {
+		self.privacy
+	}
+
+	pub(crate) fn gaps(&self) -> &[String] {
+		&self.gaps
+	}
+
+	pub(crate) fn contradictions(&self) -> &[String] {
+		&self.contradictions
+	}
+
+	pub(crate) fn source_refs(&self) -> &[String] {
+		&self.source_refs
+	}
+
+	pub(crate) fn primary_source_refs(&self) -> &[String] {
+		&self.primary_source_refs
+	}
+
+	pub(crate) fn head_sha(&self) -> Option<&str> {
+		self.head_sha.as_deref()
+	}
+
+	pub(crate) fn review_evidence(&self) -> Option<&AutonomySignalReviewEvidence> {
+		self.review_evidence.as_ref()
+	}
+
+	pub(crate) fn validate(&self) -> Result<()> {
+		validate_required("autonomy signal schema", &self.schema)?;
+		validate_required("autonomy signal id", &self.id)?;
+		validate_required("autonomy signal fingerprint", &self.fingerprint)?;
+		validate_required("autonomy signal project_id", &self.project_id)?;
+		validate_required("autonomy signal objective_id", &self.objective_id)?;
+		validate_required("autonomy signal captured_at", &self.captured_at)?;
+		validate_required("autonomy signal summary", &self.summary)?;
+		validate_required("autonomy signal created_at", &self.created_at)?;
+		validate_nonempty_list("autonomy signal source_refs", &self.source_refs)?;
+		validate_nonempty_list("autonomy signal evidence", &self.evidence)?;
+		validate_string_list("autonomy signal primary_source_refs", &self.primary_source_refs)?;
+		validate_string_list("autonomy signal contradictions", &self.contradictions)?;
+		validate_string_list("autonomy signal gaps", &self.gaps)?;
+		validate_optional_required("autonomy signal issue_id", self.issue_id.as_deref())?;
+		validate_optional_required("autonomy signal run_id", self.run_id.as_deref())?;
+		validate_optional_required("autonomy signal attempt_id", self.attempt_id.as_deref())?;
+		validate_optional_required("autonomy signal head_sha", self.head_sha.as_deref())?;
+
+		if self.schema != AUTONOMY_SIGNAL_SCHEMA {
+			eyre::bail!("Autonomy signal `{}` has unsupported schema `{}`.", self.id, self.schema);
+		}
+		if self.record_version != AUTONOMY_SIGNAL_RECORD_VERSION {
+			eyre::bail!(
+				"Autonomy signal `{}` has unsupported record_version `{}`.",
+				self.id,
+				self.record_version
+			);
+		}
+		if self.objective_version == 0 {
+			eyre::bail!(
+				"Autonomy signal `{}` objective_version must be greater than zero.",
+				self.id
+			);
+		}
+		if !self.proposal_only {
+			eyre::bail!("Autonomy signal `{}` must remain proposal-only evidence.", self.id);
+		}
+
+		self.validate_source_specific_rules()?;
+
+		let expected = autonomy_signal_fingerprint(self)?;
+
+		if expected != self.fingerprint {
+			eyre::bail!(
+				"Autonomy signal `{}` fingerprint mismatch: expected `{expected}`.",
+				self.id
+			);
+		}
+
+		let expected_id = autonomy_signal_id(&expected);
+
+		if expected_id != self.id {
+			eyre::bail!(
+				"Autonomy signal id `{}` does not match fingerprint `{expected}`.",
+				self.id
+			);
+		}
+
+		Ok(())
+	}
+
+	fn from_input(kind: AutonomySignalKind, input: AutonomySignalInput) -> Result<Self> {
+		let mut signal = Self {
+			schema: autonomy_signal_schema(),
+			record_version: autonomy_signal_record_version(),
+			id: String::new(),
+			fingerprint: String::new(),
+			project_id: input.project_id,
+			objective_id: input.objective_id,
+			objective_version: input.objective_version,
+			kind,
+			source_type: input.source_type,
+			source_refs: input.source_refs,
+			primary_source_refs: input.primary_source_refs,
+			issue_id: input.issue_id,
+			run_id: input.run_id,
+			attempt_id: input.attempt_id,
+			head_sha: input.head_sha,
+			captured_at: input.captured_at,
+			freshness: input.freshness,
+			summary: input.summary,
+			evidence: input.evidence,
+			evidence_class: input.evidence_class,
+			contradictions: input.contradictions,
+			gaps: input.gaps,
+			confidence: input.confidence,
+			privacy: input.privacy,
+			observed_counts: input.observed_counts,
+			review_evidence: input.review_evidence,
+			proposal_only: input.proposal_only,
+			created_at: input.created_at,
+		};
+		let fingerprint = autonomy_signal_fingerprint(&signal)?;
+
+		signal.id = autonomy_signal_id(&fingerprint);
+		signal.fingerprint = fingerprint;
+
+		signal.validate()?;
+
+		Ok(signal)
+	}
+
+	fn validate_source_specific_rules(&self) -> Result<()> {
+		if matches!(
+			self.source_type,
+			AutonomySignalSourceType::Memory | AutonomySignalSourceType::Report
+		) && self.primary_source_refs.is_empty()
+		{
+			eyre::bail!(
+				"Memory/report autonomy signal `{}` requires primary_source_refs.",
+				self.id
+			);
+		}
+		if self.kind == AutonomySignalKind::ReviewFeedbackCluster
+			|| self.source_type == AutonomySignalSourceType::Review
+		{
+			let Some(review_evidence) = &self.review_evidence else {
+				eyre::bail!(
+					"Review-derived autonomy signal `{}` requires review_evidence.",
+					self.id
+				);
+			};
+
+			review_evidence.validate()?;
+
+			let Some(head_sha) = self.head_sha.as_deref() else {
+				eyre::bail!("Review-derived autonomy signal `{}` requires head_sha.", self.id);
+			};
+
+			if review_evidence.head_sha != head_sha {
+				eyre::bail!(
+					"Review-derived autonomy signal `{}` head_sha must match review evidence head.",
+					self.id
+				);
+			}
+		}
+
+		Ok(())
+	}
+}
+
+fn autonomy_signal_schema() -> String {
+	AUTONOMY_SIGNAL_SCHEMA.to_owned()
+}
+
+const fn autonomy_signal_record_version() -> u16 {
+	AUTONOMY_SIGNAL_RECORD_VERSION
+}
+
+fn autonomy_signal_id(fingerprint: &str) -> String {
+	format!("autonomy_signal:{fingerprint}")
+}
+
+fn autonomy_signal_fingerprint(signal: &AutonomySignal) -> Result<String> {
+	let material = serde_json::json!({
+		"schema": signal.schema,
+		"record_version": signal.record_version,
+		"project_id": signal.project_id,
+		"objective_id": signal.objective_id,
+		"objective_version": signal.objective_version,
+		"kind": signal.kind.as_str(),
+		"source_type": signal.source_type.as_str(),
+		"source_refs": sorted_strings(&signal.source_refs),
+		"primary_source_refs": sorted_strings(&signal.primary_source_refs),
+		"issue_id": signal.issue_id,
+		"run_id": signal.run_id,
+		"attempt_id": signal.attempt_id,
+		"head_sha": signal.head_sha,
+		"freshness": signal.freshness.as_str(),
+		"summary": signal.summary,
+		"evidence": sorted_strings(&signal.evidence),
+		"evidence_class": signal.evidence_class.as_str(),
+		"contradictions": sorted_strings(&signal.contradictions),
+		"gaps": sorted_strings(&signal.gaps),
+		"confidence": signal.confidence.as_str(),
+		"privacy": signal.privacy.as_str(),
+		"review_evidence": canonical_review_evidence(signal.review_evidence.as_ref()),
+		"proposal_only": signal.proposal_only,
+	});
+	let payload = serde_json::to_vec(&material)?;
+	let digest = Sha256::digest(payload);
+	let mut hash = String::with_capacity(64);
+
+	for byte in digest {
+		hash.push(char::from(b"0123456789abcdef"[(byte >> 4) as usize]));
+		hash.push(char::from(b"0123456789abcdef"[(byte & 0x0f) as usize]));
+	}
+
+	Ok(hash)
+}
+
+fn canonical_review_evidence(evidence: Option<&AutonomySignalReviewEvidence>) -> serde_json::Value {
+	let Some(evidence) = evidence else {
+		return serde_json::Value::Null;
+	};
+	let mut finding_routes = evidence
+		.finding_routes
+		.iter()
+		.map(|route| {
+			serde_json::json!({
+				"route": route.route,
+				"finding_source": route.finding_source,
+				"finding_index": route.finding_index,
+				"summary": route.summary,
+				"evidence_refs": sorted_strings(&route.evidence_refs),
+			})
+		})
+		.collect::<Vec<_>>();
+
+	finding_routes.sort_by_key(serde_json::Value::to_string);
+
+	serde_json::json!({
+		"review_phase": evidence.review_phase,
+		"review_status": evidence.review_status,
+		"head_sha": evidence.head_sha,
+		"checkpoint_refs": sorted_strings(&evidence.checkpoint_refs),
+		"finding_routes": finding_routes,
+	})
+}
+
+fn sorted_strings(values: &[String]) -> Vec<&str> {
+	let mut values = values.iter().map(String::as_str).collect::<Vec<_>>();
+
+	values.sort_unstable();
+
+	values
+}
+
+fn validate_required(name: &str, value: &str) -> Result<()> {
+	if value.trim().is_empty() {
+		eyre::bail!("{name} must not be empty.");
+	}
+
+	Ok(())
+}
+
+fn validate_optional_required(name: &str, value: Option<&str>) -> Result<()> {
+	if let Some(value) = value {
+		validate_required(name, value)?;
+	}
+
+	Ok(())
+}
+
+fn validate_string_list(name: &str, values: &[String]) -> Result<()> {
+	for value in values {
+		validate_required(name, value)?;
+	}
+
+	Ok(())
+}
+
+fn validate_nonempty_list(name: &str, values: &[String]) -> Result<()> {
+	if values.is_empty() {
+		eyre::bail!("{name} must not be empty.");
+	}
+
+	validate_string_list(name, values)
+}
+
+#[cfg(test)]
+mod tests {
+	use std::collections::BTreeMap;
+
+	use crate::{
+		autonomy_objective::{
+			AutonomyObjectiveAcceptance, AutonomyObjectiveActorKind, AutonomyObjectiveContract,
+		},
+		autonomy_signal::{
+			AutonomySignal, AutonomySignalConfidence, AutonomySignalEvidenceClass,
+			AutonomySignalFreshness, AutonomySignalInput, AutonomySignalPrivacy,
+			AutonomySignalReviewEvidence, AutonomySignalReviewRoute, AutonomySignalSourceType,
+		},
+		state::StateStore,
+	};
+
+	fn signal_input() -> AutonomySignalInput {
+		AutonomySignalInput {
+			project_id: String::from("decodex"),
+			objective_id: String::from("quality-autonomy"),
+			objective_version: 1,
+			source_type: AutonomySignalSourceType::Runtime,
+			source_refs: vec![String::from("status:XY-1085:runtime-health")],
+			primary_source_refs: Vec::new(),
+			issue_id: Some(String::from("XY-1085")),
+			run_id: Some(String::from("xy-1085-attempt-1")),
+			attempt_id: Some(String::from("1")),
+			head_sha: Some(String::from("3273e45234aa3346e194a7a9e48cd1c58c3e408c")),
+			captured_at: String::from("2026-06-22T00:00:00Z"),
+			freshness: AutonomySignalFreshness::Fresh,
+			summary: String::from("Runtime status readback remained internally consistent."),
+			evidence: vec![String::from("status readback had no contradictory lane states")],
+			evidence_class: AutonomySignalEvidenceClass::LiveReadback,
+			contradictions: Vec::new(),
+			gaps: vec![String::from("No external dashboard readback included.")],
+			confidence: AutonomySignalConfidence::Medium,
+			privacy: AutonomySignalPrivacy::LocalPrivate,
+			observed_counts: BTreeMap::new(),
+			review_evidence: None,
+			proposal_only: true,
+			created_at: String::from("2026-06-22T00:00:05Z"),
+		}
+	}
+
+	fn review_evidence() -> AutonomySignalReviewEvidence {
+		AutonomySignalReviewEvidence {
+			review_phase: String::from("handoff"),
+			review_status: String::from("findings"),
+			head_sha: String::from("3273e45234aa3346e194a7a9e48cd1c58c3e408c"),
+			checkpoint_refs: vec![String::from(
+				"review_checkpoint:XY-1085:3273e45234aa3346e194a7a9e48cd1c58c3e408c",
+			)],
+			finding_routes: vec![AutonomySignalReviewRoute {
+				route: String::from("follow_up"),
+				finding_source: Some(String::from("accepted_findings")),
+				finding_index: Some(0),
+				summary: String::from("Follow-up evidence should inform future proposals."),
+				evidence_refs: vec![String::from("finding_routes[0]")],
+			}],
+		}
+	}
+
+	fn objective_fixture(version: u64) -> AutonomyObjectiveContract {
+		serde_json::from_value(serde_json::json!({
+			"schema": "decodex.autonomy_objective/1",
+			"record_version": 1,
+			"project_id": "decodex",
+			"id": "quality-autonomy",
+			"version": version,
+			"state": "draft",
+			"summary": "Improve Decodex autonomy quality under explicit authority.",
+			"goals": ["Reduce repeated validation and review churn."],
+			"non_goals": ["Do not bypass Decision Contract authority."],
+			"metrics": ["Validation retry count stays below objective tolerance."],
+			"allowed_surfaces": ["apps/decodex/src", "docs/spec"],
+			"allowed_signal_kinds": ["runtime_health", "review_feedback_cluster"],
+			"validation_gates": ["cargo make check-docs"],
+			"review_policy": "independent current-head review required",
+			"memory_policy": "read-only source-linked memory only",
+			"report_policy": "public-safe summaries only"
+		}))
+		.expect("objective fixture should parse")
+	}
+
+	fn accept_objective(store: &StateStore, version: u64) {
+		store
+			.upsert_autonomy_objective_draft("decodex", objective_fixture(version))
+			.expect("draft objective should store");
+		store
+			.accept_autonomy_objective_version(
+				"decodex",
+				"quality-autonomy",
+				version,
+				AutonomyObjectiveAcceptance::new(
+					"operator",
+					AutonomyObjectiveActorKind::User,
+					format!("2026-06-22T00:0{version}:00Z"),
+					"conversation",
+				)
+				.expect("acceptance should validate"),
+			)
+			.expect("objective should accept");
+	}
+
+	#[test]
+	fn autonomy_signal_fingerprint_ignores_timestamps_and_counts() {
+		let signal =
+			AutonomySignal::runtime_health(signal_input()).expect("runtime signal should validate");
+		let mut input = signal_input();
+
+		input.captured_at = String::from("2026-06-22T00:05:00Z");
+		input.created_at = String::from("2026-06-22T00:05:05Z");
+
+		input.observed_counts.insert(String::from("validation_retry_count"), 7);
+
+		let changed = AutonomySignal::runtime_health(input)
+			.expect("runtime signal with volatile fields should validate");
+
+		assert_eq!(signal.fingerprint(), changed.fingerprint());
+		assert_eq!(signal.id(), changed.id());
+	}
+
+	#[test]
+	fn autonomy_signal_review_feedback_requires_finding_routes_and_current_head_evidence() {
+		let mut input = signal_input();
+
+		input.source_type = AutonomySignalSourceType::Review;
+
+		assert!(AutonomySignal::review_feedback_cluster(input.clone()).is_err());
+
+		input.review_evidence = Some(review_evidence());
+
+		let signal = AutonomySignal::review_feedback_cluster(input)
+			.expect("review signal should require normalized route evidence");
+
+		assert_eq!(signal.review_evidence().expect("review evidence").finding_routes.len(), 1);
+		assert_eq!(signal.head_sha(), Some("3273e45234aa3346e194a7a9e48cd1c58c3e408c"));
+	}
+
+	#[test]
+	fn autonomy_signal_memory_and_report_sources_require_primary_refs_and_proposal_only() {
+		for source_type in [AutonomySignalSourceType::Memory, AutonomySignalSourceType::Report] {
+			let mut input = signal_input();
+
+			input.source_type = source_type;
+			input.source_refs = vec![String::from("memory:summary:older-context")];
+			input.primary_source_refs = Vec::new();
+			input.proposal_only = false;
+
+			assert!(AutonomySignal::docs_skill_drift(input.clone()).is_err());
+
+			input.primary_source_refs = vec![String::from("docs/spec/runtime.md")];
+			input.proposal_only = true;
+
+			AutonomySignal::docs_skill_drift(input)
+				.expect("memory/report signals with primary refs remain proposal-only");
+		}
+	}
+
+	#[test]
+	fn autonomy_signal_store_round_trips_exact_objective_version() {
+		let store = StateStore::open_in_memory().expect("store should open");
+
+		accept_objective(&store, 1);
+
+		let signal_v1 =
+			AutonomySignal::runtime_health(signal_input()).expect("runtime signal should validate");
+		let stored_v1 = store
+			.record_autonomy_signal("decodex", signal_v1.clone())
+			.expect("signal should store");
+
+		assert_eq!(stored_v1.signal().objective_version(), 1);
+		assert_eq!(stored_v1.signal().freshness(), AutonomySignalFreshness::Fresh);
+		assert_eq!(stored_v1.signal().gaps(), ["No external dashboard readback included."]);
+		assert_eq!(stored_v1.signal().privacy(), AutonomySignalPrivacy::LocalPrivate);
+
+		accept_objective(&store, 2);
+
+		let mut input_v2 = signal_input();
+
+		input_v2.objective_version = 2;
+		input_v2.source_refs = vec![String::from("status:XY-1085:runtime-health:v2")];
+
+		let signal_v2 =
+			AutonomySignal::runtime_health(input_v2).expect("runtime signal should validate");
+
+		store.record_autonomy_signal("decodex", signal_v2).expect("v2 signal should store");
+
+		let v1_signals = store
+			.list_autonomy_signals_for_objective("decodex", "quality-autonomy", 1)
+			.expect("v1 signals should list");
+		let v2_signals = store
+			.list_autonomy_signals_for_objective("decodex", "quality-autonomy", 2)
+			.expect("v2 signals should list");
+
+		assert_eq!(v1_signals.len(), 1);
+		assert_eq!(v1_signals[0].signal().id(), signal_v1.id());
+		assert_eq!(v2_signals.len(), 1);
+		assert_ne!(v1_signals[0].signal().id(), v2_signals[0].signal().id());
+	}
+
+	#[test]
+	fn autonomy_signal_persistent_store_round_trips_signal_payload() {
+		let tempdir = tempfile::tempdir().expect("tempdir should create");
+		let db_path = tempdir.path().join("runtime.sqlite3");
+		let signal = {
+			let store = StateStore::open(&db_path).expect("store should open");
+
+			accept_objective(&store, 1);
+
+			let signal = AutonomySignal::runtime_health(signal_input())
+				.expect("runtime signal should validate");
+
+			store.record_autonomy_signal("decodex", signal.clone()).expect("signal should store");
+
+			signal
+		};
+		let reopened = StateStore::open(&db_path).expect("store should reopen");
+		let stored = reopened
+			.autonomy_signal("decodex", signal.id())
+			.expect("signal read should succeed")
+			.expect("signal should exist");
+
+		assert_eq!(stored.signal(), &signal);
+		assert_eq!(stored.signal().source_refs(), ["status:XY-1085:runtime-health"]);
+		assert!(stored.signal().primary_source_refs().is_empty());
+	}
+
+	#[test]
+	fn autonomy_signal_status_readback_exposes_recent_signal_metadata() {
+		let store = StateStore::open_in_memory().expect("store should open");
+
+		accept_objective(&store, 1);
+
+		store
+			.record_autonomy_signal(
+				"decodex",
+				AutonomySignal::runtime_health(signal_input())
+					.expect("runtime signal should validate"),
+			)
+			.expect("signal should store");
+
+		let snapshot =
+			store.project_loop_evidence_snapshot("decodex").expect("loop evidence should load");
+		let recent = snapshot.recent_autonomy_signals(1);
+		let signal = recent[0].signal();
+
+		assert_eq!(signal.objective_id(), "quality-autonomy");
+		assert_eq!(signal.objective_version(), 1);
+		assert_eq!(signal.freshness(), AutonomySignalFreshness::Fresh);
+		assert_eq!(signal.confidence(), AutonomySignalConfidence::Medium);
+		assert_eq!(signal.privacy(), AutonomySignalPrivacy::LocalPrivate);
+		assert_eq!(signal.gaps(), ["No external dashboard readback included."]);
+	}
+}

--- a/apps/decodex/src/lib.rs
+++ b/apps/decodex/src/lib.rs
@@ -9,6 +9,7 @@ mod accounts;
 mod agent;
 mod archive_hygiene;
 mod autonomy_objective;
+mod autonomy_signal;
 mod cli;
 mod codex_config;
 mod commit_message;

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -8123,6 +8123,7 @@ fn operator_loop_status_for_run_with_evidence(
 		.rev()
 		.find(|event| event.event_type() == AUTHORITY_DECISION_REQUEST_EVENT_TYPE)
 		.and_then(operator_authority_decision_request_status_from_event);
+	let autonomy_signals = operator_autonomy_signal_statuses(loop_evidence);
 	let autonomy = operator_loop_autonomy(
 		boundary.as_ref(),
 		architecture_recovery.as_ref(),
@@ -8148,11 +8149,38 @@ fn operator_loop_status_for_run_with_evidence(
 		autonomy: autonomy.to_owned(),
 		summary,
 		next_action,
+		autonomy_signals,
 		review,
 		architecture_recovery,
 		boundary,
 		decision_request,
 	})
+}
+
+fn operator_autonomy_signal_statuses(
+	loop_evidence: &ProjectLoopEvidenceSnapshot,
+) -> Vec<OperatorAutonomySignalStatus> {
+	loop_evidence
+		.recent_autonomy_signals(5)
+		.into_iter()
+		.map(|record| {
+			let signal = record.signal();
+
+			OperatorAutonomySignalStatus {
+				signal_id: signal.id().to_owned(),
+				objective_id: signal.objective_id().to_owned(),
+				objective_version: signal.objective_version(),
+				kind: signal.kind().as_str().to_owned(),
+				freshness: signal.freshness().as_str().to_owned(),
+				evidence_class: signal.evidence_class().as_str().to_owned(),
+				confidence: signal.confidence().as_str().to_owned(),
+				privacy: signal.privacy().as_str().to_owned(),
+				gaps: signal.gaps().to_vec(),
+				contradictions: signal.contradictions().to_vec(),
+				updated_at: record.updated_at().to_owned(),
+			}
+		})
+		.collect()
 }
 
 fn operator_review_loop_status(
@@ -10696,9 +10724,41 @@ fn render_loop_status_summary(status: Option<&OperatorLoopStatus>) -> String {
 	let next_action = status.next_action.as_deref().unwrap_or("none");
 
 	format!(
-		"{}; review_level={}; autonomy={}; next_action={next_action}",
-		status.summary, status.review_level, status.autonomy
+		"{}; review_level={}; autonomy={}; autonomy_signals={}; next_action={next_action}",
+		status.summary,
+		status.review_level,
+		status.autonomy,
+		status.autonomy_signals.len()
 	)
+}
+
+fn render_loop_autonomy_signals_summary(status: Option<&OperatorLoopStatus>) -> String {
+	let Some(status) = status else {
+		return String::from("none");
+	};
+
+	if status.autonomy_signals.is_empty() {
+		return String::from("none");
+	}
+
+	status
+		.autonomy_signals
+		.iter()
+		.map(|signal| {
+			format!(
+				"{}:{}@v{} freshness={} confidence={} privacy={} gaps={} contradictions={}",
+				signal.kind,
+				signal.objective_id,
+				signal.objective_version,
+				signal.freshness,
+				signal.confidence,
+				signal.privacy,
+				signal.gaps.len(),
+				signal.contradictions.len()
+			)
+		})
+		.collect::<Vec<_>>()
+		.join(";")
 }
 
 fn render_loop_review_summary(status: Option<&OperatorLoopStatus>) -> String {
@@ -11149,6 +11209,7 @@ fn append_rendered_run(output: &mut String, run: &OperatorRunStatus) {
 	let accounts = render_accounts_summary(&run.accounts);
 	let private_evidence = render_private_evidence_reference(run);
 	let loop_status = render_loop_status_summary(run.loop_status.as_ref());
+	let loop_autonomy_signals = render_loop_autonomy_signals_summary(run.loop_status.as_ref());
 	let loop_review = render_loop_review_summary(run.loop_status.as_ref());
 	let loop_architecture_recovery =
 		render_loop_architecture_recovery_summary(run.loop_status.as_ref());
@@ -11159,7 +11220,7 @@ fn append_rendered_run(output: &mut String, run: &OperatorRunStatus) {
 	let phase_acceptance = render_phase_acceptance_summary(run.phase_acceptance.as_ref());
 
 	output.push_str(&format!(
-		"- run_id: {}\n  project_id: {}\n  issue_id: {}\n  issue_identifier: {}\n  title: {}\n  attempt: {}\n  status: {}\n  attempt_status: {}\n  status_projection_reason: {}\n  ownership_state: {}\n  liveness_state: {}\n  policy_state: {}\n  terminalization_state: {}\n  lane_control_next_action: {}\n  lane_control_conditions: {}\n  run_phase: {}\n  wait_reason: {}\n  current_operation: {}\n  active_goal_phase: {}\n  public_progress_phase: {}\n  run_lease: {}\n  queue_lease_state: {}\n  queue_lease: {}\n  execution_liveness: {}\n  has_fresh_execution: {}\n  counts_as_running: {}\n  needs_attention: {}\n  freshness_at: {}\n  freshness_source: {}\n  timing: run_idle={} protocol_idle={} last_progress={} protocol_event={} events={}\n  account: {}\n  accounts: {}\n  child_agent_activity: {}\n  protocol_activity: {}\n  context_pressure: {}\n  lifecycle_metrics: {}\n  lifecycle_evidence: {}\n  private_evidence: {}\n  loop_status: {}\n  loop_review: {}\n  loop_architecture_recovery: {}\n  loop_boundary: {}\n  control_capability: {}\n  thread_id: {}\n  turn_id: {}\n  thread_status: {}\n  thread_active_flags: {}\n  interactive_requested: {}\n  continuation_pending: {}\n  continuation_recovery: {}\n  phase_acceptance: {}\n  branch: {}\n  worktree_path: {}\n  updated_at: {}\n  last_run_activity_at: {}\n  last_protocol_activity_at: {}\n  last_progress_at: {}\n  idle_for_seconds: {}\n  protocol_idle_for_seconds: {}\n  suspected_stall: {}\n  progress_diagnostic: {}\n  process_id: {}\n  process_alive: {}\n  process_liveness_reason: {}\n  retry_kind: {}\n  next_retry_at: {}\n  effective_model: {}\n  effective_model_provider: {}\n  effective_cwd: {}\n  effective_approval_policy: {}\n  effective_approvals_reviewer: {}\n  effective_sandbox_mode: {}\n  protocol_event: {}\n  event_count: {}\n",
+		"- run_id: {}\n  project_id: {}\n  issue_id: {}\n  issue_identifier: {}\n  title: {}\n  attempt: {}\n  status: {}\n  attempt_status: {}\n  status_projection_reason: {}\n  ownership_state: {}\n  liveness_state: {}\n  policy_state: {}\n  terminalization_state: {}\n  lane_control_next_action: {}\n  lane_control_conditions: {}\n  run_phase: {}\n  wait_reason: {}\n  current_operation: {}\n  active_goal_phase: {}\n  public_progress_phase: {}\n  run_lease: {}\n  queue_lease_state: {}\n  queue_lease: {}\n  execution_liveness: {}\n  has_fresh_execution: {}\n  counts_as_running: {}\n  needs_attention: {}\n  freshness_at: {}\n  freshness_source: {}\n  timing: run_idle={} protocol_idle={} last_progress={} protocol_event={} events={}\n  account: {}\n  accounts: {}\n  child_agent_activity: {}\n  protocol_activity: {}\n  context_pressure: {}\n  lifecycle_metrics: {}\n  lifecycle_evidence: {}\n  private_evidence: {}\n  loop_status: {}\n  loop_autonomy_signals: {}\n  loop_review: {}\n  loop_architecture_recovery: {}\n  loop_boundary: {}\n  control_capability: {}\n  thread_id: {}\n  turn_id: {}\n  thread_status: {}\n  thread_active_flags: {}\n  interactive_requested: {}\n  continuation_pending: {}\n  continuation_recovery: {}\n  phase_acceptance: {}\n  branch: {}\n  worktree_path: {}\n  updated_at: {}\n  last_run_activity_at: {}\n  last_protocol_activity_at: {}\n  last_progress_at: {}\n  idle_for_seconds: {}\n  protocol_idle_for_seconds: {}\n  suspected_stall: {}\n  progress_diagnostic: {}\n  process_id: {}\n  process_alive: {}\n  process_liveness_reason: {}\n  retry_kind: {}\n  next_retry_at: {}\n  effective_model: {}\n  effective_model_provider: {}\n  effective_cwd: {}\n  effective_approval_policy: {}\n  effective_approvals_reviewer: {}\n  effective_sandbox_mode: {}\n  protocol_event: {}\n  event_count: {}\n",
 		run.run_id,
 		run.project_id,
 		run.issue_id,
@@ -11203,6 +11264,7 @@ fn append_rendered_run(output: &mut String, run: &OperatorRunStatus) {
 		render_lane_lifecycle_evidence(&run.lifecycle_metrics),
 		private_evidence,
 		loop_status,
+		loop_autonomy_signals,
 		loop_review,
 		loop_architecture_recovery,
 		loop_boundary,

--- a/apps/decodex/src/orchestrator/tests.rs
+++ b/apps/decodex/src/orchestrator/tests.rs
@@ -440,7 +440,7 @@ fn install_fake_post_issue_comment_gh_response(
 	TestEnvVarGuard::set("PATH", &format!("{}:{path_env}", fake_gh_dir.display()))
 }
 
-fn install_fake_admin_merge_gh_response(temp_dir: &TempDir) -> (TestEnvVarGuard, PathBuf) {
+fn install_fake_admin_merge_gh_response(temp_dir: &TempDir) -> (PathBuf, PathBuf) {
 	install_fake_admin_merge_gh_response_with_merge_exit_code(temp_dir, "deadbeef", 0)
 }
 
@@ -448,7 +448,7 @@ fn install_fake_admin_merge_gh_response_with_merge_exit_code(
 	temp_dir: &TempDir,
 	pr_head_oid: &str,
 	merge_exit_code: i32,
-) -> (TestEnvVarGuard, PathBuf) {
+) -> (PathBuf, PathBuf) {
 	let fake_gh_dir = temp_dir.path().join("fake-bin");
 	let fake_gh_path = fake_gh_dir.join("gh");
 	let invocation_log_path = temp_dir.path().join("gh-invocation.log");
@@ -487,12 +487,7 @@ exit 1\n",
 	fs::set_permissions(&fake_gh_path, permissions)
 		.expect("fake gh script should become executable");
 
-	let path_env = env::var("PATH").unwrap_or_default();
-
-	(
-		TestEnvVarGuard::set("PATH", &format!("{}:{path_env}", fake_gh_dir.display())),
-		invocation_log_path,
-	)
+	(fake_gh_path, invocation_log_path)
 }
 
 fn sample_issue(state_name: &str, labels: &[&str]) -> TrackerIssue {
@@ -1117,6 +1112,24 @@ fn sample_service_config_toml(
 	worktree_root: Option<&Path>,
 	review_level: ReviewLevel,
 ) -> String {
+	sample_service_config_toml_with_github_command_path(
+		service_id,
+		tracker_api_key_env_var,
+		github_token_env_var,
+		worktree_root,
+		review_level,
+		None,
+	)
+}
+
+fn sample_service_config_toml_with_github_command_path(
+	service_id: &str,
+	tracker_api_key_env_var: &str,
+	github_token_env_var: &str,
+	worktree_root: Option<&Path>,
+	review_level: ReviewLevel,
+	github_command_path: Option<&Path>,
+) -> String {
 	let mut toml = format!(
 		r#"service_id = "{service_id}"
 
@@ -1127,6 +1140,10 @@ api_key_env_var = "{tracker_api_key_env_var}"
 token_env_var = "{github_token_env_var}"
 "#
 	);
+
+	if let Some(github_command_path) = github_command_path {
+		toml.push_str(&format!("command_path = \"{}\"\n", github_command_path.display()));
+	}
 
 	if review_level != ReviewLevel::Strict {
 		toml.push_str("\n\n[codex]\n");
@@ -1153,16 +1170,31 @@ fn service_config_toml_for_config(
 	github_token_env_var: &str,
 	review_level: ReviewLevel,
 ) -> String {
+	service_config_toml_for_config_with_github_command_path(
+		config,
+		github_token_env_var,
+		review_level,
+		config.github().command_path(),
+	)
+}
+
+fn service_config_toml_for_config_with_github_command_path(
+	config: &ServiceConfig,
+	github_token_env_var: &str,
+	review_level: ReviewLevel,
+	github_command_path: Option<&Path>,
+) -> String {
 	let default_worktree_root = config.repo_root().join(".worktrees");
 	let worktree_root =
 		(config.worktree_root() != default_worktree_root).then_some(config.worktree_root());
 
-	sample_service_config_toml(
+	sample_service_config_toml_with_github_command_path(
 		config.service_id(),
 		config.tracker().api_key_env_var(),
 		github_token_env_var,
 		worktree_root,
 		review_level,
+		github_command_path,
 	)
 }
 
@@ -1178,13 +1210,36 @@ fn service_config_with_github_token_env_var(
 	load_service_config(config.repo_root())
 }
 
+fn service_config_with_github_token_env_var_and_command_path(
+	config: &ServiceConfig,
+	token_env_var: &str,
+	github_command_path: &Path,
+) -> ServiceConfig {
+	write_service_config(
+		config.repo_root(),
+		&service_config_toml_for_config_with_github_command_path(
+			config,
+			token_env_var,
+			config.codex().review_level(),
+			Some(github_command_path),
+		),
+	);
+
+	load_service_config(config.repo_root())
+}
+
 fn service_config_with_review_level(
 	config: &ServiceConfig,
 	review_level: ReviewLevel,
 ) -> ServiceConfig {
 	write_service_config(
 		config.repo_root(),
-		&service_config_toml_for_config(config, config.github().token_env_var(), review_level),
+		&service_config_toml_for_config_with_github_command_path(
+			config,
+			config.github().token_env_var(),
+			review_level,
+			config.github().command_path(),
+		),
 	);
 
 	load_service_config(config.repo_root())

--- a/apps/decodex/src/orchestrator/tests/intake/candidate_selection.rs
+++ b/apps/decodex/src/orchestrator/tests/intake/candidate_selection.rs
@@ -901,8 +901,21 @@ fn retained_closeout_identity_reuse_respects_attempt_history() {
 fn non_github_review_retained_drain_handles_same_issue_closeout_after_merge_visibility() {
 	for closeout_available in [true, false] {
 		let (temp_dir, config, workflow) = temp_project_layout();
+		let repo_root = config.repo_root().to_path_buf();
+		let pr_url = "https://github.com/hack-ink/decodex/pull/176";
+		let merge_subject =
+			r#"{"schema":"decodex/commit/1","summary":"current retained handoff","authority":"PUB-101"}"#;
+		let landed_merge_subject =
+			r#"{"schema":"decodex/commit/1","summary":"Land current retained handoff","authority":"PUB-101"}"#;
+		let head_oid = commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
+		let (gh_command_path, invocation_log_path) =
+			install_fake_admin_merge_gh_response_with_merge_exit_code(&temp_dir, &head_oid, 0);
 		let config = service_config_with_review_level(
-			&service_config_with_github_token_env_var(&config, "PATH"),
+			&service_config_with_github_token_env_var_and_command_path(
+				&config,
+				"PATH",
+				&gh_command_path,
+			),
 			ReviewLevel::Standard,
 		);
 		let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -916,13 +929,6 @@ fn non_github_review_retained_drain_handles_same_issue_closeout_after_merge_visi
 				vec![issue.clone()],
 			],
 		);
-		let repo_root = config.repo_root().to_path_buf();
-		let pr_url = "https://github.com/hack-ink/decodex/pull/176";
-		let merge_subject = r#"{"schema":"decodex/commit/1","summary":"current retained handoff","authority":"PUB-101"}"#;
-		let landed_merge_subject = r#"{"schema":"decodex/commit/1","summary":"Land current retained handoff","authority":"PUB-101"}"#;
-		let head_oid = commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
-		let (_path_guard, invocation_log_path) =
-			install_fake_admin_merge_gh_response_with_merge_exit_code(&temp_dir, &head_oid, 0);
 
 		state_store
 			.upsert_worktree(
@@ -985,18 +991,7 @@ fn non_github_review_retained_drain_handles_same_issue_closeout_after_merge_visi
 		)
 		.expect("non-GitHub-review retained drain should succeed");
 
-		if closeout_available {
-			assert_eq!(
-				drained.expect("merged same-issue closeout should dispatch"),
-				closeout_summary
-			);
-		} else {
-			assert!(
-				drained.is_none(),
-				"retained drain should stop cleanly when closeout is unavailable"
-			);
-		}
-
+		assert_eq!(drained, closeout_available.then_some(closeout_summary.clone()));
 		assert_eq!(*closeout_dispatches.borrow(), vec![issue.id.clone()]);
 
 		let marker = persisted_review_orchestration_marker_for_path(

--- a/apps/decodex/src/orchestrator/tests/retry/scheduling.rs
+++ b/apps/decodex/src/orchestrator/tests/retry/scheduling.rs
@@ -1480,11 +1480,15 @@ fn spawn_sleeping_daemon_child(
 #[test]
 fn daemon_tick_reconciles_ready_retained_review_lane_before_dry_run_planning() {
 	let (temp_dir, base_config, workflow) = temp_project_layout();
+	let (gh_command_path, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
 	let config = service_config_with_review_level(
-		&service_config_with_github_token_env_var(&base_config, "PATH"),
+		&service_config_with_github_token_env_var_and_command_path(
+			&base_config,
+			"PATH",
+			&gh_command_path,
+		),
 		ReviewLevel::Standard,
 	);
-	let (_path_guard, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
 		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
@@ -1590,11 +1594,15 @@ fn daemon_tick_reconciles_ready_retained_review_lane_before_dry_run_planning() {
 #[test]
 fn daemon_tick_clears_terminal_mapping_without_worktree_before_retained_land() {
 	let (temp_dir, base_config, workflow) = temp_project_layout();
+	let (gh_command_path, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
 	let config = service_config_with_review_level(
-		&service_config_with_github_token_env_var(&base_config, "PATH"),
+		&service_config_with_github_token_env_var_and_command_path(
+			&base_config,
+			"PATH",
+			&gh_command_path,
+		),
 		ReviewLevel::Standard,
 	);
-	let (_path_guard, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
 		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());

--- a/apps/decodex/src/orchestrator/tests/review_landing/orchestration.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing/orchestration.rs
@@ -399,8 +399,9 @@ fn reconcile_post_review_orchestration_skips_merged_landed_lineage_without_manua
 #[test]
 fn reconcile_post_review_orchestration_runs_admin_merge_after_external_pass() {
 	let (temp_dir, config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(&config, "PATH");
-	let (_path_guard, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
+	let (gh_command_path, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
+	let config =
+		service_config_with_github_token_env_var_and_command_path(&config, "PATH", &gh_command_path);
 	let repo_root = config.repo_root().to_path_buf();
 	let issue = post_review_sample_service_owned_issue("In Review");
 	let tracker =
@@ -485,8 +486,9 @@ fn reconcile_post_review_orchestration_runs_admin_merge_after_external_pass() {
 #[test]
 fn reconcile_post_review_orchestration_routes_non_clean_landing_to_agent_fallback() {
 	let (temp_dir, config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(&config, "PATH");
-	let (_path_guard, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
+	let (gh_command_path, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
+	let config =
+		service_config_with_github_token_env_var_and_command_path(&config, "PATH", &gh_command_path);
 	let repo_root = config.repo_root().to_path_buf();
 	let issue = post_review_sample_service_owned_issue("In Review");
 	let tracker =
@@ -569,11 +571,15 @@ fn assert_reconcile_post_review_orchestration_runs_admin_merge_without_external_
 	review_level: ReviewLevel,
 ) {
 	let (temp_dir, config, workflow) = temp_project_layout();
+	let (gh_command_path, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
 	let config = service_config_with_review_level(
-		&service_config_with_github_token_env_var(&config, "PATH"),
+		&service_config_with_github_token_env_var_and_command_path(
+			&config,
+			"PATH",
+			&gh_command_path,
+		),
 		review_level,
 	);
-	let (_path_guard, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
 	let repo_root = config.repo_root().to_path_buf();
 	let issue = post_review_sample_service_owned_issue("In Review");
 	let tracker =
@@ -654,11 +660,15 @@ fn assert_reconcile_post_review_orchestration_runs_admin_merge_without_external_
 fn reconcile_post_review_orchestration_routes_non_github_review_non_clean_landing_to_agent_fallback(
 ) {
 	let (temp_dir, config, workflow) = temp_project_layout();
+	let (gh_command_path, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
 	let config = service_config_with_review_level(
-		&service_config_with_github_token_env_var(&config, "PATH"),
+		&service_config_with_github_token_env_var_and_command_path(
+			&config,
+			"PATH",
+			&gh_command_path,
+		),
 		ReviewLevel::Standard,
 	);
-	let (_path_guard, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
 	let repo_root = config.repo_root().to_path_buf();
 	let issue = post_review_sample_service_owned_issue("In Review");
 	let tracker =
@@ -717,7 +727,6 @@ fn reconcile_post_review_orchestration_routes_non_github_review_non_clean_landin
 #[test]
 fn reconcile_post_review_orchestration_tolerates_already_merged_merge_race() {
 	let (temp_dir, config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(&config, "PATH");
 	let repo_root = config.repo_root().to_path_buf();
 	let issue = post_review_sample_service_owned_issue("In Review");
 	let tracker =
@@ -727,8 +736,10 @@ fn reconcile_post_review_orchestration_tolerates_already_merged_merge_race() {
 	let merge_subject = r#"{"schema":"decodex/commit/1","summary":"current retained handoff","authority":"PUB-101"}"#;
 	let landed_merge_subject = r#"{"schema":"decodex/commit/1","summary":"Land current retained handoff","authority":"PUB-101"}"#;
 	let head_oid = commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
-	let (_path_guard, invocation_log_path) =
+	let (gh_command_path, invocation_log_path) =
 		install_fake_admin_merge_gh_response_with_merge_exit_code(&temp_dir, &head_oid, 1);
+	let config =
+		service_config_with_github_token_env_var_and_command_path(&config, "PATH", &gh_command_path);
 
 	state_store
 		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())

--- a/apps/decodex/src/orchestrator/types.rs
+++ b/apps/decodex/src/orchestrator/types.rs
@@ -1881,10 +1881,27 @@ struct OperatorLoopStatus {
 	autonomy: String,
 	summary: String,
 	next_action: Option<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	autonomy_signals: Vec<OperatorAutonomySignalStatus>,
 	review: Option<OperatorReviewLoopStatus>,
 	architecture_recovery: Option<OperatorArchitectureRecoveryStatus>,
 	boundary: Option<OperatorBoundaryStatus>,
 	decision_request: Option<OperatorAuthorityDecisionRequestStatus>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct OperatorAutonomySignalStatus {
+	signal_id: String,
+	objective_id: String,
+	objective_version: u64,
+	kind: String,
+	freshness: String,
+	evidence_class: String,
+	confidence: String,
+	privacy: String,
+	gaps: Vec<String>,
+	contradictions: Vec<String>,
+	updated_at: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/apps/decodex/src/state.rs
+++ b/apps/decodex/src/state.rs
@@ -26,6 +26,10 @@ use crate::{
 		AutonomyObjectiveAcceptance, AutonomyObjectiveContract, AutonomyObjectiveRejection,
 		AutonomyObjectiveState, AutonomyObjectiveSupersession,
 	},
+	autonomy_signal::{
+		AutonomySignal, AutonomySignalConfidence, AutonomySignalEvidenceClass,
+		AutonomySignalFreshness, AutonomySignalKind, AutonomySignalPrivacy,
+	},
 	config::ServiceConfig,
 	execution_program::ExecutionProgram,
 	loop_contract::{DecisionContract, DecisionContractStatus, DecisionPromotion},

--- a/apps/decodex/src/state/internal.rs
+++ b/apps/decodex/src/state/internal.rs
@@ -199,6 +199,7 @@ struct StateData {
 	private_execution_events: Vec<PrivateExecutionEventRuntimeRecord>,
 	decision_contracts: HashMap<DecisionContractKey, DecisionContractRuntimeRecord>,
 	autonomy_objectives: HashMap<AutonomyObjectiveKey, AutonomyObjectiveRuntimeRecord>,
+	autonomy_signals: HashMap<AutonomySignalKey, AutonomySignalRuntimeRecord>,
 	execution_programs: HashMap<ExecutionProgramKey, ExecutionProgramRuntimeRecord>,
 	program_intake_plans: HashMap<ProgramIntakePlanKey, ProgramIntakePlanRecord>,
 	program_issue_mappings: HashMap<ProgramIssueMappingKey, ProgramIssueMappingRecord>,
@@ -225,6 +226,7 @@ impl StateData {
 		self.private_execution_events = loaded.private_execution_events;
 		self.decision_contracts = loaded.decision_contracts;
 		self.autonomy_objectives = loaded.autonomy_objectives;
+		self.autonomy_signals = loaded.autonomy_signals;
 		self.execution_programs = loaded.execution_programs;
 		self.program_intake_plans = loaded.program_intake_plans;
 		self.program_issue_mappings = loaded.program_issue_mappings;
@@ -252,6 +254,8 @@ impl StateData {
 		self.review_policy_checkpoints.extend(loaded.review_policy_checkpoints);
 		self.evidence_artifacts.retain(|key, _record| key.project_id != project_id);
 		self.evidence_artifacts.extend(loaded.evidence_artifacts);
+		self.autonomy_signals.retain(|key, _record| key.project_id != project_id);
+		self.autonomy_signals.extend(loaded.autonomy_signals);
 	}
 
 	fn replace_project_registry_state(&mut self, loaded: Self) {
@@ -496,6 +500,7 @@ ON linear_execution_events (service_id, issue_id, event_unix, recorded_at_unix);
 		self.bootstrap_private_execution_events_schema()?;
 		self.bootstrap_decision_contracts_schema()?;
 		self.bootstrap_autonomy_objectives_schema()?;
+		self.bootstrap_autonomy_signals_schema()?;
 		self.bootstrap_execution_programs_schema()?;
 		self.bootstrap_program_intake_state_schema()?;
 		self.bootstrap_loop_guardrail_schema()?;
@@ -693,6 +698,37 @@ CREATE INDEX IF NOT EXISTS autonomy_objectives_project_state_idx
 ON autonomy_objectives (project_id, state, updated_at_unix);
 CREATE INDEX IF NOT EXISTS autonomy_objectives_history_idx
 ON autonomy_objectives (project_id, objective_id, version);
+"#,
+		)?;
+
+		Ok(())
+	}
+
+	fn bootstrap_autonomy_signals_schema(&self) -> Result<()> {
+		self.connection.execute_batch(
+			r#"
+CREATE TABLE IF NOT EXISTS autonomy_signals (
+	project_id TEXT NOT NULL,
+	signal_id TEXT NOT NULL,
+	objective_id TEXT NOT NULL,
+	objective_version INTEGER NOT NULL,
+	kind TEXT NOT NULL,
+	fingerprint TEXT NOT NULL,
+	freshness TEXT NOT NULL,
+	evidence_class TEXT NOT NULL,
+	confidence TEXT NOT NULL,
+	privacy TEXT NOT NULL,
+	payload_json TEXT NOT NULL,
+	created_at TEXT NOT NULL,
+	created_at_unix INTEGER NOT NULL,
+	updated_at TEXT NOT NULL,
+	updated_at_unix INTEGER NOT NULL,
+	PRIMARY KEY (project_id, signal_id)
+);
+CREATE INDEX IF NOT EXISTS autonomy_signals_objective_idx
+ON autonomy_signals (project_id, objective_id, objective_version, updated_at_unix);
+CREATE INDEX IF NOT EXISTS autonomy_signals_recent_idx
+ON autonomy_signals (project_id, updated_at_unix);
 "#,
 		)?;
 
@@ -910,6 +946,7 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 		self.load_private_execution_events(&mut state)?;
 		self.load_decision_contracts(&mut state)?;
 		self.load_autonomy_objectives(&mut state)?;
+		self.load_autonomy_signals(&mut state)?;
 		self.load_execution_programs(&mut state)?;
 		self.load_program_intake_state(&mut state)?;
 		self.load_review_lifecycle_records(&mut state)?;
@@ -940,6 +977,7 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 		self.load_review_lifecycle_records_for_project(&mut state, project_id)?;
 		self.load_review_policy_checkpoints_for_project(&mut state, project_id)?;
 		self.load_evidence_artifacts_for_project(&mut state, project_id)?;
+		self.load_autonomy_signals_for_project(&mut state, project_id)?;
 
 		Ok(state)
 	}
@@ -966,6 +1004,7 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 		persist_private_execution_events(&transaction, state)?;
 		persist_decision_contracts(&transaction, state)?;
 		persist_autonomy_objectives(&transaction, state)?;
+		persist_autonomy_signals(&transaction, state)?;
 		persist_execution_programs(&transaction, state)?;
 		persist_program_intake_state(&transaction, state)?;
 		persist_review_lifecycle_records(&transaction, state)?;
@@ -997,6 +1036,10 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 		)?;
 		transaction.execute(
 			"DELETE FROM autonomy_objectives WHERE project_id = ?1",
+			params![service_id],
+		)?;
+		transaction.execute(
+			"DELETE FROM autonomy_signals WHERE project_id = ?1",
 			params![service_id],
 		)?;
 		transaction.execute(
@@ -1346,6 +1389,51 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 				record.objective.id(),
 				version,
 				record.state.as_str(),
+				payload_json,
+				&record.created_at,
+				record.created_at_unix,
+				&record.updated_at,
+				record.updated_at_unix,
+			],
+		)?;
+
+		Ok(())
+	}
+
+	fn upsert_autonomy_signal(&self, record: &AutonomySignalRuntimeRecord) -> Result<()> {
+		let payload_json = serde_json::to_string(&record.signal)?;
+		let version = i64::try_from(record.signal.objective_version())
+			.map_err(|_| eyre::eyre!("Autonomy signal objective_version exceeds SQLite integer range."))?;
+
+		self.connection.execute(
+			"INSERT INTO autonomy_signals (
+					project_id, signal_id, objective_id, objective_version, kind, fingerprint,
+					freshness, evidence_class, confidence, privacy, payload_json, created_at,
+					created_at_unix, updated_at, updated_at_unix
+				) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+			 ON CONFLICT(project_id, signal_id) DO UPDATE SET
+				 objective_id = excluded.objective_id,
+				 objective_version = excluded.objective_version,
+				 kind = excluded.kind,
+				 fingerprint = excluded.fingerprint,
+				 freshness = excluded.freshness,
+				 evidence_class = excluded.evidence_class,
+				 confidence = excluded.confidence,
+				 privacy = excluded.privacy,
+				 payload_json = excluded.payload_json,
+				 updated_at = excluded.updated_at,
+				 updated_at_unix = excluded.updated_at_unix",
+			params![
+				&record.project_id,
+				record.signal.id(),
+				record.signal.objective_id(),
+				version,
+				record.signal.kind().as_str(),
+				record.signal.fingerprint(),
+				record.signal.freshness().as_str(),
+				record.signal.evidence_class().as_str(),
+				record.signal.confidence().as_str(),
+				record.signal.privacy().as_str(),
 				payload_json,
 				&record.created_at,
 				record.created_at_unix,
@@ -2505,6 +2593,130 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 		Ok(records)
 	}
 
+	fn load_autonomy_signals(&self, state: &mut StateData) -> Result<()> {
+		let mut statement = self.connection.prepare(
+			"SELECT project_id, signal_id, objective_id, objective_version, kind, fingerprint, \
+			 freshness, evidence_class, confidence, privacy, payload_json, created_at, \
+			 created_at_unix, updated_at, updated_at_unix \
+			 FROM autonomy_signals \
+			 ORDER BY project_id ASC, objective_id ASC, objective_version ASC, updated_at_unix ASC",
+		)?;
+		let rows = statement.query_map([], autonomy_signal_runtime_row_parts)?;
+
+		for row in rows {
+			let record = autonomy_signal_record_from_row_parts(row?)?;
+
+			state.autonomy_signals.insert(record.key(), record);
+		}
+
+		Ok(())
+	}
+
+	fn load_autonomy_signals_for_project(
+		&self,
+		state: &mut StateData,
+		project_id: &str,
+	) -> Result<()> {
+		let mut statement = self.connection.prepare(
+			"SELECT project_id, signal_id, objective_id, objective_version, kind, fingerprint, \
+			 freshness, evidence_class, confidence, privacy, payload_json, created_at, \
+			 created_at_unix, updated_at, updated_at_unix \
+			 FROM autonomy_signals \
+			 WHERE project_id = ?1 \
+			 ORDER BY updated_at_unix DESC, signal_id ASC",
+		)?;
+		let rows = statement.query_map(params![project_id], autonomy_signal_runtime_row_parts)?;
+
+		for row in rows {
+			let record = autonomy_signal_record_from_row_parts(row?)?;
+
+			state.autonomy_signals.insert(record.key(), record);
+		}
+
+		Ok(())
+	}
+
+	fn autonomy_signal(
+		&self,
+		project_id: &str,
+		signal_id: &str,
+	) -> Result<Option<AutonomySignalRuntimeRecord>> {
+		let mut statement = self.connection.prepare(
+			"SELECT project_id, signal_id, objective_id, objective_version, kind, fingerprint, \
+			 freshness, evidence_class, confidence, privacy, payload_json, created_at, \
+			 created_at_unix, updated_at, updated_at_unix \
+			 FROM autonomy_signals \
+			 WHERE project_id = ?1 AND signal_id = ?2 \
+			 LIMIT 1",
+		)?;
+		let mut rows = statement.query(params![project_id, signal_id])?;
+
+		rows
+			.next()?
+			.map(autonomy_signal_runtime_row_parts)
+			.transpose()?
+			.map(autonomy_signal_record_from_row_parts)
+			.transpose()
+	}
+
+	fn list_autonomy_signals_for_objective(
+		&self,
+		project_id: &str,
+		objective_id: &str,
+		objective_version: u64,
+	) -> Result<Vec<AutonomySignalRuntimeRecord>> {
+		let version = i64::try_from(objective_version)
+			.map_err(|_| eyre::eyre!("Autonomy signal objective_version exceeds SQLite integer range."))?;
+		let mut statement = self.connection.prepare(
+			"SELECT project_id, signal_id, objective_id, objective_version, kind, fingerprint, \
+			 freshness, evidence_class, confidence, privacy, payload_json, created_at, \
+			 created_at_unix, updated_at, updated_at_unix \
+			 FROM autonomy_signals \
+			 WHERE project_id = ?1 AND objective_id = ?2 AND objective_version = ?3 \
+			 ORDER BY updated_at_unix ASC, signal_id ASC",
+		)?;
+		let rows = statement.query_map(
+			params![project_id, objective_id, version],
+			autonomy_signal_runtime_row_parts,
+		)?;
+		let mut records = Vec::new();
+
+		for row in rows {
+			records.push(autonomy_signal_record_from_row_parts(row?)?);
+		}
+
+		Ok(records)
+	}
+
+	fn recent_autonomy_signals_for_project(
+		&self,
+		project_id: &str,
+		limit: usize,
+	) -> Result<Vec<AutonomySignalRuntimeRecord>> {
+		let limit = i64::try_from(limit)
+			.map_err(|_| eyre::eyre!("Autonomy signal readback limit exceeds SQLite integer range."))?;
+		let mut statement = self.connection.prepare(
+			"SELECT project_id, signal_id, objective_id, objective_version, kind, fingerprint, \
+			 freshness, evidence_class, confidence, privacy, payload_json, created_at, \
+			 created_at_unix, updated_at, updated_at_unix \
+			 FROM autonomy_signals \
+			 WHERE project_id = ?1 \
+			 ORDER BY updated_at_unix DESC, signal_id ASC \
+			 LIMIT ?2",
+		)?;
+		let rows = statement.query_map(
+			params![project_id, limit],
+			autonomy_signal_runtime_row_parts,
+		)?;
+		let mut records = Vec::new();
+
+		for row in rows {
+			records.push(autonomy_signal_record_from_row_parts(row?)?);
+		}
+
+		Ok(records)
+	}
+
 	fn load_execution_programs(&self, state: &mut StateData) -> Result<()> {
 		let mut statement = self.connection.prepare(
 			"SELECT project_id, program_id, source_contract_id, payload_json, created_at, \
@@ -3281,6 +3493,43 @@ impl AutonomyObjectiveRuntimeRecord {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct AutonomySignalKey {
+	project_id: String,
+	signal_id: String,
+}
+impl AutonomySignalKey {
+	fn new(project_id: &str, signal_id: &str) -> Self {
+		Self { project_id: project_id.to_owned(), signal_id: signal_id.to_owned() }
+	}
+}
+
+#[derive(Clone, Debug)]
+struct AutonomySignalRuntimeRecord {
+	project_id: String,
+	signal: AutonomySignal,
+	created_at: String,
+	created_at_unix: i64,
+	updated_at: String,
+	updated_at_unix: i64,
+}
+impl AutonomySignalRuntimeRecord {
+	fn key(&self) -> AutonomySignalKey {
+		AutonomySignalKey::new(&self.project_id, self.signal.id())
+	}
+
+	fn as_public(&self) -> AutonomySignalRecord {
+		AutonomySignalRecord {
+			project_id: self.project_id.clone(),
+			signal: self.signal.clone(),
+			created_at: self.created_at.clone(),
+			created_at_unix: self.created_at_unix,
+			updated_at: self.updated_at.clone(),
+			updated_at_unix: self.updated_at_unix,
+		}
+	}
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct ExecutionProgramKey {
 	project_id: String,
 	program_id: String,
@@ -3683,6 +3932,24 @@ struct AutonomyObjectiveRuntimeRowParts {
 	objective_id: String,
 	version: i64,
 	state: String,
+	payload_json: String,
+	created_at: String,
+	created_at_unix: i64,
+	updated_at: String,
+	updated_at_unix: i64,
+}
+
+struct AutonomySignalRuntimeRowParts {
+	project_id: String,
+	signal_id: String,
+	objective_id: String,
+	objective_version: i64,
+	kind: String,
+	fingerprint: String,
+	freshness: String,
+	evidence_class: String,
+	confidence: String,
+	privacy: String,
 	payload_json: String,
 	created_at: String,
 	created_at_unix: i64,
@@ -4622,6 +4889,44 @@ fn persist_autonomy_objectives(
 				record.objective.id(),
 				version,
 				record.state.as_str(),
+				payload_json,
+				&record.created_at,
+				record.created_at_unix,
+				&record.updated_at,
+				record.updated_at_unix,
+			],
+		)?;
+	}
+
+	Ok(())
+}
+
+fn persist_autonomy_signals(
+	transaction: &Transaction<'_>,
+	state: &StateData,
+) -> Result<()> {
+	for record in state.autonomy_signals.values() {
+		let payload_json = serde_json::to_string(&record.signal)?;
+		let version = i64::try_from(record.signal.objective_version())
+			.map_err(|_| eyre::eyre!("Autonomy signal objective_version exceeds SQLite integer range."))?;
+
+		transaction.execute(
+			"INSERT OR REPLACE INTO autonomy_signals (
+					project_id, signal_id, objective_id, objective_version, kind, fingerprint,
+					freshness, evidence_class, confidence, privacy, payload_json, created_at,
+					created_at_unix, updated_at, updated_at_unix
+				) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+			params![
+				&record.project_id,
+				record.signal.id(),
+				record.signal.objective_id(),
+				version,
+				record.signal.kind().as_str(),
+				record.signal.fingerprint(),
+				record.signal.freshness().as_str(),
+				record.signal.evidence_class().as_str(),
+				record.signal.confidence().as_str(),
+				record.signal.privacy().as_str(),
 				payload_json,
 				&record.created_at,
 				record.created_at_unix,
@@ -5774,6 +6079,89 @@ fn autonomy_objective_record_from_row_parts(
 	})
 }
 
+fn autonomy_signal_runtime_row_parts(
+	row: &Row<'_>,
+) -> std::result::Result<AutonomySignalRuntimeRowParts, rusqlite::Error> {
+	Ok(AutonomySignalRuntimeRowParts {
+		project_id: row.get(0)?,
+		signal_id: row.get(1)?,
+		objective_id: row.get(2)?,
+		objective_version: row.get(3)?,
+		kind: row.get(4)?,
+		fingerprint: row.get(5)?,
+		freshness: row.get(6)?,
+		evidence_class: row.get(7)?,
+		confidence: row.get(8)?,
+		privacy: row.get(9)?,
+		payload_json: row.get(10)?,
+		created_at: row.get(11)?,
+		created_at_unix: row.get(12)?,
+		updated_at: row.get(13)?,
+		updated_at_unix: row.get(14)?,
+	})
+}
+
+fn autonomy_signal_record_from_row_parts(
+	parts: AutonomySignalRuntimeRowParts,
+) -> Result<AutonomySignalRuntimeRecord> {
+	let signal = serde_json::from_str::<AutonomySignal>(&parts.payload_json)?;
+	let version = u64::try_from(parts.objective_version)
+		.map_err(|_| eyre::eyre!("Autonomy signal row objective_version must be greater than zero."))?;
+
+	signal.validate()?;
+
+	if parts.project_id != signal.project_id() {
+		eyre::bail!(
+			"Autonomy signal row project `{}` contained payload project `{}`.",
+			parts.project_id,
+			signal.project_id()
+		);
+	}
+	if parts.signal_id != signal.id() {
+		eyre::bail!(
+			"Autonomy signal row `{}` contained payload `{}`.",
+			parts.signal_id,
+			signal.id()
+		);
+	}
+	if parts.objective_id != signal.objective_id() {
+		eyre::bail!(
+			"Autonomy signal row objective `{}` contained payload `{}`.",
+			parts.objective_id,
+			signal.objective_id()
+		);
+	}
+	if version != signal.objective_version() {
+		eyre::bail!(
+			"Autonomy signal row `{}` objective version {} contained payload version {}.",
+			parts.signal_id,
+			version,
+			signal.objective_version()
+		);
+	}
+	if parts.kind != signal.kind().as_str()
+		|| parts.fingerprint != signal.fingerprint()
+		|| parts.freshness != signal.freshness().as_str()
+		|| parts.evidence_class != signal.evidence_class().as_str()
+		|| parts.confidence != signal.confidence().as_str()
+		|| parts.privacy != signal.privacy().as_str()
+	{
+		eyre::bail!(
+			"Autonomy signal row `{}` readback columns differed from payload.",
+			parts.signal_id
+		);
+	}
+
+	Ok(AutonomySignalRuntimeRecord {
+		project_id: parts.project_id,
+		signal,
+		created_at: parts.created_at,
+		created_at_unix: parts.created_at_unix,
+		updated_at: parts.updated_at,
+		updated_at_unix: parts.updated_at_unix,
+	})
+}
+
 fn decision_contract_payload_has_removed_flat_issue_summaries(payload_json: &str) -> bool {
 	serde_json::from_str::<Value>(payload_json)
 		.ok()
@@ -5922,6 +6310,27 @@ fn compare_decision_contract_runtime_records(
 	left.updated_at_unix
 		.cmp(&right.updated_at_unix)
 		.then_with(|| left.contract.contract_id().cmp(right.contract.contract_id()))
+}
+
+#[allow(dead_code)]
+fn compare_autonomy_signal_runtime_records(
+	left: &AutonomySignalRuntimeRecord,
+	right: &AutonomySignalRuntimeRecord,
+) -> cmp::Ordering {
+	left.updated_at_unix
+		.cmp(&right.updated_at_unix)
+		.then_with(|| left.signal.id().cmp(right.signal.id()))
+}
+
+#[allow(dead_code)]
+fn compare_recent_autonomy_signal_runtime_records(
+	left: &AutonomySignalRuntimeRecord,
+	right: &AutonomySignalRuntimeRecord,
+) -> cmp::Ordering {
+	right
+		.updated_at_unix
+		.cmp(&left.updated_at_unix)
+		.then_with(|| left.signal.id().cmp(right.signal.id()))
 }
 
 #[allow(dead_code)]

--- a/apps/decodex/src/state/models.rs
+++ b/apps/decodex/src/state/models.rs
@@ -665,6 +665,75 @@ impl AutonomyObjectiveRecord {
 	}
 }
 
+/// SQLite-backed autonomy signal evidence retained by the local runtime.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct AutonomySignalRecord {
+	project_id: String,
+	signal: AutonomySignal,
+	created_at: String,
+	created_at_unix: i64,
+	updated_at: String,
+	updated_at_unix: i64,
+}
+#[allow(dead_code)]
+impl AutonomySignalRecord {
+	pub(crate) fn project_id(&self) -> &str {
+		&self.project_id
+	}
+
+	pub(crate) fn signal(&self) -> &AutonomySignal {
+		&self.signal
+	}
+
+	pub(crate) fn signal_id(&self) -> &str {
+		self.signal.id()
+	}
+
+	pub(crate) fn objective_id(&self) -> &str {
+		self.signal.objective_id()
+	}
+
+	pub(crate) fn objective_version(&self) -> u64 {
+		self.signal.objective_version()
+	}
+
+	pub(crate) fn kind(&self) -> AutonomySignalKind {
+		self.signal.kind()
+	}
+
+	pub(crate) fn freshness(&self) -> AutonomySignalFreshness {
+		self.signal.freshness()
+	}
+
+	pub(crate) fn evidence_class(&self) -> AutonomySignalEvidenceClass {
+		self.signal.evidence_class()
+	}
+
+	pub(crate) fn confidence(&self) -> AutonomySignalConfidence {
+		self.signal.confidence()
+	}
+
+	pub(crate) fn privacy(&self) -> AutonomySignalPrivacy {
+		self.signal.privacy()
+	}
+
+	pub(crate) fn created_at(&self) -> &str {
+		&self.created_at
+	}
+
+	pub(crate) fn created_at_unix(&self) -> i64 {
+		self.created_at_unix
+	}
+
+	pub(crate) fn updated_at(&self) -> &str {
+		&self.updated_at
+	}
+
+	pub(crate) fn updated_at_unix(&self) -> i64 {
+		self.updated_at_unix
+	}
+}
+
 /// SQLite-backed internal Execution Program retained by the local runtime.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ExecutionProgramRecord {

--- a/apps/decodex/src/state/store.rs
+++ b/apps/decodex/src/state/store.rs
@@ -48,6 +48,7 @@ pub(crate) struct ProjectLoopEvidenceSnapshot {
 	private_events: HashMap<(String, String, i64), Vec<PrivateExecutionEvent>>,
 	review_lifecycle_records: HashMap<(String, String), ReviewLifecycleRecord>,
 	review_checkpoints: HashMap<(String, String, i64, String), ReviewPolicyCheckpoint>,
+	autonomy_signals: Vec<AutonomySignalRecord>,
 }
 impl ProjectLoopEvidenceSnapshot {
 	fn insert_private_event(&mut self, event: PrivateExecutionEvent) {
@@ -80,6 +81,10 @@ impl ProjectLoopEvidenceSnapshot {
 		);
 	}
 
+	fn insert_autonomy_signal(&mut self, signal: AutonomySignalRecord) {
+		self.autonomy_signals.push(signal);
+	}
+
 	fn sort_private_events(&mut self) {
 		for events in self.private_events.values_mut() {
 			events.sort_by(|left, right| {
@@ -88,6 +93,15 @@ impl ProjectLoopEvidenceSnapshot {
 					.then_with(|| left.record_id().cmp(&right.record_id()))
 			});
 		}
+	}
+
+	fn sort_autonomy_signals(&mut self) {
+		self.autonomy_signals.sort_by(|left, right| {
+			right
+				.updated_at_unix()
+				.cmp(&left.updated_at_unix())
+				.then_with(|| left.signal_id().cmp(right.signal_id()))
+		});
 	}
 
 	pub(crate) fn private_events(
@@ -141,6 +155,10 @@ impl ProjectLoopEvidenceSnapshot {
 			attempt_number,
 			phase.to_owned(),
 		))
+	}
+
+	pub(crate) fn recent_autonomy_signals(&self, limit: usize) -> Vec<&AutonomySignalRecord> {
+		self.autonomy_signals.iter().take(limit).collect()
 	}
 }
 
@@ -2153,8 +2171,16 @@ impl StateStore {
 		{
 			snapshot.insert_review_checkpoint(record.as_public());
 		}
+		for record in state
+			.autonomy_signals
+			.values()
+			.filter(|record| record.project_id == project_id)
+		{
+			snapshot.insert_autonomy_signal(record.as_public());
+		}
 
 		snapshot.sort_private_events();
+		snapshot.sort_autonomy_signals();
 
 		Ok(snapshot)
 	}
@@ -2530,6 +2556,170 @@ impl StateStore {
 			.collect::<Vec<_>>();
 
 		records.sort_by_key(|record| record.objective.version());
+
+		Ok(records.into_iter().map(|record| record.as_public()).collect())
+	}
+
+	/// Persist one read-only autonomy signal against the currently accepted objective version.
+	#[allow(dead_code)]
+	pub(crate) fn record_autonomy_signal(
+		&self,
+		project_id: &str,
+		signal: AutonomySignal,
+	) -> Result<AutonomySignalRecord> {
+		validate_autonomy_signal_record_inputs(project_id, &signal)?;
+
+		let now = timestamp_parts();
+		let mut state = self.lock()?;
+		let objective_key = AutonomyObjectiveKey::new(
+			project_id,
+			signal.objective_id(),
+			signal.objective_version(),
+		);
+		let objective = state
+			.autonomy_objectives
+			.get(&objective_key)
+			.ok_or_else(|| {
+				eyre::eyre!(
+					"Autonomy signal `{}` references missing objective `{}` version {}.",
+					signal.id(),
+					signal.objective_id(),
+					signal.objective_version()
+				)
+			})?;
+
+		if objective.state != AutonomyObjectiveState::Accepted {
+			eyre::bail!(
+				"Autonomy signal `{}` can only be recorded for an accepted objective version; `{}` version {} is `{}`.",
+				signal.id(),
+				signal.objective_id(),
+				signal.objective_version(),
+				objective.state.as_str()
+			);
+		}
+
+		let key = AutonomySignalKey::new(project_id, signal.id());
+		let (created_at, created_at_unix) = state
+			.autonomy_signals
+			.get(&key)
+			.map_or_else(|| (now.text.clone(), now.unix), |record| {
+				(record.created_at.clone(), record.created_at_unix)
+			});
+		let record = AutonomySignalRuntimeRecord {
+			project_id: project_id.to_owned(),
+			signal,
+			created_at,
+			created_at_unix,
+			updated_at: now.text,
+			updated_at_unix: now.unix,
+		};
+
+		state.autonomy_signals.insert(record.key(), record.clone());
+		self.upsert_autonomy_signal_locked(&record)?;
+
+		Ok(record.as_public())
+	}
+
+	/// Read one autonomy signal by stable signal id.
+	#[allow(dead_code)]
+	pub(crate) fn autonomy_signal(
+		&self,
+		project_id: &str,
+		signal_id: &str,
+	) -> Result<Option<AutonomySignalRecord>> {
+		validate_required_autonomy_signal_field("project_id", project_id)?;
+		validate_required_autonomy_signal_field("signal_id", signal_id)?;
+
+		if let Some(sqlite) = &self.sqlite {
+			let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
+
+			return sqlite
+				.autonomy_signal(project_id, signal_id)
+				.map(|record| record.map(|record| record.as_public()));
+		}
+
+		let state = self.lock()?;
+
+		Ok(state
+			.autonomy_signals
+			.get(&AutonomySignalKey::new(project_id, signal_id))
+			.map(AutonomySignalRuntimeRecord::as_public))
+	}
+
+	/// List autonomy signals tied to one exact Objective Contract version.
+	#[allow(dead_code)]
+	pub(crate) fn list_autonomy_signals_for_objective(
+		&self,
+		project_id: &str,
+		objective_id: &str,
+		objective_version: u64,
+	) -> Result<Vec<AutonomySignalRecord>> {
+		validate_required_autonomy_signal_field("project_id", project_id)?;
+		validate_required_autonomy_signal_field("objective_id", objective_id)?;
+		validate_autonomy_objective_version(objective_version)?;
+
+		if let Some(sqlite) = &self.sqlite {
+			let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
+			let records = sqlite
+				.list_autonomy_signals_for_objective(project_id, objective_id, objective_version)?
+				.into_iter()
+				.map(|record| record.as_public())
+				.collect();
+
+			return Ok(records);
+		}
+
+		let state = self.lock()?;
+		let mut records = state
+			.autonomy_signals
+			.values()
+			.filter(|record| {
+				record.project_id == project_id
+					&& record.signal.objective_id() == objective_id
+					&& record.signal.objective_version() == objective_version
+			})
+			.cloned()
+			.collect::<Vec<_>>();
+
+		records.sort_by(compare_autonomy_signal_runtime_records);
+
+		Ok(records.into_iter().map(|record| record.as_public()).collect())
+	}
+
+	/// List recent autonomy signals for one project for operator readback.
+	#[allow(dead_code)]
+	pub(crate) fn recent_autonomy_signals_for_project(
+		&self,
+		project_id: &str,
+		limit: usize,
+	) -> Result<Vec<AutonomySignalRecord>> {
+		validate_required_autonomy_signal_field("project_id", project_id)?;
+
+		if limit == 0 {
+			return Ok(Vec::new());
+		}
+
+		if let Some(sqlite) = &self.sqlite {
+			let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
+			let records = sqlite
+				.recent_autonomy_signals_for_project(project_id, limit)?
+				.into_iter()
+				.map(|record| record.as_public())
+				.collect();
+
+			return Ok(records);
+		}
+
+		let state = self.lock()?;
+		let mut records = state
+			.autonomy_signals
+			.values()
+			.filter(|record| record.project_id == project_id)
+			.cloned()
+			.collect::<Vec<_>>();
+
+		records.sort_by(compare_recent_autonomy_signal_runtime_records);
+		records.truncate(limit);
 
 		Ok(records.into_iter().map(|record| record.as_public()).collect())
 	}
@@ -3900,6 +4090,21 @@ impl StateStore {
 	}
 
 	#[allow(dead_code)]
+	fn upsert_autonomy_signal_locked(
+		&self,
+		record: &AutonomySignalRuntimeRecord,
+	) -> Result<()> {
+		let Some(sqlite) = self.sqlite.as_ref() else {
+			return Ok(());
+		};
+		let sqlite = sqlite
+			.lock()
+			.map_err(|_| eyre::eyre!("StateStore SQLite mutex is poisoned."))?;
+
+		sqlite.upsert_autonomy_signal(record)
+	}
+
+	#[allow(dead_code)]
 	fn upsert_execution_program_locked(
 		&self,
 		record: &ExecutionProgramRuntimeRecord,
@@ -4960,6 +5165,34 @@ fn validate_required_autonomy_objective_field(name: &str, value: &str) -> Result
 fn validate_autonomy_objective_version(version: u64) -> Result<()> {
 	if version == 0 {
 		eyre::bail!("Autonomy objective version must be greater than zero.");
+	}
+
+	Ok(())
+}
+
+#[allow(dead_code)]
+fn validate_autonomy_signal_record_inputs(
+	project_id: &str,
+	signal: &AutonomySignal,
+) -> Result<()> {
+	validate_required_autonomy_signal_field("project_id", project_id)?;
+
+	if signal.project_id() != project_id {
+		eyre::bail!(
+			"Autonomy signal `{}` belongs to project `{}` but was stored for `{}`.",
+			signal.id(),
+			signal.project_id(),
+			project_id
+		);
+	}
+
+	signal.validate()
+}
+
+#[allow(dead_code)]
+fn validate_required_autonomy_signal_field(name: &str, value: &str) -> Result<()> {
+	if value.trim().is_empty() {
+		eyre::bail!("Autonomy signal {name} must not be empty.");
 	}
 
 	Ok(())

--- a/docs/runbook/autonomy-implementation-roadmap.md
+++ b/docs/runbook/autonomy-implementation-roadmap.md
@@ -8,6 +8,7 @@ owner: runtime
 tags: [runbook, autonomy, objective, roadmap]
 code_refs:
   - apps/decodex/src/autonomy_objective.rs
+  - apps/decodex/src/autonomy_signal.rs
   - apps/decodex/src/loop_contract.rs
   - apps/decodex/src/config.rs
   - apps/decodex/src/mcp.rs
@@ -147,6 +148,9 @@ Goal: Persist signals as evidence only.
 
 Implementation surfaces:
 
+- `apps/decodex/src/autonomy_signal.rs` owns the versioned
+  `decodex.autonomy_signal/1` payload, fingerprint, validation rules, and first
+  dogfood builders.
 - Runtime state store for `decodex.autonomy_signal/1`.
 - Signal builders for the first dogfood adapters:
   - `runtime_health`
@@ -158,6 +162,8 @@ Implementation surfaces:
   - `execution_friction`
   - `docs_skill_drift`
 - Operator/status readback for recent signals.
+- Store APIs that record one signal, read one signal, list signals by exact
+  Objective Contract id/version, and list recent project signals for status readback.
 
 Deliverables:
 
@@ -166,6 +172,8 @@ Deliverables:
 - Dedupe fingerprint that excludes volatile counts and timestamps.
 - Review signal ingestion uses `finding_routes` and current-head review evidence.
 - Memory-derived signal ingestion requires source refs and stays proposal-only.
+- Runtime/status readback exposes recent signal freshness, gaps, contradictions,
+  confidence, and privacy without treating signals as execution authority.
 
 Required tests:
 

--- a/docs/spec/autonomy-control-plane.md
+++ b/docs/spec/autonomy-control-plane.md
@@ -17,6 +17,7 @@ source_refs:
   - https://developers.openai.com/codex/learn/best-practices
 code_refs:
   - apps/decodex/src/autonomy_objective.rs
+  - apps/decodex/src/autonomy_signal.rs
   - apps/decodex/src/loop_contract.rs
   - apps/decodex/src/config.rs
   - apps/decodex/src/mcp.rs
@@ -224,12 +225,16 @@ Each signal must carry provenance:
 | Field | Meaning |
 | --- | --- |
 | `schema` | Versioned schema, initially `decodex.autonomy_signal/1`. |
+| `record_version` | Payload version for this schema, initially `1`. |
+| `id` | Stable signal id derived from the fingerprint. |
+| `fingerprint` | Stable dedupe fingerprint for objective-bound signal identity. It includes objective id/version, source refs, review route evidence, evidence class, gaps, contradictions, confidence, and privacy, but excludes volatile timestamps and observed counts. |
 | `project_id` | Registered service id. |
 | `objective_id` | Objective in force when the signal is interpreted. |
 | `objective_version` | Exact immutable objective version. |
 | `kind` | One accepted signal kind. |
-| `source_type` | User, review, CI, telemetry, runtime, docs, protocol, agent, tracker, or memory adapter. |
-| `source_ref` | Stable pointer to run, PR, issue, log, review, file, report, or external source. |
+| `source_type` | User, review, CI, telemetry, runtime, docs, protocol, agent, tracker, memory, or report. |
+| `source_refs` | Stable pointers to runs, PRs, issues, logs, reviews, files, reports, or external sources. |
+| `primary_source_refs` | Required source-of-truth pointers for memory/report-derived signals. |
 | `issue_id` | Issue identifier when issue-scoped. |
 | `run_id` | Runtime run identifier when run-scoped. |
 | `attempt_id` | Attempt identifier when attempt-scoped. |
@@ -243,11 +248,24 @@ Each signal must carry provenance:
 | `gaps` | Missing evidence or unresolved questions. |
 | `confidence` | Confidence category or score. |
 | `privacy` | Visibility boundary for reports and MCP resources. |
+| `observed_counts` | Optional counts for readback context. Counts are volatile and are not part of the dedupe fingerprint. |
+| `review_evidence` | Required for review-derived signals. Contains review phase/status, current-head SHA, checkpoint refs, and normalized `finding_routes`. |
+| `proposal_only` | Must be true. Signal persistence is evidence only and cannot grant execution authority. |
 | `created_at` | UTC signal creation timestamp. |
 
 Long runtime, high token use, expensive validation, or a hard task is not an
 autonomy problem by itself. Autonomy reacts to contradiction, repeated friction,
 objective drift, validation failure, review evidence, or measured regression.
+
+The runtime persists signals in its own `autonomy_signals` table keyed by
+`project_id` and stable signal id, with indexes for exact
+`objective_id`/`objective_version` readback and recent project readback. Storing a
+signal requires the referenced Objective Contract version to be the accepted version
+at write time; later objective versions do not reinterpret older signal rows.
+Operator status may show recent signal summaries, freshness, gaps, contradictions,
+confidence, and privacy as read-only evidence. Signal rows do not mutate tracker
+state, runtime authority rows outside signal persistence, worktrees, GitHub, Program
+Intake, proposals, or execution state.
 
 Review-derived signals must consume normalized review evidence, not raw comments.
 `review_feedback_cluster` may use only review checkpoint routes from

--- a/docs/spec/review-orchestration.md
+++ b/docs/spec/review-orchestration.md
@@ -6,9 +6,9 @@ status: active
 authority: normative
 owner: runtime
 tags: [spec]
-code_refs: [apps/decodex/src/agent/tracker_tool_bridge/review.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs]
-drift_watch: [issue_review_checkpoint, issue_review_handoff, issue_review_repair_complete, review_contract, review_cost_control, review_policy_checkpoints, evidence_artifacts]
-last_verified: 2026-06-21
+code_refs: [apps/decodex/src/agent/tracker_tool_bridge/review.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/autonomy_signal.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs]
+drift_watch: [issue_review_checkpoint, issue_review_handoff, issue_review_repair_complete, review_contract, review_cost_control, review_policy_checkpoints, finding_routes, evidence_artifacts, decodex.autonomy_signal/1]
+last_verified: 2026-06-22
 ---
 # Review Orchestration
 
@@ -241,6 +241,12 @@ A missing `finding_routes` field keeps backward compatibility by defaulting acce
 findings to `current_blocker` and rejected findings to `reviewer_rubric_gap`, but new
 prompts must instruct agents to populate explicit route evidence so non-current
 signals do not accidentally become repair input.
+
+Autonomy review-feedback signals consume only this normalized route evidence plus
+current-head checkpoint references. Raw reviewer comments, GitHub thread text, or
+unrouted review summaries cannot be persisted as `review_feedback_cluster` signals
+unless they are first represented through `finding_routes` and bound to the reviewed
+head.
 
 ## GitHub Review
 

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -6,7 +6,7 @@ status: active
 authority: normative
 owner: runtime
 tags: [spec]
-code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/mcp.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs, apps/decodex/src/config.rs, decodex.example.toml]
+code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/autonomy_signal.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/mcp.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs, apps/decodex/src/config.rs, decodex.example.toml]
 drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, protocol_events, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, decodex intake goal, program_issue_mappings, "[autonomy]", auto_promote, auto_intake, "[autonomy.runtime_policy]", accepted_objective_id, accepted_objective_version, accepted_policy_id, accepted_policy_version, policy_authority_ref]
 last_verified: 2026-06-22
 ---
@@ -143,6 +143,7 @@ mirror:
 | --- | --- |
 | Runtime SQLite `private_execution_events` | Structured private execution evidence for the local Decodex installation. This is where full checkpoint payloads, verification notes, local head evidence, recovery detail, and `decodex.harness_outcome/1` feedback records belong. |
 | Runtime SQLite `decision_contracts` | Versioned `decodex.decision_contract/1` payloads produced by research/design and later promoted into execution authority. The row status is indexed for local runtime lookup, and the structured runtime payload remains the local machine authority. Checked-in research documentation belongs in Markdown OKF concepts under `docs/research/`, not JSON docs artifacts. |
+| Runtime SQLite `autonomy_signals` | Versioned `decodex.autonomy_signal/1` payloads scoped by project and exact Objective Contract id/version. Rows are read-only evidence for future proposal compilation, expose freshness, gaps, contradictions, confidence, and privacy in status readback, and do not mutate tracker state, runtime authority rows outside signal persistence, worktrees, GitHub, Program Intake, proposals, or execution state. |
 | Runtime SQLite `execution_programs` | Versioned `decodex.execution_program/1` payloads with embedded or linked `decodex.program_intake_plan/1` planning data. They hold internal node lifecycle/readiness, dependency, conflict-domain, dispatch intent, drift, and normal-issue mapping; Linear issue descriptions and ledger comments are only coarse projections. |
 | Runtime SQLite `program_intake_plans` | Queryable local projection of `decodex.program_intake_plan/1` metadata, including intake kind, source contract when present, authority fingerprint, and public-safe summary. |
 | Runtime SQLite `program_issue_mappings` | Queryable local projection of each internal program node's mapped Linear issue, tracker state, dispatch intent, active/manual/attention facts, and dispatch-briefing fact. |
@@ -798,6 +799,9 @@ The runtime database stores at least:
 - private execution events scoped by project, issue, run, and attempt
 - Objective Contracts scoped by project, objective id, and immutable version, with
   lifecycle state and acceptance, rejection, or supersession provenance
+- autonomy signals scoped by project, stable signal id, and exact Objective Contract
+  id/version, with freshness, evidence class, contradictions, gaps, confidence, and
+  privacy retained for operator readback
 - Decision Contracts scoped by project and contract id, with optional source issue
   linkage for later issue shaping
 - Program Intake Plans and internal Execution Programs scoped by project, with


### PR DESCRIPTION
## Summary
- Add versioned decodex.autonomy_signal/1 schema, validators, fingerprints, dogfood builders, and state storage/readback APIs.
- Surface recent autonomy signals in runtime/operator readback as evidence-only metadata.
- Update owning autonomy control-plane, review orchestration, runtime, and roadmap docs.
- Repair scoped fake GitHub command handling in review-related tests.

## Validation
- cargo make fmt
- cargo make lint-fix
- cargo make test: 1400 passed, 1 skipped
- cargo test -p decodex autonomy_signal --lib: 6 passed
- cargo test -p decodex review --lib: 225 passed
- cargo make fmt-check
- cargo make check-docs
- git diff --check

## Decodex Review
- Independent fresh-context review checkpoint recorded clean for b14e5aa6f4e371d5e60345125f60ed41885086cd.
- No accepted current blockers.
- Reviewer signals normalized as invalid_or_unsubstantiated and risk_note; no repair churn.