### PR TITLE
Add Codex control-plane upgrade candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Repo-native agent orchestration, retained lanes, and local operator control.
 
 Prototype / in active development.
 
-This repository owns the Decodex runtime, native app, static site, and installable
-plugin. Upstream monitoring and public publishing automation are intentionally outside
-this repository.
+This repository owns the Decodex runtime, native app, static site, installable plugins,
+and repo-local automation source under `automations/decodex`. Recurring Codex App
+automation execution and private generated state stay outside tracked source; generated
+Radar and publishing artifacts must stay under `.agent/automations/decodex/cache`.
 
 Supported runtime host targets are macOS and Linux. Windows remains unsupported for the
 runtime.

--- a/apps/decodex/src/radar.rs
+++ b/apps/decodex/src/radar.rs
@@ -29,6 +29,7 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use crate::prelude::eyre::{self, Report};
 
 const BUNDLE_SCHEMA: &str = "github_change_bundle/v1";
+const CONTROL_PLANE_UPGRADE_CANDIDATE_SCHEMA: &str = "control_plane_upgrade_candidate/v1";
 const DEFAULT_LEDGER_PATH: &str = ".agent/automations/decodex/cache/github/radar.sqlite3";
 const DEFAULT_MIN_STABLE_TAG: &str = "rust-v0.116.0";
 const DEFAULT_PAIR_LIMIT: usize = 24;
@@ -42,7 +43,7 @@ const DEFAULT_SIGNALS_DIR: &str = ".agent/automations/decodex/cache/site-content
 const DEFAULT_STABLE_LIMIT: usize = 0;
 const DEFAULT_TAG_PREFIX: &str = "rust-v";
 const RELEASE_DELTA_SCHEMA: &str = "release_delta/v1";
-const SCHEMA_VERSION: i64 = 3;
+const SCHEMA_VERSION: i64 = 4;
 const SIGNAL_SCHEMA: &str = "signal_entry/v1";
 const SOCIAL_CANDIDATE_SCHEMA: &str = "social_candidate/v1";
 const SOCIAL_POST_SCHEMA: &str = "social_post/v1";
