### PR TITLE
Enforce authority boundary before admin merge

### DIFF
--- a/apps/decodex/src/orchestrator/run_cycle.rs
+++ b/apps/decodex/src/orchestrator/run_cycle.rs
@@ -962,6 +962,25 @@ fn start_retained_admin_merge<T>(
 where
 	T: IssueTracker,
 {
+	if let Some(reason) = authority_boundary_landing_requirement(
+		&lane.snapshot,
+		Some(PostReviewRuntimeState {
+			state_store: runtime.state_store,
+			project_id: runtime.project.service_id(),
+			review_level: runtime.project.codex().review_level(),
+		}),
+	)? {
+		tracing::info!(
+			project_id = runtime.project.service_id(),
+			issue_id = lane.snapshot.issue.id,
+			issue = lane.snapshot.issue.identifier,
+			reason,
+			"Retained admin merge is waiting for authority-boundary landing clearance."
+		);
+
+		return Ok(());
+	}
+
 	if !lane.review_state.merge_commit_allowed {
 		return apply_passive_retained_manual_attention(
 			passive_attention_runtime(runtime),

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -5595,7 +5595,11 @@ fn apply_authority_boundary_landing_policy(
 		return Ok(());
 	};
 
-	classification.decision = PostReviewLaneDecision::NeedsReviewRepair;
+	classification.decision = if reason == "authority_boundary_requires_human_decision" {
+		PostReviewLaneDecision::Block
+	} else {
+		PostReviewLaneDecision::NeedsReviewRepair
+	};
 	classification.reason = reason.to_owned();
 
 	Ok(())
@@ -5612,6 +5616,20 @@ fn authority_boundary_landing_requirement(
 		runtime_state.project_id,
 		&snapshot.issue.id,
 	)?;
+
+	if events
+		.iter()
+		.any(|event| event.event_type() == AUTHORITY_DECISION_REQUEST_EVENT_TYPE)
+	{
+		return Ok(Some("authority_boundary_requires_human_decision"));
+	}
+	if events.iter().rev().any(|event| {
+		event.event_type() == AUTHORITY_BOUNDARY_CHECK_EVENT_TYPE
+			&& authority_boundary_event_requires_human_decision(event.payload())
+	}) {
+		return Ok(Some("authority_boundary_requires_human_decision"));
+	}
+
 	let latest_clean_review_record_id = events
 		.iter()
 		.rev()
@@ -5687,6 +5705,28 @@ fn authority_boundary_event_landing_requirement(payload: &Value) -> Option<&'sta
 	}
 
 	None
+}
+
+fn authority_boundary_event_requires_human_decision(payload: &Value) -> bool {
+	authority_boundary_event_policy_decision(payload)
+		.is_some_and(|policy_decision| policy_decision == "requires_human_decision")
+		|| payload
+			.get("policy")
+			.and_then(|policy| policy.get("requires_human_decision"))
+			.and_then(Value::as_bool)
+			.unwrap_or(false)
+		|| matches!(
+			payload
+				.get("disposition")
+				.and_then(Value::as_str)
+				.or_else(|| {
+					payload
+						.get("final_disposition")
+						.and_then(|final_disposition| final_disposition.get("disposition"))
+						.and_then(Value::as_str)
+				}),
+			Some("requires_human" | "insufficient_evidence")
+		)
 }
 
 fn authority_boundary_event_policy_decision(payload: &Value) -> Option<&str> {

--- a/apps/decodex/src/orchestrator/tests/review_landing/classification_review.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing/classification_review.rs
@@ -785,6 +785,116 @@ fn classify_post_review_lane_requires_enhanced_evidence_for_authority_boundary()
 	assert_eq!(classification.reason, "external_review_passed_strict");
 }
 
+#[test]
+fn classify_post_review_lane_blocks_for_human_decision_authority_boundary() {
+	let temp_dir = TempDir::new().expect("temp dir should exist");
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue("In Review", &[]);
+	let head_oid = String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6");
+	let worktree_path = temp_dir.path().join("lane");
+
+	fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+
+	state_store
+		.upsert_worktree(
+			TEST_SERVICE_ID,
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	let worktree = state_store
+		.list_worktrees(TEST_SERVICE_ID)
+		.expect("worktree list should succeed")
+		.into_iter()
+		.next()
+		.expect("worktree should exist");
+	let snapshot = PostReviewLaneSnapshot {
+		issue,
+		worktree,
+		review_handoff: Some(sample_review_handoff_marker(
+			"x/pubfi-pub-101",
+			"https://github.com/hack-ink/decodex/pull/174",
+			&head_oid,
+		)),
+		local_branch_name: Some(String::from("x/pubfi-pub-101")),
+		local_head_oid: Some(head_oid.clone()),
+	};
+
+	seed_review_orchestration_marker(
+		&state_store,
+		TEST_SERVICE_ID,
+		&snapshot.issue.id,
+		&sample_review_orchestration_marker(
+			"x/pubfi-pub-101",
+			"https://github.com/hack-ink/decodex/pull/174",
+			&head_oid,
+			"waiting_for_result",
+			1,
+		),
+	);
+	record_requires_human_authority_boundary(&state_store, &snapshot.issue);
+
+	let mut review_state = sample_pull_request_review_state(
+		"https://github.com/hack-ink/decodex/pull/174",
+		"x/pubfi-pub-101",
+		&head_oid,
+		None,
+		"MERGEABLE",
+		"CLEAN",
+		Some("SUCCESS"),
+		0,
+	);
+
+	add_external_review_ack(&mut review_state);
+	add_external_review_pass(&mut review_state);
+
+	let classification = orchestrator::classify_post_review_lane(
+		&snapshot,
+		&state_store,
+		&sample_workflow(),
+		&FakePullRequestReviewStateInspector::new(vec![Ok(review_state)]),
+	)
+	.expect("classification should succeed");
+
+	assert_eq!(classification.decision, PostReviewLaneDecision::Block);
+	assert_eq!(
+		classification.reason,
+		"authority_boundary_requires_human_decision"
+	);
+
+	record_clean_review_checkpoint_for_head(&state_store, &snapshot.issue.id, &head_oid);
+
+	let mut review_state = sample_pull_request_review_state(
+		"https://github.com/hack-ink/decodex/pull/174",
+		"x/pubfi-pub-101",
+		&head_oid,
+		None,
+		"MERGEABLE",
+		"CLEAN",
+		Some("SUCCESS"),
+		0,
+	);
+
+	add_external_review_ack(&mut review_state);
+	add_external_review_pass(&mut review_state);
+
+	let classification = orchestrator::classify_post_review_lane(
+		&snapshot,
+		&state_store,
+		&sample_workflow(),
+		&FakePullRequestReviewStateInspector::new(vec![Ok(review_state)]),
+	)
+	.expect("classification should succeed");
+
+	assert_eq!(classification.decision, PostReviewLaneDecision::Block);
+	assert_eq!(
+		classification.reason,
+		"authority_boundary_requires_human_decision"
+	);
+}
+
 fn record_block_landing_authority_boundary(state_store: &StateStore, issue: &TrackerIssue) {
 	record_policy_authority_boundary(
 		state_store,
@@ -795,6 +905,71 @@ fn record_block_landing_authority_boundary(state_store: &StateStore, issue: &Tra
 		"Review policy changed during recovery.",
 		"Review policy evidence must be restored before landing.",
 	);
+}
+
+fn record_requires_human_authority_boundary(state_store: &StateStore, issue: &TrackerIssue) {
+	record_policy_authority_boundary(
+		state_store,
+		issue,
+		AuthorityBoundarySurface::AuthorityEvidence,
+		AuthorityBoundaryPolicyDecision::RequiresHumanDecision,
+		"authority_gap",
+		"Operator authority evidence is required before landing.",
+		"Operator acceptance must be recorded before landing.",
+	);
+}
+
+fn record_authority_decision_request(state_store: &StateStore, issue: &TrackerIssue) {
+	let boundary_event = orchestrator::record_authority_boundary_check_private_event(
+		state_store,
+		AuthorityBoundaryCheckInput {
+			project_id: TEST_SERVICE_ID,
+			issue_id: &issue.id,
+			issue_identifier: &issue.identifier,
+			run_id: "run-boundary",
+			attempt_number: 1,
+			decision_contract_ids: Vec::new(),
+			attempted_recovery_reason: "authority_gap",
+			changed_surfaces: vec![AuthorityBoundaryChangedSurface {
+				surface: AuthorityBoundarySurface::AuthorityEvidence,
+				change_summary: "Operator authority evidence is required before landing.",
+				policy_decision: AuthorityBoundaryPolicyDecision::RequiresHumanDecision,
+				legacy_disposition: AuthorityBoundaryDisposition::RequiresHuman,
+			}],
+			policy_decision: AuthorityBoundaryPolicyDecision::RequiresHumanDecision,
+			disposition: AuthorityBoundaryDisposition::RequiresHuman,
+			final_disposition_reason: "Operator acceptance must be recorded before landing.",
+			improvement_signals: Vec::new(),
+		},
+	)
+	.expect("authority boundary check should persist");
+
+	orchestrator::record_authority_decision_request_private_event(
+		state_store,
+		AuthorityDecisionRequestInput {
+			project_id: TEST_SERVICE_ID,
+			issue_id: &issue.id,
+			issue_identifier: &issue.identifier,
+			run_id: "run-boundary",
+			attempt_number: 1,
+			boundary_check_record_id: boundary_event.record_id(),
+			decision_request_id: "dr-pub-101-1",
+			reason_code: "authority_evidence_required",
+			boundary_type: "operator_acceptance",
+			proposed_change: "Land only after operator acceptance.",
+			why_exceeds_authority: "The current lane requires an explicit operator decision.",
+			options: vec![orchestrator::AuthorityDecisionOption {
+				label: "accept",
+				description: "Record operator acceptance before resuming.",
+			}],
+			recommendation: "Record operator acceptance before resuming automation.",
+			resume_condition: "Resume only after the issue, Decision Contract, or policy records the operator decision.",
+			retained_worktree_evidence: vec!["retained worktree has a PR-ready head"],
+			retained_diff_evidence: vec!["diff evidence retained privately"],
+			recovery_attempt_context: vec!["landing stopped at the authority boundary"],
+		},
+	)
+	.expect("authority decision request should persist");
 }
 
 fn record_requires_enhanced_evidence_authority_boundary(

--- a/apps/decodex/src/orchestrator/tests/review_landing/orchestration.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing/orchestration.rs
@@ -484,6 +484,222 @@ fn reconcile_post_review_orchestration_runs_admin_merge_after_external_pass() {
 }
 
 #[test]
+fn reconcile_post_review_orchestration_blocks_admin_merge_for_authority_boundary() {
+	let (temp_dir, config, workflow) = temp_project_layout();
+	let (gh_command_path, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
+	let config =
+		service_config_with_github_token_env_var_and_command_path(&config, "PATH", &gh_command_path);
+	let repo_root = config.repo_root().to_path_buf();
+	let issue = post_review_sample_service_owned_issue("In Review");
+	let tracker =
+		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let pr_url = "https://github.com/hack-ink/decodex/pull/173";
+	let merge_subject = r#"{"schema":"decodex/commit/1","summary":"current retained handoff","authority":"PUB-101"}"#;
+	let head_oid = commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
+
+	state_store
+		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
+		.expect("worktree should record");
+
+	seed_review_handoff_marker_for_path(
+		&state_store,
+		config.service_id(),
+		&repo_root,
+		&sample_review_handoff_marker("main", pr_url, &head_oid),
+	);
+	seed_review_orchestration_marker_for_path(
+		&state_store,
+		config.service_id(),
+		&repo_root,
+		&sample_review_orchestration_marker("main", pr_url, &head_oid, "waiting_for_result", 1),
+	);
+	record_block_landing_authority_boundary(&state_store, &issue);
+
+	let mut review_state = sample_pull_request_review_state(
+		pr_url,
+		"main",
+		&head_oid,
+		Some("APPROVED"),
+		"MERGEABLE",
+		"CLEAN",
+		Some("SUCCESS"),
+		0,
+	);
+
+	add_external_review_ack(&mut review_state);
+	add_external_review_pass(&mut review_state);
+
+	orchestrator::reconcile_post_review_orchestration_with_inspector(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		&FakePullRequestReviewStateInspector::new(vec![Ok(review_state)]),
+	)
+	.expect("post-review orchestration should wait for authority-boundary clearance");
+
+	let marker = persisted_review_orchestration_marker_for_path(
+		&state_store,
+		config.service_id(),
+		&repo_root,
+	);
+
+	assert_eq!(marker.phase(), "waiting_for_result");
+	assert!(marker.auto_merge_enabled_at_unix_epoch().is_none());
+	assert!(
+		!invocation_log_path.exists(),
+		"authority-boundary landing requirements must prevent runtime admin merge"
+	);
+	assert!(tracker.comments.borrow().is_empty());
+	assert!(tracker.label_additions.borrow().is_empty());
+}
+
+#[test]
+fn reconcile_post_review_orchestration_blocks_admin_merge_for_human_decision_boundary() {
+	let (temp_dir, config, workflow) = temp_project_layout();
+	let (gh_command_path, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
+	let config =
+		service_config_with_github_token_env_var_and_command_path(&config, "PATH", &gh_command_path);
+	let repo_root = config.repo_root().to_path_buf();
+	let issue = post_review_sample_service_owned_issue("In Review");
+	let tracker =
+		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let pr_url = "https://github.com/hack-ink/decodex/pull/173";
+	let merge_subject = r#"{"schema":"decodex/commit/1","summary":"current retained handoff","authority":"PUB-101"}"#;
+	let head_oid = commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
+
+	state_store
+		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
+		.expect("worktree should record");
+
+	seed_review_handoff_marker_for_path(
+		&state_store,
+		config.service_id(),
+		&repo_root,
+		&sample_review_handoff_marker("main", pr_url, &head_oid),
+	);
+	seed_review_orchestration_marker_for_path(
+		&state_store,
+		config.service_id(),
+		&repo_root,
+		&sample_review_orchestration_marker("main", pr_url, &head_oid, "waiting_for_result", 1),
+	);
+	record_requires_human_authority_boundary(&state_store, &issue);
+
+	let mut review_state = sample_pull_request_review_state(
+		pr_url,
+		"main",
+		&head_oid,
+		Some("APPROVED"),
+		"MERGEABLE",
+		"CLEAN",
+		Some("SUCCESS"),
+		0,
+	);
+
+	add_external_review_ack(&mut review_state);
+	add_external_review_pass(&mut review_state);
+
+	orchestrator::reconcile_post_review_orchestration_with_inspector(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		&FakePullRequestReviewStateInspector::new(vec![Ok(review_state)]),
+	)
+	.expect("post-review orchestration should wait for human authority decision");
+
+	let marker = persisted_review_orchestration_marker_for_path(
+		&state_store,
+		config.service_id(),
+		&repo_root,
+	);
+
+	assert_eq!(marker.phase(), "waiting_for_result");
+	assert!(marker.auto_merge_enabled_at_unix_epoch().is_none());
+	assert!(
+		!invocation_log_path.exists(),
+		"human authority decisions must prevent runtime admin merge"
+	);
+	assert!(tracker.comments.borrow().is_empty());
+	assert!(tracker.label_additions.borrow().is_empty());
+}
+
+#[test]
+fn reconcile_post_review_orchestration_blocks_admin_merge_for_authority_decision_request() {
+	let (temp_dir, config, workflow) = temp_project_layout();
+	let (gh_command_path, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);
+	let config =
+		service_config_with_github_token_env_var_and_command_path(&config, "PATH", &gh_command_path);
+	let repo_root = config.repo_root().to_path_buf();
+	let issue = post_review_sample_service_owned_issue("In Review");
+	let tracker =
+		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let pr_url = "https://github.com/hack-ink/decodex/pull/173";
+	let merge_subject = r#"{"schema":"decodex/commit/1","summary":"current retained handoff","authority":"PUB-101"}"#;
+	let head_oid = commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
+
+	state_store
+		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
+		.expect("worktree should record");
+
+	seed_review_handoff_marker_for_path(
+		&state_store,
+		config.service_id(),
+		&repo_root,
+		&sample_review_handoff_marker("main", pr_url, &head_oid),
+	);
+	seed_review_orchestration_marker_for_path(
+		&state_store,
+		config.service_id(),
+		&repo_root,
+		&sample_review_orchestration_marker("main", pr_url, &head_oid, "waiting_for_result", 1),
+	);
+	record_authority_decision_request(&state_store, &issue);
+
+	let mut review_state = sample_pull_request_review_state(
+		pr_url,
+		"main",
+		&head_oid,
+		Some("APPROVED"),
+		"MERGEABLE",
+		"CLEAN",
+		Some("SUCCESS"),
+		0,
+	);
+
+	add_external_review_ack(&mut review_state);
+	add_external_review_pass(&mut review_state);
+
+	orchestrator::reconcile_post_review_orchestration_with_inspector(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		&FakePullRequestReviewStateInspector::new(vec![Ok(review_state)]),
+	)
+	.expect("post-review orchestration should wait for authority decision request");
+
+	let marker = persisted_review_orchestration_marker_for_path(
+		&state_store,
+		config.service_id(),
+		&repo_root,
+	);
+
+	assert_eq!(marker.phase(), "waiting_for_result");
+	assert!(marker.auto_merge_enabled_at_unix_epoch().is_none());
+	assert!(
+		!invocation_log_path.exists(),
+		"authority decision requests must prevent runtime admin merge"
+	);
+	assert!(tracker.comments.borrow().is_empty());
+	assert!(tracker.label_additions.borrow().is_empty());
+}
+
+#[test]
 fn reconcile_post_review_orchestration_routes_non_clean_landing_to_agent_fallback() {
 	let (temp_dir, config, workflow) = temp_project_layout();
 	let (gh_command_path, invocation_log_path) = install_fake_admin_merge_gh_response(&temp_dir);

--- a/docs/log.md
+++ b/docs/log.md
@@ -280,3 +280,7 @@
 - Clarified that pre-existing, repo-wide, or global-baseline repo-gate failures are
   runtime-owned signals and must not be routed through agent-requested
   `manual_attention`.
+- Applied Authority Boundary landing requirements to retained admin-merge preflight,
+  so `requires_human_decision`, `requires_enhanced_evidence`, and `block_landing`
+  events block runtime auto-land through the same trusted state that operator status
+  uses.

--- a/docs/spec/post-review-lifecycle.md
+++ b/docs/spec/post-review-lifecycle.md
@@ -270,7 +270,7 @@ At any phase, contradictory state or a non-self-healing merge failure must stop 
 | --- | --- | --- | --- |
 | `review_wait` | `wait_for_external_signal` | PR-backed `In Review` handoff succeeded for the current owned lane | Actionable review repair appears, landing becomes ready, human intervention becomes required, or cancellation is explicit |
 | `review_repair` | `resume_retained_lane` | Actionable review feedback exists and the retained lane still belongs to the same issue and PR lineage | A new repaired head is pushed and review is re-requested for that head, human intervention becomes required, or cancellation is explicit |
-| `ready_to_land` | `ready_to_land` | Required approvals are satisfied, blocking review work is absent, checks are green, the branch is up to date with base, the PR is cleanly mergeable, and no unresolved Authority Boundary `requires_enhanced_evidence` or `block_landing` policy remains for the current head | Clean-path landing begins, signals fall back to wait or repair, or human intervention becomes required |
+| `ready_to_land` | `ready_to_land` | Required approvals are satisfied, blocking review work is absent, checks are green, the branch is up to date with base, the PR is cleanly mergeable, no unresolved Authority Boundary `requires_human_decision` or authority decision request remains, and no unresolved `requires_enhanced_evidence` or `block_landing` policy remains for the current head | Clean-path landing begins, signals fall back to wait or repair, or human intervention becomes required |
 | `landing` | `continue` | The runtime has committed to executing the clean merge for the current lane | Merge is recorded, landing fails into a resumable deterministic tail step, or human intervention becomes required |
 | `closeout` | `continue` | Merge already happened for the lane's authoritative anchor and tracker closeout has not yet completed | Tracker closeout succeeds, the lane blocks on contradictory closeout state, or human intervention becomes required |
 | `cleanup` | `continue` | Either (a) merge and closeout are authoritative and only worktree or branch cleanup remains, or (b) explicit pre-merge cancellation is authoritative and only deterministic retained-lane cleanup remains | The retained worktree and lane branch state are clean, or cleanup blocks on conflicting local evidence |
@@ -383,6 +383,9 @@ already deterministic:
 - required checks are green
 - the branch is already up to date with the base branch
 - mergeability is affirmative and `mergeStateStatus` is `CLEAN`
+- any earlier Authority Boundary `requires_human_decision` or authority decision
+  request has been resolved through explicit issue, Decision Contract, or supported
+  policy authority
 - any earlier Authority Boundary `requires_enhanced_evidence` or `block_landing`
   policy has been cleared by a clean review checkpoint for the current lane head
 

--- a/docs/spec/review-orchestration.md
+++ b/docs/spec/review-orchestration.md
@@ -7,8 +7,8 @@ authority: normative
 owner: runtime
 tags: [spec]
 code_refs: [apps/decodex/src/agent/tracker_tool_bridge/review.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/autonomy_signal.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs]
-drift_watch: [issue_review_checkpoint, issue_review_handoff, issue_review_repair_complete, review_contract, review_cost_control, review_policy_checkpoints, finding_routes, evidence_artifacts, decodex.autonomy_signal/1]
-last_verified: 2026-06-22
+drift_watch: [issue_review_checkpoint, issue_review_handoff, issue_review_repair_complete, review_contract, review_cost_control, review_policy_checkpoints, finding_routes, evidence_artifacts, authority_boundary_check, decodex.autonomy_signal/1]
+last_verified: 2026-06-23
 ---
 # Review Orchestration
 
@@ -347,6 +347,11 @@ Before starting landing, require all of these:
 - required checks are green
 - the PR branch is up to date with base
 - the repository merge method preserves commit-level history and supports merge commits
+- no unresolved Authority Boundary `requires_human_decision`,
+  `requires_enhanced_evidence`, or `block_landing` policy remains for the current
+  lane head, and no unresolved `authority_decision_request` remains; operator status
+  readback and runtime admin-merge preflight must read the same authority-boundary
+  landing requirement
 - runtime calls GitHub admin merge explicitly; do not use auto-merge and do not fall back to rebase or squash merge
 
 If the repository does not support merge commits, stop for `manual_intervention_required` instead of improvising another merge path.


### PR DESCRIPTION
## Summary
- route retained admin-merge preflight through the same authority-boundary landing requirement used by operator status
- keep `requires_human_decision` and `authority_decision_request` as hard landing blockers
- update post-review docs and regression tests for the authority-boundary landing contract

## Validation
- `cargo make check`
- targeted review landing and classification regression tests covered by the full gate

## Duplicate-work check
- current open PR search for XY-1103 / external validation / authority boundary / pre-land returned no active overlapping PR
- historical PR #475 is already merged and covers review checkpoint orchestration, not this admin-merge preflight gap

Authority: XY-1103