### PR TITLE
Split autonomy proposal helper modules

### DIFF
--- a/apps/decodex/src/autonomy_proposal/decision.rs
+++ b/apps/decodex/src/autonomy_proposal/decision.rs
@@ -1,383 +1,67 @@
-use std::collections::BTreeSet;
+mod accepted_authority;
+mod evidence;
+mod options;
+mod provenance;
+mod readiness;
 
 use serde_json::Value;
 
-use crate::autonomy_proposal::{
-	AutonomyProposal, AutonomyProposalChallengeEvidence, AutonomyProposalDecisionBridgeAuthority,
-	validation::{self},
-};
+use crate::autonomy_proposal::{AutonomyProposal, AutonomyProposalDecisionBridgeAuthority};
+
 pub(super) fn autonomy_decision_research_provenance(
 	proposal: &AutonomyProposal,
 	authority: &AutonomyProposalDecisionBridgeAuthority,
 ) -> Vec<Value> {
-	let mut provenance = vec![
-		serde_json::json!({
-			"kind": "autonomy_proposal",
-			"reference": proposal.id.clone(),
-			"summary": proposal.summary.clone(),
-		}),
-		serde_json::json!({
-			"kind": "autonomy_objective",
-			"reference": format!(
-				"{}:{}@{}",
-				proposal.project_id, proposal.objective_id, proposal.objective_version
-			),
-			"summary": proposal.objective_lineage.objective_summary.as_deref().unwrap_or(
-				"Accepted autonomy objective version."
-			),
-		}),
-		serde_json::json!({
-			"kind": "proposal_acceptance",
-			"reference": authority.acceptance_source.clone(),
-			"summary": format!(
-				"Accepted by {} ({}) at {}.",
-				authority.accepted_by,
-				authority.accepted_by_kind.as_str(),
-				authority.accepted_at
-			),
-		}),
-	];
-
-	if let Some(policy) = &authority.accepted_project_policy {
-		provenance.push(serde_json::json!({
-			"kind": "project_policy",
-			"reference": policy.authority_ref.clone(),
-			"summary": format!(
-				"Accepted project policy {}@{} authorized `{}` ({}) for autonomy proposal acceptance.",
-				policy.accepted_policy_id,
-				policy.accepted_policy_version,
-				policy.authorized_actor,
-				policy.authorized_actor_kind.as_str()
-			)
-		}));
-	}
-
-	provenance
+	provenance::autonomy_decision_research_provenance(proposal, authority)
 }
 
 pub(super) fn autonomy_decision_research_evidence(proposal: &AutonomyProposal) -> Vec<Value> {
-	let mut evidence = proposal
-		.source_signals
-		.iter()
-		.map(|signal| {
-			let mut support = vec![
-				format!("freshness={}", signal.freshness),
-				format!("evidence_class={}", signal.evidence_class),
-				format!("confidence={}", signal.confidence),
-			];
-
-			if !signal.gaps.is_empty() {
-				support.push(format!("gaps={}", signal.gaps.join("; ")));
-			}
-			if !signal.contradictions.is_empty() {
-				support.push(format!("contradictions={}", signal.contradictions.join("; ")));
-			}
-
-			serde_json::json!({
-				"kind": format!("autonomy_signal:{}", signal.kind),
-				"claim": format!("Autonomy signal `{}` contributed to accepted proposal `{}`.", signal.signal_id, proposal.id),
-				"support": support.join("; "),
-				"source_ref": signal.signal_id.clone(),
-			})
-		})
-		.collect::<Vec<_>>();
-
-	if !proposal.gaps.is_empty() {
-		evidence.push(serde_json::json!({
-			"kind": "autonomy_proposal_gap",
-			"claim": "Accepted proposal retained evidence gaps for downstream review.",
-			"support": proposal.gaps.join("; "),
-			"source_ref": proposal.id.clone(),
-		}));
-	}
-	if !proposal.contradictions.is_empty() {
-		evidence.push(serde_json::json!({
-			"kind": "autonomy_proposal_contradiction",
-			"claim": "Accepted proposal retained contradictions for downstream authority checks.",
-			"support": proposal.contradictions.join("; "),
-			"source_ref": proposal.id.clone(),
-		}));
-	}
-
-	for challenge in &proposal.challenge_evidence {
-		evidence.push(serde_json::json!({
-			"kind": "autonomy_proposal_challenge",
-			"claim": challenge.summary.clone(),
-			"support": challenge_support(challenge),
-			"source_ref": format!("challenge:{}", challenge.actor),
-		}));
-	}
-
-	evidence
-}
-
-pub(super) fn challenge_support(challenge: &AutonomyProposalChallengeEvidence) -> String {
-	if !challenge.objections.is_empty() {
-		challenge.objections.join("; ")
-	} else if !challenge.evidence_refs.is_empty() {
-		format!("evidence_refs={}", challenge.evidence_refs.join("; "))
-	} else {
-		String::from("Challenge recorded no objections.")
-	}
+	evidence::autonomy_decision_research_evidence(proposal)
 }
 
 pub(super) fn autonomy_decision_research_options(proposal: &AutonomyProposal) -> Vec<Value> {
-	let mut options = vec![serde_json::json!({
-		"option": proposal.summary.clone(),
-		"tradeoffs": option_tradeoffs(proposal),
-		"decision": "accepted_as_latent_decision_contract",
-		"rejected_reason": null,
-	})];
-
-	options.extend(proposal.rejected_alternatives.iter().map(|alternative| {
-		serde_json::json!({
-			"option": alternative.clone(),
-			"tradeoffs": [],
-			"decision": null,
-			"rejected_reason": "Rejected before autonomy proposal acceptance.",
-		})
-	}));
-
-	options
-}
-
-pub(super) fn option_tradeoffs(proposal: &AutonomyProposal) -> Vec<String> {
-	let mut tradeoffs = Vec::new();
-
-	tradeoffs.push(format!("Rollback path: {}", proposal.rollback_path));
-	tradeoffs.extend(
-		proposal.review_requirements.iter().map(|item| format!("Review requirement: {item}")),
-	);
-	tradeoffs
-		.extend(proposal.validation_gates.iter().map(|item| format!("Validation gate: {item}")));
-
-	tradeoffs
+	options::autonomy_decision_research_options(proposal)
 }
 
 pub(super) fn proposal_objectives(proposal: &AutonomyProposal) -> Vec<String> {
-	if proposal.goals.is_empty() { vec![proposal.summary.clone()] } else { proposal.goals.clone() }
+	accepted_authority::proposal_objectives(proposal)
 }
 
 pub(super) fn proposal_constraints(proposal: &AutonomyProposal) -> Vec<String> {
-	let mut constraints = proposal
-		.allowed_surfaces
-		.iter()
-		.map(|surface| format!("Allowed surface: {surface}"))
-		.collect::<Vec<_>>();
-
-	constraints.extend(
-		proposal
-			.review_requirements
-			.iter()
-			.map(|requirement| format!("Review requirement: {requirement}")),
-	);
-	constraints.extend(
-		proposal
-			.challenge_requirements
-			.iter()
-			.map(|requirement| format!("Challenge requirement: {requirement}")),
-	);
-
-	for challenge in &proposal.challenge_evidence {
-		constraints.extend(
-			challenge
-				.objections
-				.iter()
-				.map(|objection| format!("Challenge promotion constraint: {objection}")),
-		);
-	}
-
-	constraints.push(String::from(
-		"Accepted autonomy proposal must remain latent until Decision Contract promotion.",
-	));
-
-	constraints
+	accepted_authority::proposal_constraints(proposal)
 }
 
 pub(super) fn proposal_assumptions(
 	proposal: &AutonomyProposal,
 	authority: &AutonomyProposalDecisionBridgeAuthority,
 ) -> Vec<String> {
-	let mut assumptions =
-		proposal.metrics.iter().map(|metric| format!("Metric: {metric}")).collect::<Vec<_>>();
-
-	assumptions.push(format!(
-		"Proposal actor `{}` ({}) is distinct from acceptance authority `{}` ({}) unless resolved accepted project policy is recorded.",
-		authority.proposal_actor,
-		authority.proposal_actor_kind.as_str(),
-		authority.accepted_by,
-		authority.accepted_by_kind.as_str()
-	));
-
-	assumptions
+	accepted_authority::proposal_assumptions(proposal, authority)
 }
 
 pub(super) fn proposal_objections(proposal: &AutonomyProposal) -> Vec<String> {
-	let mut objections = proposal.contradictions.clone();
-
-	objections.extend(proposal.gaps.iter().map(|gap| format!("Evidence gap: {gap}")));
-
-	for challenge in &proposal.challenge_evidence {
-		objections.extend(challenge.objections.iter().cloned());
-	}
-
-	validation::unique_sorted_strings(objections)
+	accepted_authority::proposal_objections(proposal)
 }
 
 pub(super) fn proposal_stop_conditions(proposal: &AutonomyProposal) -> Vec<String> {
-	let mut stop_conditions = vec![
-		String::from(
-			"Stop before Program Intake unless the Decision Contract is promoted with explicit authority.",
-		),
-		format!("Rollback path: {}", proposal.rollback_path),
-	];
-
-	stop_conditions.extend(
-		proposal
-			.challenge_requirements
-			.iter()
-			.map(|requirement| format!("Challenge requirement: {requirement}")),
-	);
-
-	stop_conditions
+	accepted_authority::proposal_stop_conditions(proposal)
 }
 
 pub(super) fn proposal_validation_expectations(proposal: &AutonomyProposal) -> Vec<String> {
-	if proposal.validation_gates.is_empty() {
-		vec![String::from("Run the accepted Decision Contract validation gate before promotion.")]
-	} else {
-		proposal.validation_gates.clone()
-	}
+	readiness::proposal_validation_expectations(proposal)
 }
 
 pub(super) fn proposal_risk_notes(proposal: &AutonomyProposal) -> Vec<String> {
-	let mut risk_notes =
-		proposal.gaps.iter().map(|gap| format!("Evidence gap: {gap}")).collect::<Vec<_>>();
-
-	risk_notes.extend(
-		proposal
-			.review_requirements
-			.iter()
-			.map(|requirement| format!("Review requirement: {requirement}")),
-	);
-	risk_notes.extend(
-		proposal
-			.challenge_requirements
-			.iter()
-			.map(|requirement| format!("Challenge requirement: {requirement}")),
-	);
-
-	risk_notes
+	readiness::proposal_risk_notes(proposal)
 }
 
 pub(super) fn proposal_issue_candidates(proposal: &AutonomyProposal) -> Vec<Value> {
-	if proposal.issue_candidates.is_empty() {
-		return vec![proposal_issue_candidate(proposal)];
-	}
-
-	proposal
-		.issue_candidates
-		.iter()
-		.map(|candidate| {
-			serde_json::json!({
-				"key": candidate.key.clone(),
-				"title": candidate.title.clone(),
-				"objective": candidate.objective.clone(),
-				"stage": candidate.stage.clone(),
-				"dependencies": candidate.dependencies.clone(),
-				"conflict_domains": candidate.conflict_domains.clone(),
-				"acceptance": candidate.acceptance.clone(),
-				"validation": candidate.validation.clone(),
-				"risk": candidate.risk.clone(),
-				"queue_intent": candidate.queue_intent.clone(),
-			})
-		})
-		.collect()
-}
-
-pub(super) fn proposal_issue_candidate(proposal: &AutonomyProposal) -> Value {
-	serde_json::json!({
-		"key": format!("autonomy-{}", stable_slug(&proposal.source_family, 48)),
-		"title": proposal.summary.clone(),
-		"objective": proposal.summary.clone(),
-		"stage": proposal_issue_stage(&proposal.intended_surface),
-		"dependencies": [],
-		"conflict_domains": proposal_conflict_domains(proposal),
-		"acceptance": proposal_objectives(proposal),
-		"validation": proposal_validation_expectations(proposal),
-		"risk": proposal_risk_notes(proposal),
-		"queue_intent": "ready_to_queue",
-	})
+	readiness::proposal_issue_candidates(proposal)
 }
 
 pub(super) fn proposal_conflict_domains(proposal: &AutonomyProposal) -> Vec<String> {
-	let mut domains = BTreeSet::new();
-
-	if let Some(surface) = validation::normalize_repo_relative_path(&proposal.intended_surface) {
-		domains.insert(format!("file:{surface}"));
-	} else {
-		domains.insert(format!("surface:{}", proposal.intended_surface));
-	}
-
-	for identifier in &proposal.affected_identifiers {
-		domains.insert(format!("identifier:{identifier}"));
-	}
-
-	domains.into_iter().collect()
-}
-
-pub(super) fn proposal_issue_stage(intended_surface: &str) -> &'static str {
-	if intended_surface.starts_with("docs/spec/") {
-		"spec"
-	} else if intended_surface.starts_with("docs/") {
-		"design"
-	} else if intended_surface.starts_with("apps/decodex/src/") {
-		"runtime"
-	} else {
-		"design"
-	}
+	readiness::proposal_conflict_domains(proposal)
 }
 
 pub(super) fn proposal_source_issue_identifier(affected_identifiers: &[String]) -> Option<String> {
-	affected_identifiers
-		.iter()
-		.find(|identifier| looks_like_tracker_issue_identifier(identifier))
-		.cloned()
-}
-
-pub(super) fn looks_like_tracker_issue_identifier(value: &str) -> bool {
-	let Some((prefix, number)) = value.split_once('-') else {
-		return false;
-	};
-
-	!prefix.is_empty()
-		&& prefix.bytes().all(|byte| byte.is_ascii_uppercase())
-		&& !number.is_empty()
-		&& number.bytes().all(|byte| byte.is_ascii_digit())
-}
-
-pub(super) fn stable_slug(value: &str, max_len: usize) -> String {
-	let mut slug = String::new();
-	let mut previous_dash = false;
-
-	for character in value.chars() {
-		if character.is_ascii_alphanumeric() {
-			slug.push(character.to_ascii_lowercase());
-
-			previous_dash = false;
-		} else if !previous_dash && !slug.is_empty() {
-			slug.push('-');
-
-			previous_dash = true;
-		}
-		if slug.len() >= max_len {
-			break;
-		}
-	}
-
-	while slug.ends_with('-') {
-		slug.pop();
-	}
-
-	if slug.is_empty() { String::from("proposal") } else { slug }
+	readiness::proposal_source_issue_identifier(affected_identifiers)
 }

