### PR TITLE
Add autonomy objective acceptance and social gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,10 +196,15 @@ deliberately small. Local stdio defaults to the `admin` capability profile; Stre
 HTTP defaults to `observe`. Both can be set with
 `--capability-profile observe|plan|operate|admin`; `tools/list` filters by the active
 profile and `tools/call` returns structured refusals for tools above it. Observe is
-read-only. Plan exposes `research_compile`, `research_promote`, and `intake_goal`:
+read-only. Plan exposes research, goal-intake, and objective-driven autonomy tools:
 dry-run modes validate or preview without tracker or Program Intake mutation, while
 apply/promote modes require explicit authority fields and return structured refusals
-when authority or project context is missing. Operate exposes `decodex_lane_control`
+when authority or project context is missing. Autonomy plan tools can draft and accept
+Objective Contracts, submit signals, compile or challenge proposals, and request
+proposal promotion without starting execution. Direct Objective Contract acceptance
+requires human/operator authority; policy-backed acceptance fails closed until it is
+resolved from trusted Decodex runtime authority state. Operate exposes
+`decodex_lane_control`
 as an inspect-first lane-control facade: `inspect` returns current preconditions,
 `steer` and `interrupt` delegate through existing lane-control guards only with
 current run/turn authority, and `manual_attention` or `retained_resume` refuse back to

