### PR TITLE
Clean execution and daemon retry imports

### DIFF
--- a/apps/decodex/src/orchestrator.rs
+++ b/apps/decodex/src/orchestrator.rs
@@ -410,7 +410,7 @@ pub(in crate::orchestrator) use self::{
 };
 use crate::{
 	agent::{self, CodexAccountAuthFailure, CodexAccountPool, REVIEW_POLICY_CONVERGENCE_BUDGET},
-	git_credentials, runtime, state,
+	runtime, state,
 	state::PrivateExecutionEvent,
 	tracker::{self, privacy_classifier::PublicProjectionPrivacyClassifier},
 };

--- a/apps/decodex/src/orchestrator/daemon_retry.rs
+++ b/apps/decodex/src/orchestrator/daemon_retry.rs
@@ -1,34 +1,3 @@
-use std::{
-	path::Path,
-	process::ExitStatus,
-	time::{Duration, Instant},
-};
-
-use color_eyre::Report;
-use serde_json::json;
-use time::OffsetDateTime;
-
-use crate::{state, tracker::TrackerIssue};
-
-use super::{
-	ARCHITECTURE_RECOVERY_BUDGET, ARCHITECTURE_RECOVERY_RETRY_KIND,
-	CONTINUATION_PENDING_RUN_STATUS, CONTINUATION_RETRY_DELAY_MS, ChildExitRetryContext,
-	ChildRunRef, CloseoutDispatchEligibility, FAILURE_RETRY_BASE_DELAY_MS,
-	GhPullRequestReviewStateInspector, IssueDispatchMode, IssueRunPlan, IssueTracker,
-	LaneDecisionSnapshot, PhaseGoalRecoveryContinuation, Result, RetainedPartialProgress,
-	RetryEntry, RetryEntryLifecycle, RetryIssueStateHint, RetryKind, RetryQueue, ServiceConfig,
-	StateStore, TERMINAL_GUARDED_RUN_STATUS, TerminalFailureWritebackRuntime, WorkflowDocument,
-	WorktreeManager, WorktreeSpec, apply_terminal_failure_writeback, clear_worktree_retry_schedule,
-	configured_public_projection_privacy_classifier, decide_lane_next_action,
-	evaluate_closeout_dispatch_policy_with_inspector, handle_failure,
-	issue_has_blocking_lane_decision_evidence, issue_passes_retry_retention_policy,
-	issue_passes_review_repair_dispatch_policy, issue_retry_budget_exhausted,
-	mark_run_attempt_if_active, recover_phase_goal_continuation, refresh_issue,
-	relative_worktree_path, resolve_child_exit_run_attempt,
-	run_failure_requires_terminal_attention, superseded_run_disposition,
-	worktree_has_tracked_changes, write_retry_budget_marker, write_terminal_guard_marker,
-};
-
 mod child_exit;
 mod phase_goal;
 mod retention;
@@ -38,7 +7,7 @@ mod terminal;
 pub(crate) use child_exit::schedule_retry_after_child_exit;
 pub(in crate::orchestrator::daemon_retry) use phase_goal::recover_child_exit_phase_goal;
 pub(in crate::orchestrator) use retention::retry_entry_is_temporarily_blocked;
