### PR TITLE
Clarify Program Intake dispatch readiness

### DIFF
--- a/apps/decodex/src/orchestrator/run_cycle/target_issue.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue.rs
@@ -11,9 +11,9 @@ pub(crate) use inferred::run_target_issue_once_with_inferred_dispatch;
 #[cfg(test)] pub(crate) use program::select_target_status_visible_program_candidate;
 
 use crate::orchestrator::run_cycle::{
-	self, IssueDispatchMode, IssueTracker, PrepareIssueRunContext, Result, RetryIssueStateHint,
-	RunSummary, ServiceConfig, StateStore, TargetIssueRunContext, TrackerIssue, WorktreeManager,
-	eyre,
+	self, IssueDispatchMode, IssueRunPlan, IssueTracker, PrepareIssueRunContext, Result,
+	RetryIssueStateHint, RunSummary, ServiceConfig, StateStore, TargetIssueRunContext,
+	TrackerIssue, WorktreeManager, eyre,
 };
 
 pub(crate) fn run_target_issue_once<T>(
@@ -22,102 +22,22 @@ pub(crate) fn run_target_issue_once<T>(
 where
 	T: IssueTracker,
 {
-	let worktree_manager = WorktreeManager::new(
-		context.project.service_id(),
-		context.project.repo_root(),
-		context.project.worktree_root(),
-	);
+	run_target_issue_once_after_prepare(context, |_| Ok(()))
+}
 
-	context.state_store.configure_dispatch_slot_root(
-		context.project.service_id(),
-		context.project.worktree_root(),
-	)?;
-
-	let issue_id = identity::resolve_target_issue_id(context.tracker, context.issue_id)?;
-
-	if !context.dry_run {
-		context.state_store.canonicalize_issue_identity(context.issue_id, &issue_id)?;
-	}
-	if context.lease_preacquired && !context.dry_run {
-		lease::adopt_preacquired_target_issue_lease(&context, &issue_id)?;
-	}
-	if !context.lease_preacquired {
-		run_cycle::recover_runtime_state_from_tracker_and_worktrees(
-			context.tracker,
-			context.project,
-			context.workflow,
-			context.state_store,
-		)?;
-
-		if !context.dry_run {
-			run_cycle::reconcile_project_state(
-				context.tracker,
-				context.project,
-				context.workflow,
-				context.state_store,
-				&worktree_manager,
-			)?;
-		}
-	}
-
-	let Some(issue) = run_cycle::refresh_issue(context.tracker, &issue_id)? else {
+pub(crate) fn run_target_issue_once_after_prepare<T, F>(
+	context: TargetIssueRunContext<'_, T>,
+	after_prepare: F,
+) -> Result<Option<RunSummary>>
+where
+	T: IssueTracker,
+	F: FnOnce(&IssueRunPlan) -> Result<()>,
+{
+	let Some(issue_run) = plan_target_issue_run(&context)? else {
 		return Ok(None);
 	};
-	let closeout_preferred_run_identity =
-		closeout::target_closeout_preferred_run_identity(&context, &issue)?;
-	let preferred_run_identity = closeout::preferred_run_identity_with_closeout_fallback(
-		context.preferred_run_identity,
-		closeout_preferred_run_identity.as_ref(),
-	);
-	let retry_state_hint = RetryIssueStateHint {
-		preferred_issue_state: context.preferred_issue_state,
-		preferred_initial_issue_state: context.preferred_initial_issue_state,
-	};
 
-	if !run_cycle::issue_passes_current_dispatch_policy(
-		context.tracker,
-		&issue,
-		context.project,
-		context.workflow,
-		context.state_store,
-		context.dispatch_mode,
-		retry_state_hint,
-	)? {
-		ensure_target_closeout_dispatch_is_unblocked(&context, &issue)?;
-
-		return Ok(None);
-	}
-
-	let reuses_existing_closeout_claim =
-		closeout::target_issue_reuses_existing_closeout_claim(&context, &issue_id, &issue)?;
-
-	if target_issue_active_claim_blocks_dispatch(&context, &issue_id, &issue)? {
-		return Ok(None);
-	}
-	if !context.dry_run && context.dispatch_mode != IssueDispatchMode::Closeout {
-		run_cycle::ensure_project_has_no_merged_worktree_cleanup_debt(context.project)?;
-	}
-
-	let Some(issue_run) = run_cycle::prepare_issue_run(
-		PrepareIssueRunContext {
-			tracker: context.tracker,
-			project: context.project,
-			workflow: context.workflow,
-			state_store: context.state_store,
-			worktree_manager: &worktree_manager,
-			dry_run: context.dry_run,
-			lease_preacquired: context.lease_preacquired || reuses_existing_closeout_claim,
-			dispatch_mode: context.dispatch_mode,
-			preferred_issue_state: context.preferred_issue_state,
-			preferred_initial_issue_state: context.preferred_initial_issue_state,
-			preferred_run_identity,
-			preferred_retry_budget_base: context.preferred_retry_budget_base,
-		},
-		issue,
-	)?
-	else {
-		return Ok(None);
-	};
+	after_prepare(&issue_run)?;
 
 	run_cycle::complete_issue_run(
 		context.tracker,
@@ -160,6 +80,110 @@ where
 	T: IssueTracker,
 {
 	identity::resolve_target_issue_id(tracker, issue_reference)
+}
+
+fn plan_target_issue_run<T>(context: &TargetIssueRunContext<'_, T>) -> Result<Option<IssueRunPlan>>
+where
+	T: IssueTracker,
+{
+	let worktree_manager = WorktreeManager::new(
+		context.project.service_id(),
+		context.project.repo_root(),
+		context.project.worktree_root(),
+	);
+
+	context.state_store.configure_dispatch_slot_root(
+		context.project.service_id(),
+		context.project.worktree_root(),
+	)?;
+
+	let issue_id = identity::resolve_target_issue_id(context.tracker, context.issue_id)?;
+
+	if !context.dry_run {
+		context.state_store.canonicalize_issue_identity(context.issue_id, &issue_id)?;
+	}
+	if context.lease_preacquired && !context.dry_run {
+		lease::adopt_preacquired_target_issue_lease(context, &issue_id)?;
+	}
+	if !context.lease_preacquired {
+		run_cycle::recover_runtime_state_from_tracker_and_worktrees(
+			context.tracker,
+			context.project,
+			context.workflow,
+			context.state_store,
+		)?;
+
+		if !context.dry_run {
+			run_cycle::reconcile_project_state(
+				context.tracker,
+				context.project,
+				context.workflow,
+				context.state_store,
+				&worktree_manager,
+			)?;
+		}
+	}
+
+	let Some(issue) = run_cycle::refresh_issue(context.tracker, &issue_id)? else {
+		return Ok(None);
+	};
+	let closeout_preferred_run_identity =
+		closeout::target_closeout_preferred_run_identity(context, &issue)?;
+	let preferred_run_identity = closeout::preferred_run_identity_with_closeout_fallback(
+		context.preferred_run_identity,
+		closeout_preferred_run_identity.as_ref(),
+	);
+	let retry_state_hint = RetryIssueStateHint {
+		preferred_issue_state: context.preferred_issue_state,
+		preferred_initial_issue_state: context.preferred_initial_issue_state,
+	};
+
+	if !run_cycle::issue_passes_current_dispatch_policy(
+		context.tracker,
+		&issue,
+		context.project,
+		context.workflow,
+		context.state_store,
+		context.dispatch_mode,
+		retry_state_hint,
+	)? {
+		ensure_target_closeout_dispatch_is_unblocked(context, &issue)?;
+
+		return Ok(None);
+	}
+
+	let reuses_existing_closeout_claim =
+		closeout::target_issue_reuses_existing_closeout_claim(context, &issue_id, &issue)?;
+
+	if target_issue_active_claim_blocks_dispatch(context, &issue_id, &issue)? {
+		return Ok(None);
+	}
+	if !context.dry_run && context.dispatch_mode != IssueDispatchMode::Closeout {
+		run_cycle::ensure_project_has_no_merged_worktree_cleanup_debt(context.project)?;
+	}
+
+	let Some(issue_run) = run_cycle::prepare_issue_run(
+		PrepareIssueRunContext {
+			tracker: context.tracker,
+			project: context.project,
+			workflow: context.workflow,
+			state_store: context.state_store,
+			worktree_manager: &worktree_manager,
+			dry_run: context.dry_run,
+			lease_preacquired: context.lease_preacquired || reuses_existing_closeout_claim,
+			dispatch_mode: context.dispatch_mode,
+			preferred_issue_state: context.preferred_issue_state,
+			preferred_initial_issue_state: context.preferred_initial_issue_state,
+			preferred_run_identity,
+			preferred_retry_budget_base: context.preferred_retry_budget_base,
+		},
+		issue,
+	)?
+	else {
+		return Ok(None);
+	};
+
+	Ok(Some(issue_run))
 }
 
 fn ensure_target_closeout_dispatch_is_unblocked<T>(

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue/program.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue/program.rs
@@ -11,11 +11,26 @@ pub(crate) fn run_target_status_visible_program_once<T>(
 where
 	T: IssueTracker,
 {
-	let Some(_) = select_target_status_visible_program_candidate(&context)? else {
+	let Some(selected) = select_target_status_visible_program_candidate(&context)? else {
 		return Ok(None);
 	};
+	let program_dispatch = selected.program_dispatch.clone();
+	let dry_run = context.dry_run;
+	let state_store = context.state_store;
+	let project_id = context.project.service_id().to_owned();
 
-	target_issue::run_target_issue_once(context)
+	target_issue::run_target_issue_once_after_prepare(context, |issue_run| {
+		if !dry_run && let Some(program_dispatch) = program_dispatch.as_ref() {
+			orchestrator::record_program_dispatch_selected(
+				state_store,
+				&project_id,
+				issue_run,
+				program_dispatch,
+			)?;
+		}
+
+		Ok(())
+	})
 }
 
 pub(crate) fn select_target_status_visible_program_candidate<T>(

--- a/apps/decodex/src/orchestrator/selection/hints.rs
+++ b/apps/decodex/src/orchestrator/selection/hints.rs
@@ -18,8 +18,9 @@ pub(crate) fn format_no_eligible_issue_message(
 
 pub(crate) fn format_status_no_eligible_issue_hint(service_id: &str) -> String {
 	format!(
-		"Hint: check `Todo`, label {}, no opt-out/manual-only or needs-attention labels, non-terminal state, no open dependency blockers, and no active issue claim.",
+		"Hint: check `Todo`, label {}, no opt-out/manual-only or needs-attention labels, non-terminal state, no open dependency blockers, and no active issue claim. For Program Intake targets, check `decodex status --live` Program Intake readback; if no persisted dispatchable node is listed, run `{}` first.",
 		format_no_eligible_queue_label_hint(service_id),
+		format_program_intake_apply_hint(service_id),
 	)
 }
 
@@ -29,8 +30,9 @@ pub(crate) fn format_no_eligible_issue_hint(
 	needs_attention_label: &str,
 ) -> String {
 	format!(
-		"Hint: check `Todo`, label {}, no `{opt_out_label}`/`{needs_attention_label}`, non-terminal state, no open dependency blockers, and no active issue claim.",
+		"Hint: check `Todo`, label {}, no `{opt_out_label}`/`{needs_attention_label}`, non-terminal state, no open dependency blockers, and no active issue claim. For Program Intake targets, check `decodex status --live` Program Intake readback; if no persisted dispatchable node is listed, run `{}` first.",
 		format_no_eligible_queue_label_hint(service_id),
+		format_program_intake_apply_hint(service_id),
 	)
 }
 
@@ -41,5 +43,13 @@ pub(crate) fn format_no_eligible_queue_label_hint(service_id: &str) -> String {
 		String::from("`decodex:queued:<service-id>`")
 	} else {
 		format!("`decodex:queued:<service-id>` (this project: `{queue_label}`)")
+	}
+}
+
+fn format_program_intake_apply_hint(service_id: &str) -> String {
+	if service_id == "all" {
+		String::from("decodex intake issues --project <service-id> --apply <ISSUE>")
+	} else {
+		format!("decodex intake issues --project {service_id} --apply <ISSUE>")
 	}
 }

--- a/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_dispatch/rejections_and_summary/no_eligible_issue_message_includes_operator_hint.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_dispatch/rejections_and_summary/no_eligible_issue_message_includes_operator_hint.rs
@@ -16,4 +16,7 @@ fn no_eligible_issue_message_includes_operator_hint() {
 	assert!(message.contains("non-terminal state"));
 	assert!(message.contains("dependency blockers"));
 	assert!(message.contains("no active issue claim"));
+	assert!(message.contains("Program Intake"));
+	assert!(message.contains("decodex status --live"));
+	assert!(message.contains("decodex intake issues --project pubfi --apply <ISSUE>"));
 }

--- a/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_program_dispatch.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_program_dispatch.rs
@@ -1,4 +1,7 @@
 mod targeted_program_dispatch_tests {
+	#[cfg(unix)] use std::os::unix::fs::PermissionsExt;
+	use std::{env, fs};
+
 	use crate::{
 		execution_program::{
 			ExecutionConflictDomain, ExecutionConflictDomainKind, ExecutionLinearIssueMapping,
@@ -7,6 +10,7 @@ mod targeted_program_dispatch_tests {
 		},
 		orchestrator::{self, IssueDispatchMode, TargetIssueRunContext, tests, tests::FakeTracker},
 		state::StateStore,
+		test_support::TestEnvVarGuard,
 	};
 
 	#[test]
@@ -92,6 +96,113 @@ mod targeted_program_dispatch_tests {
 		assert_eq!(summary.issue_id, issue.id);
 		assert_eq!(summary.issue_identifier, issue.identifier);
 		assert_eq!(summary.dispatch_mode, IssueDispatchMode::Program);
+	}
+
+	#[test]
+	fn targeted_program_dispatch_records_selection_before_execution_failure() {
+		let (temp_dir, config, workflow) = tests::temp_project_layout();
+		let fake_bin_dir = temp_dir.path().join("fake-empty-bin");
+
+		fs::create_dir_all(&fake_bin_dir).expect("fake bin dir should exist");
+
+		let fake_codex_path = fake_bin_dir.join("codex");
+
+		fs::write(&fake_codex_path, "#!/bin/sh\nexit 42\n").expect("fake codex should write");
+
+		#[cfg(unix)]
+		{
+			let mut permissions = fs::metadata(&fake_codex_path)
+				.expect("fake codex metadata should read")
+				.permissions();
+
+			permissions.set_mode(0o755);
+
+			fs::set_permissions(&fake_codex_path, permissions)
+				.expect("fake codex should become executable");
+		}
+
+		let path_env = env::var("PATH").unwrap_or_default();
+		let _path_guard =
+			TestEnvVarGuard::set("PATH", &format!("{}:{path_env}", fake_bin_dir.display()));
+		let state_store = StateStore::open_in_memory().expect("state store should open");
+		let issue = tests::sample_issue_with_sort_fields(
+			"issue-program-event-before-failure",
+			"PUB-1096",
+			"Todo",
+			&[],
+			Some(1),
+			"2026-06-23T04:16:17.133Z",
+		);
+		let mapping =
+			ExecutionLinearIssueMapping::new(&issue.id, &issue.identifier, &issue.state.name)
+				.expect("program issue mapping should build");
+		let node = ExecutionProgramNode::new(
+			"node-program-event-before-failure",
+			ExecutionProgramNodeStage::Runtime,
+			"Resolve a Program Intake node before execution starts.",
+			ExecutionQueueIntent::ReadyToQueue,
+		)
+		.expect("program node should build")
+		.with_acceptance_expectations(["Program node maps to a normal Linear issue."])
+		.expect("acceptance should attach")
+		.with_validation_expectations(["Run focused Program dispatch validation."])
+		.expect("validation should attach")
+		.with_linear_issue(mapping)
+		.expect("issue mapping should attach");
+		let program = ExecutionProgram::from_issue_batch_intake(
+			"program-targeted-event-before-failure",
+			config.service_id(),
+			"program-targeted-event-before-failure-fingerprint",
+			"Targeted Program event provenance.",
+			vec![node],
+		)
+		.expect("program should build");
+
+		state_store
+			.upsert_execution_program(config.service_id(), program)
+			.expect("program should persist");
+
+		let tracker = FakeTracker::new(vec![issue.clone()]);
+		let result =
+			orchestrator::run_target_issue_once_with_inferred_dispatch(TargetIssueRunContext {
+				tracker: &tracker,
+				project: &config,
+				workflow: &workflow,
+				state_store: &state_store,
+				issue_id: &issue.identifier,
+				preferred_issue_state: None,
+				preferred_initial_issue_state: None,
+				dry_run: false,
+				lease_preacquired: false,
+				preferred_issue_claim_fd: None,
+				preferred_dispatch_slot_fd: None,
+				preferred_dispatch_slot_index: None,
+				dispatch_mode: IssueDispatchMode::Normal,
+				preferred_run_identity: None,
+				preferred_retry_budget_base: None,
+			});
+
+		assert!(result.is_err());
+
+		let events = state_store
+			.list_private_execution_events_for_issue(config.service_id(), &issue.id)
+			.expect("private events should be readable");
+		let event = events
+			.iter()
+			.find(|event| event.event_type() == "program_dispatch_selected")
+			.expect("program dispatch selection should be recorded before execution failure");
+
+		assert_eq!(event.attempt_number(), 1);
+		assert_eq!(event.payload()["issue"]["identifier"], "PUB-1096");
+		assert_eq!(event.payload()["run"]["dispatch_mode"], "program");
+		assert_eq!(
+			event.payload()["execution_program"]["program_id"],
+			"program-targeted-event-before-failure"
+		);
+		assert_eq!(
+			event.payload()["execution_program"]["node_id"],
+			"node-program-event-before-failure"
+		);
 	}
 
 	#[test]

--- a/apps/decodex/src/program_intake/issue_batch_run.rs
+++ b/apps/decodex/src/program_intake/issue_batch_run.rs
@@ -123,6 +123,7 @@ where
 		program_id,
 		dry_run,
 		persisted: persist,
+		scheduler_visible: persist,
 		counts,
 		issues: rows,
 	})

--- a/apps/decodex/src/program_intake/model/reports.rs
+++ b/apps/decodex/src/program_intake/model/reports.rs
@@ -15,6 +15,8 @@ pub(crate) struct IssueBatchIntakeReport {
 	pub(crate) dry_run: bool,
 	/// Whether local runtime state was persisted.
 	pub(crate) persisted: bool,
+	/// Whether dispatchable nodes in this report are visible to the Program scheduler.
+	pub(crate) scheduler_visible: bool,
 	/// Deterministic classification counts.
 	pub(crate) counts: IssueBatchIntakeCounts,
 	/// Per-issue classification rows.

--- a/apps/decodex/src/program_intake/render/report.rs
+++ b/apps/decodex/src/program_intake/render/report.rs
@@ -4,9 +4,11 @@ use crate::program_intake::model::{GoalIntakeReport, IssueBatchIntakeReport};
 pub(crate) fn render_issue_batch_intake_report(report: &IssueBatchIntakeReport) -> String {
 	let mode = if report.persisted { "apply" } else { "dry-run" };
 	let mut output = format!(
-		"program intake {mode}: service={} program={} ready={} held={} blocked={} stale={} unmapped={}\n",
+		"program intake {mode}: service={} program={} persisted={} scheduler_visible={} ready={} held={} blocked={} stale={} unmapped={}\n",
 		report.service_id,
 		report.program_id,
+		report.persisted,
+		report.scheduler_visible,
 		report.counts.ready,
 		report.counts.held,
 		report.counts.blocked,

--- a/apps/decodex/src/program_intake/tests/issue_batch.rs
+++ b/apps/decodex/src/program_intake/tests/issue_batch.rs
@@ -43,6 +43,13 @@ fn issue_batch_dry_run_classifies_without_persisting() {
 	)
 	.expect("dry-run should classify");
 
+	assert!(!report.persisted);
+	assert!(!report.scheduler_visible);
+
+	let rendered = program_intake::render_issue_batch_intake_report(&report);
+
+	assert!(rendered.contains("persisted=false"));
+	assert!(rendered.contains("scheduler_visible=false"));
 	assert_eq!(report.counts.ready, 1);
 	assert_eq!(report.counts.held, 1);
 	assert_eq!(report.counts.blocked, 1);
@@ -108,6 +115,12 @@ fn issue_batch_persist_writes_program_and_adjacent_intake_state() {
 	.expect("persist should write local state");
 
 	assert!(report.persisted);
+	assert!(report.scheduler_visible);
+
+	let rendered = program_intake::render_issue_batch_intake_report(&report);
+
+	assert!(rendered.contains("persisted=true"));
+	assert!(rendered.contains("scheduler_visible=true"));
 	assert_eq!(store.list_execution_programs("decodex").expect("programs").len(), 1);
 	assert_eq!(store.list_program_intake_plans("decodex").expect("plans").len(), 1);
 	assert_eq!(

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -218,7 +218,10 @@ the operator hint points to the ordinary queue checklist: `Todo`, the service-sc
 non-terminal state, no open dependency blockers, and no active issue claim. Ready
 Program Intake nodes are not queue-label candidates; they appear under Execution
 Programs, and `decodex run <ISSUE>` can start a mapped dispatchable Program node with
-`program` dispatch mode.
+`program` dispatch mode. Issue-batch dry-run reports set `scheduler_visible=false`;
+their `dispatch_action=dispatch` rows describe the transient plan only. After
+`--apply`, status Program Intake readback is the operator surface for any persisted
+node blocker before ordinary queue-label checks.
 
 The runtime database is the local source of truth for active execution. Linear and
 GitHub remain external collaboration mirrors and validation surfaces.

--- a/docs/spec/loop-runtime.md
+++ b/docs/spec/loop-runtime.md
@@ -454,11 +454,13 @@ The operator CLI surface for existing issues is
 `decodex intake issues --project <service-id> <ISSUE>... --dry-run`, or the same
 command with `--config <PROJECT_DIR>`. Dry-run reads tracker state and prints a
 deterministic ready/held/blocked/stale/unmapped report without mutating Linear and
-without persisting local runtime rows. `--apply` is an explicit local-runtime write:
-it stores the Program Intake Plan, Execution Program payload, and issue mappings, but
-it must not apply or remove `decodex:queued:<service-id>`. Ready mapped nodes are
-dispatched directly by the Program scheduler rather than converted into queued-label
-work.
+without persisting local runtime rows. Dry-run reports set `scheduler_visible=false`,
+so `dispatch_action=dispatch` means the transient plan would be dispatchable only
+after persistence. `--apply` is an explicit local-runtime write: it stores the Program
+Intake Plan, Execution Program payload, and issue mappings, and sets
+`scheduler_visible=true`, but it must not apply or remove
+`decodex:queued:<service-id>`. Ready mapped nodes are dispatched directly by the
+Program scheduler rather than converted into queued-label work.
 
 ## Internal Execution Program
 

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -144,7 +144,10 @@ state or this state machine.
   surface for existing Linear issues. It classifies the supplied batch as ready,
   held, blocked, stale, or unmapped and builds the same internal program model used
   by later persistence, but it must not mutate Linear or write local runtime rows.
-  `--apply` writes only local runtime Program Intake and Execution Program state.
+  Dry-run reports mark `scheduler_visible=false`; any `dispatch_action=dispatch`
+  in that mode is a hypothetical result for the transient plan, not scheduler
+  authority. `--apply` writes only local runtime Program Intake and Execution
+  Program state and reports `scheduler_visible=true`.
 - Each scheduler pass evaluates persisted Execution Programs before ordinary queued
   issue selection. The Program scheduler refreshes mapped Linear issue state,
   dependency observations, local shared run claims, retained review/landing
@@ -155,7 +158,10 @@ state or this state machine.
 - When `decodex run <ISSUE>` targets a mapped Program node, inferred dispatch checks
   the same persisted Program eligibility before ordinary queue-label dispatch. A
   target whose node currently has `dispatch_action = dispatch` starts with `program`
-  dispatch mode without requiring `decodex:queued:<service-id>`.
+  dispatch mode without requiring `decodex:queued:<service-id>`. If no eligible lane
+  is selected, the operator hint must include Program Intake readback guidance so the
+  operator can distinguish a missing persisted node from ordinary queue-label
+  eligibility.
 
 The evidence boundary is ordered from private runtime authority to public collaboration
 mirror:


### PR DESCRIPTION
## Summary
- add scheduler visibility to Program Intake issue reports and human output
- add Program Intake-specific no-eligible guidance for targeted runs
- record targeted Program dispatch provenance before execution so failure/closeout paths keep the original Program run identity

## Validation
- cargo test -p decodex targeted_program_dispatch --lib
- cargo test -p decodex program_intake::tests::issue_batch --lib
- cargo test -p decodex no_eligible_issue_message_includes_operator_hint --lib
- cargo make check

Refs PUB-1669, PUB-1681