### PR TITLE
Modularize lane and lifecycle model surfaces

### DIFF
--- a/apps/decodex/src/autonomy_objective/lifecycle.rs
+++ b/apps/decodex/src/autonomy_objective/lifecycle.rs
@@ -1,5 +1,11 @@
 //! Objective lifecycle metadata and states.
 
+mod records;
+
+pub(crate) use records::{
+	AutonomyObjectiveAcceptance, AutonomyObjectiveRejection, AutonomyObjectiveSupersession,
+};
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -34,15 +40,6 @@ pub(crate) enum AutonomyObjectiveActorKind {
 	RuntimePolicy,
 }
 
-/// Acceptance metadata that turns a draft objective version into authority.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct AutonomyObjectiveAcceptance {
-	accepted_by: String,
-	accepted_by_kind: AutonomyObjectiveActorKind,
-	accepted_at: String,
-	acceptance_source: String,
-}
 #[allow(dead_code)]
 impl AutonomyObjectiveAcceptance {
 	pub(crate) fn new(
@@ -92,15 +89,6 @@ impl AutonomyObjectiveAcceptance {
 	}
 }
 
-/// Rejection metadata for a draft objective version that did not become authority.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct AutonomyObjectiveRejection {
-	rejected_by: String,
-	rejected_at: String,
-	rejection_source: String,
-	reason: String,
-}
 #[allow(dead_code)]
 impl AutonomyObjectiveRejection {
 	pub(crate) fn new(
@@ -143,17 +131,6 @@ impl AutonomyObjectiveRejection {
 	}
 }
 
-/// Supersession metadata linking an older objective version to the replacing version.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct AutonomyObjectiveSupersession {
-	superseded_by_objective_id: String,
-	superseded_by_version: u64,
-	superseded_by: String,
-	superseded_at: String,
-	supersession_source: String,
-	reason: String,
-}
 #[allow(dead_code)]
 impl AutonomyObjectiveSupersession {
 	pub(crate) fn new(

--- a/apps/decodex/src/autonomy_objective/lifecycle/records.rs
+++ b/apps/decodex/src/autonomy_objective/lifecycle/records.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+use crate::autonomy_objective::AutonomyObjectiveActorKind;
+
+/// Acceptance metadata that turns a draft objective version into authority.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AutonomyObjectiveAcceptance {
+	pub(super) accepted_by: String,
+	pub(super) accepted_by_kind: AutonomyObjectiveActorKind,
+	pub(super) accepted_at: String,
+	pub(super) acceptance_source: String,
+}
+
+/// Rejection metadata for a draft objective version that did not become authority.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AutonomyObjectiveRejection {
+	pub(super) rejected_by: String,
+	pub(super) rejected_at: String,
+	pub(super) rejection_source: String,
+	pub(super) reason: String,
+}
+
+/// Supersession metadata linking an older objective version to the replacing version.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AutonomyObjectiveSupersession {
+	pub(super) superseded_by_objective_id: String,
+	pub(super) superseded_by_version: u64,
+	pub(super) superseded_by: String,
+	pub(super) superseded_at: String,
+	pub(super) supersession_source: String,
+	pub(super) reason: String,
+}

--- a/apps/decodex/src/loop_contract/readiness.rs
+++ b/apps/decodex/src/loop_contract/readiness.rs
@@ -1,28 +1,12 @@
-use serde::{Deserialize, Serialize};
+mod records;
+
+pub(crate) use records::{DecisionExecutionReadiness, DecisionProposedIssue};
 
 use crate::{
 	loop_contract::{schema::DecisionContractStatus, validation},
 	prelude::{Result, eyre},
 };
 
