### PR TITLE
Set automation reasoning effort to high

### DIFF
--- a/automations/decodex/automations.toml
+++ b/automations/decodex/automations.toml
@@ -24,7 +24,7 @@ forbidden_prompt_fragments = [
 ]
 kind = "cron"
 model = "gpt-5.5"
-reasoning_effort = "xhigh"
+reasoning_effort = "high"
 source_root = "automations/decodex"
 status = "ACTIVE"
 

--- a/automations/radar/automations.toml
+++ b/automations/radar/automations.toml
@@ -21,7 +21,7 @@ forbidden_prompt_fragments = [
 ]
 kind = "cron"
 model = "gpt-5.5"
-reasoning_effort = "xhigh"
+reasoning_effort = "high"
 source_root = "automations/radar"
 status = "ACTIVE"
 


### PR DESCRIPTION
## Summary
- set Decodex and Radar automation manifests to use high reasoning effort
- keep installed live automation configs aligned with the new manifest expectation

## Validation
- python3 automations/decodex/scripts/config/evaluate_automations.py --manifest automations/decodex/automations.toml --repo-only
- python3 automations/decodex/scripts/config/evaluate_automations.py --manifest automations/radar/automations.toml --repo-only
- cargo test -p decodex plugin_surface_tests --lib
- python3 -m unittest tests.scripts.test_sync_installable_plugins