### PR TITLE
XY-1089: [Autonomy P6] Surface autonomy lineage in operator and app readback

### DIFF
--- a/apps/decodex/src/autonomy_proposal.rs
+++ b/apps/decodex/src/autonomy_proposal.rs
@@ -430,6 +430,14 @@ impl AutonomyProposalRefusal {
 		self.reason
 	}
 
+	pub(crate) fn detail(&self) -> &str {
+		&self.detail
+	}
+
+	pub(crate) fn evidence_refs(&self) -> &[String] {
+		&self.evidence_refs
+	}
+
 	fn new(
 		reason: AutonomyProposalRefusalReason,
 		detail: impl Into<String>,
@@ -661,6 +669,14 @@ impl AutonomyProposal {
 
 	pub(crate) fn intended_surface(&self) -> &str {
 		&self.intended_surface
+	}
+
+	pub(crate) fn affected_identifiers(&self) -> &[String] {
+		&self.affected_identifiers
+	}
+
+	pub(crate) fn summary(&self) -> &str {
+		&self.summary
 	}
 
 	pub(crate) fn source_signal_ids(&self) -> &[String] {

--- a/apps/decodex/src/autonomy_signal.rs
+++ b/apps/decodex/src/autonomy_signal.rs
@@ -56,7 +56,7 @@ pub(crate) enum AutonomySignalSourceType {
 	Report,
 }
 impl AutonomySignalSourceType {
-	fn as_str(self) -> &'static str {
+	pub(crate) fn as_str(self) -> &'static str {
 		match self {
 			Self::User => "user",
 			Self::Review => "review",
@@ -336,6 +336,10 @@ impl AutonomySignal {
 
 	pub(crate) fn kind(&self) -> AutonomySignalKind {
 		self.kind
+	}
+
+	pub(crate) fn source_type(&self) -> AutonomySignalSourceType {
+		self.source_type
 	}
 
 	pub(crate) fn freshness(&self) -> AutonomySignalFreshness {

--- a/apps/decodex/src/mcp.rs
+++ b/apps/decodex/src/mcp.rs
@@ -3746,11 +3746,143 @@ fn mcp_run_activity_summary(run: &Value) -> Value {
 			.get("phase_acceptance")
 			.map(mcp_public_phase_acceptance_status)
 			.unwrap_or(Value::Null),
+		"autonomy": mcp_public_autonomy_status(run),
 		"loop_review": run
 			.get("loop_status")
 			.and_then(mcp_loop_review_status_from_loop_status)
 			.map(mcp_public_review_status)
 			.unwrap_or(Value::Null)
+	})
+}
+
+fn mcp_public_autonomy_status(run_or_lane: &Value) -> Value {
+	let Some(loop_status) = run_or_lane.get("loop_status").filter(|status| status.is_object())
+	else {
+		return Value::Null;
+	};
+
+	serde_json::json!({
+		"status": loop_status.get("autonomy").cloned().unwrap_or(Value::Null),
+		"summary": loop_status.get("summary").cloned().unwrap_or(Value::Null),
+		"objective": loop_status
+			.get("autonomy_objective")
+			.map(mcp_public_autonomy_objective)
+			.unwrap_or(Value::Null),
+		"signals": mcp_public_autonomy_signals(loop_status.get("autonomy_signals")),
+		"proposals": mcp_public_autonomy_proposals(loop_status.get("autonomy_proposals")),
+		"lineage": mcp_public_autonomy_lineage(loop_status.get("autonomy_lineage")),
+		"report": loop_status
+			.get("autonomy_report")
+			.map(mcp_public_autonomy_report)
+			.unwrap_or(Value::Null)
+	})
+}
+
+fn mcp_public_autonomy_objective(objective: &Value) -> Value {
+	serde_json::json!({
+		"objective_id": objective.get("objective_id").cloned().unwrap_or(Value::Null),
+		"objective_version": objective
+			.get("objective_version")
+			.cloned()
+			.unwrap_or(Value::Null),
+		"state": objective.get("state").cloned().unwrap_or(Value::Null),
+		"source_ref": objective.get("source_ref").cloned().unwrap_or(Value::Null),
+		"completeness": objective.get("completeness").cloned().unwrap_or(Value::Null),
+		"known_gaps": objective.get("known_gaps").cloned().unwrap_or_else(|| serde_json::json!([]))
+	})
+}
+
+fn mcp_public_autonomy_signals(signals: Option<&Value>) -> Vec<Value> {
+	signals
+		.and_then(Value::as_array)
+		.into_iter()
+		.flatten()
+		.map(|signal| {
+			serde_json::json!({
+				"signal_id": signal.get("signal_id").cloned().unwrap_or(Value::Null),
+				"objective_id": signal.get("objective_id").cloned().unwrap_or(Value::Null),
+				"objective_version": signal.get("objective_version").cloned().unwrap_or(Value::Null),
+				"kind": signal.get("kind").cloned().unwrap_or(Value::Null),
+				"source_type": signal.get("source_type").cloned().unwrap_or(Value::Null),
+				"source_refs": signal
+					.get("source_refs")
+					.cloned()
+					.unwrap_or_else(|| serde_json::json!([])),
+				"primary_source_refs": signal
+					.get("primary_source_refs")
+					.cloned()
+					.unwrap_or_else(|| serde_json::json!([])),
+				"freshness": signal.get("freshness").cloned().unwrap_or(Value::Null),
+				"evidence_class": signal.get("evidence_class").cloned().unwrap_or(Value::Null),
+				"confidence": signal.get("confidence").cloned().unwrap_or(Value::Null),
+				"redaction_level": signal
+					.get("redaction_level")
+					.cloned()
+					.unwrap_or(Value::Null),
+				"completeness": signal.get("completeness").cloned().unwrap_or(Value::Null),
+				"known_gaps": signal
+					.get("known_gaps")
+					.cloned()
+					.unwrap_or_else(|| serde_json::json!([])),
+				"updated_at": signal.get("updated_at").cloned().unwrap_or(Value::Null)
+			})
+		})
+		.collect()
+}
+
+fn mcp_public_autonomy_proposals(proposals: Option<&Value>) -> Vec<Value> {
+	proposals
+		.and_then(Value::as_array)
+		.into_iter()
+		.flatten()
+		.map(|proposal| {
+			serde_json::json!({
+				"proposal_id": proposal.get("proposal_id").cloned().unwrap_or(Value::Null),
+				"objective_id": proposal.get("objective_id").cloned().unwrap_or(Value::Null),
+				"objective_version": proposal.get("objective_version").cloned().unwrap_or(Value::Null),
+				"state": proposal.get("state").cloned().unwrap_or(Value::Null),
+				"summary": proposal.get("summary").cloned().unwrap_or(Value::Null),
+				"source_family": proposal.get("source_family").cloned().unwrap_or(Value::Null),
+				"intended_surface": proposal
+					.get("intended_surface")
+					.cloned()
+					.unwrap_or(Value::Null),
+				"source_signal_ids": proposal
+					.get("source_signal_ids")
+					.cloned()
+					.unwrap_or_else(|| serde_json::json!([])),
+				"refusal_reasons": proposal
+					.get("refusal_reasons")
+					.cloned()
+					.unwrap_or_else(|| serde_json::json!([])),
+				"refusals": proposal
+					.get("refusals")
+					.cloned()
+					.unwrap_or_else(|| serde_json::json!([])),
+				"completeness": proposal.get("completeness").cloned().unwrap_or(Value::Null),
+				"known_gaps": proposal
+					.get("known_gaps")
+					.cloned()
+					.unwrap_or_else(|| serde_json::json!([])),
+				"updated_at": proposal.get("updated_at").cloned().unwrap_or(Value::Null)
+			})
+		})
+		.collect()
+}
+
+fn mcp_public_autonomy_lineage(lineage: Option<&Value>) -> Vec<Value> {
+	lineage.and_then(Value::as_array).into_iter().flatten().cloned().collect()
+}
+
+fn mcp_public_autonomy_report(report: &Value) -> Value {
+	serde_json::json!({
+		"surface": report.get("surface").cloned().unwrap_or(Value::Null),
+		"authority": report.get("authority").cloned().unwrap_or(Value::Null),
+		"audit_authority": report.get("audit_authority").cloned().unwrap_or(Value::Null),
+		"source_refs": report.get("source_refs").cloned().unwrap_or_else(|| serde_json::json!([])),
+		"redaction_level": report.get("redaction_level").cloned().unwrap_or(Value::Null),
+		"completeness": report.get("completeness").cloned().unwrap_or(Value::Null),
+		"known_gaps": report.get("known_gaps").cloned().unwrap_or_else(|| serde_json::json!([]))
 	})
 }
 

--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -5270,7 +5270,10 @@
 					facts.push(["Decision", loopStatus.decision_request.decision_request_id]);
 				}
 				if (loopStatus.autonomy) {
-					facts.push(["Autonomy", displayToken(loopStatus.autonomy)]);
+					facts.push(["Autonomy", autonomyReadbackLabel(loopStatus)]);
+				}
+				if (loopStatus.autonomy_objective?.source_ref) {
+					facts.push(["Objective", loopStatus.autonomy_objective.source_ref]);
 				}
 
 				return facts;
@@ -5290,7 +5293,56 @@
 					return displayToken(loopStatus.review.status);
 				}
 
-				return displayToken(loopStatus.autonomy || "");
+				return autonomyReadbackLabel(loopStatus);
+			}
+
+			function autonomyReadbackHasFreshSourceRefs(loopStatus) {
+				const signals = Array.isArray(loopStatus?.autonomy_signals)
+					? loopStatus.autonomy_signals
+					: [];
+				return signals.some((signal) => {
+					const sourceRefs = Array.isArray(signal?.source_refs) ? signal.source_refs : [];
+					return sourceRefs.length > 0 && String(signal?.freshness || "") === "fresh";
+				});
+			}
+
+			function autonomyReadbackLabel(loopStatus) {
+				if (!loopStatus?.autonomy) {
+					return "";
+				}
+				if (autonomyReadbackHasFreshSourceRefs(loopStatus)) {
+					return displayToken(loopStatus.autonomy);
+				}
+
+				return "source refs needed";
+			}
+
+			function autonomyReadbackSummary(loopStatus) {
+				if (!loopStatus) {
+					return "none";
+				}
+
+				const report = loopStatus.autonomy_report || {};
+				const objective = loopStatus.autonomy_objective?.source_ref || "none";
+				const reportSourceRefs = Array.isArray(report.source_refs)
+					? report.source_refs.length
+					: 0;
+				const knownGaps = Array.isArray(report.known_gaps)
+					? report.known_gaps
+					: [];
+				const completeness = report.completeness || "unknown";
+				const authority = report.authority || "derived_query_view";
+
+				return [
+					`objective=${objective}`,
+					`signals=${(loopStatus.autonomy_signals || []).length}`,
+					`proposals=${(loopStatus.autonomy_proposals || []).length}`,
+					`lineage=${(loopStatus.autonomy_lineage || []).length}`,
+					`source_refs=${reportSourceRefs}`,
+					`completeness=${completeness}`,
+					`authority=${authority}`,
+					`gaps=${knownGaps.length}`,
+				].join("; ");
 			}
 
 			function renderAttentionFacts(candidate) {
@@ -10677,6 +10729,7 @@
 										${field("Continuation recovery", runContinuationRecoverySummary(run))}
 										${field("Loop", run.loop_status?.summary || "none")}
 										${field("Review loop", loopStatusFacts(run.loop_status).map(([label, value]) => `${label}: ${value}`).join("; ") || "none")}
+										${field("Autonomy readback", autonomyReadbackSummary(run.loop_status))}
 										${field("Model", runModelSummary(run))}
 										${field("Child agent", childAgentDebugSummary(childAgentActivity(run)))}
 										${field("Context pressure", childAgentContextSummary(childAgentActivity(run)))}

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -8294,8 +8294,16 @@ fn operator_loop_status_for_run_with_evidence(
 		.rev()
 		.find(|event| event.event_type() == AUTHORITY_DECISION_REQUEST_EVENT_TYPE)
 		.and_then(operator_authority_decision_request_status_from_event);
+	let autonomy_objective = operator_autonomy_objective_status(project, loop_evidence);
 	let autonomy_signals = operator_autonomy_signal_statuses(loop_evidence);
 	let autonomy_proposals = operator_autonomy_proposal_statuses(loop_evidence);
+	let autonomy_lineage = operator_autonomy_lineage_statuses(loop_evidence);
+	let autonomy_report = operator_autonomy_report_status(
+		autonomy_objective.as_ref(),
+		&autonomy_signals,
+		&autonomy_proposals,
+		&autonomy_lineage,
+	);
 	let autonomy = operator_loop_autonomy(
 		boundary.as_ref(),
 		architecture_recovery.as_ref(),
@@ -8321,13 +8329,82 @@ fn operator_loop_status_for_run_with_evidence(
 		autonomy: autonomy.to_owned(),
 		summary,
 		next_action,
+		autonomy_objective,
 		autonomy_signals,
 		autonomy_proposals,
+		autonomy_lineage,
+		autonomy_report,
 		review,
 		architecture_recovery,
 		boundary,
 		decision_request,
 	})
+}
+
+fn operator_autonomy_objective_status(
+	project: &ServiceConfig,
+	loop_evidence: &ProjectLoopEvidenceSnapshot,
+) -> Option<OperatorAutonomyObjectiveStatus> {
+	if let Some(policy) = project.autonomy().runtime_policy() {
+		let version = policy.accepted_objective_version().parse::<u64>().unwrap_or_default();
+		let source_ref = operator_autonomy_objective_ref(policy.accepted_objective_id(), version);
+
+		if let Some(record) = loop_evidence.autonomy_objective(policy.accepted_objective_id(), version) {
+			let objective = record.objective();
+			let mut known_gaps = Vec::new();
+
+			if record.state().as_str() != "accepted" {
+				known_gaps.push(format!("objective_state_{}", record.state().as_str()));
+			}
+
+			return Some(OperatorAutonomyObjectiveStatus {
+				objective_id: objective.id().to_owned(),
+				objective_version: objective.version(),
+				state: objective.state().as_str().to_owned(),
+				summary: public_or_redacted_status_value(objective.summary()),
+				source_ref,
+				updated_at: record.updated_at().to_owned(),
+				completeness: operator_autonomy_completeness(&known_gaps),
+				known_gaps,
+			});
+		}
+
+		let mut known_gaps = vec![String::from("objective_runtime_record_missing")];
+
+		if version == 0 {
+			known_gaps.push(String::from("objective_version_unparseable"));
+		}
+
+		return Some(OperatorAutonomyObjectiveStatus {
+			objective_id: policy.accepted_objective_id().to_owned(),
+			objective_version: version,
+			state: String::from("missing_runtime_record"),
+			summary: String::from("Accepted runtime policy references an Objective Contract that is not in local readback."),
+			source_ref,
+			updated_at: String::from("none"),
+			completeness: String::from("partial"),
+			known_gaps,
+		});
+	}
+
+	loop_evidence
+		.accepted_autonomy_objectives()
+		.into_iter()
+		.next()
+		.map(|record| {
+			let objective = record.objective();
+
+			OperatorAutonomyObjectiveStatus {
+				objective_id: objective.id().to_owned(),
+				objective_version: objective.version(),
+				state: objective.state().as_str().to_owned(),
+				summary: public_or_redacted_status_value(objective.summary()),
+				source_ref: operator_autonomy_objective_ref(objective.id(), objective.version()),
+				updated_at: record.updated_at().to_owned(),
+				completeness: String::from("complete"),
+				known_gaps: Vec::new(),
+			}
+		})
 }
 
 fn operator_autonomy_signal_statuses(
@@ -8338,18 +8415,47 @@ fn operator_autonomy_signal_statuses(
 		.into_iter()
 		.map(|record| {
 			let signal = record.signal();
+			let (source_refs, source_refs_redacted) =
+				public_autonomy_refs(signal.source_refs());
+			let (primary_source_refs, primary_source_refs_redacted) =
+				public_autonomy_refs(signal.primary_source_refs());
+			let (gaps, gaps_redacted) = public_status_values(signal.gaps());
+			let (contradictions, contradictions_redacted) =
+				public_status_values(signal.contradictions());
+			let mut known_gaps = gaps.clone();
 
+			if source_refs.is_empty() {
+				known_gaps.push(String::from("source_refs_missing_or_redacted"));
+			}
+			if source_refs_redacted || primary_source_refs_redacted {
+				known_gaps.push(String::from("source_refs_redacted"));
+			}
+			if gaps_redacted || contradictions_redacted {
+				known_gaps.push(String::from("gap_or_contradiction_redacted"));
+			}
+			if signal.freshness().as_str() != "fresh" {
+				known_gaps.push(format!("freshness_{}", signal.freshness().as_str()));
+			}
+
+			known_gaps.sort();
+			known_gaps.dedup();
 			OperatorAutonomySignalStatus {
 				signal_id: signal.id().to_owned(),
 				objective_id: signal.objective_id().to_owned(),
 				objective_version: signal.objective_version(),
 				kind: signal.kind().as_str().to_owned(),
+				source_type: signal.source_type().as_str().to_owned(),
+				source_refs,
+				primary_source_refs,
 				freshness: signal.freshness().as_str().to_owned(),
 				evidence_class: signal.evidence_class().as_str().to_owned(),
 				confidence: signal.confidence().as_str().to_owned(),
 				privacy: signal.privacy().as_str().to_owned(),
-				gaps: signal.gaps().to_vec(),
-				contradictions: signal.contradictions().to_vec(),
+				redaction_level: signal.privacy().as_str().to_owned(),
+				completeness: operator_autonomy_completeness(&known_gaps),
+				gaps,
+				known_gaps,
+				contradictions,
 				updated_at: record.updated_at().to_owned(),
 			}
 		})
@@ -8364,28 +8470,311 @@ fn operator_autonomy_proposal_statuses(
 		.into_iter()
 		.map(|record| {
 			let proposal = record.proposal();
+			let (source_family, source_family_redacted) =
+				public_status_value(proposal.source_family());
+			let (intended_surface, intended_surface_redacted) =
+				public_status_value(proposal.intended_surface());
+			let (affected_identifiers, affected_identifiers_redacted) =
+				public_status_values(proposal.affected_identifiers());
+			let (gaps, gaps_redacted) = public_status_values(proposal.gaps());
+			let (contradictions, contradictions_redacted) =
+				public_status_values(proposal.contradictions());
+			let refusals = proposal
+				.refusal_reasons()
+				.iter()
+				.map(|refusal| {
+					let (evidence_refs, _) = public_autonomy_refs(refusal.evidence_refs());
 
+					OperatorAutonomyProposalRefusalStatus {
+						reason: refusal.reason().as_str().to_owned(),
+						detail: public_or_redacted_status_value(refusal.detail()),
+						evidence_refs,
+					}
+				})
+				.collect::<Vec<_>>();
+			let mut known_gaps = gaps.clone();
+
+			if proposal.source_signal_ids().is_empty() {
+				known_gaps.push(String::from("source_signal_ids_missing"));
+			}
+			if !proposal.refusal_reasons().is_empty() {
+				known_gaps.push(String::from("proposal_refused"));
+			}
+			if source_family_redacted
+				|| intended_surface_redacted
+				|| affected_identifiers_redacted
+				|| gaps_redacted
+				|| contradictions_redacted
+			{
+				known_gaps.push(String::from("proposal_public_fields_redacted"));
+			}
+
+			known_gaps.sort();
+			known_gaps.dedup();
 			OperatorAutonomyProposalStatus {
 				proposal_id: proposal.id().to_owned(),
 				objective_id: proposal.objective_id().to_owned(),
 				objective_version: proposal.objective_version(),
 				state: proposal.state().as_str().to_owned(),
-				source_family: proposal.source_family().to_owned(),
-				intended_surface: proposal.intended_surface().to_owned(),
+				summary: public_or_redacted_status_value(proposal.summary()),
+				source_family,
+				intended_surface,
+				affected_identifiers,
 				source_signal_ids: proposal.source_signal_ids().to_vec(),
 				refusal_reasons: proposal
 					.refusal_reasons()
 					.iter()
 					.map(|refusal| refusal.reason().as_str().to_owned())
 					.collect(),
-				gaps: proposal.gaps().to_vec(),
-				contradictions: proposal.contradictions().to_vec(),
+				refusals,
+				completeness: operator_autonomy_completeness(&known_gaps),
+				known_gaps,
+				gaps,
+				contradictions,
 				challenge_evidence_count: proposal.challenge_evidence().len(),
 				updated_at: record.updated_at().to_owned(),
-				dry_run_record: proposal.clone(),
 			}
 		})
 		.collect()
+}
+
+fn operator_autonomy_lineage_statuses(
+	loop_evidence: &ProjectLoopEvidenceSnapshot,
+) -> Vec<OperatorAutonomyLineageStatus> {
+	loop_evidence
+		.recent_autonomy_proposals(5)
+		.into_iter()
+		.map(|record| {
+			let proposal = record.proposal();
+			let decision_contracts = loop_evidence
+				.decision_contracts_for_autonomy_proposal(proposal.id())
+				.into_iter()
+				.map(|record| OperatorAutonomyDecisionContractStatus {
+					contract_id: record.contract_id().to_owned(),
+					status: record.status().as_str().to_owned(),
+					updated_at: record.updated_at().to_owned(),
+					generated_issue_identifiers: record
+						.contract()
+						.links()
+						.generated_issue_identifiers()
+						.to_vec(),
+				})
+				.collect::<Vec<_>>();
+			let program_intake = decision_contracts
+				.iter()
+				.flat_map(|contract| {
+					loop_evidence
+						.program_intake_plans_for_contract(&contract.contract_id)
+						.into_iter()
+						.map(|plan| OperatorAutonomyProgramIntakeStatus {
+							program_id: plan.program_id().to_owned(),
+							plan_id: plan.plan_id().to_owned(),
+							intake_kind: plan.intake_kind().to_owned(),
+							source_contract_id: plan
+								.source_contract_id()
+								.unwrap_or("none")
+								.to_owned(),
+							public_summary: public_or_redacted_status_value(plan.public_summary()),
+							updated_at: plan.updated_at().to_owned(),
+						})
+						.collect::<Vec<_>>()
+				})
+				.collect::<Vec<_>>();
+			let mut known_gaps = Vec::new();
+
+			if proposal.source_signal_ids().is_empty() {
+				known_gaps.push(String::from("signal_lineage_missing"));
+			}
+			if decision_contracts.is_empty() {
+				known_gaps.push(String::from("decision_contract_not_materialized"));
+			}
+			if program_intake.is_empty() {
+				known_gaps.push(String::from("program_intake_not_materialized"));
+			}
+
+			let (proposal_gaps, proposal_gaps_redacted) = public_status_values(proposal.gaps());
+
+			known_gaps.extend(proposal_gaps);
+
+			if proposal_gaps_redacted {
+				known_gaps.push(String::from("proposal_gaps_redacted"));
+			}
+
+			known_gaps.sort();
+			known_gaps.dedup();
+			OperatorAutonomyLineageStatus {
+				objective_ref: operator_autonomy_objective_ref(
+					proposal.objective_id(),
+					proposal.objective_version(),
+				),
+				signal_ids: proposal.source_signal_ids().to_vec(),
+				proposal_id: Some(proposal.id().to_owned()),
+				proposal_state: Some(proposal.state().as_str().to_owned()),
+				decision_contracts,
+				program_intake,
+				completeness: operator_autonomy_completeness(&known_gaps),
+				known_gaps,
+			}
+		})
+		.collect()
+}
+
+fn operator_autonomy_report_status(
+	objective: Option<&OperatorAutonomyObjectiveStatus>,
+	signals: &[OperatorAutonomySignalStatus],
+	proposals: &[OperatorAutonomyProposalStatus],
+	lineage: &[OperatorAutonomyLineageStatus],
+) -> Option<OperatorAutonomyReportReadbackStatus> {
+	if objective.is_none() && signals.is_empty() && proposals.is_empty() && lineage.is_empty() {
+		return None;
+	}
+
+	let mut source_refs = BTreeSet::new();
+	let mut known_gaps = BTreeSet::new();
+	let mut redaction_level = "public";
+
+	if let Some(objective) = objective {
+		source_refs.insert(objective.source_ref.clone());
+
+		for gap in &objective.known_gaps {
+			known_gaps.insert(gap.clone());
+		}
+	}
+
+	for signal in signals {
+		for source_ref in &signal.source_refs {
+			source_refs.insert(source_ref.clone());
+		}
+		for primary_source_ref in &signal.primary_source_refs {
+			source_refs.insert(primary_source_ref.clone());
+		}
+		for gap in &signal.known_gaps {
+			known_gaps.insert(gap.clone());
+		}
+
+		redaction_level = operator_autonomy_max_redaction_level(redaction_level, &signal.privacy);
+	}
+	for proposal in proposals {
+		for gap in &proposal.known_gaps {
+			known_gaps.insert(gap.clone());
+		}
+	}
+	for item in lineage {
+		for gap in &item.known_gaps {
+			known_gaps.insert(gap.clone());
+		}
+	}
+
+	if source_refs.is_empty() {
+		known_gaps.insert(String::from("source_refs_missing_or_redacted"));
+	}
+
+	let known_gaps = known_gaps.into_iter().collect::<Vec<_>>();
+
+	Some(OperatorAutonomyReportReadbackStatus {
+		surface: String::from("operator_status_autonomy"),
+		authority: String::from("derived_query_view"),
+		audit_authority: false,
+		source_refs: source_refs.into_iter().collect(),
+		redaction_level: redaction_level.to_owned(),
+		completeness: operator_autonomy_completeness(&known_gaps),
+		known_gaps,
+	})
+}
+
+fn operator_autonomy_objective_ref(objective_id: &str, objective_version: u64) -> String {
+	format!("{objective_id}@v{objective_version}")
+}
+
+fn operator_autonomy_completeness(known_gaps: &[String]) -> String {
+	if known_gaps.is_empty() { String::from("complete") } else { String::from("partial") }
+}
+
+fn operator_autonomy_max_redaction_level(left: &str, right: &str) -> &'static str {
+	match (operator_autonomy_redaction_rank(left), operator_autonomy_redaction_rank(right)) {
+		(left_rank, right_rank) if left_rank >= right_rank => operator_autonomy_redaction_label(left),
+		_ => operator_autonomy_redaction_label(right),
+	}
+}
+
+fn operator_autonomy_redaction_rank(value: &str) -> u8 {
+	match value {
+		"local_private" => 2,
+		"team" => 1,
+		_ => 0,
+	}
+}
+
+fn operator_autonomy_redaction_label(value: &str) -> &'static str {
+	match value {
+		"local_private" => "local_private",
+		"team" => "team",
+		_ => "public",
+	}
+}
+
+fn public_autonomy_refs(refs: &[String]) -> (Vec<String>, bool) {
+	let mut redacted = false;
+	let refs = refs
+		.iter()
+		.filter_map(|value| {
+			let Some(value) = public_autonomy_ref(value) else {
+				redacted = true;
+
+				return None;
+			};
+
+			Some(value)
+		})
+		.collect::<BTreeSet<_>>()
+		.into_iter()
+		.collect::<Vec<_>>();
+
+	(refs, redacted)
+}
+
+fn public_autonomy_ref(value: &str) -> Option<String> {
+	let value = value.trim();
+
+	if value.is_empty() || public_text::validate_public_text_field("autonomy source_ref", value).is_err()
+	{
+		return None;
+	}
+
+	Some(value.to_owned())
+}
+
+fn public_status_values(values: &[String]) -> (Vec<String>, bool) {
+	let mut redacted = false;
+	let values = values
+		.iter()
+		.map(|value| {
+			let (value, value_redacted) = public_status_value(value);
+
+			redacted |= value_redacted;
+
+			value
+		})
+		.collect();
+
+	(values, redacted)
+}
+
+fn public_or_redacted_status_value(value: &str) -> String {
+	public_status_value(value).0
+}
+
+fn public_status_value(value: &str) -> (String, bool) {
+	let value = value.trim();
+
+	if value.is_empty() {
+		return (String::from("none"), false);
+	}
+	if public_text::validate_public_text_field("autonomy status value", value).is_err() {
+		return (String::from("redacted_sensitive_detail"), true);
+	}
+
+	(value.to_owned(), false)
 }
 
 fn operator_review_loop_status(
@@ -11074,9 +11463,19 @@ fn render_loop_status_summary(status: Option<&OperatorLoopStatus>) -> String {
 		return String::from("none");
 	};
 	let next_action = status.next_action.as_deref().unwrap_or("none");
+	let autonomy_objective = status
+		.autonomy_objective
+		.as_ref()
+		.map(|objective| objective.source_ref.as_str())
+		.unwrap_or("none");
+	let autonomy_report = status
+		.autonomy_report
+		.as_ref()
+		.map(|report| report.authority.as_str())
+		.unwrap_or("none");
 
 	format!(
-		"{}; review_level={}; autonomy={}; autonomy_signals={}; autonomy_proposals={}; next_action={next_action}",
+		"{}; review_level={}; autonomy={}; autonomy_objective={autonomy_objective}; autonomy_signals={}; autonomy_proposals={}; report={autonomy_report}; next_action={next_action}",
 		status.summary,
 		status.review_level,
 		status.autonomy,
@@ -11099,13 +11498,15 @@ fn render_loop_autonomy_signals_summary(status: Option<&OperatorLoopStatus>) -> 
 		.iter()
 		.map(|signal| {
 			format!(
-				"{}:{}@v{} freshness={} confidence={} privacy={} gaps={} contradictions={}",
+				"{}:{}@v{} freshness={} confidence={} privacy={} sources={} completeness={} gaps={} contradictions={}",
 				signal.kind,
 				signal.objective_id,
 				signal.objective_version,
 				signal.freshness,
 				signal.confidence,
 				signal.privacy,
+				signal.source_refs.len(),
+				signal.completeness,
 				signal.gaps.len(),
 				signal.contradictions.len()
 			)

--- a/apps/decodex/src/orchestrator/tests.rs
+++ b/apps/decodex/src/orchestrator/tests.rs
@@ -20,7 +20,10 @@ use rusqlite::Connection;
 use tempfile::TempDir;
 use time::OffsetDateTime;
 
-use crate::{orchestrator::RepoGatePhaseGoalController, tracker::records};
+use crate::{
+	orchestrator::RepoGatePhaseGoalController,
+	tracker::{TrackerIssueCreate, records},
+};
 #[rustfmt::skip]
 	use crate::agent::{
 		RUN_LEASE_IDLE_TIMEOUT, MODEL_EXECUTION_IDLE_TIMEOUT,
@@ -158,6 +161,7 @@ struct FakeTracker {
 	label_updates: RefCell<Vec<(String, Vec<String>)>>,
 	label_additions: RefCell<Vec<(String, Vec<String>)>>,
 	label_removals: RefCell<Vec<(String, Vec<String>)>>,
+	next_created_issue_number: RefCell<usize>,
 }
 impl FakeTracker {
 	fn new(issues: Vec<TrackerIssue>) -> Self {
@@ -193,6 +197,7 @@ impl FakeTracker {
 			label_updates: RefCell::new(Vec::new()),
 			label_additions: RefCell::new(Vec::new()),
 			label_removals: RefCell::new(Vec::new()),
+			next_created_issue_number: RefCell::new(0),
 		}
 	}
 
@@ -341,6 +346,41 @@ impl IssueTracker for FakeTracker {
 		);
 
 		Ok(())
+	}
+
+	fn create_issue(&self, request: &TrackerIssueCreate) -> Result<TrackerIssue> {
+		let identifier = {
+			let mut next_issue_number = self.next_created_issue_number.borrow_mut();
+
+			*next_issue_number += 1;
+
+			format!("PUB-G{}", *next_issue_number)
+		};
+		let state_name = request
+			.state_id
+			.as_deref()
+			.and_then(|state_id| {
+				self.listed_issues
+					.iter()
+					.flat_map(|issue| issue.team.states.iter())
+					.find(|state| state.id == state_id)
+					.map(|state| state.name.as_str())
+			})
+			.unwrap_or("Todo");
+		let mut issue = sample_issue_with_sort_fields(
+			&format!("issue-{identifier}"),
+			&identifier,
+			state_name,
+			&[],
+			None,
+			"2026-06-23T00:00:00Z",
+		);
+
+		issue.team.id.clone_from(&request.team_id);
+		issue.title.clone_from(&request.title);
+		issue.description.clone_from(&request.description);
+
+		Ok(issue)
 	}
 }
 

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -41,6 +41,13 @@ fn operator_dashboard_surfaces_loop_status_fields() {
 	assert!(response.contains("loopStatusFacts(run.loop_status)"));
 	assert!(response.contains("loopStatusFacts(lane.loop_status)"));
 	assert!(response.contains("loopStatusFacts(attention.loop_status)"));
+	assert!(response.contains("function autonomyReadbackHasFreshSourceRefs(loopStatus)"));
+	assert!(response.contains(
+		"return sourceRefs.length > 0 && String(signal?.freshness || \"\") === \"fresh\";"
+	));
+	assert!(response.contains("function autonomyReadbackSummary(loopStatus)"));
+	assert!(response.contains("field(\"Autonomy readback\", autonomyReadbackSummary(run.loop_status))"));
+	assert!(!response.contains("facts.push([\"Autonomy\", displayToken(loopStatus.autonomy)]);"));
 }
 
 #[test]

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -1,3 +1,416 @@
+mod autonomy_lineage_readback_tests {
+	use crate::orchestrator::tests::FakeTracker;
+	use std::collections::BTreeMap;
+
+	use crate::{
+		autonomy_objective::{
+			AutonomyObjectiveAcceptance, AutonomyObjectiveActorKind, AutonomyObjectiveContract,
+		},
+		autonomy_proposal::{
+			AutonomyProposalAuthorityActorKind, AutonomyProposalDecisionBridgeAuthority,
+		},
+		autonomy_signal::{
+			AutonomySignal, AutonomySignalConfidence, AutonomySignalEvidenceClass,
+			AutonomySignalFreshness, AutonomySignalInput, AutonomySignalPrivacy,
+			AutonomySignalSourceType,
+		},
+		config::ServiceConfig,
+		loop_contract::{DecisionPromotion, DecisionPromotionActorKind},
+		orchestrator::{self, OperatorStatusSnapshot},
+		program_intake::{self, GoalIntakeRunRequest},
+		state::StateStore,
+		tracker::TrackerIssue,
+		workflow::WorkflowDocument,
+	};
+
+	const SERVICE_ID: &str = "pubfi";
+	const AUTONOMY_RUN_ID: &str = "run-autonomy";
+	const OBJECTIVE_ID: &str = "quality-autonomy";
+
+	struct SeededAutonomyLineage {
+		accepted_proposal_id: String,
+		decision_contract_id: String,
+	}
+
+	#[test]
+	fn operator_status_surfaces_autonomy_lineage_without_raw_payloads() {
+		let (_temp_dir, config, workflow) = super::temp_project_layout();
+		let state_store = StateStore::open_in_memory().expect("state store should open");
+		let issue = super::sample_issue("Todo", &[]);
+		let seeded = seed_autonomy_lineage(&state_store, &config, &workflow, &issue);
+		let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+			.expect("snapshot should build");
+
+		assert_autonomy_readback(&snapshot, &seeded);
+	}
+
+	fn seed_autonomy_lineage(
+		state_store: &StateStore,
+		config: &ServiceConfig,
+		workflow: &WorkflowDocument,
+		issue: &TrackerIssue,
+	) -> SeededAutonomyLineage {
+		seed_autonomy_run(state_store, issue);
+		accept_autonomy_objective(state_store);
+
+		let signal_id = record_autonomy_signal(state_store, issue);
+		let accepted_proposal_id = record_autonomy_proposals(state_store, issue, &signal_id);
+		let decision_contract_id =
+			promote_autonomy_proposal(state_store, &accepted_proposal_id);
+
+		apply_goal_intake(state_store, config, workflow, issue, &decision_contract_id);
+		record_sensitive_autonomy_readback_fixture(state_store, issue);
+
+		SeededAutonomyLineage { accepted_proposal_id, decision_contract_id }
+	}
+
+	fn seed_autonomy_run(state_store: &StateStore, issue: &TrackerIssue) {
+		state_store
+			.record_run_attempt(AUTONOMY_RUN_ID, &issue.id, 1, "running")
+			.expect("run attempt should record");
+		state_store
+			.upsert_lease(SERVICE_ID, &issue.id, AUTONOMY_RUN_ID, "In Progress")
+			.expect("lease should record");
+		state_store
+			.append_event(AUTONOMY_RUN_ID, 1, "turn/completed", "{\"turn\":\"1\"}")
+			.expect("event should record");
+	}
+
+	fn accept_autonomy_objective(state_store: &StateStore) {
+		state_store
+			.upsert_autonomy_objective_draft(
+				SERVICE_ID,
+				autonomy_objective_fixture(SERVICE_ID),
+			)
+			.expect("objective draft should persist");
+		state_store
+			.accept_autonomy_objective_version(
+				SERVICE_ID,
+				OBJECTIVE_ID,
+				1,
+				AutonomyObjectiveAcceptance::new(
+					"operator",
+					AutonomyObjectiveActorKind::User,
+					"2026-06-23T00:00:00Z",
+					"linear:XY-1089",
+				)
+				.expect("acceptance should build"),
+			)
+			.expect("objective should accept");
+	}
+
+	fn record_autonomy_signal(state_store: &StateStore, issue: &TrackerIssue) -> String {
+		let signal = AutonomySignal::runtime_health(
+			AutonomySignalInput {
+				project_id: SERVICE_ID.to_owned(),
+				objective_id: String::from(OBJECTIVE_ID),
+				objective_version: 1,
+				source_type: AutonomySignalSourceType::Report,
+				source_refs: vec![String::from("status:operator:run-autonomy")],
+				primary_source_refs: vec![String::from("docs/spec/autonomy-control-plane.md")],
+				issue_id: Some(issue.id.clone()),
+				run_id: Some(String::from(AUTONOMY_RUN_ID)),
+				attempt_id: Some(String::from("1")),
+				head_sha: Some(String::from("0123456789abcdef0123456789abcdef01234567")),
+				captured_at: String::from("2026-06-23T00:01:00Z"),
+				freshness: AutonomySignalFreshness::Fresh,
+				summary: String::from("Operator status needs autonomy lineage readback."),
+				evidence: vec![String::from("Status readback carried source refs.")],
+				evidence_class: AutonomySignalEvidenceClass::LiveReadback,
+				contradictions: Vec::new(),
+				gaps: Vec::new(),
+				confidence: AutonomySignalConfidence::High,
+				privacy: AutonomySignalPrivacy::Public,
+				observed_counts: BTreeMap::new(),
+				review_evidence: None,
+				proposal_only: true,
+				created_at: String::from("2026-06-23T00:01:00Z"),
+			},
+		)
+		.expect("signal should build");
+		let signal_id = signal.id().to_owned();
+
+		state_store
+			.record_autonomy_signal(SERVICE_ID, signal)
+			.expect("signal should persist");
+
+		signal_id
+	}
+
+	fn record_autonomy_proposals(
+		state_store: &StateStore,
+		issue: &TrackerIssue,
+		signal_id: &str,
+	) -> String {
+		let signal_ids = vec![signal_id.to_owned()];
+		let accepted_proposal = state_store
+			.compile_autonomy_proposal_dry_run(
+				autonomy_proposal_input(
+					"apps/decodex/src/orchestrator/status.rs",
+					&issue.identifier,
+				),
+				&signal_ids,
+			)
+			.expect("proposal should compile");
+		let accepted_proposal_id = accepted_proposal.id().to_owned();
+
+		state_store
+			.record_autonomy_proposal(SERVICE_ID, accepted_proposal)
+			.expect("proposal should persist");
+
+		let refused_proposal = state_store
+			.compile_autonomy_proposal_dry_run(
+				autonomy_proposal_input("site/src/pages/index.astro", &issue.identifier),
+				&signal_ids,
+			)
+			.expect("refused proposal should compile");
+
+		state_store
+			.record_autonomy_proposal(SERVICE_ID, refused_proposal)
+			.expect("refused proposal should persist");
+
+		accepted_proposal_id
+	}
+
+	fn record_sensitive_autonomy_readback_fixture(
+		state_store: &StateStore,
+		issue: &TrackerIssue,
+	) {
+		let signal = AutonomySignal::runtime_health(
+			AutonomySignalInput {
+				project_id: SERVICE_ID.to_owned(),
+				objective_id: String::from(OBJECTIVE_ID),
+				objective_version: 1,
+				source_type: AutonomySignalSourceType::Report,
+				source_refs: vec![String::from("status:operator:sensitive-readback")],
+				primary_source_refs: vec![String::from("docs/spec/autonomy-control-plane.md")],
+				issue_id: Some(issue.id.clone()),
+				run_id: Some(String::from(AUTONOMY_RUN_ID)),
+				attempt_id: Some(String::from("1")),
+				head_sha: Some(String::from("0123456789abcdef0123456789abcdef01234567")),
+				captured_at: String::from("2026-06-23T00:04:00Z"),
+				freshness: AutonomySignalFreshness::Fresh,
+				summary: String::from("Operator status must redact raw autonomy gaps."),
+				evidence: vec![String::from("Sensitive fixture stays out of public readback.")],
+				evidence_class: AutonomySignalEvidenceClass::LiveReadback,
+				contradictions: vec![String::from(
+					"Local contradiction references /Users/x/.codex/private-evidence.json",
+				)],
+				gaps: vec![String::from(
+					"Local gap references GITHUB_PAT_Y from the developer environment.",
+				)],
+				confidence: AutonomySignalConfidence::Medium,
+				privacy: AutonomySignalPrivacy::Public,
+				observed_counts: BTreeMap::new(),
+				review_evidence: None,
+				proposal_only: true,
+				created_at: String::from("2026-06-23T00:04:00Z"),
+			},
+		)
+		.expect("sensitive signal fixture should build");
+		let signal_id = signal.id().to_owned();
+
+		state_store
+			.record_autonomy_signal(SERVICE_ID, signal)
+			.expect("sensitive signal should persist");
+
+		let sensitive_proposal = state_store
+			.compile_autonomy_proposal_dry_run(
+				autonomy_proposal_input(
+					"apps/decodex/src/orchestrator/status.rs",
+					&issue.identifier,
+				),
+				&[signal_id],
+			)
+			.expect("sensitive proposal should compile");
+
+		state_store
+			.record_autonomy_proposal(SERVICE_ID, sensitive_proposal)
+			.expect("sensitive proposal should persist");
+	}
+
+	fn promote_autonomy_proposal(state_store: &StateStore, proposal_id: &str) -> String {
+		let authority =
+			AutonomyProposalDecisionBridgeAuthority::new(
+				"operator",
+				AutonomyProposalAuthorityActorKind::User,
+				"2026-06-23T00:02:00Z",
+				"linear:XY-1089",
+				"Accept autonomy lineage proposal.",
+				"operator",
+				AutonomyProposalAuthorityActorKind::User,
+				None,
+			)
+			.expect("proposal authority should build");
+		let decision = state_store
+			.accept_autonomy_proposal_as_decision_contract_candidate(
+				SERVICE_ID,
+				proposal_id,
+				authority,
+			)
+			.expect("decision contract should persist");
+		let decision_contract_id = decision.contract_id().to_owned();
+
+		state_store
+			.promote_decision_contract(
+				SERVICE_ID,
+				&decision_contract_id,
+				DecisionPromotion::new(
+					"operator",
+					DecisionPromotionActorKind::User,
+					"2026-06-23T00:03:00Z",
+					"linear:XY-1089",
+					Some(String::from("Promote accepted autonomy proposal.")),
+				)
+				.expect("promotion should build"),
+			)
+			.expect("decision should promote");
+
+		decision_contract_id
+	}
+
+	fn apply_goal_intake(
+		state_store: &StateStore,
+		config: &ServiceConfig,
+		workflow: &WorkflowDocument,
+		issue: &TrackerIssue,
+		decision_contract_id: &str,
+	) {
+		let tracker = FakeTracker::new(vec![issue.clone()]);
+
+		program_intake::run_goal_intake(GoalIntakeRunRequest {
+			state_store,
+			tracker: &tracker,
+			config,
+			workflow,
+			contract_id: decision_contract_id,
+			team_issue_identifier: None,
+			dry_run: false,
+			apply: true,
+		})
+		.expect("goal intake should apply");
+	}
+
+	fn assert_autonomy_readback(
+		snapshot: &OperatorStatusSnapshot,
+		seeded: &SeededAutonomyLineage,
+	) {
+		let run = snapshot.current_lanes.first().expect("current lane should exist");
+		let loop_status = run.loop_status.as_ref().expect("loop status should render");
+		let objective = loop_status
+			.autonomy_objective
+			.as_ref()
+			.expect("objective readback should render");
+		let lineage = loop_status
+			.autonomy_lineage
+			.iter()
+			.find(|lineage| lineage.proposal_id.as_deref() == Some(&seeded.accepted_proposal_id))
+			.expect("accepted proposal lineage should render");
+		let clean_signal = loop_status
+			.autonomy_signals
+			.iter()
+			.find(|signal| signal.source_refs.contains(&String::from("status:operator:run-autonomy")))
+			.expect("clean autonomy signal should render");
+		let sensitive_signal = loop_status
+			.autonomy_signals
+			.iter()
+			.find(|signal| {
+				signal
+					.source_refs
+					.contains(&String::from("status:operator:sensitive-readback"))
+			})
+			.expect("sensitive autonomy signal should render");
+		let refused = loop_status
+			.autonomy_proposals
+			.iter()
+			.find(|proposal| proposal.refusal_reasons.contains(&String::from("disallowed_surface")))
+			.expect("refused proposal should render");
+		let sensitive_proposal = loop_status
+			.autonomy_proposals
+			.iter()
+			.find(|proposal| proposal.gaps.contains(&String::from("redacted_sensitive_detail")))
+			.expect("sensitive proposal should render");
+		let report = loop_status.autonomy_report.as_ref().expect("report readback should render");
+		let rendered = orchestrator::render_operator_status(snapshot);
+		let snapshot_json = serde_json::to_string(snapshot).expect("snapshot should serialize");
+
+		assert_eq!(objective.objective_id, OBJECTIVE_ID);
+		assert_eq!(objective.objective_version, 1);
+		assert_eq!(clean_signal.freshness, "fresh");
+		assert_eq!(sensitive_signal.gaps, ["redacted_sensitive_detail"]);
+		assert_eq!(sensitive_signal.contradictions, ["redacted_sensitive_detail"]);
+		assert!(
+			sensitive_signal
+				.known_gaps
+				.contains(&String::from("gap_or_contradiction_redacted"))
+		);
+		assert_eq!(lineage.decision_contracts[0].contract_id, seeded.decision_contract_id);
+		assert_eq!(lineage.program_intake[0].intake_kind, "goal_intake");
+		assert_eq!(refused.refusals[0].reason, "disallowed_surface");
+		assert_eq!(sensitive_proposal.gaps, ["redacted_sensitive_detail"]);
+		assert_eq!(sensitive_proposal.contradictions, ["redacted_sensitive_detail"]);
+		assert!(
+			report
+				.known_gaps
+				.iter()
+				.any(|gap| gap.contains("redacted") || gap == "proposal_public_fields_redacted")
+		);
+		assert_eq!(report.authority, "derived_query_view");
+		assert!(!report.audit_authority);
+		assert_eq!(report.completeness, "partial");
+		assert!(rendered.contains("loop_autonomy_signals: runtime_health:quality-autonomy@v1"));
+		assert!(rendered.contains("sources=1"));
+		assert!(rendered.contains("report=derived_query_view"));
+		assert!(!snapshot_json.contains("dry_run_record"));
+		assert!(!snapshot_json.contains("/Users/x"));
+		assert!(!snapshot_json.contains("GITHUB_PAT_Y"));
+		assert!(!rendered.contains("/Users/x"));
+		assert!(!rendered.contains("GITHUB_PAT_Y"));
+	}
+
+	fn autonomy_objective_fixture(service_id: &str) -> AutonomyObjectiveContract {
+		serde_json::from_value(serde_json::json!({
+			"schema": "decodex.autonomy_objective/1",
+			"record_version": 1,
+			"project_id": service_id,
+			"id": OBJECTIVE_ID,
+			"version": 1,
+			"state": "draft",
+			"summary": "Surface autonomy lineage in operator readback.",
+			"goals": ["Expose objective, signal, proposal, decision, and intake lineage."],
+			"non_goals": ["Do not expose raw private evidence payloads."],
+			"metrics": ["Operator can explain autonomy state without SQLite."],
+			"allowed_surfaces": ["apps/decodex/src/orchestrator", "docs/spec"],
+			"allowed_signal_kinds": ["runtime_health"],
+			"validation_gates": ["cargo test -p decodex operator --lib"],
+			"review_policy": "independent review before handoff",
+			"memory_policy": "runtime records only",
+			"report_policy": "public-safe derived query views only"
+		}))
+		.expect("objective fixture should parse")
+	}
+
+	fn autonomy_proposal_input(
+		intended_surface: &str,
+		issue_identifier: &str,
+	) -> crate::autonomy_proposal::AutonomyProposalCompileInput {
+		crate::autonomy_proposal::AutonomyProposalCompileInput {
+			project_id: SERVICE_ID.to_owned(),
+			objective_id: String::from(OBJECTIVE_ID),
+			objective_version: 1,
+			source_family: String::from("operator_status"),
+			intended_surface: intended_surface.to_owned(),
+			affected_identifiers: vec![issue_identifier.to_owned()],
+			summary: String::from("Surface autonomy lineage in operator readback."),
+			challenge_requirements: vec![String::from("Verify remote-safe projection.")],
+			rejected_alternatives: vec![String::from("Ask operators to inspect SQLite manually.")],
+			rollback_path: String::from("Remove the operator readback projection."),
+			weakened_validation_or_review: Vec::new(),
+			created_at: String::from("2026-06-23T00:02:00Z"),
+		}
+	}
+}
+
 use records::LinearExecutionEventRecord;
 
 #[derive(Clone, Copy)]

--- a/apps/decodex/src/orchestrator/types.rs
+++ b/apps/decodex/src/orchestrator/types.rs
@@ -1,6 +1,6 @@
 use state::PrivateExecutionEvent;
 
-use crate::{autonomy_proposal::AutonomyProposal, tracker};
+use crate::tracker;
 
 type PullRequestReadbackResult =
 	std::result::Result<PullRequestReviewState, PullRequestReadbackFailure>;
@@ -1881,14 +1881,32 @@ struct OperatorLoopStatus {
 	autonomy: String,
 	summary: String,
 	next_action: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	autonomy_objective: Option<OperatorAutonomyObjectiveStatus>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	autonomy_signals: Vec<OperatorAutonomySignalStatus>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	autonomy_proposals: Vec<OperatorAutonomyProposalStatus>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	autonomy_lineage: Vec<OperatorAutonomyLineageStatus>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	autonomy_report: Option<OperatorAutonomyReportReadbackStatus>,
 	review: Option<OperatorReviewLoopStatus>,
 	architecture_recovery: Option<OperatorArchitectureRecoveryStatus>,
 	boundary: Option<OperatorBoundaryStatus>,
 	decision_request: Option<OperatorAuthorityDecisionRequestStatus>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct OperatorAutonomyObjectiveStatus {
+	objective_id: String,
+	objective_version: u64,
+	state: String,
+	summary: String,
+	source_ref: String,
+	updated_at: String,
+	completeness: String,
+	known_gaps: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -1897,11 +1915,17 @@ struct OperatorAutonomySignalStatus {
 	objective_id: String,
 	objective_version: u64,
 	kind: String,
+	source_type: String,
+	source_refs: Vec<String>,
+	primary_source_refs: Vec<String>,
 	freshness: String,
 	evidence_class: String,
 	confidence: String,
 	privacy: String,
+	redaction_level: String,
+	completeness: String,
 	gaps: Vec<String>,
+	known_gaps: Vec<String>,
 	contradictions: Vec<String>,
 	updated_at: String,
 }
@@ -1912,15 +1936,67 @@ struct OperatorAutonomyProposalStatus {
 	objective_id: String,
 	objective_version: u64,
 	state: String,
+	summary: String,
 	source_family: String,
 	intended_surface: String,
+	affected_identifiers: Vec<String>,
 	source_signal_ids: Vec<String>,
 	refusal_reasons: Vec<String>,
+	refusals: Vec<OperatorAutonomyProposalRefusalStatus>,
+	completeness: String,
+	known_gaps: Vec<String>,
 	gaps: Vec<String>,
 	contradictions: Vec<String>,
 	challenge_evidence_count: usize,
 	updated_at: String,
-	dry_run_record: AutonomyProposal,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct OperatorAutonomyProposalRefusalStatus {
+	reason: String,
+	detail: String,
+	evidence_refs: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct OperatorAutonomyLineageStatus {
+	objective_ref: String,
+	signal_ids: Vec<String>,
+	proposal_id: Option<String>,
+	proposal_state: Option<String>,
+	decision_contracts: Vec<OperatorAutonomyDecisionContractStatus>,
+	program_intake: Vec<OperatorAutonomyProgramIntakeStatus>,
+	completeness: String,
+	known_gaps: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct OperatorAutonomyDecisionContractStatus {
+	contract_id: String,
+	status: String,
+	updated_at: String,
+	generated_issue_identifiers: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct OperatorAutonomyProgramIntakeStatus {
+	program_id: String,
+	plan_id: String,
+	intake_kind: String,
+	source_contract_id: String,
+	public_summary: String,
+	updated_at: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct OperatorAutonomyReportReadbackStatus {
+	surface: String,
+	authority: String,
+	audit_authority: bool,
+	source_refs: Vec<String>,
+	redaction_level: String,
+	completeness: String,
+	known_gaps: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/apps/decodex/src/state/store.rs
+++ b/apps/decodex/src/state/store.rs
@@ -48,8 +48,11 @@ pub(crate) struct ProjectLoopEvidenceSnapshot {
 	private_events: HashMap<(String, String, i64), Vec<PrivateExecutionEvent>>,
 	review_lifecycle_records: HashMap<(String, String), ReviewLifecycleRecord>,
 	review_checkpoints: HashMap<(String, String, i64, String), ReviewPolicyCheckpoint>,
+	decision_contracts: Vec<DecisionContractRecord>,
+	autonomy_objectives: Vec<AutonomyObjectiveRecord>,
 	autonomy_signals: Vec<AutonomySignalRecord>,
 	autonomy_proposals: Vec<AutonomyProposalRecord>,
+	program_intake_plans: Vec<ProgramIntakePlanRecord>,
 }
 impl ProjectLoopEvidenceSnapshot {
 	fn insert_private_event(&mut self, event: PrivateExecutionEvent) {
@@ -82,12 +85,24 @@ impl ProjectLoopEvidenceSnapshot {
 		);
 	}
 
+	fn insert_decision_contract(&mut self, contract: DecisionContractRecord) {
+		self.decision_contracts.push(contract);
+	}
+
+	fn insert_autonomy_objective(&mut self, objective: AutonomyObjectiveRecord) {
+		self.autonomy_objectives.push(objective);
+	}
+
 	fn insert_autonomy_signal(&mut self, signal: AutonomySignalRecord) {
 		self.autonomy_signals.push(signal);
 	}
 
 	fn insert_autonomy_proposal(&mut self, proposal: AutonomyProposalRecord) {
 		self.autonomy_proposals.push(proposal);
+	}
+
+	fn insert_program_intake_plan(&mut self, plan: ProgramIntakePlanRecord) {
+		self.program_intake_plans.push(plan);
 	}
 
 	fn sort_private_events(&mut self) {
@@ -98,6 +113,25 @@ impl ProjectLoopEvidenceSnapshot {
 					.then_with(|| left.record_id().cmp(&right.record_id()))
 			});
 		}
+	}
+
+	fn sort_decision_contracts(&mut self) {
+		self.decision_contracts.sort_by(|left, right| {
+			right
+				.updated_at_unix()
+				.cmp(&left.updated_at_unix())
+				.then_with(|| left.contract_id().cmp(right.contract_id()))
+		});
+	}
+
+	fn sort_autonomy_objectives(&mut self) {
+		self.autonomy_objectives.sort_by(|left, right| {
+			right
+				.updated_at_unix()
+				.cmp(&left.updated_at_unix())
+				.then_with(|| left.objective_id().cmp(right.objective_id()))
+				.then_with(|| left.version().cmp(&right.version()))
+		});
 	}
 
 	fn sort_autonomy_signals(&mut self) {
@@ -115,6 +149,16 @@ impl ProjectLoopEvidenceSnapshot {
 				.updated_at_unix()
 				.cmp(&left.updated_at_unix())
 				.then_with(|| left.proposal_id().cmp(right.proposal_id()))
+			});
+	}
+
+	fn sort_program_intake_plans(&mut self) {
+		self.program_intake_plans.sort_by(|left, right| {
+			right
+				.updated_at_unix()
+				.cmp(&left.updated_at_unix())
+				.then_with(|| left.program_id().cmp(right.program_id()))
+				.then_with(|| left.plan_id().cmp(right.plan_id()))
 		});
 	}
 
@@ -177,6 +221,48 @@ impl ProjectLoopEvidenceSnapshot {
 
 	pub(crate) fn recent_autonomy_proposals(&self, limit: usize) -> Vec<&AutonomyProposalRecord> {
 		self.autonomy_proposals.iter().take(limit).collect()
+	}
+
+	pub(crate) fn autonomy_objective(
+		&self,
+		objective_id: &str,
+		objective_version: u64,
+	) -> Option<&AutonomyObjectiveRecord> {
+		self.autonomy_objectives.iter().find(|record| {
+			record.objective_id() == objective_id && record.version() == objective_version
+		})
+	}
+
+	pub(crate) fn accepted_autonomy_objectives(&self) -> Vec<&AutonomyObjectiveRecord> {
+		self.autonomy_objectives
+			.iter()
+			.filter(|record| record.state() == AutonomyObjectiveState::Accepted)
+			.collect()
+	}
+
+	pub(crate) fn decision_contracts_for_autonomy_proposal(
+		&self,
+		proposal_id: &str,
+	) -> Vec<&DecisionContractRecord> {
+		self.decision_contracts
+			.iter()
+			.filter(|record| {
+				record.contract().research_provenance().iter().any(|provenance| {
+					provenance.kind() == "autonomy_proposal"
+						&& provenance.reference() == proposal_id
+				})
+			})
+			.collect()
+	}
+
+	pub(crate) fn program_intake_plans_for_contract(
+		&self,
+		contract_id: &str,
+	) -> Vec<&ProgramIntakePlanRecord> {
+		self.program_intake_plans
+			.iter()
+			.filter(|record| record.source_contract_id() == Some(contract_id))
+			.collect()
 	}
 }
 
@@ -2190,6 +2276,20 @@ impl StateStore {
 			snapshot.insert_review_checkpoint(record.as_public());
 		}
 		for record in state
+			.decision_contracts
+			.values()
+			.filter(|record| record.project_id == project_id)
+		{
+			snapshot.insert_decision_contract(record.as_public());
+		}
+		for record in state
+			.autonomy_objectives
+			.values()
+			.filter(|record| record.project_id == project_id)
+		{
+			snapshot.insert_autonomy_objective(record.as_public());
+		}
+		for record in state
 			.autonomy_signals
 			.values()
 			.filter(|record| record.project_id == project_id)
@@ -2203,10 +2303,20 @@ impl StateStore {
 		{
 			snapshot.insert_autonomy_proposal(record.as_public());
 		}
+		for record in state
+			.program_intake_plans
+			.values()
+			.filter(|record| record.project_id == project_id)
+		{
+			snapshot.insert_program_intake_plan(record.clone());
+		}
 
 		snapshot.sort_private_events();
+		snapshot.sort_decision_contracts();
+		snapshot.sort_autonomy_objectives();
 		snapshot.sort_autonomy_signals();
 		snapshot.sort_autonomy_proposals();
+		snapshot.sort_program_intake_plans();
 
 		Ok(snapshot)
 	}

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -6,9 +6,9 @@ status: active
 authority: current_state
 owner: docs
 tags: [reference]
-code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/recovery.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/mcp.rs]
+code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/recovery.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/types.rs, apps/decodex/src/orchestrator/operator_http.rs, apps/decodex/src/orchestrator/operator_dashboard.html, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/mcp.rs]
 drift_watch: [decodex serve, decodex status, decodex recover ghost-lane, ghost_lane_cleanup_audit_present, mcp_test_fixture_ghost_lane, decodex evidence, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, phase_acceptance_check, control_plane_snapshot, operator dashboard, runtime.sqlite3, project.toml, WORKFLOW.md]
-last_verified: 2026-06-22
+last_verified: 2026-06-23
 ---
 # Operator Control Plane
 
@@ -58,6 +58,15 @@ Decodex currently runs as a local, single-machine control plane:
   public-safe reason codes, public-safe reasons, and a recovery next action. It must not expose
   Decision Contract payloads, raw graph edges, local paths, credentials, raw logs, or
   private runtime events.
+- Autonomy readback is status-derived, not SQLite-inspection-only. Running lane status
+  may include the accepted Objective Contract id/version, recent signals with public
+  source refs and freshness, proposal states and refusal reasons, public-safe proposal
+  -> Decision Contract -> Program Intake lineage, and report metadata with source
+  refs, redaction level, completeness, and known gaps. The browser dashboard and
+  Decodex App must display autonomy progress or freshness only when the published
+  runtime status includes fresh signal source refs; otherwise they show that source
+  refs are needed. Report rows are labeled as derived query views and are not audit
+  authority.
 - Persisted Execution Programs are evaluated by the Program scheduler before ordinary
   queued-label issue selection. Ready, startable mapped nodes can be dispatched
   directly with `program` dispatch mode; blocked, stale, paused, terminal,

--- a/docs/spec/autonomy-control-plane.md
+++ b/docs/spec/autonomy-control-plane.md
@@ -24,6 +24,8 @@ code_refs:
   - apps/decodex/src/mcp.rs
   - apps/decodex/src/program_intake.rs
   - apps/decodex/src/orchestrator/status.rs
+  - apps/decodex/src/orchestrator/types.rs
+  - apps/decodex/src/orchestrator/operator_dashboard.html
   - apps/decodex/src/state/store.rs
   - apps/decodex/src/state/internal.rs
 related:
@@ -392,6 +394,14 @@ links. That lineage remains private runtime metadata; generated tracker issue te
 stays a natural-language brief and must not expose signal ids, proposal ids, Program
 ids, node ids, or graph mechanics.
 
+Operator, App, and MCP status readback may expose a public-safe projection of the same
+chain so autonomy is inspectable without SQLite. The projection must include the
+current accepted Objective Contract version, recent signal summaries with source refs,
+freshness, redaction level, completeness, and known gaps, proposal state and refusal
+reasons, and proposal -> Decision Contract -> Program Intake lineage. It must not
+include raw evidence payloads, hidden reasoning, local-only paths, credentials,
+unredacted private source refs, or generated issue graph mechanics.
+
 ## MCP And Skill Action Matrix
 
 MCP is the typed machine interface. Skills are the policy pack that tells agents
@@ -463,6 +473,9 @@ evidence.
 Generated reports must carry `generated_at`, `window_start`, `window_end`,
 `source_surfaces`, `source_refs`, `redaction_level`, `completeness`, and
 `known_gaps`.
+Operator and MCP report readback must label report output as a derived query view,
+not audit authority, and must expose source refs, redaction level, completeness, and
+known gaps before any dashboard or agent-facing surface claims freshness.
 
 ## Self-Dogfood Boundary
 

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -196,6 +196,15 @@ hydration; detailed protocol event history stays in the runtime database. This k
 concurrent runs from amplifying snapshot size by copying full journals into every
 operator-state refresh.
 
+Operator snapshots may also expose autonomy readback derived from runtime rows for
+the current/recent status window. That readback is an inspectability projection over
+accepted Objective Contract versions, recent signals, proposal states and refusals,
+public-safe proposal -> Decision Contract -> Program Intake lineage, and report
+metadata. It must carry source refs, freshness, redaction level, completeness, and
+known gaps before dashboard, App, or MCP consumers claim autonomy progress. It is not
+an audit authority and must omit raw evidence payloads, hidden reasoning, credentials,
+and local-only path details.
+
 This boundary does not create a project-local runtime database contract. The runtime store remains the single-machine Decodex SQLite database under `~/.codex/decodex/`, scoped by `project_id`.
 
 ## Runtime tuning inputs


### PR DESCRIPTION
## Summary
- Surface Objective Contract, signal, proposal, Decision Contract, and Program Intake lineage in operator status/readback.
- Add derived-query autonomy report metadata with source refs, redaction level, completeness, known gaps, and proposal refusal reasons.
- Gate dashboard autonomy progress labels on fresh signal source refs and keep MCP projections public-safe.

## Validation
- cargo make fmt
- cargo make lint-fix
- cargo make test
- cargo test -p decodex operator --lib
- cargo test -p decodex status --lib
- cargo make fmt-check
- cargo make check-docs
- git diff --check

## Review
- Independent fresh-context Decodex review checkpoint is clean for HEAD d0d248a6c66bc5e7720311694a5e474e38087a82.