### PR TITLE
Fix app-server terminal thread failure liveness

### DIFF
--- a/apps/decodex/src/agent/app_server/tests/runtime/turn_failures.rs
+++ b/apps/decodex/src/agent/app_server/tests/runtime/turn_failures.rs
@@ -111,6 +111,78 @@ fn retrying_error_notification_does_not_replace_latest_turn_failure() {
 }
 
 #[test]
+fn thread_system_error_notification_fails_turn_immediately() {
+	let notification = JsonRpcNotification {
+		method: String::from("thread/status/changed"),
+		params: serde_json::json!({
+			"threadId": "thread-1",
+			"status": {
+				"type": "systemError",
+				"activeFlags": []
+			}
+		}),
+	};
+	let mut final_output = String::new();
+	let mut latest_turn_failure = None;
+	let result = super::handle_turn_execution_notification(
+		&notification,
+		"thread-1",
+		"turn-1",
+		&mut final_output,
+		&mut latest_turn_failure,
+	);
+	let error = match result {
+		Ok(_) => panic!("systemError should fail the turn immediately"),
+		Err(error) => error,
+	};
+	let failure =
+		error.downcast_ref::<AppServerTurnFailure>().expect("error should be a turn failure");
+
+	assert!(failure.to_string().contains("systemError"));
+	assert_eq!(failure.error_class(), "app_server_turn_failed");
+	assert!(latest_turn_failure.is_none());
+}
+
+#[test]
+fn thread_system_error_notification_fails_immediately_with_latest_turn_failure() {
+	let notification = JsonRpcNotification {
+		method: String::from("thread/status/changed"),
+		params: serde_json::json!({
+			"threadId": "thread-1",
+			"status": {
+				"type": "systemError",
+				"activeFlags": []
+			}
+		}),
+	};
+	let mut final_output = String::new();
+	let mut latest_turn_failure = Some(AppServerTurnFailure::new(
+		"thread-1",
+		Some(String::from("turn-1")),
+		"failed",
+		"previous structured turn error",
+		None,
+	));
+	let result = super::handle_turn_execution_notification(
+		&notification,
+		"thread-1",
+		"turn-1",
+		&mut final_output,
+		&mut latest_turn_failure,
+	);
+	let error = match result {
+		Ok(_) => panic!("systemError should fail the turn immediately"),
+		Err(error) => error,
+	};
+	let failure =
+		error.downcast_ref::<AppServerTurnFailure>().expect("error should be a turn failure");
+
+	assert!(failure.to_string().contains("previous structured turn error"));
+	assert_eq!(failure.error_class(), "app_server_turn_failed");
+	assert!(latest_turn_failure.is_none());
+}
+
+#[test]
 fn json_rpc_error_response_becomes_recoverable_turn_failure() {
 	let error = JsonRpcError {
 		id: serde_json::json!(7),

--- a/apps/decodex/src/agent/app_server/turn_loop/completion.rs
+++ b/apps/decodex/src/agent/app_server/turn_loop/completion.rs
@@ -31,9 +31,10 @@ pub(in crate::agent::app_server) fn handle_turn_execution_notification(
 			let payload: ThreadStatusChangedNotification =
 				serde_json::from_value(notification.params.clone())?;
 
-			if payload.status.kind == "systemError" && latest_turn_failure.is_none() {
-				*latest_turn_failure =
-					Some(AppServerTurnFailure::from_system_error(&payload.thread_id));
+			if payload.status.kind == "systemError" {
+				return Err(Report::new(latest_turn_failure.take().unwrap_or_else(|| {
+					AppServerTurnFailure::from_system_error(&payload.thread_id)
+				})));
 			}
 		},
 		"error" => {

--- a/apps/decodex/src/orchestrator/kernel/lane_control/model.rs
+++ b/apps/decodex/src/orchestrator/kernel/lane_control/model.rs
@@ -20,6 +20,7 @@ pub(crate) struct LaneControlKernelInput<'a> {
 	pub(crate) host_boot_mismatch: bool,
 	pub(crate) not_running_signal: bool,
 	pub(crate) thread_active: bool,
+	pub(crate) thread_terminal_failure: bool,
 	pub(crate) protocol_recent: bool,
 	pub(crate) suspected_stall: bool,
 	pub(crate) stale_execution_without_known_process: bool,

--- a/apps/decodex/src/orchestrator/kernel/lane_control/projection.rs
+++ b/apps/decodex/src/orchestrator/kernel/lane_control/projection.rs
@@ -19,6 +19,7 @@ pub(crate) fn project_lane_control(
 		|| input.phase_needs_attention
 		|| input.suspected_stall
 		|| input.phase_stalled
+		|| input.thread_terminal_failure
 		|| input.process_alive == Some(false) && input.status_starting_or_running
 		|| input.stale_execution_without_known_process;
 	let liveness = lane_control_liveness(input);
@@ -112,14 +113,14 @@ fn lane_control_ownership(
 	terminalization: TerminalizationState,
 	needs_attention_signal: bool,
 ) -> OwnershipState {
-	if input.run_lease && input.attempt_active && !policy_requires_attention(policy) {
-		return OwnershipState::LeasedRun;
-	}
 	if policy_requires_attention(policy)
 		|| needs_attention_signal
 		|| !input.run_lease && liveness == LivenessState::HostBootMismatch
 	{
 		return OwnershipState::RetainedAttention;
+	}
+	if input.run_lease && input.attempt_active {
+		return OwnershipState::LeasedRun;
 	}
 	if input.continuation_wait {
 		return OwnershipState::ContinuationPending;

--- a/apps/decodex/src/orchestrator/kernel/lane_control/tests.rs
+++ b/apps/decodex/src/orchestrator/kernel/lane_control/tests.rs
@@ -23,6 +23,7 @@ fn input() -> LaneControlKernelInput<'static> {
 		host_boot_mismatch: false,
 		not_running_signal: false,
 		thread_active: false,
+		thread_terminal_failure: false,
 		protocol_recent: false,
 		suspected_stall: false,
 		stale_execution_without_known_process: false,
@@ -43,6 +44,24 @@ fn leased_running_lane_projects_stable_status_fields() {
 	assert!(projection.counts_as_current_lane);
 	assert!(projection.has_live_execution);
 	assert!(projection.has_authoritative_live_owner);
+}
+
+#[test]
+fn terminal_thread_failure_demotes_leased_run_to_attention() {
+	let mut input = input();
+
+	input.process_alive = None;
+	input.execution_liveness_observed = true;
+	input.thread_terminal_failure = true;
+
+	let projection = lane_control::project_lane_control(&input);
+
+	assert_eq!(projection.axes.ownership, OwnershipState::RetainedAttention);
+	assert!(projection.needs_attention_signal);
+	assert!(projection.counts_as_attention);
+	assert!(!projection.counts_as_running);
+	assert!(projection.counts_as_current_lane);
+	assert_eq!(projection.next_action, "inspect_lane_state");
 }
 
 #[test]

--- a/apps/decodex/src/orchestrator/status_run_projection/run/lane_control.rs
+++ b/apps/decodex/src/orchestrator/status_run_projection/run/lane_control.rs
@@ -118,6 +118,7 @@ fn operator_lane_control_kernel_input(run: &OperatorRunStatus) -> LaneControlKer
 		),
 		thread_active: matches!(run.thread_status.as_deref(), Some("active"))
 			|| !run.thread_active_flags.is_empty(),
+		thread_terminal_failure: operator_run_thread_terminal_failure(run),
 		protocol_recent: operator_run_has_recent_app_server_execution(run),
 		suspected_stall: run.suspected_stall,
 		stale_execution_without_known_process:
@@ -187,6 +188,12 @@ fn operator_run_has_recent_app_server_execution(run: &OperatorRunStatus) -> bool
 			u64::try_from(idle_for)
 				.is_ok_and(|idle_for| idle_for < RUN_LEASE_IDLE_TIMEOUT.as_secs())
 		})
+}
+
+fn operator_run_thread_terminal_failure(run: &OperatorRunStatus) -> bool {
+	matches!(run.thread_status.as_deref(), Some("systemError" | "failed" | "interrupted"))
+		&& matches!(run.status.as_str(), "starting" | "running")
+		&& run.phase == "executing"
 }
 
 fn operator_run_has_stale_execution_without_known_process(run: &OperatorRunStatus) -> bool {

--- a/apps/decodex/src/orchestrator/tests/operator/status/running_lanes/liveness/process_liveness.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/running_lanes/liveness/process_liveness.rs
@@ -113,6 +113,70 @@ fn operator_status_snapshot_treats_dead_leased_app_server_run_as_attention_not_r
 	assert_eq!(project.attention_count, 1);
 }
 
+#[test]
+fn operator_status_snapshot_treats_system_error_thread_as_attention_not_running() {
+	let (_temp_dir, config, _workflow) = running_lanes::temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = running_lanes::sample_issue("Todo", &[]);
+	let worktree_path = config.worktree_root().join("PUB-101");
+
+	state_store
+		.record_run_attempt("run-1", &issue.id, 1, "running")
+		.expect("run attempt should record");
+	state_store
+		.upsert_lease("pubfi", &issue.id, "run-1", "In Progress")
+		.expect("lease should record");
+	state_store
+		.upsert_worktree(
+			"pubfi",
+			&issue.id,
+			"x/pubfi-pub-101",
+			&worktree_path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	fs::create_dir_all(&worktree_path).expect("worktree path should exist");
+	state::write_run_thread_status_marker(
+		&worktree_path,
+		"run-1",
+		1,
+		Some("thread-1"),
+		Some("turn-1"),
+		"systemError",
+		&[],
+	)
+	.expect("thread status should write");
+	state::write_run_protocol_activity_marker(
+		&worktree_path,
+		&ProtocolActivityMarker {
+			run_id: "run-1",
+			attempt_number: 1,
+			thread_id: Some("thread-1"),
+			turn_id: Some("turn-1"),
+			event_count: 2,
+			last_event_type: "thread/status/changed",
+			child_agent_activity: None,
+			protocol_activity: None,
+		},
+	)
+	.expect("protocol summary should write");
+
+	let snapshot = orchestrator::build_operator_status_snapshot(&config, &state_store, 10)
+		.expect("snapshot should build");
+	let run = snapshot.current_lanes.first().expect("current lane should remain visible");
+	let project = snapshot.projects.first().expect("project summary should exist");
+
+	assert_eq!(run.status, "running");
+	assert_eq!(run.phase, "executing");
+	assert_eq!(run.thread_status.as_deref(), Some("systemError"));
+	assert_eq!(run.liveness_state, "process_alive");
+	assert!(run.needs_attention);
+	assert!(!run.counts_as_running);
+	assert_eq!(project.current_lane_count, 1);
+	assert_eq!(project.running_lane_count, 0);
+	assert_eq!(project.attention_count, 1);
+}
+
 #[cfg(unix)]
 #[test]
 fn operator_status_snapshot_counts_zombie_active_process_as_attention_not_running() {


### PR DESCRIPTION
## Summary
- fail an app-server turn immediately when the thread enters systemError, preserving a previously captured richer turn failure when present
- project terminal thread statuses on running lanes as needs-attention/not-running instead of leaving them counted as running
- add regression coverage for systemError turn handling and operator status lane projection

## Validation
- cargo test -p decodex thread_system_error_notification_fails_turn_immediately
- cargo test -p decodex thread_system_error_notification_fails_immediately_with_latest_turn_failure
- cargo test -p decodex terminal_thread_failure_demotes_leased_run_to_attention
- cargo test -p decodex operator_status_snapshot_treats_system_error_thread_as_attention_not_running
- cargo test -p decodex retrying_error_notification_does_not_replace_latest_turn_failure
- cargo test -p decodex operator_status_snapshot_treats_dead_leased_app_server_run_as_attention_not_running
- cargo test -p decodex usage_limit_notification_stops_current_turn_without_operator_attention
- cargo test -p decodex --lib
- cargo make check

## Context
Fixes the XY-1160 class where a child thread could report systemError while the Decodex lane stayed apparently running/active, hiding the attention state from autonomous follow-through.