--- a/apps/decodex/src/autonomy_proposal/decision/accepted_authority.rs
+++ b/apps/decodex/src/autonomy_proposal/decision/accepted_authority.rs
@@ -1,0 +1,91 @@
+use crate::autonomy_proposal::{
+	AutonomyProposal, AutonomyProposalDecisionBridgeAuthority, validation,
+};
+
+pub(super) fn proposal_objectives(proposal: &AutonomyProposal) -> Vec<String> {
+	if proposal.goals.is_empty() { vec![proposal.summary.clone()] } else { proposal.goals.clone() }
+}
+
+pub(super) fn proposal_constraints(proposal: &AutonomyProposal) -> Vec<String> {
+	let mut constraints = proposal
+		.allowed_surfaces
+		.iter()
+		.map(|surface| format!("Allowed surface: {surface}"))
+		.collect::<Vec<_>>();
+
+	constraints.extend(
+		proposal
+			.review_requirements
+			.iter()
+			.map(|requirement| format!("Review requirement: {requirement}")),
+	);
+	constraints.extend(
+		proposal
+			.challenge_requirements
+			.iter()
+			.map(|requirement| format!("Challenge requirement: {requirement}")),
+	);
+
+	for challenge in &proposal.challenge_evidence {
+		constraints.extend(
+			challenge
+				.objections
+				.iter()
+				.map(|objection| format!("Challenge promotion constraint: {objection}")),
+		);
+	}
+
+	constraints.push(String::from(
+		"Accepted autonomy proposal must remain latent until Decision Contract promotion.",
+	));
+
+	constraints
+}
+
+pub(super) fn proposal_assumptions(
+	proposal: &AutonomyProposal,
+	authority: &AutonomyProposalDecisionBridgeAuthority,
+) -> Vec<String> {
+	let mut assumptions =
+		proposal.metrics.iter().map(|metric| format!("Metric: {metric}")).collect::<Vec<_>>();
+
+	assumptions.push(format!(
+		"Proposal actor `{}` ({}) is distinct from acceptance authority `{}` ({}) unless resolved accepted project policy is recorded.",
+		authority.proposal_actor,
+		authority.proposal_actor_kind.as_str(),
+		authority.accepted_by,
+		authority.accepted_by_kind.as_str()
+	));
+
+	assumptions
+}
+
+pub(super) fn proposal_objections(proposal: &AutonomyProposal) -> Vec<String> {
+	let mut objections = proposal.contradictions.clone();
+
+	objections.extend(proposal.gaps.iter().map(|gap| format!("Evidence gap: {gap}")));
+
+	for challenge in &proposal.challenge_evidence {
+		objections.extend(challenge.objections.iter().cloned());
+	}
+
+	validation::unique_sorted_strings(objections)
+}
+
+pub(super) fn proposal_stop_conditions(proposal: &AutonomyProposal) -> Vec<String> {
+	let mut stop_conditions = vec![
+		String::from(
+			"Stop before Program Intake unless the Decision Contract is promoted with explicit authority.",
+		),
+		format!("Rollback path: {}", proposal.rollback_path),
+	];
+
+	stop_conditions.extend(
+		proposal
+			.challenge_requirements
+			.iter()
+			.map(|requirement| format!("Challenge requirement: {requirement}")),
+	);
+
+	stop_conditions
+}

