### PR TITLE
Modularize authority and state evidence surfaces

### DIFF
--- a/apps/decodex/src/orchestrator/types/authority/boundary.rs
+++ b/apps/decodex/src/orchestrator/types/authority/boundary.rs
@@ -1,4 +1,6 @@
-use crate::orchestrator::types::{Result, eyre};
+mod validation;
+
+pub(crate) use validation::{authority_boundary_required, validate_authority_boundary_check_input};
 
 /// Final authority disposition for one loop recovery boundary check.
 #[allow(dead_code)]
@@ -172,98 +174,4 @@ pub(crate) struct AuthorityBoundaryCheckInput<'a> {
 	pub(crate) disposition: AuthorityBoundaryDisposition,
 	pub(crate) final_disposition_reason: &'a str,
 	pub(crate) improvement_signals: Vec<AuthorityBoundaryImprovementSignal<'a>>,
-}
-
-pub(crate) fn validate_authority_boundary_check_input(
-	input: &AuthorityBoundaryCheckInput<'_>,
-) -> Result<()> {
-	authority_boundary_required("authority boundary project_id", input.project_id)?;
-	authority_boundary_required("authority boundary issue_id", input.issue_id)?;
-	authority_boundary_required("authority boundary issue_identifier", input.issue_identifier)?;
-	authority_boundary_required("authority boundary run_id", input.run_id)?;
-	authority_boundary_required(
-		"authority boundary attempted_recovery_reason",
-		input.attempted_recovery_reason,
-	)?;
-	authority_boundary_required(
-		"authority boundary final_disposition_reason",
-		input.final_disposition_reason,
-	)?;
-
-	if input.attempt_number < 1 {
-		eyre::bail!("Authority boundary attempt_number must be positive.");
-	}
-	if input.changed_surfaces.is_empty() {
-		eyre::bail!("Authority boundary changed_surfaces must not be empty.");
-	}
-
-	let mut expected_policy_decision = AuthorityBoundaryPolicyDecision::AutoContinue;
-
-	for surface in &input.changed_surfaces {
-		let surface_policy_decision = surface.surface.policy_decision();
-
-		if surface.policy_decision != surface_policy_decision {
-			eyre::bail!(
-				"Authority boundary surface `{}` must use policy decision `{}`.",
-				surface.surface.as_str(),
-				surface_policy_decision.as_str()
-			);
-		}
-		if surface.legacy_disposition != surface_policy_decision.disposition() {
-			eyre::bail!(
-				"Authority boundary surface `{}` must use legacy disposition `{}`.",
-				surface.surface.as_str(),
-				surface_policy_decision.disposition().as_str()
-			);
-		}
-
-		expected_policy_decision =
-			AuthorityBoundaryPolicyDecision::max(expected_policy_decision, surface_policy_decision);
-	}
-
-	if input.policy_decision != expected_policy_decision {
-		eyre::bail!(
-			"Authority boundary policy_decision must be `{}` for the changed surfaces.",
-			expected_policy_decision.as_str()
-		);
-	}
-	if input.disposition != input.policy_decision.disposition() {
-		eyre::bail!(
-			"Authority boundary disposition must be `{}` for policy decision `{}`.",
-			input.policy_decision.disposition().as_str(),
-			input.policy_decision.as_str()
-		);
-	}
-
-	for contract_id in &input.decision_contract_ids {
-		authority_boundary_required("authority boundary decision_contract_id", contract_id)?;
-	}
-	for surface in &input.changed_surfaces {
-		authority_boundary_required(
-			"authority boundary changed surface summary",
-			surface.change_summary,
-		)?;
-	}
-	for signal in &input.improvement_signals {
-		authority_boundary_required("authority boundary improvement kind", signal.kind)?;
-		authority_boundary_required(
-			"authority boundary improvement reason_code",
-			signal.reason_code,
-		)?;
-		authority_boundary_required("authority boundary improvement target", signal.target)?;
-		authority_boundary_required(
-			"authority boundary improvement recommendation",
-			signal.recommendation,
-		)?;
-	}
-
-	Ok(())
-}
-
-pub(crate) fn authority_boundary_required(name: &str, value: &str) -> Result<()> {
-	if value.trim().is_empty() {
-		eyre::bail!("{name} must not be empty.");
-	}
-
-	Ok(())
 }

