### PR TITLE
Split stale active worktree inspection

### DIFF
--- a/apps/decodex/src/recovery.rs
+++ b/apps/decodex/src/recovery.rs
@@ -37,6 +37,7 @@ mod reports;
 mod requests;
 mod stale_active_labels;
 mod stale_active_reentry;
+mod stale_active_worktree;
 
 use context::{
 	RecoveryContext, RecoveryRuntimeMutationPolicy, active_recovery_tracker_backoff_message,
@@ -67,14 +68,12 @@ use git_worktree::{
 	ReviewHandoffLineage, git_toplevel_path, repository_relative_path, worktree_checkout_branch_name,
 	worktree_has_tracked_changes_for_recovery,
 	worktree_head_descends_from_review_handoff,
-	worktree_head_has_unmerged_commits_against_remote_default, worktree_head_oid,
-	worktree_is_clean,
+	worktree_head_oid, worktree_is_clean,
 };
 #[cfg(test)]
 use git_worktree::worktree_blocking_status_lines;
 use process_liveness::{
-	StaleActiveProcessLiveness, stale_active_marker_thread_active,
-	stale_active_optional_marker_process_liveness,
+	StaleActiveProcessLiveness, stale_active_optional_marker_process_liveness,
 };
 use reports::{
 	GhostLaneDiagnostic, GhostLaneRecoveryReport, ReviewHandoffDiagnostic,
@@ -89,6 +88,9 @@ use stale_active_labels::{
 };
 use stale_active_reentry::{
 	StaleActiveReleaseReentryInput, apply_stale_active_release_reentries, evidence_contains,
+};
+use stale_active_worktree::{
+	inspect_stale_active_worktree, stale_active_worktree_mapping_for_keys,
 };
 pub(crate) use requests::{
 	GhostLaneCleanupRequest, GhostLaneDiagnoseRequest, LegacyCloseoutRecoveryRequest,
@@ -1853,38 +1855,6 @@ fn stale_active_runs(
 	Ok(runs)
 }
 
-fn stale_active_worktree_mapping_for_keys(
-	state_store: &StateStore,
-	issue_keys: &[String],
-) -> Result<Option<WorktreeMapping>> {
-	let mut mapping = None;
-
-	for issue_key in issue_keys {
-		let Some(candidate) = state_store.worktree_for_issue(issue_key)? else {
-			continue;
-		};
-		if let Some(existing) = mapping.as_ref() {
-			if stale_active_worktree_mappings_conflict(existing, &candidate) {
-				eyre::bail!(
-					"conflicting retained worktree mappings for stale active issue keys `{}`",
-					issue_keys.join(", ")
-				);
-			}
-		} else {
-			mapping = Some(candidate);
-		}
-	}
-
-	Ok(mapping)
-}
-
-fn stale_active_worktree_mappings_conflict(
-	left: &WorktreeMapping,
-	right: &WorktreeMapping,
-) -> bool {
-	left.branch_name() != right.branch_name() || left.worktree_path() != right.worktree_path()
-}
-
 fn latest_stale_active_run(runs: &[ProjectRunStatus]) -> Option<&ProjectRunStatus> {
 	runs.iter().max_by(|left, right| {
 		left.attempt_number()
@@ -1943,176 +1913,6 @@ fn inspect_stale_active_run_evidence(
 		evidence.push(String::from("stale_thread_reference_present"));
 	} else {
 		evidence.push(String::from("thread_reference_missing"));
-	}
-}
-
-fn inspect_stale_active_worktree(
-	worktree_path: &Path,
-	mapping: Option<&WorktreeMapping>,
-	marker: Option<&state::RunActivityMarker>,
-	marker_liveness: StaleActiveProcessLiveness,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) -> String {
-	if mapping.is_none() {
-		evidence.push(String::from("worktree_mapping_missing"));
-	}
-	match worktree_path.try_exists() {
-		Ok(false) => {
-			evidence.push(String::from("worktree_missing"));
-
-			return String::from("missing");
-		},
-		Ok(true) => {},
-		Err(error) => {
-			blockers.push(String::from("worktree_tracked_changes_unknown"));
-			evidence.push(format!("worktree_status_error:{}", error));
-
-			return String::from("tracked_changes_unknown");
-		},
-	}
-	inspect_stale_active_activity_marker(marker, marker_liveness, evidence, blockers);
-	match worktree_path.join(".git").try_exists() {
-		Ok(false) => {
-			match state::retained_path_contains_only_decodex_runtime_artifacts(worktree_path) {
-				Ok(true) => {
-					evidence.push(String::from("worktree_non_git_marker_directory"));
-
-					return String::from("non_git_marker_directory");
-				},
-				Ok(false) => {
-					blockers.push(String::from("non_git_worktree_files_present"));
-
-					return String::from("non_git_files_present");
-				},
-				Err(error) => {
-					blockers.push(String::from("worktree_tracked_changes_unknown"));
-					evidence.push(format!("worktree_status_error:{}", error));
-
-					return String::from("tracked_changes_unknown");
-				},
-			}
-		},
-		Ok(true) => {},
-		Err(error) => {
-			blockers.push(String::from("worktree_tracked_changes_unknown"));
-			evidence.push(format!("worktree_status_error:{}", error));
-
-			return String::from("tracked_changes_unknown");
-		},
-	}
-	match worktree_has_tracked_changes_for_recovery(worktree_path) {
-		Ok(true) => {
-			blockers.push(String::from("worktree_tracked_changes_present"));
-
-			return String::from("tracked_changes_present");
-		},
-		Ok(false) => {},
-		Err(error) => {
-			blockers.push(String::from("worktree_tracked_changes_unknown"));
-			evidence.push(format!("worktree_status_error:{}", error));
-
-			return String::from("tracked_changes_unknown");
-		},
-	}
-	evidence.push(String::from("worktree_clean"));
-	match worktree_head_has_unmerged_commits_against_remote_default(worktree_path) {
-		Ok(Some(true)) => {
-			blockers.push(String::from("worktree_unmerged_commits_present"));
-
-			return String::from("unmerged_commits_present");
-		},
-		Ok(Some(false)) => {
-			evidence.push(String::from("worktree_head_reachable_from_default_branch"));
-		},
-		Ok(None) => {
-			blockers.push(String::from("worktree_default_branch_unavailable"));
-			evidence.push(String::from("worktree_default_branch_unavailable"));
-
-			return String::from("default_branch_unavailable");
-		},
-		Err(error) => {
-			blockers.push(String::from("worktree_tracked_changes_unknown"));
-			evidence.push(format!("worktree_head_status_error:{}", error));
-
-			return String::from("tracked_changes_unknown");
-		},
-	}
-
-	String::from("clean")
-}
-
-fn inspect_stale_active_activity_marker(
-	marker: Option<&state::RunActivityMarker>,
-	marker_liveness: StaleActiveProcessLiveness,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) {
-	if let Some(marker) = marker {
-		match marker_liveness {
-			StaleActiveProcessLiveness::Alive => blockers.push(String::from("process_alive")),
-			StaleActiveProcessLiveness::NotAlive =>
-				evidence.push(String::from("process_not_alive")),
-			StaleActiveProcessLiveness::Unknown =>
-				blockers.push(String::from("process_liveness_unknown")),
-		}
-		if marker.last_progress_unix_epoch().is_some() {
-			if marker_liveness == StaleActiveProcessLiveness::NotAlive {
-				evidence.push(String::from("stale_activity_marker_progress_present"));
-			} else {
-				blockers.push(String::from("activity_marker_progress_present"));
-			}
-		} else {
-			evidence.push(String::from("activity_marker_progress_missing"));
-		}
-		if marker.event_count() > 0 || marker.last_event_type().is_some() {
-			if marker_liveness == StaleActiveProcessLiveness::NotAlive {
-				evidence.push(String::from("stale_protocol_event_marker_present"));
-			} else {
-				blockers.push(String::from("protocol_event_marker_present"));
-			}
-		} else {
-			evidence.push(String::from("protocol_event_marker_missing"));
-		}
-		if marker.last_protocol_activity_unix_epoch().is_some() {
-			if marker_liveness == StaleActiveProcessLiveness::NotAlive {
-				evidence.push(String::from("stale_activity_marker_protocol_activity_present"));
-			} else {
-				blockers.push(String::from("activity_marker_protocol_activity_present"));
-			}
-		} else {
-			evidence.push(String::from("activity_marker_protocol_activity_missing"));
-		}
-		if marker.child_agent_activity().is_some() {
-			if marker_liveness == StaleActiveProcessLiveness::NotAlive {
-				evidence.push(String::from("stale_activity_marker_child_agent_activity_present"));
-			} else {
-				blockers.push(String::from("activity_marker_child_agent_activity_present"));
-			}
-		} else {
-			evidence.push(String::from("activity_marker_child_agent_activity_missing"));
-		}
-		if marker.protocol_activity().is_some() {
-			if marker_liveness == StaleActiveProcessLiveness::NotAlive {
-				evidence
-					.push(String::from("stale_activity_marker_protocol_activity_summary_present"));
-			} else {
-				blockers.push(String::from("activity_marker_protocol_activity_summary_present"));
-			}
-		} else {
-			evidence.push(String::from("activity_marker_protocol_activity_summary_missing"));
-		}
-		if stale_active_marker_thread_active(marker) {
-			if marker_liveness == StaleActiveProcessLiveness::NotAlive {
-				evidence.push(String::from("stale_activity_marker_thread_active"));
-			} else {
-				blockers.push(String::from("activity_marker_thread_active"));
-			}
-		} else {
-			evidence.push(String::from("activity_marker_thread_inactive"));
-		}
-	} else {
-		evidence.push(String::from("activity_marker_missing"));
 	}
 }
 

--- a/apps/decodex/src/recovery/stale_active_worktree.rs
+++ b/apps/decodex/src/recovery/stale_active_worktree.rs
@@ -1,0 +1,220 @@
+//! Worktree mapping and status inspection for stale-active recovery.
+
+use std::path::Path;
+
+use crate::{
+	prelude::{Result, eyre},
+	state::{self, StateStore, WorktreeMapping},
+};
+
+use super::{
+	git_worktree::{
+		worktree_has_tracked_changes_for_recovery,
+		worktree_head_has_unmerged_commits_against_remote_default,
+	},
+	process_liveness::{StaleActiveProcessLiveness, stale_active_marker_thread_active},
+};
+
+pub(super) fn stale_active_worktree_mapping_for_keys(
+	state_store: &StateStore,
+	issue_keys: &[String],
+) -> Result<Option<WorktreeMapping>> {
+	let mut mapping = None;
+
+	for issue_key in issue_keys {
+		let Some(candidate) = state_store.worktree_for_issue(issue_key)? else {
+			continue;
+		};
+		if let Some(existing) = mapping.as_ref() {
+			if stale_active_worktree_mappings_conflict(existing, &candidate) {
+				eyre::bail!(
+					"conflicting retained worktree mappings for stale active issue keys `{}`",
+					issue_keys.join(", ")
+				);
+			}
+		} else {
+			mapping = Some(candidate);
+		}
+	}
+
+	Ok(mapping)
+}
+
+pub(super) fn inspect_stale_active_worktree(
+	worktree_path: &Path,
+	mapping: Option<&WorktreeMapping>,
+	marker: Option<&state::RunActivityMarker>,
+	marker_liveness: StaleActiveProcessLiveness,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> String {
+	if mapping.is_none() {
+		evidence.push(String::from("worktree_mapping_missing"));
+	}
+	match worktree_path.try_exists() {
+		Ok(false) => {
+			evidence.push(String::from("worktree_missing"));
+
+			return String::from("missing");
+		},
+		Ok(true) => {},
+		Err(error) => {
+			blockers.push(String::from("worktree_tracked_changes_unknown"));
+			evidence.push(format!("worktree_status_error:{}", error));
+
+			return String::from("tracked_changes_unknown");
+		},
+	}
+	inspect_stale_active_activity_marker(marker, marker_liveness, evidence, blockers);
+	match worktree_path.join(".git").try_exists() {
+		Ok(false) => {
+			match state::retained_path_contains_only_decodex_runtime_artifacts(worktree_path) {
+				Ok(true) => {
+					evidence.push(String::from("worktree_non_git_marker_directory"));
+
+					return String::from("non_git_marker_directory");
+				},
+				Ok(false) => {
+					blockers.push(String::from("non_git_worktree_files_present"));
+
+					return String::from("non_git_files_present");
+				},
+				Err(error) => {
+					blockers.push(String::from("worktree_tracked_changes_unknown"));
+					evidence.push(format!("worktree_status_error:{}", error));
+
+					return String::from("tracked_changes_unknown");
+				},
+			}
+		},
+		Ok(true) => {},
+		Err(error) => {
+			blockers.push(String::from("worktree_tracked_changes_unknown"));
+			evidence.push(format!("worktree_status_error:{}", error));
+
+			return String::from("tracked_changes_unknown");
+		},
+	}
+	match worktree_has_tracked_changes_for_recovery(worktree_path) {
+		Ok(true) => {
+			blockers.push(String::from("worktree_tracked_changes_present"));
+
+			return String::from("tracked_changes_present");
+		},
+		Ok(false) => {},
+		Err(error) => {
+			blockers.push(String::from("worktree_tracked_changes_unknown"));
+			evidence.push(format!("worktree_status_error:{}", error));
+
+			return String::from("tracked_changes_unknown");
+		},
+	}
+	evidence.push(String::from("worktree_clean"));
+	match worktree_head_has_unmerged_commits_against_remote_default(worktree_path) {
+		Ok(Some(true)) => {
+			blockers.push(String::from("worktree_unmerged_commits_present"));
+
+			return String::from("unmerged_commits_present");
+		},
+		Ok(Some(false)) => {
+			evidence.push(String::from("worktree_head_reachable_from_default_branch"));
+		},
+		Ok(None) => {
+			blockers.push(String::from("worktree_default_branch_unavailable"));
+			evidence.push(String::from("worktree_default_branch_unavailable"));
+
+			return String::from("default_branch_unavailable");
+		},
+		Err(error) => {
+			blockers.push(String::from("worktree_tracked_changes_unknown"));
+			evidence.push(format!("worktree_head_status_error:{}", error));
+
+			return String::from("tracked_changes_unknown");
+		},
+	}
+
+	String::from("clean")
+}
+
+fn stale_active_worktree_mappings_conflict(
+	left: &WorktreeMapping,
+	right: &WorktreeMapping,
+) -> bool {
+	left.branch_name() != right.branch_name() || left.worktree_path() != right.worktree_path()
+}
+
+fn inspect_stale_active_activity_marker(
+	marker: Option<&state::RunActivityMarker>,
+	marker_liveness: StaleActiveProcessLiveness,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) {
+	if let Some(marker) = marker {
+		match marker_liveness {
+			StaleActiveProcessLiveness::Alive => blockers.push(String::from("process_alive")),
+			StaleActiveProcessLiveness::NotAlive => {
+				evidence.push(String::from("process_not_alive"))
+			},
+			StaleActiveProcessLiveness::Unknown => {
+				blockers.push(String::from("process_liveness_unknown"))
+			},
+		}
+		if marker.last_progress_unix_epoch().is_some() {
+			if marker_liveness == StaleActiveProcessLiveness::NotAlive {
+				evidence.push(String::from("stale_activity_marker_progress_present"));
+			} else {
+				blockers.push(String::from("activity_marker_progress_present"));
+			}
+		} else {
+			evidence.push(String::from("activity_marker_progress_missing"));
+		}
+		if marker.event_count() > 0 || marker.last_event_type().is_some() {
+			if marker_liveness == StaleActiveProcessLiveness::NotAlive {
+				evidence.push(String::from("stale_protocol_event_marker_present"));
+			} else {
+				blockers.push(String::from("protocol_event_marker_present"));
+			}
+		} else {
+			evidence.push(String::from("protocol_event_marker_missing"));
+		}
+		if marker.last_protocol_activity_unix_epoch().is_some() {
+			if marker_liveness == StaleActiveProcessLiveness::NotAlive {
+				evidence.push(String::from("stale_activity_marker_protocol_activity_present"));
+			} else {
+				blockers.push(String::from("activity_marker_protocol_activity_present"));
+			}
+		} else {
+			evidence.push(String::from("activity_marker_protocol_activity_missing"));
+		}
+		if marker.child_agent_activity().is_some() {
+			if marker_liveness == StaleActiveProcessLiveness::NotAlive {
+				evidence.push(String::from("stale_activity_marker_child_agent_activity_present"));
+			} else {
+				blockers.push(String::from("activity_marker_child_agent_activity_present"));
+			}
+		} else {
+			evidence.push(String::from("activity_marker_child_agent_activity_missing"));
+		}
+		if marker.protocol_activity().is_some() {
+			if marker_liveness == StaleActiveProcessLiveness::NotAlive {
+				evidence
+					.push(String::from("stale_activity_marker_protocol_activity_summary_present"));
+			} else {
+				blockers.push(String::from("activity_marker_protocol_activity_summary_present"));
+			}
+		} else {
+			evidence.push(String::from("activity_marker_protocol_activity_summary_missing"));
+		}
+		if stale_active_marker_thread_active(marker) {
+			if marker_liveness == StaleActiveProcessLiveness::NotAlive {
+				evidence.push(String::from("stale_activity_marker_thread_active"));
+			} else {
+				blockers.push(String::from("activity_marker_thread_active"));
+			}
+		} else {
+			evidence.push(String::from("activity_marker_thread_inactive"));
+		}
+	} else {
+		evidence.push(String::from("activity_marker_missing"));
+	}
+}


### PR DESCRIPTION
## Summary
- move stale-active worktree mapping and retained worktree status inspection into recovery/stale_active_worktree.rs
- keep recovery.rs responsible for diagnostic orchestration and cleanup preflight calls
- keep the new module surface narrow: pub(super) mapping lookup plus worktree inspection

## Validation
- rustfmt --edition 2024 --check apps/decodex/src/recovery/stale_active_worktree.rs
- git diff --check
- cargo check -p decodex --all-targets --all-features
- cargo test -p decodex --all-features recovery -- --nocapture