--- a/apps/decodex/src/cli.rs
+++ b/apps/decodex/src/cli.rs
@@ -318,19 +318,16 @@ impl AccountCommand {
 	fn run(&self) -> Result<()> {
 		match &self.command {
 			AccountSubcommand::List(args) => accounts::run_account_list(args.json),
-			AccountSubcommand::Select(args) => {
-				accounts::run_account_select(&args.selector, args.json)
-			},
+			AccountSubcommand::Select(args) =>
+				accounts::run_account_select(&args.selector, args.json),
 			AccountSubcommand::Clear(args) => accounts::run_account_clear(args.json),
-			AccountSubcommand::Logout(args) => {
-				accounts::run_account_logout(&args.selector, args.json)
-			},
-			AccountSubcommand::ImportAuth(args) => {
+			AccountSubcommand::Logout(args) =>
+				accounts::run_account_logout(&args.selector, args.json),
+			AccountSubcommand::ImportAuth(args) =>
 				accounts::run_account_import(&AccountImportRequest {
 					auth_json_path: args.auth_json.clone(),
 					json: args.json,
-				})
-			},
+				}),
 			AccountSubcommand::Use(args) => accounts::run_account_use(&AccountUseRequest {
 				selector: args.selector.clone(),
 				auth_json_path: args.auth_json.clone(),
@@ -1170,12 +1167,11 @@ struct ReviewHandoffRecoveryCommand {
 impl ReviewHandoffRecoveryCommand {
 	fn run(&self, config_path: Option<&Path>) -> Result<()> {
 		match &self.command {
-			ReviewHandoffRecoverySubcommand::Diagnose(args) => {
+			ReviewHandoffRecoverySubcommand::Diagnose(args) =>
 				recovery::run_review_handoff_diagnose(
 					config_path,
 					&ReviewHandoffDiagnoseRequest { issue: args.issue.clone(), json: args.json },
-				)
-			},
+				),
 			ReviewHandoffRecoverySubcommand::Rebind(args) => recovery::run_review_handoff_rebind(
 				config_path,
 				&ReviewHandoffRebindRequest {
@@ -2042,8 +2038,8 @@ enum Command {
 	ArchiveLinear(ArchiveLinearCommand),
 	/// Maintain local Decodex logs, evidence, backups, and runtime storage.
 	Maintenance(MaintenanceCommand),
-		/// Manage the user-local Decodex Codex account pool.
-		Account(AccountCommand),
+	/// Manage the user-local Decodex Codex account pool.
+	Account(AccountCommand),
 	/// Validate the local app-server integration boundary.
 	Probe(ProbeCommand),
 	/// Run one daemon-planned attempt from a structured request.

--- a/apps/decodex/src/lib.rs
+++ b/apps/decodex/src/lib.rs
@@ -95,7 +95,5 @@ fn install_panic_hook() {
 	}));
 }
 
-#[cfg(test)]
-mod plugin_surface_tests;
-#[cfg(test)]
-mod test_support;
+#[cfg(test)] mod plugin_surface_tests;
+#[cfg(test)] mod test_support;

--- a/apps/decodex/src/mcp.rs
+++ b/apps/decodex/src/mcp.rs
@@ -17,7 +17,10 @@ use serde_json::{self, Value};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::{
-	autonomy_objective::{AutonomyObjectiveContract, AutonomyObjectiveState},
+	autonomy_objective::{
+		AutonomyObjectiveAcceptance, AutonomyObjectiveActorKind, AutonomyObjectiveContract,
+		AutonomyObjectiveState,
+	},
 	autonomy_proposal::{
 		AutonomyProposal, AutonomyProposalAuthorityActorKind, AutonomyProposalChallengeInput,
 		AutonomyProposalChallengeSource, AutonomyProposalCompileInput,
@@ -64,6 +67,7 @@ const TOOL_RESEARCH_COMPILE: &str = "research_compile";
 const TOOL_RESEARCH_PROMOTE: &str = "research_promote";
 const TOOL_INTAKE_GOAL: &str = "intake_goal";
 const TOOL_AUTONOMY_DRAFT_OBJECTIVE: &str = "autonomy_draft_objective";
+const TOOL_AUTONOMY_ACCEPT_OBJECTIVE: &str = "autonomy_accept_objective";
 const TOOL_AUTONOMY_SUBMIT_SIGNAL: &str = "autonomy_submit_signal";
 const TOOL_AUTONOMY_COMPILE_PROPOSAL: &str = "autonomy_compile_proposal";
 const TOOL_AUTONOMY_CHALLENGE_PROPOSAL: &str = "autonomy_challenge_proposal";
@@ -373,6 +377,8 @@ impl McpServer {
 			TOOL_RESEARCH_PROMOTE => Ok(self.call_research_promote_tool(arguments)),
 			TOOL_INTAKE_GOAL => Ok(self.call_intake_goal_tool(arguments)),
 			TOOL_AUTONOMY_DRAFT_OBJECTIVE => Ok(self.call_autonomy_draft_objective_tool(arguments)),
+			TOOL_AUTONOMY_ACCEPT_OBJECTIVE =>
+				Ok(self.call_autonomy_accept_objective_tool(arguments)),
 			TOOL_AUTONOMY_SUBMIT_SIGNAL => Ok(self.call_autonomy_submit_signal_tool(arguments)),
 			TOOL_AUTONOMY_COMPILE_PROPOSAL =>
 				Ok(self.call_autonomy_compile_proposal_tool(arguments)),
@@ -791,6 +797,119 @@ impl McpServer {
 				"objective_draft_refused",
 				format!(
 					"Objective Contract draft was refused by Decodex authority checks: {error}"
+				),
+			),
+		}
+	}
+
+	fn call_autonomy_accept_objective_tool(&self, arguments: Value) -> Value {
+		let params = match serde_json::from_value::<AutonomyAcceptObjectiveToolArgs>(arguments) {
+			Ok(params) => params,
+			Err(_) =>
+				return invalid_tool_arguments(
+					TOOL_AUTONOMY_ACCEPT_OBJECTIVE,
+					"`objectiveId`, `objectiveVersion`, and optional `mode` are required.",
+				),
+		};
+		let Some(objective_id) = non_empty_string(Some(params.objective_id.as_str())) else {
+			return invalid_tool_arguments(
+				TOOL_AUTONOMY_ACCEPT_OBJECTIVE,
+				"`objectiveId` is required.",
+			);
+		};
+		if !safe_autonomy_record_identifier(objective_id) {
+			return invalid_tool_arguments(
+				TOOL_AUTONOMY_ACCEPT_OBJECTIVE,
+				"`objectiveId` must be a safe Decodex autonomy identifier.",
+			);
+		}
+		if params.objective_version == 0 {
+			return invalid_tool_arguments(
+				TOOL_AUTONOMY_ACCEPT_OBJECTIVE,
+				"`objectiveVersion` must be greater than zero.",
+			);
+		}
+
+		let mode = match planning_mode(
+			params.mode.as_deref(),
+			"dry_run",
+			TOOL_AUTONOMY_ACCEPT_OBJECTIVE,
+		) {
+			Ok(mode) => mode,
+			Err(result) => return result,
+		};
+		let project_id = match planning_project_id(
+			&self.context,
+			params.project_id.as_deref(),
+			TOOL_AUTONOMY_ACCEPT_OBJECTIVE,
+		) {
+			Ok(project_id) => project_id,
+			Err(result) => return result,
+		};
+		let store = match planning_state_store(&self.context, TOOL_AUTONOMY_ACCEPT_OBJECTIVE) {
+			Ok(store) => store,
+			Err(result) => return result,
+		};
+		let record =
+			match store.autonomy_objective(&project_id, objective_id, params.objective_version) {
+				Ok(Some(record)) => record,
+				Ok(None) =>
+					return tool_refusal(
+						"objective_not_found",
+						"Autonomy Objective Contract draft was not found in the current Decodex project.",
+					),
+				Err(error) =>
+					return tool_refusal(
+						"objective_acceptance_refused",
+						format!("Objective Contract readback failed closed: {error}"),
+					),
+			};
+
+		if record.state() != AutonomyObjectiveState::Draft {
+			return tool_refusal(
+				"objective_acceptance_refused",
+				"Only draft Objective Contract versions can be accepted through autonomy_accept_objective.",
+			);
+		}
+
+		if mode == "dry_run" {
+			return tool_success(autonomy_objective_accept_tool_result(
+				&project_id,
+				record.objective(),
+				mode,
+				false,
+				Some(record.updated_at()),
+			));
+		}
+
+		let Some(authority) = params.authority else {
+			return missing_authority_refusal(
+				TOOL_AUTONOMY_ACCEPT_OBJECTIVE,
+				"autonomy_accept_objective apply requires explicit objective acceptance authority.",
+			);
+		};
+		let acceptance = match authority.into_acceptance() {
+			Ok(acceptance) => acceptance,
+			Err(result) => return result,
+		};
+
+		match store.accept_autonomy_objective_version(
+			&project_id,
+			objective_id,
+			params.objective_version,
+			acceptance,
+		) {
+			Ok(record) => tool_success(autonomy_objective_accept_tool_result(
+				&project_id,
+				record.objective(),
+				mode,
+				true,
+				Some(record.updated_at()),
+			)),
+			Err(error) => tool_refusal(
+				"objective_acceptance_refused",
+				format!(
+					"Objective Contract acceptance was refused by Decodex authority checks: {error}"
 				),
 			),
 		}
@@ -1924,6 +2043,48 @@ struct AutonomyDraftObjectiveToolArgs {
 	project_id: Option<String>,
 	objective: AutonomyObjectiveContract,
 	authority: Option<PlanningAuthorityArgs>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AutonomyAcceptObjectiveToolArgs {
+	mode: Option<String>,
+	project_id: Option<String>,
+	objective_id: String,
+	objective_version: u64,
+	authority: Option<AutonomyObjectiveAcceptanceArgs>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AutonomyObjectiveAcceptanceArgs {
+	accepted_by: String,
+	accepted_by_kind: AutonomyObjectiveActorKind,
+	accepted_at: Option<String>,
+	acceptance_source: String,
+}
+impl AutonomyObjectiveAcceptanceArgs {
+	fn into_acceptance(self) -> Result<AutonomyObjectiveAcceptance, Value> {
+		if self.accepted_by_kind == AutonomyObjectiveActorKind::RuntimePolicy {
+			return Err(tool_refusal(
+				"objective_acceptance_refused",
+				"Runtime-policy Objective Contract acceptance must be resolved from trusted Decodex authority state; caller-supplied runtime_policy acceptance fails closed.",
+			));
+		}
+
+		AutonomyObjectiveAcceptance::new(
+			self.accepted_by,
+			self.accepted_by_kind,
+			self.accepted_at.unwrap_or_else(mcp_now_rfc3339),
+			self.acceptance_source,
+		)
+		.map_err(|error| {
+			tool_refusal(
+				"objective_acceptance_refused",
+				format!("Objective Contract acceptance authority was refused: {error}"),
+			)
+		})
+	}
 }
 
 #[derive(Deserialize)]
@@ -3307,6 +3468,15 @@ fn mcp_autonomy_tools() -> Vec<McpTool> {
 		),
 		mcp_tool_entry(
 			McpCapabilityProfile::Plan,
+			TOOL_AUTONOMY_ACCEPT_OBJECTIVE,
+			"Decodex Autonomy Accept Objective",
+			"Accept a draft Objective Contract version as project-level autonomy authority without starting execution.",
+			autonomy_accept_objective_tool_input_schema(),
+			autonomy_objective_tool_output_schema(),
+			false,
+		),
+		mcp_tool_entry(
+			McpCapabilityProfile::Plan,
 			TOOL_AUTONOMY_SUBMIT_SIGNAL,
 			"Decodex Autonomy Submit Signal",
 			"Validate or persist proposal-only autonomy signal evidence under an accepted objective.",
@@ -3425,6 +3595,7 @@ fn tool_required_profile(name: &str) -> Option<McpCapabilityProfile> {
 		| TOOL_RESEARCH_PROMOTE
 		| TOOL_INTAKE_GOAL
 		| TOOL_AUTONOMY_DRAFT_OBJECTIVE
+		| TOOL_AUTONOMY_ACCEPT_OBJECTIVE
 		| TOOL_AUTONOMY_SUBMIT_SIGNAL
 		| TOOL_AUTONOMY_COMPILE_PROPOSAL
 		| TOOL_AUTONOMY_CHALLENGE_PROPOSAL
@@ -3586,6 +3757,59 @@ fn autonomy_draft_objective_tool_input_schema() -> Value {
 			"authority": planning_authority_input_schema()
 		},
 		"required": ["objective"]
+	})
+}
+
+fn autonomy_accept_objective_tool_input_schema() -> Value {
+	serde_json::json!({
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"mode": {
+				"type": "string",
+				"enum": ["dry_run", "apply"],
+				"description": "dry_run inspects the draft acceptance target; apply accepts the draft Objective Contract version."
+			},
+			"projectId": {
+				"type": "string",
+				"description": "Optional Decodex service id when the MCP context is not project-scoped."
+			},
+			"objectiveId": {
+				"type": "string",
+				"description": "Objective Contract id to accept."
+			},
+			"objectiveVersion": {
+				"type": "integer",
+				"minimum": 1,
+				"description": "Draft Objective Contract version to accept."
+			},
+			"authority": {
+				"type": "object",
+				"additionalProperties": false,
+				"description": "Explicit human/operator objective acceptance authority. Runtime-policy acceptance requires trusted Decodex state and is not accepted from caller-supplied fields.",
+				"properties": {
+					"acceptedBy": {
+						"type": "string",
+						"description": "Human or operator actor accepting the Objective Contract."
+					},
+					"acceptedByKind": {
+						"type": "string",
+						"enum": ["user"],
+						"description": "Only direct user/operator acceptance is accepted through this tool until trusted runtime-policy resolution exists."
+					},
+					"acceptedAt": {
+						"type": "string",
+						"description": "Optional RFC3339 acceptance timestamp; Decodex fills the current time when omitted."
+					},
+					"acceptanceSource": {
+						"type": "string",
+						"description": "Source of the explicit acceptance, such as conversation or operator command."
+					}
+				},
+				"required": ["acceptedBy", "acceptedByKind", "acceptanceSource"]
+			}
+		},
+		"required": ["objectiveId", "objectiveVersion"]
 	})
 }
 
@@ -4608,6 +4832,26 @@ fn autonomy_objective_tool_result(
 		"objective": mcp_autonomy_objective_summary(objective, updated_at),
 		"authority_effect": "draft_only_no_execution_authority",
 		"next_action": "Accept an Objective Contract only through explicit human or accepted-policy authority; MCP profile access is not acceptance authority.",
+		"updated_at": updated_at
+	}))
+}
+
+fn autonomy_objective_accept_tool_result(
+	project_id: &str,
+	objective: &AutonomyObjectiveContract,
+	mode: &str,
+	persisted: bool,
+	updated_at: Option<&str>,
+) -> Value {
+	mcp_sanitized_value(serde_json::json!({
+		"schema": "decodex.mcp.autonomy_objective_result/1",
+		"status": "ok",
+		"mode": mode,
+		"persisted": persisted,
+		"project_id": project_id,
+		"objective": mcp_autonomy_objective_summary(objective, updated_at),
+		"authority_effect": "accepted_objective_no_execution_authority",
+		"next_action": "Accepted Objective Contracts allow objective-bound signals and proposals; execution still requires proposal acceptance, Decision Contract promotion, and Program Intake.",
 		"updated_at": updated_at
 	}))
 }
@@ -7903,6 +8147,17 @@ mod tests {
 		assert_eq!(observe_structured["reason"], "insufficient_capability_profile");
 		assert_eq!(observe_structured["required_capability_profile"], "plan");
 
+		let observe_accept_responses = run_stdio_with_profile(
+			repo.path(),
+			McpCapabilityProfile::Observe,
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"autonomy_accept_objective","arguments":{"objectiveId":"quality-autonomy","objectiveVersion":1}}}"#,
+		);
+		let observe_accept_structured =
+			&response_at(&observe_accept_responses, 0)["result"]["structuredContent"];
+
+		assert_eq!(observe_accept_structured["reason"], "insufficient_capability_profile");
+		assert_eq!(observe_accept_structured["required_capability_profile"], "plan");
+
 		let state_store = StateStore::open_in_memory().expect("state store should open");
 		let context = McpContext {
 			repo_root: repo.path().to_path_buf(),
@@ -7920,6 +8175,74 @@ mod tests {
 		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.refusal/1");
 		assert_eq!(result["structuredContent"]["reason"], "missing_authority");
 		assert_eq!(result["structuredContent"]["tool"], "autonomy_draft_objective");
+	}
+
+	#[test]
+	fn autonomy_accept_objective_accepts_draft_without_execution_authority() {
+		let repo = test_repo();
+		let state_store = StateStore::open_in_memory().expect("state store should open");
+		let draft_call = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"autonomy_draft_objective","arguments":{"mode":"apply","objective":{"schema":"decodex.autonomy_objective/1","record_version":1,"project_id":"decodex","id":"self-iteration-pilot","version":1,"state":"draft","summary":"Pilot Decodex self-iteration only on the decodex project.","goals":["Reduce repeated operator intervention.","Convert Decodex-only feedback into evidence-backed proposals."],"non_goals":["Do not touch other projects.","Do not bypass review, landing, install, restart, or plugin-sync gates."],"metrics":["Manual-attention count.","Validated proposal replay completeness."],"allowed_surfaces":["apps/decodex/src","automations/decodex","docs","plugins/decodex","plugins/knowledge"],"allowed_signal_kinds":["runtime_health","protocol_drift","execution_friction","docs_skill_drift","validation_regression","user_feedback_cluster"],"validation_gates":["cargo make check-docs","cargo test -p decodex mcp --lib"],"review_policy":"challenge required before promotion","memory_policy":"source-linked evidence only","report_policy":"public-safe source refs with known gaps"},"authority":{"source":"mcp-test","reason":"store draft objective"}}}}"#;
+		let accept_missing_authority_call = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"autonomy_accept_objective","arguments":{"mode":"apply","objectiveId":"self-iteration-pilot","objectiveVersion":1}}}"#;
+		let accept_call = r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"autonomy_accept_objective","arguments":{"mode":"apply","objectiveId":"self-iteration-pilot","objectiveVersion":1,"authority":{"acceptedBy":"operator","acceptedByKind":"user","acceptedAt":"2026-06-27T00:00:00Z","acceptanceSource":"conversation"}}}}"#;
+		let read_call = r#"{"jsonrpc":"2.0","id":4,"method":"resources/read","params":{"uri":"decodex://projects/decodex/autonomy/objectives/self-iteration-pilot/current"}}"#;
+		let responses = run_stdio_with_context(
+			McpContext {
+				repo_root: repo.path().to_path_buf(),
+				config_path: None,
+				project_id: Some(String::from("decodex")),
+				state_store: Some(state_store),
+			},
+			&format!("{draft_call}\n{accept_missing_authority_call}\n{accept_call}\n{read_call}"),
+		);
+		let draft_result = &response_at(&responses, 0)["result"]["structuredContent"];
+		let missing_authority_result = &response_at(&responses, 1)["result"];
+		let accept_result = &response_at(&responses, 2)["result"]["structuredContent"];
+		let read_result = &response_at(&responses, 3)["result"]["contents"][0]["text"];
+		let read_json: serde_json::Value =
+			serde_json::from_str(read_result.as_str().expect("resource text should parse"))
+				.expect("resource should be json");
+
+		assert_eq!(draft_result["schema"], "decodex.mcp.autonomy_objective_result/1");
+		assert_eq!(draft_result["objective"]["state"], "draft");
+		assert_eq!(draft_result["persisted"], true);
+		assert_eq!(missing_authority_result["isError"], true);
+		assert_eq!(missing_authority_result["structuredContent"]["reason"], "missing_authority");
+		assert_eq!(accept_result["schema"], "decodex.mcp.autonomy_objective_result/1");
+		assert_eq!(accept_result["objective"]["state"], "accepted");
+		assert_eq!(accept_result["objective"]["acceptance_present"], true);
+		assert_eq!(accept_result["authority_effect"], "accepted_objective_no_execution_authority");
+		assert_eq!(read_json["objective"]["objective_id"], "self-iteration-pilot");
+		assert_eq!(read_json["objective"]["state"], "accepted");
+	}
+
+	#[test]
+	fn autonomy_accept_objective_refuses_caller_supplied_runtime_policy_authority() {
+		let repo = test_repo();
+		let state_store = StateStore::open_in_memory().expect("state store should open");
+		state_store
+			.upsert_autonomy_objective_draft("decodex", autonomy_objective_fixture())
+			.expect("objective draft should persist");
+
+		let responses = run_stdio_with_context(
+			McpContext {
+				repo_root: repo.path().to_path_buf(),
+				config_path: None,
+				project_id: Some(String::from("decodex")),
+				state_store: Some(state_store),
+			},
+			r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"autonomy_accept_objective","arguments":{"mode":"apply","objectiveId":"quality-autonomy","objectiveVersion":1,"authority":{"acceptedBy":"policy:auto","acceptedByKind":"runtime_policy","acceptanceSource":"caller-supplied-policy"}}}}"#,
+		);
+		let result = &response_at(&responses, 0)["result"];
+
+		assert_eq!(result["isError"], true);
+		assert_eq!(result["structuredContent"]["schema"], "decodex.mcp.refusal/1");
+		assert_eq!(result["structuredContent"]["reason"], "objective_acceptance_refused");
+		assert!(
+			result["structuredContent"]["message"]
+				.as_str()
+				.expect("refusal message should be text")
+				.contains("trusted Decodex authority state")
+		);
 	}
 
 	fn seed_autonomy_challenged_proposal() -> (TempDir, std::path::PathBuf, String) {

--- a/apps/decodex/src/radar.rs
+++ b/apps/decodex/src/radar.rs
@@ -1014,7 +1014,9 @@ impl GitHubError {
 			},
 			Self::Transport(error) => eyre::eyre!("GitHub API request failed for {url}: {error}"),
 			Self::Json { error, body } => {
-				eyre::eyre!("GitHub API response from {url} was not valid JSON: {error}; body: {body}")
+				eyre::eyre!(
+					"GitHub API response from {url} was not valid JSON: {error}; body: {body}"
+				)
 			},
 		}
 	}
