### PR TITLE
XY-1115 Split MCP project context resources

### DIFF
--- a/apps/decodex/src/mcp/resources/context/project.rs
+++ b/apps/decodex/src/mcp/resources/context/project.rs
@@ -1,11 +1,11 @@
-use serde_json::Value;
+mod autonomy;
+mod runtime;
 
 use crate::{
 	mcp::{
-		self, DEFAULT_MCP_STATUS_LIMIT, McpContext, McpError, autonomy_resources, observability,
+		McpContext, McpError,
 		resources::types::{ResourceContent, ResourceUri},
 	},
-	orchestrator,
 	prelude::Result,
 };
 
@@ -30,127 +30,8 @@ impl McpContext {
 		let Some(config_path) = self.config_path.as_deref() else {
 			return Err(McpError::resource_not_found());
 		};
-		let value = match (resource_kind.as_str(), rest) {
-			("status", []) =>
-				orchestrator::build_mcp_status_resource(Some(config_path), DEFAULT_MCP_STATUS_LIMIT)
-					.map_err(McpError::internal),
-			("status_live", []) =>
-				orchestrator::build_mcp_status_resource(Some(config_path), DEFAULT_MCP_STATUS_LIMIT)
-					.map(observability::mcp_status_live_resource)
-					.map_err(McpError::internal),
-			("activity_tail", []) =>
-				orchestrator::build_mcp_status_resource(Some(config_path), DEFAULT_MCP_STATUS_LIMIT)
-					.map(observability::mcp_activity_tail_resource)
-					.map_err(McpError::internal),
-			("lane-control", []) => orchestrator::build_mcp_lane_control_resource(
-				Some(config_path),
-				None,
-				None,
-				DEFAULT_MCP_STATUS_LIMIT,
-			)
-			.map(observability::mcp_public_lane_control_readback_resource)
-			.map_err(McpError::internal),
-			("lane-control", [issue]) if mcp::safe_runtime_identifier(issue) =>
-				orchestrator::build_mcp_lane_control_resource(
-					Some(config_path),
-					Some(issue),
-					None,
-					DEFAULT_MCP_STATUS_LIMIT,
-				)
-				.map(observability::mcp_public_lane_inspect_resource)
-				.map_err(McpError::internal),
-			("lane_inspect", [issue]) if mcp::safe_runtime_identifier(issue) =>
-				orchestrator::build_mcp_lane_control_resource(
-					Some(config_path),
-					Some(issue),
-					None,
-					DEFAULT_MCP_STATUS_LIMIT,
-				)
-				.map(observability::mcp_public_lane_inspect_resource)
-				.map_err(McpError::internal),
-			("runs", [run_id, resource])
-				if resource == "events" && mcp::safe_runtime_identifier(run_id) =>
-				orchestrator::build_mcp_status_resource(Some(config_path), DEFAULT_MCP_STATUS_LIMIT)
-					.map_err(McpError::internal)
-					.and_then(|snapshot| {
-						observability::mcp_run_resource(&snapshot, run_id, "events")
-					}),
-			("runs", [run_id, resource])
-				if resource == "protocol_activity" && mcp::safe_runtime_identifier(run_id) =>
-				orchestrator::build_mcp_status_resource(Some(config_path), DEFAULT_MCP_STATUS_LIMIT)
-					.map_err(McpError::internal)
-					.and_then(|snapshot| {
-						observability::mcp_run_resource(&snapshot, run_id, "protocol_activity")
-					}),
-			("runs", [run_id, resource])
-				if resource == "child_agent_activity" && mcp::safe_runtime_identifier(run_id) =>
-				orchestrator::build_mcp_status_resource(Some(config_path), DEFAULT_MCP_STATUS_LIMIT)
-					.map_err(McpError::internal)
-					.and_then(|snapshot| {
-						observability::mcp_run_resource(&snapshot, run_id, "child_agent_activity")
-					}),
-			("runs", [run_id, resource])
-				if resource == "progress_diagnostics" && mcp::safe_runtime_identifier(run_id) =>
-				orchestrator::build_mcp_status_resource(Some(config_path), DEFAULT_MCP_STATUS_LIMIT)
-					.map_err(McpError::internal)
-					.and_then(|snapshot| {
-						observability::mcp_run_resource(&snapshot, run_id, "progress_diagnostics")
-					}),
-			("pr_review_state", []) =>
-				orchestrator::build_mcp_status_resource(Some(config_path), DEFAULT_MCP_STATUS_LIMIT)
-					.map(observability::mcp_pr_review_state_resource)
-					.map_err(McpError::internal),
-			_ => return Err(McpError::resource_not_found()),
-		}?;
+		let value = runtime::read_project_runtime_resource(config_path, resource_kind, rest)?;
 
 		ResourceContent::mcp_observability_json(&uri.raw, value)
-	}
-
-	fn read_autonomy_project_resource(
-		&self,
-		project_id: &str,
-		rest: &[String],
-	) -> Result<Value, McpError> {
-		let Some(state_store) = self.state_store.as_ref() else {
-			return Err(McpError::resource_not_found());
-		};
-
-		match rest {
-			[] => autonomy_resources::mcp_autonomy_project_resource(state_store, project_id),
-			[resource] if resource == "signals" =>
-				autonomy_resources::mcp_autonomy_signals_resource(state_store, project_id),
-			[resource, signal_id]
-				if resource == "signals" && mcp::safe_autonomy_record_identifier(signal_id) =>
-				autonomy_resources::mcp_autonomy_signal_resource(state_store, project_id, signal_id),
-			[resource] if resource == "proposals" =>
-				autonomy_resources::mcp_autonomy_proposals_resource(state_store, project_id),
-			[resource, proposal_id]
-				if resource == "proposals" && mcp::safe_autonomy_record_identifier(proposal_id) =>
-				autonomy_resources::mcp_autonomy_proposal_resource(
-					state_store,
-					project_id,
-					proposal_id,
-				),
-			[resource] if resource == "evidence" =>
-				autonomy_resources::mcp_autonomy_evidence_resource(state_store, project_id),
-			[resource, objective_id, selector]
-				if resource == "objectives"
-					&& mcp::safe_runtime_identifier(objective_id)
-					&& selector == "current" =>
-				autonomy_resources::mcp_autonomy_current_objective_resource(
-					state_store,
-					project_id,
-					objective_id,
-				),
-			[resource, objective_id, version]
-				if resource == "objectives" && mcp::safe_runtime_identifier(objective_id) =>
-				autonomy_resources::mcp_autonomy_objective_version_resource(
-					state_store,
-					project_id,
-					objective_id,
-					version,
-				),
-			_ => Err(McpError::resource_not_found()),
-		}
 	}
 }

