### PR TITLE
Fix continuation retry status projection

### DIFF
--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -1906,6 +1906,12 @@ fn worktree_ownership(
 				next_action: Some(run.lane_control_next_action.clone()),
 				audit_required: true,
 			},
+			"continuation_pending" => WorktreeOwnership {
+				kind: "continuation_pending",
+				reason: format!("Lane `{}` is waiting for scheduled continuation re-entry.", run.run_id),
+				next_action: Some(run.lane_control_next_action.clone()),
+				audit_required: false,
+			},
 			_ => WorktreeOwnership {
 				kind: "orphaned_local_worktree",
 				reason: format!("Lane `{}` is not an active owner for this worktree.", run.run_id),
@@ -1990,7 +1996,11 @@ fn worktree_current_lane_owner<'a>(
 		.find(|run| {
 			matches!(
 				run.ownership_state.as_str(),
-				"leased_run" | "retained_attention" | "orphaned_live_thread" | "terminalizing"
+				"leased_run"
+					| "retained_attention"
+					| "orphaned_live_thread"
+					| "terminalizing"
+					| "continuation_pending"
 			) && (run.worktree_path.as_deref() == Some(worktree.worktree_path.as_str())
 				|| run.branch_name.as_deref() == Some(worktree.branch_name.as_str())
 				|| run.issue_id == worktree.issue_id)
@@ -7847,6 +7857,9 @@ fn operator_run_ownership_state(
 	{
 		return String::from("retained_attention");
 	}
+	if operator_run_is_continuation_wait(run) {
+		return String::from("continuation_pending");
+	}
 	if !run.run_lease
 		&& matches!(liveness_state, "process_alive" | "thread_active" | "protocol_recent")
 	{
@@ -7860,6 +7873,13 @@ fn operator_run_ownership_state(
 	}
 
 	String::from("closed")
+}
+
+fn operator_run_is_continuation_wait(run: &OperatorRunStatus) -> bool {
+	run.attempt_status == CONTINUATION_PENDING_RUN_STATUS
+		|| run.phase == "waiting_continuation"
+		|| run.retry_kind.as_deref() == Some("continuation")
+		|| run.wait_reason.as_deref() == Some("continuation_retry")
 }
 
 fn operator_run_liveness_state(run: &OperatorRunStatus) -> String {
@@ -8032,6 +8052,9 @@ fn operator_run_lane_control_next_action(
 		}
 
 		return String::from("continue_owned_attempt");
+	}
+	if ownership_state == "continuation_pending" {
+		return String::from("wait_for_continuation_reentry");
 	}
 	if ownership_state == "closed" {
 		return String::from("no_action");
@@ -11004,7 +11027,11 @@ fn rendered_worktree_role<'a>(
 
 fn rendered_worktree_role_rank(role: &str) -> u8 {
 	match role {
-		"current_lane" | "running_lane" | "blocked_queue_issue" | "queued_attention" => 0,
+		"current_lane"
+		| "running_lane"
+		| "blocked_queue_issue"
+		| "queued_attention"
+		| "continuation_pending" => 0,
 		"post_review_lane" => 1,
 		_ => 2,
 	}

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -2359,6 +2359,58 @@ fn operator_status_snapshot_reports_retry_backoff_from_worktree_marker() {
 }
 
 #[test]
+fn operator_status_snapshot_keeps_continuation_retry_from_orphaning_live_marker_worktree() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue("Todo", &[]);
+	let worktree_path = config.worktree_root().join("PUB-101");
+
+	state_store
+		.record_run_attempt("run-1", &issue.id, 1, "continuation_pending")
+		.expect("run attempt should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+	state::write_run_activity_marker_for_process(&worktree_path, "run-1", 1, process::id())
+		.expect("live marker should write");
+	state::write_run_retry_schedule(
+		&worktree_path,
+		"run-1",
+		1,
+		"continuation",
+		OffsetDateTime::now_utc().unix_timestamp() + 60,
+	)
+	.expect("continuation retry schedule marker should write");
+
+	let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+		.expect("snapshot should build");
+	let run = snapshot.recent_runs.first().expect("recent run should exist");
+	let rendered = orchestrator::render_operator_status(&snapshot);
+
+	assert!(snapshot.current_lanes.is_empty());
+	assert_eq!(run.status, "continuation_pending");
+	assert_eq!(run.phase, "retry_backoff");
+	assert_eq!(run.wait_reason.as_deref(), Some("continuation_retry"));
+	assert_eq!(run.retry_kind.as_deref(), Some("continuation"));
+	assert_eq!(run.ownership_state, "continuation_pending");
+	assert_eq!(run.liveness_state, "process_alive");
+	assert_eq!(run.lane_control_next_action, "wait_for_continuation_reentry");
+	assert_eq!(snapshot.worktrees[0].ownership, "continuation_pending");
+	assert_eq!(snapshot.projects[0].retained_worktree_count, 0);
+	assert_eq!(snapshot.projects[0].waiting_lane_count, 1);
+	assert!(rendered.contains("Recovery worktrees: 0"));
+	assert!(rendered.contains("- none (owned worktrees are shown in their lane sections above)"));
+	assert!(!rendered.contains("role: orphaned_live_thread"));
+}
+
+#[test]
 fn operator_status_snapshot_ignores_retry_schedule_on_running_attempt() {
 	let (_temp_dir, config, _workflow) = temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");


### PR DESCRIPTION
## Summary
- classify scheduled continuation retry waits as continuation_pending instead of orphaned_live_thread
- keep continuation retry worktrees out of recovery/retained counts
- add operator status regression coverage for live-marker/no-lease continuation retry waits

## Validation
- cargo test -p decodex operator_status_snapshot_keeps_continuation_retry_from_orphaning_live_marker_worktree --lib
- cargo make fmt
- cargo test -p decodex orchestrator::tests::operator_status --lib
- cargo make lint-fix
- cargo make test
- cargo make check-docs
- git diff --check