### PR TITLE
Modularize status and store dispatch surfaces

### DIFF
--- a/apps/decodex/src/agent/tracker_tool_bridge/tools/dispatch.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools/dispatch.rs
@@ -1,15 +1,15 @@
+mod fence;
+mod label;
+mod transition;
+
 use serde_json::Value;
 
-use crate::{
-	agent::tracker_tool_bridge::{
-		DynamicToolCallResponse, ISSUE_COMMENT_TOOL_NAME,
-		ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME, ISSUE_LABEL_ADD_TOOL_NAME,
-		ISSUE_PROGRESS_CHECKPOINT_TOOL_NAME, ISSUE_REVIEW_CHECKPOINT_TOOL_NAME,
-		ISSUE_REVIEW_HANDOFF_TOOL_NAME, ISSUE_REVIEW_REPAIR_COMPLETE_TOOL_NAME,
-		ISSUE_TERMINAL_FINALIZE_TOOL_NAME, ISSUE_TRANSITION_TOOL_NAME, LabelArgs,
-		TrackerToolBridge, TransitionArgs,
-	},
-	tracker,
+use crate::agent::tracker_tool_bridge::{
+	DynamicToolCallResponse, ISSUE_COMMENT_TOOL_NAME, ISSUE_DELIVERY_CLOSEOUT_COMPLETE_TOOL_NAME,
+	ISSUE_LABEL_ADD_TOOL_NAME, ISSUE_PROGRESS_CHECKPOINT_TOOL_NAME,
+	ISSUE_REVIEW_CHECKPOINT_TOOL_NAME, ISSUE_REVIEW_HANDOFF_TOOL_NAME,
+	ISSUE_REVIEW_REPAIR_COMPLETE_TOOL_NAME, ISSUE_TERMINAL_FINALIZE_TOOL_NAME,
+	ISSUE_TRANSITION_TOOL_NAME, TrackerToolBridge,
 };
 
 impl<'a> TrackerToolBridge<'a> {
@@ -34,184 +34,6 @@ impl<'a> TrackerToolBridge<'a> {
 			ISSUE_TERMINAL_FINALIZE_TOOL_NAME => self.handle_terminal_finalize(arguments),
 			_ =>
 				DynamicToolCallResponse::failure(format!("Unsupported tracker tool `{tool_name}`.")),
-		}
-	}
-
-	fn review_policy_mutation_fence(&self, tool_name: &str) -> Option<DynamicToolCallResponse> {
-		if matches!(
-			tool_name,
-			ISSUE_REVIEW_CHECKPOINT_TOOL_NAME | ISSUE_TERMINAL_FINALIZE_TOOL_NAME
-		) {
-			return None;
-		}
-
-		let review_context = self.review_context.as_ref()?;
-
-		match self.review_policy_stop_requested(review_context) {
-			Ok(Some(stop)) => Some(DynamicToolCallResponse::failure(format!(
-				"Review policy stop `{}` is active for issue `{}` after `{}` non-clean rounds; `{tool_name}` is fenced until architecture recovery or human attention resolves the lane.",
-				stop.reason.error_class(),
-				stop.issue_identifier,
-				stop.nonclean_rounds.unwrap_or_default()
-			))),
-			Ok(None) => None,
-			Err(error) => Some(DynamicToolCallResponse::failure(format!(
-				"Failed to evaluate review policy mutation fence for `{tool_name}`: {error}"
-			))),
-		}
-	}
-
-	pub(super) fn handle_transition(&self, arguments: Value) -> DynamicToolCallResponse {
-		let parsed = match serde_json::from_value::<TransitionArgs>(arguments) {
-			Ok(parsed) => parsed,
-			Err(error) => {
-				return DynamicToolCallResponse::failure(format!(
-					"Invalid `issue.transition` arguments: {error}"
-				));
-			},
-		};
-
-		if let Err(error) = self.ensure_issue_scope(&parsed.scope) {
-			return DynamicToolCallResponse::failure(error);
-		}
-
-		let allowed_states = self.allowed_transition_states();
-
-		if !allowed_states.iter().any(|state| state == &parsed.state) {
-			let success_state = self.workflow.frontmatter().tracker().success_state();
-
-			if parsed.state == success_state {
-				return DynamicToolCallResponse::failure(format!(
-					"State `{}` requires `{}` after the branch is pushed and a reviewable PR exists.",
-					parsed.state, ISSUE_REVIEW_HANDOFF_TOOL_NAME
-				));
-			}
-
-			return DynamicToolCallResponse::failure(format!(
-				"State `{}` is outside the allowed tracker tool policy.",
-				parsed.state
-			));
-		}
-
-		let Some(state_id) = self.issue.state_id_for_name(&parsed.state) else {
-			return DynamicToolCallResponse::failure(format!(
-				"State `{}` does not exist on issue `{}`.",
-				parsed.state, self.issue.identifier
-			));
-		};
-
-		match self.tracker.update_issue_state(&self.issue.id, state_id) {
-			Ok(()) => {
-				self.local_issue_state_name.replace(parsed.state.clone());
-				self.record_continuation_blocking_transition(&parsed.state);
-
-				DynamicToolCallResponse::success(format!(
-					"Issue `{}` moved to `{}`.",
-					self.issue.identifier, parsed.state
-				))
-			},
-			Err(error) => DynamicToolCallResponse::failure(format!(
-				"Failed to move issue `{}` to `{}`: {error}",
-				self.issue.identifier, parsed.state
-			)),
-		}
-	}
-
-	pub(super) fn handle_add_label(&self, arguments: Value) -> DynamicToolCallResponse {
-		let parsed = match serde_json::from_value::<LabelArgs>(arguments) {
-			Ok(parsed) => parsed,
-			Err(error) => {
-				return DynamicToolCallResponse::failure(format!(
-					"Invalid `issue.label.add` arguments: {error}"
-				));
-			},
-		};
-
-		if let Err(error) = self.ensure_issue_scope(&parsed.scope) {
-			return DynamicToolCallResponse::failure(error);
-		}
-
-		let allowed_labels = [
-			self.workflow.frontmatter().tracker().opt_out_label(),
-			self.workflow.frontmatter().tracker().needs_attention_label(),
-		];
-
-		if !allowed_labels.iter().any(|label| label == &parsed.label) {
-			return DynamicToolCallResponse::failure(format!(
-				"Label `{}` is outside the allowed tracker tool policy.",
-				parsed.label
-			));
-		}
-
-		let manual_attention_label =
-			parsed.label == self.workflow.frontmatter().tracker().needs_attention_label();
-
-		if manual_attention_label {
-			self.manual_attention_requested.replace(true);
-
-			return DynamicToolCallResponse::success(format!(
-				"Manual-attention label intent recorded for issue `{}`. Call `{ISSUE_COMMENT_TOOL_NAME}` kind `{}` next so Decodex can validate the blocker and apply label `{}`.",
-				self.issue.identifier,
-				super::COMMENT_KIND_MANUAL_ATTENTION,
-				parsed.label
-			));
-		}
-
-		let current_issue = match self.refreshed_issue_snapshot() {
-			Ok(Some(issue)) => issue,
-			Ok(None) => {
-				return DynamicToolCallResponse::failure(format!(
-					"Failed to refresh issue `{}` before updating labels: tracker returned no current snapshot.",
-					self.issue.identifier
-				));
-			},
-			Err(error) => {
-				return DynamicToolCallResponse::failure(format!(
-					"Failed to refresh issue `{}` before updating labels: {error}",
-					self.issue.identifier
-				));
-			},
-		};
-		let label_added = match tracker::set_issue_label_presence(
-			self.tracker,
-			&current_issue,
-			&parsed.label,
-			true,
-		) {
-			Ok(label_added) => label_added,
-			Err(error) => {
-				return DynamicToolCallResponse::failure(format!(
-					"Failed to add label `{}` to issue `{}`: {error}",
-					parsed.label, self.issue.identifier
-				));
-			},
-		};
-
-		if !label_added {
-			self.record_label_add_local_effects(&parsed.label, manual_attention_label);
-
-			return DynamicToolCallResponse::success(format!(
-				"Issue `{}` already has label `{}`.",
-				self.issue.identifier, parsed.label
-			));
-		}
-
-		self.record_label_add_local_effects(&parsed.label, manual_attention_label);
-
-		DynamicToolCallResponse::success(format!(
-			"Label `{}` added to issue `{}`.",
-			parsed.label, self.issue.identifier
-		))
-	}
-
-	fn record_label_add_local_effects(&self, label: &str, manual_attention_label: bool) {
-		if manual_attention_label {
-			self.manual_attention_requested.replace(true);
-		} else if label == self.workflow.frontmatter().tracker().opt_out_label() {
-			self.local_opt_out_requested.replace(true);
-			self.record_continuation_blocking_write(format!(
-				"`{ISSUE_LABEL_ADD_TOOL_NAME}` with label `{label}`",
-			));
 		}
 	}
 }

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools/dispatch/fence.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools/dispatch/fence.rs
@@ -1,0 +1,33 @@
+use crate::agent::tracker_tool_bridge::{
+	DynamicToolCallResponse, ISSUE_REVIEW_CHECKPOINT_TOOL_NAME, ISSUE_TERMINAL_FINALIZE_TOOL_NAME,
+	TrackerToolBridge,
+};
+
+impl<'a> TrackerToolBridge<'a> {
+	pub(in crate::agent::tracker_tool_bridge) fn review_policy_mutation_fence(
+		&self,
+		tool_name: &str,
+	) -> Option<DynamicToolCallResponse> {
+		if matches!(
+			tool_name,
+			ISSUE_REVIEW_CHECKPOINT_TOOL_NAME | ISSUE_TERMINAL_FINALIZE_TOOL_NAME
+		) {
+			return None;
+		}
+
+		let review_context = self.review_context.as_ref()?;
+
+		match self.review_policy_stop_requested(review_context) {
+			Ok(Some(stop)) => Some(DynamicToolCallResponse::failure(format!(
+				"Review policy stop `{}` is active for issue `{}` after `{}` non-clean rounds; `{tool_name}` is fenced until architecture recovery or human attention resolves the lane.",
+				stop.reason.error_class(),
+				stop.issue_identifier,
+				stop.nonclean_rounds.unwrap_or_default()
+			))),
+			Ok(None) => None,
+			Err(error) => Some(DynamicToolCallResponse::failure(format!(
+				"Failed to evaluate review policy mutation fence for `{tool_name}`: {error}"
+			))),
+		}
+	}
+}

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools/dispatch/label.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools/dispatch/label.rs
@@ -1,0 +1,107 @@
+use serde_json::Value;
+
+use crate::{
+	agent::tracker_tool_bridge::{
+		DynamicToolCallResponse, ISSUE_COMMENT_TOOL_NAME, ISSUE_LABEL_ADD_TOOL_NAME, LabelArgs,
+		TrackerToolBridge, tools::COMMENT_KIND_MANUAL_ATTENTION,
+	},
+	tracker,
+};
+
+impl<'a> TrackerToolBridge<'a> {
+	pub(super) fn handle_add_label(&self, arguments: Value) -> DynamicToolCallResponse {
+		let parsed = match serde_json::from_value::<LabelArgs>(arguments) {
+			Ok(parsed) => parsed,
+			Err(error) => {
+				return DynamicToolCallResponse::failure(format!(
+					"Invalid `issue.label.add` arguments: {error}"
+				));
+			},
+		};
+
+		if let Err(error) = self.ensure_issue_scope(&parsed.scope) {
+			return DynamicToolCallResponse::failure(error);
+		}
+
+		let allowed_labels = [
+			self.workflow.frontmatter().tracker().opt_out_label(),
+			self.workflow.frontmatter().tracker().needs_attention_label(),
+		];
+
+		if !allowed_labels.iter().any(|label| label == &parsed.label) {
+			return DynamicToolCallResponse::failure(format!(
+				"Label `{}` is outside the allowed tracker tool policy.",
+				parsed.label
+			));
+		}
+
+		let manual_attention_label =
+			parsed.label == self.workflow.frontmatter().tracker().needs_attention_label();
+
+		if manual_attention_label {
+			self.manual_attention_requested.replace(true);
+
+			return DynamicToolCallResponse::success(format!(
+				"Manual-attention label intent recorded for issue `{}`. Call `{ISSUE_COMMENT_TOOL_NAME}` kind `{COMMENT_KIND_MANUAL_ATTENTION}` next so Decodex can validate the blocker and apply label `{}`.",
+				self.issue.identifier, parsed.label
+			));
+		}
+
+		let current_issue = match self.refreshed_issue_snapshot() {
+			Ok(Some(issue)) => issue,
+			Ok(None) => {
+				return DynamicToolCallResponse::failure(format!(
+					"Failed to refresh issue `{}` before updating labels: tracker returned no current snapshot.",
+					self.issue.identifier
+				));
+			},
+			Err(error) => {
+				return DynamicToolCallResponse::failure(format!(
+					"Failed to refresh issue `{}` before updating labels: {error}",
+					self.issue.identifier
+				));
+			},
+		};
+		let label_added = match tracker::set_issue_label_presence(
+			self.tracker,
+			&current_issue,
+			&parsed.label,
+			true,
+		) {
+			Ok(label_added) => label_added,
+			Err(error) => {
+				return DynamicToolCallResponse::failure(format!(
+					"Failed to add label `{}` to issue `{}`: {error}",
+					parsed.label, self.issue.identifier
+				));
+			},
+		};
+
+		if !label_added {
+			self.record_label_add_local_effects(&parsed.label, manual_attention_label);
+
+			return DynamicToolCallResponse::success(format!(
+				"Issue `{}` already has label `{}`.",
+				self.issue.identifier, parsed.label
+			));
+		}
+
+		self.record_label_add_local_effects(&parsed.label, manual_attention_label);
+
+		DynamicToolCallResponse::success(format!(
+			"Label `{}` added to issue `{}`.",
+			parsed.label, self.issue.identifier
+		))
+	}
+
+	fn record_label_add_local_effects(&self, label: &str, manual_attention_label: bool) {
+		if manual_attention_label {
+			self.manual_attention_requested.replace(true);
+		} else if label == self.workflow.frontmatter().tracker().opt_out_label() {
+			self.local_opt_out_requested.replace(true);
+			self.record_continuation_blocking_write(format!(
+				"`{ISSUE_LABEL_ADD_TOOL_NAME}` with label `{label}`",
+			));
+		}
+	}
+}

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools/dispatch/transition.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools/dispatch/transition.rs
@@ -1,0 +1,63 @@
+use serde_json::Value;
+
+use crate::agent::tracker_tool_bridge::{
+	DynamicToolCallResponse, ISSUE_REVIEW_HANDOFF_TOOL_NAME, TrackerToolBridge, TransitionArgs,
+};
+
+impl<'a> TrackerToolBridge<'a> {
+	pub(super) fn handle_transition(&self, arguments: Value) -> DynamicToolCallResponse {
+		let parsed = match serde_json::from_value::<TransitionArgs>(arguments) {
+			Ok(parsed) => parsed,
+			Err(error) => {
+				return DynamicToolCallResponse::failure(format!(
+					"Invalid `issue.transition` arguments: {error}"
+				));
+			},
+		};
+
+		if let Err(error) = self.ensure_issue_scope(&parsed.scope) {
+			return DynamicToolCallResponse::failure(error);
+		}
+
+		let allowed_states = self.allowed_transition_states();
+
+		if !allowed_states.iter().any(|state| state == &parsed.state) {
+			let success_state = self.workflow.frontmatter().tracker().success_state();
+
+			if parsed.state == success_state {
+				return DynamicToolCallResponse::failure(format!(
+					"State `{}` requires `{}` after the branch is pushed and a reviewable PR exists.",
+					parsed.state, ISSUE_REVIEW_HANDOFF_TOOL_NAME
+				));
+			}
+
+			return DynamicToolCallResponse::failure(format!(
+				"State `{}` is outside the allowed tracker tool policy.",
+				parsed.state
+			));
+		}
+
+		let Some(state_id) = self.issue.state_id_for_name(&parsed.state) else {
+			return DynamicToolCallResponse::failure(format!(
+				"State `{}` does not exist on issue `{}`.",
+				parsed.state, self.issue.identifier
+			));
+		};
+
+		match self.tracker.update_issue_state(&self.issue.id, state_id) {
+			Ok(()) => {
+				self.local_issue_state_name.replace(parsed.state.clone());
+				self.record_continuation_blocking_transition(&parsed.state);
+
+				DynamicToolCallResponse::success(format!(
+					"Issue `{}` moved to `{}`.",
+					self.issue.identifier, parsed.state
+				))
+			},
+			Err(error) => DynamicToolCallResponse::failure(format!(
+				"Failed to move issue `{}` to `{}`: {error}",
+				self.issue.identifier, parsed.state
+			)),
+		}
+	}
+}

