### PR TITLE
XY-1115 Split MCP server core modules

### DIFF
--- a/apps/decodex/src/mcp/server/core.rs
+++ b/apps/decodex/src/mcp/server/core.rs
@@ -1,18 +1,12 @@
-use serde_json::{self, Value};
+mod initialize;
+mod request;
+mod tools;
 
-use crate::{
-	mcp::{
-		self, MCP_HTTP_ENDPOINT_PATH, MCP_PROTOCOL_VERSION, MCP_SESSION_HEADER,
-		McpCapabilityProfile, McpContext, McpError, McpTransport, SERVER_NAME,
-		TOOL_AUTONOMY_ACCEPT_OBJECTIVE, TOOL_AUTONOMY_CHALLENGE_PROPOSAL,
-		TOOL_AUTONOMY_COMPILE_PROPOSAL, TOOL_AUTONOMY_DRAFT_OBJECTIVE,
-		TOOL_AUTONOMY_REQUEST_PROMOTION, TOOL_AUTONOMY_SUBMIT_SIGNAL, TOOL_INTAKE_GOAL,
-		TOOL_LANE_CONTROL, TOOL_OBSERVE, TOOL_PLAN, TOOL_PROJECT_CONTROL, TOOL_RESEARCH_COMPILE,
-		TOOL_RESEARCH_PROMOTE, planning,
-		server::protocol::{self, CallToolParams, JsonRpcRequest},
-		tools,
-	},
-	prelude::Result,
+use serde_json::Value;
+
+use crate::mcp::{
+	McpCapabilityProfile, McpContext, McpTransport,
+	server::protocol::{self, JsonRpcRequest},
 };
 
 pub(in crate::mcp) struct McpServer {
@@ -29,149 +23,11 @@ impl McpServer {
 		};
 		let request = match serde_json::from_value::<JsonRpcRequest>(value) {
 			Ok(request) => request,
-			Err(_) =>
-				return vec![protocol::json_rpc_error(Value::Null, -32_600, "Invalid Request")],
+			Err(_) => {
+				return vec![protocol::json_rpc_error(Value::Null, -32_600, "Invalid Request")];
+			},
 		};
 
 		self.handle_request(request, emit_progress)
-	}
-
-	fn handle_request(&self, request: JsonRpcRequest, emit_progress: bool) -> Vec<Value> {
-		let Some(id) = request.id else {
-			return Vec::new();
-		};
-
-		if request.jsonrpc.as_deref() != Some("2.0") {
-			return vec![protocol::json_rpc_error(id, -32_600, "Invalid Request")];
-		}
-
-		let Some(method) = request.method else {
-			return vec![protocol::json_rpc_error(id, -32_600, "Invalid Request")];
-		};
-		let progress_token = emit_progress
-			.then(|| protocol::progress_token_from_params(request.params.as_ref()))
-			.flatten();
-		let result = match method.as_str() {
-			"initialize" => Ok(self.initialize()),
-			"ping" => Ok(serde_json::json!({})),
-			"logging/setLevel" => Ok(serde_json::json!({})),
-			"resources/list" => self.list_resources(),
-			"resources/read" => self.read_resource(request.params),
-			"resources/templates/list" => Ok(self.list_resource_templates()),
-			"prompts/list" => Ok(self.list_prompts()),
-			"prompts/get" => self.get_prompt(request.params),
-			"tools/list" => Ok(self.list_tools()),
-			"tools/call" => self.call_tool(request.params),
-			_ => Err(McpError::method_not_found()),
-		};
-		let mut responses = Vec::new();
-
-		if method == "tools/call"
-			&& result.as_ref().is_ok_and(mcp::tool_call_result_allows_progress)
-			&& let Some(token) = progress_token
-		{
-			responses.push(protocol::progress_notification(
-				token,
-				1,
-				Some(2),
-				"Decodex MCP tool request accepted.",
-			));
-		}
-
-		responses.push(match result {
-			Ok(result) => serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result }),
-			Err(error) => protocol::json_rpc_error(id, error.code, &error.message),
-		});
-
-		responses
-	}
-
-	fn initialize(&self) -> Value {
-		serde_json::json!({
-			"protocolVersion": MCP_PROTOCOL_VERSION,
-			"capabilities": {
-				"resources": {},
-				"prompts": {},
-				"tools": {},
-				"logging": {},
-				"experimental": {
-					"decodex": {
-						"capabilityProfile": self.capability_profile.as_str(),
-						"capabilityProfiles": McpCapabilityProfile::ALL
-							.into_iter()
-							.map(McpCapabilityProfile::as_str)
-							.collect::<Vec<_>>(),
-						"transport": self.transport.as_str(),
-						"remoteControl": {
-							"safeDefaultProfile": "observe",
-							"httpTransport": "streamable-http",
-							"httpEndpoint": MCP_HTTP_ENDPOINT_PATH,
-							"sessionHeader": MCP_SESSION_HEADER,
-							"sseResponses": true,
-							"originValidation": true,
-							"operateAdminTools": "inspect_first_guarded",
-							"mutatingToolsRequireAuthority": true,
-							"privateEvidencePayloadsExposed": false
-						}
-					}
-				}
-			},
-			"serverInfo": {
-				"name": SERVER_NAME,
-				"version": env!("CARGO_PKG_VERSION")
-			}
-		})
-	}
-
-	fn list_tools(&self) -> Value {
-		let tools = tools::mcp_tools()
-			.into_iter()
-			.filter(|tool| self.capability_profile.allows(tool.required_profile))
-			.map(|tool| tool.value)
-			.collect::<Vec<_>>();
-
-		serde_json::json!({ "tools": tools })
-	}
-
-	fn call_tool(&self, params: Option<Value>) -> Result<Value, McpError> {
-		let params = params.ok_or_else(McpError::invalid_params)?;
-		let params = serde_json::from_value::<CallToolParams>(params)
-			.map_err(|_| McpError::invalid_params())?;
-		let arguments = params.arguments.unwrap_or_else(|| serde_json::json!({}));
-		let Some(required_profile) = tools::tool_required_profile(&params.name) else {
-			return Ok(mcp::tool_refusal(
-				"unknown_tool",
-				format!("Decodex MCP tool `{}` is not registered.", params.name),
-			));
-		};
-
-		if !self.capability_profile.allows(required_profile) {
-			return Ok(mcp::capability_profile_refusal(
-				&params.name,
-				self.capability_profile,
-				required_profile,
-			));
-		}
-
-		match params.name.as_str() {
-			TOOL_OBSERVE => Ok(self.call_observe_tool(arguments)),
-			TOOL_PLAN => Ok(planning::call_plan_tool(arguments)),
-			TOOL_RESEARCH_COMPILE => Ok(self.call_research_compile_tool(arguments)),
-			TOOL_RESEARCH_PROMOTE => Ok(self.call_research_promote_tool(arguments)),
-			TOOL_INTAKE_GOAL => Ok(self.call_intake_goal_tool(arguments)),
-			TOOL_AUTONOMY_DRAFT_OBJECTIVE => Ok(self.call_autonomy_draft_objective_tool(arguments)),
-			TOOL_AUTONOMY_ACCEPT_OBJECTIVE =>
-				Ok(self.call_autonomy_accept_objective_tool(arguments)),
-			TOOL_AUTONOMY_SUBMIT_SIGNAL => Ok(self.call_autonomy_submit_signal_tool(arguments)),
-			TOOL_AUTONOMY_COMPILE_PROPOSAL =>
-				Ok(self.call_autonomy_compile_proposal_tool(arguments)),
-			TOOL_AUTONOMY_CHALLENGE_PROPOSAL =>
-				Ok(self.call_autonomy_challenge_proposal_tool(arguments)),
-			TOOL_AUTONOMY_REQUEST_PROMOTION =>
-				Ok(self.call_autonomy_request_promotion_tool(arguments)),
-			TOOL_LANE_CONTROL => Ok(self.call_lane_control_tool(arguments, required_profile)),
-			TOOL_PROJECT_CONTROL => Ok(self.call_project_control_tool(arguments, required_profile)),
-			_ => Ok(mcp::tool_refusal("unknown_tool", "Decodex MCP tool is not registered.")),
-		}
 	}
 }

