### PR TITLE
Modularize execution failure writeback domains

### DIFF
--- a/apps/decodex/src/orchestrator/execution_failure/mod.rs
+++ b/apps/decodex/src/orchestrator/execution_failure/mod.rs
@@ -28,6 +28,8 @@ use sha2::Digest;
 use crate::tracker::privacy_classifier::PublicProjectionPrivacyClassifier;
 
 mod loop_guardrail;
+mod retryable_writeback;
+mod review_handoff_drift;
 mod terminal_writeback;
 mod zero_evidence;
 
@@ -36,6 +38,9 @@ pub(super) use loop_guardrail::{
 	loop_guardrail_text_hash, loop_guardrail_worktree_fingerprint,
 	retryable_failure_loop_guardrail_stop, run_failure_requires_terminal_attention,
 };
+use retryable_writeback::apply_retryable_failure_writeback;
+#[cfg(test)] pub(super) use retryable_writeback::write_retry_schedule_marker_for_runtime_retry;
+use review_handoff_drift::handle_review_handoff_failure_drift;
 pub(super) use terminal_writeback::apply_terminal_failure_writeback;
 pub(super) use zero_evidence::{
 	AppServerZeroEvidenceStartFailure, promote_zero_evidence_app_server_start_failure,
@@ -45,11 +50,6 @@ pub(super) use zero_evidence::{
 pub(super) const LOOP_GUARDRAIL_CONVERGENCE_BUDGET: i64 = 3;
 pub(super) const ARCHITECTURE_RECOVERY_BUDGET: usize = 1;
 pub(super) const ARCHITECTURE_RECOVERY_RETRY_KIND: &str = "architecture_recovery";
-pub(super) const REVIEW_HANDOFF_STATE_DRIFT_DETECTED_EVENT_TYPE: &str =
-	"review_handoff_state_drift_detected";
-pub(super) const REVIEW_HANDOFF_STATE_DRIFT_RECOVERED_EVENT_TYPE: &str =
-	"review_handoff_state_drift_recovered";
-pub(super) const REVIEW_HANDOFF_REBOUND_ORCHESTRATION_PHASE: &str = "request_pending";
 pub(super) const RETRYABLE_FAILED_START_CLEANUP_EVENT_TYPE: &str = "retryable_failed_start_cleanup";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -182,33 +182,6 @@ pub(super) enum LoopGuardrailRecoveryDecision {
 	HumanRequired(LoopGuardrailStopRequested),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ReviewHandoffFailureDriftLineage {
-	Exact,
-	Descends,
-	Diverged,
-	Unknown,
-}
-impl ReviewHandoffFailureDriftLineage {
-	fn allows_lifecycle_recovery(self) -> bool {
-		matches!(self, Self::Exact | Self::Descends)
-	}
-
-	fn as_str(self) -> &'static str {
-		match self {
-			Self::Exact => "exact",
-			Self::Descends => "descends",
-			Self::Diverged => "diverged",
-			Self::Unknown => "unknown",
-		}
-	}
-}
-
-enum ReviewHandoffStateDriftTransition {
-	AlreadySuccess,
-	MoveToSuccess(String),
-}
-
 #[derive(Clone, Copy, Eq, PartialEq)]
 enum TerminalFailureEventRecordStatus {
 	Recorded,
@@ -301,347 +274,6 @@ pub(super) fn preserve_and_promote_app_server_run_failure(
 	promote_zero_evidence_app_server_start_failure(project, state_store, issue_run, error)
 }
 
-pub(super) fn try_recover_review_handoff_failure_drift<T>(
-	tracker: &T,
-	project: &ServiceConfig,
-	workflow: &WorkflowDocument,
-	state_store: &StateStore,
-	issue_run: &IssueRunPlan,
-	error: &Report,
-) -> Result<bool>
-where
-	T: IssueTracker,
-{
-	if !review_handoff_failure_drift_can_handle(error) {
-		return Ok(false);
-	}
-
-	let Some(worktree_fingerprint) = loop_guardrail_worktree_fingerprint(&issue_run.worktree.path)?
-	else {
-		return Ok(false);
-	};
-
-	if worktree_fingerprint.effective_delta_present {
-		return Ok(false);
-	}
-
-	let Some(review_handoff) = state_store.review_handoff_marker(
-		project.service_id(),
-		&issue_run.issue.id,
-		&issue_run.worktree.branch_name,
-	)?
-	else {
-		return Ok(false);
-	};
-
-	if review_handoff.branch_name() != issue_run.worktree.branch_name
-		|| review_handoff.pr_head_ref_name() != issue_run.worktree.branch_name
-	{
-		return Ok(false);
-	}
-
-	let lineage = review_handoff_failure_drift_lineage(
-		&issue_run.worktree.path,
-		review_handoff.pr_head_oid(),
-		&worktree_fingerprint.head_sha,
-	);
-
-	if !lineage.allows_lifecycle_recovery() {
-		return Ok(false);
-	}
-
-	let tracker_policy = workflow.frontmatter().tracker();
-	let success_state = tracker_policy.success_state();
-	let current_state = issue_run.issue.state.name.as_str();
-	let Some(success_state_transition) =
-		review_handoff_state_drift_success_transition(workflow, issue_run)?
-	else {
-		return Ok(false);
-	};
-	let issue_state_recovered =
-		matches!(success_state_transition, ReviewHandoffStateDriftTransition::MoveToSuccess(_));
-	let rebounded_orchestration = rebound_review_handoff_orchestration_marker(
-		project,
-		state_store,
-		issue_run,
-		&review_handoff,
-		&worktree_fingerprint.head_sha,
-	)?;
-	let needs_attention_cleared = tracker::set_issue_label_presence(
-		tracker,
-		&issue_run.issue,
-		tracker_policy.needs_attention_label(),
-		false,
-	)?;
-
-	if let ReviewHandoffStateDriftTransition::MoveToSuccess(state_id) = success_state_transition {
-		tracker.update_issue_state(&issue_run.issue.id, &state_id)?;
-	}
-
-	state_store
-		.clear_loop_guardrail_checkpoints_for_issue(project.service_id(), &issue_run.issue.id)?;
-	state_store.update_run_status(&issue_run.run_id, "succeeded")?;
-	state_store
-		.append_private_execution_event(
-			project.service_id(),
-			&issue_run.issue.id,
-			&issue_run.run_id,
-			issue_run.attempt_number,
-			REVIEW_HANDOFF_STATE_DRIFT_RECOVERED_EVENT_TYPE,
-			json!({
-				"schema": "decodex.review_handoff_state_drift_recovered/1",
-				"reason": "current_review_handoff_marker",
-				"source_error_class": review_handoff_failure_drift_source_error_class(error),
-				"branch_name": issue_run.worktree.branch_name,
-				"pr_url": review_handoff.pr_url(),
-				"marker_head_sha": review_handoff.pr_head_oid(),
-				"local_head_sha": worktree_fingerprint.head_sha,
-				"lineage": lineage.as_str(),
-				"previous_issue_state": current_state,
-				"target_issue_state": success_state,
-				"issue_state_recovered": issue_state_recovered,
-				"needs_attention_cleared": needs_attention_cleared,
-				"orchestration_rebound": rebounded_orchestration,
-			}),
-		)
-		.map(|_| ())?;
-
-	tracing::warn!(
-		project_id = project.service_id(),
-		issue_id = issue_run.issue.id,
-		issue = issue_run.issue.identifier,
-		run_id = issue_run.run_id,
-		attempt = issue_run.attempt_number,
-		branch = issue_run.worktree.branch_name,
-		pr_url = review_handoff.pr_url(),
-		lineage = lineage.as_str(),
-		"Recovered review handoff state drift before retry/no-diff failure writeback."
-	);
-
-	Ok(true)
-}
-
-fn review_handoff_state_drift_success_transition(
-	workflow: &WorkflowDocument,
-	issue_run: &IssueRunPlan,
-) -> Result<Option<ReviewHandoffStateDriftTransition>> {
-	let tracker_policy = workflow.frontmatter().tracker();
-	let success_state = tracker_policy.success_state();
-	let current_state = issue_run.issue.state.name.as_str();
-
-	if current_state == success_state {
-		return Ok(Some(ReviewHandoffStateDriftTransition::AlreadySuccess));
-	}
-	if current_state != tracker_policy.in_progress_state()
-		&& current_state != tracker_policy.failure_state()
-	{
-		return Ok(None);
-	}
-
-	let state_id = issue_run.issue.state_id_for_name(success_state).ok_or_else(|| {
-		eyre::eyre!(
-			"State `{success_state}` was not found for issue `{}` during review handoff state drift recovery.",
-			issue_run.issue.identifier
-		)
-	})?;
-
-	Ok(Some(ReviewHandoffStateDriftTransition::MoveToSuccess(state_id.to_owned())))
-}
-
-fn rebound_review_handoff_orchestration_marker(
-	project: &ServiceConfig,
-	state_store: &StateStore,
-	issue_run: &IssueRunPlan,
-	review_handoff: &ReviewHandoffMarker,
-	local_head_sha: &str,
-) -> Result<bool> {
-	let existing_orchestration = state_store.review_orchestration_marker(
-		project.service_id(),
-		&issue_run.issue.id,
-		review_handoff,
-	)?;
-	let rebounded_orchestration = existing_orchestration.as_ref().is_none_or(|marker| {
-		marker.branch_name() != review_handoff.branch_name()
-			|| marker.pr_url() != review_handoff.pr_url()
-			|| marker.head_sha() != local_head_sha
-			|| marker.phase() != REVIEW_HANDOFF_REBOUND_ORCHESTRATION_PHASE
-	});
-	let orchestration_marker = ReviewOrchestrationMarker::new(
-		review_handoff.run_id().to_owned(),
-		review_handoff.attempt_number(),
-		review_handoff.branch_name().to_owned(),
-		review_handoff.pr_url().to_owned(),
-		local_head_sha.to_owned(),
-		REVIEW_HANDOFF_REBOUND_ORCHESTRATION_PHASE,
-		None,
-		None,
-		None,
-		0,
-		existing_orchestration.as_ref().map_or(0, ReviewOrchestrationMarker::external_round_count),
-		None,
-	);
-
-	state_store.upsert_review_orchestration_marker(
-		project.service_id(),
-		&issue_run.issue.id,
-		&orchestration_marker,
-	)?;
-
-	Ok(rebounded_orchestration)
-}
-
-fn review_handoff_failure_drift_can_handle(error: &Report) -> bool {
-	!run_failure_requires_terminal_attention(error)
-		&& error.downcast_ref::<ManualAttentionRequested>().is_none()
-		&& error.downcast_ref::<LoopGuardrailStopRequested>().is_none()
-		&& error.downcast_ref::<ReviewHandoffNeedsAttention>().is_none()
-		&& error.downcast_ref::<RetainedReviewNeedsAttention>().is_none()
-		&& error.downcast_ref::<ReviewPolicyStopRequested>().is_none()
-		&& error.downcast_ref::<CodexAccountAuthFailure>().is_none()
-}
-
-fn review_handoff_failure_drift_source_error_class(error: &Report) -> &'static str {
-	retained_progress_source_error_class(error).unwrap_or("retryable_execution_failure")
-}
-
-fn review_handoff_failure_drift_lineage(
-	worktree_path: &Path,
-	recorded_head_oid: &str,
-	local_head_oid: &str,
-) -> ReviewHandoffFailureDriftLineage {
-	if recorded_head_oid == local_head_oid {
-		return ReviewHandoffFailureDriftLineage::Exact;
-	}
-
-	let Ok(output) = Command::new("git")
-		.arg("-C")
-		.arg(worktree_path)
-		.args(["merge-base", "--is-ancestor", recorded_head_oid, local_head_oid])
-		.output()
-	else {
-		return ReviewHandoffFailureDriftLineage::Unknown;
-	};
-
-	match output.status.code() {
-		Some(0) => ReviewHandoffFailureDriftLineage::Descends,
-		Some(1) => ReviewHandoffFailureDriftLineage::Diverged,
-		_ => ReviewHandoffFailureDriftLineage::Unknown,
-	}
-}
-
-fn review_handoff_state_drift_attention_error(
-	project: &ServiceConfig,
-	workflow: &WorkflowDocument,
-	state_store: &StateStore,
-	issue_run: &IssueRunPlan,
-	error: &Report,
-) -> Result<Option<ManualAttentionRequested>> {
-	if !review_handoff_failure_drift_can_handle(error) {
-		return Ok(None);
-	}
-
-	let Some(worktree_fingerprint) = loop_guardrail_worktree_fingerprint(&issue_run.worktree.path)?
-	else {
-		return Ok(None);
-	};
-
-	if worktree_fingerprint.effective_delta_present {
-		return Ok(None);
-	}
-
-	let checkpoint = state_store.review_policy_checkpoint(
-		project.service_id(),
-		&issue_run.issue.id,
-		&issue_run.run_id,
-		issue_run.attempt_number,
-		"handoff",
-	)?;
-	let drift_reason = match state_store.review_handoff_marker(
-		project.service_id(),
-		&issue_run.issue.id,
-		&issue_run.worktree.branch_name,
-	)? {
-		Some(review_handoff) => review_handoff_marker_drift_reason(
-			workflow,
-			issue_run,
-			&worktree_fingerprint,
-			&review_handoff,
-		)?,
-		None => {
-			let Some(checkpoint) = checkpoint.as_ref() else {
-				return Ok(None);
-			};
-
-			if checkpoint.status() != "clean"
-				|| checkpoint.head_sha() != worktree_fingerprint.head_sha
-			{
-				return Ok(None);
-			}
-
-			Some(String::from("missing_review_handoff_marker"))
-		},
-	};
-	let Some(drift_reason) = drift_reason else {
-		return Ok(None);
-	};
-
-	state_store
-		.append_private_execution_event(
-			project.service_id(),
-			&issue_run.issue.id,
-			&issue_run.run_id,
-			issue_run.attempt_number,
-			REVIEW_HANDOFF_STATE_DRIFT_DETECTED_EVENT_TYPE,
-			json!({
-				"schema": "decodex.review_handoff_state_drift_detected/1",
-				"reason": drift_reason,
-				"source_error_class": review_handoff_failure_drift_source_error_class(error),
-				"branch_name": issue_run.worktree.branch_name,
-				"checkpoint_status": checkpoint.as_ref().map(|checkpoint| checkpoint.status()),
-				"checkpoint_head_sha": checkpoint.as_ref().map(|checkpoint| checkpoint.head_sha()),
-				"local_head_sha": worktree_fingerprint.head_sha,
-				"next_action": "restore or rebind the retained review handoff marker before retrying execution",
-			}),
-		)
-		.map(|_| ())?;
-
-	Ok(Some(ManualAttentionRequested {
-		issue_identifier: issue_run.issue.identifier.clone(),
-		label: workflow.frontmatter().tracker().needs_attention_label().to_owned(),
-		run_id: issue_run.run_id.clone(),
-		error_class: Some(LoopGuardrailReason::ReviewHandoffStateDrift.error_class().to_owned()),
-	}))
-}
-
-fn review_handoff_marker_drift_reason(
-	workflow: &WorkflowDocument,
-	issue_run: &IssueRunPlan,
-	worktree_fingerprint: &LoopGuardrailWorktreeFingerprint,
-	review_handoff: &ReviewHandoffMarker,
-) -> Result<Option<String>> {
-	if review_handoff.branch_name() != issue_run.worktree.branch_name {
-		return Ok(Some(String::from("review_handoff_marker_branch_mismatch")));
-	}
-	if review_handoff.pr_head_ref_name() != issue_run.worktree.branch_name {
-		return Ok(Some(String::from("review_handoff_marker_pr_head_ref_mismatch")));
-	}
-
-	let lineage = review_handoff_failure_drift_lineage(
-		&issue_run.worktree.path,
-		review_handoff.pr_head_oid(),
-		&worktree_fingerprint.head_sha,
-	);
-
-	if !lineage.allows_lifecycle_recovery() {
-		return Ok(Some(format!("review_handoff_marker_{}", lineage.as_str())));
-	}
-	if review_handoff_state_drift_success_transition(workflow, issue_run)?.is_some() {
-		return Ok(None);
-	}
-
-	Ok(Some(String::from("review_handoff_marker_issue_state_unsupported")))
-}
-
 pub(super) fn handle_failure<T>(
 	tracker: &T,
 	project: &ServiceConfig,
@@ -700,16 +332,14 @@ where
 			loop_guardrail_stop_from_review_policy(review_policy_stop),
 			error,
 		)? {
-			LoopGuardrailRecoveryDecision::Start(recovery) => {
+			LoopGuardrailRecoveryDecision::Start(recovery) =>
 				apply_architecture_recovery_retry_writeback(
 					&failure_context,
 					recovery,
 					max_attempts,
-				)
-			},
-			LoopGuardrailRecoveryDecision::HumanRequired(loop_guardrail_stop) => {
-				apply_loop_guardrail_failure_writeback(&failure_context, loop_guardrail_stop)
-			},
+				),
+			LoopGuardrailRecoveryDecision::HumanRequired(loop_guardrail_stop) =>
+				apply_loop_guardrail_failure_writeback(&failure_context, loop_guardrail_stop),
 		};
 	}
 	if let Some(loop_guardrail_stop) = loop_guardrail_stop {
@@ -720,16 +350,14 @@ where
 			loop_guardrail_stop,
 			error,
 		)? {
-			LoopGuardrailRecoveryDecision::Start(recovery) => {
+			LoopGuardrailRecoveryDecision::Start(recovery) =>
 				apply_architecture_recovery_retry_writeback(
 					&failure_context,
 					recovery,
 					max_attempts,
-				)
-			},
-			LoopGuardrailRecoveryDecision::HumanRequired(loop_guardrail_stop) => {
-				apply_loop_guardrail_failure_writeback(&failure_context, loop_guardrail_stop)
-			},
+				),
+			LoopGuardrailRecoveryDecision::HumanRequired(loop_guardrail_stop) =>
+				apply_loop_guardrail_failure_writeback(&failure_context, loop_guardrail_stop),
 		};
 	}
 
