### PR TITLE
XY-1115 Split MCP prompt modules

### DIFF
--- a/apps/decodex/src/mcp/prompts.rs
+++ b/apps/decodex/src/mcp/prompts.rs
@@ -1,7 +1,14 @@
+mod arguments;
+mod catalog;
+mod render;
+
 use serde::Deserialize;
 use serde_json::{self, Value};
 
-use super::{McpError, McpServer};
+use crate::{
+	mcp::{McpError, McpServer},
+	prelude::Result,
+};
 
 #[derive(Deserialize)]
 struct GetPromptParams {
@@ -11,145 +18,19 @@ struct GetPromptParams {
 
 impl McpServer {
 	pub(super) fn list_prompts(&self) -> Value {
-		serde_json::json!({ "prompts": mcp_prompts() })
+		serde_json::json!({ "prompts": catalog::mcp_prompts() })
 	}
 
-	pub(super) fn get_prompt(
-		&self,
-		params: Option<Value>,
-	) -> crate::prelude::Result<Value, McpError> {
+	pub(super) fn get_prompt(&self, params: Option<Value>) -> Result<Value, McpError> {
 		let params = params.ok_or_else(McpError::invalid_params)?;
 		let params = serde_json::from_value::<GetPromptParams>(params)
 			.map_err(|_| McpError::invalid_params())?;
 		let arguments = params.arguments.unwrap_or_default();
 
-		if !prompt_required_arguments_are_present(&params.name, &arguments) {
+		if !arguments::prompt_required_arguments_are_present(&params.name, &arguments) {
 			return Err(McpError::invalid_params());
 		}
 
-		mcp_prompt_result(&params.name, arguments).ok_or_else(McpError::invalid_params)
+		render::mcp_prompt_result(&params.name, arguments).ok_or_else(McpError::invalid_params)
 	}
-}
-
-fn mcp_prompts() -> Vec<Value> {
-	vec![
-		serde_json::json!({
-			"name": "decodex_research",
-			"title": "Decodex Research",
-			"description": "Frame bounded Decodex research as a latent Decision Contract candidate.",
-			"arguments": [
-				{
-					"name": "intent",
-					"description": "Natural-language research question or design uncertainty.",
-					"required": true
-				}
-			]
-		}),
-		serde_json::json!({
-			"name": "decodex_validation_ready",
-			"title": "Decodex Validation Ready",
-			"description": "Drive an implementation or repair lane to local validation-ready evidence.",
-			"arguments": [
-				{
-					"name": "issue",
-					"description": "Linear issue identifier for the lane.",
-					"required": true
-				},
-				{
-					"name": "phase",
-					"description": "Current Decodex phase goal.",
-					"required": false
-				}
-			]
-		}),
-		serde_json::json!({
-			"name": "decodex_handoff",
-			"title": "Decodex Handoff",
-			"description": "Prepare a verified review handoff only after local validation and bounded review.",
-			"arguments": [
-				{
-					"name": "issue",
-					"description": "Linear issue identifier for the lane.",
-					"required": true
-				}
-			]
-		}),
-		serde_json::json!({
-			"name": "decodex_lane_control",
-			"title": "Decodex Lane Control",
-			"description": "Inspect first, then request guarded lane-control actions through existing Decodex authority gates.",
-			"arguments": [
-				{
-					"name": "issue",
-					"description": "Linear issue identifier or local tracker issue id.",
-					"required": true
-				},
-				{
-					"name": "runId",
-					"description": "Current run id observed through lane inspect.",
-					"required": false
-				}
-			]
-		}),
-	]
-}
-
-fn mcp_prompt_result(name: &str, arguments: Value) -> Option<Value> {
-	let text = match name {
-		"decodex_research" => format!(
-			"Use Decodex research routing for this intent, keep the result latent until explicitly promoted, and preserve evidence, options, judgment, challenge, decision, validation expectations, and stop conditions.\n\nIntent: {}",
-			prompt_argument(&arguments, "intent")?
-		),
-		"decodex_validation_ready" => format!(
-			"Work only to Decodex validation-ready state for issue {}. Implement the smallest coherent code and docs change, run targeted validation, record a current-HEAD docs-impact checkpoint, then complete the active phase goal without push or PR handoff.\n\nPhase: {}",
-			prompt_argument(&arguments, "issue")?,
-			prompt_argument(&arguments, "phase").unwrap_or("implement_to_validation_ready")
-		),
-		"decodex_handoff" => format!(
-			"Before handoff for issue {}, re-read the current diff and HEAD, run the repo-native bounded review method, require a clean current-head review checkpoint, then use the normal PR-backed Decodex handoff path.",
-			prompt_argument(&arguments, "issue")?
-		),
-		"decodex_lane_control" => format!(
-			"Inspect issue {} first. Mutating lane-control tool calls must include the observed run id, current turn preconditions when steering, and explicit authority fields; refuse instead of guessing missing authority.",
-			prompt_argument(&arguments, "issue")?
-		),
-		_ => return None,
-	};
-
-	Some(serde_json::json!({
-		"description": prompt_description(name),
-		"messages": [
-			{
-				"role": "user",
-				"content": {
-					"type": "text",
-					"text": text
-				}
-			}
-		]
-	}))
-}
-
-fn prompt_description(name: &str) -> &'static str {
-	match name {
-		"decodex_research" => "Contract-first bounded Decodex research prompt.",
-		"decodex_validation_ready" => "Decodex implementation-phase validation-ready prompt.",
-		"decodex_handoff" => "Decodex verified review-handoff prompt.",
-		"decodex_lane_control" => "Decodex inspect-first lane-control prompt.",
-		_ => "Decodex prompt.",
-	}
-}
-
-fn prompt_argument<'a>(arguments: &'a Value, key: &str) -> Option<&'a str> {
-	arguments.get(key).and_then(Value::as_str).map(str::trim).filter(|value| !value.is_empty())
-}
-
-fn prompt_required_arguments_are_present(name: &str, arguments: &Value) -> bool {
-	let required: &[&str] = match name {
-		"decodex_research" => &["intent"],
-		"decodex_validation_ready" | "decodex_handoff" | "decodex_lane_control" => &["issue"],
-		_ => return true,
-	};
-
-	required.iter().all(|key| prompt_argument(arguments, key).is_some())
 }

--- a/apps/decodex/src/mcp/prompts/arguments.rs
+++ b/apps/decodex/src/mcp/prompts/arguments.rs
@@ -1,0 +1,15 @@
+use serde_json::Value;
+
+pub(super) fn prompt_argument<'a>(arguments: &'a Value, key: &str) -> Option<&'a str> {
+	arguments.get(key).and_then(Value::as_str).map(str::trim).filter(|value| !value.is_empty())
+}
+
+pub(super) fn prompt_required_arguments_are_present(name: &str, arguments: &Value) -> bool {
+	let required: &[&str] = match name {
+		"decodex_research" => &["intent"],
+		"decodex_validation_ready" | "decodex_handoff" | "decodex_lane_control" => &["issue"],
+		_ => return true,
+	};
+
+	required.iter().all(|key| prompt_argument(arguments, key).is_some())
+}