--- a/apps/decodex/src/mcp/server/core/initialize.rs
+++ b/apps/decodex/src/mcp/server/core/initialize.rs
@@ -1,0 +1,46 @@
+use serde_json::Value;
+
+use super::McpServer;
+use crate::mcp::{
+	MCP_HTTP_ENDPOINT_PATH, MCP_PROTOCOL_VERSION, MCP_SESSION_HEADER, McpCapabilityProfile,
+	SERVER_NAME,
+};
+
+impl McpServer {
+	pub(super) fn initialize(&self) -> Value {
+		serde_json::json!({
+			"protocolVersion": MCP_PROTOCOL_VERSION,
+			"capabilities": {
+				"resources": {},
+				"prompts": {},
+				"tools": {},
+				"logging": {},
+				"experimental": {
+					"decodex": {
+						"capabilityProfile": self.capability_profile.as_str(),
+						"capabilityProfiles": McpCapabilityProfile::ALL
+							.into_iter()
+							.map(McpCapabilityProfile::as_str)
+							.collect::<Vec<_>>(),
+						"transport": self.transport.as_str(),
+						"remoteControl": {
+							"safeDefaultProfile": "observe",
+							"httpTransport": "streamable-http",
+							"httpEndpoint": MCP_HTTP_ENDPOINT_PATH,
+							"sessionHeader": MCP_SESSION_HEADER,
+							"sseResponses": true,
+							"originValidation": true,
+							"operateAdminTools": "inspect_first_guarded",
+							"mutatingToolsRequireAuthority": true,
+							"privateEvidencePayloadsExposed": false
+						}
+					}
+				}
+			},
+			"serverInfo": {
+				"name": SERVER_NAME,
+				"version": env!("CARGO_PKG_VERSION")
+			}
+		})
+	}
+}

