### PR TITLE
Split status run projection modules

### DIFF
--- a/apps/decodex/src/orchestrator/status_run_projection/run.rs
+++ b/apps/decodex/src/orchestrator/status_run_projection/run.rs
@@ -1,5 +1,18 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+mod accessors;
+mod lane_control;
+mod lifecycle;
+mod phase;
+
+use crate::orchestrator::status_process_liveness;
+use crate::orchestrator::{
+	AgentPrivateEvidenceRef, ChildAgentActivitySummary, CodexAccountActivitySummary,
+	OperatorContinuationRecoveryStatus, OperatorLaneLifecycleMetrics, OperatorLoopStatus,
+	OperatorPhaseAcceptanceStatus, OperatorRunAppServerState, OperatorRunLifecycleProjection,
+	OperatorRunProtocolSummary, OperatorRunStatus, OperatorRunTiming,
+	OperatorTerminalFinalizeProjection, PrivateExecutionEvent, ProjectLoopEvidenceSnapshot,
+	ProjectRunStatus, ProtocolActivitySummary, RunActivityMarker, ServiceConfig,
+};
+use crate::prelude::Result;
 
 pub(in crate::orchestrator) fn operator_run_status(
 	project: &ServiceConfig,
@@ -7,13 +20,13 @@ pub(in crate::orchestrator) fn operator_run_status(
 	project_display_name: &str,
 	run: ProjectRunStatus,
 	now_unix_epoch: i64,
-) -> crate::prelude::Result<OperatorRunStatus> {
-	let marker = load_operator_run_marker(&run)?;
-	let timing = operator_run_timing(&run, marker.as_ref(), now_unix_epoch);
-	let app_server_state = operator_run_app_server_state(&run, marker.as_ref());
-	let protocol_summary = operator_run_protocol_summary(&run, marker.as_ref());
+) -> Result<OperatorRunStatus> {
+	let marker = super::load_operator_run_marker(&run)?;
+	let timing = super::operator_run_timing(&run, marker.as_ref(), now_unix_epoch);
+	let app_server_state = super::operator_run_app_server_state(&run, marker.as_ref());
+	let protocol_summary = super::operator_run_protocol_summary(&run, marker.as_ref());
 	let terminal_finalize_projection =
-		operator_run_terminal_finalize_projection(loop_evidence, &run);
+		super::operator_run_terminal_finalize_projection(loop_evidence, &run);
 	let lifecycle = operator_run_lifecycle_projection(
 		&run,
 		marker.as_ref(),
@@ -23,12 +36,12 @@ pub(in crate::orchestrator) fn operator_run_status(
 		&protocol_summary,
 		now_unix_epoch,
 	);
-	let child_agent_activity = operator_run_child_agent_activity(
+	let child_agent_activity = super::operator_run_child_agent_activity(
 		marker.as_ref(),
 		run.child_agent_activity(),
 		now_unix_epoch,
 	);
-	let protocol_activity = operator_run_protocol_activity(
+	let protocol_activity = super::operator_run_protocol_activity(
 		marker.as_ref(),
 		run.protocol_activity(),
 		&app_server_state,
@@ -43,25 +56,26 @@ pub(in crate::orchestrator) fn operator_run_status(
 	);
 	let private_events =
 		loop_evidence.private_events(run.issue_id(), run.run_id(), run.attempt_number());
-	let progress_diagnostic = operator_run_progress_diagnostic(
+	let progress_diagnostic = super::operator_run_progress_diagnostic(
 		&lifecycle.phase,
 		&timing,
 		protocol_activity.as_ref(),
 		private_events,
 		now_unix_epoch,
-		run_activity_idle_timeout(marker.as_ref()),
+		status_process_liveness::run_activity_idle_timeout(marker.as_ref()),
 	);
 	let (account, accounts) = operator_run_accounts(marker.as_ref());
 	let branch_name = run.branch_name().map(str::to_owned);
 	let worktree_path = operator_run_relative_worktree_path(project, &run);
-	let issue_identifier = operator_run_issue_identifier_from_fields(
+	let issue_identifier = super::operator_run_issue_identifier_from_fields(
 		run.run_id(),
 		branch_name.as_deref(),
 		worktree_path.as_deref(),
 	);
 	let private_evidence =
 		operator_run_private_evidence(project, &run, issue_identifier.as_deref());
-	let continuation_recovery = operator_run_continuation_recovery_status(loop_evidence, &run);
+	let continuation_recovery =
+		super::operator_run_continuation_recovery_status(loop_evidence, &run);
 	let active_goal_phase = operator_run_active_goal_phase(private_events);
 	let public_progress_phase = operator_run_public_progress_phase(private_events);
 	let phase_acceptance = operator_run_phase_acceptance_status(private_events);
@@ -154,7 +168,7 @@ pub(in crate::orchestrator) fn operator_run_status_from_parts(
 		current_operation: lifecycle.current_operation,
 		active_goal_phase,
 		public_progress_phase,
-		control_capability: operator_run_control_capability(run, &app_server_state),
+		control_capability: super::operator_run_control_capability(run, &app_server_state),
 		thread_id: app_server_state.thread_id,
 		turn_id: app_server_state.turn_id,
 		thread_status: app_server_state.thread_status,
@@ -164,17 +178,19 @@ pub(in crate::orchestrator) fn operator_run_status_from_parts(
 		continuation_recovery,
 		phase_acceptance,
 		run_lease: lifecycle.run_lease,
-		queue_lease_state: operator_run_queue_lease_state(lifecycle.run_lease),
+		queue_lease_state: super::operator_run_queue_lease_state(lifecycle.run_lease),
 		execution_liveness: lifecycle.execution_liveness,
 		has_fresh_execution: false,
 		counts_as_running: false,
 		needs_attention: false,
 		updated_at: run.updated_at().to_owned(),
-		last_run_activity_at: format_optional_unix_timestamp(timing.last_run_activity_unix_epoch),
-		last_protocol_activity_at: format_optional_unix_timestamp(
+		last_run_activity_at: super::format_optional_unix_timestamp(
+			timing.last_run_activity_unix_epoch,
+		),
+		last_protocol_activity_at: super::format_optional_unix_timestamp(
 			timing.last_protocol_activity_unix_epoch,
 		),
-		last_progress_at: format_optional_unix_timestamp(timing.last_progress_unix_epoch),
+		last_progress_at: super::format_optional_unix_timestamp(timing.last_progress_unix_epoch),
 		idle_for_seconds: timing.idle_for_seconds,
 		protocol_idle_for_seconds: timing.protocol_idle_for_seconds,
 		suspected_stall: lifecycle.suspected_stall,
@@ -188,7 +204,7 @@ pub(in crate::orchestrator) fn operator_run_status_from_parts(
 		process_alive: timing.process_alive,
 		process_liveness_reason: timing.process_liveness_reason,
 		retry_kind: lifecycle.retry_kind,
-		next_retry_at: format_optional_unix_timestamp(lifecycle.retry_ready_at_unix_epoch),
+		next_retry_at: super::format_optional_unix_timestamp(lifecycle.retry_ready_at_unix_epoch),
 		effective_model: app_server_state.effective_model,
 		effective_model_provider: app_server_state.effective_model_provider,
 		effective_cwd: app_server_state.effective_cwd,
@@ -211,379 +227,25 @@ pub(in crate::orchestrator) fn operator_run_status_from_parts(
 pub(in crate::orchestrator) fn operator_run_active_goal_phase(
 	events: &[PrivateExecutionEvent],
 ) -> Option<String> {
-	for event in events.iter().rev() {
-		if matches!(event.event_type(), "phase_goal_completed" | "phase_goal_transition") {
-			return None;
-		}
-		if !matches!(event.event_type(), "phase_goal_set" | "phase_goal_status") {
-			continue;
-		}
-
-		let payload = event.payload();
-		let nested = payload.get("payload").unwrap_or(payload);
-		let status = nested.get("status").or_else(|| payload.get("status")).and_then(Value::as_str);
-
-		if status.is_some_and(|value| matches!(value, "complete" | "completed" | "blocked")) {
-			return None;
-		}
-
-		return nested
-			.get("phase")
-			.or_else(|| payload.get("phase"))
-			.and_then(Value::as_str)
-			.map(str::to_owned);
-	}
-
-	None
+	phase::operator_run_active_goal_phase(events)
 }
 
 pub(in crate::orchestrator) fn operator_run_public_progress_phase(
 	events: &[PrivateExecutionEvent],
 ) -> Option<String> {
-	events.iter().rev().find_map(|event| {
-		(event.event_type() == "progress_checkpoint")
-			.then_some(event.payload())
-			.and_then(|payload| payload.get("phase"))
-			.and_then(Value::as_str)
-			.map(str::to_owned)
-	})
+	phase::operator_run_public_progress_phase(events)
 }
 
 pub(in crate::orchestrator) fn operator_run_phase_acceptance_status(
 	events: &[PrivateExecutionEvent],
 ) -> Option<OperatorPhaseAcceptanceStatus> {
-	let event = events
-		.iter()
-		.rev()
-		.find(|event| event.event_type() == PHASE_ACCEPTANCE_CHECK_EVENT_TYPE)?;
-	let payload = event.payload();
-	let phase = payload.get("phase")?.as_str()?.to_owned();
-	let decision = payload.get("decision")?.as_str()?.to_owned();
-	let reason_code = payload.get("reason_code")?.as_str()?.to_owned();
-	let objective_covered = payload
-		.get("objective_coverage")
-		.and_then(|objective| objective.get("covered"))
-		.and_then(Value::as_bool)
-		.unwrap_or(false);
-	let effective_delta_present = payload
-		.get("effective_delta")
-		.and_then(|delta| delta.get("present"))
-		.and_then(Value::as_bool)
-		.unwrap_or(false);
-	let changed_surfaces = payload
-		.get("effective_delta")
-		.and_then(|delta| delta.get("changed_surfaces"))
-		.and_then(Value::as_array)
-		.into_iter()
-		.flatten()
-		.filter_map(Value::as_str)
-		.map(str::to_owned)
-		.collect();
-	let non_goal_passed = payload
-		.get("non_goal_check")
-		.and_then(|check| check.get("passed"))
-		.and_then(Value::as_bool)
-		.unwrap_or(false);
-	let validation_passed = payload
-		.get("validation_evidence")
-		.and_then(|evidence| evidence.get("repo_gate_passed"))
-		.and_then(Value::as_bool)
-		.unwrap_or(false);
-
-	Some(OperatorPhaseAcceptanceStatus {
-		phase,
-		decision,
-		reason_code,
-		objective_covered,
-		effective_delta_present,
-		changed_surfaces,
-		non_goal_passed,
-		validation_passed,
-		recorded_at: event.recorded_at().to_owned(),
-		run_id: event.run_id().to_owned(),
-		attempt_number: event.attempt_number(),
-		next_action: payload
-			.get("next_action")
-			.and_then(Value::as_str)
-			.unwrap_or("inspect_phase_acceptance_check")
-			.to_owned(),
-	})
+	phase::operator_run_phase_acceptance_status(events)
 }
 
 pub(in crate::orchestrator) fn hydrate_operator_run_derived_status(
-	mut status: OperatorRunStatus,
+	status: OperatorRunStatus,
 ) -> OperatorRunStatus {
-	status.has_fresh_execution = operator_run_has_fresh_execution(&status);
-	status.needs_attention = operator_run_needs_attention(&status);
-
-	let lane_control_state = operator_lane_control_state(&status);
-
-	status.ownership_state = lane_control_state.ownership_state;
-	status.liveness_state = lane_control_state.liveness_state;
-	status.policy_state = lane_control_state.policy_state;
-	status.terminalization_state = lane_control_state.terminalization_state;
-	status.lane_control_next_action = lane_control_state.next_action;
-	status.lane_control_conditions = lane_control_state.conditions;
-	status.needs_attention = operator_run_counts_as_attention(&status);
-	status.counts_as_running = operator_run_counts_as_running(&status);
-
-	status
-}
-
-pub(in crate::orchestrator) fn operator_lane_control_state(
-	run: &OperatorRunStatus,
-) -> OperatorLaneControlProjection {
-	let liveness_state = operator_run_liveness_state(run);
-	let policy_state = operator_run_policy_state(run);
-	let terminalization_state = operator_run_terminalization_state(run, &liveness_state);
-	let ownership_state =
-		operator_run_ownership_state(run, &liveness_state, &policy_state, &terminalization_state);
-	let next_action = operator_run_lane_control_next_action(
-		run,
-		&ownership_state,
-		&liveness_state,
-		&policy_state,
-		&terminalization_state,
-	);
-	let mut conditions = operator_run_lane_control_conditions(run, &liveness_state, &policy_state);
-
-	if ownership_state == "leased_run" && !run.run_lease {
-		conditions.push(String::from("invalid_leased_run_without_lease"));
-	}
-
-	OperatorLaneControlProjection {
-		ownership_state,
-		liveness_state,
-		policy_state,
-		terminalization_state,
-		next_action,
-		conditions,
-	}
-}
-
-pub(in crate::orchestrator) fn operator_run_ownership_state(
-	run: &OperatorRunStatus,
-	liveness_state: &str,
-	policy_state: &str,
-	terminalization_state: &str,
-) -> String {
-	if run.run_lease
-		&& matches!(run.attempt_status.as_str(), "starting" | "running" | "continuation_pending")
-		&& !matches!(
-			policy_state,
-			"review_churn_exceeded"
-				| "continuation_recovery_churn_exceeded"
-				| "authority_boundary_required"
-				| "human_attention_required"
-		) {
-		return String::from("leased_run");
-	}
-	if matches!(
-		policy_state,
-		"review_churn_exceeded"
-			| "continuation_recovery_churn_exceeded"
-			| "authority_boundary_required"
-			| "human_attention_required"
-	) || run.needs_attention
-		|| (!run.run_lease && liveness_state == "host_boot_mismatch")
-	{
-		return String::from("retained_attention");
-	}
-	if operator_run_is_continuation_wait(run) {
-		return String::from("continuation_pending");
-	}
-	if !run.run_lease
-		&& matches!(liveness_state, "process_alive" | "thread_active" | "protocol_recent")
-	{
-		return String::from("orphaned_live_thread");
-	}
-	if terminalization_state != "none" && terminalization_state != "cleanup_complete" {
-		return String::from("terminalizing");
-	}
-	if matches!(run.attempt_status.as_str(), "starting" | "running" | "continuation_pending") {
-		return String::from("pending");
-	}
-
-	String::from("closed")
-}
-
-pub(in crate::orchestrator) fn operator_run_is_continuation_wait(run: &OperatorRunStatus) -> bool {
-	run.attempt_status == CONTINUATION_PENDING_RUN_STATUS
-		|| run.phase == "waiting_continuation"
-		|| run.retry_kind.as_deref() == Some("continuation")
-		|| run.wait_reason.as_deref() == Some("continuation_retry")
-}
-
-pub(in crate::orchestrator) fn operator_run_liveness_state(run: &OperatorRunStatus) -> String {
-	if matches!(run.process_liveness_reason.as_deref(), Some("host_boot_id_mismatch")) {
-		return String::from("host_boot_mismatch");
-	}
-	if run.process_alive == Some(true) {
-		return String::from("process_alive");
-	}
-	if run.process_alive == Some(false)
-		|| matches!(run.execution_liveness.as_str(), "not_running" | "process_identity_mismatch")
-	{
-		return String::from("not_running");
-	}
-	if matches!(run.thread_status.as_deref(), Some("active")) || !run.thread_active_flags.is_empty()
-	{
-		return String::from("thread_active");
-	}
-	if operator_run_has_recent_app_server_execution(run) {
-		return String::from("protocol_recent");
-	}
-
-	String::from("unknown")
-}
-
-pub(in crate::orchestrator) fn operator_run_policy_state(run: &OperatorRunStatus) -> String {
-	if run.continuation_recovery.as_ref().is_some_and(|recovery| recovery.budget_exceeded) {
-		return String::from("continuation_recovery_churn_exceeded");
-	}
-
-	let Some(loop_status) = run.loop_status.as_ref() else {
-		return String::from("allowed");
-	};
-
-	if loop_status.decision_request.is_some() {
-		return String::from("authority_boundary_required");
-	}
-	if loop_status.autonomy == "human_required" {
-		return String::from("human_attention_required");
-	}
-
-	if let Some(recovery) = loop_status.architecture_recovery.as_ref() {
-		return if recovery.status == "active" {
-			String::from("architecture_recovery_pending")
-		} else {
-			String::from("human_attention_required")
-		};
-	}
-	if let Some(review) = loop_status.review.as_ref() {
-		return match review.status.as_str() {
-			"pending" => String::from("review_pending"),
-			"findings" => {
-				if review.checkpoint.as_ref().is_some_and(|checkpoint| {
-					checkpoint.nonclean_rounds >= REVIEW_POLICY_CONVERGENCE_BUDGET
-				}) {
-					String::from("review_churn_exceeded")
-				} else {
-					String::from("review_findings")
-				}
-			},
-			"blocked" | "needs_architecture_review" => String::from("human_attention_required"),
-			_ => String::from("allowed"),
-		};
-	}
-
-	String::from("allowed")
-}
-
-pub(in crate::orchestrator) fn operator_run_terminalization_state(
-	run: &OperatorRunStatus,
-	liveness_state: &str,
-) -> String {
-	if matches!(run.status.as_str(), "cleanup_complete" | "merged_closeout_reconciled")
-		|| matches!(run.current_operation.as_str(), "ledger_outcome")
-			&& matches!(run.phase.as_str(), "completed")
-	{
-		return String::from("cleanup_complete");
-	}
-	if matches!(run.phase.as_str(), "completed" | "failed" | "terminated")
-		&& !run.run_lease
-		&& matches!(liveness_state, "not_running" | "unknown")
-	{
-		return String::from("cleanup_complete");
-	}
-	if matches!(run.phase.as_str(), "completed" | "failed" | "terminated") {
-		return String::from("barrier_started");
-	}
-
-	String::from("none")
-}
-
-pub(in crate::orchestrator) fn operator_run_lane_control_conditions(
-	run: &OperatorRunStatus,
-	liveness_state: &str,
-	policy_state: &str,
-) -> Vec<String> {
-	let mut conditions = Vec::new();
-
-	if !run.run_lease
-		&& matches!(run.attempt_status.as_str(), "starting" | "running" | "continuation_pending")
-	{
-		conditions.push(String::from("run_lease_missing"));
-	}
-	if matches!(run.attempt_status.as_str(), "failed" | "interrupted" | "stalled" | "succeeded")
-		&& matches!(liveness_state, "process_alive" | "thread_active" | "protocol_recent")
-	{
-		conditions.push(String::from("terminal_attempt_has_live_evidence"));
-	}
-	if liveness_state == "host_boot_mismatch" {
-		conditions.push(String::from("host_boot_id_mismatch"));
-	}
-	if policy_state == "review_churn_exceeded" {
-		conditions.push(String::from("review_churn_threshold_exceeded"));
-	}
-	if policy_state == "continuation_recovery_churn_exceeded" {
-		conditions.push(String::from("continuation_recovery_budget_exceeded"));
-	}
-	if matches!(policy_state, "authority_boundary_required" | "human_attention_required") {
-		conditions.push(String::from("policy_requires_human_attention"));
-	}
-
-	conditions
-}
-
-pub(in crate::orchestrator) fn operator_run_lane_control_next_action(
-	run: &OperatorRunStatus,
-	ownership_state: &str,
-	liveness_state: &str,
-	policy_state: &str,
-	terminalization_state: &str,
-) -> String {
-	if policy_state == "review_churn_exceeded" {
-		return String::from("start_architecture_recovery_or_stop_for_human_attention");
-	}
-	if policy_state == "continuation_recovery_churn_exceeded" {
-		return String::from("stop_auto_continuation_and_request_architecture_recovery");
-	}
-	if matches!(policy_state, "authority_boundary_required" | "human_attention_required") {
-		return String::from("resolve_policy_stop_before_mutating_lane");
-	}
-	if ownership_state == "orphaned_live_thread" {
-		return String::from("inspect_or_interrupt_orphaned_live_thread");
-	}
-	if liveness_state == "host_boot_mismatch" {
-		return String::from("inspect_recovery_evidence");
-	}
-	if terminalization_state != "none" && terminalization_state != "cleanup_complete" {
-		return String::from("finish_terminalization");
-	}
-	if ownership_state == "leased_run" {
-		if let Some(next_action) =
-			run.loop_status.as_ref().and_then(|loop_status| loop_status.next_action.clone())
-		{
-			return next_action;
-		}
-
-		return String::from("continue_owned_attempt");
-	}
-	if ownership_state == "continuation_pending" {
-		return String::from("wait_for_continuation_reentry");
-	}
-	if ownership_state == "closed" {
-		return String::from("no_action");
-	}
-
-	if let Some(next_action) =
-		run.loop_status.as_ref().and_then(|loop_status| loop_status.next_action.clone())
-	{
-		return next_action;
-	}
-
-	String::from("inspect_lane_state")
+	lane_control::hydrate_operator_run_derived_status(status)
 }
 
 pub(in crate::orchestrator) fn operator_run_lifecycle_projection(
@@ -595,75 +257,15 @@ pub(in crate::orchestrator) fn operator_run_lifecycle_projection(
 	protocol_summary: &OperatorRunProtocolSummary,
 	now_unix_epoch: i64,
 ) -> OperatorRunLifecycleProjection {
-	let marker_current_operation = marker.and_then(RunActivityMarker::current_operation);
-	let status = terminal_finalize_projection
-		.map(|projection| projection.status.to_owned())
-		.unwrap_or_else(|| {
-			operator_run_visible_status(
-				run.status(),
-				app_server_state,
-				protocol_summary,
-				timing,
-				marker_current_operation,
-			)
-		});
-	let status_projection_reason = if terminal_finalize_projection.is_some() {
-		None
-	} else {
-		operator_run_status_projection_reason(
-			run.status(),
-			&status,
-			app_server_state,
-			protocol_summary,
-			timing,
-			marker_current_operation,
-		)
-	};
-	let (retry_kind, retry_ready_at_unix_epoch) = visible_operator_run_retry_schedule(
-		&status,
-		marker.and_then(RunActivityMarker::retry_kind),
-		marker.and_then(RunActivityMarker::retry_ready_at_unix_epoch),
+	lifecycle::operator_run_lifecycle_projection(
+		run,
+		marker,
+		terminal_finalize_projection,
+		timing,
+		app_server_state,
+		protocol_summary,
 		now_unix_epoch,
-	);
-	let (phase, wait_reason) = if let Some(projection) = terminal_finalize_projection {
-		(String::from(projection.phase), Some(String::from(projection.wait_reason)))
-	} else {
-		classify_operator_run_phase(
-			&status,
-			retry_kind.as_deref(),
-			retry_ready_at_unix_epoch,
-			now_unix_epoch,
-		)
-	};
-	let current_operation = terminal_finalize_projection
-		.map(|projection| projection.current_operation.to_owned())
-		.unwrap_or_else(|| classify_operator_run_operation(&phase, marker_current_operation));
-	let suspected_stall = terminal_finalize_projection.is_none()
-		&& operator_run_is_suspected_stall(
-			&phase,
-			timing.last_progress_unix_epoch,
-			now_unix_epoch,
-			run_activity_idle_timeout(marker),
-		);
-	let execution_liveness = if terminal_finalize_projection.is_some() {
-		String::from("not_running")
-	} else {
-		operator_run_execution_liveness(&status, timing, app_server_state, protocol_summary)
-	};
-	let run_lease = terminal_finalize_projection.is_none() && run.run_lease();
-
-	OperatorRunLifecycleProjection {
-		status,
-		status_projection_reason,
-		phase,
-		wait_reason,
-		current_operation,
-		suspected_stall,
-		execution_liveness,
-		run_lease,
-		retry_kind,
-		retry_ready_at_unix_epoch,
-	}
+	)
 }
 
 pub(in crate::orchestrator) fn operator_run_wait_reason(
@@ -671,31 +273,20 @@ pub(in crate::orchestrator) fn operator_run_wait_reason(
 	wait_reason: Option<String>,
 	protocol_activity: Option<&ProtocolActivitySummary>,
 ) -> Option<String> {
-	if wait_reason.is_some() || phase != "executing" {
-		return wait_reason;
-	}
-
-	protocol_activity
-		.and_then(|summary| summary.waiting_reason.clone())
-		.filter(|reason| reason != "turn_completed")
+	phase::operator_run_wait_reason(phase, wait_reason, protocol_activity)
 }
 
 pub(in crate::orchestrator) fn operator_run_accounts(
 	marker: Option<&RunActivityMarker>,
 ) -> (Option<CodexAccountActivitySummary>, Vec<CodexAccountActivitySummary>) {
-	let account = marker.and_then(RunActivityMarker::account).cloned();
-	let mut accounts = marker.map(|marker| marker.accounts().to_vec()).unwrap_or_default();
-
-	append_primary_account_if_missing(&mut accounts, account.as_ref());
-
-	(account, accounts)
+	accessors::operator_run_accounts(marker)
 }
 
 pub(in crate::orchestrator) fn operator_run_relative_worktree_path(
 	project: &ServiceConfig,
 	run: &ProjectRunStatus,
 ) -> Option<String> {
-	run.worktree_path().map(|path| relative_worktree_path_for_path(project, path))
+	accessors::operator_run_relative_worktree_path(project, run)
 }
 
 pub(in crate::orchestrator) fn operator_run_private_evidence(
@@ -703,14 +294,7 @@ pub(in crate::orchestrator) fn operator_run_private_evidence(
 	run: &ProjectRunStatus,
 	issue_identifier: Option<&str>,
 ) -> AgentPrivateEvidenceRef {
-	private_evidence_ref_for_run_fields(
-		project.service_id(),
-		project.config_path(),
-		run.issue_id(),
-		issue_identifier,
-		run.run_id(),
-		run.attempt_number(),
-	)
+	accessors::operator_run_private_evidence(project, run, issue_identifier)
 }
 
 pub(in crate::orchestrator) fn operator_run_loop_status(
@@ -720,15 +304,14 @@ pub(in crate::orchestrator) fn operator_run_loop_status(
 	status: &str,
 	phase: &str,
 	current_operation: &str,
-) -> crate::prelude::Result<OperatorLoopStatus> {
-	operator_loop_status_for_run_with_evidence(
+) -> Result<OperatorLoopStatus> {
+	accessors::operator_run_loop_status(
 		project,
 		loop_evidence,
-		run.issue_id(),
-		run.run_id(),
-		run.attempt_number(),
-		operator_run_default_review_phase(status, phase, current_operation),
-		operator_run_lifecycle_loop_summary(status, phase, current_operation),
+		run,
+		status,
+		phase,
+		current_operation,
 	)
 }
 
@@ -737,14 +320,7 @@ pub(in crate::orchestrator) fn operator_run_default_review_phase(
 	phase: &str,
 	current_operation: &str,
 ) -> Option<&'static str> {
-	if operator_run_has_terminal_lifecycle(status, phase, current_operation) {
-		return None;
-	}
-	if current_operation == RUN_OPERATION_REVIEW_WRITEBACK {
-		return Some("handoff");
-	}
-
-	None
+	phase::operator_run_default_review_phase(status, phase, current_operation)
 }
 
 pub(in crate::orchestrator) fn operator_run_lifecycle_loop_summary(
@@ -752,29 +328,5 @@ pub(in crate::orchestrator) fn operator_run_lifecycle_loop_summary(
 	phase: &str,
 	current_operation: &str,
 ) -> Option<String> {
-	operator_run_has_terminal_lifecycle(status, phase, current_operation)
-		.then(|| format!("terminal lifecycle: {status}"))
-}
-
-pub(in crate::orchestrator) fn operator_run_has_terminal_lifecycle(
-	status: &str,
-	phase: &str,
-	current_operation: &str,
-) -> bool {
-	phase == "completed"
-		|| phase == "terminal_pending"
-		|| current_operation == "ledger_outcome"
-		|| matches!(
-			status,
-			"succeeded"
-				| "failed" | "interrupted"
-				| "review_handoff_pending"
-				| "review_repair_pending"
-				| "closeout_pending"
-				| "manual_attention_pending"
-				| "cleanup_complete"
-				| "closeout" | "landed"
-				| "manual_attention"
-				| TERMINAL_GUARDED_RUN_STATUS
-		)
+	phase::operator_run_lifecycle_loop_summary(status, phase, current_operation)
 }

--- a/apps/decodex/src/orchestrator/status_run_projection/run/accessors.rs
+++ b/apps/decodex/src/orchestrator/status_run_projection/run/accessors.rs
@@ -1,0 +1,61 @@
+use crate::orchestrator::agent_evidence;
+use crate::orchestrator::git_ops;
+use crate::orchestrator::status;
+use crate::orchestrator::status_run_projection::loop_status;
+use crate::orchestrator::{
+	AgentPrivateEvidenceRef, CodexAccountActivitySummary, OperatorLoopStatus,
+	ProjectLoopEvidenceSnapshot, ProjectRunStatus, RunActivityMarker, ServiceConfig,
+};
+use crate::prelude::Result;
+
+pub(super) fn operator_run_accounts(
+	marker: Option<&RunActivityMarker>,
+) -> (Option<CodexAccountActivitySummary>, Vec<CodexAccountActivitySummary>) {
+	let account = marker.and_then(RunActivityMarker::account).cloned();
+	let mut accounts = marker.map(|marker| marker.accounts().to_vec()).unwrap_or_default();
+
+	status::append_primary_account_if_missing(&mut accounts, account.as_ref());
+
+	(account, accounts)
+}
+
+pub(super) fn operator_run_relative_worktree_path(
+	project: &ServiceConfig,
+	run: &ProjectRunStatus,
+) -> Option<String> {
+	run.worktree_path().map(|path| git_ops::relative_worktree_path_for_path(project, path))
+}
+
+pub(super) fn operator_run_private_evidence(
+	project: &ServiceConfig,
+	run: &ProjectRunStatus,
+	issue_identifier: Option<&str>,
+) -> AgentPrivateEvidenceRef {
+	agent_evidence::private_evidence_ref_for_run_fields(
+		project.service_id(),
+		project.config_path(),
+		run.issue_id(),
+		issue_identifier,
+		run.run_id(),
+		run.attempt_number(),
+	)
+}
+
+pub(super) fn operator_run_loop_status(
+	project: &ServiceConfig,
+	loop_evidence: &ProjectLoopEvidenceSnapshot,
+	run: &ProjectRunStatus,
+	status: &str,
+	phase: &str,
+	current_operation: &str,
+) -> Result<OperatorLoopStatus> {
+	loop_status::operator_loop_status_for_run_with_evidence(
+		project,
+		loop_evidence,
+		run.issue_id(),
+		run.run_id(),
+		run.attempt_number(),
+		super::operator_run_default_review_phase(status, phase, current_operation),
+		super::operator_run_lifecycle_loop_summary(status, phase, current_operation),
+	)
+}

--- a/apps/decodex/src/orchestrator/status_run_projection/run/lane_control.rs
+++ b/apps/decodex/src/orchestrator/status_run_projection/run/lane_control.rs
@@ -1,0 +1,281 @@
+use crate::orchestrator::status_summary;
+use crate::orchestrator::{
+	CONTINUATION_PENDING_RUN_STATUS, OperatorLaneControlProjection, OperatorRunStatus,
+	REVIEW_POLICY_CONVERGENCE_BUDGET,
+};
+
+pub(super) fn hydrate_operator_run_derived_status(
+	mut status: OperatorRunStatus,
+) -> OperatorRunStatus {
+	status.has_fresh_execution = status_summary::operator_run_has_fresh_execution(&status);
+	status.needs_attention = status_summary::operator_run_needs_attention(&status);
+
+	let lane_control_state = operator_lane_control_state(&status);
+
+	status.ownership_state = lane_control_state.ownership_state;
+	status.liveness_state = lane_control_state.liveness_state;
+	status.policy_state = lane_control_state.policy_state;
+	status.terminalization_state = lane_control_state.terminalization_state;
+	status.lane_control_next_action = lane_control_state.next_action;
+	status.lane_control_conditions = lane_control_state.conditions;
+	status.needs_attention = status_summary::operator_run_counts_as_attention(&status);
+	status.counts_as_running = status_summary::operator_run_counts_as_running(&status);
+
+	status
+}
+
+pub(super) fn operator_lane_control_state(
+	run: &OperatorRunStatus,
+) -> OperatorLaneControlProjection {
+	let liveness_state = operator_run_liveness_state(run);
+	let policy_state = operator_run_policy_state(run);
+	let terminalization_state = operator_run_terminalization_state(run, &liveness_state);
+	let ownership_state =
+		operator_run_ownership_state(run, &liveness_state, &policy_state, &terminalization_state);
+	let next_action = operator_run_lane_control_next_action(
+		run,
+		&ownership_state,
+		&liveness_state,
+		&policy_state,
+		&terminalization_state,
+	);
+	let mut conditions = operator_run_lane_control_conditions(run, &liveness_state, &policy_state);
+
+	if ownership_state == "leased_run" && !run.run_lease {
+		conditions.push(String::from("invalid_leased_run_without_lease"));
+	}
+
+	OperatorLaneControlProjection {
+		ownership_state,
+		liveness_state,
+		policy_state,
+		terminalization_state,
+		next_action,
+		conditions,
+	}
+}
+
+pub(super) fn operator_run_ownership_state(
+	run: &OperatorRunStatus,
+	liveness_state: &str,
+	policy_state: &str,
+	terminalization_state: &str,
+) -> String {
+	if run.run_lease
+		&& matches!(run.attempt_status.as_str(), "starting" | "running" | "continuation_pending")
+		&& !matches!(
+			policy_state,
+			"review_churn_exceeded"
+				| "continuation_recovery_churn_exceeded"
+				| "authority_boundary_required"
+				| "human_attention_required"
+		) {
+		return String::from("leased_run");
+	}
+	if matches!(
+		policy_state,
+		"review_churn_exceeded"
+			| "continuation_recovery_churn_exceeded"
+			| "authority_boundary_required"
+			| "human_attention_required"
+	) || run.needs_attention
+		|| (!run.run_lease && liveness_state == "host_boot_mismatch")
+	{
+		return String::from("retained_attention");
+	}
+	if operator_run_is_continuation_wait(run) {
+		return String::from("continuation_pending");
+	}
+	if !run.run_lease
+		&& matches!(liveness_state, "process_alive" | "thread_active" | "protocol_recent")
+	{
+		return String::from("orphaned_live_thread");
+	}
+	if terminalization_state != "none" && terminalization_state != "cleanup_complete" {
+		return String::from("terminalizing");
+	}
+	if matches!(run.attempt_status.as_str(), "starting" | "running" | "continuation_pending") {
+		return String::from("pending");
+	}
+
+	String::from("closed")
+}
+
+pub(super) fn operator_run_is_continuation_wait(run: &OperatorRunStatus) -> bool {
+	run.attempt_status == CONTINUATION_PENDING_RUN_STATUS
+		|| run.phase == "waiting_continuation"
+		|| run.retry_kind.as_deref() == Some("continuation")
+		|| run.wait_reason.as_deref() == Some("continuation_retry")
+}
+
+pub(super) fn operator_run_liveness_state(run: &OperatorRunStatus) -> String {
+	if matches!(run.process_liveness_reason.as_deref(), Some("host_boot_id_mismatch")) {
+		return String::from("host_boot_mismatch");
+	}
+	if run.process_alive == Some(true) {
+		return String::from("process_alive");
+	}
+	if run.process_alive == Some(false)
+		|| matches!(run.execution_liveness.as_str(), "not_running" | "process_identity_mismatch")
+	{
+		return String::from("not_running");
+	}
+	if matches!(run.thread_status.as_deref(), Some("active")) || !run.thread_active_flags.is_empty()
+	{
+		return String::from("thread_active");
+	}
+	if status_summary::operator_run_has_recent_app_server_execution(run) {
+		return String::from("protocol_recent");
+	}
+
+	String::from("unknown")
+}
+
+pub(super) fn operator_run_policy_state(run: &OperatorRunStatus) -> String {
+	if run.continuation_recovery.as_ref().is_some_and(|recovery| recovery.budget_exceeded) {
+		return String::from("continuation_recovery_churn_exceeded");
+	}
+
+	let Some(loop_status) = run.loop_status.as_ref() else {
+		return String::from("allowed");
+	};
+
+	if loop_status.decision_request.is_some() {
+		return String::from("authority_boundary_required");
+	}
+	if loop_status.autonomy == "human_required" {
+		return String::from("human_attention_required");
+	}
+
+	if let Some(recovery) = loop_status.architecture_recovery.as_ref() {
+		return if recovery.status == "active" {
+			String::from("architecture_recovery_pending")
+		} else {
+			String::from("human_attention_required")
+		};
+	}
+	if let Some(review) = loop_status.review.as_ref() {
+		return match review.status.as_str() {
+			"pending" => String::from("review_pending"),
+			"findings" => {
+				if review.checkpoint.as_ref().is_some_and(|checkpoint| {
+					checkpoint.nonclean_rounds >= REVIEW_POLICY_CONVERGENCE_BUDGET
+				}) {
+					String::from("review_churn_exceeded")
+				} else {
+					String::from("review_findings")
+				}
+			},
+			"blocked" | "needs_architecture_review" => String::from("human_attention_required"),
+			_ => String::from("allowed"),
+		};
+	}
+
+	String::from("allowed")
+}
+
+pub(super) fn operator_run_terminalization_state(
+	run: &OperatorRunStatus,
+	liveness_state: &str,
+) -> String {
+	if matches!(run.status.as_str(), "cleanup_complete" | "merged_closeout_reconciled")
+		|| matches!(run.current_operation.as_str(), "ledger_outcome")
+			&& matches!(run.phase.as_str(), "completed")
+	{
+		return String::from("cleanup_complete");
+	}
+	if matches!(run.phase.as_str(), "completed" | "failed" | "terminated")
+		&& !run.run_lease
+		&& matches!(liveness_state, "not_running" | "unknown")
+	{
+		return String::from("cleanup_complete");
+	}
+	if matches!(run.phase.as_str(), "completed" | "failed" | "terminated") {
+		return String::from("barrier_started");
+	}
+
+	String::from("none")
+}
+
+pub(super) fn operator_run_lane_control_conditions(
+	run: &OperatorRunStatus,
+	liveness_state: &str,
+	policy_state: &str,
+) -> Vec<String> {
+	let mut conditions = Vec::new();
+
+	if !run.run_lease
+		&& matches!(run.attempt_status.as_str(), "starting" | "running" | "continuation_pending")
+	{
+		conditions.push(String::from("run_lease_missing"));
+	}
+	if matches!(run.attempt_status.as_str(), "failed" | "interrupted" | "stalled" | "succeeded")
+		&& matches!(liveness_state, "process_alive" | "thread_active" | "protocol_recent")
+	{
+		conditions.push(String::from("terminal_attempt_has_live_evidence"));
+	}
+	if liveness_state == "host_boot_mismatch" {
+		conditions.push(String::from("host_boot_id_mismatch"));
+	}
+	if policy_state == "review_churn_exceeded" {
+		conditions.push(String::from("review_churn_threshold_exceeded"));
+	}
+	if policy_state == "continuation_recovery_churn_exceeded" {
+		conditions.push(String::from("continuation_recovery_budget_exceeded"));
+	}
+	if matches!(policy_state, "authority_boundary_required" | "human_attention_required") {
+		conditions.push(String::from("policy_requires_human_attention"));
+	}
+
+	conditions
+}
+
+pub(super) fn operator_run_lane_control_next_action(
+	run: &OperatorRunStatus,
+	ownership_state: &str,
+	liveness_state: &str,
+	policy_state: &str,
+	terminalization_state: &str,
+) -> String {
+	if policy_state == "review_churn_exceeded" {
+		return String::from("start_architecture_recovery_or_stop_for_human_attention");
+	}
+	if policy_state == "continuation_recovery_churn_exceeded" {
+		return String::from("stop_auto_continuation_and_request_architecture_recovery");
+	}
+	if matches!(policy_state, "authority_boundary_required" | "human_attention_required") {
+		return String::from("resolve_policy_stop_before_mutating_lane");
+	}
+	if ownership_state == "orphaned_live_thread" {
+		return String::from("inspect_or_interrupt_orphaned_live_thread");
+	}
+	if liveness_state == "host_boot_mismatch" {
+		return String::from("inspect_recovery_evidence");
+	}
+	if terminalization_state != "none" && terminalization_state != "cleanup_complete" {
+		return String::from("finish_terminalization");
+	}
+	if ownership_state == "leased_run" {
+		if let Some(next_action) =
+			run.loop_status.as_ref().and_then(|loop_status| loop_status.next_action.clone())
+		{
+			return next_action;
+		}
+
+		return String::from("continue_owned_attempt");
+	}
+	if ownership_state == "continuation_pending" {
+		return String::from("wait_for_continuation_reentry");
+	}
+	if ownership_state == "closed" {
+		return String::from("no_action");
+	}
+
+	if let Some(next_action) =
+		run.loop_status.as_ref().and_then(|loop_status| loop_status.next_action.clone())
+	{
+		return next_action;
+	}
+
+	String::from("inspect_lane_state")
+}

--- a/apps/decodex/src/orchestrator/status_run_projection/run/lifecycle.rs
+++ b/apps/decodex/src/orchestrator/status_run_projection/run/lifecycle.rs
@@ -1,0 +1,93 @@
+use crate::orchestrator::status_process_liveness;
+use crate::orchestrator::status_run_projection::runtime;
+use crate::orchestrator::{
+	OperatorRunAppServerState, OperatorRunLifecycleProjection, OperatorRunProtocolSummary,
+	OperatorRunTiming, OperatorTerminalFinalizeProjection, ProjectRunStatus, RunActivityMarker,
+};
+
+pub(super) fn operator_run_lifecycle_projection(
+	run: &ProjectRunStatus,
+	marker: Option<&RunActivityMarker>,
+	terminal_finalize_projection: Option<OperatorTerminalFinalizeProjection>,
+	timing: &OperatorRunTiming,
+	app_server_state: &OperatorRunAppServerState,
+	protocol_summary: &OperatorRunProtocolSummary,
+	now_unix_epoch: i64,
+) -> OperatorRunLifecycleProjection {
+	let marker_current_operation = marker.and_then(RunActivityMarker::current_operation);
+	let status = terminal_finalize_projection
+		.map(|projection| projection.status.to_owned())
+		.unwrap_or_else(|| {
+			runtime::operator_run_visible_status(
+				run.status(),
+				app_server_state,
+				protocol_summary,
+				timing,
+				marker_current_operation,
+			)
+		});
+	let status_projection_reason = if terminal_finalize_projection.is_some() {
+		None
+	} else {
+		runtime::operator_run_status_projection_reason(
+			run.status(),
+			&status,
+			app_server_state,
+			protocol_summary,
+			timing,
+			marker_current_operation,
+		)
+	};
+	let (retry_kind, retry_ready_at_unix_epoch) = runtime::visible_operator_run_retry_schedule(
+		&status,
+		marker.and_then(RunActivityMarker::retry_kind),
+		marker.and_then(RunActivityMarker::retry_ready_at_unix_epoch),
+		now_unix_epoch,
+	);
+	let (phase, wait_reason) = if let Some(projection) = terminal_finalize_projection {
+		(String::from(projection.phase), Some(String::from(projection.wait_reason)))
+	} else {
+		runtime::classify_operator_run_phase(
+			&status,
+			retry_kind.as_deref(),
+			retry_ready_at_unix_epoch,
+			now_unix_epoch,
+		)
+	};
+	let current_operation = terminal_finalize_projection
+		.map(|projection| projection.current_operation.to_owned())
+		.unwrap_or_else(|| {
+			runtime::classify_operator_run_operation(&phase, marker_current_operation)
+		});
+	let suspected_stall = terminal_finalize_projection.is_none()
+		&& runtime::operator_run_is_suspected_stall(
+			&phase,
+			timing.last_progress_unix_epoch,
+			now_unix_epoch,
+			status_process_liveness::run_activity_idle_timeout(marker),
+		);
+	let execution_liveness = if terminal_finalize_projection.is_some() {
+		String::from("not_running")
+	} else {
+		runtime::operator_run_execution_liveness(
+			&status,
+			timing,
+			app_server_state,
+			protocol_summary,
+		)
+	};
+	let run_lease = terminal_finalize_projection.is_none() && run.run_lease();
+
+	OperatorRunLifecycleProjection {
+		status,
+		status_projection_reason,
+		phase,
+		wait_reason,
+		current_operation,
+		suspected_stall,
+		execution_liveness,
+		run_lease,
+		retry_kind,
+		retry_ready_at_unix_epoch,
+	}
+}

--- a/apps/decodex/src/orchestrator/status_run_projection/run/phase.rs
+++ b/apps/decodex/src/orchestrator/status_run_projection/run/phase.rs
@@ -1,0 +1,167 @@
+use serde_json::Value;
+
+use crate::orchestrator::{
+	OperatorPhaseAcceptanceStatus, PHASE_ACCEPTANCE_CHECK_EVENT_TYPE, PrivateExecutionEvent,
+	ProtocolActivitySummary, RUN_OPERATION_REVIEW_WRITEBACK, TERMINAL_GUARDED_RUN_STATUS,
+};
+
+pub(super) fn operator_run_active_goal_phase(events: &[PrivateExecutionEvent]) -> Option<String> {
+	for event in events.iter().rev() {
+		if matches!(event.event_type(), "phase_goal_completed" | "phase_goal_transition") {
+			return None;
+		}
+		if !matches!(event.event_type(), "phase_goal_set" | "phase_goal_status") {
+			continue;
+		}
+
+		let payload = event.payload();
+		let nested = payload.get("payload").unwrap_or(payload);
+		let status = nested.get("status").or_else(|| payload.get("status")).and_then(Value::as_str);
+
+		if status.is_some_and(|value| matches!(value, "complete" | "completed" | "blocked")) {
+			return None;
+		}
+
+		return nested
+			.get("phase")
+			.or_else(|| payload.get("phase"))
+			.and_then(Value::as_str)
+			.map(str::to_owned);
+	}
+
+	None
+}
+
+pub(super) fn operator_run_public_progress_phase(
+	events: &[PrivateExecutionEvent],
+) -> Option<String> {
+	events.iter().rev().find_map(|event| {
+		(event.event_type() == "progress_checkpoint")
+			.then_some(event.payload())
+			.and_then(|payload| payload.get("phase"))
+			.and_then(Value::as_str)
+			.map(str::to_owned)
+	})
+}
+
+pub(super) fn operator_run_phase_acceptance_status(
+	events: &[PrivateExecutionEvent],
+) -> Option<OperatorPhaseAcceptanceStatus> {
+	let event = events
+		.iter()
+		.rev()
+		.find(|event| event.event_type() == PHASE_ACCEPTANCE_CHECK_EVENT_TYPE)?;
+	let payload = event.payload();
+	let phase = payload.get("phase")?.as_str()?.to_owned();
+	let decision = payload.get("decision")?.as_str()?.to_owned();
+	let reason_code = payload.get("reason_code")?.as_str()?.to_owned();
+	let objective_covered = payload
+		.get("objective_coverage")
+		.and_then(|objective| objective.get("covered"))
+		.and_then(Value::as_bool)
+		.unwrap_or(false);
+	let effective_delta_present = payload
+		.get("effective_delta")
+		.and_then(|delta| delta.get("present"))
+		.and_then(Value::as_bool)
+		.unwrap_or(false);
+	let changed_surfaces = payload
+		.get("effective_delta")
+		.and_then(|delta| delta.get("changed_surfaces"))
+		.and_then(Value::as_array)
+		.into_iter()
+		.flatten()
+		.filter_map(Value::as_str)
+		.map(str::to_owned)
+		.collect();
+	let non_goal_passed = payload
+		.get("non_goal_check")
+		.and_then(|check| check.get("passed"))
+		.and_then(Value::as_bool)
+		.unwrap_or(false);
+	let validation_passed = payload
+		.get("validation_evidence")
+		.and_then(|evidence| evidence.get("repo_gate_passed"))
+		.and_then(Value::as_bool)
+		.unwrap_or(false);
+
+	Some(OperatorPhaseAcceptanceStatus {
+		phase,
+		decision,
+		reason_code,
+		objective_covered,
+		effective_delta_present,
+		changed_surfaces,
+		non_goal_passed,
+		validation_passed,
+		recorded_at: event.recorded_at().to_owned(),
+		run_id: event.run_id().to_owned(),
+		attempt_number: event.attempt_number(),
+		next_action: payload
+			.get("next_action")
+			.and_then(Value::as_str)
+			.unwrap_or("inspect_phase_acceptance_check")
+			.to_owned(),
+	})
+}
+
+pub(super) fn operator_run_wait_reason(
+	phase: &str,
+	wait_reason: Option<String>,
+	protocol_activity: Option<&ProtocolActivitySummary>,
+) -> Option<String> {
+	if wait_reason.is_some() || phase != "executing" {
+		return wait_reason;
+	}
+
+	protocol_activity
+		.and_then(|summary| summary.waiting_reason.clone())
+		.filter(|reason| reason != "turn_completed")
+}
+
+pub(super) fn operator_run_default_review_phase(
+	status: &str,
+	phase: &str,
+	current_operation: &str,
+) -> Option<&'static str> {
+	if operator_run_has_terminal_lifecycle(status, phase, current_operation) {
+		return None;
+	}
+	if current_operation == RUN_OPERATION_REVIEW_WRITEBACK {
+		return Some("handoff");
+	}
+
+	None
+}
+
+pub(super) fn operator_run_lifecycle_loop_summary(
+	status: &str,
+	phase: &str,
+	current_operation: &str,
+) -> Option<String> {
+	operator_run_has_terminal_lifecycle(status, phase, current_operation)
+		.then(|| format!("terminal lifecycle: {status}"))
+}
+
+pub(super) fn operator_run_has_terminal_lifecycle(
+	status: &str,
+	phase: &str,
+	current_operation: &str,
+) -> bool {
+	phase == "completed"
+		|| phase == "terminal_pending"
+		|| current_operation == "ledger_outcome"
+		|| matches!(
+			status,
+			"succeeded"
+				| "failed" | "interrupted"
+				| "review_handoff_pending"
+				| "review_repair_pending"
+				| "closeout_pending"
+				| "manual_attention_pending"
+				| "cleanup_complete"
+				| "closeout" | "landed"
+				| "manual_attention"
+				| TERMINAL_GUARDED_RUN_STATUS
+		)
+}


### PR DESCRIPTION
## Summary
- Split operator run status projection helpers into flat Rust child modules for accessors, lane control, lifecycle projection, and phase derivation.
- Keep the existing run projection entrypoints in run.rs while removing the old glob import and avoiding mod.rs.

## Validation
- cargo check -p decodex --all-targets --all-features
- cargo test -p decodex --all-features running_lanes -- --nocapture --test-threads=1
- cargo test -p decodex --all-features lane_control -- --nocapture --test-threads=1
- cargo vstyle curate --language rust --workspace --all-features, filtered to changed files and RUST-STYLE-FILE-001
- git diff --check
- git ls-files 'apps/**/mod.rs' 'packages/**/mod.rs' | wc -l