--- a/apps/decodex/src/autonomy_proposal/decision/evidence.rs
+++ b/apps/decodex/src/autonomy_proposal/decision/evidence.rs
@@ -1,0 +1,69 @@
+use serde_json::Value;
+
+use crate::autonomy_proposal::{AutonomyProposal, AutonomyProposalChallengeEvidence};
+
+pub(super) fn autonomy_decision_research_evidence(proposal: &AutonomyProposal) -> Vec<Value> {
+	let mut evidence = proposal
+		.source_signals
+		.iter()
+		.map(|signal| {
+			let mut support = vec![
+				format!("freshness={}", signal.freshness),
+				format!("evidence_class={}", signal.evidence_class),
+				format!("confidence={}", signal.confidence),
+			];
+
+			if !signal.gaps.is_empty() {
+				support.push(format!("gaps={}", signal.gaps.join("; ")));
+			}
+			if !signal.contradictions.is_empty() {
+				support.push(format!("contradictions={}", signal.contradictions.join("; ")));
+			}
+
+			serde_json::json!({
+				"kind": format!("autonomy_signal:{}", signal.kind),
+				"claim": format!("Autonomy signal `{}` contributed to accepted proposal `{}`.", signal.signal_id, proposal.id),
+				"support": support.join("; "),
+				"source_ref": signal.signal_id.clone(),
+			})
+		})
+		.collect::<Vec<_>>();
+
+	if !proposal.gaps.is_empty() {
+		evidence.push(serde_json::json!({
+			"kind": "autonomy_proposal_gap",
+			"claim": "Accepted proposal retained evidence gaps for downstream review.",
+			"support": proposal.gaps.join("; "),
+			"source_ref": proposal.id.clone(),
+		}));
+	}
+	if !proposal.contradictions.is_empty() {
+		evidence.push(serde_json::json!({
+			"kind": "autonomy_proposal_contradiction",
+			"claim": "Accepted proposal retained contradictions for downstream authority checks.",
+			"support": proposal.contradictions.join("; "),
+			"source_ref": proposal.id.clone(),
+		}));
+	}
+
+	for challenge in &proposal.challenge_evidence {
+		evidence.push(serde_json::json!({
+			"kind": "autonomy_proposal_challenge",
+			"claim": challenge.summary.clone(),
+			"support": challenge_support(challenge),
+			"source_ref": format!("challenge:{}", challenge.actor),
+		}));
+	}
+
+	evidence
+}
+
+fn challenge_support(challenge: &AutonomyProposalChallengeEvidence) -> String {
+	if !challenge.objections.is_empty() {
+		challenge.objections.join("; ")
+	} else if !challenge.evidence_refs.is_empty() {
+		format!("evidence_refs={}", challenge.evidence_refs.join("; "))
+	} else {
+		String::from("Challenge recorded no objections.")
+	}
+}

--- a/apps/decodex/src/autonomy_proposal/decision/options.rs
+++ b/apps/decodex/src/autonomy_proposal/decision/options.rs
@@ -1,0 +1,36 @@
+use serde_json::Value;
+
+use crate::autonomy_proposal::AutonomyProposal;
+
+pub(super) fn autonomy_decision_research_options(proposal: &AutonomyProposal) -> Vec<Value> {
+	let mut options = vec![serde_json::json!({
+		"option": proposal.summary.clone(),
+		"tradeoffs": option_tradeoffs(proposal),
+		"decision": "accepted_as_latent_decision_contract",
+		"rejected_reason": null,
+	})];
+
+	options.extend(proposal.rejected_alternatives.iter().map(|alternative| {
+		serde_json::json!({
+			"option": alternative.clone(),
+			"tradeoffs": [],
+			"decision": null,
+			"rejected_reason": "Rejected before autonomy proposal acceptance.",
+		})
+	}));
+
+	options
+}
+
+fn option_tradeoffs(proposal: &AutonomyProposal) -> Vec<String> {
+	let mut tradeoffs = Vec::new();
+
+	tradeoffs.push(format!("Rollback path: {}", proposal.rollback_path));
+	tradeoffs.extend(
+		proposal.review_requirements.iter().map(|item| format!("Review requirement: {item}")),
+	);
+	tradeoffs
+		.extend(proposal.validation_gates.iter().map(|item| format!("Validation gate: {item}")));
+
+	tradeoffs
+}

