### PR TITLE
Quarantine invalid autonomy state rows

### DIFF
--- a/apps/decodex/src/state/sqlite_store/queries/autonomy_program.rs
+++ b/apps/decodex/src/state/sqlite_store/queries/autonomy_program.rs
@@ -21,7 +21,19 @@ impl super::super::SqliteStateStore {
 		let rows = statement.query_map([], decision_contract_runtime_row_parts)?;
 
 		for row in rows {
-			let record = decision_contract_record_from_row_parts(row?)?;
+			let parts = row?;
+			let record = match decision_contract_record_from_row_parts(parts) {
+				Ok(record) => record,
+				Err(error) if decision_contract_load_error_is_quarantinable(error.as_ref()) => {
+					tracing::warn!(
+						error = %error,
+						"Skipped invalid Decision Contract during state snapshot load."
+					);
+
+					continue;
+				},
+				Err(error) => return Err(error),
+			};
 
 			state.decision_contracts.insert(record.key(), record);
 		}
@@ -67,7 +79,23 @@ impl super::super::SqliteStateStore {
 		let mut records = Vec::new();
 
 		for row in rows {
-			records.push(decision_contract_record_from_row_parts(row?)?);
+			let parts = row?;
+			let record = match decision_contract_record_from_row_parts(parts) {
+				Ok(record) => record,
+				Err(error) if decision_contract_load_error_is_quarantinable(error.as_ref()) => {
+					tracing::warn!(
+						error = %error,
+						project_id,
+						source_issue_id,
+						"Skipped invalid Decision Contract during issue list read."
+					);
+
+					continue;
+				},
+				Err(error) => return Err(error),
+			};
+
+			records.push(record);
 		}
 
 		Ok(records)
@@ -88,7 +116,22 @@ impl super::super::SqliteStateStore {
 		let mut records = Vec::new();
 
 		for row in rows {
-			records.push(decision_contract_record_from_row_parts(row?)?);
+			let parts = row?;
+			let record = match decision_contract_record_from_row_parts(parts) {
+				Ok(record) => record,
+				Err(error) if decision_contract_load_error_is_quarantinable(error.as_ref()) => {
+					tracing::warn!(
+						error = %error,
+						project_id,
+						"Skipped invalid Decision Contract during project list read."
+					);
+
+					continue;
+				},
+				Err(error) => return Err(error),
+			};
+
+			records.push(record);
 		}
 
 		Ok(records)
@@ -339,7 +382,19 @@ impl super::super::SqliteStateStore {
 		let rows = statement.query_map([], autonomy_proposal_runtime_row_parts)?;
 
 		for row in rows {
-			let record = autonomy_proposal_record_from_row_parts(row?)?;
+			let parts = row?;
+			let record = match autonomy_proposal_record_from_row_parts(parts) {
+				Ok(record) => record,
+				Err(error) if autonomy_proposal_load_error_is_quarantinable(error.as_ref()) => {
+					tracing::warn!(
+						error = %error,
+						"Skipped invalid Autonomy Proposal during state snapshot load."
+					);
+
+					continue;
+				},
+				Err(error) => return Err(error),
+			};
 
 			state.autonomy_proposals.insert(record.key(), record);
 		}
@@ -363,7 +418,20 @@ impl super::super::SqliteStateStore {
 		let rows = statement.query_map(params![project_id], autonomy_proposal_runtime_row_parts)?;
 
 		for row in rows {
-			let record = autonomy_proposal_record_from_row_parts(row?)?;
+			let parts = row?;
+			let record = match autonomy_proposal_record_from_row_parts(parts) {
+				Ok(record) => record,
+				Err(error) if autonomy_proposal_load_error_is_quarantinable(error.as_ref()) => {
+					tracing::warn!(
+						error = %error,
+						project_id,
+						"Skipped invalid Autonomy Proposal during project state load."
+					);
+
+					continue;
+				},
+				Err(error) => return Err(error),
+			};
 
 			state.autonomy_proposals.insert(record.key(), record);
 		}
@@ -417,7 +485,24 @@ impl super::super::SqliteStateStore {
 		let mut records = Vec::new();
 
 		for row in rows {
-			records.push(autonomy_proposal_record_from_row_parts(row?)?);
+			let parts = row?;
+			let record = match autonomy_proposal_record_from_row_parts(parts) {
+				Ok(record) => record,
+				Err(error) if autonomy_proposal_load_error_is_quarantinable(error.as_ref()) => {
+					tracing::warn!(
+						error = %error,
+						project_id,
+						objective_id,
+						objective_version,
+						"Skipped invalid Autonomy Proposal during objective list read."
+					);
+
+					continue;
+				},
+				Err(error) => return Err(error),
+			};
+
+			records.push(record);
 		}
 
 		Ok(records)
@@ -445,7 +530,22 @@ impl super::super::SqliteStateStore {
 		let mut records = Vec::new();
 
 		for row in rows {
-			records.push(autonomy_proposal_record_from_row_parts(row?)?);
+			let parts = row?;
+			let record = match autonomy_proposal_record_from_row_parts(parts) {
+				Ok(record) => record,
+				Err(error) if autonomy_proposal_load_error_is_quarantinable(error.as_ref()) => {
+					tracing::warn!(
+						error = %error,
+						project_id,
+						"Skipped invalid Autonomy Proposal during recent project read."
+					);
+
+					continue;
+				},
+				Err(error) => return Err(error),
+			};
+
+			records.push(record);
 		}
 
 		Ok(records)
@@ -644,4 +744,23 @@ impl super::super::SqliteStateStore {
 
 		Ok(records)
 	}
+}
+
+fn decision_contract_load_error_is_quarantinable(
+	error: &(dyn std::error::Error + 'static),
+) -> bool {
+	let message = error.to_string();
+
+	message.contains("Decision Contract proposed issue `")
+		&& (message.contains("depends on unknown issue")
+			|| message.contains("must not depend on itself")
+			|| message.contains("dependency cycle includes"))
+}
+
+fn autonomy_proposal_load_error_is_quarantinable(
+	error: &(dyn std::error::Error + 'static),
+) -> bool {
+	let message = error.to_string();
+
+	message.contains("Autonomy proposal `") && message.contains("fingerprint mismatch")
 }

--- a/apps/decodex/src/state/tests.rs
+++ b/apps/decodex/src/state/tests.rs
@@ -1,6 +1,7 @@
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, IntoRawFd};
 use std::{
+	collections::BTreeMap,
 	fs,
 	path::Path,
 	process, slice,
@@ -19,6 +20,12 @@ use crate::{
 	autonomy_objective::{
 		AutonomyObjectiveAcceptance, AutonomyObjectiveActorKind, AutonomyObjectiveContract,
 		AutonomyObjectiveRejection, AutonomyObjectiveState, AutonomyObjectiveSupersession,
+	},
+	autonomy_proposal::{AutonomyProposal, AutonomyProposalCompileInput},
+	autonomy_signal::{
+		AutonomySignal, AutonomySignalConfidence, AutonomySignalEvidenceClass,
+		AutonomySignalFreshness, AutonomySignalInput, AutonomySignalPrivacy,
+		AutonomySignalSourceType,
 	},
 	execution_program::{
 		ExecutionLinearIssueMapping, ExecutionProgram, ExecutionProgramNode,
@@ -285,6 +292,71 @@ fn upsert_handoff_review_policy_checkpoint(
 			details_json: "{}",
 		})
 		.expect("review policy checkpoint should persist");
+}
+
+fn accepted_autonomy_objective_fixture() -> AutonomyObjectiveContract {
+	let mut objective = autonomy_objective_fixture(1);
+
+	objective.accept(sample_objective_acceptance()).expect("objective should accept");
+
+	objective
+}
+
+fn autonomy_signal_fixture() -> AutonomySignal {
+	AutonomySignal::validation_regression(AutonomySignalInput {
+		project_id: String::from("decodex"),
+		objective_id: String::from("quality-autonomy"),
+		objective_version: 1,
+		source_type: AutonomySignalSourceType::Runtime,
+		source_refs: vec![String::from("status:runtime-health")],
+		primary_source_refs: Vec::new(),
+		issue_id: Some(String::from("XY-1086")),
+		run_id: Some(String::from("xy-1086-attempt-1")),
+		attempt_id: Some(String::from("1")),
+		head_sha: Some(String::from("3cd19609c44cb18bff9e7a34a2f4853754afcee0")),
+		captured_at: String::from("2026-06-22T00:00:00Z"),
+		freshness: AutonomySignalFreshness::Fresh,
+		summary: String::from("Runtime status readback showed repeated friction."),
+		evidence: vec![String::from("status readback retained the repeated friction signal")],
+		evidence_class: AutonomySignalEvidenceClass::LiveReadback,
+		contradictions: Vec::new(),
+		gaps: vec![String::from("No dashboard comparison included.")],
+		confidence: AutonomySignalConfidence::Medium,
+		privacy: AutonomySignalPrivacy::Team,
+		observed_counts: BTreeMap::new(),
+		review_evidence: None,
+		proposal_only: true,
+		created_at: String::from("2026-06-22T00:00:05Z"),
+	})
+	.expect("runtime signal should validate")
+}
+
+fn autonomy_proposal_fixture() -> AutonomyProposal {
+	AutonomyProposal::compile_dry_run(
+		Some(&accepted_autonomy_objective_fixture()),
+		&[autonomy_signal_fixture()],
+		AutonomyProposalCompileInput {
+			project_id: String::from("decodex"),
+			objective_id: String::from("quality-autonomy"),
+			objective_version: 1,
+			source_family: String::from("runtime_status"),
+			intended_surface: String::from("apps/decodex/src/orchestrator/status.rs"),
+			affected_identifiers: vec![
+				String::from("OperatorLoopStatus"),
+				String::from("operator_status"),
+			],
+			summary: String::from("Compile a bounded proposal from runtime friction evidence."),
+			challenge_requirements: vec![String::from(
+				"Subagent or inline skeptic objections are evidence only.",
+			)],
+			rejected_alternatives: vec![String::from("Direct Decision Contract promotion.")],
+			rollback_path: String::from("Discard the dry-run proposal record."),
+			weakened_validation_or_review: Vec::new(),
+			issue_candidates: Vec::new(),
+			created_at: String::from("2026-06-22T00:01:00Z"),
+		},
+	)
+	.expect("autonomy proposal should compile")
 }
 
 include!("tests/review_lifecycle.rs");

--- a/apps/decodex/src/state/tests/runtime_records.rs
+++ b/apps/decodex/src/state/tests/runtime_records.rs
@@ -1096,6 +1096,126 @@ fn decision_contract_reload_rejects_row_key_payload_mismatch() {
 }
 
 #[test]
+fn decision_contract_snapshot_load_quarantines_invalid_issue_dependency_rows() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+	let store = StateStore::open(&state_path).expect("state store should open");
+
+	store
+		.upsert_decision_contract("decodex", Some("XY-852"), latent_decision_contract_fixture())
+		.expect("valid decision contract should persist");
+
+	let mut invalid_payload = serde_json::to_value(latent_decision_contract_fixture())
+		.expect("fixture should encode as JSON");
+
+	invalid_payload["contract_id"] = serde_json::json!("invalid-dependency-contract");
+	invalid_payload["execution_readiness"]["proposed_issues"][0]["dependencies"] =
+		serde_json::json!(["XY-952"]);
+
+	let connection = Connection::open(&state_path).expect("sqlite should open");
+
+	connection
+		.execute(
+			"INSERT INTO decision_contracts (
+					project_id, contract_id, source_issue_id, status, payload_json, created_at,
+					created_at_unix, updated_at, updated_at_unix
+				) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+			rusqlite::params![
+				"decodex",
+				"invalid-dependency-contract",
+				"XY-BROKEN",
+				"draft_latent",
+				serde_json::to_string(&invalid_payload)
+					.expect("invalid dependency payload should serialize"),
+				"2026-07-01T00:00:00Z",
+				1_i64,
+				"2026-07-01T00:00:00Z",
+				1_i64,
+			],
+		)
+		.expect("invalid dependency row should insert");
+
+	let reopened =
+		StateStore::open(&state_path).expect("invalid dependency contract should be quarantined");
+	let valid_contract = reopened
+		.decision_contract("decodex", "research-x-loop-contract")
+		.expect("valid contract should remain readable")
+		.expect("valid contract should exist");
+
+	assert_eq!(valid_contract.contract_id(), "research-x-loop-contract");
+	let project_contracts = reopened
+		.list_decision_contracts_for_project("decodex")
+		.expect("project contract list should skip invalid rows");
+
+	assert_eq!(project_contracts.len(), 1);
+	assert_eq!(project_contracts[0].contract_id(), "research-x-loop-contract");
+	assert!(
+		reopened
+			.list_decision_contracts_for_issue("decodex", "XY-BROKEN")
+			.expect("issue contract list should skip invalid rows")
+			.is_empty()
+	);
+	assert!(
+		reopened.decision_contract("decodex", "invalid-dependency-contract").is_err(),
+		"direct reads of the invalid contract should still fail validation"
+	);
+}
+
+#[test]
+fn autonomy_proposal_snapshot_load_quarantines_fingerprint_mismatch_rows() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_path = temp_dir.path().join("runtime.sqlite3");
+	let _store = StateStore::open(&state_path).expect("state store should open");
+	let proposal = autonomy_proposal_fixture();
+	let mut invalid_payload =
+		serde_json::to_value(&proposal).expect("proposal should encode as JSON");
+
+	invalid_payload["affected_identifiers"] = serde_json::json!(["OperatorLoopStatus"]);
+
+	let connection = Connection::open(&state_path).expect("sqlite should open");
+
+	connection
+		.execute(
+			"INSERT INTO autonomy_proposals (
+					project_id, proposal_id, objective_id, objective_version, state, fingerprint,
+					source_family, intended_surface, payload_json, created_at, created_at_unix,
+					updated_at, updated_at_unix
+				) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+			rusqlite::params![
+				"decodex",
+				proposal.id(),
+				proposal.objective_id(),
+				1_i64,
+				proposal.state().as_str(),
+				proposal.fingerprint(),
+				proposal.source_family(),
+				proposal.intended_surface(),
+				serde_json::to_string(&invalid_payload)
+					.expect("invalid proposal payload should serialize"),
+				"2026-07-01T00:00:00Z",
+				1_i64,
+				"2026-07-01T00:00:00Z",
+				1_i64,
+			],
+		)
+		.expect("invalid proposal row should insert");
+
+	let reopened =
+		StateStore::open(&state_path).expect("invalid proposal should be quarantined on open");
+
+	assert!(
+		reopened
+			.recent_autonomy_proposals_for_project("decodex", 10)
+			.expect("recent proposal list should skip invalid rows")
+			.is_empty()
+	);
+	assert!(
+		reopened.autonomy_proposal("decodex", proposal.id()).is_err(),
+		"direct reads of the invalid proposal should still fail validation"
+	);
+}
+
+#[test]
 fn decision_contract_reload_migrates_removed_flat_issue_summary_rows() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let state_path = temp_dir.path().join("runtime.sqlite3");
@@ -1136,10 +1256,11 @@ fn decision_contract_reload_migrates_removed_flat_issue_summary_rows() {
 				) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
 			rusqlite::params![
 				"decodex",
-			"removed-flat-issue-contract",
+				"removed-flat-issue-contract",
 				"XY-OLD",
 				"draft_latent",
-			serde_json::to_string(&removed_field_payload).expect("removed-field payload should serialize"),
+				serde_json::to_string(&removed_field_payload)
+					.expect("removed-field payload should serialize"),
 				"2026-06-17T00:00:00Z",
 				1_i64,
 				"2026-06-17T00:00:00Z",
@@ -1177,7 +1298,7 @@ fn decision_contract_reload_migrates_removed_flat_issue_summary_rows() {
 
 	let migrated_payload: String = connection
 		.query_row(
-				"SELECT payload_json FROM decision_contracts WHERE contract_id = 'removed-flat-issue-contract'",
+			"SELECT payload_json FROM decision_contracts WHERE contract_id = 'removed-flat-issue-contract'",
 			[],
 			|row| row.get(0),
 		)


### PR DESCRIPTION
## Summary
- Quarantine invalid Decision Contract rows during snapshot and collection reads when proposed-issue dependencies are broken
- Quarantine invalid Autonomy Proposal fingerprint-mismatch rows during snapshot and list reads
- Preserve strict direct-read validation failures for invalid records

## Validation
- rustfmt --check apps/decodex/src/state/sqlite_store/queries/autonomy_program.rs apps/decodex/src/state/tests.rs apps/decodex/src/state/tests/runtime_records.rs
- cargo test -p decodex decision_contract_snapshot_load_quarantines_invalid_issue_dependency_rows
- cargo test -p decodex autonomy_proposal_snapshot_load_quarantines_fingerprint_mismatch_rows
- cargo test -p decodex decision_contract
- cargo run -q -p decodex --bin decodex -- run --dry-run --config /Users/x/.codex/decodex/projects/pubfi/project.toml PUB-1643
- cargo run -q -p decodex --bin decodex -- status --live --config /Users/x/.codex/decodex/projects/pubfi/project.toml

## Review
- Independent subagent review found one P1 gap in Decision Contract collection reads.
- Gap was fixed and the second subagent pass reported no blocking issues.

Refs XY-1137