### PR TITLE
Fix dead run lease live status

### DIFF
--- a/apps/decodex/src/orchestrator/operator_dashboard.html
+++ b/apps/decodex/src/orchestrator/operator_dashboard.html
@@ -4465,23 +4465,14 @@
 
 			function runProcessStoppedWhileActive(run) {
 				return (
-					run.status === "running" &&
-					run.process_alive === false &&
-					!run.wait_reason &&
-					!runHasFreshExecution(run)
+					["starting", "running"].includes(run.status) &&
+					run.phase === "executing" &&
+					run.process_alive === false
 				);
 			}
 
-			function runOperationRequiresLiveAgent(run) {
-				return !run.current_operation || run.current_operation === "agent_run";
-			}
-
 			function runStoppedProcessNeedsAttention(run) {
-				return runProcessStoppedWhileActive(run) && runOperationRequiresLiveAgent(run);
-			}
-
-			function runProcessStoppedWithoutAttention(run) {
-				return runProcessStoppedWhileActive(run) && !runStoppedProcessNeedsAttention(run);
+				return runProcessStoppedWhileActive(run);
 			}
 
 				function runPhaseLabel(run) {
@@ -4531,7 +4522,7 @@
 				return (
 					["starting", "running"].includes(run.status) &&
 					run.phase === "executing" &&
-					(run.process_alive !== false || runHasFreshExecution(run)) &&
+					run.process_alive !== false &&
 					!runNeedsAttention(run)
 				);
 			}
@@ -4550,9 +4541,6 @@
 					["stalled", "failed", "terminated", "interrupted"].includes(run.status)
 				) {
 					return "tone-blocked";
-				}
-				if (runProcessStoppedWithoutAttention(run)) {
-					return "tone-run";
 				}
 				if (runTelemetryMissing(run) || runProcessStoppedWhileActive(run)) {
 					return "tone-wait";
@@ -11248,7 +11236,7 @@
 					return "tone-run";
 				}
 
