### PR TITLE
Migrate runtime startup state summaries

### DIFF
--- a/apps/decodex/src/orchestrator/tests/operator/status/text.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/text.rs
@@ -795,7 +795,7 @@ fn operator_status_json_surfaces_missing_contract_program_recovery() {
 }
 
 #[test]
-fn operator_status_readback_quarantines_legacy_flat_decision_contracts() {
+fn operator_status_readback_uses_migrated_legacy_flat_decision_contracts() {
 	let (temp_dir, config, workflow) = temp_project_layout();
 	let state_path = temp_dir.path().join("runtime.sqlite3");
 	let state_store = StateStore::open(&state_path).expect("state store should open");
@@ -853,13 +853,22 @@ fn operator_status_readback_quarantines_legacy_flat_decision_contracts() {
 				],
 			)
 			.expect("legacy decision contract row should insert");
+			connection
+				.execute("UPDATE schema_meta SET value = '11' WHERE key = 'schema_version'", [])
+				.expect("schema version should mark legacy state");
 	}
 
-	assert!(
-		state_store
-			.decision_contract(config.service_id(), contract.contract_id())
-			.is_err(),
-		"execution-facing legacy contract reads must still fail closed"
+	drop(state_store);
+	let state_store = StateStore::open(&state_path).expect("legacy contract should migrate");
+
+	let migrated_contract = state_store
+		.decision_contract(config.service_id(), contract.contract_id())
+		.expect("migrated contract read should succeed")
+		.expect("migrated contract should exist");
+
+	assert_eq!(
+		migrated_contract.contract().execution_readiness().proposed_issues()[0].objective(),
+		"Legacy flat summary that must not be re-admitted."
 	);
 
 	let snapshot = build_program_readback_snapshot(&config, &workflow, &state_store);
@@ -867,7 +876,7 @@ fn operator_status_readback_quarantines_legacy_flat_decision_contracts() {
 
 	assert_eq!(program.program_id, "program-legacy-flat-contract");
 	assert_eq!(program.status, "stale");
-	assert_eq!(program.readback_warning.as_deref(), Some("source_decision_contract_missing"));
+	assert_ne!(program.readback_warning.as_deref(), Some("source_decision_contract_missing"));
 	assert_eq!(program.stale_count, 1);
 	assert_eq!(program.mapped_issue_identifiers, vec![String::from("PUB-947")]);
 }

--- a/apps/decodex/src/state/internal.rs
+++ b/apps/decodex/src/state/internal.rs
@@ -483,8 +483,10 @@ ON linear_execution_events (service_id, issue_id, event_unix, recorded_at_unix);
 		self.bootstrap_execution_programs_schema()?;
 		self.bootstrap_program_intake_state_schema()?;
 		self.bootstrap_loop_guardrail_schema()?;
+		self.run_schema_migrations()?;
 		self.record_schema_version()?;
 		self.seal_run_activity_summary_records()?;
+		self.connection.execute_batch("PRAGMA optimize=0x10002;")?;
 
 		Ok(())
 	}
@@ -889,6 +891,76 @@ ON program_issue_mappings (project_id, issue_id, updated_at_unix);
 		Ok(())
 	}
 
