### PR TITLE
Simplify status readback UI

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -3034,30 +3034,6 @@ struct OperatorLanePopoverView: View {
 				OperatorLaneReadoutItem(label: "run phase", value: rawPanelToken(runPhase))
 			)
 		}
-		if let currentOperation = panelTrimmed(run.currentOperation) {
-			items.append(
-				OperatorLaneReadoutItem(
-					label: "current operation",
-					value: rawPanelToken(currentOperation)
-				)
-			)
-		}
-		if let activeGoalPhase = panelTrimmed(run.activeGoalPhase) {
-			items.append(
-				OperatorLaneReadoutItem(
-					label: "active goal phase",
-					value: rawPanelToken(activeGoalPhase)
-				)
-			)
-		}
-		if let publicProgressPhase = panelTrimmed(run.publicProgressPhase) {
-			items.append(
-				OperatorLaneReadoutItem(
-					label: "public progress phase",
-					value: rawPanelToken(publicProgressPhase)
-				)
-			)
-		}
 
 		return items
 	}

--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -4488,12 +4488,6 @@
 					if (runStoppedProcessNeedsAttention(run)) {
 						return run.process_liveness_reason || "process_stopped";
 					}
-					if (runProcessStoppedWhileActive(run)) {
-						return run.current_operation || run.run_phase || run.phase || "process_stopped";
-					}
-					if ((run.run_phase || run.phase) === "executing") {
-						return displayToken(run.current_operation || run.run_phase || run.phase);
-					}
 
 					return displayToken(run.run_phase || run.phase || run.status);
 				}
@@ -6370,15 +6364,6 @@
 				const focus = protocolActivityFocus(run);
 
 				facts.push(["run phase", displayToken(run.run_phase || run.phase || run.status)]);
-				if (run.current_operation) {
-					facts.push(["current operation", displayToken(run.current_operation)]);
-				}
-				if (run.active_goal_phase) {
-					facts.push(["active goal phase", displayToken(run.active_goal_phase)]);
-				}
-				if (run.public_progress_phase) {
-					facts.push(["public progress phase", displayToken(run.public_progress_phase)]);
-				}
 				if (freshness.timestamp) {
 					facts.push([freshness.sourceLabel, formatRelativeTimestamp(freshness.timestamp)]);
 				}
@@ -6392,6 +6377,26 @@
 					facts.push(["agent idle", formatDuration(run.protocol_idle_for_seconds)]);
 				}
 				return facts;
