### PR TITLE
Treat retrying app-server errors as nonterminal

### DIFF
--- a/apps/decodex/src/agent/app_server/activity/protocol/status.rs
+++ b/apps/decodex/src/agent/app_server/activity/protocol/status.rs
@@ -66,6 +66,9 @@ pub(in crate::agent::app_server::activity::protocol) fn protocol_waiting_reason(
 	if event::protocol_activity_category(event_type) == "command_output" {
 		return Some(String::from("tool_execution"));
 	}
+	if event_type == "item/started" {
+		return Some(item_started_waiting_reason(payload_value.as_ref()));
+	}
 	if matches!(event_type, "item/tool/call/response" | "item/completed" | "turn/started")
 		|| event_type.ends_with("/delta")
 		|| event_type.ends_with("/response")
@@ -85,6 +88,40 @@ pub(in crate::agent::app_server::activity::protocol) fn protocol_waiting_reason(
 	}
 
 	None
+}
+
+fn item_started_waiting_reason(payload_value: Option<&Value>) -> String {
+	let Some(item_kind) = payload_value.and_then(|value| {
+		payload::string_at_paths(
+			value,
+			&[
+				&["params", "item", "type"],
+				&["params", "item", "kind"],
+				&["item", "type"],
+				&["item", "kind"],
+				&["params", "type"],
+				&["params", "kind"],
+				&["type"],
+				&["kind"],
+			],
+		)
+	}) else {
+		return String::from("protocol_activity");
+	};
+	let item_kind = item_kind.to_ascii_lowercase();
+
+	if matches!(
+		item_kind.as_str(),
+		"agentmessage" | "agentreasoning" | "assistantmessage" | "message" | "model" | "reasoning"
+	) {
+		return String::from("model_execution");
+	}
+	if item_kind.contains("tool") || item_kind.contains("command") || item_kind.contains("function")
+	{
+		return String::from("tool_execution");
+	}
+
+	String::from("protocol_activity")
 }
 
 pub(in crate::agent::app_server::activity::protocol) fn protocol_rate_limit_status(

--- a/apps/decodex/src/agent/app_server/tests.rs
+++ b/apps/decodex/src/agent/app_server/tests.rs
@@ -459,3 +459,19 @@ fn slow_thread_start_fake_codex_script() -> String {
 		"    elif method == \"thread/start\":\n        import time\n        time.sleep(6)\n        cwd = params.get(\"cwd\")",
 	)
 }
+
+fn retrying_error_fake_codex_script() -> String {
+	orphan_response_fake_codex_script().replace(
+		"        send({\"id\": 999, \"result\": {\"late\": True}})",
+		r#"        send({"method": "error", "params": {
+            "threadId": "thread-1",
+            "turnId": "turn-1",
+            "willRetry": True,
+            "error": {
+                "message": "Reconnecting... 2/5",
+                "codexErrorInfo": "transientNetworkError"
+            }
+        }})
+        send({"id": 999, "result": {"late": True}})"#,
+	)
+}

--- a/apps/decodex/src/agent/app_server/tests/recorder/activity_summary.rs
+++ b/apps/decodex/src/agent/app_server/tests/recorder/activity_summary.rs
@@ -172,6 +172,93 @@ fn recorder_summarizes_high_value_protocol_activity() {
 			&& event.detail.as_deref() == Some("app_server_dynamic_tool_failed")
 	}));
 }