-use retention::{
+pub(in crate::orchestrator::daemon_retry) use retention::{
 	ChildExitPhaseGoalRecovery, ChildExitRetrySchedule, RetryEntryRetentionDecision,
 	child_exit_retry_retention_decision,
 };

--- a/apps/decodex/src/orchestrator/daemon_retry/child_exit.rs
+++ b/apps/decodex/src/orchestrator/daemon_retry/child_exit.rs
@@ -1,4 +1,24 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::{
+	process::ExitStatus,
+	time::Instant,
+};
+
+use serde_json::json;
+use time::OffsetDateTime;
+
+use crate::orchestrator::{
+	CONTINUATION_PENDING_RUN_STATUS, ChildExitRetryContext, ChildRunRef, IssueDispatchMode,
+	IssueTracker, LaneDecisionSnapshot, Result, RetryEntry, RetryEntryLifecycle, RetryKind,
+	RetryQueue, StateStore, WorkflowDocument, decide_lane_next_action, mark_run_attempt_if_active,
+	refresh_issue, resolve_child_exit_run_attempt, superseded_run_disposition,
+};
+use crate::orchestrator::daemon_retry::{
+	ChildExitPhaseGoalRecovery, ChildExitRetrySchedule, RetryEntryRetentionDecision,
+	child_exit_retry_budget_attempt_count, child_exit_retry_budget_limit,
+	child_exit_retry_retention_decision, clear_retry_schedule_and_release,
+	recover_child_exit_phase_goal, retry_delay, terminalize_exhausted_child_exit_retry,
+	write_retry_schedule_for_run,
+};
 
 #[allow(clippy::too_many_lines)]
 pub(crate) fn schedule_retry_after_child_exit<T>(

--- a/apps/decodex/src/orchestrator/daemon_retry/phase_goal.rs
+++ b/apps/decodex/src/orchestrator/daemon_retry/phase_goal.rs
@@ -1,5 +1,13 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use crate::{
+	orchestrator::{
+		ChildExitRetryContext, ChildRunRef, IssueDispatchMode, IssueRunPlan, IssueTracker, Result,
+		handle_failure, recover_phase_goal_continuation, run_failure_requires_terminal_attention,
+	},
+	tracker::TrackerIssue,
+};
+use crate::orchestrator::daemon_retry::{
+	ChildExitPhaseGoalRecovery, child_exit_worktree_spec, clear_retry_schedule_and_release,
+};
 
 pub(in crate::orchestrator::daemon_retry) fn recover_child_exit_phase_goal<T>(
 	context: &mut ChildExitRetryContext<'_, T>,

--- a/apps/decodex/src/orchestrator/daemon_retry/retention.rs
+++ b/apps/decodex/src/orchestrator/daemon_retry/retention.rs
@@ -1,4 +1,16 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::path::Path;
+
+use crate::{
+	orchestrator::{
+		ChildExitRetryContext, CloseoutDispatchEligibility, GhPullRequestReviewStateInspector,
+		IssueDispatchMode, IssueTracker, PhaseGoalRecoveryContinuation, Result, RetryEntry,
+		RetryEntryLifecycle, RetryIssueStateHint, RetryKind, ServiceConfig, StateStore,
+		WorkflowDocument, evaluate_closeout_dispatch_policy_with_inspector,
+		issue_has_blocking_lane_decision_evidence, issue_passes_retry_retention_policy,
+		issue_passes_review_repair_dispatch_policy, issue_retry_budget_exhausted, refresh_issue,
+	},
+	tracker::TrackerIssue,
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(in crate::orchestrator::daemon_retry) enum RetryEntryRetentionDecision {

--- a/apps/decodex/src/orchestrator/daemon_retry/schedule.rs
+++ b/apps/decodex/src/orchestrator/daemon_retry/schedule.rs
@@ -1,5 +1,12 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use std::time::Duration;
+
+use crate::{
+	orchestrator::{
+		CONTINUATION_RETRY_DELAY_MS, FAILURE_RETRY_BASE_DELAY_MS, Result, RetryKind, RetryQueue,
+		StateStore, WorkflowDocument, clear_worktree_retry_schedule,
+	},
+	state,
+};
 
 pub(crate) fn write_retry_schedule_for_run(
 	state_store: &StateStore,

--- a/apps/decodex/src/orchestrator/daemon_retry/terminal.rs
+++ b/apps/decodex/src/orchestrator/daemon_retry/terminal.rs
@@ -1,5 +1,18 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use color_eyre::Report;
+
+use crate::{
+	orchestrator::{
+		ARCHITECTURE_RECOVERY_BUDGET, ARCHITECTURE_RECOVERY_RETRY_KIND,
+		TERMINAL_GUARDED_RUN_STATUS, ChildExitRetryContext, ChildRunRef, IssueDispatchMode,
+		IssueRunPlan, IssueTracker, Result, RetainedPartialProgress, TerminalFailureWritebackRuntime,
+		WorktreeManager, WorktreeSpec, apply_terminal_failure_writeback,
+		configured_public_projection_privacy_classifier, relative_worktree_path,
+		worktree_has_tracked_changes, write_retry_budget_marker, write_terminal_guard_marker,
+	},
+	state,
+	tracker::TrackerIssue,
+};
+use crate::orchestrator::daemon_retry::clear_retry_schedule_and_release;
 
 pub(in crate::orchestrator::daemon_retry) fn child_exit_retry_budget_attempt_count<T>(
 	context: &ChildExitRetryContext<'_, T>,

--- a/apps/decodex/src/orchestrator/execution.rs
+++ b/apps/decodex/src/orchestrator/execution.rs
@@ -5,22 +5,29 @@ mod context;
 mod credentials;
 mod summary;
 
+use std::path::Path;
+
 #[cfg(test)]
 pub(crate) use self::completion::{push_retained_review_repair_head, run_completion_repo_gate};
 pub(crate) use self::summary::{planned_issue_state_for_dispatch, run_summary_from_issue_run};
-use crate::tracker;
 pub(crate) use context::write_run_operation_marker_best_effort;
 #[cfg(test)]
 pub(crate) use credentials::AgentGitCredentialEnvironment;
 pub(crate) use credentials::prepare_agent_git_credentials;
-
-use crate::orchestrator::{agent, git_credentials, IssueTracker, ServiceConfig, WorkflowDocument, StateStore, IssueRunPlan, TrackerToolBridge, AppServerProcessEnv, AppServerRunResult, ReviewHandoffContext, TurnContinuationGuard, DecodexToolBridge, PhaseGoalController, RunSummary, Result, AppServerRunRequest, RUN_LEASE_IDLE_TIMEOUT, maybe_continue_after_phase_goal_recovery, preserve_and_promote_app_server_run_failure, PullRequestReviewStateInspector, IssueTurnContinuationGuard, archive_completed_issue_threads_best_effort, build_continuation_user_input, Report, IssueDispatchMode, execute_deterministic_closeout, PhaseGoalKind, select_repo_gate_for_worktree, RUN_OPERATION_REPO_GATE, run_repo_gate_commands, RepoGateFailure, RepoGateTrackedRewriteDecision, LaneDecisionSnapshot, decide_lane_next_action, RUN_OPERATION_REVIEW_WRITEBACK, resolve_configured_env_var, RetainedReviewRepairPushFailed, RetainedReviewRepairPushFailureKind, GitCredentialSource, Command, repo_gate_output_text, RunCompletionDisposition, validate_review_handoff_runtime, ReviewHandoffWritebackFailed, ReviewHandoffNeedsAttention, record_harness_outcome_best_effort, HarnessOutcomeKind, ManualAttentionRequested, validate_review_repair_runtime, worktree_head_oid, cleanup_completed_post_review_lane, write_cleanup_complete_lifecycle_event, build_developer_instructions, build_user_input, DecodexRunContext, RUN_OPERATION_GIT_CREDENTIALS, Path, state, AgentGitCredentialsUnavailable, TrackerIssue, relative_worktree_path, ensure_automation_activity_label, reconcile_terminal_thread_archive_backlog_best_effort, handle_failure, CONTINUATION_PENDING_RUN_STATUS, GhPullRequestReviewStateInspector, build_review_run_context, build_phase_goal_controller};
-
-use agent::{CodexAccountPool, CodexAccountProvider};
+use crate::{
+	agent::{CodexAccountPool, CodexAccountProvider},
+	orchestrator::{
+		CONTINUATION_PENDING_RUN_STATUS, DecodexToolBridge, GhPullRequestReviewStateInspector,
+		IssueRunPlan, IssueTracker, Result, RunSummary, ServiceConfig, StateStore,
+		TrackerToolBridge, WorkflowDocument, build_phase_goal_controller, build_review_run_context,
+		ensure_automation_activity_label, handle_failure, reconcile_terminal_thread_archive_backlog_best_effort,
+		relative_worktree_path,
+	},
+	state, tracker,
+};
 
 use self::{
 	app_server::{CompletedAppServerRun, IssueAppServerRun, IssueAppServerRunOutcome},
-	completion::apply_run_completion_disposition,
 };
 
 pub(in crate::orchestrator) fn execute_issue_run<T>(

--- a/apps/decodex/src/orchestrator/execution/app_server.rs
+++ b/apps/decodex/src/orchestrator/execution/app_server.rs
@@ -1,7 +1,23 @@
-use crate::agent;
-use crate::orchestrator::execution::context::{self};
-#[allow(clippy::wildcard_imports)]
-use crate::orchestrator::execution::*;
+use color_eyre::Report;
+
+use crate::{
+	agent::{
+		self, AppServerProcessEnv, AppServerRunRequest, AppServerRunResult, CodexAccountProvider,
+	},
+	orchestrator::{
+		DecodexToolBridge, IssueRunPlan, IssueTracker, IssueTurnContinuationGuard,
+		PhaseGoalController, PullRequestReviewStateInspector, Result, ReviewHandoffContext,
+		RUN_LEASE_IDLE_TIMEOUT, RunSummary, ServiceConfig, StateStore, TrackerToolBridge,
+		TurnContinuationGuard, WorkflowDocument, archive_completed_issue_threads_best_effort,
+		build_continuation_user_input, maybe_continue_after_phase_goal_recovery,
+		preserve_and_promote_app_server_run_failure, resolve_resume_thread_id,
+		run_summary_from_issue_run,
+	},
+	orchestrator::execution::{
+		completion::apply_run_completion_disposition,
+		context,
+	},
+};
 
 pub(super) struct CompletedAppServerRun<'a, T>
 where

--- a/apps/decodex/src/orchestrator/execution/closeout.rs
+++ b/apps/decodex/src/orchestrator/execution/closeout.rs
@@ -1,4 +1,8 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use crate::orchestrator::{
+	IssueDispatchMode, IssueRunPlan, IssueTracker, Result, ReviewHandoffContext, RunSummary,
+	ServiceConfig, StateStore, TrackerToolBridge, WorkflowDocument, execute_deterministic_closeout,
+	run_summary_from_issue_run,
+};
 
 pub(super) fn maybe_execute_deterministic_closeout<T>(
 	tracker: &T,

--- a/apps/decodex/src/orchestrator/execution/completion.rs
+++ b/apps/decodex/src/orchestrator/execution/completion.rs
@@ -1,4 +1,23 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::process::Command;
+
+use color_eyre::Report;
+
+use crate::{
+	git_credentials::GitCredentialSource,
+	orchestrator::{
+		HarnessOutcomeKind, IssueRunPlan, IssueTracker, LaneDecisionSnapshot,
+		ManualAttentionRequested, PhaseGoalKind, RUN_OPERATION_REPO_GATE,
+		RUN_OPERATION_REVIEW_WRITEBACK, RepoGateFailure, RepoGateTrackedRewriteDecision, Result,
+		RetainedReviewRepairPushFailed, RetainedReviewRepairPushFailureKind,
+		ReviewHandoffNeedsAttention, ReviewHandoffWritebackFailed, RunCompletionDisposition,
+		ServiceConfig, StateStore, TrackerToolBridge, WorkflowDocument,
+		cleanup_completed_post_review_lane, decide_lane_next_action,
+		record_harness_outcome_best_effort, repo_gate_output_text, resolve_configured_env_var,
+		run_repo_gate_commands, select_repo_gate_for_worktree, validate_review_handoff_runtime,
+		validate_review_repair_runtime, worktree_head_oid, write_cleanup_complete_lifecycle_event,
+		write_run_operation_marker_best_effort,
+	},
+};
 
 pub(crate) fn run_completion_repo_gate(
 	project: &ServiceConfig,

--- a/apps/decodex/src/orchestrator/execution/context.rs
+++ b/apps/decodex/src/orchestrator/execution/context.rs
@@ -1,4 +1,13 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::path::Path;
+
+use crate::{
+	orchestrator::{
+		DecodexRunContext, IssueRunPlan, IssueTracker, Result, ReviewHandoffContext,
+		RUN_OPERATION_GIT_CREDENTIALS, ServiceConfig, StateStore, WorkflowDocument,
+		build_developer_instructions, build_user_input,
+	},
+	state,
+};
 
 pub(super) fn build_run_developer_instructions<T>(
 	tracker: &T,

--- a/apps/decodex/src/orchestrator/execution/credentials.rs
+++ b/apps/decodex/src/orchestrator/execution/credentials.rs
@@ -1,7 +1,12 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::path::Path;
 
-use agent::AppServerProcessEnv;
-use git_credentials::GitSigningConfig;
+use color_eyre::Report;
+
+use crate::{
+	agent::AppServerProcessEnv,
+	git_credentials::GitSigningConfig,
+	orchestrator::{AgentGitCredentialsUnavailable, Result, ServiceConfig},
+};
 
 pub(crate) struct AgentGitCredentialEnvironment {
 	process_env: AppServerProcessEnv,

--- a/apps/decodex/src/orchestrator/execution/summary.rs
+++ b/apps/decodex/src/orchestrator/execution/summary.rs
@@ -1,4 +1,10 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use crate::{
+	agent::AppServerRunResult,
+	config::ServiceConfig,
+	orchestrator::{IssueDispatchMode, IssueRunPlan, RunSummary},
+	tracker::TrackerIssue,
+	workflow::WorkflowDocument,
+};
 
 pub(crate) fn run_summary_from_issue_run(project_id: &str, issue_run: &IssueRunPlan) -> RunSummary {
 	RunSummary {


### PR DESCRIPTION
## Summary
- replace wildcard clippy allowances in orchestrator execution modules with explicit imports
- replace wildcard clippy allowances in daemon retry modules with explicit imports
- remove parent-module import plumbing that only existed to support wildcard child imports

## Validation
- cargo check -p decodex --lib --tests
- cargo clippy -p decodex --lib --tests --all-features -- -D warnings
- cargo test -p decodex execution --lib -- --format terse
- cargo test -p decodex daemon --lib -- --format terse
- git diff --check
- scoped structural scan for wildcard/import allow/include/path/mod.rs violations

## Vstyle
- cargo vstyle curate --language rust -p decodex --all-features still fails on existing package-wide style debt. This PR does not add mod.rs/include/path modules or clippy wildcard allow workarounds.