### PR TITLE
Unify installable plugin versions

### DIFF
--- a/plugins/codebase/.codex-plugin/plugin.json
+++ b/plugins/codebase/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Codebase work contracts for repository command authority, task runners, module boundaries, dependency policy, review repair, verification, and debugging.",
   "author": {
     "name": "hack-ink",

--- a/plugins/codebase/hooks/hooks.json
+++ b/plugins/codebase/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CODEX_HOME:-$HOME/.codex}/plugins/cache/hack-ink/codebase/0.1.0/scripts/codex_lifecycle_hook\" --event UserPromptSubmit",
+            "command": "python3 \"${CODEX_HOME:-$HOME/.codex}/plugins/cache/hack-ink/codebase/0.2.0/scripts/codex_lifecycle_hook\" --event UserPromptSubmit",
             "timeout": 10
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CODEX_HOME:-$HOME/.codex}/plugins/cache/hack-ink/codebase/0.1.0/scripts/codex_lifecycle_hook\" --event PreToolUse",
+            "command": "python3 \"${CODEX_HOME:-$HOME/.codex}/plugins/cache/hack-ink/codebase/0.2.0/scripts/codex_lifecycle_hook\" --event PreToolUse",
             "timeout": 10
           }
         ]
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CODEX_HOME:-$HOME/.codex}/plugins/cache/hack-ink/codebase/0.1.0/scripts/codex_lifecycle_hook\" --event PostToolUse",
+            "command": "python3 \"${CODEX_HOME:-$HOME/.codex}/plugins/cache/hack-ink/codebase/0.2.0/scripts/codex_lifecycle_hook\" --event PostToolUse",
             "timeout": 10
           }
         ]
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CODEX_HOME:-$HOME/.codex}/plugins/cache/hack-ink/codebase/0.1.0/scripts/codex_lifecycle_hook\" --event PreCompact",
+            "command": "python3 \"${CODEX_HOME:-$HOME/.codex}/plugins/cache/hack-ink/codebase/0.2.0/scripts/codex_lifecycle_hook\" --event PreCompact",
             "timeout": 10
           }
         ]

--- a/plugins/deliberation/.codex-plugin/plugin.json
+++ b/plugins/deliberation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deliberation",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Portable agent deliberation methods for read-only scout, grill, and skeptic review.",
   "author": {
     "name": "hack-ink",

--- a/plugins/knowledge/.codex-plugin/plugin.json
+++ b/plugins/knowledge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Knowledge and documentation workflows for OKF, LLM Wiki navigation, semantic drift, source-backed repo memory, and knowledge writeback.",
   "author": {
     "name": "hack-ink",


### PR DESCRIPTION
## Summary
- Set codebase, deliberation, and knowledge plugin versions to 0.2.0 to match decodex
- Update codebase hook commands to load from the 0.2.0 cache path

## Validation
- cargo test -p decodex plugin_surface_tests
- python3 -m unittest tests.plugins.codebase.test_codex_lifecycle_hook
- git diff --check
- plugin-eval analyze plugins/{codebase,decodex,deliberation,knowledge}: all 100/100, A, low risk