+
+#[test]
+fn recorder_treats_item_started_as_model_execution_wait() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let marker_path = temp_dir.path().to_path_buf();
+	let mut recorder = RunRecorder::new(&state_store, "run-1", 1, Some(&marker_path));
+
+	recorder
+		.record(
+			"turn/started",
+			r#"{"method":"turn/started","params":{"turn":{"id":"turn-1","status":"running"}}}"#,
+		)
+		.expect("turn start should record");
+	recorder
+		.record(
+			"item/started",
+			r#"{"method":"item/started","params":{"threadId":"thread-1","turnId":"turn-1","item":{"id":"item-1","kind":"agentReasoning"}}}"#,
+		)
+		.expect("item start should record");
+
+	let marker = state::read_run_activity_marker_snapshot(temp_dir.path())
+		.expect("marker snapshot should load")
+		.expect("marker snapshot should exist");
+	let summary = marker.protocol_activity().expect("protocol activity should be captured");
+
+	assert_eq!(summary.turn_status.as_deref(), Some("running"));
+	assert_eq!(summary.waiting_reason.as_deref(), Some("model_execution"));
+}
+
+#[test]
+fn recorder_does_not_treat_tool_item_started_as_model_execution_wait() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let marker_path = temp_dir.path().to_path_buf();
+	let mut recorder = RunRecorder::new(&state_store, "run-1", 1, Some(&marker_path));
+
+	recorder
+		.record(
+			"item/tool/call",
+			r#"{"method":"item/tool/call","params":{"threadId":"thread-1","turnId":"turn-1","tool":"shell","arguments":{"cmd":"sleep 60"}}}"#,
+		)
+		.expect("tool call should record");
+	recorder
+		.record(
+			"item/started",
+			r#"{"method":"item/started","params":{"threadId":"thread-1","turnId":"turn-1","item":{"id":"item-1","type":"toolCall"}}}"#,
+		)
+		.expect("tool item start should record");
+
+	let marker = state::read_run_activity_marker_snapshot(temp_dir.path())
+		.expect("marker snapshot should load")
+		.expect("marker snapshot should exist");
+	let summary = marker.protocol_activity().expect("protocol activity should be captured");
+
+	assert_eq!(summary.waiting_reason.as_deref(), Some("tool_execution"));
+}
+
+#[test]
+fn recorder_does_not_let_tool_item_started_inherit_model_execution_wait() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let marker_path = temp_dir.path().to_path_buf();
+	let mut recorder = RunRecorder::new(&state_store, "run-1", 1, Some(&marker_path));
+
+	recorder
+		.record(
+			"turn/started",
+			r#"{"method":"turn/started","params":{"turn":{"id":"turn-1","status":"running"}}}"#,
+		)
+		.expect("turn start should record");
+	recorder
+		.record(
+			"item/started",
+			r#"{"method":"item/started","params":{"threadId":"thread-1","turnId":"turn-1","item":{"id":"item-1","type":"commandExecution"}}}"#,
+		)
+		.expect("command item start should record");
+
+	let marker = state::read_run_activity_marker_snapshot(temp_dir.path())
+		.expect("marker snapshot should load")
+		.expect("marker snapshot should exist");
+	let summary = marker.protocol_activity().expect("protocol activity should be captured");
+
+	assert_eq!(summary.turn_status.as_deref(), Some("running"));
+	assert_eq!(summary.waiting_reason.as_deref(), Some("tool_execution"));
+}
+
 #[test]
 fn recorder_summarizes_v2_account_rate_limit_notifications() {
 	let temp_dir = TempDir::new().expect("tempdir should create");

--- a/apps/decodex/src/agent/app_server/tests/request_tests.rs
+++ b/apps/decodex/src/agent/app_server/tests/request_tests.rs
@@ -269,3 +269,43 @@ fn turn_completion_ignores_orphan_json_rpc_response() {
 	);
 	assert_eq!(marker.last_event_type(), Some("turn/completed"));
 }
+
+#[test]
+fn turn_completion_waits_through_retrying_error_notification() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let worktree_path = temp_dir.path().join("worktree");
+	let marker_path = temp_dir.path().join("activity");
+	let fake_bin_dir =
+		tests::install_fake_codex_script(&temp_dir, &tests::retrying_error_fake_codex_script());
+	let path_env = env::var("PATH").unwrap_or_default();
+	let _path_guard =
+		TestEnvVarGuard::set("PATH", &format!("{}:{path_env}", fake_bin_dir.display()));
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let mut request = tests::minimal_run_request();
+
+	fs::create_dir_all(&worktree_path).expect("worktree directory should create");
+
+	request.run_id = String::from("retrying-error-run");
+	request.issue_id = String::from("retrying-error-issue");
+	request.cwd = worktree_path.display().to_string();
+	request.timeout = Duration::from_secs(5);
+	request.activity_marker_path = Some(marker_path.clone());
+
+	let result = app_server::execute_app_server_run(&request, &state_store)
+		.expect("retrying error during turn wait should not fail the run");
+
+	assert_eq!(result.thread_id, "thread-1");
+	assert_eq!(result.turn_id, "turn-1");
+	assert_eq!(result.final_output, "ORPHAN_OK");
+
+	let marker = state::read_run_activity_marker_snapshot(&marker_path)
+		.expect("marker snapshot should load")
+		.expect("marker snapshot should exist");
+
+	assert_eq!(marker.last_event_type(), Some("turn/completed"));
+	assert!(
+		state_store
+			.run_has_protocol_event(&request.run_id, "error")
+			.expect("retrying error event lookup should load")
+	);
+}

