### PR TITLE
Fix Program dispatch recovery readiness

### DIFF
--- a/apps/decodex/src/execution_program.rs
+++ b/apps/decodex/src/execution_program.rs
@@ -7,6 +7,7 @@ mod model;
 mod policy;
 mod validation;
 
+#[cfg(test)] pub(crate) use self::model::ExecutionReadinessState;
 pub(crate) use self::{
 	evaluation::{
 		ExecutionNodeEvaluation, ExecutionProgramEvaluation, ExecutionProgramOperatorSummary,
@@ -15,7 +16,7 @@ pub(crate) use self::{
 		ExecutionConflictDomain, ExecutionConflictDomainKind, ExecutionDispatchAction,
 		ExecutionLinearIssueMapping, ExecutionProgram, ExecutionProgramDependency,
 		ExecutionProgramNode, ExecutionProgramNodeLifecycleState, ExecutionProgramNodeStage,
-		ExecutionQueueIntent, ExecutionReadinessState,
+		ExecutionQueueIntent,
 	},
 	policy::{
 		ExecutionDependencySnapshot, ExecutionProgramReadinessContext, ExecutionWorkflowPolicy,

--- a/apps/decodex/src/orchestrator.rs
+++ b/apps/decodex/src/orchestrator.rs
@@ -174,9 +174,9 @@ pub(crate) use self::{
 		ProgramSchedulerSummary, RefreshedExecutionProgram, execution_program_dependency_snapshots,
 		execution_program_occupied_conflict_domains, execution_program_readiness_context,
 		insert_dependency_snapshot, program_issue_occupies_conflict_domain, program_issue_snapshot,
-		record_program_dispatch_selected, refresh_execution_program_issues,
-		refresh_execution_program_local_lifecycle_facts, refresh_execution_program_tracker_facts,
-		select_execution_program_run_candidate,
+		record_program_dispatch_selected, record_program_dispatch_selected_for_summary,
+		refresh_execution_program_issues, refresh_execution_program_local_lifecycle_facts,
+		refresh_execution_program_tracker_facts, select_execution_program_run_candidate,
 		select_execution_program_run_candidate_with_summary,
 	},
 	pull_request_review::{
@@ -220,6 +220,7 @@ pub(crate) use self::{
 	run_cycle::{
 		closeout_lane_active_claim_blocks_dispatch, load_configured_cycle_workflow,
 		plan_project_issue_run_with_exclusions, run_configured_cycle, run_target_issue_once,
+		run_target_status_visible_program_once,
 	},
 };
 #[cfg(test)]

--- a/apps/decodex/src/orchestrator/daemon.rs
+++ b/apps/decodex/src/orchestrator/daemon.rs
@@ -37,8 +37,9 @@ use crate::orchestrator::{
 	apply_run_lease_reconciliation, daemon_retry, inspect_exited_daemon_child_reconciliation,
 	is_issue_not_dispatchable_for_current_dispatch, is_terminal_issue, mark_run_attempt_if_active,
 	refresh_issue, retained_review_handoff_matches_run, run_lease_reconciliation_workflow,
-	run_target_issue_once, stalled_idle_duration, stalled_run_has_retained_partial_progress,
-	superseded_run_disposition, terminal_issue_keeps_retained_closeout,
+	run_target_issue_once, run_target_status_visible_program_once, stalled_idle_duration,
+	stalled_run_has_retained_partial_progress, superseded_run_disposition,
+	terminal_issue_keeps_retained_closeout,
 };
 #[cfg(not(test))] use retry_dispatch::plan_due_retry_run;
 

--- a/apps/decodex/src/orchestrator/daemon/retry_dispatch.rs
+++ b/apps/decodex/src/orchestrator/daemon/retry_dispatch.rs
@@ -44,7 +44,7 @@ where
 				IssueDispatchMode::ReviewRepair | IssueDispatchMode::Closeout
 			))
 		.then_some(workflow.frontmatter().tracker().in_progress_state());
-		let Some(summary) = daemon::run_target_issue_once(TargetIssueRunContext {
+		let retry_context = TargetIssueRunContext {
 			tracker,
 			project,
 			workflow,
@@ -60,8 +60,13 @@ where
 			dispatch_mode: entry.dispatch_mode,
 			preferred_run_identity: None,
 			preferred_retry_budget_base: None,
-		})?
-		else {
+		};
+		let retry_summary = if entry.dispatch_mode == IssueDispatchMode::Program {
+			daemon::run_target_status_visible_program_once(retry_context)?
+		} else {
+			daemon::run_target_issue_once(retry_context)?
+		};
+		let Some(summary) = retry_summary else {
 			if daemon::retry_entry_is_temporarily_blocked(
 				tracker,
 				project,

--- a/apps/decodex/src/orchestrator/daemon/spawn.rs
+++ b/apps/decodex/src/orchestrator/daemon/spawn.rs
@@ -81,6 +81,14 @@ where
 				&daemon_spawn_state.worktree.path.display().to_string(),
 			)?;
 
+			if let Some(program_dispatch) = summary.program_dispatch.as_ref() {
+				orchestrator::record_program_dispatch_selected_for_summary(
+					state_store,
+					&summary,
+					program_dispatch,
+				)?;
+			}
+
 			let mut child = child::spawn_planned_daemon_child(
 				config_path,
 				state_store,

--- a/apps/decodex/src/orchestrator/daemon/spawn/plan.rs
+++ b/apps/decodex/src/orchestrator/daemon/spawn/plan.rs
@@ -1,6 +1,6 @@
 use crate::orchestrator::{
 	self, IssueTracker, Result, RetryDispatchDecision, RetryQueue, RunSummary, ServiceConfig,
-	StateStore, WorkflowDocument, daemon,
+	StateStore, WorkflowDocument, daemon, run_cycle,
 };
 
 pub(crate) fn plan_next_daemon_run<T>(
@@ -18,7 +18,7 @@ where
 		RetryDispatchDecision::Blocked { excluded_issue_ids } => {
 			let excluded_issue_ids =
 				excluded_issue_ids.iter().map(String::as_str).collect::<Vec<_>>();
-			let issue_run = orchestrator::plan_project_issue_run_with_exclusions(
+			let planned = run_cycle::plan_project_issue_run_with_program_dispatch(
 				tracker,
 				project,
 				workflow,
@@ -27,12 +27,19 @@ where
 				&excluded_issue_ids,
 			)?;
 
-			Ok(issue_run.map(|issue_run| {
-				(orchestrator::run_summary_from_issue_run(project.service_id(), &issue_run), false)
+			Ok(planned.map(|planned| {
+				let mut summary = orchestrator::run_summary_from_issue_run(
+					project.service_id(),
+					&planned.issue_run,
+				);
+
+				summary.program_dispatch = planned.program_dispatch;
+
+				(summary, false)
 			}))
 		},
 		RetryDispatchDecision::Continue => {
-			let issue_run = orchestrator::plan_project_issue_run_with_exclusions(
+			let planned = run_cycle::plan_project_issue_run_with_program_dispatch(
 				tracker,
 				project,
 				workflow,
@@ -41,8 +48,15 @@ where
 				&[],
 			)?;
 
-			Ok(issue_run.map(|issue_run| {
-				(orchestrator::run_summary_from_issue_run(project.service_id(), &issue_run), false)
+			Ok(planned.map(|planned| {
+				let mut summary = orchestrator::run_summary_from_issue_run(
+					project.service_id(),
+					&planned.issue_run,
+				);
+
+				summary.program_dispatch = planned.program_dispatch;
+
+				(summary, false)
 			}))
 		},
 	}

--- a/apps/decodex/src/orchestrator/execution/summary.rs
+++ b/apps/decodex/src/orchestrator/execution/summary.rs
@@ -18,6 +18,7 @@ pub(crate) fn run_summary_from_issue_run(project_id: &str, issue_run: &IssueRunP
 		attempt_number: issue_run.attempt_number,
 		run_id: issue_run.run_id.clone(),
 		continuation_pending: false,
+		program_dispatch: None,
 	}
 }
 

--- a/apps/decodex/src/orchestrator/program_reconciler.rs
+++ b/apps/decodex/src/orchestrator/program_reconciler.rs
@@ -19,7 +19,8 @@ pub(crate) use self::{
 		refresh_execution_program_local_lifecycle_facts, refresh_execution_program_tracker_facts,
 	},
 	selection::{
-		record_program_dispatch_selected, select_execution_program_run_candidate,
+		record_program_dispatch_selected, record_program_dispatch_selected_for_summary,
+		select_execution_program_run_candidate,
 		select_execution_program_run_candidate_with_summary,
 	},
 };

--- a/apps/decodex/src/orchestrator/program_reconciler/readiness.rs
+++ b/apps/decodex/src/orchestrator/program_reconciler/readiness.rs
@@ -17,11 +17,8 @@ pub(crate) fn execution_program_readiness_context(
 	let dependency_snapshots = execution_program_dependency_snapshots(programs)?;
 	let occupied_conflict_domains =
 		execution_program_occupied_conflict_domains(service_id, workflow, state_store, programs)?;
-	let active_issue_ids = state_store
-		.list_active_shared_leases(service_id)?
-		.into_iter()
-		.map(|lease| lease.issue_id().to_owned())
-		.collect::<Vec<_>>();
+	let active_issue_ids =
+		execution_program_active_issue_ids(service_id, workflow, state_store, programs)?;
 
 	Ok(ExecutionProgramReadinessContext::new()
 		.with_dependency_snapshots(dependency_snapshots)
@@ -136,4 +133,36 @@ pub(crate) fn program_issue_occupies_conflict_domain(
 		|| snapshot.has_post_review_lifecycle
 		|| retained_nonterminal
 		|| state_store.issue_has_active_shared_claim(service_id, &issue.id)?)
+}
+
+fn execution_program_active_issue_ids(
+	service_id: &str,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	programs: &[RefreshedExecutionProgram],
+) -> Result<Vec<String>> {
+	let retained_issue_ids = state_store
+		.list_worktrees(service_id)?
+		.into_iter()
+		.map(|worktree| worktree.issue_id().to_owned())
+		.collect::<BTreeSet<_>>();
+	let mut active_issue_ids = state_store
+		.list_active_shared_leases(service_id)?
+		.into_iter()
+		.map(|lease| lease.issue_id().to_owned())
+		.collect::<BTreeSet<_>>();
+
+	for refreshed in programs {
+		for snapshot in refreshed.issues_by_node.values() {
+			let issue = &snapshot.issue;
+
+			if retained_issue_ids.contains(&issue.id)
+				&& !orchestrator::state_name_is_terminal(&issue.state.name, workflow)
+			{
+				active_issue_ids.insert(issue.id.clone());
+			}
+		}
+	}
+
+	Ok(active_issue_ids.into_iter().collect())
 }

--- a/apps/decodex/src/orchestrator/program_reconciler/selection.rs
+++ b/apps/decodex/src/orchestrator/program_reconciler/selection.rs
@@ -1,13 +1,22 @@
 use crate::{
-	execution_program::{ExecutionReadinessState, ExecutionWorkflowPolicy},
+	execution_program::ExecutionWorkflowPolicy,
 	orchestrator::{
 		self, IssueDispatchMode, IssueRunPlan, IssueTracker, PROGRAM_DISPATCH_SELECTED_EVENT_TYPE,
 		PROGRAM_DISPATCH_SELECTED_SCHEMA, ProgramDispatchSelection, ProgramSchedulerSelection,
-		ProgramSchedulerSummary, Result, SelectedIssueRunCandidate, ServiceConfig, StateStore,
-		WorkflowDocument, program_reconciler,
+		ProgramSchedulerSummary, Result, RunSummary, SelectedIssueRunCandidate, ServiceConfig,
+		StateStore, WorkflowDocument, eyre, program_reconciler,
 	},
 	state::PrivateExecutionEvent,
 };
+
+struct ProgramDispatchEventFields<'a> {
+	project_id: &'a str,
+	issue_id: &'a str,
+	issue_identifier: &'a str,
+	run_id: &'a str,
+	attempt_number: i64,
+	dispatch_mode: IssueDispatchMode,
+}
 
 pub(crate) fn record_program_dispatch_selected(
 	state_store: &StateStore,
@@ -15,31 +24,36 @@ pub(crate) fn record_program_dispatch_selected(
 	issue_run: &IssueRunPlan,
 	program_dispatch: &ProgramDispatchSelection,
 ) -> Result<PrivateExecutionEvent> {
-	state_store.append_private_execution_event(
-		project_id,
-		&issue_run.issue.id,
-		&issue_run.run_id,
-		issue_run.attempt_number,
-		PROGRAM_DISPATCH_SELECTED_EVENT_TYPE,
-		serde_json::json!({
-			"schema": PROGRAM_DISPATCH_SELECTED_SCHEMA,
-			"record_version": 1,
-			"issue": {
-				"id": &issue_run.issue.id,
-				"identifier": &issue_run.issue.identifier,
-			},
-			"run": {
-				"run_id": &issue_run.run_id,
-				"attempt_number": issue_run.attempt_number,
-				"dispatch_mode": issue_run.dispatch_mode.as_str(),
-			},
-			"execution_program": {
-				"program_id": &program_dispatch.program_id,
-				"node_id": &program_dispatch.node_id,
-				"source_contract_id": &program_dispatch.source_contract_id,
-				"queue_intent": &program_dispatch.queue_intent,
-			},
-		}),
+	record_program_dispatch_selected_fields(
+		state_store,
+		ProgramDispatchEventFields {
+			project_id,
+			issue_id: &issue_run.issue.id,
+			issue_identifier: &issue_run.issue.identifier,
+			run_id: &issue_run.run_id,
+			attempt_number: issue_run.attempt_number,
+			dispatch_mode: issue_run.dispatch_mode,
+		},
+		program_dispatch,
+	)
+}
+
+pub(crate) fn record_program_dispatch_selected_for_summary(
+	state_store: &StateStore,
+	summary: &RunSummary,
+	program_dispatch: &ProgramDispatchSelection,
+) -> Result<PrivateExecutionEvent> {
+	record_program_dispatch_selected_fields(
+		state_store,
+		ProgramDispatchEventFields {
+			project_id: &summary.project_id,
+			issue_id: &summary.issue_id,
+			issue_identifier: &summary.issue_identifier,
+			run_id: &summary.run_id,
+			attempt_number: summary.attempt_number,
+			dispatch_mode: summary.dispatch_mode,
+		},
+		program_dispatch,
 	)
 }
 
@@ -134,7 +148,7 @@ where
 		summary.programs_evaluated += 1;
 
 		for node in evaluation.nodes() {
-			if node.state() != ExecutionReadinessState::Ready {
+			if !node.dispatchable() {
 				continue;
 			}
 
@@ -185,4 +199,86 @@ where
 		.sort_by(|left, right| orchestrator::compare_issue_candidates(&left.issue, &right.issue));
 
 	Ok(ProgramSchedulerSelection { selected: candidates.into_iter().next(), summary })
+}
+
+fn record_program_dispatch_selected_fields(
+	state_store: &StateStore,
+	fields: ProgramDispatchEventFields<'_>,
+	program_dispatch: &ProgramDispatchSelection,
+) -> Result<PrivateExecutionEvent> {
+	let mut conflicting_event_id = None;
+
+	for existing in state_store.list_private_execution_events(
+		fields.project_id,
+		fields.issue_id,
+		fields.run_id,
+		fields.attempt_number,
+	)? {
+		if existing.event_type() != PROGRAM_DISPATCH_SELECTED_EVENT_TYPE {
+			continue;
+		}
+		if program_dispatch_event_matches(&existing, &fields, program_dispatch) {
+			return Ok(existing);
+		}
+
+		conflicting_event_id = Some(existing.record_id().to_owned());
+
+		break;
+	}
+
+	if let Some(record_id) = conflicting_event_id {
+		eyre::bail!(
+			"Conflicting Program dispatch selection event `{record_id}` already exists for `{}` attempt {}.",
+			fields.run_id,
+			fields.attempt_number
+		);
+	}
+
+	state_store.append_private_execution_event(
+		fields.project_id,
+		fields.issue_id,
+		fields.run_id,
+		fields.attempt_number,
+		PROGRAM_DISPATCH_SELECTED_EVENT_TYPE,
+		serde_json::json!({
+			"schema": PROGRAM_DISPATCH_SELECTED_SCHEMA,
+			"record_version": 1,
+			"issue": {
+				"id": fields.issue_id,
+				"identifier": fields.issue_identifier,
+			},
+			"run": {
+				"run_id": fields.run_id,
+				"attempt_number": fields.attempt_number,
+				"dispatch_mode": fields.dispatch_mode.as_str(),
+			},
+			"execution_program": {
+				"program_id": &program_dispatch.program_id,
+				"node_id": &program_dispatch.node_id,
+				"source_contract_id": &program_dispatch.source_contract_id,
+				"queue_intent": &program_dispatch.queue_intent,
+			},
+		}),
+	)
+}
+
+fn program_dispatch_event_matches(
+	event: &PrivateExecutionEvent,
+	fields: &ProgramDispatchEventFields<'_>,
+	program_dispatch: &ProgramDispatchSelection,
+) -> bool {
+	let payload = event.payload();
+	let source_contract_id =
+		payload["execution_program"]["source_contract_id"].as_str().map(str::to_owned);
+
+	payload["schema"] == PROGRAM_DISPATCH_SELECTED_SCHEMA
+		&& payload["issue"]["id"] == fields.issue_id
+		&& payload["issue"]["identifier"] == fields.issue_identifier
+		&& payload["run"]["run_id"] == fields.run_id
+		&& payload["run"]["attempt_number"] == fields.attempt_number
+		&& payload["run"]["dispatch_mode"] == fields.dispatch_mode.as_str()
+		&& payload["execution_program"]["program_id"] == program_dispatch.program_id
+		&& payload["execution_program"]["node_id"] == program_dispatch.node_id
+		&& source_contract_id == program_dispatch.source_contract_id
+		&& payload["execution_program"]["queue_intent"] == program_dispatch.queue_intent
 }

--- a/apps/decodex/src/orchestrator/run_cycle.rs
+++ b/apps/decodex/src/orchestrator/run_cycle.rs
@@ -15,10 +15,13 @@ pub(crate) use self::{
 };
 pub(crate) use self::{
 	prepare::prepare_issue_run,
-	project::{plan_project_issue_run_with_exclusions, run_project_once},
+	project::{
+		plan_project_issue_run_with_exclusions, plan_project_issue_run_with_program_dispatch,
+		run_project_once,
+	},
 	target_issue::{
 		closeout_lane_active_claim_blocks_dispatch, run_target_issue_once,
-		run_target_issue_once_with_inferred_dispatch,
+		run_target_issue_once_with_inferred_dispatch, run_target_status_visible_program_once,
 	},
 };
 

--- a/apps/decodex/src/orchestrator/run_cycle/project.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/project.rs
@@ -3,7 +3,9 @@ mod execution;
 mod planning;
 mod queue;
 
-pub(crate) use planning::plan_project_issue_run_with_exclusions;
+pub(crate) use planning::{
+	plan_project_issue_run_with_exclusions, plan_project_issue_run_with_program_dispatch,
+};
 
 use crate::orchestrator::run_cycle::{
 	IssueTracker, Result, RunSummary, ServiceConfig, StateStore, WorkflowDocument,

--- a/apps/decodex/src/orchestrator/run_cycle/project/planning.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/project/planning.rs
@@ -1,8 +1,16 @@
-use crate::orchestrator::run_cycle::{
-	self, IssueDispatchMode, IssueRunPlan, IssueTracker, PreferredRunIdentity,
-	PrepareIssueRunContext, Result, RetryIssueStateHint, ServiceConfig, StateStore,
-	WorkflowDocument, WorktreeManager, eyre, project::candidate, slice,
+use crate::orchestrator::{
+	ProgramDispatchSelection,
+	run_cycle::{
+		self, IssueDispatchMode, IssueRunPlan, IssueTracker, PreferredRunIdentity,
+		PrepareIssueRunContext, Result, RetryIssueStateHint, ServiceConfig, StateStore,
+		WorkflowDocument, WorktreeManager, eyre, project::candidate, slice,
+	},
 };
+
+pub(crate) struct PlannedProjectIssueRun {
+	pub(crate) issue_run: IssueRunPlan,
+	pub(crate) program_dispatch: Option<ProgramDispatchSelection>,
+}
 
 pub(crate) fn plan_project_issue_run_with_exclusions<T>(
 	tracker: &T,
@@ -12,6 +20,28 @@ pub(crate) fn plan_project_issue_run_with_exclusions<T>(
 	dry_run: bool,
 	excluded_issue_ids: &[&str],
 ) -> Result<Option<IssueRunPlan>>
+where
+	T: IssueTracker,
+{
+	Ok(plan_project_issue_run_with_program_dispatch(
+		tracker,
+		project,
+		workflow,
+		state_store,
+		dry_run,
+		excluded_issue_ids,
+	)?
+	.map(|planned| planned.issue_run))
+}
+
+pub(crate) fn plan_project_issue_run_with_program_dispatch<T>(
+	tracker: &T,
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	dry_run: bool,
+	excluded_issue_ids: &[&str],
+) -> Result<Option<PlannedProjectIssueRun>>
 where
 	T: IssueTracker,
 {
@@ -85,7 +115,7 @@ where
 			return Ok(None);
 		}
 
-		return replan_project_issue_run_after_excluding(
+		return replan_project_issue_run_with_program_dispatch_after_excluding(
 			tracker,
 			project,
 			workflow,
@@ -131,10 +161,10 @@ where
 		)?;
 	}
 
-	Ok(Some(issue_run))
+	Ok(Some(PlannedProjectIssueRun { issue_run, program_dispatch }))
 }
 
-fn replan_project_issue_run_after_excluding<T>(
+fn replan_project_issue_run_with_program_dispatch_after_excluding<T>(
 	tracker: &T,
 	project: &ServiceConfig,
 	workflow: &WorkflowDocument,
@@ -142,7 +172,7 @@ fn replan_project_issue_run_after_excluding<T>(
 	dry_run: bool,
 	excluded_issue_ids: &[&str],
 	issue_id: &str,
-) -> Result<Option<IssueRunPlan>>
+) -> Result<Option<PlannedProjectIssueRun>>
 where
 	T: IssueTracker,
 {
@@ -150,7 +180,7 @@ where
 
 	next_excluded_issue_ids.push(issue_id);
 
-	plan_project_issue_run_with_exclusions(
+	plan_project_issue_run_with_program_dispatch(
 		tracker,
 		project,
 		workflow,

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue.rs
@@ -7,7 +7,10 @@ mod context;
 mod identity;
 mod lease;
 
-pub(crate) use inferred::run_target_issue_once_with_inferred_dispatch;
+pub(crate) use self::{
+	inferred::run_target_issue_once_with_inferred_dispatch,
+	program::run_target_status_visible_program_once,
+};
 #[cfg(test)] pub(crate) use program::select_target_status_visible_program_candidate;
 
 use crate::orchestrator::run_cycle::{

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue/program.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue/program.rs
@@ -18,8 +18,7 @@ where
 	let dry_run = context.dry_run;
 	let state_store = context.state_store;
 	let project_id = context.project.service_id().to_owned();
-
-	target_issue::run_target_issue_once_after_prepare(context, |issue_run| {
+	let mut summary = target_issue::run_target_issue_once_after_prepare(context, |issue_run| {
 		if !dry_run && let Some(program_dispatch) = program_dispatch.as_ref() {
 			orchestrator::record_program_dispatch_selected(
 				state_store,
@@ -30,7 +29,13 @@ where
 		}
 
 		Ok(())
-	})
+	})?;
+
+	if let Some(summary) = summary.as_mut() {
+		summary.program_dispatch = program_dispatch;
+	}
+
+	Ok(summary)
 }
 
 pub(crate) fn select_target_status_visible_program_candidate<T>(

--- a/apps/decodex/src/orchestrator/status/execution_programs/context.rs
+++ b/apps/decodex/src/orchestrator/status/execution_programs/context.rs
@@ -23,11 +23,12 @@ pub(crate) fn operator_execution_program_readiness_context(
 		state_store,
 		records,
 	)?;
-	let active_issue_ids = state_store
-		.list_active_shared_leases(service_id)?
-		.into_iter()
-		.map(|lease| lease.issue_id().to_owned())
-		.collect::<Vec<_>>();
+	let active_issue_ids = self::operator_execution_program_active_issue_ids(
+		service_id,
+		workflow,
+		state_store,
+		records,
+	)?;
 
 	Ok(ExecutionProgramReadinessContext::new()
 		.with_dependency_snapshots(dependency_snapshots)
@@ -45,6 +46,40 @@ pub(crate) fn operator_execution_program_mapped_issue_ids(
 		.collect::<BTreeSet<_>>()
 		.into_iter()
 		.collect()
+}
+
+fn operator_execution_program_active_issue_ids(
+	service_id: &str,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	records: &[ExecutionProgramRecord],
+) -> Result<Vec<String>> {
+	let retained_issue_ids = state_store
+		.list_worktrees(service_id)?
+		.into_iter()
+		.map(|worktree| worktree.issue_id().to_owned())
+		.collect::<BTreeSet<_>>();
+	let mut active_issue_ids = state_store
+		.list_active_shared_leases(service_id)?
+		.into_iter()
+		.map(|lease| lease.issue_id().to_owned())
+		.collect::<BTreeSet<_>>();
+
+	for record in records {
+		for node in record.program().nodes() {
+			let Some(issue) = node.linear_issue() else {
+				continue;
+			};
+
+			if retained_issue_ids.contains(issue.issue_id())
+				&& !orchestrator::state_name_is_terminal(issue.issue_state(), workflow)
+			{
+				active_issue_ids.insert(issue.issue_id().to_owned());
+			}
+		}
+	}
+
+	Ok(active_issue_ids.into_iter().collect())
 }
 
 fn operator_execution_program_dependency_snapshots(

--- a/apps/decodex/src/orchestrator/tests/intake_candidate_selection/support.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_candidate_selection/support.rs
@@ -43,6 +43,7 @@ pub(super) fn sample_handoff_summary(issue: &TrackerIssue, worktree_path: &Path)
 		attempt_number: 1,
 		run_id: String::from("run-review-handoff"),
 		continuation_pending: false,
+		program_dispatch: None,
 	}
 }
 

--- a/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_dispatch/normal_targeting.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_dispatch/normal_targeting.rs
@@ -32,6 +32,7 @@ fn dry_run_selects_one_issue_and_plans_worktree() {
 			attempt_number: 1,
 			run_id: summary.run_id.clone(),
 			continuation_pending: false,
+			program_dispatch: None,
 		}
 	);
 	assert!(tracker.comments.borrow().is_empty());

--- a/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_dispatch/rejections_and_summary/format_run_once_summary_surfaces_continuation_boundaries.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_dispatch/rejections_and_summary/format_run_once_summary_surfaces_continuation_boundaries.rs
@@ -17,6 +17,7 @@ fn format_run_once_summary_surfaces_continuation_boundaries() {
 		attempt_number: 1,
 		run_id: String::from("pub-101-attempt-1"),
 		continuation_pending: true,
+		program_dispatch: None,
 	};
 	let message = orchestrator::format_run_once_summary(&summary, false);
 

--- a/apps/decodex/src/orchestrator/tests/operator/status/text/program_readback/live_mapping.rs
+++ b/apps/decodex/src/orchestrator/tests/operator/status/text/program_readback/live_mapping.rs
@@ -26,6 +26,53 @@ fn operator_status_snapshot_surfaces_program_intake_and_node_readbacks() {
 }
 
 #[test]
+fn operator_status_program_readback_marks_retained_worktree_node_active_without_conflict_domain() {
+	let (_temp_dir, config, workflow) = status::temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue_id = "issue-retained-no-conflict";
+	let node = program_readback::status_program_node(
+		"node-retained-no-conflict",
+		issue_id,
+		"PUB-1598",
+		"Todo",
+		ExecutionQueueIntent::ReadyToQueue,
+	);
+	let program = ExecutionProgram::from_issue_batch_intake(
+		"program-retained-no-conflict",
+		config.service_id(),
+		"program-retained-no-conflict-fingerprint",
+		"Read retained no-conflict Program node.",
+		vec![node],
+	)
+	.expect("program should build");
+
+	state_store
+		.upsert_execution_program(config.service_id(), program)
+		.expect("program should persist");
+	state_store
+		.upsert_worktree(
+			config.service_id(),
+			issue_id,
+			"x/pubfi-pub-1598",
+			&config.repo_root().display().to_string(),
+		)
+		.expect("retained worktree should persist");
+
+	let snapshot =
+		program_readback::build_program_readback_snapshot(&config, &workflow, &state_store);
+	let program = snapshot.execution_programs.first().expect("program should surface");
+	let node = program.node_readbacks.first().expect("retained node should surface");
+
+	assert_eq!(program.status, "active");
+	assert_eq!(program.active_count, 1);
+	assert_eq!(program.dispatchable_count, 0);
+	assert_eq!(node.lifecycle_state, "active");
+	assert_eq!(node.dispatch_action, None);
+	assert!(node.reason_codes.contains(&String::from("current_lane_present")));
+	assert!(!node.reason_codes.contains(&String::from("conflict_domain_occupied")));
+}
+
+#[test]
 fn operator_status_program_readback_prefers_post_review_owner_over_stale_active_label() {
 	let (_temp_dir, config, workflow) = status::temp_project_layout();
 	let state_store = StateStore::open_in_memory().expect("state store should open");

--- a/apps/decodex/src/orchestrator/tests/recovery_closeout_dispatch/run_identity.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery_closeout_dispatch/run_identity.rs
@@ -102,6 +102,7 @@ fn same_run_closeout_reuses_matching_active_handoff_lease() {
 		attempt_number: 1,
 		run_id: fixture.completed_run_id.clone(),
 		continuation_pending: false,
+		program_dispatch: None,
 	};
 	let summary = orchestrator::run_retained_closeout_for_handoff_summary(
 		&fixture.tracker,

--- a/apps/decodex/src/orchestrator/tests/runtime_program_reconciler/selection.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime_program_reconciler/selection.rs
@@ -1,7 +1,10 @@
+use std::time::Instant;
+
 use crate::{
 	execution_program::ExecutionQueueIntent,
 	orchestrator::{
-		self, IssueDispatchMode, IssueRunPlan,
+		self, IssueDispatchMode, IssueRunPlan, RetryDispatchDecision, RetryEntry,
+		RetryEntryLifecycle, RetryKind, RetryQueue,
 		tests::{self, FakeTracker, runtime_program_reconciler::support},
 	},
 	state::StateStore,
@@ -50,6 +53,168 @@ fn selects_ready_node_for_direct_program_dispatch_without_queue_label_mutation()
 	assert_eq!(program_dispatch.queue_intent, "ready_to_queue");
 	assert!(tracker.label_additions.borrow().is_empty());
 	assert!(tracker.label_removals.borrow().is_empty());
+}
+
+#[test]
+fn daemon_planning_preserves_program_dispatch_provenance() {
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let issue = support::program_reconciler_issue("issue-daemon-ready", "PUB-204", "Todo", &[]);
+
+	store
+		.upsert_execution_program(
+			config.service_id(),
+			support::program_reconciler_program(vec![support::program_reconciler_node(
+				"node-daemon-ready",
+				&issue,
+				ExecutionQueueIntent::ReadyToQueue,
+			)]),
+		)
+		.expect("program should persist");
+
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+	let mut retry_queue = RetryQueue::default();
+	let (summary, from_retry_queue) =
+		orchestrator::plan_next_daemon_run(&mut retry_queue, &tracker, &config, &workflow, &store)
+			.expect("daemon planning should succeed")
+			.expect("daemon planning should select ready program node");
+	let program_dispatch = summary.program_dispatch.expect("daemon summary should carry program");
+
+	assert!(!from_retry_queue);
+	assert_eq!(summary.issue_id, issue.id);
+	assert_eq!(summary.dispatch_mode, IssueDispatchMode::Program);
+	assert_eq!(program_dispatch.program_id, "program-reconciler");
+	assert_eq!(program_dispatch.node_id, "node-daemon-ready");
+	assert_eq!(program_dispatch.queue_intent, "ready_to_queue");
+}
+
+#[test]
+fn retained_nonterminal_worktree_blocks_no_conflict_program_dispatch() {
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let issue =
+		support::program_reconciler_issue("issue-retained-no-conflict", "PUB-205", "Todo", &[]);
+
+	store
+		.upsert_execution_program(
+			config.service_id(),
+			support::program_reconciler_program(vec![support::program_reconciler_node(
+				"node-retained-no-conflict",
+				&issue,
+				ExecutionQueueIntent::ReadyToQueue,
+			)]),
+		)
+		.expect("program should persist");
+	store
+		.upsert_worktree(
+			config.service_id(),
+			&issue.id,
+			"x/pubfi-pub-205",
+			&config.repo_root().display().to_string(),
+		)
+		.expect("retained worktree should persist");
+
+	let tracker = FakeTracker::new(vec![issue]);
+	let selection = orchestrator::select_execution_program_run_candidate_with_summary(
+		&tracker,
+		&config,
+		&workflow,
+		&store,
+		&[],
+	)
+	.expect("program dispatch selection should evaluate");
+
+	assert!(selection.selected.is_none());
+	assert_eq!(selection.summary.programs_evaluated, 1);
+	assert_eq!(selection.summary.dispatchable_nodes, 0);
+}
+
+#[test]
+fn due_program_retry_preserves_program_dispatch_provenance() {
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let issue =
+		support::program_reconciler_issue("issue-due-program-retry", "PUB-206", "Todo", &[]);
+
+	store
+		.upsert_execution_program(
+			config.service_id(),
+			support::program_reconciler_program(vec![support::program_reconciler_node(
+				"node-due-program-retry",
+				&issue,
+				ExecutionQueueIntent::ReadyToQueue,
+			)]),
+		)
+		.expect("program should persist");
+
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+	let mut retry_queue = RetryQueue::default();
+
+	retry_queue.upsert(RetryEntry {
+		issue_id: issue.id.clone(),
+		retry_project_slug: issue
+			.project_slug
+			.clone()
+			.expect("sample issue should carry a project slug"),
+		continuation_initial_issue_state: None,
+		lifecycle: RetryEntryLifecycle::Active,
+		dispatch_mode: IssueDispatchMode::Program,
+		kind: RetryKind::Failure,
+		attempt: 1,
+		ready_at: Instant::now(),
+	});
+
+	let decision =
+		orchestrator::plan_due_retry_run(&mut retry_queue, &tracker, &config, &workflow, &store)
+			.expect("program retry planning should succeed");
+	let RetryDispatchDecision::Dispatch(summary) = decision else {
+		panic!("due program retry should dispatch");
+	};
+	let program_dispatch =
+		summary.program_dispatch.expect("due program retry should carry Program selection");
+
+	assert_eq!(summary.issue_id, issue.id);
+	assert_eq!(summary.dispatch_mode, IssueDispatchMode::Program);
+	assert_eq!(program_dispatch.program_id, "program-reconciler");
+	assert_eq!(program_dispatch.node_id, "node-due-program-retry");
+	assert_eq!(program_dispatch.queue_intent, "ready_to_queue");
+}
+
+#[test]
+fn skips_ready_node_without_dispatch_action() {
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let store = StateStore::open_in_memory().expect("state store should open");
+	let issue = support::program_reconciler_issue(
+		"issue-manual-only",
+		"PUB-203",
+		"Todo",
+		&["decodex:manual-only"],
+	);
+
+	store
+		.upsert_execution_program(
+			config.service_id(),
+			support::program_reconciler_program(vec![support::program_reconciler_node(
+				"node-manual-only",
+				&issue,
+				ExecutionQueueIntent::ReadyToQueue,
+			)]),
+		)
+		.expect("program should persist");
+
+	let tracker = FakeTracker::new(vec![issue]);
+	let selection = orchestrator::select_execution_program_run_candidate_with_summary(
+		&tracker,
+		&config,
+		&workflow,
+		&store,
+		&[],
+	)
+	.expect("program dispatch selection should evaluate");
+
+	assert!(selection.selected.is_none());
+	assert_eq!(selection.summary.programs_evaluated, 1);
+	assert_eq!(selection.summary.dispatchable_nodes, 0);
 }
 
 #[test]
@@ -120,4 +285,32 @@ fn records_private_program_dispatch_selection_event_with_node_provenance() {
 
 	assert_eq!(events.len(), 1);
 	assert_eq!(events[0].payload(), event.payload());
+
+	let duplicate = orchestrator::record_program_dispatch_selected(
+		&store,
+		config.service_id(),
+		&issue_run,
+		&program_dispatch,
+	)
+	.expect("duplicate program dispatch selection should be idempotent");
+	let events = store
+		.list_private_execution_events(config.service_id(), &issue.id, "pub-202-attempt-1-123", 1)
+		.expect("private event should be readable");
+
+	assert_eq!(events.len(), 1);
+	assert_eq!(duplicate.record_id(), event.record_id());
+
+	let summary = orchestrator::run_summary_from_issue_run(config.service_id(), &issue_run);
+	let summary_duplicate = orchestrator::record_program_dispatch_selected_for_summary(
+		&store,
+		&summary,
+		&program_dispatch,
+	)
+	.expect("summary-based program dispatch selection should be idempotent");
+	let events = store
+		.list_private_execution_events(config.service_id(), &issue.id, "pub-202-attempt-1-123", 1)
+		.expect("private event should be readable");
+
+	assert_eq!(events.len(), 1);
+	assert_eq!(summary_duplicate.record_id(), event.record_id());
 }

--- a/apps/decodex/src/orchestrator/types/requests/run_plan.rs
+++ b/apps/decodex/src/orchestrator/types/requests/run_plan.rs
@@ -1,6 +1,6 @@
 use crate::orchestrator::types::{
-	IssueDispatchMode, Path, PathBuf, RetryQueue, ServiceConfig, StateStore, TrackerIssue,
-	WorkflowDocument, WorktreeManager, WorktreeSpec,
+	IssueDispatchMode, Path, PathBuf, ProgramDispatchSelection, RetryQueue, ServiceConfig,
+	StateStore, TrackerIssue, WorkflowDocument, WorktreeManager, WorktreeSpec,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -18,6 +18,7 @@ pub(crate) struct RunSummary {
 	pub(crate) attempt_number: i64,
 	pub(crate) run_id: String,
 	pub(crate) continuation_pending: bool,
+	pub(crate) program_dispatch: Option<ProgramDispatchSelection>,
 }
 
 #[derive(Clone, Debug)]

--- a/apps/decodex/src/program_intake.rs
+++ b/apps/decodex/src/program_intake.rs
@@ -6,6 +6,7 @@ mod goal_run;
 mod issue_batch;
 mod issue_batch_run;
 mod model;
+mod readiness;
 mod render;
 
 #[cfg(test)] pub(crate) use self::render::validate_generated_issue_text;

--- a/apps/decodex/src/program_intake/goal_run.rs
+++ b/apps/decodex/src/program_intake/goal_run.rs
@@ -1,7 +1,9 @@
 use crate::{
-	execution_program::{ExecutionProgramReadinessContext, ExecutionWorkflowPolicy},
+	execution_program::ExecutionWorkflowPolicy,
 	prelude::{Result, eyre},
-	program_intake::{GoalIntakeReport, GoalIntakeRunRequest, goal, model::ApplyGoalIssuesInput},
+	program_intake::{
+		GoalIntakeReport, GoalIntakeRunRequest, goal, model::ApplyGoalIssuesInput, readiness,
+	},
 	tracker::IssueTracker,
 };
 
@@ -69,7 +71,13 @@ where
 		let evaluation = program.evaluate(
 			&linked_contract,
 			&ExecutionWorkflowPolicy::from_workflow(config.service_id(), workflow)?,
-			&ExecutionProgramReadinessContext::new(),
+			&readiness::intake_readiness_context(
+				config.service_id(),
+				workflow,
+				state_store,
+				&program,
+				Vec::new(),
+			)?,
 		)?;
 		let rows = goal::applied_goal_issue_rows(&plans, &issues, &linked_issues, &evaluation);
 

--- a/apps/decodex/src/program_intake/issue_batch_run.rs
+++ b/apps/decodex/src/program_intake/issue_batch_run.rs
@@ -2,13 +2,12 @@ use std::collections::BTreeMap;
 
 use crate::{
 	config::ServiceConfig,
-	execution_program::{
-		ExecutionProgram, ExecutionProgramReadinessContext, ExecutionWorkflowPolicy,
-	},
+	execution_program::{ExecutionProgram, ExecutionWorkflowPolicy},
 	prelude::{Result, eyre},
 	program_intake::{
 		IssueBatchIntakeReport,
 		issue_batch::{identity, nodes, reporting},
+		readiness,
 	},
 	state::StateStore,
 	tracker::{self, IssueTracker},
@@ -78,8 +77,13 @@ where
 		format!("Issue-batch intake for {} issue(s).", issue_identifiers.len()),
 		nodes,
 	)?;
-	let context =
-		ExecutionProgramReadinessContext::new().with_dependency_snapshots(dependency_snapshots);
+	let context = readiness::intake_readiness_context(
+		config.service_id(),
+		workflow,
+		state_store,
+		&program,
+		dependency_snapshots,
+	)?;
 	let evaluation = program.evaluate_issue_batch(&policy, &context)?;
 	let evaluation_by_issue = evaluation
 		.nodes()

--- a/apps/decodex/src/program_intake/readiness.rs
+++ b/apps/decodex/src/program_intake/readiness.rs
@@ -1,0 +1,96 @@
+use std::collections::BTreeSet;
+
+use crate::{
+	execution_program::{
+		ExecutionConflictDomain, ExecutionDependencySnapshot, ExecutionProgram,
+		ExecutionProgramReadinessContext,
+	},
+	orchestrator,
+	prelude::Result,
+	state::StateStore,
+	workflow::WorkflowDocument,
+};
+
+pub(in crate::program_intake) fn intake_readiness_context(
+	service_id: &str,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	program: &ExecutionProgram,
+	dependency_snapshots: Vec<ExecutionDependencySnapshot>,
+) -> Result<ExecutionProgramReadinessContext> {
+	let retained_issue_ids = state_store
+		.list_worktrees(service_id)?
+		.into_iter()
+		.map(|worktree| worktree.issue_id().to_owned())
+		.collect::<BTreeSet<_>>();
+	let mut active_issue_ids = state_store
+		.list_active_shared_leases(service_id)?
+		.into_iter()
+		.map(|lease| lease.issue_id().to_owned())
+		.collect::<BTreeSet<_>>();
+
+	for node in program.nodes() {
+		let Some(issue) = node.linear_issue() else {
+			continue;
+		};
+
+		if retained_issue_ids.contains(issue.issue_id())
+			&& !orchestrator::state_name_is_terminal(issue.issue_state(), workflow)
+		{
+			active_issue_ids.insert(issue.issue_id().to_owned());
+		}
+	}
+
+	let occupied_conflict_domains =
+		intake_occupied_conflict_domains(service_id, workflow, state_store)?;
+
+	Ok(ExecutionProgramReadinessContext::new()
+		.with_dependency_snapshots(dependency_snapshots)
+		.with_occupied_conflict_domains(occupied_conflict_domains)
+		.with_active_issue_ids(active_issue_ids))
+}
+
+fn intake_occupied_conflict_domains(
+	service_id: &str,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+) -> Result<Vec<ExecutionConflictDomain>> {
+	let retained_issue_ids = state_store
+		.list_worktrees(service_id)?
+		.into_iter()
+		.map(|worktree| worktree.issue_id().to_owned())
+		.collect::<BTreeSet<_>>();
+	let mut occupied = Vec::new();
+	let mut seen = BTreeSet::new();
+
+	for record in state_store.list_execution_programs(service_id)? {
+		for node in record.program().nodes() {
+			let Some(issue) = node.linear_issue() else {
+				continue;
+			};
+			let retained_nonterminal = retained_issue_ids.contains(issue.issue_id())
+				&& !orchestrator::state_name_is_terminal(issue.issue_state(), workflow);
+			let has_post_review_lifecycle =
+				state_store.issue_has_review_lifecycle_record(service_id, issue.issue_id())?;
+			let issue_occupies_domain = issue.has_active_label()
+				|| issue.has_needs_attention_label()
+				|| has_post_review_lifecycle
+				|| retained_nonterminal
+				|| state_store.issue_has_active_shared_claim(service_id, issue.issue_id())?;
+
+			if !issue_occupies_domain {
+				continue;
+			}
+
+			for domain in node.conflict_domains() {
+				let key = format!("{}:{}", domain.kind().as_str(), domain.key());
+
+				if seen.insert(key) {
+					occupied.push(domain.clone());
+				}
+			}
+		}
+	}
+
+	Ok(occupied)
+}

--- a/apps/decodex/src/program_intake/tests/issue_batch.rs
+++ b/apps/decodex/src/program_intake/tests/issue_batch.rs
@@ -77,6 +77,76 @@ fn issue_batch_dry_run_classifies_without_persisting() {
 }
 
 #[test]
+fn issue_batch_dry_run_uses_runtime_context_for_dispatch_action() {
+	let store = StateStore::open_in_memory().expect("store should open");
+	let workflow = test_support::workflow();
+	let config = test_support::test_config();
+	let tracker = FakeTracker::default().with_issues([test_support::issue("XY-1", "Todo")]);
+
+	store
+		.upsert_worktree("decodex", "id-XY-1", "x/decodex-xy-1", "/tmp/decodex/.worktrees/XY-1")
+		.expect("retained worktree should record");
+
+	let report = program_intake::run_issue_batch_intake(
+		&store,
+		&tracker,
+		&config,
+		&workflow,
+		vec![String::from("XY-1")],
+		true,
+		false,
+	)
+	.expect("dry-run should classify with runtime context");
+
+	assert_eq!(report.counts.ready, 0);
+	assert_eq!(report.counts.held, 1);
+	assert_eq!(report.issues[0].classification, IssueBatchIntakeClassification::Held);
+	assert_eq!(report.issues[0].dispatch_action, None);
+}
+
+#[test]
+fn issue_batch_dry_run_uses_runtime_conflict_occupancy() {
+	let store = StateStore::open_in_memory().expect("store should open");
+	let workflow = test_support::workflow();
+	let config = test_support::test_config();
+	let tracker = FakeTracker::default().with_issues([
+		test_support::issue("XY-0", "In Progress").with_label("repo:alpha"),
+		test_support::issue("XY-1", "Todo").with_label("repo:alpha"),
+	]);
+
+	program_intake::run_issue_batch_intake(
+		&store,
+		&tracker,
+		&config,
+		&workflow,
+		vec![String::from("XY-0")],
+		false,
+		true,
+	)
+	.expect("persist should write occupied program");
+
+	store
+		.upsert_worktree("decodex", "id-XY-0", "x/decodex-xy-0", "/tmp/decodex/.worktrees/XY-0")
+		.expect("retained worktree should record");
+
+	let report = program_intake::run_issue_batch_intake(
+		&store,
+		&tracker,
+		&config,
+		&workflow,
+		vec![String::from("XY-1")],
+		true,
+		false,
+	)
+	.expect("dry-run should classify with occupied conflict domains");
+
+	assert_eq!(report.counts.ready, 0);
+	assert_eq!(report.counts.blocked, 1);
+	assert_eq!(report.issues[0].classification, IssueBatchIntakeClassification::Blocked);
+	assert_eq!(report.issues[0].dispatch_action, None);
+}
+
+#[test]
 fn project_registration_is_persist_only_for_command_path() {
 	let store = StateStore::open_in_memory().expect("store should open");
 	let temp_dir = TempDir::new().expect("temp dir should create");

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,12 @@
 # Documentation Log
 
+## 2026-07-06
+
+- Clarified that Program Intake dry-run dispatch readback uses current local runtime
+  occupancy, including live shared leases and retained nonterminal worktrees, and
+  that daemon Program dispatch must preserve selected Program node provenance before
+  child spawn records `program_dispatch_selected`.
+
 ## 2026-07-04
 
 - Documented account-pool reset-credit visibility: the server-owned account API now

--- a/docs/reference/operator-control-plane.md
+++ b/docs/reference/operator-control-plane.md
@@ -6,7 +6,7 @@ status: active
 authority: current_state
 owner: docs
 tags: [reference]
-code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/recovery.rs, apps/decodex/src/recovery/stale_active_guidance.rs, apps/decodex/src/recovery/review_handoff/issue.rs, apps/decodex/src/recovery/review_handoff/labels.rs, apps/decodex/src/recovery/review_handoff_diagnosis.rs, apps/decodex/src/recovery/reports.rs, apps/decodex/src/recovery/tests/review_handoff/rebind_validation.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/status_worktrees/ownership.rs, apps/decodex/src/orchestrator/types.rs, apps/decodex/src/orchestrator/operator_http.rs, apps/decodex/src/orchestrator/operator_http/api/account.rs, apps/decodex/src/orchestrator/operator_dashboard/body.html, apps/decodex/src/orchestrator/operator_dashboard/app/accounts/pool/rows.js, apps/decodex/src/orchestrator/operator_dashboard/app/accounts/profile/credits.js, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/orchestrator/tests/operator/status/http.rs, apps/decodex/src/orchestrator/tests/operator/status/history/attention/terminal_attention.rs, apps/decodex/src/agent/codex_accounts/pool/usage_probe.rs, apps/decodex/src/accounts/types.rs, apps/decodex-app/Sources/DecodexApp/CodexAccount.swift, apps/decodex-app/Sources/DecodexApp/AccountUsageSummaryViews.swift, apps/decodex/src/mcp.rs]
+code_refs: [apps/decodex/src/cli.rs, apps/decodex/src/recovery.rs, apps/decodex/src/recovery/stale_active_guidance.rs, apps/decodex/src/recovery/review_handoff/issue.rs, apps/decodex/src/recovery/review_handoff/labels.rs, apps/decodex/src/recovery/review_handoff_diagnosis.rs, apps/decodex/src/recovery/reports.rs, apps/decodex/src/recovery/tests/review_handoff/rebind_validation.rs, apps/decodex/src/orchestrator/status.rs, apps/decodex/src/orchestrator/status/operator_worktrees/ownership.rs, apps/decodex/src/orchestrator/types.rs, apps/decodex/src/orchestrator/operator_http.rs, apps/decodex/src/orchestrator/operator_http/api/account.rs, apps/decodex/src/orchestrator/operator_dashboard/body.html, apps/decodex/src/orchestrator/operator_dashboard/app/accounts/pool/rows.js, apps/decodex/src/orchestrator/operator_dashboard/app/accounts/profile/credits.js, apps/decodex/src/orchestrator/run_cycle.rs, apps/decodex/src/orchestrator/agent_evidence.rs, apps/decodex/src/orchestrator/tests/operator/status/http.rs, apps/decodex/src/orchestrator/tests/operator/status/history/attention/terminal_attention.rs, apps/decodex/src/agent/codex_accounts/pool/usage_probe.rs, apps/decodex/src/accounts/types.rs, apps/decodex-app/Sources/DecodexApp/CodexAccount.swift, apps/decodex-app/Sources/DecodexApp/AccountUsageSummaryViews.swift, apps/decodex/src/mcp.rs]
 drift_watch: [decodex serve, decodex status, decodex status --live, decodex lane inspect, decodex recover review-handoff, decodex recover ghost-lane, decodex recover stale-active, review_handoff_writeback_failed, retained_attention, stale_active_release, stale_active_state_restore_pending, run_stale_active_recovery, linear_active_label_present, ghost_lane_cleanup_audit_present, mcp_test_fixture_ghost_lane, decodex evidence, decodex mcp serve --transport stdio, decodex mcp serve --transport streamable-http, phase_acceptance_check, control_plane_snapshot, operator dashboard, /api/accounts, /wham/rate-limit-reset-credits, reset_credits_available_count, reset_credits, runtime.sqlite3, project.toml, WORKFLOW.md]
 last_verified: 2026-07-04
 ---
@@ -219,9 +219,10 @@ non-terminal state, no open dependency blockers, and no active issue claim. Read
 Program Intake nodes are not queue-label candidates; they appear under Execution
 Programs, and `decodex run <ISSUE>` can start a mapped dispatchable Program node with
 `program` dispatch mode. Issue-batch dry-run reports set `scheduler_visible=false`;
-their `dispatch_action=dispatch` rows describe the transient plan only. After
-`--apply`, status Program Intake readback is the operator surface for any persisted
-node blocker before ordinary queue-label checks.
+their `dispatch_action=dispatch` rows describe the transient plan under current
+local runtime occupancy only; live shared leases and retained nonterminal worktrees
+render held rows instead. After `--apply`, status Program Intake readback is the
+operator surface for any persisted node blocker before ordinary queue-label checks.
 
 The runtime database is the local source of truth for active execution. Linear and
 GitHub remain external collaboration mirrors and validation surfaces.

--- a/docs/runbook/orchestration-kernel-cutover.md
+++ b/docs/runbook/orchestration-kernel-cutover.md
@@ -16,7 +16,7 @@ code_refs:
   - apps/decodex/src/orchestrator/kernel/post_review.rs
   - apps/decodex/src/orchestrator/kernel/state.rs
   - apps/decodex/src/orchestrator/lane_decision.rs
-  - apps/decodex/src/orchestrator/status_run_projection/run/lane_control.rs
+  - apps/decodex/src/orchestrator/status/run_projection/run/lane_control.rs
   - apps/decodex/src/orchestrator/status/queue.rs
   - apps/decodex/src/orchestrator/status/review_orchestration.rs
   - apps/decodex/src/orchestrator/retained_review_orchestration.rs

--- a/docs/spec/lane-control-state.md
+++ b/docs/spec/lane-control-state.md
@@ -10,10 +10,10 @@ source_refs: []
 code_refs:
   - apps/decodex/src/orchestrator/kernel/lane_control.rs
   - apps/decodex/src/orchestrator/kernel/state.rs
-  - apps/decodex/src/orchestrator/status_run_projection/run/lane_control.rs
-  - apps/decodex/src/orchestrator/status_summary.rs
-  - apps/decodex/src/orchestrator/status_history_projection.rs
-  - apps/decodex/src/orchestrator/status_ghost_lane_cleanup/projection.rs
+  - apps/decodex/src/orchestrator/status/run_projection/run/lane_control.rs
+  - apps/decodex/src/orchestrator/status/summary.rs
+  - apps/decodex/src/orchestrator/status/history_projection.rs
+  - apps/decodex/src/orchestrator/status/ghost_lane_cleanup/projection.rs
   - apps/decodex/src/orchestrator/tests/operator/status/http.rs
   - apps/decodex/src/agent/tracker_tool_bridge/tools.rs
 related: [lane-control.md, runtime.md]

--- a/docs/spec/loop-runtime.md
+++ b/docs/spec/loop-runtime.md
@@ -455,9 +455,11 @@ The operator CLI surface for existing issues is
 command with `--config <PROJECT_DIR>`. Dry-run reads tracker state and prints a
 deterministic ready/held/blocked/stale/unmapped report without mutating Linear and
 without persisting local runtime rows. Dry-run reports set `scheduler_visible=false`,
-so `dispatch_action=dispatch` means the transient plan would be dispatchable only
-after persistence. `--apply` is an explicit local-runtime write: it stores the Program
-Intake Plan, Execution Program payload, and issue mappings, and sets
+so `dispatch_action=dispatch` means the transient plan would be dispatchable after
+persistence under the current local runtime occupancy. Existing live shared leases
+and retained nonterminal worktree mappings are part of that occupancy and must render
+the row held instead of dispatchable. `--apply` is an explicit local-runtime write: it
+stores the Program Intake Plan, Execution Program payload, and issue mappings, and sets
 `scheduler_visible=true`, but it must not apply or remove
 `decodex:queued:<service-id>`. Ready mapped nodes are dispatched directly by the
 Program scheduler rather than converted into queued-label work.

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -145,16 +145,20 @@ state or this state machine.
   held, blocked, stale, or unmapped and builds the same internal program model used
   by later persistence, but it must not mutate Linear or write local runtime rows.
   Dry-run reports mark `scheduler_visible=false`; any `dispatch_action=dispatch`
-  in that mode is a hypothetical result for the transient plan, not scheduler
-  authority. `--apply` writes only local runtime Program Intake and Execution
-  Program state and reports `scheduler_visible=true`.
+  in that mode is a hypothetical result for the transient plan under current local
+  runtime occupancy, not scheduler authority. Retained nonterminal worktree mappings
+  and live shared leases must suppress dry-run dispatch readback the same way they
+  suppress scheduler dispatch. `--apply` writes only local runtime Program Intake
+  and Execution Program state and reports `scheduler_visible=true`.
 - Each scheduler pass evaluates persisted Execution Programs before ordinary queued
   issue selection. The Program scheduler refreshes mapped Linear issue state,
   dependency observations, local shared run claims, retained review/landing
   worktrees, needs-attention labels, and occupied conflict domains; then it directly selects
-  dispatchable ready nodes with `program` dispatch mode. It must not apply or remove
-  service queue labels, and Program readiness must not wait for the ordinary
-  Linear-backed queue scan interval.
+  nodes with a concrete Program dispatch action using `program` dispatch mode. Daemon
+  child planning must preserve the selected Program id/node id until spawn records the
+  `program_dispatch_selected` private event, before launching the child process. It
+  must not apply or remove service queue labels, and Program readiness must not wait
+  for the ordinary Linear-backed queue scan interval.
 - When `decodex run <ISSUE>` targets a mapped Program node, inferred dispatch checks
   the same persisted Program eligibility before ordinary queue-label dispatch. A
   target whose node currently has `dispatch_action = dispatch` starts with `program`

--- a/plugins/codebase/.codex-plugin/plugin.json
+++ b/plugins/codebase/.codex-plugin/plugin.json
@@ -22,7 +22,7 @@
   "interface": {
     "displayName": "Codebase",
     "shortDescription": "Follow repository command, module, review, verification, and debugging contracts.",
-    "longDescription": "Routes checked-in command authority, task-runner structure, module-boundary and modularization defaults, dependency policy, review repair, verification evidence, root-cause debugging, and dynamic read-only subagent boundaries for code repositories.",
+    "longDescription": "Routes checked-in command authority, task-runner structure, module-boundary defaults, modularization defaults, dependency policy, review repair, verification evidence, root-cause debugging, and dynamic read-only subagent boundaries for code repositories.",
     "developerName": "hack-ink",
     "category": "Development",
     "capabilities": [


### PR DESCRIPTION
## Summary
- make Program Intake dry-run and scheduler readiness account for retained nonterminal Program worktrees and occupied conflict domains
- carry Program dispatch provenance into runtime summaries, daemon planning, due retry dispatch, and private execution events
- update operator readback/docs and plugin manifest copy for the refreshed surface contract

## Validation
- cargo test -p decodex plugin_surface_tests::manifests::packaged_plugin_manifests_route_split_surface_owners --lib
- cargo make check

Authority: PUB-1689
Related: PUB-1688, PUB-1669