### PR TITLE
Clean OpenWiki migration terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,8 +375,6 @@ The tracked workspace currently keeps:
 - `plugins/decodex/` as the canonical installable Decodex plugin source
 - `openwiki/` as the repo-local project knowledge and agent context surface
 - `dev/` as local development helpers, such as the operator dashboard mock server
-- `openwiki/` as the repo-local project knowledge and agent context surface
-- `dev/` as local development helpers, such as the operator mock server
 - `assets/` as generated Decodex App icon source notes, Icon Composer foreground,
   generated `.icns`, and menu bar template assets
 

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools/completion/events.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools/completion/events.rs
@@ -106,7 +106,7 @@ impl<'a> TrackerToolBridge<'a> {
 			)
 			.map_err(|error| {
 				format!(
-					"Failed to inspect docs-impact checkpoints for issue `{}`: {error}",
+					"Failed to inspect OpenWiki-impact checkpoints for issue `{}`: {error}",
 					self.issue.identifier
 				)
 			})?;

--- a/apps/decodex/src/autonomy_proposal/tests/compile/refusals.rs
+++ b/apps/decodex/src/autonomy_proposal/tests/compile/refusals.rs
@@ -99,11 +99,14 @@ fn autonomy_proposal_refusal_reasons_are_specific_and_inspectable() {
 	assert_eq!(traversal_surface.state(), AutonomyProposalState::Rejected);
 	assert!(traversal_surface.has_refusal_reason(AutonomyProposalRefusalReason::DisallowedSurface));
 
-	let docs_signal = AutonomySignal::docs_plugin_drift(tests::signal_input())
-		.expect("docs signal should validate");
-	let disallowed_kind =
-		AutonomyProposal::compile_dry_run(Some(&objective), &[docs_signal], tests::compile_input())
-			.expect("disallowed signal proposal should compile as refusal");
+	let openwiki_signal = AutonomySignal::openwiki_drift(tests::signal_input())
+		.expect("OpenWiki signal should validate");
+	let disallowed_kind = AutonomyProposal::compile_dry_run(
+		Some(&objective),
+		&[openwiki_signal],
+		tests::compile_input(),
+	)
+	.expect("disallowed signal proposal should compile as refusal");
 
 	assert_eq!(disallowed_kind.state(), AutonomyProposalState::Rejected);
 	assert!(

--- a/apps/decodex/src/autonomy_signal/fingerprint.rs
+++ b/apps/decodex/src/autonomy_signal/fingerprint.rs
@@ -12,14 +12,26 @@ pub(super) fn autonomy_signal_id(fingerprint: &str) -> String {
 }
 
 pub(super) fn autonomy_signal_fingerprint(signal: &AutonomySignal) -> Result<String> {
-	autonomy_signal_fingerprint_for_kind(signal, signal.kind.as_str())
+	autonomy_signal_fingerprint_for_material(
+		signal,
+		signal.kind.as_str(),
+		signal.source_type.as_str(),
+	)
 }
 
-pub(super) fn legacy_docs_skill_drift_fingerprint(signal: &AutonomySignal) -> Result<String> {
-	autonomy_signal_fingerprint_for_kind(signal, "docs_skill_drift")
+pub(super) fn legacy_signal_fingerprint_for_material(
+	signal: &AutonomySignal,
+	kind: &str,
+	source_type: &str,
+) -> Result<String> {
+	autonomy_signal_fingerprint_for_material(signal, kind, source_type)
 }
 
-fn autonomy_signal_fingerprint_for_kind(signal: &AutonomySignal, kind: &str) -> Result<String> {
+fn autonomy_signal_fingerprint_for_material(
+	signal: &AutonomySignal,
+	kind: &str,
+	source_type: &str,
+) -> Result<String> {
 	let material = serde_json::json!({
 		"schema": signal.schema,
 		"record_version": signal.record_version,
@@ -27,7 +39,7 @@ fn autonomy_signal_fingerprint_for_kind(signal: &AutonomySignal, kind: &str) -> 
 		"objective_id": signal.objective_id,
 		"objective_version": signal.objective_version,
 		"kind": kind,
-		"source_type": signal.source_type.as_str(),
+		"source_type": source_type,
 		"source_refs": sorted_strings(&signal.source_refs),
 		"primary_source_refs": sorted_strings(&signal.primary_source_refs),
 		"issue_id": signal.issue_id,

--- a/apps/decodex/src/autonomy_signal/model/constructor.rs
+++ b/apps/decodex/src/autonomy_signal/model/constructor.rs
@@ -43,8 +43,8 @@ impl AutonomySignal {
 		Self::from_input(AutonomySignalKind::ExecutionFriction, input)
 	}
 
-	pub(crate) fn docs_plugin_drift(input: AutonomySignalInput) -> Result<Self> {
-		Self::from_input(AutonomySignalKind::DocsPluginDrift, input)
+	pub(crate) fn openwiki_drift(input: AutonomySignalInput) -> Result<Self> {
+		Self::from_input(AutonomySignalKind::OpenWikiDrift, input)
 	}
 
 	fn from_input(kind: AutonomySignalKind, input: AutonomySignalInput) -> Result<Self> {
@@ -94,8 +94,16 @@ impl AutonomySignal {
 		Ok(())
 	}
 
-	pub(crate) fn legacy_docs_skill_drift_identity(&self) -> Result<(String, String)> {
-		let fingerprint = fingerprint::legacy_docs_skill_drift_fingerprint(self)?;
+	pub(crate) fn legacy_material_identity(
+		&self,
+		kind: &str,
+		source_type: &str,
+	) -> Result<(String, String)> {
+		let fingerprint = fingerprint::legacy_signal_fingerprint_for_material(
+			self,
+			kind,
+			source_type,
+		)?;
 		let id = fingerprint::autonomy_signal_id(&fingerprint);
 
 		Ok((id, fingerprint))

--- a/apps/decodex/src/autonomy_signal/tests/autonomy_signal_memory_and_report_sources_require_primary_refs_and_proposal_only.rs
+++ b/apps/decodex/src/autonomy_signal/tests/autonomy_signal_memory_and_report_sources_require_primary_refs_and_proposal_only.rs
@@ -10,12 +10,12 @@ fn autonomy_signal_memory_and_report_sources_require_primary_refs_and_proposal_o
 		input.primary_source_refs = Vec::new();
 		input.proposal_only = false;
 
-		assert!(AutonomySignal::docs_plugin_drift(input.clone()).is_err());
+		assert!(AutonomySignal::openwiki_drift(input.clone()).is_err());
 
 		input.primary_source_refs = vec![String::from("openwiki/specs/contracts-and-data.md")];
 		input.proposal_only = true;
 
-		AutonomySignal::docs_plugin_drift(input)
+		AutonomySignal::openwiki_drift(input)
 			.expect("memory/report signals with primary refs remain proposal-only");
 	}
 }

--- a/apps/decodex/src/autonomy_signal/tests/autonomy_signal_persistent_store_round_trips_signal_payload.rs
+++ b/apps/decodex/src/autonomy_signal/tests/autonomy_signal_persistent_store_round_trips_signal_payload.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 
 use crate::{
 	autonomy_signal::{
-		AutonomySignal,
+		AutonomySignal, AutonomySignalSourceType,
 		tests::{self},
 	},
 	state::StateStore,
@@ -38,6 +38,20 @@ fn autonomy_signal_persistent_store_round_trips_signal_payload() {
 
 #[test]
 fn autonomy_signal_store_reads_and_migrates_legacy_docs_skill_drift_kind() {
+	for legacy_kind in ["docs_plugin_drift", "docs_skill_drift"] {
+		for legacy_source_type in ["runtime", "docs"] {
+			autonomy_signal_store_reads_and_migrates_legacy_openwiki_drift_kind(
+				legacy_kind,
+				legacy_source_type,
+			);
+		}
+	}
+}
+
+fn autonomy_signal_store_reads_and_migrates_legacy_openwiki_drift_kind(
+	legacy_kind: &str,
+	legacy_source_type: &str,
+) {
 	let tempdir = tempfile::tempdir().expect("tempdir should create");
 	let db_path = tempdir.path().join("runtime.sqlite3");
 	let signal = {
@@ -45,24 +59,28 @@ fn autonomy_signal_store_reads_and_migrates_legacy_docs_skill_drift_kind() {
 
 		tests::accept_objective(&store, 1);
 
-		let signal = AutonomySignal::docs_plugin_drift(tests::signal_input())
-			.expect("docs plugin signal should validate");
+		let signal = AutonomySignal::openwiki_drift(tests::signal_input())
+			.expect("OpenWiki signal should validate");
 
 		store.record_autonomy_signal("decodex", signal.clone()).expect("signal should store");
 
 		signal
 	};
-	let (legacy_id, legacy_fingerprint, legacy_payload) = legacy_docs_skill_drift_payload(&signal);
+	let (legacy_id, legacy_fingerprint, legacy_payload) =
+		legacy_openwiki_drift_payload(&signal, legacy_kind, legacy_source_type);
 	let connection = Connection::open(&db_path).expect("db should open");
+	let update_sql = format!(
+		"UPDATE autonomy_signals
+		 SET signal_id = ?3,
+		     kind = '{legacy_kind}',
+		     fingerprint = ?4,
+		     payload_json = ?5
+		 WHERE project_id = ?1 AND signal_id = ?2"
+	);
 
 	connection
 		.execute(
-			"UPDATE autonomy_signals
-			 SET signal_id = ?3,
-			     kind = 'docs_skill_drift',
-			     fingerprint = ?4,
-			     payload_json = ?5
-			 WHERE project_id = ?1 AND signal_id = ?2",
+			&update_sql,
 			rusqlite::params![
 				"decodex",
 				signal.id(),
@@ -73,18 +91,22 @@ fn autonomy_signal_store_reads_and_migrates_legacy_docs_skill_drift_kind() {
 		)
 		.expect("legacy row should update");
 
+	let canonical_signal = canonical_signal_for_legacy_source(legacy_source_type);
 	let reopened = StateStore::open(&db_path).expect("store should reopen");
 	let stored = reopened
-		.autonomy_signal("decodex", signal.id())
+		.autonomy_signal("decodex", canonical_signal.id())
 		.expect("legacy signal read should succeed")
 		.expect("legacy signal should exist");
 	let migrated_legacy_lookup = reopened
 		.autonomy_signal("decodex", &legacy_id)
 		.expect("migrated legacy lookup should succeed");
 
-	assert_eq!(stored.signal().kind().as_str(), "docs_plugin_drift");
-	assert_eq!(stored.signal().id(), signal.id());
-	assert_eq!(stored.signal().fingerprint(), signal.fingerprint());
+	assert_eq!(stored.signal().kind().as_str(), "openwiki_drift");
+	if legacy_source_type == "docs" {
+		assert_eq!(stored.signal().source_type().as_str(), "openwiki");
+	}
+	assert_eq!(stored.signal().id(), canonical_signal.id());
+	assert_eq!(stored.signal().fingerprint(), canonical_signal.fingerprint());
 	assert!(migrated_legacy_lookup.is_none());
 }
 
@@ -97,14 +119,15 @@ fn autonomy_signal_store_rejects_corrupted_legacy_docs_skill_drift_row() {
 
 		tests::accept_objective(&store, 1);
 
-		let signal = AutonomySignal::docs_plugin_drift(tests::signal_input())
-			.expect("docs plugin signal should validate");
+		let signal = AutonomySignal::openwiki_drift(tests::signal_input())
+			.expect("OpenWiki signal should validate");
 
 		store.record_autonomy_signal("decodex", signal.clone()).expect("signal should store");
 
 		signal
 	};
-	let (legacy_id, _legacy_fingerprint, legacy_payload) = legacy_docs_skill_drift_payload(&signal);
+	let (legacy_id, _legacy_fingerprint, legacy_payload) =
+		legacy_openwiki_drift_payload(&signal, "docs_skill_drift", "docs");
 	let connection = Connection::open(&db_path).expect("db should open");
 
 	connection
@@ -130,19 +153,35 @@ fn autonomy_signal_store_rejects_corrupted_legacy_docs_skill_drift_row() {
 	);
 }
 
-fn legacy_docs_skill_drift_payload(signal: &AutonomySignal) -> (String, String, String) {
-	let (legacy_id, legacy_fingerprint) =
-		signal.legacy_docs_skill_drift_identity().expect("legacy identity should compute");
+fn legacy_openwiki_drift_payload(
+	signal: &AutonomySignal,
+	legacy_kind: &str,
+	legacy_source_type: &str,
+) -> (String, String, String) {
+	let (legacy_id, legacy_fingerprint) = signal
+		.legacy_material_identity(legacy_kind, legacy_source_type)
+		.expect("legacy identity should compute");
 	let mut payload =
 		serde_json::to_value(signal).expect("signal should serialize to legacy payload");
 
 	payload["id"] = Value::String(legacy_id.clone());
 	payload["fingerprint"] = Value::String(legacy_fingerprint.clone());
-	payload["kind"] = Value::String(String::from("docs_skill_drift"));
+	payload["kind"] = Value::String(String::from(legacy_kind));
+	payload["source_type"] = Value::String(String::from(legacy_source_type));
 
 	(
 		legacy_id,
 		legacy_fingerprint,
 		serde_json::to_string(&payload).expect("legacy payload should serialize"),
 	)
+}
+
+fn canonical_signal_for_legacy_source(legacy_source_type: &str) -> AutonomySignal {
+	let mut input = tests::signal_input();
+
+	if legacy_source_type == "docs" {
+		input.source_type = AutonomySignalSourceType::OpenWiki;
+	}
+
+	AutonomySignal::openwiki_drift(input).expect("canonical OpenWiki signal should validate")
 }

--- a/apps/decodex/src/autonomy_signal/types.rs
+++ b/apps/decodex/src/autonomy_signal/types.rs
@@ -13,8 +13,10 @@ pub(crate) enum AutonomySignalKind {
 	ProtocolDrift,
 	MetricRegression,
 	ExecutionFriction,
+	#[serde(rename = "openwiki_drift")]
+	#[serde(alias = "docs_plugin_drift")]
 	#[serde(alias = "docs_skill_drift")]
-	DocsPluginDrift,
+	OpenWikiDrift,
 }
 impl AutonomySignalKind {
 	pub(crate) fn as_str(self) -> &'static str {
@@ -27,13 +29,14 @@ impl AutonomySignalKind {
 			Self::ProtocolDrift => "protocol_drift",
 			Self::MetricRegression => "metric_regression",
 			Self::ExecutionFriction => "execution_friction",
-			Self::DocsPluginDrift => "docs_plugin_drift",
+			Self::OpenWikiDrift => "openwiki_drift",
 		}
 	}
 
 	pub(crate) fn matches_stored_kind(self, value: &str) -> bool {
 		value == self.as_str()
-			|| matches!(self, Self::DocsPluginDrift) && value == "docs_skill_drift"
+			|| matches!(self, Self::OpenWikiDrift)
+				&& matches!(value, "docs_plugin_drift" | "docs_skill_drift")
 	}
 }
 
@@ -45,7 +48,10 @@ pub(crate) enum AutonomySignalSourceType {
 	Ci,
 	Telemetry,
 	Runtime,
-	Docs,
+	#[serde(rename = "openwiki")]
+	#[serde(alias = "docs")]
+	#[serde(alias = "open_wiki")]
+	OpenWiki,
 	Protocol,
 	Agent,
 	Tracker,
@@ -60,7 +66,7 @@ impl AutonomySignalSourceType {
 			Self::Ci => "ci",
 			Self::Telemetry => "telemetry",
 			Self::Runtime => "runtime",
-			Self::Docs => "docs",
+			Self::OpenWiki => "openwiki",
 			Self::Protocol => "protocol",
 			Self::Agent => "agent",
 			Self::Tracker => "tracker",

--- a/apps/decodex/src/mcp/planning/autonomy/signal.rs
+++ b/apps/decodex/src/mcp/planning/autonomy/signal.rs
@@ -96,7 +96,7 @@ fn autonomy_signal_from_tool_args(
 		AutonomySignalKind::ProtocolDrift => AutonomySignal::protocol_drift(input),
 		AutonomySignalKind::MetricRegression => AutonomySignal::metric_regression(input),
 		AutonomySignalKind::ExecutionFriction => AutonomySignal::execution_friction(input),
-		AutonomySignalKind::DocsPluginDrift => AutonomySignal::docs_plugin_drift(input),
+		AutonomySignalKind::OpenWikiDrift => AutonomySignal::openwiki_drift(input),
 	};
 
 	signal.map_err(|error| {

--- a/apps/decodex/src/mcp/prompts/render.rs
+++ b/apps/decodex/src/mcp/prompts/render.rs
@@ -5,7 +5,7 @@ use crate::mcp::prompts::arguments;
 pub(super) fn mcp_prompt_result(name: &str, arguments: Value) -> Option<Value> {
 	let text = match name {
 		"decodex_validation_ready" => format!(
-			"Work only to Decodex validation-ready state for issue {}. Implement the smallest coherent code and docs change, run targeted validation, record a current-HEAD docs-impact checkpoint, then complete the active phase goal without push or PR handoff.\n\nPhase: {}",
+			"Work only to Decodex validation-ready state for issue {}. Implement the smallest coherent code and OpenWiki change, run targeted validation, record OpenWiki impact in a current-HEAD `issue_progress_checkpoint` using the compatibility field `docs_impact`, then complete the active phase goal without push or PR handoff.\n\nPhase: {}",
 			arguments::prompt_argument(&arguments, "issue")?,
 			arguments::prompt_argument(&arguments, "phase")
 				.unwrap_or("implement_to_validation_ready")

--- a/apps/decodex/src/mcp/tests/autonomy/objectives.rs
+++ b/apps/decodex/src/mcp/tests/autonomy/objectives.rs
@@ -53,10 +53,30 @@ fn autonomy_tools_are_plan_profile_and_apply_requires_authority() {
 }
 
 #[test]
+fn autonomy_submit_signal_accepts_current_openwiki_drift_kind() {
+	let repo = support::test_repo();
+	let responses = support::run_stdio_with_context(
+		McpContext {
+			repo_root: repo.path().to_path_buf(),
+			config_path: None,
+			project_id: Some(String::from("decodex")),
+			state_store: Some(StateStore::open_in_memory().expect("state store should open")),
+		},
+		r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"autonomy_submit_signal","arguments":{"mode":"dry_run","kind":"openwiki_drift","signal":{"objectiveId":"quality-autonomy","objectiveVersion":1,"sourceType":"openwiki","sourceRefs":["openwiki/specs/contracts-and-data.md"],"freshness":"fresh","summary":"OpenWiki contract map changed.","evidence":["OpenWiki source reviewed"],"evidenceClass":"repo_source","confidence":"high","privacy":"team"}}}}"#,
+	);
+	let structured = &support::response_at(&responses, 0)["result"]["structuredContent"];
+
+	assert_eq!(structured["schema"], "decodex.mcp.autonomy_signal_result/1");
+	assert_eq!(structured["persisted"], false);
+	assert_eq!(structured["signal"]["kind"], "openwiki_drift");
+	assert_eq!(structured["signal"]["source_type"], "openwiki");
+}
+
+#[test]
 fn autonomy_accept_objective_accepts_draft_without_execution_authority() {
 	let repo = support::test_repo();
 	let state_store = StateStore::open_in_memory().expect("state store should open");
-	let draft_call = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"autonomy_draft_objective","arguments":{"mode":"apply","objective":{"schema":"decodex.autonomy_objective/1","record_version":1,"project_id":"decodex","id":"self-iteration-pilot","version":1,"state":"draft","summary":"Pilot Decodex self-iteration only on the decodex project.","goals":["Reduce repeated operator intervention.","Convert Decodex-only feedback into evidence-backed proposals."],"non_goals":["Do not touch other projects.","Do not bypass review, landing, install, restart, or plugin-sync gates."],"metrics":["Manual-attention count.","Validated proposal replay completeness."],"allowed_surfaces":["apps/decodex/src","automations/decodex","docs","plugins/decodex"],"allowed_signal_kinds":["runtime_health","protocol_drift","execution_friction","validation_regression","user_feedback_cluster"],"validation_gates":["cargo test -p decodex mcp --lib"],"review_policy":"challenge required before promotion","memory_policy":"source-linked evidence only","report_policy":"public-safe source refs with known gaps"},"authority":{"source":"mcp-test","reason":"store draft objective"}}}}"#;
+	let draft_call = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"autonomy_draft_objective","arguments":{"mode":"apply","objective":{"schema":"decodex.autonomy_objective/1","record_version":1,"project_id":"decodex","id":"self-iteration-pilot","version":1,"state":"draft","summary":"Pilot Decodex self-iteration only on the decodex project.","goals":["Reduce repeated operator intervention.","Convert Decodex-only feedback into evidence-backed proposals."],"non_goals":["Do not touch other projects.","Do not bypass review, landing, install, restart, or plugin-sync gates."],"metrics":["Manual-attention count.","Validated proposal replay completeness."],"allowed_surfaces":["apps/decodex/src","automations/decodex","openwiki","plugins/decodex"],"allowed_signal_kinds":["runtime_health","protocol_drift","execution_friction","validation_regression","user_feedback_cluster"],"validation_gates":["cargo test -p decodex mcp --lib"],"review_policy":"challenge required before promotion","memory_policy":"source-linked evidence only","report_policy":"public-safe source refs with known gaps"},"authority":{"source":"mcp-test","reason":"store draft objective"}}}}"#;
 	let accept_missing_authority_call = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"autonomy_accept_objective","arguments":{"mode":"apply","objectiveId":"self-iteration-pilot","objectiveVersion":1}}}"#;
 	let accept_call = r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"autonomy_accept_objective","arguments":{"mode":"apply","objectiveId":"self-iteration-pilot","objectiveVersion":1,"authority":{"acceptedBy":"operator","acceptedByKind":"user","acceptedAt":"2026-06-27T00:00:00Z","acceptanceSource":"conversation"}}}}"#;
 	let read_call = r#"{"jsonrpc":"2.0","id":4,"method":"resources/read","params":{"uri":"decodex://projects/decodex/autonomy/objectives/self-iteration-pilot/current"}}"#;

--- a/apps/decodex/src/mcp/tests/prompts_tools/tool_listing.rs
+++ b/apps/decodex/src/mcp/tests/prompts_tools/tool_listing.rs
@@ -27,6 +27,10 @@ fn tools_list_exposes_schema_bound_tools() {
 		.iter()
 		.find(|tool| tool.get("name").and_then(Value::as_str) == Some("autonomy_compile_proposal"))
 		.expect("autonomy_compile_proposal tool should exist");
+	let autonomy_submit_signal = tools
+		.iter()
+		.find(|tool| tool.get("name").and_then(Value::as_str) == Some("autonomy_submit_signal"))
+		.expect("autonomy_submit_signal tool should exist");
 	let intake_goal = tools
 		.iter()
 		.find(|tool| tool.get("name").and_then(Value::as_str) == Some(intake_goal_tool_name))
@@ -46,6 +50,17 @@ fn tools_list_exposes_schema_bound_tools() {
 		autonomy_compile["inputSchema"]["properties"]["proposal"]["properties"]["issueCandidates"]
 			["items"]["properties"]["dependencies"]["description"],
 		"Candidate keys that must complete before this candidate."
+	);
+	let autonomy_signal_kind_schema =
+		&autonomy_submit_signal["inputSchema"]["properties"]["kind"]["enum"];
+
+	assert!(
+		autonomy_signal_kind_schema.as_array().is_some_and(|kinds| {
+			kinds.iter().any(|kind| kind.as_str() == Some("openwiki_drift"))
+				&& !kinds.iter().any(|kind| kind.as_str() == Some("docs_plugin_drift"))
+				&& !kinds.iter().any(|kind| kind.as_str() == Some("docs_skill_drift"))
+		}),
+		"autonomy_submit_signal should expose only the current OpenWiki drift kind"
 	);
 
 	support::assert_tool_output_schema_variant(

--- a/apps/decodex/src/mcp/tests/support/autonomy.rs
+++ b/apps/decodex/src/mcp/tests/support/autonomy.rs
@@ -107,7 +107,7 @@ pub(in crate::mcp::tests) fn autonomy_objective_fixture() -> AutonomyObjectiveCo
 		"non_goals": ["Do not bypass Decision Contract authority."],
 		"metrics": ["Validation retry count stays below objective tolerance."],
 		"allowed_surfaces": ["apps/decodex/src/mcp.rs", "openwiki/specs/contracts-and-data.md"],
-		"allowed_signal_kinds": ["runtime_health", "docs_plugin_drift"],
+		"allowed_signal_kinds": ["runtime_health", "openwiki_drift"],
 		"validation_gates": ["cargo test -p decodex mcp --lib"],
 		"review_policy": "independent current-head review required",
 		"memory_policy": "source-linked read-only memory only",

--- a/apps/decodex/src/mcp/tool_schemas/autonomy/input/proposal/schema.rs
+++ b/apps/decodex/src/mcp/tool_schemas/autonomy/input/proposal/schema.rs
@@ -21,7 +21,7 @@ pub(in crate::mcp::tool_schemas::autonomy::input::proposal) fn autonomy_compile_
 			},
 			"intendedSurface": {
 				"type": "string",
-				"description": "Repo, docs, runtime, or workflow surface the proposal may affect."
+				"description": "Repo, OpenWiki, runtime, or workflow surface the proposal may affect."
 			},
 			"affectedIdentifiers": {
 				"type": "array",

--- a/apps/decodex/src/mcp/tool_schemas/autonomy/input/signal.rs
+++ b/apps/decodex/src/mcp/tool_schemas/autonomy/input/signal.rs
@@ -27,7 +27,7 @@ pub(in crate::mcp) fn autonomy_submit_signal_tool_input_schema() -> Value {
 					"protocol_drift",
 					"metric_regression",
 					"execution_friction",
-					"docs_plugin_drift"
+					"openwiki_drift"
 				]
 			},
 			"signal": {

--- a/apps/decodex/src/orchestrator/execution_architecture_recovery/surface/path_classification.rs
+++ b/apps/decodex/src/orchestrator/execution_architecture_recovery/surface/path_classification.rs
@@ -8,7 +8,7 @@ pub(super) fn architecture_recovery_surfaces_for_path(
 	let mut surfaces = Vec::new();
 
 	if lower.starts_with("openwiki/") {
-		surfaces.push(AuthorityBoundarySurface::Docs);
+		surfaces.push(AuthorityBoundarySurface::OpenWiki);
 
 		return surfaces;
 	}
@@ -59,7 +59,7 @@ pub(super) fn architecture_recovery_surface_summary(
 		AuthorityBoundarySurface::Runtime =>
 			"Runtime implementation files changed during recovery.",
 		AuthorityBoundarySurface::Tests => "Test files changed during recovery.",
-		AuthorityBoundarySurface::Docs => "OpenWiki documentation files changed during recovery.",
+		AuthorityBoundarySurface::OpenWiki => "OpenWiki files changed during recovery.",
 		AuthorityBoundarySurface::PublicApi =>
 			"Public API or command surface files changed during recovery.",
 		AuthorityBoundarySurface::Config => "Configuration files changed during recovery.",

--- a/apps/decodex/src/orchestrator/tests/runtime_failure/loop_guardrail/boundary_events.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime_failure/loop_guardrail/boundary_events.rs
@@ -50,7 +50,7 @@ fn authority_boundary_surface_policy_matrix_classifies_risk() {
 		AuthorityBoundarySurface::ImplementationStrategy,
 		AuthorityBoundarySurface::Runtime,
 		AuthorityBoundarySurface::Tests,
-		AuthorityBoundarySurface::Docs,
+		AuthorityBoundarySurface::OpenWiki,
 	] {
 		assert_eq!(surface.policy_decision(), AuthorityBoundaryPolicyDecision::AutoContinue);
 	}

--- a/apps/decodex/src/orchestrator/types/authority/boundary.rs
+++ b/apps/decodex/src/orchestrator/types/authority/boundary.rs
@@ -27,7 +27,7 @@ pub(crate) enum AuthorityBoundarySurface {
 	ImplementationStrategy,
 	Runtime,
 	Tests,
-	Docs,
+	OpenWiki,
 	PublicApi,
 	Config,
 	Security,
@@ -48,7 +48,7 @@ impl AuthorityBoundarySurface {
 			Self::ImplementationStrategy => "implementation_strategy",
 			Self::Runtime => "runtime",
 			Self::Tests => "tests",
-			Self::Docs => "docs",
+			Self::OpenWiki => "openwiki",
 			Self::PublicApi => "public_api",
 			Self::Config => "config",
 			Self::Security => "security",
@@ -67,7 +67,7 @@ impl AuthorityBoundarySurface {
 
 	pub(crate) fn policy_decision(self) -> AuthorityBoundaryPolicyDecision {
 		match self {
-			Self::ImplementationStrategy | Self::Runtime | Self::Tests | Self::Docs =>
+			Self::ImplementationStrategy | Self::Runtime | Self::Tests | Self::OpenWiki =>
 				AuthorityBoundaryPolicyDecision::AutoContinue,
 			Self::PublicApi
 			| Self::Config

--- a/apps/decodex/src/state/runtime_row_parsers/autonomy/signal.rs
+++ b/apps/decodex/src/state/runtime_row_parsers/autonomy/signal.rs
@@ -33,17 +33,27 @@ pub(in crate::state) fn autonomy_signal_record_from_row_parts(
 	parts: AutonomySignalRuntimeRowParts,
 ) -> crate::prelude::Result<AutonomySignalRuntimeRecord> {
 	let payload = serde_json::from_str::<Value>(&parts.payload_json)?;
-	let payload_kind = payload.get("kind").and_then(Value::as_str);
-	let legacy_docs_skill_drift = parts.kind == "docs_skill_drift";
+	let payload_kind = payload.get("kind").and_then(Value::as_str).map(str::to_owned);
+	let payload_source_type =
+		payload.get("source_type").and_then(Value::as_str).map(str::to_owned);
+	let legacy_openwiki_drift_kind = legacy_openwiki_drift_kind(&parts.kind);
 
-	if legacy_docs_skill_drift && payload_kind != Some("docs_skill_drift") {
+	if legacy_openwiki_drift_kind.is_some() && payload_kind.as_deref() != Some(parts.kind.as_str())
+	{
 		eyre::bail!("Legacy autonomy signal row `{}` kind did not match payload.", parts.signal_id);
 	}
 
 	let mut signal = serde_json::from_value::<AutonomySignal>(payload)?;
 
-	if legacy_docs_skill_drift {
-		let (legacy_id, legacy_fingerprint) = signal.legacy_docs_skill_drift_identity()?;
+	if let Some(legacy_kind) = legacy_openwiki_drift_kind {
+		let Some(legacy_source_type) = payload_source_type else {
+			eyre::bail!(
+				"Legacy autonomy signal row `{}` source_type was missing.",
+				parts.signal_id
+			);
+		};
+		let (legacy_id, legacy_fingerprint) =
+			signal.legacy_material_identity(legacy_kind, &legacy_source_type)?;
 
 		if signal.id() != legacy_id || parts.signal_id != legacy_id {
 			eyre::bail!(
@@ -74,7 +84,7 @@ pub(in crate::state) fn autonomy_signal_record_from_row_parts(
 			signal.project_id()
 		);
 	}
-	if parts.signal_id != signal.id() && !legacy_docs_skill_drift {
+	if parts.signal_id != signal.id() && legacy_openwiki_drift_kind.is_none() {
 		eyre::bail!(
 			"Autonomy signal row `{}` contained payload `{}`.",
 			parts.signal_id,
@@ -97,7 +107,7 @@ pub(in crate::state) fn autonomy_signal_record_from_row_parts(
 		);
 	}
 	if !signal.kind().matches_stored_kind(&parts.kind)
-		|| (parts.fingerprint != signal.fingerprint() && !legacy_docs_skill_drift)
+		|| (parts.fingerprint != signal.fingerprint() && legacy_openwiki_drift_kind.is_none())
 		|| parts.freshness != signal.freshness().as_str()
 		|| parts.evidence_class != signal.evidence_class().as_str()
 		|| parts.confidence != signal.confidence().as_str()
@@ -117,4 +127,11 @@ pub(in crate::state) fn autonomy_signal_record_from_row_parts(
 		updated_at: parts.updated_at,
 		updated_at_unix: parts.updated_at_unix,
 	})
+}
+
+fn legacy_openwiki_drift_kind(kind: &str) -> Option<&str> {
+	match kind {
+		"docs_plugin_drift" | "docs_skill_drift" => Some(kind),
+		_ => None,
+	}
 }

--- a/apps/decodex/src/state/sqlite_store/queries/autonomy_program/signals.rs
+++ b/apps/decodex/src/state/sqlite_store/queries/autonomy_program/signals.rs
@@ -63,7 +63,7 @@ impl SqliteStateStore {
 			return Ok(Some(record));
 		}
 
-		self.legacy_docs_skill_drift_signal_by_canonical_id(project_id, signal_id)
+		self.legacy_openwiki_drift_signal_by_canonical_id(project_id, signal_id)
 	}
 
 	fn autonomy_signal_by_stored_id(
@@ -88,7 +88,7 @@ impl SqliteStateStore {
 			.transpose()
 	}
 
-	fn legacy_docs_skill_drift_signal_by_canonical_id(
+	fn legacy_openwiki_drift_signal_by_canonical_id(
 		&self,
 		project_id: &str,
 		signal_id: &str,
@@ -99,7 +99,7 @@ impl SqliteStateStore {
 				 freshness, evidence_class, confidence, privacy, payload_json, created_at, \
 				 created_at_unix, updated_at, updated_at_unix \
 				 FROM autonomy_signals \
-				 WHERE project_id = ?1 AND kind = 'docs_skill_drift' \
+				 WHERE project_id = ?1 AND kind IN ('docs_plugin_drift', 'docs_skill_drift') \
 				 ORDER BY updated_at_unix DESC, signal_id ASC",
 			)?;
 			let rows = statement.query_map(
@@ -129,7 +129,8 @@ impl SqliteStateStore {
 		self.upsert_autonomy_signal(&record)?;
 		self.connection.execute(
 			"DELETE FROM autonomy_signals
-			 WHERE project_id = ?1 AND signal_id = ?2 AND kind = 'docs_skill_drift'",
+			 WHERE project_id = ?1 AND signal_id = ?2 \
+			   AND kind IN ('docs_plugin_drift', 'docs_skill_drift')",
 			rusqlite::params![project_id, legacy_signal_id],
 		)?;
 

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -141,7 +141,7 @@ npm --prefix site run build
 npm --prefix site run dev
 ```
 
-Site caveat: `site/README.md` still says the scaffold stops at a route shell and mentions future signal content scaffolding. That appears stale relative to the current source and site contract; prefer `site/src/` and the site contract when documenting current behavior.
+Use `site/README.md`, `site/src/`, `site/package.json`, and the site contract together when documenting current behavior. The README records the static-site boundary; source and build output remain the final check for rendered behavior.
 
 ## Generated and local-only paths
 

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -162,7 +162,7 @@ npm --prefix site run build
 npm --prefix site run dev
 ```
 
-`site/README.md` appears stale because it still describes route-shell scaffolding; prefer `site/src/`, `site/package.json`, and `openwiki/integrations/plugins-automations-and-auxiliary-tools.md` for current site behavior until that README is refreshed.
+Use `site/README.md`, `site/src/`, `site/package.json`, and `openwiki/integrations/plugins-automations-and-auxiliary-tools.md` for the current static-site boundary and validation commands.
 
 ## Native macOS app checks
 

--- a/site/README.md
+++ b/site/README.md
@@ -1,14 +1,15 @@
 # Decodex Site
 
-This directory owns the isolated static-site surface for the GitHub-first Decodex
-MVP.
+This directory owns the static public Decodex product site and app download entry.
+It is an Astro/TypeScript surface and must stay independent from live Decodex daemon
+state.
 
 Current scope:
 
-- Astro + TypeScript application shell
+- Astro + TypeScript site rendering
 - Tailwind-powered global styling
-- homepage route aligned to the one-page site contract
-- site-owned signal content collection scaffolding
+- public product homepage and app download content
+- static assets and content owned by the site build
 
 Local commands:
 
@@ -17,5 +18,6 @@ Local commands:
 - `npm run build`
 - `npm run check`
 
-This scaffold intentionally stops at the route shell. Real GitHub-backed signal
-entries and bundle tooling land in later execution tasks.
+External automation owns publication to GitHub Pages. Runtime scheduling, tracker
+writes, local operator state, app-server orchestration, and Radar/Publisher
+automation remain outside this static site boundary.


### PR DESCRIPTION
## Summary
- rename user/MCP-facing docs drift surfaces to OpenWiki terminology
- keep legacy docs drift/source compatibility for persisted autonomy signal rows
- refresh stale site/OpenWiki notes and remove duplicate README layout entries

## Validation
- cargo check --all-features --all-targets --workspace
- cargo make test
- git diff --check
- skeptic subagent review: no blockers