### PR TITLE
Clean orchestrator core wildcard imports

### DIFF
--- a/apps/decodex/src/orchestrator.rs
+++ b/apps/decodex/src/orchestrator.rs
@@ -410,7 +410,7 @@ pub(in crate::orchestrator) use self::{
 };
 use crate::{
 	agent::{self, CodexAccountAuthFailure, CodexAccountPool, REVIEW_POLICY_CONVERGENCE_BUDGET},
-	default_branch_sync, git_credentials, runtime, state,
+	git_credentials, runtime, state,
 	state::PrivateExecutionEvent,
 	tracker::{self, privacy_classifier::PublicProjectionPrivacyClassifier},
 };

--- a/apps/decodex/src/orchestrator/dispatch_policy.rs
+++ b/apps/decodex/src/orchestrator/dispatch_policy.rs
@@ -1,5 +1,11 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use crate::{
+	config::ServiceConfig,
+	orchestrator::{IssueDispatchMode, RetryIssueStateHint},
+	prelude::Result,
+	state::StateStore,
+	tracker::{self, IssueTracker, TrackerIssue},
+	workflow::WorkflowDocument,
+};
 
 mod closeout;
 mod description;

--- a/apps/decodex/src/orchestrator/dispatch_policy/closeout.rs
+++ b/apps/decodex/src/orchestrator/dispatch_policy/closeout.rs
@@ -1,5 +1,14 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use std::path::Path;
+
+use crate::{
+	orchestrator::{
+		CloseoutDispatchEligibility, GhPullRequestReviewStateInspector, IssueTracker,
+		PullRequestReviewStateInspector, Result, RetainedCloseoutPrMergeGate, ServiceConfig,
+		StateStore, TrackerIssue, WorkflowDocument, issue_has_service_ownership,
+		retained_closeout_pr_merge_gate_with_inspector,
+	},
+	worktree::{WorktreeManager, WorktreeSpec},
+};
 
 pub(in crate::orchestrator) fn issue_passes_review_repair_dispatch_policy<T>(
 	tracker: &T,

--- a/apps/decodex/src/orchestrator/dispatch_policy/description.rs
+++ b/apps/decodex/src/orchestrator/dispatch_policy/description.rs
@@ -1,5 +1,6 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use serde_json::Value;
+
+use crate::tracker::TrackerIssue;
 
 pub(in crate::orchestrator::dispatch_policy) fn description_is_machine_only_fenced_block(
 	description: &str,

--- a/apps/decodex/src/orchestrator/dispatch_policy/lifecycle.rs
+++ b/apps/decodex/src/orchestrator/dispatch_policy/lifecycle.rs
@@ -1,5 +1,19 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use std::path::Path;
+
+use crate::git_credentials::GitCredentialSource;
+use crate::{
+	default_branch_sync, github,
+	orchestrator::{
+		IssueDispatchMode, IssueRunPlan, IssueTracker, Result, ServiceConfig, StateStore,
+		TrackerIssue, WorkflowDocument, delete_local_branch_if_present,
+		detach_worktree_head_from_branch_if_checked_out, issue_passes_dispatch_policy,
+		issue_passes_review_repair_dispatch_policy,
+		ordinary_dispatch_blocked_by_retained_review_handoff, tracker,
+	},
+	prelude::eyre,
+	state::{self, WorktreeMapping},
+	worktree::WorktreeManager,
+};
 
 pub(in crate::orchestrator) fn clear_recovered_issue_lease(
 	project_id: &str,

--- a/apps/decodex/src/orchestrator/dispatch_policy/retry_budget.rs
+++ b/apps/decodex/src/orchestrator/dispatch_policy/retry_budget.rs
@@ -1,5 +1,17 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use std::{
+	fs,
+	io::ErrorKind,
+	path::{Path, PathBuf},
+};
+
+use crate::{
+	orchestrator::{
+		IssueDispatchMode, IssueTracker, Result, RetryIssueStateHint, ServiceConfig, StateStore,
+		TERMINAL_GUARD_MARKER_FILE, TERMINAL_GUARDED_RUN_STATUS, TrackerIssue, WorkflowDocument,
+		ordinary_dispatch_blocked_by_retained_review_handoff, tracker,
+	},
+	state,
+};
 
 pub(in crate::orchestrator) fn issue_passes_retry_dispatch_policy<T>(
 	tracker: &T,

--- a/apps/decodex/src/orchestrator/run_cycle.rs
+++ b/apps/decodex/src/orchestrator/run_cycle.rs
@@ -1,18 +1,22 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use crate::{
+	config::ServiceConfig,
+	orchestrator::{IssueDispatchMode, Result, RunCycleRequest, RunSummary, TargetIssueRunContext},
+	tracker::linear::LinearClient,
+	workflow::WorkflowDocument,
+};
 
-const INTERNAL_RETAINED_DRAIN_MAX_PASSES: usize = 2;
+pub(in crate::orchestrator::run_cycle) const INTERNAL_RETAINED_DRAIN_MAX_PASSES: usize = 2;
 
-mod complete;
-mod prepare;
+pub(in crate::orchestrator::run_cycle) mod complete;
+pub(in crate::orchestrator::run_cycle) mod prepare;
 mod project;
 mod target_issue;
 
-use complete::complete_issue_run;
 #[cfg(test)]
 pub(crate) use complete::{
 	drain_non_github_review_retained_tail_with_inspector, run_retained_closeout_for_handoff_summary,
 };
+#[cfg(test)]
 pub(crate) use prepare::prepare_issue_run;
 pub(crate) use project::{plan_project_issue_run_with_exclusions, run_project_once};
 pub(crate) use target_issue::{

--- a/apps/decodex/src/orchestrator/run_cycle/complete.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/complete.rs
@@ -1,6 +1,18 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::path::Path;
 
-pub(super) fn complete_issue_run<T>(
+use crate::{
+	config::ServiceConfig,
+	orchestrator::{
+		GhPullRequestReviewStateInspector, IssueDispatchMode, IssueRunPlan, IssueTracker,
+		PullRequestReviewStateInspector, Result, RunSummary, StateStore, TargetIssueRunContext,
+		build_post_review_lane_statuses, execute_issue_run, post_review_lane_is_closeout_candidate,
+		reconcile_post_review_orchestration_with_inspector,
+		reconcile_terminal_thread_archive_backlog_best_effort, run_summary_from_issue_run,
+	},
+	workflow::WorkflowDocument,
+};
+
+pub(in crate::orchestrator::run_cycle) fn complete_issue_run<T>(
 	tracker: &T,
 	project: &ServiceConfig,
 	workflow: &WorkflowDocument,
@@ -58,7 +70,7 @@ pub(crate) fn run_retained_closeout_for_handoff_summary<T>(
 where
 	T: IssueTracker,
 {
-	run_target_issue_once(TargetIssueRunContext {
+	crate::orchestrator::run_cycle::run_target_issue_once(TargetIssueRunContext {
 		tracker,
 		project,
 		workflow,
@@ -104,7 +116,7 @@ where
 
 	let completed_state = workflow.frontmatter().tracker().resolved_completed_state();
 
-	for pass in 0..INTERNAL_RETAINED_DRAIN_MAX_PASSES {
+	for pass in 0..crate::orchestrator::run_cycle::INTERNAL_RETAINED_DRAIN_MAX_PASSES {
 		reconcile_post_review_orchestration_with_inspector(
 			tracker,
 			project,
@@ -133,7 +145,7 @@ where
 			return Ok(None);
 		}
 		if lane.reason != "non_github_review_waiting_for_merge"
-			|| pass + 1 == INTERNAL_RETAINED_DRAIN_MAX_PASSES
+			|| pass + 1 == crate::orchestrator::run_cycle::INTERNAL_RETAINED_DRAIN_MAX_PASSES
 		{
 			return Ok(None);
 		}

--- a/apps/decodex/src/orchestrator/run_cycle/prepare.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/prepare.rs
@@ -1,5 +1,17 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use std::path::Path;
+
+use crate::{
+	orchestrator::{
+		IssueDispatchMode, IssueRunPlan, IssueTracker, PreferredRunIdentity,
+		PrepareIssueRunContext, Result, RetryIssueStateHint, StateStore, TrackerIssue,
+		build_run_id, cleanup_terminal_worktree, clear_terminal_guard_marker,
+		closeout_dispatch_block_reason, is_terminal_issue, issue_passes_current_dispatch_policy,
+		planned_issue_state_for_dispatch, refresh_issue, retry_budget_base_for_dispatch_mode,
+		validate_workflow_read_first_files, write_prepare_lifecycle_events,
+	},
+	prelude::eyre,
+	worktree::WorktreeSpec,
+};
 
 pub(crate) fn prepare_issue_run<T>(
 	context: PrepareIssueRunContext<'_, T>,

--- a/apps/decodex/src/orchestrator/run_cycle/project.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/project.rs
@@ -1,5 +1,23 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use std::slice;
+
+use crate::{
+	config::ServiceConfig,
+	orchestrator::{
+		IssueDispatchMode, IssueRunPlan, IssueTracker, PreferredRunIdentity,
+		PrepareIssueRunContext, RecoveredRuntimeState, Result, RetryIssueStateHint, RunSummary,
+		SelectedIssueRunCandidate, StateStore, TrackerIssue, WorkflowDocument,
+		apply_queued_candidate_guardrail_commands, build_queued_candidate_status_plan,
+		closeout_dispatch_block_reason, ensure_project_has_no_merged_worktree_cleanup_debt,
+		is_terminal_issue, issue_passes_current_dispatch_policy,
+		reconcile_post_review_orchestration, reconcile_project_state,
+		reconcile_terminal_thread_archive_backlog_best_effort, record_program_dispatch_selected,
+		recover_runtime_state_from_tracker_and_worktrees, select_execution_program_run_candidate,
+		select_issue_candidate_with_exclusions, select_post_review_issue_candidate,
+	},
+	prelude::eyre,
+	tracker,
+	worktree::WorktreeManager,
+};
 
 pub(crate) fn run_project_once<T>(
 	tracker: &T,
@@ -41,7 +59,14 @@ where
 		return Ok(None);
 	};
 
-	complete_issue_run(tracker, project, workflow, state_store, issue_run, dry_run)
+	crate::orchestrator::run_cycle::complete::complete_issue_run(
+		tracker,
+		project,
+		workflow,
+		state_store,
+		issue_run,
+		dry_run,
+	)
 }
 
 pub(crate) fn plan_project_issue_run_with_exclusions<T>(
@@ -121,7 +146,7 @@ where
 		);
 	}
 
-	let Some(issue_run) = prepare_issue_run(
+	let Some(issue_run) = crate::orchestrator::run_cycle::prepare::prepare_issue_run(
 		PrepareIssueRunContext {
 			tracker,
 			project,

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue.rs
@@ -1,9 +1,20 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use time::OffsetDateTime;
 
-use state::PreacquiredLeaseGuards;
-
-use crate::commit_message;
+use crate::{
+	commit_message,
+	config::ServiceConfig,
+	orchestrator::{
+		IssueDispatchMode, IssueTracker, PreferredRunIdentity, PrepareIssueRunContext, Result,
+		RetainedReviewRunIdentity, RetryIssueStateHint, RunSummary, StateStore,
+		TargetIssueRunContext, TrackerIssue, closeout_dispatch_block_reason,
+		ensure_project_has_no_merged_worktree_cleanup_debt, issue_passes_current_dispatch_policy,
+		reconcile_project_state, recover_runtime_state_from_tracker_and_worktrees, refresh_issue,
+		retained_closeout_lease_has_fresh_activity, retained_closeout_preferred_run_identity,
+	},
+	prelude::eyre,
+	state::PreacquiredLeaseGuards,
+	worktree::WorktreeManager,
+};
 
 pub(in crate::orchestrator::run_cycle::target_issue) mod inferred;
 pub(in crate::orchestrator::run_cycle::target_issue) mod post_review;
@@ -94,7 +105,7 @@ where
 		ensure_project_has_no_merged_worktree_cleanup_debt(context.project)?;
 	}
 
-	let Some(issue_run) = prepare_issue_run(
+	let Some(issue_run) = crate::orchestrator::run_cycle::prepare::prepare_issue_run(
 		PrepareIssueRunContext {
 			tracker: context.tracker,
 			project: context.project,
@@ -115,7 +126,7 @@ where
 		return Ok(None);
 	};
 
-	complete_issue_run(
+	crate::orchestrator::run_cycle::complete::complete_issue_run(
 		context.tracker,
 		context.project,
 		context.workflow,

--- a/apps/decodex/src/orchestrator/run_cycle_reconciliation.rs
+++ b/apps/decodex/src/orchestrator/run_cycle_reconciliation.rs
@@ -2,7 +2,8 @@ mod leases;
 mod terminal_cleanup;
 mod worktrees;
 
-use leases::{clear_terminal_lane_labels_once, reconcile_active_project_leases};
+use leases::reconcile_active_project_leases;
+pub(in crate::orchestrator::run_cycle_reconciliation) use leases::clear_terminal_lane_labels_once;
 pub(crate) use leases::{
 	retained_closeout_lease_has_fresh_activity, terminal_issue_keeps_retained_closeout,
 };
@@ -17,29 +18,23 @@ use worktrees::{
 
 use std::{
 	collections::{HashMap, HashSet},
-	path::Path,
-	time::Duration,
 };
 
 use time::OffsetDateTime;
 
-use super::{
-	IssueTracker, RunAttempt, RunLeaseDisposition, RunLeaseReconciliation, ServiceConfig,
-	StateStore, TERMINAL_GUARDED_RUN_STATUS, TrackerIssue, WorkflowDocument, WorktreeManager,
-	WorktreeMapping, apply_run_lease_reconciliation, cleanup_worktree_mapping,
-	closeout_dispatch_block_reason, is_issue_in_progress_for_run, is_terminal_issue,
-	issue_has_service_ownership, issue_passes_closeout_dispatch_policy, mark_run_attempt_if_active,
-	marker_process_is_alive, observed_idle_duration, retained_review_handoff_matches_run,
-	stalled_idle_duration, worktree_activity_marker_is_fresh, worktree_has_tracked_changes,
-	worktree_mapping_is_stale_terminal_local_residue,
-};
 use crate::{
+	config::ServiceConfig,
 	prelude::Result,
-	state::{self, IssueLease},
-	tracker,
+	state::StateStore,
+	tracker::IssueTracker,
+	workflow::WorkflowDocument,
+	worktree::WorktreeManager,
 };
 
-struct ProjectStateReconciliationContext<'a, T> {
+pub(in crate::orchestrator::run_cycle_reconciliation) struct ProjectStateReconciliationContext<
+	'a,
+	T,
+> {
 	tracker: &'a T,
 	project: &'a ServiceConfig,
 	workflow: &'a WorkflowDocument,

--- a/apps/decodex/src/orchestrator/run_cycle_reconciliation/leases.rs
+++ b/apps/decodex/src/orchestrator/run_cycle_reconciliation/leases.rs
@@ -1,4 +1,19 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::collections::{HashMap, HashSet};
+
+use crate::{
+	config::ServiceConfig,
+	orchestrator::{
+		IssueTracker, closeout_dispatch_block_reason, is_terminal_issue,
+		issue_passes_closeout_dispatch_policy, mark_run_attempt_if_active,
+		retained_review_handoff_matches_run, run_cycle_reconciliation::ProjectStateReconciliationContext,
+		worktree_activity_marker_is_fresh,
+	},
+	prelude::Result,
+	state::{self, IssueLease, StateStore},
+	tracker::{self, TrackerIssue},
+	workflow::WorkflowDocument,
+	worktree::WorktreeManager,
+};
 
 pub(super) fn reconcile_active_project_leases<T>(
 	context: &ProjectStateReconciliationContext<'_, T>,
@@ -127,7 +142,7 @@ where
 	context.state_store.clear_lease(lease.issue_id())
 }
 
-pub(super) fn clear_terminal_lane_labels_once<T>(
+pub(in crate::orchestrator::run_cycle_reconciliation) fn clear_terminal_lane_labels_once<T>(
 	tracker: &T,
 	project: &ServiceConfig,
 	issue: &TrackerIssue,

--- a/apps/decodex/src/orchestrator/run_cycle_reconciliation/terminal_cleanup.rs
+++ b/apps/decodex/src/orchestrator/run_cycle_reconciliation/terminal_cleanup.rs
@@ -1,4 +1,11 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::collections::HashSet;
+
+use crate::{
+	config::ServiceConfig,
+	orchestrator::{TERMINAL_GUARDED_RUN_STATUS, worktree_mapping_is_stale_terminal_local_residue},
+	prelude::Result,
+	state::{IssueLease, StateStore, WorktreeMapping},
+};
 
 pub(super) fn clear_stale_terminal_local_worktree_mappings(
 	project: &ServiceConfig,

--- a/apps/decodex/src/orchestrator/run_cycle_reconciliation/worktrees.rs
+++ b/apps/decodex/src/orchestrator/run_cycle_reconciliation/worktrees.rs
@@ -1,4 +1,23 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::{
+	collections::{HashMap, HashSet},
+	path::Path,
+	time::Duration,
+};
+
+use crate::{
+	orchestrator::{
+		IssueTracker, RunAttempt, RunLeaseDisposition,
+		RunLeaseReconciliation, apply_run_lease_reconciliation, cleanup_worktree_mapping,
+		is_issue_in_progress_for_run, is_terminal_issue, issue_has_service_ownership,
+		marker_process_is_alive, observed_idle_duration,
+		run_cycle_reconciliation::{ProjectStateReconciliationContext, clear_terminal_lane_labels_once},
+		stalled_idle_duration, terminal_issue_keeps_retained_closeout,
+		worktree_has_tracked_changes,
+	},
+	prelude::Result,
+	state::{self, IssueLease, StateStore, WorktreeMapping},
+	tracker::TrackerIssue,
+};
 
 pub(super) fn cleanup_missing_orphaned_project_worktree_mappings<T>(
 	context: &ProjectStateReconciliationContext<'_, T>,


### PR DESCRIPTION
## Summary
- replace wildcard clippy allowances in dispatch policy, run cycle, and run-cycle reconciliation modules with explicit imports
- keep the existing flat Rust module layout without mod.rs/include/path workarounds
- preserve runtime behavior while tightening module visibility around run-cycle helpers

## Validation
- cargo check -p decodex --lib --tests
- cargo clippy -p decodex --lib --tests --all-features -- -D warnings
- cargo test -p decodex prepare_issue_run --lib -- --format terse
- cargo test -p decodex dispatch_policy --lib -- --format terse
- cargo test -p decodex reconciliation --lib -- --format terse
- git diff --check
- scoped structural scan for wildcard/import allow/include/path/mod.rs violations

## Vstyle
- cargo vstyle curate --language rust -p decodex --all-features still fails on existing package-wide style debt, including import-qualification and item-order rules outside and inside these touched modules; no mod.rs or clippy wildcard allow was added.