--- a/apps/decodex/src/orchestrator/types/authority/boundary/validation.rs
+++ b/apps/decodex/src/orchestrator/types/authority/boundary/validation.rs
@@ -1,0 +1,97 @@
+use crate::orchestrator::types::{
+	AuthorityBoundaryCheckInput, AuthorityBoundaryPolicyDecision, Result, eyre,
+};
+
+pub(crate) fn validate_authority_boundary_check_input(
+	input: &AuthorityBoundaryCheckInput<'_>,
+) -> Result<()> {
+	authority_boundary_required("authority boundary project_id", input.project_id)?;
+	authority_boundary_required("authority boundary issue_id", input.issue_id)?;
+	authority_boundary_required("authority boundary issue_identifier", input.issue_identifier)?;
+	authority_boundary_required("authority boundary run_id", input.run_id)?;
+	authority_boundary_required(
+		"authority boundary attempted_recovery_reason",
+		input.attempted_recovery_reason,
+	)?;
+	authority_boundary_required(
+		"authority boundary final_disposition_reason",
+		input.final_disposition_reason,
+	)?;
+
+	if input.attempt_number < 1 {
+		eyre::bail!("Authority boundary attempt_number must be positive.");
+	}
+	if input.changed_surfaces.is_empty() {
+		eyre::bail!("Authority boundary changed_surfaces must not be empty.");
+	}
+
+	let mut expected_policy_decision = AuthorityBoundaryPolicyDecision::AutoContinue;
+
+	for surface in &input.changed_surfaces {
+		let surface_policy_decision = surface.surface.policy_decision();
+
+		if surface.policy_decision != surface_policy_decision {
+			eyre::bail!(
+				"Authority boundary surface `{}` must use policy decision `{}`.",
+				surface.surface.as_str(),
+				surface_policy_decision.as_str()
+			);
+		}
+		if surface.legacy_disposition != surface_policy_decision.disposition() {
+			eyre::bail!(
+				"Authority boundary surface `{}` must use legacy disposition `{}`.",
+				surface.surface.as_str(),
+				surface_policy_decision.disposition().as_str()
+			);
+		}
+
+		expected_policy_decision =
+			AuthorityBoundaryPolicyDecision::max(expected_policy_decision, surface_policy_decision);
+	}
+
+	if input.policy_decision != expected_policy_decision {
+		eyre::bail!(
+			"Authority boundary policy_decision must be `{}` for the changed surfaces.",
+			expected_policy_decision.as_str()
+		);
+	}
+	if input.disposition != input.policy_decision.disposition() {
+		eyre::bail!(
+			"Authority boundary disposition must be `{}` for policy decision `{}`.",
+			input.policy_decision.disposition().as_str(),
+			input.policy_decision.as_str()
+		);
+	}
+
+	for contract_id in &input.decision_contract_ids {
+		authority_boundary_required("authority boundary decision_contract_id", contract_id)?;
+	}
+	for surface in &input.changed_surfaces {
+		authority_boundary_required(
+			"authority boundary changed surface summary",
+			surface.change_summary,
+		)?;
+	}
+	for signal in &input.improvement_signals {
+		authority_boundary_required("authority boundary improvement kind", signal.kind)?;
+		authority_boundary_required(
+			"authority boundary improvement reason_code",
+			signal.reason_code,
+		)?;
+		authority_boundary_required("authority boundary improvement target", signal.target)?;
+		authority_boundary_required(
+			"authority boundary improvement recommendation",
+			signal.recommendation,
+		)?;
+	}
+
+	Ok(())
+}
+
+pub(crate) fn authority_boundary_required(name: &str, value: &str) -> Result<()> {
+	if value.trim().is_empty() {
+		eyre::bail!("{name} must not be empty.");
+	}
+
+	Ok(())
+}

