### PR TITLE
Migrate legacy Decision Contract readiness fields

### DIFF
--- a/apps/decodex/src/orchestrator/tests/operator/status/text.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/text.rs
@@ -830,6 +830,10 @@ fn operator_status_readback_uses_migrated_legacy_flat_decision_contracts() {
 		String::from("proposed_issue_summaries"),
 		serde_json::json!(["Legacy flat summary that must not be re-admitted."]),
 	);
+	readiness.insert(
+		String::from("queue_intent"),
+		serde_json::json!(["Legacy queue intent that must not be re-admitted."]),
+	);
 
 	{
 		let connection = Connection::open(&state_path).expect("sqlite should open");

--- a/apps/decodex/src/state/internal.rs
+++ b/apps/decodex/src/state/internal.rs
@@ -1020,6 +1020,7 @@ ON CONFLICT(key) DO UPDATE SET value =
 				"SELECT project_id, contract_id, payload_json
 				 FROM decision_contracts
 				 WHERE json_type(payload_json, '$.execution_readiness.proposed_issue_summaries') IS NOT NULL
+				 OR json_type(payload_json, '$.execution_readiness.queue_intent') IS NOT NULL
 				 ORDER BY project_id ASC, contract_id ASC",
 			)?;
 			let rows = statement.query_map([], |row| {
@@ -5578,6 +5579,7 @@ fn migrate_legacy_decision_contract_payload(payload_json: &str) -> Result<String
 		.and_then(Value::as_object_mut)
 		.ok_or_else(|| eyre::eyre!("Decision Contract payload missing execution_readiness."))?;
 	let summaries = readiness.remove("proposed_issue_summaries");
+	readiness.remove("queue_intent");
 
 	let should_insert_issues = readiness
 		.get("proposed_issues")

--- a/apps/decodex/src/state/tests.rs
+++ b/apps/decodex/src/state/tests.rs
@@ -4543,6 +4543,10 @@ fn decision_contract_reload_migrates_legacy_flat_issue_summary_rows() {
 		String::from("proposed_issue_summaries"),
 		serde_json::json!(["Legacy flat summary that must not be compiled."]),
 	);
+	readiness.insert(
+		String::from("queue_intent"),
+		serde_json::json!(["Legacy queue intent that must not be re-admitted."]),
+	);
 
 	let connection = Connection::open(&state_path).expect("sqlite should open");
 
@@ -4606,6 +4610,10 @@ fn decision_contract_reload_migrates_legacy_flat_issue_summary_rows() {
 	assert!(
 		migrated_value.pointer("/execution_readiness/proposed_issue_summaries").is_none(),
 		"legacy field should be removed after migration"
+	);
+	assert!(
+		migrated_value.pointer("/execution_readiness/queue_intent").is_none(),
+		"legacy queue intent should be removed after migration"
 	);
 }
 

--- a/docs/spec/loop-runtime.md
+++ b/docs/spec/loop-runtime.md
@@ -175,11 +175,12 @@ least one structured proposed issue fail readiness validation and cannot be
 materialized for goal intake or Program Intake.
 
 Runtime schema migration may rewrite old local SQLite payloads that still carry
-`execution_readiness.proposed_issue_summaries`. That rewrite is a one-time data
-migration only: each legacy summary becomes a structured `proposed_issues[]` entry
-with `handoff` stage and `not_ready` queue intent so operators can inspect and revise
-the contract. Normal readback, status, Program Intake, and compile paths remain strict
-and must not treat the removed flat field as a supported compatibility input.
+`execution_readiness.proposed_issue_summaries` or
+`execution_readiness.queue_intent`. That rewrite is a one-time data migration only:
+each legacy summary becomes a structured `proposed_issues[]` entry with `handoff`
+stage and `not_ready` queue intent so operators can inspect and revise the contract.
+Normal readback, status, Program Intake, and compile paths remain strict and must not
+treat the removed flat fields as supported compatibility input.
 
 Decision Contracts are top-level snapshots. Terminal status, selected option, material
 evidence, unresolved gaps, validation expectations, and promotion target must be

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -96,10 +96,11 @@ state or this state machine.
   Decision Contract writes. They update the SQLite `decision_contracts` surface and do
   not by themselves create Linear issues, queue intent, goals, or executable lanes.
 - Runtime schema migration owns legacy Decision Contract payload rewrites. Schema 12
-  removes legacy `execution_readiness.proposed_issue_summaries` rows from SQLite by
-  converting them into structured `proposed_issues[]` with `handoff` stage and
-  `not_ready` queue intent. After migration, normal Decision Contract readback is
-  strict: it does not skip, quarantine, or compile the removed flat field.
+  removes legacy `execution_readiness.proposed_issue_summaries` and
+  `execution_readiness.queue_intent` rows from SQLite by converting summaries into
+  structured `proposed_issues[]` with `handoff` stage and `not_ready` queue intent.
+  After migration, normal Decision Contract readback is strict: it does not skip,
+  quarantine, or compile the removed flat fields.
 - `decodex mcp serve --transport stdio` is the local MCP gateway for desktop and CLI
   clients. The stdio gateway advertises resources, resource templates, prompts, tools,
   logging compatibility, and progress notifications. Resources read checked-in docs,


### PR DESCRIPTION
## Summary
- extend schema 12 legacy Decision Contract migration to remove execution_readiness.queue_intent as well as proposed_issue_summaries
- cover legacy payloads matching the local runtime DB shape that blocked the server restart
- document that removed flat readiness fields are migration-only inputs, not supported readback or Program Intake compatibility

## Validation
- cargo test -p decodex decision_contract_reload_migrates_legacy_flat_issue_summary_rows -- --nocapture
- cargo test -p decodex operator_status_readback_uses_migrated_legacy_flat_decision_contracts -- --nocapture
- cargo test -p decodex persistent_open_keeps_protocol_backfill_marker_when_later_migration_fails -- --nocapture
- cargo test -p decodex decision_contract -- --nocapture
- cargo check --all-features --all-targets --workspace
- cargo clippy --all-features --all-targets --workspace -- -D warnings
- git diff --check