### PR TITLE
Split tracker tool bridge modules

### DIFF
--- a/apps/decodex/src/agent/tracker_tool_bridge/tools.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools.rs
@@ -4,6 +4,8 @@ mod review_checkpoint;
 mod review_checkpoint_flow;
 mod tool_specs;
 
+use serde_json::{self, Value};
+
 use self::review_checkpoint::{
 	ReviewFindingPolicyUpdate, current_review_blocker_findings, non_empty_string_array_schema,
 	normalize_review_checkpoint_payload, review_checkpoint_checks_schema,
@@ -15,29 +17,24 @@ use self::review_checkpoint::{
 };
 use crate::{
 	agent::tracker_tool_bridge::{
-		self, AuthorityDecisionOptionArgs, AuthorityDecisionRequestArgs, DocsImpact,
-		DynamicToolCallResponse, DynamicToolSpec, ExecutionProgressPhase, ISSUE_COMMENT_TOOL_NAME,
-		ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME, ISSUE_LABEL_ADD_TOOL_NAME,
-		ISSUE_PROGRESS_CHECKPOINT_TOOL_NAME, ISSUE_REVIEW_CHECKPOINT_TOOL_NAME,
-		ISSUE_REVIEW_HANDOFF_TOOL_NAME, ISSUE_REVIEW_REPAIR_COMPLETE_TOOL_NAME,
-		ISSUE_TERMINAL_FINALIZE_TOOL_NAME, ISSUE_TRANSITION_TOOL_NAME, LabelArgs, LocalRepoDetails,
-		NormalizedProgressCheckpoint, NormalizedReviewCheckpointPayload, PendingReviewAction,
-		PendingReviewCompletion, ProgressCheckpointArgs, PullRequestDetails,
-		REVIEW_POLICY_CONVERGENCE_BUDGET, ReviewCheckpointArgs, ReviewExecutionMode,
-		ReviewHandoffArgs, ReviewHandoffContext, ReviewPolicyPhase, ReviewPolicyStatus,
-		RunCompletionDisposition, TerminalFinalizeArgs, TrackerToolBridge, TransitionArgs,
-	},
-	orchestrator::{
-		self, AUTHORITY_BOUNDARY_CHECK_EVENT_TYPE, AuthorityDecisionOption,
-		AuthorityDecisionRequestInput,
+		self, DocsImpact, DynamicToolCallResponse, DynamicToolSpec, ExecutionProgressPhase,
+		ISSUE_COMMENT_TOOL_NAME, ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME,
+		ISSUE_LABEL_ADD_TOOL_NAME, ISSUE_PROGRESS_CHECKPOINT_TOOL_NAME,
+		ISSUE_REVIEW_CHECKPOINT_TOOL_NAME, ISSUE_REVIEW_HANDOFF_TOOL_NAME,
+		ISSUE_REVIEW_REPAIR_COMPLETE_TOOL_NAME, ISSUE_TERMINAL_FINALIZE_TOOL_NAME,
+		ISSUE_TRANSITION_TOOL_NAME, LabelArgs, LocalRepoDetails, NormalizedProgressCheckpoint,
+		NormalizedReviewCheckpointPayload, PendingReviewAction, PendingReviewCompletion,
+		ProgressCheckpointArgs, PullRequestDetails, REVIEW_POLICY_CONVERGENCE_BUDGET,
+		ReviewCheckpointArgs, ReviewExecutionMode, ReviewHandoffArgs, ReviewHandoffContext,
+		ReviewPolicyPhase, ReviewPolicyStatus, RunCompletionDisposition, TerminalFinalizeArgs,
+		TrackerToolBridge, TransitionArgs,
 	},
 	state::StateStore,
 	tracker::{
-		self, public_text, records,
-		records::{LinearExecutionEventIdentity, LinearExecutionEventRecord},
+		self,
+		records::{self, LinearExecutionEventIdentity, LinearExecutionEventRecord},
 	},
 };
-use serde_json::{self, Value};
 
 pub(super) const REVIEW_COMPLETION_INTENT_EVENT_TYPE: &str = "review_completion_intent";
 

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools/manual_attention.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools/manual_attention.rs
@@ -1,12 +1,24 @@
-use super::{
-	AUTHORITY_BOUNDARY_CHECK_EVENT_TYPE, AuthorityDecisionOption, AuthorityDecisionOptionArgs,
-	AuthorityDecisionRequestArgs, AuthorityDecisionRequestInput, COMMENT_KIND_MANUAL_ATTENTION,
-	DynamicToolCallResponse, ISSUE_COMMENT_TOOL_NAME, ISSUE_LABEL_ADD_TOOL_NAME,
-	LinearExecutionEventIdentity, LinearExecutionEventRecord, MANUAL_ATTENTION_TERMINAL_PATH,
-	ReviewHandoffContext, StateStore, TrackerToolBridge, Value, orchestrator, public_text, records,
-	serde_json, tracker, tracker_tool_bridge,
+mod comment_body;
+mod normalize;
+
+use serde_json::{self, Value};
+
+use crate::agent::tracker_tool_bridge::tools::{
+	COMMENT_KIND_MANUAL_ATTENTION, MANUAL_ATTENTION_TERMINAL_PATH,
 };
-use crate::agent::tracker_tool_bridge::CommentArgs;
+use crate::agent::tracker_tool_bridge::{
+	self, CommentArgs, DynamicToolCallResponse, ISSUE_COMMENT_TOOL_NAME, ISSUE_LABEL_ADD_TOOL_NAME,
+	ReviewHandoffContext, TrackerToolBridge,
+};
+use crate::orchestrator::{
+	self, AUTHORITY_BOUNDARY_CHECK_EVENT_TYPE, AuthorityDecisionOption,
+	AuthorityDecisionRequestInput,
+};
+use crate::state::StateStore;
+use crate::tracker::{
+	self,
+	records::{self, LinearExecutionEventIdentity, LinearExecutionEventRecord},
+};
 
 #[derive(Debug)]
 struct NormalizedManualAttentionComment {
@@ -90,7 +102,7 @@ impl<'a> TrackerToolBridge<'a> {
 				));
 			},
 		};