--- a/apps/decodex/src/state/sqlite_store/mutations/autonomy.rs
+++ b/apps/decodex/src/state/sqlite_store/mutations/autonomy.rs
@@ -1,7 +1,8 @@
+mod signals;
+
 use crate::state::sqlite_store::mutations::{
-	self, AutonomyObjectiveRuntimeRecord, AutonomyProposalRuntimeRecord,
-	AutonomySignalRuntimeRecord, DecisionContractRuntimeRecord, ExecutionProgramRuntimeRecord,
-	Result, SqliteStateStore, eyre, persist,
+	self, AutonomyObjectiveRuntimeRecord, DecisionContractRuntimeRecord,
+	ExecutionProgramRuntimeRecord, Result, SqliteStateStore, eyre, persist,
 };
 
 impl SqliteStateStore {
@@ -63,100 +64,6 @@ impl SqliteStateStore {
 				record.objective.id(),
 				version,
 				record.state.as_str(),
-				payload_json,
-				&record.created_at,
-				record.created_at_unix,
-				&record.updated_at,
-				record.updated_at_unix,
-			],
-		)?;
-
-		Ok(())
-	}
-
-	pub(in crate::state) fn upsert_autonomy_signal(
-		&self,
-		record: &AutonomySignalRuntimeRecord,
-	) -> Result<()> {
-		let payload_json = serde_json::to_string(&record.signal)?;
-		let version = i64::try_from(record.signal.objective_version()).map_err(|_| {
-			eyre::eyre!("Autonomy signal objective_version exceeds SQLite integer range.")
-		})?;
-
-		self.connection.execute(
-			"INSERT INTO autonomy_signals (
-					project_id, signal_id, objective_id, objective_version, kind, fingerprint,
-					freshness, evidence_class, confidence, privacy, payload_json, created_at,
-					created_at_unix, updated_at, updated_at_unix
-				) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
-			 ON CONFLICT(project_id, signal_id) DO UPDATE SET
-				 objective_id = excluded.objective_id,
-				 objective_version = excluded.objective_version,
-				 kind = excluded.kind,
-				 fingerprint = excluded.fingerprint,
-				 freshness = excluded.freshness,
-				 evidence_class = excluded.evidence_class,
-				 confidence = excluded.confidence,
-				 privacy = excluded.privacy,
-				 payload_json = excluded.payload_json,
-				 updated_at = excluded.updated_at,
-				 updated_at_unix = excluded.updated_at_unix",
-			mutations::params![
-				&record.project_id,
-				record.signal.id(),
-				record.signal.objective_id(),
-				version,
-				record.signal.kind().as_str(),
-				record.signal.fingerprint(),
-				record.signal.freshness().as_str(),
-				record.signal.evidence_class().as_str(),
-				record.signal.confidence().as_str(),
-				record.signal.privacy().as_str(),
-				payload_json,
-				&record.created_at,
-				record.created_at_unix,
-				&record.updated_at,
-				record.updated_at_unix,
-			],
-		)?;
-
-		Ok(())
-	}
-
-	pub(in crate::state) fn upsert_autonomy_proposal(
-		&self,
-		record: &AutonomyProposalRuntimeRecord,
-	) -> Result<()> {
-		let payload_json = serde_json::to_string(&record.proposal)?;
-		let version = i64::try_from(record.proposal.objective_version()).map_err(|_| {
-			eyre::eyre!("Autonomy proposal objective_version exceeds SQLite integer range.")
-		})?;
-
-		self.connection.execute(
-			"INSERT INTO autonomy_proposals (
-					project_id, proposal_id, objective_id, objective_version, state, fingerprint,
-					source_family, intended_surface, payload_json, created_at, created_at_unix,
-					updated_at, updated_at_unix
-				) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
-			 ON CONFLICT(project_id, proposal_id) DO UPDATE SET
-				 objective_id = excluded.objective_id,
-				 objective_version = excluded.objective_version,
-				 state = excluded.state,
-				 fingerprint = excluded.fingerprint,
-				 source_family = excluded.source_family,
-				 intended_surface = excluded.intended_surface,
-				 payload_json = excluded.payload_json,
-				 updated_at = excluded.updated_at,
-				 updated_at_unix = excluded.updated_at_unix",
-			mutations::params![
-				&record.project_id,
-				record.proposal.id(),
-				record.proposal.objective_id(),
-				version,
-				record.state.as_str(),
-				record.proposal.fingerprint(),
-				record.proposal.source_family(),
-				record.proposal.intended_surface(),
 				payload_json,
 				&record.created_at,
 				record.created_at_unix,

--- a/apps/decodex/src/state/sqlite_store/mutations/autonomy/signals.rs
+++ b/apps/decodex/src/state/sqlite_store/mutations/autonomy/signals.rs
@@ -1,0 +1,100 @@
+use crate::state::sqlite_store::mutations::{
+	self, AutonomyProposalRuntimeRecord, AutonomySignalRuntimeRecord, Result, SqliteStateStore,
+	eyre,
+};
+
+impl SqliteStateStore {
+	pub(in crate::state) fn upsert_autonomy_signal(
+		&self,
+		record: &AutonomySignalRuntimeRecord,
+	) -> Result<()> {
+		let payload_json = serde_json::to_string(&record.signal)?;
+		let version = i64::try_from(record.signal.objective_version()).map_err(|_| {
+			eyre::eyre!("Autonomy signal objective_version exceeds SQLite integer range.")
+		})?;
+
+		self.connection.execute(
+			"INSERT INTO autonomy_signals (
+					project_id, signal_id, objective_id, objective_version, kind, fingerprint,
+					freshness, evidence_class, confidence, privacy, payload_json, created_at,
+					created_at_unix, updated_at, updated_at_unix
+				) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+			 ON CONFLICT(project_id, signal_id) DO UPDATE SET
+				 objective_id = excluded.objective_id,
+				 objective_version = excluded.objective_version,
+				 kind = excluded.kind,
+				 fingerprint = excluded.fingerprint,
+				 freshness = excluded.freshness,
+				 evidence_class = excluded.evidence_class,
+				 confidence = excluded.confidence,
+				 privacy = excluded.privacy,
+				 payload_json = excluded.payload_json,
+				 updated_at = excluded.updated_at,
+				 updated_at_unix = excluded.updated_at_unix",
+			mutations::params![
+				&record.project_id,
+				record.signal.id(),
+				record.signal.objective_id(),
+				version,
+				record.signal.kind().as_str(),
+				record.signal.fingerprint(),
+				record.signal.freshness().as_str(),
+				record.signal.evidence_class().as_str(),
+				record.signal.confidence().as_str(),
+				record.signal.privacy().as_str(),
+				payload_json,
+				&record.created_at,
+				record.created_at_unix,
+				&record.updated_at,
+				record.updated_at_unix,
+			],
+		)?;
+
+		Ok(())
+	}
+
+	pub(in crate::state) fn upsert_autonomy_proposal(
+		&self,
+		record: &AutonomyProposalRuntimeRecord,
+	) -> Result<()> {
+		let payload_json = serde_json::to_string(&record.proposal)?;
+		let version = i64::try_from(record.proposal.objective_version()).map_err(|_| {
+			eyre::eyre!("Autonomy proposal objective_version exceeds SQLite integer range.")
+		})?;
+
+		self.connection.execute(
+			"INSERT INTO autonomy_proposals (
+					project_id, proposal_id, objective_id, objective_version, state, fingerprint,
+					source_family, intended_surface, payload_json, created_at, created_at_unix,
+					updated_at, updated_at_unix
+				) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+			 ON CONFLICT(project_id, proposal_id) DO UPDATE SET
+				 objective_id = excluded.objective_id,
+				 objective_version = excluded.objective_version,
+				 state = excluded.state,
+				 fingerprint = excluded.fingerprint,
+				 source_family = excluded.source_family,
+				 intended_surface = excluded.intended_surface,
+				 payload_json = excluded.payload_json,
+				 updated_at = excluded.updated_at,
+				 updated_at_unix = excluded.updated_at_unix",
+			mutations::params![
+				&record.project_id,
+				record.proposal.id(),
+				record.proposal.objective_id(),
+				version,
+				record.state.as_str(),
+				record.proposal.fingerprint(),
+				record.proposal.source_family(),
+				record.proposal.intended_surface(),
+				payload_json,
+				&record.created_at,
+				record.created_at_unix,
+				&record.updated_at,
+				record.updated_at_unix,
+			],
+		)?;
+
+		Ok(())
+	}
+}

