### PR TITLE
XY-1115 Preserve retained closeout worktree identity

### DIFF
--- a/apps/decodex/src/orchestrator/daemon.rs
+++ b/apps/decodex/src/orchestrator/daemon.rs
@@ -755,6 +755,23 @@ fn materialize_run_summary_worktree(
 	workflow: &WorkflowDocument,
 	summary: &RunSummary,
 ) -> Result<WorktreeSpec> {
+	if summary.dispatch_mode == IssueDispatchMode::Closeout {
+		if !summary.worktree_path.try_exists()? {
+			eyre::bail!(
+				"planned retained closeout worktree `{}` is missing for issue `{}`",
+				summary.worktree_path.display(),
+				summary.issue_identifier
+			);
+		}
+
+		return Ok(WorktreeSpec {
+			branch_name: summary.branch_name.clone(),
+			issue_identifier: summary.issue_identifier.clone(),
+			path: summary.worktree_path.clone(),
+			reused_existing: true,
+		});
+	}
+
 	let worktree_manager =
 		WorktreeManager::new(project.service_id(), project.repo_root(), project.worktree_root());
 	let worktree = worktree_manager.ensure_worktree_with_hooks(

--- a/apps/decodex/src/orchestrator/dispatch_policy.rs
+++ b/apps/decodex/src/orchestrator/dispatch_policy.rs
@@ -326,13 +326,35 @@ where
 		return Ok(CloseoutDispatchEligibility::Ineligible);
 	}
 
-	let worktree_manager =
-		WorktreeManager::new(project.service_id(), project.repo_root(), project.worktree_root());
-	let worktree = worktree_manager.plan_for_issue(&issue.identifier);
+	let worktree = match state_store.worktree_for_issue(&issue.id)? {
+		Some(mapping) => {
+			if mapping.project_id() != project.service_id()
+				|| !mapping.worktree_path().try_exists()?
+			{
+				return Ok(CloseoutDispatchEligibility::Ineligible);
+			}
 
-	if !worktree.path.exists() {
-		return Ok(CloseoutDispatchEligibility::Ineligible);
-	}
+			WorktreeSpec {
+				branch_name: mapping.branch_name().to_owned(),
+				issue_identifier: issue.identifier.clone(),
+				path: mapping.worktree_path().to_path_buf(),
+				reused_existing: true,
+			}
+		},
+		None => {
+			let worktree_manager = WorktreeManager::new(
+				project.service_id(),
+				project.repo_root(),
+				project.worktree_root(),
+			);
+			let planned_worktree = worktree_manager.plan_for_issue(&issue.identifier);
+			if !planned_worktree.path.try_exists()? {
+				return Ok(CloseoutDispatchEligibility::Ineligible);
+			}
+
+			planned_worktree
+		},
+	};
 
 	let Some(review_handoff) =
 		state_store.review_handoff_marker(project.service_id(), &issue.id, &worktree.branch_name)?

--- a/apps/decodex/src/orchestrator/run_cycle.rs
+++ b/apps/decodex/src/orchestrator/run_cycle.rs
@@ -2550,7 +2550,10 @@ fn prepare_issue_run<T>(
 where
 	T: IssueTracker,
 {
-	let planned_worktree = context.worktree_manager.plan_for_issue(&issue.identifier);
+	let retained_closeout_worktree = retained_closeout_prepare_worktree(&context, &issue)?;
+	let planned_worktree = retained_closeout_worktree
+		.clone()
+		.unwrap_or_else(|| context.worktree_manager.plan_for_issue(&issue.identifier));
 	let Some((attempt_number, run_id)) =
 		resolve_prepare_run_identity(context.state_store, &issue, context.preferred_run_identity)?
 	else {
@@ -2585,12 +2588,15 @@ where
 	}
 
 	match (|| -> Result<Option<IssueRunPlan>> {
-		let worktree =
+		let worktree = if let Some(worktree) = retained_closeout_worktree.clone() {
+			worktree
+		} else {
 			context.worktree_manager.ensure_worktree_with_hooks(
 				&issue.identifier,
 				context.dry_run,
 				context.workflow.frontmatter().execution().workspace_hooks(),
-			)?;
+			)?
+		};
 
 		if !context.dry_run {
 			context.state_store.upsert_worktree(
@@ -2667,6 +2673,34 @@ where
 			Err(error)
 		},
 	}
+}
+
+fn retained_closeout_prepare_worktree<T>(
+	context: &PrepareIssueRunContext<'_, T>,
+	issue: &TrackerIssue,
+) -> Result<Option<WorktreeSpec>>
+where
+	T: IssueTracker,
+{
+	if context.dispatch_mode != IssueDispatchMode::Closeout {
+		return Ok(None);
+	}
+
+	let Some(worktree) = context.state_store.worktree_for_issue(&issue.id)? else {
+		return Ok(None);
+	};
+	if worktree.project_id() != context.project.service_id()
+		|| !worktree.worktree_path().try_exists()?
+	{
+		return Ok(None);
+	}
+
+	Ok(Some(WorktreeSpec {
+		branch_name: worktree.branch_name().to_owned(),
+		issue_identifier: issue.identifier.clone(),
+		path: worktree.worktree_path().to_path_buf(),
+		reused_existing: true,
+	}))
 }
 
 fn prepare_issue_run_dispatch_allowed<T>(

--- a/apps/decodex/src/orchestrator/status.rs
+++ b/apps/decodex/src/orchestrator/status.rs
@@ -7106,7 +7106,14 @@ fn recover_issue_runtime_state<T>(
 where
 	T: IssueTracker,
 {
-	let worktree = worktree_manager.plan_for_issue(&issue.identifier);
+	let planned_worktree = worktree_manager.plan_for_issue(&issue.identifier);
+	let existing_worktree_mapping = state_store.worktree_for_issue(&issue.id)?;
+	let existing_worktree = existing_recoverable_worktree_spec(
+		project.service_id(),
+		&issue,
+		existing_worktree_mapping.as_ref(),
+	)?;
+	let worktree = existing_worktree.unwrap_or(planned_worktree);
 
 	if !worktree.path.exists() {
 		return Ok(None);
@@ -7115,7 +7122,6 @@ where
 	state_store.canonicalize_issue_identity(&issue.identifier, &issue.id)?;
 
 	let activity_marker = state::read_run_activity_marker_snapshot(&worktree.path)?;
-	let existing_worktree_mapping = state_store.worktree_for_issue(&issue.id)?;
 	let recovered_service_ownership =
 		issue_has_recovered_service_ownership(tracker, &issue, project.service_id())?;
 
@@ -7201,6 +7207,26 @@ where
 	}
 
 	Ok(None)
+}
+
+fn existing_recoverable_worktree_spec(
+	project_id: &str,
+	issue: &TrackerIssue,
+	mapping: Option<&WorktreeMapping>,
+) -> crate::prelude::Result<Option<WorktreeSpec>> {
+	let Some(mapping) = mapping else {
+		return Ok(None);
+	};
+	if mapping.project_id() != project_id || !mapping.worktree_path().try_exists()? {
+		return Ok(None);
+	}
+
+	Ok(Some(WorktreeSpec {
+		branch_name: mapping.branch_name().to_owned(),
+		issue_identifier: issue.identifier.clone(),
+		path: mapping.worktree_path().to_path_buf(),
+		reused_existing: true,
+	}))
 }
 
 fn upsert_recovered_worktree_mapping(

--- a/apps/decodex/src/orchestrator/tests/intake/candidate_selection.rs
+++ b/apps/decodex/src/orchestrator/tests/intake/candidate_selection.rs
@@ -1276,9 +1276,17 @@ fn closeout_dispatch_policy_blocks_completed_issue_with_missing_review_handoff_r
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
 		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
-	let _worktree = worktree_manager
+	let worktree = worktree_manager
 		.ensure_worktree(&closeout_issue.identifier, false)
 		.expect("worktree should exist");
+	state_store
+		.upsert_worktree(
+			config.service_id(),
+			&closeout_issue.id,
+			&worktree.branch_name,
+			&worktree.path.display().to_string(),
+		)
+		.expect("retained closeout worktree mapping should persist");
 
 	assert!(
 		!orchestrator::issue_passes_closeout_dispatch_policy(


### PR DESCRIPTION
## Summary
- Preserve persisted retained closeout worktree mappings across dispatch policy, prepare, recovery, and daemon materialization.
- Fall back to the planned issue worktree only when no persisted mapping exists, keeping legacy handoff-marker paths covered without recomputing real retained lanes from the current Git identity.
- Make the missing-review-handoff closeout policy test persist the retained mapping explicitly.

## Validation
- cargo test -p decodex closeout --lib
- cargo make check-rust
- cargo make lint-rust
- cargo make test-rust
- git diff --check

Known baseline: cargo make fmt-rust-check still fails on existing apps/decodex/src/radar.rs and apps/decodex/src/recovery.rs formatting drift, unchanged by this PR.