### PR TITLE
Split Swift app bridge networking modules by responsibility

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/DashboardWebSocketConnection.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DashboardWebSocketConnection.swift
@@ -1,7 +1,5 @@
 import Foundation
 import Network
-import Security
-
 
 actor DashboardWebSocketConnection {
 	let url: URL
@@ -50,48 +48,6 @@ actor DashboardWebSocketConnection {
 			default:
 				continue
 			}
-		}
-	}
-
-	static func handshakeRequest(host: String, port: Int, path: String, key: String) -> Data {
-		let lines = [
-			"GET \(path) HTTP/1.1",
-			"Host: \(host):\(port)",
-			"Upgrade: websocket",
-			"Connection: Upgrade",
-			"Sec-WebSocket-Key: \(key)",
-			"Sec-WebSocket-Version: 13",
-			"",
-			"",
-		]
-
-		return Data(lines.joined(separator: "\r\n").utf8)
-	}
-
-	func sendHandshake(host: String, port: Int) async throws {
-		let key = websocketKey()
-		let path = websocketRequestPath()
-
-		try await send(Self.handshakeRequest(host: host, port: port, path: path, key: key))
-	}
-
-	func readHandshakeResponse() async throws {
-		let delimiter = Data("\r\n\r\n".utf8)
-
-		while buffer.range(of: delimiter) == nil {
-			try await receiveMore()
-		}
-
-		guard let range = buffer.range(of: delimiter) else {
-			throw DecodexAppBridgeError.invalidResponse("dashboard WebSocket handshake response is incomplete")
-		}
-
-		let headerData = buffer[..<range.upperBound]
-		buffer.removeSubrange(..<range.upperBound)
-
-		let header = String(decoding: headerData, as: UTF8.self)
-		guard header.hasPrefix("HTTP/1.1 101") || header.hasPrefix("HTTP/1.0 101") else {
-			throw DecodexAppBridgeError.invalidResponse("dashboard WebSocket handshake failed: \(header)")
 		}
 	}
 
@@ -165,141 +121,6 @@ actor DashboardWebSocketConnection {
 			})
 		}
 	}
