### PR TITLE
XY-1091: [Autonomy P8] Self-dogfood objective autonomy and production gate

### DIFF
--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -8682,35 +8682,23 @@ fn operator_autonomy_execution_evidence_statuses(
 	let mut evidence = Vec::new();
 
 	for (issue_id, issue_identifier) in operator_autonomy_generated_issue_pairs(contracts) {
-		for review in loop_evidence.review_lifecycle_records_for_issue(&issue_id) {
-			evidence.push(operator_autonomy_pr_evidence_status(
-				review,
-				issue_identifier.as_deref(),
-			));
-		}
+		let review_records = loop_evidence.review_lifecycle_records_for_issue(&issue_id);
+
 		for event in loop_evidence.private_events_for_issue(&issue_id) {
 			if let Some(status) = operator_autonomy_replay_evidence_status_from_event(
 				event,
 				proposal_id,
 				&contract_ids,
 				issue_identifier.as_deref(),
+				&review_records,
 			) {
 				evidence.push(status);
 			}
 		}
 	}
 
-	evidence.sort_by(|left, right| {
-		left.kind
-			.cmp(&right.kind)
-			.then_with(|| left.issue_identifier.cmp(&right.issue_identifier))
-			.then_with(|| left.source_refs.cmp(&right.source_refs))
-	});
-	evidence.dedup_by(|left, right| {
-		left.kind == right.kind
-			&& left.issue_identifier == right.issue_identifier
-			&& left.source_refs == right.source_refs
-	});
+	evidence.sort_by(operator_autonomy_execution_evidence_order);
+	evidence.dedup_by(operator_autonomy_execution_evidence_key_matches);
 
 	evidence
 }
@@ -8743,26 +8731,72 @@ fn operator_autonomy_generated_issue_pairs(
 	pairs
 }
 