-		let comment = match Self::normalize_manual_attention_comment(parsed) {
+		let comment = match normalize::normalize_manual_attention_comment(parsed) {
 			Ok(comment) => comment,
 			Err(error) => return DynamicToolCallResponse::failure(error),
 		};
@@ -105,7 +117,7 @@ impl<'a> TrackerToolBridge<'a> {
 		}
 
 		let record = self.manual_attention_execution_event(review_context, &comment);
-		let body = format_manual_attention_comment(review_context, &comment);
+		let body = comment_body::format_manual_attention_comment(review_context, &comment);
 		let projection = match tracker::prepare_linear_execution_event_comment(
 			&body,
 			&record,
@@ -149,45 +161,6 @@ impl<'a> TrackerToolBridge<'a> {
 		}
 	}
 
-	fn normalize_manual_attention_comment(
-		parsed: CommentArgs,
-	) -> Result<NormalizedManualAttentionComment, String> {
-		let error_class = normalize_required_comment_field(parsed.error_class, "error_class")?;
-		let next_action = normalize_required_comment_field(parsed.next_action, "next_action")?;
-		let blockers = tracker_tool_bridge::normalize_progress_list(parsed.blockers);
-		let evidence = tracker_tool_bridge::normalize_progress_list(parsed.evidence);
-		let failed_command =
-			tracker_tool_bridge::normalize_optional_progress_field(parsed.failed_command);
-		let raw_error = tracker_tool_bridge::normalize_optional_progress_field(parsed.raw_error);
-		let summary = tracker_tool_bridge::normalize_optional_progress_field(parsed.summary);
-		let decision_request =
-			parsed.decision_request.map(Self::normalize_authority_decision_request).transpose()?;
-
-		validate_manual_attention_error_class(&error_class)?;
-
-		if blockers.is_empty() {
-			return Err(format!(
-				"`{ISSUE_COMMENT_TOOL_NAME}` kind `{COMMENT_KIND_MANUAL_ATTENTION}` requires at least one public `blockers` item."
-			));
-		}
-		if evidence.is_empty() {
-			return Err(format!(
-				"`{ISSUE_COMMENT_TOOL_NAME}` kind `{COMMENT_KIND_MANUAL_ATTENTION}` requires at least one public `evidence` item."
-			));
-		}
-
-		Ok(NormalizedManualAttentionComment {
-			error_class,
-			next_action,
-			blockers,
-			evidence,
-			failed_command,
-			raw_error,
-			summary,
-			decision_request,
-		})
-	}
-
 	fn apply_manual_attention_label(&self) -> Result<(), String> {
 		let label = self.workflow.frontmatter().tracker().needs_attention_label();
 		let current_issue = match self.refreshed_issue_snapshot() {
@@ -216,103 +189,6 @@ impl<'a> TrackerToolBridge<'a> {
 		)?;
 
 		Ok(())
-	}
-
-	fn normalize_authority_decision_request(
-		parsed: AuthorityDecisionRequestArgs,
-	) -> Result<NormalizedAuthorityDecisionRequest, String> {
-		let decision_request_id = normalize_required_decision_request_field(
-			Some(parsed.decision_request_id),
-			"decision_request_id",
-		)?;
-		let reason_code =
-			normalize_required_decision_request_field(Some(parsed.reason_code), "reason_code")?;
-		let boundary_type =
-			normalize_required_decision_request_field(Some(parsed.boundary_type), "boundary_type")?;
-		let proposed_change = normalize_required_decision_request_field(
-			Some(parsed.proposed_change),
-			"proposed_change",
-		)?;
-		let why_exceeds_authority = normalize_required_decision_request_field(
-			Some(parsed.why_exceeds_authority),
-			"why_exceeds_authority",
-		)?;
-		let recommendation = normalize_required_decision_request_field(
-			Some(parsed.recommendation),
-			"recommendation",
-		)?;
-		let resume_condition = normalize_required_decision_request_field(
-			Some(parsed.resume_condition),
-			"resume_condition",
-		)?;
-		let options = parsed
-			.options
-			.into_iter()
-			.map(Self::normalize_authority_decision_option)
-			.collect::<Result<Vec<_>, _>>()?;
-		let retained_worktree_evidence =
-			tracker_tool_bridge::normalize_progress_list(parsed.retained_worktree_evidence);
-		let retained_diff_evidence =
-			tracker_tool_bridge::normalize_progress_list(parsed.retained_diff_evidence);
-		let recovery_attempt_context =
-			tracker_tool_bridge::normalize_progress_list(parsed.recovery_attempt_context);
-
-		if parsed.boundary_check_id < 1 {
-			return Err(String::from(
-				"`decision_request.boundary_check_id` must be a positive private evidence record id.",
-			));
-		}
-
-		validate_public_error_class(&reason_code)?;
-		validate_public_error_class(&boundary_type)?;
-
-		if options.is_empty() {
-			return Err(String::from(
-				"`decision_request.options` must include at least one public option.",
-			));
-		}
-
-		validate_public_decision_request_text(
-			&decision_request_id,
-			&proposed_change,
-			&why_exceeds_authority,
-			&options,
-			&recommendation,
-			&resume_condition,
-		)?;
-
-		Ok(NormalizedAuthorityDecisionRequest {
-			boundary_check_id: parsed.boundary_check_id,
-			decision_request_id,
-			reason_code,
-			boundary_type,
-			proposed_change,
-			why_exceeds_authority,
-			options,
-			recommendation,
-			resume_condition,
-			retained_worktree_evidence,
-			retained_diff_evidence,
-			recovery_attempt_context,
-		})
-	}
-
-	fn normalize_authority_decision_option(
-		parsed: AuthorityDecisionOptionArgs,
-	) -> Result<NormalizedAuthorityDecisionOption, String> {
-		let label = normalize_required_decision_request_field(Some(parsed.label), "option.label")?;
-		let description = normalize_required_decision_request_field(
-			Some(parsed.description),
-			"option.description",
-		)?;
-
-		validate_public_decision_request_field("decision_request.option.label", &label)?;
-		validate_public_decision_request_field(
-			"decision_request.option.description",
-			&description,
-		)?;
-
-		Ok(NormalizedAuthorityDecisionOption { label, description })
 	}
 
 	fn append_private_authority_decision_request(
@@ -466,182 +342,4 @@ impl<'a> TrackerToolBridge<'a> {
 
 		record
 	}
-}
-
-fn normalize_required_comment_field(
-	value: Option<String>,
-	field_name: &str,
-) -> Result<String, String> {
-	let value = tracker_tool_bridge::normalize_optional_progress_field(value).ok_or_else(|| {
-		format!(
-			"`{ISSUE_COMMENT_TOOL_NAME}` kind `{COMMENT_KIND_MANUAL_ATTENTION}` requires `{field_name}`."
-		)
-	})?;
-
-	Ok(value)
-}
-
-fn normalize_required_decision_request_field(
-	value: Option<String>,
-	field_name: &str,
-) -> Result<String, String> {
-	tracker_tool_bridge::normalize_optional_progress_field(value)
-		.ok_or_else(|| format!("`decision_request.{field_name}` must be present and non-empty."))
-}
-
-fn validate_public_decision_request_text(
-	decision_request_id: &str,
-	proposed_change: &str,
-	why_exceeds_authority: &str,
-	options: &[NormalizedAuthorityDecisionOption],
-	recommendation: &str,
-	resume_condition: &str,
-) -> Result<(), String> {
-	validate_public_decision_request_field(
-		"decision_request.decision_request_id",
-		decision_request_id,
-	)?;
-	validate_public_decision_request_field("decision_request.proposed_change", proposed_change)?;
-	validate_public_decision_request_field(
-		"decision_request.why_exceeds_authority",
-		why_exceeds_authority,
-	)?;
-	validate_public_decision_request_field("decision_request.recommendation", recommendation)?;
-	validate_public_decision_request_field("decision_request.resume_condition", resume_condition)?;
-
-	for option in options {
-		validate_public_decision_request_field("decision_request.option.label", &option.label)?;
-		validate_public_decision_request_field(
-			"decision_request.option.description",
-			&option.description,
-		)?;
-	}
-
-	Ok(())
-}
-
-fn validate_public_decision_request_field(field_name: &str, value: &str) -> Result<(), String> {
-	public_text::validate_public_text_field(field_name, value).map_err(|error| error.to_string())
-}
-
-fn validate_public_error_class(error_class: &str) -> Result<(), String> {
-	let mut chars = error_class.chars();
-	let Some(first) = chars.next() else {
-		return Err(String::from("`error_class` must be a public snake_case identifier."));
-	};
-
-	if !first.is_ascii_lowercase()
-		|| !chars.all(|character| {
-			character.is_ascii_lowercase() || character.is_ascii_digit() || character == '_'
-		}) {
-		return Err(String::from("`error_class` must be a public snake_case identifier."));
-	}
-
-	Ok(())
-}
-
-fn validate_manual_attention_error_class(error_class: &str) -> Result<(), String> {
-	validate_public_error_class(error_class)?;
-
-	if is_runtime_owned_manual_attention_error_class(error_class) {
-		return Err(format!(
-			"`{ISSUE_COMMENT_TOOL_NAME}` kind `{COMMENT_KIND_MANUAL_ATTENTION}` cannot use runtime-owned error class `{error_class}`; keep repairing, retrying, or letting Decodex retain the lane, and use a human-owned blocker class only when automation cannot clear the blocker."
-		));
-	}
-
-	Ok(())
-}
-
-fn is_runtime_owned_manual_attention_error_class(error_class: &str) -> bool {
-	matches!(
-		error_class,
-		"retryable_execution_failure"
-			| "repo_gate_canonicalize_failed"
-			| "repo_gate_verify_failed"
-			| "repo_gate_baseline_failed"
-			| "repo_gate_preexisting_baseline_failed"
-			| "repo_gate_global_baseline_failed"
-			| "repo_gate_tracked_rewrites_left"
-			| "repo_gate_git_lock_contention"
-			| "stalled_run_detected"
-			| "app_server_zero_evidence_start_failed"
-			| "app_server_plugin_list_timeout"
-			| "app_server_preflight_timeout"
-			| "app_server_transport_disconnected"
-			| "phase_goal_terminal_path_missing"
-			| "app_server_dynamic_tool_protocol_failure"
-			| "app_server_dynamic_tool_failed"
-			| "app_server_turn_failed"
-			| "app_server_usage_limit_exceeded"
-	) || runtime_owned_baseline_error_class(error_class)
-}
-
-fn runtime_owned_baseline_error_class(error_class: &str) -> bool {
-	[
-		"baseline",
-		"preexisting",
-		"pre_existing",
-		"repo_wide",
-		"repository_wide",
-		"global_baseline",
-		"docs_okf",
-	]
-	.iter()
-	.any(|pattern| error_class.contains(pattern))
-}
-
-fn format_manual_attention_comment(
-	review_context: &ReviewHandoffContext,
-	comment: &NormalizedManualAttentionComment,
-) -> String {
-	let mut lines = vec![
-		String::from("decodex run needs manual attention"),
-		String::new(),
-		format!("- run_id: `{}`", review_context.run_id),
-		format!(
-			"- run_sequence_attempt: `{}` (not retry-budget count)",
-			review_context.attempt_number
-		),
-		format!("- reported_at: `{}`", tracker_tool_bridge::current_timestamp()),
-		format!("- branch: `{}`", review_context.branch_name),
-		format!("- worktree_path: `{}`", review_context.worktree_path),
-		format!("- comment_kind: `{COMMENT_KIND_MANUAL_ATTENTION}`"),
-		format!("- error_class: `{}`", comment.error_class),
-		format!("- next_action: {}", comment.next_action),
-	];
-
-	if let Some(summary) = comment.summary.as_deref() {
-		lines.push(format!("- summary: {summary}"));
-	}
-
-	for blocker in &comment.blockers {
-		lines.push(format!("- blocker: {blocker}"));
-	}
-	for evidence in &comment.evidence {
-		lines.push(format!("- evidence: {evidence}"));
-	}
-
-	if let Some(request) = comment.decision_request.as_ref() {
-		lines.push(String::from("- decision_request: authority_boundary"));
-		lines.push(format!("- decision_request_id: `{}`", request.decision_request_id));
-		lines.push(format!("- decision_reason: `{}`", request.reason_code));
-		lines.push(format!("- boundary: `{}`", request.boundary_type));
-		lines.push(format!("- proposed_change: {}", request.proposed_change));
-		lines.push(format!("- why_exceeds_authority: {}", request.why_exceeds_authority));
-
-		for option in &request.options {
-			lines.push(format!("- decision_option: `{}` - {}", option.label, option.description));
-		}
-
-		lines.push(format!("- recommendation: {}", request.recommendation));
-		lines.push(format!("- resume_condition: {}", request.resume_condition));
-	}
-	if let Some(failed_command) = comment.failed_command.as_deref() {
-		lines.push(format!("- failed_command: {failed_command}"));
-	}
-	if let Some(raw_error) = comment.raw_error.as_deref() {
-		lines.push(format!("- raw_error: {raw_error}"));
-	}
-
-	lines.join("\n")
 }

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools/manual_attention/comment_body.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools/manual_attention/comment_body.rs
@@ -1,0 +1,60 @@
+use crate::agent::tracker_tool_bridge::tools::{
+	COMMENT_KIND_MANUAL_ATTENTION, manual_attention::NormalizedManualAttentionComment,
+};
+use crate::agent::tracker_tool_bridge::{self, ReviewHandoffContext};
+
+pub(super) fn format_manual_attention_comment(
+	review_context: &ReviewHandoffContext,
+	comment: &NormalizedManualAttentionComment,
+) -> String {
+	let mut lines = vec![
+		String::from("decodex run needs manual attention"),
+		String::new(),
+		format!("- run_id: `{}`", review_context.run_id),
+		format!(
+			"- run_sequence_attempt: `{}` (not retry-budget count)",
+			review_context.attempt_number
+		),
+		format!("- reported_at: `{}`", tracker_tool_bridge::current_timestamp()),
+		format!("- branch: `{}`", review_context.branch_name),
+		format!("- worktree_path: `{}`", review_context.worktree_path),
+		format!("- comment_kind: `{COMMENT_KIND_MANUAL_ATTENTION}`"),
+		format!("- error_class: `{}`", comment.error_class),
+		format!("- next_action: {}", comment.next_action),
+	];
+
+	if let Some(summary) = comment.summary.as_deref() {
+		lines.push(format!("- summary: {summary}"));
+	}
+
+	for blocker in &comment.blockers {
+		lines.push(format!("- blocker: {blocker}"));
+	}
+	for evidence in &comment.evidence {
+		lines.push(format!("- evidence: {evidence}"));
+	}
+
+	if let Some(request) = comment.decision_request.as_ref() {
+		lines.push(String::from("- decision_request: authority_boundary"));
+		lines.push(format!("- decision_request_id: `{}`", request.decision_request_id));
+		lines.push(format!("- decision_reason: `{}`", request.reason_code));
+		lines.push(format!("- boundary: `{}`", request.boundary_type));
+		lines.push(format!("- proposed_change: {}", request.proposed_change));
+		lines.push(format!("- why_exceeds_authority: {}", request.why_exceeds_authority));
+
+		for option in &request.options {
+			lines.push(format!("- decision_option: `{}` - {}", option.label, option.description));
+		}
+
+		lines.push(format!("- recommendation: {}", request.recommendation));
+		lines.push(format!("- resume_condition: {}", request.resume_condition));
+	}
+	if let Some(failed_command) = comment.failed_command.as_deref() {
+		lines.push(format!("- failed_command: {failed_command}"));
+	}
+	if let Some(raw_error) = comment.raw_error.as_deref() {
+		lines.push(format!("- raw_error: {raw_error}"));
+	}
+
+	lines.join("\n")
+}

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools/manual_attention/normalize.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools/manual_attention/normalize.rs
@@ -1,0 +1,261 @@
+use crate::agent::tracker_tool_bridge::tools::{
+	COMMENT_KIND_MANUAL_ATTENTION,
+	manual_attention::{
+		NormalizedAuthorityDecisionOption, NormalizedAuthorityDecisionRequest,
+		NormalizedManualAttentionComment,
+	},
+};
+use crate::agent::tracker_tool_bridge::{
+	self, AuthorityDecisionOptionArgs, AuthorityDecisionRequestArgs, CommentArgs,
+	ISSUE_COMMENT_TOOL_NAME,
+};
+use crate::tracker::public_text;
+
+pub(super) fn normalize_manual_attention_comment(
+	parsed: CommentArgs,
+) -> Result<NormalizedManualAttentionComment, String> {
+	let error_class = normalize_required_comment_field(parsed.error_class, "error_class")?;
+	let next_action = normalize_required_comment_field(parsed.next_action, "next_action")?;
+	let blockers = tracker_tool_bridge::normalize_progress_list(parsed.blockers);
+	let evidence = tracker_tool_bridge::normalize_progress_list(parsed.evidence);
+	let failed_command =
+		tracker_tool_bridge::normalize_optional_progress_field(parsed.failed_command);
+	let raw_error = tracker_tool_bridge::normalize_optional_progress_field(parsed.raw_error);
+	let summary = tracker_tool_bridge::normalize_optional_progress_field(parsed.summary);
+	let decision_request =
+		parsed.decision_request.map(normalize_authority_decision_request).transpose()?;
+
+	validate_manual_attention_error_class(&error_class)?;
+
+	if blockers.is_empty() {
+		return Err(format!(
+			"`{ISSUE_COMMENT_TOOL_NAME}` kind `{COMMENT_KIND_MANUAL_ATTENTION}` requires at least one public `blockers` item."
+		));
+	}
+	if evidence.is_empty() {
+		return Err(format!(
+			"`{ISSUE_COMMENT_TOOL_NAME}` kind `{COMMENT_KIND_MANUAL_ATTENTION}` requires at least one public `evidence` item."
+		));
+	}
+
+	Ok(NormalizedManualAttentionComment {
+		error_class,
+		next_action,
+		blockers,
+		evidence,
+		failed_command,
+		raw_error,
+		summary,
+		decision_request,
+	})
+}
+
+fn normalize_authority_decision_request(
+	parsed: AuthorityDecisionRequestArgs,
+) -> Result<NormalizedAuthorityDecisionRequest, String> {
+	let decision_request_id = normalize_required_decision_request_field(
+		Some(parsed.decision_request_id),
+		"decision_request_id",
+	)?;
+	let reason_code =
+		normalize_required_decision_request_field(Some(parsed.reason_code), "reason_code")?;
+	let boundary_type =
+		normalize_required_decision_request_field(Some(parsed.boundary_type), "boundary_type")?;
+	let proposed_change =
+		normalize_required_decision_request_field(Some(parsed.proposed_change), "proposed_change")?;
+	let why_exceeds_authority = normalize_required_decision_request_field(
+		Some(parsed.why_exceeds_authority),
+		"why_exceeds_authority",
+	)?;
+	let recommendation =
+		normalize_required_decision_request_field(Some(parsed.recommendation), "recommendation")?;
+	let resume_condition = normalize_required_decision_request_field(
+		Some(parsed.resume_condition),
+		"resume_condition",
+	)?;
+	let options = parsed
+		.options
+		.into_iter()
+		.map(normalize_authority_decision_option)
+		.collect::<Result<Vec<_>, _>>()?;
+	let retained_worktree_evidence =
+		tracker_tool_bridge::normalize_progress_list(parsed.retained_worktree_evidence);
+	let retained_diff_evidence =
+		tracker_tool_bridge::normalize_progress_list(parsed.retained_diff_evidence);
+	let recovery_attempt_context =
+		tracker_tool_bridge::normalize_progress_list(parsed.recovery_attempt_context);
+
+	if parsed.boundary_check_id < 1 {
+		return Err(String::from(
+			"`decision_request.boundary_check_id` must be a positive private evidence record id.",
+		));
+	}
+
+	validate_public_error_class(&reason_code)?;
+	validate_public_error_class(&boundary_type)?;
+
+	if options.is_empty() {
+		return Err(String::from(
+			"`decision_request.options` must include at least one public option.",
+		));
+	}
+
+	validate_public_decision_request_text(
+		&decision_request_id,
+		&proposed_change,
+		&why_exceeds_authority,
+		&options,
+		&recommendation,
+		&resume_condition,
+	)?;
+
+	Ok(NormalizedAuthorityDecisionRequest {
+		boundary_check_id: parsed.boundary_check_id,
+		decision_request_id,
+		reason_code,
+		boundary_type,
+		proposed_change,
+		why_exceeds_authority,
+		options,
+		recommendation,
+		resume_condition,
+		retained_worktree_evidence,
+		retained_diff_evidence,
+		recovery_attempt_context,
+	})
+}
+
+fn normalize_authority_decision_option(
+	parsed: AuthorityDecisionOptionArgs,
+) -> Result<NormalizedAuthorityDecisionOption, String> {
+	let label = normalize_required_decision_request_field(Some(parsed.label), "option.label")?;
+	let description =
+		normalize_required_decision_request_field(Some(parsed.description), "option.description")?;
+
+	validate_public_decision_request_field("decision_request.option.label", &label)?;
+	validate_public_decision_request_field("decision_request.option.description", &description)?;
+
+	Ok(NormalizedAuthorityDecisionOption { label, description })
+}
+
+fn normalize_required_comment_field(
+	value: Option<String>,
+	field_name: &str,
+) -> Result<String, String> {
+	let value = tracker_tool_bridge::normalize_optional_progress_field(value).ok_or_else(|| {
+		format!(
+			"`{ISSUE_COMMENT_TOOL_NAME}` kind `{COMMENT_KIND_MANUAL_ATTENTION}` requires `{field_name}`."
+		)
+	})?;
+
+	Ok(value)
+}
+
+fn normalize_required_decision_request_field(
+	value: Option<String>,
+	field_name: &str,
+) -> Result<String, String> {
+	tracker_tool_bridge::normalize_optional_progress_field(value)
+		.ok_or_else(|| format!("`decision_request.{field_name}` must be present and non-empty."))
+}
+
+fn validate_public_decision_request_text(
+	decision_request_id: &str,
+	proposed_change: &str,
+	why_exceeds_authority: &str,
+	options: &[NormalizedAuthorityDecisionOption],
+	recommendation: &str,
+	resume_condition: &str,
+) -> Result<(), String> {
+	validate_public_decision_request_field(
+		"decision_request.decision_request_id",
+		decision_request_id,
+	)?;
+	validate_public_decision_request_field("decision_request.proposed_change", proposed_change)?;
+	validate_public_decision_request_field(
+		"decision_request.why_exceeds_authority",
+		why_exceeds_authority,
+	)?;
+	validate_public_decision_request_field("decision_request.recommendation", recommendation)?;
+	validate_public_decision_request_field("decision_request.resume_condition", resume_condition)?;
+
+	for option in options {
+		validate_public_decision_request_field("decision_request.option.label", &option.label)?;
+		validate_public_decision_request_field(
+			"decision_request.option.description",
+			&option.description,
+		)?;
+	}
+
+	Ok(())
+}
+
+fn validate_public_decision_request_field(field_name: &str, value: &str) -> Result<(), String> {
+	public_text::validate_public_text_field(field_name, value).map_err(|error| error.to_string())
+}
+
+fn validate_public_error_class(error_class: &str) -> Result<(), String> {
+	let mut chars = error_class.chars();
+	let Some(first) = chars.next() else {
+		return Err(String::from("`error_class` must be a public snake_case identifier."));
+	};
+
+	if !first.is_ascii_lowercase()
+		|| !chars.all(|character| {
+			character.is_ascii_lowercase() || character.is_ascii_digit() || character == '_'
+		}) {
+		return Err(String::from("`error_class` must be a public snake_case identifier."));
+	}
+
+	Ok(())
+}
+
+fn validate_manual_attention_error_class(error_class: &str) -> Result<(), String> {
+	validate_public_error_class(error_class)?;
+
+	if is_runtime_owned_manual_attention_error_class(error_class) {
+		return Err(format!(
+			"`{ISSUE_COMMENT_TOOL_NAME}` kind `{COMMENT_KIND_MANUAL_ATTENTION}` cannot use runtime-owned error class `{error_class}`; keep repairing, retrying, or letting Decodex retain the lane, and use a human-owned blocker class only when automation cannot clear the blocker."
+		));
+	}
+
+	Ok(())
+}
+
+fn is_runtime_owned_manual_attention_error_class(error_class: &str) -> bool {
+	matches!(
+		error_class,
+		"retryable_execution_failure"
+			| "repo_gate_canonicalize_failed"
+			| "repo_gate_verify_failed"
+			| "repo_gate_baseline_failed"
+			| "repo_gate_preexisting_baseline_failed"
+			| "repo_gate_global_baseline_failed"
+			| "repo_gate_tracked_rewrites_left"
+			| "repo_gate_git_lock_contention"
+			| "stalled_run_detected"
+			| "app_server_zero_evidence_start_failed"
+			| "app_server_plugin_list_timeout"
+			| "app_server_preflight_timeout"
+			| "app_server_transport_disconnected"
+			| "phase_goal_terminal_path_missing"
+			| "app_server_dynamic_tool_protocol_failure"
+			| "app_server_dynamic_tool_failed"
+			| "app_server_turn_failed"
+			| "app_server_usage_limit_exceeded"
+	) || runtime_owned_baseline_error_class(error_class)
+}
+
+fn runtime_owned_baseline_error_class(error_class: &str) -> bool {
+	[
+		"baseline",
+		"preexisting",
+		"pre_existing",
+		"repo_wide",
+		"repository_wide",
+		"global_baseline",
+		"docs_okf",
+	]
+	.iter()
+	.any(|pattern| error_class.contains(pattern))
+}

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools/review_checkpoint/normalize.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools/review_checkpoint/normalize.rs
@@ -1,29 +1,20 @@
-use serde_json;
+mod contract;
+mod cost_control;
+
 use sha2::{Digest as _, Sha256};
 
-use crate::{
-	agent::tracker_tool_bridge::{
-		self, ISSUE_REVIEW_CHECKPOINT_TOOL_NAME, LocalRepoDetails,
-		NormalizedRejectedReviewCheckpointFinding, NormalizedReviewCheckpointContract,
-		NormalizedReviewCheckpointFinding, NormalizedReviewCheckpointFindingRoute,
-		NormalizedReviewCheckpointPayload, NormalizedReviewCostControl, ReviewCheckpointArgs,
-		ReviewCheckpointChecksArgs, ReviewCheckpointContractArgs, ReviewCheckpointFindingArgs,
-		ReviewCheckpointHeadBinding, ReviewCheckpointLineRangeArgs,
-		ReviewCheckpointRejectedFindingArgs, ReviewCostControlArgs, ReviewPolicyPhase,
-		ReviewPolicyStatus,
-	},
-	tracker::public_text,
+use crate::agent::tracker_tool_bridge::tools::review_checkpoint::finding_policy::ReviewFindingPolicyUpdate;
+use crate::agent::tracker_tool_bridge::tools::review_checkpoint::{
+	INDEPENDENT_FRESH_CONTEXT_REVIEWER, REVIEW_ROUTE_CURRENT_BLOCKER, REVIEW_ROUTE_SOURCE_ACCEPTED,
+	finding_policy, routes,
 };
-
-use super::{
-	INDEPENDENT_FRESH_CONTEXT_REVIEWER, MAX_COMPACT_REVIEW_CHANGED_SURFACE_COUNT,
-	REVIEW_CLASS_COMPACT_CURRENT_HEAD, REVIEW_CLASS_FULL_CURRENT_HEAD,
-	REVIEW_COST_CONTROL_NOT_PROVIDED, REVIEW_ROUTE_CURRENT_BLOCKER, REVIEW_ROUTE_SOURCE_ACCEPTED,
-	finding_policy::{ReviewFindingPolicyUpdate, empty_review_finding_policy},
-	routes::{
-		current_review_blocker_routes, normalize_review_checkpoint_finding_routes,
-		review_route_blocks_landing, summarize_review_checkpoint_finding_routes,
-	},
+use crate::agent::tracker_tool_bridge::{
+	self, ISSUE_REVIEW_CHECKPOINT_TOOL_NAME, LocalRepoDetails,
+	NormalizedRejectedReviewCheckpointFinding, NormalizedReviewCheckpointFinding,
+	NormalizedReviewCheckpointPayload, NormalizedReviewCostControl, ReviewCheckpointArgs,
+	ReviewCheckpointChecksArgs, ReviewCheckpointFindingArgs, ReviewCheckpointHeadBinding,
+	ReviewCheckpointLineRangeArgs, ReviewCheckpointRejectedFindingArgs, ReviewPolicyPhase,
+	ReviewPolicyStatus,
 };
 
 pub(in crate::agent::tracker_tool_bridge::tools) fn normalize_review_checkpoint_payload(
@@ -39,25 +30,27 @@ pub(in crate::agent::tracker_tool_bridge::tools) fn normalize_review_checkpoint_
 		.filter(|reviewer| !reviewer.is_empty())
 		.ok_or_else(|| {
 			format!(
-				"`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `reviewer` set to `{INDEPENDENT_FRESH_CONTEXT_REVIEWER}`."
+				"`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `reviewer` set to `{}`.",
+				INDEPENDENT_FRESH_CONTEXT_REVIEWER
 			)
 		})?;
 
 	if reviewer != INDEPENDENT_FRESH_CONTEXT_REVIEWER {
 		return Err(format!(
-			"`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` reviewer must be `{INDEPENDENT_FRESH_CONTEXT_REVIEWER}`, not `{reviewer}`."
+			"`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` reviewer must be `{}`, not `{reviewer}`.",
+			INDEPENDENT_FRESH_CONTEXT_REVIEWER
 		));
 	}
 
-	let review_contract = normalize_review_checkpoint_contract(
+	let review_contract = contract::normalize_review_checkpoint_contract(
 		parsed.review_contract.ok_or_else(|| {
 			format!("`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `review_contract`.")
 		})?,
 		review_policy_phase,
 	)?;
-	let review_contract_hash = review_checkpoint_contract_hash(&review_contract)?;
+	let review_contract_hash = contract::review_checkpoint_contract_hash(&review_contract)?;
 	let review_cost_control =
-		normalize_review_cost_control(parsed.review_cost_control, &review_contract)?;
+		cost_control::normalize_review_cost_control(parsed.review_cost_control, &review_contract)?;
 	let checks = normalize_review_checkpoint_checks(
 		parsed
 			.checks
@@ -74,14 +67,14 @@ pub(in crate::agent::tracker_tool_bridge::tools) fn normalize_review_checkpoint_
 		.into_iter()
 		.map(normalize_rejected_review_checkpoint_finding)
 		.collect::<Result<Vec<_>, _>>()?;
-	let finding_routes = normalize_review_checkpoint_finding_routes(
+	let finding_routes = routes::normalize_review_checkpoint_finding_routes(
 		parsed.finding_routes,
 		&accepted_findings,
 		&rejected_findings,
 	)?;
-	let finding_route_summary = summarize_review_checkpoint_finding_routes(&finding_routes);
+	let finding_route_summary = routes::summarize_review_checkpoint_finding_routes(&finding_routes);
 
-	validate_review_cost_control_for_checkpoint(
+	cost_control::validate_review_cost_control_for_checkpoint(
 		&review_cost_control,
 		review_policy_phase,
 		status,
@@ -91,7 +84,7 @@ pub(in crate::agent::tracker_tool_bridge::tools) fn normalize_review_checkpoint_
 	)?;
 
 	if status == ReviewPolicyStatus::Findings
-		&& !current_review_blocker_routes(&finding_routes).any(|route| {
+		&& !routes::current_review_blocker_routes(&finding_routes).any(|route| {
 			route.finding_source == REVIEW_ROUTE_SOURCE_ACCEPTED
 				&& route.finding_fingerprint.is_some()
 		}) {
@@ -106,14 +99,15 @@ pub(in crate::agent::tracker_tool_bridge::tools) fn normalize_review_checkpoint_
 	}
 	if status == ReviewPolicyStatus::Clean
 		&& finding_routes.iter().any(|route| {
-			route.route == REVIEW_ROUTE_CURRENT_BLOCKER || review_route_blocks_landing(route)
+			route.route == REVIEW_ROUTE_CURRENT_BLOCKER
+				|| routes::review_route_blocks_landing(route)
 		}) {
 		return Err(String::from(
 			"`issue_review_checkpoint` status `clean` can record only non-blocking `finding_routes` such as `follow_up`, `risk_note`, `reviewer_rubric_gap`, or `invalid_or_unsubstantiated`.",
 		));
 	}
 	if matches!(status, ReviewPolicyStatus::Blocked | ReviewPolicyStatus::NeedsArchitectureReview)
-		&& !finding_routes.iter().any(review_route_blocks_landing)
+		&& !finding_routes.iter().any(routes::review_route_blocks_landing)
 	{
 		return Err(String::from(
 			"`issue_review_checkpoint` status `blocked` or `needs_architecture_review` requires at least one landing-blocking `finding_routes` item with evidence, resolver, and machine-actionable next_action.",
@@ -136,379 +130,19 @@ pub(in crate::agent::tracker_tool_bridge::tools) fn normalize_review_checkpoint_
 		rejected_findings,
 		finding_routes,
 		finding_route_summary,
-		finding_policy: empty_review_finding_policy(review_policy_phase, status, head_sha),
+		finding_policy: finding_policy::empty_review_finding_policy(
+			review_policy_phase,
+			status,
+			head_sha,
+		),
 	})
-}
-
-fn normalize_review_checkpoint_contract(
-	contract: ReviewCheckpointContractArgs,
-	review_policy_phase: ReviewPolicyPhase,
-) -> Result<NormalizedReviewCheckpointContract, String> {
-	let workflow_policy_source = normalize_required_review_text(
-		contract.workflow_policy_source,
-		"review_contract.workflow_policy_source",
-	)?;
-
-	if workflow_policy_source != "registered_project_workflow" {
-		return Err(format!(
-			"`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `review_contract.workflow_policy_source` to be `registered_project_workflow`, not `{workflow_policy_source}`."
-		));
-	}
-
-	let review_type = normalize_review_type(contract.review_type, review_policy_phase)?;
-	let risk_tier = normalize_review_risk_tier(contract.risk_tier)?;
-	let objective =
-		normalize_required_review_text(contract.objective, "review_contract.objective")?;
-	let scope = normalize_required_review_contract_list(contract.scope, "review_contract.scope")?;
-	let non_goals =
-		normalize_required_review_contract_list(contract.non_goals, "review_contract.non_goals")?;
-	let required_checks = normalize_required_review_contract_list(
-		contract.required_checks,
-		"review_contract.required_checks",
-	)?;
-	let allowed_expansion_triggers = normalize_required_review_contract_list(
-		contract.allowed_expansion_triggers,
-		"review_contract.allowed_expansion_triggers",
-	)?;
-	let validation_evidence = normalize_required_review_contract_list(
-		contract.validation_evidence,
-		"review_contract.validation_evidence",
-	)?;
-
-	Ok(NormalizedReviewCheckpointContract {
-		workflow_policy_source,
-		review_type,
-		risk_tier,
-		objective,
-		scope,
-		non_goals,
-		required_checks,
-		allowed_expansion_triggers,
-		validation_evidence,
-	})
-}
-
-fn normalize_review_type(
-	review_type: String,
-	review_policy_phase: ReviewPolicyPhase,
-) -> Result<String, String> {
-	let review_type = review_type.trim().to_ascii_lowercase().replace([' ', '-'], "_");
-	let expected = match review_policy_phase {
-		ReviewPolicyPhase::Handoff => "full_current_head_review",
-		ReviewPolicyPhase::Repair => "repair_verification",
-	};
-
-	if review_type != expected {
-		return Err(format!(
-			"`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `review_contract.review_type` to be `{expected}` for `{}` review checkpoints, not `{review_type}`.",
-			review_policy_phase.as_str()
-		));
-	}
-
-	Ok(review_type)
-}
-
-fn normalize_review_risk_tier(risk_tier: String) -> Result<String, String> {
-	let risk_tier = risk_tier.trim().to_ascii_lowercase().replace([' ', '-'], "_");
-
-	match risk_tier.as_str() {
-		"low" | "localized" | "high" => Ok(risk_tier),
-		other => Err(format!(
-			"`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `review_contract.risk_tier` to be `low`, `localized`, or `high`, not `{other}`."
-		)),
-	}
-}
-
-fn normalize_required_review_contract_list(
-	values: Vec<String>,
-	field_name: &str,
-) -> Result<Vec<String>, String> {
-	let values = tracker_tool_bridge::normalize_progress_list(values);
-
-	if values.is_empty() {
-		return Err(format!("`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `{field_name}`."));
-	}
-
-	Ok(values)
-}
-
-fn review_checkpoint_contract_hash(
-	contract: &NormalizedReviewCheckpointContract,
-) -> Result<String, String> {
-	let serialized = serde_json::to_vec(contract).map_err(|error| {
-		format!(
-			"Failed to serialize `review_contract` for `{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}`: {error}"
-		)
-	})?;
-	let digest = Sha256::digest(serialized);
-	let hash = digest.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
-
-	Ok(format!("review_contract:{hash}"))
-}
-
-fn normalize_review_cost_control(
-	cost_control: Option<ReviewCostControlArgs>,
-	review_contract: &NormalizedReviewCheckpointContract,
-) -> Result<NormalizedReviewCostControl, String> {
-	let Some(cost_control) = cost_control else {
-		return Ok(NormalizedReviewCostControl {
-			review_class: String::from(REVIEW_CLASS_FULL_CURRENT_HEAD),
-			risk_class: review_contract.risk_tier.clone(),
-			compact_eligible: false,
-			changed_surface_count: 0,
-			changed_surface_summary: vec![String::from(
-				"Review cost-control metadata was not supplied; standard full review remains required.",
-			)],
-			high_risk_surfaces: Vec::new(),
-			current_head_evidence: false,
-			validation_backed: false,
-			validation_current: false,
-			evidence_sufficient: false,
-			reviewer_judgment: String::from(
-				"No compact-review judgment was recorded; defaulting to full independent review.",
-			),
-			fallback_reason: Some(String::from(REVIEW_COST_CONTROL_NOT_PROVIDED)),
-		});
-	};
-	let review_class = normalize_review_class(cost_control.review_class)?;
-	let risk_class = normalize_review_risk_tier(cost_control.risk_class)?;
-	let changed_surface_summary = normalize_review_cost_control_list(
-		cost_control.changed_surface_summary,
-		"review_cost_control.changed_surface_summary",
-		true,
-	)?;
-	let high_risk_surfaces = normalize_review_cost_control_list(
-		cost_control.high_risk_surfaces,
-		"review_cost_control.high_risk_surfaces",
-		false,
-	)?;
-	let reviewer_judgment = normalize_public_review_cost_control_text(
-		cost_control.reviewer_judgment,
-		"review_cost_control.reviewer_judgment",
-	)?;
-	let fallback_reason = normalize_optional_public_review_cost_control_reason(
-		cost_control.fallback_reason,
-		"review_cost_control.fallback_reason",
-	)?;
-	let compact_eligible = review_class == REVIEW_CLASS_COMPACT_CURRENT_HEAD;
-
-	if !compact_eligible && fallback_reason.is_none() {
-		return Err(String::from(
-			"`issue_review_checkpoint` requires `review_cost_control.fallback_reason` when `review_class` is `full_current_head_review`.",
-		));
-	}
-
-	Ok(NormalizedReviewCostControl {
-		review_class,
-		risk_class,
-		compact_eligible,
-		changed_surface_count: cost_control.changed_surface_count,
-		changed_surface_summary,
-		high_risk_surfaces,
-		current_head_evidence: cost_control.current_head_evidence,
-		validation_backed: cost_control.validation_backed,
-		validation_current: cost_control.validation_current,
-		evidence_sufficient: cost_control.evidence_sufficient,
-		reviewer_judgment,
-		fallback_reason,
-	})
-}
-
-fn normalize_review_class(review_class: String) -> Result<String, String> {
-	let review_class = review_class.trim().to_ascii_lowercase().replace([' ', '-'], "_");
-	let review_class = match review_class.as_str() {
-		"compact" => REVIEW_CLASS_COMPACT_CURRENT_HEAD,
-		"full" | "standard" => REVIEW_CLASS_FULL_CURRENT_HEAD,
-		other => other,
-	};
-
-	match review_class {
-		REVIEW_CLASS_COMPACT_CURRENT_HEAD | REVIEW_CLASS_FULL_CURRENT_HEAD =>
-			Ok(review_class.to_owned()),
-		other => Err(format!(
-			"`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `review_cost_control.review_class` to be `{REVIEW_CLASS_COMPACT_CURRENT_HEAD}` or `{REVIEW_CLASS_FULL_CURRENT_HEAD}`, not `{other}`."
-		)),
-	}
-}
-
-fn normalize_review_cost_control_list(
-	values: Vec<String>,
-	field_name: &str,
-	required: bool,
-) -> Result<Vec<String>, String> {
-	let values = tracker_tool_bridge::normalize_progress_list(values)
-		.into_iter()
-		.map(|value| normalize_public_review_cost_control_text(value, field_name))
-		.collect::<Result<Vec<_>, _>>()?;
-
-	if required && values.is_empty() {
-		return Err(format!("`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `{field_name}`."));
-	}
-
-	Ok(values)
-}
-
-fn normalize_public_review_cost_control_text(
-	value: String,
-	field_name: &str,
-) -> Result<String, String> {
-	let value = normalize_required_review_text(value, field_name)?;
-
-	public_text::validate_public_text_field(field_name, &value)
-		.map_err(|error| error.to_string())?;
-
-	Ok(value)
-}
-
-fn normalize_optional_public_review_cost_control_reason(
-	value: Option<String>,
-	field_name: &str,
-) -> Result<Option<String>, String> {
-	let Some(value) = tracker_tool_bridge::normalize_optional_progress_field(value) else {
-		return Ok(None);
-	};
-	let value = normalize_public_review_cost_control_text(value, field_name)?;
-
-	Ok(Some(value))
-}
-
-fn validate_review_cost_control_for_checkpoint(
-	cost_control: &NormalizedReviewCostControl,
-	review_policy_phase: ReviewPolicyPhase,
-	status: ReviewPolicyStatus,
-	review_contract: &NormalizedReviewCheckpointContract,
-	accepted_findings: &[NormalizedReviewCheckpointFinding],
-	finding_routes: &[NormalizedReviewCheckpointFindingRoute],
-) -> Result<(), String> {
-	if cost_control.review_class == REVIEW_CLASS_FULL_CURRENT_HEAD {
-		return Ok(());
-	}
-
-	let mut forced_full_reasons = compact_review_forced_full_reasons(
-		cost_control,
-		review_policy_phase,
-		status,
-		review_contract,
-		accepted_findings,
-		finding_routes,
-	);
-
-	if forced_full_reasons.is_empty() {
-		return Ok(());
-	}
-
-	forced_full_reasons.sort();
-	forced_full_reasons.dedup();
-
-	Err(format!(
-		"`issue_review_checkpoint` cannot record `review_cost_control.review_class = {REVIEW_CLASS_COMPACT_CURRENT_HEAD}` because full review is required: {}.",
-		forced_full_reasons.join(", ")
-	))
-}
-
-fn compact_review_forced_full_reasons(
-	cost_control: &NormalizedReviewCostControl,
-	review_policy_phase: ReviewPolicyPhase,
-	status: ReviewPolicyStatus,
-	review_contract: &NormalizedReviewCheckpointContract,
-	accepted_findings: &[NormalizedReviewCheckpointFinding],
-	finding_routes: &[NormalizedReviewCheckpointFindingRoute],
-) -> Vec<&'static str> {
-	let mut reasons = Vec::new();
-
-	if review_policy_phase != ReviewPolicyPhase::Handoff {
-		reasons.push("repair_review_phase");
-	}
-	if status != ReviewPolicyStatus::Clean {
-		reasons.push("nonclean_review_status");
-	}
-	if review_contract.risk_tier != "low" {
-		reasons.push("review_contract_risk_tier_not_low");
-	}
-	if cost_control.risk_class != "low" {
-		reasons.push("review_cost_risk_class_not_low");
-	}
-	if cost_control.changed_surface_count == 0 {
-		reasons.push("missing_changed_surface_count");
-	}
-	if cost_control.changed_surface_count > MAX_COMPACT_REVIEW_CHANGED_SURFACE_COUNT {
-		reasons.push("changed_surface_count_exceeds_compact_limit");
-	}
-	if !cost_control.high_risk_surfaces.is_empty() {
-		reasons.push("high_risk_surfaces_present");
-	}
-	if !cost_control.current_head_evidence {
-		reasons.push("missing_current_head_evidence");
-	}
-	if !cost_control.validation_backed {
-		reasons.push("missing_validation_evidence");
-	}
-	if !cost_control.validation_current {
-		reasons.push("stale_validation_evidence");
-	}
-	if !cost_control.evidence_sufficient {
-		reasons.push("weak_evidence");
-	}
-	if !accepted_findings.is_empty() {
-		reasons.push("accepted_findings_present");
-	}
-	if finding_routes.iter().any(|route| {
-		route.route == REVIEW_ROUTE_CURRENT_BLOCKER || review_route_blocks_landing(route)
-	}) {
-		reasons.push("blocking_finding_routes_present");
-	}
-
-	reasons
 }
 
 pub(in crate::agent::tracker_tool_bridge::tools) fn validate_review_cost_control_policy_state(
 	cost_control: &NormalizedReviewCostControl,
 	policy_update: &ReviewFindingPolicyUpdate,
 ) -> Result<(), String> {
-	if cost_control.review_class != REVIEW_CLASS_COMPACT_CURRENT_HEAD
-		|| policy_update.previous_nonclean_rounds == 0
-	{
-		return Ok(());
-	}
-
-	Err(format!(
-		"`issue_review_checkpoint` cannot record `review_cost_control.review_class = {REVIEW_CLASS_COMPACT_CURRENT_HEAD}` because full review is required: prior_nonclean_review_rounds_present."
-	))
-}
-
-fn normalize_review_checkpoint_checks(
-	checks: ReviewCheckpointChecksArgs,
-) -> Result<ReviewCheckpointChecksArgs, String> {
-	Ok(ReviewCheckpointChecksArgs {
-		intended_behavior: normalize_required_review_text(
-			checks.intended_behavior,
-			"checks.intended_behavior",
-		)?,
-		regression_risk: normalize_required_review_text(
-			checks.regression_risk,
-			"checks.regression_risk",
-		)?,
-		missing_tests: normalize_required_review_text(
-			checks.missing_tests,
-			"checks.missing_tests",
-		)?,
-		docs_config_drift: normalize_required_review_text(
-			checks.docs_config_drift,
-			"checks.docs_config_drift",
-		)?,
-		migration_fallout: normalize_required_review_text(
-			checks.migration_fallout,
-			"checks.migration_fallout",
-		)?,
-		operator_facing_fallout: normalize_required_review_text(
-			checks.operator_facing_fallout,
-			"checks.operator_facing_fallout",
-		)?,
-		loop_decision_contract: normalize_required_review_text(
-			checks.loop_decision_contract,
-			"checks.loop_decision_contract",
-		)?,
-	})
+	cost_control::validate_review_cost_control_policy_state(cost_control, policy_update)
 }
 
 pub(super) fn normalize_review_checkpoint_finding(
@@ -552,40 +186,6 @@ pub(super) fn normalize_review_checkpoint_finding(
 	})
 }
 
-fn normalize_rejected_review_checkpoint_finding(
-	finding: ReviewCheckpointRejectedFindingArgs,
-) -> Result<NormalizedRejectedReviewCheckpointFinding, String> {
-	let severity = normalize_review_severity(finding.severity, "rejected_findings.severity")?;
-	let summary = normalize_required_review_text(finding.summary, "rejected_findings.summary")?;
-	let rejection_reason = normalize_required_review_text(
-		finding.rejection_reason,
-		"rejected_findings.rejection_reason",
-	)?;
-	let kind = normalize_optional_review_kind(finding.kind, "rejected_findings.kind")?
-		.unwrap_or_else(|| String::from("rejected_finding"));
-	let file = normalize_optional_review_file(finding.file)?;
-	let line = normalize_optional_review_line(finding.line)?;
-	let line_range = normalize_optional_review_line_range(
-		line,
-		finding.line_range,
-		"rejected_findings.line_range",
-	)?;
-
-	Ok(NormalizedRejectedReviewCheckpointFinding {
-		severity,
-		summary,
-		rejection_reason,
-		evidence: normalize_required_review_evidence_list(
-			finding.evidence,
-			"rejected_findings.evidence",
-		)?,
-		kind,
-		file,
-		line,
-		line_range,
-	})
-}
-
 pub(super) fn normalize_review_severity(
 	severity: String,
 	field_name: &str,
@@ -624,6 +224,75 @@ pub(super) fn normalize_required_review_evidence_list(
 	}
 
 	Ok(values)
+}
+
+fn normalize_review_checkpoint_checks(
+	checks: ReviewCheckpointChecksArgs,
+) -> Result<ReviewCheckpointChecksArgs, String> {
+	Ok(ReviewCheckpointChecksArgs {
+		intended_behavior: normalize_required_review_text(
+			checks.intended_behavior,
+			"checks.intended_behavior",
+		)?,
+		regression_risk: normalize_required_review_text(
+			checks.regression_risk,
+			"checks.regression_risk",
+		)?,
+		missing_tests: normalize_required_review_text(
+			checks.missing_tests,
+			"checks.missing_tests",
+		)?,
+		docs_config_drift: normalize_required_review_text(
+			checks.docs_config_drift,
+			"checks.docs_config_drift",
+		)?,
+		migration_fallout: normalize_required_review_text(
+			checks.migration_fallout,
+			"checks.migration_fallout",
+		)?,
+		operator_facing_fallout: normalize_required_review_text(
+			checks.operator_facing_fallout,
+			"checks.operator_facing_fallout",
+		)?,
+		loop_decision_contract: normalize_required_review_text(
+			checks.loop_decision_contract,
+			"checks.loop_decision_contract",
+		)?,
+	})
+}
+
+fn normalize_rejected_review_checkpoint_finding(
+	finding: ReviewCheckpointRejectedFindingArgs,
+) -> Result<NormalizedRejectedReviewCheckpointFinding, String> {
+	let severity = normalize_review_severity(finding.severity, "rejected_findings.severity")?;
+	let summary = normalize_required_review_text(finding.summary, "rejected_findings.summary")?;
+	let rejection_reason = normalize_required_review_text(
+		finding.rejection_reason,
+		"rejected_findings.rejection_reason",
+	)?;
+	let kind = normalize_optional_review_kind(finding.kind, "rejected_findings.kind")?
+		.unwrap_or_else(|| String::from("rejected_finding"));
+	let file = normalize_optional_review_file(finding.file)?;
+	let line = normalize_optional_review_line(finding.line)?;
+	let line_range = normalize_optional_review_line_range(
+		line,
+		finding.line_range,
+		"rejected_findings.line_range",
+	)?;
+
+	Ok(NormalizedRejectedReviewCheckpointFinding {
+		severity,
+		summary,
+		rejection_reason,
+		evidence: normalize_required_review_evidence_list(
+			finding.evidence,
+			"rejected_findings.evidence",
+		)?,
+		kind,
+		file,
+		line,
+		line_range,
+	})
 }
 
 fn normalize_optional_review_file(value: Option<String>) -> Result<Option<String>, String> {

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools/review_checkpoint/normalize/contract.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools/review_checkpoint/normalize/contract.rs
@@ -1,0 +1,113 @@
+use serde_json;
+use sha2::{Digest as _, Sha256};
+
+use crate::agent::tracker_tool_bridge::{
+	self, ISSUE_REVIEW_CHECKPOINT_TOOL_NAME, NormalizedReviewCheckpointContract,
+	ReviewCheckpointContractArgs, ReviewPolicyPhase,
+};
+
+pub(super) fn normalize_review_checkpoint_contract(
+	contract: ReviewCheckpointContractArgs,
+	review_policy_phase: ReviewPolicyPhase,
+) -> Result<NormalizedReviewCheckpointContract, String> {
+	let workflow_policy_source = super::normalize_required_review_text(
+		contract.workflow_policy_source,
+		"review_contract.workflow_policy_source",
+	)?;
+
+	if workflow_policy_source != "registered_project_workflow" {
+		return Err(format!(
+			"`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `review_contract.workflow_policy_source` to be `registered_project_workflow`, not `{workflow_policy_source}`."
+		));
+	}
+
+	let review_type = normalize_review_type(contract.review_type, review_policy_phase)?;
+	let risk_tier = normalize_review_risk_tier(contract.risk_tier)?;
+	let objective =
+		super::normalize_required_review_text(contract.objective, "review_contract.objective")?;
+	let scope = normalize_required_review_contract_list(contract.scope, "review_contract.scope")?;
+	let non_goals =
+		normalize_required_review_contract_list(contract.non_goals, "review_contract.non_goals")?;
+	let required_checks = normalize_required_review_contract_list(
+		contract.required_checks,
+		"review_contract.required_checks",
+	)?;
+	let allowed_expansion_triggers = normalize_required_review_contract_list(
+		contract.allowed_expansion_triggers,
+		"review_contract.allowed_expansion_triggers",
+	)?;
+	let validation_evidence = normalize_required_review_contract_list(
+		contract.validation_evidence,
+		"review_contract.validation_evidence",
+	)?;
+
+	Ok(NormalizedReviewCheckpointContract {
+		workflow_policy_source,
+		review_type,
+		risk_tier,
+		objective,
+		scope,
+		non_goals,
+		required_checks,
+		allowed_expansion_triggers,
+		validation_evidence,
+	})
+}
+
+pub(super) fn normalize_review_risk_tier(risk_tier: String) -> Result<String, String> {
+	let risk_tier = risk_tier.trim().to_ascii_lowercase().replace([' ', '-'], "_");
+
+	match risk_tier.as_str() {
+		"low" | "localized" | "high" => Ok(risk_tier),
+		other => Err(format!(
+			"`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `review_contract.risk_tier` to be `low`, `localized`, or `high`, not `{other}`."
+		)),
+	}
+}
+
+pub(super) fn review_checkpoint_contract_hash(
+	contract: &NormalizedReviewCheckpointContract,
+) -> Result<String, String> {
+	let serialized = serde_json::to_vec(contract).map_err(|error| {
+		format!(
+			"Failed to serialize `review_contract` for `{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}`: {error}"
+		)
+	})?;
+	let digest = Sha256::digest(serialized);
+	let hash = digest.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+
+	Ok(format!("review_contract:{hash}"))
+}
+
+fn normalize_review_type(
+	review_type: String,
+	review_policy_phase: ReviewPolicyPhase,
+) -> Result<String, String> {
+	let review_type = review_type.trim().to_ascii_lowercase().replace([' ', '-'], "_");
+	let expected = match review_policy_phase {
+		ReviewPolicyPhase::Handoff => "full_current_head_review",
+		ReviewPolicyPhase::Repair => "repair_verification",
+	};
+
+	if review_type != expected {
+		return Err(format!(
+			"`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `review_contract.review_type` to be `{expected}` for `{}` review checkpoints, not `{review_type}`.",
+			review_policy_phase.as_str()
+		));
+	}
+
+	Ok(review_type)
+}
+
+fn normalize_required_review_contract_list(
+	values: Vec<String>,
+	field_name: &str,
+) -> Result<Vec<String>, String> {
+	let values = tracker_tool_bridge::normalize_progress_list(values);
+
+	if values.is_empty() {
+		return Err(format!("`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `{field_name}`."));
+	}
+
+	Ok(values)
+}

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools/review_checkpoint/normalize/cost_control.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools/review_checkpoint/normalize/cost_control.rs
@@ -1,0 +1,253 @@
+use crate::agent::tracker_tool_bridge::tools::review_checkpoint::finding_policy::ReviewFindingPolicyUpdate;
+use crate::agent::tracker_tool_bridge::tools::review_checkpoint::{
+	MAX_COMPACT_REVIEW_CHANGED_SURFACE_COUNT, REVIEW_CLASS_COMPACT_CURRENT_HEAD,
+	REVIEW_CLASS_FULL_CURRENT_HEAD, REVIEW_COST_CONTROL_NOT_PROVIDED, REVIEW_ROUTE_CURRENT_BLOCKER,
+	normalize::{self, contract},
+	routes,
+};
+use crate::agent::tracker_tool_bridge::{
+	self, ISSUE_REVIEW_CHECKPOINT_TOOL_NAME, NormalizedReviewCheckpointContract,
+	NormalizedReviewCheckpointFinding, NormalizedReviewCheckpointFindingRoute,
+	NormalizedReviewCostControl, ReviewCostControlArgs, ReviewPolicyPhase, ReviewPolicyStatus,
+};
+use crate::tracker::public_text;
+
+pub(super) fn normalize_review_cost_control(
+	cost_control: Option<ReviewCostControlArgs>,
+	review_contract: &NormalizedReviewCheckpointContract,
+) -> Result<NormalizedReviewCostControl, String> {
+	let Some(cost_control) = cost_control else {
+		return Ok(NormalizedReviewCostControl {
+			review_class: String::from(REVIEW_CLASS_FULL_CURRENT_HEAD),
+			risk_class: review_contract.risk_tier.clone(),
+			compact_eligible: false,
+			changed_surface_count: 0,
+			changed_surface_summary: vec![String::from(
+				"Review cost-control metadata was not supplied; standard full review remains required.",
+			)],
+			high_risk_surfaces: Vec::new(),
+			current_head_evidence: false,
+			validation_backed: false,
+			validation_current: false,
+			evidence_sufficient: false,
+			reviewer_judgment: String::from(
+				"No compact-review judgment was recorded; defaulting to full independent review.",
+			),
+			fallback_reason: Some(String::from(REVIEW_COST_CONTROL_NOT_PROVIDED)),
+		});
+	};
+	let review_class = normalize_review_class(cost_control.review_class)?;
+	let risk_class = contract::normalize_review_risk_tier(cost_control.risk_class)?;
+	let changed_surface_summary = normalize_review_cost_control_list(
+		cost_control.changed_surface_summary,
+		"review_cost_control.changed_surface_summary",
+		true,
+	)?;
+	let high_risk_surfaces = normalize_review_cost_control_list(
+		cost_control.high_risk_surfaces,
+		"review_cost_control.high_risk_surfaces",
+		false,
+	)?;
+	let reviewer_judgment = normalize_public_review_cost_control_text(
+		cost_control.reviewer_judgment,
+		"review_cost_control.reviewer_judgment",
+	)?;
+	let fallback_reason = normalize_optional_public_review_cost_control_reason(
+		cost_control.fallback_reason,
+		"review_cost_control.fallback_reason",
+	)?;
+	let compact_eligible = review_class == REVIEW_CLASS_COMPACT_CURRENT_HEAD;
+
+	if !compact_eligible && fallback_reason.is_none() {
+		return Err(String::from(
+			"`issue_review_checkpoint` requires `review_cost_control.fallback_reason` when `review_class` is `full_current_head_review`.",
+		));
+	}
+
+	Ok(NormalizedReviewCostControl {
+		review_class,
+		risk_class,
+		compact_eligible,
+		changed_surface_count: cost_control.changed_surface_count,
+		changed_surface_summary,
+		high_risk_surfaces,
+		current_head_evidence: cost_control.current_head_evidence,
+		validation_backed: cost_control.validation_backed,
+		validation_current: cost_control.validation_current,
+		evidence_sufficient: cost_control.evidence_sufficient,
+		reviewer_judgment,
+		fallback_reason,
+	})
+}
+
+pub(super) fn validate_review_cost_control_for_checkpoint(
+	cost_control: &NormalizedReviewCostControl,
+	review_policy_phase: ReviewPolicyPhase,
+	status: ReviewPolicyStatus,
+	review_contract: &NormalizedReviewCheckpointContract,
+	accepted_findings: &[NormalizedReviewCheckpointFinding],
+	finding_routes: &[NormalizedReviewCheckpointFindingRoute],
+) -> Result<(), String> {
+	if cost_control.review_class == REVIEW_CLASS_FULL_CURRENT_HEAD {
+		return Ok(());
+	}
+
+	let mut forced_full_reasons = compact_review_forced_full_reasons(
+		cost_control,
+		review_policy_phase,
+		status,
+		review_contract,
+		accepted_findings,
+		finding_routes,
+	);
+
+	if forced_full_reasons.is_empty() {
+		return Ok(());
+	}
+
+	forced_full_reasons.sort();
+	forced_full_reasons.dedup();
+
+	let review_class = REVIEW_CLASS_COMPACT_CURRENT_HEAD;
+
+	Err(format!(
+		"`issue_review_checkpoint` cannot record `review_cost_control.review_class = {review_class}` because full review is required: {}.",
+		forced_full_reasons.join(", ")
+	))
+}
+
+pub(super) fn validate_review_cost_control_policy_state(
+	cost_control: &NormalizedReviewCostControl,
+	policy_update: &ReviewFindingPolicyUpdate,
+) -> Result<(), String> {
+	if cost_control.review_class != REVIEW_CLASS_COMPACT_CURRENT_HEAD
+		|| policy_update.previous_nonclean_rounds == 0
+	{
+		return Ok(());
+	}
+
+	let review_class = REVIEW_CLASS_COMPACT_CURRENT_HEAD;
+
+	Err(format!(
+		"`issue_review_checkpoint` cannot record `review_cost_control.review_class = {review_class}` because full review is required: prior_nonclean_review_rounds_present."
+	))
+}
+
+fn normalize_review_class(review_class: String) -> Result<String, String> {
+	let review_class = review_class.trim().to_ascii_lowercase().replace([' ', '-'], "_");
+	let review_class = match review_class.as_str() {
+		"compact" => REVIEW_CLASS_COMPACT_CURRENT_HEAD,
+		"full" | "standard" => REVIEW_CLASS_FULL_CURRENT_HEAD,
+		other => other,
+	};
+
+	match review_class {
+		REVIEW_CLASS_COMPACT_CURRENT_HEAD | REVIEW_CLASS_FULL_CURRENT_HEAD => {
+			Ok(review_class.to_owned())
+		},
+		other => {
+			let compact = REVIEW_CLASS_COMPACT_CURRENT_HEAD;
+			let full = REVIEW_CLASS_FULL_CURRENT_HEAD;
+
+			Err(format!(
+				"`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `review_cost_control.review_class` to be `{compact}` or `{full}`, not `{other}`."
+			))
+		},
+	}
+}
+
+fn normalize_review_cost_control_list(
+	values: Vec<String>,
+	field_name: &str,
+	required: bool,
+) -> Result<Vec<String>, String> {
+	let values = tracker_tool_bridge::normalize_progress_list(values)
+		.into_iter()
+		.map(|value| normalize_public_review_cost_control_text(value, field_name))
+		.collect::<Result<Vec<_>, _>>()?;
+
+	if required && values.is_empty() {
+		return Err(format!("`{ISSUE_REVIEW_CHECKPOINT_TOOL_NAME}` requires `{field_name}`."));
+	}
+
+	Ok(values)
+}
+
+fn normalize_public_review_cost_control_text(
+	value: String,
+	field_name: &str,
+) -> Result<String, String> {
+	let value = normalize::normalize_required_review_text(value, field_name)?;
+
+	public_text::validate_public_text_field(field_name, &value)
+		.map_err(|error| error.to_string())?;
+
+	Ok(value)
+}
+
+fn normalize_optional_public_review_cost_control_reason(
+	value: Option<String>,
+	field_name: &str,
+) -> Result<Option<String>, String> {
+	let Some(value) = tracker_tool_bridge::normalize_optional_progress_field(value) else {
+		return Ok(None);
+	};
+	let value = normalize_public_review_cost_control_text(value, field_name)?;
+
+	Ok(Some(value))
+}
+
+fn compact_review_forced_full_reasons(
+	cost_control: &NormalizedReviewCostControl,
+	review_policy_phase: ReviewPolicyPhase,
+	status: ReviewPolicyStatus,
+	review_contract: &NormalizedReviewCheckpointContract,
+	accepted_findings: &[NormalizedReviewCheckpointFinding],
+	finding_routes: &[NormalizedReviewCheckpointFindingRoute],
+) -> Vec<&'static str> {
+	let mut reasons = Vec::new();
+
+	if review_policy_phase != ReviewPolicyPhase::Handoff {
+		reasons.push("repair_review_phase");
+	}
+	if status != ReviewPolicyStatus::Clean {
+		reasons.push("nonclean_review_status");
+	}
+	if review_contract.risk_tier != "low" {
+		reasons.push("review_contract_risk_tier_not_low");
+	}
+	if cost_control.risk_class != "low" {
+		reasons.push("review_cost_risk_class_not_low");
+	}
+	if cost_control.changed_surface_count == 0 {
+		reasons.push("missing_changed_surface_count");
+	}
+	if cost_control.changed_surface_count > MAX_COMPACT_REVIEW_CHANGED_SURFACE_COUNT {
+		reasons.push("changed_surface_count_exceeds_compact_limit");
+	}
+	if !cost_control.high_risk_surfaces.is_empty() {
+		reasons.push("high_risk_surfaces_present");
+	}
+	if !cost_control.current_head_evidence {
+		reasons.push("missing_current_head_evidence");
+	}
+	if !cost_control.validation_backed {
+		reasons.push("missing_validation_evidence");
+	}
+	if !cost_control.validation_current {
+		reasons.push("stale_validation_evidence");
+	}
+	if !cost_control.evidence_sufficient {
+		reasons.push("weak_evidence");
+	}
+	if !accepted_findings.is_empty() {
+		reasons.push("accepted_findings_present");
+	}
+	if finding_routes.iter().any(|route| {
+		route.route == REVIEW_ROUTE_CURRENT_BLOCKER || routes::review_route_blocks_landing(route)
+	}) {
+		reasons.push("blocking_finding_routes_present");
+	}
+
+	reasons
+}


### PR DESCRIPTION
## Summary
- Split review checkpoint normalization into flat child modules for contract hashing and cost-control validation.
- Split manual-attention normalization and public comment rendering into flat child modules.
- Kept tracker tool bridge dispatch/persistence behavior unchanged and avoided any mod.rs module files.

## Validation
- cargo check -p decodex --all-targets --all-features
- cargo test -p decodex --all-features manual_attention -- --nocapture --test-threads=1
- cargo test -p decodex --all-features review_checkpoint -- --nocapture --test-threads=1
- cargo make lint-vstyle-rust, filtered touched files plus RUST-STYLE-FILE-001: no hits
- git diff --check
- git ls-files 'apps/**/mod.rs' 'packages/**/mod.rs' | wc -l => 0