--- a/apps/decodex/src/autonomy_proposal/decision/provenance.rs
+++ b/apps/decodex/src/autonomy_proposal/decision/provenance.rs
@@ -1,0 +1,52 @@
+use serde_json::Value;
+
+use crate::autonomy_proposal::{AutonomyProposal, AutonomyProposalDecisionBridgeAuthority};
+
+pub(super) fn autonomy_decision_research_provenance(
+	proposal: &AutonomyProposal,
+	authority: &AutonomyProposalDecisionBridgeAuthority,
+) -> Vec<Value> {
+	let mut provenance = vec![
+		serde_json::json!({
+			"kind": "autonomy_proposal",
+			"reference": proposal.id.clone(),
+			"summary": proposal.summary.clone(),
+		}),
+		serde_json::json!({
+			"kind": "autonomy_objective",
+			"reference": format!(
+				"{}:{}@{}",
+				proposal.project_id, proposal.objective_id, proposal.objective_version
+			),
+			"summary": proposal.objective_lineage.objective_summary.as_deref().unwrap_or(
+				"Accepted autonomy objective version."
+			),
+		}),
+		serde_json::json!({
+			"kind": "proposal_acceptance",
+			"reference": authority.acceptance_source.clone(),
+			"summary": format!(
+				"Accepted by {} ({}) at {}.",
+				authority.accepted_by,
+				authority.accepted_by_kind.as_str(),
+				authority.accepted_at
+			),
+		}),
+	];
+
+	if let Some(policy) = &authority.accepted_project_policy {
+		provenance.push(serde_json::json!({
+			"kind": "project_policy",
+			"reference": policy.authority_ref.clone(),
+			"summary": format!(
+				"Accepted project policy {}@{} authorized `{}` ({}) for autonomy proposal acceptance.",
+				policy.accepted_policy_id,
+				policy.accepted_policy_version,
+				policy.authorized_actor,
+				policy.authorized_actor_kind.as_str()
+			)
+		}));
+	}
+
+	provenance
+}

