### PR TITLE
Modularize contract and research design models

### DIFF
--- a/apps/decodex/src/loop_contract.rs
+++ b/apps/decodex/src/loop_contract.rs
@@ -1,39 +1,39 @@
 //! Versioned Loop/Decision Contract model for research-to-execution handoff.
 
-mod evidence;
-mod links;
-mod promotion;
-mod schema;
-mod validation;
+pub(crate) mod authority;
+pub(crate) mod evidence;
+pub(crate) mod links;
+pub(crate) mod promotion;
+pub(crate) mod readiness;
+pub(crate) mod research;
+pub(crate) mod schema;
+pub(crate) mod source_intent;
+pub(crate) mod validation;
+
+pub(crate) use self::{
+	authority::DecisionAcceptedAuthority,
+	evidence::DecisionEvidenceBoundary,
+	links::DecisionContractLinks,
+	promotion::DecisionPromotion,
+	readiness::{DecisionExecutionReadiness, DecisionProposedIssue},
+	research::{DecisionResearchEvidence, DecisionResearchOption, DecisionResearchProvenance},
+	schema::{
+		DECISION_CONTRACT_RECORD_VERSION, DECISION_CONTRACT_SCHEMA, DecisionContractStatus,
+		DecisionPromotionActorKind,
+	},
+	source_intent::DecisionSourceIntent,
+};
 
 use serde::{Deserialize, Serialize};
 
 use crate::prelude::{Result, eyre};
 
-pub(crate) use self::{
-	evidence::DecisionEvidenceBoundary,
-	links::DecisionContractLinks,
-	promotion::DecisionPromotion,
-	schema::{
-		DECISION_CONTRACT_RECORD_VERSION, DECISION_CONTRACT_SCHEMA, DecisionContractStatus,
-		DecisionPromotionActorKind,
-	},
-};
-use self::{
-	schema::{decision_contract_record_version, decision_contract_schema},
-	validation::{
-		default_research_evidence_kind, normalized_link_values, validate_optional,
-		validate_proposed_issue_queue_intent, validate_proposed_issue_stage,
-		validate_proposed_issues, validate_required, validate_string_list,
-	},
-};
-
 /// Versioned research-to-execution contract payload.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub(crate) struct DecisionContract {
-	#[serde(default = "decision_contract_schema")]
+	#[serde(default = "schema::decision_contract_schema")]
 	schema: String,
-	#[serde(default = "decision_contract_record_version")]
+	#[serde(default = "schema::decision_contract_record_version")]
 	record_version: u16,
 	contract_id: String,
 	status: DecisionContractStatus,
@@ -102,9 +102,10 @@ impl DecisionContract {
 	) -> Result<()> {
 		let mut candidate = self.clone();
 
-		candidate.links.generated_issue_ids = normalized_link_values(issue_ids)?;
-		candidate.links.generated_issue_identifiers = normalized_link_values(issue_identifiers)?;
-		candidate.links.execution_program_node_ids = normalized_link_values(node_ids)?;
+		candidate.links.generated_issue_ids = validation::normalized_link_values(issue_ids)?;
+		candidate.links.generated_issue_identifiers =
+			validation::normalized_link_values(issue_identifiers)?;
+		candidate.links.execution_program_node_ids = validation::normalized_link_values(node_ids)?;
 
 		candidate.validate()?;
 
@@ -114,8 +115,8 @@ impl DecisionContract {
 	}
 
 	pub(crate) fn validate(&self) -> Result<()> {
-		validate_required("decision contract schema", &self.schema)?;
-		validate_required("decision contract contract_id", &self.contract_id)?;
+		validation::validate_required("decision contract schema", &self.schema)?;
+		validation::validate_required("decision contract contract_id", &self.contract_id)?;
 
 		self.source_intent.validate()?;
 		self.accepted_authority.validate(self.status)?;
@@ -218,7 +219,7 @@ impl DecisionContract {
 
 		let reason = reason.into();
 
-		validate_required("decision contract human-decision reason", &reason)?;
+		validation::validate_required("decision contract human-decision reason", &reason)?;
 
 		let mut candidate = self.clone();
 
@@ -248,7 +249,10 @@ impl DecisionContract {
 		let mut candidate = self.clone();
 
 		if let Some(contract_id) = superseded_by_contract_id {
-			validate_required("decision contract superseded_by_contract_id", &contract_id)?;
+			validation::validate_required(
+				"decision contract superseded_by_contract_id",
+				&contract_id,
+			)?;
 
 			candidate.links.superseded_by_contract_id = Some(contract_id);
 		}
@@ -260,365 +264,6 @@ impl DecisionContract {
 		*self = candidate;
 
 		Ok(())
-	}
-}
-
-/// Natural-language source intent that led to research or design work.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub(crate) struct DecisionSourceIntent {
-	summary: String,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	user_utterance: Option<String>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	source_issue_identifier: Option<String>,
-}
-#[allow(dead_code)]
-impl DecisionSourceIntent {
-	pub(crate) fn summary(&self) -> &str {
-		&self.summary
-	}
-
-	pub(crate) fn source_issue_identifier(&self) -> Option<&str> {
-		self.source_issue_identifier.as_deref()
-	}
-
-	fn validate(&self) -> Result<()> {
-		validate_required("decision contract source_intent.summary", &self.summary)?;
-		validate_optional(
-			"decision contract source_intent.user_utterance",
-			self.user_utterance.as_deref(),
-		)?;
-
-		validate_optional(
-			"decision contract source_intent.source_issue_identifier",
-			self.source_issue_identifier.as_deref(),
-		)
-	}
-}
-
-/// Research or design source used to produce the contract.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub(crate) struct DecisionResearchProvenance {
-	kind: String,
-	reference: String,
-	summary: String,
-}
-impl DecisionResearchProvenance {
-	pub(crate) fn kind(&self) -> &str {
-		&self.kind
-	}
-
-	pub(crate) fn reference(&self) -> &str {
-		&self.reference
-	}
-
-	fn validate(&self) -> Result<()> {
-		validate_required("decision contract research_provenance.kind", &self.kind)?;
-		validate_required("decision contract research_provenance.reference", &self.reference)?;
-
-		validate_required("decision contract research_provenance.summary", &self.summary)
-	}
-}
-
-/// Non-authoritative research evidence retained before promotion.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub(crate) struct DecisionResearchEvidence {
-	#[serde(default = "default_research_evidence_kind")]
-	kind: String,
-	claim: String,
-	support: String,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	source_ref: Option<String>,
-}
-impl DecisionResearchEvidence {
-	pub(crate) fn kind(&self) -> &str {
-		&self.kind
-	}
-
-	pub(crate) fn source_ref(&self) -> Option<&str> {
-		self.source_ref.as_deref()
-	}
-
-	fn validate(&self) -> Result<()> {
-		validate_required("decision contract research_evidence.kind", &self.kind)?;
-		validate_required("decision contract research_evidence.claim", &self.claim)?;
-		validate_required("decision contract research_evidence.support", &self.support)?;
-
-		validate_optional(
-			"decision contract research_evidence.source_ref",
-			self.source_ref.as_deref(),
-		)
-	}
-}
-
-/// Option comparison retained as non-authoritative research context.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub(crate) struct DecisionResearchOption {
-	option: String,
-	#[serde(default)]
-	tradeoffs: Vec<String>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	decision: Option<String>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	rejected_reason: Option<String>,
-}
-#[allow(dead_code)]
-impl DecisionResearchOption {
-	pub(crate) fn option(&self) -> &str {
-		&self.option
-	}
-
-	fn validate(&self) -> Result<()> {
-		validate_required("decision contract research_options.option", &self.option)?;
-		validate_string_list("decision contract research_options.tradeoffs", &self.tradeoffs)?;
-		validate_optional("decision contract research_options.decision", self.decision.as_deref())?;
-
-		validate_optional(
-			"decision contract research_options.rejected_reason",
-			self.rejected_reason.as_deref(),
-		)
-	}
-}
-
-/// Proposed or accepted execution authority carried by the contract.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
-pub(crate) struct DecisionAcceptedAuthority {
-	#[serde(default)]
-	accepted_objectives: Vec<String>,
-	#[serde(default)]
-	non_goals: Vec<String>,
-	#[serde(default)]
-	constraints: Vec<String>,
-	#[serde(default)]
-	assumptions: Vec<String>,
-	#[serde(default)]
-	objections: Vec<String>,
-	#[serde(default)]
-	stop_conditions: Vec<String>,
-}
-#[allow(dead_code)]
-impl DecisionAcceptedAuthority {
-	pub(crate) fn accepted_objectives(&self) -> &[String] {
-		&self.accepted_objectives
-	}
-
-	pub(crate) fn non_goals(&self) -> &[String] {
-		&self.non_goals
-	}
-
-	pub(crate) fn constraints(&self) -> &[String] {
-		&self.constraints
-	}
-
-	pub(crate) fn assumptions(&self) -> &[String] {
-		&self.assumptions
-	}
-
-	pub(crate) fn objections(&self) -> &[String] {
-		&self.objections
-	}
-
-	pub(crate) fn stop_conditions(&self) -> &[String] {
-		&self.stop_conditions
-	}
-
-	fn validate(&self, status: DecisionContractStatus) -> Result<()> {
-		if status == DecisionContractStatus::AcceptedPromoted && self.accepted_objectives.is_empty()
-		{
-			eyre::bail!("Accepted decision contracts must include accepted objectives.");
-		}
-
-		validate_string_list("decision contract accepted_objectives", &self.accepted_objectives)?;
-		validate_string_list("decision contract non_goals", &self.non_goals)?;
-		validate_string_list("decision contract constraints", &self.constraints)?;
-		validate_string_list("decision contract assumptions", &self.assumptions)?;
-		validate_string_list("decision contract objections", &self.objections)?;
-
-		validate_string_list("decision contract stop_conditions", &self.stop_conditions)
-	}
-}
-
-/// Natural-language readiness summary for later issue shaping.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct DecisionExecutionReadiness {
-	summary: String,
-	ready_for_issue_shaping: bool,
-	#[serde(default)]
-	missing_decisions: Vec<String>,
-	#[serde(default)]
-	validation_expectations: Vec<String>,
-	#[serde(default)]
-	risk_notes: Vec<String>,
-	proposed_issues: Vec<DecisionProposedIssue>,
-	#[serde(default)]
-	promotion_targets: Vec<String>,
-	#[serde(default)]
-	conflict_domains: Vec<String>,
-}
-#[allow(dead_code)]
-impl DecisionExecutionReadiness {
-	pub(crate) fn summary(&self) -> &str {
-		&self.summary
-	}
-
-	pub(crate) fn ready_for_issue_shaping(&self) -> bool {
-		self.ready_for_issue_shaping
-	}
-
-	pub(crate) fn missing_decisions(&self) -> &[String] {
-		&self.missing_decisions
-	}
-
-	pub(crate) fn proposed_issues(&self) -> &[DecisionProposedIssue] {
-		&self.proposed_issues
-	}
-
-	pub(crate) fn promotion_targets(&self) -> &[String] {
-		&self.promotion_targets
-	}
-
-	pub(crate) fn conflict_domains(&self) -> &[String] {
-		&self.conflict_domains
-	}
-
-	pub(crate) fn validation_expectations(&self) -> &[String] {
-		&self.validation_expectations
-	}
-
-	pub(crate) fn risk_notes(&self) -> &[String] {
-		&self.risk_notes
-	}
-
-	fn validate(&self, status: DecisionContractStatus) -> Result<()> {
-		validate_required("decision contract execution_readiness.summary", &self.summary)?;
-		validate_string_list("decision contract missing_decisions", &self.missing_decisions)?;
-		validate_string_list(
-			"decision contract validation_expectations",
-			&self.validation_expectations,
-		)?;
-		validate_string_list("decision contract risk_notes", &self.risk_notes)?;
-		validate_proposed_issues(&self.proposed_issues)?;
-		validate_string_list("decision contract promotion_targets", &self.promotion_targets)?;
-		validate_string_list("decision contract conflict_domains", &self.conflict_domains)?;
-
-		match status {
-			DecisionContractStatus::AcceptedPromoted => {
-				if !self.ready_for_issue_shaping {
-					eyre::bail!("Accepted decision contracts must be ready for issue shaping.");
-				}
-				if self.proposed_issues.is_empty() {
-					eyre::bail!(
-						"Accepted decision contracts must include structured proposed_issues."
-					);
-				}
-				if !self.missing_decisions.is_empty() {
-					eyre::bail!(
-						"Accepted decision contracts must not carry unresolved missing decisions."
-					);
-				}
-			},
-			DecisionContractStatus::NeedsHumanDecision =>
-				if self.missing_decisions.is_empty() {
-					eyre::bail!(
-						"Needs-human-decision contracts must include at least one missing decision."
-					);
-				},
-			DecisionContractStatus::DraftLatent | DecisionContractStatus::RejectedSuperseded => {},
-		}
-
-		Ok(())
-	}
-}
-
-/// Structured issue-shaping input retained inside Decision Contract readiness.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct DecisionProposedIssue {
-	key: String,
-	title: String,
-	objective: String,
-	stage: String,
-	dependencies: Vec<String>,
-	conflict_domains: Vec<String>,
-	acceptance: Vec<String>,
-	validation: Vec<String>,
-	risk: Vec<String>,
-	queue_intent: String,
-}
-#[allow(dead_code)]
-impl DecisionProposedIssue {
-	pub(crate) fn key(&self) -> &str {
-		&self.key
-	}
-
-	pub(crate) fn title(&self) -> &str {
-		&self.title
-	}
-
-	pub(crate) fn objective(&self) -> &str {
-		&self.objective
-	}
-
-	pub(crate) fn stage(&self) -> &str {
-		&self.stage
-	}
-
-	pub(crate) fn dependencies(&self) -> &[String] {
-		&self.dependencies
-	}
-
-	pub(crate) fn conflict_domains(&self) -> &[String] {
-		&self.conflict_domains
-	}
-
-	pub(crate) fn acceptance(&self) -> &[String] {
-		&self.acceptance
-	}
-
-	pub(crate) fn validation(&self) -> &[String] {
-		&self.validation
-	}
-
-	pub(crate) fn risk(&self) -> &[String] {
-		&self.risk
-	}
-
-	pub(crate) fn queue_intent(&self) -> &str {
-		&self.queue_intent
-	}
-
-	fn validate(&self) -> Result<()> {
-		validate_required("decision contract proposed_issues.key", &self.key)?;
-		validate_required("decision contract proposed_issues.title", &self.title)?;
-		validate_required("decision contract proposed_issues.objective", &self.objective)?;
-		validate_required("decision contract proposed_issues.stage", &self.stage)?;
-		validate_string_list("decision contract proposed_issues.dependencies", &self.dependencies)?;
-		validate_string_list(
-			"decision contract proposed_issues.conflict_domains",
-			&self.conflict_domains,
-		)?;
-		validate_string_list("decision contract proposed_issues.acceptance", &self.acceptance)?;
-		validate_string_list("decision contract proposed_issues.validation", &self.validation)?;
-		validate_string_list("decision contract proposed_issues.risk", &self.risk)?;
-		validate_required("decision contract proposed_issues.queue_intent", &self.queue_intent)?;
-
-		if self.acceptance.is_empty() {
-			eyre::bail!(
-				"Decision Contract proposed issue `{}` must include acceptance criteria.",
-				self.key
-			);
-		}
-		if self.validation.is_empty() {
-			eyre::bail!(
-				"Decision Contract proposed issue `{}` must include validation expectations.",
-				self.key
-			);
-		}
-
-		validate_proposed_issue_stage(&self.key, &self.stage)?;
-
-		validate_proposed_issue_queue_intent(&self.key, &self.queue_intent)
 	}
 }
 

