### PR TITLE
Accept legacy autonomy support agent source

### DIFF
--- a/apps/decodex/src/autonomy_proposal.rs
+++ b/apps/decodex/src/autonomy_proposal.rs
@@ -70,6 +70,7 @@ impl AutonomyProposalRefusalReason {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum AutonomyProposalChallengeSource {
+	#[serde(alias = "support_agent")]
 	Subagent,
 	InlineSkeptic,
 }
@@ -1859,17 +1860,22 @@ mod tests {
 	}
 
 	#[test]
-	fn autonomy_proposal_challenge_source_rejects_legacy_support_agent_alias() {
+	fn autonomy_proposal_challenge_source_accepts_legacy_support_agent_alias() {
 		let source: AutonomyProposalChallengeSource =
 			serde_json::from_value(serde_json::json!("subagent"))
 				.expect("canonical subagent source should parse");
+		let legacy_source: AutonomyProposalChallengeSource =
+			serde_json::from_value(serde_json::json!("support_agent"))
+				.expect("legacy support_agent source should parse");
 
 		assert_eq!(source, AutonomyProposalChallengeSource::Subagent);
 		assert!(
-			serde_json::from_value::<AutonomyProposalChallengeSource>(serde_json::json!(
-				"support_agent"
-			))
-			.is_err()
+			legacy_source == AutonomyProposalChallengeSource::Subagent,
+			"legacy support_agent should canonicalize to Subagent"
+		);
+		assert_eq!(
+			serde_json::to_value(legacy_source).expect("source should serialize"),
+			serde_json::json!("subagent")
 		);
 	}
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -37,6 +37,9 @@
   in-progress state, the same recovery command may restore the issue to the first
   configured startable state only when the same run/attempt release audit and local
   cleanup evidence are present.
+- Restored backward-compatible reads for autonomy proposal challenge records written
+  with legacy `support_agent` source values; new serialization remains canonical
+  `subagent`.
 
 ## 2026-06-27
 

--- a/plugins/codebase/references/codebase.md
+++ b/plugins/codebase/references/codebase.md
@@ -6,15 +6,17 @@ Read when `$codebase:work` needs exact command, structure, validation, or eviden
 
 - Inspect checked-in authority first: nearest `AGENTS.md`, README/docs, task runner,
   manifests, OKF/LLM Wiki, or repo-memory owner.
-- Prefer repo-native `fmt`, `fmt-check`, `check`, `lint`, `test`, `build`, `smoke`,
-  and codegen tasks over raw tool defaults.
+- Do not duplicate this routing in host bootstrap files; route to the owning plugin
+  surface instead.
+- Prefer repo-native commands: `fmt`, `fmt-check`, `check`, `lint`, `test`, `build`,
+  `smoke`, and codegen tasks over raw tool defaults.
 - Use English for durable or executable artifacts unless the user requests another
   language, source text is being preserved, or the file is a locale/i18n fixture.
 - After behavior, command, config, status/help, public contract, architecture, or
   plugin/skill changes, classify docs drift or writeback before ready.
 - Before substantial implementation, inspect existing package/module ownership. Do not leave generated monoliths or files mixing unrelated parsing, state, I/O, rendering, persistence, CLI wiring, or tests.
 
-## Task Runners
+## Task Runner Structure
 
 - Treat `Makefile.toml` and equivalents as public command APIs.
 - Group by action family, not domain/toolchain: `Check`, `Build`, `Format`, `Lint`,
@@ -32,6 +34,8 @@ Read when `$codebase:work` needs exact command, structure, validation, or eviden
   Put real logic in `scripts/` or the owning package.
 - After task renames/removals, reverse-scan docs, CI, scripts, tests, fixtures,
   reports, help/status text, and examples for stale commands.
+- Task-runner review checklist: authority source, public command names, action-family
+  grouping, docs/help references, CI callers, and generated artifacts.
 
 ## Validation And Claims
 
@@ -62,13 +66,13 @@ Read when `$codebase:work` needs exact command, structure, validation, or eviden
 ## Plugin Changes
 
 - Treat Codex skill/plugin edits as executable workflow changes.
-- When plugin-eval is available, run `plugin-eval analyze <plugin-root> --format
-  markdown` before ready claims; report the score, highest-priority finding, and
+- Run `plugin-eval analyze <plugin-root> --format markdown` before ready claims when
+  plugin-eval is available; report the score, highest-priority finding, and
   static-vs-measured limitation.
 
 ## Evidence To Report
 
-- Checked-in command authority and whether a task runner existed.
+- Checked-in command authority used and whether a task runner existed.
 - Task-runner naming/structure evidence when task config changed.
 - Validation scope and why it matches the touched files and risk.
 - Drift/debugging/verification owner used when relevant.

--- a/plugins/codebase/references/dependency-policy.md
+++ b/plugins/codebase/references/dependency-policy.md
@@ -27,6 +27,8 @@ generated dependency artifacts, or GitHub Actions action pins affect repository 
 
 - `.github/workflows/*.yml` and `.github/workflows/*.yaml` external `uses:` refs are
   dependencies. Local actions/workflows are repo code.
+- External `uses: owner/action@ref` entries must resolve through the same dependency
+  policy as manifest dependencies.
 - For roll mode, choose the latest verified compatible release/tag first, then pin
   the full commit SHA it resolves to. For annotated tags, pin the peeled commit SHA.
 - For style mode, convert the existing selected ref to the full commit SHA without

--- a/plugins/deliberation/.codex-plugin/plugin.json
+++ b/plugins/deliberation/.codex-plugin/plugin.json
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Deliberation",
     "shortDescription": "Run scout, grill, and skeptic passes.",
-    "longDescription": "Provides compact scout, grill, and skeptic methods for evidence, framing, critique, and ready or decision-ready claims.",
+    "longDescription": "Provides compact scout, grill, and skeptic methods for read-only evidence scouting, decision grilling, evidence sufficiency, framing, critique, and ready or decision-ready claims.",
     "developerName": "hack-ink",
     "category": "Development",
     "capabilities": [


### PR DESCRIPTION
## Summary
- accept legacy `support_agent` autonomy proposal challenge source values as the canonical `subagent` source when reading persisted state
- keep new serialization canonical as `subagent`
- restore packaged plugin surface text required by the codebase/deliberation plugin surface tests

## Why
After PR #522 was installed from latest main, PubFi runtime state readback failed on historical autonomy proposal records containing `support_agent`. The recovery path itself was valid, but the installed binary could not open the runtime store. This keeps durable state backward-compatible without editing runtime SQLite.

## Validation
- `cargo test -p decodex autonomy_proposal --lib`
- `cargo test -p decodex packaged_codebase_skills_preserve_command_and_verification_authority --lib`
- `cargo test -p decodex packaged_plugin_manifests_route_split_surface_owners --lib`
- `cargo make test-rust` (1548 passed, 1 skipped)
- `cargo make lint-rust`
- `cargo make check-docs`
- `git diff --check`
- `python3 scripts/semantic-drift/semantic_drift_audit.py --json` with agent verdict pass
- real PubFi branch binary: `recover stale-active diagnose PUB-1626 --json` classified `stale_active_state_restore_pending` with `blockers=[]`
- real PubFi branch binary: `recover stale-active release PUB-1626 --dry-run` validated classification `stale_active_state_restore_pending`