@@ -1298,9 +1300,8 @@ pub(crate) fn build_bundle(request: &RadarBundleBuildRequest) -> crate::prelude:
 			};
 
 			match promoted_pr {
-				Some(pr_number) => {
-					client.build_pr_bundle(&request.repo, pr_number, &request.notes)?
-				},
+				Some(pr_number) =>
+					client.build_pr_bundle(&request.repo, pr_number, &request.notes)?,
 				None => client.build_commit_bundle(&request.repo, commit_sha, &request.notes)?,
 			}
 		},
@@ -4576,9 +4577,8 @@ fn validate_artifact(payload: &Value) -> ArtifactValidation {
 		Some(SIGNAL_SCHEMA) => validate_signal(entry, &mut errors),
 		Some(SOCIAL_CANDIDATE_SCHEMA) => validate_social_candidate(entry, &mut errors),
 		Some(SOCIAL_POST_SCHEMA) => validate_social_post(entry, &mut errors),
-		Some(SOCIAL_PUBLISH_RESERVATION_SCHEMA) => {
-			validate_social_publish_reservation(entry, &mut errors)
-		},
+		Some(SOCIAL_PUBLISH_RESERVATION_SCHEMA) =>
+			validate_social_publish_reservation(entry, &mut errors),
 		Some(UPSTREAM_IMPACT_SCHEMA) => validate_upstream_impact(entry, &mut errors),
 		Some(UPSTREAM_REVIEW_QUEUE_SCHEMA) => validate_upstream_review_queue(entry, &mut errors),
 		Some(UPSTREAM_REVIEW_SCHEMA) => validate_upstream_review(entry, &mut errors),
@@ -4822,11 +4822,10 @@ fn collect_json_strings(value: &Value, text: &mut String) {
 			text.push(' ');
 			text.push_str(value);
 		},
-		Value::Array(values) => {
+		Value::Array(values) =>
 			for value in values {
 				collect_json_strings(value, text);
-			}
-		},
+			},
 		Value::Object(object) => collect_json_strings_from_map(object, text),
 		Value::Bool(_) | Value::Null | Value::Number(_) => {},
 	}
