### PR TITLE
XY-1101: Fix retained review-repair terminalization after validated local PR head

### DIFF
--- a/apps/decodex/src/execution_program.rs
+++ b/apps/decodex/src/execution_program.rs
@@ -1810,12 +1810,13 @@ fn lifecycle_state_for(
 	}
 
 	match state {
-		ExecutionReadinessState::NotReady | ExecutionReadinessState::Paused =>
+		ExecutionReadinessState::NotReady | ExecutionReadinessState::Paused => {
 			if node.linear_issue().is_some() {
 				ExecutionProgramNodeLifecycleState::Mapped
 			} else {
 				ExecutionProgramNodeLifecycleState::Planned
-			},
+			}
+		},
 		ExecutionReadinessState::Ready => ExecutionProgramNodeLifecycleState::Ready,
 		ExecutionReadinessState::Blocked => ExecutionProgramNodeLifecycleState::Blocked,
 		ExecutionReadinessState::Active => ExecutionProgramNodeLifecycleState::Active,

--- a/apps/decodex/src/loop_contract.rs
+++ b/apps/decodex/src/loop_contract.rs
@@ -877,8 +877,9 @@ fn validate_proposed_issue_stage(key: &str, stage: &str) -> Result<()> {
 	match stage {
 		"research" | "design" | "spec" | "schema" | "runtime" | "plugin" | "eval" | "handoff" =>
 			Ok(()),
-		_ =>
-			eyre::bail!("Decision Contract proposed issue `{key}` has unsupported stage `{stage}`."),
+		_ => {
+			eyre::bail!("Decision Contract proposed issue `{key}` has unsupported stage `{stage}`.")
+		},
 	}
 }
 

--- a/apps/decodex/src/mcp.rs
+++ b/apps/decodex/src/mcp.rs
@@ -453,11 +453,12 @@ impl McpServer {
 	fn call_observe_tool(&self, arguments: Value) -> Value {
 		let params = match serde_json::from_value::<ObserveToolArgs>(arguments) {
 			Ok(params) => params,
-			Err(_) =>
+			Err(_) => {
 				return invalid_tool_arguments(
 					TOOL_OBSERVE,
 					"`issue`, `runId`, and `limit` are the only supported observe arguments.",
-				),
+				);
+			},
 		};
 		let limit = params.limit.unwrap_or(DEFAULT_MCP_STATUS_LIMIT);
 
@@ -479,11 +480,12 @@ impl McpServer {
 		};
 		let mut value = match observability_result {
 			Ok(value) => value,
-			Err(_) =>
+			Err(_) => {
 				return tool_refusal(
 					"observability_unavailable",
 					"Decodex observability requires a registered project config or --config.",
-				),
+				);
+			},
 		};
 
 		sanitize_mcp_observability_value(&mut value);
