### PR TITLE
Close automation experiment authority and evidence gaps

### DIFF
--- a/automations/decodex/automations.toml
+++ b/automations/decodex/automations.toml
@@ -73,6 +73,7 @@ required_paths = [
 	"automations/decodex/scripts/config/automation_eval/validators.py",
 	"automations/decodex/scripts/config/evaluate_automations.py",
 	"automations/decodex/scripts/config/sync_automations.py",
+	"automations/decodex/scripts/operations/summarize_automation_effectiveness.py",
 	"automations/radar/automations.toml",
 	"openwiki/quickstart.md",
 ]

--- a/automations/decodex/prompts/automation-evaluator.md
+++ b/automations/decodex/prompts/automation-evaluator.md
@@ -14,15 +14,17 @@ Required reads:
 - `automations/radar/automations.toml`
 - `automations/decodex/scripts/config/evaluate_automations.py`
 - `automations/decodex/scripts/config/sync_automations.py`
+- `automations/decodex/scripts/operations/summarize_automation_effectiveness.py`
 - `openwiki/quickstart.md`
 
 Workflow:
 1. Run live evaluation for both manifests with `--json`.
-2. If both pass, record a healthy terminal result.
+2. Persist a seven-day effectiveness scorecard. Inspect Daily Manager coverage, active-experiment status, recent terminal Manager/Weekly records, and open manager handoffs; an ACTIVE live config is not evidence that scheduled work completed.
 3. If repo-only evaluation fails, do not repair live config. Report the exact source defect.
 4. If repo-only evaluation passes and failures are confined to managed live status, cwd, prompt, schedule, model, reasoning effort, or missing live config, run the canonical sync installer with `--apply` from the primary `main` checkout.
-5. Re-run both live evaluations. Claim repaired only when every managed id passes and no cwd contains `.worktrees`.
-6. Persist a concise health record under `.agent/automations/decodex/cache/manager/health/<yyyy-mm-dd>/` containing before/after results and the repair action.
+5. Re-run both live evaluations and the scorecard after repair. Claim config repaired only when every managed id passes and no cwd contains `.worktrees`.
+6. Treat a scorecard P0 as a terminal health failure. Treat missing/expired/invalid active strategy, post-cutover Daily Manager coverage gaps, or unresolved operational handoffs as P1 even when live config passes; emit the exact owner and next check instead of reporting healthy.
+7. Persist a concise health record under `.agent/automations/decodex/cache/manager/health/<yyyy-mm-dd>/` containing before/after results, scorecard path, repair action, operational evidence, and unresolved blockers.
 
 Terminal report:
-Report every managed id, before/after status, worktree-binding violations, repair action, final validation, health-record path, and unresolved blockers. Archive the run after a terminal healthy, repaired, or fail-closed outcome.
+Report every managed id, before/after status, worktree-binding violations, Daily Manager coverage, active-experiment status, repair action, final validation, health-record path, and unresolved blockers. Archive the run after a terminal healthy, repaired, needs-action, or fail-closed outcome.

--- a/automations/decodex/prompts/automation-manager.md
+++ b/automations/decodex/prompts/automation-manager.md
@@ -3,8 +3,9 @@ Act as the accountable Decodex product-ops, automation-ops, and marketing-ops ma
 Operating contract:
 - Run only from the primary clean `main` checkout. Never bind this automation or another managed automation to `.worktrees`.
 - Generated manager state must stay under `.agent/automations/decodex/cache/manager`; social state stays under `.agent/automations/decodex/cache/social`; Radar state may be read under `.agent/automations/radar/cache`.
-- Every run must take a measurable action: close a live-config incident, close a stale reservation, create one qualified candidate, record a justified quality skip, update an active experiment, or write a structured Decodex implementation handoff.
+- Every run must take a measurable action: close a live-config incident, close a stale reservation, create one qualified candidate, record a justified quality skip, record experiment evidence plus a Weekly recommendation, or write a structured Decodex implementation handoff.
 - Publisher is the sole X writer. Radar is the upstream evidence owner. Manager owns selection, prioritization, outcome learning, and follow-through.
