### PR TITLE
Split Codex account selection

### DIFF
--- a/apps/decodex/src/agent/codex_accounts.rs
+++ b/apps/decodex/src/agent/codex_accounts.rs
@@ -1,6 +1,5 @@
 #[cfg(unix)] use std::os::unix::fs::PermissionsExt as _;
 use std::{
-	cmp::Ordering,
 	env,
 	error::Error,
 	fmt::{self, Display, Formatter},
@@ -25,6 +24,10 @@ use crate::{
 	runtime,
 	state::{CodexAccountActivitySummary, CodexAccountProfileDailyUsageSummary},
 };
+
+mod selection;
+
+use self::selection::{account_summaries, account_summary_is_limited, compare_account_candidates};
 
 const DEFAULT_USAGE_ENDPOINT: &str = "https://chatgpt.com/backend-api/wham/usage";
 const DEFAULT_PROFILE_ENDPOINT: &str = "https://chatgpt.com/backend-api/wham/profiles/me";
@@ -1520,15 +1523,6 @@ impl Display for UsageProbeError {
 
 impl Error for UsageProbeError {}
 
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-struct AccountCandidateScore {
-	not_limited: bool,
-	bottleneck_remaining_percent: i64,
-	combined_remaining_score: i64,
-	primary_remaining_percent: i64,
-	secondary_remaining_percent: i64,
-}
-
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 enum AccountPoolLine {
@@ -1999,54 +1993,8 @@ const fn base64_url_value(byte: u8) -> Option<u8> {
 	}
 }
 
-fn compare_account_candidates(left: &CodexAccountLogin, right: &CodexAccountLogin) -> Ordering {
-	account_candidate_score(right)
-		.cmp(&account_candidate_score(left))
-		.then_with(|| {
-			left.last_selected_at_unix_epoch
-				.unwrap_or(0)
-				.cmp(&right.last_selected_at_unix_epoch.unwrap_or(0))
-		})
-		.then_with(|| left.summary.account_fingerprint.cmp(&right.summary.account_fingerprint))
-}
-
-fn account_candidate_score(candidate: &CodexAccountLogin) -> AccountCandidateScore {
-	let summary = candidate.summary();
-	let primary = summary
-		.primary_remaining_percent
-		.unwrap_or_else(|| summary.secondary_remaining_percent.unwrap_or(0));
-	let secondary = summary.secondary_remaining_percent.unwrap_or(primary);
-
-	AccountCandidateScore {
-		not_limited: !account_summary_is_limited(summary),
-		bottleneck_remaining_percent: primary.min(secondary),
-		combined_remaining_score: primary.saturating_mul(secondary),
-		primary_remaining_percent: primary,
-		secondary_remaining_percent: secondary,
-	}
-}
-
-fn account_summary_is_limited(summary: &CodexAccountActivitySummary) -> bool {
-	summary.rate_limit_reached_type.is_some()
-		|| summary.status.to_lowercase().contains("limit")
-		|| summary.primary_remaining_percent == Some(0)
-		|| summary.secondary_remaining_percent == Some(0)
-}
-
 fn token_refresh_auth_status(status: StatusCode) -> bool {
 	matches!(status, StatusCode::BAD_REQUEST | StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN)
-}
-
-fn account_summaries(
-	selected: &CodexAccountLogin,
-	candidates: &[CodexAccountLogin],
-) -> Vec<CodexAccountActivitySummary> {
-	let mut summaries = Vec::with_capacity(candidates.len() + 1);
-
-	summaries.push(selected.summary().clone());
-	summaries.extend(candidates.iter().map(|candidate| candidate.summary().clone()));
-
-	summaries
 }
 
 fn redact_account_id(account_id: &str) -> String {

--- a/apps/decodex/src/agent/codex_accounts/selection.rs
+++ b/apps/decodex/src/agent/codex_accounts/selection.rs
@@ -1,0 +1,63 @@
+use std::cmp::Ordering;
+
+use crate::state::CodexAccountActivitySummary;
+
+use super::CodexAccountLogin;
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct AccountCandidateScore {
+	not_limited: bool,
+	bottleneck_remaining_percent: i64,
+	combined_remaining_score: i64,
+	primary_remaining_percent: i64,
+	secondary_remaining_percent: i64,
+}
+
+pub(super) fn compare_account_candidates(
+	left: &CodexAccountLogin,
+	right: &CodexAccountLogin,
+) -> Ordering {
+	account_candidate_score(right)
+		.cmp(&account_candidate_score(left))
+		.then_with(|| {
+			left.last_selected_at_unix_epoch
+				.unwrap_or(0)
+				.cmp(&right.last_selected_at_unix_epoch.unwrap_or(0))
+		})
+		.then_with(|| left.summary.account_fingerprint.cmp(&right.summary.account_fingerprint))
+}
+
+fn account_candidate_score(candidate: &CodexAccountLogin) -> AccountCandidateScore {
+	let summary = candidate.summary();
+	let primary = summary
+		.primary_remaining_percent
+		.unwrap_or_else(|| summary.secondary_remaining_percent.unwrap_or(0));
+	let secondary = summary.secondary_remaining_percent.unwrap_or(primary);
+
+	AccountCandidateScore {
+		not_limited: !account_summary_is_limited(summary),
+		bottleneck_remaining_percent: primary.min(secondary),
+		combined_remaining_score: primary.saturating_mul(secondary),
+		primary_remaining_percent: primary,
+		secondary_remaining_percent: secondary,
+	}
+}
+
+pub(super) fn account_summary_is_limited(summary: &CodexAccountActivitySummary) -> bool {
+	summary.rate_limit_reached_type.is_some()
+		|| summary.status.to_lowercase().contains("limit")
+		|| summary.primary_remaining_percent == Some(0)
+		|| summary.secondary_remaining_percent == Some(0)
+}
+
+pub(super) fn account_summaries(
+	selected: &CodexAccountLogin,
+	candidates: &[CodexAccountLogin],
+) -> Vec<CodexAccountActivitySummary> {
+	let mut summaries = Vec::with_capacity(candidates.len() + 1);
+
+	summaries.push(selected.summary().clone());
+	summaries.extend(candidates.iter().map(|candidate| candidate.summary().clone()));
+
+	summaries
+}


### PR DESCRIPTION
## Summary
- split Codex account candidate selection/scoring helpers into agent/codex_accounts/selection.rs
- keep account file IO, probing, refresh, and persistence orchestration in codex_accounts.rs
- preserve existing selection policy and module-private visibility

## Verification
- git diff --check
- rustup run nightly rustfmt --check apps/decodex/src/agent/codex_accounts.rs apps/decodex/src/agent/codex_accounts/selection.rs
- cargo test -p decodex codex_accounts --lib
- cargo make lint-rust
- cargo make test-rust
- cargo make fmt-rust-check (fails only on existing unrelated apps/decodex/src/radar.rs and apps/decodex/src/recovery.rs formatting drift)