-/// Natural-language readiness summary for later issue shaping.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct DecisionExecutionReadiness {
-	summary: String,
-	pub(super) ready_for_issue_shaping: bool,
-	#[serde(default)]
-	pub(super) missing_decisions: Vec<String>,
-	#[serde(default)]
-	validation_expectations: Vec<String>,
-	#[serde(default)]
-	risk_notes: Vec<String>,
-	pub(super) proposed_issues: Vec<DecisionProposedIssue>,
-	#[serde(default)]
-	promotion_targets: Vec<String>,
-	#[serde(default)]
-	conflict_domains: Vec<String>,
-}
 #[allow(dead_code)]
 impl DecisionExecutionReadiness {
 	pub(crate) fn summary(&self) -> &str {
@@ -110,21 +94,6 @@ impl DecisionExecutionReadiness {
 	}
 }
 
-/// Structured issue-shaping input retained inside Decision Contract readiness.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct DecisionProposedIssue {
-	key: String,
-	title: String,
-	objective: String,
-	stage: String,
-	dependencies: Vec<String>,
-	conflict_domains: Vec<String>,
-	acceptance: Vec<String>,
-	validation: Vec<String>,
-	risk: Vec<String>,
-	queue_intent: String,
-}
 #[allow(dead_code)]
 impl DecisionProposedIssue {
 	pub(crate) fn key(&self) -> &str {

--- a/apps/decodex/src/loop_contract/readiness/records.rs
+++ b/apps/decodex/src/loop_contract/readiness/records.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+/// Natural-language readiness summary for later issue shaping.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DecisionExecutionReadiness {
+	pub(in crate::loop_contract) summary: String,
+	pub(in crate::loop_contract) ready_for_issue_shaping: bool,
+	#[serde(default)]
+	pub(in crate::loop_contract) missing_decisions: Vec<String>,
+	#[serde(default)]
+	pub(in crate::loop_contract) validation_expectations: Vec<String>,
+	#[serde(default)]
+	pub(in crate::loop_contract) risk_notes: Vec<String>,
+	pub(in crate::loop_contract) proposed_issues: Vec<DecisionProposedIssue>,
+	#[serde(default)]
+	pub(in crate::loop_contract) promotion_targets: Vec<String>,
+	#[serde(default)]
+	pub(in crate::loop_contract) conflict_domains: Vec<String>,
+}
+
+/// Structured issue-shaping input retained inside Decision Contract readiness.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DecisionProposedIssue {
+	pub(in crate::loop_contract) key: String,
+	pub(in crate::loop_contract) title: String,
+	pub(in crate::loop_contract) objective: String,
+	pub(in crate::loop_contract) stage: String,
+	pub(in crate::loop_contract) dependencies: Vec<String>,
+	pub(in crate::loop_contract) conflict_domains: Vec<String>,
+	pub(in crate::loop_contract) acceptance: Vec<String>,
+	pub(in crate::loop_contract) validation: Vec<String>,
+	pub(in crate::loop_contract) risk: Vec<String>,
+	pub(in crate::loop_contract) queue_intent: String,
+}

--- a/apps/decodex/src/orchestrator/lane_decision.rs
+++ b/apps/decodex/src/orchestrator/lane_decision.rs
@@ -1,6 +1,9 @@
+mod decision_model;
 mod json_projection;
 mod model;
 mod projection;
