### PR TITLE
Split tracker tool bridge modules

### DIFF
--- a/apps/decodex/src/agent/tracker_tool_bridge.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge.rs
@@ -1,13 +1,9 @@
+mod construction;
 mod inspectors;
 mod model;
 mod review;
+mod text;
 mod tools;
-
-use std::{borrow::Cow, cell::RefCell, path::Path};
-
-use color_eyre::Report;
-use serde_json::Value;
-use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 pub(crate) use self::model::{
 	DynamicToolCallResponse, DynamicToolContentItem, DynamicToolSpec, LocalRepoDetails,
@@ -15,6 +11,13 @@ pub(crate) use self::model::{
 	ReviewPolicyStopReason, ReviewPolicyStopRequested, RunCompletionDisposition,
 	TurnCompletionStatus,
 };
+
+use std::{cell::RefCell, path::Path};
+
+use color_eyre::Report;
+use serde_json::Value;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
 use self::{
 	inspectors::{
 		GhPullRequestInspector, LocalGitRepoInspector, resolve_review_handoff_github_token,
@@ -33,22 +36,21 @@ use self::{
 		ReviewFindingPolicyRecord, ReviewFindingPolicyState, ReviewHandoffArgs, ReviewPolicyPhase,
 		ReviewPolicyState, ReviewPolicyStatus, ScopeArgs, TerminalFinalizeArgs, TransitionArgs,
 	},
+	text::{
+		format_review_handoff_comment, format_review_repair_comment,
+		normalize_optional_progress_field, normalize_progress_list, normalize_summary,
+		public_summary_or_fallback,
+	},
 };
-
 #[cfg(test)]
 use self::inspectors::{
 	RepositoryIdentity, parse_github_repository_identity, parse_remote_head_symref_output,
 	resolve_lane_default_branch, review_blocking_status_lines,
 };
-#[cfg(test)]
-use crate::tracker::privacy_classifier::DISABLED_PUBLIC_PROJECTION_PRIVACY_CLASSIFIER;
 use crate::{
 	prelude::eyre,
 	state::StateStore,
-	tracker::{
-		IssueTracker, TrackerIssue, privacy_classifier::PublicProjectionPrivacyClassifier,
-		public_text,
-	},
+	tracker::{IssueTracker, TrackerIssue, privacy_classifier::PublicProjectionPrivacyClassifier},
 	workflow::WorkflowDocument,
 };
 
@@ -63,11 +65,12 @@ pub(crate) const ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME: &str = "issue_close
 pub(crate) const ISSUE_TERMINAL_FINALIZE_TOOL_NAME: &str = "issue_terminal_finalize";
 pub(crate) const REVIEW_POLICY_CONVERGENCE_BUDGET: i64 = 3;
 
-const REVIEW_HANDOFF_PUBLIC_SUMMARY_FALLBACK: &str =
+pub(super) const REVIEW_HANDOFF_PUBLIC_SUMMARY_FALLBACK: &str =
 	"Implementation completed and the PR is ready for review.";
-const REVIEW_REPAIR_PUBLIC_SUMMARY_FALLBACK: &str =
+pub(super) const REVIEW_REPAIR_PUBLIC_SUMMARY_FALLBACK: &str =
 	"Review repair completed and the PR is ready for fresh review.";
-const CLOSEOUT_PUBLIC_SUMMARY_FALLBACK: &str = "Retained closeout completed for the merged PR.";
+pub(super) const CLOSEOUT_PUBLIC_SUMMARY_FALLBACK: &str =
+	"Retained closeout completed for the merged PR.";
 
 static GH_PULL_REQUEST_INSPECTOR: GhPullRequestInspector = GhPullRequestInspector;
 static LOCAL_GIT_REPO_INSPECTOR: LocalGitRepoInspector = LocalGitRepoInspector;
@@ -133,231 +136,6 @@ pub(crate) struct TrackerToolBridge<'a> {
 	pending_review_completion: RefCell<Option<PendingReviewCompletion>>,
 	finalized_completion_path: RefCell<Option<RunCompletionDisposition>>,
 }
-impl<'a> TrackerToolBridge<'a> {
-	#[cfg(test)]
-	pub(crate) fn new(
-		tracker: &'a dyn IssueTracker,
-		issue: &'a TrackerIssue,
-		workflow: &'a WorkflowDocument,
-	) -> Self {
-		Self {
-			tracker,
-			issue,
-			workflow,
-			review_context: None,
-			state_store: None,
-			public_projection_privacy_classifier: &DISABLED_PUBLIC_PROJECTION_PRIVACY_CLASSIFIER,
-			pull_request_inspector: &GH_PULL_REQUEST_INSPECTOR,
-			local_repo_inspector: &LOCAL_GIT_REPO_INSPECTOR,
-			local_issue_state_name: RefCell::new(issue.state.name.clone()),
-			local_opt_out_requested: RefCell::new(
-				issue.has_label(workflow.frontmatter().tracker().opt_out_label()),
-			),
-			manual_attention_requested: RefCell::new(false),
-			manual_attention_comment_recorded: RefCell::new(false),
-			manual_attention_error_class: RefCell::new(None),
-			continuation_blocking_tracker_write: RefCell::new(None),
-			pending_review_completion: RefCell::new(None),
-			finalized_completion_path: RefCell::new(None),
-		}
-	}
-
-	#[cfg(test)]
-	fn with_review_handoff_inspectors(
-		tracker: &'a dyn IssueTracker,
-		issue: &'a TrackerIssue,
-		workflow: &'a WorkflowDocument,
-		review_context: ReviewHandoffContext,
-		state_store: Option<&'a StateStore>,
-		pull_request_inspector: &'a dyn PullRequestInspector,
-		local_repo_inspector: &'a dyn LocalRepoInspector,
-	) -> Self {
-		Self::with_review_handoff_options(
-			tracker,
-			issue,
-			workflow,
-			review_context,
-			TrackerToolBridgeOptions {
-				state_store,
-				public_projection_privacy_classifier:
-					&DISABLED_PUBLIC_PROJECTION_PRIVACY_CLASSIFIER,
-				pull_request_inspector,
-				local_repo_inspector,
-			},
-		)
-	}
-
-	fn with_review_handoff_options(
-		tracker: &'a dyn IssueTracker,
-		issue: &'a TrackerIssue,
-		workflow: &'a WorkflowDocument,
-		review_context: ReviewHandoffContext,
-		options: TrackerToolBridgeOptions<'a>,
-	) -> Self {
-		Self {
-			tracker,
-			issue,
-			workflow,
-			review_context: Some(review_context),
-			state_store: options.state_store,
-			public_projection_privacy_classifier: options.public_projection_privacy_classifier,
-			pull_request_inspector: options.pull_request_inspector,
-			local_repo_inspector: options.local_repo_inspector,
-			local_issue_state_name: RefCell::new(issue.state.name.clone()),
-			local_opt_out_requested: RefCell::new(
-				issue.has_label(workflow.frontmatter().tracker().opt_out_label()),
-			),
-			manual_attention_requested: RefCell::new(false),
-			manual_attention_comment_recorded: RefCell::new(false),
-			manual_attention_error_class: RefCell::new(None),
-			continuation_blocking_tracker_write: RefCell::new(None),
-			pending_review_completion: RefCell::new(None),
-			finalized_completion_path: RefCell::new(None),
-		}
-	}
-
-	#[cfg(test)]
-	fn leaked_test_state_store() -> &'static StateStore {
-		Box::leak(Box::new(
-			StateStore::open_in_memory().expect("test runtime state store should open"),
-		))
-	}
-
-	#[cfg(test)]
-	pub(crate) fn with_review_handoff_for_test(
-		tracker: &'a dyn IssueTracker,
-		issue: &'a TrackerIssue,
-		workflow: &'a WorkflowDocument,
-		review_context: ReviewHandoffContext,
-		pull_request_inspector: &'a dyn PullRequestInspector,
-		local_repo_inspector: &'a dyn LocalRepoInspector,
-	) -> Self {
-		Self::with_review_handoff_inspectors(
-			tracker,
-			issue,
-			workflow,
-			review_context,
-			Some(Self::leaked_test_state_store()),
-			pull_request_inspector,
-			local_repo_inspector,
-		)
-	}
-
-	#[cfg(test)]
-	pub(crate) fn with_review_repair_for_test(
-		tracker: &'a dyn IssueTracker,
-		issue: &'a TrackerIssue,
-		workflow: &'a WorkflowDocument,
-		review_context: ReviewHandoffContext,
-		pull_request_inspector: &'a dyn PullRequestInspector,
-		local_repo_inspector: &'a dyn LocalRepoInspector,
-	) -> Self {
-		Self::with_review_handoff_inspectors(
-			tracker,
-			issue,
-			workflow,
-			review_context,
-			Some(Self::leaked_test_state_store()),
-			pull_request_inspector,
-			local_repo_inspector,
-		)
-	}
-
-	#[cfg(test)]
-	pub(crate) fn with_run_context(
-		tracker: &'a dyn IssueTracker,
-		issue: &'a TrackerIssue,
-		workflow: &'a WorkflowDocument,
-		review_context: ReviewHandoffContext,
-	) -> Self {
-		Self::with_review_handoff_inspectors(
-			tracker,
-			issue,
-			workflow,
-			review_context,
-			Some(Self::leaked_test_state_store()),
-			&GH_PULL_REQUEST_INSPECTOR,
-			&LOCAL_GIT_REPO_INSPECTOR,
-		)
-	}
-
-	#[cfg(test)]
-	pub(crate) fn with_run_context_and_state_store(
-		tracker: &'a dyn IssueTracker,
-		issue: &'a TrackerIssue,
-		workflow: &'a WorkflowDocument,
-		review_context: ReviewHandoffContext,
-		state_store: &'a StateStore,
-	) -> Self {
-		Self::with_review_handoff_options(
-			tracker,
-			issue,
-			workflow,
-			review_context,
-			TrackerToolBridgeOptions {
-				state_store: Some(state_store),
-				public_projection_privacy_classifier:
-					&DISABLED_PUBLIC_PROJECTION_PRIVACY_CLASSIFIER,
-				pull_request_inspector: &GH_PULL_REQUEST_INSPECTOR,
-				local_repo_inspector: &LOCAL_GIT_REPO_INSPECTOR,
-			},
-		)
-	}
-
-	pub(crate) fn with_run_context_state_store_and_privacy_classifier(
-		tracker: &'a dyn IssueTracker,
-		issue: &'a TrackerIssue,
-		workflow: &'a WorkflowDocument,
-		review_context: ReviewHandoffContext,
-		state_store: &'a StateStore,
-		public_projection_privacy_classifier: &'a dyn PublicProjectionPrivacyClassifier,
-	) -> Self {
-		Self::with_review_handoff_options(
-			tracker,
-			issue,
-			workflow,
-			review_context,
-			TrackerToolBridgeOptions {
-				state_store: Some(state_store),
-				public_projection_privacy_classifier,
-				pull_request_inspector: &GH_PULL_REQUEST_INSPECTOR,
-				local_repo_inspector: &LOCAL_GIT_REPO_INSPECTOR,
-			},
-		)
-	}
-
-	#[cfg(test)]
-	pub(crate) fn with_review_handoff_classifier_for_test(
-		tracker: &'a dyn IssueTracker,
-		issue: &'a TrackerIssue,
-		workflow: &'a WorkflowDocument,
-		review_context: ReviewHandoffContext,
-		public_projection_privacy_classifier: &'a dyn PublicProjectionPrivacyClassifier,
-		local_repo_inspector: &'a dyn LocalRepoInspector,
-	) -> Self {
-		Self::with_review_handoff_options(
-			tracker,
-			issue,
-			workflow,
-			review_context,
-			TrackerToolBridgeOptions {
-				state_store: Some(Self::leaked_test_state_store()),
-				public_projection_privacy_classifier,
-				pull_request_inspector: &GH_PULL_REQUEST_INSPECTOR,
-				local_repo_inspector,
-			},
-		)
-	}
-
-	pub(crate) fn review_context(&self) -> Option<&ReviewHandoffContext> {
-		self.review_context.as_ref()
-	}
-
-	pub(crate) fn manual_attention_error_class(&self) -> Option<String> {
-		self.manual_attention_error_class.borrow().clone()
-	}
-}
-
 impl DynamicToolHandler for TrackerToolBridge<'_> {
 	fn tool_specs(&self) -> Vec<DynamicToolSpec> {
 		self.build_tool_specs()
@@ -477,13 +255,6 @@ impl DynamicToolHandler for TrackerToolBridge<'_> {
 	}
 }
 
