### PR TITLE
Enforce the Publisher terminal outcome SLA

### DIFF
--- a/automations/decodex/scripts/operations/summarize_automation_effectiveness.py
+++ b/automations/decodex/scripts/operations/summarize_automation_effectiveness.py
@@ -113,11 +113,15 @@ def inspect_social(start: datetime, end: datetime) -> dict[str, Any]:
 		if value.get("decision", {}).get("idempotency_key")
 	}
 	open_candidates = []
+	overdue_candidates = []
 	for path, value in candidates:
 		decision = value.get("decision", {})
 		key = decision.get("idempotency_key")
 		if decision.get("worthiness") == "publish" and key not in terminal_keys:
 			open_candidates.append(path.name)
+			modified = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
+			if modified + timedelta(hours=24) <= end:
+				overdue_candidates.append(path.name)
 
 	window_posts = [
 		value
@@ -149,6 +153,7 @@ def inspect_social(start: datetime, end: datetime) -> dict[str, Any]:
 	return {
 		"candidate_files": len(candidates),
 		"open_publishable_candidates": open_candidates,
+		"overdue_publishable_candidates": overdue_candidates,
 		"post_outcomes": dict(sorted(status_counts.items())),
 		"published_records": len(published),
 		"published_post_units": published_units,
@@ -274,6 +279,8 @@ def build_scorecard(codex_home: Path, start: datetime, end: datetime) -> dict[st
 		blockers.append({"severity": "p0", "code": "managed_automations_not_active"})
 	if social["stale_reservations"]:
 		blockers.append({"severity": "p0", "code": "stale_social_reservations"})
+	if social["overdue_publishable_candidates"]:
+		blockers.append({"severity": "p1", "code": "publisher_terminal_outcome_overdue"})
 	if management["daily_reports"] == 0:
 		blockers.append({"severity": "p1", "code": "missing_daily_manager_evidence"})
 	elif len(management["daily_coverage_days"]) < management["expected_daily_coverage_days"]:

--- a/automations/decodex/scripts/operations/tests/test_summarize_automation_effectiveness.py
+++ b/automations/decodex/scripts/operations/tests/test_summarize_automation_effectiveness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
@@ -24,7 +25,8 @@ class EffectivenessScorecardTests(unittest.TestCase):
 			(social / "candidates").mkdir(parents=True)
 			(social / "posts").mkdir()
 			(social / "reservations").mkdir()
-			(social / "candidates/candidate.json").write_text(
+			candidate = social / "candidates/candidate.json"
+			candidate.write_text(
 				json.dumps(
 					{
 						"decision": {
@@ -35,6 +37,8 @@ class EffectivenessScorecardTests(unittest.TestCase):
 				),
 				encoding="utf-8",
 			)
+			old = datetime(2026, 7, 8, tzinfo=timezone.utc).timestamp()
+			os.utime(candidate, (old, old))
 			(social / "reservations/reservation.json").write_text(
 				json.dumps(
 					{
@@ -48,6 +52,7 @@ class EffectivenessScorecardTests(unittest.TestCase):
 			with patch.object(effectiveness, "RUNTIME_ROOT", root):
 				result = effectiveness.inspect_social(end - timedelta(days=7), end)
 			self.assertEqual(result["open_publishable_candidates"], ["candidate.json"])
+			self.assertEqual(result["overdue_publishable_candidates"], ["candidate.json"])
 			self.assertEqual(result["stale_reservations"], ["reservation.json"])
 
 	def test_live_config_reports_worktree_binding(self) -> None:
@@ -153,6 +158,7 @@ class EffectivenessScorecardTests(unittest.TestCase):
 		}
 		social = {
 			"stale_reservations": [],
+			"overdue_publishable_candidates": [],
 			"published_records": 1,
 			"open_publishable_candidates": [],
 		}

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -88,9 +88,10 @@ The operating loop has explicit owners:
   experiment. The deterministic scorecard treats missing, invalid, or expired active
   strategy and post-cutover Daily Manager coverage gaps as operational P1 evidence;
   unresolved `decodex_automation_handoff/v1` items are also P1 evidence, while
-  authority-gated implementation proposals remain separate. An ACTIVE live config
-  alone is not successful execution. Paid X MCP reads are bounded and used only when
-  fresh outcome or benchmark evidence can change the decision.
+  authority-gated implementation proposals remain separate. A publishable candidate
+  without a terminal Publisher outcome after 24 hours is another P1. An ACTIVE live
+  config alone is not successful execution. Paid X MCP reads are bounded and used
+  only when fresh outcome or benchmark evidence can change the decision.
 
 Operational autonomy does not bypass repository authority. Prompt/live-config repair,
 candidate selection, publishing, outcome learning, and strategy updates can close


### PR DESCRIPTION
## Summary
- flag publishable candidates older than 24 hours without a terminal Publisher record
- expose overdue candidate names in deterministic scorecards
- add focused test coverage and align OpenWiki

## Validation
- scorecard unit tests passed 6/6
- Decodex repo-only automation evaluation passed 5/5
- `decodex openwiki check` passed
- current live candidate remains within SLA and scorecard stays healthy