### PR TITLE
Split Radar GitHub bundle client

### DIFF
--- a/apps/decodex/src/radar.rs
+++ b/apps/decodex/src/radar.rs
@@ -9,16 +9,11 @@ use std::{
 	path::{Path, PathBuf},
 	process::{self, Command},
 	sync::OnceLock,
-	thread,
 	time::Duration,
 };
 
 use regex::Regex;
-use reqwest::{
-	StatusCode,
-	blocking::Client,
-	header::{ACCEPT, HeaderMap, LINK, USER_AGENT},
-};
+use reqwest::StatusCode;
 use rusqlite::{self, Connection, OptionalExtension as _};
 use serde_json::{self, Map, Value};
 use sha2::{Digest as _, Sha256};
@@ -27,9 +22,11 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use crate::prelude::eyre::{self, Report};
 
 mod github_api;
+mod github_bundle_client;
 mod requests;
 
 use github_api::GitHubApi;
+use github_bundle_client::GithubClient;
 
 pub(crate) use requests::{
 	RadarBackfillReleaseRangeReport, RadarBackfillReleaseRangeRequest, RadarBundleBuildRequest,
@@ -199,8 +196,6 @@ const ARTIFACT_KINDS: &[&str] = &[
 	"upstream_impact",
 ];
 const GITHUB_REQUEST_ATTEMPTS: usize = 4;
-const GITHUB_REQUEST_BACKOFF_SECONDS: u64 = 1;
-const GITHUB_REQUEST_TIMEOUT_SECONDS: u64 = 30;
 const GITHUB_REQUEST_BACKOFF: Duration = Duration::from_secs(1);
 const GITHUB_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const RETRYABLE_GITHUB_STATUS_CODES: &[StatusCode] = &[
@@ -465,149 +460,6 @@ struct RadarSubject {
 	repo: String,
 	subject_kind: String,
 	subject_id: String,
-}
-
-struct GithubClient {
-	http: Client,
-	token: Option<String>,
-}
-impl GithubClient {
-	fn new(token: Option<&str>) -> crate::prelude::Result<Self> {
-		Ok(Self {
-			http: Client::builder()
-				.timeout(Duration::from_secs(GITHUB_REQUEST_TIMEOUT_SECONDS))
-				.build()?,
-			token: token.map(str::to_owned),
-		})
-	}
-
-	fn build_pr_bundle(
-		&self,
-		repo: &str,
-		pr_number: u64,
-		notes: &[String],
-	) -> crate::prelude::Result<Value> {
-		let (pr, _) =
-			self.github_request(&format!("https://api.github.com/repos/{repo}/pulls/{pr_number}"))?;
-		let commits = self.github_paginated(&format!(
-			"https://api.github.com/repos/{repo}/pulls/{pr_number}/commits?per_page=100"
-		))?;
-		let files = self.github_paginated(&format!(
-			"https://api.github.com/repos/{repo}/pulls/{pr_number}/files?per_page=100"
-		))?;
-		let default_branch = self.repo_default_branch(repo)?;
-
-		build_pr_bundle_from_sources(repo, &pr, &commits, &files, &default_branch, notes)
-	}
-
-	fn build_commit_bundle(
-		&self,
-		repo: &str,
-		commit_sha: &str,
-		notes: &[String],
-	) -> crate::prelude::Result<Value> {
-		let (commit, _) = self
-			.github_request(&format!("https://api.github.com/repos/{repo}/commits/{commit_sha}"))?;
-		let default_branch = self.repo_default_branch(repo)?;
-
-		build_commit_bundle_from_sources(repo, &commit, &default_branch, notes)
-	}
-
-	fn maybe_promote_commit_to_pr(&self, repo: &str, commit_sha: &str) -> Option<u64> {
-		let pulls = self
-			.github_paginated(&format!(
-				"https://api.github.com/repos/{repo}/commits/{commit_sha}/pulls"
-			))
-			.ok()?;
-		let first = pulls.first()?.as_object()?;
-
-		first.get("number").and_then(Value::as_u64)
-	}
-
-	fn repo_default_branch(&self, repo: &str) -> crate::prelude::Result<String> {
-		let (payload, _) = self.github_request(&format!("https://api.github.com/repos/{repo}"))?;
-		let default_branch = payload.get("default_branch").and_then(Value::as_str);
-
-		default_branch
-			.filter(|value| !value.is_empty())
-			.map(str::to_owned)
-			.ok_or_else(|| eyre::eyre!("Unable to resolve default branch for {repo}"))
-	}
-
-	fn github_paginated(&self, url: &str) -> crate::prelude::Result<Vec<Value>> {
-		let mut items = Vec::new();
-		let mut next_url = Some(url.to_owned());
-
-		while let Some(url) = next_url {
-			let (payload, headers) = self.github_request(&url)?;
-			let Some(values) = payload.as_array() else {
-				eyre::bail!("Expected list payload from {url}");
-			};
-
-			items.extend(values.iter().cloned());
-
-			next_url =
-				headers.get(LINK).and_then(|value| value.to_str().ok()).and_then(parse_next_link);
-		}
-
-		Ok(items)
-	}
-
-	fn github_request(&self, url: &str) -> crate::prelude::Result<(Value, HeaderMap)> {
-		for attempt in 1..=GITHUB_REQUEST_ATTEMPTS {
-			let mut request = self
-				.http
-				.get(url)
-				.header(ACCEPT, "application/vnd.github+json")
-				.header(USER_AGENT, "decodex-github-bundle-builder");
-
-			if let Some(token) = &self.token {
-				request = request.bearer_auth(token);
-			}
-
-			match request.send() {
-				Ok(response) => {
-					let status = response.status();
-					let headers = response.headers().clone();
-
-					if status.is_success() {
-						let body = response.text()?;
-						let payload = serde_json::from_str(&body).map_err(|error| {
-							eyre::eyre!(
-								"GitHub API response from {url} was not valid JSON: {error}; body: {}",
-								body_excerpt(&body)
-							)
-						})?;
-
-						return Ok((payload, headers));
-					}
-
-					let details = response.text().unwrap_or_default();
-
-					if RETRYABLE_GITHUB_STATUS_CODES.contains(&status)
-						&& attempt < GITHUB_REQUEST_ATTEMPTS
-					{
-						sleep_before_retry(attempt);
-
-						continue;
-					}
-
-					eyre::bail!("GitHub API request failed for {url}: {status} {details}");
-				},
-				Err(error) => {
-					if !error.is_timeout() && !error.is_connect()
-						|| attempt == GITHUB_REQUEST_ATTEMPTS
-					{
-						eyre::bail!("GitHub API request failed for {url}: {error}");
-					}
-
-					sleep_before_retry(attempt);
-				},
-			}
-		}
-
-		eyre::bail!("GitHub API request failed for {url}: exhausted retry loop")
-	}
 }
 
 #[derive(Debug, Default)]
@@ -4110,25 +3962,6 @@ fn truncate_patch(value: &str) -> Option<String> {
 
 fn first_line(value: &str) -> String {
 	value.trim().lines().next().unwrap_or("").into()
-}
-
-fn parse_next_link(header: &str) -> Option<String> {
-	for part in header.split(',') {
-		let mut sections = part.trim().split(';');
-		let Some(url_part) = sections.next() else {
-			continue;
-		};
-
-		if sections.any(|section| section.trim() == r#"rel="next""#) {
-			return Some(url_part.trim().trim_start_matches('<').trim_end_matches('>').into());
-		}
-	}
-
-	None
-}
-
-fn sleep_before_retry(attempt: usize) {
-	thread::sleep(Duration::from_secs(GITHUB_REQUEST_BACKOFF_SECONDS * attempt as u64));
 }
 
 fn routed_token_env() -> Option<String> {

--- a/apps/decodex/src/radar/github_bundle_client.rs
+++ b/apps/decodex/src/radar/github_bundle_client.rs
@@ -1,0 +1,179 @@
+use std::{thread, time::Duration};
+
+use reqwest::{
+	blocking::Client,
+	header::{ACCEPT, HeaderMap, LINK, USER_AGENT},
+};
+use serde_json::{self, Value};
+
+use crate::prelude::eyre;
+
+use super::{
+	GITHUB_REQUEST_ATTEMPTS, RETRYABLE_GITHUB_STATUS_CODES, body_excerpt,
+	build_commit_bundle_from_sources, build_pr_bundle_from_sources,
+};
+
+const GITHUB_REQUEST_BACKOFF_SECONDS: u64 = 1;
+const GITHUB_REQUEST_TIMEOUT_SECONDS: u64 = 30;
+
+pub(super) struct GithubClient {
+	http: Client,
+	token: Option<String>,
+}
+impl GithubClient {
+	pub(super) fn new(token: Option<&str>) -> crate::prelude::Result<Self> {
+		Ok(Self {
+			http: Client::builder()
+				.timeout(Duration::from_secs(GITHUB_REQUEST_TIMEOUT_SECONDS))
+				.build()?,
+			token: token.map(str::to_owned),
+		})
+	}
+
+	pub(super) fn build_pr_bundle(
+		&self,
+		repo: &str,
+		pr_number: u64,
+		notes: &[String],
+	) -> crate::prelude::Result<Value> {
+		let (pr, _) =
+			self.github_request(&format!("https://api.github.com/repos/{repo}/pulls/{pr_number}"))?;
+		let commits = self.github_paginated(&format!(
+			"https://api.github.com/repos/{repo}/pulls/{pr_number}/commits?per_page=100"
+		))?;
+		let files = self.github_paginated(&format!(
+			"https://api.github.com/repos/{repo}/pulls/{pr_number}/files?per_page=100"
+		))?;
+		let default_branch = self.repo_default_branch(repo)?;
+
+		build_pr_bundle_from_sources(repo, &pr, &commits, &files, &default_branch, notes)
+	}
+
+	pub(super) fn build_commit_bundle(
+		&self,
+		repo: &str,
+		commit_sha: &str,
+		notes: &[String],
+	) -> crate::prelude::Result<Value> {
+		let (commit, _) = self
+			.github_request(&format!("https://api.github.com/repos/{repo}/commits/{commit_sha}"))?;
+		let default_branch = self.repo_default_branch(repo)?;
+
+		build_commit_bundle_from_sources(repo, &commit, &default_branch, notes)
+	}
+
+	pub(super) fn maybe_promote_commit_to_pr(&self, repo: &str, commit_sha: &str) -> Option<u64> {
+		let pulls = self
+			.github_paginated(&format!(
+				"https://api.github.com/repos/{repo}/commits/{commit_sha}/pulls"
+			))
+			.ok()?;
+		let first = pulls.first()?.as_object()?;
+
+		first.get("number").and_then(Value::as_u64)
+	}
+
+	fn repo_default_branch(&self, repo: &str) -> crate::prelude::Result<String> {
+		let (payload, _) = self.github_request(&format!("https://api.github.com/repos/{repo}"))?;
+		let default_branch = payload.get("default_branch").and_then(Value::as_str);
+
+		default_branch
+			.filter(|value| !value.is_empty())
+			.map(str::to_owned)
+			.ok_or_else(|| eyre::eyre!("Unable to resolve default branch for {repo}"))
+	}
+
+	fn github_paginated(&self, url: &str) -> crate::prelude::Result<Vec<Value>> {
+		let mut items = Vec::new();
+		let mut next_url = Some(url.to_owned());
+
+		while let Some(url) = next_url {
+			let (payload, headers) = self.github_request(&url)?;
+			let Some(values) = payload.as_array() else {
+				eyre::bail!("Expected list payload from {url}");
+			};
+
+			items.extend(values.iter().cloned());
+
+			next_url =
+				headers.get(LINK).and_then(|value| value.to_str().ok()).and_then(parse_next_link);
+		}
+
+		Ok(items)
+	}
+
+	fn github_request(&self, url: &str) -> crate::prelude::Result<(Value, HeaderMap)> {
+		for attempt in 1..=GITHUB_REQUEST_ATTEMPTS {
+			let mut request = self
+				.http
+				.get(url)
+				.header(ACCEPT, "application/vnd.github+json")
+				.header(USER_AGENT, "decodex-github-bundle-builder");
+
+			if let Some(token) = &self.token {
+				request = request.bearer_auth(token);
+			}
+
+			match request.send() {
+				Ok(response) => {
+					let status = response.status();
+					let headers = response.headers().clone();
+
+					if status.is_success() {
+						let body = response.text()?;
+						let payload = serde_json::from_str(&body).map_err(|error| {
+							eyre::eyre!(
+								"GitHub API response from {url} was not valid JSON: {error}; body: {}",
+								body_excerpt(&body)
+							)
+						})?;
+
+						return Ok((payload, headers));
+					}
+
+					let details = response.text().unwrap_or_default();
+
+					if RETRYABLE_GITHUB_STATUS_CODES.contains(&status)
+						&& attempt < GITHUB_REQUEST_ATTEMPTS
+					{
+						sleep_before_retry(attempt);
+
+						continue;
+					}
+
+					eyre::bail!("GitHub API request failed for {url}: {status} {details}");
+				},
+				Err(error) => {
+					if !error.is_timeout() && !error.is_connect()
+						|| attempt == GITHUB_REQUEST_ATTEMPTS
+					{
+						eyre::bail!("GitHub API request failed for {url}: {error}");
+					}
+
+					sleep_before_retry(attempt);
+				},
+			}
+		}
+
+		eyre::bail!("GitHub API request failed for {url}: exhausted retry loop")
+	}
+}
+
+fn parse_next_link(header: &str) -> Option<String> {
+	for part in header.split(',') {
+		let mut sections = part.trim().split(';');
+		let Some(url_part) = sections.next() else {
+			continue;
+		};
+
+		if sections.any(|section| section.trim() == r#"rel="next""#) {
+			return Some(url_part.trim().trim_start_matches('<').trim_end_matches('>').into());
+		}
+	}
+
+	None
+}
+
+fn sleep_before_retry(attempt: usize) {
+	thread::sleep(Duration::from_secs(GITHUB_REQUEST_BACKOFF_SECONDS * attempt as u64));
+}


### PR DESCRIPTION
## Summary
- move the legacy Radar GitHub bundle-building client into apps/decodex/src/radar/github_bundle_client.rs
- keep bundle payload construction in radar.rs and call it through a narrow parent-module boundary
- move the bundle client's pagination parser and retry sleep helper into the new module

## Validation
- cargo check -p decodex --all-targets --all-features
- cargo test -p decodex --all-features radar -- --nocapture
- rustfmt --edition 2024 --check apps/decodex/src/radar.rs apps/decodex/src/radar/github_bundle_client.rs apps/decodex/src/radar/github_api.rs
- git diff --cached --check