-fn operator_autonomy_pr_evidence_status(
-	review: &ReviewLifecycleRecord,
+fn operator_autonomy_pr_evidence_status_from_event(
+	event: &PrivateExecutionEvent,
+	payload: &Value,
 	issue_identifier: Option<&str>,
+	review_records: &[&ReviewLifecycleRecord],
 ) -> OperatorAutonomyExecutionEvidenceStatus {
-	let (source_refs, refs_redacted) = public_autonomy_refs(&[review.pr_url().to_owned()]);
+	let (event_source_refs, event_refs_redacted) =
+		operator_autonomy_replay_evidence_source_refs(payload);
+	let matching_reviews = review_records
+		.iter()
+		.copied()
+		.filter(|review| {
+			review.run_id() == event.run_id() && review.attempt_number() == event.attempt_number()
+		})
+		.collect::<Vec<_>>();
+	let matching_review = matching_reviews
+		.iter()
+		.copied()
+		.find(|review| event_source_refs.iter().any(|source_ref| source_ref == review.pr_url()))
+		.or_else(|| matching_reviews.first().copied());
+	let (summary, summary_redacted) = operator_autonomy_replay_evidence_summary(
+		payload,
+		"PR-backed review handoff replay evidence recorded.",
+	);
 	let mut known_gaps = Vec::new();
+	let (source_refs, review_updated_at) = match matching_review {
+		Some(review) => {
+			if !event_source_refs.iter().any(|source_ref| source_ref == review.pr_url()) {
+				known_gaps.push(String::from("review_lifecycle_pr_url_mismatch"));
+			}
+
+			let (review_refs, review_refs_redacted) =
+				public_autonomy_refs(&[review.pr_url().to_owned()]);
+
+			if review_refs_redacted {
+				known_gaps.push(String::from("source_refs_redacted"));
+			}
+
+			(review_refs, Some(review))
+		}
+
+		None => {
+			known_gaps.push(String::from("review_lifecycle_record_missing"));
+
+			(event_source_refs, None)
+		}
+	};
 
 	if source_refs.is_empty() {
 		known_gaps.push(String::from("source_refs_missing_or_redacted"));
 	}
-	if refs_redacted {
-		known_gaps.push(String::from("source_refs_redacted"));
+	if event_refs_redacted {
+		known_gaps.push(String::from("replay_source_refs_redacted"));
+	}
+	if summary_redacted {
+		known_gaps.push(String::from("summary_redacted"));
 	}
 
+	known_gaps.sort();
+	known_gaps.dedup();
 	OperatorAutonomyExecutionEvidenceStatus {
 		kind: String::from("pr"),
 		issue_identifier: issue_identifier.map(str::to_owned),
 		source_refs,
-		summary: String::from("PR-backed review handoff readback recorded."),
-		updated_at: review.updated_at().to_owned(),
+		summary,
+		updated_at: operator_autonomy_latest_replay_updated_at(event, review_updated_at),
 		completeness: operator_autonomy_completeness(&known_gaps),
 		known_gaps,
 	}
@@ -8773,6 +8807,7 @@ fn operator_autonomy_replay_evidence_status_from_event(
 	proposal_id: &str,
 	contract_ids: &BTreeSet<&str>,
 	issue_identifier: Option<&str>,
+	review_records: &[&ReviewLifecycleRecord],
 ) -> Option<OperatorAutonomyExecutionEvidenceStatus> {
 	let payload = event.payload();
 
@@ -8784,24 +8819,22 @@ fn operator_autonomy_replay_evidence_status_from_event(
 	}
 
 	let kind = match payload.get("kind").and_then(Value::as_str) {
-		Some(kind @ ("validation" | "post_land")) => kind.to_owned(),
+		Some(kind @ ("pr" | "validation" | "post_land")) => kind,
 		_ => return None,
 	};
-	let raw_source_refs = payload
-		.get("source_refs")
-		.and_then(Value::as_array)
-		.into_iter()
-		.flatten()
-		.filter_map(Value::as_str)
-		.map(str::to_owned)
-		.collect::<Vec<_>>();
-	let (source_refs, refs_redacted) = public_autonomy_refs(&raw_source_refs);
-	let (summary, summary_redacted) = public_status_value(
-		payload
-			.get("summary")
-			.and_then(Value::as_str)
-			.unwrap_or("Dogfood replay evidence recorded."),
-	);
+
+	if kind == "pr" {
+		return Some(operator_autonomy_pr_evidence_status_from_event(
+			event,
+			payload,
+			issue_identifier,
+			review_records,
+		));
+	}
+
+	let (source_refs, refs_redacted) = operator_autonomy_replay_evidence_source_refs(payload);
+	let (summary, summary_redacted) =
+		operator_autonomy_replay_evidence_summary(payload, "Dogfood replay evidence recorded.");
 	let mut known_gaps = Vec::new();
 
 	if source_refs.is_empty() {
@@ -8815,7 +8848,7 @@ fn operator_autonomy_replay_evidence_status_from_event(
 	}
 
 	Some(OperatorAutonomyExecutionEvidenceStatus {
-		kind,
+		kind: kind.to_owned(),
 		issue_identifier: issue_identifier.map(str::to_owned),
 		source_refs,
 		summary,
@@ -8823,6 +8856,68 @@ fn operator_autonomy_replay_evidence_status_from_event(
 		completeness: operator_autonomy_completeness(&known_gaps),
 		known_gaps,
 	})
+}
+
+fn operator_autonomy_execution_evidence_order(
+	left: &OperatorAutonomyExecutionEvidenceStatus,
+	right: &OperatorAutonomyExecutionEvidenceStatus,
+) -> Ordering {
+	left.kind
+		.cmp(&right.kind)
+		.then_with(|| left.issue_identifier.cmp(&right.issue_identifier))
+		.then_with(|| left.source_refs.cmp(&right.source_refs))
+		.then_with(|| {
+			operator_autonomy_execution_evidence_completeness_rank(left)
+				.cmp(&operator_autonomy_execution_evidence_completeness_rank(right))
+		})
+		.then_with(|| left.known_gaps.len().cmp(&right.known_gaps.len()))
+		.then_with(|| right.updated_at.cmp(&left.updated_at))
+		.then_with(|| left.summary.cmp(&right.summary))
+		.then_with(|| left.known_gaps.cmp(&right.known_gaps))
+}
+
+fn operator_autonomy_execution_evidence_key_matches(
+	left: &mut OperatorAutonomyExecutionEvidenceStatus,
+	right: &mut OperatorAutonomyExecutionEvidenceStatus,
+) -> bool {
+	left.kind == right.kind
+		&& left.issue_identifier == right.issue_identifier
+		&& left.source_refs == right.source_refs
+}
+
+fn operator_autonomy_execution_evidence_completeness_rank(
+	status: &OperatorAutonomyExecutionEvidenceStatus,
+) -> u8 {
+	if status.completeness == "complete" { 0 } else { 1 }
+}
+
+fn operator_autonomy_replay_evidence_source_refs(payload: &Value) -> (Vec<String>, bool) {
+	let raw_source_refs = payload
+		.get("source_refs")
+		.and_then(Value::as_array)
+		.into_iter()
+		.flatten()
+		.filter_map(Value::as_str)
+		.map(str::to_owned)
+		.collect::<Vec<_>>();
+
+	public_autonomy_refs(&raw_source_refs)
+}
+
+fn operator_autonomy_replay_evidence_summary(
+	payload: &Value,
+	fallback: &str,
+) -> (String, bool) {
+	public_status_value(payload.get("summary").and_then(Value::as_str).unwrap_or(fallback))
+}
+
+fn operator_autonomy_latest_replay_updated_at(
+	event: &PrivateExecutionEvent,
+	review: Option<&ReviewLifecycleRecord>,
+) -> String {
+	review
+		.filter(|record| record.updated_at_unix() >= event.recorded_at_unix())
+		.map_or_else(|| event.recorded_at().to_owned(), |record| record.updated_at().to_owned())
 }
 
 fn operator_autonomy_replay_evidence_matches(

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -35,6 +35,13 @@ mod autonomy_lineage_readback_tests {
 		generated_issue_identifier: String,
 	}
 
+	#[derive(Clone, Copy)]
+	struct DogfoodReplayEvidence<'a> {
+		kind: &'a str,
+		source_ref: &'a str,
+		summary: &'a str,
+	}
+
 	#[test]
 	fn operator_status_surfaces_autonomy_lineage_without_raw_payloads() {
 		let (_temp_dir, config, workflow) = super::temp_project_layout();
@@ -45,6 +52,75 @@ mod autonomy_lineage_readback_tests {
 			.expect("snapshot should build");
 
 		assert_autonomy_readback(&snapshot, &seeded);
+	}
+
+	#[test]
+	fn operator_status_does_not_count_stale_review_pr_as_autonomy_replay_evidence() {
+		let (_temp_dir, config, workflow) = super::temp_project_layout();
+		let state_store = StateStore::open_in_memory().expect("state store should open");
+		let issue = super::sample_issue("Todo", &[]);
+
+		seed_autonomy_run(&state_store, &issue);
+		accept_autonomy_objective(&state_store);
+
+		let signal_id = record_autonomy_signal(&state_store, &issue);
+		let accepted_proposal_id = record_autonomy_proposals(&state_store, &issue, &signal_id);
+		let decision_contract_id = promote_autonomy_proposal(&state_store, &accepted_proposal_id);
+
+		apply_goal_intake(&state_store, &config, &workflow, &issue, &decision_contract_id);
+
+		let (generated_issue_id, generated_issue_identifier) =
+			generated_issue_link_for_contract(&state_store, &decision_contract_id);
+		let stale_review_marker = ReviewHandoffMarker::new(
+			"run-stale-review",
+			1,
+			"y/decodex-stale-review",
+			"https://github.com/hack-ink/decodex/pull/1090",
+			"main",
+			"y/decodex-stale-review",
+			"abcdefabcdefabcdefabcdefabcdefabcdefabcd",
+		);
+
+		state_store
+			.upsert_review_handoff_marker(SERVICE_ID, &generated_issue_id, &stale_review_marker)
+			.expect("stale review marker should persist");
+
+		for evidence in dogfood_tail_replay_evidence() {
+			append_dogfood_replay_evidence_event(
+				&state_store,
+				&generated_issue_id,
+				"run-dogfood-validation",
+				&accepted_proposal_id,
+				&decision_contract_id,
+				evidence,
+			);
+		}
+
+		let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+			.expect("snapshot should build");
+		let run = snapshot.current_lanes.first().expect("current lane should exist");
+		let lineage = run
+			.loop_status
+			.as_ref()
+			.expect("loop status should render")
+			.autonomy_lineage
+			.iter()
+			.find(|lineage| lineage.proposal_id.as_deref() == Some(&accepted_proposal_id))
+			.expect("accepted proposal lineage should render");
+		let source_refs = lineage
+			.execution_evidence
+			.iter()
+			.flat_map(|evidence| evidence.source_refs.iter().map(String::as_str))
+			.collect::<BTreeSet<_>>();
+
+		assert_eq!(
+			lineage.decision_contracts[0].generated_issue_identifiers,
+			vec![generated_issue_identifier]
+		);
+		assert_eq!(lineage.completeness, "partial");
+		assert!(lineage.known_gaps.contains(&String::from("pr_evidence_missing")));
+		assert!(!lineage.execution_evidence.iter().any(|evidence| evidence.kind == "pr"));
+		assert!(!source_refs.contains("https://github.com/hack-ink/decodex/pull/1090"));
 	}
 
 	fn seed_autonomy_lineage(
@@ -331,38 +407,100 @@ mod autonomy_lineage_readback_tests {
 			.upsert_review_handoff_marker(SERVICE_ID, &generated_issue_id, &review_marker)
 			.expect("review handoff marker should persist");
 
-		for (kind, source_ref, summary) in [
-			(
-				"validation",
-				"validation:cargo-make-check:passed",
-				"Repo validation gate passed before review handoff.",
-			),
-			(
-				"post_land",
-				"post_land:decodex-land:merge-install-restart-audit",
-				"Post-land evidence was recorded after normal lifecycle authority.",
-			),
-		] {
-			state_store
-				.append_private_execution_event(
-					SERVICE_ID,
-					&generated_issue_id,
-					"run-dogfood-review",
-					1,
-					"autonomy/replay_evidence",
-					serde_json::json!({
-						"schema": "decodex.autonomy_replay_evidence/1",
-						"proposal_id": proposal_id,
-						"contract_id": decision_contract_id,
-						"kind": kind,
-						"source_refs": [source_ref],
-						"summary": summary,
-					}),
-				)
-				.expect("replay evidence should persist");
+		append_dogfood_replay_evidence_event(
+			state_store,
+			&generated_issue_id,
+			"run-dogfood-review",
+			proposal_id,
+			decision_contract_id,
+			DogfoodReplayEvidence {
+				kind: "validation",
+				source_ref: "validation:cargo-make-check:passed",
+				summary: "Local validation payload mentions /Users/x/private-validation.json.",
+			},
+		);
+		append_dogfood_replay_evidence_event(
+			state_store,
+			&generated_issue_id,
+			"run-dogfood-review",
+			proposal_id,
+			decision_contract_id,
+			DogfoodReplayEvidence {
+				kind: "pr",
+				source_ref: "https://github.com/hack-ink/decodex/pull/1091",
+				summary: "PR-backed review handoff was recorded for the accepted proposal.",
+			},
+		);
+
+		for evidence in dogfood_tail_replay_evidence() {
+			append_dogfood_replay_evidence_event(
+				state_store,
+				&generated_issue_id,
+				"run-dogfood-review",
+				proposal_id,
+				decision_contract_id,
+				evidence,
+			);
 		}
 
 		generated_issue_identifier
+	}
+
+	fn generated_issue_link_for_contract(
+		state_store: &StateStore,
+		decision_contract_id: &str,
+	) -> (String, String) {
+		let linked = state_store
+			.decision_contract(SERVICE_ID, decision_contract_id)
+			.expect("decision contract should read")
+			.expect("decision contract should exist");
+
+		(
+			linked.contract().links().generated_issue_ids()[0].clone(),
+			linked.contract().links().generated_issue_identifiers()[0].clone(),
+		)
+	}
+
+	fn dogfood_tail_replay_evidence() -> [DogfoodReplayEvidence<'static>; 2] {
+		[
+			DogfoodReplayEvidence {
+				kind: "validation",
+				source_ref: "validation:cargo-make-check:passed",
+				summary: "Repo validation gate passed before review handoff.",
+			},
+			DogfoodReplayEvidence {
+				kind: "post_land",
+				source_ref: "post_land:decodex-land:merge-install-restart-audit",
+				summary: "Post-land lifecycle-tail evidence was recorded after normal authority.",
+			},
+		]
+	}
+
+	fn append_dogfood_replay_evidence_event(
+		state_store: &StateStore,
+		generated_issue_id: &str,
+		run_id: &str,
+		proposal_id: &str,
+		decision_contract_id: &str,
+		evidence: DogfoodReplayEvidence<'_>,
+	) {
+		state_store
+			.append_private_execution_event(
+				SERVICE_ID,
+				generated_issue_id,
+				run_id,
+				1,
+				"autonomy/replay_evidence",
+				serde_json::json!({
+					"schema": "decodex.autonomy_replay_evidence/1",
+					"proposal_id": proposal_id,
+					"contract_id": decision_contract_id,
+					"kind": evidence.kind,
+					"source_refs": [evidence.source_ref],
+					"summary": evidence.summary,
+				}),
+			)
+			.expect("replay evidence should persist");
 	}
 
 	fn assert_autonomy_readback(

--- a/docs/log.md
+++ b/docs/log.md
@@ -3,9 +3,11 @@
 ## 2026-06-23
 
 - Added Phase 8 self-dogfood production-gate readback: autonomy lineage now projects
-  public-safe PR handoff, validation, and post-land replay evidence from retained
-  review lifecycle rows and scoped private evidence pointers without granting
-  landing, install, restart, plugin sync, or closeout authority.
+  public-safe PR handoff, validation, and post-land replay evidence from scoped
+  private evidence pointers. PR evidence now also requires a matching retained review
+  lifecycle row for the same generated issue, run, attempt, and PR ref, while
+  `post_land` denotes lifecycle-tail proof after normal landing, install, restart, or
+  plugin-sync authority without granting those actions.
 - Added the Phase 7 autonomy MCP and external-agent surface to the autonomy spec,
   MCP capability-gateway decision, and Decodex router skill: observe resources expose
   objective, signal, proposal, and evidence summaries, while plan tools can draft

--- a/docs/runbook/autonomy-implementation-roadmap.md
+++ b/docs/runbook/autonomy-implementation-roadmap.md
@@ -404,6 +404,13 @@ Production readiness requires:
   execution, records PR handoff, validation, and post-land evidence under the same
   replay chain, and only lands, installs, restarts, or syncs plugins through normal
   lifecycle authority.
+- PR replay evidence is complete only when a chain-scoped private replay evidence
+  event for the proposal or Decision Contract matches the retained review lifecycle
+  row for the generated issue, run id, attempt number, and PR source ref. Stale PR
+  rows on the same generated issue remain incomplete with explicit known gaps.
+- `post_land` evidence means lifecycle-tail proof after normal landing authority,
+  including post-merge, install, restart, or plugin-sync readback when those steps are
+  part of the accepted work.
 
 Recommended full gate before broad enablement:
 
@@ -423,6 +430,8 @@ Stop conditions:
   Decision Contract, Program Intake, PR, validation, and post-land evidence.
 - Replay evidence is only a report artifact or raw private payload rather than a
   public-safe operator/MCP readback projection tied back to generated issue links.
+- A stale or unrelated PR/review lifecycle row on the same generated issue can satisfy
+  PR evidence for a different autonomy proposal or Decision Contract.
 
 ## Branch Strategy
 

--- a/docs/spec/autonomy-control-plane.md
+++ b/docs/spec/autonomy-control-plane.md
@@ -400,13 +400,21 @@ current accepted Objective Contract version, recent signal summaries with source
 freshness, redaction level, completeness, and known gaps, proposal state and refusal
 reasons, proposal -> Decision Contract -> Program Intake lineage, and replay evidence
 from PR handoff, validation, and post-land or post-restart proof when the autonomy
-work has reached those lifecycle surfaces. PR replay evidence is derived from retained
-review lifecycle readback. Validation and post-land replay evidence may be projected
-from private runtime events with schema `decodex.autonomy_replay_evidence/1`; those
-events are evidence pointers only and do not authorize review, landing, installation,
-restart, plugin sync, or closeout. The projection must not include raw evidence
-payloads, hidden reasoning, local-only paths, credentials, unredacted private source
-refs, or generated issue graph mechanics.
+work has reached those lifecycle surfaces. Each replay evidence row must be tied to
+the same replay chain by matching the proposal id or Decision Contract id. PR replay
+evidence additionally requires a chain-scoped private runtime event with schema
+`decodex.autonomy_replay_evidence/1`, kind `pr`, and a matching retained review
+lifecycle row for the same generated issue, run id, attempt number, and PR source
+ref. Stale or unrelated retained review lifecycle rows for the generated issue must
+remain incomplete and surface an explicit known gap instead of satisfying PR evidence.
+Validation and `post_land` replay evidence may also be projected from chain-scoped
+private runtime events with schema `decodex.autonomy_replay_evidence/1`.
+`post_land` is the lifecycle-tail evidence bucket for post-merge, install, restart,
+and plugin-sync proof only after those actions happen through normal lifecycle
+authority. Replay events are evidence pointers only and do not authorize review,
+landing, installation, restart, plugin sync, or closeout. The projection must not
+include raw evidence payloads, hidden reasoning, local-only paths, credentials,
+unredacted private source refs, or generated issue graph mechanics.
 
 ## MCP And Skill Action Matrix
 


### PR DESCRIPTION
## Summary
- Scope autonomy PR replay evidence to the same proposal/Decision Contract replay chain instead of accepting any retained review lifecycle row for the generated issue.
- Add regression coverage so stale or unrelated PR rows on the same generated issue keep PR evidence incomplete with explicit gaps.
- Update dedup ordering and autonomy docs/runbook/log vocabulary for freshness/completeness and `post_land` lifecycle-tail proof.

## Validation
- `cargo make fmt-check`
- `cargo make check-docs`
- `cargo test -p decodex --lib`
- `cargo make check`

## Review
- Independent fresh-context read-only review for committed HEAD `6d33853ac82d1738d680c5d80c0f77038500dc45`: clean, no accepted current blockers.
