### PR TITLE
Split stale active authority checks

### DIFF
--- a/apps/decodex/src/recovery.rs
+++ b/apps/decodex/src/recovery.rs
@@ -35,6 +35,7 @@ mod identifiers;
 mod process_liveness;
 mod reports;
 mod requests;
+mod stale_active_authority;
 mod stale_active_labels;
 mod stale_active_reentry;
 mod stale_active_runtime;
@@ -58,8 +59,7 @@ use evidence::{
 	ghost_lane_private_event_is_cleanup_audit,
 	ghost_lane_private_events_are_cleanup_audit_evidence,
 	ghost_lane_private_events_are_mcp_test_recovery_evidence,
-	ghost_lane_record_has_pr_or_review_lineage, stale_active_private_event_allows_release,
-	stale_active_private_event_is_release_audit_for_run,
+	ghost_lane_record_has_pr_or_review_lineage,
 };
 use identifiers::{
 	ghost_lane_issue_identifier, ghost_lane_run_matches_selector, ghost_lane_tracker_issue_selectors,
@@ -79,6 +79,10 @@ use reports::{
 	ReviewHandoffRecoveryReport, StaleActiveDiagnostic, StaleActiveRecoveryReport,
 	render_ghost_lane_issue, render_ghost_lane_recovery_report,
 	render_review_handoff_recovery_report, render_stale_active_recovery_report,
+};
+use stale_active_authority::{
+	ensure_stale_active_review_authority_missing, inspect_stale_active_private_evidence,
+	inspect_stale_active_review_lineage,
 };
 use stale_active_labels::{
 	inspect_stale_active_labels, inspect_stale_active_shared_claim,
@@ -1819,84 +1823,6 @@ fn stale_active_diagnostic_outcome(
 	}
 }
 
-fn inspect_stale_active_private_evidence(
-	project_id: &str,
-	state_store: &StateStore,
-	issue_keys: &[String],
-	latest_run: Option<&ProjectRunStatus>,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) -> Result<()> {
-	let mut events = Vec::new();
-
-	for issue_key in issue_keys {
-		events.extend(state_store.list_private_execution_events_for_issue(project_id, issue_key)?);
-	}
-
-	if events.is_empty() {
-		evidence.push(String::from("private_evidence_missing"));
-	} else {
-		if events
-			.iter()
-			.any(|event| stale_active_private_event_is_release_audit_for_run(event, latest_run))
-		{
-			evidence.push(String::from("stale_active_release_audit_present"));
-		}
-		if events.iter().all(stale_active_private_event_allows_release) {
-			evidence.push(String::from("only_stale_active_or_failed_control_evidence_present"));
-		} else {
-			blockers.push(String::from("private_progress_evidence_present"));
-		}
-	}
-
-	Ok(())
-}
-
-fn inspect_stale_active_review_lineage<T>(
-	project_id: &str,
-	state_store: &StateStore,
-	tracker: &T,
-	issue: &TrackerIssue,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) -> Result<()>
-where
-	T: IssueTracker + ?Sized,
-{
-	if state_store.issue_has_review_lifecycle_record(project_id, &issue.id)?
-		|| (issue.identifier != issue.id
-			&& state_store.issue_has_review_lifecycle_record(project_id, &issue.identifier)?)
-	{
-		blockers.push(String::from("review_lifecycle_present"));
-
-		return Ok(());
-	}
-	if state_store.issue_has_review_policy_checkpoint(project_id, &issue.id)?
-		|| (issue.identifier != issue.id
-			&& state_store.issue_has_review_policy_checkpoint(project_id, &issue.identifier)?)
-	{
-		blockers.push(String::from("review_policy_checkpoint_present"));
-
-		return Ok(());
-	}
-
-	let records = stale_active_review_lineage_records(
-		project_id,
-		state_store,
-		tracker,
-		&issue.id,
-		&issue.identifier,
-	)?;
-
-	if records.iter().any(ghost_lane_record_has_pr_or_review_lineage) {
-		blockers.push(String::from("pr_or_review_lineage_present"));
-	} else {
-		evidence.push(String::from("review_lineage_missing"));
-	}
-
-	Ok(())
-}
-
 fn inspect_ghost_lane_tracker_issue<T>(
 	tracker: &T,
 	run: &ProjectRunStatus,
@@ -2428,88 +2354,6 @@ fn ensure_stale_active_run_claim_guard(
 			error
 		),
 	}
-}
-
-fn ensure_stale_active_review_authority_missing<T>(
-	tracker: &T,
-	state_store: &StateStore,
-	diagnostic: &StaleActiveDiagnostic,
-) -> Result<()>
-where
-	T: IssueTracker + ?Sized,
-{
-	let mut blockers = Vec::new();
-
-	if state_store
-		.issue_has_review_lifecycle_record(&diagnostic.project_id, &diagnostic.issue_id)?
-		|| (diagnostic.issue_identifier != diagnostic.issue_id
-			&& state_store.issue_has_review_lifecycle_record(
-				&diagnostic.project_id,
-				&diagnostic.issue_identifier,
-			)?) {
-		blockers.push("review_lifecycle_present");
-	}
-	if state_store
-		.issue_has_review_policy_checkpoint(&diagnostic.project_id, &diagnostic.issue_id)?
-		|| (diagnostic.issue_identifier != diagnostic.issue_id
-			&& state_store.issue_has_review_policy_checkpoint(
-				&diagnostic.project_id,
-				&diagnostic.issue_identifier,
-			)?) {
-		blockers.push("review_policy_checkpoint_present");
-	}
-
-	let records = stale_active_review_lineage_records(
-		&diagnostic.project_id,
-		state_store,
-		tracker,
-		&diagnostic.issue_id,
-		&diagnostic.issue_identifier,
-	)?;
-	if records.iter().any(ghost_lane_record_has_pr_or_review_lineage) {
-		blockers.push("pr_or_review_lineage_present");
-	}
-
-	if blockers.is_empty() {
-		return Ok(());
-	}
-
-	eyre::bail!(
-		"`recover stale-active release` refused `{}` because review authority appeared before active-label release: {}",
-		diagnostic.issue_identifier,
-		blockers.join(", ")
-	)
-}
-
-fn stale_active_review_lineage_records<T>(
-	project_id: &str,
-	state_store: &StateStore,
-	tracker: &T,
-	issue_id: &str,
-	issue_identifier: &str,
-) -> Result<Vec<LinearExecutionEventRecord>>
-where
-	T: IssueTracker + ?Sized,
-{
-	let mut records = state_store.list_linear_execution_events(project_id, issue_id)?;
-
-	if issue_identifier != issue_id {
-		records.extend(state_store.list_linear_execution_events(project_id, issue_identifier)?);
-	}
-
-	let comments = tracker.list_comments(issue_id)?;
-
-	records.extend(comments.iter().filter_map(|comment| {
-		records::parse_linear_execution_event_record(&comment.body).filter(|record| {
-			record.service_id == project_id
-				&& (record.issue_id == issue_id
-					|| record.issue_id == issue_identifier
-					|| record.issue_identifier == issue_identifier
-					|| record.issue_identifier == issue_id)
-		})
-	}));
-
-	Ok(records)
 }
 
 #[derive(Clone, Debug)]