+	fn schema_version(&self) -> Result<Option<i64>> {
+		self.ensure_schema_meta_table()?;
+		let version = self
+			.connection
+			.query_row(
+				"SELECT value FROM schema_meta WHERE key = 'schema_version'",
+				[],
+				|row| row.get::<_, String>(0),
+			)
+			.optional()?
+			.and_then(|value| value.parse::<i64>().ok());
+
+		Ok(version)
+	}
+
+	fn ensure_schema_meta_table(&self) -> Result<()> {
+		self.connection.execute_batch(
+			r#"
+CREATE TABLE IF NOT EXISTS schema_meta (
+	key TEXT PRIMARY KEY NOT NULL,
+	value TEXT NOT NULL
+);
+"#,
+		)?;
+
+		Ok(())
+	}
+
+	fn schema_migration_completed(&self, key: &str) -> Result<bool> {
+		self.ensure_schema_meta_table()?;
+		let value = self
+			.connection
+			.query_row("SELECT value FROM schema_meta WHERE key = ?1", params![key], |row| {
+				row.get::<_, String>(0)
+			})
+			.optional()?;
+
+		Ok(value.as_deref() == Some("completed"))
+	}
+
+	fn record_schema_migration_completed(&self, key: &str) -> Result<()> {
+		self.ensure_schema_meta_table()?;
+		self.connection.execute(
+			"INSERT INTO schema_meta (key, value)
+			 VALUES (?1, 'completed')
+			 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+			params![key],
+		)?;
+
+		Ok(())
+	}
+
+	fn run_schema_migrations(&self) -> Result<()> {
+		let version = self.schema_version()?.unwrap_or(0);
+
+		if version < 12 {
+			if !self.schema_migration_completed(
+				"migration:protocol_event_summaries_from_events:v12",
+			)? {
+				self.backfill_protocol_event_summaries_from_events()?;
+				self.record_schema_migration_completed(
+					"migration:protocol_event_summaries_from_events:v12",
+				)?;
+			}
+			self.migrate_legacy_decision_contract_issue_summaries()?;
+		}
+
+		Ok(())
+	}
+
 	fn record_schema_version(&self) -> Result<()> {
 		self.connection.execute_batch(
 			r#"
@@ -897,10 +969,93 @@ CREATE TABLE IF NOT EXISTS schema_meta (
 	value TEXT NOT NULL
 );
 INSERT INTO schema_meta (key, value)
-VALUES ('schema_version', '11')
-ON CONFLICT(key) DO UPDATE SET value = excluded.value;
+VALUES ('schema_version', '12')
+ON CONFLICT(key) DO UPDATE SET value =
+	CASE
+		WHEN CAST(schema_meta.value AS INTEGER) < CAST(excluded.value AS INTEGER)
+		THEN excluded.value
+		ELSE schema_meta.value
+	END;
 "#,
 		)?;
+
+		Ok(())
+	}
+
+	fn backfill_protocol_event_summaries_from_events(&self) -> Result<()> {
+		let now = timestamp_parts();
+
+		self.connection.execute(
+			"INSERT INTO protocol_event_summaries (
+					run_id, event_count, last_sequence_number, last_event_type, last_event_at,
+					last_event_at_unix, compacted_at, compacted_at_unix
+				)
+			 SELECT totals.run_id, totals.event_count, totals.last_sequence_number,
+					last.event_type, last.created_at, last.created_at_unix, ?1, ?2
+			 FROM (
+				 SELECT run_id, COUNT(*) AS event_count, MAX(sequence_number) AS last_sequence_number
+				 FROM protocol_events
+				 GROUP BY run_id
+			 ) totals
+			 JOIN protocol_events last
+			 ON last.run_id = totals.run_id
+			 AND last.sequence_number = totals.last_sequence_number
+			 ON CONFLICT(run_id) DO UPDATE SET
+				 event_count = excluded.event_count,
+				 last_sequence_number = excluded.last_sequence_number,
+				 last_event_type = excluded.last_event_type,
+				 last_event_at = excluded.last_event_at,
+				 last_event_at_unix = excluded.last_event_at_unix,
+				 compacted_at = excluded.compacted_at,
+				 compacted_at_unix = excluded.compacted_at_unix",
+			params![now.text, now.unix],
+		)?;
+
+		Ok(())
+	}
+
+	fn migrate_legacy_decision_contract_issue_summaries(&self) -> Result<()> {
+		let updates = {
+			let mut statement = self.connection.prepare(
+				"SELECT project_id, contract_id, payload_json
+				 FROM decision_contracts
+				 WHERE json_type(payload_json, '$.execution_readiness.proposed_issue_summaries') IS NOT NULL
+				 ORDER BY project_id ASC, contract_id ASC",
+			)?;
+			let rows = statement.query_map([], |row| {
+				Ok((
+					row.get::<_, String>(0)?,
+					row.get::<_, String>(1)?,
+					row.get::<_, String>(2)?,
+				))
+			})?;
+			let mut updates = Vec::new();
+
+			for row in rows {
+				let (project_id, contract_id, payload_json) = row?;
+				let migrated_payload = migrate_legacy_decision_contract_payload(&payload_json)
+					.map_err(|error| {
+						eyre::eyre!(
+							"Decision Contract `{project_id}/{contract_id}` legacy payload migration failed: {error}"
+						)
+					})?;
+
+				if migrated_payload != payload_json {
+					updates.push((project_id, contract_id, migrated_payload));
+				}
+			}
+
+			updates
+		};
+
+		for (project_id, contract_id, payload_json) in updates {
+			self.connection.execute(
+				"UPDATE decision_contracts
+				 SET payload_json = ?3
+				 WHERE project_id = ?1 AND contract_id = ?2",
+				params![project_id, contract_id, payload_json],
+			)?;
+		}
 
 		Ok(())
 	}
