### PR TITLE
Improve macOS account removal interaction

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -8,12 +8,10 @@ struct AccountPanelView: View {
 	@ObservedObject var loginWindowState: LoginWindowState
 	@Environment(\.colorScheme) private var colorScheme
 	@State private var accountScrollOffset: CGFloat = 0
-	@State private var currentTime = Date()
-	@State private var pendingLogout: CodexAccount?
 	@State private var armedLogoutAccountID: String?
-	@State private var logoutArmToken = UUID()
+	@State private var deletingLogoutAccountID: String?
+	@State private var logoutErrorMessage: String?
 	@AppStorage("decodex.operator.accountPrivacy") private var accountPrivacy = AccountPrivacy.hiddenValue
-	private let localClock = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
 	var body: some View {
 		Group {
@@ -25,38 +23,12 @@ struct AccountPanelView: View {
 				panelContent
 			}
 		}
-		.confirmationDialog(
-			"Remove account?",
-			isPresented: Binding(
-				get: { pendingLogout != nil },
-				set: { visible in
-					if visible == false {
-						pendingLogout = nil
-						disarmLogout()
-					}
-				}
-			),
-			titleVisibility: .visible
-		) {
-			if let account = pendingLogout {
-				Button("Remove \(displayName(for: account))", role: .destructive) {
-					disarmLogout()
-					Task {
-						await store.logout(account)
-					}
-				}
-			}
-		} message: {
-			if let account = pendingLogout {
-				Text("This removes \(displayName(for: account)) from the Decodex account pool on this Mac.")
-			}
-		}
 		.background {
 			LoginPanelPresenter(store: store, state: loginWindowState)
 				.frame(width: 0, height: 0)
 		}
-		.onReceive(localClock) { tick in
-			currentTime = tick
+		.onDisappear {
+			disarmLogout()
 		}
 	}
 
@@ -280,7 +252,8 @@ struct AccountPanelView: View {
 					displayName: displayName(for: account),
 					showsDivider: index < store.accounts.count - 1,
 					isLogoutArmed: armedLogoutAccountID == account.id,
-					currentTime: currentTime,
+					isLogoutPending: deletingLogoutAccountID == account.id,
+					logoutErrorMessage: armedLogoutAccountID == account.id ? logoutErrorMessage : nil,
 					useInCodex: {
 						Task {
 							await store.useInCodex(account)
@@ -296,6 +269,12 @@ struct AccountPanelView: View {
 					},
 					logout: {
 						requestLogout(account)
+					},
+					cancelLogout: {
+						disarmLogout()
+					},
+					confirmLogout: {
+						confirmLogout(account)
 					}
 				)
 			}
@@ -486,34 +465,38 @@ struct AccountPanelView: View {
 	}
 
 	private func requestLogout(_ account: CodexAccount) {
+		guard deletingLogoutAccountID == nil else {
+			return
+		}
 		if armedLogoutAccountID == account.id {
-			pendingLogout = account
-			disarmLogout()
 			return
 		}
 
-		let token = UUID()
-		logoutArmToken = token
-		withAnimation(PanelMotion.state) {
-			armedLogoutAccountID = account.id
-		}
+		logoutErrorMessage = nil
+		armedLogoutAccountID = account.id
+	}
 
-		Task { @MainActor in
-			try? await Task.sleep(nanoseconds: 2_400_000_000)
-			guard logoutArmToken == token, armedLogoutAccountID == account.id else {
-				return
-			}
-			withAnimation(PanelMotion.state) {
-				armedLogoutAccountID = nil
+	private func confirmLogout(_ account: CodexAccount) {
+		Task {
+			deletingLogoutAccountID = account.id
+			logoutErrorMessage = nil
+			do {
+				try await store.logout(account)
+				deletingLogoutAccountID = nil
+				disarmLogout()
+			} catch {
+				deletingLogoutAccountID = nil
+				logoutErrorMessage = error.localizedDescription
 			}
 		}
 	}
 
 	private func disarmLogout() {
-		logoutArmToken = UUID()
-		withAnimation(PanelMotion.state) {
-			armedLogoutAccountID = nil
+		guard deletingLogoutAccountID == nil else {
+			return
 		}
+		logoutErrorMessage = nil
+		armedLogoutAccountID = nil
 	}
 
 	private func presentLogin(_ mode: AccountLoginSheetMode) {

--- a/apps/decodex-app/Sources/DecodexApp/AccountRowView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountRowView.swift
@@ -6,11 +6,14 @@ struct AccountRowView: View {
 	let displayName: String
 	let showsDivider: Bool
 	let isLogoutArmed: Bool
-	let currentTime: Date
+	let isLogoutPending: Bool
+	let logoutErrorMessage: String?
 	let useInCodex: () -> Void
 	let routeRunsHere: () -> Void
 	let login: () -> Void
 	let logout: () -> Void
+	let cancelLogout: () -> Void
+	let confirmLogout: () -> Void
 	@Environment(\.colorScheme) private var colorScheme
 
 	var body: some View {
@@ -53,63 +56,15 @@ struct AccountRowView: View {
 				}
 				.frame(maxWidth: .infinity, alignment: .leading)
 
-				HStack(spacing: 3) {
-					if account.needsLogin {
-						PanelIconButtonView(
-							symbol: "person.crop.circle.badge.plus",
-							tint: PanelPalette.warning(colorScheme),
-							isActive: false,
-							isPrimary: true,
-							size: 21,
-							action: login,
-							help: loginHelp
-						)
-					} else {
-						PanelIconButtonView(
-							symbol: account.codexActive ? "person.crop.circle.fill" : "person.crop.circle",
-							tint: PanelPalette.codexAccent(colorScheme),
-							isActive: account.codexActive,
-							isDisabled: account.codexActive || account.canUseInCodex == false,
-							isSubtle: true,
-							size: 21,
-							action: useInCodex,
-							help: account.codexActive ? "Current Codex account" : "Use as Codex account"
-						)
-					}
-
-					PanelIconButtonView(
-						symbol: "arrow.triangle.branch",
-						tint: account.selected
-							? PanelPalette.routeAccent(colorScheme)
-							: PanelPalette.actionBlue(colorScheme),
-						isActive: account.selected,
-						isDisabled: account.canRouteRuns == false && account.selected == false,
-						isSubtle: true,
-						size: 21,
-						action: routeRunsHere,
-						help: routeHelp
-					)
-
-					PanelIconButtonView(
-						symbol: isLogoutArmed ? "trash.fill" : "trash",
-						tint: PanelPalette.destructive(colorScheme),
-						isActive: isLogoutArmed,
-						isDestructive: true,
-						isSubtle: isLogoutArmed == false,
-						size: 21,
-						action: logout,
-						help: isLogoutArmed ? "Click again to confirm removal" : "Remove account"
-					)
-					.modifier(DeleteArmedShakeModifier(isArmed: isLogoutArmed))
-				}
+				actionCluster
 			}
 
 			if runs.isEmpty == false {
-				AccountRunSummaryView(runs: runs, currentTime: currentTime)
+				AccountRunSummaryView(runs: runs)
 			}
 
 			if account.hasUsageSummary {
-				AccountUsageSummaryView(account: account, currentTime: currentTime)
+				AccountUsageSummaryView(account: account)
 			}
 		}
 		.padding(.vertical, 7)
@@ -127,7 +82,38 @@ struct AccountRowView: View {
 		}
 		.animation(PanelMotion.state, value: account.selected)
 		.animation(PanelMotion.state, value: account.codexActive)
-		.animation(PanelMotion.state, value: isLogoutArmed)
+	}
+
+	@ViewBuilder
+	private var actionCluster: some View {
+		ZStack(alignment: .trailing) {
+			AccountDefaultActionsView(
+				account: account,
+				loginHelp: loginHelp,
+				routeHelp: routeHelp,
+				login: login,
+				useInCodex: useInCodex,
+				routeRunsHere: routeRunsHere,
+				logout: logout
+			)
+			.opacity(isLogoutArmed ? 0 : 1)
+			.offset(x: isLogoutArmed ? -5 : 0)
+			.allowsHitTesting(isLogoutArmed == false)
+
+			AccountLogoutConfirmActionsView(
+				displayName: displayName,
+				errorMessage: logoutErrorMessage,
+				isPending: isLogoutPending,
+				cancel: cancelLogout,
+				remove: confirmLogout
+			)
+			.opacity(isLogoutArmed ? 1 : 0)
+			.offset(x: isLogoutArmed ? 0 : 5)
+			.allowsHitTesting(isLogoutArmed)
+		}
+		.frame(width: isLogoutArmed ? AccountActionClusterLayout.confirmWidth : AccountActionClusterLayout.defaultWidth, alignment: .trailing)
+		.clipped()
+		.animation(AccountActionClusterLayout.transition, value: isLogoutArmed)
 	}
 
 	private var routeHelp: String {
@@ -153,33 +139,128 @@ struct AccountRowView: View {
 	}
 }
 
-private struct DeleteArmedShakeModifier: ViewModifier {
-	let isArmed: Bool
-	@State private var shakeTrigger = 0
+private enum AccountActionClusterLayout {
+	static let defaultWidth: CGFloat = 70
+	static let confirmWidth: CGFloat = 82
+	static let transition = Animation.interactiveSpring(response: 0.2, dampingFraction: 0.9, blendDuration: 0.03)
+}
 
-	func body(content: Content) -> some View {
-		content
-			.modifier(DeleteShakeEffect(animatableData: CGFloat(shakeTrigger)))
-			.scaleEffect(isArmed ? 1.045 : 1)
-			.onChange(of: isArmed) { _, armed in
-				guard armed else {
-					return
-				}
-				withAnimation(.linear(duration: 0.42)) {
-					shakeTrigger += 1
-				}
+private struct AccountDefaultActionsView: View {
+	let account: CodexAccount
+	let loginHelp: String
+	let routeHelp: String
+	let login: () -> Void
+	let useInCodex: () -> Void
+	let routeRunsHere: () -> Void
+	let logout: () -> Void
+	@Environment(\.colorScheme) private var colorScheme
+
+	var body: some View {
+		HStack(spacing: 3) {
+			if account.needsLogin {
+				PanelIconButtonView(
+					symbol: "person.crop.circle.badge.plus",
+					tint: PanelPalette.warning(colorScheme),
+					isActive: false,
+					isPrimary: true,
+					size: 21,
+					action: login,
+					help: loginHelp
+				)
+			} else {
+				PanelIconButtonView(
+					symbol: account.codexActive ? "person.crop.circle.fill" : "person.crop.circle",
+					tint: PanelPalette.codexAccent(colorScheme),
+					isActive: account.codexActive,
+					isDisabled: account.codexActive || account.canUseInCodex == false,
+					isSubtle: true,
+					size: 21,
+					action: useInCodex,
+					help: account.codexActive ? "Current Codex account" : "Use as Codex account"
+				)
 			}
+
+			PanelIconButtonView(
+				symbol: "arrow.triangle.branch",
+				tint: account.selected
+					? PanelPalette.routeAccent(colorScheme)
+					: PanelPalette.actionBlue(colorScheme),
+				isActive: account.selected,
+				isDisabled: account.canRouteRuns == false && account.selected == false,
+				isSubtle: true,
+				size: 21,
+				action: routeRunsHere,
+				help: routeHelp
+			)
+
+			PanelIconButtonView(
+				symbol: "trash",
+				tint: PanelPalette.destructive(colorScheme),
+				isActive: false,
+				isDestructive: true,
+				isSubtle: true,
+				size: 21,
+				action: logout,
+				help: "Remove account"
+			)
+		}
 	}
 }
 
-private struct DeleteShakeEffect: GeometryEffect {
-	var travel: CGFloat = 1.8
-	var shakesPerUnit: CGFloat = 3
-	var animatableData: CGFloat
+private struct AccountLogoutConfirmActionsView: View {
+	let displayName: String
+	let errorMessage: String?
+	let isPending: Bool
+	let cancel: () -> Void
+	let remove: () -> Void
+	@Environment(\.colorScheme) private var colorScheme
 
-	func effectValue(size: CGSize) -> ProjectionTransform {
-		let xOffset = travel * sin(animatableData * .pi * shakesPerUnit * 2)
-		return ProjectionTransform(CGAffineTransform(translationX: xOffset, y: 0))
+	var body: some View {
+		HStack(spacing: 5) {
+			Button(action: cancel) {
+				Image(systemName: "xmark")
+					.font(PanelFont.tertiary)
+					.frame(width: 15, height: 18)
+			}
+			.buttonStyle(AccountInlineConfirmButtonStyle(tint: PanelPalette.secondaryText(colorScheme)))
+			.keyboardShortcut(.cancelAction)
+			.disabled(isPending)
+			.help("Keep \(displayName)")
+
+			Button(role: .destructive, action: remove) {
+				HStack(spacing: 3) {
+					if isPending {
+						ProgressView()
+							.controlSize(.mini)
+							.frame(width: 10, height: 10)
+					} else {
+						Image(systemName: "trash")
+					}
+					Text(isPending ? "Removing" : "Remove")
+				}
+				.font(PanelFont.tertiary)
+				.lineLimit(1)
+			}
+			.buttonStyle(AccountInlineConfirmButtonStyle(tint: PanelPalette.destructive(colorScheme)))
+			.disabled(isPending)
+			.help("Remove \(displayName) from the local Decodex account pool")
+		}
+		.fixedSize(horizontal: true, vertical: false)
+		.transition(.opacity)
 	}
 }
 
+private struct AccountInlineConfirmButtonStyle: ButtonStyle {
+	let tint: Color
+
+	func makeBody(configuration: Configuration) -> some View {
+		configuration.label
+			.foregroundStyle(tint)
+			.opacity(configuration.isPressed ? 0.72 : 1)
+			.padding(.horizontal, 2)
+			.padding(.vertical, 2)
+			.contentShape(Rectangle())
+			.scaleEffect(configuration.isPressed ? 0.97 : 1)
+			.animation(PanelMotion.press, value: configuration.isPressed)
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/AccountRunChipView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountRunChipView.swift
@@ -12,7 +12,6 @@ enum AccountRunChipLayout {
 
 struct AccountRunChipView: View {
 	let card: OperatorCurrentLaneCard
-	let currentTime: Date
 	@Environment(\.colorScheme) private var colorScheme
 	@State private var isHovered = false
 	@State private var showsPopover = false
@@ -52,8 +51,10 @@ struct AccountRunChipView: View {
 			cancelPopover()
 		}
 		.popover(isPresented: $showsPopover, arrowEdge: .trailing) {
-			OperatorLanePopoverView(run: card.run, currentTime: currentTime)
-				.fixedSize(horizontal: true, vertical: false)
+			TimelineView(.periodic(from: Date(), by: 1)) { timeline in
+				OperatorLanePopoverView(run: card.run, currentTime: timeline.date)
+					.fixedSize(horizontal: true, vertical: false)
+			}
 		}
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountRunStripView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountRunStripView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 struct AccountRunSummaryView: View {
 	let runs: [OperatorCurrentLaneCard]
-	let currentTime: Date
 	@State private var placementStore = AccountRunStripPlacementStore()
 	@State private var scrollProxy = AccountRunStripScrollProxy()
 	@State private var scrollMetrics = AccountRunStripMetrics()
@@ -33,7 +32,7 @@ struct AccountRunSummaryView: View {
 			) {
 				HStack(spacing: 5) {
 					ForEach(runs) { card in
-						AccountRunChipView(card: card, currentTime: currentTime)
+						AccountRunChipView(card: card)
 							.modifier(
 								AccountRunChipPlacementReporter(
 									runID: card.id,

--- a/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
@@ -320,7 +320,7 @@ final class AccountStore: ObservableObject {
 		}
 	}
 
-	func logout(_ account: CodexAccount) async {
+	func logout(_ account: CodexAccount) async throws {
 		do {
 			accountList = try await bridge.runJSON(
 				.accountLogout(selector: account.selector),
@@ -328,7 +328,7 @@ final class AccountStore: ObservableObject {
 			)
 			notice = nil
 		} catch {
-			notice = error.localizedDescription
+			throw error
 		}
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountUsageSummaryViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountUsageSummaryViews.swift
@@ -3,42 +3,43 @@ import SwiftUI
 
 struct AccountUsageSummaryView: View {
 	let account: CodexAccount
-	let currentTime: Date
 
 	var body: some View {
-		VStack(spacing: 5) {
-			if account.hasProfileSummary {
-				AccountProfileSummaryView(account: account)
-			}
+		TimelineView(.periodic(from: Date(), by: 30)) { timeline in
+			VStack(spacing: 5) {
+				if account.hasProfileSummary {
+					AccountProfileSummaryView(account: account)
+				}
 
-			if account.hasPrimaryUsageData {
-				AccountUsageMeterView(
-					label: account.windowLabel(seconds: account.primaryWindowSeconds),
-					remainingPercent: account.primaryRemainingPercent,
-					resetAtUnixEpoch: account.primaryResetsAtUnixEpoch,
-					dailyAveragePercent: account.sevenDayAveragePercent(
-						forWindowSeconds: account.primaryWindowSeconds
-					),
-					tone: account.usageTone(remainingPercent: account.primaryRemainingPercent),
-					currentTime: currentTime
-				)
-			}
+				if account.hasPrimaryUsageData {
+					AccountUsageMeterView(
+						label: account.windowLabel(seconds: account.primaryWindowSeconds),
+						remainingPercent: account.primaryRemainingPercent,
+						resetAtUnixEpoch: account.primaryResetsAtUnixEpoch,
+						dailyAveragePercent: account.sevenDayAveragePercent(
+							forWindowSeconds: account.primaryWindowSeconds
+						),
+						tone: account.usageTone(remainingPercent: account.primaryRemainingPercent),
+						currentTime: timeline.date
+					)
+				}
 
-			if account.hasSecondaryUsageData {
-				AccountUsageMeterView(
-					label: account.windowLabel(seconds: account.secondaryWindowSeconds),
-					remainingPercent: account.secondaryRemainingPercent,
-					resetAtUnixEpoch: account.secondaryResetsAtUnixEpoch,
-					dailyAveragePercent: account.sevenDayAveragePercent(
-						forWindowSeconds: account.secondaryWindowSeconds
-					),
-					tone: account.usageTone(remainingPercent: account.secondaryRemainingPercent),
-					currentTime: currentTime
-				)
+				if account.hasSecondaryUsageData {
+					AccountUsageMeterView(
+						label: account.windowLabel(seconds: account.secondaryWindowSeconds),
+						remainingPercent: account.secondaryRemainingPercent,
+						resetAtUnixEpoch: account.secondaryResetsAtUnixEpoch,
+						dailyAveragePercent: account.sevenDayAveragePercent(
+							forWindowSeconds: account.secondaryWindowSeconds
+						),
+						tone: account.usageTone(remainingPercent: account.secondaryRemainingPercent),
+						currentTime: timeline.date
+					)
+				}
 			}
+			.frame(maxWidth: .infinity)
+			.padding(.horizontal, 1)
+			.padding(.vertical, 1)
 		}
-		.frame(maxWidth: .infinity)
-		.padding(.horizontal, 1)
-		.padding(.vertical, 1)
 	}
 }


### PR DESCRIPTION
## Summary
- replace the account removal confirmation dialog with an inline row action state
- keep removal confirmation animation local to the row action cluster so account rows do not change height
- move recurring time updates into small TimelineView subtrees instead of invalidating the whole account panel every second

## Validation
- swift test --package-path apps/decodex-app
- git diff --check