### PR TITLE
Structure interrupted app-server turn failures

### DIFF
--- a/apps/decodex/src/agent/app_server/tests.rs
+++ b/apps/decodex/src/agent/app_server/tests.rs
@@ -53,7 +53,8 @@ use dynamic_tool_handlers::{
 	LiveResumeDynamicToolHandler, NamespacedDynamicToolHandler,
 };
 use fake_codex_scripts::{
-	install_fake_codex_script, orphan_response_fake_codex_script, retrying_error_fake_codex_script,
+	install_fake_codex_script, interrupted_without_error_fake_codex_script,
+	orphan_response_fake_codex_script, retrying_error_fake_codex_script,
 	slow_thread_start_fake_codex_script,
 };
 use phase_goal_support::{

--- a/apps/decodex/src/agent/app_server/tests/fake_codex_scripts.rs
+++ b/apps/decodex/src/agent/app_server/tests/fake_codex_scripts.rs
@@ -144,3 +144,16 @@ pub(super) fn retrying_error_fake_codex_script() -> String {
         send({"id": 999, "result": {"late": True}})"#,
 	)
 }
+
+pub(super) fn interrupted_without_error_fake_codex_script() -> String {
+	orphan_response_fake_codex_script().replace(
+		r#"        send({"method": "turn/completed", "params": {
+            "threadId": "thread-1",
+            "turn": {"id": "turn-1", "status": "completed", "error": None}
+        }})"#,
+		r#"        send({"method": "turn/completed", "params": {
+            "threadId": "thread-1",
+            "turn": {"id": "turn-1", "status": "interrupted", "error": None}
+        }})"#,
+	)
+}

--- a/apps/decodex/src/agent/app_server/tests/request_tests.rs
+++ b/apps/decodex/src/agent/app_server/tests/request_tests.rs
@@ -6,8 +6,8 @@ use tempfile::TempDir;
 use crate::{
 	agent::{
 		app_server::{
-			self, AppServerDynamicToolFailure, CommandExecHealthCheck, UserInput, tests,
-			tests::InvalidToolNameHandler,
+			self, AppServerDynamicToolFailure, AppServerTurnFailure, CommandExecHealthCheck,
+			UserInput, tests, tests::InvalidToolNameHandler,
 		},
 		tracker_tool_bridge::{DynamicToolCallResponse, DynamicToolHandler, DynamicToolSpec},
 	},
@@ -307,5 +307,47 @@ fn turn_completion_waits_through_retrying_error_notification() {
 		state_store
 			.run_has_protocol_event(&request.run_id, "error")
 			.expect("retrying error event lookup should load")
+	);
+}
+
+#[test]
+fn app_server_run_records_interrupted_turn_without_error_as_structured_failure() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let worktree_path = temp_dir.path().join("worktree");
+	let fake_bin_dir = tests::install_fake_codex_script(
+		&temp_dir,
+		&tests::interrupted_without_error_fake_codex_script(),
+	);
+	let path_env = env::var("PATH").unwrap_or_default();
+	let _path_guard =
+		TestEnvVarGuard::set("PATH", &format!("{}:{path_env}", fake_bin_dir.display()));
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let mut request = tests::minimal_run_request();
+
+	fs::create_dir_all(&worktree_path).expect("worktree directory should create");
+
+	request.run_id = String::from("interrupted-no-error-run");
+	request.issue_id = String::from("interrupted-no-error-issue");
+	request.cwd = worktree_path.display().to_string();
+	request.timeout = Duration::from_secs(5);
+
+	let error = app_server::execute_app_server_run(&request, &state_store)
+		.expect_err("interrupted turn without error payload should fail the run");
+	let failure =
+		error.downcast_ref::<AppServerTurnFailure>().expect("error should be a turn failure");
+	let attempt = state_store
+		.run_attempt(&request.run_id)
+		.expect("run attempt lookup should load")
+		.expect("run attempt should exist");
+
+	assert_eq!(failure.error_class(), "app_server_turn_missing_error_payload");
+	assert!(failure.to_string().contains("status `interrupted`"));
+	assert_eq!(attempt.status(), "failed");
+	assert_eq!(attempt.thread_id(), Some("thread-1"));
+	assert_eq!(attempt.turn_id(), Some("turn-1"));
+	assert!(
+		state_store
+			.run_has_protocol_event(&request.run_id, "turn/completed")
+			.expect("turn completed event lookup should load")
 	);
 }