-struct TrackerToolBridgeOptions<'a> {
-	state_store: Option<&'a StateStore>,
-	public_projection_privacy_classifier: &'a dyn PublicProjectionPrivacyClassifier,
-	pull_request_inspector: &'a dyn PullRequestInspector,
-	local_repo_inspector: &'a dyn LocalRepoInspector,
-}
-
 pub(super) fn summarize_review_blocking_changes(review_blocking_changes: &[String]) -> String {
 	const MAX_REVIEW_BLOCKING_CHANGES: usize = 5;
 
@@ -510,64 +281,6 @@ pub(crate) fn dynamic_tool_identifier_is_valid(identifier: &str) -> bool {
 
 pub(crate) fn current_timestamp() -> String {
 	OffsetDateTime::now_utc().format(&Rfc3339).expect("timestamp formatting should succeed")
-}
-
-fn normalize_summary(summary: &str) -> String {
-	summary.split_whitespace().collect::<Vec<_>>().join(" ")
-}
-
-fn normalize_progress_list(items: Vec<String>) -> Vec<String> {
-	items.into_iter().map(|item| normalize_summary(&item)).filter(|item| !item.is_empty()).collect()
-}
-
-fn normalize_optional_progress_field(value: Option<String>) -> Option<String> {
-	value.and_then(|value| {
-		let normalized = normalize_summary(&value);
-
-		(!normalized.is_empty()).then_some(normalized)
-	})
-}
-
-fn public_summary_or_fallback<'a>(summary: &'a str, fallback: &'static str) -> Cow<'a, str> {
-	if public_text::validate_public_text_field("summary", summary).is_ok() {
-		Cow::Borrowed(summary)
-	} else {
-		Cow::Borrowed(fallback)
-	}
-}
-
-fn format_review_handoff_comment(
-	review_context: &ReviewHandoffContext,
-	pending_review_handoff: &PendingReviewAction,
-	summary: &str,
-) -> String {
-	format!(
-		"decodex run completed and is ready for review\n\n- run_id: `{run_id}`\n- run_sequence_attempt: `{attempt}` (not retry-budget count)\n- finished_at: `{finished_at}`\n- branch: `{branch}`\n- pr_url: `{pr_url}`\n- worktree_path: `{worktree_path}`\n- validation_result: `passed`\n- summary: {summary}",
-		run_id = review_context.run_id,
-		attempt = review_context.attempt_number,
-		finished_at = current_timestamp(),
-		branch = review_context.branch_name,
-		pr_url = pending_review_handoff.pr_url,
-		worktree_path = review_context.worktree_path,
-		summary = summary,
-	)
-}
-
-fn format_review_repair_comment(
-	review_context: &ReviewHandoffContext,
-	pending_review_repair: &PendingReviewAction,
-	summary: &str,
-) -> String {
-	format!(
-		"decodex review repair completed and requested fresh review\n\n- run_id: `{run_id}`\n- run_sequence_attempt: `{attempt}` (not retry-budget count)\n- finished_at: `{finished_at}`\n- branch: `{branch}`\n- pr_url: `{pr_url}`\n- worktree_path: `{worktree_path}`\n- validation_result: `passed`\n- summary: {summary}",
-		run_id = review_context.run_id,
-		attempt = review_context.attempt_number,
-		finished_at = current_timestamp(),
-		branch = review_context.branch_name,
-		pr_url = pending_review_repair.pr_url,
-		worktree_path = review_context.worktree_path,
-		summary = summary,
-	)
 }
 
 #[cfg(test)] mod tests;

--- a/apps/decodex/src/agent/tracker_tool_bridge/construction.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/construction.rs
@@ -1,0 +1,245 @@
+use std::cell::RefCell;
+
+#[cfg(test)]
+use crate::tracker::privacy_classifier::DISABLED_PUBLIC_PROJECTION_PRIVACY_CLASSIFIER;
+use crate::{
+	agent::tracker_tool_bridge::{
+		GH_PULL_REQUEST_INSPECTOR, LOCAL_GIT_REPO_INSPECTOR, LocalRepoInspector,
+		PullRequestInspector, ReviewHandoffContext, TrackerToolBridge,
+	},
+	state::StateStore,
+	tracker::{IssueTracker, TrackerIssue, privacy_classifier::PublicProjectionPrivacyClassifier},
+	workflow::WorkflowDocument,
+};
+
+struct TrackerToolBridgeOptions<'a> {
+	state_store: Option<&'a StateStore>,
+	public_projection_privacy_classifier: &'a dyn PublicProjectionPrivacyClassifier,
+	pull_request_inspector: &'a dyn PullRequestInspector,
+	local_repo_inspector: &'a dyn LocalRepoInspector,
+}
+
+impl<'a> TrackerToolBridge<'a> {
+	#[cfg(test)]
+	pub(crate) fn new(
+		tracker: &'a dyn IssueTracker,
+		issue: &'a TrackerIssue,
+		workflow: &'a WorkflowDocument,
+	) -> Self {
+		Self {
+			tracker,
+			issue,
+			workflow,
+			review_context: None,
+			state_store: None,
+			public_projection_privacy_classifier: &DISABLED_PUBLIC_PROJECTION_PRIVACY_CLASSIFIER,
+			pull_request_inspector: &GH_PULL_REQUEST_INSPECTOR,
+			local_repo_inspector: &LOCAL_GIT_REPO_INSPECTOR,
+			local_issue_state_name: RefCell::new(issue.state.name.clone()),
+			local_opt_out_requested: RefCell::new(
+				issue.has_label(workflow.frontmatter().tracker().opt_out_label()),
+			),
+			manual_attention_requested: RefCell::new(false),
+			manual_attention_comment_recorded: RefCell::new(false),
+			manual_attention_error_class: RefCell::new(None),
+			continuation_blocking_tracker_write: RefCell::new(None),
+			pending_review_completion: RefCell::new(None),
+			finalized_completion_path: RefCell::new(None),
+		}
+	}
+
+	#[cfg(test)]
+	pub(super) fn with_review_handoff_inspectors(
+		tracker: &'a dyn IssueTracker,
+		issue: &'a TrackerIssue,
+		workflow: &'a WorkflowDocument,
+		review_context: ReviewHandoffContext,
+		state_store: Option<&'a StateStore>,
+		pull_request_inspector: &'a dyn PullRequestInspector,
+		local_repo_inspector: &'a dyn LocalRepoInspector,
+	) -> Self {
+		Self::with_review_handoff_options(
+			tracker,
+			issue,
+			workflow,
+			review_context,
+			TrackerToolBridgeOptions {
+				state_store,
+				public_projection_privacy_classifier:
+					&DISABLED_PUBLIC_PROJECTION_PRIVACY_CLASSIFIER,
+				pull_request_inspector,
+				local_repo_inspector,
+			},
+		)
+	}
+
+	fn with_review_handoff_options(
+		tracker: &'a dyn IssueTracker,
+		issue: &'a TrackerIssue,
+		workflow: &'a WorkflowDocument,
+		review_context: ReviewHandoffContext,
+		options: TrackerToolBridgeOptions<'a>,
+	) -> Self {
+		Self {
+			tracker,
+			issue,
+			workflow,
+			review_context: Some(review_context),
+			state_store: options.state_store,
+			public_projection_privacy_classifier: options.public_projection_privacy_classifier,
+			pull_request_inspector: options.pull_request_inspector,
+			local_repo_inspector: options.local_repo_inspector,
+			local_issue_state_name: RefCell::new(issue.state.name.clone()),
+			local_opt_out_requested: RefCell::new(
+				issue.has_label(workflow.frontmatter().tracker().opt_out_label()),
+			),
+			manual_attention_requested: RefCell::new(false),
+			manual_attention_comment_recorded: RefCell::new(false),
+			manual_attention_error_class: RefCell::new(None),
+			continuation_blocking_tracker_write: RefCell::new(None),
+			pending_review_completion: RefCell::new(None),
+			finalized_completion_path: RefCell::new(None),
+		}
+	}
+
+	#[cfg(test)]
+	pub(super) fn leaked_test_state_store() -> &'static StateStore {
+		Box::leak(Box::new(
+			StateStore::open_in_memory().expect("test runtime state store should open"),
+		))
+	}
+
+	#[cfg(test)]
+	pub(crate) fn with_review_handoff_for_test(
+		tracker: &'a dyn IssueTracker,
+		issue: &'a TrackerIssue,
+		workflow: &'a WorkflowDocument,
+		review_context: ReviewHandoffContext,
+		pull_request_inspector: &'a dyn PullRequestInspector,
+		local_repo_inspector: &'a dyn LocalRepoInspector,
+	) -> Self {
+		Self::with_review_handoff_inspectors(
+			tracker,
+			issue,
+			workflow,
+			review_context,
+			Some(Self::leaked_test_state_store()),
+			pull_request_inspector,
+			local_repo_inspector,
+		)
+	}
+
+	#[cfg(test)]
+	pub(crate) fn with_review_repair_for_test(
+		tracker: &'a dyn IssueTracker,
+		issue: &'a TrackerIssue,
+		workflow: &'a WorkflowDocument,
+		review_context: ReviewHandoffContext,
+		pull_request_inspector: &'a dyn PullRequestInspector,
+		local_repo_inspector: &'a dyn LocalRepoInspector,
+	) -> Self {
+		Self::with_review_handoff_inspectors(
+			tracker,
+			issue,
+			workflow,
+			review_context,
+			Some(Self::leaked_test_state_store()),
+			pull_request_inspector,
+			local_repo_inspector,
+		)
+	}
+
+	#[cfg(test)]
+	pub(crate) fn with_run_context(
+		tracker: &'a dyn IssueTracker,
+		issue: &'a TrackerIssue,
+		workflow: &'a WorkflowDocument,
+		review_context: ReviewHandoffContext,
+	) -> Self {
+		Self::with_review_handoff_inspectors(
+			tracker,
+			issue,
+			workflow,
+			review_context,
+			Some(Self::leaked_test_state_store()),
+			&GH_PULL_REQUEST_INSPECTOR,
+			&LOCAL_GIT_REPO_INSPECTOR,
+		)
+	}
+
+	#[cfg(test)]
+	pub(crate) fn with_run_context_and_state_store(
+		tracker: &'a dyn IssueTracker,
+		issue: &'a TrackerIssue,
+		workflow: &'a WorkflowDocument,
+		review_context: ReviewHandoffContext,
+		state_store: &'a StateStore,
+	) -> Self {
+		Self::with_review_handoff_options(
+			tracker,
+			issue,
+			workflow,
+			review_context,
+			TrackerToolBridgeOptions {
+				state_store: Some(state_store),
+				public_projection_privacy_classifier:
+					&DISABLED_PUBLIC_PROJECTION_PRIVACY_CLASSIFIER,
+				pull_request_inspector: &GH_PULL_REQUEST_INSPECTOR,
+				local_repo_inspector: &LOCAL_GIT_REPO_INSPECTOR,
+			},
+		)
+	}
+
+	pub(crate) fn with_run_context_state_store_and_privacy_classifier(
+		tracker: &'a dyn IssueTracker,
+		issue: &'a TrackerIssue,
+		workflow: &'a WorkflowDocument,
+		review_context: ReviewHandoffContext,
+		state_store: &'a StateStore,
+		public_projection_privacy_classifier: &'a dyn PublicProjectionPrivacyClassifier,
+	) -> Self {
+		Self::with_review_handoff_options(
+			tracker,
+			issue,
+			workflow,
+			review_context,
+			TrackerToolBridgeOptions {
+				state_store: Some(state_store),
+				public_projection_privacy_classifier,
+				pull_request_inspector: &GH_PULL_REQUEST_INSPECTOR,
+				local_repo_inspector: &LOCAL_GIT_REPO_INSPECTOR,
+			},
+		)
+	}
+
+	#[cfg(test)]
+	pub(crate) fn with_review_handoff_classifier_for_test(
+		tracker: &'a dyn IssueTracker,
+		issue: &'a TrackerIssue,
+		workflow: &'a WorkflowDocument,
+		review_context: ReviewHandoffContext,
+		public_projection_privacy_classifier: &'a dyn PublicProjectionPrivacyClassifier,
+		local_repo_inspector: &'a dyn LocalRepoInspector,
+	) -> Self {
+		Self::with_review_handoff_options(
+			tracker,
+			issue,
+			workflow,
+			review_context,
+			TrackerToolBridgeOptions {
+				state_store: Some(Self::leaked_test_state_store()),
+				public_projection_privacy_classifier,
+				pull_request_inspector: &GH_PULL_REQUEST_INSPECTOR,
+				local_repo_inspector,
+			},
+		)
+	}
+
+	pub(crate) fn review_context(&self) -> Option<&ReviewHandoffContext> {
+		self.review_context.as_ref()
+	}
+
+	pub(crate) fn manual_attention_error_class(&self) -> Option<String> {
+		self.manual_attention_error_class.borrow().clone()
+	}
+}

