### PR TITLE
Fix account panel window resizing

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -75,6 +75,7 @@ struct AccountPanelView: View {
 		.controlSize(.small)
 		.symbolRenderingMode(.hierarchical)
 		.animation(PanelMotion.panelLayout, value: panelAnimationKey)
+		.sizesPanelWindowToContent()
 	}
 
 	private var accountList: some View {

--- a/apps/decodex-app/Sources/DecodexApp/PanelWindowSizing.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelWindowSizing.swift
@@ -1,0 +1,186 @@
+import AppKit
+import SwiftUI
+
+private struct PanelWindowContentSizeKey: PreferenceKey {
+	static let defaultValue = CGSize.zero
+
+	static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+		let next = nextValue()
+		guard next != .zero else {
+			return
+		}
+		value = next
+	}
+}
+
+private struct PanelWindowSizeReporter: NSViewRepresentable {
+	let contentSize: CGSize
+
+	func makeNSView(context: Context) -> NSView {
+		let view = PanelWindowSizingView(frame: .zero)
+		view.didMoveToWindow = { [weak coordinator = context.coordinator] view in
+			coordinator?.retryResizeAfterWindowAttachment(from: view)
+		}
+		return view
+	}
+
+	func updateNSView(_ nsView: NSView, context: Context) {
+		context.coordinator.scheduleResize(from: nsView, contentSize: contentSize)
+	}
+
+	func makeCoordinator() -> Coordinator {
+		Coordinator()
+	}
+
+	final class Coordinator {
+		private var lastAppliedSize = NSSize.zero
+		private var pendingSize = CGSize.zero
+		private var resizeIsScheduled = false
+
+		@MainActor
+		func scheduleResize(from view: NSView, contentSize: CGSize) {
+			guard contentSize.width > 0, contentSize.height > 0 else {
+				return
+			}
+
+			pendingSize = contentSize
+			guard resizeIsScheduled == false else {
+				return
+			}
+
+			resizeIsScheduled = true
+			DispatchQueue.main.async { [weak self, weak view] in
+				guard let self, let view else {
+					return
+				}
+				self.resizeIsScheduled = false
+				self.resizeWindow(from: view, contentSize: self.pendingSize)
+			}
+		}
+
+		@MainActor
+		private func resizeWindow(from view: NSView, contentSize: CGSize) {
+			guard let window = view.window else {
+				return
+			}
+
+			let targetSize = PanelWindowSizingLayout.roundedContentSize(for: contentSize)
+			guard Self.sizeDiffers(targetSize, lastAppliedSize)
+				|| Self.sizeDiffers(targetSize, window.contentLayoutRect.size)
+			else {
+				return
+			}
+
+			let frame = PanelWindowSizingLayout.frame(
+				forContentSize: targetSize,
+				currentFrame: window.frame
+			) { contentSize in
+				window.frameRect(forContentRect: NSRect(origin: .zero, size: contentSize)).size
+			} visibleFrame: {
+				(window.screen ?? NSScreen.main)?.visibleFrame
+			}
+			window.setFrame(frame, display: true)
+			lastAppliedSize = targetSize
+		}
+
+		@MainActor
+		func retryResizeAfterWindowAttachment(from view: NSView) {
+			guard pendingSize != .zero else {
+				return
+			}
+
+			scheduleResize(from: view, contentSize: pendingSize)
+		}
+
+		private static func sizeDiffers(_ lhs: NSSize, _ rhs: NSSize) -> Bool {
+			abs(lhs.width - rhs.width) > 0.5 || abs(lhs.height - rhs.height) > 0.5
+		}
+	}
+}
+
+private final class PanelWindowSizingView: NSView {
+	var didMoveToWindow: ((PanelWindowSizingView) -> Void)?
+
+	override func viewDidMoveToWindow() {
+		super.viewDidMoveToWindow()
+		didMoveToWindow?(self)
+	}
+}
+
+enum PanelWindowSizingLayout {
+	private static let placementMargin: CGFloat = 8
+
+	static func roundedContentSize(for contentSize: CGSize) -> NSSize {
+		NSSize(
+			width: ceil(contentSize.width),
+			height: ceil(contentSize.height)
+		)
+	}
+
+	static func frame(
+		forContentSize contentSize: NSSize,
+		currentFrame: NSRect,
+		frameSizeForContentSize: (NSSize) -> NSSize,
+		visibleFrame: () -> NSRect?
+	) -> NSRect {
+		let frameSize = frameSizeForContentSize(contentSize)
+		let proposedFrame = NSRect(
+			x: currentFrame.midX - frameSize.width / 2,
+			y: currentFrame.maxY - frameSize.height,
+			width: frameSize.width,
+			height: frameSize.height
+		)
+		guard let visibleFrame = visibleFrame() else {
+			return proposedFrame
+		}
+
+		return NSRect(
+			x: clamped(
+				proposedFrame.origin.x,
+				min: visibleFrame.minX + placementMargin,
+				max: visibleFrame.maxX - frameSize.width - placementMargin
+			),
+			y: clamped(
+				proposedFrame.origin.y,
+				min: visibleFrame.minY + placementMargin,
+				max: visibleFrame.maxY - frameSize.height - placementMargin
+			),
+			width: frameSize.width,
+			height: frameSize.height
+		)
+	}
+
+	private static func clamped(_ value: CGFloat, min: CGFloat, max: CGFloat) -> CGFloat {
+		guard min <= max else {
+			return min
+		}
+
+		return Swift.min(Swift.max(value, min), max)
+	}
+}
+
+private struct PanelWindowSizingModifier: ViewModifier {
+	@State private var contentSize = CGSize.zero
+
+	func body(content: Content) -> some View {
+		content
+			.background {
+				GeometryReader { proxy in
+					Color.clear.preference(key: PanelWindowContentSizeKey.self, value: proxy.size)
+				}
+			}
+			.onPreferenceChange(PanelWindowContentSizeKey.self) { size in
+				contentSize = size
+			}
+			.background {
+				PanelWindowSizeReporter(contentSize: contentSize)
+					.frame(width: 0, height: 0)
+			}
+	}
+}
+
+extension View {
+	func sizesPanelWindowToContent() -> some View {
+		modifier(PanelWindowSizingModifier())
+	}
+}