--- a/apps/decodex/src/agent/app_server/tests/runtime/turn_failures.rs
+++ b/apps/decodex/src/agent/app_server/tests/runtime/turn_failures.rs
@@ -183,6 +183,39 @@ fn thread_system_error_notification_fails_immediately_with_latest_turn_failure()
 }
 
 #[test]
+fn turn_completed_without_error_payload_becomes_structured_turn_failure() {
+	let notification = JsonRpcNotification {
+		method: String::from("turn/completed"),
+		params: serde_json::json!({
+			"turn": {
+				"id": "turn-1",
+				"status": "interrupted",
+				"error": null
+			}
+		}),
+	};
+	let mut final_output = String::new();
+	let mut latest_turn_failure = None;
+	let result = super::handle_turn_execution_notification(
+		&notification,
+		"thread-1",
+		"turn-1",
+		&mut final_output,
+		&mut latest_turn_failure,
+	);
+	let error = match result {
+		Ok(_) => panic!("interrupted turn without payload should fail the turn"),
+		Err(error) => error,
+	};
+	let failure =
+		error.downcast_ref::<AppServerTurnFailure>().expect("error should be a turn failure");
+
+	assert_eq!(failure.error_class(), "app_server_turn_missing_error_payload");
+	assert!(failure.to_string().contains("without an explicit error payload"));
+	assert!(latest_turn_failure.is_none());
+}
+
+#[test]
 fn json_rpc_error_response_becomes_recoverable_turn_failure() {
 	let error = JsonRpcError {
 		id: serde_json::json!(7),

--- a/apps/decodex/src/agent/app_server/turn_failure.rs
+++ b/apps/decodex/src/agent/app_server/turn_failure.rs
@@ -10,6 +10,7 @@ pub(crate) struct AppServerTurnFailure {
 	status: String,
 	message: String,
 	codex_error_info: Option<String>,
+	missing_error_payload: bool,
 }
 impl AppServerTurnFailure {
 	pub(crate) fn new(
@@ -25,6 +26,7 @@ impl AppServerTurnFailure {
 			status: status.into(),
 			message: message.into(),
 			codex_error_info,
+			missing_error_payload: false,
 		}
 	}
 
@@ -36,6 +38,17 @@ impl AppServerTurnFailure {
 			"thread entered systemError before a turn error was reported",
 			None,
 		)
+	}
+
+	pub(super) fn from_missing_error_payload(thread_id: &str, turn_id: &str, status: &str) -> Self {
+		Self {
+			thread_id: thread_id.to_owned(),
+			turn_id: Some(turn_id.to_owned()),
+			status: status.to_owned(),
+			message: format!("turn ended with status `{status}` without an explicit error payload"),
+			codex_error_info: None,
+			missing_error_payload: true,
+		}
 	}
 
 	pub(crate) fn requires_operator_attention(&self) -> bool {
@@ -51,6 +64,10 @@ impl AppServerTurnFailure {
 	}
 
 	pub(crate) fn error_class(&self) -> &'static str {
+		if self.missing_error_payload {
+			return "app_server_turn_missing_error_payload";
+		}
+
 		match self.codex_error_info.as_deref() {
 			Some("usageLimitExceeded") => "app_server_usage_limit_exceeded",
 			_ => "app_server_turn_failed",
@@ -58,6 +75,10 @@ impl AppServerTurnFailure {
 	}
 
 	pub(crate) fn retry_next_action(&self) -> &'static str {
+		if self.missing_error_payload {
+			return "decodex will retry automatically with the structured missing turn-error payload recorded";
+		}
+
 		match self.codex_error_info.as_deref() {
 			Some("usageLimitExceeded") =>
 				"decodex will retry automatically and reselect or refresh the Codex account before the next attempt",
@@ -66,6 +87,13 @@ impl AppServerTurnFailure {
 	}
 
 	pub(crate) fn terminal_next_action(&self, recovery_gate: &str) -> String {
+		if self.missing_error_payload {
+			return format!(
+				"inspect app-server protocol activity for the terminal turn status `{}`, verify whether the interrupted turn left useful worktree changes, {recovery_gate}",
+				self.status
+			);
+		}
+
 		match self.codex_error_info.as_deref() {
 			Some("usageLimitExceeded") => format!(
 				"inspect Codex account usage and retry after credits or the usage reset are available, {recovery_gate}"

--- a/apps/decodex/src/agent/app_server/turn_loop/completion/notification.rs
+++ b/apps/decodex/src/agent/app_server/turn_loop/completion/notification.rs
@@ -15,7 +15,7 @@ use crate::{
 		},
 		json_rpc::JsonRpcNotification,
 	},
-	prelude::{Result, eyre},
+	prelude::Result,
 };
 
 pub(in crate::agent::app_server) fn handle_turn_execution_notification(
@@ -102,11 +102,11 @@ pub(in crate::agent::app_server) fn handle_turn_execution_notification(
 				return Err(Report::new(failure));
 			}
 
-			eyre::bail!(
-				"Turn `{}` ended with status `{}` without an explicit error payload.",
-				payload.turn.id,
-				payload.turn.status
-			);
+			return Err(Report::new(AppServerTurnFailure::from_missing_error_payload(
+				target_thread_id,
+				&payload.turn.id,
+				&payload.turn.status,
+			)));
 		},
 		"thread/goal/updated" => {
 			let payload: ThreadGoalUpdatedNotification =

--- a/apps/decodex/src/agent/tracker_tool_bridge/tests/mutation/dispatch/comment/manual_attention.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests/mutation/dispatch/comment/manual_attention.rs
@@ -149,6 +149,7 @@ fn rejects_manual_attention_comment_with_runtime_owned_error_class() {
 		"stalled_run_detected",
 		"app_server_plugin_list_timeout",
 		"app_server_turn_failed",
+		"app_server_turn_missing_error_payload",
 		"app_server_usage_limit_exceeded",
 		"app_server_dynamic_tool_failed",
 		"phase_goal_terminal_path_missing",

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools/manual_attention/normalize/runtime_owned.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools/manual_attention/normalize/runtime_owned.rs
@@ -20,6 +20,7 @@ pub(in crate::agent::tracker_tool_bridge::tools::manual_attention::normalize) fn
 			| "app_server_dynamic_tool_protocol_failure"
 			| "app_server_dynamic_tool_failed"
 			| "app_server_turn_failed"
+			| "app_server_turn_missing_error_payload"
 			| "app_server_usage_limit_exceeded"
 	) || runtime_owned_baseline_error_class(error_class)
 }

--- a/apps/decodex/src/orchestrator/selection/failure_details/retry.rs
+++ b/apps/decodex/src/orchestrator/selection/failure_details/retry.rs
@@ -56,9 +56,7 @@ pub(crate) fn retry_comment_details(error: &Report) -> (&'static str, String) {
 		);
 	}
 
-	if let Some(app_server_failure) = error.downcast_ref::<AppServerTurnFailure>()
-		&& app_server_failure.is_retryable_capacity_failure()
-	{
+	if let Some(app_server_failure) = error.downcast_ref::<AppServerTurnFailure>() {
 		return (
 			app_server_failure.error_class(),
 			app_server_failure.retry_next_action().to_owned(),

--- a/apps/decodex/src/orchestrator/tests/recovery_terminal_failures/retry_budget.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery_terminal_failures/retry_budget.rs
@@ -46,7 +46,7 @@ fn retryable_app_server_failures_do_not_write_attention_before_budget_exhaustion
 			"transient model failure",
 			None,
 		)),
-		"retryable_execution_failure",
+		"app_server_turn_failed",
 	);
 	assert_retryable_failure_writeback_does_not_require_attention(
 		&config,

--- a/apps/decodex/src/orchestrator/tests/runtime_failure/comments/retry_comments.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime_failure/comments/retry_comments.rs
@@ -1,8 +1,9 @@
 use crate::orchestrator::{
 	RepoGateFailure,
 	tests::runtime_failure::{
-		self, AppServerCapabilityPreflightFailure, Duration, RUN_LEASE_IDLE_TIMEOUT,
-		RepoGateFailureKind, Report, RetryComment, StalledRunNeedsAttention, orchestrator,
+		self, AppServerCapabilityPreflightFailure, AppServerTurnFailure, Duration,
+		RUN_LEASE_IDLE_TIMEOUT, RepoGateFailureKind, Report, RetryComment,
+		StalledRunNeedsAttention, orchestrator,
 	},
 };
 
@@ -115,4 +116,19 @@ fn app_server_preflight_timeout_retry_comments_preserve_specific_error_class() {
 	assert!(next_action.contains("retry app-server preflight automatically"));
 	assert!(next_action.contains("`plugin/list` timeout"));
 	assert!(next_action.contains("retry budget exhausts"));
+}
+
+#[test]
+fn app_server_turn_retry_comments_preserve_specific_error_class() {
+	let error = Report::new(AppServerTurnFailure::new(
+		"thread-1",
+		Some(String::from("turn-1")),
+		"failed",
+		"transient model failure",
+		None,
+	));
+	let (error_class, next_action) = orchestrator::retry_comment_details(&error);
+
+	assert_eq!(error_class, "app_server_turn_failed");
+	assert_eq!(next_action, "decodex will retry automatically");
 }

--- a/apps/decodex/src/recovery/evidence/stale_active/guardrail.rs
+++ b/apps/decodex/src/recovery/evidence/stale_active/guardrail.rs
@@ -21,7 +21,10 @@ fn stale_active_no_diff_guardrail_source_is_startup_or_turn_failure(
 ) -> bool {
 	let source_error_class = payload.get("source_error_class").and_then(serde_json::Value::as_str);
 
-	matches!(source_error_class, Some("app_server_turn_failed") | None)
+	matches!(
+		source_error_class,
+		Some("app_server_turn_failed" | "app_server_turn_missing_error_payload") | None
+	)
 }
 
 fn stale_active_guardrail_details_have_no_delta(payload: &serde_json::Value) -> bool {

--- a/apps/decodex/src/recovery/tests/stale_active/telemetry/harness.rs
+++ b/apps/decodex/src/recovery/tests/stale_active/telemetry/harness.rs
@@ -214,3 +214,41 @@ fn stale_active_diagnose_allows_startup_no_diff_guardrail_without_error_class() 
 	assert_eq!(diagnostic.classification, STALE_ACTIVE_CLASSIFICATION);
 	assert!(diagnostic.recoverable(), "unexpected blockers: {:?}", diagnostic.blockers);
 }
+
+#[test]
+fn stale_active_diagnose_allows_missing_error_payload_no_diff_guardrail() {
+	let temp_dir = TempDir::new().expect("tempdir should create");
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let workflow = tests::sample_workflow();
+	let active_label = tracker::automation_active_label("pubfi");
+	let queue_label = tracker::automation_queue_label("pubfi");
+	let worktree_path = temp_dir.path().join("PUB-1626");
+	let mut issue = tests::sample_issue_with_labels("In Progress", &[active_label, queue_label]);
+
+	issue.identifier = String::from("PUB-1626");
+
+	stale_active::seed_dead_orphan_runtime_telemetry(&store, &issue, &worktree_path);
+	stale_active::append_no_diff_guardrail_event_with_source_error_class(
+		&store,
+		&issue.id,
+		false,
+		false,
+		Some("app_server_turn_missing_error_payload"),
+	);
+
+	let tracker = GhostLaneTestTracker::with_issues(vec![issue]);
+	let diagnostics = super::diagnose_stale_active_issues(
+		"pubfi",
+		&workflow,
+		temp_dir.path(),
+		&store,
+		&tracker,
+		Some("PUB-1626"),
+		RecoveryRuntimeMutationPolicy::ReadOnly,
+	)
+	.expect("stale active diagnosis should run");
+	let diagnostic = diagnostics.first().expect("diagnostic should exist");
+
+	assert_eq!(diagnostic.classification, STALE_ACTIVE_CLASSIFICATION);
+	assert!(diagnostic.recoverable(), "unexpected blockers: {:?}", diagnostic.blockers);
+}

--- a/docs/spec/app-server.md
+++ b/docs/spec/app-server.md
@@ -581,6 +581,11 @@ Rationale:
 - Classify the turn as success, retryable failure, or terminal failure.
 - A same-thread completion for the adopted notification turn id completes the active
   Decodex turn even when the original `turn/start` response id was different.
+- A terminal non-`completed` turn status without a `turn.error` payload is still a
+  structured app-server turn failure, not a generic runtime error. Decodex records
+  `app_server_turn_missing_error_payload`, preserves the terminal status such as
+  `interrupted` in the private error message, and routes retry or retry-budget
+  exhaustion through the same retained-lane recovery path as other turn failures.
 
 ## Error handling
 


### PR DESCRIPTION
## Summary
- convert interrupted turn/completed notifications without turn.error into structured AppServerTurnFailure payloads
- preserve the missing-payload error class through retry comments, manual-attention ownership checks, and stale-active recovery
- add regression coverage for direct runtime handling, fake app-server execution, retry comments, manual-attention class rejection, stale-active recovery, and app-server docs

## Validation
- cargo test -p decodex turn_completed_without_error_payload_becomes_structured_turn_failure -- --nocapture
- cargo test -p decodex app_server_run_records_interrupted_turn_without_error_as_structured_failure -- --nocapture
- cargo test -p decodex stale_active_diagnose_allows_missing_error_payload_no_diff_guardrail -- --nocapture
- cargo make check (1656 passed, 1 skipped)

Authority: PUB-1669