### PR TITLE
Treat terminal program nodes as completed

### DIFF
--- a/apps/decodex/src/execution_program/evaluation/node.rs
+++ b/apps/decodex/src/execution_program/evaluation/node.rs
@@ -103,7 +103,18 @@ pub(crate) fn evaluate_node(input: EvaluateNodeInput<'_>) -> Result<ExecutionNod
 	let mut state = ExecutionReadinessState::Ready;
 	let mut lifecycle_state = None;
 
-	if !authority_matches
+	if let Some(issue) = node.linear_issue()
+		&& policy.issue_is_terminal(issue)
+	{
+		state = ExecutionReadinessState::Completed;
+		lifecycle_state = Some(ExecutionProgramNodeLifecycleState::Completed);
+
+		reasons.push(format!(
+			"mapped issue `{}` is already terminal in `{}`",
+			issue.issue_identifier(),
+			issue.issue_state()
+		));
+	} else if !authority_matches
 		|| current_fingerprint != program.accepted_contract_fingerprint
 		|| current_fingerprint != node.contract_fingerprint
 	{
@@ -119,17 +130,6 @@ pub(crate) fn evaluate_node(input: EvaluateNodeInput<'_>) -> Result<ExecutionNod
 		);
 
 		reasons.push(String::from("node no longer matches the accepted Decision Contract"));
-	} else if let Some(issue) = node.linear_issue()
-		&& policy.issue_is_terminal(issue)
-	{
-		state = ExecutionReadinessState::Completed;
-		lifecycle_state = Some(ExecutionProgramNodeLifecycleState::Completed);
-
-		reasons.push(format!(
-			"mapped issue `{}` is already terminal in `{}`",
-			issue.issue_identifier(),
-			issue.issue_state()
-		));
 	} else if let Some(issue) = node.linear_issue()
 		&& active_issue_ids.contains(issue.issue_id())
 		&& !issue.has_opt_out_label()

--- a/apps/decodex/src/execution_program/tests.rs
+++ b/apps/decodex/src/execution_program/tests.rs
@@ -189,6 +189,25 @@ fn stale_contract_drift_blocks_direct_dispatch() {
 }
 
 #[test]
+fn terminal_issue_mapping_wins_over_stale_contract_drift() {
+	let terminal_node = ready_node("node-terminal", "XY-903")
+		.with_contract_fingerprint("stale-contract-fingerprint")
+		.expect("fingerprint should override")
+		.with_linear_issue(issue("XY-903", "Done"))
+		.expect("terminal issue should attach");
+	let (contract, program) = program_with(vec![terminal_node]);
+	let evaluation = program
+		.evaluate(&contract, &workflow_policy(), &ExecutionProgramReadinessContext::new())
+		.expect("program should evaluate");
+	let node = &evaluation.nodes()[0];
+
+	assert_eq!(node.state(), ExecutionReadinessState::Completed);
+	assert_eq!(node.dispatch_action(), None);
+	assert_eq!(evaluation.operator_summary().completed_count, 1);
+	assert_eq!(evaluation.operator_summary().stale_count, 0);
+}
+
+#[test]
 fn conflict_domain_blocks_ready_node() {
 	let conflict = ExecutionConflictDomain::new(
 		ExecutionConflictDomainKind::File,


### PR DESCRIPTION
## Summary
- treat terminal mapped issues as completed before stale Decision Contract checks
- keep nonterminal contract drift blocked as stale
- cover the terminal/stale-contract interaction with a focused execution-program test

## Validation
- cargo test -p decodex execution_program::tests -- --nocapture
- rustup run nightly cargo fmt --all -- --check
- cargo check -p decodex --all-features --all-targets
- installed local decodex binary with cargo install --path apps/decodex --bin decodex --force
- verified ELF status now reports the old agent-knowledge program as completed with stale=0