--- a/apps/decodex/src/state/store/execution_evidence/snapshot.rs
+++ b/apps/decodex/src/state/store/execution_evidence/snapshot.rs
@@ -1,12 +1,10 @@
+mod autonomy;
+
 use std::collections::HashMap;
 
-use crate::{
-	autonomy_objective::AutonomyObjectiveState,
-	state::store::{
-		AutonomyObjectiveRecord, AutonomyProposalRecord, AutonomySignalRecord,
-		DecisionContractRecord, PrivateExecutionEvent, ProgramIntakePlanRecord,
-		ReviewLifecycleRecord, ReviewPolicyCheckpoint,
-	},
+use crate::state::store::{
+	AutonomyObjectiveRecord, AutonomyProposalRecord, AutonomySignalRecord, DecisionContractRecord,
+	PrivateExecutionEvent, ProgramIntakePlanRecord, ReviewLifecycleRecord, ReviewPolicyCheckpoint,
 };
 
 /// Project-scoped loop evidence cached for one operator status render.
@@ -194,55 +192,5 @@ impl ProjectLoopEvidenceSnapshot {
 			attempt_number,
 			phase.to_owned(),
 		))
-	}
-
-	pub(crate) fn recent_autonomy_signals(&self, limit: usize) -> Vec<&AutonomySignalRecord> {
-		self.autonomy_signals.iter().take(limit).collect()
-	}
-
-	pub(crate) fn recent_autonomy_proposals(&self, limit: usize) -> Vec<&AutonomyProposalRecord> {
-		self.autonomy_proposals.iter().take(limit).collect()
-	}
-
-	pub(crate) fn autonomy_objective(
-		&self,
-		objective_id: &str,
-		objective_version: u64,
-	) -> Option<&AutonomyObjectiveRecord> {
-		self.autonomy_objectives.iter().find(|record| {
-			record.objective_id() == objective_id && record.version() == objective_version
-		})
-	}
-
-	pub(crate) fn accepted_autonomy_objectives(&self) -> Vec<&AutonomyObjectiveRecord> {
-		self.autonomy_objectives
-			.iter()
-			.filter(|record| record.state() == AutonomyObjectiveState::Accepted)
-			.collect()
-	}
-
-	pub(crate) fn decision_contracts_for_autonomy_proposal(
-		&self,
-		proposal_id: &str,
-	) -> Vec<&DecisionContractRecord> {
-		self.decision_contracts
-			.iter()
-			.filter(|record| {
-				record.contract().research_provenance().iter().any(|provenance| {
-					provenance.kind() == "autonomy_proposal"
-						&& provenance.reference() == proposal_id
-				})
-			})
-			.collect()
-	}
-
-	pub(crate) fn program_intake_plans_for_contract(
-		&self,
-		contract_id: &str,
-	) -> Vec<&ProgramIntakePlanRecord> {
-		self.program_intake_plans
-			.iter()
-			.filter(|record| record.source_contract_id() == Some(contract_id))
-			.collect()
 	}
 }

