### PR TITLE
Split recovery process liveness

### DIFF
--- a/apps/decodex/src/recovery.rs
+++ b/apps/decodex/src/recovery.rs
@@ -32,6 +32,7 @@ mod events;
 mod evidence;
 mod git_worktree;
 mod identifiers;
+mod process_liveness;
 mod reports;
 mod requests;
 
@@ -69,6 +70,10 @@ use git_worktree::{
 };
 #[cfg(test)]
 use git_worktree::worktree_blocking_status_lines;
+use process_liveness::{
+	StaleActiveProcessLiveness, stale_active_marker_thread_active,
+	stale_active_optional_marker_process_liveness,
+};
 use reports::{
 	GhostLaneDiagnostic, GhostLaneRecoveryReport, ReviewHandoffDiagnostic,
 	ReviewHandoffRecoveryReport, StaleActiveDiagnostic, StaleActiveRecoveryReport,
@@ -5116,80 +5121,6 @@ fn write_merged_closeout_event(
 
 fn landing_url(landing_state: &PullRequestLandingState) -> &str {
 	&landing_state.url
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum StaleActiveProcessLiveness {
-	Alive,
-	NotAlive,
-	Unknown,
-}
-
-fn stale_active_optional_marker_process_liveness(
-	marker: Option<&state::RunActivityMarker>,
-) -> StaleActiveProcessLiveness {
-	marker.map(stale_active_marker_process_liveness).unwrap_or(StaleActiveProcessLiveness::Unknown)
-}
-
-fn stale_active_marker_process_liveness(
-	marker: &state::RunActivityMarker,
-) -> StaleActiveProcessLiveness {
-	let Some(process_id) = marker.process_id() else {
-		return StaleActiveProcessLiveness::Unknown;
-	};
-
-	if !stale_active_process_is_alive(process_id) {
-		return StaleActiveProcessLiveness::NotAlive;
-	}
-	let Some(marker_host_boot_id) = marker.host_boot_id() else {
-		return StaleActiveProcessLiveness::Unknown;
-	};
-	let Some(current_host_boot_id) = state::current_host_boot_id() else {
-		return StaleActiveProcessLiveness::Unknown;
-	};
-
-	if marker_host_boot_id != current_host_boot_id.as_str() {
-		return StaleActiveProcessLiveness::NotAlive;
-	}
-
-	let Some(marker_process_start_identity) = marker.process_start_identity() else {
-		return StaleActiveProcessLiveness::Unknown;
-	};
-	let Some(current_process_start_identity) = state::process_start_identity(process_id) else {
-		return StaleActiveProcessLiveness::Unknown;
-	};
-
-	if marker_process_start_identity == current_process_start_identity.as_str() {
-		StaleActiveProcessLiveness::Alive
-	} else {
-		StaleActiveProcessLiveness::NotAlive
-	}
-}
-
-fn stale_active_marker_thread_active(marker: &state::RunActivityMarker) -> bool {
-	matches!(marker.thread_status(), Some("active")) || !marker.thread_active_flags().is_empty()
-}
-
-#[cfg(unix)]
-fn stale_active_process_is_alive(process_id: u32) -> bool {
-	let Ok(process_id) = libc::pid_t::try_from(process_id) else {
-		return false;
-	};
-
-	if process_id <= 0 {
-		return false;
-	}
-
-	match unsafe { libc::kill(process_id, 0) } {
-		0 => true,
-		-1 => matches!(std::io::Error::last_os_error().raw_os_error(), Some(libc::EPERM)),
-		_ => false,
-	}
-}
-
-#[cfg(not(unix))]
-fn stale_active_process_is_alive(_process_id: u32) -> bool {
-	false
 }
 
 fn relative_worktree_path_for_recovery(

--- a/apps/decodex/src/recovery/process_liveness.rs
+++ b/apps/decodex/src/recovery/process_liveness.rs
@@ -1,0 +1,77 @@
+//! Process and thread liveness predicates for stale-active recovery.
+
+use crate::state;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum StaleActiveProcessLiveness {
+	Alive,
+	NotAlive,
+	Unknown,
+}
+
+pub(super) fn stale_active_optional_marker_process_liveness(
+	marker: Option<&state::RunActivityMarker>,
+) -> StaleActiveProcessLiveness {
+	marker.map(stale_active_marker_process_liveness).unwrap_or(StaleActiveProcessLiveness::Unknown)
+}
+
+fn stale_active_marker_process_liveness(
+	marker: &state::RunActivityMarker,
+) -> StaleActiveProcessLiveness {
+	let Some(process_id) = marker.process_id() else {
+		return StaleActiveProcessLiveness::Unknown;
+	};
+
+	if !stale_active_process_is_alive(process_id) {
+		return StaleActiveProcessLiveness::NotAlive;
+	}
+	let Some(marker_host_boot_id) = marker.host_boot_id() else {
+		return StaleActiveProcessLiveness::Unknown;
+	};
+	let Some(current_host_boot_id) = state::current_host_boot_id() else {
+		return StaleActiveProcessLiveness::Unknown;
+	};
+
+	if marker_host_boot_id != current_host_boot_id.as_str() {
+		return StaleActiveProcessLiveness::NotAlive;
+	}
+
+	let Some(marker_process_start_identity) = marker.process_start_identity() else {
+		return StaleActiveProcessLiveness::Unknown;
+	};
+	let Some(current_process_start_identity) = state::process_start_identity(process_id) else {
+		return StaleActiveProcessLiveness::Unknown;
+	};
+
+	if marker_process_start_identity == current_process_start_identity.as_str() {
+		StaleActiveProcessLiveness::Alive
+	} else {
+		StaleActiveProcessLiveness::NotAlive
+	}
+}
+
+pub(super) fn stale_active_marker_thread_active(marker: &state::RunActivityMarker) -> bool {
+	matches!(marker.thread_status(), Some("active")) || !marker.thread_active_flags().is_empty()
+}
+
+#[cfg(unix)]
+fn stale_active_process_is_alive(process_id: u32) -> bool {
+	let Ok(process_id) = libc::pid_t::try_from(process_id) else {
+		return false;
+	};
+
+	if process_id <= 0 {
+		return false;
+	}
+
+	match unsafe { libc::kill(process_id, 0) } {
+		0 => true,
+		-1 => matches!(std::io::Error::last_os_error().raw_os_error(), Some(libc::EPERM)),
+		_ => false,
+	}
+}
+
+#[cfg(not(unix))]
+fn stale_active_process_is_alive(_process_id: u32) -> bool {
+	false
+}


### PR DESCRIPTION
## Summary
- move stale-active marker process/thread liveness helpers into `recovery/process_liveness.rs`
- keep recovery.rs focused on recovery orchestration and diagnostic flow
- expose only the `pub(super)` liveness enum and predicates consumed by stale-active recovery

## Validation
- rustfmt --edition 2024 --check apps/decodex/src/recovery/process_liveness.rs
- cargo check -p decodex --all-targets --all-features
- cargo test -p decodex --all-features recovery -- --nocapture
- git diff --check

Authority: XY-1115