### PR TITLE
Tighten dependency roll plugin contract

### DIFF
--- a/apps/decodex/src/plugin_surface_tests.rs
+++ b/apps/decodex/src/plugin_surface_tests.rs
@@ -426,6 +426,9 @@ fn packaged_codebase_skills_preserve_command_and_verification_authority() {
 	assert_contains(&repo_surface, "Run `plugin-eval analyze <plugin-root> --format markdown`");
 	assert_contains(&repo_surface, "Task-runner review checklist");
 	assert_contains(&repo_surface, "External `uses: owner/action@ref`");
+	assert_contains(&repo_surface, "whole discoverable dependency surface");
+	assert_contains(&repo_surface, "open Dependabot PRs are authoritative candidates");
+	assert_contains(&repo_surface, "residual dependency checks");
 	assert_contains(&repo_surface, "requires-follow-up-migration");
 	assert_contains(&repo_surface, "Do not duplicate this routing in host bootstrap files");
 }

--- a/plugins/codebase/references/dependency-policy.md
+++ b/plugins/codebase/references/dependency-policy.md
@@ -5,16 +5,27 @@ generated dependency artifacts, or GitHub Actions action pins affect repository 
 
 ## Modes
 
-- `roll`: move to the latest supportable compatible release set for the affected
-  ecosystem. Migrate reasonable source/config/workflow breakage in the same lane.
+- `roll`: enumerate the whole discoverable dependency surface first, then move to
+  the latest supportable compatible release set for the affected ecosystem in one
+  consolidated lane. Migrate reasonable source/config/workflow breakage in the same
+  lane. A roll is not just `cargo update`, lockfile refresh, or the first green PR.
 - `style`: normalize dependency specifiers, manifest entry shape, or GitHub Actions
   full-SHA pins without selecting newer dependency versions.
 
 ## Rules
 
+- Start with an inventory. Include direct package manifests, lockfiles, generated
+  dependency artifacts, workflow action refs, ecosystem-specific tool manifests,
+  and open Dependabot PRs when GitHub PR access is available.
+- Treat open Dependabot PRs as authoritative update candidates, not as separate work
+  to land one by one. Consolidate their versions or SHAs into the roll, then
+  reconcile or supersede them only after the consolidated change has passed
+  verification.
 - Change manifests before regenerating lockfiles or generated dependency artifacts.
   Never hand-edit generated dependency artifacts.
 - Preserve repo-local manifest style unless checked-in policy says otherwise.
+- Do not stop at the current manifest constraint. In roll mode, direct manifests are
+  in scope, including semver-major bumps.
 - Do not stop at an older major just because the first bump fails. Inspect the break,
   migrate reasonable incompatibilities, and leave older versions only with concrete
   runtime, platform, API, constraint, upstream, or migration-scope evidence.
@@ -22,6 +33,20 @@ generated dependency artifacts, or GitHub Actions action pins affect repository 
   record `requires-follow-up-migration` with attempted target, failure evidence, and
   next lane.
 - Reconcile Dependabot last, after manifests, lockfiles, and verification.
+
+## Compatibility
+
+Compatible means supportable after reasonable agent-applied migration, not "builds
+without source changes." API, build-script, formatting, config, workflow, generated
+artifact, or feature-flag changes are part of the roll when they can be migrated with
+repository-local judgment and validation.
+
+Use `blocked` only for concrete blockers such as upstream packages that do not build
+for the required target or feature set, MSRV/runtime/toolchain constraints outside
+repo policy, security/license/policy conflicts, or migration decisions requiring
+product/API authority outside dependency maintenance. Use
+`requires-follow-up-migration` for supportable-but-larger migrations that need their
+own lane.
 
 ## GitHub Actions
 
@@ -39,5 +64,12 @@ generated dependency artifacts, or GitHub Actions action pins affect repository 
 ## Evidence
 
 Report mode, changed manifests/workflows, lockfiles/generated artifacts, selected
