### PR TITLE
Add Decodex plugin package boundary

### DIFF
--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -38,6 +38,10 @@ The installer is `scripts/config/sync_installable_plugins.py`. It finds the repo
 $CODEX_HOME/plugins/cache/hack-ink/<plugin>/<version>
 ```
 
+Each plugin manifest declares `package.include` and `package.exclude`. The sync
+script materializes only that runtime package contract; source-only assets such
+as `plugins/decodex/tests/` stay out of installed plugin cache entries.
+
 Commands:
 
 ```sh

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -149,6 +149,11 @@ python3 scripts/config/sync_installable_plugins.py --apply --clean-repo-local-sk
 python3 -m unittest tests/scripts/test_sync_installable_plugins.py
 ```
 
+The Decodex plugin manifest declares runtime package include/exclude patterns.
+`scripts/config/sync_installable_plugins.py` must honor that contract when
+installing to `$CODEX_HOME/plugins/cache/hack-ink/decodex/<version>`, so
+source-only plugin tests are not copied into installed packages.
+
 Codex App automation sync and evaluation:
 
 ```sh

--- a/plugins/decodex/.codex-plugin/plugin.json
+++ b/plugins/decodex/.codex-plugin/plugin.json
@@ -18,6 +18,18 @@
     "diagnostics",
     "orchestration"
   ],
+  "package": {
+    "include": [
+      ".codex-plugin/**",
+      "hooks/**",
+      "references/**",
+      "scripts/**",
+      "skills/**"
+    ],
+    "exclude": [
+      "tests/**"
+    ]
+  },
   "skills": "./skills/",
   "interface": {
     "displayName": "Decodex",

--- a/scripts/config/sync_installable_plugins.py
+++ b/scripts/config/sync_installable_plugins.py
@@ -4,12 +4,16 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass
+from fnmatch import fnmatch
 from pathlib import Path
+from pathlib import PurePosixPath
 
 
 NAMESPACE = "hack-ink"
@@ -57,6 +61,73 @@ def plugin_sources(repo_root: Path) -> list[Path]:
     )
 
 
+def package_contract(plugin_root: Path) -> tuple[list[str], list[str]]:
+    manifest_path = plugin_root / ".codex-plugin" / "plugin.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    package = manifest.get("package")
+    if not isinstance(package, dict):
+        raise RuntimeError(f"{manifest_path} is missing package contract")
+
+    include = package.get("include", [])
+    exclude = package.get("exclude", [])
+    if not isinstance(include, list) or not include:
+        raise RuntimeError(f"{manifest_path} package.include must be a non-empty list")
+    if not isinstance(exclude, list):
+        raise RuntimeError(f"{manifest_path} package.exclude must be a list")
+
+    for pattern in include + exclude:
+        if not isinstance(pattern, str):
+            raise RuntimeError(f"{manifest_path} package patterns must be strings")
+        path = PurePosixPath(pattern)
+        if path.is_absolute() or ".." in path.parts:
+            raise RuntimeError(f"{manifest_path} has unsafe package pattern: {pattern}")
+
+    return include, exclude
+
+
+def package_files(plugin_root: Path) -> list[Path]:
+    include, exclude = package_contract(plugin_root)
+    repo_root = find_repo_root(plugin_root)
+    plugin_relative = plugin_root.resolve().relative_to(repo_root).as_posix()
+    output = subprocess.check_output(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+            plugin_relative,
+        ],
+        text=True,
+    )
+    files = []
+    for line in output.splitlines():
+        path = repo_root / line
+        relative = path.relative_to(plugin_root).as_posix()
+        if any(fnmatch(relative, pattern) for pattern in include) and not any(
+            fnmatch(relative, pattern) for pattern in exclude
+        ):
+            files.append(path)
+    if not files:
+        raise RuntimeError(f"{plugin_root} package contract matched no files")
+    return sorted(files)
+
+
+def copy_plugin_package(source: Path, destination: Path) -> None:
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True, exist_ok=True)
+
+    for file_path in package_files(source):
+        relative = file_path.relative_to(source)
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(file_path, target)
+
+
 def repo_local_skills(repo_root: Path) -> list[RepoLocalSkill]:
     skills: list[RepoLocalSkill] = []
     for skill_file in sorted((repo_root / "automations").glob("*/skills/*/SKILL.md")):
@@ -70,12 +141,10 @@ def sync_plugins(repo_root: Path, codex_home: Path, version: str, apply: bool) -
 
     for source in plugin_sources(repo_root):
         destination = cache_root / source.name / version
+        package_files(source)
         actions.append(f"sync plugin {source.name} -> {destination}")
         if apply:
-            if destination.exists():
-                shutil.rmtree(destination)
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copytree(source, destination)
+            copy_plugin_package(source, destination)
 
     return actions
 


### PR DESCRIPTION
Adds an explicit package include/exclude contract for the Decodex plugin and updates the install sync path to materialize that runtime package contract. Updates OpenWiki install/package notes.\n\nValidation:\n- python3 -m unittest tests/scripts/test_sync_installable_plugins.py\n- python3 -m unittest plugins/decodex/tests/test_lifecycle_hook.py\n- git diff --check\n- python3 -m py_compile scripts/config/sync_installable_plugins.py\n- jq empty plugins/decodex/.codex-plugin/plugin.json\n- plugin-eval analyze plugins/decodex --format markdown