-				return "tone-run";
+				return toneForRun(run);
 			}
 
 			function dashboardRunActivityIsStale(payload) {

--- a/apps/decodex/src/orchestrator/status_run_projection.rs
+++ b/apps/decodex/src/orchestrator/status_run_projection.rs
@@ -445,17 +445,17 @@ fn operator_run_liveness_state(run: &OperatorRunStatus) -> String {
 	if run.process_alive == Some(true) {
 		return String::from("process_alive");
 	}
+	if run.process_alive == Some(false)
+		|| matches!(run.execution_liveness.as_str(), "not_running" | "process_identity_mismatch")
+	{
+		return String::from("not_running");
+	}
 	if matches!(run.thread_status.as_deref(), Some("active")) || !run.thread_active_flags.is_empty()
 	{
 		return String::from("thread_active");
 	}
 	if operator_run_has_recent_app_server_execution(run) {
 		return String::from("protocol_recent");
-	}
-	if run.process_alive == Some(false)
-		|| matches!(run.execution_liveness.as_str(), "not_running" | "process_identity_mismatch")
-	{
-		return String::from("not_running");
 	}
 
 	String::from("unknown")

--- a/apps/decodex/src/orchestrator/status_summary.rs
+++ b/apps/decodex/src/orchestrator/status_summary.rs
@@ -358,7 +358,7 @@ pub(super) fn operator_run_counts_as_running(run: &OperatorRunStatus) -> bool {
 	run.ownership_state == "leased_run"
 		&& matches!(run.status.as_str(), "starting" | "running")
 		&& run.phase == "executing"
-		&& (run.process_alive != Some(false) || run.has_fresh_execution)
+		&& run.process_alive != Some(false)
 		&& !operator_run_needs_attention(run)
 }
 
@@ -379,10 +379,7 @@ pub(super) fn operator_run_needs_attention(run: &OperatorRunStatus) -> bool {
 		|| run.phase == "needs_attention"
 		|| run.suspected_stall
 		|| run.phase == "stalled"
-		|| run.process_alive == Some(false)
-			&& matches!(run.status.as_str(), "starting" | "running")
-			&& run.wait_reason.is_none()
-			&& !run.has_fresh_execution
+		|| run.process_alive == Some(false) && matches!(run.status.as_str(), "starting" | "running")
 		|| operator_run_has_stale_execution_without_known_process(run)
 }
 

--- a/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/dashboard.rs
@@ -622,8 +622,8 @@ fn operator_dashboard_current_lane_status_copy_stays_concise() {
 		"[\"model_execution\", \"tool_execution\", \"protocol_activity\"].includes(run.wait_reason)"
 	));
 	assert!(response.contains("run.wait_reason && !runWaitReasonShowsExecutionProgress(run)"));
-	assert!(response.contains("runOperationRequiresLiveAgent"));
-	assert!(response.contains("runProcessStoppedWithoutAttention"));
+	assert!(!response.contains("runOperationRequiresLiveAgent"));
+	assert!(!response.contains("runProcessStoppedWithoutAttention"));
 	assert!(response.contains("runPhaseLabel"));
 	assert!(response.contains("return run.process_liveness_reason || \"process_stopped\";"));
 	assert!(response.contains("return displayToken(run.run_phase || run.phase || run.status);"));
@@ -1527,6 +1527,9 @@ fn operator_dashboard_projects_show_compact_activity_work_and_location() {
 	assert!(response.contains("`${project.attention_count ?? 0} attention`"));
 	assert!(response.contains("`${cleanup} cleanup`"));
 	assert!(response.contains("run.process_alive !== false"));
+	assert!(!response.contains("(run.process_alive !== false || runHasFreshExecution(run))"));
+	assert!(!response.contains("run.process_alive === false &&\n\t\t\t\t\t!run.wait_reason &&\n\t\t\t\t\t!runHasFreshExecution(run)"));
+	assert!(response.contains("return toneForRun(run);"));
 	assert!(response.contains("return project.running_lane_count ?? project.current_lane_count ?? 0;"));
 	assert!(response.contains("run: derived.currentLaneCount > 0,"));
 	assert!(!response.contains("const running = project.current_lane_count ?? 0;"));

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes.rs
@@ -3648,6 +3648,77 @@ fn operator_status_snapshot_counts_stopped_active_process_as_attention_not_runni
 	assert_eq!(project.attention_count, 1);
 }
 
+#[test]
+fn operator_status_snapshot_treats_dead_leased_app_server_run_as_attention_not_running() {
+	let (_temp_dir, config, _workflow) = temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = sample_issue("Todo", &[]);
+	let worktree_path = config.worktree_root().join("PUB-101");
+
+	state_store
+		.record_run_attempt("run-1", &issue.id, 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", &issue.id, "run-1", "In Progress")
+		.expect("lease should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+	state::write_run_activity_marker_for_process(&worktree_path, "run-1", 1, u32::MAX)
+		.expect("stopped process marker should write");
+	state::write_run_thread_status_marker(
+		&worktree_path,
+		"run-1",
+		1,
+		Some("thread-1"),
+		Some("turn-1"),
+		"active",
+		&[],
+	)
+	.expect("thread status should write");
+	state::write_run_protocol_activity_marker(
+		&worktree_path,
+		&ProtocolActivityMarker {
+			run_id: "run-1",
+			attempt_number: 1,
+			thread_id: Some("thread-1"),
+			turn_id: Some("turn-1"),
+			event_count: 2,
+			last_event_type: "model/response",
+			child_agent_activity: None,
+			protocol_activity: None,
+		},
+	)
+	.expect("protocol summary should write");
+
+	let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+		.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("current lane should remain visible");
+	let project = snapshot.projects.first().expect("project summary should exist");
+
+	assert_eq!(run.status, "running");
+	assert_eq!(run.attempt_status, "running");
+	assert!(run.run_lease);
+	assert_eq!(run.queue_lease_state, "held");
+	assert_eq!(run.process_alive, Some(false));
+	assert_eq!(run.process_liveness_reason.as_deref(), Some("process_stopped"));
+	assert_eq!(run.thread_status.as_deref(), Some("active"));
+	assert_eq!(run.liveness_state, "not_running");
+	assert!(run.has_fresh_execution);
+	assert!(!run.counts_as_running);
+	assert!(run.needs_attention);
+	assert_eq!(project.current_lane_count, 1);
+	assert_eq!(project.running_lane_count, 0);
+	assert_eq!(project.attention_count, 1);
+}
+
 #[cfg(unix)]
 #[test]
 fn operator_status_snapshot_counts_zombie_active_process_as_attention_not_running() {


### PR DESCRIPTION
## Summary
- Treat `process_alive=false` as not-running/attention even when a run lease and fresh app-server protocol evidence remain.
- Align dashboard fallback running/attention tone logic with server-side status semantics.
- Add a regression test for a leased running attempt with dead process and active thread/protocol evidence.

## Validation
- cargo test -p decodex operator_status_snapshot_treats_dead_leased_app_server_run_as_attention_not_running -- --nocapture
- cargo test -p decodex operator_dashboard_current_lane_status_copy_stays_concise -- --nocapture
- cargo test -p decodex operator_dashboard_projects_show_compact_activity_work_and_location -- --nocapture
- cargo make fmt-check
- cargo make check-rust
- cargo make lint-rust

## Notes
- `cargo make test-rust` currently stops on unrelated `autonomy_lineage_readback_tests::operator_status_surfaces_autonomy_lineage_without_raw_payloads` because serialized test output contains `/Users/x`.

Fixes XY-1124.
Related XY-1123.