--- a/apps/decodex/src/autonomy_proposal/decision/readiness.rs
+++ b/apps/decodex/src/autonomy_proposal/decision/readiness.rs
@@ -1,0 +1,145 @@
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+use crate::autonomy_proposal::{AutonomyProposal, decision, validation};
+
+pub(super) fn proposal_validation_expectations(proposal: &AutonomyProposal) -> Vec<String> {
+	if proposal.validation_gates.is_empty() {
+		vec![String::from("Run the accepted Decision Contract validation gate before promotion.")]
+	} else {
+		proposal.validation_gates.clone()
+	}
+}
+
+pub(super) fn proposal_risk_notes(proposal: &AutonomyProposal) -> Vec<String> {
+	let mut risk_notes =
+		proposal.gaps.iter().map(|gap| format!("Evidence gap: {gap}")).collect::<Vec<_>>();
+
+	risk_notes.extend(
+		proposal
+			.review_requirements
+			.iter()
+			.map(|requirement| format!("Review requirement: {requirement}")),
+	);
+	risk_notes.extend(
+		proposal
+			.challenge_requirements
+			.iter()
+			.map(|requirement| format!("Challenge requirement: {requirement}")),
+	);
+
+	risk_notes
+}
+
+pub(super) fn proposal_issue_candidates(proposal: &AutonomyProposal) -> Vec<Value> {
+	if proposal.issue_candidates.is_empty() {
+		return vec![proposal_issue_candidate(proposal)];
+	}
+
+	proposal
+		.issue_candidates
+		.iter()
+		.map(|candidate| {
+			serde_json::json!({
+				"key": candidate.key.clone(),
+				"title": candidate.title.clone(),
+				"objective": candidate.objective.clone(),
+				"stage": candidate.stage.clone(),
+				"dependencies": candidate.dependencies.clone(),
+				"conflict_domains": candidate.conflict_domains.clone(),
+				"acceptance": candidate.acceptance.clone(),
+				"validation": candidate.validation.clone(),
+				"risk": candidate.risk.clone(),
+				"queue_intent": candidate.queue_intent.clone(),
+			})
+		})
+		.collect()
+}
+
+pub(super) fn proposal_conflict_domains(proposal: &AutonomyProposal) -> Vec<String> {
+	let mut domains = BTreeSet::new();
+
+	if let Some(surface) = validation::normalize_repo_relative_path(&proposal.intended_surface) {
+		domains.insert(format!("file:{surface}"));
+	} else {
+		domains.insert(format!("surface:{}", proposal.intended_surface));
+	}
+
+	for identifier in &proposal.affected_identifiers {
+		domains.insert(format!("identifier:{identifier}"));
+	}
+
+	domains.into_iter().collect()
+}
+
+pub(super) fn proposal_source_issue_identifier(affected_identifiers: &[String]) -> Option<String> {
+	affected_identifiers
+		.iter()
+		.find(|identifier| looks_like_tracker_issue_identifier(identifier))
+		.cloned()
+}
+
+fn proposal_issue_candidate(proposal: &AutonomyProposal) -> Value {
+	serde_json::json!({
+		"key": format!("autonomy-{}", stable_slug(&proposal.source_family, 48)),
+		"title": proposal.summary.clone(),
+		"objective": proposal.summary.clone(),
+		"stage": proposal_issue_stage(&proposal.intended_surface),
+		"dependencies": [],
+		"conflict_domains": proposal_conflict_domains(proposal),
+		"acceptance": decision::proposal_objectives(proposal),
+		"validation": proposal_validation_expectations(proposal),
+		"risk": proposal_risk_notes(proposal),
+		"queue_intent": "ready_to_queue",
+	})
+}
+
+fn proposal_issue_stage(intended_surface: &str) -> &'static str {
+	if intended_surface.starts_with("docs/spec/") {
+		"spec"
+	} else if intended_surface.starts_with("docs/") {
+		"design"
+	} else if intended_surface.starts_with("apps/decodex/src/") {
+		"runtime"
+	} else {
+		"design"
+	}
+}
+
+fn looks_like_tracker_issue_identifier(value: &str) -> bool {
+	let Some((prefix, number)) = value.split_once('-') else {
+		return false;
+	};
+
+	!prefix.is_empty()
+		&& prefix.bytes().all(|byte| byte.is_ascii_uppercase())
+		&& !number.is_empty()
+		&& number.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn stable_slug(value: &str, max_len: usize) -> String {
+	let mut slug = String::new();
+	let mut previous_dash = false;
+
+	for character in value.chars() {
+		if character.is_ascii_alphanumeric() {
+			slug.push(character.to_ascii_lowercase());
+
+			previous_dash = false;
+		} else if !previous_dash && !slug.is_empty() {
+			slug.push('-');
+
+			previous_dash = true;
+		}
+		if slug.len() >= max_len {
+			break;
+		}
+	}
+
+	while slug.ends_with('-') {
+		slug.pop();
+	}
+
+	if slug.is_empty() { String::from("proposal") } else { slug }
+}

--- a/apps/decodex/src/autonomy_proposal/validation.rs
+++ b/apps/decodex/src/autonomy_proposal/validation.rs
@@ -1,408 +1,83 @@
-use std::{
-	collections::BTreeSet,
-	path::{Component, Path},
-};
-
-use sha2::{Digest as _, Sha256};
+mod common;
+mod identity;
+mod input;
+mod paths;
+mod refusals;
 
 use crate::{
-	autonomy_objective::{AutonomyObjectiveContract, AutonomyObjectiveState},
+	autonomy_objective::AutonomyObjectiveContract,
 	autonomy_proposal::{
-		AUTONOMY_PROPOSAL_RECORD_VERSION, AUTONOMY_PROPOSAL_SCHEMA, AutonomyProposal,
-		AutonomyProposalCompileInput, AutonomyProposalIssueCandidate, AutonomyProposalRefusal,
-		AutonomyProposalRefusalReason, AutonomyProposalState,
+		AutonomyProposal, AutonomyProposalCompileInput, AutonomyProposalRefusal,
+		AutonomyProposalState,
 	},
-	autonomy_signal::{AutonomySignal, AutonomySignalFreshness},
-	prelude::{Result, eyre},
+	autonomy_signal::AutonomySignal,
+	prelude::Result,
 };
+
 pub(super) fn proposal_refusals(
 	objective: Option<&AutonomyObjectiveContract>,
 	signals: &[AutonomySignal],
 	input: &AutonomyProposalCompileInput,
 	contradictions: &[String],
 ) -> Vec<AutonomyProposalRefusal> {
-	let mut refusals = Vec::new();
-
-	match objective {
-		Some(objective)
-			if objective.project_id() == input.project_id
-				&& objective.id() == input.objective_id
-				&& objective.version() == input.objective_version
-				&& objective.state() == AutonomyObjectiveState::Accepted => {
-				for signal in signals {
-					if signal.project_id() != input.project_id
-						|| signal.objective_id() != input.objective_id
-						|| signal.objective_version() != input.objective_version
-					{
-						refusals.push(AutonomyProposalRefusal::new(
-							AutonomyProposalRefusalReason::MissingObjective,
-							format!(
-								"Signal `{}` is not tied to objective `{}` version {}.",
-								signal.id(),
-								input.objective_id,
-								input.objective_version
-							),
-							vec![signal.id().to_owned()],
-						));
-					}
-					if !objective
-						.allowed_signal_kinds()
-						.iter()
-						.any(|kind| kind == signal.kind().as_str())
-					{
-						refusals.push(AutonomyProposalRefusal::new(
-							AutonomyProposalRefusalReason::DisallowedSignalKind,
-							format!(
-								"Signal `{}` kind `{}` is outside the accepted objective allowed_signal_kinds.",
-								signal.id(),
-								signal.kind().as_str()
-							),
-							vec![signal.id().to_owned()],
-						));
-					}
-					if signal.freshness() != AutonomySignalFreshness::Fresh {
-						refusals.push(AutonomyProposalRefusal::new(
-							AutonomyProposalRefusalReason::StaleEvidence,
-							format!(
-								"Signal `{}` freshness is `{}` and requires fresh readback before acceptance.",
-								signal.id(),
-								signal.freshness().as_str()
-							),
-							vec![signal.id().to_owned()],
-						));
-					}
-				}
-
-				if !surface_allowed(&input.intended_surface, objective.allowed_surfaces()) {
-					refusals.push(AutonomyProposalRefusal::new(
-						AutonomyProposalRefusalReason::DisallowedSurface,
-						format!(
-							"Intended surface `{}` is outside the accepted objective allowed_surfaces.",
-							input.intended_surface
-						),
-						vec![input.objective_id.clone()],
-					));
-				}
-			},
-		Some(objective) => refusals.push(AutonomyProposalRefusal::new(
-			AutonomyProposalRefusalReason::MissingObjective,
-			format!(
-				"Objective `{}` version {} exists in state `{}` but is not the accepted exact proposal objective.",
-				objective.id(),
-				objective.version(),
-				objective.state().as_str()
-			),
-			vec![input.objective_id.clone()],
-		)),
-		None => refusals.push(AutonomyProposalRefusal::new(
-			AutonomyProposalRefusalReason::MissingObjective,
-			format!(
-				"Objective `{}` version {} is missing.",
-				input.objective_id,
-				input.objective_version
-			),
-			vec![input.objective_id.clone()],
-		)),
-	}
-
-	for contradiction in contradictions {
-		refusals.push(AutonomyProposalRefusal::new(
-			AutonomyProposalRefusalReason::UnresolvedContradiction,
-			format!("Contradiction remains unresolved: {contradiction}"),
-			vec![input.objective_id.clone()],
-		));
-	}
-	for note in &input.weakened_validation_or_review {
-		refusals.push(AutonomyProposalRefusal::new(
-			AutonomyProposalRefusalReason::WeakenedValidationReview,
-			format!("Validation or review evidence is weakened: {note}"),
-			vec![input.objective_id.clone()],
-		));
-	}
-
-	refusals
+	refusals::proposal_refusals(objective, signals, input, contradictions)
 }
 
 pub(super) fn derive_proposal_state(
 	has_signals: bool,
 	refusals: &[AutonomyProposalRefusal],
 ) -> AutonomyProposalState {
-	if refusals.iter().any(|refusal| {
-		matches!(
-			refusal.reason,
-			AutonomyProposalRefusalReason::DisallowedSignalKind
-				| AutonomyProposalRefusalReason::DisallowedSurface
-		)
-	}) {
-		return AutonomyProposalState::Rejected;
-	}
-	if refusals
-		.iter()
-		.any(|refusal| refusal.reason == AutonomyProposalRefusalReason::UnresolvedContradiction)
-	{
-		return AutonomyProposalState::NeedsHumanDecision;
-	}
-	if !refusals.is_empty() {
-		return AutonomyProposalState::NeedsEvidence;
-	}
-	if has_signals {
-		AutonomyProposalState::DecisionCandidate
-	} else {
-		AutonomyProposalState::Draft
-	}
-}
-
-pub(super) fn surface_allowed(intended_surface: &str, allowed_surfaces: &[String]) -> bool {
-	let Some(intended_surface) = normalize_repo_relative_path(intended_surface) else {
-		return false;
-	};
-
-	allowed_surfaces.iter().any(|surface| {
-		normalize_repo_relative_path(surface).is_some_and(|surface| {
-			intended_surface == surface
-				|| intended_surface
-					.strip_prefix(&surface)
-					.is_some_and(|suffix| suffix.starts_with('/'))
-		})
-	})
+	refusals::derive_proposal_state(has_signals, refusals)
 }
 
 pub(super) fn normalize_repo_relative_path(value: &str) -> Option<String> {
-	let path = Path::new(value);
-
-	if path.is_absolute() {
-		return None;
-	}
-
-	let mut parts = Vec::new();
-
-	for component in path.components() {
-		let Component::Normal(part) = component else {
-			return None;
-		};
-
-		parts.push(part.to_str()?);
-	}
-
-	if parts.is_empty() {
-		return None;
-	}
-
-	Some(parts.join("/"))
+	paths::normalize_repo_relative_path(value)
 }
 
 pub(super) fn autonomy_proposal_schema() -> String {
-	AUTONOMY_PROPOSAL_SCHEMA.to_owned()
+	identity::autonomy_proposal_schema()
 }
 
 pub(super) const fn autonomy_proposal_record_version() -> u16 {
-	AUTONOMY_PROPOSAL_RECORD_VERSION
+	identity::autonomy_proposal_record_version()
 }
 
 pub(super) fn autonomy_proposal_id(fingerprint: &str) -> String {
-	format!("autonomy_proposal:{fingerprint}")
+	identity::autonomy_proposal_id(fingerprint)
 }
 
 pub(super) fn autonomy_proposal_fingerprint(proposal: &AutonomyProposal) -> Result<String> {
-	let material = serde_json::json!({
-		"project_id": proposal.project_id,
-		"objective_id": proposal.objective_id,
-		"objective_version": proposal.objective_version,
-		"source_signal_ids": proposal.source_signal_ids,
-		"affected_identifiers": proposal.affected_identifiers,
-		"source_family": proposal.source_family,
-		"intended_surface": proposal.intended_surface,
-		"issue_candidates": proposal.issue_candidates,
-	});
-	let payload = serde_json::to_vec(&material)?;
-	let digest = Sha256::digest(payload);
-	let mut hash = String::with_capacity(64);
-
-	for byte in digest {
-		hash.push(char::from(b"0123456789abcdef"[(byte >> 4) as usize]));
-		hash.push(char::from(b"0123456789abcdef"[(byte & 0x0f) as usize]));
-	}
-
-	Ok(hash)
+	identity::autonomy_proposal_fingerprint(proposal)
 }
 
 pub(super) fn validate_compile_input(input: &AutonomyProposalCompileInput) -> Result<()> {
-	validate_required("autonomy proposal input.project_id", &input.project_id)?;
-	validate_required("autonomy proposal input.objective_id", &input.objective_id)?;
-	validate_required("autonomy proposal input.source_family", &input.source_family)?;
-	validate_required("autonomy proposal input.intended_surface", &input.intended_surface)?;
-	validate_required("autonomy proposal input.summary", &input.summary)?;
-	validate_required("autonomy proposal input.rollback_path", &input.rollback_path)?;
-	validate_required("autonomy proposal input.created_at", &input.created_at)?;
-	validate_string_list(
-		"autonomy proposal input.affected_identifiers",
-		&input.affected_identifiers,
-	)?;
-	validate_string_list(
-		"autonomy proposal input.challenge_requirements",
-		&input.challenge_requirements,
-	)?;
-	validate_string_list(
-		"autonomy proposal input.rejected_alternatives",
-		&input.rejected_alternatives,
-	)?;
-	validate_string_list(
-		"autonomy proposal input.weakened_validation_or_review",
-		&input.weakened_validation_or_review,
-	)?;
-	validate_issue_candidates(&input.issue_candidates)?;
-
-	if input.objective_version == 0 {
-		eyre::bail!("Autonomy proposal input objective_version must be greater than zero.");
-	}
-
-	Ok(())
-}
-
-pub(super) fn validate_issue_candidates(
-	issue_candidates: &[AutonomyProposalIssueCandidate],
-) -> Result<()> {
-	let mut keys = BTreeSet::new();
-
-	for issue_candidate in issue_candidates {
-		issue_candidate.validate()?;
-
-		if !keys.insert(issue_candidate.key.as_str()) {
-			eyre::bail!(
-				"Autonomy proposal issue candidate key `{}` is duplicated.",
-				issue_candidate.key
-			);
-		}
-	}
-	for issue_candidate in issue_candidates {
-		for dependency in &issue_candidate.dependencies {
-			if !keys.contains(dependency.as_str()) {
-				eyre::bail!(
-					"Autonomy proposal issue candidate `{}` depends on unknown key `{}`.",
-					issue_candidate.key,
-					dependency
-				);
-			}
-		}
-	}
-
-	let mut visited = BTreeSet::new();
-
-	for issue_candidate in issue_candidates {
-		let mut visiting = BTreeSet::new();
-
-		validate_issue_candidate_acyclic(
-			issue_candidate.key.as_str(),
-			issue_candidates,
-			&mut visiting,
-			&mut visited,
-		)?;
-	}
-
-	Ok(())
+	input::validate_compile_input(input)
 }
 
 pub(super) fn validate_proposed_issue_stage(key: &str, stage: &str) -> Result<()> {
-	match stage {
-		"research" | "design" | "spec" | "schema" | "runtime" | "plugin" | "eval" | "handoff" =>
-			Ok(()),
-		_ => {
-			eyre::bail!(
-				"Autonomy proposal issue candidate `{key}` has unsupported stage `{stage}`."
-			)
-		},
-	}
+	input::validate_proposed_issue_stage(key, stage)
 }
 
 pub(super) fn validate_proposed_issue_queue_intent(key: &str, queue_intent: &str) -> Result<()> {
-	match queue_intent {
-		"not_ready" | "ready_to_queue" | "queued" | "active" | "paused" | "done" | "canceled" =>
-			Ok(()),
-		_ => eyre::bail!(
-			"Autonomy proposal issue candidate `{key}` has unsupported queue_intent `{queue_intent}`."
-		),
-	}
+	input::validate_proposed_issue_queue_intent(key, queue_intent)
 }
 
 pub(super) fn validate_required(name: &str, value: &str) -> Result<()> {
-	if value.trim().is_empty() {
-		eyre::bail!("{name} must not be empty.");
-	}
-
-	Ok(())
+	common::validate_required(name, value)
 }
 
 pub(super) fn validate_optional_required(name: &str, value: Option<&str>) -> Result<()> {
-	if let Some(value) = value {
-		validate_required(name, value)?;
-	}
-
-	Ok(())
+	common::validate_optional_required(name, value)
 }
 
 pub(super) fn validate_string_list(name: &str, values: &[String]) -> Result<()> {
-	for value in values {
-		validate_required(name, value)?;
-	}
-
-	Ok(())
+	common::validate_string_list(name, values)
 }
 
 pub(super) fn validate_sorted_unique(name: &str, values: &[String]) -> Result<()> {
-	validate_string_list(name, values)?;
-
-	let mut seen = BTreeSet::new();
-	let mut previous = None;
-
-	for value in values {
-		if previous.is_some_and(|previous| previous > value.as_str()) {
-			eyre::bail!("{name} must be sorted.");
-		}
-		if !seen.insert(value.as_str()) {
-			eyre::bail!("{name} must not contain duplicates.");
-		}
-
-		previous = Some(value.as_str());
-	}
-
-	Ok(())
+	common::validate_sorted_unique(name, values)
 }
 
 pub(super) fn unique_sorted_strings(values: impl IntoIterator<Item = String>) -> Vec<String> {
-	values
-		.into_iter()
-		.map(|value| value.trim().to_owned())
-		.filter(|value| !value.is_empty())
-		.collect::<BTreeSet<_>>()
-		.into_iter()
-		.collect()
-}
-
-fn validate_issue_candidate_acyclic<'a>(
-	key: &'a str,
-	issue_candidates: &'a [AutonomyProposalIssueCandidate],
-	visiting: &mut BTreeSet<&'a str>,
-	visited: &mut BTreeSet<&'a str>,
-) -> Result<()> {
-	if visited.contains(key) {
-		return Ok(());
-	}
-	if !visiting.insert(key) {
-		eyre::bail!("Autonomy proposal issue candidate `{key}` has cyclic dependencies.");
-	}
-
-	let Some(issue_candidate) =
-		issue_candidates.iter().find(|issue_candidate| issue_candidate.key == key)
-	else {
-		return Ok(());
-	};
-
-	for dependency in &issue_candidate.dependencies {
-		validate_issue_candidate_acyclic(dependency.as_str(), issue_candidates, visiting, visited)?;
-	}
-
-	visiting.remove(key);
-	visited.insert(key);
-
-	Ok(())
+	common::unique_sorted_strings(values)
 }

