### PR TITLE
Widen app-server thread startup timeout

### DIFF
--- a/apps/decodex/src/agent/app_server.rs
+++ b/apps/decodex/src/agent/app_server.rs
@@ -72,7 +72,7 @@ use self::schema_probe::{
 use self::server_requests::{record_interactive_request_state, record_server_request};
 use self::{
 	activity::{ChildActivityAccumulator, ProtocolActivityAccumulator, redact_identifier},
-	constants::{JSONRPC_METHOD_NOT_FOUND, REQUEST_TIMEOUT},
+	constants::{JSONRPC_METHOD_NOT_FOUND, REQUEST_TIMEOUT, THREAD_SESSION_REQUEST_TIMEOUT},
 	dynamic_tools::{
 		dispatch_dynamic_tool_call, dynamic_tool_call_unavailable_for_phase,
 		respond_to_dynamic_tool_call_dispatch,

--- a/apps/decodex/src/agent/app_server/constants.rs
+++ b/apps/decodex/src/agent/app_server/constants.rs
@@ -5,6 +5,7 @@ pub(crate) const MODEL_EXECUTION_IDLE_TIMEOUT: Duration = Duration::from_secs(30
 
 pub(super) const PROBE_TIMEOUT: Duration = Duration::from_secs(30);
 pub(super) const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+pub(super) const THREAD_SESSION_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 pub(super) const RUN_CONTROL_POLL_INTERVAL: Duration = Duration::from_millis(500);
 pub(super) const PROBE_RUN_ID: &str = "protocol-probe-run";
 pub(super) const PROBE_ISSUE_ID: &str = "protocol-probe";

--- a/apps/decodex/src/agent/app_server/protocol/client.rs
+++ b/apps/decodex/src/agent/app_server/protocol/client.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::{
 	agent::{
 		app_server::{
-			REQUEST_TIMEOUT,
+			REQUEST_TIMEOUT, THREAD_SESSION_REQUEST_TIMEOUT,
 			protocol::{
 				ClientInfo, CommandExecParams, CommandExecResponse, ConfigReadParams,
 				ConfigReadResponse, InitializeCapabilities, InitializeParams, InitializeResponse,
@@ -116,7 +116,12 @@ impl AppServerClient {
 	where
 		H: FnMut(&mut JsonRpcConnection, &WireMessage, &JsonRpcRequest) -> Result<()>,
 	{
-		self.connection.request_with_handler("thread/start", &params, REQUEST_TIMEOUT, handler)
+		self.connection.request_with_handler(
+			"thread/start",
+			&params,
+			THREAD_SESSION_REQUEST_TIMEOUT,
+			handler,
+		)
 	}
 
 	#[allow(dead_code)]
@@ -140,7 +145,12 @@ impl AppServerClient {
 	where
 		H: FnMut(&mut JsonRpcConnection, &WireMessage, &JsonRpcRequest) -> Result<()>,
 	{
-		self.connection.request_with_handler("thread/resume", &params, REQUEST_TIMEOUT, handler)
+		self.connection.request_with_handler(
+			"thread/resume",
+			&params,
+			THREAD_SESSION_REQUEST_TIMEOUT,
+			handler,
+		)
 	}
 
 	pub(in crate::agent::app_server) fn archive_thread(

--- a/apps/decodex/src/agent/app_server/tests.rs
+++ b/apps/decodex/src/agent/app_server/tests.rs
@@ -695,6 +695,13 @@ for line in sys.stdin:
 "#
 }
 
+fn slow_thread_start_fake_codex_script() -> String {
+	orphan_response_fake_codex_script().replace(
+		"    elif method == \"thread/start\":\n        cwd = params.get(\"cwd\")",
+		"    elif method == \"thread/start\":\n        import time\n        time.sleep(6)\n        cwd = params.get(\"cwd\")",
+	)
+}
+
 fn phase_goal_fake_codex_script(
 	turn_outputs: &[&str],
 	goal_statuses: &[&str],

--- a/apps/decodex/src/agent/app_server/tests/request_tests.rs
+++ b/apps/decodex/src/agent/app_server/tests/request_tests.rs
@@ -177,6 +177,39 @@ fn synthetic_probe_thread_start_is_ephemeral_when_requested() {
 }
 
 #[test]
+fn thread_session_timeout_allows_slow_app_server_setup() {
+	assert!(app_server::THREAD_SESSION_REQUEST_TIMEOUT > app_server::REQUEST_TIMEOUT);
+	assert_eq!(app_server::THREAD_SESSION_REQUEST_TIMEOUT, Duration::from_secs(30));
+}
+
+#[test]
+fn app_server_run_accepts_thread_start_after_base_request_timeout() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let worktree_path = temp_dir.path().join("worktree");
+	let fake_bin_dir =
+		tests::install_fake_codex_script(&temp_dir, &tests::slow_thread_start_fake_codex_script());
+	let path_env = env::var("PATH").unwrap_or_default();
+	let _path_guard =
+		TestEnvVarGuard::set("PATH", &format!("{}:{path_env}", fake_bin_dir.display()));
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let mut request = tests::minimal_run_request();
+
+	fs::create_dir_all(&worktree_path).expect("worktree directory should create");
+
+	request.run_id = String::from("slow-thread-start-run");
+	request.issue_id = String::from("slow-thread-start-issue");
+	request.cwd = worktree_path.display().to_string();
+	request.timeout = Duration::from_secs(20);
+
+	let result = app_server::execute_app_server_run(&request, &state_store)
+		.expect("thread/start slower than base request timeout should still complete");
+
+	assert_eq!(result.thread_id, "thread-1");
+	assert_eq!(result.turn_id, "turn-1");
+	assert_eq!(result.final_output, "ORPHAN_OK");
+}
+
+#[test]
 fn command_exec_health_check_uses_bounded_standalone_request() {
 	let health_check = CommandExecHealthCheck {
 		command: vec![String::from("/bin/sh"), String::from("-c"), String::from("printf ok")],

--- a/apps/decodex/src/recovery/evidence.rs
+++ b/apps/decodex/src/recovery/evidence.rs
@@ -209,10 +209,17 @@ fn stale_active_private_event_is_no_diff_guardrail(event: &PrivateExecutionEvent
 
 	payload.get("schema").and_then(serde_json::Value::as_str)
 		== Some("decodex.loop_guardrail_checkpoint/1")
-		&& payload.get("source_error_class").and_then(serde_json::Value::as_str)
-			== Some("app_server_turn_failed")
+		&& stale_active_no_diff_guardrail_source_is_startup_or_turn_failure(payload)
 		&& payload.get("reason").and_then(serde_json::Value::as_str) == Some("no_effective_diff")
 		&& stale_active_guardrail_details_have_no_delta(payload)
+}
+
+fn stale_active_no_diff_guardrail_source_is_startup_or_turn_failure(
+	payload: &serde_json::Value,
+) -> bool {
+	let source_error_class = payload.get("source_error_class").and_then(serde_json::Value::as_str);
+
+	matches!(source_error_class, Some("app_server_turn_failed") | None)
 }
 
 fn stale_active_private_event_is_phase_goal_runtime_failure_telemetry(

--- a/apps/decodex/src/recovery/tests/stale_active.rs
+++ b/apps/decodex/src/recovery/tests/stale_active.rs
@@ -380,6 +380,22 @@ fn append_no_diff_guardrail_event(
 	branch_delta_present: bool,
 	effective_delta_present: bool,
 ) {
+	append_no_diff_guardrail_event_with_source_error_class(
+		store,
+		issue_id,
+		branch_delta_present,
+		effective_delta_present,
+		Some("app_server_turn_failed"),
+	);
+}
+
+fn append_no_diff_guardrail_event_with_source_error_class(
+	store: &StateStore,
+	issue_id: &str,
+	branch_delta_present: bool,
+	effective_delta_present: bool,
+	source_error_class: Option<&str>,
+) {
 	store
 		.append_private_execution_event(
 			"pubfi",
@@ -395,7 +411,7 @@ fn append_no_diff_guardrail_event(
 				.to_string(),
 				"reason": "no_effective_diff",
 				"schema": "decodex.loop_guardrail_checkpoint/1",
-				"source_error_class": "app_server_turn_failed",
+				"source_error_class": source_error_class,
 			}),
 		)
 		.expect("private guardrail evidence should record");

--- a/apps/decodex/src/recovery/tests/stale_active/telemetry.rs
+++ b/apps/decodex/src/recovery/tests/stale_active/telemetry.rs
@@ -417,6 +417,40 @@ fn stale_active_diagnose_blocks_no_diff_guardrail_with_delta() {
 }
 
 #[test]
+fn stale_active_diagnose_allows_startup_no_diff_guardrail_without_error_class() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let workflow = tests::sample_workflow();
+	let active_label = tracker::automation_active_label("pubfi");
+	let queue_label = tracker::automation_queue_label("pubfi");
+	let worktree_path = temp_dir.path().join("PUB-1626");
+	let mut issue = tests::sample_issue_with_labels("In Progress", &[active_label, queue_label]);
+
+	issue.identifier = String::from("PUB-1626");
+
+	stale_active::seed_dead_orphan_runtime_telemetry(&store, &issue, &worktree_path);
+	stale_active::append_no_diff_guardrail_event_with_source_error_class(
+		&store, &issue.id, false, false, None,
+	);
+
+	let tracker = GhostLaneTestTracker::with_issues(vec![issue]);
+	let diagnostics = super::diagnose_stale_active_issues(
+		"pubfi",
+		&workflow,
+		temp_dir.path(),
+		&store,
+		&tracker,
+		Some("PUB-1626"),
+		RecoveryRuntimeMutationPolicy::ReadOnly,
+	)
+	.expect("stale active diagnosis should run");
+	let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+	assert_eq!(diagnostic.classification, STALE_ACTIVE_CLASSIFICATION);
+	assert!(diagnostic.recoverable(), "unexpected blockers: {:?}", diagnostic.blockers);
+}
+
+#[test]
 fn stale_active_diagnose_allows_app_server_phase_goal_recovery_telemetry() {
 	let temp_dir = TempDir::new().expect("tempdir should create");
 	let store = StateStore::open_in_memory().expect("state store should open");

--- a/docs/spec/app-server.md
+++ b/docs/spec/app-server.md
@@ -364,6 +364,10 @@ internal logical tool declaration flat so callback authorization can still match
 Decodex must not inject project-owned config, model, personality, service-tier, sandbox, or approval-policy overrides into `thread/start`. Child runs inherit runtime defaults from the active Codex runtime.
 
 `ThreadStartResponse` returns the effective thread plus the effective execution settings.
+`thread/start` is allowed a longer bounded startup timeout than ordinary metadata
+requests because current Codex app-server builds may need to hydrate tool, skill, and
+thread runtime state before the first response. The longer timeout is still a startup
+transport timeout, not a model-execution wait.
 
 ## `thread/resume`
 
@@ -575,6 +579,9 @@ Rationale:
 - JSON-RPC transport failure before a thread session is attached is a retryable
   startup failure. This covers the client waiting on `initialize`,
   `account/login/start`, `thread/start`, or `thread/resume`.
+- `thread/start` and `thread/resume` may use a longer bounded timeout than ordinary
+  metadata requests; they still fail as startup transport failures when the timeout is
+  exhausted before a thread id is attached.
 - If that startup transport failure exhausts the registered retry budget, the
   terminal failure must still preserve `app_server_transport_disconnected`.
 - JSON-RPC transport failure after a thread session is attached, including


### PR DESCRIPTION
## Summary
- use a longer bounded timeout for `thread/start` and `thread/resume` while keeping ordinary metadata requests at the existing short timeout
- add a delayed fake app-server regression test proving a `thread/start` response after the old 5s timeout but before the new 30s timeout succeeds
- allow stale-active recovery to release no-diff startup attempts that recorded no source error class and no effective delta
- document the app-server startup timeout boundary

## Validation
- `cargo make fmt-rust-check`
- `cargo test -p decodex app_server_run_accepts_thread_start_after_base_request_timeout --all-features`
- `cargo test -p decodex agent::app_server --all-features`
- `cargo test -p decodex recovery::tests::stale_active --all-features`
- `cargo make check-rust`
- `cargo make lint-rust`
- `npm ci` in `site/`
- `cargo make check` passed: site build/check, docs check, Rust check/fmt/taplo/clippy/vstyle, and 1669 nextest tests passed with 1 skipped.

## Operational Evidence
- Installed Decodex timed out waiting for app-server output during `thread/start`.
- The patched debug binary allowed PubFi `PUB-1657` to progress from stale active/no diff to review handoff.
- PubFi PR created by that patched run: https://github.com/helixbox/pubfi-mono/pull/773
