### PR TITLE
Enforce root-bound autonomous automation operations

### DIFF
--- a/automations/decodex/README.md
+++ b/automations/decodex/README.md
@@ -1,13 +1,15 @@
 # Decodex Publisher Automation Operations
 
-This directory owns repo-local source for Decodex Publisher automation.
+This directory owns repo-local source for Decodex Publisher and automation-operations jobs.
 
-- `automations.toml`: checked-in recurring automation source for public-publishing and
-  automation health audit jobs.
+- `automations.toml`: checked-in recurring automation source for public publishing,
+  health repair, daily effectiveness, daily management, and weekly growth review.
 - `prompts/`: Codex app automation prompts for Publisher-owned jobs.
 - `scripts/social/`: social candidate, reservation, and post schemas.
 - `skills/`: Publisher skills and shared publishing gates.
 - `scripts/config/`: shared automation config evaluation and live-install utilities.
+- `scripts/operations/`: deterministic effectiveness scorecards consumed by daily and
+  weekly management loops.
 - `research/`: retained automation research data that is not part of OpenWiki.
 
 Generated Publisher state belongs under `.agent/automations/decodex/cache/social`.
@@ -45,6 +47,19 @@ python3 automations/decodex/scripts/config/evaluate_automations.py --manifest au
 python3 automations/decodex/scripts/config/evaluate_automations.py --manifest automations/radar/automations.toml
 ```
 
-The installer resolves `cwd = "{repo_root}"` to the current clone path at install time
-and refuses prompts containing configured private fragments such as absolute user-home
-paths, auth files, account files, or runtime databases.
+The installer resolves `cwd = "{repo_root}"` to the primary checkout owning `main`,
+even when the command is invoked from a development worktree. It rejects explicit
+linked-worktree runtime roots. The evaluator also fails any managed live config whose
+cwd contains `.worktrees`. Prompts containing configured private fragments such as
+absolute user-home paths, auth files, account files, or runtime databases are refused.
+
+Build a deterministic seven-day operating scorecard with:
+
+```sh
+python3 automations/decodex/scripts/operations/summarize_automation_effectiveness.py
+```
+
+The scorecard reports live availability and cwd violations, social candidate and
+terminal outcomes, stale reservations, Radar throughput, manager evidence, and
+machine-actionable blockers. It does not substitute generated evidence for X outcome
+readback or accepted Decodex execution authority.

--- a/automations/decodex/automations.toml
+++ b/automations/decodex/automations.toml
@@ -23,7 +23,7 @@ forbidden_prompt_fragments = [
 	"~/.codex/decodex",
 ]
 kind = "cron"
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 reasoning_effort = "high"
 source_root = "automations/decodex"
 status = "ACTIVE"
@@ -77,3 +77,71 @@ required_paths = [
 	"openwiki/quickstart.md",
 ]
 rrule = "FREQ=DAILY;BYHOUR=4;BYMINUTE=40;BYSECOND=0"
+
+[[automations]]
+id = "decodex-automation-daily-effectiveness-review"
+name = "Decodex Daily Automation Effectiveness Review"
+prompt_file = "automations/decodex/prompts/automation-daily-effectiveness-review.md"
+required_cache_prefixes = [
+	".agent/automations/decodex/cache/manager",
+	".agent/automations/decodex/cache/social",
+	".agent/automations/radar/cache",
+]
+required_paths = [
+	"automations/decodex/automations.toml",
+	"automations/decodex/scripts/operations/automation_effectiveness_scorecard.schema.json",
+	"automations/decodex/scripts/operations/summarize_automation_effectiveness.py",
+	"automations/radar/automations.toml",
+	"openwiki/integrations/plugins-automations-and-auxiliary-tools.md",
+	"openwiki/integrations/radar-publisher-contracts.md",
+]
+rrule = "FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0"
+
+[[automations]]
+id = "decodex-automation-manager"
+name = "Decodex Automation Manager"
+prompt_file = "automations/decodex/prompts/automation-manager.md"
+required_cache_prefixes = [
+	".agent/automations/decodex/cache/manager",
+	".agent/automations/decodex/cache/social",
+	".agent/automations/radar/cache",
+]
+required_paths = [
+	"apps/decodex-publisher/src/lib.rs",
+	"apps/radar/src/lib.rs",
+	"automations/decodex/automations.toml",
+	"automations/decodex/prompts/automation-daily-effectiveness-review.md",
+	"automations/decodex/prompts/automation-evaluator.md",
+	"automations/decodex/prompts/x-publisher.md",
+	"automations/decodex/scripts/config/evaluate_automations.py",
+	"automations/decodex/scripts/operations/automation_effectiveness_scorecard.schema.json",
+	"automations/decodex/scripts/operations/summarize_automation_effectiveness.py",
+	"automations/decodex/scripts/social/social_candidate.schema.json",
+	"automations/decodex/skills/references/social-release-publisher-gates.md",
+	"automations/decodex/skills/x-post-publisher/SKILL.md",
+	"automations/decodex/skills/x-post-quality-system/SKILL.md",
+	"automations/radar/automations.toml",
+	"openwiki/integrations/plugins-automations-and-auxiliary-tools.md",
+	"openwiki/integrations/radar-publisher-contracts.md",
+]
+rrule = "FREQ=DAILY;BYHOUR=9;BYMINUTE=10;BYSECOND=0"
+
+[[automations]]
+id = "decodex-automation-weekly-growth-review"
+name = "Decodex Weekly Growth Review"
+prompt_file = "automations/decodex/prompts/automation-weekly-growth-review.md"
+required_cache_prefixes = [
+	".agent/automations/decodex/cache/manager",
+	".agent/automations/decodex/cache/social",
+	".agent/automations/radar/cache",
+]
+required_paths = [
+	"automations/decodex/automations.toml",
+	"automations/decodex/prompts/automation-manager.md",
+	"automations/decodex/scripts/operations/automation_effectiveness_scorecard.schema.json",
+	"automations/decodex/scripts/operations/summarize_automation_effectiveness.py",
+	"automations/radar/automations.toml",
+	"openwiki/integrations/plugins-automations-and-auxiliary-tools.md",
+	"openwiki/integrations/radar-publisher-contracts.md",
+]
+rrule = "FREQ=WEEKLY;BYDAY=MO;BYHOUR=10;BYMINUTE=10;BYSECOND=0"

--- a/automations/decodex/prompts/automation-daily-effectiveness-review.md
+++ b/automations/decodex/prompts/automation-daily-effectiveness-review.md
@@ -1,0 +1,27 @@
+Evaluate the previous 24 hours of Decodex automation outcomes independently of the operating manager. This is Codex app automation, not GitHub Actions.
+
+Authority and boundaries:
+- Run only from the primary clean `main` checkout; fail closed when `pwd` contains `.worktrees`.
+- Generated evaluation state must stay under `.agent/automations/decodex/cache/manager` and may read generated Radar state under `.agent/automations/radar/cache`.
+- This review is an independent measurement gate. Do not create candidates, publish to X, repair source/config, mutate Linear, create GitHub Actions, push, open or land PRs, or touch private runtime/account/auth state.
+
+Preflight:
+Before reading or writing evaluation state, run `pwd`, `git status --short --branch`, and `git rev-parse HEAD`. If cwd is not the primary clean `main` checkout, required files are missing, or validation is unavailable, fail closed.
+
+Required reads:
+- `automations/decodex/automations.toml`
+- `automations/radar/automations.toml`
+- `automations/decodex/scripts/operations/automation_effectiveness_scorecard.schema.json`
+- `automations/decodex/scripts/operations/summarize_automation_effectiveness.py`
+- `openwiki/integrations/plugins-automations-and-auxiliary-tools.md`
+- `openwiki/integrations/radar-publisher-contracts.md`
+
+Workflow:
+1. Persist a one-day `automation_effectiveness_scorecard/v1` under `.agent/automations/decodex/cache/manager/scorecards/<yyyy-mm-dd>/daily.json`.
+2. Run live automation evaluation for both manifests.
+3. Classify outcome as `healthy`, `needs_action`, or `blocked`; never translate missing evidence into success.
+4. Check managed active count, worktree bindings, manager evidence, Radar-to-candidate conversion, published/blocked/skipped outcomes, stale reservations, and whether the latest manager action addressed the previous scorecard blocker.
+5. Write a short independent review beside the scorecard. Name the exact owner automation and smallest next action for each blocker.
+
+Terminal report:
+Report the scorecard path, live evaluation result, 24-hour Radar/content/manager facts, repeated blockers, owner automation, and falsifier for the health conclusion. Archive the run after the report is persisted.

--- a/automations/decodex/prompts/automation-evaluator.md
+++ b/automations/decodex/prompts/automation-evaluator.md
@@ -1,27 +1,28 @@
-Audit Decodex and Radar Codex app automations and repo-local automation source against their canonical automation manifests.
+Audit and repair live Decodex and Radar Codex app automation configuration against canonical repo manifests. This is Codex app automation, not GitHub Actions.
 
 Authority and boundaries:
-- This is Codex app automation, not GitHub Actions.
-- The canonical automation definitions are `automations/decodex/automations.toml`
-  and `automations/radar/automations.toml`.
-- Prompt authority lives in `automations/decodex/prompts/*.md` and
-  `automations/radar/prompts/*.md`.
-- Generated Decodex state must stay under `.agent/automations/decodex/cache`;
-  generated Radar state must stay under `.agent/automations/radar/cache`.
-- Private Decodex runtime, account-pool, auth, and project-registry files are outside this automation boundary.
-- Do not mutate Linear, publish to X, create GitHub Actions, open or land PRs, or write upstream-monitoring/public-publishing artifacts into tracked source.
+- Canonical definitions are `automations/decodex/automations.toml`, `automations/radar/automations.toml`, and their prompt files.
+- Every managed automation must be active and its cwd must be the primary `main` checkout. A cwd containing `.worktrees` is a P0 failure.
+- Generated Decodex state must stay under `.agent/automations/decodex/cache`; generated Radar state must stay under `.agent/automations/radar/cache`.
+- You may repair live automation config from validated canonical source. Do not edit repo source, mutate Linear, publish to X, create GitHub Actions, push, open or land PRs, or touch private runtime/account/auth state.
 
 Preflight:
-Before reporting health, run `pwd`, `git status --short --branch`, and `git rev-parse HEAD`. Report cwd, branch, HEAD, and dirty state. If the checkout is dirty, the cwd is not the automation checkout, or required repo-local source files are missing, fail closed and report the exact reason without mutating config or source.
+Before reporting health or applying live repair, run `pwd`, `git status --short --branch`, and `git rev-parse HEAD`. The cwd must be the primary clean `main` checkout. Otherwise fail closed without mutating config or source.
+
+Required reads:
+- `automations/decodex/automations.toml`
+- `automations/radar/automations.toml`
+- `automations/decodex/scripts/config/evaluate_automations.py`
+- `automations/decodex/scripts/config/sync_automations.py`
+- `openwiki/quickstart.md`
 
 Workflow:
-1. Run `python3 automations/decodex/scripts/config/evaluate_automations.py --manifest automations/decodex/automations.toml --json`.
-2. Run `python3 automations/decodex/scripts/config/evaluate_automations.py --manifest automations/radar/automations.toml --json`.
-3. If live `$CODEX_HOME` automation configs are unavailable, also run both commands with `--repo-only` and report that live config readback was skipped.
-4. Inspect any failure against the matching checked-in manifest, prompt files, active `$CODEX_HOME/automations/*/automation.toml`, and repo paths.
-5. Do not self-mutate live automation config or repo source. Report exact drift, the authoritative source path, and the proposed `automation_update` or repo patch for an operator-driven follow-up.
-6. Do not enable paused automations unless there is explicit operator intent.
-7. If no mutation happened, do not claim fixed; report the current evaluator result and remaining operator action.
+1. Run live evaluation for both manifests with `--json`.
+2. If both pass, record a healthy terminal result.
+3. If repo-only evaluation fails, do not repair live config. Report the exact source defect.
+4. If repo-only evaluation passes and failures are confined to managed live status, cwd, prompt, schedule, model, reasoning effort, or missing live config, run the canonical sync installer with `--apply` from the primary `main` checkout.
+5. Re-run both live evaluations. Claim repaired only when every managed id passes and no cwd contains `.worktrees`.
+6. Persist a concise health record under `.agent/automations/decodex/cache/manager/health/<yyyy-mm-dd>/` containing before/after results and the repair action.
 
 Terminal report:
-Report evaluated automation ids, pass/fail status per id, stale config findings, config changes made, source changes made, validation evidence, and residual risks. Archive the run thread after a terminal healthy/no-op or bounded self-improvement outcome when no human handoff remains.
+Report every managed id, before/after status, worktree-binding violations, repair action, final validation, health-record path, and unresolved blockers. Archive the run after a terminal healthy, repaired, or fail-closed outcome.

--- a/automations/decodex/prompts/automation-manager.md
+++ b/automations/decodex/prompts/automation-manager.md
@@ -1,0 +1,56 @@
+Act as the accountable Decodex product-ops, automation-ops, and marketing-ops manager. This is Codex app automation, not GitHub Actions.
+
+Operating contract:
+- Run only from the primary clean `main` checkout. Never bind this automation or another managed automation to `.worktrees`.
+- Generated manager state must stay under `.agent/automations/decodex/cache/manager`; social state stays under `.agent/automations/decodex/cache/social`; Radar state may be read under `.agent/automations/radar/cache`.
+- Every run must take a measurable action: close a live-config incident, close a stale reservation, create one qualified candidate, record a justified quality skip, update an active experiment, or write a structured Decodex implementation handoff.
+- Publisher is the sole X writer. Radar is the upstream evidence owner. Manager owns selection, prioritization, outcome learning, and follow-through.
+- Do not mutate Linear, create GitHub Actions, push, open or land PRs, merge code, or touch private runtime/account/auth state. Repo implementation proposals go to a structured handoff; they do not self-approve.
+
+X MCP budget:
+- Plan before calling. Prefer local records.
+- Daily maximum: 2 paid calls, 8 Post Read resources, 1 User Read resource, 1 count request, and $0.05 estimated spend.
+- Use at most one batched Post Read for recent `@decodexspace` outcome metrics. Do not fetch liking/repost actors or paginate.
+- Record planned and actual calls, resources, reference unit prices, and estimated spend. If fresh metrics cannot change today's action, spend $0.
+
+Preflight:
+Before reading state or writing manager output, run `pwd`, `git status --short --branch`, and `git rev-parse HEAD`. If cwd is not the primary clean `main` checkout, contains `.worktrees`, required files are missing, or validation is unavailable, fail closed.
+
+Required reads:
+- `automations/decodex/automations.toml`
+- `automations/radar/automations.toml`
+- `automations/decodex/prompts/automation-evaluator.md`
+- `automations/decodex/prompts/automation-daily-effectiveness-review.md`
+- `automations/decodex/prompts/x-publisher.md`
+- `automations/decodex/scripts/config/evaluate_automations.py`
+- `automations/decodex/scripts/operations/automation_effectiveness_scorecard.schema.json`
+- `automations/decodex/scripts/operations/summarize_automation_effectiveness.py`
+- `automations/decodex/scripts/social/social_candidate.schema.json`
+- `automations/decodex/skills/x-post-publisher/SKILL.md`
+- `automations/decodex/skills/x-post-quality-system/SKILL.md`
+- `automations/decodex/skills/references/social-release-publisher-gates.md`
+- `openwiki/integrations/plugins-automations-and-auxiliary-tools.md`
+- `openwiki/integrations/radar-publisher-contracts.md`
+
+Daily loop:
+1. Read the latest independent daily review, weekly strategy, active experiment, previous manager action, and Publisher terminal state.
+2. Persist a seven-day effectiveness scorecard and run both live manifest evaluations.
+3. Treat missing/paused/worktree-bound live automation, invalid generated state, and stale reservations as P0. Repair live-config-only drift through canonical sync when repo-only evaluation passes; otherwise write an exact source handoff.
+4. Inspect fresh Radar reviews/impacts/signals and rank opportunities by operator actionability, recency, novelty, evidence strength, and relevance to the active experiment.
+5. If material Radar evidence exists and no unconsumed candidate exists, create exactly one `social_candidate/v1`. It must state what changed, who should act, why now, and the direct source. Validate social state before handoff.
+6. If no candidate is worth publishing, persist a quality skip with considered sources and rejection reasons. No-op without evidence is failure.
+7. When recent published post ids exist and outcome data can change the next action, use one budgeted X MCP batch read. Record impressions and interactions without treating the manager's own thread replies as organic engagement.
+8. Compare outcome against the active experiment. Keep, modify, or stop the experiment with a reason. Adjust the next candidate's hook, format, depth, media recommendation, or audience; never rewrite historical measurements.
+9. Inspect protocol/control-plane candidates. Operational prompt/live-config fixes may be applied only through canonical validated source. Code/schema/runtime changes become structured Decodex handoffs with evidence, acceptance tests, rollback, and authority requirement.
+10. Persist a machine-readable action record and a concise report under `.agent/automations/decodex/cache/manager/reports/<yyyy-mm-dd>/`.
+
+Daily success conditions:
+- Every managed automation is active on primary `main`; none is worktree-bound.
+- No stale active reservation remains.
+- Material Radar evidence becomes a terminal quality decision within 24 hours.
+- A publishable candidate is consumed by Publisher or receives a precise terminal outcome.
+- Published content receives an outcome read within 48 hours when the paid read can change strategy.
+- The next action explicitly incorporates the current experiment and prior outcome.
+
+Terminal report:
+Report terminal action, scorecard status/path, live health, Radar opportunities considered, candidate/skip created, latest publication/outcome metrics, experiment decision, X MCP planned/actual cost, validation, handoffs, and the next run's mandatory check. Archive after a terminal action or precise fail-closed handoff.

--- a/automations/decodex/prompts/automation-weekly-growth-review.md
+++ b/automations/decodex/prompts/automation-weekly-growth-review.md
@@ -1,0 +1,37 @@
+Own the weekly Decodex automation growth and strategy loop. This is Codex app automation, not GitHub Actions.
+
+Authority and boundaries:
+- Run only from the primary clean `main` checkout; never bind managed automations to `.worktrees`.
+- Generated strategy state must stay under `.agent/automations/decodex/cache/manager`; Radar evidence may be read under `.agent/automations/radar/cache`.
+- Do not publish to X, mutate Linear, create GitHub Actions, push, open or land PRs, merge code, or touch private runtime/account/auth state.
+- Daily Manager executes strategy; Weekly Growth Review owns experiment selection, benchmark comparison, stop/continue decisions, and unresolved-handoff escalation.
+
+X MCP budget:
+- Prefer local records. Weekly maximum: 4 paid calls, 40 Post Read resources, 4 User Read resources, 2 count requests, and $0.30 estimated spend.
+- Sample `@decodexspace` plus at most two benchmark surfaces only when fresh data changes an experiment decision. No actor-list reads or pagination.
+- Record planned and actual resources and estimated spend.
+
+Preflight:
+Before reading or writing strategy state, run `pwd`, `git status --short --branch`, and `git rev-parse HEAD`. If cwd is not the primary clean `main` checkout, contains `.worktrees`, required files are missing, or validation is unavailable, fail closed.
+
+Required reads:
+- `automations/decodex/automations.toml`
+- `automations/radar/automations.toml`
+- `automations/decodex/prompts/automation-manager.md`
+- `automations/decodex/scripts/operations/automation_effectiveness_scorecard.schema.json`
+- `automations/decodex/scripts/operations/summarize_automation_effectiveness.py`
+- `openwiki/integrations/plugins-automations-and-auxiliary-tools.md`
+- `openwiki/integrations/radar-publisher-contracts.md`
+
+Weekly loop:
+1. Produce machine-readable scorecards for the latest seven-day window and the preceding seven-day window.
+2. Compare automation availability, worktree violations, manager coverage, Radar throughput, candidate conversion, publish/skip/block rates, stale reservations, publication cadence, outcome-read coverage, impressions, and non-self interactions where denominators exist.
+3. Identify repeated causes, unresolved handoffs, content topics overused or missing, and upstream evidence that never reached a terminal content/protocol decision.
+4. Use budgeted X MCP reads only for decision-critical fresh outcome or benchmark evidence. Benchmark posts are style/market evidence, never technical claim authority.
+5. Select one primary and at most one secondary experiment for the next seven days. Each experiment must define hypothesis, audience, content format, source requirements, owner, daily trigger, metric, minimum sample, stop condition, rollback, and cost ceiling.
+6. Persist the active experiment in machine-readable form under `.agent/automations/decodex/cache/manager/experiments/active.json`; the Daily Manager must consume it.
+7. Convert repeated operational drift into canonical prompt/config repair or a structured Decodex implementation handoff. Never count an unlanded local commit as an improvement outcome.
+8. Write the weekly report under `.agent/automations/decodex/cache/manager/weekly/<yyyy-mm-dd>/` and name the next Daily Manager action.
+
+Terminal report:
+Report both scorecards, week-over-week deltas, outcome quality, benchmark evidence, active experiments, stopped experiments, planned/actual X MCP cost, resolved/unresolved handoffs, validation, and next daily action. Archive after strategy is persisted or a precise fail-closed handoff exists.

--- a/automations/decodex/prompts/x-publisher.md
+++ b/automations/decodex/prompts/x-publisher.md
@@ -2,12 +2,13 @@ Publish low-frequency, high-value Decodex X posts from `@decodexspace` only when
 
 Authority and boundaries:
 - This is Codex app automation, not GitHub Actions.
+- Run only from the primary `main` checkout. A cwd containing `.worktrees` is a terminal preflight failure.
 - Repo-local automation source is `automations/decodex`.
 - Generated state must stay under `.agent/automations/decodex/cache`.
 - Do not perform upstream source analysis, mutate Linear, open or land PRs, or write generated publication state into tracked source.
 
 Preflight:
-Before reading candidates, writing reservations, opening Chrome, or taking any public action, run `pwd`, `git status --short --branch`, and `git rev-parse HEAD`. Report cwd, branch, HEAD, and dirty state. If the checkout is dirty, the cwd is not the automation checkout, required repo-local source files are missing, or the generated-state validator is unavailable, fail closed before mutating cache state or touching X.
+Before reading candidates, writing reservations, opening Chrome, or taking any public action, run `pwd`, `git status --short --branch`, and `git rev-parse HEAD`. Report cwd, branch, HEAD, and dirty state. If the checkout is dirty, the cwd is not the primary `main` checkout, the cwd contains `.worktrees`, required repo-local source files are missing, or the generated-state validator is unavailable, fail closed before mutating cache state or touching X.
 
 Required reads:
 - `automations/decodex/skills/x-post-publisher/SKILL.md`

--- a/automations/decodex/scripts/config/automation_checkout.py
+++ b/automations/decodex/scripts/config/automation_checkout.py
@@ -1,0 +1,72 @@
+"""Resolve and validate the primary checkout used by Codex automations."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _git(repo_root: Path, *args: str) -> str:
+	completed = subprocess.run(
+		["git", "-C", str(repo_root), *args],
+		check=True,
+		capture_output=True,
+		text=True,
+	)
+	return completed.stdout.strip()
+
+
+def parse_worktree_list(value: str) -> list[dict[str, str]]:
+	records: list[dict[str, str]] = []
+	record: dict[str, str] = {}
+	for line in value.splitlines() + [""]:
+		if not line:
+			if record:
+				records.append(record)
+				record = {}
+			continue
+		key, _, field_value = line.partition(" ")
+		record[key] = field_value
+	return records
+
+
+def primary_checkout_for_branch(source_root: Path, branch: str = "main") -> Path:
+	ref = f"refs/heads/{branch}"
+	records = parse_worktree_list(_git(source_root, "worktree", "list", "--porcelain"))
+	matches = [Path(record["worktree"]).resolve() for record in records if record.get("branch") == ref]
+	if len(matches) != 1:
+		raise ValueError(f"expected exactly one checkout for {ref}, found {len(matches)}")
+	return matches[0]
+
+
+def is_linked_worktree(repo_root: Path) -> bool:
+	git_dir = Path(_git(repo_root, "rev-parse", "--path-format=absolute", "--git-dir")).resolve()
+	common_dir = Path(
+		_git(repo_root, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	).resolve()
+	return git_dir != common_dir
+
+
+def validate_runtime_checkout(repo_root: Path, branch: str = "main") -> None:
+	repo_root = repo_root.resolve()
+	if ".worktrees" in repo_root.parts or is_linked_worktree(repo_root):
+		raise ValueError("automation runtime cwd must not be a linked worktree")
+	current_branch = _git(repo_root, "branch", "--show-current")
+	if current_branch != branch:
+		raise ValueError(
+			f"automation runtime cwd must use branch {branch!r}, got {current_branch!r}"
+		)
+
+
+def resolve_runtime_checkout(
+	source_root: Path,
+	explicit_root: str | None,
+	branch: str = "main",
+) -> Path:
+	repo_root = (
+		Path(explicit_root).expanduser().resolve()
+		if explicit_root
+		else primary_checkout_for_branch(source_root, branch)
+	)
+	validate_runtime_checkout(repo_root, branch)
+	return repo_root

--- a/automations/decodex/scripts/config/automation_eval/io.py
+++ b/automations/decodex/scripts/config/automation_eval/io.py
@@ -7,6 +7,7 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
+from automation_checkout import primary_checkout_for_branch
 from automation_eval.constants import REPO_ROOT
 
 
@@ -24,7 +25,8 @@ def read_text(path: Path) -> str:
 
 
 def expected_cwd(value: str) -> str:
-    return value.replace("{repo_root}", str(REPO_ROOT))
+    runtime_root = primary_checkout_for_branch(REPO_ROOT)
+    return value.replace("{repo_root}", str(runtime_root))
 
 
 def active_automation_path(codex_home: Path, automation_id: str) -> Path:

--- a/automations/decodex/scripts/config/automation_eval/validators.py
+++ b/automations/decodex/scripts/config/automation_eval/validators.py
@@ -138,6 +138,10 @@ def validate_active_config(
             result.fail(f"active {field_name} mismatch: expected {expected!r}, got {actual!r}")
 
     active_cwds = active_config.get("cwds")
+    if isinstance(active_cwds, list) and any(
+        ".worktrees" in str(value).replace("\\", "/").split("/") for value in active_cwds
+    ):
+        result.fail("active cwds must not bind automations to a worktree")
     expected = expected_cwd(str(defaults.get("cwd", "{repo_root}")))
     if active_cwds != [expected]:
         result.fail(f"active cwds mismatch: expected {[expected]!r}, got {active_cwds!r}")

--- a/automations/decodex/scripts/config/automation_sync/cli.py
+++ b/automations/decodex/scripts/config/automation_sync/cli.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from automation_checkout import resolve_runtime_checkout
 from automation_sync.manifest import automation_specs
 from automation_sync.paths import (
     REPO_ROOT,
@@ -29,7 +30,11 @@ def parse_args() -> argparse.Namespace:
         help="Automation manifest path. Defaults to Decodex and Radar manifests.",
     )
     parser.add_argument("--codex-home", default=default_codex_home(), help="Codex home path.")
-    parser.add_argument("--repo-root", default=str(REPO_ROOT), help="Repo checkout path for live cwds.")
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Primary main checkout path for live cwds. Defaults to the checkout owning main.",
+    )
     parser.add_argument("--automation-id", action="append", help="Install only this id. Repeatable.")
     parser.add_argument("--apply", action="store_true", help="Write live automation.toml files.")
     parser.add_argument("--json", action="store_true", help="Write machine-readable output.")
@@ -79,7 +84,10 @@ def sync_automations(
 
 def main() -> int:
     args = parse_args()
-    repo_root = Path(args.repo_root).expanduser().resolve()
+    try:
+        repo_root = resolve_runtime_checkout(REPO_ROOT, args.repo_root)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
     codex_home = resolve_codex_home(args.codex_home, repo_root)
     specs = selected_automation_specs(args.manifest, args.automation_id)
     results = sync_automations(specs, codex_home, repo_root, args.apply)

--- a/automations/decodex/scripts/config/tests/test_automation_checkout.py
+++ b/automations/decodex/scripts/config/tests/test_automation_checkout.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+CONFIG_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CONFIG_ROOT))
+
+import automation_checkout  # noqa: E402
+from automation_eval.model import AutomationResult  # noqa: E402
+from automation_eval.validators import validate_active_config  # noqa: E402
+
+
+class AutomationCheckoutTests(unittest.TestCase):
+	def test_selects_checkout_owning_main(self) -> None:
+		worktrees = """worktree /repo
+HEAD abc
+branch refs/heads/main
+
+worktree /repo/.worktrees/task
+HEAD def
+branch refs/heads/xy/task
+"""
+		with patch.object(automation_checkout, "_git", return_value=worktrees):
+			self.assertEqual(
+				automation_checkout.primary_checkout_for_branch(Path("/repo/.worktrees/task")),
+				Path("/repo"),
+			)
+
+	def test_rejects_linked_worktree_runtime_root(self) -> None:
+		with patch.object(automation_checkout, "is_linked_worktree", return_value=True):
+			with self.assertRaisesRegex(ValueError, "must not be a linked worktree"):
+				automation_checkout.validate_runtime_checkout(Path("/repo/.worktrees/task"))
+
+	def test_requires_main_branch(self) -> None:
+		with (
+			patch.object(automation_checkout, "is_linked_worktree", return_value=False),
+			patch.object(automation_checkout, "_git", return_value="xy/task"),
+		):
+			with self.assertRaisesRegex(ValueError, "must use branch 'main'"):
+				automation_checkout.validate_runtime_checkout(Path("/repo"))
+
+	def test_active_config_rejects_worktree_cwd_explicitly(self) -> None:
+		result = AutomationResult("manager")
+		defaults = {
+			"kind": "cron",
+			"status": "ACTIVE",
+			"model": "gpt-5.6-sol",
+			"reasoning_effort": "high",
+			"execution_environment": "local",
+			"cwd": "{repo_root}",
+		}
+		automation = {"name": "Manager", "rrule": "FREQ=DAILY"}
+		active = {
+			"kind": "cron",
+			"name": "Manager",
+			"status": "ACTIVE",
+			"rrule": "FREQ=DAILY",
+			"model": "gpt-5.6-sol",
+			"reasoning_effort": "high",
+			"execution_environment": "local",
+			"cwds": ["/repo/.worktrees/task"],
+			"prompt": "prompt",
+		}
+		with patch("automation_eval.validators.expected_cwd", return_value="/repo"):
+			validate_active_config(automation, defaults, "prompt", active, result)
+		self.assertIn(
+			"active cwds must not bind automations to a worktree",
+			result.errors,
+		)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/automations/decodex/scripts/operations/automation_effectiveness_scorecard.schema.json
+++ b/automations/decodex/scripts/operations/automation_effectiveness_scorecard.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "automation_effectiveness_scorecard.schema.json",
+  "title": "Decodex automation effectiveness scorecard",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generated_at",
+    "window",
+    "status",
+    "live",
+    "social",
+    "radar",
+    "management",
+    "blockers"
+  ],
+  "properties": {
+    "schema": { "const": "automation_effectiveness_scorecard/v1" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "window": {
+      "type": "object",
+      "required": ["start", "end"],
+      "properties": {
+        "start": { "type": "string", "format": "date-time" },
+        "end": { "type": "string", "format": "date-time" }
+      }
+    },
+    "status": { "enum": ["healthy", "needs_action", "blocked"] },
+    "live": { "type": "object" },
+    "social": { "type": "object" },
+    "radar": { "type": "object" },
+    "management": { "type": "object" },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["severity", "code"],
+        "properties": {
+          "severity": { "enum": ["p0", "p1"] },
+          "code": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/automations/decodex/scripts/operations/summarize_automation_effectiveness.py
+++ b/automations/decodex/scripts/operations/summarize_automation_effectiveness.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Build a deterministic Decodex automation effectiveness scorecard."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tomllib
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SOURCE_ROOT = Path(__file__).resolve().parents[4]
+CONFIG_ROOT = SOURCE_ROOT / "automations/decodex/scripts/config"
+sys.path.insert(0, str(CONFIG_ROOT))
+
+from automation_checkout import primary_checkout_for_branch  # noqa: E402
+
+
+RUNTIME_ROOT = primary_checkout_for_branch(SOURCE_ROOT)
+MANIFESTS = (
+	SOURCE_ROOT / "automations/decodex/automations.toml",
+	SOURCE_ROOT / "automations/radar/automations.toml",
+)
+MANAGER_ROOT = RUNTIME_ROOT / ".agent/automations/decodex/cache/manager"
+
+
+def parse_time(value: str) -> datetime:
+	return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def load_json(path: Path) -> dict[str, Any] | None:
+	try:
+		value = json.loads(path.read_text(encoding="utf-8"))
+	except (OSError, json.JSONDecodeError):
+		return None
+	return value if isinstance(value, dict) else None
+
+
+def files_in_window(root: Path, pattern: str, start: datetime, end: datetime) -> list[Path]:
+	if not root.exists():
+		return []
+	result = []
+	for path in root.glob(pattern):
+		if not path.is_file():
+			continue
+		modified = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
+		if start <= modified < end:
+			result.append(path)
+	return sorted(result)
+
+
+def managed_automation_ids() -> list[str]:
+	ids: list[str] = []
+	for path in MANIFESTS:
+		with path.open("rb") as handle:
+			manifest = tomllib.load(handle)
+		ids.extend(item["id"] for item in manifest.get("automations", []))
+	return ids
+
+
+def inspect_live_configs(codex_home: Path, managed_ids: list[str]) -> dict[str, Any]:
+	statuses: Counter[str] = Counter()
+	missing: list[str] = []
+	worktree_bound: list[str] = []
+	for automation_id in managed_ids:
+		path = codex_home / "automations" / automation_id / "automation.toml"
+		if not path.exists():
+			missing.append(automation_id)
+			continue
+		with path.open("rb") as handle:
+			config = tomllib.load(handle)
+		statuses[str(config.get("status", "UNKNOWN"))] += 1
+		cwds = config.get("cwds", [])
+		if any(".worktrees" in Path(str(cwd)).parts for cwd in cwds):
+			worktree_bound.append(automation_id)
+	return {
+		"managed": len(managed_ids),
+		"statuses": dict(sorted(statuses.items())),
+		"missing": missing,
+		"worktree_bound": worktree_bound,
+	}
+
+
+def all_json(root: Path, pattern: str) -> Iterable[tuple[Path, dict[str, Any]]]:
+	if not root.exists():
+		return
+	for path in sorted(root.glob(pattern)):
+		if value := load_json(path):
+			yield path, value
+
+
+def inspect_social(start: datetime, end: datetime) -> dict[str, Any]:
+	root = RUNTIME_ROOT / ".agent/automations/decodex/cache/social/x"
+	posts = list(all_json(root / "posts", "**/*.json"))
+	reservations = list(all_json(root / "reservations", "**/*.json"))
+	candidates = list(all_json(root / "candidates", "*.json"))
+	terminal_keys = {
+		str(value.get("decision", {}).get("idempotency_key"))
+		for _, value in posts
+		if value.get("decision", {}).get("idempotency_key")
+	}
+	open_candidates = []
+	for path, value in candidates:
+		decision = value.get("decision", {})
+		key = decision.get("idempotency_key")
+		if decision.get("worthiness") == "publish" and key not in terminal_keys:
+			open_candidates.append(path.name)
+
+	window_posts = [
+		value
+		for path, value in posts
+		if start <= datetime.fromtimestamp(path.stat().st_mtime, timezone.utc) < end
+	]
+	status_counts = Counter(str(value.get("status", "unknown")) for value in window_posts)
+	published = [value for value in window_posts if value.get("status") == "published"]
+	published_units = sum(
+		max(1, len(value.get("text", []))) if isinstance(value.get("text"), list) else 1
+		for value in published
+	)
+	latest_urls = []
+	for value in published:
+		for url in value.get("source_refs", {}).get("urls", []):
+			if isinstance(url, str) and url.startswith("https://x.com/"):
+				latest_urls.append(url)
+
+	stale_reservations = []
+	active_reservations = []
+	for path, value in reservations:
+		if value.get("status") != "active":
+			continue
+		active_reservations.append(path.name)
+		expires_at = value.get("expires_at")
+		if isinstance(expires_at, str) and parse_time(expires_at) < end:
+			stale_reservations.append(path.name)
+
+	return {
+		"candidate_files": len(candidates),
+		"open_publishable_candidates": open_candidates,
+		"post_outcomes": dict(sorted(status_counts.items())),
+		"published_records": len(published),
+		"published_post_units": published_units,
+		"latest_published_url": latest_urls[-1] if latest_urls else None,
+		"active_reservations": active_reservations,
+		"stale_reservations": stale_reservations,
+	}
+
+
+def inspect_radar(start: datetime, end: datetime) -> dict[str, int]:
+	root = RUNTIME_ROOT / ".agent/automations/radar/cache"
+	patterns = {
+		"reviews": "github/reviews/*.json",
+		"impacts": "github/impact/*.json",
+		"signals": "site-content/signals/*.json",
+		"control_plane_candidates": "github/control-plane-upgrades/*.json",
+		"release_checkpoints": "generated/release-checkpoints/*",
+	}
+	return {
+		name: len(files_in_window(root, pattern, start, end))
+		for name, pattern in patterns.items()
+	}
+
+
+def inspect_management(start: datetime, end: datetime) -> dict[str, Any]:
+	daily = files_in_window(MANAGER_ROOT / "reports", "**/*.md", start, end)
+	weekly = files_in_window(MANAGER_ROOT / "weekly", "**/*.md", start, end)
+	covered_days = sorted(
+		{
+			datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).date().isoformat()
+			for path in daily
+		}
+	)
+	return {
+		"daily_reports": len(daily),
+		"daily_coverage_days": covered_days,
+		"weekly_reports": len(weekly),
+		"latest_daily_report": str(daily[-1].relative_to(RUNTIME_ROOT)) if daily else None,
+	}
+
+
+def build_scorecard(codex_home: Path, start: datetime, end: datetime) -> dict[str, Any]:
+	managed_ids = managed_automation_ids()
+	live = inspect_live_configs(codex_home, managed_ids)
+	social = inspect_social(start, end)
+	radar = inspect_radar(start, end)
+	management = inspect_management(start, end)
+	blockers: list[dict[str, str]] = []
+
+	if live["missing"]:
+		blockers.append({"severity": "p0", "code": "missing_live_automations"})
+	if live["worktree_bound"]:
+		blockers.append({"severity": "p0", "code": "worktree_bound_automations"})
+	if live["statuses"].get("ACTIVE", 0) != live["managed"]:
+		blockers.append({"severity": "p0", "code": "managed_automations_not_active"})
+	if social["stale_reservations"]:
+		blockers.append({"severity": "p0", "code": "stale_social_reservations"})
+	if management["daily_reports"] == 0:
+		blockers.append({"severity": "p1", "code": "missing_daily_manager_evidence"})
+	if (
+		radar["impacts"] > 0
+		and social["published_records"] == 0
+		and not social["open_publishable_candidates"]
+	):
+		blockers.append({"severity": "p1", "code": "radar_to_publisher_pipeline_starved"})
+
+	status = "healthy"
+	if any(item["severity"] == "p0" for item in blockers):
+		status = "blocked"
+	elif blockers:
+		status = "needs_action"
+	return {
+		"schema": "automation_effectiveness_scorecard/v1",
+		"generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+		"window": {
+			"start": start.isoformat().replace("+00:00", "Z"),
+			"end": end.isoformat().replace("+00:00", "Z"),
+		},
+		"status": status,
+		"live": live,
+		"social": social,
+		"radar": radar,
+		"management": management,
+		"blockers": blockers,
+	}
+
+
+def parse_args() -> argparse.Namespace:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("--codex-home", default=os.environ.get("CODEX_HOME", str(Path.home() / ".codex")))
+	parser.add_argument("--window-days", type=int, default=7)
+	parser.add_argument("--as-of", help="Exclusive ISO-8601 window end. Defaults to now.")
+	parser.add_argument("--output", help="Optional scorecard path under the manager scorecard cache.")
+	return parser.parse_args()
+
+
+def main() -> int:
+	args = parse_args()
+	if args.window_days < 1:
+		raise SystemExit("--window-days must be positive")
+	end = parse_time(args.as_of) if args.as_of else datetime.now(timezone.utc)
+	start = end - timedelta(days=args.window_days)
+	payload = build_scorecard(Path(args.codex_home).expanduser(), start, end)
+	rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+	if args.output:
+		path = Path(args.output)
+		path = path if path.is_absolute() else RUNTIME_ROOT / path
+		path = path.resolve()
+		allowed = (MANAGER_ROOT / "scorecards").resolve()
+		if path.parent != allowed and allowed not in path.parents:
+			raise SystemExit("--output must stay under the manager scorecard cache")
+		path.parent.mkdir(parents=True, exist_ok=True)
+		temporary = path.with_suffix(path.suffix + ".tmp")
+		temporary.write_text(rendered, encoding="utf-8")
+		temporary.replace(path)
+	sys.stdout.write(rendered)
+	return 0 if payload["status"] == "healthy" else 1
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/automations/decodex/scripts/operations/tests/test_summarize_automation_effectiveness.py
+++ b/automations/decodex/scripts/operations/tests/test_summarize_automation_effectiveness.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "summarize_automation_effectiveness.py"
+SPEC = importlib.util.spec_from_file_location("effectiveness", SCRIPT)
+assert SPEC and SPEC.loader
+effectiveness = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(effectiveness)
+
+
+class EffectivenessScorecardTests(unittest.TestCase):
+	def test_social_finds_open_candidate_and_stale_reservation(self) -> None:
+		with tempfile.TemporaryDirectory() as value:
+			root = Path(value)
+			social = root / ".agent/automations/decodex/cache/social/x"
+			(social / "candidates").mkdir(parents=True)
+			(social / "posts").mkdir()
+			(social / "reservations").mkdir()
+			(social / "candidates/candidate.json").write_text(
+				json.dumps(
+					{
+						"decision": {
+							"worthiness": "publish",
+							"idempotency_key": "candidate-1",
+						}
+					}
+				),
+				encoding="utf-8",
+			)
+			(social / "reservations/reservation.json").write_text(
+				json.dumps(
+					{
+						"status": "active",
+						"expires_at": "2026-07-01T00:00:00Z",
+					}
+				),
+				encoding="utf-8",
+			)
+			end = datetime(2026, 7, 10, tzinfo=timezone.utc)
+			with patch.object(effectiveness, "RUNTIME_ROOT", root):
+				result = effectiveness.inspect_social(end - timedelta(days=7), end)
+			self.assertEqual(result["open_publishable_candidates"], ["candidate.json"])
+			self.assertEqual(result["stale_reservations"], ["reservation.json"])
+
+	def test_live_config_reports_worktree_binding(self) -> None:
+		with tempfile.TemporaryDirectory() as value:
+			codex_home = Path(value)
+			path = codex_home / "automations/manager/automation.toml"
+			path.parent.mkdir(parents=True)
+			path.write_text(
+				'status = "ACTIVE"\ncwds = ["/repo/.worktrees/task"]\n',
+				encoding="utf-8",
+			)
+			result = effectiveness.inspect_live_configs(codex_home, ["manager"])
+			self.assertEqual(result["worktree_bound"], ["manager"])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/automations/radar/automations.toml
+++ b/automations/radar/automations.toml
@@ -20,7 +20,7 @@ forbidden_prompt_fragments = [
 	"~/.codex/decodex",
 ]
 kind = "cron"
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 reasoning_effort = "high"
 source_root = "automations/radar"
 status = "ACTIVE"

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -59,7 +59,7 @@ Automation source is checked in under:
 - `automations/decodex/`: Publisher automation, public-publishing jobs, automation health audit jobs, social schemas, skills, and shared config tooling.
 - `automations/radar/`: Radar upstream review, release checkpoint curation, artifact retention, GitHub/Codex analysis helpers, and Radar skills.
 
-These are portable sources. Live Codex App configs under `$CODEX_HOME/automations/*/automation.toml` are generated and machine-local. Source manifests use relative paths and `{repo_root}` placeholders, and the installer refuses configured private fragments such as absolute user-home paths, auth files, account files, or runtime databases (`automations/decodex/README.md`).
+These are portable sources. Live Codex App configs under `$CODEX_HOME/automations/*/automation.toml` are generated and machine-local. Source manifests use relative paths and `{repo_root}` placeholders. Runtime cwd is always the primary checkout owning `main`: the installer rejects linked-worktree runtime roots and the evaluator treats any managed `.worktrees` cwd as a P0 failure. The installer also refuses configured private fragments such as absolute user-home paths, auth files, account files, or runtime databases (`automations/decodex/README.md`).
 
 Commands:
 
@@ -68,7 +68,26 @@ python3 automations/decodex/scripts/config/sync_automations.py
 python3 automations/decodex/scripts/config/sync_automations.py --apply
 python3 automations/decodex/scripts/config/evaluate_automations.py --manifest automations/decodex/automations.toml
 python3 automations/decodex/scripts/config/evaluate_automations.py --manifest automations/radar/automations.toml
+python3 automations/decodex/scripts/operations/summarize_automation_effectiveness.py
 ```
