### PR TITLE
Improve macOS account removal lifecycle

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -33,7 +33,7 @@ struct AccountPanelView: View {
 	}
 
 	private var panelContent: some View {
-		VStack(alignment: .leading, spacing: 6) {
+		return VStack(alignment: .leading, spacing: 6) {
 			header
 			accountSummary
 
@@ -43,23 +43,29 @@ struct AccountPanelView: View {
 					usageEstimate: store.accountList?.usageEstimate,
 					accounts: store.accounts
 				)
+				.transition(.panelSection)
 			}
 
 			if let notice = store.notice {
 				NoticeView(text: notice)
+					.transition(.panelSection)
 			}
 
 			if let usageProbeError = store.accountList?.usageProbeError {
 				NoticeView(text: "Usage probe: \(usageProbeError)")
+					.transition(.panelSection)
 			}
 
-			if store.isInitialLoading {
-				loadingState
-			} else if store.accounts.isEmpty {
-				emptyState
-			} else {
-				accountList
+			Group {
+				if store.isInitialLoading {
+					loadingState
+				} else if store.accounts.isEmpty {
+					emptyState
+				} else {
+					accountList
+				}
 			}
+			.transition(.panelSection)
 		}
 		.frame(width: 322)
 		.padding(9)
@@ -69,6 +75,7 @@ struct AccountPanelView: View {
 		)
 		.controlSize(.small)
 		.symbolRenderingMode(.hierarchical)
+		.animation(PanelMotion.panelLayout, value: panelAnimationKey)
 	}
 
 	private var header: some View {
@@ -101,7 +108,9 @@ struct AccountPanelView: View {
 					tint: PanelPalette.secondaryText(colorScheme),
 					isActive: false,
 					action: {
-						accountPrivacy = emailsHidden ? AccountPrivacy.visibleValue : AccountPrivacy.hiddenValue
+						withAnimation(PanelMotion.inlineLayout) {
+							accountPrivacy = emailsHidden ? AccountPrivacy.visibleValue : AccountPrivacy.hiddenValue
+						}
 					},
 					help: emailsHidden ? "Show account emails" : "Hide account emails"
 				)
@@ -242,15 +251,17 @@ struct AccountPanelView: View {
 	}
 
 	private var accountRows: some View {
-		VStack(spacing: 0) {
-			ForEach(Array(store.accounts.enumerated()), id: \.element.id) { index, account in
+		let accounts = store.accounts
+
+		return VStack(spacing: 0) {
+			ForEach(Array(accounts.enumerated()), id: \.element.id) { index, account in
 				let runs = operatorCurrentLaneCards(for: account)
 
 				AccountRowView(
 					account: account,
 					runs: runs,
 					displayName: displayName(for: account),
-					showsDivider: index < store.accounts.count - 1,
+					showsDivider: index < accounts.count - 1,
 					isLogoutArmed: armedLogoutAccountID == account.id,
 					isLogoutPending: deletingLogoutAccountID == account.id,
 					logoutErrorMessage: armedLogoutAccountID == account.id ? logoutErrorMessage : nil,
@@ -277,8 +288,10 @@ struct AccountPanelView: View {
 						confirmLogout(account)
 					}
 				)
+				.transition(.accountRowRemoval)
 			}
 		}
+		.animation(PanelMotion.accountRemoval, value: accounts.map(\.id))
 	}
 
 	private var codexAuthLabel: String {
@@ -341,6 +354,20 @@ struct AccountPanelView: View {
 
 	private var accountListNeedsScrolling: Bool {
 		accountListContentHeight > accountListAvailableHeight + 1
+	}
+
+	private var panelAnimationKey: AccountPanelAnimationKey {
+		AccountPanelAnimationKey(
+			accountIDs: store.accounts.map(\.id),
+			isInitialLoading: store.isInitialLoading,
+			hasAccounts: store.accounts.isEmpty == false,
+			hasTelemetry: telemetryMatrixIsVisible,
+			hasNotice: store.notice != nil,
+			hasUsageProbeError: store.accountList?.usageProbeError != nil,
+			hasFixedSelection: hasFixedSelection,
+			emailsHidden: emailsHidden,
+			needsScrolling: accountListNeedsScrolling
+		)
 	}
 
 	private var accountListAvailableHeight: CGFloat {
@@ -472,21 +499,29 @@ struct AccountPanelView: View {
 			return
 		}
 
-		logoutErrorMessage = nil
-		armedLogoutAccountID = account.id
+		withAnimation(PanelMotion.inlineLayout) {
+			logoutErrorMessage = nil
+			armedLogoutAccountID = account.id
+		}
 	}
 
 	private func confirmLogout(_ account: CodexAccount) {
 		Task {
-			deletingLogoutAccountID = account.id
+			withAnimation(PanelMotion.accountRemoval) {
+				deletingLogoutAccountID = account.id
+				store.beginOptimisticLogoutRemoval(account)
+			}
 			logoutErrorMessage = nil
 			do {
 				try await store.logout(account)
 				deletingLogoutAccountID = nil
 				disarmLogout()
 			} catch {
-				deletingLogoutAccountID = nil
-				logoutErrorMessage = error.localizedDescription
+				withAnimation(PanelMotion.accountRemoval) {
+					store.cancelOptimisticLogoutRemoval(account)
+					deletingLogoutAccountID = nil
+					logoutErrorMessage = error.localizedDescription
+				}
 			}
 		}
 	}
@@ -495,8 +530,10 @@ struct AccountPanelView: View {
 		guard deletingLogoutAccountID == nil else {
 			return
 		}
-		logoutErrorMessage = nil
-		armedLogoutAccountID = nil
+		withAnimation(PanelMotion.inlineLayout) {
+			logoutErrorMessage = nil
+			armedLogoutAccountID = nil
+		}
 	}
 
 	private func presentLogin(_ mode: AccountLoginSheetMode) {
@@ -505,4 +542,16 @@ struct AccountPanelView: View {
 		NSApp.activate(ignoringOtherApps: true)
 		loginWindowState.isPresented = true
 	}
+}
+
+private struct AccountPanelAnimationKey: Equatable {
+	let accountIDs: [String]
+	let isInitialLoading: Bool
+	let hasAccounts: Bool
+	let hasTelemetry: Bool
+	let hasNotice: Bool
+	let hasUsageProbeError: Bool
+	let hasFixedSelection: Bool
+	let emailsHidden: Bool
+	let needsScrolling: Bool
 }

--- a/apps/decodex-app/Sources/DecodexApp/AccountRowView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountRowView.swift
@@ -61,10 +61,12 @@ struct AccountRowView: View {
 
 			if runs.isEmpty == false {
 				AccountRunSummaryView(runs: runs)
+					.transition(.panelInline)
 			}
 
 			if account.hasUsageSummary {
 				AccountUsageSummaryView(account: account)
+					.transition(.panelInline)
 			}
 		}
 		.padding(.vertical, 7)
@@ -82,6 +84,9 @@ struct AccountRowView: View {
 		}
 		.animation(PanelMotion.state, value: account.selected)
 		.animation(PanelMotion.state, value: account.codexActive)
+		.animation(PanelMotion.inlineLayout, value: runs.map(\.id))
+		.animation(PanelMotion.inlineLayout, value: account.hasUsageSummary)
+		.animation(PanelMotion.inlineLayout, value: showsDivider)
 	}
 
 	@ViewBuilder
@@ -114,6 +119,7 @@ struct AccountRowView: View {
 		.frame(width: isLogoutArmed ? AccountActionClusterLayout.confirmWidth : AccountActionClusterLayout.defaultWidth, alignment: .trailing)
 		.clipped()
 		.animation(AccountActionClusterLayout.transition, value: isLogoutArmed)
+		.animation(PanelMotion.inlineLayout, value: isLogoutPending)
 	}
 
 	private var routeHelp: String {

--- a/apps/decodex-app/Sources/DecodexApp/AccountRunStripView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountRunStripView.swift
@@ -21,6 +21,7 @@ struct AccountRunSummaryView: View {
 				} stopContinuousAction: {
 					scrollProxy.stopContinuousScroll()
 				}
+				.transition(.panelInline)
 			}
 
 			AccountRunStripScrollView(
@@ -61,6 +62,7 @@ struct AccountRunSummaryView: View {
 				} stopContinuousAction: {
 					scrollProxy.stopContinuousScroll()
 				}
+				.transition(.panelInline)
 			}
 		}
 		.frame(height: AccountRunChipLayout.height)
@@ -73,6 +75,7 @@ struct AccountRunSummaryView: View {
 		.onChange(of: runs.map(\.id)) { _, runIDs in
 			placementStore.retainOnly(Set(runIDs))
 		}
+		.animation(PanelMotion.inlineLayout, value: showsEdgeControls)
 	}
 
 	private func updateScrollMetrics(_ metrics: AccountRunStripMetrics) {
@@ -85,11 +88,18 @@ struct AccountRunSummaryView: View {
 			scrollProxy.stopContinuousScroll()
 		}
 
-		var transaction = Transaction()
-		transaction.disablesAnimations = true
-		withTransaction(transaction) {
-			scrollMetrics = metrics
-			showsEdgeControls = nextShowsEdgeControls
+		if metrics != scrollMetrics {
+			var transaction = Transaction()
+			transaction.disablesAnimations = true
+			withTransaction(transaction) {
+				scrollMetrics = metrics
+			}
+		}
+
+		if nextShowsEdgeControls != showsEdgeControls {
+			withAnimation(PanelMotion.inlineLayout) {
+				showsEdgeControls = nextShowsEdgeControls
+			}
 		}
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
@@ -19,6 +19,7 @@ final class AccountStore: ObservableObject {
 	@Published private(set) var isSettingFastMode = false
 	@Published var loginTranscript = ""
 	@Published var notice: String?
+	@Published private var pendingLogoutRemovalKeys = Set<String>()
 
 	private let bridge = DecodexAppBridge()
 	private var automaticRefreshTask: Task<Void, Never>?
@@ -35,7 +36,11 @@ final class AccountStore: ObservableObject {
 	}
 
 	var accounts: [CodexAccount] {
-		accountList?.accounts ?? []
+		guard let accounts = accountList?.accounts else {
+			return []
+		}
+
+		return accounts.filter { isLogoutRemovalPending(for: $0) == false }
 	}
 
 	var fastModeEnabled: Bool {
@@ -88,10 +93,10 @@ final class AccountStore: ObservableObject {
 		}
 
 		do {
-			accountList = try await bridge.runJSON(
+			applyAccountList(try await bridge.runJSON(
 				.accountList(forceRefresh: force),
 				as: AccountListResponse.self
-			)
+			))
 			notice = nil
 			await refreshFastMode()
 		} catch {
@@ -271,12 +276,12 @@ final class AccountStore: ObservableObject {
 	func select(_ account: CodexAccount) async {
 		do {
 			if account.selected {
-				accountList = try await bridge.runJSON(.accountClear, as: AccountListResponse.self)
+				applyAccountList(try await bridge.runJSON(.accountClear, as: AccountListResponse.self))
 			} else {
-				accountList = try await bridge.runJSON(
+				applyAccountList(try await bridge.runJSON(
 					.accountSelect(selector: account.selector),
 					as: AccountListResponse.self
-				)
+				))
 			}
 			notice = nil
 		} catch {
@@ -286,7 +291,7 @@ final class AccountStore: ObservableObject {
 
 	func clearSelection() async {
 		do {
-			accountList = try await bridge.runJSON(.accountClear, as: AccountListResponse.self)
+			applyAccountList(try await bridge.runJSON(.accountClear, as: AccountListResponse.self))
 			notice = nil
 		} catch {
 			notice = error.localizedDescription
@@ -321,13 +326,16 @@ final class AccountStore: ObservableObject {
 	}
 
 	func logout(_ account: CodexAccount) async throws {
+		beginOptimisticLogoutRemoval(account)
+
 		do {
-			accountList = try await bridge.runJSON(
+			applyAccountList(try await bridge.runJSON(
 				.accountLogout(selector: account.selector),
 				as: AccountListResponse.self
-			)
+			))
 			notice = nil
 		} catch {
+			cancelOptimisticLogoutRemoval(account)
 			throw error
 		}
 	}
@@ -338,9 +346,9 @@ final class AccountStore: ObservableObject {
 		notice = nil
 
 		do {
-			accountList = try await bridge.runStreaming(.accountLogin(), as: AccountListResponse.self) { [weak self] chunk in
+			applyAccountList(try await bridge.runStreaming(.accountLogin(), as: AccountListResponse.self) { [weak self] chunk in
 				self?.loginTranscript += chunk
-			}
+			})
 			notice = nil
 			await refreshFastMode()
 		} catch {
@@ -358,6 +366,54 @@ final class AccountStore: ObservableObject {
 			)
 		} catch {
 			notice = error.localizedDescription
+		}
+	}
+
+	func beginOptimisticLogoutRemoval(_ account: CodexAccount) {
+		pendingLogoutRemovalKeys.formUnion(Self.logoutRemovalKeys(for: account))
+	}
+
+	func cancelOptimisticLogoutRemoval(_ account: CodexAccount) {
+		pendingLogoutRemovalKeys.subtract(Self.logoutRemovalKeys(for: account))
+	}
+
+	func applyAccountList(_ response: AccountListResponse) {
+		accountList = response
+		reconcilePendingLogoutRemovals(with: response.accounts)
+	}
+
+	private func reconcilePendingLogoutRemovals(with accounts: [CodexAccount]) {
+		guard pendingLogoutRemovalKeys.isEmpty == false else {
+			return
+		}
+
+		let visibleKeys = accounts.reduce(into: Set<String>()) { keys, account in
+			keys.formUnion(Self.logoutRemovalKeys(for: account))
+		}
+		pendingLogoutRemovalKeys = pendingLogoutRemovalKeys.intersection(visibleKeys)
+	}
+
+	private func isLogoutRemovalPending(for account: CodexAccount) -> Bool {
+		Self.logoutRemovalKeys(for: account).isDisjoint(with: pendingLogoutRemovalKeys) == false
+	}
+
+	private static func logoutRemovalKeys(for account: CodexAccount) -> Set<String> {
+		[
+			account.id,
+			account.selector,
+			account.email,
+			account.accountFingerprint,
+		]
+		.compactMap { value in
+			guard let key = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+				key.isEmpty == false
+			else {
+				return nil
+			}
+			return key
+		}
+		.reduce(into: Set<String>()) { keys, key in
+			keys.insert(key)
 		}
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/AccountUsageSummaryViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountUsageSummaryViews.swift
@@ -9,6 +9,7 @@ struct AccountUsageSummaryView: View {
 			VStack(spacing: 5) {
 				if account.hasProfileSummary {
 					AccountProfileSummaryView(account: account)
+						.transition(.panelInline)
 				}
 
 				if account.hasPrimaryUsageData {
@@ -22,6 +23,7 @@ struct AccountUsageSummaryView: View {
 						tone: account.usageTone(remainingPercent: account.primaryRemainingPercent),
 						currentTime: timeline.date
 					)
+					.transition(.panelInline)
 				}
 
 				if account.hasSecondaryUsageData {
@@ -35,11 +37,15 @@ struct AccountUsageSummaryView: View {
 						tone: account.usageTone(remainingPercent: account.secondaryRemainingPercent),
 						currentTime: timeline.date
 					)
+					.transition(.panelInline)
 				}
 			}
 			.frame(maxWidth: .infinity)
 			.padding(.horizontal, 1)
 			.padding(.vertical, 1)
+			.animation(PanelMotion.inlineLayout, value: account.hasProfileSummary)
+			.animation(PanelMotion.inlineLayout, value: account.hasPrimaryUsageData)
+			.animation(PanelMotion.inlineLayout, value: account.hasSecondaryUsageData)
 		}
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
@@ -103,6 +103,40 @@ enum PanelMotion {
 	static let hover = Animation.interactiveSpring(response: 0.22, dampingFraction: 0.86, blendDuration: 0.04)
 	static let press = Animation.interactiveSpring(response: 0.16, dampingFraction: 0.78, blendDuration: 0.02)
 	static let state = Animation.interactiveSpring(response: 0.24, dampingFraction: 0.88, blendDuration: 0.05)
+	static let inlineLayout = Animation.interactiveSpring(response: 0.2, dampingFraction: 0.9, blendDuration: 0.03)
+	static let panelLayout = Animation.interactiveSpring(response: 0.3, dampingFraction: 0.92, blendDuration: 0.05)
+	static let accountRemoval = Animation.interactiveSpring(response: 0.28, dampingFraction: 0.94, blendDuration: 0.04)
+}
+
+extension AnyTransition {
+	static var panelSection: AnyTransition {
+		.asymmetric(
+			insertion: .opacity
+				.combined(with: .offset(y: -4))
+				.combined(with: .scale(scale: 0.992, anchor: .top)),
+			removal: .opacity
+				.combined(with: .offset(y: -3))
+				.combined(with: .scale(scale: 0.996, anchor: .top))
+		)
+	}
+
+	static var accountRowRemoval: AnyTransition {
+		.asymmetric(
+			insertion: .opacity
+				.combined(with: .offset(y: -3))
+				.combined(with: .scale(scale: 0.992, anchor: .top)),
+			removal: .opacity
+				.combined(with: .offset(y: -5))
+				.combined(with: .scale(scale: 0.985, anchor: .top))
+		)
+	}
+
+	static var panelInline: AnyTransition {
+		.asymmetric(
+			insertion: .opacity.combined(with: .offset(y: -2)),
+			removal: .opacity.combined(with: .offset(y: -2))
+		)
+	}
 }
 
 private extension View {

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountModelTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountModelTests.swift
@@ -74,6 +74,36 @@ final class AccountModelTests: XCTestCase {
 		XCTAssertEqual(AccountDisplay.compactEmail("xavier.lau@helixbox.ai"), "xav...lau@helixbox.ai")
 	}
 
+	@MainActor
+	func testOptimisticLogoutRemovalMasksStaleAccountListsUntilBackendCatchesUp() {
+		let removedAccount = makeAccount(
+			status: "available",
+			email: "remove@example.com",
+			accountFingerprint: "fp-remove"
+		)
+		let keptAccount = makeAccount(
+			status: "available",
+			email: "keep@example.com",
+			accountFingerprint: "fp-keep"
+		)
+		let store = AccountStore()
+
+		store.applyAccountList(makeAccountList([removedAccount, keptAccount]))
+		XCTAssertEqual(store.accounts.map(\.id), [removedAccount.id, keptAccount.id])
+
+		store.beginOptimisticLogoutRemoval(removedAccount)
+		XCTAssertEqual(store.accounts.map(\.id), [keptAccount.id])
+
+		store.applyAccountList(makeAccountList([removedAccount, keptAccount]))
+		XCTAssertEqual(store.accounts.map(\.id), [keptAccount.id])
+
+		store.applyAccountList(makeAccountList([keptAccount]))
+		XCTAssertEqual(store.accounts.map(\.id), [keptAccount.id])
+
+		store.applyAccountList(makeAccountList([removedAccount, keptAccount]))
+		XCTAssertEqual(store.accounts.map(\.id), [removedAccount.id, keptAccount.id])
+	}
+
 	func testUsageResetDisplayUsesInjectedClock() {
 		let base = Date(timeIntervalSince1970: 1_800_000_000)
 		let thirteenMinutesLater = Int(base.timeIntervalSince1970) + 780
@@ -1119,6 +1149,19 @@ final class AccountModelTests: XCTestCase {
 			sevenDayUsedPercent: nil,
 			sevenDayDailyAveragePercent: nil,
 			usageRecords: nil
+		)
+	}
+
+	private func makeAccountList(_ accounts: [CodexAccount]) -> AccountListResponse {
+		AccountListResponse(
+			accountsPath: "/tmp/accounts.json",
+			globalConfigPath: "/tmp/config.toml",
+			codexAuthPath: "/tmp/auth.json",
+			codexAuth: nil,
+			control: AccountControl(mode: "balanced", accountSelector: nil),
+			accounts: accounts,
+			usageEstimate: nil,
+			usageProbeError: nil
 		)
 	}
 }


### PR DESCRIPTION
## Summary\n- hide removed accounts immediately with local tombstones while backend account refresh catches up\n- add cohesive panel, row, notice, telemetry, usage, and run-strip transitions\n- cover stale account-list masking with a regression test\n\n## Tests\n- swift test --package-path apps/decodex-app