### PR TITLE
Split radar social publish reservations

### DIFF
--- a/apps/decodex/src/radar.rs
+++ b/apps/decodex/src/radar.rs
@@ -26,6 +26,7 @@ mod github_token;
 mod ledger;
 mod requests;
 mod signal_render;
+mod social_publish;
 
 #[cfg(test)]
 use artifact_validation::has_legacy_multi_agent_v2_context;
@@ -40,6 +41,7 @@ use github_bundle_client::GithubClient;
 use github_token::github_token;
 use ledger::RadarLedger;
 use signal_render::{rendered_config_flags, rendered_signal};
+pub(crate) use social_publish::reserve_social_publish;
 
 pub(crate) use ledger::{
 	default_ledger_path, ledger_artifact_link, ledger_bootstrap, ledger_ingest,
@@ -254,13 +256,6 @@ struct ReleasePair {
 	preview: Value,
 }
 
-#[derive(Debug, Default)]
-struct SocialPublishStateScan {
-	published_count: usize,
-	active_reservation_count: usize,
-	idempotency_conflict: Option<PathBuf>,
-}
-
 #[derive(Debug)]
 enum RefreshKind {
 	Queue,
@@ -363,72 +358,6 @@ pub(crate) fn validate(
 	} else {
 		Err(eyre::eyre!("Radar validation failed:\n- {}", errors.join("\n- ")))
 	}
-}
-
-pub(crate) fn reserve_social_publish(
-	request: &RadarSocialReservePublishRequest,
-) -> crate::prelude::Result<RadarSocialReservePublishReport> {
-	if request.slug.trim().is_empty() {
-		return Err(eyre::eyre!("slug is required"));
-	}
-	if request.idempotency_key.trim().is_empty() {
-		return Err(eyre::eyre!("idempotency_key is required"));
-	}
-	if request.daily_limit == 0 {
-		return Err(eyre::eyre!("daily_limit must be positive"));
-	}
-	if request.candidate_paths.is_empty() && request.urls.is_empty() {
-		return Err(eyre::eyre!("at least one candidate path or URL is required"));
-	}
-	if request.duplicate_keys.is_empty() {
-		return Err(eyre::eyre!("at least one duplicate key is required"));
-	}
-
-	let root = repo_root()?;
-	let out_dir = resolve_against(&root, &request.out_dir);
-	let posts_dir = resolve_against(&root, &request.posts_dir);
-	let reservation_path =
-		out_dir.join(&request.day).join(format!("{}.json", slugify(&request.slug)));
-	let scan =
-		scan_social_publish_state(&out_dir, &posts_dir, &request.idempotency_key, &request.day)?;
-
-	if scan.idempotency_conflict.is_some() {
-		return Err(eyre::eyre!(
-			"idempotency_key already has an active reservation or terminal post: {}",
-			request.idempotency_key
-		));
-	}
-	if scan.published_count + scan.active_reservation_count >= request.daily_limit {
-		return Err(eyre::eyre!(
-			"daily publish cap exhausted for {}: published={}, active_reservations={}, limit={}",
-			request.day,
-			scan.published_count,
-			scan.active_reservation_count,
-			request.daily_limit
-		));
-	}
-
-	let payload = social_publish_reservation_payload(request, &root);
-	let validation = validate_artifact(&payload);
-
-	if !validation.errors.is_empty() {
-		return Err(eyre::eyre!(
-			"generated reservation failed validation: {}",
-			validation.errors.join("; ")
-		));
-	}
-	if !request.dry_run {
-		write_new_json(&reservation_path, &payload)?;
-	}
-
-	Ok(RadarSocialReservePublishReport {
-		status: if request.dry_run { "dry_run".into() } else { "reserved".into() },
-		path: path_arg(&root, &reservation_path),
-		idempotency_key: request.idempotency_key.clone(),
-		daily_limit: request.daily_limit,
-		published_count: scan.published_count,
-		active_reservation_count: scan.active_reservation_count,
-	})
 }
 
 /// Build a deterministic GitHub change bundle and write it to disk.
@@ -2182,133 +2111,6 @@ fn write_new_json(path: &Path, payload: &Value) -> crate::prelude::Result<()> {
 	file.sync_all()?;
 
 	Ok(())
-}
-
-fn scan_social_publish_state(
-	reservations_dir: &Path,
-	posts_dir: &Path,
-	idempotency_key: &str,
-	day: &str,
-) -> crate::prelude::Result<SocialPublishStateScan> {
-	let mut scan = SocialPublishStateScan::default();
-
-	for payload_path in existing_json_files(reservations_dir)? {
-		let payload = load_json(&payload_path)?;
-
-		if payload.get("schema").and_then(Value::as_str) != Some(SOCIAL_PUBLISH_RESERVATION_SCHEMA)
-		{
-			continue;
-		}
-		if payload.get("status").and_then(Value::as_str) == Some("active") {
-			if payload.get("day").and_then(Value::as_str) == Some(day) {
-				scan.active_reservation_count += 1;
-			}
-			if payload.get("idempotency_key").and_then(Value::as_str) == Some(idempotency_key) {
-				scan.idempotency_conflict.get_or_insert(payload_path);
-			}
-		}
-	}
-	for payload_path in existing_json_files(posts_dir)? {
-		let payload = load_json(&payload_path)?;
-
-		if payload.get("schema").and_then(Value::as_str) != Some(SOCIAL_POST_SCHEMA) {
-			continue;
-		}
-
-		let status = payload.get("status").and_then(Value::as_str);
-
-		if status == Some("published")
-			&& payload
-				.get("decision")
-				.and_then(Value::as_object)
-				.and_then(|decision| decision.get("day"))
-				.and_then(Value::as_str)
-				== Some(day)
-		{
-			scan.published_count += 1;
-		}
-		if status != Some("failed")
-			&& payload
-				.get("decision")
-				.and_then(Value::as_object)
-				.and_then(|decision| decision.get("idempotency_key"))
-				.and_then(Value::as_str)
-				== Some(idempotency_key)
-		{
-			scan.idempotency_conflict.get_or_insert(payload_path);
-		}
-	}
-
-	Ok(scan)
-}
-
-fn existing_json_files(path: &Path) -> crate::prelude::Result<Vec<PathBuf>> {
-	if !path.exists() {
-		return Ok(Vec::new());
-	}
-
-	collect_json_files(&[path.to_path_buf()])
-}
-
-fn social_publish_reservation_payload(
-	request: &RadarSocialReservePublishRequest,
-	root: &Path,
-) -> Value {
-	let mut refs = Map::new();
-
-	if !request.candidate_paths.is_empty() {
-		refs.insert(
-			"social_candidates".into(),
-			Value::Array(
-				request
-					.candidate_paths
-					.iter()
-					.map(|path| Value::String(path_arg(root, &resolve_against(root, path))))
-					.collect(),
-			),
-		);
-	}
-	if !request.urls.is_empty() {
-		refs.insert(
-			"urls".into(),
-			Value::Array(request.urls.iter().cloned().map(Value::String).collect()),
-		);
-	}
-
-	let mut owner = Map::new();
-
-	if let Some(value) = request.automation_id.as_deref().filter(|value| !value.is_empty()) {
-		owner.insert("automation_id".into(), Value::String(value.to_owned()));
-	}
-	if let Some(value) = request.run_id.as_deref().filter(|value| !value.is_empty()) {
-		owner.insert("run_id".into(), Value::String(value.to_owned()));
-	}
-	if let Some(value) = request.branch.as_deref().filter(|value| !value.is_empty()) {
-		owner.insert("branch".into(), Value::String(value.to_owned()));
-	}
-
-	let mut payload = serde_json::json!({
-		"schema": SOCIAL_PUBLISH_RESERVATION_SCHEMA,
-		"slug": request.slug,
-		"channel": "x",
-		"target_account": "decodexspace",
-		"controller_account": "hackink",
-		"mode": request.mode,
-		"status": "active",
-		"idempotency_key": request.idempotency_key,
-		"reserved_at": request.reserved_at,
-		"expires_at": request.expires_at,
-		"day": request.day,
-		"timezone": request.timezone,
-		"candidate_refs": refs,
-		"duplicate_keys": request.duplicate_keys,
-	});
-
-	if !owner.is_empty() {
-		payload["owner"] = Value::Object(owner);
-	}
-
-	payload
 }
 
 fn require_member(value: &str, allowed: &[&str], label: &str) -> crate::prelude::Result<()> {

--- a/apps/decodex/src/radar/social_publish.rs
+++ b/apps/decodex/src/radar/social_publish.rs
@@ -1,0 +1,203 @@
+//! Social publishing reservation generation and conflict checks.
+
+use super::*;
+
+#[derive(Debug, Default)]
+struct SocialPublishStateScan {
+	published_count: usize,
+	active_reservation_count: usize,
+	idempotency_conflict: Option<PathBuf>,
+}
+
+pub(crate) fn reserve_social_publish(
+	request: &RadarSocialReservePublishRequest,
+) -> crate::prelude::Result<RadarSocialReservePublishReport> {
+	if request.slug.trim().is_empty() {
+		return Err(eyre::eyre!("slug is required"));
+	}
+	if request.idempotency_key.trim().is_empty() {
+		return Err(eyre::eyre!("idempotency_key is required"));
+	}
+	if request.daily_limit == 0 {
+		return Err(eyre::eyre!("daily_limit must be positive"));
+	}
+	if request.candidate_paths.is_empty() && request.urls.is_empty() {
+		return Err(eyre::eyre!("at least one candidate path or URL is required"));
+	}
+	if request.duplicate_keys.is_empty() {
+		return Err(eyre::eyre!("at least one duplicate key is required"));
+	}
+
+	let root = repo_root()?;
+	let out_dir = resolve_against(&root, &request.out_dir);
+	let posts_dir = resolve_against(&root, &request.posts_dir);
+	let reservation_path =
+		out_dir.join(&request.day).join(format!("{}.json", slugify(&request.slug)));
+	let scan =
+		scan_social_publish_state(&out_dir, &posts_dir, &request.idempotency_key, &request.day)?;
+
+	if scan.idempotency_conflict.is_some() {
+		return Err(eyre::eyre!(
+			"idempotency_key already has an active reservation or terminal post: {}",
+			request.idempotency_key
+		));
+	}
+	if scan.published_count + scan.active_reservation_count >= request.daily_limit {
+		return Err(eyre::eyre!(
+			"daily publish cap exhausted for {}: published={}, active_reservations={}, limit={}",
+			request.day,
+			scan.published_count,
+			scan.active_reservation_count,
+			request.daily_limit
+		));
+	}
+
+	let payload = social_publish_reservation_payload(request, &root);
+	let validation = validate_artifact(&payload);
+
+	if !validation.errors.is_empty() {
+		return Err(eyre::eyre!(
+			"generated reservation failed validation: {}",
+			validation.errors.join("; ")
+		));
+	}
+	if !request.dry_run {
+		write_new_json(&reservation_path, &payload)?;
+	}
+
+	Ok(RadarSocialReservePublishReport {
+		status: if request.dry_run { "dry_run".into() } else { "reserved".into() },
+		path: path_arg(&root, &reservation_path),
+		idempotency_key: request.idempotency_key.clone(),
+		daily_limit: request.daily_limit,
+		published_count: scan.published_count,
+		active_reservation_count: scan.active_reservation_count,
+	})
+}
+
+fn scan_social_publish_state(
+	reservations_dir: &Path,
+	posts_dir: &Path,
+	idempotency_key: &str,
+	day: &str,
+) -> crate::prelude::Result<SocialPublishStateScan> {
+	let mut scan = SocialPublishStateScan::default();
+
+	for payload_path in existing_json_files(reservations_dir)? {
+		let payload = load_json(&payload_path)?;
+
+		if payload.get("schema").and_then(Value::as_str) != Some(SOCIAL_PUBLISH_RESERVATION_SCHEMA)
+		{
+			continue;
+		}
+		if payload.get("status").and_then(Value::as_str) == Some("active") {
+			if payload.get("day").and_then(Value::as_str) == Some(day) {
+				scan.active_reservation_count += 1;
+			}
+			if payload.get("idempotency_key").and_then(Value::as_str) == Some(idempotency_key) {
+				scan.idempotency_conflict.get_or_insert(payload_path);
+			}
+		}
+	}
+	for payload_path in existing_json_files(posts_dir)? {
+		let payload = load_json(&payload_path)?;
+
+		if payload.get("schema").and_then(Value::as_str) != Some(SOCIAL_POST_SCHEMA) {
+			continue;
+		}
+
+		let status = payload.get("status").and_then(Value::as_str);
+
+		if status == Some("published")
+			&& payload
+				.get("decision")
+				.and_then(Value::as_object)
+				.and_then(|decision| decision.get("day"))
+				.and_then(Value::as_str)
+				== Some(day)
+		{
+			scan.published_count += 1;
+		}
+		if status != Some("failed")
+			&& payload
+				.get("decision")
+				.and_then(Value::as_object)
+				.and_then(|decision| decision.get("idempotency_key"))
+				.and_then(Value::as_str)
+				== Some(idempotency_key)
+		{
+			scan.idempotency_conflict.get_or_insert(payload_path);
+		}
+	}
+
+	Ok(scan)
+}
+
+fn existing_json_files(path: &Path) -> crate::prelude::Result<Vec<PathBuf>> {
+	if !path.exists() {
+		return Ok(Vec::new());
+	}
+
+	collect_json_files(&[path.to_path_buf()])
+}
+
+fn social_publish_reservation_payload(
+	request: &RadarSocialReservePublishRequest,
+	root: &Path,
+) -> Value {
+	let mut refs = Map::new();
+
+	if !request.candidate_paths.is_empty() {
+		refs.insert(
+			"social_candidates".into(),
+			Value::Array(
+				request
+					.candidate_paths
+					.iter()
+					.map(|path| Value::String(path_arg(root, &resolve_against(root, path))))
+					.collect(),
+			),
+		);
+	}
+	if !request.urls.is_empty() {
+		refs.insert(
+			"urls".into(),
+			Value::Array(request.urls.iter().cloned().map(Value::String).collect()),
+		);
+	}
+
+	let mut owner = Map::new();
+
+	if let Some(value) = request.automation_id.as_deref().filter(|value| !value.is_empty()) {
+		owner.insert("automation_id".into(), Value::String(value.to_owned()));
+	}
+	if let Some(value) = request.run_id.as_deref().filter(|value| !value.is_empty()) {
+		owner.insert("run_id".into(), Value::String(value.to_owned()));
+	}
+	if let Some(value) = request.branch.as_deref().filter(|value| !value.is_empty()) {
+		owner.insert("branch".into(), Value::String(value.to_owned()));
+	}
+
+	let mut payload = serde_json::json!({
+		"schema": SOCIAL_PUBLISH_RESERVATION_SCHEMA,
+		"slug": request.slug,
+		"channel": "x",
+		"target_account": "decodexspace",
+		"controller_account": "hackink",
+		"mode": request.mode,
+		"status": "active",
+		"idempotency_key": request.idempotency_key,
+		"reserved_at": request.reserved_at,
+		"expires_at": request.expires_at,
+		"day": request.day,
+		"timezone": request.timezone,
+		"candidate_refs": refs,
+		"duplicate_keys": request.duplicate_keys,
+	});
+
+	if !owner.is_empty() {
+		payload["owner"] = Value::Object(owner);
+	}
+
+	payload
+}


### PR DESCRIPTION
## Summary
- move social publish reservation generation, conflict scanning, and reservation payload construction into radar/social_publish.rs
- keep radar.rs exposing reserve_social_publish through a module re-export
- leave artifact validation and broader radar bundle/release logic untouched

## Validation
- cargo check -p decodex --all-targets --all-features
- cargo test -p decodex --all-features radar -- --nocapture
- rustfmt --check --edition 2024 apps/decodex/src/radar/social_publish.rs
- git diff --check