### PR TITLE
XY-1095: Fix stale review repair status projection

### DIFF
--- a/apps/decodex/src/mcp.rs
+++ b/apps/decodex/src/mcp.rs
@@ -3624,7 +3624,7 @@ fn mcp_pr_review_state_resource(snapshot: Value) -> Value {
 	let current_lane_reviews = mcp_current_lane_runs(&snapshot)
 		.into_iter()
 		.filter_map(|run| {
-			let review = run.get("loop_status")?.get("review")?;
+			let review = mcp_loop_review_status(run)?;
 
 			Some(serde_json::json!({
 				"run_id": run.get("run_id").cloned().unwrap_or(Value::Null),
@@ -3676,7 +3676,7 @@ fn mcp_public_post_review_lane(lane: &Value) -> Value {
 		"readback_root_cause": lane.get("readback_root_cause").cloned().unwrap_or(Value::Null),
 		"loop_review": lane
 			.get("loop_status")
-			.and_then(|status| status.get("review"))
+			.and_then(mcp_loop_review_status_from_loop_status)
 			.map(mcp_public_review_status)
 			.unwrap_or(Value::Null)
 	})
@@ -3748,7 +3748,7 @@ fn mcp_run_activity_summary(run: &Value) -> Value {
 			.unwrap_or(Value::Null),
 		"loop_review": run
 			.get("loop_status")
-			.and_then(|status| status.get("review"))
+			.and_then(mcp_loop_review_status_from_loop_status)
 			.map(mcp_public_review_status)
 			.unwrap_or(Value::Null)
 	})
@@ -3779,6 +3779,14 @@ fn mcp_public_review_status(review: &Value) -> Value {
 			.map(mcp_public_review_checkpoint_status)
 			.unwrap_or(Value::Null)
 	})
+}
+
+fn mcp_loop_review_status(run_or_lane: &Value) -> Option<&Value> {
+	run_or_lane.get("loop_status").and_then(mcp_loop_review_status_from_loop_status)
+}
+
+fn mcp_loop_review_status_from_loop_status(loop_status: &Value) -> Option<&Value> {
+	loop_status.get("review").filter(|review| review.is_object())
 }
 
 fn mcp_public_review_checkpoint_status(checkpoint: &Value) -> Value {
@@ -5204,26 +5212,13 @@ mod tests {
 		assert!(
 			combined["live"]["current_lanes"][0]["phase_acceptance"]["changed_surfaces"].is_null()
 		);
-		assert_eq!(combined["live"]["current_lanes"][0]["loop_review"]["status"], "pending");
-		assert_eq!(combined["live"]["current_lanes"][0]["loop_review"]["checkpoint"]["round"], 3);
-		assert!(
-			combined["live"]["current_lanes"][0]["loop_review"]["checkpoint"]["head_sha"].is_null()
-		);
+		assert!(combined["live"]["current_lanes"][0]["loop_review"].is_null());
 		assert_eq!(combined["review"]["post_review_lanes"][0]["pr_url"], "https://example/pr/1");
 		assert!(combined["review"]["post_review_lanes"][0]["branch_name"].is_null());
 		assert!(combined["review"]["post_review_lanes"][0]["loop_status"].is_null());
 		assert_eq!(
 			combined["review"]["current_lane_reviews"].as_array().expect("review array").len(),
-			1
-		);
-		assert_eq!(combined["review"]["current_lane_reviews"][0]["review"]["status"], "pending");
-		assert_eq!(
-			combined["review"]["current_lane_reviews"][0]["review"]["checkpoint"]["round"],
-			3
-		);
-		assert!(
-			combined["review"]["current_lane_reviews"][0]["review"]["checkpoint"]["active_fingerprints"]
-				.is_null()
+			0
 		);
 
 		assert_no_sensitive_observability_content(&combined);
@@ -5255,6 +5250,74 @@ mod tests {
 		assert_eq!(review["schema"], "decodex.mcp.pr_review_state/1");
 		assert_eq!(review["current_lane_reviews"].as_array().expect("review array").len(), 0);
 		assert!(!serialized.contains("stale_recent_finding"));
+	}
+
+	#[test]
+	fn pr_review_state_includes_object_current_lane_review() {
+		let snapshot = serde_json::json!({
+			"schema": "decodex.mcp.status_resource/1",
+			"project_id": "decodex",
+			"current_lanes": [
+				{
+					"run_id": "run-review",
+					"issue_id": "issue-review",
+					"issue_identifier": "XY-1095",
+					"loop_status": {
+						"review": observability_review_status_fixture(
+							"private-head-sha",
+							"fingerprint-private",
+							"stop-fingerprint-private",
+							3
+						)
+					}
+				}
+			],
+			"post_review_lanes": []
+		});
+		let review = super::mcp_pr_review_state_resource(snapshot);
+		let current_lane_reviews = review["current_lane_reviews"].as_array().expect("review array");
+
+		assert_eq!(current_lane_reviews.len(), 1);
+		assert_eq!(current_lane_reviews[0]["run_id"], "run-review");
+		assert_eq!(current_lane_reviews[0]["review"]["status"], "pending");
+		assert_eq!(current_lane_reviews[0]["review"]["checkpoint"]["round"], 3);
+		assert!(current_lane_reviews[0]["review"]["checkpoint"]["active_fingerprints"].is_null());
+	}
+
+	#[test]
+	fn mcp_review_surfaces_ignore_null_loop_review_status() {
+		let snapshot = serde_json::json!({
+			"schema": "decodex.mcp.status_resource/1",
+			"project_id": "decodex",
+			"current_lanes": [
+				{
+					"run_id": "run-null-review",
+					"issue_id": "issue-null-review",
+					"issue_identifier": "XY-1095",
+					"loop_status": {
+						"review": null
+					}
+				}
+			],
+			"post_review_lanes": [
+				{
+					"project_id": "decodex",
+					"issue_id": "issue-null-review",
+					"issue_identifier": "XY-1095",
+					"loop_status": {
+						"review": null
+					}
+				}
+			]
+		});
+		let review = super::mcp_pr_review_state_resource(snapshot.clone());
+		let activity = super::mcp_run_activity_summary(&snapshot["current_lanes"][0]);
+		let post_review_lane =
+			super::mcp_public_post_review_lane(&snapshot["post_review_lanes"][0]);
+
+		assert_eq!(review["current_lane_reviews"].as_array().expect("review array").len(), 0);
+		assert!(activity["loop_review"].is_null());
+		assert!(post_review_lane["loop_review"].is_null());
 	}
 
 	#[test]
@@ -5316,9 +5379,10 @@ mod tests {
 		let current_lane_reviews =
 			pr_review_state["current_lane_reviews"].as_array().expect("review array");
 
-		assert_eq!(current_lane_reviews.len(), 1);
-		assert_eq!(current_lane_reviews[0]["run_id"], "run-12");
-		assert_eq!(current_lane_reviews[0]["review"]["status"], "pending");
+		assert!(
+			current_lane_reviews.is_empty(),
+			"unexpected current lane reviews: {current_lane_reviews:?}"
+		);
 		assert_eq!(protocol_activity["schema"], "decodex.mcp.protocol_activity/1");
 		assert_eq!(protocol_activity["run_id"], "run-12");
 		assert!(
@@ -5428,9 +5492,10 @@ mod tests {
 		let current_lane_reviews =
 			pr_review_state["current_lane_reviews"].as_array().expect("review array");
 
-		assert_eq!(current_lane_reviews.len(), 1);
-		assert_eq!(current_lane_reviews[0]["run_id"], "run-12");
-		assert_eq!(current_lane_reviews[0]["review"]["status"], "pending");
+		assert!(
+			current_lane_reviews.is_empty(),
+			"unexpected current lane reviews: {current_lane_reviews:?}"
+		);
 		assert!(
 			serde_json::to_string(&protocol_activity)
 				.expect("protocol activity should serialize")
@@ -6833,14 +6898,6 @@ mod tests {
 				"path": "/private/activity-marker"
 			},
 			"phase_acceptance": observability_phase_acceptance_fixture(),
-			"loop_status": {
-				"review": observability_review_status_fixture(
-					"private-head-sha",
-					"fingerprint-private",
-					"stop-fingerprint-private",
-					3
-				)
-			},
 			"private_evidence": {
 				"raw": "hidden"
 			},

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -19,6 +19,7 @@ use state::WORKTREE_PROVENANCE_GIT_HYGIENE_SCAN;
 use state::WORKTREE_PROVENANCE_LEGACY_UNKNOWN;
 use state::ProjectLoopEvidenceSnapshot;
 use state::ProtocolActivityEventSummary;
+use state::ReviewCheckpointArtifactLookup;
 
 use crate::agent::REVIEW_POLICY_CONVERGENCE_BUDGET;
 use crate::pull_request::{self, PullRequestLandingGateView};
@@ -81,6 +82,13 @@ struct LiveOperatorStatusSnapshotOptions {
 	run_issue_metadata_hydration: RunIssueMetadataHydration,
 	account_activity_mode: AccountActivityMode,
 	configure_dispatch_slots: bool,
+}
+
+#[derive(Clone, Copy)]
+struct PostReviewRuntimeState<'a> {
+	state_store: &'a StateStore,
+	project_id: &'a str,
+	review_level: ReviewLevel,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -2114,7 +2122,7 @@ fn refresh_operator_project_summary(
 fn project_waiting_lane_count(snapshot: &OperatorStatusSnapshot) -> usize {
 	let waiting_run_count = project_summary_runs(snapshot)
 		.into_iter()
-		.filter(|run| operator_run_counts_as_waiting(run))
+		.filter(|run| operator_run_counts_as_project_waiting(run))
 		.map(|run| run.run_id.as_str())
 		.collect::<HashSet<_>>()
 		.len();
@@ -2142,6 +2150,23 @@ fn project_summary_runs(snapshot: &OperatorStatusSnapshot) -> Vec<&OperatorRunSt
 
 fn operator_run_counts_as_waiting(run: &OperatorRunStatus) -> bool {
 	run.phase == "retry_backoff" || run.phase == "waiting_continuation" || run.wait_reason.is_some()
+}
+
+fn operator_run_counts_as_project_waiting(run: &OperatorRunStatus) -> bool {
+	if operator_run_counts_as_attention(run) {
+		return false;
+	}
+	if matches!(run.phase.as_str(), "retry_backoff" | "waiting_continuation") {
+		return true;
+	}
+	if run.current_operation == RUN_OPERATION_WAITING_EXTERNAL {
+		return true;
+	}
+
+	matches!(
+		run.wait_reason.as_deref(),
+		Some("approval_or_user_input" | "protocol_idleness")
+	)
 }
 
 fn queued_candidate_counts_as_waiting_intake(candidate: &OperatorQueuedIssueStatus) -> bool {
@@ -5434,7 +5459,11 @@ where
 		workflow,
 		review_state_inspector,
 		true,
-		Some((state_store, "pubfi")),
+		Some(PostReviewRuntimeState {
+			state_store,
+			project_id: "pubfi",
+			review_level: ReviewLevel::Standard,
+		}),
 	)
 }
 
@@ -5453,7 +5482,11 @@ where
 		workflow,
 		review_state_inspector,
 		project.codex().review_level().uses_github_review(),
-		Some((state_store, project.service_id())),
+		Some(PostReviewRuntimeState {
+			state_store,
+			project_id: project.service_id(),
+			review_level: project.codex().review_level(),
+		}),
 	)?;
 
 	confirm_status_visible_merged_closeout(snapshot, project, &mut classification);
@@ -5466,7 +5499,7 @@ fn classify_post_review_lane_with_external_review<I>(
 	workflow: &WorkflowDocument,
 	review_state_inspector: &I,
 	github_review_enabled: bool,
-	runtime_state: Option<(&StateStore, &str)>,
+	runtime_state: Option<PostReviewRuntimeState<'_>>,
 ) -> crate::prelude::Result<PostReviewLaneClassification>
 where
 	I: PullRequestReviewStateInspector,
@@ -5540,7 +5573,7 @@ where
 fn apply_authority_boundary_landing_policy(
 	snapshot: &PostReviewLaneSnapshot,
 	classification: &mut PostReviewLaneClassification,
-	runtime_state: Option<(&StateStore, &str)>,
+	runtime_state: Option<PostReviewRuntimeState<'_>>,
 ) -> crate::prelude::Result<()> {
 	if classification.decision != PostReviewLaneDecision::ReadyToLand {
 		return Ok(());
@@ -5558,13 +5591,13 @@ fn apply_authority_boundary_landing_policy(
 
 fn authority_boundary_landing_requirement(
 	snapshot: &PostReviewLaneSnapshot,
-	runtime_state: Option<(&StateStore, &str)>,
+	runtime_state: Option<PostReviewRuntimeState<'_>>,
 ) -> crate::prelude::Result<Option<&'static str>> {
-	let Some((state_store, project_id)) = runtime_state else {
+	let Some(runtime_state) = runtime_state else {
 		return Ok(None);
 	};
-	let events = state_store.list_private_execution_events_for_issue(
-		project_id,
+	let events = runtime_state.state_store.list_private_execution_events_for_issue(
+		runtime_state.project_id,
 		&snapshot.issue.id,
 	)?;
 	let latest_clean_review_record_id = events
@@ -5980,18 +6013,35 @@ fn load_post_review_orchestration_marker(
 	snapshot: &PostReviewLaneSnapshot,
 	review_state: &PullRequestReviewState,
 	classification: &mut PostReviewLaneClassification,
-	runtime_state: Option<(&StateStore, &str)>,
+	runtime_state: Option<PostReviewRuntimeState<'_>>,
 ) -> crate::prelude::Result<Option<ReviewOrchestrationMarker>> {
 	let review_handoff = snapshot
 		.review_handoff
 		.as_ref()
 		.expect("review handoff should exist before orchestration classification");
-	let orchestration_marker = if let Some((state_store, project_id)) = runtime_state {
-		state_store.review_orchestration_marker(project_id, &snapshot.issue.id, review_handoff)?
+	let orchestration_marker = if let Some(runtime_state) = runtime_state {
+		runtime_state.state_store.review_orchestration_marker(
+			runtime_state.project_id,
+			&snapshot.issue.id,
+			review_handoff,
+		)?
 	} else {
 		None
 	};
 	let Some(orchestration_marker) = orchestration_marker else {
+		if clean_current_head_review_repair_writeback_pending(
+			snapshot,
+			review_state,
+			runtime_state,
+		)? {
+			classification.reason =
+				String::from("review_repair_writeback_missing_lifecycle_marker");
+			classification.readback_warning =
+				Some(String::from("review_repair_writeback_missing_lifecycle_marker"));
+
+			return Ok(None);
+		}
+
 		classification.reason = String::from("external_review_request_pending");
 
 		return Ok(None);
@@ -6000,12 +6050,130 @@ fn load_post_review_orchestration_marker(
 	if let Some(reason) =
 		validate_review_orchestration_marker(snapshot, review_state, &orchestration_marker)
 	{
+		if reason == "review_orchestration_head_mismatch"
+			&& clean_current_head_review_repair_writeback_pending(
+				snapshot,
+				review_state,
+				runtime_state,
+			)?
+		{
+			classification.reason =
+				String::from("review_repair_writeback_stale_lifecycle_marker");
+			classification.readback_warning =
+				Some(String::from("review_repair_writeback_stale_lifecycle_marker"));
+
+			return Ok(None);
+		}
+
 		*classification = blocked_post_review_lane_from_state(review_state, reason);
 
 		return Ok(None);
 	}
 
 	Ok(Some(orchestration_marker))
+}
+
+fn clean_current_head_review_repair_writeback_pending(
+	snapshot: &PostReviewLaneSnapshot,
+	review_state: &PullRequestReviewState,
+	runtime_state: Option<PostReviewRuntimeState<'_>>,
+) -> crate::prelude::Result<bool> {
+	let Some(runtime_state) = runtime_state else {
+		return Ok(false);
+	};
+	let Some(local_head_oid) = snapshot.local_head_oid.as_deref() else {
+		return Ok(false);
+	};
+
+	if review_state.head_ref_oid != local_head_oid
+		|| review_state.head_ref_name != snapshot.worktree.branch_name()
+	{
+		return Ok(false);
+	}
+
+	let events = runtime_state.state_store.list_private_execution_events_for_issue(
+		runtime_state.project_id,
+		&snapshot.issue.id,
+	)?;
+
+	for terminal_event in events.iter().rev() {
+		if !review_repair_terminal_finalize_event_matches_snapshot(terminal_event, snapshot) {
+			continue;
+		}
+
+		let Some(intent_event) = events.iter().rev().find(|event| {
+			event.run_id() == terminal_event.run_id()
+				&& event.attempt_number() == terminal_event.attempt_number()
+				&& review_repair_completion_intent_matches_current_head(
+					event,
+					snapshot,
+					review_state,
+					local_head_oid,
+				)
+		}) else {
+			continue;
+		};
+		let Some(checkpoint) = runtime_state
+			.state_store
+			.review_checkpoint_artifact(ReviewCheckpointArtifactLookup {
+				project_id: runtime_state.project_id,
+				issue_id: &snapshot.issue.id,
+				phase: "repair",
+				review_level: runtime_state.review_level.as_str(),
+				head_sha: local_head_oid,
+			})?
+		else {
+			continue;
+		};
+
+		if checkpoint.status() == "clean"
+			&& checkpoint.head_sha() == local_head_oid
+			&& checkpoint.run_id() == intent_event.run_id()
+			&& checkpoint.attempt_number() == intent_event.attempt_number()
+		{
+			return Ok(true);
+		}
+	}
+
+	Ok(false)
+}
+
+fn review_repair_terminal_finalize_event_matches_snapshot(
+	event: &PrivateExecutionEvent,
+	snapshot: &PostReviewLaneSnapshot,
+) -> bool {
+	let payload = event.payload();
+
+	event.event_type() == "terminal_finalize"
+		&& payload.get("path").and_then(Value::as_str) == Some("review_repair")
+		&& payload.get("mode").and_then(Value::as_str) == Some("repair")
+		&& payload.get("branch").and_then(Value::as_str) == Some(snapshot.worktree.branch_name())
+		&& payload
+			.get("worktree_path")
+			.and_then(Value::as_str)
+			== Some(snapshot.worktree.worktree_path().display().to_string().as_str())
+}
+
+fn review_repair_completion_intent_matches_current_head(
+	event: &PrivateExecutionEvent,
+	snapshot: &PostReviewLaneSnapshot,
+	review_state: &PullRequestReviewState,
+	local_head_oid: &str,
+) -> bool {
+	let payload = event.payload();
+
+	event.event_type() == "review_completion_intent"
+		&& payload.get("path").and_then(Value::as_str) == Some("review_repair")
+		&& payload.get("mode").and_then(Value::as_str) == Some("repair")
+		&& payload.get("branch").and_then(Value::as_str) == Some(snapshot.worktree.branch_name())
+		&& payload
+			.get("worktree_path")
+			.and_then(Value::as_str)
+			== Some(snapshot.worktree.worktree_path().display().to_string().as_str())
+		&& payload.get("pr_url").and_then(Value::as_str) == Some(review_state.url.as_str())
+		&& payload.get("pr_head_ref").and_then(Value::as_str)
+			== Some(review_state.head_ref_name.as_str())
+		&& payload.get("pr_head_oid").and_then(Value::as_str) == Some(local_head_oid)
 }
 
 fn apply_review_orchestration_phase_classification(
@@ -8034,8 +8202,11 @@ fn operator_run_default_review_phase(
 	if operator_run_has_terminal_lifecycle(status, phase, current_operation) {
 		return None;
 	}
+	if current_operation == RUN_OPERATION_REVIEW_WRITEBACK {
+		return Some("handoff");
+	}
 
-	Some("handoff")
+	None
 }
 
 fn operator_run_lifecycle_loop_summary(
@@ -8225,6 +8396,15 @@ fn operator_review_loop_status(
 	attempt_number: i64,
 	default_review_phase: Option<&str>,
 ) -> crate::prelude::Result<Option<OperatorReviewLoopStatus>> {
+	if let Some(checkpoint) = operator_latest_review_checkpoint_event_status(
+		loop_evidence,
+		issue_id,
+		run_id,
+		attempt_number,
+	) {
+		return Ok(Some(checkpoint));
+	}
+
 	let latest_checkpoint = ["handoff", "repair"]
 		.into_iter()
 		.filter_map(|phase| {
@@ -8271,6 +8451,64 @@ fn operator_review_loop_status(
 	}
 
 	Ok(None)
+}
+
+fn operator_latest_review_checkpoint_event_status(
+	loop_evidence: &ProjectLoopEvidenceSnapshot,
+	issue_id: &str,
+	run_id: &str,
+	attempt_number: i64,
+) -> Option<OperatorReviewLoopStatus> {
+	loop_evidence
+		.private_events(issue_id, run_id, attempt_number)
+		.iter()
+		.rev()
+		.find_map(|event| {
+			let payload = event.payload();
+
+			if event.event_type() != "review_checkpoint" {
+				return None;
+			}
+
+			let phase = payload.get("phase").and_then(Value::as_str)?;
+			let status = payload.get("status").and_then(Value::as_str)?;
+			let head_sha = payload.get("head_sha").and_then(Value::as_str)?;
+			let nonclean_rounds = payload
+				.get("nonclean_rounds")
+				.and_then(Value::as_i64)
+				.unwrap_or(0);
+			let checkpoint =
+				loop_evidence.review_policy_checkpoint(issue_id, run_id, attempt_number, phase)?;
+
+			if checkpoint.status() != status
+				|| checkpoint.head_sha() != head_sha
+				|| checkpoint.nonclean_rounds() != nonclean_rounds
+			{
+				return None;
+			}
+
+			let details_json = payload.get("review").unwrap_or(payload).to_string();
+			let summary = operator_review_checkpoint_summary_fields(&details_json);
+
+			Some(OperatorReviewLoopStatus {
+				phase: phase.to_owned(),
+				status: status.to_owned(),
+				checkpoint: Some(OperatorReviewCheckpointStatus {
+					head_sha: head_sha.to_owned(),
+					round: nonclean_rounds,
+					nonclean_rounds,
+					review_class: summary.review_class,
+					risk_class: summary.risk_class,
+					compact_eligible: summary.compact_eligible,
+					fallback_reason: summary.fallback_reason,
+					active_fingerprints: summary.active_fingerprints,
+					stop_fingerprint: summary.stop_fingerprint,
+					route_counts: summary.route_counts,
+					route_next_action: summary.route_next_action,
+					updated_at: checkpoint.updated_at().to_owned(),
+				}),
+			})
+		})
 }
 
 fn operator_review_checkpoint_summary_fields(
@@ -8689,6 +8927,12 @@ fn operator_loop_status_next_action(
 		}
 
 		match review.status.as_str() {
+			"clean" if review.phase == "handoff" => Some(String::from(
+				"Push or update the PR and record review handoff for the clean current lane head.",
+			)),
+			"clean" if review.phase == "repair" => Some(String::from(
+				"Record a fresh current-head handoff review checkpoint for the repaired lane head.",
+			)),
 			"pending" => Some(String::from(
 				"Record the independent Decodex Review checkpoint for the current lane head.",
 			)),
@@ -8901,7 +9145,8 @@ fn operator_run_protocol_summary(
 	marker: Option<&RunActivityMarker>,
 ) -> OperatorRunProtocolSummary {
 	let use_marker_protocol_summary =
-		run.event_count() == 0 && run.last_event_type().is_none() && run.last_event_at().is_none();
+		run.event_count() == 0 && run.last_event_type().is_none() && run.last_event_at().is_none()
+			|| marker_protocol_summary_supersedes_run(run, marker);
 
 	if use_marker_protocol_summary {
 		return OperatorRunProtocolSummary {
@@ -8918,6 +9163,27 @@ fn operator_run_protocol_summary(
 		last_event_at: run.last_event_at().map(str::to_owned),
 		event_count: run.event_count(),
 	}
+}
+
+fn marker_protocol_summary_supersedes_run(
+	run: &ProjectRunStatus,
+	marker: Option<&RunActivityMarker>,
+) -> bool {
+	let Some(marker) = marker else {
+		return false;
+	};
+	if marker.last_event_type().is_none() {
+		return false;
+	}
+
+	let Some(marker_event_at) = marker.last_protocol_activity_unix_epoch() else {
+		return false;
+	};
+
+	run.last_event_at_unix().is_none_or(|run_event_at| {
+		marker_event_at > run_event_at
+			|| marker_event_at == run_event_at && marker.event_count() > run.event_count()
+	})
 }
 
 fn operator_run_terminal_finalize_projection(
@@ -8946,7 +9212,11 @@ fn operator_run_terminal_finalize_projection(
 		"review_repair" => Some(OperatorTerminalFinalizeProjection {
 			status: "review_repair_pending",
 			phase: "terminal_pending",
-			wait_reason: "review_repair_writeback",
+			wait_reason: review_repair_terminal_finalize_wait_reason(
+				loop_evidence,
+				run,
+				events,
+			),
 			current_operation: RUN_OPERATION_REVIEW_WRITEBACK,
 		}),
 		"closeout" => Some(OperatorTerminalFinalizeProjection {
@@ -8991,6 +9261,53 @@ fn review_handoff_terminal_finalize_wait_reason(
 	}
 
 	"review_handoff_writeback"
+}
+
+fn review_repair_terminal_finalize_wait_reason(
+	loop_evidence: &ProjectLoopEvidenceSnapshot,
+	run: &ProjectRunStatus,
+	events: &[PrivateExecutionEvent],
+) -> &'static str {
+	let Some(intent) = events.iter().rev().find(|event| {
+		let payload = event.payload();
+
+		event.event_type() == "review_completion_intent"
+			&& payload.get("path").and_then(Value::as_str) == Some("review_repair")
+			&& payload.get("mode").and_then(Value::as_str) == Some("repair")
+			&& payload.get("pr_url").and_then(Value::as_str).is_some()
+			&& payload.get("pr_head_ref").and_then(Value::as_str).is_some()
+			&& payload.get("pr_head_oid").and_then(Value::as_str).is_some()
+			&& payload.get("worktree_path").and_then(Value::as_str).is_some()
+	}) else {
+		return "review_repair_writeback";
+	};
+	let payload = intent.payload();
+	let Some(branch) = payload.get("branch").and_then(Value::as_str) else {
+		return "review_repair_writeback";
+	};
+	let Some(pr_url) = payload.get("pr_url").and_then(Value::as_str) else {
+		return "review_repair_writeback";
+	};
+	let Some(pr_head_ref) = payload.get("pr_head_ref").and_then(Value::as_str) else {
+		return "review_repair_writeback";
+	};
+	let Some(pr_head_oid) = payload.get("pr_head_oid").and_then(Value::as_str) else {
+		return "review_repair_writeback";
+	};
+	let Some(lifecycle_record) = loop_evidence.review_lifecycle_record(run.issue_id(), branch)
+	else {
+		return "review_repair_writeback_missing_lifecycle_marker";
+	};
+
+	if lifecycle_record.pr_url() != pr_url
+		|| lifecycle_record.pr_head_ref_name() != pr_head_ref
+		|| lifecycle_record.pr_head_oid() != pr_head_oid
+		|| lifecycle_record.head_sha() != pr_head_oid
+	{
+		return "review_repair_writeback_stale_lifecycle_marker";
+	}
+
+	"review_repair_writeback"
 }
 
 fn operator_run_continuation_recovery_status(

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -9172,6 +9172,7 @@ fn marker_protocol_summary_supersedes_run(
 	let Some(marker) = marker else {
 		return false;
 	};
+
 	if marker.last_event_type().is_none() {
 		return false;
 	}

--- a/apps/decodex/src/orchestrator/tests/operator/status/http.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/http.rs
@@ -2088,12 +2088,9 @@ fn operator_lane_inspect_api_returns_lane_identity() {
 	assert_eq!(data["runs"][0]["runLease"], true);
 	assert_eq!(data["runs"][0]["ownershipState"], "leased_run");
 	assert_eq!(data["runs"][0]["livenessState"], "unknown");
-	assert_eq!(data["runs"][0]["policyState"], "review_pending");
+	assert_eq!(data["runs"][0]["policyState"], "allowed");
 	assert_eq!(data["runs"][0]["terminalizationState"], "none");
-	assert_eq!(
-		data["runs"][0]["laneControlNextAction"],
-		"Record the independent Decodex Review checkpoint for the current lane head."
-	);
+	assert_eq!(data["runs"][0]["laneControlNextAction"], "continue_owned_attempt");
 	assert_eq!(data["runs"][0]["threadId"], "thread-1");
 	assert_eq!(data["runs"][0]["turnId"], "turn-1");
 	assert_eq!(data["runs"][0]["softInterruptAvailable"], false);

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -1,5 +1,16 @@
 use records::LinearExecutionEventRecord;
 
+#[derive(Clone, Copy)]
+struct ReviewCheckpointSeed<'a> {
+	issue_id: &'a str,
+	run_id: &'a str,
+	phase: &'a str,
+	status: &'a str,
+	head_sha: &'a str,
+	nonclean_rounds: i64,
+	details_json: &'a str,
+}
+
 #[test]
 fn failure_comments_use_repo_relative_worktree_paths() {
 	let (_temp_dir, config, _workflow) = temp_project_layout();
@@ -55,6 +66,19 @@ fn operator_status_snapshot_includes_current_lanes_and_repo_relative_paths() {
 	assert_eq!(snapshot.current_lanes[0].run_id, "run-1");
 	assert_eq!(snapshot.current_lanes[0].phase, "executing");
 	assert_eq!(snapshot.current_lanes[0].current_operation, state::RUN_OPERATION_AGENT_RUN);
+	assert_eq!(snapshot.current_lanes[0].policy_state, "allowed");
+	assert_eq!(
+		snapshot.current_lanes[0].lane_control_next_action,
+		"continue_owned_attempt"
+	);
+	assert!(
+		snapshot.current_lanes[0]
+			.loop_status
+			.as_ref()
+			.and_then(|status| status.review.as_ref())
+			.is_none(),
+		"ordinary running lanes must not synthesize a pending review checkpoint"
+	);
 	assert_eq!(snapshot.current_lanes[0].thread_id.as_deref(), Some("thread-1"));
 	assert_eq!(snapshot.current_lanes[0].branch_name.as_deref(), Some("x/pubfi-pub-101"));
 	assert_eq!(snapshot.current_lanes[0].worktree_path.as_deref(), Some(".worktrees/PUB-101"));
@@ -75,6 +99,45 @@ fn operator_status_snapshot_includes_current_lanes_and_repo_relative_paths() {
 	);
 	assert_eq!(project.connector_state, "ok");
 	assert!(project.last_activity_at.is_some());
+
+	let rendered = orchestrator::render_operator_status(&snapshot);
+
+	assert!(!rendered.contains("Record the independent Decodex Review checkpoint"));
+}
+
+#[test]
+fn operator_status_does_not_synthesize_review_for_continuation_pending_attempt() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue("Todo", &[]);
+	let worktree_path = config.worktree_root().join("PUB-101");
+
+	state_store
+		.record_run_attempt("run-1", &issue.id, 1, "continuation_pending")
+		.expect("run attempt should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+		.expect("snapshot should build");
+	let run = snapshot.recent_runs.first().expect("recent run should exist");
+	let loop_status = run.loop_status.as_ref().expect("loop status should render");
+	let rendered = orchestrator::render_operator_status(&snapshot);
+
+	assert!(snapshot.current_lanes.is_empty());
+	assert_eq!(run.status, "continuation_pending");
+	assert_eq!(run.phase, "waiting_continuation");
+	assert_eq!(run.current_operation, state::RUN_OPERATION_WAITING_EXTERNAL);
+	assert_eq!(run.policy_state, "allowed");
+	assert!(loop_status.review.is_none());
+	assert_eq!(snapshot.projects[0].waiting_lane_count, 1);
+	assert!(!rendered.contains("Record the independent Decodex Review checkpoint"));
 }
 
 #[test]
@@ -1792,10 +1855,7 @@ fn idle_operator_status_snapshot_includes_configured_codex_accounts() {
 
 	assert!(snapshot.current_lanes.is_empty());
 	assert_eq!(snapshot_json["account_control"]["mode"], "balanced");
-	assert_eq!(
-		snapshot_json["account_control"]["account_selector"],
-		serde_json::Value::Null,
-	);
+	assert!(snapshot_json["account_control"]["account_selector"].is_null());
 	assert_eq!(accounts.len(), 2);
 	assert_eq!(accounts[0]["email"], "default@example.com");
 	assert_eq!(accounts[0]["status"], "available");
@@ -1858,7 +1918,7 @@ fn status_command_snapshot_does_not_probe_configured_codex_accounts() {
 	assert_eq!(accounts[0]["email"], "default@example.com");
 	assert_eq!(accounts[0]["status"], "available");
 	assert_eq!(accounts[0]["refresh_status"], "not_checked");
-	assert_eq!(accounts[0]["primary_remaining_percent"], serde_json::Value::Null);
+	assert!(accounts[0]["primary_remaining_percent"].is_null());
 	assert!(!snapshot.warnings.contains(&String::from("codex_accounts_unavailable")));
 }
 
@@ -3370,6 +3430,186 @@ fn operator_status_projects_terminal_finalized_handoff_missing_lifecycle_marker(
 	assert_eq!(run.current_operation, state::RUN_OPERATION_REVIEW_WRITEBACK);
 }
 
+#[test]
+fn operator_status_projects_terminal_finalized_repair_missing_lifecycle_marker() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let registration = ProjectRegistration::from_config(
+		config.service_id(),
+		&service_config_path(config.repo_root()),
+		&config,
+		true,
+		"test-fingerprint",
+	);
+	let issue = sample_issue("Todo", &[]);
+	let worktree_path = config.worktree_root().join("PUB-101");
+	let pr_head_oid = "08a20f7dfb9526e7421a5f095b1c6adec84e52d6";
+
+	state_store.upsert_project(&registration).expect("project should register");
+	state_store
+		.record_run_attempt("run-1", &issue.id, 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+	state_store
+		.append_private_execution_event(
+			"pubfi",
+			&issue.id,
+			"run-1",
+			1,
+			"review_completion_intent",
+			serde_json::json!({
+				"path": "review_repair",
+				"mode": "repair",
+				"branch": "x/pubfi-pub-101",
+				"worktree_path": worktree_path.display().to_string(),
+				"pr_url": "https://github.com/hack-ink/decodex/pull/101",
+				"pr_base_ref": "main",
+				"pr_head_ref": "x/pubfi-pub-101",
+				"pr_head_oid": pr_head_oid,
+				"summary": "Review repair is clean."
+			}),
+		)
+		.expect("repair intent should record");
+	state_store
+		.append_private_execution_event(
+			"pubfi",
+			&issue.id,
+			"run-1",
+			1,
+			"terminal_finalize",
+			serde_json::json!({
+				"path": "review_repair",
+				"mode": "repair",
+				"branch": "x/pubfi-pub-101",
+				"worktree_path": worktree_path.display().to_string(),
+			}),
+		)
+		.expect("terminal finalize event should record");
+
+	fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+
+	let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+		.expect("snapshot should build");
+	let run = snapshot
+		.recent_runs
+		.iter()
+		.find(|run| run.run_id == "run-1")
+		.expect("terminal-pending run should remain inspectable in recent runs");
+
+	assert_eq!(run.status, "review_repair_pending");
+	assert_eq!(run.phase, "terminal_pending");
+	assert_eq!(
+		run.wait_reason.as_deref(),
+		Some("review_repair_writeback_missing_lifecycle_marker")
+	);
+	assert_eq!(run.current_operation, state::RUN_OPERATION_REVIEW_WRITEBACK);
+}
+
+#[test]
+fn operator_status_projects_terminal_finalized_repair_stale_lifecycle_marker() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let registration = ProjectRegistration::from_config(
+		config.service_id(),
+		&service_config_path(config.repo_root()),
+		&config,
+		true,
+		"test-fingerprint",
+	);
+	let issue = sample_issue("Todo", &[]);
+	let worktree_path = config.worktree_root().join("PUB-101");
+	let old_head_oid = "1111111111111111111111111111111111111111";
+	let repaired_head_oid = "2222222222222222222222222222222222222222";
+
+	state_store.upsert_project(&registration).expect("project should register");
+	state_store
+		.record_run_attempt("run-1", &issue.id, 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+	state_store
+		.upsert_review_handoff_marker(
+			"pubfi",
+			&issue.id,
+			&ReviewHandoffMarker::new(
+				"run-old",
+				1,
+				"x/pubfi-pub-101",
+				"https://github.com/hack-ink/decodex/pull/101",
+				"main",
+				"x/pubfi-pub-101",
+				old_head_oid,
+			),
+		)
+		.expect("old review lifecycle should record");
+	state_store
+		.append_private_execution_event(
+			"pubfi",
+			&issue.id,
+			"run-1",
+			1,
+			"review_completion_intent",
+			serde_json::json!({
+				"path": "review_repair",
+				"mode": "repair",
+				"branch": "x/pubfi-pub-101",
+				"worktree_path": worktree_path.display().to_string(),
+				"pr_url": "https://github.com/hack-ink/decodex/pull/101",
+				"pr_base_ref": "main",
+				"pr_head_ref": "x/pubfi-pub-101",
+				"pr_head_oid": repaired_head_oid,
+				"summary": "Review repair is clean."
+			}),
+		)
+		.expect("repair intent should record");
+	state_store
+		.append_private_execution_event(
+			"pubfi",
+			&issue.id,
+			"run-1",
+			1,
+			"terminal_finalize",
+			serde_json::json!({
+				"path": "review_repair",
+				"mode": "repair",
+				"branch": "x/pubfi-pub-101",
+				"worktree_path": worktree_path.display().to_string(),
+			}),
+		)
+		.expect("terminal finalize event should record");
+
+	fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+
+	let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+		.expect("snapshot should build");
+	let run = snapshot
+		.recent_runs
+		.iter()
+		.find(|run| run.run_id == "run-1")
+		.expect("terminal-pending run should remain inspectable in recent runs");
+
+	assert_eq!(run.status, "review_repair_pending");
+	assert_eq!(run.phase, "terminal_pending");
+	assert_eq!(
+		run.wait_reason.as_deref(),
+		Some("review_repair_writeback_stale_lifecycle_marker")
+	);
+	assert_eq!(run.current_operation, state::RUN_OPERATION_REVIEW_WRITEBACK);
+}
+
 fn assert_terminal_pending_status_projection(snapshot: &OperatorStatusSnapshot) {
 	let project = snapshot.projects.first().expect("project summary should exist");
 	let run = snapshot
@@ -3410,18 +3650,18 @@ fn assert_terminal_pending_lane_inspect(state_store: &StateStore) {
 		.as_bytes(),
 	))
 	.expect("lane inspect response should be utf-8");
-	let data = operator_status_response_json_body(&response, "lane inspect");
+	let body = operator_status_response_body(&response, "lane inspect");
 
 	assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
-	assert_eq!(data["matchedRunCount"], 1);
-	assert_eq!(data["runs"][0]["status"], "review_handoff_pending");
-	assert_eq!(data["runs"][0]["phase"], "terminal_pending");
-	assert_eq!(data["runs"][0]["waitReason"], "review_handoff_writeback");
-	assert_eq!(data["runs"][0]["currentOperation"], state::RUN_OPERATION_REVIEW_WRITEBACK);
-	assert_eq!(data["runs"][0]["runLease"], false);
-	assert_eq!(data["runs"][0]["executionLiveness"], "not_running");
-	assert_eq!(data["runs"][0]["softInterruptAvailable"], false);
-	assert_eq!(data["runs"][0]["hardInterruptAvailable"], false);
+	assert!(body.contains(r#""matchedRunCount":1"#));
+	assert!(body.contains(r#""status":"review_handoff_pending""#));
+	assert!(body.contains(r#""phase":"terminal_pending""#));
+	assert!(body.contains(r#""waitReason":"review_handoff_writeback""#));
+	assert!(body.contains(r#""currentOperation":"review_writeback""#));
+	assert!(body.contains(r#""runLease":false"#));
+	assert!(body.contains(r#""executionLiveness":"not_running""#));
+	assert!(body.contains(r#""softInterruptAvailable":false"#));
+	assert!(body.contains(r#""hardInterruptAvailable":false"#));
 }
 
 fn assert_terminal_pending_interrupt_rejects_force(state_store: &StateStore) {
@@ -3437,21 +3677,19 @@ fn assert_terminal_pending_interrupt_rejects_force(state_store: &StateStore) {
 		.as_bytes(),
 	))
 	.expect("lane interrupt response should be utf-8");
-	let data = operator_status_response_json_body(&response, "lane interrupt");
+	let body = operator_status_response_body(&response, "lane interrupt");
 
 	assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
-	assert_eq!(data["classification"], "soft_interrupt_unavailable");
-	assert_eq!(data["softInterrupt"]["errorClass"], "lane_not_active");
-	assert_eq!(data["hardInterrupt"], Value::Null);
+	assert!(body.contains(r#""classification":"soft_interrupt_unavailable""#));
+	assert!(body.contains(r#""errorClass":"lane_not_active""#));
+	assert!(body.contains(r#""hardInterrupt":null"#));
 }
 
-fn operator_status_response_json_body(response: &str, context: &str) -> Value {
-	let body = response
+fn operator_status_response_body<'a>(response: &'a str, context: &str) -> &'a str {
+	response
 		.split_once("\r\n\r\n")
 		.map(|(_, body)| body)
-		.unwrap_or_else(|| panic!("{context} response should include body"));
-
-	serde_json::from_str(body).unwrap_or_else(|_| panic!("{context} response should be json"))
+		.unwrap_or_else(|| panic!("{context} response should include body"))
 }
 
 #[test]
@@ -3813,6 +4051,10 @@ fn operator_status_snapshot_rolls_current_child_bucket_elapsed_time_into_bucket(
 
 	assert_eq!(run.wait_reason.as_deref(), Some("tool_execution"));
 	assert_eq!(protocol_activity.waiting_reason.as_deref(), Some("tool_execution"));
+	assert_eq!(
+		snapshot.projects[0].waiting_lane_count, 0,
+		"normal active tool execution is running work, not project-level waiting"
+	);
 	assert_eq!(run.lifecycle_metrics.attempt_count, 1);
 	assert_eq!(run.lifecycle_metrics.captured_attempt_count, 1);
 	assert_eq!(run.lifecycle_metrics.tool_call_count, 1);
@@ -3939,6 +4181,176 @@ fn operator_status_current_lane_lifecycle_reconstructs_all_issue_attempts() {
 	assert_eq!(run.lifecycle_metrics.phases[1].wall_seconds, 300);
 
 	assert_compact_review_checkpoint_status(run);
+}
+
+#[test]
+fn operator_status_supersedes_stale_repair_findings_after_clean_handoff_checkpoint() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue(
+		"In Progress",
+		&[tracker::automation_active_label(TEST_SERVICE_ID).as_str()],
+	);
+	let run_id = "run-review";
+	let repair_head = "1111111111111111111111111111111111111111";
+	let clean_head = "2222222222222222222222222222222222222222";
+
+	state_store
+		.record_run_attempt(run_id, &issue.id, 2, "running")
+		.expect("review attempt should record");
+	state_store
+		.upsert_lease(TEST_SERVICE_ID, &issue.id, run_id, "In Progress")
+		.expect("lease should record");
+
+	let stale_repair_next_action = seed_stale_repair_and_clean_handoff_checkpoints(
+		&state_store,
+		&config,
+		&issue.id,
+		run_id,
+		repair_head,
+		clean_head,
+	);
+	let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 0)
+		.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("current lane should exist");
+	let loop_status = run.loop_status.as_ref().expect("loop status should render");
+	let review = loop_status.review.as_ref().expect("review status should render");
+	let checkpoint = review.checkpoint.as_ref().expect("review checkpoint should render");
+
+	assert_eq!(review.phase, "handoff");
+	assert_eq!(review.status, "clean");
+	assert_eq!(checkpoint.head_sha, clean_head);
+	assert!(checkpoint.active_fingerprints.is_empty());
+	assert_eq!(run.policy_state, "allowed");
+	assert_eq!(
+		run.lane_control_next_action,
+		"Push or update the PR and record review handoff for the clean current lane head."
+	);
+	assert_ne!(loop_status.next_action.as_deref(), Some(stale_repair_next_action));
+}
+
+fn seed_stale_repair_and_clean_handoff_checkpoints(
+	state_store: &StateStore,
+	config: &ServiceConfig,
+	issue_id: &str,
+	run_id: &str,
+	repair_head: &str,
+	clean_head: &str,
+) -> &'static str {
+	let stale_repair_next_action = "Repair the stale review finding.";
+	let repair_details_json = r#"{
+		"finding_route_summary": {
+			"route_counts": [{"route": "current_blocker", "count": 1}],
+			"next_action": "Repair the stale review finding."
+		},
+		"finding_policy": {
+			"active_fingerprints": ["stale-finding"],
+			"stop_fingerprint": null
+		}
+	}"#;
+	let clean_details_json = r#"{
+		"review_cost_control": {
+			"review_class": "full_current_head_review",
+			"risk_class": "localized",
+			"compact_eligible": false,
+			"fallback_reason": "repair_review"
+		},
+		"finding_route_summary": {
+			"route_counts": [],
+			"next_action": null
+		},
+		"finding_policy": {
+			"active_fingerprints": [],
+			"stop_fingerprint": null
+		}
+	}"#;
+
+	seed_review_policy_checkpoint_with_event(
+		state_store,
+		config,
+		ReviewCheckpointSeed {
+			issue_id,
+			run_id,
+			phase: "repair",
+			status: "findings",
+			head_sha: repair_head,
+			nonclean_rounds: 1,
+			details_json: repair_details_json,
+		},
+	);
+	seed_review_policy_checkpoint_with_event(
+		state_store,
+		config,
+		ReviewCheckpointSeed {
+			issue_id,
+			run_id,
+			phase: "handoff",
+			status: "clean",
+			head_sha: clean_head,
+			nonclean_rounds: 0,
+			details_json: clean_details_json,
+		},
+	);
+	seed_review_policy_checkpoint(
+		state_store,
+		config,
+		ReviewCheckpointSeed {
+			issue_id,
+			run_id,
+			phase: "repair",
+			status: "findings",
+			head_sha: repair_head,
+			nonclean_rounds: 1,
+			details_json: repair_details_json,
+		},
+	);
+
+	stale_repair_next_action
+}
+
+fn seed_review_policy_checkpoint_with_event(
+	state_store: &StateStore,
+	config: &ServiceConfig,
+	seed: ReviewCheckpointSeed<'_>,
+) {
+	seed_review_policy_checkpoint(state_store, config, seed);
+
+	state_store
+		.append_private_execution_event(
+			TEST_SERVICE_ID,
+			seed.issue_id,
+			seed.run_id,
+			2,
+			"review_checkpoint",
+			serde_json::json!({
+				"phase": seed.phase,
+				"status": seed.status,
+				"head_sha": seed.head_sha,
+				"nonclean_rounds": seed.nonclean_rounds
+			}),
+		)
+		.expect("review checkpoint event should record");
+}
+
+fn seed_review_policy_checkpoint(
+	state_store: &StateStore,
+	config: &ServiceConfig,
+	seed: ReviewCheckpointSeed<'_>,
+) {
+	state_store
+		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
+			project_id: TEST_SERVICE_ID,
+			issue_id: seed.issue_id,
+			run_id: seed.run_id,
+			attempt_number: 2,
+			phase: seed.phase,
+			review_level: config.codex().review_level().as_str(),
+			status: seed.status,
+			head_sha: seed.head_sha,
+			nonclean_rounds: seed.nonclean_rounds,
+			details_json: seed.details_json,
+		})
+		.expect("review policy checkpoint should record");
 }
 
 fn assert_compact_review_checkpoint_status(run: &OperatorRunStatus) {
@@ -4160,7 +4572,58 @@ fn operator_status_snapshot_uses_structured_protocol_activity_summary() {
 
 	assert_eq!(run.wait_reason.as_deref(), Some("approval_or_user_input"));
 	assert_eq!(run.protocol_activity.as_ref(), Some(&protocol_activity));
+	assert_eq!(
+		snapshot.projects[0].waiting_lane_count, 1,
+		"approval or user-input waits should remain project-level waiting"
+	);
 	assert!(rendered.contains("protocol_activity: turn=running; waiting=approval_or_user_input; rate_limit=primary; recent=item/tool/requestUserInput, plan/update:verify"));
+}
+
+#[test]
+fn operator_status_snapshot_prefers_newer_protocol_marker_over_stale_archive_event() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue("Todo", &[]);
+	let worktree_path = config.worktree_root().join("PUB-101");
+
+	state_store
+		.record_run_attempt("run-1", &issue.id, 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", &issue.id, "run-1", "In Progress")
+		.expect("lease should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+	state_store
+		.append_event("run-1", 1, "thread/archive/discarded", "{}")
+		.expect("archive event should record");
+	state::write_run_protocol_activity_marker(
+		&worktree_path,
+		&ProtocolActivityMarker {
+			run_id: "run-1",
+			attempt_number: 1,
+			thread_id: Some("thread-1"),
+			turn_id: Some("turn-1"),
+			event_count: 2,
+			last_event_type: "item/tool/call",
+			child_agent_activity: None,
+			protocol_activity: None,
+		},
+	)
+	.expect("protocol activity marker should write");
+
+	let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+		.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("current lane should exist");
+
+	assert_eq!(run.last_event_type.as_deref(), Some("item/tool/call"));
+	assert_eq!(run.event_count, 2);
 }
 
 #[test]

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -4603,6 +4603,7 @@ fn operator_status_snapshot_prefers_newer_protocol_marker_over_stale_archive_eve
 	state_store
 		.append_event("run-1", 1, "thread/archive/discarded", "{}")
 		.expect("archive event should record");
+
 	state::write_run_protocol_activity_marker(
 		&worktree_path,
 		&ProtocolActivityMarker {

--- a/apps/decodex/src/orchestrator/tests/operator/status/text.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/text.rs
@@ -985,10 +985,10 @@ fn operator_status_json_and_text_surface_loop_review_and_recovery_state() {
 	let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
 		.expect("snapshot should build");
 	let snapshot_json = serde_json::to_value(&snapshot).expect("snapshot should serialize");
-	let pending = current_lane_json(&snapshot_json, "run-pending");
-	let clean = current_lane_json(&snapshot_json, "run-clean");
-	let findings = current_lane_json(&snapshot_json, "run-findings");
-	let blocked = current_lane_json(&snapshot_json, "run-blocked");
+	let pending = status_run_json(&snapshot_json, "run-pending");
+	let clean = status_run_json(&snapshot_json, "run-clean");
+	let findings = status_run_json(&snapshot_json, "run-findings");
+	let blocked = status_run_json(&snapshot_json, "run-blocked");
 
 	assert_eq!(pending["loop_status"]["review_level"], "strict");
 	assert_eq!(pending["loop_status"]["review"]["status"], "pending");
@@ -1025,7 +1025,9 @@ fn operator_status_json_and_text_surface_loop_review_and_recovery_state() {
 
 	let rendered = orchestrator::render_operator_status(&snapshot);
 
-	assert!(rendered.contains("loop_review: phase=handoff status=pending checkpoint=none"));
+	assert!(rendered.contains(
+		"loop_review: phase=handoff status=pending checkpoint=head:0000000000000000000000000000000000000000 round:0"
+	));
 	assert!(rendered.contains("loop_review: phase=handoff status=findings checkpoint=head:2222222222222222222222222222222222222222 round:2"));
 	assert!(rendered.contains(
 		"loop_architecture_recovery: status=active reason=architecture_recovery_started"
@@ -1055,6 +1057,20 @@ fn seed_loop_status_runs(state_store: &StateStore, config: &ServiceConfig) {
 }
 
 fn seed_loop_status_review_checkpoints(state_store: &StateStore, config: &ServiceConfig) {
+	state_store
+		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
+			project_id: config.service_id(),
+			issue_id: "issue-pending",
+			run_id: "run-pending",
+			attempt_number: 1,
+			phase: "handoff",
+			review_level: config.codex().review_level().as_str(),
+			status: "pending",
+			head_sha: "0000000000000000000000000000000000000000",
+			nonclean_rounds: 0,
+			details_json: "{}",
+		})
+		.expect("pending checkpoint should record");
 	state_store
 		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
 			project_id: config.service_id(),
@@ -1166,13 +1182,19 @@ fn seed_loop_status_private_events(state_store: &StateStore, config: &ServiceCon
 		.expect("decision request should record");
 }
 
-fn current_lane_json<'a>(snapshot_json: &'a Value, run_id: &str) -> &'a Value {
-	snapshot_json["current_lanes"]
-		.as_array()
-		.expect("current lanes should be an array")
-		.iter()
-		.find(|run| run["run_id"] == run_id)
-		.unwrap_or_else(|| panic!("current lane `{run_id}` should exist"))
+fn status_run_json<'a>(snapshot_json: &'a Value, run_id: &str) -> &'a Value {
+	for collection in ["current_lanes", "recent_runs"] {
+		if let Some(run) = snapshot_json[collection]
+			.as_array()
+			.expect("status run collection should be an array")
+			.iter()
+			.find(|run| run["run_id"] == run_id)
+		{
+			return run;
+		}
+	}
+
+	panic!("status run `{run_id}` should exist")
 }
 
 #[test]

--- a/apps/decodex/src/orchestrator/tests/review_landing/status_rows.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing/status_rows.rs
@@ -79,6 +79,204 @@ fn build_post_review_lane_statuses_reports_ready_to_land() {
 }
 
 #[test]
+fn build_post_review_lane_statuses_waits_when_clean_repair_head_outruns_lifecycle_marker() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let issue = sample_issue("In Review", &[]);
+	let tracker =
+		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let pr_url = "https://github.com/hack-ink/decodex/pull/173";
+	let (worktree, repaired_head_oid) =
+		retained_worktree_with_stale_review_lifecycle_marker(
+			&config,
+			&state_store,
+			&issue,
+			pr_url,
+		);
+
+	seed_clean_repair_completion_writeback_gap(
+		&config,
+		&state_store,
+		&issue,
+		&worktree,
+		pr_url,
+		&repaired_head_oid,
+	);
+
+	let review_state = sample_pull_request_review_state(
+		pr_url,
+		&worktree.branch_name,
+		&repaired_head_oid,
+		Some("APPROVED"),
+		"MERGEABLE",
+		"CLEAN",
+		Some("SUCCESS"),
+		0,
+	);
+	let lanes = orchestrator::build_post_review_lane_statuses(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		&FakePullRequestReviewStateInspector::new(vec![Ok(review_state)]),
+	)
+	.expect("post-review lane status build should succeed");
+
+	assert_eq!(lanes.len(), 1);
+	assert_eq!(lanes[0].classification, "wait_for_review");
+	assert_eq!(lanes[0].reason, "review_repair_writeback_stale_lifecycle_marker");
+	assert_eq!(
+		lanes[0].readback_warning.as_deref(),
+		Some("review_repair_writeback_stale_lifecycle_marker")
+	);
+}
+
+fn retained_worktree_with_stale_review_lifecycle_marker(
+	config: &ServiceConfig,
+	state_store: &StateStore,
+	issue: &TrackerIssue,
+	pr_url: &str,
+) -> (WorktreeSpec, String) {
+	let worktree_manager =
+		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
+	let worktree = worktree_manager
+		.ensure_worktree(&issue.identifier, false)
+		.expect("worktree should exist");
+	let old_head_oid = git_head_oid_for_worktree(&worktree);
+
+	state_store
+		.upsert_worktree(
+			config.service_id(),
+			&issue.id,
+			&worktree.branch_name,
+			&worktree.path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	seed_review_orchestration_marker_for_path(
+		state_store,
+		config.service_id(),
+		&worktree.path,
+		&sample_review_orchestration_marker(
+			&worktree.branch_name,
+			pr_url,
+			&old_head_oid,
+			"waiting_for_result",
+			1,
+		),
+	);
+
+	let repaired_head_oid = commit_empty_repair_head_for_worktree(&worktree);
+
+	(worktree, repaired_head_oid)
+}
+
+fn git_head_oid_for_worktree(worktree: &WorktreeSpec) -> String {
+	String::from_utf8(
+		Command::new("git")
+			.arg("-C")
+			.arg(&worktree.path)
+			.args(["rev-parse", "HEAD"])
+			.output()
+			.expect("git rev-parse should run")
+			.stdout,
+	)
+	.expect("git output should be utf-8")
+	.trim()
+	.to_owned()
+}
+
+fn commit_empty_repair_head_for_worktree(worktree: &WorktreeSpec) -> String {
+	assert!(
+		Command::new("git")
+			.arg("-C")
+			.arg(&worktree.path)
+			.args([
+				"-c",
+				"user.name=Decodex Test",
+				"-c",
+				"user.email=decodex-test@example.invalid",
+				"commit",
+				"--allow-empty",
+				"-m",
+				"repair head",
+			])
+			.status()
+			.expect("git commit should run")
+			.success()
+	);
+
+	git_head_oid_for_worktree(worktree)
+}
+
+fn seed_clean_repair_completion_writeback_gap(
+	config: &ServiceConfig,
+	state_store: &StateStore,
+	issue: &TrackerIssue,
+	worktree: &WorktreeSpec,
+	pr_url: &str,
+	repaired_head_oid: &str,
+) {
+	state_store
+		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
+			project_id: config.service_id(),
+			issue_id: &issue.id,
+			run_id: "run-repair",
+			attempt_number: 2,
+			phase: "repair",
+			review_level: config.codex().review_level().as_str(),
+			status: "clean",
+			head_sha: repaired_head_oid,
+			nonclean_rounds: 0,
+			details_json: "{}",
+		})
+		.expect("clean repair checkpoint should record");
+	state_store
+		.clear_review_policy_checkpoints_for_run_attempt(
+			config.service_id(),
+			&issue.id,
+			"run-repair",
+			2,
+		)
+		.expect("active repair checkpoint row should clear after completion");
+	state_store
+		.append_private_execution_event(
+			config.service_id(),
+			&issue.id,
+			"run-repair",
+			2,
+			"review_completion_intent",
+			serde_json::json!({
+				"path": "review_repair",
+				"mode": "repair",
+				"branch": &worktree.branch_name,
+				"worktree_path": worktree.path.display().to_string(),
+				"pr_url": pr_url,
+				"pr_base_ref": "main",
+				"pr_head_ref": &worktree.branch_name,
+				"pr_head_oid": repaired_head_oid,
+				"summary": "Review repair is clean."
+			}),
+		)
+		.expect("repair completion intent should record");
+	state_store
+		.append_private_execution_event(
+			config.service_id(),
+			&issue.id,
+			"run-repair",
+			2,
+			"terminal_finalize",
+			serde_json::json!({
+				"path": "review_repair",
+				"mode": "repair",
+				"branch": &worktree.branch_name,
+				"worktree_path": worktree.path.display().to_string(),
+			}),
+		)
+		.expect("repair terminal finalize should record");
+}
+
+#[test]
 fn build_post_review_lane_statuses_preserves_handoff_marker_when_pr_readback_fails() {
 	let (_temp_dir, config, workflow) = temp_project_layout();
 	let repo_root = config.repo_root().to_path_buf();

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,16 @@
 
 ## 2026-06-22
 
+- Tightened operator review-control projection so ordinary running lanes no longer
+  synthesize pending Decodex Review checkpoints, stale repair checkpoint rows cannot
+  override newer clean checkpoint events, and clean review-repair terminal writeback
+  gaps surface deterministic missing/stale lifecycle-marker reasons instead of
+  reviving old repair control.
+- Tightened operator status project metrics and protocol readback after live-history
+  audit: ordinary fresh model/tool/repo-gate execution no longer inflates
+  project-level waiting counts, continuation-pending attempts no longer inherit
+  synthetic review prompts, and newer current-attempt marker events supersede stale
+  durable maintenance events such as archive readback.
 - Promoted the final autonomy architecture into authoritative docs: Decodex autonomy
   is now specified as an objective-driven project control plane with first-class
   Objective Contracts, typed signals, non-executable proposals, explicit

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -305,6 +305,11 @@ no visible local work. Neither
 state is, by itself, evidence that the
 Linear tracker or GitHub connector failed; confirm the central project registry and
 service queue label before treating it as a connector problem.
+The `Work.waiting` project number is a blocked/deferred-work summary: retry backoff,
+continuation waits, explicit external waits, operator or user-input waits, protocol
+idleness, queued waiting candidates, and unshadowed wait-for-review lanes. Normal
+fresh model, tool, and repo-gate execution remains running work even when the lane row
+shows detailed wait/tone diagnostics.
 
 The browser dashboard and Decodex App read the complete published operator state from
 the local `GET /dashboard/control` WebSocket. That socket is the dashboard/App
@@ -384,8 +389,8 @@ protocol activity durable outside the local operator surface.
 | Section | Meaning |
 | --- | --- |
 | `Accounts` | Shared Codex account pool and usage table from `~/.codex/decodex/accounts.jsonl` when `[codex.accounts]` is enabled for a project. Account identity can be obscured from the `Account` column header eye without changing the underlying snapshot. The row weight column shows the capacity multiplier used for pool usage estimates: `pro` accounts count as `20x`, and all other plans count as `1x`. Usage probes read Codex `/wham/usage` for window capacity and `/wham/profiles/me` for profile token stats such as lifetime tokens, peak daily tokens, longest task, streaks, and daily token activity. Refresh authentication failures are persisted as `auth_failed` on the matching account, excluded from later selection, and surfaced with login recovery rather than retry-probe recovery. Selecting an account writes the global `[codex.accounts].fixed_account` selector in `~/.codex/decodex/config.toml`; clearing it returns all new account-pool runs to balanced account selection. Account display-name rerolls write `[codex.account_names.offsets]` in the same global config so Decodex App and the dashboard share the privacy-preserving names. Theme, sort, and identity-visibility preferences are client-local presentation state. The selector is global and does not pin a project to an account. |
-| `Projects` | Fleet-level project table. The section-level filter toggles between active project work and the full registry. Location is its own compact path column and can be obscured from the location header eye. `Activity` shows a relative timestamp or `-`; `Work` is `running/waiting/attention`. It should not duplicate per-lane details already shown below. |
-| `Running Lanes` | Active leased or live-executing issue lanes. A lane here is currently owned by this local control plane, or a live process/thread/protocol marker still explains active execution even when the queue lease is not held. It shows issue identity, phase, operation, attempt, queue lease state, execution liveness, thread/protocol status, child-agent activity when captured, phase-goal status when app-server reports it, timing, branch, and worktree. |
+| `Projects` | Fleet-level project table. The section-level filter toggles between active project work and the full registry. Location is its own compact path column and can be obscured from the location header eye. `Activity` shows a relative timestamp or `-`; `Work` is `running/waiting/attention`. Its waiting number summarizes blocked/deferred work and should not duplicate per-lane diagnostics already shown below. |
+| `Running Lanes` | Active leased or live-executing issue lanes. A lane here is currently owned by this local control plane, or a live process/thread/protocol marker still explains active execution even when the queue lease is not held. It shows issue identity, phase, operation, attempt, queue lease state, execution liveness, thread/protocol status, child-agent activity when captured, phase-goal status when app-server reports it, timing, branch, and worktree. For the same run/attempt, newer marker protocol summary supersedes stale durable event readback so current tool/model activity is not hidden behind older maintenance events. |
 | `Program Intake` | Read-only Program Intake and Execution Program progress. It shows each active program's public intake summary, status, mapped issue identifiers, summary counts, dispatchable counts, and sparse node diagnostics for dispatch decisions or held/blocked/stale/attention nodes. It does not expose graph editing, raw node-edge mutation controls, Decision Contract payloads, or private runtime evidence. |
 | `Intake Queue` | Queued tracker issues before execution. Candidates are classified as `ready`, capacity-waiting, claimed without a matching local lane, blocked, or closed/stale. Repeated identical open dependency blockers surface as `dependency_program_stale` after the guardrail threshold so operators can distinguish a stale Execution Program/dependency plan from a newly blocked queue item. A queued candidate whose retained worktree already has a matching review lifecycle record is blocked with `review_handoff_state_transition_pending`; post-review recovery, review repair, landing, or closeout owns the next step instead of ordinary intake. A blocked queued candidate can still show an attached `.worktrees/XY-*` path when the queue owns the attention state; if that worktree has tracked changes after stalled reconciliation, failure writeback, or retries, the candidate is partial retained progress and not just a generic stalled or retry-budget hold. If the worktree is clean but stale active ownership remains after failed-start retry accounting, the candidate is failed-start cleanup debt rather than retained partial progress only when private evidence has no open issue-level phase continuation such as `handoff_evidence`. Human-required authority stops expose their compact decision request fields here: `phase = human_required`, reason, boundary, `decision_request_id`, and `next_action`. When queued attention still maps to a run/attempt, it also carries the same compact loop status used by running lanes. Running lanes are not repeated as normal intake work. |
 | `Review & Landing` | Retained PR lanes after review handoff. This section owns post-review repair, wait-for-review, ready-to-land, closeout, cleanup, and blocked retained-lane visibility. Retained lanes expose compact loop status for their bound handoff run/attempt so operators can see review repair checkpoint state, architecture recovery stops, and boundary/human-required disposition without direct SQLite inspection. |
@@ -764,6 +769,11 @@ map to an operator decision.
   Decodex is finishing the terminal path. They are not active execution, do not hold a
   queue lease, do not count as suspected stalls, and should not expose hard-interrupt
   fallback as an available control.
+  Handoff and repair writeback gaps must use deterministic wait reasons such as
+  `review_handoff_writeback_missing_lifecycle_marker`,
+  `review_repair_writeback_missing_lifecycle_marker`, or
+  `review_repair_writeback_stale_lifecycle_marker` instead of projecting an ordinary
+  implementation lane as pending review work.
 - Child-agent activity comes from `.decodex-run-activity` when the app-server recorder
   captured model/tool/tracker/browser/image buckets.
 - The child-agent breakdown is diagnostic. It explains where observed wall time went;
@@ -773,6 +783,11 @@ map to an operator decision.
 - Review-policy checkpoint state comes from runtime SQLite, not marker files. Legacy
   marker fields such as `review_policy_status` may explain an old worktree, but they
   must not override the store-backed checkpoint row for handoff or repair gating.
+  Ordinary running implementation lanes with no current checkpoint must remain
+  `policy_state = allowed` with `lane_control_next_action = continue_owned_attempt`;
+  status may synthesize a pending review only for an in-progress review-writeback
+  operation or from current runtime checkpoint evidence. Terminal writeback gaps use
+  terminal lifecycle summaries and deterministic wait reasons instead.
 
 The dashboard should avoid pretending that every bucket has a fixed total budget.
 When a row is event-only or sub-second, the UI should present it as diagnostic event

--- a/docs/spec/post-review-lifecycle.md
+++ b/docs/spec/post-review-lifecycle.md
@@ -332,6 +332,17 @@ human intervention. If the checkpoint reports `needs_architecture_review` /
 `"off"` or `"basic"`, retained repair completion skips that Decodex Review checkpoint
 requirement but still requires the repaired head to be pushed and the configured
 repository validation gate to pass.
+During the narrow interval after `issue_review_repair_complete` and
+`issue_terminal_finalize(path = "review_repair")` are recorded but before the retained
+`review_lifecycle_records` row has been refreshed to the repaired PR head, operator
+status must treat the exact private completion intent plus current-head clean repair
+checkpoint artifact as transitional writeback evidence. That transition may surface
+`review_repair_writeback_missing_lifecycle_marker` or
+`review_repair_writeback_stale_lifecycle_marker`, but it must not revive stale repair
+findings, request a duplicate review checkpoint, or classify the repaired lane as a
+new ordinary implementation run. The transition is valid only when the issue, branch,
+run attempt, PR URL, PR head ref, PR head OID, local `HEAD`, and clean repair
+checkpoint artifact all match.
 Every retained repair completion, regardless of review level, also requires the latest
 private `issue_progress_checkpoint` for the current run attempt to include parseable
 `docs_impact` and a `head_sha` matching the repaired lane `HEAD`; `review_repair`

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -7,8 +7,8 @@ authority: normative
 owner: runtime
 tags: [spec]
 code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/autonomy_signal.rs, apps/decodex/src/autonomy_proposal.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/mcp.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs, apps/decodex/src/config.rs, decodex.example.toml]
-drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, protocol_events, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, decodex intake goal, program_issue_mappings, autonomy_proposals, decodex.autonomy_proposal/1, "[autonomy]", auto_promote, auto_intake, "[autonomy.runtime_policy]", accepted_objective_id, accepted_objective_version, accepted_policy_id, accepted_policy_version, policy_authority_ref]
-last_verified: 2026-06-22
+drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, protocol_events, review_policy_checkpoints, review_checkpoint, review_lifecycle_records, lane_control_next_action, review_handoff_pending, review_repair_pending, review_repair_writeback_missing_lifecycle_marker, review_repair_writeback_stale_lifecycle_marker, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, decodex intake goal, program_issue_mappings, autonomy_proposals, decodex.autonomy_proposal/1, "[autonomy]", auto_promote, auto_intake, "[autonomy.runtime_policy]", accepted_objective_id, accepted_objective_version, accepted_policy_id, accepted_policy_version, policy_authority_ref]
+last_verified: 2026-06-23
 ---
 # Runtime Specification
 
@@ -590,6 +590,12 @@ operator status and private evidence readback may expose route counts and one
 route-derived next action, but not raw reviewer finding bodies. Linear receives only
 coarse lifecycle projections; raw reviewer findings stay in local runtime evidence
 unless another allowlisted lifecycle summary renders a public-safe summary.
+Operator status must treat the newest matching private `review_checkpoint` event for
+the same project, issue, run id, attempt, phase, status, head, and nonclean-round
+count as the active loop-review readback before falling back to the per-phase
+`review_policy_checkpoints` rows. Older per-phase rows remain repair history, but a
+stale `repair` row must not keep `lane_control_next_action` on old finding repair
+instructions after a newer current-head clean `handoff` checkpoint has been recorded.
 Recording `issue_review_handoff` or `issue_review_repair_complete` clears the current
 run-attempt `review_policy_checkpoints` row for that phase after the reusable clean
 evidence artifact has been consumed.
@@ -873,11 +879,21 @@ is still safe to preserve, operator-local status may expose a typed
 GitHub auth failure, API/read failure, parse/shape failure, or lineage validation
 failure while keeping public-safe warning reasons such as
 `pull_request_state_read_failed` stable. The retained lifecycle controller must
-preserve the post-review classification decision when it converts status readback into
-runtime action: only a non-shadowed `Block` classification may write passive retained
-manual attention or add `decodex:needs-attention`; degraded readback classified as
-`WaitForReview` must remain a wait/retry status row and must not be promoted to
-manual attention by the run-cycle path.
+distinguish clean review-repair writeback debt from unresolved review findings. When a
+terminalized `review_repair` attempt has a matching repair completion intent for the
+current retained worktree branch, PR URL, PR head ref, and local/PR head OID, and the
+runtime still has a clean reusable repair checkpoint artifact for that same head, a
+missing or stale review lifecycle marker is a typed pending writeback condition
+(`review_repair_writeback_missing_lifecycle_marker` or
+`review_repair_writeback_stale_lifecycle_marker`). Status may keep the retained lane
+in `wait_for_review` while that writeback catches up, but it must not re-project old
+review-finding repair instructions or request a new external review from stale
+lifecycle state. The retained lifecycle controller must preserve the post-review
+classification decision when it converts status readback into runtime action: only a
+non-shadowed `Block` classification may write passive retained manual attention or add
+`decodex:needs-attention`; degraded readback classified as `WaitForReview` must remain
+a wait/retry status row and must not be promoted to manual attention by the run-cycle
+path.
 The only source-tree runtime artifacts that clean-source checks may ignore are the untracked top-level `.decodex-run-activity` heartbeat marker and `.decodex-run-control/` local control-channel directory. Durable review lifecycle records, review-policy checkpoints, retry, phase timing, and retained PR state belong in the Decodex runtime database, not in root-level or worktree-local review marker files. If the heartbeat marker carries similarly named fields for compatibility or operator diagnostics, those breadcrumb values cannot override runtime-store rows.
 
 ### Dispatch-slot handoff invariant
@@ -1033,6 +1049,22 @@ After a process restart, recent-run history, run lease ownership, retained post-
 - If stalled reconciliation finds no tracked changes in the retained worktree, it must classify the lane as structured retryable recovery with `error_class = "stalled_run_detected"` while retry budget remains. The retry must keep active ownership, write a failure retry schedule for the same worktree, and must not add `decodex:needs-attention` until retry budget exhaustion or another terminal boundary applies.
 - If the supervised child already exited before the next control-plane tick, stalled reconciliation must still inspect the just-finished lane using recorded protocol activity and retained worktree state rather than skipping directly to generic failure handling.
 - Operator status snapshots must expose structured liveness and wait-state fields derived from runtime records plus marker breadcrumbs, including explicit `run_phase`, optional wait reason, `current_operation`, optional `active_goal_phase`, optional `public_progress_phase`, last run/protocol/progress times, idle age, a soft `suspected_stall` signal, optional progress diagnostics, and any queued retry kind plus due time, so operators can distinguish active execution from continuation waits, retry backoff, early stall suspicion, and genuine hard stalls without inferring progress from filesystem churn. The snapshot producer owns the derived operator booleans `has_fresh_execution`, `counts_as_running`, and `needs_attention`; dashboard, App, and other UI consumers must use those fields when present instead of reinterpreting raw `process_alive`, thread, protocol, or idle fields independently. The snapshot producer also owns `shadowed_by_current_lane` on retained post-review lanes, and current project review, waiting, attention, landing, and cleanup counts must exclude lanes shadowed by fresh active execution for the same issue. `process_alive = false` is only process-marker evidence and must not be displayed as stopped when `has_fresh_execution = true`. `last_progress_at` is meaningful-work progress only: tool calls, file or diff changes, plan/model output, repo validation, PR/review/terminal lifecycle, or other explicit work events may refresh it, but account, rate-limit, phase-goal, passive status, warning, token-usage, heartbeat, or similar non-work protocol traffic must only refresh protocol liveness. When a lane remains in `model_execution` with fresh protocol activity but stale or missing work progress and the recent protocol events are only non-work traffic, status should expose `progress_diagnostic = "protocol_only_activity"` while preserving process and protocol liveness separately.
+- Project-level `waiting_lane_count` is a fleet-summary count of blocked or deferred
+  work, not a duplicate of every lane card that has a local wait reason. It counts
+  retry backoff, continuation waits, explicit external waits, operator/user-input
+  waits, protocol idleness waits, queued waiting candidates, and unshadowed
+  wait-for-review lanes. It must not count ordinary fresh execution in
+  `model_execution`, `tool_execution`, or repo-gate execution as project-level waiting
+  just because the lane has a diagnostic wait reason; those lanes remain running work
+  while the lane row may still show the detailed operation and wait/tone fields.
+- Operator status must not synthesize a pending Decodex Review checkpoint for every
+  ordinary leased running lane. Pending review-checkpoint readback is reserved for
+  current checkpoint state bound to the same project, issue, run id, and attempt, or
+  for a non-terminal review-writeback operation. Terminal states such as
+  `review_handoff_pending` and `review_repair_pending` use terminal lifecycle
+  summaries and deterministic wait reasons instead. A normal running lane with no
+  review writeback or checkpoint evidence remains policy `allowed` with
+  `continue_owned_attempt`.
 - Operator status snapshots may expose an additive `child_agent_activity` object when app-server protocol events have produced one for the current run. The object must stay machine-readable and dashboard/CLI shared, and should describe dynamic observed buckets rather than a fixed workflow: current child bucket and elapsed time, bucket wall/event/tool counts, current/max/cumulative input tokens, cumulative output tokens, largest tool output, and warnings for repeated large outputs. Lifecycle metrics that group attempts by run phase must be presented in operator UI/readback as lifecycle buckets, not as generic stages. Missing `child_agent_activity` means no child breakdown was captured; existing JSON consumers must continue to work without it.
 - If the agent Git credential preflight fails, operator status must report the retained lane as a credential failure requiring operator recovery, not as a still-running lane.
 - If retry budget or needs-attention recovery finds tracked changes in the retained worktree after active phase-goal recovery has no applicable continuation path, operator status must report retained partial progress rather than only a generic retry-budget hold. Retained progress is the recovery disposition; later runtime, app-server, credential, transport, or repo-gate failure classes must be preserved as source evidence instead of overriding the retained-progress lifecycle path. The failure class may be `partial_progress_retained` when no more specific runtime error class is available. Operators should then inspect the patch, finish validation and PR handoff if it is useful, or reset the retained worktree explicitly.
@@ -1085,7 +1117,7 @@ After a process restart, recent-run history, run lease ownership, retained post-
   output. A cleanup-only worktree with `provenance_source = "legacy_unknown"` must set
   `audit_required = true` and provide a `decodex recover legacy-closeout` next action;
   this is a last-resort operator audit path, not an automatic rebind or cleanup signal.
-- During an active run, operator snapshots must expose `thread_id` as soon as the Codex thread exists, plus monotonically advancing `event_count`, `last_event_type`, and `last_event_at` once protocol events are recorded. These fields may be hydrated either from the current process journal or from the active lane's `.decodex-run-activity` marker when `status` is running in a separate process.
+- During an active run, operator snapshots must expose `thread_id` as soon as the Codex thread exists, plus monotonically advancing `event_count`, `last_event_type`, and `last_event_at` once protocol events are recorded. These fields may be hydrated either from the current process journal or from the active lane's `.decodex-run-activity` marker when `status` is running in a separate process. If both durable run rows and the marker carry protocol summaries for the same run/attempt, the snapshot must prefer the newer summary by protocol timestamp, breaking equal timestamps by larger event count. A stale durable maintenance event such as `thread/archive` must not mask newer current-attempt marker evidence such as model or tool activity.
 - `thread_id = null` is expected only before the worker creates the Codex thread for the current run. `event_count = 0`, `last_event_type = null`, and `last_event_at = null` are expected only before the first protocol event for that same run. After the thread exists and protocol activity has started, those empty values indicate missing hydration rather than normal progress.
 - Operator snapshots may expose an additive `protocol_activity` object derived from app-server structured messages for the current run. The object stays local/operator-only and should summarize turn status, waiting reason, rate-limit status, and a compact recent event list for high-value app-server activity such as `turn/started`, `turn/completed`, plan updates, diff updates, item start/completion, command output deltas, server request responses, account updates, and rate-limit updates. Missing `protocol_activity` means no structured summary was captured yet; consumers must continue to rely on the older `event_count`, `last_event_type`, `last_event_at`, thread fields, and `child_agent_activity` fields when it is absent. Presence in `protocol_activity` is not by itself meaningful progress; non-work account, rate-limit, phase-goal, passive status, warning, model-routing, and token-usage events must remain distinguishable from work-progress events through `last_progress_at` and `progress_diagnostic`.
 - The operator snapshot transport must stay local/operator-only. `decodex serve` exposes the human-facing operator console from the canonical HTTP `GET /` and `GET /dashboard` routes, serves only the necessary dashboard assets, `GET /livez` liveness probe, and local account-control API over HTTP, and delivers published snapshots, current-lane activity, and dashboard control acknowledgements through the local `GET /dashboard/control` WebSocket upgrade.


### PR DESCRIPTION
## Summary

Manual recovery for `XY-1095` after the Decodex-owned lane retained a validated patch but stopped at `needs_attention` with `repo_gate_tracked_rewrites_left`.

This change fixes stale review-repair status projection so old repair findings cannot remain the active lane-control action after newer clean current-head review evidence exists. It also keeps ordinary running/continuation lanes from synthesizing pending Decodex Review checkpoints without current checkpoint or review-writeback evidence.

## Evidence

Decodex attempt `xy-1095-attempt-3-1782147502` recorded passing validation before closeout failed on tracked rewrites:

- `cargo make fmt`: passed
- `cargo make lint-fix`: passed with 0 vstyle fixes
- `cargo test -p decodex review --lib`: passed, 228 tests
- `cargo test -p decodex loop_contract --lib`: passed, 9 tests
- focused operator status and post-review tests: passed
- MCP resource tests: passed
- `cargo make fmt-check`: passed
- `cargo make check-docs`: passed
- `cargo make check`: passed; nextest summary 1415 passed, 1 skipped

Post manual recovery commit verification:

- `cargo test -p decodex operator_status_supersedes_stale_repair_findings_after_clean_handoff_checkpoint --lib`: passed
- `cargo test -p decodex build_post_review_lane_statuses_waits_when_clean_repair_head_outruns_lifecycle_marker --lib`: passed
- `cargo make fmt-check`: passed
- `cargo make check-docs`: passed

## Operator Note

The lane did not close autonomously. The remaining Decodex bug is that gate/canonicalize rewrites can leave validated tracked changes retained instead of being committed or continued cleanly. That follow-up should remain separate from this status projection fix.
