### PR TITLE
Move review handoff lineage ownership

### DIFF
--- a/apps/decodex/src/recovery.rs
+++ b/apps/decodex/src/recovery.rs
@@ -64,7 +64,7 @@ use identifiers::{
 	ghost_lane_worktree_selectors,
 };
 use git_worktree::{
-	git_toplevel_path, repository_relative_path, worktree_checkout_branch_name,
+	ReviewHandoffLineage, git_toplevel_path, repository_relative_path, worktree_checkout_branch_name,
 	worktree_has_tracked_changes_for_recovery,
 	worktree_head_descends_from_review_handoff,
 	worktree_head_has_unmerged_commits_against_remote_default, worktree_head_oid,
@@ -281,12 +281,6 @@ impl RebindMode {
 			Self::CompleteExistingHandoffState => "completed retained review handoff state",
 		}
 	}
-}
-
-enum ReviewHandoffLineage {
-	Descends,
-	Diverged,
-	Unknown,
 }
 
 /// Run a read-only retained review handoff diagnostic.

--- a/apps/decodex/src/recovery/git_worktree.rs
+++ b/apps/decodex/src/recovery/git_worktree.rs
@@ -11,7 +11,11 @@ use crate::{
 	state,
 };
 
-use super::ReviewHandoffLineage;
+pub(super) enum ReviewHandoffLineage {
+	Descends,
+	Diverged,
+	Unknown,
+}
 
 pub(super) fn git_toplevel_path(cwd: &Path) -> Result<PathBuf> {
 	let output =


### PR DESCRIPTION
## Summary
- move ReviewHandoffLineage into recovery/git_worktree.rs, where the lineage result is produced
- keep recovery.rs as the caller that matches the returned lineage
- reduce parent recovery module ownership of git-worktree-specific classification details

## Validation
- rustfmt --edition 2024 --check apps/decodex/src/recovery/git_worktree.rs
- git diff --check
- cargo check -p decodex --all-targets --all-features
- cargo test -p decodex --all-features recovery -- --nocapture