--- a/apps/decodex/src/autonomy_proposal/validation/common.rs
+++ b/apps/decodex/src/autonomy_proposal/validation/common.rs
@@ -1,0 +1,57 @@
+use std::collections::BTreeSet;
+
+use crate::prelude::{Result, eyre};
+
+pub(super) fn validate_required(name: &str, value: &str) -> Result<()> {
+	if value.trim().is_empty() {
+		eyre::bail!("{name} must not be empty.");
+	}
+
+	Ok(())
+}
+
+pub(super) fn validate_optional_required(name: &str, value: Option<&str>) -> Result<()> {
+	if let Some(value) = value {
+		validate_required(name, value)?;
+	}
+
+	Ok(())
+}
+
+pub(super) fn validate_string_list(name: &str, values: &[String]) -> Result<()> {
+	for value in values {
+		validate_required(name, value)?;
+	}
+
+	Ok(())
+}
+
+pub(super) fn validate_sorted_unique(name: &str, values: &[String]) -> Result<()> {
+	validate_string_list(name, values)?;
+
+	let mut seen = BTreeSet::new();
+	let mut previous = None;
+
+	for value in values {
+		if previous.is_some_and(|previous| previous > value.as_str()) {
+			eyre::bail!("{name} must be sorted.");
+		}
+		if !seen.insert(value.as_str()) {
+			eyre::bail!("{name} must not contain duplicates.");
+		}
+
+		previous = Some(value.as_str());
+	}
+
+	Ok(())
+}
+
+pub(super) fn unique_sorted_strings(values: impl IntoIterator<Item = String>) -> Vec<String> {
+	values
+		.into_iter()
+		.map(|value| value.trim().to_owned())
+		.filter(|value| !value.is_empty())
+		.collect::<BTreeSet<_>>()
+		.into_iter()
+		.collect()
+}

