### PR TITLE
Restrict CodeQL push trigger to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "xy/**"
   pull_request:
     branches:
       - main

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -114,7 +114,7 @@ Success requires head/base preconditions, preventing stale green statuses after 
 
 GitHub rulesets for this repository require CodeQL code scanning before merge.
 The checked-in workflow is `.github/workflows/codeql.yml` and runs on pushes to
-`main` and `xy/**`, pull requests targeting `main`, and a weekly schedule. It
+`main`, pull requests targeting `main`, and a weekly schedule. It
 analyzes Rust and JavaScript/TypeScript with no-build CodeQL mode so the
 required code-scanning tool is configured for PR heads without adding a second
 repository build gate.


### PR DESCRIPTION
## Summary
- Remove the CodeQL push trigger for xy/** branches
- Keep CodeQL on main pushes, PRs targeting main, and weekly schedule
- Update OpenWiki code scanning notes to match

## Validation
- ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/codeql.yml
- git diff --check