### PR TITLE
Add Decodex lifecycle hook guardrails

### DIFF
--- a/plugins/decodex/hooks/hooks.json
+++ b/plugins/decodex/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Shell|exec_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CODEX_HOME:-$HOME/.codex}/plugins/cache/hack-ink/decodex/0.2.0/scripts/decodex_lifecycle_hook\" --event PreToolUse",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/decodex/scripts/decodex_lifecycle_hook
+++ b/plugins/decodex/scripts/decodex_lifecycle_hook
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Scoped Codex guardrail for Decodex commit and landing authority."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+COMMIT_BLOCK = (
+    "Use `decodex commit \"<summary>\"` or "
+    "`decodex commit --manual-authority \"<summary>\"` instead of raw `git commit` "
+    "inside Decodex-owned scope."
+)
+LAND_BLOCK = (
+    "Use `decodex land --authority <ISSUE> --pr <URL> \"<summary>\"` or "
+    "`decodex land --manual-authority --pr <URL> \"<summary>\"` instead of raw "
+    "`gh pr merge` inside Decodex-owned scope."
+)
+
+
+def load_payload() -> dict[str, Any]:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def payload_command_text(payload: dict[str, Any]) -> str:
+    candidates: list[Any] = [payload.get("cmd"), payload.get("command"), payload.get("script")]
+    tool_input = payload.get("tool_input") or payload.get("toolInput") or payload.get("input")
+    if isinstance(tool_input, dict):
+        candidates.extend([tool_input.get("cmd"), tool_input.get("command"), tool_input.get("script")])
+    for candidate in candidates:
+        if isinstance(candidate, str):
+            return candidate
+    return ""
+
+
+def shell_segments(text: str) -> list[list[str]]:
+    try:
+        text = normalize_shell_separators(text)
+        lexer = shlex.shlex(text, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        return []
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token in {"&&", "||", ";", "\n"}:
+            if current:
+                segments.append(current)
+                current = []
+            continue
+        current.append(token)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def normalize_shell_separators(text: str) -> str:
+    output: list[str] = []
+    single_quoted = False
+    double_quoted = False
+    escaped = False
+    for char in text:
+        if escaped:
+            output.append(char)
+            escaped = False
+            continue
+        if char == "\\" and not single_quoted:
+            output.append(char)
+            escaped = True
+            continue
+        if char == "'" and not double_quoted:
+            single_quoted = not single_quoted
+            output.append(char)
+            continue
+        if char == '"' and not single_quoted:
+            double_quoted = not double_quoted
+            output.append(char)
+            continue
+        if char == "\n" and not single_quoted and not double_quoted:
+            output.append(" ; ")
+            continue
+        output.append(char)
+    return "".join(output)
+
+
+def unwrap_command(tokens: list[str]) -> list[list[str]]:
+    if not tokens:
+        return []
+    if tokens[0] in {"bash", "sh", "zsh"}:
+        for index, token in enumerate(tokens[1:], start=1):
+            if token in {"-c", "-lc", "-lic", "-ic"} and index + 1 < len(tokens):
+                return shell_segments(tokens[index + 1])
+        return [tokens]
+    if tokens[0] in {"env", "command"}:
+        index = 1
+        while index < len(tokens) and ("=" in tokens[index] or tokens[index].startswith("-")):
+            index += 1
+        return unwrap_command(tokens[index:]) if index < len(tokens) else []
+    return [tokens]
+
+
+def git_root(cwd: Path) -> Path | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(cwd),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    try:
+        return Path(result.stdout.strip()).resolve()
+    except OSError:
+        return None
+
+
+def path_contains(path: Path, parent: Path) -> bool:
+    try:
+        path = path.resolve()
+        parent = parent.resolve()
+    except OSError:
+        return False
+    return path == parent or parent in path.parents
+
+
+def decodex_repo_root(path: Path) -> Path | None:
+    root = git_root(path) if path.exists() else None
+    if not root:
+        return None
+    if (
+        (root / "plugins" / "decodex" / ".codex-plugin" / "plugin.json").is_file()
+        and (root / "apps" / "decodex").is_dir()
+    ):
+        return root
+    return None
+
+
+def registered_project_paths() -> list[Path]:
+    codex_home = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex").expanduser()
+    project_root = codex_home / "decodex" / "projects"
+    paths: list[Path] = []
+    for project_file in sorted(project_root.glob("*/project.toml")):
+        try:
+            data = tomllib.loads(project_file.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+        path_table = data.get("paths")
+        if not isinstance(path_table, dict):
+            continue
+        repo_root = resolved_project_path(project_file.parent, None, path_table.get("repo_root"))
+        if repo_root:
+            paths.append(repo_root)
+        worktree_root = resolved_project_path(project_file.parent, repo_root, path_table.get("worktree_root"))
+        if worktree_root:
+            paths.append(worktree_root)
+    return paths
+
+
+def resolved_project_path(config_dir: Path, repo_root: Path | None, value: Any) -> Path | None:
+    if not isinstance(value, str) or not value:
+        return None
+    path = Path(value).expanduser()
+    if path.is_absolute():
+        return path
+    base = repo_root or config_dir
+    return base / path
+
+
+def in_decodex_scope(path: Path) -> bool:
+    if decodex_repo_root(path):
+        return True
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    for owned_path in registered_project_paths():
+        if path_contains(resolved, owned_path):
+            return True
+    return False
+
+
+def git_command(tokens: list[str], default_cwd: Path) -> tuple[str, list[str], Path] | None:
+    if not tokens or tokens[0] != "git":
+        return None
+    index = 1
+    command_cwd = default_cwd
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "-C" and index + 1 < len(tokens):
+            candidate = Path(tokens[index + 1]).expanduser()
+            command_cwd = candidate if candidate.is_absolute() else command_cwd / candidate
+            index += 2
+            continue
+        if token.startswith("-C") and len(token) > 2:
+            candidate = Path(token[2:]).expanduser()
+            command_cwd = candidate if candidate.is_absolute() else command_cwd / candidate
+            index += 1
+            continue
+        if token in {"-c", "--config-env", "--git-dir", "--namespace"} and index + 1 < len(tokens):
+            index += 2
+            continue
+        if token == "--work-tree" and index + 1 < len(tokens):
+            candidate = Path(tokens[index + 1]).expanduser()
+            command_cwd = candidate if candidate.is_absolute() else command_cwd / candidate
+            index += 2
+            continue
+        if token.startswith("--work-tree="):
+            candidate = Path(token.partition("=")[2]).expanduser()
+            command_cwd = candidate if candidate.is_absolute() else command_cwd / candidate
+            index += 1
+            continue
+        if token.startswith(("--config-env=", "--git-dir=", "--namespace=")):
+            index += 1
+            continue
+        if token == "--":
+            index += 1
+            break
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    if index >= len(tokens):
+        return None
+    return tokens[index], tokens[index + 1 :], command_cwd
+
+
+def decodex_repo_selector(value: str) -> bool:
+    normalized = value.strip().removesuffix(".git")
+    for prefix in (
+        "https://github.com/",
+        "http://github.com/",
+        "ssh://git@github.com/",
+        "git@github.com:",
+        "github.com/",
+    ):
+        if normalized.startswith(prefix):
+            normalized = normalized.removeprefix(prefix)
+            break
+    if normalized in {"hack-ink/decodex", "decodex"}:
+        return True
+    if normalized.startswith("hack-ink/decodex/"):
+        return True
+    parsed = urlparse(value)
+    if parsed.netloc == "github.com" and parsed.path.strip("/").startswith("hack-ink/decodex/"):
+        return True
+    return False
+
+
+def gh_command(tokens: list[str], default_cwd: Path) -> tuple[str, list[str], Path, bool] | None:
+    if not tokens or tokens[0] != "gh":
+        return None
+    index = 1
+    command_cwd = default_cwd
+    targets_decodex_repo = False
+    while index < len(tokens):
+        token = tokens[index]
+        if token in {"-R", "--repo", "--hostname"} and index + 1 < len(tokens):
+            targets_decodex_repo = targets_decodex_repo or (
+                token in {"-R", "--repo"} and decodex_repo_selector(tokens[index + 1])
+            )
+            index += 2
+            continue
+        if token.startswith("-R") and len(token) > 2:
+            targets_decodex_repo = targets_decodex_repo or decodex_repo_selector(token[2:])
+            index += 1
+            continue
+        if token.startswith("--repo="):
+            targets_decodex_repo = targets_decodex_repo or decodex_repo_selector(token.partition("=")[2])
+            index += 1
+            continue
+        if token.startswith("--hostname="):
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    if index >= len(tokens):
+        return None
+    command = tokens[index]
+    args = tokens[index + 1 :]
+    targets_decodex_repo = targets_decodex_repo or any(decodex_repo_selector(arg) for arg in args)
+    return command, args, command_cwd, targets_decodex_repo
+
+
+def block_reason_for_tokens(tokens: list[str], cwd: Path) -> str | None:
+    for command_tokens in unwrap_command(tokens):
+        if not command_tokens:
+            continue
+        parsed_git = git_command(command_tokens, cwd)
+        if parsed_git:
+            command, _, command_cwd = parsed_git
+            if command == "commit" and in_decodex_scope(command_cwd):
+                return COMMIT_BLOCK
+            continue
+        parsed_gh = gh_command(command_tokens, cwd)
+        if parsed_gh:
+            command, args, command_cwd, targets_decodex_repo = parsed_gh
+            if command == "pr" and args and args[0] == "merge" and (
+                targets_decodex_repo or in_decodex_scope(command_cwd)
+            ):
+                return LAND_BLOCK
+    return None
+
+
+def block_reason(command_text: str, cwd: Path) -> str | None:
+    for segment in shell_segments(command_text):
+        reason = block_reason_for_tokens(segment, cwd)
+        if reason:
+            return reason
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    args = parser.parse_args()
+    if args.event != "PreToolUse":
+        return 0
+    payload = load_payload()
+    command_text = payload_command_text(payload)
+    if not command_text:
+        return 0
+    reason = block_reason(command_text, Path.cwd())
+    if reason:
+        print(json.dumps({"decision": "block", "reason": reason}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/decodex/tests/test_lifecycle_hook.py
+++ b/plugins/decodex/tests/test_lifecycle_hook.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+HOOK_SCRIPT = PLUGIN_ROOT / "scripts" / "decodex_lifecycle_hook"
+REPO_ROOT = PLUGIN_ROOT.parents[1]
+
+
+class DecodexLifecycleHookTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.root = Path(self.tempdir.name)
+        self.home = self.root / "home"
+        self.home.mkdir()
+
+    def run_hook(self, cwd: Path, command: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["CODEX_HOME"] = str(self.home / ".codex")
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        return subprocess.run(
+            [str(HOOK_SCRIPT), "--event", "PreToolUse"],
+            cwd=cwd,
+            input=json.dumps({"tool_name": "exec_command", "tool_input": {"cmd": command}}),
+            text=True,
+            capture_output=True,
+            check=True,
+            env=env,
+        )
+
+    def make_git_repo(self, name: str) -> Path:
+        repo = self.root / name
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+        return repo
+
+    def make_decodex_repo(self) -> Path:
+        repo = self.make_git_repo("decodex")
+        (repo / "plugins" / "decodex" / ".codex-plugin").mkdir(parents=True)
+        (repo / "plugins" / "decodex" / ".codex-plugin" / "plugin.json").write_text(
+            "{}\n",
+            encoding="utf-8",
+        )
+        (repo / "apps" / "decodex").mkdir(parents=True)
+        return repo
+
+    def write_project_config(
+        self,
+        repo: Path | str,
+        worktree_root: Path | str | None = None,
+        project_name: str = "demo",
+    ) -> Path:
+        project = self.home / ".codex" / "decodex" / "projects" / project_name
+        project.mkdir(parents=True)
+        lines = ["[paths]", f'repo_root = "{repo}"']
+        if worktree_root:
+            lines.append(f'worktree_root = "{worktree_root}"')
+        (project / "project.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return project
+
+    def assert_blocked(self, result: subprocess.CompletedProcess[str], expected: str) -> None:
+        output = json.loads(result.stdout)
+        self.assertEqual(output["decision"], "block")
+        self.assertIn(expected, output["reason"])
+
+    def test_blocks_git_commit_inside_decodex_repo(self) -> None:
+        repo = self.make_decodex_repo()
+
+        result = self.run_hook(repo, "git commit -m test")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_blocks_git_commit_with_git_c_inside_decodex_repo(self) -> None:
+        repo = self.make_decodex_repo()
+        outside = self.make_git_repo("outside")
+
+        result = self.run_hook(outside, f"git -C {repo} commit --amend --no-edit")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_blocks_git_commit_with_git_config_option_inside_decodex_repo(self) -> None:
+        repo = self.make_decodex_repo()
+
+        result = self.run_hook(repo, "git -c user.name=test commit -m test")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_blocks_git_commit_with_work_tree_option_inside_decodex_repo(self) -> None:
+        repo = self.make_decodex_repo()
+        outside = self.make_git_repo("outside")
+
+        result = self.run_hook(outside, f"git --work-tree {repo} commit -m test")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_blocks_gh_pr_merge_inside_decodex_repo(self) -> None:
+        repo = self.make_decodex_repo()
+
+        result = self.run_hook(repo, "gh pr merge 123 --merge")
+
+        self.assert_blocked(result, "decodex land")
+
+    def test_blocks_gh_pr_merge_with_long_repo_option_inside_decodex_repo(self) -> None:
+        repo = self.make_decodex_repo()
+
+        result = self.run_hook(repo, "gh --repo hack-ink/decodex pr merge 123 --merge")
+
+        self.assert_blocked(result, "decodex land")
+
+    def test_blocks_gh_pr_merge_with_repo_option_outside_decodex_repo(self) -> None:
+        repo = self.make_git_repo("ordinary")
+
+        result = self.run_hook(repo, "gh --repo hack-ink/decodex pr merge 123 --merge")
+
+        self.assert_blocked(result, "decodex land")
+
+    def test_blocks_gh_pr_merge_with_host_qualified_repo_option_outside_decodex_repo(self) -> None:
+        repo = self.make_git_repo("ordinary")
+
+        result = self.run_hook(repo, "gh --repo github.com/hack-ink/decodex pr merge 123 --merge")
+
+        self.assert_blocked(result, "decodex land")
+
+    def test_blocks_gh_pr_merge_with_joined_short_repo_option_outside_decodex_repo(self) -> None:
+        repo = self.make_git_repo("ordinary")
+
+        result = self.run_hook(repo, "gh -Rgithub.com/hack-ink/decodex pr merge 123 --merge")
+
+        self.assert_blocked(result, "decodex land")
+
+    def test_blocks_gh_pr_merge_with_pr_url_outside_decodex_repo(self) -> None:
+        repo = self.make_git_repo("ordinary")
+
+        result = self.run_hook(
+            repo,
+            "gh pr merge https://github.com/hack-ink/decodex/pull/123 --merge",
+        )
+
+        self.assert_blocked(result, "decodex land")
+
+    def test_blocks_git_commit_inside_registered_project_repo(self) -> None:
+        repo = self.make_git_repo("project-repo")
+        self.write_project_config(repo)
+
+        result = self.run_hook(repo, "git commit -m test")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_blocks_git_commit_inside_registered_worktree_root(self) -> None:
+        repo = self.make_git_repo("project-repo")
+        worktree_root = self.root / "worktrees"
+        worktree = worktree_root / "ISSUE-1"
+        worktree.mkdir(parents=True)
+        self.write_project_config(repo, worktree_root)
+
+        result = self.run_hook(worktree, "git commit -m test")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_blocks_git_commit_inside_registered_relative_project_repo(self) -> None:
+        project = self.write_project_config("relative-repo", project_name="relative-repo")
+        repo = project / "relative-repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+
+        result = self.run_hook(repo, "git commit -m test")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_blocks_git_commit_inside_registered_relative_worktree_root(self) -> None:
+        repo = self.make_git_repo("relative-worktree-repo")
+        worktree = repo / "lanes" / "ISSUE-1"
+        worktree.mkdir(parents=True)
+        self.write_project_config(repo, "lanes", project_name="relative-worktree")
+
+        result = self.run_hook(worktree, "git commit -m test")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_allows_git_commit_outside_decodex_scope(self) -> None:
+        repo = self.make_git_repo("ordinary")
+
+        result = self.run_hook(repo, "git commit -m test")
+
+        self.assertEqual("", result.stdout)
+
+    def test_allows_git_c_commit_outside_decodex_scope_from_decodex_repo(self) -> None:
+        repo = self.make_decodex_repo()
+        outside = self.make_git_repo("outside")
+
+        result = self.run_hook(repo, f"git -C {outside} commit -m test")
+
+        self.assertEqual("", result.stdout)
+
+    def test_allows_gh_pr_merge_outside_decodex_scope(self) -> None:
+        repo = self.make_git_repo("ordinary")
+
+        result = self.run_hook(repo, "gh pr merge 123 --merge")
+
+        self.assertEqual("", result.stdout)
+
+    def test_allows_read_only_git_commands_inside_decodex_repo(self) -> None:
+        repo = self.make_decodex_repo()
+        for command in ("git status --short", "git diff", "git log --oneline -1"):
+            with self.subTest(command=command):
+                result = self.run_hook(repo, command)
+                self.assertEqual("", result.stdout)
+
+    def test_allows_decodex_commit_and_land(self) -> None:
+        repo = self.make_decodex_repo()
+        for command in (
+            'decodex commit "summary"',
+            'decodex commit --manual-authority "summary"',
+            'decodex land --manual-authority --pr https://github.com/x/y/pull/1 "summary"',
+        ):
+            with self.subTest(command=command):
+                result = self.run_hook(repo, command)
+                self.assertEqual("", result.stdout)
+
+    def test_allows_read_only_mentions_of_git_commit(self) -> None:
+        repo = self.make_decodex_repo()
+
+        result = self.run_hook(repo, "rg 'git commit' plugins/decodex/skills")
+
+        self.assertEqual("", result.stdout)
+
+    def test_blocks_wrapped_git_commit(self) -> None:
+        repo = self.make_decodex_repo()
+
+        result = self.run_hook(repo, "bash -lc 'git add . && git commit -m test'")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_blocks_adjacent_shell_operator_git_commit(self) -> None:
+        repo = self.make_decodex_repo()
+
+        result = self.run_hook(repo, "git add .&&git commit -m test")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_blocks_multiline_git_commit(self) -> None:
+        repo = self.make_decodex_repo()
+
+        result = self.run_hook(repo, "git add .\ngit commit -m test")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_blocks_wrapped_git_config_commit(self) -> None:
+        repo = self.make_decodex_repo()
+
+        result = self.run_hook(repo, "bash -lc 'git -c user.name=test commit -m test'")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_blocks_wrapped_multiline_git_commit(self) -> None:
+        repo = self.make_decodex_repo()
+
+        result = self.run_hook(repo, "bash -lc 'git add .\ngit commit -m test'")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_blocks_env_wrapped_bash_git_commit(self) -> None:
+        repo = self.make_decodex_repo()
+
+        result = self.run_hook(repo, "env FOO=bar bash -lc 'git commit -m test'")
+
+        self.assert_blocked(result, "decodex commit")
+
+    def test_hook_config_uses_workspace_versioned_cache_path(self) -> None:
+        hooks = json.loads((PLUGIN_ROOT / "hooks" / "hooks.json").read_text(encoding="utf-8"))["hooks"]
+        if (REPO_ROOT / "Cargo.toml").is_file():
+            cargo_toml = (REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8")
+            version = re.search(r'(?ms)^\[workspace\.package\].*?^version\s*=\s*"([^"]+)"', cargo_toml)
+            self.assertIsNotNone(version)
+            version_text = version.group(1)
+        else:
+            version_text = PLUGIN_ROOT.name
+        expected_path = f"plugins/cache/hack-ink/decodex/{version_text}/scripts/decodex_lifecycle_hook"
+
+        self.assertEqual({"PreToolUse"}, set(hooks))
+        for entries in hooks.values():
+            for entry in entries:
+                for hook in entry["hooks"]:
+                    self.assertIn(expected_path, hook["command"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_sync_installable_plugins.py
+++ b/tests/scripts/test_sync_installable_plugins.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
 import shutil
 import sys
 import tempfile
@@ -47,6 +49,20 @@ class SyncInstallablePluginsTests(unittest.TestCase):
                     / "plugins/cache/hack-ink/decodex/0.2.0/.codex-plugin/plugin.json"
                 ).is_file()
             )
+            hooks_path = codex_home / "plugins/cache/hack-ink/decodex/0.2.0/hooks/hooks.json"
+            hook_script = codex_home / "plugins/cache/hack-ink/decodex/0.2.0/scripts/decodex_lifecycle_hook"
+            self.assertTrue(hooks_path.is_file())
+            self.assertTrue(hook_script.is_file())
+            self.assertTrue(os.access(hook_script, os.X_OK))
+            hooks = json.loads(hooks_path.read_text(encoding="utf-8"))["hooks"]
+            self.assertEqual({"PreToolUse"}, set(hooks))
+            commands = [
+                hook["command"]
+                for entry in hooks["PreToolUse"]
+                for hook in entry["hooks"]
+            ]
+            self.assertEqual(1, len(commands))
+            self.assertIn("scripts/decodex_lifecycle_hook", commands[0])
             self.assertFalse(global_skill.exists())
 
     def test_clean_refuses_modified_global_repo_local_skill(self):


### PR DESCRIPTION
## Summary
- add a Decodex plugin PreToolUse hook that blocks accidental raw git commit and gh pr merge lifecycle bypasses
- cover Decodex repo scope, registered project/worktree scope, wrapped shell commands, multiline commands, and gh repo selectors
- verify installable plugin sync includes hook config and executable script

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s plugins/decodex/tests -p 'test_*.py'
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests/scripts/test_sync_installable_plugins.py
- git diff --check
- python3 scripts/config/sync_installable_plugins.py --apply
- installed plugin tests under ~/.codex/plugins/cache/hack-ink/decodex/0.2.0/tests
