### PR TITLE
Modularize runtime marker and retry status code

### DIFF
--- a/apps/decodex/src/orchestrator/execution_failure/retryable_writeback.rs
+++ b/apps/decodex/src/orchestrator/execution_failure/retryable_writeback.rs
@@ -1,13 +1,15 @@
+mod schedule;
+
+pub(crate) use schedule::write_retry_schedule_marker_for_runtime_retry;
+
 use crate::{
 	orchestrator::execution_failure::{
-		self, AppServerCapabilityPreflightFailure, AppServerPhaseGoalFailure,
-		AppServerTransportFailure, AppServerZeroEvidenceStartFailure, FailureHandlingContext,
-		HarnessOutcomeKind, IssueDispatchMode, IssueRunPlan, IssueTracker, OffsetDateTime,
-		RETRYABLE_FAILED_START_CLEANUP_EVENT_TYPE, RepoGateFailure, Report, Result, RetryComment,
-		RetryKind, StalledRunNeedsAttention, WorkflowDocument,
-		retained_progress_source_error_class,
+		self, AppServerCapabilityPreflightFailure, AppServerTransportFailure,
+		AppServerZeroEvidenceStartFailure, FailureHandlingContext, HarnessOutcomeKind,
+		IssueDispatchMode, IssueTracker, RETRYABLE_FAILED_START_CLEANUP_EVENT_TYPE,
+		RepoGateFailure, Report, Result, RetryComment, retained_progress_source_error_class,
 	},
-	state, tracker,
+	tracker,
 };
 
 pub(super) fn apply_retryable_failure_writeback<T>(
@@ -74,38 +76,6 @@ where
 	cleanup_retryable_failed_start_ownership(context, error)?;
 
 	Ok(())
-}
-
-pub(crate) fn write_retry_schedule_marker_for_runtime_retry(
-	error: &Report,
-	workflow: &WorkflowDocument,
-	issue_run: &IssueRunPlan,
-	retry_budget_attempts: i64,
-) -> Result<()> {
-	if error.downcast_ref::<StalledRunNeedsAttention>().is_some() {
-		return write_failure_retry_schedule_marker(workflow, issue_run, retry_budget_attempts);
-	}
-	if error
-		.downcast_ref::<AppServerCapabilityPreflightFailure>()
-		.is_some_and(AppServerCapabilityPreflightFailure::is_retryable_timeout)
-	{
-		return write_failure_retry_schedule_marker(workflow, issue_run, retry_budget_attempts);
-	}
-	if error
-		.downcast_ref::<AppServerPhaseGoalFailure>()
-		.is_some_and(AppServerPhaseGoalFailure::is_terminal_path_missing)
-	{
-		return write_failure_retry_schedule_marker(workflow, issue_run, retry_budget_attempts);
-	}
-
-	let Some(repo_gate_failure) = error.downcast_ref::<RepoGateFailure>() else {
-		return Ok(());
-	};
-	let Some(retry_kind) = repo_gate_failure.retry_schedule_kind() else {
-		return Ok(());
-	};
-
-	write_retry_schedule_marker(workflow, issue_run, retry_budget_attempts, retry_kind)
 }
 
 fn cleanup_retryable_failed_start_ownership<T>(
@@ -252,33 +222,4 @@ fn retryable_failure_validation_result(
 	} else {
 		None
 	}
-}
-
-fn write_failure_retry_schedule_marker(
-	workflow: &WorkflowDocument,
-	issue_run: &IssueRunPlan,
-	retry_budget_attempts: i64,
-) -> Result<()> {
-	write_retry_schedule_marker(workflow, issue_run, retry_budget_attempts, "failure")
-}
-
-fn write_retry_schedule_marker(
-	workflow: &WorkflowDocument,
-	issue_run: &IssueRunPlan,
-	retry_budget_attempts: i64,
-	retry_kind: &str,
-) -> Result<()> {
-	let retry_attempt = u32::try_from(retry_budget_attempts).unwrap_or(u32::MAX).max(1);
-	let delay = execution_failure::retry_delay(RetryKind::Failure, retry_attempt, workflow);
-	let retry_ready_at_unix_epoch = OffsetDateTime::now_utc().unix_timestamp().saturating_add(
-		i64::try_from((delay.as_millis().saturating_add(999)) / 1_000).unwrap_or(i64::MAX),
-	);
-
-	state::write_run_retry_schedule(
-		&issue_run.worktree.path,
-		&issue_run.run_id,
-		issue_run.attempt_number,
-		retry_kind,
-		retry_ready_at_unix_epoch,
-	)
 }

--- a/apps/decodex/src/orchestrator/execution_failure/retryable_writeback/schedule.rs
+++ b/apps/decodex/src/orchestrator/execution_failure/retryable_writeback/schedule.rs
@@ -1,0 +1,69 @@
+use crate::{
+	orchestrator::execution_failure::{
+		self, AppServerCapabilityPreflightFailure, AppServerPhaseGoalFailure, IssueRunPlan,
+		OffsetDateTime, RepoGateFailure, Report, Result, RetryKind, StalledRunNeedsAttention,
+		WorkflowDocument,
+	},
+	state,
+};
+
+pub(crate) fn write_retry_schedule_marker_for_runtime_retry(
+	error: &Report,
+	workflow: &WorkflowDocument,
+	issue_run: &IssueRunPlan,
+	retry_budget_attempts: i64,
+) -> Result<()> {
+	if error.downcast_ref::<StalledRunNeedsAttention>().is_some() {
+		return write_failure_retry_schedule_marker(workflow, issue_run, retry_budget_attempts);
+	}
+	if error
+		.downcast_ref::<AppServerCapabilityPreflightFailure>()
+		.is_some_and(AppServerCapabilityPreflightFailure::is_retryable_timeout)
+	{
+		return write_failure_retry_schedule_marker(workflow, issue_run, retry_budget_attempts);
+	}
+	if error
+		.downcast_ref::<AppServerPhaseGoalFailure>()
+		.is_some_and(AppServerPhaseGoalFailure::is_terminal_path_missing)
+	{
+		return write_failure_retry_schedule_marker(workflow, issue_run, retry_budget_attempts);
+	}
+
+	let Some(repo_gate_failure) = error.downcast_ref::<RepoGateFailure>() else {
+		return Ok(());
+	};
+	let Some(retry_kind) = repo_gate_failure.retry_schedule_kind() else {
+		return Ok(());
+	};
+
+	write_retry_schedule_marker(workflow, issue_run, retry_budget_attempts, retry_kind)
+}
+
+fn write_failure_retry_schedule_marker(
+	workflow: &WorkflowDocument,
+	issue_run: &IssueRunPlan,
+	retry_budget_attempts: i64,
+) -> Result<()> {
+	write_retry_schedule_marker(workflow, issue_run, retry_budget_attempts, "failure")
+}
+
+fn write_retry_schedule_marker(
+	workflow: &WorkflowDocument,
+	issue_run: &IssueRunPlan,
+	retry_budget_attempts: i64,
+	retry_kind: &str,
+) -> Result<()> {
+	let retry_attempt = u32::try_from(retry_budget_attempts).unwrap_or(u32::MAX).max(1);
+	let delay = execution_failure::retry_delay(RetryKind::Failure, retry_attempt, workflow);
+	let retry_ready_at_unix_epoch = OffsetDateTime::now_utc().unix_timestamp().saturating_add(
+		i64::try_from((delay.as_millis().saturating_add(999)) / 1_000).unwrap_or(i64::MAX),
+	);
+
+	state::write_run_retry_schedule(
+		&issue_run.worktree.path,
+		&issue_run.run_id,
+		issue_run.attempt_number,
+		retry_kind,
+		retry_ready_at_unix_epoch,
+	)
+}

