### PR TITLE
XY-1088: [Autonomy P5] Map accepted autonomy work into Program Intake and normal lanes

### DIFF
--- a/apps/decodex/src/execution_program.rs
+++ b/apps/decodex/src/execution_program.rs
@@ -50,6 +50,12 @@ pub(crate) struct ProgramIntakePlan {
 	intake_kind: ProgramIntakeKind,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	source_contract_id: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	source_objective_ref: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	source_proposal_id: Option<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	source_signal_refs: Vec<String>,
 	accepted_contract_fingerprint: String,
 	public_summary: String,
 }
@@ -74,6 +80,15 @@ impl ProgramIntakePlan {
 			service_id: service_id.into(),
 			intake_kind: ProgramIntakeKind::GoalIntake,
 			source_contract_id: Some(contract.contract_id().to_owned()),
+			source_objective_ref: decision_contract_provenance_reference(
+				contract,
+				"autonomy_objective",
+			),
+			source_proposal_id: decision_contract_provenance_reference(
+				contract,
+				"autonomy_proposal",
+			),
+			source_signal_refs: decision_contract_autonomy_signal_refs(contract),
 			accepted_contract_fingerprint: accepted_contract_fingerprint.into(),
 			public_summary,
 		};
@@ -98,6 +113,9 @@ impl ProgramIntakePlan {
 			service_id: service_id.into(),
 			intake_kind: ProgramIntakeKind::IssueBatchIntake,
 			source_contract_id: None,
+			source_objective_ref: None,
+			source_proposal_id: None,
+			source_signal_refs: Vec::new(),
 			accepted_contract_fingerprint: accepted_contract_fingerprint.into(),
 			public_summary: public_summary.into(),
 		};
@@ -125,6 +143,21 @@ impl ProgramIntakePlan {
 	/// Accepted Decision Contract id for goal intake.
 	pub(crate) fn source_contract_id(&self) -> Option<&str> {
 		self.source_contract_id.as_deref()
+	}
+
+	/// Accepted Objective Contract lineage, when this plan came from autonomy work.
+	pub(crate) fn source_objective_ref(&self) -> Option<&str> {
+		self.source_objective_ref.as_deref()
+	}
+
+	/// Accepted autonomy proposal lineage, when this plan came from autonomy work.
+	pub(crate) fn source_proposal_id(&self) -> Option<&str> {
+		self.source_proposal_id.as_deref()
+	}
+
+	/// Accepted autonomy signal lineage, when this plan came from autonomy work.
+	pub(crate) fn source_signal_refs(&self) -> &[String] {
+		&self.source_signal_refs
 	}
 
 	/// Stable authority fingerprint for this intake boundary.
@@ -174,6 +207,40 @@ impl ProgramIntakePlan {
 				self.plan_id
 			);
 		}
+		if self.intake_kind == ProgramIntakeKind::IssueBatchIntake
+			&& self.source_objective_ref.as_deref().is_some_and(|id| !id.is_empty())
+		{
+			eyre::bail!(
+				"Issue-batch intake plan `{}` must not reference autonomy objective lineage.",
+				self.plan_id
+			);
+		}
+		if self.intake_kind == ProgramIntakeKind::IssueBatchIntake
+			&& self.source_proposal_id.as_deref().is_some_and(|id| !id.is_empty())
+		{
+			eyre::bail!(
+				"Issue-batch intake plan `{}` must not reference autonomy proposal lineage.",
+				self.plan_id
+			);
+		}
+		if self.intake_kind == ProgramIntakeKind::IssueBatchIntake
+			&& !self.source_signal_refs.is_empty()
+		{
+			eyre::bail!(
+				"Issue-batch intake plan `{}` must not reference autonomy signal lineage.",
+				self.plan_id
+			);
+		}
+
+		validate_optional(
+			"program intake plan source_objective_ref",
+			self.source_objective_ref.as_deref(),
+		)?;
+		validate_optional(
+			"program intake plan source_proposal_id",
+			self.source_proposal_id.as_deref(),
+		)?;
+		validate_string_list("program intake plan source_signal_refs", &self.source_signal_refs)?;
 
 		Ok(())
 	}
@@ -1778,6 +1845,36 @@ fn decision_contract_fingerprint(contract: &DecisionContract) -> Result<String> 
 	let digest = Sha256::digest(payload);
 
 	Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect::<String>())
