### PR TITLE
Make automation scorecards account for unresolved handoffs

### DIFF
--- a/automations/decodex/scripts/operations/summarize_automation_effectiveness.py
+++ b/automations/decodex/scripts/operations/summarize_automation_effectiveness.py
@@ -27,6 +27,7 @@ MANIFESTS = (
 	SOURCE_ROOT / "automations/radar/automations.toml",
 )
 MANAGER_ROOT = RUNTIME_ROOT / ".agent/automations/decodex/cache/manager"
+TERMINAL_AUTOMATION_HANDOFF_STATUSES = {"closed", "resolved", "superseded"}
 
 
 def parse_time(value: str) -> datetime:
@@ -205,6 +206,25 @@ def inspect_active_experiment(end: datetime) -> dict[str, Any]:
 	}
 
 
+def inspect_automation_handoffs() -> dict[str, Any]:
+	handoffs = []
+	for path, value in all_json(MANAGER_ROOT / "handoffs", "**/*.json"):
+		if value.get("schema") != "decodex_automation_handoff/v1":
+			continue
+		status = str(value.get("status", "unknown"))
+		if status in TERMINAL_AUTOMATION_HANDOFF_STATUSES:
+			continue
+		handoffs.append(
+			{
+				"id": str(value.get("id", path.stem)),
+				"severity": str(value.get("severity", "p1")),
+				"status": status,
+				"path": str(path.relative_to(RUNTIME_ROOT)),
+			}
+		)
+	return {"unresolved": handoffs, "unresolved_count": len(handoffs)}
+
+
 def inspect_management(
 	start: datetime,
 	end: datetime,
@@ -230,6 +250,7 @@ def inspect_management(
 		"coverage_baseline": coverage_start.isoformat().replace("+00:00", "Z"),
 		"expected_daily_coverage_days": expected_days,
 		"active_experiment": inspect_active_experiment(end),
+		"automation_handoffs": inspect_automation_handoffs(),
 	}
 
 
@@ -259,6 +280,8 @@ def build_scorecard(codex_home: Path, start: datetime, end: datetime) -> dict[st
 		blockers.append({"severity": "p1", "code": "daily_manager_coverage_gap"})
 	if management["active_experiment"]["status"] in {"missing", "invalid", "expired", "pending"}:
 		blockers.append({"severity": "p1", "code": "active_experiment_unavailable"})
+	if management["automation_handoffs"]["unresolved_count"]:
+		blockers.append({"severity": "p1", "code": "unresolved_automation_handoffs"})
 	if (
 		radar["impacts"] > 0
 		and social["published_records"] == 0

--- a/automations/decodex/scripts/operations/tests/test_summarize_automation_effectiveness.py
+++ b/automations/decodex/scripts/operations/tests/test_summarize_automation_effectiveness.py
@@ -110,6 +110,39 @@ class EffectivenessScorecardTests(unittest.TestCase):
 			self.assertEqual(result["expected_daily_coverage_days"], 0)
 			self.assertEqual(result["daily_reports"], 1)
 
+	def test_automation_handoffs_exclude_terminal_and_implementation_proposals(self) -> None:
+		with tempfile.TemporaryDirectory() as value:
+			root = Path(value)
+			manager_root = root / ".agent/automations/decodex/cache/manager"
+			handoffs = manager_root / "handoffs/2026-07-10"
+			handoffs.mkdir(parents=True)
+			for name, payload in {
+				"open.json": {
+					"schema": "decodex_automation_handoff/v1",
+					"id": "open-automation-handoff",
+					"status": "open",
+					"severity": "p1",
+				},
+				"resolved.json": {
+					"schema": "decodex_automation_handoff/v1",
+					"id": "resolved-automation-handoff",
+					"status": "resolved",
+				},
+				"implementation.json": {
+					"schema": "decodex_implementation_handoff/v1",
+					"id": "authority-gated-proposal",
+					"status": "needs_decision",
+				},
+			}.items():
+				(handoffs / name).write_text(json.dumps(payload), encoding="utf-8")
+			with (
+				patch.object(effectiveness, "RUNTIME_ROOT", root),
+				patch.object(effectiveness, "MANAGER_ROOT", manager_root),
+			):
+				result = effectiveness.inspect_automation_handoffs()
+		self.assertEqual(result["unresolved_count"], 1)
+		self.assertEqual(result["unresolved"][0]["id"], "open-automation-handoff")
+
 	def test_scorecard_blocks_missing_experiment_and_coverage_gap(self) -> None:
 		live = {
 			"managed": 1,
@@ -128,6 +161,7 @@ class EffectivenessScorecardTests(unittest.TestCase):
 			"daily_coverage_days": ["2026-07-09"],
 			"expected_daily_coverage_days": 7,
 			"active_experiment": {"status": "missing"},
+			"automation_handoffs": {"unresolved_count": 1},
 		}
 		with (
 			patch.object(effectiveness, "managed_automation_ids", return_value=["manager"]),
@@ -144,7 +178,11 @@ class EffectivenessScorecardTests(unittest.TestCase):
 		self.assertEqual(result["status"], "needs_action")
 		self.assertEqual(
 			[item["code"] for item in result["blockers"]],
-			["daily_manager_coverage_gap", "active_experiment_unavailable"],
+			[
+				"daily_manager_coverage_gap",
+				"active_experiment_unavailable",
+				"unresolved_automation_handoffs",
+			],
 		)
 
 

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -85,9 +85,10 @@ The operating loop has explicit owners:
 - Weekly Growth Review compares consecutive seven-day windows and persists the next
   experiment. The deterministic scorecard treats missing, invalid, or expired active
   strategy and post-cutover Daily Manager coverage gaps as operational P1 evidence;
-  an ACTIVE live config alone is not successful execution. Paid X MCP reads are
-  bounded and used only when fresh outcome or benchmark evidence can change the
-  decision.
+  unresolved `decodex_automation_handoff/v1` items are also P1 evidence, while
+  authority-gated implementation proposals remain separate. An ACTIVE live config
+  alone is not successful execution. Paid X MCP reads are bounded and used only when
+  fresh outcome or benchmark evidence can change the decision.
 
 Operational autonomy does not bypass repository authority. Prompt/live-config repair,
 candidate selection, publishing, outcome learning, and strategy updates can close


### PR DESCRIPTION
## Summary
- include unresolved automation-ops handoffs in deterministic scorecards
- keep authority-gated implementation proposals separate from automation health
- add focused tests and align OpenWiki

## Validation
- `python3 -m unittest automations.decodex.scripts.operations.tests.test_summarize_automation_effectiveness` (6 passed)
- `cargo run -q -p decodex --bin decodex -- openwiki check`
- live handoff-aware scorecard returns `needs_action` with both open automation handoffs