--- a/apps/decodex/src/mcp/resources/context/project/autonomy.rs
+++ b/apps/decodex/src/mcp/resources/context/project/autonomy.rs
@@ -1,0 +1,56 @@
+use serde_json::Value;
+
+use crate::{
+	mcp::{self, McpContext, McpError, autonomy_resources},
+	prelude::Result,
+};
+
+impl McpContext {
+	pub(super) fn read_autonomy_project_resource(
+		&self,
+		project_id: &str,
+		rest: &[String],
+	) -> Result<Value, McpError> {
+		let Some(state_store) = self.state_store.as_ref() else {
+			return Err(McpError::resource_not_found());
+		};
+
+		match rest {
+			[] => autonomy_resources::mcp_autonomy_project_resource(state_store, project_id),
+			[resource] if resource == "signals" =>
+				autonomy_resources::mcp_autonomy_signals_resource(state_store, project_id),
+			[resource, signal_id]
+				if resource == "signals" && mcp::safe_autonomy_record_identifier(signal_id) =>
+				autonomy_resources::mcp_autonomy_signal_resource(state_store, project_id, signal_id),
+			[resource] if resource == "proposals" =>
+				autonomy_resources::mcp_autonomy_proposals_resource(state_store, project_id),
+			[resource, proposal_id]
+				if resource == "proposals" && mcp::safe_autonomy_record_identifier(proposal_id) =>
+				autonomy_resources::mcp_autonomy_proposal_resource(
+					state_store,
+					project_id,
+					proposal_id,
+				),
+			[resource] if resource == "evidence" =>
+				autonomy_resources::mcp_autonomy_evidence_resource(state_store, project_id),
+			[resource, objective_id, selector]
+				if resource == "objectives"
+					&& mcp::safe_runtime_identifier(objective_id)
+					&& selector == "current" =>
+				autonomy_resources::mcp_autonomy_current_objective_resource(
+					state_store,
+					project_id,
+					objective_id,
+				),
+			[resource, objective_id, version]
+				if resource == "objectives" && mcp::safe_runtime_identifier(objective_id) =>
+				autonomy_resources::mcp_autonomy_objective_version_resource(
+					state_store,
+					project_id,
+					objective_id,
+					version,
+				),
+			_ => Err(McpError::resource_not_found()),
+		}
+	}
+}

