### PR TITLE
Split recovery lane diagnosis modules

### DIFF
--- a/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection.rs
+++ b/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection.rs
@@ -1,14 +1,17 @@
+mod control;
+mod outcome;
+mod private;
+mod review_lineage;
+mod tracker_issue;
+mod worktree;
+
 use std::path::Path;
 
 use crate::{
 	prelude::Result,
-	recovery::{
-		self, GHOST_LANE_BLOCKED_CLASSIFICATION, GHOST_LANE_CLASSIFICATION,
-		MCP_TEST_FIXTURE_GHOST_LANE_CLASSIFICATION, evidence, identifiers,
-		reports::GhostLaneDiagnostic,
-	},
+	recovery::{self, identifiers, reports::GhostLaneDiagnostic},
 	state::{ProjectRunStatus, StateStore},
-	tracker::{self, IssueTracker},
+	tracker::IssueTracker,
 };
 
 pub(super) fn inspect_ghost_lane<T>(
@@ -23,7 +26,7 @@ where
 	T: IssueTracker + ?Sized,
 {
 	let issue_identifier = identifiers::ghost_lane_issue_identifier(run, requested_selector);
-	let mcp_test_fixture = ghost_lane_mcp_test_fixture_control_evidence(
+	let mcp_test_fixture = private::ghost_lane_mcp_test_fixture_control_evidence(
 		project_id,
 		state_store,
 		run,
@@ -38,7 +41,7 @@ where
 		blockers.push(String::from("run_lease_missing"));
 	}
 
-	inspect_ghost_lane_tracker_issue(
+	tracker_issue::inspect_ghost_lane_tracker_issue(
 		tracker,
 		run,
 		issue_identifier.as_deref(),
@@ -46,7 +49,7 @@ where
 		&mut evidence,
 		&mut blockers,
 	)?;
-	inspect_ghost_lane_worktree(
+	worktree::inspect_ghost_lane_worktree(
 		worktree_root,
 		state_store,
 		run,
@@ -56,11 +59,15 @@ where
 		&mut blockers,
 	)?;
 
-	let control_channel =
-		inspect_ghost_lane_control_channel(run, mcp_test_fixture, &mut evidence, &mut blockers);
+	let control_channel = control::inspect_ghost_lane_control_channel(
+		run,
+		mcp_test_fixture,
+		&mut evidence,
+		&mut blockers,
+	);
 
-	inspect_ghost_lane_live_evidence(run, mcp_test_fixture, &mut evidence, &mut blockers);
-	inspect_ghost_lane_private_evidence(
+	control::inspect_ghost_lane_live_evidence(run, mcp_test_fixture, &mut evidence, &mut blockers);
+	private::inspect_ghost_lane_private_evidence(
 		project_id,
 		state_store,
 		run,
@@ -68,7 +75,7 @@ where
 		&mut evidence,
 		&mut blockers,
 	)?;
-	inspect_ghost_lane_review_lineage(
+	review_lineage::inspect_ghost_lane_review_lineage(
 		project_id,
 		state_store,
 		run,
@@ -77,36 +84,12 @@ where
 		&mut blockers,
 	)?;
 
-	let (classification, reason, next_action) = if blockers.is_empty() {
-		let (classification, reason) = if mcp_test_fixture {
-			(
-				String::from(MCP_TEST_FIXTURE_GHOST_LANE_CLASSIFICATION),
-				String::from("tracker_issue_missing_and_only_mcp_test_control_fixture_evidence"),
-			)
-		} else {
-			(
-				String::from(GHOST_LANE_CLASSIFICATION),
-				String::from("tracker_issue_missing_and_no_live_or_retained_lane_evidence"),
-			)
-		};
-
-		(
-			classification,
-			reason,
-			format!(
-				"Run `decodex recover ghost-lane cleanup {} --dry-run`, then rerun without `--dry-run` if the report stays safe.",
-				issue_identifier.as_deref().unwrap_or(run.issue_id())
-			),
-		)
-	} else {
-		(
-			String::from(GHOST_LANE_BLOCKED_CLASSIFICATION),
-			String::from("safety_check_blocked"),
-			String::from(
-				"Preserve attention and inspect the listed blockers before using a recovery command.",
-			),
-		)
-	};
+	let (classification, reason, next_action) = outcome::ghost_lane_diagnostic_outcome(
+		run,
+		issue_identifier.as_deref(),
+		mcp_test_fixture,
+		&blockers,
+	);
 
 	Ok(GhostLaneDiagnostic {
 		project_id: project_id.to_owned(),
@@ -123,278 +106,4 @@ where
 		blockers: recovery::sorted_unique(blockers),
 		next_action,
 	})
-}
-
-fn inspect_ghost_lane_tracker_issue<T>(
-	tracker: &T,
-	run: &ProjectRunStatus,
-	issue_identifier: Option<&str>,
-	requested_selector: Option<&str>,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) -> Result<()>
-where
-	T: IssueTracker + ?Sized,
-{
-	let refreshed = match tracker.refresh_issues(&[run.issue_id().to_owned()]) {
-		Ok(refreshed) => refreshed,
-		Err(error) if tracker::issue_lookup_missing_error_for_candidate(&error, run.issue_id()) =>
-			Vec::new(),
-		Err(error) => return Err(error),
-	};
-
-	if !refreshed.is_empty() {
-		blockers.push(String::from("tracker_issue_present"));
-
-		return Ok(());
-	}
-
-	for selector in
-		identifiers::ghost_lane_tracker_issue_selectors(run, issue_identifier, requested_selector)
-	{
-		match tracker.get_issue_by_identifier(&selector) {
-			Ok(Some(_)) => {
-				blockers.push(String::from("tracker_issue_present"));
-
-				return Ok(());
-			},
-			Ok(None) => {},
-			Err(error) if tracker::issue_lookup_missing_error_for_candidate(&error, &selector) => {
-			},
-			Err(error) => return Err(error),
-		}
-	}
-
-	evidence.push(String::from("tracker_issue_missing"));
-
-	Ok(())
-}
-
-fn inspect_ghost_lane_worktree(
-	worktree_root: &Path,
-	state_store: &StateStore,
-	run: &ProjectRunStatus,
-	issue_identifier: Option<&str>,
-	requested_selector: Option<&str>,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) -> Result<()> {
-	let mut retained_worktree_present = false;
-	let mut mapping_checked = false;
-
-	if let Some(worktree_path) = run.worktree_path() {
-		mapping_checked = true;
-
-		if worktree_path.exists() {
-			retained_worktree_present = true;
-		} else {
-			evidence.push(String::from("worktree_mapping_path_missing"));
-		}
-	}
-	if let Some(mapping) = state_store.worktree_for_issue(run.issue_id())? {
-		mapping_checked = true;
-
-		if mapping.worktree_path().exists() {
-			retained_worktree_present = true;
-		} else {
-			evidence.push(String::from("worktree_mapping_path_missing"));
-		}
-	}
-
-	for selector in
-		identifiers::ghost_lane_worktree_selectors(run, issue_identifier, requested_selector)
-	{
-		if worktree_root.join(&selector).exists() {
-			retained_worktree_present = true;
-		}
-	}
-
-	if retained_worktree_present {
-		blockers.push(String::from("retained_worktree_present"));
-	} else {
-		if !mapping_checked {
-			evidence.push(String::from("worktree_mapping_missing"));
-		}
-
-		evidence.push(String::from("worktree_missing"));
-	}
-
-	Ok(())
-}
-
-fn inspect_ghost_lane_control_channel(
-	run: &ProjectRunStatus,
-	mcp_test_fixture: bool,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) -> String {
-	let Some(channel) = run.control_channel() else {
-		evidence.push(String::from("control_channel_missing"));
-
-		return String::from("missing");
-	};
-
-	if channel.channel_path().exists() {
-		evidence.push(String::from("control_channel_file_present"));
-		blockers.push(String::from("control_channel_present"));
-	} else {
-		evidence.push(String::from("control_channel_file_missing"));
-
-		if mcp_test_fixture {
-			evidence.push(String::from("mcp_test_fixture_control_channel_row_present"));
-		} else {
-			blockers.push(String::from("control_channel_present"));
-		}
-	}
-
-	format!("{}:present", channel.status())
-}
-
-fn inspect_ghost_lane_live_evidence(
-	run: &ProjectRunStatus,
-	mcp_test_fixture: bool,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) {
-	let mut live_blockers = Vec::new();
-
-	if run.event_count() > 0 || run.last_event_type().is_some() || run.last_event_at().is_some() {
-		live_blockers.push(String::from("protocol_event_evidence_present"));
-	}
-	if run.child_agent_activity().is_some() {
-		live_blockers.push(String::from("child_agent_activity_present"));
-	}
-	if run.protocol_activity().is_some() {
-		live_blockers.push(String::from("protocol_activity_present"));
-	}
-	if run.thread_id().is_some() || run.turn_id().is_some() {
-		live_blockers.push(String::from("thread_reference_present"));
-	}
-	if live_blockers.is_empty() {
-		evidence.push(String::from("no_live_execution_evidence"));
-
-		return;
-	}
-	if mcp_test_fixture
-		&& live_blockers
-			.iter()
-			.all(|blocker| evidence::ghost_lane_mcp_test_fixture_allowed_live_blocker(blocker))
-	{
-		evidence.push(String::from("mcp_test_fixture_protocol_or_thread_evidence_present"));
-
-		return;
-	}
-
-	blockers.extend(live_blockers);
-}
-
-fn inspect_ghost_lane_private_evidence(
-	project_id: &str,
-	state_store: &StateStore,
-	run: &ProjectRunStatus,
-	mcp_test_fixture: bool,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) -> Result<()> {
-	let events = state_store.list_private_execution_events(
-		project_id,
-		run.issue_id(),
-		run.run_id(),
-		run.attempt_number(),
-	)?;
-
-	if events.is_empty() {
-		evidence.push(String::from("private_evidence_missing"));
-	} else if mcp_test_fixture {
-		evidence.push(String::from("mcp_test_fixture_private_control_evidence_present"));
-
-		if events.iter().any(evidence::ghost_lane_private_event_is_cleanup_audit) {
-			evidence.push(String::from("ghost_lane_cleanup_audit_present"));
-		}
-	} else if evidence::ghost_lane_private_events_are_cleanup_audit_evidence(&events) {
-		evidence.push(String::from("ghost_lane_cleanup_audit_present"));
-	} else {
-		blockers.push(String::from("private_evidence_present"));
-	}
-
-	Ok(())
-}
-
-fn ghost_lane_mcp_test_fixture_control_evidence(
-	project_id: &str,
-	state_store: &StateStore,
-	run: &ProjectRunStatus,
-	issue_identifier: Option<&str>,
-) -> Result<bool> {
-	if !evidence::ghost_lane_has_mcp_test_fixture_identity(project_id, run, issue_identifier) {
-		return Ok(false);
-	}
-
-	let events = state_store.list_private_execution_events(
-		project_id,
-		run.issue_id(),
-		run.run_id(),
-		run.attempt_number(),
-	)?;
-
-	Ok(evidence::ghost_lane_private_events_are_mcp_test_recovery_evidence(&events))
-}
-
-fn inspect_ghost_lane_review_lineage(
-	project_id: &str,
-	state_store: &StateStore,
-	run: &ProjectRunStatus,
-	issue_identifier: Option<&str>,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) -> Result<()> {
-	if state_store.issue_has_review_lifecycle_record(project_id, run.issue_id())? {
-		blockers.push(String::from("review_lifecycle_present"));
-
-		return Ok(());
-	}
-	if ghost_lane_run_has_review_policy_checkpoint(project_id, state_store, run)? {
-		blockers.push(String::from("review_policy_checkpoint_present"));
-
-		return Ok(());
-	}
-
-	let mut records = state_store.list_linear_execution_events(project_id, run.issue_id())?;
-
-	if let Some(issue_identifier) = issue_identifier
-		.filter(|issue_identifier| !issue_identifier.eq_ignore_ascii_case(run.issue_id()))
-	{
-		records.extend(state_store.list_linear_execution_events(project_id, issue_identifier)?);
-	}
-
-	if records.iter().any(evidence::ghost_lane_record_has_pr_or_review_lineage) {
-		blockers.push(String::from("pr_or_review_lineage_present"));
-	} else {
-		evidence.push(String::from("review_lineage_missing"));
-	}
-
-	Ok(())
-}
-
-fn ghost_lane_run_has_review_policy_checkpoint(
-	project_id: &str,
-	state_store: &StateStore,
-	run: &ProjectRunStatus,
-) -> Result<bool> {
-	for phase in ["handoff", "repair"] {
-		if state_store
-			.review_policy_checkpoint(
-				project_id,
-				run.issue_id(),
-				run.run_id(),
-				run.attempt_number(),
-				phase,
-			)?
-			.is_some()
-		{
-			return Ok(true);
-		}
-	}
-
-	Ok(false)
 }

--- a/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection/control.rs
+++ b/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection/control.rs
@@ -1,0 +1,67 @@
+use crate::{recovery::evidence, state::ProjectRunStatus};
+
+pub(super) fn inspect_ghost_lane_control_channel(
+	run: &ProjectRunStatus,
+	mcp_test_fixture: bool,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> String {
+	let Some(channel) = run.control_channel() else {
+		evidence.push(String::from("control_channel_missing"));
+
+		return String::from("missing");
+	};
+
+	if channel.channel_path().exists() {
+		evidence.push(String::from("control_channel_file_present"));
+		blockers.push(String::from("control_channel_present"));
+	} else {
+		evidence.push(String::from("control_channel_file_missing"));
+
+		if mcp_test_fixture {
+			evidence.push(String::from("mcp_test_fixture_control_channel_row_present"));
+		} else {
+			blockers.push(String::from("control_channel_present"));
+		}
+	}
+
+	format!("{}:present", channel.status())
+}
+
+pub(super) fn inspect_ghost_lane_live_evidence(
+	run: &ProjectRunStatus,
+	mcp_test_fixture: bool,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) {
+	let mut live_blockers = Vec::new();
+
+	if run.event_count() > 0 || run.last_event_type().is_some() || run.last_event_at().is_some() {
+		live_blockers.push(String::from("protocol_event_evidence_present"));
+	}
+	if run.child_agent_activity().is_some() {
+		live_blockers.push(String::from("child_agent_activity_present"));
+	}
+	if run.protocol_activity().is_some() {
+		live_blockers.push(String::from("protocol_activity_present"));
+	}
+	if run.thread_id().is_some() || run.turn_id().is_some() {
+		live_blockers.push(String::from("thread_reference_present"));
+	}
+	if live_blockers.is_empty() {
+		evidence.push(String::from("no_live_execution_evidence"));
+
+		return;
+	}
+	if mcp_test_fixture
+		&& live_blockers
+			.iter()
+			.all(|blocker| evidence::ghost_lane_mcp_test_fixture_allowed_live_blocker(blocker))
+	{
+		evidence.push(String::from("mcp_test_fixture_protocol_or_thread_evidence_present"));
+
+		return;
+	}
+
+	blockers.extend(live_blockers);
+}

--- a/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection/outcome.rs
+++ b/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection/outcome.rs
@@ -1,0 +1,45 @@
+use crate::{
+	recovery::{
+		GHOST_LANE_BLOCKED_CLASSIFICATION, GHOST_LANE_CLASSIFICATION,
+		MCP_TEST_FIXTURE_GHOST_LANE_CLASSIFICATION,
+	},
+	state::ProjectRunStatus,
+};
+
+pub(super) fn ghost_lane_diagnostic_outcome(
+	run: &ProjectRunStatus,
+	issue_identifier: Option<&str>,
+	mcp_test_fixture: bool,
+	blockers: &[String],
+) -> (String, String, String) {
+	if blockers.is_empty() {
+		let (classification, reason) = if mcp_test_fixture {
+			(
+				String::from(MCP_TEST_FIXTURE_GHOST_LANE_CLASSIFICATION),
+				String::from("tracker_issue_missing_and_only_mcp_test_control_fixture_evidence"),
+			)
+		} else {
+			(
+				String::from(GHOST_LANE_CLASSIFICATION),
+				String::from("tracker_issue_missing_and_no_live_or_retained_lane_evidence"),
+			)
+		};
+
+		return (
+			classification,
+			reason,
+			format!(
+				"Run `decodex recover ghost-lane cleanup {} --dry-run`, then rerun without `--dry-run` if the report stays safe.",
+				issue_identifier.unwrap_or(run.issue_id())
+			),
+		);
+	}
+
+	(
+		String::from(GHOST_LANE_BLOCKED_CLASSIFICATION),
+		String::from("safety_check_blocked"),
+		String::from(
+			"Preserve attention and inspect the listed blockers before using a recovery command.",
+		),
+	)
+}

--- a/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection/private.rs
+++ b/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection/private.rs
@@ -1,0 +1,57 @@
+use crate::{
+	prelude::Result,
+	recovery::evidence,
+	state::{ProjectRunStatus, StateStore},
+};
+
+pub(super) fn inspect_ghost_lane_private_evidence(
+	project_id: &str,
+	state_store: &StateStore,
+	run: &ProjectRunStatus,
+	mcp_test_fixture: bool,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Result<()> {
+	let events = state_store.list_private_execution_events(
+		project_id,
+		run.issue_id(),
+		run.run_id(),
+		run.attempt_number(),
+	)?;
+
+	if events.is_empty() {
+		evidence.push(String::from("private_evidence_missing"));
+	} else if mcp_test_fixture {
+		evidence.push(String::from("mcp_test_fixture_private_control_evidence_present"));
+
+		if events.iter().any(evidence::ghost_lane_private_event_is_cleanup_audit) {
+			evidence.push(String::from("ghost_lane_cleanup_audit_present"));
+		}
+	} else if evidence::ghost_lane_private_events_are_cleanup_audit_evidence(&events) {
+		evidence.push(String::from("ghost_lane_cleanup_audit_present"));
+	} else {
+		blockers.push(String::from("private_evidence_present"));
+	}
+
+	Ok(())
+}
+
+pub(super) fn ghost_lane_mcp_test_fixture_control_evidence(
+	project_id: &str,
+	state_store: &StateStore,
+	run: &ProjectRunStatus,
+	issue_identifier: Option<&str>,
+) -> Result<bool> {
+	if !evidence::ghost_lane_has_mcp_test_fixture_identity(project_id, run, issue_identifier) {
+		return Ok(false);
+	}
+
+	let events = state_store.list_private_execution_events(
+		project_id,
+		run.issue_id(),
+		run.run_id(),
+		run.attempt_number(),
+	)?;
+
+	Ok(evidence::ghost_lane_private_events_are_mcp_test_recovery_evidence(&events))
+}

--- a/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection/review_lineage.rs
+++ b/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection/review_lineage.rs
@@ -1,0 +1,64 @@
+use crate::{
+	prelude::Result,
+	recovery::evidence,
+	state::{ProjectRunStatus, StateStore},
+};
+
+pub(super) fn inspect_ghost_lane_review_lineage(
+	project_id: &str,
+	state_store: &StateStore,
+	run: &ProjectRunStatus,
+	issue_identifier: Option<&str>,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Result<()> {
+	if state_store.issue_has_review_lifecycle_record(project_id, run.issue_id())? {
+		blockers.push(String::from("review_lifecycle_present"));
+
+		return Ok(());
+	}
+	if ghost_lane_run_has_review_policy_checkpoint(project_id, state_store, run)? {
+		blockers.push(String::from("review_policy_checkpoint_present"));
+
+		return Ok(());
+	}
+
+	let mut records = state_store.list_linear_execution_events(project_id, run.issue_id())?;
+
+	if let Some(issue_identifier) = issue_identifier
+		.filter(|issue_identifier| !issue_identifier.eq_ignore_ascii_case(run.issue_id()))
+	{
+		records.extend(state_store.list_linear_execution_events(project_id, issue_identifier)?);
+	}
+
+	if records.iter().any(evidence::ghost_lane_record_has_pr_or_review_lineage) {
+		blockers.push(String::from("pr_or_review_lineage_present"));
+	} else {
+		evidence.push(String::from("review_lineage_missing"));
+	}
+
+	Ok(())
+}
+
+fn ghost_lane_run_has_review_policy_checkpoint(
+	project_id: &str,
+	state_store: &StateStore,
+	run: &ProjectRunStatus,
+) -> Result<bool> {
+	for phase in ["handoff", "repair"] {
+		if state_store
+			.review_policy_checkpoint(
+				project_id,
+				run.issue_id(),
+				run.run_id(),
+				run.attempt_number(),
+				phase,
+			)?
+			.is_some()
+		{
+			return Ok(true);
+		}
+	}
+
+	Ok(false)
+}

--- a/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection/tracker_issue.rs
+++ b/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection/tracker_issue.rs
@@ -1,0 +1,51 @@
+use crate::{
+	prelude::Result,
+	recovery::identifiers,
+	state::ProjectRunStatus,
+	tracker::{self, IssueTracker},
+};
+
+pub(super) fn inspect_ghost_lane_tracker_issue<T>(
+	tracker: &T,
+	run: &ProjectRunStatus,
+	issue_identifier: Option<&str>,
+	requested_selector: Option<&str>,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Result<()>
+where
+	T: IssueTracker + ?Sized,
+{
+	let refreshed = match tracker.refresh_issues(&[run.issue_id().to_owned()]) {
+		Ok(refreshed) => refreshed,
+		Err(error) if tracker::issue_lookup_missing_error_for_candidate(&error, run.issue_id()) =>
+			Vec::new(),
+		Err(error) => return Err(error),
+	};
+
+	if !refreshed.is_empty() {
+		blockers.push(String::from("tracker_issue_present"));
+
+		return Ok(());
+	}
+
+	for selector in
+		identifiers::ghost_lane_tracker_issue_selectors(run, issue_identifier, requested_selector)
+	{
+		match tracker.get_issue_by_identifier(&selector) {
+			Ok(Some(_)) => {
+				blockers.push(String::from("tracker_issue_present"));
+
+				return Ok(());
+			},
+			Ok(None) => {},
+			Err(error) if tracker::issue_lookup_missing_error_for_candidate(&error, &selector) => {
+			},
+			Err(error) => return Err(error),
+		}
+	}
+
+	evidence.push(String::from("tracker_issue_missing"));
+
+	Ok(())
+}

--- a/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection/worktree.rs
+++ b/apps/decodex/src/recovery/ghost_lane_diagnosis/inspection/worktree.rs
@@ -1,0 +1,59 @@
+use std::path::Path;
+
+use crate::{
+	prelude::Result,
+	recovery::identifiers,
+	state::{ProjectRunStatus, StateStore},
+};
+
+pub(super) fn inspect_ghost_lane_worktree(
+	worktree_root: &Path,
+	state_store: &StateStore,
+	run: &ProjectRunStatus,
+	issue_identifier: Option<&str>,
+	requested_selector: Option<&str>,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Result<()> {
+	let mut retained_worktree_present = false;
+	let mut mapping_checked = false;
+
+	if let Some(worktree_path) = run.worktree_path() {
+		mapping_checked = true;
+
+		if worktree_path.exists() {
+			retained_worktree_present = true;
+		} else {
+			evidence.push(String::from("worktree_mapping_path_missing"));
+		}
+	}
+	if let Some(mapping) = state_store.worktree_for_issue(run.issue_id())? {
+		mapping_checked = true;
+
+		if mapping.worktree_path().exists() {
+			retained_worktree_present = true;
+		} else {
+			evidence.push(String::from("worktree_mapping_path_missing"));
+		}
+	}
+
+	for selector in
+		identifiers::ghost_lane_worktree_selectors(run, issue_identifier, requested_selector)
+	{
+		if worktree_root.join(&selector).exists() {
+			retained_worktree_present = true;
+		}
+	}
+
+	if retained_worktree_present {
+		blockers.push(String::from("retained_worktree_present"));
+	} else {
+		if !mapping_checked {
+			evidence.push(String::from("worktree_mapping_missing"));
+		}
+
+		evidence.push(String::from("worktree_missing"));
+	}
+
+	Ok(())
+}

--- a/apps/decodex/src/recovery/stale_active_diagnosis/inspection.rs
+++ b/apps/decodex/src/recovery/stale_active_diagnosis/inspection.rs
@@ -1,64 +1,29 @@
+mod authority;
+mod dead_ownership;
+mod diagnostic;
+mod inputs;
+mod reentry;
+mod sources;
+
 use std::path::Path;
 
 use crate::{
 	prelude::Result,
 	recovery::{
-		self, STALE_ACTIVE_BLOCKED_CLASSIFICATION, STALE_ACTIVE_CLASSIFICATION,
-		STALE_ACTIVE_STATE_RESTORE_CLASSIFICATION,
 		context::RecoveryRuntimeMutationPolicy,
 		process_liveness::{self, StaleActiveProcessLiveness},
 		reports::StaleActiveDiagnostic,
-		stale_active_authority, stale_active_guidance,
-		stale_active_labels::{self, StaleActiveLabelSnapshot},
-		stale_active_reentry::{self, StaleActiveReleaseReentryInput},
+		stale_active_labels::{self},
 		stale_active_runtime, stale_active_worktree,
 	},
-	state::{self, ProjectRunStatus, RunActivityMarker, StateStore, WorktreeMapping},
+	state::{ProjectRunStatus, StateStore},
 	tracker::{IssueTracker, TrackerIssue},
 	workflow::WorkflowDocument,
 };
-
-struct StaleActiveDiagnosticParts<'a> {
-	project_id: &'a str,
-	issue: TrackerIssue,
-	labels: StaleActiveLabelSnapshot,
-	latest_run: Option<&'a ProjectRunStatus>,
-	run_lease: bool,
-	active_shared_claim: bool,
-	control_channel: String,
-	worktree_path: &'a Path,
-	worktree_state: String,
-	evidence: Vec<String>,
-	blockers: Vec<String>,
-}
-
-struct StaleActiveDeadOwnershipInput<'a> {
-	project_id: &'a str,
-	state_store: &'a StateStore,
-	issue_keys: &'a [String],
-	marker: Option<&'a RunActivityMarker>,
-	marker_liveness: StaleActiveProcessLiveness,
-	latest_run: Option<&'a ProjectRunStatus>,
-	run_lease: bool,
-	active_shared_claim: bool,
-}
-
-struct StaleActiveReleaseReentryInspection<'a> {
-	latest_run: Option<&'a ProjectRunStatus>,
-	run_lease: bool,
-	active_shared_claim: bool,
-	labels: &'a StaleActiveLabelSnapshot,
-	issue: &'a TrackerIssue,
-	workflow: &'a WorkflowDocument,
-	worktree_state: &'a str,
-	control_channel: &'a str,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-struct StaleActiveDeadLocalClaims {
-	matching_claim_count: usize,
-	incompatible_claim_present: bool,
-}
+use inputs::{
+	StaleActiveAuthorityEvidenceInspection, StaleActiveDeadOwnershipInput,
+	StaleActiveDiagnosticParts, StaleActiveReleaseReentryInspection,
+};
 
 pub(super) fn inspect_stale_active_issue<T>(
 	project_id: &str,
@@ -99,19 +64,24 @@ where
 	let latest_run = stale_active_runtime::latest_stale_active_run(&runs);
 	let run_lease = runs.iter().any(ProjectRunStatus::run_lease);
 
-	record_stale_active_run_lease_evidence(run_lease, &mut evidence, &mut blockers);
+	sources::record_stale_active_run_lease_evidence(run_lease, &mut evidence, &mut blockers);
 
-	let mapping =
-		read_stale_active_worktree_mapping(state_store, &issue_keys, &mut evidence, &mut blockers);
+	let mapping = sources::read_stale_active_worktree_mapping(
+		state_store,
+		&issue_keys,
+		&mut evidence,
+		&mut blockers,
+	);
 	let worktree_path = mapping
 		.as_ref()
 		.map(|mapping| mapping.worktree_path().to_path_buf())
 		.unwrap_or_else(|| worktree_root.join(&issue.identifier));
-	let marker = read_stale_active_activity_marker(&worktree_path, &mut evidence, &mut blockers);
+	let marker =
+		sources::read_stale_active_activity_marker(&worktree_path, &mut evidence, &mut blockers);
 	let marker_liveness =
 		process_liveness::stale_active_optional_marker_process_liveness(marker.as_ref());
 
-	record_recoverable_dead_leased_ownership(
+	inspect_stale_active_dead_ownership_and_runs(
 		StaleActiveDeadOwnershipInput {
 			project_id,
 			state_store,
@@ -122,11 +92,6 @@ where
 			run_lease,
 			active_shared_claim,
 		},
-		&mut evidence,
-		&mut blockers,
-	);
-
-	stale_active_runtime::inspect_stale_active_run_evidence(
 		&runs,
 		marker_liveness,
 		&mut evidence,
@@ -149,18 +114,20 @@ where
 		&mut blockers,
 	);
 
-	inspect_stale_active_authority_evidence(
-		project_id,
-		state_store,
-		tracker,
-		&issue,
-		issue_keys.as_slice(),
-		latest_run,
-		marker_liveness,
+	authority::inspect_stale_active_authority_evidence(
+		StaleActiveAuthorityEvidenceInspection {
+			project_id,
+			state_store,
+			tracker,
+			issue: &issue,
+			issue_keys: &issue_keys,
+			latest_run,
+			marker_liveness,
+		},
 		&mut evidence,
 		&mut blockers,
 	)?;
-	apply_stale_active_release_reentry(
+	reentry::apply_stale_active_release_reentry(
 		StaleActiveReleaseReentryInspection {
 			latest_run,
 			run_lease,
@@ -175,7 +142,7 @@ where
 		&mut blockers,
 	);
 
-	Ok(stale_active_diagnostic_from_parts(StaleActiveDiagnosticParts {
+	Ok(diagnostic::stale_active_diagnostic_from_parts(StaleActiveDiagnosticParts {
 		project_id,
 		issue,
 		labels,
@@ -190,261 +157,22 @@ where
 	}))
 }
 
-fn stale_active_diagnostic_from_parts(
-	parts: StaleActiveDiagnosticParts<'_>,
-) -> StaleActiveDiagnostic {
-	let (classification, reason, next_action) =
-		stale_active_diagnostic_outcome(&parts.issue.identifier, &parts.evidence, &parts.blockers);
-
-	StaleActiveDiagnostic {
-		project_id: parts.project_id.to_owned(),
-		issue_id: parts.issue.id,
-		issue_identifier: parts.issue.identifier,
-		issue_state: parts.issue.state.name,
-		classification,
-		reason,
-		queue_label_present: parts.labels.queue_label_present,
-		active_label_present: parts.labels.active_label_present,
-		needs_attention_label_present: parts.labels.needs_attention_label_present,
-		latest_run_id: parts.latest_run.map(|run| run.run_id().to_owned()),
-		latest_attempt_number: parts.latest_run.map(ProjectRunStatus::attempt_number),
-		latest_attempt_status: parts.latest_run.map(|run| run.status().to_owned()),
-		run_lease: parts.run_lease,
-		active_shared_claim: parts.active_shared_claim,
-		control_channel: parts.control_channel,
-		worktree_path: Some(parts.worktree_path.to_string_lossy().to_string()),
-		worktree_state: parts.worktree_state,
-		evidence: recovery::sorted_unique(parts.evidence),
-		blockers: recovery::sorted_unique(parts.blockers),
-		next_action,
-	}
-}
-
-#[allow(clippy::too_many_arguments)]
-fn inspect_stale_active_authority_evidence<T>(
-	project_id: &str,
-	state_store: &StateStore,
-	tracker: &T,
-	issue: &TrackerIssue,
-	issue_keys: &[String],
-	latest_run: Option<&ProjectRunStatus>,
+fn inspect_stale_active_dead_ownership_and_runs(
+	dead_ownership_input: StaleActiveDeadOwnershipInput<'_>,
+	runs: &[ProjectRunStatus],
 	marker_liveness: StaleActiveProcessLiveness,
 	evidence: &mut Vec<String>,
 	blockers: &mut Vec<String>,
-) -> Result<()>
-where
-	T: IssueTracker + ?Sized,
-{
-	stale_active_authority::inspect_stale_active_private_evidence(
-		project_id,
-		state_store,
-		issue_keys,
-		latest_run,
-		marker_liveness,
-		evidence,
-		blockers,
-	)?;
-
-	stale_active_authority::inspect_stale_active_review_lineage(
-		project_id,
-		state_store,
-		tracker,
-		issue,
-		evidence,
-		blockers,
-	)
-}
-
-fn apply_stale_active_release_reentry(
-	inspection: StaleActiveReleaseReentryInspection<'_>,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
 ) {
-	stale_active_reentry::apply_stale_active_release_reentries(
-		StaleActiveReleaseReentryInput {
-			run: inspection.latest_run,
-			run_lease: inspection.run_lease,
-			active_shared_claim: inspection.active_shared_claim,
-			labels: inspection.labels,
-			issue: inspection.issue,
-			tracker_policy: inspection.workflow.frontmatter().tracker(),
-			worktree_state: inspection.worktree_state,
-			control_channel: inspection.control_channel,
-		},
+	dead_ownership::record_recoverable_dead_leased_ownership(
+		dead_ownership_input,
 		evidence,
 		blockers,
 	);
-}
-
-fn record_stale_active_run_lease_evidence(
-	run_lease: bool,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) {
-	if run_lease {
-		blockers.push(String::from("run_lease_present"));
-	} else {
-		evidence.push(String::from("run_lease_missing"));
-	}
-}
-
-fn read_stale_active_worktree_mapping(
-	state_store: &StateStore,
-	issue_keys: &[String],
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) -> Option<WorktreeMapping> {
-	match stale_active_worktree::stale_active_worktree_mapping_for_keys(state_store, issue_keys) {
-		Ok(mapping) => mapping,
-		Err(error) => {
-			blockers.push(String::from("worktree_mapping_ambiguous"));
-			evidence.push(format!("worktree_mapping_error:{}", error));
-
-			None
-		},
-	}
-}
-
-fn read_stale_active_activity_marker(
-	worktree_path: &Path,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) -> Option<RunActivityMarker> {
-	match state::read_run_activity_marker_snapshot(worktree_path) {
-		Ok(marker) => marker,
-		Err(error) => {
-			blockers.push(String::from("worktree_tracked_changes_unknown"));
-			evidence.push(format!("worktree_status_error:{}", error));
-
-			None
-		},
-	}
-}
-
-fn record_recoverable_dead_leased_ownership(
-	input: StaleActiveDeadOwnershipInput<'_>,
-	evidence: &mut Vec<String>,
-	blockers: &mut Vec<String>,
-) {
-	let Some(latest_run) = input.latest_run else {
-		return;
-	};
-
-	if !(input.run_lease
-		&& stale_active_dead_marker_matches_run(input.marker, input.marker_liveness, latest_run))
-	{
-		return;
-	}
-
-	let Ok(local_claims) = stale_active_dead_local_claims_for_run(
-		input.project_id,
-		input.state_store,
-		input.issue_keys,
-		latest_run,
-	) else {
-		blockers.push(String::from("active_shared_claim_unknown"));
-		evidence.push(String::from("active_shared_claim_error:dead_local_claim_inspection_failed"));
-
-		return;
-	};
-
-	if local_claims.matching_claim_count == 0 {
-		return;
-	}
-	if local_claims.incompatible_claim_present {
-		evidence.push(String::from("stale_active_claim_identity_mismatch_present"));
-
-		return;
-	}
-
-	blockers.retain(|blocker| blocker != "run_lease_present");
-	evidence.push(String::from("stale_run_lease_present"));
-
-	if input.active_shared_claim {
-		blockers.retain(|blocker| blocker != "active_shared_claim_present");
-		evidence.push(String::from("stale_active_shared_claim_present"));
-	}
-}
-
-fn stale_active_dead_marker_matches_run(
-	marker: Option<&RunActivityMarker>,
-	marker_liveness: StaleActiveProcessLiveness,
-	run: &ProjectRunStatus,
-) -> bool {
-	marker_liveness == StaleActiveProcessLiveness::NotAlive
-		&& marker.is_some_and(|marker| {
-			marker.run_id() == run.run_id() && marker.attempt_number() == run.attempt_number()
-		})
-}
-
-fn stale_active_dead_local_claims_for_run(
-	project_id: &str,
-	state_store: &StateStore,
-	issue_keys: &[String],
-	run: &ProjectRunStatus,
-) -> Result<StaleActiveDeadLocalClaims> {
-	let mut claims = StaleActiveDeadLocalClaims::default();
-
-	for issue_key in issue_keys {
-		let local_claim_matches =
-			state_store.lease_for_issue(issue_key)?.as_ref().is_some_and(|lease| {
-				lease.project_id() == project_id && lease.run_id() == run.run_id()
-			});
-		let active_claim =
-			state_store.issue_has_active_shared_claim_read_only(project_id, issue_key)?;
-		let external_claim =
-			state_store.issue_has_external_shared_claim_read_only(project_id, issue_key)?;
-
-		if local_claim_matches {
-			claims.matching_claim_count += 1;
-		}
-		if external_claim || (active_claim && !local_claim_matches) {
-			claims.incompatible_claim_present = true;
-		}
-	}
-
-	Ok(claims)
-}
-
-fn stale_active_diagnostic_outcome(
-	issue_identifier: &str,
-	evidence: &[String],
-	blockers: &[String],
-) -> (String, String, String) {
-	if blockers.is_empty() {
-		if stale_active_reentry::evidence_contains(
-			evidence,
-			"stale_active_startable_state_restore_pending",
-		) {
-			(
-				String::from(STALE_ACTIVE_STATE_RESTORE_CLASSIFICATION),
-				String::from(
-					"queued_issue_needs_startable_state_restore_after_stale_active_release",
-				),
-				format!(
-					"Run `decodex recover stale-active release {issue_identifier} --dry-run`, then rerun without `--dry-run` if the report stays safe.",
-				),
-			)
-		} else {
-			(
-				String::from(STALE_ACTIVE_CLASSIFICATION),
-				String::from(
-					"tracker_issue_has_stale_active_label_without_live_or_retained_progress",
-				),
-				format!(
-					"Run `decodex recover stale-active release {issue_identifier} --dry-run`, then rerun without `--dry-run` if the report stays safe.",
-				),
-			)
-		}
-	} else {
-		(
-			String::from(STALE_ACTIVE_BLOCKED_CLASSIFICATION),
-			String::from("safety_check_blocked"),
-			stale_active_guidance::blocked_stale_active_next_action(
-				issue_identifier,
-				blockers,
-				evidence,
-			),
-		)
-	}
+	stale_active_runtime::inspect_stale_active_run_evidence(
+		runs,
+		marker_liveness,
+		evidence,
+		blockers,
+	);
 }

--- a/apps/decodex/src/recovery/stale_active_diagnosis/inspection/authority.rs
+++ b/apps/decodex/src/recovery/stale_active_diagnosis/inspection/authority.rs
@@ -1,0 +1,36 @@
+use crate::{
+	prelude::Result,
+	recovery::{
+		stale_active_authority,
+		stale_active_diagnosis::inspection::StaleActiveAuthorityEvidenceInspection,
+	},
+	tracker::IssueTracker,
+};
+
+pub(super) fn inspect_stale_active_authority_evidence<T>(
+	inspection: StaleActiveAuthorityEvidenceInspection<'_, T>,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Result<()>
+where
+	T: IssueTracker + ?Sized,
+{
+	stale_active_authority::inspect_stale_active_private_evidence(
+		inspection.project_id,
+		inspection.state_store,
+		inspection.issue_keys,
+		inspection.latest_run,
+		inspection.marker_liveness,
+		evidence,
+		blockers,
+	)?;
+
+	stale_active_authority::inspect_stale_active_review_lineage(
+		inspection.project_id,
+		inspection.state_store,
+		inspection.tracker,
+		inspection.issue,
+		evidence,
+		blockers,
+	)
+}

--- a/apps/decodex/src/recovery/stale_active_diagnosis/inspection/dead_ownership.rs
+++ b/apps/decodex/src/recovery/stale_active_diagnosis/inspection/dead_ownership.rs
@@ -1,0 +1,95 @@
+use crate::{
+	prelude::Result,
+	recovery::{
+		process_liveness::StaleActiveProcessLiveness,
+		stale_active_diagnosis::inspection::inputs::{
+			StaleActiveDeadLocalClaims, StaleActiveDeadOwnershipInput,
+		},
+	},
+	state::{ProjectRunStatus, RunActivityMarker, StateStore},
+};
+
+pub(super) fn record_recoverable_dead_leased_ownership(
+	input: StaleActiveDeadOwnershipInput<'_>,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) {
+	let Some(latest_run) = input.latest_run else {
+		return;
+	};
+
+	if !(input.run_lease
+		&& stale_active_dead_marker_matches_run(input.marker, input.marker_liveness, latest_run))
+	{
+		return;
+	}
+
+	let Ok(local_claims) = stale_active_dead_local_claims_for_run(
+		input.project_id,
+		input.state_store,
+		input.issue_keys,
+		latest_run,
+	) else {
+		blockers.push(String::from("active_shared_claim_unknown"));
+		evidence.push(String::from("active_shared_claim_error:dead_local_claim_inspection_failed"));
+
+		return;
+	};
+
+	if local_claims.matching_claim_count == 0 {
+		return;
+	}
+	if local_claims.incompatible_claim_present {
+		evidence.push(String::from("stale_active_claim_identity_mismatch_present"));
+
+		return;
+	}
+
+	blockers.retain(|blocker| blocker != "run_lease_present");
+	evidence.push(String::from("stale_run_lease_present"));
+
+	if input.active_shared_claim {
+		blockers.retain(|blocker| blocker != "active_shared_claim_present");
+		evidence.push(String::from("stale_active_shared_claim_present"));
+	}
+}
+
+fn stale_active_dead_marker_matches_run(
+	marker: Option<&RunActivityMarker>,
+	marker_liveness: StaleActiveProcessLiveness,
+	run: &ProjectRunStatus,
+) -> bool {
+	marker_liveness == StaleActiveProcessLiveness::NotAlive
+		&& marker.is_some_and(|marker| {
+			marker.run_id() == run.run_id() && marker.attempt_number() == run.attempt_number()
+		})
+}
+
+fn stale_active_dead_local_claims_for_run(
+	project_id: &str,
+	state_store: &StateStore,
+	issue_keys: &[String],
+	run: &ProjectRunStatus,
+) -> Result<StaleActiveDeadLocalClaims> {
+	let mut claims = StaleActiveDeadLocalClaims::default();
+
+	for issue_key in issue_keys {
+		let local_claim_matches =
+			state_store.lease_for_issue(issue_key)?.as_ref().is_some_and(|lease| {
+				lease.project_id() == project_id && lease.run_id() == run.run_id()
+			});
+		let active_claim =
+			state_store.issue_has_active_shared_claim_read_only(project_id, issue_key)?;
+		let external_claim =
+			state_store.issue_has_external_shared_claim_read_only(project_id, issue_key)?;
+
+		if local_claim_matches {
+			claims.matching_claim_count += 1;
+		}
+		if external_claim || (active_claim && !local_claim_matches) {
+			claims.incompatible_claim_present = true;
+		}
+	}
+
+	Ok(claims)
+}

--- a/apps/decodex/src/recovery/stale_active_diagnosis/inspection/diagnostic.rs
+++ b/apps/decodex/src/recovery/stale_active_diagnosis/inspection/diagnostic.rs
@@ -1,0 +1,82 @@
+use crate::{
+	recovery::{
+		self, STALE_ACTIVE_BLOCKED_CLASSIFICATION, STALE_ACTIVE_CLASSIFICATION,
+		STALE_ACTIVE_STATE_RESTORE_CLASSIFICATION, reports::StaleActiveDiagnostic,
+		stale_active_diagnosis::inspection::inputs::StaleActiveDiagnosticParts,
+		stale_active_guidance, stale_active_reentry,
+	},
+	state::ProjectRunStatus,
+};
+
+pub(super) fn stale_active_diagnostic_from_parts(
+	parts: StaleActiveDiagnosticParts<'_>,
+) -> StaleActiveDiagnostic {
+	let (classification, reason, next_action) =
+		stale_active_diagnostic_outcome(&parts.issue.identifier, &parts.evidence, &parts.blockers);
+
+	StaleActiveDiagnostic {
+		project_id: parts.project_id.to_owned(),
+		issue_id: parts.issue.id,
+		issue_identifier: parts.issue.identifier,
+		issue_state: parts.issue.state.name,
+		classification,
+		reason,
+		queue_label_present: parts.labels.queue_label_present,
+		active_label_present: parts.labels.active_label_present,
+		needs_attention_label_present: parts.labels.needs_attention_label_present,
+		latest_run_id: parts.latest_run.map(|run| run.run_id().to_owned()),
+		latest_attempt_number: parts.latest_run.map(ProjectRunStatus::attempt_number),
+		latest_attempt_status: parts.latest_run.map(|run| run.status().to_owned()),
+		run_lease: parts.run_lease,
+		active_shared_claim: parts.active_shared_claim,
+		control_channel: parts.control_channel,
+		worktree_path: Some(parts.worktree_path.to_string_lossy().to_string()),
+		worktree_state: parts.worktree_state,
+		evidence: recovery::sorted_unique(parts.evidence),
+		blockers: recovery::sorted_unique(parts.blockers),
+		next_action,
+	}
+}
+
+fn stale_active_diagnostic_outcome(
+	issue_identifier: &str,
+	evidence: &[String],
+	blockers: &[String],
+) -> (String, String, String) {
+	if blockers.is_empty() {
+		if stale_active_reentry::evidence_contains(
+			evidence,
+			"stale_active_startable_state_restore_pending",
+		) {
+			(
+				String::from(STALE_ACTIVE_STATE_RESTORE_CLASSIFICATION),
+				String::from(
+					"queued_issue_needs_startable_state_restore_after_stale_active_release",
+				),
+				format!(
+					"Run `decodex recover stale-active release {issue_identifier} --dry-run`, then rerun without `--dry-run` if the report stays safe.",
+				),
+			)
+		} else {
+			(
+				String::from(STALE_ACTIVE_CLASSIFICATION),
+				String::from(
+					"tracker_issue_has_stale_active_label_without_live_or_retained_progress",
+				),
+				format!(
+					"Run `decodex recover stale-active release {issue_identifier} --dry-run`, then rerun without `--dry-run` if the report stays safe.",
+				),
+			)
+		}
+	} else {
+		(
+			String::from(STALE_ACTIVE_BLOCKED_CLASSIFICATION),
+			String::from("safety_check_blocked"),
+			stale_active_guidance::blocked_stale_active_next_action(
+				issue_identifier,
+				blockers,
+				evidence,
+			),
+		)
+	}
+}

--- a/apps/decodex/src/recovery/stale_active_diagnosis/inspection/inputs.rs
+++ b/apps/decodex/src/recovery/stale_active_diagnosis/inspection/inputs.rs
@@ -1,0 +1,65 @@
+use std::path::Path;
+
+use crate::{
+	recovery::{
+		process_liveness::StaleActiveProcessLiveness, stale_active_labels::StaleActiveLabelSnapshot,
+	},
+	state::{ProjectRunStatus, RunActivityMarker, StateStore},
+	tracker::{IssueTracker, TrackerIssue},
+	workflow::WorkflowDocument,
+};
+
+pub(super) struct StaleActiveDiagnosticParts<'a> {
+	pub(super) project_id: &'a str,
+	pub(super) issue: TrackerIssue,
+	pub(super) labels: StaleActiveLabelSnapshot,
+	pub(super) latest_run: Option<&'a ProjectRunStatus>,
+	pub(super) run_lease: bool,
+	pub(super) active_shared_claim: bool,
+	pub(super) control_channel: String,
+	pub(super) worktree_path: &'a Path,
+	pub(super) worktree_state: String,
+	pub(super) evidence: Vec<String>,
+	pub(super) blockers: Vec<String>,
+}
+
+pub(super) struct StaleActiveDeadOwnershipInput<'a> {
+	pub(super) project_id: &'a str,
+	pub(super) state_store: &'a StateStore,
+	pub(super) issue_keys: &'a [String],
+	pub(super) marker: Option<&'a RunActivityMarker>,
+	pub(super) marker_liveness: StaleActiveProcessLiveness,
+	pub(super) latest_run: Option<&'a ProjectRunStatus>,
+	pub(super) run_lease: bool,
+	pub(super) active_shared_claim: bool,
+}
+
+pub(super) struct StaleActiveAuthorityEvidenceInspection<'a, T>
+where
+	T: IssueTracker + ?Sized,
+{
+	pub(super) project_id: &'a str,
+	pub(super) state_store: &'a StateStore,
+	pub(super) tracker: &'a T,
+	pub(super) issue: &'a TrackerIssue,
+	pub(super) issue_keys: &'a [String],
+	pub(super) latest_run: Option<&'a ProjectRunStatus>,
+	pub(super) marker_liveness: StaleActiveProcessLiveness,
+}
+
+pub(super) struct StaleActiveReleaseReentryInspection<'a> {
+	pub(super) latest_run: Option<&'a ProjectRunStatus>,
+	pub(super) run_lease: bool,
+	pub(super) active_shared_claim: bool,
+	pub(super) labels: &'a StaleActiveLabelSnapshot,
+	pub(super) issue: &'a TrackerIssue,
+	pub(super) workflow: &'a WorkflowDocument,
+	pub(super) worktree_state: &'a str,
+	pub(super) control_channel: &'a str,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct StaleActiveDeadLocalClaims {
+	pub(super) matching_claim_count: usize,
+	pub(super) incompatible_claim_present: bool,
+}

--- a/apps/decodex/src/recovery/stale_active_diagnosis/inspection/reentry.rs
+++ b/apps/decodex/src/recovery/stale_active_diagnosis/inspection/reentry.rs
@@ -1,0 +1,25 @@
+use crate::recovery::{
+	stale_active_diagnosis::inspection::inputs::StaleActiveReleaseReentryInspection,
+	stale_active_reentry::{self, StaleActiveReleaseReentryInput},
+};
+
+pub(super) fn apply_stale_active_release_reentry(
+	inspection: StaleActiveReleaseReentryInspection<'_>,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) {
+	stale_active_reentry::apply_stale_active_release_reentries(
+		StaleActiveReleaseReentryInput {
+			run: inspection.latest_run,
+			run_lease: inspection.run_lease,
+			active_shared_claim: inspection.active_shared_claim,
+			labels: inspection.labels,
+			issue: inspection.issue,
+			tracker_policy: inspection.workflow.frontmatter().tracker(),
+			worktree_state: inspection.worktree_state,
+			control_channel: inspection.control_channel,
+		},
+		evidence,
+		blockers,
+	);
+}

--- a/apps/decodex/src/recovery/stale_active_diagnosis/inspection/sources.rs
+++ b/apps/decodex/src/recovery/stale_active_diagnosis/inspection/sources.rs
@@ -1,0 +1,51 @@
+use std::path::Path;
+
+use crate::{
+	recovery::stale_active_worktree,
+	state::{self, RunActivityMarker, StateStore, WorktreeMapping},
+};
+
+pub(super) fn record_stale_active_run_lease_evidence(
+	run_lease: bool,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) {
+	if run_lease {
+		blockers.push(String::from("run_lease_present"));
+	} else {
+		evidence.push(String::from("run_lease_missing"));
+	}
+}
+
+pub(super) fn read_stale_active_worktree_mapping(
+	state_store: &StateStore,
+	issue_keys: &[String],
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Option<WorktreeMapping> {
+	match stale_active_worktree::stale_active_worktree_mapping_for_keys(state_store, issue_keys) {
+		Ok(mapping) => mapping,
+		Err(error) => {
+			blockers.push(String::from("worktree_mapping_ambiguous"));
+			evidence.push(format!("worktree_mapping_error:{}", error));
+
+			None
+		},
+	}
+}
+
+pub(super) fn read_stale_active_activity_marker(
+	worktree_path: &Path,
+	evidence: &mut Vec<String>,
+	blockers: &mut Vec<String>,
+) -> Option<RunActivityMarker> {
+	match state::read_run_activity_marker_snapshot(worktree_path) {
+		Ok(marker) => marker,
+		Err(error) => {
+			blockers.push(String::from("worktree_tracked_changes_unknown"));
+			evidence.push(format!("worktree_status_error:{}", error));
+
+			None
+		},
+	}
+}

--- a/apps/decodex/src/recovery/stale_active_release.rs
+++ b/apps/decodex/src/recovery/stale_active_release.rs
@@ -1,33 +1,30 @@
 //! Apply path for stale-active release recovery.
 
-use std::path::{Path, PathBuf};
-
-use color_eyre::eyre::WrapErr;
+mod claims;
+mod diagnostic;
+mod state_restore;
+mod worktree_cleanup;
 
 use crate::{
 	config::ServiceConfig,
-	prelude::{Result, eyre},
+	prelude::Result,
 	recovery::{
 		GHOST_LANE_TERMINAL_STATUS, STALE_ACTIVE_RECOVERY_SCHEMA, STALE_ACTIVE_RELEASE_EVENT,
-		context::{RecoveryContext, RecoveryRuntimeMutationPolicy},
-		git_worktree,
+		context::RecoveryContext,
 		reports::StaleActiveDiagnostic,
 		stale_active_authority,
 		stale_active_diagnosis::{self},
-		stale_active_labels::{self},
-		stale_active_worktree,
 	},
-	state::{RUN_CONTROL_CHANNEL_STATUS_FAILED, StateStore, WorktreeMapping},
-	tracker::{self, IssueTracker, TrackerIssue},
+	state::{RUN_CONTROL_CHANNEL_STATUS_FAILED, StateStore},
+	tracker::{self, IssueTracker},
 	workflow::WorkflowDocument,
-	worktree::WorktreeManager,
 };
 
-#[derive(Clone, Debug)]
-enum StaleActiveWorktreeCleanup {
-	None,
-	UnmappedPath(PathBuf),
-	Mapped(WorktreeMapping),
+pub(super) fn preflight_stale_active_worktree_cleanup(
+	state_store: &StateStore,
+	diagnostic: &StaleActiveDiagnostic,
+) -> Result<()> {
+	worktree_cleanup::preflight_stale_active_worktree_cleanup(state_store, diagnostic)
 }
 
 pub(super) fn apply_stale_active_release(
@@ -53,14 +50,15 @@ pub(super) fn apply_stale_active_release_with_tracker<T>(
 where
 	T: IssueTracker + ?Sized,
 {
-	let diagnostic = refreshed_stale_active_release_diagnostic(
+	let diagnostic = diagnostic::refreshed_stale_active_release_diagnostic(
 		tracker,
 		config,
 		workflow,
 		state_store,
 		diagnostic,
 	)?;
-	let worktree_cleanup = preflight_stale_active_worktree_cleanup_plan(state_store, &diagnostic)?;
+	let worktree_cleanup =
+		worktree_cleanup::preflight_stale_active_worktree_cleanup_plan(state_store, &diagnostic)?;
 
 	stale_active_authority::ensure_stale_active_review_authority_missing(
 		tracker,
@@ -69,9 +67,9 @@ where
 	)?;
 
 	let cleared_run_lease =
-		clear_stale_active_dead_run_claims_before_release(state_store, &diagnostic)?;
+		claims::clear_stale_active_dead_run_claims_before_release(state_store, &diagnostic)?;
 
-	ensure_stale_active_run_claim_guard(config, state_store, &diagnostic)?;
+	claims::ensure_stale_active_run_claim_guard(config, state_store, &diagnostic)?;
 
 	let active_label = tracker::automation_active_label(config.service_id());
 
@@ -81,7 +79,7 @@ where
 		if diagnostic
 			.latest_attempt_status
 			.as_deref()
-			.is_some_and(stale_active_attempt_status_needs_terminal_guard)
+			.is_some_and(claims::stale_active_attempt_status_needs_terminal_guard)
 		{
 			state_store.update_run_status(run_id, GHOST_LANE_TERMINAL_STATUS)?;
 		}
@@ -98,8 +96,7 @@ where
 		state_store,
 		&diagnostic,
 	)?;
-
-	cleanup_stale_active_worktree_mapping(
+	worktree_cleanup::cleanup_stale_active_worktree_mapping(
 		config,
 		workflow,
 		state_store,
@@ -142,10 +139,9 @@ where
 		state_store,
 		&diagnostic,
 	)?;
+	claims::ensure_stale_active_run_claim_guard(config, state_store, &diagnostic)?;
 
-	ensure_stale_active_run_claim_guard(config, state_store, &diagnostic)?;
-
-	let final_diagnostic = refreshed_stale_active_release_diagnostic(
+	let final_diagnostic = diagnostic::refreshed_stale_active_release_diagnostic(
 		tracker,
 		config,
 		workflow,
@@ -158,268 +154,35 @@ where
 		state_store,
 		&final_diagnostic,
 	)?;
-
-	ensure_stale_active_run_claim_guard(config, state_store, &final_diagnostic)?;
+	claims::ensure_stale_active_run_claim_guard(config, state_store, &final_diagnostic)?;
 
 	let issue =
 		stale_active_diagnosis::lookup_stale_active_issue(tracker, &diagnostic.issue_identifier)?;
 
-	restore_stale_active_startable_state_if_queued(tracker, workflow, &issue, &final_diagnostic)?;
-
+	state_restore::restore_stale_active_startable_state_if_queued(
+		tracker,
+		workflow,
+		&issue,
+		&final_diagnostic,
+	)?;
 	tracker::set_issue_label_presence(tracker, &issue, &active_label, false)?;
 
 	Ok(())
 }
 
-pub(super) fn clear_stale_active_dead_run_claims_before_release(
+#[cfg(test)]
+pub(crate) fn clear_stale_active_dead_run_claims_before_release(
 	state_store: &StateStore,
 	diagnostic: &StaleActiveDiagnostic,
 ) -> Result<bool> {
-	if !diagnostic.run_lease
-		|| !diagnostic.evidence.iter().any(|evidence| evidence == "stale_run_lease_present")
-	{
-		return Ok(false);
-	}
-
-	let Some(run_id) = diagnostic.latest_run_id.as_deref() else {
-		return Ok(false);
-	};
-	let mut cleared = false;
-
-	for issue_key in stale_active_labels::stale_active_diagnostic_issue_keys(diagnostic) {
-		let Some(lease) = state_store.lease_for_issue(&issue_key)? else {
-			continue;
-		};
-
-		if lease.project_id() == diagnostic.project_id && lease.run_id() == run_id {
-			state_store.clear_lease(&issue_key)?;
-
-			cleared = true;
-		}
-	}
-
-	Ok(cleared)
+	claims::clear_stale_active_dead_run_claims_before_release(state_store, diagnostic)
 }
 
-pub(super) fn ensure_stale_active_run_claim_guard(
+#[cfg(test)]
+pub(crate) fn ensure_stale_active_run_claim_guard(
 	config: &ServiceConfig,
 	state_store: &StateStore,
 	diagnostic: &StaleActiveDiagnostic,
 ) -> Result<()> {
-	let issue_keys = stale_active_labels::stale_active_diagnostic_issue_keys(diagnostic);
-
-	match stale_active_labels::stale_active_issue_has_active_shared_claim(
-		config.service_id(),
-		state_store,
-		&issue_keys,
-	) {
-		Ok(false) => Ok(()),
-		Ok(true) => eyre::bail!(
-			"`recover stale-active release` refused `{}` because a run lease or shared claim appeared before active-label release.",
-			diagnostic.issue_identifier
-		),
-		Err(error) => eyre::bail!(
-			"`recover stale-active release` refused `{}` because run lease/shared claim state could not be inspected before active-label release: {}",
-			diagnostic.issue_identifier,
-			error
-		),
-	}
-}
-
-pub(super) fn preflight_stale_active_worktree_cleanup(
-	state_store: &StateStore,
-	diagnostic: &StaleActiveDiagnostic,
-) -> Result<()> {
-	preflight_stale_active_worktree_cleanup_plan(state_store, diagnostic).map(|_| ())
-}
-
-fn refreshed_stale_active_release_diagnostic<T>(
-	tracker: &T,
-	config: &ServiceConfig,
-	workflow: &WorkflowDocument,
-	state_store: &StateStore,
-	original: &StaleActiveDiagnostic,
-) -> Result<StaleActiveDiagnostic>
-where
-	T: IssueTracker + ?Sized,
-{
-	let mut diagnostics = stale_active_diagnosis::diagnose_stale_active_issues(
-		config.service_id(),
-		workflow,
-		config.worktree_root(),
-		state_store,
-		tracker,
-		Some(&original.issue_identifier),
-		RecoveryRuntimeMutationPolicy::ReadOnly,
-	)?;
-	let diagnostic = diagnostics.pop().ok_or_else(|| {
-		eyre::eyre!("No stale active issue matched `{}`.", original.issue_identifier)
-	})?;
-
-	if !diagnostic.recoverable() {
-		eyre::bail!(
-			"`recover stale-active release` refused `{}` because safety inspection changed before apply: {}",
-			original.issue_identifier,
-			diagnostic.blockers.join(", ")
-		);
-	}
-	if diagnostic.issue_id != original.issue_id
-		|| diagnostic.latest_run_id != original.latest_run_id
-		|| diagnostic.latest_attempt_number != original.latest_attempt_number
-	{
-		eyre::bail!(
-			"`recover stale-active release` refused `{}` because the stale ownership target changed before apply.",
-			original.issue_identifier
-		);
-	}
-
-	Ok(diagnostic)
-}
-
-fn restore_stale_active_startable_state_if_queued<T>(
-	tracker: &T,
-	workflow: &WorkflowDocument,
-	issue: &TrackerIssue,
-	diagnostic: &StaleActiveDiagnostic,
-) -> Result<()>
-where
-	T: IssueTracker + ?Sized,
-{
-	if !diagnostic.queue_label_present {
-		return Ok(());
-	}
-
-	let tracker_policy = workflow.frontmatter().tracker();
-
-	if tracker_policy.startable_states().iter().any(|state| state == &issue.state.name) {
-		return Ok(());
-	}
-	if issue.state.name != tracker_policy.in_progress_state() {
-		eyre::bail!(
-			"`recover stale-active release` refused `{}` because queued issue state `{}` is not `{}` or a configured startable state.",
-			diagnostic.issue_identifier,
-			issue.state.name,
-			tracker_policy.in_progress_state()
-		);
-	}
-
-	let startable_state = tracker_policy.startable_states().first().ok_or_else(|| {
-		eyre::eyre!("Workflow tracker startable_states must contain at least one state.")
-	})?;
-	let state_id = issue.state_id_for_name(startable_state).ok_or_else(|| {
-		eyre::eyre!(
-			"Issue `{}` team does not expose configured startable state `{}`.",
-			issue.identifier,
-			startable_state
-		)
-	})?;
-
-	tracker.update_issue_state(&issue.id, state_id)
-}
-
-fn stale_active_attempt_status_needs_terminal_guard(status: &str) -> bool {
-	matches!(
-		status,
-		"starting" | "running" | "continuation_pending" | "stalled" | "failed" | "interrupted"
-	)
-}
-
-fn preflight_stale_active_worktree_cleanup_plan(
-	state_store: &StateStore,
-	diagnostic: &StaleActiveDiagnostic,
-) -> Result<StaleActiveWorktreeCleanup> {
-	let issue_keys = stale_active_labels::stale_active_diagnostic_issue_keys(diagnostic);
-	let Some(mapping) =
-		stale_active_worktree::stale_active_worktree_mapping_for_keys(state_store, &issue_keys)?
-	else {
-		if let Some(worktree_path) = diagnostic.worktree_path.as_deref().map(PathBuf::from)
-			&& stale_active_worktree_path_exists_for_cleanup(
-				&diagnostic.issue_identifier,
-				&worktree_path,
-			)? {
-			ensure_stale_active_worktree_clean(&diagnostic.issue_identifier, &worktree_path)?;
-
-			return Ok(StaleActiveWorktreeCleanup::UnmappedPath(worktree_path));
-		}
-
-		return Ok(StaleActiveWorktreeCleanup::None);
-	};
-
-	if stale_active_worktree_path_exists_for_cleanup(
-		&diagnostic.issue_identifier,
-		mapping.worktree_path(),
-	)? {
-		ensure_stale_active_worktree_clean(&diagnostic.issue_identifier, mapping.worktree_path())?;
-
-		return Ok(StaleActiveWorktreeCleanup::Mapped(mapping));
-	}
-
-	Ok(StaleActiveWorktreeCleanup::None)
-}
-
-fn stale_active_worktree_path_exists_for_cleanup(
-	issue_identifier: &str,
-	worktree_path: &Path,
-) -> Result<bool> {
-	worktree_path.try_exists().wrap_err_with(|| {
-		format!(
-			"`recover stale-active release` refused `{}` because retained worktree `{}` could not be inspected before cleanup.",
-			issue_identifier,
-			worktree_path.display()
-		)
-	})
-}
-
-fn ensure_stale_active_worktree_clean(issue_identifier: &str, worktree_path: &Path) -> Result<()> {
-	if git_worktree::worktree_has_tracked_changes_for_recovery(worktree_path)? {
-		eyre::bail!(
-			"`recover stale-active release` refused `{}` because retained worktree changes appeared before cleanup.",
-			issue_identifier
-		);
-	}
-
-	Ok(())
-}
-
-fn cleanup_stale_active_worktree_mapping(
-	config: &ServiceConfig,
-	workflow: &WorkflowDocument,
-	state_store: &StateStore,
-	diagnostic: &StaleActiveDiagnostic,
-	cleanup: StaleActiveWorktreeCleanup,
-) -> Result<()> {
-	match cleanup {
-		StaleActiveWorktreeCleanup::None => {},
-		StaleActiveWorktreeCleanup::UnmappedPath(worktree_path) => {
-			let worktree_manager = WorktreeManager::new(
-				config.service_id(),
-				config.repo_root(),
-				config.worktree_root(),
-			);
-
-			worktree_manager.remove_worktree_path(&worktree_path)?;
-		},
-		StaleActiveWorktreeCleanup::Mapped(mapping) => {
-			let worktree_manager = WorktreeManager::new(
-				config.service_id(),
-				config.repo_root(),
-				config.worktree_root(),
-			);
-
-			worktree_manager.remove_worktree_path_with_hooks(
-				&diagnostic.issue_identifier,
-				mapping.branch_name(),
-				mapping.worktree_path(),
-				workflow.frontmatter().execution().workspace_hooks(),
-			)?;
-		},
-	};
-
-	state_store.clear_worktree_mapping(&diagnostic.issue_id)?;
-
-	if diagnostic.issue_identifier != diagnostic.issue_id {
-		state_store.clear_worktree_mapping(&diagnostic.issue_identifier)?;
-	}
-
-	Ok(())
+	claims::ensure_stale_active_run_claim_guard(config, state_store, diagnostic)
 }

--- a/apps/decodex/src/recovery/stale_active_release/claims.rs
+++ b/apps/decodex/src/recovery/stale_active_release/claims.rs
@@ -1,0 +1,68 @@
+use crate::{
+	config::ServiceConfig,
+	prelude::{Result, eyre},
+	recovery::{reports::StaleActiveDiagnostic, stale_active_labels},
+	state::StateStore,
+};
+
+pub(super) fn clear_stale_active_dead_run_claims_before_release(
+	state_store: &StateStore,
+	diagnostic: &StaleActiveDiagnostic,
+) -> Result<bool> {
+	if !diagnostic.run_lease
+		|| !diagnostic.evidence.iter().any(|evidence| evidence == "stale_run_lease_present")
+	{
+		return Ok(false);
+	}
+
+	let Some(run_id) = diagnostic.latest_run_id.as_deref() else {
+		return Ok(false);
+	};
+	let mut cleared = false;
+
+	for issue_key in stale_active_labels::stale_active_diagnostic_issue_keys(diagnostic) {
+		let Some(lease) = state_store.lease_for_issue(&issue_key)? else {
+			continue;
+		};
+
+		if lease.project_id() == diagnostic.project_id && lease.run_id() == run_id {
+			state_store.clear_lease(&issue_key)?;
+
+			cleared = true;
+		}
+	}
+
+	Ok(cleared)
+}
+
+pub(super) fn ensure_stale_active_run_claim_guard(
+	config: &ServiceConfig,
+	state_store: &StateStore,
+	diagnostic: &StaleActiveDiagnostic,
+) -> Result<()> {
+	let issue_keys = stale_active_labels::stale_active_diagnostic_issue_keys(diagnostic);
+
+	match stale_active_labels::stale_active_issue_has_active_shared_claim(
+		config.service_id(),
+		state_store,
+		&issue_keys,
+	) {
+		Ok(false) => Ok(()),
+		Ok(true) => eyre::bail!(
+			"`recover stale-active release` refused `{}` because a run lease or shared claim appeared before active-label release.",
+			diagnostic.issue_identifier
+		),
+		Err(error) => eyre::bail!(
+			"`recover stale-active release` refused `{}` because run lease/shared claim state could not be inspected before active-label release: {}",
+			diagnostic.issue_identifier,
+			error
+		),
+	}
+}
+
+pub(super) fn stale_active_attempt_status_needs_terminal_guard(status: &str) -> bool {
+	matches!(
+		status,
+		"starting" | "running" | "continuation_pending" | "stalled" | "failed" | "interrupted"
+	)
+}

--- a/apps/decodex/src/recovery/stale_active_release/diagnostic.rs
+++ b/apps/decodex/src/recovery/stale_active_release/diagnostic.rs
@@ -1,0 +1,54 @@
+use crate::{
+	config::ServiceConfig,
+	prelude::{Result, eyre},
+	recovery::{
+		context::RecoveryRuntimeMutationPolicy, reports::StaleActiveDiagnostic,
+		stale_active_diagnosis,
+	},
+	state::StateStore,
+	tracker::IssueTracker,
+	workflow::WorkflowDocument,
+};
+
+pub(super) fn refreshed_stale_active_release_diagnostic<T>(
+	tracker: &T,
+	config: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	original: &StaleActiveDiagnostic,
+) -> Result<StaleActiveDiagnostic>
+where
+	T: IssueTracker + ?Sized,
+{
+	let mut diagnostics = stale_active_diagnosis::diagnose_stale_active_issues(
+		config.service_id(),
+		workflow,
+		config.worktree_root(),
+		state_store,
+		tracker,
+		Some(&original.issue_identifier),
+		RecoveryRuntimeMutationPolicy::ReadOnly,
+	)?;
+	let diagnostic = diagnostics.pop().ok_or_else(|| {
+		eyre::eyre!("No stale active issue matched `{}`.", original.issue_identifier)
+	})?;
+
+	if !diagnostic.recoverable() {
+		eyre::bail!(
+			"`recover stale-active release` refused `{}` because safety inspection changed before apply: {}",
+			original.issue_identifier,
+			diagnostic.blockers.join(", ")
+		);
+	}
+	if diagnostic.issue_id != original.issue_id
+		|| diagnostic.latest_run_id != original.latest_run_id
+		|| diagnostic.latest_attempt_number != original.latest_attempt_number
+	{
+		eyre::bail!(
+			"`recover stale-active release` refused `{}` because the stale ownership target changed before apply.",
+			original.issue_identifier
+		);
+	}
+
+	Ok(diagnostic)
+}

--- a/apps/decodex/src/recovery/stale_active_release/state_restore.rs
+++ b/apps/decodex/src/recovery/stale_active_release/state_restore.rs
@@ -1,0 +1,47 @@
+use crate::{
+	prelude::{Result, eyre},
+	recovery::reports::StaleActiveDiagnostic,
+	tracker::{IssueTracker, TrackerIssue},
+	workflow::WorkflowDocument,
+};
+
+pub(super) fn restore_stale_active_startable_state_if_queued<T>(
+	tracker: &T,
+	workflow: &WorkflowDocument,
+	issue: &TrackerIssue,
+	diagnostic: &StaleActiveDiagnostic,
+) -> Result<()>
+where
+	T: IssueTracker + ?Sized,
+{
+	if !diagnostic.queue_label_present {
+		return Ok(());
+	}
+
+	let tracker_policy = workflow.frontmatter().tracker();
+
+	if tracker_policy.startable_states().iter().any(|state| state == &issue.state.name) {
+		return Ok(());
+	}
+	if issue.state.name != tracker_policy.in_progress_state() {
+		eyre::bail!(
+			"`recover stale-active release` refused `{}` because queued issue state `{}` is not `{}` or a configured startable state.",
+			diagnostic.issue_identifier,
+			issue.state.name,
+			tracker_policy.in_progress_state()
+		);
+	}
+
+	let startable_state = tracker_policy.startable_states().first().ok_or_else(|| {
+		eyre::eyre!("Workflow tracker startable_states must contain at least one state.")
+	})?;
+	let state_id = issue.state_id_for_name(startable_state).ok_or_else(|| {
+		eyre::eyre!(
+			"Issue `{}` team does not expose configured startable state `{}`.",
+			issue.identifier,
+			startable_state
+		)
+	})?;
+
+	tracker.update_issue_state(&issue.id, state_id)
+}

--- a/apps/decodex/src/recovery/stale_active_release/worktree_cleanup.rs
+++ b/apps/decodex/src/recovery/stale_active_release/worktree_cleanup.rs
@@ -1,0 +1,128 @@
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::WrapErr;
+
+use crate::{
+	config::ServiceConfig,
+	prelude::{Result, eyre},
+	recovery::{
+		git_worktree, reports::StaleActiveDiagnostic, stale_active_labels, stale_active_worktree,
+	},
+	state::{StateStore, WorktreeMapping},
+	workflow::WorkflowDocument,
+	worktree::WorktreeManager,
+};
+
+#[derive(Clone, Debug)]
+pub(super) enum StaleActiveWorktreeCleanup {
+	None,
+	UnmappedPath(PathBuf),
+	Mapped(WorktreeMapping),
+}
+
+pub(super) fn preflight_stale_active_worktree_cleanup(
+	state_store: &StateStore,
+	diagnostic: &StaleActiveDiagnostic,
+) -> Result<()> {
+	preflight_stale_active_worktree_cleanup_plan(state_store, diagnostic).map(|_| ())
+}
+
+pub(super) fn preflight_stale_active_worktree_cleanup_plan(
+	state_store: &StateStore,
+	diagnostic: &StaleActiveDiagnostic,
+) -> Result<StaleActiveWorktreeCleanup> {
+	let issue_keys = stale_active_labels::stale_active_diagnostic_issue_keys(diagnostic);
+	let Some(mapping) =
+		stale_active_worktree::stale_active_worktree_mapping_for_keys(state_store, &issue_keys)?
+	else {
+		if let Some(worktree_path) = diagnostic.worktree_path.as_deref().map(PathBuf::from)
+			&& stale_active_worktree_path_exists_for_cleanup(
+				&diagnostic.issue_identifier,
+				&worktree_path,
+			)? {
+			ensure_stale_active_worktree_clean(&diagnostic.issue_identifier, &worktree_path)?;
+
+			return Ok(StaleActiveWorktreeCleanup::UnmappedPath(worktree_path));
+		}
+
+		return Ok(StaleActiveWorktreeCleanup::None);
+	};
+
+	if stale_active_worktree_path_exists_for_cleanup(
+		&diagnostic.issue_identifier,
+		mapping.worktree_path(),
+	)? {
+		ensure_stale_active_worktree_clean(&diagnostic.issue_identifier, mapping.worktree_path())?;
+
+		return Ok(StaleActiveWorktreeCleanup::Mapped(mapping));
+	}
+
+	Ok(StaleActiveWorktreeCleanup::None)
+}
+
+pub(super) fn cleanup_stale_active_worktree_mapping(
+	config: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	diagnostic: &StaleActiveDiagnostic,
+	cleanup: StaleActiveWorktreeCleanup,
+) -> Result<()> {
+	match cleanup {
+		StaleActiveWorktreeCleanup::None => {},
+		StaleActiveWorktreeCleanup::UnmappedPath(worktree_path) => {
+			let worktree_manager = WorktreeManager::new(
+				config.service_id(),
+				config.repo_root(),
+				config.worktree_root(),
+			);
+
+			worktree_manager.remove_worktree_path(&worktree_path)?;
+		},
+		StaleActiveWorktreeCleanup::Mapped(mapping) => {
+			let worktree_manager = WorktreeManager::new(
+				config.service_id(),
+				config.repo_root(),
+				config.worktree_root(),
+			);
+
+			worktree_manager.remove_worktree_path_with_hooks(
+				&diagnostic.issue_identifier,
+				mapping.branch_name(),
+				mapping.worktree_path(),
+				workflow.frontmatter().execution().workspace_hooks(),
+			)?;
+		},
+	};
+
+	state_store.clear_worktree_mapping(&diagnostic.issue_id)?;
+
+	if diagnostic.issue_identifier != diagnostic.issue_id {
+		state_store.clear_worktree_mapping(&diagnostic.issue_identifier)?;
+	}
+
+	Ok(())
+}
+
+fn stale_active_worktree_path_exists_for_cleanup(
+	issue_identifier: &str,
+	worktree_path: &Path,
+) -> Result<bool> {
+	worktree_path.try_exists().wrap_err_with(|| {
+		format!(
+			"`recover stale-active release` refused `{}` because retained worktree `{}` could not be inspected before cleanup.",
+			issue_identifier,
+			worktree_path.display()
+		)
+	})
+}
+
+fn ensure_stale_active_worktree_clean(issue_identifier: &str, worktree_path: &Path) -> Result<()> {
+	if git_worktree::worktree_has_tracked_changes_for_recovery(worktree_path)? {
+		eyre::bail!(
+			"`recover stale-active release` refused `{}` because retained worktree changes appeared before cleanup.",
+			issue_identifier
+		);
+	}
+
+	Ok(())
+}


### PR DESCRIPTION
## Summary
- split ghost-lane diagnosis into control, outcome, private evidence, review-lineage, tracker, and worktree modules
- split stale-active diagnosis into authority, dead ownership, diagnostic assembly, inputs, reentry, and source modules
- split stale-active release apply into claims, diagnostic refresh, state restore, and worktree cleanup modules
- removed the stale-active diagnosis too-many-arguments lint exception by introducing an authority inspection input type

## Validation
- rustup run nightly cargo fmt --all --check
- cargo make lint-vstyle-rust
- cargo check -p decodex --lib --tests
- cargo clippy -p decodex --lib --tests --all-features -- -D warnings
- cargo test -p decodex recovery::tests::ghost_lane --lib -- --format terse
- cargo test -p decodex recovery::tests::stale_active --lib -- --format terse
- git diff --check
- find apps -path '*/target' -prune -o -type f -name mod.rs -print 2>/dev/null\n- scanned changed recovery surfaces for new allow/expect, wildcard imports, include!, and #[path]