### PR TITLE
Remove tracker bridge test includes

### DIFF
--- a/apps/decodex/src/agent/tracker_tool_bridge/tests.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests.rs
@@ -1,3 +1,5 @@
+mod mutation;
+mod review;
 mod review_policy;
 
 use std::{
@@ -5,9 +7,7 @@ use std::{
 	collections::HashMap,
 	env,
 	ffi::OsString,
-	fs,
 	path::{Path, PathBuf},
-	process,
 };
 
 use serde_json::Value;
@@ -16,14 +16,12 @@ use tempfile::TempDir;
 use crate::{
 	agent::tracker_tool_bridge::{
 		DynamicToolContentItem, DynamicToolHandler, ISSUE_COMMENT_TOOL_NAME,
-		ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME, ISSUE_LABEL_ADD_TOOL_NAME,
-		ISSUE_PROGRESS_CHECKPOINT_TOOL_NAME, ISSUE_REVIEW_CHECKPOINT_TOOL_NAME,
-		ISSUE_REVIEW_HANDOFF_TOOL_NAME, ISSUE_REVIEW_REPAIR_COMPLETE_TOOL_NAME,
-		ISSUE_TERMINAL_FINALIZE_TOOL_NAME, ISSUE_TRANSITION_TOOL_NAME, LocalRepoDetails,
-		LocalRepoInspector, PullRequestDetails, PullRequestInspector, ReviewExecutionMode,
-		ReviewHandoffContext, ReviewHandoffWritebackFailed, ReviewPolicyStopReason,
-		ReviewPolicyStopRequested, RunCompletionDisposition, TrackerToolBridge,
-		TurnCompletionStatus,
+		ISSUE_LABEL_ADD_TOOL_NAME, ISSUE_PROGRESS_CHECKPOINT_TOOL_NAME,
+		ISSUE_REVIEW_CHECKPOINT_TOOL_NAME, ISSUE_REVIEW_HANDOFF_TOOL_NAME,
+		ISSUE_REVIEW_REPAIR_COMPLETE_TOOL_NAME, ISSUE_TERMINAL_FINALIZE_TOOL_NAME,
+		ISSUE_TRANSITION_TOOL_NAME, LocalRepoDetails, LocalRepoInspector, PullRequestDetails,
+		PullRequestInspector, ReviewExecutionMode, ReviewHandoffContext, ReviewPolicyStopReason,
+		ReviewPolicyStopRequested, TrackerToolBridge, TurnCompletionStatus,
 	},
 	config::ReviewLevel,
 	prelude::eyre,
@@ -33,21 +31,9 @@ use crate::{
 	},
 	tracker::{
 		IssueTracker, TrackerComment, TrackerIssue, TrackerLabel, TrackerState, TrackerTeam,
-		privacy_classifier::{
-			PublicProjectionPrivacyClassification, PublicProjectionPrivacyClassifier,
-		},
-		records,
 	},
 	workflow::WorkflowDocument,
 };
-
-// Tracker mutation policy for active execution turns.
-include!("tests/mutation/dispatch.rs");
-include!("tests/mutation/continuation.rs");
-include!("tests/mutation/progress.rs");
-
-// Review handoff, repair, closeout, and Decodex Review policy.
-include!("tests/review/handoff.rs");
 
 const TEST_SERVICE_ID: &str = "pubfi";
 
@@ -552,6 +538,29 @@ fn sample_local_repo() -> LocalRepoDetails {
 		repository_owner: String::from("hack-ink"),
 		review_blocking_changes: Vec::new(),
 	}
+}
+
+fn seed_docs_impact_checkpoint(
+	state_store: &StateStore,
+	review_context: &ReviewHandoffContext,
+	issue_id: &str,
+	phase: &str,
+	head_sha: &str,
+) {
+	state_store
+		.append_private_execution_event(
+			&review_context.service_id,
+			issue_id,
+			&review_context.run_id,
+			review_context.attempt_number,
+			"progress_checkpoint",
+			serde_json::json!({
+				"phase": phase,
+				"docs_impact": "none",
+				"head_sha": head_sha
+			}),
+		)
+		.expect("docs impact checkpoint should seed");
 }
 
 fn write_review_policy_checkpoint(

--- a/apps/decodex/src/agent/tracker_tool_bridge/tests/mutation.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests/mutation.rs
@@ -1,0 +1,3 @@
+mod continuation;
+mod dispatch;
+mod progress;

--- a/apps/decodex/src/agent/tracker_tool_bridge/tests/mutation/continuation.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests/mutation/continuation.rs
@@ -1,15 +1,31 @@
+use tempfile::TempDir;
+
+use crate::agent::tracker_tool_bridge::tests::{
+	self, FakeLocalRepoInspector, FakePullRequestInspector, FakeTracker,
+};
+use crate::{
+	agent::tracker_tool_bridge::{
+		DynamicToolContentItem, DynamicToolHandler, ISSUE_COMMENT_TOOL_NAME,
+		ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME, ISSUE_LABEL_ADD_TOOL_NAME,
+		ISSUE_REVIEW_HANDOFF_TOOL_NAME, ISSUE_TERMINAL_FINALIZE_TOOL_NAME,
+		ISSUE_TRANSITION_TOOL_NAME, PullRequestDetails, RunCompletionDisposition,
+		TrackerToolBridge, TurnCompletionStatus,
+	},
+	tracker::{TrackerLabel, TrackerState, records},
+};
+
 #[test]
 fn completion_disposition_allows_manual_attention_exit_without_review_handoff() {
-	let issue = sample_issue();
-	let tracker = tracker_with_current_issue_snapshot(&issue);
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let tracker = tests::tracker_with_current_issue_snapshot(&issue);
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(Vec::new());
 	let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context(),
+		tests::sample_review_context(),
 		&inspector,
 		&local_repo_inspector,
 	);
@@ -21,13 +37,14 @@ fn completion_disposition_allows_manual_attention_exit_without_review_handoff() 
 	let comment_response = DynamicToolHandler::handle_call(
 		&bridge,
 		ISSUE_COMMENT_TOOL_NAME,
-		manual_attention_comment_args(),
+		tests::manual_attention_comment_args(),
 	);
 
 	assert!(response.success);
 	assert!(comment_response.success);
 
-	let comment = tracker.comments.borrow().first().expect("manual attention comment should write").clone();
+	let comment =
+		tracker.comments.borrow().first().expect("manual attention comment should write").clone();
 	let record = records::parse_linear_execution_event_record(&comment)
 		.expect("manual attention comment should include a ledger record");
 
@@ -43,15 +60,15 @@ fn completion_disposition_allows_manual_attention_exit_without_review_handoff() 
 #[test]
 fn turn_completion_rejects_xy_156_shape_without_terminal_tracker_action() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(Vec::new());
 	let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context(),
+		tests::sample_review_context(),
 		&inspector,
 		&local_repo_inspector,
 	);
@@ -67,15 +84,15 @@ fn turn_completion_rejects_xy_156_shape_without_terminal_tracker_action() {
 #[test]
 fn turn_classification_allows_continuation_without_terminal_tracker_action() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(Vec::new());
 	let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context(),
+		tests::sample_review_context(),
 		&inspector,
 		&local_repo_inspector,
 	);