-
-	func readFrame() async throws -> WebSocketFrame {
-		while buffer.count < 2 {
-			try await receiveMore()
-		}
-
-		let firstByte = buffer[buffer.startIndex]
-		let secondByte = buffer[buffer.index(after: buffer.startIndex)]
-		let opcode = firstByte & 0x0F
-		let masked = (secondByte & 0x80) != 0
-		var length = UInt64(secondByte & 0x7F)
-		var headerLength = 2
-
-		if length == 126 {
-			while buffer.count < 4 {
-				try await receiveMore()
-			}
-			length = UInt64(readUInt16(offset: 2))
-			headerLength = 4
-		} else if length == 127 {
-			while buffer.count < 10 {
-				try await receiveMore()
-			}
-			length = readUInt64(offset: 2)
-			headerLength = 10
-		}
-
-		let maskLength = masked ? 4 : 0
-		let payloadLength = try checkedPayloadLength(length)
-		let frameLength = headerLength + maskLength + payloadLength
-
-		while buffer.count < frameLength {
-			try await receiveMore()
-		}
-
-		let maskStart = headerLength
-		let payloadStart = headerLength + maskLength
-		var payload = buffer.subdata(in: payloadStart..<frameLength)
-
-		if masked {
-			let mask = buffer.subdata(in: maskStart..<maskStart + maskLength)
-			for index in payload.indices {
-				payload[index] ^= mask[index % 4]
-			}
-		}
-
-		buffer.removeSubrange(..<frameLength)
-
-		return WebSocketFrame(opcode: opcode, payload: payload)
-	}
-
-	func sendPong(_ payload: Data) async throws {
-		try await send(clientFrame(opcode: 0xA, payload: payload))
-	}
-
-	private func websocketRequestPath() -> String {
-		var path = url.path.isEmpty ? "/" : url.path
-		if let query = url.query, query.isEmpty == false {
-			path += "?\(query)"
-		}
-
-		return path
-	}
-
-	private func websocketKey() -> String {
-		randomData(byteCount: 16).base64EncodedString()
-	}
-
-	private func clientFrame(opcode: UInt8, payload: Data) -> Data {
-		var output = Data()
-		let length = payload.count
-
-		output.append(0x80 | opcode)
-		if length <= 125 {
-			output.append(0x80 | UInt8(length))
-		} else if length <= UInt16.max {
-			output.append(0x80 | 126)
-			output.append(UInt8((length >> 8) & 0xFF))
-			output.append(UInt8(length & 0xFF))
-		} else {
-			output.append(0x80 | 127)
-			output.append(contentsOf: UInt64(length).bigEndianBytes)
-		}
-
-		let mask = randomData(byteCount: 4)
-		output.append(mask)
-		for index in payload.indices {
-			output.append(payload[index] ^ mask[index % 4])
-		}
-
-		return output
-	}
-
-	private func checkedPayloadLength(_ length: UInt64) throws -> Int {
-		guard length <= UInt64(Int.max) else {
-			throw DecodexAppBridgeError.invalidResponse("dashboard WebSocket frame is too large")
-		}
-
-		return Int(length)
-	}
-
-	private func readUInt16(offset: Int) -> UInt16 {
-		let first = UInt16(buffer[offset])
-		let second = UInt16(buffer[offset + 1])
-
-		return (first << 8) | second
-	}
-
-	private func readUInt64(offset: Int) -> UInt64 {
-		var value: UInt64 = 0
-		for byte in buffer[offset..<offset + 8] {
-			value = (value << 8) | UInt64(byte)
-		}
-
-		return value
-	}
-}
-
-extension DashboardWebSocketConnection {
-	func randomData(byteCount: Int) -> Data {
-		var bytes = [UInt8](repeating: 0, count: byteCount)
-		let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
-		if status != errSecSuccess {
-			for index in bytes.indices {
-				bytes[index] = UInt8.random(in: UInt8.min...UInt8.max)
-			}
-		}
-
-		return Data(bytes)
-	}
-}
-
-struct WebSocketFrame {
-	let opcode: UInt8
-	let payload: Data
 }
 
 final class DashboardConnectionResumeBox: @unchecked Sendable {
@@ -321,13 +142,5 @@ final class DashboardConnectionResumeBox: @unchecked Sendable {
 		}
 		resumed = true
 		continuation.resume(with: result)
-	}
-}
-
-private extension UInt64 {
-	var bigEndianBytes: [UInt8] {
-		withUnsafeBytes(of: bigEndian) { bytes in
-			Array(bytes)
-		}
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/DashboardWebSocketFrames.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DashboardWebSocketFrames.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Security
+
+extension DashboardWebSocketConnection {
+	func readFrame() async throws -> WebSocketFrame {
+		while buffer.count < 2 {
+			try await receiveMore()
+		}
+
+		let firstByte = buffer[buffer.startIndex]
+		let secondByte = buffer[buffer.index(after: buffer.startIndex)]
+		let opcode = firstByte & 0x0F
+		let masked = (secondByte & 0x80) != 0
+		var length = UInt64(secondByte & 0x7F)
+		var headerLength = 2
+
+		if length == 126 {
+			while buffer.count < 4 {
+				try await receiveMore()
+			}
+			length = UInt64(readUInt16(offset: 2))
+			headerLength = 4
+		} else if length == 127 {
+			while buffer.count < 10 {
+				try await receiveMore()
+			}
+			length = readUInt64(offset: 2)
+			headerLength = 10
+		}
+
+		let maskLength = masked ? 4 : 0
+		let payloadLength = try checkedPayloadLength(length)
+		let frameLength = headerLength + maskLength + payloadLength
+
+		while buffer.count < frameLength {
+			try await receiveMore()
+		}
+
+		let maskStart = headerLength
+		let payloadStart = headerLength + maskLength
+		var payload = buffer.subdata(in: payloadStart..<frameLength)
+
+		if masked {
+			let mask = buffer.subdata(in: maskStart..<maskStart + maskLength)
+			for index in payload.indices {
+				payload[index] ^= mask[index % 4]
+			}
+		}
+
+		buffer.removeSubrange(..<frameLength)
+
+		return WebSocketFrame(opcode: opcode, payload: payload)
+	}
+
+	func sendPong(_ payload: Data) async throws {
+		try await send(clientFrame(opcode: 0xA, payload: payload))
+	}
+
+	func randomData(byteCount: Int) -> Data {
+		var bytes = [UInt8](repeating: 0, count: byteCount)
+		let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+		if status != errSecSuccess {
+			for index in bytes.indices {
+				bytes[index] = UInt8.random(in: UInt8.min...UInt8.max)
+			}
+		}
+
+		return Data(bytes)
+	}
+
+	private func clientFrame(opcode: UInt8, payload: Data) -> Data {
+		var output = Data()
+		let length = payload.count
+
+		output.append(0x80 | opcode)
+		if length <= 125 {
+			output.append(0x80 | UInt8(length))
+		} else if length <= UInt16.max {
+			output.append(0x80 | 126)
+			output.append(UInt8((length >> 8) & 0xFF))
+			output.append(UInt8(length & 0xFF))
+		} else {
+			output.append(0x80 | 127)
+			output.append(contentsOf: UInt64(length).bigEndianBytes)
+		}
+
+		let mask = randomData(byteCount: 4)
+		output.append(mask)
+		for index in payload.indices {
+			output.append(payload[index] ^ mask[index % 4])
+		}
+
+		return output
+	}
+
+	private func checkedPayloadLength(_ length: UInt64) throws -> Int {
+		guard length <= UInt64(Int.max) else {
+			throw DecodexAppBridgeError.invalidResponse("dashboard WebSocket frame is too large")
+		}
+
+		return Int(length)
+	}
+
+	private func readUInt16(offset: Int) -> UInt16 {
+		let first = UInt16(buffer[offset])
+		let second = UInt16(buffer[offset + 1])
+
+		return (first << 8) | second
+	}
+
+	private func readUInt64(offset: Int) -> UInt64 {
+		var value: UInt64 = 0
+		for byte in buffer[offset..<offset + 8] {
+			value = (value << 8) | UInt64(byte)
+		}
+
+		return value
+	}
+}
+
+struct WebSocketFrame {
+	let opcode: UInt8
+	let payload: Data
+}
+
+private extension UInt64 {
+	var bigEndianBytes: [UInt8] {
+		withUnsafeBytes(of: bigEndian) { bytes in
+			Array(bytes)
+		}
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/DashboardWebSocketHandshake.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DashboardWebSocketHandshake.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+extension DashboardWebSocketConnection {
+	static func handshakeRequest(host: String, port: Int, path: String, key: String) -> Data {
+		let lines = [
+			"GET \(path) HTTP/1.1",
+			"Host: \(host):\(port)",
+			"Upgrade: websocket",
+			"Connection: Upgrade",
+			"Sec-WebSocket-Key: \(key)",
+			"Sec-WebSocket-Version: 13",
+			"",
+			"",
+		]
+
+		return Data(lines.joined(separator: "\r\n").utf8)
+	}
+
+	func sendHandshake(host: String, port: Int) async throws {
+		let key = websocketKey()
+		let path = websocketRequestPath()
+
+		try await send(Self.handshakeRequest(host: host, port: port, path: path, key: key))
+	}
+
+	func readHandshakeResponse() async throws {
+		let delimiter = Data("\r\n\r\n".utf8)
+
+		while buffer.range(of: delimiter) == nil {
+			try await receiveMore()
+		}
+
+		guard let range = buffer.range(of: delimiter) else {
+			throw DecodexAppBridgeError.invalidResponse("dashboard WebSocket handshake response is incomplete")
+		}
+
+		let headerData = buffer[..<range.upperBound]
+		buffer.removeSubrange(..<range.upperBound)
+
+		let header = String(decoding: headerData, as: UTF8.self)
+		guard header.hasPrefix("HTTP/1.1 101") || header.hasPrefix("HTTP/1.0 101") else {
+			throw DecodexAppBridgeError.invalidResponse("dashboard WebSocket handshake failed: \(header)")
+		}
+	}
+
+	private func websocketRequestPath() -> String {
+		var path = url.path.isEmpty ? "/" : url.path
+		if let query = url.query, query.isEmpty == false {
+			path += "?\(query)"
+		}
+
+		return path
+	}
+
+	private func websocketKey() -> String {
+		randomData(byteCount: 16).base64EncodedString()
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/DecodexServerBridge.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexServerBridge.swift
@@ -6,12 +6,6 @@ struct ServerRoute {
 	let body: Data?
 }
 
-private enum DecodexServerProbe: Equatable {
-	case live
-	case reachable(String)
-	case unreachable
-}
-
 actor DecodexServerBridge {
 	static let shared = DecodexServerBridge()
 
@@ -98,13 +92,13 @@ actor DecodexServerBridge {
 		return url
 	}
 
-	private func configuredServerURL() throws -> URL? {
+	func configuredServerURL() throws -> URL? {
 		let value = ProcessInfo.processInfo.environment["DECODEX_APP_SERVER_URL"] ?? ""
 
 		return try Self.configuredServerURL(from: value)
 	}
 
-	private func decodexExecutableURL() throws -> URL {
+	func decodexExecutableURL() throws -> URL {
 		if let override = ProcessInfo.processInfo.environment["DECODEX_APP_DECODEX"], override.isEmpty == false {
 			let overrideURL = URL(fileURLWithPath: override)
 			if FileManager.default.isExecutableFile(atPath: overrideURL.path) {
@@ -123,189 +117,5 @@ actor DecodexServerBridge {
 		throw DecodexAppBridgeError.helperMissing(
 			"Bundled decodex server is missing. Rebuild the app bundle with apps/decodex-app/script/build_and_run.sh."
 		)
-	}
-}
-
-extension DecodexServerBridge {
-	func ensureServer() async throws -> URL {
-		if let configured = try configuredServerURL() {
-			if serverBaseURL == configured, hasFreshLiveCheck(configured) {
-				return configured
-			}
-			switch await probeServer(configured) {
-			case .live:
-				noteLive(configured)
-
-				return configured
-			case .reachable(let reason):
-				throw DecodexAppBridgeError.invalidResponse(
-					"Decodex server at \(configured.absoluteString) is reachable but not app-compatible: \(reason)"
-				)
-			case .unreachable:
-				throw DecodexAppBridgeError.invalidResponse(
-					"Configured Decodex App server \(configured.absoluteString) is unreachable. Start that server or unset DECODEX_APP_SERVER_URL."
-				)
-			}
-		}
-
-		if let serverBaseURL, hasFreshLiveCheck(serverBaseURL) {
-			return serverBaseURL
-		}
-
-		if let serverBaseURL, await probeServer(serverBaseURL) == .live {
-			noteLive(serverBaseURL)
-
-			return serverBaseURL
-		}
-
-		switch await probeServer(defaultBaseURL) {
-		case .live:
-			noteLive(defaultBaseURL)
-
-			return defaultBaseURL
-		case .reachable(let reason):
-			throw DecodexAppBridgeError.invalidResponse(
-				"Port \(defaultListenAddress) already has a server, but it is not app-compatible: \(reason). Decodex App will not start its bundled server over an existing process."
-			)
-		case .unreachable:
-			break
-		}
-
-		try startBundledServer()
-
-		for _ in 0..<40 {
-			if await probeServer(defaultBaseURL) == .live {
-				noteLive(defaultBaseURL)
-
-				return defaultBaseURL
-			}
-
-			try await Task.sleep(nanoseconds: 100_000_000)
-		}
-
-		throw DecodexAppBridgeError.launchFailed("Decodex server did not become ready on \(defaultListenAddress)")
-	}
-
-	func send<T: Decodable & Sendable>(
-		_ route: ServerRoute,
-		baseURL: URL,
-		as type: T.Type
-	) async throws -> T {
-		let url = try routeURL(baseURL: baseURL, route: route)
-		var urlRequest = URLRequest(url: url)
-
-		urlRequest.httpMethod = route.method
-		urlRequest.timeoutInterval = 15
-		if let body = route.body {
-			urlRequest.httpBody = body
-			urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		}
-
-		let (data, response) = try await URLSession.shared.data(for: urlRequest)
-		guard let httpResponse = response as? HTTPURLResponse else {
-			throw DecodexAppBridgeError.invalidResponse("Decodex server returned a non-HTTP response")
-		}
-		if httpResponse.statusCode == 404, route.path.hasPrefix("api/accounts") {
-			throw DecodexAppBridgeError.invalidResponse(
-				"Decodex server at \(baseURL.absoluteString) does not support /api/accounts. Restart decodex serve with the bundled app version."
-			)
-		}
-		guard 200..<300 ~= httpResponse.statusCode else {
-			let message = String(decoding: data, as: UTF8.self)
-			throw DecodexAppBridgeError.commandFailed(
-				Int32(httpResponse.statusCode),
-				message.isEmpty ? "Decodex server request failed" : message
-			)
-		}
-
-		noteLive(baseURL)
-
-		return try JSONDecoder().decode(type, from: data)
-	}
-
-	func startBundledServer() throws {
-		if let startedProcess, startedProcess.isRunning {
-			return
-		}
-
-		let process = Process()
-		let nullDevice = FileHandle(forWritingAtPath: "/dev/null")
-
-		process.executableURL = try decodexExecutableURL()
-		process.arguments = Self.bundledServerArguments(listenAddress: defaultListenAddress)
-		process.standardOutput = nullDevice
-		process.standardError = nullDevice
-
-		do {
-			try process.run()
-		} catch {
-			throw DecodexAppBridgeError.launchFailed(error.localizedDescription)
-		}
-
-		startedProcess = process
-	}
-
-	func hasFreshLiveCheck(_ baseURL: URL) -> Bool {
-		guard liveCheckBaseURL == baseURL, let liveCheckedAt else {
-			return false
-		}
-
-		return Date().timeIntervalSince(liveCheckedAt) < liveCheckFreshness
-	}
-
-	func noteLive(_ baseURL: URL) {
-		serverBaseURL = baseURL
-		liveCheckBaseURL = baseURL
-		liveCheckedAt = Date()
-	}
-
-	func clearLive(_ baseURL: URL) {
-		if serverBaseURL == baseURL {
-			serverBaseURL = nil
-		}
-		if liveCheckBaseURL == baseURL {
-			liveCheckBaseURL = nil
-			liveCheckedAt = nil
-		}
-	}
-
-	private func routeURL(baseURL: URL, route: ServerRoute) throws -> URL {
-		let parts = route.path.split(separator: "?", maxSplits: 1).map(String.init)
-		guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
-			throw DecodexAppBridgeError.invalidResponse("Decodex server URL is invalid")
-		}
-
-		components.path = "/" + parts[0]
-		if parts.count == 2 {
-			components.query = parts[1]
-		}
-
-		guard let url = components.url else {
-			throw DecodexAppBridgeError.invalidResponse("Decodex server route URL is invalid")
-		}
-
-		return url
-	}
-
-	private func probeServer(_ baseURL: URL) async -> DecodexServerProbe {
-		let url = baseURL.appendingPathComponent("livez")
-		var request = URLRequest(url: url)
-
-		request.timeoutInterval = 0.75
-
-		do {
-			let (data, response) = try await URLSession.shared.data(for: request)
-			guard let httpResponse = response as? HTTPURLResponse else {
-				return .reachable("non-HTTP response from /livez")
-			}
-			let body = String(decoding: data, as: UTF8.self)
-			if httpResponse.statusCode == 200 && body.trimmingCharacters(in: .whitespacesAndNewlines) == "ok" {
-				return .live
-			}
-
-			return .reachable("/livez returned HTTP \(httpResponse.statusCode)")
-		} catch {
-			return .unreachable
-		}
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/DecodexServerHTTP.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexServerHTTP.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+extension DecodexServerBridge {
+	func send<T: Decodable & Sendable>(
+		_ route: ServerRoute,
+		baseURL: URL,
+		as type: T.Type
+	) async throws -> T {
+		let url = try routeURL(baseURL: baseURL, route: route)
+		var urlRequest = URLRequest(url: url)
+
+		urlRequest.httpMethod = route.method
+		urlRequest.timeoutInterval = 15
+		if let body = route.body {
+			urlRequest.httpBody = body
+			urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		}
+
+		let (data, response) = try await URLSession.shared.data(for: urlRequest)
+		guard let httpResponse = response as? HTTPURLResponse else {
+			throw DecodexAppBridgeError.invalidResponse("Decodex server returned a non-HTTP response")
+		}
+		if httpResponse.statusCode == 404, route.path.hasPrefix("api/accounts") {
+			throw DecodexAppBridgeError.invalidResponse(
+				"Decodex server at \(baseURL.absoluteString) does not support /api/accounts. Restart decodex serve with the bundled app version."
+			)
+		}
+		guard 200..<300 ~= httpResponse.statusCode else {
+			let message = String(decoding: data, as: UTF8.self)
+			throw DecodexAppBridgeError.commandFailed(
+				Int32(httpResponse.statusCode),
+				message.isEmpty ? "Decodex server request failed" : message
+			)
+		}
+
+		noteLive(baseURL)
+
+		return try JSONDecoder().decode(type, from: data)
+	}
+
+	private func routeURL(baseURL: URL, route: ServerRoute) throws -> URL {
+		let parts = route.path.split(separator: "?", maxSplits: 1).map(String.init)
+		guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+			throw DecodexAppBridgeError.invalidResponse("Decodex server URL is invalid")
+		}
+
+		components.path = "/" + parts[0]
+		if parts.count == 2 {
+			components.query = parts[1]
+		}
+
+		guard let url = components.url else {
+			throw DecodexAppBridgeError.invalidResponse("Decodex server route URL is invalid")
+		}
+
+		return url
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/DecodexServerLifecycle.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexServerLifecycle.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+private enum DecodexServerProbe: Equatable {
+	case live
+	case reachable(String)
+	case unreachable
+}
+
+extension DecodexServerBridge {
+	func ensureServer() async throws -> URL {
+		if let configured = try configuredServerURL() {
+			if serverBaseURL == configured, hasFreshLiveCheck(configured) {
+				return configured
+			}
+			switch await probeServer(configured) {
+			case .live:
+				noteLive(configured)
+
+				return configured
+			case .reachable(let reason):
+				throw DecodexAppBridgeError.invalidResponse(
+					"Decodex server at \(configured.absoluteString) is reachable but not app-compatible: \(reason)"
+				)
+			case .unreachable:
+				throw DecodexAppBridgeError.invalidResponse(
+					"Configured Decodex App server \(configured.absoluteString) is unreachable. Start that server or unset DECODEX_APP_SERVER_URL."
+				)
+			}
+		}
+
+		if let serverBaseURL, hasFreshLiveCheck(serverBaseURL) {
+			return serverBaseURL
+		}
+
+		if let serverBaseURL, await probeServer(serverBaseURL) == .live {
+			noteLive(serverBaseURL)
+
+			return serverBaseURL
+		}
+
+		switch await probeServer(defaultBaseURL) {
+		case .live:
+			noteLive(defaultBaseURL)
+
+			return defaultBaseURL
+		case .reachable(let reason):
+			throw DecodexAppBridgeError.invalidResponse(
+				"Port \(defaultListenAddress) already has a server, but it is not app-compatible: \(reason). Decodex App will not start its bundled server over an existing process."
+			)
+		case .unreachable:
+			break
+		}
+
+		try startBundledServer()
+
+		for _ in 0..<40 {
+			if await probeServer(defaultBaseURL) == .live {
+				noteLive(defaultBaseURL)
+
+				return defaultBaseURL
+			}
+
+			try await Task.sleep(nanoseconds: 100_000_000)
+		}
+
+		throw DecodexAppBridgeError.launchFailed("Decodex server did not become ready on \(defaultListenAddress)")
+	}
+
+	func startBundledServer() throws {
+		if let startedProcess, startedProcess.isRunning {
+			return
+		}
+
+		let process = Process()
+		let nullDevice = FileHandle(forWritingAtPath: "/dev/null")
+
+		process.executableURL = try decodexExecutableURL()
+		process.arguments = Self.bundledServerArguments(listenAddress: defaultListenAddress)
+		process.standardOutput = nullDevice
+		process.standardError = nullDevice
+
+		do {
+			try process.run()
+		} catch {
+			throw DecodexAppBridgeError.launchFailed(error.localizedDescription)
+		}
+
+		startedProcess = process
+	}
+
+	func hasFreshLiveCheck(_ baseURL: URL) -> Bool {
+		guard liveCheckBaseURL == baseURL, let liveCheckedAt else {
+			return false
+		}
+
+		return Date().timeIntervalSince(liveCheckedAt) < liveCheckFreshness
+	}
+
+	func noteLive(_ baseURL: URL) {
+		serverBaseURL = baseURL
+		liveCheckBaseURL = baseURL
+		liveCheckedAt = Date()
+	}
+
+	func clearLive(_ baseURL: URL) {
+		if serverBaseURL == baseURL {
+			serverBaseURL = nil
+		}
+		if liveCheckBaseURL == baseURL {
+			liveCheckBaseURL = nil
+			liveCheckedAt = nil
+		}
+	}
+
+	private func probeServer(_ baseURL: URL) async -> DecodexServerProbe {
+		let url = baseURL.appendingPathComponent("livez")
+		var request = URLRequest(url: url)
+
+		request.timeoutInterval = 0.75
+
+		do {
+			let (data, response) = try await URLSession.shared.data(for: request)
+			guard let httpResponse = response as? HTTPURLResponse else {
+				return .reachable("non-HTTP response from /livez")
+			}
+			let body = String(decoding: data, as: UTF8.self)
+			if httpResponse.statusCode == 200 && body.trimmingCharacters(in: .whitespacesAndNewlines) == "ok" {
+				return .live
+			}
+
+			return .reachable("/livez returned HTTP \(httpResponse.statusCode)")
+		} catch {
+			return .unreachable
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Split Decodex server bridge HTTP transport from server lifecycle/probing.
- Split dashboard WebSocket handshake and frame codec from the core connection actor.
- Keep cohesive actor state and connection lifecycle together; this is a responsibility-boundary cleanup, not a line-count split.

## Validation
- cargo vstyle curate --language swift --workspace
- git diff --check
- swift test --package-path apps/decodex-app (blocked by existing local CommandLineTools SwiftUI macro issue: SwiftUIMacros.StateMacro plugin not found in existing @State views)