### PR TITLE
Split status and activity support modules

### DIFF
--- a/apps/decodex/src/orchestrator/agent_evidence/private_readback.rs
+++ b/apps/decodex/src/orchestrator/agent_evidence/private_readback.rs
@@ -1,89 +1,33 @@
 mod architecture;
 mod boundary;
+mod events;
 mod payload;
 mod phase;
+mod reference;
 mod render;
 mod repo_gate;
 mod review;
+mod target;
 
-pub(crate) use self::render::render_private_evidence_readback;
-
-use std::{collections::BTreeSet, path::Path};
-
-use crate::{
-	orchestrator::agent_evidence::{
-		self, AgentPrivateEvidenceRef, EvidenceRequest, OperatorRunStatus,
-		PRIVATE_EVIDENCE_READBACK_SCHEMA, PrivateEvidenceReadback, PrivateEvidenceReadbackEvent,
-		PrivateEvidenceTarget, ProjectRunStatus, Result, ServiceConfig, StateStore, eyre,
+pub(crate) use self::{
+	reference::{
+		agent_private_evidence_ref, private_evidence_ref_for_run_fields,
+		render_private_evidence_reference,
 	},
-	state,
+	render::render_private_evidence_readback,
 };
 
-pub(crate) fn render_private_evidence_reference(run: &OperatorRunStatus) -> String {
-	let private_evidence = agent_private_evidence_ref(run);
-
-	format!(
-		"ref={} source={} default_view={} read=`{}`",
-		private_evidence.evidence_ref,
-		private_evidence.source,
-		private_evidence.default_view,
-		private_evidence.read_command
-	)
-}
-
-pub(crate) fn agent_private_evidence_ref(run: &OperatorRunStatus) -> AgentPrivateEvidenceRef {
-	run.private_evidence.clone()
-}
-
-pub(crate) fn private_evidence_ref_for_run_fields(
-	project_id: &str,
-	project_config_path: &Path,
-	issue_id: &str,
-	issue_identifier: Option<&str>,
-	run_id: &str,
-	attempt_number: i64,
-) -> AgentPrivateEvidenceRef {
-	AgentPrivateEvidenceRef {
-		evidence_ref: private_evidence_ref_for_parts(project_id, issue_id, run_id, attempt_number),
-		source: String::from("runtime_sqlite"),
-		default_view: String::from("summarized_payloads"),
-		read_command: private_evidence_read_command(
-			project_config_path,
-			issue_identifier.unwrap_or(issue_id),
-			Some(run_id),
-			Some(attempt_number),
-			true,
-			false,
-		),
-	}
-}
-
-pub(crate) fn private_evidence_ref_for_parts(
-	project_id: &str,
-	issue_id: &str,
-	run_id: &str,
-	attempt_number: i64,
-) -> String {
-	format!("private-evidence:{project_id}/{issue_id}/{run_id}/{attempt_number}")
-}
-
-pub(crate) fn shell_quote(raw: &str) -> String {
-	if !raw.is_empty()
-		&& raw.bytes().all(|byte| {
-			byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'/' | b':')
-		}) {
-		return raw.to_owned();
-	}
-
-	format!("'{}'", raw.replace('\'', "'\\''"))
-}
+use crate::orchestrator::agent_evidence::{
+	self, EvidenceRequest, PRIVATE_EVIDENCE_READBACK_SCHEMA, PrivateEvidenceReadback, Result,
+	ServiceConfig, StateStore,
+};
 
 pub(crate) fn build_private_evidence_readback(
 	state_store: &StateStore,
 	project: &ServiceConfig,
 	request: &EvidenceRequest<'_>,
 ) -> Result<PrivateEvidenceReadback> {
-	let target = resolve_private_evidence_target(
+	let target = target::resolve_private_evidence_target(
 		state_store,
 		project,
 		request.issue,
@@ -103,7 +47,7 @@ pub(crate) fn build_private_evidence_readback(
 		Vec::new()
 	};
 	let issue_selector = target.issue_identifier.as_deref().unwrap_or(&target.issue_id).to_owned();
-	let read_command = private_evidence_read_command(
+	let read_command = reference::private_evidence_read_command(
 		project.config_path(),
 		&issue_selector,
 		Some(&target.run_id),
@@ -121,7 +65,7 @@ pub(crate) fn build_private_evidence_readback(
 		run_id: target.run_id.clone(),
 		attempt_number: target.attempt_number,
 		source: "runtime_sqlite",
-		evidence_ref: private_evidence_ref_for_parts(
+		evidence_ref: reference::private_evidence_ref_for_parts(
 			project.service_id(),
 			&target.issue_id,
 			&target.run_id,
@@ -145,161 +89,8 @@ pub(crate) fn build_private_evidence_readback(
 		),
 		events: events
 			.iter()
-			.map(|event| private_evidence_readback_event(event, request.include_payload))
+			.map(|event| events::private_evidence_readback_event(event, request.include_payload))
 			.collect(),
 		warnings,
 	})
-}
-
-fn private_evidence_read_command(
-	project_config_path: &Path,
-	issue_selector: &str,
-	run_id: Option<&str>,
-	attempt_number: Option<i64>,
-	json: bool,
-	include_payload: bool,
-) -> String {
-	let mut command = format!(
-		"decodex evidence --config {} {}",
-		shell_quote(&project_config_path.display().to_string()),
-		shell_quote(issue_selector)
-	);
-
-	if let Some(run_id) = run_id {
-		command.push_str(&format!(" --run-id {}", shell_quote(run_id)));
-	}
-	if let Some(attempt_number) = attempt_number {
-		command.push_str(&format!(" --attempt {attempt_number}"));
-	}
-
-	if json {
-		command.push_str(" --json");
-	}
-	if include_payload {
-		command.push_str(" --include-payload");
-	}
-
-	command
-}
-
-fn resolve_private_evidence_target(
-	state_store: &StateStore,
-	project: &ServiceConfig,
-	issue_selector: &str,
-	run_id: Option<&str>,
-	attempt_number: Option<i64>,
-) -> Result<PrivateEvidenceTarget> {
-	let (_, runs) = state_store.list_project_runs(project.service_id(), usize::MAX)?;
-	let selector = issue_selector.trim();
-	let matching_run = runs
-		.iter()
-		.filter(|run| private_evidence_run_matches_issue(project, run, selector))
-		.filter(|run| run_id.is_none_or(|run_id| run.run_id() == run_id))
-		.find(|run| attempt_number.is_none_or(|attempt| run.attempt_number() == attempt));
-
-	if let Some(run) = matching_run {
-		let branch_name = run.branch_name().map(str::to_owned);
-		let worktree_path = run
-			.worktree_path()
-			.map(|path| agent_evidence::relative_worktree_path_for_path(project, path));
-		let issue_identifier = agent_evidence::operator_run_issue_identifier_from_fields(
-			run.run_id(),
-			branch_name.as_deref(),
-			worktree_path.as_deref(),
-		);
-
-		return Ok(PrivateEvidenceTarget {
-			issue_id: run.issue_id().to_owned(),
-			issue_identifier,
-			run_id: run.run_id().to_owned(),
-			attempt_number: run.attempt_number(),
-		});
-	}
-	if let (Some(run_id), Some(attempt_number)) = (run_id, attempt_number) {
-		let events = state_store.list_private_execution_events_for_run_attempt(
-			project.service_id(),
-			run_id,
-			attempt_number,
-		)?;
-
-		if let Some(issue_id) = private_evidence_direct_lookup_issue_id(&events, selector)? {
-			return Ok(PrivateEvidenceTarget {
-				issue_identifier: (issue_id != selector).then(|| selector.to_owned()),
-				issue_id,
-				run_id: run_id.to_owned(),
-				attempt_number,
-			});
-		}
-
-		return Ok(PrivateEvidenceTarget {
-			issue_id: selector.to_owned(),
-			issue_identifier: None,
-			run_id: run_id.to_owned(),
-			attempt_number,
-		});
-	}
-
-	eyre::bail!(
-		"No local run matched issue `{selector}` in project `{}`. Pass --run-id and --attempt for direct runtime-store lookup, or run `decodex status --json` to find local run ids.",
-		project.service_id()
-	)
-}
-
-fn private_evidence_direct_lookup_issue_id(
-	events: &[state::PrivateExecutionEvent],
-	selector: &str,
-) -> Result<Option<String>> {
-	let issue_ids =
-		events.iter().map(state::PrivateExecutionEvent::issue_id).collect::<BTreeSet<_>>();
-
-	if issue_ids.is_empty() {
-		return Ok(None);
-	}
-	if issue_ids.len() == 1 {
-		return Ok(issue_ids.iter().next().map(|issue_id| (*issue_id).to_owned()));
-	}
-	if issue_ids.contains(selector) {
-		return Ok(Some(selector.to_owned()));
-	}
-
-	eyre::bail!(
-		"Direct private evidence lookup for issue `{selector}` matched multiple local issue ids for the supplied run and attempt; pass the local issue id from `decodex status --json`."
-	)
-}
-
-fn private_evidence_run_matches_issue(
-	project: &ServiceConfig,
-	run: &ProjectRunStatus,
-	selector: &str,
-) -> bool {
-	if run.issue_id() == selector {
-		return true;
-	}
-
-	let branch_name = run.branch_name().map(str::to_owned);
-	let worktree_path = run
-		.worktree_path()
-		.map(|path| agent_evidence::relative_worktree_path_for_path(project, path));
-	let issue_identifier = agent_evidence::operator_run_issue_identifier_from_fields(
-		run.run_id(),
-		branch_name.as_deref(),
-		worktree_path.as_deref(),
-	);
-
-	issue_identifier
-		.as_deref()
-		.is_some_and(|issue_identifier| issue_identifier.eq_ignore_ascii_case(selector))
-}
-
-fn private_evidence_readback_event(
-	event: &state::PrivateExecutionEvent,
-	include_payload: bool,
-) -> PrivateEvidenceReadbackEvent {
-	PrivateEvidenceReadbackEvent {
-		record_id: event.record_id(),
-		event_type: event.event_type().to_owned(),
-		recorded_at: event.recorded_at().to_owned(),
-		payload_summary: self::payload::summarize_private_evidence_payload(event.payload()),
-		payload: include_payload.then(|| event.payload().clone()),
-	}
 }

--- a/apps/decodex/src/orchestrator/agent_evidence/private_readback/events.rs
+++ b/apps/decodex/src/orchestrator/agent_evidence/private_readback/events.rs
@@ -1,0 +1,17 @@
+use crate::{
+	orchestrator::agent_evidence::{PrivateEvidenceReadbackEvent, private_readback::payload},
+	state::PrivateExecutionEvent,
+};
+
+pub(crate) fn private_evidence_readback_event(
+	event: &PrivateExecutionEvent,
+	include_payload: bool,
+) -> PrivateEvidenceReadbackEvent {
+	PrivateEvidenceReadbackEvent {
+		record_id: event.record_id(),
+		event_type: event.event_type().to_owned(),
+		recorded_at: event.recorded_at().to_owned(),
+		payload_summary: payload::summarize_private_evidence_payload(event.payload()),
+		payload: include_payload.then(|| event.payload().clone()),
+	}
+}

--- a/apps/decodex/src/orchestrator/agent_evidence/private_readback/reference.rs
+++ b/apps/decodex/src/orchestrator/agent_evidence/private_readback/reference.rs
@@ -1,0 +1,93 @@
+use std::path::Path;
+
+use crate::orchestrator::agent_evidence::{AgentPrivateEvidenceRef, OperatorRunStatus};
+
+pub(crate) fn render_private_evidence_reference(run: &OperatorRunStatus) -> String {
+	let private_evidence = agent_private_evidence_ref(run);
+
+	format!(
+		"ref={} source={} default_view={} read=`{}`",
+		private_evidence.evidence_ref,
+		private_evidence.source,
+		private_evidence.default_view,
+		private_evidence.read_command
+	)
+}
+
+pub(crate) fn agent_private_evidence_ref(run: &OperatorRunStatus) -> AgentPrivateEvidenceRef {
+	run.private_evidence.clone()
+}
+
+pub(crate) fn private_evidence_ref_for_run_fields(
+	project_id: &str,
+	project_config_path: &Path,
+	issue_id: &str,
+	issue_identifier: Option<&str>,
+	run_id: &str,
+	attempt_number: i64,
+) -> AgentPrivateEvidenceRef {
+	AgentPrivateEvidenceRef {
+		evidence_ref: private_evidence_ref_for_parts(project_id, issue_id, run_id, attempt_number),
+		source: String::from("runtime_sqlite"),
+		default_view: String::from("summarized_payloads"),
+		read_command: private_evidence_read_command(
+			project_config_path,
+			issue_identifier.unwrap_or(issue_id),
+			Some(run_id),
+			Some(attempt_number),
+			true,
+			false,
+		),
+	}
+}
+
+pub(crate) fn private_evidence_ref_for_parts(
+	project_id: &str,
+	issue_id: &str,
+	run_id: &str,
+	attempt_number: i64,
+) -> String {
+	format!("private-evidence:{project_id}/{issue_id}/{run_id}/{attempt_number}")
+}
+
+pub(crate) fn private_evidence_read_command(
+	project_config_path: &Path,
+	issue_selector: &str,
+	run_id: Option<&str>,
+	attempt_number: Option<i64>,
+	json: bool,
+	include_payload: bool,
+) -> String {
+	let mut command = format!(
+		"decodex evidence --config {} {}",
+		shell_quote(&project_config_path.display().to_string()),
+		shell_quote(issue_selector)
+	);
+
+	if let Some(run_id) = run_id {
+		command.push_str(&format!(" --run-id {}", shell_quote(run_id)));
+	}
+	if let Some(attempt_number) = attempt_number {
+		command.push_str(&format!(" --attempt {attempt_number}"));
+	}
+
+	if json {
+		command.push_str(" --json");
+	}
+	if include_payload {
+		command.push_str(" --include-payload");
+	}
+
+	command
+}
+
+fn shell_quote(raw: &str) -> String {
+	if !raw.is_empty()
+		&& raw.bytes().all(|byte| {
+			byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'/' | b':')
+		}) {
+		return raw.to_owned();
+	}
+
+	format!("'{}'", raw.replace('\'', "'\\''"))
+}

--- a/apps/decodex/src/orchestrator/agent_evidence/private_readback/target.rs
+++ b/apps/decodex/src/orchestrator/agent_evidence/private_readback/target.rs
@@ -1,0 +1,117 @@
+use std::collections::BTreeSet;
+
+use crate::{
+	orchestrator::agent_evidence::{
+		self, PrivateEvidenceTarget, ProjectRunStatus, Result, ServiceConfig, StateStore, eyre,
+	},
+	state,
+};
+
+pub(crate) fn resolve_private_evidence_target(
+	state_store: &StateStore,
+	project: &ServiceConfig,
+	issue_selector: &str,
+	run_id: Option<&str>,
+	attempt_number: Option<i64>,
+) -> Result<PrivateEvidenceTarget> {
+	let (_, runs) = state_store.list_project_runs(project.service_id(), usize::MAX)?;
+	let selector = issue_selector.trim();
+	let matching_run = runs
+		.iter()
+		.filter(|run| private_evidence_run_matches_issue(project, run, selector))
+		.filter(|run| run_id.is_none_or(|run_id| run.run_id() == run_id))
+		.find(|run| attempt_number.is_none_or(|attempt| run.attempt_number() == attempt));
+
+	if let Some(run) = matching_run {
+		let branch_name = run.branch_name().map(str::to_owned);
+		let worktree_path = run
+			.worktree_path()
+			.map(|path| agent_evidence::relative_worktree_path_for_path(project, path));
+		let issue_identifier = agent_evidence::operator_run_issue_identifier_from_fields(
+			run.run_id(),
+			branch_name.as_deref(),
+			worktree_path.as_deref(),
+		);
+
+		return Ok(PrivateEvidenceTarget {
+			issue_id: run.issue_id().to_owned(),
+			issue_identifier,
+			run_id: run.run_id().to_owned(),
+			attempt_number: run.attempt_number(),
+		});
+	}
+	if let (Some(run_id), Some(attempt_number)) = (run_id, attempt_number) {
+		let events = state_store.list_private_execution_events_for_run_attempt(
+			project.service_id(),
+			run_id,
+			attempt_number,
+		)?;
+
+		if let Some(issue_id) = private_evidence_direct_lookup_issue_id(&events, selector)? {
+			return Ok(PrivateEvidenceTarget {
+				issue_identifier: (issue_id != selector).then(|| selector.to_owned()),
+				issue_id,
+				run_id: run_id.to_owned(),
+				attempt_number,
+			});
+		}
+
+		return Ok(PrivateEvidenceTarget {
+			issue_id: selector.to_owned(),
+			issue_identifier: None,
+			run_id: run_id.to_owned(),
+			attempt_number,
+		});
+	}
+
+	eyre::bail!(
+		"No local run matched issue `{selector}` in project `{}`. Pass --run-id and --attempt for direct runtime-store lookup, or run `decodex status --json` to find local run ids.",
+		project.service_id()
+	)
+}
+
+fn private_evidence_direct_lookup_issue_id(
+	events: &[state::PrivateExecutionEvent],
+	selector: &str,
+) -> Result<Option<String>> {
+	let issue_ids =
+		events.iter().map(state::PrivateExecutionEvent::issue_id).collect::<BTreeSet<_>>();
+
+	if issue_ids.is_empty() {
+		return Ok(None);
+	}
+	if issue_ids.len() == 1 {
+		return Ok(issue_ids.iter().next().map(|issue_id| (*issue_id).to_owned()));
+	}
+	if issue_ids.contains(selector) {
+		return Ok(Some(selector.to_owned()));
+	}
+
+	eyre::bail!(
+		"Direct private evidence lookup for issue `{selector}` matched multiple local issue ids for the supplied run and attempt; pass the local issue id from `decodex status --json`."
+	)
+}
+
+fn private_evidence_run_matches_issue(
+	project: &ServiceConfig,
+	run: &ProjectRunStatus,
+	selector: &str,
+) -> bool {
+	if run.issue_id() == selector {
+		return true;
+	}
+
+	let branch_name = run.branch_name().map(str::to_owned);
+	let worktree_path = run
+		.worktree_path()
+		.map(|path| agent_evidence::relative_worktree_path_for_path(project, path));
+	let issue_identifier = agent_evidence::operator_run_issue_identifier_from_fields(
+		run.run_id(),
+		branch_name.as_deref(),
+		worktree_path.as_deref(),
+	);
+
+	issue_identifier
+		.as_deref()
+		.is_some_and(|issue_identifier| issue_identifier.eq_ignore_ascii_case(selector))
+}

--- a/apps/decodex/src/orchestrator/daemon/active_children.rs
+++ b/apps/decodex/src/orchestrator/daemon/active_children.rs
@@ -1,8 +1,15 @@
+mod cleanup;
+mod inspection;
+
+pub(crate) use self::cleanup::{clear_orphaned_daemon_child_state, resolve_child_exit_run_attempt};
+#[cfg(test)]
+pub(crate) use self::inspection::{
+	inspect_current_daemon_child_reconciliation, inspect_current_daemon_child_reconciliation_at,
+};
+
 use crate::orchestrator::daemon::{
-	self, ActiveWorkflowOverride, Child, ChildExitRetryContext, ChildRunRef,
-	CurrentChildRunContext, DaemonRunChild, IssueDispatchMode, IssueTracker, OffsetDateTime,
-	Result, RetryQueue, RunAttempt, RunLeaseDisposition, RunLeaseReconciliation, ServiceConfig,
-	StateStore, WorkflowDocument, WorktreeManager,
+	self, ChildExitRetryContext, ChildRunRef, CurrentChildRunContext, DaemonRunChild, IssueTracker,
+	Result, RetryQueue, ServiceConfig, StateStore, WorkflowDocument, WorktreeManager,
 };
 
 pub(crate) fn inspect_or_clear_active_children<T>(
@@ -46,7 +53,7 @@ where
 				child_ref.run_id,
 			)?
 		} else {
-			inspect_current_daemon_child_reconciliation(
+			inspection::inspect_current_daemon_child_reconciliation(
 				tracker,
 				project,
 				workflow,
@@ -76,7 +83,7 @@ where
 					attempt_number: daemon_child.attempt_number,
 				};
 
-				clear_orphaned_daemon_child_state(state_store, child_ref, false)?;
+				cleanup::clear_orphaned_daemon_child_state(state_store, child_ref, false)?;
 
 				if let Some(exit_status) = child_exit_status {
 					daemon::schedule_retry_after_child_exit(
@@ -110,7 +117,7 @@ where
 			retry_queue.release(&daemon_child.issue_id);
 		}
 		if !child_exited {
-			stop_daemon_child(&mut daemon_child.child)?;
+			cleanup::stop_daemon_child(&mut daemon_child.child)?;
 		}
 
 		daemon::apply_run_lease_reconciliation(
@@ -121,187 +128,6 @@ where
 			actions,
 		)?;
 	}
-
-	Ok(())
-}
-
-pub(crate) fn inspect_current_daemon_child_reconciliation<T>(
-	tracker: &T,
-	project: &ServiceConfig,
-	workflow: &WorkflowDocument,
-	state_store: &StateStore,
-	child_context: CurrentChildRunContext<'_>,
-) -> Result<Vec<RunLeaseReconciliation>>
-where
-	T: IssueTracker,
-{
-	inspect_current_daemon_child_reconciliation_at(
-		tracker,
-		project,
-		workflow,
-		state_store,
-		child_context,
-		OffsetDateTime::now_utc().unix_timestamp(),
-	)
-}
-
-pub(crate) fn inspect_current_daemon_child_reconciliation_at<T>(
-	tracker: &T,
-	project: &ServiceConfig,
-	workflow: &WorkflowDocument,
-	state_store: &StateStore,
-	child_context: CurrentChildRunContext<'_>,
-	now_unix_epoch: i64,
-) -> Result<Vec<RunLeaseReconciliation>>
-where
-	T: IssueTracker,
-{
-	let child = child_context.child;
-	let Some(issue) = daemon::refresh_issue(tracker, child.issue_id)? else {
-		return Ok(Vec::new());
-	};
-	let Some(run_attempt) = state_store.run_attempt(child.run_id)? else {
-		return Ok(Vec::new());
-	};
-	let worktree_mapping = state_store.worktree_for_issue(&issue.id)?;
-
-	if let Some(disposition) = daemon::superseded_run_disposition(state_store, &run_attempt)? {
-		return Ok(vec![RunLeaseReconciliation {
-			issue: issue.clone(),
-			run_attempt,
-			worktree_mapping,
-			disposition,
-			workflow: workflow.clone(),
-		}]);
-	}
-
-	let action_workflow = daemon::run_lease_reconciliation_workflow(
-		workflow,
-		Some(ActiveWorkflowOverride { child, workflow: child_context.workflow }),
-		&issue,
-		&run_attempt,
-	);
-	let retained_closeout = daemon::terminal_issue_keeps_retained_closeout(
-		tracker,
-		&issue,
-		project,
-		action_workflow,
-		state_store,
-	)?;
-	let completed_closeout_child =
-		matches!(child_context.dispatch_mode, IssueDispatchMode::Closeout)
-			&& daemon::is_terminal_issue(&issue, action_workflow);
-	let disposition = if !retained_closeout
-		&& !completed_closeout_child
-		&& daemon::is_terminal_issue(&issue, action_workflow)
-	{
-		Some(RunLeaseDisposition::Terminal)
-	} else if !retained_closeout
-		&& !completed_closeout_child
-		&& daemon::is_issue_not_dispatchable_for_current_dispatch(
-			tracker,
-			&issue,
-			project,
-			action_workflow,
-			child_context.dispatch_mode,
-		)? {
-		Some(RunLeaseDisposition::NotDispatchable)
-	} else if let Some(idle_for) = daemon::stalled_idle_duration(
-		state_store,
-		&run_attempt,
-		worktree_mapping.as_ref(),
-		now_unix_epoch,
-	)? {
-		if daemon::retained_review_handoff_matches_run(
-			state_store,
-			&run_attempt,
-			worktree_mapping.as_ref(),
-		)? {
-			Some(RunLeaseDisposition::RetainedReviewComplete)
-		} else if daemon::stalled_run_has_retained_partial_progress(worktree_mapping.as_ref()) {
-			Some(RunLeaseDisposition::StalledRetainedPartialProgress { idle_for })
-		} else {
-			Some(RunLeaseDisposition::Stalled { idle_for })
-		}
-	} else {
-		None
-	};
-
-	Ok(disposition.map_or_else(Vec::new, |disposition| {
-		vec![RunLeaseReconciliation {
-			issue: issue.clone(),
-			run_attempt,
-			worktree_mapping,
-			disposition,
-			workflow: action_workflow.clone(),
-		}]
-	}))
-}
-
-pub(crate) fn clear_orphaned_daemon_child_state(
-	state_store: &StateStore,
-	child: ChildRunRef<'_>,
-	mark_interrupted: bool,
-) -> Result<()> {
-	let resolved_run_attempt = resolve_child_exit_run_attempt(state_store, child)?;
-
-	if resolved_run_attempt.is_none() {
-		tracing::debug!(
-			issue_id = child.issue_id,
-			run_id = child.run_id,
-			attempt = child.attempt_number,
-			"Daemon child exited without a matching recorded run attempt; skipping orphan cleanup."
-		);
-	}
-	if mark_interrupted && let Some(run_attempt) = resolved_run_attempt.as_ref() {
-		daemon::mark_run_attempt_if_active(state_store, run_attempt.run_id(), "interrupted")?;
-	}
-
-	let existing_lease = state_store.lease_for_issue(child.issue_id)?;
-	let issue_unowned_or_matches_run = existing_lease.as_ref().is_none_or(|lease| {
-		resolved_run_attempt
-			.as_ref()
-			.is_some_and(|run_attempt| lease.run_id() == run_attempt.run_id())
-			|| lease.run_id() == child.run_id
-	});
-
-	if existing_lease.is_some() && issue_unowned_or_matches_run {
-		state_store.clear_lease(child.issue_id)?;
-	}
-	if resolved_run_attempt.is_some()
-		&& issue_unowned_or_matches_run
-		&& let Some(mapping) = state_store.worktree_for_issue(child.issue_id)?
-		&& !mapping.worktree_path().try_exists()?
-	{
-		tracing::debug!(
-			issue_id = child.issue_id,
-			run_id = child.run_id,
-			attempt = child.attempt_number,
-			branch = mapping.branch_name(),
-			worktree_path = %mapping.worktree_path().display(),
-			"Cleared daemon child worktree mapping after the checkout was removed."
-		);
-
-		state_store.clear_worktree(child.issue_id)?;
-	}
-
-	Ok(())
-}
-
-pub(crate) fn resolve_child_exit_run_attempt(
-	state_store: &StateStore,
-	child: ChildRunRef<'_>,
-) -> Result<Option<RunAttempt>> {
-	state_store.run_attempt(child.run_id)
-}
-
-fn stop_daemon_child(child: &mut Child) -> Result<()> {
-	if child.try_wait()?.is_some() {
-		return Ok(());
-	}
-
-	let _ = child.kill();
-	let _ = child.wait();
 
 	Ok(())
 }

--- a/apps/decodex/src/orchestrator/daemon/active_children/cleanup.rs
+++ b/apps/decodex/src/orchestrator/daemon/active_children/cleanup.rs
@@ -1,0 +1,69 @@
+use crate::orchestrator::daemon::{self, Child, ChildRunRef, Result, RunAttempt, StateStore};
+
+pub(crate) fn clear_orphaned_daemon_child_state(
+	state_store: &StateStore,
+	child: ChildRunRef<'_>,
+	mark_interrupted: bool,
+) -> Result<()> {
+	let resolved_run_attempt = resolve_child_exit_run_attempt(state_store, child)?;
+
+	if resolved_run_attempt.is_none() {
+		tracing::debug!(
+			issue_id = child.issue_id,
+			run_id = child.run_id,
+			attempt = child.attempt_number,
+			"Daemon child exited without a matching recorded run attempt; skipping orphan cleanup."
+		);
+	}
+	if mark_interrupted && let Some(run_attempt) = resolved_run_attempt.as_ref() {
+		daemon::mark_run_attempt_if_active(state_store, run_attempt.run_id(), "interrupted")?;
+	}
+
+	let existing_lease = state_store.lease_for_issue(child.issue_id)?;
+	let issue_unowned_or_matches_run = existing_lease.as_ref().is_none_or(|lease| {
+		resolved_run_attempt
+			.as_ref()
+			.is_some_and(|run_attempt| lease.run_id() == run_attempt.run_id())
+			|| lease.run_id() == child.run_id
+	});
+
+	if existing_lease.is_some() && issue_unowned_or_matches_run {
+		state_store.clear_lease(child.issue_id)?;
+	}
+	if resolved_run_attempt.is_some()
+		&& issue_unowned_or_matches_run
+		&& let Some(mapping) = state_store.worktree_for_issue(child.issue_id)?
+		&& !mapping.worktree_path().try_exists()?
+	{
+		tracing::debug!(
+			issue_id = child.issue_id,
+			run_id = child.run_id,
+			attempt = child.attempt_number,
+			branch = mapping.branch_name(),
+			worktree_path = %mapping.worktree_path().display(),
+			"Cleared daemon child worktree mapping after the checkout was removed."
+		);
+
+		state_store.clear_worktree(child.issue_id)?;
+	}
+
+	Ok(())
+}
+
+pub(crate) fn resolve_child_exit_run_attempt(
+	state_store: &StateStore,
+	child: ChildRunRef<'_>,
+) -> Result<Option<RunAttempt>> {
+	state_store.run_attempt(child.run_id)
+}
+
+pub(crate) fn stop_daemon_child(child: &mut Child) -> Result<()> {
+	if child.try_wait()?.is_some() {
+		return Ok(());
+	}
+
+	let _ = child.kill();
+	let _ = child.wait();
+
+	Ok(())
+}

--- a/apps/decodex/src/orchestrator/daemon/active_children/inspection.rs
+++ b/apps/decodex/src/orchestrator/daemon/active_children/inspection.rs
@@ -1,0 +1,118 @@
+use crate::orchestrator::daemon::{
+	self, ActiveWorkflowOverride, CurrentChildRunContext, IssueDispatchMode, IssueTracker,
+	OffsetDateTime, Result, RunLeaseDisposition, RunLeaseReconciliation, ServiceConfig, StateStore,
+	WorkflowDocument,
+};
+
+pub(crate) fn inspect_current_daemon_child_reconciliation<T>(
+	tracker: &T,
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	child_context: CurrentChildRunContext<'_>,
+) -> Result<Vec<RunLeaseReconciliation>>
+where
+	T: IssueTracker,
+{
+	inspect_current_daemon_child_reconciliation_at(
+		tracker,
+		project,
+		workflow,
+		state_store,
+		child_context,
+		OffsetDateTime::now_utc().unix_timestamp(),
+	)
+}
+
+pub(crate) fn inspect_current_daemon_child_reconciliation_at<T>(
+	tracker: &T,
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	child_context: CurrentChildRunContext<'_>,
+	now_unix_epoch: i64,
+) -> Result<Vec<RunLeaseReconciliation>>
+where
+	T: IssueTracker,
+{
+	let child = child_context.child;
+	let Some(issue) = daemon::refresh_issue(tracker, child.issue_id)? else {
+		return Ok(Vec::new());
+	};
+	let Some(run_attempt) = state_store.run_attempt(child.run_id)? else {
+		return Ok(Vec::new());
+	};
+	let worktree_mapping = state_store.worktree_for_issue(&issue.id)?;
+
+	if let Some(disposition) = daemon::superseded_run_disposition(state_store, &run_attempt)? {
+		return Ok(vec![RunLeaseReconciliation {
+			issue: issue.clone(),
+			run_attempt,
+			worktree_mapping,
+			disposition,
+			workflow: workflow.clone(),
+		}]);
+	}
+
+	let action_workflow = daemon::run_lease_reconciliation_workflow(
+		workflow,
+		Some(ActiveWorkflowOverride { child, workflow: child_context.workflow }),
+		&issue,
+		&run_attempt,
+	);
+	let retained_closeout = daemon::terminal_issue_keeps_retained_closeout(
+		tracker,
+		&issue,
+		project,
+		action_workflow,
+		state_store,
+	)?;
+	let completed_closeout_child =
+		matches!(child_context.dispatch_mode, IssueDispatchMode::Closeout)
+			&& daemon::is_terminal_issue(&issue, action_workflow);
+	let disposition = if !retained_closeout
+		&& !completed_closeout_child
+		&& daemon::is_terminal_issue(&issue, action_workflow)
+	{
+		Some(RunLeaseDisposition::Terminal)
+	} else if !retained_closeout
+		&& !completed_closeout_child
+		&& daemon::is_issue_not_dispatchable_for_current_dispatch(
+			tracker,
+			&issue,
+			project,
+			action_workflow,
+			child_context.dispatch_mode,
+		)? {
+		Some(RunLeaseDisposition::NotDispatchable)
+	} else if let Some(idle_for) = daemon::stalled_idle_duration(
+		state_store,
+		&run_attempt,
+		worktree_mapping.as_ref(),
+		now_unix_epoch,
+	)? {
+		if daemon::retained_review_handoff_matches_run(
+			state_store,
+			&run_attempt,
+			worktree_mapping.as_ref(),
+		)? {
+			Some(RunLeaseDisposition::RetainedReviewComplete)
+		} else if daemon::stalled_run_has_retained_partial_progress(worktree_mapping.as_ref()) {
+			Some(RunLeaseDisposition::StalledRetainedPartialProgress { idle_for })
+		} else {
+			Some(RunLeaseDisposition::Stalled { idle_for })
+		}
+	} else {
+		None
+	};
+
+	Ok(disposition.map_or_else(Vec::new, |disposition| {
+		vec![RunLeaseReconciliation {
+			issue: issue.clone(),
+			run_attempt,
+			worktree_mapping,
+			disposition,
+			workflow: action_workflow.clone(),
+		}]
+	}))
+}

--- a/apps/decodex/src/orchestrator/status_autonomy/evidence.rs
+++ b/apps/decodex/src/orchestrator/status_autonomy/evidence.rs
@@ -1,16 +1,11 @@
+mod replay;
+
 use std::collections::BTreeSet;
 
-use serde_json::Value;
-
 use crate::{
-	orchestrator::{OperatorAutonomyExecutionEvidenceStatus, status_autonomy},
-	state::{
-		DecisionContractRecord, PrivateExecutionEvent, ProjectLoopEvidenceSnapshot,
-		ReviewLifecycleRecord,
-	},
+	orchestrator::OperatorAutonomyExecutionEvidenceStatus,
+	state::{DecisionContractRecord, ProjectLoopEvidenceSnapshot},
 };
-
-const AUTONOMY_REPLAY_EVIDENCE_SCHEMA: &str = "decodex.autonomy_replay_evidence/1";
 
 pub(crate) fn operator_autonomy_execution_evidence_statuses(
 	loop_evidence: &ProjectLoopEvidenceSnapshot,
@@ -24,7 +19,7 @@ pub(crate) fn operator_autonomy_execution_evidence_statuses(
 		let review_lifecycle_records = loop_evidence.review_lifecycle_records_for_issue(&issue_id);
 
 		for event in loop_evidence.private_events_for_issue(&issue_id) {
-			if let Some(status) = operator_autonomy_replay_evidence_status_from_event(
+			if let Some(status) = replay::operator_autonomy_replay_evidence_status_from_event(
 				event,
 				proposal_id,
 				&contract_ids,
@@ -42,8 +37,8 @@ pub(crate) fn operator_autonomy_execution_evidence_statuses(
 			.then_with(|| left.issue_identifier.cmp(&right.issue_identifier))
 			.then_with(|| left.source_refs.cmp(&right.source_refs))
 			.then_with(|| {
-				operator_autonomy_evidence_completeness_rank(&right.completeness)
-					.cmp(&operator_autonomy_evidence_completeness_rank(&left.completeness))
+				replay::operator_autonomy_evidence_completeness_rank(&right.completeness)
+					.cmp(&replay::operator_autonomy_evidence_completeness_rank(&left.completeness))
 			})
 			.then_with(|| right.updated_at.cmp(&left.updated_at))
 			.then_with(|| left.summary.cmp(&right.summary))
@@ -80,225 +75,4 @@ fn operator_autonomy_generated_issue_pairs(
 	pairs.dedup();
 
 	pairs
-}
-
-fn operator_autonomy_pr_evidence_status_from_event(
-	event: &PrivateExecutionEvent,
-	review: &ReviewLifecycleRecord,
-	issue_identifier: Option<&str>,
-	summary: String,
-	summary_redacted: bool,
-) -> OperatorAutonomyExecutionEvidenceStatus {
-	let (source_refs, refs_redacted) =
-		status_autonomy::public_autonomy_refs(&[review.pr_url().to_owned()]);
-	let mut known_gaps = Vec::new();
-
-	if source_refs.is_empty() {
-		known_gaps.push(String::from("source_refs_missing_or_redacted"));
-	}
-	if refs_redacted {
-		known_gaps.push(String::from("source_refs_redacted"));
-	}
-	if summary_redacted {
-		known_gaps.push(String::from("summary_redacted"));
-	}
-
-	OperatorAutonomyExecutionEvidenceStatus {
-		kind: String::from("pr"),
-		issue_identifier: issue_identifier.map(str::to_owned),
-		source_refs,
-		summary,
-		updated_at: [review.updated_at(), event.recorded_at()]
-			.into_iter()
-			.max()
-			.unwrap_or_else(|| event.recorded_at())
-			.to_owned(),
-		completeness: status_autonomy::operator_autonomy_completeness(&known_gaps),
-		known_gaps,
-	}
-}
-
-fn operator_autonomy_replay_evidence_status_from_event(
-	event: &PrivateExecutionEvent,
-	proposal_id: &str,
-	contract_ids: &BTreeSet<&str>,
-	issue_identifier: Option<&str>,
-	review_lifecycle_records: &[&ReviewLifecycleRecord],
-) -> Option<OperatorAutonomyExecutionEvidenceStatus> {
-	let payload = event.payload();
-
-	if payload.get("schema").and_then(Value::as_str) != Some(AUTONOMY_REPLAY_EVIDENCE_SCHEMA) {
-		return None;
-	}
-	if !operator_autonomy_replay_evidence_matches(payload, proposal_id, contract_ids) {
-		return None;
-	}
-
-	let kind = match payload.get("kind").and_then(Value::as_str) {
-		Some(kind @ ("pr" | "validation" | "post_land")) => kind.to_owned(),
-		_ => return None,
-	};
-	let raw_source_refs = payload
-		.get("source_refs")
-		.and_then(Value::as_array)
-		.into_iter()
-		.flatten()
-		.filter_map(Value::as_str)
-		.map(str::to_owned)
-		.collect::<Vec<_>>();
-	let (source_refs, refs_redacted) = status_autonomy::public_autonomy_refs(&raw_source_refs);
-	let (summary, summary_redacted) = status_autonomy::public_status_value(
-		payload
-			.get("summary")
-			.and_then(Value::as_str)
-			.unwrap_or("Dogfood replay evidence recorded."),
-	);
-	let mut known_gaps = Vec::new();
-
-	if kind == "pr" {
-		let pr_head_ref = payload
-			.get("pr_head_ref")
-			.and_then(Value::as_str)
-			.map(str::trim)
-			.filter(|value| !value.is_empty());
-		let pr_head_oid = payload
-			.get("pr_head_oid")
-			.and_then(Value::as_str)
-			.map(str::trim)
-			.filter(|value| !value.is_empty());
-
-		return Some(
-			match operator_autonomy_matching_pr_review(
-				event,
-				&raw_source_refs,
-				pr_head_ref,
-				pr_head_oid,
-				review_lifecycle_records,
-			) {
-				Some(review) => operator_autonomy_pr_evidence_status_from_event(
-					event,
-					review,
-					issue_identifier,
-					summary,
-					summary_redacted,
-				),
-				None => {
-					if source_refs.is_empty() {
-						known_gaps.push(String::from("source_refs_missing_or_redacted"));
-					}
-					if refs_redacted {
-						known_gaps.push(String::from("source_refs_redacted"));
-					}
-					if summary_redacted {
-						known_gaps.push(String::from("summary_redacted"));
-					}
-					if pr_head_ref.is_none() || pr_head_oid.is_none() {
-						known_gaps.push(String::from("pr_head_identity_missing"));
-					} else if operator_autonomy_pr_review_candidate_exists(
-						event,
-						&raw_source_refs,
-						review_lifecycle_records,
-					) {
-						known_gaps.push(String::from("review_lifecycle_stale_or_mismatched"));
-					} else {
-						known_gaps.push(String::from("review_lifecycle_missing"));
-					}
-
-					OperatorAutonomyExecutionEvidenceStatus {
-						kind,
-						issue_identifier: issue_identifier.map(str::to_owned),
-						source_refs,
-						summary,
-						updated_at: event.recorded_at().to_owned(),
-						completeness: status_autonomy::operator_autonomy_completeness(&known_gaps),
-						known_gaps,
-					}
-				},
-			},
-		);
-	}
-	if source_refs.is_empty() {
-		known_gaps.push(String::from("source_refs_missing_or_redacted"));
-	}
-	if refs_redacted {
-		known_gaps.push(String::from("source_refs_redacted"));
-	}
-	if summary_redacted {
-		known_gaps.push(String::from("summary_redacted"));
-	}
-
-	Some(OperatorAutonomyExecutionEvidenceStatus {
-		kind,
-		issue_identifier: issue_identifier.map(str::to_owned),
-		source_refs,
-		summary,
-		updated_at: event.recorded_at().to_owned(),
-		completeness: status_autonomy::operator_autonomy_completeness(&known_gaps),
-		known_gaps,
-	})
-}
-
-fn operator_autonomy_matching_pr_review<'a>(
-	event: &PrivateExecutionEvent,
-	raw_source_refs: &[String],
-	pr_head_ref: Option<&str>,
-	pr_head_oid: Option<&str>,
-	review_lifecycle_records: &'a [&'a ReviewLifecycleRecord],
-) -> Option<&'a ReviewLifecycleRecord> {
-	let pr_head_ref = pr_head_ref?;
-	let pr_head_oid = pr_head_oid?;
-	let raw_source_refs =
-		raw_source_refs.iter().map(|source_ref| source_ref.trim()).collect::<BTreeSet<_>>();
-
-	review_lifecycle_records
-		.iter()
-		.copied()
-		.filter(|review| {
-			review.run_id() == event.run_id()
-				&& review.attempt_number() == event.attempt_number()
-				&& raw_source_refs.contains(review.pr_url())
-				&& review.branch_name() == pr_head_ref
-				&& review.pr_head_ref_name() == pr_head_ref
-				&& review.pr_head_oid() == pr_head_oid
-				&& review.head_sha() == pr_head_oid
-		})
-		.max_by(|left, right| {
-			left.updated_at_unix()
-				.cmp(&right.updated_at_unix())
-				.then_with(|| left.branch_name().cmp(right.branch_name()))
-		})
-}
-
-fn operator_autonomy_pr_review_candidate_exists(
-	event: &PrivateExecutionEvent,
-	raw_source_refs: &[String],
-	review_lifecycle_records: &[&ReviewLifecycleRecord],
-) -> bool {
-	let raw_source_refs =
-		raw_source_refs.iter().map(|source_ref| source_ref.trim()).collect::<BTreeSet<_>>();
-
-	review_lifecycle_records.iter().any(|review| {
-		review.run_id() == event.run_id()
-			&& review.attempt_number() == event.attempt_number()
-			&& raw_source_refs.contains(review.pr_url())
-	})
-}
-
-fn operator_autonomy_replay_evidence_matches(
-	payload: &Value,
-	proposal_id: &str,
-	contract_ids: &BTreeSet<&str>,
-) -> bool {
-	payload.get("proposal_id").and_then(Value::as_str) == Some(proposal_id)
-		|| payload
-			.get("contract_id")
-			.and_then(Value::as_str)
-			.is_some_and(|contract_id| contract_ids.contains(contract_id))
-}
-
-fn operator_autonomy_evidence_completeness_rank(value: &str) -> u8 {
-	match value {
-		"complete" => 1,
-		_ => 0,
-	}
 }

--- a/apps/decodex/src/orchestrator/status_autonomy/evidence/replay.rs
+++ b/apps/decodex/src/orchestrator/status_autonomy/evidence/replay.rs
@@ -1,0 +1,231 @@
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+use crate::{
+	orchestrator::{OperatorAutonomyExecutionEvidenceStatus, status_autonomy},
+	state::{PrivateExecutionEvent, ReviewLifecycleRecord},
+};
+
+const AUTONOMY_REPLAY_EVIDENCE_SCHEMA: &str = "decodex.autonomy_replay_evidence/1";
+
+pub(crate) fn operator_autonomy_evidence_completeness_rank(value: &str) -> u8 {
+	match value {
+		"complete" => 1,
+		_ => 0,
+	}
+}
+
+pub(crate) fn operator_autonomy_replay_evidence_status_from_event(
+	event: &PrivateExecutionEvent,
+	proposal_id: &str,
+	contract_ids: &BTreeSet<&str>,
+	issue_identifier: Option<&str>,
+	review_lifecycle_records: &[&ReviewLifecycleRecord],
+) -> Option<OperatorAutonomyExecutionEvidenceStatus> {
+	let payload = event.payload();
+
+	if payload.get("schema").and_then(Value::as_str) != Some(AUTONOMY_REPLAY_EVIDENCE_SCHEMA) {
+		return None;
+	}
+	if !operator_autonomy_replay_evidence_matches(payload, proposal_id, contract_ids) {
+		return None;
+	}
+
+	let kind = match payload.get("kind").and_then(Value::as_str) {
+		Some(kind @ ("pr" | "validation" | "post_land")) => kind.to_owned(),
+		_ => return None,
+	};
+	let raw_source_refs = payload
+		.get("source_refs")
+		.and_then(Value::as_array)
+		.into_iter()
+		.flatten()
+		.filter_map(Value::as_str)
+		.map(str::to_owned)
+		.collect::<Vec<_>>();
+	let (source_refs, refs_redacted) = status_autonomy::public_autonomy_refs(&raw_source_refs);
+	let (summary, summary_redacted) = status_autonomy::public_status_value(
+		payload
+			.get("summary")
+			.and_then(Value::as_str)
+			.unwrap_or("Dogfood replay evidence recorded."),
+	);
+	let mut known_gaps = Vec::new();
+
+	if kind == "pr" {
+		let pr_head_ref = payload
+			.get("pr_head_ref")
+			.and_then(Value::as_str)
+			.map(str::trim)
+			.filter(|value| !value.is_empty());
+		let pr_head_oid = payload
+			.get("pr_head_oid")
+			.and_then(Value::as_str)
+			.map(str::trim)
+			.filter(|value| !value.is_empty());
+
+		return Some(
+			match operator_autonomy_matching_pr_review(
+				event,
+				&raw_source_refs,
+				pr_head_ref,
+				pr_head_oid,
+				review_lifecycle_records,
+			) {
+				Some(review) => operator_autonomy_pr_evidence_status_from_event(
+					event,
+					review,
+					issue_identifier,
+					summary,
+					summary_redacted,
+				),
+				None => {
+					if source_refs.is_empty() {
+						known_gaps.push(String::from("source_refs_missing_or_redacted"));
+					}
+					if refs_redacted {
+						known_gaps.push(String::from("source_refs_redacted"));
+					}
+					if summary_redacted {
+						known_gaps.push(String::from("summary_redacted"));
+					}
+					if pr_head_ref.is_none() || pr_head_oid.is_none() {
+						known_gaps.push(String::from("pr_head_identity_missing"));
+					} else if operator_autonomy_pr_review_candidate_exists(
+						event,
+						&raw_source_refs,
+						review_lifecycle_records,
+					) {
+						known_gaps.push(String::from("review_lifecycle_stale_or_mismatched"));
+					} else {
+						known_gaps.push(String::from("review_lifecycle_missing"));
+					}
+
+					OperatorAutonomyExecutionEvidenceStatus {
+						kind,
+						issue_identifier: issue_identifier.map(str::to_owned),
+						source_refs,
+						summary,
+						updated_at: event.recorded_at().to_owned(),
+						completeness: status_autonomy::operator_autonomy_completeness(&known_gaps),
+						known_gaps,
+					}
+				},
+			},
+		);
+	}
+	if source_refs.is_empty() {
+		known_gaps.push(String::from("source_refs_missing_or_redacted"));
+	}
+	if refs_redacted {
+		known_gaps.push(String::from("source_refs_redacted"));
+	}
+	if summary_redacted {
+		known_gaps.push(String::from("summary_redacted"));
+	}
+
+	Some(OperatorAutonomyExecutionEvidenceStatus {
+		kind,
+		issue_identifier: issue_identifier.map(str::to_owned),
+		source_refs,
+		summary,
+		updated_at: event.recorded_at().to_owned(),
+		completeness: status_autonomy::operator_autonomy_completeness(&known_gaps),
+		known_gaps,
+	})
+}
+
+fn operator_autonomy_pr_evidence_status_from_event(
+	event: &PrivateExecutionEvent,
+	review: &ReviewLifecycleRecord,
+	issue_identifier: Option<&str>,
+	summary: String,
+	summary_redacted: bool,
+) -> OperatorAutonomyExecutionEvidenceStatus {
+	let (source_refs, refs_redacted) =
+		status_autonomy::public_autonomy_refs(&[review.pr_url().to_owned()]);
+	let mut known_gaps = Vec::new();
+
+	if source_refs.is_empty() {
+		known_gaps.push(String::from("source_refs_missing_or_redacted"));
+	}
+	if refs_redacted {
+		known_gaps.push(String::from("source_refs_redacted"));
+	}
+	if summary_redacted {
+		known_gaps.push(String::from("summary_redacted"));
+	}
+
+	OperatorAutonomyExecutionEvidenceStatus {
+		kind: String::from("pr"),
+		issue_identifier: issue_identifier.map(str::to_owned),
+		source_refs,
+		summary,
+		updated_at: [review.updated_at(), event.recorded_at()]
+			.into_iter()
+			.max()
+			.unwrap_or_else(|| event.recorded_at())
+			.to_owned(),
+		completeness: status_autonomy::operator_autonomy_completeness(&known_gaps),
+		known_gaps,
+	}
+}
+
+fn operator_autonomy_matching_pr_review<'a>(
+	event: &PrivateExecutionEvent,
+	raw_source_refs: &[String],
+	pr_head_ref: Option<&str>,
+	pr_head_oid: Option<&str>,
+	review_lifecycle_records: &'a [&'a ReviewLifecycleRecord],
+) -> Option<&'a ReviewLifecycleRecord> {
+	let pr_head_ref = pr_head_ref?;
+	let pr_head_oid = pr_head_oid?;
+	let raw_source_refs =
+		raw_source_refs.iter().map(|source_ref| source_ref.trim()).collect::<BTreeSet<_>>();
+
+	review_lifecycle_records
+		.iter()
+		.copied()
+		.filter(|review| {
+			review.run_id() == event.run_id()
+				&& review.attempt_number() == event.attempt_number()
+				&& raw_source_refs.contains(review.pr_url())
+				&& review.branch_name() == pr_head_ref
+				&& review.pr_head_ref_name() == pr_head_ref
+				&& review.pr_head_oid() == pr_head_oid
+				&& review.head_sha() == pr_head_oid
+		})
+		.max_by(|left, right| {
+			left.updated_at_unix()
+				.cmp(&right.updated_at_unix())
+				.then_with(|| left.branch_name().cmp(right.branch_name()))
+		})
+}
+
+fn operator_autonomy_pr_review_candidate_exists(
+	event: &PrivateExecutionEvent,
+	raw_source_refs: &[String],
+	review_lifecycle_records: &[&ReviewLifecycleRecord],
+) -> bool {
+	let raw_source_refs =
+		raw_source_refs.iter().map(|source_ref| source_ref.trim()).collect::<BTreeSet<_>>();
+
+	review_lifecycle_records.iter().any(|review| {
+		review.run_id() == event.run_id()
+			&& review.attempt_number() == event.attempt_number()
+			&& raw_source_refs.contains(review.pr_url())
+	})
+}
+
+fn operator_autonomy_replay_evidence_matches(
+	payload: &Value,
+	proposal_id: &str,
+	contract_ids: &BTreeSet<&str>,
+) -> bool {
+	payload.get("proposal_id").and_then(Value::as_str) == Some(proposal_id)
+		|| payload
+			.get("contract_id")
+			.and_then(Value::as_str)
+			.is_some_and(|contract_id| contract_ids.contains(contract_id))
+}

--- a/apps/decodex/src/state/models/activity.rs
+++ b/apps/decodex/src/state/models/activity.rs
@@ -1,3 +1,6 @@
+mod child_agent;
+mod run_marker;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
@@ -17,60 +20,6 @@ pub(crate) struct ChildAgentActivitySummary {
 	pub(crate) largest_tool_output_bytes: Option<i64>,
 	pub(crate) largest_tool_output_tool: Option<String>,
 	pub(crate) large_output_warnings: Vec<String>,
-}
-impl ChildAgentActivitySummary {
-	pub(crate) fn sealed_durable(mut self) -> Self {
-		self.seal_open_interval();
-
-		self
-	}
-
-	pub(crate) fn live_projection(mut self, now_unix_epoch: i64) -> Self {
-		let observed_elapsed_seconds =
-			self.current_elapsed_seconds.filter(|elapsed| *elapsed >= 0).unwrap_or(0);
-		let current_elapsed_seconds = self.current_started_unix_epoch.and_then(|started_at| {
-			now_unix_epoch.checked_sub(started_at).filter(|elapsed| *elapsed >= 0)
-		});
-		let open_delta_seconds = current_elapsed_seconds.and_then(|elapsed| {
-			elapsed.checked_sub(observed_elapsed_seconds).filter(|delta| *delta > 0)
-		});
-
-		self.current_elapsed_seconds = current_elapsed_seconds;
-
-		let current_bucket = self.current_bucket.clone();
-
-		if let (Some(current_bucket), Some(open_delta_seconds)) =
-			(current_bucket, open_delta_seconds)
-		{
-			let bucket = self.bucket_mut(&current_bucket);
-
-			bucket.wall_seconds = bucket.wall_seconds.saturating_add(open_delta_seconds);
-		}
-
-		self
-	}
-
-	fn seal_open_interval(&mut self) {
-		self.current_bucket = None;
-		self.current_detail = None;
-		self.current_started_unix_epoch = None;
-		self.current_elapsed_seconds = None;
-	}
-
-	fn bucket_mut(&mut self, name: &str) -> &mut ChildAgentActivityBucket {
-		if let Some(index) = self.buckets.iter().position(|bucket| bucket.name == name) {
-			return &mut self.buckets[index];
-		}
-
-		self.buckets.push(ChildAgentActivityBucket {
-			name: name.to_owned(),
-			..ChildAgentActivityBucket::default()
-		});
-
-		let last_index = self.buckets.len().saturating_sub(1);
-
-		&mut self.buckets[last_index]
-	}
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
@@ -176,117 +125,4 @@ pub(crate) struct RunActivityMarker {
 	pub(in crate::state) retry_budget_attempt_count: Option<i64>,
 	pub(in crate::state) retry_kind: Option<String>,
 	pub(in crate::state) retry_ready_at_unix_epoch: Option<i64>,
-}
-impl RunActivityMarker {
-	pub(crate) fn run_id(&self) -> &str {
-		&self.run_id
-	}
-
-	pub(crate) fn attempt_number(&self) -> i64 {
-		self.attempt_number
-	}
-
-	pub(crate) fn process_id(&self) -> Option<u32> {
-		self.process_id
-	}
-
-	pub(crate) fn host_boot_id(&self) -> Option<&str> {
-		self.host_boot_id.as_deref()
-	}
-
-	pub(crate) fn process_start_identity(&self) -> Option<&str> {
-		self.process_start_identity.as_deref()
-	}
-
-	pub(crate) fn last_activity_unix_epoch(&self) -> Option<i64> {
-		self.last_activity_unix_epoch
-	}
-
-	pub(crate) fn last_protocol_activity_unix_epoch(&self) -> Option<i64> {
-		self.last_protocol_activity_unix_epoch
-	}
-
-	pub(crate) fn last_progress_unix_epoch(&self) -> Option<i64> {
-		self.last_progress_unix_epoch
-	}
-
-	pub(crate) fn current_operation(&self) -> Option<&str> {
-		self.current_operation.as_deref()
-	}
-
-	pub(crate) fn thread_id(&self) -> Option<&str> {
-		self.thread_id.as_deref()
-	}
-
-	pub(crate) fn turn_id(&self) -> Option<&str> {
-		self.turn_id.as_deref()
-	}
-
-	pub(crate) fn thread_status(&self) -> Option<&str> {
-		self.thread_status.as_deref()
-	}
-
-	pub(crate) fn thread_active_flags(&self) -> &[String] {
-		&self.thread_active_flags
-	}
-
-	pub(crate) fn event_count(&self) -> i64 {
-		self.event_count.unwrap_or(0)
-	}
-
-	pub(crate) fn last_event_type(&self) -> Option<&str> {
-		self.last_event_type.as_deref()
-	}
-
-	pub(crate) fn effective_model(&self) -> Option<&str> {
-		self.effective_model.as_deref()
-	}
-
-	pub(crate) fn effective_model_provider(&self) -> Option<&str> {
-		self.effective_model_provider.as_deref()
-	}
-
-	pub(crate) fn effective_cwd(&self) -> Option<&str> {
-		self.effective_cwd.as_deref()
-	}
-
-	pub(crate) fn effective_approval_policy(&self) -> Option<&str> {
-		self.effective_approval_policy.as_deref()
-	}
-
-	pub(crate) fn effective_approvals_reviewer(&self) -> Option<&str> {
-		self.effective_approvals_reviewer.as_deref()
-	}
-
-	pub(crate) fn effective_sandbox_mode(&self) -> Option<&str> {
-		self.effective_sandbox_mode.as_deref()
-	}
-
-	pub(crate) fn child_agent_activity(&self) -> Option<&ChildAgentActivitySummary> {
-		self.child_agent_activity.as_ref()
-	}
-
-	pub(crate) fn protocol_activity(&self) -> Option<&ProtocolActivitySummary> {
-		self.protocol_activity.as_ref()
-	}
-
-	pub(crate) fn account(&self) -> Option<&CodexAccountActivitySummary> {
-		self.account.as_ref()
-	}
-
-	pub(crate) fn accounts(&self) -> &[CodexAccountActivitySummary] {
-		&self.accounts
-	}
-
-	pub(crate) fn retry_kind(&self) -> Option<&str> {
-		self.retry_kind.as_deref()
-	}
-
-	pub(crate) fn retry_ready_at_unix_epoch(&self) -> Option<i64> {
-		self.retry_ready_at_unix_epoch
-	}
-
-	pub(crate) fn retry_budget_attempt_count(&self) -> Option<i64> {
-		self.retry_budget_attempt_count
-	}
 }

--- a/apps/decodex/src/state/models/activity/child_agent.rs
+++ b/apps/decodex/src/state/models/activity/child_agent.rs
@@ -1,0 +1,56 @@
+use crate::state::{ChildAgentActivityBucket, ChildAgentActivitySummary};
+
+impl ChildAgentActivitySummary {
+	pub(crate) fn sealed_durable(mut self) -> Self {
+		self.seal_open_interval();
+
+		self
+	}
+
+	pub(crate) fn live_projection(mut self, now_unix_epoch: i64) -> Self {
+		let observed_elapsed_seconds =
+			self.current_elapsed_seconds.filter(|elapsed| *elapsed >= 0).unwrap_or(0);
+		let current_elapsed_seconds = self.current_started_unix_epoch.and_then(|started_at| {
+			now_unix_epoch.checked_sub(started_at).filter(|elapsed| *elapsed >= 0)
+		});
+		let open_delta_seconds = current_elapsed_seconds.and_then(|elapsed| {
+			elapsed.checked_sub(observed_elapsed_seconds).filter(|delta| *delta > 0)
+		});
+
+		self.current_elapsed_seconds = current_elapsed_seconds;
+
+		let current_bucket = self.current_bucket.clone();
+
+		if let (Some(current_bucket), Some(open_delta_seconds)) =
+			(current_bucket, open_delta_seconds)
+		{
+			let bucket = self.bucket_mut(&current_bucket);
+
+			bucket.wall_seconds = bucket.wall_seconds.saturating_add(open_delta_seconds);
+		}
+
+		self
+	}
+
+	fn seal_open_interval(&mut self) {
+		self.current_bucket = None;
+		self.current_detail = None;
+		self.current_started_unix_epoch = None;
+		self.current_elapsed_seconds = None;
+	}
+
+	fn bucket_mut(&mut self, name: &str) -> &mut ChildAgentActivityBucket {
+		if let Some(index) = self.buckets.iter().position(|bucket| bucket.name == name) {
+			return &mut self.buckets[index];
+		}
+
+		self.buckets.push(ChildAgentActivityBucket {
+			name: name.to_owned(),
+			..ChildAgentActivityBucket::default()
+		});
+
+		let last_index = self.buckets.len().saturating_sub(1);
+
+		&mut self.buckets[last_index]
+	}
+}

--- a/apps/decodex/src/state/models/activity/run_marker.rs
+++ b/apps/decodex/src/state/models/activity/run_marker.rs
@@ -1,0 +1,118 @@
+use crate::state::{
+	ChildAgentActivitySummary, CodexAccountActivitySummary, ProtocolActivitySummary,
+	RunActivityMarker,
+};
+
+impl RunActivityMarker {
+	pub(crate) fn run_id(&self) -> &str {
+		&self.run_id
+	}
+
+	pub(crate) fn attempt_number(&self) -> i64 {
+		self.attempt_number
+	}
+
+	pub(crate) fn process_id(&self) -> Option<u32> {
+		self.process_id
+	}
+
+	pub(crate) fn host_boot_id(&self) -> Option<&str> {
+		self.host_boot_id.as_deref()
+	}
+
+	pub(crate) fn process_start_identity(&self) -> Option<&str> {
+		self.process_start_identity.as_deref()
+	}
+
+	pub(crate) fn last_activity_unix_epoch(&self) -> Option<i64> {
+		self.last_activity_unix_epoch
+	}
+
+	pub(crate) fn last_protocol_activity_unix_epoch(&self) -> Option<i64> {
+		self.last_protocol_activity_unix_epoch
+	}
+
+	pub(crate) fn last_progress_unix_epoch(&self) -> Option<i64> {
+		self.last_progress_unix_epoch
+	}
+
+	pub(crate) fn current_operation(&self) -> Option<&str> {
+		self.current_operation.as_deref()
+	}
+
+	pub(crate) fn thread_id(&self) -> Option<&str> {
+		self.thread_id.as_deref()
+	}
+
+	pub(crate) fn turn_id(&self) -> Option<&str> {
+		self.turn_id.as_deref()
+	}
+
+	pub(crate) fn thread_status(&self) -> Option<&str> {
+		self.thread_status.as_deref()
+	}
+
+	pub(crate) fn thread_active_flags(&self) -> &[String] {
+		&self.thread_active_flags
+	}
+
+	pub(crate) fn event_count(&self) -> i64 {
+		self.event_count.unwrap_or(0)
+	}
+
+	pub(crate) fn last_event_type(&self) -> Option<&str> {
+		self.last_event_type.as_deref()
+	}
+
+	pub(crate) fn effective_model(&self) -> Option<&str> {
+		self.effective_model.as_deref()
+	}
+
+	pub(crate) fn effective_model_provider(&self) -> Option<&str> {
+		self.effective_model_provider.as_deref()
+	}
+
+	pub(crate) fn effective_cwd(&self) -> Option<&str> {
+		self.effective_cwd.as_deref()
+	}
+
+	pub(crate) fn effective_approval_policy(&self) -> Option<&str> {
+		self.effective_approval_policy.as_deref()
+	}
+
+	pub(crate) fn effective_approvals_reviewer(&self) -> Option<&str> {
+		self.effective_approvals_reviewer.as_deref()
+	}
+
+	pub(crate) fn effective_sandbox_mode(&self) -> Option<&str> {
+		self.effective_sandbox_mode.as_deref()
+	}
+
+	pub(crate) fn child_agent_activity(&self) -> Option<&ChildAgentActivitySummary> {
+		self.child_agent_activity.as_ref()
+	}
+
+	pub(crate) fn protocol_activity(&self) -> Option<&ProtocolActivitySummary> {
+		self.protocol_activity.as_ref()
+	}
+
+	pub(crate) fn account(&self) -> Option<&CodexAccountActivitySummary> {
+		self.account.as_ref()
+	}
+
+	pub(crate) fn accounts(&self) -> &[CodexAccountActivitySummary] {
+		&self.accounts
+	}
+
+	pub(crate) fn retry_kind(&self) -> Option<&str> {
+		self.retry_kind.as_deref()
+	}
+
+	pub(crate) fn retry_ready_at_unix_epoch(&self) -> Option<i64> {
+		self.retry_ready_at_unix_epoch
+	}
+
+	pub(crate) fn retry_budget_attempt_count(&self) -> Option<i64> {
+		self.retry_budget_attempt_count
+	}
+}


### PR DESCRIPTION
## Summary
- split private evidence readback reference, target resolution, and event rendering into flat Rust modules
- split daemon active-child cleanup and live reconciliation into dedicated modules
- split run activity accessors and child-agent activity projection into flat state model modules
- split autonomy execution replay evidence into a dedicated module

## Validation
- `rustup run nightly cargo fmt --all --check`
- `cargo make check-rust`
- `cargo make lint-vstyle-rust`
- `cargo make lint-rust`
- `cargo test -p decodex activity --lib -- --format terse`
- `cargo test -p decodex daemon --lib -- --format terse`
- `cargo test -p decodex private_readback --lib -- --format terse`
- `cargo test -p decodex autonomy --lib -- --format terse`
- guard scans: no added `allow`/`expect`, wildcard imports, `include!`, `#[path]`, `use super`, `super::`, or `mod.rs`

Note: full `cargo test -p decodex --lib -- --format terse --test-threads=1` hit the existing env-mutex poisoning cascade after `mcp::tests::resources::live_activity_http::streamable_http_resources_read_exposes_observability_resources`; that seed test passes when rerun alone.