@@ -744,53 +372,6 @@ where
 		manual_attention_requested,
 		terminal_error,
 	)
-}
-
-fn handle_review_handoff_failure_drift<T>(
-	tracker: &T,
-	project: &ServiceConfig,
-	workflow: &WorkflowDocument,
-	state_store: &StateStore,
-	issue_run: &IssueRunPlan,
-	error: &Report,
-	worktree_path: &str,
-) -> Result<bool>
-where
-	T: IssueTracker,
-{
-	if try_recover_review_handoff_failure_drift(
-		tracker,
-		project,
-		workflow,
-		state_store,
-		issue_run,
-		error,
-	)? {
-		return Ok(true);
-	}
-
-	let Some(attention_error) = review_handoff_state_drift_attention_error(
-		project,
-		workflow,
-		state_store,
-		issue_run,
-		error,
-	)?
-	else {
-		return Ok(false);
-	};
-
-	apply_review_handoff_state_drift_attention_writeback(
-		tracker,
-		project,
-		workflow,
-		state_store,
-		issue_run,
-		worktree_path,
-		attention_error,
-	)?;
-
-	Ok(true)
 }
 
 fn apply_terminal_attention_failure_writeback<T>(
@@ -861,259 +442,6 @@ pub(super) fn retryable_failure_loop_guardrail_stop_unless_terminal_attention(
 		Ok(None)
 	} else {
 		retryable_failure_loop_guardrail_stop(project, state_store, issue_run, error)
-	}
-}
-
-fn apply_review_handoff_state_drift_attention_writeback<T>(
-	tracker: &T,
-	project: &ServiceConfig,
-	workflow: &WorkflowDocument,
-	state_store: &StateStore,
-	issue_run: &IssueRunPlan,
-	worktree_path: &str,
-	attention_error: ManualAttentionRequested,
-) -> Result<()>
-where
-	T: IssueTracker,
-{
-	let terminal_error = Report::new(attention_error);
-	let privacy_classifier = configured_public_projection_privacy_classifier(project)?;
-	let outcome = apply_terminal_failure_writeback(
-		tracker,
-		TerminalFailureWritebackRuntime {
-			service_id: project.service_id(),
-			state_store: Some(state_store),
-			privacy_classifier: &privacy_classifier,
-		},
-		workflow,
-		issue_run,
-		worktree_path,
-		true,
-		&terminal_error,
-	)?;
-
-	if outcome.retry_guarded_by_state {
-		write_terminal_guard_marker(
-			&issue_run.worktree.path,
-			&issue_run.run_id,
-			issue_run.attempt_number,
-		)?;
-
-		state_store.update_run_status(&issue_run.run_id, TERMINAL_GUARDED_RUN_STATUS)?;
-	}
-
-	Ok(())
-}
-
-fn apply_retryable_failure_writeback<T>(
-	context: &FailureHandlingContext<'_, T>,
-	error: &Report,
-	max_attempts: i64,
-) -> Result<()>
-where
-	T: IssueTracker,
-{
-	let (retry_error_class, retry_next_action) = retry_comment_details(error);
-
-	write_retry_schedule_marker_for_runtime_retry(
-		error,
-		context.workflow,
-		context.issue_run,
-		context.retry_budget_attempts,
-	)?;
-
-	tracing::warn!(
-		project_id = context.project.service_id(),
-		issue_id = context.issue_run.issue.id,
-		issue = context.issue_run.issue.identifier,
-		run_id = context.issue_run.run_id,
-		attempt = context.issue_run.attempt_number,
-		retry_budget_attempt = context.retry_budget_attempts,
-		max_attempts,
-		branch = context.issue_run.worktree.branch_name,
-		worktree_path = %context.worktree_path,
-		error_class = retry_error_class,
-		"Run failed and remains retryable."
-	);
-
-	tracker::create_public_comment(
-		context.tracker,
-		&context.issue_run.issue.id,
-		&format_retry_comment(RetryComment {
-			run_id: &context.issue_run.run_id,
-			attempt_number: context.issue_run.attempt_number,
-			retry_budget_attempt_number: context.retry_budget_attempts,
-			max_attempts,
-			worktree_path: context.worktree_path.to_owned(),
-			branch_name: &context.issue_run.worktree.branch_name,
-			error_class: retry_error_class,
-			next_action: &retry_next_action,
-		}),
-	)?;
-
-	write_retry_budget_marker(
-		&context.issue_run.worktree.path,
-		&context.issue_run.run_id,
-		context.issue_run.attempt_number,
-		context.retry_budget_attempts,
-	)?;
-	record_harness_outcome_best_effort(
-		context.state_store,
-		context.project.service_id(),
-		context.issue_run,
-		HarnessOutcomeKind::RetryableFailure,
-		Some(retry_error_class),
-		retryable_failure_validation_result(error, retry_error_class),
-		None,
-	);
-	cleanup_retryable_failed_start_ownership(context, error)?;
-
-	Ok(())
-}
-
-fn cleanup_retryable_failed_start_ownership<T>(
-	context: &FailureHandlingContext<'_, T>,
-	error: &Report,
-) -> Result<()>
-where
-	T: IssueTracker,
-{
-	if !retryable_failed_start_cleanup_allowed(context, error)? {
-		return Ok(());
-	}
-
-	let tracker_policy = context.workflow.frontmatter().tracker();
-	let failure_state_name = tracker_policy.failure_state();
-	let failure_state_is_startable =
-		tracker_policy.startable_states().iter().any(|state| state == failure_state_name);
-
-	if !failure_state_is_startable {
-		tracing::warn!(
-			issue_id = context.issue_run.issue.id,
-			issue = context.issue_run.issue.identifier,
-			target_state = failure_state_name,
-			"Retryable failed-start cleanup skipped because the configured failure state is not startable."
-		);
-
-		return Ok(());
-	}
-
-	let Some(state_id) = context.issue_run.issue.state_id_for_name(failure_state_name) else {
-		tracing::warn!(
-			issue_id = context.issue_run.issue.id,
-			issue = context.issue_run.issue.identifier,
-			target_state = failure_state_name,
-			"Retryable failed-start cleanup skipped because the target state id was not available."
-		);
-
-		return Ok(());
-	};
-
-	context.tracker.update_issue_state(&context.issue_run.issue.id, state_id)?;
-
-	ensure_automation_activity_label(
-		context.tracker,
-		&context.issue_run.issue,
-		context.project.service_id(),
-		false,
-	)?;
-
-	context.state_store.clear_worktree(&context.issue_run.issue.id)?;
-	context
-		.state_store
-		.append_private_execution_event(
-			context.project.service_id(),
-			&context.issue_run.issue.id,
-			&context.issue_run.run_id,
-			context.issue_run.attempt_number,
-			RETRYABLE_FAILED_START_CLEANUP_EVENT_TYPE,
-			json!({
-				"schema": "decodex.retryable_failed_start_cleanup/1",
-				"source_error_class": retained_progress_source_error_class(error)
-					.unwrap_or("retryable_execution_failure"),
-				"dispatch_mode": context.issue_run.dispatch_mode.as_str(),
-				"active_label_cleared": true,
-				"worktree_mapping_cleared": true,
-				"target_issue_state": failure_state_name,
-				"issue_state_reset": true,
-				"retryable_by_next_program_pass": true,
-			}),
-		)
-		.map(|_| ())?;
-
-	tracing::info!(
-		project_id = context.project.service_id(),
-		issue_id = context.issue_run.issue.id,
-		issue = context.issue_run.issue.identifier,
-		run_id = context.issue_run.run_id,
-		attempt = context.issue_run.attempt_number,
-		branch = context.issue_run.worktree.branch_name,
-		worktree_path = %context.worktree_path,
-		issue_state_reset = true,
-		"Cleared retryable failed-start ownership after a no-diff Program run failure."
-	);
-
-	Ok(())
-}
-
-fn retryable_failed_start_cleanup_allowed<T>(
-	context: &FailureHandlingContext<'_, T>,
-	error: &Report,
-) -> Result<bool>
-where
-	T: IssueTracker,
-{
-	if context.issue_run.dispatch_mode != IssueDispatchMode::Program {
-		return Ok(false);
-	}
-	if !retryable_failure_happened_before_effective_agent_execution(error) {
-		return Ok(false);
-	}
-	if context.state_store.lease_for_issue(&context.issue_run.issue.id)?.is_some() {
-		return Ok(false);
-	}
-	if context.state_store.issue_has_review_lifecycle_record(
-		context.project.service_id(),
-		&context.issue_run.issue.id,
-	)? {
-		return Ok(false);
-	}
-	if latest_open_issue_phase_goal_before_attempt(
-		context.project,
-		context.state_store,
-		&context.issue_run.issue.id,
-		&context.issue_run.run_id,
-		context.issue_run.attempt_number,
-	)?
-	.is_some()
-	{
-		return Ok(false);
-	}
-
-	Ok(loop_guardrail_worktree_fingerprint(&context.issue_run.worktree.path)?
-		.is_some_and(|fingerprint| !fingerprint.effective_delta_present))
-}
-
-fn retryable_failure_happened_before_effective_agent_execution(error: &Report) -> bool {
-	error.downcast_ref::<AppServerZeroEvidenceStartFailure>().is_some()
-		|| error
-			.downcast_ref::<AppServerCapabilityPreflightFailure>()
-			.is_some_and(AppServerCapabilityPreflightFailure::is_retryable_timeout)
-		|| error
-			.downcast_ref::<AppServerTransportFailure>()
-			.is_some_and(AppServerTransportFailure::is_retryable_startup)
-}
-
-fn retryable_failure_validation_result(
-	error: &Report,
-	retry_error_class: &str,
-) -> Option<&'static str> {
-	if retry_error_class.starts_with("repo_gate_")
-		|| error.downcast_ref::<RepoGateFailure>().is_some()
-	{
-		Some("failed")
-	} else {
-		None
 	}
 }
 
