### PR TITLE
Clean daemon and reconciliation imports

### DIFF
--- a/apps/decodex/src/orchestrator.rs
+++ b/apps/decodex/src/orchestrator.rs
@@ -304,8 +304,6 @@ pub(crate) use types::{
 	record_authority_boundary_check_private_event, record_authority_decision_request_private_event,
 };
 
-#[cfg(unix)]
-use std::os::fd::AsRawFd;
 use std::{
 	cmp::Ordering,
 	collections::{BTreeSet, HashMap, HashSet},
@@ -313,10 +311,10 @@ use std::{
 	error::Error,
 	fmt::{self, Display, Formatter},
 	fs::{self, File},
-	io::{ErrorKind, Write},
+	io::ErrorKind,
 	net::{SocketAddr, TcpListener},
 	path::{Path, PathBuf},
-	process::{Child, Command, Stdio},
+	process::{Child, Command},
 	slice,
 	sync::{
 		Arc, Mutex,
@@ -409,7 +407,7 @@ pub(in crate::orchestrator) use self::{
 	},
 };
 use crate::{
-	agent::{self, CodexAccountAuthFailure, CodexAccountPool, REVIEW_POLICY_CONVERGENCE_BUDGET},
+	agent::{CodexAccountAuthFailure, CodexAccountPool, REVIEW_POLICY_CONVERGENCE_BUDGET},
 	runtime, state,
 	state::PrivateExecutionEvent,
 	tracker::{self, privacy_classifier::PublicProjectionPrivacyClassifier},

--- a/apps/decodex/src/orchestrator/daemon.rs
+++ b/apps/decodex/src/orchestrator/daemon.rs
@@ -1,4 +1,22 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::path::Path;
+
+use crate::{
+	config::ServiceConfig,
+	orchestrator::{
+		AccountActivityMode, CachedWorkflowDocument, DaemonRunChild, DaemonTickContext,
+		GhPullRequestReviewStateInspector, IssueTracker, OperatorConnectorBackoffStatus,
+		OperatorStatusSnapshot, PullRequestReviewStateInspector, RecoverableWorktreeSkipCache,
+		Result, RetryQueue, StateStore, WorkflowDocument, WorktreeManager,
+		add_operator_snapshot_warning, apply_terminal_history_ledger_outcomes,
+		build_control_plane_operator_status_snapshot, build_degraded_post_review_lane_statuses,
+		build_operator_status_snapshot_with_account_mode,
+		hydrate_history_lanes_from_local_ledger, reconcile_post_review_orchestration_with_inspector,
+		reconcile_project_state, reconcile_terminal_thread_archive_backlog_best_effort,
+		recover_runtime_state_from_tracker_and_worktrees_with_skip_cache,
+		refresh_operator_project_summary, warnings_include_tracker_backoff,
+	},
+	tracker::linear::LinearClient,
+};
 
 mod active_children;
 mod retry_dispatch;
@@ -19,12 +37,6 @@ use spawn::spawn_next_daemon_child;
 #[cfg(test)]
 pub(crate) use spawn::{
 	materialize_daemon_spawn_state, materialize_run_summary_worktree, plan_next_daemon_run,
-};
-
-use crate::cli::AttemptRequest;
-use daemon_retry::{
-	clear_retry_schedule_and_release, retry_entry_is_temporarily_blocked,
-	schedule_retry_after_child_exit,
 };
 
 pub(crate) struct DaemonTickRuntimeContext<'a, T, I> {

--- a/apps/decodex/src/orchestrator/daemon/active_children.rs
+++ b/apps/decodex/src/orchestrator/daemon/active_children.rs
@@ -1,4 +1,18 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::process::Child;
+
+use time::OffsetDateTime;
+
+use crate::orchestrator::{
+	ActiveWorkflowOverride, ChildExitRetryContext, ChildRunRef, CurrentChildRunContext,
+	DaemonRunChild, IssueDispatchMode, IssueTracker, Result, RetryQueue, RunAttempt,
+	RunLeaseDisposition, RunLeaseReconciliation, ServiceConfig, StateStore, WorkflowDocument,
+	WorktreeManager, apply_run_lease_reconciliation, inspect_exited_daemon_child_reconciliation,
+	is_issue_not_dispatchable_for_current_dispatch, is_terminal_issue, mark_run_attempt_if_active,
+	refresh_issue, retained_review_handoff_matches_run, run_lease_reconciliation_workflow,
+	stalled_idle_duration, stalled_run_has_retained_partial_progress,
+	superseded_run_disposition, terminal_issue_keeps_retained_closeout,
+};
+use crate::orchestrator::daemon_retry::schedule_retry_after_child_exit;
 
 pub(crate) fn inspect_or_clear_active_children<T>(
 	active_children: &mut Vec<DaemonRunChild>,

--- a/apps/decodex/src/orchestrator/daemon/retry_dispatch.rs
+++ b/apps/decodex/src/orchestrator/daemon/retry_dispatch.rs
@@ -1,4 +1,12 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::time::Instant;
+
+use crate::orchestrator::{
+	IssueDispatchMode, IssueTracker, Result, RetryDispatchDecision, RetryKind, RetryQueue,
+	ServiceConfig, StateStore, TargetIssueRunContext, WorkflowDocument, run_target_issue_once,
+};
+use crate::orchestrator::daemon_retry::{
+	clear_retry_schedule_and_release, retry_entry_is_temporarily_blocked,
+};
 
 pub(crate) fn plan_due_retry_run<T>(
 	retry_queue: &mut RetryQueue,

--- a/apps/decodex/src/orchestrator/daemon/spawn.rs
+++ b/apps/decodex/src/orchestrator/daemon/spawn.rs
@@ -1,4 +1,28 @@
-#[allow(clippy::wildcard_imports)] use super::*;
+use std::{
+	env,
+	io::Write,
+	path::Path,
+	process::{Child, Command, Stdio},
+};
+
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+
+use crate::{
+	cli::AttemptRequest,
+	orchestrator::{
+		DaemonRunChild, IssueDispatchMode, IssueTracker, MaterializedDaemonSpawnState,
+		PullRequestReviewStateInspector, Result, RetryDispatchDecision, RetryQueue,
+		RUN_OPERATION_AGENT_RUN, RunSummary, ServiceConfig, SpawnRunOnceChildRequest, StateStore,
+		WorkflowDocument, WorktreeManager, WorktreeSpec,
+		ensure_project_has_no_merged_worktree_cleanup_debt, plan_project_issue_run_with_exclusions,
+		retry_budget_base_for_dispatch_mode, run_summary_from_issue_run, validate_workflow_read_first_files,
+	},
+	prelude::eyre,
+	state,
+};
+
+use crate::orchestrator::daemon::{DaemonTickRuntimeContext, plan_due_retry_run};
 
 pub(super) fn spawn_next_daemon_child<T>(
 	config_path: &Path,

--- a/apps/decodex/src/orchestrator/reconciliation.rs
+++ b/apps/decodex/src/orchestrator/reconciliation.rs
@@ -1,5 +1,21 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+#[cfg(test)]
+use std::collections::HashMap;
+
+use time::OffsetDateTime;
+
+use crate::{
+	orchestrator::{
+		ActiveWorkflowOverride, IssueTracker, Result, RunAttempt, RunLeaseDisposition,
+		RunLeaseReconciliation, ServiceConfig, StateStore, TrackerIssue, WorkflowDocument,
+		WorktreeManager, cleanup_worktree_mapping, is_issue_in_progress_for_run,
+		mark_run_attempt_if_active, refresh_issue,
+	},
+	tracker,
+};
+#[cfg(test)]
+use crate::orchestrator::{
+	dispatch_policy, is_terminal_issue, terminal_issue_keeps_retained_closeout,
+};
 
 mod actions;
 mod idle;

--- a/apps/decodex/src/orchestrator/reconciliation/actions.rs
+++ b/apps/decodex/src/orchestrator/reconciliation/actions.rs
@@ -1,5 +1,7 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use crate::orchestrator::{
+	Result, RunLeaseReconciliation, ServiceConfig, StateStore, WorktreeManager,
+	mark_run_attempt_if_active, retry_budget_base_for_issue_worktree, write_retry_budget_marker,
+};
 
 pub(in crate::orchestrator::reconciliation) fn reconcile_superseded_run_lease(
 	project: &ServiceConfig,

--- a/apps/decodex/src/orchestrator/reconciliation/idle.rs
+++ b/apps/decodex/src/orchestrator/reconciliation/idle.rs
@@ -1,5 +1,13 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use std::time::Duration;
+
+use crate::{
+	agent,
+	orchestrator::{
+		RUN_LEASE_IDLE_TIMEOUT, RUN_OPERATION_REPO_GATE, Result, RunActivityMarker, RunAttempt,
+		StateStore, WorktreeMapping, marker_process_is_alive,
+	},
+	state,
+};
 
 pub(in crate::orchestrator) fn stalled_idle_duration(
 	state_store: &StateStore,

--- a/apps/decodex/src/orchestrator/reconciliation/stalled.rs
+++ b/apps/decodex/src/orchestrator/reconciliation/stalled.rs
@@ -1,5 +1,25 @@
-#[allow(clippy::wildcard_imports)]
-use super::*;
+use std::{
+	path::Path,
+	time::Duration,
+};
+
+use color_eyre::Report;
+use time::OffsetDateTime;
+
+use crate::{
+	orchestrator::{
+		CONTINUATION_PENDING_RUN_STATUS, IssueDispatchMode, IssueRunPlan, IssueTracker,
+		RetainedPartialProgress, RetryKind, RunAttempt, RunLeaseDisposition,
+		RunLeaseReconciliation, RUN_OPERATION_RECONCILIATION, Result, ServiceConfig, StateStore,
+		StalledRunNeedsAttention, WorkflowDocument, WorktreeManager, WorktreeMapping,
+		WorktreeSpec, handle_failure, planned_issue_state_for_dispatch,
+		recover_phase_goal_continuation, relative_worktree_path,
+		retry_budget_base_for_issue_worktree, retry_delay, run_failure_requires_terminal_attention,
+		worktree_has_tracked_changes, write_retry_schedule_for_run,
+	},
+	state,
+	tracker::TrackerIssue,
+};
 
 pub(in crate::orchestrator::reconciliation) fn reconcile_stalled_run_lease<T>(
 	tracker: &T,


### PR DESCRIPTION
## Summary
- replace wildcard clippy allowances in orchestrator daemon modules with explicit imports
- replace wildcard clippy allowances in run-lease reconciliation modules with explicit imports
- remove parent-module imports that became unused after normal module boundary cleanup

## Validation
- cargo check -p decodex --lib --tests
- cargo clippy -p decodex --lib --tests --all-features -- -D warnings
- cargo test -p decodex daemon --lib -- --format terse
- cargo test -p decodex reconciliation --lib -- --format terse
- git diff --check
- scoped structural scan for wildcard/import allow/include/path/mod.rs violations

## Vstyle
- cargo vstyle curate --language rust -p decodex --all-features still fails on existing package-wide style debt. This PR does not add mod.rs/include/path modules or clippy wildcard allow workarounds.