--- a/apps/decodex/src/mcp/server/core/request.rs
+++ b/apps/decodex/src/mcp/server/core/request.rs
@@ -1,0 +1,63 @@
+use serde_json::Value;
+
+use super::McpServer;
+use crate::mcp::{
+	self, McpError,
+	server::protocol::{self, JsonRpcRequest},
+};
+
+impl McpServer {
+	pub(super) fn handle_request(
+		&self,
+		request: JsonRpcRequest,
+		emit_progress: bool,
+	) -> Vec<Value> {
+		let Some(id) = request.id else {
+			return Vec::new();
+		};
+
+		if request.jsonrpc.as_deref() != Some("2.0") {
+			return vec![protocol::json_rpc_error(id, -32_600, "Invalid Request")];
+		}
+
+		let Some(method) = request.method else {
+			return vec![protocol::json_rpc_error(id, -32_600, "Invalid Request")];
+		};
+		let progress_token = emit_progress
+			.then(|| protocol::progress_token_from_params(request.params.as_ref()))
+			.flatten();
+		let result = match method.as_str() {
+			"initialize" => Ok(self.initialize()),
+			"ping" => Ok(serde_json::json!({})),
+			"logging/setLevel" => Ok(serde_json::json!({})),
+			"resources/list" => self.list_resources(),
+			"resources/read" => self.read_resource(request.params),
+			"resources/templates/list" => Ok(self.list_resource_templates()),
+			"prompts/list" => Ok(self.list_prompts()),
+			"prompts/get" => self.get_prompt(request.params),
+			"tools/list" => Ok(self.list_tools()),
+			"tools/call" => self.call_tool(request.params),
+			_ => Err(McpError::method_not_found()),
+		};
+		let mut responses = Vec::new();
+
+		if method == "tools/call"
+			&& result.as_ref().is_ok_and(mcp::tool_call_result_allows_progress)
+			&& let Some(token) = progress_token
+		{
+			responses.push(protocol::progress_notification(
+				token,
+				1,
+				Some(2),
+				"Decodex MCP tool request accepted.",
+			));
+		}
+
+		responses.push(match result {
+			Ok(result) => serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+			Err(error) => protocol::json_rpc_error(id, error.code, &error.message),
+		});
+
+		responses
+	}
+}