+			}
+
+			function currentLaneReadbackValues(run) {
+				return [
+					run?.run_phase || run?.phase || run?.status,
+					run?.current_operation,
+					run?.active_goal_phase,
+					run?.public_progress_phase,
+				].filter(Boolean);
+			}
+
+			function currentLaneVisibleSummary(card, run) {
+				const summary = String(card?.detail || "").trim();
+				if (!summary) {
+					return "";
+				}
+
+				return currentLaneReadbackValues(run).some((value) => displayTextRepeats(summary, value))
+					? ""
+					: summary;
 			}
 
 			function renderRunMetaFact(label, value, valueClass = "", title = "") {
@@ -9471,7 +9476,7 @@
 							issue: issueKey,
 							title: runStoppedProcessNeedsAttention(run)
 								? "Stopped agent process"
-								: displayToken(run.current_operation || run.run_phase || run.phase),
+								: displayToken(run.run_phase || run.phase || run.status),
 							summary: runStoppedProcessNeedsAttention(run)
 								? `Agent process stopped while lane remains active. ${COPY.protocolEvent} ${run.last_event_type || "none"}.`
 								: runStaleWithoutKnownProcessNeedsAttention(run)
@@ -9505,7 +9510,7 @@
 							tone,
 							scope: "Running",
 							issue: issueKey,
-							title: displayToken(run.current_operation || run.run_phase || run.phase),
+							title: displayToken(run.run_phase || run.phase || run.status),
 							summary: run.next_retry_at
 								? `Retry scheduled for ${formatTimestamp(run.next_retry_at)}.`
 								: `Waiting on ${displayToken(run.wait_reason || run.run_phase || run.phase)}.`,
@@ -10583,7 +10588,7 @@
 							const renderKey = card.id || card.run_id || `presentation-card:${index}`;
 							const issueKey = card.issue_identifier || "unknown";
 							const issueTitle = card.title || "Run";
-							const summary = card.detail || "";
+							const summary = currentLaneVisibleSummary(card, run);
 							if (run.ownership_state && run.ownership_state !== "leased_run") {
 								statusBits.push(inlineStatusFact("Owner", displayToken(run.ownership_state)));
 							}
@@ -10650,6 +10655,10 @@
 									<div class="grid debug-grid">
 										${field("Run", run.run_id)}
 										${field("Attempt status", run.attempt_status || run.status)}
+										${field("Run phase", capturedValue(run.run_phase || run.phase))}
+										${field("Current operation", capturedValue(run.current_operation))}
+										${field("Active goal phase", capturedValue(run.active_goal_phase))}
+										${field("Public progress phase", capturedValue(run.public_progress_phase))}
 										${field("Updated", formatTimestamp(run.updated_at))}
 										${field("Codex thread", runThreadSummary(run))}
 										${field("Thread flags", runThreadFlagSummary(run))}

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -619,17 +619,20 @@ fn operator_dashboard_current_lane_status_copy_stays_concise() {
 	assert!(response.contains("runProcessStoppedWithoutAttention"));
 	assert!(response.contains("runPhaseLabel"));
 	assert!(response.contains("return run.process_liveness_reason || \"process_stopped\";"));
-	assert!(
-		response.contains("return run.current_operation || run.run_phase || run.phase || \"process_stopped\";")
-	);
+	assert!(response.contains("return displayToken(run.run_phase || run.phase || run.status);"));
+	assert!(!response.contains("return run.current_operation || run.run_phase || run.phase || \"process_stopped\";"));
+	assert!(!response.contains("displayToken(run.current_operation || run.run_phase || run.phase)"));
 	assert!(response.contains("Stopped agent process"));
 	assert!(response.contains("attention stopped"));
 	assert!(response.contains("inlineStatusFact(\"Agent\", \"Done\")"));
 	assert!(response.contains("const waitReason = displayToken(run.wait_reason);"));
 	assert!(response.contains("if (!displayTextRepeats(summary, waitReason))"));
 	assert!(response.contains("displayTextRepeats(summary, \"operator input\")"));
+	assert!(response.contains("function currentLaneVisibleSummary(card, run)"));
+	assert!(response.contains("currentLaneReadbackValues(run).some((value) => displayTextRepeats(summary, value))"));
 	assert!(response.contains("const issueTitle = card.title || \"Run\";"));
-	assert!(response.contains("const summary = card.detail || \"\";"));
+	assert!(response.contains("const summary = currentLaneVisibleSummary(card, run);"));
+	assert!(!response.contains("const summary = card.detail || \"\";"));
 	assert!(!response.contains("Operator input needed."));
 	assert!(!response.contains("Protocol idle."));
 	assert!(response.contains("status: \"waiting\","));
@@ -1798,13 +1801,17 @@ fn operator_dashboard_active_freshness_prefers_live_activity_source() {
 	assert!(response.contains("function currentLaneLifecycleMetrics(run, summary = childAgentActivity(run))"));
 	assert!(response.contains("function lifecycleMetricFacts(metrics, { includeAttempts = false } = {})"));
 	assert!(response.contains("facts.push([\"run phase\", displayToken(run.run_phase || run.phase || run.status)]);"));
-	assert!(response.contains("facts.push([\"current operation\", displayToken(run.current_operation)]);"));
-	assert!(response.contains("facts.push([\"active goal phase\", displayToken(run.active_goal_phase)]);"));
-	assert!(response.contains("facts.push([\"public progress phase\", displayToken(run.public_progress_phase)]);"));
+	assert!(!response.contains("facts.push([\"current operation\", displayToken(run.current_operation)]);"));
+	assert!(!response.contains("facts.push([\"active goal phase\", displayToken(run.active_goal_phase)]);"));
+	assert!(!response.contains("facts.push([\"public progress phase\", displayToken(run.public_progress_phase)]);"));
 	assert!(response.contains("function lifecycleRecoveryDebugSummary(metrics)"));
 	assert!(response.contains("function lifecycleEvidenceDebugSummary(metrics)"));
 	assert!(response.contains("${field(\"Lifecycle recovery\", lifecycleRecoveryDebugSummary(currentLaneLifecycleMetrics(run)))}"));
 	assert!(response.contains("${field(\"Lifecycle evidence\", lifecycleEvidenceDebugSummary(currentLaneLifecycleMetrics(run)))}"));
+	assert!(response.contains("${field(\"Run phase\", capturedValue(run.run_phase || run.phase))}"));
+	assert!(response.contains("${field(\"Current operation\", capturedValue(run.current_operation))}"));
+	assert!(response.contains("${field(\"Active goal phase\", capturedValue(run.active_goal_phase))}"));
+	assert!(response.contains("${field(\"Public progress phase\", capturedValue(run.public_progress_phase))}"));
 	assert!(response.contains("facts.push([\"tokens\", tokenSummary]);"));
 	assert!(response.contains("facts.push([\"tools\", formatCompactCount(metrics.tool_call_count)]);"));
 	assert!(response.contains("\"max output\","));


### PR DESCRIPTION
## Summary
- simplify macOS App lane popover Status to show only run_phase
- simplify Web UI current-lane status/meta/attention/waiting surfaces to prefer run_phase
- keep current_operation, active_goal_phase, and public_progress_phase in Web Debug Details

## Verification
- cargo make fmt
- cargo make lint-fix
- cargo make test
- swift test --package-path apps/decodex-app
- git diff --check