+mod snapshot_json;
+mod snapshot_observation;
 
 pub(super) use self::{
 	model::{LaneDecisionSnapshot, LaneNextAction},

--- a/apps/decodex/src/orchestrator/lane_decision/decision_model.rs
+++ b/apps/decodex/src/orchestrator/lane_decision/decision_model.rs
@@ -1,0 +1,28 @@
+use crate::orchestrator::{
+	RetryKind,
+	kernel::{action::OwnedLaneAction, command::CommandIntentKind},
+	lane_decision::model::LaneDecision,
+};
+
+impl LaneDecision {
+	pub(in crate::orchestrator) fn permits_child_exit_retry_kind(&self, kind: RetryKind) -> bool {
+		let required_intent = match kind {
+			RetryKind::Continuation => CommandIntentKind::ResumeRetainedLane,
+			RetryKind::Failure => CommandIntentKind::ScheduleRetry,
+		};
+
+		self.has_command_intent(required_intent)
+	}
+
+	pub(in crate::orchestrator) fn permits_phase_repair_retry(&self) -> bool {
+		self.has_command_intent(CommandIntentKind::ScheduleRetry)
+	}
+
+	pub(in crate::orchestrator) fn blocks_automatic_execution(&self) -> bool {
+		self.kernel_decision.decision_class == OwnedLaneAction::ManualInterventionRequired
+	}
+
+	fn has_command_intent(&self, kind: CommandIntentKind) -> bool {
+		self.kernel_decision.command_intents.iter().any(|intent| intent.kind == kind)
+	}
+}

--- a/apps/decodex/src/orchestrator/lane_decision/model.rs
+++ b/apps/decodex/src/orchestrator/lane_decision/model.rs
@@ -1,15 +1,6 @@
-use serde_json::Value;
-
 use crate::orchestrator::{
 	IssueDispatchMode, PhaseGoalKind, RepoGateFailureDisposition, RetryKind,
-	kernel::{
-		action::OwnedLaneAction,
-		command::CommandIntentKind,
-		decision::OwnedLaneDecision,
-		facts::LaneObservation,
-		state::{LivenessState, TerminalizationState},
-	},
-	lane_decision::{json_projection, projection},
+	kernel::decision::OwnedLaneDecision,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -148,61 +139,6 @@ impl LaneDecisionSnapshot {
 			terminal_evidence_present: false,
 		}
 	}
-
-	pub(in crate::orchestrator) fn to_json(&self, action: LaneNextAction, reason: &str) -> Value {
-		let decision = projection::decide_lane_next_action(self);
-
-		serde_json::json!({
-			"schema": "decodex.lane_decision_snapshot/1",
-			"issue_identifier": self.issue_identifier,
-			"run_id": self.run_id,
-			"attempt_number": self.attempt_number,
-			"dispatch_mode": self.dispatch_mode.as_str(),
-			"active_phase": self.active_phase.map(PhaseGoalKind::as_str),
-			"continuation_pending": self.continuation_pending,
-			"retry_kind": self.retry_kind.map(RetryKind::as_str),
-			"retry_budget_consumed": self.retry_budget_consumed,
-			"progress_blocker_count": self.progress_blocker_count,
-			"non_goal_violation": self.non_goal_violation,
-			"phase_acceptance_failure": self.phase_acceptance_failure,
-			"repo_gate_disposition": self.repo_gate_disposition.map(RepoGateFailureDisposition::as_str),
-			"scope_envelope_violation": self.scope_envelope_violation,
-			"ambiguous_lineage": self.ambiguous_lineage,
-			"terminal_evidence_present": self.terminal_evidence_present,
-			"next_action": action.as_str(),
-			"reason": reason,
-			"kernel_decision": json_projection::owned_lane_decision_to_json(&decision.kernel_decision),
-		})
-	}
-
-	pub(super) fn to_kernel_observation(&self) -> LaneObservation {
-		let mut observation = LaneObservation::for_issue(self.issue_identifier.clone());
-
-		observation.run_id = Some(self.run_id.clone());
-		observation.authority_complete = true;
-		observation.run_lease = true;
-		observation.active_owned_work = true;
-		observation.liveness = LivenessState::ThreadActive;
-		observation.terminalization = if self.terminal_evidence_present {
-			TerminalizationState::CleanupPending
-		} else {
-			TerminalizationState::None
-		};
-		observation.contradictory_authority = self.ambiguous_lineage;
-		observation.human_attention_signal = self.progress_blocker_count > 0
-			|| self.non_goal_violation
-			|| self.scope_envelope_violation
-			|| self.repo_gate_disposition == Some(RepoGateFailureDisposition::NeedsHumanAttention);
-		observation.retry_budget_available = self.phase_acceptance_failure
-			|| self.retry_kind.is_some()
-			|| self.repo_gate_disposition == Some(RepoGateFailureDisposition::ContinueRepair);
-		observation.retry_budget_exhausted = false;
-		observation.retained_lane_reusable = self.continuation_pending;
-		observation.external_signal_pending =
-			self.repo_gate_disposition == Some(RepoGateFailureDisposition::RetryAfterBackoff);
-
-		observation
-	}
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -218,26 +154,5 @@ impl LaneDecision {
 		kernel_decision: OwnedLaneDecision,
 	) -> Self {
 		Self { next_action, reason, kernel_decision }
-	}
-
-	pub(in crate::orchestrator) fn permits_child_exit_retry_kind(&self, kind: RetryKind) -> bool {
-		let required_intent = match kind {
-			RetryKind::Continuation => CommandIntentKind::ResumeRetainedLane,
-			RetryKind::Failure => CommandIntentKind::ScheduleRetry,
-		};
-
-		self.has_command_intent(required_intent)
-	}
-
-	pub(in crate::orchestrator) fn permits_phase_repair_retry(&self) -> bool {
-		self.has_command_intent(CommandIntentKind::ScheduleRetry)
-	}
-
-	pub(in crate::orchestrator) fn blocks_automatic_execution(&self) -> bool {
-		self.kernel_decision.decision_class == OwnedLaneAction::ManualInterventionRequired
-	}
-
-	fn has_command_intent(&self, kind: CommandIntentKind) -> bool {
-		self.kernel_decision.command_intents.iter().any(|intent| intent.kind == kind)
 	}
 }