--- a/apps/decodex/src/mcp/server/core/tools.rs
+++ b/apps/decodex/src/mcp/server/core/tools.rs
@@ -1,0 +1,71 @@
+use serde_json::Value;
+
+use super::McpServer;
+use crate::{
+	mcp::{
+		self, McpError, TOOL_AUTONOMY_ACCEPT_OBJECTIVE, TOOL_AUTONOMY_CHALLENGE_PROPOSAL,
+		TOOL_AUTONOMY_COMPILE_PROPOSAL, TOOL_AUTONOMY_DRAFT_OBJECTIVE,
+		TOOL_AUTONOMY_REQUEST_PROMOTION, TOOL_AUTONOMY_SUBMIT_SIGNAL, TOOL_INTAKE_GOAL,
+		TOOL_LANE_CONTROL, TOOL_OBSERVE, TOOL_PLAN, TOOL_PROJECT_CONTROL, TOOL_RESEARCH_COMPILE,
+		TOOL_RESEARCH_PROMOTE, planning, server::protocol::CallToolParams, tools,
+	},
+	prelude::Result,
+};
+
+impl McpServer {
+	pub(super) fn list_tools(&self) -> Value {
+		let tools = tools::mcp_tools()
+			.into_iter()
+			.filter(|tool| self.capability_profile.allows(tool.required_profile))
+			.map(|tool| tool.value)
+			.collect::<Vec<_>>();
+
+		serde_json::json!({ "tools": tools })
+	}
+
+	pub(super) fn call_tool(&self, params: Option<Value>) -> Result<Value, McpError> {
+		let params = params.ok_or_else(McpError::invalid_params)?;
+		let params = serde_json::from_value::<CallToolParams>(params)
+			.map_err(|_| McpError::invalid_params())?;
+		let arguments = params.arguments.unwrap_or_else(|| serde_json::json!({}));
+		let Some(required_profile) = tools::tool_required_profile(&params.name) else {
+			return Ok(mcp::tool_refusal(
+				"unknown_tool",
+				format!("Decodex MCP tool `{}` is not registered.", params.name),
+			));
+		};
+
+		if !self.capability_profile.allows(required_profile) {
+			return Ok(mcp::capability_profile_refusal(
+				&params.name,
+				self.capability_profile,
+				required_profile,
+			));
+		}
+
+		match params.name.as_str() {
+			TOOL_OBSERVE => Ok(self.call_observe_tool(arguments)),
+			TOOL_PLAN => Ok(planning::call_plan_tool(arguments)),
+			TOOL_RESEARCH_COMPILE => Ok(self.call_research_compile_tool(arguments)),
+			TOOL_RESEARCH_PROMOTE => Ok(self.call_research_promote_tool(arguments)),
+			TOOL_INTAKE_GOAL => Ok(self.call_intake_goal_tool(arguments)),
+			TOOL_AUTONOMY_DRAFT_OBJECTIVE => Ok(self.call_autonomy_draft_objective_tool(arguments)),
+			TOOL_AUTONOMY_ACCEPT_OBJECTIVE => {
+				Ok(self.call_autonomy_accept_objective_tool(arguments))
+			},
+			TOOL_AUTONOMY_SUBMIT_SIGNAL => Ok(self.call_autonomy_submit_signal_tool(arguments)),
+			TOOL_AUTONOMY_COMPILE_PROPOSAL => {
+				Ok(self.call_autonomy_compile_proposal_tool(arguments))
+			},
+			TOOL_AUTONOMY_CHALLENGE_PROPOSAL => {
+				Ok(self.call_autonomy_challenge_proposal_tool(arguments))
+			},
+			TOOL_AUTONOMY_REQUEST_PROMOTION => {
+				Ok(self.call_autonomy_request_promotion_tool(arguments))
+			},
+			TOOL_LANE_CONTROL => Ok(self.call_lane_control_tool(arguments, required_profile)),
+			TOOL_PROJECT_CONTROL => Ok(self.call_project_control_tool(arguments, required_profile)),
+			_ => Ok(mcp::tool_refusal("unknown_tool", "Decodex MCP tool is not registered.")),
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- keep `McpServer` state and line parsing in the server core facade
- move JSON-RPC request dispatch into `core/request.rs`
- move initialize capability payload construction into `core/initialize.rs`
- move tool listing and tool-call routing into `core/tools.rs`

## Validation
- rustfmt --check on touched server core files
- cargo test -p decodex mcp --lib
- cargo make check-rust
- cargo make lint-rust
- cargo nextest run -p decodex recovery::tests::stale_active_release_allows_reentry_after_local_cleanup_audit recovery::tests::stale_active_release_reentry_rejects_release_audit_from_other_run
- cargo make test-rust

Note: the first full `cargo make test-rust` run hit a transient GPG signing resource error in two unrelated recovery tests (`gpg: signing failed: Cannot allocate memory`). Both failed tests passed on targeted rerun, and the full suite passed on rerun.
