### PR TITLE
XY-1094: Decodex program-intake dispatchable nodes are not consistently bridged to queue/run/live status

### DIFF
--- a/apps/decodex/src/cli.rs
+++ b/apps/decodex/src/cli.rs
@@ -29,7 +29,13 @@ use crate::{
 	},
 	prelude::{Result, eyre},
 	program_intake::{self, GoalIntakeCommandRequest, IssueBatchIntakeCommandRequest},
-	radar,
+	radar::{
+		self, RadarBackfillReleaseRangeRequest, RadarBundleBuildRequest,
+		RadarBundleValidateRequest, RadarLedgerArtifactLinkRequest, RadarLedgerBootstrapRequest,
+		RadarLedgerIngestExistingRequest, RadarLedgerIngestRequest, RadarLedgerSummaryRequest,
+		RadarRefreshQueueRequest, RadarRefreshReleaseDeltaRequest, RadarRenderSignalRequest,
+		RadarSocialReservePublishRequest, RadarValidateRequest,
+	},
 	recovery::{
 		self, GhostLaneCleanupRequest, GhostLaneDiagnoseRequest, LegacyCloseoutRecoveryRequest,
 		MergedCloseoutRecoveryRequest, ReviewHandoffAdoptRequest, ReviewHandoffDiagnoseRequest,
@@ -318,19 +324,16 @@ impl AccountCommand {
 	fn run(&self) -> Result<()> {
 		match &self.command {
 			AccountSubcommand::List(args) => accounts::run_account_list(args.json),
-			AccountSubcommand::Select(args) => {
-				accounts::run_account_select(&args.selector, args.json)
-			},
+			AccountSubcommand::Select(args) =>
+				accounts::run_account_select(&args.selector, args.json),
 			AccountSubcommand::Clear(args) => accounts::run_account_clear(args.json),
-			AccountSubcommand::Logout(args) => {
-				accounts::run_account_logout(&args.selector, args.json)
-			},
-			AccountSubcommand::ImportAuth(args) => {
+			AccountSubcommand::Logout(args) =>
+				accounts::run_account_logout(&args.selector, args.json),
+			AccountSubcommand::ImportAuth(args) =>
 				accounts::run_account_import(&AccountImportRequest {
 					auth_json_path: args.auth_json.clone(),
 					json: args.json,
-				})
-			},
+				}),
 			AccountSubcommand::Use(args) => accounts::run_account_use(&AccountUseRequest {
 				selector: args.selector.clone(),
 				auth_json_path: args.auth_json.clone(),
@@ -1170,12 +1173,11 @@ struct ReviewHandoffRecoveryCommand {
 impl ReviewHandoffRecoveryCommand {
 	fn run(&self, config_path: Option<&Path>) -> Result<()> {
 		match &self.command {
-			ReviewHandoffRecoverySubcommand::Diagnose(args) => {
+			ReviewHandoffRecoverySubcommand::Diagnose(args) =>
 				recovery::run_review_handoff_diagnose(
 					config_path,
 					&ReviewHandoffDiagnoseRequest { issue: args.issue.clone(), json: args.json },
-				)
-			},
+				),
 			ReviewHandoffRecoverySubcommand::Rebind(args) => recovery::run_review_handoff_rebind(
 				config_path,
 				&ReviewHandoffRebindRequest {
@@ -1355,7 +1357,7 @@ struct RadarValidateCommand {
 }
 impl RadarValidateCommand {
 	fn run(&self) -> Result<()> {
-		let report = radar::validate(&radar::RadarValidateRequest { paths: self.paths.clone() })?;
+		let report = radar::validate(&RadarValidateRequest { paths: self.paths.clone() })?;
 
 		println!("{report:#?}");
 
@@ -1392,7 +1394,7 @@ struct RadarRefreshUpstreamQueueCommand {
 }
 impl RadarRefreshUpstreamQueueCommand {
 	fn run(&self) -> Result<()> {
-		let report = radar::refresh_queue(&radar::RadarRefreshQueueRequest {
+		let report = radar::refresh_queue(&RadarRefreshQueueRequest {
 			repo: self.repo.clone(),
 			search_limit: self.search_limit,
 			signals_dir: self.signals_dir.clone(),
@@ -1442,7 +1444,7 @@ struct RadarRefreshReleaseDeltaCommand {
 }
 impl RadarRefreshReleaseDeltaCommand {
 	fn run(&self) -> Result<()> {
-		let report = radar::refresh_release_delta(&radar::RadarRefreshReleaseDeltaRequest {
+		let report = radar::refresh_release_delta(&RadarRefreshReleaseDeltaRequest {
 			repo: self.repo.clone(),
 			signals_dir: self.signals_dir.clone(),
 			out: self.out.clone(),
@@ -1494,7 +1496,7 @@ struct RadarBundleBuildCommand {
 }
 impl RadarBundleBuildCommand {
 	fn run(&self) -> Result<()> {
-		let out = radar::build_bundle(&radar::RadarBundleBuildRequest {
+		let out = radar::build_bundle(&RadarBundleBuildRequest {
 			repo: self.repo.clone(),
 			pr: self.pr,
 			commit: self.commit.clone(),
@@ -1517,9 +1519,8 @@ struct RadarBundleValidateCommand {
 }
 impl RadarBundleValidateCommand {
 	fn run(&self) -> Result<()> {
-		let report = radar::validate_bundles(&radar::RadarBundleValidateRequest {
-			paths: self.paths.clone(),
-		})?;
+		let report =
+			radar::validate_bundles(&RadarBundleValidateRequest { paths: self.paths.clone() })?;
 
 		println!("{report:#?}");
 
@@ -1587,7 +1588,7 @@ struct RadarSocialReservePublishCommand {
 }
 impl RadarSocialReservePublishCommand {
 	fn run(&self) -> Result<()> {
-		let report = radar::reserve_social_publish(&radar::RadarSocialReservePublishRequest {
+		let report = radar::reserve_social_publish(&RadarSocialReservePublishRequest {
 			slug: self.slug.clone(),
 			mode: self.mode.clone(),
 			idempotency_key: self.idempotency_key.clone(),
@@ -1626,7 +1627,7 @@ struct RadarRenderSignalCommand {
 }
 impl RadarRenderSignalCommand {
 	fn run(&self) -> Result<()> {
-		let report = radar::render_signal(&radar::RadarRenderSignalRequest {
+		let report = radar::render_signal(&RadarRenderSignalRequest {
 			bundle: self.bundle.clone(),
 			analysis: self.analysis.clone(),
 			out: self.out.clone(),
@@ -1694,7 +1695,7 @@ struct RadarBackfillReleaseRangeCommand {
 }
 impl RadarBackfillReleaseRangeCommand {
 	fn run(&self) -> Result<()> {
-		let report = radar::backfill_release_range(&radar::RadarBackfillReleaseRangeRequest {
+		let report = radar::backfill_release_range(&RadarBackfillReleaseRangeRequest {
 			repo: self.repo.clone(),
 			release_delta: self.release_delta.clone(),
 			stable_tag: self.stable_tag.clone(),
@@ -1744,7 +1745,7 @@ struct RadarLedgerBootstrapCommand {
 }
 impl RadarLedgerBootstrapCommand {
 	fn run(&self) -> Result<()> {
-		radar::ledger_bootstrap(&radar::RadarLedgerBootstrapRequest {
+		radar::ledger_bootstrap(&RadarLedgerBootstrapRequest {
 			db_path: self.db_path.clone().unwrap_or_else(radar::default_ledger_path),
 		})?;
 
@@ -1765,7 +1766,7 @@ struct RadarLedgerIngestCommand {
 }
 impl RadarLedgerIngestCommand {
 	fn run(&self) -> Result<()> {
-		let summary = radar::ledger_ingest(&radar::RadarLedgerIngestRequest {
+		let summary = radar::ledger_ingest(&RadarLedgerIngestRequest {
 			db_path: self.db_path.clone().unwrap_or_else(radar::default_ledger_path),
 			bundle_path: self.bundle_path.clone(),
 			analysis_path: self.analysis_path.clone(),
@@ -1803,7 +1804,7 @@ struct RadarLedgerIngestExistingCommand {
 }
 impl RadarLedgerIngestExistingCommand {
 	fn run(&self) -> Result<()> {
-		let summary = radar::ledger_ingest_existing(&radar::RadarLedgerIngestExistingRequest {
+		let summary = radar::ledger_ingest_existing(&RadarLedgerIngestExistingRequest {
 			db_path: self.db_path.clone().unwrap_or_else(radar::default_ledger_path),
 			bundles_dir: self.bundles_dir.clone(),
 			analysis_dir: self.analysis_dir.clone(),
@@ -1833,7 +1834,7 @@ struct RadarLedgerArtifactLinkCommand {
 }
 impl RadarLedgerArtifactLinkCommand {
 	fn run(&self) -> Result<()> {
-		let summary = radar::ledger_artifact_link(&radar::RadarLedgerArtifactLinkRequest {
+		let summary = radar::ledger_artifact_link(&RadarLedgerArtifactLinkRequest {
 			db_path: self.db_path.clone().unwrap_or_else(radar::default_ledger_path),
 			repo: self.repo.clone(),
 			subject_kind: self.subject_kind.clone(),
@@ -1855,7 +1856,7 @@ struct RadarLedgerSummaryCommand {
 }
 impl RadarLedgerSummaryCommand {
 	fn run(&self) -> Result<()> {
-		let summary = radar::ledger_summary(&radar::RadarLedgerSummaryRequest {
+		let summary = radar::ledger_summary(&RadarLedgerSummaryRequest {
 			db_path: self.db_path.clone().unwrap_or_else(radar::default_ledger_path),
 		})?;
 
@@ -2042,8 +2043,8 @@ enum Command {
 	ArchiveLinear(ArchiveLinearCommand),
 	/// Maintain local Decodex logs, evidence, backups, and runtime storage.
 	Maintenance(MaintenanceCommand),
-		/// Manage the user-local Decodex Codex account pool.
-		Account(AccountCommand),
+	/// Manage the user-local Decodex Codex account pool.
+	Account(AccountCommand),
 	/// Validate the local app-server integration boundary.
 	Probe(ProbeCommand),
 	/// Run one daemon-planned attempt from a structured request.

--- a/apps/decodex/src/execution_program.rs
+++ b/apps/decodex/src/execution_program.rs
@@ -1040,6 +1040,8 @@ impl ExecutionProgram {
 			self.nodes.iter().map(|node| (node.node_id.as_str(), node)).collect::<BTreeMap<_, _>>();
 		let dependency_lookup = context.dependency_lookup();
 		let occupied_conflicts = context.occupied_conflict_domains.iter().collect::<HashSet<_>>();
+		let active_issue_ids =
+			context.active_issue_ids.iter().map(String::as_str).collect::<HashSet<_>>();
 		let mut nodes = Vec::new();
 
 		for node in &self.nodes {
@@ -1052,6 +1054,7 @@ impl ExecutionProgram {
 				node_lookup: &node_lookup,
 				dependency_lookup: &dependency_lookup,
 				occupied_conflicts: &occupied_conflicts,
+				active_issue_ids: &active_issue_ids,
 			})?);
 		}
 
@@ -1299,6 +1302,7 @@ impl ExecutionDependencySnapshot {
 pub(crate) struct ExecutionProgramReadinessContext {
 	dependency_snapshots: Vec<ExecutionDependencySnapshot>,
 	occupied_conflict_domains: Vec<ExecutionConflictDomain>,
+	active_issue_ids: Vec<String>,
 }
 impl ExecutionProgramReadinessContext {
 	/// Build an empty readiness context.
@@ -1322,6 +1326,16 @@ impl ExecutionProgramReadinessContext {
 		domains: impl IntoIterator<Item = ExecutionConflictDomain>,
 	) -> Self {
 		self.occupied_conflict_domains = domains.into_iter().collect();
+
+		self
+	}
+
+	/// Add mapped Linear issues already owned by a live run claim.
+	pub(crate) fn with_active_issue_ids(
+		mut self,
+		issue_ids: impl IntoIterator<Item = impl Into<String>>,
+	) -> Self {
+		self.active_issue_ids = issue_ids.into_iter().map(Into::into).collect();
 
 		self
 	}
@@ -1523,6 +1537,7 @@ struct EvaluateNodeInput<'a> {
 	node_lookup: &'a BTreeMap<&'a str, &'a ExecutionProgramNode>,
 	dependency_lookup: &'a BTreeMap<&'a str, &'a ExecutionDependencySnapshot>,
 	occupied_conflicts: &'a HashSet<&'a ExecutionConflictDomain>,
+	active_issue_ids: &'a HashSet<&'a str>,
 }
 
 fn evaluate_node(input: EvaluateNodeInput<'_>) -> Result<ExecutionNodeEvaluation> {
@@ -1535,6 +1550,7 @@ fn evaluate_node(input: EvaluateNodeInput<'_>) -> Result<ExecutionNodeEvaluation
 		node_lookup,
 		dependency_lookup,
 		occupied_conflicts,
+		active_issue_ids,
 	} = input;
 	let authority_matches =
 		current_contract.map_or(program.source_contract_id.is_none(), |contract| {
@@ -1572,6 +1588,16 @@ fn evaluate_node(input: EvaluateNodeInput<'_>) -> Result<ExecutionNodeEvaluation
 			issue.issue_identifier(),
 			issue.issue_state()
 		));
+	} else if let Some(issue) = node.linear_issue()
+		&& active_issue_ids.contains(issue.issue_id())
+		&& !issue.has_opt_out_label()
+		&& !issue.has_needs_attention_label()
+		&& !issue.has_post_review_lifecycle()
+	{
+		state = ExecutionReadinessState::Active;
+		lifecycle_state = Some(ExecutionProgramNodeLifecycleState::Active);
+
+		reasons.push(String::from("node already has a current lane"));
 	} else {
 		match node.queue_intent {
 			ExecutionQueueIntent::NotReady => {

--- a/apps/decodex/src/lib.rs
+++ b/apps/decodex/src/lib.rs
@@ -95,7 +95,5 @@ fn install_panic_hook() {
 	}));
 }
 
-#[cfg(test)]
-mod plugin_surface_tests;
-#[cfg(test)]
-mod test_support;
+#[cfg(test)] mod plugin_surface_tests;
+#[cfg(test)] mod test_support;

--- a/apps/decodex/src/manual.rs
+++ b/apps/decodex/src/manual.rs
@@ -17,7 +17,7 @@ use crate::{
 	github::{self, RepositoryContext},
 	orchestrator,
 	prelude::{Result, eyre},
-	pull_request::{self, PullRequestLandingState},
+	pull_request::{self, LandingGateMode, PullRequestLandingGateView, PullRequestLandingState},
 	runtime,
 	state::{self, ReviewHandoffMarker, StateStore, WorktreeMapping},
 	tracker::{
@@ -1146,8 +1146,7 @@ fn validate_landing_state(
 		);
 	}
 
-	let decision =
-		pull_request::classify_landing_gate(gate_view, pull_request::LandingGateMode::ManualLand);
+	let decision = pull_request::classify_landing_gate(gate_view, LandingGateMode::ManualLand);
 
 	match decision {
 		pull_request::LandingGateDecision::Satisfied => {
@@ -1162,7 +1161,7 @@ fn validate_landing_state(
 
 fn manual_landing_gate_error(
 	decision: pull_request::LandingGateDecision,
-	gate_view: pull_request::PullRequestLandingGateView<'_>,
+	gate_view: PullRequestLandingGateView<'_>,
 	pr_url: &str,
 ) -> Result<LandExecutionMode> {
 	match decision {
@@ -3039,7 +3038,6 @@ exit 1\n",
 			related: Vec::new(),
 			breaking: false,
 		};
-
 		let context = manual::prepare_unregistered_manual_land_context(
 			repo_root.clone(),
 			repo_root.clone(),
@@ -3712,6 +3710,7 @@ exit 1\n",
 			String::from("xy/pub-1161"),
 			String::from("3cf2d24033527a774340c7d70c5ce437c90afe55"),
 		);
+
 		state_store
 			.record_run_attempt(handoff.run_id(), &issue.id, handoff.attempt_number(), "failed")
 			.expect("failed handoff attempt should record");

--- a/apps/decodex/src/orchestrator/program_reconciler.rs
+++ b/apps/decodex/src/orchestrator/program_reconciler.rs
@@ -330,10 +330,16 @@ fn execution_program_readiness_context(
 	let dependency_snapshots = execution_program_dependency_snapshots(programs)?;
 	let occupied_conflict_domains =
 		execution_program_occupied_conflict_domains(service_id, workflow, state_store, programs)?;
+	let active_issue_ids = state_store
+		.list_active_shared_leases(service_id)?
+		.into_iter()
+		.map(|lease| lease.issue_id().to_owned())
+		.collect::<Vec<_>>();
 
 	Ok(ExecutionProgramReadinessContext::new()
 		.with_dependency_snapshots(dependency_snapshots)
-		.with_occupied_conflict_domains(occupied_conflict_domains))
+		.with_occupied_conflict_domains(occupied_conflict_domains)
+		.with_active_issue_ids(active_issue_ids))
 }
 
 fn execution_program_dependency_snapshots(

--- a/apps/decodex/src/orchestrator/run_cycle.rs
+++ b/apps/decodex/src/orchestrator/run_cycle.rs
@@ -2033,6 +2033,11 @@ where
 		return run_target_status_visible_closeout_once(context);
 	}
 
+	if let Some(summary) = run_target_status_visible_program_once(
+		target_issue_run_context_with_dispatch_mode(&context, IssueDispatchMode::Program),
+	)? {
+		return Ok(Some(summary));
+	}
 	if let Some(summary) = run_target_issue_once(target_issue_run_context_with_dispatch_mode(
 		&context,
 		IssueDispatchMode::Normal,
@@ -2052,6 +2057,107 @@ where
 	}
 
 	run_target_status_visible_closeout_once(context)
+}
+
+fn run_target_status_visible_program_once<T>(
+	context: TargetIssueRunContext<'_, T>,
+) -> Result<Option<RunSummary>>
+where
+	T: IssueTracker,
+{
+	let Some(_) = select_target_status_visible_program_candidate(&context)? else {
+		return Ok(None);
+	};
+
+	run_target_issue_once(context)
+}
+
+fn select_target_status_visible_program_candidate<T>(
+	context: &TargetIssueRunContext<'_, T>,
+) -> Result<Option<SelectedIssueRunCandidate>>
+where
+	T: IssueTracker,
+{
+	let worktree_manager = WorktreeManager::new(
+		context.project.service_id(),
+		context.project.repo_root(),
+		context.project.worktree_root(),
+	);
+
+	context.state_store.configure_dispatch_slot_root(
+		context.project.service_id(),
+		context.project.worktree_root(),
+		context.workflow.frontmatter().execution().max_concurrent_agents(),
+	)?;
+
+	let target_issue_id = resolve_target_issue_id(context.tracker, context.issue_id)?;
+
+	if !context.lease_preacquired {
+		recover_runtime_state_from_tracker_and_worktrees(
+			context.tracker,
+			context.project,
+			context.workflow,
+			context.state_store,
+		)?;
+
+		if !context.dry_run {
+			reconcile_project_state(
+				context.tracker,
+				context.project,
+				context.workflow,
+				context.state_store,
+				&worktree_manager,
+			)?;
+			reconcile_post_review_orchestration(
+				context.tracker,
+				context.project,
+				context.workflow,
+				context.state_store,
+			)?;
+		}
+	}
+
+	let excluded_issue_ids = execution_program_non_target_mapped_issue_ids(
+		context.state_store,
+		context.project.service_id(),
+		&target_issue_id,
+	)?;
+	let excluded_issue_ids = excluded_issue_ids.iter().map(String::as_str).collect::<Vec<_>>();
+	let ProgramSchedulerSelection { selected, .. } = select_execution_program_run_candidate_with_summary(
+		context.tracker,
+		context.project,
+		context.workflow,
+		context.state_store,
+		&excluded_issue_ids,
+	)?;
+	let Some(selected) = selected else {
+		return Ok(None);
+	};
+
+	if selected.issue.id != target_issue_id {
+		return Ok(None);
+	}
+
+	Ok(Some(selected))
+}
+
+fn execution_program_non_target_mapped_issue_ids(
+	state_store: &StateStore,
+	service_id: &str,
+	target_issue_id: &str,
+) -> Result<Vec<String>> {
+	let records = state_store.list_execution_programs(service_id)?;
+
+	Ok(records
+		.iter()
+		.flat_map(|record| record.program().nodes())
+		.filter_map(|node| node.linear_issue())
+		.map(|issue| issue.issue_id())
+		.filter(|issue_id| *issue_id != target_issue_id)
+		.map(str::to_owned)
+		.collect::<BTreeSet<_>>()
+		.into_iter()
+		.collect())
 }
 
 fn target_issue_has_status_visible_review_repair<T>(

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -1213,10 +1213,16 @@ fn operator_execution_program_readiness_context(
 	let dependency_snapshots = operator_execution_program_dependency_snapshots(records)?;
 	let occupied_conflict_domains =
 		operator_execution_program_occupied_conflict_domains(service_id, workflow, state_store, records)?;
+	let active_issue_ids = state_store
+		.list_active_shared_leases(service_id)?
+		.into_iter()
+		.map(|lease| lease.issue_id().to_owned())
+		.collect::<Vec<_>>();
 
 	Ok(ExecutionProgramReadinessContext::new()
 		.with_dependency_snapshots(dependency_snapshots)
-		.with_occupied_conflict_domains(occupied_conflict_domains))
+		.with_occupied_conflict_domains(occupied_conflict_domains)
+		.with_active_issue_ids(active_issue_ids))
 }
 
 fn operator_execution_program_dependency_snapshots(

--- a/apps/decodex/src/orchestrator/tests/intake/run_and_prompting.rs
+++ b/apps/decodex/src/orchestrator/tests/intake/run_and_prompting.rs
@@ -1,3 +1,210 @@
+mod targeted_program_dispatch_tests {
+	use crate::execution_program::{
+		ExecutionConflictDomain, ExecutionConflictDomainKind, ExecutionLinearIssueMapping,
+		ExecutionProgram, ExecutionProgramNode, ExecutionProgramNodeStage, ExecutionQueueIntent,
+	};
+	use crate::orchestrator::{self, IssueDispatchMode, TargetIssueRunContext};
+	use crate::orchestrator::tests::{
+		FakeTracker, sample_issue_with_sort_fields, temp_project_layout,
+	};
+	use crate::state::StateStore;
+
+#[test]
+fn targeted_identifier_dispatch_accepts_status_ready_program_node() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue_with_sort_fields(
+		"issue-program-ready",
+		"PUB-1094",
+		"Todo",
+		&[],
+		Some(1),
+		"2026-06-23T04:16:17.133Z",
+	);
+	let mapping = ExecutionLinearIssueMapping::new(
+		&issue.id,
+		&issue.identifier,
+		&issue.state.name,
+	)
+	.expect("program issue mapping should build");
+	let node = ExecutionProgramNode::new(
+		"node-program-ready",
+		ExecutionProgramNodeStage::Runtime,
+		"Resolve a dispatchable Program Intake node.",
+		ExecutionQueueIntent::ReadyToQueue,
+	)
+	.expect("program node should build")
+	.with_acceptance_expectations(["Program node maps to a normal Linear issue."])
+	.expect("acceptance should attach")
+	.with_validation_expectations(["Run focused Program dispatch validation."])
+	.expect("validation should attach")
+	.with_linear_issue(mapping)
+	.expect("issue mapping should attach");
+	let program = ExecutionProgram::from_issue_batch_intake(
+		"program-targeted-run",
+		config.service_id(),
+		"program-targeted-run-fingerprint",
+		"Targeted Program run bridge.",
+		vec![node],
+	)
+	.expect("program should build");
+
+	state_store
+		.upsert_execution_program(config.service_id(), program)
+		.expect("program should persist");
+
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("status snapshot should build");
+	let program = snapshot
+		.execution_programs
+		.iter()
+		.find(|program| program.program_id == "program-targeted-run")
+		.expect("program should appear in status");
+
+	assert_eq!(program.dispatchable_count, 1);
+	assert_eq!(program.node_readbacks[0].dispatch_action.as_deref(), Some("dispatch"));
+
+	let summary = orchestrator::run_target_issue_once_with_inferred_dispatch(
+		TargetIssueRunContext {
+			tracker: &tracker,
+			project: &config,
+			workflow: &workflow,
+			state_store: &state_store,
+			issue_id: &issue.identifier,
+			preferred_issue_state: None,
+			preferred_initial_issue_state: None,
+			dry_run: true,
+			lease_preacquired: false,
+			preferred_issue_claim_fd: None,
+			preferred_dispatch_slot_fd: None,
+			preferred_dispatch_slot_index: None,
+			dispatch_mode: IssueDispatchMode::Normal,
+			preferred_run_identity: None,
+			preferred_retry_budget_base: None,
+		},
+	)
+	.expect("targeted identifier run should succeed")
+	.expect("status-ready program issue should dispatch by identifier");
+
+	assert_eq!(summary.issue_id, issue.id);
+	assert_eq!(summary.issue_identifier, issue.identifier);
+	assert_eq!(summary.dispatch_mode, IssueDispatchMode::Program);
+}
+
+#[test]
+fn targeted_program_selection_reconciles_stale_worktree_mapping_before_dispatch() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue_with_sort_fields(
+		"issue-program-stale-mapping",
+		"PUB-1095",
+		"Todo",
+		&[],
+		Some(1),
+		"2026-06-23T04:16:17.133Z",
+	);
+	let missing_worktree_path = config.worktree_root().join(&issue.identifier);
+	let conflict = ExecutionConflictDomain::new(
+		ExecutionConflictDomainKind::Module,
+		"runtime",
+	)
+	.expect("conflict should build");
+	let mapping = ExecutionLinearIssueMapping::new(
+		&issue.id,
+		&issue.identifier,
+		&issue.state.name,
+	)
+	.expect("program issue mapping should build");
+	let node = ExecutionProgramNode::new(
+		"node-program-stale-mapping",
+		ExecutionProgramNodeStage::Runtime,
+		"Resolve a dispatchable Program node after stale worktree cleanup.",
+		ExecutionQueueIntent::ReadyToQueue,
+	)
+	.expect("program node should build")
+	.with_acceptance_expectations(["Program node maps to a normal Linear issue."])
+	.expect("acceptance should attach")
+	.with_validation_expectations(["Run focused Program dispatch validation."])
+	.expect("validation should attach")
+	.with_conflict_domains([conflict])
+	.expect("conflict should attach")
+	.with_linear_issue(mapping)
+	.expect("issue mapping should attach");
+	let program = ExecutionProgram::from_issue_batch_intake(
+		"program-targeted-stale-mapping",
+		config.service_id(),
+		"program-targeted-stale-mapping-fingerprint",
+		"Targeted Program run bridge with stale mapping.",
+		vec![node],
+	)
+	.expect("program should build");
+
+	state_store
+		.upsert_worktree(
+			config.service_id(),
+			&issue.id,
+			"x/pubfi-pub-1095",
+			&missing_worktree_path.display().to_string(),
+		)
+		.expect("stale worktree mapping should persist");
+	state_store
+		.upsert_execution_program(config.service_id(), program)
+		.expect("program should persist");
+
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+	let blocked = orchestrator::select_execution_program_run_candidate_with_summary(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		&[],
+	)
+	.expect("stale mapping should evaluate");
+
+	assert!(blocked.selected.is_none());
+	assert_eq!(blocked.summary.dispatchable_nodes, 0);
+
+	let candidate = orchestrator::select_target_status_visible_program_candidate(
+		&TargetIssueRunContext {
+			tracker: &tracker,
+			project: &config,
+			workflow: &workflow,
+			state_store: &state_store,
+			issue_id: &issue.identifier,
+			preferred_issue_state: None,
+			preferred_initial_issue_state: None,
+			dry_run: false,
+			lease_preacquired: false,
+			preferred_issue_claim_fd: None,
+			preferred_dispatch_slot_fd: None,
+			preferred_dispatch_slot_index: None,
+			dispatch_mode: IssueDispatchMode::Program,
+			preferred_run_identity: None,
+			preferred_retry_budget_base: None,
+		},
+	)
+	.expect("targeted Program selection should reconcile")
+	.expect("targeted Program issue should select after stale mapping cleanup");
+
+	assert_eq!(candidate.issue.id, issue.id);
+	assert_eq!(candidate.dispatch_mode, IssueDispatchMode::Program);
+	assert!(
+		state_store
+			.worktree_for_issue(&issue.id)
+			.expect("worktree lookup should succeed")
+			.is_none()
+	);
+}
+
+}
+
 use crate::agent::ReviewExecutionMode;
 use crate::agent::ReviewHandoffContext;
 

--- a/apps/decodex/src/orchestrator/tests/runtime/program_reconciler.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime/program_reconciler.rs
@@ -594,6 +594,159 @@ fn live_reconciliation_clears_missing_orphaned_mapping_before_program_selection(
 }
 
 #[test]
+fn active_shared_lease_marks_program_node_active_without_self_conflict() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let issue = program_reconciler_issue("issue-active-claim", "PUB-1094", "Todo", &[]);
+	let worktree_manager =
+		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
+	let worktree =
+		worktree_manager.ensure_worktree(&issue.identifier, false).expect("worktree should exist");
+	let conflict = ExecutionConflictDomain::new(ExecutionConflictDomainKind::Module, "runtime")
+		.expect("conflict should build");
+
+	store
+		.upsert_execution_program(
+			config.service_id(),
+			program_reconciler_program(vec![program_reconciler_node(
+				"node-active-claim",
+				&issue,
+				ExecutionQueueIntent::ReadyToQueue,
+			)
+			.with_conflict_domains([conflict])
+			.expect("conflict should attach")]),
+		)
+		.expect("program should persist");
+	store
+		.record_run_attempt("pub-1094-attempt-1", &issue.id, 1, "running")
+		.expect("run attempt should record");
+	store
+		.upsert_lease(config.service_id(), &issue.id, "pub-1094-attempt-1", "In Progress")
+		.expect("lease should record");
+	store
+		.upsert_worktree(
+			config.service_id(),
+			&issue.id,
+			&worktree.branch_name,
+			&worktree.path.display().to_string(),
+		)
+		.expect("worktree mapping should record");
+
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+	let selection = orchestrator::select_execution_program_run_candidate_with_summary(
+		&tracker,
+		&config,
+		&workflow,
+		&store,
+		&[],
+	)
+	.expect("active claim should evaluate");
+
+	assert!(selection.selected.is_none());
+	assert_eq!(selection.summary.dispatchable_nodes, 0);
+
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&store,
+		10,
+	)
+	.expect("status snapshot should build");
+	let program = snapshot.execution_programs.first().expect("program should render");
+	let node = program.node_readbacks.first().expect("active node should render");
+
+	assert_eq!(program.active_count, 1);
+	assert_eq!(program.blocked_count, 0);
+	assert_eq!(program.dispatchable_count, 0);
+	assert_eq!(node.lifecycle_state, "active");
+	assert_eq!(node.readiness_state, "active");
+	assert!(node.reason_codes.contains(&String::from("current_lane_present")));
+	assert!(!node.reason_codes.contains(&String::from("conflict_domain_occupied")));
+}
+
+#[test]
+fn active_shared_lease_occupies_peer_conflict_domain() {
+	let (_temp_dir, config, workflow) = temp_project_layout();
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let active_issue = program_reconciler_issue("issue-active-peer", "PUB-1094", "Todo", &[]);
+	let peer_issue = program_reconciler_issue("issue-ready-peer", "PUB-1095", "Todo", &[]);
+	let conflict = ExecutionConflictDomain::new(ExecutionConflictDomainKind::Module, "runtime")
+		.expect("conflict should build");
+
+	store
+		.upsert_execution_program(
+			config.service_id(),
+			program_reconciler_program(vec![
+				program_reconciler_node(
+					"node-active-peer",
+					&active_issue,
+					ExecutionQueueIntent::ReadyToQueue,
+				)
+				.with_conflict_domains([conflict.clone()])
+				.expect("active conflict should attach"),
+				program_reconciler_node(
+					"node-ready-peer",
+					&peer_issue,
+					ExecutionQueueIntent::ReadyToQueue,
+				)
+				.with_conflict_domains([conflict])
+				.expect("peer conflict should attach"),
+			]),
+		)
+		.expect("program should persist");
+	store
+		.record_run_attempt("pub-1094-attempt-1", &active_issue.id, 1, "running")
+		.expect("run attempt should record");
+	store
+		.upsert_lease(
+			config.service_id(),
+			&active_issue.id,
+			"pub-1094-attempt-1",
+			"In Progress",
+		)
+		.expect("lease should record");
+
+	let tracker = FakeTracker::new(vec![active_issue.clone(), peer_issue.clone()]);
+	let selection = orchestrator::select_execution_program_run_candidate_with_summary(
+		&tracker,
+		&config,
+		&workflow,
+		&store,
+		&[],
+	)
+	.expect("active claim should occupy peer conflict");
+
+	assert!(selection.selected.is_none());
+	assert_eq!(selection.summary.dispatchable_nodes, 0);
+
+	let snapshot =
+		orchestrator::build_live_operator_status_snapshot(&tracker, &config, &workflow, &store, 10)
+			.expect("status snapshot should build");
+	let program = snapshot.execution_programs.first().expect("program should render");
+	let active_node = program
+		.node_readbacks
+		.iter()
+		.find(|node| node.issue_identifier.as_deref() == Some(active_issue.identifier.as_str()))
+		.expect("active node should render");
+	let peer_node = program
+		.node_readbacks
+		.iter()
+		.find(|node| node.issue_identifier.as_deref() == Some(peer_issue.identifier.as_str()))
+		.expect("peer node should render");
+
+	assert_eq!(program.active_count, 1);
+	assert_eq!(program.blocked_count, 1);
+	assert_eq!(program.dispatchable_count, 0);
+	assert_eq!(active_node.lifecycle_state, "active");
+	assert_eq!(active_node.readiness_state, "active");
+	assert!(active_node.reason_codes.contains(&String::from("current_lane_present")));
+	assert_eq!(peer_node.lifecycle_state, "blocked");
+	assert_eq!(peer_node.readiness_state, "blocked");
+	assert!(peer_node.reason_codes.contains(&String::from("conflict_domain_occupied")));
+}
+
+#[test]
 fn needs_attention_node_is_not_selected_even_with_stale_queue_label() {
 	let (_temp_dir, config, workflow) = temp_project_layout();
 	let store = StateStore::open_in_memory().expect("state store should open");
@@ -615,6 +768,12 @@ fn needs_attention_node_is_not_selected_even_with_stale_queue_label() {
 			)]),
 		)
 		.expect("program should persist");
+	store
+		.record_run_attempt("pub-206-attempt-1", &issue.id, 1, "running")
+		.expect("run attempt should record");
+	store
+		.upsert_lease(config.service_id(), &issue.id, "pub-206-attempt-1", "In Progress")
+		.expect("lease should record");
 
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let selection = orchestrator::select_execution_program_run_candidate_with_summary(
@@ -630,6 +789,15 @@ fn needs_attention_node_is_not_selected_even_with_stale_queue_label() {
 	assert_eq!(selection.summary.dispatchable_nodes, 0);
 	assert!(tracker.label_additions.borrow().is_empty());
 	assert!(tracker.label_removals.borrow().is_empty());
+
+	let snapshot =
+		orchestrator::build_live_operator_status_snapshot(&tracker, &config, &workflow, &store, 10)
+			.expect("status snapshot should build");
+	let program = snapshot.execution_programs.first().expect("program should render");
+	let node = program.node_readbacks.first().expect("attention node should render");
+
+	assert_eq!(node.lifecycle_state, "needs_attention");
+	assert!(node.reason_codes.contains(&String::from("mapped_issue_needs_attention")));
 }
 
 #[test]

--- a/apps/decodex/src/pull_request.rs
+++ b/apps/decodex/src/pull_request.rs
@@ -46,7 +46,6 @@ pub(crate) enum LandingGateMode {
 	Adopt,
 	Retained,
 }
-
 impl LandingGateMode {
 	fn allows_closeout_only(self) -> bool {
 		matches!(self, Self::ManualLand)
@@ -100,19 +99,23 @@ pub(crate) fn classify_landing_gate(
 	if view.review_decision == Some("CHANGES_REQUESTED") {
 		return LandingGateDecision::Repair("review_changes_requested");
 	}
+
 	if let Some(reason) =
 		merge_state_requires_review_repair(view.mergeable, view.merge_state_status)
 	{
 		return LandingGateDecision::Repair(reason);
 	}
+
 	if failed_checks_require_repair(view.status_check_rollup_state, view.merge_state_status) {
 		return LandingGateDecision::Repair("required_checks_failed");
 	}
+
 	if let Some(check_state) = view.status_check_rollup_state
 		&& checks_require_wait(Some(check_state))
 	{
 		return LandingGateDecision::Wait("checks_waiting");
 	}
+
 	if mergeability_unknown(view) {
 		return LandingGateDecision::Wait("mergeability_unknown");
 	}

--- a/apps/decodex/src/radar.rs
+++ b/apps/decodex/src/radar.rs
@@ -4,8 +4,8 @@ use std::{
 	collections::{BTreeMap, BTreeSet, HashSet},
 	env,
 	fmt::{self, Display, Formatter},
-	fs,
-	io::Write,
+	fs::{self, OpenOptions},
+	io::Write as _,
 	iter,
 	path::{Path, PathBuf},
 	process::{self, Command},
@@ -986,6 +986,13 @@ impl GithubClient {
 	}
 }
 
+#[derive(Debug, Default)]
+struct SocialPublishStateScan {
+	published_count: usize,
+	active_reservation_count: usize,
+	idempotency_conflict: Option<PathBuf>,
+}
+
 #[derive(Debug)]
 enum RefreshKind {
 	Queue,
@@ -1014,7 +1021,9 @@ impl GitHubError {
 			},
 			Self::Transport(error) => eyre::eyre!("GitHub API request failed for {url}: {error}"),
 			Self::Json { error, body } => {
-				eyre::eyre!("GitHub API response from {url} was not valid JSON: {error}; body: {body}")
+				eyre::eyre!(
+					"GitHub API response from {url} was not valid JSON: {error}; body: {body}"
+				)
 			},
 		}
 	}
@@ -1163,13 +1172,13 @@ pub(crate) fn reserve_social_publish(
 
 	let payload = social_publish_reservation_payload(request, &root);
 	let validation = validate_artifact(&payload);
+
 	if !validation.errors.is_empty() {
 		return Err(eyre::eyre!(
 			"generated reservation failed validation: {}",
 			validation.errors.join("; ")
 		));
 	}
-
 	if !request.dry_run {
 		write_new_json(&reservation_path, &payload)?;
 	}
@@ -1298,9 +1307,8 @@ pub(crate) fn build_bundle(request: &RadarBundleBuildRequest) -> crate::prelude:
 			};
 
 			match promoted_pr {
-				Some(pr_number) => {
-					client.build_pr_bundle(&request.repo, pr_number, &request.notes)?
-				},
+				Some(pr_number) =>
+					client.build_pr_bundle(&request.repo, pr_number, &request.notes)?,
 				None => client.build_commit_bundle(&request.repo, commit_sha, &request.notes)?,
 			}
 		},
@@ -3342,9 +3350,11 @@ fn write_json(path: &Path, payload: &Value) -> crate::prelude::Result<()> {
 		.ok_or_else(|| eyre::eyre!("JSON output path must end in a valid file name"))?;
 	let temp_path = parent.join(format!(".{file_name}.tmp-{}", process::id()));
 	let write_result = (|| -> crate::prelude::Result<()> {
-		let mut file = fs::OpenOptions::new().write(true).create_new(true).open(&temp_path)?;
+		let mut file = OpenOptions::new().write(true).create_new(true).open(&temp_path)?;
+
 		file.write_all(output.as_bytes())?;
 		file.sync_all()?;
+
 		fs::rename(&temp_path, path)?;
 
 		Ok(())
@@ -3353,6 +3363,7 @@ fn write_json(path: &Path, payload: &Value) -> crate::prelude::Result<()> {
 	if write_result.is_err() {
 		let _ = fs::remove_file(&temp_path);
 	}
+
 	write_result?;
 
 	Ok(())
@@ -3367,18 +3378,12 @@ fn write_new_json(path: &Path, payload: &Value) -> crate::prelude::Result<()> {
 
 	output.push('\n');
 
-	let mut file = fs::OpenOptions::new().write(true).create_new(true).open(path)?;
+	let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+
 	file.write_all(output.as_bytes())?;
 	file.sync_all()?;
 
 	Ok(())
-}
-
-#[derive(Debug, Default)]
-struct SocialPublishStateScan {
-	published_count: usize,
-	active_reservation_count: usize,
-	idempotency_conflict: Option<PathBuf>,
 }
 
 fn scan_social_publish_state(
@@ -3391,6 +3396,7 @@ fn scan_social_publish_state(
 
 	for payload_path in existing_json_files(reservations_dir)? {
 		let payload = load_json(&payload_path)?;
+
 		if payload.get("schema").and_then(Value::as_str) != Some(SOCIAL_PUBLISH_RESERVATION_SCHEMA)
 		{
 			continue;
@@ -3404,13 +3410,15 @@ fn scan_social_publish_state(
 			}
 		}
 	}
-
 	for payload_path in existing_json_files(posts_dir)? {
 		let payload = load_json(&payload_path)?;
+
 		if payload.get("schema").and_then(Value::as_str) != Some(SOCIAL_POST_SCHEMA) {
 			continue;
 		}
+
 		let status = payload.get("status").and_then(Value::as_str);
+
 		if status == Some("published")
 			&& payload
 				.get("decision")
@@ -3449,6 +3457,7 @@ fn social_publish_reservation_payload(
 	root: &Path,
 ) -> Value {
 	let mut refs = Map::new();
+
 	if !request.candidate_paths.is_empty() {
 		refs.insert(
 			"social_candidates".into(),
@@ -3469,6 +3478,7 @@ fn social_publish_reservation_payload(
 	}
 
 	let mut owner = Map::new();
+
 	if let Some(value) = request.automation_id.as_deref().filter(|value| !value.is_empty()) {
 		owner.insert("automation_id".into(), Value::String(value.to_owned()));
 	}
@@ -3495,6 +3505,7 @@ fn social_publish_reservation_payload(
 		"candidate_refs": refs,
 		"duplicate_keys": request.duplicate_keys,
 	});
+
 	if !owner.is_empty() {
 		payload["owner"] = Value::Object(owner);
 	}
@@ -4576,9 +4587,8 @@ fn validate_artifact(payload: &Value) -> ArtifactValidation {
 		Some(SIGNAL_SCHEMA) => validate_signal(entry, &mut errors),
 		Some(SOCIAL_CANDIDATE_SCHEMA) => validate_social_candidate(entry, &mut errors),
 		Some(SOCIAL_POST_SCHEMA) => validate_social_post(entry, &mut errors),
-		Some(SOCIAL_PUBLISH_RESERVATION_SCHEMA) => {
-			validate_social_publish_reservation(entry, &mut errors)
-		},
+		Some(SOCIAL_PUBLISH_RESERVATION_SCHEMA) =>
+			validate_social_publish_reservation(entry, &mut errors),
 		Some(UPSTREAM_IMPACT_SCHEMA) => validate_upstream_impact(entry, &mut errors),
 		Some(UPSTREAM_REVIEW_QUEUE_SCHEMA) => validate_upstream_review_queue(entry, &mut errors),
 		Some(UPSTREAM_REVIEW_SCHEMA) => validate_upstream_review(entry, &mut errors),
@@ -4822,11 +4832,10 @@ fn collect_json_strings(value: &Value, text: &mut String) {
 			text.push(' ');
 			text.push_str(value);
 		},
-		Value::Array(values) => {
+		Value::Array(values) =>
 			for value in values {
 				collect_json_strings(value, text);
-			}
-		},
+			},
 		Value::Object(object) => collect_json_strings_from_map(object, text),
 		Value::Bool(_) | Value::Null | Value::Number(_) => {},
 	}
@@ -5126,31 +5135,25 @@ fn validate_release_comparison_tags(
 	errors: &mut Vec<String>,
 ) {
 	match string_field(comparison, "stable_tag_name") {
-		Some("") => {
-			errors.push(format!("comparisons[{index}].stable_tag_name must be a non-empty string"))
-		},
+		Some("") =>
+			errors.push(format!("comparisons[{index}].stable_tag_name must be a non-empty string")),
 		Some(tag_name)
 			if !option_tags.stable.is_empty() && !option_tags.stable.contains(tag_name) =>
-		{
 			errors.push(format!(
 				"comparisons[{index}].stable_tag_name must exist in release_options.stable"
-			))
-		},
+			)),
 		Some(_) => {},
-		None => {
-			errors.push(format!("comparisons[{index}].stable_tag_name must be a non-empty string"))
-		},
+		None =>
+			errors.push(format!("comparisons[{index}].stable_tag_name must be a non-empty string")),
 	}
 	match string_field(comparison, "prerelease_tag_name") {
 		Some("") => errors
 			.push(format!("comparisons[{index}].prerelease_tag_name must be a non-empty string")),
 		Some(tag_name)
 			if !option_tags.preview.is_empty() && !option_tags.preview.contains(tag_name) =>
-		{
 			errors.push(format!(
 				"comparisons[{index}].prerelease_tag_name must exist in release_options.preview"
-			))
-		},
+			)),
 		Some(_) => {},
 		None => errors
 			.push(format!("comparisons[{index}].prerelease_tag_name must be a non-empty string")),
@@ -5589,6 +5592,7 @@ fn validate_control_plane_upgrade_authority(authority: Option<&Value>, errors: &
 			errors.push(format!("authority.{field} must be true"));
 		}
 	}
+
 	if authority.get("mutation_allowed").and_then(Value::as_bool) != Some(false) {
 		errors.push("authority.mutation_allowed must be false".into());
 	}
@@ -5720,13 +5724,16 @@ fn validate_radar_archive_manifest(entry: &Map<String, Value>, errors: &mut Vec<
 			errors.push(format!("{field} must be a non-empty string"));
 		}
 	}
+
 	validate_rfc3339_field(entry, "created_at", errors);
+
 	if entry.get("retention_days").and_then(Value::as_u64) != Some(21) {
 		errors.push("retention_days must be 21".into());
 	}
 	if !is_https_string(entry.get("release_url")) {
 		errors.push("release_url must be an https URL".into());
 	}
+
 	validate_archive_asset(entry.get("archive_asset"), "archive_asset", true, errors);
 	validate_archive_asset(entry.get("checksum_asset"), "checksum_asset", false, errors);
 	validate_archive_files(entry.get("files"), errors);
@@ -5769,11 +5776,13 @@ fn validate_archive_files(value: Option<&Value>, errors: &mut Vec<String>) {
 
 			continue;
 		};
+
 		for field in ["path", "kind"] {
 			if !is_non_empty_string(file.get(field)) {
 				errors.push(format!("files[{index}].{field} must be a non-empty string"));
 			}
 		}
+
 		if !matches_one_of(
 			file.get("kind"),
 			&["analysis", "bundle", "ledger_export", "other", "source_cache"],
@@ -5865,12 +5874,10 @@ fn validate_social_publish_reservation_status_payload(
 	errors: &mut Vec<String>,
 ) {
 	match string_field(entry, "status") {
-		Some("consumed") if !is_non_empty_string(entry.get("consumed_by_social_post")) => {
-			errors.push("consumed_by_social_post is required when status is consumed".into())
-		},
-		Some("canceled" | "expired") if !is_non_empty_string(entry.get("release_reason")) => {
-			errors.push("release_reason is required when status is canceled or expired".into())
-		},
+		Some("consumed") if !is_non_empty_string(entry.get("consumed_by_social_post")) =>
+			errors.push("consumed_by_social_post is required when status is consumed".into()),
+		Some("canceled" | "expired") if !is_non_empty_string(entry.get("release_reason")) =>
+			errors.push("release_reason is required when status is canceled or expired".into()),
 		_ => {},
 	}
 }
@@ -6052,12 +6059,10 @@ fn validate_social_post_status_payload(entry: &Map<String, Value>, errors: &mut 
 	match string_field(entry, "status") {
 		Some("published") => validate_social_post_publication(entry.get("publication"), errors),
 		Some("blocked") => validate_social_post_block(entry, errors),
-		Some("failed") if entry.get("failure").and_then(Value::as_object).is_none() => {
-			errors.push("failure is required when status is failed".into())
-		},
-		Some("skipped") if entry.get("skip").and_then(Value::as_object).is_none() => {
-			errors.push("skip is required when status is skipped".into())
-		},
+		Some("failed") if entry.get("failure").and_then(Value::as_object).is_none() =>
+			errors.push("failure is required when status is failed".into()),
+		Some("skipped") if entry.get("skip").and_then(Value::as_object).is_none() =>
+			errors.push("skip is required when status is skipped".into()),
 		_ => {},
 	}
 }
@@ -6667,7 +6672,9 @@ mod tests {
 	#[test]
 	fn rejects_radar_archive_manifest_without_external_assets() {
 		let mut manifest = valid_radar_archive_manifest();
+
 		manifest["retention_days"] = serde_json::json!(30);
+
 		manifest.as_object_mut().expect("manifest should be object").remove("archive_asset");
 
 		assert_errors(&manifest, ["retention_days must be 21", "archive_asset must be an object"]);
@@ -6677,7 +6684,6 @@ mod tests {
 	fn social_reserve_publish_dry_run_does_not_write() {
 		let temp_dir = tempfile::tempdir().expect("temp dir should create");
 		let request = social_reserve_request(temp_dir.path(), true);
-
 		let report =
 			radar::reserve_social_publish(&request).expect("dry-run reservation should pass");
 
@@ -6692,7 +6698,6 @@ mod tests {
 	fn social_reserve_publish_writes_active_reservation_once() {
 		let temp_dir = tempfile::tempdir().expect("temp dir should create");
 		let request = social_reserve_request(temp_dir.path(), false);
-
 		let report = radar::reserve_social_publish(&request).expect("reservation should pass");
 
 		assert_eq!(report.status, "reserved");
@@ -6700,9 +6705,11 @@ mod tests {
 			temp_dir.path().join("reservations/2026-06-02/openai-codex-pr-22414.json").exists(),
 			"reservation should be written"
 		);
+
 		let duplicate = radar::reserve_social_publish(&request)
 			.expect_err("duplicate reservation should fail closed")
 			.to_string();
+
 		assert!(duplicate.contains("idempotency_key already has an active reservation"));
 	}
 
@@ -6865,23 +6872,19 @@ mod tests {
 		assert_errors(&candidate, ["authority.mutation_allowed must be false"]);
 
 		let mut missing_contract = valid_control_plane_upgrade_candidate();
+
 		missing_contract["authority"]["decision_contract_required"] = serde_json::json!(false);
 
-		assert_errors(
-			&missing_contract,
-			["authority.decision_contract_required must be true"],
-		);
+		assert_errors(&missing_contract, ["authority.decision_contract_required must be true"]);
 
 		let mut missing_program = valid_control_plane_upgrade_candidate();
+
 		missing_program["authority"]
 			.as_object_mut()
 			.expect("authority should be an object")
 			.remove("program_intake_required");
 
-		assert_errors(
-			&missing_program,
-			["authority.program_intake_required must be true"],
-		);
+		assert_errors(&missing_program, ["authority.program_intake_required must be true"]);
 	}
 
 	#[test]
@@ -7880,7 +7883,7 @@ mod tests {
 			"release_url": "https://github.com/hack-ink/decodex/releases/tag/radar-archive-2026-06-02",
 			"archive_asset": {
 				"name": "radar-archive-2026-06-02.tar.zst",
-				"size_bytes": 1024,
+				"size_bytes": 1_024,
 				"sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 			},
 			"checksum_asset": {

--- a/apps/decodex/src/recovery.rs
+++ b/apps/decodex/src/recovery.rs
@@ -16,7 +16,7 @@ use crate::{
 	config::ServiceConfig,
 	github, orchestrator,
 	prelude::{Result, eyre},
-	pull_request::{self, PullRequestLandingState},
+	pull_request::{self, LandingGateMode, PullRequestLandingGateView, PullRequestLandingState},
 	runtime,
 	state::{
 		self, ConnectorBackoffInput, PrivateExecutionEvent, ProjectRunStatus,
@@ -3415,9 +3415,7 @@ fn validate_adopt_issue_state_for_policy(
 fn validate_adopt_landing_state(landing_state: &PullRequestLandingState) -> Result<()> {
 	let pr_url = landing_url(landing_state);
 	let gate_view = landing_state.gate_view();
-
-	let decision =
-		pull_request::classify_landing_gate(gate_view, pull_request::LandingGateMode::Adopt);
+	let decision = pull_request::classify_landing_gate(gate_view, LandingGateMode::Adopt);
 
 	match decision {
 		pull_request::LandingGateDecision::Satisfied => Ok(()),
@@ -3427,7 +3425,7 @@ fn validate_adopt_landing_state(landing_state: &PullRequestLandingState) -> Resu
 
 fn adopt_landing_gate_error(
 	decision: pull_request::LandingGateDecision,
-	gate_view: pull_request::PullRequestLandingGateView<'_>,
+	gate_view: PullRequestLandingGateView<'_>,
 	pr_url: &str,
 ) -> Result<()> {
 	match decision {

--- a/automations/decodex/automations.toml
+++ b/automations/decodex/automations.toml
@@ -1,136 +1,136 @@
 version = 1
 
 [defaults]
-kind = "cron"
-status = "ACTIVE"
+cache_root = ".agent/automations/decodex/cache"
+cwd = "{repo_root}"
 execution_environment = "local"
+forbidden_prompt_fragments = [
+	".agent/decodex",
+	".codex/decodex",
+	".github/workflows",
+	"/Users/x/Documents/automations",
+	"DECODEX_AGENT_HOME",
+	"Documents/automations",
+	"accounts.jsonl",
+	"apps/decodex/src/radar.rs",
+	"auth.json",
+	"migrate-agent-home",
+	"runtime.sqlite3",
+	"site/src/content",
+	"~/.codex/decodex",
+]
+kind = "cron"
 model = "gpt-5.5"
 reasoning_effort = "xhigh"
-cwd = "{repo_root}"
 source_root = "automations/decodex"
-cache_root = ".agent/automations/decodex/cache"
-forbidden_prompt_fragments = [
-  "/Users/x/Documents/automations",
-  "Documents/automations",
-  ".github/workflows",
-  "site/src/content",
-  "apps/decodex/src/radar.rs",
-  ".agent/decodex",
-  "~/.codex/decodex",
-  ".codex/decodex",
-  "accounts.jsonl",
-  "auth.json",
-  "runtime.sqlite3",
-  "DECODEX_AGENT_HOME",
-  "migrate-agent-home",
-]
+status = "ACTIVE"
 
 [[automations]]
 id = "codex-upstream-radar-review"
 name = "Decodex Radar Review"
-rrule = "FREQ=HOURLY;INTERVAL=6;BYMINUTE=0;BYSECOND=0"
 prompt_file = "automations/decodex/prompts/radar-review.md"
-required_paths = [
-  "automations/decodex/skills/codex-upstream-triage/SKILL.md",
-  "automations/decodex/skills/codex-code-analysis/SKILL.md",
-  "automations/decodex/skills/github-signal/SKILL.md",
-  "automations/decodex/scripts/github/run_codex_analysis.py",
-  "automations/decodex/scripts/github/control_plane_upgrade_candidate.schema.json",
-  "apps/decodex/src/radar.rs",
-  "docs/spec/upstream-review.md",
-  "docs/spec/github-change-bundle.md",
-  "docs/spec/signal-entry.md",
-  "docs/spec/upstream-impact.md",
-  "docs/spec/control-plane-upgrade-candidate.md",
-  "docs/spec/social-candidate.md",
-]
 required_cache_prefixes = [
-  ".agent/automations/decodex/cache/github/review-queue",
-  ".agent/automations/decodex/cache/github/bundles",
-  ".agent/automations/decodex/cache/github/reviews",
-  ".agent/automations/decodex/cache/github/impact",
-  ".agent/automations/decodex/cache/github/control-plane-upgrades",
-  ".agent/automations/decodex/cache/generated/analysis",
-  ".agent/automations/decodex/cache/site-content/signals",
+	".agent/automations/decodex/cache/generated/analysis",
+	".agent/automations/decodex/cache/github/bundles",
+	".agent/automations/decodex/cache/github/control-plane-upgrades",
+	".agent/automations/decodex/cache/github/impact",
+	".agent/automations/decodex/cache/github/review-queue",
+	".agent/automations/decodex/cache/github/reviews",
+	".agent/automations/decodex/cache/site-content/signals",
 ]
+required_paths = [
+	"apps/decodex/src/radar.rs",
+	"automations/decodex/scripts/github/control_plane_upgrade_candidate.schema.json",
+	"automations/decodex/scripts/github/run_codex_analysis.py",
+	"automations/decodex/skills/codex-code-analysis/SKILL.md",
+	"automations/decodex/skills/codex-upstream-triage/SKILL.md",
+	"automations/decodex/skills/github-signal/SKILL.md",
+	"docs/spec/control-plane-upgrade-candidate.md",
+	"docs/spec/github-change-bundle.md",
+	"docs/spec/signal-entry.md",
+	"docs/spec/social-candidate.md",
+	"docs/spec/upstream-impact.md",
+	"docs/spec/upstream-review.md",
+]
+rrule = "FREQ=HOURLY;INTERVAL=6;BYMINUTE=0;BYSECOND=0"
 
 [[automations]]
 id = "codex-release-checkpoint-publisher"
 name = "Decodex Release Curator"
-rrule = "FREQ=HOURLY;INTERVAL=6;BYMINUTE=20;BYSECOND=0"
 prompt_file = "automations/decodex/prompts/release-curator.md"
-required_paths = [
-  "automations/decodex/skills/codex-release-analysis/SKILL.md",
-  "automations/decodex/skills/x-post-quality-system/SKILL.md",
-  "automations/decodex/skills/references/social-release-publisher-gates.md",
-  "apps/decodex/src/radar.rs",
-  "docs/spec/release-delta.md",
-  "docs/spec/upstream-review.md",
-  "docs/spec/upstream-impact.md",
-  "docs/spec/social-candidate.md",
-  "docs/spec/social-publishing.md",
-]
 required_cache_prefixes = [
-  ".agent/automations/decodex/cache/site-content/release-deltas",
-  ".agent/automations/decodex/cache/site-content/signals",
-  ".agent/automations/decodex/cache/github/social-candidates",
-  ".agent/automations/decodex/cache/github/reviews",
-  ".agent/automations/decodex/cache/github/impact",
+	".agent/automations/decodex/cache/github/impact",
+	".agent/automations/decodex/cache/github/reviews",
+	".agent/automations/decodex/cache/github/social-candidates",
+	".agent/automations/decodex/cache/site-content/release-deltas",
+	".agent/automations/decodex/cache/site-content/signals",
 ]
+required_paths = [
+	"apps/decodex/src/radar.rs",
+	"automations/decodex/skills/codex-release-analysis/SKILL.md",
+	"automations/decodex/skills/references/social-release-publisher-gates.md",
+	"automations/decodex/skills/x-post-quality-system/SKILL.md",
+	"docs/spec/release-delta.md",
+	"docs/spec/social-candidate.md",
+	"docs/spec/social-publishing.md",
+	"docs/spec/upstream-impact.md",
+	"docs/spec/upstream-review.md",
+]
+rrule = "FREQ=HOURLY;INTERVAL=6;BYMINUTE=20;BYSECOND=0"
 
 [[automations]]
 id = "decodex-x-publisher"
 name = "Decodex X Publisher"
-rrule = "FREQ=HOURLY;INTERVAL=6;BYMINUTE=50;BYSECOND=0"
 prompt_file = "automations/decodex/prompts/x-publisher.md"
-required_paths = [
-  "automations/decodex/skills/x-post-publisher/SKILL.md",
-  "automations/decodex/skills/x-post-quality-system/SKILL.md",
-  "automations/decodex/skills/references/social-release-publisher-gates.md",
-  "apps/decodex/src/radar.rs",
-  "docs/spec/social-candidate.md",
-  "docs/spec/social-publishing.md",
-  "docs/runbook/social-publishing-workflow.md",
-]
 required_cache_prefixes = [
-  ".agent/automations/decodex/cache/github/social-candidates",
-  ".agent/automations/decodex/cache/social/x/reservations",
-  ".agent/automations/decodex/cache/social/x/posts",
+	".agent/automations/decodex/cache/github/social-candidates",
+	".agent/automations/decodex/cache/social/x/posts",
+	".agent/automations/decodex/cache/social/x/reservations",
 ]
+required_paths = [
+	"apps/decodex/src/radar.rs",
+	"automations/decodex/skills/references/social-release-publisher-gates.md",
+	"automations/decodex/skills/x-post-publisher/SKILL.md",
+	"automations/decodex/skills/x-post-quality-system/SKILL.md",
+	"docs/runbook/social-publishing-workflow.md",
+	"docs/spec/social-candidate.md",
+	"docs/spec/social-publishing.md",
+]
+rrule = "FREQ=HOURLY;INTERVAL=6;BYMINUTE=50;BYSECOND=0"
 
 [[automations]]
 id = "decodex-radar-artifact-archive"
 name = "Decodex Automation Retention"
-rrule = "FREQ=DAILY;BYHOUR=3;BYMINUTE=30;BYSECOND=0"
 prompt_file = "automations/decodex/prompts/retention.md"
-required_paths = [
-  "apps/decodex/src/radar.rs",
-  "docs/spec/radar-artifact-retention.md",
-  "docs/runbook/radar-artifact-archive.md",
-]
 required_cache_prefixes = [
-  ".agent/automations/decodex/cache/github/bundles",
-  ".agent/automations/decodex/cache/github/reviews",
-  ".agent/automations/decodex/cache/github/impact",
-  ".agent/automations/decodex/cache/generated/analysis",
-  ".agent/automations/decodex/cache/archive/index",
+	".agent/automations/decodex/cache/archive/index",
+	".agent/automations/decodex/cache/generated/analysis",
+	".agent/automations/decodex/cache/github/bundles",
+	".agent/automations/decodex/cache/github/impact",
+	".agent/automations/decodex/cache/github/reviews",
 ]
+required_paths = [
+	"apps/decodex/src/radar.rs",
+	"docs/runbook/radar-artifact-archive.md",
+	"docs/spec/radar-artifact-retention.md",
+]
+rrule = "FREQ=DAILY;BYHOUR=3;BYMINUTE=30;BYSECOND=0"
 
 [[automations]]
 id = "decodex-automation-health-audit"
 name = "Decodex Automation Evaluator"
-rrule = "FREQ=DAILY;BYHOUR=4;BYMINUTE=40;BYSECOND=0"
 prompt_file = "automations/decodex/prompts/automation-evaluator.md"
-required_paths = [
-  "automations/decodex/automations.toml",
-  "automations/decodex/scripts/config/evaluate_automations.py",
-  "apps/decodex/src/radar.rs",
-  "automations/decodex/README.md",
-  "docs/policy.md",
-]
 required_cache_prefixes = [
-  ".agent/automations/decodex/cache/github",
-  ".agent/automations/decodex/cache/social",
-  ".agent/automations/decodex/cache/archive",
-  ".agent/automations/decodex/cache/generated",
+	".agent/automations/decodex/cache/archive",
+	".agent/automations/decodex/cache/generated",
+	".agent/automations/decodex/cache/github",
+	".agent/automations/decodex/cache/social",
 ]
+required_paths = [
+	"apps/decodex/src/radar.rs",
+	"automations/decodex/README.md",
+	"automations/decodex/automations.toml",
+	"automations/decodex/scripts/config/evaluate_automations.py",
+	"docs/policy.md",
+]
+rrule = "FREQ=DAILY;BYHOUR=4;BYMINUTE=40;BYSECOND=0"

--- a/docs/log.md
+++ b/docs/log.md
@@ -12,6 +12,11 @@
 - Corrected repository ownership docs so `automations/decodex` is the repo-owned
   source for upstream monitoring and guarded publishing automation, while recurring
   Codex App execution and private generated state remain outside tracked source.
+- Bridged Program Intake dispatchable nodes into the targeted run path and operator
+  readback: `decodex run <ISSUE>` can infer `program` dispatch for a mapped
+  dispatchable Program node without a service queue label, and live status treats
+  local shared run claims as active Program ownership instead of a self-conflicting
+  cleanup-only worktree.
 
 ## 2026-06-25
 

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -8,7 +8,7 @@ owner: docs
 tags: [reference]
 code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/recovery.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/types.rs, apps/decodex/src/orchestrator/operator_http.rs, apps/decodex/src/orchestrator/operator_dashboard.html, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/mcp.rs]
 drift_watch: [decodex serve, decodex status, decodex recover ghost-lane, ghost_lane_cleanup_audit_present, mcp_test_fixture_ghost_lane, decodex evidence, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, phase_acceptance_check, control_plane_snapshot, operator dashboard, runtime.sqlite3, project.toml, WORKFLOW.md]
-last_verified: 2026-06-23
+last_verified: 2026-06-27
 ---
 # Operator Control Plane
 
@@ -208,9 +208,12 @@ issues manually with service-scoped queue labels, but persisted Execution Progra
 dispatch ready mapped nodes directly and do not mutate those labels.
 
 When `decodex run --dry-run` or the status output has no eligible intake candidate,
-the operator hint points to the short checklist: `Todo`, the service-scoped
+the operator hint points to the ordinary queue checklist: `Todo`, the service-scoped
 `decodex:queued:<service-id>` label, no opt-out or needs-attention labels, a
-non-terminal state, no open dependency blockers, and available local capacity.
+non-terminal state, no open dependency blockers, and available local capacity. Ready
+Program Intake nodes are not queue-label candidates; they appear under Execution
+Programs, and `decodex run <ISSUE>` can start a mapped dispatchable Program node with
+`program` dispatch mode.
 
 The runtime database is the local source of truth for active execution. Linear and
 GitHub remain external collaboration mirrors and validation surfaces.
@@ -350,7 +353,9 @@ identifiers, dispatchable count, and sparse `node_readbacks[]` for direct dispat
 decisions or nodes that need operator context. Live status refreshes mapped issue
 state, service labels, needs-attention labels, dependency blockers, and post-review
 lifecycle ownership before it evaluates those program counts, so terminal Linear
-states and cleared labels supersede older persisted Program mappings. Dependency
+states and cleared labels supersede older persisted Program mappings. It also reads
+local shared run claims; a mapped issue with a live lease is shown as an active
+Program node rather than a cleanup-only conflict-domain blocker. Dependency
 diagnostics use `dependency_not_terminal` with a next action to complete the
 dependency issue or refresh the Execution Program dependency plan when a stale
 dependency program is the real blocker.

--- a/docs/spec/loop-runtime.md
+++ b/docs/spec/loop-runtime.md
@@ -8,7 +8,7 @@ owner: runtime
 tags: [spec]
 code_refs: [apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/prompting.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/research_design.rs, apps/decodex/src/autonomy_proposal.rs, apps/decodex/src/loop_contract.rs, apps/decodex/src/execution_program.rs, apps/decodex/src/program_intake.rs]
 drift_watch: [phase_goal, phase_acceptance_check, docs_impact, review_contract, issue_review_checkpoint, decodex.autonomy_proposal/1, decodex.decision_contract/1, execution_program, decodex research compile, decodex research promote, decodex intake goal]
-last_verified: 2026-06-23
+last_verified: 2026-06-27
 ---
 # Loop Runtime Specification
 
@@ -527,7 +527,11 @@ The Program scheduler is event-driven from local runtime state:
   selection.
 - The scheduler refreshes only mapped Linear issue facts required for readiness:
   issue state, active/manual-only/needs-attention labels, open blockers, briefing
-  presence, dependency observations, and occupied conflict domains.
+  presence, dependency observations, local shared run claims, and occupied conflict
+  domains.
+- A local shared run claim for the mapped issue makes that Program node active for
+  scheduler and status readback, so startup worktree ownership does not self-block as
+  `conflict_domain_occupied` while the live lane is already leased.
 - When several nodes are dispatchable, normal issue candidate ordering chooses the
   first lane, and project/account concurrency still gates actual execution.
 - Service queue labels are not applied, retained, removed, or treated as Program

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -8,7 +8,7 @@ owner: runtime
 tags: [spec]
 code_refs: [apps/decodex/src/agent/tracker_tool_bridge.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs, apps/decodex/src/autonomy_signal.rs, apps/decodex/src/autonomy_proposal.rs, apps/decodex/src/orchestrator/execution.rs, apps/decodex/src/orchestrator/git_ops.rs, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/mcp.rs, apps/decodex/src/state/store.rs, apps/decodex/src/state/internal.rs, apps/decodex/src/program_intake.rs, apps/decodex/src/execution_program.rs, apps/decodex/src/config.rs, decodex.example.toml]
 drift_watch: [issue_progress_checkpoint, phase_acceptance_check, issue_terminal_finalize, docs_impact, manual_attention, review_handoff, review_repair, closeout, phase_goal, repo_gate_tracked_rewrites_left, protocol_events, review_policy_checkpoints, review_checkpoint, review_lifecycle_records, lane_control_next_action, review_handoff_pending, review_repair_pending, review_repair_writeback_missing_lifecycle_marker, review_repair_writeback_stale_lifecycle_marker, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call, decodex intake goal, program_issue_mappings, autonomy_proposals, decodex.autonomy_proposal/1, "[autonomy]", auto_promote, auto_intake, "[autonomy.runtime_policy]", accepted_objective_id, accepted_objective_version, accepted_policy_id, accepted_policy_version, policy_authority_ref]
-last_verified: 2026-06-23
+last_verified: 2026-06-27
 ---
 # Runtime Specification
 
@@ -135,11 +135,15 @@ state or this state machine.
   `--apply` writes only local runtime Program Intake and Execution Program state.
 - Each scheduler pass evaluates persisted Execution Programs before ordinary queued
   issue selection. The Program scheduler refreshes mapped Linear issue state,
-  dependency observations, local run leases, retained review/landing worktrees,
-  needs-attention labels, and occupied conflict domains; then it directly selects
+  dependency observations, local shared run claims, retained review/landing
+  worktrees, needs-attention labels, and occupied conflict domains; then it directly selects
   dispatchable ready nodes with `program` dispatch mode. It must not apply or remove
   service queue labels, and Program readiness must not wait for the ordinary
   Linear-backed queue scan interval.
+- When `decodex run <ISSUE>` targets a mapped Program node, inferred dispatch checks
+  the same persisted Program eligibility before ordinary queue-label dispatch. A
+  target whose node currently has `dispatch_action = dispatch` starts with `program`
+  dispatch mode without requiring `decodex:queued:<service-id>`.
 
 The evidence boundary is ordered from private runtime authority to public collaboration
 mirror:


### PR DESCRIPTION
## Summary
- Bridge mapped Program Intake nodes into targeted `decodex run <ISSUE>` dispatch using `program` dispatch mode when scheduler eligibility says the node is dispatchable.
- Feed active shared run claims into Program readiness/status so a mapped live lane reads as active instead of self-blocked by `conflict_domain_occupied`.
- Add regression coverage for targeted Program dispatch, stale mapping reconciliation, active self-conflict suppression, peer conflict blocking, and needs-attention precedence.
- Update runtime/operator docs for Program dispatch and live status behavior.

## Validation
- `cargo make fmt`
- `cargo make lint-fix`
- `cargo make test` (1494 passed, 1 skipped)
- `cargo make check-docs`

## Review
- Independent fresh-context current-head review checkpoint recorded clean for `e0d286866af0861095e22e38b87fa1ac8f9e252f`.