### PR TITLE
Split orchestrator recovery tests into flat modules

### DIFF
--- a/apps/decodex/src/orchestrator/tests.rs
+++ b/apps/decodex/src/orchestrator/tests.rs
@@ -4,10 +4,18 @@ mod intake_eligibility;
 mod intake_prepare_issue_run;
 mod intake_run_and_prompting;
 mod intake_workflow_reload;
+mod recovery_closeout_cleanup;
+mod recovery_closeout_dispatch;
+mod recovery_closeout_identity;
+mod recovery_reconciliation;
+mod recovery_runtime_reentry;
+mod recovery_terminal_failures;
+mod recovery_terminal_support;
 mod runtime_failure;
 // Operator status plus retained post-review review/landing behavior.
 mod operator;
 
+#[cfg(unix)] use std::os::unix::fs::PermissionsExt;
 use std::{
 	cell::RefCell,
 	collections::{BTreeSet, HashMap},
@@ -49,7 +57,7 @@ use crate::config::{ReviewLevel, ServiceConfig};
 use crate::github;
 use crate::loop_contract::DecisionContract;
 #[rustfmt::skip]
-use crate::orchestrator::{self, AppServerZeroEvidenceStartFailure, CurrentChildRunContext, RunLeaseDisposition, RunLeaseReconciliation, AgentEvidenceSource, AuthorityBoundaryChangedSurface, AuthorityBoundaryCheckInput, AuthorityBoundaryDisposition, AuthorityBoundaryPolicyDecision, AuthorityBoundarySurface, AuthorityDecisionRequestInput, ChildExitRetryContext, ChildRunRef, ControlPlaneProjectTick, CONTINUATION_PENDING_RUN_STATUS, DaemonRunChild, DaemonTickRuntimeContext, DashboardEventHub, EvidenceRequest, GhPullRequestReviewStateInspector, IssueDispatchMode, IssueRunPlan, ManualAttentionRequested, OPERATOR_DASHBOARD_ALIAS_ENDPOINT_PATH, OPERATOR_DASHBOARD_ENDPOINT_PATH, PHASE_ACCEPTANCE_CHECK_EVENT_TYPE, PHASE_GOAL_RECOVERY_BLOCKED_EVENT_TYPE, PHASE_GOAL_RECOVERY_EVENT_TYPE, OperatorCodexAccountControlStatus, OperatorExecutionProgramNodeStatus, OperatorExecutionProgramStatus, OperatorGitHubCliAuthority, OperatorProjectStatus, OperatorStatusSnapshot, PostReviewLaneClassification, PostReviewLaneDecision, PostReviewLaneSnapshot, PrepareIssueRunContext, PublishedOperatorSnapshot, PullRequestCommitConnection, PullRequestCommitNode, PullRequestCommitPayload, PullRequestIssueCommentConnection, PullRequestIssueCommentState, PullRequestIssueCommentsNode, PullRequestPageInfo, PullRequestReactionGroup, PullRequestReactionUsersConnection, PullRequestActor, PullRequestRepository, PullRequestRepositoryOwner, PullRequestReviewConnection, PullRequestIssueCommentNode, PullRequestReviewNode, PullRequestReviewRequestConnection, PullRequestReviewState, PullRequestReviewStateInspector, PullRequestReviewStateNode, PullRequestReviewStateRepository, PullRequestReviewSummaryState, PullRequestReviewThreadConnection, PullRequestReviewThreadNode, PullRequestStatusCheckRollup, RecoveredRuntimeState, RetainedPartialProgress, RetainedReviewRepairPushFailed, RetainedReviewRunIdentity, RetryComment, RetryDispatchDecision, RetryEntry, RetryEntryLifecycle, RetryKind, RetryQueue, RunCompletionDisposition, RunSummary, RepoGateFailure, RepoGateFailureKind, StalledRunNeedsAttention, TERMINAL_GUARD_MARKER_FILE, TERMINAL_GUARDED_RUN_STATUS, TRACKER_RATE_LIMIT_WARNING, TRACKER_TRANSIENT_TIMEOUT_WARNING, TargetIssueRunContext, EXTERNAL_REVIEW_ACTOR_LOGIN, EXTERNAL_REVIEW_PASS_PHRASE, EXTERNAL_REVIEW_REQUEST_BODY};
+use crate::orchestrator::{self, AgentEvidenceSource, AuthorityBoundaryChangedSurface, AuthorityBoundaryCheckInput, AuthorityBoundaryDisposition, AuthorityBoundaryPolicyDecision, AuthorityBoundarySurface, AuthorityDecisionRequestInput, ChildExitRetryContext, ChildRunRef, ControlPlaneProjectTick, CONTINUATION_PENDING_RUN_STATUS, DaemonRunChild, DaemonTickRuntimeContext, DashboardEventHub, EvidenceRequest, GhPullRequestReviewStateInspector, IssueDispatchMode, IssueRunPlan, ManualAttentionRequested, OPERATOR_DASHBOARD_ALIAS_ENDPOINT_PATH, OPERATOR_DASHBOARD_ENDPOINT_PATH, PHASE_ACCEPTANCE_CHECK_EVENT_TYPE, PHASE_GOAL_RECOVERY_BLOCKED_EVENT_TYPE, PHASE_GOAL_RECOVERY_EVENT_TYPE, OperatorCodexAccountControlStatus, OperatorExecutionProgramNodeStatus, OperatorExecutionProgramStatus, OperatorGitHubCliAuthority, OperatorProjectStatus, OperatorStatusSnapshot, PostReviewLaneClassification, PostReviewLaneDecision, PostReviewLaneSnapshot, PrepareIssueRunContext, PublishedOperatorSnapshot, PullRequestCommitConnection, PullRequestCommitNode, PullRequestCommitPayload, PullRequestIssueCommentConnection, PullRequestIssueCommentState, PullRequestIssueCommentsNode, PullRequestPageInfo, PullRequestReactionGroup, PullRequestReactionUsersConnection, PullRequestActor, PullRequestRepository, PullRequestRepositoryOwner, PullRequestReviewConnection, PullRequestIssueCommentNode, PullRequestReviewNode, PullRequestReviewRequestConnection, PullRequestReviewState, PullRequestReviewStateInspector, PullRequestReviewStateNode, PullRequestReviewStateRepository, PullRequestReviewSummaryState, PullRequestReviewThreadConnection, PullRequestReviewThreadNode, PullRequestStatusCheckRollup, RecoveredRuntimeState, RetainedPartialProgress, RetainedReviewRepairPushFailed, RetryComment, RetryDispatchDecision, RetryEntry, RetryEntryLifecycle, RetryKind, RetryQueue, RunCompletionDisposition, RepoGateFailure, TERMINAL_GUARDED_RUN_STATUS, TRACKER_RATE_LIMIT_WARNING, TRACKER_TRANSIENT_TIMEOUT_WARNING, TargetIssueRunContext, EXTERNAL_REVIEW_ACTOR_LOGIN, EXTERNAL_REVIEW_PASS_PHRASE, EXTERNAL_REVIEW_REQUEST_BODY};
 #[rustfmt::skip]
 use crate::prelude::Result;
 #[rustfmt::skip]
@@ -84,20 +92,6 @@ include!("tests/runtime/program_reconciler.rs");
 include!("tests/runtime/program_intake_dogfood.rs");
 
 include!("tests/runtime/thread_archive.rs");
-
-include!("tests/recovery/reconciliation.rs");
-
-include!("tests/recovery/terminal_support.rs");
-
-include!("tests/recovery/closeout/dispatch.rs");
-
-include!("tests/recovery/closeout/identity.rs");
-
-include!("tests/recovery/closeout/cleanup.rs");
-
-include!("tests/recovery/terminal_failures.rs");
-
-include!("tests/recovery/runtime_reentry.rs");
 
 include!("tests/review_landing/status_support.rs");
 

--- a/apps/decodex/src/orchestrator/tests/intake_candidate_selection.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_candidate_selection.rs
@@ -1,22 +1,39 @@
 use std::{cell::RefCell, fs, path::Path};
 
+use tempfile::TempDir;
+
 use crate::{
 	config::ReviewLevel,
 	orchestrator::{
 		self, IssueDispatchMode, RetainedReviewRunIdentity, ReviewHandoffMarker, RunSummary,
 		TERMINAL_GUARDED_RUN_STATUS, TargetIssueRunContext,
-		tests::{self, FakePullRequestReviewStateInspector, FakeTracker, TEST_SERVICE_ID},
+		tests::{
+			self, FakePullRequestReviewStateInspector, FakeTracker, TEST_SERVICE_ID,
+			recovery_terminal_support,
+		},
 	},
 	state::{self, StateStore},
+	test_support::TestEnvVarGuard,
 	tracker::{self, TrackerIssue},
 	workflow::WorkflowDocument,
-	worktree::WorktreeManager,
+	worktree::{WorktreeManager, WorktreeSpec},
 };
 
 fn candidate_selection_service_owned_issue(state_name: &str) -> TrackerIssue {
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
 
 	tests::sample_issue(state_name, &[active_label.as_str()])
+}
+
+fn install_merged_pr_response(
+	temp_dir: &TempDir,
+	worktree: &WorktreeSpec,
+	pr_url: &str,
+	head_oid: &str,
+) -> TestEnvVarGuard {
+	recovery_terminal_support::install_fake_merged_pr_gh_response(
+		temp_dir, worktree, pr_url, head_oid,
+	)
 }
 
 fn sample_handoff_summary(issue: &TrackerIssue, worktree_path: &Path) -> RunSummary {
@@ -587,8 +604,7 @@ fn plan_project_issue_run_prefers_post_review_closeout_lane_over_normal_candidat
 		),
 	);
 