--- a/apps/decodex/src/loop_contract/authority.rs
+++ b/apps/decodex/src/loop_contract/authority.rs
@@ -1,0 +1,67 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+	loop_contract::{schema::DecisionContractStatus, validation},
+	prelude::{Result, eyre},
+};
+
+/// Proposed or accepted execution authority carried by the contract.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+pub(crate) struct DecisionAcceptedAuthority {
+	#[serde(default)]
+	accepted_objectives: Vec<String>,
+	#[serde(default)]
+	non_goals: Vec<String>,
+	#[serde(default)]
+	constraints: Vec<String>,
+	#[serde(default)]
+	assumptions: Vec<String>,
+	#[serde(default)]
+	objections: Vec<String>,
+	#[serde(default)]
+	stop_conditions: Vec<String>,
+}
+#[allow(dead_code)]
+impl DecisionAcceptedAuthority {
+	pub(crate) fn accepted_objectives(&self) -> &[String] {
+		&self.accepted_objectives
+	}
+
+	pub(crate) fn non_goals(&self) -> &[String] {
+		&self.non_goals
+	}
+
+	pub(crate) fn constraints(&self) -> &[String] {
+		&self.constraints
+	}
+
+	pub(crate) fn assumptions(&self) -> &[String] {
+		&self.assumptions
+	}
+
+	pub(crate) fn objections(&self) -> &[String] {
+		&self.objections
+	}
+
+	pub(crate) fn stop_conditions(&self) -> &[String] {
+		&self.stop_conditions
+	}
+
+	pub(super) fn validate(&self, status: DecisionContractStatus) -> Result<()> {
+		if status == DecisionContractStatus::AcceptedPromoted && self.accepted_objectives.is_empty()
+		{
+			eyre::bail!("Accepted decision contracts must include accepted objectives.");
+		}
+
+		validation::validate_string_list(
+			"decision contract accepted_objectives",
+			&self.accepted_objectives,
+		)?;
+		validation::validate_string_list("decision contract non_goals", &self.non_goals)?;
+		validation::validate_string_list("decision contract constraints", &self.constraints)?;
+		validation::validate_string_list("decision contract assumptions", &self.assumptions)?;
+		validation::validate_string_list("decision contract objections", &self.objections)?;
+
+		validation::validate_string_list("decision contract stop_conditions", &self.stop_conditions)
+	}
+}

--- a/apps/decodex/src/loop_contract/evidence.rs
+++ b/apps/decodex/src/loop_contract/evidence.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-use crate::prelude::{Result, eyre};
-
-use super::validation::{validate_optional, validate_required};
+use crate::{
+	loop_contract::validation,
+	prelude::{Result, eyre},
+};
 
 /// Boundary between private runtime evidence and public tracker projection.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
@@ -32,7 +33,7 @@ impl DecisionEvidenceBoundary {
 			projection_ref.validate()?;
 		}
 