--- a/apps/decodex/src/autonomy_proposal/validation/identity.rs
+++ b/apps/decodex/src/autonomy_proposal/validation/identity.rs
@@ -1,0 +1,43 @@
+use sha2::{Digest as _, Sha256};
+
+use crate::{
+	autonomy_proposal::{
+		AUTONOMY_PROPOSAL_RECORD_VERSION, AUTONOMY_PROPOSAL_SCHEMA, AutonomyProposal,
+	},
+	prelude::Result,
+};
+
+pub(super) fn autonomy_proposal_schema() -> String {
+	AUTONOMY_PROPOSAL_SCHEMA.to_owned()
+}
+
+pub(super) const fn autonomy_proposal_record_version() -> u16 {
+	AUTONOMY_PROPOSAL_RECORD_VERSION
+}
+
+pub(super) fn autonomy_proposal_id(fingerprint: &str) -> String {
+	format!("autonomy_proposal:{fingerprint}")
+}
+
+pub(super) fn autonomy_proposal_fingerprint(proposal: &AutonomyProposal) -> Result<String> {
+	let material = serde_json::json!({
+		"project_id": proposal.project_id,
+		"objective_id": proposal.objective_id,
+		"objective_version": proposal.objective_version,
+		"source_signal_ids": proposal.source_signal_ids,
+		"affected_identifiers": proposal.affected_identifiers,
+		"source_family": proposal.source_family,
+		"intended_surface": proposal.intended_surface,
+		"issue_candidates": proposal.issue_candidates,
+	});
+	let payload = serde_json::to_vec(&material)?;
+	let digest = Sha256::digest(payload);
+	let mut hash = String::with_capacity(64);
+
+	for byte in digest {
+		hash.push(char::from(b"0123456789abcdef"[(byte >> 4) as usize]));
+		hash.push(char::from(b"0123456789abcdef"[(byte & 0x0f) as usize]));
+	}
+
+	Ok(hash)
+}

--- a/apps/decodex/src/autonomy_proposal/validation/input.rs
+++ b/apps/decodex/src/autonomy_proposal/validation/input.rs
@@ -1,0 +1,136 @@
+use std::collections::BTreeSet;
+
+use crate::{
+	autonomy_proposal::{
+		AutonomyProposalCompileInput, AutonomyProposalIssueCandidate, validation::common,
+	},
+	prelude::{Result, eyre},
+};
+
+pub(super) fn validate_compile_input(input: &AutonomyProposalCompileInput) -> Result<()> {
+	common::validate_required("autonomy proposal input.project_id", &input.project_id)?;
+	common::validate_required("autonomy proposal input.objective_id", &input.objective_id)?;
+	common::validate_required("autonomy proposal input.source_family", &input.source_family)?;
+	common::validate_required("autonomy proposal input.intended_surface", &input.intended_surface)?;
+	common::validate_required("autonomy proposal input.summary", &input.summary)?;
+	common::validate_required("autonomy proposal input.rollback_path", &input.rollback_path)?;
+	common::validate_required("autonomy proposal input.created_at", &input.created_at)?;
+	common::validate_string_list(
+		"autonomy proposal input.affected_identifiers",
+		&input.affected_identifiers,
+	)?;
+	common::validate_string_list(
+		"autonomy proposal input.challenge_requirements",
+		&input.challenge_requirements,
+	)?;
+	common::validate_string_list(
+		"autonomy proposal input.rejected_alternatives",
+		&input.rejected_alternatives,
+	)?;
+	common::validate_string_list(
+		"autonomy proposal input.weakened_validation_or_review",
+		&input.weakened_validation_or_review,
+	)?;
+
+	validate_issue_candidates(&input.issue_candidates)?;
+
+	if input.objective_version == 0 {
+		eyre::bail!("Autonomy proposal input objective_version must be greater than zero.");
+	}
+
+	Ok(())
+}
+
+pub(super) fn validate_issue_candidates(
+	issue_candidates: &[AutonomyProposalIssueCandidate],
+) -> Result<()> {
+	let mut keys = BTreeSet::new();
+
+	for issue_candidate in issue_candidates {
+		issue_candidate.validate()?;
+
+		if !keys.insert(issue_candidate.key.as_str()) {
+			eyre::bail!(
+				"Autonomy proposal issue candidate key `{}` is duplicated.",
+				issue_candidate.key
+			);
+		}
+	}
+	for issue_candidate in issue_candidates {
+		for dependency in &issue_candidate.dependencies {
+			if !keys.contains(dependency.as_str()) {
+				eyre::bail!(
+					"Autonomy proposal issue candidate `{}` depends on unknown key `{}`.",
+					issue_candidate.key,
+					dependency
+				);
+			}
+		}
+	}
+
+	let mut visited = BTreeSet::new();
+
+	for issue_candidate in issue_candidates {
+		let mut visiting = BTreeSet::new();
+
+		validate_issue_candidate_acyclic(
+			issue_candidate.key.as_str(),
+			issue_candidates,
+			&mut visiting,
+			&mut visited,
+		)?;
+	}
+
+	Ok(())
+}
+
+pub(super) fn validate_proposed_issue_stage(key: &str, stage: &str) -> Result<()> {
+	match stage {
+		"research" | "design" | "spec" | "schema" | "runtime" | "plugin" | "eval" | "handoff" =>
+			Ok(()),
+		_ => {
+			eyre::bail!(
+				"Autonomy proposal issue candidate `{key}` has unsupported stage `{stage}`."
+			)
+		},
+	}
+}
+
+pub(super) fn validate_proposed_issue_queue_intent(key: &str, queue_intent: &str) -> Result<()> {
+	match queue_intent {
+		"not_ready" | "ready_to_queue" | "queued" | "active" | "paused" | "done" | "canceled" =>
+			Ok(()),
+		_ => eyre::bail!(
+			"Autonomy proposal issue candidate `{key}` has unsupported queue_intent `{queue_intent}`."
+		),
+	}
+}
+
+fn validate_issue_candidate_acyclic<'a>(
+	key: &'a str,
+	issue_candidates: &'a [AutonomyProposalIssueCandidate],
+	visiting: &mut BTreeSet<&'a str>,
+	visited: &mut BTreeSet<&'a str>,
+) -> Result<()> {
+	if visited.contains(key) {
+		return Ok(());
+	}
+	if !visiting.insert(key) {
+		eyre::bail!("Autonomy proposal issue candidate `{key}` has cyclic dependencies.");
+	}
+
+	let Some(issue_candidate) =
+		issue_candidates.iter().find(|issue_candidate| issue_candidate.key == key)
+	else {
+		return Ok(());
+	};
+
+	for dependency in &issue_candidate.dependencies {
+		validate_issue_candidate_acyclic(dependency.as_str(), issue_candidates, visiting, visited)?;
+	}
+
+	visiting.remove(key);
+	visited.insert(key);
+
+	Ok(())
+}

