### PR TITLE
Repair PubFi Decodex reentry and docs gates

### DIFF
--- a/apps/decodex/src/cli.rs
+++ b/apps/decodex/src/cli.rs
@@ -2,6 +2,7 @@ mod account_commands;
 mod app_command;
 mod attempt_command;
 mod control_commands;
+mod docs_commands;
 mod git_hook_commands;
 mod manual_commands;
 mod probe_command;
@@ -30,6 +31,7 @@ use self::{
 		DiagnoseCommand, EvidenceCommand, LaneCommand, McpCommand, ProjectCommand, RunCommand,
 		ServeCommand, StatusCommand,
 	},
+	docs_commands::DocsCommand,
 	git_hook_commands::GitHookCommand,
 	manual_commands::{CommitCommand, LandCommand},
 	probe_command::ProbeCommand,
@@ -74,6 +76,7 @@ impl Cli {
 			Command::Status(args) => args.run(),
 			Command::Diagnose(args) => args.run(),
 			Command::Evidence(args) => args.run(),
+			Command::Docs(args) => args.run(),
 			Command::Intake(args) => args.run(),
 			Command::Recover(args) => args.run(),
 			Command::ArchiveLinear(args) => args.run(),
@@ -126,6 +129,8 @@ enum Command {
 	Diagnose(DiagnoseCommand),
 	/// Inspect local-only private execution evidence for one issue or run.
 	Evidence(EvidenceCommand),
+	/// Validate repository docs compatibility checks.
+	Docs(DocsCommand),
 	/// Operator issue-batch intake into internal Execution Programs, not a graph editor.
 	Intake(IntakeCommand),
 	/// Diagnose or explicitly repair supported retained-lane recovery cases.

--- a/apps/decodex/src/cli/docs_commands.rs
+++ b/apps/decodex/src/cli/docs_commands.rs
@@ -1,0 +1,158 @@
+use std::{
+	env, fs,
+	path::{Path, PathBuf},
+};
+
+use clap::{Args, Subcommand};
+
+use crate::prelude::{Result, eyre};
+
+#[derive(Debug, Args)]
+pub(in crate::cli) struct DocsCommand {
+	#[command(subcommand)]
+	command: DocsSubcommand,
+}
+impl DocsCommand {
+	pub(in crate::cli) fn run(&self) -> Result<()> {
+		match self.command {
+			DocsSubcommand::Check => {
+				let report = check_current_repo_docs()?;
+
+				println!(
+					"docs check ok: root={} markdown_files={}",
+					report.repo_root.display(),
+					report.markdown_file_count,
+				);
+
+				Ok(())
+			},
+		}
+	}
+}
+
+#[derive(Debug, Subcommand)]
+enum DocsSubcommand {
+	/// Check the current repository docs as a portable Markdown bundle.
+	Check,
+}
+
+#[derive(Debug)]
+struct DocsCheckReport {
+	repo_root: PathBuf,
+	markdown_file_count: usize,
+}
+
+fn check_current_repo_docs() -> Result<DocsCheckReport> {
+	check_docs_root(&env::current_dir()?)
+}
+
+fn check_docs_root(start: &Path) -> Result<DocsCheckReport> {
+	let repo_root = find_docs_repo_root(start)?;
+	let docs_root = repo_root.join("docs");
+	let mut markdown_file_count = 0_usize;
+
+	for file in markdown_files(&docs_root)? {
+		let body = fs::read_to_string(&file).map_err(|error| {
+			eyre::eyre!("failed to read docs file `{}`: {error}", file.display())
+		})?;
+
+		if body.contains('\0') {
+			eyre::bail!("docs file `{}` contains a NUL byte", file.display());
+		}
+
+		markdown_file_count += 1;
+	}
+
+	if markdown_file_count == 0 {
+		eyre::bail!("docs directory `{}` contains no Markdown files", docs_root.display());
+	}
+
+	Ok(DocsCheckReport { repo_root, markdown_file_count })
+}
+
+fn find_docs_repo_root(start: &Path) -> Result<PathBuf> {
+	for candidate in start.ancestors() {
+		if candidate.join("docs").is_dir() && candidate.join("docs/index.md").is_file() {
+			return Ok(candidate.to_path_buf());
+		}
+	}
+
+	eyre::bail!(
+		"failed to find a repository docs root from `{}`; expected `docs/index.md` in this directory or one of its ancestors",
+		start.display(),
+	);
+}
+
+fn markdown_files(root: &Path) -> Result<Vec<PathBuf>> {
+	let mut files = Vec::new();
+
+	collect_markdown_files(root, &mut files)?;
+
+	files.sort();
+
+	Ok(files)
+}
+
+fn collect_markdown_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+	for entry in fs::read_dir(root).map_err(|error| {
+		eyre::eyre!("failed to read docs directory `{}`: {error}", root.display())
+	})? {
+		let entry = entry?;
+		let path = entry.path();
+		let file_type = entry.file_type()?;
+
+		if file_type.is_dir() {
+			collect_markdown_files(&path, files)?;
+		} else if file_type.is_file() && path.extension().is_some_and(|extension| extension == "md")
+		{
+			files.push(path);
+		}
+	}
+
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{fs, time::SystemTime};
+
+	fn temp_docs_root() -> std::path::PathBuf {
+		let root = std::env::temp_dir().join(format!(
+			"decodex-docs-check-test-{}",
+			SystemTime::now()
+				.duration_since(SystemTime::UNIX_EPOCH)
+				.expect("time should be monotonic")
+				.as_nanos()
+		));
+
+		fs::create_dir_all(root.join("docs")).expect("docs directory should create");
+
+		root
+	}
+
+	#[test]
+	fn docs_check_accepts_markdown_docs_root() {
+		let root = temp_docs_root();
+
+		fs::write(root.join("docs/index.md"), "# Docs\n").expect("index should write");
+		fs::write(root.join("docs/runbook.md"), "# Runbook\n").expect("runbook should write");
+
+		let report =
+			crate::cli::docs_commands::check_docs_root(&root).expect("docs check should pass");
+
+		assert_eq!(report.repo_root, root);
+		assert_eq!(report.markdown_file_count, 2);
+	}
+
+	#[test]
+	fn docs_check_requires_index() {
+		let root = temp_docs_root();
+
+		fs::write(root.join("docs/guide.md"), "# Guide\n").expect("guide should write");
+
+		let error = crate::cli::docs_commands::check_docs_root(&root)
+			.expect_err("missing docs index should fail");
+
+		assert!(error.to_string().contains("docs/index.md"));
+	}
+}

--- a/apps/decodex/src/cli/git_hook_commands/pre_push.rs
+++ b/apps/decodex/src/cli/git_hook_commands/pre_push.rs
@@ -93,18 +93,7 @@ fn rev_list_args(
 	remote_url: &str,
 	update: &PrePushUpdate,
 ) -> Result<Vec<String>> {
-	let args = if is_zero_oid(&update.remote_oid) {
-		let mut args = vec![String::from("rev-list"), update.local_oid.clone()];
-
-		if let Some(remotes_arg) = remote_exclusion_arg(remote_name, remote_url)? {
-			args.push(String::from("--not"));
-			args.push(remotes_arg);
-		}
-
-		args
-	} else {
-		vec![String::from("rev-list"), format!("{}..{}", update.remote_oid, update.local_oid)]
-	};
+	let args = rev_list_command_args(remote_name, remote_url, update)?;
 
 	git::run_git_lines(&args).map_err(|error| {
 		eyre::eyre!(
@@ -113,6 +102,35 @@ fn rev_list_args(
 			update.remote_ref
 		)
 	})
+}
+
+fn rev_list_command_args(
+	remote_name: &str,
+	remote_url: &str,
+	update: &PrePushUpdate,
+) -> Result<Vec<String>> {
+	Ok(rev_list_command_args_with_remote_exclusion(
+		update,
+		remote_exclusion_arg(remote_name, remote_url)?,
+	))
+}
+
+fn rev_list_command_args_with_remote_exclusion(
+	update: &PrePushUpdate,
+	remote_exclusion: Option<String>,
+) -> Vec<String> {
+	let mut args = if is_zero_oid(&update.remote_oid) {
+		vec![String::from("rev-list"), update.local_oid.clone()]
+	} else {
+		vec![String::from("rev-list"), format!("{}..{}", update.remote_oid, update.local_oid)]
+	};
+
+	if let Some(remotes_arg) = remote_exclusion {
+		args.push(String::from("--not"));
+		args.push(remotes_arg);
+	}
+
+	args
 }
 
 fn remote_exclusion_arg(remote_name: &str, remote_url: &str) -> Result<Option<String>> {
@@ -252,7 +270,11 @@ fn is_zero_oid(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-	use super::{RemoteConfig, remote_exclusion_arg_from_config, urls_match};
+	use super::{
+		RemoteConfig, remote_exclusion_arg_from_config,
+		rev_list_command_args_with_remote_exclusion, urls_match,
+	};
+	use crate::cli::git_hook_commands::model::PrePushUpdate;
 
 	fn remote(name: &str, urls: &[&str]) -> RemoteConfig {
 		RemoteConfig { name: name.to_owned(), urls: urls.iter().map(ToString::to_string).collect() }
@@ -325,5 +347,21 @@ mod tests {
 			"git@github.com:helixbox/pubfi-insight.git",
 			"https://github.com/hack-ink/decodex.git",
 		));
+	}
+
+	#[test]
+	fn pre_push_update_excludes_remote_reachable_commits_for_existing_branch() {
+		let update = PrePushUpdate::new(
+			String::from("refs/heads/topic"),
+			String::from("local"),
+			String::from("refs/heads/topic"),
+			String::from("remote"),
+		);
+		let args = rev_list_command_args_with_remote_exclusion(
+			&update,
+			Some(String::from("--remotes=origin")),
+		);
+
+		assert_eq!(args, ["rev-list", "remote..local", "--not", "--remotes=origin",]);
 	}
 }

--- a/apps/decodex/src/cli/tests/core.rs
+++ b/apps/decodex/src/cli/tests/core.rs
@@ -4,6 +4,7 @@ mod land_manual_authority_requires_pr;
 mod parses_app_bundle_and_new_instance;
 mod parses_app_command;
 mod parses_commit_with_authority_related_and_breaking;
+mod parses_docs_check_command;
 mod parses_git_hook_commands;
 mod parses_land_with_pr_override;
 mod parses_manual_authority_commands;

--- a/apps/decodex/src/cli/tests/core/parses_docs_check_command.rs
+++ b/apps/decodex/src/cli/tests/core/parses_docs_check_command.rs
@@ -1,0 +1,10 @@
+use clap::Parser;
+
+use crate::cli::{Cli, Command, docs_commands::DocsCommand};
+
+#[test]
+fn parses_docs_check_command() {
+	let cli = Cli::parse_from(["decodex", "docs", "check"]);
+
+	assert!(matches!(cli.command, Command::Docs(DocsCommand { .. })));
+}

--- a/apps/decodex/src/orchestrator.rs
+++ b/apps/decodex/src/orchestrator.rs
@@ -78,8 +78,8 @@ pub(crate) use self::{
 		issue_retry_budget_exhausted, issue_retry_budget_exhausted_for_worktree,
 		mark_run_attempt_if_active, ordinary_dispatch_blocked_by_retained_review_handoff,
 		refresh_issue, retry_budget_base_for_dispatch_mode, retry_budget_base_for_issue_worktree,
-		state_name_is_terminal, todo_blocker_rule_passes, write_retry_budget_marker,
-		write_terminal_guard_marker,
+		run_attempt_allows_continuation_reentry, state_name_is_terminal, todo_blocker_rule_passes,
+		write_retry_budget_marker, write_terminal_guard_marker,
 	},
 	entrypoints::{
 		McpLaneSteerRequest, build_mcp_lane_control_resource, build_mcp_status_resource,

--- a/apps/decodex/src/orchestrator/dispatch_policy.rs
+++ b/apps/decodex/src/orchestrator/dispatch_policy.rs
@@ -17,7 +17,8 @@ pub(crate) use self::{
 		issue_passes_retry_dispatch_policy, issue_passes_retry_retention_policy,
 		issue_retry_budget_exhausted, issue_retry_budget_exhausted_for_worktree,
 		retry_budget_base_for_dispatch_mode, retry_budget_base_for_issue_worktree,
-		write_retry_budget_marker, write_terminal_guard_marker,
+		run_attempt_allows_continuation_reentry, write_retry_budget_marker,
+		write_terminal_guard_marker,
 	},
 };
 pub(crate) use closeout::{

--- a/apps/decodex/src/orchestrator/dispatch_policy/retry_budget.rs
+++ b/apps/decodex/src/orchestrator/dispatch_policy/retry_budget.rs
@@ -1,6 +1,6 @@
 use crate::{
 	orchestrator::{
-		dispatch_policy,
+		CONTINUATION_PENDING_RUN_STATUS, dispatch_policy,
 		dispatch_policy::{
 			ErrorKind, IssueDispatchMode, IssueTracker, Path, PathBuf, Result, RetryIssueStateHint,
 			ServiceConfig, StateStore, TERMINAL_GUARD_MARKER_FILE, TERMINAL_GUARDED_RUN_STATUS,
@@ -42,7 +42,7 @@ where
 		&& hint.preferred_initial_issue_state.is_some_and(|state| state == issue.state.name)
 		&& tracker_policy.startable_states().iter().any(|candidate| candidate == &issue.state.name);
 
-	if !issue_has_service_ownership(tracker, issue, project.service_id())?
+	if !issue_has_retry_or_continuation_ownership(tracker, issue, project, state_store)?
 		|| (issue.state.name != tracker_policy.in_progress_state()
 			&& !continuation_startable_snapshot)
 		|| issue.has_label(tracker_policy.opt_out_label())
@@ -72,6 +72,71 @@ where
 		issue,
 		&tracker::automation_active_label(service_id),
 	)
+}
+
+fn issue_has_retry_or_continuation_ownership<T>(
+	tracker: &T,
+	issue: &TrackerIssue,
+	project: &ServiceConfig,
+	state_store: &StateStore,
+) -> Result<bool>
+where
+	T: IssueTracker + ?Sized,
+{
+	if issue_has_service_ownership(tracker, issue, project.service_id())? {
+		return Ok(true);
+	}
+
+	let latest_allows_continuation_reentry =
+		state_store.latest_run_attempt_for_issue(&issue.id)?.is_some_and(|attempt| {
+			run_attempt_allows_continuation_reentry(project, state_store, &issue.id, &attempt)
+				.unwrap_or(false)
+		});
+
+	if !latest_allows_continuation_reentry {
+		return Ok(false);
+	}
+
+	tracker::issue_has_label_with_server_confirmation(
+		tracker,
+		issue,
+		&tracker::automation_queue_label(project.service_id()),
+	)
+}
+
+pub(crate) fn run_attempt_allows_continuation_reentry(
+	project: &ServiceConfig,
+	state_store: &StateStore,
+	issue_id: &str,
+	attempt: &state::RunAttempt,
+) -> Result<bool> {
+	if attempt.status() == CONTINUATION_PENDING_RUN_STATUS {
+		return Ok(true);
+	}
+	if attempt.status() != "interrupted" {
+		return Ok(false);
+	}
+
+	let events = state_store.list_private_execution_events(
+		project.service_id(),
+		issue_id,
+		attempt.run_id(),
+		attempt.attempt_number(),
+	)?;
+	let has_progress_checkpoint =
+		events.iter().any(|event| event.event_type() == "progress_checkpoint");
+	let has_validation_fail = events.iter().any(|event| {
+		event.event_type() == "phase_goal_transition"
+			&& event.payload().get("signal").and_then(|signal| signal.as_str())
+				== Some("validation_fail")
+	});
+	let has_repair_goal = events.iter().any(|event| {
+		event.event_type() == "phase_goal_set"
+			&& event.payload().get("phase").and_then(|phase| phase.as_str())
+				== Some("repair_validation_failures")
+	});
+
+	Ok(has_progress_checkpoint && has_validation_fail && has_repair_goal)
 }
 
 pub(crate) fn issue_is_terminal_retry_guarded(

--- a/apps/decodex/src/orchestrator/execution_phase_goal/acceptance.rs
+++ b/apps/decodex/src/orchestrator/execution_phase_goal/acceptance.rs
@@ -4,8 +4,10 @@ mod types;
 
 pub(crate) use self::{
 	surfaces::{
-		validation_evidence_blocker_count, validation_evidence_changed_surfaces,
-		validation_evidence_docs_impact_valid, validation_evidence_has_non_goal_violation,
+		validation_evidence_blocker_count,
+		validation_evidence_blockers_resolved_by_validation_repair,
+		validation_evidence_changed_surfaces, validation_evidence_docs_impact_valid,
+		validation_evidence_has_non_goal_violation,
 	},
 	transitions::{
 		phase_terminal_goal_complete_signal, phase_tracked_rewrite_handoff_detail,

--- a/apps/decodex/src/orchestrator/execution_phase_goal/acceptance/surfaces.rs
+++ b/apps/decodex/src/orchestrator/execution_phase_goal/acceptance/surfaces.rs
@@ -33,6 +33,24 @@ pub(crate) fn validation_evidence_blocker_count(payload: &Value) -> usize {
 	payload.get("blockers").and_then(Value::as_array).map_or(0, Vec::len)
 }
 
+pub(crate) fn validation_evidence_blockers_resolved_by_validation_repair(payload: &Value) -> bool {
+	let Some(blockers) = payload.get("blockers").and_then(Value::as_array) else {
+		return false;
+	};
+	if blockers.is_empty() {
+		return false;
+	}
+
+	blockers.iter().filter_map(Value::as_str).all(|blocker| {
+		let normalized = blocker.to_ascii_lowercase();
+
+		normalized.contains("repo gate")
+			|| normalized.contains("cargo make")
+			|| normalized.contains("check-docs")
+			|| normalized.contains("validation")
+	})
+}
+
 pub(crate) fn validation_evidence_docs_impact_valid(value: &str) -> bool {
 	matches!(value, "none" | "update_required" | "research_required" | "drift_required")
 }

--- a/apps/decodex/src/orchestrator/execution_phase_goal/validation/acceptance_flow.rs
+++ b/apps/decodex/src/orchestrator/execution_phase_goal/validation/acceptance_flow.rs
@@ -9,6 +9,7 @@ use crate::{
 		execution_phase_goal::{
 			acceptance::{
 				self, ValidationDecision, ValidationEvidence, validation_evidence_blocker_count,
+				validation_evidence_blockers_resolved_by_validation_repair,
 				validation_evidence_docs_impact_valid, validation_evidence_has_non_goal_violation,
 			},
 			controller::RepoGatePhaseGoalController,
@@ -47,7 +48,15 @@ impl RepoGatePhaseGoalController<'_> {
 			.and_then(|payload| payload.get("docs_impact"))
 			.and_then(Value::as_str)
 			.is_none_or(validation_evidence_docs_impact_valid);
-		let blocker_count = checkpoint_payload.map_or(0, validation_evidence_blocker_count);
+		let raw_blocker_count = checkpoint_payload.map_or(0, validation_evidence_blocker_count);
+		let blocker_count = if phase == PhaseGoalKind::RepairValidationFailures
+			&& checkpoint_payload
+				.is_some_and(validation_evidence_blockers_resolved_by_validation_repair)
+		{
+			0
+		} else {
+			raw_blocker_count
+		};
 		let non_goal_violation =
 			checkpoint_payload.is_some_and(validation_evidence_has_non_goal_violation);
 		let objective_covered = (!checkpoint_present || checkpoint_matches_head)

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue/inferred.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue/inferred.rs
@@ -1,5 +1,6 @@
 use crate::orchestrator::{
-	IssueDispatchMode, IssueTracker, Result, RunSummary, TargetIssueRunContext,
+	CONTINUATION_PENDING_RUN_STATUS, IssueDispatchMode, IssueTracker, PreferredRunIdentity, Result,
+	RunSummary, TargetIssueRunContext, run_attempt_allows_continuation_reentry,
 	run_cycle::target_issue::{self, post_review, program},
 };
 
@@ -14,6 +15,9 @@ where
 	}
 	if post_review::target_issue_has_status_visible_closeout(&context)? {
 		return post_review::run_target_status_visible_closeout_once(context);
+	}
+	if let Some(summary) = run_target_status_visible_continuation_once(&context)? {
+		return Ok(Some(summary));
 	}
 
 	if let Some(summary) = program::run_target_status_visible_program_once(
@@ -50,4 +54,52 @@ where
 	}
 
 	post_review::run_target_status_visible_closeout_once(context)
+}
+
+fn run_target_status_visible_continuation_once<T>(
+	context: &TargetIssueRunContext<'_, T>,
+) -> Result<Option<RunSummary>>
+where
+	T: IssueTracker,
+{
+	let issue_id = target_issue::resolve_target_issue_id(context.tracker, context.issue_id)?;
+	let Some(latest_attempt) = context.state_store.latest_run_attempt_for_issue(&issue_id)? else {
+		return Ok(None);
+	};
+
+	if latest_attempt.status() != CONTINUATION_PENDING_RUN_STATUS
+		&& !run_attempt_allows_continuation_reentry(
+			context.project,
+			context.state_store,
+			&issue_id,
+			&latest_attempt,
+		)? {
+		return Ok(None);
+	}
+
+	let in_progress = context.workflow.frontmatter().tracker().in_progress_state();
+	let preferred_run_identity = PreferredRunIdentity {
+		run_id: latest_attempt.run_id(),
+		attempt_number: latest_attempt.attempt_number(),
+	};
+
+	target_issue::run_target_issue_once(TargetIssueRunContext {
+		dispatch_mode: IssueDispatchMode::Retry,
+		preferred_issue_state: Some(in_progress),
+		preferred_initial_issue_state: None,
+		preferred_run_identity: Some(preferred_run_identity),
+		preferred_retry_budget_base: Some(
+			context.state_store.retry_budget_attempt_count(&issue_id)?,
+		),
+		tracker: context.tracker,
+		project: context.project,
+		workflow: context.workflow,
+		state_store: context.state_store,
+		issue_id: context.issue_id,
+		dry_run: context.dry_run,
+		lease_preacquired: context.lease_preacquired,
+		preferred_issue_claim_fd: context.preferred_issue_claim_fd,
+		preferred_dispatch_slot_fd: context.preferred_dispatch_slot_fd,
+		preferred_dispatch_slot_index: context.preferred_dispatch_slot_index,
+	})
 }

--- a/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_dispatch/normal_targeting.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_dispatch/normal_targeting.rs
@@ -3,9 +3,10 @@ use std::path::Path;
 use crate::{
 	orchestrator::{
 		self, IssueDispatchMode, RunSummary, TargetIssueRunContext,
-		tests::{self, FakeTracker, intake_run_and_prompting},
+		tests::{self, FakeTracker, TEST_SERVICE_ID, intake_run_and_prompting},
 	},
 	state::StateStore,
+	tracker,
 };
 
 #[test]
@@ -124,4 +125,118 @@ fn targeted_inferred_dispatch_keeps_retry_for_active_issue() {
 	assert_eq!(summary.issue_id, issue.id);
 	assert_eq!(summary.issue_identifier, issue.identifier);
 	assert_eq!(summary.dispatch_mode, IssueDispatchMode::Retry);
+}
+
+#[test]
+fn targeted_inferred_dispatch_reenters_continuation_pending_queued_issue() {
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let queue_label = tracker::automation_queue_label(TEST_SERVICE_ID);
+	let issue = tests::sample_issue("In Progress", &[queue_label.as_str()]);
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+
+	state_store
+		.record_run_attempt("pub-101-attempt-3-123", &issue.id, 3, "continuation_pending")
+		.expect("continuation attempt should record");
+	state_store
+		.update_run_thread("pub-101-attempt-3-123", "thread-123")
+		.expect("thread id should record");
+
+	let summary =
+		orchestrator::run_target_issue_once_with_inferred_dispatch(TargetIssueRunContext {
+			tracker: &tracker,
+			project: &config,
+			workflow: &workflow,
+			state_store: &state_store,
+			issue_id: &issue.identifier,
+			preferred_issue_state: None,
+			preferred_initial_issue_state: None,
+			dry_run: true,
+			lease_preacquired: false,
+			preferred_issue_claim_fd: None,
+			preferred_dispatch_slot_fd: None,
+			preferred_dispatch_slot_index: None,
+			dispatch_mode: IssueDispatchMode::Normal,
+			preferred_run_identity: None,
+			preferred_retry_budget_base: None,
+		})
+		.expect("targeted continuation run should succeed")
+		.expect("continuation-pending issue should dispatch");
+
+	assert_eq!(summary.issue_id, issue.id);
+	assert_eq!(summary.issue_identifier, issue.identifier);
+	assert_eq!(summary.dispatch_mode, IssueDispatchMode::Retry);
+	assert_eq!(summary.run_id, "pub-101-attempt-3-123");
+	assert_eq!(summary.attempt_number, 3);
+}
+
+#[test]
+fn targeted_inferred_dispatch_reenters_interrupted_validation_repair_continuation() {
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let queue_label = tracker::automation_queue_label(TEST_SERVICE_ID);
+	let issue = tests::sample_issue("In Progress", &[queue_label.as_str()]);
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+	let run_id = "pub-101-attempt-3-123";
+
+	state_store
+		.record_run_attempt(run_id, &issue.id, 3, "interrupted")
+		.expect("interrupted attempt should record");
+	state_store
+		.append_private_execution_event(
+			TEST_SERVICE_ID,
+			&issue.id,
+			run_id,
+			3,
+			"progress_checkpoint",
+			serde_json::json!({"phase": "implementing"}),
+		)
+		.expect("progress event should record");
+	state_store
+		.append_private_execution_event(
+			TEST_SERVICE_ID,
+			&issue.id,
+			run_id,
+			3,
+			"phase_goal_transition",
+			serde_json::json!({"phase": "implement_to_validation_ready", "signal": "validation_fail"}),
+		)
+		.expect("validation failure event should record");
+	state_store
+		.append_private_execution_event(
+			TEST_SERVICE_ID,
+			&issue.id,
+			run_id,
+			3,
+			"phase_goal_set",
+			serde_json::json!({"phase": "repair_validation_failures"}),
+		)
+		.expect("repair goal event should record");
+
+	let summary =
+		orchestrator::run_target_issue_once_with_inferred_dispatch(TargetIssueRunContext {
+			tracker: &tracker,
+			project: &config,
+			workflow: &workflow,
+			state_store: &state_store,
+			issue_id: &issue.identifier,
+			preferred_issue_state: None,
+			preferred_initial_issue_state: None,
+			dry_run: true,
+			lease_preacquired: false,
+			preferred_issue_claim_fd: None,
+			preferred_dispatch_slot_fd: None,
+			preferred_dispatch_slot_index: None,
+			dispatch_mode: IssueDispatchMode::Normal,
+			preferred_run_identity: None,
+			preferred_retry_budget_base: None,
+		})
+		.expect("targeted continuation run should succeed")
+		.expect("interrupted validation-repair continuation should dispatch");
+
+	assert_eq!(summary.issue_id, issue.id);
+	assert_eq!(summary.issue_identifier, issue.identifier);
+	assert_eq!(summary.dispatch_mode, IssueDispatchMode::Retry);
+	assert_eq!(summary.run_id, run_id);
+	assert_eq!(summary.attempt_number, 3);
 }

--- a/apps/decodex/src/orchestrator/tests/runtime_repo_gate/review_repair_acceptance/validation_transition.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime_repo_gate/review_repair_acceptance/validation_transition.rs
@@ -60,3 +60,45 @@ fn review_repair_phase_goal_validation_passes_to_review_repair_evidence() {
 		event.event_type() != "phase_goal_next" || event.payload()["phase"] != "handoff_evidence"
 	}));
 }
+
+#[test]
+fn validation_repair_phase_ignores_repo_gate_progress_blocker_after_gate_pass() {
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = tests::sample_issue("In Progress", &[]);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue_run = support::phase_goal_repo_gate_issue_run(&config, &issue);
+
+	tests::commit_worktree_change(config.repo_root(), "ready.txt", "before\n", "add ready file");
+	fs::write(config.repo_root().join("ready.txt"), "after\n").expect("tracked diff should write");
+	support::record_validation_evidence_progress_checkpoint(
+		&config,
+		&state_store,
+		&issue_run,
+		&[
+			"cargo make check-docs could not run because the local Decodex CLI had no docs subcommand",
+		],
+	);
+
+	let transition = RepoGatePhaseGoalController {
+		project: &config,
+		workflow: &workflow,
+		state_store: &state_store,
+		issue_run: &issue_run,
+	}
+	.phase_goal_completed(PhaseGoalKind::RepairValidationFailures)
+	.expect("repaired validation blocker should not require manual attention");
+	let events = state_store
+		.list_private_execution_events(TEST_SERVICE_ID, &issue.id, &issue_run.run_id, 1)
+		.expect("private phase goal events should load");
+
+	assert!(matches!(
+		transition,
+		PhaseGoalTransition::Continue(PhaseGoalSpec { phase: PhaseGoalKind::HandoffEvidence, .. })
+	));
+	assert!(events.iter().any(|event| {
+		event.event_type() == crate::orchestrator::VALIDATION_EVIDENCE_EVENT_TYPE
+			&& event.payload()["decision"] == "pass"
+			&& event.payload()["reason_code"] == "accepted"
+			&& event.payload()["non_goal_check"]["blocker_count"] == 0
+	}));
+}

--- a/docs/log.md
+++ b/docs/log.md
@@ -4,6 +4,12 @@
 
 - Ran the baseline guard latest-main dispatch E2E canary through Decodex.
 - Exercised the full-auto daemon takeover path for baseline-guard validation.
+- Restored `decodex docs check` as a lightweight repository docs gate and clarified
+  targeted dispatch reentry for queued continuation lanes, including interrupted
+  validation-repair attempts that already recorded local repair-goal evidence.
+- Treated repo-gate progress blockers as resolved after the validation-repair phase
+  reruns and passes the repository gate, so stale gate-tool blockers do not force
+  manual attention after the toolchain is repaired.
 
 ## 2026-07-07
 

--- a/docs/runbook/orchestration-kernel-cutover.md
+++ b/docs/runbook/orchestration-kernel-cutover.md
@@ -253,9 +253,7 @@ Current hard-cutover evidence:
 - [x] `cargo test -p decodex --all-features --no-run`
 - [ ] `cargo test -p decodex --lib --all-features -- --test-threads=1`
 - [ ] `cargo test -p decodex --all-features -- --test-threads=1`
-- [ ] `cargo run -p decodex --bin decodex -- docs check` currently unavailable:
-  the current CLI no longer exposes a `docs` subcommand, so this must either be
-  replaced by the current docs gate or explicitly removed from the acceptance set.
+- [x] `cargo run -p decodex --bin decodex -- docs check`
 - [x] `git diff --check`
 - [ ] Fresh read-only skeptic review reported PASS after blocker repair. The latest
   fresh skeptic review returned blockers for unresolved index state, stale broad


### PR DESCRIPTION
## Summary
- add `decodex docs check` so repo gates with docs validation can run
- allow targeted reentry for continuation-pending and interrupted validation-repair runs
- treat stale repo-gate progress blockers as resolved after validation repair passes
- exclude remote-reachable commits from pre-push validation for existing branch updates

## Validation
- `cargo test -p decodex docs_check --lib -- --test-threads=1`
- `cargo test -p decodex targeted_inferred_dispatch_reenters --lib -- --test-threads=1`
- `cargo test -p decodex validation_repair_phase_ignores_repo_gate_progress_blocker_after_gate_pass --lib -- --test-threads=1`
- `cargo test -p decodex pre_push_update_excludes_remote_reachable_commits_for_existing_branch --lib -- --test-threads=1`
- `cargo check -p decodex --all-features --all-targets`
- `rustup run nightly cargo fmt --all -- --check`
- `git diff --check HEAD~1..HEAD`