### PR TITLE
docs: establish Decodex vNext authority

### DIFF
--- a/openwiki/decisions/design-rationale.md
+++ b/openwiki/decisions/design-rationale.md
@@ -1,5 +1,10 @@
 # Design Rationale
 
+Scope: current v0.2 rationale and historical decisions. For vNext target design, the
+[vNext authority decision](vnext-authority.md) and
+[vNext authority contract](../specs/vnext-authority.md) supersede conflicting product,
+runtime, state, identity, transport, migration, and delivery claims on this page.
+
 This page preserves durable "why" decisions that were previously scattered across historical decision records. It is not runtime authority by itself. Current authority lives in source, contracts, tests, checked-in manifests, and local runtime state; this page explains why those authority boundaries exist and where future agents should verify them.
 
 ## Current authority and status

--- a/openwiki/decisions/lane-authority-v2.md
+++ b/openwiki/decisions/lane-authority-v2.md
@@ -1,6 +1,7 @@
 # Lane Authority V2
 
-Status: accepted target architecture, not yet implemented.
+Status: superseded and frozen by [XY-1260](vnext-authority.md). Historical architecture
+and incident provenance only; do not implement or advance C1-C7.
 
 Tracking issue: [XY-1251](https://linear.app/hack-ink/issue/XY-1251/lane-authority-v2-unify-decodex-project-lane-lifecycle-and-effect-authority)
 

--- a/openwiki/decisions/vnext-authority.md
+++ b/openwiki/decisions/vnext-authority.md
@@ -1,0 +1,83 @@
+# Decodex vNext Authority Decision
+
+Status: accepted repository authority for vNext.
+
+Tracking issue: [XY-1260](https://linear.app/hack-ink/issue/XY-1260/promote-the-vnext-authority-contract-and-supersede-lane-authority-v2)
+
+Source planning record: [Decodex vNext Design Baseline](https://linear.app/hack-ink/document/decodex-vnext-design-baseline-681f7d8ad284), accepted 2026-07-12 against repository snapshot `5546dcb3b2eb0a8aecf7d6a3b117d2605ea315b8`.
+
+## Decision
+
+Decodex vNext is a rebuild of the agent workspace, not an incremental extension of the
+current Linear-lane and SQLite runtime. The normative product and runtime contract is
+[the vNext authority contract](../specs/vnext-authority.md); its ordered proof and
+implementation boundaries are in [the vNext gate manifest](../specs/vnext-gates.md).
+
+The accepted planning baseline is provenance for this decision. Where the baseline and
+these repository documents agree, these repository documents own implementation. A
+concrete contradiction must stop the affected milestone for explicit resolution; later
+workers must not silently reinterpret either source.
+
+## Decision hierarchy
+
+Within vNext work, authority descends in this order:
+
+1. explicit user direction and checked-in project policy;
+2. this decision, the vNext authority contract, and the vNext gate manifest;
+3. accepted project policies and versioned domain/protocol contracts created under
+   those documents;
+4. source, tests, migrations, and operational runbooks implementing an accepted gate;
+5. OpenWiki navigation and current-runtime descriptions;
+6. Linear plans and research as provenance or candidate changes.
+
+Current source remains authority for current v0.2 behavior but cannot override the
+accepted vNext target. Conversely, target documents do not claim that vNext behavior is
+already implemented. Git/filesystem and GitHub remain the authorities for repository
+content and provider readback respectively; PostgreSQL becomes product-state authority
+only when its bootstrap/cutover gate is accepted.
+
+## Supersession
+
+Lane Authority v2 and its C1-C7 program are superseded and frozen. Its decision,
+contract, effect registry, gate manifest, checkpoint ledger, fixtures, scripts, review
+findings, and incident scenarios remain useful historical evidence. They must not be
+continued, repaired, activated, or treated as vNext acceptance gates. In particular,
+vNext rejects Lane Authority v2's SQLite authority, Linear issue/lane identity, local
+Unix authority ledger, and compatibility migration target.
+
+PR #1092 is likewise historical/incident evidence: freeze or close it, do not merge it,
+and do not wholesale cherry-pick its implementation. Reuse a behavior only after the
+vNext owner and a focused gate/test make that behavior authoritative.
+
+## Accepted shape
+
+- PostgreSQL owns Decodex product state; a transactional outbox and leases support
+  commands and recovery. It is not event sourced.
+- A shared normal `~/.codex` owns persistent Codex rollout/thread continuity and Codex
+  UI visibility. Decodex maps only threads that it created.
+- `decodexd` alone owns scheduling, app-server children, product mutations, repository
+  side effects, and adapters. GPUI, the menubar app, CLI, and MCP use the same versioned
+  application protocol and are not parallel authority paths.
+- Decodex owns Project, stable Advisor/Lead, execution-scoped Task/Reviewer, Program,
+  Objective, WorkItem, Conversation, RuntimeSession, ManagedRun, Automation,
+  ContextRevision, AgentMessage, Artifact, RoleProfile, and their policies.
+- One Project has exactly one stable Lead in V1. The Lead serializes decisions while
+  Task and Reviewer execution may be parallel. Advisor is global and advisory only.
+- A managed implementation Task owns its implement/review/repair/revalidate loop by
+  spawning an independent read-only reviewer subagent. Lead/Manager owns dispatch,
+  final acceptance, and merge; Quick Tasks are exempt, and missing/failed review is a
+  typed ManagedRun wait and optional WorkItem block rather than reviewed success.
+- A Project policy grants bounded unattended authority once; repository, tool, path,
+  merge, budget, approval, parallelism, and quiet-period limits remain hard stops.
+- Work lands through focused task branches/PRs directly to `main`; there is no long-lived
+  vNext branch.
+
+## Rejected alternatives and falsifiers
+
+Rejected V1 alternatives are enumerated normatively in the contract. The decision may
+change only for evidence that cross-account continuation cannot preserve useful
+continuity, GPUI cannot meet pinned build/package/accessibility/test gates, PostgreSQL
+cannot be operated reliably on the intended host, app-server cannot provide required
+ownership/read/list/collaboration behavior, or real dogfood proves one Lead cannot keep
+decision latency within policy. Such evidence blocks or revises the owning gate; it does
+not authorize a compatibility facade or silent fallback.

--- a/openwiki/evidence/lane-authority-v2-checkpoints.md
+++ b/openwiki/evidence/lane-authority-v2-checkpoints.md
@@ -1,14 +1,18 @@
 # Lane Authority V2 Checkpoints
 
+Status: frozen historical ledger. [XY-1260](../decisions/vnext-authority.md) superseded
+Lane Authority v2; C1-C7 must not advance. Preserve this file as evidence and provenance.
+
 Tracking issue: [XY-1251](https://linear.app/hack-ink/issue/XY-1251/lane-authority-v2-unify-decodex-project-lane-lifecycle-and-effect-authority)
 
-This is the durable anti-drift ledger for the Lane Authority v2 program. Update it at
-every checkpoint with facts, inferences, exact source/PR identities, validation results,
-migration state, unresolved objections, scope changes, and the next checkpoint.
+This was the durable anti-drift ledger for the Lane Authority v2 program. Its entries are
+frozen snapshots of facts, inferences, exact source/PR identities, validation results,
+migration state, unresolved objections, scope changes, and planned next checkpoints. Do
+not update them as active checkpoint state.
 
 ## C0 Baseline And Architecture Freeze
 
-Status: in progress.
+Historical status at supersession: in progress.
 
 Recorded at: 2026-07-09 (America/New_York).
 
@@ -108,16 +112,17 @@ Refreshed at: 2026-07-10 (America/New_York).
 - Existing overwritten global-key rows cannot be reconstructed safely from the winning
   row alone. Migration must use independent evidence or quarantine them.
 
-### Architecture decisions
+### Architecture decisions recorded at C0 (superseded)
 
-- [Lane Authority v2](../decisions/lane-authority-v2.md) is the accepted target.
-- [Lane Authority v2 target contract](../specs/lane-authority-v2.md) defines records,
+- At C0, [Lane Authority v2](../decisions/lane-authority-v2.md) was the accepted target;
+  XY-1260 later superseded it.
+- The historical [Lane Authority v2 target contract](../specs/lane-authority-v2.md) defines records,
   transitions, migration, telemetry, and the scenario matrix.
 - PR #1073 is not the final implementation path. Its requirements and tests remain
   evidence until replacement capability is proven.
 - Migration is an offline one-shot cutover, not a long-lived dual-authority rollout.
 
-### Unresolved objections
+### Objections unresolved when the program was frozen
 
 - Provider capabilities for conditional PR close/reopen, exact-head merge, and comment
   reconciliation must be verified before C3 implementation. Unsupported semantics are

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -8,16 +8,16 @@ OpenWiki is the repo-local project knowledge surface for agents and maintainers.
 
 - [Runtime architecture](architecture/runtime-architecture.md): process topology, CLI bootstrap, app-server runs, operator HTTP/MCP, and state ownership.
 - [Design rationale](decisions/design-rationale.md): why Decodex keeps loop graphs internal, autonomy authority typed, MCP/skills split, the site static, and Radar/Publisher bounded.
-- [Lane Authority v2](decisions/lane-authority-v2.md): accepted target architecture for project binding, canonical lane authority, effect orchestration, migration, and telemetry. This target is not current runtime behavior until its checkpoints land.
+- [vNext authority decision](decisions/vnext-authority.md): the accepted product, ownership, state-authority, cutover, and delivery decision for the rebuild.
+- [vNext authority contract](specs/vnext-authority.md): normative entities, runtime boundaries, protocol, account continuity, non-goals, and migration contract for later implementation.
+- [vNext gate manifest](specs/vnext-gates.md): ordered feasibility and implementation gates, downstream issue ownership, and decision-changing falsifiers.
+- [Lane Authority v2](decisions/lane-authority-v2.md): superseded historical target retained as architecture and incident provenance; C1-C7 are frozen and must not be implemented.
 - [Drift audits](evidence/drift-audits.md): public-safe evidence notes, current MCP remote-control watched claims, reverse checks, validation commands, and stop conditions.
 - [Runtime operator workflows](workflows/runtime-operator-workflows.md): project registry, run/serve/status, lane control, recovery, intake, commit/land, accounts, and MCP workflows.
-- [Contracts and data](specs/contracts-and-data.md): project config, `WORKFLOW.md`, SQLite state, Decision Contracts, Program Intake, tracker tools, review lifecycle, and commit messages.
-- [Runtime contracts](specs/runtime-contracts.md): runtime state ownership, project/`WORKFLOW.md` contracts, leases/attempts, app-server protocol, tracker writeback, evidence/privacy, and recovery boundaries.
-- [Runtime lifecycle](specs/runtime-lifecycle.md): lane authority, app-server protocol, tracker tools, evidence, loop runtime, review lifecycle, and autonomy control-plane boundaries.
-- [Lane Authority v2 target contract](specs/lane-authority-v2.md): target records, transitions, migration rules, scenario matrix, and checkpoint gates.
-- [Lane Authority v2 gate manifest](specs/lane-authority-v2-gates.md): normative scenario ids, commands, expected assertions, fixture paths, and evidence requirements for C0-C7.
-- [Lane Authority v2 effect registry](specs/lane-authority-v2-effects.md): exhaustive runtime-owned mutation kinds, reconciliation and compensation rules, and adapter enforcement.
-- [Lane Authority v2 checkpoints](evidence/lane-authority-v2-checkpoints.md): durable anti-drift record, review objections, validation evidence, and C0-C7 advancement state.
+- [Contracts and data](specs/contracts-and-data.md): current v0.2 project config, SQLite, Decision Contract, Program Intake, tracker, review, and commit behavior; superseded for vNext target work.
+- [Runtime contracts](specs/runtime-contracts.md): current v0.2 state, app-server, tracker, evidence/privacy, and recovery contracts; superseded for vNext target work.
+- [Runtime lifecycle](specs/runtime-lifecycle.md): current v0.2 lane, app-server, tracker, review, and autonomy lifecycle; superseded for vNext target work.
+- [Lane Authority v2 target contract](specs/lane-authority-v2.md), [effect registry](specs/lane-authority-v2-effects.md), [gate manifest](specs/lane-authority-v2-gates.md), and [checkpoint ledger](evidence/lane-authority-v2-checkpoints.md): superseded provenance only, not active implementation authority.
 - [Commands and validation](operations/commands-and-validation.md): task runner, tests, targeted checks, status publishing, app/site/Radar/Publisher validation.
 - [Operator runbooks](operations/operator-runbooks.md): lane-control recovery, review handoff recovery, release readiness, GitHub operations, and control-plane workflows.
 - [Plugins, automations, and auxiliary tools](integrations/plugins-automations-and-auxiliary-tools.md): installable plugin lifecycle, hook guardrails, automation sync, Radar, Publisher, native App, and site boundaries.

--- a/openwiki/specs/contracts-and-data.md
+++ b/openwiki/specs/contracts-and-data.md
@@ -1,5 +1,9 @@
 # Contracts And Data
 
+Scope: current v0.2 behavior only. For vNext target implementation, the
+[vNext authority contract](vnext-authority.md) supersedes this page's Linear tracker,
+SQLite, Goal, transport, data, and authority model.
+
 This page is the primary map for Decodex contracts and data boundaries. Use it to identify the source file or test area that owns behavior before editing. For the concise runtime authority contract across state ownership, project/`WORKFLOW.md`, app-server, tracker writeback, privacy, and recovery, start with [Runtime contracts](runtime-contracts.md).
 
 ## Project contract

--- a/openwiki/specs/lane-authority-v2-effects.md
+++ b/openwiki/specs/lane-authority-v2-effects.md
@@ -1,6 +1,8 @@
 # Lane Authority V2 Effect Registry
 
-Status: normative mutation registry for XY-1251.
+Status: superseded and frozen by the [vNext authority decision](../decisions/vnext-authority.md).
+Historical design and incident provenance only; this is not a normative vNext registry
+and must not be implemented.
 
 Every Decodex mutation of project-, tracker-issue-, lane-, lifecycle-, cleanup-, archive-,
 or authority-relevant state is either a local `commit_transition` transaction or one

--- a/openwiki/specs/lane-authority-v2-gates.md
+++ b/openwiki/specs/lane-authority-v2-gates.md
@@ -1,6 +1,8 @@
 # Lane Authority V2 Gate Manifest
 
-Status: normative gate manifest for XY-1251.
+Status: superseded and frozen by the [vNext authority decision](../decisions/vnext-authority.md).
+C1-C7 are canceled as implementation gates. The commands and scenarios below are
+retained only as historical design, review, and incident evidence.
 
 This file makes C0-C7 advancement falsifiable. The machine scenario manifest lives at
 `apps/decodex/src/orchestrator/tests/fixtures/lane_authority_v2/scenario_manifest.json`

--- a/openwiki/specs/lane-authority-v2.md
+++ b/openwiki/specs/lane-authority-v2.md
@@ -1,7 +1,8 @@
 # Lane Authority V2 Target Contract
 
-Status: accepted target contract. Current runtime behavior remains documented in
-[Contracts and data](contracts-and-data.md) until each checkpoint lands.
+Status: superseded and frozen by the [vNext authority decision](../decisions/vnext-authority.md).
+Retained as historical design and incident provenance only; do not implement this
+contract or advance C1-C7.
 
 ## Core Records
 

--- a/openwiki/specs/runtime-contracts.md
+++ b/openwiki/specs/runtime-contracts.md
@@ -1,5 +1,9 @@
 # Runtime Contracts
 
+Scope: current v0.2 behavior only. For vNext target implementation, the
+[vNext authority contract](vnext-authority.md) supersedes this page's Linear lane,
+SQLite, Goal, transport, lifecycle, and authority model.
+
 This page is the compact contract map for Decodex runtime behavior. It consolidates the checked-in OpenWiki pages with the legacy runtime, app-server, tracker-tool, and workflow-file specs inspected from git history, while treating current Rust source as authority.
 
 Use this page before changing lease ownership, app-server dispatch, tracker writeback, evidence/privacy boundaries, project config, `WORKFLOW.md`, or recovery behavior. For deeper lifecycle detail, continue to [Runtime lifecycle](runtime-lifecycle.md); for schema and row-family detail, continue to [Contracts and data](contracts-and-data.md).

--- a/openwiki/specs/runtime-lifecycle.md
+++ b/openwiki/specs/runtime-lifecycle.md
@@ -1,5 +1,9 @@
 # Runtime Lifecycle
 
+Scope: current v0.2 behavior only. For vNext target implementation, the
+[vNext authority contract](vnext-authority.md) supersedes this page's Linear lane,
+SQLite, Goal, transport, lifecycle, and authority model.
+
 This page covers Decodex runtime authority, lane lifecycle, review lifecycle, app-server protocol, tracker tools, agent evidence, loop runtime, and autonomy boundaries. For the compact cross-cutting contract map, see [Runtime contracts](runtime-contracts.md).
 
 ## Authority model

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -1,0 +1,200 @@
+# Decodex vNext Authority Contract
+
+Status: normative target contract; implementation is gate-controlled.
+
+Owner: [vNext authority decision](../decisions/vnext-authority.md). Gates:
+[vNext gate manifest](vnext-gates.md).
+
+## Product entities
+
+| Entity | Contract |
+| --- | --- |
+| Project | Decodex-owned repository identity and policy; `active`, `paused`, or `archived`. |
+| Agent | Stable global Advisor or exactly one stable Lead per Project; `active`, `paused`, or `retired`. |
+| RoleProfile | Versioned user choice of model, reasoning effort, service tier, and instructions for `advisor`, `lead`, `task`, or `reviewer`. |
+| Program | Open-ended responsibility/context; `active`, `needs_attention`, `blocked`, `paused`, or `retired`. It is not an agent. |
+| Objective | Finite outcome in a Program or Project; `proposed`, `active`, `blocked`, `achieved`, or `abandoned`. |
+| WorkItem | Concrete board item/execution request; `inbox`, `planned`, `ready`, `running`, `review`, `blocked`, `done`, or `canceled`. |
+| Conversation | Durable logical dialogue presented by Decodex; `open` or `archived`. |
+| RuntimeSession | Codex thread segment bound to an account, process, and immutable RoleProfile snapshot; `starting`, `active`, `ended`, or `diverged`. |
+| ManagedRun | Controlled WorkItem execution with independent lifecycle, phase, and wait reason as defined below. |
+| Automation | Deterministic trigger targeting a Program, WorkItem, Advisor, or Lead; `enabled`, `paused`, or `retired`. It is not an agent. |
+| ContextRevision | Immutable, inspectable, provenance-linked long-term context snapshot. |
+| AgentMessage | Durable sender/recipient envelope with correlation, causation, dedupe, artifact, response, and loop-budget fields; `pending`, `delivered`, `acknowledged`, or `expired`. |
+| Artifact | Content-addressed large output/evidence with PostgreSQL metadata; `active`, `expired`, or `deleted`. |
+
+There is no Domain Agent, automatic multi-Lead topology, arbitrary durable role, or Goal
+product entity in V1. Task and Reviewer agents are execution-scoped. Codex-native
+subagents are run-local runtime actors normalized into the same activity/message graph;
+durable cross-run and cross-project routing belongs to Decodex.
+
+## Interaction and work
+
+Advisor is the global default, owns consultation and cross-project recommendations, and
+cannot modify project code or call project write tools. A Project Lead owns project
+context, user decisions, WorkItems, execution-mode selection, dispatch, and result
+acceptance through one serial decision queue. Task and Reviewer agents may execute in
+parallel. Reviewer output never mutates code; for a managed implementation task, the
+owning Task thread performs accepted repairs under the same WorkItem. Separately
+dispatched non-implementation review remains an execution-scoped Reviewer run.
+
+For a managed independent implementation task, the Task thread owns its inner quality
+loop: implement, spawn an independent read-only reviewer subagent, evaluate every
+finding, repair valid findings, revalidate, and hand the result back to the Lead/Manager.
+The Lead/Manager owns dispatch, final acceptance, and merge. Quick Tasks are exempt. A
+missing or failed reviewer cannot produce a successful reviewed run; the ManagedRun
+remains `waiting` and the WorkItem may become `blocked`, with a typed
+`reviewer_unavailable` or `reviewer_failed` wait reason.
+
+A Quick Task is an ordinary multi-turn Codex conversation with no WorkItem, ManagedRun,
+reviewer, PR, harness, or Goal. A ManagedRun separates:
+
+- lifecycle: `queued`, `active`, `waiting`, `terminal`;
+- phase: `prepare`, `execute`, `validate`, `review`, `repair`, `land`, `close`;
+- wait reason: `usage`, `auth`, `plugin`, `dependency`, `approval`, `user`, `external`,
+  `reviewer_unavailable`, `reviewer_failed`.
+
+Project/Program policy is versioned authority over allowed repositories, tools, paths, merge
+behavior, parallelism, budgets, approvals, and quiet periods. Commands use expected
+revisions and idempotency keys. Side effects require receipts and authoritative readback;
+an outcome that may already have caused side effects is reconciled, never blindly
+replayed.
+
+## Runtime and state authority
+
+| State/surface | Authority |
+| --- | --- |
+| Projects, agents, policies, Programs, Objectives, WorkItems, ManagedRuns, Automations, profiles, context, messages, mappings, and UI-visible conversation/activity projections | PostgreSQL domain tables with optimistic revisions, leases, append-only activity projection, and transactional outbox |
+| Codex thread continuation and Codex UI visibility | persistent Codex rollout under the shared normal `~/.codex` |
+| Repository files and worktrees | Git/filesystem on the `decodexd` host |
+| PR/check/merge readback | GitHub |
+| Large tool output and evidence bytes | content-addressed local blob store, with PostgreSQL metadata |
+| GPUI local state | bounded disposable cache only; SQLite is permitted only here |
+| Credentials | host credential-vault boundary; PostgreSQL stores account metadata/health, never ordinary credential rows |
+| v0.2 state | cold backup/tag and historical evidence only; vNext never reads it as runtime input |
+
+PostgreSQL is not event sourced and no graph database is used. Stable IDs plus correlated
+activity derive graph/timeline projections. `decodexd` is the sole product scheduler,
+app-server child owner, mutation coordinator, and repository-side-effect owner. GPUI,
+SwiftUI menubar, CLI, and MCP are clients/adapters over common application services; they
+never read PostgreSQL, rollout files, blobs, or repositories directly. V1 is single-host
+and has no worker registry or distributed mesh. Remote UI may be added only through the
+protocol security gate.
+
+## Conversation, context, and communication
+
+Every meaningful Decodex-created thread uses `ephemeral=false`, the shared normal
+`~/.codex`, the repository `cwd`, and discoverable title/provenance. Advisor and Lead
+threads are never auto-archived. Task/Reviewer threads remain searchable and are archived
+only by explicit retention policy; probes may be ephemeral. Decodex never imports
+Codex-created threads and persists mappings only for Decodex-created threads.
+
+A logical Conversation may span RuntimeSessions when size, resume latency, compatibility,
+or account failure requires it. Each mapping records conversation, session, Codex thread,
+account, profile snapshot, and last known turn. Decodex persists normalized visible
+messages/items for UI and remote access and offloads large payloads to blobs.
+`thread/read(includeTurns=true)` is a lossy reconciliation source. External Codex activity
+may be provenance-imported for ordinary Quick/Advisor/Lead conversations; on an active
+ManagedRun it marks the session `diverged` and blocks side effects until tool/repository
+readback reconciles them.
+
+Long-term context consists of immutable Project, Advisor, and Program revisions. Project
+context records decisions, constraints, repository facts, active Programs/Objectives,
+unresolved risks, and accepted handoffs. Advisor briefs compact cross-project status and
+risk. Program context records metrics/signals, recent decisions, quiet periods, and next
+review. A Context Pack contains the current revision, recent raw window, relevant
+artifacts, and repository instructions/OpenWiki. Summaries never silently replace
+sources; users can inspect pinned memory and provenance. V1 uses structured PostgreSQL
+queries and full-text search, not vectors.
+
+AgentMessage carries logical endpoints, project, correlation and causal parent, dedupe
+key, artifact refs, requested response, hop count, and response budget. Deterministic
+dedupe, budgets, quiet periods, and causal chains prevent loops. Automation results cannot
+recursively wake themselves without a new material signal.
+Agents communicate directly only when capability and Project policy permit. Stable
+cross-run communication is delivered by Decodex as turns to recipient Conversations.
+
+## Account continuity and profiles
+
+Each app-server process is bound to one account. Shared `~/.codex` supplies configuration
+and plugins; per-process credentials are never switched under a live runner. Account
+state is `available`, `depleted`, `unknown`, `auth_failed`, `plugin_unready`, or
+`disabled`. Each quota window stores its class/duration, remaining amount, reset time,
+observation time, and confidence; 5-hour and 7-day windows are never inferred from
+positional primary/secondary ordering.
+
+Routing honors an available sticky Advisor/Lead account, otherwise chooses an available
+compatible account by user policy and quota facts. Every known depleted window excludes
+an account until reset; unknown is distinct and receives bounded probe/backoff. When all
+accounts are depleted, persist `waiting_usage` and the earliest ready time. Persist the
+specific account/window exclusion before rate-limit failover.
+
+Cross-account resume of the same Codex thread is allowed only after the two-account E2E
+gate. Otherwise start a new RuntimeSession from a Context Pack while preserving the
+Conversation and ManagedRun. Never replay a possibly side-effecting turn without receipt,
+worktree/Git, and artifact reconciliation.
+
+Users exclusively select the four global RoleProfiles. Runtime cannot alter model,
+reasoning, or service tier. Each RuntimeSession snapshots its profile. Decodex keeps a
+desired plugin manifest and audits account inventories; V1 reports readiness differences
+and guides supported login/install/OAuth work rather than claiming file replacement can
+install cloud-bound plugins.
+
+## Automation and protocol
+
+An Automation deterministically turns a schedule, webhook, metric, or repository event
+into a deduplicated/materiality- and budget-checked delivery to a Program, WorkItem,
+Advisor, or Lead inbox. Lead decision may create a WorkItem/ManagedRun. PubFi, Radar, and
+Publisher workflows become Programs plus triggers only when explicitly adopted.
+
+One authenticated, versioned WebSocket multiplexes `control/ack/result`,
+`conversation/stream`, `project/work`, `run/activity`, `agent/message`,
+`automation/firing`, `accounts/health`, and `system/health`. Commands carry client command
+ID, idempotency key, and optional expected revision. Events carry protocol major/minor,
+server ID, resumable monotonic sequence, entity ID/revision, correlation/causation, and
+payload type. Reconnect is snapshot plus cursor-resumed deltas with backpressure. Major
+versions match exactly; server supports current and previous minor for UI/server rollout.
+Large artifacts use authenticated HTTP, never WebSocket snapshots. Non-loopback binding
+remains disabled until authentication, TLS, authorization, and redaction gates pass.
+
+GPUI is the primary workspace and exposes the Advisor inbox; Projects with persistent
+Lead Conversations; Quick Tasks; Program/Objective/WorkItem board; Run, review, repair,
+and landing state; agent/thread/automation graph and causal timeline; accounts, plugin
+readiness, global RoleProfiles, and system health. Users can always talk to Advisor or a
+Project Lead, start Quick Tasks, intervene in WorkItems/ManagedRuns, and inspect all
+agent/message/automation relationships. SwiftUI is a thin accounts/run-health menubar
+client over the restricted protocol. GPUI caches are bounded, disposable,
+cursor-paginated, and keyed by server/schema/content hash; project opening never eagerly
+loads all history.
+
+## Migration and delivery
+
+Cutover has no availability requirement. Stop v0.2, tag the trusted `main`, and preserve
+cold copies of old SQLite/config/automation inventory plus incident scenarios. Start
+vNext with empty PostgreSQL product state. Do not import old Codex sessions, SQLite
+execution state, Linear lanes, or Codex-created tasks. Recreate Projects and Automations
+explicitly from reviewed inventory.
+
+Freeze/close PR #1092 and do not cherry-pick its implementation wholesale. Every task
+uses a focused worktree branch and PR directly into `main`; there is no long-lived vNext
+branch. Product-incomplete `main` is acceptable during replacement only when each merge
+compiles, tests, and states current capability. Remove Linear, SQLite product authority,
+Goal, and old operator transport after replacement behavior and gates exist; do not add
+dual writes, dual reads, or compatibility facades. Radar, Publisher, and the static site
+may remain outside the runtime until explicitly adopted.
+
+## V1 non-goals
+
+- Pi as a second runtime; per-run/per-agent `CODEX_HOME`; Codex Project sync.
+- Linear import, projection, identity, lane authority, or compatibility.
+- SQLite product authority, dual writes, historical Codex/SQLite execution migration.
+- Domain Agents, automatic multi-Lead, arbitrary durable roles, or Goal as general
+  planning/review/development state.
+- Graph/vector databases, event sourcing, CRDT/DeltaDB worktrees, distributed workers.
+- Unauthenticated remote control or runtime-selected model/reasoning/service tier.
+
+## Decision-changing evidence
+
+Only the falsifiers in the owning decision may revise this contract. A failing gate
+freezes the affected milestone and records the contradiction; it does not authorize a
+silent legacy fallback.

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -1,0 +1,70 @@
+# Decodex vNext Gate Manifest
+
+Status: normative sequencing and acceptance boundary.
+
+Owner: [vNext authority decision](../decisions/vnext-authority.md). Contract:
+[vNext authority contract](vnext-authority.md).
+
+## Sequencing rules
+
+XY-1260 establishes authority only. It does not implement PostgreSQL, app-server/Codex
+adapters, GPUI, protocol, runtime services, or migration. No later milestone may begin by
+reinterpreting a superseded Lane Authority v2 C1-C7 checkpoint. Each gate must record the
+exact source revision, command/test evidence, contradictions, and accepted outcome before
+its dependent implementation uses the result.
+
+## Downstream ownership
+
+| Range | Accepted downstream ownership |
+| --- | --- |
+| [XY-1261](https://linear.app/hack-ink/issue/XY-1261)-[XY-1264](https://linear.app/hack-ink/issue/XY-1264) | Freeze v0.2; prove Codex ownership/continuation, pinned GPUI, and PostgreSQL/blob/cache operation. These are the M0 prerequisites. |
+| [XY-1265](https://linear.app/hack-ink/issue/XY-1265)-[XY-1269](https://linear.app/hack-ink/issue/XY-1269) | Workspace ownership boundaries, `decodexd` protocol, PostgreSQL persistence, `~/.decodex`/API-only CLI, and GPUI shell/cache. |
+| [XY-1270](https://linear.app/hack-ink/issue/XY-1270)-[XY-1276](https://linear.app/hack-ink/issue/XY-1276) | Typed app-server adapter; Conversations/RuntimeSessions/history; shared-home reconciliation; account vault/runner pool; typed quota failover; user profiles/plugin readiness; Quick Task slice. |
+| [XY-1277](https://linear.app/hack-ink/issue/XY-1277)-[XY-1286](https://linear.app/hack-ink/issue/XY-1286) | Projects/Advisor/Lead, context, messages/collaboration, decision queues, Programs/Objectives, WorkItems, ManagedRuns, repository services, Task-owned independent review/repair/landing, and Project/Program authority policy. |
+| [XY-1287](https://linear.app/hack-ink/issue/XY-1287)-[XY-1290](https://linear.app/hack-ink/issue/XY-1290) | Automation definitions/firings, materiality/loop safety, removal of manager agents, and PubFi/SEO/GEO/Radar/Publisher dogfood. |
+| [XY-1291](https://linear.app/hack-ink/issue/XY-1291)-[XY-1297](https://linear.app/hack-ink/issue/XY-1297) | GPUI conversations, project/run workspace, graph/timeline, operational surfaces, multi-GB pagination/cache/search, thin menubar, and accessibility/interaction gates. |
+| [XY-1298](https://linear.app/hack-ink/issue/XY-1298)-[XY-1303](https://linear.app/hack-ink/issue/XY-1303) | Observability/retention, authenticated remote security/backups, E2E and fault injection, performance budgets, empty-state legacy cutover/removal, and package/dogfood/release reconciliation. |
+
+Each issue is accepted only for its own stated scope and blocked-by relations. The ranges
+are navigation, not permission to collapse tasks or skip gates. Linear relations are
+planning metadata, not product/runtime identity.
+
+## Required architecture and implementation gates
+
+1. GPUI exact-revision build/package/test/accessibility spike (XY-1263).
+2. Shared-home persistent thread visibility in Codex (XY-1262).
+3. Ownership isolation between Codex-created and Decodex-created threads (XY-1262).
+4. Real two-account continuation after quota failure, including crash points (XY-1262).
+5. Typed 5h/7d quota matrix with unknown, stale, and reversed windows (XY-1262).
+6. App-server capability/schema negotiation, thread read/list, and native collaboration
+   behavior (XY-1262).
+7. Empty PostgreSQL bootstrap, backup/rollback, and concurrent lease/outbox tests
+   (XY-1264).
+8. WebSocket reconnect, cursor resume, command idempotency, and current/previous-minor
+   compatibility tests (XY-1266 and regression owner XY-1300).
+9. Large-history pagination/cache test proving multi-GB history is never eagerly loaded
+   (XY-1263, implementation XY-1295, and regression owner XY-1300).
+10. ManagedRun restart and side-effect reconciliation fault injection, including the
+    Task-owned independent review loop and typed reviewer wait/failure states (XY-1283,
+    XY-1285, and regression owner XY-1300).
+11. Real Program/Automation/Lead/Task/Reviewer dogfood, using PubFi or equivalent
+    (XY-1290 and release dogfood owner XY-1303).
+12. Remote binding stays disabled until authentication, TLS, authorization, and
+    redaction gates pass (XY-1299).
+
+## Cutover gate
+
+Cutover may occur only after replacement behavior has accepted tests and the v0.2
+inventory is frozen. The accepted procedure stops v0.2, verifies the trusted tag/cold
+backup, initializes empty PostgreSQL state, explicitly recreates selected Projects and
+Automations, and starts only vNext. It imports no legacy execution history and enables no
+dual authority. Removal of old Linear/SQLite/Goal/operator transport follows replacement
+proof, not speculative deletion.
+
+## Stop conditions
+
+Stop the owning gate on any contradiction with the authority contract, any unproven
+authority boundary, credentials entering ordinary PostgreSQL rows, a second mutation
+path around `decodexd`, possible side-effect replay without reconciliation, unbounded UI
+history loading, or attempted remote binding before security acceptance. Decision-level
+falsifiers are listed in the owning decision and require explicit architecture revision.


### PR DESCRIPTION
## Summary
- establish the repository-owned Decodex vNext authority decision, contract, and gate manifest
- freeze Lane Authority v2 and scope conflicting runtime documents to v0.2
- define the managed Task-owned reviewer subagent loop and map XY-1261 through XY-1303

## Validation
- independent implementation review found four gaps; all were repaired
- final independent reviewer pass: no residual findings
- all relative Markdown links resolve
- `git diff --check main..cee1635cf7fc659153693effef9bf4693d77495e`
- documentation-only scope verified

Linear: https://linear.app/hack-ink/issue/XY-1260/promote-the-vnext-authority-contract-and-supersede-lane-authority-v2