### PR TITLE
XY-1116: Recover validated retained PR lanes after review_handoff_writeback_failed

### DIFF
--- a/apps/decodex/src/orchestrator/status_history_ledger/outcome.rs
+++ b/apps/decodex/src/orchestrator/status_history_ledger/outcome.rs
@@ -217,11 +217,17 @@ fn closeout_status_from_record(record: &LinearExecutionEventRecord) -> Option<St
 
 fn history_attention_reason(final_record: &OperatorHistoryLedgerRecord) -> Option<String> {
 	match final_record.record.event_type.as_str() {
-		"needs_attention" | "terminal_failure" => final_record
+		"needs_attention" => final_record
 			.record
 			.summary
 			.clone()
 			.or_else(|| final_record.record.error_class.clone())
+			.or_else(|| final_record.record.next_action.clone()),
+		"terminal_failure" => final_record
+			.record
+			.error_class
+			.clone()
+			.or_else(|| final_record.record.summary.clone())
 			.or_else(|| final_record.record.next_action.clone()),
 		_ => None,
 	}

--- a/apps/decodex/src/orchestrator/status_worktrees/ownership.rs
+++ b/apps/decodex/src/orchestrator/status_worktrees/ownership.rs
@@ -102,13 +102,7 @@ fn worktree_ownership(
 				"Run Ledger owns this worktree through terminal `{}` outcome.",
 				lane.ledger_outcome.final_outcome
 			),
-			next_action: Some(lane.ledger_outcome.needs_attention_reason.clone().unwrap_or_else(
-				|| {
-					String::from(
-						"inspect the retained worktree diff and resolve the terminal attention outcome manually",
-					)
-				},
-			)),
+			next_action: Some(history_attention_worktree_next_action(lane)),
 			audit_required: false,
 		};
 	}
@@ -143,6 +137,25 @@ fn worktree_ownership(
 		next_action: audit_required.then(|| legacy_cleanup_next_action(worktree)),
 		audit_required,
 	}
+}
+
+fn history_attention_worktree_next_action(lane: &OperatorHistoryLaneStatus) -> String {
+	let Some(reason) = lane.ledger_outcome.needs_attention_reason.as_deref() else {
+		return String::from(
+			"inspect the retained worktree diff and resolve the terminal attention outcome manually",
+		);
+	};
+
+	if lane.ledger_outcome.final_outcome == "terminal_failure"
+		&& reason == "review_handoff_writeback_failed"
+		&& let Some(issue_identifier) = lane.issue_identifier.as_deref()
+	{
+		return format!(
+			"Run `decodex recover review-handoff diagnose {issue_identifier} --json` to verify retained PR lineage, then follow the reported rebind recovery command."
+		);
+	}
+
+	reason.to_owned()
 }
 
 fn post_review_worktree_ownership(lane: &OperatorPostReviewLaneStatus) -> WorktreeOwnership {

--- a/apps/decodex/src/orchestrator/tests/operator/status/history/attention/terminal_attention.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/history/attention/terminal_attention.rs
@@ -215,6 +215,70 @@ fn live_status_counts_terminal_attention_when_current_attention_label_remains() 
 }
 
 #[test]