+}
+
+fn decision_contract_provenance_reference(
+	contract: &DecisionContract,
+	kind: &str,
+) -> Option<String> {
+	contract
+		.research_provenance()
+		.iter()
+		.find(|provenance| provenance.kind() == kind)
+		.map(|provenance| provenance.reference().to_owned())
+}
+
+fn decision_contract_autonomy_signal_refs(contract: &DecisionContract) -> Vec<String> {
+	let mut refs = contract
+		.research_evidence()
+		.iter()
+		.filter_map(|evidence| {
+			if evidence.kind().starts_with("autonomy_signal:") {
+				evidence.source_ref().map(str::to_owned)
+			} else {
+				None
+			}
+		})
+		.collect::<Vec<_>>();
+
+	refs.sort();
+	refs.dedup();
+
+	refs
 }
 
 fn execution_program_schema() -> String {

--- a/apps/decodex/src/loop_contract.rs
+++ b/apps/decodex/src/loop_contract.rs
@@ -83,6 +83,14 @@ impl DecisionContract {
 		&self.research_options
 	}
 
+	pub(crate) fn research_provenance(&self) -> &[DecisionResearchProvenance] {
+		&self.research_provenance
+	}
+
+	pub(crate) fn research_evidence(&self) -> &[DecisionResearchEvidence] {
+		&self.research_evidence
+	}
+
 	pub(crate) fn execution_readiness(&self) -> &DecisionExecutionReadiness {
 		&self.execution_readiness
 	}
@@ -305,6 +313,14 @@ pub(crate) struct DecisionResearchProvenance {
 	summary: String,
 }
 impl DecisionResearchProvenance {
+	pub(crate) fn kind(&self) -> &str {
+		&self.kind
+	}
+
+	pub(crate) fn reference(&self) -> &str {
+		&self.reference
+	}
+
 	fn validate(&self) -> Result<()> {
 		validate_required("decision contract research_provenance.kind", &self.kind)?;
 		validate_required("decision contract research_provenance.reference", &self.reference)?;
@@ -324,6 +340,14 @@ pub(crate) struct DecisionResearchEvidence {
 	source_ref: Option<String>,
 }
 impl DecisionResearchEvidence {
+	pub(crate) fn kind(&self) -> &str {
+		&self.kind
+	}
+
+	pub(crate) fn source_ref(&self) -> Option<&str> {
+		self.source_ref.as_deref()
+	}
+
 	fn validate(&self) -> Result<()> {
 		validate_required("decision contract research_evidence.kind", &self.kind)?;
 		validate_required("decision contract research_evidence.claim", &self.claim)?;

--- a/apps/decodex/src/program_intake.rs
+++ b/apps/decodex/src/program_intake.rs
@@ -665,8 +665,12 @@ fn goal_issue_plans(contract: &DecisionContract, program_id: &str) -> Result<Vec
 			validation: &validation,
 			risk: &risk,
 		})?;
+		let private_identifiers =
+			generated_issue_private_identifiers(contract, program_id, &node_id);
+		let private_identifier_refs =
+			private_identifiers.iter().map(String::as_str).collect::<Vec<_>>();
 
-		validate_generated_issue_text(&title, &description, &[program_id, &node_id])?;
+		validate_generated_issue_text(&title, &description, &private_identifier_refs)?;
 
 		plans.push(GoalIssuePlan {
 			key: issue.key().to_owned(),
@@ -1011,11 +1015,18 @@ fn render_goal_issue_brief(input: GoalIssueBriefInput<'_>) -> Result<String> {
 	append_heading(&mut output, "Authority");
 	append_item(
 		&mut output,
-		&format!("Accepted Decision Contract: `{}`", input.contract.contract_id()),
+		"Accepted Decision Contract authority is recorded in Decodex runtime state.",
 	);
 	append_optional_item(
 		&mut output,
 		"Source issue",
+		input.contract.source_intent().source_issue_identifier(),
+	);
+	append_heading(&mut output, "Required Reading");
+	append_item(&mut output, "This issue brief.");
+	append_optional_item(
+		&mut output,
+		"Linked source issue",
 		input.contract.source_intent().source_issue_identifier(),
 	);
 	append_heading(&mut output, "Scope");
@@ -1023,16 +1034,37 @@ fn render_goal_issue_brief(input: GoalIssueBriefInput<'_>) -> Result<String> {
 	append_items(&mut output, input.contract.accepted_authority().accepted_objectives());
 	append_items(&mut output, input.contract.accepted_authority().constraints());
 	append_items(&mut output, input.contract.accepted_authority().assumptions());
+	append_heading(&mut output, "Ownership Boundary");
+	append_item(
+		&mut output,
+		"Work only on this generated issue's objective and avoid unrelated cleanup.",
+	);
+	append_item(
+		&mut output,
+		"Do not use Program graph ids, queue labels, or private runtime state as execution authority.",
+	);
 	append_heading(&mut output, "Non-goals");
 	append_items_or_none(&mut output, input.contract.accepted_authority().non_goals());
 	append_heading(&mut output, "Dependencies");
 	append_items_or_none(&mut output, input.dependencies);
 	append_heading(&mut output, "Conflict Domains");
 	append_items_or_none(&mut output, &conflict_domain_labels(input.conflict_domains));
+	append_heading(&mut output, "Current-tree Landing Zone");
+	append_items_or_none(&mut output, &conflict_domain_labels(input.conflict_domains));
 	append_heading(&mut output, "Acceptance");
 	append_items(&mut output, input.acceptance);
 	append_heading(&mut output, "Validation");
 	append_items(&mut output, input.validation);
+	append_heading(&mut output, "Lifecycle Gates");
+	append_item(&mut output, "Run the repo-native validation gate before review handoff.");
+	append_item(
+		&mut output,
+		"Use normal Decodex review, PR handoff, landing, closeout, and cleanup gates.",
+	);
+	append_item(
+		&mut output,
+		"Run install or restart steps only when the owning issue or workflow requires them.",
+	);
 	append_heading(&mut output, "Risk");
 	append_items_or_none(&mut output, input.risk);
 	append_heading(&mut output, "Stop Conditions");
@@ -1117,6 +1149,33 @@ fn ensure_no_generated_issue_private_identifier(
 	}
 
 	Ok(())
+}
+
+fn generated_issue_private_identifiers(
+	contract: &DecisionContract,
+	program_id: &str,
+	node_id: &str,
+) -> Vec<String> {
+	let mut identifiers = vec![program_id.to_owned(), node_id.to_owned()];
+
+	identifiers.extend(contract.research_provenance().iter().filter_map(|provenance| {
+		if matches!(provenance.kind(), "autonomy_objective" | "autonomy_proposal") {
+			Some(provenance.reference().to_owned())
+		} else {
+			None
+		}
+	}));
+	identifiers.extend(contract.research_evidence().iter().filter_map(|evidence| {
+		if evidence.kind().starts_with("autonomy_signal:") {
+			evidence.source_ref().map(str::to_owned)
+		} else {
+			None
+		}
+	}));
+	identifiers.sort();
+	identifiers.dedup();
+
+	identifiers
 }
 
 fn goal_objective_lineage(contract: &DecisionContract) -> Vec<String> {
@@ -1641,7 +1700,8 @@ mod tests {
 		loop_contract::{DecisionContract, DecisionPromotion, DecisionPromotionActorKind},
 		prelude::eyre,
 		program_intake::{
-			self, GoalIntakeIssueAction, GoalIntakeRunRequest, IssueBatchIntakeClassification,
+			self, GoalIntakeIssueAction, GoalIntakeReport, GoalIntakeRunRequest,
+			IssueBatchIntakeClassification,
 		},
 		state::StateStore,
 		tracker::{
@@ -2088,6 +2148,18 @@ mod tests {
 		})
 		.expect("apply should materialize issues and program");
 
+		assert_goal_intake_apply_report(&report, &tracker);
+		assert_goal_intake_runtime_links(&store, &report);
+
+		let updated = tracker
+			.get_issue_by_identifier("XY-G1")
+			.expect("issue lookup should work")
+			.expect("updated issue should exist");
+
+		assert_goal_issue_brief_is_public(&updated.description, &report);
+	}
+
+	fn assert_goal_intake_apply_report(report: &GoalIntakeReport, tracker: &FakeTracker) {
 		assert!(report.applied);
 		assert!(report.persisted);
 		assert_eq!(tracker.updated_issue_count(), 1);
@@ -2102,81 +2174,104 @@ mod tests {
 				.iter()
 				.any(|reason| reason.contains("has not reached a required terminal state"))
 		);
+	}
 
+	fn assert_goal_intake_runtime_links(store: &StateStore, report: &GoalIntakeReport) {
 		let linked_contract = store
 			.decision_contract("decodex", "goal-intake-contract")
 			.expect("contract lookup should read")
 			.expect("contract should exist");
+		let node_ids = report.issues.iter().map(|issue| issue.node_id.clone()).collect::<Vec<_>>();
 
 		assert_eq!(
 			linked_contract.contract().links().generated_issue_identifiers(),
 			&[String::from("XY-G1"), String::from("XY-G2")]
 		);
-		assert_eq!(
-			linked_contract.contract().links().execution_program_node_ids(),
-			&report.issues.iter().map(|issue| issue.node_id.clone()).collect::<Vec<_>>()
-		);
+		assert_eq!(linked_contract.contract().links().execution_program_node_ids(), &node_ids);
 
 		let programs = store
 			.list_execution_programs_for_contract("decodex", "goal-intake-contract")
 			.expect("programs should list");
-
-		assert_eq!(programs.len(), 1);
-		assert_eq!(programs[0].program_id(), report.program_id);
-
 		let intake_plans =
 			store.list_program_intake_plans("decodex").expect("intake plans should list");
 
+		assert_eq!(programs.len(), 1);
+		assert_eq!(programs[0].program_id(), report.program_id);
 		assert_eq!(intake_plans.len(), 1);
 		assert_eq!(intake_plans[0].intake_kind(), "goal_intake");
 		assert_eq!(intake_plans[0].source_contract_id(), Some("goal-intake-contract"));
 
-		let mappings = store
-			.list_program_issue_mappings("decodex", &report.program_id)
-			.expect("mappings should list");
+		assert_goal_intake_plan_lineage(&programs[0]);
 
-		assert_eq!(mappings.len(), 2);
-
-		let updated = tracker
-			.get_issue_by_identifier("XY-G1")
-			.expect("issue lookup should work")
-			.expect("updated issue should exist");
-
-		assert!(updated.description.contains("## Objective"));
-		assert!(updated.description.contains("## Authority"));
-		assert!(updated.description.contains("Accepted Decision Contract: `goal-intake-contract`"));
-		assert!(updated.description.contains("Source issue: `XY-852`"));
-		assert!(updated.description.contains("## Dependencies"));
-		assert!(updated.description.contains("## Acceptance"));
-		assert!(
-			updated
-				.description
-				.contains("Goal intake dry-run renders generated issue briefs without mutation.")
+		assert_eq!(
+			store
+				.list_program_issue_mappings("decodex", &report.program_id)
+				.expect("mappings should list")
+				.len(),
+			2
 		);
-		assert!(updated.description.contains("## Validation"));
-		assert!(updated.description.contains("Run cargo make test before handoff."));
-		assert!(updated.description.contains("## Risk"));
-		assert!(
-			updated
-				.description
-				.contains("Generated issue descriptions must stay natural-language.")
-		);
-		assert!(updated.description.contains("## Stop Conditions"));
-		assert!(
-			updated
-				.description
-				.contains("Stop when promotion authority or required decisions are missing.")
-		);
-		assert!(!updated.description.contains("Execution Program: `"));
-		assert!(!updated.description.contains("Execution Program node:"));
-		assert!(!updated.description.contains(&report.program_id));
+	}
 
-		for issue in &report.issues {
-			assert!(!updated.description.contains(&issue.node_id));
+	fn assert_goal_intake_plan_lineage(record: &crate::state::ExecutionProgramRecord) {
+		let intake_plan = record
+			.program()
+			.program_intake_plan()
+			.expect("program payload should retain intake plan lineage");
+
+		assert_eq!(intake_plan.source_objective_ref(), Some("decodex:quality-autonomy@1"));
+		assert_eq!(intake_plan.source_proposal_id(), Some("autonomy_proposal:test-proposal"));
+		assert_eq!(
+			intake_plan.source_signal_refs(),
+			&[String::from("autonomy_signal:test-signal")]
+		);
+	}
+
+	fn assert_goal_issue_brief_is_public(description: &str, report: &GoalIntakeReport) {
+		for heading in [
+			"## Objective",
+			"## Authority",
+			"## Required Reading",
+			"## Ownership Boundary",
+			"## Dependencies",
+			"## Current-tree Landing Zone",
+			"## Acceptance",
+			"## Validation",
+			"## Lifecycle Gates",
+			"## Risk",
+			"## Stop Conditions",
+		] {
+			assert!(description.contains(heading));
 		}
 
-		assert!(!updated.description.contains("```"));
-		assert!(!updated.description.contains("private_evidence_refs"));
+		assert!(description.contains(
+			"Accepted Decision Contract authority is recorded in Decodex runtime state."
+		));
+		assert!(description.contains("Source issue: `XY-852`"));
+		assert!(description.contains("Goal intake dry-run renders generated issue briefs"));
+		assert!(description.contains("Use normal Decodex review, PR handoff, landing"));
+		assert!(description.contains("Run install or restart steps only when"));
+		assert!(description.contains("Stop when promotion authority"));
+
+		assert_goal_issue_brief_hides_private_ids(description, report);
+	}
+
+	fn assert_goal_issue_brief_hides_private_ids(description: &str, report: &GoalIntakeReport) {
+		for private_id in [
+			"Execution Program: `",
+			"Execution Program node:",
+			"goal-intake-contract",
+			"autonomy_proposal:test-proposal",
+			"decodex:quality-autonomy@1",
+			"autonomy_signal:test-signal",
+			&report.program_id,
+			"```",
+			"private_evidence_refs",
+		] {
+			assert!(!description.contains(private_id));
+		}
+		for issue in &report.issues {
+			assert!(!description.contains(&issue.node_id));
+		}
 	}
 
 	#[test]
@@ -2206,6 +2301,50 @@ mod tests {
 				"generated issue description contains a private Program Intake identifier"
 			)
 		);
+	}
+
+	#[test]
+	fn goal_intake_apply_rejects_generated_briefs_that_leak_autonomy_lineage_ids() {
+		let store = StateStore::open_in_memory().expect("store should open");
+		let mut payload = serde_json::to_value(accepted_goal_contract())
+			.expect("accepted goal contract should serialize");
+
+		payload["accepted_authority"]["constraints"]
+			.as_array_mut()
+			.expect("constraints should be an array")
+			.push(serde_json::json!(
+				"Do not expose autonomy_signal:test-signal in generated issue text."
+			));
+
+		let leaking_contract: DecisionContract =
+			serde_json::from_value(payload).expect("leaking contract should deserialize");
+
+		store
+			.upsert_decision_contract("decodex", Some("XY-852"), leaking_contract)
+			.expect("contract should persist");
+
+		let tracker = FakeTracker::default().with_issues([issue("XY-852", "Todo")]);
+		let config = test_config();
+		let workflow = workflow();
+		let error = program_intake::run_goal_intake(GoalIntakeRunRequest {
+			state_store: &store,
+			tracker: &tracker,
+			config: &config,
+			workflow: &workflow,
+			contract_id: "goal-intake-contract",
+			team_issue_identifier: None,
+			dry_run: false,
+			apply: true,
+		})
+		.expect_err("private autonomy lineage ids must fail generated brief validation");
+
+		assert!(
+			error.to_string().contains(
+				"generated issue description contains a private Program Intake identifier"
+			)
+		);
+		assert_eq!(tracker.created_issue_count(), 0);
+		assert!(store.list_execution_programs("decodex").expect("programs").is_empty());
 	}
 
 	#[test]
@@ -2342,122 +2481,137 @@ mod tests {
 	}
 
 	fn latent_goal_contract() -> DecisionContract {
-		serde_json::from_value(serde_json::json!({
+		serde_json::from_value(latent_goal_contract_payload())
+			.expect("goal contract should deserialize")
+	}
+
+	fn latent_goal_contract_payload() -> serde_json::Value {
+		serde_json::json!({
 			"schema": crate::loop_contract::DECISION_CONTRACT_SCHEMA,
 			"record_version": crate::loop_contract::DECISION_CONTRACT_RECORD_VERSION,
 			"contract_id": "goal-intake-contract",
 			"status": "draft_latent",
-			"source_intent": {
-				"summary": "Ship promoted goal intake.",
-				"user_utterance": "arrange this goal",
-				"source_issue_identifier": "XY-852",
-			},
-			"research_provenance": [
-				{
-					"kind": "spec",
-					"reference": "docs/spec/loop-runtime.md",
-					"summary": "Promoted contracts can shape normal Linear issues."
-				}
-			],
-			"research_evidence": [
-				{
-					"claim": "Goal intake needs generated issues and an internal program.",
-					"support": "The loop-runtime spec defines Program Intake and Execution Program records.",
-					"source_ref": "docs/spec/loop-runtime.md"
-				}
-			],
+			"source_intent": latent_goal_source_intent(),
+			"research_provenance": latent_goal_research_provenance(),
+			"research_evidence": latent_goal_research_evidence(),
 			"research_options": [],
-			"accepted_authority": {
-				"accepted_objectives": [
-					"Materialize accepted goal intake into normal Linear issues.",
-					"Persist the internal Execution Program without exposing graph mechanics."
-				],
-				"non_goals": [
-					"Do not run implementation from goal intake."
-				],
-				"constraints": [
-					"Linear receives only public-safe issue briefs and sparse links."
-				],
-				"assumptions": [
-					"The source issue anchors the generated issue team."
-				],
-				"objections": [],
-				"stop_conditions": [
-					"Stop when promotion authority or required decisions are missing."
-				]
-			},
-			"execution_readiness": {
-				"summary": "Ready for issue shaping after promotion.",
-				"ready_for_issue_shaping": true,
-				"missing_decisions": [],
-				"validation_expectations": [
-					"Run cargo make test before handoff."
-				],
-				"risk_notes": [
-					"Generated issue descriptions must stay natural-language."
-				],
-				"proposed_issues": [
-					{
-						"key": "goal-intake-runtime",
-						"title": "Implement goal intake CLI/API behavior.",
-						"objective": "Implement goal intake CLI/API behavior.",
-						"stage": "runtime",
-						"dependencies": [],
-						"conflict_domains": [
-							"module:runtime"
-						],
-						"acceptance": [
-							"Goal intake dry-run renders generated issue briefs without mutation."
-						],
-						"validation": [
-							"Run cargo make test before handoff."
-						],
-						"risk": [
-							"Generated issue descriptions must stay natural-language."
-						],
-						"queue_intent": "ready_to_queue"
-					},
-					{
-						"key": "goal-intake-links",
-						"title": "Persist Execution Program links for generated issues.",
-						"objective": "Persist Execution Program links for generated issues.",
-						"stage": "runtime",
-						"dependencies": [
-							"goal-intake-runtime"
-						],
-						"conflict_domains": [
-							"module:runtime",
-							"file:docs/spec/loop-runtime.md"
-						],
-						"acceptance": [
-							"Apply links generated issue identifiers and execution nodes back to the accepted contract."
-						],
-						"validation": [
-							"Run cargo make test before handoff."
-						],
-						"risk": [
-							"Generated issue descriptions must stay natural-language."
-						],
-						"queue_intent": "ready_to_queue"
-					}
-				],
-				"conflict_domains": [
-					"module:runtime",
-					"file:docs/spec/loop-runtime.md"
-				]
-			},
+			"accepted_authority": latent_goal_accepted_authority(),
+			"execution_readiness": latent_goal_execution_readiness(),
 			"links": {
 				"generated_issue_ids": [],
 				"generated_issue_identifiers": [],
-				"execution_program_node_ids": []
-			},
-			"evidence_boundary": {
-				"private_evidence_refs": [],
-				"public_projection_refs": [],
+			"execution_program_node_ids": []
+		},
+		"evidence_boundary": {
+			"private_evidence_refs": [],
+			"public_projection_refs": [],
 				"public_summary": "Goal intake contract ready for issue shaping."
 			}
-		}))
-		.expect("goal contract should deserialize")
+		})
+	}
+
+	fn latent_goal_source_intent() -> serde_json::Value {
+		serde_json::json!({
+			"summary": "Ship promoted goal intake.",
+			"user_utterance": "arrange this goal",
+			"source_issue_identifier": "XY-852",
+		})
+	}
+
+	fn latent_goal_research_provenance() -> serde_json::Value {
+		serde_json::json!([
+			{
+				"kind": "autonomy_proposal",
+				"reference": "autonomy_proposal:test-proposal",
+				"summary": "Accepted autonomy proposal produced this Decision Contract candidate."
+			},
+			{
+				"kind": "autonomy_objective",
+				"reference": "decodex:quality-autonomy@1",
+				"summary": "Accepted autonomy objective version."
+			},
+			{
+				"kind": "spec",
+				"reference": "docs/spec/loop-runtime.md",
+				"summary": "Promoted contracts can shape normal Linear issues."
+			}
+		])
+	}
+
+	fn latent_goal_research_evidence() -> serde_json::Value {
+		serde_json::json!([
+			{
+				"kind": "autonomy_signal:runtime_health",
+				"claim": "Autonomy signal `autonomy_signal:test-signal` contributed.",
+				"support": "freshness=fresh; evidence_class=repo_source; confidence=high",
+				"source_ref": "autonomy_signal:test-signal"
+			},
+			{
+				"claim": "Goal intake needs generated issues and an internal program.",
+				"support": "The loop-runtime spec defines Program Intake records.",
+				"source_ref": "docs/spec/loop-runtime.md"
+			}
+		])
+	}
+
+	fn latent_goal_accepted_authority() -> serde_json::Value {
+		serde_json::json!({
+			"accepted_objectives": [
+				"Materialize accepted goal intake into normal Linear issues.",
+				"Persist the internal Execution Program without exposing graph mechanics."
+			],
+			"non_goals": ["Do not run implementation from goal intake."],
+			"constraints": ["Linear receives only public-safe issue briefs and sparse links."],
+			"assumptions": ["The source issue anchors the generated issue team."],
+			"objections": [],
+			"stop_conditions": [
+				"Stop when promotion authority or required decisions are missing."
+			]
+		})
+	}
+
+	fn latent_goal_execution_readiness() -> serde_json::Value {
+		serde_json::json!({
+			"summary": "Ready for issue shaping after promotion.",
+			"ready_for_issue_shaping": true,
+			"missing_decisions": [],
+			"validation_expectations": ["Run cargo make test before handoff."],
+			"risk_notes": ["Generated issue descriptions must stay natural-language."],
+			"proposed_issues": [goal_intake_runtime_issue(), goal_intake_links_issue()],
+			"conflict_domains": ["module:runtime", "file:docs/spec/loop-runtime.md"]
+		})
+	}
+
+	fn goal_intake_runtime_issue() -> serde_json::Value {
+		serde_json::json!({
+			"key": "goal-intake-runtime",
+			"title": "Implement goal intake CLI/API behavior.",
+			"objective": "Implement goal intake CLI/API behavior.",
+			"stage": "runtime",
+			"dependencies": [],
+			"conflict_domains": ["module:runtime"],
+			"acceptance": ["Goal intake dry-run renders generated issue briefs without mutation."],
+			"validation": ["Run cargo make test before handoff."],
+			"risk": ["Generated issue descriptions must stay natural-language."],
+			"queue_intent": "ready_to_queue"
+		})
+	}
+
+	fn goal_intake_links_issue() -> serde_json::Value {
+		serde_json::json!({
+			"key": "goal-intake-links",
+			"title": "Persist Execution Program links for generated issues.",
+			"objective": "Persist Execution Program links for generated issues.",
+			"stage": "runtime",
+			"dependencies": ["goal-intake-runtime"],
+			"conflict_domains": ["module:runtime", "file:docs/spec/loop-runtime.md"],
+			"acceptance": [
+				"Apply links generated issue identifiers and execution nodes back to the accepted contract."
+			],
+			"validation": ["Run cargo make test before handoff."],
+			"risk": ["Generated issue descriptions must stay natural-language."],
+			"queue_intent": "ready_to_queue"
+		})
 	}
 
 	fn accepted_goal_contract() -> DecisionContract {

--- a/docs/spec/autonomy-control-plane.md
+++ b/docs/spec/autonomy-control-plane.md
@@ -44,7 +44,7 @@ drift_watch:
   - Program Intake
   - finding_routes
   - decodex mcp serve
-last_verified: 2026-06-22
+last_verified: 2026-06-23
 ---
 # Autonomy Control Plane
 
@@ -385,6 +385,12 @@ Every executable proposal must become a normal Decodex execution surface. For
 tracker-backed work this means a normal issue with a cold-start dispatch brief.
 Private pointers, proposal ids, report text, or graph ids do not substitute for the
 brief.
+When accepted autonomy work is materialized through Program Intake, runtime state must
+retain the replay chain from Objective Contract version to signal-derived proposal,
+Decision Contract, Program Intake Plan, Execution Program, and generated normal issue
+links. That lineage remains private runtime metadata; generated tracker issue text
+stays a natural-language brief and must not expose signal ids, proposal ids, Program
+ids, node ids, or graph mechanics.
 
 ## MCP And Skill Action Matrix
 

--- a/docs/spec/loop-runtime.md
+++ b/docs/spec/loop-runtime.md
@@ -8,7 +8,7 @@ owner: runtime
 tags: [spec]
 code_refs: [apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/prompting.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/research_design.rs, apps/decodex/src/autonomy_proposal.rs, apps/decodex/src/loop_contract.rs, apps/decodex/src/execution_program.rs, apps/decodex/src/program_intake.rs]
 drift_watch: [phase_goal, phase_acceptance_check, docs_impact, review_contract, issue_review_checkpoint, decodex.autonomy_proposal/1, decodex.decision_contract/1, execution_program, decodex research compile, decodex research promote, decodex intake goal]
-last_verified: 2026-06-22
+last_verified: 2026-06-23
 ---
 # Loop Runtime Specification
 
@@ -396,6 +396,9 @@ The payload carries:
 | `service_id` | Registered service that owns program scheduling for this plan. |
 | `intake_kind` | `goal_intake` for promoted natural-language goals, or `issue_batch_intake` for a supplied batch of executable issue briefs. |
 | `source_contract_id` | Accepted Decision Contract id for goal intake, when present. |
+| `source_objective_ref` | Optional private Objective Contract lineage for accepted autonomy-derived goal intake. |
+| `source_proposal_id` | Optional private autonomy proposal id for accepted autonomy-derived goal intake. |
+| `source_signal_refs` | Optional private autonomy signal ids that contributed to the accepted autonomy-derived proposal. |
 | `accepted_contract_fingerprint` | Fingerprint used to detect drift from the accepted contract or batch boundary. |
 | `public_summary` | Public-safe objective/readiness summary suitable for status readback. |
 | `node_projection` | Optional public-safe node summary or count metadata. The full internal nodes, dependencies, conflict domains, issue mapping, dispatch readiness, and lifecycle evaluation inputs live in the paired `decodex.execution_program/1` payload. |
@@ -415,10 +418,13 @@ summary, required reading, in-scope work, explicit non-goals, current-tree landi
 zone, ownership boundary, acceptance criteria, validation expectations, stop
 conditions, and any real dependencies, blockers, or conflict domains. The public
 authority summary may cite the accepted Decision Contract or source issue, but it must
-not render the internal Execution Program id or node id. At minimum, runtime
-eligibility rejects a machine-only fenced block as the issue description; private
-pointers, progress checkpoints, review summaries, PR bodies, or runtime events do not
-substitute for the issue briefing.
+not render autonomy signal ids, autonomy proposal ids, internal Execution Program ids,
+Program node ids, or graph mechanics. It must also preserve the normal lane lifecycle
+by naming validation, review, PR handoff, landing, install/restart when applicable,
+closeout, and cleanup as gates owned by the normal Decodex runtime rather than by
+Program Intake. At minimum, runtime eligibility rejects a machine-only fenced block as
+the issue description; private pointers, progress checkpoints, review summaries, PR
+bodies, or runtime events do not substitute for the issue briefing.
 
 The operator CLI surface for promoted goals is
 `decodex intake goal --project <service-id> <CONTRACT_ID> --dry-run`, or the same

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -118,11 +118,16 @@ state or this state machine.
   without mutating Linear or persisting Program Intake rows. `--apply` creates or
   updates generated normal Linear issue briefs, links generated issue ids and internal
   node ids back into private runtime records, and persists the local Program Intake
-  Plan plus Execution Program state. The Linear description stays a natural-language
-  issue brief with objective, public authority summary, acceptance, validation, and
-  stop conditions; it must not include Execution Program ids or node ids. It must not
-  start implementation inline and must not apply queue labels; direct Program dispatch
-  is performed by the scheduler after the Program is persisted.
+  Plan plus Execution Program state. When the contract came from accepted autonomy
+  work, the Program Intake Plan preserves objective, signal, and proposal lineage
+  privately so the runtime can replay objective -> signal -> proposal -> Decision
+  Contract -> intake -> program -> generated issue links. The Linear description
+  stays a natural-language issue brief with objective, public authority summary,
+  ownership boundary, acceptance, validation, lifecycle gates, and stop conditions; it
+  must not include autonomy signal ids, autonomy proposal ids, Execution Program ids,
+  Program node ids, or graph mechanics. It must not start implementation inline and
+  must not apply queue labels; direct Program dispatch is performed by the scheduler
+  after the Program is persisted.
 - `decodex intake issues <ISSUE>... --dry-run` is a tracker-read-only operator
   surface for existing Linear issues. It classifies the supplied batch as ready,
   held, blocked, stale, or unmapped and builds the same internal program model used
@@ -146,7 +151,7 @@ mirror:
 | Runtime SQLite `autonomy_signals` | Versioned `decodex.autonomy_signal/1` payloads scoped by project and exact Objective Contract id/version. Rows are read-only evidence for future proposal compilation, expose freshness, gaps, contradictions, confidence, and privacy in status readback, and do not mutate tracker state, runtime authority rows outside signal persistence, worktrees, GitHub, Program Intake, proposals, or execution state. |
 | Runtime SQLite `autonomy_proposals` | Versioned `decodex.autonomy_proposal/1` dry-run records scoped by project, exact Objective Contract id/version, and referenced signal ids. Rows expose stable evidence-bound proposal identity, objective lineage, source signals, goals, metrics, non-goals, allowed surfaces, validation gates, review and challenge requirements, rejected alternatives, rollback path, contradictions, gaps, refusal reasons, and challenge evidence in readback. Proposal persistence remains non-executable and must not mutate tracker state, GitHub, worktrees, Program Intake, Decision Contracts, or execution state. |
 | Runtime SQLite `execution_programs` | Versioned `decodex.execution_program/1` payloads with embedded or linked `decodex.program_intake_plan/1` planning data. They hold internal node lifecycle/readiness, dependency, conflict-domain, dispatch intent, drift, and normal-issue mapping; Linear issue descriptions and ledger comments are only coarse projections. |
-| Runtime SQLite `program_intake_plans` | Queryable local projection of `decodex.program_intake_plan/1` metadata, including intake kind, source contract when present, authority fingerprint, and public-safe summary. |
+| Runtime SQLite `program_intake_plans` | Queryable local projection of `decodex.program_intake_plan/1` metadata, including intake kind, source contract when present, authority fingerprint, and public-safe summary. The paired versioned program payload retains optional private objective/signal/proposal lineage for accepted autonomy-derived intake. |
 | Runtime SQLite `program_issue_mappings` | Queryable local projection of each internal program node's mapped Linear issue, tracker state, dispatch intent, active/manual/attention facts, and dispatch-briefing fact. |
 | Runtime SQLite `run_control_channels` | Local control capability metadata for active run attempts. It records the project, issue, run id, attempt, transport, local channel path, channel status, and publish/update timestamps needed to route future control requests without bypassing run lease ownership. |
 | Runtime SQLite `review_lifecycle_records` | Single authoritative post-review record for one retained PR-backed lane. It stores handoff identity, PR URL, base/head branch, validated head OID, current post-review phase, review-request metadata, landing/closeout/repair state, evidence, and next action. Handoff and orchestration tool-boundary shapes are projections of this record, not separate durable authority. Historical `review_handoffs` and `review_orchestrations` tables are dropped during bootstrap, not migrated or used as readback authority. |


### PR DESCRIPTION
## Summary
- Link accepted autonomy objective/proposal/signal lineage into Program Intake Plan and Execution Program runtime state.
- Render generated tracker-backed work as normal cold-start issue briefs while rejecting private Program/autonomy id leaks.
- Update runtime specs for the private replay chain and normal lifecycle gate preservation.

## Validation
- cargo make fmt
- cargo make lint-fix
- cargo test -p decodex program_intake --lib
- cargo test -p decodex orchestrator --lib
- cargo make fmt-check
- cargo make check-docs
- cargo make test

## Review
- Independent read-only Decodex Review checkpoint: clean for HEAD fde21e88c8ae8133ccb3ae9c10032943e44df8d6.