@@ -2035,40 +2190,7 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 	}
 
 	fn load_protocol_event_summaries(&self, state: &mut StateData) -> Result<()> {
-		self.load_compacted_protocol_event_summaries(state)?;
-
-		let mut statement = self.connection.prepare(
-			"SELECT totals.run_id, totals.event_count, totals.last_sequence_number, \
-			 last.event_type, last.created_at, last.created_at_unix \
-			 FROM (
-			 SELECT run_id, COUNT(*) AS event_count, MAX(sequence_number) AS last_sequence_number \
-			 FROM protocol_events GROUP BY run_id
-			 ) totals \
-			 JOIN protocol_events last \
-			 ON last.run_id = totals.run_id \
-			 AND last.sequence_number = totals.last_sequence_number \
-			 ORDER BY totals.run_id",
-		)?;
-		let rows = statement.query_map([], |row| {
-			Ok((
-				row.get::<_, String>(0)?,
-				ProtocolEventSummaryRecord {
-					event_count: row.get(1)?,
-					last_sequence_number: Some(row.get(2)?),
-					last_event_type: Some(row.get(3)?),
-					last_event_at: Some(row.get(4)?),
-					last_event_at_unix: Some(row.get(5)?),
-				},
-			))
-		})?;
-
-		for row in rows {
-			let (run_id, summary) = row?;
-
-			state.event_summaries.insert(run_id, summary);
-		}
-
-		Ok(())
+		self.load_compacted_protocol_event_summaries(state)
 	}
 
 	fn load_protocol_event_summaries_for_runs(
@@ -2078,8 +2200,9 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 	) -> Result<()> {
 		for run_id in run_ids {
 			state.event_summaries.remove(run_id);
-			self.load_compacted_protocol_event_summary_for_run(state, run_id)?;
-			self.load_protocol_event_summary_for_run(state, run_id)?;
+			if !self.load_compacted_protocol_event_summary_for_run(state, run_id)? {
+				self.load_protocol_event_summary_for_run(state, run_id)?;
+			}
 		}
 
 		Ok(())
@@ -2114,6 +2237,7 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 			.optional()?;
 
 		if let Some(summary) = summary {
+			self.upsert_protocol_event_summary(run_id, &summary)?;
 			state.event_summaries.insert(run_id.to_owned(), summary);
 		}
 
@@ -2203,7 +2327,7 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 		&self,
 		state: &mut StateData,
 		run_id: &str,
-	) -> Result<()> {
+	) -> Result<bool> {
 		let mut statement = self.connection.prepare(
 			"SELECT event_count, last_sequence_number, last_event_type, last_event_at, \
 			 last_event_at_unix FROM protocol_event_summaries WHERE run_id = ?1",
@@ -2222,7 +2346,36 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 
 		if let Some(summary) = summary {
 			state.event_summaries.insert(run_id.to_owned(), summary);
+
+			return Ok(true);
 		}
+
+		Ok(false)
+	}
+
+	fn upsert_protocol_event_summary(
+		&self,
+		run_id: &str,
+		summary: &ProtocolEventSummaryRecord,
+	) -> Result<()> {
+		let now = timestamp_parts();
+
+		self.connection.execute(
+			"INSERT OR REPLACE INTO protocol_event_summaries (
+					run_id, event_count, last_sequence_number, last_event_type, last_event_at,
+					last_event_at_unix, compacted_at, compacted_at_unix
+				) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+			params![
+				run_id,
+				summary.event_count,
+				summary.last_sequence_number,
+				summary.last_event_type.as_deref(),
+				summary.last_event_at.as_deref(),
+				summary.last_event_at_unix,
+				now.text,
+				now.unix,
+			],
+		)?;
 
 		Ok(())
 	}
@@ -2443,9 +2596,9 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 		let rows = statement.query_map([], decision_contract_runtime_row_parts)?;
 
 		for row in rows {
-			if let Some(record) = maybe_decision_contract_record_from_row_parts(row?)? {
-				state.decision_contracts.insert(record.key(), record);
-			}
+			let record = decision_contract_record_from_row_parts(row?)?;
+
+			state.decision_contracts.insert(record.key(), record);
 		}
 
 		Ok(())
