### PR TITLE
Split target dispatch modules

### DIFF
--- a/apps/decodex/src/orchestrator.rs
+++ b/apps/decodex/src/orchestrator.rs
@@ -27,7 +27,8 @@ pub(crate) use lane_control::{
 	print_lane_inspect, steer_lane,
 };
 
-#[cfg(unix)] use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 use std::{
 	cmp::Ordering,
 	collections::{BTreeSet, HashMap, HashSet},
@@ -68,7 +69,8 @@ use crate::{agent::{RUN_LEASE_IDLE_TIMEOUT, AppServerCapabilityPreflightFailure,
 use execution_architecture_recovery::{
 	architecture_recovery_retry_next_action, loop_guardrail_architecture_recovery_decision,
 };
-#[cfg(test)] use execution_closeout::ensure_closeout_issue_completed_state;
+#[cfg(test)]
+use execution_closeout::ensure_closeout_issue_completed_state;
 use execution_closeout::execute_deterministic_closeout;
 use execution_failure::{
 	ARCHITECTURE_RECOVERY_BUDGET, ARCHITECTURE_RECOVERY_RETRY_KIND,
@@ -89,7 +91,8 @@ use execution_failure::{
 	promote_zero_evidence_app_server_start_failure, retry_budget_attempts_for_current_failure,
 	write_retry_schedule_marker_for_runtime_retry,
 };
-#[cfg(test)] use execution_phase_goal::RepoGatePhaseGoalController;
+#[cfg(test)]
+use execution_phase_goal::RepoGatePhaseGoalController;
 use execution_phase_goal::{
 	PhaseAcceptanceCheckFailure, PhaseGoalRecoveryContinuation, build_phase_goal_controller,
 	issue_has_blocking_lane_decision_evidence, latest_open_issue_phase_goal_before_attempt,
@@ -300,7 +303,8 @@ pub(crate) use run_cycle_reconciliation::{
 };
 
 mod daemon_retry;
-#[cfg(test)] pub(crate) use daemon_retry::schedule_retry_after_child_exit;
+#[cfg(test)]
+pub(crate) use daemon_retry::schedule_retry_after_child_exit;
 pub(crate) use daemon_retry::{retry_delay, write_retry_schedule_for_run};
 
 mod daemon;
@@ -383,12 +387,12 @@ pub(in crate::orchestrator) use dispatch_policy::{
 	closeout_dispatch_block_reason, evaluate_closeout_dispatch_policy_with_inspector,
 	is_issue_eligible, is_issue_in_progress_for_run,
 	is_issue_not_dispatchable_for_current_dispatch, is_terminal_issue, issue_has_service_ownership,
-	issue_passes_closeout_dispatch_policy, issue_passes_dispatch_policy,
-	issue_passes_retry_dispatch_policy, issue_passes_retry_retention_policy,
-	issue_passes_review_repair_dispatch_policy, issue_retry_budget_exhausted,
-	issue_retry_budget_exhausted_for_worktree, mark_run_attempt_if_active,
-	ordinary_dispatch_blocked_by_retained_review_handoff, refresh_issue,
-	render_issue_description_for_prompt, retry_budget_base_for_dispatch_mode,
+	issue_passes_closeout_dispatch_policy, issue_passes_current_dispatch_policy,
+	issue_passes_dispatch_policy, issue_passes_retry_dispatch_policy,
+	issue_passes_retry_retention_policy, issue_passes_review_repair_dispatch_policy,
+	issue_retry_budget_exhausted, issue_retry_budget_exhausted_for_worktree,
+	mark_run_attempt_if_active, ordinary_dispatch_blocked_by_retained_review_handoff,
+	refresh_issue, render_issue_description_for_prompt, retry_budget_base_for_dispatch_mode,
 	retry_budget_base_for_issue_worktree, state_name_is_terminal, todo_blocker_rule_passes,
 	write_retry_budget_marker, write_terminal_guard_marker,
 };
@@ -428,7 +432,8 @@ pub(crate) use status_render::{render_operator_status, render_queue_explain};
 include!("orchestrator/selection.rs");
 
 mod agent_evidence;
-#[cfg(test)] use agent_evidence::PrivateEvidenceReadback;
+#[cfg(test)]
+use agent_evidence::PrivateEvidenceReadback;
 use agent_evidence::{
 	AgentEvidenceSource, AgentPrivateEvidenceRef, build_private_evidence_readback,
 	private_evidence_ref_for_run_fields, render_agent_evidence_write_result,
@@ -601,4 +606,5 @@ query($owner: String!, $name: String!, $number: Int!, $commentsAfter: String) {
 }
 "#;
 
-#[cfg(test)] mod tests;
+#[cfg(test)]
+mod tests;

--- a/apps/decodex/src/orchestrator/dispatch_policy.rs
+++ b/apps/decodex/src/orchestrator/dispatch_policy.rs
@@ -109,3 +109,49 @@ where
 
 	Ok(true)
 }
+
+pub(in crate::orchestrator) fn issue_passes_current_dispatch_policy<T>(
+	tracker: &T,
+	issue: &TrackerIssue,
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	dispatch_mode: IssueDispatchMode,
+	hint: RetryIssueStateHint<'_>,
+) -> Result<bool>
+where
+	T: IssueTracker + ?Sized,
+{
+	match dispatch_mode {
+		IssueDispatchMode::Normal => {
+			let queue_label = tracker::automation_queue_label(project.service_id());
+
+			Ok(issue_passes_dispatch_policy(tracker, issue, workflow, &queue_label, false)?
+				&& !ordinary_dispatch_blocked_by_retained_review_handoff(
+					project.service_id(),
+					issue,
+					state_store,
+				)?)
+		},
+		IssueDispatchMode::Program => {
+			let queue_label = tracker::automation_queue_label(project.service_id());
+
+			Ok(issue_passes_dispatch_policy(tracker, issue, workflow, &queue_label, true)?
+				&& !ordinary_dispatch_blocked_by_retained_review_handoff(
+					project.service_id(),
+					issue,
+					state_store,
+				)?)
+		},
+		IssueDispatchMode::Retry => {
+			issue_passes_retry_dispatch_policy(tracker, issue, project, workflow, state_store, hint)
+		},
+		IssueDispatchMode::ReviewRepair => {
+			Ok(issue_passes_review_repair_dispatch_policy(tracker, issue, project, workflow)?
+				&& !issue_retry_budget_exhausted(workflow, state_store, &issue.id)?)
+		},
+		IssueDispatchMode::Closeout => {
+			issue_passes_closeout_dispatch_policy(tracker, issue, project, workflow, state_store)
+		},
+	}
+}

--- a/apps/decodex/src/orchestrator/run_cycle.rs
+++ b/apps/decodex/src/orchestrator/run_cycle.rs
@@ -1,11 +1,12 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+#[allow(clippy::wildcard_imports)]
+use super::*;
 
 const INTERNAL_RETAINED_DRAIN_MAX_PASSES: usize = 2;
 
 mod complete;
 mod prepare;
 mod project;
-mod target;
+mod target_issue;
 
 use complete::complete_issue_run;
 #[cfg(test)]
@@ -14,12 +15,12 @@ pub(crate) use complete::{
 };
 pub(crate) use prepare::prepare_issue_run;
 pub(crate) use project::{plan_project_issue_run_with_exclusions, run_project_once};
-pub(crate) use target::{
+pub(crate) use target_issue::{
 	closeout_lane_active_claim_blocks_dispatch, run_target_issue_once,
 	run_target_issue_once_with_inferred_dispatch,
 };
 #[cfg(test)]
-pub(crate) use target::{
+pub(crate) use target_issue::{
 	select_target_status_visible_program_candidate, target_issue_active_claim_blocks_dispatch,
 };
 

--- a/apps/decodex/src/orchestrator/run_cycle/prepare.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/prepare.rs
@@ -1,4 +1,5 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+#[allow(clippy::wildcard_imports)]
+use super::*;
 
 pub(crate) fn prepare_issue_run<T>(
 	context: PrepareIssueRunContext<'_, T>,
@@ -162,12 +163,13 @@ fn prepare_issue_run_dispatch_allowed<T>(
 where
 	T: IssueTracker,
 {
-	let dispatch_allowed = context.dispatch_mode.allows_issue(
+	let dispatch_allowed = issue_passes_current_dispatch_policy(
 		context.tracker,
 		refreshed_issue,
 		context.project,
 		context.workflow,
 		context.state_store,
+		context.dispatch_mode,
 		RetryIssueStateHint {
 			preferred_issue_state: context.preferred_issue_state,
 			preferred_initial_issue_state: context.preferred_initial_issue_state,
@@ -251,7 +253,8 @@ fn resolve_prepare_run_identity(
 				preferred_run_identity.run_id.to_owned(),
 			)))
 		},
-		None =>
-			Ok(Some((next_attempt_number, build_run_id(&issue.identifier, next_attempt_number)?))),
+		None => {
+			Ok(Some((next_attempt_number, build_run_id(&issue.identifier, next_attempt_number)?)))
+		},
 	}
 }

--- a/apps/decodex/src/orchestrator/run_cycle/project.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/project.rs
@@ -1,4 +1,5 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+#[allow(clippy::wildcard_imports)]
+use super::*;
 
 pub(crate) fn run_project_once<T>(
 	tracker: &T,
@@ -89,12 +90,13 @@ where
 	if !dry_run && dispatch_mode != IssueDispatchMode::Closeout {
 		ensure_project_has_no_merged_worktree_cleanup_debt(project)?;
 	}
-	if !dispatch_mode.allows_issue(
+	if !issue_passes_current_dispatch_policy(
 		tracker,
 		&issue,
 		project,
 		workflow,
 		state_store,
+		dispatch_mode,
 		RetryIssueStateHint::default(),
 	)? {
 		if dispatch_mode == IssueDispatchMode::Closeout

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue.rs
@@ -1,8 +1,17 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+#[allow(clippy::wildcard_imports)]
+use super::*;
 
 use state::PreacquiredLeaseGuards;
 
 use crate::commit_message;
+
+pub(in crate::orchestrator::run_cycle::target_issue) mod inferred;
+pub(in crate::orchestrator::run_cycle::target_issue) mod post_review;
+pub(in crate::orchestrator::run_cycle::target_issue) mod program;
+
+pub(crate) use inferred::run_target_issue_once_with_inferred_dispatch;
+#[cfg(test)]
+pub(crate) use program::select_target_status_visible_program_candidate;
 
 pub(crate) fn run_target_issue_once<T>(
 	context: TargetIssueRunContext<'_, T>,
@@ -61,12 +70,13 @@ where
 		preferred_initial_issue_state: context.preferred_initial_issue_state,
 	};
 
-	if !context.dispatch_mode.allows_issue(
+	if !issue_passes_current_dispatch_policy(
 		context.tracker,
 		&issue,
 		context.project,
 		context.workflow,
 		context.state_store,
+		context.dispatch_mode,
 		retry_state_hint,
 	)? {
 		ensure_target_closeout_dispatch_is_unblocked(&context, &issue)?;
@@ -174,274 +184,6 @@ fn preferred_run_identity_with_closeout_fallback<'a>(
 	}
 }
 
-pub(crate) fn run_target_issue_once_with_inferred_dispatch<T>(
-	context: TargetIssueRunContext<'_, T>,
-) -> Result<Option<RunSummary>>
-where
-	T: IssueTracker,
-{
-	if target_issue_has_status_visible_review_repair(&context)? {
-		return run_target_status_visible_review_repair_once(context);
-	}
-	if target_issue_has_status_visible_closeout(&context)? {
-		return run_target_status_visible_closeout_once(context);
-	}
-
-	if let Some(summary) = run_target_status_visible_program_once(
-		target_issue_run_context_with_dispatch_mode(&context, IssueDispatchMode::Program),
-	)? {
-		return Ok(Some(summary));
-	}
-	if let Some(summary) = run_target_issue_once(target_issue_run_context_with_dispatch_mode(
-		&context,
-		IssueDispatchMode::Normal,
-	))? {
-		return Ok(Some(summary));
-	}
-	if let Some(summary) = run_target_issue_once(target_issue_run_context_with_dispatch_mode(
-		&context,
-		IssueDispatchMode::Retry,
-	))? {
-		return Ok(Some(summary));
-	}
-	if let Some(summary) = run_target_status_visible_review_repair_once(
-		target_issue_run_context_with_dispatch_mode(&context, IssueDispatchMode::ReviewRepair),
-	)? {
-		return Ok(Some(summary));
-	}
-
-	run_target_status_visible_closeout_once(context)
-}
-
-fn run_target_status_visible_program_once<T>(
-	context: TargetIssueRunContext<'_, T>,
-) -> Result<Option<RunSummary>>
-where
-	T: IssueTracker,
-{
-	let Some(_) = select_target_status_visible_program_candidate(&context)? else {
-		return Ok(None);
-	};
-
-	run_target_issue_once(context)
-}
-
-pub(crate) fn select_target_status_visible_program_candidate<T>(
-	context: &TargetIssueRunContext<'_, T>,
-) -> Result<Option<SelectedIssueRunCandidate>>
-where
-	T: IssueTracker,
-{
-	let worktree_manager = WorktreeManager::new(
-		context.project.service_id(),
-		context.project.repo_root(),
-		context.project.worktree_root(),
-	);
-
-	context.state_store.configure_dispatch_slot_root(
-		context.project.service_id(),
-		context.project.worktree_root(),
-	)?;
-
-	let target_issue_id = resolve_target_issue_id(context.tracker, context.issue_id)?;
-
-	if !context.lease_preacquired {
-		recover_runtime_state_from_tracker_and_worktrees(
-			context.tracker,
-			context.project,
-			context.workflow,
-			context.state_store,
-		)?;
-
-		if !context.dry_run {
-			reconcile_project_state(
-				context.tracker,
-				context.project,
-				context.workflow,
-				context.state_store,
-				&worktree_manager,
-			)?;
-			reconcile_post_review_orchestration(
-				context.tracker,
-				context.project,
-				context.workflow,
-				context.state_store,
-			)?;
-		}
-	}
-
-	let excluded_issue_ids = execution_program_non_target_mapped_issue_ids(
-		context.state_store,
-		context.project.service_id(),
-		&target_issue_id,
-	)?;
-	let excluded_issue_ids = excluded_issue_ids.iter().map(String::as_str).collect::<Vec<_>>();
-	let ProgramSchedulerSelection { selected, .. } =
-		select_execution_program_run_candidate_with_summary(
-			context.tracker,
-			context.project,
-			context.workflow,
-			context.state_store,
-			&excluded_issue_ids,
-		)?;
-	let Some(selected) = selected else {
-		return Ok(None);
-	};
-
-	if selected.issue.id != target_issue_id {
-		return Ok(None);
-	}
-
-	Ok(Some(selected))
-}
-
-fn execution_program_non_target_mapped_issue_ids(
-	state_store: &StateStore,
-	service_id: &str,
-	target_issue_id: &str,
-) -> Result<Vec<String>> {
-	let records = state_store.list_execution_programs(service_id)?;
-
-	Ok(records
-		.iter()
-		.flat_map(|record| record.program().nodes())
-		.filter_map(|node| node.linear_issue())
-		.map(|issue| issue.issue_id())
-		.filter(|issue_id| *issue_id != target_issue_id)
-		.map(str::to_owned)
-		.collect::<BTreeSet<_>>()
-		.into_iter()
-		.collect())
-}
-
-fn target_issue_has_status_visible_review_repair<T>(
-	context: &TargetIssueRunContext<'_, T>,
-) -> Result<bool>
-where
-	T: IssueTracker,
-{
-	let target_issue_id = resolve_target_issue_id(context.tracker, context.issue_id)?;
-	let review_state_inspector = GhPullRequestReviewStateInspector {
-		github_token_env_var: Some(context.project.github().token_env_var().to_owned()),
-		github_command_path: context.project.github().command_path().map(Path::to_path_buf),
-	};
-
-	Ok(build_post_review_lane_statuses(
-		context.tracker,
-		context.project,
-		context.workflow,
-		context.state_store,
-		&review_state_inspector,
-	)?
-	.into_iter()
-	.any(|lane| lane.issue_id == target_issue_id && post_review_lane_is_repair_candidate(&lane)))
-}
-
-fn run_target_status_visible_review_repair_once<T>(
-	context: TargetIssueRunContext<'_, T>,
-) -> Result<Option<RunSummary>>
-where
-	T: IssueTracker,
-{
-	let target_issue_id = resolve_target_issue_id(context.tracker, context.issue_id)?;
-	let review_state_inspector = GhPullRequestReviewStateInspector {
-		github_token_env_var: Some(context.project.github().token_env_var().to_owned()),
-		github_command_path: context.project.github().command_path().map(Path::to_path_buf),
-	};
-	let Some(_issue) = select_target_post_review_repair_issue_candidate_with_inspector(
-		context.tracker,
-		context.project,
-		context.workflow,
-		context.state_store,
-		&target_issue_id,
-		context.issue_id,
-		&review_state_inspector,
-	)?
-	else {
-		return Ok(None);
-	};
-
-	run_target_issue_once(target_issue_run_context_with_dispatch_mode(
-		&context,
-		IssueDispatchMode::ReviewRepair,
-	))
-}
-
-fn target_issue_has_status_visible_closeout<T>(
-	context: &TargetIssueRunContext<'_, T>,
-) -> Result<bool>
-where
-	T: IssueTracker,
-{
-	let target_issue_id = resolve_target_issue_id(context.tracker, context.issue_id)?;
-	let completed_state = context.workflow.frontmatter().tracker().resolved_completed_state();
-	let review_state_inspector = GhPullRequestReviewStateInspector {
-		github_token_env_var: Some(context.project.github().token_env_var().to_owned()),
-		github_command_path: context.project.github().command_path().map(Path::to_path_buf),
-	};
-
-	Ok(build_post_review_lane_statuses(
-		context.tracker,
-		context.project,
-		context.workflow,
-		context.state_store,
-		&review_state_inspector,
-	)?
-	.into_iter()
-	.any(|lane| {
-		lane.issue_id == target_issue_id
-			&& post_review_lane_is_closeout_candidate(&lane, completed_state)
-	}))
-}
-
-fn run_target_status_visible_closeout_once<T>(
-	context: TargetIssueRunContext<'_, T>,
-) -> Result<Option<RunSummary>>
-where
-	T: IssueTracker,
-{
-	let target_issue_id = resolve_target_issue_id(context.tracker, context.issue_id)?;
-	let review_state_inspector = GhPullRequestReviewStateInspector {
-		github_token_env_var: Some(context.project.github().token_env_var().to_owned()),
-		github_command_path: context.project.github().command_path().map(Path::to_path_buf),
-	};
-	let Some(candidate) = select_target_post_review_closeout_issue_candidate_with_inspector(
-		context.tracker,
-		context.project,
-		context.workflow,
-		context.state_store,
-		&target_issue_id,
-		context.issue_id,
-		&review_state_inspector,
-	)?
-	else {
-		return Ok(None);
-	};
-	let preferred_run_identity =
-		candidate.preferred_run_identity.as_ref().map(|identity| PreferredRunIdentity {
-			run_id: identity.run_id.as_str(),
-			attempt_number: identity.attempt_number,
-		});
-
-	run_target_issue_once(TargetIssueRunContext {
-		tracker: context.tracker,
-		project: context.project,
-		workflow: context.workflow,
-		state_store: context.state_store,
-		issue_id: context.issue_id,
-		preferred_issue_state: context.preferred_issue_state,
-		preferred_initial_issue_state: context.preferred_initial_issue_state,
-		dry_run: context.dry_run,
-		lease_preacquired: context.lease_preacquired,
-		preferred_issue_claim_fd: context.preferred_issue_claim_fd,
-		preferred_dispatch_slot_fd: context.preferred_dispatch_slot_fd,
-		preferred_dispatch_slot_index: context.preferred_dispatch_slot_index,
-		dispatch_mode: IssueDispatchMode::Closeout,
-		preferred_run_identity,
-		preferred_retry_budget_base: context.preferred_retry_budget_base,
-	})
-}
-
 fn target_issue_reuses_existing_closeout_claim<T>(
 	context: &TargetIssueRunContext<'_, T>,
 	issue_id: &str,
@@ -505,7 +247,10 @@ pub(crate) fn closeout_lane_active_claim_blocks_dispatch(
 	retained_closeout_lease_has_fresh_activity(&lease, issue, project, now_unix_epoch)
 }
 
-fn target_issue_run_context_with_dispatch_mode<'a, T>(
+pub(in crate::orchestrator::run_cycle::target_issue) fn target_issue_run_context_with_dispatch_mode<
+	'a,
+	T,
+>(
 	context: &TargetIssueRunContext<'a, T>,
 	dispatch_mode: IssueDispatchMode,
 ) -> TargetIssueRunContext<'a, T> {
@@ -528,7 +273,10 @@ fn target_issue_run_context_with_dispatch_mode<'a, T>(
 	}
 }
 
-fn resolve_target_issue_id<T>(tracker: &T, issue_reference: &str) -> Result<String>
+pub(in crate::orchestrator::run_cycle::target_issue) fn resolve_target_issue_id<T>(
+	tracker: &T,
+	issue_reference: &str,
+) -> Result<String>
 where
 	T: IssueTracker,
 {

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue/inferred.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue/inferred.rs
@@ -1,0 +1,53 @@
+use crate::orchestrator::{
+	IssueDispatchMode, IssueTracker, Result, RunSummary, TargetIssueRunContext,
+	run_cycle::target_issue::{self, post_review, program},
+};
+
+pub(crate) fn run_target_issue_once_with_inferred_dispatch<T>(
+	context: TargetIssueRunContext<'_, T>,
+) -> Result<Option<RunSummary>>
+where
+	T: IssueTracker,
+{
+	if post_review::target_issue_has_status_visible_review_repair(&context)? {
+		return post_review::run_target_status_visible_review_repair_once(context);
+	}
+	if post_review::target_issue_has_status_visible_closeout(&context)? {
+		return post_review::run_target_status_visible_closeout_once(context);
+	}
+
+	if let Some(summary) = program::run_target_status_visible_program_once(
+		target_issue::target_issue_run_context_with_dispatch_mode(
+			&context,
+			IssueDispatchMode::Program,
+		),
+	)? {
+		return Ok(Some(summary));
+	}
+	if let Some(summary) = target_issue::run_target_issue_once(
+		target_issue::target_issue_run_context_with_dispatch_mode(
+			&context,
+			IssueDispatchMode::Normal,
+		),
+	)? {
+		return Ok(Some(summary));
+	}
+	if let Some(summary) = target_issue::run_target_issue_once(
+		target_issue::target_issue_run_context_with_dispatch_mode(
+			&context,
+			IssueDispatchMode::Retry,
+		),
+	)? {
+		return Ok(Some(summary));
+	}
+	if let Some(summary) = post_review::run_target_status_visible_review_repair_once(
+		target_issue::target_issue_run_context_with_dispatch_mode(
+			&context,
+			IssueDispatchMode::ReviewRepair,
+		),
+	)? {
+		return Ok(Some(summary));
+	}
+
+	post_review::run_target_status_visible_closeout_once(context)
+}

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue/post_review.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue/post_review.rs
@@ -1,0 +1,145 @@
+use std::path::Path;
+
+use crate::orchestrator::{
+	self, GhPullRequestReviewStateInspector, IssueDispatchMode, IssueTracker, PreferredRunIdentity,
+	Result, RunSummary, TargetIssueRunContext, run_cycle::target_issue,
+};
+
+pub(in crate::orchestrator::run_cycle::target_issue) fn target_issue_has_status_visible_review_repair<
+	T,
+>(
+	context: &TargetIssueRunContext<'_, T>,
+) -> Result<bool>
+where
+	T: IssueTracker,
+{
+	let target_issue_id = target_issue::resolve_target_issue_id(context.tracker, context.issue_id)?;
+	let review_state_inspector = GhPullRequestReviewStateInspector {
+		github_token_env_var: Some(context.project.github().token_env_var().to_owned()),
+		github_command_path: context.project.github().command_path().map(Path::to_path_buf),
+	};
+
+	Ok(orchestrator::build_post_review_lane_statuses(
+		context.tracker,
+		context.project,
+		context.workflow,
+		context.state_store,
+		&review_state_inspector,
+	)?
+	.into_iter()
+	.any(|lane| {
+		lane.issue_id == target_issue_id
+			&& orchestrator::post_review_lane_is_repair_candidate(&lane)
+	}))
+}
+
+pub(in crate::orchestrator::run_cycle::target_issue) fn run_target_status_visible_review_repair_once<
+	T,
+>(
+	context: TargetIssueRunContext<'_, T>,
+) -> Result<Option<RunSummary>>
+where
+	T: IssueTracker,
+{
+	let target_issue_id = target_issue::resolve_target_issue_id(context.tracker, context.issue_id)?;
+	let review_state_inspector = GhPullRequestReviewStateInspector {
+		github_token_env_var: Some(context.project.github().token_env_var().to_owned()),
+		github_command_path: context.project.github().command_path().map(Path::to_path_buf),
+	};
+	let Some(_issue) =
+		orchestrator::select_target_post_review_repair_issue_candidate_with_inspector(
+			context.tracker,
+			context.project,
+			context.workflow,
+			context.state_store,
+			&target_issue_id,
+			context.issue_id,
+			&review_state_inspector,
+		)?
+	else {
+		return Ok(None);
+	};
+
+	target_issue::run_target_issue_once(target_issue::target_issue_run_context_with_dispatch_mode(
+		&context,
+		IssueDispatchMode::ReviewRepair,
+	))
+}
+
+pub(in crate::orchestrator::run_cycle::target_issue) fn target_issue_has_status_visible_closeout<
+	T,
+>(
+	context: &TargetIssueRunContext<'_, T>,
+) -> Result<bool>
+where
+	T: IssueTracker,
+{
+	let target_issue_id = target_issue::resolve_target_issue_id(context.tracker, context.issue_id)?;
+	let completed_state = context.workflow.frontmatter().tracker().resolved_completed_state();
+	let review_state_inspector = GhPullRequestReviewStateInspector {
+		github_token_env_var: Some(context.project.github().token_env_var().to_owned()),
+		github_command_path: context.project.github().command_path().map(Path::to_path_buf),
+	};
+
+	Ok(orchestrator::build_post_review_lane_statuses(
+		context.tracker,
+		context.project,
+		context.workflow,
+		context.state_store,
+		&review_state_inspector,
+	)?
+	.into_iter()
+	.any(|lane| {
+		lane.issue_id == target_issue_id
+			&& orchestrator::post_review_lane_is_closeout_candidate(&lane, completed_state)
+	}))
+}
+
+pub(in crate::orchestrator::run_cycle::target_issue) fn run_target_status_visible_closeout_once<T>(
+	context: TargetIssueRunContext<'_, T>,
+) -> Result<Option<RunSummary>>
+where
+	T: IssueTracker,
+{
+	let target_issue_id = target_issue::resolve_target_issue_id(context.tracker, context.issue_id)?;
+	let review_state_inspector = GhPullRequestReviewStateInspector {
+		github_token_env_var: Some(context.project.github().token_env_var().to_owned()),
+		github_command_path: context.project.github().command_path().map(Path::to_path_buf),
+	};
+	let Some(candidate) =
+		orchestrator::select_target_post_review_closeout_issue_candidate_with_inspector(
+			context.tracker,
+			context.project,
+			context.workflow,
+			context.state_store,
+			&target_issue_id,
+			context.issue_id,
+			&review_state_inspector,
+		)?
+	else {
+		return Ok(None);
+	};
+	let preferred_run_identity =
+		candidate.preferred_run_identity.as_ref().map(|identity| PreferredRunIdentity {
+			run_id: identity.run_id.as_str(),
+			attempt_number: identity.attempt_number,
+		});
+
+	target_issue::run_target_issue_once(TargetIssueRunContext {
+		tracker: context.tracker,
+		project: context.project,
+		workflow: context.workflow,
+		state_store: context.state_store,
+		issue_id: context.issue_id,
+		preferred_issue_state: context.preferred_issue_state,
+		preferred_initial_issue_state: context.preferred_initial_issue_state,
+		dry_run: context.dry_run,
+		lease_preacquired: context.lease_preacquired,
+		preferred_issue_claim_fd: context.preferred_issue_claim_fd,
+		preferred_dispatch_slot_fd: context.preferred_dispatch_slot_fd,
+		preferred_dispatch_slot_index: context.preferred_dispatch_slot_index,
+		dispatch_mode: IssueDispatchMode::Closeout,
+		preferred_run_identity,
+		preferred_retry_budget_base: context.preferred_retry_budget_base,
+	})
+}

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue/program.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue/program.rs
@@ -1,0 +1,107 @@
+use std::collections::BTreeSet;
+
+use crate::orchestrator::{
+	self, IssueTracker, ProgramSchedulerSelection, Result, RunSummary, SelectedIssueRunCandidate,
+	StateStore, TargetIssueRunContext, WorktreeManager, run_cycle::target_issue,
+};
+
+pub(in crate::orchestrator::run_cycle::target_issue) fn run_target_status_visible_program_once<T>(
+	context: TargetIssueRunContext<'_, T>,
+) -> Result<Option<RunSummary>>
+where
+	T: IssueTracker,
+{
+	let Some(_) = select_target_status_visible_program_candidate(&context)? else {
+		return Ok(None);
+	};
+
+	target_issue::run_target_issue_once(context)
+}
+
+pub(crate) fn select_target_status_visible_program_candidate<T>(
+	context: &TargetIssueRunContext<'_, T>,
+) -> Result<Option<SelectedIssueRunCandidate>>
+where
+	T: IssueTracker,
+{
+	let worktree_manager = WorktreeManager::new(
+		context.project.service_id(),
+		context.project.repo_root(),
+		context.project.worktree_root(),
+	);
+
+	context.state_store.configure_dispatch_slot_root(
+		context.project.service_id(),
+		context.project.worktree_root(),
+	)?;
+
+	let target_issue_id = target_issue::resolve_target_issue_id(context.tracker, context.issue_id)?;
+
+	if !context.lease_preacquired {
+		orchestrator::recover_runtime_state_from_tracker_and_worktrees(
+			context.tracker,
+			context.project,
+			context.workflow,
+			context.state_store,
+		)?;
+
+		if !context.dry_run {
+			orchestrator::reconcile_project_state(
+				context.tracker,
+				context.project,
+				context.workflow,
+				context.state_store,
+				&worktree_manager,
+			)?;
+			orchestrator::reconcile_post_review_orchestration(
+				context.tracker,
+				context.project,
+				context.workflow,
+				context.state_store,
+			)?;
+		}
+	}
+
+	let excluded_issue_ids = execution_program_non_target_mapped_issue_ids(
+		context.state_store,
+		context.project.service_id(),
+		&target_issue_id,
+	)?;
+	let excluded_issue_ids = excluded_issue_ids.iter().map(String::as_str).collect::<Vec<_>>();
+	let ProgramSchedulerSelection { selected, .. } =
+		orchestrator::select_execution_program_run_candidate_with_summary(
+			context.tracker,
+			context.project,
+			context.workflow,
+			context.state_store,
+			&excluded_issue_ids,
+		)?;
+	let Some(selected) = selected else {
+		return Ok(None);
+	};
+
+	if selected.issue.id != target_issue_id {
+		return Ok(None);
+	}
+
+	Ok(Some(selected))
+}
+
+fn execution_program_non_target_mapped_issue_ids(
+	state_store: &StateStore,
+	service_id: &str,
+	target_issue_id: &str,
+) -> Result<Vec<String>> {
+	let records = state_store.list_execution_programs(service_id)?;
+
+	Ok(records
+		.iter()
+		.flat_map(|record| record.program().nodes())
+		.filter_map(|node| node.linear_issue())
+		.map(|issue| issue.issue_id())
+		.filter(|issue_id| *issue_id != target_issue_id)
+		.map(str::to_owned)
+		.collect::<BTreeSet<_>>()
+		.into_iter()
+		.collect())
+}

--- a/apps/decodex/src/orchestrator/types/dispatch.rs
+++ b/apps/decodex/src/orchestrator/types/dispatch.rs
@@ -1,12 +1,6 @@
-use crate::tracker;
-
 use super::{
-	Duration, IssueTracker, PostReviewLaneClassification, PullRequestReviewState,
-	RetainedReviewLane, RetainedReviewLaneBlocked, RetainedReviewRunIdentity, RunSummary,
-	ServiceConfig, StateStore, TrackerIssue, WorkflowDocument,
-	issue_passes_closeout_dispatch_policy, issue_passes_dispatch_policy,
-	issue_passes_retry_dispatch_policy, issue_passes_review_repair_dispatch_policy,
-	issue_retry_budget_exhausted, ordinary_dispatch_blocked_by_retained_review_handoff,
+	Duration, PostReviewLaneClassification, PullRequestReviewState, RetainedReviewLane,
+	RetainedReviewLaneBlocked, RetainedReviewRunIdentity, RunSummary, TrackerIssue,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -25,58 +19,6 @@ impl IssueDispatchMode {
 			Self::Retry => "retry",
 			Self::ReviewRepair => "review_repair",
 			Self::Closeout => "closeout",
-		}
-	}
-
-	pub(crate) fn allows_issue(
-		self,
-		tracker: &dyn IssueTracker,
-		issue: &TrackerIssue,
-		project: &ServiceConfig,
-		workflow: &WorkflowDocument,
-		state_store: &StateStore,
-		hint: RetryIssueStateHint<'_>,
-	) -> crate::prelude::Result<bool> {
-		match self {
-			Self::Normal => {
-				let queue_label = tracker::automation_queue_label(project.service_id());
-
-				Ok(issue_passes_dispatch_policy(tracker, issue, workflow, &queue_label, false)?
-					&& !ordinary_dispatch_blocked_by_retained_review_handoff(
-						project.service_id(),
-						issue,
-						state_store,
-					)?)
-			},
-			Self::Program => {
-				let queue_label = tracker::automation_queue_label(project.service_id());
-
-				Ok(issue_passes_dispatch_policy(tracker, issue, workflow, &queue_label, true)?
-					&& !ordinary_dispatch_blocked_by_retained_review_handoff(
-						project.service_id(),
-						issue,
-						state_store,
-					)?)
-			},
-			Self::Retry => issue_passes_retry_dispatch_policy(
-				tracker,
-				issue,
-				project,
-				workflow,
-				state_store,
-				hint,
-			),
-			Self::ReviewRepair => {
-				Ok(issue_passes_review_repair_dispatch_policy(tracker, issue, project, workflow)?
-					&& !issue_retry_budget_exhausted(workflow, state_store, &issue.id)?)
-			},
-			Self::Closeout => issue_passes_closeout_dispatch_policy(
-				tracker,
-				issue,
-				project,
-				workflow,
-				state_store,
-			),
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- split targeted issue dispatch into flat Rust modules under `run_cycle/target_issue/` without introducing `mod.rs`
- move current-dispatch policy evaluation out of `IssueDispatchMode` and into `dispatch_policy`
- avoid the ignored `run_cycle/target/` directory name by using `target_issue`

## Validation
- `cargo check -p decodex --all-targets --all-features`
- `cargo test -p decodex --all-features orchestrator::tests::targeted_`
- `cargo test -p decodex --all-features orchestrator::tests::prepare_issue_run_`
- `cargo test -p decodex --all-features orchestrator::tests::program_reconciler::`
- `find apps -type f -path '*/mod.rs' -print | sort | wc -l` => `0`\n- `git ls-files '*/mod.rs' | wc -l` => `0`\n- `cargo make lint-vstyle-rust` still exits nonzero on existing global style debt; filtered output has no `mod.rs` rule hits. Touched legacy facades still report pre-existing wildcard/super import and module ordering style debt.\n