### PR TITLE
XY-1114: Use one shared upstream Codex radar artifact as the Decodex-only self-iteration input for release publishing and protocol-upgrade proposals, while preserving non-execution authority and carrying challenge checks as promotion constraints rather than blockers.

### DIFF
--- a/apps/decodex/src/autonomy_proposal.rs
+++ b/apps/decodex/src/autonomy_proposal.rs
@@ -715,12 +715,6 @@ impl AutonomyProposal {
 		let challenge = AutonomyProposalChallengeEvidence::from_input(input)?;
 		let mut candidate = self.clone();
 
-		if !challenge.objections.is_empty()
-			&& candidate.state == AutonomyProposalState::DecisionCandidate
-		{
-			candidate.state = AutonomyProposalState::NeedsHumanDecision;
-		}
-
 		candidate.challenge_evidence.push(challenge);
 		candidate.validate()?;
 
@@ -1047,7 +1041,7 @@ fn challenge_support(challenge: &AutonomyProposalChallengeEvidence) -> String {
 	} else if !challenge.evidence_refs.is_empty() {
 		format!("evidence_refs={}", challenge.evidence_refs.join("; "))
 	} else {
-		String::from("Challenge recorded no blocking objections.")
+		String::from("Challenge recorded no objections.")
 	}
 }
 
@@ -1101,6 +1095,22 @@ fn proposal_constraints(proposal: &AutonomyProposal) -> Vec<String> {
 			.iter()
 			.map(|requirement| format!("Review requirement: {requirement}")),
 	);
+	constraints.extend(
+		proposal
+			.challenge_requirements
+			.iter()
+			.map(|requirement| format!("Challenge requirement: {requirement}")),
+	);
+
+	for challenge in &proposal.challenge_evidence {
+		constraints.extend(
+			challenge
+				.objections
+				.iter()
+				.map(|objection| format!("Challenge promotion constraint: {objection}")),
+		);
+	}
+
 	constraints.push(String::from(
 		"Accepted autonomy proposal must remain latent until Decision Contract promotion.",
 	));
