### PR TITLE
Split Decodex app account store modules

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
@@ -1,30 +1,24 @@
 import AppKit
 import Foundation
-import OSLog
-
-private let accountStoreLog = Logger(subsystem: "ink.hack.DecodexApp", category: "AccountStore")
-private let accountUsageRefreshIntervalNanoseconds: UInt64 = 15_000_000_000
-private let operatorSnapshotReconnectInitialDelay: UInt64 = 1_000_000_000
-private let operatorSnapshotReconnectMaxDelay: UInt64 = 30_000_000_000
 
 @MainActor
 final class AccountStore: ObservableObject {
-	@Published private(set) var accountList: AccountListResponse?
-	@Published private(set) var fastMode: CodexFastModeResponse?
-	@Published private(set) var operatorSnapshot: OperatorSnapshotResponse?
-	@Published private(set) var operatorPresentation: OperatorSnapshotPresentation?
-	@Published private(set) var operatorSnapshotUpdatedAt: Date?
-	@Published private(set) var isRefreshing = false
-	@Published private(set) var isLoggingIn = false
-	@Published private(set) var isSettingFastMode = false
+	@Published var accountList: AccountListResponse?
+	@Published var fastMode: CodexFastModeResponse?
+	@Published var operatorSnapshot: OperatorSnapshotResponse?
+	@Published var operatorPresentation: OperatorSnapshotPresentation?
+	@Published var operatorSnapshotUpdatedAt: Date?
+	@Published var isRefreshing = false
+	@Published var isLoggingIn = false
+	@Published var isSettingFastMode = false
 	@Published var loginTranscript = ""
 	@Published var notice: String?
-	@Published private var pendingLogoutRemovalKeys = Set<String>()
+	@Published var pendingLogoutRemovalKeys = Set<String>()
 
-	private let bridge = DecodexAppBridge()
-	private var automaticRefreshTask: Task<Void, Never>?
-	private var operatorSnapshotStreamTask: Task<Void, Never>?
-	private var operatorSnapshotPublishedAtUnixEpoch: Int64?
+	let bridge = DecodexAppBridge()
+	var automaticRefreshTask: Task<Void, Never>?
+	var operatorSnapshotStreamTask: Task<Void, Never>?
+	var operatorSnapshotPublishedAtUnixEpoch: Int64?
 
 	deinit {
 		automaticRefreshTask?.cancel()
@@ -79,38 +73,8 @@ final class AccountStore: ObservableObject {
 			return "Ready"
 		}
 
-		return "Importing account"
-	}
-
-	func refresh(force: Bool = false) async {
-		guard isRefreshing == false else {
-			return
+			return "Importing account"
 		}
-
-		isRefreshing = true
-		defer {
-			isRefreshing = false
-		}
-
-		do {
-			applyAccountList(try await bridge.runJSON(
-				.accountList(forceRefresh: force),
-				as: AccountListResponse.self
-			))
-			notice = nil
-			await refreshFastMode()
-		} catch {
-			notice = error.localizedDescription
-		}
-	}
-
-	func refreshIfNeeded() async {
-		guard accountList == nil else {
-			return
-		}
-
-		await refresh(force: true)
-	}
 
 	func openWebUI() async {
 		do {
@@ -130,290 +94,5 @@ final class AccountStore: ObservableObject {
 
 		loginTranscript = ""
 		notice = nil
-	}
-
-	func startAutomaticRefresh() {
-		guard automaticRefreshTask == nil else {
-			return
-		}
-
-		automaticRefreshTask = Task { [weak self] in
-			while Task.isCancelled == false {
-				do {
-					try await Task.sleep(nanoseconds: accountUsageRefreshIntervalNanoseconds)
-				} catch {
-					return
-				}
-
-				await self?.refresh(force: true)
-			}
-		}
-
-		startOperatorSnapshotStream()
-	}
-
-	func startOperatorSnapshotStream() {
-		guard operatorSnapshotStreamTask == nil else {
-			return
-		}
-
-		operatorSnapshotStreamTask = makeOperatorSnapshotStreamTask()
-	}
-
-	private func makeOperatorSnapshotStreamTask() -> Task<Void, Never> {
-		Task { [weak self] in
-			await self?.runOperatorSnapshotStream()
-		}
-	}
-
-	private func runOperatorSnapshotStream() async {
-		var reconnectDelay = operatorSnapshotReconnectInitialDelay
-
-		while Task.isCancelled == false {
-			do {
-				try await connectOperatorSnapshotStream()
-				reconnectDelay = operatorSnapshotReconnectInitialDelay
-			} catch {
-				accountStoreLog.warning("Operator snapshot stream dropped: \(error.localizedDescription, privacy: .public)")
-			}
-
-			do {
-				try await Task.sleep(nanoseconds: reconnectDelay)
-			} catch {
-				return
-			}
-			reconnectDelay = min(operatorSnapshotReconnectMaxDelay, reconnectDelay * 2)
-		}
-	}
-
-	private func connectOperatorSnapshotStream() async throws {
-		let url = try await DecodexServerBridge.shared.dashboardWebSocketURL()
-		let socket = DashboardWebSocketConnection(url: url)
-
-		try await withTaskCancellationHandler {
-			do {
-				try await socket.connect()
-				while Task.isCancelled == false {
-					let data = try await socket.readMessageData()
-					do {
-						let event = try JSONDecoder().decode(OperatorDashboardSocketEvent.self, from: data)
-						applyOperatorDashboardEvent(event)
-					} catch {
-						accountStoreLog.debug("Skipped dashboard WebSocket message bytes=\(data.count, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
-						continue
-					}
-				}
-				await socket.close()
-			} catch {
-				await socket.close()
-				throw error
-			}
-		} onCancel: {
-			Task {
-				await socket.close()
-			}
-		}
-	}
-
-	func applyOperatorDashboardEvent(_ event: OperatorDashboardSocketEvent) {
-		guard let payload = event.payload else {
-			return
-		}
-
-		switch event.type {
-		case "snapshot":
-			guard let snapshot = payload.snapshot else {
-				return
-			}
-
-			operatorSnapshot = snapshot
-			operatorPresentation = snapshot.presentation
-			operatorSnapshotPublishedAtUnixEpoch = payload.snapshotPublishedAtUnixEpoch
-			operatorSnapshotUpdatedAt = payload.snapshotPublishedAt ?? Date()
-		case "runActivity":
-			guard let presentation = payload.presentation else {
-				return
-			}
-			guard isStaleRunActivity(payload) == false else {
-				return
-			}
-
-			operatorPresentation = presentation
-			operatorSnapshotUpdatedAt = payload.emittedAt ?? Date()
-		default:
-			break
-		}
-	}
-
-	private func isStaleRunActivity(_ payload: OperatorDashboardSocketPayload) -> Bool {
-		guard let emittedAtUnixEpoch = payload.emittedAtUnixEpoch,
-			let snapshotPublishedAtUnixEpoch = operatorSnapshotPublishedAtUnixEpoch
-		else {
-			return false
-		}
-
-		return emittedAtUnixEpoch < snapshotPublishedAtUnixEpoch
-	}
-
-	func useInCodex(_ account: CodexAccount) async {
-		let previousAccountList = accountList
-		notice = nil
-		accountList = accountList?.updatingCodexAuth(account.authIdentity)
-
-		do {
-			let response = try await bridge.runJSON(
-				.accountUse(selector: account.selector),
-				as: CodexAuthUseResponse.self
-			)
-			accountList = accountList?.updatingCodexAuth(response.account)
-			notice = nil
-		} catch {
-			accountList = previousAccountList
-			notice = error.localizedDescription
-		}
-	}
-
-	func select(_ account: CodexAccount) async {
-		do {
-			if account.selected {
-				applyAccountList(try await bridge.runJSON(.accountClear, as: AccountListResponse.self))
-			} else {
-				applyAccountList(try await bridge.runJSON(
-					.accountSelect(selector: account.selector),
-					as: AccountListResponse.self
-				))
-			}
-			notice = nil
-		} catch {
-			notice = error.localizedDescription
-		}
-	}
-
-	func clearSelection() async {
-		do {
-			applyAccountList(try await bridge.runJSON(.accountClear, as: AccountListResponse.self))
-			notice = nil
-		} catch {
-			notice = error.localizedDescription
-		}
-	}
-
-	func setFastMode(_ enabled: Bool) async {
-		guard isSettingFastMode == false else {
-			return
-		}
-
-		let previous = fastMode
-		fastMode = CodexFastModeResponse(
-			codexConfigPath: previous?.codexConfigPath ?? "",
-			enabled: enabled
-		)
-		isSettingFastMode = true
-		defer {
-			isSettingFastMode = false
-		}
-
-		do {
-			fastMode = try await bridge.runJSON(
-				.codexFastModeSet(enabled: enabled),
-				as: CodexFastModeResponse.self
-			)
-			notice = nil
-		} catch {
-			fastMode = previous
-			notice = error.localizedDescription
-		}
-	}
-
-	func logout(_ account: CodexAccount) async throws {
-		beginOptimisticLogoutRemoval(account)
-
-		do {
-			applyAccountList(try await bridge.runJSON(
-				.accountLogout(selector: account.selector),
-				as: AccountListResponse.self
-			))
-			notice = nil
-		} catch {
-			cancelOptimisticLogoutRemoval(account)
-			throw error
-		}
-	}
-
-	func login() async {
-		isLoggingIn = true
-		loginTranscript = ""
-		notice = nil
-
-		do {
-			applyAccountList(try await bridge.runStreaming(.accountLogin(), as: AccountListResponse.self) { [weak self] chunk in
-				self?.loginTranscript += chunk
-			})
-			notice = nil
-			await refreshFastMode()
-		} catch {
-			notice = error.localizedDescription
-		}
-
-		isLoggingIn = false
-	}
-
-	private func refreshFastMode() async {
-		do {
-			fastMode = try await bridge.runJSON(
-				.codexFastModeStatus,
-				as: CodexFastModeResponse.self
-			)
-		} catch {
-			notice = error.localizedDescription
-		}
-	}
-
-	func beginOptimisticLogoutRemoval(_ account: CodexAccount) {
-		pendingLogoutRemovalKeys.formUnion(Self.logoutRemovalKeys(for: account))
-	}
-
-	func cancelOptimisticLogoutRemoval(_ account: CodexAccount) {
-		pendingLogoutRemovalKeys.subtract(Self.logoutRemovalKeys(for: account))
-	}
-
-	func applyAccountList(_ response: AccountListResponse) {
-		accountList = response
-		reconcilePendingLogoutRemovals(with: response.accounts)
-	}
-
-	private func reconcilePendingLogoutRemovals(with accounts: [CodexAccount]) {
-		guard pendingLogoutRemovalKeys.isEmpty == false else {
-			return
-		}
-
-		let visibleKeys = accounts.reduce(into: Set<String>()) { keys, account in
-			keys.formUnion(Self.logoutRemovalKeys(for: account))
-		}
-		pendingLogoutRemovalKeys = pendingLogoutRemovalKeys.intersection(visibleKeys)
-	}
-
-	private func isLogoutRemovalPending(for account: CodexAccount) -> Bool {
-		Self.logoutRemovalKeys(for: account).isDisjoint(with: pendingLogoutRemovalKeys) == false
-	}
-
-	private static func logoutRemovalKeys(for account: CodexAccount) -> Set<String> {
-		[
-			account.id,
-			account.selector,
-			account.email,
-			account.accountFingerprint,
-		]
-		.compactMap { value in
-			guard let key = value?.trimmingCharacters(in: .whitespacesAndNewlines),
-				key.isEmpty == false
-			else {
-				return nil
-			}
-			return key
-		}
-		.reduce(into: Set<String>()) { keys, key in
-			keys.insert(key)
-		}
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/AccountStoreAccountList.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStoreAccountList.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+extension AccountStore {
+	func beginOptimisticLogoutRemoval(_ account: CodexAccount) {
+		pendingLogoutRemovalKeys.formUnion(Self.logoutRemovalKeys(for: account))
+	}
+
+	func cancelOptimisticLogoutRemoval(_ account: CodexAccount) {
+		pendingLogoutRemovalKeys.subtract(Self.logoutRemovalKeys(for: account))
+	}
+
+	func applyAccountList(_ response: AccountListResponse) {
+		accountList = response
+		reconcilePendingLogoutRemovals(with: response.accounts)
+	}
+
+	private func reconcilePendingLogoutRemovals(with accounts: [CodexAccount]) {
+		guard pendingLogoutRemovalKeys.isEmpty == false else {
+			return
+		}
+
+		let visibleKeys = accounts.reduce(into: Set<String>()) { keys, account in
+			keys.formUnion(Self.logoutRemovalKeys(for: account))
+		}
+		pendingLogoutRemovalKeys = pendingLogoutRemovalKeys.intersection(visibleKeys)
+	}
+
+	func isLogoutRemovalPending(for account: CodexAccount) -> Bool {
+		Self.logoutRemovalKeys(for: account).isDisjoint(with: pendingLogoutRemovalKeys) == false
+	}
+
+	private static func logoutRemovalKeys(for account: CodexAccount) -> Set<String> {
+		[
+			account.id,
+			account.selector,
+			account.email,
+			account.accountFingerprint,
+		]
+		.compactMap { value in
+			guard let key = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+				key.isEmpty == false
+			else {
+				return nil
+			}
+			return key
+		}
+		.reduce(into: Set<String>()) { keys, key in
+			keys.insert(key)
+		}
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/AccountStoreActions.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStoreActions.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+extension AccountStore {
+	func useInCodex(_ account: CodexAccount) async {
+		let previousAccountList = accountList
+		notice = nil
+		accountList = accountList?.updatingCodexAuth(account.authIdentity)
+
+		do {
+			let response = try await bridge.runJSON(
+				.accountUse(selector: account.selector),
+				as: CodexAuthUseResponse.self
+			)
+			accountList = accountList?.updatingCodexAuth(response.account)
+			notice = nil
+		} catch {
+			accountList = previousAccountList
+			notice = error.localizedDescription
+		}
+	}
+
+	func select(_ account: CodexAccount) async {
+		do {
+			if account.selected {
+				applyAccountList(try await bridge.runJSON(.accountClear, as: AccountListResponse.self))
+			} else {
+				applyAccountList(try await bridge.runJSON(
+					.accountSelect(selector: account.selector),
+					as: AccountListResponse.self
+				))
+			}
+			notice = nil
+		} catch {
+			notice = error.localizedDescription
+		}
+	}
+
+	func clearSelection() async {
+		do {
+			applyAccountList(try await bridge.runJSON(.accountClear, as: AccountListResponse.self))
+			notice = nil
+		} catch {
+			notice = error.localizedDescription
+		}
+	}
+
+	func setFastMode(_ enabled: Bool) async {
+		guard isSettingFastMode == false else {
+			return
+		}
+
+		let previous = fastMode
+		fastMode = CodexFastModeResponse(
+			codexConfigPath: previous?.codexConfigPath ?? "",
+			enabled: enabled
+		)
+		isSettingFastMode = true
+		defer {
+			isSettingFastMode = false
+		}
+
+		do {
+			fastMode = try await bridge.runJSON(
+				.codexFastModeSet(enabled: enabled),
+				as: CodexFastModeResponse.self
+			)
+			notice = nil
+		} catch {
+			fastMode = previous
+			notice = error.localizedDescription
+		}
+	}
+
+	func logout(_ account: CodexAccount) async throws {
+		beginOptimisticLogoutRemoval(account)
+
+		do {
+			applyAccountList(try await bridge.runJSON(
+				.accountLogout(selector: account.selector),
+				as: AccountListResponse.self
+			))
+			notice = nil
+		} catch {
+			cancelOptimisticLogoutRemoval(account)
+			throw error
+		}
+	}
+
+	func login() async {
+		isLoggingIn = true
+		loginTranscript = ""
+		notice = nil
+
+		do {
+			applyAccountList(try await bridge.runStreaming(.accountLogin(), as: AccountListResponse.self) { [weak self] chunk in
+				self?.loginTranscript += chunk
+			})
+			notice = nil
+			await refreshFastMode()
+		} catch {
+			notice = error.localizedDescription
+		}
+
+		isLoggingIn = false
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/AccountStoreOperatorStream.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStoreOperatorStream.swift
@@ -1,0 +1,111 @@
+import Foundation
+import OSLog
+
+private let accountStoreLog = Logger(subsystem: "ink.hack.DecodexApp", category: "AccountStore")
+private let operatorSnapshotReconnectInitialDelay: UInt64 = 1_000_000_000
+private let operatorSnapshotReconnectMaxDelay: UInt64 = 30_000_000_000
+
+extension AccountStore {
+	func startOperatorSnapshotStream() {
+		guard operatorSnapshotStreamTask == nil else {
+			return
+		}
+
+		operatorSnapshotStreamTask = makeOperatorSnapshotStreamTask()
+	}
+
+	private func makeOperatorSnapshotStreamTask() -> Task<Void, Never> {
+		Task { [weak self] in
+			await self?.runOperatorSnapshotStream()
+		}
+	}
+
+	private func runOperatorSnapshotStream() async {
+		var reconnectDelay = operatorSnapshotReconnectInitialDelay
+
+		while Task.isCancelled == false {
+			do {
+				try await connectOperatorSnapshotStream()
+				reconnectDelay = operatorSnapshotReconnectInitialDelay
+			} catch {
+				accountStoreLog.warning("Operator snapshot stream dropped: \(error.localizedDescription, privacy: .public)")
+			}
+
+			do {
+				try await Task.sleep(nanoseconds: reconnectDelay)
+			} catch {
+				return
+			}
+			reconnectDelay = min(operatorSnapshotReconnectMaxDelay, reconnectDelay * 2)
+		}
+	}
+
+	private func connectOperatorSnapshotStream() async throws {
+		let url = try await DecodexServerBridge.shared.dashboardWebSocketURL()
+		let socket = DashboardWebSocketConnection(url: url)
+
+		try await withTaskCancellationHandler {
+			do {
+				try await socket.connect()
+				while Task.isCancelled == false {
+					let data = try await socket.readMessageData()
+					do {
+						let event = try JSONDecoder().decode(OperatorDashboardSocketEvent.self, from: data)
+						applyOperatorDashboardEvent(event)
+					} catch {
+						accountStoreLog.debug("Skipped dashboard WebSocket message bytes=\(data.count, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+						continue
+					}
+				}
+				await socket.close()
+			} catch {
+				await socket.close()
+				throw error
+			}
+		} onCancel: {
+			Task {
+				await socket.close()
+			}
+		}
+	}
+
+	func applyOperatorDashboardEvent(_ event: OperatorDashboardSocketEvent) {
+		guard let payload = event.payload else {
+			return
+		}
+
+		switch event.type {
+		case "snapshot":
+			guard let snapshot = payload.snapshot else {
+				return
+			}
+
+			operatorSnapshot = snapshot
+			operatorPresentation = snapshot.presentation
+			operatorSnapshotPublishedAtUnixEpoch = payload.snapshotPublishedAtUnixEpoch
+			operatorSnapshotUpdatedAt = payload.snapshotPublishedAt ?? Date()
+		case "runActivity":
+			guard let presentation = payload.presentation else {
+				return
+			}
+			guard isStaleRunActivity(payload) == false else {
+				return
+			}
+
+			operatorPresentation = presentation
+			operatorSnapshotUpdatedAt = payload.emittedAt ?? Date()
+		default:
+			break
+		}
+	}
+
+	private func isStaleRunActivity(_ payload: OperatorDashboardSocketPayload) -> Bool {
+		guard let emittedAtUnixEpoch = payload.emittedAtUnixEpoch,
+			let snapshotPublishedAtUnixEpoch = operatorSnapshotPublishedAtUnixEpoch
+		else {
+			return false
+		}
+
+		return emittedAtUnixEpoch < snapshotPublishedAtUnixEpoch
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/AccountStoreRefresh.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStoreRefresh.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+private let accountUsageRefreshIntervalNanoseconds: UInt64 = 15_000_000_000
+
+extension AccountStore {
+	func refresh(force: Bool = false) async {
+		guard isRefreshing == false else {
+			return
+		}
+
+		isRefreshing = true
+		defer {
+			isRefreshing = false
+		}
+
+		do {
+			applyAccountList(try await bridge.runJSON(
+				.accountList(forceRefresh: force),
+				as: AccountListResponse.self
+			))
+			notice = nil
+			await refreshFastMode()
+		} catch {
+			notice = error.localizedDescription
+		}
+	}
+
+	func refreshIfNeeded() async {
+		guard accountList == nil else {
+			return
+		}
+
+		await refresh(force: true)
+	}
+
+	func startAutomaticRefresh() {
+		guard automaticRefreshTask == nil else {
+			return
+		}
+
+		automaticRefreshTask = Task { [weak self] in
+			while Task.isCancelled == false {
+				do {
+					try await Task.sleep(nanoseconds: accountUsageRefreshIntervalNanoseconds)
+				} catch {
+					return
+				}
+
+				await self?.refresh(force: true)
+			}
+		}
+
+		startOperatorSnapshotStream()
+	}
+
+	func refreshFastMode() async {
+		do {
+			fastMode = try await bridge.runJSON(
+				.codexFastModeStatus,
+				as: CodexFastModeResponse.self
+			)
+		} catch {
+			notice = error.localizedDescription
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- split AccountStore account-list mutation, user actions, refresh loop, and operator WebSocket stream logic into focused extension files
- keep AccountStore.swift focused on observable state, lifecycle cancellation, and derived read models
- preserve existing app-target internal boundaries while avoiding public API expansion

## Validation
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build --package-path apps/decodex-app
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app
- cargo vstyle curate --language swift --workspace
- git ls-files '*/mod.rs' | wc -l