### PR TITLE
Make missing-payload guidance status-neutral

### DIFF
--- a/apps/decodex/src/agent/app_server/tests/runtime/turn_failures.rs
+++ b/apps/decodex/src/agent/app_server/tests/runtime/turn_failures.rs
@@ -216,6 +216,40 @@ fn turn_completed_without_error_payload_becomes_structured_turn_failure() {
 }
 
 #[test]
+fn missing_error_payload_terminal_guidance_is_status_neutral() {
+	let notification = JsonRpcNotification {
+		method: String::from("turn/completed"),
+		params: serde_json::json!({
+			"turn": {
+				"id": "turn-1",
+				"status": "failed",
+				"error": null
+			}
+		}),
+	};
+	let mut final_output = String::new();
+	let mut latest_turn_failure = None;
+	let result = super::handle_turn_execution_notification(
+		&notification,
+		"thread-1",
+		"turn-1",
+		&mut final_output,
+		&mut latest_turn_failure,
+	);
+	let error = match result {
+		Ok(_) => panic!("failed turn without payload should fail the turn"),
+		Err(error) => error,
+	};
+	let failure =
+		error.downcast_ref::<AppServerTurnFailure>().expect("error should be a turn failure");
+	let next_action = failure.terminal_next_action("recover manually");
+
+	assert!(next_action.contains("terminal turn status `failed`"));
+	assert!(next_action.contains("terminal turn left useful worktree changes"));
+	assert!(!next_action.contains("interrupted turn"));
+}
+
+#[test]
 fn json_rpc_error_response_becomes_recoverable_turn_failure() {
 	let error = JsonRpcError {
 		id: serde_json::json!(7),

--- a/apps/decodex/src/agent/app_server/turn_failure.rs
+++ b/apps/decodex/src/agent/app_server/turn_failure.rs
@@ -89,7 +89,7 @@ impl AppServerTurnFailure {
 	pub(crate) fn terminal_next_action(&self, recovery_gate: &str) -> String {
 		if self.missing_error_payload {
 			return format!(
-				"inspect app-server protocol activity for the terminal turn status `{}`, verify whether the interrupted turn left useful worktree changes, {recovery_gate}",
+				"inspect app-server protocol activity for the terminal turn status `{}`, verify whether the terminal turn left useful worktree changes, {recovery_gate}",
 				self.status
 			);
 		}

--- a/plugins/codebase/scripts/codex_lifecycle_hook
+++ b/plugins/codebase/scripts/codex_lifecycle_hook
@@ -11,6 +11,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+sys.dont_write_bytecode = True
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))


### PR DESCRIPTION
Summary:
- make missing-error-payload terminal guidance status-neutral for failed/interrupted app-server turns
- add regression coverage for failed turn/completed without an error payload
- prevent the installed codebase lifecycle hook from creating plugin __pycache__ noise

Validation:
- cargo make fmt
- cargo test -p decodex missing_error_payload_terminal_guidance_is_status_neutral -- --nocapture
- cargo make check (1657 passed, 1 skipped)
- plugin-eval analyze plugins/codebase --format markdown (86/100, existing warnings only)
- direct codebase hook smoke confirmed no plugins/ __pycache__ regeneration
- subagent skeptic review: no blocking findings