### PR TITLE
Prefer post-review ownership over orphan thread residue

### DIFF
--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -1904,7 +1904,15 @@ fn worktree_ownership(
 	snapshot: &OperatorStatusSnapshot,
 	completed_state: Option<&str>,
 ) -> WorktreeOwnership {
+	let post_review_owner = worktree_post_review_owner(worktree, snapshot);
+
 	if let Some(run) = worktree_current_lane_owner(worktree, snapshot) {
+		if run.ownership_state == "orphaned_live_thread"
+			&& let Some(lane) = post_review_owner
+		{
+			return post_review_worktree_ownership(lane);
+		}
+
 		return match run.ownership_state.as_str() {
 			"leased_run" => WorktreeOwnership {
 				kind: "current_lane",
@@ -1956,13 +1964,8 @@ fn worktree_ownership(
 			},
 		};
 	}
-	if let Some(lane) = worktree_post_review_owner(worktree, snapshot) {
-		return WorktreeOwnership {
-			kind: "post_review_lane",
-			reason: format!("Review & Landing owns this worktree as `{}`.", lane.classification),
-			next_action: None,
-			audit_required: false,
-		};
+	if let Some(lane) = post_review_owner {
+		return post_review_worktree_ownership(lane);
 	}
 	if let Some(lane) = worktree_history_attention_owner(worktree, snapshot) {
 		return WorktreeOwnership {
@@ -2011,6 +2014,15 @@ fn worktree_ownership(
 		reason: worktree_cleanup_only_reason(worktree, completed_state),
 		next_action: audit_required.then(|| legacy_cleanup_next_action(worktree)),
 		audit_required,
+	}
+}
+
+fn post_review_worktree_ownership(lane: &OperatorPostReviewLaneStatus) -> WorktreeOwnership {
+	WorktreeOwnership {
+		kind: "post_review_lane",
+		reason: format!("Review & Landing owns this worktree as `{}`.", lane.classification),
+		next_action: None,
+		audit_required: false,
 	}
 }
 

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -3906,6 +3906,78 @@ fn operator_status_snapshot_does_not_shadow_post_review_lane_with_retained_atten
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
+fn operator_status_snapshot_post_review_lane_owns_orphaned_live_thread_worktree() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue("In Review", &[]);
+	let worktree_path = config.worktree_root().join("PUB-101");
+
+	state_store
+		.record_run_attempt("run-1", &issue.id, 1, "succeeded")
+		.expect("run attempt should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+	state::write_run_activity_marker_for_process(&worktree_path, "run-1", 1, process::id())
+		.expect("live process marker should write");
+
+	let mut snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+		.expect("snapshot should build");
+
+	snapshot.post_review_lanes = vec![orchestrator::OperatorPostReviewLaneStatus {
+		project_id: String::from("pubfi"),
+		issue_id: issue.id.clone(),
+		issue_identifier: issue.identifier.clone(),
+		issue_state: String::from("In Review"),
+		branch_name: String::from("x/pubfi-pub-101"),
+		worktree_path: String::from(".worktrees/PUB-101"),
+		classification: String::from("wait_for_review"),
+		reason: String::from("non_github_review_waiting_gates"),
+		pr_url: Some(String::from("https://github.com/hack-ink/pubfi-mono-v2/pull/101")),
+		pr_head_sha: Some(String::from("1111111111111111111111111111111111111111")),
+		pr_state: Some(String::from("OPEN")),
+		review_decision: None,
+		mergeable: Some(String::from("MERGEABLE")),
+		check_state: Some(String::from("PENDING")),
+		unresolved_review_threads: Some(0),
+		shadowed_by_current_lane: false,
+		readback_warning: None,
+		readback_root_cause: None,
+		loop_status: None,
+	}];
+
+	orchestrator::hydrate_post_review_lane_current_lane_shadowing(&mut snapshot);
+	orchestrator::refresh_worktree_ownership(&mut snapshot, None);
+	orchestrator::refresh_operator_project_summary(&mut snapshot, None);
+
+	let project = snapshot.projects.first().expect("project summary should exist");
+	let rendered = orchestrator::render_operator_status(&snapshot);
+
+	assert!(snapshot.current_lanes.is_empty());
+	assert_eq!(snapshot.recent_runs[0].ownership_state, "orphaned_live_thread");
+	assert_eq!(snapshot.worktrees[0].ownership, "post_review_lane");
+	assert_eq!(
+		snapshot.worktrees[0].ownership_reason,
+		"Review & Landing owns this worktree as `wait_for_review`."
+	);
+	assert_eq!(snapshot.worktrees[0].recovery_next_action, None);
+	assert!(!snapshot.worktrees[0].provenance.audit_required);
+	assert_eq!(project.post_review_lane_count, 1);
+	assert_eq!(project.retained_worktree_count, 1);
+	assert!(rendered.contains("role: post_review_lane"));
+	assert!(rendered.contains("recovery_next_action: none"));
+	assert!(!rendered.contains("role: orphaned_live_thread"));
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
 fn operator_status_snapshot_counts_reused_pid_as_attention_not_running() {
 	let (_temp_dir, config, _workflow) = temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");


### PR DESCRIPTION
## Summary

- Let post-review worktree ownership supersede only stale `orphaned_live_thread` run residue.
- Preserve current-lane priority for `leased_run`, `retained_attention`, `terminalizing`, and `continuation_pending` ownership states.
- Add a regression test matching the PUB-1626 shape: a terminal run with live marker residue plus an active Review & Landing lane.

## Root Cause

`worktree_ownership` checked current/recent run ownership before post-review ownership. A terminal review-handoff run with live evidence but no active lease could therefore project its worktree as `orphaned_live_thread`, even after Review & Landing had become the real owner.

## Live Readback

Running this branch against the real PubFi project now projects PUB-1626's worktree as `role: post_review_lane`, `audit_required: false`, and `recovery_next_action: none`. The post-review lane is visible as `classification: ready_to_land` with `check_state: SUCCESS`.

## Validation

- `cargo test -p decodex operator_status_snapshot_post_review_lane_owns_orphaned_live_thread_worktree --lib`
- `cargo test -p decodex unleased_live_process --lib`
- `cargo test -p decodex recent_orphan_bucket --lib`
- `cargo test -p decodex retained_attention_run --lib`
- `cargo test -p decodex post_review_lane --lib`
- `cargo test -p decodex status --lib`
- `cargo make lint-rust`
- `cargo make test-rust` (1549 passed, 1 skipped)
- `git diff --check`
- `cargo run -p decodex --bin decodex -- status --config /Users/x/.codex/decodex/projects/pubfi --live --limit 3`
