### PR TITLE
Repair autonomy replay evidence chain

### DIFF
--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -8682,18 +8682,15 @@ fn operator_autonomy_execution_evidence_statuses(
 	let mut evidence = Vec::new();
 
 	for (issue_id, issue_identifier) in operator_autonomy_generated_issue_pairs(contracts) {
-		for review in loop_evidence.review_lifecycle_records_for_issue(&issue_id) {
-			evidence.push(operator_autonomy_pr_evidence_status(
-				review,
-				issue_identifier.as_deref(),
-			));
-		}
+		let review_lifecycle_records = loop_evidence.review_lifecycle_records_for_issue(&issue_id);
+
 		for event in loop_evidence.private_events_for_issue(&issue_id) {
 			if let Some(status) = operator_autonomy_replay_evidence_status_from_event(
 				event,
 				proposal_id,
 				&contract_ids,
 				issue_identifier.as_deref(),
+				&review_lifecycle_records,
 			) {
 				evidence.push(status);
 			}
@@ -8705,6 +8702,12 @@ fn operator_autonomy_execution_evidence_statuses(
 			.cmp(&right.kind)
 			.then_with(|| left.issue_identifier.cmp(&right.issue_identifier))
 			.then_with(|| left.source_refs.cmp(&right.source_refs))
+			.then_with(|| {
+				operator_autonomy_evidence_completeness_rank(&right.completeness)
+					.cmp(&operator_autonomy_evidence_completeness_rank(&left.completeness))
+			})
+			.then_with(|| right.updated_at.cmp(&left.updated_at))
+			.then_with(|| left.summary.cmp(&right.summary))
 	});
 	evidence.dedup_by(|left, right| {
 		left.kind == right.kind
@@ -8743,9 +8746,12 @@ fn operator_autonomy_generated_issue_pairs(
 	pairs
 }
 
-fn operator_autonomy_pr_evidence_status(
+fn operator_autonomy_pr_evidence_status_from_event(
+	event: &PrivateExecutionEvent,
 	review: &ReviewLifecycleRecord,
 	issue_identifier: Option<&str>,
+	summary: String,
+	summary_redacted: bool,
 ) -> OperatorAutonomyExecutionEvidenceStatus {
 	let (source_refs, refs_redacted) = public_autonomy_refs(&[review.pr_url().to_owned()]);
 	let mut known_gaps = Vec::new();
@@ -8756,13 +8762,20 @@ fn operator_autonomy_pr_evidence_status(
 	if refs_redacted {
 		known_gaps.push(String::from("source_refs_redacted"));
 	}
+	if summary_redacted {
+		known_gaps.push(String::from("summary_redacted"));
+	}
 
 	OperatorAutonomyExecutionEvidenceStatus {
 		kind: String::from("pr"),
 		issue_identifier: issue_identifier.map(str::to_owned),
 		source_refs,
-		summary: String::from("PR-backed review handoff readback recorded."),
-		updated_at: review.updated_at().to_owned(),
+		summary,
+		updated_at: [review.updated_at(), event.recorded_at()]
+			.into_iter()
+			.max()
+			.unwrap_or_else(|| event.recorded_at())
+			.to_owned(),
 		completeness: operator_autonomy_completeness(&known_gaps),
 		known_gaps,
 	}
@@ -8773,6 +8786,7 @@ fn operator_autonomy_replay_evidence_status_from_event(
 	proposal_id: &str,
 	contract_ids: &BTreeSet<&str>,
 	issue_identifier: Option<&str>,
+	review_lifecycle_records: &[&ReviewLifecycleRecord],
 ) -> Option<OperatorAutonomyExecutionEvidenceStatus> {
 	let payload = event.payload();
 
@@ -8784,7 +8798,7 @@ fn operator_autonomy_replay_evidence_status_from_event(
 	}
 
 	let kind = match payload.get("kind").and_then(Value::as_str) {
-		Some(kind @ ("validation" | "post_land")) => kind.to_owned(),
+		Some(kind @ ("pr" | "validation" | "post_land")) => kind.to_owned(),
 		_ => return None,
 	};
 	let raw_source_refs = payload
@@ -8804,6 +8818,39 @@ fn operator_autonomy_replay_evidence_status_from_event(
 	);
 	let mut known_gaps = Vec::new();
 
+	if kind == "pr" {
+		return Some(match operator_autonomy_matching_pr_review(event, &raw_source_refs, review_lifecycle_records) {
+			Some(review) => operator_autonomy_pr_evidence_status_from_event(
+				event,
+				review,
+				issue_identifier,
+				summary,
+				summary_redacted,
+			),
+			None => {
+				if source_refs.is_empty() {
+					known_gaps.push(String::from("source_refs_missing_or_redacted"));
+				}
+				if refs_redacted {
+					known_gaps.push(String::from("source_refs_redacted"));
+				}
+				if summary_redacted {
+					known_gaps.push(String::from("summary_redacted"));
+				}
+
+				known_gaps.push(String::from("review_lifecycle_missing"));
+				OperatorAutonomyExecutionEvidenceStatus {
+					kind,
+					issue_identifier: issue_identifier.map(str::to_owned),
+					source_refs,
+					summary,
+					updated_at: event.recorded_at().to_owned(),
+					completeness: operator_autonomy_completeness(&known_gaps),
+					known_gaps,
+				}
+			}
+		});
+	}
 	if source_refs.is_empty() {
 		known_gaps.push(String::from("source_refs_missing_or_redacted"));
 	}
@@ -8823,6 +8870,31 @@ fn operator_autonomy_replay_evidence_status_from_event(
 		completeness: operator_autonomy_completeness(&known_gaps),
 		known_gaps,
 	})
+}
+
+fn operator_autonomy_matching_pr_review<'a>(
+	event: &PrivateExecutionEvent,
+	raw_source_refs: &[String],
+	review_lifecycle_records: &'a [&'a ReviewLifecycleRecord],
+) -> Option<&'a ReviewLifecycleRecord> {
+	let raw_source_refs = raw_source_refs
+		.iter()
+		.map(|source_ref| source_ref.trim())
+		.collect::<BTreeSet<_>>();
+
+	review_lifecycle_records
+		.iter()
+		.copied()
+		.filter(|review| {
+			review.run_id() == event.run_id()
+				&& review.attempt_number() == event.attempt_number()
+				&& raw_source_refs.contains(review.pr_url())
+		})
+		.max_by(|left, right| {
+			left.updated_at_unix()
+				.cmp(&right.updated_at_unix())
+				.then_with(|| left.branch_name().cmp(right.branch_name()))
+		})
 }
 
 fn operator_autonomy_replay_evidence_matches(
@@ -8914,6 +8986,13 @@ fn operator_autonomy_objective_ref(objective_id: &str, objective_version: u64) -
 
 fn operator_autonomy_completeness(known_gaps: &[String]) -> String {
 	if known_gaps.is_empty() { String::from("complete") } else { String::from("partial") }
+}
+
+fn operator_autonomy_evidence_completeness_rank(value: &str) -> u8 {
+	match value {
+		"complete" => 1,
+		_ => 0,
+	}
 }
 
 fn operator_autonomy_max_redaction_level(left: &str, right: &str) -> &'static str {

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -8819,37 +8819,66 @@ fn operator_autonomy_replay_evidence_status_from_event(
 	let mut known_gaps = Vec::new();
 
 	if kind == "pr" {
-		return Some(match operator_autonomy_matching_pr_review(event, &raw_source_refs, review_lifecycle_records) {
-			Some(review) => operator_autonomy_pr_evidence_status_from_event(
-				event,
-				review,
-				issue_identifier,
-				summary,
-				summary_redacted,
-			),
-			None => {
-				if source_refs.is_empty() {
-					known_gaps.push(String::from("source_refs_missing_or_redacted"));
-				}
-				if refs_redacted {
-					known_gaps.push(String::from("source_refs_redacted"));
-				}
-				if summary_redacted {
-					known_gaps.push(String::from("summary_redacted"));
-				}
+		let pr_head_ref = payload
+			.get("pr_head_ref")
+			.and_then(Value::as_str)
+			.map(str::trim)
+			.filter(|value| !value.is_empty());
+		let pr_head_oid = payload
+			.get("pr_head_oid")
+			.and_then(Value::as_str)
+			.map(str::trim)
+			.filter(|value| !value.is_empty());
 
-				known_gaps.push(String::from("review_lifecycle_missing"));
-				OperatorAutonomyExecutionEvidenceStatus {
-					kind,
-					issue_identifier: issue_identifier.map(str::to_owned),
-					source_refs,
+		return Some(
+			match operator_autonomy_matching_pr_review(
+				event,
+				&raw_source_refs,
+				pr_head_ref,
+				pr_head_oid,
+				review_lifecycle_records,
+			) {
+				Some(review) => operator_autonomy_pr_evidence_status_from_event(
+					event,
+					review,
+					issue_identifier,
 					summary,
-					updated_at: event.recorded_at().to_owned(),
-					completeness: operator_autonomy_completeness(&known_gaps),
-					known_gaps,
+					summary_redacted,
+				),
+				None => {
+					if source_refs.is_empty() {
+						known_gaps.push(String::from("source_refs_missing_or_redacted"));
+					}
+					if refs_redacted {
+						known_gaps.push(String::from("source_refs_redacted"));
+					}
+					if summary_redacted {
+						known_gaps.push(String::from("summary_redacted"));
+					}
+					if pr_head_ref.is_none() || pr_head_oid.is_none() {
+						known_gaps.push(String::from("pr_head_identity_missing"));
+					} else if operator_autonomy_pr_review_candidate_exists(
+						event,
+						&raw_source_refs,
+						review_lifecycle_records,
+					) {
+						known_gaps.push(String::from("review_lifecycle_stale_or_mismatched"));
+					} else {
+						known_gaps.push(String::from("review_lifecycle_missing"));
+					}
+
+					OperatorAutonomyExecutionEvidenceStatus {
+						kind,
+						issue_identifier: issue_identifier.map(str::to_owned),
+						source_refs,
+						summary,
+						updated_at: event.recorded_at().to_owned(),
+						completeness: operator_autonomy_completeness(&known_gaps),
+						known_gaps,
+					}
 				}
-			}
-		});
+			},
+		);
 	}
 	if source_refs.is_empty() {
 		known_gaps.push(String::from("source_refs_missing_or_redacted"));
@@ -8875,8 +8904,12 @@ fn operator_autonomy_replay_evidence_status_from_event(
 fn operator_autonomy_matching_pr_review<'a>(
 	event: &PrivateExecutionEvent,
 	raw_source_refs: &[String],
+	pr_head_ref: Option<&str>,
+	pr_head_oid: Option<&str>,
 	review_lifecycle_records: &'a [&'a ReviewLifecycleRecord],
 ) -> Option<&'a ReviewLifecycleRecord> {
+	let pr_head_ref = pr_head_ref?;
+	let pr_head_oid = pr_head_oid?;
 	let raw_source_refs = raw_source_refs
 		.iter()
 		.map(|source_ref| source_ref.trim())
@@ -8889,12 +8922,33 @@ fn operator_autonomy_matching_pr_review<'a>(
 			review.run_id() == event.run_id()
 				&& review.attempt_number() == event.attempt_number()
 				&& raw_source_refs.contains(review.pr_url())
+				&& review.branch_name() == pr_head_ref
+				&& review.pr_head_ref_name() == pr_head_ref
+				&& review.pr_head_oid() == pr_head_oid
+				&& review.head_sha() == pr_head_oid
 		})
 		.max_by(|left, right| {
 			left.updated_at_unix()
 				.cmp(&right.updated_at_unix())
 				.then_with(|| left.branch_name().cmp(right.branch_name()))
 		})
+}
+
+fn operator_autonomy_pr_review_candidate_exists(
+	event: &PrivateExecutionEvent,
+	raw_source_refs: &[String],
+	review_lifecycle_records: &[&ReviewLifecycleRecord],
+) -> bool {
+	let raw_source_refs = raw_source_refs
+		.iter()
+		.map(|source_ref| source_ref.trim())
+		.collect::<BTreeSet<_>>();
+
+	review_lifecycle_records.iter().any(|review| {
+		review.run_id() == event.run_id()
+			&& review.attempt_number() == event.attempt_number()
+			&& raw_source_refs.contains(review.pr_url())
+	})
 }
 
 fn operator_autonomy_replay_evidence_matches(

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -35,6 +35,15 @@ mod autonomy_lineage_readback_tests {
 		generated_issue_identifier: String,
 	}
 
+	struct ReplayEvidenceSeed<'a> {
+		proposal_id: &'a str,
+		decision_contract_id: &'a str,
+		run_id: &'a str,
+		kind: &'a str,
+		source_ref: &'a str,
+		summary: &'a str,
+	}
+
 	#[test]
 	fn operator_status_surfaces_autonomy_lineage_without_raw_payloads() {
 		let (_temp_dir, config, workflow) = super::temp_project_layout();
@@ -47,7 +56,107 @@ mod autonomy_lineage_readback_tests {
 		assert_autonomy_readback(&snapshot, &seeded);
 	}
 
+	#[test]
+	fn autonomy_lineage_does_not_use_unlinked_review_lifecycle_as_pr_evidence() {
+		let (_temp_dir, config, workflow) = super::temp_project_layout();
+		let state_store = StateStore::open_in_memory().expect("state store should open");
+		let issue = super::sample_issue("Todo", &[]);
+		let seeded =
+			seed_autonomy_lineage_without_execution_evidence(&state_store, &config, &workflow, &issue);
+		let (generated_issue_id, generated_issue_identifier) =
+			generated_issue_link(&state_store, &seeded.decision_contract_id);
+		let stale_review_marker = ReviewHandoffMarker::new(
+			"stale-review-run",
+			1,
+			"y/decodex-stale-review",
+			"https://github.com/hack-ink/decodex/pull/stale",
+			"main",
+			"y/decodex-stale-review",
+			"abcdefabcdefabcdefabcdefabcdefabcdefabcd",
+		);
+
+		state_store
+			.upsert_review_handoff_marker(SERVICE_ID, &generated_issue_id, &stale_review_marker)
+			.expect("stale review marker should persist");
+
+		for (kind, source_ref, summary) in [
+			(
+				"validation",
+				"validation:cargo-make-check:passed",
+				"Repo validation gate passed before review handoff.",
+			),
+			(
+				"post_land",
+				"post_land:decodex-land:merge-install-restart-audit",
+				"Post-land evidence was recorded after normal lifecycle authority.",
+			),
+		] {
+			record_replay_evidence_event(
+				&state_store,
+				&generated_issue_id,
+				ReplayEvidenceSeed {
+					proposal_id: &seeded.accepted_proposal_id,
+					decision_contract_id: &seeded.decision_contract_id,
+					run_id: "run-dogfood-review",
+					kind,
+					source_ref,
+					summary,
+				},
+			);
+		}
+
+		let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+			.expect("snapshot should build");
+		let lineage = autonomy_lineage_for_seed(&snapshot, &seeded);
+		let evidence_kinds = lineage
+			.execution_evidence
+			.iter()
+			.map(|evidence| evidence.kind.as_str())
+			.collect::<BTreeSet<_>>();
+
+		assert_eq!(lineage.program_intake[0].intake_kind, "goal_intake");
+		assert_eq!(lineage.completeness, "partial");
+		assert!(
+			lineage
+				.known_gaps
+				.contains(&String::from("pr_evidence_missing"))
+		);
+		assert_eq!(evidence_kinds, BTreeSet::from(["post_land", "validation"]));
+		assert!(
+			lineage
+				.execution_evidence
+				.iter()
+				.all(|evidence| evidence.issue_identifier.as_deref()
+					== Some(generated_issue_identifier.as_str()))
+		);
+		assert!(
+			!lineage
+				.execution_evidence
+				.iter()
+				.any(|evidence| evidence.source_refs.iter().any(|source_ref| source_ref.contains("stale")))
+		);
+	}
+
 	fn seed_autonomy_lineage(
+		state_store: &StateStore,
+		config: &ServiceConfig,
+		workflow: &WorkflowDocument,
+		issue: &TrackerIssue,
+	) -> SeededAutonomyLineage {
+		let seeded =
+			seed_autonomy_lineage_without_execution_evidence(state_store, config, workflow, issue);
+		let generated_issue_identifier = record_dogfood_execution_evidence(
+			state_store,
+			&seeded.accepted_proposal_id,
+			&seeded.decision_contract_id,
+		);
+
+		record_sensitive_autonomy_readback_fixture(state_store, issue);
+
+		SeededAutonomyLineage { generated_issue_identifier, ..seeded }
+	}
+
+	fn seed_autonomy_lineage_without_execution_evidence(
 		state_store: &StateStore,
 		config: &ServiceConfig,
 		workflow: &WorkflowDocument,
@@ -63,13 +172,8 @@ mod autonomy_lineage_readback_tests {
 
 		apply_goal_intake(state_store, config, workflow, issue, &decision_contract_id);
 
-		let generated_issue_identifier = record_dogfood_execution_evidence(
-			state_store,
-			&accepted_proposal_id,
-			&decision_contract_id,
-		);
-
-		record_sensitive_autonomy_readback_fixture(state_store, issue);
+		let (_generated_issue_id, generated_issue_identifier) =
+			generated_issue_link(state_store, &decision_contract_id);
 
 		SeededAutonomyLineage {
 			accepted_proposal_id,
@@ -310,13 +414,8 @@ mod autonomy_lineage_readback_tests {
 		proposal_id: &str,
 		decision_contract_id: &str,
 	) -> String {
-		let linked = state_store
-			.decision_contract(SERVICE_ID, decision_contract_id)
-			.expect("decision contract should read")
-			.expect("decision contract should exist");
-		let generated_issue_id = linked.contract().links().generated_issue_ids()[0].clone();
-		let generated_issue_identifier =
-			linked.contract().links().generated_issue_identifiers()[0].clone();
+		let (generated_issue_id, generated_issue_identifier) =
+			generated_issue_link(state_store, decision_contract_id);
 		let review_marker = ReviewHandoffMarker::new(
 			"run-dogfood-review",
 			1,
@@ -331,7 +430,25 @@ mod autonomy_lineage_readback_tests {
 			.upsert_review_handoff_marker(SERVICE_ID, &generated_issue_id, &review_marker)
 			.expect("review handoff marker should persist");
 
+		record_replay_evidence_event(
+			state_store,
+			&generated_issue_id,
+			ReplayEvidenceSeed {
+				proposal_id,
+				decision_contract_id,
+				run_id: "run-dogfood-review",
+				kind: "validation",
+				source_ref: "validation:cargo-make-check:passed",
+				summary: "Local validation summary referenced GITHUB_PAT_Y before clean replay evidence.",
+			},
+		);
+
 		for (kind, source_ref, summary) in [
+			(
+				"pr",
+				"https://github.com/hack-ink/decodex/pull/1091",
+				"PR-backed review handoff readback recorded.",
+			),
 			(
 				"validation",
 				"validation:cargo-make-check:passed",
@@ -343,26 +460,60 @@ mod autonomy_lineage_readback_tests {
 				"Post-land evidence was recorded after normal lifecycle authority.",
 			),
 		] {
-			state_store
-				.append_private_execution_event(
-					SERVICE_ID,
-					&generated_issue_id,
-					"run-dogfood-review",
-					1,
-					"autonomy/replay_evidence",
-					serde_json::json!({
-						"schema": "decodex.autonomy_replay_evidence/1",
-						"proposal_id": proposal_id,
-						"contract_id": decision_contract_id,
-						"kind": kind,
-						"source_refs": [source_ref],
-						"summary": summary,
-					}),
-				)
-				.expect("replay evidence should persist");
+			record_replay_evidence_event(
+				state_store,
+				&generated_issue_id,
+				ReplayEvidenceSeed {
+					proposal_id,
+					decision_contract_id,
+					run_id: "run-dogfood-review",
+					kind,
+					source_ref,
+					summary,
+				},
+			);
 		}
 
 		generated_issue_identifier
+	}
+
+	fn generated_issue_link(
+		state_store: &StateStore,
+		decision_contract_id: &str,
+	) -> (String, String) {
+		let linked = state_store
+			.decision_contract(SERVICE_ID, decision_contract_id)
+			.expect("decision contract should read")
+			.expect("decision contract should exist");
+
+		(
+			linked.contract().links().generated_issue_ids()[0].clone(),
+			linked.contract().links().generated_issue_identifiers()[0].clone(),
+		)
+	}
+
+	fn record_replay_evidence_event(
+		state_store: &StateStore,
+		generated_issue_id: &str,
+		seed: ReplayEvidenceSeed<'_>,
+	) {
+		state_store
+			.append_private_execution_event(
+				SERVICE_ID,
+				generated_issue_id,
+				seed.run_id,
+				1,
+				"autonomy/replay_evidence",
+				serde_json::json!({
+					"schema": "decodex.autonomy_replay_evidence/1",
+					"proposal_id": seed.proposal_id,
+					"contract_id": seed.decision_contract_id,
+					"kind": seed.kind,
+					"source_refs": [seed.source_ref],
+					"summary": seed.summary,
+				}),
+			)
+			.expect("replay evidence should persist");
 	}
 
 	fn assert_autonomy_readback(
@@ -375,11 +526,7 @@ mod autonomy_lineage_readback_tests {
 			.autonomy_objective
 			.as_ref()
 			.expect("objective readback should render");
-		let lineage = loop_status
-			.autonomy_lineage
-			.iter()
-			.find(|lineage| lineage.proposal_id.as_deref() == Some(&seeded.accepted_proposal_id))
-			.expect("accepted proposal lineage should render");
+		let lineage = autonomy_lineage_for_seed(snapshot, seeded);
 		let clean_signal = loop_status
 			.autonomy_signals
 			.iter()
@@ -445,6 +592,20 @@ mod autonomy_lineage_readback_tests {
 		assert!(!snapshot_json.contains("GITHUB_PAT_Y"));
 		assert!(!rendered.contains("/Users/x"));
 		assert!(!rendered.contains("GITHUB_PAT_Y"));
+	}
+
+	fn autonomy_lineage_for_seed<'a>(
+		snapshot: &'a OperatorStatusSnapshot,
+		seeded: &SeededAutonomyLineage,
+	) -> &'a OperatorAutonomyLineageStatus {
+		let run = snapshot.current_lanes.first().expect("current lane should exist");
+		let loop_status = run.loop_status.as_ref().expect("loop status should render");
+
+		loop_status
+			.autonomy_lineage
+			.iter()
+			.find(|lineage| lineage.proposal_id.as_deref() == Some(&seeded.accepted_proposal_id))
+			.expect("accepted proposal lineage should render")
 	}
 
 	fn assert_dogfood_execution_evidence(

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -42,6 +42,8 @@ mod autonomy_lineage_readback_tests {
 		kind: &'a str,
 		source_ref: &'a str,
 		summary: &'a str,
+		pr_head_ref: Option<&'a str>,
+		pr_head_oid: Option<&'a str>,
 	}
 
 	#[test]
@@ -101,6 +103,8 @@ mod autonomy_lineage_readback_tests {
 					kind,
 					source_ref,
 					summary,
+					pr_head_ref: None,
+					pr_head_oid: None,
 				},
 			);
 		}
@@ -134,6 +138,69 @@ mod autonomy_lineage_readback_tests {
 				.execution_evidence
 				.iter()
 				.any(|evidence| evidence.source_refs.iter().any(|source_ref| source_ref.contains("stale")))
+		);
+	}
+
+	#[test]
+	fn autonomy_lineage_marks_same_pr_stale_head_lifecycle_as_partial() {
+		let (_temp_dir, config, workflow) = super::temp_project_layout();
+		let state_store = StateStore::open_in_memory().expect("state store should open");
+		let issue = super::sample_issue("Todo", &[]);
+		let seeded =
+			seed_autonomy_lineage_without_execution_evidence(&state_store, &config, &workflow, &issue);
+		let (generated_issue_id, _generated_issue_identifier) =
+			generated_issue_link(&state_store, &seeded.decision_contract_id);
+		let stale_head_oid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+		let fresh_head_oid = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+		let stale_review_marker = ReviewHandoffMarker::new(
+			"run-dogfood-review",
+			1,
+			"y/decodex-xy-1091",
+			"https://github.com/hack-ink/decodex/pull/1091",
+			"main",
+			"y/decodex-xy-1091",
+			stale_head_oid,
+		);
+
+		state_store
+			.upsert_review_handoff_marker(SERVICE_ID, &generated_issue_id, &stale_review_marker)
+			.expect("stale review marker should persist");
+
+		record_replay_evidence_event(
+			&state_store,
+			&generated_issue_id,
+			ReplayEvidenceSeed {
+				proposal_id: &seeded.accepted_proposal_id,
+				decision_contract_id: &seeded.decision_contract_id,
+				run_id: "run-dogfood-review",
+				kind: "pr",
+				source_ref: "https://github.com/hack-ink/decodex/pull/1091",
+				summary: "PR-backed review handoff readback recorded.",
+				pr_head_ref: Some("y/decodex-xy-1091"),
+				pr_head_oid: Some(fresh_head_oid),
+			},
+		);
+
+		let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+			.expect("snapshot should build");
+		let lineage = autonomy_lineage_for_seed(&snapshot, &seeded);
+		let pr_evidence = lineage
+			.execution_evidence
+			.iter()
+			.find(|evidence| evidence.kind == "pr")
+			.expect("partial PR replay evidence should render");
+
+		assert_eq!(lineage.completeness, "partial");
+		assert_eq!(pr_evidence.completeness, "partial");
+		assert!(
+			pr_evidence
+				.known_gaps
+				.contains(&String::from("review_lifecycle_stale_or_mismatched"))
+		);
+		assert!(
+			lineage
+				.known_gaps
+				.contains(&String::from("review_lifecycle_stale_or_mismatched"))
 		);
 	}
 
@@ -440,6 +507,8 @@ mod autonomy_lineage_readback_tests {
 				kind: "validation",
 				source_ref: "validation:cargo-make-check:passed",
 				summary: "Local validation summary referenced GITHUB_PAT_Y before clean replay evidence.",
+				pr_head_ref: None,
+				pr_head_oid: None,
 			},
 		);
 
@@ -470,6 +539,9 @@ mod autonomy_lineage_readback_tests {
 					kind,
 					source_ref,
 					summary,
+					pr_head_ref: (kind == "pr").then_some("y/decodex-xy-1091"),
+					pr_head_oid: (kind == "pr")
+						.then_some("0123456789abcdef0123456789abcdef01234567"),
 				},
 			);
 		}
@@ -511,6 +583,8 @@ mod autonomy_lineage_readback_tests {
 					"kind": seed.kind,
 					"source_refs": [seed.source_ref],
 					"summary": seed.summary,
+					"pr_head_ref": seed.pr_head_ref,
+					"pr_head_oid": seed.pr_head_oid,
 				}),
 			)
 			.expect("replay evidence should persist");

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,9 @@
 
 ## 2026-06-23
 
+- Tightened Phase 8 replay evidence after dogfood review: PR evidence now requires
+  a proposal/Decision Contract replay pointer corroborated by retained review
+  lifecycle readback, and duplicate replay refs prefer complete fresh metadata.
 - Added Phase 8 self-dogfood production-gate readback: autonomy lineage now projects
   public-safe PR handoff, validation, and post-land replay evidence from retained
   review lifecycle rows and scoped private evidence pointers without granting

--- a/docs/log.md
+++ b/docs/log.md
@@ -4,7 +4,8 @@
 
 - Tightened Phase 8 replay evidence after dogfood review: PR evidence now requires
   a proposal/Decision Contract replay pointer corroborated by retained review
-  lifecycle readback, and duplicate replay refs prefer complete fresh metadata.
+  lifecycle readback with matching PR head identity, and duplicate replay refs prefer
+  complete fresh metadata.
 - Added Phase 8 self-dogfood production-gate readback: autonomy lineage now projects
   public-safe PR handoff, validation, and post-land replay evidence from retained
   review lifecycle rows and scoped private evidence pointers without granting

--- a/docs/runbook/autonomy-implementation-roadmap.md
+++ b/docs/runbook/autonomy-implementation-roadmap.md
@@ -406,8 +406,8 @@ Production readiness requires:
   lifecycle authority.
 - PR handoff replay evidence must be corroborated by retained review lifecycle
   readback and a matching replay-evidence pointer for the same proposal or Decision
-  Contract. A stale PR row for the same generated issue must not satisfy the replay
-  chain.
+  Contract, run, attempt, PR URL, PR head ref, and PR head oid. A stale PR row for
+  the same generated issue or same PR URL must not satisfy the replay chain.
 
 Recommended full gate before broad enablement:
 
@@ -428,7 +428,7 @@ Stop conditions:
 - Replay evidence is only a report artifact or raw private payload rather than a
   public-safe operator/MCP readback projection tied back to generated issue links.
 - PR replay evidence is inferred from issue-level lifecycle rows without a matching
-  proposal or Decision Contract pointer.
+  proposal or Decision Contract pointer and matching PR head identity.
 
 ## Branch Strategy
 

--- a/docs/runbook/autonomy-implementation-roadmap.md
+++ b/docs/runbook/autonomy-implementation-roadmap.md
@@ -404,6 +404,10 @@ Production readiness requires:
   execution, records PR handoff, validation, and post-land evidence under the same
   replay chain, and only lands, installs, restarts, or syncs plugins through normal
   lifecycle authority.
+- PR handoff replay evidence must be corroborated by retained review lifecycle
+  readback and a matching replay-evidence pointer for the same proposal or Decision
+  Contract. A stale PR row for the same generated issue must not satisfy the replay
+  chain.
 
 Recommended full gate before broad enablement:
 
@@ -423,6 +427,8 @@ Stop conditions:
   Decision Contract, Program Intake, PR, validation, and post-land evidence.
 - Replay evidence is only a report artifact or raw private payload rather than a
   public-safe operator/MCP readback projection tied back to generated issue links.
+- PR replay evidence is inferred from issue-level lifecycle rows without a matching
+  proposal or Decision Contract pointer.
 
 ## Branch Strategy
 

--- a/docs/spec/autonomy-control-plane.md
+++ b/docs/spec/autonomy-control-plane.md
@@ -402,8 +402,9 @@ reasons, proposal -> Decision Contract -> Program Intake lineage, and replay evi
 from PR handoff, validation, and post-land or post-restart proof when the autonomy
 work has reached those lifecycle surfaces. PR replay evidence is derived from retained
 review lifecycle readback only when a matching private replay-evidence pointer ties
-the retained PR row back to the same proposal or Decision Contract. Validation and
-post-land replay evidence may be projected from private runtime events with schema
+the retained PR row back to the same proposal or Decision Contract, run, attempt, PR
+URL, PR head ref, and PR head oid. Validation and post-land replay evidence may be
+projected from private runtime events with schema
 `decodex.autonomy_replay_evidence/1`; `post_land` is the post-lifecycle umbrella for
 post-land, post-restart, installation, and plugin-sync proof. Those events are
 evidence pointers only and do not authorize review, landing, installation, restart,

--- a/docs/spec/autonomy-control-plane.md
+++ b/docs/spec/autonomy-control-plane.md
@@ -401,12 +401,15 @@ freshness, redaction level, completeness, and known gaps, proposal state and ref
 reasons, proposal -> Decision Contract -> Program Intake lineage, and replay evidence
 from PR handoff, validation, and post-land or post-restart proof when the autonomy
 work has reached those lifecycle surfaces. PR replay evidence is derived from retained
-review lifecycle readback. Validation and post-land replay evidence may be projected
-from private runtime events with schema `decodex.autonomy_replay_evidence/1`; those
-events are evidence pointers only and do not authorize review, landing, installation,
-restart, plugin sync, or closeout. The projection must not include raw evidence
-payloads, hidden reasoning, local-only paths, credentials, unredacted private source
-refs, or generated issue graph mechanics.
+review lifecycle readback only when a matching private replay-evidence pointer ties
+the retained PR row back to the same proposal or Decision Contract. Validation and
+post-land replay evidence may be projected from private runtime events with schema
+`decodex.autonomy_replay_evidence/1`; `post_land` is the post-lifecycle umbrella for
+post-land, post-restart, installation, and plugin-sync proof. Those events are
+evidence pointers only and do not authorize review, landing, installation, restart,
+plugin sync, or closeout. The projection must not include raw evidence payloads,
+hidden reasoning, local-only paths, credentials, unredacted private source refs, or
+generated issue graph mechanics.
 
 ## MCP And Skill Action Matrix
 


### PR DESCRIPTION
## Summary
- bind PR replay evidence to a matching autonomy replay pointer plus retained review lifecycle row for the same run, attempt, PR URL, PR head ref, and PR head oid
- keep stale issue-level or stale same-PR review lifecycle rows from satisfying the P8 replay chain
- make duplicate evidence refs prefer complete and fresh metadata, and document the Phase 8 requirement

## Validation
- `cargo test -p decodex autonomy_lineage --lib` (4 passed)
- `cargo make fmt-check`
- `cargo make lint-vstyle-rust`
- `cargo make check` (1441 passed, 1 skipped)

## Review feedback handled
- Kant found that same-run/same-attempt/same-PR lifecycle rows could still be stale across PR head updates. The branch now requires PR head ref and oid identity, and has a stale same-PR head regression test.

## Context
Repairs `XY-1091` after PR #505 landed before the external validation blocker could be applied. `XY-1103` tracks the separate server orchestration fix for the missing pre-land external validation gate.