@@ -2489,7 +2642,7 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 			return Ok(None);
 		};
 
-		maybe_decision_contract_record_from_row_parts(parts)
+		decision_contract_record_from_row_parts(parts).map(Some)
 	}
 
 	fn list_decision_contracts_for_issue(
@@ -2509,9 +2662,7 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 		let mut records = Vec::new();
 
 		for row in rows {
-			if let Some(record) = maybe_decision_contract_record_from_row_parts(row?)? {
-				records.push(record);
-			}
+			records.push(decision_contract_record_from_row_parts(row?)?);
 		}
 
 		Ok(records)
@@ -2532,9 +2683,7 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value;
 		let mut records = Vec::new();
 
 		for row in rows {
-			if let Some(record) = maybe_decision_contract_record_from_row_parts(row?)? {
-				records.push(record);
-			}
+			records.push(decision_contract_record_from_row_parts(row?)?);
 		}
 
 		Ok(records)
@@ -5188,30 +5337,6 @@ fn decision_contract_record_from_row_parts(
 	})
 }
 
-fn maybe_decision_contract_record_from_row_parts(
-	parts: DecisionContractRuntimeRowParts,
-) -> Result<Option<DecisionContractRuntimeRecord>> {
-	let has_removed_flat_issue_summaries =
-		decision_contract_payload_has_removed_flat_issue_summaries(&parts.payload_json);
-	let project_id = parts.project_id.clone();
-	let contract_id = parts.contract_id.clone();
-
-	match decision_contract_record_from_row_parts(parts) {
-		Ok(record) => Ok(Some(record)),
-		Err(error) if has_removed_flat_issue_summaries => {
-			tracing::warn!(
-				project_id = %project_id,
-				contract_id = %contract_id,
-				error = %error,
-				"skipping legacy Decision Contract row with removed proposed_issue_summaries field"
-			);
-
-			Ok(None)
-		},
-		Err(error) => Err(error),
-	}
-}
-
 fn autonomy_objective_runtime_row_parts(
 	row: &Row<'_>,
 ) -> std::result::Result<AutonomyObjectiveRuntimeRowParts, rusqlite::Error> {
@@ -5446,16 +5571,88 @@ fn autonomy_proposal_record_from_row_parts(
 	})
 }
 