--- a/apps/decodex/src/orchestrator/status_run_projection/run.rs
+++ b/apps/decodex/src/orchestrator/status_run_projection/run.rs
@@ -1,4 +1,5 @@
 mod accessors;
+mod builder;
 mod lane_control;
 mod lifecycle;
 mod phase;
@@ -11,12 +12,10 @@ use crate::{
 		OperatorRunProtocolSummary, OperatorRunStatus, OperatorRunTiming,
 		OperatorTerminalFinalizeProjection, PrivateExecutionEvent, ProjectLoopEvidenceSnapshot,
 		ProjectRunStatus, ProtocolActivitySummary, RunActivityMarker, ServiceConfig,
-		status_process_liveness,
 	},
 	prelude::Result,
 };
 use lane_control::OperatorRunLaneControlReadback;
-use status::OperatorRunStatusParts;
 
 pub(crate) fn operator_run_status(
 	project: &ServiceConfig,
@@ -25,99 +24,7 @@ pub(crate) fn operator_run_status(
 	run: ProjectRunStatus,
 	now_unix_epoch: i64,
 ) -> Result<OperatorRunStatus> {
-	let marker = super::load_operator_run_marker(&run)?;
-	let timing = super::operator_run_timing(&run, marker.as_ref(), now_unix_epoch);
-	let app_server_state = super::operator_run_app_server_state(&run, marker.as_ref());
-	let protocol_summary = super::operator_run_protocol_summary(&run, marker.as_ref());
-	let terminal_finalize_projection =
-		super::operator_run_terminal_finalize_projection(loop_evidence, &run);
-	let lifecycle = operator_run_lifecycle_projection(
-		&run,
-		marker.as_ref(),
-		terminal_finalize_projection,
-		&timing,
-		&app_server_state,
-		&protocol_summary,
-		now_unix_epoch,
-	);
-	let child_agent_activity = super::operator_run_child_agent_activity(
-		marker.as_ref(),
-		run.child_agent_activity(),
-		now_unix_epoch,
-	);
-	let protocol_activity = super::operator_run_protocol_activity(
-		marker.as_ref(),
-		run.protocol_activity(),
-		&app_server_state,
-		child_agent_activity.as_ref(),
-		timing.protocol_idle_for_seconds,
-		matches!(lifecycle.status.as_str(), "starting" | "running"),
-	);
-	let wait_reason = operator_run_wait_reason(
-		&lifecycle.phase,
-		lifecycle.wait_reason.clone(),
-		protocol_activity.as_ref(),
-	);
-	let private_events =
-		loop_evidence.private_events(run.issue_id(), run.run_id(), run.attempt_number());
-	let progress_diagnostic = super::operator_run_progress_diagnostic(
-		&lifecycle.phase,
-		&timing,
-		protocol_activity.as_ref(),
-		private_events,
-		now_unix_epoch,
-		status_process_liveness::run_activity_idle_timeout(marker.as_ref()),
-	);
-	let (account, accounts) = operator_run_accounts(marker.as_ref());
-	let branch_name = run.branch_name().map(str::to_owned);
-	let worktree_path = operator_run_relative_worktree_path(project, &run);
-	let issue_identifier = super::operator_run_issue_identifier_from_fields(
-		run.run_id(),
-		branch_name.as_deref(),
-		worktree_path.as_deref(),
-	);
-	let private_evidence =
-		operator_run_private_evidence(project, &run, issue_identifier.as_deref());
-	let continuation_recovery =
-		super::operator_run_continuation_recovery_status(loop_evidence, &run);
-	let active_goal_phase = operator_run_active_goal_phase(private_events);
-	let public_progress_phase = operator_run_public_progress_phase(private_events);
-	let phase_acceptance = operator_run_phase_acceptance_status(private_events);
-	let loop_status = operator_run_loop_status(
-		project,
-		loop_evidence,
-		&run,
-		&lifecycle.status,
-		&lifecycle.phase,
-		&lifecycle.current_operation,
-	)?;
-
-	Ok(hydrate_operator_run_derived_status(status::operator_run_status_from_parts(
-		OperatorRunStatusParts {
-			project,
-			project_display_name,
-			run: &run,
-			lifecycle,
-			wait_reason,
-			app_server_state,
-			timing,
-			protocol_summary,
-			child_agent_activity,
-			protocol_activity,
-			progress_diagnostic,
-			account,
-			accounts,
-			branch_name,
-			worktree_path,
-			issue_identifier,
-			private_evidence,
-			continuation_recovery,
-			phase_acceptance,
-			active_goal_phase,
-			public_progress_phase,
-			loop_status,
-		},
-	)))
+	builder::operator_run_status(project, loop_evidence, project_display_name, run, now_unix_epoch)
 }
 
 pub(crate) fn operator_run_active_goal_phase(events: &[PrivateExecutionEvent]) -> Option<String> {

--- a/apps/decodex/src/orchestrator/status_run_projection/run/builder.rs
+++ b/apps/decodex/src/orchestrator/status_run_projection/run/builder.rs
@@ -1,0 +1,120 @@
+use crate::{
+	orchestrator::{
+		OperatorRunStatus, ProjectLoopEvidenceSnapshot, ProjectRunStatus, ServiceConfig,
+		status_process_liveness,
+		status_run_projection::{
+			self,
+			run::status::{self, OperatorRunStatusParts},
+		},
+	},
+	prelude::Result,
+};
+
+pub(crate) fn operator_run_status(
+	project: &ServiceConfig,
+	loop_evidence: &ProjectLoopEvidenceSnapshot,
+	project_display_name: &str,
+	run: ProjectRunStatus,
+	now_unix_epoch: i64,
+) -> Result<OperatorRunStatus> {
+	let marker = status_run_projection::load_operator_run_marker(&run)?;
+	let timing = status_run_projection::operator_run_timing(&run, marker.as_ref(), now_unix_epoch);
+	let app_server_state =
+		status_run_projection::operator_run_app_server_state(&run, marker.as_ref());
+	let protocol_summary =
+		status_run_projection::operator_run_protocol_summary(&run, marker.as_ref());
+	let terminal_finalize_projection =
+		status_run_projection::operator_run_terminal_finalize_projection(loop_evidence, &run);
+	let lifecycle = status_run_projection::operator_run_lifecycle_projection(
+		&run,
+		marker.as_ref(),
+		terminal_finalize_projection,
+		&timing,
+		&app_server_state,
+		&protocol_summary,
+		now_unix_epoch,
+	);
+	let child_agent_activity = status_run_projection::operator_run_child_agent_activity(
+		marker.as_ref(),
+		run.child_agent_activity(),
+		now_unix_epoch,
+	);
+	let protocol_activity = status_run_projection::operator_run_protocol_activity(
+		marker.as_ref(),
+		run.protocol_activity(),
+		&app_server_state,
+		child_agent_activity.as_ref(),
+		timing.protocol_idle_for_seconds,
+		matches!(lifecycle.status.as_str(), "starting" | "running"),
+	);
+	let wait_reason = status_run_projection::operator_run_wait_reason(
+		&lifecycle.phase,
+		lifecycle.wait_reason.clone(),
+		protocol_activity.as_ref(),
+	);
+	let private_events =
+		loop_evidence.private_events(run.issue_id(), run.run_id(), run.attempt_number());
+	let progress_diagnostic = status_run_projection::operator_run_progress_diagnostic(
+		&lifecycle.phase,
+		&timing,
+		protocol_activity.as_ref(),
+		private_events,
+		now_unix_epoch,
+		status_process_liveness::run_activity_idle_timeout(marker.as_ref()),
+	);
+	let (account, accounts) = status_run_projection::operator_run_accounts(marker.as_ref());
+	let branch_name = run.branch_name().map(str::to_owned);
+	let worktree_path = status_run_projection::operator_run_relative_worktree_path(project, &run);
+	let issue_identifier = status_run_projection::operator_run_issue_identifier_from_fields(
+		run.run_id(),
+		branch_name.as_deref(),
+		worktree_path.as_deref(),
+	);
+	let private_evidence = status_run_projection::operator_run_private_evidence(
+		project,
+		&run,
+		issue_identifier.as_deref(),
+	);
+	let continuation_recovery =
+		status_run_projection::operator_run_continuation_recovery_status(loop_evidence, &run);
+	let active_goal_phase = status_run_projection::operator_run_active_goal_phase(private_events);
+	let public_progress_phase =
+		status_run_projection::operator_run_public_progress_phase(private_events);
+	let phase_acceptance =
+		status_run_projection::operator_run_phase_acceptance_status(private_events);
+	let loop_status = status_run_projection::operator_run_loop_status(
+		project,
+		loop_evidence,
+		&run,
+		&lifecycle.status,
+		&lifecycle.phase,
+		&lifecycle.current_operation,
+	)?;
+
+	Ok(status_run_projection::hydrate_operator_run_derived_status(
+		status::operator_run_status_from_parts(OperatorRunStatusParts {
+			project,
+			project_display_name,
+			run: &run,
+			lifecycle,
+			wait_reason,
+			app_server_state,
+			timing,
+			protocol_summary,
+			child_agent_activity,
+			protocol_activity,
+			progress_diagnostic,
+			account,
+			accounts,
+			branch_name,
+			worktree_path,
+			issue_identifier,
+			private_evidence,
+			continuation_recovery,
+			phase_acceptance,
+			active_goal_phase,
+			public_progress_phase,
+			loop_status,
+		}),
+	))
+}

--- a/apps/decodex/src/state/store/decision_contracts.rs
+++ b/apps/decodex/src/state/store/decision_contracts.rs
@@ -1,14 +1,10 @@
+mod mutation;
+mod query;
+
 use crate::{
 	loop_contract::{DecisionContract, DecisionPromotion},
-	prelude::{Result, eyre},
-	state::{
-		runtime_records::{DecisionContractKey, DecisionContractRuntimeRecord},
-		store,
-		store::{
-			DecisionContractRecord, StateStore, compare_decision_contract_runtime_records,
-			validation,
-		},
-	},
+	prelude::Result,
+	state::store::{DecisionContractRecord, StateStore},
 };
 
 impl StateStore {
@@ -18,34 +14,7 @@ impl StateStore {
 		source_issue_id: Option<&str>,
 		contract: DecisionContract,
 	) -> Result<DecisionContractRecord> {
-		validation::validate_decision_contract_record_inputs(
-			project_id,
-			source_issue_id,
-			&contract,
-		)?;
-
-		let now = store::timestamp_parts();
-		let mut state = self.lock_without_refresh()?;
-		let key = DecisionContractKey::new(project_id, contract.contract_id());
-		let (created_at, created_at_unix) = state.decision_contracts.get(&key).map_or_else(
-			|| (now.text.clone(), now.unix),
-			|record| (record.created_at.clone(), record.created_at_unix),
-		);
-		let record = DecisionContractRuntimeRecord {
-			project_id: project_id.to_owned(),
-			source_issue_id: source_issue_id.map(str::to_owned),
-			status: contract.status(),
-			contract,
-			created_at,
-			created_at_unix,
-			updated_at: now.text,
-			updated_at_unix: now.unix,
-		};
-
-		state.decision_contracts.insert(record.key(), record.clone());
-		self.upsert_decision_contract_locked(&record)?;
-
-		Ok(record.as_public())
+		mutation::upsert_decision_contract(self, project_id, source_issue_id, contract)
 	}
 
 	/// Read one local Loop/Decision Contract by project and contract id.
@@ -55,23 +24,7 @@ impl StateStore {
 		project_id: &str,
 		contract_id: &str,
 	) -> Result<Option<DecisionContractRecord>> {
-		validation::validate_required_decision_contract_field("project_id", project_id)?;
-		validation::validate_required_decision_contract_field("contract_id", contract_id)?;
-
-		if let Some(sqlite) = &self.sqlite {
-			let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
-
-			return sqlite
-				.decision_contract(project_id, contract_id)
-				.map(|record| record.map(|record| record.as_public()));
-		}
-
-		let state = self.lock()?;
-
-		Ok(state
-			.decision_contracts
-			.get(&DecisionContractKey::new(project_id, contract_id))
-			.map(DecisionContractRuntimeRecord::as_public))
+		query::decision_contract(self, project_id, contract_id)
 	}
 
 	/// List local Loop/Decision Contracts sourced from one tracker issue.
@@ -81,34 +34,7 @@ impl StateStore {
 		project_id: &str,
 		source_issue_id: &str,
 	) -> Result<Vec<DecisionContractRecord>> {
-		validation::validate_required_decision_contract_field("project_id", project_id)?;
-		validation::validate_required_decision_contract_field("source_issue_id", source_issue_id)?;
-
-		if let Some(sqlite) = &self.sqlite {
-			let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
-			let records = sqlite
-				.list_decision_contracts_for_issue(project_id, source_issue_id)?
-				.into_iter()
-				.map(|record| record.as_public())
-				.collect();
-
-			return Ok(records);
-		}
-
-		let state = self.lock()?;
-		let mut records = state
-			.decision_contracts
-			.values()
-			.filter(|record| {
-				record.project_id == project_id
-					&& record.source_issue_id.as_deref() == Some(source_issue_id)
-			})
-			.cloned()
-			.collect::<Vec<_>>();
-
-		records.sort_by(compare_decision_contract_runtime_records);
-
-		Ok(records.into_iter().map(|record| record.as_public()).collect())
+		query::list_decision_contracts_for_issue(self, project_id, source_issue_id)
 	}
 
 	/// List local Loop/Decision Contracts for one project.
@@ -117,30 +43,7 @@ impl StateStore {
 		&self,
 		project_id: &str,
 	) -> Result<Vec<DecisionContractRecord>> {
-		validation::validate_required_decision_contract_field("project_id", project_id)?;
-
-		if let Some(sqlite) = &self.sqlite {
-			let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
-			let records = sqlite
-				.list_decision_contracts_for_project(project_id)?
-				.into_iter()
-				.map(|record| record.as_public())
-				.collect();
-
-			return Ok(records);
-		}
-
-		let state = self.lock()?;
-		let mut records = state
-			.decision_contracts
-			.values()
-			.filter(|record| record.project_id == project_id)
-			.cloned()
-			.collect::<Vec<_>>();
-
-		records.sort_by(compare_decision_contract_runtime_records);
-
-		Ok(records.into_iter().map(|record| record.as_public()).collect())
+		query::list_decision_contracts_for_project(self, project_id)
 	}
 
 	/// Promote a latent Loop/Decision Contract into accepted execution authority.
@@ -189,29 +92,6 @@ impl StateStore {
 		contract_id: &str,
 		update: impl FnOnce(&mut DecisionContract) -> Result<()>,
 	) -> Result<DecisionContractRecord> {
-		validation::validate_required_decision_contract_field("project_id", project_id)?;
-		validation::validate_required_decision_contract_field("contract_id", contract_id)?;
-
-		let now = store::timestamp_parts();
-		let key = DecisionContractKey::new(project_id, contract_id);
-		let mut state = self.lock()?;
-		let mut record = state
-			.decision_contracts
-			.get(&key)
-			.cloned()
-			.ok_or_else(|| eyre::eyre!("Decision contract `{contract_id}` does not exist."))?;
-
-		update(&mut record.contract)?;
-
-		record.contract.validate()?;
-
-		record.status = record.contract.status();
-		record.updated_at = now.text;
-		record.updated_at_unix = now.unix;
-
-		state.decision_contracts.insert(key, record.clone());
-		self.upsert_decision_contract_locked(&record)?;
-
-		Ok(record.as_public())
+		mutation::update_decision_contract(self, project_id, contract_id, update)
 	}
 }

--- a/apps/decodex/src/state/store/decision_contracts/mutation.rs
+++ b/apps/decodex/src/state/store/decision_contracts/mutation.rs
@@ -1,0 +1,73 @@
+use crate::{
+	loop_contract::DecisionContract,
+	prelude::{Result, eyre},
+	state::{
+		runtime_records::{DecisionContractKey, DecisionContractRuntimeRecord},
+		store,
+		store::{DecisionContractRecord, StateStore, validation},
+	},
+};
+
+pub(in crate::state::store::decision_contracts) fn upsert_decision_contract(
+	store: &StateStore,
+	project_id: &str,
+	source_issue_id: Option<&str>,
+	contract: DecisionContract,
+) -> Result<DecisionContractRecord> {
+	validation::validate_decision_contract_record_inputs(project_id, source_issue_id, &contract)?;
+
+	let now = store::timestamp_parts();
+	let mut state = store.lock_without_refresh()?;
+	let key = DecisionContractKey::new(project_id, contract.contract_id());
+	let (created_at, created_at_unix) = state.decision_contracts.get(&key).map_or_else(
+		|| (now.text.clone(), now.unix),
+		|record| (record.created_at.clone(), record.created_at_unix),
+	);
+	let record = DecisionContractRuntimeRecord {
+		project_id: project_id.to_owned(),
+		source_issue_id: source_issue_id.map(str::to_owned),
+		status: contract.status(),
+		contract,
+		created_at,
+		created_at_unix,
+		updated_at: now.text,
+		updated_at_unix: now.unix,
+	};
+
+	state.decision_contracts.insert(record.key(), record.clone());
+	store.upsert_decision_contract_locked(&record)?;
+
+	Ok(record.as_public())
+}
+
+pub(in crate::state::store::decision_contracts) fn update_decision_contract(
+	store: &StateStore,
+	project_id: &str,
+	contract_id: &str,
+	update: impl FnOnce(&mut DecisionContract) -> Result<()>,
+) -> Result<DecisionContractRecord> {
+	validation::validate_required_decision_contract_field("project_id", project_id)?;
+	validation::validate_required_decision_contract_field("contract_id", contract_id)?;
+
+	let now = store::timestamp_parts();
+	let key = DecisionContractKey::new(project_id, contract_id);
+	let mut state = store.lock()?;
+	let mut record = state
+		.decision_contracts
+		.get(&key)
+		.cloned()
+		.ok_or_else(|| eyre::eyre!("Decision contract `{contract_id}` does not exist."))?;
+
+	update(&mut record.contract)?;
+
+	record.contract.validate()?;
+
+	record.status = record.contract.status();
+	record.updated_at = now.text;
+	record.updated_at_unix = now.unix;
+
+	state.decision_contracts.insert(key, record.clone());
+	store.upsert_decision_contract_locked(&record)?;
+
+	Ok(record.as_public())
+}

--- a/apps/decodex/src/state/store/decision_contracts/query.rs
+++ b/apps/decodex/src/state/store/decision_contracts/query.rs
@@ -1,0 +1,99 @@
+use crate::{
+	prelude::{Result, eyre},
+	state::{
+		runtime_records::{DecisionContractKey, DecisionContractRuntimeRecord},
+		store::{
+			DecisionContractRecord, StateStore, compare_decision_contract_runtime_records,
+			validation,
+		},
+	},
+};
+
+pub(in crate::state::store::decision_contracts) fn decision_contract(
+	store: &StateStore,
+	project_id: &str,
+	contract_id: &str,
+) -> Result<Option<DecisionContractRecord>> {
+	validation::validate_required_decision_contract_field("project_id", project_id)?;
+	validation::validate_required_decision_contract_field("contract_id", contract_id)?;
+
+	if let Some(sqlite) = &store.sqlite {
+		let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
+
+		return sqlite
+			.decision_contract(project_id, contract_id)
+			.map(|record| record.map(|record| record.as_public()));
+	}
+
+	let state = store.lock()?;
+
+	Ok(state
+		.decision_contracts
+		.get(&DecisionContractKey::new(project_id, contract_id))
+		.map(DecisionContractRuntimeRecord::as_public))
+}
+
+pub(in crate::state::store::decision_contracts) fn list_decision_contracts_for_issue(
+	store: &StateStore,
+	project_id: &str,
+	source_issue_id: &str,
+) -> Result<Vec<DecisionContractRecord>> {
+	validation::validate_required_decision_contract_field("project_id", project_id)?;
+	validation::validate_required_decision_contract_field("source_issue_id", source_issue_id)?;
+
+	if let Some(sqlite) = &store.sqlite {
+		let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
+		let records = sqlite
+			.list_decision_contracts_for_issue(project_id, source_issue_id)?
+			.into_iter()
+			.map(|record| record.as_public())
+			.collect();
+
+		return Ok(records);
+	}
+
+	let state = store.lock()?;
+	let mut records = state
+		.decision_contracts
+		.values()
+		.filter(|record| {
+			record.project_id == project_id
+				&& record.source_issue_id.as_deref() == Some(source_issue_id)
+		})
+		.cloned()
+		.collect::<Vec<_>>();
+
+	records.sort_by(compare_decision_contract_runtime_records);
+
+	Ok(records.into_iter().map(|record| record.as_public()).collect())
+}
+
+pub(in crate::state::store::decision_contracts) fn list_decision_contracts_for_project(
+	store: &StateStore,
+	project_id: &str,
+) -> Result<Vec<DecisionContractRecord>> {
+	validation::validate_required_decision_contract_field("project_id", project_id)?;
+
+	if let Some(sqlite) = &store.sqlite {
+		let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
+		let records = sqlite
+			.list_decision_contracts_for_project(project_id)?
+			.into_iter()
+			.map(|record| record.as_public())
+			.collect();
+
+		return Ok(records);
+	}
+
+	let state = store.lock()?;
+	let mut records = state
+		.decision_contracts
+		.values()
+		.filter(|record| record.project_id == project_id)
+		.cloned()
+		.collect::<Vec<_>>();
+
+	records.sort_by(compare_decision_contract_runtime_records);
+
+	Ok(records.into_iter().map(|record| record.as_public()).collect())
+}

--- a/apps/decodex/src/state/store/programs.rs
+++ b/apps/decodex/src/state/store/programs.rs
@@ -1,14 +1,11 @@
+mod mutation;
+mod query;
+
 use crate::{
 	execution_program::ExecutionProgram,
-	prelude::{Result, eyre},
-	state::{
-		runtime_records::{ExecutionProgramKey, ExecutionProgramRuntimeRecord},
-		store,
-		store::{
-			ExecutionProgramRecord, ProgramIntakePlanRecord, ProgramIssueMappingRecord, StateStore,
-			compare_execution_program_runtime_records, compare_program_intake_plan_records,
-			compare_program_issue_mapping_records, validation,
-		},
+	prelude::Result,
+	state::store::{
+		ExecutionProgramRecord, ProgramIntakePlanRecord, ProgramIssueMappingRecord, StateStore,
 	},
 };
 
@@ -20,32 +17,7 @@ impl StateStore {
 		project_id: &str,
 		program: ExecutionProgram,
 	) -> Result<ExecutionProgramRecord> {
-		validation::validate_execution_program_record_inputs(project_id, &program)?;
-
-		let now = store::timestamp_parts();
-		let mut state = self.lock_without_refresh()?;
-		let key = ExecutionProgramKey::new(project_id, program.program_id());
-		let (created_at, created_at_unix) = state.execution_programs.get(&key).map_or_else(
-			|| (now.text.clone(), now.unix),
-			|record| (record.created_at.clone(), record.created_at_unix),
-		);
-		let record = ExecutionProgramRuntimeRecord {
-			project_id: project_id.to_owned(),
-			source_contract_id: program.source_contract_id().map(str::to_owned),
-			program,
-			created_at,
-			created_at_unix,
-			updated_at: now.text,
-			updated_at_unix: now.unix,
-		};
-
-		state.execution_programs.insert(record.key(), record.clone());
-
-		store::apply_derived_program_intake_state(&mut state, &record);
-
-		self.upsert_execution_program_locked(&record)?;
-
-		Ok(record.as_public())
+		mutation::upsert_execution_program(self, project_id, program)
 	}
 
 	/// Read one local internal Execution Program by project and program id.
@@ -55,23 +27,7 @@ impl StateStore {
 		project_id: &str,
 		program_id: &str,
 	) -> Result<Option<ExecutionProgramRecord>> {
-		validation::validate_required_execution_program_field("project_id", project_id)?;
-		validation::validate_required_execution_program_field("program_id", program_id)?;
-
-		if let Some(sqlite) = &self.sqlite {
-			let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
-
-			return sqlite
-				.execution_program(project_id, program_id)
-				.map(|record| record.map(|record| record.as_public()));
-		}
-
-		let state = self.lock()?;
-
-		Ok(state
-			.execution_programs
-			.get(&ExecutionProgramKey::new(project_id, program_id))
-			.map(ExecutionProgramRuntimeRecord::as_public))
+		query::execution_program(self, project_id, program_id)
 	}
 
 	/// List local internal Execution Programs derived from one Decision Contract.
@@ -81,37 +37,7 @@ impl StateStore {
 		project_id: &str,
 		source_contract_id: &str,
 	) -> Result<Vec<ExecutionProgramRecord>> {
-		validation::validate_required_execution_program_field("project_id", project_id)?;
-		validation::validate_required_execution_program_field(
-			"source_contract_id",
-			source_contract_id,
-		)?;
-
-		if let Some(sqlite) = &self.sqlite {
-			let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
-			let records = sqlite
-				.list_execution_programs_for_contract(project_id, source_contract_id)?
-				.into_iter()
-				.map(|record| record.as_public())
-				.collect();
-
-			return Ok(records);
-		}
-
-		let state = self.lock()?;
-		let mut records = state
-			.execution_programs
-			.values()
-			.filter(|record| {
-				record.project_id == project_id
-					&& record.source_contract_id.as_deref() == Some(source_contract_id)
-			})
-			.cloned()
-			.collect::<Vec<_>>();
-
-		records.sort_by(compare_execution_program_runtime_records);
-
-		Ok(records.into_iter().map(|record| record.as_public()).collect())
+		query::list_execution_programs_for_contract(self, project_id, source_contract_id)
 	}
 
 	/// List local internal Execution Programs retained for one project.
@@ -120,30 +46,7 @@ impl StateStore {
 		&self,
 		project_id: &str,
 	) -> Result<Vec<ExecutionProgramRecord>> {
-		validation::validate_required_execution_program_field("project_id", project_id)?;
-
-		if let Some(sqlite) = &self.sqlite {
-			let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
-			let records = sqlite
-				.list_execution_programs(project_id)?
-				.into_iter()
-				.map(|record| record.as_public())
-				.collect();
-
-			return Ok(records);
-		}
-
-		let state = self.lock()?;
-		let mut records = state
-			.execution_programs
-			.values()
-			.filter(|record| record.project_id == project_id)
-			.cloned()
-			.collect::<Vec<_>>();
-
-		records.sort_by(compare_execution_program_runtime_records);
-
-		Ok(records.into_iter().map(|record| record.as_public()).collect())
+		query::list_execution_programs(self, project_id)
 	}
 
 	/// List local Program Intake Plan records retained for one project.
@@ -152,25 +55,7 @@ impl StateStore {
 		&self,
 		project_id: &str,
 	) -> Result<Vec<ProgramIntakePlanRecord>> {
-		validation::validate_required_execution_program_field("project_id", project_id)?;
-
-		if let Some(sqlite) = &self.sqlite {
-			let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
-
-			return sqlite.list_program_intake_plans(project_id);
-		}
-
-		let state = self.lock()?;
-		let mut records = state
-			.program_intake_plans
-			.values()
-			.filter(|record| record.project_id == project_id)
-			.cloned()
-			.collect::<Vec<_>>();
-
-		records.sort_by(compare_program_intake_plan_records);
-
-		Ok(records)
+		query::list_program_intake_plans(self, project_id)
 	}
 
 	/// List local issue mappings for one internal Execution Program.
@@ -180,25 +65,6 @@ impl StateStore {
 		project_id: &str,
 		program_id: &str,
 	) -> Result<Vec<ProgramIssueMappingRecord>> {
-		validation::validate_required_execution_program_field("project_id", project_id)?;
-		validation::validate_required_execution_program_field("program_id", program_id)?;
-
-		if let Some(sqlite) = &self.sqlite {
-			let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
-
-			return sqlite.list_program_issue_mappings(project_id, program_id);
-		}
-
-		let state = self.lock()?;
-		let mut records = state
-			.program_issue_mappings
-			.values()
-			.filter(|record| record.project_id == project_id && record.program_id == program_id)
-			.cloned()
-			.collect::<Vec<_>>();
-
-		records.sort_by(compare_program_issue_mapping_records);
-
-		Ok(records)
+		query::list_program_issue_mappings(self, project_id, program_id)
 	}
 }

--- a/apps/decodex/src/state/store/programs/mutation.rs
+++ b/apps/decodex/src/state/store/programs/mutation.rs
@@ -1,0 +1,42 @@
+use crate::{
+	execution_program::ExecutionProgram,
+	prelude::Result,
+	state::{
+		runtime_records::{ExecutionProgramKey, ExecutionProgramRuntimeRecord},
+		store,
+		store::{ExecutionProgramRecord, StateStore, validation},
+	},
+};
+
+pub(in crate::state::store::programs) fn upsert_execution_program(
+	store: &StateStore,
+	project_id: &str,
+	program: ExecutionProgram,
+) -> Result<ExecutionProgramRecord> {
+	validation::validate_execution_program_record_inputs(project_id, &program)?;
+
+	let now = store::timestamp_parts();
+	let mut state = store.lock_without_refresh()?;
+	let key = ExecutionProgramKey::new(project_id, program.program_id());
+	let (created_at, created_at_unix) = state.execution_programs.get(&key).map_or_else(
+		|| (now.text.clone(), now.unix),
+		|record| (record.created_at.clone(), record.created_at_unix),
+	);
+	let record = ExecutionProgramRuntimeRecord {
+		project_id: project_id.to_owned(),
+		source_contract_id: program.source_contract_id().map(str::to_owned),
+		program,
+		created_at,
+		created_at_unix,
+		updated_at: now.text,
+		updated_at_unix: now.unix,
+	};
+
+	state.execution_programs.insert(record.key(), record.clone());
+
+	store::apply_derived_program_intake_state(&mut state, &record);
+
+	store.upsert_execution_program_locked(&record)?;
+
+	Ok(record.as_public())
+}

--- a/apps/decodex/src/state/store/programs/query.rs
+++ b/apps/decodex/src/state/store/programs/query.rs
@@ -1,0 +1,155 @@
+use crate::{
+	prelude::{Result, eyre},
+	state::{
+		runtime_records::{ExecutionProgramKey, ExecutionProgramRuntimeRecord},
+		store::{
+			ExecutionProgramRecord, ProgramIntakePlanRecord, ProgramIssueMappingRecord, StateStore,
+			compare_execution_program_runtime_records, compare_program_intake_plan_records,
+			compare_program_issue_mapping_records, validation,
+		},
+	},
+};
+
+pub(in crate::state::store::programs) fn execution_program(
+	store: &StateStore,
+	project_id: &str,
+	program_id: &str,
+) -> Result<Option<ExecutionProgramRecord>> {
+	validation::validate_required_execution_program_field("project_id", project_id)?;
+	validation::validate_required_execution_program_field("program_id", program_id)?;
+
+	if let Some(sqlite) = &store.sqlite {
+		let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
+
+		return sqlite
+			.execution_program(project_id, program_id)
+			.map(|record| record.map(|record| record.as_public()));
+	}
+
+	let state = store.lock()?;
+
+	Ok(state
+		.execution_programs
+		.get(&ExecutionProgramKey::new(project_id, program_id))
+		.map(ExecutionProgramRuntimeRecord::as_public))
+}
+
+pub(in crate::state::store::programs) fn list_execution_programs_for_contract(
+	store: &StateStore,
+	project_id: &str,
+	source_contract_id: &str,
+) -> Result<Vec<ExecutionProgramRecord>> {
+	validation::validate_required_execution_program_field("project_id", project_id)?;
+	validation::validate_required_execution_program_field(
+		"source_contract_id",
+		source_contract_id,
+	)?;
+
+	if let Some(sqlite) = &store.sqlite {
+		let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
+		let records = sqlite
+			.list_execution_programs_for_contract(project_id, source_contract_id)?
+			.into_iter()
+			.map(|record| record.as_public())
+			.collect();
+
+		return Ok(records);
+	}
+
+	let state = store.lock()?;
+	let mut records = state
+		.execution_programs
+		.values()
+		.filter(|record| {
+			record.project_id == project_id
+				&& record.source_contract_id.as_deref() == Some(source_contract_id)
+		})
+		.cloned()
+		.collect::<Vec<_>>();
+
+	records.sort_by(compare_execution_program_runtime_records);
+
+	Ok(records.into_iter().map(|record| record.as_public()).collect())
+}
+
+pub(in crate::state::store::programs) fn list_execution_programs(
+	store: &StateStore,
+	project_id: &str,
+) -> Result<Vec<ExecutionProgramRecord>> {
+	validation::validate_required_execution_program_field("project_id", project_id)?;
+
+	if let Some(sqlite) = &store.sqlite {
+		let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
+		let records = sqlite
+			.list_execution_programs(project_id)?
+			.into_iter()
+			.map(|record| record.as_public())
+			.collect();
+
+		return Ok(records);
+	}
+
+	let state = store.lock()?;
+	let mut records = state
+		.execution_programs
+		.values()
+		.filter(|record| record.project_id == project_id)
+		.cloned()
+		.collect::<Vec<_>>();
+
+	records.sort_by(compare_execution_program_runtime_records);
+
+	Ok(records.into_iter().map(|record| record.as_public()).collect())
+}
+
+pub(in crate::state::store::programs) fn list_program_intake_plans(
+	store: &StateStore,
+	project_id: &str,
+) -> Result<Vec<ProgramIntakePlanRecord>> {
+	validation::validate_required_execution_program_field("project_id", project_id)?;
+
+	if let Some(sqlite) = &store.sqlite {
+		let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
+
+		return sqlite.list_program_intake_plans(project_id);
+	}
+
+	let state = store.lock()?;
+	let mut records = state
+		.program_intake_plans
+		.values()
+		.filter(|record| record.project_id == project_id)
+		.cloned()
+		.collect::<Vec<_>>();
+
+	records.sort_by(compare_program_intake_plan_records);
+
+	Ok(records)
+}
+
+pub(in crate::state::store::programs) fn list_program_issue_mappings(
+	store: &StateStore,
+	project_id: &str,
+	program_id: &str,
+) -> Result<Vec<ProgramIssueMappingRecord>> {
+	validation::validate_required_execution_program_field("project_id", project_id)?;
+	validation::validate_required_execution_program_field("program_id", program_id)?;
+
+	if let Some(sqlite) = &store.sqlite {
+		let sqlite = sqlite.lock().map_err(|_| eyre::eyre!("State store lock poisoned."))?;
+
+		return sqlite.list_program_issue_mappings(project_id, program_id);
+	}
+
+	let state = store.lock()?;
+	let mut records = state
+		.program_issue_mappings
+		.values()
+		.filter(|record| record.project_id == project_id && record.program_id == program_id)
+		.cloned()
+		.collect::<Vec<_>>();
+
+	records.sort_by(compare_program_issue_mapping_records);
+
+	Ok(records)
+}


### PR DESCRIPTION
## Summary
- Split tracker dispatch routing from transition, label, and review-policy mutation-fence handling.
- Split operator run status assembly into a builder module while keeping projection helpers as explicit module APIs.
- Split StateStore decision contract and execution program persistence into mutation/query modules while preserving existing public method surfaces.

## Validation
- cargo +nightly fmt --all --check
- cargo check -p decodex --all-features --all-targets
- cargo make lint-vstyle-rust
- cargo clippy --workspace --all-features --all-targets -- -D clippy::all -D clippy::too_many_lines -D clippy::unwrap_used -D clippy::use_self -D clippy::wildcard_imports -D missing-docs -D unused-crate-dependencies -D warnings
- git diff --check
- find apps packages -type f -path '*/mod.rs'
- diff guard for include/path/super/wildcard/allow/expect additions
- cargo nextest run -p decodex --all-features -E 'test(/tracker_tool_bridge/) or test(/status/) or test(/run_control/) or test(/decision_contract/) or test(/program/) or test(/autonomy/)'

Targeted nextest result: 537 passed, 1087 skipped.