### PR TITLE
Refresh docs plugin drift after latest install

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,10 @@ Linear, dispatch work, or accept `--config`. Decodex App's normal
 fallback server is ordinary `decodex serve --listen-address 127.0.0.1:8192`; the CLI
 owns the default scheduler cadences. App launch connects to an
 existing live default listener instead of starting a duplicate server only when
-`DECODEX_APP_SERVER_URL` is unset. `decodex app` opens the installed Decodex App by
+`DECODEX_APP_SERVER_URL` is unset. Keep exactly one owner for the default listener:
+if Decodex App's bundled helper is listening on `127.0.0.1:8192`, remove any
+standalone launchd job or extra `decodex serve --listen-address 127.0.0.1:8192`
+process that would collide with it. `decodex app` opens the installed Decodex App by
 default and preserves the caller's environment, including any explicit
 `DECODEX_APP_SERVER_URL` override. Use `--bundle <APP_BUNDLE>` and `--new` when
 previewing a staged app. For dashboard and App preview UI work, prefer the single mock

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,12 @@
 
 ## 2026-06-27
 
+- Refreshed docs/plugin drift after the latest local install readback: Codex stable
+  compatibility now points at `0.142.3` and Decodex `0.2.0-26dc90d3`, preview
+  planning now points at `0.143.0-alpha.26`, the docs gate reference names the
+  `decodex docs lint` compatibility alias used by `cargo make check-docs`, and
+  operator docs now forbid duplicate owners for the default `127.0.0.1:8192`
+  Decodex App/helper listener.
 - Made `decodex radar validate` path-aware for existing operations cache drift:
   generated analysis drafts are validated as helper outputs without a `schema` field,
   historical archive manifests may retain their original retention policy, and

--- a/docs/reference/build-test-run.md
+++ b/docs/reference/build-test-run.md
@@ -10,7 +10,7 @@ source_refs: []
 code_refs: [Makefile.toml, Cargo.toml, apps/decodex/Cargo.toml, site/package.json, apps/decodex-app/Package.swift, README.md]
 related: [./workspace-layout.md, ./test-suite.md, ./docs-knowledge-map.md, ../policy.md, ../runbook/release-readiness.md, ../spec/okf-knowledge-layer.md]
 drift_watch: [Makefile.toml, Cargo.toml, site/package.json, apps/decodex-app/Package.swift, cargo make --list-all-steps, cargo make check, cargo nextest list --workspace --all-targets --all-features]
-last_verified: 2026-06-18
+last_verified: 2026-06-27
 ---
 
 # Build Test Run Entrypoints
@@ -55,7 +55,7 @@ explain why a narrower check is sufficient.
 | Task | Command surface | Owns |
 | --- | --- | --- |
 | `cargo make check` | composite root task | Aggregate build, docs, node, Rust, format, lint, and test validation |
-| `cargo make check-docs` | `decodex docs check` | Decodex docs OKF/profile validation |
+| `cargo make check-docs` | `decodex docs lint` compatibility alias for `decodex docs check` | Decodex docs OKF/profile validation |
 | `cargo make check-rust` | `cargo check --all-features --all-targets --workspace` | Rust workspace type checking |
 | `cargo make check-node` | `npm run check` in `site/` | Astro and TypeScript site checks |
 | `cargo make fmt-check` | Rust nightly fmt plus Taplo check | Rust and TOML formatting |

--- a/docs/reference/codex-compatibility-matrix.md
+++ b/docs/reference/codex-compatibility-matrix.md
@@ -38,8 +38,8 @@ validation.
 
 | Decodex build | Codex channel | Codex version/tag | Evidence | Status | Caveat |
 | --- | --- | --- | --- | --- | --- |
-| `0.2.0-afb36056` | stable | `0.142.2`, `rust-v0.142.2` | Local `codex --version` reported `codex-cli 0.142.2`; `npm view @openai/codex version dist-tags --json` reported `latest = 0.142.2`; Decodex CLI and app helper reported `decodex 0.2.0-afb36056-aarch64-apple-darwin`; `decodex probe` returned `PROBE_OK` on 2026-06-27. | compatible | Probe evidence covers the local installed stable CLI/app-server path, not every upstream change since the prior reviewed release. |
-| `0.2.0-afb36056` | preview | `0.143.0-alpha.25`, `rust-v0.143.0-alpha.25` | `npm view @openai/codex dist-tags` reported `alpha = 0.143.0-alpha.25`; `decodex radar refresh-release-delta --dry-run` identified the preview tag and a stable-to-preview compare window. | needs_review | Preview was not installed or probe-tested in this checkout. Radar must review app-server, MCP, plugin, sandbox, auth, browser, and config changes before Decodex treats the preview as compatible. |
+| `0.2.0-26dc90d3` | stable | `0.142.3`, `rust-v0.142.3` | Local `codex --version` and `/opt/homebrew/bin/codex --version` reported `codex-cli 0.142.3`; `npm view @openai/codex version dist-tags --json` reported `latest = 0.142.3`; the GitHub `rust-v0.142.3` release was marked Latest; Decodex CLI and app helper reported `decodex 0.2.0-26dc90d3-aarch64-apple-darwin`; `decodex probe stdio://` returned `PROBE_OK` on 2026-06-27. | compatible | Probe evidence covers the local installed stable CLI/app-server path, not every upstream change since the prior reviewed release. |
+| `0.2.0-26dc90d3` | preview | `0.143.0-alpha.26`, `rust-v0.143.0-alpha.26` | `npm view @openai/codex dist-tags` reported `alpha = 0.143.0-alpha.26` and platform alpha tags ending in `0.143.0-alpha.26`. | needs_review | Preview was not installed or probe-tested in this checkout. Radar must review app-server, MCP, plugin, sandbox, auth, browser, and config changes before Decodex treats the preview as compatible. |
 
 ## Review Triggers
 

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -84,6 +84,11 @@ for future dispatch, uses the CLI-owned default cadences, and serves the dashboa
 account APIs, `GET /api/operator-snapshot`,
 `POST /api/linear-scan`, `GET /api/lane/inspect`, and `POST /api/lane/interrupt` from
 the single local listener.
+The default listener must have exactly one owner. When Decodex App has started its
+bundled helper on `127.0.0.1:8192`, do not also keep a standalone launchd job such as
+`space.decodex.serve` or another `decodex serve --listen-address 127.0.0.1:8192`
+process running; that duplicate owner will repeatedly fail with `Address already in use`
+and should be removed or pointed at a different explicit listen address.
 Use `decodex app` to open the installed macOS app from the CLI; use
 `decodex app --bundle <APP_BUNDLE> --new` for a staged app bundle. The launch preserves
 the caller's environment, so `DECODEX_APP_SERVER_URL` remains an explicit App preview


### PR DESCRIPTION
## Summary
- refresh Codex compatibility matrix to codex-cli 0.142.3 and preview alpha.26
- document single-owner behavior for the Decodex App/helper default listener
- align docs gate reference with the check-docs compatibility alias

## Validation
- decodex probe stdio://
- decodex docs check
- cargo make check-docs
- cargo test -p decodex plugin_surface_tests -- --nocapture
- git diff --check