@@ -2446,7 +2456,7 @@ mod tests {
 			.expect("challenge should record");
 
 		assert_eq!(proposal.id(), proposal_id);
-		assert_eq!(proposal.state(), AutonomyProposalState::NeedsHumanDecision);
+		assert_eq!(proposal.state(), AutonomyProposalState::DecisionCandidate);
 		assert_eq!(proposal.challenge_evidence().len(), 1);
 		assert!(!proposal.challenge_evidence()[0].acceptance_authority);
 		assert_eq!(
@@ -2460,6 +2470,20 @@ mod tests {
 		assert_eq!(
 			dry_run_json["challenge_evidence"][0]["objections"][0],
 			"Needs a fresher operator status readback."
+		);
+
+		let candidate = proposal
+			.to_decision_contract_candidate(bridge_authority())
+			.expect("challenge objections should remain promotion constraints");
+
+		assert!(candidate.accepted_authority().constraints().contains(&String::from(
+			"Challenge promotion constraint: Needs a fresher operator status readback."
+		)));
+		assert!(
+			candidate
+				.accepted_authority()
+				.objections()
+				.contains(&String::from("Needs a fresher operator status readback."))
 		);
 	}
 
@@ -2545,7 +2569,7 @@ mod tests {
 			.expect("proposal should exist");
 
 		assert_eq!(readback.proposal(), &stored_proposal);
-		assert_eq!(readback.state(), AutonomyProposalState::NeedsHumanDecision);
+		assert_eq!(readback.state(), AutonomyProposalState::DecisionCandidate);
 		assert_eq!(
 			reopened
 				.recent_autonomy_proposals_for_project("decodex", 1)

--- a/apps/decodex/src/mcp.rs
+++ b/apps/decodex/src/mcp.rs
@@ -817,6 +817,7 @@ impl McpServer {
 				"`objectiveId` is required.",
 			);
 		};
+
 		if !safe_autonomy_record_identifier(objective_id) {
 			return invalid_tool_arguments(
 				TOOL_AUTONOMY_ACCEPT_OBJECTIVE,
@@ -871,7 +872,6 @@ impl McpServer {
 				"Only draft Objective Contract versions can be accepted through autonomy_accept_objective.",
 			);
 		}
-
 		if mode == "dry_run" {
 			return tool_success(autonomy_objective_accept_tool_result(
 				&project_id,
@@ -4912,7 +4912,7 @@ fn autonomy_challenge_tool_result(
 		"proposal": mcp_autonomy_proposal_summary(proposal, updated_at),
 		"challenge_evidence_count": proposal.challenge_evidence().len(),
 		"authority_effect": "challenge_evidence_not_acceptance_authority",
-		"next_action": "Resolve material objections before requesting proposal promotion.",
+		"next_action": "Carry challenge objections as promotion constraints and request explicit promotion authority before creating execution work.",
 		"updated_at": updated_at
 	}))
 }
@@ -8219,6 +8219,7 @@ mod tests {
 	fn autonomy_accept_objective_refuses_caller_supplied_runtime_policy_authority() {
 		let repo = test_repo();
 		let state_store = StateStore::open_in_memory().expect("state store should open");
+
 		state_store
 			.upsert_autonomy_objective_draft("decodex", autonomy_objective_fixture())
 			.expect("objective draft should persist");

--- a/apps/decodex/src/radar.rs
+++ b/apps/decodex/src/radar.rs
@@ -5532,6 +5532,12 @@ fn validate_control_plane_upgrade_source_refs(refs: Option<&Value>, errors: &mut
 				.into(),
 		);
 	}
+	if non_empty_array(refs.get("upstream_impacts")).is_none() {
+		errors.push(
+			"source_refs.upstream_impacts must include the shared upstream_impact/v1 handoff"
+				.into(),
+		);
+	}
 	if refs.get("urls").is_some_and(|urls| !is_https_string_array(urls)) {
 		errors.push("source_refs.urls must be a list of https URLs".into());
 	}
@@ -5678,8 +5684,23 @@ fn validate_social_candidate_source_refs(refs: Option<&Value>, errors: &mut Vec<
 				.into(),
 		);
 	}
+
+	let uses_radar_inputs = ["upstream_reviews", "release_deltas"]
+		.iter()
+		.any(|field| non_empty_array(refs.get(*field)).is_some());
+
+	if uses_radar_inputs && non_empty_array(refs.get("upstream_impacts")).is_none() {
+		errors.push(
+			"source_refs.upstream_impacts must include the shared upstream_impact/v1 handoff for Radar-derived social candidates"
+				.into(),
+		);
+	}
 	if refs.get("urls").is_some_and(|urls| !is_https_string_array(urls)) {
 		errors.push("source_refs.urls must be a list of https URLs".into());
+	}
+
+	for field in ["upstream_reviews", "upstream_impacts", "signals", "release_deltas"] {
+		validate_optional_string_list(refs.get(field), &format!("source_refs.{field}"), errors);
 	}
 }
 
@@ -5940,6 +5961,7 @@ fn validate_social_post_text(text: Option<&Value>, errors: &mut Vec<String>) {
 
 			continue;
 		};
+
 		validate_social_post_text_item(text, index, errors);
 	}
 }
@@ -5958,6 +5980,7 @@ fn validate_social_post_text_item(text: &str, index: usize, errors: &mut Vec<Str
 	}
 
 	let normalized = text.trim().to_ascii_lowercase();
+
 	if normalized == "watching this"
 		|| normalized.starts_with("watching this.")
 		|| normalized.starts_with("tracking this.")
@@ -6870,6 +6893,18 @@ mod tests {
 		candidate["source_refs"] = serde_json::json!({});
 
 		assert_errors(&candidate, ["source_refs must include upstream_reviews"]);
+
+		let mut missing_shared_handoff = valid_social_candidate();
+
+		missing_shared_handoff["source_refs"]
+			.as_object_mut()
+			.expect("source refs should be an object")
+			.remove("upstream_impacts");
+
+		assert_errors(
+			&missing_shared_handoff,
+			["source_refs.upstream_impacts must include the shared upstream_impact/v1 handoff"],
+		);
 	}
 
 	#[test]
@@ -6884,18 +6919,21 @@ mod tests {
 	#[test]
 	fn social_candidate_rejects_low_quality_public_text() {
 		let mut attribution = valid_social_candidate();
+
 		attribution["candidate_text"] =
 			serde_json::json!(["Automated by @hackink: new release available"]);
 
 		assert_errors(&attribution, ["text[0] must not include automation attribution"]);
 
 		let mut overpacked = valid_social_candidate();
+
 		overpacked["candidate_text"] =
 			serde_json::json!([format!("{}", "Codex checkpoint ".repeat(18))]);
 
 		assert_errors(&overpacked, ["longer than 260 characters"]);
 
 		let mut generic = valid_social_candidate();
+
 		generic["candidate_text"] = serde_json::json!(["Watching this."]);
 
 		assert_errors(&generic, ["must name a concrete source-backed"]);
@@ -6921,6 +6959,18 @@ mod tests {
 		candidate["authority"]["mutation_allowed"] = serde_json::json!(true);
 
 		assert_errors(&candidate, ["authority.mutation_allowed must be false"]);
+
+		let mut missing_shared_handoff = valid_control_plane_upgrade_candidate();
+
+		missing_shared_handoff["source_refs"]
+			.as_object_mut()
+			.expect("source refs should be an object")
+			.remove("upstream_impacts");
+
+		assert_errors(
+			&missing_shared_handoff,
+			["source_refs.upstream_impacts must include the shared upstream_impact/v1 handoff"],
+		);
 
 		let mut missing_contract = valid_control_plane_upgrade_candidate();
 
@@ -6952,16 +7002,19 @@ mod tests {
 	#[test]
 	fn social_post_rejects_low_quality_public_text() {
 		let mut attribution = valid_social_post();
+
 		attribution["text"] = serde_json::json!(["Automated by @hackink: tracking this."]);
 
 		assert_errors(&attribution, ["text[0] must not include automation attribution"]);
 
 		let mut overpacked = valid_social_post();
+
 		overpacked["text"] = serde_json::json!([format!("{}", "Codex checkpoint ".repeat(18))]);
 
 		assert_errors(&overpacked, ["longer than 260 characters"]);
 
 		let mut with_source_url = valid_social_post();
+
 		with_source_url["text"] = serde_json::json!([format!(
 			"{} https://github.com/openai/codex/pull/22414",
 			"Codex checkpoint ".repeat(13)

--- a/automations/decodex/README.md
+++ b/automations/decodex/README.md
@@ -29,12 +29,13 @@ is for automation source. Generated state belongs under `.agent/automations/deco
 ## Pipeline Boundary
 
 `codex-upstream-radar-review` is the shared upstream evidence producer. It refreshes
-the upstream review queue, creates source-backed review/impact artifacts, and may
-write Control Plane upgrade candidates or public social candidates as evidence.
+the upstream review queue, creates source-backed review artifacts, and promotes shared
+`upstream_impact/v1` handoff artifacts before downstream Control Plane upgrade
+candidates or public social candidates consume the same upstream scan.
 
 `codex-release-checkpoint-publisher` and `decodex-x-publisher` are downstream
-consumers. They should read existing `release_delta/v1`, `upstream_review/v1`,
-`upstream_impact/v1`, `signal_entry/v1`, and `social_candidate/v1` artifacts instead
-of repeating upstream source analysis. Release Curator may refresh only the lightweight
+consumers. They should read existing `upstream_impact/v1`, `release_delta/v1`,
+`upstream_review/v1`, `signal_entry/v1`, and `social_candidate/v1` artifacts instead of
+repeating upstream source analysis. Release Curator may refresh only the lightweight
 release-delta checkpoint when that artifact is missing or stale. X Publisher may only
 publish from a validated candidate or explicit operator handoff.

--- a/automations/decodex/prompts/radar-review.md
+++ b/automations/decodex/prompts/radar-review.md
@@ -25,10 +25,18 @@ Workflow:
 2. Read `.agent/automations/decodex/cache/github/review-queue/openai-codex-latest.json` and select the smallest high-value batch that can finish in this run.
 3. For each selected subject, build or validate its bundle under `.agent/automations/decodex/cache/github/bundles`.
 4. Run Codex source analysis only through the explicit AI boundary in `automations/decodex/scripts/github/run_codex_analysis.py` or the Rust `cargo run --manifest-path apps/decodex/Cargo.toml --bin decodex -- radar` command that wraps it.
-5. Persist source-backed `upstream_review/v1`, optional `upstream_impact/v1`, optional `control_plane_upgrade_candidate/v1`, optional `analysis_draft`, optional rendered `signal_entry/v1`, and optional `social_candidate/v1` under `.agent/automations/decodex/cache`.
+5. Persist source-backed `upstream_review/v1`. When the reviewed change has any
+   Publisher or Control Plane relevance, also persist the matching
+   `upstream_impact/v1`; this is the shared upstream scan artifact consumed by Release
+   Curator and Control Plane upgrade proposals.
+6. Persist optional `control_plane_upgrade_candidate/v1`, optional `analysis_draft`,
+   optional rendered `signal_entry/v1`, and optional `social_candidate/v1` under
+   `.agent/automations/decodex/cache` only after the shared `upstream_impact/v1`
+   exists for Radar-derived Publisher or Control Plane work.
    - Write Control Plane upgrade candidates only under `.agent/automations/decodex/cache/github/control-plane-upgrades`.
+   - Cite the shared impact artifact in downstream `source_refs.upstream_impacts`.
    - A Control Plane upgrade candidate is evidence for later Decision Contract and Program Intake work; it must not mutate Linear, GitHub, worktrees, project config, Codex installs, or Decodex source.
-6. Validate changed JSON with `cargo run --manifest-path apps/decodex/Cargo.toml --bin decodex -- radar validate` before terminal completion.
+7. Validate changed JSON with `cargo run --manifest-path apps/decodex/Cargo.toml --bin decodex -- radar validate` before terminal completion.
 
 Terminal report:
 Report selected subjects, generated or updated paths, validation commands, skipped/deferred subjects, evidence gaps, and residual risks. Archive the run thread after a terminal no-op, no-new-subject, artifacts-persisted, blocked, skipped, or failed-closed outcome when no human handoff remains.

--- a/automations/decodex/prompts/release-curator.md
+++ b/automations/decodex/prompts/release-curator.md
@@ -21,9 +21,18 @@ Required reads:
 
 Workflow:
 1. Read `.agent/automations/decodex/cache/site-content/release-deltas/openai-codex-latest.json` first. Run `cargo run --manifest-path apps/decodex/Cargo.toml --bin decodex -- radar refresh-release-delta` only when that checkpoint artifact is missing, stale, invalid, or explicitly needed for a newly observed release tag. Do not refresh the upstream review queue or perform deep source analysis here.
-2. Compare release/changelog claims against source-backed Radar evidence produced by Decodex Radar Review under `.agent/automations/decodex/cache/github/reviews`, `.agent/automations/decodex/cache/github/impact`, and `.agent/automations/decodex/cache/site-content/signals`.
-3. Do not perform deep upstream source analysis here. If claims need unreviewed PR or commit evidence, write a defer/no-op outcome with exact gaps for Radar Review.
-4. When publication is justified, write or update `social_candidate/v1` under `.agent/automations/decodex/cache/github/social-candidates`.
+2. Compare release/changelog claims against the shared `upstream_impact/v1` artifacts
+   produced by Decodex Radar Review under
+   `.agent/automations/decodex/cache/github/impact`. Use `release_delta/v1`,
+   `upstream_review/v1`, `signal_entry/v1`, release URLs, and compare metadata as
+   provenance or gap evidence, not as a parallel source-analysis path.
+3. Do not perform deep upstream source analysis here. If claims need unreviewed PR or
+   commit evidence, write a defer/no-op outcome with exact gaps for Radar Review so it
+   can produce or update the shared `upstream_impact/v1` artifact.
+4. When publication is justified, write or update `social_candidate/v1` under
+   `.agent/automations/decodex/cache/github/social-candidates`; for Radar-derived
+   candidates, include the consumed shared impact artifact in
+   `source_refs.upstream_impacts`.
 5. Validate changed JSON with `cargo run --manifest-path apps/decodex/Cargo.toml --bin decodex -- radar validate`.
 
 Terminal report:

--- a/automations/decodex/scripts/github/README.md
+++ b/automations/decodex/scripts/github/README.md
@@ -130,11 +130,11 @@ decodex radar backfill-release-range \
 
 Codex app automation or an explicit local operator run may refresh upstream queues,
 release deltas, and validation through `decodex radar ...`. Codex automation owns AI
-review of queued subjects and may then
-promote source-backed conclusions into `upstream_impact/v1`,
-`control_plane_upgrade_candidate/v1`, `analysis_draft`, `decodex radar render-signal`
-output, or `social_candidate/v1`; Publisher automation writes terminal
-`social_post/v1` records.
+review of queued subjects and promotes Publisher or Control Plane conclusions into the
+shared `upstream_impact/v1` handoff artifact before downstream
+`control_plane_upgrade_candidate/v1`, `analysis_draft`,
+`decodex radar render-signal` output, or `social_candidate/v1` artifacts consume that
+same reviewed scan. Publisher automation writes terminal `social_post/v1` records.
 
 Do not wire `run_codex_analysis.py` into GitHub Actions. Actions must not pass
 `--allow-ai-analysis-boundary` or set `DECODEX_ALLOW_CODEX_ANALYSIS`; that

--- a/automations/decodex/scripts/github/control_plane_upgrade_candidate.schema.json
+++ b/automations/decodex/scripts/github/control_plane_upgrade_candidate.schema.json
@@ -38,20 +38,7 @@
     "source_refs": {
       "type": "object",
       "additionalProperties": false,
-      "anyOf": [
-        {
-          "required": ["upstream_reviews"]
-        },
-        {
-          "required": ["upstream_impacts"]
-        },
-        {
-          "required": ["release_deltas"]
-        },
-        {
-          "required": ["urls"]
-        }
-      ],
+      "required": ["upstream_impacts"],
       "properties": {
         "upstream_reviews": {
           "type": "array",

--- a/automations/decodex/scripts/github/social_candidate.schema.json
+++ b/automations/decodex/scripts/github/social_candidate.schema.json
@@ -106,6 +106,23 @@
           "required": ["urls"]
         }
       ],
+      "allOf": [
+        {
+          "if": {
+            "anyOf": [
+              {
+                "required": ["upstream_reviews"]
+              },
+              {
+                "required": ["release_deltas"]
+              }
+            ]
+          },
+          "then": {
+            "required": ["upstream_impacts"]
+          }
+        }
+      ],
       "properties": {
         "upstream_reviews": {
           "type": "array",

--- a/automations/decodex/skills/codex-release-analysis/SKILL.md
+++ b/automations/decodex/skills/codex-release-analysis/SKILL.md
@@ -26,6 +26,10 @@ or prerelease decision.
   upstream evidence producer. Release Analysis may refresh only the lightweight
   `release_delta/v1` checkpoint when the existing release-delta artifact is missing,
   stale, invalid, or explicitly needed for a newly observed release tag.
+- For continuous Radar-derived release and prerelease candidates, consume
+  `upstream_impact/v1` as the shared handoff artifact. Use release deltas, compare
+  metadata, reviews, signals, and URLs as provenance or gap evidence, not as a second
+  source-analysis path.
 - Use compare metadata to identify PR/commit gaps; route behavior claims that need code
   review to `upstream_analysis_required`.
 - Treat official Codex app/mobile changelog entries as first-class sources when the post
@@ -43,8 +47,9 @@ or prerelease decision.
    - stable: current stable -> previous stable
    - prerelease: current prerelease -> previous prerelease in the same train
    - first prerelease after stable: stable -> first prerelease
-3. Read existing `release_delta/v1`, `signal_entry/v1`, `upstream_review/v1`, and
-   `upstream_impact/v1` artifacts that match the channel.
+3. Read existing `upstream_impact/v1` artifacts that match the channel first, then use
+   `release_delta/v1`, `signal_entry/v1`, and `upstream_review/v1` artifacts to check
+   lineage, evidence, and gaps.
 4. Use `decodex radar backfill-release-range --dry-run` when compare PR gaps may need
    later source review.
 5. Choose exactly one primary mode:
@@ -66,6 +71,6 @@ Return source/timestamp, chosen mode, release-body quality, compare/PR evidence,
 matching signal slugs, Control Plane impact if any, and `social_candidate/v1`
 `decision.worthiness`.
 
-Promote durable conclusions only through existing artifacts: `upstream_impact/v1`,
-Codex-owned `analysis_draft` plus `decodex radar render-signal`, refreshed
-`release_delta/v1`, `social_candidate/v1`, or terminal `social_post/v1`.
+Promote durable conclusions only through existing artifacts: shared
+`upstream_impact/v1`, Codex-owned `analysis_draft` plus `decodex radar render-signal`,
+refreshed `release_delta/v1`, `social_candidate/v1`, or terminal `social_post/v1`.

--- a/automations/decodex/skills/github-signal/SKILL.md
+++ b/automations/decodex/skills/github-signal/SKILL.md
@@ -96,11 +96,13 @@ Write a JSON analysis draft with these fields:
    code-analysis result.
 3. Decide whether the change is signal-worthy.
 4. Draft the `analysis_draft` JSON under `.agent/automations/decodex/cache/generated/analysis/`.
-5. Draft or update an `upstream_impact/v1` artifact when the change affects Control Plane or
-   Publisher follow-up.
+5. Draft or update an `upstream_impact/v1` artifact when the change affects Control
+   Plane or Publisher follow-up. This impact artifact is the shared handoff that
+   release publishing and Control Plane upgrade proposals should consume.
 6. Draft or update `control_plane_upgrade_candidate/v1` only when source-backed
    evidence shows Decodex may need adoption, compatibility mitigation, or discovery;
-   do not create Linear issues or mutate runtime state from this skill.
+   cite the shared `upstream_impact/v1` and do not create Linear issues or mutate
+   runtime state from this skill.
 7. Render the final signal entry with `decodex radar render-signal`.
 8. Validate the published signal collection and site build.
 

--- a/docs/decisions/codex-upstream-radar-redesign.md
+++ b/docs/decisions/codex-upstream-radar-redesign.md
@@ -25,11 +25,13 @@ The new pipeline has four layers:
    possible, assigns routing hints, and writes an `upstream_review_queue/v1` artifact.
 2. Codex automation consumes that queue and performs AI source review for each queued
    subject.
-3. Source-backed reviews promote only valuable outcomes into `upstream_impact/v1`,
-   `signal_entry/v1`, `social_post/v1`, or
-   `control_plane_upgrade_candidate/v1`.
-4. Release and prerelease summaries roll up accumulated commit and PR analysis instead
-   of treating sparse release notes as enough evidence.
+3. Source-backed reviews promote valuable Publisher or Control Plane conclusions into
+   `upstream_impact/v1`, the shared downstream handoff artifact.
+4. Release and prerelease summaries, public candidates, and
+   `control_plane_upgrade_candidate/v1` records consume that shared impact artifact
+   plus release/version provenance instead of re-fetching or independently
+   reinterpreting upstream source. Sparse release notes remain insufficient by
+   themselves.
 
 GitHub Actions must stay deterministic. It may refresh GitHub metadata, release deltas,
 review queues, and validation results, but it must not install Codex, inject Codex auth,
@@ -43,6 +45,8 @@ Consequences:
   Publisher promotions from source-backed review.
 - Decodex compatibility risks and adoption opportunities can be tracked before they
   become public content.
+- Release Publisher and Control Plane upgrade analysis share the same
+  `upstream_impact/v1` conclusion for a Radar-reviewed upstream change.
 - Control Plane upgrade work enters execution only through the candidate artifact,
   Decision Contract, and Program Intake bridge; Radar review does not create Linear
   issues directly.

--- a/docs/decisions/radar-control-plane-publisher.md
+++ b/docs/decisions/radar-control-plane-publisher.md
@@ -37,6 +37,10 @@ Consequences:
   Upstream Codex changes that touch app-server, plugins, browser automation, MCP,
   permission profiles, config, or sandbox behavior should be classified for Control
   Plane impact before they become engineering work.
+- `upstream_impact/v1` is the shared Radar handoff for downstream Publisher and
+  Control Plane self-iteration. Release deltas, compare metadata, reviews, and URLs
+  remain provenance and gap evidence, but new Radar-derived publication candidates and
+  Control Plane upgrade candidates should reuse the same impact conclusion.
 - Publisher remains static-first. Public pages and social publication records are
   generated from checked-in artifacts and reviewed content, not from a live Decodex
   daemon.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-27
 
+- Made `upstream_impact/v1` the shared Radar handoff for Decodex-only release
+  publishing and Control Plane upgrade proposal work, and updated autonomy challenge
+  disposition so challenge objections are retained as promotion constraints rather
+  than automatic proposal blockers.
 - Added the `autonomy_accept_objective` MCP plan tool to close the Objective Contract
   lifecycle gap between draft creation and accepted project-autonomy authority, and
   aligned the Decodex router skill, MCP capability decision, autonomy spec, roadmap,

--- a/docs/reference/codex-compatibility-matrix.md
+++ b/docs/reference/codex-compatibility-matrix.md
@@ -56,3 +56,6 @@ PR, or commit touches any of these surfaces:
 Candidate creation is still evidence-only. Promotion to executable work requires the
 authority bridge in
 [`../spec/control-plane-upgrade-candidate.md`](../spec/control-plane-upgrade-candidate.md).
+For Radar-derived Codex release or preview rows, the compatibility matrix should point
+Control Plane work at the shared `upstream_impact/v1` handoff and a
+`control_plane_upgrade_candidate/v1`, not at a version-string-only adoption path.

--- a/docs/runbook/autonomy-implementation-roadmap.md
+++ b/docs/runbook/autonomy-implementation-roadmap.md
@@ -211,7 +211,8 @@ Deliverables:
   family, and intended surface.
 - Refusal rules for missing objective, disallowed signal kind, disallowed surface,
   stale evidence, unresolved contradiction, and weakened validation or review.
-- Challenge hook that records support-agent or inline skeptic objections as evidence.
+- Challenge hook that records support-agent or inline skeptic objections as evidence
+  and promotion constraints, not automatic blockers.
 
 Required tests:
 

--- a/docs/runbook/control-plane-upgrade-workflow.md
+++ b/docs/runbook/control-plane-upgrade-workflow.md
@@ -44,7 +44,9 @@ The current tested Codex versions are recorded in
    explicit operator-run Codex analysis pass.
 
 3. Persist source-backed `upstream_review/v1`. When a reviewed change affects Decodex
-   compatibility or adoption, also persist `upstream_impact/v1`.
+   compatibility or adoption, also persist `upstream_impact/v1`; this is the shared
+   upstream scan artifact that Control Plane upgrade candidates and release publishing
+   both reuse.
 
 4. If `control_plane_impact` is `candidate`, `compat_risk`, or `adopt_now`, write a
    `control_plane_upgrade_candidate/v1` artifact under:
@@ -52,6 +54,10 @@ The current tested Codex versions are recorded in
    ```text
    .agent/automations/decodex/cache/github/control-plane-upgrades/
    ```
+
+   Cite the matching `upstream_impact/v1` in `source_refs.upstream_impacts`. Use
+   `release_delta/v1`, release URLs, or `target_codex` fields for version context
+   rather than re-fetching or reinterpreting upstream Codex independently.
 
 5. Validate the changed artifacts:
 
@@ -81,6 +87,7 @@ The current tested Codex versions are recorded in
 Do not promote a candidate when any of these is true:
 
 - no source-backed `upstream_review/v1` exists
+- no matching `upstream_impact/v1` exists for a Radar-derived candidate
 - the candidate has no target Codex version, tag, commit, or release URL
 - `authority.mutation_allowed` is not `false`
 - `decision_contract_required` or `program_intake_required` is not `true`

--- a/docs/runbook/social-publishing-workflow.md
+++ b/docs/runbook/social-publishing-workflow.md
@@ -112,6 +112,10 @@ one exact compare URL intentionally carries the detailed PR list.
 1. Start from source evidence.
    - Prefer a source-backed `upstream_review/v1`, merged PR bundle, release-delta
      compare entry, already-rendered `signal_entry/v1`, or `upstream_impact/v1`.
+   - For continuous Radar-derived release or prerelease work, treat
+     `upstream_impact/v1` as the shared handoff from Radar Review into Publisher.
+     Use release-delta and compare metadata to identify checkpoints and gaps, but do
+     not duplicate upstream source analysis inside Publisher.
    - For Codex app and mobile updates, the official Codex changelog is source
      evidence. Use GitHub only for repository behavior claims.
    - Do not start from social engagement alone.
@@ -133,6 +137,9 @@ one exact compare URL intentionally carries the detailed PR list.
 3. Decide whether to create or consume a candidate.
    - Release checkpoint automation should write `social_candidate/v1` with
      `decision.worthiness = "publish"`, `"defer"`, or `"skip"`.
+   - New Radar-derived candidates should cite the shared `upstream_impact/v1` under
+     `source_refs.upstream_impacts` so Publisher and Control Plane use the same
+     upstream scan conclusion.
    - General Publisher automation should consume only candidates whose
      `decision.worthiness = "publish"`. It must not turn `defer` or `skip` decisions
      into posts.

--- a/docs/spec/autonomy-control-plane.md
+++ b/docs/spec/autonomy-control-plane.md
@@ -361,8 +361,11 @@ Non-trivial proposals use the generic challenge method. When tool support and ac
 workflow allow it, Decodex should request a fresh dynamic read-only support-agent
 challenge for architecture, review-repair, generated implementation, or
 ready/decision-ready claims. Inline challenge is a fallback for small local checks or
-when support-agent tooling is unavailable. Challenge output is objection evidence; it
-does not create authority.
+when support-agent tooling is unavailable. Challenge output is objection evidence and
+promotion constraints; it does not create acceptance authority and does not by itself
+turn a `decision_candidate` into `needs_human_decision`. Material contradictions,
+disallowed surfaces, weakened validation/review, or explicit authority gaps still use
+the normal refusal rules.
 
 ## Execution Flow
 
@@ -425,7 +428,7 @@ when and how to use it.
 | Draft objective | `plan` | Identified actor | Creates draft only. |
 | Accept objective | `plan` or higher | Human/operator or accepted policy actor | Creates immutable Objective Contract version. |
 | Compile proposal | `plan` | Accepted objective and allowed signal kinds | Creates proposal evidence only. |
-| Challenge proposal | `plan` | Review actor or support-agent evidence | Adds objections; no execution. |
+| Challenge proposal | `plan` | Review actor or support-agent evidence | Adds objections as promotion constraints; no execution or acceptance authority. |
 | Promote proposal to Decision Contract | `plan` or higher | Explicit acceptance or accepted project policy | Creates a latent Decision Contract candidate; accepted execution authority still requires normal Decision Contract promotion. |
 | Intake promoted work | `plan` or higher | Accepted Decision Contract and explicit intake authority | Creates Program Intake or issue materialization. |
 | Dispatch lane | Runtime scheduler | Program readiness plus workflow eligibility | Starts normal lane; not direct MCP authority. |

--- a/docs/spec/control-plane-upgrade-candidate.md
+++ b/docs/spec/control-plane-upgrade-candidate.md
@@ -82,12 +82,22 @@ Optional fields:
 
 ## Source References
 
-`source_refs` must include at least one of:
+`source_refs` must include:
+
+- `upstream_impacts`
+
+`source_refs` may also include:
 
 - `upstream_reviews`
-- `upstream_impacts`
 - `release_deltas`
 - `urls`
+
+Treat `upstream_impacts` as the shared upstream scan artifact that release publishing
+and Control Plane proposal work reuse.
+`upstream_reviews`, `release_deltas`, and URLs may supply provenance, target-version
+context, or gap evidence, but they should not be the only source for a new Decodex
+Control Plane candidate when a reviewed `upstream_impact/v1` exists or can be produced
+by Radar Review.
 
 `urls` must use HTTPS. Local generated artifact references should use repository-relative
 paths under `.agent/automations/decodex/cache`.
@@ -134,6 +144,12 @@ it does not replace the accepted Decision Contract for execution.
 - `release_delta/v1`
 - official Codex release URLs
 - source-backed local validation evidence
+
+For normal upstream Codex Radar output, consume `upstream_impact/v1` as the
+Control Plane handoff and carry release/version evidence through `source_refs` and
+`target_codex`. This keeps release publishing and protocol-upgrade proposal analysis
+on one reviewed Radar artifact instead of duplicate upstream fetches or parallel
+interpretations.
 
 It may later support:
 

--- a/docs/spec/social-candidate.md
+++ b/docs/spec/social-candidate.md
@@ -6,7 +6,9 @@ status: active
 authority: normative
 owner: automation
 tags: [spec, publishing]
-last_verified: 2026-06-25
+code_refs: [apps/decodex/src/radar.rs, automations/decodex/scripts/github/social_candidate.schema.json]
+drift_watch: [social_candidate/v1, upstream_impact/v1, source_refs.upstream_impacts]
+last_verified: 2026-06-27
 ---
 # Social Candidate
 
@@ -84,6 +86,13 @@ Optional fields:
 
 Prefer a source-backed `upstream_review/v1` plus an `upstream_impact/v1` when the
 candidate comes from continuous Radar.
+For new Radar-derived release or prerelease candidates, `upstream_impacts` is the
+shared handoff from Radar Review into Publisher. `release_deltas`, official release
+URLs, compare metadata, and `upstream_reviews` can support channel lineage and claim
+evidence, but they should not become a parallel release-analysis source when a matching
+`upstream_impact/v1` exists or Radar Review can produce one.
+`decodex radar validate` rejects a Radar-derived social candidate that cites
+`upstream_reviews` or `release_deltas` without also citing `upstream_impacts`.
 
 ## Decision Object
 

--- a/docs/spec/upstream-impact.md
+++ b/docs/spec/upstream-impact.md
@@ -6,6 +6,16 @@ status: active
 authority: normative
 owner: automation
 tags: [spec, radar]
+code_refs:
+  - apps/decodex/src/radar.rs
+  - automations/decodex/prompts/radar-review.md
+  - automations/decodex/prompts/release-curator.md
+drift_watch:
+  - upstream_impact/v1
+  - social_candidate/v1
+  - control_plane_upgrade_candidate/v1
+  - codex-upstream-radar-review
+  - codex-release-checkpoint-publisher
 last_verified: 2026-06-27
 ---
 # Upstream Impact
@@ -49,6 +59,20 @@ The canonical schema identifier is:
 Recommended checked-in location:
 
 - `.agent/automations/decodex/cache/github/impact/<source-slug>.json`
+
+## Shared Handoff Rule
+
+`upstream_impact/v1` is the shared Radar handoff artifact for downstream Decodex-only
+self-iteration consumers. Radar Review may read bundles and source-backed
+`upstream_review/v1` records, but release publishing and Control Plane upgrade
+proposal work should consume the reviewed `upstream_impact/v1` conclusion first.
+
+New Radar-derived `social_candidate/v1` and
+`control_plane_upgrade_candidate/v1` artifacts should cite the matching
+`upstream_impact/v1` under their `source_refs`. Raw `upstream_review/v1`,
+`release_delta/v1`, release URLs, and compare metadata remain evidence and gap-finding
+inputs; they do not replace the shared impact artifact when both Publisher and Control
+Plane reasoning depend on the same upstream scan.
 
 ## Required fields
 


### PR DESCRIPTION
## Summary
- Make upstream_impact/v1 the shared Radar handoff for Radar-derived release publishing and Control Plane upgrade candidates.
- Preserve autonomy challenge evidence as promotion constraints instead of automatic blockers.
- Align validators, schemas, automation prompts, and Decodex docs with the shared handoff and non-execution authority boundary.

## Validation
- cargo make fmt
- cargo make check-docs
- cargo test -p decodex autonomy_objective --lib
- cargo test -p decodex autonomy_signal --lib
- cargo test -p decodex autonomy_proposal --lib
- cargo test -p decodex mcp::tests::autonomy --lib
- cargo test -p decodex radar --lib
- decodex probe
- cargo make check

## Review
- Independent fresh-context Decodex Review checkpoint recorded clean for HEAD 61bcf323.