--- a/apps/decodex/src/orchestrator/lane_decision/snapshot_json.rs
+++ b/apps/decodex/src/orchestrator/lane_decision/snapshot_json.rs
@@ -1,0 +1,34 @@
+use serde_json::Value;
+
+use crate::orchestrator::{
+	PhaseGoalKind, RepoGateFailureDisposition, RetryKind,
+	lane_decision::{LaneDecisionSnapshot, LaneNextAction, json_projection, projection},
+};
+
+impl LaneDecisionSnapshot {
+	pub(in crate::orchestrator) fn to_json(&self, action: LaneNextAction, reason: &str) -> Value {
+		let decision = projection::decide_lane_next_action(self);
+
+		serde_json::json!({
+			"schema": "decodex.lane_decision_snapshot/1",
+			"issue_identifier": self.issue_identifier,
+			"run_id": self.run_id,
+			"attempt_number": self.attempt_number,
+			"dispatch_mode": self.dispatch_mode.as_str(),
+			"active_phase": self.active_phase.map(PhaseGoalKind::as_str),
+			"continuation_pending": self.continuation_pending,
+			"retry_kind": self.retry_kind.map(RetryKind::as_str),
+			"retry_budget_consumed": self.retry_budget_consumed,
+			"progress_blocker_count": self.progress_blocker_count,
+			"non_goal_violation": self.non_goal_violation,
+			"phase_acceptance_failure": self.phase_acceptance_failure,
+			"repo_gate_disposition": self.repo_gate_disposition.map(RepoGateFailureDisposition::as_str),
+			"scope_envelope_violation": self.scope_envelope_violation,
+			"ambiguous_lineage": self.ambiguous_lineage,
+			"terminal_evidence_present": self.terminal_evidence_present,
+			"next_action": action.as_str(),
+			"reason": reason,
+			"kernel_decision": json_projection::owned_lane_decision_to_json(&decision.kernel_decision),
+		})
+	}
+}

