### PR TITLE
Clarify Decodex attempt reporting

### DIFF
--- a/apps/decodex/src/agent/tracker_tool_bridge.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge.rs
@@ -1624,7 +1624,7 @@ fn format_review_handoff_comment(
 	summary: &str,
 ) -> String {
 	format!(
-		"decodex run completed and is ready for review\n\n- run_id: `{run_id}`\n- attempt: `{attempt}`\n- finished_at: `{finished_at}`\n- branch: `{branch}`\n- pr_url: `{pr_url}`\n- worktree_path: `{worktree_path}`\n- validation_result: `passed`\n- summary: {summary}",
+		"decodex run completed and is ready for review\n\n- run_id: `{run_id}`\n- run_sequence_attempt: `{attempt}` (not retry-budget count)\n- finished_at: `{finished_at}`\n- branch: `{branch}`\n- pr_url: `{pr_url}`\n- worktree_path: `{worktree_path}`\n- validation_result: `passed`\n- summary: {summary}",
 		run_id = review_context.run_id,
 		attempt = review_context.attempt_number,
 		finished_at = current_timestamp(),
@@ -1641,7 +1641,7 @@ fn format_review_repair_comment(
 	summary: &str,
 ) -> String {
 	format!(
-		"decodex review repair completed and requested fresh review\n\n- run_id: `{run_id}`\n- attempt: `{attempt}`\n- finished_at: `{finished_at}`\n- branch: `{branch}`\n- pr_url: `{pr_url}`\n- worktree_path: `{worktree_path}`\n- validation_result: `passed`\n- summary: {summary}",
+		"decodex review repair completed and requested fresh review\n\n- run_id: `{run_id}`\n- run_sequence_attempt: `{attempt}` (not retry-budget count)\n- finished_at: `{finished_at}`\n- branch: `{branch}`\n- pr_url: `{pr_url}`\n- worktree_path: `{worktree_path}`\n- validation_result: `passed`\n- summary: {summary}",
 		run_id = review_context.run_id,
 		attempt = review_context.attempt_number,
 		finished_at = current_timestamp(),

--- a/apps/decodex/src/agent/tracker_tool_bridge/review.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/review.rs
@@ -918,10 +918,24 @@ impl<'a> TrackerToolBridge<'a> {
 			&pull_request,
 			public_summary.as_ref(),
 		);
+		let retry_budget_line = self
+			.state_store
+			.map(|state_store| {
+				state_store.retry_budget_attempt_count(&self.issue.id).map(|count| {
+					if count > 0 {
+						format!("\n- retry_budget_attempts_consumed: `{count}`")
+					} else {
+						String::new()
+					}
+				})
+			})
+			.transpose()?
+			.unwrap_or_default();
 		let closeout_comment = format!(
-			"decodex closeout completed\n\n- run_id: `{}`\n- attempt: `{}`\n- finished_at: `{}`\n- branch: `{}`\n- pr_url: `{}`\n- worktree_path: `{}`\n- summary: {}",
+			"decodex closeout completed\n\n- run_id: `{}`\n- run_sequence_attempt: `{}` (not retry-budget count){}\n- finished_at: `{}`\n- branch: `{}`\n- pr_url: `{}`\n- worktree_path: `{}`\n- summary: {}",
 			review_context.run_id,
 			review_context.attempt_number,
+			retry_budget_line,
 			tracker_tool_bridge::current_timestamp(),
 			review_context.branch_name,
 			pull_request.url,

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools.rs
@@ -3796,7 +3796,10 @@ fn format_manual_attention_comment(
 		String::from("decodex run needs manual attention"),
 		String::new(),
 		format!("- run_id: `{}`", review_context.run_id),
-		format!("- attempt: `{}`", review_context.attempt_number),
+		format!(
+			"- run_sequence_attempt: `{}` (not retry-budget count)",
+			review_context.attempt_number
+		),
 		format!("- reported_at: `{}`", tracker_tool_bridge::current_timestamp()),
 		format!("- branch: `{}`", review_context.branch_name),
 		format!("- worktree_path: `{}`", review_context.worktree_path),

--- a/apps/decodex/src/manual.rs
+++ b/apps/decodex/src/manual.rs
@@ -1672,6 +1672,11 @@ where
 	}
 
 	write_manual_land_landed_and_closeout_events(tracker, ledger)?;
+	succeed_manual_land_handoff_attempt(
+		ledger.state_store,
+		&ledger.issue.id,
+		ledger.handoff.run_id(),
+	)?;
 
 	Ok(())
 }
@@ -1711,7 +1716,12 @@ fn write_manual_land_lifecycle_event<T>(
 where
 	T: IssueTracker + ?Sized,
 {
-	let body = format!("Decodex execution event: {}", record.event_type);
+	let retry_budget_attempt_count =
+		ledger.state_store.retry_budget_attempt_count(&ledger.issue.id)?;
+	let retry_budget_attempt_count =
+		(retry_budget_attempt_count > 0).then_some(retry_budget_attempt_count);
+	let body =
+		records::render_linear_execution_event_comment_body(record, retry_budget_attempt_count);
 	let projection =
 		tracker::prepare_linear_execution_event_comment(&body, record, ledger.privacy_classifier)?;
 
@@ -3702,6 +3712,10 @@ exit 1\n",
 			String::from("xy/pub-1161"),
 			String::from("3cf2d24033527a774340c7d70c5ce437c90afe55"),
 		);
+		state_store
+			.record_run_attempt(handoff.run_id(), &issue.id, handoff.attempt_number(), "failed")
+			.expect("failed handoff attempt should record");
+
 		let merge_commit = "81e90b530148a0be69afa5bd33ce6ab84d485a3a";
 		let landed_change_record =
 			r#"{"schema":"decodex/commit/1","summary":"Land PUB-1161","authority":"PUB-1161"}"#;
@@ -3751,6 +3765,10 @@ exit 1\n",
 			comments.iter().all(|comment| !comment.starts_with("decodex land completed")),
 			"matching legacy closeout marker should not replay the ordinary closeout comment"
 		);
+		assert!(comments.iter().all(|comment| {
+			comment.contains("- run_sequence_attempt: `1` (not retry-budget count)")
+				&& !comment.contains("- attempt:")
+		}));
 		assert!(records.iter().all(|record| record.run_id == "pub-1161-attempt-1"));
 		assert!(records.iter().all(|record| record.attempt_number == 1));
 		assert_eq!(records[0].pr_head_sha.as_deref(), Some(handoff.pr_head_oid()));
@@ -3765,6 +3783,14 @@ exit 1\n",
 			cached_records.iter().map(|record| record.event_type.as_str()).collect::<Vec<_>>();
 
 		assert_eq!(cached_event_types, vec!["landed", "closeout", "cleanup_complete"]);
+		assert_eq!(
+			state_store
+				.run_attempt(handoff.run_id())
+				.expect("run attempt lookup should succeed")
+				.expect("handoff attempt should exist")
+				.status(),
+			"succeeded"
+		);
 	}
 
 	#[test]

--- a/apps/decodex/src/orchestrator/execution.rs
+++ b/apps/decodex/src/orchestrator/execution.rs
@@ -1270,7 +1270,11 @@ fn write_lifecycle_event<T>(
 where
 	T: IssueTracker + ?Sized,
 {
-	let body = format!("Decodex execution event: {}", record.event_type);
+	let retry_budget_attempt_count = state_store.retry_budget_attempt_count(issue_id)?;
+	let retry_budget_attempt_count = (retry_budget_attempt_count > 0)
+		.then_some(retry_budget_attempt_count);
+	let body =
+		records::render_linear_execution_event_comment_body(record, retry_budget_attempt_count);
 	let projection =
 		tracker::prepare_linear_execution_event_comment(&body, record, privacy_classifier)?;
 

--- a/apps/decodex/src/orchestrator/selection.rs
+++ b/apps/decodex/src/orchestrator/selection.rs
@@ -120,7 +120,7 @@ fn format_retry_comment(comment: RetryComment<'_>) -> String {
 	} = comment;
 
 	format!(
-		"decodex run failed and will retry\n\n- run_id: `{run_id}`\n- attempt: `{attempt_number}`\n- retry_budget_attempt: `{retry_budget_attempt_number}` / `{max_attempts}`\n- failed_at: `{failed_at}`\n- branch: `{branch}`\n- worktree_path: `{worktree}`\n- error_class: `{error_class}`\n- next_action: `{next_action}`\n- error_summary: `Sensitive runtime details were withheld from the tracker comment; inspect the local lane for the full failure context.`",
+		"decodex run failed and will retry\n\n- run_id: `{run_id}`\n- run_sequence_attempt: `{attempt_number}` (not retry-budget count)\n- retry_budget_attempt: `{retry_budget_attempt_number}` / `{max_attempts}`\n- failed_at: `{failed_at}`\n- branch: `{branch}`\n- worktree_path: `{worktree}`\n- error_class: `{error_class}`\n- next_action: `{next_action}`\n- error_summary: `Sensitive runtime details were withheld from the tracker comment; inspect the local lane for the full failure context.`",
 		failed_at = current_timestamp(),
 		branch = branch_name,
 		worktree = worktree_path,
@@ -210,7 +210,7 @@ fn format_terminal_failure_comment(
 	};
 
 	format!(
-		"{heading}\n\n- run_id: `{run_id}`\n- attempt: `{attempt_number}`\n- {timestamp_label}: `{timestamp}`\n- branch: `{branch}`{pr_url_line}\n- worktree_path: `{worktree}`\n- error_class: `{error_class}`\n- next_action: `{next_action}`\n- error_summary: `{error_summary}`",
+		"{heading}\n\n- run_id: `{run_id}`\n- run_sequence_attempt: `{attempt_number}` (not retry-budget count)\n- {timestamp_label}: `{timestamp}`\n- branch: `{branch}`{pr_url_line}\n- worktree_path: `{worktree}`\n- error_class: `{error_class}`\n- next_action: `{next_action}`\n- error_summary: `{error_summary}`",
 		timestamp = current_timestamp(),
 		branch = branch_name,
 		worktree = worktree_path

--- a/apps/decodex/src/orchestrator/tests/operator/status_support.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status_support.rs
@@ -193,7 +193,7 @@ where
 
 	TrackerComment {
 		body: records::append_structured_comment_record(
-			&format!("Decodex execution event: {event_type}"),
+			&records::render_linear_execution_event_comment_body(&record, None),
 			&record,
 		)
 		.expect("structured comment should serialize"),

--- a/apps/decodex/src/orchestrator/tests/recovery/terminal_failures.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery/terminal_failures.rs
@@ -1822,7 +1822,7 @@ fn retryable_failures_ignore_prior_continuation_attempts_in_writeback() {
 	assert!(tracker.label_removals.borrow().is_empty());
 	assert!(tracker.comments.borrow().iter().any(|comment| {
 		comment.contains("retryable_execution_failure")
-			&& comment.contains("- attempt: `4`")
+			&& comment.contains("- run_sequence_attempt: `4` (not retry-budget count)")
 			&& comment.contains("- retry_budget_attempt: `1` / `3`")
 	}));
 	assert!(!tracker.comments.borrow().iter().any(|comment| {

--- a/apps/decodex/src/recovery.rs
+++ b/apps/decodex/src/recovery.rs
@@ -4083,11 +4083,19 @@ fn write_rebind_audit(
 	validation: &RebindValidation,
 	event: &LinearExecutionEventRecord,
 ) -> Result<()> {
-	let body = format!(
+	let recovery_body = format!(
 		"Decodex operator recovery: {} for `{}` to `{}`. This does not land the pull request.",
 		validation.mode.summary_action(),
 		validation.issue.identifier,
 		landing_url(&validation.landing_state)
+	);
+	let retry_budget_attempt_count =
+		context.state_store.retry_budget_attempt_count(&validation.issue.id)?;
+	let retry_budget_attempt_count =
+		(retry_budget_attempt_count > 0).then_some(retry_budget_attempt_count);
+	let body = format!(
+		"{recovery_body}\n\n{}",
+		records::render_linear_execution_event_comment_body(event, retry_budget_attempt_count)
 	);
 	let privacy_classifier = ConfiguredPublicProjectionPrivacyClassifier::from_config(
 		context.config.privacy_classifier(),
@@ -4109,10 +4117,18 @@ fn write_adopt_audit(
 	validation: &AdoptValidation,
 	event: &LinearExecutionEventRecord,
 ) -> Result<()> {
-	let body = format!(
+	let recovery_body = format!(
 		"Decodex operator recovery: adopted human-owned PR `{}` for `{}` into retained review handoff state. This does not land the pull request.",
 		landing_url(&validation.landing_state),
 		validation.issue.identifier,
+	);
+	let retry_budget_attempt_count =
+		context.state_store.retry_budget_attempt_count(&validation.issue.id)?;
+	let retry_budget_attempt_count =
+		(retry_budget_attempt_count > 0).then_some(retry_budget_attempt_count);
+	let body = format!(
+		"{recovery_body}\n\n{}",
+		records::render_linear_execution_event_comment_body(event, retry_budget_attempt_count)
 	);
 	let privacy_classifier = ConfiguredPublicProjectionPrivacyClassifier::from_config(
 		context.config.privacy_classifier(),
@@ -4188,11 +4204,19 @@ fn write_legacy_closeout_audit(
 	validation: &LegacyCloseoutValidation,
 	event: &LinearExecutionEventRecord,
 ) -> Result<bool> {
-	let body = format!(
+	let audit_body = format!(
 		"Decodex legacy manual closeout audit: verified merged PR `{}` for `{}`. Runtime provenance was `{}`, so this records the manual fallback before local cleanup.",
 		landing_url(&validation.landing_state),
 		validation.issue.identifier,
 		validation.worktree.provenance().source()
+	);
+	let retry_budget_attempt_count =
+		context.state_store.retry_budget_attempt_count(&validation.issue.id)?;
+	let retry_budget_attempt_count =
+		(retry_budget_attempt_count > 0).then_some(retry_budget_attempt_count);
+	let body = format!(
+		"{audit_body}\n\n{}",
+		records::render_linear_execution_event_comment_body(event, retry_budget_attempt_count)
 	);
 	let privacy_classifier = ConfiguredPublicProjectionPrivacyClassifier::from_config(
 		context.config.privacy_classifier(),
@@ -4256,6 +4280,8 @@ fn apply_merged_closeout_recovery(
 		}
 	}
 
+	context.state_store.update_run_status(&validation.run_id, "succeeded")?;
+
 	Ok((closeout_recorded, cleanup_recorded))
 }
 
@@ -4268,8 +4294,16 @@ fn write_merged_closeout_event(
 	let privacy_classifier = ConfiguredPublicProjectionPrivacyClassifier::from_config(
 		context.config.privacy_classifier(),
 	)?;
+	let retry_budget_attempt_count =
+		context.state_store.retry_budget_attempt_count(&validation.issue.id)?;
+	let retry_budget_attempt_count =
+		(retry_budget_attempt_count > 0).then_some(retry_budget_attempt_count);
+	let body = format!(
+		"{body}\n\n{}",
+		records::render_linear_execution_event_comment_body(event, retry_budget_attempt_count)
+	);
 	let projection =
-		tracker::prepare_linear_execution_event_comment(body, event, &privacy_classifier)?;
+		tracker::prepare_linear_execution_event_comment(&body, event, &privacy_classifier)?;
 	let recorded = context.state_store.record_linear_execution_event(&projection.record)?;
 
 	if !recorded {

--- a/apps/decodex/src/tracker/records.rs
+++ b/apps/decodex/src/tracker/records.rs
@@ -177,6 +177,24 @@ pub(crate) struct LinearExecutionEventPublicProjection {
 	pub(crate) classifier_withheld_text: bool,
 }
 
+pub(crate) fn render_linear_execution_event_comment_body(
+	record: &LinearExecutionEventRecord,
+	retry_budget_attempt_count: Option<i64>,
+) -> String {
+	let mut body = format!(
+		"Decodex execution event: {}\n\n- run_sequence_attempt: `{}` (not retry-budget count)",
+		record.event_type, record.attempt_number
+	);
+
+	if let Some(retry_budget_attempt_count) = retry_budget_attempt_count {
+		body.push_str(&format!(
+			"\n- retry_budget_attempts_consumed: `{retry_budget_attempt_count}`"
+		));
+	}
+
+	body
+}
+
 pub(crate) fn linear_execution_event_public_projection(
 	body: &str,
 	record: &LinearExecutionEventRecord,
@@ -795,6 +813,28 @@ mod tests {
 			String::from("2026-05-25T00:00:00Z"),
 			"anchor",
 		)
+	}
+
+	#[test]
+	fn renders_attempt_number_as_run_sequence_in_comment_body() {
+		let record = LinearExecutionEventRecord::new(
+			LinearExecutionEventIdentity {
+				service_id: "decodex",
+				issue_id: "issue-id",
+				issue_identifier: "XY-519",
+				run_id: "xy-519-attempt-4",
+				attempt_number: 4,
+			},
+			"closeout",
+			String::from("2026-05-25T00:00:00Z"),
+			"anchor",
+		);
+		let body = super::render_linear_execution_event_comment_body(&record, Some(1));
+
+		assert!(body.contains("Decodex execution event: closeout"));
+		assert!(body.contains("- run_sequence_attempt: `4` (not retry-budget count)"));
+		assert!(body.contains("- retry_budget_attempts_consumed: `1`"));
+		assert!(!body.contains("- attempt:"));
 	}
 
 	#[test]

--- a/docs/spec/linear-execution-ledger.md
+++ b/docs/spec/linear-execution-ledger.md
@@ -6,7 +6,18 @@ status: active
 authority: normative
 owner: runtime
 tags: [spec]
-last_verified: 2026-06-17
+code_refs:
+  - apps/decodex/src/tracker/records.rs
+  - apps/decodex/src/orchestrator/selection.rs
+  - apps/decodex/src/orchestrator/execution.rs
+  - apps/decodex/src/manual.rs
+  - apps/decodex/src/recovery.rs
+drift_watch:
+  - attempt_number
+  - run_sequence_attempt
+  - retry_budget_attempt
+  - retry_budget_attempts_consumed
+last_verified: 2026-06-26
 ---
 # Linear Execution Ledger
 
@@ -55,6 +66,8 @@ Recommended shape:
 
 ````text
 Decodex execution event: review_handoff
+
+- run_sequence_attempt: `1` (not retry-budget count)
 
 ```json
 {
@@ -146,11 +159,17 @@ All field names are snake_case.
 | `issue_id` | yes | string | The tracker issue id used by Linear APIs and local leases. |
 | `issue_identifier` | yes | string | The human-visible Linear identifier such as `XY-352`. |
 | `run_id` | yes | string | The Decodex run id for this attempt. |
-| `attempt_number` | yes | integer | The 1-based attempt number for `run_id`. |
+| `attempt_number` | yes | integer | The 1-based run-sequence attempt number for `run_id`. This is not the retry-budget attempt count. |
 
 Ledger records are run-bound. If Decodex detects a candidate issue before it has a
 `run_id` and `attempt_number`, that pre-run observation is not a Linear execution
 ledger record.
+
+Human-readable ledger comment text must label this value as `run_sequence_attempt` so
+operators do not read continuation attempts as retry-budget failures. Retry comments
+may additionally include `retry_budget_attempt`, and generic lifecycle comments may
+include `retry_budget_attempts_consumed` when at least one retry-budget-consuming
+attempt is already recorded locally.
 
 ## Shared optional fields
 


### PR DESCRIPTION
## Summary

- Label public Decodex attempt comments as run_sequence_attempt instead of retry-budget attempt.
- Include retry budget consumption only where it is actually known.
- Mark manual/merged closeout recovery runs succeeded after successful closeout ledger writeback.
- Update the Linear execution ledger spec for the run-sequence vs retry-budget distinction.

## Root Cause

PUB-1620 looked like repeated retry-budget failure because operator-facing comments exposed the ledger attempt_number without explaining that it is the run sequence. The observed attempts were mostly continuation boundaries; the actual bug was stale local failed status after successful manual/merged closeout.

## Validation

- cargo make build
- cargo make check-node
- cargo make check-docs
- cargo make check-rust
- cargo make test: 1488 passed, 1 skipped
- git diff --check
- semantic_drift_audit.py --repo . --json, reviewed manually

## Known Gate Note

- cargo make check and cargo make lint are blocked by existing repo-wide fmt/vstyle drift in unrelated files such as apps/decodex/src/cli.rs, apps/decodex/src/radar.rs, and apps/decodex/src/pull_request.rs. Those files are outside this patch and were not changed.