-fn decision_contract_payload_has_removed_flat_issue_summaries(payload_json: &str) -> bool {
-	serde_json::from_str::<Value>(payload_json)
-		.ok()
-		.and_then(|payload| {
-			payload
-				.get("execution_readiness")
-				.and_then(|readiness| readiness.get("proposed_issue_summaries"))
-				.map(|_| ())
-		})
-		.is_some()
+fn migrate_legacy_decision_contract_payload(payload_json: &str) -> Result<String> {
+	let mut payload = serde_json::from_str::<Value>(payload_json)?;
+	let readiness = payload
+		.get_mut("execution_readiness")
+		.and_then(Value::as_object_mut)
+		.ok_or_else(|| eyre::eyre!("Decision Contract payload missing execution_readiness."))?;
+	let summaries = readiness.remove("proposed_issue_summaries");
+
+	let should_insert_issues = readiness
+		.get("proposed_issues")
+		.and_then(Value::as_array)
+		.is_none_or(Vec::is_empty);
+
+	if should_insert_issues {
+		let summaries = legacy_issue_summary_values(summaries.as_ref());
+
+		readiness.insert(
+			String::from("proposed_issues"),
+			Value::Array(
+				summaries
+					.iter()
+					.enumerate()
+					.map(|(index, summary)| legacy_issue_summary_to_proposed_issue(index, summary))
+					.collect(),
+			),
+		);
+	}
+
+	let contract = serde_json::from_value::<DecisionContract>(payload.clone())?;
+
+	contract.validate()?;
+
+	Ok(serde_json::to_string(&payload)?)
+}
+
+fn legacy_issue_summary_values(value: Option<&Value>) -> Vec<String> {
+	let summaries = match value {
+		Some(Value::Array(values)) => values
+			.iter()
+			.map(|value| {
+				value
+					.as_str()
+					.map(str::to_owned)
+					.unwrap_or_else(|| value.to_string())
+					.trim()
+					.to_owned()
+			})
+			.filter(|value| !value.is_empty())
+			.collect::<Vec<_>>(),
+		Some(Value::String(value)) if !value.trim().is_empty() => vec![value.trim().to_owned()],
+		Some(value) => vec![value.to_string()],
+		None => Vec::new(),
+	};
+
+	if summaries.is_empty() {
+		vec![String::from("Legacy proposed issue summary was empty.")]
+	} else {
+		summaries
+	}
+}
+
+fn legacy_issue_summary_to_proposed_issue(index: usize, summary: &str) -> Value {
+	let issue_number = index + 1;
+
+	serde_json::json!({
+		"key": format!("legacy-proposed-issue-{issue_number}"),
+		"title": format!("Legacy proposed issue {issue_number}"),
+		"objective": summary,
+		"stage": "handoff",
+		"dependencies": [],
+		"conflict_domains": ["legacy_decision_contract_migration"],
+		"acceptance": [
+			format!("Review and preserve the migrated legacy proposed issue summary: {summary}")
+		],
+		"validation": [
+			"Review the migrated legacy proposed issue before promotion or intake."
+		],
+		"risk": [
+			"Migrated from removed proposed_issue_summaries; structured fields may be incomplete."
+		],
+		"queue_intent": "not_ready"
+	})
 }
 
 fn execution_program_runtime_row_parts(

--- a/apps/decodex/src/state/store.rs
+++ b/apps/decodex/src/state/store.rs
@@ -1956,6 +1956,9 @@ impl StateStore {
 				inserted_event.sequence_number == last_sequence_number.saturating_add(1)
 			}) {
 				summary.record_event(&inserted_event);
+				let summary = summary.clone();
+
+				self.upsert_protocol_event_summary_locked(run_id, &summary)?;
 			} else {
 				self.refresh_protocol_event_summaries_for_runs_locked(state, &[run_id.to_owned()])?;
 			}
@@ -4184,6 +4187,20 @@ impl StateStore {
 			sqlite.lock().map_err(|_| eyre::eyre!("StateStore SQLite mutex is poisoned."))?;
 
 		sqlite.load_protocol_event_summaries_for_runs(state, run_ids)
+	}
+
+	fn upsert_protocol_event_summary_locked(
+		&self,
+		run_id: &str,
+		summary: &ProtocolEventSummaryRecord,
+	) -> Result<()> {
+		let Some(sqlite) = self.sqlite.as_ref() else {
+			return Ok(());
+		};
+		let sqlite =
+			sqlite.lock().map_err(|_| eyre::eyre!("StateStore SQLite mutex is poisoned."))?;
+
+		sqlite.upsert_protocol_event_summary(run_id, summary)
 	}
 
 	fn refresh_run_activity_summaries_for_runs_locked(

--- a/apps/decodex/src/state/tests.rs
+++ b/apps/decodex/src/state/tests.rs
@@ -1087,6 +1087,207 @@ fn persistent_append_event_does_not_refresh_full_event_journal() {
 }
 
 #[test]
+fn persistent_open_backfills_protocol_event_summaries_from_legacy_journal() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+
+	{
+		let store = StateStore::open(&state_path).expect("state store should create schema");
+
+		store.record_run_attempt("run-legacy", "PUB-101", 1, "running").expect("run should record");
+	}
+
+	let connection = Connection::open(&state_path).expect("sqlite should open");
+
+	connection
+		.execute("DELETE FROM schema_meta WHERE key = 'schema_version'", [])
+		.expect("schema version should reset");
+	connection
+		.execute(
+			"DELETE FROM schema_meta
+			 WHERE key = 'migration:protocol_event_summaries_from_events:v12'",
+			[],
+		)
+		.expect("protocol summary migration marker should reset");
+	connection
+		.execute("DELETE FROM protocol_event_summaries", [])
+		.expect("summary rows should clear");
+	connection
+		.execute(
+			"INSERT INTO protocol_events (
+					run_id, sequence_number, event_type, payload_sha256, created_at, created_at_unix
+				) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+			rusqlite::params![
+				"run-legacy",
+				1_i64,
+				"turn/started",
+				"sha-1",
+				"2026-06-17T00:00:00Z",
+				1_i64,
+			],
+		)
+		.expect("legacy event should insert");
+	connection
+		.execute(
+			"INSERT INTO protocol_events (
+					run_id, sequence_number, event_type, payload_sha256, created_at, created_at_unix
+				) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+			rusqlite::params![
+				"run-legacy",
+				2_i64,
+				"turn/completed",
+				"sha-2",
+				"2026-06-17T00:00:01Z",
+				2_i64,
+			],
+		)
+		.expect("legacy event should insert");
+
+	let reopened = StateStore::open(&state_path).expect("state store should migrate");
+
+	assert_eq!(reopened.event_count("run-legacy").expect("event count should load"), 2);
+
+	let summary = connection
+		.query_row(
+			"SELECT event_count, last_sequence_number, last_event_type
+			 FROM protocol_event_summaries
+			 WHERE run_id = 'run-legacy'",
+			[],
+			|row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?, row.get::<_, String>(2)?)),
+		)
+		.expect("summary should persist");
+
+	assert_eq!(summary, (2, 2, String::from("turn/completed")));
+}
+
+#[test]
+fn persistent_open_keeps_protocol_backfill_marker_when_later_migration_fails() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+
+	{
+		let store = StateStore::open(&state_path).expect("state store should create schema");
+
+		store.record_run_attempt("run-legacy", "PUB-102", 1, "running").expect("run should record");
+	}
+
+	let connection = Connection::open(&state_path).expect("sqlite should open");
+	let mut legacy_payload = serde_json::to_value(latent_decision_contract_fixture())
+		.expect("fixture should encode as JSON");
+
+	legacy_payload["contract_id"] = serde_json::json!("legacy-invalid-contract");
+	legacy_payload["status"] = serde_json::json!("accepted_promoted");
+	legacy_payload["execution_readiness"]["ready_for_issue_shaping"] = serde_json::json!(false);
+
+	let readiness = legacy_payload
+		.get_mut("execution_readiness")
+		.expect("readiness should exist")
+		.as_object_mut()
+		.expect("readiness should be an object");
+
+	readiness.remove("proposed_issues");
+	readiness.insert(
+		String::from("proposed_issue_summaries"),
+		serde_json::json!(["Legacy invalid summary."]),
+	);
+
+	connection
+		.execute("UPDATE schema_meta SET value = '11' WHERE key = 'schema_version'", [])
+		.expect("schema version should mark legacy state");
+	connection
+		.execute(
+			"DELETE FROM schema_meta
+			 WHERE key = 'migration:protocol_event_summaries_from_events:v12'",
+			[],
+		)
+		.expect("protocol summary migration marker should reset");
+	connection
+		.execute("DELETE FROM protocol_event_summaries", [])
+		.expect("summary rows should clear");
+	connection
+		.execute(
+			"INSERT INTO protocol_events (
+					run_id, sequence_number, event_type, payload_sha256, created_at, created_at_unix
+				) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+			rusqlite::params![
+				"run-legacy",
+				1_i64,
+				"turn/started",
+				"sha-1",
+				"2026-06-17T00:00:00Z",
+				1_i64,
+			],
+		)
+		.expect("legacy event should insert");
+	connection
+		.execute(
+			"INSERT INTO decision_contracts (
+					project_id, contract_id, source_issue_id, status, payload_json, created_at,
+					created_at_unix, updated_at, updated_at_unix
+				) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+			rusqlite::params![
+				"decodex",
+				"legacy-invalid-contract",
+				"XY-BAD",
+				"accepted_promoted",
+				serde_json::to_string(&legacy_payload).expect("legacy payload should serialize"),
+				"2026-06-17T00:00:00Z",
+				1_i64,
+				"2026-06-17T00:00:00Z",
+				1_i64,
+			],
+		)
+		.expect("invalid legacy decision contract row should insert");
+
+	assert!(
+		StateStore::open(&state_path).is_err(),
+		"invalid legacy decision contract migration should still fail closed"
+	);
+
+	let marker: String = connection
+		.query_row(
+			"SELECT value FROM schema_meta
+			 WHERE key = 'migration:protocol_event_summaries_from_events:v12'",
+			[],
+			|row| row.get(0),
+		)
+		.expect("protocol backfill marker should persist after later migration failure");
+	let event_count: i64 = connection
+		.query_row(
+			"SELECT event_count FROM protocol_event_summaries WHERE run_id = 'run-legacy'",
+			[],
+			|row| row.get(0),
+		)
+		.expect("protocol summary should persist after later migration failure");
+
+	assert_eq!(marker, "completed");
+	assert_eq!(event_count, 1);
+}
+
+#[test]
+fn persistent_open_preserves_future_schema_version() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+
+	StateStore::open(&state_path).expect("state store should create schema");
+	let connection = Connection::open(&state_path).expect("sqlite should open");
+
+	connection
+		.execute("UPDATE schema_meta SET value = '13' WHERE key = 'schema_version'", [])
+		.expect("future schema version should set");
+
+	StateStore::open(&state_path).expect("state store should reopen");
+
+	let version: String = connection
+		.query_row("SELECT value FROM schema_meta WHERE key = 'schema_version'", [], |row| {
+			row.get(0)
+		})
+		.expect("schema version should read");
+
+	assert_eq!(version, "13");
+}
+
+#[test]
 fn protocol_event_replay_is_idempotent_when_payload_matches() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let state_path = temp_dir.path().join("runtime.sqlite3");