+fn local_status_projects_review_handoff_writeback_failure_recovery_action() {
+	let (_temp_dir, config, workflow) = status::temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = status::sample_issue_with_sort_fields(
+		"issue-xy-1113",
+		"XY-1113",
+		"Todo",
+		&["decodex:needs-attention"],
+		Some(3),
+		"2026-06-27T00:17:07Z",
+	);
+
+	state_store
+		.upsert_worktree(
+			TEST_SERVICE_ID,
+			&issue.id,
+			"y/profit-pilot-xy-1113",
+			&config.worktree_root().join(&issue.identifier).display().to_string(),
+		)
+		.expect("retained worktree should be recorded");
+	state_store
+		.record_run_attempt("xy-1113-attempt-1-1782480586", &issue.id, 1, "failed")
+		.expect("failed attempt should record");
+
+	status::seed_local_linear_execution_events(
+		&state_store,
+		&[status::linear_execution_history_comment(
+			&issue,
+			"terminal_failure",
+			"2026-06-27T00:17:07Z",
+			"manual_attention",
+			|record| {
+				record.branch = Some(String::from("y/profit-pilot-xy-1113"));
+				record.worktree_path = Some(String::from(".worktrees/XY-1113"));
+				record.pr_url =
+					Some(String::from("https://github.com/hack-ink/profit-pilot/pull/398"));
+				record.summary = Some(String::from("Decodex run failed and needs attention."));
+				record.error_class = Some(String::from("review_handoff_writeback_failed"));
+				record.next_action = Some(String::from("Decodex run failed and needs attention."));
+				record.blockers = Some(vec![String::from("review handoff writeback failed")]);
+				record.evidence = Some(vec![String::from("retained PR lane evidence present")]);
+			},
+		)],
+	);
+
+	let snapshot = orchestrator::build_operator_state_snapshot_without_live_observers(
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("snapshot should build");
+	let worktree = snapshot.worktrees.first().expect("retained worktree should render");
+
+	assert_eq!(worktree.ownership, "retained_attention");
+	assert_eq!(
+		worktree.recovery_next_action.as_deref(),
+		Some(
+			"Run `decodex recover review-handoff diagnose XY-1113 --json` to verify retained PR lineage, then follow the reported rebind recovery command."
+		)
+	);
+}
+
+#[test]
 fn live_status_treats_adopted_ready_to_land_history_attention_as_history_only() {
 	let (_temp_dir, config, workflow) = status::temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");

--- a/apps/decodex/src/recovery/reports.rs
+++ b/apps/decodex/src/recovery/reports.rs
@@ -31,6 +31,7 @@ pub(super) struct ReviewHandoffDiagnostic {
 	pub(super) existing_lifecycle_phase_head_oid: Option<String>,
 	pub(super) pr_base_ref: Option<String>,
 	pub(super) pr_head_oid: Option<String>,
+	pub(super) pr_read_error: Option<String>,
 	pub(super) mismatched_field: Option<String>,
 	pub(super) active_label_present: Option<bool>,
 	pub(super) next_action: String,
@@ -118,7 +119,7 @@ pub(super) fn render_review_handoff_recovery_report(
 
 	for diagnostic in &report.diagnostics {
 		output.push_str(&format!(
-			"- issue: {}\n  state: {}\n  classification: {}\n  reason: {}\n  branch: {}\n  worktree_path: {}\n  local_branch: {}\n  local_head: {}\n  worktree_clean: {}\n  existing_pr_url: {}\n  existing_lifecycle_handoff_head: {}\n  existing_lifecycle_phase_head: {}\n  pr_base_ref: {}\n  pr_head: {}\n  mismatched_field: {}\n  active_label_present: {}\n  next_action: {}\n",
+			"- issue: {}\n  state: {}\n  classification: {}\n  reason: {}\n  branch: {}\n  worktree_path: {}\n  local_branch: {}\n  local_head: {}\n  worktree_clean: {}\n  existing_pr_url: {}\n  existing_lifecycle_handoff_head: {}\n  existing_lifecycle_phase_head: {}\n  pr_base_ref: {}\n  pr_head: {}\n  pr_read_error: {}\n  mismatched_field: {}\n  active_label_present: {}\n  next_action: {}\n",
 			diagnostic.issue_identifier,
 			diagnostic.issue_state,
 			diagnostic.classification,
@@ -133,6 +134,7 @@ pub(super) fn render_review_handoff_recovery_report(
 			optional_text(diagnostic.existing_lifecycle_phase_head_oid.as_deref()),
 			optional_text(diagnostic.pr_base_ref.as_deref()),
 			optional_text(diagnostic.pr_head_oid.as_deref()),
+			optional_text(diagnostic.pr_read_error.as_deref()),
 			optional_text(diagnostic.mismatched_field.as_deref()),
 			diagnostic.active_label_present.map_or_else(|| String::from("unknown"), |present| present.to_string()),
 			diagnostic.next_action,

--- a/apps/decodex/src/recovery/review_handoff_diagnosis.rs
+++ b/apps/decodex/src/recovery/review_handoff_diagnosis.rs
@@ -48,13 +48,17 @@ where
 	let tracker_policy = context.workflow.frontmatter().tracker();
 	let success_state = tracker_policy.success_state();
 	let in_progress_state = tracker_policy.in_progress_state();
+	let failure_state = tracker_policy.failure_state();
 
 	for worktree in worktrees {
 		let Some(issue) = issues_by_id.get(worktree.issue_id()).cloned() else {
 			continue;
 		};
 
-		if issue.state.name != success_state && issue.state.name != in_progress_state {
+		if issue.state.name != success_state
+			&& issue.state.name != in_progress_state
+			&& issue.state.name != failure_state
+		{
 			continue;
 		}
 
@@ -133,6 +137,7 @@ fn stale_terminal_residue_review_handoff_diagnostic(
 		existing_lifecycle_phase_head_oid: None,
 		pr_base_ref: None,
 		pr_head_oid: None,
+		pr_read_error: None,
 		mismatched_field: None,
 		active_label_present: None,
 		next_action: String::from(
@@ -198,10 +203,13 @@ fn diagnose_issue_worktree(
 		})
 		.transpose()?
 		.flatten();
-	let pr_inspection = existing_handoff
-		.as_ref()
-		.and_then(|handoff| recovery::inspect_project_pull_request(context, handoff.pr_url()).ok())
-		.map(|(landing_state, _default_branch)| landing_state);
+	let (pr_inspection, pr_read_error) =
+		existing_handoff.as_ref().map_or((None, None), |handoff| {
+			match recovery::inspect_project_pull_request(context, handoff.pr_url()) {
+				Ok((landing_state, _default_branch)) => (Some(landing_state), None),
+				Err(error) => (None, Some(error.to_string())),
+			}
+		});
 	let local_branch_name =
 		git_worktree::worktree_checkout_branch_name(worktree.worktree_path()).ok().flatten();
 	let local_head_oid = git_worktree::worktree_head_oid(worktree.worktree_path()).ok().flatten();
@@ -251,6 +259,7 @@ fn diagnose_issue_worktree(
 			.map(|orchestration| orchestration.head_sha().to_owned()),
 		pr_base_ref: binding.pr_base_ref,
 		pr_head_oid: binding.pr_head_oid,
+		pr_read_error,
 		mismatched_field: binding.mismatched_field,
 		active_label_present,
 		next_action: binding.next_action,

--- a/apps/decodex/src/recovery/review_handoff_diagnosis/actions.rs
+++ b/apps/decodex/src/recovery/review_handoff_diagnosis/actions.rs
@@ -11,12 +11,14 @@ pub(super) fn missing_handoff_next_action(service_id: &str, issue_identifier: &s
 
 pub(super) fn bound_handoff_next_action(
 	service_id: &str,
+	issue_identifier: &str,
+	pr_url: &str,
 	active_label_present: Option<bool>,
 ) -> String {
 	if active_label_present == Some(false) {
 		return format!(
-			"Restore explicit lane ownership with label `{}`, then rerun `decodex recover review-handoff diagnose <ISSUE>` and continue the existing post-review lifecycle.",
-			tracker::automation_active_label(service_id)
+			"Run `decodex recover review-handoff rebind {issue_identifier} --pr {pr_url} --dry-run`, then rerun without `--dry-run` to restore `{}` ownership if validation passes.",
+			tracker::automation_active_label(service_id),
 		);
 	}
 

--- a/apps/decodex/src/recovery/review_handoff_diagnosis/binding.rs
+++ b/apps/decodex/src/recovery/review_handoff_diagnosis/binding.rs
@@ -132,6 +132,8 @@ pub(in crate::recovery) fn diagnostic_binding(
 		mismatched_field: None,
 		next_action: actions::bound_handoff_next_action(
 			request.service_id,
+			request.issue_identifier,
+			existing_handoff.pr_url(),
 			request.active_label_present,
 		),
 	}
@@ -152,7 +154,12 @@ fn handoff_issue_state_drift_diagnostic(
 				existing_handoff.pr_url(),
 			)
 		} else if request.issue_state_name == request.success_state {
-			actions::bound_handoff_next_action(request.service_id, request.active_label_present)
+			actions::bound_handoff_next_action(
+				request.service_id,
+				request.issue_identifier,
+				existing_handoff.pr_url(),
+				request.active_label_present,
+			)
 		} else {
 			actions::issue_state_mismatch_next_action(
 				request.success_state,

--- a/apps/decodex/src/recovery/tests/context.rs
+++ b/apps/decodex/src/recovery/tests/context.rs
@@ -8,7 +8,7 @@ use crate::{
 		RecoveryRuntimeMutationPolicy,
 		tests::{self, GhostLaneTestTracker},
 	},
-	state::ConnectorBackoffInput,
+	state::{ConnectorBackoffInput, ReviewHandoffMarker},
 };
 
 #[test]
@@ -144,5 +144,64 @@ fn review_handoff_diagnose_targeted_terminal_identifier_worktree_before_tracker_
 	assert!(
 		tracker.refresh_queries.borrow().is_empty(),
 		"targeted terminal local residue must not be sent to tracker refresh"
+	);
+}
+
+#[test]
+fn review_handoff_diagnose_includes_failure_state_retained_lane_and_pr_read_error() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let context =
+		tests::sample_recovery_context(&temp_dir, RecoveryRuntimeMutationPolicy::ReadOnly);
+	let issue = tests::sample_issue_with_labels("Todo", &[String::from("decodex:needs-attention")]);
+	let tracker = GhostLaneTestTracker::with_issues(vec![issue.clone()]);
+	let pr_url = "https://github.com/hack-ink/pubfi-mono-v2/pull/14";
+	let branch_name = "x/pubfi-pub-718";
+	let (worktree_dir, _original_head, head_oid) = tests::temp_git_worktree(branch_name);
+
+	context
+		.state_store
+		.upsert_worktree(
+			context.config.service_id(),
+			&issue.id,
+			branch_name,
+			&worktree_dir.path().display().to_string(),
+		)
+		.expect("retained worktree should record");
+	context
+		.state_store
+		.record_run_attempt("pub-718-attempt-1", &issue.id, 1, "failed")
+		.expect("failed attempt should record");
+	context
+		.state_store
+		.upsert_review_handoff_marker(
+			context.config.service_id(),
+			&issue.id,
+			&ReviewHandoffMarker::new(
+				"pub-718-attempt-1",
+				1,
+				branch_name,
+				pr_url,
+				"main",
+				branch_name,
+				&head_oid,
+			),
+		)
+		.expect("review handoff marker should record");
+
+	let diagnostics =
+		super::diagnose_all_retained_review_worktrees_with_tracker(&context, &tracker)
+			.expect("retained review diagnostics should build");
+	let diagnostic = diagnostics.first().expect("retained failure-state diagnostic should render");
+
+	assert_eq!(diagnostics.len(), 1);
+	assert_eq!(diagnostic.issue_identifier, "PUB-718");
+	assert_eq!(diagnostic.issue_state, "Todo");
+	assert_eq!(diagnostic.reason, "pull_request_state_read_failed");
+	assert_eq!(diagnostic.existing_pr_url.as_deref(), Some(pr_url));
+	assert_eq!(diagnostic.local_head_oid.as_deref(), Some(head_oid.as_str()));
+	assert_eq!(diagnostic.active_label_present, Some(false));
+	assert!(
+		diagnostic.pr_read_error.as_deref().is_some_and(|error| !error.trim().is_empty()),
+		"diagnose should report the concrete external PR read failure"
 	);
 }

--- a/apps/decodex/src/recovery/tests/review_handoff/diagnostics/ownership_drift.rs
+++ b/apps/decodex/src/recovery/tests/review_handoff/diagnostics/ownership_drift.rs
@@ -57,7 +57,8 @@ fn diagnostic_bound_handoff_reports_missing_active_ownership_recovery() {
 	assert_eq!(diagnostic.reason, "active_ownership_label_missing");
 	assert_eq!(diagnostic.mismatched_field.as_deref(), Some("issue.labels"));
 	assert!(diagnostic.next_action.contains("decodex:active:pubfi"));
-	assert!(diagnostic.next_action.contains("Restore explicit lane ownership"));
+	assert!(diagnostic.next_action.contains("rebind PUB-718"));
+	assert!(diagnostic.next_action.contains("--dry-run"));
 }
 
 #[test]

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,13 @@
 # Documentation Log
 
+## 2026-07-04
+
+- Updated review-handoff recovery docs for validated retained PR lanes that failed
+  during `review_handoff_writeback_failed`: diagnosis now covers failure-state
+  retained lanes, reports concrete PR readback errors, and routes missing active
+  ownership through audited `recover review-handoff rebind` instead of manual label
+  surgery.
+
 ## 2026-07-02
 
 - Added blocker-family guidance for tracker-present stale-active diagnostics so

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -6,9 +6,9 @@ status: active
 authority: current_state
 owner: docs
 tags: [reference]
-code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/recovery.rs, apps/decodex/src/recovery/stale_active_guidance.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/types.rs, apps/decodex/src/orchestrator/operator_http.rs, apps/decodex/src/orchestrator/operator_dashboard/body.html, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/orchestrator/tests/operator/status/http.rs, apps/decodex/src/mcp.rs]
-drift_watch: [decodex serve, decodex status, decodex lane inspect, decodex recover review-handoff, decodex recover ghost-lane, decodex recover stale-active, stale_active_release, stale_active_state_restore_pending, run_stale_active_recovery, linear_active_label_present, ghost_lane_cleanup_audit_present, mcp_test_fixture_ghost_lane, decodex evidence, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, phase_acceptance_check, control_plane_snapshot, operator dashboard, runtime.sqlite3, project.toml, WORKFLOW.md]
-last_verified: 2026-07-02
+code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/recovery.rs, apps/decodex/src/recovery/stale_active_guidance.rs, apps/decodex/src/recovery/review_handoff_diagnosis.rs, apps/decodex/src/recovery/reports.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/status_worktrees/ownership.rs, apps/decodex/src/orchestrator/types.rs, apps/decodex/src/orchestrator/operator_http.rs, apps/decodex/src/orchestrator/operator_dashboard/body.html, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/orchestrator/tests/operator/status/http.rs, apps/decodex/src/orchestrator/tests/operator/status/history/attention/terminal_attention.rs, apps/decodex/src/mcp.rs]
+drift_watch: [decodex serve, decodex status, decodex status --live, decodex lane inspect, decodex recover review-handoff, decodex recover ghost-lane, decodex recover stale-active, review_handoff_writeback_failed, retained_attention, stale_active_release, stale_active_state_restore_pending, run_stale_active_recovery, linear_active_label_present, ghost_lane_cleanup_audit_present, mcp_test_fixture_ghost_lane, decodex evidence, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, phase_acceptance_check, control_plane_snapshot, operator dashboard, runtime.sqlite3, project.toml, WORKFLOW.md]
+last_verified: 2026-07-04
 ---
 # Operator Control Plane
 
@@ -706,7 +706,12 @@ Worktree visibility follows the owning dashboard section:
   same issue is currently owned by a non-attention `Review & Landing` row such as
   `wait_for_review` or `ready_to_land`, that row controls the current action summary;
   stale active-label or worktree echoes from an older terminal ledger record stay in
-  Run Ledger history instead of reappearing as current attention.
+  Run Ledger history instead of reappearing as current attention. When the final
+  terminal failure class is `review_handoff_writeback_failed`, the retained worktree
+  `recovery_next_action` points first to
+  `decodex recover review-handoff diagnose <ISSUE> --json`; the diagnostic then
+  reports either verified retained PR lineage with a rebind plan or the concrete
+  external PR read failure through `pr_read_error`.
 - `decodex lane inspect` applies the same issue-scoped terminal Run Ledger projection
   to old or unowned runs. Cleanup-complete history renders as
   `status=cleanup_complete`, `ownership_state=closed`, `liveness_state=not_running`,

--- a/docs/runbook/recover-review-handoff.md
+++ b/docs/runbook/recover-review-handoff.md
@@ -6,7 +6,9 @@ status: active
 authority: procedural
 owner: automation
 tags: [runbook]
-last_verified: 2026-06-27
+code_refs: [apps/decodex/src/recovery/review_handoff.rs, apps/decodex/src/recovery/review_handoff_diagnosis.rs, apps/decodex/src/recovery/review_handoff_diagnosis/actions.rs, apps/decodex/src/recovery/reports.rs, apps/decodex/src/recovery/tests/review_handoff/diagnostics/ownership_drift.rs, apps/decodex/src/recovery/tests/context.rs]
+drift_watch: [decodex recover review-handoff diagnose, decodex recover review-handoff rebind, review_handoff_writeback_failed, review_handoff_ownership_drift, pull_request_state_read_failed, decodex:active:<service-id>, decodex:needs-attention]
+last_verified: 2026-07-04
 ---
 # Recover Review Handoff
 
@@ -38,8 +40,11 @@ Use `--json` for a structured report.
 The diagnostic is read-only. It reports the issue, tracker state, branch, worktree,
 local branch, local head, worktree cleanliness, existing PR URL when one is already
 bound, stored lifecycle handoff head, stored lifecycle phase head, PR base/head when
-readable, the mismatched field when one is known, active automation label presence,
-and the suggested next command.
+readable, the exact PR readback error when an external PR read fails, the mismatched
+field when one is known, active automation label presence, and the suggested next
+command. Retained lanes that already reached review handoff but then failed during
+handoff writeback remain diagnosable even when the tracker issue is back in the
+workflow `tracker.failure_state` and is missing `decodex:active:<service-id>`.
 
 ## Explicit Rebind
 


### PR DESCRIPTION
## Summary
- include retained terminal failure lanes in review-handoff diagnostics and surface PR readback failures
- route missing active ownership recovery through audited review-handoff rebind guidance
- add retained-attention status next action plus regression coverage and operator docs

## Validation
- cargo make fmt
- cargo make check