### PR TITLE
Force Decodex App staging to release builds

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -41,13 +41,13 @@ percentage snapshots for account-pool display and does not contain token materia
 
 ## Development
 
-Build the SwiftPM app:
+Build the SwiftPM app in release mode:
 
 ```sh
-swift build --package-path apps/decodex-app
+swift build --package-path apps/decodex-app -c release
 ```
 
-Run it as a local `.app` bundle:
+Run it as a local release `.app` bundle:
 
 ```sh
 apps/decodex-app/script/build_and_run.sh
@@ -61,16 +61,19 @@ scripts/macos/test_decodex_app_stage.sh
 
 The stage test script builds the Swift app, the Rust `decodex` server binary, and
 `decodex-app-helper`, copies both Rust executables into `Contents/Helpers/`, then
-verifies the staged bundle layout and signature.
+verifies the staged bundle layout and signature. The app staging script always builds
+Swift and Rust artifacts in release mode. If the active developer directory lacks
+macOS SwiftUI macro support, the script uses
+`/Applications/Xcode-beta.app/Contents/Developer`.
 Direct SwiftPM launches are development-only; when needed, point them at workspace-built
 executables:
 
 ```sh
-cargo build -p decodex --bin decodex-app-helper
-cargo build -p decodex --bin decodex
-DECODEX_APP_DECODEX="$(pwd)/target/debug/decodex" \
-DECODEX_APP_HELPER="$(pwd)/target/debug/decodex-app-helper" \
-swift run --package-path apps/decodex-app DecodexApp
+cargo build --release -p decodex --bin decodex-app-helper
+cargo build --release -p decodex --bin decodex
+DECODEX_APP_DECODEX="$(pwd)/target/release/decodex" \
+DECODEX_APP_HELPER="$(pwd)/target/release/decodex-app-helper" \
+swift run --package-path apps/decodex-app -c release DecodexApp
 ```
 
 Use hidden `decodex serve --dev` only when manually testing local account APIs, the app
@@ -83,13 +86,12 @@ The staging script follows the local Rsnap-style signing path: it writes
 `target/decodex-app/Decodex.app`, signs the bundle with an Apple Development
 identity, enables hardened runtime, and verifies the signature before launch. Override
 the signing identity with `DECODEX_APP_SIGN_IDENTITY`; override the staging directory
-with `DECODEX_APP_STAGE_DIR`. Override the Rust profile with
-`DECODEX_APP_RUST_PROFILE`; external release automation should use `final-release`.
+with `DECODEX_APP_STAGE_DIR`.
 
 Release packaging is owned by external Codex automation. That automation supplies
 `APPLE_CERTIFICATE_P12_BASE64`, `APPLE_CERTIFICATE_PASSWORD`, and
-`APPLE_SIGNING_IDENTITY`, builds the Swift app in release mode, bundles the
-`final-release` Rust `decodex` and `decodex-app-helper` executables, then publishes
+`APPLE_SIGNING_IDENTITY`, builds the Swift app in release mode, bundles the release
+Rust `decodex` and `decodex-app-helper` executables, then publishes
 `decodex-app-aarch64-apple-darwin.zip` beside the CLI archives. If
 `APPLE_NOTARY_KEY_ID` and `APPLE_NOTARY_KEY_P8` are set, the automation notarizes and
 staples the staged app before packaging; `APPLE_NOTARY_ISSUER` is used when present.

--- a/apps/decodex-app/script/build_and_run.sh
+++ b/apps/decodex-app/script/build_and_run.sh
@@ -28,38 +28,15 @@ APP_ICON_SOURCE="$WORKTREE_ROOT/assets/app-icon/generated/app-icon.icns"
 APP_ICON_NAME="AppIcon.icns"
 STATUS_ICON_SOURCE="$WORKTREE_ROOT/assets/tray-icon/generated/tray-icon-template.png"
 STATUS_ICON_NAME="StatusBarIcon.png"
-SWIFT_BUILD_FLAGS=()
-RUST_BUILD_FLAGS=()
+SWIFT_BUILD_FLAGS=(-c release)
+RUST_BUILD_FLAGS=(--release)
 RUST_TARGET_DIR=""
 BUILD_ROOT=""
 BUILD_BINARY=""
 HELPER_BINARY=""
 SERVER_BINARY=""
 RESOLVED_SIGN_IDENTITY=""
-
-SWIFT_CONFIGURATION="${DECODEX_APP_SWIFT_CONFIGURATION:-debug}"
-RUST_PROFILE="${DECODEX_APP_RUST_PROFILE:-}"
-if [[ "$SWIFT_CONFIGURATION" == "release" ]]; then
-	SWIFT_BUILD_FLAGS=(-c release)
-	RUST_PROFILE="${RUST_PROFILE:-release}"
-elif [[ "$SWIFT_CONFIGURATION" != "debug" ]]; then
-	echo "error: DECODEX_APP_SWIFT_CONFIGURATION must be debug or release." >&2
-	exit 2
-else
-	RUST_PROFILE="${RUST_PROFILE:-debug}"
-fi
-
-case "$RUST_PROFILE" in
-	debug)
-		RUST_BUILD_FLAGS=()
-		;;
-	release)
-		RUST_BUILD_FLAGS=(--release)
-		;;
-	*)
-		RUST_BUILD_FLAGS=(--profile "$RUST_PROFILE")
-		;;
-esac
+RUST_PROFILE="release"
 
 if [[ "${DECODEX_APP_CARGO_LOCKED:-0}" == "1" ]]; then
 	RUST_BUILD_FLAGS+=(--locked)
@@ -73,6 +50,34 @@ if [[ -z "$APP_VERSION" ]]; then
 	)"
 fi
 APP_VERSION="${APP_VERSION:-0.2.0}"
+
+developer_dir_has_macos_swiftui_macros() {
+	local developer_dir="$1"
+
+	[[ -f "$developer_dir/Platforms/MacOSX.platform/Developer/usr/lib/swift/host/plugins/libSwiftUIMacros.dylib" ]]
+}
+
+ensure_macos_swiftui_macro_toolchain() {
+	local active_developer_dir xcode_beta_developer_dir
+
+	active_developer_dir="${DEVELOPER_DIR:-}"
+	if [[ -z "$active_developer_dir" ]]; then
+		active_developer_dir="$(xcode-select -p 2>/dev/null || true)"
+	fi
+	if [[ -n "$active_developer_dir" ]] && developer_dir_has_macos_swiftui_macros "$active_developer_dir"; then
+		return 0
+	fi
+
+	xcode_beta_developer_dir="/Applications/Xcode-beta.app/Contents/Developer"
+	if developer_dir_has_macos_swiftui_macros "$xcode_beta_developer_dir"; then
+		export DEVELOPER_DIR="$xcode_beta_developer_dir"
+		return 0
+	fi
+
+	echo "error: the active developer directory is missing macOS SwiftUI macro support." >&2
+	echo "error: install Xcode beta at /Applications/Xcode-beta.app or set DEVELOPER_DIR to a full Xcode with libSwiftUIMacros.dylib." >&2
+	exit 1
+}
 
 terminate_running_app() {
 	pkill -x "$EXECUTABLE_NAME" >/dev/null 2>&1 || true
@@ -183,6 +188,7 @@ sign_staged_app_bundle() {
 }
 
 stage_app_bundle() {
+	ensure_macos_swiftui_macro_toolchain
 	BUILD_ROOT="$(swift build --package-path "$ROOT_DIR" "${SWIFT_BUILD_FLAGS[@]}" --show-bin-path)"
 	BUILD_BINARY="$BUILD_ROOT/$EXECUTABLE_NAME"
 	RUST_TARGET_DIR="$WORKTREE_ROOT/target"
@@ -229,9 +235,6 @@ case "$MODE" in
 	run)
 		open_app
 		;;
-	--debug|debug)
-		lldb -- "$APP_BINARY"
-		;;
 	--logs|logs)
 		open_app
 		/usr/bin/log stream --info --style compact --predicate "process == \"$EXECUTABLE_NAME\""
@@ -243,7 +246,7 @@ case "$MODE" in
 		codesign --verify --deep --strict "$APP_BUNDLE"
 		;;
 	*)
-		echo "usage: $0 [run|stage|--debug|--logs|--verify]" >&2
+		echo "usage: $0 [run|stage|--logs|--verify]" >&2
 		exit 2
 		;;
 esac


### PR DESCRIPTION
## Summary
- make Decodex App staging always build Swift and Rust artifacts in release mode
- remove the debug build/debug launch path from the app staging script
- fall back to `/Applications/Xcode-beta.app/Contents/Developer` when the active developer directory lacks macOS SwiftUI macro support
- update app README examples to match release-only staging

## Validation
- `bash -n apps/decodex-app/script/build_and_run.sh`
- `git diff --check`
- `./apps/decodex-app/script/build_and_run.sh stage`
- `scripts/macos/test_decodex_app_stage.sh`
- installed `/Applications/Decodex.app` from release staging
- restarted standalone `decodex serve --listen-address 127.0.0.1:8192`; `/livez` returns `ok`