@@ -4317,7 +4518,7 @@ fn decision_contract_reload_rejects_row_key_payload_mismatch() {
 }
 
 #[test]
-fn decision_contract_reload_skips_legacy_flat_issue_summary_rows() {
+fn decision_contract_reload_migrates_legacy_flat_issue_summary_rows() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let state_path = temp_dir.path().join("runtime.sqlite3");
 	let store = StateStore::open(&state_path).expect("state store should open");
@@ -4364,24 +4565,47 @@ fn decision_contract_reload_skips_legacy_flat_issue_summary_rows() {
 			],
 		)
 		.expect("legacy decision contract row should insert");
+	connection
+		.execute("UPDATE schema_meta SET value = '11' WHERE key = 'schema_version'", [])
+		.expect("schema version should mark legacy state");
 
-	let reopened = StateStore::open(&state_path)
-		.expect("legacy flat issue summary row should not block state reload");
+	let reopened =
+		StateStore::open(&state_path).expect("legacy flat issue summary row should migrate");
 	let project_contracts = reopened
 		.list_decision_contracts_for_project("decodex")
 		.expect("project contracts should list");
+	let contract_ids =
+		project_contracts.iter().map(|record| record.contract_id()).collect::<Vec<_>>();
 
-	assert_eq!(project_contracts.len(), 1);
-	assert_eq!(project_contracts[0].contract_id(), "research-x-loop-contract");
-	assert!(
-		reopened
-			.list_decision_contracts_for_issue("decodex", "XY-OLD")
-			.expect("legacy issue contracts should list as empty")
-			.is_empty()
+	assert_eq!(project_contracts.len(), 2);
+	assert!(contract_ids.contains(&"research-x-loop-contract"));
+	assert!(contract_ids.contains(&"legacy-flat-issue-contract"));
+
+	let legacy_contract = reopened
+		.decision_contract("decodex", "legacy-flat-issue-contract")
+		.expect("legacy contract read should succeed")
+		.expect("legacy contract should exist");
+
+	assert_eq!(legacy_contract.source_issue_id(), Some("XY-OLD"));
+	assert_eq!(legacy_contract.contract().execution_readiness().proposed_issues().len(), 1);
+	assert_eq!(
+		legacy_contract.contract().execution_readiness().proposed_issues()[0].objective(),
+		"Legacy flat summary that must not be compiled."
 	);
+
+	let migrated_payload: String = connection
+		.query_row(
+			"SELECT payload_json FROM decision_contracts WHERE contract_id = 'legacy-flat-issue-contract'",
+			[],
+			|row| row.get(0),
+		)
+		.expect("migrated payload should read");
+	let migrated_value: serde_json::Value =
+		serde_json::from_str(&migrated_payload).expect("migrated payload should parse");
+
 	assert!(
-		reopened.decision_contract("decodex", "legacy-flat-issue-contract").is_err(),
-		"direct legacy contract reads must still fail closed"
+		migrated_value.pointer("/execution_readiness/proposed_issue_summaries").is_none(),
+		"legacy field should be removed after migration"
 	);
 }
 