--- a/apps/decodex/src/agent/app_server/tests/runtime.rs
+++ b/apps/decodex/src/agent/app_server/tests/runtime.rs
@@ -291,6 +291,51 @@ fn structured_error_notification_becomes_turn_failure() {
 }
 
 #[test]
+fn retrying_error_notification_does_not_replace_latest_turn_failure() {
+	let notification = JsonRpcNotification {
+		method: String::from("error"),
+		params: serde_json::json!({
+			"error": {
+				"message": "Reconnecting... 2/5",
+				"codexErrorInfo": "transientNetworkError"
+			},
+			"threadId": "thread-1",
+			"turnId": "turn-1",
+			"willRetry": true
+		}),
+	};
+	let mut final_output = String::new();
+	let mut latest_turn_failure = Some(AppServerTurnFailure::new(
+		"thread-1",
+		Some(String::from("turn-1")),
+		"failed",
+		"previous transient failure",
+		None,
+	));
+
+	let outcome = super::handle_turn_execution_notification(
+		&notification,
+		"thread-1",
+		"turn-1",
+		&mut final_output,
+		&mut latest_turn_failure,
+	)
+	.expect("retrying error notification should remain nonterminal");
+
+	assert!(outcome.is_none());
+	assert_eq!(
+		latest_turn_failure,
+		Some(AppServerTurnFailure::new(
+			"thread-1",
+			Some(String::from("turn-1")),
+			"failed",
+			"previous transient failure",
+			None,
+		))
+	);
+}
+
+#[test]
 fn json_rpc_error_response_becomes_recoverable_turn_failure() {
 	let error = JsonRpcError {
 		id: serde_json::json!(7),

--- a/apps/decodex/src/agent/app_server/turn_loop/completion.rs
+++ b/apps/decodex/src/agent/app_server/turn_loop/completion.rs
@@ -40,9 +40,11 @@ pub(in crate::agent::app_server) fn handle_turn_execution_notification(
 			if let Some((failure, will_retry)) =
 				failure_from_error_notification(notification, target_thread_id, target_turn_id)?
 			{
-				if (failure.requires_operator_attention() || failure.should_stop_current_turn())
-					&& will_retry != Some(true)
-				{
+				if will_retry == Some(true) {
+					return Ok(None);
+				}
+
+				if failure.requires_operator_attention() || failure.should_stop_current_turn() {
 					return Err(Report::new(failure));
 				}
 

--- a/docs/spec/app-server.md
+++ b/docs/spec/app-server.md
@@ -178,6 +178,14 @@ To validate an upstream app-server protocol change:
 Additional notifications may be recorded opportunistically for diagnostics.
 `thread/goal/updated` is recorded as local protocol activity and may summarize the
 active phase and status for operator readback. It is not a public tracker signal.
+
+Retrying app-server `error` notifications are nonterminal. When an error payload
+sets `willRetry: true`, `decodex` must keep waiting for the same turn instead of
+treating the notification as the latest terminal turn failure. A later terminal
+`turn/completed` error, a non-retrying `error`, or the idle timeout may still end
+the attempt. Model-side `item/started` notifications keep the turn in the
+`model_execution` waiting state for liveness timeout selection; tool and command
+item starts must not extend model-execution idle handling.
 After `thread/archive` or `thread/archive/discarded` is recorded for a run, Decodex
 treats later non-terminal app-server events for that run as late diagnostics rather
 than authoritative progress. Those events are discarded into the runtime journal's


### PR DESCRIPTION
## Summary
- keep app-server `error` notifications with `willRetry: true` nonterminal so retrying reconnects do not become terminal turn failures
- classify `item/started` liveness explicitly so model items use model execution timeout while tool/command/function items do not inherit it
- add regression coverage for retrying error success, preserved prior terminal failure, and item-start wait classification

## Validation
- `cargo make fmt && cargo make test` (1637 passed, 1 skipped)
- `git diff --check HEAD~1..HEAD`
- `target/debug/decodex probe stdio://`

## Review
- fresh skeptic subagent review after rebase: no findings, would not block landing
