### PR TITLE
Tighten account panel window sizing

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/DecodexApp.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexApp.swift
@@ -104,6 +104,7 @@ struct DecodexApp: App {
 			}
 		}
 		.menuBarExtraStyle(.window)
+		.windowResizability(.contentSize)
 	}
 
 	@ViewBuilder

--- a/apps/decodex-app/Sources/DecodexApp/PanelWindowSizing.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelWindowSizing.swift
@@ -91,6 +91,7 @@ private struct PanelWindowSizingModifier: ViewModifier {
 
 	func body(content: Content) -> some View {
 		content
+			.fixedSize(horizontal: false, vertical: true)
 			.background {
 				GeometryReader { proxy in
 					Color.clear.preference(key: PanelWindowContentSizeKey.self, value: proxy.size)


### PR DESCRIPTION
## Summary
- constrain the menu bar extra window to SwiftUI content size
- force the account panel sizing probe to measure the panel's ideal vertical height instead of a stale expanded proposal

## Validation
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer scripts/macos/test_decodex_app_stage.sh
- npm --prefix site ci
- cargo make check