### PR TITLE
Fix Rust vstyle violations

### DIFF
--- a/apps/decodex/src/agent/tracker_tool_bridge/review/closeout.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/review/closeout.rs
@@ -7,13 +7,16 @@ use crate::{
 		ReviewHandoffContext, TrackerToolBridge, eyre, tracker_tool_bridge,
 	},
 	orchestrator::{
-		PostReviewLifecycleFactsInput, PullRequestReviewState, build_post_review_lifecycle_facts,
-		kernel::lifecycle::{
-			LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome,
-			PreviousLifecycleAuthority, decide_lifecycle_transition,
+		self, PostReviewLifecycleFactsInput, PullRequestReviewState,
+		kernel::{
+			lifecycle,
+			lifecycle::{
+				LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome,
+				PreviousLifecycleAuthority,
+			},
 		},
-		runtime_review_checkpoint_status_for_head,
 	},
+	state::StateStore,
 	tracker,
 };
 
@@ -205,6 +208,7 @@ impl<'a> TrackerToolBridge<'a> {
 		let Some(state_store) = self.state_store else {
 			return Ok(());
 		};
+
 		self.record_closeout_lifecycle_transition(
 			state_store,
 			review_context,
@@ -215,6 +219,7 @@ impl<'a> TrackerToolBridge<'a> {
 			"not_started",
 			"closeout_landing_readback",
 		)?;
+
 		self.record_closeout_lifecycle_transition(
 			state_store,
 			review_context,
@@ -230,7 +235,7 @@ impl<'a> TrackerToolBridge<'a> {
 	#[allow(clippy::too_many_arguments)]
 	fn record_closeout_lifecycle_transition(
 		&self,
-		state_store: &crate::state::StateStore,
+		state_store: &StateStore,
 		review_context: &ReviewHandoffContext,
 		pull_request: &PullRequestDetails,
 		evidence_kind: LifecycleEvidenceKind,
@@ -239,7 +244,7 @@ impl<'a> TrackerToolBridge<'a> {
 		cleanup_state: &str,
 		causation_id: &str,
 	) -> crate::prelude::Result<()> {
-		let checkpoint = runtime_review_checkpoint_status_for_head(
+		let checkpoint = orchestrator::runtime_review_checkpoint_status_for_head(
 			state_store,
 			&review_context.service_id,
 			&self.issue.id,
@@ -273,22 +278,23 @@ impl<'a> TrackerToolBridge<'a> {
 			&self.issue.id,
 			&review_context.branch_name,
 		)?;
-		let facts = build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
-			project_id: &review_context.service_id,
-			issue_id: &self.issue.id,
-			review_lifecycle: previous_record.as_ref(),
-			review_state: &review_state,
-			worktree_path: Path::new(&review_context.worktree_path),
-			review_level: review_context.review_level,
-			phase: "closeout",
-			landing_state: Some(landing_state),
-			closeout_state: Some(closeout_state),
-			validated_head_sha: Some(&pull_request.head_ref_oid),
-			review_checkpoint_phase: checkpoint.as_ref().map(|checkpoint| checkpoint.phase),
-			review_checkpoint_status: checkpoint
-				.as_ref()
-				.map(|checkpoint| checkpoint.status.as_str()),
-		});
+		let facts =
+			orchestrator::build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
+				project_id: &review_context.service_id,
+				issue_id: &self.issue.id,
+				review_lifecycle: previous_record.as_ref(),
+				review_state: &review_state,
+				worktree_path: Path::new(&review_context.worktree_path),
+				review_level: review_context.review_level,
+				phase: "closeout",
+				landing_state: Some(landing_state),
+				closeout_state: Some(closeout_state),
+				validated_head_sha: Some(&pull_request.head_ref_oid),
+				review_checkpoint_phase: checkpoint.as_ref().map(|checkpoint| checkpoint.phase),
+				review_checkpoint_status: checkpoint
+					.as_ref()
+					.map(|checkpoint| checkpoint.status.as_str()),
+			});
 		let previous = previous_record.as_ref().map(|record| PreviousLifecycleAuthority {
 			sequence: record.sequence(),
 			next_state: record.next_state(),
@@ -302,7 +308,7 @@ impl<'a> TrackerToolBridge<'a> {
 			evidence_kind.as_str(),
 			causation_id
 		);
-		let decision = decide_lifecycle_transition(LifecycleDecisionInput {
+		let decision = lifecycle::decide_lifecycle_transition(LifecycleDecisionInput {
 			facts: &facts,
 			previous,
 			evidence_kind,

--- a/apps/decodex/src/agent/tracker_tool_bridge/tests/review_policy/review_policy_handoff_surface/tool_surface/review_level.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tests/review_policy/review_policy_handoff_surface/tool_surface/review_level.rs
@@ -19,7 +19,6 @@ fn review_checkpoint_tool_surface_respects_review_level() {
 		temp_dir.path(),
 		"https://github.com/hack-ink/decodex/pull/242",
 	);
-
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -44,12 +43,14 @@ fn review_checkpoint_tool_surface_respects_review_level() {
 		.into_iter()
 		.map(|tool| tool.name)
 		.collect::<Vec<_>>();
+
 	assert!(!tool_names.contains(&String::from(ISSUE_REVIEW_CHECKPOINT_TOOL_NAME)));
 	assert!(tool_names.contains(&String::from(ISSUE_REVIEW_HANDOFF_TOOL_NAME)));
 	assert!(!repair_tool_names.contains(&String::from(ISSUE_REVIEW_CHECKPOINT_TOOL_NAME)));
 	assert!(repair_tool_names.contains(&String::from(ISSUE_REVIEW_REPAIR_COMPLETE_TOOL_NAME)));
 
 	review_context.review_level = ReviewLevel::Off;
+
 	let bridge = TrackerToolBridge::with_review_handoff_for_test(
 		&tracker,
 		&issue,
@@ -67,6 +68,7 @@ fn review_checkpoint_tool_surface_respects_review_level() {
 			"evidence": []
 		}),
 	);
+
 	assert!(!checkpoint_response.success);
 	assert!(matches!(
 		checkpoint_response.content_items.as_slice(),

--- a/apps/decodex/src/agent/tracker_tool_bridge/tools/review_checkpoint_flow.rs
+++ b/apps/decodex/src/agent/tracker_tool_bridge/tools/review_checkpoint_flow.rs
@@ -5,9 +5,13 @@ mod writeback;
 
 use serde_json::Value;
 
-use crate::agent::tracker_tool_bridge::{
-	DynamicToolCallResponse, NormalizedReviewCheckpointPayload, ReviewCheckpointArgs,
-	ReviewPolicyPhase, ReviewPolicyStatus, TrackerToolBridge, tools::review_checkpoint,
+use crate::{
+	agent::tracker_tool_bridge::{
+		DynamicToolCallResponse, DynamicToolContentItem, NormalizedReviewCheckpointPayload,
+		ReviewCheckpointArgs, ReviewPolicyPhase, ReviewPolicyStatus, TrackerToolBridge,
+		tools::review_checkpoint,
+	},
+	prelude::Result,
 };
 
 struct ReviewCheckpointPayloadCounts {
@@ -27,10 +31,7 @@ struct PreparedReviewCheckpoint {
 }
 
 impl<'a> TrackerToolBridge<'a> {
-	pub(crate) fn record_runtime_review_checkpoint(
-		&self,
-		arguments: Value,
-	) -> crate::prelude::Result<()> {
+	pub(crate) fn record_runtime_review_checkpoint(&self, arguments: Value) -> Result<()> {
 		let response = self.handle_review_checkpoint(arguments);
 
 		if response.success {
@@ -41,8 +42,7 @@ impl<'a> TrackerToolBridge<'a> {
 			.content_items
 			.into_iter()
 			.map(|item| match item {
-				crate::agent::tracker_tool_bridge::DynamicToolContentItem::InputText { text } =>
-					text,
+				DynamicToolContentItem::InputText { text } => text,
 			})
 			.collect::<Vec<_>>()
 			.join("\n");

--- a/apps/decodex/src/cli/git_hook_commands/pre_push.rs
+++ b/apps/decodex/src/cli/git_hook_commands/pre_push.rs
@@ -28,6 +28,24 @@ impl PrePushHookCommand {
 	}
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RemoteConfig {
+	name: String,
+	urls: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RemoteUrlIdentity {
+	host: String,
+	path: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RemoteUrlMode {
+	Fetch,
+	Push,
+}
+
 pub(in crate::cli::git_hook_commands) fn read_pre_push_updates(
 	reader: impl BufRead,
 ) -> Result<Vec<PrePushUpdate>> {
@@ -129,11 +147,9 @@ fn remote_exclusion_arg_from_config(
 	if remote_name.is_empty() {
 		return Some(String::from("--remotes"));
 	}
-
 	if remotes.iter().any(|candidate| candidate.name == remote_name) {
 		return Some(format!("--remotes={remote_name}"));
 	}
-
 	if !remote_url.is_empty()
 		&& let Some(remote) = remotes.iter().find(|candidate| {
 			candidate.urls.iter().any(|candidate_url| urls_match(candidate_url, remote_url))
@@ -146,6 +162,7 @@ fn remote_exclusion_arg_from_config(
 
 fn configured_remotes() -> Result<Vec<RemoteConfig>> {
 	let remote_names = git::run_git_lines(&[String::from("remote")])?;
+
 	remote_names
 		.into_iter()
 		.map(|name| Ok(RemoteConfig { urls: remote_urls(&name)?, name }))
@@ -157,30 +174,20 @@ fn remote_urls(remote: &str) -> Result<Vec<String>> {
 
 	for mode in [RemoteUrlMode::Fetch, RemoteUrlMode::Push] {
 		let mut args = vec![String::from("remote"), String::from("get-url")];
+
 		if mode == RemoteUrlMode::Push {
 			args.push(String::from("--push"));
 		}
+
 		args.push(String::from("--all"));
 		args.push(remote.to_owned());
-
 		urls.extend(git::run_git_lines(&args)?);
 	}
 
 	urls.sort();
 	urls.dedup();
+
 	Ok(urls)
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum RemoteUrlMode {
-	Fetch,
-	Push,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct RemoteConfig {
-	name: String,
-	urls: Vec<String>,
 }
 
 fn urls_match(candidate: &str, remote_url: &str) -> bool {
@@ -193,6 +200,7 @@ fn urls_match(candidate: &str, remote_url: &str) -> bool {
 
 fn remote_url_identity(value: &str) -> Option<RemoteUrlIdentity> {
 	let value = value.trim();
+
 	if value.is_empty() || value.starts_with('/') || value.starts_with('.') {
 		return None;
 	}
@@ -205,6 +213,7 @@ fn remote_url_identity(value: &str) -> Option<RemoteUrlIdentity> {
 	let path_separator = value[user_host_separator + 1..].find(':')? + user_host_separator + 1;
 	let host = &value[user_host_separator + 1..path_separator];
 	let path = &value[path_separator + 1..];
+
 	remote_url_identity_parts(host, path)
 }
 
@@ -213,12 +222,14 @@ fn url_identity_from_authority_path(value: &str) -> Option<RemoteUrlIdentity> {
 	let authority = &value[..path_separator];
 	let path = &value[path_separator + 1..];
 	let host = authority.rsplit_once('@').map_or(authority, |(_, host)| host);
+
 	remote_url_identity_parts(host, path)
 }
 
 fn remote_url_identity_parts(host: &str, path: &str) -> Option<RemoteUrlIdentity> {
 	let host = host.trim();
 	let path = path.trim().trim_start_matches('/').trim_end_matches('/');
+
 	if host.is_empty() || path.is_empty() {
 		return None;
 	}
@@ -227,12 +238,6 @@ fn remote_url_identity_parts(host: &str, path: &str) -> Option<RemoteUrlIdentity
 		host: host.to_ascii_lowercase(),
 		path: path.strip_suffix(".git").unwrap_or(path).to_owned(),
 	})
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct RemoteUrlIdentity {
-	host: String,
-	path: String,
 }
 
 fn commit_message_text(oid: &str) -> Result<String> {
@@ -252,7 +257,7 @@ fn is_zero_oid(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-	use super::{RemoteConfig, remote_exclusion_arg_from_config, urls_match};
+	use crate::cli::git_hook_commands::pre_push::{self, RemoteConfig};
 
 	fn remote(name: &str, urls: &[&str]) -> RemoteConfig {
 		RemoteConfig { name: name.to_owned(), urls: urls.iter().map(ToString::to_string).collect() }
@@ -260,7 +265,7 @@ mod tests {
 
 	#[test]
 	fn remote_exclusion_uses_configured_remote_name() {
-		let exclusion = remote_exclusion_arg_from_config(
+		let exclusion = pre_push::remote_exclusion_arg_from_config(
 			"origin",
 			"https://github.com/hack-ink/decodex.git",
 			&[remote("origin", &["git@github.com-y:hack-ink/decodex.git"])],
@@ -271,7 +276,7 @@ mod tests {
 
 	#[test]
 	fn remote_exclusion_maps_exact_url_remote_name_to_configured_remote() {
-		let exclusion = remote_exclusion_arg_from_config(
+		let exclusion = pre_push::remote_exclusion_arg_from_config(
 			"https://github.com/helixbox/pubfi-insight.git",
 			"https://github.com/helixbox/pubfi-insight.git",
 			&[remote(
@@ -288,7 +293,7 @@ mod tests {
 
 	#[test]
 	fn remote_exclusion_maps_https_url_push_to_ssh_configured_remote() {
-		let exclusion = remote_exclusion_arg_from_config(
+		let exclusion = pre_push::remote_exclusion_arg_from_config(
 			"https://github.com/helixbox/pubfi-insight.git",
 			"https://github.com/helixbox/pubfi-insight.git",
 			&[remote("origin", &["git@github.com:helixbox/pubfi-insight.git"])],
@@ -299,7 +304,7 @@ mod tests {
 
 	#[test]
 	fn remote_exclusion_does_not_exclude_unmatched_url_remotes() {
-		let exclusion = remote_exclusion_arg_from_config(
+		let exclusion = pre_push::remote_exclusion_arg_from_config(
 			"https://github.com/example/other.git",
 			"https://github.com/example/other.git",
 			&[
@@ -313,15 +318,15 @@ mod tests {
 
 	#[test]
 	fn remote_url_matching_accepts_common_git_url_forms() {
-		assert!(urls_match(
+		assert!(pre_push::urls_match(
 			"git@github.com:helixbox/pubfi-insight.git",
 			"https://github.com/helixbox/pubfi-insight.git",
 		));
-		assert!(urls_match(
+		assert!(pre_push::urls_match(
 			"ssh://git@github.com/helixbox/pubfi-insight.git",
 			"https://github.com/helixbox/pubfi-insight",
 		));
-		assert!(!urls_match(
+		assert!(!pre_push::urls_match(
 			"git@github.com:helixbox/pubfi-insight.git",
 			"https://github.com/hack-ink/decodex.git",
 		));

--- a/apps/decodex/src/cli/openwiki_commands.rs
+++ b/apps/decodex/src/cli/openwiki_commands.rs
@@ -73,12 +73,14 @@ fn discover_repo_root(start: &Path) -> Result<PathBuf> {
 
 fn check_openwiki_surface(root: &Path) -> Result<OpenWikiCheckReport> {
 	let openwiki = root.join("openwiki");
+
 	if !openwiki.is_dir() {
 		eyre::bail!("No OpenWiki surface found under `{}`. Expected `openwiki/`.", root.display());
 	}
 
 	check_openwiki_router(&openwiki)?;
 	check_local_markdown_links(&openwiki)?;
+
 	let markdown_files = count_readable_markdown_files(&openwiki)?;
 
 	if markdown_files == 0 {
@@ -95,10 +97,10 @@ fn check_openwiki_router(path: &Path) -> Result<()> {
 	reject_openwiki_symlink(path)?;
 
 	let quickstart = path.join("quickstart.md");
+
 	if !quickstart.is_file() {
 		eyre::bail!("OpenWiki surface is missing `{}`.", quickstart.display());
 	}
-
 	if fs::read_to_string(&quickstart)?.trim().is_empty() {
 		eyre::bail!("OpenWiki router `{}` is empty.", quickstart.display());
 	}
@@ -108,12 +110,15 @@ fn check_openwiki_router(path: &Path) -> Result<()> {
 
 fn check_local_markdown_links(root: &Path) -> Result<()> {
 	let surface_root = root.canonicalize()?;
+
 	for path in markdown_files(root)? {
 		let text = fs::read_to_string(&path)?;
+
 		for raw_target in markdown_link_targets(&text) {
 			let Some(target) = local_markdown_link_target(&path, raw_target)? else {
 				continue;
 			};
+
 			if !target.starts_with(&surface_root) {
 				eyre::bail!(
 					"OpenWiki link in `{}` escapes `{}`: `{}`.",
@@ -122,6 +127,7 @@ fn check_local_markdown_links(root: &Path) -> Result<()> {
 					raw_target
 				);
 			}
+
 			let Ok(metadata) = fs::symlink_metadata(&target) else {
 				eyre::bail!(
 					"OpenWiki link in `{}` points to missing file `{}`.",
@@ -129,6 +135,7 @@ fn check_local_markdown_links(root: &Path) -> Result<()> {
 					raw_target
 				);
 			};
+
 			if metadata.file_type().is_symlink() {
 				eyre::bail!(
 					"OpenWiki link in `{}` points to symlink `{}`.",
@@ -159,6 +166,7 @@ fn reject_openwiki_symlink(path: &Path) -> Result<()> {
 
 fn count_readable_markdown_files(path: &Path) -> Result<usize> {
 	let files = markdown_files(path)?;
+
 	for file in &files {
 		if fs::read_to_string(file)?.trim().is_empty() {
 			eyre::bail!("OpenWiki file `{}` is empty.", file.display());
@@ -170,15 +178,18 @@ fn count_readable_markdown_files(path: &Path) -> Result<usize> {
 
 fn markdown_files(path: &Path) -> Result<Vec<PathBuf>> {
 	let mut files = Vec::new();
+
 	for entry in fs::read_dir(path)? {
 		let entry = entry?;
 		let path = entry.path();
 		let file_type = entry.file_type()?;
+
 		if file_type.is_symlink() {
 			eyre::bail!("OpenWiki tree must not contain symlink `{}`.", path.display());
 		}
 		if file_type.is_dir() {
 			files.extend(markdown_files(&path)?);
+
 			continue;
 		}
 		if !file_type.is_file() {
@@ -187,8 +198,10 @@ fn markdown_files(path: &Path) -> Result<Vec<PathBuf>> {
 		if !is_markdown_file(&path) {
 			continue;
 		}
+
 		files.push(path);
 	}
+
 	Ok(files)
 }
 
@@ -201,22 +214,31 @@ fn is_markdown_file(path: &Path) -> bool {
 fn markdown_link_targets(text: &str) -> Vec<&str> {
 	let mut targets = Vec::new();
 	let mut cursor = text;
+
 	while let Some(label_start) = cursor.find('[') {
 		cursor = &cursor[label_start + 1..];
+
 		let Some(label_end) = cursor.find(']') else {
 			break;
 		};
+
 		cursor = &cursor[label_end + 1..];
+
 		if !cursor.starts_with('(') {
 			continue;
 		}
+
 		cursor = &cursor[1..];
+
 		let Some(target_end) = cursor.find(')') else {
 			break;
 		};
+
 		targets.push(cursor[..target_end].trim());
+
 		cursor = &cursor[target_end + 1..];
 	}
+
 	targets
 }
 
@@ -230,14 +252,18 @@ fn local_markdown_link_target(path: &Path, raw_target: &str) -> Result<Option<Pa
 	{
 		return Ok(None);
 	}
+
 	let target = raw_target.split('#').next().unwrap_or_default();
+
 	if target.is_empty() || !target.ends_with(".md") {
 		return Ok(None);
 	}
+
 	let Some(parent) = path.parent() else {
 		return Ok(None);
 	};
 	let mut resolved = parent.canonicalize()?;
+
 	for component in Path::new(target).components() {
 		match component {
 			Component::CurDir => {},
@@ -248,6 +274,7 @@ fn local_markdown_link_target(path: &Path, raw_target: &str) -> Result<Option<Pa
 			Component::Prefix(_) | Component::RootDir => return Ok(None),
 		}
 	}
+
 	Ok(Some(resolved))
 }
 
@@ -258,13 +285,13 @@ mod tests {
 		time::{SystemTime, UNIX_EPOCH},
 	};
 
-	use super::*;
+	use crate::cli::openwiki_commands::{self, PathBuf, env};
 
 	#[test]
 	fn openwiki_check_rejects_missing_surface() {
 		let root = temp_root("missing_surface");
-
-		let error = check_openwiki_surface(&root).expect_err("missing surface should fail");
+		let error = openwiki_commands::check_openwiki_surface(&root)
+			.expect_err("missing surface should fail");
 
 		assert!(error.to_string().contains("No OpenWiki surface found"));
 	}
@@ -273,10 +300,12 @@ mod tests {
 	fn openwiki_check_rejects_missing_local_markdown_link() {
 		let root = temp_root("missing_link");
 		let openwiki = root.join("openwiki");
+
 		fs::create_dir_all(&openwiki).unwrap();
 		fs::write(openwiki.join("quickstart.md"), "[Missing](missing.md)\n").unwrap();
 
-		let error = check_openwiki_surface(&root).expect_err("missing link should fail");
+		let error =
+			openwiki_commands::check_openwiki_surface(&root).expect_err("missing link should fail");
 
 		assert!(error.to_string().contains("points to missing file"));
 	}
@@ -285,11 +314,13 @@ mod tests {
 	fn openwiki_check_rejects_empty_markdown_file() {
 		let root = temp_root("empty_markdown");
 		let openwiki = root.join("openwiki");
+
 		fs::create_dir_all(&openwiki).unwrap();
 		fs::write(openwiki.join("quickstart.md"), "# Quickstart\n").unwrap();
 		fs::write(openwiki.join("empty.md"), "\n").unwrap();
 
-		let error = check_openwiki_surface(&root).expect_err("empty file should fail");
+		let error =
+			openwiki_commands::check_openwiki_surface(&root).expect_err("empty file should fail");
 
 		assert!(error.to_string().contains("is empty"));
 	}
@@ -300,13 +331,15 @@ mod tests {
 		let root = temp_root("symlinked_entry");
 		let openwiki = root.join("openwiki");
 		let external = root.join("external");
+
 		fs::create_dir_all(&openwiki).unwrap();
 		fs::create_dir_all(&external).unwrap();
 		fs::write(openwiki.join("quickstart.md"), "# Quickstart\n").unwrap();
 		fs::write(external.join("outside.md"), "# Outside\n").unwrap();
 		std::os::unix::fs::symlink(&external, openwiki.join("linked")).unwrap();
 
-		let error = check_openwiki_surface(&root).expect_err("symlinked entry should fail");
+		let error = openwiki_commands::check_openwiki_surface(&root)
+			.expect_err("symlinked entry should fail");
 
 		assert!(error.to_string().contains("must not contain symlink"));
 	}
@@ -314,7 +347,9 @@ mod tests {
 	fn temp_root(name: &str) -> PathBuf {
 		let nonce = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
 		let root = env::temp_dir().join(format!("decodex_openwiki_check_{name}_{nonce}"));
+
 		fs::create_dir_all(&root).unwrap();
+
 		root
 	}
 }

--- a/apps/decodex/src/cli/tests/core/verify_publish_status_e2e.rs
+++ b/apps/decodex/src/cli/tests/core/verify_publish_status_e2e.rs
@@ -2,7 +2,7 @@ use std::{
 	env,
 	ffi::OsString,
 	fs,
-	os::unix::fs::PermissionsExt,
+	os::unix::fs::PermissionsExt as _,
 	path::{Path, PathBuf},
 };
 
@@ -151,9 +151,11 @@ esac
 	);
 
 	fs::write(&gh_path, script).expect("fake gh should write");
+
 	let mut permissions = fs::metadata(&gh_path).expect("fake gh metadata").permissions();
 
 	permissions.set_mode(0o755);
+
 	fs::set_permissions(&gh_path, permissions).expect("fake gh should be executable");
 
 	gh_path

--- a/apps/decodex/src/cli/verify_commands.rs
+++ b/apps/decodex/src/cli/verify_commands.rs
@@ -1,12 +1,10 @@
 use clap::{Args, Subcommand, ValueEnum};
+use color_eyre::eyre;
 
 use crate::{
 	cli::ProjectConfigArgs,
 	config::ServiceConfig,
-	github::{
-		self, CommitStatusPublishRequest, CommitStatusState,
-		commit_status_description_with_base_ref_oid,
-	},
+	github::{self, CommitStatusPublishRequest, CommitStatusState},
 	prelude::Result,
 };
 
@@ -60,9 +58,10 @@ struct PublishStatusCommand {
 }
 impl PublishStatusCommand {
 	fn run(&self) -> Result<()> {
-		let config_path = self.project_config.as_path().ok_or_else(|| {
-			color_eyre::eyre::eyre!("`decodex verify publish-status` requires `--config`.")
-		})?;
+		let config_path = self
+			.project_config
+			.as_path()
+			.ok_or_else(|| eyre::eyre!("`decodex verify publish-status` requires `--config`."))?;
 		let config = ServiceConfig::from_path(config_path)?;
 		let github_token = config.github().resolve_token()?;
 		let landing_state = github::inspect_pull_request_landing_state(
@@ -73,6 +72,7 @@ impl PublishStatusCommand {
 			&[],
 			&[],
 		)?;
+
 		if self.state == PublishStatusState::Success && self.expected_head.is_none() {
 			color_eyre::eyre::bail!(
 				"`decodex verify publish-status --state success` requires `--expected-head`."
@@ -88,6 +88,7 @@ impl PublishStatusCommand {
 				"`decodex verify publish-status --state success` requires `--expected-base-oid`."
 			);
 		}
+
 		if let Some(expected_head) = self.expected_head.as_deref()
 			&& landing_state.head_ref_oid != expected_head
 		{
@@ -115,14 +116,13 @@ impl PublishStatusCommand {
 				landing_state.base_ref_oid.as_deref().unwrap_or("<unknown>")
 			);
 		}
+
 		let locator = github::parse_pull_request_url(&self.pr)?;
 		let description = if self.state == PublishStatusState::Success {
-			Some(commit_status_description_with_base_ref_oid(
+			Some(github::commit_status_description_with_base_ref_oid(
 				self.description.as_deref(),
 				landing_state.base_ref_oid.as_deref().ok_or_else(|| {
-					color_eyre::eyre::eyre!(
-						"GitHub did not return a PR base SHA; refusing to publish success."
-					)
+					eyre::eyre!("GitHub did not return a PR base SHA; refusing to publish success.")
 				})?,
 			))
 		} else {

--- a/apps/decodex/src/commit_message/build.rs
+++ b/apps/decodex/src/commit_message/build.rs
@@ -15,6 +15,7 @@ pub(crate) fn build_commit_message(
 	if !related.is_empty() {
 		eyre::bail!("`decodex/commit/2` is commit-local and does not accept related issues");
 	}
+
 	let summary = normalize::normalize_single_line_field("summary", summary)?;
 	let authority = normalize::normalize_commit_authority("authority", authority)?;
 	let impact = commit_impact(breaking);

--- a/apps/decodex/src/config/github.rs
+++ b/apps/decodex/src/config/github.rs
@@ -91,6 +91,7 @@ impl ProjectGitHubConfig {
 		if let Some(command_path) = self.command_path.as_deref() {
 			validation::validate_nonempty_path("github.command_path", command_path)?;
 		}
+
 		if self.landing_mode.is_fast() && self.landing_actors.is_empty() {
 			color_eyre::eyre::bail!(
 				"`github.landing_actors` must include at least one trusted GitHub actor when `github.landing_mode = \"fast\"`."
@@ -101,6 +102,7 @@ impl ProjectGitHubConfig {
 				"`github.landing_actors` is only valid when `github.landing_mode = \"fast\"`."
 			);
 		}
+
 		for actor in &self.landing_actors {
 			validation::validate_required_config_string("github.landing_actors", actor)?;
 		}

--- a/apps/decodex/src/github/landing_state.rs
+++ b/apps/decodex/src/github/landing_state.rs
@@ -57,6 +57,7 @@ pub(crate) fn inspect_pull_request_landing_state(
 	let mut landing_state = landing_state.ok_or_else(|| {
 		eyre::eyre!("GitHub GraphQL response for `{pr_url}` did not include a pull request.")
 	})?;
+
 	landing_state.required_status_contexts = github::inspect_required_commit_status_contexts(
 		cwd,
 		&locator.owner,

--- a/apps/decodex/src/github/status.rs
+++ b/apps/decodex/src/github/status.rs
@@ -105,16 +105,6 @@ pub(crate) fn inspect_required_commit_status_contexts(
 		.collect())
 }
 
-fn latest_status_for_context<'a>(
-	statuses: &'a [CommitStatusResponse],
-	context: &str,
-) -> Option<&'a CommitStatusResponse> {
-	statuses
-		.iter()
-		.filter(|status| status.context == context)
-		.max_by_key(|status| status.updated_at.as_deref().unwrap_or(""))
-}
-
 pub(crate) fn commit_status_description_with_base_ref_oid(
 	description: Option<&str>,
 	base_ref_oid: &str,
@@ -125,30 +115,27 @@ pub(crate) fn commit_status_description_with_base_ref_oid(
 	}
 }
 
-fn commit_status_description_base_ref_oid(description: &str) -> Option<&str> {
-	description
-		.split(|character: char| character.is_whitespace() || character == ';' || character == ',')
-		.find_map(|part| part.strip_prefix("base_ref_oid=").filter(|value| !value.is_empty()))
-}
-
 pub(crate) fn publish_commit_status(request: CommitStatusPublishRequest<'_>) -> Result<()> {
-	let mut command = github::gh_command_with_config(request.gh_command_path);
 	let endpoint = format!("repos/{}/{}/statuses/{}", request.owner, request.repo, request.sha);
+	let mut command = github::gh_command_with_config(request.gh_command_path);
 
 	command.args(["api", "--method", "POST", &endpoint]);
 	command.args(["-f", &format!("state={}", request.state.as_str())]);
 	command.args(["-f", &format!("context={}", request.context)]);
+
 	if let Some(description) = request.description {
 		command.args(["-f", &format!("description={description}")]);
 	}
 	if let Some(target_url) = request.target_url {
 		command.args(["-f", &format!("target_url={target_url}")]);
 	}
+
 	command.current_dir(request.cwd);
 
 	github::configure_gh_command(&mut command, request.github_token);
 
 	let output = command.output()?;
+
 	if !output.status.success() {
 		let stderr = String::from_utf8_lossy(&output.stderr);
 
@@ -165,6 +152,22 @@ pub(crate) fn publish_commit_status(request: CommitStatusPublishRequest<'_>) -> 
 	Ok(())
 }
 
+fn latest_status_for_context<'a>(
+	statuses: &'a [CommitStatusResponse],
+	context: &str,
+) -> Option<&'a CommitStatusResponse> {
+	statuses
+		.iter()
+		.filter(|status| status.context == context)
+		.max_by_key(|status| status.updated_at.as_deref().unwrap_or(""))
+}
+
+fn commit_status_description_base_ref_oid(description: &str) -> Option<&str> {
+	description
+		.split(|character: char| character.is_whitespace() || character == ';' || character == ',')
+		.find_map(|part| part.strip_prefix("base_ref_oid=").filter(|value| !value.is_empty()))
+}
+
 fn query_commit_statuses(
 	cwd: &Path,
 	owner: &str,
@@ -173,8 +176,8 @@ fn query_commit_statuses(
 	github_token: &str,
 	gh_command_path: Option<&Path>,
 ) -> Result<Vec<CommitStatusResponse>> {
-	let mut command = github::gh_command_with_config(gh_command_path);
 	let endpoint = format!("repos/{owner}/{repo}/commits/{sha}/statuses");
+	let mut command = github::gh_command_with_config(gh_command_path);
 
 	command.args(["api", &endpoint]);
 	command.current_dir(cwd);
@@ -182,6 +185,7 @@ fn query_commit_statuses(
 	github::configure_gh_command(&mut command, github_token);
 
 	let output = command.output()?;
+
 	if !output.status.success() {
 		let stderr = String::from_utf8_lossy(&output.stderr);
 
@@ -196,11 +200,11 @@ fn query_commit_statuses(
 
 #[cfg(test)]
 mod tests {
-	use std::{fs, os::unix::fs::PermissionsExt};
+	use std::{fs, os::unix::fs::PermissionsExt as _};
 
 	use tempfile::TempDir;
 
-	use super::*;
+	use crate::github::status::{self, CommitStatusPublishRequest, CommitStatusState};
 
 	#[test]
 	fn inspect_required_commit_status_contexts_reads_exact_context_and_creator() {
@@ -209,8 +213,7 @@ mod tests {
 			&temp_dir,
 			r#"[{"context":"decodex/local-full-check","state":"success","creator":{"login":"decodex-bot"}},{"context":"ci/slow","state":"pending","creator":{"login":"github-actions"}}]"#,
 		);
-
-		let statuses = inspect_required_commit_status_contexts(
+		let statuses = status::inspect_required_commit_status_contexts(
 			temp_dir.path(),
 			"hack-ink",
 			"decodex",
@@ -245,8 +248,7 @@ mod tests {
 			&temp_dir,
 			r#"[{"context":"decodex/local-full-check","state":"success","description":"cargo make check passed; base_ref_oid=base-sha","creator":{"login":"decodex-bot"}}]"#,
 		);
-
-		let statuses = inspect_required_commit_status_contexts(
+		let statuses = status::inspect_required_commit_status_contexts(
 			temp_dir.path(),
 			"hack-ink",
 			"decodex",
@@ -270,8 +272,7 @@ mod tests {
 			&temp_dir,
 			r#"[{"context":"decodex/local-full-check","state":"failure","updated_at":"2026-07-09T01:00:00Z","creator":{"login":"decodex-bot"}},{"context":"decodex/local-full-check","state":"success","updated_at":"2026-07-09T02:00:00Z","creator":{"login":"yvette-carlisle"}}]"#,
 		);
-
-		let statuses = inspect_required_commit_status_contexts(
+		let statuses = status::inspect_required_commit_status_contexts(
 			temp_dir.path(),
 			"hack-ink",
 			"decodex",
@@ -295,7 +296,7 @@ mod tests {
 		let gh_path = fake_gh(&temp_dir, "{}");
 		let log_path = temp_dir.path().join("gh.log");
 
-		publish_commit_status(CommitStatusPublishRequest {
+		status::publish_commit_status(CommitStatusPublishRequest {
 			cwd: temp_dir.path(),
 			owner: "hack-ink",
 			repo: "decodex",
@@ -332,9 +333,11 @@ JSON
 		);
 
 		fs::write(&gh_path, script).expect("fake gh should write");
+
 		let mut permissions = fs::metadata(&gh_path).expect("fake gh metadata").permissions();
 
 		permissions.set_mode(0o755);
+
 		fs::set_permissions(&gh_path, permissions).expect("fake gh should be executable");
 
 		gh_path

--- a/apps/decodex/src/manual/closeout.rs
+++ b/apps/decodex/src/manual/closeout.rs
@@ -3,10 +3,6 @@ mod issue;
 mod ledger;
 mod receipt;
 
-use std::path::Path;
-
-use time::{OffsetDateTime, format_description::well_known::Rfc3339};
-
 #[cfg(test)] pub(super) use self::issue::ensure_manual_closeout_issue_scope;
 #[cfg(test)] pub(super) use self::receipt::read_manual_land_closeout_receipt;
 pub(super) use self::{
@@ -22,20 +18,27 @@ pub(super) use self::{
 	receipt::{manual_land_closeout_receipt_matches, write_manual_land_closeout_receipt},
 };
 
+use std::path::Path;
+
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
 use crate::{
 	config::ReviewLevel,
 	default_branch_sync,
 	manual::{ManualLandContext, ManualLandLedgerContext},
 	orchestrator::{
-		PostReviewLifecycleFactsInput, PullRequestReviewState, build_post_review_lifecycle_facts,
-		kernel::lifecycle::{
-			LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome,
-			PreviousLifecycleAuthority, decide_lifecycle_transition,
+		self, PostReviewLifecycleFactsInput, PullRequestReviewState,
+		kernel::{
+			lifecycle,
+			lifecycle::{
+				LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome,
+				PreviousLifecycleAuthority,
+			},
 		},
-		runtime_review_checkpoint_status_for_head,
 	},
 	prelude::{Result, eyre},
 	runtime,
+	state::StateStore,
 };
 
 pub(super) fn finalize_land_closeout(
@@ -51,48 +54,14 @@ pub(super) fn finalize_land_closeout(
 	};
 	let worktree_path_for_event = cleanup::manual_land_relative_worktree_path(context);
 
-	if let Some(prepared_closeout) = context.prepared_closeout.as_ref() {
-		let state_store = state_store
-			.as_ref()
-			.ok_or_else(|| eyre::eyre!("Manual closeout state store was not opened."))?;
-		let lifecycle_record = context.review_lifecycle.as_ref().ok_or_else(|| {
-			eyre::eyre!(
-				"`decodex land` issue closeout requires retained review lifecycle authority."
-			)
-		})?;
-		let ledger = ManualLandLedgerContext {
-			service_id: &prepared_closeout.service_id,
-			issue: &prepared_closeout.issue,
-			state_store,
-			lifecycle_record,
-			pr_url: &context.pr_url,
-			merge_commit,
-			branch_name: &context.current_branch,
-			worktree_path: &worktree_path_for_event,
-			completed_state: &prepared_closeout.completed_state,
-			default_branch,
-			privacy_classifier: &context.public_projection_privacy_classifier,
-		};
-
-		record_manual_land_lifecycle_decision(
-			&ledger,
-			prepared_closeout.review_level,
-			LifecycleEvidenceKind::LandingReadback,
-			LifecycleOutcome::Succeeded,
-			Some(merge_commit),
-			"landed",
-			"not_started",
-			"not_started",
-			"manual_land_readback",
-		)?;
-		apply_closeout(
-			&context.cwd,
-			&prepared_closeout.tracker,
-			&prepared_closeout.completed_state,
-			&ledger,
-			landed_change_record,
-		)?;
-	}
+	apply_prepared_manual_land_closeout(
+		context,
+		state_store.as_ref(),
+		merge_commit,
+		default_branch,
+		landed_change_record,
+		&worktree_path_for_event,
+	)?;
 
 	default_branch_sync::sync_repo_root_default_branch(
 		&context.canonical_repo_root,
@@ -118,58 +87,123 @@ pub(super) fn finalize_land_closeout(
 	}
 
 	cleanup_manual_land_lane_checkout(context)?;
-
-	if let Some(prepared_closeout) = context.prepared_closeout.as_ref() {
-		let state_store = state_store
-			.as_ref()
-			.ok_or_else(|| eyre::eyre!("Manual closeout state store was not opened."))?;
-		let lifecycle_record = context.review_lifecycle.as_ref().ok_or_else(|| {
-			eyre::eyre!(
-				"`decodex land` issue cleanup requires retained review lifecycle authority."
-			)
-		})?;
-
-		clear_manual_closeout_runtime_state(
-			state_store,
-			&prepared_closeout.issue.id,
-			lifecycle_record.run_id(),
-		)?;
-		clear_manual_closeout_issue_scope(
-			&prepared_closeout.tracker,
-			&prepared_closeout.issue,
-			&prepared_closeout.service_id,
-			&prepared_closeout.needs_attention_label,
-		)?;
-
-		let ledger = ManualLandLedgerContext {
-			service_id: &prepared_closeout.service_id,
-			issue: &prepared_closeout.issue,
-			state_store,
-			lifecycle_record,
-			pr_url: &context.pr_url,
-			merge_commit,
-			branch_name: &context.current_branch,
-			worktree_path: &worktree_path_for_event,
-			completed_state: &prepared_closeout.completed_state,
-			default_branch,
-			privacy_classifier: &context.public_projection_privacy_classifier,
-		};
-
-		write_manual_land_cleanup_complete_event(&prepared_closeout.tracker, &ledger)?;
-		record_manual_land_lifecycle_decision(
-			&ledger,
-			prepared_closeout.review_level,
-			LifecycleEvidenceKind::CloseoutCompletion,
-			LifecycleOutcome::Succeeded,
-			Some(merge_commit),
-			"landed",
-			"completed",
-			"completed",
-			"manual_land_closeout_complete",
-		)?;
-	}
+	complete_prepared_manual_land_cleanup(
+		context,
+		state_store.as_ref(),
+		merge_commit,
+		default_branch,
+		&worktree_path_for_event,
+	)?;
 
 	Ok(())
+}
+
+fn apply_prepared_manual_land_closeout(
+	context: &ManualLandContext,
+	state_store: Option<&StateStore>,
+	merge_commit: &str,
+	default_branch: &str,
+	landed_change_record: &str,
+	worktree_path_for_event: &str,
+) -> Result<()> {
+	let Some(prepared_closeout) = context.prepared_closeout.as_ref() else {
+		return Ok(());
+	};
+	let state_store =
+		state_store.ok_or_else(|| eyre::eyre!("Manual closeout state store was not opened."))?;
+	let lifecycle_record = context.review_lifecycle.as_ref().ok_or_else(|| {
+		eyre::eyre!("`decodex land` issue closeout requires retained review lifecycle authority.")
+	})?;
+	let ledger = ManualLandLedgerContext {
+		service_id: &prepared_closeout.service_id,
+		issue: &prepared_closeout.issue,
+		state_store,
+		lifecycle_record,
+		pr_url: &context.pr_url,
+		merge_commit,
+		branch_name: &context.current_branch,
+		worktree_path: worktree_path_for_event,
+		completed_state: &prepared_closeout.completed_state,
+		default_branch,
+		privacy_classifier: &context.public_projection_privacy_classifier,
+	};
+
+	record_manual_land_lifecycle_decision(
+		&ledger,
+		prepared_closeout.review_level,
+		LifecycleEvidenceKind::LandingReadback,
+		LifecycleOutcome::Succeeded,
+		Some(merge_commit),
+		"landed",
+		"not_started",
+		"not_started",
+		"manual_land_readback",
+	)?;
+
+	apply_closeout(
+		&context.cwd,
+		&prepared_closeout.tracker,
+		&prepared_closeout.completed_state,
+		&ledger,
+		landed_change_record,
+	)
+}
+
+fn complete_prepared_manual_land_cleanup(
+	context: &ManualLandContext,
+	state_store: Option<&StateStore>,
+	merge_commit: &str,
+	default_branch: &str,
+	worktree_path_for_event: &str,
+) -> Result<()> {
+	let Some(prepared_closeout) = context.prepared_closeout.as_ref() else {
+		return Ok(());
+	};
+	let state_store =
+		state_store.ok_or_else(|| eyre::eyre!("Manual closeout state store was not opened."))?;
+	let lifecycle_record = context.review_lifecycle.as_ref().ok_or_else(|| {
+		eyre::eyre!("`decodex land` issue cleanup requires retained review lifecycle authority.")
+	})?;
+
+	clear_manual_closeout_runtime_state(
+		state_store,
+		&prepared_closeout.issue.id,
+		lifecycle_record.run_id(),
+	)?;
+	clear_manual_closeout_issue_scope(
+		&prepared_closeout.tracker,
+		&prepared_closeout.issue,
+		&prepared_closeout.service_id,
+		&prepared_closeout.needs_attention_label,
+	)?;
+
+	let ledger = ManualLandLedgerContext {
+		service_id: &prepared_closeout.service_id,
+		issue: &prepared_closeout.issue,
+		state_store,
+		lifecycle_record,
+		pr_url: &context.pr_url,
+		merge_commit,
+		branch_name: &context.current_branch,
+		worktree_path: worktree_path_for_event,
+		completed_state: &prepared_closeout.completed_state,
+		default_branch,
+		privacy_classifier: &context.public_projection_privacy_classifier,
+	};
+
+	write_manual_land_cleanup_complete_event(&prepared_closeout.tracker, &ledger)?;
+
+	record_manual_land_lifecycle_decision(
+		&ledger,
+		prepared_closeout.review_level,
+		LifecycleEvidenceKind::CloseoutCompletion,
+		LifecycleOutcome::Succeeded,
+		Some(merge_commit),
+		"landed",
+		"completed",
+		"completed",
+		"manual_land_closeout_complete",
+	)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -184,7 +218,7 @@ fn record_manual_land_lifecycle_decision(
 	cleanup_state: &str,
 	causation_id: &str,
 ) -> Result<()> {
-	let checkpoint = runtime_review_checkpoint_status_for_head(
+	let checkpoint = orchestrator::runtime_review_checkpoint_status_for_head(
 		ledger.state_store,
 		ledger.service_id,
 		&ledger.issue.id,
@@ -197,7 +231,7 @@ fn record_manual_land_lifecycle_decision(
 		&ledger.issue.id,
 		ledger.branch_name,
 	)?;
-	let facts = build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
+	let facts = orchestrator::build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
 		project_id: ledger.service_id,
 		issue_id: &ledger.issue.id,
 		review_lifecycle: previous_record.as_ref(),
@@ -224,7 +258,7 @@ fn record_manual_land_lifecycle_decision(
 		causation_id
 	);
 	let decided_at = current_timestamp();
-	let decision = decide_lifecycle_transition(LifecycleDecisionInput {
+	let decision = lifecycle::decide_lifecycle_transition(LifecycleDecisionInput {
 		facts: &facts,
 		previous,
 		evidence_kind,

--- a/apps/decodex/src/manual/context/closeout.rs
+++ b/apps/decodex/src/manual/context/closeout.rs
@@ -100,6 +100,7 @@ pub(in crate::manual) fn read_manual_land_lifecycle(
 	else {
 		return Ok(None);
 	};
+
 	if lifecycle_record.target_base_ref_name().is_none() {
 		eyre::bail!(
 			"Manual land found incomplete review lifecycle authority for issue `{issue_id}` branch `{current_branch}`."

--- a/apps/decodex/src/mcp/tests/prompts_tools/tool_listing.rs
+++ b/apps/decodex/src/mcp/tests/prompts_tools/tool_listing.rs
@@ -51,6 +51,7 @@ fn tools_list_exposes_schema_bound_tools() {
 			["items"]["properties"]["dependencies"]["description"],
 		"Candidate keys that must complete before this candidate."
 	);
+
 	let autonomy_signal_kind_schema =
 		&autonomy_submit_signal["inputSchema"]["properties"]["kind"]["enum"];
 

--- a/apps/decodex/src/orchestrator.rs
+++ b/apps/decodex/src/orchestrator.rs
@@ -1,3 +1,5 @@
+#[allow(dead_code)] pub(crate) mod kernel;
+
 mod agent_evidence;
 mod baseline_guard;
 mod constants;
@@ -17,7 +19,6 @@ mod execution_phase_goal;
 mod execution_thread_archive;
 mod git_ops;
 mod harness_improvement;
-#[allow(dead_code)] pub(crate) mod kernel;
 mod lane_control;
 mod lane_decision;
 mod operator_http;
@@ -36,6 +37,7 @@ mod runtime_validation;
 mod selection;
 mod status;
 mod types;
+
 pub(crate) use self::{
 	baseline_guard::{
 		BaselineGuardDispatchOutcome, ensure_clean_baseline_before_dispatch,

--- a/apps/decodex/src/orchestrator/baseline_guard.rs
+++ b/apps/decodex/src/orchestrator/baseline_guard.rs
@@ -1,8 +1,8 @@
 use std::{
-	fs::{self, OpenOptions},
-	io::{ErrorKind, Read as _},
+	fs::{self, File, OpenOptions},
+	io::{ErrorKind, Read as _, Write as _},
 	path::{Path, PathBuf},
-	process::{Command, Output},
+	process::{self, Command, Output},
 	thread,
 	time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -24,14 +24,6 @@ use crate::{
 	state::ProjectLoopEvidenceSnapshot,
 };
 
-const BASELINE_ISSUE_ID: &str = "__baseline__";
-const BASELINE_ATTEMPT_NUMBER: i64 = 1;
-const LOCK_FILE_NAME: &str = ".decodex-baseline-normalization.lock";
-const LOCK_SCHEMA: &str = "decodex/baseline_normalization_lock/1";
-const MERGE_READBACK_TIMEOUT: Duration = Duration::from_secs(120);
-const NORMALIZATION_WAIT_TIMEOUT: Duration = Duration::from_secs(30 * 60);
-const NORMALIZATION_WAIT_INTERVAL: Duration = Duration::from_secs(5);
-
 pub(crate) const BASELINE_GUARD_CLEAN_EVENT_TYPE: &str = "baseline_guard_clean";
 pub(crate) const BASELINE_GUARD_DIRTY_EVENT_TYPE: &str = "baseline_guard_dirty";
 pub(crate) const BASELINE_GUARD_FAILED_EVENT_TYPE: &str = "baseline_guard_failed";
@@ -49,228 +41,18 @@ pub(crate) const BASELINE_NORMALIZATION_RECHECK_FAILED_EVENT_TYPE: &str =
 	"baseline_normalization_recheck_failed";
 pub(crate) const BASELINE_NORMALIZATION_FAILED_EVENT_TYPE: &str = "baseline_normalization_failed";
 
-pub(crate) fn baseline_guard_applies_to_dispatch_mode(dispatch_mode: IssueDispatchMode) -> bool {
-	matches!(
-		dispatch_mode,
-		IssueDispatchMode::Normal | IssueDispatchMode::Program | IssueDispatchMode::Retry
-	)
-}
+const BASELINE_ISSUE_ID: &str = "__baseline__";
+const BASELINE_ATTEMPT_NUMBER: i64 = 1;
+const LOCK_FILE_NAME: &str = ".decodex-baseline-normalization.lock";
+const LOCK_SCHEMA: &str = "decodex/baseline_normalization_lock/1";
+const MERGE_READBACK_TIMEOUT: Duration = Duration::from_secs(120);
+const NORMALIZATION_WAIT_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+const NORMALIZATION_WAIT_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum BaselineGuardDispatchOutcome {
 	Clean,
 	NormalizedMain,
-}
-
-pub(crate) fn ensure_clean_baseline_before_dispatch(
-	project: &ServiceConfig,
-	workflow: &WorkflowDocument,
-	state_store: &StateStore,
-	dispatch_mode: IssueDispatchMode,
-	dry_run: bool,
-) -> Result<BaselineGuardDispatchOutcome> {
-	if dry_run || !baseline_guard_applies_to_dispatch_mode(dispatch_mode) {
-		return Ok(BaselineGuardDispatchOutcome::Clean);
-	}
-	let repo_gate = BaselineRepoGateCommands::from_workflow(workflow);
-	if repo_gate.canonicalize_commands.is_empty() {
-		return Ok(BaselineGuardDispatchOutcome::Clean);
-	}
-
-	let context = BaselineGuardContext::new(project, workflow)?;
-
-	if let Some((event_type, payload)) =
-		latest_baseline_event_for_context(project, state_store, &context)?
-	{
-		match event_type.as_str() {
-			BASELINE_GUARD_CLEAN_EVENT_TYPE | BASELINE_NORMALIZATION_RECHECK_PASSED_EVENT_TYPE => {
-			},
-			BASELINE_NORMALIZATION_STARTED_EVENT_TYPE
-			| BASELINE_NORMALIZATION_PR_CREATED_EVENT_TYPE
-			| BASELINE_NORMALIZATION_REPO_GATE_PASSED_EVENT_TYPE
-			| BASELINE_NORMALIZATION_MERGED_EVENT_TYPE => {
-				if baseline_normalization_lock_is_active(project.worktree_root())? {
-					return wait_for_existing_normalization(
-						project,
-						workflow,
-						state_store,
-						dispatch_mode,
-					);
-				}
-				if let Some(outcome) = resume_existing_normalization_from_payload(
-					project,
-					&repo_gate,
-					state_store,
-					&context,
-					&payload,
-				)? {
-					return Ok(outcome);
-				}
-			},
-			BASELINE_NORMALIZATION_REPO_GATE_FAILED_EVENT_TYPE
-			| BASELINE_NORMALIZATION_RECHECK_FAILED_EVENT_TYPE
-			| BASELINE_NORMALIZATION_FAILED_EVENT_TYPE => {
-				if !baseline_normalization_lock_is_active(project.worktree_root())?
-					&& let Some(outcome) = resume_existing_normalization_from_payload(
-						project,
-						&repo_gate,
-						state_store,
-						&context,
-						&payload,
-					)? {
-					return Ok(outcome);
-				}
-			},
-			_ => {},
-		}
-	}
-
-	let guard_run_id = context.guard_run_id();
-
-	match run_guard_once(project, &repo_gate, state_store, &context, &guard_run_id)? {
-		BaselineGuardCheck::Clean =>
-			if sync_repo_root_to_guarded_main(project, &context)? {
-				Ok(BaselineGuardDispatchOutcome::Clean)
-			} else {
-				Ok(BaselineGuardDispatchOutcome::NormalizedMain)
-			},
-		BaselineGuardCheck::Dirty => {
-			let Some(_lock) =
-				BaselineNormalizationLock::acquire(project.worktree_root(), &context)?
-			else {
-				return wait_for_existing_normalization(
-					project,
-					workflow,
-					state_store,
-					dispatch_mode,
-				);
-			};
-
-			let merged_main_oid =
-				run_baseline_normalization(project, &repo_gate, state_store, &context)?;
-			finish_normalized_main(project, &repo_gate, state_store, &context, merged_main_oid)
-		},
-	}
-}
-
-fn finish_normalized_main(
-	project: &ServiceConfig,
-	repo_gate: &BaselineRepoGateCommands,
-	state_store: &StateStore,
-	context: &BaselineGuardContext,
-	merged_main_oid: String,
-) -> Result<BaselineGuardDispatchOutcome> {
-	let recheck_context = context.with_main_oid(merged_main_oid);
-	let recheck_run_id = recheck_context.recheck_run_id();
-
-	match run_guard_once(project, repo_gate, state_store, &recheck_context, &recheck_run_id) {
-		Ok(BaselineGuardCheck::Clean) => {
-			record_event(
-				project,
-				state_store,
-				&recheck_run_id,
-				BASELINE_NORMALIZATION_RECHECK_PASSED_EVENT_TYPE,
-				recheck_context.payload(),
-			)?;
-			Ok(BaselineGuardDispatchOutcome::NormalizedMain)
-		},
-		Ok(BaselineGuardCheck::Dirty) => {
-			record_event(
-				project,
-				state_store,
-				&recheck_run_id,
-				BASELINE_NORMALIZATION_RECHECK_FAILED_EVENT_TYPE,
-				recheck_context.payload(),
-			)?;
-			eyre::bail!(
-				"Baseline canonicalization still rewrites tracked files after normalization for `{}` at `{}`.",
-				project.service_id(),
-				recheck_context.main_oid
-			)
-		},
-		Err(error) => {
-			record_event(
-				project,
-				state_store,
-				&recheck_run_id,
-				BASELINE_NORMALIZATION_RECHECK_FAILED_EVENT_TYPE,
-				payload_with_error(recheck_context.payload(), &error),
-			)?;
-			Err(error)
-		},
-	}
-}
-
-fn resume_existing_normalization_from_payload(
-	project: &ServiceConfig,
-	repo_gate: &BaselineRepoGateCommands,
-	state_store: &StateStore,
-	context: &BaselineGuardContext,
-	payload: &Value,
-) -> Result<Option<BaselineGuardDispatchOutcome>> {
-	let run = BaselineNormalizationRun::new(project, context);
-
-	if let Some(merge_commit) = payload.get("merge_commit").and_then(Value::as_str) {
-		let merged_main_oid =
-			resolve_merged_baseline_main(project, state_store, context, &run, merge_commit)?;
-
-		return finish_normalized_main(project, repo_gate, state_store, context, merged_main_oid)
-			.map(Some);
-	}
-
-	let Some(pr_url) = payload.get("pr_url").and_then(Value::as_str) else {
-		return Ok(None);
-	};
-	let Some(head_oid) = payload.get("head_oid").and_then(Value::as_str) else {
-		return Ok(None);
-	};
-
-	with_detached_worktree(project.repo_root(), &run.path, head_oid, &context.git_env, || {
-		let merge_commit =
-			merge_baseline_normalization_pr(project, state_store, context, &run, head_oid, pr_url)?;
-		let merged_main_oid =
-			resolve_merged_baseline_main(project, state_store, context, &run, &merge_commit)?;
-
-		finish_normalized_main(project, repo_gate, state_store, context, merged_main_oid).map(Some)
-	})
-}
-
-pub(crate) fn push_baseline_status_projection(
-	project: &ServiceConfig,
-	loop_evidence: &ProjectLoopEvidenceSnapshot,
-	warnings: &mut Vec<String>,
-	warning_details: &mut Vec<OperatorSnapshotWarningDetail>,
-) {
-	let Some(event) = loop_evidence.private_events_for_issue(BASELINE_ISSUE_ID).into_iter().last()
-	else {
-		return;
-	};
-	let warning = match event.event_type() {
-		BASELINE_GUARD_CLEAN_EVENT_TYPE | BASELINE_NORMALIZATION_RECHECK_PASSED_EVENT_TYPE => {
-			return;
-		},
-		BASELINE_GUARD_DIRTY_EVENT_TYPE => "baseline_guard_dirty",
-		BASELINE_GUARD_FAILED_EVENT_TYPE => "baseline_guard_failed",
-		BASELINE_NORMALIZATION_STARTED_EVENT_TYPE
-		| BASELINE_NORMALIZATION_PR_CREATED_EVENT_TYPE
-		| BASELINE_NORMALIZATION_REPO_GATE_PASSED_EVENT_TYPE
-		| BASELINE_NORMALIZATION_MERGED_EVENT_TYPE => "baseline_normalization_in_progress",
-		BASELINE_NORMALIZATION_REPO_GATE_FAILED_EVENT_TYPE => "baseline_normalization_gate_failed",
-		BASELINE_NORMALIZATION_RECHECK_FAILED_EVENT_TYPE => "baseline_normalization_recheck_failed",
-		BASELINE_NORMALIZATION_FAILED_EVENT_TYPE => "baseline_normalization_failed",
-		_ => return,
-	};
-
-	warnings.push(String::from(warning));
-	warning_details.push(OperatorSnapshotWarningDetail {
-		warning: String::from(warning),
-		project_id: Some(project.service_id().to_owned()),
-		repo_root: Some(project.repo_root().display().to_string()),
-		reason: baseline_status_reason(event.event_type(), event.payload()),
-		next_action: Some(String::from(
-			"let Decodex finish automatic baseline normalization before dispatching ordinary task lanes",
-		)),
-	});
 }
 
 enum BaselineGuardCheck {
@@ -321,7 +103,7 @@ impl BaselineGuardContext {
 		let timestamp =
 			SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO).as_nanos();
 
-		format!("{}-{}-{timestamp}", self.binding_id(), std::process::id())
+		format!("{}-{}-{timestamp}", self.binding_id(), process::id())
 	}
 
 	fn guard_run_id(&self) -> String {
@@ -362,6 +144,7 @@ struct BaselineNormalizationLock {
 impl BaselineNormalizationLock {
 	fn acquire(worktree_root: &Path, context: &BaselineGuardContext) -> Result<Option<Self>> {
 		fs::create_dir_all(worktree_root)?;
+
 		let path = worktree_root.join(LOCK_FILE_NAME);
 
 		remove_stale_lock_if_needed(&path)?;
@@ -377,9 +160,8 @@ impl BaselineNormalizationLock {
 
 		match file_result {
 			Ok(mut file) => {
-				use std::io::Write as _;
-
 				file.write_all(lock_payload.to_string().as_bytes())?;
+
 				Ok(Some(Self { path }))
 			},
 			Err(error) if error.kind() == ErrorKind::AlreadyExists => Ok(None),
@@ -387,10 +169,256 @@ impl BaselineNormalizationLock {
 		}
 	}
 }
+
 impl Drop for BaselineNormalizationLock {
 	fn drop(&mut self) {
 		let _ = fs::remove_file(&self.path);
 	}
+}
+
+struct BaselineNormalizationRun {
+	run_id: String,
+	branch_name: String,
+	path: PathBuf,
+}
+impl BaselineNormalizationRun {
+	fn new(project: &ServiceConfig, context: &BaselineGuardContext) -> Self {
+		let binding_id = context.binding_id();
+
+		Self {
+			run_id: context.normalization_run_id(),
+			branch_name: format!(
+				"xy/{}-baseline-normalize-{}",
+				git_ref_component(project.service_id()),
+				binding_id.as_str()
+			),
+			path: baseline_worktree_path(project, "normalization", &binding_id),
+		}
+	}
+}
+
+pub(crate) fn baseline_guard_applies_to_dispatch_mode(dispatch_mode: IssueDispatchMode) -> bool {
+	matches!(
+		dispatch_mode,
+		IssueDispatchMode::Normal | IssueDispatchMode::Program | IssueDispatchMode::Retry
+	)
+}
+
+pub(crate) fn ensure_clean_baseline_before_dispatch(
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	dispatch_mode: IssueDispatchMode,
+	dry_run: bool,
+) -> Result<BaselineGuardDispatchOutcome> {
+	if dry_run || !baseline_guard_applies_to_dispatch_mode(dispatch_mode) {
+		return Ok(BaselineGuardDispatchOutcome::Clean);
+	}
+
+	let repo_gate = BaselineRepoGateCommands::from_workflow(workflow);
+
+	if repo_gate.canonicalize_commands.is_empty() {
+		return Ok(BaselineGuardDispatchOutcome::Clean);
+	}
+
+	let context = BaselineGuardContext::new(project, workflow)?;
+
+	if let Some((event_type, payload)) =
+		latest_baseline_event_for_context(project, state_store, &context)?
+	{
+		match event_type.as_str() {
+			BASELINE_GUARD_CLEAN_EVENT_TYPE | BASELINE_NORMALIZATION_RECHECK_PASSED_EVENT_TYPE => {
+			},
+			BASELINE_NORMALIZATION_STARTED_EVENT_TYPE
+			| BASELINE_NORMALIZATION_PR_CREATED_EVENT_TYPE
+			| BASELINE_NORMALIZATION_REPO_GATE_PASSED_EVENT_TYPE
+			| BASELINE_NORMALIZATION_MERGED_EVENT_TYPE => {
+				if baseline_normalization_lock_is_active(project.worktree_root())? {
+					return wait_for_existing_normalization(
+						project,
+						workflow,
+						state_store,
+						dispatch_mode,
+					);
+				}
+
+				if let Some(outcome) = resume_existing_normalization_from_payload(
+					project,
+					&repo_gate,
+					state_store,
+					&context,
+					&payload,
+				)? {
+					return Ok(outcome);
+				}
+			},
+			BASELINE_NORMALIZATION_REPO_GATE_FAILED_EVENT_TYPE
+			| BASELINE_NORMALIZATION_RECHECK_FAILED_EVENT_TYPE
+			| BASELINE_NORMALIZATION_FAILED_EVENT_TYPE => {
+				if !baseline_normalization_lock_is_active(project.worktree_root())?
+					&& let Some(outcome) = resume_existing_normalization_from_payload(
+						project,
+						&repo_gate,
+						state_store,
+						&context,
+						&payload,
+					)? {
+					return Ok(outcome);
+				}
+			},
+			_ => {},
+		}
+	}
+
+	let guard_run_id = context.guard_run_id();
+
+	match run_guard_once(project, &repo_gate, state_store, &context, &guard_run_id)? {
+		BaselineGuardCheck::Clean =>
+			if sync_repo_root_to_guarded_main(project, &context)? {
+				Ok(BaselineGuardDispatchOutcome::Clean)
+			} else {
+				Ok(BaselineGuardDispatchOutcome::NormalizedMain)
+			},
+		BaselineGuardCheck::Dirty => {
+			let Some(_lock) =
+				BaselineNormalizationLock::acquire(project.worktree_root(), &context)?
+			else {
+				return wait_for_existing_normalization(
+					project,
+					workflow,
+					state_store,
+					dispatch_mode,
+				);
+			};
+			let merged_main_oid =
+				run_baseline_normalization(project, &repo_gate, state_store, &context)?;
+
+			finish_normalized_main(project, &repo_gate, state_store, &context, merged_main_oid)
+		},
+	}
+}
+
+pub(crate) fn push_baseline_status_projection(
+	project: &ServiceConfig,
+	loop_evidence: &ProjectLoopEvidenceSnapshot,
+	warnings: &mut Vec<String>,
+	warning_details: &mut Vec<OperatorSnapshotWarningDetail>,
+) {
+	let Some(event) = loop_evidence.private_events_for_issue(BASELINE_ISSUE_ID).into_iter().last()
+	else {
+		return;
+	};
+	let warning = match event.event_type() {
+		BASELINE_GUARD_CLEAN_EVENT_TYPE | BASELINE_NORMALIZATION_RECHECK_PASSED_EVENT_TYPE => {
+			return;
+		},
+		BASELINE_GUARD_DIRTY_EVENT_TYPE => "baseline_guard_dirty",
+		BASELINE_GUARD_FAILED_EVENT_TYPE => "baseline_guard_failed",
+		BASELINE_NORMALIZATION_STARTED_EVENT_TYPE
+		| BASELINE_NORMALIZATION_PR_CREATED_EVENT_TYPE
+		| BASELINE_NORMALIZATION_REPO_GATE_PASSED_EVENT_TYPE
+		| BASELINE_NORMALIZATION_MERGED_EVENT_TYPE => "baseline_normalization_in_progress",
+		BASELINE_NORMALIZATION_REPO_GATE_FAILED_EVENT_TYPE => "baseline_normalization_gate_failed",
+		BASELINE_NORMALIZATION_RECHECK_FAILED_EVENT_TYPE => "baseline_normalization_recheck_failed",
+		BASELINE_NORMALIZATION_FAILED_EVENT_TYPE => "baseline_normalization_failed",
+		_ => return,
+	};
+
+	warnings.push(String::from(warning));
+	warning_details.push(OperatorSnapshotWarningDetail {
+		warning: String::from(warning),
+		project_id: Some(project.service_id().to_owned()),
+		repo_root: Some(project.repo_root().display().to_string()),
+		reason: baseline_status_reason(event.event_type(), event.payload()),
+		next_action: Some(String::from(
+			"let Decodex finish automatic baseline normalization before dispatching ordinary task lanes",
+		)),
+	});
+}
+
+fn finish_normalized_main(
+	project: &ServiceConfig,
+	repo_gate: &BaselineRepoGateCommands,
+	state_store: &StateStore,
+	context: &BaselineGuardContext,
+	merged_main_oid: String,
+) -> Result<BaselineGuardDispatchOutcome> {
+	let recheck_context = context.with_main_oid(merged_main_oid);
+	let recheck_run_id = recheck_context.recheck_run_id();
+
+	match run_guard_once(project, repo_gate, state_store, &recheck_context, &recheck_run_id) {
+		Ok(BaselineGuardCheck::Clean) => {
+			record_event(
+				project,
+				state_store,
+				&recheck_run_id,
+				BASELINE_NORMALIZATION_RECHECK_PASSED_EVENT_TYPE,
+				recheck_context.payload(),
+			)?;
+
+			Ok(BaselineGuardDispatchOutcome::NormalizedMain)
+		},
+		Ok(BaselineGuardCheck::Dirty) => {
+			record_event(
+				project,
+				state_store,
+				&recheck_run_id,
+				BASELINE_NORMALIZATION_RECHECK_FAILED_EVENT_TYPE,
+				recheck_context.payload(),
+			)?;
+
+			eyre::bail!(
+				"Baseline canonicalization still rewrites tracked files after normalization for `{}` at `{}`.",
+				project.service_id(),
+				recheck_context.main_oid
+			)
+		},
+		Err(error) => {
+			record_event(
+				project,
+				state_store,
+				&recheck_run_id,
+				BASELINE_NORMALIZATION_RECHECK_FAILED_EVENT_TYPE,
+				payload_with_error(recheck_context.payload(), &error),
+			)?;
+
+			Err(error)
+		},
+	}
+}
+
+fn resume_existing_normalization_from_payload(
+	project: &ServiceConfig,
+	repo_gate: &BaselineRepoGateCommands,
+	state_store: &StateStore,
+	context: &BaselineGuardContext,
+	payload: &Value,
+) -> Result<Option<BaselineGuardDispatchOutcome>> {
+	let run = BaselineNormalizationRun::new(project, context);
+
+	if let Some(merge_commit) = payload.get("merge_commit").and_then(Value::as_str) {
+		let merged_main_oid =
+			resolve_merged_baseline_main(project, state_store, context, &run, merge_commit)?;
+
+		return finish_normalized_main(project, repo_gate, state_store, context, merged_main_oid)
+			.map(Some);
+	}
+
+	let Some(pr_url) = payload.get("pr_url").and_then(Value::as_str) else {
+		return Ok(None);
+	};
+	let Some(head_oid) = payload.get("head_oid").and_then(Value::as_str) else {
+		return Ok(None);
+	};
+
+	with_detached_worktree(project.repo_root(), &run.path, head_oid, &context.git_env, || {
+		let merge_commit =
+			merge_baseline_normalization_pr(project, state_store, context, &run, head_oid, pr_url)?;
+		let merged_main_oid =
+			resolve_merged_baseline_main(project, state_store, context, &run, &merge_commit)?;
+
+		finish_normalized_main(project, repo_gate, state_store, context, merged_main_oid).map(Some)
+	})
 }
 
 fn baseline_normalization_lock_is_active(worktree_root: &Path) -> Result<bool> {
@@ -410,6 +438,7 @@ fn sync_repo_root_to_guarded_main(
 		&context.default_branch,
 		Some(GitCredentialSource::new(project.github().token_env_var(), &context.github_token)),
 	)?;
+
 	let local_main_oid =
 		git_capture(project.repo_root(), &["rev-parse", "HEAD"], &context.git_env)?;
 
@@ -426,9 +455,11 @@ fn run_guard_once(
 	let guard_path = baseline_worktree_path(project, "guard", &context.unique_binding_id());
 
 	remove_worktree_best_effort(project.repo_root(), &guard_path, &context.git_env);
+
 	if let Some(parent) = guard_path.parent() {
 		fs::create_dir_all(parent)?;
 	}
+
 	git_checked(
 		project.repo_root(),
 		&["worktree", "add", "--detach", path_arg(&guard_path).as_str(), &context.main_oid],
@@ -441,13 +472,17 @@ fn run_guard_once(
 	match result {
 		Ok(()) => {
 			let has_tracked_changes = worktree_has_tracked_changes(&guard_path, &context.git_env)?;
+
 			remove_worktree_best_effort(project.repo_root(), &guard_path, &context.git_env);
+
 			let event_type = if has_tracked_changes {
 				BASELINE_GUARD_DIRTY_EVENT_TYPE
 			} else {
 				BASELINE_GUARD_CLEAN_EVENT_TYPE
 			};
+
 			record_event(project, state_store, run_id, event_type, context.payload())?;
+
 			Ok(if has_tracked_changes {
 				BaselineGuardCheck::Dirty
 			} else {
@@ -463,6 +498,7 @@ fn run_guard_once(
 				payload_with_error(context.payload(), &error),
 			)?;
 			remove_worktree_best_effort(project.repo_root(), &guard_path, &context.git_env);
+
 			Err(error)
 		},
 	}
@@ -486,27 +522,6 @@ fn run_baseline_normalization(
 		&context.git_env,
 		|| execute_baseline_normalization(project, repo_gate, state_store, context, &run),
 	)
-}
-
-struct BaselineNormalizationRun {
-	run_id: String,
-	branch_name: String,
-	path: PathBuf,
-}
-impl BaselineNormalizationRun {
-	fn new(project: &ServiceConfig, context: &BaselineGuardContext) -> Self {
-		let binding_id = context.binding_id();
-
-		Self {
-			run_id: context.normalization_run_id(),
-			branch_name: format!(
-				"xy/{}-baseline-normalize-{}",
-				git_ref_component(project.service_id()),
-				binding_id.as_str()
-			),
-			path: baseline_worktree_path(project, "normalization", &binding_id),
-		}
-	}
 }
 
 fn record_baseline_normalization_started(
@@ -545,7 +560,9 @@ fn execute_baseline_normalization(
 	commit_normalization_diff(&run.path, context).inspect_err(|error| {
 		let _ = record_normalization_failed(project, state_store, &run.run_id, context, error);
 	})?;
+
 	let head_oid = git_capture(&run.path, &["rev-parse", "HEAD"], &context.git_env)?;
+
 	run_baseline_normalization_repo_gate(
 		project,
 		repo_gate,
@@ -555,6 +572,7 @@ fn execute_baseline_normalization(
 		&head_oid,
 		None,
 	)?;
+
 	let pr_url = push_baseline_normalization_pr(project, state_store, context, run, &head_oid)?;
 	let merge_commit =
 		merge_baseline_normalization_pr(project, state_store, context, run, &head_oid, &pr_url)?;
@@ -578,6 +596,7 @@ fn push_baseline_normalization_pr(
 	.inspect_err(|error| {
 		let _ = record_normalization_failed(project, state_store, &run.run_id, context, error);
 	})?;
+
 	let pr_url = create_pull_request(
 		&run.path,
 		&run.branch_name,
@@ -629,6 +648,7 @@ fn run_baseline_normalization_repo_gate(
 				BASELINE_NORMALIZATION_REPO_GATE_FAILED_EVENT_TYPE,
 				payload_with_error(normalization_payload(context, run, head_oid, pr_url), &error),
 			)?;
+
 			Err(error)
 		},
 	}
@@ -661,6 +681,7 @@ fn merge_baseline_normalization_pr(
 			payload_with_error(normalization_payload(context, run, head_oid, Some(pr_url)), error),
 		);
 	})?;
+
 	let merge_commit = github::wait_for_pull_request_merge_commit(
 		&run.path,
 		pr_url,
@@ -704,11 +725,13 @@ fn resolve_merged_baseline_main(
 		&context.default_branch,
 		&context.git_env,
 	)?;
+
 	if merged_main_oid != merge_commit {
 		let error = eyre::eyre!(
 			"Baseline normalization merge readback returned `{merge_commit}`, but `origin/{}` resolved to `{merged_main_oid}` after fetch.",
 			context.default_branch
 		);
+
 		record_event(
 			project,
 			state_store,
@@ -725,6 +748,7 @@ fn resolve_merged_baseline_main(
 
 		return Err(error);
 	}
+
 	default_branch_sync::sync_repo_root_default_branch(
 		project.repo_root(),
 		&context.default_branch,
@@ -733,13 +757,16 @@ fn resolve_merged_baseline_main(
 	.inspect_err(|error| {
 		let _ = record_normalization_failed(project, state_store, &run.run_id, context, error);
 	})?;
+
 	let local_main_oid =
 		git_capture(project.repo_root(), &["rev-parse", "HEAD"], &context.git_env)?;
+
 	if local_main_oid != merge_commit {
 		let error = eyre::eyre!(
 			"Baseline normalization synced `origin/{}` to `{merge_commit}`, but the local repo root HEAD is `{local_main_oid}`.",
 			context.default_branch
 		);
+
 		record_event(
 			project,
 			state_store,
@@ -830,6 +857,7 @@ fn create_pull_request(
 		"--head",
 		branch_name,
 	]);
+
 	github::configure_gh_command(&mut command, github_token);
 
 	let output = command.output()?;
@@ -862,10 +890,13 @@ where
 	F: FnOnce() -> Result<T>,
 {
 	remove_worktree_best_effort(repo_root, worktree_path, git_env);
+
 	if let Some(parent) = worktree_path.parent() {
 		fs::create_dir_all(parent)?;
 	}
+
 	let _ = git_status(repo_root, &["branch", "-D", branch_name], git_env);
+
 	git_checked(
 		repo_root,
 		&["worktree", "add", "-b", branch_name, path_arg(worktree_path).as_str(), start_oid],
@@ -874,10 +905,13 @@ where
 	)?;
 
 	let result = action();
+
 	if result.is_ok() {
 		remove_worktree_best_effort(repo_root, worktree_path, git_env);
+
 		let _ = git_status(repo_root, &["branch", "-D", branch_name], git_env);
 	}
+
 	result
 }
 
@@ -892,9 +926,11 @@ where
 	F: FnOnce() -> Result<T>,
 {
 	remove_worktree_best_effort(repo_root, worktree_path, git_env);
+
 	if let Some(parent) = worktree_path.parent() {
 		fs::create_dir_all(parent)?;
 	}
+
 	git_checked(
 		repo_root,
 		&["worktree", "add", "--detach", path_arg(worktree_path).as_str(), start_oid],
@@ -903,9 +939,11 @@ where
 	)?;
 
 	let result = action();
+
 	if result.is_ok() {
 		remove_worktree_best_effort(repo_root, worktree_path, git_env);
 	}
+
 	result
 }
 
@@ -928,8 +966,10 @@ fn resolve_origin_default_branch(
 		&["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
 		git_env,
 	)?;
+
 	if output.status.success() {
 		let remote_head = output_text(&output);
+
 		if let Some(default_branch) = remote_head.strip_prefix("origin/") {
 			return Ok(default_branch.to_owned());
 		}
@@ -1036,11 +1076,13 @@ fn remove_worktree_best_effort(
 }
 
 fn remove_stale_lock_if_needed(path: &Path) -> Result<()> {
-	let Ok(mut file) = fs::File::open(path) else {
+	let Ok(mut file) = File::open(path) else {
 		return Ok(());
 	};
 	let mut contents = String::new();
+
 	file.read_to_string(&mut contents)?;
+
 	let payload = serde_json::from_str::<Value>(&contents).ok();
 	let lock_has_valid_schema =
 		payload.as_ref().and_then(|payload| payload.get("schema").and_then(Value::as_str))
@@ -1100,7 +1142,6 @@ fn wait_for_existing_normalization(
 				false,
 			);
 		}
-
 		if Instant::now() >= deadline {
 			eyre::bail!(
 				"Timed out waiting for existing baseline normalization for `{}` to finish.",
@@ -1240,13 +1281,127 @@ fn output_text(output: &Output) -> String {
 
 #[cfg(test)]
 mod tests {
-	#[cfg(unix)] use std::os::unix::fs::PermissionsExt;
-	use std::{fs, path::Path, process::Command};
+	#[cfg(unix)] use std::os::unix::fs::PermissionsExt as _;
+	use std::{fs, path::Path, process::Command, thread, time::Duration};
 
 	use tempfile::TempDir;
 
-	use super::*;
-	use crate::{config::ServiceConfig, state::StateStore, test_support::TestEnvVarGuard};
+	use crate::{
+		config::ServiceConfig,
+		orchestrator::{
+			BaselineGuardDispatchOutcome,
+			baseline_guard::{
+				self, BASELINE_GUARD_CLEAN_EVENT_TYPE, BASELINE_GUARD_DIRTY_EVENT_TYPE,
+				BASELINE_GUARD_FAILED_EVENT_TYPE, BASELINE_ISSUE_ID,
+				BASELINE_NORMALIZATION_FAILED_EVENT_TYPE, BASELINE_NORMALIZATION_MERGED_EVENT_TYPE,
+				BASELINE_NORMALIZATION_PR_CREATED_EVENT_TYPE,
+				BASELINE_NORMALIZATION_RECHECK_PASSED_EVENT_TYPE,
+				BASELINE_NORMALIZATION_REPO_GATE_FAILED_EVENT_TYPE,
+				BASELINE_NORMALIZATION_REPO_GATE_PASSED_EVENT_TYPE,
+				BASELINE_NORMALIZATION_STARTED_EVENT_TYPE, BaselineGuardContext,
+				BaselineNormalizationLock, BaselineNormalizationRun, BaselineRepoGateCommands,
+				IssueDispatchMode, LOCK_FILE_NAME, LOCK_SCHEMA, WorkflowDocument, eyre, git_ops,
+			},
+		},
+		state::StateStore,
+		test_support::TestEnvVarGuard,
+	};
+
+	struct BaselineGuardFixture {
+		_temp_dir: TempDir,
+		config: ServiceConfig,
+		workflow: WorkflowDocument,
+	}
+
+	impl BaselineGuardFixture {
+		fn new(execution_command_lines: &str) -> Self {
+			Self::new_with_optional_github_command_path(execution_command_lines, None)
+		}
+
+		fn new_with_github_command_path(
+			execution_command_lines: &str,
+			github_command_path: &Path,
+		) -> Self {
+			Self::new_with_optional_github_command_path(
+				execution_command_lines,
+				Some(github_command_path),
+			)
+		}
+
+		fn new_with_optional_github_command_path(
+			execution_command_lines: &str,
+			github_command_path: Option<&Path>,
+		) -> Self {
+			let temp_dir = TempDir::new().expect("temp dir should create");
+			let repo_root = temp_dir.path().join("repo");
+			let remote_root = temp_dir.path().join("origin.git");
+			let config_dir = temp_dir.path().join("config");
+
+			fs::create_dir_all(&repo_root).expect("repo should create");
+			fs::create_dir_all(repo_root.join(".worktrees")).expect("worktrees should create");
+			fs::create_dir_all(&config_dir).expect("config dir should create");
+			fs::write(repo_root.join("README.md"), "baseline\n").expect("readme should write");
+
+			run_git(&repo_root, &["init", "-b", "main"]);
+			run_git(&repo_root, &["config", "user.name", "Decodex Tests"]);
+			run_git(&repo_root, &["config", "user.email", "decodex-tests@example.com"]);
+			run_git(&repo_root, &["config", "commit.gpgsign", "false"]);
+			run_git(&repo_root, &["config", "core.hooksPath", "/dev/null"]);
+			run_git(&repo_root, &["add", "."]);
+			run_git(
+				&repo_root,
+				&[
+					"commit",
+					"-m",
+					r#"{"schema":"decodex/commit/2","change":"Bootstrap test repo","authority":"manual","impact":"compatible"}"#,
+				],
+			);
+			run_git(
+				temp_dir.path(),
+				&["init", "--bare", "-b", "main", baseline_guard::path_arg(&remote_root).as_str()],
+			);
+			run_git(
+				&repo_root,
+				&["remote", "add", "origin", baseline_guard::path_arg(&remote_root).as_str()],
+			);
+			run_git(&repo_root, &["push", "-u", "origin", "main"]);
+
+			fs::write(config_dir.join("WORKFLOW.md"), workflow_markdown(execution_command_lines))
+				.expect("workflow should write");
+
+			let github_command_path_line = github_command_path
+				.map(|path| format!("command_path = \"{}\"\n", path.display()))
+				.unwrap_or_default();
+
+			fs::write(
+				config_dir.join("project.toml"),
+				format!(
+					r#"service_id = "baseline-test"
+
+[tracker]
+api_key_env_var = "BASELINE_GUARD_TEST_LINEAR_TOKEN"
+
+[github]
+token_env_var = "BASELINE_GUARD_TEST_GITHUB_TOKEN"
+{github_command_path_line}
+
+[paths]
+repo_root = "{}"
+worktree_root = ".worktrees"
+"#,
+					repo_root.display()
+				),
+			)
+			.expect("config should write");
+
+			let config = ServiceConfig::from_path(config_dir.join("project.toml"))
+				.expect("config should load");
+			let workflow =
+				WorkflowDocument::from_path(config.workflow_path()).expect("workflow should load");
+
+			Self { _temp_dir: temp_dir, config, workflow }
+		}
+	}
 
 	#[test]
 	fn clean_guard_records_clean_event_and_leaves_no_worktree() {
@@ -1257,7 +1412,7 @@ verify_commands = []"#,
 		);
 		let state_store = StateStore::open_in_memory().expect("state store should open");
 
-		ensure_clean_baseline_before_dispatch(
+		baseline_guard::ensure_clean_baseline_before_dispatch(
 			&fixture.config,
 			&fixture.workflow,
 			&state_store,
@@ -1289,6 +1444,7 @@ verify_commands = []"#,
 
 		fs::write(fixture.config.repo_root().join("README.md"), "remote baseline\n")
 			.expect("readme should write");
+
 		run_git(fixture.config.repo_root(), &["add", "README.md"]);
 		run_git(
 			fixture.config.repo_root(),
@@ -1299,15 +1455,17 @@ verify_commands = []"#,
 			],
 		);
 		run_git(fixture.config.repo_root(), &["push", "origin", "main"]);
+
 		let remote_head = git_capture_plain(fixture.config.repo_root(), &["rev-parse", "HEAD"]);
 
 		run_git(fixture.config.repo_root(), &["reset", "--hard", "HEAD~1"]);
+
 		let stale_local_head =
 			git_capture_plain(fixture.config.repo_root(), &["rev-parse", "HEAD"]);
 
 		assert_ne!(stale_local_head, remote_head);
 
-		let outcome = ensure_clean_baseline_before_dispatch(
+		let outcome = baseline_guard::ensure_clean_baseline_before_dispatch(
 			&fixture.config,
 			&fixture.workflow,
 			&state_store,
@@ -1329,8 +1487,7 @@ verify_commands = []"#,
 verify_commands = []"#,
 		);
 		let state_store = StateStore::open_in_memory().expect("state store should open");
-
-		let error = ensure_clean_baseline_before_dispatch(
+		let error = baseline_guard::ensure_clean_baseline_before_dispatch(
 			&fixture.config,
 			&fixture.workflow,
 			&state_store,
@@ -1347,13 +1504,14 @@ verify_commands = []"#,
 
 		assert_eq!(events.len(), 1);
 		assert_eq!(events[0].event_type(), BASELINE_GUARD_FAILED_EVENT_TYPE);
+
 		let loop_evidence = state_store
 			.project_loop_evidence_snapshot("baseline-test")
 			.expect("loop evidence should load");
 		let mut warnings = Vec::new();
 		let mut warning_details = Vec::new();
 
-		push_baseline_status_projection(
+		baseline_guard::push_baseline_status_projection(
 			&fixture.config,
 			&loop_evidence,
 			&mut warnings,
@@ -1432,7 +1590,9 @@ verify_commands = []"#,
 				.expect("dead lock should be replaced");
 
 		assert!(dead_lock.is_some());
+
 		drop(dead_lock);
+
 		assert!(!lock_path.exists());
 	}
 
@@ -1447,7 +1607,7 @@ verify_commands = []"#,
 			.expect("context should load");
 		let first = BaselineNormalizationRun::new(&fixture.config, &context);
 
-		std::thread::sleep(Duration::from_millis(1));
+		thread::sleep(Duration::from_millis(1));
 
 		let second = BaselineNormalizationRun::new(&fixture.config, &context);
 
@@ -1460,7 +1620,7 @@ verify_commands = []"#,
 		let fixture = BaselineGuardFixture::new("canonicalize_commands = []\nverify_commands = []");
 		let state_store = StateStore::open_in_memory().expect("state store should open");
 
-		ensure_clean_baseline_before_dispatch(
+		baseline_guard::ensure_clean_baseline_before_dispatch(
 			&fixture.config,
 			&fixture.workflow,
 			&state_store,
@@ -1491,7 +1651,7 @@ verify_commands = ["python3 -c \"from pathlib import Path; assert Path('README.m
 		);
 		let state_store = StateStore::open_in_memory().expect("state store should open");
 
-		ensure_clean_baseline_before_dispatch(
+		baseline_guard::ensure_clean_baseline_before_dispatch(
 			&fixture.config,
 			&fixture.workflow,
 			&state_store,
@@ -1553,8 +1713,7 @@ canonicalize_commands = ["python3 -c \"from pathlib import Path; Path('README.md
 verify_commands = ["python3 -c \"from pathlib import Path; assert Path('README.md').read_text() == 'profile-normalized\\n'\""]"#,
 		);
 		let state_store = StateStore::open_in_memory().expect("state store should open");
-
-		let outcome = ensure_clean_baseline_before_dispatch(
+		let outcome = baseline_guard::ensure_clean_baseline_before_dispatch(
 			&fixture.config,
 			&fixture.workflow,
 			&state_store,
@@ -1562,7 +1721,6 @@ verify_commands = ["python3 -c \"from pathlib import Path; assert Path('README.m
 			false,
 		)
 		.expect("baseline guard should not run profile-scoped canonicalize commands");
-
 		let origin_main =
 			git_capture_plain(fixture.config.repo_root(), &["show", "origin/main:README.md"]);
 		let events = state_store
@@ -1612,8 +1770,8 @@ verify_commands = ["cargo make check-b"]"#,
 		.expect("second workflow should parse");
 
 		assert_eq!(
-			workflow_hash(&first).expect("first hash"),
-			workflow_hash(&second).expect("second hash")
+			baseline_guard::workflow_hash(&first).expect("first hash"),
+			baseline_guard::workflow_hash(&second).expect("second hash")
 		);
 	}
 
@@ -1636,7 +1794,7 @@ verify_commands = ["python3 -c \"from pathlib import Path; assert Path('README.m
 			.expect("context should load");
 		let run = BaselineNormalizationRun::new(&fixture.config, &context);
 		let repo_gate = BaselineRepoGateCommands::from_workflow(&fixture.workflow);
-		let head_oid = with_branch_worktree(
+		let head_oid = baseline_guard::with_branch_worktree(
 			fixture.config.repo_root(),
 			&run.path,
 			&run.branch_name,
@@ -1644,9 +1802,15 @@ verify_commands = ["python3 -c \"from pathlib import Path; assert Path('README.m
 			&context.git_env,
 			|| {
 				git_ops::run_canonicalize_commands(&repo_gate.canonicalize_commands, &run.path)?;
-				commit_normalization_diff(&run.path, &context)?;
-				let head_oid = git_capture(&run.path, &["rev-parse", "HEAD"], &context.git_env)?;
-				git_checked(
+				baseline_guard::commit_normalization_diff(&run.path, &context)?;
+
+				let head_oid = baseline_guard::git_capture(
+					&run.path,
+					&["rev-parse", "HEAD"],
+					&context.git_env,
+				)?;
+
+				baseline_guard::git_checked(
 					&run.path,
 					&["push", "-u", "origin", &run.branch_name],
 					"push seeded baseline normalization branch",
@@ -1658,12 +1822,12 @@ verify_commands = ["python3 -c \"from pathlib import Path; assert Path('README.m
 		)
 		.expect("seed normalization branch should succeed");
 
-		record_event(
+		baseline_guard::record_event(
 			&fixture.config,
 			&state_store,
 			&run.run_id,
 			BASELINE_NORMALIZATION_PR_CREATED_EVENT_TYPE,
-			normalization_payload(
+			baseline_guard::normalization_payload(
 				&context,
 				&run,
 				&head_oid,
@@ -1671,8 +1835,7 @@ verify_commands = ["python3 -c \"from pathlib import Path; assert Path('README.m
 			),
 		)
 		.expect("pr-created event should record");
-
-		ensure_clean_baseline_before_dispatch(
+		baseline_guard::ensure_clean_baseline_before_dispatch(
 			&fixture.config,
 			&fixture.workflow,
 			&state_store,
@@ -1701,7 +1864,7 @@ verify_commands = []"#,
 		let context = BaselineGuardContext::new(&fixture.config, &fixture.workflow)
 			.expect("context should load");
 
-		record_event(
+		baseline_guard::record_event(
 			&fixture.config,
 			&state_store,
 			&context.guard_run_id(),
@@ -1709,8 +1872,7 @@ verify_commands = []"#,
 			context.payload(),
 		)
 		.expect("stale clean event should record");
-
-		ensure_clean_baseline_before_dispatch(
+		baseline_guard::ensure_clean_baseline_before_dispatch(
 			&fixture.config,
 			&fixture.workflow,
 			&state_store,
@@ -1747,16 +1909,18 @@ verify_commands = []"#,
 		let context = BaselineGuardContext::new(&fixture.config, &fixture.workflow)
 			.expect("context should load");
 
-		record_event(
+		baseline_guard::record_event(
 			&fixture.config,
 			&state_store,
 			&context.normalization_run_id(),
 			BASELINE_NORMALIZATION_FAILED_EVENT_TYPE,
-			payload_with_error(context.payload(), &eyre::eyre!("transient failure")),
+			baseline_guard::payload_with_error(
+				context.payload(),
+				&eyre::eyre!("transient failure"),
+			),
 		)
 		.expect("failed event should record");
-
-		ensure_clean_baseline_before_dispatch(
+		baseline_guard::ensure_clean_baseline_before_dispatch(
 			&fixture.config,
 			&fixture.workflow,
 			&state_store,
@@ -1796,7 +1960,7 @@ verify_commands = []"#,
 		let lock_path = fixture.config.worktree_root().join(LOCK_FILE_NAME);
 
 		fs::write(&lock_path, "").expect("malformed lock should write");
-		record_event(
+		baseline_guard::record_event(
 			&fixture.config,
 			&state_store,
 			&context.normalization_run_id(),
@@ -1804,8 +1968,7 @@ verify_commands = []"#,
 			context.payload(),
 		)
 		.expect("started event should record");
-
-		ensure_clean_baseline_before_dispatch(
+		baseline_guard::ensure_clean_baseline_before_dispatch(
 			&fixture.config,
 			&fixture.workflow,
 			&state_store,
@@ -1815,6 +1978,7 @@ verify_commands = []"#,
 		.expect("malformed stale lock should not block retry");
 
 		assert!(!lock_path.exists());
+
 		let origin_main =
 			git_capture_plain(fixture.config.repo_root(), &["show", "origin/main:README.md"]);
 
@@ -1835,8 +1999,7 @@ verify_commands = []"#,
 			&fake_gh_path,
 		);
 		let state_store = StateStore::open_in_memory().expect("state store should open");
-
-		let error = ensure_clean_baseline_before_dispatch(
+		let error = baseline_guard::ensure_clean_baseline_before_dispatch(
 			&fixture.config,
 			&fixture.workflow,
 			&state_store,
@@ -1870,8 +2033,7 @@ verify_commands = ["python3 -c \"raise SystemExit(3)\""]"#,
 			&fake_gh_path,
 		);
 		let state_store = StateStore::open_in_memory().expect("state store should open");
-
-		let first_error = ensure_clean_baseline_before_dispatch(
+		let first_error = baseline_guard::ensure_clean_baseline_before_dispatch(
 			&fixture.config,
 			&fixture.workflow,
 			&state_store,
@@ -1898,7 +2060,7 @@ verify_commands = ["python3 -c \"raise SystemExit(3)\""]"#,
 					== BASELINE_NORMALIZATION_REPO_GATE_FAILED_EVENT_TYPE)
 		);
 
-		let second_error = ensure_clean_baseline_before_dispatch(
+		let second_error = baseline_guard::ensure_clean_baseline_before_dispatch(
 			&fixture.config,
 			&fixture.workflow,
 			&state_store,
@@ -1917,96 +2079,6 @@ verify_commands = ["python3 -c \"raise SystemExit(3)\""]"#,
 				.iter()
 				.any(|event| event.event_type() == BASELINE_NORMALIZATION_PR_CREATED_EVENT_TYPE)
 		);
-	}
-
-	struct BaselineGuardFixture {
-		_temp_dir: TempDir,
-		config: ServiceConfig,
-		workflow: WorkflowDocument,
-	}
-	impl BaselineGuardFixture {
-		fn new(execution_command_lines: &str) -> Self {
-			Self::new_with_optional_github_command_path(execution_command_lines, None)
-		}
-
-		fn new_with_github_command_path(
-			execution_command_lines: &str,
-			github_command_path: &Path,
-		) -> Self {
-			Self::new_with_optional_github_command_path(
-				execution_command_lines,
-				Some(github_command_path),
-			)
-		}
-
-		fn new_with_optional_github_command_path(
-			execution_command_lines: &str,
-			github_command_path: Option<&Path>,
-		) -> Self {
-			let temp_dir = TempDir::new().expect("temp dir should create");
-			let repo_root = temp_dir.path().join("repo");
-			let remote_root = temp_dir.path().join("origin.git");
-			let config_dir = temp_dir.path().join("config");
-
-			fs::create_dir_all(&repo_root).expect("repo should create");
-			fs::create_dir_all(repo_root.join(".worktrees")).expect("worktrees should create");
-			fs::create_dir_all(&config_dir).expect("config dir should create");
-			fs::write(repo_root.join("README.md"), "baseline\n").expect("readme should write");
-
-			run_git(&repo_root, &["init", "-b", "main"]);
-			run_git(&repo_root, &["config", "user.name", "Decodex Tests"]);
-			run_git(&repo_root, &["config", "user.email", "decodex-tests@example.com"]);
-			run_git(&repo_root, &["config", "commit.gpgsign", "false"]);
-			run_git(&repo_root, &["config", "core.hooksPath", "/dev/null"]);
-			run_git(&repo_root, &["add", "."]);
-			run_git(
-				&repo_root,
-				&[
-					"commit",
-					"-m",
-					r#"{"schema":"decodex/commit/2","change":"Bootstrap test repo","authority":"manual","impact":"compatible"}"#,
-				],
-			);
-			run_git(
-				temp_dir.path(),
-				&["init", "--bare", "-b", "main", path_arg(&remote_root).as_str()],
-			);
-			run_git(&repo_root, &["remote", "add", "origin", path_arg(&remote_root).as_str()]);
-			run_git(&repo_root, &["push", "-u", "origin", "main"]);
-
-			fs::write(config_dir.join("WORKFLOW.md"), workflow_markdown(execution_command_lines))
-				.expect("workflow should write");
-			let github_command_path_line = github_command_path
-				.map(|path| format!("command_path = \"{}\"\n", path.display()))
-				.unwrap_or_default();
-			fs::write(
-				config_dir.join("project.toml"),
-				format!(
-					r#"service_id = "baseline-test"
-
-[tracker]
-api_key_env_var = "BASELINE_GUARD_TEST_LINEAR_TOKEN"
-
-[github]
-token_env_var = "BASELINE_GUARD_TEST_GITHUB_TOKEN"
-{github_command_path_line}
-
-[paths]
-repo_root = "{}"
-worktree_root = ".worktrees"
-"#,
-					repo_root.display()
-				),
-			)
-			.expect("config should write");
-
-			let config = ServiceConfig::from_path(config_dir.join("project.toml"))
-				.expect("config should load");
-			let workflow =
-				WorkflowDocument::from_path(config.workflow_path()).expect("workflow should load");
-
-			Self { _temp_dir: temp_dir, config, workflow }
-		}
 	}
 
 	fn write_fake_gh(path: &Path) {
@@ -2061,7 +2133,9 @@ exit 1
 		#[cfg(unix)]
 		{
 			let mut permissions = fs::metadata(path).expect("fake gh metadata").permissions();
+
 			permissions.set_mode(0o755);
+
 			fs::set_permissions(path, permissions).expect("fake gh executable");
 		}
 	}
@@ -2122,7 +2196,9 @@ exit 1
 		#[cfg(unix)]
 		{
 			let mut permissions = fs::metadata(path).expect("fake gh metadata").permissions();
+
 			permissions.set_mode(0o755);
+
 			fs::set_permissions(path, permissions).expect("fake gh executable");
 		}
 	}

--- a/apps/decodex/src/orchestrator/daemon/spawn.rs
+++ b/apps/decodex/src/orchestrator/daemon/spawn.rs
@@ -12,8 +12,9 @@ use std::path::Path;
 
 use crate::{
 	orchestrator::{
-		self, DaemonRunChild, IssueDispatchMode, IssueTracker, PullRequestReviewStateInspector,
-		RUN_OPERATION_AGENT_RUN, Result, RetryQueue, StateStore, daemon::DaemonTickRuntimeContext,
+		self, BaselineGuardDispatchOutcome, DaemonRunChild, IssueDispatchMode, IssueTracker,
+		PullRequestReviewStateInspector, RUN_OPERATION_AGENT_RUN, Result, RetryQueue, RunSummary,
+		StateStore, daemon::DaemonTickRuntimeContext,
 	},
 	state,
 };
@@ -37,116 +38,14 @@ where
 	)?;
 
 	match next_run {
-		Some((summary, from_retry_queue)) => {
-			if summary.dispatch_mode != IssueDispatchMode::Closeout {
-				orchestrator::ensure_project_has_no_merged_worktree_cleanup_debt(context.project)?;
-			}
-
-			orchestrator::validate_workflow_read_first_files(context.project, context.workflow)?;
-
-			state_store.configure_dispatch_slot_root(
-				context.project.service_id(),
-				context.project.worktree_root(),
-			)?;
-
-			if orchestrator::ensure_clean_baseline_before_dispatch(
-				context.project,
-				context.workflow,
-				state_store,
-				summary.dispatch_mode,
-				false,
-			)? == orchestrator::BaselineGuardDispatchOutcome::NormalizedMain
-			{
-				return Ok(false);
-			}
-
-			if !state_store.try_acquire_lease(
-				context.project.service_id(),
-				&summary.issue_id,
-				&summary.run_id,
-				&summary.issue_state,
-			)? {
-				return Ok(false);
-			}
-
-			let daemon_spawn_state = materialize::materialize_daemon_spawn_state(
-				context.project,
-				context.workflow,
-				state_store,
-				&summary,
-			)
-			.inspect_err(|_error| {
-				let _ = state_store.clear_lease(&summary.issue_id);
-			})?;
-
-			state_store.record_run_attempt(
-				&summary.run_id,
-				&summary.issue_id,
-				summary.attempt_number,
-				"starting",
-			)?;
-			state_store.upsert_worktree(
-				context.project.service_id(),
-				&summary.issue_id,
-				&daemon_spawn_state.worktree.branch_name,
-				&daemon_spawn_state.worktree.path.display().to_string(),
-			)?;
-
-			if let Some(program_dispatch) = summary.program_dispatch.as_ref() {
-				orchestrator::record_program_dispatch_selected_for_summary(
-					state_store,
-					&summary,
-					program_dispatch,
-				)?;
-			}
-
-			let mut child = child::spawn_planned_daemon_child(
-				config_path,
-				state_store,
-				context.workflow,
-				&summary,
-				daemon_spawn_state.retry_budget_base,
-			)?;
-
-			if let Err(error) = state::write_run_operation_marker_for_process(
-				&daemon_spawn_state.worktree.path,
-				&summary.run_id,
-				summary.attempt_number,
-				child.id(),
-				RUN_OPERATION_AGENT_RUN,
-			) {
-				let _ = child.kill();
-				let _ = child.wait();
-				let _ = state_store.update_run_status(&summary.run_id, "failed");
-				let _ = state_store.clear_lease(&summary.issue_id);
-
-				return Err(error);
-			}
-
-			state_store.update_run_status(&summary.run_id, "running")?;
-
-			tracing::info!(
-				issue = summary.issue_identifier,
-				worktree = %daemon_spawn_state.worktree.path.display(),
-				retry = from_retry_queue,
-				"Spawned control-plane child for current issue lane."
-			);
-
-			active_children.push(DaemonRunChild {
-				child,
-				issue_id: summary.issue_id,
-				run_id: summary.run_id,
-				attempt_number: summary.attempt_number,
-				initial_issue_state: summary.initial_issue_state,
-				#[cfg(test)]
-				retry_project_slug: String::new(),
-				dispatch_mode: summary.dispatch_mode,
-				from_retry_queue,
-				workflow: context.workflow.clone(),
-			});
-
-			Ok(true)
-		},
+		Some((summary, from_retry_queue)) => spawn_planned_next_daemon_child(
+			config_path,
+			state_store,
+			active_children,
+			context,
+			summary,
+			from_retry_queue,
+		),
 		None => {
 			if retry_queue.is_empty() {
 				tracing::debug!("Daemon tick found no eligible issue.");
@@ -157,4 +56,124 @@ where
 			Ok(false)
 		},
 	}
+}
+
+fn spawn_planned_next_daemon_child<T>(
+	config_path: &Path,
+	state_store: &StateStore,
+	active_children: &mut Vec<DaemonRunChild>,
+	context: &DaemonTickRuntimeContext<'_, T, impl PullRequestReviewStateInspector>,
+	summary: RunSummary,
+	from_retry_queue: bool,
+) -> Result<bool>
+where
+	T: IssueTracker,
+{
+	if summary.dispatch_mode != IssueDispatchMode::Closeout {
+		orchestrator::ensure_project_has_no_merged_worktree_cleanup_debt(context.project)?;
+	}
+
+	orchestrator::validate_workflow_read_first_files(context.project, context.workflow)?;
+
+	state_store.configure_dispatch_slot_root(
+		context.project.service_id(),
+		context.project.worktree_root(),
+	)?;
+
+	if orchestrator::ensure_clean_baseline_before_dispatch(
+		context.project,
+		context.workflow,
+		state_store,
+		summary.dispatch_mode,
+		false,
+	)? == BaselineGuardDispatchOutcome::NormalizedMain
+	{
+		return Ok(false);
+	}
+	if !state_store.try_acquire_lease(
+		context.project.service_id(),
+		&summary.issue_id,
+		&summary.run_id,
+		&summary.issue_state,
+	)? {
+		return Ok(false);
+	}
+
+	let daemon_spawn_state = materialize::materialize_daemon_spawn_state(
+		context.project,
+		context.workflow,
+		state_store,
+		&summary,
+	)
+	.inspect_err(|_error| {
+		let _ = state_store.clear_lease(&summary.issue_id);
+	})?;
+
+	state_store.record_run_attempt(
+		&summary.run_id,
+		&summary.issue_id,
+		summary.attempt_number,
+		"starting",
+	)?;
+	state_store.upsert_worktree(
+		context.project.service_id(),
+		&summary.issue_id,
+		&daemon_spawn_state.worktree.branch_name,
+		&daemon_spawn_state.worktree.path.display().to_string(),
+	)?;
+
+	if let Some(program_dispatch) = summary.program_dispatch.as_ref() {
+		orchestrator::record_program_dispatch_selected_for_summary(
+			state_store,
+			&summary,
+			program_dispatch,
+		)?;
+	}
+
+	let mut child = child::spawn_planned_daemon_child(
+		config_path,
+		state_store,
+		context.workflow,
+		&summary,
+		daemon_spawn_state.retry_budget_base,
+	)?;
+
+	if let Err(error) = state::write_run_operation_marker_for_process(
+		&daemon_spawn_state.worktree.path,
+		&summary.run_id,
+		summary.attempt_number,
+		child.id(),
+		RUN_OPERATION_AGENT_RUN,
+	) {
+		let _ = child.kill();
+		let _ = child.wait();
+		let _ = state_store.update_run_status(&summary.run_id, "failed");
+		let _ = state_store.clear_lease(&summary.issue_id);
+
+		return Err(error);
+	}
+
+	state_store.update_run_status(&summary.run_id, "running")?;
+
+	tracing::info!(
+		issue = summary.issue_identifier,
+		worktree = %daemon_spawn_state.worktree.path.display(),
+		retry = from_retry_queue,
+		"Spawned control-plane child for current issue lane."
+	);
+
+	active_children.push(DaemonRunChild {
+		child,
+		issue_id: summary.issue_id,
+		run_id: summary.run_id,
+		attempt_number: summary.attempt_number,
+		initial_issue_state: summary.initial_issue_state,
+		#[cfg(test)]
+		retry_project_slug: String::new(),
+		dispatch_mode: summary.dispatch_mode,
+		from_retry_queue,
+		workflow: context.workflow.clone(),
+	});
+
+	Ok(true)
 }

--- a/apps/decodex/src/orchestrator/execution_closeout.rs
+++ b/apps/decodex/src/orchestrator/execution_closeout.rs
@@ -39,7 +39,9 @@ where
 	tracker_tool_bridge.apply_validated_deterministic_closeout(pull_request.clone())?;
 
 	orchestrator::cleanup_completed_post_review_lane(project, workflow, state_store, issue_run)?;
+
 	tracker_tool_bridge.record_validated_deterministic_cleanup_completion(&pull_request)?;
+
 	orchestrator::write_cleanup_complete_lifecycle_event(
 		tracker,
 		project,

--- a/apps/decodex/src/orchestrator/git_ops/rewrite/outcome.rs
+++ b/apps/decodex/src/orchestrator/git_ops/rewrite/outcome.rs
@@ -145,7 +145,6 @@ fn repo_gate_tracked_rewrite_decision(
 			rewritten_files,
 		));
 	}
-
 	if owned {
 		Some(RepoGateTrackedRewriteDecision::lane_owned_requires_clean_boundary(rewritten_files))
 	} else {

--- a/apps/decodex/src/orchestrator/kernel/lifecycle.rs
+++ b/apps/decodex/src/orchestrator/kernel/lifecycle.rs
@@ -68,7 +68,7 @@ pub(crate) struct PreviousLifecycleAuthority<'a> {
 	pub(crate) next_state: &'a str,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub(crate) struct LifecycleAuthorityRecord {
 	pub(crate) schema_version: String,
 	pub(crate) project_id: String,
@@ -99,7 +99,7 @@ pub(crate) struct LifecycleAuthorityRecord {
 	pub(crate) decided_at: String,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub(crate) struct LifecycleEventEnvelope {
 	pub(crate) schema_version: String,
 	pub(crate) event_type: String,
@@ -129,6 +129,7 @@ pub(crate) fn decide_lifecycle_transition(input: LifecycleDecisionInput<'_>) -> 
 	let next_action =
 		lifecycle_next_action(input.evidence_kind, input.outcome, &next_state, &phase);
 	let mut source_evidence_refs = input.facts.source_evidence_refs.clone();
+
 	source_evidence_refs.push(format!(
 		"lifecycle_evidence:{}:{}",
 		input.evidence_kind.as_str(),
@@ -285,67 +286,65 @@ mod tests {
 	use crate::{
 		config::ReviewLevel,
 		orchestrator::{
-			PullRequestReviewState,
+			self, PostReviewLifecycleFactsInput, PullRequestReviewState,
 			kernel::lifecycle::{
 				LIFECYCLE_EVENT_SCHEMA_VERSION, LifecycleDecisionInput, LifecycleEvidenceKind,
-				LifecycleOutcome, decide_lifecycle_transition,
+				LifecycleOutcome,
 			},
 		},
 		state::{ReviewLifecycleHandoffFixture, ReviewLifecycleRecord},
 	};
 
-	use crate::orchestrator::{PostReviewLifecycleFactsInput, build_post_review_lifecycle_facts};
-
 	#[test]
 	fn lifecycle_kernel_is_pure_and_emits_authority_record_envelope() {
-		let facts = build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
-			project_id: "pubfi",
-			issue_id: "PUB-101",
-			review_lifecycle: Some(&ReviewLifecycleRecord::from_test_lifecycle_fixtures(
-				&ReviewLifecycleHandoffFixture::new(
-					"run-1",
-					1,
-					"x/pub-101",
-					"https://github.com/hack-ink/decodex/pull/101",
-					"main",
-					"x/pub-101",
-					"head-sha",
-				),
-				None,
-			)),
-			review_state: &PullRequestReviewState {
-				url: String::from("https://github.com/hack-ink/decodex/pull/101"),
-				state: String::from("OPEN"),
-				is_draft: false,
-				review_decision: Some(String::from("APPROVED")),
-				merge_commit_allowed: true,
-				pending_review_requests: 0,
-				mergeable: String::from("MERGEABLE"),
-				merge_state_status: String::from("CLEAN"),
-				base_ref_oid: Some(String::from("base-sha")),
-				head_ref_name: String::from("x/pub-101"),
-				head_ref_oid: String::from("head-sha"),
-				merge_commit_oid: None,
-				head_repository_name: None,
-				head_repository_owner: None,
-				status_check_rollup_state: Some(String::from("SUCCESS")),
-				required_status_contexts: Vec::new(),
-				unresolved_review_threads: 0,
-				issue_description_external_review_thumbs_up_count: 0,
-				issue_comments: Vec::new(),
-				reviews: Vec::new(),
-			},
-			worktree_path: Path::new("/tmp/pubfi"),
-			review_level: ReviewLevel::Standard,
-			phase: "request_pending",
-			landing_state: None,
-			closeout_state: None,
-			validated_head_sha: Some("head-sha"),
-			review_checkpoint_phase: Some("handoff"),
-			review_checkpoint_status: Some("clean"),
-		});
-
-		let decision = decide_lifecycle_transition(LifecycleDecisionInput {
+		let facts =
+			orchestrator::build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
+				project_id: "pubfi",
+				issue_id: "PUB-101",
+				review_lifecycle: Some(&ReviewLifecycleRecord::from_test_lifecycle_fixtures(
+					&ReviewLifecycleHandoffFixture::new(
+						"run-1",
+						1,
+						"x/pub-101",
+						"https://github.com/hack-ink/decodex/pull/101",
+						"main",
+						"x/pub-101",
+						"head-sha",
+					),
+					None,
+				)),
+				review_state: &PullRequestReviewState {
+					url: String::from("https://github.com/hack-ink/decodex/pull/101"),
+					state: String::from("OPEN"),
+					is_draft: false,
+					review_decision: Some(String::from("APPROVED")),
+					merge_commit_allowed: true,
+					pending_review_requests: 0,
+					mergeable: String::from("MERGEABLE"),
+					merge_state_status: String::from("CLEAN"),
+					base_ref_oid: Some(String::from("base-sha")),
+					head_ref_name: String::from("x/pub-101"),
+					head_ref_oid: String::from("head-sha"),
+					merge_commit_oid: None,
+					head_repository_name: None,
+					head_repository_owner: None,
+					status_check_rollup_state: Some(String::from("SUCCESS")),
+					required_status_contexts: Vec::new(),
+					unresolved_review_threads: 0,
+					issue_description_external_review_thumbs_up_count: 0,
+					issue_comments: Vec::new(),
+					reviews: Vec::new(),
+				},
+				worktree_path: Path::new("/tmp/pubfi"),
+				review_level: ReviewLevel::Standard,
+				phase: "request_pending",
+				landing_state: None,
+				closeout_state: None,
+				validated_head_sha: Some("head-sha"),
+				review_checkpoint_phase: Some("handoff"),
+				review_checkpoint_status: Some("clean"),
+			});
+		let decision = super::decide_lifecycle_transition(LifecycleDecisionInput {
 			facts: &facts,
 			previous: None,
 			evidence_kind: LifecycleEvidenceKind::LandingReadback,

--- a/apps/decodex/src/orchestrator/lane_decision/model.rs
+++ b/apps/decodex/src/orchestrator/lane_decision/model.rs
@@ -51,23 +51,6 @@ pub(in crate::orchestrator) struct LaneDecisionSnapshot {
 	pub(in crate::orchestrator) ambiguous_lineage: bool,
 	pub(in crate::orchestrator) terminal_evidence_present: bool,
 }
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(in crate::orchestrator) struct RepoGateFailureSignal {
-	pub(in crate::orchestrator) disposition: RepoGateFailureDisposition,
-	pub(in crate::orchestrator) error_class: &'static str,
-	pub(in crate::orchestrator) scope_envelope_violation: bool,
-}
-impl RepoGateFailureSignal {
-	pub(in crate::orchestrator) const fn new(
-		disposition: RepoGateFailureDisposition,
-		error_class: &'static str,
-		scope_envelope_violation: bool,
-	) -> Self {
-		Self { disposition, error_class, scope_envelope_violation }
-	}
-}
-
 impl LaneDecisionSnapshot {
 	#[allow(clippy::too_many_arguments)]
 	pub(in crate::orchestrator) fn validation_evidence(
@@ -158,6 +141,22 @@ impl LaneDecisionSnapshot {
 			ambiguous_lineage: false,
 			terminal_evidence_present: false,
 		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::orchestrator) struct RepoGateFailureSignal {
+	pub(in crate::orchestrator) disposition: RepoGateFailureDisposition,
+	pub(in crate::orchestrator) error_class: &'static str,
+	pub(in crate::orchestrator) scope_envelope_violation: bool,
+}
+impl RepoGateFailureSignal {
+	pub(in crate::orchestrator) const fn new(
+		disposition: RepoGateFailureDisposition,
+		error_class: &'static str,
+		scope_envelope_violation: bool,
+	) -> Self {
+		Self { disposition, error_class, scope_envelope_violation }
 	}
 }
 

--- a/apps/decodex/src/orchestrator/lane_decision/projection.rs
+++ b/apps/decodex/src/orchestrator/lane_decision/projection.rs
@@ -65,6 +65,7 @@ fn project_lane_reason(
 		if snapshot.repo_gate_error_class == Some("repo_gate_lane_external_tracked_rewrite") {
 			return "repo-gate lane-external tracked rewrite requires project cleanup or explicit scoped-gate authority";
 		}
+
 		return match disposition {
 			RepoGateFailureDisposition::ContinueRepair =>
 				"repo-gate failure remains an issue-local repair",

--- a/apps/decodex/src/orchestrator/post_review_facts.rs
+++ b/apps/decodex/src/orchestrator/post_review_facts.rs
@@ -45,6 +45,7 @@ impl RuntimeReviewGateState {
 		if validated_head_sha.is_none_or(str::is_empty) {
 			return Self::WorktreeHeadMissing;
 		}
+
 		match checkpoint_status {
 			None => Self::Pending,
 			Some("clean") => Self::Clean,
@@ -103,6 +104,7 @@ pub(crate) fn build_post_review_lifecycle_facts(
 		input.validated_head_sha.unwrap_or(input.review_state.head_ref_oid.as_str()).to_owned();
 	let mut source_evidence_refs =
 		vec![format!("pr_readback:{}:{}", input.review_state.url, input.review_state.head_ref_oid)];
+
 	if let Some(lifecycle) = input.review_lifecycle {
 		source_evidence_refs.push(format!(
 			"review_lifecycle:{}:{}:{}",
@@ -111,6 +113,7 @@ pub(crate) fn build_post_review_lifecycle_facts(
 			lifecycle.pr_head_oid()
 		));
 	}
+
 	if input.review_checkpoint_status.is_some() {
 		source_evidence_refs.push(format!(
 			"review_checkpoint:{}:{}:{}",
@@ -210,8 +213,10 @@ pub(crate) fn worktree_has_review_blocking_changes(worktree_path: &Path) -> Resu
 		.arg(worktree_path)
 		.args(["status", "--porcelain=v1", "--untracked-files=all"])
 		.output()?;
+
 	if !output.status.success() {
 		let stderr = String::from_utf8_lossy(&output.stderr);
+
 		eyre::bail!(
 			"Failed to inspect review-blocking worktree status in `{}`: {}",
 			worktree_path.display(),
@@ -220,6 +225,7 @@ pub(crate) fn worktree_has_review_blocking_changes(worktree_path: &Path) -> Resu
 	}
 
 	let status = String::from_utf8(output.stdout)?;
+
 	Ok(status
 		.lines()
 		.map(str::trim)
@@ -229,9 +235,11 @@ pub(crate) fn worktree_has_review_blocking_changes(worktree_path: &Path) -> Resu
 
 #[cfg(test)]
 mod tests {
-	use super::*;
 	use crate::{
-		orchestrator::PullRequestReviewState,
+		orchestrator::{
+			PullRequestReviewState, RuntimeReviewGateState,
+			post_review_facts::{self, Path, PostReviewLifecycleFactsInput, ReviewLevel},
+		},
 		state::{
 			ReviewLifecycleHandoffFixture, ReviewLifecycleRecord, ReviewPolicyCheckpointInput,
 			StateStore,
@@ -271,23 +279,23 @@ mod tests {
 			"x/pub-101",
 			"head-sha",
 		);
-
-		let facts = build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
-			project_id: "pubfi",
-			issue_id: "PUB-101",
-			review_lifecycle: Some(&ReviewLifecycleRecord::from_test_lifecycle_fixtures(
-				&handoff, None,
-			)),
-			review_state: &review_state,
-			worktree_path: Path::new("/tmp/pubfi"),
-			review_level: ReviewLevel::Standard,
-			phase: "request_pending",
-			landing_state: None,
-			closeout_state: None,
-			validated_head_sha: Some("head-sha"),
-			review_checkpoint_phase: Some("handoff"),
-			review_checkpoint_status: Some("clean"),
-		});
+		let facts =
+			post_review_facts::build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
+				project_id: "pubfi",
+				issue_id: "PUB-101",
+				review_lifecycle: Some(&ReviewLifecycleRecord::from_test_lifecycle_fixtures(
+					&handoff, None,
+				)),
+				review_state: &review_state,
+				worktree_path: Path::new("/tmp/pubfi"),
+				review_level: ReviewLevel::Standard,
+				phase: "request_pending",
+				landing_state: None,
+				closeout_state: None,
+				validated_head_sha: Some("head-sha"),
+				review_checkpoint_phase: Some("handoff"),
+				review_checkpoint_status: Some("clean"),
+			});
 
 		assert_eq!(facts.project_id, "pubfi");
 		assert_eq!(facts.issue_id, "PUB-101");
@@ -339,7 +347,7 @@ mod tests {
 			})
 			.expect("handoff checkpoint should persist");
 
-		let checkpoint = runtime_review_checkpoint_status_for_head(
+		let checkpoint = post_review_facts::runtime_review_checkpoint_status_for_head(
 			&state_store,
 			"pubfi",
 			"PUB-101",

--- a/apps/decodex/src/orchestrator/retained_review_orchestration/admin_merge.rs
+++ b/apps/decodex/src/orchestrator/retained_review_orchestration/admin_merge.rs
@@ -6,10 +6,12 @@ use crate::{
 	commit_message,
 	orchestrator::{
 		self, EXTERNAL_REVIEW_MERGE_VISIBILITY_TIMEOUT_SECS, PostReviewLifecycleFactsInput,
-		build_post_review_lifecycle_facts,
-		kernel::lifecycle::{
-			LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome,
-			PreviousLifecycleAuthority, decide_lifecycle_transition,
+		kernel::{
+			lifecycle,
+			lifecycle::{
+				LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome,
+				PreviousLifecycleAuthority,
+			},
 		},
 		retained_review_orchestration,
 		retained_review_orchestration::{
@@ -17,7 +19,6 @@ use crate::{
 			RetainedAdminMergeReasons, RetainedReviewLane, RetainedReviewRuntime, ServiceConfig,
 			attention, eyre, github,
 		},
-		runtime_review_checkpoint_status_for_head,
 	},
 };
 
@@ -39,77 +40,23 @@ where
 		CommandIntentKind::StartRetainedLanding,
 	)?;
 
-	if let Some(reason) = orchestrator::authority_boundary_landing_requirement(
-		&lane.snapshot,
-		Some(PostReviewRuntimeState {
-			state_store: runtime.state_store,
-			project_id: runtime.project.service_id(),
-			review_level: runtime.project.codex().review_level(),
-		}),
-	)? {
-		tracing::info!(
-			project_id = runtime.project.service_id(),
-			issue_id = lane.snapshot.issue.id,
-			issue = lane.snapshot.issue.identifier,
-			reason,
-			"Retained admin merge is waiting for authority-boundary landing clearance."
-		);
-
+	if retained_admin_merge_waits_for_authority_boundary(runtime, lane)? {
 		return Ok(());
-	}
-
+	};
 	if !lane.review_state.merge_commit_allowed {
-		record_retained_landing_decision(
+		return apply_retained_admin_merge_attention(
 			runtime,
 			lane,
-			LifecycleEvidenceKind::LandingReadback,
 			LifecycleOutcome::NeedsManualAttention,
-			None,
 			"manual_attention_required",
-			"not_started",
-			reasons.admin_merge_unavailable,
-		)?;
-
-		return retained_review_orchestration::apply_passive_retained_manual_attention(
-			attention::passive_attention_runtime(runtime),
-			&lane.snapshot.issue,
-			&lane.snapshot.worktree,
-			lane.lifecycle_record(),
 			reasons.admin_merge_unavailable,
 		);
 	}
 
-	let merge_subject = match retained_review_merge_subject(lane) {
-		Ok(subject) => subject,
-		Err(error) => {
-			tracing::warn!(
-				issue_id = lane.snapshot.issue.id,
-				issue = lane.snapshot.issue.identifier,
-				branch = lane.snapshot.worktree.branch_name(),
-				?error,
-				"Retained admin merge could not derive a compliant landed change record."
-			);
-
-			record_retained_landing_decision(
-				runtime,
-				lane,
-				LifecycleEvidenceKind::LandingReadback,
-				LifecycleOutcome::NeedsManualAttention,
-				None,
-				"manual_attention_required",
-				"not_started",
-				"retained_admin_merge_subject_unavailable",
-			)?;
-
-			return retained_review_orchestration::apply_passive_retained_manual_attention(
-				attention::passive_attention_runtime(runtime),
-				&lane.snapshot.issue,
-				&lane.snapshot.worktree,
-				lane.lifecycle_record(),
-				"retained_admin_merge_subject_unavailable",
-			);
-		},
+	let Some(merge_subject) = retained_admin_merge_subject_or_attention(runtime, lane)? else {
+		return Ok(());
 	};
+
 	record_retained_landing_decision(
 		runtime,
 		lane,
@@ -120,12 +67,114 @@ where
 		"not_started",
 		reasons.start_landing,
 	)?;
-	let github_token = retained_review_github_token(runtime.project, &mut *runtime.github_token)?;
-	let merge_succeeded = match github::admin_merge_pull_request(
+
+	let github_token =
+		retained_review_github_token(runtime.project, &mut *runtime.github_token)?.to_owned();
+
+	if retained_admin_merge_succeeded(runtime, lane, &merge_subject, &github_token) {
+		return record_retained_admin_merge_success(runtime, lane, &github_token);
+	}
+
+	apply_retained_admin_merge_attention(
+		runtime,
+		lane,
+		LifecycleOutcome::Failed,
+		"failed",
+		reasons.admin_merge_failed,
+	)
+}
+
+pub(super) fn retained_review_github_token<'a>(
+	project: &ServiceConfig,
+	github_token: &'a mut Option<String>,
+) -> Result<&'a str> {
+	if github_token.is_none() {
+		*github_token = Some(orchestrator::resolve_configured_env_var(
+			"github.token_env_var",
+			Some(project.github().token_env_var()),
+		)?);
+	}
+
+	github_token.as_deref().ok_or_else(|| {
+		eyre::eyre!("Retained review orchestration requires a configured GitHub token.")
+	})
+}
+
+fn retained_admin_merge_waits_for_authority_boundary<T>(
+	runtime: &RetainedReviewRuntime<'_, T>,
+	lane: &RetainedReviewLane,
+) -> Result<bool>
+where
+	T: IssueTracker,
+{
+	let Some(reason) = orchestrator::authority_boundary_landing_requirement(
+		&lane.snapshot,
+		Some(PostReviewRuntimeState {
+			state_store: runtime.state_store,
+			project_id: runtime.project.service_id(),
+			review_level: runtime.project.codex().review_level(),
+		}),
+	)?
+	else {
+		return Ok(false);
+	};
+
+	tracing::info!(
+		project_id = runtime.project.service_id(),
+		issue_id = lane.snapshot.issue.id,
+		issue = lane.snapshot.issue.identifier,
+		reason,
+		"Retained admin merge is waiting for authority-boundary landing clearance."
+	);
+
+	Ok(true)
+}
+
+fn retained_admin_merge_subject_or_attention<T>(
+	runtime: &RetainedReviewRuntime<'_, T>,
+	lane: &RetainedReviewLane,
+) -> Result<Option<String>>
+where
+	T: IssueTracker,
+{
+	match retained_review_merge_subject(lane) {
+		Ok(subject) => Ok(Some(subject)),
+		Err(error) => {
+			tracing::warn!(
+				issue_id = lane.snapshot.issue.id,
+				issue = lane.snapshot.issue.identifier,
+				branch = lane.snapshot.worktree.branch_name(),
+				?error,
+				"Retained admin merge could not derive a compliant landed change record."
+			);
+
+			apply_retained_admin_merge_attention(
+				runtime,
+				lane,
+				LifecycleOutcome::NeedsManualAttention,
+				"manual_attention_required",
+				"retained_admin_merge_subject_unavailable",
+			)?;
+
+			Ok(None)
+		},
+	}
+}
+
+fn retained_admin_merge_succeeded<T>(
+	runtime: &RetainedReviewRuntime<'_, T>,
+	lane: &RetainedReviewLane,
+	merge_subject: &str,
+	github_token: &str,
+) -> bool
+where
+	T: IssueTracker,
+{
+	match github::admin_merge_pull_request(
 		lane.snapshot.worktree.worktree_path(),
 		lane.review_state.url.as_str(),
 		lane.lifecycle_record().head_sha(),
-		Some(merge_subject.as_str()),
+		Some(merge_subject),
 		github_token,
 		runtime.project.github().command_path(),
 	) {
@@ -140,68 +189,75 @@ where
 			),
 			Ok(true)
 		),
-	};
-
-	if merge_succeeded {
-		let merge_commit = match github::wait_for_pull_request_merge_commit(
-			lane.snapshot.worktree.worktree_path(),
-			lane.review_state.url.as_str(),
-			github_token,
-			Duration::from_secs(EXTERNAL_REVIEW_MERGE_VISIBILITY_TIMEOUT_SECS as u64),
-			runtime.project.github().command_path(),
-		) {
-			Ok(merge_commit) => merge_commit,
-			Err(error) => {
-				record_retained_landing_decision(
-					runtime,
-					lane,
-					LifecycleEvidenceKind::LandingReadback,
-					LifecycleOutcome::NeedsManualAttention,
-					None,
-					"readback_unavailable",
-					"not_started",
-					"retained_admin_merge_readback_unavailable",
-				)?;
-				tracing::warn!(
-					issue_id = lane.snapshot.issue.id,
-					issue = lane.snapshot.issue.identifier,
-					pr_url = lane.review_state.url,
-					?error,
-					"Retained admin merge succeeded, but merge commit readback is unavailable."
-				);
-
-				return retained_review_orchestration::apply_passive_retained_manual_attention(
-					attention::passive_attention_runtime(runtime),
-					&lane.snapshot.issue,
-					&lane.snapshot.worktree,
-					lane.lifecycle_record(),
-					"retained_admin_merge_readback_unavailable",
-				);
-			},
-		};
-		record_retained_landing_decision(
-			runtime,
-			lane,
-			LifecycleEvidenceKind::LandingReadback,
-			LifecycleOutcome::Succeeded,
-			Some(merge_commit.as_str()),
-			"landed",
-			"not_started",
-			"retained_admin_merge_readback",
-		)?;
-
-		return Ok(());
 	}
+}
+
+fn record_retained_admin_merge_success<T>(
+	runtime: &RetainedReviewRuntime<'_, T>,
+	lane: &RetainedReviewLane,
+	github_token: &str,
+) -> Result<()>
+where
+	T: IssueTracker,
+{
+	let merge_commit = match github::wait_for_pull_request_merge_commit(
+		lane.snapshot.worktree.worktree_path(),
+		lane.review_state.url.as_str(),
+		github_token,
+		Duration::from_secs(EXTERNAL_REVIEW_MERGE_VISIBILITY_TIMEOUT_SECS as u64),
+		runtime.project.github().command_path(),
+	) {
+		Ok(merge_commit) => merge_commit,
+		Err(error) => {
+			tracing::warn!(
+				issue_id = lane.snapshot.issue.id,
+				issue = lane.snapshot.issue.identifier,
+				pr_url = lane.review_state.url,
+				?error,
+				"Retained admin merge succeeded, but merge commit readback is unavailable."
+			);
+
+			return apply_retained_admin_merge_attention(
+				runtime,
+				lane,
+				LifecycleOutcome::NeedsManualAttention,
+				"readback_unavailable",
+				"retained_admin_merge_readback_unavailable",
+			);
+		},
+	};
 
 	record_retained_landing_decision(
 		runtime,
 		lane,
 		LifecycleEvidenceKind::LandingReadback,
-		LifecycleOutcome::Failed,
-		None,
-		"failed",
+		LifecycleOutcome::Succeeded,
+		Some(merge_commit.as_str()),
+		"landed",
 		"not_started",
-		reasons.admin_merge_failed,
+		"retained_admin_merge_readback",
+	)
+}
+
+fn apply_retained_admin_merge_attention<T>(
+	runtime: &RetainedReviewRuntime<'_, T>,
+	lane: &RetainedReviewLane,
+	outcome: LifecycleOutcome,
+	landing_state: &str,
+	reason: &str,
+) -> Result<()>
+where
+	T: IssueTracker,
+{
+	record_retained_landing_decision(
+		runtime,
+		lane,
+		LifecycleEvidenceKind::LandingReadback,
+		outcome,
+		None,
+		landing_state,
+		"not_started",
+		reason,
 	)?;
 
 	retained_review_orchestration::apply_passive_retained_manual_attention(
@@ -209,7 +265,7 @@ where
 		&lane.snapshot.issue,
 		&lane.snapshot.worktree,
 		lane.lifecycle_record(),
-		reasons.admin_merge_failed,
+		reason,
 	)
 }
 
@@ -227,14 +283,14 @@ fn record_retained_landing_decision<T>(
 where
 	T: IssueTracker,
 {
-	let review_checkpoint = runtime_review_checkpoint_status_for_head(
+	let review_checkpoint = orchestrator::runtime_review_checkpoint_status_for_head(
 		runtime.state_store,
 		runtime.project.service_id(),
 		&lane.snapshot.issue.id,
 		runtime.project.codex().review_level(),
 		lane.lifecycle_record().head_sha(),
 	)?;
-	let facts = build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
+	let facts = orchestrator::build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
 		project_id: runtime.project.service_id(),
 		issue_id: &lane.snapshot.issue.id,
 		review_lifecycle: Some(lane.lifecycle_record()),
@@ -267,7 +323,7 @@ where
 		evidence_kind.as_str(),
 		causation_id
 	);
-	let decision = decide_lifecycle_transition(LifecycleDecisionInput {
+	let decision = lifecycle::decide_lifecycle_transition(LifecycleDecisionInput {
 		facts: &facts,
 		previous,
 		evidence_kind,
@@ -293,22 +349,6 @@ where
 
 fn current_timestamp() -> String {
 	OffsetDateTime::now_utc().format(&Rfc3339).expect("timestamp formatting should succeed")
-}
-
-pub(super) fn retained_review_github_token<'a>(
-	project: &ServiceConfig,
-	github_token: &'a mut Option<String>,
-) -> Result<&'a str> {
-	if github_token.is_none() {
-		*github_token = Some(orchestrator::resolve_configured_env_var(
-			"github.token_env_var",
-			Some(project.github().token_env_var()),
-		)?);
-	}
-
-	github_token.as_deref().ok_or_else(|| {
-		eyre::eyre!("Retained review orchestration requires a configured GitHub token.")
-	})
 }
 
 fn retained_review_merge_subject(lane: &RetainedReviewLane) -> Result<String> {

--- a/apps/decodex/src/orchestrator/retained_review_orchestration/lifecycle_authority.rs
+++ b/apps/decodex/src/orchestrator/retained_review_orchestration/lifecycle_authority.rs
@@ -113,6 +113,7 @@ fn write_retained_review_lifecycle_authority(
 		lane.snapshot.local_head_oid.as_deref().ok_or_else(|| {
 			eyre::eyre!("Retained review orchestration requires a local lane HEAD.")
 		})?;
+
 	state_store.record_review_lifecycle_transition(
 		lane.snapshot.worktree.project_id(),
 		&lane.snapshot.issue.id,

--- a/apps/decodex/src/orchestrator/retained_review_orchestration/load.rs
+++ b/apps/decodex/src/orchestrator/retained_review_orchestration/load.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::{
 	orchestrator::{
 		PostReviewLaneClassification, PostReviewLaneDecision, PostReviewLaneSnapshot,
@@ -9,7 +11,7 @@ use crate::{
 		status,
 	},
 	prelude::{Result, eyre},
-	state::{ReviewLifecycleRecord, StateStore, WorktreeMapping},
+	state::{self, ReviewLifecycleRecord, StateStore, WorktreeMapping},
 	tracker::{self, IssueTracker, TrackerIssue},
 };
 
@@ -53,7 +55,9 @@ where
 			"missing_review_handoff_record",
 		));
 	};
+
 	ensure_lifecycle_record_has_base_branch(&lifecycle_record)?;
+
 	let local_branch_name = match status::worktree_checkout_branch_name(worktree.worktree_path()) {
 		Ok(local_branch_name) => local_branch_name,
 		Err(_error) => {
@@ -123,6 +127,7 @@ fn ensure_lifecycle_record_has_base_branch(record: &ReviewLifecycleRecord) -> Re
 	if record.target_base_ref_name().is_some() {
 		return Ok(());
 	}
+
 	Err(eyre::eyre!(
 		"Retained review lifecycle authority for `{}` on branch `{}` is missing the PR base branch.",
 		record.issue_id(),
@@ -186,13 +191,13 @@ fn blocked_retained_review_lane(
 }
 
 fn retained_review_run_identity(
-	worktree_path: &std::path::Path,
+	worktree_path: &Path,
 	lifecycle_record: Option<&ReviewLifecycleRecord>,
 ) -> (String, i64) {
 	if let Some(lifecycle_record) = lifecycle_record {
 		return (lifecycle_record.run_id().to_owned(), lifecycle_record.attempt_number());
 	}
-	if let Ok(Some(marker)) = crate::state::read_run_activity_marker_snapshot(worktree_path) {
+	if let Ok(Some(marker)) = state::read_run_activity_marker_snapshot(worktree_path) {
 		return (marker.run_id().to_owned(), marker.attempt_number());
 	}
 

--- a/apps/decodex/src/orchestrator/retained_review_orchestration/phases/non_github.rs
+++ b/apps/decodex/src/orchestrator/retained_review_orchestration/phases/non_github.rs
@@ -1,23 +1,26 @@
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::orchestrator::{
-	self, PostReviewLifecycleFacts, PostReviewLifecycleFactsInput, RuntimeReviewGateState,
-	build_post_review_lifecycle_facts,
-	kernel::lifecycle::{
-		LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome,
-		PreviousLifecycleAuthority, decide_lifecycle_transition,
+	self, PostReviewLifecycleFacts, PostReviewLifecycleFactsInput, RuntimeReviewCheckpointStatus,
+	RuntimeReviewGateState,
+	kernel::{
+		lifecycle,
+		lifecycle::{
+			LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome,
+			PreviousLifecycleAuthority,
+		},
 	},
-	latest_runtime_review_checkpoint_status,
 	retained_review_orchestration::{
-		CommandIntentKind, IssueTracker, PassiveRetainedAttentionRuntime, Result,
+		self, CommandIntentKind, IssueTracker, PassiveRetainedAttentionRuntime, Result,
 		RetainedAdminMergeReasons, RetainedReviewLane, RetainedReviewLifecycleAuthorityFields,
 		RetainedReviewRuntime, ServiceConfig, StateStore, WorkflowDocument, admin_merge,
 		lifecycle_authority,
-		phases::{merge, result},
+		phases::{
+			RetainedReviewLifecycleAction, merge,
+			non_github::lifecycle::decide_lifecycle_transition, result,
+		},
 	},
-	runtime_review_checkpoint_status_for_head_phase,
-	runtime_standard_review::{RuntimeStandardReviewRunner, runtime_review_execution_mode},
-	worktree_has_review_blocking_changes,
+	runtime_standard_review::{self, RuntimeStandardReviewRunner},
 };
 
 const PRODUCER_FAILURE_BUDGET: i64 = 3;
@@ -38,8 +41,7 @@ pub(in crate::orchestrator::retained_review_orchestration::phases) fn handle_non
 where
 	T: IssueTracker,
 {
-	let action =
-		super::RetainedReviewLifecycleAction::parse(lane.lifecycle_record().next_action())?;
+	let action = RetainedReviewLifecycleAction::parse(lane.lifecycle_record().next_action())?;
 
 	if matches!(
 		action,
@@ -129,7 +131,7 @@ pub(super) fn runtime_standard_review_gate_requires_wait_or_repair(
 	} else {
 		None
 	};
-	let facts = build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
+	let facts = orchestrator::build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
 		project_id: project.service_id(),
 		issue_id: &lane.snapshot.issue.id,
 		review_lifecycle: Some(lane.lifecycle_record()),
@@ -146,8 +148,9 @@ pub(super) fn runtime_standard_review_gate_requires_wait_or_repair(
 
 	match facts.review_gate_state {
 		RuntimeReviewGateState::NotRequired => Ok(false),
-		RuntimeReviewGateState::Clean =>
-			Ok(worktree_has_review_blocking_changes(lane.snapshot.worktree.worktree_path())?),
+		RuntimeReviewGateState::Clean => Ok(orchestrator::worktree_has_review_blocking_changes(
+			lane.snapshot.worktree.worktree_path(),
+		)?),
 		RuntimeReviewGateState::Findings => {
 			lifecycle_authority::write_retained_review_lifecycle_authority_for_command(
 				state_store,
@@ -159,6 +162,7 @@ pub(super) fn runtime_standard_review_gate_requires_wait_or_repair(
 					lane.lifecycle_record(),
 				),
 			)?;
+
 			Ok(true)
 		},
 		RuntimeReviewGateState::WorktreeHeadMissing => Ok(true),
@@ -172,6 +176,7 @@ pub(super) fn runtime_standard_review_gate_requires_wait_or_repair(
 				&facts,
 				"runtime_standard_review_needs_architecture_review",
 			)?;
+
 			Ok(true)
 		},
 		RuntimeReviewGateState::Blocked => {
@@ -184,6 +189,7 @@ pub(super) fn runtime_standard_review_gate_requires_wait_or_repair(
 				&facts,
 				"runtime_standard_review_blocked",
 			)?;
+
 			Ok(true)
 		},
 		RuntimeReviewGateState::Unknown(_) => {
@@ -196,49 +202,67 @@ pub(super) fn runtime_standard_review_gate_requires_wait_or_repair(
 				&facts,
 				"runtime_standard_review_unknown_checkpoint_status",
 			)?;
-			Ok(true)
-		},
-		RuntimeReviewGateState::Pending => {
-			match orchestrator::runtime_standard_review::ensure_runtime_standard_review_checkpoint_with_runner(
-				tracker,
-				project,
-				workflow,
-				state_store,
-				lane,
-				runtime_review_runner,
-			) {
-				Ok(()) => {},
-				Err(error) => {
-					let retry_count = lane.lifecycle_record().request_retry_count() + 1;
-					tracing::warn!(
-						?error,
-						project_id = project.service_id(),
-						issue_id = lane.snapshot.issue.id.as_str(),
-						retry_count,
-						"Runtime-owned Decodex Review checkpoint producer failed."
-					);
-					write_runtime_standard_review_producer_retry_count(
-						state_store,
-						lane,
-						retry_count,
-					)?;
-					if retry_count >= PRODUCER_FAILURE_BUDGET {
-						apply_runtime_standard_review_manual_attention(
-							tracker,
-							project,
-							workflow,
-							state_store,
-							lane,
-							&facts,
-							"runtime_standard_review_checkpoint_producer_failed",
-						)?;
-					}
-				},
-			}
 
 			Ok(true)
 		},
+		RuntimeReviewGateState::Pending => handle_pending_runtime_standard_review_gate(
+			tracker,
+			project,
+			workflow,
+			state_store,
+			lane,
+			runtime_review_runner,
+			&facts,
+		),
 	}
+}
+
+fn handle_pending_runtime_standard_review_gate(
+	tracker: &impl IssueTracker,
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	lane: &RetainedReviewLane,
+	runtime_review_runner: &impl RuntimeStandardReviewRunner,
+	facts: &PostReviewLifecycleFacts,
+) -> Result<bool> {
+	match runtime_standard_review::ensure_runtime_standard_review_checkpoint_with_runner(
+		tracker,
+		project,
+		workflow,
+		state_store,
+		lane,
+		runtime_review_runner,
+	) {
+		Ok(()) => {},
+		Err(error) => {
+			let retry_count = lane.lifecycle_record().request_retry_count() + 1;
+
+			tracing::warn!(
+				?error,
+				project_id = project.service_id(),
+				issue_id = lane.snapshot.issue.id.as_str(),
+				retry_count,
+				"Runtime-owned Decodex Review checkpoint producer failed."
+			);
+
+			write_runtime_standard_review_producer_retry_count(state_store, lane, retry_count)?;
+
+			if retry_count >= PRODUCER_FAILURE_BUDGET {
+				apply_runtime_standard_review_manual_attention(
+					tracker,
+					project,
+					workflow,
+					state_store,
+					lane,
+					facts,
+					"runtime_standard_review_checkpoint_producer_failed",
+				)?;
+			}
+		},
+	}
+
+	Ok(true)
 }
 
 fn runtime_standard_review_checkpoint_for_gate(
@@ -246,9 +270,11 @@ fn runtime_standard_review_checkpoint_for_gate(
 	state_store: &StateStore,
 	lane: &RetainedReviewLane,
 	local_head_oid: &str,
-) -> Result<Option<crate::orchestrator::RuntimeReviewCheckpointStatus>> {
-	let expected_phase = runtime_review_execution_mode(project, state_store, lane)?.as_str();
-	let handoff = runtime_review_checkpoint_status_for_head_phase(
+) -> Result<Option<RuntimeReviewCheckpointStatus>> {
+	let expected_phase =
+		runtime_standard_review::runtime_review_execution_mode(project, state_store, lane)?
+			.as_str();
+	let handoff = orchestrator::runtime_review_checkpoint_status_for_head_phase(
 		state_store,
 		project.service_id(),
 		&lane.snapshot.issue.id,
@@ -256,7 +282,7 @@ fn runtime_standard_review_checkpoint_for_gate(
 		local_head_oid,
 		"handoff",
 	)?;
-	let repair = runtime_review_checkpoint_status_for_head_phase(
+	let repair = orchestrator::runtime_review_checkpoint_status_for_head_phase(
 		state_store,
 		project.service_id(),
 		&lane.snapshot.issue.id,
@@ -264,12 +290,11 @@ fn runtime_standard_review_checkpoint_for_gate(
 		local_head_oid,
 		"repair",
 	)?;
-
-	let latest = latest_runtime_review_checkpoint_status(vec![handoff, repair])?;
+	let latest = orchestrator::latest_runtime_review_checkpoint_status(vec![handoff, repair])?;
 
 	Ok(match latest {
 		Some(checkpoint) => Some(checkpoint),
-		None => runtime_review_checkpoint_status_for_head_phase(
+		None => orchestrator::runtime_review_checkpoint_status_for_head_phase(
 			state_store,
 			project.service_id(),
 			&lane.snapshot.issue.id,
@@ -308,7 +333,7 @@ fn apply_runtime_standard_review_manual_attention(
 ) -> Result<()> {
 	record_runtime_standard_review_manual_attention_authority(state_store, lane, facts, reason)?;
 
-	orchestrator::retained_review_orchestration::apply_passive_retained_manual_attention(
+	retained_review_orchestration::apply_passive_retained_manual_attention(
 		PassiveRetainedAttentionRuntime { tracker, project, workflow, state_store },
 		&lane.snapshot.issue,
 		&lane.snapshot.worktree,
@@ -340,7 +365,7 @@ fn record_runtime_standard_review_manual_attention_authority(
 		LifecycleEvidenceKind::LandingReadback.as_str(),
 		reason
 	);
-	let decision = decide_lifecycle_transition(LifecycleDecisionInput {
+	let decision = self::decide_lifecycle_transition(LifecycleDecisionInput {
 		facts,
 		previous,
 		evidence_kind: LifecycleEvidenceKind::LandingReadback,

--- a/apps/decodex/src/orchestrator/retained_review_orchestration/phases/result.rs
+++ b/apps/decodex/src/orchestrator/retained_review_orchestration/phases/result.rs
@@ -1,14 +1,13 @@
-use crate::{
-	orchestrator,
-	orchestrator::{
-		retained_review_orchestration::{
-			self, CommandIntentKind, IssueTracker, PullRequestReviewState, Result,
-			RetainedAdminMergeReasons, RetainedReviewLane, RetainedReviewLifecycleAuthorityFields,
-			RetainedReviewRuntime, ReviewLifecycleReadback, admin_merge, attention,
-			lifecycle_authority, phases::RetainedReviewLifecycleAction,
-		},
-		runtime_standard_review::RuntimeStandardReviewRunner,
+use crate::orchestrator::{
+	self,
+	retained_review_orchestration::{
+		self, CommandIntentKind, IssueTracker, PullRequestReviewState, Result,
+		RetainedAdminMergeReasons, RetainedReviewLane, RetainedReviewLifecycleAuthorityFields,
+		RetainedReviewRuntime, ReviewLifecycleReadback, admin_merge, attention,
+		lifecycle_authority,
+		phases::{RetainedReviewLifecycleAction, non_github},
 	},
+	runtime_standard_review::RuntimeStandardReviewRunner,
 };
 
 pub(in crate::orchestrator::retained_review_orchestration::phases) fn handle_waiting_for_result_phase<
@@ -61,7 +60,7 @@ where
 		lane.lifecycle_record(),
 	) {
 		if orchestrator::review_state_clean_path_landing_gates_satisfied(&lane.review_state) {
-			if super::non_github::runtime_standard_review_gate_requires_wait_or_repair(
+			if non_github::runtime_standard_review_gate_requires_wait_or_repair(
 				runtime.tracker,
 				runtime.project,
 				runtime.workflow,

--- a/apps/decodex/src/orchestrator/run_cycle/project/planning.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/project/planning.rs
@@ -1,9 +1,9 @@
 use crate::orchestrator::{
-	BaselineGuardDispatchOutcome, ProgramDispatchSelection, ensure_clean_baseline_before_dispatch,
+	self, BaselineGuardDispatchOutcome, ProgramDispatchSelection,
 	run_cycle::{
 		self, IssueDispatchMode, IssueRunPlan, IssueTracker, PreferredRunIdentity,
 		PrepareIssueRunContext, Result, RetryIssueStateHint, ServiceConfig, StateStore,
-		WorkflowDocument, WorktreeManager, eyre, project::candidate, slice,
+		TrackerIssue, WorkflowDocument, WorktreeManager, eyre, project::candidate, slice,
 	},
 };
 
@@ -80,8 +80,7 @@ where
 	else {
 		return Ok(None);
 	};
-	let mut refreshed_issues = tracker.refresh_issues(slice::from_ref(&selected_issue.issue.id))?;
-	let Some(issue) = refreshed_issues.pop() else {
+	let Some(issue) = refresh_selected_issue(tracker, &selected_issue.issue.id)? else {
 		return Ok(None);
 	};
 	let dispatch_mode = selected_issue.dispatch_mode;
@@ -91,41 +90,21 @@ where
 	if !dry_run && dispatch_mode != IssueDispatchMode::Closeout {
 		run_cycle::ensure_project_has_no_merged_worktree_cleanup_debt(project)?;
 	}
-	if !run_cycle::issue_passes_current_dispatch_policy(
+
+	if let Some(replanned) = replan_if_dispatch_policy_blocks(
 		tracker,
 		&issue,
 		project,
 		workflow,
 		state_store,
 		dispatch_mode,
-		RetryIssueStateHint::default(),
+		dry_run,
+		excluded_issue_ids,
 	)? {
-		if dispatch_mode == IssueDispatchMode::Closeout
-			&& let Some(reason) = run_cycle::closeout_dispatch_block_reason(
-				tracker,
-				&issue,
-				project,
-				workflow,
-				state_store,
-			)? {
-			if !dry_run {
-				eyre::bail!("retained closeout dispatch blocked: {reason}");
-			}
-
-			return Ok(None);
-		}
-
-		return replan_program_dispatch_after_excluding(
-			tracker,
-			project,
-			workflow,
-			state_store,
-			dry_run,
-			excluded_issue_ids,
-			issue.id.as_str(),
-		);
+		return Ok(replanned);
 	}
-	if ensure_clean_baseline_before_dispatch(
+
+	if orchestrator::ensure_clean_baseline_before_dispatch(
 		project,
 		workflow,
 		state_store,
@@ -172,6 +151,67 @@ where
 	}
 
 	Ok(Some(PlannedProjectIssueRun { issue_run, program_dispatch }))
+}
+
+fn refresh_selected_issue<T>(tracker: &T, issue_id: &str) -> Result<Option<TrackerIssue>>
+where
+	T: IssueTracker,
+{
+	let issue_id = issue_id.to_owned();
+	let mut refreshed_issues = tracker.refresh_issues(slice::from_ref(&issue_id))?;
+
+	Ok(refreshed_issues.pop())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn replan_if_dispatch_policy_blocks<T>(
+	tracker: &T,
+	issue: &TrackerIssue,
+	project: &ServiceConfig,
+	workflow: &WorkflowDocument,
+	state_store: &StateStore,
+	dispatch_mode: IssueDispatchMode,
+	dry_run: bool,
+	excluded_issue_ids: &[&str],
+) -> Result<Option<Option<PlannedProjectIssueRun>>>
+where
+	T: IssueTracker,
+{
+	if run_cycle::issue_passes_current_dispatch_policy(
+		tracker,
+		issue,
+		project,
+		workflow,
+		state_store,
+		dispatch_mode,
+		RetryIssueStateHint::default(),
+	)? {
+		return Ok(None);
+	}
+	if dispatch_mode == IssueDispatchMode::Closeout
+		&& let Some(reason) = run_cycle::closeout_dispatch_block_reason(
+			tracker,
+			issue,
+			project,
+			workflow,
+			state_store,
+		)? {
+		if !dry_run {
+			eyre::bail!("retained closeout dispatch blocked: {reason}");
+		}
+
+		return Ok(Some(None));
+	}
+
+	Ok(Some(replan_program_dispatch_after_excluding(
+		tracker,
+		project,
+		workflow,
+		state_store,
+		dry_run,
+		excluded_issue_ids,
+		issue.id.as_str(),
+	)?))
 }
 
 fn replan_program_dispatch_after_excluding<T>(

--- a/apps/decodex/src/orchestrator/run_cycle/target_issue.rs
+++ b/apps/decodex/src/orchestrator/run_cycle/target_issue.rs
@@ -14,7 +14,7 @@ pub(crate) use self::{
 #[cfg(test)] pub(crate) use program::select_target_status_visible_program_candidate;
 
 use crate::orchestrator::{
-	BaselineGuardDispatchOutcome, ensure_clean_baseline_before_dispatch,
+	self, BaselineGuardDispatchOutcome,
 	run_cycle::{
 		self, IssueDispatchMode, IssueRunPlan, IssueTracker, PrepareIssueRunContext, Result,
 		RetryIssueStateHint, RunSummary, ServiceConfig, StateStore, TargetIssueRunContext,
@@ -167,7 +167,7 @@ where
 	if !context.dry_run && context.dispatch_mode != IssueDispatchMode::Closeout {
 		run_cycle::ensure_project_has_no_merged_worktree_cleanup_debt(context.project)?;
 	}
-	if ensure_clean_baseline_before_dispatch(
+	if orchestrator::ensure_clean_baseline_before_dispatch(
 		context.project,
 		context.workflow,
 		context.state_store,

--- a/apps/decodex/src/orchestrator/runtime_standard_review.rs
+++ b/apps/decodex/src/orchestrator/runtime_standard_review.rs
@@ -1,14 +1,14 @@
 use std::path::{Path, PathBuf};
 
-use serde_json::{Map, Value, json};
+use serde_json::{self, Map, Value};
 
 use crate::{
 	agent::{
 		self, AppServerProcessEnv, AppServerRunRequest, RUN_LEASE_IDLE_TIMEOUT, ReviewExecutionMode,
 	},
 	orchestrator::{
-		IssueTracker, Result, RetainedReviewLane, ServiceConfig, StateStore, TrackerToolBridge,
-		WorkflowDocument, configured_public_projection_privacy_classifier,
+		self, IssueTracker, Result, RetainedReviewLane, ReviewHandoffContext, ServiceConfig,
+		StateStore, TrackerToolBridge, WorkflowDocument,
 	},
 	prelude::eyre,
 };
@@ -112,8 +112,9 @@ where
 	};
 	let review_mode = runtime_review_execution_mode(project, state_store, lane)?;
 	let review_run_id = runtime_review_run_id(marker.run_id(), review_mode, head_sha);
-	let privacy_classifier = configured_public_projection_privacy_classifier(project)?;
-	let review_context = crate::agent::ReviewHandoffContext {
+	let privacy_classifier =
+		orchestrator::configured_public_projection_privacy_classifier(project)?;
+	let review_context = ReviewHandoffContext {
 		attempt_number: marker.attempt_number(),
 		branch_name: marker.branch_name().to_owned(),
 		run_id: review_run_id.clone(),
@@ -174,6 +175,26 @@ pub(crate) fn runtime_review_execution_mode(
 	}
 
 	Ok(ReviewExecutionMode::Handoff)
+}
+
+pub(crate) fn record_runtime_standard_review_checkpoint_from_output(
+	tracker_tool_bridge: &TrackerToolBridge<'_>,
+	issue_id: &str,
+	issue_identifier: &str,
+	head_sha: &str,
+	review_mode: ReviewExecutionMode,
+	final_output: &str,
+) -> Result<()> {
+	let checkpoint = checkpoint_json_from_reviewer_output(final_output)?;
+	let arguments = runtime_review_checkpoint_arguments(
+		checkpoint,
+		issue_id,
+		issue_identifier,
+		head_sha,
+		review_mode,
+	)?;
+
+	tracker_tool_bridge.record_runtime_review_checkpoint(arguments)
 }
 
 fn runtime_review_run_id(
@@ -268,26 +289,6 @@ fn runtime_standard_review_user_input(
 	)
 }
 
-pub(crate) fn record_runtime_standard_review_checkpoint_from_output(
-	tracker_tool_bridge: &TrackerToolBridge<'_>,
-	issue_id: &str,
-	issue_identifier: &str,
-	head_sha: &str,
-	review_mode: ReviewExecutionMode,
-	final_output: &str,
-) -> Result<()> {
-	let checkpoint = checkpoint_json_from_reviewer_output(final_output)?;
-	let arguments = runtime_review_checkpoint_arguments(
-		checkpoint,
-		issue_id,
-		issue_identifier,
-		head_sha,
-		review_mode,
-	)?;
-
-	tracker_tool_bridge.record_runtime_review_checkpoint(arguments)
-}
-
 fn checkpoint_json_from_reviewer_output(final_output: &str) -> Result<Value> {
 	let trimmed = final_output.trim();
 
@@ -357,7 +358,7 @@ fn insert_runtime_owned_checkpoint_fields(
 }
 
 fn runtime_review_contract_json(review_mode: ReviewExecutionMode) -> Value {
-	json!({
+	serde_json::json!({
 		"workflow_policy_source": "registered_project_workflow",
 		"review_type": runtime_review_type(review_mode),
 		"risk_tier": "localized",
@@ -399,13 +400,11 @@ fn runtime_review_type(review_mode: ReviewExecutionMode) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-	use crate::orchestrator::runtime_standard_review::{
-		checkpoint_json_from_reviewer_output, runtime_review_checkpoint_arguments,
-	};
+	use crate::orchestrator::runtime_standard_review::{self};
 
 	#[test]
 	fn runtime_review_output_parser_accepts_fenced_json() {
-		let parsed = checkpoint_json_from_reviewer_output(
+		let parsed = runtime_standard_review::checkpoint_json_from_reviewer_output(
 			r#"```json
 {"status":"clean","checks":{"intended_behavior":"ok","regression_risk":"low","missing_tests":"none","openwiki_config_drift":"none","migration_fallout":"none","operator_facing_fallout":"none","loop_decision_contract":"ok"},"evidence":["read current HEAD"]}
 ```"#,
@@ -417,7 +416,7 @@ mod tests {
 
 	#[test]
 	fn runtime_review_arguments_override_authority_binding_fields() {
-		let arguments = runtime_review_checkpoint_arguments(
+		let arguments = runtime_standard_review::runtime_review_checkpoint_arguments(
 			serde_json::json!({
 				"issue_id": "wrong",
 				"issue_identifier": "WRONG-1",

--- a/apps/decodex/src/orchestrator/status/models/post_review.rs
+++ b/apps/decodex/src/orchestrator/status/models/post_review.rs
@@ -85,35 +85,6 @@ pub(in crate::orchestrator) struct PostReviewOrchestrationStatus {
 	pub(in crate::orchestrator) clean_path_landing_gates_satisfied: bool,
 	pub(in crate::orchestrator) landing_requires_agent_fallback: bool,
 }
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(in crate::orchestrator) enum PostReviewLifecycleAction {
-	StartReviewGateOrExternalReview,
-	RequestExternalReview,
-	WaitForExternalReviewAck,
-	WaitForExternalReviewResult,
-	WaitForLandingGates,
-	RunReviewRepair,
-	PollLandingReadback,
-	RunCloseoutAdapter,
-	RequestManualAttention,
-}
-impl PostReviewLifecycleAction {
-	pub(in crate::orchestrator) fn parse(value: &str) -> Result<Self> {
-		Ok(match value {
-			"wait_for_runtime_review_gate_or_external_review" =>
-				Self::StartReviewGateOrExternalReview,
-			"request_external_review" => Self::RequestExternalReview,
-			"wait_for_external_review_ack" => Self::WaitForExternalReviewAck,
-			"wait_for_external_review_result" => Self::WaitForExternalReviewResult,
-			"wait_for_landing_gates" => Self::WaitForLandingGates,
-			"run_retained_review_repair_adapter" => Self::RunReviewRepair,
-			"poll_landing_readback" => Self::PollLandingReadback,
-			"run_retained_closeout_adapter" => Self::RunCloseoutAdapter,
-			"request_manual_attention" => Self::RequestManualAttention,
-			_ => eyre::bail!("Unknown post-review lifecycle action `{value}`."),
-		})
-	}
-}
 impl PostReviewOrchestrationStatus {
 	pub(in crate::orchestrator) fn from_review_state(
 		review_state: &PullRequestReviewState,
@@ -140,6 +111,36 @@ impl PostReviewOrchestrationStatus {
 				orchestrator::review_state_clean_path_landing_gates_satisfied(review_state),
 			landing_requires_agent_fallback:
 				orchestrator::review_state_landing_requires_agent_fallback(review_state),
+		})
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::orchestrator) enum PostReviewLifecycleAction {
+	StartReviewGateOrExternalReview,
+	RequestExternalReview,
+	WaitForExternalReviewAck,
+	WaitForExternalReviewResult,
+	WaitForLandingGates,
+	RunReviewRepair,
+	PollLandingReadback,
+	RunCloseoutAdapter,
+	RequestManualAttention,
+}
+impl PostReviewLifecycleAction {
+	pub(in crate::orchestrator) fn parse(value: &str) -> Result<Self> {
+		Ok(match value {
+			"wait_for_runtime_review_gate_or_external_review" =>
+				Self::StartReviewGateOrExternalReview,
+			"request_external_review" => Self::RequestExternalReview,
+			"wait_for_external_review_ack" => Self::WaitForExternalReviewAck,
+			"wait_for_external_review_result" => Self::WaitForExternalReviewResult,
+			"wait_for_landing_gates" => Self::WaitForLandingGates,
+			"run_retained_review_repair_adapter" => Self::RunReviewRepair,
+			"poll_landing_readback" => Self::PollLandingReadback,
+			"run_retained_closeout_adapter" => Self::RunCloseoutAdapter,
+			"request_manual_attention" => Self::RequestManualAttention,
+			_ => eyre::bail!("Unknown post-review lifecycle action `{value}`."),
 		})
 	}
 }

--- a/apps/decodex/src/orchestrator/status/post_review/classification.rs
+++ b/apps/decodex/src/orchestrator/status/post_review/classification.rs
@@ -1,22 +1,20 @@
-use crate::state::ReviewLifecycleRecord;
-
 #[cfg(test)] use crate::orchestrator::ReviewLevel;
 use crate::{
 	orchestrator::{
-		PostReviewLifecycleFactsInput, RuntimeReviewGateState, build_post_review_lifecycle_facts,
-		runtime_review_checkpoint_status_for_head,
+		self, PostReviewLifecycleFactsInput, RuntimeReviewGateState,
 		status::{
-			blocked_post_review_lane_from_state, post_review,
+			PullRequestReviewState, post_review,
 			post_review::{
 				OffsetDateTime, PostReviewLaneClassification, PostReviewLaneDecision,
 				PostReviewLaneKernelInput, PostReviewLaneSnapshot, PostReviewLaneStateLoad,
 				PostReviewOrchestrationStatus, PostReviewRuntimeState,
 				PullRequestReviewStateInspector, ServiceConfig, StateStore, WorkflowDocument,
 			},
+			review_state,
 		},
-		worktree_has_review_blocking_changes,
 	},
 	prelude::Result,
+	state::ReviewLifecycleRecord,
 };
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -108,7 +106,6 @@ where
 		if classification.decision == PostReviewLaneDecision::Block {
 			return Ok(finalize_post_review_lane_classification(snapshot, classification));
 		}
-
 		if apply_runtime_standard_review_gate(
 			snapshot,
 			&review_state,
@@ -153,6 +150,7 @@ where
 		&orchestration_status,
 		OffsetDateTime::now_utc().unix_timestamp(),
 	);
+
 	if classification.decision == PostReviewLaneDecision::ReadyToLand
 		&& classification.reason == "external_review_passed_strict"
 		&& apply_runtime_standard_review_gate(
@@ -164,6 +162,7 @@ where
 		)? {
 		return Ok(finalize_post_review_lane_classification(snapshot, classification));
 	}
+
 	post_review::apply_authority_boundary_landing_policy(
 		snapshot,
 		&mut classification,
@@ -203,21 +202,22 @@ pub(crate) fn finalize_post_review_lane_classification_with_retry_budget(
 
 fn apply_runtime_standard_review_gate(
 	snapshot: &PostReviewLaneSnapshot,
-	review_state: &crate::orchestrator::status::PullRequestReviewState,
+	review_state: &PullRequestReviewState,
 	classification: &mut PostReviewLaneClassification,
 	runtime_state: Option<PostReviewRuntimeState<'_>>,
-	lifecycle_record: Option<&crate::state::ReviewLifecycleRecord>,
+	lifecycle_record: Option<&ReviewLifecycleRecord>,
 ) -> Result<bool> {
 	let Some(runtime_state) = runtime_state else {
 		return Ok(false);
 	};
+
 	if !runtime_state.review_level.requires_review_checkpoint() {
 		return Ok(false);
 	}
 
 	let local_head_oid = snapshot.local_head_oid.as_deref();
 	let checkpoint = if let Some(local_head_oid) = local_head_oid {
-		runtime_review_checkpoint_status_for_head(
+		orchestrator::runtime_review_checkpoint_status_for_head(
 			runtime_state.state_store,
 			runtime_state.project_id,
 			&snapshot.issue.id,
@@ -227,7 +227,7 @@ fn apply_runtime_standard_review_gate(
 	} else {
 		None
 	};
-	let facts = build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
+	let facts = orchestrator::build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
 		project_id: runtime_state.project_id,
 		issue_id: &snapshot.issue.id,
 		review_lifecycle: lifecycle_record,
@@ -245,50 +245,61 @@ fn apply_runtime_standard_review_gate(
 	match facts.review_gate_state {
 		RuntimeReviewGateState::NotRequired => Ok(false),
 		RuntimeReviewGateState::Clean => {
-			if worktree_has_review_blocking_changes(snapshot.worktree.worktree_path())? {
-				*classification = blocked_post_review_lane_from_state(
+			if orchestrator::worktree_has_review_blocking_changes(
+				snapshot.worktree.worktree_path(),
+			)? {
+				*classification = review_state::blocked_post_review_lane_from_state(
 					review_state,
 					"runtime_standard_review_clean_checkpoint_worktree_dirty",
 				);
+
 				return Ok(true);
 			}
 
 			Ok(false)
 		},
 		RuntimeReviewGateState::WorktreeHeadMissing => {
-			*classification =
-				blocked_post_review_lane_from_state(review_state, "worktree_head_missing");
+			*classification = review_state::blocked_post_review_lane_from_state(
+				review_state,
+				"worktree_head_missing",
+			);
+
 			Ok(true)
 		},
 		RuntimeReviewGateState::Pending => {
 			classification.decision = PostReviewLaneDecision::WaitForReview;
 			classification.reason = String::from("runtime_standard_review_checkpoint_pending");
+
 			Ok(true)
 		},
 		RuntimeReviewGateState::Findings => {
 			classification.decision = PostReviewLaneDecision::NeedsReviewRepair;
 			classification.reason = String::from("runtime_standard_review_repair_required");
+
 			Ok(true)
 		},
 		RuntimeReviewGateState::NeedsArchitectureReview => {
-			*classification = blocked_post_review_lane_from_state(
+			*classification = review_state::blocked_post_review_lane_from_state(
 				review_state,
 				"runtime_standard_review_needs_architecture_review",
 			);
+
 			Ok(true)
 		},
 		RuntimeReviewGateState::Blocked => {
-			*classification = blocked_post_review_lane_from_state(
+			*classification = review_state::blocked_post_review_lane_from_state(
 				review_state,
 				"runtime_standard_review_blocked",
 			);
+
 			Ok(true)
 		},
 		RuntimeReviewGateState::Unknown(_) => {
-			*classification = blocked_post_review_lane_from_state(
+			*classification = review_state::blocked_post_review_lane_from_state(
 				review_state,
 				"runtime_standard_review_unknown_checkpoint_status",
 			);
+
 			Ok(true)
 		},
 	}

--- a/apps/decodex/src/orchestrator/status/post_review/lanes/build.rs
+++ b/apps/decodex/src/orchestrator/status/post_review/lanes/build.rs
@@ -81,6 +81,7 @@ where
 	if issue.state.name == context.completed_state && lifecycle_record.is_none() {
 		return Ok(None);
 	}
+
 	let local_branch_name =
 		match post_review::worktree_checkout_branch_name(worktree.worktree_path()) {
 			Ok(local_branch_name) => local_branch_name,

--- a/apps/decodex/src/orchestrator/status/post_review/retry_budget/closeout_confirmation.rs
+++ b/apps/decodex/src/orchestrator/status/post_review/retry_budget/closeout_confirmation.rs
@@ -1,9 +1,10 @@
-use crate::state::ReviewLifecycleRecord;
-
-use crate::orchestrator::status::post_review::{
-	self, PostReviewLaneClassification, PostReviewLaneDecision, PostReviewLaneSnapshot,
-	PullRequestMergeViewResponse, PullRequestReadbackRootCause, ServiceConfig, github,
-	retry_budget,
+use crate::{
+	orchestrator::status::post_review::{
+		self, PostReviewLaneClassification, PostReviewLaneDecision, PostReviewLaneSnapshot,
+		PullRequestMergeViewResponse, PullRequestReadbackRootCause, ServiceConfig, github,
+		retry_budget,
+	},
+	state::ReviewLifecycleRecord,
 };
 
 pub(crate) fn confirm_status_visible_merged_closeout(

--- a/apps/decodex/src/orchestrator/status/post_review/worktrees.rs
+++ b/apps/decodex/src/orchestrator/status/post_review/worktrees.rs
@@ -1,5 +1,3 @@
-use crate::state::ReviewLifecycleRecord;
-
 use crate::{
 	orchestrator::status::{
 		post_review,
@@ -11,6 +9,7 @@ use crate::{
 		},
 	},
 	prelude::{Result, eyre},
+	state::ReviewLifecycleRecord,
 };
 
 pub(crate) fn build_post_review_lane_statuses<T, I>(
@@ -123,6 +122,7 @@ where
 		else {
 			continue;
 		};
+
 		if lifecycle_record.target_base_ref_name().is_none() {
 			return Err(eyre::eyre!(
 				"Degraded post-review status requires lifecycle authority for `{}` on branch `{}` to include the PR base branch.",
@@ -130,6 +130,7 @@ where
 				worktree.branch_name()
 			));
 		}
+
 		let issue_identifier = retained_issue_identifier_from_worktree(&worktree);
 		let review_state = review_state_inspector
 			.inspect_review_state(worktree.worktree_path(), lifecycle_record.pr_url())

--- a/apps/decodex/src/orchestrator/status/render/run_rows/run.rs
+++ b/apps/decodex/src/orchestrator/status/render/run_rows/run.rs
@@ -19,6 +19,10 @@ fn operator_run_phase_readback(run: &OperatorRunStatus) -> &str {
 	if run.run_phase.trim().is_empty() { &run.phase } else { &run.run_phase }
 }
 
+fn render_optional_seconds(value: Option<i64>) -> String {
+	value.map_or_else(|| String::from("none"), |value| value.to_string())
+}
+
 fn append_rendered_run_impl(output: &mut String, run: &OperatorRunStatus) {
 	let (freshness_source, freshness_at) = freshness::operator_run_freshness(run);
 	let protocol_event = thread::render_run_protocol_event(run);
@@ -26,11 +30,8 @@ fn append_rendered_run_impl(output: &mut String, run: &OperatorRunStatus) {
 	let turn_id = run.turn_id.as_deref().unwrap_or("none");
 	let thread_status = run.thread_status.as_deref().unwrap_or("none");
 	let thread_active_flags = thread::render_run_thread_active_flags(run);
-	let idle_for_seconds =
-		run.idle_for_seconds.map_or_else(|| String::from("none"), |value| value.to_string());
-	let protocol_idle_for_seconds = run
-		.protocol_idle_for_seconds
-		.map_or_else(|| String::from("none"), |value| value.to_string());
+	let idle_for_seconds = render_optional_seconds(run.idle_for_seconds);
+	let protocol_idle_for_seconds = render_optional_seconds(run.protocol_idle_for_seconds);
 	let branch_name = run.branch_name.as_deref().unwrap_or("none");
 	let worktree_path = run.worktree_path.as_deref().unwrap_or("none");
 	let queue_lease = control::operator_run_queue_lease_summary(run);

--- a/apps/decodex/src/orchestrator/status/review_state/classification.rs
+++ b/apps/decodex/src/orchestrator/status/review_state/classification.rs
@@ -1,9 +1,10 @@
-use crate::state::ReviewLifecycleRecord;
-
-use crate::orchestrator::status::{
-	self, OperatorPostReviewLaneStatus, PostReviewLaneClassification, PostReviewLaneDecision,
-	PostReviewReadbackDegradation, PullRequestReadbackRootCause, PullRequestReviewState,
-	ServiceConfig, TrackerIssue, WorktreeMapping,
+use crate::{
+	orchestrator::status::{
+		self, OperatorPostReviewLaneStatus, PostReviewLaneClassification, PostReviewLaneDecision,
+		PostReviewReadbackDegradation, PullRequestReadbackRootCause, PullRequestReviewState,
+		ServiceConfig, TrackerIssue, WorktreeMapping,
+	},
+	state::ReviewLifecycleRecord,
 };
 
 pub(crate) fn initial_post_review_lane_classification(

--- a/apps/decodex/src/orchestrator/status/review_state/gates.rs
+++ b/apps/decodex/src/orchestrator/status/review_state/gates.rs
@@ -2,7 +2,7 @@ use crate::{
 	orchestrator::status::{
 		ExternalReviewRequestCiGate, PullRequestLandingGateView, PullRequestReviewState,
 	},
-	pull_request,
+	pull_request::{self, LandingGateMode},
 };
 
 pub(crate) fn external_review_request_ci_gate(
@@ -11,7 +11,7 @@ pub(crate) fn external_review_request_ci_gate(
 	if !review_state.required_status_contexts.is_empty() {
 		return match pull_request::classify_landing_gate(
 			review_state_landing_gate_view(review_state),
-			pull_request::LandingGateMode::Retained,
+			LandingGateMode::Retained,
 		) {
 			pull_request::LandingGateDecision::Repair(
 				"required_status_context_failed" | "required_checks_failed",

--- a/apps/decodex/src/orchestrator/status/review_state/worktree.rs
+++ b/apps/decodex/src/orchestrator/status/review_state/worktree.rs
@@ -1,8 +1,9 @@
-use crate::state::ReviewLifecycleRecord;
-
-use crate::orchestrator::status::{
-	self, Command, Path, PostReviewLaneSnapshot, PostReviewLaneStateLoad, PullRequestReviewState,
-	PullRequestReviewStateInspector, RetainedCloseoutPrMergeGate,
+use crate::{
+	orchestrator::status::{
+		self, Command, Path, PostReviewLaneSnapshot, PostReviewLaneStateLoad,
+		PullRequestReviewState, PullRequestReviewStateInspector, RetainedCloseoutPrMergeGate,
+	},
+	state::ReviewLifecycleRecord,
 };
 
 pub(crate) fn retained_closeout_pr_merge_gate_with_inspector<I>(

--- a/apps/decodex/src/orchestrator/status/snapshot/base.rs
+++ b/apps/decodex/src/orchestrator/status/snapshot/base.rs
@@ -59,12 +59,14 @@ pub(crate) fn build_operator_status_snapshot_with_account_mode(
 	let (worktrees, mut warnings, warning_details) =
 		status::operator_status_worktrees(project, state_store)?;
 	let mut warning_details = warning_details;
+
 	orchestrator::push_baseline_status_projection(
 		project,
 		&loop_evidence,
 		&mut warnings,
 		&mut warning_details,
 	);
+
 	let accounts =
 		status::codex_account_activity_summaries(project, &mut warnings, account_activity_mode);
 	let mut snapshot = OperatorStatusSnapshot {

--- a/apps/decodex/src/orchestrator/tests/intake_candidate_selection/retained_drain.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_candidate_selection/retained_drain.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::{cell::RefCell, path::Path};
 
 use crate::{
 	config::ReviewLevel,
@@ -11,6 +11,7 @@ use crate::{
 		},
 	},
 	state::{ReviewPolicyCheckpointInput, StateStore},
+	tracker::TrackerIssue,
 };
 
 #[test]
@@ -37,15 +38,7 @@ fn handles_same_issue_closeout_after_merge_visibility() {
 		);
 		let state_store = StateStore::open_in_memory().expect("state store should open");
 		let issue = support::candidate_selection_service_owned_issue("In Review");
-		let tracker = FakeTracker::with_refresh_snapshots(
-			vec![issue.clone()],
-			vec![
-				vec![issue.clone()],
-				vec![issue.clone()],
-				vec![issue.clone()],
-				vec![issue.clone()],
-			],
-		);
+		let tracker = retained_drain_tracker(&issue);
 
 		state_store
 			.upsert_worktree(
@@ -62,6 +55,7 @@ fn handles_same_issue_closeout_after_merge_visibility() {
 			&repo_root,
 			&tests::sample_review_lifecycle_handoff_fixture("main", pr_url, &head_oid),
 		);
+
 		state_store
 			.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
 				project_id: config.service_id(),
@@ -125,21 +119,48 @@ fn handles_same_issue_closeout_after_merge_visibility() {
 		assert_eq!(drained, closeout_available.then_some(closeout_summary.clone()));
 		assert_eq!(*closeout_dispatches.borrow(), vec![issue.id.clone()]);
 
-		let marker = tests::persisted_review_lifecycle_transition_fixture_for_path(
+		assert_retained_drain_landed(
 			&state_store,
 			config.service_id(),
 			&repo_root,
-		);
-
-		assert_eq!(marker.phase(), "landed");
-
-		support::assert_admin_merge_invocation(
 			&invocation_log_path,
 			&head_oid,
 			landed_merge_subject,
 			pr_url,
 		);
 	}
+}
+
+fn retained_drain_tracker(issue: &TrackerIssue) -> FakeTracker {
+	FakeTracker::with_refresh_snapshots(
+		vec![issue.clone()],
+		vec![vec![issue.clone()], vec![issue.clone()], vec![issue.clone()], vec![issue.clone()]],
+	)
+}
+
+fn assert_retained_drain_landed(
+	state_store: &StateStore,
+	service_id: &str,
+	repo_root: &Path,
+	invocation_log_path: &Path,
+	head_oid: &str,
+	landed_merge_subject: &str,
+	pr_url: &str,
+) {
+	let marker = tests::persisted_review_lifecycle_transition_fixture_for_path(
+		state_store,
+		service_id,
+		repo_root,
+	);
+
+	assert_eq!(marker.phase(), "landed");
+
+	support::assert_admin_merge_invocation(
+		invocation_log_path,
+		head_oid,
+		landed_merge_subject,
+		pr_url,
+	);
 }
 
 #[test]

--- a/apps/decodex/src/orchestrator/tests/intake_candidate_selection/support.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_candidate_selection/support.rs
@@ -58,7 +58,6 @@ pub(super) fn assert_admin_merge_invocation(
 		.lines()
 		.map(str::to_owned)
 		.collect::<Vec<_>>();
-
 	let expected = vec![
 		String::from("pr"),
 		String::from("merge"),
@@ -79,6 +78,7 @@ pub(super) fn assert_admin_merge_invocation(
 	];
 
 	assert!(gh_invocation.starts_with(&expected));
+
 	for extra_view in gh_invocation[expected.len()..].chunks(5) {
 		assert_eq!(
 			extra_view,

--- a/apps/decodex/src/orchestrator/tests/intake_run_and_prompting.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_run_and_prompting.rs
@@ -70,9 +70,10 @@ fn assert_review_repair_developer_prompt(prompt: &str) {
 	assert!(prompt.contains(ISSUE_REVIEW_REPAIR_COMPLETE_TOOL_NAME));
 	assert!(prompt.contains("Do not move the issue back to `In Progress`"));
 	assert!(prompt.contains("do not call `issue_review_handoff`"));
-	assert_runtime_owned_review_prompt_guidance(prompt);
-	assert!(prompt.contains("registered project workflow policy"));
 
+	assert_runtime_owned_review_prompt_guidance(prompt);
+
+	assert!(prompt.contains("registered project workflow policy"));
 	assert!(prompt.contains(
 		"including non-thread review summaries, validate the claim against the codebase, tests, and requirements"
 	));
@@ -85,6 +86,7 @@ fn assert_review_repair_developer_prompt(prompt: &str) {
 
 fn assert_review_repair_user_prompt(prompt: &str, pr_url: &str) {
 	assert!(prompt.contains(pr_url));
+
 	assert_runtime_owned_review_prompt_guidance(prompt);
 
 	assert!(prompt.contains(
@@ -105,6 +107,7 @@ fn assert_review_repair_user_prompt(prompt: &str, pr_url: &str) {
 
 fn assert_review_repair_continuation_prompt(prompt: &str) {
 	assert!(prompt.contains("Resume by committing any review-blocking repair edits"));
+
 	assert_runtime_owned_review_prompt_guidance(prompt);
 
 	assert!(prompt.contains(

--- a/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_prompts/prompt_contract.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_run_and_prompting/intake_run_prompting_prompts/prompt_contract.rs
@@ -103,7 +103,6 @@ fn developer_instructions_render_registered_repo_gate_commands() {
 		run_id: String::from("pub-101-attempt-1-123"),
 		retry_budget_base: 0,
 	};
-
 	let instructions = orchestrator::build_developer_instructions(
 		&tracker,
 		&config,

--- a/apps/decodex/src/orchestrator/tests/intake_workflow_reload.rs
+++ b/apps/decodex/src/orchestrator/tests/intake_workflow_reload.rs
@@ -33,7 +33,6 @@ pub(super) fn expected_developer_instructions(
 		format_command_list(workflow.frontmatter().execution().canonicalize_commands()),
 		format_command_list(workflow.frontmatter().execution().verify_commands())
 	));
-
 	sections.extend(
 		read_first_files
 			.iter()

--- a/apps/decodex/src/orchestrator/tests/recovery_closeout_dispatch/merged_lane.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery_closeout_dispatch/merged_lane.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::{
 	orchestrator::{
 		self, IssueDispatchMode,
@@ -116,13 +118,16 @@ fn closeout_dispatch_completes_merged_lane_without_agent_turn() {
 		.collect::<Vec<_>>();
 
 	assert_eq!(event_types, vec![String::from("closeout"), String::from("cleanup_complete")]);
+
 	let lifecycle_record = state_store
 		.review_lifecycle_record(config.service_id(), &issue.id, &worktree.branch_name)
 		.expect("lifecycle authority lookup should succeed")
 		.expect("deterministic closeout should preserve lifecycle authority");
+
 	assert_eq!(lifecycle_record.next_state(), "closed");
 	assert_eq!(lifecycle_record.transition(), "closeout_completed");
 	assert_eq!(lifecycle_record.cleanup_state(), "completed");
+
 	assert_stale_review_wait_sync_preserves_closed_lifecycle(
 		&state_store,
 		StaleReviewWaitSync {
@@ -135,16 +140,22 @@ fn closeout_dispatch_completes_merged_lane_without_agent_turn() {
 			head_oid: &head_oid,
 		},
 	);
-	assert!(!worktree.path.exists(), "deterministic closeout should remove the retained worktree");
+	assert_closeout_cleared_runtime_state(&state_store, &tracker, &issue.id, &worktree.path);
+}
+
+fn assert_closeout_cleared_runtime_state(
+	state_store: &StateStore,
+	tracker: &FakeTracker,
+	issue_id: &str,
+	worktree_path: &Path,
+) {
+	assert!(!worktree_path.exists(), "deterministic closeout should remove the retained worktree");
 	assert!(
-		state_store
-			.worktree_for_issue(&issue.id)
-			.expect("worktree lookup should succeed")
-			.is_none(),
+		state_store.worktree_for_issue(issue_id).expect("worktree lookup should succeed").is_none(),
 		"deterministic closeout should clear retained worktree state"
 	);
 	assert!(
-		state_store.lease_for_issue(&issue.id).expect("lease lookup should succeed").is_none(),
+		state_store.lease_for_issue(issue_id).expect("lease lookup should succeed").is_none(),
 		"deterministic closeout should not leave an run lease"
 	);
 	assert_eq!(

--- a/apps/decodex/src/orchestrator/tests/recovery_runtime_reentry/startup_recovery.rs
+++ b/apps/decodex/src/orchestrator/tests/recovery_runtime_reentry/startup_recovery.rs
@@ -151,6 +151,7 @@ fn run_project_once_recovers_ready_post_review_lane_before_landing() {
 		&issue.id,
 		&tests::sample_review_lifecycle_handoff_fixture(&worktree.branch_name, pr_url, &head_oid),
 	);
+
 	state_store
 		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
 			project_id: config.service_id(),

--- a/apps/decodex/src/orchestrator/tests/retry_scheduling/daemon_retained/daemon_tick_clears_terminal_mapping_without_worktree_before_retained_land.rs
+++ b/apps/decodex/src/orchestrator/tests/retry_scheduling/daemon_retained/daemon_tick_clears_terminal_mapping_without_worktree_before_retained_land.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::{
 	orchestrator::{
 		self, DaemonTickRuntimeContext, RetryQueue, ReviewLevel, StateStore, tests,
@@ -76,39 +78,16 @@ fn daemon_tick_clears_terminal_mapping_without_worktree_before_retained_land() {
 			&config.worktree_root().join("PUB-703").display().to_string(),
 		)
 		.expect("terminal stale worktree should record");
-	state_store
-		.upsert_worktree(
-			config.service_id(),
-			&retained_issue.id,
-			&retained_worktree.branch_name,
-			&retained_worktree.path.display().to_string(),
-		)
-		.expect("retained worktree should record");
 
-	tests::seed_review_lifecycle_handoff_fixture_value(
+	seed_ready_retained_lane(
 		&state_store,
 		config.service_id(),
 		&retained_issue.id,
-		&tests::sample_review_lifecycle_handoff_fixture(
-			&retained_worktree.branch_name,
-			pr_url,
-			&head_oid,
-		),
+		&retained_worktree.branch_name,
+		&retained_worktree.path,
+		pr_url,
+		&head_oid,
 	);
-	state_store
-		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
-			project_id: config.service_id(),
-			issue_id: &retained_issue.id,
-			run_id: "run-1",
-			attempt_number: 1,
-			phase: "handoff",
-			review_level: "standard",
-			status: "clean",
-			head_sha: &head_oid,
-			nonclean_rounds: 0,
-			details_json: "{}",
-		})
-		.expect("runtime standard checkpoint should persist");
 
 	let mut active_children = Vec::new();
 	let mut retry_queue = RetryQueue::default();
@@ -149,4 +128,40 @@ fn daemon_tick_clears_terminal_mapping_without_worktree_before_retained_land() {
 		PUB_704_RETAINED_LANDED_SUBJECT,
 		pr_url,
 	);
+}
+
+fn seed_ready_retained_lane(
+	state_store: &StateStore,
+	service_id: &str,
+	issue_id: &str,
+	branch_name: &str,
+	worktree_path: &Path,
+	pr_url: &str,
+	head_oid: &str,
+) {
+	state_store
+		.upsert_worktree(service_id, issue_id, branch_name, &worktree_path.display().to_string())
+		.expect("retained worktree should record");
+
+	tests::seed_review_lifecycle_handoff_fixture_value(
+		state_store,
+		service_id,
+		issue_id,
+		&tests::sample_review_lifecycle_handoff_fixture(branch_name, pr_url, head_oid),
+	);
+
+	state_store
+		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
+			project_id: service_id,
+			issue_id,
+			run_id: "run-1",
+			attempt_number: 1,
+			phase: "handoff",
+			review_level: "standard",
+			status: "clean",
+			head_sha: head_oid,
+			nonclean_rounds: 0,
+			details_json: "{}",
+		})
+		.expect("runtime standard checkpoint should persist");
 }

--- a/apps/decodex/src/orchestrator/tests/retry_scheduling/daemon_retained/daemon_tick_reconciles_ready_retained_review_lane_before_dry_run_planning.rs
+++ b/apps/decodex/src/orchestrator/tests/retry_scheduling/daemon_retained/daemon_tick_reconciles_ready_retained_review_lane_before_dry_run_planning.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::{
 	orchestrator::{
 		self, DaemonTickRuntimeContext, RetryQueue, ReviewLevel, StateStore, tests,
@@ -60,42 +62,19 @@ fn daemon_tick_reconciles_ready_retained_review_lane_before_dry_run_planning() {
 		PUB_704_RETAINED_HEAD_SUBJECT,
 	);
 
-	state_store
-		.upsert_worktree(
-			config.service_id(),
-			&retained_issue.id,
-			&retained_worktree.branch_name,
-			&retained_worktree.path.display().to_string(),
-		)
-		.expect("retained worktree should record");
-	state_store
-		.record_run_attempt("leased-run", &active_issue.id, 1, "running")
-		.expect("current lane should record");
-
-	tests::seed_review_lifecycle_handoff_fixture_value(
+	seed_ready_retained_lane(
 		&state_store,
 		config.service_id(),
 		&retained_issue.id,
-		&tests::sample_review_lifecycle_handoff_fixture(
-			&retained_worktree.branch_name,
-			pr_url,
-			&head_oid,
-		),
+		&retained_worktree.branch_name,
+		&retained_worktree.path,
+		pr_url,
+		&head_oid,
 	);
+
 	state_store
-		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
-			project_id: config.service_id(),
-			issue_id: &retained_issue.id,
-			run_id: "runtime-review",
-			attempt_number: 1,
-			phase: "handoff",
-			review_level: "standard",
-			status: "clean",
-			head_sha: &head_oid,
-			nonclean_rounds: 0,
-			details_json: "{}",
-		})
-		.expect("runtime clean review checkpoint should seed");
+		.record_run_attempt("leased-run", &active_issue.id, 1, "running")
+		.expect("current lane should record");
 
 	let review_state = tests::sample_pull_request_review_state(
 		pr_url,
@@ -144,4 +123,40 @@ fn daemon_tick_reconciles_ready_retained_review_lane_before_dry_run_planning() {
 		PUB_704_RETAINED_LANDED_SUBJECT,
 		pr_url,
 	);
+}
+
+fn seed_ready_retained_lane(
+	state_store: &StateStore,
+	service_id: &str,
+	issue_id: &str,
+	branch_name: &str,
+	worktree_path: &Path,
+	pr_url: &str,
+	head_oid: &str,
+) {
+	state_store
+		.upsert_worktree(service_id, issue_id, branch_name, &worktree_path.display().to_string())
+		.expect("retained worktree should record");
+
+	tests::seed_review_lifecycle_handoff_fixture_value(
+		state_store,
+		service_id,
+		issue_id,
+		&tests::sample_review_lifecycle_handoff_fixture(branch_name, pr_url, head_oid),
+	);
+
+	state_store
+		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
+			project_id: service_id,
+			issue_id,
+			run_id: "runtime-review",
+			attempt_number: 1,
+			phase: "handoff",
+			review_level: "standard",
+			status: "clean",
+			head_sha: head_oid,
+			nonclean_rounds: 0,
+			details_json: "{}",
+		})
+		.expect("runtime clean review checkpoint should seed");
 }

--- a/apps/decodex/src/orchestrator/tests/review_landing_classification_checks/landing_gates/review_checks.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_classification_checks/landing_gates/review_checks.rs
@@ -54,6 +54,7 @@ fn review_state_gates_allow_configured_status_context_when_rollup_pending() {
 		Some("PENDING"),
 		0,
 	);
+
 	review_state.required_status_contexts = vec![PullRequestRequiredStatusContext {
 		context: String::from("decodex/local-full-check"),
 		state: Some(String::from("success")),
@@ -82,6 +83,7 @@ fn review_state_gates_wait_for_configured_status_context_on_stale_base() {
 		Some("SUCCESS"),
 		0,
 	);
+
 	review_state.required_status_contexts = vec![PullRequestRequiredStatusContext {
 		context: String::from("decodex/local-full-check"),
 		state: Some(String::from("success")),
@@ -110,6 +112,7 @@ fn configured_status_context_success_ignores_failed_global_rollup() {
 		Some("FAILURE"),
 		0,
 	);
+
 	review_state.required_status_contexts = vec![PullRequestRequiredStatusContext {
 		context: String::from("decodex/local-full-check"),
 		state: Some(String::from("success")),

--- a/apps/decodex/src/orchestrator/tests/review_landing_classification_review.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_classification_review.rs
@@ -170,6 +170,7 @@ pub(super) fn initialize_empty_git_worktree(worktree_path: &Path) {
 		.stderr(Stdio::null())
 		.status()
 		.expect("git init should run");
+
 	assert!(status.success(), "git init should succeed");
 }
 

--- a/apps/decodex/src/orchestrator/tests/review_landing_classification_review/authority_boundary/zero_review.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_classification_review/authority_boundary/zero_review.rs
@@ -74,7 +74,7 @@ fn classify_post_review_lane_ready_to_land_allows_zero_required_review_repos() {
 
 	tests::add_external_review_ack(&mut review_state);
 	tests::add_external_review_pass(&mut review_state);
-	super::super::record_clean_review_checkpoint_for_head(
+	review_landing_classification_review::record_clean_review_checkpoint_for_head(
 		&state_store,
 		&snapshot.issue.id,
 		&head_oid,

--- a/apps/decodex/src/orchestrator/tests/review_landing_orchestration/landed_lineage_merge/admin_merge.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_orchestration/landed_lineage_merge/admin_merge.rs
@@ -53,6 +53,7 @@ fn reconcile_post_review_orchestration_runs_admin_merge_after_external_pass() {
 			1,
 		),
 	);
+
 	state_store
 		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
 			project_id: config.service_id(),
@@ -117,10 +118,12 @@ fn reconcile_post_review_orchestration_runs_admin_merge_after_external_pass() {
 			String::from("state,headRefOid,mergeCommit"),
 		]
 	);
+
 	let lifecycle = state_store
 		.review_lifecycle_record(config.service_id(), &issue.id, "main")
 		.expect("lifecycle record should read")
 		.expect("landing authority should record");
+
 	assert_eq!(lifecycle.next_state(), "landed");
 	assert_eq!(lifecycle.transition(), "landed");
 	assert_eq!(lifecycle.merge_commit(), Some("cafebabe"));
@@ -142,6 +145,7 @@ fn records_lifecycle_attention_when_admin_merge_unavailable() {
 	state_store
 		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
 		.expect("worktree should record");
+
 	tests::seed_review_lifecycle_handoff_fixture_for_path(
 		&state_store,
 		config.service_id(),
@@ -160,6 +164,7 @@ fn records_lifecycle_attention_when_admin_merge_unavailable() {
 			1,
 		),
 	);
+
 	state_store
 		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
 			project_id: config.service_id(),
@@ -185,8 +190,10 @@ fn records_lifecycle_attention_when_admin_merge_unavailable() {
 		Some("SUCCESS"),
 		0,
 	);
+
 	tests::add_external_review_ack(&mut review_state);
 	tests::add_external_review_pass(&mut review_state);
+
 	review_state.merge_commit_allowed = false;
 
 	orchestrator::reconcile_post_review_orchestration_with_inspector(
@@ -202,6 +209,7 @@ fn records_lifecycle_attention_when_admin_merge_unavailable() {
 		.review_lifecycle_record(config.service_id(), &issue.id, "main")
 		.expect("lifecycle record should read")
 		.expect("manual attention authority should record");
+
 	assert_eq!(lifecycle.next_state(), "manual_attention_required");
 	assert_eq!(lifecycle.transition(), "manual_attention_required");
 	assert_eq!(lifecycle.next_action(), "request_manual_attention");

--- a/apps/decodex/src/orchestrator/tests/review_landing_orchestration/landed_lineage_merge/authority_boundaries/blocks_admin_merge_for_authority_request.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_orchestration/landed_lineage_merge/authority_boundaries/blocks_admin_merge_for_authority_request.rs
@@ -51,6 +51,7 @@ fn blocks_admin_merge_for_authority_request() {
 			1,
 		),
 	);
+
 	state_store
 		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
 			project_id: config.service_id(),
@@ -65,6 +66,7 @@ fn blocks_admin_merge_for_authority_request() {
 			details_json: "{}",
 		})
 		.expect("runtime review checkpoint should persist");
+
 	review_landing_classification_review::record_authority_decision_request(&state_store, &issue);
 
 	let mut review_state = tests::sample_pull_request_review_state(

--- a/apps/decodex/src/orchestrator/tests/review_landing_orchestration/landed_lineage_merge/authority_boundaries/blocks_admin_merge_for_human_boundary.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_orchestration/landed_lineage_merge/authority_boundaries/blocks_admin_merge_for_human_boundary.rs
@@ -51,6 +51,7 @@ fn blocks_admin_merge_for_human_boundary() {
 			1,
 		),
 	);
+
 	state_store
 		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
 			project_id: config.service_id(),
@@ -65,6 +66,7 @@ fn blocks_admin_merge_for_human_boundary() {
 			details_json: "{}",
 		})
 		.expect("runtime review checkpoint should persist");
+
 	review_landing_classification_review::record_requires_human_authority_boundary(
 		&state_store,
 		&issue,

--- a/apps/decodex/src/orchestrator/tests/review_landing_orchestration/landed_lineage_merge/authority_boundaries/reconcile_post_review_orchestration_blocks_admin_merge_for_authority_boundary.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_orchestration/landed_lineage_merge/authority_boundaries/reconcile_post_review_orchestration_blocks_admin_merge_for_authority_boundary.rs
@@ -51,6 +51,7 @@ fn reconcile_post_review_orchestration_blocks_admin_merge_for_authority_boundary
 			1,
 		),
 	);
+
 	state_store
 		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
 			project_id: config.service_id(),
@@ -65,6 +66,7 @@ fn reconcile_post_review_orchestration_blocks_admin_merge_for_authority_boundary
 			details_json: "{}",
 		})
 		.expect("runtime review checkpoint should persist");
+
 	review_landing_classification_review::record_block_landing_authority_boundary(
 		&state_store,
 		&issue,

--- a/apps/decodex/src/orchestrator/tests/review_landing_orchestration/landing_fallbacks.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_orchestration/landing_fallbacks.rs
@@ -20,23 +20,33 @@ use std::{
 use crate::{
 	agent::ReviewExecutionMode,
 	orchestrator::{
-		self, ReviewLevel, StateStore,
+		self, ReviewLevel, StateStore, retained_review_orchestration,
 		runtime_standard_review::{RuntimeStandardReviewRunRequest, RuntimeStandardReviewRunner},
 		tests::{
 			self, FakePullRequestReviewStateInspector, FakeTracker, review_landing_status_support,
 		},
 	},
 	prelude::{Result, eyre},
-	state::ReviewPolicyCheckpointInput,
+	state::{ReviewCheckpointArtifactLookup, ReviewPolicyCheckpointInput},
 };
 
 struct FailingRuntimeReviewRunner {
 	calls: Cell<usize>,
 }
-
 impl FailingRuntimeReviewRunner {
 	fn new() -> Self {
 		Self { calls: Cell::new(0) }
+	}
+}
+
+impl RuntimeStandardReviewRunner for FailingRuntimeReviewRunner {
+	fn run_runtime_standard_review(
+		&self,
+		_request: RuntimeStandardReviewRunRequest<'_>,
+	) -> Result<String> {
+		self.calls.set(self.calls.get() + 1);
+
+		eyre::bail!("fake runtime review runner keeps checkpoint pending")
 	}
 }
 
@@ -45,7 +55,6 @@ struct CleanRuntimeReviewRunner {
 	last_review_mode: Cell<Option<ReviewExecutionMode>>,
 	last_head_sha: RefCell<Option<String>>,
 }
-
 impl CleanRuntimeReviewRunner {
 	fn new() -> Self {
 		Self {
@@ -56,10 +65,51 @@ impl CleanRuntimeReviewRunner {
 	}
 }
 
+impl RuntimeStandardReviewRunner for CleanRuntimeReviewRunner {
+	fn run_runtime_standard_review(
+		&self,
+		request: RuntimeStandardReviewRunRequest<'_>,
+	) -> Result<String> {
+		self.calls.set(self.calls.get() + 1);
+		self.last_review_mode.set(Some(request.review_mode()));
+
+		*self.last_head_sha.borrow_mut() = Some(request.head_sha().to_owned());
+
+		Ok(serde_json::json!({
+			"status": "clean",
+			"checks": {
+				"intended_behavior": "The retained PR head still satisfies the issue objective.",
+				"regression_risk": "No current-head regression was found.",
+				"missing_tests": "No additional required tests were identified.",
+				"openwiki_config_drift": "No OpenWiki or config drift was found.",
+				"migration_fallout": "No migration fallout was found.",
+				"operator_facing_fallout": "No operator-facing fallout was found.",
+				"loop_decision_contract": "The lifecycle can proceed after the runtime-owned checkpoint."
+			},
+			"evidence": [
+				"Independent reviewer inspected the current retained HEAD and PR lineage."
+			],
+			"review_cost_control": {
+				"review_class": "full_current_head_review",
+				"risk_class": "localized",
+				"changed_surface_count": 1,
+				"changed_surface_summary": ["retained.txt"],
+				"high_risk_surfaces": [],
+				"current_head_evidence": true,
+				"validation_backed": true,
+				"validation_current": true,
+				"evidence_sufficient": true,
+				"reviewer_judgment": "The current retained HEAD has enough evidence for landing.",
+				"fallback_reason": "runtime_full_review"
+			}
+		})
+		.to_string())
+	}
+}
+
 struct TerminalRuntimeReviewRunner {
 	status: &'static str,
 }
-
 impl TerminalRuntimeReviewRunner {
 	fn new(status: &'static str) -> Self {
 		Self { status }
@@ -114,58 +164,6 @@ impl RuntimeStandardReviewRunner for TerminalRuntimeReviewRunner {
 			}
 		})
 		.to_string())
-	}
-}
-
-impl RuntimeStandardReviewRunner for CleanRuntimeReviewRunner {
-	fn run_runtime_standard_review(
-		&self,
-		request: RuntimeStandardReviewRunRequest<'_>,
-	) -> Result<String> {
-		self.calls.set(self.calls.get() + 1);
-		self.last_review_mode.set(Some(request.review_mode()));
-		*self.last_head_sha.borrow_mut() = Some(request.head_sha().to_owned());
-
-		Ok(serde_json::json!({
-			"status": "clean",
-			"checks": {
-				"intended_behavior": "The retained PR head still satisfies the issue objective.",
-				"regression_risk": "No current-head regression was found.",
-				"missing_tests": "No additional required tests were identified.",
-				"openwiki_config_drift": "No OpenWiki or config drift was found.",
-				"migration_fallout": "No migration fallout was found.",
-				"operator_facing_fallout": "No operator-facing fallout was found.",
-				"loop_decision_contract": "The lifecycle can proceed after the runtime-owned checkpoint."
-			},
-			"evidence": [
-				"Independent reviewer inspected the current retained HEAD and PR lineage."
-			],
-			"review_cost_control": {
-				"review_class": "full_current_head_review",
-				"risk_class": "localized",
-				"changed_surface_count": 1,
-				"changed_surface_summary": ["retained.txt"],
-				"high_risk_surfaces": [],
-				"current_head_evidence": true,
-				"validation_backed": true,
-				"validation_current": true,
-				"evidence_sufficient": true,
-				"reviewer_judgment": "The current retained HEAD has enough evidence for landing.",
-				"fallback_reason": "runtime_full_review"
-			}
-		})
-		.to_string())
-	}
-}
-
-impl RuntimeStandardReviewRunner for FailingRuntimeReviewRunner {
-	fn run_runtime_standard_review(
-		&self,
-		_request: RuntimeStandardReviewRunRequest<'_>,
-	) -> Result<String> {
-		self.calls.set(self.calls.get() + 1);
-
-		eyre::bail!("fake runtime review runner keeps checkpoint pending")
 	}
 }
 
@@ -262,10 +260,12 @@ fn assert_admin_merge_without_external_review(review_level: ReviewLevel) {
 			String::from("state,headRefOid,mergeCommit"),
 		]
 	);
+
 	let lifecycle = state_store
 		.review_lifecycle_record(config.service_id(), &issue.id, "main")
 		.expect("lifecycle record should read")
 		.expect("landing authority should record");
+
 	assert_eq!(lifecycle.next_state(), "landed");
 	assert_eq!(lifecycle.merge_commit(), Some("cafebabe"));
 	assert!(
@@ -295,6 +295,7 @@ fn assert_waits_for_checkpoint() {
 	let merge_subject = r#"{"schema":"decodex/commit/2","change":"current retained handoff","authority":"PUB-101","impact":"compatible"}"#;
 	let head_oid =
 		tests::commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
+
 	configure_cached_github_origin(&repo_root);
 
 	state_store
@@ -318,9 +319,9 @@ fn assert_waits_for_checkpoint() {
 		Some("SUCCESS"),
 		0,
 	);
-
 	let runtime_review_runner = FailingRuntimeReviewRunner::new();
-	orchestrator::retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
+
+	retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
 		&tracker,
 		&config,
 		&workflow,
@@ -370,11 +371,13 @@ fn assert_checkpoint_failure_after_budget() {
 	let merge_subject = r#"{"schema":"decodex/commit/2","change":"current retained handoff","authority":"PUB-101","impact":"compatible"}"#;
 	let head_oid =
 		tests::commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
+
 	configure_cached_github_origin(&repo_root);
 
 	state_store
 		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
 		.expect("worktree should record");
+
 	tests::seed_review_lifecycle_handoff_fixture_for_path(
 		&state_store,
 		config.service_id(),
@@ -397,7 +400,7 @@ fn assert_checkpoint_failure_after_budget() {
 	let runtime_review_runner = FailingRuntimeReviewRunner::new();
 
 	for _ in 0..3 {
-		orchestrator::retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
+		retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
 			&tracker,
 			&config,
 			&workflow,
@@ -428,6 +431,7 @@ fn assert_checkpoint_failure_after_budget() {
 		!invocation_log_path.exists(),
 		"bounded producer failures must not fall through to admin merge",
 	);
+
 	assert_standard_review_attention_lifecycle_authority(
 		&state_store,
 		config.service_id(),
@@ -457,11 +461,13 @@ fn assert_terminal_review_status_attention(status: &'static str, expected_reason
 	let merge_subject = r#"{"schema":"decodex/commit/2","change":"current retained handoff","authority":"PUB-101","impact":"compatible"}"#;
 	let head_oid =
 		tests::commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
+
 	configure_cached_github_origin(&repo_root);
 
 	state_store
 		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
 		.expect("worktree should record");
+
 	tests::seed_review_lifecycle_handoff_fixture_for_path(
 		&state_store,
 		config.service_id(),
@@ -483,7 +489,7 @@ fn assert_terminal_review_status_attention(status: &'static str, expected_reason
 	};
 	let runtime_review_runner = TerminalRuntimeReviewRunner::new(status);
 
-	orchestrator::retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
+	retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
 		&tracker,
 		&config,
 		&workflow,
@@ -494,7 +500,7 @@ fn assert_terminal_review_status_attention(status: &'static str, expected_reason
 	.expect("first pass should record terminal runtime review checkpoint");
 
 	let checkpoint = state_store
-		.review_checkpoint_artifact(crate::state::ReviewCheckpointArtifactLookup {
+		.review_checkpoint_artifact(ReviewCheckpointArtifactLookup {
 			project_id: config.service_id(),
 			issue_id: &issue.id,
 			phase: "handoff",
@@ -503,10 +509,11 @@ fn assert_terminal_review_status_attention(status: &'static str, expected_reason
 		})
 		.expect("checkpoint lookup should succeed")
 		.expect("terminal runtime review checkpoint should persist");
+
 	assert_eq!(checkpoint.status(), status);
 	assert!(tracker.comments.borrow().is_empty());
 
-	orchestrator::retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
+	retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
 		&tracker,
 		&config,
 		&workflow,
@@ -524,6 +531,7 @@ fn assert_terminal_review_status_attention(status: &'static str, expected_reason
 		!invocation_log_path.exists(),
 		"terminal Standard review status must not fall through to admin merge",
 	);
+
 	assert_standard_review_attention_lifecycle_authority(
 		&state_store,
 		config.service_id(),
@@ -553,17 +561,20 @@ fn assert_unknown_review_status_attention() {
 	let merge_subject = r#"{"schema":"decodex/commit/2","change":"current retained handoff","authority":"PUB-101","impact":"compatible"}"#;
 	let head_oid =
 		tests::commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
+
 	configure_cached_github_origin(&repo_root);
 
 	state_store
 		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
 		.expect("worktree should record");
+
 	tests::seed_review_lifecycle_handoff_fixture_for_path(
 		&state_store,
 		config.service_id(),
 		&repo_root,
 		&tests::sample_review_lifecycle_handoff_fixture("main", pr_url, &head_oid),
 	);
+
 	state_store
 		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
 			project_id: config.service_id(),
@@ -591,7 +602,7 @@ fn assert_unknown_review_status_attention() {
 	);
 	let runtime_review_runner = CleanRuntimeReviewRunner::new();
 
-	orchestrator::retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
+	retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
 		&tracker,
 		&config,
 		&workflow,
@@ -614,6 +625,7 @@ fn assert_unknown_review_status_attention() {
 		!invocation_log_path.exists(),
 		"unknown Standard review status must not fall through to admin merge",
 	);
+
 	assert_standard_review_attention_lifecycle_authority(
 		&state_store,
 		config.service_id(),
@@ -659,11 +671,13 @@ fn assert_skips_review_while_gates_pending() {
 	let merge_subject = r#"{"schema":"decodex/commit/2","change":"current retained handoff","authority":"PUB-101","impact":"compatible"}"#;
 	let head_oid =
 		tests::commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
+
 	configure_cached_github_origin(&repo_root);
 
 	state_store
 		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
 		.expect("worktree should record");
+
 	tests::seed_review_lifecycle_handoff_fixture_for_path(
 		&state_store,
 		config.service_id(),
@@ -683,7 +697,7 @@ fn assert_skips_review_while_gates_pending() {
 	);
 	let runtime_review_runner = CleanRuntimeReviewRunner::new();
 
-	orchestrator::retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
+	retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
 		&tracker,
 		&config,
 		&workflow,
@@ -721,11 +735,13 @@ fn assert_runtime_review_after_external_pass() {
 	let merge_subject = r#"{"schema":"decodex/commit/2","change":"current retained handoff","authority":"PUB-101","impact":"compatible"}"#;
 	let head_oid =
 		tests::commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
+
 	configure_cached_github_origin(&repo_root);
 
 	state_store
 		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
 		.expect("worktree should record");
+
 	tests::seed_review_lifecycle_handoff_fixture_for_path(
 		&state_store,
 		config.service_id(),
@@ -756,13 +772,15 @@ fn assert_runtime_review_after_external_pass() {
 			Some("SUCCESS"),
 			0,
 		);
+
 		tests::add_external_review_ack(&mut review_state);
 		tests::add_external_review_pass(&mut review_state);
+
 		review_state
 	};
 	let runtime_review_runner = CleanRuntimeReviewRunner::new();
 
-	orchestrator::retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
+	retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
 		&tracker,
 		&config,
 		&workflow,
@@ -779,7 +797,7 @@ fn assert_runtime_review_after_external_pass() {
 		"strict review must not land in the same tick that records runtime review evidence",
 	);
 
-	orchestrator::retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
+	retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
 		&tracker,
 		&config,
 		&workflow,
@@ -823,11 +841,13 @@ fn assert_strict_failure_no_external_restart() {
 	let merge_subject = r#"{"schema":"decodex/commit/2","change":"current retained handoff","authority":"PUB-101","impact":"compatible"}"#;
 	let head_oid =
 		tests::commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
+
 	configure_cached_github_origin(&repo_root);
 
 	state_store
 		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
 		.expect("worktree should record");
+
 	tests::seed_review_lifecycle_handoff_fixture_for_path(
 		&state_store,
 		config.service_id(),
@@ -858,14 +878,16 @@ fn assert_strict_failure_no_external_restart() {
 			Some("SUCCESS"),
 			0,
 		);
+
 		tests::add_external_review_ack(&mut review_state);
 		tests::add_external_review_pass(&mut review_state);
+
 		review_state
 	};
 	let runtime_review_runner = FailingRuntimeReviewRunner::new();
 
 	for _ in 0..3 {
-		orchestrator::retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
+		retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
 			&tracker,
 			&config,
 			&workflow,
@@ -920,6 +942,7 @@ fn assert_checkpoint_before_admin_merge() {
 	let merge_subject = r#"{"schema":"decodex/commit/2","change":"current retained handoff","authority":"PUB-101","impact":"compatible"}"#;
 	let head_oid =
 		tests::commit_worktree_change(&repo_root, "retained.txt", "ready\n", merge_subject);
+
 	configure_cached_github_origin(&repo_root);
 
 	state_store
@@ -947,7 +970,7 @@ fn assert_checkpoint_before_admin_merge() {
 	};
 	let runtime_review_runner = CleanRuntimeReviewRunner::new();
 
-	orchestrator::retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
+	retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
 		&tracker,
 		&config,
 		&workflow,
@@ -966,7 +989,7 @@ fn assert_checkpoint_before_admin_merge() {
 	);
 
 	let checkpoint = state_store
-		.review_checkpoint_artifact(crate::state::ReviewCheckpointArtifactLookup {
+		.review_checkpoint_artifact(ReviewCheckpointArtifactLookup {
 			project_id: config.service_id(),
 			issue_id: &issue.id,
 			phase: "handoff",
@@ -975,9 +998,10 @@ fn assert_checkpoint_before_admin_merge() {
 		})
 		.expect("checkpoint lookup should succeed")
 		.expect("runtime-owned review checkpoint should persist");
+
 	assert_eq!(checkpoint.status(), "clean");
 
-	orchestrator::retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
+	retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
 		&tracker,
 		&config,
 		&workflow,
@@ -992,6 +1016,7 @@ fn assert_checkpoint_before_admin_merge() {
 		1,
 		"existing current-head checkpoint must prevent duplicate runtime review"
 	);
+
 	let lifecycle = state_store
 		.review_lifecycle_record(config.service_id(), &issue.id, "main")
 		.expect("lifecycle record should read")
@@ -1034,6 +1059,7 @@ fn assert_repair_checkpoint_after_findings() {
 		"repaired\n",
 		r#"{"schema":"decodex/commit/2","change":"repair retained findings","authority":"PUB-101","impact":"compatible"}"#,
 	);
+
 	configure_cached_github_origin(&repo_root);
 
 	state_store
@@ -1053,6 +1079,7 @@ fn assert_repair_checkpoint_after_findings() {
 	state_store
 		.upsert_worktree("pubfi", &issue.id, "main", &repo_root.display().to_string())
 		.expect("worktree should record");
+
 	tests::seed_review_lifecycle_handoff_fixture_for_path(
 		&state_store,
 		config.service_id(),
@@ -1072,7 +1099,7 @@ fn assert_repair_checkpoint_after_findings() {
 	);
 	let runtime_review_runner = CleanRuntimeReviewRunner::new();
 
-	orchestrator::retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
+	retained_review_orchestration::reconcile_post_review_orchestration_with_runners(
 		&tracker,
 		&config,
 		&workflow,
@@ -1088,8 +1115,9 @@ fn assert_repair_checkpoint_after_findings() {
 		runtime_review_runner.last_head_sha.borrow().as_deref(),
 		Some(repaired_head_oid.as_str()),
 	);
+
 	let checkpoint = state_store
-		.review_checkpoint_artifact(crate::state::ReviewCheckpointArtifactLookup {
+		.review_checkpoint_artifact(ReviewCheckpointArtifactLookup {
 			project_id: config.service_id(),
 			issue_id: &issue.id,
 			phase: "repair",

--- a/apps/decodex/src/orchestrator/tests/review_landing_orchestration/wait_conditions/merge_race.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_orchestration/wait_conditions/merge_race.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs, path::Path};
 
 use crate::{
 	orchestrator::{
@@ -53,6 +53,7 @@ fn reconcile_post_review_orchestration_tolerates_already_merged_merge_race() {
 			1,
 		),
 	);
+
 	state_store
 		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
 			project_id: config.service_id(),
@@ -90,7 +91,29 @@ fn reconcile_post_review_orchestration_tolerates_already_merged_merge_race() {
 	)
 	.expect("post-review orchestration should accept an already-merged PR race");
 
-	let gh_invocation = fs::read_to_string(&invocation_log_path)
+	assert_merge_race_invocation(&invocation_log_path, &head_oid, landed_merge_subject, pr_url);
+
+	let lifecycle = state_store
+		.review_lifecycle_record(config.service_id(), &issue.id, "main")
+		.expect("lifecycle record should read")
+		.expect("landing authority should record");
+
+	assert_eq!(lifecycle.next_state(), "landed");
+	assert_eq!(lifecycle.merge_commit(), Some("cafebabe"));
+	assert!(
+		tracker.comments.borrow().is_empty(),
+		"already-merged race handling should persist orchestration in StateStore, not Linear comments",
+	);
+	assert!(tracker.label_additions.borrow().is_empty());
+}
+
+fn assert_merge_race_invocation(
+	invocation_log_path: &Path,
+	head_oid: &str,
+	landed_merge_subject: &str,
+	pr_url: &str,
+) {
+	let gh_invocation = fs::read_to_string(invocation_log_path)
 		.expect("fake gh invocation log should read")
 		.lines()
 		.map(str::to_owned)
@@ -104,7 +127,7 @@ fn reconcile_post_review_orchestration_tolerates_already_merged_merge_race() {
 			String::from("--admin"),
 			String::from("--merge"),
 			String::from("--match-head-commit"),
-			head_oid,
+			String::from(head_oid),
 			String::from("--subject"),
 			String::from(landed_merge_subject),
 			String::from("--body"),
@@ -122,15 +145,4 @@ fn reconcile_post_review_orchestration_tolerates_already_merged_merge_race() {
 			String::from("state,headRefOid,mergeCommit"),
 		]
 	);
-	let lifecycle = state_store
-		.review_lifecycle_record(config.service_id(), &issue.id, "main")
-		.expect("lifecycle record should read")
-		.expect("landing authority should record");
-	assert_eq!(lifecycle.next_state(), "landed");
-	assert_eq!(lifecycle.merge_commit(), Some("cafebabe"));
-	assert!(
-		tracker.comments.borrow().is_empty(),
-		"already-merged race handling should persist orchestration in StateStore, not Linear comments",
-	);
-	assert!(tracker.label_additions.borrow().is_empty());
 }

--- a/apps/decodex/src/orchestrator/tests/review_landing_status_markers.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_status_markers.rs
@@ -15,9 +15,9 @@ fn ignores_stale_marker_projection_from_prior_handoff() {
 	let head_oid = "abc123";
 	let branch_name = "x/pubfi-pub-101";
 	let stale_pr_url = "https://github.com/hack-ink/decodex/pull/99";
-
 	let stale_handoff =
 		tests::sample_review_lifecycle_handoff_fixture(branch_name, stale_pr_url, "deadbeef");
+
 	state_store
 		.upsert_review_lifecycle_handoff_fixture(config.service_id(), &issue.id, &stale_handoff)
 		.expect("stale handoff should persist");
@@ -44,9 +44,11 @@ fn ignores_stale_marker_projection_from_prior_handoff() {
 
 	let current_handoff =
 		tests::sample_review_lifecycle_handoff_fixture(branch_name, current_pr_url, head_oid);
+
 	state_store
 		.upsert_review_lifecycle_handoff_fixture(config.service_id(), &issue.id, &current_handoff)
 		.expect("current lifecycle authority should persist");
+
 	let lifecycle_record = state_store
 		.review_lifecycle_record(config.service_id(), &issue.id, branch_name)
 		.expect("lifecycle lookup should succeed")

--- a/apps/decodex/src/orchestrator/tests/review_landing_status_rows/review_signals/readback.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_status_rows/review_signals/readback.rs
@@ -215,6 +215,7 @@ fn standard_review_waits_for_runtime_review_checkpoint_before_landing() {
 
 	fs::write(repo_root.join("dirty-after-review.txt"), "dirty\n")
 		.expect("dirty worktree file should write");
+
 	let lanes = orchestrator::build_post_review_lane_statuses(
 		&tracker,
 		&config,

--- a/apps/decodex/src/orchestrator/tests/review_landing_status_rows/review_signals/thumbs_up.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_status_rows/review_signals/thumbs_up.rs
@@ -83,6 +83,7 @@ fn accepts_existing_thumbs_up_for_later_pass_rounds() {
 		"APPROVED",
 		TEST_EXTERNAL_REVIEW_REQUEST_CREATED_AT + 1,
 	);
+
 	state_store
 		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
 			project_id: config.service_id(),

--- a/apps/decodex/src/orchestrator/tests/review_landing_status_rows/worktree_handoff/allows_descendant_head_after_repair.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_status_rows/worktree_handoff/allows_descendant_head_after_repair.rs
@@ -68,6 +68,7 @@ fn allows_descendant_head_after_repair() {
 
 	tests::add_external_review_ack(&mut review_state);
 	tests::add_external_review_pass(&mut review_state);
+
 	state_store
 		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
 			project_id: config.service_id(),

--- a/apps/decodex/src/orchestrator/tests/review_landing_status_rows/worktree_handoff/leaves_managed_git_metadata.rs
+++ b/apps/decodex/src/orchestrator/tests/review_landing_status_rows/worktree_handoff/leaves_managed_git_metadata.rs
@@ -96,6 +96,7 @@ fn leaves_managed_git_metadata() {
 
 	tests::add_external_review_ack(&mut review_state);
 	tests::add_external_review_pass(&mut review_state);
+
 	state_store
 		.upsert_review_policy_checkpoint(ReviewPolicyCheckpointInput {
 			project_id: config.service_id(),

--- a/apps/decodex/src/orchestrator/tests/runtime_repo_gate/cleanliness_scope/repo_gate_preflight_rejects_missing_cwd_before_commands.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime_repo_gate/cleanliness_scope/repo_gate_preflight_rejects_missing_cwd_before_commands.rs
@@ -4,6 +4,7 @@ use crate::orchestrator::{self, RepoGateFailure, tests};
 fn repo_gate_preflight_rejects_missing_cwd_before_commands() {
 	let (temp_dir, config, _workflow) = tests::temp_project_layout();
 	let missing_worktree = config.repo_root().join("missing-worktree");
+
 	drop(temp_dir);
 
 	let error = orchestrator::run_repo_gate_commands(

--- a/apps/decodex/src/orchestrator/tests/runtime_repo_gate/cleanliness_scope/repo_gate_rejects_dirty_tracked_files_left_by_canonicalize_commands.rs
+++ b/apps/decodex/src/orchestrator/tests/runtime_repo_gate/cleanliness_scope/repo_gate_rejects_dirty_tracked_files_left_by_canonicalize_commands.rs
@@ -29,9 +29,11 @@ fn repo_gate_rejects_dirty_tracked_files_left_by_canonicalize_commands() {
 		repo_gate_failure.disposition(),
 		orchestrator::RepoGateFailureDisposition::NeedsHumanAttention
 	);
+
 	let decision = repo_gate_failure
 		.tracked_rewrite_decision()
 		.expect("lane-external tracked rewrite should include rewrite evidence");
+
 	assert_eq!(decision.to_json()["classification"], "lane_external_tracked_rewrite");
 	assert_eq!(decision.to_json()["decision"], "require_scoped_authority");
 	assert_eq!(decision.to_json()["fileCount"], 1);

--- a/apps/decodex/src/orchestrator/types/review_readback/inspector.rs
+++ b/apps/decodex/src/orchestrator/types/review_readback/inspector.rs
@@ -129,6 +129,7 @@ impl PullRequestReviewStateInspector for GhPullRequestReviewStateInspector {
 			comments_after =
 				types::merge_pull_request_issue_comment_page(&mut review_state, &pull_request)?;
 		}
+
 		review_state.required_status_contexts = github::inspect_required_commit_status_contexts(
 			cwd,
 			&locator.owner,

--- a/apps/decodex/src/orchestrator/types/review_readback/models.rs
+++ b/apps/decodex/src/orchestrator/types/review_readback/models.rs
@@ -1,3 +1,5 @@
+use crate::pull_request::PullRequestRequiredStatusContext;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct PullRequestReviewState {
 	pub(crate) url: String,
@@ -15,7 +17,7 @@ pub(crate) struct PullRequestReviewState {
 	pub(crate) head_repository_name: Option<String>,
 	pub(crate) head_repository_owner: Option<String>,
 	pub(crate) status_check_rollup_state: Option<String>,
-	pub(crate) required_status_contexts: Vec<crate::pull_request::PullRequestRequiredStatusContext>,
+	pub(crate) required_status_contexts: Vec<PullRequestRequiredStatusContext>,
 	pub(crate) unresolved_review_threads: usize,
 	pub(crate) issue_description_external_review_thumbs_up_count: usize,
 	pub(crate) issue_comments: Vec<PullRequestIssueCommentState>,

--- a/apps/decodex/src/pull_request/gates.rs
+++ b/apps/decodex/src/pull_request/gates.rs
@@ -32,7 +32,6 @@ pub(crate) fn classify_landing_gate(
 	{
 		return LandingGateDecision::Repair(reason);
 	}
-
 	if let Some(decision) = required_status_context_gate(view) {
 		return decision;
 	}
@@ -42,14 +41,12 @@ pub(crate) fn classify_landing_gate(
 	{
 		return LandingGateDecision::Repair("required_checks_failed");
 	}
-
 	if !has_required_status_contexts(view)
 		&& let Some(check_state) = view.status_check_rollup_state
 		&& checks_require_wait(Some(check_state))
 	{
 		return LandingGateDecision::Wait("checks_waiting");
 	}
-
 	if mergeability_unknown(view) {
 		return LandingGateDecision::Wait("mergeability_unknown");
 	}
@@ -114,17 +111,6 @@ pub(crate) fn merge_state_allows_ready_to_land(merge_state_status: &str) -> bool
 	matches!(merge_state_status, "CLEAN" | "HAS_HOOKS" | "UNSTABLE")
 }
 
-fn merge_state_allows_ready_to_land_for_view(view: PullRequestLandingGateView<'_>) -> bool {
-	merge_state_allows_ready_to_land(view.merge_state_status)
-		|| (view.fast_landing && view.merge_state_status == "BLOCKED")
-}
-
-fn merge_state_allows_clean_path_landing(view: PullRequestLandingGateView<'_>) -> bool {
-	view.merge_state_status == "CLEAN"
-		|| (view.fast_landing
-			&& matches!(view.merge_state_status, "BLOCKED" | "HAS_HOOKS" | "UNSTABLE"))
-}
-
 pub(crate) fn checks_require_wait(check_state: Option<&str>) -> bool {
 	matches!(check_state, Some("EXPECTED" | "PENDING"))
 }
@@ -148,6 +134,17 @@ pub(crate) fn merge_state_requires_review_repair(
 	}
 
 	None
+}
+
+fn merge_state_allows_ready_to_land_for_view(view: PullRequestLandingGateView<'_>) -> bool {
+	merge_state_allows_ready_to_land(view.merge_state_status)
+		|| (view.fast_landing && view.merge_state_status == "BLOCKED")
+}
+
+fn merge_state_allows_clean_path_landing(view: PullRequestLandingGateView<'_>) -> bool {
+	view.merge_state_status == "CLEAN"
+		|| (view.fast_landing
+			&& matches!(view.merge_state_status, "BLOCKED" | "HAS_HOOKS" | "UNSTABLE"))
 }
 
 fn has_required_status_contexts(view: PullRequestLandingGateView<'_>) -> bool {

--- a/apps/decodex/src/recovery/closeout/apply.rs
+++ b/apps/decodex/src/recovery/closeout/apply.rs
@@ -4,16 +4,21 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::{
 	orchestrator::{
-		PostReviewLifecycleFactsInput, PullRequestReviewState, build_post_review_lifecycle_facts,
-		kernel::lifecycle::{
-			LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome,
-			PreviousLifecycleAuthority, decide_lifecycle_transition,
+		self, PostReviewLifecycleFactsInput, PullRequestReviewState,
+		kernel::{
+			lifecycle,
+			lifecycle::{
+				LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome,
+				PreviousLifecycleAuthority,
+			},
 		},
-		runtime_review_checkpoint_status_for_head,
 	},
 	prelude::Result,
 	recovery::{
-		closeout::{LegacyCloseoutValidation, MergedCloseoutValidation, events},
+		closeout::{
+			LegacyCloseoutValidation, MergedCloseoutValidation,
+			apply::lifecycle::decide_lifecycle_transition, events,
+		},
 		context::RecoveryContext,
 		pull_request_inspection,
 	},
@@ -106,6 +111,7 @@ pub(super) fn apply_merged_closeout_recovery(
 	}
 
 	record_merged_closeout_lifecycle_authority(context, validation)?;
+
 	context.state_store.update_run_status(&validation.run_id, "succeeded")?;
 
 	Ok((closeout_recorded, cleanup_recorded))
@@ -163,6 +169,7 @@ fn record_merged_closeout_lifecycle_authority(
 		"not_started",
 		"merged_closeout_recovery_landed_readback",
 	)?;
+
 	record_merged_closeout_lifecycle_decision(
 		context,
 		validation,
@@ -187,7 +194,7 @@ fn record_merged_closeout_lifecycle_decision(
 	causation_id: &str,
 ) -> Result<()> {
 	let review_level = context.config.codex().review_level();
-	let checkpoint = runtime_review_checkpoint_status_for_head(
+	let checkpoint = orchestrator::runtime_review_checkpoint_status_for_head(
 		&context.state_store,
 		context.config.service_id(),
 		&validation.issue.id,
@@ -195,7 +202,7 @@ fn record_merged_closeout_lifecycle_decision(
 		&validation.landing_state.head_ref_oid,
 	)?;
 	let review_state = merged_closeout_review_state(validation);
-	let facts = build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
+	let facts = orchestrator::build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
 		project_id: context.config.service_id(),
 		issue_id: &validation.issue.id,
 		review_lifecycle: None,
@@ -227,7 +234,7 @@ fn record_merged_closeout_lifecycle_decision(
 		causation_id
 	);
 	let decided_at = current_timestamp();
-	let decision = decide_lifecycle_transition(LifecycleDecisionInput {
+	let decision = self::decide_lifecycle_transition(LifecycleDecisionInput {
 		facts: &facts,
 		previous,
 		evidence_kind,

--- a/apps/decodex/src/recovery/review_handoff_apply/rebind.rs
+++ b/apps/decodex/src/recovery/review_handoff_apply/rebind.rs
@@ -21,6 +21,7 @@ pub(in crate::recovery) fn apply_review_handoff_rebind(
 		head_ref_name: &validation.landing_state.head_ref_name,
 		head_sha: &validation.local_head_oid,
 	};
+
 	lifecycle::write_review_lifecycle_with_rollback(
 		&context.state_store,
 		context.config.service_id(),

--- a/apps/decodex/src/recovery/tests/review_handoff/rebind_validation/existing_handoff/rebind_validation_preserves_terminal_landed_lifecycle_authority.rs
+++ b/apps/decodex/src/recovery/tests/review_handoff/rebind_validation/existing_handoff/rebind_validation_preserves_terminal_landed_lifecycle_authority.rs
@@ -1,20 +1,8 @@
 use std::path::Path;
 
-use crate::{
-	config::ReviewLevel,
-	orchestrator::{
-		PostReviewLifecycleFactsInput, PullRequestReviewState, build_post_review_lifecycle_facts,
-		kernel::lifecycle::{
-			LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome,
-			PreviousLifecycleAuthority, decide_lifecycle_transition,
-		},
-	},
-	recovery::tests::review_handoff,
-	state::{
-		ReviewLifecycleHandoffFixture, ReviewLifecycleHandoffInput, ReviewLifecycleTransitionInput,
-		StateStore,
-	},
-};
+use crate::recovery::tests::review_handoff::rebind_validation::existing_handoff::rebind_validation_preserves_terminal_landed_lifecycle_authority::lifecycle::decide_lifecycle_transition;
+use crate::{config::ReviewLevel, orchestrator::{self, PostReviewLifecycleFactsInput, PullRequestReviewState, kernel::lifecycle::{LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome, PreviousLifecycleAuthority}}, recovery::tests::review_handoff, state::{ReviewLifecycleHandoffFixture, ReviewLifecycleHandoffInput, ReviewLifecycleTransitionInput, StateStore}};
+use crate::orchestrator::kernel::lifecycle::self;
 
 fn merged_review_state(pr_url: &str, branch_name: &str, head_oid: &str) -> PullRequestReviewState {
 	PullRequestReviewState {
@@ -56,15 +44,17 @@ fn rebind_validation_preserves_terminal_landed_lifecycle_authority() {
 		branch_name,
 		head_oid,
 	);
+
 	state_store
 		.upsert_review_lifecycle_handoff_fixture("pubfi", "issue-id", &handoff)
 		.expect("handoff authority should persist");
+
 	let lifecycle_record = state_store
 		.review_lifecycle_record("pubfi", "issue-id", branch_name)
 		.expect("authority record should read")
 		.expect("authority record should exist");
 	let review_state = merged_review_state(pr_url, branch_name, head_oid);
-	let facts = build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
+	let facts = orchestrator::build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
 		project_id: "pubfi",
 		issue_id: "issue-id",
 		review_lifecycle: Some(&lifecycle_record),
@@ -78,7 +68,7 @@ fn rebind_validation_preserves_terminal_landed_lifecycle_authority() {
 		review_checkpoint_phase: Some("handoff"),
 		review_checkpoint_status: Some("clean"),
 	});
-	let landed_decision = decide_lifecycle_transition(LifecycleDecisionInput {
+	let landed_decision = self::decide_lifecycle_transition(LifecycleDecisionInput {
 		facts: &facts,
 		previous: Some(PreviousLifecycleAuthority {
 			sequence: lifecycle_record.sequence(),
@@ -95,9 +85,11 @@ fn rebind_validation_preserves_terminal_landed_lifecycle_authority() {
 		causation_id: Some("landing_complete"),
 		decided_at: "2026-07-07T00:00:00Z",
 	});
+
 	state_store
 		.record_lifecycle_decision("pub-718-attempt-1", 1, &landed_decision)
 		.expect("landed authority should persist");
+
 	let event_count_before_rebind = state_store
 		.list_private_execution_events_for_issue("pubfi", "issue-id")
 		.expect("events should list")

--- a/apps/decodex/src/state.rs
+++ b/apps/decodex/src/state.rs
@@ -13,6 +13,10 @@ mod sqlite_store;
 mod store;
 mod store_run_control;
 
+#[cfg(test)]
+pub(crate) use self::{
+	models::ReviewLifecycleHandoffFixture, models::ReviewLifecycleTransitionFixture,
+};
 pub(crate) use self::{
 	models::{
 		AutonomyObjectiveRecord, AutonomyProposalRecord, AutonomySignalRecord,
@@ -46,8 +50,6 @@ pub(crate) use self::{
 	},
 };
 pub(crate) use internal::{CodexAccountMarker, EffectiveRuntimeMarker, ProtocolActivityMarker};
-#[cfg(test)] pub(crate) use models::ReviewLifecycleHandoffFixture;
-#[cfg(test)] pub(crate) use models::ReviewLifecycleTransitionFixture;
 #[allow(unused_imports)] pub(crate) use models::WorktreeProvenance;
 #[cfg(test)]
 pub(crate) use run_activity_marker::{

--- a/apps/decodex/src/state/models/review.rs
+++ b/apps/decodex/src/state/models/review.rs
@@ -1,5 +1,4 @@
 mod checkpoints;
-#[cfg(test)] mod handoff;
 mod records;
 
 #[cfg(test)] pub(crate) use self::handoff::ReviewLifecycleHandoffFixture;
@@ -125,22 +124,6 @@ impl ReviewLifecycleTransitionFixture {
 }
 
 #[cfg(test)]
-#[allow(dead_code)]
-impl ReviewLifecycleHandoffFixture {
-	pub(crate) fn from_lifecycle_record(record: &ReviewLifecycleRecord) -> Option<Self> {
-		Some(Self::new(
-			record.run_id().to_owned(),
-			record.attempt_number(),
-			record.branch_name().to_owned(),
-			record.pr_url().to_owned(),
-			record.target_base_ref_name()?.to_owned(),
-			record.pr_head_ref_name().to_owned(),
-			record.pr_head_oid().to_owned(),
-		))
-	}
-}
-
-#[cfg(test)]
 impl ReviewLifecycleReadback for ReviewLifecycleTransitionFixture {
 	fn branch_name(&self) -> &str {
 		self.branch_name()
@@ -175,6 +158,22 @@ impl ReviewLifecycleReadback for ReviewLifecycleTransitionFixture {
 	}
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
+impl ReviewLifecycleHandoffFixture {
+	pub(crate) fn from_lifecycle_record(record: &ReviewLifecycleRecord) -> Option<Self> {
+		Some(Self::new(
+			record.run_id().to_owned(),
+			record.attempt_number(),
+			record.branch_name().to_owned(),
+			record.pr_url().to_owned(),
+			record.target_base_ref_name()?.to_owned(),
+			record.pr_head_ref_name().to_owned(),
+			record.pr_head_oid().to_owned(),
+		))
+	}
+}
+
 #[allow(dead_code)]
 impl ReviewLifecycleRecord {
 	#[cfg(test)]
@@ -185,6 +184,7 @@ impl ReviewLifecycleRecord {
 		let head_sha = orchestration
 			.map(ReviewLifecycleTransitionFixture::head_sha)
 			.unwrap_or_else(|| handoff.pr_head_oid());
+
 		Self {
 			project_id: String::from("test"),
 			issue_id: String::from("test"),
@@ -454,3 +454,5 @@ impl ReviewLifecycleReadback for ReviewLifecycleRecord {
 		self.request_retry_count()
 	}
 }
+
+#[cfg(test)] mod handoff;

--- a/apps/decodex/src/state/review_records/lifecycle.rs
+++ b/apps/decodex/src/state/review_records/lifecycle.rs
@@ -3,9 +3,8 @@ mod cleanup;
 mod handoff;
 mod orchestration;
 mod queries;
+use crate::state::ReviewLifecycleRecord;
 
-fn terminal_lifecycle_authority_must_not_reenter_review(
-	record: &crate::state::ReviewLifecycleRecord,
-) -> bool {
+fn terminal_lifecycle_authority_must_not_reenter_review(record: &ReviewLifecycleRecord) -> bool {
 	matches!(record.next_state(), "landed" | "closed")
 }

--- a/apps/decodex/src/state/review_records/lifecycle/authority.rs
+++ b/apps/decodex/src/state/review_records/lifecycle/authority.rs
@@ -2,7 +2,7 @@
 
 use crate::{
 	orchestrator::kernel::lifecycle::{
-		LIFECYCLE_EVENT_TYPE, LifecycleAuthorityRecord, LifecycleDecision,
+		LIFECYCLE_EVENT_TYPE, LifecycleAuthorityRecord, LifecycleDecision, LifecycleEventEnvelope,
 	},
 	prelude::Result,
 	state::{
@@ -66,6 +66,7 @@ impl StateStore {
 
 		state.private_execution_events.push(event.clone());
 		self.persist_runtime_state_locked(&state)?;
+
 		event.record_id = state.next_private_execution_event_id()?.saturating_sub(1);
 
 		Ok(event.as_public())
@@ -130,7 +131,7 @@ fn new_lifecycle_authority_record(
 fn upsert_lifecycle_authority_projection(
 	runtime_record: &mut ReviewLifecycleRuntimeRecord,
 	record: &LifecycleAuthorityRecord,
-	envelope: &crate::orchestrator::kernel::lifecycle::LifecycleEventEnvelope,
+	envelope: &LifecycleEventEnvelope,
 	updated_at: &str,
 	updated_at_unix: i64,
 ) -> Result<()> {
@@ -140,14 +141,19 @@ fn upsert_lifecycle_authority_projection(
 	runtime_record.pr_head_oid = record.validated_head_sha.clone();
 	runtime_record.head_sha = record.validated_head_sha.clone();
 	runtime_record.phase = record.phase.clone();
+
 	let landing_state = landing_state_from_record(record);
+
 	if landing_state != "not_started" || runtime_record.landing_state == "not_started" {
 		runtime_record.landing_state = landing_state;
 	}
+
 	let closeout_state = closeout_state_from_record(record);
+
 	if closeout_state != "not_started" || runtime_record.closeout_state == "not_started" {
 		runtime_record.closeout_state = closeout_state;
 	}
+
 	runtime_record.evidence_json = serde_json::to_string(envelope)?;
 	runtime_record.next_action = record.next_action.clone();
 	runtime_record.schema_version = record.schema_version.clone();

--- a/apps/decodex/src/state/review_records/lifecycle/handoff.rs
+++ b/apps/decodex/src/state/review_records/lifecycle/handoff.rs
@@ -1,4 +1,3 @@
-use super::terminal_lifecycle_authority_must_not_reenter_review;
 #[cfg(test)]
 use crate::state::{ReviewLifecycleHandoffFixture, runtime_records::ReviewLifecycleKey};
 use crate::{
@@ -6,11 +5,13 @@ use crate::{
 		PostReviewLifecycleFacts, RuntimeReviewGateState,
 		kernel::lifecycle::{
 			LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome,
-			PreviousLifecycleAuthority, decide_lifecycle_transition,
+			PreviousLifecycleAuthority,
 		},
 	},
 	prelude::Result,
-	state::{ReviewLifecycleHandoffInput, StateStore, runtime_row_parsers},
+	state::{
+		ReviewLifecycleHandoffInput, StateStore, review_records::lifecycle, runtime_row_parsers,
+	},
 };
 
 impl StateStore {
@@ -21,10 +22,9 @@ impl StateStore {
 		issue_id: &str,
 		input: ReviewLifecycleHandoffInput<'_>,
 	) -> Result<()> {
-		if self
-			.review_lifecycle_record(project_id, issue_id, input.branch_name)?
-			.is_some_and(|record| terminal_lifecycle_authority_must_not_reenter_review(&record))
-		{
+		if self.review_lifecycle_record(project_id, issue_id, input.branch_name)?.is_some_and(
+			|record| lifecycle::terminal_lifecycle_authority_must_not_reenter_review(&record),
+		) {
 			return Ok(());
 		}
 
@@ -39,10 +39,9 @@ impl StateStore {
 		issue_id: &str,
 		marker: &ReviewLifecycleHandoffFixture,
 	) -> Result<()> {
-		if self
-			.review_lifecycle_record(project_id, issue_id, marker.branch_name())?
-			.is_some_and(|record| terminal_lifecycle_authority_must_not_reenter_review(&record))
-		{
+		if self.review_lifecycle_record(project_id, issue_id, marker.branch_name())?.is_some_and(
+			|record| lifecycle::terminal_lifecycle_authority_must_not_reenter_review(&record),
+		) {
 			return Ok(());
 		}
 
@@ -60,6 +59,7 @@ impl StateStore {
 				head_sha: marker.pr_head_oid(),
 			},
 		)?;
+
 		let now = runtime_row_parsers::timestamp_parts();
 		let key = ReviewLifecycleKey::new(project_id, issue_id, marker.branch_name());
 		let mut state = self.lock()?;
@@ -134,7 +134,8 @@ fn record_handoff_lifecycle_authority(
 ) -> Result<()> {
 	let previous_record =
 		state_store.review_lifecycle_record(project_id, issue_id, input.branch_name)?;
-	if previous_record.as_ref().is_some_and(terminal_lifecycle_authority_must_not_reenter_review) {
+
+	if previous_record.as_ref().is_some_and(crate::state::review_records::lifecycle::terminal_lifecycle_authority_must_not_reenter_review) {
 		return Ok(());
 	}
 
@@ -167,20 +168,22 @@ fn record_handoff_lifecycle_authority(
 			input.run_id, input.attempt_number, input.head_sha
 		)],
 	};
-	let decision = decide_lifecycle_transition(LifecycleDecisionInput {
-		facts: &facts,
-		previous,
-		evidence_kind: LifecycleEvidenceKind::Handoff,
-		outcome: LifecycleOutcome::Intent,
-		merge_commit: None,
-		cleanup_state: Some("not_started"),
-		authority: "review_lifecycle_runtime",
-		actor: "state_adapter",
-		idempotency_key: &idempotency_key,
-		correlation_id: input.run_id,
-		causation_id: Some("review_lifecycle_handoff"),
-		decided_at: &decided_at,
-	});
+	let decision = crate::orchestrator::kernel::lifecycle::decide_lifecycle_transition(
+		LifecycleDecisionInput {
+			facts: &facts,
+			previous,
+			evidence_kind: LifecycleEvidenceKind::Handoff,
+			outcome: LifecycleOutcome::Intent,
+			merge_commit: None,
+			cleanup_state: Some("not_started"),
+			authority: "review_lifecycle_runtime",
+			actor: "state_adapter",
+			idempotency_key: &idempotency_key,
+			correlation_id: input.run_id,
+			causation_id: Some("review_lifecycle_handoff"),
+			decided_at: &decided_at,
+		},
+	);
 
 	state_store.record_lifecycle_decision(input.run_id, input.attempt_number, &decision)?;
 

--- a/apps/decodex/src/state/review_records/lifecycle/orchestration.rs
+++ b/apps/decodex/src/state/review_records/lifecycle/orchestration.rs
@@ -1,4 +1,3 @@
-use super::terminal_lifecycle_authority_must_not_reenter_review;
 #[cfg(test)]
 use crate::state::{ReviewLifecycleHandoffFixture, ReviewLifecycleTransitionFixture};
 use crate::{
@@ -6,13 +5,13 @@ use crate::{
 		PostReviewLifecycleFacts, RuntimeReviewGateState,
 		kernel::lifecycle::{
 			LifecycleDecisionInput, LifecycleEvidenceKind, LifecycleOutcome,
-			PreviousLifecycleAuthority, decide_lifecycle_transition,
+			PreviousLifecycleAuthority,
 		},
 	},
 	prelude::Result,
 	state::{
-		ReviewLifecycleTransitionInput, StateStore, runtime_records::ReviewLifecycleKey,
-		runtime_row_parsers,
+		ReviewLifecycleTransitionInput, StateStore, review_records::lifecycle,
+		runtime_records::ReviewLifecycleKey, runtime_row_parsers,
 	},
 };
 
@@ -23,14 +22,14 @@ impl StateStore {
 		issue_id: &str,
 		input: ReviewLifecycleTransitionInput<'_>,
 	) -> Result<()> {
-		if self
-			.review_lifecycle_record(project_id, issue_id, input.branch_name)?
-			.is_some_and(|record| terminal_lifecycle_authority_must_not_reenter_review(&record))
-		{
+		if self.review_lifecycle_record(project_id, issue_id, input.branch_name)?.is_some_and(
+			|record| lifecycle::terminal_lifecycle_authority_must_not_reenter_review(&record),
+		) {
 			return Ok(());
 		}
 
 		record_orchestration_lifecycle_authority(self, project_id, issue_id, &input)?;
+
 		let now = runtime_row_parsers::timestamp_parts();
 		let key = ReviewLifecycleKey::new(project_id, issue_id, input.branch_name);
 		let mut state = self.lock()?;
@@ -168,20 +167,22 @@ fn record_orchestration_lifecycle_authority(
 			input.run_id, input.attempt_number, input.phase, input.head_sha
 		)],
 	};
-	let decision = decide_lifecycle_transition(LifecycleDecisionInput {
-		facts: &facts,
-		previous,
-		evidence_kind,
-		outcome: LifecycleOutcome::Intent,
-		merge_commit: None,
-		cleanup_state: Some("not_started"),
-		authority: "review_lifecycle_runtime",
-		actor: "state_adapter",
-		idempotency_key: &idempotency_key,
-		correlation_id: input.run_id,
-		causation_id: Some(input.phase),
-		decided_at: &decided_at,
-	});
+	let decision = crate::orchestrator::kernel::lifecycle::decide_lifecycle_transition(
+		LifecycleDecisionInput {
+			facts: &facts,
+			previous,
+			evidence_kind,
+			outcome: LifecycleOutcome::Intent,
+			merge_commit: None,
+			cleanup_state: Some("not_started"),
+			authority: "review_lifecycle_runtime",
+			actor: "state_adapter",
+			idempotency_key: &idempotency_key,
+			correlation_id: input.run_id,
+			causation_id: Some(input.phase),
+			decided_at: &decided_at,
+		},
+	);
 
 	state_store.record_lifecycle_decision(input.run_id, input.attempt_number, &decision)?;
 

--- a/apps/decodex/src/state/runtime_row_parsers/autonomy/signal.rs
+++ b/apps/decodex/src/state/runtime_row_parsers/autonomy/signal.rs
@@ -1,9 +1,10 @@
+use rusqlite::{Error, Row};
+
 use crate::{
 	autonomy_signal::AutonomySignal,
 	prelude::eyre,
 	state::{AutonomySignalRuntimeRecord, AutonomySignalRuntimeRowParts},
 };
-use rusqlite::{Error, Row};
 
 pub(in crate::state) fn autonomy_signal_runtime_row_parts(
 	row: &Row<'_>,
@@ -31,7 +32,6 @@ pub(in crate::state) fn autonomy_signal_record_from_row_parts(
 	parts: AutonomySignalRuntimeRowParts,
 ) -> crate::prelude::Result<AutonomySignalRuntimeRecord> {
 	let signal = serde_json::from_str::<AutonomySignal>(&parts.payload_json)?;
-
 	let version = u64::try_from(parts.objective_version).map_err(|_| {
 		eyre::eyre!("Autonomy signal row objective_version must be greater than zero.")
 	})?;

--- a/apps/decodex/src/state/sqlite_store/mutations/cleanup.rs
+++ b/apps/decodex/src/state/sqlite_store/mutations/cleanup.rs
@@ -1,3 +1,5 @@
+use rusqlite::Transaction;
+
 use crate::state::sqlite_store::mutations::{self, Result, SqliteStateStore};
 
 impl SqliteStateStore {
@@ -95,36 +97,9 @@ impl SqliteStateStore {
 			"DELETE FROM evidence_artifacts WHERE issue_id = ?1",
 			mutations::params![previous_issue_id],
 		)?;
-		transaction.execute(
-			"INSERT OR IGNORE INTO review_lifecycle_records (
-					project_id, issue_id, branch_name, run_id, attempt_number, pr_url,
-					target_base_ref_name, pr_head_ref_name, pr_head_oid, head_sha, phase,
-					request_comment_database_id, request_created_at_unix_epoch,
-					request_description_thumbs_up_count, request_retry_count, external_round_count,
-					auto_merge_enabled_at_unix_epoch, landing_state, closeout_state,
-					repair_attempt_count, evidence_json, next_action, schema_version, subject_id,
-					sequence, transition, previous_state, next_state, review_level,
-					review_gate_state, base_branch, validated_head_sha, worktree_path, merge_commit,
-					cleanup_state, authority, actor, source_evidence_refs_json, idempotency_key,
-					correlation_id, causation_id, decided_at, updated_at, updated_at_unix
-				)
-			 SELECT project_id, ?2, branch_name, run_id, attempt_number, pr_url,
-					target_base_ref_name, pr_head_ref_name, pr_head_oid, head_sha, phase,
-					request_comment_database_id, request_created_at_unix_epoch,
-					request_description_thumbs_up_count, request_retry_count, external_round_count,
-					auto_merge_enabled_at_unix_epoch, landing_state, closeout_state,
-					repair_attempt_count, evidence_json, next_action, schema_version, subject_id,
-					sequence, transition, previous_state, next_state, review_level,
-					review_gate_state, base_branch, validated_head_sha, worktree_path, merge_commit,
-					cleanup_state, authority, actor, source_evidence_refs_json, idempotency_key,
-					correlation_id, causation_id, decided_at, updated_at, updated_at_unix
-			 FROM review_lifecycle_records WHERE issue_id = ?1",
-			mutations::params![previous_issue_id, canonical_issue_id],
-		)?;
-		transaction.execute(
-			"DELETE FROM review_lifecycle_records WHERE issue_id = ?1",
-			mutations::params![previous_issue_id],
-		)?;
+
+		retarget_review_lifecycle_records(&transaction, previous_issue_id, canonical_issue_id)?;
+
 		transaction.commit()?;
 
 		Ok(())
@@ -242,4 +217,43 @@ impl SqliteStateStore {
 
 		Ok(())
 	}
+}
+
+fn retarget_review_lifecycle_records(
+	transaction: &Transaction<'_>,
+	previous_issue_id: &str,
+	canonical_issue_id: &str,
+) -> Result<()> {
+	transaction.execute(
+		"INSERT OR IGNORE INTO review_lifecycle_records (
+				project_id, issue_id, branch_name, run_id, attempt_number, pr_url,
+				target_base_ref_name, pr_head_ref_name, pr_head_oid, head_sha, phase,
+				request_comment_database_id, request_created_at_unix_epoch,
+				request_description_thumbs_up_count, request_retry_count, external_round_count,
+				auto_merge_enabled_at_unix_epoch, landing_state, closeout_state,
+				repair_attempt_count, evidence_json, next_action, schema_version, subject_id,
+				sequence, transition, previous_state, next_state, review_level,
+				review_gate_state, base_branch, validated_head_sha, worktree_path, merge_commit,
+				cleanup_state, authority, actor, source_evidence_refs_json, idempotency_key,
+				correlation_id, causation_id, decided_at, updated_at, updated_at_unix
+			)
+		 SELECT project_id, ?2, branch_name, run_id, attempt_number, pr_url,
+				target_base_ref_name, pr_head_ref_name, pr_head_oid, head_sha, phase,
+				request_comment_database_id, request_created_at_unix_epoch,
+				request_description_thumbs_up_count, request_retry_count, external_round_count,
+				auto_merge_enabled_at_unix_epoch, landing_state, closeout_state,
+				repair_attempt_count, evidence_json, next_action, schema_version, subject_id,
+				sequence, transition, previous_state, next_state, review_level,
+				review_gate_state, base_branch, validated_head_sha, worktree_path, merge_commit,
+				cleanup_state, authority, actor, source_evidence_refs_json, idempotency_key,
+				correlation_id, causation_id, decided_at, updated_at, updated_at_unix
+		 FROM review_lifecycle_records WHERE issue_id = ?1",
+		mutations::params![previous_issue_id, canonical_issue_id],
+	)?;
+	transaction.execute(
+		"DELETE FROM review_lifecycle_records WHERE issue_id = ?1",
+		mutations::params![previous_issue_id],
+	)?;
+
+	Ok(())
 }

--- a/apps/decodex/src/state/sqlite_store/schema/review.rs
+++ b/apps/decodex/src/state/sqlite_store/schema/review.rs
@@ -97,6 +97,7 @@ impl SqliteStateStore {
 			"details_json",
 			"ALTER TABLE review_policy_checkpoints ADD COLUMN details_json TEXT NOT NULL DEFAULT '{}'",
 		)?;
+
 		for (column, sql) in [
 			(
 				"schema_version",

--- a/apps/decodex/src/state/tests/review_lifecycle/review_records/lifecycle_authority_adapter_writes_record_and_event_transactionally.rs
+++ b/apps/decodex/src/state/tests/review_lifecycle/review_records/lifecycle_authority_adapter_writes_record_and_event_transactionally.rs
@@ -3,11 +3,13 @@ use std::path::Path;
 use crate::{
 	config::ReviewLevel,
 	orchestrator::{
-		PostReviewLifecycleFactsInput, PullRequestReviewState, build_post_review_lifecycle_facts,
-		kernel::lifecycle::{
-			LIFECYCLE_EVENT_SCHEMA_VERSION, LIFECYCLE_EVENT_TYPE, LifecycleDecisionInput,
-			LifecycleEvidenceKind, LifecycleOutcome, PreviousLifecycleAuthority,
-			decide_lifecycle_transition,
+		self, PostReviewLifecycleFactsInput, PullRequestReviewState,
+		kernel::{
+			lifecycle,
+			lifecycle::{
+				LIFECYCLE_EVENT_SCHEMA_VERSION, LIFECYCLE_EVENT_TYPE, LifecycleDecisionInput,
+				LifecycleEvidenceKind, LifecycleOutcome, PreviousLifecycleAuthority,
+			},
 		},
 	},
 	state::{
@@ -76,7 +78,7 @@ fn lifecycle_authority_adapter_writes_record_and_event_transactionally() {
 		issue_comments: Vec::new(),
 		reviews: Vec::new(),
 	};
-	let facts = build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
+	let facts = orchestrator::build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
 		project_id: "pubfi",
 		issue_id: "PUB-101",
 		review_lifecycle: Some(&lifecycle_record),
@@ -90,7 +92,7 @@ fn lifecycle_authority_adapter_writes_record_and_event_transactionally() {
 		review_checkpoint_phase: Some("handoff"),
 		review_checkpoint_status: Some("clean"),
 	});
-	let decision = decide_lifecycle_transition(LifecycleDecisionInput {
+	let decision = lifecycle::decide_lifecycle_transition(LifecycleDecisionInput {
 		facts: &facts,
 		previous: None,
 		evidence_kind: LifecycleEvidenceKind::LandingReadback,
@@ -104,7 +106,6 @@ fn lifecycle_authority_adapter_writes_record_and_event_transactionally() {
 		causation_id: Some("landing-intent-1"),
 		decided_at: "2026-07-07T00:00:00Z",
 	});
-
 	let event = store
 		.record_lifecycle_decision("run-1", 1, &decision)
 		.expect("lifecycle decision should persist");
@@ -164,15 +165,17 @@ fn review_wait_sync_does_not_regress_terminal_lifecycle_authority() {
 		"x/pub-101",
 		"head-sha",
 	);
+
 	store
 		.upsert_review_lifecycle_handoff_fixture("pubfi", "PUB-101", &handoff)
 		.expect("handoff authority should persist");
+
 	let lifecycle_record = store
 		.review_lifecycle_record("pubfi", "PUB-101", "x/pub-101")
 		.expect("authority record should read")
 		.expect("authority record should exist");
 	let review_state = pub_101_merged_review_state();
-	let facts = build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
+	let facts = orchestrator::build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
 		project_id: "pubfi",
 		issue_id: "PUB-101",
 		review_lifecycle: Some(&lifecycle_record),
@@ -186,7 +189,7 @@ fn review_wait_sync_does_not_regress_terminal_lifecycle_authority() {
 		review_checkpoint_phase: Some("handoff"),
 		review_checkpoint_status: Some("clean"),
 	});
-	let closeout_decision = decide_lifecycle_transition(LifecycleDecisionInput {
+	let closeout_decision = lifecycle::decide_lifecycle_transition(LifecycleDecisionInput {
 		facts: &facts,
 		previous: Some(PreviousLifecycleAuthority {
 			sequence: lifecycle_record.sequence(),
@@ -203,9 +206,11 @@ fn review_wait_sync_does_not_regress_terminal_lifecycle_authority() {
 		causation_id: Some("manual_land_closeout_complete"),
 		decided_at: "2026-07-07T00:00:00Z",
 	});
+
 	store
 		.record_lifecycle_decision("run-1", 1, &closeout_decision)
 		.expect("closeout authority should persist");
+
 	let event_count_before_stale_sync = store
 		.list_private_execution_events_for_issue("pubfi", "PUB-101")
 		.expect("events should list")
@@ -260,15 +265,17 @@ fn review_handoff_sync_does_not_regress_landed_lifecycle_authority() {
 		"x/pub-101",
 		"head-sha",
 	);
+
 	store
 		.upsert_review_lifecycle_handoff_fixture("pubfi", "PUB-101", &handoff)
 		.expect("handoff authority should persist");
+
 	let lifecycle_record = store
 		.review_lifecycle_record("pubfi", "PUB-101", "x/pub-101")
 		.expect("authority record should read")
 		.expect("authority record should exist");
 	let review_state = pub_101_merged_review_state();
-	let facts = build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
+	let facts = orchestrator::build_post_review_lifecycle_facts(PostReviewLifecycleFactsInput {
 		project_id: "pubfi",
 		issue_id: "PUB-101",
 		review_lifecycle: Some(&lifecycle_record),
@@ -282,7 +289,7 @@ fn review_handoff_sync_does_not_regress_landed_lifecycle_authority() {
 		review_checkpoint_phase: Some("handoff"),
 		review_checkpoint_status: Some("clean"),
 	});
-	let landed_decision = decide_lifecycle_transition(LifecycleDecisionInput {
+	let landed_decision = lifecycle::decide_lifecycle_transition(LifecycleDecisionInput {
 		facts: &facts,
 		previous: Some(PreviousLifecycleAuthority {
 			sequence: lifecycle_record.sequence(),
@@ -299,9 +306,11 @@ fn review_handoff_sync_does_not_regress_landed_lifecycle_authority() {
 		causation_id: Some("landing_complete"),
 		decided_at: "2026-07-07T00:00:00Z",
 	});
+
 	store
 		.record_lifecycle_decision("run-1", 1, &landed_decision)
 		.expect("landed authority should persist");
+
 	let event_count_before_stale_sync = store
 		.list_private_execution_events_for_issue("pubfi", "PUB-101")
 		.expect("events should list")


### PR DESCRIPTION
## Summary
- Apply vstyle Rust tune fixes across the workspace
- Manually refactor remaining style-only violations for imports, module ordering, impl grouping, and short function bodies

## Validation
- cargo make lint-vstyle-rust
- cargo make fmt-rust-check
- cargo check --all-features --all-targets --workspace
- cargo make check