@@ -56,6 +57,7 @@ const DEFAULT_VALIDATION_PATHS: &[&str] = &[
 	".agent/automations/decodex/cache/github/review-queue",
 	".agent/automations/decodex/cache/github/reviews",
 	".agent/automations/decodex/cache/github/impact",
+	".agent/automations/decodex/cache/github/control-plane-upgrades",
 	".agent/automations/decodex/cache/github/social-candidates",
 	".agent/automations/decodex/cache/social/x",
 	".agent/automations/decodex/cache/site-content/signals",
@@ -89,10 +91,21 @@ const SOCIAL_POST_LIFECYCLE_STATES: &[&str] = &[
 ];
 const SOCIAL_PUBLISH_RESERVATION_STATUSES: &[&str] = &["active", "canceled", "consumed", "expired"];
 const SOURCE_ITEM_KINDS: &[&str] = &["commit", "pull_request"];
+const CONTROL_PLANE_UPGRADE_IMPACTS: &[&str] = &["adopt_now", "candidate", "compat_risk"];
+const CONTROL_PLANE_UPGRADE_PATHS: &[&str] = &["adopt_now", "compat_risk_mitigation", "discovery"];
+const CONTROL_PLANE_UPGRADE_STATUSES: &[&str] = &["blocked", "deferred", "proposed", "superseded"];
+const CODEX_COMPATIBILITY_STATUSES: &[&str] =
+	&["compatible", "incompatible", "needs_review", "not_tested", "unknown"];
+const CODEX_TARGET_CHANNELS: &[&str] = &["main", "preview", "stable"];
 const UPSTREAM_IMPACT_KINDS: &[&str] =
 	&["browser_observation", "changelog", "commit", "pull_request", "release", "signal"];
-const UPSTREAM_REVIEW_ACTION_TYPES: &[&str] =
-	&["linear_followup", "none", "signal_entry", "social_candidate", "upstream_impact"];
+const UPSTREAM_REVIEW_ACTION_TYPES: &[&str] = &[
+	"control_plane_upgrade_candidate",
+	"none",
+	"signal_entry",
+	"social_candidate",
+	"upstream_impact",
+];
 const UPSTREAM_REVIEW_NEXT_STEPS: &[&str] = &["ai_review_required"];
 const UPSTREAM_REVIEW_PRIORITIES: &[&str] = &["critical", "high", "low", "normal"];
 const UPSTREAM_SOURCE_STATES: &[&str] = &["closed", "commit_only", "merged", "open"];
@@ -161,6 +174,7 @@ const ARTIFACT_KINDS: &[&str] = &[
 	"analysis",
 	"archive_manifest",
 	"bundle",
+	"control_plane_upgrade_candidate",
 	"ledger_export",
 	"release_delta",
 	"signal",
@@ -3555,6 +3569,7 @@ fn initialize_ledger(connection: &Connection) -> crate::prelude::Result<()> {
 		      'analysis',
 		      'signal',
 		      'upstream_impact',
+		      'control_plane_upgrade_candidate',
 		      'social_candidate',
 		      'social_post',
 		      'release_delta',
@@ -3615,7 +3630,10 @@ fn migrate_artifact_link_kinds(connection: &Connection) -> crate::prelude::Resul
 		return Ok(());
 	};
 
-	if table_sql.contains("social_candidate") && !table_sql.contains("social_draft") {
+	if table_sql.contains("social_candidate")
+		&& table_sql.contains("control_plane_upgrade_candidate")
+		&& !table_sql.contains("social_draft")
+	{
 		return Ok(());
 	}
 
@@ -3633,6 +3651,7 @@ fn migrate_artifact_link_kinds(connection: &Connection) -> crate::prelude::Resul
 		      'analysis',
 		      'signal',
 		      'upstream_impact',
+		      'control_plane_upgrade_candidate',
 		      'social_candidate',
 		      'social_post',
 		      'release_delta',
@@ -4550,6 +4569,8 @@ fn validate_artifact(payload: &Value) -> ArtifactValidation {
 	match schema.as_deref() {
 		Some(BUNDLE_SCHEMA) => validate_bundle(entry, &mut errors),
 		Some(CONFIG_FEATURE_CATALOG_SCHEMA) => validate_config_feature_catalog(entry, &mut errors),
+		Some(CONTROL_PLANE_UPGRADE_CANDIDATE_SCHEMA) =>
+			validate_control_plane_upgrade_candidate(entry, &mut errors),
 		Some(RADAR_ARCHIVE_MANIFEST_SCHEMA) => validate_radar_archive_manifest(entry, &mut errors),
 		Some(RELEASE_DELTA_SCHEMA) => validate_release_delta(entry, &mut errors),
 		Some(SIGNAL_SCHEMA) => validate_signal(entry, &mut errors),
@@ -5456,6 +5477,129 @@ fn validate_upstream_impact(entry: &Map<String, Value>, errors: &mut Vec<String>
 	}
 }
 
+fn validate_control_plane_upgrade_candidate(entry: &Map<String, Value>, errors: &mut Vec<String>) {
+	for field in ["slug", "repo", "observed_change", "reason"] {
+		if !is_non_empty_string(entry.get(field)) {
+			errors.push(format!("{field} must be a non-empty string"));
+		}
+	}
+
+	if string_field(entry, "repo").is_some_and(|repo| !repo.contains('/')) {
+		errors.push("repo must be owner/name".into());
+	}
+	if !matches_one_of(entry.get("status"), CONTROL_PLANE_UPGRADE_STATUSES) {
+		errors.push(format!("status must be one of {}", choices(CONTROL_PLANE_UPGRADE_STATUSES)));
+	}
+	if !matches_one_of(entry.get("control_plane_impact"), CONTROL_PLANE_UPGRADE_IMPACTS) {
+		errors.push(format!(
+			"control_plane_impact must be one of {}",
+			choices(CONTROL_PLANE_UPGRADE_IMPACTS)
+		));
+	}
+	if !matches_one_of(entry.get("upgrade_path"), CONTROL_PLANE_UPGRADE_PATHS) {
+		errors
+			.push(format!("upgrade_path must be one of {}", choices(CONTROL_PLANE_UPGRADE_PATHS)));
+	}
+
+	validate_control_plane_upgrade_source_refs(entry.get("source_refs"), errors);
+	validate_control_plane_upgrade_target_codex(entry.get("target_codex"), errors);
+	validate_control_plane_upgrade_authority(entry.get("authority"), errors);
+	validate_non_empty_string_list(entry.get("affected_surfaces"), "affected_surfaces", errors);
+	validate_non_empty_string_list(entry.get("validation_gates"), "validation_gates", errors);
+	validate_non_empty_string_list(entry.get("stop_conditions"), "stop_conditions", errors);
+
+	for field in ["acceptance_criteria", "caveats", "next_steps"] {
+		validate_optional_string_list(entry.get(field), field, errors);
+	}
+}
+
+fn validate_control_plane_upgrade_source_refs(refs: Option<&Value>, errors: &mut Vec<String>) {
+	let Some(refs) = refs.and_then(Value::as_object) else {
+		errors.push("source_refs must be an object".into());
+
+		return;
+	};
+	let has_refs = ["upstream_reviews", "upstream_impacts", "release_deltas", "urls"]
+		.iter()
+		.any(|field| non_empty_array(refs.get(*field)).is_some());
+
+	if !has_refs {
+		errors.push(
+			"source_refs must include upstream_reviews, upstream_impacts, release_deltas, or urls"
+				.into(),
+		);
+	}
+	if refs.get("urls").is_some_and(|urls| !is_https_string_array(urls)) {
+		errors.push("source_refs.urls must be a list of https URLs".into());
+	}
+
+	for field in ["upstream_reviews", "upstream_impacts", "release_deltas"] {
+		validate_optional_string_list(refs.get(field), &format!("source_refs.{field}"), errors);
+	}
+}
+
+fn validate_control_plane_upgrade_target_codex(target: Option<&Value>, errors: &mut Vec<String>) {
+	let Some(target) = target.and_then(Value::as_object) else {
+		errors.push("target_codex must be an object".into());
+
+		return;
+	};
+
+	if !matches_one_of(target.get("channel"), CODEX_TARGET_CHANNELS) {
+		errors.push(format!(
+			"target_codex.channel must be one of {}",
+			choices(CODEX_TARGET_CHANNELS)
+		));
+	}
+	if !["version", "tag", "commit_sha", "release_url"]
+		.iter()
+		.any(|field| is_non_empty_string(target.get(*field)))
+	{
+		errors.push("target_codex must include version, tag, commit_sha, or release_url".into());
+	}
+	if target.get("release_url").is_some_and(|url| !is_https_string(Some(url))) {
+		errors.push("target_codex.release_url must be an https URL when present".into());
+	}
+	if target
+		.get("compatibility_status")
+		.is_some_and(|status| !matches_one_of(Some(status), CODEX_COMPATIBILITY_STATUSES))
+	{
+		errors.push(format!(
+			"target_codex.compatibility_status must be one of {}",
+			choices(CODEX_COMPATIBILITY_STATUSES)
+		));
+	}
+
+	for field in ["version", "tag", "commit_sha", "matrix_ref", "probe_evidence"] {
+		if target.get(field).is_some_and(|value| !is_non_empty_string(Some(value))) {
+			errors.push(format!("target_codex.{field} must be non-empty when present"));
+		}
+	}
+}
+
+fn validate_control_plane_upgrade_authority(authority: Option<&Value>, errors: &mut Vec<String>) {
+	let Some(authority) = authority.and_then(Value::as_object) else {
+		errors.push("authority must be an object".into());
+
+		return;
+	};
+
+	for field in ["decision_contract_required", "program_intake_required"] {
+		if authority.get(field).and_then(Value::as_bool) != Some(true) {
+			errors.push(format!("authority.{field} must be true"));
+		}
+	}
+	if authority.get("mutation_allowed").and_then(Value::as_bool) != Some(false) {
+		errors.push("authority.mutation_allowed must be false".into());
+	}
+
+	for field in ["objective_id", "objective_version", "policy_ref"] {
+		if authority.get(field).is_some_and(|value| !is_non_empty_string(Some(value))) {
+			errors.push(format!("authority.{field} must be non-empty when present"));
+		}
+	}
+}
+
 fn validate_upstream_impact_source_refs(refs: Option<&Value>, errors: &mut Vec<String>) {
 	let Some(refs) = refs.and_then(Value::as_object) else {
 		errors.push("source_refs must be an object".into());
@@ -6246,6 +6390,7 @@ fn known_schemas() -> String {
 	choices(&[
 		BUNDLE_SCHEMA,
 		CONFIG_FEATURE_CATALOG_SCHEMA,
+		CONTROL_PLANE_UPGRADE_CANDIDATE_SCHEMA,
 		RADAR_ARCHIVE_MANIFEST_SCHEMA,
 		RELEASE_DELTA_SCHEMA,
 		SIGNAL_SCHEMA,
@@ -6660,10 +6805,18 @@ mod tests {
 	}
 
 	#[test]
-	fn accepts_valid_upstream_review_and_rejects_bad_action() {
+	fn accepts_valid_upstream_review_upgrade_action_and_rejects_stale_action() {
 		let mut review = valid_upstream_review();
 
 		assert_errors(&review, []);
+
+		review["next_actions"][0]["type"] = serde_json::json!("control_plane_upgrade_candidate");
+
+		assert_errors(&review, []);
+
+		review["next_actions"][0]["type"] = serde_json::json!("linear_followup");
+
+		assert_errors(&review, ["next_actions[0].type must be one of"]);
 
 		review["next_actions"][0]["type"] = serde_json::json!("publish_now");
 
@@ -6699,6 +6852,36 @@ mod tests {
 		impact["publisher_angle"] = serde_json::json!("viral_thread");
 
 		assert_errors(&impact, ["publisher_angle must be one of"]);
+	}
+
+	#[test]
+	fn accepts_valid_control_plane_upgrade_candidate_and_rejects_direct_mutation() {
+		let mut candidate = valid_control_plane_upgrade_candidate();
+
+		assert_errors(&candidate, []);
+
+		candidate["authority"]["mutation_allowed"] = serde_json::json!(true);
+
+		assert_errors(&candidate, ["authority.mutation_allowed must be false"]);
+
+		let mut missing_contract = valid_control_plane_upgrade_candidate();
+		missing_contract["authority"]["decision_contract_required"] = serde_json::json!(false);
+
+		assert_errors(
+			&missing_contract,
+			["authority.decision_contract_required must be true"],
+		);
+
+		let mut missing_program = valid_control_plane_upgrade_candidate();
+		missing_program["authority"]
+			.as_object_mut()
+			.expect("authority should be an object")
+			.remove("program_intake_required");
+
+		assert_errors(
+			&missing_program,
+			["authority.program_intake_required must be true"],
+		);
 	}
 
 	#[test]
@@ -6962,7 +7145,7 @@ mod tests {
 			.expect("schema version should be readable");
 
 		assert_eq!(artifact_kind, "social_post");
-		assert_eq!(schema_version, "3");
+		assert_eq!(schema_version, "4");
 	}
 
 	#[test]
@@ -7094,6 +7277,64 @@ mod tests {
 			path: social_candidate_path,
 		})
 		.expect("social candidate artifact link should be recorded");
+
+		assert_eq!(summary.get("artifact_links"), Some(&1));
+	}
+
+	#[test]
+	fn ledger_artifact_link_records_control_plane_upgrade_candidate_after_schema_migration() {
+		let temp_dir = tempfile::tempdir().expect("temporary directory should be created");
+		let db_path = temp_dir.path().join("radar.sqlite3");
+		let candidate_path = temp_dir.path().join("upgrade.json");
+		let connection =
+			rusqlite::Connection::open(&db_path).expect("temporary ledger should open");
+
+		connection
+			.execute_batch(
+				"
+				CREATE TABLE artifact_link (
+				  repo TEXT NOT NULL,
+				  subject_kind TEXT NOT NULL CHECK (subject_kind IN ('commit', 'pr')),
+				  subject_id TEXT NOT NULL,
+				  artifact_kind TEXT NOT NULL CHECK (
+				    artifact_kind IN (
+				      'bundle',
+				      'analysis',
+				      'signal',
+				      'upstream_impact',
+				      'social_candidate',
+				      'social_post',
+				      'release_delta',
+				      'archive_manifest',
+				      'ledger_export'
+				    )
+				  ),
+				  path TEXT NOT NULL,
+				  sha256 TEXT NOT NULL,
+				  size_bytes INTEGER NOT NULL,
+				  created_at TEXT NOT NULL,
+				  PRIMARY KEY (repo, subject_kind, subject_id, artifact_kind, path)
+				);
+				",
+			)
+			.expect("legacy artifact link schema should be created");
+
+		drop(connection);
+
+		fs::write(&candidate_path, r#"{"schema":"control_plane_upgrade_candidate/v1"}"#)
+			.expect("upgrade candidate fixture should be written");
+		radar::ledger_bootstrap(&RadarLedgerBootstrapRequest { db_path: db_path.clone() })
+			.expect("ledger bootstrap should add control-plane upgrade artifact kind");
+
+		let summary = radar::ledger_artifact_link(&RadarLedgerArtifactLinkRequest {
+			db_path: db_path.clone(),
+			repo: "openai/codex".into(),
+			subject_kind: "pr".into(),
+			subject_id: "22414".into(),
+			artifact_kind: "control_plane_upgrade_candidate".into(),
+			path: candidate_path,
+		})
+		.expect("control-plane upgrade artifact link should be recorded");
 
 		assert_eq!(summary.get("artifact_links"), Some(&1));
 	}
@@ -7468,6 +7709,48 @@ mod tests {
 			"publisher_angle": "operator_impact",
 			"confidence": "confirmed",
 			"evidence": ["PR #22414 updates app-server endpoint handling."]
+		})
+	}
+
+	fn valid_control_plane_upgrade_candidate() -> Value {
+		serde_json::json!({
+			"schema": "control_plane_upgrade_candidate/v1",
+			"slug": "openai-codex-pr-22414-control-plane",
+			"repo": "openai/codex",
+			"status": "proposed",
+			"source_refs": {
+				"upstream_reviews": [
+					".agent/automations/decodex/cache/github/reviews/openai-codex-pr-22414.review.json"
+				],
+				"upstream_impacts": [
+					".agent/automations/decodex/cache/github/impact/openai-codex-pr-22414.json"
+				],
+				"urls": ["https://github.com/openai/codex/pull/22414"]
+			},
+			"observed_change": "Remote Codex can use Unix socket endpoints.",
+			"control_plane_impact": "compat_risk",
+			"upgrade_path": "compat_risk_mitigation",
+			"affected_surfaces": ["app-server protocol"],
+			"target_codex": {
+				"channel": "stable",
+				"version": "0.142.2",
+				"tag": "rust-v0.142.2",
+				"release_url": "https://github.com/openai/codex/releases/tag/rust-v0.142.2",
+				"compatibility_status": "needs_review",
+				"matrix_ref": "docs/reference/codex-compatibility-matrix.md#codex-01422"
+			},
+			"authority": {
+				"decision_contract_required": true,
+				"program_intake_required": true,
+				"mutation_allowed": false,
+				"objective_id": "decodex-self-iteration"
+			},
+			"reason": "The upstream app-server transport change may affect Decodex Control Plane compatibility.",
+			"validation_gates": ["decodex probe stdio://", "cargo test -p decodex app_server --lib"],
+			"stop_conditions": ["Missing accepted Decision Contract", "Probe failure against the target Codex build"],
+			"acceptance_criteria": [
+				"Compatibility impact is proven or dismissed with source-backed evidence."
+			]
 		})
 	}
 

--- a/automations/decodex/automations.toml
+++ b/automations/decodex/automations.toml
@@ -35,11 +35,13 @@ required_paths = [
   "automations/decodex/skills/codex-code-analysis/SKILL.md",
   "automations/decodex/skills/github-signal/SKILL.md",
   "automations/decodex/scripts/github/run_codex_analysis.py",
+  "automations/decodex/scripts/github/control_plane_upgrade_candidate.schema.json",
   "apps/decodex/src/radar.rs",
   "docs/spec/upstream-review.md",
   "docs/spec/github-change-bundle.md",
   "docs/spec/signal-entry.md",
   "docs/spec/upstream-impact.md",
+  "docs/spec/control-plane-upgrade-candidate.md",
   "docs/spec/social-candidate.md",
 ]
 required_cache_prefixes = [
@@ -47,6 +49,7 @@ required_cache_prefixes = [
   ".agent/automations/decodex/cache/github/bundles",
   ".agent/automations/decodex/cache/github/reviews",
   ".agent/automations/decodex/cache/github/impact",
+  ".agent/automations/decodex/cache/github/control-plane-upgrades",
   ".agent/automations/decodex/cache/generated/analysis",
   ".agent/automations/decodex/cache/site-content/signals",
 ]

--- a/automations/decodex/prompts/radar-review.md
+++ b/automations/decodex/prompts/radar-review.md
@@ -17,6 +17,7 @@ Required reads:
 - `docs/spec/github-change-bundle.md`
 - `docs/spec/signal-entry.md`
 - `docs/spec/upstream-impact.md`
+- `docs/spec/control-plane-upgrade-candidate.md`
 - `docs/spec/social-candidate.md`
 
 Workflow:
@@ -24,7 +25,9 @@ Workflow:
 2. Read `.agent/automations/decodex/cache/github/review-queue/openai-codex-latest.json` and select the smallest high-value batch that can finish in this run.
 3. For each selected subject, build or validate its bundle under `.agent/automations/decodex/cache/github/bundles`.
 4. Run Codex source analysis only through the explicit AI boundary in `automations/decodex/scripts/github/run_codex_analysis.py` or the Rust `cargo run --manifest-path apps/decodex/Cargo.toml --bin decodex -- radar` command that wraps it.
-5. Persist source-backed `upstream_review/v1`, optional `upstream_impact/v1`, optional `analysis_draft`, optional rendered `signal_entry/v1`, and optional `social_candidate/v1` under `.agent/automations/decodex/cache`.
+5. Persist source-backed `upstream_review/v1`, optional `upstream_impact/v1`, optional `control_plane_upgrade_candidate/v1`, optional `analysis_draft`, optional rendered `signal_entry/v1`, and optional `social_candidate/v1` under `.agent/automations/decodex/cache`.
+   - Write Control Plane upgrade candidates only under `.agent/automations/decodex/cache/github/control-plane-upgrades`.
+   - A Control Plane upgrade candidate is evidence for later Decision Contract and Program Intake work; it must not mutate Linear, GitHub, worktrees, project config, Codex installs, or Decodex source.
 6. Validate changed JSON with `cargo run --manifest-path apps/decodex/Cargo.toml --bin decodex -- radar validate` before terminal completion.
 
 Terminal report:

--- a/automations/decodex/scripts/github/README.md
+++ b/automations/decodex/scripts/github/README.md
@@ -49,6 +49,8 @@ Current checked contracts:
 - `upstream_review/v1` artifacts are validated by `decodex radar validate`.
 - `release_delta/v1` artifacts are validated by `decodex radar validate`.
 - `upstream_impact/v1` artifacts are validated by `decodex radar validate`.
+- `control_plane_upgrade_candidate/v1` artifacts are validated by
+  `decodex radar validate`.
 - `social_candidate/v1` artifacts are validated by `decodex radar validate`.
 - `social_publish_reservation/v1` artifacts are validated by
   `decodex radar validate`.
@@ -60,6 +62,8 @@ Contract ownership:
 - upstream review queue and AI review boundary: `docs/spec/upstream-review.md`
 - output signal shape: `docs/spec/signal-entry.md`
 - upstream impact shape: `docs/spec/upstream-impact.md`
+- Control Plane upgrade candidate shape:
+  `docs/spec/control-plane-upgrade-candidate.md`
 - social candidate shape: `docs/spec/social-candidate.md`
 - social publication shape: `docs/spec/social-publishing.md`
 
@@ -127,9 +131,10 @@ decodex radar backfill-release-range \
 Codex app automation or an explicit local operator run may refresh upstream queues,
 release deltas, and validation through `decodex radar ...`. Codex automation owns AI
 review of queued subjects and may then
-promote source-backed conclusions into `upstream_impact/v1`, `analysis_draft`,
-`decodex radar render-signal` output, or `social_candidate/v1`; Publisher automation
-writes terminal `social_post/v1` records.
+promote source-backed conclusions into `upstream_impact/v1`,
+`control_plane_upgrade_candidate/v1`, `analysis_draft`, `decodex radar render-signal`
+output, or `social_candidate/v1`; Publisher automation writes terminal
+`social_post/v1` records.
 
 Do not wire `run_codex_analysis.py` into GitHub Actions. Actions must not pass
 `--allow-ai-analysis-boundary` or set `DECODEX_ALLOW_CODEX_ANALYSIS`; that

--- a/automations/decodex/scripts/github/contracts.py
+++ b/automations/decodex/scripts/github/contracts.py
@@ -18,6 +18,7 @@ UPSTREAM_REVIEW_SCHEMA = "upstream_review/v1"
 SOCIAL_CANDIDATE_SCHEMA = "social_candidate/v1"
 SOCIAL_POST_SCHEMA = "social_post/v1"
 SOCIAL_PUBLISH_RESERVATION_SCHEMA = "social_publish_reservation/v1"
+CONTROL_PLANE_UPGRADE_CANDIDATE_SCHEMA = "control_plane_upgrade_candidate/v1"
 ANALYSIS_MODES = {"pr_first", "commit_only"}
 SIGNAL_KINDS = {"capability", "behavior_change", "try_now"}
 SIGNAL_CONFIDENCE = {"confirmed", "likely", "weak"}
@@ -32,8 +33,19 @@ UPSTREAM_REVIEW_ACTION_TYPES = {
     "upstream_impact",
     "signal_entry",
     "social_candidate",
-    "linear_followup",
+    "control_plane_upgrade_candidate",
 }
+CONTROL_PLANE_UPGRADE_IMPACTS = {"adopt_now", "candidate", "compat_risk"}
+CONTROL_PLANE_UPGRADE_PATHS = {"adopt_now", "compat_risk_mitigation", "discovery"}
+CONTROL_PLANE_UPGRADE_STATUSES = {"blocked", "deferred", "proposed", "superseded"}
+CODEX_COMPATIBILITY_STATUSES = {
+    "compatible",
+    "incompatible",
+    "needs_review",
+    "not_tested",
+    "unknown",
+}
+CODEX_TARGET_CHANNELS = {"main", "preview", "stable"}
 SOCIAL_POST_MODES = {
     "release_pulse",
     "release_rollup",
@@ -637,6 +649,123 @@ def validate_upstream_review(entry: dict[str, Any]) -> ValidationResult:
                 errors.append(f"next_actions[{index}].type must be one of {sorted(UPSTREAM_REVIEW_ACTION_TYPES)}")
             if not isinstance(action.get("reason"), str) or not action["reason"]:
                 errors.append(f"next_actions[{index}].reason must be a non-empty string")
+
+    return ValidationResult(ok=not errors, errors=errors)
+
+
+def validate_control_plane_upgrade_candidate(entry: dict[str, Any]) -> ValidationResult:
+    errors: list[str] = []
+
+    if entry.get("schema") != CONTROL_PLANE_UPGRADE_CANDIDATE_SCHEMA:
+        errors.append(f"schema must be {CONTROL_PLANE_UPGRADE_CANDIDATE_SCHEMA}")
+
+    for field in ("slug", "repo", "observed_change", "reason"):
+        if not isinstance(entry.get(field), str) or not entry[field]:
+            errors.append(f"{field} must be a non-empty string")
+
+    repo = entry.get("repo")
+    if isinstance(repo, str) and "/" not in repo:
+        errors.append("repo must be owner/name")
+
+    if entry.get("status") not in CONTROL_PLANE_UPGRADE_STATUSES:
+        errors.append(f"status must be one of {sorted(CONTROL_PLANE_UPGRADE_STATUSES)}")
+    if entry.get("control_plane_impact") not in CONTROL_PLANE_UPGRADE_IMPACTS:
+        errors.append(
+            f"control_plane_impact must be one of {sorted(CONTROL_PLANE_UPGRADE_IMPACTS)}"
+        )
+    if entry.get("upgrade_path") not in CONTROL_PLANE_UPGRADE_PATHS:
+        errors.append(f"upgrade_path must be one of {sorted(CONTROL_PLANE_UPGRADE_PATHS)}")
+
+    refs = entry.get("source_refs")
+    if not isinstance(refs, dict):
+        errors.append("source_refs must be an object")
+    else:
+        present = [
+            field
+            for field in ("upstream_reviews", "upstream_impacts", "release_deltas", "urls")
+            if isinstance(refs.get(field), list) and refs[field]
+        ]
+        if not present:
+            errors.append(
+                "source_refs must include upstream_reviews, upstream_impacts, release_deltas, or urls"
+            )
+        for field in ("upstream_reviews", "upstream_impacts", "release_deltas"):
+            values = refs.get(field, [])
+            if values and (
+                not isinstance(values, list)
+                or not all(isinstance(item, str) and item for item in values)
+            ):
+                errors.append(f"source_refs.{field} must be a list of non-empty strings")
+        urls = refs.get("urls", [])
+        if urls and (
+            not isinstance(urls, list)
+            or not all(isinstance(url, str) and url.startswith("https://") for url in urls)
+        ):
+            errors.append("source_refs.urls must be a list of https URLs")
+
+    target = entry.get("target_codex")
+    if not isinstance(target, dict):
+        errors.append("target_codex must be an object")
+    else:
+        if target.get("channel") not in CODEX_TARGET_CHANNELS:
+            errors.append(
+                f"target_codex.channel must be one of {sorted(CODEX_TARGET_CHANNELS)}"
+            )
+        if not any(
+            isinstance(target.get(field), str) and target[field]
+            for field in ("version", "tag", "commit_sha", "release_url")
+        ):
+            errors.append("target_codex must include version, tag, commit_sha, or release_url")
+        release_url = target.get("release_url")
+        if release_url is not None and (
+            not isinstance(release_url, str) or not release_url.startswith("https://")
+        ):
+            errors.append("target_codex.release_url must be an https URL when present")
+        compatibility_status = target.get("compatibility_status")
+        if (
+            compatibility_status is not None
+            and compatibility_status not in CODEX_COMPATIBILITY_STATUSES
+        ):
+            errors.append(
+                "target_codex.compatibility_status must be one of "
+                f"{sorted(CODEX_COMPATIBILITY_STATUSES)}"
+            )
+        for field in ("version", "tag", "commit_sha", "matrix_ref", "probe_evidence"):
+            value = target.get(field)
+            if value is not None and (not isinstance(value, str) or not value):
+                errors.append(f"target_codex.{field} must be non-empty when present")
+
+    authority = entry.get("authority")
+    if not isinstance(authority, dict):
+        errors.append("authority must be an object")
+    else:
+        if authority.get("decision_contract_required") is not True:
+            errors.append("authority.decision_contract_required must be true")
+        if authority.get("program_intake_required") is not True:
+            errors.append("authority.program_intake_required must be true")
+        if authority.get("mutation_allowed") is not False:
+            errors.append("authority.mutation_allowed must be false")
+        for field in ("objective_id", "objective_version", "policy_ref"):
+            value = authority.get(field)
+            if value is not None and (not isinstance(value, str) or not value):
+                errors.append(f"authority.{field} must be non-empty when present")
+
+    for list_field in ("affected_surfaces", "validation_gates", "stop_conditions"):
+        values = entry.get(list_field)
+        if (
+            not isinstance(values, list)
+            or not values
+            or not all(isinstance(item, str) and item for item in values)
+        ):
+            errors.append(f"{list_field} must be a non-empty list of strings")
+
+    for list_field in ("acceptance_criteria", "caveats", "next_steps"):
+        values = entry.get(list_field, [])
+        if values is not None and (
+            not isinstance(values, list)
+            or not all(isinstance(item, str) and item for item in values)
+        ):
+            errors.append(f"{list_field} must be a list of non-empty strings when present")
 
     return ValidationResult(ok=not errors, errors=errors)
 

--- a/automations/decodex/scripts/github/control_plane_upgrade_candidate.schema.json
+++ b/automations/decodex/scripts/github/control_plane_upgrade_candidate.schema.json
@@ -1,0 +1,233 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Decodex Control Plane upgrade candidate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "slug",
+    "repo",
+    "status",
+    "source_refs",
+    "observed_change",
+    "control_plane_impact",
+    "upgrade_path",
+    "affected_surfaces",
+    "target_codex",
+    "authority",
+    "reason",
+    "validation_gates",
+    "stop_conditions"
+  ],
+  "properties": {
+    "schema": {
+      "const": "control_plane_upgrade_candidate/v1"
+    },
+    "slug": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repo": {
+      "type": "string",
+      "pattern": "^[^/]+/[^/]+$"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["proposed", "deferred", "blocked", "superseded"]
+    },
+    "source_refs": {
+      "type": "object",
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": ["upstream_reviews"]
+        },
+        {
+          "required": ["upstream_impacts"]
+        },
+        {
+          "required": ["release_deltas"]
+        },
+        {
+          "required": ["urls"]
+        }
+      ],
+      "properties": {
+        "upstream_reviews": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "upstream_impacts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "release_deltas": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "urls": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^https://"
+          }
+        }
+      }
+    },
+    "observed_change": {
+      "type": "string",
+      "minLength": 1
+    },
+    "control_plane_impact": {
+      "type": "string",
+      "enum": ["candidate", "compat_risk", "adopt_now"]
+    },
+    "upgrade_path": {
+      "type": "string",
+      "enum": ["discovery", "compat_risk_mitigation", "adopt_now"]
+    },
+    "affected_surfaces": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "target_codex": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["channel"],
+      "anyOf": [
+        {
+          "required": ["version"]
+        },
+        {
+          "required": ["tag"]
+        },
+        {
+          "required": ["commit_sha"]
+        },
+        {
+          "required": ["release_url"]
+        }
+      ],
+      "properties": {
+        "channel": {
+          "type": "string",
+          "enum": ["stable", "preview", "main"]
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string",
+          "minLength": 1
+        },
+        "commit_sha": {
+          "type": "string",
+          "minLength": 1
+        },
+        "release_url": {
+          "type": "string",
+          "pattern": "^https://"
+        },
+        "compatibility_status": {
+          "type": "string",
+          "enum": ["compatible", "incompatible", "needs_review", "not_tested", "unknown"]
+        },
+        "matrix_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "probe_evidence": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision_contract_required", "program_intake_required", "mutation_allowed"],
+      "properties": {
+        "decision_contract_required": {
+          "const": true
+        },
+        "program_intake_required": {
+          "const": true
+        },
+        "mutation_allowed": {
+          "const": false
+        },
+        "objective_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "objective_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "validation_gates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "stop_conditions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "acceptance_criteria": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "caveats": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/automations/decodex/scripts/github/upstream_review.schema.json
+++ b/automations/decodex/scripts/github/upstream_review.schema.json
@@ -143,7 +143,13 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["none", "upstream_impact", "signal_entry", "social_candidate", "linear_followup"]
+            "enum": [
+              "none",
+              "upstream_impact",
+              "signal_entry",
+              "social_candidate",
+              "control_plane_upgrade_candidate"
+            ]
           },
           "reason": {
             "type": "string",

--- a/automations/decodex/skills/README.md
+++ b/automations/decodex/skills/README.md
@@ -49,8 +49,8 @@ those gaps belongs back in the upstream analysis stage.
 Default posture: track every upstream Codex commit as a possible evidence unit. Resolve
 commits back to PRs when possible, decide whether the change matters to Decodex Control
 Plane or the wider Codex community, and only then promote important, useful, or
-deprecated behavior into a signal, upstream-impact artifact, follow-up issue, or X
-post.
+deprecated behavior into a signal, upstream-impact artifact, Control Plane upgrade
+candidate, or X post.
 
 For upstream releases and prereleases, use `codex-release-analysis` as a rollup over
 the accumulated commit/PR analysis. Codex prerelease notes are often too sparse to
@@ -60,7 +60,7 @@ release metadata, compare metadata, and caveats create real reader value.
 
 Checked-in contracts for this workflow are `upstream_review_queue/v1`,
 `upstream_review/v1`, `github_change_bundle/v1`, `analysis_draft`, `signal_entry/v1`,
-`upstream_impact/v1`, `release_delta/v1`, `social_candidate/v1`, `social_post/v1`, and
-their supporting generated artifacts. The triage, code-analysis, and release-analysis
-skills are reasoning passes unless their conclusions are promoted into one of those
-contracts.
+`upstream_impact/v1`, `control_plane_upgrade_candidate/v1`, `release_delta/v1`,
+`social_candidate/v1`, `social_post/v1`, and their supporting generated artifacts. The
+triage, code-analysis, and release-analysis skills are reasoning passes unless their
+conclusions are promoted into one of those contracts.

--- a/automations/decodex/skills/codex-code-analysis/SKILL.md
+++ b/automations/decodex/skills/codex-code-analysis/SKILL.md
@@ -21,6 +21,7 @@ of redoing the source pass.
 - `docs/spec/github-change-bundle.md`
 - `docs/spec/upstream-review.md`
 - `docs/spec/upstream-impact.md`
+- `docs/spec/control-plane-upgrade-candidate.md`
 - `docs/spec/signal-entry.md`
 - `automations/decodex/skills/README.md`
 
@@ -35,7 +36,7 @@ of redoing the source pass.
 This skill may produce an `upstream_review/v1` when Codex automation is processing the
 continuous review queue. Keep ad hoc manual notes in-session unless they are promoted
 into `upstream_review/v1`, `analysis_draft`, `upstream_impact/v1`, or
-`social_candidate/v1`.
+`control_plane_upgrade_candidate/v1`, or `social_candidate/v1`.
 
 ## Analysis Loop
 
@@ -97,7 +98,8 @@ Return an analysis note that can feed `github-signal`, `codex-release-analysis`,
 - Publisher angle, if any
 - confidence and caveats
 - recommended next artifact: `none`, `analysis_draft` through `github-signal`,
-  `upstream_impact/v1`, or `social_candidate/v1`
+  `upstream_impact/v1`, `control_plane_upgrade_candidate/v1`, or
+  `social_candidate/v1`
 - downstream consumer gates: which artifacts are safe to consume and which claims still
   require source review
 

--- a/automations/decodex/skills/codex-upstream-triage/SKILL.md
+++ b/automations/decodex/skills/codex-upstream-triage/SKILL.md
@@ -17,6 +17,7 @@ Decodex plugin skill.
 - `docs/spec/github-change-bundle.md`
 - `docs/spec/upstream-review.md`
 - `docs/spec/upstream-impact.md`
+- `docs/spec/control-plane-upgrade-candidate.md`
 - `docs/runbook/local-github-signal-workflow.md`
 - `automations/decodex/skills/codex-code-analysis/SKILL.md`
 - `automations/decodex/skills/codex-release-analysis/SKILL.md`
@@ -96,7 +97,8 @@ Return a compact triage note with:
 - next skill to use
 - confidence limits
 
-Do not draft `signal_entry/v1`, `social_candidate/v1`, or `social_post/v1` directly
-from this skill. Do not treat deterministic queue hints as technical claims. The durable
-review layer is `upstream_review/v1`; public and Control Plane artifacts are promotions
-from that source-backed review.
+Do not draft `signal_entry/v1`, `control_plane_upgrade_candidate/v1`,
+`social_candidate/v1`, or `social_post/v1` directly from this skill. Do not treat
+deterministic queue hints as technical claims. The durable review layer is
+`upstream_review/v1`; public and Control Plane artifacts are promotions from that
+source-backed review.

--- a/automations/decodex/skills/github-signal/SKILL.md
+++ b/automations/decodex/skills/github-signal/SKILL.md
@@ -18,6 +18,7 @@ It consumes a reviewed bundle plus source-backed analysis and drafts the JSON th
 
 - `docs/spec/github-change-bundle.md`
 - `docs/spec/upstream-impact.md`
+- `docs/spec/control-plane-upgrade-candidate.md`
 - `docs/spec/signal-entry.md`
 - `docs/spec/social-publishing.md`
 - `docs/runbook/local-github-signal-workflow.md`
@@ -31,6 +32,8 @@ It consumes a reviewed bundle plus source-backed analysis and drafts the JSON th
   `automations/decodex/skills/codex-code-analysis/SKILL.md`
 - An output path under `.agent/automations/decodex/cache/generated/analysis/`
 - Optional upstream impact output under `.agent/automations/decodex/cache/github/impact/`
+- Optional Control Plane upgrade candidate output under
+  `.agent/automations/decodex/cache/github/control-plane-upgrades/`
 
 ## Companion Skill Routing
 
@@ -95,8 +98,11 @@ Write a JSON analysis draft with these fields:
 4. Draft the `analysis_draft` JSON under `.agent/automations/decodex/cache/generated/analysis/`.
 5. Draft or update an `upstream_impact/v1` artifact when the change affects Control Plane or
    Publisher follow-up.
-6. Render the final signal entry with `decodex radar render-signal`.
-7. Validate the published signal collection and site build.
+6. Draft or update `control_plane_upgrade_candidate/v1` only when source-backed
+   evidence shows Decodex may need adoption, compatibility mitigation, or discovery;
+   do not create Linear issues or mutate runtime state from this skill.
+7. Render the final signal entry with `decodex radar render-signal`.
+8. Validate the published signal collection and site build.
 
 ## Commands
 

--- a/docs/decisions/codex-upstream-radar-redesign.md
+++ b/docs/decisions/codex-upstream-radar-redesign.md
@@ -6,7 +6,7 @@ status: active
 authority: rationale
 owner: automation
 tags: [decision, radar]
-last_verified: 2026-06-25
+last_verified: 2026-06-27
 ---
 # Codex Upstream Radar Redesign
 
@@ -26,7 +26,8 @@ The new pipeline has four layers:
 2. Codex automation consumes that queue and performs AI source review for each queued
    subject.
 3. Source-backed reviews promote only valuable outcomes into `upstream_impact/v1`,
-   `signal_entry/v1`, `social_post/v1`, or Linear follow-up work.
+   `signal_entry/v1`, `social_post/v1`, or
+   `control_plane_upgrade_candidate/v1`.
 4. Release and prerelease summaries roll up accumulated commit and PR analysis instead
    of treating sparse release notes as enough evidence.
 
@@ -42,6 +43,9 @@ Consequences:
   Publisher promotions from source-backed review.
 - Decodex compatibility risks and adoption opportunities can be tracked before they
   become public content.
+- Control Plane upgrade work enters execution only through the candidate artifact,
+  Decision Contract, and Program Intake bridge; Radar review does not create Linear
+  issues directly.
 - Prerelease rollups can explain changes with prior commit/PR evidence even when the
   upstream prerelease has no release notes.
 - Raw bundles and review artifacts remain subject to the 21-day hot-window archive

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,11 @@ The split below is by question type, not by human-versus-agent audience.
 - Need the implementation order for objective-driven autonomy -> `docs/runbook/autonomy-implementation-roadmap.md`
 - Need current Decodex/Codex app-server protocol support
   evidence -> `docs/spec/app-server.md`
+- Need current Decodex-to-Codex version compatibility evidence ->
+  `docs/reference/codex-compatibility-matrix.md`
+- Need upstream Codex changes that may require Decodex Control Plane upgrade work ->
+  `docs/spec/control-plane-upgrade-candidate.md` and
+  `docs/runbook/control-plane-upgrade-workflow.md`
 - Need Decodex operator lane-control capability support, including inspect,
   pause/resume, scan, interrupt, steer, retained retry/resume, manual attention, or
   unsupported/deferred controls -> `docs/spec/lane-control.md`

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,18 @@
 # Documentation Log
 
+## 2026-06-27
+
+- Added `control_plane_upgrade_candidate/v1` as the evidence-only bridge from
+  upstream Codex Radar review into Decodex Control Plane upgrade work, including the
+  governing spec, upgrade workflow runbook, compatibility matrix reference, Radar
+  validation surface, automation prompt routing, and retention policy updates.
+- Refreshed the Codex compatibility matrix for local Decodex `0.2.0-35fa270f` against
+  Codex stable `0.142.2` and preview `0.143.0-alpha.25`, keeping version rows as
+  planning evidence while preserving capability probes as runtime authority.
+- Corrected repository ownership docs so `automations/decodex` is the repo-owned
+  source for upstream monitoring and guarded publishing automation, while recurring
+  Codex App execution and private generated state remain outside tracked source.
+
 ## 2026-06-25
 
 - Added the lightweight Deliberation Gate across the Codex workflow plugins:

--- a/docs/reference/codex-compatibility-matrix.md
+++ b/docs/reference/codex-compatibility-matrix.md
@@ -1,0 +1,58 @@
+---
+type: "Reference"
+title: "Codex Compatibility Matrix"
+description: "Record the current source-backed compatibility evidence between Decodex and upstream Codex CLI/app-server releases."
+status: active
+authority: current_state
+owner: automation
+tags: [reference, codex, compatibility]
+source_refs: [https://github.com/openai/codex/releases, https://www.npmjs.com/package/@openai/codex]
+code_refs: [apps/decodex/src/agent/app_server.rs, apps/decodex/src/radar.rs, docs/spec/app-server.md]
+drift_watch: [codex --version, npm view @openai/codex version dist-tags --json, decodex probe, release_delta/v1, control_plane_upgrade_candidate/v1]
+last_verified: 2026-06-27
+---
+# Codex Compatibility Matrix
+
+Purpose: Record the current source-backed compatibility evidence between Decodex and
+upstream Codex CLI/app-server releases.
+
+Read this when: You need to know which upstream Codex release Decodex has been tested
+against, or whether a preview release needs Radar review before Decodex adopts protocol
+or app-server changes.
+
+Not this document: The app-server protocol contract. Read
+[`../spec/app-server.md`](../spec/app-server.md). The upgrade artifact shape is
+[`../spec/control-plane-upgrade-candidate.md`](../spec/control-plane-upgrade-candidate.md).
+
+## Boundary
+
+This matrix is planning evidence, not runtime dispatch logic. Decodex must keep using
+capability probes, app-server preflight, targeted tests, and `decodex probe` as the
+authority for compatibility.
+
+Do not branch behavior only on a Codex version string. Version and tag rows exist to
+help Radar and operators decide what needs source review, not to bypass protocol
+validation.
+
+## Current Rows
+
+| Decodex build | Codex channel | Codex version/tag | Evidence | Status | Caveat |
+| --- | --- | --- | --- | --- | --- |
+| `0.2.0-35fa270f` | stable | `0.142.2`, `rust-v0.142.2` | Local `/opt/homebrew/bin/codex --version` reported `codex-cli 0.142.2`; `npm view @openai/codex version dist-tags --json` reported `latest = 0.142.2`; `decodex probe` returned `PROBE_OK` on 2026-06-27. | compatible | Probe evidence covers the local installed stable CLI/app-server path, not every upstream change since the prior reviewed release. |
+| `0.2.0-35fa270f` | preview | `0.143.0-alpha.25`, `rust-v0.143.0-alpha.25` | `npm view @openai/codex dist-tags` reported `alpha = 0.143.0-alpha.25`; `decodex radar refresh-release-delta --dry-run` identified the preview tag and a stable-to-preview compare window. | needs_review | Preview was not installed or probe-tested in this checkout. Radar must review app-server, MCP, plugin, sandbox, auth, browser, and config changes before Decodex treats the preview as compatible. |
+
+## Review Triggers
+
+Create or update `control_plane_upgrade_candidate/v1` when a Codex release, preview,
+PR, or commit touches any of these surfaces:
+
+- app-server protocol methods, events, JSON schema, or error behavior
+- dynamic tools, plugin discovery, MCP, browser, or Chrome integration
+- sandbox, approval, permission profiles, hooks, auth, or account state
+- config schema, model defaults, provider behavior, or CLI flags used by Decodex
+- app/server lifecycle behavior that affects `decodex serve`, `decodex app`, or
+  retained lanes
+
+Candidate creation is still evidence-only. Promotion to executable work requires the
+authority bridge in
+[`../spec/control-plane-upgrade-candidate.md`](../spec/control-plane-upgrade-candidate.md).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -21,6 +21,9 @@ Question this index answers: "how is it currently organized or implemented?"
 
 - [`build-test-run.md`](./build-test-run.md) for repo-native setup, build, test, run,
   validation, task-runner automation, and source-entrypoint commands.
+- [`codex-compatibility-matrix.md`](./codex-compatibility-matrix.md) for current
+  source-backed Decodex compatibility evidence against upstream Codex stable and
+  preview CLI/app-server releases.
 - [`docs-knowledge-map.md`](./docs-knowledge-map.md) for the current OKF/LLM Wiki
   knowledge-map shape, value evaluation, graph maintenance anchors, and owner-coverage
   observations.

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -6,7 +6,7 @@ status: active
 authority: current_state
 owner: docs
 tags: [reference]
-last_verified: 2026-06-18
+last_verified: 2026-06-27
 ---
 # Workspace Layout
 
@@ -32,6 +32,7 @@ For build, test, run, setup, validation, and task-runner command entrypoints, re
 | `apps/decodex/` | Rust package that builds the `decodex` CLI and runtime. Runtime, orchestration, tracker integration, app-server integration, operator HTTP, and local control-plane behavior live under `apps/decodex/src/`. |
 | `apps/decodex-app/` | SwiftPM macOS app for local Decodex Codex account-pool management. It talks to the bundled `decodex-app-helper`, which links the Rust account service directly, and does not own runtime scheduling or operator dashboard state. |
 | `site/` | Astro static site for the public Decodex product surface and app download entry. It is not backed by a live Decodex daemon and does not own upstream monitoring or public publishing automation. |
+| `automations/decodex/` | Repo-local source for Codex App automations that monitor upstream Codex, curate Decodex Radar artifacts, and drive guarded public publishing candidates. Active recurring automation configs live under the operator's Codex home; generated artifacts stay under `.agent/automations/decodex/cache`. |
 | `scripts/assets/` | Asset-generation helpers for checked-in app and tray icon assets. |
 | `scripts/macos/` | macOS-only app packaging and local bundle verification helpers. |
 | `plugins/decodex/` | Canonical installable Decodex lifecycle plugin source. It owns research, issue briefing, planning, runtime ops, commit, and land. |
@@ -88,7 +89,8 @@ The site does not own:
 - upstream monitoring
 - public publishing automation
 
-Those runtime and operator surfaces stay in `apps/decodex/` and `docs/spec/`.
+Those runtime, automation, and operator surfaces stay in `apps/decodex/`,
+`automations/decodex/`, and `docs/spec/`.
 
 ## Installable Codex surface
 

--- a/docs/runbook/control-plane-upgrade-workflow.md
+++ b/docs/runbook/control-plane-upgrade-workflow.md
@@ -1,0 +1,99 @@
+---
+type: "Runbook"
+title: "Control Plane Upgrade Workflow"
+description: "Operate the bridge from upstream Codex Radar evidence to Decodex Control Plane upgrade work."
+status: active
+authority: procedural
+owner: automation
+tags: [runbook, radar, control-plane]
+code_refs: [automations/decodex/prompts/radar-review.md, automations/decodex/automations.toml, apps/decodex/src/radar.rs]
+drift_watch: [control_plane_upgrade_candidate/v1, Codex compatibility matrix, decodex probe, Program Intake, Decision Contract]
+last_verified: 2026-06-27
+---
+# Control Plane Upgrade Workflow
+
+Purpose: Operate the bridge from upstream Codex Radar evidence to Decodex Control Plane
+upgrade work.
+
+Read this when: Radar finds an upstream Codex app-server, protocol, MCP, plugin,
+browser, sandbox, auth, config, or CLI change that may affect Decodex.
+
+Not this document: The artifact schema. Read
+[`../spec/control-plane-upgrade-candidate.md`](../spec/control-plane-upgrade-candidate.md).
+The current tested Codex versions are recorded in
+[`../reference/codex-compatibility-matrix.md`](../reference/codex-compatibility-matrix.md).
+
+## Preconditions
+
+- Decodex App, CLI, and `decodex serve` are installed from the intended Decodex build.
+- `decodex probe` passes against the local Codex app-server path.
+- Radar Review automation is active and its prompt matches
+  `automations/decodex/prompts/radar-review.md`.
+- Generated Radar artifacts stay under `.agent/automations/decodex/cache`.
+
+## Sequence
+
+1. Refresh upstream source state:
+
+   ```sh
+   decodex radar refresh-upstream-queue --repo openai/codex
+   decodex radar refresh-release-delta --repo openai/codex
+   ```
+
+2. Review high-priority queue subjects through the Radar Review automation or an
+   explicit operator-run Codex analysis pass.
+
+3. Persist source-backed `upstream_review/v1`. When a reviewed change affects Decodex
+   compatibility or adoption, also persist `upstream_impact/v1`.
+
+4. If `control_plane_impact` is `candidate`, `compat_risk`, or `adopt_now`, write a
+   `control_plane_upgrade_candidate/v1` artifact under:
+
+   ```text
+   .agent/automations/decodex/cache/github/control-plane-upgrades/
+   ```
+
+5. Validate the changed artifacts:
+
+   ```sh
+   decodex radar validate \
+     .agent/automations/decodex/cache/github/reviews \
+     .agent/automations/decodex/cache/github/impact \
+     .agent/automations/decodex/cache/github/control-plane-upgrades
+   ```
+
+6. Update [`../reference/codex-compatibility-matrix.md`](../reference/codex-compatibility-matrix.md)
+   when the candidate changes the known stable or preview compatibility state.
+
+7. Promote only through normal authority:
+
+   - accepted Decision Contract
+   - Program Intake
+   - normal Decodex lane execution
+   - normal validation, review, land, install, restart, and plugin-sync gates
+
+   Accepted autonomy project policy may authorize drafting, challenge, or acceptance
+   of a Decision Contract candidate. It does not replace the accepted Decision Contract
+   in the execution path.
+
+## Stop Conditions
+
+Do not promote a candidate when any of these is true:
+
+- no source-backed `upstream_review/v1` exists
+- the candidate has no target Codex version, tag, commit, or release URL
+- `authority.mutation_allowed` is not `false`
+- `decision_contract_required` or `program_intake_required` is not `true`
+- `decodex probe` fails for the tested Codex path
+- affected surfaces are too broad to validate in one coherent lane
+- compatibility depends on private or unobservable upstream rollout state
+
+## Operator Notes
+
+Radar Review may propose upgrade candidates, but it does not install Codex, modify
+Decodex source, restart services, open PRs, create Linear issues, or enqueue Program
+nodes. Those actions belong to the normal Decodex execution lifecycle after promotion.
+
+When a candidate is only a watch item, keep it as `status = "deferred"` or leave the
+upstream impact at `control_plane_impact = "watch"` without creating an executable
+lane.

--- a/docs/runbook/index.md
+++ b/docs/runbook/index.md
@@ -30,6 +30,9 @@ Question this index answers: "which sequence should I execute?"
   implementing objective-driven Decodex autonomy from Objective Contracts through
   signals, proposal dry-runs, Decision Contract promotion, Program Intake, operator
   readback, MCP exposure, and self-dogfood.
+- [`control-plane-upgrade-workflow.md`](./control-plane-upgrade-workflow.md) for
+  operating the bridge from upstream Codex Radar evidence to Decodex Control Plane
+  upgrade candidates, Decision Contract promotion, and Program Intake.
 - [`github-pages-deploy.md`](./github-pages-deploy.md) for GitHub Pages deployment and
   `decodex.space` custom-domain setup for the static public site.
 - [`linear-archive-hygiene.md`](./linear-archive-hygiene.md) for dry-run-first

--- a/docs/runbook/radar-artifact-archive.md
+++ b/docs/runbook/radar-artifact-archive.md
@@ -6,7 +6,7 @@ status: active
 authority: procedural
 owner: automation
 tags: [runbook, radar]
-last_verified: 2026-06-25
+last_verified: 2026-06-27
 ---
 # Radar Artifact Archive
 
@@ -37,6 +37,8 @@ Do not archive these as part of raw cleanup:
 - `.agent/automations/decodex/cache/site-content/signals/*.json`
 - the current `.agent/automations/decodex/cache/site-content/release-deltas/openai-codex-latest.json`
 - `.agent/automations/decodex/cache/github/impact/*.json` with active Control Plane or Publisher relevance
+- `.agent/automations/decodex/cache/github/control-plane-upgrades/*.json` with active
+  Control Plane review relevance
 - `.agent/automations/decodex/cache/social/x/posts/*.json`
 - `.agent/automations/decodex/cache/archive/index/*.json`
 

--- a/docs/spec/control-plane-upgrade-candidate.md
+++ b/docs/spec/control-plane-upgrade-candidate.md
@@ -1,0 +1,145 @@
+---
+type: "Spec"
+title: "Control Plane Upgrade Candidate"
+description: "Define the evidence-only artifact that turns upstream Codex changes into Decodex Control Plane upgrade candidates."
+status: active
+authority: normative
+owner: automation
+tags: [spec, radar, control-plane]
+code_refs: [apps/decodex/src/radar.rs, automations/decodex/scripts/github/control_plane_upgrade_candidate.schema.json]
+drift_watch: [control_plane_upgrade_candidate/v1, control_plane_upgrade_candidate, control-plane-upgrades, Codex compatibility matrix, Decision Contract, Program Intake]
+last_verified: 2026-06-27
+---
+# Control Plane Upgrade Candidate
+
+Purpose: Define the evidence-only artifact that turns upstream Codex changes into
+Decodex Control Plane upgrade candidates.
+
+Status: normative
+
+Read this when:
+- You are deciding whether an upstream Codex change should trigger Decodex runtime,
+  app-server, plugin, MCP, browser, sandbox, config, or automation upgrade work.
+- You are validating Radar artifacts under
+  `.agent/automations/decodex/cache/github/control-plane-upgrades/`.
+- You are bridging Codex release monitoring into Decodex Program Intake.
+
+Not this document:
+- The upstream review source-analysis boundary. Read [`upstream-review.md`](./upstream-review.md).
+- The editorial impact shape. Read [`upstream-impact.md`](./upstream-impact.md).
+- The project-autonomy authority model. Read
+  [`autonomy-control-plane.md`](./autonomy-control-plane.md).
+- The upgrade procedure. Read
+  [`../runbook/control-plane-upgrade-workflow.md`](../runbook/control-plane-upgrade-workflow.md).
+
+Defines:
+- The `control_plane_upgrade_candidate/v1` artifact.
+- The rule that upstream Radar automation may propose upgrade candidates but must not
+  directly mutate Decodex execution, tracker, GitHub, source, installs, or runtime
+  authority.
+- The bridge from upstream Codex compatibility evidence into Decision Contract and
+  Program Intake.
+
+## Artifact Identity
+
+The canonical schema identifier is:
+
+- `control_plane_upgrade_candidate/v1`
+
+Recommended checked-in location:
+
+- `.agent/automations/decodex/cache/github/control-plane-upgrades/<source-slug>.json`
+
+Rust validation entrypoint:
+
+- `decodex radar validate`
+
+## Required Fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `schema` | string | Must be `control_plane_upgrade_candidate/v1`. |
+| `slug` | string | Stable URL-safe identifier. |
+| `repo` | string | Upstream repository, normally `openai/codex`. |
+| `status` | string | `proposed`, `deferred`, `blocked`, or `superseded`. |
+| `source_refs` | object | Upstream review, impact, release-delta, or URL evidence. |
+| `observed_change` | string | One factual sentence about the upstream change. |
+| `control_plane_impact` | string | `adopt_now`, `candidate`, or `compat_risk`. |
+| `upgrade_path` | string | `adopt_now`, `compat_risk_mitigation`, or `discovery`. |
+| `affected_surfaces` | array | Non-empty Decodex surfaces that may need work. |
+| `target_codex` | object | Codex channel/version/tag/commit/release evidence. |
+| `authority` | object | Decision Contract and Program Intake guard fields. |
+| `reason` | string | Why this candidate exists. |
+| `validation_gates` | array | Non-empty commands or checks required before adoption. |
+| `stop_conditions` | array | Non-empty conditions that prevent unattended promotion. |
+
+Optional fields:
+
+- `acceptance_criteria`: checks that would make the candidate ready for promotion.
+- `caveats`: uncertainty, rollout limits, or source gaps.
+- `next_steps`: evidence-gathering or review steps that still preserve the candidate as
+  non-executable.
+
+## Source References
+
+`source_refs` must include at least one of:
+
+- `upstream_reviews`
+- `upstream_impacts`
+- `release_deltas`
+- `urls`
+
+`urls` must use HTTPS. Local generated artifact references should use repository-relative
+paths under `.agent/automations/decodex/cache`.
+
+## Target Codex
+
+`target_codex` must name the upstream target with at least one of:
+
+- `version`
+- `tag`
+- `commit_sha`
+- `release_url`
+
+`channel` must be `stable`, `preview`, or `main`. `compatibility_status`, when present,
+must be one of `compatible`, `incompatible`, `needs_review`, `not_tested`, or `unknown`.
+`matrix_ref` should point to [`../reference/codex-compatibility-matrix.md`](../reference/codex-compatibility-matrix.md)
+when the candidate is tied to a known Codex release or preview.
+
+The compatibility matrix is planning evidence. It must not become version-string
+dispatch logic. Runtime compatibility remains capability-probed through Decodex app-server
+preflight, `decodex probe`, and the relevant validation gates.
+
+## Authority Guard
+
+`authority` must set:
+
+- `decision_contract_required = true`
+- `program_intake_required = true`
+- `mutation_allowed = false`
+
+These fields make the artifact evidence-only. A candidate cannot create Linear issues,
+enqueue Program nodes, mutate GitHub, edit worktrees, install Codex or Decodex, restart
+servers, change project config, or write runtime authority rows. Executable promotion
+requires an accepted Decision Contract and then Program Intake. Accepted project
+autonomy policy may authorize drafting, challenging, or accepting a Decision Contract;
+it does not replace the accepted Decision Contract for execution.
+
+## Relationship To Other Artifacts
+
+`control_plane_upgrade_candidate/v1` may consume:
+
+- `upstream_review/v1`
+- `upstream_impact/v1`
+- `release_delta/v1`
+- official Codex release URLs
+- source-backed local validation evidence
+
+It may later support:
+
+- a latent research contract
+- an accepted Decision Contract
+- Program Intake
+- normal executable Decodex lanes
+
+It does not replace those artifacts.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -62,6 +62,9 @@ Then keep the body explicit:
   objective-driven project autonomy control plane, Objective Contract boundary,
   signal and proposal schemas, MCP action matrix, memory boundary, and self-dogfood
   limits.
+- [`control-plane-upgrade-candidate.md`](./control-plane-upgrade-candidate.md) defines
+  the evidence-only Radar artifact that bridges upstream Codex changes into Decodex
+  Control Plane upgrade candidates.
 - [`runtime.md`](./runtime.md) defines the runtime state model, reconciliation rules, and
   tracker writeback boundaries.
 - [`app-server.md`](./app-server.md) defines the direct Codex `app-server` interaction

--- a/docs/spec/radar-artifact-retention.md
+++ b/docs/spec/radar-artifact-retention.md
@@ -6,7 +6,7 @@ status: active
 authority: normative
 owner: automation
 tags: [spec, radar]
-last_verified: 2026-06-25
+last_verified: 2026-06-27
 ---
 # Radar Artifact Retention
 
@@ -41,7 +41,7 @@ Decodex uses three retention classes for Radar and Publisher data.
 | Class | Storage | Examples | Retention |
 | --- | --- | --- | --- |
 | Hot raw artifacts | Operations cache | `.agent/automations/decodex/cache/github/bundles/*.json`, `.agent/automations/decodex/cache/github/reviews/*.review.json`, `.agent/automations/decodex/cache/generated/analysis/*.analysis.json` | At most 21 days in hot cache after collection or publication. |
-| Warm curated artifacts | Operations cache | `.agent/automations/decodex/cache/site-content/signals/*.json`, `.agent/automations/decodex/cache/site-content/release-deltas/openai-codex-latest.json`, `.agent/automations/decodex/cache/github/impact/*.json`, `.agent/automations/decodex/cache/social/x/posts/*.json` | Retained while they are part of the public snapshot, Control Plane review trail, Publisher record, or cap analysis. |
+| Warm curated artifacts | Operations cache | `.agent/automations/decodex/cache/site-content/signals/*.json`, `.agent/automations/decodex/cache/site-content/release-deltas/openai-codex-latest.json`, `.agent/automations/decodex/cache/github/impact/*.json`, `.agent/automations/decodex/cache/github/control-plane-upgrades/*.json`, `.agent/automations/decodex/cache/social/x/posts/*.json` | Retained while they are part of the public snapshot, Control Plane review trail, Publisher record, or cap analysis. |
 | Cold raw archive | `.agent/automations/decodex/cache/archive` manifest plus optional external assets | Archived bundle and analysis batches, optional source snapshots, optional ledger exports | Retained outside hot cache. The manifest stays in `.agent/automations/decodex/cache/archive/index`. |
 
 The hot raw window is intentionally short. Continuous Radar should keep every upstream
@@ -71,6 +71,8 @@ Keep these artifacts in cache unless a separate content cleanup explicitly remov
 - the current homepage `release_delta/v1` artifact
 - the latest `upstream_review_queue/v1` artifact under `.agent/automations/decodex/cache/github/review-queue/`
 - `upstream_impact/v1` records that affect Decodex Control Plane or Publisher follow-up
+- `control_plane_upgrade_candidate/v1` records that preserve Control Plane upgrade
+  review, deferral, blocker, or supersession evidence
 - `social_candidate/v1` records that preserve `publish`, `defer`, or `skip` Publisher
   intake decisions
 - `social_post/v1` records, including daily-cap blocks

--- a/docs/spec/upstream-impact.md
+++ b/docs/spec/upstream-impact.md
@@ -6,7 +6,7 @@ status: active
 authority: normative
 owner: automation
 tags: [spec, radar]
-last_verified: 2026-06-25
+last_verified: 2026-06-27
 ---
 # Upstream Impact
 
@@ -29,6 +29,8 @@ Not this document:
 - The social publishing schema. Read [`social-publishing.md`](./social-publishing.md).
 - The social candidate handoff schema. Read
   [`social-candidate.md`](./social-candidate.md).
+- The Control Plane upgrade candidate schema. Read
+  [`control-plane-upgrade-candidate.md`](./control-plane-upgrade-candidate.md).
 - The operator procedure for publishing. Read
   [`../runbook/social-publishing-workflow.md`](../runbook/social-publishing-workflow.md).
 
@@ -65,7 +67,8 @@ Recommended checked-in location:
 
 Optional fields:
 
-- `candidate_followups`: bounded engineering or research follow-up suggestions.
+- `candidate_followups`: bounded evidence-gathering suggestions for a later
+  `control_plane_upgrade_candidate/v1`; they are not executable work.
 - `social_notes`: notes useful to a later `social_candidate/v1` or terminal
   `social_post/v1`.
 - `caveats`: uncertainty, version gating, platform limits, or rollout limits.
@@ -122,6 +125,6 @@ summary.
   change came from continuous Radar.
 - It may support a `signal_entry/v1`.
 - It may support a `social_candidate/v1` or terminal `social_post/v1`.
-- It may justify a later Linear issue or implementation brief.
+- It may justify a later `control_plane_upgrade_candidate/v1`.
 
 It does not replace any of those artifacts.

--- a/docs/spec/upstream-review.md
+++ b/docs/spec/upstream-review.md
@@ -6,7 +6,7 @@ status: active
 authority: normative
 owner: automation
 tags: [spec, radar]
-last_verified: 2026-06-25
+last_verified: 2026-06-27
 ---
 # Upstream Review
 
@@ -25,6 +25,8 @@ Read this when:
 Not this document:
 - The normalized GitHub source bundle schema. Read [`github-change-bundle.md`](./github-change-bundle.md).
 - The Control Plane and Publisher impact shape. Read [`upstream-impact.md`](./upstream-impact.md).
+- The Control Plane upgrade candidate shape. Read
+  [`control-plane-upgrade-candidate.md`](./control-plane-upgrade-candidate.md).
 - The public signal schema. Read [`signal-entry.md`](./signal-entry.md).
 - The raw artifact archive policy. Read [`radar-artifact-retention.md`](./radar-artifact-retention.md).
 
@@ -33,7 +35,8 @@ Defines:
 - The AI-owned `upstream_review/v1` artifact.
 - The rule that release and prerelease tags are rollup checkpoints over commit and PR
   evidence, not first-class discovery roots.
-- The promotion boundary from upstream review into impact, site, social, or Linear work.
+- The promotion boundary from upstream review into impact, site, social, or Control
+  Plane upgrade candidate work.
 
 ## Core rule
 
@@ -69,8 +72,9 @@ Recommended checked-in location:
 - `.agent/automations/decodex/cache/github/reviews/<source-slug>.review.json`
 
 Review artifacts are hot Radar artifacts unless they are promoted into
-`upstream_impact/v1`, `signal_entry/v1`, `social_candidate/v1`, or a Linear follow-up.
-Apply the 21-day hot-window rule from [`radar-artifact-retention.md`](./radar-artifact-retention.md).
+`upstream_impact/v1`, `signal_entry/v1`, `social_candidate/v1`, or
+`control_plane_upgrade_candidate/v1`. Apply the 21-day hot-window rule from
+[`radar-artifact-retention.md`](./radar-artifact-retention.md).
 
 ## Queue requirements
 
@@ -122,7 +126,7 @@ or public value.
 - confidence: `confirmed`, `likely`, or `weak`
 - source-backed evidence notes
 - next actions, each mapped to `none`, `upstream_impact`, `signal_entry`,
-  `social_candidate`, or `linear_followup`
+  `social_candidate`, or `control_plane_upgrade_candidate`
 
 AI review must read enough source evidence to explain behavior. A PR title, release
 title, or deterministic queue hint is not enough for a confirmed claim.
@@ -145,7 +149,9 @@ Promote an upstream review into:
   behavior, try path, or migration value.
 - `social_candidate/v1` when there is a clear public angle and source links are
   available. Publisher later decides whether to write terminal `social_post/v1`.
-- a Linear issue when Decodex should adopt, guard, migrate, or investigate the change.
+- `control_plane_upgrade_candidate/v1` when Decodex should adopt, guard, migrate, or
+  investigate the change. The candidate remains evidence-only until Decision Contract
+  and Program Intake promotion.
 
 Do not promote low-value internal churn into public artifacts. Keep it traceable in the
 ledger and use it only as release-rollup background if later evidence makes it relevant.


### PR DESCRIPTION
## Summary

- Add `control_plane_upgrade_candidate/v1` as the evidence-only bridge from upstream Codex Radar review to Decodex Control Plane upgrade work.
- Replace the stale `linear_followup` route with `control_plane_upgrade_candidate` across Rust validation, Python contracts, JSON schema, Radar prompt, automation manifest, and repo-local skills.
- Add the governing spec, upgrade workflow runbook, Codex compatibility matrix, retention updates, and docs routing.

## Validation

- `cargo test -p decodex radar::tests --lib`
- `cargo run -p decodex --bin decodex -- docs lint`
- `python3 -m py_compile automations/decodex/scripts/github/contracts.py`
- Python validator smoke for `control_plane_upgrade_candidate/v1`
- `decodex radar validate` on a temporary `control_plane_upgrade_candidate/v1` fixture
- `git diff --check`

## Notes

`python3 automations/decodex/scripts/config/evaluate_automations.py --json` is intentionally not a passing worktree gate before merge: the live Codex App automation configs are bound to `/Users/x/code/y/hack-ink/decodex` on main, while this PR runs in `.worktrees/decodex-autonomy-radar-bridge`. After land, run the evaluator from the main checkout and sync the live Radar Review prompt if needed.