-		validate_optional(
+		validation::validate_optional(
 			"decision contract evidence_boundary.public_summary",
 			self.public_summary.as_deref(),
 		)
@@ -53,9 +54,18 @@ pub(crate) struct DecisionPrivateEvidenceRef {
 }
 impl DecisionPrivateEvidenceRef {
 	fn validate(&self) -> Result<()> {
-		validate_required("decision contract private_evidence_ref.project_id", &self.project_id)?;
-		validate_required("decision contract private_evidence_ref.issue_id", &self.issue_id)?;
-		validate_required("decision contract private_evidence_ref.run_id", &self.run_id)?;
+		validation::validate_required(
+			"decision contract private_evidence_ref.project_id",
+			&self.project_id,
+		)?;
+		validation::validate_required(
+			"decision contract private_evidence_ref.issue_id",
+			&self.issue_id,
+		)?;
+		validation::validate_required(
+			"decision contract private_evidence_ref.run_id",
+			&self.run_id,
+		)?;
 
 		if self.attempt_number < 1 {
 			eyre::bail!("Decision contract private evidence attempt_number must be positive.");
@@ -67,7 +77,7 @@ impl DecisionPrivateEvidenceRef {
 			eyre::bail!("Decision contract private evidence record_id must be positive.");
 		}
 
-		validate_optional(
+		validation::validate_optional(
 			"decision contract private_evidence_ref.event_type",
 			self.event_type.as_deref(),
 		)
@@ -83,9 +93,18 @@ pub(crate) struct DecisionPublicProjectionRef {
 }
 impl DecisionPublicProjectionRef {
 	fn validate(&self) -> Result<()> {
-		validate_required("decision contract public_projection_ref.surface", &self.surface)?;
-		validate_required("decision contract public_projection_ref.reference", &self.reference)?;
+		validation::validate_required(
+			"decision contract public_projection_ref.surface",
+			&self.surface,
+		)?;
+		validation::validate_required(
+			"decision contract public_projection_ref.reference",
+			&self.reference,
+		)?;
 
-		validate_required("decision contract public_projection_ref.summary", &self.summary)
+		validation::validate_required(
+			"decision contract public_projection_ref.summary",
+			&self.summary,
+		)
 	}
 }

--- a/apps/decodex/src/loop_contract/links.rs
+++ b/apps/decodex/src/loop_contract/links.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::prelude::Result;
-
-use super::validation::{validate_optional, validate_string_list};
+use crate::{loop_contract::validation, prelude::Result};
 
 /// Links from the decision contract to generated execution surfaces.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
@@ -35,20 +33,20 @@ impl DecisionContractLinks {
 	}
 
 	pub(super) fn validate(&self) -> Result<()> {
-		validate_string_list(
+		validation::validate_string_list(
 			"decision contract links.generated_issue_ids",
 			&self.generated_issue_ids,
 		)?;
-		validate_string_list(
+		validation::validate_string_list(
 			"decision contract links.generated_issue_identifiers",
 			&self.generated_issue_identifiers,
 		)?;
-		validate_string_list(
+		validation::validate_string_list(
 			"decision contract links.execution_program_node_ids",
 			&self.execution_program_node_ids,
 		)?;
 
-		validate_optional(
+		validation::validate_optional(
 			"decision contract links.superseded_by_contract_id",
 			self.superseded_by_contract_id.as_deref(),
 		)

--- a/apps/decodex/src/loop_contract/promotion.rs
+++ b/apps/decodex/src/loop_contract/promotion.rs
@@ -1,10 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use crate::prelude::Result;
-
-use super::{
-	DecisionPromotionActorKind,
-	validation::{validate_optional, validate_required},
+use crate::{
+	loop_contract::{DecisionPromotionActorKind, validation},
+	prelude::Result,
 };
 
 /// Promotion metadata that records who or what accepted the contract and when.
@@ -48,14 +46,20 @@ impl DecisionPromotion {
 	}
 
 	pub(super) fn validate(&self) -> Result<()> {
-		validate_required("decision contract promotion.accepted_by", &self.accepted_by)?;
-		validate_required("decision contract promotion.accepted_at", &self.accepted_at)?;
-		validate_required(
+		validation::validate_required(
+			"decision contract promotion.accepted_by",
+			&self.accepted_by,
+		)?;
+		validation::validate_required(
+			"decision contract promotion.accepted_at",
+			&self.accepted_at,
+		)?;
+		validation::validate_required(
 			"decision contract promotion.acceptance_source",
 			&self.acceptance_source,
 		)?;
 
-		validate_optional(
+		validation::validate_optional(
 			"decision contract promotion.promotion_reason",
 			self.promotion_reason.as_deref(),
 		)

--- a/apps/decodex/src/loop_contract/readiness.rs
+++ b/apps/decodex/src/loop_contract/readiness.rs
@@ -1,0 +1,218 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+	loop_contract::{schema::DecisionContractStatus, validation},
+	prelude::{Result, eyre},
+};
+
+/// Natural-language readiness summary for later issue shaping.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DecisionExecutionReadiness {
+	summary: String,
+	pub(super) ready_for_issue_shaping: bool,
+	#[serde(default)]
+	pub(super) missing_decisions: Vec<String>,
+	#[serde(default)]
+	validation_expectations: Vec<String>,
+	#[serde(default)]
+	risk_notes: Vec<String>,
+	pub(super) proposed_issues: Vec<DecisionProposedIssue>,
+	#[serde(default)]
+	promotion_targets: Vec<String>,
+	#[serde(default)]
+	conflict_domains: Vec<String>,
+}
+#[allow(dead_code)]
+impl DecisionExecutionReadiness {
+	pub(crate) fn summary(&self) -> &str {
+		&self.summary
+	}
+
+	pub(crate) fn ready_for_issue_shaping(&self) -> bool {
+		self.ready_for_issue_shaping
+	}
+
+	pub(crate) fn missing_decisions(&self) -> &[String] {
+		&self.missing_decisions
+	}
+
+	pub(crate) fn proposed_issues(&self) -> &[DecisionProposedIssue] {
+		&self.proposed_issues
+	}
+
+	pub(crate) fn promotion_targets(&self) -> &[String] {
+		&self.promotion_targets
+	}
+
+	pub(crate) fn conflict_domains(&self) -> &[String] {
+		&self.conflict_domains
+	}
+
+	pub(crate) fn validation_expectations(&self) -> &[String] {
+		&self.validation_expectations
+	}
+
+	pub(crate) fn risk_notes(&self) -> &[String] {
+		&self.risk_notes
+	}
+
+	pub(super) fn validate(&self, status: DecisionContractStatus) -> Result<()> {
+		validation::validate_required(
+			"decision contract execution_readiness.summary",
+			&self.summary,
+		)?;
+		validation::validate_string_list(
+			"decision contract missing_decisions",
+			&self.missing_decisions,
+		)?;
+		validation::validate_string_list(
+			"decision contract validation_expectations",
+			&self.validation_expectations,
+		)?;
+		validation::validate_string_list("decision contract risk_notes", &self.risk_notes)?;
+		validation::validate_proposed_issues(&self.proposed_issues)?;
+		validation::validate_string_list(
+			"decision contract promotion_targets",
+			&self.promotion_targets,
+		)?;
+		validation::validate_string_list(
+			"decision contract conflict_domains",
+			&self.conflict_domains,
+		)?;
+
+		match status {
+			DecisionContractStatus::AcceptedPromoted => {
+				if !self.ready_for_issue_shaping {
+					eyre::bail!("Accepted decision contracts must be ready for issue shaping.");
+				}
+				if self.proposed_issues.is_empty() {
+					eyre::bail!(
+						"Accepted decision contracts must include structured proposed_issues."
+					);
+				}
+				if !self.missing_decisions.is_empty() {
+					eyre::bail!(
+						"Accepted decision contracts must not carry unresolved missing decisions."
+					);
+				}
+			},
+			DecisionContractStatus::NeedsHumanDecision => {
+				if self.missing_decisions.is_empty() {
+					eyre::bail!(
+						"Needs-human-decision contracts must include at least one missing decision."
+					);
+				}
+			},
+			DecisionContractStatus::DraftLatent | DecisionContractStatus::RejectedSuperseded => {},
+		}
+
+		Ok(())
+	}
+}
+
+/// Structured issue-shaping input retained inside Decision Contract readiness.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DecisionProposedIssue {
+	key: String,
+	title: String,
+	objective: String,
+	stage: String,
+	dependencies: Vec<String>,
+	conflict_domains: Vec<String>,
+	acceptance: Vec<String>,
+	validation: Vec<String>,
+	risk: Vec<String>,
+	queue_intent: String,
+}
+#[allow(dead_code)]
+impl DecisionProposedIssue {
+	pub(crate) fn key(&self) -> &str {
+		&self.key
+	}
+
+	pub(crate) fn title(&self) -> &str {
+		&self.title
+	}
+
+	pub(crate) fn objective(&self) -> &str {
+		&self.objective
+	}
+
+	pub(crate) fn stage(&self) -> &str {
+		&self.stage
+	}
+
+	pub(crate) fn dependencies(&self) -> &[String] {
+		&self.dependencies
+	}
+
+	pub(crate) fn conflict_domains(&self) -> &[String] {
+		&self.conflict_domains
+	}
+
+	pub(crate) fn acceptance(&self) -> &[String] {
+		&self.acceptance
+	}
+
+	pub(crate) fn validation(&self) -> &[String] {
+		&self.validation
+	}
+
+	pub(crate) fn risk(&self) -> &[String] {
+		&self.risk
+	}
+
+	pub(crate) fn queue_intent(&self) -> &str {
+		&self.queue_intent
+	}
+
+	pub(super) fn validate(&self) -> Result<()> {
+		validation::validate_required("decision contract proposed_issues.key", &self.key)?;
+		validation::validate_required("decision contract proposed_issues.title", &self.title)?;
+		validation::validate_required(
+			"decision contract proposed_issues.objective",
+			&self.objective,
+		)?;
+		validation::validate_required("decision contract proposed_issues.stage", &self.stage)?;
+		validation::validate_string_list(
+			"decision contract proposed_issues.dependencies",
+			&self.dependencies,
+		)?;
+		validation::validate_string_list(
+			"decision contract proposed_issues.conflict_domains",
+			&self.conflict_domains,
+		)?;
+		validation::validate_string_list(
+			"decision contract proposed_issues.acceptance",
+			&self.acceptance,
+		)?;
+		validation::validate_string_list(
+			"decision contract proposed_issues.validation",
+			&self.validation,
+		)?;
+		validation::validate_string_list("decision contract proposed_issues.risk", &self.risk)?;
+		validation::validate_required(
+			"decision contract proposed_issues.queue_intent",
+			&self.queue_intent,
+		)?;
+
+		if self.acceptance.is_empty() {
+			eyre::bail!(
+				"Decision Contract proposed issue `{}` must include acceptance criteria.",
+				self.key
+			);
+		}
+		if self.validation.is_empty() {
+			eyre::bail!(
+				"Decision Contract proposed issue `{}` must include validation expectations.",
+				self.key
+			);
+		}
+
+		validation::validate_proposed_issue_stage(&self.key, &self.stage)?;
+
+		validation::validate_proposed_issue_queue_intent(&self.key, &self.queue_intent)
+	}
+}

--- a/apps/decodex/src/loop_contract/research.rs
+++ b/apps/decodex/src/loop_contract/research.rs
@@ -1,0 +1,102 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{loop_contract::validation, prelude::Result};
+
+/// Research or design source used to produce the contract.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub(crate) struct DecisionResearchProvenance {
+	kind: String,
+	reference: String,
+	summary: String,
+}
+impl DecisionResearchProvenance {
+	pub(crate) fn kind(&self) -> &str {
+		&self.kind
+	}
+
+	pub(crate) fn reference(&self) -> &str {
+		&self.reference
+	}
+
+	pub(super) fn validate(&self) -> Result<()> {
+		validation::validate_required("decision contract research_provenance.kind", &self.kind)?;
+		validation::validate_required(
+			"decision contract research_provenance.reference",
+			&self.reference,
+		)?;
+
+		validation::validate_required(
+			"decision contract research_provenance.summary",
+			&self.summary,
+		)
+	}
+}
+
+/// Non-authoritative research evidence retained before promotion.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub(crate) struct DecisionResearchEvidence {
+	#[serde(default = "validation::default_research_evidence_kind")]
+	kind: String,
+	claim: String,
+	support: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	source_ref: Option<String>,
+}
+impl DecisionResearchEvidence {
+	pub(crate) fn kind(&self) -> &str {
+		&self.kind
+	}
+
+	pub(crate) fn source_ref(&self) -> Option<&str> {
+		self.source_ref.as_deref()
+	}
+
+	pub(super) fn validate(&self) -> Result<()> {
+		validation::validate_required("decision contract research_evidence.kind", &self.kind)?;
+		validation::validate_required("decision contract research_evidence.claim", &self.claim)?;
+		validation::validate_required(
+			"decision contract research_evidence.support",
+			&self.support,
+		)?;
+
+		validation::validate_optional(
+			"decision contract research_evidence.source_ref",
+			self.source_ref.as_deref(),
+		)
+	}
+}
+
+/// Option comparison retained as non-authoritative research context.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub(crate) struct DecisionResearchOption {
+	option: String,
+	#[serde(default)]
+	tradeoffs: Vec<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	decision: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	rejected_reason: Option<String>,
+}
+#[allow(dead_code)]
+impl DecisionResearchOption {
+	pub(crate) fn option(&self) -> &str {
+		&self.option
+	}
+
+	pub(super) fn validate(&self) -> Result<()> {
+		validation::validate_required("decision contract research_options.option", &self.option)?;
+		validation::validate_string_list(
+			"decision contract research_options.tradeoffs",
+			&self.tradeoffs,
+		)?;
+		validation::validate_optional(
+			"decision contract research_options.decision",
+			self.decision.as_deref(),
+		)?;
+
+		validation::validate_optional(
+			"decision contract research_options.rejected_reason",
+			self.rejected_reason.as_deref(),
+		)
+	}
+}

--- a/apps/decodex/src/loop_contract/source_intent.rs
+++ b/apps/decodex/src/loop_contract/source_intent.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{loop_contract::validation, prelude::Result};
+
+/// Natural-language source intent that led to research or design work.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub(crate) struct DecisionSourceIntent {
+	summary: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	user_utterance: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	source_issue_identifier: Option<String>,
+}
+#[allow(dead_code)]
+impl DecisionSourceIntent {
+	pub(crate) fn summary(&self) -> &str {
+		&self.summary
+	}
+
+	pub(crate) fn source_issue_identifier(&self) -> Option<&str> {
+		self.source_issue_identifier.as_deref()
+	}
+
+	pub(super) fn validate(&self) -> Result<()> {
+		validation::validate_required("decision contract source_intent.summary", &self.summary)?;
+		validation::validate_optional(
+			"decision contract source_intent.user_utterance",
+			self.user_utterance.as_deref(),
+		)?;
+
+		validation::validate_optional(
+			"decision contract source_intent.source_issue_identifier",
+			self.source_issue_identifier.as_deref(),
+		)
+	}
+}

--- a/apps/decodex/src/loop_contract/validation.rs
+++ b/apps/decodex/src/loop_contract/validation.rs
@@ -49,8 +49,9 @@ pub(super) fn validate_proposed_issues(issues: &[DecisionProposedIssue]) -> Resu
 
 pub(super) fn validate_proposed_issue_stage(key: &str, stage: &str) -> Result<()> {
 	match stage {
-		"research" | "design" | "spec" | "schema" | "runtime" | "plugin" | "eval" | "handoff" =>
-			Ok(()),
+		"research" | "design" | "spec" | "schema" | "runtime" | "plugin" | "eval" | "handoff" => {
+			Ok(())
+		},
 		_ => {
 			eyre::bail!("Decision Contract proposed issue `{key}` has unsupported stage `{stage}`.")
 		},
@@ -59,8 +60,9 @@ pub(super) fn validate_proposed_issue_stage(key: &str, stage: &str) -> Result<()
 
 pub(super) fn validate_proposed_issue_queue_intent(key: &str, queue_intent: &str) -> Result<()> {
 	match queue_intent {
-		"not_ready" | "ready_to_queue" | "queued" | "active" | "paused" | "done" | "canceled" =>
-			Ok(()),
+		"not_ready" | "ready_to_queue" | "queued" | "active" | "paused" | "done" | "canceled" => {
+			Ok(())
+		},
 		_ => eyre::bail!(
 			"Decision Contract proposed issue `{key}` has unsupported queue_intent `{queue_intent}`."
 		),

--- a/apps/decodex/src/research_design.rs
+++ b/apps/decodex/src/research_design.rs
@@ -1,310 +1,44 @@
 //! Decodex-native research/design runner and Decision Contract compiler.
 
+pub(crate) mod compiler;
+pub(crate) mod input;
+pub(crate) mod lifecycle;
+pub(crate) mod normalized;
+pub(crate) mod reports;
+pub(crate) mod requests;
+
+pub(crate) use self::{
+	compiler::dry_run_research_design_compile,
+	input::{ResearchDesignOutcome, ResearchDesignRunInput},
+	lifecycle::{persist_research_design_run, promote_research_design_contract},
+	reports::{ResearchDesignPromotionReport, ResearchDesignRunReport},
+	requests::{ResearchDesignCompileRequest, ResearchDesignPromoteRequest},
+};
+
 use std::{
 	env,
 	path::{Path, PathBuf},
 };
 
-use serde::Serialize;
-use serde_json::{self, Value};
-use sha2::{Digest as _, Sha256};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::{
 	config::ServiceConfig,
-	loop_contract::{
-		DecisionContract, DecisionContractStatus, DecisionPromotion, DecisionPromotionActorKind,
-		DecisionProposedIssue,
-	},
+	loop_contract::{DecisionPromotion, DecisionPromotionActorKind},
 	prelude::{Result, eyre},
 	runtime,
-	state::{DecisionContractRecord, StateStore},
+	state::StateStore,
 };
-
-mod input;
-
-pub(crate) use input::{ResearchDesignOutcome, ResearchDesignRunInput};
-use input::{
-	ResearchEvidenceInput, ResearchOptionInput, ResearchPrivateEvidenceRefInput,
-	ResearchProposedIssueInput, ResearchProvenanceInput, ResearchPublicProjectionRefInput,
-	ResearchSubworkInput,
+#[cfg(test)]
+use self::{
+	compiler::compile_research_design_run,
+	input::{
+		ResearchEvidenceInput, ResearchOptionInput, ResearchPrivateEvidenceRefInput,
+		ResearchProposedIssueInput, ResearchProvenanceInput, ResearchPublicProjectionRefInput,
+		ResearchSubworkInput,
+	},
+	lifecycle::ensure_contract_authorizes_execution,
 };
-
-/// CLI/runtime request for compiling and persisting one research/design contract.
-pub(crate) struct ResearchDesignCompileRequest<'a> {
-	pub(crate) config_path: Option<&'a Path>,
-	pub(crate) input: ResearchDesignRunInput,
-}
-
-/// CLI/runtime request for promoting an already persisted research/design contract.
-pub(crate) struct ResearchDesignPromoteRequest<'a> {
-	pub(crate) config_path: Option<&'a Path>,
-	pub(crate) contract_id: &'a str,
-	pub(crate) accepted_by: &'a str,
-	pub(crate) accepted_at: Option<&'a str>,
-	pub(crate) acceptance_source: &'a str,
-	pub(crate) promotion_reason: Option<String>,
-}
-
-/// Compiler report for one persisted research/design run.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-pub(crate) struct ResearchDesignRunReport {
-	pub(crate) outcome: ResearchDesignOutcome,
-	pub(crate) contract_id: String,
-	pub(crate) contract_status: DecisionContractStatus,
-	pub(crate) source_issue_id: Option<String>,
-	pub(crate) ready_for_issue_shaping: bool,
-	pub(crate) issue_generation_ready_after_promotion: bool,
-	pub(crate) execution_authority_granted: bool,
-	pub(crate) feedback: String,
-	pub(crate) missing_decisions: Vec<String>,
-	pub(crate) blockers: Vec<String>,
-	pub(crate) proposed_issues: Vec<DecisionProposedIssue>,
-	pub(crate) promotion_targets: Vec<String>,
-	pub(crate) conflict_domains: Vec<String>,
-	pub(crate) private_evidence_ref_count: usize,
-	pub(crate) public_projection_ref_count: usize,
-}
-impl ResearchDesignRunReport {
-	fn from_compilation(
-		input: &NormalizedResearchDesignInput,
-		contract: &DecisionContract,
-	) -> Self {
-		Self {
-			outcome: input.outcome,
-			contract_id: contract.contract_id().to_owned(),
-			contract_status: contract.status(),
-			source_issue_id: input.source_issue_identifier.clone(),
-			ready_for_issue_shaping: contract.execution_readiness().ready_for_issue_shaping(),
-			issue_generation_ready_after_promotion: input.ready_for_issue_shaping(),
-			execution_authority_granted: false,
-			feedback: default_feedback(input.outcome).to_owned(),
-			missing_decisions: input.missing_decisions(),
-			blockers: input.blockers.clone(),
-			proposed_issues: contract.execution_readiness().proposed_issues().to_vec(),
-			promotion_targets: contract.execution_readiness().promotion_targets().to_vec(),
-			conflict_domains: contract.execution_readiness().conflict_domains().to_vec(),
-			private_evidence_ref_count: input.private_evidence_refs.len(),
-			public_projection_ref_count: input.public_projection_refs.len(),
-		}
-	}
-
-	fn with_record(mut self, record: &DecisionContractRecord) -> Self {
-		self.contract_id = record.contract_id().to_owned();
-		self.contract_status = record.status();
-		self.ready_for_issue_shaping =
-			record.contract().execution_readiness().ready_for_issue_shaping();
-
-		self
-	}
-}
-
-/// Promotion report for an accepted research/design contract.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-pub(crate) struct ResearchDesignPromotionReport {
-	pub(crate) contract_id: String,
-	pub(crate) contract_status: DecisionContractStatus,
-	pub(crate) execution_authority_granted: bool,
-	pub(crate) ready_for_issue_shaping: bool,
-}
-
-struct ResearchDesignCompilation {
-	contract: DecisionContract,
-	report: ResearchDesignRunReport,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct NormalizedResearchDesignInput {
-	contract_id: String,
-	intent: String,
-	source_issue_identifier: Option<String>,
-	outcome: ResearchDesignOutcome,
-	provenance: Vec<ResearchProvenanceInput>,
-	evidence: Vec<ResearchEvidenceInput>,
-	options: Vec<ResearchOptionInput>,
-	ai_subwork: Vec<ResearchSubworkInput>,
-	objectives: Vec<String>,
-	non_goals: Vec<String>,
-	constraints: Vec<String>,
-	assumptions: Vec<String>,
-	objections: Vec<String>,
-	unresolved_decisions: Vec<String>,
-	evidence_gaps: Vec<String>,
-	blockers: Vec<String>,
-	stop_conditions: Vec<String>,
-	readiness_summary: String,
-	validation_expectations: Vec<String>,
-	risk_notes: Vec<String>,
-	proposed_issues: Vec<ResearchProposedIssueInput>,
-	promotion_targets: Vec<String>,
-	conflict_domains: Vec<String>,
-	private_evidence_refs: Vec<ResearchPrivateEvidenceRefInput>,
-	public_projection_refs: Vec<ResearchPublicProjectionRefInput>,
-	public_summary: Option<String>,
-}
-impl NormalizedResearchDesignInput {
-	fn new(input: ResearchDesignRunInput) -> Result<Self> {
-		let contract_id = match input.contract_id.clone() {
-			Some(contract_id) => normalize_required_text("contract_id", contract_id)?,
-			None => generated_contract_id(&input)?,
-		};
-
-		Ok(Self {
-			contract_id,
-			intent: normalize_required_text("intent", input.intent)?,
-			source_issue_identifier: normalize_optional_text(
-				"source_issue_identifier",
-				input.source_issue_identifier,
-			)?,
-			outcome: input.outcome,
-			provenance: input
-				.provenance
-				.into_iter()
-				.map(ResearchProvenanceInput::normalized)
-				.collect::<Result<Vec<_>>>()?,
-			evidence: input
-				.evidence
-				.into_iter()
-				.map(ResearchEvidenceInput::normalized)
-				.collect::<Result<Vec<_>>>()?,
-			options: input
-				.options
-				.into_iter()
-				.map(ResearchOptionInput::normalized)
-				.collect::<Result<Vec<_>>>()?,
-			ai_subwork: input
-				.ai_subwork
-				.into_iter()
-				.map(ResearchSubworkInput::normalized)
-				.collect::<Result<Vec<_>>>()?,
-			objectives: normalize_text_list("objectives", input.objectives)?,
-			non_goals: normalize_text_list("non_goals", input.non_goals)?,
-			constraints: normalize_text_list("constraints", input.constraints)?,
-			assumptions: normalize_text_list("assumptions", input.assumptions)?,
-			objections: normalize_text_list("objections", input.objections)?,
-			unresolved_decisions: normalize_text_list(
-				"unresolved_decisions",
-				input.unresolved_decisions,
-			)?,
-			evidence_gaps: normalize_text_list("evidence_gaps", input.evidence_gaps)?,
-			blockers: normalize_text_list("blockers", input.blockers)?,
-			stop_conditions: normalize_text_list("stop_conditions", input.stop_conditions)?,
-			readiness_summary: normalize_optional_text(
-				"readiness_summary",
-				input.readiness_summary,
-			)?
-			.unwrap_or_else(|| default_feedback(input.outcome).to_owned()),
-			validation_expectations: normalize_text_list(
-				"validation_expectations",
-				input.validation_expectations,
-			)?,
-			risk_notes: normalize_text_list("risk_notes", input.risk_notes)?,
-			proposed_issues: input
-				.proposed_issues
-				.into_iter()
-				.map(ResearchProposedIssueInput::normalized)
-				.collect::<Result<Vec<_>>>()?,
-			promotion_targets: normalize_text_list("promotion_targets", input.promotion_targets)?,
-			conflict_domains: normalize_text_list("conflict_domains", input.conflict_domains)?,
-			private_evidence_refs: input
-				.private_evidence_refs
-				.into_iter()
-				.map(ResearchPrivateEvidenceRefInput::normalized)
-				.collect::<Result<Vec<_>>>()?,
-			public_projection_refs: input
-				.public_projection_refs
-				.into_iter()
-				.map(ResearchPublicProjectionRefInput::normalized)
-				.collect::<Result<Vec<_>>>()?,
-			public_summary: normalize_optional_text("public_summary", input.public_summary)?,
-		})
-	}
-
-	fn validate_outcome(&self) -> Result<()> {
-		match self.outcome {
-			ResearchDesignOutcome::DecisionReady => self.validate_decision_ready(),
-			ResearchDesignOutcome::NotDecisionReady => Ok(()),
-			ResearchDesignOutcome::Blocked => self.validate_blocked(),
-			ResearchDesignOutcome::NeedsHumanDecision => self.validate_needs_human_decision(),
-		}
-	}
-
-	fn validate_decision_ready(&self) -> Result<()> {
-		if self.objectives.is_empty() {
-			eyre::bail!("decision-ready research requires at least one accepted objective.");
-		}
-		if self.evidence.is_empty() {
-			eyre::bail!("decision-ready research requires at least one evidence claim.");
-		}
-		if self.evidence.iter().any(|evidence| evidence.kind == "unspecified") {
-			eyre::bail!("decision-ready research requires an evidence kind for each claim.");
-		}
-		if self.options.is_empty() {
-			eyre::bail!("decision-ready research requires at least one option comparison.");
-		}
-		if self.objections.is_empty() {
-			eyre::bail!(
-				"decision-ready research requires at least one recorded challenge objection or objection note."
-			);
-		}
-		if self.validation_expectations.is_empty() {
-			eyre::bail!("decision-ready research requires validation expectations.");
-		}
-		if self.proposed_issues.is_empty() {
-			eyre::bail!(
-				"decision-ready research requires at least one structured proposed issue for downstream shaping."
-			);
-		}
-		if self.promotion_targets.is_empty() {
-			eyre::bail!("decision-ready research requires at least one promotion target.");
-		}
-		if !self.unresolved_decisions.is_empty() || !self.evidence_gaps.is_empty() {
-			eyre::bail!(
-				"decision-ready research cannot carry unresolved decisions or evidence gaps."
-			);
-		}
-		if !self.blockers.is_empty() {
-			eyre::bail!("decision-ready research cannot carry unresolved blockers.");
-		}
-
-		Ok(())
-	}
-
-	fn validate_blocked(&self) -> Result<()> {
-		if self.blockers.is_empty() {
-			eyre::bail!("blocked research requires at least one blocker.");
-		}
-
-		Ok(())
-	}
-
-	fn validate_needs_human_decision(&self) -> Result<()> {
-		if self.unresolved_decisions.is_empty() {
-			eyre::bail!("needs-human-decision research requires an unresolved decision.");
-		}
-
-		Ok(())
-	}
-
-	fn ready_for_issue_shaping(&self) -> bool {
-		self.outcome == ResearchDesignOutcome::DecisionReady
-	}
-
-	fn missing_decisions(&self) -> Vec<String> {
-		let mut missing = Vec::new();
-
-		missing.extend(self.unresolved_decisions.clone());
-		missing.extend(self.evidence_gaps.iter().map(|gap| format!("Evidence gap: {gap}")));
-
-		if self.outcome == ResearchDesignOutcome::NotDecisionReady && missing.is_empty() {
-			missing.push(String::from(
-				"Research is not decision-ready; gather more evidence or narrow the decision.",
-			));
-		}
-
-		missing
-	}
-}
 
 /// Compile and persist a research/design result into the local runtime store.
 pub(crate) fn run_compile(
@@ -316,7 +50,7 @@ pub(crate) fn run_compile(
 
 	runtime::register_project_config(&state_store, &config_path, true)?;
 
-	persist_research_design_run(&state_store, config.service_id(), request.input)
+	lifecycle::persist_research_design_run(&state_store, config.service_id(), request.input)
 }
 
 /// Promote an already persisted contract into accepted execution authority.
@@ -340,7 +74,7 @@ pub(crate) fn run_promote(
 		request.acceptance_source,
 		request.promotion_reason,
 	)?;
-	let record = promote_research_design_contract(
+	let record = lifecycle::promote_research_design_contract(
 		&state_store,
 		config.service_id(),
 		request.contract_id,
@@ -353,139 +87,6 @@ pub(crate) fn run_promote(
 		execution_authority_granted: true,
 		ready_for_issue_shaping: record.contract().execution_readiness().ready_for_issue_shaping(),
 	})
-}
-
-pub(crate) fn dry_run_research_design_compile(
-	input: ResearchDesignRunInput,
-	project_id: &str,
-) -> Result<ResearchDesignRunReport> {
-	Ok(compile_research_design_run(input, project_id)?.report)
-}
-
-pub(crate) fn persist_research_design_run(
-	store: &StateStore,
-	project_id: &str,
-	input: ResearchDesignRunInput,
-) -> Result<ResearchDesignRunReport> {
-	let source_issue_id = input.source_issue_identifier().map(str::to_owned);
-	let compilation = compile_research_design_run(input, project_id)?;
-	let record = store.upsert_decision_contract(
-		project_id,
-		source_issue_id.as_deref(),
-		compilation.contract,
-	)?;
-
-	Ok(ResearchDesignRunReport { source_issue_id, ..compilation.report.with_record(&record) })
-}
-
-pub(crate) fn promote_research_design_contract(
-	store: &StateStore,
-	project_id: &str,
-	contract_id: &str,
-	promotion: DecisionPromotion,
-) -> Result<DecisionContractRecord> {
-	let record = store.promote_decision_contract(project_id, contract_id, promotion)?;
-
-	ensure_contract_authorizes_execution(&record)?;
-
-	Ok(record)
-}
-
-#[allow(dead_code)]
-fn ensure_contract_authorizes_execution(record: &DecisionContractRecord) -> Result<()> {
-	if record.status() != DecisionContractStatus::AcceptedPromoted {
-		eyre::bail!(
-			"Research/design contract `{}` is not accepted; refusing to create execution work from unaccepted research.",
-			record.contract_id()
-		);
-	}
-	if !record.contract().execution_readiness().ready_for_issue_shaping() {
-		eyre::bail!(
-			"Accepted research/design contract `{}` is not ready for issue shaping.",
-			record.contract_id()
-		);
-	}
-	if !record.contract().execution_readiness().missing_decisions().is_empty() {
-		eyre::bail!(
-			"Accepted research/design contract `{}` still has unresolved decisions.",
-			record.contract_id()
-		);
-	}
-	if record.contract().execution_readiness().proposed_issues().is_empty() {
-		eyre::bail!(
-			"Accepted research/design contract `{}` has no structured proposed issues.",
-			record.contract_id()
-		);
-	}
-
-	Ok(())
-}
-
-fn compile_research_design_run(
-	input: ResearchDesignRunInput,
-	project_id: &str,
-) -> Result<ResearchDesignCompilation> {
-	let normalized = NormalizedResearchDesignInput::new(input)?;
-
-	normalized.validate_outcome()?;
-
-	let contract = build_decision_contract(&normalized, project_id)?;
-	let report = ResearchDesignRunReport::from_compilation(&normalized, &contract);
-
-	Ok(ResearchDesignCompilation { contract, report })
-}
-
-fn build_decision_contract(
-	input: &NormalizedResearchDesignInput,
-	project_id: &str,
-) -> Result<DecisionContract> {
-	let payload = serde_json::json!({
-		"schema": crate::loop_contract::DECISION_CONTRACT_SCHEMA,
-		"record_version": crate::loop_contract::DECISION_CONTRACT_RECORD_VERSION,
-		"contract_id": input.contract_id,
-		"status": input.outcome.contract_status(),
-		"source_intent": {
-			"summary": input.intent,
-			"user_utterance": input.intent,
-			"source_issue_identifier": input.source_issue_identifier,
-		},
-		"research_provenance": research_provenance_json(input),
-		"research_evidence": research_evidence_json(input),
-		"research_options": research_options_json(input),
-		"accepted_authority": {
-			"accepted_objectives": input.objectives,
-			"non_goals": input.non_goals,
-			"constraints": input.constraints,
-			"assumptions": input.assumptions,
-			"objections": input.objections,
-			"stop_conditions": stop_conditions(input),
-		},
-		"execution_readiness": {
-			"summary": input.readiness_summary,
-			"ready_for_issue_shaping": input.ready_for_issue_shaping(),
-			"missing_decisions": input.missing_decisions(),
-			"validation_expectations": input.validation_expectations,
-			"risk_notes": risk_notes(input),
-			"proposed_issues": input.proposed_issues,
-			"promotion_targets": input.promotion_targets,
-			"conflict_domains": input.conflict_domains,
-		},
-		"links": {
-			"generated_issue_ids": [],
-			"generated_issue_identifiers": [],
-			"execution_program_node_ids": [],
-		},
-		"evidence_boundary": {
-			"private_evidence_refs": private_evidence_refs_json(input, project_id),
-			"public_projection_refs": public_projection_refs_json(input),
-			"public_summary": input.public_summary,
-		},
-	});
-	let contract = serde_json::from_value::<DecisionContract>(payload)?;
-
-	contract.validate()?;
-
-	Ok(contract)
 }
 
 fn resolve_research_project_config_path(
@@ -505,190 +106,5 @@ fn resolve_research_project_config_path(
 	})
 }
 
-fn research_provenance_json(input: &NormalizedResearchDesignInput) -> Vec<Value> {
-	let mut provenance = input
-		.provenance
-		.iter()
-		.map(|item| {
-			serde_json::json!({
-				"kind": item.kind,
-				"reference": item.reference,
-				"summary": item.summary,
-			})
-		})
-		.collect::<Vec<_>>();
-
-	for subwork in &input.ai_subwork {
-		provenance.push(serde_json::json!({
-			"kind": format!("ai_subwork_{}", subwork.worker_kind),
-			"reference": subwork.objective,
-			"summary": subwork.summary(),
-		}));
-	}
-
-	provenance
-}
-
-fn research_evidence_json(input: &NormalizedResearchDesignInput) -> Vec<Value> {
-	input
-		.evidence
-		.iter()
-		.map(|item| {
-			serde_json::json!({
-				"kind": item.kind,
-				"claim": item.claim,
-				"support": item.support,
-				"source_ref": item.source_ref,
-			})
-		})
-		.collect()
-}
-
-fn research_options_json(input: &NormalizedResearchDesignInput) -> Vec<Value> {
-	input
-		.options
-		.iter()
-		.map(|item| {
-			serde_json::json!({
-				"option": item.option,
-				"tradeoffs": item.tradeoffs,
-				"decision": item.decision,
-				"rejected_reason": item.rejected_reason,
-			})
-		})
-		.collect()
-}
-
-fn private_evidence_refs_json(
-	input: &NormalizedResearchDesignInput,
-	project_id: &str,
-) -> Vec<Value> {
-	input
-		.private_evidence_refs
-		.iter()
-		.map(|item| {
-			serde_json::json!({
-				"project_id": item.project_id.as_deref().unwrap_or(project_id),
-				"issue_id": item.issue_id,
-				"run_id": item.run_id,
-				"attempt_number": item.attempt_number,
-				"record_id": item.record_id,
-				"event_type": item.event_type,
-			})
-		})
-		.collect()
-}
-
-fn public_projection_refs_json(input: &NormalizedResearchDesignInput) -> Vec<Value> {
-	input
-		.public_projection_refs
-		.iter()
-		.map(|item| {
-			serde_json::json!({
-				"surface": item.surface,
-				"reference": item.reference,
-				"summary": item.summary,
-			})
-		})
-		.collect()
-}
-
-fn stop_conditions(input: &NormalizedResearchDesignInput) -> Vec<String> {
-	let mut stop_conditions = input.stop_conditions.clone();
-
-	for blocker in &input.blockers {
-		stop_conditions.push(format!("Stop research promotion until blocker resolves: {blocker}"));
-	}
-
-	stop_conditions
-}
-
-fn risk_notes(input: &NormalizedResearchDesignInput) -> Vec<String> {
-	let mut risk_notes = input.risk_notes.clone();
-
-	if input.outcome == ResearchDesignOutcome::NotDecisionReady {
-		risk_notes.push(String::from(
-			"Research is not decision-ready and must not become implementation work.",
-		));
-	}
-
-	for blocker in &input.blockers {
-		risk_notes.push(format!("Research/design blocker: {blocker}"));
-	}
-
-	risk_notes
-}
-
-fn default_feedback(outcome: ResearchDesignOutcome) -> &'static str {
-	match outcome {
-		ResearchDesignOutcome::DecisionReady =>
-			"Decision-ready research/design output is stored as a latent contract until promotion.",
-		ResearchDesignOutcome::NotDecisionReady =>
-			"Research/design output is not decision-ready and must not become implementation work.",
-		ResearchDesignOutcome::Blocked =>
-			"Research/design output is blocked; resolve blockers before promotion.",
-		ResearchDesignOutcome::NeedsHumanDecision =>
-			"Research/design output needs an explicit human decision before execution authority exists.",
-	}
-}
-
-fn generated_contract_id(input: &ResearchDesignRunInput) -> Result<String> {
-	let slug = intent_slug(&input.intent);
-	let encoded = serde_json::to_vec(input)?;
-	let digest = Sha256::digest(&encoded);
-	let mut hash = String::with_capacity(12);
-
-	for byte in digest.iter().take(6) {
-		hash.push(char::from(b"0123456789abcdef"[(byte >> 4) as usize]));
-		hash.push(char::from(b"0123456789abcdef"[(byte & 0x0f) as usize]));
-	}
-
-	Ok(format!("research-design-{slug}-{hash}"))
-}
-
-fn intent_slug(intent: &str) -> String {
-	let mut slug = String::new();
-	let mut previous_dash = false;
-
-	for character in intent.chars() {
-		if character.is_ascii_alphanumeric() {
-			slug.push(character.to_ascii_lowercase());
-
-			previous_dash = false;
-		} else if !previous_dash && !slug.is_empty() {
-			slug.push('-');
-
-			previous_dash = true;
-		}
-		if slug.len() >= 40 {
-			break;
-		}
-	}
-
-	while slug.ends_with('-') {
-		slug.pop();
-	}
-
-	if slug.is_empty() { String::from("research") } else { slug }
-}
-
-fn normalize_required_text(name: &str, value: impl Into<String>) -> Result<String> {
-	let value = value.into();
-	let value = value.trim();
-
-	if value.is_empty() {
-		eyre::bail!("{name} must not be empty.");
-	}
-
-	Ok(value.to_owned())
-}
-
-fn normalize_optional_text(name: &str, value: Option<String>) -> Result<Option<String>> {
-	value.map(|value| normalize_required_text(name, value)).transpose()
-}
-
-fn normalize_text_list(name: &str, values: Vec<String>) -> Result<Vec<String>> {
-	values.into_iter().map(|value| normalize_required_text(name, value)).collect()
-}
-
-#[cfg(test)] mod tests;
+#[cfg(test)]
+mod tests;

--- a/apps/decodex/src/research_design/compiler.rs
+++ b/apps/decodex/src/research_design/compiler.rs
@@ -1,0 +1,196 @@
+use serde_json::{self, Value};
+
+use crate::{loop_contract::DecisionContract, prelude::Result};
+use crate::research_design::{
+	ResearchDesignOutcome, ResearchDesignRunInput,
+	normalized::NormalizedResearchDesignInput,
+	reports::{ResearchDesignCompilation, ResearchDesignRunReport},
+};
+
+pub(crate) fn dry_run_research_design_compile(
+	input: ResearchDesignRunInput,
+	project_id: &str,
+) -> Result<ResearchDesignRunReport> {
+	Ok(compile_research_design_run(input, project_id)?.report)
+}
+
+pub(super) fn compile_research_design_run(
+	input: ResearchDesignRunInput,
+	project_id: &str,
+) -> Result<ResearchDesignCompilation> {
+	let normalized = NormalizedResearchDesignInput::new(input)?;
+
+	normalized.validate_outcome()?;
+
+	let contract = build_decision_contract(&normalized, project_id)?;
+	let report = ResearchDesignRunReport::from_compilation(&normalized, &contract);
+
+	Ok(ResearchDesignCompilation { contract, report })
+}
+
+fn build_decision_contract(
+	input: &NormalizedResearchDesignInput,
+	project_id: &str,
+) -> Result<DecisionContract> {
+	let payload = serde_json::json!({
+		"schema": crate::loop_contract::DECISION_CONTRACT_SCHEMA,
+		"record_version": crate::loop_contract::DECISION_CONTRACT_RECORD_VERSION,
+		"contract_id": input.contract_id,
+		"status": input.outcome.contract_status(),
+		"source_intent": {
+			"summary": input.intent,
+			"user_utterance": input.intent,
+			"source_issue_identifier": input.source_issue_identifier,
+		},
+		"research_provenance": research_provenance_json(input),
+		"research_evidence": research_evidence_json(input),
+		"research_options": research_options_json(input),
+		"accepted_authority": {
+			"accepted_objectives": input.objectives,
+			"non_goals": input.non_goals,
+			"constraints": input.constraints,
+			"assumptions": input.assumptions,
+			"objections": input.objections,
+			"stop_conditions": stop_conditions(input),
+		},
+		"execution_readiness": {
+			"summary": input.readiness_summary,
+			"ready_for_issue_shaping": input.ready_for_issue_shaping(),
+			"missing_decisions": input.missing_decisions(),
+			"validation_expectations": input.validation_expectations,
+			"risk_notes": risk_notes(input),
+			"proposed_issues": input.proposed_issues,
+			"promotion_targets": input.promotion_targets,
+			"conflict_domains": input.conflict_domains,
+		},
+		"links": {
+			"generated_issue_ids": [],
+			"generated_issue_identifiers": [],
+			"execution_program_node_ids": [],
+		},
+		"evidence_boundary": {
+			"private_evidence_refs": private_evidence_refs_json(input, project_id),
+			"public_projection_refs": public_projection_refs_json(input),
+			"public_summary": input.public_summary,
+		},
+	});
+	let contract = serde_json::from_value::<DecisionContract>(payload)?;
+
+	contract.validate()?;
+
+	Ok(contract)
+}
+
+fn research_provenance_json(input: &NormalizedResearchDesignInput) -> Vec<Value> {
+	let mut provenance = input
+		.provenance
+		.iter()
+		.map(|item| {
+			serde_json::json!({
+				"kind": item.kind,
+				"reference": item.reference,
+				"summary": item.summary,
+			})
+		})
+		.collect::<Vec<_>>();
+
+	for subwork in &input.ai_subwork {
+		provenance.push(serde_json::json!({
+			"kind": format!("ai_subwork_{}", subwork.worker_kind),
+			"reference": subwork.objective,
+			"summary": subwork.summary(),
+		}));
+	}
+
+	provenance
+}
+
+fn research_evidence_json(input: &NormalizedResearchDesignInput) -> Vec<Value> {
+	input
+		.evidence
+		.iter()
+		.map(|item| {
+			serde_json::json!({
+				"kind": item.kind,
+				"claim": item.claim,
+				"support": item.support,
+				"source_ref": item.source_ref,
+			})
+		})
+		.collect()
+}
+
+fn research_options_json(input: &NormalizedResearchDesignInput) -> Vec<Value> {
+	input
+		.options
+		.iter()
+		.map(|item| {
+			serde_json::json!({
+				"option": item.option,
+				"tradeoffs": item.tradeoffs,
+				"decision": item.decision,
+				"rejected_reason": item.rejected_reason,
+			})
+		})
+		.collect()
+}
+
+fn private_evidence_refs_json(
+	input: &NormalizedResearchDesignInput,
+	project_id: &str,
+) -> Vec<Value> {
+	input
+		.private_evidence_refs
+		.iter()
+		.map(|item| {
+			serde_json::json!({
+				"project_id": item.project_id.as_deref().unwrap_or(project_id),
+				"issue_id": item.issue_id,
+				"run_id": item.run_id,
+				"attempt_number": item.attempt_number,
+				"record_id": item.record_id,
+				"event_type": item.event_type,
+			})
+		})
+		.collect()
+}
+
+fn public_projection_refs_json(input: &NormalizedResearchDesignInput) -> Vec<Value> {
+	input
+		.public_projection_refs
+		.iter()
+		.map(|item| {
+			serde_json::json!({
+				"surface": item.surface,
+				"reference": item.reference,
+				"summary": item.summary,
+			})
+		})
+		.collect()
+}
+
+fn stop_conditions(input: &NormalizedResearchDesignInput) -> Vec<String> {
+	let mut stop_conditions = input.stop_conditions.clone();
+
+	for blocker in &input.blockers {
+		stop_conditions.push(format!("Stop research promotion until blocker resolves: {blocker}"));
+	}
+
+	stop_conditions
+}
+
+fn risk_notes(input: &NormalizedResearchDesignInput) -> Vec<String> {
+	let mut risk_notes = input.risk_notes.clone();
+
+	if input.outcome == ResearchDesignOutcome::NotDecisionReady {
+		risk_notes.push(String::from(
+			"Research is not decision-ready and must not become implementation work.",
+		));
+	}
+
+	for blocker in &input.blockers {
+		risk_notes.push(format!("Research/design blocker: {blocker}"));
+	}
+
+	risk_notes
+}

--- a/apps/decodex/src/research_design/input.rs
+++ b/apps/decodex/src/research_design/input.rs
@@ -4,8 +4,7 @@ use crate::{
 	loop_contract::DecisionContractStatus,
 	prelude::{Result, eyre},
 };
-
-use super::{normalize_optional_text, normalize_required_text, normalize_text_list};
+use crate::research_design::normalized;
 
 /// Research/design outcome before any execution authority exists.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -19,8 +18,9 @@ pub(crate) enum ResearchDesignOutcome {
 impl ResearchDesignOutcome {
 	pub(super) fn contract_status(self) -> DecisionContractStatus {
 		match self {
-			Self::DecisionReady | Self::NotDecisionReady | Self::Blocked =>
-				DecisionContractStatus::DraftLatent,
+			Self::DecisionReady | Self::NotDecisionReady | Self::Blocked => {
+				DecisionContractStatus::DraftLatent
+			},
 			Self::NeedsHumanDecision => DecisionContractStatus::NeedsHumanDecision,
 		}
 	}
@@ -133,9 +133,9 @@ pub(crate) struct ResearchProvenanceInput {
 impl ResearchProvenanceInput {
 	pub(super) fn normalized(self) -> Result<Self> {
 		Ok(Self {
-			kind: normalize_required_text("provenance.kind", self.kind)?,
-			reference: normalize_required_text("provenance.reference", self.reference)?,
-			summary: normalize_required_text("provenance.summary", self.summary)?,
+			kind: normalized::normalize_required_text("provenance.kind", self.kind)?,
+			reference: normalized::normalize_required_text("provenance.reference", self.reference)?,
+			summary: normalized::normalize_required_text("provenance.summary", self.summary)?,
 		})
 	}
 }
@@ -154,10 +154,13 @@ pub(crate) struct ResearchEvidenceInput {
 impl ResearchEvidenceInput {
 	pub(super) fn normalized(self) -> Result<Self> {
 		Ok(Self {
-			kind: normalize_required_text("evidence.kind", self.kind)?,
-			claim: normalize_required_text("evidence.claim", self.claim)?,
-			support: normalize_required_text("evidence.support", self.support)?,
-			source_ref: normalize_optional_text("evidence.source_ref", self.source_ref)?,
+			kind: normalized::normalize_required_text("evidence.kind", self.kind)?,
+			claim: normalized::normalize_required_text("evidence.claim", self.claim)?,
+			support: normalized::normalize_required_text("evidence.support", self.support)?,
+			source_ref: normalized::normalize_optional_text(
+				"evidence.source_ref",
+				self.source_ref,
+			)?,
 		})
 	}
 }
@@ -177,10 +180,10 @@ pub(crate) struct ResearchOptionInput {
 impl ResearchOptionInput {
 	pub(super) fn normalized(self) -> Result<Self> {
 		Ok(Self {
-			option: normalize_required_text("options.option", self.option)?,
-			tradeoffs: normalize_text_list("options.tradeoffs", self.tradeoffs)?,
-			decision: normalize_optional_text("options.decision", self.decision)?,
-			rejected_reason: normalize_optional_text(
+			option: normalized::normalize_required_text("options.option", self.option)?,
+			tradeoffs: normalized::normalize_text_list("options.tradeoffs", self.tradeoffs)?,
+			decision: normalized::normalize_optional_text("options.decision", self.decision)?,
+			rejected_reason: normalized::normalize_optional_text(
 				"options.rejected_reason",
 				self.rejected_reason,
 			)?,
@@ -201,10 +204,16 @@ pub(crate) struct ResearchSubworkInput {
 impl ResearchSubworkInput {
 	pub(super) fn normalized(self) -> Result<Self> {
 		Ok(Self {
-			worker_kind: normalize_required_text("ai_subwork.worker_kind", self.worker_kind)?,
-			objective: normalize_required_text("ai_subwork.objective", self.objective)?,
-			outcome: normalize_required_text("ai_subwork.outcome", self.outcome)?,
-			evidence_refs: normalize_text_list("ai_subwork.evidence_refs", self.evidence_refs)?,
+			worker_kind: normalized::normalize_required_text(
+				"ai_subwork.worker_kind",
+				self.worker_kind,
+			)?,
+			objective: normalized::normalize_required_text("ai_subwork.objective", self.objective)?,
+			outcome: normalized::normalize_required_text("ai_subwork.outcome", self.outcome)?,
+			evidence_refs: normalized::normalize_text_list(
+				"ai_subwork.evidence_refs",
+				self.evidence_refs,
+			)?,
 		})
 	}
 
@@ -235,19 +244,31 @@ pub(crate) struct ResearchProposedIssueInput {
 impl ResearchProposedIssueInput {
 	pub(super) fn normalized(self) -> Result<Self> {
 		let issue = Self {
-			key: normalize_required_text("proposed_issues.key", self.key)?,
-			title: normalize_required_text("proposed_issues.title", self.title)?,
-			objective: normalize_required_text("proposed_issues.objective", self.objective)?,
-			stage: normalize_required_text("proposed_issues.stage", self.stage)?,
-			dependencies: normalize_text_list("proposed_issues.dependencies", self.dependencies)?,
-			conflict_domains: normalize_text_list(
+			key: normalized::normalize_required_text("proposed_issues.key", self.key)?,
+			title: normalized::normalize_required_text("proposed_issues.title", self.title)?,
+			objective: normalized::normalize_required_text(
+				"proposed_issues.objective",
+				self.objective,
+			)?,
+			stage: normalized::normalize_required_text("proposed_issues.stage", self.stage)?,
+			dependencies: normalized::normalize_text_list(
+				"proposed_issues.dependencies",
+				self.dependencies,
+			)?,
+			conflict_domains: normalized::normalize_text_list(
 				"proposed_issues.conflict_domains",
 				self.conflict_domains,
 			)?,
-			acceptance: normalize_text_list("proposed_issues.acceptance", self.acceptance)?,
-			validation: normalize_text_list("proposed_issues.validation", self.validation)?,
-			risk: normalize_text_list("proposed_issues.risk", self.risk)?,
-			queue_intent: normalize_required_text(
+			acceptance: normalized::normalize_text_list(
+				"proposed_issues.acceptance",
+				self.acceptance,
+			)?,
+			validation: normalized::normalize_text_list(
+				"proposed_issues.validation",
+				self.validation,
+			)?,
+			risk: normalized::normalize_text_list("proposed_issues.risk", self.risk)?,
+			queue_intent: normalized::normalize_required_text(
 				"proposed_issues.queue_intent",
 				self.queue_intent,
 			)?,
@@ -281,15 +302,21 @@ pub(crate) struct ResearchPrivateEvidenceRefInput {
 impl ResearchPrivateEvidenceRefInput {
 	pub(super) fn normalized(self) -> Result<Self> {
 		Ok(Self {
-			project_id: normalize_optional_text(
+			project_id: normalized::normalize_optional_text(
 				"private_evidence_refs.project_id",
 				self.project_id,
 			)?,
-			issue_id: normalize_required_text("private_evidence_refs.issue_id", self.issue_id)?,
-			run_id: normalize_required_text("private_evidence_refs.run_id", self.run_id)?,
+			issue_id: normalized::normalize_required_text(
+				"private_evidence_refs.issue_id",
+				self.issue_id,
+			)?,
+			run_id: normalized::normalize_required_text(
+				"private_evidence_refs.run_id",
+				self.run_id,
+			)?,
 			attempt_number: self.attempt_number,
 			record_id: self.record_id,
-			event_type: normalize_optional_text(
+			event_type: normalized::normalize_optional_text(
 				"private_evidence_refs.event_type",
 				self.event_type,
 			)?,
@@ -308,9 +335,18 @@ pub(crate) struct ResearchPublicProjectionRefInput {
 impl ResearchPublicProjectionRefInput {
 	pub(super) fn normalized(self) -> Result<Self> {
 		Ok(Self {
-			surface: normalize_required_text("public_projection_refs.surface", self.surface)?,
-			reference: normalize_required_text("public_projection_refs.reference", self.reference)?,
-			summary: normalize_required_text("public_projection_refs.summary", self.summary)?,
+			surface: normalized::normalize_required_text(
+				"public_projection_refs.surface",
+				self.surface,
+			)?,
+			reference: normalized::normalize_required_text(
+				"public_projection_refs.reference",
+				self.reference,
+			)?,
+			summary: normalized::normalize_required_text(
+				"public_projection_refs.summary",
+				self.summary,
+			)?,
 		})
 	}
 }

--- a/apps/decodex/src/research_design/lifecycle.rs
+++ b/apps/decodex/src/research_design/lifecycle.rs
@@ -1,0 +1,65 @@
+use crate::{
+	loop_contract::{DecisionContractStatus, DecisionPromotion},
+	prelude::{Result, eyre},
+	state::{DecisionContractRecord, StateStore},
+};
+use crate::research_design::{ResearchDesignRunInput, compiler, reports::ResearchDesignRunReport};
+
+pub(crate) fn persist_research_design_run(
+	store: &StateStore,
+	project_id: &str,
+	input: ResearchDesignRunInput,
+) -> Result<ResearchDesignRunReport> {
+	let source_issue_id = input.source_issue_identifier().map(str::to_owned);
+	let compilation = compiler::compile_research_design_run(input, project_id)?;
+	let record = store.upsert_decision_contract(
+		project_id,
+		source_issue_id.as_deref(),
+		compilation.contract,
+	)?;
+
+	Ok(ResearchDesignRunReport { source_issue_id, ..compilation.report.with_record(&record) })
+}
+
+pub(crate) fn promote_research_design_contract(
+	store: &StateStore,
+	project_id: &str,
+	contract_id: &str,
+	promotion: DecisionPromotion,
+) -> Result<DecisionContractRecord> {
+	let record = store.promote_decision_contract(project_id, contract_id, promotion)?;
+
+	ensure_contract_authorizes_execution(&record)?;
+
+	Ok(record)
+}
+
+#[allow(dead_code)]
+pub(super) fn ensure_contract_authorizes_execution(record: &DecisionContractRecord) -> Result<()> {
+	if record.status() != DecisionContractStatus::AcceptedPromoted {
+		eyre::bail!(
+			"Research/design contract `{}` is not accepted; refusing to create execution work from unaccepted research.",
+			record.contract_id()
+		);
+	}
+	if !record.contract().execution_readiness().ready_for_issue_shaping() {
+		eyre::bail!(
+			"Accepted research/design contract `{}` is not ready for issue shaping.",
+			record.contract_id()
+		);
+	}
+	if !record.contract().execution_readiness().missing_decisions().is_empty() {
+		eyre::bail!(
+			"Accepted research/design contract `{}` still has unresolved decisions.",
+			record.contract_id()
+		);
+	}
+	if record.contract().execution_readiness().proposed_issues().is_empty() {
+		eyre::bail!(
+			"Accepted research/design contract `{}` has no structured proposed issues.",
+			record.contract_id()
+		);
+	}
+
+	Ok(())
+}

--- a/apps/decodex/src/research_design/normalized.rs
+++ b/apps/decodex/src/research_design/normalized.rs
@@ -1,0 +1,280 @@
+use sha2::{Digest as _, Sha256};
+
+use crate::prelude::{Result, eyre};
+use crate::research_design::{
+	ResearchDesignOutcome, ResearchDesignRunInput,
+	input::{
+		ResearchEvidenceInput, ResearchOptionInput, ResearchPrivateEvidenceRefInput,
+		ResearchProposedIssueInput, ResearchProvenanceInput, ResearchPublicProjectionRefInput,
+		ResearchSubworkInput,
+	},
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct NormalizedResearchDesignInput {
+	pub(super) contract_id: String,
+	pub(super) intent: String,
+	pub(super) source_issue_identifier: Option<String>,
+	pub(super) outcome: ResearchDesignOutcome,
+	pub(super) provenance: Vec<ResearchProvenanceInput>,
+	pub(super) evidence: Vec<ResearchEvidenceInput>,
+	pub(super) options: Vec<ResearchOptionInput>,
+	pub(super) ai_subwork: Vec<ResearchSubworkInput>,
+	pub(super) objectives: Vec<String>,
+	pub(super) non_goals: Vec<String>,
+	pub(super) constraints: Vec<String>,
+	pub(super) assumptions: Vec<String>,
+	pub(super) objections: Vec<String>,
+	pub(super) unresolved_decisions: Vec<String>,
+	pub(super) evidence_gaps: Vec<String>,
+	pub(super) blockers: Vec<String>,
+	pub(super) stop_conditions: Vec<String>,
+	pub(super) readiness_summary: String,
+	pub(super) validation_expectations: Vec<String>,
+	pub(super) risk_notes: Vec<String>,
+	pub(super) proposed_issues: Vec<ResearchProposedIssueInput>,
+	pub(super) promotion_targets: Vec<String>,
+	pub(super) conflict_domains: Vec<String>,
+	pub(super) private_evidence_refs: Vec<ResearchPrivateEvidenceRefInput>,
+	pub(super) public_projection_refs: Vec<ResearchPublicProjectionRefInput>,
+	pub(super) public_summary: Option<String>,
+}
+impl NormalizedResearchDesignInput {
+	pub(super) fn new(input: ResearchDesignRunInput) -> Result<Self> {
+		let contract_id = match input.contract_id.clone() {
+			Some(contract_id) => normalize_required_text("contract_id", contract_id)?,
+			None => generated_contract_id(&input)?,
+		};
+
+		Ok(Self {
+			contract_id,
+			intent: normalize_required_text("intent", input.intent)?,
+			source_issue_identifier: normalize_optional_text(
+				"source_issue_identifier",
+				input.source_issue_identifier,
+			)?,
+			outcome: input.outcome,
+			provenance: input
+				.provenance
+				.into_iter()
+				.map(ResearchProvenanceInput::normalized)
+				.collect::<Result<Vec<_>>>()?,
+			evidence: input
+				.evidence
+				.into_iter()
+				.map(ResearchEvidenceInput::normalized)
+				.collect::<Result<Vec<_>>>()?,
+			options: input
+				.options
+				.into_iter()
+				.map(ResearchOptionInput::normalized)
+				.collect::<Result<Vec<_>>>()?,
+			ai_subwork: input
+				.ai_subwork
+				.into_iter()
+				.map(ResearchSubworkInput::normalized)
+				.collect::<Result<Vec<_>>>()?,
+			objectives: normalize_text_list("objectives", input.objectives)?,
+			non_goals: normalize_text_list("non_goals", input.non_goals)?,
+			constraints: normalize_text_list("constraints", input.constraints)?,
+			assumptions: normalize_text_list("assumptions", input.assumptions)?,
+			objections: normalize_text_list("objections", input.objections)?,
+			unresolved_decisions: normalize_text_list(
+				"unresolved_decisions",
+				input.unresolved_decisions,
+			)?,
+			evidence_gaps: normalize_text_list("evidence_gaps", input.evidence_gaps)?,
+			blockers: normalize_text_list("blockers", input.blockers)?,
+			stop_conditions: normalize_text_list("stop_conditions", input.stop_conditions)?,
+			readiness_summary: normalize_optional_text(
+				"readiness_summary",
+				input.readiness_summary,
+			)?
+			.unwrap_or_else(|| default_feedback(input.outcome).to_owned()),
+			validation_expectations: normalize_text_list(
+				"validation_expectations",
+				input.validation_expectations,
+			)?,
+			risk_notes: normalize_text_list("risk_notes", input.risk_notes)?,
+			proposed_issues: input
+				.proposed_issues
+				.into_iter()
+				.map(ResearchProposedIssueInput::normalized)
+				.collect::<Result<Vec<_>>>()?,
+			promotion_targets: normalize_text_list("promotion_targets", input.promotion_targets)?,
+			conflict_domains: normalize_text_list("conflict_domains", input.conflict_domains)?,
+			private_evidence_refs: input
+				.private_evidence_refs
+				.into_iter()
+				.map(ResearchPrivateEvidenceRefInput::normalized)
+				.collect::<Result<Vec<_>>>()?,
+			public_projection_refs: input
+				.public_projection_refs
+				.into_iter()
+				.map(ResearchPublicProjectionRefInput::normalized)
+				.collect::<Result<Vec<_>>>()?,
+			public_summary: normalize_optional_text("public_summary", input.public_summary)?,
+		})
+	}
+
+	pub(super) fn validate_outcome(&self) -> Result<()> {
+		match self.outcome {
+			ResearchDesignOutcome::DecisionReady => self.validate_decision_ready(),
+			ResearchDesignOutcome::NotDecisionReady => Ok(()),
+			ResearchDesignOutcome::Blocked => self.validate_blocked(),
+			ResearchDesignOutcome::NeedsHumanDecision => self.validate_needs_human_decision(),
+		}
+	}
+
+	pub(super) fn ready_for_issue_shaping(&self) -> bool {
+		self.outcome == ResearchDesignOutcome::DecisionReady
+	}
+
+	pub(super) fn missing_decisions(&self) -> Vec<String> {
+		let mut missing = Vec::new();
+
+		missing.extend(self.unresolved_decisions.clone());
+		missing.extend(self.evidence_gaps.iter().map(|gap| format!("Evidence gap: {gap}")));
+
+		if self.outcome == ResearchDesignOutcome::NotDecisionReady && missing.is_empty() {
+			missing.push(String::from(
+				"Research is not decision-ready; gather more evidence or narrow the decision.",
+			));
+		}
+
+		missing
+	}
+
+	fn validate_decision_ready(&self) -> Result<()> {
+		if self.objectives.is_empty() {
+			eyre::bail!("decision-ready research requires at least one accepted objective.");
+		}
+		if self.evidence.is_empty() {
+			eyre::bail!("decision-ready research requires at least one evidence claim.");
+		}
+		if self.evidence.iter().any(|evidence| evidence.kind == "unspecified") {
+			eyre::bail!("decision-ready research requires an evidence kind for each claim.");
+		}
+		if self.options.is_empty() {
+			eyre::bail!("decision-ready research requires at least one option comparison.");
+		}
+		if self.objections.is_empty() {
+			eyre::bail!(
+				"decision-ready research requires at least one recorded challenge objection or objection note."
+			);
+		}
+		if self.validation_expectations.is_empty() {
+			eyre::bail!("decision-ready research requires validation expectations.");
+		}
+		if self.proposed_issues.is_empty() {
+			eyre::bail!(
+				"decision-ready research requires at least one structured proposed issue for downstream shaping."
+			);
+		}
+		if self.promotion_targets.is_empty() {
+			eyre::bail!("decision-ready research requires at least one promotion target.");
+		}
+		if !self.unresolved_decisions.is_empty() || !self.evidence_gaps.is_empty() {
+			eyre::bail!(
+				"decision-ready research cannot carry unresolved decisions or evidence gaps."
+			);
+		}
+		if !self.blockers.is_empty() {
+			eyre::bail!("decision-ready research cannot carry unresolved blockers.");
+		}
+
+		Ok(())
+	}
+
+	fn validate_blocked(&self) -> Result<()> {
+		if self.blockers.is_empty() {
+			eyre::bail!("blocked research requires at least one blocker.");
+		}
+
+		Ok(())
+	}
+
+	fn validate_needs_human_decision(&self) -> Result<()> {
+		if self.unresolved_decisions.is_empty() {
+			eyre::bail!("needs-human-decision research requires an unresolved decision.");
+		}
+
+		Ok(())
+	}
+}
+
+pub(super) fn default_feedback(outcome: ResearchDesignOutcome) -> &'static str {
+	match outcome {
+		ResearchDesignOutcome::DecisionReady => {
+			"Decision-ready research/design output is stored as a latent contract until promotion."
+		},
+		ResearchDesignOutcome::NotDecisionReady => {
+			"Research/design output is not decision-ready and must not become implementation work."
+		},
+		ResearchDesignOutcome::Blocked => {
+			"Research/design output is blocked; resolve blockers before promotion."
+		},
+		ResearchDesignOutcome::NeedsHumanDecision => {
+			"Research/design output needs an explicit human decision before execution authority exists."
+		},
+	}
+}
+
+pub(super) fn normalize_required_text(name: &str, value: impl Into<String>) -> Result<String> {
+	let value = value.into();
+	let value = value.trim();
+
+	if value.is_empty() {
+		eyre::bail!("{name} must not be empty.");
+	}
+
+	Ok(value.to_owned())
+}
+
+pub(super) fn normalize_optional_text(name: &str, value: Option<String>) -> Result<Option<String>> {
+	value.map(|value| normalize_required_text(name, value)).transpose()
+}
+
+pub(super) fn normalize_text_list(name: &str, values: Vec<String>) -> Result<Vec<String>> {
+	values.into_iter().map(|value| normalize_required_text(name, value)).collect()
+}
+
+fn generated_contract_id(input: &ResearchDesignRunInput) -> Result<String> {
+	let slug = intent_slug(&input.intent);
+	let encoded = serde_json::to_vec(input)?;
+	let digest = Sha256::digest(&encoded);
+	let mut hash = String::with_capacity(12);
+
+	for byte in digest.iter().take(6) {
+		hash.push(char::from(b"0123456789abcdef"[(byte >> 4) as usize]));
+		hash.push(char::from(b"0123456789abcdef"[(byte & 0x0f) as usize]));
+	}
+
+	Ok(format!("research-design-{slug}-{hash}"))
+}
+
+fn intent_slug(intent: &str) -> String {
+	let mut slug = String::new();
+	let mut previous_dash = false;
+
+	for character in intent.chars() {
+		if character.is_ascii_alphanumeric() {
+			slug.push(character.to_ascii_lowercase());
+
+			previous_dash = false;
+		} else if !previous_dash && !slug.is_empty() {
+			slug.push('-');
+
+			previous_dash = true;
+		}
+		if slug.len() >= 40 {
+			break;
+		}
+	}
+
+	while slug.ends_with('-') {
+		slug.pop();
+	}
+
+	if slug.is_empty() { String::from("research") } else { slug }
+}

--- a/apps/decodex/src/research_design/reports.rs
+++ b/apps/decodex/src/research_design/reports.rs
@@ -1,0 +1,77 @@
+use serde::Serialize;
+
+use crate::{
+	loop_contract::{DecisionContract, DecisionContractStatus, DecisionProposedIssue},
+	state::DecisionContractRecord,
+};
+use crate::research_design::{
+	ResearchDesignOutcome,
+	normalized::{self, NormalizedResearchDesignInput},
+};
+
+/// Compiler report for one persisted research/design run.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct ResearchDesignRunReport {
+	pub(crate) outcome: ResearchDesignOutcome,
+	pub(crate) contract_id: String,
+	pub(crate) contract_status: DecisionContractStatus,
+	pub(crate) source_issue_id: Option<String>,
+	pub(crate) ready_for_issue_shaping: bool,
+	pub(crate) issue_generation_ready_after_promotion: bool,
+	pub(crate) execution_authority_granted: bool,
+	pub(crate) feedback: String,
+	pub(crate) missing_decisions: Vec<String>,
+	pub(crate) blockers: Vec<String>,
+	pub(crate) proposed_issues: Vec<DecisionProposedIssue>,
+	pub(crate) promotion_targets: Vec<String>,
+	pub(crate) conflict_domains: Vec<String>,
+	pub(crate) private_evidence_ref_count: usize,
+	pub(crate) public_projection_ref_count: usize,
+}
+impl ResearchDesignRunReport {
+	pub(super) fn from_compilation(
+		input: &NormalizedResearchDesignInput,
+		contract: &DecisionContract,
+	) -> Self {
+		Self {
+			outcome: input.outcome,
+			contract_id: contract.contract_id().to_owned(),
+			contract_status: contract.status(),
+			source_issue_id: input.source_issue_identifier.clone(),
+			ready_for_issue_shaping: contract.execution_readiness().ready_for_issue_shaping(),
+			issue_generation_ready_after_promotion: input.ready_for_issue_shaping(),
+			execution_authority_granted: false,
+			feedback: normalized::default_feedback(input.outcome).to_owned(),
+			missing_decisions: input.missing_decisions(),
+			blockers: input.blockers.clone(),
+			proposed_issues: contract.execution_readiness().proposed_issues().to_vec(),
+			promotion_targets: contract.execution_readiness().promotion_targets().to_vec(),
+			conflict_domains: contract.execution_readiness().conflict_domains().to_vec(),
+			private_evidence_ref_count: input.private_evidence_refs.len(),
+			public_projection_ref_count: input.public_projection_refs.len(),
+		}
+	}
+
+	pub(super) fn with_record(mut self, record: &DecisionContractRecord) -> Self {
+		self.contract_id = record.contract_id().to_owned();
+		self.contract_status = record.status();
+		self.ready_for_issue_shaping =
+			record.contract().execution_readiness().ready_for_issue_shaping();
+
+		self
+	}
+}
+
+/// Promotion report for an accepted research/design contract.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct ResearchDesignPromotionReport {
+	pub(crate) contract_id: String,
+	pub(crate) contract_status: DecisionContractStatus,
+	pub(crate) execution_authority_granted: bool,
+	pub(crate) ready_for_issue_shaping: bool,
+}
+
+pub(super) struct ResearchDesignCompilation {
+	pub(super) contract: DecisionContract,
+	pub(super) report: ResearchDesignRunReport,
+}

--- a/apps/decodex/src/research_design/requests.rs
+++ b/apps/decodex/src/research_design/requests.rs
@@ -1,0 +1,19 @@
+use std::path::Path;
+
+use crate::research_design::ResearchDesignRunInput;
+
+/// CLI/runtime request for compiling and persisting one research/design contract.
+pub(crate) struct ResearchDesignCompileRequest<'a> {
+	pub(crate) config_path: Option<&'a Path>,
+	pub(crate) input: ResearchDesignRunInput,
+}
+
+/// CLI/runtime request for promoting an already persisted research/design contract.
+pub(crate) struct ResearchDesignPromoteRequest<'a> {
+	pub(crate) config_path: Option<&'a Path>,
+	pub(crate) contract_id: &'a str,
+	pub(crate) accepted_by: &'a str,
+	pub(crate) accepted_at: Option<&'a str>,
+	pub(crate) acceptance_source: &'a str,
+	pub(crate) promotion_reason: Option<String>,
+}


### PR DESCRIPTION
## Summary
- split Decision Contract submodels into responsibility modules for authority, readiness, research context, and source intent
- split research design into compile, lifecycle, normalization, report, and request modules
- kept Rust module files explicit without mod.rs, include!, or path indirection

## Validation
- cargo check -p decodex --all-targets --all-features
- cargo test -p decodex loop_contract --all-features -- --nocapture --test-threads=1
- cargo test -p decodex research_design --all-features -- --nocapture --test-threads=1
- cargo vstyle curate --language rust --workspace --all-features (no touched-path findings under loop_contract or research_design; existing repo-wide findings remain outside this PR)
- git diff --check HEAD~1 HEAD
- find/rg confirmed no mod.rs, include!, or #[path] in touched module trees