--- a/apps/decodex/src/recovery/stale_active_authority.rs
+++ b/apps/decodex/src/recovery/stale_active_authority.rs
@@ -1,0 +1,178 @@
+//! Private evidence and review authority checks for stale-active recovery.
+
+use crate::{
+	prelude::{Result, eyre},
+	state::{ProjectRunStatus, StateStore},
+	tracker::{
+		IssueTracker, TrackerIssue,
+		records::{self, LinearExecutionEventRecord},
+	},
+};
+
+use super::{
+	evidence::{
+		ghost_lane_record_has_pr_or_review_lineage, stale_active_private_event_allows_release,
+		stale_active_private_event_is_release_audit_for_run,
+	},
+	reports::StaleActiveDiagnostic,
+};
+
+pub(super) fn inspect_stale_active_private_evidence(
+	project_id: &str,
+	state_store: &StateStore,
+	issue_keys: &[String],
+	latest_run: Option<&ProjectRunStatus>,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Result<()> {
+	let mut events = Vec::new();
+
+	for issue_key in issue_keys {
+		events.extend(state_store.list_private_execution_events_for_issue(project_id, issue_key)?);
+	}
+
+	if events.is_empty() {
+		evidence.push(String::from("private_evidence_missing"));
+	} else {
+		if events
+			.iter()
+			.any(|event| stale_active_private_event_is_release_audit_for_run(event, latest_run))
+		{
+			evidence.push(String::from("stale_active_release_audit_present"));
+		}
+		if events.iter().all(stale_active_private_event_allows_release) {
+			evidence.push(String::from("only_stale_active_or_failed_control_evidence_present"));
+		} else {
+			blockers.push(String::from("private_progress_evidence_present"));
+		}
+	}
+
+	Ok(())
+}
+
+pub(super) fn inspect_stale_active_review_lineage<T>(
+	project_id: &str,
+	state_store: &StateStore,
+	tracker: &T,
+	issue: &TrackerIssue,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Result<()>
+where
+	T: IssueTracker + ?Sized,
+{
+	if state_store.issue_has_review_lifecycle_record(project_id, &issue.id)?
+		|| (issue.identifier != issue.id
+			&& state_store.issue_has_review_lifecycle_record(project_id, &issue.identifier)?)
+	{
+		blockers.push(String::from("review_lifecycle_present"));
+
+		return Ok(());
+	}
+	if state_store.issue_has_review_policy_checkpoint(project_id, &issue.id)?
+		|| (issue.identifier != issue.id
+			&& state_store.issue_has_review_policy_checkpoint(project_id, &issue.identifier)?)
+	{
+		blockers.push(String::from("review_policy_checkpoint_present"));
+
+		return Ok(());
+	}
+
+	let records = stale_active_review_lineage_records(
+		project_id,
+		state_store,
+		tracker,
+		&issue.id,
+		&issue.identifier,
+	)?;
+
+	if records.iter().any(ghost_lane_record_has_pr_or_review_lineage) {
+		blockers.push(String::from("pr_or_review_lineage_present"));
+	} else {
+		evidence.push(String::from("review_lineage_missing"));
+	}
+
+	Ok(())
+}
+
+pub(super) fn ensure_stale_active_review_authority_missing<T>(
+	tracker: &T,
+	state_store: &StateStore,
+	diagnostic: &StaleActiveDiagnostic,
+) -> Result<()>
+where
+	T: IssueTracker + ?Sized,
+{
+	let mut blockers = Vec::new();
+
+	if state_store
+		.issue_has_review_lifecycle_record(&diagnostic.project_id, &diagnostic.issue_id)?
+		|| (diagnostic.issue_identifier != diagnostic.issue_id
+			&& state_store.issue_has_review_lifecycle_record(
+				&diagnostic.project_id,
+				&diagnostic.issue_identifier,
+			)?) {
+		blockers.push("review_lifecycle_present");
+	}
+	if state_store
+		.issue_has_review_policy_checkpoint(&diagnostic.project_id, &diagnostic.issue_id)?
+		|| (diagnostic.issue_identifier != diagnostic.issue_id
+			&& state_store.issue_has_review_policy_checkpoint(
+				&diagnostic.project_id,
+				&diagnostic.issue_identifier,
+			)?) {
+		blockers.push("review_policy_checkpoint_present");
+	}
+
+	let records = stale_active_review_lineage_records(
+		&diagnostic.project_id,
+		state_store,
+		tracker,
+		&diagnostic.issue_id,
+		&diagnostic.issue_identifier,
+	)?;
+	if records.iter().any(ghost_lane_record_has_pr_or_review_lineage) {
+		blockers.push("pr_or_review_lineage_present");
+	}
+
+	if blockers.is_empty() {
+		return Ok(());
+	}
+
+	eyre::bail!(
+		"`recover stale-active release` refused `{}` because review authority appeared before active-label release: {}",
+		diagnostic.issue_identifier,
+		blockers.join(", ")
+	)
+}
+
+fn stale_active_review_lineage_records<T>(
+	project_id: &str,
+	state_store: &StateStore,
+	tracker: &T,
+	issue_id: &str,
+	issue_identifier: &str,
+) -> Result<Vec<LinearExecutionEventRecord>>
+where
+	T: IssueTracker + ?Sized,
+{
+	let mut records = state_store.list_linear_execution_events(project_id, issue_id)?;
+
+	if issue_identifier != issue_id {
+		records.extend(state_store.list_linear_execution_events(project_id, issue_identifier)?);
+	}
+
+	let comments = tracker.list_comments(issue_id)?;
+
+	records.extend(comments.iter().filter_map(|comment| {
+		records::parse_linear_execution_event_record(&comment.body).filter(|record| {
+			record.service_id == project_id
+				&& (record.issue_id == issue_id
+					|| record.issue_id == issue_identifier
+					|| record.issue_identifier == issue_identifier
+					|| record.issue_identifier == issue_id)
+		})
+	}));
+
+	Ok(records)
+}


### PR DESCRIPTION
## Summary
- move stale-active private evidence inspection into recovery/stale_active_authority.rs
- move stale-active review lineage inspection and final review-authority guard into the same module
- keep recovery.rs focused on diagnostic and release orchestration, with a narrow pub(super) module surface

## Validation
- rustfmt --edition 2024 --check apps/decodex/src/recovery/stale_active_authority.rs
- git diff --check
- cargo check -p decodex --all-targets --all-features
- cargo test -p decodex --all-features recovery -- --nocapture