+- Weekly Growth Review owns experiment selection and continue/modify/stop decisions. Daily Manager executes the active strategy, measures it, and recommends changes without mutating experiment status or selection.
 - Do not mutate Linear, create GitHub Actions, push, open or land PRs, merge code, or touch private runtime/account/auth state. Repo implementation proposals go to a structured handoff; they do not self-approve.
 
 X MCP budget:
@@ -40,7 +41,7 @@ Daily loop:
 5. If material Radar evidence exists and no unconsumed candidate exists, create exactly one `social_candidate/v1`. It must state what changed, who should act, why now, and the direct source. Validate social state before handoff.
 6. If no candidate is worth publishing, persist a quality skip with considered sources and rejection reasons. No-op without evidence is failure.
 7. When recent published post ids exist and outcome data can change the next action, use one budgeted X MCP batch read. Record impressions and interactions without treating the manager's own thread replies as organic engagement.
-8. Compare outcome against the active experiment. Keep, modify, or stop the experiment with a reason. Adjust the next candidate's hook, format, depth, media recommendation, or audience; never rewrite historical measurements.
+8. Compare outcome against the active experiment. Apply only candidate adjustments already authorized by the active experiment, preserve historical measurements, and record an evidence-backed continue/modify/stop recommendation for Weekly. Do not mutate experiment status, selection, stop conditions, or authority.
 9. Inspect protocol/control-plane candidates. Operational prompt/live-config fixes may be applied only through canonical validated source. Code/schema/runtime changes become structured Decodex handoffs with evidence, acceptance tests, rollback, and authority requirement.
 10. Persist a machine-readable action record and a concise report under `.agent/automations/decodex/cache/manager/reports/<yyyy-mm-dd>/`.
 
@@ -50,7 +51,7 @@ Daily success conditions:
 - Material Radar evidence becomes a terminal quality decision within 24 hours.
 - A publishable candidate is consumed by Publisher or receives a precise terminal outcome.
 - Published content receives an outcome read within 48 hours when the paid read can change strategy.
-- The next action explicitly incorporates the current experiment and prior outcome.
+- The next action explicitly incorporates the current experiment and prior outcome without taking Weekly strategy authority.
 
 Terminal report:
-Report terminal action, scorecard status/path, live health, Radar opportunities considered, candidate/skip created, latest publication/outcome metrics, experiment decision, X MCP planned/actual cost, validation, handoffs, and the next run's mandatory check. Archive after a terminal action or precise fail-closed handoff.
+Report terminal action, scorecard status/path, live health, Radar opportunities considered, candidate/skip created, latest publication/outcome metrics, experiment evidence and Weekly recommendation, X MCP planned/actual cost, validation, handoffs, and the next run's mandatory check. Archive after a terminal action or precise fail-closed handoff.

--- a/automations/decodex/prompts/automation-weekly-growth-review.md
+++ b/automations/decodex/prompts/automation-weekly-growth-review.md
@@ -30,8 +30,9 @@ Weekly loop:
 4. Use budgeted X MCP reads only for decision-critical fresh outcome or benchmark evidence. Benchmark posts are style/market evidence, never technical claim authority.
 5. Select one primary and at most one secondary experiment for the next seven days. Each experiment must define hypothesis, audience, content format, source requirements, owner, daily trigger, metric, minimum sample, stop condition, rollback, and cost ceiling.
 6. Persist the active experiment in machine-readable form under `.agent/automations/decodex/cache/manager/experiments/active.json`; the Daily Manager must consume it.
