### PR TITLE
XY-1246: Decodex post-review lanes can wait forever after operator review findings outside runtime checkpoint

### DIFF
--- a/apps/decodex/src/orchestrator.rs
+++ b/apps/decodex/src/orchestrator.rs
@@ -121,7 +121,7 @@ pub(crate) use self::{
 		worktree_mapping_is_stale_terminal_local_residue,
 	},
 	run_cycle_post_review::{
-		post_review_lane_is_closeout_candidate, post_review_lane_is_repair_candidate,
+		post_review_lane_is_closeout_candidate, post_review_lane_is_repair_dispatch_candidate,
 		retained_closeout_preferred_run_identity, select_post_review_issue_candidate,
 		select_target_closeout_candidate_with_inspector,
 		select_target_review_repair_candidate_with_inspector,

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue/post_review.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue/post_review.rs
@@ -22,7 +22,7 @@ where
 	.into_iter()
 	.any(|lane| {
 		lane.issue_id == target_issue_id
-			&& orchestrator::post_review_lane_is_repair_candidate(&lane)
+			&& orchestrator::post_review_lane_is_repair_dispatch_candidate(&lane)
 	}))
 }
 

--- a/apps/decodex/src/orchestrator/run_cycle_post_review.rs
+++ b/apps/decodex/src/orchestrator/run_cycle_post_review.rs
@@ -6,7 +6,9 @@ mod targeted;
 pub(crate) use self::{
 	candidate::select_post_review_issue_candidate,
 	closeout_identity::retained_closeout_preferred_run_identity,
-	predicates::{post_review_lane_is_closeout_candidate, post_review_lane_is_repair_candidate},
+	predicates::{
+		post_review_lane_is_closeout_candidate, post_review_lane_is_repair_dispatch_candidate,
+	},
 	targeted::{
 		select_target_closeout_candidate_with_inspector,
 		select_target_review_repair_candidate_with_inspector,

--- a/apps/decodex/src/orchestrator/run_cycle_post_review/candidate.rs
+++ b/apps/decodex/src/orchestrator/run_cycle_post_review/candidate.rs
@@ -86,7 +86,7 @@ where
 	)?;
 	let candidate_issue_ids = lanes
 		.iter()
-		.filter(|lane| predicates::post_review_lane_is_repair_candidate(lane))
+		.filter(|lane| predicates::post_review_lane_is_repair_dispatch_candidate(lane))
 		.filter(|lane| !excluded_issue_ids.contains(&lane.issue_id.as_str()))
 		.map(|lane| lane.issue_id.clone())
 		.collect::<Vec<_>>();
@@ -100,7 +100,7 @@ where
 		issues.into_iter().map(|issue| (issue.id.clone(), issue)).collect::<HashMap<_, _>>();
 
 	for lane in lanes {
-		if !predicates::post_review_lane_is_repair_candidate(&lane) {
+		if !predicates::post_review_lane_is_repair_dispatch_candidate(&lane) {
 			continue;
 		}
 		if excluded_issue_ids.contains(&lane.issue_id.as_str()) {

--- a/apps/decodex/src/orchestrator/run_cycle_post_review/predicates.rs
+++ b/apps/decodex/src/orchestrator/run_cycle_post_review/predicates.rs
@@ -12,3 +12,12 @@ pub(crate) fn post_review_lane_is_repair_candidate(lane: &OperatorPostReviewLane
 	PostReviewLaneDecision::from_str(&lane.classification)
 		== Some(PostReviewLaneDecision::NeedsReviewRepair)
 }
+
+pub(crate) fn post_review_lane_is_repair_dispatch_candidate(
+	lane: &OperatorPostReviewLaneStatus,
+) -> bool {
+	post_review_lane_is_repair_candidate(lane)
+		|| (PostReviewLaneDecision::from_str(&lane.classification)
+			== Some(PostReviewLaneDecision::WaitForReview)
+			&& lane.reason == "runtime_standard_review_checkpoint_pending")
+}

--- a/apps/decodex/src/orchestrator/run_cycle_post_review/targeted.rs
+++ b/apps/decodex/src/orchestrator/run_cycle_post_review/targeted.rs
@@ -29,7 +29,7 @@ where
 	)?;
 	let repair_lanes = lanes
 		.into_iter()
-		.filter(predicates::post_review_lane_is_repair_candidate)
+		.filter(predicates::post_review_lane_is_repair_dispatch_candidate)
 		.collect::<Vec<_>>();
 
 	if repair_lanes.is_empty() {

--- a/apps/decodex/src/orchestrator/tests/intake_candidate_selection/post_review_repair.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_candidate_selection/post_review_repair.rs
@@ -1,6 +1,6 @@
 use crate::{
 	orchestrator::{
-		self, IssueDispatchMode, TargetIssueRunContext,
+		self, IssueDispatchMode, ReviewLevel, TargetIssueRunContext,
 		tests::{
 			self, FakePullRequestReviewStateInspector, FakeTracker, TEST_SERVICE_ID,
 			intake_candidate_selection::support,
@@ -111,6 +111,127 @@ fn plan_project_issue_run_prefers_post_review_repair_lane_over_normal_candidate(
 	assert_eq!(summary.issue_identifier, repair_issue.identifier);
 	assert_eq!(summary.dispatch_mode, orchestrator::IssueDispatchMode::ReviewRepair);
 	assert_eq!(summary.issue_state, "In Review");
+}
+
+#[test]
+fn post_review_repair_selection_accepts_pending_runtime_review_checkpoint() {
+	let (_temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_review_level(&base_config, ReviewLevel::Standard);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let repair_issue = support::candidate_selection_service_owned_issue("In Review");
+	let tracker = FakeTracker::with_refresh_snapshots(
+		vec![repair_issue.clone()],
+		vec![vec![repair_issue.clone()], vec![repair_issue.clone()]],
+	);
+	let worktree_manager =
+		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
+	let worktree = worktree_manager
+		.ensure_worktree(&repair_issue.identifier, false)
+		.expect("worktree should exist");
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let pr_url = "https://github.com/hack-ink/decodex/pull/174";
+
+	state_store
+		.upsert_worktree(
+			config.service_id(),
+			&repair_issue.id,
+			&worktree.branch_name,
+			&worktree.path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	tests::seed_review_lifecycle_handoff_fixture_value(
+		&state_store,
+		config.service_id(),
+		&repair_issue.id,
+		&tests::sample_review_lifecycle_handoff_fixture(&worktree.branch_name, pr_url, &head_oid),
+	);
+
+	let inspector = FakePullRequestReviewStateInspector::new(vec![Ok(
+		tests::sample_pull_request_review_state(
+			pr_url,
+			&worktree.branch_name,
+			&head_oid,
+			Some("APPROVED"),
+			"MERGEABLE",
+			"CLEAN",
+			Some("SUCCESS"),
+			0,
+		),
+	)]);
+	let selected = orchestrator::select_post_review_repair_issue_candidate_with_inspector(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		&[],
+		&inspector,
+	)
+	.expect("post-review repair selection should succeed")
+	.expect("checkpoint-pending lane should be selected for retained continuation");
+
+	assert_eq!(selected.identifier, repair_issue.identifier);
+}
+
+#[test]
+fn targeted_post_review_repair_selection_accepts_pending_runtime_review_checkpoint() {
+	let (_temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let config = tests::service_config_with_review_level(&base_config, ReviewLevel::Standard);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let repair_issue = support::candidate_selection_service_owned_issue("In Review");
+	let tracker = FakeTracker::with_refresh_snapshots(
+		vec![repair_issue.clone()],
+		vec![vec![repair_issue.clone()], vec![repair_issue.clone()]],
+	);
+	let worktree_manager =
+		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
+	let worktree = worktree_manager
+		.ensure_worktree(&repair_issue.identifier, false)
+		.expect("worktree should exist");
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let pr_url = "https://github.com/hack-ink/decodex/pull/174";
+
+	state_store
+		.upsert_worktree(
+			config.service_id(),
+			&repair_issue.id,
+			&worktree.branch_name,
+			&worktree.path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	tests::seed_review_lifecycle_handoff_fixture_value(
+		&state_store,
+		config.service_id(),
+		&repair_issue.id,
+		&tests::sample_review_lifecycle_handoff_fixture(&worktree.branch_name, pr_url, &head_oid),
+	);
+
+	let inspector = FakePullRequestReviewStateInspector::new(vec![Ok(
+		tests::sample_pull_request_review_state(
+			pr_url,
+			&worktree.branch_name,
+			&head_oid,
+			Some("APPROVED"),
+			"MERGEABLE",
+			"CLEAN",
+			Some("SUCCESS"),
+			0,
+		),
+	)]);
+	let selected = orchestrator::select_target_review_repair_candidate_with_inspector(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		&repair_issue.id,
+		&repair_issue.identifier,
+		&inspector,
+	)
+	.expect("targeted post-review repair selection should succeed")
+	.expect("targeted checkpoint-pending lane should be selected");
+
+	assert_eq!(selected.identifier, repair_issue.identifier);
 }
 
 #[test]

--- a/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_dispatch/retained_lanes/targeted_identifier_dispatch_accepts_status_visible_review_repair_lane.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_dispatch/retained_lanes/targeted_identifier_dispatch_accepts_status_visible_review_repair_lane.rs
@@ -1,6 +1,6 @@
 use crate::{
 	orchestrator::{
-		self, IssueDispatchMode, TargetIssueRunContext,
+		self, IssueDispatchMode, ReviewLevel, TargetIssueRunContext,
 		tests::{self, FakeTracker, intake_run_and_prompting, recovery_terminal_support},
 	},
 	state::StateStore,
@@ -77,6 +77,84 @@ fn targeted_identifier_dispatch_accepts_status_visible_review_repair_lane() {
 		})
 		.expect("targeted retained repair identifier run should succeed")
 		.expect("status-visible retained repair lane should dispatch by identifier");
+
+	assert_eq!(summary.issue_id, issue.id);
+	assert_eq!(summary.issue_identifier, issue.identifier);
+	assert_eq!(summary.dispatch_mode, IssueDispatchMode::ReviewRepair);
+	assert_eq!(summary.issue_state, "In Review");
+}
+
+#[test]
+fn targeted_identifier_dispatch_accepts_pending_runtime_review_checkpoint_lane() {
+	let (temp_dir, base_config, workflow) = tests::temp_project_layout();
+	let base_config = tests::service_config_with_github_token_env_var(&base_config, "HOME");
+	let config = tests::service_config_with_review_level(&base_config, ReviewLevel::Standard);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let issue = intake_run_and_prompting::run_and_prompting_service_owned_issue("In Review");
+	let tracker = FakeTracker::new(vec![issue.clone()]);
+	let worktree_manager =
+		WorktreeManager::new(config.service_id(), config.repo_root(), config.worktree_root());
+	let worktree =
+		worktree_manager.ensure_worktree(&issue.identifier, false).expect("worktree should exist");
+	let head_oid = tests::git_output(&worktree.path, &["rev-parse", "HEAD"]);
+	let pr_url = "https://github.com/hack-ink/decodex/pull/184";
+
+	state_store
+		.upsert_worktree(
+			config.service_id(),
+			&issue.id,
+			&worktree.branch_name,
+			&worktree.path.display().to_string(),
+		)
+		.expect("worktree should record");
+
+	tests::seed_review_lifecycle_handoff_fixture_for_path(
+		&state_store,
+		config.service_id(),
+		&worktree.path,
+		&tests::sample_review_lifecycle_handoff_fixture(&worktree.branch_name, pr_url, &head_oid),
+	);
+
+	let _path_guard = recovery_terminal_support::install_fake_open_pr_gh_response(
+		&temp_dir, &worktree, pr_url, &head_oid,
+	);
+	let snapshot = orchestrator::build_live_operator_status_snapshot(
+		&tracker,
+		&config,
+		&workflow,
+		&state_store,
+		10,
+	)
+	.expect("status snapshot should build");
+	let lane = snapshot
+		.post_review_lanes
+		.iter()
+		.find(|lane| lane.issue_identifier == issue.identifier)
+		.expect("retained lane should appear in status");
+
+	assert_eq!(lane.classification, "wait_for_review");
+	assert_eq!(lane.reason, "runtime_standard_review_checkpoint_pending");
+
+	let summary =
+		orchestrator::run_target_issue_once_with_inferred_dispatch(TargetIssueRunContext {
+			tracker: &tracker,
+			project: &config,
+			workflow: &workflow,
+			state_store: &state_store,
+			issue_id: &issue.identifier,
+			preferred_issue_state: None,
+			preferred_initial_issue_state: None,
+			dry_run: true,
+			lease_preacquired: false,
+			preferred_issue_claim_fd: None,
+			preferred_dispatch_slot_fd: None,
+			preferred_dispatch_slot_index: None,
+			dispatch_mode: IssueDispatchMode::Normal,
+			preferred_run_identity: None,
+			preferred_retry_budget_base: None,
+		})
+		.expect("targeted retained checkpoint-pending run should succeed")
+		.expect("checkpoint-pending retained lane should dispatch by identifier");
 
 	assert_eq!(summary.issue_id, issue.id);
 	assert_eq!(summary.issue_identifier, issue.identifier);

--- a/openwiki/workflows/runtime-operator-workflows.md
+++ b/openwiki/workflows/runtime-operator-workflows.md
@@ -39,6 +39,10 @@ Important behavior:
 - `--dry-run --explain` is queue explanation only and rejects a preferred issue.
 - Without a preferred issue, project selection may choose ordinary queued work, persisted Program dispatch nodes, retry candidates, retained closeout, or post-review work depending on runtime state.
 - With an issue, dispatch mode is inferred unless a daemon child request supplies one internally.
+- Retained post-review lanes that are waiting only for a missing runtime-owned
+  standard review checkpoint are eligible as post-review repair continuations, so
+  `decodex run <ISSUE>` can resume the retained lane instead of leaving the issue
+  as "No eligible issue found".
 - Tracker connector backoff is persisted and rendered instead of repeatedly failing the connector.
 - Baseline canonicalization guard may run before normal/program/retry dispatch when workflow canonicalization commands exist (`apps/decodex/src/orchestrator/baseline_guard.rs`).
 


### PR DESCRIPTION
Summary:
- Make runtime_standard_review_checkpoint_pending retained post-review lanes dispatchable as review-repair continuations.
- Cover automatic selection, targeted selection, and targeted inferred dispatch for checkpoint-pending retained lanes.
- Update OpenWiki operator workflow notes for the new retained dispatch behavior.

Validation:
- cargo make fmt
- cargo make test (1660 passed, 1 skipped)