### PR TITLE
Split orchestration control modules

### DIFF
--- a/apps/decodex/src/orchestrator/daemon_retry/child_exit.rs
+++ b/apps/decodex/src/orchestrator/daemon_retry/child_exit.rs
@@ -1,11 +1,12 @@
-use crate::orchestrator::{
-	RunAttempt, TrackerIssue,
-	daemon_retry::{
-		self, CONTINUATION_PENDING_RUN_STATUS, ChildExitPhaseGoalRecovery, ChildExitRetryContext,
-		ChildExitRetrySchedule, ChildRunRef, ExitStatus, Instant, IssueDispatchMode, IssueTracker,
-		LaneDecisionSnapshot, OffsetDateTime, Result, RetryEntry, RetryEntryLifecycle,
-		RetryEntryRetentionDecision, RetryKind, RetryQueue, StateStore, WorkflowDocument,
-	},
+mod active;
+mod lane;
+mod plan;
+mod queue;
+
+use crate::orchestrator::daemon_retry::{
+	self, CONTINUATION_PENDING_RUN_STATUS, ChildExitPhaseGoalRecovery, ChildExitRetryContext,
+	ChildExitRetrySchedule, ChildRunRef, ExitStatus, IssueDispatchMode, IssueTracker, Result,
+	RetryEntryLifecycle, RetryEntryRetentionDecision, RetryKind,
 };
 
 pub(crate) fn schedule_retry_after_child_exit<T>(
@@ -19,11 +20,13 @@ pub(crate) fn schedule_retry_after_child_exit<T>(
 where
 	T: IssueTracker,
 {
-	let Some(run_attempt) = active_child_exit_run_attempt(&mut context, child, exit_status)? else {
+	let Some(run_attempt) =
+		active::active_child_exit_run_attempt(&mut context, child, exit_status)?
+	else {
 		return Ok(());
 	};
 	let issue_id = run_attempt.issue_id();
-	let Some(issue) = refreshed_child_exit_issue(&mut context, issue_id)? else {
+	let Some(issue) = active::refreshed_child_exit_issue(&mut context, issue_id)? else {
 		return Ok(());
 	};
 	let continuation_pending =
@@ -71,13 +74,13 @@ where
 		ChildExitPhaseGoalRecovery::Terminalized => return Ok(()),
 	};
 	let (kind, attempt, continuation_initial_issue_state) = if continuation_pending {
-		continuation_child_exit_retry_plan(&run_attempt, initial_issue_state)
+		plan::continuation_child_exit_retry_plan(&run_attempt, initial_issue_state)
 	} else if recovered_phase_goal_continuation.is_some() {
 		context
 			.state_store
 			.update_run_status(run_attempt.run_id(), CONTINUATION_PENDING_RUN_STATUS)?;
 
-		continuation_child_exit_retry_plan(&run_attempt, initial_issue_state)
+		plan::continuation_child_exit_retry_plan(&run_attempt, initial_issue_state)
 	} else if exit_status.success() {
 		daemon_retry::clear_retry_schedule_and_release(
 			context.retry_queue,
@@ -106,7 +109,7 @@ where
 		(RetryKind::Failure, retry_budget_attempts, None)
 	};
 
-	if !child_exit_lane_decision_permits_retry(
+	if !lane::child_exit_lane_decision_permits_retry(
 		&mut context,
 		&issue,
 		&run_attempt,
@@ -116,7 +119,7 @@ where
 		return Ok(());
 	}
 
-	queue_child_exit_retry(
+	queue::queue_child_exit_retry(
 		context.retry_queue,
 		context.state_store,
 		context.workflow,
@@ -131,193 +134,4 @@ where
 			attempt,
 		},
 	)
-}
-
-pub(crate) fn queue_child_exit_retry(
-	retry_queue: &mut RetryQueue,
-	state_store: &StateStore,
-	workflow: &WorkflowDocument,
-	schedule: ChildExitRetrySchedule<'_>,
-) -> Result<()> {
-	let attempt = schedule.attempt.max(1);
-	let delay = daemon_retry::retry_delay(schedule.kind, attempt, workflow);
-
-	tracing::info!(
-		issue_id = schedule.issue_id,
-		retry_kind = ?schedule.kind,
-		retry_attempt = attempt,
-		retry_delay_ms = delay.as_millis(),
-		"Queued retry after control-plane child exit."
-	);
-
-	let retry_ready_at_unix_epoch = OffsetDateTime::now_utc().unix_timestamp().saturating_add(
-		i64::try_from((delay.as_millis().saturating_add(999)) / 1_000).unwrap_or(i64::MAX),
-	);
-
-	daemon_retry::write_retry_schedule_for_run(
-		state_store,
-		schedule.issue_id,
-		schedule.run_id,
-		schedule.attempt_number,
-		schedule.kind,
-		retry_ready_at_unix_epoch,
-	)?;
-
-	if schedule.kind == RetryKind::Continuation {
-		state_store.append_private_execution_event(
-			schedule.project_id,
-			schedule.issue_id,
-			schedule.run_id,
-			schedule.attempt_number,
-			"continuation_lineage",
-			daemon_retry::json!({
-				"schema": "decodex.continuation_lineage/1",
-				"continuation_of_run_id": schedule.run_id,
-				"source_attempt_number": schedule.attempt_number,
-				"phase_cursor": "issue_private_evidence",
-				"retry_budget_consumed": false,
-				"retry_schedule_attempt": attempt,
-				"continuation_initial_issue_state": schedule.continuation_initial_issue_state.as_deref(),
-				"dispatch_mode": schedule.dispatch_mode.as_str(),
-				"next_retry_kind": schedule.kind.as_str(),
-			}),
-		)?;
-	}
-
-	retry_queue.upsert(RetryEntry {
-		issue_id: schedule.issue_id.to_owned(),
-		#[cfg(test)]
-		retry_project_slug: String::new(),
-		continuation_initial_issue_state: schedule.continuation_initial_issue_state,
-		lifecycle: RetryEntryLifecycle::for_dispatch_mode(schedule.dispatch_mode),
-		dispatch_mode: schedule.dispatch_mode,
-		kind: schedule.kind,
-		attempt,
-		ready_at: Instant::now() + delay,
-	});
-
-	Ok(())
-}
-
-fn continuation_child_exit_retry_plan(
-	run_attempt: &RunAttempt,
-	initial_issue_state: &str,
-) -> (RetryKind, u32, Option<String>) {
-	(
-		RetryKind::Continuation,
-		u32::try_from(run_attempt.attempt_number()).unwrap_or(u32::MAX).max(1),
-		Some(initial_issue_state.to_owned()),
-	)
-}
-
-fn active_child_exit_run_attempt<T>(
-	context: &mut ChildExitRetryContext<'_, T>,
-	child: ChildRunRef<'_>,
-	exit_status: ExitStatus,
-) -> Result<Option<RunAttempt>>
-where
-	T: IssueTracker,
-{
-	let Some(run_attempt) =
-		daemon_retry::resolve_child_exit_run_attempt(context.state_store, child)?
-	else {
-		tracing::debug!(
-			issue_id = child.issue_id,
-			run_id = child.run_id,
-			attempt = child.attempt_number,
-			"Daemon child exited without a matching recorded run attempt; skipping retry scheduling."
-		);
-
-		return Ok(None);
-	};
-
-	if !exit_status.success() {
-		daemon_retry::mark_run_attempt_if_active(
-			context.state_store,
-			run_attempt.run_id(),
-			"failed",
-		)?;
-	}
-
-	let Some(run_attempt) = context.state_store.run_attempt(run_attempt.run_id())? else {
-		return Ok(None);
-	};
-
-	if daemon_retry::superseded_run_disposition(context.state_store, &run_attempt)?.is_some() {
-		daemon_retry::clear_retry_schedule_and_release(
-			context.retry_queue,
-			context.state_store,
-			child.issue_id,
-		)?;
-
-		return Ok(None);
-	}
-
-	Ok(Some(run_attempt))
-}
-
-fn refreshed_child_exit_issue<T>(
-	context: &mut ChildExitRetryContext<'_, T>,
-	issue_id: &str,
-) -> Result<Option<TrackerIssue>>
-where
-	T: IssueTracker,
-{
-	let issue = daemon_retry::refresh_issue(context.tracker, issue_id)?;
-
-	if issue.is_none() {
-		daemon_retry::clear_retry_schedule_and_release(
-			context.retry_queue,
-			context.state_store,
-			issue_id,
-		)?;
-	}
-
-	Ok(issue)
-}
-
-fn child_exit_lane_decision_permits_retry<T>(
-	context: &mut ChildExitRetryContext<'_, T>,
-	issue: &TrackerIssue,
-	run_attempt: &RunAttempt,
-	dispatch_mode: IssueDispatchMode,
-	kind: RetryKind,
-) -> Result<bool>
-where
-	T: IssueTracker,
-{
-	let lane_snapshot = LaneDecisionSnapshot::child_exit_retry(
-		issue.identifier.clone(),
-		run_attempt.run_id().to_owned(),
-		run_attempt.attempt_number(),
-		dispatch_mode,
-		kind == RetryKind::Continuation,
-		Some(kind),
-		0,
-		false,
-		false,
-	);
-	let lane_decision = daemon_retry::decide_lane_next_action(&lane_snapshot);
-
-	context.state_store.append_private_execution_event(
-		context.project.service_id(),
-		issue.id.as_str(),
-		run_attempt.run_id(),
-		run_attempt.attempt_number(),
-		"lane_decision",
-		lane_snapshot.to_json(lane_decision.next_action, lane_decision.reason),
-	)?;
-
-	let retry_permitted = !lane_decision.blocks_automatic_execution()
-		&& lane_decision.permits_child_exit_retry_kind(kind);
-
-	if !retry_permitted {
-		daemon_retry::clear_retry_schedule_and_release(
-			context.retry_queue,
-			context.state_store,
-			issue.id.as_str(),
-		)?;
-	}
-
-	Ok(retry_permitted)
 }

--- a/apps/decodex/src/orchestrator/daemon_retry/child_exit/active.rs
+++ b/apps/decodex/src/orchestrator/daemon_retry/child_exit/active.rs
@@ -1,0 +1,70 @@
+use crate::orchestrator::{
+	RunAttempt, TrackerIssue,
+	daemon_retry::{self, ChildExitRetryContext, ChildRunRef, ExitStatus, IssueTracker, Result},
+};
+
+pub(crate) fn active_child_exit_run_attempt<T>(
+	context: &mut ChildExitRetryContext<'_, T>,
+	child: ChildRunRef<'_>,
+	exit_status: ExitStatus,
+) -> Result<Option<RunAttempt>>
+where
+	T: IssueTracker,
+{
+	let Some(run_attempt) =
+		daemon_retry::resolve_child_exit_run_attempt(context.state_store, child)?
+	else {
+		tracing::debug!(
+			issue_id = child.issue_id,
+			run_id = child.run_id,
+			attempt = child.attempt_number,
+			"Daemon child exited without a matching recorded run attempt; skipping retry scheduling."
+		);
+
+		return Ok(None);
+	};
+
+	if !exit_status.success() {
+		daemon_retry::mark_run_attempt_if_active(
+			context.state_store,
+			run_attempt.run_id(),
+			"failed",
+		)?;
+	}
+
+	let Some(run_attempt) = context.state_store.run_attempt(run_attempt.run_id())? else {
+		return Ok(None);
+	};
+
+	if daemon_retry::superseded_run_disposition(context.state_store, &run_attempt)?.is_some() {
+		daemon_retry::clear_retry_schedule_and_release(
+			context.retry_queue,
+			context.state_store,
+			child.issue_id,
+		)?;
+
+		return Ok(None);
+	}
+
+	Ok(Some(run_attempt))
+}
+
+pub(crate) fn refreshed_child_exit_issue<T>(
+	context: &mut ChildExitRetryContext<'_, T>,
+	issue_id: &str,
+) -> Result<Option<TrackerIssue>>
+where
+	T: IssueTracker,
+{
+	let issue = daemon_retry::refresh_issue(context.tracker, issue_id)?;
+
+	if issue.is_none() {
+		daemon_retry::clear_retry_schedule_and_release(
+			context.retry_queue,
+			context.state_store,
+			issue_id,
+		)?;
+	}
+
+	Ok(issue)
+}

--- a/apps/decodex/src/orchestrator/daemon_retry/child_exit/lane.rs
+++ b/apps/decodex/src/orchestrator/daemon_retry/child_exit/lane.rs
@@ -1,0 +1,53 @@
+use crate::orchestrator::{
+	RunAttempt, TrackerIssue,
+	daemon_retry::{
+		self, ChildExitRetryContext, IssueDispatchMode, IssueTracker, LaneDecisionSnapshot, Result,
+		RetryKind,
+	},
+};
+
+pub(crate) fn child_exit_lane_decision_permits_retry<T>(
+	context: &mut ChildExitRetryContext<'_, T>,
+	issue: &TrackerIssue,
+	run_attempt: &RunAttempt,
+	dispatch_mode: IssueDispatchMode,
+	kind: RetryKind,
+) -> Result<bool>
+where
+	T: IssueTracker,
+{
+	let lane_snapshot = LaneDecisionSnapshot::child_exit_retry(
+		issue.identifier.clone(),
+		run_attempt.run_id().to_owned(),
+		run_attempt.attempt_number(),
+		dispatch_mode,
+		kind == RetryKind::Continuation,
+		Some(kind),
+		0,
+		false,
+		false,
+	);
+	let lane_decision = daemon_retry::decide_lane_next_action(&lane_snapshot);
+
+	context.state_store.append_private_execution_event(
+		context.project.service_id(),
+		issue.id.as_str(),
+		run_attempt.run_id(),
+		run_attempt.attempt_number(),
+		"lane_decision",
+		lane_snapshot.to_json(lane_decision.next_action, lane_decision.reason),
+	)?;
+
+	let retry_permitted = !lane_decision.blocks_automatic_execution()
+		&& lane_decision.permits_child_exit_retry_kind(kind);
+
+	if !retry_permitted {
+		daemon_retry::clear_retry_schedule_and_release(
+			context.retry_queue,
+			context.state_store,
+			issue.id.as_str(),
+		)?;
+	}
+
+	Ok(retry_permitted)
+}

--- a/apps/decodex/src/orchestrator/daemon_retry/child_exit/plan.rs
+++ b/apps/decodex/src/orchestrator/daemon_retry/child_exit/plan.rs
@@ -1,0 +1,12 @@
+use crate::orchestrator::{RunAttempt, daemon_retry::RetryKind};
+
+pub(crate) fn continuation_child_exit_retry_plan(
+	run_attempt: &RunAttempt,
+	initial_issue_state: &str,
+) -> (RetryKind, u32, Option<String>) {
+	(
+		RetryKind::Continuation,
+		u32::try_from(run_attempt.attempt_number()).unwrap_or(u32::MAX).max(1),
+		Some(initial_issue_state.to_owned()),
+	)
+}

--- a/apps/decodex/src/orchestrator/daemon_retry/child_exit/queue.rs
+++ b/apps/decodex/src/orchestrator/daemon_retry/child_exit/queue.rs
@@ -1,0 +1,70 @@
+use crate::orchestrator::daemon_retry::{
+	self, ChildExitRetrySchedule, Instant, OffsetDateTime, Result, RetryEntry, RetryEntryLifecycle,
+	RetryKind, RetryQueue, StateStore, WorkflowDocument,
+};
+
+pub(crate) fn queue_child_exit_retry(
+	retry_queue: &mut RetryQueue,
+	state_store: &StateStore,
+	workflow: &WorkflowDocument,
+	schedule: ChildExitRetrySchedule<'_>,
+) -> Result<()> {
+	let attempt = schedule.attempt.max(1);
+	let delay = daemon_retry::retry_delay(schedule.kind, attempt, workflow);
+
+	tracing::info!(
+		issue_id = schedule.issue_id,
+		retry_kind = ?schedule.kind,
+		retry_attempt = attempt,
+		retry_delay_ms = delay.as_millis(),
+		"Queued retry after control-plane child exit."
+	);
+
+	let retry_ready_at_unix_epoch = OffsetDateTime::now_utc().unix_timestamp().saturating_add(
+		i64::try_from((delay.as_millis().saturating_add(999)) / 1_000).unwrap_or(i64::MAX),
+	);
+
+	daemon_retry::write_retry_schedule_for_run(
+		state_store,
+		schedule.issue_id,
+		schedule.run_id,
+		schedule.attempt_number,
+		schedule.kind,
+		retry_ready_at_unix_epoch,
+	)?;
+
+	if schedule.kind == RetryKind::Continuation {
+		state_store.append_private_execution_event(
+			schedule.project_id,
+			schedule.issue_id,
+			schedule.run_id,
+			schedule.attempt_number,
+			"continuation_lineage",
+			daemon_retry::json!({
+				"schema": "decodex.continuation_lineage/1",
+				"continuation_of_run_id": schedule.run_id,
+				"source_attempt_number": schedule.attempt_number,
+				"phase_cursor": "issue_private_evidence",
+				"retry_budget_consumed": false,
+				"retry_schedule_attempt": attempt,
+				"continuation_initial_issue_state": schedule.continuation_initial_issue_state.as_deref(),
+				"dispatch_mode": schedule.dispatch_mode.as_str(),
+				"next_retry_kind": schedule.kind.as_str(),
+			}),
+		)?;
+	}
+
+	retry_queue.upsert(RetryEntry {
+		issue_id: schedule.issue_id.to_owned(),
+		#[cfg(test)]
+		retry_project_slug: String::new(),
+		continuation_initial_issue_state: schedule.continuation_initial_issue_state,
+		lifecycle: RetryEntryLifecycle::for_dispatch_mode(schedule.dispatch_mode),
+		dispatch_mode: schedule.dispatch_mode,
+		kind: schedule.kind,
+		attempt,
+		ready_at: Instant::now() + delay,
+	});
+
+	Ok(())
+}

--- a/apps/decodex/src/orchestrator/execution_failure.rs
+++ b/apps/decodex/src/orchestrator/execution_failure.rs
@@ -50,9 +50,9 @@ use crate::{
 		architecture_recovery_retry_next_action, configured_public_projection_privacy_classifier,
 		eyre, format_retry_comment, format_terminal_failure_comment, json,
 		latest_open_issue_phase_goal_before_attempt, loop_guardrail_architecture_recovery_decision,
-		record_harness_outcome_best_effort, records::LinearExecutionEventPublicProjection,
-		relative_worktree_path, repo_gate_changed_tracked_files, retry_comment_details,
-		retry_delay, terminal_failure_comment_details, terminal_failure_lifecycle_event,
+		record_harness_outcome_best_effort, relative_worktree_path,
+		repo_gate_changed_tracked_files, retry_comment_details, retry_delay,
+		terminal_failure_comment_details, terminal_failure_lifecycle_event,
 		terminal_failure_pr_url, terminal_failure_recovery_gate, worktree_has_tracked_changes,
 		worktree_head_oid, write_retry_budget_marker, write_terminal_guard_marker,
 	},
@@ -103,13 +103,6 @@ impl RunFailureWritebackDisposition {
 pub(super) enum LoopGuardrailRecoveryDecision {
 	Start(ArchitectureRecoveryStart),
 	HumanRequired(LoopGuardrailStopRequested),
-}
-
-#[derive(Clone, Copy, Eq, PartialEq)]
-enum TerminalFailureEventRecordStatus {
-	Recorded,
-	Duplicate,
-	NoLocalStore,
 }
 
 #[derive(Debug)]
@@ -181,16 +174,6 @@ pub(super) struct LoopGuardrailWorktreeFingerprint {
 	pub(super) effective_status_hash: String,
 	pub(super) branch_delta_present: bool,
 	pub(super) effective_delta_present: bool,
-}
-
-struct PreparedTerminalFailureWriteback {
-	failure_state_id: String,
-	needs_attention_label: String,
-	needs_attention_label_id: Option<String>,
-	terminal_failure_state_name: String,
-	projection: LinearExecutionEventPublicProjection,
-	error_class: &'static str,
-	retry_guarded_by_state: bool,
 }
 
 struct FailureHandlingContext<'a, T>

--- a/apps/decodex/src/orchestrator/execution_failure/terminal_writeback.rs
+++ b/apps/decodex/src/orchestrator/execution_failure/terminal_writeback.rs
@@ -1,15 +1,31 @@
-use crate::{
-	orchestrator::{
-		execution_failure,
-		execution_failure::{
-			HarnessOutcomeKind, IssueRunPlan, IssueTracker, PreparedTerminalFailureWriteback,
-			Report, Result, RetainedPartialProgress, TerminalFailureEventRecordStatus,
-			TerminalFailureLifecycle, TerminalFailureOutcome, TerminalFailureWritebackRuntime,
-			WorkflowDocument, eyre,
-		},
+mod apply;
+mod prepare;
+mod record;
+
+use crate::orchestrator::{
+	execution_failure::{
+		self, HarnessOutcomeKind, IssueRunPlan, IssueTracker, Report, Result,
+		TerminalFailureOutcome, TerminalFailureWritebackRuntime, WorkflowDocument,
 	},
-	tracker::{self, records},
+	records::LinearExecutionEventPublicProjection,
 };
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum TerminalFailureEventRecordStatus {
+	Recorded,
+	Duplicate,
+	NoLocalStore,
+}
+
+struct PreparedTerminalFailureWriteback {
+	failure_state_id: String,
+	needs_attention_label: String,
+	needs_attention_label_id: Option<String>,
+	terminal_failure_state_name: String,
+	projection: LinearExecutionEventPublicProjection,
+	error_class: &'static str,
+	retry_guarded_by_state: bool,
+}
 
 pub(crate) fn apply_terminal_failure_writeback<T>(
 	tracker: &T,
@@ -23,7 +39,7 @@ pub(crate) fn apply_terminal_failure_writeback<T>(
 where
 	T: IssueTracker,
 {
-	let writeback = prepare_terminal_failure_writeback(
+	let writeback = prepare::prepare_terminal_failure_writeback(
 		tracker,
 		runtime,
 		workflow,
@@ -33,17 +49,17 @@ where
 		error,
 	)?;
 	let event_status =
-		record_terminal_failure_writeback_event(tracker, runtime, issue_run, &writeback)?;
+		record::record_terminal_failure_writeback_event(tracker, runtime, issue_run, &writeback)?;
 
 	if event_status == TerminalFailureEventRecordStatus::Duplicate {
 		return Ok(terminal_failure_outcome(&writeback));
 	}
 
 	let writeback_result =
-		apply_terminal_failure_tracker_writeback(tracker, runtime, issue_run, &writeback);
+		apply::apply_terminal_failure_tracker_writeback(tracker, runtime, issue_run, &writeback);
 
 	if let Err(error) = writeback_result {
-		forget_terminal_failure_writeback_event(runtime, event_status, &writeback)?;
+		record::forget_terminal_failure_writeback_event(runtime, event_status, &writeback)?;
 
 		return Err(error);
 	}
@@ -68,220 +84,6 @@ where
 	Ok(terminal_failure_outcome(&writeback))
 }
 
-fn prepare_terminal_failure_writeback<T>(
-	tracker: &T,
-	runtime: TerminalFailureWritebackRuntime<'_>,
-	workflow: &WorkflowDocument,
-	issue_run: &IssueRunPlan,
-	worktree_path: &str,
-	manual_attention_requested: bool,
-	error: &Report,
-) -> Result<PreparedTerminalFailureWriteback>
-where
-	T: IssueTracker,
-{
-	let tracker_policy = workflow.frontmatter().tracker();
-	let needs_attention_label = tracker_policy.needs_attention_label();
-	let needs_attention_label_id = tracker::issue_team_label_id_with_server_confirmation(
-		tracker,
-		&issue_run.issue,
-		needs_attention_label,
-	)?;
-	let failure_state_name = tracker_policy.failure_state();
-	let failure_state_is_startable =
-		tracker_policy.startable_states().iter().any(|state| state == failure_state_name);
-	let retry_guarded_by_state = needs_attention_label_id.is_none() && failure_state_is_startable;
-	let terminal_failure_state_name = if retry_guarded_by_state {
-		tracker_policy.in_progress_state()
-	} else {
-		failure_state_name
-	};
-	let failure_state_id =
-		issue_run.issue.state_id_for_name(terminal_failure_state_name).ok_or_else(|| {
-			eyre::eyre!(
-				"State `{}` was not found for issue `{}`.",
-				terminal_failure_state_name,
-				issue_run.issue.identifier
-			)
-		})?;
-	let recovery_gate = execution_failure::terminal_failure_recovery_gate(
-		needs_attention_label,
-		needs_attention_label_id.is_some(),
-		retry_guarded_by_state,
-		tracker_policy.in_progress_state(),
-	);
-	let (error_class, next_action) = execution_failure::terminal_failure_comment_details(
-		manual_attention_requested,
-		error,
-		&recovery_gate,
-	);
-	let pr_url = execution_failure::terminal_failure_pr_url(error);
-	let retained_source_error_class = error
-		.downcast_ref::<RetainedPartialProgress>()
-		.and_then(|partial_progress| partial_progress.source_error_class.as_deref());
-	let comment = execution_failure::format_terminal_failure_comment(
-		&issue_run.run_id,
-		issue_run.attempt_number,
-		worktree_path.to_owned(),
-		&issue_run.worktree.branch_name,
-		pr_url,
-		error_class,
-		&next_action,
-	);
-	let event = execution_failure::terminal_failure_lifecycle_event(
-		runtime.service_id,
-		issue_run,
-		TerminalFailureLifecycle {
-			error_class,
-			next_action: &next_action,
-			pr_url,
-			target_state: terminal_failure_state_name,
-			worktree_path,
-			manual_attention_requested,
-			retained_source_error_class,
-		},
-	);
-	let projection = tracker::prepare_linear_execution_event_comment(
-		&comment,
-		&event,
-		runtime.privacy_classifier,
-	)?;
-
-	Ok(PreparedTerminalFailureWriteback {
-		failure_state_id: failure_state_id.to_owned(),
-		needs_attention_label: needs_attention_label.to_owned(),
-		needs_attention_label_id,
-		terminal_failure_state_name: terminal_failure_state_name.to_owned(),
-		projection,
-		error_class,
-		retry_guarded_by_state,
-	})
-}
-
-fn record_terminal_failure_writeback_event<T>(
-	tracker: &T,
-	runtime: TerminalFailureWritebackRuntime<'_>,
-	issue_run: &IssueRunPlan,
-	writeback: &PreparedTerminalFailureWriteback,
-) -> Result<TerminalFailureEventRecordStatus>
-where
-	T: IssueTracker,
-{
-	let event_status = if let Some(state_store) = runtime.state_store {
-		if !state_store.record_linear_execution_event(&writeback.projection.record)? {
-			return Ok(TerminalFailureEventRecordStatus::Duplicate);
-		}
-
-		TerminalFailureEventRecordStatus::Recorded
-	} else {
-		TerminalFailureEventRecordStatus::NoLocalStore
-	};
-
-	if remote_terminal_failure_writeback_exists(
-		tracker,
-		runtime,
-		issue_run,
-		writeback,
-		event_status,
-	)? {
-		return Ok(TerminalFailureEventRecordStatus::Duplicate);
-	}
-
-	Ok(event_status)
-}
-
-fn remote_terminal_failure_writeback_exists<T>(
-	tracker: &T,
-	runtime: TerminalFailureWritebackRuntime<'_>,
-	issue_run: &IssueRunPlan,
-	writeback: &PreparedTerminalFailureWriteback,
-	event_status: TerminalFailureEventRecordStatus,
-) -> Result<bool>
-where
-	T: IssueTracker,
-{
-	let comments = match tracker.list_comments(&issue_run.issue.id) {
-		Ok(comments) => comments,
-		Err(error) => {
-			forget_terminal_failure_writeback_event(runtime, event_status, writeback)?;
-
-			return Err(error);
-		},
-	};
-
-	if !records::has_linear_execution_event_record(
-		&comments,
-		&writeback.projection.record.service_id,
-		&writeback.projection.record.issue_id,
-		&writeback.projection.record.idempotency_key,
-	) {
-		return Ok(false);
-	}
-
-	tracing::debug!(
-		service_id = writeback.projection.record.service_id,
-		issue_id = issue_run.issue.id,
-		issue = issue_run.issue.identifier,
-		run_id = issue_run.run_id,
-		attempt = issue_run.attempt_number,
-		event_type = writeback.projection.record.event_type,
-		"Skipping terminal failure writeback already present in remote Linear ledger."
-	);
-
-	Ok(true)
-}
-
-fn apply_terminal_failure_tracker_writeback<T>(
-	tracker: &T,
-	runtime: TerminalFailureWritebackRuntime<'_>,
-	issue_run: &IssueRunPlan,
-	writeback: &PreparedTerminalFailureWriteback,
-) -> Result<()>
-where
-	T: IssueTracker,
-{
-	tracker.update_issue_state(&issue_run.issue.id, &writeback.failure_state_id)?;
-
-	apply_needs_attention_label(
-		tracker,
-		issue_run,
-		runtime.service_id,
-		&writeback.needs_attention_label,
-		writeback.needs_attention_label_id.clone(),
-		&writeback.terminal_failure_state_name,
-	)?;
-
-	if runtime.state_store.is_some() {
-		tracker::create_prepared_linear_execution_event_comment_without_remote_scan(
-			tracker,
-			&issue_run.issue.id,
-			&writeback.projection,
-		)?;
-	} else {
-		tracker::create_prepared_linear_execution_event_comment(
-			tracker,
-			&issue_run.issue.id,
-			&writeback.projection,
-		)?;
-	}
-
-	Ok(())
-}
-
-fn forget_terminal_failure_writeback_event(
-	runtime: TerminalFailureWritebackRuntime<'_>,
-	event_status: TerminalFailureEventRecordStatus,
-	writeback: &PreparedTerminalFailureWriteback,
-) -> Result<()> {
-	if event_status == TerminalFailureEventRecordStatus::Recorded
-		&& let Some(state_store) = runtime.state_store
-	{
-		state_store.forget_linear_execution_event(&writeback.projection.record.idempotency_key)?;
-	}
-
-	Ok(())
-}
-
 fn terminal_failure_outcome(
 	writeback: &PreparedTerminalFailureWriteback,
 ) -> TerminalFailureOutcome {
@@ -289,42 +91,4 @@ fn terminal_failure_outcome(
 		error_class: writeback.error_class,
 		retry_guarded_by_state: writeback.retry_guarded_by_state,
 	}
-}
-
-fn apply_needs_attention_label<T>(
-	tracker: &T,
-	issue_run: &IssueRunPlan,
-	service_id: &str,
-	needs_attention_label: &str,
-	needs_attention_label_id: Option<String>,
-	terminal_failure_state_name: &str,
-) -> Result<bool>
-where
-	T: IssueTracker,
-{
-	if let Some(label_id) = needs_attention_label_id.as_deref() {
-		if !tracker::issue_has_label_with_server_confirmation(
-			tracker,
-			&issue_run.issue,
-			needs_attention_label,
-		)? {
-			tracker.add_issue_labels(&issue_run.issue.id, &[label_id.to_owned()])?;
-		}
-	} else {
-		tracing::warn!(
-			label = needs_attention_label,
-			issue = issue_run.issue.identifier,
-			guard_state = terminal_failure_state_name,
-			"Needs-attention label was not found in the issue team; using a non-startable state guard when needed."
-		);
-	}
-
-	execution_failure::ensure_automation_activity_label(
-		tracker,
-		&issue_run.issue,
-		service_id,
-		false,
-	)?;
-
-	Ok(needs_attention_label_id.is_some())
 }

--- a/apps/decodex/src/orchestrator/execution_failure/terminal_writeback/apply.rs
+++ b/apps/decodex/src/orchestrator/execution_failure/terminal_writeback/apply.rs
@@ -1,0 +1,85 @@
+use crate::{
+	orchestrator::{
+		execution_failure,
+		execution_failure::{
+			IssueRunPlan, IssueTracker, Result, TerminalFailureWritebackRuntime,
+			terminal_writeback::PreparedTerminalFailureWriteback,
+		},
+	},
+	tracker,
+};
+
+pub(crate) fn apply_terminal_failure_tracker_writeback<T>(
+	tracker: &T,
+	runtime: TerminalFailureWritebackRuntime<'_>,
+	issue_run: &IssueRunPlan,
+	writeback: &PreparedTerminalFailureWriteback,
+) -> Result<()>
+where
+	T: IssueTracker,
+{
+	tracker.update_issue_state(&issue_run.issue.id, &writeback.failure_state_id)?;
+
+	apply_needs_attention_label(
+		tracker,
+		issue_run,
+		runtime.service_id,
+		&writeback.needs_attention_label,
+		writeback.needs_attention_label_id.clone(),
+		&writeback.terminal_failure_state_name,
+	)?;
+
+	if runtime.state_store.is_some() {
+		tracker::create_prepared_linear_execution_event_comment_without_remote_scan(
+			tracker,
+			&issue_run.issue.id,
+			&writeback.projection,
+		)?;
+	} else {
+		tracker::create_prepared_linear_execution_event_comment(
+			tracker,
+			&issue_run.issue.id,
+			&writeback.projection,
+		)?;
+	}
+
+	Ok(())
+}
+
+fn apply_needs_attention_label<T>(
+	tracker: &T,
+	issue_run: &IssueRunPlan,
+	service_id: &str,
+	needs_attention_label: &str,
+	needs_attention_label_id: Option<String>,
+	terminal_failure_state_name: &str,
+) -> Result<bool>
+where
+	T: IssueTracker,
+{
+	if let Some(label_id) = needs_attention_label_id.as_deref() {
+		if !tracker::issue_has_label_with_server_confirmation(
+			tracker,
+			&issue_run.issue,
+			needs_attention_label,
+		)? {
+			tracker.add_issue_labels(&issue_run.issue.id, &[label_id.to_owned()])?;
+		}
+	} else {
+		tracing::warn!(
+			label = needs_attention_label,
+			issue = issue_run.issue.identifier,
+			guard_state = terminal_failure_state_name,
+			"Needs-attention label was not found in the issue team; using a non-startable state guard when needed."
+		);
+	}
+
+	execution_failure::ensure_automation_activity_label(
+		tracker,
+		&issue_run.issue,
+		service_id,
+		false,
+	)?;
+
+	Ok(needs_attention_label_id.is_some())
+}

--- a/apps/decodex/src/orchestrator/execution_failure/terminal_writeback/prepare.rs
+++ b/apps/decodex/src/orchestrator/execution_failure/terminal_writeback/prepare.rs
@@ -1,0 +1,101 @@
+use crate::{
+	orchestrator::{
+		execution_failure,
+		execution_failure::{
+			IssueRunPlan, IssueTracker, Report, Result, RetainedPartialProgress,
+			TerminalFailureLifecycle, TerminalFailureWritebackRuntime, WorkflowDocument, eyre,
+			terminal_writeback::PreparedTerminalFailureWriteback,
+		},
+	},
+	tracker,
+};
+
+pub(crate) fn prepare_terminal_failure_writeback<T>(
+	tracker: &T,
+	runtime: TerminalFailureWritebackRuntime<'_>,
+	workflow: &WorkflowDocument,
+	issue_run: &IssueRunPlan,
+	worktree_path: &str,
+	manual_attention_requested: bool,
+	error: &Report,
+) -> Result<PreparedTerminalFailureWriteback>
+where
+	T: IssueTracker,
+{
+	let tracker_policy = workflow.frontmatter().tracker();
+	let needs_attention_label = tracker_policy.needs_attention_label();
+	let needs_attention_label_id = tracker::issue_team_label_id_with_server_confirmation(
+		tracker,
+		&issue_run.issue,
+		needs_attention_label,
+	)?;
+	let failure_state_name = tracker_policy.failure_state();
+	let failure_state_is_startable =
+		tracker_policy.startable_states().iter().any(|state| state == failure_state_name);
+	let retry_guarded_by_state = needs_attention_label_id.is_none() && failure_state_is_startable;
+	let terminal_failure_state_name = if retry_guarded_by_state {
+		tracker_policy.in_progress_state()
+	} else {
+		failure_state_name
+	};
+	let failure_state_id =
+		issue_run.issue.state_id_for_name(terminal_failure_state_name).ok_or_else(|| {
+			eyre::eyre!(
+				"State `{}` was not found for issue `{}`.",
+				terminal_failure_state_name,
+				issue_run.issue.identifier
+			)
+		})?;
+	let recovery_gate = execution_failure::terminal_failure_recovery_gate(
+		needs_attention_label,
+		needs_attention_label_id.is_some(),
+		retry_guarded_by_state,
+		tracker_policy.in_progress_state(),
+	);
+	let (error_class, next_action) = execution_failure::terminal_failure_comment_details(
+		manual_attention_requested,
+		error,
+		&recovery_gate,
+	);
+	let pr_url = execution_failure::terminal_failure_pr_url(error);
+	let retained_source_error_class = error
+		.downcast_ref::<RetainedPartialProgress>()
+		.and_then(|partial_progress| partial_progress.source_error_class.as_deref());
+	let comment = execution_failure::format_terminal_failure_comment(
+		&issue_run.run_id,
+		issue_run.attempt_number,
+		worktree_path.to_owned(),
+		&issue_run.worktree.branch_name,
+		pr_url,
+		error_class,
+		&next_action,
+	);
+	let event = execution_failure::terminal_failure_lifecycle_event(
+		runtime.service_id,
+		issue_run,
+		TerminalFailureLifecycle {
+			error_class,
+			next_action: &next_action,
+			pr_url,
+			target_state: terminal_failure_state_name,
+			worktree_path,
+			manual_attention_requested,
+			retained_source_error_class,
+		},
+	);
+	let projection = tracker::prepare_linear_execution_event_comment(
+		&comment,
+		&event,
+		runtime.privacy_classifier,
+	)?;
+
+	Ok(PreparedTerminalFailureWriteback {
+		failure_state_id: failure_state_id.to_owned(),
+		needs_attention_label: needs_attention_label.to_owned(),
+		needs_attention_label_id,
+		terminal_failure_state_name: terminal_failure_state_name.to_owned(),
+		projection,
+		error_class,
+		retry_guarded_by_state,
+	})
+}

--- a/apps/decodex/src/orchestrator/execution_failure/terminal_writeback/record.rs
+++ b/apps/decodex/src/orchestrator/execution_failure/terminal_writeback/record.rs
@@ -1,0 +1,94 @@
+use crate::{
+	orchestrator::execution_failure::{
+		IssueRunPlan, IssueTracker, Result, TerminalFailureWritebackRuntime,
+		terminal_writeback::{PreparedTerminalFailureWriteback, TerminalFailureEventRecordStatus},
+	},
+	tracker::records,
+};
+
+pub(crate) fn record_terminal_failure_writeback_event<T>(
+	tracker: &T,
+	runtime: TerminalFailureWritebackRuntime<'_>,
+	issue_run: &IssueRunPlan,
+	writeback: &PreparedTerminalFailureWriteback,
+) -> Result<TerminalFailureEventRecordStatus>
+where
+	T: IssueTracker,
+{
+	let event_status = if let Some(state_store) = runtime.state_store {
+		if !state_store.record_linear_execution_event(&writeback.projection.record)? {
+			return Ok(TerminalFailureEventRecordStatus::Duplicate);
+		}
+
+		TerminalFailureEventRecordStatus::Recorded
+	} else {
+		TerminalFailureEventRecordStatus::NoLocalStore
+	};
+
+	if remote_terminal_failure_writeback_exists(
+		tracker,
+		runtime,
+		issue_run,
+		writeback,
+		event_status,
+	)? {
+		return Ok(TerminalFailureEventRecordStatus::Duplicate);
+	}
+
+	Ok(event_status)
+}
+
+pub(crate) fn forget_terminal_failure_writeback_event(
+	runtime: TerminalFailureWritebackRuntime<'_>,
+	event_status: TerminalFailureEventRecordStatus,
+	writeback: &PreparedTerminalFailureWriteback,
+) -> Result<()> {
+	if event_status == TerminalFailureEventRecordStatus::Recorded
+		&& let Some(state_store) = runtime.state_store
+	{
+		state_store.forget_linear_execution_event(&writeback.projection.record.idempotency_key)?;
+	}
+
+	Ok(())
+}
+
+fn remote_terminal_failure_writeback_exists<T>(
+	tracker: &T,
+	runtime: TerminalFailureWritebackRuntime<'_>,
+	issue_run: &IssueRunPlan,
+	writeback: &PreparedTerminalFailureWriteback,
+	event_status: TerminalFailureEventRecordStatus,
+) -> Result<bool>
+where
+	T: IssueTracker,
+{
+	let comments = match tracker.list_comments(&issue_run.issue.id) {
+		Ok(comments) => comments,
+		Err(error) => {
+			forget_terminal_failure_writeback_event(runtime, event_status, writeback)?;
+
+			return Err(error);
+		},
+	};
+
+	if !records::has_linear_execution_event_record(
+		&comments,
+		&writeback.projection.record.service_id,
+		&writeback.projection.record.issue_id,
+		&writeback.projection.record.idempotency_key,
+	) {
+		return Ok(false);
+	}
+
+	tracing::debug!(
+		service_id = writeback.projection.record.service_id,
+		issue_id = issue_run.issue.id,
+		issue = issue_run.issue.identifier,
+		run_id = issue_run.run_id,
+		attempt = issue_run.attempt_number,
+		event_type = writeback.projection.record.event_type,
+		"Skipping terminal failure writeback already present in remote Linear ledger."
+	);
+
+	Ok(true)
+}

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue.rs
@@ -2,21 +2,18 @@ pub(crate) mod inferred;
 pub(crate) mod post_review;
 pub(crate) mod program;
 
+mod closeout;
+mod context;
+mod identity;
+mod lease;
+
 pub(crate) use inferred::run_target_issue_once_with_inferred_dispatch;
 #[cfg(test)] pub(crate) use program::select_target_status_visible_program_candidate;
 
-use crate::{
-	commit_message,
-	orchestrator::{
-		run_cycle,
-		run_cycle::{
-			IssueDispatchMode, IssueTracker, OffsetDateTime, PreferredRunIdentity,
-			PrepareIssueRunContext, Result, RetainedReviewRunIdentity, RetryIssueStateHint,
-			RunSummary, ServiceConfig, StateStore, TargetIssueRunContext, TrackerIssue,
-			WorktreeManager, eyre,
-		},
-	},
-	state::PreacquiredLeaseGuards,
+use crate::orchestrator::run_cycle::{
+	self, IssueDispatchMode, IssueTracker, PrepareIssueRunContext, Result, RetryIssueStateHint,
+	RunSummary, ServiceConfig, StateStore, TargetIssueRunContext, TrackerIssue, WorktreeManager,
+	eyre,
 };
 
 pub(crate) fn run_target_issue_once<T>(
@@ -36,13 +33,13 @@ where
 		context.project.worktree_root(),
 	)?;
 
-	let issue_id = resolve_target_issue_id(context.tracker, context.issue_id)?;
+	let issue_id = identity::resolve_target_issue_id(context.tracker, context.issue_id)?;
 
 	if !context.dry_run {
 		context.state_store.canonicalize_issue_identity(context.issue_id, &issue_id)?;
 	}
 	if context.lease_preacquired && !context.dry_run {
-		adopt_preacquired_target_issue_lease(&context, &issue_id)?;
+		lease::adopt_preacquired_target_issue_lease(&context, &issue_id)?;
 	}
 	if !context.lease_preacquired {
 		run_cycle::recover_runtime_state_from_tracker_and_worktrees(
@@ -66,8 +63,9 @@ where
 	let Some(issue) = run_cycle::refresh_issue(context.tracker, &issue_id)? else {
 		return Ok(None);
 	};
-	let closeout_preferred_run_identity = target_closeout_preferred_run_identity(&context, &issue)?;
-	let preferred_run_identity = preferred_run_identity_with_closeout_fallback(
+	let closeout_preferred_run_identity =
+		closeout::target_closeout_preferred_run_identity(&context, &issue)?;
+	let preferred_run_identity = closeout::preferred_run_identity_with_closeout_fallback(
 		context.preferred_run_identity,
 		closeout_preferred_run_identity.as_ref(),
 	);
@@ -91,7 +89,7 @@ where
 	}
 
 	let reuses_existing_closeout_claim =
-		target_issue_reuses_existing_closeout_claim(&context, &issue_id, &issue)?;
+		closeout::target_issue_reuses_existing_closeout_claim(&context, &issue_id, &issue)?;
 
 	if target_issue_active_claim_blocks_dispatch(&context, &issue_id, &issue)? {
 		return Ok(None);
@@ -139,21 +137,7 @@ pub(crate) fn target_issue_active_claim_blocks_dispatch<T>(
 where
 	T: IssueTracker,
 {
-	if context.lease_preacquired {
-		return Ok(false);
-	}
-	if !context.state_store.issue_has_active_shared_claim(context.project.service_id(), issue_id)? {
-		return Ok(false);
-	}
-	if context.dispatch_mode == IssueDispatchMode::Closeout {
-		return closeout_lane_active_claim_blocks_dispatch(
-			context.project,
-			context.state_store,
-			issue,
-		);
-	}
-
-	Ok(true)
+	closeout::target_issue_active_claim_blocks_dispatch(context, issue_id, issue)
 }
 
 pub(crate) fn closeout_lane_active_claim_blocks_dispatch(
@@ -161,52 +145,21 @@ pub(crate) fn closeout_lane_active_claim_blocks_dispatch(
 	state_store: &StateStore,
 	issue: &TrackerIssue,
 ) -> Result<bool> {
-	if !state_store.issue_has_active_shared_claim(project.service_id(), &issue.id)? {
-		return Ok(false);
-	}
-
-	let Some(lease) = state_store.lease_for_issue(&issue.id)? else {
-		return Ok(true);
-	};
-	let now_unix_epoch = OffsetDateTime::now_utc().unix_timestamp();
-
-	run_cycle::retained_closeout_lease_has_fresh_activity(&lease, issue, project, now_unix_epoch)
+	closeout::closeout_lane_active_claim_blocks_dispatch(project, state_store, issue)
 }
 
 pub(crate) fn target_issue_run_context_with_dispatch_mode<'a, T>(
 	context: &TargetIssueRunContext<'a, T>,
 	dispatch_mode: IssueDispatchMode,
 ) -> TargetIssueRunContext<'a, T> {
-	TargetIssueRunContext {
-		tracker: context.tracker,
-		project: context.project,
-		workflow: context.workflow,
-		state_store: context.state_store,
-		issue_id: context.issue_id,
-		preferred_issue_state: context.preferred_issue_state,
-		preferred_initial_issue_state: context.preferred_initial_issue_state,
-		dry_run: context.dry_run,
-		lease_preacquired: context.lease_preacquired,
-		preferred_issue_claim_fd: context.preferred_issue_claim_fd,
-		preferred_dispatch_slot_fd: context.preferred_dispatch_slot_fd,
-		preferred_dispatch_slot_index: context.preferred_dispatch_slot_index,
-		dispatch_mode,
-		preferred_run_identity: context.preferred_run_identity,
-		preferred_retry_budget_base: context.preferred_retry_budget_base,
-	}
+	context::target_issue_run_context_with_dispatch_mode(context, dispatch_mode)
 }
 
 pub(crate) fn resolve_target_issue_id<T>(tracker: &T, issue_reference: &str) -> Result<String>
 where
 	T: IssueTracker,
 {
-	if commit_message::looks_like_issue_identifier(issue_reference)
-		&& let Some(issue) = tracker.get_issue_by_identifier(issue_reference)?
-	{
-		return Ok(issue.id);
-	}
-
-	Ok(issue_reference.to_owned())
+	identity::resolve_target_issue_id(tracker, issue_reference)
 }
 
 fn ensure_target_closeout_dispatch_is_unblocked<T>(
@@ -232,93 +185,4 @@ where
 	};
 
 	eyre::bail!("retained closeout dispatch blocked: {reason}");
-}
-
-fn target_closeout_preferred_run_identity<T>(
-	context: &TargetIssueRunContext<'_, T>,
-	issue: &TrackerIssue,
-) -> Result<Option<RetainedReviewRunIdentity>>
-where
-	T: IssueTracker,
-{
-	if context.dispatch_mode != IssueDispatchMode::Closeout
-		|| context.preferred_run_identity.is_some()
-	{
-		return Ok(None);
-	}
-
-	run_cycle::retained_closeout_preferred_run_identity(
-		context.state_store,
-		context.project.service_id(),
-		issue,
-	)
-}
-
-fn preferred_run_identity_with_closeout_fallback<'a>(
-	preferred_run_identity: Option<PreferredRunIdentity<'a>>,
-	closeout_preferred_run_identity: Option<&'a RetainedReviewRunIdentity>,
-) -> Option<PreferredRunIdentity<'a>> {
-	match (preferred_run_identity, closeout_preferred_run_identity) {
-		(Some(identity), _) => Some(identity),
-		(None, Some(identity)) => Some(PreferredRunIdentity {
-			run_id: identity.run_id.as_str(),
-			attempt_number: identity.attempt_number,
-		}),
-		(None, None) => None,
-	}
-}
-
-fn target_issue_reuses_existing_closeout_claim<T>(
-	context: &TargetIssueRunContext<'_, T>,
-	issue_id: &str,
-	issue: &TrackerIssue,
-) -> Result<bool>
-where
-	T: IssueTracker,
-{
-	if context.lease_preacquired || context.dispatch_mode != IssueDispatchMode::Closeout {
-		return Ok(false);
-	}
-	if !context.state_store.issue_has_active_shared_claim(context.project.service_id(), issue_id)? {
-		return Ok(false);
-	}
-	if context.state_store.lease_for_issue(&issue.id)?.is_none() {
-		return Ok(false);
-	}
-
-	Ok(!closeout_lane_active_claim_blocks_dispatch(context.project, context.state_store, issue)?)
-}
-
-fn adopt_preacquired_target_issue_lease<T>(
-	context: &TargetIssueRunContext<'_, T>,
-	issue_id: &str,
-) -> Result<()>
-where
-	T: IssueTracker,
-{
-	let preferred_run_identity = context.preferred_run_identity.ok_or_else(|| {
-		eyre::eyre!("daemon child lease handoff requires a planned run identifier")
-	})?;
-	let preferred_issue_state = context
-		.preferred_issue_state
-		.ok_or_else(|| eyre::eyre!("daemon child lease handoff requires a planned issue state"))?;
-	let issue_claim_fd = context.preferred_issue_claim_fd.ok_or_else(|| {
-		eyre::eyre!("daemon child lease handoff requires an inherited issue-claim fd")
-	})?;
-	let dispatch_slot_fd = context.preferred_dispatch_slot_fd.ok_or_else(|| {
-		eyre::eyre!("daemon child lease handoff requires an inherited dispatch-slot fd")
-	})?;
-	let dispatch_slot_index = context.preferred_dispatch_slot_index.ok_or_else(|| {
-		eyre::eyre!("daemon child lease handoff requires an inherited dispatch-slot index")
-	})?;
-
-	context.state_store.adopt_preacquired_lease(
-		context.project.service_id(),
-		issue_id,
-		preferred_run_identity.run_id,
-		preferred_issue_state,
-		PreacquiredLeaseGuards { issue_claim_fd, dispatch_slot_fd, dispatch_slot_index },
-	)?;
-
-	Ok(())
 }

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue/closeout.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue/closeout.rs
@@ -1,0 +1,101 @@
+use crate::orchestrator::run_cycle::{
+	self, IssueDispatchMode, IssueTracker, OffsetDateTime, PreferredRunIdentity, Result,
+	RetainedReviewRunIdentity, ServiceConfig, StateStore, TargetIssueRunContext, TrackerIssue,
+};
+
+pub(crate) fn target_issue_active_claim_blocks_dispatch<T>(
+	context: &TargetIssueRunContext<'_, T>,
+	issue_id: &str,
+	issue: &TrackerIssue,
+) -> Result<bool>
+where
+	T: IssueTracker,
+{
+	if context.lease_preacquired {
+		return Ok(false);
+	}
+	if !context.state_store.issue_has_active_shared_claim(context.project.service_id(), issue_id)? {
+		return Ok(false);
+	}
+	if context.dispatch_mode == IssueDispatchMode::Closeout {
+		return closeout_lane_active_claim_blocks_dispatch(
+			context.project,
+			context.state_store,
+			issue,
+		);
+	}
+
+	Ok(true)
+}
+
+pub(crate) fn closeout_lane_active_claim_blocks_dispatch(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	issue: &TrackerIssue,
+) -> Result<bool> {
+	if !state_store.issue_has_active_shared_claim(project.service_id(), &issue.id)? {
+		return Ok(false);
+	}
+
+	let Some(lease) = state_store.lease_for_issue(&issue.id)? else {
+		return Ok(true);
+	};
+	let now_unix_epoch = OffsetDateTime::now_utc().unix_timestamp();
+
+	run_cycle::retained_closeout_lease_has_fresh_activity(&lease, issue, project, now_unix_epoch)
+}
+
+pub(crate) fn target_closeout_preferred_run_identity<T>(
+	context: &TargetIssueRunContext<'_, T>,
+	issue: &TrackerIssue,
+) -> Result<Option<RetainedReviewRunIdentity>>
+where
+	T: IssueTracker,
+{
+	if context.dispatch_mode != IssueDispatchMode::Closeout
+		|| context.preferred_run_identity.is_some()
+	{
+		return Ok(None);
+	}
+
+	run_cycle::retained_closeout_preferred_run_identity(
+		context.state_store,
+		context.project.service_id(),
+		issue,
+	)
+}
+
+pub(crate) fn preferred_run_identity_with_closeout_fallback<'a>(
+	preferred_run_identity: Option<PreferredRunIdentity<'a>>,
+	closeout_preferred_run_identity: Option<&'a RetainedReviewRunIdentity>,
+) -> Option<PreferredRunIdentity<'a>> {
+	match (preferred_run_identity, closeout_preferred_run_identity) {
+		(Some(identity), _) => Some(identity),
+		(None, Some(identity)) => Some(PreferredRunIdentity {
+			run_id: identity.run_id.as_str(),
+			attempt_number: identity.attempt_number,
+		}),
+		(None, None) => None,
+	}
+}
+
+pub(crate) fn target_issue_reuses_existing_closeout_claim<T>(
+	context: &TargetIssueRunContext<'_, T>,
+	issue_id: &str,
+	issue: &TrackerIssue,
+) -> Result<bool>
+where
+	T: IssueTracker,
+{
+	if context.lease_preacquired || context.dispatch_mode != IssueDispatchMode::Closeout {
+		return Ok(false);
+	}
+	if !context.state_store.issue_has_active_shared_claim(context.project.service_id(), issue_id)? {
+		return Ok(false);
+	}
+	if context.state_store.lease_for_issue(&issue.id)?.is_none() {
+		return Ok(false);
+	}
+
+	Ok(!closeout_lane_active_claim_blocks_dispatch(context.project, context.state_store, issue)?)
+}

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue/context.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue/context.rs
@@ -1,0 +1,24 @@
+use crate::orchestrator::run_cycle::{IssueDispatchMode, TargetIssueRunContext};
+
+pub(crate) fn target_issue_run_context_with_dispatch_mode<'a, T>(
+	context: &TargetIssueRunContext<'a, T>,
+	dispatch_mode: IssueDispatchMode,
+) -> TargetIssueRunContext<'a, T> {
+	TargetIssueRunContext {
+		tracker: context.tracker,
+		project: context.project,
+		workflow: context.workflow,
+		state_store: context.state_store,
+		issue_id: context.issue_id,
+		preferred_issue_state: context.preferred_issue_state,
+		preferred_initial_issue_state: context.preferred_initial_issue_state,
+		dry_run: context.dry_run,
+		lease_preacquired: context.lease_preacquired,
+		preferred_issue_claim_fd: context.preferred_issue_claim_fd,
+		preferred_dispatch_slot_fd: context.preferred_dispatch_slot_fd,
+		preferred_dispatch_slot_index: context.preferred_dispatch_slot_index,
+		dispatch_mode,
+		preferred_run_identity: context.preferred_run_identity,
+		preferred_retry_budget_base: context.preferred_retry_budget_base,
+	}
+}

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue/identity.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue/identity.rs
@@ -1,0 +1,17 @@
+use crate::{
+	commit_message,
+	orchestrator::run_cycle::{IssueTracker, Result},
+};
+
+pub(crate) fn resolve_target_issue_id<T>(tracker: &T, issue_reference: &str) -> Result<String>
+where
+	T: IssueTracker,
+{
+	if commit_message::looks_like_issue_identifier(issue_reference)
+		&& let Some(issue) = tracker.get_issue_by_identifier(issue_reference)?
+	{
+		return Ok(issue.id);
+	}
+
+	Ok(issue_reference.to_owned())
+}

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue/lease.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue/lease.rs
@@ -1,0 +1,38 @@
+use crate::{
+	orchestrator::run_cycle::{IssueTracker, Result, TargetIssueRunContext, eyre},
+	state::PreacquiredLeaseGuards,
+};
+
+pub(crate) fn adopt_preacquired_target_issue_lease<T>(
+	context: &TargetIssueRunContext<'_, T>,
+	issue_id: &str,
+) -> Result<()>
+where
+	T: IssueTracker,
+{
+	let preferred_run_identity = context.preferred_run_identity.ok_or_else(|| {
+		eyre::eyre!("daemon child lease handoff requires a planned run identifier")
+	})?;
+	let preferred_issue_state = context
+		.preferred_issue_state
+		.ok_or_else(|| eyre::eyre!("daemon child lease handoff requires a planned issue state"))?;
+	let issue_claim_fd = context.preferred_issue_claim_fd.ok_or_else(|| {
+		eyre::eyre!("daemon child lease handoff requires an inherited issue-claim fd")
+	})?;
+	let dispatch_slot_fd = context.preferred_dispatch_slot_fd.ok_or_else(|| {
+		eyre::eyre!("daemon child lease handoff requires an inherited dispatch-slot fd")
+	})?;
+	let dispatch_slot_index = context.preferred_dispatch_slot_index.ok_or_else(|| {
+		eyre::eyre!("daemon child lease handoff requires an inherited dispatch-slot index")
+	})?;
+
+	context.state_store.adopt_preacquired_lease(
+		context.project.service_id(),
+		issue_id,
+		preferred_run_identity.run_id,
+		preferred_issue_state,
+		PreacquiredLeaseGuards { issue_claim_fd, dispatch_slot_fd, dispatch_slot_index },
+	)?;
+
+	Ok(())
+}


### PR DESCRIPTION
## Summary\n- split daemon retry child-exit handling into active issue refresh, lane decision, retry plan, and queue modules\n- split terminal failure writeback into preparation, ledger recording, and tracker application modules\n- split targeted run-cycle helpers into closeout, context, identity, and lease modules\n\n## Validation\n- rustup run nightly cargo fmt --all --check\n- cargo check -p decodex --lib --tests\n- cargo test -p decodex --lib -- --format terse\n- cargo make lint-vstyle-rust\n- cargo make lint-rust\n- guard scan: no new allow/expect, wildcard imports, include!, #[path], use super/super::, clippy wildcard allow, or mod.rs in changed files