-	let _path_guard =
-		tests::install_fake_merged_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = install_merged_pr_response(&temp_dir, &worktree, pr_url, &head_oid);
 	let mut merged_review_state = tests::sample_pull_request_review_state(
 		pr_url,
 		&worktree.branch_name,
@@ -717,8 +733,7 @@ fn plan_project_issue_run_allows_merged_closeout_after_retry_budget() {
 			.expect("failed attempt should record");
 	}
 
-	let _path_guard =
-		tests::install_fake_merged_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = install_merged_pr_response(&temp_dir, &worktree, pr_url, &head_oid);
 	let mut merged_review_state = tests::sample_pull_request_review_state(
 		pr_url,
 		&worktree.branch_name,

--- a/apps/decodex/src/orchestrator/tests/intake_run_and_prompting.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_run_and_prompting.rs
@@ -207,7 +207,7 @@ use crate::{
 		TargetIssueRunContext, TurnContinuationGuard,
 		tests::{
 			self, FakePullRequestReviewStateInspector, FakeTracker, TEST_SERVICE_ID,
-			intake_workflow_reload,
+			intake_workflow_reload, recovery_terminal_support,
 		},
 	},
 	state::{self, StateStore},
@@ -583,8 +583,9 @@ fn targeted_identifier_dispatch_accepts_status_visible_retained_closeout_lane() 
 		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
-	let _path_guard =
-		tests::install_fake_merged_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_merged_pr_gh_response(
+		&temp_dir, &worktree, pr_url, &head_oid,
+	);
 	let snapshot = orchestrator::build_live_operator_status_snapshot(
 		&tracker,
 		&config,
@@ -661,8 +662,9 @@ fn targeted_identifier_dispatch_accepts_status_visible_review_repair_lane() {
 		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
-	let _path_guard =
-		tests::install_fake_conflicting_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_conflicting_pr_gh_response(
+		&temp_dir, &worktree, pr_url, &head_oid,
+	);
 	let snapshot = orchestrator::build_live_operator_status_snapshot(
 		&tracker,
 		&config,
@@ -745,8 +747,9 @@ fn targeted_identifier_dispatch_accepts_stopped_active_closeout_lease() {
 		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
-	let _path_guard =
-		tests::install_fake_merged_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_merged_pr_gh_response(
+		&temp_dir, &worktree, pr_url, &head_oid,
+	);
 	let snapshot = orchestrator::build_live_operator_status_snapshot(
 		&tracker,
 		&config,
@@ -874,8 +877,9 @@ fn targeted_identifier_dispatch_rejects_different_status_visible_closeout_lane()
 		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
-	let _path_guard =
-		tests::install_fake_merged_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_merged_pr_gh_response(
+		&temp_dir, &worktree, pr_url, &head_oid,
+	);
 	let snapshot = orchestrator::build_live_operator_status_snapshot(
 		&tracker,
 		&config,
@@ -962,8 +966,9 @@ fn targeted_identifier_dispatch_rejects_different_status_visible_review_repair_l
 		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
-	let _path_guard =
-		tests::install_fake_conflicting_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_conflicting_pr_gh_response(
+		&temp_dir, &worktree, pr_url, &head_oid,
+	);
 	let snapshot = orchestrator::build_live_operator_status_snapshot(
 		&tracker,
 		&config,

--- a/apps/decodex/src/orchestrator/tests/operator/status/queue.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/queue.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::orchestrator::tests::recovery_terminal_support;
 
 #[test]
 fn live_operator_status_snapshot_includes_queued_candidates_with_dispatch_classification() {
@@ -1872,7 +1873,7 @@ fn live_operator_status_snapshot_recovers_shared_claims_for_fresh_status_store_i
 #[test]
 fn live_operator_status_snapshot_reconstructs_same_shared_view_for_fresh_state_stores() {
 	let (_temp_dir, config, workflow) = temp_project_layout();
-	let active_issue = sample_active_issue("In Progress");
+	let active_issue = recovery_terminal_support::sample_active_issue("In Progress");
 	let closed_issue = sample_issue_with_sort_fields(
 		"issue-closed",
 		"PUB-104",

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes/recovery_lineage.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes/recovery_lineage.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::orchestrator::tests::recovery_terminal_support;
 
 #[test]
 fn operator_status_snapshot_surfaces_repeated_continuation_recovery_lineage() {
@@ -808,7 +809,7 @@ fn runtime_recovery_preserves_legacy_cleanup_only_provenance_without_recoverable
 #[test]
 fn runtime_recovery_records_recovered_provenance_for_fresh_active_worktree() {
 	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_active_issue("In Progress");
+	let issue = recovery_terminal_support::sample_active_issue("In Progress");
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_path = config.worktree_root().join(&issue.identifier);
@@ -851,7 +852,7 @@ fn runtime_recovery_records_recovered_provenance_for_fresh_active_worktree() {
 #[test]
 fn runtime_recovery_splits_invalid_local_id_batch_without_losing_valid_issue() {
 	let (_temp_dir, config, workflow) = temp_project_layout();
-	let mut issue = sample_active_issue("In Progress");
+	let mut issue = recovery_terminal_support::sample_active_issue("In Progress");
 
 	issue.id = String::from("00000000-0000-0000-0000-000000000101");
 
@@ -909,7 +910,7 @@ fn runtime_recovery_splits_invalid_local_id_batch_without_losing_valid_issue() {
 #[test]
 fn post_review_worktree_refresh_splits_invalid_local_id_batch_without_losing_valid_issue() {
 	let (_temp_dir, config, _workflow) = temp_project_layout();
-	let mut issue = sample_active_issue("In Review");
+	let mut issue = recovery_terminal_support::sample_active_issue("In Review");
 
 	issue.id = String::from("00000000-0000-0000-0000-000000000101");
 

--- a/apps/decodex/src/orchestrator/tests/recovery_closeout_cleanup.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery_closeout_cleanup.rs
@@ -1,13 +1,27 @@
+use std::fs;
+
+use crate::{
+	orchestrator::{
+		self, IssueDispatchMode, IssueRunPlan, ReviewHandoffMarker,
+		tests::{
+			FakePullRequestReviewStateInspector, FakeTracker, recovery_terminal_support, {self},
+		},
+	},
+	state::StateStore,
+	test_support,
+	worktree::{WorktreeManager, WorktreeSpec},
+};
+
 #[test]
 fn cleanup_completed_post_review_lane_preserves_worktree_when_remote_delete_fails() {
-	let (temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(&base_config, "HOME");
-	let issue = sample_issue("Done", &[]);
+	let (temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(&base_config, "HOME");
+	let issue = tests::sample_issue("Done", &[]);
 	let _tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let remote_root =
 		config.repo_root().parent().expect("repo root should have a parent").join("origin.git");
-	let head_oid = git_output(config.repo_root(), &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(config.repo_root(), &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/67";
 	let worktree = WorktreeSpec {
 		branch_name: String::from("main"),
@@ -15,16 +29,13 @@ fn cleanup_completed_post_review_lane_preserves_worktree_when_remote_delete_fail
 		path: config.repo_root().to_path_buf(),
 		reused_existing: true,
 	};
-	let _path_guard = install_fake_merged_pr_gh_response_with_delete_exit_code(
-		&temp_dir,
-		&worktree,
-		pr_url,
-		&head_oid,
-		1,
-	);
+	let _path_guard =
+		recovery_terminal_support::install_fake_merged_pr_gh_response_with_delete_exit_code(
+			&temp_dir, &worktree, pr_url, &head_oid, 1,
+		);
 
-	initialize_closeout_cleanup_origin(config.repo_root(), &remote_root);
-	seed_review_handoff_marker_value(
+	recovery_terminal_support::initialize_closeout_cleanup_origin(config.repo_root(), &remote_root);
+	tests::seed_review_handoff_marker_value(
 		&state_store,
 		config.service_id(),
 		&issue.id,
@@ -48,7 +59,11 @@ fn cleanup_completed_post_review_lane_preserves_worktree_when_remote_delete_fail
 		)
 		.expect("worktree should record");
 
-	let issue_run = sample_closeout_issue_run(&issue, &worktree, "run-closeout-cleanup");
+	let issue_run = recovery_terminal_support::sample_closeout_issue_run(
+		&issue,
+		&worktree,
+		"run-closeout-cleanup",
+	);
 	let error = orchestrator::cleanup_completed_post_review_lane(
 		&config,
 		&workflow,
@@ -73,7 +88,7 @@ fn cleanup_completed_post_review_lane_preserves_worktree_when_remote_delete_fail
 		"worktree mapping must remain so cleanup can retry later"
 	);
 	assert!(
-		!git_output(config.repo_root(), &["branch", "--list", "main"]).is_empty(),
+		!tests::git_output(config.repo_root(), &["branch", "--list", "main"]).is_empty(),
 		"cleanup must not mutate local branch state when remote delete fails before local cleanup"
 	);
 }
@@ -81,9 +96,9 @@ fn cleanup_completed_post_review_lane_preserves_worktree_when_remote_delete_fail
 #[test]
 fn merged_closeout_retry_exhaustion_reports_cleanup_blocker_with_pr_url_after_default_branch_dirty()
 {
-	let (temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(&base_config, "HOME");
-	let issue = sample_issue("Done", &[]);
+	let (temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(&base_config, "HOME");
+	let issue = tests::sample_issue("Done", &[]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
@@ -91,16 +106,18 @@ fn merged_closeout_retry_exhaustion_reports_cleanup_blocker_with_pr_url_after_de
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained closeout worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/119";
-	let _path_guard = install_fake_merged_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_merged_pr_gh_response(
+		&temp_dir, &worktree, pr_url, &head_oid,
+	);
 	let remote_root =
 		config.repo_root().parent().expect("repo root should have a parent").join("origin.git");
 
-	initialize_closeout_cleanup_origin(config.repo_root(), &remote_root);
+	recovery_terminal_support::initialize_closeout_cleanup_origin(config.repo_root(), &remote_root);
 
 	assert!(
-		crate::test_support::hermetic_git_command()
+		test_support::hermetic_git_command()
 			.arg("-C")
 			.arg(config.repo_root())
 			.args(["push", "origin", &format!("HEAD:{}", worktree.branch_name)])
@@ -109,11 +126,11 @@ fn merged_closeout_retry_exhaustion_reports_cleanup_blocker_with_pr_url_after_de
 			.success()
 	);
 
-	seed_review_handoff_marker_value(
+	tests::seed_review_handoff_marker_value(
 		&state_store,
 		config.service_id(),
 		&issue.id,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
 	state_store
@@ -128,7 +145,11 @@ fn merged_closeout_retry_exhaustion_reports_cleanup_blocker_with_pr_url_after_de
 	fs::write(config.repo_root().join("README.md"), "local repo override\n")
 		.expect("tracked repo-root file should become dirty");
 
-	let issue_run = sample_closeout_issue_run(&issue, &worktree, "run-closeout-dirty-root");
+	let issue_run = recovery_terminal_support::sample_closeout_issue_run(
+		&issue,
+		&worktree,
+		"run-closeout-dirty-root",
+	);
 	let error = orchestrator::cleanup_completed_post_review_lane(
 		&config,
 		&workflow,
@@ -154,7 +175,7 @@ fn merged_closeout_retry_exhaustion_reports_cleanup_blocker_with_pr_url_after_de
 			.expect("failed closeout attempt should record");
 	}
 
-	let mut merged_review_state = sample_pull_request_review_state(
+	let mut merged_review_state = tests::sample_pull_request_review_state(
 		pr_url,
 		&worktree.branch_name,
 		&head_oid,
@@ -185,9 +206,9 @@ fn merged_closeout_retry_exhaustion_reports_cleanup_blocker_with_pr_url_after_de
 
 #[test]
 fn cleanup_completed_post_review_lane_fails_closed_when_pr_target_branch_drifted() {
-	let (temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(&base_config, "HOME");
-	let issue = sample_issue("Done", &[]);
+	let (temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(&base_config, "HOME");
+	let issue = tests::sample_issue("Done", &[]);
 	let _tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
@@ -195,9 +216,9 @@ fn cleanup_completed_post_review_lane_fails_closed_when_pr_target_branch_drifted
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained closeout worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/180";
-	let _path_guard = install_fake_merged_pr_gh_response_with_base_ref(
+	let _path_guard = recovery_terminal_support::install_fake_merged_pr_gh_response_with_base_ref(
 		&temp_dir,
 		&worktree,
 		pr_url,
@@ -205,11 +226,11 @@ fn cleanup_completed_post_review_lane_fails_closed_when_pr_target_branch_drifted
 		"release/1.x",
 	);
 
-	seed_review_handoff_marker_value(
+	tests::seed_review_handoff_marker_value(
 		&state_store,
 		config.service_id(),
 		&issue.id,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
 	state_store
@@ -267,9 +288,9 @@ fn cleanup_completed_post_review_lane_fails_closed_when_pr_target_branch_drifted
 
 #[test]
 fn cleanup_completed_post_review_lane_deletes_local_lane_branch_after_worktree_cleanup() {
-	let (temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(&base_config, "HOME");
-	let issue = sample_issue("Done", &[]);
+	let (temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(&base_config, "HOME");
+	let issue = tests::sample_issue("Done", &[]);
 	let _tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
@@ -277,16 +298,18 @@ fn cleanup_completed_post_review_lane_deletes_local_lane_branch_after_worktree_c
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained closeout worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/181";
-	let _path_guard = install_fake_merged_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_merged_pr_gh_response(
+		&temp_dir, &worktree, pr_url, &head_oid,
+	);
 	let remote_root =
 		config.repo_root().parent().expect("repo root should have a parent").join("origin.git");
 
-	initialize_closeout_cleanup_origin(config.repo_root(), &remote_root);
+	recovery_terminal_support::initialize_closeout_cleanup_origin(config.repo_root(), &remote_root);
 
 	assert!(
-		crate::test_support::hermetic_git_command()
+		test_support::hermetic_git_command()
 			.arg("-C")
 			.arg(config.repo_root())
 			.args(["push", "origin", &format!("HEAD:{}", worktree.branch_name)])
@@ -295,11 +318,11 @@ fn cleanup_completed_post_review_lane_deletes_local_lane_branch_after_worktree_c
 			.success()
 	);
 
-	seed_review_handoff_marker_value(
+	tests::seed_review_handoff_marker_value(
 		&state_store,
 		config.service_id(),
 		&issue.id,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
 	state_store
@@ -311,15 +334,19 @@ fn cleanup_completed_post_review_lane_deletes_local_lane_branch_after_worktree_c
 		)
 		.expect("worktree mapping should record");
 
-	let issue_run =
-		sample_closeout_issue_run(&issue, &worktree, "run-closeout-local-branch-cleanup");
+	let issue_run = recovery_terminal_support::sample_closeout_issue_run(
+		&issue,
+		&worktree,
+		"run-closeout-local-branch-cleanup",
+	);
 
 	orchestrator::cleanup_completed_post_review_lane(&config, &workflow, &state_store, &issue_run)
 		.expect("cleanup should succeed once merged closeout is authoritative");
 
 	assert!(!worktree.path.exists(), "cleanup should remove the retained worktree path");
 	assert!(
-		git_output(config.repo_root(), &["branch", "--list", &worktree.branch_name]).is_empty(),
+		tests::git_output(config.repo_root(), &["branch", "--list", &worktree.branch_name])
+			.is_empty(),
 		"cleanup should delete the retained local lane branch"
 	);
 	assert!(
@@ -351,27 +378,31 @@ fn cleanup_completed_post_review_lane_uses_persisted_handoff_marker() {
 	];
 
 	for (case_name, pr_url, marker_run_id, marker_attempt, issue_run_id) in cases {
-		let (temp_dir, base_config, workflow) = temp_project_layout();
-		let config = service_config_with_github_token_env_var(&base_config, "HOME");
-		let issue = sample_issue("Done", &[]);
+		let (temp_dir, base_config, workflow) = tests::temp_project_layout();
+		let config = tests::service_config_with_github_token_env_var(&base_config, "HOME");
+		let issue = tests::sample_issue("Done", &[]);
 		let state_store = StateStore::open_in_memory().expect("state store should open");
 		let worktree_manager =
 			WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
 		let worktree = worktree_manager
 			.ensure_worktree(&issue.identifier, false)
 			.expect("retained closeout worktree should exist");
-		let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
-		let _path_guard =
-			install_fake_merged_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+		let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
+		let _path_guard = recovery_terminal_support::install_fake_merged_pr_gh_response(
+			&temp_dir, &worktree, pr_url, &head_oid,
+		);
 		let remote_root =
 			config.repo_root().parent().expect("repo root should have a parent").join("origin.git");
 
-		initialize_closeout_cleanup_origin(config.repo_root(), &remote_root);
-		git_status_success(
+		recovery_terminal_support::initialize_closeout_cleanup_origin(
+			config.repo_root(),
+			&remote_root,
+		);
+		tests::git_status_success(
 			config.repo_root(),
 			&["push", "origin", &format!("HEAD:{}", worktree.branch_name)],
 		);
-		seed_review_handoff_marker_value(
+		tests::seed_review_handoff_marker_value(
 			&state_store,
 			config.service_id(),
 			&issue.id,
@@ -395,7 +426,8 @@ fn cleanup_completed_post_review_lane_uses_persisted_handoff_marker() {
 			)
 			.expect("worktree mapping should record");
 
-		let issue_run = sample_closeout_issue_run(&issue, &worktree, issue_run_id);
+		let issue_run =
+			recovery_terminal_support::sample_closeout_issue_run(&issue, &worktree, issue_run_id);
 
 		orchestrator::cleanup_completed_post_review_lane(
 			&config,
@@ -414,9 +446,9 @@ fn cleanup_completed_post_review_lane_uses_persisted_handoff_marker() {
 
 #[test]
 fn cleanup_completed_post_review_lane_preserves_worktree_when_local_branch_delete_fails() {
-	let (temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(&base_config, "HOME");
-	let issue = sample_issue("Done", &[]);
+	let (temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(&base_config, "HOME");
+	let issue = tests::sample_issue("Done", &[]);
 	let _tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
@@ -424,17 +456,19 @@ fn cleanup_completed_post_review_lane_preserves_worktree_when_local_branch_delet
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained closeout worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/182";
-	let _path_guard = install_fake_merged_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_merged_pr_gh_response(
+		&temp_dir, &worktree, pr_url, &head_oid,
+	);
 	let remote_root =
 		config.repo_root().parent().expect("repo root should have a parent").join("origin.git");
 	let blocking_worktree = config.worktree_root().join("blocking-local-branch-delete");
 
-	initialize_closeout_cleanup_origin(config.repo_root(), &remote_root);
+	recovery_terminal_support::initialize_closeout_cleanup_origin(config.repo_root(), &remote_root);
 
 	assert!(
-		crate::test_support::hermetic_git_command()
+		test_support::hermetic_git_command()
 			.arg("-C")
 			.arg(config.repo_root())
 			.args(["push", "origin", &format!("HEAD:{}", worktree.branch_name)])
@@ -443,7 +477,7 @@ fn cleanup_completed_post_review_lane_preserves_worktree_when_local_branch_delet
 			.success()
 	);
 	assert!(
-		crate::test_support::hermetic_git_command()
+		test_support::hermetic_git_command()
 			.arg("-C")
 			.arg(&worktree.path)
 			.args(["checkout", "--quiet", "--detach"])
@@ -452,7 +486,7 @@ fn cleanup_completed_post_review_lane_preserves_worktree_when_local_branch_delet
 			.success()
 	);
 	assert!(
-		crate::test_support::hermetic_git_command()
+		test_support::hermetic_git_command()
 			.arg("-C")
 			.arg(config.repo_root())
 			.args([
@@ -467,11 +501,11 @@ fn cleanup_completed_post_review_lane_preserves_worktree_when_local_branch_delet
 			.success()
 	);
 
-	seed_review_handoff_marker_value(
+	tests::seed_review_handoff_marker_value(
 		&state_store,
 		config.service_id(),
 		&issue.id,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
 	state_store
@@ -483,8 +517,11 @@ fn cleanup_completed_post_review_lane_preserves_worktree_when_local_branch_delet
 		)
 		.expect("worktree mapping should record");
 
-	let issue_run =
-		sample_closeout_issue_run(&issue, &worktree, "run-closeout-local-branch-delete-blocked");
+	let issue_run = recovery_terminal_support::sample_closeout_issue_run(
+		&issue,
+		&worktree,
+		"run-closeout-local-branch-delete-blocked",
+	);
 	let error = orchestrator::cleanup_completed_post_review_lane(
 		&config,
 		&workflow,

--- a/apps/decodex/src/orchestrator/tests/recovery_closeout_dispatch.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery_closeout_dispatch.rs
@@ -1,9 +1,27 @@
+use std::path::PathBuf;
+
+use crate::{
+	orchestrator::{
+		self, IssueDispatchMode, RunSummary, TargetIssueRunContext,
+		tests::{
+			FakeTracker, TEST_SERVICE_ID, recovery_terminal_support, {self},
+		},
+	},
+	state::StateStore,
+	test_support,
+	tracker::{self, TrackerState, records},
+	worktree::{WorktreeManager, WorktreeSpec},
+};
+
 #[test]
 fn closeout_dispatch_completes_merged_lane_without_agent_turn() {
-	let (temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(&base_config, "HOME");
+	let (temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(&base_config, "HOME");
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = issue_with_completed_state(sample_issue("In Review", &[active_label.as_str()]));
+	let issue = recovery_terminal_support::issue_with_completed_state(tests::sample_issue(
+		"In Review",
+		&[active_label.as_str()],
+	));
 	let mut completed_issue = issue.clone();
 
 	completed_issue.state =
@@ -24,17 +42,22 @@ fn closeout_dispatch_completes_merged_lane_without_agent_turn() {
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained closeout worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/701";
-	let _path_guard = install_fake_closeout_gh_responses(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_closeout_gh_responses(
+		&temp_dir, &worktree, pr_url, &head_oid,
+	);
 	let remote_root =
 		config.repo_root().parent().expect("repo root should have a parent").join("origin.git");
 
-	initialize_closeout_cleanup_origin(config.repo_root(), &remote_root);
-	route_origin_github_url_to_local_bare_repo(config.repo_root(), &remote_root);
+	recovery_terminal_support::initialize_closeout_cleanup_origin(config.repo_root(), &remote_root);
+	recovery_terminal_support::route_origin_github_url_to_local_bare_repo(
+		config.repo_root(),
+		&remote_root,
+	);
 
 	assert!(
-		crate::test_support::hermetic_git_command()
+		test_support::hermetic_git_command()
 			.arg("-C")
 			.arg(config.repo_root())
 			.args(["push", "origin", &format!("HEAD:{}", worktree.branch_name)])
@@ -43,7 +66,7 @@ fn closeout_dispatch_completes_merged_lane_without_agent_turn() {
 			.success()
 	);
 
-	seed_review_handoff_marker(
+	tests::seed_review_handoff_marker(
 		&state_store,
 		config.service_id(),
 		&issue.id,
@@ -52,7 +75,11 @@ fn closeout_dispatch_completes_merged_lane_without_agent_turn() {
 		&head_oid,
 	);
 
-	let issue_run = sample_closeout_issue_run(&issue, &worktree, "pub-701-attempt-3-closeout");
+	let issue_run = recovery_terminal_support::sample_closeout_issue_run(
+		&issue,
+		&worktree,
+		"pub-701-attempt-3-closeout",
+	);
 
 	state_store
 		.record_run_attempt(&issue_run.run_id, &issue.id, issue_run.attempt_number, "starting")
@@ -100,10 +127,10 @@ fn closeout_dispatch_completes_merged_lane_without_agent_turn() {
 
 #[test]
 fn direct_closeout_dispatch_reuses_completed_handoff_run_identity_for_record_and_summary() {
-	let fixture = closeout_identity_fixture();
+	let fixture = recovery_terminal_support::closeout_identity_fixture();
 	let _keep_fixture_alive = (&fixture._temp_dir, &fixture._path_guard);
 
-	assert_closeout_lane_ready(&fixture);
+	recovery_terminal_support::assert_closeout_lane_ready(&fixture);
 
 	let summary = orchestrator::run_target_issue_once(TargetIssueRunContext {
 		tracker: &fixture.tracker,
@@ -166,10 +193,10 @@ fn direct_closeout_dispatch_reuses_completed_handoff_run_identity_for_record_and
 
 #[test]
 fn same_run_closeout_reuses_matching_active_handoff_lease() {
-	let fixture = closeout_identity_fixture();
+	let fixture = recovery_terminal_support::closeout_identity_fixture();
 	let _keep_fixture_alive = (&fixture._temp_dir, &fixture._path_guard);
 
-	assert_closeout_lane_ready(&fixture);
+	recovery_terminal_support::assert_closeout_lane_ready(&fixture);
 
 	fixture
 		.state_store
@@ -219,9 +246,12 @@ fn same_run_closeout_reuses_matching_active_handoff_lease() {
 
 #[test]
 fn closeout_completed_state_check_skips_redundant_transition() {
-	let (_temp_dir, _config, workflow) = temp_project_layout();
+	let (_temp_dir, _config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = issue_with_completed_state(sample_issue("Done", &[active_label.as_str()]));
+	let issue = recovery_terminal_support::issue_with_completed_state(tests::sample_issue(
+		"Done",
+		&[active_label.as_str()],
+	));
 	let tracker =
 		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
 	let worktree = WorktreeSpec {
@@ -230,7 +260,11 @@ fn closeout_completed_state_check_skips_redundant_transition() {
 		path: PathBuf::from(".worktrees/PUB-101"),
 		reused_existing: true,
 	};
-	let issue_run = sample_closeout_issue_run(&issue, &worktree, "pub-101-closeout-done");
+	let issue_run = recovery_terminal_support::sample_closeout_issue_run(
+		&issue,
+		&worktree,
+		"pub-101-closeout-done",
+	);
 
 	orchestrator::ensure_closeout_issue_completed_state(&tracker, &workflow, &issue_run)
 		.expect("completed issue should not require another transition");
@@ -243,10 +277,13 @@ fn closeout_completed_state_check_skips_redundant_transition() {
 
 #[test]
 fn closeout_dispatch_validates_pr_before_marking_issue_done() {
-	let (temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(&base_config, "HOME");
+	let (temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(&base_config, "HOME");
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = issue_with_completed_state(sample_issue("In Review", &[active_label.as_str()]));
+	let issue = recovery_terminal_support::issue_with_completed_state(tests::sample_issue(
+		"In Review",
+		&[active_label.as_str()],
+	));
 	let tracker =
 		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -255,24 +292,31 @@ fn closeout_dispatch_validates_pr_before_marking_issue_done() {
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained closeout worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/702";
-	let _path_guard = install_fake_closeout_gh_responses_with_state(
+	let _path_guard = recovery_terminal_support::install_fake_closeout_gh_responses_with_state(
 		&temp_dir, &worktree, pr_url, &head_oid, "OPEN",
 	);
 	let remote_root =
 		config.repo_root().parent().expect("repo root should have a parent").join("origin.git");
 
-	initialize_closeout_cleanup_origin(config.repo_root(), &remote_root);
-	route_origin_github_url_to_local_bare_repo(config.repo_root(), &remote_root);
-	seed_review_handoff_marker_value(
+	recovery_terminal_support::initialize_closeout_cleanup_origin(config.repo_root(), &remote_root);
+	recovery_terminal_support::route_origin_github_url_to_local_bare_repo(
+		config.repo_root(),
+		&remote_root,
+	);
+	tests::seed_review_handoff_marker_value(
 		&state_store,
 		config.service_id(),
 		&issue.id,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
-	let issue_run = sample_closeout_issue_run(&issue, &worktree, "pub-702-attempt-1-closeout");
+	let issue_run = recovery_terminal_support::sample_closeout_issue_run(
+		&issue,
+		&worktree,
+		"pub-702-attempt-1-closeout",
+	);
 
 	state_store
 		.record_run_attempt(&issue_run.run_id, &issue.id, issue_run.attempt_number, "starting")

--- a/apps/decodex/src/orchestrator/tests/recovery_closeout_identity.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery_closeout_identity.rs
@@ -1,9 +1,21 @@
+use crate::{
+	orchestrator::{
+		self, IssueDispatchMode, RetryQueue, ReviewOrchestrationMarker,
+		tests::{
+			TEST_EXTERNAL_REVIEW_AUTO_MERGE_ENABLED_AT, TEST_EXTERNAL_REVIEW_REQUEST_COMMENT_ID,
+			TEST_EXTERNAL_REVIEW_REQUEST_CREATED_AT, recovery_terminal_support, {self},
+		},
+	},
+	state,
+	tracker::records,
+};
+
 #[test]
 fn run_project_once_closeout_reuses_completed_handoff_run_identity_for_record_and_summary() {
-	let fixture = closeout_identity_fixture();
+	let fixture = recovery_terminal_support::closeout_identity_fixture();
 	let _keep_fixture_alive = (&fixture._temp_dir, &fixture._path_guard);
 
-	assert_closeout_lane_ready(&fixture);
+	recovery_terminal_support::assert_closeout_lane_ready(&fixture);
 
 	let planned = orchestrator::run_project_once(
 		&fixture.tracker,
@@ -88,18 +100,18 @@ fn run_project_once_closeout_reuses_completed_handoff_run_identity_for_record_an
 
 #[test]
 fn daemon_planned_closeout_reuses_handoff_identity_after_parent_failed_status() {
-	let fixture = closeout_identity_fixture();
+	let fixture = recovery_terminal_support::closeout_identity_fixture();
 	let _keep_fixture_alive = (&fixture._temp_dir, &fixture._path_guard);
 	let mut retry_queue = RetryQueue::default();
 
-	assert_closeout_lane_ready(&fixture);
+	recovery_terminal_support::assert_closeout_lane_ready(&fixture);
 
 	fixture
 		.state_store
 		.update_run_status(&fixture.completed_run_id, "failed")
 		.expect("daemon parent failed status should record");
 
-	seed_review_orchestration_marker_for_path(
+	tests::seed_review_orchestration_marker_for_path(
 		&fixture.state_store,
 		fixture.config.service_id(),
 		&fixture.worktree.path,
@@ -125,7 +137,6 @@ fn daemon_planned_closeout_reuses_handoff_identity_after_parent_failed_status() 
 		&fixture.config,
 		&fixture.workflow,
 		&fixture.state_store,
-
 	)
 	.expect("daemon planning should succeed")
 	.expect("retained closeout should be selected");
@@ -188,11 +199,11 @@ fn daemon_planned_closeout_reuses_handoff_identity_after_parent_failed_status() 
 
 #[test]
 fn daemon_planned_closeout_allocates_retry_after_recorded_closeout_failure() {
-	let fixture = closeout_identity_fixture();
+	let fixture = recovery_terminal_support::closeout_identity_fixture();
 	let _keep_fixture_alive = (&fixture._temp_dir, &fixture._path_guard);
 	let mut retry_queue = RetryQueue::default();
 
-	assert_closeout_lane_ready(&fixture);
+	recovery_terminal_support::assert_closeout_lane_ready(&fixture);
 
 	fixture
 		.state_store
@@ -214,7 +225,6 @@ fn daemon_planned_closeout_allocates_retry_after_recorded_closeout_failure() {
 		&fixture.config,
 		&fixture.workflow,
 		&fixture.state_store,
-
 	)
 	.expect("daemon planning should succeed")
 	.expect("retained closeout should be selected");
@@ -227,7 +237,7 @@ fn daemon_planned_closeout_allocates_retry_after_recorded_closeout_failure() {
 
 #[test]
 fn run_project_once_closeout_preserves_handoff_identity_after_fresh_activity_recovery() {
-	let fixture = closeout_identity_fixture();
+	let fixture = recovery_terminal_support::closeout_identity_fixture();
 	let _keep_fixture_alive = (&fixture._temp_dir, &fixture._path_guard);
 
 	state::write_run_activity_marker(&fixture.worktree.path, &fixture.completed_run_id, 1)

--- a/apps/decodex/src/orchestrator/tests/recovery_reconciliation.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery_reconciliation.rs
@@ -1,4 +1,25 @@
+use std::{fs, path::Path, process, time::Duration};
+
 use serde::Serialize;
+use time::OffsetDateTime;
+
+use crate::{
+	agent::{MODEL_EXECUTION_IDLE_TIMEOUT, RUN_LEASE_IDLE_TIMEOUT},
+	orchestrator::{
+		self, CONTINUATION_PENDING_RUN_STATUS, ChildRunRef, CurrentChildRunContext,
+		IssueDispatchMode, PHASE_ACCEPTANCE_CHECK_EVENT_TYPE, ReviewHandoffMarker,
+		RunLeaseDisposition, RunLeaseReconciliation, TERMINAL_GUARDED_RUN_STATUS,
+		tests::{
+			FakeTracker, TEST_SERVICE_ID, {self},
+		},
+	},
+	state::{
+		self, RUN_ACTIVITY_MARKER_FILE, RUN_OPERATION_REPO_GATE, ReviewPolicyCheckpointInput,
+		StateStore,
+	},
+	tracker::{self, TrackerIssue, records},
+	worktree::WorktreeManager,
+};
 
 struct StalledPhaseGoalOutcome {
 	run_status: String,
@@ -14,14 +35,14 @@ struct StalledPhaseGoalOutcome {
 fn reconciliation_sample_service_owned_issue(state_name: &str) -> TrackerIssue {
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
 
-	sample_issue(state_name, &[active_label.as_str()])
+	tests::sample_issue(state_name, &[active_label.as_str()])
 }
 
 #[test]
 fn run_lease_reconciliation_detects_terminal_not_dispatchable_and_stalled_runs() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let terminal_issue = sample_issue_with_sort_fields(
+	let terminal_issue = tests::sample_issue_with_sort_fields(
 		"issue-terminal",
 		"PUB-201",
 		"Done",
@@ -29,7 +50,7 @@ fn run_lease_reconciliation_detects_terminal_not_dispatchable_and_stalled_runs()
 		Some(3),
 		"2026-03-13T04:16:17.133Z",
 	);
-	let not_dispatchable_issue = sample_issue_with_sort_fields(
+	let not_dispatchable_issue = tests::sample_issue_with_sort_fields(
 		"issue-not-dispatchable",
 		"PUB-202",
 		"Blocked",
@@ -37,7 +58,7 @@ fn run_lease_reconciliation_detects_terminal_not_dispatchable_and_stalled_runs()
 		Some(3),
 		"2026-03-13T04:16:17.133Z",
 	);
-	let stalled_issue = sample_issue_with_sort_fields(
+	let stalled_issue = tests::sample_issue_with_sort_fields(
 		"issue-stalled",
 		"PUB-203",
 		"In Progress",
@@ -101,9 +122,9 @@ fn run_lease_reconciliation_detects_terminal_not_dispatchable_and_stalled_runs()
 
 #[test]
 fn run_lease_reconciliation_detects_stalled_run_without_protocol_events() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let stalled_issue = sample_issue_with_sort_fields(
+	let stalled_issue = tests::sample_issue_with_sort_fields(
 		"issue-stalled-no-events",
 		"PUB-204",
 		"In Progress",
@@ -154,9 +175,9 @@ fn run_lease_reconciliation_detects_stalled_run_without_protocol_events() {
 
 #[test]
 fn run_lease_reconciliation_supersedes_stale_lease_for_newer_attempt() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue_with_sort_fields(
+	let issue = tests::sample_issue_with_sort_fields(
 		"issue-superseded-lease",
 		"PUB-207",
 		"In Progress",
@@ -225,8 +246,8 @@ fn run_lease_reconciliation_supersedes_stale_lease_for_newer_attempt() {
 
 #[test]
 fn run_lease_reconciliation_keeps_completed_closeout_lane_with_fresh_activity() {
-	let (_temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(
+	let (_temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(
 		&base_config,
 		"DECODEX_TEST_MISSING_ACTIVE_DELIVERY_CLOSEOUT_GITHUB_TOKEN",
 	);
@@ -239,7 +260,7 @@ fn run_lease_reconciliation_keeps_completed_closeout_lane_with_fresh_activity() 
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained closeout worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/180";
 
 	state_store
@@ -255,13 +276,12 @@ fn run_lease_reconciliation_keeps_completed_closeout_lane_with_fresh_activity() 
 		)
 		.expect("worktree mapping should record");
 
-	seed_review_handoff_marker_for_path(
+	tests::seed_review_handoff_marker_for_path(
 		&state_store,
 		config.service_id(),
 		&worktree.path,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
-
 	state::write_run_activity_marker(&worktree.path, run_id, 1)
 		.expect("fresh activity marker should write");
 
@@ -283,8 +303,8 @@ fn run_lease_reconciliation_keeps_completed_closeout_lane_with_fresh_activity() 
 
 #[test]
 fn active_daemon_child_reconciliation_keeps_completed_closeout_lane_with_fresh_activity() {
-	let (_temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(
+	let (_temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(
 		&base_config,
 		"DECODEX_TEST_MISSING_ACTIVE_DAEMON_DELIVERY_CLOSEOUT_GITHUB_TOKEN",
 	);
@@ -297,7 +317,7 @@ fn active_daemon_child_reconciliation_keeps_completed_closeout_lane_with_fresh_a
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained closeout worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/181";
 
 	state_store
@@ -313,13 +333,12 @@ fn active_daemon_child_reconciliation_keeps_completed_closeout_lane_with_fresh_a
 		)
 		.expect("worktree mapping should record");
 
-	seed_review_handoff_marker_for_path(
+	tests::seed_review_handoff_marker_for_path(
 		&state_store,
 		config.service_id(),
 		&worktree.path,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
-
 	state::write_run_activity_marker(&worktree.path, run_id, 1)
 		.expect("fresh activity marker should write");
 
@@ -344,7 +363,7 @@ fn active_daemon_child_reconciliation_keeps_completed_closeout_lane_with_fresh_a
 
 #[test]
 fn current_daemon_child_reconciliation_keeps_review_repair_lane_in_review() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let issue = reconciliation_sample_service_owned_issue("In Review");
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -391,8 +410,8 @@ fn current_daemon_child_reconciliation_keeps_review_repair_lane_in_review() {
 
 #[test]
 fn current_daemon_child_reconciliation_keeps_closeout_child_after_tracker_completion() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_issue("Done", &[]);
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue("Done", &[]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let run_id = "run-closeout-completed";
@@ -425,8 +444,8 @@ fn current_daemon_child_reconciliation_keeps_closeout_child_after_tracker_comple
 
 #[test]
 fn run_lease_reconciliation_treats_completed_retained_handoff_as_success() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_issue_with_sort_fields(
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue_with_sort_fields(
 		"issue-handoff-complete",
 		"PUB-205",
 		"In Progress",
@@ -442,7 +461,7 @@ fn run_lease_reconciliation_treats_completed_retained_handoff_as_success() {
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained review worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/205";
 
 	state_store
@@ -463,11 +482,11 @@ fn run_lease_reconciliation_treats_completed_retained_handoff_as_success() {
 		.append_event(run_id, 1, "thread/status/changed", "{\"status\":\"active\"}")
 		.expect("stale run activity should record");
 
-	seed_review_handoff_marker_for_path(
+	tests::seed_review_handoff_marker_for_path(
 		&state_store,
 		config.service_id(),
 		&worktree.path,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
 	let now =
@@ -518,8 +537,8 @@ fn run_lease_reconciliation_treats_completed_retained_handoff_as_success() {
 
 #[test]
 fn run_lease_reconciliation_ignores_stale_retained_handoff_marker() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_issue_with_sort_fields(
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue_with_sort_fields(
 		"issue-stale-handoff",
 		"PUB-205B",
 		"In Progress",
@@ -535,7 +554,7 @@ fn run_lease_reconciliation_ignores_stale_retained_handoff_marker() {
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained review worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 
 	state_store
 		.record_run_attempt(run_id, &issue.id, 1, "running")
@@ -555,7 +574,7 @@ fn run_lease_reconciliation_ignores_stale_retained_handoff_marker() {
 		.append_event(run_id, 1, "thread/status/changed", "{\"status\":\"active\"}")
 		.expect("stale run activity should record");
 
-	seed_review_handoff_marker_for_path(
+	tests::seed_review_handoff_marker_for_path(
 		&state_store,
 		config.service_id(),
 		&worktree.path,
@@ -592,8 +611,8 @@ fn run_lease_reconciliation_ignores_stale_retained_handoff_marker() {
 
 #[test]
 fn active_daemon_child_reconciliation_treats_completed_retained_handoff_as_success() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_issue_with_sort_fields(
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue_with_sort_fields(
 		"issue-daemon-handoff-complete",
 		"PUB-206",
 		"In Progress",
@@ -609,7 +628,7 @@ fn active_daemon_child_reconciliation_treats_completed_retained_handoff_as_succe
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained review worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/206";
 
 	state_store
@@ -630,11 +649,11 @@ fn active_daemon_child_reconciliation_treats_completed_retained_handoff_as_succe
 		.append_event(run_id, 1, "thread/status/changed", "{\"status\":\"active\"}")
 		.expect("stale run activity should record");
 
-	seed_review_handoff_marker_for_path(
+	tests::seed_review_handoff_marker_for_path(
 		&state_store,
 		config.service_id(),
 		&worktree.path,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
 	let now =
@@ -689,8 +708,8 @@ fn stalled_idle_duration_ignores_future_last_activity() {
 
 #[test]
 fn run_lease_reconciliation_uses_worktree_activity_marker_from_child_process() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_issue("In Progress", &[]);
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue("In Progress", &[]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let run_id = "run-shared-activity";
@@ -746,8 +765,8 @@ fn run_lease_reconciliation_uses_worktree_activity_marker_from_child_process() {
 
 #[test]
 fn run_lease_reconciliation_allows_running_model_execution_until_model_timeout() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_issue("In Progress", &[]);
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue("In Progress", &[]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let run_id = "run-model-execution-idle";
@@ -774,8 +793,7 @@ fn run_lease_reconciliation_allows_running_model_execution_until_model_timeout()
 		.last_run_activity_unix_epoch(run_id)
 		.expect("last activity lookup should succeed")
 		.expect("run activity should exist");
-	let protocol_activity =
-		r#"{"turn_status":"running","waiting_reason":"model_execution","rate_limit_status":null,"recent_events":[]}"#;
+	let protocol_activity = r#"{"turn_status":"running","waiting_reason":"model_execution","rate_limit_status":null,"recent_events":[]}"#;
 
 	fs::write(
 		worktree_path.join(RUN_ACTIVITY_MARKER_FILE),
@@ -817,19 +835,19 @@ fn run_lease_reconciliation_allows_running_model_execution_until_model_timeout()
 				RunLeaseDisposition::Stalled{ idle_for }
 					if idle_for >= MODEL_EXECUTION_IDLE_TIMEOUT
 			)
-		}));
+	}));
 }
 
 #[test]
 fn run_lease_reconciliation_defers_live_repo_gate_even_with_dirty_worktree() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_issue("In Progress", &[]);
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue("In Progress", &[]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let run_id = "run-live-repo-gate";
 	let worktree_path = config.worktree_root().join("PUB-101-repo-gate");
 
-	git_status_success(
+	tests::git_status_success(
 		config.repo_root(),
 		&[
 			"worktree",
@@ -840,7 +858,6 @@ fn run_lease_reconciliation_defers_live_repo_gate_even_with_dirty_worktree() {
 			"main",
 		],
 	);
-
 	fs::write(worktree_path.join("README.md"), "repo gate is still running\n")
 		.expect("tracked worktree file should change");
 
@@ -922,15 +939,15 @@ fn run_lease_reconciliation_defers_live_repo_gate_even_with_dirty_worktree() {
 
 #[test]
 fn exited_child_reconciliation_defers_dirty_worktree_with_retry_marker() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("In Progress", &[active_label.as_str()]);
+	let issue = tests::sample_issue("In Progress", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let run_id = "run-failed-with-retry-marker";
 	let worktree_path = config.worktree_root().join("PUB-101-retry-marker");
 
-	git_status_success(
+	tests::git_status_success(
 		config.repo_root(),
 		&[
 			"worktree",
@@ -941,7 +958,6 @@ fn exited_child_reconciliation_defers_dirty_worktree_with_retry_marker() {
 			"main",
 		],
 	);
-
 	fs::write(worktree_path.join("README.md"), "retry still owns this patch\n")
 		.expect("tracked worktree file should change");
 
@@ -989,7 +1005,7 @@ fn record_active_validation_ready_phase_goal_progress(
 	progress_phase: &str,
 	blockers: impl Serialize,
 ) {
-	let head_sha = git_output(worktree_path, &["rev-parse", "HEAD"]);
+	let head_sha = tests::git_output(worktree_path, &["rev-parse", "HEAD"]);
 
 	state_store
 		.append_private_execution_event(
@@ -1030,8 +1046,8 @@ fn apply_stalled_phase_goal_reconciliation(
 	progress_phase: &str,
 	blockers: impl Serialize,
 ) -> StalledPhaseGoalOutcome {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_issue("In Progress", &[]);
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue("In Progress", &[]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
@@ -1039,7 +1055,7 @@ fn apply_stalled_phase_goal_reconciliation(
 	let run_id = "run-stalled-phase-goal";
 	let worktree_path = config.worktree_root().join("PUB-101-phase-goal");
 
-	git_status_success(
+	tests::git_status_success(
 		config.repo_root(),
 		&[
 			"worktree",
@@ -1050,7 +1066,6 @@ fn apply_stalled_phase_goal_reconciliation(
 			"main",
 		],
 	);
-
 	fs::write(worktree_path.join("README.md"), "validation-ready retained patch\n")
 		.expect("tracked worktree file should change");
 
@@ -1204,9 +1219,9 @@ fn stalled_protocol_idle_duration_ignores_future_protocol_activity() {
 
 #[test]
 fn run_lease_reconciliation_ignores_startable_preclaim_states() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue_with_sort_fields(
+	let issue = tests::sample_issue_with_sort_fields(
 		"issue-startable",
 		"PUB-204",
 		"Todo",
@@ -1239,7 +1254,7 @@ fn run_lease_reconciliation_ignores_startable_preclaim_states() {
 
 #[test]
 fn run_lease_reconciliation_clears_terminal_lane_labels() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let issue = reconciliation_sample_service_owned_issue("Done");
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -1297,12 +1312,12 @@ fn run_lease_reconciliation_clears_terminal_lane_labels() {
 
 #[test]
 fn run_lease_reconciliation_keeps_nonterminal_not_dispatchable_worktrees() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
 		WorktreeManager::new("pubfi", config.repo_root(), config.worktree_root());
-	let issue = sample_issue("Todo", &[]);
+	let issue = tests::sample_issue("Todo", &[]);
 	let run_id = "run-not-dispatchable";
 	let worktree_path = config.worktree_root().join("PUB-101");
 
@@ -1362,12 +1377,12 @@ fn run_lease_reconciliation_keeps_nonterminal_not_dispatchable_worktrees() {
 
 #[test]
 fn stalled_run_reconciliation_schedules_retry_before_attention_budget_exhaustion() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
 		WorktreeManager::new("pubfi", config.repo_root(), config.worktree_root());
-	let issue = sample_issue("In Progress", &[]);
+	let issue = tests::sample_issue("In Progress", &[]);
 	let run_id = "run-stalled";
 	let worktree_path = config.worktree_root().join("PUB-101");
 
@@ -1454,14 +1469,16 @@ fn stalled_run_reconciliation_schedules_retry_before_attention_budget_exhaustion
 		.expect("retry marker should exist");
 
 	assert_eq!(marker.retry_kind(), Some("failure"));
-	assert!(marker.retry_ready_at_unix_epoch().is_some_and(
-		|retry_ready_at| retry_ready_at > OffsetDateTime::now_utc().unix_timestamp()
-	));
+	assert!(
+		marker.retry_ready_at_unix_epoch().is_some_and(
+			|retry_ready_at| retry_ready_at > OffsetDateTime::now_utc().unix_timestamp()
+		)
+	);
 }
 
 #[test]
 fn stalled_run_reconciliation_routes_to_needs_attention_after_retry_budget_exhaustion() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
@@ -1540,20 +1557,19 @@ fn stalled_run_reconciliation_routes_to_needs_attention_after_retry_budget_exhau
 
 #[test]
 fn stalled_run_reconciliation_reports_retained_partial_progress_for_dirty_worktree() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
 		WorktreeManager::new("pubfi", config.repo_root(), config.worktree_root());
-	let issue = sample_issue("In Progress", &[]);
+	let issue = tests::sample_issue("In Progress", &[]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let run_id = "run-stalled-dirty";
 	let worktree_path = config.worktree_root().join("PUB-102");
 
-	git_status_success(
+	tests::git_status_success(
 		config.repo_root(),
 		&["worktree", "add", "-b", "x/pubfi-pub-102", ".worktrees/PUB-102", "main"],
 	);
-
 	fs::write(worktree_path.join("README.md"), "retained partial work\n")
 		.expect("tracked worktree file should change");
 
@@ -1630,11 +1646,11 @@ fn assert_dirty_stalled_retained_progress_comments(comments: &[String]) {
 			&& comment.contains(".worktrees/PUB-102")
 	}));
 	assert!(
-		comments
-			.iter()
-			.all(|comment| !comment.contains("- error_class: `stalled_run_detected`"))
+		comments.iter().all(|comment| !comment.contains("- error_class: `stalled_run_detected`"))
 	);
-	assert!(comments.iter().all(|comment| !comment.contains("decodex run failed and needs attention")));
+	assert!(
+		comments.iter().all(|comment| !comment.contains("decodex run failed and needs attention"))
+	);
 
 	let ledger_event = comments
 		.iter()
@@ -1650,34 +1666,28 @@ fn assert_dirty_stalled_retained_progress_comments(comments: &[String]) {
 	);
 	assert_eq!(
 		ledger_event.blockers.as_deref(),
-		Some([String::from(
-			"Retained tracked worktree changes require operator recovery."
-		)]
-		.as_slice())
+		Some(
+			[String::from("Retained tracked worktree changes require operator recovery.")]
+				.as_slice()
+		)
 	);
 	assert!(
-		ledger_event
-			.evidence
-			.as_deref()
-			.is_some_and(|evidence| evidence
-				.iter()
-				.any(|item| item.contains("tracked worktree changes retained"))),
+		ledger_event.evidence.as_deref().is_some_and(|evidence| evidence
+			.iter()
+			.any(|item| item.contains("tracked worktree changes retained"))),
 		"retained partial progress evidence should mention retained tracked changes"
 	);
 	assert!(
-		ledger_event
-			.evidence
-			.as_deref()
-			.is_some_and(|evidence| evidence
-				.iter()
-				.any(|item| item.contains("Source failure class `stalled_run_detected`"))),
+		ledger_event.evidence.as_deref().is_some_and(|evidence| evidence
+			.iter()
+			.any(|item| item.contains("Source failure class `stalled_run_detected`"))),
 		"retained partial progress evidence should preserve the stalled source class"
 	);
 }
 
 #[test]
 fn project_reconciliation_schedules_retry_for_orphaned_active_worktree_run() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let issue = reconciliation_sample_service_owned_issue("In Progress");
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -1745,7 +1755,7 @@ fn project_reconciliation_schedules_retry_for_orphaned_active_worktree_run() {
 
 #[test]
 fn project_reconciliation_clears_terminal_identifier_worktree_before_tracker_refresh() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(Vec::new());
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
@@ -1794,10 +1804,10 @@ fn project_reconciliation_clears_terminal_identifier_worktree_before_tracker_ref
 
 #[test]
 fn project_reconciliation_preserves_terminal_identifier_worktree_with_review_authority() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let stale_issue_id = "PUB-001";
 	let branch_name = "x/pubfi-pub-001";
-	let issue = sample_issue_with_sort_fields(
+	let issue = tests::sample_issue_with_sort_fields(
 		stale_issue_id,
 		stale_issue_id,
 		"In Review",
@@ -1823,7 +1833,7 @@ fn project_reconciliation_preserves_terminal_identifier_worktree_with_review_aut
 		)
 		.expect("stale worktree mapping should record");
 
-	seed_review_handoff_marker(
+	tests::seed_review_handoff_marker(
 		&state_store,
 		config.service_id(),
 		stale_issue_id,
@@ -1872,13 +1882,7 @@ fn project_reconciliation_preserves_terminal_identifier_worktree_with_review_aut
 	);
 	assert!(
 		state_store
-			.review_policy_checkpoint(
-				config.service_id(),
-				stale_issue_id,
-				"run-01",
-				1,
-				"handoff",
-			)
+			.review_policy_checkpoint(config.service_id(), stale_issue_id, "run-01", 1, "handoff",)
 			.expect("review checkpoint lookup should succeed")
 			.is_some(),
 		"review checkpoint authority must be preserved"
@@ -1887,8 +1891,8 @@ fn project_reconciliation_preserves_terminal_identifier_worktree_with_review_aut
 
 #[test]
 fn project_reconciliation_marks_orphaned_attention_worktree_run_stalled_without_tracker_writes() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_issue("Todo", &["decodex:needs-attention"]);
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue("Todo", &["decodex:needs-attention"]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
@@ -1943,12 +1947,12 @@ fn project_reconciliation_marks_orphaned_attention_worktree_run_stalled_without_
 
 #[test]
 fn stalled_run_reconciliation_preserves_retry_budget_marker_from_retained_worktree() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
 		WorktreeManager::new("pubfi", config.repo_root(), config.worktree_root());
-	let issue = sample_issue("In Progress", &[]);
+	let issue = tests::sample_issue("In Progress", &[]);
 	let run_id = "run-stalled-budget";
 	let worktree_path = config.worktree_root().join("PUB-101");
 

--- a/apps/decodex/src/orchestrator/tests/recovery_runtime_reentry.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery_runtime_reentry.rs
@@ -1,10 +1,29 @@
-use orchestrator::RecoverableWorktreeSkipCache;
+use std::{
+	fs,
+	process::{self, Command},
+};
+
+use time::OffsetDateTime;
+
+use crate::{
+	agent::RUN_LEASE_IDLE_TIMEOUT,
+	orchestrator::{
+		self, RecoverableWorktreeSkipCache, ReviewLevel, RunLeaseDisposition,
+		TERMINAL_GUARD_MARKER_FILE,
+		tests::{
+			FakeTracker, TEST_SERVICE_ID, recovery_terminal_support, {self},
+		},
+	},
+	state::{self, ProtocolActivityMarker, StateStore},
+	tracker::{self},
+	worktree::WorktreeManager,
+};
 
 #[test]
 fn exited_child_reconciliation_detects_stalled_failed_runs_from_protocol_idle() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue_with_sort_fields(
+	let issue = tests::sample_issue_with_sort_fields(
 		"issue-stalled-after-exit",
 		"PUB-205",
 		"In Progress",
@@ -40,12 +59,12 @@ fn exited_child_reconciliation_detects_stalled_failed_runs_from_protocol_idle() 
 			attempt_number: 1,
 			thread_id: None,
 			turn_id: None,
-				event_count: 1,
-				last_event_type: "thread/status/changed",
-				child_agent_activity: None,
-				protocol_activity: None,
-			},
-		)
+			event_count: 1,
+			last_event_type: "thread/status/changed",
+			child_agent_activity: None,
+			protocol_activity: None,
+		},
+	)
 	.expect("protocol marker should write");
 
 	let last_protocol_activity =
@@ -75,9 +94,9 @@ fn exited_child_reconciliation_detects_stalled_failed_runs_from_protocol_idle() 
 
 #[test]
 fn exited_child_reconciliation_detects_retained_partial_progress_from_dirty_worktree() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue_with_sort_fields(
+	let issue = tests::sample_issue_with_sort_fields(
 		"issue-stalled-dirty-after-exit",
 		"PUB-206",
 		"In Progress",
@@ -89,11 +108,10 @@ fn exited_child_reconciliation_detects_retained_partial_progress_from_dirty_work
 	let run_id = "run-stalled-dirty-after-exit";
 	let worktree_path = config.worktree_root().join(&issue.identifier);
 
-	git_status_success(
+	tests::git_status_success(
 		config.repo_root(),
 		&["worktree", "add", "-b", "x/pubfi-pub-206", ".worktrees/PUB-206", "main"],
 	);
-
 	fs::write(worktree_path.join("README.md"), "retained partial work\n")
 		.expect("tracked worktree file should change");
 
@@ -124,9 +142,10 @@ fn exited_child_reconciliation_detects_retained_partial_progress_from_dirty_work
 	)
 	.expect("protocol marker should write");
 
-	let last_protocol_activity = state::read_run_protocol_activity_marker(&worktree_path, run_id, 1)
-		.expect("protocol marker should read")
-		.expect("protocol activity should exist");
+	let last_protocol_activity =
+		state::read_run_protocol_activity_marker(&worktree_path, run_id, 1)
+			.expect("protocol marker should read")
+			.expect("protocol activity should exist");
 	let actions = orchestrator::inspect_exited_daemon_child_reconciliation_at(
 		&tracker,
 		&config,
@@ -148,9 +167,9 @@ fn exited_child_reconciliation_detects_retained_partial_progress_from_dirty_work
 
 #[test]
 fn exited_child_reconciliation_ignores_superseded_failed_run() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue_with_sort_fields(
+	let issue = tests::sample_issue_with_sort_fields(
 		"issue-superseded-after-exit",
 		"PUB-206",
 		"In Progress",
@@ -243,8 +262,8 @@ fn exited_child_reconciliation_ignores_superseded_failed_run() {
 
 #[test]
 fn run_project_once_prefers_recovered_in_progress_worktree_after_empty_state_startup() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_active_issue("In Progress");
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = recovery_terminal_support::sample_active_issue("In Progress");
 	let tracker =
 		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -272,8 +291,8 @@ fn run_project_once_prefers_recovered_in_progress_worktree_after_empty_state_sta
 
 #[test]
 fn recover_runtime_state_recovers_fresh_review_repair_activity_marker() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_active_issue("In Review");
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = recovery_terminal_support::sample_active_issue("In Review");
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
@@ -309,9 +328,9 @@ fn recover_runtime_state_recovers_fresh_review_repair_activity_marker() {
 
 #[test]
 fn run_project_once_recovers_retained_worktree_from_issue_identifier() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue_with_project_slug_and_sort_fields(
+	let issue = tests::sample_issue_with_project_slug_and_sort_fields(
 		"issue-1",
 		"PUB-101",
 		"tracker-project",
@@ -340,12 +359,12 @@ fn run_project_once_recovers_retained_worktree_from_issue_identifier() {
 
 #[test]
 fn run_project_once_recovers_ready_post_review_lane_before_landing() {
-	let (temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_review_level(
-		&service_config_with_github_token_env_var(&base_config, "PATH"),
+	let (temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_review_level(
+		&tests::service_config_with_github_token_env_var(&base_config, "PATH"),
 		ReviewLevel::Standard,
 	);
-	let issue = sample_active_issue("In Review");
+	let issue = recovery_terminal_support::sample_active_issue("In Review");
 	let tracker = FakeTracker::with_refresh_snapshots(
 		vec![issue.clone()],
 		vec![vec![issue.clone()], vec![issue.clone()], vec![issue.clone()]],
@@ -361,16 +380,22 @@ fn run_project_once_recovers_ready_post_review_lane_before_landing() {
 		r#"{"schema":"decodex/commit/1","summary":"Add retry hint","authority":"PUB-101"}"#;
 	let landed_subject =
 		r#"{"schema":"decodex/commit/1","summary":"Land Add retry hint","authority":"PUB-101"}"#;
-	let head_oid =
-		commit_worktree_change(&worktree.path, "retained-ready.txt", "ready\n", head_subject);
+	let head_oid = tests::commit_worktree_change(
+		&worktree.path,
+		"retained-ready.txt",
+		"ready\n",
+		head_subject,
+	);
 	let (_path_guard, invocation_log_path) =
-		install_fake_ready_to_land_admin_merge_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+		recovery_terminal_support::install_fake_ready_to_land_admin_merge_gh_response(
+			&temp_dir, &worktree, pr_url, &head_oid,
+		);
 
-	seed_review_handoff_marker_value(
+	tests::seed_review_handoff_marker_value(
 		&state_store,
 		config.service_id(),
 		&issue.id,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
 	let summary = orchestrator::run_project_once(&tracker, &config, &workflow, &state_store, false)
@@ -381,7 +406,7 @@ fn run_project_once_recovers_ready_post_review_lane_before_landing() {
 		"ready retained post-review landing should not dispatch a new current lane"
 	);
 
-	let marker = persisted_review_orchestration_marker_for_path(
+	let marker = tests::persisted_review_orchestration_marker_for_path(
 		&state_store,
 		config.service_id(),
 		&worktree.path,
@@ -413,8 +438,8 @@ fn run_project_once_recovers_ready_post_review_lane_before_landing() {
 
 #[test]
 fn materialize_run_summary_worktree_creates_worktree_before_child_activity_marker() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_issue("Todo", &[]);
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue("Todo", &[]);
 	let tracker = FakeTracker::with_refresh_snapshots(
 		vec![issue.clone()],
 		vec![vec![issue.clone()], vec![issue.clone()]],
@@ -488,7 +513,7 @@ read_first = []
 Follow the repository policy.
 	"#;
 	let (_temp_dir, config, workflow) =
-		temp_project_layout_with_workflow_markdown(workflow_markdown);
+		tests::temp_project_layout_with_workflow_markdown(workflow_markdown);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
 		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
@@ -514,15 +539,16 @@ Follow the repository policy.
 	);
 	assert!(!worktree.path.exists(), "cleanup should still remove the worktree");
 	assert!(
-		!git_output(config.repo_root(), &["branch", "--list", &worktree.branch_name]).is_empty(),
+		!tests::git_output(config.repo_root(), &["branch", "--list", &worktree.branch_name])
+			.is_empty(),
 		"generic terminal cleanup should preserve the retained local branch ref"
 	);
 }
 
 #[test]
 fn materialize_daemon_spawn_state_starts_fresh_budget_for_normal_queue_intake() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_issue("Todo", &[]);
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue("Todo", &[]);
 	let tracker = FakeTracker::with_refresh_snapshots(
 		vec![issue.clone()],
 		vec![vec![issue.clone()], vec![issue.clone()]],
@@ -553,8 +579,8 @@ fn materialize_daemon_spawn_state_starts_fresh_budget_for_normal_queue_intake() 
 
 #[test]
 fn materialize_daemon_spawn_state_uses_retained_retry_budget_marker_for_recovered_retry() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_active_issue("In Progress");
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = recovery_terminal_support::sample_active_issue("In Progress");
 	let tracker = FakeTracker::with_refresh_snapshots(
 		vec![issue.clone()],
 		vec![vec![issue.clone()], vec![issue.clone()]],
@@ -586,8 +612,8 @@ fn materialize_daemon_spawn_state_uses_retained_retry_budget_marker_for_recovere
 
 #[test]
 fn run_project_once_skips_recovered_worktree_with_fresh_activity_marker() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_active_issue("In Progress");
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = recovery_terminal_support::sample_active_issue("In Progress");
 	let tracker =
 		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -628,8 +654,8 @@ fn run_project_once_skips_recovered_worktree_with_fresh_activity_marker() {
 #[cfg(unix)]
 #[test]
 fn run_project_once_retries_recovered_worktree_after_marker_process_is_killed() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_active_issue("In Progress");
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = recovery_terminal_support::sample_active_issue("In Progress");
 	let tracker = FakeTracker::with_refresh_snapshots(
 		vec![issue.clone()],
 		vec![vec![issue.clone()], vec![issue.clone()]],
@@ -677,8 +703,8 @@ fn run_project_once_retries_recovered_worktree_after_marker_process_is_killed() 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn run_project_once_retries_recovered_worktree_from_previous_boot() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_active_issue("In Progress");
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = recovery_terminal_support::sample_active_issue("In Progress");
 	let tracker = FakeTracker::with_refresh_snapshots(
 		vec![issue.clone()],
 		vec![vec![issue.clone()], vec![issue.clone()]],
@@ -692,8 +718,7 @@ fn run_project_once_retries_recovered_worktree_from_previous_boot() {
 
 	state::write_run_activity_marker_for_process(&worktree.path, "run-1", 1, process::id())
 		.expect("activity marker should write");
-
-	rewrite_run_activity_marker_host_boot_id(&worktree.path, "previous-boot");
+	tests::rewrite_run_activity_marker_host_boot_id(&worktree.path, "previous-boot");
 
 	let summary = orchestrator::run_project_once(&tracker, &config, &workflow, &state_store, true)
 		.expect("previous-boot recovery should succeed")
@@ -710,8 +735,8 @@ fn run_project_once_retries_recovered_worktree_from_previous_boot() {
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn run_project_once_retries_recovered_worktree_from_reused_pid() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_active_issue("In Progress");
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = recovery_terminal_support::sample_active_issue("In Progress");
 	let tracker = FakeTracker::with_refresh_snapshots(
 		vec![issue.clone()],
 		vec![vec![issue.clone()], vec![issue.clone()]],
@@ -725,8 +750,10 @@ fn run_project_once_retries_recovered_worktree_from_reused_pid() {
 
 	state::write_run_activity_marker_for_process(&worktree.path, "run-1", 1, process::id())
 		.expect("activity marker should write");
-
-	rewrite_run_activity_marker_process_start_identity(&worktree.path, "previous-process-start");
+	tests::rewrite_run_activity_marker_process_start_identity(
+		&worktree.path,
+		"previous-process-start",
+	);
 
 	let summary = orchestrator::run_project_once(&tracker, &config, &workflow, &state_store, true)
 		.expect("same-boot PID-reuse recovery should succeed")
@@ -755,8 +782,8 @@ fn process_is_alive_handles_current_process_and_invalid_sentinel() {
 
 #[test]
 fn run_project_once_clears_recovered_lease_when_marker_turns_stale() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_active_issue("In Progress");
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = recovery_terminal_support::sample_active_issue("In Progress");
 	let tracker = FakeTracker::with_refresh_snapshots(
 		vec![issue.clone()],
 		vec![vec![issue.clone()], vec![issue.clone()]],
@@ -805,8 +832,10 @@ fn run_project_once_clears_recovered_lease_when_marker_turns_stale() {
 
 #[test]
 fn run_project_once_skips_recovered_terminal_guarded_worktree_after_empty_state_startup() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_active_issue_without_needs_attention_team_label("In Progress");
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = recovery_terminal_support::sample_active_issue_without_needs_attention_team_label(
+		"In Progress",
+	);
 	let tracker =
 		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -840,9 +869,9 @@ fn run_project_once_skips_recovered_terminal_guarded_worktree_after_empty_state_
 
 #[test]
 fn run_project_once_clears_terminal_queued_lane_labels_without_dispatch() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("Done", &[active_label.as_str()]);
+	let issue = tests::sample_issue("Done", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let summary = orchestrator::run_project_once(&tracker, &config, &workflow, &state_store, false)
@@ -860,9 +889,9 @@ fn run_project_once_clears_terminal_queued_lane_labels_without_dispatch() {
 
 #[test]
 fn run_project_once_dry_run_keeps_terminal_queued_lane_labels() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("Done", &[active_label.as_str()]);
+	let issue = tests::sample_issue("Done", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let summary = orchestrator::run_project_once(&tracker, &config, &workflow, &state_store, true)
@@ -878,8 +907,8 @@ fn run_project_once_dry_run_keeps_terminal_queued_lane_labels() {
 #[test]
 fn run_project_once_preserves_terminal_recovered_worktree_without_prior_state_when_review_handoff_is_missing()
  {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_active_issue("Done");
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = recovery_terminal_support::sample_active_issue("Done");
 	let tracker =
 		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -910,12 +939,12 @@ fn run_project_once_preserves_terminal_recovered_worktree_without_prior_state_wh
 
 #[test]
 fn run_project_once_clears_stale_completed_closeout_lease_but_keeps_worktree() {
-	let (_temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(
+	let (_temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(
 		&base_config,
 		"DECODEX_TEST_MISSING_STARTUP_DELIVERY_CLOSEOUT_GITHUB_TOKEN",
 	);
-	let issue = sample_active_issue("Done");
+	let issue = recovery_terminal_support::sample_active_issue("Done");
 	let tracker =
 		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -924,15 +953,15 @@ fn run_project_once_clears_stale_completed_closeout_lease_but_keeps_worktree() {
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained closeout worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let run_id = "run-closeout-startup";
 	let pr_url = "https://github.com/hack-ink/decodex/pull/178";
 
-	seed_review_handoff_marker_value(
+	tests::seed_review_handoff_marker_value(
 		&state_store,
 		config.service_id(),
 		&issue.id,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
 	state_store
@@ -984,12 +1013,12 @@ fn run_project_once_clears_stale_completed_closeout_lease_but_keeps_worktree() {
 
 #[test]
 fn run_project_once_preserves_fresh_completed_closeout_lease() {
-	let (_temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(
+	let (_temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(
 		&base_config,
 		"DECODEX_TEST_MISSING_STARTUP_DELIVERY_CLOSEOUT_GITHUB_TOKEN",
 	);
-	let issue = sample_active_issue("Done");
+	let issue = recovery_terminal_support::sample_active_issue("Done");
 	let tracker =
 		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -998,17 +1027,16 @@ fn run_project_once_preserves_fresh_completed_closeout_lease() {
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained closeout worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let run_id = "run-closeout-fresh-startup";
 	let pr_url = "https://github.com/hack-ink/decodex/pull/178";
 
-	seed_review_handoff_marker_value(
+	tests::seed_review_handoff_marker_value(
 		&state_store,
 		config.service_id(),
 		&issue.id,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
-
 	state::write_run_activity_marker(&worktree.path, run_id, 1)
 		.expect("fresh activity marker should write");
 
@@ -1061,9 +1089,9 @@ fn run_project_once_preserves_fresh_completed_closeout_lease() {
 
 #[test]
 fn run_project_once_preserves_completed_unmerged_closeout_worktree() {
-	let (temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(&base_config, "HOME");
-	let issue = sample_active_issue("Done");
+	let (temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(&base_config, "HOME");
+	let issue = recovery_terminal_support::sample_active_issue("Done");
 	let tracker =
 		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -1072,16 +1100,18 @@ fn run_project_once_preserves_completed_unmerged_closeout_worktree() {
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained closeout worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let run_id = "run-closeout-open-pr-startup";
 	let pr_url = "https://github.com/hack-ink/decodex/pull/179";
-	let _path_guard = install_fake_open_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_open_pr_gh_response(
+		&temp_dir, &worktree, pr_url, &head_oid,
+	);
 
-	seed_review_handoff_marker_value(
+	tests::seed_review_handoff_marker_value(
 		&state_store,
 		config.service_id(),
 		&issue.id,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
 
 	state_store
@@ -1133,8 +1163,8 @@ fn run_project_once_preserves_completed_unmerged_closeout_worktree() {
 
 #[test]
 fn run_project_once_skips_recovered_worktree_without_service_active_label() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_issue("In Progress", &[]);
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue("In Progress", &[]);
 	let tracker =
 		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -1167,9 +1197,9 @@ fn run_project_once_skips_recovered_worktree_without_service_active_label() {
 
 #[test]
 fn run_project_once_recovers_worktree_when_identifier_lookup_labels_are_truncated() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let listed_issue = sample_active_issue("In Progress");
+	let listed_issue = recovery_terminal_support::sample_active_issue("In Progress");
 	let mut identifier_lookup_issue = listed_issue.clone();
 
 	identifier_lookup_issue.labels_complete = false;
@@ -1199,8 +1229,8 @@ fn run_project_once_recovers_worktree_when_identifier_lookup_labels_are_truncate
 
 #[test]
 fn recovery_skip_cache_suppresses_repeated_unowned_worktree_lookup() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_issue("Todo", &[]);
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue("Todo", &[]);
 	let tracker = FakeTracker::new(Vec::new()).with_identifier_lookup_issues(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_path = config.worktree_root().join(&issue.identifier);
@@ -1242,11 +1272,11 @@ fn recovery_skip_cache_suppresses_repeated_unowned_worktree_lookup() {
 
 #[test]
 fn live_run_skips_issue_that_becomes_ineligible_after_worktree_prepare() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let listed_issue = sample_issue("Todo", &[]);
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let listed_issue = tests::sample_issue("Todo", &[]);
 	let tracker = FakeTracker::with_refresh_snapshots(
 		vec![listed_issue.clone()],
-		vec![vec![], vec![listed_issue.clone()], vec![sample_issue("In Progress", &[])]],
+		vec![vec![], vec![listed_issue.clone()], vec![tests::sample_issue("In Progress", &[])]],
 	);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let summary = orchestrator::run_project_once(&tracker, &config, &workflow, &state_store, false)
@@ -1267,8 +1297,8 @@ fn live_run_skips_issue_that_becomes_ineligible_after_worktree_prepare() {
 
 #[test]
 fn live_run_clears_claimed_lease_when_refresh_fails_after_worktree_prepare() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let listed_issue = sample_issue("Todo", &[]);
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let listed_issue = tests::sample_issue("Todo", &[]);
 	let tracker =
 		FakeTracker::with_refresh_error(vec![listed_issue.clone()], "transient refresh failure");
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -1286,8 +1316,8 @@ fn live_run_clears_claimed_lease_when_refresh_fails_after_worktree_prepare() {
 
 #[test]
 fn run_project_once_ignores_fresh_marker_for_exited_process() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let issue = sample_active_issue("In Progress");
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = recovery_terminal_support::sample_active_issue("In Progress");
 	let tracker =
 		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -1315,12 +1345,12 @@ fn run_project_once_ignores_fresh_marker_for_exited_process() {
 
 #[test]
 fn idle_daemon_recovery_reconstructs_completed_closeout_worktree_mapping() {
-	let (_temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(
+	let (_temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(
 		&base_config,
 		"DECODEX_TEST_MISSING_DAEMON_DELIVERY_CLOSEOUT_GITHUB_TOKEN",
 	);
-	let issue = sample_active_issue("Done");
+	let issue = recovery_terminal_support::sample_active_issue("Done");
 	let tracker =
 		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
@@ -1329,16 +1359,15 @@ fn idle_daemon_recovery_reconstructs_completed_closeout_worktree_mapping() {
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained closeout worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/178";
 
-	seed_review_handoff_marker_value(
+	tests::seed_review_handoff_marker_value(
 		&state_store,
 		config.service_id(),
 		&issue.id,
-		&sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
+		&tests::sample_review_handoff_marker(&worktree.branch_name, pr_url, &head_oid),
 	);
-
 	orchestrator::recover_and_reconcile_idle_daemon_state(
 		&tracker,
 		&config,

--- a/apps/decodex/src/orchestrator/tests/recovery_terminal_failures.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery_terminal_failures.rs
@@ -1,14 +1,36 @@
-use orchestrator::ReviewHandoffNeedsAttention;
-use orchestrator::PassiveRetainedAttentionRuntime;
+use std::{fs, time::Duration};
+
+use color_eyre::Report;
+
+use crate::{
+	agent::{
+		AppServerCapabilityPreflightFailure, AppServerDynamicToolFailure,
+		AppServerHomePreflightFailure, AppServerPhaseGoalFailure, AppServerTransportFailure,
+		AppServerTurnFailure, ReviewPolicyStopReason, ReviewPolicyStopRequested,
+	},
+	orchestrator::{
+		self, AppServerZeroEvidenceStartFailure, IssueDispatchMode, IssueRunPlan,
+		ManualAttentionRequested, PassiveRetainedAttentionRuntime, PhaseGoalKind,
+		PrepareIssueRunContext, RUN_LEASE_IDLE_TIMEOUT, RepoGateFailure, RepoGateFailureKind,
+		RetainedReviewRunIdentity, ReviewHandoffNeedsAttention, ServiceConfig,
+		StalledRunNeedsAttention, TERMINAL_GUARD_MARKER_FILE, WorkflowDocument,
+		tests::{
+			FakeTracker, TEST_SERVICE_ID, recovery_terminal_support, {self},
+		},
+	},
+	state::{self, StateStore},
+	tracker::{self, records},
+	worktree::{WorktreeManager, WorktreeSpec},
+};
 
 #[test]
 fn terminal_failures_without_needs_attention_label_use_nonstartable_guard_state() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
 	let mut issue =
-		sample_issue_without_needs_attention_team_label("Todo", &[active_label.as_str()]);
+		tests::sample_issue_without_needs_attention_team_label("Todo", &[active_label.as_str()]);
 
 	for label in &mut issue.labels {
 		label.id = issue
@@ -84,11 +106,11 @@ fn terminal_failures_without_needs_attention_label_use_nonstartable_guard_state(
 
 #[test]
 fn terminal_failures_apply_incremental_label_mutations_when_issue_labels_paginate() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let mut issue = sample_issue("Todo", &[active_label.as_str()]);
+	let mut issue = tests::sample_issue("Todo", &[active_label.as_str()]);
 
 	issue.labels_complete = false;
 
@@ -165,18 +187,17 @@ fn terminal_failures_apply_incremental_label_mutations_when_issue_labels_paginat
 
 #[test]
 fn terminal_failure_with_retained_tracked_changes_records_retained_partial_progress() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("In Progress", &[active_label.as_str()]);
+	let issue = tests::sample_issue("In Progress", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_path = config.worktree_root().join("PUB-101");
 
-	git_status_success(
+	tests::git_status_success(
 		config.repo_root(),
 		&["worktree", "add", "-b", "x/pubfi-pub-101", ".worktrees/PUB-101", "main"],
 	);
-
 	fs::write(worktree_path.join("README.md"), "retained terminal patch\n")
 		.expect("tracked worktree file should change");
 
@@ -190,7 +211,10 @@ fn terminal_failure_with_retained_tracked_changes_records_retained_partial_progr
 			path: worktree_path,
 			reused_existing: true,
 		},
-		retry_project_slug: issue.project_slug.clone().expect("sample issue should carry a project slug"),
+		retry_project_slug: issue
+			.project_slug
+			.clone()
+			.expect("sample issue should carry a project slug"),
 		dispatch_mode: IssueDispatchMode::Normal,
 		attempt_number: 1,
 		run_id: String::from("pub-101-attempt-1-123"),
@@ -215,7 +239,9 @@ fn terminal_failure_with_retained_tracked_changes_records_retained_partial_progr
 			&& comment.contains("partial_progress_retained")
 			&& comment.contains("finish validation and PR handoff or reset the patch manually")
 	}));
-	assert!(comments.iter().all(|comment| !comment.contains("decodex run failed and needs attention")));
+	assert!(
+		comments.iter().all(|comment| !comment.contains("decodex run failed and needs attention"))
+	);
 
 	let ledger_event = comments
 		.iter()
@@ -226,30 +252,26 @@ fn terminal_failure_with_retained_tracked_changes_records_retained_partial_progr
 	assert_eq!(ledger_event.error_class.as_deref(), Some("partial_progress_retained"));
 	assert_eq!(ledger_event.terminal_path.as_deref(), Some("retained_partial_progress"));
 	assert!(
-		ledger_event
-			.evidence
-			.as_deref()
-			.is_some_and(|evidence| evidence
-				.iter()
-				.any(|item| item.contains("Source failure class `repo_gate_command_spawn_failed`"))),
-			"retained partial progress evidence should preserve the source failure class"
+		ledger_event.evidence.as_deref().is_some_and(|evidence| evidence
+			.iter()
+			.any(|item| item.contains("Source failure class `repo_gate_command_spawn_failed`"))),
+		"retained partial progress evidence should preserve the source failure class"
 	);
 }
 
 #[test]
 fn repo_gate_tracked_rewrites_left_records_retained_partial_progress_without_retry() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("In Progress", &[active_label.as_str()]);
+	let issue = tests::sample_issue("In Progress", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_path = config.worktree_root().join("PUB-102");
 
-	git_status_success(
+	tests::git_status_success(
 		config.repo_root(),
 		&["worktree", "add", "-b", "x/pubfi-pub-102", ".worktrees/PUB-102", "main"],
 	);
-
 	fs::write(worktree_path.join("README.md"), "repo gate left tracked rewrites\n")
 		.expect("tracked worktree file should change");
 
@@ -263,7 +285,10 @@ fn repo_gate_tracked_rewrites_left_records_retained_partial_progress_without_ret
 			path: worktree_path,
 			reused_existing: true,
 		},
-		retry_project_slug: issue.project_slug.clone().expect("sample issue should carry a project slug"),
+		retry_project_slug: issue
+			.project_slug
+			.clone()
+			.expect("sample issue should carry a project slug"),
 		dispatch_mode: IssueDispatchMode::Normal,
 		attempt_number: 1,
 		run_id: String::from("pub-102-attempt-1-123"),
@@ -289,9 +314,7 @@ fn repo_gate_tracked_rewrites_left_records_retained_partial_progress_without_ret
 			&& comment.contains("finish validation and PR handoff or reset the patch manually")
 	}));
 	assert!(
-		comments
-			.iter()
-			.all(|comment| !comment.contains("decodex run failed and will retry")),
+		comments.iter().all(|comment| !comment.contains("decodex run failed and will retry")),
 		"tracked repo-gate rewrites should not continue automatic retry"
 	);
 
@@ -304,30 +327,26 @@ fn repo_gate_tracked_rewrites_left_records_retained_partial_progress_without_ret
 	assert_eq!(ledger_event.error_class.as_deref(), Some("partial_progress_retained"));
 	assert_eq!(ledger_event.terminal_path.as_deref(), Some("retained_partial_progress"));
 	assert!(
-		ledger_event
-			.evidence
-			.as_deref()
-			.is_some_and(|evidence| evidence
-				.iter()
-				.any(|item| item.contains("Source failure class `repo_gate_tracked_rewrites_left`"))),
-			"retained progress evidence should preserve the source repo-gate failure class"
+		ledger_event.evidence.as_deref().is_some_and(|evidence| evidence
+			.iter()
+			.any(|item| item.contains("Source failure class `repo_gate_tracked_rewrites_left`"))),
+		"retained progress evidence should preserve the source repo-gate failure class"
 	);
 }
 
 #[test]
 fn retryable_runtime_failure_with_retained_tracked_changes_retries_before_attention() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("In Progress", &[active_label.as_str()]);
+	let issue = tests::sample_issue("In Progress", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_path = config.worktree_root().join("PUB-102");
 
-	git_status_success(
+	tests::git_status_success(
 		config.repo_root(),
 		&["worktree", "add", "-b", "x/pubfi-pub-102", ".worktrees/PUB-102", "main"],
 	);
-
 	fs::write(worktree_path.join("README.md"), "retained validation-ready runtime patch\n")
 		.expect("tracked worktree file should change");
 
@@ -341,13 +360,18 @@ fn retryable_runtime_failure_with_retained_tracked_changes_retries_before_attent
 			path: worktree_path,
 			reused_existing: true,
 		},
-		retry_project_slug: issue.project_slug.clone().expect("sample issue should carry a project slug"),
+		retry_project_slug: issue
+			.project_slug
+			.clone()
+			.expect("sample issue should carry a project slug"),
 		dispatch_mode: IssueDispatchMode::Normal,
 		attempt_number: 1,
 		run_id: String::from("pub-102-attempt-1-123"),
 		retry_budget_base: 0,
 	};
-	let error = Report::msg("app-server run ended after a validation-ready checkpoint without a terminal path");
+	let error = Report::msg(
+		"app-server run ended after a validation-ready checkpoint without a terminal path",
+	);
 
 	state_store
 		.record_run_attempt(&issue_run.run_id, &issue.id, issue_run.attempt_number, "failed")
@@ -368,21 +392,23 @@ fn retryable_runtime_failure_with_retained_tracked_changes_retries_before_attent
 	assert!(
 		comments
 			.iter()
-			.all(|comment| !comment.contains("decodex retained partial progress and needs attention")),
+			.all(|comment| !comment
+				.contains("decodex retained partial progress and needs attention")),
 		"retained work must not force manual attention while retry budget remains"
 	);
 	assert!(
-		comments.iter().all(|comment| records::parse_linear_execution_event_record(comment)
-			.is_none()),
+		comments
+			.iter()
+			.all(|comment| records::parse_linear_execution_event_record(comment).is_none()),
 		"retryable retained work should not write a terminal needs-attention ledger event"
 	);
 }
 
 #[test]
 fn duplicate_terminal_failure_event_does_not_reapply_tracker_writeback() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("In Review", &[active_label.as_str()]);
+	let issue = tests::sample_issue("In Review", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let issue_run = IssueRunPlan {
@@ -395,7 +421,10 @@ fn duplicate_terminal_failure_event_does_not_reapply_tracker_writeback() {
 			path: config.worktree_root().join("PUB-101"),
 			reused_existing: true,
 		},
-		retry_project_slug: issue.project_slug.clone().expect("sample issue should carry a project slug"),
+		retry_project_slug: issue
+			.project_slug
+			.clone()
+			.expect("sample issue should carry a project slug"),
 		dispatch_mode: IssueDispatchMode::ReviewRepair,
 		attempt_number: 2,
 		run_id: String::from("pub-101-attempt-2-123"),
@@ -441,9 +470,9 @@ fn duplicate_terminal_failure_event_does_not_reapply_tracker_writeback() {
 
 #[test]
 fn duplicate_remote_terminal_failure_event_does_not_reapply_tracker_writeback() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("In Review", &[active_label.as_str()]);
+	let issue = tests::sample_issue("In Review", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let first_state_store = StateStore::open_in_memory().expect("state store should open");
 	let second_state_store = StateStore::open_in_memory().expect("state store should open");
@@ -457,7 +486,10 @@ fn duplicate_remote_terminal_failure_event_does_not_reapply_tracker_writeback() 
 			path: config.worktree_root().join("PUB-101"),
 			reused_existing: true,
 		},
-		retry_project_slug: issue.project_slug.clone().expect("sample issue should carry a project slug"),
+		retry_project_slug: issue
+			.project_slug
+			.clone()
+			.expect("sample issue should carry a project slug"),
 		dispatch_mode: IssueDispatchMode::ReviewRepair,
 		attempt_number: 2,
 		run_id: String::from("pub-101-attempt-2-123"),
@@ -512,9 +544,9 @@ fn duplicate_remote_terminal_failure_event_does_not_reapply_tracker_writeback() 
 
 #[test]
 fn duplicate_passive_retained_review_attention_event_does_not_reapply_tracker_writeback() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("In Review", &[active_label.as_str()]);
+	let issue = tests::sample_issue("In Review", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
@@ -587,9 +619,9 @@ fn duplicate_passive_retained_review_attention_event_does_not_reapply_tracker_wr
 
 #[test]
 fn rebound_handoff_marker_suppresses_stale_missing_handoff_attention_writeback() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("In Review", &[active_label.as_str()]);
+	let issue = tests::sample_issue("In Review", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
@@ -597,7 +629,7 @@ fn rebound_handoff_marker_suppresses_stale_missing_handoff_attention_writeback()
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let run_identity = RetainedReviewRunIdentity {
 		run_id: String::from("pub-101-attempt-8-123"),
 		attempt_number: 8,
@@ -615,7 +647,7 @@ fn rebound_handoff_marker_suppresses_stale_missing_handoff_attention_writeback()
 		.upsert_review_handoff_marker(
 			config.service_id(),
 			&issue.id,
-			&sample_review_handoff_marker(
+			&tests::sample_review_handoff_marker(
 				&worktree.branch_name,
 				"https://github.com/hack-ink/decodex/pull/101",
 				&head_oid,
@@ -657,10 +689,10 @@ fn rebound_handoff_marker_suppresses_stale_missing_handoff_attention_writeback()
 
 #[test]
 fn review_policy_exhausted_failures_start_architecture_recovery_pre_pr() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue("In Progress", &[]);
+	let issue = tests::sample_issue("In Progress", &[]);
 	let issue_run = IssueRunPlan {
 		issue: issue.clone(),
 		issue_state: issue.state.name.clone(),
@@ -730,10 +762,10 @@ fn review_policy_exhausted_failures_start_architecture_recovery_pre_pr() {
 
 #[test]
 fn review_policy_blocked_failures_skip_retry_and_require_attention_in_review() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue("In Review", &[]);
+	let issue = tests::sample_issue("In Review", &[]);
 	let issue_run = IssueRunPlan {
 		issue: issue.clone(),
 		issue_state: issue.state.name.clone(),
@@ -792,7 +824,7 @@ fn review_policy_blocked_failures_skip_retry_and_require_attention_in_review() {
 
 #[test]
 fn app_server_failures_skip_retry_and_require_attention() {
-	assert_app_server_failure_requires_attention(
+	recovery_terminal_support::assert_app_server_failure_requires_attention(
 		Report::new(AppServerCapabilityPreflightFailure::blocked_for_test(
 			"skills",
 			"skills/list returned no enabled skills.",
@@ -800,14 +832,14 @@ fn app_server_failures_skip_retry_and_require_attention() {
 		"app_server_runtime_preflight_failed",
 		"repair the local Codex runtime configuration",
 	);
-	assert_app_server_failure_requires_attention(
+	recovery_terminal_support::assert_app_server_failure_requires_attention(
 		Report::new(AppServerHomePreflightFailure::resolution_failed(String::from(
 			"app_server_preflight_failed: HOME is not set, so Decodex cannot resolve the shared Codex home for app-server dispatch.",
 		))),
 		"app_server_codex_home_preflight_failed",
 		"inspect the local Decodex and Codex home sharing",
 	);
-	assert_app_server_failure_requires_attention(
+	recovery_terminal_support::assert_app_server_failure_requires_attention(
 		Report::new(AppServerHomePreflightFailure::initialize_mismatch(
 			String::from("/tmp/per-account-codex-home"),
 			String::from("/Users/test/.codex"),
@@ -815,14 +847,14 @@ fn app_server_failures_skip_retry_and_require_attention() {
 		"app_server_codex_home_mismatch",
 		"restart `decodex serve`",
 	);
-	assert_app_server_failure_requires_attention(
+	recovery_terminal_support::assert_app_server_failure_requires_attention(
 		Report::new(AppServerTransportFailure::new(String::from(
 			"App-server stdout disconnected unexpectedly.",
 		))),
 		"app_server_transport_disconnected",
 		"resolve the Codex app-server transport failure manually",
 	);
-	assert_app_server_failure_requires_attention(
+	recovery_terminal_support::assert_app_server_failure_requires_attention(
 		Report::new(AppServerTransportFailure::with_phase(
 			String::from("App-server stdout disconnected unexpectedly."),
 			"turn/start",
@@ -835,10 +867,10 @@ fn app_server_failures_skip_retry_and_require_attention() {
 
 #[test]
 fn app_server_preflight_timeouts_retry_before_attention_budget_is_exhausted() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue("In Progress", &[]);
+	let issue = tests::sample_issue("In Progress", &[]);
 	let issue_run = IssueRunPlan {
 		issue: issue.clone(),
 		issue_state: issue.state.name.clone(),
@@ -896,10 +928,10 @@ fn app_server_preflight_timeouts_retry_before_attention_budget_is_exhausted() {
 
 #[test]
 fn exhausted_app_server_preflight_timeout_retry_budget_requires_attention_with_timeout_class() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue("In Progress", &[]);
+	let issue = tests::sample_issue("In Progress", &[]);
 	let issue_run = IssueRunPlan {
 		issue: issue.clone(),
 		issue_state: issue.state.name.clone(),
@@ -940,7 +972,8 @@ fn exhausted_app_server_preflight_timeout_retry_budget_requires_attention_with_t
 	assert!(tracker.comments.borrow().iter().any(|comment| {
 		comment.contains("decodex run failed and needs attention")
 			&& comment.contains("app_server_plugin_list_timeout")
-			&& comment.contains("app_server_preflight_failed evidence for the `plugin/list` timeout")
+			&& comment
+				.contains("app_server_preflight_failed evidence for the `plugin/list` timeout")
 	}));
 	assert!(
 		!tracker
@@ -953,10 +986,10 @@ fn exhausted_app_server_preflight_timeout_retry_budget_requires_attention_with_t
 
 #[test]
 fn phase_goal_terminal_path_missing_retries_before_attention_budget_is_exhausted() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue("In Progress", &[]);
+	let issue = tests::sample_issue("In Progress", &[]);
 	let issue_run = IssueRunPlan {
 		issue: issue.clone(),
 		issue_state: issue.state.name.clone(),
@@ -1013,18 +1046,17 @@ fn phase_goal_terminal_path_missing_retries_before_attention_budget_is_exhausted
 
 #[test]
 fn phase_goal_terminal_path_missing_with_retained_changes_retries_before_attention() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("In Progress", &[active_label.as_str()]);
+	let issue = tests::sample_issue("In Progress", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_path = config.worktree_root().join("PUB-103");
 
-	git_status_success(
+	tests::git_status_success(
 		config.repo_root(),
 		&["worktree", "add", "-b", "x/pubfi-pub-103", ".worktrees/PUB-103", "main"],
 	);
-
 	fs::write(worktree_path.join("README.md"), "retained handoff patch\n")
 		.expect("tracked worktree file should change");
 
@@ -1075,7 +1107,7 @@ fn phase_goal_terminal_path_missing_with_retained_changes_retries_before_attenti
 
 #[test]
 fn retryable_app_server_failures_do_not_write_attention_before_budget_exhaustion() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 
 	assert_retryable_failure_writeback_does_not_require_attention(
 		&config,
@@ -1167,7 +1199,7 @@ fn retryable_app_server_failures_do_not_write_attention_before_budget_exhaustion
 
 #[test]
 fn retryable_orchestrator_failures_do_not_write_attention_before_budget_exhaustion() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 
 	assert_retryable_failure_writeback_does_not_require_attention(
 		&config,
@@ -1204,7 +1236,7 @@ fn retryable_orchestrator_failures_do_not_write_attention_before_budget_exhausti
 
 #[test]
 fn dirty_retryable_runtime_failures_keep_automatic_recovery_before_budget_exhaustion() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 
 	assert_dirty_retryable_failure_writeback_does_not_require_attention(
 		&config,
@@ -1280,10 +1312,10 @@ fn dirty_retryable_runtime_failures_keep_automatic_recovery_before_budget_exhaus
 
 #[test]
 fn startup_transport_failures_retry_before_attention_budget_is_exhausted() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue("In Progress", &[]);
+	let issue = tests::sample_issue("In Progress", &[]);
 	let issue_run = IssueRunPlan {
 		issue: issue.clone(),
 		issue_state: issue.state.name.clone(),
@@ -1337,10 +1369,10 @@ fn startup_transport_failures_retry_before_attention_budget_is_exhausted() {
 
 #[test]
 fn exhausted_startup_transport_retry_budget_requires_attention_with_transport_class() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue("In Progress", &[]);
+	let issue = tests::sample_issue("In Progress", &[]);
 	let issue_run = IssueRunPlan {
 		issue: issue.clone(),
 		issue_state: issue.state.name.clone(),
@@ -1395,10 +1427,10 @@ fn exhausted_startup_transport_retry_budget_requires_attention_with_transport_cl
 
 #[test]
 fn usage_limit_turn_failures_retry_before_attention_budget_is_exhausted() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue("In Progress", &[]);
+	let issue = tests::sample_issue("In Progress", &[]);
 	let issue_run = IssueRunPlan {
 		issue: issue.clone(),
 		issue_state: issue.state.name.clone(),
@@ -1453,18 +1485,17 @@ fn usage_limit_turn_failures_retry_before_attention_budget_is_exhausted() {
 
 #[test]
 fn usage_limit_turn_failures_with_retained_tracked_changes_retry_before_attention() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("In Progress", &[active_label.as_str()]);
+	let issue = tests::sample_issue("In Progress", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_path = config.worktree_root().join("PUB-103");
 
-	git_status_success(
+	tests::git_status_success(
 		config.repo_root(),
 		&["worktree", "add", "-b", "x/pubfi-pub-103", ".worktrees/PUB-103", "main"],
 	);
-
 	fs::write(worktree_path.join("README.md"), "retained usage-limit patch\n")
 		.expect("tracked worktree file should change");
 
@@ -1520,10 +1551,10 @@ fn usage_limit_turn_failures_with_retained_tracked_changes_retry_before_attentio
 
 #[test]
 fn exhausted_usage_limit_retry_budget_requires_attention_with_usage_class() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue("In Progress", &[]);
+	let issue = tests::sample_issue("In Progress", &[]);
 	let issue_run = IssueRunPlan {
 		issue: issue.clone(),
 		issue_state: issue.state.name.clone(),
@@ -1580,18 +1611,17 @@ fn exhausted_usage_limit_retry_budget_requires_attention_with_usage_class() {
 
 #[test]
 fn dirty_runtime_failures_record_retained_progress_instead_of_terminal_failure() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("In Progress", &[active_label.as_str()]);
+	let issue = tests::sample_issue("In Progress", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_path = config.worktree_root().join("PUB-101");
 
-	git_status_success(
+	tests::git_status_success(
 		config.repo_root(),
 		&["worktree", "add", "-b", "x/pubfi-pub-101", ".worktrees/PUB-101", "main"],
 	);
-
 	fs::write(worktree_path.join("README.md"), "retained runtime recovery work\n")
 		.expect("tracked worktree file should change");
 
@@ -1634,9 +1664,7 @@ fn dirty_runtime_failures_record_retained_progress_instead_of_terminal_failure()
 			&& comment.contains("app_server_runtime_preflight_failed")
 	}));
 	assert!(
-		comments
-			.iter()
-			.all(|comment| !comment.contains("decodex run failed and needs attention"))
+		comments.iter().all(|comment| !comment.contains("decodex run failed and needs attention"))
 	);
 
 	let ledger_event = comments
@@ -1648,30 +1676,26 @@ fn dirty_runtime_failures_record_retained_progress_instead_of_terminal_failure()
 	assert_eq!(ledger_event.error_class.as_deref(), Some("partial_progress_retained"));
 	assert_eq!(ledger_event.terminal_path.as_deref(), Some("retained_partial_progress"));
 	assert!(
-		ledger_event
-			.evidence
-			.as_deref()
-			.is_some_and(|evidence| evidence
-				.iter()
-				.any(|item| item.contains("app_server_runtime_preflight_failed"))),
+		ledger_event.evidence.as_deref().is_some_and(|evidence| evidence
+			.iter()
+			.any(|item| item.contains("app_server_runtime_preflight_failed"))),
 		"retained progress evidence should preserve the source runtime error class"
 	);
 }
 
 #[test]
 fn explicit_manual_attention_keeps_manual_terminal_path_with_dirty_worktree() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue("In Progress", &[active_label.as_str()]);
+	let issue = tests::sample_issue("In Progress", &[active_label.as_str()]);
 	let tracker = FakeTracker::new(vec![issue.clone()]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_path = config.worktree_root().join("PUB-101");
 
-	git_status_success(
+	tests::git_status_success(
 		config.repo_root(),
 		&["worktree", "add", "-b", "x/pubfi-pub-101", ".worktrees/PUB-101", "main"],
 	);
-
 	fs::write(worktree_path.join("README.md"), "manual attention work\n")
 		.expect("tracked worktree file should change");
 
@@ -1718,17 +1742,14 @@ fn explicit_manual_attention_keeps_manual_terminal_path_with_dirty_worktree() {
 	assert_eq!(ledger_event.event_type, "needs_attention");
 	assert_eq!(ledger_event.error_class.as_deref(), Some("human_attention_required"));
 	assert_eq!(ledger_event.terminal_path.as_deref(), Some("manual_attention"));
-	assert_eq!(
-		ledger_event.summary.as_deref(),
-		Some("Decodex run failed and needs attention.")
-	);
+	assert_eq!(ledger_event.summary.as_deref(), Some("Decodex run failed and needs attention."));
 }
 
 #[test]
 fn prepare_issue_run_clears_terminal_guard_marker_when_new_attempt_starts() {
-	let (_temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(&base_config, "HOME");
-	let issue = sample_issue("Todo", &[]);
+	let (_temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(&base_config, "HOME");
+	let issue = tests::sample_issue("Todo", &[]);
 	let tracker = FakeTracker::with_refresh_snapshots(vec![], vec![vec![issue.clone()]]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
@@ -1769,10 +1790,10 @@ fn prepare_issue_run_clears_terminal_guard_marker_when_new_attempt_starts() {
 
 #[test]
 fn retryable_failures_ignore_prior_continuation_attempts_in_writeback() {
-	let (_temp_dir, config, workflow) = temp_project_layout();
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let tracker = FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue("In Progress", &[]);
+	let issue = tests::sample_issue("In Progress", &[]);
 	let issue_run = IssueRunPlan {
 		issue: issue.clone(),
 		issue_state: issue.state.name.clone(),
@@ -1860,7 +1881,7 @@ fn assert_retryable_failure_writeback_does_not_require_attention(
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let issue_id = format!("issue-{case_number}");
 	let issue_identifier = format!("PUB-10{case_number}");
-	let issue = sample_issue_with_sort_fields(
+	let issue = tests::sample_issue_with_sort_fields(
 		&issue_id,
 		&issue_identifier,
 		"In Progress",
@@ -1909,14 +1930,16 @@ fn assert_retryable_failure_writeback_does_not_require_attention(
 		!comment.contains("decodex run failed and needs attention")
 			&& !comment.contains("decodex retained partial progress and needs attention")
 	}));
-	assert!(comments.iter().all(|comment| {
-		records::parse_linear_execution_event_record(comment).is_none()
-	}));
+	assert!(
+		comments
+			.iter()
+			.all(|comment| { records::parse_linear_execution_event_record(comment).is_none() })
+	);
 	assert!(
 		state_store
 			.list_linear_execution_events(config.service_id(), &issue.id)
-		.expect("linear execution events should list")
-		.is_empty()
+			.expect("linear execution events should list")
+			.is_empty()
 	);
 }
 
@@ -1932,7 +1955,7 @@ fn assert_dirty_retryable_failure_writeback_does_not_require_attention(
 	let issue_id = format!("issue-dirty-{case_number}");
 	let issue_identifier = format!("PUB-30{case_number}");
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = sample_issue_with_sort_fields(
+	let issue = tests::sample_issue_with_sort_fields(
 		&issue_id,
 		&issue_identifier,
 		"In Progress",
@@ -1944,11 +1967,10 @@ fn assert_dirty_retryable_failure_writeback_does_not_require_attention(
 	let worktree_rel_path = format!(".worktrees/{issue_identifier}");
 	let worktree_path = config.worktree_root().join(&issue_identifier);
 
-	git_status_success(
+	tests::git_status_success(
 		config.repo_root(),
 		&["worktree", "add", "-b", &branch_name, &worktree_rel_path, "main"],
 	);
-
 	fs::write(
 		worktree_path.join("README.md"),
 		format!("dirty retryable recovery case {case_number}\n"),
@@ -1997,9 +2019,11 @@ fn assert_dirty_retryable_failure_writeback_does_not_require_attention(
 		}),
 		"retained tracked changes must not force manual attention for `{expected_error_class}` while retry budget remains"
 	);
-	assert!(comments.iter().all(|comment| {
-		records::parse_linear_execution_event_record(comment).is_none()
-	}));
+	assert!(
+		comments
+			.iter()
+			.all(|comment| { records::parse_linear_execution_event_record(comment).is_none() })
+	);
 	assert!(
 		state_store
 			.list_linear_execution_events(config.service_id(), &issue.id)

--- a/apps/decodex/src/orchestrator/tests/recovery_terminal_support.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery_terminal_support.rs
@@ -1,32 +1,58 @@
 #[cfg(unix)] use std::os::unix::fs::PermissionsExt;
+use std::{
+	env, fs,
+	path::{Path, PathBuf},
+};
 
-struct CloseoutIdentityFixture {
-	_temp_dir: TempDir,
-	_path_guard: TestEnvVarGuard,
-	config: ServiceConfig,
-	workflow: WorkflowDocument,
-	tracker: FakeTracker,
-	state_store: StateStore,
-	issue: TrackerIssue,
-	worktree: WorktreeSpec,
-	pr_url: String,
-	head_oid: String,
-	completed_run_id: String,
+use color_eyre::Report;
+use tempfile::TempDir;
+
+#[rustfmt::skip]
+use crate::config::ServiceConfig;
+#[rustfmt::skip]
+use crate::orchestrator::tests::{self, FakePullRequestReviewStateInspector, TEST_SERVICE_ID};
+#[rustfmt::skip]
+use crate::orchestrator::{self, IssueDispatchMode, ReviewHandoffMarker};
+#[rustfmt::skip]
+use crate::state::StateStore;
+#[rustfmt::skip]
+use crate::test_support::{self, TestEnvVarGuard};
+#[rustfmt::skip]
+use crate::tracker::{self, TrackerIssue, TrackerState};
+#[rustfmt::skip]
+use crate::workflow::WorkflowDocument;
+#[rustfmt::skip]
+use crate::worktree::{WorktreeManager, WorktreeSpec};
+
+pub(super) struct CloseoutIdentityFixture {
+	pub(super) _temp_dir: TempDir,
+	pub(super) _path_guard: TestEnvVarGuard,
+	pub(super) config: ServiceConfig,
+	pub(super) workflow: WorkflowDocument,
+	pub(super) tracker: tests::FakeTracker,
+	pub(super) state_store: StateStore,
+	pub(super) issue: TrackerIssue,
+	pub(super) worktree: WorktreeSpec,
+	pub(super) pr_url: String,
+	pub(super) head_oid: String,
+	pub(super) completed_run_id: String,
 }
 
-fn sample_active_issue(state_name: &str) -> TrackerIssue {
+pub(super) fn sample_active_issue(state_name: &str) -> TrackerIssue {
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
 
-	sample_issue(state_name, &[active_label.as_str()])
+	tests::sample_issue(state_name, &[active_label.as_str()])
 }
 
-fn sample_active_issue_without_needs_attention_team_label(state_name: &str) -> TrackerIssue {
+pub(super) fn sample_active_issue_without_needs_attention_team_label(
+	state_name: &str,
+) -> TrackerIssue {
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
 
-	sample_issue_without_needs_attention_team_label(state_name, &[active_label.as_str()])
+	tests::sample_issue_without_needs_attention_team_label(state_name, &[active_label.as_str()])
 }
 
-fn install_fake_open_pr_gh_response(
+pub(super) fn install_fake_open_pr_gh_response(
 	temp_dir: &TempDir,
 	worktree: &WorktreeSpec,
 	pr_url: &str,
@@ -89,7 +115,7 @@ fn install_fake_open_pr_gh_response(
 	TestEnvVarGuard::set("PATH", &format!("{}:{path_env}", fake_gh_dir.display()))
 }
 
-fn install_fake_conflicting_pr_gh_response(
+pub(super) fn install_fake_conflicting_pr_gh_response(
 	temp_dir: &TempDir,
 	worktree: &WorktreeSpec,
 	pr_url: &str,
@@ -152,7 +178,7 @@ fn install_fake_conflicting_pr_gh_response(
 	TestEnvVarGuard::set("PATH", &format!("{}:{path_env}", fake_gh_dir.display()))
 }
 
-fn install_fake_ready_to_land_admin_merge_gh_response(
+pub(super) fn install_fake_ready_to_land_admin_merge_gh_response(
 	temp_dir: &TempDir,
 	worktree: &WorktreeSpec,
 	pr_url: &str,
@@ -246,7 +272,7 @@ exit 1\n",
 	)
 }
 
-fn install_fake_merged_pr_gh_response(
+pub(super) fn install_fake_merged_pr_gh_response(
 	temp_dir: &TempDir,
 	worktree: &WorktreeSpec,
 	pr_url: &str,
@@ -257,7 +283,7 @@ fn install_fake_merged_pr_gh_response(
 	)
 }
 
-fn install_fake_merged_pr_gh_response_with_base_ref(
+pub(super) fn install_fake_merged_pr_gh_response_with_base_ref(
 	temp_dir: &TempDir,
 	worktree: &WorktreeSpec,
 	pr_url: &str,
@@ -274,7 +300,7 @@ fn install_fake_merged_pr_gh_response_with_base_ref(
 	)
 }
 
-fn install_fake_merged_pr_gh_response_with_delete_exit_code(
+pub(super) fn install_fake_merged_pr_gh_response_with_delete_exit_code(
 	temp_dir: &TempDir,
 	worktree: &WorktreeSpec,
 	pr_url: &str,
@@ -291,7 +317,7 @@ fn install_fake_merged_pr_gh_response_with_delete_exit_code(
 	)
 }
 
-fn install_fake_merged_pr_gh_response_with_base_ref_and_delete_exit_code(
+pub(super) fn install_fake_merged_pr_gh_response_with_base_ref_and_delete_exit_code(
 	temp_dir: &TempDir,
 	worktree: &WorktreeSpec,
 	pr_url: &str,
@@ -385,7 +411,7 @@ exit 1\n",
 	TestEnvVarGuard::set("PATH", &format!("{}:{path_env}", fake_gh_dir.display()))
 }
 
-fn install_fake_closeout_gh_responses(
+pub(super) fn install_fake_closeout_gh_responses(
 	temp_dir: &TempDir,
 	worktree: &WorktreeSpec,
 	pr_url: &str,
@@ -394,7 +420,7 @@ fn install_fake_closeout_gh_responses(
 	install_fake_closeout_gh_responses_with_state(temp_dir, worktree, pr_url, head_oid, "MERGED")
 }
 
-fn install_fake_closeout_gh_responses_with_state(
+pub(super) fn install_fake_closeout_gh_responses_with_state(
 	temp_dir: &TempDir,
 	worktree: &WorktreeSpec,
 	pr_url: &str,
@@ -406,7 +432,7 @@ fn install_fake_closeout_gh_responses_with_state(
 	)
 }
 
-fn install_fake_closeout_gh_responses_with_states(
+pub(super) fn install_fake_closeout_gh_responses_with_states(
 	temp_dir: &TempDir,
 	worktree: &WorktreeSpec,
 	pr_url: &str,
@@ -505,8 +531,8 @@ exit 1\n",
 	TestEnvVarGuard::set("PATH", &format!("{}:{path_env}", fake_gh_dir.display()))
 }
 
-fn initialize_closeout_cleanup_origin(repo_root: &Path, remote_root: &Path) {
-	git_status_success(
+pub(super) fn initialize_closeout_cleanup_origin(repo_root: &Path, remote_root: &Path) {
+	tests::git_status_success(
 		remote_root.parent().expect("remote root should have parent"),
 		&[
 			"init",
@@ -516,25 +542,25 @@ fn initialize_closeout_cleanup_origin(repo_root: &Path, remote_root: &Path) {
 			remote_root.to_str().expect("remote path should be utf-8"),
 		],
 	);
-	git_status_success(
+	tests::git_status_success(
 		repo_root,
 		&["remote", "add", "origin", remote_root.to_string_lossy().as_ref()],
 	);
-	git_status_success(repo_root, &["push", "-u", "origin", "main"]);
+	tests::git_status_success(repo_root, &["push", "-u", "origin", "main"]);
 }
 
-fn route_origin_github_url_to_local_bare_repo(repo_root: &Path, remote_root: &Path) {
+pub(super) fn route_origin_github_url_to_local_bare_repo(repo_root: &Path, remote_root: &Path) {
 	let github_remote = "https://github.com/hack-ink/decodex.git";
 	let local_remote = format!("file://{}", remote_root.display());
 
-	git_status_success(
+	tests::git_status_success(
 		repo_root,
 		&["config", &format!("url.{local_remote}.insteadOf"), github_remote],
 	);
-	git_status_success(repo_root, &["remote", "set-url", "origin", github_remote]);
+	tests::git_status_success(repo_root, &["remote", "set-url", "origin", github_remote]);
 }
 
-fn issue_with_completed_state(mut issue: TrackerIssue) -> TrackerIssue {
+pub(super) fn issue_with_completed_state(mut issue: TrackerIssue) -> TrackerIssue {
 	if !issue.team.states.iter().any(|state| state.name == "Done") {
 		issue
 			.team
@@ -545,7 +571,7 @@ fn issue_with_completed_state(mut issue: TrackerIssue) -> TrackerIssue {
 	issue
 }
 
-fn sample_closeout_issue_run(
+pub(super) fn sample_closeout_issue_run(
 	issue: &TrackerIssue,
 	worktree: &WorktreeSpec,
 	run_id: &str,
@@ -571,20 +597,23 @@ fn sample_closeout_issue_run(
 	}
 }
 
-fn closeout_identity_fixture() -> CloseoutIdentityFixture {
-	let (temp_dir, base_config, workflow) = temp_project_layout();
-	let config = service_config_with_github_token_env_var(&base_config, "HOME");
+pub(super) fn closeout_identity_fixture() -> CloseoutIdentityFixture {
+	let (temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_github_token_env_var(&base_config, "HOME");
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let issue = issue_with_completed_state(sample_issue("In Review", &[active_label.as_str()]));
-	let tracker =
-		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]; 8]);
+	let issue =
+		issue_with_completed_state(tests::sample_issue("In Review", &[active_label.as_str()]));
+	let tracker = tests::FakeTracker::with_refresh_snapshots(
+		vec![issue.clone()],
+		vec![vec![issue.clone()]; 8],
+	);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let worktree_manager =
 		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
 	let worktree = worktree_manager
 		.ensure_worktree(&issue.identifier, false)
 		.expect("retained closeout worktree should exist");
-	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = String::from("https://github.com/hack-ink/decodex/pull/703");
 	let _path_guard = install_fake_closeout_gh_responses(&temp_dir, &worktree, &pr_url, &head_oid);
 	let remote_root =
@@ -595,7 +624,7 @@ fn closeout_identity_fixture() -> CloseoutIdentityFixture {
 	route_origin_github_url_to_local_bare_repo(config.repo_root(), &remote_root);
 
 	assert!(
-		crate::test_support::hermetic_git_command()
+		test_support::hermetic_git_command()
 			.arg("-C")
 			.arg(config.repo_root())
 			.args(["push", "origin", &format!("HEAD:{}", worktree.branch_name)])
@@ -646,8 +675,8 @@ fn closeout_identity_fixture() -> CloseoutIdentityFixture {
 	}
 }
 
-fn assert_closeout_lane_ready(fixture: &CloseoutIdentityFixture) {
-	let mut merged_review_state = sample_pull_request_review_state(
+pub(super) fn assert_closeout_lane_ready(fixture: &CloseoutIdentityFixture) {
+	let mut merged_review_state = tests::sample_pull_request_review_state(
 		&fixture.pr_url,
 		&fixture.worktree.branch_name,
 		&fixture.head_oid,
@@ -693,15 +722,15 @@ fn assert_closeout_lane_ready(fixture: &CloseoutIdentityFixture) {
 	);
 }
 
-fn assert_app_server_failure_requires_attention(
+pub(super) fn assert_app_server_failure_requires_attention(
 	error: Report,
 	error_class: &str,
 	next_action_fragment: &str,
 ) {
-	let (_temp_dir, config, workflow) = temp_project_layout();
-	let tracker = FakeTracker::new(vec![]);
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let tracker = tests::FakeTracker::new(vec![]);
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let issue = sample_issue("In Progress", &[]);
+	let issue = tests::sample_issue("In Progress", &[]);
 	let issue_run = orchestrator::IssueRunPlan {
 		issue: issue.clone(),
 		issue_state: issue.state.name.clone(),

--- a/apps/decodex/src/orchestrator/tests/retry/scheduling.rs
+++ b/apps/decodex/src/orchestrator/tests/retry/scheduling.rs
@@ -431,7 +431,9 @@ fn schedule_retry_after_child_exit_records_failure_retry_for_closeout_issue_afte
 		worktree_manager.ensure_worktree(&issue.identifier, false).expect("worktree should exist");
 	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/175";
-	let _path_guard = install_fake_merged_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_merged_pr_gh_response(
+		&temp_dir, &worktree, pr_url, &head_oid,
+	);
 
 	seed_review_handoff_marker(
 		&state_store,
@@ -516,7 +518,9 @@ fn schedule_retry_after_child_exit_keeps_blocked_closeout_retry_for_completed_is
 		worktree_manager.ensure_worktree(&issue.identifier, false).expect("worktree should exist");
 	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/176";
-	let _path_guard = install_fake_open_pr_gh_response(&temp_dir, &worktree, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_open_pr_gh_response(
+		&temp_dir, &worktree, pr_url, &head_oid,
+	);
 
 	seed_review_handoff_marker(
 		&state_store,

--- a/apps/decodex/src/orchestrator/tests/review_landing/status_rows.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing/status_rows.rs
@@ -65,17 +65,10 @@ fn build_post_review_lane_statuses_reports_ready_to_land() {
 	assert_eq!(lanes[0].reason, "external_review_passed_strict");
 	assert_eq!(lanes[0].pr_url.as_deref(), Some(pr_url));
 	assert!(
-		lanes[0]
-			.loop_status
-			.as_ref()
-			.and_then(|status| status.review.as_ref())
-			.is_none(),
+		lanes[0].loop_status.as_ref().and_then(|status| status.review.as_ref()).is_none(),
 		"ready_to_land must not project a pending review checkpoint"
 	);
-	assert_eq!(
-		lanes[0].readback_warning.as_deref(),
-		Some("active_ownership_label_missing")
-	);
+	assert_eq!(lanes[0].readback_warning.as_deref(), Some("active_ownership_label_missing"));
 }
 
 #[test]
@@ -87,12 +80,7 @@ fn build_post_review_lane_statuses_waits_when_clean_repair_head_outruns_lifecycl
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let pr_url = "https://github.com/hack-ink/decodex/pull/173";
 	let (worktree, repaired_head_oid) =
-		retained_worktree_with_stale_review_lifecycle_marker(
-			&config,
-			&state_store,
-			&issue,
-			pr_url,
-		);
+		retained_worktree_with_stale_review_lifecycle_marker(&config, &state_store, &issue, pr_url);
 
 	seed_clean_repair_completion_writeback_gap(
 		&config,
@@ -139,9 +127,8 @@ fn retained_worktree_with_stale_review_lifecycle_marker(
 ) -> (WorktreeSpec, String) {
 	let worktree_manager =
 		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
-	let worktree = worktree_manager
-		.ensure_worktree(&issue.identifier, false)
-		.expect("worktree should exist");
+	let worktree =
+		worktree_manager.ensure_worktree(&issue.identifier, false).expect("worktree should exist");
 	let old_head_oid = git_head_oid_for_worktree(&worktree);
 
 	state_store
@@ -327,14 +314,8 @@ fn build_post_review_lane_statuses_preserves_handoff_marker_when_pr_readback_fai
 	assert_eq!(lanes[0].branch_name, "main");
 	assert_eq!(lanes[0].pr_url.as_deref(), Some(pr_url));
 	assert_eq!(lanes[0].pr_head_sha.as_deref(), Some(head_oid.as_str()));
-	assert_eq!(
-		lanes[0].readback_warning.as_deref(),
-		Some("pull_request_state_read_failed")
-	);
-	assert_eq!(
-		lanes[0].readback_root_cause.as_deref(),
-		Some("github_api_read_failed")
-	);
+	assert_eq!(lanes[0].readback_warning.as_deref(), Some("pull_request_state_read_failed"));
+	assert_eq!(lanes[0].readback_root_cause.as_deref(), Some("github_api_read_failed"));
 	assert_eq!(lanes[0].pr_state, None);
 }
 
@@ -396,11 +377,7 @@ fn build_post_review_lane_statuses_skips_external_review_when_disabled() {
 	assert_eq!(lanes[0].reason, "non_github_review_ready_to_land");
 	assert_eq!(lanes[0].pr_url.as_deref(), Some(pr_url));
 	assert!(
-		lanes[0]
-			.loop_status
-			.as_ref()
-			.and_then(|status| status.review.as_ref())
-			.is_none(),
+		lanes[0].loop_status.as_ref().and_then(|status| status.review.as_ref()).is_none(),
 		"ready_to_land must not project a pending review checkpoint"
 	);
 }
@@ -546,7 +523,7 @@ fn build_post_review_lane_statuses_ignores_non_external_review_signals() {
 					&mut review_state,
 					TEST_NON_EXTERNAL_REVIEW_ACTOR_LOGIN,
 				);
-			}
+			},
 
 			_ => unreachable!("test case should use a known non-external signal"),
 		}
@@ -564,11 +541,7 @@ fn build_post_review_lane_statuses_ignores_non_external_review_signals() {
 		assert_eq!(lanes[0].classification, "wait_for_review");
 		assert_eq!(lanes[0].reason, expected_reason);
 		assert!(
-			lanes[0]
-				.loop_status
-				.as_ref()
-				.and_then(|status| status.review.as_ref())
-				.is_none(),
+			lanes[0].loop_status.as_ref().and_then(|status| status.review.as_ref()).is_none(),
 			"wait_for_review must not project a repair review checkpoint"
 		);
 	}
@@ -691,8 +664,12 @@ fn build_post_review_lane_statuses_keeps_completed_issue_visible_for_closeout_ta
 		path: repo_root.clone(),
 		reused_existing: true,
 	};
-	let _path_guard =
-		install_fake_closeout_gh_responses(&temp_dir, &worktree_spec, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_closeout_gh_responses(
+		&temp_dir,
+		&worktree_spec,
+		pr_url,
+		&head_oid,
+	);
 
 	state_store
 		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
@@ -762,8 +739,12 @@ fn build_post_review_lane_statuses_keeps_merged_closeout_visible_after_retry_bud
 		path: repo_root.clone(),
 		reused_existing: true,
 	};
-	let _path_guard =
-		install_fake_closeout_gh_responses(&temp_dir, &worktree_spec, pr_url, &head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_closeout_gh_responses(
+		&temp_dir,
+		&worktree_spec,
+		pr_url,
+		&head_oid,
+	);
 
 	state_store
 		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
@@ -830,8 +811,12 @@ fn build_post_review_lane_statuses_keeps_merged_closeout_visible_after_landed_ma
 	let current_head_oid =
 		commit_worktree_change(&worktree.path, "later.txt", "later\n", "advance main later");
 	let pr_url = "https://github.com/hack-ink/decodex/pull/203";
-	let _path_guard =
-		install_fake_closeout_gh_responses(&temp_dir, &worktree, pr_url, &pr_head_oid);
+	let _path_guard = recovery_terminal_support::install_fake_closeout_gh_responses(
+		&temp_dir,
+		&worktree,
+		pr_url,
+		&pr_head_oid,
+	);
 
 	state_store
 		.upsert_worktree(
@@ -895,7 +880,7 @@ fn build_post_review_lane_statuses_blocks_closeout_when_merge_readbacks_conflict
 		.expect("retained worktree should exist");
 	let head_oid = git_output(&worktree.path, &["rev-parse", "HEAD"]);
 	let pr_url = "https://github.com/hack-ink/decodex/pull/204";
-	let _path_guard = install_fake_closeout_gh_responses_with_states(
+	let _path_guard = recovery_terminal_support::install_fake_closeout_gh_responses_with_states(
 		&temp_dir, &worktree, pr_url, &head_oid, "OPEN", "MERGED",
 	);
 
@@ -941,10 +926,7 @@ fn build_post_review_lane_statuses_blocks_closeout_when_merge_readbacks_conflict
 	assert_eq!(lanes[0].classification, "blocked");
 	assert_eq!(lanes[0].reason, "pull_request_merge_state_conflict");
 	assert_eq!(lanes[0].readback_warning.as_deref(), Some("pull_request_merge_state_conflict"));
-	assert_eq!(
-		lanes[0].readback_root_cause.as_deref(),
-		Some("lineage_validation_failed")
-	);
+	assert_eq!(lanes[0].readback_root_cause.as_deref(), Some("lineage_validation_failed"));
 	assert_eq!(lanes[0].pr_state.as_deref(), Some("OPEN"));
 	assert_eq!(lanes[0].pr_url.as_deref(), Some(pr_url));
 }
@@ -1239,10 +1221,7 @@ fn build_post_review_lane_statuses_blocks_review_handoff_lineage_rewrite() {
 	assert_eq!(lanes.len(), 1);
 	assert_eq!(lanes[0].classification, "blocked");
 	assert_eq!(lanes[0].reason, "review_handoff_lineage_mismatch");
-	assert_eq!(
-		lanes[0].readback_root_cause.as_deref(),
-		Some("lineage_validation_failed")
-	);
+	assert_eq!(lanes[0].readback_root_cause.as_deref(), Some("lineage_validation_failed"));
 	assert_eq!(lanes[0].pr_url.as_deref(), Some(pr_url));
 }
 


### PR DESCRIPTION
## Summary
- Replace the recovery test include fragments with normal flat Rust modules.
- Move recovery helpers behind sibling-visible module APIs instead of parent-scope include leakage.
- Update closeout/recovery call sites to qualify helper access through recovery_terminal_support.

## Validation
- cargo test -p decodex orchestrator::tests::recovery --lib
- cargo check -p decodex
- cargo test -p decodex orchestrator::tests::recovery --lib --no-run
- rustup run nightly rustfmt --check <touched Rust files>
- git diff --cached --check
- rg confirmed no recovery include!, #[path], mod.rs, or super::* in the new flat recovery modules; git ls-files confirmed no tracked mod.rs files.
- cargo make lint-vstyle-rust still exits 105 on historical workspace debt; the new recovery_*.rs modules are not in the filtered violation set.