### PR TITLE
Preserve persisted continuation retries after child exit

### DIFF
--- a/apps/decodex/src/orchestrator/daemon_retry/child_exit.rs
+++ b/apps/decodex/src/orchestrator/daemon_retry/child_exit.rs
@@ -29,10 +29,9 @@ where
 	let Some(issue) = active::refreshed_child_exit_issue(&mut context, issue_id)? else {
 		return Ok(());
 	};
-	let continuation_pending =
-		exit_status.success() && run_attempt.status() == CONTINUATION_PENDING_RUN_STATUS;
+	let continuation_pending = run_attempt.status() == CONTINUATION_PENDING_RUN_STATUS;
 
-	if !exit_status.success() && run_attempt.status() != "failed" {
+	if !exit_status.success() && run_attempt.status() != "failed" && !continuation_pending {
 		daemon_retry::clear_retry_schedule_and_release(
 			context.retry_queue,
 			context.state_store,
@@ -60,18 +59,22 @@ where
 		return Ok(());
 	}
 
-	let recovered_phase_goal_continuation = match daemon_retry::recover_child_exit_phase_goal(
-		&mut context,
-		&issue,
-		child,
-		issue_id,
-		initial_issue_state,
-		dispatch_mode,
-		exit_status.success(),
-	)? {
-		ChildExitPhaseGoalRecovery::None => None,
-		ChildExitPhaseGoalRecovery::Continuation(recovery) => Some(recovery),
-		ChildExitPhaseGoalRecovery::Terminalized => return Ok(()),
+	let recovered_phase_goal_continuation = if continuation_pending {
+		None
+	} else {
+		match daemon_retry::recover_child_exit_phase_goal(
+			&mut context,
+			&issue,
+			child,
+			issue_id,
+			initial_issue_state,
+			dispatch_mode,
+			exit_status.success(),
+		)? {
+			ChildExitPhaseGoalRecovery::None => None,
+			ChildExitPhaseGoalRecovery::Continuation(recovery) => Some(recovery),
+			ChildExitPhaseGoalRecovery::Terminalized => return Ok(()),
+		}
 	};
 	let (kind, attempt, continuation_initial_issue_state) = if continuation_pending {
 		plan::continuation_child_exit_retry_plan(&run_attempt, initial_issue_state)

--- a/apps/decodex/src/orchestrator/tests/retry_scheduling/phase_goal_exit/continuation.rs
+++ b/apps/decodex/src/orchestrator/tests/retry_scheduling/phase_goal_exit/continuation.rs
@@ -55,6 +55,68 @@ fn schedule_retry_after_child_exit_records_continuation_retry_for_clean_exit() {
 }
 
 #[test]
+fn schedule_retry_after_child_exit_preserves_persisted_continuation_after_failed_exit() {
+	let (_temp_dir, config, workflow) = tests::temp_project_layout();
+	let issue = support::sample_service_owned_issue("In Progress");
+	let tracker =
+		FakeTracker::with_refresh_snapshots(vec![issue.clone()], vec![vec![issue.clone()]]);
+	let state_store = StateStore::open_in_memory().expect("state store should open");
+	let run_id = "run-failed-exit-continuation";
+
+	state_store
+		.record_run_attempt(run_id, &issue.id, 2, CONTINUATION_PENDING_RUN_STATUS)
+		.expect("continuation-pending run attempt should record");
+	state_store
+		.append_private_execution_event(
+			TEST_SERVICE_ID,
+			&issue.id,
+			run_id,
+			2,
+			"phase_goal_next",
+			serde_json::json!({
+				"schema": "decodex.phase_goal_signal/1",
+				"phase": "repair_validation_failures",
+				"reason": "validation_fail",
+			}),
+		)
+		.expect("persisted next phase should record");
+
+	let exit_status =
+		Command::new("sh").args(["-c", "exit 1"]).status().expect("failure exit should run");
+	let mut retry_queue = RetryQueue::default();
+
+	orchestrator::schedule_retry_after_child_exit(
+		ChildExitRetryContext {
+			retry_queue: &mut retry_queue,
+			tracker: &tracker,
+			project: &config,
+			workflow: &workflow,
+			state_store: &state_store,
+		},
+		ChildRunRef { issue_id: &issue.id, run_id, attempt_number: 2 },
+		issue.project_slug.as_deref().expect("sample issue should carry a project slug"),
+		&issue.state.name,
+		IssueDispatchMode::Program,
+		exit_status,
+	)
+	.expect("persisted continuation should schedule despite failed child exit");
+
+	let entry =
+		retry_queue.entries.get(&issue.id).expect("continuation retry should remain queued");
+	let events = state_store
+		.list_private_execution_events(TEST_SERVICE_ID, &issue.id, run_id, 2)
+		.expect("private continuation events should load");
+
+	assert_eq!(entry.kind, orchestrator::RetryKind::Continuation);
+	assert_eq!(entry.attempt, 2);
+	assert!(events.iter().any(|event| {
+		event.event_type() == "continuation_lineage"
+			&& event.payload()["continuation_of_run_id"] == run_id
+			&& event.payload()["next_retry_kind"] == "continuation"
+	}));
+}
+
+#[test]
 fn retains_continuation_retry_for_stale_startable_issue() {
 	let (_temp_dir, config, workflow) = tests::temp_project_layout();
 	let issue = support::sample_service_owned_issue("Todo");

--- a/openwiki/workflows/runtime-operator-workflows.md
+++ b/openwiki/workflows/runtime-operator-workflows.md
@@ -138,6 +138,7 @@ Rules:
 - Issue-batch apply persists local Program Intake/Execution Program state for existing issues.
 - Issue-batch Program identity is stable for the service and normalized supplied issue identifiers. Reapplying the same batch refreshes its tracker snapshot in place and retires exact legacy duplicates rather than accumulating competing Programs.
 - Runtime reconciliation releases an issue-batch node whose persisted `active` intent came from ownership that is now absent, while preserving explicit terminal, paused, and not-ready intents.
+- A persisted `continuation_pending` run remains eligible for daemon continuation even when the child process exits non-zero after the continuation boundary. The persisted phase cursor and lane policy remain authoritative; the exit code alone must not clear its retry schedule.
 - Program dispatch is direct. It does not apply, remove, or wait for service queue labels.
 - Internal graph/node ids, proposal ids, private evidence refs, and local runtime rows must not be exposed in public Linear briefs.
 


### PR DESCRIPTION
## Summary
- preserve continuation scheduling when a child exits non-zero after persisting the continuation boundary
- avoid re-running phase-goal recovery when continuation state is already durable
- cover the failed-exit continuation path and document the runtime contract

## Validation
- [cargo-make] INFO - cargo make 0.37.24
[cargo-make] INFO - 
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: check
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Execute Command: "npm" "run" "build"

> decodex-site@0.0.0 build
> astro build

10:46:40 [WARN] [vite] warning: `optimizeDeps.esbuildOptions` option was specified by "astro:dev-toolbar" plugin. This option is deprecated, please use `optimizeDeps.rolldownOptions` instead.
10:46:40 [WARN] [vite] `resolve.alias` contains an alias with `customResolver` option. This is deprecated and will be removed in Vite 9. Please use a custom plugin with a resolveId hook and `enforce: 'pre'` instead.
10:46:40 [WARN] [vite] You or a plugin you are using have set `optimizeDeps.esbuildOptions` but this option is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rolldownOptions` instead.
10:46:40 [types] Generated 18ms
10:46:40 [build] output: "static"
10:46:40 [build] mode: "static"
10:46:40 [build] directory: /Users/x/code/y/hack-ink/decodex/.worktrees/continuation-exit-retry/site/dist/
10:46:40 [build] Collecting build info...
10:46:40 [build] ✓ Completed in 24ms.
10:46:40 [build] Building static entrypoints...
10:46:40 [WARN] [vite] warning: `optimizeDeps.esbuildOptions` option was specified by "astro:dev-toolbar" plugin. This option is deprecated, please use `optimizeDeps.rolldownOptions` instead.
10:46:40 [WARN] [vite] `resolve.alias` contains an alias with `customResolver` option. This is deprecated and will be removed in Vite 9. Please use a custom plugin with a resolveId hook and `enforce: 'pre'` instead.
10:46:40 [WARN] [vite] You or a plugin you are using have set `optimizeDeps.esbuildOptions` but this option is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rolldownOptions` instead.
10:46:40 [WARN] [vite] warning: `optimizeDeps.esbuildOptions` option was specified by "astro:dev-toolbar" plugin. This option is deprecated, please use `optimizeDeps.rolldownOptions` instead.
10:46:40 [WARN] [vite] `resolve.alias` contains an alias with `customResolver` option. This is deprecated and will be removed in Vite 9. Please use a custom plugin with a resolveId hook and `enforce: 'pre'` instead.
10:46:40 [WARN] [vite] You or a plugin you are using have set `optimizeDeps.esbuildOptions` but this option is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rolldownOptions` instead.
10:46:40 [WARN] [vite] warning: `optimizeDeps.esbuildOptions` option was specified by "astro:dev-toolbar" plugin. This option is deprecated, please use `optimizeDeps.rolldownOptions` instead.
10:46:40 [WARN] [vite] `resolve.alias` contains an alias with `customResolver` option. This is deprecated and will be removed in Vite 9. Please use a custom plugin with a resolveId hook and `enforce: 'pre'` instead.
10:46:40 [WARN] [vite] You or a plugin you are using have set `optimizeDeps.esbuildOptions` but this option is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rolldownOptions` instead.
10:46:40 [WARN] [vite] warning: `optimizeDeps.esbuildOptions` option was specified by "astro:dev-toolbar" plugin. This option is deprecated, please use `optimizeDeps.rolldownOptions` instead.
10:46:40 [WARN] [vite] `resolve.alias` contains an alias with `customResolver` option. This is deprecated and will be removed in Vite 9. Please use a custom plugin with a resolveId hook and `enforce: 'pre'` instead.
10:46:40 [WARN] [vite] You or a plugin you are using have set `optimizeDeps.esbuildOptions` but this option is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rolldownOptions` instead.
10:46:40 [WARN] [vite] warning: `optimizeDeps.esbuildOptions` option was specified by "astro:dev-toolbar" plugin. This option is deprecated, please use `optimizeDeps.rolldownOptions` instead.
10:46:40 [WARN] [vite] `resolve.alias` contains an alias with `customResolver` option. This is deprecated and will be removed in Vite 9. Please use a custom plugin with a resolveId hook and `enforce: 'pre'` instead.
10:46:40 [WARN] [vite] You or a plugin you are using have set `optimizeDeps.esbuildOptions` but this option is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rolldownOptions` instead.
10:46:40 [vite] ✓ built in 126ms
10:46:40 [vite] ✓ built in 10ms
10:46:40 [build] Rearranging server assets...

 generating static routes 
10:46:40   ├─ /index.html (+4ms) 
10:46:40 ✓ Completed in 10ms.

10:46:40 [build] ✓ Completed in 161ms.
10:46:40 [build] 1 page(s) built in 186ms
10:46:40 [build] Complete!
[cargo-make] INFO - Execute Command: "npm" "run" "check"

> decodex-site@0.0.0 check
> astro check

10:46:41 [WARN] [vite] warning: `optimizeDeps.esbuildOptions` option was specified by "astro:dev-toolbar" plugin. This option is deprecated, please use `optimizeDeps.rolldownOptions` instead.
10:46:41 [WARN] [vite] `resolve.alias` contains an alias with `customResolver` option. This is deprecated and will be removed in Vite 9. Please use a custom plugin with a resolveId hook and `enforce: 'pre'` instead.
10:46:41 [WARN] [vite] You or a plugin you are using have set `optimizeDeps.esbuildOptions` but this option is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rolldownOptions` instead.
10:46:41 [types] Generated 19ms
10:46:41 [check] Getting diagnostics for Astro files in /Users/x/code/y/hack-ink/decodex/.worktrees/continuation-exit-retry/site...
Result (22 files): 
- 0 errors
- 0 warnings
- 0 hints

[cargo-make] INFO - Execute Command: "cargo" "check" "--all-features" "--all-targets" "--workspace"
[cargo-make] INFO - Execute Command: "rustup" "run" "nightly" "cargo" "fmt" "--all" "--" "--check"
[cargo-make] INFO - Execute Command: "taplo" "fmt" "--check"
[cargo-make] INFO - Execute Command: "cargo" "clippy" "--all-features" "--all-targets" "--workspace" "--" "-D" "clippy::all" "-D" "clippy::too_many_lines" "-D" "clippy::unwrap_used" "-D" "clippy::use_self" "-D" "clippy::wildcard_imports" "-D" "missing-docs" "-D" "unused-crate-dependencies" "-D" "warnings"
[cargo-make] INFO - Execute Command: "cargo" "vstyle" "curate" "--language" "rust" "--workspace" "--all-features"

Checked 3186 file(s).
[cargo-make] INFO - Execute Command: "cargo" "nextest" "run" "--workspace" "--all-targets" "--all-features"
[cargo-make] INFO - Build Done in 113.99 seconds. (1683 passed, 1 skipped)