--- a/apps/decodex/src/orchestrator/lane_decision/snapshot_observation.rs
+++ b/apps/decodex/src/orchestrator/lane_decision/snapshot_observation.rs
@@ -1,0 +1,39 @@
+use crate::orchestrator::{
+	RepoGateFailureDisposition,
+	kernel::{
+		facts::LaneObservation,
+		state::{LivenessState, TerminalizationState},
+	},
+	lane_decision::model::LaneDecisionSnapshot,
+};
+
+impl LaneDecisionSnapshot {
+	pub(in crate::orchestrator) fn to_kernel_observation(&self) -> LaneObservation {
+		let mut observation = LaneObservation::for_issue(self.issue_identifier.clone());
+
+		observation.run_id = Some(self.run_id.clone());
+		observation.authority_complete = true;
+		observation.run_lease = true;
+		observation.active_owned_work = true;
+		observation.liveness = LivenessState::ThreadActive;
+		observation.terminalization = if self.terminal_evidence_present {
+			TerminalizationState::CleanupPending
+		} else {
+			TerminalizationState::None
+		};
+		observation.contradictory_authority = self.ambiguous_lineage;
+		observation.human_attention_signal = self.progress_blocker_count > 0
+			|| self.non_goal_violation
+			|| self.scope_envelope_violation
+			|| self.repo_gate_disposition == Some(RepoGateFailureDisposition::NeedsHumanAttention);
+		observation.retry_budget_available = self.phase_acceptance_failure
+			|| self.retry_kind.is_some()
+			|| self.repo_gate_disposition == Some(RepoGateFailureDisposition::ContinueRepair);
+		observation.retry_budget_exhausted = false;
+		observation.retained_lane_reusable = self.continuation_pending;
+		observation.external_signal_pending =
+			self.repo_gate_disposition == Some(RepoGateFailureDisposition::RetryAfterBackoff);
+
+		observation
+	}
+}

--- a/apps/decodex/src/state/models/review.rs
+++ b/apps/decodex/src/state/models/review.rs
@@ -1,26 +1,13 @@
 mod checkpoints;
 mod handoff;