@@ -1323,67 +651,6 @@ pub(super) fn retained_progress_source_error_class(error: &Report) -> Option<&'s
 	} else {
 		None
 	}
-}
-
-pub(super) fn write_retry_schedule_marker_for_runtime_retry(
-	error: &Report,
-	workflow: &WorkflowDocument,
-	issue_run: &IssueRunPlan,
-	retry_budget_attempts: i64,
-) -> Result<()> {
-	if error.downcast_ref::<StalledRunNeedsAttention>().is_some() {
-		return write_failure_retry_schedule_marker(workflow, issue_run, retry_budget_attempts);
-	}
-	if error
-		.downcast_ref::<AppServerCapabilityPreflightFailure>()
-		.is_some_and(AppServerCapabilityPreflightFailure::is_retryable_timeout)
-	{
-		return write_failure_retry_schedule_marker(workflow, issue_run, retry_budget_attempts);
-	}
-	if error
-		.downcast_ref::<AppServerPhaseGoalFailure>()
-		.is_some_and(AppServerPhaseGoalFailure::is_terminal_path_missing)
-	{
-		return write_failure_retry_schedule_marker(workflow, issue_run, retry_budget_attempts);
-	}
-
-	let Some(repo_gate_failure) = error.downcast_ref::<RepoGateFailure>() else {
-		return Ok(());
-	};
-	let Some(retry_kind) = repo_gate_failure.retry_schedule_kind() else {
-		return Ok(());
-	};
-
-	write_retry_schedule_marker(workflow, issue_run, retry_budget_attempts, retry_kind)
-}
-
-fn write_failure_retry_schedule_marker(
-	workflow: &WorkflowDocument,
-	issue_run: &IssueRunPlan,
-	retry_budget_attempts: i64,
-) -> Result<()> {
-	write_retry_schedule_marker(workflow, issue_run, retry_budget_attempts, "failure")
-}
-
-fn write_retry_schedule_marker(
-	workflow: &WorkflowDocument,
-	issue_run: &IssueRunPlan,
-	retry_budget_attempts: i64,
-	retry_kind: &str,
-) -> Result<()> {
-	let retry_attempt = u32::try_from(retry_budget_attempts).unwrap_or(u32::MAX).max(1);
-	let delay = retry_delay(RetryKind::Failure, retry_attempt, workflow);
-	let retry_ready_at_unix_epoch = OffsetDateTime::now_utc().unix_timestamp().saturating_add(
-		i64::try_from((delay.as_millis().saturating_add(999)) / 1_000).unwrap_or(i64::MAX),
-	);
-
-	state::write_run_retry_schedule(
-		&issue_run.worktree.path,
-		&issue_run.run_id,
-		issue_run.attempt_number,
-		retry_kind,
-		retry_ready_at_unix_epoch,
-	)
 }
 
 pub(super) fn ensure_automation_activity_label<T>(

--- a/apps/decodex/src/orchestrator/execution_failure/retryable_writeback.rs
+++ b/apps/decodex/src/orchestrator/execution_failure/retryable_writeback.rs
@@ -1,0 +1,284 @@
+use super::{
+	AppServerCapabilityPreflightFailure, AppServerPhaseGoalFailure, AppServerTransportFailure,
+	AppServerZeroEvidenceStartFailure, FailureHandlingContext, HarnessOutcomeKind,
+	IssueDispatchMode, IssueRunPlan, IssueTracker, OffsetDateTime,
+	RETRYABLE_FAILED_START_CLEANUP_EVENT_TYPE, RepoGateFailure, Report, Result, RetryComment,
+	RetryKind, StalledRunNeedsAttention, WorkflowDocument, ensure_automation_activity_label,
+	format_retry_comment, json, latest_open_issue_phase_goal_before_attempt,
+	loop_guardrail_worktree_fingerprint, record_harness_outcome_best_effort,
+	retained_progress_source_error_class, retry_comment_details, retry_delay, state, tracker,
+	write_retry_budget_marker,
+};
+
+pub(super) fn apply_retryable_failure_writeback<T>(
+	context: &FailureHandlingContext<'_, T>,
+	error: &Report,
+	max_attempts: i64,
+) -> Result<()>
+where
+	T: IssueTracker,
+{
+	let (retry_error_class, retry_next_action) = retry_comment_details(error);
+
+	write_retry_schedule_marker_for_runtime_retry(
+		error,
+		context.workflow,
+		context.issue_run,
+		context.retry_budget_attempts,
+	)?;
+
+	tracing::warn!(
+		project_id = context.project.service_id(),
+		issue_id = context.issue_run.issue.id,
+		issue = context.issue_run.issue.identifier,
+		run_id = context.issue_run.run_id,
+		attempt = context.issue_run.attempt_number,
+		retry_budget_attempt = context.retry_budget_attempts,
+		max_attempts,
+		branch = context.issue_run.worktree.branch_name,
+		worktree_path = %context.worktree_path,
+		error_class = retry_error_class,
+		"Run failed and remains retryable."
+	);
+
+	tracker::create_public_comment(
+		context.tracker,
+		&context.issue_run.issue.id,
+		&format_retry_comment(RetryComment {
+			run_id: &context.issue_run.run_id,
+			attempt_number: context.issue_run.attempt_number,
+			retry_budget_attempt_number: context.retry_budget_attempts,
+			max_attempts,
+			worktree_path: context.worktree_path.to_owned(),
+			branch_name: &context.issue_run.worktree.branch_name,
+			error_class: retry_error_class,
+			next_action: &retry_next_action,
+		}),
+	)?;
+
+	write_retry_budget_marker(
+		&context.issue_run.worktree.path,
+		&context.issue_run.run_id,
+		context.issue_run.attempt_number,
+		context.retry_budget_attempts,
+	)?;
+	record_harness_outcome_best_effort(
+		context.state_store,
+		context.project.service_id(),
+		context.issue_run,
+		HarnessOutcomeKind::RetryableFailure,
+		Some(retry_error_class),
+		retryable_failure_validation_result(error, retry_error_class),
+		None,
+	);
+	cleanup_retryable_failed_start_ownership(context, error)?;
+
+	Ok(())
+}
+
+pub(in crate::orchestrator) fn write_retry_schedule_marker_for_runtime_retry(
+	error: &Report,
+	workflow: &WorkflowDocument,
+	issue_run: &IssueRunPlan,
+	retry_budget_attempts: i64,
+) -> Result<()> {
+	if error.downcast_ref::<StalledRunNeedsAttention>().is_some() {
+		return write_failure_retry_schedule_marker(workflow, issue_run, retry_budget_attempts);
+	}
+	if error
+		.downcast_ref::<AppServerCapabilityPreflightFailure>()
+		.is_some_and(AppServerCapabilityPreflightFailure::is_retryable_timeout)
+	{
+		return write_failure_retry_schedule_marker(workflow, issue_run, retry_budget_attempts);
+	}
+	if error
+		.downcast_ref::<AppServerPhaseGoalFailure>()
+		.is_some_and(AppServerPhaseGoalFailure::is_terminal_path_missing)
+	{
+		return write_failure_retry_schedule_marker(workflow, issue_run, retry_budget_attempts);
+	}
+
+	let Some(repo_gate_failure) = error.downcast_ref::<RepoGateFailure>() else {
+		return Ok(());
+	};
+	let Some(retry_kind) = repo_gate_failure.retry_schedule_kind() else {
+		return Ok(());
+	};
+
+	write_retry_schedule_marker(workflow, issue_run, retry_budget_attempts, retry_kind)
+}
+
+fn cleanup_retryable_failed_start_ownership<T>(
+	context: &FailureHandlingContext<'_, T>,
+	error: &Report,
+) -> Result<()>
+where
+	T: IssueTracker,
+{
+	if !retryable_failed_start_cleanup_allowed(context, error)? {
+		return Ok(());
+	}
+
+	let tracker_policy = context.workflow.frontmatter().tracker();
+	let failure_state_name = tracker_policy.failure_state();
+	let failure_state_is_startable =
+		tracker_policy.startable_states().iter().any(|state| state == failure_state_name);
+
+	if !failure_state_is_startable {
+		tracing::warn!(
+			issue_id = context.issue_run.issue.id,
+			issue = context.issue_run.issue.identifier,
+			target_state = failure_state_name,
+			"Retryable failed-start cleanup skipped because the configured failure state is not startable."
+		);
+
+		return Ok(());
+	}
+
+	let Some(state_id) = context.issue_run.issue.state_id_for_name(failure_state_name) else {
+		tracing::warn!(
+			issue_id = context.issue_run.issue.id,
+			issue = context.issue_run.issue.identifier,
+			target_state = failure_state_name,
+			"Retryable failed-start cleanup skipped because the target state id was not available."
+		);
+
+		return Ok(());
+	};
+
+	context.tracker.update_issue_state(&context.issue_run.issue.id, state_id)?;
+
+	ensure_automation_activity_label(
+		context.tracker,
+		&context.issue_run.issue,
+		context.project.service_id(),
+		false,
+	)?;
+
+	context.state_store.clear_worktree(&context.issue_run.issue.id)?;
+	context
+		.state_store
+		.append_private_execution_event(
+			context.project.service_id(),
+			&context.issue_run.issue.id,
+			&context.issue_run.run_id,
+			context.issue_run.attempt_number,
+			RETRYABLE_FAILED_START_CLEANUP_EVENT_TYPE,
+			json!({
+				"schema": "decodex.retryable_failed_start_cleanup/1",
+				"source_error_class": retained_progress_source_error_class(error)
+					.unwrap_or("retryable_execution_failure"),
+				"dispatch_mode": context.issue_run.dispatch_mode.as_str(),
+				"active_label_cleared": true,
+				"worktree_mapping_cleared": true,
+				"target_issue_state": failure_state_name,
+				"issue_state_reset": true,
+				"retryable_by_next_program_pass": true,
+			}),
+		)
+		.map(|_| ())?;
+
+	tracing::info!(
+		project_id = context.project.service_id(),
+		issue_id = context.issue_run.issue.id,
+		issue = context.issue_run.issue.identifier,
+		run_id = context.issue_run.run_id,
+		attempt = context.issue_run.attempt_number,
+		branch = context.issue_run.worktree.branch_name,
+		worktree_path = %context.worktree_path,
+		issue_state_reset = true,
+		"Cleared retryable failed-start ownership after a no-diff Program run failure."
+	);
+
+	Ok(())
+}
+
+fn retryable_failed_start_cleanup_allowed<T>(
+	context: &FailureHandlingContext<'_, T>,
+	error: &Report,
+) -> Result<bool>
+where
+	T: IssueTracker,
+{
+	if context.issue_run.dispatch_mode != IssueDispatchMode::Program {
+		return Ok(false);
+	}
+	if !retryable_failure_happened_before_effective_agent_execution(error) {
+		return Ok(false);
+	}
+	if context.state_store.lease_for_issue(&context.issue_run.issue.id)?.is_some() {
+		return Ok(false);
+	}
+	if context.state_store.issue_has_review_lifecycle_record(
+		context.project.service_id(),
+		&context.issue_run.issue.id,
+	)? {
+		return Ok(false);
+	}
+	if latest_open_issue_phase_goal_before_attempt(
+		context.project,
+		context.state_store,
+		&context.issue_run.issue.id,
+		&context.issue_run.run_id,
+		context.issue_run.attempt_number,
+	)?
+	.is_some()
+	{
+		return Ok(false);
+	}
+
+	Ok(loop_guardrail_worktree_fingerprint(&context.issue_run.worktree.path)?
+		.is_some_and(|fingerprint| !fingerprint.effective_delta_present))
+}
+
+fn retryable_failure_happened_before_effective_agent_execution(error: &Report) -> bool {
+	error.downcast_ref::<AppServerZeroEvidenceStartFailure>().is_some()
+		|| error
+			.downcast_ref::<AppServerCapabilityPreflightFailure>()
+			.is_some_and(AppServerCapabilityPreflightFailure::is_retryable_timeout)
+		|| error
+			.downcast_ref::<AppServerTransportFailure>()
+			.is_some_and(AppServerTransportFailure::is_retryable_startup)
+}
+
+fn retryable_failure_validation_result(
+	error: &Report,
+	retry_error_class: &str,
+) -> Option<&'static str> {
+	if retry_error_class.starts_with("repo_gate_")
+		|| error.downcast_ref::<RepoGateFailure>().is_some()
+	{
+		Some("failed")
+	} else {
+		None
+	}
+}
+
+fn write_failure_retry_schedule_marker(
+	workflow: &WorkflowDocument,
+	issue_run: &IssueRunPlan,
+	retry_budget_attempts: i64,
+) -> Result<()> {
+	write_retry_schedule_marker(workflow, issue_run, retry_budget_attempts, "failure")
+}
+
+fn write_retry_schedule_marker(
+	workflow: &WorkflowDocument,
+	issue_run: &IssueRunPlan,
+	retry_budget_attempts: i64,
+	retry_kind: &str,
+) -> Result<()> {
+	let retry_attempt = u32::try_from(retry_budget_attempts).unwrap_or(u32::MAX).max(1);
+	let delay = retry_delay(RetryKind::Failure, retry_attempt, workflow);
+	let retry_ready_at_unix_epoch = OffsetDateTime::now_utc().unix_timestamp().saturating_add(
+		i64::try_from((delay.as_millis().saturating_add(999)) / 1_000).unwrap_or(i64::MAX),
+	);
+
+	state::write_run_retry_schedule(
+		&issue_run.worktree.path,
+		&issue_run.run_id,
+		issue_run.attempt_number,
+		retry_kind,
+		retry_ready_at_unix_epoch,
+	)
+}