@@ -499,11 +501,12 @@ impl McpServer {
 	fn call_research_compile_tool(&self, arguments: Value) -> Value {
 		let params = match serde_json::from_value::<ResearchCompileToolArgs>(arguments) {
 			Ok(params) => params,
-			Err(_) =>
+			Err(_) => {
 				return invalid_tool_arguments(
 					TOOL_RESEARCH_COMPILE,
 					"`mode` must be dry_run or apply, with either `input` or `intent`.",
-				),
+				);
+			},
 		};
 		let mode = match planning_mode(params.mode.as_deref(), "dry_run", TOOL_RESEARCH_COMPILE) {
 			Ok(mode) => mode,
@@ -552,11 +555,12 @@ impl McpServer {
 	fn call_research_promote_tool(&self, arguments: Value) -> Value {
 		let params = match serde_json::from_value::<ResearchPromoteToolArgs>(arguments) {
 			Ok(params) => params,
-			Err(_) =>
+			Err(_) => {
 				return invalid_tool_arguments(
 					TOOL_RESEARCH_PROMOTE,
 					"`contractId` is required and `mode` must be dry_run or apply.",
-				),
+				);
+			},
 		};
 		let Some(contract_id) = non_empty_string(Some(params.contract_id.as_str())) else {
 			return invalid_tool_arguments(TOOL_RESEARCH_PROMOTE, "`contractId` is required.");
@@ -614,11 +618,12 @@ impl McpServer {
 			Some(accepted_at) => accepted_at.to_owned(),
 			None => match OffsetDateTime::now_utc().format(&Rfc3339) {
 				Ok(value) => value,
-				Err(_) =>
+				Err(_) => {
 					return tool_refusal(
 						"research_promote_refused",
 						"Promotion timestamp could not be prepared.",
-					),
+					);
+				},
 			},
 		};
 		let promotion = match DecisionPromotion::new(
@@ -629,11 +634,12 @@ impl McpServer {
 			authority.reason.cloned(),
 		) {
 			Ok(promotion) => promotion,
-			Err(_) =>
+			Err(_) => {
 				return tool_refusal(
 					"research_promote_refused",
 					"Promotion authority did not satisfy Decodex Decision Contract requirements.",
-				),
+				);
+			},
 		};
 
 		match research_design::promote_research_design_contract(
@@ -659,11 +665,12 @@ impl McpServer {
 	fn call_intake_goal_tool(&self, arguments: Value) -> Value {
 		let params = match serde_json::from_value::<IntakeGoalToolArgs>(arguments) {
 			Ok(params) => params,
-			Err(_) =>
+			Err(_) => {
 				return invalid_tool_arguments(
 					TOOL_INTAKE_GOAL,
 					"`contractId` is required and `mode` must be dry_run or apply.",
-				),
+				);
+			},
 		};
 		let Some(contract_id) = non_empty_string(Some(params.contract_id.as_str())) else {
 			return invalid_tool_arguments(TOOL_INTAKE_GOAL, "`contractId` is required.");
@@ -699,27 +706,30 @@ impl McpServer {
 		};
 		let config_path = match self.context.config_path.as_deref() {
 			Some(path) => path,
-			None =>
+			None => {
 				return tool_refusal(
 					"missing_project_context",
 					"intake_goal dry-run requires a registered Decodex project config or --config.",
-				),
+				);
+			},
 		};
 		let config = match ServiceConfig::from_path(config_path) {
 			Ok(config) => config,
-			Err(_) =>
+			Err(_) => {
 				return tool_refusal(
 					"missing_project_context",
 					"intake_goal dry-run could not load the Decodex project config.",
-				),
+				);
+			},
 		};
 		let workflow = match WorkflowDocument::from_path(config.workflow_path()) {
 			Ok(workflow) => workflow,
-			Err(_) =>
+			Err(_) => {
 				return tool_refusal(
 					"missing_project_context",
 					"intake_goal dry-run could not load the Decodex workflow contract.",
-				),
+				);
+			},
 		};
 		let tracker = McpDryRunTracker;
 
@@ -772,11 +782,12 @@ impl McpServer {
 	fn call_lane_control_tool(&self, arguments: Value, profile: McpCapabilityProfile) -> Value {
 		let params = match serde_json::from_value::<LaneControlToolArgs>(arguments) {
 			Ok(params) => params,
-			Err(_) =>
+			Err(_) => {
 				return invalid_tool_arguments(
 					TOOL_LANE_CONTROL,
 					"`action` is required and must be one of inspect, interrupt, steer, manual_attention, or retained_resume.",
-				),
+				);
+			},
 		};
 
 		if !matches!(
@@ -841,13 +852,14 @@ impl McpServer {
 			DEFAULT_MCP_STATUS_LIMIT,
 		) {
 			Ok(report) => report,
-			Err(error) =>
+			Err(error) => {
 				return lane_control_refusal_result(
 					params,
 					profile,
 					"lane_inspect_unavailable",
 					format!("Lane inspect failed closed: {error}"),
-				),
+				);
+			},
 		};
 		let mut result = serde_json::json!({
 			"schema": "decodex.mcp.lane_control_result/1",
@@ -927,13 +939,14 @@ impl McpServer {
 			authority.source,
 		) {
 			Ok(report) => report,
-			Err(error) =>
+			Err(error) => {
 				return lane_control_refusal_result(
 					params,
 					profile,
 					"lane_interrupt_unavailable",
 					format!("Lane interrupt failed closed: {error}"),
-				),
+				);
+			},
 		};
 
 		lane_control_interrupt_result(params, profile, report)
@@ -1016,13 +1029,14 @@ impl McpServer {
 			wait_timeout: DEFAULT_STEER_RESULT_WAIT_TIMEOUT,
 		}) {
 			Ok(report) => report,
-			Err(error) =>
+			Err(error) => {
 				return lane_control_refusal_result(
 					params,
 					profile,
 					"lane_steer_unavailable",
 					format!("Lane steer failed closed: {error}"),
-				),
+				);
+			},
 		};
 
 		lane_control_steer_result(params, profile, report)
@@ -1031,11 +1045,12 @@ impl McpServer {
 	fn call_project_control_tool(&self, arguments: Value, profile: McpCapabilityProfile) -> Value {
 		let params = match serde_json::from_value::<ProjectControlToolArgs>(arguments) {
 			Ok(params) => params,
-			Err(_) =>
+			Err(_) => {
 				return invalid_tool_arguments(
 					TOOL_PROJECT_CONTROL,
 					"`action` is required and must be one of status, pause, resume, or scan.",
-				),
+				);
+			},
 		};
 
 		if !matches!(params.action.as_str(), "status" | "pause" | "resume" | "scan") {
@@ -1106,13 +1121,14 @@ impl McpServer {
 
 		let state_store = match runtime::open_runtime_store_lazy() {
 			Ok(state_store) => state_store,
-			Err(error) =>
+			Err(error) => {
 				return project_control_refusal_result(
 					params,
 					profile,
 					"project_control_unavailable",
 					format!("Project control failed closed: {error}"),
-				),
+				);
+			},
 		};
 
 		if let Some(config_path) = self.context.config_path.as_deref()
@@ -1824,11 +1840,12 @@ impl McpHttpHandler {
 	) -> crate::prelude::Result<McpHttpResponse> {
 		let cors_origin = match self.allowed_cors_origin(&request) {
 			Ok(origin) => origin,
-			Err(()) =>
+			Err(()) => {
 				return Ok(McpHttpResponse::json_error(
 					"403 Forbidden",
 					json_rpc_error(Value::Null, -32_000, "Forbidden origin"),
-				)),
+				));
+			},
 		};
 		let mut response = if request.path != MCP_HTTP_ENDPOINT_PATH {
 			McpHttpResponse::empty("404 Not Found")
@@ -1871,11 +1888,12 @@ impl McpHttpHandler {
 
 		let body = match str::from_utf8(&request.body) {
 			Ok(body) => body,
-			Err(_) =>
+			Err(_) => {
 				return Ok(McpHttpResponse::json_error(
 					"400 Bad Request",
 					json_rpc_error(Value::Null, -32_700, "Parse error"),
-				)),
+				));
+			},
 		};
 		let method = json_rpc_method_name(body);
 		let is_initialize = method.as_deref() == Some("initialize");
@@ -3218,11 +3236,12 @@ fn tool_validation_error_output_schema() -> Value {
 fn call_plan_tool(arguments: Value) -> Value {
 	let params = match serde_json::from_value::<PlanToolArgs>(arguments) {
 		Ok(params) => params,
-		Err(_) =>
+		Err(_) => {
 			return invalid_tool_arguments(
 				TOOL_PLAN,
 				"`intent` is required and must be one of research, validation_ready, handoff, or lane_control.",
-			),
+			);
+		},
 	};
 
 	if !matches!(
@@ -4226,23 +4245,25 @@ fn project_control_status_result(
 ) -> Value {
 	let state_store = match runtime::open_runtime_store_lazy() {
 		Ok(state_store) => state_store,
-		Err(error) =>
+		Err(error) => {
 			return project_control_refusal_result(
 				params,
 				profile,
 				"project_control_unavailable",
 				format!("Project status failed closed: {error}"),
-			),
+			);
+		},
 	};
 	let projects = match state_store.list_projects() {
 		Ok(projects) => projects,
-		Err(error) =>
+		Err(error) => {
 			return project_control_refusal_result(
 				params,
 				profile,
 				"project_registry_unavailable",
 				format!("Project registry read failed closed: {error}"),
-			),
+			);
+		},
 	};
 	let Some(project) = projects.iter().find(|project| project.service_id() == project_id) else {
 		return project_control_refusal_result(
@@ -4444,10 +4465,11 @@ fn serve_streamable_http_with_profile(
 
 	for stream in listener.incoming() {
 		match stream {
-			Ok(mut stream) =>
+			Ok(mut stream) => {
 				if let Err(error) = handle_mcp_http_stream(&mut stream, &mut handler) {
 					tracing::warn!(?error, "Decodex MCP Streamable HTTP request failed.");
-				},
+				}
+			},
 			Err(error) if error.kind() == ErrorKind::Interrupted => continue,
 			Err(error) => return Err(error.into()),
 		}

--- a/apps/decodex/src/orchestrator/execution.rs
+++ b/apps/decodex/src/orchestrator/execution.rs
@@ -60,6 +60,72 @@ impl Display for AppServerZeroEvidenceStartFailure {
 
 impl Error for AppServerZeroEvidenceStartFailure {}
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RetainedReviewRepairPushFailureKind {
+	Auth,
+	Refspec,
+	RemoteRejected,
+	Failed,
+}
+impl RetainedReviewRepairPushFailureKind {
+	fn error_class(self) -> &'static str {
+		match self {
+			Self::Auth => "retained_review_repair_push_auth_failed",
+			Self::Refspec => "retained_review_repair_push_refspec_failed",
+			Self::RemoteRejected => "retained_review_repair_push_remote_rejected",
+			Self::Failed => "retained_review_repair_push_failed",
+		}
+	}
+}
+
+#[derive(Debug)]
+pub(crate) struct RetainedReviewRepairPushFailed {
+	issue_identifier: String,
+	run_id: String,
+	branch_name: String,
+	pr_url: Option<String>,
+	kind: RetainedReviewRepairPushFailureKind,
+	detail: String,
+}
+impl RetainedReviewRepairPushFailed {
+	fn error_class(&self) -> &'static str {
+		self.kind.error_class()
+	}
+
+	fn terminal_next_action(&self, recovery_gate: &str) -> String {
+		match self.kind {
+			RetainedReviewRepairPushFailureKind::Auth => format!(
+				"repair GitHub authentication, then rerun retained review repair for branch `{}`, {recovery_gate}",
+				self.branch_name
+			),
+			RetainedReviewRepairPushFailureKind::Refspec => format!(
+				"inspect retained review-repair branch `{}` and push refspec, repair the branch/ref mismatch manually, {recovery_gate}",
+				self.branch_name
+			),
+			RetainedReviewRepairPushFailureKind::RemoteRejected => format!(
+				"inspect remote branch `{}` for non-fast-forward or protection drift, reconcile the retained PR branch, {recovery_gate}",
+				self.branch_name
+			),
+			RetainedReviewRepairPushFailureKind::Failed => format!(
+				"inspect the retained review-repair push failure for branch `{}`, repair the remote update blocker, {recovery_gate}",
+				self.branch_name
+			),
+		}
+	}
+}
+
+impl Display for RetainedReviewRepairPushFailed {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		write!(
+			formatter,
+			"Run `{}` for issue `{}` could not push retained review-repair branch `{}` before handoff validation: {}",
+			self.run_id, self.issue_identifier, self.branch_name, self.detail
+		)
+	}
+}
+
+impl Error for RetainedReviewRepairPushFailed {}
+
 struct AgentGitCredentialEnvironment {
 	process_env: AppServerProcessEnv,
 }
@@ -850,6 +916,7 @@ pub(crate) fn run_failure_writeback_disposition(
 			.downcast_ref::<AppServerPhaseGoalFailure>()
 			.is_some_and(|failure| !failure.is_terminal_path_missing())
 		|| error.downcast_ref::<ReviewHandoffNeedsAttention>().is_some()
+		|| error.downcast_ref::<RetainedReviewRepairPushFailed>().is_some()
 		|| error.downcast_ref::<RetainedPartialProgress>().is_some()
 		|| error
 			.downcast_ref::<AppServerCapabilityPreflightFailure>()
@@ -2577,6 +2644,97 @@ fn run_completion_repo_gate(workflow: &WorkflowDocument, issue_run: &IssueRunPla
 	Ok(())
 }
 
+fn push_retained_review_repair_head(
+	project: &ServiceConfig,
+	issue_run: &IssueRunPlan,
+	pr_url: Option<&str>,
+) -> Result<()> {
+	let token_env_var = project.github().token_env_var();
+	let github_token =
+		resolve_configured_env_var("github.token_env_var", Some(token_env_var)).map_err(
+			|error| {
+				Report::new(RetainedReviewRepairPushFailed {
+					issue_identifier: issue_run.issue.identifier.clone(),
+					run_id: issue_run.run_id.clone(),
+					branch_name: issue_run.worktree.branch_name.clone(),
+					pr_url: pr_url.map(ToOwned::to_owned),
+					kind: RetainedReviewRepairPushFailureKind::Auth,
+					detail: error.to_string(),
+				})
+			},
+		)?;
+	let git_credentials =
+		GitCredentialSource::new(token_env_var, &github_token).materialize_github_credentials();
+	let refspec = format!("HEAD:{}", issue_run.worktree.branch_name);
+	let mut command = Command::new("git");
+
+	command
+		.arg("-C")
+		.arg(&issue_run.worktree.path)
+		.arg("push")
+		.arg("origin")
+		.arg(&refspec);
+	git_credentials.apply_to(&mut command);
+
+	let output = command.output().map_err(|error| {
+		Report::new(RetainedReviewRepairPushFailed {
+			issue_identifier: issue_run.issue.identifier.clone(),
+			run_id: issue_run.run_id.clone(),
+			branch_name: issue_run.worktree.branch_name.clone(),
+			pr_url: pr_url.map(ToOwned::to_owned),
+			kind: RetainedReviewRepairPushFailureKind::Failed,
+			detail: error.to_string(),
+		})
+	})?;
+
+	if output.status.success() {
+		return Ok(());
+	}
+
+	let detail = repo_gate_output_text(&output);
+	let kind = classify_retained_review_repair_push_failure(&detail);
+
+	Err(Report::new(RetainedReviewRepairPushFailed {
+		issue_identifier: issue_run.issue.identifier.clone(),
+		run_id: issue_run.run_id.clone(),
+		branch_name: issue_run.worktree.branch_name.clone(),
+		pr_url: pr_url.map(ToOwned::to_owned),
+		kind,
+		detail,
+	}))
+}
+
+fn classify_retained_review_repair_push_failure(
+	detail: &str,
+) -> RetainedReviewRepairPushFailureKind {
+	let normalized = detail.to_ascii_lowercase();
+
+	if normalized.contains("authentication failed")
+		|| normalized.contains("could not read username")
+		|| normalized.contains("permission denied")
+		|| normalized.contains("repository not found")
+		|| normalized.contains("403")
+		|| normalized.contains("401")
+	{
+		return RetainedReviewRepairPushFailureKind::Auth;
+	}
+	if normalized.contains("src refspec")
+		|| normalized.contains("dst refspec")
+		|| normalized.contains("invalid refspec")
+	{
+		return RetainedReviewRepairPushFailureKind::Refspec;
+	}
+	if normalized.contains("rejected")
+		|| normalized.contains("non-fast-forward")
+		|| normalized.contains("fetch first")
+		|| normalized.contains("protected branch hook declined")
+	{
+		return RetainedReviewRepairPushFailureKind::RemoteRejected;
+	}
+
+	RetainedReviewRepairPushFailureKind::Failed
+}
+
 fn apply_run_completion_disposition<T>(
 	tracker: &T,
 	project: &ServiceConfig,
@@ -2628,7 +2786,15 @@ where
 			}));
 		},
 		RunCompletionDisposition::ReviewRepair => {
+			validate_review_repair_runtime(project, false)?;
 			run_completion_repo_gate(workflow, issue_run)?;
+			push_retained_review_repair_head(
+				project,
+				issue_run,
+				tracker_tool_bridge
+					.review_context()
+					.and_then(|context| context.recorded_pr_url.as_deref()),
+			)?;
 
 			tracker_tool_bridge.apply_review_repair()?;
 
@@ -5137,6 +5303,7 @@ fn retained_progress_should_defer_to_terminal_intent(error: &Report) -> bool {
 	error.downcast_ref::<ManualAttentionRequested>().is_some()
 		|| error.downcast_ref::<LoopGuardrailStopRequested>().is_some()
 		|| error.downcast_ref::<ReviewHandoffNeedsAttention>().is_some()
+		|| error.downcast_ref::<RetainedReviewRepairPushFailed>().is_some()
 		|| error.downcast_ref::<RetainedPartialProgress>().is_some()
 		|| error.downcast_ref::<RetainedReviewNeedsAttention>().is_some()
 		|| error.downcast_ref::<ReviewPolicyStopRequested>().is_some()
@@ -5150,6 +5317,8 @@ fn retained_progress_source_error_class(error: &Report) -> Option<&'static str> 
 		Some("stalled_run_detected")
 	} else if error.downcast_ref::<AgentGitCredentialsUnavailable>().is_some() {
 		Some("github_credentials_unavailable")
+	} else if let Some(push_failure) = error.downcast_ref::<RetainedReviewRepairPushFailed>() {
+		Some(push_failure.error_class())
 	} else if let Some(app_server_failure) =
 		error.downcast_ref::<AppServerCapabilityPreflightFailure>()
 	{

--- a/apps/decodex/src/orchestrator/selection.rs
+++ b/apps/decodex/src/orchestrator/selection.rs
@@ -218,7 +218,14 @@ fn format_terminal_failure_comment(
 }
 
 fn terminal_failure_pr_url(error: &Report) -> Option<&str> {
-	error.downcast_ref::<ReviewHandoffNeedsAttention>().map(|error| error.pr_url.as_str())
+	error
+		.downcast_ref::<ReviewHandoffNeedsAttention>()
+		.map(|error| error.pr_url.as_str())
+		.or_else(|| {
+			error
+				.downcast_ref::<RetainedReviewRepairPushFailed>()
+				.and_then(|error| error.pr_url.as_deref())
+		})
 }
 
 fn terminal_failure_comment_details(
@@ -268,6 +275,8 @@ fn terminal_failure_comment_details(
 				"inspect the tracker state, PR, and worktree, repair the incomplete review handoff manually, {recovery_gate}"
 			),
 		)
+	} else if let Some(push_failure) = error.downcast_ref::<RetainedReviewRepairPushFailed>() {
+		(push_failure.error_class(), push_failure.terminal_next_action(recovery_gate))
 	} else if let Some(partial_progress) = error.downcast_ref::<RetainedPartialProgress>() {
 		(
 			"partial_progress_retained",

--- a/apps/decodex/src/orchestrator/tests/runtime/failure.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/failure.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use orchestrator::{
 	AgentGitCredentialEnvironment, AgentGitCredentialsUnavailable, RepoGateFailureKind,
+	RetainedReviewRepairPushFailed,
 };
 use orchestrator::AppServerZeroEvidenceStartFailure;
 use orchestrator::LoopGuardrailReason;
@@ -2655,6 +2656,81 @@ fn validate_review_handoff_runtime_requires_gh_and_github_token_authority() {
 
 	assert!(
 		error.to_string().contains("Required command `__decodex_missing_command__` is unavailable")
+	);
+}
+
+#[test]
+fn retained_review_repair_completion_pushes_repaired_head_to_pr_branch() {
+	let (temp_dir, base_config, _workflow) = temp_project_layout();
+	let env_var = format!("DECODEX_TEST_REPAIR_PUSH_GITHUB_TOKEN_ENV_{}", process::id());
+	let _env_guard = TestEnvVarGuard::set(&env_var, "secret-token-value");
+	let config = service_config_with_github_token_env_var(&base_config, &env_var);
+	let remote_root = temp_dir.path().join("origin.git");
+	let issue = sample_issue("In Review", &[]);
+	let issue_run = loop_guardrail_issue_run(&config, &issue, 2);
+
+	add_origin_remote(config.repo_root(), &remote_root);
+	checkout_new_branch(config.repo_root(), &issue_run.worktree.branch_name);
+
+	let local_head = commit_worktree_change(
+		config.repo_root(),
+		"repair.txt",
+		"repair\n",
+		"retained review repair",
+	);
+
+	orchestrator::push_retained_review_repair_head(
+		&config,
+		&issue_run,
+		Some("https://github.com/hack-ink/decodex/pull/502"),
+	)
+	.expect("retained review-repair completion should push the repaired head");
+
+	let output = Command::new("git")
+		.arg("--git-dir")
+		.arg(&remote_root)
+		.args(["rev-parse", &format!("refs/heads/{}", issue_run.worktree.branch_name)])
+		.output()
+		.expect("remote head probe should run");
+
+	assert!(
+		output.status.success(),
+		"remote retained repair branch should exist: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), local_head);
+}
+
+#[test]
+fn retained_review_repair_push_failures_are_structured_terminal_attention() {
+	let _env_lock = TestEnvVarGuard::lock();
+	let (_temp_dir, base_config, _workflow) = temp_project_layout();
+	let missing_env_var = format!("DECODEX_TEST_MISSING_REPAIR_PUSH_TOKEN_ENV_{}", process::id());
+	let config = service_config_with_github_token_env_var(&base_config, &missing_env_var);
+	let issue = sample_issue("In Review", &[]);
+	let issue_run = loop_guardrail_issue_run(&config, &issue, 2);
+	let error = orchestrator::push_retained_review_repair_head(
+		&config,
+		&issue_run,
+		Some("https://github.com/hack-ink/decodex/pull/502"),
+	)
+	.expect_err("missing GitHub token should produce a typed push failure");
+	let push_failure = error
+		.downcast_ref::<RetainedReviewRepairPushFailed>()
+		.expect("missing push authority should preserve typed error");
+	let (error_class, next_action) = orchestrator::terminal_failure_comment_details(
+		false,
+		&error,
+		"clear label `decodex:needs-attention`",
+	);
+
+	assert_eq!(push_failure.error_class(), "retained_review_repair_push_auth_failed");
+	assert_eq!(error_class, "retained_review_repair_push_auth_failed");
+	assert!(next_action.contains("repair GitHub authentication"));
+	assert!(next_action.contains(&issue_run.worktree.branch_name));
+	assert_eq!(
+		orchestrator::run_failure_writeback_disposition(&error),
+		RunFailureWritebackDisposition::TerminalAttention
 	);
 }
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-23
 
+- Added the retained review-repair terminalization contract: after local validation
+  passes, Decodex now owns pushing the repaired head to the retained PR branch,
+  records typed push failures before marker refresh, and only refreshes retained
+  review lineage after PR readback confirms the remote head matches local `HEAD`.
 - Tightened the Codebase Codex lifecycle hook so Codex-owned commit/push attempts
   receive the `decodex/commit/1` JSON message contract, large implementation diffs
   trigger module-boundary challenge guidance before ready claims, public

--- a/docs/spec/post-review-lifecycle.md
+++ b/docs/spec/post-review-lifecycle.md
@@ -7,6 +7,7 @@ authority: normative
 owner: runtime
 tags: [spec]
 code_refs:
+  - apps/decodex/src/orchestrator/execution.rs
   - apps/decodex/src/orchestrator/dispatch_policy.rs
   - apps/decodex/src/orchestrator/run_cycle.rs
   - apps/decodex/src/orchestrator/status.rs
@@ -21,7 +22,7 @@ drift_watch:
   - IssueDispatchMode::Retry
   - IssueDispatchMode::ReviewRepair
   - IssueDispatchMode::Closeout
-last_verified: 2026-06-22
+last_verified: 2026-06-23
 ---
 # Post-Review Lifecycle
 
@@ -318,9 +319,15 @@ If the issue also uses `execution-state`, that overlay remains only durable exec
 
 In the current XY-174 slice, a retained repair run finishes by recording an explicit
 `issue_review_repair_complete` action for the same PR URL, then finalizing the run with
-the `review_repair` terminal path. Applying that completion refreshes the local
-runtime handoff row to the repaired PR head while keeping the tracker issue
-in `In Review`; it does not re-run the original `issue_review_handoff` state transition.
+the `review_repair` terminal path. After the local repository gate passes, Decodex
+must push the validated local `HEAD` to the retained PR branch before applying that
+completion. Push auth, refspec, and remote-rejection failures are structured
+retained-review-repair push failures; they must stop before refreshing the retained
+handoff row. After a successful push, applying completion must re-read the PR and
+verify that the remote PR head matches the validated local `HEAD`. Only then may it
+refresh the local runtime handoff row to the repaired PR head while keeping the
+tracker issue in `In Review`; it does not re-run the original
+`issue_review_handoff` state transition.
 When `[codex].review` is `"standard"` or `"strict"`,
 `issue_review_repair_complete` is valid only when the latest retained repair
 checkpoint is `clean` for the current repaired head. If repeated repair checkpoints

--- a/docs/spec/tracker-tools.md
+++ b/docs/spec/tracker-tools.md
@@ -8,7 +8,7 @@ owner: runtime
 tags: [spec]
 code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/agent/tracker_tool_bridge/review.rs, apps/decodex/src/orchestrator/execution.rs]
 drift_watch: [issue_progress_checkpoint, issue_review_checkpoint, issue_review_handoff, issue_review_repair_complete, review_contract, review_cost_control, phase_acceptance_check, issue_terminal_finalize, docs_impact, private_execution_events, linear_execution_event]
-last_verified: 2026-06-22
+last_verified: 2026-06-23
 ---
 # Tracker Tool Specification
 
@@ -288,7 +288,7 @@ In either invalid case, `decodex` must fail the attempt rather than infer which 
   succeed. If an existing lifecycle row for the lane branch points at a different PR
   URL, head ref, base ref, or head OID, the tool must fail closed and require explicit
   review-handoff recovery instead of rebinding implicitly.
-- `issue_review_repair_complete` records retained repair completion metadata during the turn, but `decodex` owns the final completion comment and refreshed retained-lineage marker after service-side validation succeeds.
+- `issue_review_repair_complete` records retained repair completion metadata during the turn, but `decodex` owns the final completion comment and refreshed retained-lineage marker after service-side validation succeeds. For retained repair finalization, service-side validation includes pushing the validated local `HEAD` to the retained PR branch, surfacing typed push auth/refspec/remote-rejection failures before marker refresh, and then re-reading the PR so the refreshed retained-lineage marker is written only when the remote PR head matches the validated local `HEAD`.
 - Agent-authored PR lifecycle summaries are public text inputs. If the summary recorded
   by `issue_review_handoff`, `issue_review_repair_complete`, or `issue_closeout_complete`
   fails the public-text guard during Decodex-owned writeback, Decodex must use fixed


### PR DESCRIPTION
## Summary
- push retained review-repair heads before repair writeback and preserve PR head revalidation
- surface typed retained review-repair push failures before marker refresh
- document the retained repair push/readback contract and add regression coverage

## Validation
- cargo make check