+
+The operating loop has explicit owners:
+
+- Health Audit repairs live-config-only drift from validated canonical source and
+  re-evaluates every managed automation. It never edits repo source.
+- Daily Effectiveness Review independently measures the previous 24 hours and writes
+  `automation_effectiveness_scorecard/v1` evidence.
+- Automation Manager consumes that evidence, ranks fresh Radar opportunities, creates
+  at most one qualified social candidate, closes operational incidents, and updates the
+  active content experiment. Publisher remains the sole X writer.
+- Weekly Growth Review compares consecutive seven-day windows and persists the next
+  experiment. Paid X MCP reads are bounded and used only when fresh outcome or benchmark
+  evidence can change the decision.
+
+Operational autonomy does not bypass repository authority. Prompt/live-config repair,
+candidate selection, publishing, outcome learning, and strategy updates can close
+automatically. Code, schema, runtime, PR, and landing changes still require normal
+Decodex authority and are emitted as structured implementation handoffs.
 
 Do not copy full automation prompts into OpenWiki. Summarize boundaries and link to source files when a task needs details.
 


### PR DESCRIPTION
## Summary
- forbid managed Codex automations from binding linked worktrees and resolve runtime cwd to the primary main checkout
- restore daily effectiveness, automation manager, and weekly growth loops with bounded X MCP budgets and autonomous live-config repair
- add deterministic automation effectiveness scorecards, tests, and OpenWiki operations guidance

## Validation
- cargo make check
- cargo run -p decodex --bin decodex -- openwiki check
- python3 -m unittest automations/decodex/scripts/config/tests/test_automation_checkout.py automations/decodex/scripts/operations/tests/test_summarize_automation_effectiveness.py
- repo-only Decodex and Radar automation evaluation
- sync dry-run and explicit linked-worktree rejection