-7. Convert repeated operational drift into canonical prompt/config repair or a structured Decodex implementation handoff. Never count an unlanded local commit as an improvement outcome.
-8. Write the weekly report under `.agent/automations/decodex/cache/manager/weekly/<yyyy-mm-dd>/` and name the next Daily Manager action.
+7. Reconcile Daily Manager experiment evidence and continue/modify/stop recommendations. Weekly alone may change experiment selection, status, stop conditions, rollback, or cost ceiling.
+8. Convert repeated operational drift into canonical prompt/config repair or a structured Decodex implementation handoff. Never count an unlanded local commit as an improvement outcome.
+9. Write the weekly report under `.agent/automations/decodex/cache/manager/weekly/<yyyy-mm-dd>/` and name the next Daily Manager action.
 
 Terminal report:
 Report both scorecards, week-over-week deltas, outcome quality, benchmark evidence, active experiments, stopped experiments, planned/actual X MCP cost, resolved/unresolved handoffs, validation, and next daily action. Archive after strategy is persisted or a precise fail-closed handoff exists.

--- a/automations/decodex/scripts/operations/summarize_automation_effectiveness.py
+++ b/automations/decodex/scripts/operations/summarize_automation_effectiveness.py
@@ -67,6 +67,7 @@ def inspect_live_configs(codex_home: Path, managed_ids: list[str]) -> dict[str, 
 	statuses: Counter[str] = Counter()
 	missing: list[str] = []
 	worktree_bound: list[str] = []
+	updated_at: dict[str, str] = {}
 	for automation_id in managed_ids:
 		path = codex_home / "automations" / automation_id / "automation.toml"
 		if not path.exists():
@@ -78,11 +79,17 @@ def inspect_live_configs(codex_home: Path, managed_ids: list[str]) -> dict[str, 
 		cwds = config.get("cwds", [])
 		if any(".worktrees" in Path(str(cwd)).parts for cwd in cwds):
 			worktree_bound.append(automation_id)
+		if isinstance(config.get("updated_at"), int):
+			updated_at[automation_id] = datetime.fromtimestamp(
+				config["updated_at"] / 1000,
+				timezone.utc,
+			).isoformat().replace("+00:00", "Z")
 	return {
 		"managed": len(managed_ids),
 		"statuses": dict(sorted(statuses.items())),
 		"missing": missing,
 		"worktree_bound": worktree_bound,
+		"updated_at": updated_at,
 	}
 
 
@@ -165,7 +172,44 @@ def inspect_radar(start: datetime, end: datetime) -> dict[str, int]:
 	}
 
 
-def inspect_management(start: datetime, end: datetime) -> dict[str, Any]:
+def inspect_active_experiment(end: datetime) -> dict[str, Any]:
+	path = MANAGER_ROOT / "experiments/active.json"
+	value = load_json(path)
+	if value is None:
+		return {"status": "missing", "path": str(path.relative_to(RUNTIME_ROOT))}
+	try:
+		window = value["effective_window"]
+		window_start = parse_time(window["start"])
+		window_end = parse_time(window["end"])
+		experiments = value["experiments"]
+	except (KeyError, TypeError, ValueError):
+		return {"status": "invalid", "path": str(path.relative_to(RUNTIME_ROOT))}
+	if not isinstance(experiments, list) or not experiments:
+		status = "invalid"
+	elif window_end <= end:
+		status = "expired"
+	elif window_start > end:
+		status = "pending"
+	elif not any(item.get("status") == "active" for item in experiments if isinstance(item, dict)):
+		status = "invalid"
+	else:
+		status = "active"
+	return {
+		"status": status,
+		"path": str(path.relative_to(RUNTIME_ROOT)),
+		"effective_window": {
+			"start": window_start.isoformat().replace("+00:00", "Z"),
+			"end": window_end.isoformat().replace("+00:00", "Z"),
+		},
+		"experiment_count": len(experiments),
+	}
+
+
+def inspect_management(
+	start: datetime,
+	end: datetime,
+	manager_updated_at: str | None = None,
+) -> dict[str, Any]:
 	daily = files_in_window(MANAGER_ROOT / "reports", "**/*.md", start, end)
 	weekly = files_in_window(MANAGER_ROOT / "weekly", "**/*.md", start, end)
 	covered_days = sorted(
@@ -174,11 +218,18 @@ def inspect_management(start: datetime, end: datetime) -> dict[str, Any]:
 			for path in daily
 		}
 	)