@@ -94,11 +111,11 @@ fn turn_classification_allows_continuation_without_terminal_tracker_action() {
 fn turn_classification_rejects_clean_closeout_continuation() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let pr_url = "https://github.com/hack-ink/decodex/pull/260";
 	let merged_pull_request = {
-		let mut pull_request = sample_pull_request();
+		let mut pull_request = tests::sample_pull_request();
 
 		pull_request.url = String::from(pr_url);
 		pull_request.state = String::from("MERGED");
@@ -106,12 +123,12 @@ fn turn_classification_rejects_clean_closeout_continuation() {
 		pull_request
 	};
 	let inspector = FakePullRequestInspector::new(vec![Ok(merged_pull_request)]);
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_closeout_context_in(temp_dir.path(), pr_url),
+		tests::sample_closeout_context_in(temp_dir.path(), pr_url),
 		&inspector,
 		&local_repo_inspector,
 	);
@@ -132,7 +149,7 @@ fn turn_classification_rejects_continuation_blocking_writes_without_terminal_pat
 		(ISSUE_LABEL_ADD_TOOL_NAME, serde_json::json!({ "label": "decodex:manual-only" })),
 		(ISSUE_TRANSITION_TOOL_NAME, serde_json::json!({ "state": "Todo" })),
 	] {
-		let mut refreshed_issue = sample_issue();
+		let mut refreshed_issue = tests::sample_issue();
 
 		if tool_name == ISSUE_LABEL_ADD_TOOL_NAME {
 			refreshed_issue.labels.push(TrackerLabel {
@@ -145,15 +162,15 @@ fn turn_classification_rejects_continuation_blocking_writes_without_terminal_pat
 		}
 
 		let tracker = FakeTracker::with_refresh_snapshots(vec![vec![refreshed_issue]]);
-		let issue = sample_issue();
-		let workflow = sample_workflow();
+		let issue = tests::sample_issue();
+		let workflow = tests::sample_workflow();
 		let inspector = FakePullRequestInspector::new(Vec::new());
 		let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 		let bridge = TrackerToolBridge::with_review_handoff_for_test(
 			&tracker,
 			&issue,
 			&workflow,
-			sample_review_context(),
+			tests::sample_review_context(),
 			&inspector,
 			&local_repo_inspector,
 		);
@@ -178,17 +195,17 @@ fn turn_classification_rejects_continuation_blocking_writes_for_stale_active_ref
 		(ISSUE_LABEL_ADD_TOOL_NAME, serde_json::json!({ "label": "decodex:manual-only" })),
 		(ISSUE_TRANSITION_TOOL_NAME, serde_json::json!({ "state": "Todo" })),
 	] {
-		let active_issue = sample_in_progress_issue();
+		let active_issue = tests::sample_in_progress_issue();
 		let tracker = FakeTracker::with_refresh_snapshots(vec![vec![active_issue]]);
-		let issue = sample_in_progress_issue();
-		let workflow = sample_workflow();
+		let issue = tests::sample_in_progress_issue();
+		let workflow = tests::sample_workflow();
 		let inspector = FakePullRequestInspector::new(Vec::new());
 		let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 		let bridge = TrackerToolBridge::with_review_handoff_for_test(
 			&tracker,
 			&issue,
 			&workflow,
-			sample_review_context(),
+			tests::sample_review_context(),
 			&inspector,
 			&local_repo_inspector,
 		);
@@ -213,7 +230,7 @@ fn turn_classification_allows_continuation_blocking_writes_after_reactivation() 
 		(ISSUE_LABEL_ADD_TOOL_NAME, serde_json::json!({ "label": "decodex:manual-only" })),
 		(ISSUE_TRANSITION_TOOL_NAME, serde_json::json!({ "state": "Todo" })),
 	] {
-		let mut reactivated_issue = sample_issue();
+		let mut reactivated_issue = tests::sample_issue();
 
 		reactivated_issue.state =
 			TrackerState { id: String::from("state-progress"), name: String::from("In Progress") };
@@ -222,15 +239,15 @@ fn turn_classification_allows_continuation_blocking_writes_after_reactivation() 
 			vec![reactivated_issue.clone()],
 			vec![reactivated_issue],
 		]);
-		let issue = sample_issue();
-		let workflow = sample_workflow();
+		let issue = tests::sample_issue();
+		let workflow = tests::sample_workflow();
 		let inspector = FakePullRequestInspector::new(Vec::new());
 		let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 		let bridge = TrackerToolBridge::with_review_handoff_for_test(
 			&tracker,
 			&issue,
 			&workflow,
-			sample_review_context(),
+			tests::sample_review_context(),
 			&inspector,
 			&local_repo_inspector,
 		);
@@ -250,16 +267,16 @@ fn turn_classification_allows_continuation_blocking_writes_after_reactivation() 
 
 #[test]
 fn manual_attention_requires_explanatory_comment() {
-	let issue = sample_issue();
-	let tracker = tracker_with_current_issue_snapshot(&issue);
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let tracker = tests::tracker_with_current_issue_snapshot(&issue);
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(Vec::new());
 	let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context(),
+		tests::sample_review_context(),
 		&inspector,
 		&local_repo_inspector,
 	);
@@ -285,15 +302,15 @@ fn manual_attention_requires_explanatory_comment() {
 #[test]
 fn failed_needs_attention_label_update_does_not_record_manual_attention() {
 	let tracker = FakeTracker::with_label_update_error("tracker labels unavailable");
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(Vec::new());
 	let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context(),
+		tests::sample_review_context(),
 		&inspector,
 		&local_repo_inspector,
 	);
@@ -305,7 +322,7 @@ fn failed_needs_attention_label_update_does_not_record_manual_attention() {
 	let comment_response = DynamicToolHandler::handle_call(
 		&bridge,
 		ISSUE_COMMENT_TOOL_NAME,
-		manual_attention_comment_args(),
+		tests::manual_attention_comment_args(),
 	);
 
 	assert!(response.success);
@@ -323,7 +340,7 @@ fn failed_needs_attention_label_update_does_not_record_manual_attention() {
 
 #[test]
 fn opt_out_label_add_uses_refreshed_issue_snapshot_for_label_ids() {
-	let initial_issue = sample_issue();
+	let initial_issue = tests::sample_issue();
 	let mut refreshed_issue = initial_issue.clone();
 
 	refreshed_issue.labels.push(TrackerLabel {
@@ -332,7 +349,7 @@ fn opt_out_label_add_uses_refreshed_issue_snapshot_for_label_ids() {
 	});
 
 	let tracker = FakeTracker::with_refresh_snapshots(vec![vec![refreshed_issue]]);
-	let workflow = sample_workflow();
+	let workflow = tests::sample_workflow();
 	let bridge = TrackerToolBridge::new(&tracker, &initial_issue, &workflow);
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -347,8 +364,8 @@ fn opt_out_label_add_uses_refreshed_issue_snapshot_for_label_ids() {
 #[test]
 fn label_add_fails_when_refresh_returns_no_snapshot() {
 	let tracker = FakeTracker::with_refresh_snapshots(vec![Vec::new()]);
-	let workflow = sample_workflow();
-	let issue = sample_issue();
+	let workflow = tests::sample_workflow();
+	let issue = tests::sample_issue();
 	let bridge = TrackerToolBridge::new(&tracker, &issue, &workflow);
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -372,7 +389,7 @@ fn label_add_fails_when_refresh_returns_no_snapshot() {
 
 #[test]
 fn turn_classification_rejects_continuation_blocking_write_when_refresh_returns_no_snapshot() {
-	let mut opted_out_issue = sample_issue();
+	let mut opted_out_issue = tests::sample_issue();
 
 	opted_out_issue.labels.push(TrackerLabel {
 		id: String::from("label-manual"),
@@ -380,15 +397,15 @@ fn turn_classification_rejects_continuation_blocking_write_when_refresh_returns_
 	});
 
 	let tracker = FakeTracker::with_refresh_snapshots(vec![vec![opted_out_issue], Vec::new()]);
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(Vec::new());
 	let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context(),
+		tests::sample_review_context(),
 		&inspector,
 		&local_repo_inspector,
 	);
@@ -413,9 +430,9 @@ fn turn_classification_rejects_continuation_blocking_write_when_refresh_returns_
 #[test]
 fn completion_disposition_rejects_conflicting_review_handoff_and_manual_attention() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
-	let issue = sample_issue();
-	let tracker = tracker_with_current_issue_snapshot(&issue);
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let tracker = tests::tracker_with_current_issue_snapshot(&issue);
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(vec![Ok(PullRequestDetails {
 		head_ref_name: String::from("x/decodex-pub-618"),
 		head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
@@ -426,8 +443,8 @@ fn completion_disposition_rejects_conflicting_review_handoff_and_manual_attentio
 		base_ref_name: String::from("main"),
 		url: String::from("https://github.com/hack-ink/decodex/pull/48"),
 	})]);
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -437,7 +454,7 @@ fn completion_disposition_rejects_conflicting_review_handoff_and_manual_attentio
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let review_response = DynamicToolHandler::handle_call(
 		&bridge,

--- a/apps/decodex/src/agent/tracker_tool_bridge/tests/mutation/dispatch.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests/mutation/dispatch.rs
@@ -1,38 +1,34 @@
-use records::CLOSEOUT_RECORD_TYPE;
-use records::CloseoutRecord;
+use std::process;
 
-use crate::tracker::{self, public_text};
-use crate::orchestrator::{self, AuthorityBoundaryPolicyDecision};
-use crate::orchestrator::AuthorityBoundaryCheckInput;
-use crate::orchestrator::AuthorityBoundaryDisposition;
+use tempfile::TempDir;
 
-fn seed_docs_impact_checkpoint(
-	state_store: &StateStore,
-	review_context: &ReviewHandoffContext,
-	issue_id: &str,
-	phase: &str,
-	head_sha: &str,
-) {
-	state_store
-		.append_private_execution_event(
-			&review_context.service_id,
-			issue_id,
-			&review_context.run_id,
-			review_context.attempt_number,
-			"progress_checkpoint",
-			serde_json::json!({
-				"phase": phase,
-				"docs_impact": "none",
-				"head_sha": head_sha
-			}),
-		)
-		.expect("docs impact checkpoint should seed");
-}
+use crate::agent::tracker_tool_bridge::tests::{
+	self, FakeLocalRepoInspector, FakePullRequestInspector, FakeTracker,
+	GitHubTokenAssertingPullRequestInspector, TEST_SERVICE_ID, TestEnvVarGuard,
+};
+use crate::{
+	agent::tracker_tool_bridge::{
+		DynamicToolContentItem, DynamicToolHandler, ISSUE_COMMENT_TOOL_NAME,
+		ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME, ISSUE_LABEL_ADD_TOOL_NAME,
+		ISSUE_REVIEW_HANDOFF_TOOL_NAME, ISSUE_TERMINAL_FINALIZE_TOOL_NAME,
+		ISSUE_TRANSITION_TOOL_NAME, TrackerToolBridge,
+	},
+	orchestrator::{
+		self, AuthorityBoundaryCheckInput, AuthorityBoundaryDisposition,
+		AuthorityBoundaryPolicyDecision,
+	},
+	state::StateStore,
+	tracker::{
+		self, TrackerComment, TrackerIssue, TrackerLabel, TrackerState, public_text,
+		records::{self, CLOSEOUT_RECORD_TYPE, CloseoutRecord},
+	},
+	workflow::WorkflowDocument,
+};
 
 #[test]
 fn closeout_apply_validates_merged_pr_and_completed_issue_state() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
-	let mut completed_issue = sample_review_issue();
+	let mut completed_issue = tests::sample_review_issue();
 
 	completed_issue.state =
 		TrackerState { id: String::from("state-done"), name: String::from("Done") };
@@ -41,10 +37,10 @@ fn closeout_apply_validates_merged_pr_and_completed_issue_state() {
 		vec![completed_issue.clone()],
 		vec![completed_issue],
 	]);
-	let issue = sample_review_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_review_issue();
+	let workflow = tests::sample_workflow();
 	let pr_url = "https://github.com/hack-ink/decodex/pull/260";
-	let mut merged_pull_request = sample_pull_request();
+	let mut merged_pull_request = tests::sample_pull_request();
 
 	merged_pull_request.url = String::from(pr_url);
 	merged_pull_request.state = String::from("MERGED");
@@ -53,9 +49,11 @@ fn closeout_apply_validates_merged_pr_and_completed_issue_state() {
 		Ok(merged_pull_request.clone()),
 		Ok(merged_pull_request),
 	]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
-	let review_context = sample_closeout_context_in(temp_dir.path(), pr_url);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
+	let review_context = tests::sample_closeout_context_in(temp_dir.path(), pr_url);
 	let bridge = TrackerToolBridge::with_review_handoff_inspectors(
 		&tracker,
 		&issue,
@@ -69,17 +67,17 @@ fn closeout_apply_validates_merged_pr_and_completed_issue_state() {
 		&bridge,
 		ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME,
 		serde_json::json!({
-			"pr_url": pr_url,
-			"summary": "Merged the approved lane and finished closeout."
-			}),
-		);
+		"pr_url": pr_url,
+		"summary": "Merged the approved lane and finished closeout."
+		}),
+	);
 
-	seed_docs_impact_checkpoint(
-		bridge_state_store(&bridge),
+	tests::seed_docs_impact_checkpoint(
+		tests::bridge_state_store(&bridge),
 		&review_context,
 		&issue.id,
 		"closeout",
-		&sample_local_repo().head_oid,
+		&tests::sample_local_repo().head_oid,
 	);
 
 	let finalize_response = DynamicToolHandler::handle_call(
@@ -108,7 +106,7 @@ fn closeout_apply_validates_merged_pr_and_completed_issue_state() {
 #[test]
 fn closeout_apply_writes_coarse_comment_without_replaying_existing_records() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
-	let mut completed_issue = sample_review_issue();
+	let mut completed_issue = tests::sample_review_issue();
 
 	completed_issue.state =
 		TrackerState { id: String::from("state-done"), name: String::from("Done") };
@@ -122,10 +120,10 @@ fn closeout_apply_writes_coarse_comment_without_replaying_existing_records() {
 		vec![completed_issue.clone()],
 		vec![completed_issue],
 	]);
-	let issue = sample_review_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_review_issue();
+	let workflow = tests::sample_workflow();
 	let pr_url = "https://github.com/hack-ink/decodex/pull/260";
-	let mut merged_pull_request = sample_pull_request();
+	let mut merged_pull_request = tests::sample_pull_request();
 
 	merged_pull_request.url = String::from(pr_url);
 	merged_pull_request.state = String::from("MERGED");
@@ -155,9 +153,11 @@ fn closeout_apply_writes_coarse_comment_without_replaying_existing_records() {
 		Ok(merged_pull_request.clone()),
 		Ok(merged_pull_request),
 	]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
-	let review_context = sample_closeout_context_in(temp_dir.path(), pr_url);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
+	let review_context = tests::sample_closeout_context_in(temp_dir.path(), pr_url);
 	let bridge = TrackerToolBridge::with_review_handoff_inspectors(
 		&tracker,
 		&issue,
@@ -171,17 +171,17 @@ fn closeout_apply_writes_coarse_comment_without_replaying_existing_records() {
 		&bridge,
 		ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME,
 		serde_json::json!({
-			"pr_url": pr_url,
-			"summary": "Merged the approved lane and finished closeout."
-			}),
-		);
+		"pr_url": pr_url,
+		"summary": "Merged the approved lane and finished closeout."
+		}),
+	);
 
-	seed_docs_impact_checkpoint(
-		bridge_state_store(&bridge),
+	tests::seed_docs_impact_checkpoint(
+		tests::bridge_state_store(&bridge),
 		&review_context,
 		&issue.id,
 		"closeout",
-		&sample_local_repo().head_oid,
+		&tests::sample_local_repo().head_oid,
 	);
 
 	let finalize_response = DynamicToolHandler::handle_call(
@@ -208,7 +208,7 @@ fn closeout_clear_uses_server_team_label_lookup_for_active_label_removal() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
 	let queue_label = tracker::automation_queue_label(TEST_SERVICE_ID);
-	let mut completed_issue = sample_review_issue();
+	let mut completed_issue = tests::sample_review_issue();
 
 	completed_issue.state =
 		TrackerState { id: String::from("state-done"), name: String::from("Done") };
@@ -226,10 +226,10 @@ fn closeout_clear_uses_server_team_label_lookup_for_active_label_removal() {
 		vec![completed_issue.clone()],
 	])
 	.with_team_label_lookup_id(&completed_issue.team.id, &active_label, "label-active");
-	let issue = sample_review_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_review_issue();
+	let workflow = tests::sample_workflow();
 	let pr_url = "https://github.com/hack-ink/decodex/pull/260";
-	let mut merged_pull_request = sample_pull_request();
+	let mut merged_pull_request = tests::sample_pull_request();
 
 	merged_pull_request.url = String::from(pr_url);
 	merged_pull_request.state = String::from("MERGED");
@@ -238,9 +238,11 @@ fn closeout_clear_uses_server_team_label_lookup_for_active_label_removal() {
 		Ok(merged_pull_request.clone()),
 		Ok(merged_pull_request),
 	]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
-	let review_context = sample_closeout_context_in(temp_dir.path(), pr_url);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
+	let review_context = tests::sample_closeout_context_in(temp_dir.path(), pr_url);
 	let bridge = TrackerToolBridge::with_review_handoff_inspectors(
 		&tracker,
 		&issue,
@@ -254,17 +256,17 @@ fn closeout_clear_uses_server_team_label_lookup_for_active_label_removal() {
 		&bridge,
 		ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME,
 		serde_json::json!({
-			"pr_url": pr_url,
-			"summary": "Merged the approved lane and finished closeout."
-			}),
-		);
+		"pr_url": pr_url,
+		"summary": "Merged the approved lane and finished closeout."
+		}),
+	);
 
-	seed_docs_impact_checkpoint(
-		bridge_state_store(&bridge),
+	tests::seed_docs_impact_checkpoint(
+		tests::bridge_state_store(&bridge),
 		&review_context,
 		&issue.id,
 		"closeout",
-		&sample_local_repo().head_oid,
+		&tests::sample_local_repo().head_oid,
 	);
 
 	let finalize_response = DynamicToolHandler::handle_call(
@@ -291,7 +293,7 @@ fn closeout_clear_uses_server_team_label_lookup_for_active_label_removal() {
 fn closeout_apply_keeps_active_label_until_cleanup() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
-	let mut completed_issue = sample_review_issue();
+	let mut completed_issue = tests::sample_review_issue();
 
 	completed_issue.state =
 		TrackerState { id: String::from("state-done"), name: String::from("Done") };
@@ -304,10 +306,10 @@ fn closeout_apply_keeps_active_label_until_cleanup() {
 		vec![completed_issue.clone()],
 	])
 	.with_label_lookup_issues(&active_label, vec![completed_issue.clone()]);
-	let issue = sample_review_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_review_issue();
+	let workflow = tests::sample_workflow();
 	let pr_url = "https://github.com/hack-ink/decodex/pull/260";
-	let mut merged_pull_request = sample_pull_request();
+	let mut merged_pull_request = tests::sample_pull_request();
 
 	merged_pull_request.url = String::from(pr_url);
 	merged_pull_request.state = String::from("MERGED");
@@ -316,9 +318,11 @@ fn closeout_apply_keeps_active_label_until_cleanup() {
 		Ok(merged_pull_request.clone()),
 		Ok(merged_pull_request),
 	]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
-	let review_context = sample_closeout_context_in(temp_dir.path(), pr_url);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
+	let review_context = tests::sample_closeout_context_in(temp_dir.path(), pr_url);
 	let bridge = TrackerToolBridge::with_review_handoff_inspectors(
 		&tracker,
 		&issue,
@@ -332,17 +336,17 @@ fn closeout_apply_keeps_active_label_until_cleanup() {
 		&bridge,
 		ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME,
 		serde_json::json!({
-			"pr_url": pr_url,
-			"summary": "Merged the approved lane and finished closeout."
-			}),
-		);
+		"pr_url": pr_url,
+		"summary": "Merged the approved lane and finished closeout."
+		}),
+	);
 
-	seed_docs_impact_checkpoint(
-		bridge_state_store(&bridge),
+	tests::seed_docs_impact_checkpoint(
+		tests::bridge_state_store(&bridge),
 		&review_context,
 		&issue.id,
 		"closeout",
-		&sample_local_repo().head_oid,
+		&tests::sample_local_repo().head_oid,
 	);
 
 	let finalize_response = DynamicToolHandler::handle_call(
@@ -370,7 +374,7 @@ fn closeout_clear_clears_active_label_when_issue_labels_paginate() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
 	let queue_label = tracker::automation_queue_label(TEST_SERVICE_ID);
-	let mut completed_issue = sample_review_issue();
+	let mut completed_issue = tests::sample_review_issue();
 
 	completed_issue.state =
 		TrackerState { id: String::from("state-done"), name: String::from("Done") };
@@ -381,11 +385,11 @@ fn closeout_clear_clears_active_label_when_issue_labels_paginate() {
 	let tracker = FakeTracker::with_refresh_snapshots(vec![vec![completed_issue.clone()]])
 		.with_label_lookup_issues(&active_label, vec![completed_issue.clone()])
 		.with_label_lookup_issues(&queue_label, vec![completed_issue.clone()]);
-	let issue = sample_review_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_review_issue();
+	let workflow = tests::sample_workflow();
 	let pr_url = "https://github.com/hack-ink/decodex/pull/260";
 	let merged_pull_request = {
-		let mut pull_request = sample_pull_request();
+		let mut pull_request = tests::sample_pull_request();
 
 		pull_request.url = String::from(pr_url);
 		pull_request.state = String::from("MERGED");
@@ -396,13 +400,15 @@ fn closeout_clear_clears_active_label_when_issue_labels_paginate() {
 		Ok(merged_pull_request.clone()),
 		Ok(merged_pull_request),
 	]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
 	let bridge = TrackerToolBridge::with_review_handoff_inspectors(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_closeout_context_in(temp_dir.path(), pr_url),
+		tests::sample_closeout_context_in(temp_dir.path(), pr_url),
 		Some(TrackerToolBridge::leaked_test_state_store()),
 		&inspector,
 		&local_repo_inspector,
@@ -423,7 +429,7 @@ fn closeout_clear_treats_missing_lane_label_removal_as_idempotent() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
 	let queue_label = tracker::automation_queue_label(TEST_SERVICE_ID);
-	let mut completed_issue = sample_review_issue();
+	let mut completed_issue = tests::sample_review_issue();
 
 	completed_issue.state =
 		TrackerState { id: String::from("state-done"), name: String::from("Done") };
@@ -440,11 +446,11 @@ fn closeout_clear_treats_missing_lane_label_removal_as_idempotent() {
 
 	tracker.refresh_snapshots.replace(vec![vec![completed_issue.clone()]]);
 
-	let issue = sample_review_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_review_issue();
+	let workflow = tests::sample_workflow();
 	let pr_url = "https://github.com/hack-ink/decodex/pull/260";
 	let merged_pull_request = {
-		let mut pull_request = sample_pull_request();
+		let mut pull_request = tests::sample_pull_request();
 
 		pull_request.url = String::from(pr_url);
 		pull_request.state = String::from("MERGED");
@@ -455,13 +461,15 @@ fn closeout_clear_treats_missing_lane_label_removal_as_idempotent() {
 		Ok(merged_pull_request.clone()),
 		Ok(merged_pull_request),
 	]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
 	let bridge = TrackerToolBridge::with_review_handoff_inspectors(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_closeout_context_in(temp_dir.path(), pr_url),
+		tests::sample_closeout_context_in(temp_dir.path(), pr_url),
 		Some(TrackerToolBridge::leaked_test_state_store()),
 		&inspector,
 		&local_repo_inspector,
@@ -477,7 +485,7 @@ fn closeout_clear_skips_lane_labels_when_server_confirms_absent() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let active_label = tracker::automation_active_label(TEST_SERVICE_ID);
 	let queue_label = tracker::automation_queue_label(TEST_SERVICE_ID);
-	let mut completed_issue = sample_review_issue();
+	let mut completed_issue = tests::sample_review_issue();
 
 	completed_issue.state =
 		TrackerState { id: String::from("state-done"), name: String::from("Done") };
@@ -487,11 +495,11 @@ fn closeout_clear_skips_lane_labels_when_server_confirms_absent() {
 		.retain(|label| label.name != active_label.as_str() && label.name != queue_label.as_str());
 
 	let tracker = FakeTracker::with_refresh_snapshots(vec![vec![completed_issue.clone()]]);
-	let issue = sample_review_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_review_issue();
+	let workflow = tests::sample_workflow();
 	let pr_url = "https://github.com/hack-ink/decodex/pull/260";
 	let merged_pull_request = {
-		let mut pull_request = sample_pull_request();
+		let mut pull_request = tests::sample_pull_request();
 
 		pull_request.url = String::from(pr_url);
 		pull_request.state = String::from("MERGED");
@@ -502,13 +510,15 @@ fn closeout_clear_skips_lane_labels_when_server_confirms_absent() {
 		Ok(merged_pull_request.clone()),
 		Ok(merged_pull_request),
 	]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
 	let bridge = TrackerToolBridge::with_review_handoff_inspectors(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_closeout_context_in(temp_dir.path(), pr_url),
+		tests::sample_closeout_context_in(temp_dir.path(), pr_url),
 		Some(TrackerToolBridge::leaked_test_state_store()),
 		&inspector,
 		&local_repo_inspector,
@@ -524,11 +534,11 @@ fn closeout_clear_skips_lane_labels_when_server_confirms_absent() {
 #[test]
 fn closeout_complete_rejects_issue_that_is_not_yet_completed() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
-	let tracker = tracker_with_current_issue_snapshot(&sample_review_issue());
-	let issue = sample_review_issue();
-	let workflow = sample_workflow();
+	let tracker = tests::tracker_with_current_issue_snapshot(&tests::sample_review_issue());
+	let issue = tests::sample_review_issue();
+	let workflow = tests::sample_workflow();
 	let pr_url = "https://github.com/hack-ink/decodex/pull/261";
-	let mut merged_pull_request = sample_pull_request();
+	let mut merged_pull_request = tests::sample_pull_request();
 
 	merged_pull_request.url = String::from(pr_url);
 	merged_pull_request.state = String::from("MERGED");
@@ -537,13 +547,15 @@ fn closeout_complete_rejects_issue_that_is_not_yet_completed() {
 		Ok(merged_pull_request.clone()),
 		Ok(merged_pull_request),
 	]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
 	let bridge = TrackerToolBridge::with_review_handoff_inspectors(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_closeout_context_in(temp_dir.path(), pr_url),
+		tests::sample_closeout_context_in(temp_dir.path(), pr_url),
 		Some(TrackerToolBridge::leaked_test_state_store()),
 		&inspector,
 		&local_repo_inspector,
@@ -570,16 +582,16 @@ fn closeout_complete_rejects_issue_that_is_not_yet_completed() {
 fn review_handoff_inspection_uses_configured_github_token() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let token_env_var = "DECODEX_TEST_REVIEW_HANDOFF_GITHUB_TOKEN";
 	let _env_guard = TestEnvVarGuard::set(token_env_var, "configured-review-token");
 	let inspector = GitHubTokenAssertingPullRequestInspector {
 		expected_token: String::from("configured-review-token"),
-		response: sample_pull_request(),
+		response: tests::sample_pull_request(),
 	};
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
-	let mut review_context = sample_review_context_in(temp_dir.path());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
+	let mut review_context = tests::sample_review_context_in(temp_dir.path());
 
 	review_context.github_token_env_var = Some(String::from(token_env_var));
 
@@ -592,7 +604,7 @@ fn review_handoff_inspection_uses_configured_github_token() {
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -611,11 +623,12 @@ fn review_handoff_inspection_rejects_missing_or_blank_github_token() {
 	{
 		let temp_dir = TempDir::new().expect("tempdir should create");
 		let tracker = FakeTracker::new();
-		let issue = sample_issue();
-		let workflow = sample_workflow();
+		let issue = tests::sample_issue();
+		let workflow = tests::sample_workflow();
 		let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
-		let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
-		let mut review_context = sample_review_context_in(temp_dir.path());
+		let local_repo_inspector =
+			FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
+		let mut review_context = tests::sample_review_context_in(temp_dir.path());
 
 		review_context.github_token_env_var = None;
 
@@ -624,13 +637,13 @@ fn review_handoff_inspection_rejects_missing_or_blank_github_token() {
 			&issue,
 			&workflow,
 			review_context.clone(),
-				&pull_request_inspector,
-				&local_repo_inspector,
-			);
+			&pull_request_inspector,
+			&local_repo_inspector,
+		);
 
-			write_clean_review_checkpoint(&bridge, &issue, &review_context);
+		tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
-			let response = DynamicToolHandler::handle_call(
+		let response = DynamicToolHandler::handle_call(
 			&bridge,
 			ISSUE_REVIEW_HANDOFF_TOOL_NAME,
 			serde_json::json!({
@@ -652,14 +665,15 @@ fn review_handoff_inspection_rejects_missing_or_blank_github_token() {
 	{
 		let temp_dir = TempDir::new().expect("tempdir should create");
 		let tracker = FakeTracker::new();
-		let issue = sample_issue();
-		let workflow = sample_workflow();
+		let issue = tests::sample_issue();
+		let workflow = tests::sample_workflow();
 		let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
-		let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+		let local_repo_inspector =
+			FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 		let env_var =
 			format!("DECODEX_TEST_BLANK_REVIEW_HANDOFF_GITHUB_TOKEN_ENV_{}", process::id());
 		let _env_guard = TestEnvVarGuard::set(&env_var, "");
-		let mut review_context = sample_review_context_in(temp_dir.path());
+		let mut review_context = tests::sample_review_context_in(temp_dir.path());
 
 		review_context.github_token_env_var = Some(env_var.clone());
 
@@ -668,13 +682,13 @@ fn review_handoff_inspection_rejects_missing_or_blank_github_token() {
 			&issue,
 			&workflow,
 			review_context.clone(),
-				&pull_request_inspector,
-				&local_repo_inspector,
-			);
+			&pull_request_inspector,
+			&local_repo_inspector,
+		);
 
-			write_clean_review_checkpoint(&bridge, &issue, &review_context);
+		tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
-			let response = DynamicToolHandler::handle_call(
+		let response = DynamicToolHandler::handle_call(
 			&bridge,
 			ISSUE_REVIEW_HANDOFF_TOOL_NAME,
 			serde_json::json!({
@@ -698,8 +712,8 @@ fn review_handoff_inspection_rejects_missing_or_blank_github_token() {
 #[test]
 fn transitions_current_issue_with_allowed_state() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let bridge = TrackerToolBridge::new(&tracker, &issue, &workflow);
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -714,8 +728,8 @@ fn transitions_current_issue_with_allowed_state() {
 #[test]
 fn rejects_success_transition_without_review_handoff() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let bridge = TrackerToolBridge::new(&tracker, &issue, &workflow);
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -738,8 +752,8 @@ fn rejects_success_transition_without_review_handoff() {
 #[test]
 fn rejects_invalid_transition_argument_shapes() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let bridge = TrackerToolBridge::new(&tracker, &issue, &workflow);
 	let cases = [
 		(
@@ -772,12 +786,17 @@ fn rejects_invalid_transition_argument_shapes() {
 #[test]
 fn rejects_success_transition_regardless_of_other_workflow_state_membership() {
 	for workflow in [
-		sample_workflow_with_startable_states(&["Todo", "In Review"]),
-		sample_workflow_with_tracker_states(&["Todo"], "In Progress", "In Review", "In Review"),
-		sample_workflow_with_tracker_states(&["Todo"], "In Review", "In Review", "Todo"),
+		tests::sample_workflow_with_startable_states(&["Todo", "In Review"]),
+		tests::sample_workflow_with_tracker_states(
+			&["Todo"],
+			"In Progress",
+			"In Review",
+			"In Review",
+		),
+		tests::sample_workflow_with_tracker_states(&["Todo"], "In Review", "In Review", "Todo"),
 	] {
 		let tracker = FakeTracker::new();
-		let issue = sample_issue();
+		let issue = tests::sample_issue();
 
 		assert_success_transition_requires_review_handoff(workflow, &tracker, &issue);
 	}
@@ -810,18 +829,14 @@ fn assert_success_transition_requires_review_handoff(
 #[test]
 fn rejects_tool_calls_for_another_issue() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let bridge = TrackerToolBridge::new(&tracker, &issue, &workflow);
-	let mut args = manual_attention_comment_args();
+	let mut args = tests::manual_attention_comment_args();
 
 	args["issue_identifier"] = serde_json::json!("DEC-999");
 
-	let response = DynamicToolHandler::handle_call(
-		&bridge,
-		ISSUE_COMMENT_TOOL_NAME,
-		args,
-	);
+	let response = DynamicToolHandler::handle_call(&bridge, ISSUE_COMMENT_TOOL_NAME, args);
 
 	assert!(!response.success);
 	assert!(tracker.comments.borrow().is_empty());
@@ -829,16 +844,16 @@ fn rejects_tool_calls_for_another_issue() {
 
 #[test]
 fn accepts_manual_attention_public_summary_kind() {
-	let issue = sample_issue();
-	let tracker = tracker_with_current_issue_snapshot(&issue);
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let tracker = tests::tracker_with_current_issue_snapshot(&issue);
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(Vec::new());
 	let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context(),
+		tests::sample_review_context(),
 		&inspector,
 		&local_repo_inspector,
 	);
@@ -854,8 +869,11 @@ fn accepts_manual_attention_public_summary_kind() {
 		"manual-attention label intent must not mutate Linear before comment validation"
 	);
 
-	let comment_response =
-		DynamicToolHandler::handle_call(&bridge, ISSUE_COMMENT_TOOL_NAME, manual_attention_comment_args());
+	let comment_response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_COMMENT_TOOL_NAME,
+		tests::manual_attention_comment_args(),
+	);
 
 	assert!(comment_response.success);
 
@@ -872,24 +890,18 @@ fn accepts_manual_attention_public_summary_kind() {
 	assert!(comment.contains("- raw_error: repo gate failed with public test output"));
 	assert_eq!(record.event_type, "needs_attention");
 	assert_eq!(record.error_class.as_deref(), Some("operator_decision_required"));
-	assert_eq!(
-		record.failed_command.as_deref(),
-		Some("cargo make test")
-	);
-	assert_eq!(
-		record.raw_error.as_deref(),
-		Some("repo gate failed with public test output")
-	);
+	assert_eq!(record.failed_command.as_deref(), Some("cargo make test"));
+	assert_eq!(record.raw_error.as_deref(), Some("repo gate failed with public test output"));
 }
 
 #[test]
 fn accepts_authority_boundary_decision_request_without_public_private_evidence_leakage() {
-	let issue = sample_issue();
-	let tracker = tracker_with_current_issue_snapshot(&issue);
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let tracker = tests::tracker_with_current_issue_snapshot(&issue);
+	let workflow = tests::sample_workflow();
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let private_diff_evidence = "private diff path /Users/example/decodex/.worktrees/DEC-1";
-	let review_context = sample_review_context();
+	let review_context = tests::sample_review_context();
 	let boundary_event = orchestrator::record_authority_boundary_check_private_event(
 		&state_store,
 		AuthorityBoundaryCheckInput {
@@ -908,8 +920,7 @@ fn accepts_authority_boundary_decision_request_without_public_private_evidence_l
 				legacy_disposition:
 					crate::orchestrator::AuthorityBoundaryDisposition::RequiresHuman,
 			}],
-			policy_decision:
-				AuthorityBoundaryPolicyDecision::RequiresHumanDecision,
+			policy_decision: AuthorityBoundaryPolicyDecision::RequiresHumanDecision,
 			disposition: AuthorityBoundaryDisposition::RequiresHuman,
 			final_disposition_reason: "Accepted behavior needs explicit authority.",
 			improvement_signals: Vec::new(),
@@ -928,7 +939,7 @@ fn accepts_authority_boundary_decision_request_without_public_private_evidence_l
 		ISSUE_LABEL_ADD_TOOL_NAME,
 		serde_json::json!({ "label": "decodex:needs-attention" }),
 	);
-	let mut args = manual_attention_comment_args();
+	let mut args = tests::manual_attention_comment_args();
 
 	args["error_class"] = serde_json::json!("contract_boundary_required");
 	args["next_action"] = serde_json::json!(
@@ -968,12 +979,7 @@ fn accepts_authority_boundary_decision_request_without_public_private_evidence_l
 	let record = records::parse_linear_execution_event_record(comment)
 		.expect("decision request summary should include a ledger record");
 	let events = state_store
-		.list_private_execution_events(
-			TEST_SERVICE_ID,
-			&issue.id,
-			"pub-618-attempt-2-123",
-			2,
-		)
+		.list_private_execution_events(TEST_SERVICE_ID, &issue.id, "pub-618-attempt-2-123", 2)
 		.expect("private decision event should list");
 	let decision_event = events
 		.iter()
@@ -986,10 +992,7 @@ fn accepts_authority_boundary_decision_request_without_public_private_evidence_l
 	assert!(comment.contains("- boundary: `accepted_behavior`"));
 	assert!(comment.contains("- recommendation: Revise the Decision Contract"));
 	assert!(!comment.contains(private_diff_evidence));
-	assert_eq!(
-		decision_event.payload()["decision_request_id"],
-		serde_json::json!("dr-dec-1-2")
-	);
+	assert_eq!(decision_event.payload()["decision_request_id"], serde_json::json!("dr-dec-1-2"));
 	assert_eq!(
 		decision_event.payload()["retained_diff_evidence"][0],
 		serde_json::json!(private_diff_evidence)
@@ -999,8 +1002,8 @@ fn accepts_authority_boundary_decision_request_without_public_private_evidence_l
 #[test]
 fn rejects_arbitrary_issue_comment_bodies() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let bridge = TrackerToolBridge::new(&tracker, &issue, &workflow);
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -1051,16 +1054,16 @@ fn rejects_manual_attention_comments_with_private_or_unsupported_fields() {
 			"`summary` must be public/team-visible text; credential-like names are not allowed.",
 		),
 	] {
-		let issue = sample_issue();
-		let tracker = tracker_with_current_issue_snapshot(&issue);
-		let workflow = sample_workflow();
+		let issue = tests::sample_issue();
+		let tracker = tests::tracker_with_current_issue_snapshot(&issue);
+		let workflow = tests::sample_workflow();
 		let inspector = FakePullRequestInspector::new(Vec::new());
 		let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 		let bridge = TrackerToolBridge::with_review_handoff_for_test(
 			&tracker,
 			&issue,
 			&workflow,
-			sample_review_context(),
+			tests::sample_review_context(),
 			&inspector,
 			&local_repo_inspector,
 		);
@@ -1069,7 +1072,7 @@ fn rejects_manual_attention_comments_with_private_or_unsupported_fields() {
 			ISSUE_LABEL_ADD_TOOL_NAME,
 			serde_json::json!({ "label": "decodex:needs-attention" }),
 		);
-		let mut args = manual_attention_comment_args();
+		let mut args = tests::manual_attention_comment_args();
 
 		args[field_name] = if matches!(field_name, "blockers" | "evidence") {
 			serde_json::json!([value])
@@ -1111,16 +1114,16 @@ fn rejects_manual_attention_comment_with_runtime_owned_error_class() {
 		"app_server_dynamic_tool_failed",
 		"phase_goal_terminal_path_missing",
 	] {
-		let issue = sample_issue();
-		let tracker = tracker_with_current_issue_snapshot(&issue);
-		let workflow = sample_workflow();
+		let issue = tests::sample_issue();
+		let tracker = tests::tracker_with_current_issue_snapshot(&issue);
+		let workflow = tests::sample_workflow();
 		let inspector = FakePullRequestInspector::new(Vec::new());
 		let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 		let bridge = TrackerToolBridge::with_review_handoff_for_test(
 			&tracker,
 			&issue,
 			&workflow,
-			sample_review_context(),
+			tests::sample_review_context(),
 			&inspector,
 			&local_repo_inspector,
 		);
@@ -1129,7 +1132,7 @@ fn rejects_manual_attention_comment_with_runtime_owned_error_class() {
 			ISSUE_LABEL_ADD_TOOL_NAME,
 			serde_json::json!({ "label": "decodex:needs-attention" }),
 		);
-		let mut args = manual_attention_comment_args();
+		let mut args = tests::manual_attention_comment_args();
 
 		args["error_class"] = serde_json::json!(error_class);
 
@@ -1156,16 +1159,16 @@ fn rejects_manual_attention_comment_with_runtime_owned_error_class() {
 
 #[test]
 fn rejects_unsupported_issue_comment_kinds_without_mutation() {
-	let issue = sample_issue();
-	let tracker = tracker_with_current_issue_snapshot(&issue);
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let tracker = tests::tracker_with_current_issue_snapshot(&issue);
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(Vec::new());
 	let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context(),
+		tests::sample_review_context(),
 		&inspector,
 		&local_repo_inspector,
 	);
@@ -1202,21 +1205,24 @@ fn rejects_unsupported_issue_comment_kinds_without_mutation() {
 
 #[test]
 fn rejects_manual_attention_comment_before_needs_attention_label() {
-	let issue = sample_issue();
+	let issue = tests::sample_issue();
 	let tracker = FakeTracker::new();
-	let workflow = sample_workflow();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(Vec::new());
 	let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context(),
+		tests::sample_review_context(),
 		&inspector,
 		&local_repo_inspector,
 	);
-	let response =
-		DynamicToolHandler::handle_call(&bridge, ISSUE_COMMENT_TOOL_NAME, manual_attention_comment_args());
+	let response = DynamicToolHandler::handle_call(
+		&bridge,
+		ISSUE_COMMENT_TOOL_NAME,
+		tests::manual_attention_comment_args(),
+	);
 
 	assert!(!response.success);
 	assert!(tracker.comments.borrow().is_empty());
@@ -1229,16 +1235,16 @@ fn rejects_manual_attention_comment_before_needs_attention_label() {
 
 #[test]
 fn rejects_manual_attention_comment_with_non_public_error_class_shape() {
-	let issue = sample_issue();
-	let tracker = tracker_with_current_issue_snapshot(&issue);
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let tracker = tests::tracker_with_current_issue_snapshot(&issue);
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(Vec::new());
 	let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context(),
+		tests::sample_review_context(),
 		&inspector,
 		&local_repo_inspector,
 	);
@@ -1247,7 +1253,7 @@ fn rejects_manual_attention_comment_with_non_public_error_class_shape() {
 		ISSUE_LABEL_ADD_TOOL_NAME,
 		serde_json::json!({ "label": "decodex:needs-attention" }),
 	);
-	let mut args = manual_attention_comment_args();
+	let mut args = tests::manual_attention_comment_args();
 
 	args["error_class"] = serde_json::json!("Missing-GITHUB_PAT_Y");
 
@@ -1293,9 +1299,9 @@ fn rejects_legacy_public_comments_with_sensitive_or_unknown_paths() {
 
 #[test]
 fn records_manual_attention_label_intent_without_linear_mutation() {
-	let issue = sample_issue();
+	let issue = tests::sample_issue();
 	let tracker = FakeTracker::new();
-	let workflow = sample_workflow();
+	let workflow = tests::sample_workflow();
 	let bridge = TrackerToolBridge::new(&tracker, &issue, &workflow);
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -1314,9 +1320,9 @@ fn records_manual_attention_label_intent_without_linear_mutation() {
 
 #[test]
 fn adds_allowed_workflow_opt_out_label() {
-	let issue = sample_issue();
-	let tracker = tracker_with_current_issue_snapshot(&issue);
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let tracker = tests::tracker_with_current_issue_snapshot(&issue);
+	let workflow = tests::sample_workflow();
 	let bridge = TrackerToolBridge::new(&tracker, &issue, &workflow);
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -1331,8 +1337,8 @@ fn adds_allowed_workflow_opt_out_label() {
 #[test]
 fn rejects_invalid_label_add_argument_shapes() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let bridge = TrackerToolBridge::new(&tracker, &issue, &workflow);
 	let cases = [
 		(

--- a/apps/decodex/src/agent/tracker_tool_bridge/tests/mutation/progress.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests/mutation/progress.rs
@@ -1,3 +1,24 @@
+use std::cell::RefCell;
+
+use tempfile::TempDir;
+
+use crate::agent::tracker_tool_bridge::tests::sample_local_repo;
+use crate::agent::tracker_tool_bridge::tests::{
+	self, FakeLocalRepoInspector, FakePullRequestInspector, FakeTracker, TEST_SERVICE_ID,
+};
+use crate::{
+	agent::tracker_tool_bridge::{
+		DynamicToolContentItem, DynamicToolHandler, ISSUE_PROGRESS_CHECKPOINT_TOOL_NAME,
+		TrackerToolBridge,
+	},
+	tracker::{
+		privacy_classifier::{
+			PublicProjectionPrivacyClassification, PublicProjectionPrivacyClassifier,
+		},
+		records,
+	},
+};
+
 struct FakeProjectionClassifier {
 	verdict: PublicProjectionPrivacyClassification,
 	seen_text: RefCell<Vec<String>>,
@@ -23,16 +44,16 @@ impl PublicProjectionPrivacyClassifier for FakeProjectionClassifier {
 #[test]
 fn progress_checkpoint_preserves_private_payload_and_publishes_projection() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context_in(temp_dir.path()),
+		tests::sample_review_context_in(temp_dir.path()),
 		&pull_request_inspector,
 		&local_repo_inspector,
 	);
@@ -76,7 +97,7 @@ fn progress_checkpoint_preserves_private_payload_and_publishes_projection() {
 	assert!(record.verification.is_none());
 	assert!(record.commit_sha.is_none());
 
-	let private_events = bridge_state_store(&bridge)
+	let private_events = tests::bridge_state_store(&bridge)
 		.list_private_execution_events(TEST_SERVICE_ID, &issue.id, "pub-618-attempt-2-123", 2)
 		.expect("private checkpoint events should list");
 
@@ -86,39 +107,40 @@ fn progress_checkpoint_preserves_private_payload_and_publishes_projection() {
 		private_events[0].payload()["focus"],
 		serde_json::json!("Wire the new execution-state skill into tracker-driven flows.")
 	);
-		assert_eq!(
-			private_events[0].payload()["next_action"],
-			serde_json::json!("Add the issue_progress_checkpoint runtime tool.")
-		);
-		assert_eq!(private_events[0].payload()["docs_impact"], serde_json::json!("none"));
-		assert_eq!(
-			private_events[0].payload()["evidence"],
-			serde_json::json!(["Research decision favors Linear-backed execution snapshots."])
-		);
+	assert_eq!(
+		private_events[0].payload()["next_action"],
+		serde_json::json!("Add the issue_progress_checkpoint runtime tool.")
+	);
+	assert_eq!(private_events[0].payload()["docs_impact"], serde_json::json!("none"));
+	assert_eq!(
+		private_events[0].payload()["evidence"],
+		serde_json::json!(["Research decision favors Linear-backed execution snapshots."])
+	);
 	assert_eq!(
 		private_events[0].payload()["verification"],
-		serde_json::json!(["Local inventory of active execution-state boundary references completed."])
+		serde_json::json!([
+			"Local inventory of active execution-state boundary references completed."
+		])
 	);
 	assert_eq!(
 		private_events[0].payload()["head_sha"],
-		serde_json::json!(sample_local_repo().head_oid)
+		serde_json::json!(tests::sample_local_repo().head_oid)
 	);
 }
 
 #[test]
 fn progress_checkpoint_classifier_allows_public_projection() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let temp_dir = TempDir::new().expect("tempdir should create");
-	let classifier =
-		FakeProjectionClassifier::new(PublicProjectionPrivacyClassification::Allow);
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let classifier = FakeProjectionClassifier::new(PublicProjectionPrivacyClassification::Allow);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 	let bridge = TrackerToolBridge::with_review_handoff_classifier_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context_in(temp_dir.path()),
+		tests::sample_review_context_in(temp_dir.path()),
 		&classifier,
 		&local_repo_inspector,
 	);
@@ -154,19 +176,19 @@ fn progress_checkpoint_classifier_allows_public_projection() {
 #[test]
 fn progress_checkpoint_suspicious_classifier_replaces_public_summary() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let classifier =
 		FakeProjectionClassifier::new(PublicProjectionPrivacyClassification::Suspicious {
 			reason: String::from("fake suspicious projection"),
 		});
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 	let bridge = TrackerToolBridge::with_review_handoff_classifier_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context_in(temp_dir.path()),
+		tests::sample_review_context_in(temp_dir.path()),
 		&classifier,
 		&local_repo_inspector,
 	);
@@ -198,19 +220,19 @@ fn progress_checkpoint_suspicious_classifier_replaces_public_summary() {
 #[test]
 fn progress_checkpoint_unavailable_classifier_preserves_private_event() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let classifier =
 		FakeProjectionClassifier::new(PublicProjectionPrivacyClassification::Unavailable {
 			reason: String::from("fake unavailable classifier"),
 		});
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 	let bridge = TrackerToolBridge::with_review_handoff_classifier_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context_in(temp_dir.path()),
+		tests::sample_review_context_in(temp_dir.path()),
 		&classifier,
 		&local_repo_inspector,
 	);
@@ -238,7 +260,7 @@ fn progress_checkpoint_unavailable_classifier_preserves_private_event() {
 		Some(records::PRIVACY_CLASSIFIER_WITHHELD_PUBLIC_SUMMARY)
 	);
 
-	let private_events = bridge_state_store(&bridge)
+	let private_events = tests::bridge_state_store(&bridge)
 		.list_private_execution_events(TEST_SERVICE_ID, &issue.id, "pub-618-attempt-2-123", 2)
 		.expect("private checkpoint events should list");
 
@@ -255,8 +277,8 @@ fn progress_checkpoint_unavailable_classifier_preserves_private_event() {
 #[test]
 fn blocked_progress_checkpoint_requires_concrete_blocker() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let bridge = TrackerToolBridge::new(&tracker, &issue, &workflow);
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -284,16 +306,16 @@ fn blocked_progress_checkpoint_requires_concrete_blocker() {
 #[test]
 fn progress_checkpoint_rejects_stale_head_sha() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context_in(temp_dir.path()),
+		tests::sample_review_context_in(temp_dir.path()),
 		&pull_request_inspector,
 		&local_repo_inspector,
 	);
@@ -324,16 +346,16 @@ fn progress_checkpoint_rejects_stale_head_sha() {
 #[test]
 fn progress_checkpoint_normalizes_matching_short_head_sha_to_full_head() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context_in(temp_dir.path()),
+		tests::sample_review_context_in(temp_dir.path()),
 		&pull_request_inspector,
 		&local_repo_inspector,
 	);
@@ -347,7 +369,7 @@ fn progress_checkpoint_normalizes_matching_short_head_sha_to_full_head() {
 			"next_action": "Record the closeout checkpoint with the live lane head.",
 			"blockers": [],
 			"evidence": [],
-			"head_sha": &sample_local_repo().head_oid[..7]
+			"head_sha": &tests::sample_local_repo().head_oid[..7]
 		}),
 	);
 
@@ -359,29 +381,29 @@ fn progress_checkpoint_normalizes_matching_short_head_sha_to_full_head() {
 
 	assert!(record.commit_sha.is_none());
 
-	let private_events = bridge_state_store(&bridge)
+	let private_events = tests::bridge_state_store(&bridge)
 		.list_private_execution_events(TEST_SERVICE_ID, &issue.id, "pub-618-attempt-2-123", 2)
 		.expect("private checkpoint events should list");
 
 	assert_eq!(
 		private_events[0].payload()["head_sha"],
-		serde_json::json!(sample_local_repo().head_oid)
+		serde_json::json!(tests::sample_local_repo().head_oid)
 	);
 }
 
 #[test]
 fn progress_checkpoint_retries_preserve_private_events_without_duplicate_public_projection() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context_in(temp_dir.path()),
+		tests::sample_review_context_in(temp_dir.path()),
 		&pull_request_inspector,
 		&local_repo_inspector,
 	);
@@ -406,7 +428,7 @@ fn progress_checkpoint_retries_preserve_private_events_without_duplicate_public_
 	assert!(second.success);
 	assert_eq!(tracker.comments.borrow().len(), 1);
 
-	let private_events = bridge_state_store(&bridge)
+	let private_events = tests::bridge_state_store(&bridge)
 		.list_private_execution_events(TEST_SERVICE_ID, &issue.id, "pub-618-attempt-2-123", 2)
 		.expect("private checkpoint events should list");
 
@@ -416,16 +438,16 @@ fn progress_checkpoint_retries_preserve_private_events_without_duplicate_public_
 #[test]
 fn progress_checkpoint_public_projection_changes_only_on_material_signal() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context_in(temp_dir.path()),
+		tests::sample_review_context_in(temp_dir.path()),
 		&pull_request_inspector,
 		&local_repo_inspector,
 	);
@@ -478,7 +500,7 @@ fn progress_checkpoint_public_projection_changes_only_on_material_signal() {
 		"private-only changes inside the same public phase must not flood Linear"
 	);
 
-	let private_events = bridge_state_store(&bridge)
+	let private_events = tests::bridge_state_store(&bridge)
 		.list_private_execution_events(TEST_SERVICE_ID, &issue.id, "pub-618-attempt-2-123", 2)
 		.expect("private checkpoint events should list");
 
@@ -488,16 +510,16 @@ fn progress_checkpoint_public_projection_changes_only_on_material_signal() {
 #[test]
 fn progress_checkpoint_stores_private_text_but_redacts_public_projection() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let pull_request_inspector = FakePullRequestInspector::new(Vec::new());
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context_in(temp_dir.path()),
+		tests::sample_review_context_in(temp_dir.path()),
 		&pull_request_inspector,
 		&local_repo_inspector,
 	);
@@ -532,7 +554,7 @@ fn progress_checkpoint_stores_private_text_but_redacts_public_projection() {
 	assert!(record.next_action.is_none());
 	assert!(record.evidence.is_none());
 
-	let private_events = bridge_state_store(&bridge)
+	let private_events = tests::bridge_state_store(&bridge)
 		.list_private_execution_events(TEST_SERVICE_ID, &issue.id, "pub-618-attempt-2-123", 2)
 		.expect("private checkpoint events should list");
 

--- a/apps/decodex/src/agent/tracker_tool_bridge/tests/review.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests/review.rs
@@ -1,0 +1,1 @@
+mod handoff;

--- a/apps/decodex/src/agent/tracker_tool_bridge/tests/review/handoff.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests/review/handoff.rs
@@ -1,13 +1,34 @@
-use records::{REVIEW_HANDOFF_RECORD_TYPE, ReviewHandoffRecord};
+use std::{fs, path::Path};
 
-use crate::test_support;
+use tempfile::TempDir;
+
+use crate::{
+	agent::tracker_tool_bridge,
+	agent::tracker_tool_bridge::tests::{
+		self, FakeLocalRepoInspector, FakePullRequestInspector, FakeTracker, TEST_SERVICE_ID,
+		review_policy,
+	},
+	agent::tracker_tool_bridge::{
+		DynamicToolContentItem, DynamicToolHandler, ISSUE_COMMENT_TOOL_NAME,
+		ISSUE_LABEL_ADD_TOOL_NAME, ISSUE_PROGRESS_CHECKPOINT_TOOL_NAME,
+		ISSUE_REVIEW_CHECKPOINT_TOOL_NAME, ISSUE_REVIEW_HANDOFF_TOOL_NAME,
+		ISSUE_TERMINAL_FINALIZE_TOOL_NAME, PullRequestDetails, RepositoryIdentity,
+		ReviewHandoffWritebackFailed, RunCompletionDisposition, TrackerToolBridge,
+	},
+	state::{ReviewHandoffMarker, StateStore},
+	test_support,
+	tracker::{
+		TrackerComment,
+		records::{self, REVIEW_HANDOFF_RECORD_TYPE, ReviewHandoffRecord},
+	},
+};
 
 #[test]
 fn turn_completion_requires_explicit_terminal_finalize_after_review_handoff() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(vec![Ok(PullRequestDetails {
 		head_ref_name: String::from("x/decodex-pub-618"),
 		head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
@@ -18,8 +39,8 @@ fn turn_completion_requires_explicit_terminal_finalize_after_review_handoff() {
 		base_ref_name: String::from("main"),
 		url: String::from("https://github.com/hack-ink/decodex/pull/52"),
 	})]);
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -29,7 +50,7 @@ fn turn_completion_requires_explicit_terminal_finalize_after_review_handoff() {
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -53,12 +74,12 @@ fn turn_completion_requires_explicit_terminal_finalize_after_review_handoff() {
 fn review_handoff_reuses_same_head_clean_checkpoint_artifact_across_attempts() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let state_store = StateStore::open_in_memory().expect("state store should open");
 	let first_pull_request_inspector = FakePullRequestInspector::new(Vec::new());
-	let first_local_repo = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
-	let first_context = sample_review_context_in(temp_dir.path());
+	let first_local_repo = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
+	let first_context = tests::sample_review_context_in(temp_dir.path());
 	let first_bridge = TrackerToolBridge::with_review_handoff_inspectors(
 		&tracker,
 		&issue,
@@ -74,7 +95,7 @@ fn review_handoff_reuses_same_head_clean_checkpoint_artifact_across_attempts() {
 		serde_json::json!({
 			"reviewer": "independent_fresh_context",
 			"status": "clean",
-			"head_sha": sample_local_repo().head_oid,
+			"head_sha": tests::sample_local_repo().head_oid,
 			"review_contract": review_policy::handoff_review_contract_json(),
 			"checks": review_policy::review_checks_json(),
 			"evidence": ["fresh reviewer read the issue contract, current diff, and HEAD"]
@@ -83,14 +104,14 @@ fn review_handoff_reuses_same_head_clean_checkpoint_artifact_across_attempts() {
 
 	assert!(checkpoint_response.success);
 
-	let mut second_context = sample_review_context_in(temp_dir.path());
+	let mut second_context = tests::sample_review_context_in(temp_dir.path());
 
 	second_context.run_id = String::from("pub-618-attempt-3-456");
 	second_context.attempt_number = 3;
 
 	let pull_request_inspector = FakePullRequestInspector::new(vec![Ok(PullRequestDetails {
 		head_ref_name: String::from("x/decodex-pub-618"),
-		head_ref_oid: sample_local_repo().head_oid,
+		head_ref_oid: tests::sample_local_repo().head_oid,
 		head_repository_name: String::from("decodex"),
 		head_repository_owner: String::from("hack-ink"),
 		is_draft: false,
@@ -98,7 +119,7 @@ fn review_handoff_reuses_same_head_clean_checkpoint_artifact_across_attempts() {
 		base_ref_name: String::from("main"),
 		url: String::from("https://github.com/hack-ink/decodex/pull/54"),
 	})]);
-	let second_local_repo = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let second_local_repo = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 	let second_bridge = TrackerToolBridge::with_review_handoff_inspectors(
 		&tracker,
 		&issue,
@@ -136,8 +157,8 @@ fn review_handoff_reuses_same_head_clean_checkpoint_artifact_across_attempts() {
 fn terminal_finalize_accepts_matching_review_handoff_path() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let pull_request = PullRequestDetails {
 		head_ref_name: String::from("x/decodex-pub-618"),
 		head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
@@ -150,8 +171,8 @@ fn terminal_finalize_accepts_matching_review_handoff_path() {
 	};
 	let inspector =
 		FakePullRequestInspector::new(vec![Ok(pull_request.clone()), Ok(pull_request.clone())]);
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -163,7 +184,7 @@ fn terminal_finalize_accepts_matching_review_handoff_path() {
 	let run_id = review_context.run_id.clone();
 	let attempt_number = review_context.attempt_number;
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let review_response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -202,7 +223,7 @@ fn terminal_finalize_accepts_matching_review_handoff_path() {
 	DynamicToolHandler::validate_turn_completion(&bridge, "done")
 		.expect("matching finalization should allow the turn to complete");
 
-	let events = bridge_state_store(&bridge)
+	let events = tests::bridge_state_store(&bridge)
 		.list_private_execution_events(TEST_SERVICE_ID, &issue.id, &run_id, attempt_number)
 		.expect("private terminal events should read");
 
@@ -215,7 +236,7 @@ fn terminal_finalize_accepts_matching_review_handoff_path() {
 		event.event_type() == "terminal_finalize" && event.payload()["path"] == "review_handoff"
 	}));
 
-	let handoff_marker = persisted_review_handoff_marker(&bridge, &issue, &review_context);
+	let handoff_marker = tests::persisted_review_handoff_marker(&bridge, &issue, &review_context);
 
 	assert_eq!(handoff_marker.pr_url(), "https://github.com/hack-ink/decodex/pull/53");
 	assert_eq!(handoff_marker.pr_head_oid(), "08a20f7dfb9526e7421a5f095b1c6adec84e52d6");
@@ -225,8 +246,8 @@ fn terminal_finalize_accepts_matching_review_handoff_path() {
 fn terminal_finalize_rejects_review_handoff_when_existing_marker_points_at_different_pr() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let pull_request = PullRequestDetails {
 		head_ref_name: String::from("x/decodex-pub-618"),
 		head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
@@ -239,9 +260,11 @@ fn terminal_finalize_rejects_review_handoff_when_existing_marker_points_at_diffe
 	};
 	let inspector =
 		FakePullRequestInspector::new(vec![Ok(pull_request.clone()), Ok(pull_request.clone())]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -251,8 +274,8 @@ fn terminal_finalize_rejects_review_handoff_when_existing_marker_points_at_diffe
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
-	bridge_state_store(&bridge)
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::bridge_state_store(&bridge)
 		.upsert_review_handoff_marker(
 			TEST_SERVICE_ID,
 			&issue.id,
@@ -303,7 +326,7 @@ fn terminal_finalize_rejects_review_handoff_when_existing_marker_points_at_diffe
 			if text.contains("Use explicit review-handoff recovery before rebinding this lane.")
 	));
 	assert_eq!(
-		persisted_review_handoff_marker(&bridge, &issue, &review_context).pr_url(),
+		tests::persisted_review_handoff_marker(&bridge, &issue, &review_context).pr_url(),
 		"https://github.com/hack-ink/decodex/pull/99"
 	);
 }
@@ -312,8 +335,8 @@ fn terminal_finalize_rejects_review_handoff_when_existing_marker_points_at_diffe
 fn terminal_finalize_requires_docs_impact_checkpoint_for_success_paths() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(vec![Ok(PullRequestDetails {
 		head_ref_name: String::from("x/decodex-pub-618"),
 		head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
@@ -324,8 +347,8 @@ fn terminal_finalize_requires_docs_impact_checkpoint_for_success_paths() {
 		base_ref_name: String::from("main"),
 		url: String::from("https://github.com/hack-ink/decodex/pull/55"),
 	})]);
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -335,7 +358,7 @@ fn terminal_finalize_requires_docs_impact_checkpoint_for_success_paths() {
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let review_response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -364,8 +387,8 @@ fn terminal_finalize_requires_docs_impact_checkpoint_for_success_paths() {
 fn terminal_finalize_requires_docs_impact_checkpoint_for_current_head() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(vec![Ok(PullRequestDetails {
 		head_ref_name: String::from("x/decodex-pub-618"),
 		head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
@@ -376,17 +399,17 @@ fn terminal_finalize_requires_docs_impact_checkpoint_for_current_head() {
 		base_ref_name: String::from("main"),
 		url: String::from("https://github.com/hack-ink/decodex/pull/56"),
 	})]);
-	let mut updated_local_repo = sample_local_repo();
+	let mut updated_local_repo = tests::sample_local_repo();
 
 	updated_local_repo.head_oid = String::from("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
 
 	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
-		Ok(sample_local_repo()),
-		Ok(sample_local_repo()),
-		Ok(sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
 		Ok(updated_local_repo),
 	]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -396,7 +419,7 @@ fn terminal_finalize_requires_docs_impact_checkpoint_for_current_head() {
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let checkpoint_response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -438,8 +461,8 @@ fn terminal_finalize_requires_docs_impact_checkpoint_for_current_head() {
 fn terminal_finalize_rejects_mismatched_path() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(vec![Ok(PullRequestDetails {
 		head_ref_name: String::from("x/decodex-pub-618"),
 		head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
@@ -450,8 +473,8 @@ fn terminal_finalize_rejects_mismatched_path() {
 		base_ref_name: String::from("main"),
 		url: String::from("https://github.com/hack-ink/decodex/pull/54"),
 	})]);
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -461,7 +484,7 @@ fn terminal_finalize_rejects_mismatched_path() {
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let review_response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -490,16 +513,16 @@ fn terminal_finalize_rejects_mismatched_path() {
 
 #[test]
 fn terminal_finalize_accepts_matching_manual_attention_path() {
-	let issue = sample_issue();
-	let tracker = tracker_with_current_issue_snapshot(&issue);
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let tracker = tests::tracker_with_current_issue_snapshot(&issue);
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(Vec::new());
-	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context(),
+		tests::sample_review_context(),
 		&inspector,
 		&local_repo_inspector,
 	);
@@ -511,7 +534,7 @@ fn terminal_finalize_accepts_matching_manual_attention_path() {
 	let comment_response = DynamicToolHandler::handle_call(
 		&bridge,
 		ISSUE_COMMENT_TOOL_NAME,
-		manual_attention_comment_args(),
+		tests::manual_attention_comment_args(),
 	);
 	let checkpoint_response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -544,8 +567,8 @@ fn terminal_finalize_accepts_matching_manual_attention_path() {
 fn rejects_review_handoff_apply_when_lane_head_changes_after_recording() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(vec![
 		Ok(PullRequestDetails {
 			head_ref_name: String::from("x/decodex-pub-618"),
@@ -568,16 +591,16 @@ fn rejects_review_handoff_apply_when_lane_head_changes_after_recording() {
 			url: String::from("https://github.com/hack-ink/decodex/pull/47"),
 		}),
 	]);
-	let mut updated_local_repo = sample_local_repo();
+	let mut updated_local_repo = tests::sample_local_repo();
 
 	updated_local_repo.head_oid = String::from("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
 
 	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
-		Ok(sample_local_repo()),
-		Ok(sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
 		Ok(updated_local_repo),
 	]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -587,7 +610,7 @@ fn rejects_review_handoff_apply_when_lane_head_changes_after_recording() {
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -613,17 +636,19 @@ fn rejects_review_handoff_apply_when_lane_head_changes_after_recording() {
 fn review_handoff_apply_writes_coarse_comment_without_replaying_existing_records() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
-	let mut pull_request = sample_pull_request();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
+	let mut pull_request = tests::sample_pull_request();
 
 	pull_request.url = String::from("https://github.com/hack-ink/decodex/pull/47");
 
 	let inspector =
 		FakePullRequestInspector::new(vec![Ok(pull_request.clone()), Ok(pull_request.clone())]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 	let existing_record = records::append_structured_comment_record(
 		"Review handoff already persisted.",
 		&ReviewHandoffRecord {
@@ -658,7 +683,7 @@ fn review_handoff_apply_writes_coarse_comment_without_replaying_existing_records
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -683,9 +708,9 @@ fn review_handoff_apply_writes_coarse_comment_without_replaying_existing_records
 fn review_handoff_apply_does_not_duplicate_existing_ledger_event() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
-	let pull_request = sample_pull_request();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
+	let pull_request = tests::sample_pull_request();
 	let inspector = FakePullRequestInspector::new(vec![
 		Ok(pull_request.clone()),
 		Ok(pull_request.clone()),
@@ -693,12 +718,12 @@ fn review_handoff_apply_does_not_duplicate_existing_ledger_event() {
 		Ok(pull_request.clone()),
 	]);
 	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
-		Ok(sample_local_repo()),
-		Ok(sample_local_repo()),
-		Ok(sample_local_repo()),
-		Ok(sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
 	]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 
 	for _ in 0..2 {
 		let bridge = TrackerToolBridge::with_review_handoff_for_test(
@@ -710,7 +735,7 @@ fn review_handoff_apply_does_not_duplicate_existing_ledger_event() {
 			&local_repo_inspector,
 		);
 
-		write_clean_review_checkpoint(&bridge, &issue, &review_context);
+		tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 		let response = DynamicToolHandler::handle_call(
 			&bridge,
@@ -739,8 +764,8 @@ fn review_handoff_apply_does_not_duplicate_existing_ledger_event() {
 fn keeps_review_handoff_marker_when_state_transition_fails_after_tracker_record_write() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::with_state_update_error("tracker state write failed");
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(vec![
 		Ok(PullRequestDetails {
 			head_ref_name: String::from("x/decodex-pub-618"),
@@ -763,9 +788,11 @@ fn keeps_review_handoff_marker_when_state_transition_fails_after_tracker_record_
 			url: String::from("https://github.com/hack-ink/decodex/pull/49"),
 		}),
 	]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -775,7 +802,7 @@ fn keeps_review_handoff_marker_when_state_transition_fails_after_tracker_record_
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -796,7 +823,7 @@ fn keeps_review_handoff_marker_when_state_transition_fails_after_tracker_record_
 	assert_eq!(tracker.comments.borrow().len(), 1);
 	assert!(tracker.state_updates.borrow().is_empty());
 	assert_eq!(
-		bridge_state_store(&bridge)
+		tests::bridge_state_store(&bridge)
 			.review_handoff_marker(TEST_SERVICE_ID, &issue.id, "x/decodex-pub-618")
 			.expect("runtime handoff marker read should succeed")
 			.expect("partial review handoff should keep the retained marker")
@@ -809,8 +836,8 @@ fn keeps_review_handoff_marker_when_state_transition_fails_after_tracker_record_
 fn reports_review_handoff_writeback_failure_when_tracker_comment_write_fails() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::with_comment_error("tracker comment write failed");
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(vec![
 		Ok(PullRequestDetails {
 			head_ref_name: String::from("x/decodex-pub-618"),
@@ -844,11 +871,11 @@ fn reports_review_handoff_writeback_failure_when_tracker_comment_write_fails() {
 		}),
 	]);
 	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
-		Ok(sample_local_repo()),
-		Ok(sample_local_repo()),
-		Ok(sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
 	]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -858,7 +885,7 @@ fn reports_review_handoff_writeback_failure_when_tracker_comment_write_fails() {
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -871,7 +898,7 @@ fn reports_review_handoff_writeback_failure_when_tracker_comment_write_fails() {
 
 	assert!(response.success);
 
-	bridge_state_store(&bridge)
+	tests::bridge_state_store(&bridge)
 		.append_private_execution_event(
 			TEST_SERVICE_ID,
 			&issue.id,
@@ -881,7 +908,7 @@ fn reports_review_handoff_writeback_failure_when_tracker_comment_write_fails() {
 			serde_json::json!({
 				"phase": "ready_for_review",
 				"docs_impact": "none",
-				"head_sha": sample_local_repo().head_oid,
+				"head_sha": tests::sample_local_repo().head_oid,
 				"focus": "Finalize review handoff.",
 				"next_action": "Record terminal finalize.",
 				"blockers": [],
@@ -913,7 +940,7 @@ fn reports_review_handoff_writeback_failure_when_tracker_comment_write_fails() {
 	assert!(tracker.state_updates.borrow().is_empty());
 	assert!(tracker.comments.borrow().is_empty());
 	assert_eq!(
-		bridge_state_store(&bridge)
+		tests::bridge_state_store(&bridge)
 			.review_handoff_marker(TEST_SERVICE_ID, &issue.id, "x/decodex-pub-618")
 			.expect("runtime handoff marker read should succeed")
 			.expect("tracker writeback failure should keep durable handoff marker")
@@ -926,8 +953,8 @@ fn reports_review_handoff_writeback_failure_when_tracker_comment_write_fails() {
 fn review_handoff_writeback_replaces_private_summary_with_public_fallback() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let pull_request = PullRequestDetails {
 		head_ref_name: String::from("x/decodex-pub-618"),
 		head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
@@ -940,9 +967,11 @@ fn review_handoff_writeback_replaces_private_summary_with_public_fallback() {
 	};
 	let inspector =
 		FakePullRequestInspector::new(vec![Ok(pull_request.clone()), Ok(pull_request.clone())]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -952,7 +981,7 @@ fn review_handoff_writeback_replaces_private_summary_with_public_fallback() {
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -988,8 +1017,8 @@ fn review_handoff_writeback_replaces_private_summary_with_public_fallback() {
 fn review_handoff_validation_failure_reports_recoverable_writeback_with_pr_url() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let pull_request = PullRequestDetails {
 		head_ref_name: String::from("x/decodex-pub-618"),
 		head_ref_oid: String::from("08a20f7dfb9526e7421a5f095b1c6adec84e52d6"),
@@ -1002,9 +1031,11 @@ fn review_handoff_validation_failure_reports_recoverable_writeback_with_pr_url()
 	};
 	let inspector =
 		FakePullRequestInspector::new(vec![Ok(pull_request.clone()), Ok(pull_request.clone())]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
-	let mut review_context = sample_review_context_in(temp_dir.path());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
+	let mut review_context = tests::sample_review_context_in(temp_dir.path());
 
 	review_context.worktree_path = String::from("/Users/example/repo/.worktrees/PUB-618");
 
@@ -1017,7 +1048,7 @@ fn review_handoff_validation_failure_reports_recoverable_writeback_with_pr_url()
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -1049,7 +1080,7 @@ fn review_handoff_validation_failure_reports_recoverable_writeback_with_pr_url()
 	assert!(tracker.comments.borrow().is_empty());
 	assert!(tracker.state_updates.borrow().is_empty());
 	assert!(
-		bridge_state_store(&bridge)
+		tests::bridge_state_store(&bridge)
 			.review_handoff_marker(TEST_SERVICE_ID, &issue.id, "x/decodex-pub-618")
 			.expect("runtime handoff marker read should succeed")
 			.is_none()
@@ -1060,8 +1091,8 @@ fn review_handoff_validation_failure_reports_recoverable_writeback_with_pr_url()
 fn review_handoff_persists_runtime_state_without_local_marker_cache() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(vec![
 		Ok(PullRequestDetails {
 			head_ref_name: String::from("x/decodex-pub-618"),
@@ -1084,9 +1115,11 @@ fn review_handoff_persists_runtime_state_without_local_marker_cache() {
 			url: String::from("https://github.com/hack-ink/decodex/pull/150"),
 		}),
 	]);
-	let local_repo_inspector =
-		FakeLocalRepoInspector::new(vec![Ok(sample_local_repo()), Ok(sample_local_repo())]);
-	let review_context = sample_review_context_in(temp_dir.path());
+	let local_repo_inspector = FakeLocalRepoInspector::new(vec![
+		Ok(tests::sample_local_repo()),
+		Ok(tests::sample_local_repo()),
+	]);
+	let review_context = tests::sample_review_context_in(temp_dir.path());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -1096,7 +1129,7 @@ fn review_handoff_persists_runtime_state_without_local_marker_cache() {
 		&local_repo_inspector,
 	);
 
-	write_clean_review_checkpoint(&bridge, &issue, &review_context);
+	tests::write_clean_review_checkpoint(&bridge, &issue, &review_context);
 
 	let response = DynamicToolHandler::handle_call(
 		&bridge,
@@ -1116,10 +1149,10 @@ fn review_handoff_persists_runtime_state_without_local_marker_cache() {
 	assert_eq!(tracker.state_updates.borrow().as_slice(), ["state-review"]);
 	assert_eq!(tracker.comments.borrow().len(), 1);
 	assert_eq!(
-		persisted_review_handoff_marker(
+		tests::persisted_review_handoff_marker(
 			&bridge,
 			&issue,
-			&sample_review_context_in(temp_dir.path())
+			&tests::sample_review_context_in(temp_dir.path())
 		)
 		.pr_url(),
 		"https://github.com/hack-ink/decodex/pull/150"
@@ -1217,16 +1250,17 @@ fn rejects_invalid_pull_requests_for_review_handoff() {
 		),
 	] {
 		let tracker = FakeTracker::new();
-		let issue = sample_issue();
-		let workflow = sample_workflow();
+		let issue = tests::sample_issue();
+		let workflow = tests::sample_workflow();
 		let pr_url = pull_request.url.clone();
 		let inspector = FakePullRequestInspector::new(vec![Ok(pull_request)]);
-		let local_repo_inspector = FakeLocalRepoInspector::new(vec![Ok(sample_local_repo())]);
+		let local_repo_inspector =
+			FakeLocalRepoInspector::new(vec![Ok(tests::sample_local_repo())]);
 		let bridge = TrackerToolBridge::with_review_handoff_for_test(
 			&tracker,
 			&issue,
 			&workflow,
-			sample_review_context(),
+			tests::sample_review_context(),
 			&inspector,
 			&local_repo_inspector,
 		);
@@ -1259,23 +1293,20 @@ fn rejects_invalid_pull_requests_for_review_handoff() {
 
 #[test]
 fn parses_credentialed_https_github_remote() {
-	let repository = super::parse_github_repository_identity(
+	let repository = tracker_tool_bridge::parse_github_repository_identity(
 		"https://x-access-token@github.com/hack-ink/decodex.git",
 	)
 	.expect("credentialed GitHub remote should parse");
 
 	assert_eq!(
 		repository,
-		super::RepositoryIdentity {
-			owner: String::from("hack-ink"),
-			name: String::from("decodex"),
-		}
+		RepositoryIdentity { owner: String::from("hack-ink"), name: String::from("decodex") }
 	);
 }
 
 #[test]
 fn parses_default_branch_from_ls_remote_symref_output() {
-	let parsed = super::parse_remote_head_symref_output(
+	let parsed = tracker_tool_bridge::parse_remote_head_symref_output(
 		"ref: refs/heads/main\tHEAD\n9c0ffee\tHEAD\n9c0ffee\trefs/heads/main\n",
 	);
 
@@ -1284,7 +1315,7 @@ fn parses_default_branch_from_ls_remote_symref_output() {
 
 #[test]
 fn ignores_non_head_lines_when_parsing_default_branch_from_ls_remote_output() {
-	let parsed = super::parse_remote_head_symref_output(
+	let parsed = tracker_tool_bridge::parse_remote_head_symref_output(
 		"9c0ffee\trefs/heads/main\n9c0ffee\trefs/heads/release/1.x\n",
 	);
 
@@ -1332,8 +1363,8 @@ fn resolve_lane_default_branch_prefers_cached_origin_head() {
 	);
 	run_git_for_handoff(&repo_root, &["checkout", "main"]);
 
-	let resolved =
-		super::resolve_lane_default_branch(&repo_root).expect("default branch should resolve");
+	let resolved = tracker_tool_bridge::resolve_lane_default_branch(&repo_root)
+		.expect("default branch should resolve");
 
 	assert_eq!(resolved, "main");
 }
@@ -1375,8 +1406,8 @@ fn resolve_lane_default_branch_uses_remote_head_when_local_cache_is_missing() {
 	run_git_for_handoff(&remote_root, &["symbolic-ref", "HEAD", "refs/heads/trunk"]);
 	run_git_for_handoff(&repo_root, &["checkout", "main"]);
 
-	let resolved =
-		super::resolve_lane_default_branch(&repo_root).expect("default branch should resolve");
+	let resolved = tracker_tool_bridge::resolve_lane_default_branch(&repo_root)
+		.expect("default branch should resolve");
 
 	assert_eq!(resolved, "trunk");
 }
@@ -1427,8 +1458,8 @@ fn resolve_lane_default_branch_uses_cached_origin_head_without_reachable_remote(
 		],
 	);
 
-	let resolved =
-		super::resolve_lane_default_branch(&repo_root).expect("default branch should resolve");
+	let resolved = tracker_tool_bridge::resolve_lane_default_branch(&repo_root)
+		.expect("default branch should resolve");
 
 	assert_eq!(resolved, "main");
 }
@@ -1447,15 +1478,15 @@ fn run_git_for_handoff(cwd: &Path, args: &[&str]) {
 #[test]
 fn publishes_protocol_safe_tool_names() {
 	let tracker = FakeTracker::new();
-	let issue = sample_issue();
-	let workflow = sample_workflow();
+	let issue = tests::sample_issue();
+	let workflow = tests::sample_workflow();
 	let inspector = FakePullRequestInspector::new(Vec::new());
 	let local_repo_inspector = FakeLocalRepoInspector::new(Vec::new());
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
 		&workflow,
-		sample_review_context(),
+		tests::sample_review_context(),
 		&inspector,
 		&local_repo_inspector,
 	);


### PR DESCRIPTION
## Summary
- Replace tracker tool bridge test include! fragments with normal Rust test modules
- Add flat mutation/review module files instead of mod.rs
- Move shared docs-impact checkpoint helper into the parent test module and qualify child test helpers explicitly

## Validation
- cargo check -p decodex --lib --tests
- cargo clippy -p decodex --lib --tests --all-features -- -D warnings
- cargo test -p decodex tracker_tool_bridge --lib -- --format terse
- cargo vstyle curate --language rust -p decodex --all-features (touched tracker bridge test files clean; repo still has existing unrelated style debt: 3153 total / 123 manual)
- structural scan for wildcard clippy allows, wildcard imports, include!, #[path], and mod.rs in touched test subtree
- git diff --check