--- a/apps/decodex/src/agent/tracker_tool_bridge/text.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/text.rs
@@ -1,0 +1,67 @@
+use std::borrow::Cow;
+
+use crate::{
+	agent::tracker_tool_bridge::{self, PendingReviewAction, ReviewHandoffContext},
+	tracker::public_text,
+};
+
+pub(super) fn normalize_summary(summary: &str) -> String {
+	summary.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+pub(super) fn normalize_progress_list(items: Vec<String>) -> Vec<String> {
+	items.into_iter().map(|item| normalize_summary(&item)).filter(|item| !item.is_empty()).collect()
+}
+
+pub(super) fn normalize_optional_progress_field(value: Option<String>) -> Option<String> {
+	value.and_then(|value| {
+		let normalized = normalize_summary(&value);
+
+		(!normalized.is_empty()).then_some(normalized)
+	})
+}
+
+pub(super) fn public_summary_or_fallback<'a>(
+	summary: &'a str,
+	fallback: &'static str,
+) -> Cow<'a, str> {
+	if public_text::validate_public_text_field("summary", summary).is_ok() {
+		Cow::Borrowed(summary)
+	} else {
+		Cow::Borrowed(fallback)
+	}
+}
+
+pub(super) fn format_review_handoff_comment(
+	review_context: &ReviewHandoffContext,
+	pending_review_handoff: &PendingReviewAction,
+	summary: &str,
+) -> String {
+	format!(
+		"decodex run completed and is ready for review\n\n- run_id: `{run_id}`\n- run_sequence_attempt: `{attempt}` (not retry-budget count)\n- finished_at: `{finished_at}`\n- branch: `{branch}`\n- pr_url: `{pr_url}`\n- worktree_path: `{worktree_path}`\n- validation_result: `passed`\n- summary: {summary}",
+		run_id = review_context.run_id,
+		attempt = review_context.attempt_number,
+		finished_at = tracker_tool_bridge::current_timestamp(),
+		branch = review_context.branch_name,
+		pr_url = pending_review_handoff.pr_url,
+		worktree_path = review_context.worktree_path,
+		summary = summary,
+	)
+}
+
+pub(super) fn format_review_repair_comment(
+	review_context: &ReviewHandoffContext,
+	pending_review_repair: &PendingReviewAction,
+	summary: &str,
+) -> String {
+	format!(
+		"decodex review repair completed and requested fresh review\n\n- run_id: `{run_id}`\n- run_sequence_attempt: `{attempt}` (not retry-budget count)\n- finished_at: `{finished_at}`\n- branch: `{branch}`\n- pr_url: `{pr_url}`\n- worktree_path: `{worktree_path}`\n- validation_result: `passed`\n- summary: {summary}",
+		run_id = review_context.run_id,
+		attempt = review_context.attempt_number,
+		finished_at = tracker_tool_bridge::current_timestamp(),
+		branch = review_context.branch_name,
+		pr_url = pending_review_repair.pr_url,
+		worktree_path = review_context.worktree_path,
+		summary = summary,
+	)
+}


### PR DESCRIPTION
## Summary
- split tracker tool bridge construction helpers into a flat construction module
- split public summary/comment text helpers into a flat text module
- keep the parent bridge as the public surface and dispatch implementation, with no mod.rs files

## Validation
- cargo check -p decodex
- cargo test -p decodex agent::tracker_tool_bridge::tests --lib (122 passed)
- cargo vstyle curate --language rust --workspace --all-features | filtered to changed tracker bridge files: no changed-file violations after fixes
- cargo make lint-vstyle-rust still fails on the existing repo-wide baseline: 3829 style violations / 218 manual-fix violations
- git ls-files "*/mod.rs" | wc -l => 0
- git diff --cached --check