--- a/apps/decodex/src/mcp/prompts/catalog.rs
+++ b/apps/decodex/src/mcp/prompts/catalog.rs
@@ -1,0 +1,64 @@
+use serde_json::Value;
+
+pub(super) fn mcp_prompts() -> Vec<Value> {
+	vec![
+		serde_json::json!({
+			"name": "decodex_research",
+			"title": "Decodex Research",
+			"description": "Frame bounded Decodex research as a latent Decision Contract candidate.",
+			"arguments": [
+				{
+					"name": "intent",
+					"description": "Natural-language research question or design uncertainty.",
+					"required": true
+				}
+			]
+		}),
+		serde_json::json!({
+			"name": "decodex_validation_ready",
+			"title": "Decodex Validation Ready",
+			"description": "Drive an implementation or repair lane to local validation-ready evidence.",
+			"arguments": [
+				{
+					"name": "issue",
+					"description": "Linear issue identifier for the lane.",
+					"required": true
+				},
+				{
+					"name": "phase",
+					"description": "Current Decodex phase goal.",
+					"required": false
+				}
+			]
+		}),
+		serde_json::json!({
+			"name": "decodex_handoff",
+			"title": "Decodex Handoff",
+			"description": "Prepare a verified review handoff only after local validation and bounded review.",
+			"arguments": [
+				{
+					"name": "issue",
+					"description": "Linear issue identifier for the lane.",
+					"required": true
+				}
+			]
+		}),
+		serde_json::json!({
+			"name": "decodex_lane_control",
+			"title": "Decodex Lane Control",
+			"description": "Inspect first, then request guarded lane-control actions through existing Decodex authority gates.",
+			"arguments": [
+				{
+					"name": "issue",
+					"description": "Linear issue identifier or local tracker issue id.",
+					"required": true
+				},
+				{
+					"name": "runId",
+					"description": "Current run id observed through lane inspect.",
+					"required": false
+				}
+			]
+		}),
+	]
+}