-release/tag to full-SHA provenance, commands run, and `covered`,
-`requires-follow-up-migration`, `blocked`, or intentionally deferred items.
+release/tag to full-SHA provenance, discovered update candidates, commands run,
+residual dependency checks, and `covered`, `requires-follow-up-migration`,
+`blocked`, or intentionally deferred items.
+
+Roll-ready evidence must include the remaining candidate scan appropriate to the
+repository, such as open dependency PRs, manifest outdated checks, lockfile update
+dry-runs, workflow action refs, or ecosystem-specific update reports. If any scan is
+unavailable, report the missing access or tool as an evidence gap instead of claiming
+full coverage.

--- a/plugins/codebase/scripts/codex_lifecycle_hook
+++ b/plugins/codebase/scripts/codex_lifecycle_hook
@@ -70,7 +70,8 @@ PUBLIC_SURFACE_HINT = (
 DEPENDENCY_POLICY_HINT = (
     "Changed files include dependency manifests, lockfiles, generated dependency "
     "artifacts, or workflow action refs. Load $codebase:dependency-policy and report "
-    "whether this is a roll or style-only dependency change with version/SHA evidence."
+    "whether this is a roll or style-only dependency change with version/SHA evidence, "
+    "a discovered-candidate inventory, and residual dependency checks."
 )
 TASK_RUNNER_HINT = (
     "Changed files include Makefile.toml or an equivalent task-runner surface. Load "

--- a/plugins/codebase/skills/dependency-policy/SKILL.md
+++ b/plugins/codebase/skills/dependency-policy/SKILL.md
@@ -15,14 +15,27 @@ lockfiles, generated dependency artifacts, Dependabot branches, or
 
 ## Modes
 
-- `roll`: move to the latest supportable compatible release set, migrate reasonable
-  source/config breakage in the same lane, and record concrete blockers for anything
-  left behind.
+- `roll`: enumerate the whole discoverable dependency surface first, then move to
+  the latest supportable compatible release set in one consolidated lane. This is
+  not lockfile-only update. Include direct manifest bumps, including semver-major
+  bumps, generated dependency artifacts, existing Dependabot PR candidates, and
+  GitHub Actions external refs. Migrate reasonable source/config/workflow breakage
+  in the same lane, and record concrete blockers for anything left behind.
 - `style`: normalize dependency specifiers, manifest entry shape, or GitHub Actions
   full-SHA pins without selecting newer dependency versions.
+
+## Roll Completion
+
+Before claiming a dependency roll is ready, prove the consolidated change covered,
+blocked, or intentionally deferred every discovered update candidate. For repositories
+with GitHub PR access, open Dependabot PRs are authoritative candidates, and the
+completion evidence must include the residual open dependency PR check. Do not claim
+completion from a passing PR alone when other dependency PRs, manifest bumps, or action
+refs remain outside the consolidated change.
 
 ## Output
 
 Report mode, changed manifests/workflows, lockfiles or generated artifacts, selected
-release/tag to full-SHA provenance, verification commands, and any covered,
-blocked, deferred, or `requires-follow-up-migration` items.
+release/tag to full-SHA provenance, discovered update candidates, residual checks,
+verification commands, and any covered, blocked, deferred, or
+`requires-follow-up-migration` items.

--- a/tests/plugins/codebase/test_codex_lifecycle_hook.py
+++ b/tests/plugins/codebase/test_codex_lifecycle_hook.py
@@ -163,6 +163,8 @@ class CodexLifecycleHookTests(unittest.TestCase):
         joined = "\n".join(hints)
         self.assertIn("$codebase:dependency-policy", joined)
         self.assertIn("roll or style-only", joined)
+        self.assertIn("discovered-candidate inventory", joined)
+        self.assertIn("residual dependency checks", joined)
 
     def test_task_runner_surface_adds_task_runner_hint(self) -> None:
         self.hook.large_change_paths = lambda stats=None: []


### PR DESCRIPTION
## Summary
- Define dependency roll as a full discovered-candidate inventory plus one consolidated update lane
- Treat open Dependabot PRs, direct manifest bumps, generated artifacts, and workflow action refs as roll candidates
- Require residual dependency checks before ready claims

## Validation
- cargo test -p decodex plugin_surface_tests::packaged_codebase_skills_preserve_command_and_verification_authority
- python3 -m unittest tests.plugins.codebase.test_codex_lifecycle_hook.CodexLifecycleHookTests.test_dependency_surface_adds_dependency_policy_hint
- git diff --check
- plugin-eval analyze plugins/codebase: 100/100, A, low risk
