### PR TITLE
Fix pre-push range for URL new branches

### DIFF
--- a/apps/decodex/src/cli/git_hook_commands/pre_push.rs
+++ b/apps/decodex/src/cli/git_hook_commands/pre_push.rs
@@ -18,13 +18,13 @@ pub(in crate::cli) struct PrePushHookCommand {
 	remote_name: String,
 	/// Remote URL supplied by Git.
 	#[arg(value_name = "REMOTE_URL")]
-	_remote_url: String,
+	remote_url: String,
 }
 impl PrePushHookCommand {
 	pub(super) fn run(&self) -> Result<()> {
 		let updates = read_pre_push_updates(io::stdin().lock())?;
 
-		validate_pre_push_updates(&self.remote_name, &updates)
+		validate_pre_push_updates(&self.remote_name, &self.remote_url, &updates)
 	}
 }
 
@@ -57,13 +57,17 @@ pub(in crate::cli::git_hook_commands) fn read_pre_push_updates(
 	Ok(updates)
 }
 
-fn validate_pre_push_updates(remote_name: &str, updates: &[PrePushUpdate]) -> Result<()> {
+fn validate_pre_push_updates(
+	remote_name: &str,
+	remote_url: &str,
+	updates: &[PrePushUpdate],
+) -> Result<()> {
 	for update in updates {
 		if is_zero_oid(&update.local_oid) {
 			continue;
 		}
 
-		for oid in rev_list_args(remote_name, update)? {
+		for oid in rev_list_args(remote_name, remote_url, update)? {
 			let message = commit_message_text(&oid)?;
 			let subject = commit_msg::extract_commit_subject(&message).map_err(|error| {
 				eyre::eyre!(
@@ -84,15 +88,20 @@ fn validate_pre_push_updates(remote_name: &str, updates: &[PrePushUpdate]) -> Re
 	Ok(())
 }
 
-fn rev_list_args(remote_name: &str, update: &PrePushUpdate) -> Result<Vec<String>> {
+fn rev_list_args(
+	remote_name: &str,
+	remote_url: &str,
+	update: &PrePushUpdate,
+) -> Result<Vec<String>> {
 	let args = if is_zero_oid(&update.remote_oid) {
-		let remotes_arg = if remote_name.is_empty() {
-			String::from("--remotes")
-		} else {
-			format!("--remotes={remote_name}")
-		};
+		let mut args = vec![String::from("rev-list"), update.local_oid.clone()];
 
-		vec![String::from("rev-list"), update.local_oid.clone(), String::from("--not"), remotes_arg]
+		if let Some(remotes_arg) = remote_exclusion_arg(remote_name, remote_url)? {
+			args.push(String::from("--not"));
+			args.push(remotes_arg);
+		}
+
+		args
 	} else {
 		vec![String::from("rev-list"), format!("{}..{}", update.remote_oid, update.local_oid)]
 	};
@@ -104,6 +113,126 @@ fn rev_list_args(remote_name: &str, update: &PrePushUpdate) -> Result<Vec<String
 			update.remote_ref
 		)
 	})
+}
+
+fn remote_exclusion_arg(remote_name: &str, remote_url: &str) -> Result<Option<String>> {
+	let remotes = configured_remotes()?;
+
+	Ok(remote_exclusion_arg_from_config(remote_name, remote_url, &remotes))
+}
+
+fn remote_exclusion_arg_from_config(
+	remote_name: &str,
+	remote_url: &str,
+	remotes: &[RemoteConfig],
+) -> Option<String> {
+	if remote_name.is_empty() {
+		return Some(String::from("--remotes"));
+	}
+
+	if remotes.iter().any(|candidate| candidate.name == remote_name) {
+		return Some(format!("--remotes={remote_name}"));
+	}
+
+	if !remote_url.is_empty()
+		&& let Some(remote) = remotes.iter().find(|candidate| {
+			candidate.urls.iter().any(|candidate_url| urls_match(candidate_url, remote_url))
+		}) {
+		return Some(format!("--remotes={}", remote.name));
+	}
+
+	None
+}
+
+fn configured_remotes() -> Result<Vec<RemoteConfig>> {
+	let remote_names = git::run_git_lines(&[String::from("remote")])?;
+	remote_names
+		.into_iter()
+		.map(|name| Ok(RemoteConfig { urls: remote_urls(&name)?, name }))
+		.collect()
+}
+
+fn remote_urls(remote: &str) -> Result<Vec<String>> {
+	let mut urls = Vec::new();
+
+	for mode in [RemoteUrlMode::Fetch, RemoteUrlMode::Push] {
+		let mut args = vec![String::from("remote"), String::from("get-url")];
+		if mode == RemoteUrlMode::Push {
+			args.push(String::from("--push"));
+		}
+		args.push(String::from("--all"));
+		args.push(remote.to_owned());
+
+		urls.extend(git::run_git_lines(&args)?);
+	}
+
+	urls.sort();
+	urls.dedup();
+	Ok(urls)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RemoteUrlMode {
+	Fetch,
+	Push,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RemoteConfig {
+	name: String,
+	urls: Vec<String>,
+}
+
+fn urls_match(candidate: &str, remote_url: &str) -> bool {
+	candidate == remote_url
+		|| match (remote_url_identity(candidate), remote_url_identity(remote_url)) {
+			(Some(candidate), Some(remote)) => candidate == remote,
+			_ => false,
+		}
+}
+
+fn remote_url_identity(value: &str) -> Option<RemoteUrlIdentity> {
+	let value = value.trim();
+	if value.is_empty() || value.starts_with('/') || value.starts_with('.') {
+		return None;
+	}
+
+	if let Some(scheme_separator) = value.find("://") {
+		return url_identity_from_authority_path(&value[scheme_separator + 3..]);
+	}
+
+	let user_host_separator = value.find('@')?;
+	let path_separator = value[user_host_separator + 1..].find(':')? + user_host_separator + 1;
+	let host = &value[user_host_separator + 1..path_separator];
+	let path = &value[path_separator + 1..];
+	remote_url_identity_parts(host, path)
+}
+
+fn url_identity_from_authority_path(value: &str) -> Option<RemoteUrlIdentity> {
+	let path_separator = value.find('/')?;
+	let authority = &value[..path_separator];
+	let path = &value[path_separator + 1..];
+	let host = authority.rsplit_once('@').map_or(authority, |(_, host)| host);
+	remote_url_identity_parts(host, path)
+}
+
+fn remote_url_identity_parts(host: &str, path: &str) -> Option<RemoteUrlIdentity> {
+	let host = host.trim();
+	let path = path.trim().trim_start_matches('/').trim_end_matches('/');
+	if host.is_empty() || path.is_empty() {
+		return None;
+	}
+
+	Some(RemoteUrlIdentity {
+		host: host.to_ascii_lowercase(),
+		path: path.strip_suffix(".git").unwrap_or(path).to_owned(),
+	})
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RemoteUrlIdentity {
+	host: String,
+	path: String,
 }
 
 fn commit_message_text(oid: &str) -> Result<String> {
@@ -119,4 +248,82 @@ fn commit_message_text(oid: &str) -> Result<String> {
 
 fn is_zero_oid(value: &str) -> bool {
 	value == ZERO_OID
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{RemoteConfig, remote_exclusion_arg_from_config, urls_match};
+
+	fn remote(name: &str, urls: &[&str]) -> RemoteConfig {
+		RemoteConfig { name: name.to_owned(), urls: urls.iter().map(ToString::to_string).collect() }
+	}
+
+	#[test]
+	fn remote_exclusion_uses_configured_remote_name() {
+		let exclusion = remote_exclusion_arg_from_config(
+			"origin",
+			"https://github.com/hack-ink/decodex.git",
+			&[remote("origin", &["git@github.com-y:hack-ink/decodex.git"])],
+		);
+
+		assert_eq!(exclusion.as_deref(), Some("--remotes=origin"));
+	}
+
+	#[test]
+	fn remote_exclusion_maps_exact_url_remote_name_to_configured_remote() {
+		let exclusion = remote_exclusion_arg_from_config(
+			"https://github.com/helixbox/pubfi-insight.git",
+			"https://github.com/helixbox/pubfi-insight.git",
+			&[remote(
+				"origin",
+				&[
+					"git@github.com:helixbox/pubfi-insight.git",
+					"https://github.com/helixbox/pubfi-insight.git",
+				],
+			)],
+		);
+
+		assert_eq!(exclusion.as_deref(), Some("--remotes=origin"));
+	}
+
+	#[test]
+	fn remote_exclusion_maps_https_url_push_to_ssh_configured_remote() {
+		let exclusion = remote_exclusion_arg_from_config(
+			"https://github.com/helixbox/pubfi-insight.git",
+			"https://github.com/helixbox/pubfi-insight.git",
+			&[remote("origin", &["git@github.com:helixbox/pubfi-insight.git"])],
+		);
+
+		assert_eq!(exclusion.as_deref(), Some("--remotes=origin"));
+	}
+
+	#[test]
+	fn remote_exclusion_does_not_exclude_unmatched_url_remotes() {
+		let exclusion = remote_exclusion_arg_from_config(
+			"https://github.com/example/other.git",
+			"https://github.com/example/other.git",
+			&[
+				remote("origin", &["https://github.com/hack-ink/decodex.git"]),
+				remote("backup", &["https://github.com/example/backup.git"]),
+			],
+		);
+
+		assert_eq!(exclusion, None);
+	}
+
+	#[test]
+	fn remote_url_matching_accepts_common_git_url_forms() {
+		assert!(urls_match(
+			"git@github.com:helixbox/pubfi-insight.git",
+			"https://github.com/helixbox/pubfi-insight.git",
+		));
+		assert!(urls_match(
+			"ssh://git@github.com/helixbox/pubfi-insight.git",
+			"https://github.com/helixbox/pubfi-insight",
+		));
+		assert!(!urls_match(
+			"git@github.com:helixbox/pubfi-insight.git",
+			"https://github.com/hack-ink/decodex.git",
+		));
+	}
 }

--- a/apps/decodex/src/orchestrator/tests/runtime_failure/runtime_ops/review_repair/retained_review_repair_completion_pushes_repaired_head_to_pr_branch.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime_failure/runtime_ops/review_repair/retained_review_repair_completion_pushes_repaired_head_to_pr_branch.rs
@@ -23,7 +23,7 @@ fn retained_review_repair_completion_pushes_repaired_head_to_pr_branch() {
 		config.repo_root(),
 		"repair.txt",
 		"repair\n",
-		r#"{"schema":"decodex/commit/1","summary":"Retain review repair","authority":"XY-1115"}"#,
+		r#"{"schema":"decodex/commit/2","change":"Retain review repair","authority":"XY-1115","impact":"compatible"}"#,
 	);
 
 	orchestrator::push_retained_review_repair_head(


### PR DESCRIPTION
## Summary
- limit new-branch pre-push validation to commits not already reachable from the target remote
- map URL-style pre-push remote arguments back to configured remotes, including HTTPS pushes to SSH-configured origins
- fail closed for unmatched URL remotes instead of excluding every local remote

## Validation
- cargo test -p decodex cli::git_hook_commands -- --nocapture
- cargo nextest run -p decodex orchestrator::tests::runtime_failure::runtime_ops::review_repair::retained_review_repair_completion_pushes_repaired_head_to_pr_branch --all-targets --all-features
- cargo check --workspace --all-features --all-targets
- git diff --check
- rustup run nightly rustfmt --check apps/decodex/src/cli/git_hook_commands/pre_push.rs apps/decodex/src/orchestrator/tests/runtime_failure/runtime_ops/review_repair/retained_review_repair_completion_pushes_repaired_head_to_pr_branch.rs
- cargo nextest run -p decodex --all-targets --all-features
- cargo nextest run --workspace --all-targets --all-features
- cargo clippy -p decodex --all-features --all-targets -- -D warnings -A clippy::too_many_arguments -A clippy::too_many_lines -A clippy::bool_assert_comparison -A clippy::collapsible_if
- temp-repo reproduction for HTTPS URL push to SSH-configured origin

Subagent review: passed with no blocking issues after the URL matching and unmatched-URL fail-closed fixes.