### PR TITLE
Remove post-review and publisher wildcard imports

### DIFF
--- a/apps/decodex-publisher/src/social_validation.rs
+++ b/apps/decodex-publisher/src/social_validation.rs
@@ -8,15 +8,11 @@ mod reservation;
 
 pub(crate) use cross_file::SocialValidationState;
 
-use std::{collections::BTreeMap, path::Path};
+use std::path::Path;
 
 use serde_json::{Map, Value};
-use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
-use crate::{
-	SOCIAL_CANDIDATE_SCHEMA, SOCIAL_POST_SCHEMA, SOCIAL_PUBLISH_RESERVATION_SCHEMA, path_arg,
-	repo_root,
-};
+use crate::{SOCIAL_CANDIDATE_SCHEMA, SOCIAL_POST_SCHEMA, SOCIAL_PUBLISH_RESERVATION_SCHEMA};
 
 const SIGNAL_CONFIDENCE: &[&str] = &["confirmed", "likely", "weak"];
 const SOCIAL_BLOCK_REASONS: &[&str] =
@@ -61,8 +57,9 @@ pub(crate) fn validate_social_artifact(payload: &Value) -> SocialArtifactValidat
 	match string_field(entry, "schema") {
 		Some(SOCIAL_CANDIDATE_SCHEMA) => candidate::validate_social_candidate(entry, &mut errors),
 		Some(SOCIAL_POST_SCHEMA) => post::validate_social_post(entry, &mut errors),
-		Some(SOCIAL_PUBLISH_RESERVATION_SCHEMA) =>
-			reservation::validate_social_publish_reservation(entry, &mut errors),
+		Some(SOCIAL_PUBLISH_RESERVATION_SCHEMA) => {
+			reservation::validate_social_publish_reservation(entry, &mut errors)
+		},
 		Some(_) | None => errors.push(format!(
 			"schema must be one of {}",
 			choices(&[

--- a/apps/decodex-publisher/src/social_validation/candidate.rs
+++ b/apps/decodex-publisher/src/social_validation/candidate.rs
@@ -1,6 +1,13 @@
 //! social_candidate/v1 schema validation.
 
-#[allow(clippy::wildcard_imports)] use super::*;
+use serde_json::{Map, Value};
+
+use super::{
+	SOCIAL_POST_MODES, SOCIAL_POST_PRIORITIES, choices, is_empty_or_missing_array,
+	is_https_string_array, is_non_empty_string, matches_one_of, non_empty_array, string_field,
+	validate_non_empty_string_list, validate_optional_string_list, validate_social_post_claims,
+	validate_social_post_text,
+};
 
 pub(super) fn validate_social_candidate(entry: &Map<String, Value>, errors: &mut Vec<String>) {
 	for field in ["slug", "repo", "audience"] {

--- a/apps/decodex-publisher/src/social_validation/common.rs
+++ b/apps/decodex-publisher/src/social_validation/common.rs
@@ -1,6 +1,7 @@
 //! Shared social artifact validation predicates.
 
-#[allow(clippy::wildcard_imports)] use super::*;
+use serde_json::{Map, Value};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 pub(super) fn validate_non_empty_string_list(
 	value: Option<&Value>,

--- a/apps/decodex-publisher/src/social_validation/cross_file.rs
+++ b/apps/decodex-publisher/src/social_validation/cross_file.rs
@@ -1,6 +1,11 @@
 //! Cross-file social artifact uniqueness checks.
 
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::{collections::BTreeMap, path::Path};
+
+use serde_json::Value;
+
+use super::{SOCIAL_POST_SCHEMA, SOCIAL_PUBLISH_RESERVATION_SCHEMA};
+use crate::{path_arg, repo_root};
 
 #[derive(Debug)]
 pub(crate) struct SocialValidationState {

--- a/apps/decodex-publisher/src/social_validation/post.rs
+++ b/apps/decodex-publisher/src/social_validation/post.rs
@@ -1,6 +1,13 @@
 //! social_post/v1 schema validation.
 
-#[allow(clippy::wildcard_imports)] use super::*;
+use serde_json::{Map, Value};
+
+use super::{
+	SIGNAL_CONFIDENCE, SOCIAL_BLOCK_REASONS, SOCIAL_POST_LIFECYCLE_STATES, SOCIAL_POST_MODES,
+	SOCIAL_POST_PRIORITIES, SOCIAL_POST_STATUSES, SOCIAL_POST_WORTHINESS, choices,
+	is_empty_or_missing_array, is_https_string_array, is_non_empty_string, matches_one_of,
+	non_empty_array, string_field, validate_optional_string_list, validate_rfc3339_field,
+};
 
 pub(super) fn validate_social_post(entry: &Map<String, Value>, errors: &mut Vec<String>) {
 	for field in ["slug", "audience"] {
@@ -195,16 +202,20 @@ fn validate_social_post_decision_counts(
 	match string_field(entry, "status") {
 		Some("published")
 			if before.zip(after).is_none_or(|(before, after)| after != before + 1) =>
+		{
 			errors.push(
 				"decision.daily_count_after must equal daily_count_before + 1 for published posts"
 					.into(),
-			),
+			)
+		},
 		Some("blocked" | "failed" | "skipped")
 			if before.zip(after).is_none_or(|(before, after)| after != before) =>
+		{
 			errors.push(
 				"decision.daily_count_after must equal daily_count_before for non-published posts"
 					.into(),
-			),
+			)
+		},
 		_ => {},
 	}
 }
@@ -213,10 +224,12 @@ fn validate_social_post_status_payload(entry: &Map<String, Value>, errors: &mut 
 	match string_field(entry, "status") {
 		Some("published") => validate_social_post_publication(entry.get("publication"), errors),
 		Some("blocked") => validate_social_post_block(entry, errors),
-		Some("failed") if !is_non_empty_string(entry.get("failure_reason")) =>
-			errors.push("failure_reason is required when status is failed".into()),
-		Some("skipped") if !is_non_empty_string(entry.get("skip_reason")) =>
-			errors.push("skip_reason is required when status is skipped".into()),
+		Some("failed") if !is_non_empty_string(entry.get("failure_reason")) => {
+			errors.push("failure_reason is required when status is failed".into())
+		},
+		Some("skipped") if !is_non_empty_string(entry.get("skip_reason")) => {
+			errors.push("skip_reason is required when status is skipped".into())
+		},
 		_ => {},
 	}
 }

--- a/apps/decodex-publisher/src/social_validation/reservation.rs
+++ b/apps/decodex-publisher/src/social_validation/reservation.rs
@@ -1,6 +1,12 @@
 //! social_publish_reservation/v1 schema validation.
 
-#[allow(clippy::wildcard_imports)] use super::*;
+use serde_json::{Map, Value};
+
+use super::{
+	SOCIAL_POST_MODES, SOCIAL_PUBLISH_RESERVATION_STATUSES, choices, is_https_string,
+	is_https_string_array, is_non_empty_string, matches_one_of, non_empty_array, string_field,
+	validate_non_empty_string_list, validate_optional_string_list, validate_rfc3339_field,
+};
 
 pub(super) fn validate_social_publish_reservation(
 	entry: &Map<String, Value>,
@@ -96,10 +102,12 @@ fn validate_social_publish_reservation_status_payload(
 	errors: &mut Vec<String>,
 ) {
 	match string_field(entry, "status") {
-		Some("consumed") if !is_non_empty_string(entry.get("consumed_by_social_post")) =>
-			errors.push("consumed_by_social_post is required when status is consumed".into()),
-		Some("canceled" | "expired") if !is_non_empty_string(entry.get("release_reason")) =>
-			errors.push("release_reason is required when status is canceled or expired".into()),
+		Some("consumed") if !is_non_empty_string(entry.get("consumed_by_social_post")) => {
+			errors.push("consumed_by_social_post is required when status is consumed".into())
+		},
+		Some("canceled" | "expired") if !is_non_empty_string(entry.get("release_reason")) => {
+			errors.push("release_reason is required when status is canceled or expired".into())
+		},
 		_ => {},
 	}
 }

--- a/apps/decodex/src/orchestrator/status/post_review.rs
+++ b/apps/decodex/src/orchestrator/status/post_review.rs
@@ -1,12 +1,12 @@
 use super::{
-	AUTHORITY_BOUNDARY_CHECK_EVENT_TYPE, AUTHORITY_DECISION_REQUEST_EVENT_TYPE, Command, HashMap,
-	IssueTracker, OffsetDateTime, OperatorLoopStatus, OperatorPostReviewLaneStatus,
-	OperatorStatusSnapshot, Path, PostReviewLaneBuildContext, PostReviewLaneClassification,
-	PostReviewLaneDecision, PostReviewLaneSnapshot, PostReviewLaneStateLoad,
-	PostReviewOrchestrationStatus, PostReviewReadbackDegradation, PostReviewRuntimeState,
-	PrivateExecutionEvent, PullRequestMergeViewResponse, PullRequestReadbackRootCause,
-	PullRequestReviewState, PullRequestReviewStateInspector, ReviewHandoffMarker, ServiceConfig,
-	StateStore, TrackerIssue, Value, WorkflowDocument, WorktreeMapping, active_shared_issue_ids,
+	AUTHORITY_BOUNDARY_CHECK_EVENT_TYPE, AUTHORITY_DECISION_REQUEST_EVENT_TYPE, IssueTracker,
+	OperatorLoopStatus, OperatorPostReviewLaneStatus, OperatorStatusSnapshot,
+	PostReviewLaneBuildContext, PostReviewLaneClassification, PostReviewLaneDecision,
+	PostReviewLaneSnapshot, PostReviewLaneStateLoad, PostReviewOrchestrationStatus,
+	PostReviewReadbackDegradation, PostReviewRuntimeState, PrivateExecutionEvent,
+	PullRequestMergeViewResponse, PullRequestReadbackRootCause, PullRequestReviewState,
+	PullRequestReviewStateInspector, ReviewHandoffMarker, ServiceConfig, StateStore, TrackerIssue,
+	WorkflowDocument, WorktreeMapping, active_shared_issue_ids,
 	apply_non_github_review_post_review_classification,
 	apply_pre_orchestration_post_review_classification,
 	apply_review_orchestration_phase_classification, blocked_post_review_lane_status,
@@ -23,7 +23,8 @@ use crate::orchestrator::kernel::post_review::{
 	PostReviewLaneKernelInput, decide_post_review_lane, project_post_review_lane_decision,
 };
 
-#[cfg(test)] use super::ReviewLevel;
+#[cfg(test)]
+use super::ReviewLevel;
 
 mod authority_boundary;
 mod classification;
@@ -31,7 +32,15 @@ mod lanes;
 mod retry_budget;
 mod worktrees;
 
-#[allow(clippy::wildcard_imports)]
 pub(in crate::orchestrator) use self::{
-	authority_boundary::*, classification::*, lanes::*, retry_budget::*, worktrees::*,
+	authority_boundary::authority_boundary_landing_requirement,
+	worktrees::{
+		build_degraded_post_review_lane_statuses, build_post_review_lane_statuses,
+		build_post_review_lane_statuses_and_hydrate_worktrees,
+	},
+};
+
+#[cfg(test)]
+pub(in crate::orchestrator) use self::{
+	classification::classify_post_review_lane, worktrees::load_post_review_worktree_issues,
 };

--- a/apps/decodex/src/orchestrator/status/post_review/authority_boundary.rs
+++ b/apps/decodex/src/orchestrator/status/post_review/authority_boundary.rs
@@ -1,4 +1,11 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use serde_json::Value;
+
+use super::{
+	AUTHORITY_BOUNDARY_CHECK_EVENT_TYPE, AUTHORITY_DECISION_REQUEST_EVENT_TYPE,
+	PostReviewLaneClassification, PostReviewLaneDecision, PostReviewLaneSnapshot,
+	PostReviewRuntimeState, PrivateExecutionEvent, ReviewHandoffMarker,
+	operator_boundary_policy_blocks_landing, operator_boundary_policy_requires_enhanced_evidence,
+};
 
 pub(in crate::orchestrator) fn apply_authority_boundary_landing_policy(
 	snapshot: &PostReviewLaneSnapshot,

--- a/apps/decodex/src/orchestrator/status/post_review/classification.rs
+++ b/apps/decodex/src/orchestrator/status/post_review/classification.rs
@@ -1,4 +1,22 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use time::OffsetDateTime;
+
+use super::{
+	PostReviewLaneClassification, PostReviewLaneDecision, PostReviewLaneKernelInput,
+	PostReviewLaneSnapshot, PostReviewLaneStateLoad, PostReviewOrchestrationStatus,
+	PostReviewRuntimeState, PullRequestReviewStateInspector, ReviewHandoffMarker, ServiceConfig,
+	StateStore, WorkflowDocument, apply_non_github_review_post_review_classification,
+	apply_pre_orchestration_post_review_classification,
+	apply_review_orchestration_phase_classification, decide_post_review_lane,
+	initial_post_review_lane_classification, load_post_review_lane_review_state,
+	load_post_review_orchestration_marker, project_post_review_lane_decision,
+};
+use super::{
+	authority_boundary::apply_authority_boundary_landing_policy,
+	retry_budget::confirm_status_visible_merged_closeout,
+};
+
+#[cfg(test)]
+use super::ReviewLevel;
 
 #[cfg_attr(not(test), allow(dead_code))]
 #[cfg(test)]

--- a/apps/decodex/src/orchestrator/status/post_review/lanes.rs
+++ b/apps/decodex/src/orchestrator/status/post_review/lanes.rs
@@ -1,4 +1,17 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::collections::HashMap;
+
+use super::{
+	OperatorLoopStatus, OperatorPostReviewLaneStatus, OperatorStatusSnapshot,
+	PostReviewLaneBuildContext, PostReviewLaneClassification, PostReviewLaneDecision,
+	PostReviewLaneSnapshot, PullRequestReviewStateInspector, ServiceConfig, StateStore,
+	TrackerIssue, WorkflowDocument, WorktreeMapping, blocked_post_review_lane_status,
+	issue_retry_budget_exhausted_for_worktree, operator_loop_status_for_run,
+	relative_worktree_path_for_path, tracker, worktree_checkout_branch_name, worktree_head_oid,
+};
+use super::{
+	classification::classify_post_review_lane_with_project,
+	retry_budget::retry_budget_exhausted_post_review_lane_classification,
+};
 
 pub(in crate::orchestrator) fn build_post_review_lane_statuses_from_worktree_issues<I>(
 	project: &ServiceConfig,

--- a/apps/decodex/src/orchestrator/status/post_review/retry_budget.rs
+++ b/apps/decodex/src/orchestrator/status/post_review/retry_budget.rs
@@ -1,4 +1,16 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::{path::Path, process::Command};
+
+use super::classification::{
+	finalize_post_review_lane_classification,
+	finalize_post_review_lane_classification_with_retry_budget,
+};
+use super::{
+	PostReviewLaneClassification, PostReviewLaneDecision, PostReviewLaneSnapshot,
+	PullRequestMergeViewResponse, PullRequestReadbackRootCause, PullRequestReviewState,
+	PullRequestReviewStateInspector, ReviewHandoffMarker, ServiceConfig, WorkflowDocument,
+	apply_pre_orchestration_post_review_classification, classify_pull_request_readback_report,
+	github, initial_post_review_lane_classification, resolve_configured_env_var,
+};
 
 pub(in crate::orchestrator) fn retry_budget_exhausted_post_review_lane_classification<I>(
 	snapshot: &PostReviewLaneSnapshot,

--- a/apps/decodex/src/orchestrator/status/post_review/worktrees.rs
+++ b/apps/decodex/src/orchestrator/status/post_review/worktrees.rs
@@ -1,4 +1,16 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::collections::HashMap;
+
+use super::lanes::{
+	build_post_review_lane_statuses_from_worktree_issues, hydrate_worktree_issue_metadata,
+};
+use super::{
+	IssueTracker, OperatorPostReviewLaneStatus, OperatorStatusSnapshot,
+	PostReviewLaneClassification, PostReviewReadbackDegradation, PullRequestReviewStateInspector,
+	ReviewHandoffMarker, ServiceConfig, StateStore, TrackerIssue, WorkflowDocument,
+	WorktreeMapping, active_shared_issue_ids, operator_loop_status_for_run,
+	refresh_recoverable_runtime_issues, relative_worktree_path_for_path,
+	worktree_mapping_is_stale_terminal_local_residue,
+};
 
 pub(in crate::orchestrator) fn build_post_review_lane_statuses<T, I>(
 	tracker: &T,


### PR DESCRIPTION
## Summary
- Replace wildcard-import clippy allowances in Decodex post-review status modules with explicit imports and explicit re-export surfaces.
- Replace Decodex Publisher social validation wildcard imports with explicit module imports.
- Keep normal Rust modules only; no mod.rs, include!, #[path], or clippy wildcard allow bypasses.

## Validation
- cargo check -p decodex -p decodex-publisher --lib --tests
- cargo clippy -p decodex -p decodex-publisher --lib --tests --all-features -- -D warnings
- cargo test -p decodex-publisher --lib -- --format terse
- cargo test -p decodex post_review --lib -- --format terse
- scoped structural scan for wildcard imports/allows, include!, #[path], and mod.rs in changed scopes
- cargo vstyle curate --language rust -p decodex -p decodex-publisher --all-features (still fails on existing broad style debt; changed scopes also retain non-clippy vstyle import/style debt such as crate-absolute import and free-function qualification rules)