--- a/apps/decodex/src/state/store/execution_evidence/snapshot/autonomy.rs
+++ b/apps/decodex/src/state/store/execution_evidence/snapshot/autonomy.rs
@@ -1,0 +1,59 @@
+use crate::{
+	autonomy_objective::AutonomyObjectiveState,
+	state::store::{
+		AutonomyObjectiveRecord, AutonomyProposalRecord, AutonomySignalRecord,
+		DecisionContractRecord, ProgramIntakePlanRecord, ProjectLoopEvidenceSnapshot,
+	},
+};
+
+impl ProjectLoopEvidenceSnapshot {
+	pub(crate) fn recent_autonomy_signals(&self, limit: usize) -> Vec<&AutonomySignalRecord> {
+		self.autonomy_signals.iter().take(limit).collect()
+	}
+
+	pub(crate) fn recent_autonomy_proposals(&self, limit: usize) -> Vec<&AutonomyProposalRecord> {
+		self.autonomy_proposals.iter().take(limit).collect()
+	}
+
+	pub(crate) fn autonomy_objective(
+		&self,
+		objective_id: &str,
+		objective_version: u64,
+	) -> Option<&AutonomyObjectiveRecord> {
+		self.autonomy_objectives.iter().find(|record| {
+			record.objective_id() == objective_id && record.version() == objective_version
+		})
+	}
+
+	pub(crate) fn accepted_autonomy_objectives(&self) -> Vec<&AutonomyObjectiveRecord> {
+		self.autonomy_objectives
+			.iter()
+			.filter(|record| record.state() == AutonomyObjectiveState::Accepted)
+			.collect()
+	}
+
+	pub(crate) fn decision_contracts_for_autonomy_proposal(
+		&self,
+		proposal_id: &str,
+	) -> Vec<&DecisionContractRecord> {
+		self.decision_contracts
+			.iter()
+			.filter(|record| {
+				record.contract().research_provenance().iter().any(|provenance| {
+					provenance.kind() == "autonomy_proposal"
+						&& provenance.reference() == proposal_id
+				})
+			})
+			.collect()
+	}
+
+	pub(crate) fn program_intake_plans_for_contract(
+		&self,
+		contract_id: &str,
+	) -> Vec<&ProgramIntakePlanRecord> {
+		self.program_intake_plans
+			.iter()
+			.filter(|record| record.source_contract_id() == Some(contract_id))
+			.collect()
+	}
+}