--- a/apps/decodex/src/orchestrator/execution_failure/review_handoff_drift.rs
+++ b/apps/decodex/src/orchestrator/execution_failure/review_handoff_drift.rs
@@ -1,0 +1,471 @@
+use super::{
+	CodexAccountAuthFailure, Command, IssueRunPlan, IssueTracker, LoopGuardrailReason,
+	LoopGuardrailStopRequested, LoopGuardrailWorktreeFingerprint, ManualAttentionRequested, Path,
+	Report, Result, RetainedReviewNeedsAttention, ReviewHandoffMarker, ReviewHandoffNeedsAttention,
+	ReviewOrchestrationMarker, ReviewPolicyStopRequested, ServiceConfig, StateStore,
+	TERMINAL_GUARDED_RUN_STATUS, TerminalFailureWritebackRuntime, WorkflowDocument,
+	apply_terminal_failure_writeback, configured_public_projection_privacy_classifier, eyre, json,
+	loop_guardrail_worktree_fingerprint, retained_progress_source_error_class,
+	run_failure_requires_terminal_attention, tracker, write_terminal_guard_marker,
+};
+
+const REVIEW_HANDOFF_STATE_DRIFT_DETECTED_EVENT_TYPE: &str = "review_handoff_state_drift_detected";
+const REVIEW_HANDOFF_STATE_DRIFT_RECOVERED_EVENT_TYPE: &str =
+	"review_handoff_state_drift_recovered";
+const REVIEW_HANDOFF_REBOUND_ORCHESTRATION_PHASE: &str = "request_pending";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReviewHandoffFailureDriftLineage {
+	Exact,
+	Descends,
+	Diverged,
+	Unknown,
+}
+impl ReviewHandoffFailureDriftLineage {
+	fn allows_lifecycle_recovery(self) -> bool {
+		matches!(self, Self::Exact | Self::Descends)
+	}
+
+	fn as_str(self) -> &'static str {
+		match self {
+			Self::Exact => "exact",
+			Self::Descends => "descends",
+			Self::Diverged => "diverged",
+			Self::Unknown => "unknown",
+		}
+	}
+}
+
+enum ReviewHandoffStateDriftTransition {
+	AlreadySuccess,
+	MoveToSuccess(String),
+}
+
+pub(super) fn handle_review_handoff_failure_drift<T>(
+	tracker: &T,
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	issue_run: &IssueRunPlan,
+	error: &Report,
+	worktree_path: &str,
+) -> Result<bool>
+where
+	T: IssueTracker,
+{
+	if try_recover_review_handoff_failure_drift(
+		tracker,
+		project,
+		workflow,
+		state_store,
+		issue_run,
+		error,
+	)? {
+		return Ok(true);
+	}
+
+	let Some(attention_error) = review_handoff_state_drift_attention_error(
+		project,
+		workflow,
+		state_store,
+		issue_run,
+		error,
+	)?
+	else {
+		return Ok(false);
+	};
+
+	apply_review_handoff_state_drift_attention_writeback(
+		tracker,
+		project,
+		workflow,
+		state_store,
+		issue_run,
+		worktree_path,
+		attention_error,
+	)?;
+
+	Ok(true)
+}
+
+fn try_recover_review_handoff_failure_drift<T>(
+	tracker: &T,
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	issue_run: &IssueRunPlan,
+	error: &Report,
+) -> Result<bool>
+where
+	T: IssueTracker,
+{
+	if !review_handoff_failure_drift_can_handle(error) {
+		return Ok(false);
+	}
+
+	let Some(worktree_fingerprint) = loop_guardrail_worktree_fingerprint(&issue_run.worktree.path)?
+	else {
+		return Ok(false);
+	};
+
+	if worktree_fingerprint.effective_delta_present {
+		return Ok(false);
+	}
+
+	let Some(review_handoff) = state_store.review_handoff_marker(
+		project.service_id(),
+		&issue_run.issue.id,
+		&issue_run.worktree.branch_name,
+	)?
+	else {
+		return Ok(false);
+	};
+
+	if review_handoff.branch_name() != issue_run.worktree.branch_name
+		|| review_handoff.pr_head_ref_name() != issue_run.worktree.branch_name
+	{
+		return Ok(false);
+	}
+
+	let lineage = review_handoff_failure_drift_lineage(
+		&issue_run.worktree.path,
+		review_handoff.pr_head_oid(),
+		&worktree_fingerprint.head_sha,
+	);
+
+	if !lineage.allows_lifecycle_recovery() {
+		return Ok(false);
+	}
+
+	let tracker_policy = workflow.frontmatter().tracker();
+	let success_state = tracker_policy.success_state();
+	let current_state = issue_run.issue.state.name.as_str();
+	let Some(success_state_transition) =
+		review_handoff_state_drift_success_transition(workflow, issue_run)?
+	else {
+		return Ok(false);
+	};
+	let issue_state_recovered =
+		matches!(success_state_transition, ReviewHandoffStateDriftTransition::MoveToSuccess(_));
+	let rebounded_orchestration = rebound_review_handoff_orchestration_marker(
+		project,
+		state_store,
+		issue_run,
+		&review_handoff,
+		&worktree_fingerprint.head_sha,
+	)?;
+	let needs_attention_cleared = tracker::set_issue_label_presence(
+		tracker,
+		&issue_run.issue,
+		tracker_policy.needs_attention_label(),
+		false,
+	)?;
+
+	if let ReviewHandoffStateDriftTransition::MoveToSuccess(state_id) = success_state_transition {
+		tracker.update_issue_state(&issue_run.issue.id, &state_id)?;
+	}
+
+	state_store
+		.clear_loop_guardrail_checkpoints_for_issue(project.service_id(), &issue_run.issue.id)?;
+	state_store.update_run_status(&issue_run.run_id, "succeeded")?;
+	state_store
+		.append_private_execution_event(
+			project.service_id(),
+			&issue_run.issue.id,
+			&issue_run.run_id,
+			issue_run.attempt_number,
+			REVIEW_HANDOFF_STATE_DRIFT_RECOVERED_EVENT_TYPE,
+			json!({
+				"schema": "decodex.review_handoff_state_drift_recovered/1",
+				"reason": "current_review_handoff_marker",
+				"source_error_class": review_handoff_failure_drift_source_error_class(error),
+				"branch_name": issue_run.worktree.branch_name,
+				"pr_url": review_handoff.pr_url(),
+				"marker_head_sha": review_handoff.pr_head_oid(),
+				"local_head_sha": worktree_fingerprint.head_sha,
+				"lineage": lineage.as_str(),
+				"previous_issue_state": current_state,
+				"target_issue_state": success_state,
+				"issue_state_recovered": issue_state_recovered,
+				"needs_attention_cleared": needs_attention_cleared,
+				"orchestration_rebound": rebounded_orchestration,
+			}),
+		)
+		.map(|_| ())?;
+
+	tracing::warn!(
+		project_id = project.service_id(),
+		issue_id = issue_run.issue.id,
+		issue = issue_run.issue.identifier,
+		run_id = issue_run.run_id,
+		attempt = issue_run.attempt_number,
+		branch = issue_run.worktree.branch_name,
+		pr_url = review_handoff.pr_url(),
+		lineage = lineage.as_str(),
+		"Recovered review handoff state drift before retry/no-diff failure writeback."
+	);
+
+	Ok(true)
+}
+
+fn review_handoff_state_drift_success_transition(
+	workflow: &WorkflowDocument,
+	issue_run: &IssueRunPlan,
+) -> Result<Option<ReviewHandoffStateDriftTransition>> {
+	let tracker_policy = workflow.frontmatter().tracker();
+	let success_state = tracker_policy.success_state();
+	let current_state = issue_run.issue.state.name.as_str();
+
+	if current_state == success_state {
+		return Ok(Some(ReviewHandoffStateDriftTransition::AlreadySuccess));
+	}
+	if current_state != tracker_policy.in_progress_state()
+		&& current_state != tracker_policy.failure_state()
+	{
+		return Ok(None);
+	}
+
+	let state_id = issue_run.issue.state_id_for_name(success_state).ok_or_else(|| {
+		eyre::eyre!(
+			"State `{success_state}` was not found for issue `{}` during review handoff state drift recovery.",
+			issue_run.issue.identifier
+		)
+	})?;
+
+	Ok(Some(ReviewHandoffStateDriftTransition::MoveToSuccess(state_id.to_owned())))
+}
+
+fn rebound_review_handoff_orchestration_marker(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	issue_run: &IssueRunPlan,
+	review_handoff: &ReviewHandoffMarker,
+	local_head_sha: &str,
+) -> Result<bool> {
+	let existing_orchestration = state_store.review_orchestration_marker(
+		project.service_id(),
+		&issue_run.issue.id,
+		review_handoff,
+	)?;
+	let rebounded_orchestration = existing_orchestration.as_ref().is_none_or(|marker| {
+		marker.branch_name() != review_handoff.branch_name()
+			|| marker.pr_url() != review_handoff.pr_url()
+			|| marker.head_sha() != local_head_sha
+			|| marker.phase() != REVIEW_HANDOFF_REBOUND_ORCHESTRATION_PHASE
+	});
+	let orchestration_marker = ReviewOrchestrationMarker::new(
+		review_handoff.run_id().to_owned(),
+		review_handoff.attempt_number(),
+		review_handoff.branch_name().to_owned(),
+		review_handoff.pr_url().to_owned(),
+		local_head_sha.to_owned(),
+		REVIEW_HANDOFF_REBOUND_ORCHESTRATION_PHASE,
+		None,
+		None,
+		None,
+		0,
+		existing_orchestration.as_ref().map_or(0, ReviewOrchestrationMarker::external_round_count),
+		None,
+	);
+
+	state_store.upsert_review_orchestration_marker(
+		project.service_id(),
+		&issue_run.issue.id,
+		&orchestration_marker,
+	)?;
+
+	Ok(rebounded_orchestration)
+}
+
+fn review_handoff_failure_drift_can_handle(error: &Report) -> bool {
+	!run_failure_requires_terminal_attention(error)
+		&& error.downcast_ref::<ManualAttentionRequested>().is_none()
+		&& error.downcast_ref::<LoopGuardrailStopRequested>().is_none()
+		&& error.downcast_ref::<ReviewHandoffNeedsAttention>().is_none()
+		&& error.downcast_ref::<RetainedReviewNeedsAttention>().is_none()
+		&& error.downcast_ref::<ReviewPolicyStopRequested>().is_none()
+		&& error.downcast_ref::<CodexAccountAuthFailure>().is_none()
+}
+
+fn review_handoff_failure_drift_source_error_class(error: &Report) -> &'static str {
+	retained_progress_source_error_class(error).unwrap_or("retryable_execution_failure")
+}
+
+fn review_handoff_failure_drift_lineage(
+	worktree_path: &Path,
+	recorded_head_oid: &str,
+	local_head_oid: &str,
+) -> ReviewHandoffFailureDriftLineage {
+	if recorded_head_oid == local_head_oid {
+		return ReviewHandoffFailureDriftLineage::Exact;
+	}
+
+	let Ok(output) = Command::new("git")
+		.arg("-C")
+		.arg(worktree_path)
+		.args(["merge-base", "--is-ancestor", recorded_head_oid, local_head_oid])
+		.output()
+	else {
+		return ReviewHandoffFailureDriftLineage::Unknown;
+	};
+
+	match output.status.code() {
+		Some(0) => ReviewHandoffFailureDriftLineage::Descends,
+		Some(1) => ReviewHandoffFailureDriftLineage::Diverged,
+		_ => ReviewHandoffFailureDriftLineage::Unknown,
+	}
+}
+
+fn review_handoff_state_drift_attention_error(
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	issue_run: &IssueRunPlan,
+	error: &Report,
+) -> Result<Option<ManualAttentionRequested>> {
+	if !review_handoff_failure_drift_can_handle(error) {
+		return Ok(None);
+	}
+
+	let Some(worktree_fingerprint) = loop_guardrail_worktree_fingerprint(&issue_run.worktree.path)?
+	else {
+		return Ok(None);
+	};
+
+	if worktree_fingerprint.effective_delta_present {
+		return Ok(None);
+	}
+
+	let checkpoint = state_store.review_policy_checkpoint(
+		project.service_id(),
+		&issue_run.issue.id,
+		&issue_run.run_id,
+		issue_run.attempt_number,
+		"handoff",
+	)?;
+	let drift_reason = match state_store.review_handoff_marker(
+		project.service_id(),
+		&issue_run.issue.id,
+		&issue_run.worktree.branch_name,
+	)? {
+		Some(review_handoff) => review_handoff_marker_drift_reason(
+			workflow,
+			issue_run,
+			&worktree_fingerprint,
+			&review_handoff,
+		)?,
+		None => {
+			let Some(checkpoint) = checkpoint.as_ref() else {
+				return Ok(None);
+			};
+
+			if checkpoint.status() != "clean"
+				|| checkpoint.head_sha() != worktree_fingerprint.head_sha
+			{
+				return Ok(None);
+			}
+
+			Some(String::from("missing_review_handoff_marker"))
+		},
+	};
+	let Some(drift_reason) = drift_reason else {
+		return Ok(None);
+	};
+
+	state_store
+		.append_private_execution_event(
+			project.service_id(),
+			&issue_run.issue.id,
+			&issue_run.run_id,
+			issue_run.attempt_number,
+			REVIEW_HANDOFF_STATE_DRIFT_DETECTED_EVENT_TYPE,
+			json!({
+				"schema": "decodex.review_handoff_state_drift_detected/1",
+				"reason": drift_reason,
+				"source_error_class": review_handoff_failure_drift_source_error_class(error),
+				"branch_name": issue_run.worktree.branch_name,
+				"checkpoint_status": checkpoint.as_ref().map(|checkpoint| checkpoint.status()),
+				"checkpoint_head_sha": checkpoint.as_ref().map(|checkpoint| checkpoint.head_sha()),
+				"local_head_sha": worktree_fingerprint.head_sha,
+				"next_action": "restore or rebind the retained review handoff marker before retrying execution",
+			}),
+		)
+		.map(|_| ())?;
+
+	Ok(Some(ManualAttentionRequested {
+		issue_identifier: issue_run.issue.identifier.clone(),
+		label: workflow.frontmatter().tracker().needs_attention_label().to_owned(),
+		run_id: issue_run.run_id.clone(),
+		error_class: Some(LoopGuardrailReason::ReviewHandoffStateDrift.error_class().to_owned()),
+	}))
+}
+
+fn review_handoff_marker_drift_reason(
+	workflow: &WorkflowDocument,
+	issue_run: &IssueRunPlan,
+	worktree_fingerprint: &LoopGuardrailWorktreeFingerprint,
+	review_handoff: &ReviewHandoffMarker,
+) -> Result<Option<String>> {
+	if review_handoff.branch_name() != issue_run.worktree.branch_name {
+		return Ok(Some(String::from("review_handoff_marker_branch_mismatch")));
+	}
+	if review_handoff.pr_head_ref_name() != issue_run.worktree.branch_name {
+		return Ok(Some(String::from("review_handoff_marker_pr_head_ref_mismatch")));
+	}
+
+	let lineage = review_handoff_failure_drift_lineage(
+		&issue_run.worktree.path,
+		review_handoff.pr_head_oid(),
+		&worktree_fingerprint.head_sha,
+	);
+
+	if !lineage.allows_lifecycle_recovery() {
+		return Ok(Some(format!("review_handoff_marker_{}", lineage.as_str())));
+	}
+	if review_handoff_state_drift_success_transition(workflow, issue_run)?.is_some() {
+		return Ok(None);
+	}
+
+	Ok(Some(String::from("review_handoff_marker_issue_state_unsupported")))
+}
+
+fn apply_review_handoff_state_drift_attention_writeback<T>(
+	tracker: &T,
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	issue_run: &IssueRunPlan,
+	worktree_path: &str,
+	attention_error: ManualAttentionRequested,
+) -> Result<()>
+where
+	T: IssueTracker,
+{
+	let terminal_error = Report::new(attention_error);
+	let privacy_classifier = configured_public_projection_privacy_classifier(project)?;
+	let outcome = apply_terminal_failure_writeback(
+		tracker,
+		TerminalFailureWritebackRuntime {
+			service_id: project.service_id(),
+			state_store: Some(state_store),
+			privacy_classifier: &privacy_classifier,
+		},
+		workflow,
+		issue_run,
+		worktree_path,
+		true,
+		&terminal_error,
+	)?;
+
+	if outcome.retry_guarded_by_state {
+		write_terminal_guard_marker(
+			&issue_run.worktree.path,
+			&issue_run.run_id,
+			issue_run.attempt_number,
+		)?;
+
+		state_store.update_run_status(&issue_run.run_id, TERMINAL_GUARDED_RUN_STATUS)?;
+	}
+
+	Ok(())
+}


### PR DESCRIPTION
## Summary
- Split review handoff state-drift recovery and rebind writeback into a dedicated execution_failure module.
- Split retryable failure writeback, retry schedule marker writing, and failed-start ownership cleanup into a dedicated module.
- Kept execution_failure/mod.rs as the orchestration facade; it is now 672 lines, down from 1405 after the previous batch.

## Validation
- cargo check -p decodex --all-targets --all-features
- cargo test -p decodex runtime_failure --all-features -- --nocapture --test-threads=1
- git diff --check
- rg "#\[path|include!|use .*::\*" apps/decodex/src/orchestrator/execution_failure/mod.rs apps/decodex/src/orchestrator/execution_failure/review_handoff_drift.rs apps/decodex/src/orchestrator/execution_failure/retryable_writeback.rs

## Notes
- cargo check/test still report the existing app_server unused-import warnings; this PR does not touch that surface.