+mod records;
 
 pub(crate) use self::{
 	checkpoints::{LoopGuardrailCheckpoint, ReviewPolicyCheckpoint},
 	handoff::ReviewHandoffMarker,
+	records::{ReviewLifecycleRecord, ReviewOrchestrationMarker},
 };
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct ReviewOrchestrationMarker {
-	pub(in crate::state) run_id: String,
-	pub(in crate::state) attempt_number: i64,
-	pub(in crate::state) branch_name: String,
-	pub(in crate::state) pr_url: String,
-	pub(in crate::state) head_sha: String,
-	pub(in crate::state) phase: String,
-	pub(in crate::state) request_comment_database_id: Option<i64>,
-	pub(in crate::state) request_created_at_unix_epoch: Option<i64>,
-	pub(in crate::state) request_description_thumbs_up_count: Option<usize>,
-	pub(in crate::state) request_retry_count: i64,
-	pub(in crate::state) external_round_count: i64,
-	pub(in crate::state) auto_merge_enabled_at_unix_epoch: Option<i64>,
-}
 impl ReviewOrchestrationMarker {
 	#[allow(clippy::too_many_arguments)]
 	pub(crate) fn new(
@@ -102,34 +89,6 @@ impl ReviewOrchestrationMarker {
 	}
 }
 
-/// Runtime-owned review lifecycle record for one retained PR-backed lane.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct ReviewLifecycleRecord {
-	pub(in crate::state) project_id: String,
-	pub(in crate::state) issue_id: String,
-	pub(in crate::state) branch_name: String,
-	pub(in crate::state) run_id: String,
-	pub(in crate::state) attempt_number: i64,
-	pub(in crate::state) pr_url: String,
-	pub(in crate::state) target_base_ref_name: Option<String>,
-	pub(in crate::state) pr_head_ref_name: String,
-	pub(in crate::state) pr_head_oid: String,
-	pub(in crate::state) head_sha: String,
-	pub(in crate::state) phase: String,
-	pub(in crate::state) request_comment_database_id: Option<i64>,
-	pub(in crate::state) request_created_at_unix_epoch: Option<i64>,
-	pub(in crate::state) request_description_thumbs_up_count: Option<usize>,
-	pub(in crate::state) request_retry_count: i64,
-	pub(in crate::state) external_round_count: i64,
-	pub(in crate::state) auto_merge_enabled_at_unix_epoch: Option<i64>,
-	pub(in crate::state) landing_state: String,
-	pub(in crate::state) closeout_state: String,
-	pub(in crate::state) repair_attempt_count: i64,
-	pub(in crate::state) evidence_json: String,
-	pub(in crate::state) next_action: String,
-	pub(in crate::state) updated_at: String,
-	pub(in crate::state) updated_at_unix: i64,
-}
 #[allow(dead_code)]
 impl ReviewLifecycleRecord {
 	pub(crate) fn project_id(&self) -> &str {

--- a/apps/decodex/src/state/models/review/records.rs
+++ b/apps/decodex/src/state/models/review/records.rs
@@ -1,0 +1,44 @@
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ReviewOrchestrationMarker {
+	pub(in crate::state) run_id: String,
+	pub(in crate::state) attempt_number: i64,
+	pub(in crate::state) branch_name: String,
+	pub(in crate::state) pr_url: String,
+	pub(in crate::state) head_sha: String,
+	pub(in crate::state) phase: String,
+	pub(in crate::state) request_comment_database_id: Option<i64>,
+	pub(in crate::state) request_created_at_unix_epoch: Option<i64>,
+	pub(in crate::state) request_description_thumbs_up_count: Option<usize>,
+	pub(in crate::state) request_retry_count: i64,
+	pub(in crate::state) external_round_count: i64,
+	pub(in crate::state) auto_merge_enabled_at_unix_epoch: Option<i64>,
+}
+
+/// Runtime-owned review lifecycle record for one retained PR-backed lane.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ReviewLifecycleRecord {
+	pub(in crate::state) project_id: String,
+	pub(in crate::state) issue_id: String,
+	pub(in crate::state) branch_name: String,
+	pub(in crate::state) run_id: String,
+	pub(in crate::state) attempt_number: i64,
+	pub(in crate::state) pr_url: String,
+	pub(in crate::state) target_base_ref_name: Option<String>,
+	pub(in crate::state) pr_head_ref_name: String,
+	pub(in crate::state) pr_head_oid: String,
+	pub(in crate::state) head_sha: String,
+	pub(in crate::state) phase: String,
+	pub(in crate::state) request_comment_database_id: Option<i64>,
+	pub(in crate::state) request_created_at_unix_epoch: Option<i64>,
+	pub(in crate::state) request_description_thumbs_up_count: Option<usize>,
+	pub(in crate::state) request_retry_count: i64,
+	pub(in crate::state) external_round_count: i64,
+	pub(in crate::state) auto_merge_enabled_at_unix_epoch: Option<i64>,
+	pub(in crate::state) landing_state: String,
+	pub(in crate::state) closeout_state: String,
+	pub(in crate::state) repair_attempt_count: i64,
+	pub(in crate::state) evidence_json: String,
+	pub(in crate::state) next_action: String,
+	pub(in crate::state) updated_at: String,
+	pub(in crate::state) updated_at_unix: i64,
+}


### PR DESCRIPTION
## Summary
- Move lane-decision behavior out of the central model type into focused flat Rust modules.
- Move lifecycle/readiness/review record structs into owned record modules without mod.rs.
- Keep visibility explicit and avoid new allow/expect/path/include/wildcard/super patterns.

## Validation
- cargo check -p decodex --all-features --all-targets
- cargo +nightly fmt --all --check
- cargo make lint-vstyle-rust
- cargo clippy --workspace --all-features --all-targets -- -D clippy::all -D clippy::too_many_lines -D clippy::unwrap_used -D clippy::use_self -D clippy::wildcard_imports -D missing-docs -D unused-crate-dependencies -D warnings
- git diff --check
- find apps packages -type f -path "*/mod.rs"
- git diff guard for include/path/wildcard/super/new allow/expect patterns
- cargo nextest run -p decodex --all-features -E "test(/lane_decision/) or test(/loop_contract::tests/) or test(/autonomy_objective::tests/) or test(/state::tests::review_lifecycle::review_records/)"

## Notes
- A broader targeted nextest expression ran 416/420 passing, then was interrupted after four unrelated slow review-handoff/runtime tests exceeded five minutes. The narrower changed-surface suite passed 26/26.