--- a/apps/decodex/src/orchestrator/status_queued_attention/status.rs
+++ b/apps/decodex/src/orchestrator/status_queued_attention/status.rs
@@ -1,16 +1,18 @@
+mod readback;
+mod retry;
+mod timing;
+
 use crate::{
 	config::ServiceConfig,
 	orchestrator::{
-		self, ATTENTION_ERROR_EVIDENCE_MISSING, AUTHORITY_DECISION_REQUEST_EVENT_TYPE,
-		OperatorAuthorityDecisionRequestStatus, OperatorLoopStatus,
-		OperatorQueuedIssueAttentionStatus, QUEUE_REASON_LINEAR_ACTIVE_LABEL_PRESENT,
-		WorktreeTrackedChangeState, marker_process_liveness_for_marker,
+		self, ATTENTION_ERROR_EVIDENCE_MISSING, OperatorQueuedIssueAttentionStatus,
+		QUEUE_REASON_LINEAR_ACTIVE_LABEL_PRESENT, WorktreeTrackedChangeState,
+		marker_process_liveness_for_marker,
 		status_queued_attention::{
 			active_label,
 			context::{self, OperatorQueuedIssueWorktreeContext},
 			records, summary,
 		},
-		status_run_projection,
 	},
 	prelude::Result,
 	state::{RunActivityMarker, StateStore},
@@ -41,9 +43,9 @@ where
 	let OperatorQueuedIssueWorktreeContext { path: worktree_path, marker, marker_unreadable } =
 		context::operator_queued_issue_worktree_context(project, state_store, issue)?;
 	let retry_budget_attempts =
-		operator_queued_issue_retry_budget_attempts(state_store, issue, marker.as_ref())?;
+		retry::operator_queued_issue_retry_budget_attempts(state_store, issue, marker.as_ref())?;
 	let retry_budget_max_attempts = i64::from(workflow.frontmatter().execution().max_attempts());
-	let auto_retry_blocked_reason = operator_queued_issue_auto_retry_blocked_reason(reason);
+	let auto_retry_blocked_reason = retry::operator_queued_issue_auto_retry_blocked_reason(reason);
 	let attention_record = records::operator_queued_issue_latest_attention_record(
 		tracker,
 		project,
@@ -57,26 +59,26 @@ where
 		marker.as_ref(),
 		reason,
 	)?;
-	let attention_error_class = if private_evidence_missing {
-		Some(String::from(ATTENTION_ERROR_EVIDENCE_MISSING))
-	} else {
-		attention_record.as_ref().and_then(|record| record.error_class.clone())
-	};
-	let decision_request = operator_queued_issue_decision_request_status(
+	let attention_error_class = operator_queued_issue_attention_error_class(
+		private_evidence_missing,
+		attention_record.as_ref(),
+	);
+	let decision_request = readback::operator_queued_issue_decision_request_status(
 		project,
 		state_store,
 		issue,
 		attention_record.as_ref(),
 		marker.as_ref(),
 	)?;
-	let loop_status = operator_queued_issue_loop_status(
+	let loop_status = readback::operator_queued_issue_loop_status(
 		project,
 		state_store,
 		issue,
 		attention_record.as_ref(),
 		marker.as_ref(),
 	)?;
-	let attempt_status = operator_queued_issue_attempt_status(state_store, marker.as_ref())?;
+	let attempt_status =
+		readback::operator_queued_issue_attempt_status(state_store, marker.as_ref())?;
 	let worktree_tracked_change_state = if marker_unreadable {
 		WorktreeTrackedChangeState::Unknown
 	} else {
@@ -126,8 +128,8 @@ where
 		attention_next_action,
 		retry_budget_attempt_count: (retry_budget_attempts > 0).then_some(retry_budget_attempts),
 		retry_budget_max_attempts,
-		last_activity_at: operator_queued_issue_marker_activity_at(marker.as_ref()),
-		last_progress_at: operator_queued_issue_marker_progress_at(marker.as_ref()),
+		last_activity_at: timing::operator_queued_issue_marker_activity_at(marker.as_ref()),
+		last_progress_at: timing::operator_queued_issue_marker_progress_at(marker.as_ref()),
 		last_event_type: marker
 			.as_ref()
 			.and_then(RunActivityMarker::last_event_type)
@@ -141,36 +143,14 @@ where
 	}))
 }
 
