### PR TITLE
Guard installable plugin sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,17 @@ cargo make test
 Use `lint` for the read-only lint gate and `lint-fix` for the canonicalizing lint
 path used by registered Decodex workflow gates.
 
+Sync installable Codex plugins with the guarded installer:
+
+```sh
+python3 scripts/config/sync_installable_plugins.py --apply --clean-repo-local-skills
+```
+
+This installs only `plugins/*` into `$CODEX_HOME/plugins/cache/hack-ink/*/<version>`.
+Repo-local skills under `automations/*/skills/` are development and automation
+inputs for this repository; they must not be installed into global
+`$CODEX_HOME/skills`.
+
 Node package type checks and builds are available separately:
 
 ```sh

--- a/automations/decodex/skills/README.md
+++ b/automations/decodex/skills/README.md
@@ -4,7 +4,8 @@ Purpose: Route repo-local skills for Decodex Publisher public-post quality and
 publication records.
 
 These skills are checked-in repository-development instructions. They are not packaged
-with the installable Decodex plugin under `plugins/decodex/`.
+with the installable Decodex plugin under `plugins/decodex/`, and they must not be
+copied into global `$CODEX_HOME/skills`.
 
 ## Skill Map
 

--- a/automations/radar/skills/README.md
+++ b/automations/radar/skills/README.md
@@ -4,7 +4,8 @@ Purpose: Route repo-local Radar skills for upstream Codex evidence gathering and
 signal drafting.
 
 These skills are checked-in repository-development instructions. They are not packaged
-with the installable Decodex plugin under `plugins/decodex/`.
+with the installable Decodex plugin under `plugins/decodex/`, and they must not be
+copied into global `$CODEX_HOME/skills`.
 
 ## Skill Map
 

--- a/docs/spec/installable-agent-policy.md
+++ b/docs/spec/installable-agent-policy.md
@@ -33,6 +33,11 @@ policy.
   `docs/spec/`, the
   registered project `WORKFLOW.md`, project `project.toml`, repo-local runbooks, or
   the Decodex plugin skill that owns a reusable method.
+- Repo-local skills under `automations/*/skills/` are not installable global skills.
+  They may be referenced by repo-owned automation prompts and runbooks, but they must
+  not be copied into `$CODEX_HOME/skills`. Use
+  `scripts/config/sync_installable_plugins.py --apply --clean-repo-local-skills` to
+  sync installable `plugins/*` and remove exact-copy global mistakes.
 - Global agent guidance may point agents toward repository-declared policy, but it
   must not become the source of truth for a repository gate, tracker state name,
   token environment variable, Linear label, branch layout, review loop, merge method,

--- a/scripts/config/sync_installable_plugins.py
+++ b/scripts/config/sync_installable_plugins.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Sync installable Decodex plugins without installing repo-local skills globally."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+NAMESPACE = "hack-ink"
+
+
+@dataclass(frozen=True)
+class RepoLocalSkill:
+    name: str
+    source: Path
+
+
+def find_repo_root(start: Path) -> Path:
+    for candidate in [start, *start.parents]:
+        if (candidate / "plugins").is_dir() and (candidate / "Cargo.toml").is_file():
+            return candidate
+    raise RuntimeError(f"could not find repo root from {start}")
+
+
+def workspace_version(repo_root: Path) -> str:
+    manifest = repo_root / "Cargo.toml"
+    in_workspace_package = False
+    version_pattern = re.compile(r'^version\s*=\s*"([^"]+)"')
+
+    for line in manifest.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped == "[workspace.package]":
+            in_workspace_package = True
+            continue
+        if in_workspace_package and stripped.startswith("["):
+            break
+        if in_workspace_package:
+            match = version_pattern.match(stripped)
+            if match:
+                return match.group(1)
+
+    raise RuntimeError("workspace package version not found in Cargo.toml")
+
+
+def plugin_sources(repo_root: Path) -> list[Path]:
+    plugin_root = repo_root / "plugins"
+    return sorted(
+        candidate
+        for candidate in plugin_root.iterdir()
+        if (candidate / ".codex-plugin" / "plugin.json").is_file()
+    )
+
+
+def repo_local_skills(repo_root: Path) -> list[RepoLocalSkill]:
+    skills: list[RepoLocalSkill] = []
+    for skill_file in sorted((repo_root / "automations").glob("*/skills/*/SKILL.md")):
+        skills.append(RepoLocalSkill(name=skill_file.parent.name, source=skill_file.parent))
+    return skills
+
+
+def sync_plugins(repo_root: Path, codex_home: Path, version: str, apply: bool) -> list[str]:
+    actions: list[str] = []
+    cache_root = codex_home / "plugins" / "cache" / NAMESPACE
+
+    for source in plugin_sources(repo_root):
+        destination = cache_root / source.name / version
+        actions.append(f"sync plugin {source.name} -> {destination}")
+        if apply:
+            if destination.exists():
+                shutil.rmtree(destination)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(source, destination)
+
+    return actions
+
+
+def clean_repo_local_global_skills(repo_root: Path, codex_home: Path, apply: bool) -> list[str]:
+    actions: list[str] = []
+    global_skill_root = codex_home / "skills"
+
+    for skill in repo_local_skills(repo_root):
+        destination = global_skill_root / skill.name
+        destination_skill = destination / "SKILL.md"
+        if not destination.exists():
+            continue
+        if not destination_skill.is_file():
+            raise RuntimeError(f"refusing to remove non-skill global path: {destination}")
+
+        source_text = (skill.source / "SKILL.md").read_text(encoding="utf-8")
+        destination_text = destination_skill.read_text(encoding="utf-8")
+        if source_text != destination_text:
+            raise RuntimeError(
+                f"refusing to remove modified global repo-local skill: {destination}"
+            )
+
+        actions.append(f"remove repo-local global skill {skill.name} -> {destination}")
+        if apply:
+            shutil.rmtree(destination)
+
+    return actions
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Sync installable Decodex plugins to CODEX_HOME without copying "
+            "automations/*/skills into global skills."
+        )
+    )
+    parser.add_argument("--apply", action="store_true", help="write changes")
+    parser.add_argument(
+        "--clean-repo-local-skills",
+        action="store_true",
+        help=(
+            "remove global ~/.codex/skills entries that are exact copies of "
+            "repo-local automations/*/skills"
+        ),
+    )
+    parser.add_argument("--codex-home", type=Path, default=None, help="override CODEX_HOME")
+    parser.add_argument("--repo-root", type=Path, default=None, help="override repo root")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    script_path = Path(__file__).resolve()
+    repo_root = args.repo_root.resolve() if args.repo_root else find_repo_root(script_path)
+    codex_home = (
+        args.codex_home
+        or Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
+    ).expanduser().resolve()
+    version = workspace_version(repo_root)
+
+    actions = sync_plugins(repo_root, codex_home, version, args.apply)
+    if args.clean_repo_local_skills:
+        actions.extend(clean_repo_local_global_skills(repo_root, codex_home, args.apply))
+
+    mode = "apply" if args.apply else "dry-run"
+    for action in actions:
+        print(f"{mode}: {action}")
+
+    if not args.apply:
+        print("dry-run only; pass --apply to write changes")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_sync_installable_plugins.py
+++ b/tests/scripts/test_sync_installable_plugins.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/config/sync_installable_plugins.py"
+
+
+def load_sync_module():
+    spec = importlib.util.spec_from_file_location("sync_installable_plugins", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["sync_installable_plugins"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class SyncInstallablePluginsTests(unittest.TestCase):
+    def test_sync_installs_plugins_without_global_repo_local_skills(self):
+        module = load_sync_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            codex_home = Path(temp_dir) / ".codex"
+            global_skill = codex_home / "skills/x-post-publisher"
+            shutil.copytree(REPO_ROOT / "automations/decodex/skills/x-post-publisher", global_skill)
+
+            result = module.main(
+                [
+                    "--apply",
+                    "--clean-repo-local-skills",
+                    "--repo-root",
+                    str(REPO_ROOT),
+                    "--codex-home",
+                    str(codex_home),
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            self.assertTrue(
+                (
+                    codex_home
+                    / "plugins/cache/hack-ink/decodex/0.2.0/.codex-plugin/plugin.json"
+                ).is_file()
+            )
+            self.assertFalse(global_skill.exists())
+
+    def test_clean_refuses_modified_global_repo_local_skill(self):
+        module = load_sync_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            codex_home = Path(temp_dir) / ".codex"
+            global_skill = codex_home / "skills/github-signal"
+            shutil.copytree(REPO_ROOT / "automations/radar/skills/github-signal", global_skill)
+            (global_skill / "SKILL.md").write_text("modified\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "modified global repo-local skill"):
+                module.main(
+                    [
+                        "--apply",
+                        "--clean-repo-local-skills",
+                        "--repo-root",
+                        str(REPO_ROOT),
+                        "--codex-home",
+                        str(codex_home),
+                    ]
+                )
+
+            self.assertTrue(global_skill.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add guarded plugin sync script that installs only plugins/* into CODEX_HOME plugin cache
- clean exact-copy repo-local automation skills from global CODEX_HOME/skills
- document that automations/*/skills are repo-local and must not be globally installed

## Validation
- python3 -m unittest tests/scripts/test_sync_installable_plugins.py
- cargo run -p decodex --bin decodex -- docs check
- python3 scripts/config/sync_installable_plugins.py --apply --clean-repo-local-skills