### PR TITLE
Split operator dashboard mock server modules

### DIFF
--- a/dev/operator-dashboard-mock.mjs
+++ b/dev/operator-dashboard-mock.mjs
@@ -1,27 +1,13 @@
 #!/usr/bin/env node
 
-import http from "node:http";
-import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import {
-	accountMatchesSelector,
-	accountsWithSelection,
-	usageEstimate,
-} from "./operator-dashboard-mock/accounts.mjs";
 import { parseArgs, splitListenAddress } from "./operator-dashboard-mock/args.mjs";
 import { codexAuthAccounts } from "./operator-dashboard-mock/auth.mjs";
 import { mockAccounts } from "./operator-dashboard-mock/fixtures.mjs";
-import { buildSnapshot } from "./operator-dashboard-mock/snapshot.mjs";
-import { nowUnix } from "./operator-dashboard-mock/time.mjs";
-import {
-	dashboardControlAck,
-	decodeWebSocketFrames,
-	send,
-	sendWebSocketJson,
-	websocketAcceptValue,
-} from "./operator-dashboard-mock/websocket.mjs";
+import { createMockDashboardServer } from "./operator-dashboard-mock/server/index.mjs";
+import { createMockServerState } from "./operator-dashboard-mock/server/state.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -30,217 +16,12 @@ async function main() {
 	const staticAccounts = options.authDir
 		? await codexAuthAccounts(options.authDir)
 		: mockAccounts();
-	let fixedAccountSelector =
-		staticAccounts.find((item) => item.status === "selected")?.account_email ||
-		staticAccounts[0]?.account_email ||
-		null;
-	let lastPublishedAt = nowUnix();
+	const state = createMockServerState(staticAccounts);
 	const { host, port } = splitListenAddress(options.listenAddress);