-fn operator_queued_issue_marker_activity_at(marker: Option<&RunActivityMarker>) -> Option<String> {
-	marker.and_then(RunActivityMarker::last_activity_unix_epoch).and_then(|unix_epoch| {
-		status_run_projection::format_optional_unix_timestamp(Some(unix_epoch))
-	})
-}
-
-fn operator_queued_issue_marker_progress_at(marker: Option<&RunActivityMarker>) -> Option<String> {
-	marker.and_then(RunActivityMarker::last_progress_unix_epoch).and_then(|unix_epoch| {
-		status_run_projection::format_optional_unix_timestamp(Some(unix_epoch))
-	})
-}
-
-fn operator_queued_issue_retry_budget_attempts(
-	state_store: &StateStore,
-	issue: &TrackerIssue,
-	marker: Option<&RunActivityMarker>,
-) -> Result<i64> {
-	let state_retry_attempts = state_store.retry_budget_attempt_count(&issue.id)?;
-	let marker_retry_attempts =
-		marker.and_then(RunActivityMarker::retry_budget_attempt_count).unwrap_or(0);
-
-	Ok(state_retry_attempts.max(marker_retry_attempts))
-}
-
-fn operator_queued_issue_auto_retry_blocked_reason(reason: &str) -> Option<String> {
-	match reason {
-		"issue_needs_attention" => Some(String::from("needs_attention_label")),
-		QUEUE_REASON_LINEAR_ACTIVE_LABEL_PRESENT =>
-			Some(String::from(QUEUE_REASON_LINEAR_ACTIVE_LABEL_PRESENT)),
-		_ => None,
+fn operator_queued_issue_attention_error_class(
+	private_evidence_missing: bool,
+	attention_record: Option<&LinearExecutionEventRecord>,
+) -> Option<String> {
+	if private_evidence_missing {
+		Some(String::from(ATTENTION_ERROR_EVIDENCE_MISSING))
+	} else {
+		attention_record.and_then(|record| record.error_class.clone())
 	}
 }
 
@@ -184,76 +164,6 @@ fn operator_queued_issue_attention_next_action(
 	} else {
 		recorded_next_action.or(stale_active_next_action)
 	}
-}
-
-fn operator_queued_issue_attempt_status(
-	state_store: &StateStore,
-	marker: Option<&RunActivityMarker>,
-) -> Result<Option<String>> {
-	Ok(marker
-		.and_then(|marker| state_store.run_attempt(marker.run_id()).transpose())
-		.transpose()?
-		.map(|run_attempt| run_attempt.status().to_owned()))
-}
-
-fn operator_queued_issue_loop_status(
-	project: &ServiceConfig,
-	state_store: &StateStore,
-	issue: &TrackerIssue,
-	attention_record: Option<&LinearExecutionEventRecord>,
-	marker: Option<&RunActivityMarker>,
-) -> Result<Option<OperatorLoopStatus>> {
-	let run_id = attention_record
-		.map(|record| record.run_id.as_str())
-		.or_else(|| marker.map(RunActivityMarker::run_id));
-	let attempt_number = attention_record
-		.map(|record| record.attempt_number)
-		.or_else(|| marker.map(RunActivityMarker::attempt_number));
-
-	match (run_id, attempt_number) {
-		(Some(run_id), Some(attempt_number)) =>
-			status_run_projection::operator_loop_status_for_run(
-				project,
-				state_store,
-				&issue.id,
-				run_id,
-				attempt_number,
-				Some("handoff"),
-				None,
-			)
-			.map(Some),
-		_ => Ok(None),
-	}
-}
-
-fn operator_queued_issue_decision_request_status(
-	project: &ServiceConfig,
-	state_store: &StateStore,
-	issue: &TrackerIssue,
-	attention_record: Option<&LinearExecutionEventRecord>,
-	marker: Option<&RunActivityMarker>,
-) -> Result<Option<OperatorAuthorityDecisionRequestStatus>> {
-	let run_id = attention_record
-		.map(|record| record.run_id.as_str())
-		.or_else(|| marker.map(RunActivityMarker::run_id));
-	let attempt_number = attention_record
-		.map(|record| record.attempt_number)
-		.or_else(|| marker.map(RunActivityMarker::attempt_number));
-	let (Some(run_id), Some(attempt_number)) = (run_id, attempt_number) else {
-		return Ok(None);
-	};
-	let events = state_store.list_private_execution_events(
-		project.service_id(),
-		&issue.id,
-		run_id,
-		attempt_number,
-	)?;
-
-	Ok(events
-		.iter()
-		.rev()
-		.find(|event| event.event_type() == AUTHORITY_DECISION_REQUEST_EVENT_TYPE)
-		.and_then(records::operator_authority_decision_request_status_from_event))
 }
 
 fn operator_queued_issue_private_evidence_missing(

--- a/apps/decodex/src/orchestrator/status_queued_attention/status/readback.rs
+++ b/apps/decodex/src/orchestrator/status_queued_attention/status/readback.rs
@@ -1,0 +1,80 @@
+use crate::{
+	config::ServiceConfig,
+	orchestrator::{
+		AUTHORITY_DECISION_REQUEST_EVENT_TYPE, OperatorAuthorityDecisionRequestStatus,
+		OperatorLoopStatus, status_queued_attention::records, status_run_projection,
+	},
+	prelude::Result,
+	state::{RunActivityMarker, StateStore},
+	tracker::{TrackerIssue, records::LinearExecutionEventRecord},
+};
+
+pub(crate) fn operator_queued_issue_attempt_status(
+	state_store: &StateStore,
+	marker: Option<&RunActivityMarker>,
+) -> Result<Option<String>> {
+	Ok(marker
+		.and_then(|marker| state_store.run_attempt(marker.run_id()).transpose())
+		.transpose()?
+		.map(|run_attempt| run_attempt.status().to_owned()))
+}
+
+pub(crate) fn operator_queued_issue_loop_status(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	issue: &TrackerIssue,
+	attention_record: Option<&LinearExecutionEventRecord>,
+	marker: Option<&RunActivityMarker>,
+) -> Result<Option<OperatorLoopStatus>> {
+	let run_id = attention_record
+		.map(|record| record.run_id.as_str())
+		.or_else(|| marker.map(RunActivityMarker::run_id));
+	let attempt_number = attention_record
+		.map(|record| record.attempt_number)
+		.or_else(|| marker.map(RunActivityMarker::attempt_number));
+
+	match (run_id, attempt_number) {
+		(Some(run_id), Some(attempt_number)) =>
+			status_run_projection::operator_loop_status_for_run(
+				project,
+				state_store,
+				&issue.id,
+				run_id,
+				attempt_number,
+				Some("handoff"),
+				None,
+			)
+			.map(Some),
+		_ => Ok(None),
+	}
+}
+
+pub(crate) fn operator_queued_issue_decision_request_status(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	issue: &TrackerIssue,
+	attention_record: Option<&LinearExecutionEventRecord>,
+	marker: Option<&RunActivityMarker>,
+) -> Result<Option<OperatorAuthorityDecisionRequestStatus>> {
+	let run_id = attention_record
+		.map(|record| record.run_id.as_str())
+		.or_else(|| marker.map(RunActivityMarker::run_id));
+	let attempt_number = attention_record
+		.map(|record| record.attempt_number)
+		.or_else(|| marker.map(RunActivityMarker::attempt_number));
+	let (Some(run_id), Some(attempt_number)) = (run_id, attempt_number) else {
+		return Ok(None);
+	};
+	let events = state_store.list_private_execution_events(
+		project.service_id(),
+		&issue.id,
+		run_id,
+		attempt_number,
+	)?;
+
+	Ok(events
+		.iter()
+		.rev()
+		.find(|event| event.event_type() == AUTHORITY_DECISION_REQUEST_EVENT_TYPE)
+		.and_then(records::operator_authority_decision_request_status_from_event))
+}

--- a/apps/decodex/src/orchestrator/status_queued_attention/status/retry.rs
+++ b/apps/decodex/src/orchestrator/status_queued_attention/status/retry.rs
@@ -1,0 +1,27 @@
+use crate::{
+	orchestrator::QUEUE_REASON_LINEAR_ACTIVE_LABEL_PRESENT,
+	prelude::Result,
+	state::{RunActivityMarker, StateStore},
+	tracker::TrackerIssue,
+};
+
+pub(crate) fn operator_queued_issue_retry_budget_attempts(
+	state_store: &StateStore,
+	issue: &TrackerIssue,
+	marker: Option<&RunActivityMarker>,
+) -> Result<i64> {
+	let state_retry_attempts = state_store.retry_budget_attempt_count(&issue.id)?;
+	let marker_retry_attempts =
+		marker.and_then(RunActivityMarker::retry_budget_attempt_count).unwrap_or(0);
+
+	Ok(state_retry_attempts.max(marker_retry_attempts))
+}
+
+pub(crate) fn operator_queued_issue_auto_retry_blocked_reason(reason: &str) -> Option<String> {
+	match reason {
+		"issue_needs_attention" => Some(String::from("needs_attention_label")),
+		QUEUE_REASON_LINEAR_ACTIVE_LABEL_PRESENT =>
+			Some(String::from(QUEUE_REASON_LINEAR_ACTIVE_LABEL_PRESENT)),
+		_ => None,
+	}
+}

--- a/apps/decodex/src/orchestrator/status_queued_attention/status/timing.rs
+++ b/apps/decodex/src/orchestrator/status_queued_attention/status/timing.rs
@@ -1,0 +1,17 @@
+use crate::{orchestrator::status_run_projection, state::RunActivityMarker};
+
+pub(crate) fn operator_queued_issue_marker_activity_at(
+	marker: Option<&RunActivityMarker>,
+) -> Option<String> {
+	marker.and_then(RunActivityMarker::last_activity_unix_epoch).and_then(|unix_epoch| {
+		status_run_projection::format_optional_unix_timestamp(Some(unix_epoch))
+	})
+}
+
+pub(crate) fn operator_queued_issue_marker_progress_at(
+	marker: Option<&RunActivityMarker>,
+) -> Option<String> {
+	marker.and_then(RunActivityMarker::last_progress_unix_epoch).and_then(|unix_epoch| {
+		status_run_projection::format_optional_unix_timestamp(Some(unix_epoch))
+	})
+}

--- a/apps/decodex/src/state/run_activity_marker/storage.rs
+++ b/apps/decodex/src/state/run_activity_marker/storage.rs
@@ -1,20 +1,14 @@
-use std::{
-	fs::{self, OpenOptions},
-	io::{ErrorKind, Write as _},
-	path::Path,
-	process,
-	sync::atomic::{AtomicU64, Ordering},
-};
+mod account_preservation;
+mod atomic_write;
+mod parse;
+mod serialize;
+
+use std::{fs, io::ErrorKind, path::Path};
 
 use crate::{
-	prelude::{Result, eyre},
-	state::{
-		CodexAccountActivitySummary, RUN_ACTIVITY_MARKER_FILE,
-		run_activity_marker::record::RunActivityMarkerRecord,
-	},
+	prelude::Result,
+	state::{RUN_ACTIVITY_MARKER_FILE, run_activity_marker::record::RunActivityMarkerRecord},
 };
-
-static RUN_ACTIVITY_MARKER_WRITE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn read_run_activity_marker_record(
@@ -26,58 +20,8 @@ pub(crate) fn read_run_activity_marker_record(
 		Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
 		Err(error) => return Err(error.into()),
 	};
-	let mut marker = RunActivityMarkerRecord::default();
 
-	for line in marker_body.lines() {
-		let Some((key, value)) = line.split_once('=') else {
-			continue;
-		};
-
-		match key {
-			"run_id" => marker.run_id = Some(value.to_owned()),
-			"attempt_number" => marker.attempt_number = value.parse::<i64>().ok(),
-			"process_id" => marker.process_id = value.parse::<u32>().ok(),
-			"host_boot_id" => marker.host_boot_id = Some(value.to_owned()),
-			"process_start_identity" => marker.process_start_identity = Some(value.to_owned()),
-			"last_activity_unix_epoch" =>
-				marker.last_activity_unix_epoch = value.parse::<i64>().ok(),
-			"last_protocol_activity_unix_epoch" =>
-				marker.last_protocol_activity_unix_epoch = value.parse::<i64>().ok(),
-			"last_progress_unix_epoch" =>
-				marker.last_progress_unix_epoch = value.parse::<i64>().ok(),
-			"current_operation" => marker.current_operation = Some(value.to_owned()),
-			"thread_id" => marker.thread_id = Some(value.to_owned()),
-			"turn_id" => marker.turn_id = Some(value.to_owned()),
-			"thread_status" => marker.thread_status = Some(value.to_owned()),
-			"thread_active_flags" => marker.thread_active_flags = parse_marker_list(value),
-			"event_count" => marker.event_count = value.parse::<i64>().ok(),
-			"last_event_type" => marker.last_event_type = Some(value.to_owned()),
-			"effective_model" => marker.effective_model = Some(value.to_owned()),
-			"effective_model_provider" => marker.effective_model_provider = Some(value.to_owned()),
-			"effective_cwd" => marker.effective_cwd = Some(value.to_owned()),
-			"effective_approval_policy" =>
-				marker.effective_approval_policy = Some(value.to_owned()),
-			"effective_approvals_reviewer" =>
-				marker.effective_approvals_reviewer = Some(value.to_owned()),
-			"effective_sandbox_mode" => marker.effective_sandbox_mode = Some(value.to_owned()),
-			"child_agent_activity" =>
-				marker.child_agent_activity = serde_json::from_str(value).ok(),
-			"protocol_activity" => marker.protocol_activity = serde_json::from_str(value).ok(),
-			"account" => marker.account = serde_json::from_str(value).ok(),
-			"accounts" =>
-				if let Ok(accounts) = serde_json::from_str(value) {
-					marker.accounts = accounts;
-				},
-			"retry_budget_attempt_count" =>
-				marker.retry_budget_attempt_count = value.parse::<i64>().ok(),
-			"retry_kind" => marker.retry_kind = Some(value.to_owned()),
-			"retry_ready_at_unix_epoch" =>
-				marker.retry_ready_at_unix_epoch = value.parse::<i64>().ok(),
-			_ => {},
-		}
-	}
-
-	Ok(Some(marker))
+	Ok(Some(parse::parse_run_activity_marker_record(&marker_body)))
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -89,207 +33,16 @@ pub(crate) fn write_run_activity_marker_record(
 	let mut marker = marker.clone();
 
 	if let Some(current_marker) = read_run_activity_marker_record(worktree_path)? {
-		preserve_current_run_account_marker_fields(&current_marker, &mut marker);
+		account_preservation::preserve_current_run_account_marker_fields(
+			&current_marker,
+			&mut marker,
+		);
 	}
 
-	write_run_activity_marker_body_atomic(
+	atomic_write::write_run_activity_marker_body_atomic(
 		&marker_path,
-		&serialize_run_activity_marker_record(&marker),
+		&serialize::serialize_run_activity_marker_record(&marker),
 	)?;
 
 	Ok(())
-}
-
-fn preserve_current_run_account_marker_fields(
-	current: &RunActivityMarkerRecord,
-	next: &mut RunActivityMarkerRecord,
-) {
-	if current.run_id != next.run_id || current.attempt_number != next.attempt_number {
-		return;
-	}
-
-	let Some(current_account) = selected_marker_account(current).cloned() else {
-		return;
-	};
-	let keep_current_account = match next.account.as_ref() {
-		Some(next_account) =>
-			account_marker_observed_unix_epoch(&current_account)
-				> account_marker_observed_unix_epoch(next_account),
-		None => true,
-	};
-
-	if keep_current_account {
-		next.account = Some(current_account.clone());
-		next.accounts = if current.accounts.is_empty() {
-			vec![current_account]
-		} else {
-			current.accounts.clone()
-		};
-	} else if next.accounts.is_empty() && !current.accounts.is_empty() {
-		next.accounts = current.accounts.clone();
-	}
-}
-
-fn selected_marker_account(
-	marker: &RunActivityMarkerRecord,
-) -> Option<&CodexAccountActivitySummary> {
-	marker
-		.account
-		.as_ref()
-		.or_else(|| {
-			marker.accounts.iter().find(|account| account.status.eq_ignore_ascii_case("selected"))
-		})
-		.or_else(|| marker.accounts.first())
-}
-
-fn account_marker_observed_unix_epoch(account: &CodexAccountActivitySummary) -> i64 {
-	[account.selected_at_unix_epoch, account.checked_at_unix_epoch]
-		.into_iter()
-		.flatten()
-		.max()
-		.unwrap_or(0)
-}
-
-fn write_run_activity_marker_body_atomic(marker_path: &Path, body: &str) -> Result<()> {
-	let parent = marker_path.parent().ok_or_else(|| {
-		eyre::eyre!("activity marker path `{}` has no parent directory", marker_path.display())
-	})?;
-	let sequence = RUN_ACTIVITY_MARKER_WRITE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-	let temp_path =
-		parent.join(format!(".{RUN_ACTIVITY_MARKER_FILE}.{}.{}.tmp", process::id(), sequence,));
-	let result = (|| -> Result<()> {
-		let mut temp_file = OpenOptions::new().write(true).create_new(true).open(&temp_path)?;
-
-		temp_file.write_all(body.as_bytes())?;
-		temp_file.flush()?;
-
-		drop(temp_file);
-
-		fs::rename(&temp_path, marker_path)?;
-
-		Ok(())
-	})();
-
-	if result.is_err() {
-		let _ = fs::remove_file(&temp_path);
-	}
-
-	result
-}
-
-fn serialize_run_activity_marker_record(marker: &RunActivityMarkerRecord) -> String {
-	let mut body = String::new();
-
-	if let Some(run_id) = &marker.run_id {
-		body.push_str(&format!("run_id={run_id}\n"));
-	}
-	if let Some(attempt_number) = marker.attempt_number {
-		body.push_str(&format!("attempt_number={attempt_number}\n"));
-	}
-	if let Some(process_id) = marker.process_id {
-		body.push_str(&format!("process_id={process_id}\n"));
-	}
-	if let Some(host_boot_id) = &marker.host_boot_id {
-		body.push_str(&format!("host_boot_id={host_boot_id}\n"));
-	}
-	if let Some(process_start_identity) = &marker.process_start_identity {
-		body.push_str(&format!("process_start_identity={process_start_identity}\n"));
-	}
-	if let Some(last_activity_unix_epoch) = marker.last_activity_unix_epoch {
-		body.push_str(&format!("last_activity_unix_epoch={last_activity_unix_epoch}\n"));
-	}
-	if let Some(last_protocol_activity_unix_epoch) = marker.last_protocol_activity_unix_epoch {
-		body.push_str(&format!(
-			"last_protocol_activity_unix_epoch={last_protocol_activity_unix_epoch}\n"
-		));
-	}
-	if let Some(last_progress_unix_epoch) = marker.last_progress_unix_epoch {
-		body.push_str(&format!("last_progress_unix_epoch={last_progress_unix_epoch}\n"));
-	}
-	if let Some(current_operation) = &marker.current_operation {
-		body.push_str(&format!("current_operation={current_operation}\n"));
-	}
-	if let Some(thread_id) = &marker.thread_id {
-		body.push_str(&format!("thread_id={thread_id}\n"));
-	}
-	if let Some(turn_id) = &marker.turn_id {
-		body.push_str(&format!("turn_id={turn_id}\n"));
-	}
-	if let Some(thread_status) = &marker.thread_status {
-		body.push_str(&format!("thread_status={thread_status}\n"));
-	}
-
-	if !marker.thread_active_flags.is_empty() {
-		body.push_str(&format!("thread_active_flags={}\n", marker.thread_active_flags.join(",")));
-	}
-
-	if let Some(event_count) = marker.event_count {
-		body.push_str(&format!("event_count={event_count}\n"));
-	}
-	if let Some(last_event_type) = &marker.last_event_type {
-		body.push_str(&format!("last_event_type={last_event_type}\n"));
-	}
-	if let Some(effective_model) = &marker.effective_model {
-		body.push_str(&format!("effective_model={effective_model}\n"));
-	}
-	if let Some(effective_model_provider) = &marker.effective_model_provider {
-		body.push_str(&format!("effective_model_provider={effective_model_provider}\n"));
-	}
-	if let Some(effective_cwd) = &marker.effective_cwd {
-		body.push_str(&format!("effective_cwd={effective_cwd}\n"));
-	}
-	if let Some(effective_approval_policy) = &marker.effective_approval_policy {
-		body.push_str(&format!("effective_approval_policy={effective_approval_policy}\n"));
-	}
-	if let Some(effective_approvals_reviewer) = &marker.effective_approvals_reviewer {
-		body.push_str(&format!("effective_approvals_reviewer={effective_approvals_reviewer}\n"));
-	}
-	if let Some(effective_sandbox_mode) = &marker.effective_sandbox_mode {
-		body.push_str(&format!("effective_sandbox_mode={effective_sandbox_mode}\n"));
-	}
-	if let Some(child_agent_activity) = &marker.child_agent_activity
-		&& let Ok(summary_json) = serde_json::to_string(child_agent_activity)
-	{
-		body.push_str(&format!("child_agent_activity={summary_json}\n"));
-	}
-	if let Some(protocol_activity) = &marker.protocol_activity
-		&& let Ok(summary_json) = serde_json::to_string(protocol_activity)
-	{
-		body.push_str(&format!("protocol_activity={summary_json}\n"));
-	}
-
-	append_run_activity_marker_account_fields(&mut body, marker);
-	append_run_activity_marker_retry_fields(&mut body, marker);
-
-	body
-}
-
-fn append_run_activity_marker_account_fields(body: &mut String, marker: &RunActivityMarkerRecord) {
-	if let Some(account) = &marker.account
-		&& let Ok(summary_json) = serde_json::to_string(account)
-	{
-		body.push_str(&format!("account={summary_json}\n"));
-	}
-
-	if !marker.accounts.is_empty()
-		&& let Ok(accounts_json) = serde_json::to_string(&marker.accounts)
-	{
-		body.push_str(&format!("accounts={accounts_json}\n"));
-	}
-}
-
-fn append_run_activity_marker_retry_fields(body: &mut String, marker: &RunActivityMarkerRecord) {
-	if let Some(retry_budget_attempt_count) = marker.retry_budget_attempt_count {
-		body.push_str(&format!("retry_budget_attempt_count={retry_budget_attempt_count}\n"));
-	}
-	if let Some(retry_kind) = &marker.retry_kind {
-		body.push_str(&format!("retry_kind={retry_kind}\n"));
-	}
-	if let Some(retry_ready_at_unix_epoch) = marker.retry_ready_at_unix_epoch {
-		body.push_str(&format!("retry_ready_at_unix_epoch={retry_ready_at_unix_epoch}\n"));
-	}
-}
-
-fn parse_marker_list(value: &str) -> Vec<String> {
-	value.split(',').filter(|part| !part.is_empty()).map(str::to_owned).collect()
 }

--- a/apps/decodex/src/state/run_activity_marker/storage/account_preservation.rs
+++ b/apps/decodex/src/state/run_activity_marker/storage/account_preservation.rs
@@ -1,0 +1,53 @@
+use crate::state::{
+	CodexAccountActivitySummary, run_activity_marker::record::RunActivityMarkerRecord,
+};
+
+pub(crate) fn preserve_current_run_account_marker_fields(
+	current: &RunActivityMarkerRecord,
+	next: &mut RunActivityMarkerRecord,
+) {
+	if current.run_id != next.run_id || current.attempt_number != next.attempt_number {
+		return;
+	}
+
+	let Some(current_account) = selected_marker_account(current).cloned() else {
+		return;
+	};
+	let keep_current_account = match next.account.as_ref() {
+		Some(next_account) =>
+			account_marker_observed_unix_epoch(&current_account)
+				> account_marker_observed_unix_epoch(next_account),
+		None => true,
+	};
+
+	if keep_current_account {
+		next.account = Some(current_account.clone());
+		next.accounts = if current.accounts.is_empty() {
+			vec![current_account]
+		} else {
+			current.accounts.clone()
+		};
+	} else if next.accounts.is_empty() && !current.accounts.is_empty() {
+		next.accounts = current.accounts.clone();
+	}
+}
+
+fn selected_marker_account(
+	marker: &RunActivityMarkerRecord,
+) -> Option<&CodexAccountActivitySummary> {
+	marker
+		.account
+		.as_ref()
+		.or_else(|| {
+			marker.accounts.iter().find(|account| account.status.eq_ignore_ascii_case("selected"))
+		})
+		.or_else(|| marker.accounts.first())
+}
+
+fn account_marker_observed_unix_epoch(account: &CodexAccountActivitySummary) -> i64 {
+	[account.selected_at_unix_epoch, account.checked_at_unix_epoch]
+		.into_iter()
+		.flatten()
+		.max()
+		.unwrap_or(0)
+}

--- a/apps/decodex/src/state/run_activity_marker/storage/atomic_write.rs
+++ b/apps/decodex/src/state/run_activity_marker/storage/atomic_write.rs
@@ -1,0 +1,41 @@
+use std::{
+	fs::{self, OpenOptions},
+	io::Write as _,
+	path::Path,
+	process,
+	sync::atomic::{AtomicU64, Ordering},
+};
+
+use crate::{
+	prelude::{Result, eyre},
+	state::RUN_ACTIVITY_MARKER_FILE,
+};
+
+static RUN_ACTIVITY_MARKER_WRITE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn write_run_activity_marker_body_atomic(marker_path: &Path, body: &str) -> Result<()> {
+	let parent = marker_path.parent().ok_or_else(|| {
+		eyre::eyre!("activity marker path `{}` has no parent directory", marker_path.display())
+	})?;
+	let sequence = RUN_ACTIVITY_MARKER_WRITE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+	let temp_path =
+		parent.join(format!(".{RUN_ACTIVITY_MARKER_FILE}.{}.{}.tmp", process::id(), sequence,));
+	let result = (|| -> Result<()> {
+		let mut temp_file = OpenOptions::new().write(true).create_new(true).open(&temp_path)?;
+
+		temp_file.write_all(body.as_bytes())?;
+		temp_file.flush()?;
+
+		drop(temp_file);
+
+		fs::rename(&temp_path, marker_path)?;
+
+		Ok(())
+	})();
+
+	if result.is_err() {
+		let _ = fs::remove_file(&temp_path);
+	}
+
+	result
+}

--- a/apps/decodex/src/state/run_activity_marker/storage/parse.rs
+++ b/apps/decodex/src/state/run_activity_marker/storage/parse.rs
@@ -1,0 +1,60 @@
+use crate::state::run_activity_marker::record::RunActivityMarkerRecord;
+
+pub(crate) fn parse_run_activity_marker_record(marker_body: &str) -> RunActivityMarkerRecord {
+	let mut marker = RunActivityMarkerRecord::default();
+
+	for line in marker_body.lines() {
+		let Some((key, value)) = line.split_once('=') else {
+			continue;
+		};
+
+		match key {
+			"run_id" => marker.run_id = Some(value.to_owned()),
+			"attempt_number" => marker.attempt_number = value.parse::<i64>().ok(),
+			"process_id" => marker.process_id = value.parse::<u32>().ok(),
+			"host_boot_id" => marker.host_boot_id = Some(value.to_owned()),
+			"process_start_identity" => marker.process_start_identity = Some(value.to_owned()),
+			"last_activity_unix_epoch" =>
+				marker.last_activity_unix_epoch = value.parse::<i64>().ok(),
+			"last_protocol_activity_unix_epoch" =>
+				marker.last_protocol_activity_unix_epoch = value.parse::<i64>().ok(),
+			"last_progress_unix_epoch" =>
+				marker.last_progress_unix_epoch = value.parse::<i64>().ok(),
+			"current_operation" => marker.current_operation = Some(value.to_owned()),
+			"thread_id" => marker.thread_id = Some(value.to_owned()),
+			"turn_id" => marker.turn_id = Some(value.to_owned()),
+			"thread_status" => marker.thread_status = Some(value.to_owned()),
+			"thread_active_flags" => marker.thread_active_flags = parse_marker_list(value),
+			"event_count" => marker.event_count = value.parse::<i64>().ok(),
+			"last_event_type" => marker.last_event_type = Some(value.to_owned()),
+			"effective_model" => marker.effective_model = Some(value.to_owned()),
+			"effective_model_provider" => marker.effective_model_provider = Some(value.to_owned()),
+			"effective_cwd" => marker.effective_cwd = Some(value.to_owned()),
+			"effective_approval_policy" =>
+				marker.effective_approval_policy = Some(value.to_owned()),
+			"effective_approvals_reviewer" =>
+				marker.effective_approvals_reviewer = Some(value.to_owned()),
+			"effective_sandbox_mode" => marker.effective_sandbox_mode = Some(value.to_owned()),
+			"child_agent_activity" =>
+				marker.child_agent_activity = serde_json::from_str(value).ok(),
+			"protocol_activity" => marker.protocol_activity = serde_json::from_str(value).ok(),
+			"account" => marker.account = serde_json::from_str(value).ok(),
+			"accounts" =>
+				if let Ok(accounts) = serde_json::from_str(value) {
+					marker.accounts = accounts;
+				},
+			"retry_budget_attempt_count" =>
+				marker.retry_budget_attempt_count = value.parse::<i64>().ok(),
+			"retry_kind" => marker.retry_kind = Some(value.to_owned()),
+			"retry_ready_at_unix_epoch" =>
+				marker.retry_ready_at_unix_epoch = value.parse::<i64>().ok(),
+			_ => {},
+		}
+	}
+
+	marker
+}
+
+fn parse_marker_list(value: &str) -> Vec<String> {
+	value.split(',').filter(|part| !part.is_empty()).map(str::to_owned).collect()
+}

--- a/apps/decodex/src/state/run_activity_marker/storage/serialize.rs
+++ b/apps/decodex/src/state/run_activity_marker/storage/serialize.rs
@@ -1,0 +1,128 @@
+use crate::state::run_activity_marker::record::RunActivityMarkerRecord;
+
+pub(crate) fn serialize_run_activity_marker_record(marker: &RunActivityMarkerRecord) -> String {
+	let mut body = String::new();
+
+	append_run_activity_marker_identity_fields(&mut body, marker);
+	append_run_activity_marker_thread_fields(&mut body, marker);
+	append_run_activity_marker_runtime_fields(&mut body, marker);
+	append_run_activity_marker_summary_fields(&mut body, marker);
+	append_run_activity_marker_account_fields(&mut body, marker);
+	append_run_activity_marker_retry_fields(&mut body, marker);
+
+	body
+}
+
+fn append_run_activity_marker_identity_fields(body: &mut String, marker: &RunActivityMarkerRecord) {
+	if let Some(run_id) = &marker.run_id {
+		body.push_str(&format!("run_id={run_id}\n"));
+	}
+	if let Some(attempt_number) = marker.attempt_number {
+		body.push_str(&format!("attempt_number={attempt_number}\n"));
+	}
+	if let Some(process_id) = marker.process_id {
+		body.push_str(&format!("process_id={process_id}\n"));
+	}
+	if let Some(host_boot_id) = &marker.host_boot_id {
+		body.push_str(&format!("host_boot_id={host_boot_id}\n"));
+	}
+	if let Some(process_start_identity) = &marker.process_start_identity {
+		body.push_str(&format!("process_start_identity={process_start_identity}\n"));
+	}
+}
+
+fn append_run_activity_marker_thread_fields(body: &mut String, marker: &RunActivityMarkerRecord) {
+	if let Some(current_operation) = &marker.current_operation {
+		body.push_str(&format!("current_operation={current_operation}\n"));
+	}
+	if let Some(thread_id) = &marker.thread_id {
+		body.push_str(&format!("thread_id={thread_id}\n"));
+	}
+	if let Some(turn_id) = &marker.turn_id {
+		body.push_str(&format!("turn_id={turn_id}\n"));
+	}
+	if let Some(thread_status) = &marker.thread_status {
+		body.push_str(&format!("thread_status={thread_status}\n"));
+	}
+
+	if !marker.thread_active_flags.is_empty() {
+		body.push_str(&format!("thread_active_flags={}\n", marker.thread_active_flags.join(",")));
+	}
+}
+
+fn append_run_activity_marker_runtime_fields(body: &mut String, marker: &RunActivityMarkerRecord) {
+	if let Some(last_activity_unix_epoch) = marker.last_activity_unix_epoch {
+		body.push_str(&format!("last_activity_unix_epoch={last_activity_unix_epoch}\n"));
+	}
+	if let Some(last_protocol_activity_unix_epoch) = marker.last_protocol_activity_unix_epoch {
+		body.push_str(&format!(
+			"last_protocol_activity_unix_epoch={last_protocol_activity_unix_epoch}\n"
+		));
+	}
+	if let Some(last_progress_unix_epoch) = marker.last_progress_unix_epoch {
+		body.push_str(&format!("last_progress_unix_epoch={last_progress_unix_epoch}\n"));
+	}
+	if let Some(effective_model) = &marker.effective_model {
+		body.push_str(&format!("effective_model={effective_model}\n"));
+	}
+	if let Some(effective_model_provider) = &marker.effective_model_provider {
+		body.push_str(&format!("effective_model_provider={effective_model_provider}\n"));
+	}
+	if let Some(effective_cwd) = &marker.effective_cwd {
+		body.push_str(&format!("effective_cwd={effective_cwd}\n"));
+	}
+	if let Some(effective_approval_policy) = &marker.effective_approval_policy {
+		body.push_str(&format!("effective_approval_policy={effective_approval_policy}\n"));
+	}
+	if let Some(effective_approvals_reviewer) = &marker.effective_approvals_reviewer {
+		body.push_str(&format!("effective_approvals_reviewer={effective_approvals_reviewer}\n"));
+	}
+	if let Some(effective_sandbox_mode) = &marker.effective_sandbox_mode {
+		body.push_str(&format!("effective_sandbox_mode={effective_sandbox_mode}\n"));
+	}
+}
+
+fn append_run_activity_marker_summary_fields(body: &mut String, marker: &RunActivityMarkerRecord) {
+	if let Some(event_count) = marker.event_count {
+		body.push_str(&format!("event_count={event_count}\n"));
+	}
+	if let Some(last_event_type) = &marker.last_event_type {
+		body.push_str(&format!("last_event_type={last_event_type}\n"));
+	}
+	if let Some(child_agent_activity) = &marker.child_agent_activity
+		&& let Ok(summary_json) = serde_json::to_string(child_agent_activity)
+	{
+		body.push_str(&format!("child_agent_activity={summary_json}\n"));
+	}
+	if let Some(protocol_activity) = &marker.protocol_activity
+		&& let Ok(summary_json) = serde_json::to_string(protocol_activity)
+	{
+		body.push_str(&format!("protocol_activity={summary_json}\n"));
+	}
+}
+
+fn append_run_activity_marker_account_fields(body: &mut String, marker: &RunActivityMarkerRecord) {
+	if let Some(account) = &marker.account
+		&& let Ok(summary_json) = serde_json::to_string(account)
+	{
+		body.push_str(&format!("account={summary_json}\n"));
+	}
+
+	if !marker.accounts.is_empty()
+		&& let Ok(accounts_json) = serde_json::to_string(&marker.accounts)
+	{
+		body.push_str(&format!("accounts={accounts_json}\n"));
+	}
+}
+
+fn append_run_activity_marker_retry_fields(body: &mut String, marker: &RunActivityMarkerRecord) {
+	if let Some(retry_budget_attempt_count) = marker.retry_budget_attempt_count {
+		body.push_str(&format!("retry_budget_attempt_count={retry_budget_attempt_count}\n"));
+	}
+	if let Some(retry_kind) = &marker.retry_kind {
+		body.push_str(&format!("retry_kind={retry_kind}\n"));
+	}
+	if let Some(retry_ready_at_unix_epoch) = marker.retry_ready_at_unix_epoch {
+		body.push_str(&format!("retry_ready_at_unix_epoch={retry_ready_at_unix_epoch}\n"));
+	}
+}


### PR DESCRIPTION
## Summary
- split run activity marker storage into parse, serialize, account preservation, and atomic-write modules
- split queued attention status readback, retry, and timing helpers into focused modules
- split retryable failure retry-schedule writing from retryable writeback cleanup

## Validation
- rustup run nightly cargo fmt --all -- --check
- cargo make lint-vstyle-rust
- cargo check --workspace --all-features --all-targets
- cargo clippy --workspace --all-features --all-targets -- -D clippy::all -D clippy::too_many_lines -D clippy::unwrap_used -D clippy::use_self -D clippy::wildcard_imports -D missing-docs -D unused-crate-dependencies -D warnings
- cargo test -p decodex run_activity_marker --lib
- cargo test -p decodex operator::status::queue --lib
- cargo test -p decodex retry_markers --lib
- cargo test -p decodex retryable_failure --lib
- cargo test -p decodex runtime_program_reconciler::failed_start_cleanup --lib
- cargo test -p decodex recovery_terminal_failures::retry_budget --lib
- git diff --check
- added-change guards found no mod.rs, wildcard imports, include!, #[path], use super, super::, #[allow(...)] or #[expect(...)]