--- a/docs/spec/loop-runtime.md
+++ b/docs/spec/loop-runtime.md
@@ -174,6 +174,13 @@ deprecated, and runtimes must not compile issues from it. Each proposed issue ca
 least one structured proposed issue fail readiness validation and cannot be
 materialized for goal intake or Program Intake.
 
+Runtime schema migration may rewrite old local SQLite payloads that still carry
+`execution_readiness.proposed_issue_summaries`. That rewrite is a one-time data
+migration only: each legacy summary becomes a structured `proposed_issues[]` entry
+with `handoff` stage and `not_ready` queue intent so operators can inspect and revise
+the contract. Normal readback, status, Program Intake, and compile paths remain strict
+and must not treat the removed flat field as a supported compatibility input.
+
 Decision Contracts are top-level snapshots. Terminal status, selected option, material
 evidence, unresolved gaps, validation expectations, and promotion target must be
 readable from the payload without replaying chat or scanning a chronological event

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -62,6 +62,12 @@ state or this state machine.
   the same event type and digest are idempotent and must not inflate event counts or
   fail a continuation/recovery path. A different event type or different digest at the
   same sequence remains a journal integrity error.
+- Protocol event summaries are compact startup state, not advisory cache. Schema
+  migrations must backfill `protocol_event_summaries` from legacy raw journals once,
+  and normal startup/status paths must load those summary rows instead of aggregating
+  the full `protocol_events` journal. Bounded raw-journal recomputation is reserved for
+  a requested run whose compact summary is missing, and it must persist the repaired
+  summary before returning.
 - `thread/archive` and `thread/archive/discarded` are terminal protocol barriers for
   one run. After either barrier is recorded, later non-terminal app-server events for
   the same run must not compete for the normal positive protocol sequence namespace.