--- a/apps/decodex/src/mcp/prompts/render.rs
+++ b/apps/decodex/src/mcp/prompts/render.rs
@@ -1,0 +1,50 @@
+use serde_json::Value;
+
+use crate::mcp::prompts::arguments;
+
+pub(super) fn mcp_prompt_result(name: &str, arguments: Value) -> Option<Value> {
+	let text = match name {
+		"decodex_research" => format!(
+			"Use Decodex research routing for this intent, keep the result latent until explicitly promoted, and preserve evidence, options, judgment, challenge, decision, validation expectations, and stop conditions.\n\nIntent: {}",
+			arguments::prompt_argument(&arguments, "intent")?
+		),
+		"decodex_validation_ready" => format!(
+			"Work only to Decodex validation-ready state for issue {}. Implement the smallest coherent code and docs change, run targeted validation, record a current-HEAD docs-impact checkpoint, then complete the active phase goal without push or PR handoff.\n\nPhase: {}",
+			arguments::prompt_argument(&arguments, "issue")?,
+			arguments::prompt_argument(&arguments, "phase")
+				.unwrap_or("implement_to_validation_ready")
+		),
+		"decodex_handoff" => format!(
+			"Before handoff for issue {}, re-read the current diff and HEAD, run the repo-native bounded review method, require a clean current-head review checkpoint, then use the normal PR-backed Decodex handoff path.",
+			arguments::prompt_argument(&arguments, "issue")?
+		),
+		"decodex_lane_control" => format!(
+			"Inspect issue {} first. Mutating lane-control tool calls must include the observed run id, current turn preconditions when steering, and explicit authority fields; refuse instead of guessing missing authority.",
+			arguments::prompt_argument(&arguments, "issue")?
+		),
+		_ => return None,
+	};
+
+	Some(serde_json::json!({
+		"description": prompt_description(name),
+		"messages": [
+			{
+				"role": "user",
+				"content": {
+					"type": "text",
+					"text": text
+				}
+			}
+		]
+	}))
+}
+
+fn prompt_description(name: &str) -> &'static str {
+	match name {
+		"decodex_research" => "Contract-first bounded Decodex research prompt.",
+		"decodex_validation_ready" => "Decodex implementation-phase validation-ready prompt.",
+		"decodex_handoff" => "Decodex verified review-handoff prompt.",
+		"decodex_lane_control" => "Decodex inspect-first lane-control prompt.",
+		_ => "Decodex prompt.",
+	}
+}


### PR DESCRIPTION
## Summary
- Keep `mcp/prompts.rs` as the MCP prompt gateway.
- Move prompt catalog metadata, prompt rendering, and argument validation into focused `mcp/prompts/*.rs` modules.
- Preserve existing prompt names, required-argument behavior, descriptions, and rendered message text.

## Validation
- Targeted rustfmt on `mcp/prompts.rs` and new `mcp/prompts/*.rs` modules
- `git diff --check` / `git diff --cached --check` on touched prompt files
- `cargo vstyle curate --language rust --workspace --all-features` scoped to touched prompt files
- `cargo test -p decodex prompts --lib` (16 passed)
- `cargo test -p decodex mcp --lib` (77 passed)
- `cargo make check-rust`
- `cargo make lint-rust`

## Known Baseline
- `cargo make fmt-rust-check` still exits 105 on pre-existing formatting drift in `apps/decodex/src/radar.rs` and `apps/decodex/src/recovery.rs`; touched prompt files pass targeted rustfmt.
- `cargo make test-rust` is currently blocked by three closeout/recovery tests that also fail exact on current `main` with `missing_review_handoff_record`: `daemon_planned_closeout_allocates_retry_after_recorded_closeout_failure`, `daemon_planned_closeout_reuses_handoff_identity_after_parent_failed_status`, and `direct_closeout_dispatch_reuses_completed_handoff_run_identity_for_record_and_summary`.