### PR TITLE
XY-1096: Commit validated gate rewrites instead of retaining manual attention

### DIFF
--- a/apps/decodex/src/orchestrator/execution.rs
+++ b/apps/decodex/src/orchestrator/execution.rs
@@ -210,14 +210,14 @@ impl RepoGatePhaseGoalController<'_> {
 			RUN_OPERATION_REPO_GATE,
 		);
 
-		match run_repo_gate_commands(
+		match run_repo_gate_commands_allow_owned_tracked_rewrites(
 			selected_repo_gate.canonicalize_commands(),
 			selected_repo_gate.verify_commands(),
 			&self.issue_run.worktree.path,
 		) {
-			Ok(()) => {
+			Ok(repo_gate_outcome) => {
 				let acceptance_check =
-					self.evaluate_phase_acceptance(phase, &selected_repo_gate)?;
+					self.evaluate_phase_acceptance(phase, &selected_repo_gate, &repo_gate_outcome)?;
 
 				self.record_phase_acceptance_check(&acceptance_check)?;
 
@@ -229,13 +229,25 @@ impl RepoGatePhaseGoalController<'_> {
 					self.project.service_id(),
 					&self.issue_run.issue.id,
 				)?;
-				self.record_phase_goal_transition(
-					phase,
-					"validation_pass",
-					json!({ "nextPhase": PhaseGoalKind::HandoffEvidence.as_str() }),
-				)?;
 
-				let next_goal = self.phase_goal_spec(PhaseGoalKind::HandoffEvidence, None);
+				let mut transition_payload =
+					json!({ "nextPhase": PhaseGoalKind::HandoffEvidence.as_str() });
+
+				if let Some(decision) = repo_gate_outcome.tracked_rewrite_decision() {
+					transition_payload["trackedRewrites"] = decision.to_json();
+				}
+
+				self.record_phase_goal_transition(phase, "validation_pass", transition_payload)?;
+
+				let handoff_detail =
+					repo_gate_outcome.tracked_rewrite_decision().map(|decision| {
+						format!(
+							"Repo gate validation passed after rewriting owned tracked files: {}. Commit these issue-owned gate rewrites with the lane changes before review handoff.",
+							decision.files_display()
+						)
+					});
+				let next_goal =
+					self.phase_goal_spec(PhaseGoalKind::HandoffEvidence, handoff_detail.as_deref());
 
 				self.persist_next_phase_goal(&next_goal, "validation_pass")?;
 
@@ -243,14 +255,16 @@ impl RepoGatePhaseGoalController<'_> {
 			},
 			Err(error) => {
 				if let Some(repo_gate_failure) = error.downcast_ref::<RepoGateFailure>() {
-					self.record_phase_goal_transition(
-						phase,
-						"validation_fail",
-						json!({
-							"errorClass": repo_gate_failure.error_class(),
-							"disposition": repo_gate_failure.disposition().as_str(),
-						}),
-					)?;
+					let mut transition_payload = json!({
+						"errorClass": repo_gate_failure.error_class(),
+						"disposition": repo_gate_failure.disposition().as_str(),
+					});
+
+					if let Some(decision) = repo_gate_failure.tracked_rewrite_decision() {
+						transition_payload["trackedRewrites"] = decision.to_json();
+					}
+
+					self.record_phase_goal_transition(phase, "validation_fail", transition_payload)?;
 
 					if repo_gate_failure.disposition() == RepoGateFailureDisposition::ContinueRepair {
 						if let Some(loop_guardrail_stop) = retryable_failure_loop_guardrail_stop(
@@ -324,9 +338,10 @@ impl RepoGatePhaseGoalController<'_> {
 				self.issue_run.issue.identifier
 			),
 			PhaseGoalKind::HandoffEvidence => format!(
-				"Decodex phase: {}\nAfter Decodex validation, prepare PR-backed handoff evidence for {}: record a current-HEAD `issue_progress_checkpoint` with `docs_impact`, run the bounded review policy as instructed, push the branch when ready, create or update the non-draft PR, then record the required Decodex terminal path. Goal completion alone is not issue success.",
+				"Decodex phase: {}\nAfter Decodex validation, prepare PR-backed handoff evidence for {}: record a current-HEAD `issue_progress_checkpoint` with `docs_impact`, run the bounded review policy as instructed, push the branch when ready, create or update the non-draft PR, then record the required Decodex terminal path. Goal completion alone is not issue success.{}",
 				phase.as_str(),
-				self.issue_run.issue.identifier
+				self.issue_run.issue.identifier,
+				detail.map_or_else(String::new, |detail| format!(" {detail}"))
 			),
 		};
 
@@ -377,6 +392,7 @@ impl RepoGatePhaseGoalController<'_> {
 		&self,
 		phase: PhaseGoalKind,
 		repo_gate: &ResolvedRepoGate<'_>,
+		repo_gate_outcome: &RepoGateCommandOutcome,
 	) -> Result<PhaseAcceptanceCheck> {
 		let fingerprint = loop_guardrail_worktree_fingerprint(&self.issue_run.worktree.path)?;
 		let head_sha = fingerprint.as_ref().map(|value| value.head_sha.clone());
@@ -431,6 +447,7 @@ impl RepoGatePhaseGoalController<'_> {
 			repo_gate_profile: repo_gate.profile_name().map(str::to_owned),
 			canonicalize_commands: repo_gate.canonicalize_commands().to_vec(),
 			verify_commands: repo_gate.verify_commands().to_vec(),
+			repo_gate_tracked_rewrites: repo_gate_outcome.tracked_rewrite_decision().cloned(),
 			checkpoint_record_id: checkpoint.as_ref().map(state::PrivateExecutionEvent::record_id),
 			checkpoint_head_sha,
 			worktree_head_sha: head_sha,
@@ -542,6 +559,10 @@ impl RepoGatePhaseGoalController<'_> {
 					"repo_gate_profile": check.repo_gate_profile.as_deref(),
 					"canonicalize_commands": &check.canonicalize_commands,
 					"verify_commands": &check.verify_commands,
+					"tracked_rewrites": check
+						.repo_gate_tracked_rewrites
+						.as_ref()
+						.map(RepoGateTrackedRewriteDecision::to_json),
 				},
 				"next_action": check.next_action(),
 			}),
@@ -615,6 +636,7 @@ struct PhaseAcceptanceCheck {
 	repo_gate_profile: Option<String>,
 	canonicalize_commands: Vec<String>,
 	verify_commands: Vec<String>,
+	repo_gate_tracked_rewrites: Option<RepoGateTrackedRewriteDecision>,
 	checkpoint_record_id: Option<i64>,
 	checkpoint_head_sha: Option<String>,
 	worktree_head_sha: Option<String>,

--- a/apps/decodex/src/orchestrator/git_ops.rs
+++ b/apps/decodex/src/orchestrator/git_ops.rs
@@ -1,6 +1,7 @@
 mod repo_gate_failure {
 	use std::fmt::Formatter;
 	use std::fmt::Display;
+	use crate::orchestrator::RepoGateTrackedRewriteDecision;
 	#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 	pub(super) enum RepoGateFailureDisposition {
 		ContinueRepair,
@@ -101,10 +102,24 @@ mod repo_gate_failure {
 	pub(super) struct RepoGateFailure {
 		kind: RepoGateFailureKind,
 		message: String,
+		tracked_rewrite_decision: Option<RepoGateTrackedRewriteDecision>,
 	}
 	impl RepoGateFailure {
 		pub(super) fn new(kind: RepoGateFailureKind, message: String) -> Self {
-			Self { kind, message }
+			Self {
+				kind,
+				message,
+				tracked_rewrite_decision: None,
+			}
+		}
+
+		pub(super) fn with_tracked_rewrite_decision(
+			mut self,
+			decision: RepoGateTrackedRewriteDecision,
+		) -> Self {
+			self.tracked_rewrite_decision = Some(decision);
+
+			self
 		}
 
 		pub(super) fn error_class(&self) -> &'static str {
@@ -126,6 +141,10 @@ mod repo_gate_failure {
 		pub(super) fn terminal_next_action(&self, recovery_gate: &str) -> String {
 			self.kind.terminal_next_action(recovery_gate)
 		}
+
+		pub(super) fn tracked_rewrite_decision(&self) -> Option<&RepoGateTrackedRewriteDecision> {
+			self.tracked_rewrite_decision.as_ref()
+		}
 	}
 	impl std::error::Error for RepoGateFailure {}
 
@@ -143,6 +162,81 @@ use std::process::Output;
 
 use repo_gate_failure::{RepoGateFailure, RepoGateFailureDisposition, RepoGateFailureKind};
 use crate::workflow::ResolvedRepoGate;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RepoGateTrackedRewriteDecision {
+	files: Vec<String>,
+	owned: bool,
+	decision: &'static str,
+	reason: &'static str,
+}
+impl RepoGateTrackedRewriteDecision {
+	fn continue_to_commit_capable_phase(files: Vec<String>) -> Self {
+		Self {
+			files,
+			owned: true,
+			decision: "continue_to_commit_capable_phase",
+			reason:
+				"all rewritten files were already present in the pre-gate implementation diff and the repo gate passed",
+		}
+	}
+
+	fn require_attention(
+		files: Vec<String>,
+		owned: bool,
+		reason: &'static str,
+	) -> Self {
+		Self {
+			files,
+			owned,
+			decision: "repo_gate_tracked_rewrites_left",
+			reason,
+		}
+	}
+
+	fn files_display(&self) -> String {
+		if self.files.is_empty() {
+			String::from("(no tracked files reported)")
+		} else {
+			self.files.join(", ")
+		}
+	}
+
+	fn to_json(&self) -> Value {
+		json!({
+			"files": &self.files,
+			"owned": self.owned,
+			"decision": self.decision,
+			"reason": self.reason,
+		})
+	}
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct RepoGateCommandOutcome {
+	tracked_rewrite_decision: Option<RepoGateTrackedRewriteDecision>,
+}
+impl RepoGateCommandOutcome {
+	fn clean() -> Self {
+		Self::default()
+	}
+
+	fn with_tracked_rewrite_decision(decision: RepoGateTrackedRewriteDecision) -> Self {
+		Self {
+			tracked_rewrite_decision: Some(decision),
+		}
+	}
+
+	fn tracked_rewrite_decision(&self) -> Option<&RepoGateTrackedRewriteDecision> {
+		self.tracked_rewrite_decision.as_ref()
+	}
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct RepoGateTrackedDiffSnapshot {
+	full_diff: String,
+	path_diffs: BTreeMap<String, String>,
+}
 
 impl RepoGateFailureKind {
 	fn retry_schedule_kind(self) -> Option<&'static str> {
@@ -579,8 +673,24 @@ fn run_verify_commands(commands: &[String], cwd: &Path) -> Result<()> {
 	Ok(())
 }
 
-fn ensure_repo_gate_left_no_tracked_changes(cwd: &Path, phase: &str) -> Result<()> {
-	let output = run_repo_gate_cleanliness_check_with_git(std::ffi::OsStr::new("git"), cwd)?;
+fn read_repo_gate_tracked_diff_paths(
+	cwd: &Path,
+	phase: &str,
+) -> Result<BTreeSet<String>> {
+	let output = Command::new("git")
+		.arg("-C")
+		.arg(cwd)
+		.args(["diff", "--name-only", "--diff-filter=ACDMRTUXB", "HEAD", "--"])
+		.output()
+		.map_err(|error| {
+			Report::new(RepoGateFailure::new(
+				RepoGateFailureKind::CommandSpawnFailed,
+				format!(
+					"Failed to spawn tracked-file path check after repo gate {phase} in `{}`: {error}",
+					cwd.display()
+				),
+			))
+		})?;
 
 	if !output.status.success() {
 		let output_text = repo_gate_output_text(&output);
@@ -591,28 +701,14 @@ fn ensure_repo_gate_left_no_tracked_changes(cwd: &Path, phase: &str) -> Result<(
 				&output_text,
 			),
 			format!(
-				"Failed to inspect tracked-file cleanliness after repo gate {phase} in `{}`: {}",
+				"Failed to inspect tracked-file paths after repo gate {phase} in `{}`: {}",
 				cwd.display(),
 				output_text
 			),
 		)));
 	}
 
-	let stdout = String::from_utf8_lossy(&output.stdout);
-	let dirty_entries = stdout.trim();
-
-	if !dirty_entries.is_empty() {
-		return Err(Report::new(RepoGateFailure::new(
-			RepoGateFailureKind::TrackedRewritesLeft,
-			format!(
-				"Repo gate {phase} rewrote tracked files in `{}`; commit or revert these changes before continuing:\n{}",
-				cwd.display(),
-				dirty_entries
-			),
-		)));
-	}
-
-	Ok(())
+	Ok(repo_gate_git_output_lines(&output))
 }
 
 fn read_repo_gate_tracked_diff(cwd: &Path, phase: &str) -> Result<String> {
@@ -650,29 +746,161 @@ fn read_repo_gate_tracked_diff(cwd: &Path, phase: &str) -> Result<String> {
 	Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
-fn ensure_repo_gate_preserved_tracked_diff(
+fn read_repo_gate_tracked_diff_for_path(
 	cwd: &Path,
 	phase: &str,
-	before_diff: &str,
-) -> Result<()> {
-	let after_diff = read_repo_gate_tracked_diff(cwd, phase)?;
+	path: &str,
+) -> Result<String> {
+	let output = Command::new("git")
+		.arg("-C")
+		.arg(cwd)
+		.args(["diff", "--no-ext-diff", "--binary", "HEAD", "--"])
+		.arg(path)
+		.output()
+		.map_err(|error| {
+			Report::new(RepoGateFailure::new(
+				RepoGateFailureKind::CommandSpawnFailed,
+				format!(
+					"Failed to spawn tracked-file diff check for `{}` after repo gate {phase} in `{}`: {error}",
+					path,
+					cwd.display()
+				),
+			))
+		})?;
 
-	if after_diff == before_diff {
-		return Ok(());
+	if !output.status.success() {
+		let output_text = repo_gate_output_text(&output);
+
+		return Err(Report::new(RepoGateFailure::new(
+			repo_gate_failure_kind_for_output(
+				RepoGateFailureKind::CleanlinessCheckFailed,
+				&output_text,
+			),
+			format!(
+				"Failed to inspect tracked-file diff for `{}` after repo gate {phase} in `{}`: {}",
+				path,
+				cwd.display(),
+				output_text
+			),
+		)));
+	}
+
+	Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn read_repo_gate_tracked_diff_snapshot(
+	cwd: &Path,
+	phase: &str,
+) -> Result<RepoGateTrackedDiffSnapshot> {
+	let full_diff = read_repo_gate_tracked_diff(cwd, phase)?;
+	let changed_paths = read_repo_gate_tracked_diff_paths(cwd, phase)?;
+	let mut path_diffs = BTreeMap::new();
+
+	for path in changed_paths {
+		let path_diff = read_repo_gate_tracked_diff_for_path(cwd, phase, &path)?;
+
+		path_diffs.insert(path, path_diff);
+	}
+
+	Ok(RepoGateTrackedDiffSnapshot { full_diff, path_diffs })
+}
+
+fn repo_gate_rewritten_files(
+	before: &RepoGateTrackedDiffSnapshot,
+	after: &RepoGateTrackedDiffSnapshot,
+) -> Vec<String> {
+	let mut paths = before.path_diffs.keys().cloned().collect::<BTreeSet<_>>();
+
+	paths.extend(after.path_diffs.keys().cloned());
+
+	paths
+		.into_iter()
+		.filter(|path| before.path_diffs.get(path) != after.path_diffs.get(path))
+		.collect()
+}
+
+fn repo_gate_tracked_rewrite_decision(
+	before: &RepoGateTrackedDiffSnapshot,
+	after: &RepoGateTrackedDiffSnapshot,
+	allow_owned_rewrites: bool,
+) -> Option<RepoGateTrackedRewriteDecision> {
+	if before.full_diff == after.full_diff {
+		return None;
+	}
+
+	let rewritten_files = repo_gate_rewritten_files(before, after);
+	let owned = !rewritten_files.is_empty()
+		&& rewritten_files.iter().all(|path| before.path_diffs.contains_key(path));
+
+	if allow_owned_rewrites && owned {
+		return Some(RepoGateTrackedRewriteDecision::continue_to_commit_capable_phase(
+			rewritten_files,
+		));
+	}
+
+	let reason = if owned {
+		"all rewritten files were pre-gate implementation paths, but this lifecycle boundary requires a clean committed worktree"
+	} else {
+		"one or more rewritten files were not present in the pre-gate implementation diff"
+	};
+
+	Some(RepoGateTrackedRewriteDecision::require_attention(
+		rewritten_files,
+		owned,
+		reason,
+	))
+}
+
+fn repo_gate_diff_rewrite_outcome(
+	cwd: &Path,
+	phase: &str,
+	before: &RepoGateTrackedDiffSnapshot,
+	allow_owned_rewrites: bool,
+) -> Result<RepoGateCommandOutcome> {
+	let after = read_repo_gate_tracked_diff_snapshot(cwd, phase)?;
+	let Some(decision) =
+		repo_gate_tracked_rewrite_decision(before, &after, allow_owned_rewrites)
+	else {
+		return Ok(RepoGateCommandOutcome::clean());
+	};
+
+	if decision.decision == "continue_to_commit_capable_phase" {
+		return Ok(RepoGateCommandOutcome::with_tracked_rewrite_decision(decision));
 	}
 
 	let output = run_repo_gate_cleanliness_check_with_git(std::ffi::OsStr::new("git"), cwd)?;
+
+	if !output.status.success() {
+		let output_text = repo_gate_output_text(&output);
+
+		return Err(Report::new(RepoGateFailure::new(
+			repo_gate_failure_kind_for_output(
+				RepoGateFailureKind::CleanlinessCheckFailed,
+				&output_text,
+			),
+			format!(
+				"Failed to inspect tracked-file cleanliness after repo gate {phase} in `{}`: {}",
+				cwd.display(),
+				output_text
+			),
+		)));
+	}
+
 	let output_text = repo_gate_output_text(&output);
 	let dirty_entries = output_text.trim();
 
 	Err(Report::new(RepoGateFailure::new(
 		RepoGateFailureKind::TrackedRewritesLeft,
 		format!(
-			"Repo gate {phase} rewrote tracked files in `{}`; commit or revert these changes before continuing:\n{}",
+			"Repo gate {phase} rewrote tracked files in `{}`; owned={}; decision={}; reason={}; files={}; commit or revert these changes before continuing:\n{}",
 			cwd.display(),
+			decision.owned,
+			decision.decision,
+			decision.reason,
+			decision.files_display(),
 			dirty_entries
 		),
-	)))
+	).with_tracked_rewrite_decision(decision)))
 }
 
 fn run_repo_gate_commands(
@@ -680,18 +908,35 @@ fn run_repo_gate_commands(
 	verify_commands: &[String],
 	cwd: &Path,
 ) -> Result<()> {
-	let baseline_tracked_diff = read_repo_gate_tracked_diff(cwd, "baseline")?;
+	run_repo_gate_commands_with_rewrite_policy(canonicalize_commands, verify_commands, cwd, false)
+		.map(|_| ())
+}
+
+fn run_repo_gate_commands_allow_owned_tracked_rewrites(
+	canonicalize_commands: &[String],
+	verify_commands: &[String],
+	cwd: &Path,
+) -> Result<RepoGateCommandOutcome> {
+	run_repo_gate_commands_with_rewrite_policy(canonicalize_commands, verify_commands, cwd, true)
+}
+
+fn run_repo_gate_commands_with_rewrite_policy(
+	canonicalize_commands: &[String],
+	verify_commands: &[String],
+	cwd: &Path,
+	allow_owned_rewrites: bool,
+) -> Result<RepoGateCommandOutcome> {
+	let baseline_tracked_diff = read_repo_gate_tracked_diff_snapshot(cwd, "baseline")?;
 
 	run_canonicalize_commands(canonicalize_commands, cwd)?;
 	run_verify_commands(verify_commands, cwd)?;
 
-	if baseline_tracked_diff.is_empty() {
-		ensure_repo_gate_left_no_tracked_changes(cwd, "verification")?;
-	} else {
-		ensure_repo_gate_preserved_tracked_diff(cwd, "verification", &baseline_tracked_diff)?;
-	}
-
-	Ok(())
+	repo_gate_diff_rewrite_outcome(
+		cwd,
+		"verification",
+		&baseline_tracked_diff,
+		allow_owned_rewrites,
+	)
 }
 
 fn relative_worktree_path(project: &ServiceConfig, worktree: &WorktreeSpec) -> String {

--- a/apps/decodex/src/orchestrator/tests/retry/scheduling.rs
+++ b/apps/decodex/src/orchestrator/tests/retry/scheduling.rs
@@ -830,7 +830,7 @@ fn schedule_retry_after_child_exit_terminalizes_open_phase_goal_tracked_rewrites
 		)
 		.replace(
 			"canonicalize_commands = []",
-			"canonicalize_commands = [\"printf 'rewritten\\\\n' > ready.txt\"]",
+			"canonicalize_commands = [\"printf 'rewritten\\\\n' > other.txt\"]",
 		),
 	);
 	let issue = sample_service_owned_issue("In Progress");
@@ -840,6 +840,7 @@ fn schedule_retry_after_child_exit_terminalizes_open_phase_goal_tracked_rewrites
 	let run_id = "run-3";
 
 	commit_worktree_change(config.repo_root(), "ready.txt", "before\n", "add ready file");
+	commit_worktree_change(config.repo_root(), "other.txt", "before\n", "add other file");
 
 	fs::write(config.repo_root().join("ready.txt"), "after\n")
 		.expect("tracked diff should write");
@@ -911,6 +912,7 @@ fn schedule_retry_after_child_exit_terminalizes_open_phase_goal_tracked_rewrites
 		event.event_type() == "phase_goal_transition"
 			&& event.payload()["signal"] == "validation_fail"
 			&& event.payload()["payload"]["disposition"] == "needs_human_attention"
+			&& event.payload()["payload"]["trackedRewrites"]["owned"] == false
 	}));
 	assert!(events.iter().all(|event| event.event_type() != "phase_goal_recovery"));
 	assert!(comments.iter().any(|comment| {

--- a/apps/decodex/src/orchestrator/tests/runtime/repo_gate.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/repo_gate.rs
@@ -211,6 +211,86 @@ fn phase_goal_completion_runs_repo_gate_and_persists_handoff_phase() {
 }
 
 #[test]
+fn phase_goal_completion_continues_with_owned_tracked_rewrites_after_validation() {
+	let (_temp_dir, config, workflow) = temp_project_layout_with_workflow_markdown(
+		&sample_workflow_markdown(
+			"pubfi",
+			&[],
+			"Phase goal validation policy.\n",
+			3,
+		)
+		.replace(
+			"canonicalize_commands = []",
+			"canonicalize_commands = [\"printf 'rewritten\\\\n' > ready.txt\"]",
+		)
+		.replace("verify_commands = []", "verify_commands = [\"grep -qx rewritten ready.txt\"]"),
+	);
+	let issue = sample_issue("In Progress", &[tracker::automation_active_label(TEST_SERVICE_ID).as_str()]);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue_run = IssueRunPlan {
+		issue: issue.clone(),
+		issue_state: String::from("In Progress"),
+		initial_issue_state: String::from("Todo"),
+		worktree: WorktreeSpec {
+			branch_name: String::from("x/pubfi-pub-101"),
+			issue_identifier: issue.identifier.clone(),
+			path: config.repo_root().to_path_buf(),
+			reused_existing: false,
+		},
+		retry_project_slug: String::from("pubfi"),
+		dispatch_mode: IssueDispatchMode::Normal,
+		attempt_number: 1,
+		run_id: String::from("pub-101-attempt-1"),
+		retry_budget_base: 0,
+	};
+
+	commit_worktree_change(config.repo_root(), "ready.txt", "before\n", "add ready file");
+
+	fs::write(config.repo_root().join("ready.txt"), "after\n").expect("tracked diff should write");
+
+	record_phase_acceptance_progress_checkpoint(&config, &state_store, &issue_run, &[]);
+
+	let transition = RepoGatePhaseGoalController {
+		project: &config,
+		workflow: &workflow,
+		state_store: &state_store,
+		issue_run: &issue_run,
+	}
+	.phase_goal_completed(PhaseGoalKind::ImplementToValidationReady)
+	.expect("owned tracked canonicalize rewrites should satisfy phase validation");
+	let events = state_store
+		.list_private_execution_events(TEST_SERVICE_ID, &issue.id, &issue_run.run_id, 1)
+		.expect("private phase goal events should load");
+
+	match transition {
+		PhaseGoalTransition::Continue(PhaseGoalSpec {
+			phase: PhaseGoalKind::HandoffEvidence,
+			objective,
+			..
+		}) => {
+			assert!(objective.contains("ready.txt"));
+			assert!(objective.contains("Commit these issue-owned gate rewrites"));
+		},
+		_ => panic!("owned tracked rewrites should continue to handoff evidence"),
+	}
+
+	assert!(events.iter().any(|event| {
+		event.event_type() == "phase_goal_transition"
+			&& event.payload()["signal"] == "validation_pass"
+			&& event.payload()["payload"]["trackedRewrites"]["owned"] == true
+			&& event.payload()["payload"]["trackedRewrites"]["decision"]
+				== "continue_to_commit_capable_phase"
+	}));
+	assert!(events.iter().any(|event| {
+		event.event_type() == PHASE_ACCEPTANCE_CHECK_EVENT_TYPE
+			&& event.payload()["decision"] == "pass"
+			&& event.payload()["validation_evidence"]["tracked_rewrites"]["files"]
+				.as_array()
+				.is_some_and(|files| files.iter().any(|file| file.as_str() == Some("ready.txt")))
+	}));
+}
+
+#[test]
 fn phase_goal_acceptance_accepts_committed_branch_delta_with_clean_worktree() {
 	let (temp_dir, config, workflow) = temp_project_layout();
 	let remote_root = temp_dir.path().join("origin.git");
@@ -789,7 +869,7 @@ fn program_phase_goal_skips_empty_failed_start_attempt_for_cross_attempt_resume(
 }
 
 #[test]
-fn open_phase_goal_tracked_rewrites_stop_instead_of_repair_continuation() {
+fn open_phase_goal_unowned_tracked_rewrites_stop_instead_of_repair_continuation() {
 	let (_temp_dir, config, workflow) = temp_project_layout_with_workflow_markdown(
 		&sample_workflow_markdown(
 			"pubfi",
@@ -799,7 +879,7 @@ fn open_phase_goal_tracked_rewrites_stop_instead_of_repair_continuation() {
 		)
 		.replace(
 			"canonicalize_commands = []",
-			"canonicalize_commands = [\"printf 'rewritten\\\\n' > ready.txt\"]",
+			"canonicalize_commands = [\"printf 'rewritten\\\\n' > other.txt\"]",
 		),
 	);
 	let repo_root = config.repo_root();
@@ -823,8 +903,11 @@ fn open_phase_goal_tracked_rewrites_stop_instead_of_repair_continuation() {
 	};
 
 	commit_worktree_change(repo_root, "ready.txt", "before\n", "add ready file");
+	commit_worktree_change(repo_root, "other.txt", "before\n", "add other file");
 
 	fs::write(repo_root.join("ready.txt"), "after\n").expect("tracked diff should write");
+
+	record_phase_acceptance_progress_checkpoint(&config, &state_store, &issue_run, &[]);
 
 	state_store
 		.append_private_execution_event(
@@ -868,9 +951,107 @@ fn open_phase_goal_tracked_rewrites_stop_instead_of_repair_continuation() {
 		event.event_type() == "phase_goal_transition"
 			&& event.payload()["signal"] == "validation_fail"
 			&& event.payload()["payload"]["disposition"] == "needs_human_attention"
+			&& event.payload()["payload"]["trackedRewrites"]["owned"] == false
+			&& event.payload()["payload"]["trackedRewrites"]["files"]
+				.as_array()
+				.is_some_and(|files| files.iter().any(|file| file.as_str() == Some("other.txt")))
 	}));
 	assert!(events.iter().all(|event| event.event_type() != "phase_goal_next"));
 	assert!(events.iter().all(|event| event.event_type() != "phase_goal_recovery"));
+}
+
+#[test]
+fn open_phase_goal_owned_tracked_rewrites_continue_to_handoff_recovery() {
+	let (_temp_dir, config, workflow) = temp_project_layout_with_workflow_markdown(
+		&sample_workflow_markdown(
+			"pubfi",
+			&[],
+			"Phase goal validation policy.\n",
+			1,
+		)
+		.replace(
+			"canonicalize_commands = []",
+			"canonicalize_commands = [\"printf 'rewritten\\\\n' > ready.txt\"]",
+		),
+	);
+	let repo_root = config.repo_root();
+	let issue = sample_issue("In Progress", &[tracker::automation_active_label(TEST_SERVICE_ID).as_str()]);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue_run = IssueRunPlan {
+		issue: issue.clone(),
+		issue_state: String::from("In Progress"),
+		initial_issue_state: String::from("Todo"),
+		worktree: WorktreeSpec {
+			branch_name: String::from("x/pubfi-pub-101"),
+			issue_identifier: issue.identifier.clone(),
+			path: repo_root.to_path_buf(),
+			reused_existing: false,
+		},
+		retry_project_slug: String::from("pubfi"),
+		dispatch_mode: IssueDispatchMode::Normal,
+		attempt_number: 1,
+		run_id: String::from("pub-101-attempt-1"),
+		retry_budget_base: 0,
+	};
+
+	commit_worktree_change(repo_root, "ready.txt", "before\n", "add ready file");
+
+	fs::write(repo_root.join("ready.txt"), "after\n").expect("tracked diff should write");
+
+	record_phase_acceptance_progress_checkpoint(&config, &state_store, &issue_run, &[]);
+
+	state_store
+		.append_private_execution_event(
+			TEST_SERVICE_ID,
+			&issue.id,
+			&issue_run.run_id,
+			1,
+			"phase_goal_set",
+			serde_json::json!({
+				"schema": "decodex.phase_goal_signal/1",
+				"phase": "implement_to_validation_ready",
+				"payload": {
+					"phase": "implement_to_validation_ready",
+					"status": "active",
+				},
+			}),
+		)
+		.expect("phase goal event should record");
+
+	let summary = orchestrator::maybe_continue_after_phase_goal_recovery(
+		&config,
+		&workflow,
+		&state_store,
+		&issue_run,
+		&Report::msg("app server transport closed after local verification"),
+	)
+	.expect("owned tracked repo-gate rewrites should keep phase-goal recovery automatic")
+	.expect("owned tracked repo-gate rewrites should schedule continuation");
+	let events = state_store
+		.list_private_execution_events(TEST_SERVICE_ID, &issue.id, &issue_run.run_id, 1)
+		.expect("private events should load");
+
+	assert!(summary.continuation_pending);
+	assert!(events.iter().any(|event| {
+		event.event_type() == "phase_goal_transition"
+			&& event.payload()["signal"] == "validation_pass"
+			&& event.payload()["payload"]["nextPhase"] == "handoff_evidence"
+			&& event.payload()["payload"]["trackedRewrites"]["owned"] == true
+			&& event.payload()["payload"]["trackedRewrites"]["decision"]
+				== "continue_to_commit_capable_phase"
+			&& event.payload()["payload"]["trackedRewrites"]["files"]
+				.as_array()
+				.is_some_and(|files| files.iter().any(|file| file.as_str() == Some("ready.txt")))
+	}));
+	assert!(events.iter().any(|event| {
+		event.event_type() == PHASE_ACCEPTANCE_CHECK_EVENT_TYPE
+			&& event.payload()["decision"] == "pass"
+			&& event.payload()["validation_evidence"]["tracked_rewrites"]["owned"] == true
+	}));
+	assert!(events.iter().any(|event| {
+		event.event_type() == "phase_goal_next" && event.payload()["phase"] == "handoff_evidence"
+	}));
+	assert!(events.iter().any(|event| event.event_type() == "phase_goal_recovery"));
 }
 
 #[test]

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,12 @@
 # Documentation Log
 
+## 2026-06-23
+
+- Narrowed repo-gate tracked-rewrite handling so validation-satisfied phase goals can
+  continue to a commit-capable handoff when canonicalize rewrites only pre-gate
+  implementation paths, while unsafe or strict-boundary rewrites still preserve
+  `repo_gate_tracked_rewrites_left`.
+
 ## 2026-06-22
 
 - Tightened operator review-control projection so ordinary running lanes no longer

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -6,8 +6,8 @@ status: active
 authority: normative
 owner: runtime
 tags: [spec]
-code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/autonomy_signal.rs, apps/decodex/src/autonomy_proposal.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/mcp.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs, apps/decodex/src/config.rs, decodex.example.toml]
-drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, protocol_events, review_policy_checkpoints, review_checkpoint, review_lifecycle_records, lane_control_next_action, review_handoff_pending, review_repair_pending, review_repair_writeback_missing_lifecycle_marker, review_repair_writeback_stale_lifecycle_marker, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, decodex intake goal, program_issue_mappings, autonomy_proposals, decodex.autonomy_proposal/1, "[autonomy]", auto_promote, auto_intake, "[autonomy.runtime_policy]", accepted_objective_id, accepted_objective_version, accepted_policy_id, accepted_policy_version, policy_authority_ref]
+code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/autonomy_signal.rs, apps/decodex/src/autonomy_proposal.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/git_ops.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/mcp.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs, apps/decodex/src/config.rs, decodex.example.toml]
+drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, repo_gate_tracked_rewrites_left, protocol_events, review_policy_checkpoints, review_checkpoint, review_lifecycle_records, lane_control_next_action, review_handoff_pending, review_repair_pending, review_repair_writeback_missing_lifecycle_marker, review_repair_writeback_stale_lifecycle_marker, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, decodex intake goal, program_issue_mappings, autonomy_proposals, decodex.autonomy_proposal/1, "[autonomy]", auto_promote, auto_intake, "[autonomy.runtime_policy]", accepted_objective_id, accepted_objective_version, accepted_policy_id, accepted_policy_version, policy_authority_ref]
 last_verified: 2026-06-23
 ---
 # Runtime Specification
@@ -506,12 +506,17 @@ When `decodex` runs the repo-native gate during `validating`, it must preserve t
 
 - `canonicalize_commands` non-zero exit: continued repair in the retained lane
 - `verify_commands` non-zero exit: continued repair in the retained lane
-- repo gate changes the tracked-file diff from the pre-gate implementation baseline
-  after its commands complete: retained partial progress that requires operator
-  attention
+- repo gate changes only tracked files that were already present in the pre-gate
+  implementation diff during phase-goal validation, after the canonicalize and verify
+  commands pass: continue to the commit-capable handoff phase and record private
+  evidence listing the rewritten files, ownership decision, and continuation reason
+- repo gate changes tracked files outside the pre-gate implementation diff, or changes
+  tracked files at a lifecycle boundary that requires a clean committed worktree:
+  retained partial progress that preserves `repo_gate_tracked_rewrites_left` and
+  requires operator attention
 - repo-gate command spawn failures or tracked-file cleanliness inspection failures: human-attention failure path immediately
 
-The continued-repair classes above are ordinary bounded churn: the coding agent should keep repairing code and rerun the repo gate rather than requesting `manual_attention` just because the gate has not passed yet. A tracked-rewrite residue after the gate commands have changed the pre-gate implementation diff is different: Decodex must not infer repository file meaning, generated-artifact ownership, or fixture policy. It must preserve the retained worktree, write `error_class = "partial_progress_retained"` with the repo-gate source class in evidence, and stop until an operator decides whether to finish validation and handoff or reset the patch. Human-attention exits also remain reserved for environment, toolchain, or operator-owned blockers that the coding agent cannot clear from the retained worktree alone.
+The continued-repair classes above are ordinary bounded churn: the coding agent should keep repairing code and rerun the repo gate rather than requesting `manual_attention` just because the gate has not passed yet. A tracked-rewrite residue after the gate commands have changed the pre-gate implementation diff is different unless every rewritten file was already in the pre-gate implementation diff and the active phase can continue to a commit-capable handoff. Decodex must not infer repository file meaning, generated-artifact ownership, or fixture policy; ownership here is only same tracked path membership in the pre-gate implementation diff. Unsafe or strict-boundary tracked rewrites must preserve the retained worktree, write `error_class = "partial_progress_retained"` with the repo-gate source class in evidence, and stop until an operator decides whether to finish validation and handoff or reset the patch. Human-attention exits also remain reserved for environment, toolchain, or operator-owned blockers that the coding agent cannot clear from the retained worktree alone.
 
 Continued repair is still bounded by loop guardrails. For each retryable failure,
 Decodex records local `loop_guardrail_checkpoint` evidence and updates the

--- a/docs/spec/workflow-file.md
+++ b/docs/spec/workflow-file.md
@@ -6,7 +6,9 @@ status: active
 authority: normative
 owner: runtime
 tags: [spec]
-last_verified: 2026-06-16
+code_refs: [apps/decodex/src/workflow.rs, apps/decodex/src/orchestrator/git_ops.rs, apps/decodex/src/orchestrator/execution.rs]
+drift_watch: [canonicalize_commands, verify_commands, repo_gate_tracked_rewrites_left, phase_acceptance_check, phase_goal_next]
+last_verified: 2026-06-23
 ---
 # Workflow File Specification
 
@@ -269,9 +271,9 @@ The runtime-owned failure model for this repo gate must distinguish at least the
 - a `verify_commands` entry failed
 - the repo gate completed its commands but left tracked-file rewrites behind
 
-The first two classes are explicit continued-repair outcomes in normal retained-lane policy: the retained lane stays in implementation or review-repair flow until the coding agent repairs the worktree and reruns the gate, or until retry policy is exhausted. The tracked-rewrite residue class is a retained-partial-progress stop. Decodex must preserve the source repo-gate class as evidence, but it must not add project-specific artifact, generated-file, fixture, or snapshot semantics to decide which tracked rewrites are acceptable.
+The first two classes are explicit continued-repair outcomes in normal retained-lane policy: the retained lane stays in implementation or review-repair flow until the coding agent repairs the worktree and reruns the gate, or until retry policy is exhausted. The tracked-rewrite residue class remains available for unsafe rewrites and for lifecycle boundaries that require a clean committed worktree. During phase-goal validation only, if the repo gate commands pass and every rewritten tracked file was already present in the pre-gate implementation diff, Decodex may continue to the commit-capable handoff phase instead of terminalizing. That continuation must record private readback with the file list, same-path ownership decision, selected continue/attention action, and reason. Decodex must preserve the source repo-gate class as evidence for unsafe cases, but it must not add project-specific artifact, generated-file, fixture, or snapshot semantics to decide which tracked rewrites are acceptable.
 
-Human-attention exits are reserved for repo-gate failures that the coding agent cannot reasonably repair from the worktree alone, such as command-spawn failures, missing runtime prerequisites, inability to inspect tracked-file cleanliness, or tracked rewrites left after the gate completed. When the runtime takes that path, prompts and tracker comments should preserve the repo-gate source failure class instead of collapsing it into vague generic wording.
+Human-attention exits are reserved for repo-gate failures that the coding agent cannot reasonably repair from the worktree alone, such as command-spawn failures, missing runtime prerequisites, inability to inspect tracked-file cleanliness, or unsafe tracked rewrites left after the gate completed. When the runtime takes that path, prompts and tracker comments should preserve the repo-gate source failure class instead of collapsing it into vague generic wording.
 
 Landing policy is no longer repository-configurable in the machine-readable workflow contract for this repo surface. For retained review landing, `decodex` applies a fixed strict policy: require green checks, require an up-to-date base branch, preserve commit-level history, use merge commits, and never squash or rebase.
 


### PR DESCRIPTION
## Summary
- allow validation-satisfied phase-goal repo gates to continue to handoff when canonicalize rewrites only pre-gate tracked implementation paths
- preserve repo_gate_tracked_rewrites_left for unowned rewrites and strict lifecycle boundaries
- add private readback for rewritten files, ownership decision, selected action, and reason
- update runtime/workflow docs for the tracked-rewrite boundary

## Validation
- cargo make fmt
- cargo make lint-fix
- cargo make check (nextest summary: 1419 passed, 1 skipped)
- independent fresh-context review checkpoint: clean