--- a/apps/decodex/src/autonomy_proposal/validation/paths.rs
+++ b/apps/decodex/src/autonomy_proposal/validation/paths.rs
@@ -1,0 +1,40 @@
+use std::path::{Component, Path};
+
+pub(super) fn surface_allowed(intended_surface: &str, allowed_surfaces: &[String]) -> bool {
+	let Some(intended_surface) = normalize_repo_relative_path(intended_surface) else {
+		return false;
+	};
+
+	allowed_surfaces.iter().any(|surface| {
+		normalize_repo_relative_path(surface).is_some_and(|surface| {
+			intended_surface == surface
+				|| intended_surface
+					.strip_prefix(&surface)
+					.is_some_and(|suffix| suffix.starts_with('/'))
+		})
+	})
+}
+
+pub(super) fn normalize_repo_relative_path(value: &str) -> Option<String> {
+	let path = Path::new(value);
+
+	if path.is_absolute() {
+		return None;
+	}
+
+	let mut parts = Vec::new();
+
+	for component in path.components() {
+		let Component::Normal(part) = component else {
+			return None;
+		};
+
+		parts.push(part.to_str()?);
+	}
+
+	if parts.is_empty() {
+		return None;
+	}
+
+	Some(parts.join("/"))
+}

--- a/apps/decodex/src/autonomy_proposal/validation/refusals.rs
+++ b/apps/decodex/src/autonomy_proposal/validation/refusals.rs
@@ -1,0 +1,145 @@
+use crate::{
+	autonomy_objective::{AutonomyObjectiveContract, AutonomyObjectiveState},
+	autonomy_proposal::{
+		AutonomyProposalCompileInput, AutonomyProposalRefusal, AutonomyProposalRefusalReason,
+		AutonomyProposalState, validation::paths,
+	},
+	autonomy_signal::{AutonomySignal, AutonomySignalFreshness},
+};
+
+pub(super) fn proposal_refusals(
+	objective: Option<&AutonomyObjectiveContract>,
+	signals: &[AutonomySignal],
+	input: &AutonomyProposalCompileInput,
+	contradictions: &[String],
+) -> Vec<AutonomyProposalRefusal> {
+	let mut refusals = Vec::new();
+
+	match objective {
+		Some(objective)
+			if objective.project_id() == input.project_id
+				&& objective.id() == input.objective_id
+				&& objective.version() == input.objective_version
+				&& objective.state() == AutonomyObjectiveState::Accepted => {
+				for signal in signals {
+					if signal.project_id() != input.project_id
+						|| signal.objective_id() != input.objective_id
+						|| signal.objective_version() != input.objective_version
+					{
+						refusals.push(AutonomyProposalRefusal::new(
+							AutonomyProposalRefusalReason::MissingObjective,
+							format!(
+								"Signal `{}` is not tied to objective `{}` version {}.",
+								signal.id(),
+								input.objective_id,
+								input.objective_version
+							),
+							vec![signal.id().to_owned()],
+						));
+					}
+					if !objective
+						.allowed_signal_kinds()
+						.iter()
+						.any(|kind| kind == signal.kind().as_str())
+					{
+						refusals.push(AutonomyProposalRefusal::new(
+							AutonomyProposalRefusalReason::DisallowedSignalKind,
+							format!(
+								"Signal `{}` kind `{}` is outside the accepted objective allowed_signal_kinds.",
+								signal.id(),
+								signal.kind().as_str()
+							),
+							vec![signal.id().to_owned()],
+						));
+					}
+					if signal.freshness() != AutonomySignalFreshness::Fresh {
+						refusals.push(AutonomyProposalRefusal::new(
+							AutonomyProposalRefusalReason::StaleEvidence,
+							format!(
+								"Signal `{}` freshness is `{}` and requires fresh readback before acceptance.",
+								signal.id(),
+								signal.freshness().as_str()
+							),
+							vec![signal.id().to_owned()],
+						));
+					}
+				}
+
+				if !paths::surface_allowed(&input.intended_surface, objective.allowed_surfaces()) {
+					refusals.push(AutonomyProposalRefusal::new(
+						AutonomyProposalRefusalReason::DisallowedSurface,
+						format!(
+							"Intended surface `{}` is outside the accepted objective allowed_surfaces.",
+							input.intended_surface
+						),
+						vec![input.objective_id.clone()],
+					));
+				}
+			},
+		Some(objective) => refusals.push(AutonomyProposalRefusal::new(
+			AutonomyProposalRefusalReason::MissingObjective,
+			format!(
+				"Objective `{}` version {} exists in state `{}` but is not the accepted exact proposal objective.",
+				objective.id(),
+				objective.version(),
+				objective.state().as_str()
+			),
+			vec![input.objective_id.clone()],
+		)),
+		None => refusals.push(AutonomyProposalRefusal::new(
+			AutonomyProposalRefusalReason::MissingObjective,
+			format!(
+				"Objective `{}` version {} is missing.",
+				input.objective_id,
+				input.objective_version
+			),
+			vec![input.objective_id.clone()],
+		)),
+	}
+
+	for contradiction in contradictions {
+		refusals.push(AutonomyProposalRefusal::new(
+			AutonomyProposalRefusalReason::UnresolvedContradiction,
+			format!("Contradiction remains unresolved: {contradiction}"),
+			vec![input.objective_id.clone()],
+		));
+	}
+	for note in &input.weakened_validation_or_review {
+		refusals.push(AutonomyProposalRefusal::new(
+			AutonomyProposalRefusalReason::WeakenedValidationReview,
+			format!("Validation or review evidence is weakened: {note}"),
+			vec![input.objective_id.clone()],
+		));
+	}
+
+	refusals
+}
+
+pub(super) fn derive_proposal_state(
+	has_signals: bool,
+	refusals: &[AutonomyProposalRefusal],
+) -> AutonomyProposalState {
+	if refusals.iter().any(|refusal| {
+		matches!(
+			refusal.reason,
+			AutonomyProposalRefusalReason::DisallowedSignalKind
+				| AutonomyProposalRefusalReason::DisallowedSurface
+		)
+	}) {
+		return AutonomyProposalState::Rejected;
+	}
+	if refusals
+		.iter()
+		.any(|refusal| refusal.reason == AutonomyProposalRefusalReason::UnresolvedContradiction)
+	{
+		return AutonomyProposalState::NeedsHumanDecision;
+	}
+	if !refusals.is_empty() {
+		return AutonomyProposalState::NeedsEvidence;
+	}
+	if has_signals {
+		AutonomyProposalState::DecisionCandidate
+	} else {
+		AutonomyProposalState::Draft
+	}
+}


### PR DESCRIPTION
## Summary
- Split autonomy proposal decision bridge helpers into focused flat Rust modules.
- Split proposal validation helpers into focused flat Rust modules while keeping stable facade APIs for existing callers.
- Avoided mod.rs, wildcard imports, include/path indirection, and clippy allow/expect workarounds.

## Validation
- rustup run nightly cargo fmt --all --check
- cargo make lint-vstyle-rust
- cargo check -p decodex --lib --tests
- cargo clippy -p decodex --lib --tests --all-features -- -D warnings
- cargo test -p decodex autonomy_proposal::tests --lib -- --format terse
- git diff --check
- find apps -path '*/target' -prune -o -type f -name mod.rs -print 2>/dev/null
- rg scan over changed proposal helper modules for allow/expect, wildcard imports, include!, and #[path]