### PR TITLE
XY-1115 Split MCP docs context resources

### DIFF
--- a/apps/decodex/src/mcp/resources/context/docs.rs
+++ b/apps/decodex/src/mcp/resources/context/docs.rs
@@ -1,8 +1,5 @@
-use std::{
-	fs,
-	io::ErrorKind,
-	path::{Path, PathBuf},
-};
+mod files;
+mod listing;
 
 use crate::{
 	mcp::{
@@ -14,51 +11,7 @@ use crate::{
 
 impl McpContext {
 	pub(in crate::mcp::resources) fn docs_resources(&self) -> Result<Vec<McpResource>, McpError> {
-		let mut resources = Vec::new();
-
-		push_file_resource(
-			&mut resources,
-			self.repo_root.join("docs/index.md"),
-			"decodex://docs/index",
-			"Documentation index",
-			"Checked-in Decodex documentation router.",
-		);
-		push_file_resource(
-			&mut resources,
-			self.repo_root.join("docs/policy.md"),
-			"decodex://docs/policy",
-			"Documentation policy",
-			"Checked-in Decodex documentation policy.",
-		);
-
-		for lane in ["spec", "runbook", "reference", "decisions", "research"] {
-			let docs_dir = self.repo_root.join("docs").join(lane);
-
-			for entry in read_sorted_dir(&docs_dir)? {
-				let Some(stem) = markdown_stem(&entry) else {
-					continue;
-				};
-
-				resources.push(McpResource::markdown(
-					format!("decodex://docs/{lane}/{stem}"),
-					format!("docs/{lane}/{stem}.md"),
-					"Checked-in Decodex documentation resource.",
-				));
-			}
-		}
-		for entry in read_sorted_dir(&self.repo_root.join("docs/research"))? {
-			let Some(stem) = markdown_stem(&entry) else {
-				continue;
-			};
-
-			resources.push(McpResource::markdown(
-				format!("decodex://research/{stem}"),
-				format!("docs/research/{stem}.md"),
-				"Checked-in Markdown Research Contract concept.",
-			));
-		}
-
-		Ok(resources)
+		listing::docs_resources(&self.repo_root)
 	}
 
 	pub(super) fn read_docs_resource(
@@ -68,12 +21,12 @@ impl McpContext {
 		let path = match uri.segments.as_slice() {
 			[segment] if segment == "index" => self.repo_root.join("docs/index.md"),
 			[segment] if segment == "policy" => self.repo_root.join("docs/policy.md"),
-			[lane, topic] if docs_lane_allowed(lane) && safe_resource_stem(topic) =>
+			[lane, topic] if files::docs_lane_allowed(lane) && files::safe_resource_stem(topic) =>
 				self.repo_root.join("docs").join(lane).join(format!("{topic}.md")),
 			_ => return Err(McpError::resource_not_found()),
 		};
 
-		read_file_resource(&uri.raw, path, "text/markdown")
+		files::read_file_resource(&uri.raw, path, "text/markdown")
 	}
 
 	pub(super) fn read_research_resource(
@@ -84,71 +37,14 @@ impl McpContext {
 			return Err(McpError::resource_not_found());
 		};
 
-		if !safe_resource_stem(concept) {
+		if !files::safe_resource_stem(concept) {
 			return Err(McpError::resource_not_found());
 		}
 
-		read_file_resource(
+		files::read_file_resource(
 			&uri.raw,
 			self.repo_root.join("docs/research").join(format!("{concept}.md")),
 			"text/markdown",
 		)
 	}
-}
-
-fn push_file_resource(
-	resources: &mut Vec<McpResource>,
-	path: PathBuf,
-	uri: &str,
-	name: &str,
-	description: &str,
-) {
-	if path.is_file() {
-		resources.push(McpResource::markdown(uri, name, description));
-	}
-}
-
-fn read_sorted_dir(path: &Path) -> Result<Vec<PathBuf>, McpError> {
-	let entries = match fs::read_dir(path) {
-		Ok(entries) => entries,
-		Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
-		Err(error) => return Err(McpError::internal(error)),
-	};
-	let mut paths = entries
-		.map(|entry| entry.map(|entry| entry.path()).map_err(McpError::internal))
-		.collect::<Result<Vec<_>, _>>()?;
-
-	paths.sort();
-
-	Ok(paths)
-}
-
-fn markdown_stem(path: &Path) -> Option<String> {
-	if path.extension().and_then(|extension| extension.to_str()) != Some("md") {
-		return None;
-	}
-
-	path.file_stem().and_then(|stem| stem.to_str()).map(str::to_owned)
-}
-
-fn read_file_resource(
-	uri: &str,
-	path: PathBuf,
-	mime_type: &str,
-) -> Result<ResourceContent, McpError> {
-	let text = fs::read_to_string(path).map_err(|error| match error.kind() {
-		ErrorKind::NotFound => McpError::resource_not_found(),
-		_ => McpError::internal(error),
-	})?;
-
-	Ok(ResourceContent { uri: uri.to_owned(), mime_type: mime_type.to_owned(), text })
-}
-
-fn docs_lane_allowed(lane: &str) -> bool {
-	matches!(lane, "spec" | "runbook" | "reference" | "decisions" | "research")
-}
-
-fn safe_resource_stem(value: &str) -> bool {
-	!value.is_empty()
-		&& value.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }

--- a/apps/decodex/src/mcp/resources/context/docs/files.rs
+++ b/apps/decodex/src/mcp/resources/context/docs/files.rs
@@ -1,0 +1,28 @@
+use std::{fs, io::ErrorKind, path::PathBuf};
+
+use crate::{
+	mcp::{McpError, resources::types::ResourceContent},
+	prelude::Result,
+};
+
+pub(super) fn read_file_resource(
+	uri: &str,
+	path: PathBuf,
+	mime_type: &str,
+) -> Result<ResourceContent, McpError> {
+	let text = fs::read_to_string(path).map_err(|error| match error.kind() {
+		ErrorKind::NotFound => McpError::resource_not_found(),
+		_ => McpError::internal(error),
+	})?;
+
+	Ok(ResourceContent { uri: uri.to_owned(), mime_type: mime_type.to_owned(), text })
+}
+
+pub(super) fn docs_lane_allowed(lane: &str) -> bool {
+	matches!(lane, "spec" | "runbook" | "reference" | "decisions" | "research")
+}
+
+pub(super) fn safe_resource_stem(value: &str) -> bool {
+	!value.is_empty()
+		&& value.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}

--- a/apps/decodex/src/mcp/resources/context/docs/listing.rs
+++ b/apps/decodex/src/mcp/resources/context/docs/listing.rs
@@ -1,0 +1,93 @@
+use std::{
+	fs,
+	io::ErrorKind,
+	path::{Path, PathBuf},
+};
+
+use crate::{
+	mcp::{McpError, resources::types::McpResource},
+	prelude::Result,
+};
+
+pub(super) fn docs_resources(repo_root: &Path) -> Result<Vec<McpResource>, McpError> {
+	let mut resources = Vec::new();
+
+	push_file_resource(
+		&mut resources,
+		repo_root.join("docs/index.md"),
+		"decodex://docs/index",
+		"Documentation index",
+		"Checked-in Decodex documentation router.",
+	);
+	push_file_resource(
+		&mut resources,
+		repo_root.join("docs/policy.md"),
+		"decodex://docs/policy",
+		"Documentation policy",
+		"Checked-in Decodex documentation policy.",
+	);
+
+	for lane in ["spec", "runbook", "reference", "decisions", "research"] {
+		let docs_dir = repo_root.join("docs").join(lane);
+
+		for entry in read_sorted_dir(&docs_dir)? {
+			let Some(stem) = markdown_stem(&entry) else {
+				continue;
+			};
+
+			resources.push(McpResource::markdown(
+				format!("decodex://docs/{lane}/{stem}"),
+				format!("docs/{lane}/{stem}.md"),
+				"Checked-in Decodex documentation resource.",
+			));
+		}
+	}
+	for entry in read_sorted_dir(&repo_root.join("docs/research"))? {
+		let Some(stem) = markdown_stem(&entry) else {
+			continue;
+		};
+
+		resources.push(McpResource::markdown(
+			format!("decodex://research/{stem}"),
+			format!("docs/research/{stem}.md"),
+			"Checked-in Markdown Research Contract concept.",
+		));
+	}
+
+	Ok(resources)
+}
+
+fn push_file_resource(
+	resources: &mut Vec<McpResource>,
+	path: PathBuf,
+	uri: &str,
+	name: &str,
+	description: &str,
+) {
+	if path.is_file() {
+		resources.push(McpResource::markdown(uri, name, description));
+	}
+}
+
+fn read_sorted_dir(path: &Path) -> Result<Vec<PathBuf>, McpError> {
+	let entries = match fs::read_dir(path) {
+		Ok(entries) => entries,
+		Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+		Err(error) => return Err(McpError::internal(error)),
+	};
+	let mut paths = entries
+		.map(|entry| entry.map(|entry| entry.path()).map_err(McpError::internal))
+		.collect::<Result<Vec<_>, _>>()?;
+
+	paths.sort();
+
+	Ok(paths)
+}
+
+fn markdown_stem(path: &Path) -> Option<String> {
+	if path.extension().and_then(|extension| extension.to_str()) != Some("md") {
+		return None;
+	}
+
+	path.file_stem().and_then(|stem| stem.to_str()).map(str::to_owned)
+}


### PR DESCRIPTION
## Summary
- keep docs/research read entrypoints in docs.rs
- move docs and research resource enumeration into docs/listing.rs
- move safe stem/lane checks and file content reads into docs/files.rs

## Validation
- rustup run nightly rustfmt --edition 2024 apps/decodex/src/mcp/resources/context/docs.rs apps/decodex/src/mcp/resources/context/docs/files.rs apps/decodex/src/mcp/resources/context/docs/listing.rs
- git diff --check
- cargo test -p decodex mcp --lib
- cargo make check-rust
- cargo make lint-rust
- cargo make test-rust

Known baseline: cargo make fmt-rust-check still fails on existing apps/decodex/src/radar.rs formatting drift, unchanged by this PR.