--- a/apps/decodex/src/mcp/resources/context/project/runtime.rs
+++ b/apps/decodex/src/mcp/resources/context/project/runtime.rs
@@ -1,0 +1,77 @@
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::{
+	mcp::{self, DEFAULT_MCP_STATUS_LIMIT, McpError, observability},
+	orchestrator,
+	prelude::Result,
+};
+
+pub(super) fn read_project_runtime_resource(
+	config_path: &Path,
+	resource_kind: &str,
+	rest: &[String],
+) -> Result<Value, McpError> {
+	match (resource_kind, rest) {
+		("status", []) =>
+			orchestrator::build_mcp_status_resource(Some(config_path), DEFAULT_MCP_STATUS_LIMIT)
+				.map_err(McpError::internal),
+		("status_live", []) =>
+			orchestrator::build_mcp_status_resource(Some(config_path), DEFAULT_MCP_STATUS_LIMIT)
+				.map(observability::mcp_status_live_resource)
+				.map_err(McpError::internal),
+		("activity_tail", []) =>
+			orchestrator::build_mcp_status_resource(Some(config_path), DEFAULT_MCP_STATUS_LIMIT)
+				.map(observability::mcp_activity_tail_resource)
+				.map_err(McpError::internal),
+		("lane-control", []) => orchestrator::build_mcp_lane_control_resource(
+			Some(config_path),
+			None,
+			None,
+			DEFAULT_MCP_STATUS_LIMIT,
+		)
+		.map(observability::mcp_public_lane_control_readback_resource)
+		.map_err(McpError::internal),
+		("lane-control", [issue]) if mcp::safe_runtime_identifier(issue) =>
+			project_lane_inspect_resource(config_path, issue),
+		("lane_inspect", [issue]) if mcp::safe_runtime_identifier(issue) =>
+			project_lane_inspect_resource(config_path, issue),
+		("runs", [run_id, resource])
+			if run_resource_allowed(resource) && mcp::safe_runtime_identifier(run_id) =>
+			project_run_resource(config_path, run_id, resource),
+		("pr_review_state", []) =>
+			orchestrator::build_mcp_status_resource(Some(config_path), DEFAULT_MCP_STATUS_LIMIT)
+				.map(observability::mcp_pr_review_state_resource)
+				.map_err(McpError::internal),
+		_ => Err(McpError::resource_not_found()),
+	}
+}
+
+fn project_lane_inspect_resource(config_path: &Path, issue: &str) -> Result<Value, McpError> {
+	orchestrator::build_mcp_lane_control_resource(
+		Some(config_path),
+		Some(issue),
+		None,
+		DEFAULT_MCP_STATUS_LIMIT,
+	)
+	.map(observability::mcp_public_lane_inspect_resource)
+	.map_err(McpError::internal)
+}
+
+fn project_run_resource(
+	config_path: &Path,
+	run_id: &str,
+	resource: &str,
+) -> Result<Value, McpError> {
+	orchestrator::build_mcp_status_resource(Some(config_path), DEFAULT_MCP_STATUS_LIMIT)
+		.map_err(McpError::internal)
+		.and_then(|snapshot| observability::mcp_run_resource(&snapshot, run_id, resource))
+}
+
+fn run_resource_allowed(resource: &str) -> bool {
+	matches!(
+		resource,
+		"events" | "protocol_activity" | "child_agent_activity" | "progress_diagnostics"
+	)
+}


### PR DESCRIPTION
## Summary
- keep project context URI ownership and project-id/config gates in project.rs
- move autonomy project resources into project/autonomy.rs
- move status, activity, lane-control, run, and PR review state resources into project/runtime.rs

## Validation
- rustup run nightly rustfmt --edition 2024 apps/decodex/src/mcp/resources/context/project.rs apps/decodex/src/mcp/resources/context/project/autonomy.rs apps/decodex/src/mcp/resources/context/project/runtime.rs
- git diff --check
- cargo test -p decodex mcp --lib
- cargo make check-rust
- cargo make lint-rust
- cargo make test-rust

Known baseline: cargo make fmt-rust-check still fails on existing apps/decodex/src/radar.rs formatting drift, unchanged by this PR.