@@ -5126,31 +5125,25 @@ fn validate_release_comparison_tags(
 	errors: &mut Vec<String>,
 ) {
 	match string_field(comparison, "stable_tag_name") {
-		Some("") => {
-			errors.push(format!("comparisons[{index}].stable_tag_name must be a non-empty string"))
-		},
+		Some("") =>
+			errors.push(format!("comparisons[{index}].stable_tag_name must be a non-empty string")),
 		Some(tag_name)
 			if !option_tags.stable.is_empty() && !option_tags.stable.contains(tag_name) =>
-		{
 			errors.push(format!(
 				"comparisons[{index}].stable_tag_name must exist in release_options.stable"
-			))
-		},
+			)),
 		Some(_) => {},
-		None => {
-			errors.push(format!("comparisons[{index}].stable_tag_name must be a non-empty string"))
-		},
+		None =>
+			errors.push(format!("comparisons[{index}].stable_tag_name must be a non-empty string")),
 	}
 	match string_field(comparison, "prerelease_tag_name") {
 		Some("") => errors
 			.push(format!("comparisons[{index}].prerelease_tag_name must be a non-empty string")),
 		Some(tag_name)
 			if !option_tags.preview.is_empty() && !option_tags.preview.contains(tag_name) =>
-		{
 			errors.push(format!(
 				"comparisons[{index}].prerelease_tag_name must exist in release_options.preview"
-			))
-		},
+			)),
 		Some(_) => {},
 		None => errors
 			.push(format!("comparisons[{index}].prerelease_tag_name must be a non-empty string")),
@@ -5865,12 +5858,10 @@ fn validate_social_publish_reservation_status_payload(
 	errors: &mut Vec<String>,
 ) {
 	match string_field(entry, "status") {
-		Some("consumed") if !is_non_empty_string(entry.get("consumed_by_social_post")) => {
-			errors.push("consumed_by_social_post is required when status is consumed".into())
-		},
-		Some("canceled" | "expired") if !is_non_empty_string(entry.get("release_reason")) => {
-			errors.push("release_reason is required when status is canceled or expired".into())
-		},
+		Some("consumed") if !is_non_empty_string(entry.get("consumed_by_social_post")) =>
+			errors.push("consumed_by_social_post is required when status is consumed".into()),
+		Some("canceled" | "expired") if !is_non_empty_string(entry.get("release_reason")) =>
+			errors.push("release_reason is required when status is canceled or expired".into()),
 		_ => {},
 	}
 }
