### PR TITLE
Split stale active label inspection

### DIFF
--- a/apps/decodex/src/recovery.rs
+++ b/apps/decodex/src/recovery.rs
@@ -35,6 +35,7 @@ mod identifiers;
 mod process_liveness;
 mod reports;
 mod requests;
+mod stale_active_labels;
 mod stale_active_reentry;
 
 use context::{
@@ -80,6 +81,11 @@ use reports::{
 	ReviewHandoffRecoveryReport, StaleActiveDiagnostic, StaleActiveRecoveryReport,
 	render_ghost_lane_issue, render_ghost_lane_recovery_report,
 	render_review_handoff_recovery_report, render_stale_active_recovery_report,
+};
+use stale_active_labels::{
+	inspect_stale_active_labels, inspect_stale_active_shared_claim,
+	stale_active_diagnostic_issue_keys, stale_active_issue_has_active_shared_claim,
+	stale_active_tracker_issue_keys,
 };
 use stale_active_reentry::{
 	StaleActiveReleaseReentryInput, apply_stale_active_release_reentries, evidence_contains,
@@ -1639,99 +1645,6 @@ where
 		.ok_or_else(|| eyre::eyre!("No tracker issue matched `{selector}`."))
 }
 
-fn stale_active_issue_keys(issue_id: &str, issue_identifier: &str) -> Vec<String> {
-	let mut keys = vec![issue_id.to_owned()];
-
-	if issue_identifier != issue_id {
-		keys.push(issue_identifier.to_owned());
-	}
-	keys
-}
-
-fn stale_active_tracker_issue_keys(issue: &TrackerIssue) -> Vec<String> {
-	stale_active_issue_keys(&issue.id, &issue.identifier)
-}
-
-fn stale_active_diagnostic_issue_keys(diagnostic: &StaleActiveDiagnostic) -> Vec<String> {
-	stale_active_issue_keys(&diagnostic.issue_id, &diagnostic.issue_identifier)
-}
-
-struct StaleActiveLabelSnapshot {
-	queue_label_present: bool,
-	active_label_present: bool,
-	needs_attention_label_present: bool,
-}
-
-fn inspect_stale_active_labels<T>(
-	project_id: &str,
-	workflow: &WorkflowDocument,
-	tracker: &T,
-	issue: &TrackerIssue,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) -> Result<StaleActiveLabelSnapshot>
-where
-	T: IssueTracker + ?Sized,
-{
-	let active_label = tracker::automation_active_label(project_id);
-	let queue_label = tracker::automation_queue_label(project_id);
-	let needs_attention_label = workflow.frontmatter().tracker().needs_attention_label();
-	let active_label_present =
-		tracker::issue_has_label_with_server_confirmation(tracker, issue, &active_label)?;
-	let queue_label_present =
-		tracker::issue_has_label_with_server_confirmation(tracker, issue, &queue_label)?;
-	let needs_attention_label_present =
-		tracker::issue_has_label_with_server_confirmation(tracker, issue, needs_attention_label)?;
-
-	if active_label_present {
-		evidence.push(String::from("active_label_present"));
-	} else {
-		blockers.push(String::from("active_label_missing"));
-	}
-	if queue_label_present {
-		evidence.push(String::from("queue_label_present"));
-	} else {
-		evidence.push(String::from("queue_label_missing"));
-	}
-	if needs_attention_label_present {
-		blockers.push(String::from("needs_attention_label_present"));
-	} else {
-		evidence.push(String::from("needs_attention_label_missing"));
-	}
-
-	Ok(StaleActiveLabelSnapshot {
-		queue_label_present,
-		active_label_present,
-		needs_attention_label_present,
-	})
-}
-
-fn inspect_stale_active_shared_claim(
-	project_id: &str,
-	state_store: &StateStore,
-	issue_keys: &[String],
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) -> bool {
-	let active_shared_claim =
-		match stale_active_issue_has_active_shared_claim(project_id, state_store, issue_keys) {
-			Ok(active_shared_claim) => active_shared_claim,
-			Err(error) => {
-				blockers.push(String::from("active_shared_claim_unknown"));
-				evidence.push(format!("active_shared_claim_error:{}", error));
-
-				false
-			},
-		};
-	if active_shared_claim {
-		blockers.push(String::from("active_shared_claim_present"));
-	} else if !blockers.iter().any(|blocker| blocker == "active_shared_claim_unknown") {
-		evidence.push(String::from("active_shared_claim_missing"));
-	}
-
-	active_shared_claim
-}
-
 fn inspect_stale_active_issue<T>(
 	project_id: &str,
 	workflow: &WorkflowDocument,
@@ -1944,20 +1857,6 @@ fn stale_active_runs(
 	});
 
 	Ok(runs)
-}
-
-fn stale_active_issue_has_active_shared_claim(
-	project_id: &str,
-	state_store: &StateStore,
-	issue_keys: &[String],
-) -> Result<bool> {
-	for issue_key in issue_keys {
-		if state_store.issue_has_active_shared_claim_read_only(project_id, issue_key)? {
-			return Ok(true);
-		}
-	}
-
-	Ok(false)
 }
 
 fn stale_active_worktree_mapping_for_keys(

--- a/apps/decodex/src/recovery/stale_active_labels.rs
+++ b/apps/decodex/src/recovery/stale_active_labels.rs
@@ -1,0 +1,119 @@
+//! Tracker label and shared-claim inspection for stale-active recovery.
+
+use crate::{
+	prelude::Result,
+	state::StateStore,
+	tracker::{self, IssueTracker, TrackerIssue},
+	workflow::WorkflowDocument,
+};
+
+use super::reports::StaleActiveDiagnostic;
+
+pub(super) struct StaleActiveLabelSnapshot {
+	pub(super) queue_label_present: bool,
+	pub(super) active_label_present: bool,
+	pub(super) needs_attention_label_present: bool,
+}
+
+pub(super) fn stale_active_tracker_issue_keys(issue: &TrackerIssue) -> Vec<String> {
+	stale_active_issue_keys(&issue.id, &issue.identifier)
+}
+
+pub(super) fn stale_active_diagnostic_issue_keys(
+	diagnostic: &StaleActiveDiagnostic,
+) -> Vec<String> {
+	stale_active_issue_keys(&diagnostic.issue_id, &diagnostic.issue_identifier)
+}
+
+pub(super) fn inspect_stale_active_labels<T>(
+	project_id: &str,
+	workflow: &WorkflowDocument,
+	tracker: &T,
+	issue: &TrackerIssue,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Result<StaleActiveLabelSnapshot>
+where
+	T: IssueTracker + ?Sized,
+{
+	let active_label = tracker::automation_active_label(project_id);
+	let queue_label = tracker::automation_queue_label(project_id);
+	let needs_attention_label = workflow.frontmatter().tracker().needs_attention_label();
+	let active_label_present =
+		tracker::issue_has_label_with_server_confirmation(tracker, issue, &active_label)?;
+	let queue_label_present =
+		tracker::issue_has_label_with_server_confirmation(tracker, issue, &queue_label)?;
+	let needs_attention_label_present =
+		tracker::issue_has_label_with_server_confirmation(tracker, issue, needs_attention_label)?;
+
+	if active_label_present {
+		evidence.push(String::from("active_label_present"));
+	} else {
+		blockers.push(String::from("active_label_missing"));
+	}
+	if queue_label_present {
+		evidence.push(String::from("queue_label_present"));
+	} else {
+		evidence.push(String::from("queue_label_missing"));
+	}
+	if needs_attention_label_present {
+		blockers.push(String::from("needs_attention_label_present"));
+	} else {
+		evidence.push(String::from("needs_attention_label_missing"));
+	}
+
+	Ok(StaleActiveLabelSnapshot {
+		queue_label_present,
+		active_label_present,
+		needs_attention_label_present,
+	})
+}
+
+pub(super) fn inspect_stale_active_shared_claim(
+	project_id: &str,
+	state_store: &StateStore,
+	issue_keys: &[String],
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> bool {
+	let active_shared_claim =
+		match stale_active_issue_has_active_shared_claim(project_id, state_store, issue_keys) {
+			Ok(active_shared_claim) => active_shared_claim,
+			Err(error) => {
+				blockers.push(String::from("active_shared_claim_unknown"));
+				evidence.push(format!("active_shared_claim_error:{}", error));
+
+				false
+			},
+		};
+	if active_shared_claim {
+		blockers.push(String::from("active_shared_claim_present"));
+	} else if !blockers.iter().any(|blocker| blocker == "active_shared_claim_unknown") {
+		evidence.push(String::from("active_shared_claim_missing"));
+	}
+
+	active_shared_claim
+}
+
+pub(super) fn stale_active_issue_has_active_shared_claim(
+	project_id: &str,
+	state_store: &StateStore,
+	issue_keys: &[String],
+) -> Result<bool> {
+	for issue_key in issue_keys {
+		if state_store.issue_has_active_shared_claim_read_only(project_id, issue_key)? {
+			return Ok(true);
+		}
+	}
+
+	Ok(false)
+}
+
+fn stale_active_issue_keys(issue_id: &str, issue_identifier: &str) -> Vec<String> {
+	let mut keys = vec![issue_id.to_owned()];
+
+	if issue_identifier != issue_id {
+		keys.push(issue_identifier.to_owned());
+	}
+	keys
+}

--- a/apps/decodex/src/recovery/stale_active_reentry.rs
+++ b/apps/decodex/src/recovery/stale_active_reentry.rs
@@ -2,7 +2,7 @@
 
 use crate::{state::ProjectRunStatus, tracker::TrackerIssue, workflow::WorkflowTracker};
 
-use super::{GHOST_LANE_TERMINAL_STATUS, StaleActiveLabelSnapshot};
+use super::{GHOST_LANE_TERMINAL_STATUS, stale_active_labels::StaleActiveLabelSnapshot};
 
 struct StaleActiveStartableStateRestoreReentryInput<'a> {
 	run: Option<&'a ProjectRunStatus>,


### PR DESCRIPTION
## Summary
- move stale-active issue key, tracker label, and shared-claim inspection helpers into recovery/stale_active_labels.rs
- keep recovery.rs as the orchestration flow and expose only pub(super) helpers/snapshot fields
- update stale_active_reentry to read the snapshot from the new normal Rust module

## Validation
- rustfmt --edition 2024 --check apps/decodex/src/recovery/stale_active_labels.rs apps/decodex/src/recovery/stale_active_reentry.rs
- git diff --check
- cargo check -p decodex --all-targets --all-features
- cargo test -p decodex --all-features recovery -- --nocapture

Note: full rustfmt on recovery.rs recursively wants unrelated checked-in formatting changes in sibling modules, so this PR keeps the diff scoped.