-	const server = http.createServer(async (request, response) => {
-		try {
-			if (request.method !== "GET") {
-				send(response, 405, "text/plain; charset=utf-8", "method not allowed");
-				return;
-			}
-			const url = new URL(request.url || "/", `http://${options.listenAddress}`);
-			if (url.pathname === "/" || url.pathname === "/dashboard") {
-				const html = await fs.readFile(options.dashboardHtml, "utf8");
-				send(response, 200, "text/html; charset=utf-8", html);
-				return;
-			}
-			if (url.pathname === "/api/accounts") {
-				const controlledAccounts = accountsWithSelection(staticAccounts, fixedAccountSelector);
-				send(
-					response,
-					200,
-					"application/json; charset=utf-8",
-					JSON.stringify({
-						accounts_path: "/tmp/decodex-mock/accounts.jsonl",
-						global_config_path: "/tmp/decodex-mock/config.toml",
-						codex_auth_path: "/tmp/decodex-mock/auth.json",
-						codex_auth: null,
-						control: {
-							mode: fixedAccountSelector ? "fixed" : "balanced",
-							account_selector: fixedAccountSelector || null,
-						},
-						accounts: controlledAccounts,
-						usage_estimate: usageEstimate(controlledAccounts),
-						usage_probe_error: null,
-					}),
-				);
-				return;
-			}
-			if (url.pathname === "/livez") {
-				send(response, 200, "text/plain; charset=utf-8", "ok");
-				return;
-			}
-
-			send(response, 404, "text/plain; charset=utf-8", "not found");
-		} catch (error) {
-			send(response, 500, "text/plain; charset=utf-8", error?.message || "mock server error");
-		}
-	});
-
-	server.on("upgrade", (request, socket) => {
-		const url = new URL(request.url || "/", `http://${options.listenAddress}`);
-		if (url.pathname !== "/dashboard/control") {
-			socket.destroy();
-			return;
-		}
-
-		const key = request.headers["sec-websocket-key"];
-		if (!key) {
-			socket.destroy();
-			return;
-		}
-
-		socket.write(
-			[
-				"HTTP/1.1 101 Switching Protocols",
-				"Upgrade: websocket",
-				"Connection: Upgrade",
-				`Sec-WebSocket-Accept: ${websocketAcceptValue(key)}`,
-				"",
-				"",
-			].join("\r\n"),
-		);
-		sendWebSocketJson(socket, {
-			type: "controlReady",
-			payload: {
-				supportedActions: [
-					"subscribe",
-					"focus",
-					"clearFocus",
-					"pauseProject",
-					"resumeProject",
-					"interruptRun",
-					"selectAccount",
-					"clearAccountSelection",
-					"ack",
-				],
-				subscription: {},
-			},
-		});
-		sendWebSocketJson(socket, {
-			type: "snapshot",
-			payload: {
-				snapshot: buildSnapshot(staticAccounts, fixedAccountSelector),
-				snapshotPublishedAtUnixEpoch: lastPublishedAt,
-			},
-		});
-
-		let buffered = Buffer.alloc(0);
-		socket.on("data", (chunk) => {
-			buffered = Buffer.concat([buffered, chunk]);
-			const decoded = decodeWebSocketFrames(buffered);
-			buffered = decoded.remaining;
-			if (decoded.closed) {
-				socket.end();
-				return;
-			}
-
-			for (const text of decoded.messages) {
-				let message;
-				try {
-					message = JSON.parse(text);
-				} catch (_error) {
-					sendWebSocketJson(socket, {
-						type: "controlAck",
-						payload: {
-							requestId: null,
-							action: "control",
-							accepted: false,
-							status: "invalid_json",
-							message: "Mock dashboard control received invalid JSON.",
-						},
-					});
-					continue;
-				}
-
-				if (message.type === "subscribe") {
-					sendWebSocketJson(
-						socket,
-						dashboardControlAck(message, true, "accepted", "Mock subscription accepted."),
-					);
-					continue;
-				}
-
-				if (message.type !== "control") {
-					sendWebSocketJson(
-						socket,
-						dashboardControlAck(
-							message,
-							false,
-							"unsupported",
-							"Mock dashboard control type is unsupported.",
-						),
-					);
-					continue;
-				}
-
-				if (message.action === "selectAccount") {
-					const selector = String(message.accountSelector || "").trim();
-					if (!staticAccounts.some((item) => accountMatchesSelector(item, selector))) {
-						sendWebSocketJson(
-							socket,
-							dashboardControlAck(
-								message,
-								false,
-								"unknown_account",
-								"Mock account selector was not found.",
-							),
-						);
-						continue;
-					}
-					fixedAccountSelector = selector;
-					lastPublishedAt = nowUnix();
-					sendWebSocketJson(
-						socket,
-						dashboardControlAck(message, true, "accepted", "Mock account selection updated."),
-					);
-					sendWebSocketJson(socket, {
-						type: "snapshot",
-						payload: {
-							snapshot: buildSnapshot(staticAccounts, fixedAccountSelector),
-							snapshotPublishedAtUnixEpoch: lastPublishedAt,
-						},
-					});
-					continue;
-				}
-
-				if (message.action === "clearAccountSelection") {
-					fixedAccountSelector = null;
-					lastPublishedAt = nowUnix();
-					sendWebSocketJson(
-						socket,
-						dashboardControlAck(
-							message,
-							true,
-							"accepted",
-							"Mock account selection returned to balanced mode.",
-						),
-					);
-					sendWebSocketJson(socket, {
-						type: "snapshot",
-						payload: {
-							snapshot: buildSnapshot(staticAccounts, fixedAccountSelector),
-							snapshotPublishedAtUnixEpoch: lastPublishedAt,
-						},
-					});
-					continue;
-				}
-
-				sendWebSocketJson(
-					socket,
-					dashboardControlAck(
-						message,
-						false,
-						"unsupported",
-						"Mock dashboard control action is unsupported.",
-					),
-				);
-			}
-		});
+	const server = createMockDashboardServer({
+		options,
+		staticAccounts,
+		state,
 	});
 
 	server.listen(port, host, () => {

--- a/dev/operator-dashboard-mock/server/control-socket.mjs
+++ b/dev/operator-dashboard-mock/server/control-socket.mjs
@@ -1,0 +1,184 @@
+import { accountMatchesSelector } from "../accounts.mjs";
+import { buildSnapshot } from "../snapshot.mjs";
+import { nowUnix } from "../time.mjs";
+import {
+	dashboardControlAck,
+	decodeWebSocketFrames,
+	sendWebSocketJson,
+	websocketAcceptValue,
+} from "../websocket.mjs";
+
+const SUPPORTED_ACTIONS = [
+	"subscribe",
+	"focus",
+	"clearFocus",
+	"pauseProject",
+	"resumeProject",
+	"interruptRun",
+	"selectAccount",
+	"clearAccountSelection",
+	"ack",
+];
+
+export function handleDashboardUpgrade(context, request, socket) {
+	const { options } = context;
+	const url = new URL(request.url || "/", `http://${options.listenAddress}`);
+	if (url.pathname !== "/dashboard/control") {
+		socket.destroy();
+		return;
+	}
+
+	const key = request.headers["sec-websocket-key"];
+	if (!key) {
+		socket.destroy();
+		return;
+	}
+
+	socket.write(
+		[
+			"HTTP/1.1 101 Switching Protocols",
+			"Upgrade: websocket",
+			"Connection: Upgrade",
+			`Sec-WebSocket-Accept: ${websocketAcceptValue(key)}`,
+			"",
+			"",
+		].join("\r\n"),
+	);
+	sendControlReady(socket);
+	sendSnapshot(socket, context);
+
+	let buffered = Buffer.alloc(0);
+	socket.on("data", (chunk) => {
+		buffered = Buffer.concat([buffered, chunk]);
+		const decoded = decodeWebSocketFrames(buffered);
+		buffered = decoded.remaining;
+		if (decoded.closed) {
+			socket.end();
+			return;
+		}
+
+		for (const text of decoded.messages) {
+			handleControlText(context, socket, text);
+		}
+	});
+}
+
+function sendControlReady(socket) {
+	sendWebSocketJson(socket, {
+		type: "controlReady",
+		payload: {
+			supportedActions: SUPPORTED_ACTIONS,
+			subscription: {},
+		},
+	});
+}
+
+function sendSnapshot(socket, context) {
+	const { state, staticAccounts } = context;
+	sendWebSocketJson(socket, {
+		type: "snapshot",
+		payload: {
+			snapshot: buildSnapshot(staticAccounts, state.fixedAccountSelector),
+			snapshotPublishedAtUnixEpoch: state.lastPublishedAt,
+		},
+	});
+}
+
+function handleControlText(context, socket, text) {
+	let message;
+	try {
+		message = JSON.parse(text);
+	} catch (_error) {
+		sendInvalidJson(socket);
+		return;
+	}
+
+	if (message.type === "subscribe") {
+		sendWebSocketJson(
+			socket,
+			dashboardControlAck(message, true, "accepted", "Mock subscription accepted."),
+		);
+		return;
+	}
+
+	if (message.type !== "control") {
+		sendWebSocketJson(
+			socket,
+			dashboardControlAck(
+				message,
+				false,
+				"unsupported",
+				"Mock dashboard control type is unsupported.",
+			),
+		);
+		return;
+	}
+
+	handleControlAction(context, socket, message);
+}
+
+function sendInvalidJson(socket) {
+	sendWebSocketJson(socket, {
+		type: "controlAck",
+		payload: {
+			requestId: null,
+			action: "control",
+			accepted: false,
+			status: "invalid_json",
+			message: "Mock dashboard control received invalid JSON.",
+		},
+	});
+}
+
+function handleControlAction(context, socket, message) {
+	const { state, staticAccounts } = context;
+	if (message.action === "selectAccount") {
+		const selector = String(message.accountSelector || "").trim();
+		if (!staticAccounts.some((item) => accountMatchesSelector(item, selector))) {
+			sendWebSocketJson(
+				socket,
+				dashboardControlAck(
+					message,
+					false,
+					"unknown_account",
+					"Mock account selector was not found.",
+				),
+			);
+			return;
+		}
+		state.fixedAccountSelector = selector;
+		state.lastPublishedAt = nowUnix();
+		sendWebSocketJson(
+			socket,
+			dashboardControlAck(message, true, "accepted", "Mock account selection updated."),
+		);
+		sendSnapshot(socket, context);
+		return;
+	}
+
+	if (message.action === "clearAccountSelection") {
+		state.fixedAccountSelector = null;
+		state.lastPublishedAt = nowUnix();
+		sendWebSocketJson(
+			socket,
+			dashboardControlAck(
+				message,
+				true,
+				"accepted",
+				"Mock account selection returned to balanced mode.",
+			),
+		);
+		sendSnapshot(socket, context);
+		return;
+	}
+
+	sendWebSocketJson(
+		socket,
+		dashboardControlAck(
+			message,
+			false,
+			"unsupported",
+			"Mock dashboard control action is unsupported.",
+		),
+	);
+}

--- a/dev/operator-dashboard-mock/server/http-routes.mjs
+++ b/dev/operator-dashboard-mock/server/http-routes.mjs
@@ -1,0 +1,58 @@
+import fs from "node:fs/promises";
+
+import {
+	accountsWithSelection,
+	usageEstimate,
+} from "../accounts.mjs";
+import { send } from "../websocket.mjs";
+
+export async function handleDashboardRequest(context, request, response) {
+	const { options } = context;
+	try {
+		if (request.method !== "GET") {
+			send(response, 405, "text/plain; charset=utf-8", "method not allowed");
+			return;
+		}
+		const url = new URL(request.url || "/", `http://${options.listenAddress}`);
+		if (url.pathname === "/" || url.pathname === "/dashboard") {
+			const html = await fs.readFile(options.dashboardHtml, "utf8");
+			send(response, 200, "text/html; charset=utf-8", html);
+			return;
+		}
+		if (url.pathname === "/api/accounts") {
+			sendAccountPayload(context, response);
+			return;
+		}
+		if (url.pathname === "/livez") {
+			send(response, 200, "text/plain; charset=utf-8", "ok");
+			return;
+		}
+
+		send(response, 404, "text/plain; charset=utf-8", "not found");
+	} catch (error) {
+		send(response, 500, "text/plain; charset=utf-8", error?.message || "mock server error");
+	}
+}
+
+function sendAccountPayload(context, response) {
+	const { state, staticAccounts } = context;
+	const controlledAccounts = accountsWithSelection(staticAccounts, state.fixedAccountSelector);
+	send(
+		response,
+		200,
+		"application/json; charset=utf-8",
+		JSON.stringify({
+			accounts_path: "/tmp/decodex-mock/accounts.jsonl",
+			global_config_path: "/tmp/decodex-mock/config.toml",
+			codex_auth_path: "/tmp/decodex-mock/auth.json",
+			codex_auth: null,
+			control: {
+				mode: state.fixedAccountSelector ? "fixed" : "balanced",
+				account_selector: state.fixedAccountSelector || null,
+			},
+			accounts: controlledAccounts,
+			usage_estimate: usageEstimate(controlledAccounts),
+			usage_probe_error: null,
+		}),
+	);
+}

--- a/dev/operator-dashboard-mock/server/index.mjs
+++ b/dev/operator-dashboard-mock/server/index.mjs
@@ -1,0 +1,14 @@
+import http from "node:http";
+
+import { handleDashboardUpgrade } from "./control-socket.mjs";
+import { handleDashboardRequest } from "./http-routes.mjs";
+
+export function createMockDashboardServer(context) {
+	const server = http.createServer((request, response) => {
+		handleDashboardRequest(context, request, response);
+	});
+	server.on("upgrade", (request, socket) => {
+		handleDashboardUpgrade(context, request, socket);
+	});
+	return server;
+}

--- a/dev/operator-dashboard-mock/server/state.mjs
+++ b/dev/operator-dashboard-mock/server/state.mjs
@@ -1,0 +1,16 @@
+import { nowUnix } from "../time.mjs";
+
+export function createMockServerState(staticAccounts) {
+	return {
+		fixedAccountSelector: initialFixedAccountSelector(staticAccounts),
+		lastPublishedAt: nowUnix(),
+	};
+}
+
+function initialFixedAccountSelector(staticAccounts) {
+	return (
+		staticAccounts.find((item) => item.status === "selected")?.account_email ||
+		staticAccounts[0]?.account_email ||
+		null
+	);
+}


### PR DESCRIPTION
## Summary
- split dev/operator-dashboard-mock.mjs into server, HTTP route, WebSocket control, and state modules
- keep the existing CLI path and arguments unchanged
- preserve the account selection state flow used by HTTP and WebSocket snapshots

## Validation
- node --check dev/operator-dashboard-mock.mjs and new server modules
- mock server smoke for /livez, /dashboard with explicit dashboard HTML, /api/accounts, and WebSocket upgrade
- git diff --check
- diff guard for no added Rust allow/expect, wildcard imports, include/path/super tricks, or mod.rs