### PR TITLE
Guard root worktree task branch mutations

### DIFF
--- a/plugins/codebase/scripts/codex_lifecycle_hook
+++ b/plugins/codebase/scripts/codex_lifecycle_hook
@@ -6,6 +6,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
+import shlex
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -79,6 +81,18 @@ TASK_RUNNER_HINT = (
     "action-first public names, no command aliases, deterministic ordering, no long "
     "inline shell, and stale-command reverse checks."
 )
+
+ROOT_TASK_BRANCH_BLOCK = (
+    "Refusing repository mutation from the root worktree on a non-default branch. "
+    "Root direct-push work must stay on the default branch. PR/task-branch work "
+    "must happen in `.worktrees/<task>/`; a task branch in the root worktree is not "
+    "an isolated working context."
+)
+ROOT_TASK_BRANCH_SWITCH_BLOCK = (
+    "Refusing to switch the root worktree to a task branch. Root direct-push work "
+    "must stay on the default branch. PR/task-branch work must happen in "
+    "`.worktrees/<task>/`."
+)
 DELIBERATION_GATE_HINT = (
     "When the task involves design, architecture, refactor, root-cause debugging, "
     "research, option comparison, or important ready/done claims, use compact "
@@ -98,6 +112,78 @@ COMMIT_COMMAND_TERMS = [
     "git push",
     "gh pr merge",
 ]
+ALWAYS_MUTATING_TOOL_NAMES = {
+    "apply_patch",
+    "edit",
+    "write",
+}
+MUTATING_COMMAND_TERMS = (
+    "add",
+    "am",
+    "apply",
+    "cherry-pick",
+    "clean",
+    "commit",
+    "merge",
+    "mv",
+    "pull",
+    "push",
+    "rebase",
+    "reset",
+    "restore",
+    "rm",
+    "stash",
+    "switch",
+    "checkout",
+)
+GIT_GLOBAL_OPTIONS_WITH_ARG = {
+    "-C",
+    "-c",
+    "--exec-path",
+    "--git-dir",
+    "--namespace",
+    "--super-prefix",
+    "--work-tree",
+}
+GIT_GLOBAL_OPTIONS_WITH_VALUE_PREFIX = (
+    "--exec-path=",
+    "--git-dir=",
+    "--namespace=",
+    "--super-prefix=",
+    "--work-tree=",
+)
+GIT_BRANCH_CREATE_OPTIONS = {
+    "-b",
+    "-B",
+    "-c",
+    "-C",
+    "--create",
+    "--force-create",
+    "--orphan",
+}
+GIT_OPTIONS_WITH_ARG = {
+    "--conflict",
+    "--pathspec-from-file",
+}
+SHELL_MUTATING_COMMANDS = {
+    "cp",
+    "install",
+    "mkdir",
+    "mv",
+    "rm",
+    "tee",
+    "touch",
+}
+REDIRECTION_OPERATORS = {
+    ">",
+    ">>",
+    "1>",
+    "1>>",
+    "2>",
+    "2>>",
+    "&>",
+    "&>>",
+}
 PUBLIC_SURFACE_PREFIXES = (
     ".agents/",
     ".codex/",
@@ -226,11 +312,36 @@ def walk_strings(value: Any) -> list[str]:
     return []
 
 
-def git_output(args: list[str], timeout: int = 3) -> str | None:
+def first_payload_string_for_keys(value: Any, keys: set[str]) -> str | None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key in keys and isinstance(item, str):
+                return item
+        for item in value.values():
+            nested = first_payload_string_for_keys(item, keys)
+            if nested is not None:
+                return nested
+    if isinstance(value, list):
+        for item in value:
+            nested = first_payload_string_for_keys(item, keys)
+            if nested is not None:
+                return nested
+    return None
+
+
+def payload_command_text(payload: dict[str, Any]) -> str:
+    command = first_payload_string_for_keys(payload, {"cmd", "command", "script"})
+    if command is not None:
+        return command
+    return " ".join(walk_strings(payload))
+
+
+def git_output(args: list[str], timeout: int = 3, cwd: Path | None = None) -> str | None:
     try:
         result = subprocess.run(
             args,
             check=True,
+            cwd=str(cwd) if cwd is not None else None,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
@@ -244,6 +355,46 @@ def git_output(args: list[str], timeout: int = 3) -> str | None:
 def git_root() -> str | None:
     output = git_output(["git", "rev-parse", "--show-toplevel"], timeout=2)
     return output.strip() if output else None
+
+
+def git_current_branch() -> str | None:
+    output = git_output(["git", "branch", "--show-current"], timeout=2)
+    branch = output.strip() if output else ""
+    return branch or None
+
+
+def git_default_branch() -> str | None:
+    output = git_output(["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"], timeout=2)
+    if output:
+        branch = output.strip()
+        if "/" in branch:
+            return branch.split("/", maxsplit=1)[1]
+        if branch:
+            return branch
+    output = git_output(["git", "config", "--get", "init.defaultBranch"], timeout=2)
+    branch = output.strip() if output else ""
+    return branch or "main"
+
+
+def git_is_root_worktree() -> bool:
+    git_dir = git_output(["git", "rev-parse", "--path-format=absolute", "--git-dir"], timeout=2)
+    common_dir = git_output(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        timeout=2,
+    )
+    if not git_dir or not common_dir:
+        return False
+    try:
+        return Path(git_dir.strip()).resolve() == Path(common_dir.strip()).resolve()
+    except OSError:
+        return git_dir.strip() == common_dir.strip()
+
+
+def git_branch_ref_exists(target: str) -> bool:
+    if not target:
+        return False
+    refs = [target, f"refs/heads/{target}", f"refs/remotes/{target}", f"refs/remotes/origin/{target}"]
+    return any(git_output(["git", "rev-parse", "--verify", "--quiet", ref], timeout=2) for ref in refs)
 
 
 def changed_file_stats() -> list[dict[str, Any]]:
@@ -424,6 +575,380 @@ def text_has_any(text: str, terms: list[str]) -> bool:
     return any(term in lowered for term in terms)
 
 
+def payload_tool_name(payload: dict[str, Any]) -> str:
+    for key in ("tool_name", "toolName", "tool"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def shell_segments(text: str) -> list[str]:
+    return [" ".join(tokens) for tokens in shell_token_segments(text)]
+
+
+def shell_token_segments(text: str) -> list[list[str]]:
+    segments: list[list[str]] = []
+    try:
+        lexer = shlex.shlex(text.replace("\n", ";"), posix=True, punctuation_chars=";&|<>")
+        lexer.whitespace_split = True
+        tokens = list(lexer)
+    except ValueError:
+        return []
+    current: list[str] = []
+    for token in tokens:
+        if token in {";", "&&", "||", "|", "&"}:
+            if current:
+                segments.append(current)
+                current = []
+            continue
+        current.append(token)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def shell_tokens(segment: str) -> list[str]:
+    segments = shell_token_segments(segment)
+    return segments[0] if segments else []
+
+
+def split_git_command(tokens: list[str]) -> tuple[str, list[str], str | None] | None:
+    tokens = unwrap_shell_command_tokens(tokens)
+    if not tokens or tokens[0] != "git":
+        return None
+    index = 1
+    command_cwd: str | None = None
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if token in GIT_GLOBAL_OPTIONS_WITH_ARG:
+            if token == "-C" and index + 1 < len(tokens):
+                command_cwd = tokens[index + 1]
+            index += 2
+            continue
+        if any(token.startswith(prefix) for prefix in GIT_GLOBAL_OPTIONS_WITH_VALUE_PREFIX):
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    if index >= len(tokens):
+        return None
+    return tokens[index], tokens[index + 1 :], command_cwd
+
+
+def unwrap_shell_command_tokens(tokens: list[str]) -> list[str]:
+    index = 0
+    while index < len(tokens) and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", tokens[index]):
+        index += 1
+    if index < len(tokens) and tokens[index] == "env":
+        index += 1
+        while index < len(tokens):
+            token = tokens[index]
+            if token == "--":
+                index += 1
+                break
+            if token in {"-S", "--split-string"} and index + 1 < len(tokens):
+                try:
+                    return shlex.split(tokens[index + 1]) + tokens[index + 2 :]
+                except ValueError:
+                    return []
+            if token.startswith("-S") and len(token) > 2:
+                try:
+                    return shlex.split(token[2:]) + tokens[index + 1 :]
+                except ValueError:
+                    return []
+            if token.startswith("--split-string="):
+                try:
+                    return shlex.split(token.split("=", maxsplit=1)[1]) + tokens[index + 1 :]
+                except ValueError:
+                    return []
+            if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", token):
+                index += 1
+                continue
+            if token in {"-i", "--ignore-environment", "-0", "--null"}:
+                index += 1
+                continue
+            if token in {"-u", "--unset", "-C", "--chdir", "-P", "--path"}:
+                index += 2
+                continue
+            if token.startswith(("--unset=", "--chdir=", "--path=")):
+                index += 1
+                continue
+            if token.startswith("-"):
+                index += 1
+                continue
+            break
+        while index < len(tokens) and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", tokens[index]):
+            index += 1
+    return tokens[index:]
+
+
+def git_command_cwd_targets_root(command_cwd: str | None, root: str | None) -> bool:
+    if not command_cwd or not root:
+        return True
+    try:
+        root_path = Path(root).resolve()
+        cwd_path = Path(command_cwd)
+        if not cwd_path.is_absolute():
+            cwd_path = root_path / cwd_path
+        cwd_path = cwd_path.resolve()
+    except OSError:
+        return True
+    worktrees_path = root_path / ".worktrees"
+    if cwd_path == worktrees_path or worktrees_path not in cwd_path.parents:
+        return True
+    target_root = git_output(["git", "rev-parse", "--show-toplevel"], timeout=2, cwd=cwd_path)
+    if not target_root:
+        return True
+    try:
+        return Path(target_root.strip()).resolve() == root_path
+    except OSError:
+        return True
+
+
+def checkout_branch_target(args: list[str], command: str) -> tuple[str, bool] | None:
+    args_before_pathspec = args[: args.index("--")] if "--" in args else args
+    index = 0
+    operands: list[str] = []
+    while index < len(args_before_pathspec):
+        token = args_before_pathspec[index]
+        if token in GIT_BRANCH_CREATE_OPTIONS:
+            target = args_before_pathspec[index + 1] if index + 1 < len(args_before_pathspec) else ""
+            return target, True
+        if token in GIT_OPTIONS_WITH_ARG:
+            index += 2
+            continue
+        if token.startswith("--"):
+            index += 1
+            continue
+        if token.startswith("-") and token not in {"-", "@{-1}"}:
+            index += 1
+            continue
+        operands.append(token)
+        index += 1
+
+    if "--" in args:
+        return None
+    if not operands:
+        return None
+    target = operands[0]
+    if command == "switch" or target in {"-", "@{-1}"} or git_branch_ref_exists(target):
+        return target, False
+    return None
+
+
+def git_switch_targets(text: str, root: str | None = None) -> list[tuple[str, bool]]:
+    targets: list[tuple[str, bool]] = []
+    for tokens in shell_token_segments(text):
+        parsed = split_git_command(tokens)
+        if not parsed:
+            continue
+        command, args, command_cwd = parsed
+        if not git_command_cwd_targets_root(command_cwd, root):
+            continue
+        if command not in {"switch", "checkout"}:
+            continue
+        target = checkout_branch_target(args, command)
+        if target:
+            targets.append(target)
+    return targets
+
+
+def target_is_default_branch(target: str, default_branch: str) -> bool:
+    return target in {default_branch, f"origin/{default_branch}", f"refs/heads/{default_branch}"}
+
+
+def switches_root_to_non_default_branch(text: str, default_branch: str, root: str | None = None) -> bool:
+    for target, creates_branch in git_switch_targets(text, root):
+        if creates_branch:
+            return True
+        if target and not target_is_default_branch(target, default_branch):
+            return True
+    return False
+
+
+def switches_root_back_to_default_branch(text: str, default_branch: str, root: str | None = None) -> bool:
+    targets = git_switch_targets(text, root)
+    return bool(targets) and all(
+        not creates_branch and target_is_default_branch(target, default_branch)
+        for target, creates_branch in targets
+    )
+
+
+def is_switch_back_segment(tokens: list[str], default_branch: str, root: str | None = None) -> bool:
+    parsed = split_git_command(tokens)
+    if not parsed:
+        return False
+    command, args, command_cwd = parsed
+    if not git_command_cwd_targets_root(command_cwd, root):
+        return False
+    if command not in {"switch", "checkout"}:
+        return False
+    target = checkout_branch_target(args, command)
+    return bool(
+        target
+        and not target[1]
+        and target_is_default_branch(target[0], default_branch)
+    )
+
+
+def has_shell_control_or_redirection(text: str) -> bool:
+    return has_unquoted_shell_control(text) or has_unquoted_redirection(text) or has_shell_substitution(text)
+
+
+def has_shell_substitution(text: str) -> bool:
+    single_quote = False
+    double_quote = False
+    escaped = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if char == "\\":
+            escaped = True
+            index += 1
+            continue
+        if char == "'" and not double_quote:
+            single_quote = not single_quote
+            index += 1
+            continue
+        if char == '"' and not single_quote:
+            double_quote = not double_quote
+            index += 1
+            continue
+        if not single_quote and (char == "`" or text.startswith("$(", index)):
+            return True
+        index += 1
+    return False
+
+
+def has_unquoted_shell_control(text: str) -> bool:
+    single_quote = False
+    double_quote = False
+    escaped = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if char == "\\":
+            escaped = True
+            index += 1
+            continue
+        if char == "'" and not double_quote:
+            single_quote = not single_quote
+            index += 1
+            continue
+        if char == '"' and not single_quote:
+            double_quote = not double_quote
+            index += 1
+            continue
+        if not single_quote and not double_quote:
+            if text.startswith("&&", index) or text.startswith("||", index):
+                return True
+            if char in {"|", ";", "&", "\n"}:
+                return True
+        index += 1
+    return False
+
+
+def has_unquoted_redirection(text: str) -> bool:
+    single_quote = False
+    double_quote = False
+    escaped = False
+    for char in text:
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "'" and not double_quote:
+            single_quote = not single_quote
+            continue
+        if char == '"' and not single_quote:
+            double_quote = not double_quote
+            continue
+        if not single_quote and not double_quote and char in {"<", ">"}:
+            return True
+    return False
+
+
+def is_only_root_switch_back(text: str, default_branch: str, root: str | None = None) -> bool:
+    if has_shell_control_or_redirection(text):
+        return False
+    segments = shell_token_segments(text)
+    return bool(segments) and all(is_switch_back_segment(segment, default_branch, root) for segment in segments)
+
+
+def payload_is_mutating(payload: dict[str, Any], text: str, root: str | None = None) -> bool:
+    tool_name = payload_tool_name(payload).lower()
+    if any(name in tool_name for name in ALWAYS_MUTATING_TOOL_NAMES):
+        return True
+    if has_shell_substitution(text) or has_unquoted_redirection(text):
+        return True
+    for tokens in shell_token_segments(text):
+        if shell_segment_is_mutating(tokens, root):
+            return True
+    return False
+
+
+def shell_segment_is_mutating(tokens: list[str], root: str | None = None) -> bool:
+    if not tokens:
+        return False
+    tokens = unwrap_shell_command_tokens(tokens)
+    if not tokens:
+        return False
+    parsed = split_git_command(tokens)
+    if parsed:
+        command, _, command_cwd = parsed
+        if not git_command_cwd_targets_root(command_cwd, root):
+            return False
+        return command in MUTATING_COMMAND_TERMS
+    command = tokens[0]
+    if command in SHELL_MUTATING_COMMANDS:
+        return True
+    if command == "cargo":
+        return len(tokens) > 1 and (tokens[1] in {"fmt", "fix"} or (tokens[1] == "clippy" and "--fix" in tokens))
+    if command in {"npm", "pnpm", "yarn", "bun"}:
+        return len(tokens) > 1 and tokens[1] in {"add", "install", "remove", "update"}
+    if command in {"perl", "sed"}:
+        return any(token in {"-i", "--in-place"} or token.startswith("-i") for token in tokens[1:])
+    return False
+
+
+def pre_tool_use_block_reason(payload: dict[str, Any], root: str | None, text: str) -> str | None:
+    if not root or not git_is_root_worktree():
+        return None
+
+    default_branch = git_default_branch()
+    current_branch = git_current_branch()
+    if not default_branch or not current_branch:
+        return None
+
+    if current_branch == default_branch:
+        if switches_root_to_non_default_branch(text, default_branch, root):
+            return ROOT_TASK_BRANCH_SWITCH_BLOCK
+        return None
+
+    if is_only_root_switch_back(text, default_branch, root):
+        return None
+
+    if payload_is_mutating(payload, text, root):
+        return ROOT_TASK_BRANCH_BLOCK
+    return None
+
+
 def dedupe_hints(hints: list[str]) -> list[str]:
     seen = set()
     unique = []
@@ -524,6 +1049,13 @@ def main() -> int:
     payload = load_payload()
     root = git_root()
     prompt_text = " ".join(walk_strings(payload))
+    command_text = payload_command_text(payload)
+    if args.event == "PreToolUse":
+        block_reason = pre_tool_use_block_reason(payload, root, command_text)
+        if block_reason:
+            record_event(args.event, payload, root, [block_reason])
+            print(json.dumps({"decision": "block", "reason": block_reason}))
+            return 0
     hints = route_hints(prompt_text, root, args.event)
     record_event(args.event, payload, root, hints)
     if hints:

--- a/tests/plugins/codebase/test_codex_lifecycle_hook.py
+++ b/tests/plugins/codebase/test_codex_lifecycle_hook.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
+import sys
 import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
@@ -86,6 +89,515 @@ class CodexLifecycleHookTests(unittest.TestCase):
         joined = "\n".join(hints)
         self.assertIn("repair non-JSON ahead commit subjects", joined)
         self.assertIn("plain prose subject", joined)
+
+    def test_root_task_branch_apply_patch_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+        payload = {"tool_name": "apply_patch", "tool_input": {"patch": "*** Begin Patch"}}
+
+        reason = self.hook.pre_tool_use_block_reason(
+            payload,
+            "/tmp/repo",
+            "apply_patch *** Begin Patch",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+        self.assertIn(".worktrees/<task>", reason or "")
+
+    def test_root_task_branch_read_only_command_is_allowed(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "git status --short"}},
+            "/tmp/repo",
+            "git status --short",
+        )
+
+        self.assertIsNone(reason)
+
+    def test_root_task_branch_can_switch_back_to_default(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "git switch main"}},
+            "/tmp/repo",
+            "git switch main",
+        )
+
+        self.assertIsNone(reason)
+
+    def test_root_task_branch_switch_back_mixed_with_mutation_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "git switch main && touch x"}},
+            "/tmp/repo",
+            "git switch main && touch x",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_task_branch_switch_back_with_redirection_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "git switch main > out"}},
+            "/tmp/repo",
+            "git switch main > out",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_task_branch_switch_back_with_command_substitution_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "git switch main $(touch x)"}},
+            "/tmp/repo",
+            "git switch main $(touch x)",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_task_branch_read_only_with_command_substitution_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "git status $(touch x)"}},
+            "/tmp/repo",
+            "git status $(touch x)",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_task_branch_quoted_command_substitution_search_is_allowed(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "rg '$(' docs"}},
+            "/tmp/repo",
+            "rg '$(' docs",
+        )
+
+        self.assertIsNone(reason)
+
+    def test_root_task_branch_double_quoted_command_substitution_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "echo \"'$(touch x)'\""}},
+            "/tmp/repo",
+            "echo \"'$(touch x)'\"",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_task_branch_mutation_without_spaced_operator_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "git status&&touch out"}},
+            "/tmp/repo",
+            "git status&&touch out",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_task_branch_ampersand_separated_mutation_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "git status & touch out"}},
+            "/tmp/repo",
+            "git status & touch out",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_task_branch_newline_separated_mutation_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "git status\ntouch out"}},
+            "/tmp/repo",
+            "git status\ntouch out",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_task_branch_assignment_prefixed_mutation_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "VAR=1 touch x"}},
+            "/tmp/repo",
+            "VAR=1 touch x",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_task_branch_redirection_without_spaced_operator_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "echo hi>out"}},
+            "/tmp/repo",
+            "echo hi>out",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_default_branch_can_direct_push_mutate(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "main"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "apply_patch", "tool_input": {"patch": "*** Begin Patch"}},
+            "/tmp/repo",
+            "apply_patch *** Begin Patch",
+        )
+
+        self.assertIsNone(reason)
+
+    def test_root_default_branch_task_switch_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "main"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "git switch -c xy/task"}},
+            "/tmp/repo",
+            "git switch -c xy/task",
+        )
+
+        self.assertIn("Refusing to switch the root worktree", reason or "")
+
+    def test_root_default_branch_task_switch_with_git_c_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "main"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "git -C /tmp/repo switch -c xy/task"}},
+            "/tmp/repo",
+            "git -C /tmp/repo switch -c xy/task",
+        )
+
+        self.assertIn("Refusing to switch the root worktree", reason or "")
+
+    def test_root_default_branch_assignment_prefixed_task_switch_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "main"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "VAR=1 git switch -c xy/task"}},
+            "/tmp/repo",
+            "VAR=1 git switch -c xy/task",
+        )
+
+        self.assertIn("Refusing to switch the root worktree", reason or "")
+
+    def test_root_default_branch_env_prefixed_task_switch_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "main"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "env VAR=1 git switch -c xy/task"}},
+            "/tmp/repo",
+            "env VAR=1 git switch -c xy/task",
+        )
+
+        self.assertIn("Refusing to switch the root worktree", reason or "")
+
+    def test_root_default_branch_env_option_prefixed_task_switch_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "main"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "env -i git switch -c xy/task"}},
+            "/tmp/repo",
+            "env -i git switch -c xy/task",
+        )
+
+        self.assertIn("Refusing to switch the root worktree", reason or "")
+
+    def test_root_default_branch_env_double_dash_task_switch_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "main"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "env -- git switch -c xy/task"}},
+            "/tmp/repo",
+            "env -- git switch -c xy/task",
+        )
+
+        self.assertIn("Refusing to switch the root worktree", reason or "")
+
+    def test_root_default_branch_env_split_string_task_switch_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "main"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "env -S 'git switch -c xy/task'"}},
+            "/tmp/repo",
+            "env -S 'git switch -c xy/task'",
+        )
+
+        self.assertIn("Refusing to switch the root worktree", reason or "")
+
+    def test_root_default_branch_env_attached_split_string_task_switch_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "main"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "env -S'git switch -c xy/task'"}},
+            "/tmp/repo",
+            "env -S'git switch -c xy/task'",
+        )
+
+        self.assertIn("Refusing to switch the root worktree", reason or "")
+
+    def test_root_task_branch_env_prefixed_git_mutation_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "env VAR=1 git reset --hard"}},
+            "/tmp/repo",
+            "env VAR=1 git reset --hard",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_task_branch_env_option_git_mutation_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "env -i git reset --hard"}},
+            "/tmp/repo",
+            "env -i git reset --hard",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_task_branch_env_split_string_git_mutation_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "env -S 'git reset --hard'"}},
+            "/tmp/repo",
+            "env -S 'git reset --hard'",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_task_branch_env_attached_split_string_git_mutation_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "env -S'git reset --hard'"}},
+            "/tmp/repo",
+            "env -S'git reset --hard'",
+        )
+
+        self.assertIn("root worktree on a non-default branch", reason or "")
+
+    def test_root_default_branch_git_c_worktree_task_switch_is_allowed(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "main"
+        self.hook.git_command_cwd_targets_root = lambda command_cwd, root: False
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {
+                "tool_name": "exec_command",
+                "tool_input": {"cmd": "git -C .worktrees/task switch -c xy/task"},
+            },
+            "/tmp/repo",
+            "git -C .worktrees/task switch -c xy/task",
+        )
+
+        self.assertIsNone(reason)
+
+    def test_root_default_branch_git_c_worktrees_container_task_switch_is_blocked(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "main"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {
+                "tool_name": "exec_command",
+                "tool_input": {"cmd": "git -C .worktrees switch -c xy/task"},
+            },
+            "/tmp/repo",
+            "git -C .worktrees switch -c xy/task",
+        )
+
+        self.assertIn("Refusing to switch the root worktree", reason or "")
+
+    def test_root_default_branch_checkout_path_is_allowed(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "main"
+        self.hook.git_branch_ref_exists = lambda target: False
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "git checkout -- README.md"}},
+            "/tmp/repo",
+            "git checkout -- README.md",
+        )
+
+        self.assertIsNone(reason)
+
+    def test_root_default_branch_checkout_treeish_path_is_allowed(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "main"
+        self.hook.git_branch_ref_exists = lambda target: True
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "git checkout HEAD -- README.md"}},
+            "/tmp/repo",
+            "git checkout HEAD -- README.md",
+        )
+
+        self.assertIsNone(reason)
+
+    def test_root_non_default_read_only_search_with_git_words_is_allowed(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": 'rg "git reset" docs'}},
+            "/tmp/repo",
+            'rg "git reset" docs',
+        )
+
+        self.assertIsNone(reason)
+
+    def test_root_non_default_read_only_search_with_quoted_redirection_is_allowed(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": 'rg "a > b" docs'}},
+            "/tmp/repo",
+            'rg "a > b" docs',
+        )
+
+        self.assertIsNone(reason)
+
+    def test_root_non_default_read_only_search_single_quoted_redirection_is_allowed(self) -> None:
+        self.hook.git_is_root_worktree = lambda: True
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "exec_command", "tool_input": {"cmd": "rg '>' docs"}},
+            "/tmp/repo",
+            "rg '>' docs",
+        )
+
+        self.assertIsNone(reason)
+
+    def test_main_pre_tool_use_block_emits_decision_json_only(self) -> None:
+        self.hook.load_payload = lambda: {"tool_name": "apply_patch", "tool_input": {"patch": "x"}}
+        self.hook.git_root = lambda: "/tmp/repo"
+        self.hook.pre_tool_use_block_reason = lambda payload, root, text: "blocked for test"
+        self.hook.record_event = lambda event, payload, root, hints: None
+        original_argv = sys.argv
+        output = io.StringIO()
+        try:
+            sys.argv = ["codex_lifecycle_hook", "--event", "PreToolUse"]
+            with contextlib.redirect_stdout(output):
+                exit_code = self.hook.main()
+        finally:
+            sys.argv = original_argv
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(output.getvalue()), {"decision": "block", "reason": "blocked for test"})
+
+    def test_main_pre_tool_use_uses_tool_input_command_text(self) -> None:
+        seen: dict[str, str] = {}
+        self.hook.load_payload = lambda: {
+            "tool_name": "exec_command",
+            "tool_input": {"cmd": "git switch -c xy/task"},
+        }
+        self.hook.git_root = lambda: "/tmp/repo"
+
+        def fake_block_reason(payload, root, text):
+            seen["text"] = text
+            return "blocked for test"
+
+        self.hook.pre_tool_use_block_reason = fake_block_reason
+        self.hook.record_event = lambda event, payload, root, hints: None
+        original_argv = sys.argv
+        output = io.StringIO()
+        try:
+            sys.argv = ["codex_lifecycle_hook", "--event", "PreToolUse"]
+            with contextlib.redirect_stdout(output):
+                exit_code = self.hook.main()
+        finally:
+            sys.argv = original_argv
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(seen["text"], "git switch -c xy/task")
+
+    def test_linked_worktree_task_branch_mutation_is_allowed(self) -> None:
+        self.hook.git_is_root_worktree = lambda: False
+        self.hook.git_default_branch = lambda: "main"
+        self.hook.git_current_branch = lambda: "xy/task"
+
+        reason = self.hook.pre_tool_use_block_reason(
+            {"tool_name": "apply_patch", "tool_input": {"patch": "*** Begin Patch"}},
+            "/tmp/repo/.worktrees/task",
+            "apply_patch *** Begin Patch",
+        )
+
+        self.assertIsNone(reason)
 
     def test_ready_with_large_change_adds_monolith_guard(self) -> None:
         self.hook.large_change_paths = lambda stats=None: ["src/large.rs"]


### PR DESCRIPTION
## Summary
- add a Codex PreToolUse guard for root-worktree task branch mutations and task-branch switches
- preserve direct-push default-branch workflows and linked .worktrees task workflows
- cover shell parsing edge cases for env wrappers, command substitution, separators, redirection, and quoted literals

## Validation
- python3 -m unittest tests.plugins.codebase.test_codex_lifecycle_hook
- python3 -m py_compile plugins/codebase/scripts/codex_lifecycle_hook tests/plugins/codebase/test_codex_lifecycle_hook.py
- git diff --check

## Review
- Independent subagent review completed with no P1/P2 findings after fixes; residual risk is heuristic shell parsing for unknown wrappers.