--- a/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
@@ -1,0 +1,56 @@
+import AppKit
+@testable import DecodexApp
+import XCTest
+
+final class PanelWindowSizingLayoutTests: XCTestCase {
+	func testRoundedContentSizeCeilsFractionalDimensions() {
+		let size = PanelWindowSizingLayout.roundedContentSize(for: CGSize(width: 339.2, height: 641.1))
+
+		XCTAssertEqual(size, NSSize(width: 340, height: 642))
+	}
+
+	func testFrameKeepsTopEdgeAndCenterWhenContentShrinks() {
+		let currentFrame = NSRect(x: 120, y: 200, width: 360, height: 700)
+		let frame = PanelWindowSizingLayout.frame(
+			forContentSize: NSSize(width: 322, height: 520),
+			currentFrame: currentFrame
+		) { contentSize in
+			NSSize(width: contentSize.width + 18, height: contentSize.height + 18)
+		} visibleFrame: {
+			NSRect(x: 0, y: 0, width: 1_000, height: 1_000)
+		}
+
+		XCTAssertEqual(frame.width, 340)
+		XCTAssertEqual(frame.height, 538)
+		XCTAssertEqual(frame.midX, currentFrame.midX)
+		XCTAssertEqual(frame.maxY, currentFrame.maxY)
+	}
+
+	func testFrameClampsInsideVisibleFrameWhenContentGrowsNearScreenEdge() {
+		let frame = PanelWindowSizingLayout.frame(
+			forContentSize: NSSize(width: 420, height: 360),
+			currentFrame: NSRect(x: 700, y: 620, width: 340, height: 220)
+		) { contentSize in
+			contentSize
+		} visibleFrame: {
+			NSRect(x: 0, y: 0, width: 800, height: 700)
+		}
+
+		XCTAssertEqual(frame.minX, 800 - 420 - 8)
+		XCTAssertEqual(frame.maxY, 700 - 8)
+	}
+
+	func testOversizedFrameFallsBackToVisibleFrameLeadingMargin() {
+		let frame = PanelWindowSizingLayout.frame(
+			forContentSize: NSSize(width: 900, height: 760),
+			currentFrame: NSRect(x: 100, y: 100, width: 340, height: 220)
+		) { contentSize in
+			contentSize
+		} visibleFrame: {
+			NSRect(x: 0, y: 0, width: 800, height: 700)
+		}
+
+		XCTAssertEqual(frame.minX, 8)
+		XCTAssertEqual(frame.minY, 8)
+	}
+}


### PR DESCRIPTION
## Summary
- resize the Decodex App menu-bar panel window to measured SwiftUI content so shortened account content does not leave a transparent glass tail
- retry sizing after AppKit window attachment and clamp the resized frame to the visible screen
- add layout tests for shrink anchoring, edge clamping, oversized fallback, and fractional sizing

## Validation
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app
- cargo make check
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer scripts/macos/test_decodex_app_stage.sh

## Review
- subagent review found no landing blockers after the attachment retry and visible-frame clamp changes