@@ -89,6 +95,11 @@ state or this state machine.
 - `decodex research compile` and `decodex research promote` are runtime-local
   Decision Contract writes. They update the SQLite `decision_contracts` surface and do
   not by themselves create Linear issues, queue intent, goals, or executable lanes.
+- Runtime schema migration owns legacy Decision Contract payload rewrites. Schema 12
+  removes legacy `execution_readiness.proposed_issue_summaries` rows from SQLite by
+  converting them into structured `proposed_issues[]` with `handoff` stage and
+  `not_ready` queue intent. After migration, normal Decision Contract readback is
+  strict: it does not skip, quarantine, or compile the removed flat field.
 - `decodex mcp serve --transport stdio` is the local MCP gateway for desktop and CLI
   clients. The stdio gateway advertises resources, resource templates, prompts, tools,
   logging compatibility, and progress notifications. Resources read checked-in docs,
@@ -833,6 +844,7 @@ The runtime database stores at least:
 - run leases and dispatch ownership
 - run attempts and attempt status
 - protocol event journals
+- protocol event summaries used by startup/status readback
 - private execution events scoped by project, issue, run, and attempt
 - Objective Contracts scoped by project, objective id, and immutable version, with
   lifecycle state and acceptance, rejection, or supersession provenance


### PR DESCRIPTION
## Summary
- migrate legacy protocol event journals into protocol_event_summaries during schema 12 bootstrap, then make normal startup load compact summaries only
- persist protocol summaries on append and bounded per-run repair paths
- migrate removed Decision Contract execution_readiness.proposed_issue_summaries into structured handoff/not_ready proposed_issues before strict readback
- preserve future schema versions and track the expensive protocol backfill with its own migration marker so later migration failures do not repeat the full raw-event scan

## Research
- real runtime DB had about 2,033,654 protocol_events rows and only 1,686 protocol_event_summaries rows
- previous StateStore::open() -> load_state() path still unconditionally ran SELECT run_id, COUNT(*), MAX(sequence_number) FROM protocol_events GROUP BY run_id
- EXPLAIN QUERY PLAN showed a scan of protocol_events for that aggregate, while the summary-table path scans only protocol_event_summaries
- SQLite docs confirm SCAN is a scan over the table/index, and PRAGMA optimize helps planner stats but does not remove the startup aggregation cost

## Review
- subagent Parfit found two issues: repeated expensive backfill if later Decision Contract migration failed, and schema_version downgrading future versions
- both were fixed with a per-migration marker and max-only schema version update, with regression tests

## Validation
- cargo test -p decodex persistent_open_backfills_protocol_event_summaries_from_legacy_journal -- --nocapture
- cargo test -p decodex persistent_open_keeps_protocol_backfill_marker_when_later_migration_fails -- --nocapture
- cargo test -p decodex persistent_open_preserves_future_schema_version -- --nocapture
- cargo test -p decodex persistent_append_event_does_not_refresh_full_event_journal -- --nocapture
- cargo test -p decodex decision_contract -- --nocapture
- cargo test -p decodex program_intake -- --nocapture
- cargo check --all-features --all-targets --workspace
- cargo clippy --all-features --all-targets --workspace -- -D warnings
- git diff --check

Note: cargo fmt --package decodex --check still fails on pre-existing repo-wide rustfmt drift outside this patch.