--- a/apps/decodex/src/state/store_run_control/audit.rs
+++ b/apps/decodex/src/state/store_run_control/audit.rs
@@ -1,3 +1,5 @@
+mod event;
+
 use crate::{
 	prelude::Result,
 	state::{
@@ -143,60 +145,6 @@ impl StateStore {
 		reason: &str,
 		parent_record_id: Option<i64>,
 	) -> Result<PrivateExecutionEvent> {
-		validation::validate_run_control_action_outcome(outcome)?;
-
-		let channel = target.channel.as_ref();
-		let failure_class =
-			validation::run_control_action_failure_class(&target.action, outcome, reason);
-		let payload = serde_json::json!({
-			"schema": "decodex.run_control_action/v1",
-			"action": target.action,
-			"source": target.source,
-			"outcome": outcome,
-			"reason": reason,
-			"failure_class": failure_class,
-			"parent_record_id": parent_record_id,
-			"requested": {
-				"project_id": target.project_id,
-				"issue_id": target.issue_id,
-				"run_id": target.run_id,
-				"attempt_number": target.attempt_number,
-				"thread_id": target.thread_id,
-				"turn_id": target.turn_id,
-				"timeout_ms": target.timeout_ms,
-			},
-			"observed": {
-				"thread_id": target.current_thread_id.as_deref(),
-				"turn_id": target.current_turn_id.as_deref(),
-			},
-			"lane": {
-				"attempt_status": target.attempt_status.as_deref(),
-				"run_lease": target.run_lease,
-				"branch": target.branch_name.as_deref(),
-				"worktree_path": target.worktree_path.as_ref().map(|path| path.display().to_string()),
-				"event_count": target.event_count,
-				"last_event_type": target.last_event_type.as_deref(),
-				"last_event_at": target.last_event_at.as_deref(),
-			},
-			"metadata": target.metadata.as_ref(),
-			"context": target.context.as_ref(),
-			"channel": channel.map(|channel| serde_json::json!({
-				"transport": channel.transport(),
-				"channel_path": channel.channel_path().display().to_string(),
-				"status": channel.status(),
-				"published_at": channel.published_at(),
-				"updated_at": channel.updated_at(),
-				"path_exists": channel.channel_path().exists(),
-			})),
-		});
-
-		self.append_private_execution_event(
-			&target.project_id,
-			&target.issue_id,
-			&target.run_id,
-			target.attempt_number,
-			"control_action",
-			payload,
-		)
+		event::append_run_control_audit_event(self, target, outcome, reason, parent_record_id)
 	}
 }

--- a/apps/decodex/src/state/store_run_control/audit/event.rs
+++ b/apps/decodex/src/state/store_run_control/audit/event.rs
@@ -1,0 +1,71 @@
+use crate::{
+	prelude::Result,
+	state::{
+		PrivateExecutionEvent, StateStore,
+		store_run_control::{types::RunControlAuditTarget, validation},
+	},
+};
+
+pub(in crate::state::store_run_control::audit) fn append_run_control_audit_event(
+	store: &StateStore,
+	target: &RunControlAuditTarget,
+	outcome: &str,
+	reason: &str,
+	parent_record_id: Option<i64>,
+) -> Result<PrivateExecutionEvent> {
+	validation::validate_run_control_action_outcome(outcome)?;
+
+	let channel = target.channel.as_ref();
+	let failure_class =
+		validation::run_control_action_failure_class(&target.action, outcome, reason);
+	let payload = serde_json::json!({
+		"schema": "decodex.run_control_action/v1",
+		"action": target.action,
+		"source": target.source,
+		"outcome": outcome,
+		"reason": reason,
+		"failure_class": failure_class,
+		"parent_record_id": parent_record_id,
+		"requested": {
+			"project_id": target.project_id,
+			"issue_id": target.issue_id,
+			"run_id": target.run_id,
+			"attempt_number": target.attempt_number,
+			"thread_id": target.thread_id,
+			"turn_id": target.turn_id,
+			"timeout_ms": target.timeout_ms,
+		},
+		"observed": {
+			"thread_id": target.current_thread_id.as_deref(),
+			"turn_id": target.current_turn_id.as_deref(),
+		},
+		"lane": {
+			"attempt_status": target.attempt_status.as_deref(),
+			"run_lease": target.run_lease,
+			"branch": target.branch_name.as_deref(),
+			"worktree_path": target.worktree_path.as_ref().map(|path| path.display().to_string()),
+			"event_count": target.event_count,
+			"last_event_type": target.last_event_type.as_deref(),
+			"last_event_at": target.last_event_at.as_deref(),
+		},
+		"metadata": target.metadata.as_ref(),
+		"context": target.context.as_ref(),
+		"channel": channel.map(|channel| serde_json::json!({
+			"transport": channel.transport(),
+			"channel_path": channel.channel_path().display().to_string(),
+			"status": channel.status(),
+			"published_at": channel.published_at(),
+			"updated_at": channel.updated_at(),
+			"path_exists": channel.channel_path().exists(),
+		})),
+	});
+
+	store.append_private_execution_event(
+		&target.project_id,
+		&target.issue_id,
+		&target.run_id,
+		target.attempt_number,
+		"control_action",
+		payload,
+	)
+}


### PR DESCRIPTION
## Summary
- Split authority boundary validation out of the authority model file while preserving the same validation API.
- Split loop evidence autonomy readbacks into an evidence-owned submodule.
- Split SQLite autonomy signal/proposal persistence and run-control audit event construction into focused modules.

## Validation
- cargo +nightly fmt --all --check
- cargo check -p decodex --all-features --all-targets
- cargo make lint-vstyle-rust
- cargo clippy --workspace --all-features --all-targets -- -D clippy::all -D clippy::too_many_lines -D clippy::unwrap_used -D clippy::use_self -D clippy::wildcard_imports -D missing-docs -D unused-crate-dependencies -D warnings
- git diff --check
- find apps packages -type f -path '*/mod.rs'
- diff guard for include/path/super/wildcard/allow/expect additions
- cargo nextest run -p decodex --all-features -E 'test(/authority/) or test(/boundary/) or test(/autonomy/) or test(/execution_evidence/) or test(/run_control/) or test(/program/) or test(/decision_contract/)'

Targeted nextest result: 186 passed, 1438 skipped.