### PR TITLE
Fix lifecycle status and recovery convergence

### DIFF
--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -682,16 +682,43 @@ fn build_lane_inspect_operator_runs(
 			continue;
 		}
 
-		runs.push(operator_run_status(
+		let mut run = operator_run_status(
 			project,
 			&loop_evidence,
 			&project_display_name,
 			run,
 			now_unix_epoch,
-		)?);
+		)?;
+
+		apply_terminal_ledger_projection_to_lane_inspect_run(project, state_store, &mut run)?;
+
+		runs.push(run);
 	}
 
 	Ok(runs)
+}
+
+fn apply_terminal_ledger_projection_to_lane_inspect_run(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	run: &mut OperatorRunStatus,
+) -> crate::prelude::Result<()> {
+	let records = state_store.list_linear_execution_events(project.service_id(), &run.issue_id)?;
+
+	if records.is_empty() {
+		return Ok(());
+	}
+
+	let records = local_history_ledger_records(records);
+	let outcome = operator_history_ledger_outcome(&records);
+
+	if history_ledger_outcome_is_terminal(&outcome)
+		&& !current_lane_has_authoritative_live_owner(run)
+	{
+		apply_terminal_history_ledger_outcome_to_run(run, &outcome);
+	}
+
+	Ok(())
 }
 
 fn project_run_status_issue_matches(run: &ProjectRunStatus, issue: &str) -> bool {
@@ -1806,34 +1833,51 @@ fn history_ledger_outcome_requires_attention(outcome: &OperatorHistoryLedgerOutc
 }
 
 fn apply_terminal_history_ledger_outcome_to_latest_run(lane: &mut OperatorHistoryLaneStatus) {
-	let final_outcome = lane.ledger_outcome.final_outcome.clone();
-	let final_event_at = lane.ledger_outcome.final_event_at.clone();
-	let requires_attention = history_ledger_outcome_requires_attention(&lane.ledger_outcome);
+	apply_terminal_history_ledger_outcome_to_run(&mut lane.latest_run, &lane.ledger_outcome);
+}
 
-	lane.latest_run.status = final_outcome.clone();
-	lane.latest_run.attempt_status = final_outcome;
-	lane.latest_run.status_projection_reason = None;
-	lane.latest_run.phase = String::from(if requires_attention { "needs_attention" } else { "completed" });
-	lane.latest_run.run_phase = lane.latest_run.phase.clone();
-	lane.latest_run.wait_reason = None;
-	lane.latest_run.current_operation = String::from("ledger_outcome");
-	lane.latest_run.continuation_pending = false;
-	lane.latest_run.run_lease = false;
-	lane.latest_run.queue_lease_state = String::from("not_held");
-	lane.latest_run.execution_liveness = String::from("not_running");
-	lane.latest_run.suspected_stall = false;
-	lane.latest_run.retry_kind = None;
-	lane.latest_run.next_retry_at = None;
+fn apply_terminal_history_ledger_outcome_to_run(
+	run: &mut OperatorRunStatus,
+	outcome: &OperatorHistoryLedgerOutcome,
+) {
+	let final_outcome = outcome.final_outcome.clone();
+	let final_event_at = outcome.final_event_at.clone();
+	let requires_attention = history_ledger_outcome_requires_attention(outcome);
 
-	if let Some(loop_status) = lane.latest_run.loop_status.as_mut() {
+	run.status = final_outcome.clone();
+	run.attempt_status = final_outcome;
+	run.status_projection_reason = None;
+	run.phase = String::from(if requires_attention { "needs_attention" } else { "completed" });
+	run.run_phase = run.phase.clone();
+	run.wait_reason = None;
+	run.current_operation = String::from("ledger_outcome");
+	run.continuation_pending = false;
+	run.run_lease = false;
+	run.queue_lease_state = String::from("not_held");
+	run.execution_liveness = String::from("not_running");
+	run.ownership_state =
+		String::from(if requires_attention { "retained_attention" } else { "closed" });
+	run.liveness_state = String::from("not_running");
+	run.policy_state = String::from("allowed");
+	run.terminalization_state =
+		String::from(if requires_attention { "none" } else { "cleanup_complete" });
+	run.lane_control_conditions.clear();
+	run.suspected_stall = false;
+	run.retry_kind = None;
+	run.next_retry_at = None;
+	run.has_fresh_execution = false;
+	run.counts_as_running = false;
+	run.needs_attention = requires_attention;
+	run.control_capability = None;
+
+	if let Some(loop_status) = run.loop_status.as_mut() {
 		loop_status.summary = format!(
 			"terminal {}: {}",
 			if requires_attention { "attention" } else { "lifecycle" },
-			lane.latest_run.status
+			run.status
 		);
-		loop_status.next_action = requires_attention
-			.then(|| lane.ledger_outcome.needs_attention_reason.clone())
-			.flatten();
+		loop_status.next_action =
+			requires_attention.then(|| outcome.needs_attention_reason.clone()).flatten();
 
 		if loop_status
 			.review
@@ -1843,9 +1887,17 @@ fn apply_terminal_history_ledger_outcome_to_latest_run(lane: &mut OperatorHistor
 			loop_status.review = None;
 		}
 	}
+	run.lane_control_next_action = if requires_attention {
+		run.loop_status
+			.as_ref()
+			.and_then(|loop_status| loop_status.next_action.clone())
+			.unwrap_or_else(|| String::from("inspect_lane_state"))
+	} else {
+		String::from("no_action")
+	};
 	if let Some(final_event_at) = final_event_at {
-		lane.latest_run.updated_at = final_event_at.clone();
-		lane.latest_run.last_run_activity_at = Some(final_event_at);
+		run.updated_at = final_event_at.clone();
+		run.last_run_activity_at = Some(final_event_at);
 	}
 }
 

--- a/apps/decodex/src/orchestrator/tests/operator/status/http.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/http.rs
@@ -2098,6 +2098,127 @@ fn operator_lane_inspect_api_returns_lane_identity() {
 }
 
 #[test]
+fn operator_lane_inspect_projects_terminal_ledger_for_unowned_stale_run() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let registration = ProjectRegistration::from_config(
+		config.service_id(),
+		&service_config_path(config.repo_root()),
+		&config,
+		true,
+		"test-fingerprint",
+	);
+	let issue = sample_issue("Done", &[]);
+	let worktree_path = config.worktree_root().join(&issue.identifier);
+
+	fs::create_dir_all(&worktree_path).expect("worktree should exist");
+
+	state_store.upsert_project(&registration).expect("project should register");
+	state_store
+		.record_run_attempt("pub-101-attempt-1", &issue.id, 1, "running")
+		.expect("stale running attempt should record");
+	state_store
+		.upsert_worktree(
+			config.service_id(),
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+	seed_local_linear_execution_events(
+		&state_store,
+		&successful_linear_execution_history_comments_with_cleanup(&issue),
+	);
+
+	let response = String::from_utf8(orchestrator::build_operator_lane_inspect_http_response(
+		&state_store,
+		format!(
+			"GET {}?projectId=pubfi&issue=PUB-101&runId=pub-101-attempt-1 HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+			orchestrator::OPERATOR_LANE_INSPECT_ENDPOINT_PATH
+		)
+		.as_bytes(),
+	))
+	.expect("lane inspect response should be utf-8");
+	let body = response
+		.split_once("\r\n\r\n")
+		.map(|(_, body)| body)
+		.expect("lane inspect response should include body");
+	let data: Value = serde_json::from_str(body).expect("lane inspect response should be json");
+
+	assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
+	assert_eq!(data["matchedRunCount"], 1);
+	assert_eq!(data["runs"][0]["runId"], "pub-101-attempt-1");
+	assert_eq!(data["runs"][0]["status"], "cleanup_complete");
+	assert_eq!(data["runs"][0]["attemptStatus"], "cleanup_complete");
+	assert_eq!(data["runs"][0]["phase"], "completed");
+	assert_eq!(data["runs"][0]["currentOperation"], "ledger_outcome");
+	assert_eq!(data["runs"][0]["runLease"], false);
+	assert_eq!(data["runs"][0]["livenessState"], "not_running");
+	assert_eq!(data["runs"][0]["ownershipState"], "closed");
+}
+
+#[test]
+fn operator_lane_inspect_does_not_project_terminal_ledger_over_leased_run() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let registration = ProjectRegistration::from_config(
+		config.service_id(),
+		&service_config_path(config.repo_root()),
+		&config,
+		true,
+		"test-fingerprint",
+	);
+	let issue = sample_issue("In Progress", &[]);
+	let worktree_path = config.worktree_root().join(&issue.identifier);
+
+	fs::create_dir_all(&worktree_path).expect("worktree should exist");
+
+	state_store.upsert_project(&registration).expect("project should register");
+	state_store
+		.record_run_attempt("pub-101-attempt-1", &issue.id, 1, "running")
+		.expect("running attempt should record");
+	state_store
+		.upsert_lease(config.service_id(), &issue.id, "pub-101-attempt-1", "In Progress")
+		.expect("lease should record");
+	state_store
+		.upsert_worktree(
+			config.service_id(),
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+	seed_local_linear_execution_events(
+		&state_store,
+		&successful_linear_execution_history_comments_with_cleanup(&issue),
+	);
+
+	let response = String::from_utf8(orchestrator::build_operator_lane_inspect_http_response(
+		&state_store,
+		format!(
+			"GET {}?projectId=pubfi&issue=PUB-101&runId=pub-101-attempt-1 HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+			orchestrator::OPERATOR_LANE_INSPECT_ENDPOINT_PATH
+		)
+		.as_bytes(),
+	))
+	.expect("lane inspect response should be utf-8");
+	let body = response
+		.split_once("\r\n\r\n")
+		.map(|(_, body)| body)
+		.expect("lane inspect response should include body");
+	let data: Value = serde_json::from_str(body).expect("lane inspect response should be json");
+
+	assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
+	assert_eq!(data["matchedRunCount"], 1);
+	assert_eq!(data["runs"][0]["runId"], "pub-101-attempt-1");
+	assert_eq!(data["runs"][0]["status"], "running");
+	assert_eq!(data["runs"][0]["attemptStatus"], "running");
+	assert_eq!(data["runs"][0]["runLease"], true);
+	assert_eq!(data["runs"][0]["ownershipState"], "leased_run");
+	assert_eq!(data["runs"][0]["currentOperation"], "agent_run");
+}
+
+#[test]
 fn operator_lane_inspect_api_filters_by_run_id() {
 	let (_temp_dir, config, _workflow) = temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");

--- a/apps/decodex/src/radar.rs
+++ b/apps/decodex/src/radar.rs
@@ -52,6 +52,9 @@ const UPSTREAM_IMPACT_SCHEMA: &str = "upstream_impact/v1";
 const UPSTREAM_REVIEW_QUEUE_SCHEMA: &str = "upstream_review_queue/v1";
 const UPSTREAM_REVIEW_SCHEMA: &str = "upstream_review/v1";
 const CONFIG_FEATURE_CATALOG_SCHEMA: &str = "codex_config_feature_catalog/v1";
+const ANALYSIS_DRAFT_KIND: &str = "analysis_draft";
+const RADAR_ARCHIVE_HISTORICAL_RETENTION_CUTOFF: &str = "2026-06-07T00:00:00Z";
+const UPSTREAM_REVIEW_LINEAR_FOLLOWUP_CUTOFF: &str = "2026-06-12T00:00:00Z";
 const DEFAULT_VALIDATION_PATHS: &[&str] = &[
 	".agent/automations/decodex/cache/github/bundles",
 	".agent/automations/decodex/cache/github/review-queue",
@@ -516,6 +519,12 @@ pub(crate) struct RadarValidationReport {
 struct ArtifactValidation {
 	schema: Option<String>,
 	errors: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ArtifactValidationOptions {
+	allow_historical_archive_retention: bool,
+	allow_historical_upstream_review_linear_followup: bool,
 }
 
 #[derive(Debug)]
@@ -1093,7 +1102,7 @@ pub(crate) fn validate(
 
 	for path in &files {
 		let payload = load_json(path)?;
-		let validation = validate_artifact(&payload);
+		let validation = validate_artifact_for_path(path, &payload);
 
 		if validation.schema.as_deref() == Some(SIGNAL_SCHEMA) {
 			validate_signal_slug_uniqueness(path, &payload, &mut state, &mut errors);
@@ -4567,7 +4576,101 @@ fn routed_token_env() -> Option<String> {
 	}
 }
 
+fn is_analysis_draft_path(path: &Path) -> bool {
+	let normalized = normalized_path(path);
+
+	normalized.ends_with(".analysis.json")
+		&& (normalized.contains("/generated/analysis/")
+			|| normalized.starts_with("generated/analysis/"))
+}
+
+fn is_historical_archive_manifest_path(path: &Path, payload: &Value) -> bool {
+	let Some(entry) = payload.as_object() else {
+		return false;
+	};
+	let normalized = normalized_path(path);
+
+	string_field(entry, "schema") == Some(RADAR_ARCHIVE_MANIFEST_SCHEMA)
+		&& normalized.contains("/cache/archive/index/")
+		&& timestamp_field_before(
+			entry,
+			"created_at",
+			RADAR_ARCHIVE_HISTORICAL_RETENTION_CUTOFF,
+		)
+}
+
+fn is_historical_upstream_review_path(path: &Path, payload: &Value) -> bool {
+	let Some(entry) = payload.as_object() else {
+		return false;
+	};
+	let normalized = normalized_path(path);
+
+	string_field(entry, "schema") == Some(UPSTREAM_REVIEW_SCHEMA)
+		&& normalized.contains("/cache/github/reviews/")
+		&& timestamp_field_before(entry, "reviewed_at", UPSTREAM_REVIEW_LINEAR_FOLLOWUP_CUTOFF)
+}
+
+fn timestamp_field_before(entry: &Map<String, Value>, field: &str, cutoff: &str) -> bool {
+	let Some(value) = entry.get(field).and_then(Value::as_str) else {
+		return false;
+	};
+	let Ok(value) = OffsetDateTime::parse(value, &Rfc3339) else {
+		return false;
+	};
+	let Ok(cutoff) = OffsetDateTime::parse(cutoff, &Rfc3339) else {
+		return false;
+	};
+
+	value < cutoff
+}
+
+fn normalized_path(path: &Path) -> String {
+	path.to_string_lossy().replace('\\', "/")
+}
+
+fn analysis_draft_error_lines(error: Report) -> Vec<String> {
+	error
+		.to_string()
+		.lines()
+		.map(str::trim)
+		.filter(|line| !line.is_empty())
+		.map(|line| line.trim_start_matches("- ").to_owned())
+		.collect()
+}
+
 fn validate_artifact(payload: &Value) -> ArtifactValidation {
+	validate_artifact_with_options(payload, ArtifactValidationOptions::default())
+}
+
+fn validate_artifact_for_path(path: &Path, payload: &Value) -> ArtifactValidation {
+	if is_analysis_draft_path(path) && payload.get("schema").is_none() {
+		return match validate_analysis_draft(payload) {
+			Ok(()) => ArtifactValidation {
+				schema: Some(ANALYSIS_DRAFT_KIND.into()),
+				errors: Vec::new(),
+			},
+			Err(error) => ArtifactValidation {
+				schema: Some(ANALYSIS_DRAFT_KIND.into()),
+				errors: analysis_draft_error_lines(error),
+			},
+		};
+	}
+
+	validate_artifact_with_options(
+		payload,
+		ArtifactValidationOptions {
+			allow_historical_archive_retention: is_historical_archive_manifest_path(path, payload),
+			allow_historical_upstream_review_linear_followup: is_historical_upstream_review_path(
+				path, payload,
+			),
+		},
+	)
+}
+
+fn validate_artifact_with_options(
+	payload: &Value,
+	options: ArtifactValidationOptions,
+) -> ArtifactValidation {
 	let Some(entry) = payload.as_object() else {
 		return ArtifactValidation {
 			schema: None,
@@ -4582,7 +4685,8 @@ fn validate_artifact(payload: &Value) -> ArtifactValidation {
 		Some(CONFIG_FEATURE_CATALOG_SCHEMA) => validate_config_feature_catalog(entry, &mut errors),
 		Some(CONTROL_PLANE_UPGRADE_CANDIDATE_SCHEMA) =>
 			validate_control_plane_upgrade_candidate(entry, &mut errors),
-		Some(RADAR_ARCHIVE_MANIFEST_SCHEMA) => validate_radar_archive_manifest(entry, &mut errors),
+		Some(RADAR_ARCHIVE_MANIFEST_SCHEMA) =>
+			validate_radar_archive_manifest(entry, options, &mut errors),
 		Some(RELEASE_DELTA_SCHEMA) => validate_release_delta(entry, &mut errors),
 		Some(SIGNAL_SCHEMA) => validate_signal(entry, &mut errors),
 		Some(SOCIAL_CANDIDATE_SCHEMA) => validate_social_candidate(entry, &mut errors),
@@ -4591,7 +4695,7 @@ fn validate_artifact(payload: &Value) -> ArtifactValidation {
 			validate_social_publish_reservation(entry, &mut errors),
 		Some(UPSTREAM_IMPACT_SCHEMA) => validate_upstream_impact(entry, &mut errors),
 		Some(UPSTREAM_REVIEW_QUEUE_SCHEMA) => validate_upstream_review_queue(entry, &mut errors),
-		Some(UPSTREAM_REVIEW_SCHEMA) => validate_upstream_review(entry, &mut errors),
+		Some(UPSTREAM_REVIEW_SCHEMA) => validate_upstream_review(entry, options, &mut errors),
 		Some(_) | None => errors.push(format!("schema must be one of {}", known_schemas())),
 	}
 
@@ -5329,7 +5433,11 @@ fn validate_upstream_review_counts(
 	}
 }
 
-fn validate_upstream_review(entry: &Map<String, Value>, errors: &mut Vec<String>) {
+fn validate_upstream_review(
+	entry: &Map<String, Value>,
+	options: ArtifactValidationOptions,
+	errors: &mut Vec<String>,
+) {
 	for field in ["slug", "repo", "reviewed_at", "observed_change"] {
 		if !is_non_empty_string(entry.get(field)) {
 			errors.push(format!("{field} must be a non-empty string"));
@@ -5353,7 +5461,7 @@ fn validate_upstream_review(entry: &Map<String, Value>, errors: &mut Vec<String>
 		errors.push(format!("confidence must be one of {}", choices(SIGNAL_CONFIDENCE)));
 	}
 
-	validate_upstream_review_actions(entry.get("next_actions"), errors);
+	validate_upstream_review_actions(entry.get("next_actions"), options, errors);
 }
 
 fn validate_upstream_review_subject_object(subject: Option<&Value>, errors: &mut Vec<String>) {
@@ -5415,7 +5523,11 @@ fn validate_upstream_review_optional_strings(entry: &Map<String, Value>, errors:
 	}
 }
 
-fn validate_upstream_review_actions(next_actions: Option<&Value>, errors: &mut Vec<String>) {
+fn validate_upstream_review_actions(
+	next_actions: Option<&Value>,
+	options: ArtifactValidationOptions,
+	errors: &mut Vec<String>,
+) {
 	let Some(next_actions) = non_empty_array(next_actions) else {
 		errors.push("next_actions must be a non-empty list".into());
 
@@ -5429,7 +5541,10 @@ fn validate_upstream_review_actions(next_actions: Option<&Value>, errors: &mut V
 			continue;
 		};
 
-		if !matches_one_of(action.get("type"), UPSTREAM_REVIEW_ACTION_TYPES) {
+		let legacy_linear_followup = options.allow_historical_upstream_review_linear_followup
+			&& string_field(action, "type") == Some("linear_followup");
+
+		if !legacy_linear_followup && !matches_one_of(action.get("type"), UPSTREAM_REVIEW_ACTION_TYPES) {
 			errors.push(format!(
 				"next_actions[{index}].type must be one of {}",
 				choices(UPSTREAM_REVIEW_ACTION_TYPES)
@@ -5739,7 +5854,11 @@ fn validate_social_publish_reservation(entry: &Map<String, Value>, errors: &mut 
 	validate_social_publish_reservation_status_payload(entry, errors);
 }
 
-fn validate_radar_archive_manifest(entry: &Map<String, Value>, errors: &mut Vec<String>) {
+fn validate_radar_archive_manifest(
+	entry: &Map<String, Value>,
+	options: ArtifactValidationOptions,
+	errors: &mut Vec<String>,
+) {
 	for field in ["archive_id", "created_at", "source_commit", "release_tag", "release_url"] {
 		if !is_non_empty_string(entry.get(field)) {
 			errors.push(format!("{field} must be a non-empty string"));
@@ -5748,7 +5867,9 @@ fn validate_radar_archive_manifest(entry: &Map<String, Value>, errors: &mut Vec<
 
 	validate_rfc3339_field(entry, "created_at", errors);
 
-	if entry.get("retention_days").and_then(Value::as_u64) != Some(21) {
+	if entry.get("retention_days").and_then(Value::as_u64) != Some(21)
+		&& !options.allow_historical_archive_retention
+	{
 		errors.push("retention_days must be 21".into());
 	}
 	if !is_https_string(entry.get("release_url")) {
@@ -6540,6 +6661,40 @@ mod tests {
 	}
 
 	#[test]
+	fn path_validation_accepts_generated_analysis_drafts_without_schema() {
+		let mut draft = serde_json::json!({
+			"kind": "behavior_change",
+			"title": "Remote control avoids duplicate account headers",
+			"summary": "Merged PR centralizes remote-control HTTP auth header construction.",
+			"why_it_matters": "Remote-control requests avoid duplicate account headers.",
+			"confidence": "confirmed",
+			"impact": "low",
+			"proof_points": ["The source helper inserts the account header once."],
+			"slug": "remote-control-account-header-deduped",
+			"config_flags": [],
+			"how_to_try": null,
+			"expected_effect": null,
+			"caveats": null,
+			"watch_state": null
+		});
+
+		assert_errors(&draft, ["schema must be one of"]);
+		assert_path_errors(
+			".agent/automations/decodex/cache/generated/analysis/openai-codex-pr-29893.analysis.json",
+			&draft,
+			[],
+		);
+
+		draft["proof_points"] = serde_json::json!([]);
+
+		assert_path_errors(
+			".agent/automations/decodex/cache/generated/analysis/openai-codex-pr-29893.analysis.json",
+			&draft,
+			["proof_points must be a non-empty list"],
+		);
+	}
+
+	#[test]
 	fn rejects_current_multi_agent_v2_signal_assign_task_without_followup_context() {
 		let mut signal = valid_signal();
 
@@ -6735,6 +6890,21 @@ mod tests {
 	}
 
 	#[test]
+	fn path_validation_accepts_historical_archive_retention_policy() {
+		let mut manifest = valid_radar_archive_manifest();
+
+		manifest["created_at"] = serde_json::json!("2026-05-13T07:52:56Z");
+		manifest["retention_days"] = serde_json::json!(28);
+
+		assert_errors(&manifest, ["retention_days must be 21"]);
+		assert_path_errors(
+			".agent/automations/decodex/cache/archive/index/2026-05-13-pre-2026-04-13.json",
+			&manifest,
+			[],
+		);
+	}
+
+	#[test]
 	fn social_reserve_publish_dry_run_does_not_write() {
 		let temp_dir = tempfile::tempdir().expect("temp dir should create");
 		let request = social_reserve_request(temp_dir.path(), true);
@@ -6882,6 +7052,29 @@ mod tests {
 		review["next_actions"][0]["type"] = serde_json::json!("publish_now");
 
 		assert_errors(&review, ["next_actions[0].type must be one of"]);
+	}
+
+	#[test]
+	fn path_validation_accepts_historical_upstream_review_linear_followup_only_before_cutoff() {
+		let mut review = valid_upstream_review();
+
+		review["reviewed_at"] = serde_json::json!("2026-06-11T20:07:07Z");
+		review["next_actions"][0]["type"] = serde_json::json!("linear_followup");
+
+		assert_errors(&review, ["next_actions[0].type must be one of"]);
+		assert_path_errors(
+			".agent/automations/decodex/cache/github/reviews/openai-codex-pr-25018.review.json",
+			&review,
+			[],
+		);
+
+		review["reviewed_at"] = serde_json::json!("2026-06-12T00:00:00Z");
+
+		assert_path_errors(
+			".agent/automations/decodex/cache/github/reviews/openai-codex-pr-25018.review.json",
+			&review,
+			["next_actions[0].type must be one of"],
+		);
 	}
 
 	#[test]
@@ -7557,6 +7750,22 @@ mod tests {
 
 	fn assert_errors<const N: usize>(payload: &Value, expected: [&str; N]) {
 		let validation = radar::validate_artifact(payload);
+
+		for expected_error in expected {
+			assert!(
+				validation.errors.iter().any(|error| error.contains(expected_error)),
+				"expected error containing {expected_error:?}, got {:?}",
+				validation.errors
+			);
+		}
+
+		if expected.is_empty() {
+			assert_eq!(validation.errors, Vec::<String>::new());
+		}
+	}
+
+	fn assert_path_errors<const N: usize>(path: &str, payload: &Value, expected: [&str; N]) {
+		let validation = radar::validate_artifact_for_path(Path::new(path), payload);
 
 		for expected_error in expected {
 			assert!(

--- a/apps/decodex/src/recovery.rs
+++ b/apps/decodex/src/recovery.rs
@@ -213,6 +213,7 @@ struct HandoffDiagnosticRequest<'a> {
 	issue_state_name: &'a str,
 	success_state: &'a str,
 	in_progress_state: &'a str,
+	failure_state: &'a str,
 	worktree: &'a WorktreeMapping,
 	existing_handoff: Option<&'a ReviewHandoffMarker>,
 	existing_orchestration: Option<&'a ReviewOrchestrationMarker>,
@@ -261,9 +262,15 @@ struct RebindValidation {
 	local_head_oid: String,
 	worktree_path_for_event: Option<String>,
 	active_label_present: bool,
+	restore_active_label: bool,
 	mode: RebindMode,
 	success_state_transition: Option<RebindSuccessStateTransition>,
 	clear_needs_attention_label: bool,
+}
+impl RebindValidation {
+	fn should_restore_active_label(&self) -> bool {
+		self.restore_active_label
+	}
 }
 
 struct AdoptValidation {
@@ -320,6 +327,7 @@ struct RebindSuccessStateTransition {
 
 struct RebindLabelValidation {
 	active_label_present: bool,
+	restore_active_label: bool,
 	clear_needs_attention_label: bool,
 }
 
@@ -431,7 +439,7 @@ pub(crate) fn run_review_handoff_rebind(
 			.map_or("none", |transition| transition.state_name.as_str());
 
 		println!(
-			"dry run: review handoff rebind validated for project={} issue={} branch={} pr={} head={} mode={} active_label_present={} state_transition={}",
+			"dry run: review handoff rebind validated for project={} issue={} branch={} pr={} head={} mode={} active_label_present={} would_restore_active_label={} state_transition={}",
 			context.config.service_id(),
 			validation.issue.identifier,
 			validation.worktree.branch_name(),
@@ -439,6 +447,7 @@ pub(crate) fn run_review_handoff_rebind(
 			validation.local_head_oid,
 			validation.mode.evidence_value(),
 			validation.active_label_present,
+			validation.should_restore_active_label(),
 			state_transition
 		);
 
@@ -1110,6 +1119,7 @@ fn diagnose_issue_worktree(
 		issue_state_name: &issue.state.name,
 		success_state: context.workflow.frontmatter().tracker().success_state(),
 		in_progress_state: context.workflow.frontmatter().tracker().in_progress_state(),
+		failure_state: context.workflow.frontmatter().tracker().failure_state(),
 		worktree: &worktree,
 		existing_handoff: existing_handoff.as_ref(),
 		existing_orchestration: existing_orchestration.as_ref(),
@@ -1209,22 +1219,42 @@ fn diagnostic_binding(request: HandoffDiagnosticRequest<'_>) -> HandoffBindingDi
 	}
 
 	if request.active_label_present == Some(false) {
+		let next_action = if request.issue_state_name == request.in_progress_state
+			|| request.issue_state_name == request.failure_state
+		{
+			rebind_state_transition_next_action(request.issue_identifier, existing_handoff.pr_url())
+		} else if request.issue_state_name == request.success_state {
+			bound_handoff_next_action(request.service_id, request.active_label_present)
+		} else {
+			issue_state_mismatch_next_action(request.success_state, request.in_progress_state)
+		};
+
 		return HandoffBindingDiagnostic {
 			classification: String::from(REVIEW_HANDOFF_OWNERSHIP_DRIFT_CLASSIFICATION),
 			reason: String::from("active_ownership_label_missing"),
 			pr_base_ref,
 			pr_head_oid,
 			mismatched_field: Some(String::from("issue.labels")),
-			next_action: bound_handoff_next_action(
-				request.service_id,
-				request.active_label_present,
-			),
+			next_action,
 		};
 	}
 	if request.issue_state_name == request.in_progress_state {
 		return HandoffBindingDiagnostic {
 			classification: String::from(REVIEW_HANDOFF_REBIND_REQUIRED_CLASSIFICATION),
 			reason: String::from("review_handoff_state_transition_pending"),
+			pr_base_ref,
+			pr_head_oid,
+			mismatched_field: Some(String::from("issue.state")),
+			next_action: rebind_state_transition_next_action(
+				request.issue_identifier,
+				existing_handoff.pr_url(),
+			),
+		};
+	}
+	if request.issue_state_name == request.failure_state {
+		return HandoffBindingDiagnostic {
+			classification: String::from(REVIEW_HANDOFF_REBIND_REQUIRED_CLASSIFICATION),
+			reason: String::from("review_handoff_failure_state_drift"),
 			pr_base_ref,
 			pr_head_oid,
 			mismatched_field: Some(String::from("issue.state")),
@@ -2497,6 +2527,7 @@ fn validate_rebind_request(
 		local_head_oid,
 		worktree_path_for_event,
 		active_label_present: label_validation.active_label_present,
+		restore_active_label: label_validation.restore_active_label,
 		mode,
 		success_state_transition,
 		clear_needs_attention_label: label_validation.clear_needs_attention_label,
@@ -3276,15 +3307,32 @@ fn validate_rebind_tracker_labels(
 	let active_label = tracker::automation_active_label(context.config.service_id());
 	let active_label_present =
 		tracker::issue_has_label_with_server_confirmation(&context.tracker, issue, &active_label)?;
+	let tracker_policy = context.workflow.frontmatter().tracker();
 
 	if !active_label_present {
-		eyre::bail!(
-			"Issue `{}` is missing active automation label `{active_label}`. Restore explicit lane ownership before rebind.",
-			issue.identifier
-		);
+		if !mode.allows_failure_state_drift_repair()
+			|| issue.state.name != tracker_policy.failure_state()
+		{
+			eyre::bail!(
+				"Issue `{}` is missing active automation label `{active_label}`. Restore explicit lane ownership before rebind.",
+				issue.identifier
+			);
+		}
+
+		if tracker::issue_team_label_id_with_server_confirmation(
+			&context.tracker,
+			issue,
+			&active_label,
+		)?
+		.is_none()
+		{
+			eyre::bail!(
+				"Issue `{}` is missing active automation label `{active_label}`, but that label was not found on the team.",
+				issue.identifier
+			);
+		}
 	}
 
-	let tracker_policy = context.workflow.frontmatter().tracker();
 	let needs_attention_label = tracker_policy.needs_attention_label();
 	let needs_attention_present = tracker::issue_has_label_with_server_confirmation(
 		&context.tracker,
@@ -3295,6 +3343,7 @@ fn validate_rebind_tracker_labels(
 	if !needs_attention_present {
 		return Ok(RebindLabelValidation {
 			active_label_present,
+			restore_active_label: !active_label_present,
 			clear_needs_attention_label: false,
 		});
 	}
@@ -3316,6 +3365,7 @@ fn validate_rebind_tracker_labels(
 
 		return Ok(RebindLabelValidation {
 			active_label_present,
+			restore_active_label: !active_label_present,
 			clear_needs_attention_label: true,
 		});
 	}
@@ -3373,7 +3423,11 @@ fn validate_adopt_issue_context(
 		);
 	}
 
-	Ok(RebindLabelValidation { active_label_present, clear_needs_attention_label: false })
+	Ok(RebindLabelValidation {
+		active_label_present,
+		restore_active_label: false,
+		clear_needs_attention_label: false,
+	})
 }
 
 fn validate_adopt_issue_state(
@@ -3658,18 +3712,36 @@ fn apply_review_handoff_rebind(
 		0,
 		None,
 	);
-	let event = review_handoff_rebind_event(context, validation);
 
-	context.state_store.upsert_review_handoff_marker(
+	write_review_lifecycle_markers_with_rollback(
+		&context.state_store,
 		context.config.service_id(),
 		&validation.issue.id,
 		&handoff_marker,
-	)?;
-	context.state_store.upsert_review_orchestration_marker(
-		context.config.service_id(),
-		&validation.issue.id,
 		&orchestration_marker,
+		|| {
+			context.state_store.upsert_review_orchestration_marker(
+				context.config.service_id(),
+				&validation.issue.id,
+				&orchestration_marker,
+			)
+		},
 	)?;
+
+	let active_label_restored = match restore_rebind_active_label(context, validation) {
+		Ok(active_label_restored) => active_label_restored,
+		Err(error) => {
+			context.state_store.clear_review_lifecycle_for_handoff(
+				context.config.service_id(),
+				&validation.issue.id,
+				&handoff_marker,
+				&orchestration_marker,
+			)?;
+
+			return Err(error);
+		},
+	};
+	let event = review_handoff_rebind_event(context, validation, active_label_restored);
 
 	if let Err(error) = write_rebind_audit(context, validation, &event)
 		.and_then(|()| context.state_store.record_linear_execution_event(&event))
@@ -3680,6 +3752,8 @@ fn apply_review_handoff_rebind(
 			&handoff_marker,
 			&orchestration_marker,
 		)?;
+
+		rollback_rebind_active_label_restoration(context, validation, active_label_restored)?;
 
 		return Err(error);
 	}
@@ -3702,7 +3776,36 @@ fn apply_review_handoff_rebind(
 		context.config.service_id(),
 		validation,
 		"local_markers_written",
+		active_label_restored,
 	)?;
+
+	Ok(())
+}
+
+fn write_review_lifecycle_markers_with_rollback<F>(
+	state_store: &StateStore,
+	project_id: &str,
+	issue_id: &str,
+	handoff_marker: &ReviewHandoffMarker,
+	orchestration_marker: &ReviewOrchestrationMarker,
+	write_orchestration_marker: F,
+) -> Result<()>
+where
+	F: FnOnce() -> Result<()>,
+{
+	if let Err(error) = state_store
+		.upsert_review_handoff_marker(project_id, issue_id, handoff_marker)
+		.and_then(|()| write_orchestration_marker())
+	{
+		state_store.clear_review_lifecycle_for_handoff(
+			project_id,
+			issue_id,
+			handoff_marker,
+			orchestration_marker,
+		)?;
+
+		return Err(error);
+	}
 
 	Ok(())
 }
@@ -3843,6 +3946,35 @@ fn write_adopt_local_state(
 		})
 }
 
+fn restore_rebind_active_label(
+	context: &RecoveryContext,
+	validation: &RebindValidation,
+) -> Result<bool> {
+	if !validation.should_restore_active_label() {
+		return Ok(false);
+	}
+
+	let active_label = tracker::automation_active_label(context.config.service_id());
+
+	tracker::set_issue_label_presence(&context.tracker, &validation.issue, &active_label, true)
+}
+
+fn rollback_rebind_active_label_restoration(
+	context: &RecoveryContext,
+	validation: &RebindValidation,
+	active_label_restored: bool,
+) -> Result<()> {
+	if !active_label_restored {
+		return Ok(());
+	}
+
+	let active_label = tracker::automation_active_label(context.config.service_id());
+
+	tracker::set_issue_label_presence(&context.tracker, &validation.issue, &active_label, false)?;
+
+	Ok(())
+}
+
 fn restore_adopt_active_label(
 	context: &RecoveryContext,
 	validation: &AdoptValidation,
@@ -3905,6 +4037,7 @@ fn append_review_handoff_rebind_private_event(
 	service_id: &str,
 	validation: &RebindValidation,
 	writeback_stage: &str,
+	active_label_restored: bool,
 ) -> Result<()> {
 	state_store
 		.append_private_execution_event(
@@ -3928,6 +4061,8 @@ fn append_review_handoff_rebind_private_event(
 				"merge_state_status": &validation.landing_state.merge_state_status,
 				"status_check_rollup_state": &validation.landing_state.status_check_rollup_state,
 				"mode": validation.mode.as_str(),
+				"active_label_present": validation.active_label_present,
+				"active_label_restored": active_label_restored,
 				"clear_needs_attention_label": validation.clear_needs_attention_label,
 				"next_action": "continue retained post-review lifecycle",
 			}),
@@ -3977,6 +4112,7 @@ fn append_review_handoff_adopt_private_event(
 fn review_handoff_rebind_event(
 	context: &RecoveryContext,
 	validation: &RebindValidation,
+	active_label_restored: bool,
 ) -> LinearExecutionEventRecord {
 	let pr_url = landing_url(&validation.landing_state);
 	let stable_anchor = records::stable_event_anchor(&[
@@ -4015,6 +4151,8 @@ fn review_handoff_rebind_event(
 		format!("pr_url={pr_url}"),
 		format!("pr_head_sha={}", validation.local_head_oid),
 		format!("existing_review_lifecycle_record={}", validation.mode.evidence_value()),
+		format!("active_label_present={}", validation.active_label_present),
+		format!("active_label_repair={active_label_restored}"),
 		format!("needs_attention_label_repair={}", validation.clear_needs_attention_label),
 	]);
 	event.next_action = Some(String::from("continue retained post-review lifecycle"));
@@ -6431,6 +6569,7 @@ token_env_var = "HOME"
 			local_head_oid: head_oid.to_owned(),
 			worktree_path_for_event: Some(String::from(".worktrees/PUB-718")),
 			active_label_present: true,
+			restore_active_label: false,
 			mode: super::RebindMode::RefreshExistingHandoff,
 			success_state_transition: None,
 			clear_needs_attention_label: false,
@@ -6441,6 +6580,7 @@ token_env_var = "HOME"
 			"pubfi",
 			&validation,
 			"local_markers_written",
+			false,
 		)
 		.expect("rebind private event should append");
 
@@ -6461,9 +6601,68 @@ token_env_var = "HOME"
 		assert_eq!(payload["event"], REVIEW_HANDOFF_REBIND_EVENT);
 		assert_eq!(payload["writeback_stage"], "local_markers_written");
 		assert_eq!(payload["mode"], "refresh_existing_handoff");
+		assert_eq!(payload["active_label_present"], true);
+		assert_eq!(payload["active_label_restored"], false);
 		assert_eq!(payload["pr_url"], pr_url);
 		assert_eq!(payload["pr_head_sha"], head_oid);
 		assert_eq!(payload["next_action"], "continue retained post-review lifecycle");
+	}
+
+	#[test]
+	fn rebind_lifecycle_marker_write_failure_clears_partial_handoff_marker() {
+		let state_store = StateStore::open_in_memory().expect("state store should open");
+		let branch_name = "x/pubfi-pub-718";
+		let pr_url = "https://github.com/hack-ink/pubfi-mono-v2/pull/14";
+		let head_oid = "1123456789abcdef0123456789abcdef01234567";
+		let handoff = ReviewHandoffMarker::new(
+			"pub-718-attempt-1",
+			1,
+			branch_name,
+			pr_url,
+			"main",
+			branch_name,
+			head_oid,
+		);
+		let orchestration = ReviewOrchestrationMarker::new(
+			"pub-718-attempt-1",
+			1,
+			branch_name,
+			pr_url,
+			head_oid,
+			"request_pending",
+			None,
+			None,
+			None,
+			0,
+			0,
+			None,
+		);
+
+		let error = super::write_review_lifecycle_markers_with_rollback(
+			&state_store,
+			"pubfi",
+			"issue-id",
+			&handoff,
+			&orchestration,
+			|| -> crate::prelude::Result<()> {
+				Err(crate::prelude::eyre::eyre!("orchestration marker write failed"))
+			},
+		)
+		.expect_err("orchestration write failure should be returned");
+
+		assert!(error.to_string().contains("orchestration marker write failed"));
+		assert!(
+			state_store
+				.review_lifecycle_record("pubfi", "issue-id", branch_name)
+				.expect("lifecycle read should succeed")
+				.is_none()
+		);
+		assert!(
+			state_store
+				.review_handoff_marker("pubfi", "issue-id", branch_name)
+				.expect("handoff read should succeed")
+				.is_none()
+		);
 	}
 
 	#[test]
@@ -6488,6 +6687,7 @@ token_env_var = "HOME"
 			issue_state_name: "In Review",
 			success_state: "In Review",
 			in_progress_state: "In Progress",
+			failure_state: "Todo",
 			worktree: &worktree,
 			existing_handoff: Some(&handoff),
 			existing_orchestration: None,
@@ -6539,6 +6739,7 @@ token_env_var = "HOME"
 			issue_state_name: "In Progress",
 			success_state: "In Review",
 			in_progress_state: "In Progress",
+			failure_state: "Todo",
 			worktree: &worktree,
 			existing_handoff: Some(&handoff),
 			existing_orchestration: Some(&orchestration),
@@ -6578,6 +6779,7 @@ token_env_var = "HOME"
 			issue_state_name: "In Review",
 			success_state: "In Review",
 			in_progress_state: "In Progress",
+			failure_state: "Todo",
 			worktree: &worktree,
 			existing_handoff: Some(&handoff),
 			existing_orchestration: None,
@@ -6632,6 +6834,7 @@ token_env_var = "HOME"
 			issue_state_name: "In Review",
 			success_state: "In Review",
 			in_progress_state: "In Progress",
+			failure_state: "Todo",
 			worktree: &worktree,
 			existing_handoff: Some(&handoff),
 			existing_orchestration: Some(&orchestration),
@@ -6683,6 +6886,7 @@ token_env_var = "HOME"
 			issue_state_name: "In Review",
 			success_state: "In Review",
 			in_progress_state: "In Progress",
+			failure_state: "Todo",
 			worktree: &worktree,
 			existing_handoff: Some(&handoff),
 			existing_orchestration: Some(&orchestration),
@@ -6698,6 +6902,115 @@ token_env_var = "HOME"
 		assert_eq!(diagnostic.mismatched_field.as_deref(), Some("issue.labels"));
 		assert!(diagnostic.next_action.contains("decodex:active:pubfi"));
 		assert!(diagnostic.next_action.contains("Restore explicit lane ownership"));
+	}
+
+	#[test]
+	fn diagnostic_reports_rebind_for_failure_state_ownership_drift() {
+		let branch_name = "x/pubfi-pub-718";
+		let pr_url = "https://github.com/hack-ink/pubfi-mono-v2/pull/14";
+		let head_oid = "1123456789abcdef0123456789abcdef01234567";
+		let worktree = sample_worktree(branch_name);
+		let handoff = ReviewHandoffMarker::new(
+			"pub-718-attempt-1",
+			1,
+			branch_name,
+			pr_url,
+			"main",
+			branch_name,
+			head_oid,
+		);
+		let orchestration = ReviewOrchestrationMarker::new(
+			"pub-718-attempt-1",
+			1,
+			branch_name,
+			pr_url,
+			head_oid,
+			"request_pending",
+			None,
+			None,
+			None,
+			0,
+			0,
+			None,
+		);
+		let landing_state = sample_landing_state(pr_url, branch_name, head_oid);
+		let diagnostic = super::diagnostic_binding(super::HandoffDiagnosticRequest {
+			service_id: "pubfi",
+			issue_identifier: "PUB-718",
+			issue_state_name: "Todo",
+			success_state: "In Review",
+			in_progress_state: "In Progress",
+			failure_state: "Todo",
+			worktree: &worktree,
+			existing_handoff: Some(&handoff),
+			existing_orchestration: Some(&orchestration),
+			local_branch_name: Some(branch_name),
+			local_head_oid: Some(head_oid),
+			worktree_clean: Some(true),
+			pr_inspection: Some(&landing_state),
+			active_label_present: Some(false),
+		});
+
+		assert_eq!(diagnostic.classification, REVIEW_HANDOFF_OWNERSHIP_DRIFT_CLASSIFICATION);
+		assert_eq!(diagnostic.reason, "active_ownership_label_missing");
+		assert_eq!(diagnostic.mismatched_field.as_deref(), Some("issue.labels"));
+		assert!(diagnostic.next_action.contains("rebind PUB-718"));
+		assert!(diagnostic.next_action.contains("--dry-run"));
+		assert!(!diagnostic.next_action.contains("Restore explicit lane ownership"));
+	}
+
+	#[test]
+	fn diagnostic_reports_rebind_for_failure_state_drift_with_active_label() {
+		let branch_name = "x/pubfi-pub-718";
+		let pr_url = "https://github.com/hack-ink/pubfi-mono-v2/pull/14";
+		let head_oid = "1123456789abcdef0123456789abcdef01234567";
+		let worktree = sample_worktree(branch_name);
+		let handoff = ReviewHandoffMarker::new(
+			"pub-718-attempt-1",
+			1,
+			branch_name,
+			pr_url,
+			"main",
+			branch_name,
+			head_oid,
+		);
+		let orchestration = ReviewOrchestrationMarker::new(
+			"pub-718-attempt-1",
+			1,
+			branch_name,
+			pr_url,
+			head_oid,
+			"request_pending",
+			None,
+			None,
+			None,
+			0,
+			0,
+			None,
+		);
+		let landing_state = sample_landing_state(pr_url, branch_name, head_oid);
+		let diagnostic = super::diagnostic_binding(super::HandoffDiagnosticRequest {
+			service_id: "pubfi",
+			issue_identifier: "PUB-718",
+			issue_state_name: "Todo",
+			success_state: "In Review",
+			in_progress_state: "In Progress",
+			failure_state: "Todo",
+			worktree: &worktree,
+			existing_handoff: Some(&handoff),
+			existing_orchestration: Some(&orchestration),
+			local_branch_name: Some(branch_name),
+			local_head_oid: Some(head_oid),
+			worktree_clean: Some(true),
+			pr_inspection: Some(&landing_state),
+			active_label_present: Some(true),
+		});
+
+		assert_eq!(diagnostic.classification, REVIEW_HANDOFF_REBIND_REQUIRED_CLASSIFICATION);
+		assert_eq!(diagnostic.reason, "review_handoff_failure_state_drift");
+		assert_eq!(diagnostic.mismatched_field.as_deref(), Some("issue.state"));
+		assert!(diagnostic.next_action.contains("rebind PUB-718"));
+		assert!(diagnostic.next_action.contains("--dry-run"));
 	}
 
 	#[test]

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,16 @@
 
 ## 2026-06-27
 
+- Made `decodex radar validate` path-aware for existing operations cache drift:
+  generated analysis drafts are validated as helper outputs without a `schema` field,
+  historical archive manifests may retain their original retention policy, and
+  pre-shared-handoff upstream reviews can still read old `linear_followup` actions
+  while new artifacts remain on `upstream_impact` or
+  `control_plane_upgrade_candidate`.
+- Aligned review-handoff recovery and lane-control docs with terminal Run Ledger
+  projection and ownership-drift rebind: old unowned run inspect now projects
+  cleanup/terminal outcomes, while current same-PR same-head failure-state drift can
+  restore active ownership through validated `review-handoff rebind`.
 - Made `upstream_impact/v1` the shared Radar handoff for Decodex-only release
   publishing and Control Plane upgrade proposal work, and updated autonomy challenge
   disposition so challenge objections are retained as promotion constraints rather

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -6,8 +6,8 @@ status: active
 authority: current_state
 owner: docs
 tags: [reference]
-code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/recovery.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/types.rs, apps/decodex/src/orchestrator/operator_http.rs, apps/decodex/src/orchestrator/operator_dashboard.html, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/mcp.rs]
-drift_watch: [decodex serve, decodex status, decodex recover ghost-lane, ghost_lane_cleanup_audit_present, mcp_test_fixture_ghost_lane, decodex evidence, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, phase_acceptance_check, control_plane_snapshot, operator dashboard, runtime.sqlite3, project.toml, WORKFLOW.md]
+code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/recovery.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/types.rs, apps/decodex/src/orchestrator/operator_http.rs, apps/decodex/src/orchestrator/operator_dashboard.html, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/orchestrator/tests/operator/status/http.rs, apps/decodex/src/mcp.rs]
+drift_watch: [decodex serve, decodex status, decodex lane inspect, decodex recover review-handoff, decodex recover ghost-lane, ghost_lane_cleanup_audit_present, mcp_test_fixture_ghost_lane, decodex evidence, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, phase_acceptance_check, control_plane_snapshot, operator dashboard, runtime.sqlite3, project.toml, WORKFLOW.md]
 last_verified: 2026-06-27
 ---
 # Operator Control Plane
@@ -575,6 +575,13 @@ Worktree visibility follows the owning dashboard section:
   identify the lifecycle record, and `decodex recover review-handoff diagnose <ISSUE>`
   reports the stored handoff head, phase head, PR head, and mismatched field before
   any explicit rebind refresh.
+- `review_handoff_ownership_drift` means the retained lifecycle record is bound but
+  the active service label is missing. If the same-PR same-head lane is still in
+  progress state or has drifted back to the workflow failure state, diagnosis points to
+  `decodex recover review-handoff rebind --dry-run`; live rebind can restore the
+  active service label only after proving retained worktree and PR lineage. Bound
+  success-state lanes may still ask for ownership confirmation before the existing
+  post-review lifecycle continues.
 - `ownership_state = ghost_lane` with
   `policy_state = runtime_recovery_required` in live observer status or a fresh
   daemon-cached status means a local current lane still has a run lease, but tracker
@@ -666,6 +673,12 @@ Worktree visibility follows the owning dashboard section:
   `wait_for_review` or `ready_to_land`, that row controls the current action summary;
   stale active-label or worktree echoes from an older terminal ledger record stay in
   Run Ledger history instead of reappearing as current attention.
+- `decodex lane inspect` applies the same issue-scoped terminal Run Ledger projection
+  to old or unowned runs. Cleanup-complete history renders as
+  `status=cleanup_complete`, `ownership_state=closed`, `liveness_state=not_running`,
+  and `lane_control_next_action=no_action`; terminal failure history renders as
+  retained attention instead of stale `review_handoff_pending` or `running`. A still
+  leased current attempt is not overwritten by older terminal ledger history.
 - If private evidence shows `phase_goal_recovery` followed by a queued continuation,
   the lane is not a retained-attention worktree even when the preceding child failed
   or stalled reconciliation first found retained dirty progress. Treat it as

--- a/docs/runbook/recover-review-handoff.md
+++ b/docs/runbook/recover-review-handoff.md
@@ -1,22 +1,22 @@
 ---
 type: "Runbook"
 title: "Recover Review Handoff"
-description: "Diagnose and explicitly repair retained review lanes that are blocked by a missing or stale runtime DB review lifecycle record."
+description: "Diagnose and explicitly repair retained review lanes blocked by missing, stale, or ownership-drifted review lifecycle state."
 status: active
 authority: procedural
 owner: automation
 tags: [runbook]
-last_verified: 2026-06-17
+last_verified: 2026-06-27
 ---
 # Recover Review Handoff
 
 Purpose: Diagnose and explicitly repair retained review lanes that are blocked by a
-missing or stale runtime DB review lifecycle record.
+missing, stale, or ownership-drifted runtime DB review lifecycle record.
 
 Use this when: `decodex status` or the dashboard shows a `Review & Landing` lane
 blocked with `missing_review_handoff_record`, a review lifecycle head or phase
-mismatch, or a similar retained review lifecycle mismatch after manual repair or
-rebase.
+mismatch, `review_handoff_state_transition_pending`, or an ownership-drifted retained
+handoff after manual repair, stale failure writeback, or rebase.
 
 Do not use this for: healthy PR handoffs, review repair, landing, closeout, cleanup-only
 worktrees, or manual PR landing.
@@ -50,7 +50,9 @@ progress.
 
 Only rebind when the diagnosis says the review lifecycle record is absent, says the
 existing same-branch same-PR record must be refreshed after the retained worktree and
-PR head have been checked, or reports `review_handoff_state_transition_pending`.
+PR head have been checked, reports `review_handoff_state_transition_pending`, or
+reports `review_handoff_ownership_drift` for an already-current same-PR same-head lane
+that is in `tracker.in_progress_state` or `tracker.failure_state`.
 
 ```sh
 decodex recover review-handoff rebind <ISSUE> --pr <PR_URL> --dry-run
@@ -65,10 +67,11 @@ missing, or where an already-current record exists but the issue state was not
 advanced, the command may also move the issue from the workflow
 `tracker.in_progress_state` to `tracker.success_state` after the rebind audit
 succeeds. If stale failure writeback already moved an already-current record lane to
-`tracker.failure_state` and added `tracker.needs_attention_label`, rebind may clear that
-label and move the issue to `tracker.success_state`; this is only for current same-PR
-same-head records, not for missing or stale record recovery. It does not merge the PR,
-queue follow-up issues, or clean worktrees.
+`tracker.failure_state`, removed `decodex:active:<service-id>`, or added
+`tracker.needs_attention_label`, rebind may restore the active service label, clear the
+needs-attention label, and move the issue to `tracker.success_state`; this is only for
+current same-PR same-head records, not for missing or stale record recovery. It does
+not merge the PR, queue follow-up issues, or clean worktrees.
 
 The command rejects the rebind unless all of these are true:
 
@@ -80,7 +83,10 @@ The command rejects the rebind unless all of these are true:
 - the issue does not have the needs-attention label, except for the already-current
   record plus `tracker.failure_state` drift case where rebind clears it after recording
   the audit
-- the issue still has `decodex:active:<service-id>` ownership
+- the issue still has `decodex:active:<service-id>` ownership, except for the
+  already-current record plus `tracker.failure_state` drift case where rebind verifies
+  the active service label exists on the issue team and restores it after local
+  lifecycle state is written
 - the retained worktree branch matches the runtime DB worktree mapping
 - the retained worktree has no local source changes except top-level Decodex runtime
   artifacts such as `.decodex-run-activity` and `.decodex-run-control/`
@@ -198,15 +204,17 @@ plus explicit rebind before any manual cleanup.
 ## Active Ownership Recovery
 
 If diagnosis reports `classification: review_handoff_ownership_drift`,
-`reason: active_ownership_label_missing`, and `active_label_present: false`, do not run
-rebind just to restore ownership. If the lane has no retained lifecycle record because
-a human PR needs manual takeover, run `recover review-handoff adopt --dry-run`; the
-dry run reports `would_restore_active_label=true` when live adopt can restore the
-active service label after validating the issue, managed worktree, PR branch, PR head,
-and landability gates. If the lane already has a retained lifecycle record, use the
-ordinary diagnosis/rebind or post-review path instead of hand-adding labels. If the issue still
-has `decodex:needs-attention`, clear that label only after the recorded blocker has
-been repaired or an explicit recovery command says it will clear the label itself.
+`reason: active_ownership_label_missing`, and `active_label_present: false`, follow
+the diagnostic `next_action` instead of hand-adding labels. For an already-current
+same-PR same-head lane in `tracker.failure_state` or `tracker.in_progress_state`, that
+next action is `recover review-handoff rebind --dry-run`; the dry run reports
+`would_restore_active_label=true` when live rebind can restore the active service
+label after validating the retained worktree and PR lineage. If the lane has no
+retained lifecycle record because a human PR needs manual takeover, run
+`recover review-handoff adopt --dry-run`; adopt reports `would_restore_active_label`
+for its own takeover path. If the issue still has `decodex:needs-attention`, clear that
+label only after the recorded blocker has been repaired or an explicit recovery
+command says it will clear the label itself.
 
 After an explicit recovery restores or confirms ownership, rerun:
 

--- a/docs/spec/lane-control-state.md
+++ b/docs/spec/lane-control-state.md
@@ -7,10 +7,10 @@ authority: normative
 owner: runtime
 tags: [lane-control, runtime, scheduler]
 source_refs: []
-code_refs: [apps/decodex/src/orchestrator/status.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs]
+code_refs: [apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/tests/operator/status/http.rs, apps/decodex/src/agent/tracker_tool_bridge/tools.rs]
 related: [lane-control.md, runtime.md]
 drift_watch: [ownership_state, liveness_state, policy_state, terminalization_state, review_churn_exceeded]
-last_verified: 2026-06-17
+last_verified: 2026-06-27
 ---
 
 # Lane-Control State Specification
@@ -103,6 +103,12 @@ from protocol activity.
 - `run_lease=false` is incompatible with `ownership_state=leased_run`.
 - Terminal attempt statuses such as `failed`, `interrupted`, `stalled`, or `succeeded`
   must not be promoted to `running` by live process, thread, or protocol evidence.
+- Issue-scoped terminal Run Ledger outcomes are authoritative for old or unowned run
+  inspect/status projection. If no run lease or other authoritative live owner remains,
+  `decodex lane inspect` and operator status must project the final ledger outcome
+  into `status`, `attempt_status`, `phase`, `ownership_state`, `liveness_state`, and
+  `lane_control_next_action`. That projection must not overwrite a still-leased
+  current attempt for the same issue.
 - `policy_state=review_churn_exceeded` blocks further review-repair mutation for the
   same strategy until architecture recovery or human attention changes the policy
   state.

--- a/docs/spec/post-review-lifecycle.md
+++ b/docs/spec/post-review-lifecycle.md
@@ -26,7 +26,7 @@ drift_watch:
   - IssueDispatchMode::Retry
   - IssueDispatchMode::ReviewRepair
   - IssueDispatchMode::Closeout
-last_verified: 2026-06-25
+last_verified: 2026-06-27
 ---
 # Post-Review Lifecycle
 
@@ -164,9 +164,14 @@ When Linear issue metadata readback is degraded by connector backoff, operator s
 must still keep locally retained lifecycle rows visible with the lifecycle PR URL and
 head SHA and must mark the row as tracker-readback degraded instead of presenting the
 PR or code state as failed. If the lifecycle record is bound but
-`decodex:active:<service-id>` is
-missing, recovery diagnosis must classify the state as ownership drift and give the
-single label repair action instead of recommending rebind.
+`decodex:active:<service-id>` is missing, recovery diagnosis must classify the state
+as ownership drift. A bound lane already in `tracker.success_state` may ask the
+operator to confirm or restore ownership before continuing the existing lifecycle. An
+already-current same-PR same-head lane that drifted back to `tracker.in_progress_state`
+or `tracker.failure_state` must instead point to the explicit
+`review-handoff rebind --dry-run` path, because that path can validate the retained
+worktree and PR lineage before restoring the active service label and completing the
+issue-state transition.
 
 The supported operator recovery surface is `decodex recover review-handoff`. This is a
 break-glass recovery path for orphaned retained review lanes and stale lifecycle
@@ -204,17 +209,19 @@ success path.
   missing, or when an already-current lifecycle record exists but the issue state was
   not advanced, and the validated PR plus retained worktree prove the handoff lineage.
   If stale failure writeback already moved that already-current lifecycle lane back to
-  `tracker.failure_state` and applied `tracker.needs_attention_label`, explicit rebind
-  may clear that label and move the issue to `tracker.success_state` after the rebind
-  audit succeeds. Decodex must reject this failure-state recovery for missing or stale
-  lifecycle records because those still need explicit PR-lineage repair before tracker
-  state can be trusted.
+  `tracker.failure_state`, removed `decodex:active:<service-id>`, or applied
+  `tracker.needs_attention_label`, explicit rebind may restore the active service
+  label, clear needs-attention, and move the issue to `tracker.success_state` after
+  the rebind audit succeeds. Decodex must reject this failure-state recovery for
+  missing or stale lifecycle records because those still need explicit PR-lineage
+  repair before tracker state can be trusted.
 - If no review lifecycle record exists, `rebind` restores the missing lifecycle record
   from the validated PR and retained worktree. If a record already exists for the same
   branch and PR but its stored handoff head or phase head is stale, `rebind` may
   refresh that record to the validated PR head. It must reject an existing record for a
   different PR, and it must reject a current same-branch same-PR record as a no-op
-  unless the issue is still in `tracker.in_progress_state` and only the success-state
+  unless the issue is still in `tracker.in_progress_state` or `tracker.failure_state`
+  and only the active-label repair, needs-attention repair, or success-state
   transition remains.
 - A successful adopt writes a runtime worktree mapping for the current managed checkout,
   creates a local run attempt identity for the takeover, writes the same runtime DB
@@ -232,11 +239,14 @@ success path.
   GitHub credentials and workspace hooks, but pure manual-authority landing must not
   refresh project registry state unless issue closeout is actually in scope.
 - A successful rebind writes the same runtime DB review lifecycle record as normal
-  `issue_review_handoff` needs, and records a `review_handoff_rebind` audit
-  event. It does not land the PR, queue follow-up work, or substitute for healthy lanes'
-  normal `issue_review_handoff` plus `issue_terminal_finalize(path = "review_handoff")`
-  path. If any audit write fails after lifecycle record creation, the command must
-  clear the new record and report failure instead of leaving a silently rebound lane.
+  `issue_review_handoff` needs, records a `review_handoff_rebind` audit event, and
+  records whether active ownership or needs-attention labels were repaired. It does
+  not land the PR, queue follow-up work, or substitute for healthy lanes' normal
+  `issue_review_handoff` plus `issue_terminal_finalize(path = "review_handoff")`
+  path. If either lifecycle marker write fails, the command must clear any partial
+  handoff record before reporting failure. If any audit write fails after lifecycle
+  record creation, the command must clear the new record and roll back any active
+  service label restored by that rebind before reporting failure.
 - Once a rebind or equivalent current lifecycle record exists for a retained lane, stale
   passive failure handling for the earlier `missing_review_handoff_record` observation
   must not move the issue back to the failure state or add `decodex:needs-attention`.

--- a/docs/spec/radar-artifact-retention.md
+++ b/docs/spec/radar-artifact-retention.md
@@ -54,6 +54,11 @@ Raw GitHub bundles, upstream review artifacts, and local editorial analysis draf
 not remain in hot cache for more than 21 days after collection or publication unless a human
 explicitly marks the batch as still active.
 
+Analysis drafts under `.agent/automations/decodex/cache/generated/analysis/*.analysis.json`
+are Codex helper output, not first-class Radar artifacts, so they do not carry a
+`schema` field. `decodex radar validate` still checks them by path against the
+`analysis_draft` contract before they can feed `signal_entry/v1` rendering.
+
 For existing artifacts that do not carry their own collection timestamp, the retention
 clock should use the paired `signal_entry/v1.published_at` when available. If no paired
 signal exists, the archive batch must record the operator-selected evidence date in its

--- a/docs/spec/upstream-review.md
+++ b/docs/spec/upstream-review.md
@@ -153,6 +153,11 @@ Promote an upstream review into:
   investigate the change. The candidate remains evidence-only until Decision Contract
   and Program Intake promotion.
 
+Historical raw `upstream_review/v1` records created before the shared handoff cutover
+may still contain `linear_followup` in `next_actions` so archive validation can read
+old cache state. New upstream review output must use `upstream_impact` or
+`control_plane_upgrade_candidate`; it must not emit `linear_followup`.
+
 Do not promote low-value internal churn into public artifacts. Keep it traceable in the
 ledger and use it only as release-rollup background if later evidence makes it relevant.
 


### PR DESCRIPTION
## Summary

Fixes the Decodex lifecycle/status/recovery drift behind XY-1115, XY-1116, and XY-1093 surfaces:

- Projects terminal Run Ledger outcomes into old/unowned lane inspect runs so cleanup-complete and terminal-failure attempts no longer look live/running.
- Keeps leased/current attempts authoritative so historical terminal ledger records cannot overwrite a live lane.
- Adds a supported review-handoff rebind path for current same-PR same-head failure-state drift, including active-label restoration when validated.
- Rolls back partial review lifecycle marker writes on rebind failure and documents the recovery contract.
- Makes `radar validate` path-aware for existing cache drift while keeping new artifact validation strict.

## Verification

- `cargo test -p decodex --lib` (`1504 passed; 0 failed; 1 ignored`)
- `cargo test -p decodex recovery::tests -- --nocapture` (`58 passed`)
- `cargo run -p decodex --bin decodex -- docs check` (`status: pass`)
- `git diff --check`
- `decodex radar validate .agent/automations/decodex/cache` (`checked_files: 1426`)
- Runtime readback: XY-1094 now projects `cleanup_complete/not_running/no_action`
- Runtime readback: XY-1113 now projects `terminal_failure/retained_attention/not_running`
- Recovery dry-run: XY-1113 rebind validates `would_restore_active_label=true` and `state_transition=In Review`

## Residual Risk

Active-label rollback after an audit/local ledger failure is code-inspected and direct, but not covered by a fake-tracker failure-injection test. The reviewer challenge treated this as non-blocking because the path is narrow and the marker-write rollback path now has direct regression coverage.
