### PR TITLE
Fix Linux process liveness fs import

### DIFF
--- a/apps/decodex/src/orchestrator/status/process_liveness.rs
+++ b/apps/decodex/src/orchestrator/status/process_liveness.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "linux")] use std::fs;
 #[cfg(target_os = "macos")] use std::mem;
 #[cfg(target_os = "macos")] use std::mem::MaybeUninit;
 use std::time::Duration;


### PR DESCRIPTION
## Summary

- import `std::fs` under the Linux cfg used by process liveness
- unblock Linux compilation and Lane Authority C1I qualified-owner closure

## Validation

- `cargo check -p decodex --all-features --all-targets`
- Linux target check reached native SQLite compilation and is locally blocked only by the absent `x86_64-linux-gnu-gcc`; GitHub Linux CI provides the authoritative target build

Authority: XY-1251