+	coverage_start = start
+	if manager_updated_at:
+		coverage_start = max(start, parse_time(manager_updated_at))
+	expected_days = max(0, int((end - coverage_start).total_seconds() // 86400))
 	return {
 		"daily_reports": len(daily),
 		"daily_coverage_days": covered_days,
 		"weekly_reports": len(weekly),
 		"latest_daily_report": str(daily[-1].relative_to(RUNTIME_ROOT)) if daily else None,
+		"coverage_baseline": coverage_start.isoformat().replace("+00:00", "Z"),
+		"expected_daily_coverage_days": expected_days,
+		"active_experiment": inspect_active_experiment(end),
 	}
 
 
@@ -187,7 +238,11 @@ def build_scorecard(codex_home: Path, start: datetime, end: datetime) -> dict[st
 	live = inspect_live_configs(codex_home, managed_ids)
 	social = inspect_social(start, end)
 	radar = inspect_radar(start, end)
-	management = inspect_management(start, end)
+	management = inspect_management(
+		start,
+		end,
+		live["updated_at"].get("decodex-automation-manager"),
+	)
 	blockers: list[dict[str, str]] = []
 
 	if live["missing"]:
@@ -200,6 +255,10 @@ def build_scorecard(codex_home: Path, start: datetime, end: datetime) -> dict[st
 		blockers.append({"severity": "p0", "code": "stale_social_reservations"})
 	if management["daily_reports"] == 0:
 		blockers.append({"severity": "p1", "code": "missing_daily_manager_evidence"})
+	elif len(management["daily_coverage_days"]) < management["expected_daily_coverage_days"]:
+		blockers.append({"severity": "p1", "code": "daily_manager_coverage_gap"})
+	if management["active_experiment"]["status"] in {"missing", "invalid", "expired", "pending"}:
+		blockers.append({"severity": "p1", "code": "active_experiment_unavailable"})
 	if (
 		radar["impacts"] > 0
 		and social["published_records"] == 0

--- a/automations/decodex/scripts/operations/tests/test_summarize_automation_effectiveness.py
+++ b/automations/decodex/scripts/operations/tests/test_summarize_automation_effectiveness.py
@@ -62,6 +62,91 @@ class EffectivenessScorecardTests(unittest.TestCase):
 			result = effectiveness.inspect_live_configs(codex_home, ["manager"])
 			self.assertEqual(result["worktree_bound"], ["manager"])
 
+	def test_active_experiment_reports_active_and_expired(self) -> None:
+		with tempfile.TemporaryDirectory() as value:
+			root = Path(value)
+			path = root / ".agent/automations/decodex/cache/manager/experiments/active.json"
+			path.parent.mkdir(parents=True)
+			path.write_text(
+				json.dumps(
+					{
+						"effective_window": {
+							"start": "2026-07-10T00:00:00Z",
+							"end": "2026-07-17T00:00:00Z",
+						},
+						"experiments": [{"status": "active"}],
+					}
+				),
+				encoding="utf-8",
+			)
+			with (
+				patch.object(effectiveness, "RUNTIME_ROOT", root),
+				patch.object(effectiveness, "MANAGER_ROOT", path.parents[1]),
+			):
+				active = effectiveness.inspect_active_experiment(
+					datetime(2026, 7, 12, tzinfo=timezone.utc)
+				)
+				expired = effectiveness.inspect_active_experiment(
+					datetime(2026, 7, 18, tzinfo=timezone.utc)
+				)
+			self.assertEqual(active["status"], "active")
+			self.assertEqual(expired["status"], "expired")
+
+	def test_management_uses_live_update_as_coverage_baseline(self) -> None:
+		with tempfile.TemporaryDirectory() as value:
+			root = Path(value)
+			manager_root = root / ".agent/automations/decodex/cache/manager"
+			(manager_root / "reports/2026-07-10").mkdir(parents=True)
+			(manager_root / "reports/2026-07-10/report.md").write_text("report\n", encoding="utf-8")
+			with (
+				patch.object(effectiveness, "RUNTIME_ROOT", root),
+				patch.object(effectiveness, "MANAGER_ROOT", manager_root),
+			):
+				result = effectiveness.inspect_management(
+					datetime(2026, 7, 3, tzinfo=timezone.utc),
+					datetime(2026, 7, 10, 12, tzinfo=timezone.utc),
+					"2026-07-10T00:00:00Z",
+				)
+			self.assertEqual(result["expected_daily_coverage_days"], 0)
+			self.assertEqual(result["daily_reports"], 1)
+
+	def test_scorecard_blocks_missing_experiment_and_coverage_gap(self) -> None:
+		live = {
+			"managed": 1,
+			"statuses": {"ACTIVE": 1},
+			"missing": [],
+			"worktree_bound": [],
+			"updated_at": {"decodex-automation-manager": "2026-07-01T00:00:00Z"},
+		}
+		social = {
+			"stale_reservations": [],
+			"published_records": 1,
+			"open_publishable_candidates": [],
+		}
+		management = {
+			"daily_reports": 1,
+			"daily_coverage_days": ["2026-07-09"],
+			"expected_daily_coverage_days": 7,
+			"active_experiment": {"status": "missing"},
+		}
+		with (
+			patch.object(effectiveness, "managed_automation_ids", return_value=["manager"]),
+			patch.object(effectiveness, "inspect_live_configs", return_value=live),
+			patch.object(effectiveness, "inspect_social", return_value=social),
+			patch.object(effectiveness, "inspect_radar", return_value={"impacts": 0}),
+			patch.object(effectiveness, "inspect_management", return_value=management),
+		):
+			result = effectiveness.build_scorecard(
+				Path("/tmp/codex-home"),
+				datetime(2026, 7, 3, tzinfo=timezone.utc),
+				datetime(2026, 7, 10, tzinfo=timezone.utc),
+			)
+		self.assertEqual(result["status"], "needs_action")
+		self.assertEqual(
+			[item["code"] for item in result["blockers"]],
+			["daily_manager_coverage_gap", "active_experiment_unavailable"],
+		)
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -78,11 +78,16 @@ The operating loop has explicit owners:
 - Daily Effectiveness Review independently measures the previous 24 hours and writes
   `automation_effectiveness_scorecard/v1` evidence.
 - Automation Manager consumes that evidence, ranks fresh Radar opportunities, creates
-  at most one qualified social candidate, closes operational incidents, and updates the
-  active content experiment. Publisher remains the sole X writer.
+  at most one qualified social candidate, closes operational incidents, and executes
+  the active content experiment. Daily records measurements and recommends strategy
+  changes; Weekly alone selects, modifies, continues, or stops experiments. Publisher
+  remains the sole X writer.
 - Weekly Growth Review compares consecutive seven-day windows and persists the next
-  experiment. Paid X MCP reads are bounded and used only when fresh outcome or benchmark
-  evidence can change the decision.
+  experiment. The deterministic scorecard treats missing, invalid, or expired active
+  strategy and post-cutover Daily Manager coverage gaps as operational P1 evidence;
+  an ACTIVE live config alone is not successful execution. Paid X MCP reads are
+  bounded and used only when fresh outcome or benchmark evidence can change the
+  decision.
 
 Operational autonomy does not bypass repository authority. Prompt/live-config repair,
 candidate selection, publishing, outcome learning, and strategy updates can close


### PR DESCRIPTION
## Summary
- make Weekly Growth Review the sole experiment strategy authority
- make health evaluation require execution evidence, daily coverage, and a valid active experiment
- add deterministic scorecard tests and align OpenWiki

## Validation
- `cargo make check` (1662 passed, 1 skipped)
- `python3 -m unittest automations.decodex.scripts.operations.tests.test_summarize_automation_effectiveness` (9 passed)
- Decodex and Radar live evaluator checks passed
- `decodex openwiki check` passed