@@ -5921,13 +5912,44 @@ fn validate_social_post_constants(entry: &Map<String, Value>, errors: &mut Vec<S
 }
 
 fn validate_social_post_text(text: Option<&Value>, errors: &mut Vec<String>) {
-	let valid = non_empty_array(text).is_some_and(|text| {
-		text.iter()
-			.all(|item| item.as_str().is_some_and(|text| !text.is_empty() && text.len() <= 280))
-	});
-
-	if !valid {
+	let Some(items) = non_empty_array(text) else {
 		errors.push("text must be a non-empty list of X-sized strings".into());
+
+		return;
+	};
+
+	for (index, item) in items.iter().enumerate() {
+		let Some(text) = item.as_str() else {
+			errors.push(format!("text[{index}] must be a string"));
+
+			continue;
+		};
+		validate_social_post_text_item(text, index, errors);
+	}
+}
+
+fn validate_social_post_text_item(text: &str, index: usize, errors: &mut Vec<String>) {
+	if text.is_empty() || text.len() > 280 {
+		errors.push(format!("text[{index}] must be a non-empty X-sized string"));
+	}
+	if text.contains("Automated by @hackink") {
+		errors.push(format!("text[{index}] must not include automation attribution"));
+	}
+	if text.len() > 260 && !text.contains("https://") {
+		errors.push(format!(
+			"text[{index}] longer than 260 characters must include an unavoidable direct source URL"
+		));
+	}
+
+	let normalized = text.trim().to_ascii_lowercase();
+	if normalized == "watching this"
+		|| normalized.starts_with("watching this.")
+		|| normalized.starts_with("tracking this.")
+		|| normalized.contains("new release available")
+	{
+		errors.push(format!(
+			"text[{index}] must name a concrete source-backed release, PR, protocol surface, workflow impact, or operator action"
+		));
 	}
 }
 
@@ -6052,12 +6074,10 @@ fn validate_social_post_status_payload(entry: &Map<String, Value>, errors: &mut 
 	match string_field(entry, "status") {
 		Some("published") => validate_social_post_publication(entry.get("publication"), errors),
 		Some("blocked") => validate_social_post_block(entry, errors),
-		Some("failed") if entry.get("failure").and_then(Value::as_object).is_none() => {
-			errors.push("failure is required when status is failed".into())
-		},
-		Some("skipped") if entry.get("skip").and_then(Value::as_object).is_none() => {
-			errors.push("skip is required when status is skipped".into())
-		},
+		Some("failed") if entry.get("failure").and_then(Value::as_object).is_none() =>
+			errors.push("failure is required when status is failed".into()),
+		Some("skipped") if entry.get("skip").and_then(Value::as_object).is_none() =>
+			errors.push("skip is required when status is skipped".into()),
 		_ => {},
 	}
 }
@@ -6844,6 +6864,26 @@ mod tests {
 	}
 
 	#[test]
+	fn social_candidate_rejects_low_quality_public_text() {
+		let mut attribution = valid_social_candidate();
+		attribution["candidate_text"] =
+			serde_json::json!(["Automated by @hackink: new release available"]);
+
+		assert_errors(&attribution, ["text[0] must not include automation attribution"]);
+
+		let mut overpacked = valid_social_candidate();
+		overpacked["candidate_text"] =
+			serde_json::json!([format!("{}", "Codex checkpoint ".repeat(18))]);
+
+		assert_errors(&overpacked, ["longer than 260 characters"]);
+
+		let mut generic = valid_social_candidate();
+		generic["candidate_text"] = serde_json::json!(["Watching this."]);
+
+		assert_errors(&generic, ["must name a concrete source-backed"]);
+	}
+
+	#[test]
 	fn accepts_valid_upstream_impact_and_rejects_bad_angle() {
 		let mut impact = valid_upstream_impact();
 
@@ -6867,10 +6907,7 @@ mod tests {
 		let mut missing_contract = valid_control_plane_upgrade_candidate();
 		missing_contract["authority"]["decision_contract_required"] = serde_json::json!(false);
 
-		assert_errors(
-			&missing_contract,
-			["authority.decision_contract_required must be true"],
-		);
+		assert_errors(&missing_contract, ["authority.decision_contract_required must be true"]);
 
 		let mut missing_program = valid_control_plane_upgrade_candidate();
 		missing_program["authority"]
@@ -6878,10 +6915,7 @@ mod tests {
 			.expect("authority should be an object")
 			.remove("program_intake_required");
 
-		assert_errors(
-			&missing_program,
-			["authority.program_intake_required must be true"],
-		);
+		assert_errors(&missing_program, ["authority.program_intake_required must be true"]);
 	}
 
 	#[test]
@@ -6893,6 +6927,27 @@ mod tests {
 		social_post["decision"]["daily_limit"] = serde_json::json!(9);
 
 		assert_errors(&social_post, ["decision.daily_limit must be 8"]);
+	}
+
+	#[test]
+	fn social_post_rejects_low_quality_public_text() {
+		let mut attribution = valid_social_post();
+		attribution["text"] = serde_json::json!(["Automated by @hackink: tracking this."]);
+
+		assert_errors(&attribution, ["text[0] must not include automation attribution"]);
+
+		let mut overpacked = valid_social_post();
+		overpacked["text"] = serde_json::json!([format!("{}", "Codex checkpoint ".repeat(18))]);
+
+		assert_errors(&overpacked, ["longer than 260 characters"]);
+
+		let mut with_source_url = valid_social_post();
+		with_source_url["text"] = serde_json::json!([format!(
+			"{} https://github.com/openai/codex/pull/22414",
+			"Codex checkpoint ".repeat(13)
+		)]);
+
+		assert_errors(&with_source_url, []);
 	}
 
 	#[test]

--- a/automations/decodex/README.md
+++ b/automations/decodex/README.md
@@ -25,3 +25,16 @@ It is intentionally operations-shaped and repo-local:
 
 Product/runtime/app code remains under `apps/`, `site/`, and `plugins/`. This directory
 is for automation source. Generated state belongs under `.agent/automations/decodex/`.
+
+## Pipeline Boundary
+
+`codex-upstream-radar-review` is the shared upstream evidence producer. It refreshes
+the upstream review queue, creates source-backed review/impact artifacts, and may
+write Control Plane upgrade candidates or public social candidates as evidence.
+
+`codex-release-checkpoint-publisher` and `decodex-x-publisher` are downstream
+consumers. They should read existing `release_delta/v1`, `upstream_review/v1`,
+`upstream_impact/v1`, `signal_entry/v1`, and `social_candidate/v1` artifacts instead
+of repeating upstream source analysis. Release Curator may refresh only the lightweight
+release-delta checkpoint when that artifact is missing or stale. X Publisher may only
+publish from a validated candidate or explicit operator handoff.

--- a/automations/decodex/prompts/release-curator.md
+++ b/automations/decodex/prompts/release-curator.md
@@ -20,8 +20,8 @@ Required reads:
 - `docs/spec/social-publishing.md`
 
 Workflow:
-1. Refresh or read `.agent/automations/decodex/cache/site-content/release-deltas/openai-codex-latest.json`.
-2. Compare release/changelog claims against source-backed Radar evidence under `.agent/automations/decodex/cache/github/reviews`, `.agent/automations/decodex/cache/github/impact`, and `.agent/automations/decodex/cache/site-content/signals`.
+1. Read `.agent/automations/decodex/cache/site-content/release-deltas/openai-codex-latest.json` first. Run `cargo run --manifest-path apps/decodex/Cargo.toml --bin decodex -- radar refresh-release-delta` only when that checkpoint artifact is missing, stale, invalid, or explicitly needed for a newly observed release tag. Do not refresh the upstream review queue or perform deep source analysis here.
+2. Compare release/changelog claims against source-backed Radar evidence produced by Decodex Radar Review under `.agent/automations/decodex/cache/github/reviews`, `.agent/automations/decodex/cache/github/impact`, and `.agent/automations/decodex/cache/site-content/signals`.
 3. Do not perform deep upstream source analysis here. If claims need unreviewed PR or commit evidence, write a defer/no-op outcome with exact gaps for Radar Review.
 4. When publication is justified, write or update `social_candidate/v1` under `.agent/automations/decodex/cache/github/social-candidates`.
 5. Validate changed JSON with `cargo run --manifest-path apps/decodex/Cargo.toml --bin decodex -- radar validate`.

--- a/automations/decodex/prompts/x-publisher.md
+++ b/automations/decodex/prompts/x-publisher.md
@@ -19,9 +19,9 @@ Required reads:
 
 Workflow:
 1. Read candidates under `.agent/automations/decodex/cache/github/social-candidates`.
-2. Publish only when `decision.worthiness = "publish"`, evidence is sufficient, duplicate checks pass, account verification is reliable, and the Asia/Shanghai daily cap remains available.
+2. Publish only when `decision.worthiness = "publish"`, evidence is sufficient, duplicate checks pass, account verification is reliable, text passes the X quality gates, and the Asia/Shanghai daily cap remains available. Reject or skip candidates whose post body starts with or repeats `Automated by @hackink`, exceeds the 260-character soft limit without an unavoidable source URL, or lacks a concrete source-backed release, PR, protocol, workflow, or operator implication.
 3. Before composing on X, create the active `social_publish_reservation/v1` only through `cargo run --manifest-path apps/decodex/Cargo.toml --bin decodex -- radar social reserve-publish`; do not hand-write reservation JSON. The command must pass daily-cap, active-reservation, terminal-post, idempotency, and validation checks.
-4. Use Chrome for X only after `cargo run --manifest-path apps/decodex/Cargo.toml --bin decodex -- radar social reserve-publish` returns a reserved path. Verify the account before composing.
+4. Use Chrome for X only after `cargo run --manifest-path apps/decodex/Cargo.toml --bin decodex -- radar social reserve-publish` returns a reserved path. Verify the logged-in account is `@decodexspace` before composing; any other account is a terminal blocked outcome, not a manual workaround.
 5. Fail closed if account verification, duplicate detection, media upload, final URL readback, or account/media readback is unreliable.
 6. Always write a terminal `social_post/v1` record under `.agent/automations/decodex/cache/social/x/posts` for published, blocked, failed, or skipped outcomes.
 7. Validate changed JSON with `cargo run --manifest-path apps/decodex/Cargo.toml --bin decodex -- radar validate`.

--- a/automations/decodex/scripts/github/contracts.py
+++ b/automations/decodex/scripts/github/contracts.py
@@ -770,6 +770,41 @@ def validate_control_plane_upgrade_candidate(entry: dict[str, Any]) -> Validatio
     return ValidationResult(ok=not errors, errors=errors)
 
 
+def validate_social_text_list(value: Any, field: str, errors: list[str]) -> None:
+    if not isinstance(value, list) or not value:
+        errors.append(f"{field} must be a non-empty list of X-sized strings")
+        return
+
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            errors.append(f"{field}[{index}] must be a string")
+            continue
+        validate_social_text_item(item, f"{field}[{index}]", errors)
+
+
+def validate_social_text_item(text: str, label: str, errors: list[str]) -> None:
+    if not text or len(text) > 280:
+        errors.append(f"{label} must be a non-empty X-sized string")
+    if "Automated by @hackink" in text:
+        errors.append(f"{label} must not include automation attribution")
+    if len(text) > 260 and "https://" not in text:
+        errors.append(
+            f"{label} longer than 260 characters must include an unavoidable direct source URL"
+        )
+
+    normalized = text.strip().lower()
+    if (
+        normalized == "watching this"
+        or normalized.startswith("watching this.")
+        or normalized.startswith("tracking this.")
+        or "new release available" in normalized
+    ):
+        errors.append(
+            f"{label} must name a concrete source-backed release, PR, protocol surface, "
+            "workflow impact, or operator action"
+        )
+
+
 def validate_social_candidate(entry: dict[str, Any]) -> ValidationResult:
     errors: list[str] = []
 
@@ -791,13 +826,7 @@ def validate_social_candidate(entry: dict[str, Any]) -> ValidationResult:
     if entry.get("priority") not in SOCIAL_POST_PRIORITIES:
         errors.append(f"priority must be one of {sorted(SOCIAL_POST_PRIORITIES)}")
 
-    candidate_text = entry.get("candidate_text")
-    if (
-        not isinstance(candidate_text, list)
-        or not candidate_text
-        or not all(isinstance(item, str) and 0 < len(item) <= 280 for item in candidate_text)
-    ):
-        errors.append("candidate_text must be a non-empty list of X-sized strings")
+    validate_social_text_list(entry.get("candidate_text"), "candidate_text", errors)
 
     refs = entry.get("source_refs")
     if not isinstance(refs, dict):
@@ -976,12 +1005,7 @@ def validate_social_post(entry: dict[str, Any]) -> ValidationResult:
         errors.append(f"status must be one of {sorted(SOCIAL_POST_STATUSES)}")
 
     text = entry.get("text")
-    if (
-        not isinstance(text, list)
-        or not text
-        or not all(isinstance(item, str) and 0 < len(item) <= 280 for item in text)
-    ):
-        errors.append("text must be a non-empty list of X-sized strings")
+    validate_social_text_list(text, "text", errors)
 
     refs = entry.get("source_refs")
     if not isinstance(refs, dict):

--- a/automations/decodex/scripts/github/social_candidate.schema.json
+++ b/automations/decodex/scripts/github/social_candidate.schema.json
@@ -61,7 +61,29 @@
       "items": {
         "type": "string",
         "minLength": 1,
-        "maxLength": 280
+        "maxLength": 280,
+        "allOf": [
+          {
+            "not": {
+              "pattern": "Automated by @hackink"
+            }
+          },
+          {
+            "not": {
+              "pattern": "^\\s*([Ww][Aa][Tt][Cc][Hh][Ii][Nn][Gg] [Tt][Hh][Ii][Ss]\\.?|[Tt][Rr][Aa][Cc][Kk][Ii][Nn][Gg] [Tt][Hh][Ii][Ss]\\.|.*[Nn][Ee][Ww] [Rr][Ee][Ll][Ee][Aa][Ss][Ee] [Aa][Vv][Aa][Ii][Ll][Aa][Bb][Ll][Ee].*)"
+            }
+          },
+          {
+            "anyOf": [
+              {
+                "maxLength": 260
+              },
+              {
+                "pattern": "https://"
+              }
+            ]
+          }
+        ]
       }
     },
     "source_refs": {

--- a/automations/decodex/scripts/github/social_post.schema.json
+++ b/automations/decodex/scripts/github/social_post.schema.json
@@ -60,7 +60,29 @@
       "items": {
         "type": "string",
         "minLength": 1,
-        "maxLength": 280
+        "maxLength": 280,
+        "allOf": [
+          {
+            "not": {
+              "pattern": "Automated by @hackink"
+            }
+          },
+          {
+            "not": {
+              "pattern": "^\\s*([Ww][Aa][Tt][Cc][Hh][Ii][Nn][Gg] [Tt][Hh][Ii][Ss]\\.?|[Tt][Rr][Aa][Cc][Kk][Ii][Nn][Gg] [Tt][Hh][Ii][Ss]\\.|.*[Nn][Ee][Ww] [Rr][Ee][Ll][Ee][Aa][Ss][Ee] [Aa][Vv][Aa][Ii][Ll][Aa][Bb][Ll][Ee].*)"
+            }
+          },
+          {
+            "anyOf": [
+              {
+                "maxLength": 260
+              },
+              {
+                "pattern": "https://"
+              }
+            ]
+          }
+        ]
       }
     },
     "source_refs": {

--- a/automations/decodex/scripts/github/test_contracts.py
+++ b/automations/decodex/scripts/github/test_contracts.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Tests for GitHub automation contract validators."""
+
+from __future__ import annotations
+
+import copy
+import unittest
+
+from contracts import validate_social_post
+
+
+def valid_social_post() -> dict:
+    return {
+        "schema": "social_post/v1",
+        "slug": "openai-codex-pr-22414",
+        "channel": "x",
+        "target_account": "decodexspace",
+        "controller_account": "hackink",
+        "mode": "operator_impact",
+        "status": "published",
+        "audience": "Codex operators",
+        "text": [
+            "Remote Codex can now use Unix socket endpoints. Source: https://github.com/openai/codex/pull/22414"
+        ],
+        "source_refs": {
+            "urls": ["https://github.com/openai/codex/pull/22414"],
+        },
+        "evidence_notes": ["PR #22414 changes remote endpoint handling."],
+        "claims": [
+            {
+                "text": "Remote Codex can use Unix socket endpoints.",
+                "evidence": "https://github.com/openai/codex/pull/22414",
+                "confidence": "confirmed",
+            }
+        ],
+        "decision": {
+            "worthiness": "publish",
+            "priority": "high",
+            "idempotency_key": "x:decodexspace:operator_impact:openai-codex-pr-22414",
+            "reason": "High-value Control Plane transport implication.",
+            "daily_limit": 8,
+            "daily_count_before": 2,
+            "daily_count_after": 3,
+            "day": "2026-06-02",
+            "timezone": "Asia/Shanghai",
+        },
+        "publication": {
+            "posted_at": "2026-06-02T03:00:00Z",
+            "published_urls": ["https://x.com/decodexspace/status/1"],
+            "publisher": "chrome",
+            "account_verified": True,
+            "made_with_ai": True,
+        },
+        "media_refs": ["https://x.com/decodexspace/status/1/photo/1"],
+    }
+
+
+class SocialPostContractTests(unittest.TestCase):
+    def assert_text_rejected(self, text: str, expected_error: str) -> None:
+        entry = copy.deepcopy(valid_social_post())
+        entry["text"] = [text]
+
+        result = validate_social_post(entry)
+
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any(expected_error in error for error in result.errors),
+            f"expected {expected_error!r} in {result.errors!r}",
+        )
+
+    def test_social_post_rejects_automation_attribution(self) -> None:
+        self.assert_text_rejected(
+            "Automated by @hackink: tracking this.",
+            "must not include automation attribution",
+        )
+
+    def test_social_post_rejects_overpacked_text_without_source_url(self) -> None:
+        self.assert_text_rejected(
+            "Codex checkpoint " * 18,
+            "longer than 260 characters",
+        )
+
+    def test_social_post_rejects_generic_copy_without_crashing(self) -> None:
+        self.assert_text_rejected(
+            "Watching this.",
+            "must name a concrete source-backed",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/automations/decodex/skills/README.md
+++ b/automations/decodex/skills/README.md
@@ -24,6 +24,12 @@ content or follow-up work:
    Radar artifacts, then write a low-frequency
    `social_post/v1` publication, block, skip, or failure record for `@decodexspace`.
 
+The scheduled automation boundary is producer-consumer shaped: Radar Review owns
+upstream queue refresh and source-backed review/impact artifacts; Release Analysis and
+Publisher consume those artifacts. Release Analysis may refresh only the lightweight
+release-delta checkpoint when missing or stale. Publisher must not refresh upstream
+state or fill evidence gaps.
+
 Use only the skills needed for the current artifact. Do not publish a social post just
 because a signal exists.
 

--- a/automations/decodex/skills/codex-release-analysis/SKILL.md
+++ b/automations/decodex/skills/codex-release-analysis/SKILL.md
@@ -22,6 +22,10 @@ or prerelease decision.
 ## Hard Boundaries
 
 - Do not perform fresh upstream source analysis here.
+- Do not refresh the upstream review queue here. Treat Radar Review as the shared
+  upstream evidence producer. Release Analysis may refresh only the lightweight
+  `release_delta/v1` checkpoint when the existing release-delta artifact is missing,
+  stale, invalid, or explicitly needed for a newly observed release tag.
 - Use compare metadata to identify PR/commit gaps; route behavior claims that need code
   review to `upstream_analysis_required`.
 - Treat official Codex app/mobile changelog entries as first-class sources when the post

--- a/automations/decodex/skills/x-post-quality-system/SKILL.md
+++ b/automations/decodex/skills/x-post-quality-system/SKILL.md
@@ -46,6 +46,20 @@ compatibility boundaries, and plugin/config/sandbox/tool/release-engineering cha
 Formatting is part of the quality bar. Reject dense paragraphs when bullets, blank
 lines, and direct PR URLs would make the evidence easier to scan.
 
+Reject post bodies that start with or repeat automation attribution such as
+`Automated by @hackink`. Attribution belongs in durable records and account metadata,
+not in the reader-facing post text. Also reject cramped post bodies longer than 260
+characters unless one unavoidable source URL forces the post toward X's limit; prefer
+a short thread over a single packed paragraph. A good post should leave room for X
+link rendering, quote metadata, and minor manual edits without hitting the hard
+platform limit.
+
+Prefer concrete evidence over generic release prose. A publishable post should name
+the release, PR, commit cluster, protocol surface, workflow, or operator action that
+matters. If the best available text is only "tracking", "watching", or "new release
+available" without a reader action or source-backed implication, keep the candidate as
+`defer` or `skip`.
+
 ## Media Gate
 
 Use media only when it is fresh, candidate-specific, and adds reader value beyond the

--- a/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
+++ b/docs/decisions/mcp-capability-gateway-and-skill-slimming.md
@@ -8,7 +8,7 @@ owner: docs
 tags: [decision]
 code_refs: [apps/decodex/src/mcp.rs, README.md, docs/spec/runtime.md, docs/reference/operator-control-plane.md]
 drift_watch: [decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, resources/templates/list, prompts/list, prompts/get, tools/list, tools/call]
-last_verified: 2026-06-18
+last_verified: 2026-06-27
 ---
 # MCP Capability Gateway And Skill Slimming
 
@@ -187,6 +187,11 @@ Tools:
 - `autonomy_draft_objective(mode, projectId, objective, authority)`: validates or
   persists a draft Objective Contract only. It does not accept the objective or grant
   execution authority.
+- `autonomy_accept_objective(mode, projectId, objectiveId, objectiveVersion,
+  authority)`: inspects or accepts a draft Objective Contract version. Apply requires
+  explicit human/operator Objective Contract acceptance authority and still grants no
+  execution authority. Runtime-policy acceptance is refused until it can be resolved
+  from trusted Decodex authority state instead of caller-supplied fields.
 - `autonomy_submit_signal(mode, projectId, kind, signal, authority)`: validates or
   persists proposal-only autonomy signal evidence against an accepted objective.
 - `autonomy_compile_proposal(mode, projectId, proposal, signalIds, authority)`:

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,18 @@
 
 ## 2026-06-27
 
+- Added the `autonomy_accept_objective` MCP plan tool to close the Objective Contract
+  lifecycle gap between draft creation and accepted project-autonomy authority, and
+  aligned the Decodex router skill, MCP capability decision, autonomy spec, roadmap,
+  and README with the draft-to-accept-to-proposal flow.
+- Refreshed the Codex compatibility matrix for local Decodex
+  `0.2.0-afb36056-aarch64-apple-darwin` against Codex stable `0.142.2` and preview
+  `0.143.0-alpha.25`, preserving runtime probes as the compatibility authority.
+- Clarified Decodex automation as a producer-consumer pipeline: Radar Review owns
+  upstream queue/source analysis, Release Curator consumes existing Radar artifacts and
+  refreshes only lightweight release-delta checkpoints when needed, and X Publisher
+  now hard-rejects attribution-prefixed, overpacked, or generic post bodies before
+  touching `@decodexspace`.
 - Added `control_plane_upgrade_candidate/v1` as the evidence-only bridge from
   upstream Codex Radar review into Decodex Control Plane upgrade work, including the
   governing spec, upgrade workflow runbook, compatibility matrix reference, Radar

--- a/docs/reference/codex-compatibility-matrix.md
+++ b/docs/reference/codex-compatibility-matrix.md
@@ -38,8 +38,8 @@ validation.
 
 | Decodex build | Codex channel | Codex version/tag | Evidence | Status | Caveat |
 | --- | --- | --- | --- | --- | --- |
-| `0.2.0-35fa270f` | stable | `0.142.2`, `rust-v0.142.2` | Local `/opt/homebrew/bin/codex --version` reported `codex-cli 0.142.2`; `npm view @openai/codex version dist-tags --json` reported `latest = 0.142.2`; `decodex probe` returned `PROBE_OK` on 2026-06-27. | compatible | Probe evidence covers the local installed stable CLI/app-server path, not every upstream change since the prior reviewed release. |
-| `0.2.0-35fa270f` | preview | `0.143.0-alpha.25`, `rust-v0.143.0-alpha.25` | `npm view @openai/codex dist-tags` reported `alpha = 0.143.0-alpha.25`; `decodex radar refresh-release-delta --dry-run` identified the preview tag and a stable-to-preview compare window. | needs_review | Preview was not installed or probe-tested in this checkout. Radar must review app-server, MCP, plugin, sandbox, auth, browser, and config changes before Decodex treats the preview as compatible. |
+| `0.2.0-afb36056` | stable | `0.142.2`, `rust-v0.142.2` | Local `codex --version` reported `codex-cli 0.142.2`; `npm view @openai/codex version dist-tags --json` reported `latest = 0.142.2`; Decodex CLI and app helper reported `decodex 0.2.0-afb36056-aarch64-apple-darwin`; `decodex probe` returned `PROBE_OK` on 2026-06-27. | compatible | Probe evidence covers the local installed stable CLI/app-server path, not every upstream change since the prior reviewed release. |
+| `0.2.0-afb36056` | preview | `0.143.0-alpha.25`, `rust-v0.143.0-alpha.25` | `npm view @openai/codex dist-tags` reported `alpha = 0.143.0-alpha.25`; `decodex radar refresh-release-delta --dry-run` identified the preview tag and a stable-to-preview compare window. | needs_review | Preview was not installed or probe-tested in this checkout. Radar must review app-server, MCP, plugin, sandbox, auth, browser, and config changes before Decodex treats the preview as compatible. |
 
 ## Review Triggers
 

--- a/docs/runbook/autonomy-implementation-roadmap.md
+++ b/docs/runbook/autonomy-implementation-roadmap.md
@@ -29,7 +29,7 @@ drift_watch:
   - allowed_signal_kinds
   - Program Intake
   - decodex mcp serve
-last_verified: 2026-06-23
+last_verified: 2026-06-27
 ---
 # Autonomy Implementation Roadmap
 
@@ -348,8 +348,8 @@ Implementation surfaces:
 Deliverables:
 
 - Observe profile can read objective, signal, proposal, and evidence summaries.
-- Plan profile can submit signals, draft objectives, compile proposals, challenge
-  proposals, and request explicit promotion surfaces.
+- Plan profile can draft and accept objectives, submit signals, compile proposals,
+  challenge proposals, and request explicit promotion surfaces.
 - Operate/admin profiles do not gain new bypasses; lane control and project control
   keep existing guards.
 - External agents cannot accept their own proposals unless accepted policy authority

--- a/docs/spec/autonomy-control-plane.md
+++ b/docs/spec/autonomy-control-plane.md
@@ -46,7 +46,7 @@ drift_watch:
   - Program Intake
   - finding_routes
   - decodex mcp serve
-last_verified: 2026-06-23
+last_verified: 2026-06-27
 ---
 # Autonomy Control Plane
 
@@ -456,22 +456,26 @@ The Phase 7 autonomy MCP surface is deliberately small and typed:
   `decodex://projects/{project_id}/autonomy/proposals/{proposal_id}`, and
   `decodex://projects/{project_id}/autonomy/evidence`
 - plan-profile tools:
-  `autonomy_draft_objective`, `autonomy_submit_signal`,
-  `autonomy_compile_proposal`, `autonomy_challenge_proposal`, and
+  `autonomy_draft_objective`, `autonomy_accept_objective`,
+  `autonomy_submit_signal`, `autonomy_compile_proposal`,
+  `autonomy_challenge_proposal`, and
   `autonomy_request_promotion`
 
 The observe resources return summaries and authority-boundary metadata only. They are
-not raw runtime payload exports. The plan tools validate or persist draft/objective,
-signal, proposal, challenge, and latent Decision Contract candidate evidence through
-runtime model checks. Apply-style calls require explicit authority fields and still
-stop before normal Decision Contract promotion, Program Intake, review, PR handoff,
-landing, install, restart, closeout, or cleanup authority. `autonomy_request_promotion`
+not raw runtime payload exports. The plan tools validate or persist Objective Contract
+draft and acceptance records, signal, proposal, challenge, and latent Decision
+Contract candidate evidence through runtime model checks. Apply-style calls require
+explicit authority fields and still stop before normal Decision Contract promotion,
+Program Intake, review, PR handoff, landing, install, restart, closeout, or cleanup
+authority. `autonomy_request_promotion`
 may create only a latent Decision Contract candidate from an accepted proposal; the
 result still requires normal `research_promote` and later Program Intake before
 execution work exists. MCP callers cannot prove accepted project policy authority by
-supplying an `acceptedProjectPolicy` body. Policy-backed runtime or external-agent
-acceptance must be resolved from trusted Decodex authority state; until that resolver
-exists, the MCP promotion request fails closed with a structured refusal. Local-private
+supplying an `acceptedProjectPolicy` body or by self-asserting `runtime_policy`
+Objective Contract acceptance. Policy-backed runtime or external-agent acceptance must
+be resolved from trusted Decodex authority state; until that resolver exists, MCP
+policy-backed objective acceptance and proposal promotion requests fail closed with
+structured refusals. Local-private
 signals expose ref counts and redaction metadata only, not raw `source_refs` or
 `primary_source_refs`.
 

--- a/docs/spec/social-publishing.md
+++ b/docs/spec/social-publishing.md
@@ -6,7 +6,7 @@ status: active
 authority: normative
 owner: automation
 tags: [spec, publishing]
-last_verified: 2026-06-25
+last_verified: 2026-06-27
 ---
 # Social Publishing
 
@@ -160,6 +160,15 @@ Rules:
   publish as a quote of that previous post. This keeps the prerelease history visible
   before the stable release ships. Deleted, superseded, failed, or text-only test posts
   must not become quote targets for the next prerelease.
+- Do not put automation attribution such as `Automated by @hackink` in the public post
+  body. Attribution belongs in durable `social_post/v1` records and account metadata,
+  not reader-facing copy.
+- Keep each post body at or below 260 characters unless an unavoidable direct source
+  URL requires using more of X's limit. Prefer a short thread over a dense paragraph
+  that leaves no room for quote metadata, link rendering, or manual correction.
+- Do not publish generic "watching this" or "new release available" prose when the
+  source evidence can name a concrete release, PR, commit cluster, protocol surface,
+  workflow impact, or operator action.
 
 ## Decision Object
 

--- a/plugins/decodex/skills/decodex/SKILL.md
+++ b/plugins/decodex/skills/decodex/SKILL.md
@@ -32,9 +32,10 @@ For autonomy work, route to `decodex://docs/spec/autonomy-control-plane`,
 `decodex://docs/decisions/mcp-capability-gateway-and-skill-slimming`, and the
 capability-profiled MCP surface: observe reads `decodex://projects/{service_id}/autonomy`
 summaries, while plan may use `autonomy_draft_objective`,
-`autonomy_submit_signal`, `autonomy_compile_proposal`,
-`autonomy_challenge_proposal`, and `autonomy_request_promotion`. Auth and profile
-prove access only; proposal acceptance still requires explicit human or accepted
+`autonomy_accept_objective`, `autonomy_submit_signal`,
+`autonomy_compile_proposal`, `autonomy_challenge_proposal`, and
+`autonomy_request_promotion`. Auth and profile prove access only; Objective Contract
+acceptance and proposal acceptance still require explicit human or accepted
 project-policy authority resolved from trusted Decodex state, not a caller-supplied
 policy body.
 


### PR DESCRIPTION
## Summary
- add the plan-profile `autonomy_accept_objective` MCP tool so Objective Contracts can move from draft to accepted without granting execution authority
- fail closed on caller-supplied runtime-policy Objective Contract acceptance and document the trusted-authority boundary
- harden Decodex automation social publishing gates across Rust Radar validation, Python contracts, JSON schemas, prompts, skills, and docs
- clarify the upstream Radar Review producer / Release Curator and X Publisher consumer split

## Verification
- `cargo make check-docs`
- `rustup run nightly cargo fmt --all -- --check`
- `cargo test -p decodex mcp::tests::autonomy --lib`
- `cargo test -p decodex mcp::tests::tools_list --lib`
- `cargo test -p decodex social_candidate --lib`
- `cargo test -p decodex social_post --lib`
- `python3 automations/decodex/scripts/github/test_contracts.py`
- JSON schema bad-sample probe for social candidate/post text
- automation source-only check via `evaluate_automations.py` helpers
- `git diff --check`

## Notes
- `plugin-eval` was not available in PATH, so plugin-eval was not run.
- Full `cargo make check` was not run; validation was scoped to the touched MCP, Radar, docs, automation, and skill surfaces.
- Repo-wide fmt changed mechanical formatting in `apps/decodex/src/cli.rs` and `apps/decodex/src/lib.rs` so `fmt-check` passes.