### PR TITLE
XY-1262 Record failed Codex runtime gate evidence

### DIFF
--- a/openwiki/evidence/fixtures/xy-1262-live-receipt.json
+++ b/openwiki/evidence/fixtures/xy-1262-live-receipt.json
@@ -1,0 +1,103 @@
+{
+  "schema": "decodex/vnext-codex-evidence-bundle/1",
+  "overall_acceptance": false,
+  "sources": [
+    "python3 scripts/vnext/codex_app_server_probe.py schema",
+    "python3 scripts/vnext/codex_app_server_probe.py live --account-a <selector-a> --account-b <selector-b>",
+    "codex_app.send_message_to_thread(primary_thread_id, fixed no-tool marker)",
+    "codex_app.read_thread(primary_thread_id)",
+    "codex_app.list_threads(title_query)",
+    "focused app-server thread/list plus archive/unarchive readback"
+  ],
+  "observed_at_unix": 1783917977,
+  "repository_head": "f9d6c4e70198e94e5b9461b8cac7518ae14d41ef",
+  "codex_cli": "codex-cli 0.144.0-alpha.4",
+  "shared_home": "~/.codex",
+  "per_run_codex_home": false,
+  "account_aliases": ["A", "B"],
+  "credentials_emitted": false,
+  "auth_state_unchanged": true,
+  "initialize": {
+    "codexHome": "~/.codex",
+    "platformFamily": "unix",
+    "platformOs": "macos"
+  },
+  "capability_negotiation": [
+    {
+      "capability": "paginated_threads",
+      "schema_result": "advertised",
+      "live_result": "rejected",
+      "error_code": -32601,
+      "fallback": "legacy"
+    }
+  ],
+  "account_windows": {
+    "A": [
+      { "limit_id": "codex", "source_field": "primary", "duration_minutes": 10080, "used_percent": 0, "resets_at": 1784522304 },
+      { "limit_id": "codex_bengalfox", "source_field": "primary", "duration_minutes": 10080, "used_percent": 0, "resets_at": 1784522796 }
+    ],
+    "B": [
+      { "limit_id": "codex", "source_field": "primary", "duration_minutes": 10080, "used_percent": 0, "resets_at": 1784522381 },
+      { "limit_id": "codex_bengalfox", "source_field": "primary", "duration_minutes": 10080, "used_percent": 0, "resets_at": 1784522810 }
+    ]
+  },
+  "experiments": {
+    "runner_a_killed_after_completed_turn": true,
+    "restart_list_title_match": true,
+    "restart_thread_search_match": false,
+    "codex_desktop_read_exact_id": true,
+    "codex_desktop_global_title_query_match": false,
+    "cross_account_same_thread_resume_without_forced_quota": true,
+    "cross_account_second_turn_completed_without_forced_quota": true,
+    "real_quota_failure_failover": false,
+    "auth_failed_before_resume_or_turn": true,
+    "context_pack_new_runtime_session_after_auth_rejection": true,
+    "context_pack_after_resume_denial": false,
+    "external_codex_activity_visible_to_thread_read": true,
+    "managed_run_divergence_transition_executed": false,
+    "native_collaboration_receipt": "xy-1262-native-collaboration.json",
+    "explicit_archive_round_trip": true,
+    "ownership_isolation": {
+      "listed_thread_count_for_cwd": 9,
+      "decodex_created_ids": 2,
+      "ignored_non_decodex_count": 7,
+      "mapping_source": "thread IDs returned by Decodex probe thread/start only"
+    },
+    "primary_thread": {
+      "id": "019f59cc-2ec1-76a1-8eaf-68e572fa204c",
+      "cwd": "/Users/x/.codex/worktrees/e9b9/decodex",
+      "ephemeral": false,
+      "history_mode": "legacy",
+      "name": "Decodex XY-1262 shared-home proof 1783917977",
+      "turn_count_before_resume": 1,
+      "turn_count_after_account_b": 2,
+      "turn_count_after_external_codex_activity": 3,
+      "turn_item_types": ["agentMessage", "userMessage"],
+      "thread_source_before_resume": "decodex.xy1262.probe",
+      "thread_source_after_resume": null
+    },
+    "fallback_thread": {
+      "id": "019f59cc-ca2e-74a3-b69c-e18fdaf026f0",
+      "cwd": "/Users/x/.codex/worktrees/e9b9/decodex",
+      "ephemeral": false,
+      "history_mode": "legacy",
+      "name": "Decodex XY-1262 shared-home proof 1783917977 context-pack fallback",
+      "new_runtime_session": true,
+      "turn_count": 1,
+      "side_effect_reconciliation": "none declared; repository HEAD pinned"
+    }
+  },
+  "schema_receipt": {
+    "digest_encoding": "canonical JSON with recursively sorted object keys",
+    "ClientRequest.json": "3f82e5aec5be786c40d21440dfb6d0667d194d872bfa7041bd81c39b4ba56dc3",
+    "ServerNotification.json": "16ce6adadf33aa182f98840c5d33f6294c3c37b2866bb05545c24e0dbf2cc2d2",
+    "codex_app_server_protocol.v2.schemas.json": "f5e8d20f3a8f9bb5e5b23ab0c5aa6bde7b12e7e0713606c5d0132651a4959d37"
+  },
+  "negative_evidence": [
+    "Two additional stored accounts were rejected by process-scoped account/login/start with invalid ID token format.",
+    "Two authenticated alternate-account attempts resumed local history but did not produce a turn terminal event within the probe timeout.",
+    "A later rerun timed out, so same-thread continuation remains capability/build/account-class gated rather than universal.",
+    "No account was depleted, so quota exclusion persistence and quota-triggered failover were not exercised.",
+    "Context-Pack fallback followed authentication rejection, not a same-thread resume denial."
+  ]
+}

--- a/openwiki/evidence/fixtures/xy-1262-native-collaboration.json
+++ b/openwiki/evidence/fixtures/xy-1262-native-collaboration.json
@@ -1,0 +1,30 @@
+{
+  "schema": "decodex/vnext-native-collaboration-receipt/1",
+  "observed_at_unix": 1783918655,
+  "parent_thread_id": "019f59bf-6d96-7512-aebd-6fd36ce5fc58",
+  "child_thread_id": "019f59d3-4222-7e11-9ea2-6b72ca0064e9",
+  "reviewer_identity": "/root/xy1262_reviewer",
+  "readbacks": {
+    "thread_list_ancestor": {
+      "child_returned": true,
+      "parent_thread_id_matches": true,
+      "agent_role": null
+    },
+    "codex_desktop_read_child": {
+      "turn_status": "completed",
+      "item_types": ["agentMessage", "reasoning", "subAgentActivity"],
+      "subagent_activity": {
+        "kind": "interacted",
+        "agent_thread_id": "019f59bf-6d96-7512-aebd-6fd36ce5fc58",
+        "agent_path": "/root"
+      }
+    }
+  },
+  "normalization": {
+    "runtime_actor_id": "child_thread_id",
+    "parent_runtime_actor_id": "parent_thread_id",
+    "activity_kind": "subAgentActivity.kind",
+    "logical_agent_role": "not inferred when agentRole is null",
+    "durability": "run-local runtime actor; Decodex owns cross-run routing"
+  }
+}

--- a/openwiki/evidence/fixtures/xy-1262-quota-matrix.json
+++ b/openwiki/evidence/fixtures/xy-1262-quota-matrix.json
@@ -1,0 +1,132 @@
+{
+  "schema": "decodex/vnext-quota-matrix/1",
+  "window_identity": {
+    "five_hour": { "duration_minutes": 300 },
+    "seven_day": { "duration_minutes": 10080 }
+  },
+  "rules": {
+    "positional_fields_are_identity": false,
+    "account_ready_at": "maximum reset_at among that account's fresh depleted windows",
+    "all_accounts_ready_at": "minimum account_ready_at among accounts excluded only by usage",
+    "elapsed_reset_transition": "unknown until a fresh observation proves availability",
+    "stale_transition": "unknown and bounded probe; never depleted or available by inference"
+  },
+  "cases": [
+    {
+      "id": "available_both_windows",
+      "input": {
+        "auth": "valid",
+        "observed_at": 1000,
+        "now": 1001,
+        "windows": [
+          { "source_field": "primary", "duration_minutes": 300, "remaining_percent": 80, "reset_at": 2000 },
+          { "source_field": "secondary", "duration_minutes": 10080, "remaining_percent": 40, "reset_at": 9000 }
+        ]
+      },
+      "expect": { "state": "available", "decision": "usable", "ready_at": 1001 }
+    },
+    {
+      "id": "depleted_five_hour",
+      "input": {
+        "auth": "valid",
+        "observed_at": 1000,
+        "now": 1001,
+        "windows": [
+          { "source_field": "primary", "duration_minutes": 300, "remaining_percent": 0, "reset_at": 2000 },
+          { "source_field": "secondary", "duration_minutes": 10080, "remaining_percent": 40, "reset_at": 9000 }
+        ]
+      },
+      "expect": { "state": "depleted", "decision": "excluded_usage", "ready_at": 2000 }
+    },
+    {
+      "id": "depleted_seven_day",
+      "input": {
+        "auth": "valid",
+        "observed_at": 1000,
+        "now": 1001,
+        "windows": [
+          { "source_field": "primary", "duration_minutes": 300, "remaining_percent": 80, "reset_at": 2000 },
+          { "source_field": "secondary", "duration_minutes": 10080, "remaining_percent": 0, "reset_at": 9000 }
+        ]
+      },
+      "expect": { "state": "depleted", "decision": "excluded_usage", "ready_at": 9000 }
+    },
+    {
+      "id": "unknown_missing_five_hour",
+      "input": {
+        "auth": "valid",
+        "observed_at": 1000,
+        "now": 1001,
+        "windows": [
+          { "source_field": "primary", "duration_minutes": 10080, "remaining_percent": 40, "reset_at": 9000 }
+        ]
+      },
+      "expect": { "state": "unknown", "decision": "probe_required", "ready_at": null }
+    },
+    {
+      "id": "stale_observation",
+      "input": {
+        "auth": "valid",
+        "observed_at": 1000,
+        "stale_after_seconds": 300,
+        "now": 1401,
+        "windows": [
+          { "source_field": "primary", "duration_minutes": 300, "remaining_percent": 80, "reset_at": 2000 },
+          { "source_field": "secondary", "duration_minutes": 10080, "remaining_percent": 40, "reset_at": 9000 }
+        ]
+      },
+      "expect": { "state": "unknown", "decision": "probe_required", "ready_at": null }
+    },
+    {
+      "id": "reversed_positional_fields",
+      "input": {
+        "auth": "valid",
+        "observed_at": 1000,
+        "now": 1001,
+        "windows": [
+          { "source_field": "primary", "duration_minutes": 10080, "remaining_percent": 0, "reset_at": 9000 },
+          { "source_field": "secondary", "duration_minutes": 300, "remaining_percent": 80, "reset_at": 2000 }
+        ]
+      },
+      "expect": {
+        "state": "depleted",
+        "decision": "excluded_usage",
+        "ready_at": 9000,
+        "classified": { "five_hour_source": "secondary", "seven_day_source": "primary" }
+      }
+    },
+    {
+      "id": "depletion_reset_elapsed",
+      "input": {
+        "auth": "valid",
+        "observed_at": 1000,
+        "now": 2001,
+        "windows": [
+          { "source_field": "primary", "duration_minutes": 300, "remaining_percent": 0, "reset_at": 2000 },
+          { "source_field": "secondary", "duration_minutes": 10080, "remaining_percent": 40, "reset_at": 9000 }
+        ]
+      },
+      "expect": { "state": "unknown", "decision": "probe_required", "ready_at": null }
+    },
+    {
+      "id": "auth_failed",
+      "input": { "auth": "failed", "observed_at": 1000, "now": 1001, "windows": [] },
+      "expect": { "state": "auth_failed", "decision": "excluded_auth", "ready_at": null }
+    },
+    {
+      "id": "all_accounts_depleted",
+      "input": {
+        "accounts": [
+          { "id": "A", "depleted_resets_at": [2000, 9000] },
+          { "id": "B", "depleted_resets_at": [3000] }
+        ]
+      },
+      "expect": {
+        "state": "depleted",
+        "decision": "waiting_usage",
+        "account_ready_at": { "A": 9000, "B": 3000 },
+        "earliest_ready_at": 3000
+      }
+    }
+  ]
+}

--- a/openwiki/evidence/vnext-codex-runtime-proof.md
+++ b/openwiki/evidence/vnext-codex-runtime-proof.md
@@ -1,0 +1,114 @@
+# XY-1262 Codex runtime proof
+
+Status: gate evidence at repository revision `f9d6c4e70198e94e5b9461b8cac7518ae14d41ef`.
+
+Observed: 2026-07-13 using `codex-cli 0.144.0-alpha.4` and the normal shared
+`~/.codex`. This is a proof spike, not the vNext adapter.
+
+## Reproduce
+
+The probe reads two explicitly selected records from the existing Decodex account pool,
+passes their tokens only through process-scoped `account/login/start`, redacts account
+identity as A/B, and verifies that `~/.codex/auth.json` has the same SHA-256 before and
+after. It does not select, import, remove, or overwrite accounts or plugins.
+
+```sh
+python3 scripts/vnext/codex_app_server_probe.py schema
+python3 scripts/vnext/codex_app_server_probe.py live \
+  --account-a <selector-a> --account-b <selector-b>
+python3 scripts/vnext/codex_app_server_probe.py validate
+python3 -m unittest tests/scripts/test_codex_app_server_probe.py
+```
+
+The checked-in redacted live receipt is
+[`fixtures/xy-1262-live-receipt.json`](fixtures/xy-1262-live-receipt.json). The typed
+quota cases are
+[`fixtures/xy-1262-quota-matrix.json`](fixtures/xy-1262-quota-matrix.json).
+The native reviewer event is
+[`fixtures/xy-1262-native-collaboration.json`](fixtures/xy-1262-native-collaboration.json).
+The live fixture is an evidence bundle, not raw probe stdout: its `sources` array records
+the probe, Codex Desktop, and focused archive/ownership readbacks that were normalized
+into it. `validate` rejects credential-shaped fields and checks the bundle invariants.
+
+## Results and falsifiers
+
+| Gate | Verdict | Direct evidence | Falsifier / downstream rule |
+| --- | --- | --- | --- |
+| Shared-home persistence | Pass | A non-ephemeral, named thread was created at the repository cwd, received a completed turn, survived a killed runner, and was returned by `thread/list(searchTerm=...)` and `thread/read(includeTurns=true)` from a new process. Codex Desktop `read_thread` returned both turns by exact ID. | Fail if a normal app restart loses the rollout or the app cannot read the exact ID. |
+| Search/UI discovery | Partial fail | App-server filtered list found the title after restart and Codex Desktop could read the thread, but `thread/search` and Codex Desktop global query did not return it in this run. | XY-1270/1272 must not equate app-server listability with sidebar/global-search discovery. Keep this M0 sub-gate failed until a desktop restart/indexing experiment returns the thread by title. |
+| Ownership isolation | Partial pass | The only mapped IDs are IDs returned to the probe's own `thread/start`; the same cwd listing contained other threads, all counted and ignored without reading their turns. A production mapping transaction does not yet exist. | Never discover ownership from cwd, source, title, list membership, or rollout scanning. Persist the creation receipt transactionally before exposing the Conversation. |
+| External activity/divergence | Partial pass | A later turn was sent through Codex Desktop rather than the probe runner and became observable by `thread/read`, proving the last-known-turn mismatch input. `threadSource` also disappeared after resume while visible messages remained. No production ManagedRun exists to execute the `diverged` transition. | Ordinary Conversation reconciliation may provenance-import visible messages. Any unseen turn on an active ManagedRun sets `RuntimeSession=diverged` and blocks side effects until receipts, Git/worktree state, and artifacts reconcile. Never infer tool completion from `thread/read`. |
+| Schema/capability negotiation | Pass with contradiction | Canonical-JSON schema digests expose start/list/search/read/resume, quota, and collaboration shapes. Raw aggregate schema bytes are nondeterministic across generations, so the probe canonicalizes JSON before hashing. A live `historyMode=paginated` start returned JSON-RPC `-32601` (`paginated_threads` unsupported); retry with `legacy` succeeded. | Generated schema is not a runtime capability promise. XY-1270 must negotiate initialize/schema plus live method outcome and cache the observed capability by CLI build. |
+| Real cross-account continuation | Partial pass; quota-failover gate failed | Account A created and completed a turn; its process was killed; a different stored/authenticated Account B resumed the exact thread ID and completed a second turn. Both accounts had fresh 7-day windows at 0% used, so this did not exercise quota exclusion or depletion. | Same-thread cross-account resume is proven only for this healthy account/build pair. XY-1273 remains blocked on a real quota-failure exclusion/failover run. |
+| Context-Pack/new-session fallback | Partial pass; denied-resume gate failed | A process-scoped invalid credential was rejected before resume/turn. A new persistent RuntimeSession on healthy Account A received a Context Pack naming the prior session, durable marker, repository HEAD, and `possible_side_effects=none`, then completed. No same-thread resume rejection/incompatibility occurred. | The mechanism is viable, but XY-1271/1273 still require a real resume-denied/incompatible path. The fallback must preserve logical IDs and never replay a possibly side-effecting turn. |
+| Explicit archive | Pass | The probe archived only its fallback thread, observed it through `thread/list(archived=true)`, and unarchived it. The primary meaningful proof thread remained unarchived. | vNext must remove current terminal auto-archive behavior; retention is an explicit policy command with readback. |
+| Native collaboration | Pass for observed run-local shape | The mandatory reviewer produced a child thread returned by `thread/list(ancestorThreadId=...)` with `parentThreadId`; Codex Desktop readback showed a completed child turn containing `subAgentActivity { kind=interacted, agentThreadId=<parent>, agentPath=/root }`. Schema additionally exposes `collabAgentToolCall`, nickname, and role fields. | Normalize observed parent/child, activity, correlation, and terminal fields without treating optional nickname/role as identity. Native spawn remains run-local, never the durable cross-account/top-level router. |
+
+## Crash and recovery matrix
+
+| Crash/failure point | Durable fact required before crash | Recovery result | Duplicate/side-effect rule |
+| --- | --- | --- | --- |
+| Pre-submit selection, before exclusion commit | No turn ID or submission receipt | Repeat selection/probe; no account is yet excluded. | This row applies only before turn submission. |
+| Rate limit observed after turn submission, before exclusion commit | Turn ID, error/limit observation, and side-effect state `unknown` | Reconcile the old turn, receipts, Git/worktree, and artifacts; then persist the specific account/window exclusion before selecting a fallback. | Never infer that no side effect occurred and never replay blindly. |
+| After exclusion, before runner start | Account/window exclusion with observation and reset | Select another eligible account or persist `waiting_usage`. | No turn was submitted. |
+| Runner dies after `thread/start` response | Conversation/RuntimeSession/thread mapping and creation receipt | `thread/list`/`thread/read`; adopt the one mapped thread. | Never start a replacement until readback proves mapping state. |
+| Runner dies after `turn/start` but before terminal event | Turn ID plus submitted idempotency key; side-effect state unknown | Resume/read, then reconcile tool receipts, Git/worktree, and artifacts. | Never replay the turn blindly. |
+| Account B login rejected | Typed `auth_failed` exclusion before fallback | Choose another available account; otherwise typed auth wait. | No resume or turn on the rejected account. |
+| Same-thread resume rejected/incompatible | Failed RuntimeSession and prior last-known turn | Start one new RuntimeSession from a Context Pack. | Preserve Conversation/ManagedRun; do not forge the old thread mapping. |
+| All accounts have fresh depleted windows | Per-account depleted windows | `waiting_usage`; wake at `min(max(account depleted resets))`. | Unknown/stale/auth-failed accounts are not silently treated as depleted. |
+
+The live process-kill experiment covers runner death and shared-rollout persistence. The
+remaining broker crash rows are executable requirements for XY-1273/1274 rather than a
+claim that a production broker already exists.
+
+## Quota contract
+
+Window class is determined only by `windowDurationMins`: 300 is five-hour and 10080 is
+seven-day. `primary`/`secondary` are retained solely as source provenance. Missing or
+stale windows and elapsed resets transition to `unknown` and require a bounded fresh
+probe. A fresh zero remainder excludes an account until that account's latest depleted
+window reset. If every account is excluded only by usage, the ManagedRun waits until the
+earliest per-account ready time. Authentication failure is a separate exclusion and has
+no quota reset time.
+
+The live accounts exposed 7-day windows only. Therefore the live 5-hour observation is
+`unknown`; no 5-hour state is inferred from the positional fields. The typed fixture
+covers available, five-hour depleted, seven-day depleted, unknown, stale, reversed,
+reset elapsed, auth-failed, and all-accounts-depleted behavior.
+
+## Adapter implementation conclusions
+
+1. XY-1270 must pin generated-schema digests and separately record live capability
+   outcomes. It must support legacy history for this build and treat paginated history
+   as unavailable despite its schema enum.
+2. XY-1271/1272 must persist Conversation, RuntimeSession, owned creation receipt,
+   account/profile snapshot, thread ID, and last-known turn. `thread/read` is visible
+   message reconciliation, not a complete tool/side-effect ledger.
+3. XY-1273 must bind one runner process to one account and never overwrite normal
+   `auth.json` for routing. Same-thread cross-account continuation is build/capability
+   gated; fallback creates one new RuntimeSession from an inspectable Context Pack.
+4. XY-1274 must store typed window duration, remaining amount, reset, observation time,
+   and confidence. It must never derive five-hour/seven-day identity from
+   primary/secondary position.
+5. XY-1280 collaboration normalization must preserve parent thread, native actor,
+   tool-call correlation, status transitions, and terminal outcome. Durable routing
+   remains Decodex-owned.
+
+Acceptance verdict: **failed**. Healthy-account same-thread continuation, Context-Pack
+mechanics, ownership-by-creation-receipt, exact-ID readback, native run-local
+collaboration shape, archive behavior, schema negotiation, and the typed quota decision
+table are usable downstream evidence. Global title discovery, real quota-depletion
+failover/exclusion persistence, a resume-denied Context-Pack transition, and an
+executable ManagedRun divergence transition remain unproven falsifiers.
+
+## Independent review
+
+Reviewer `/root/xy1262_reviewer` performed read-only review over the actual diff and
+evidence. The first review rejected quota-failover, denied-resume fallback, external
+divergence, native collaboration, receipt reproducibility, credential safety, and one
+crash rule as overclaimed or incomplete. All valid findings were dispositioned by
+downgrading the unrun gates, adding external/native readbacks, canonical schema hashing,
+an executable input-only quota classifier, redaction validation, auth-integrity failure,
+and separate pre-/post-submit crash rules. After a material re-review and a targeted
+final confirmation, the reviewer reported no remaining blocker and accepted this as a
+focused failed-gate evidence commit, not as a passing XY-1262 gate.

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -11,6 +11,7 @@ OpenWiki is the repo-local project knowledge surface for agents and maintainers.
 - [vNext authority decision](decisions/vnext-authority.md): the accepted product, ownership, state-authority, cutover, and delivery decision for the rebuild.
 - [vNext authority contract](specs/vnext-authority.md): normative entities, runtime boundaries, protocol, account continuity, non-goals, and migration contract for later implementation.
 - [vNext gate manifest](specs/vnext-gates.md): ordered feasibility and implementation gates, downstream issue ownership, and decision-changing falsifiers.
+- [XY-1262 Codex runtime proof](evidence/vnext-codex-runtime-proof.md): shared-home, ownership, schema, collaboration, cross-account, fallback, crash, and typed-quota evidence for the Codex feasibility gate.
 - [Lane Authority v2](decisions/lane-authority-v2.md): superseded historical target retained as architecture and incident provenance; C1-C7 are frozen and must not be implemented.
 - [Drift audits](evidence/drift-audits.md): public-safe evidence notes, current MCP remote-control watched claims, reverse checks, validation commands, and stop conditions.
 - [v0.2 freeze receipt](evidence/v0.2-freeze.md): exact trusted tag, cold-config and automation inventory, frozen legacy work, preserved incident evidence, cleanup ownership, and the unresolved SQLite-backup gap.

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -52,6 +52,29 @@ planning metadata, not product/runtime identity.
 12. Remote binding stays disabled until authentication, TLS, authorization, and
     redaction gates pass (XY-1299).
 
+### XY-1262 evidence status
+
+The [Codex runtime proof](../evidence/vnext-codex-runtime-proof.md) at
+`f9d6c4e70198e94e5b9461b8cac7518ae14d41ef` supplies partial evidence for shared-home
+persistence, creation-receipt ownership isolation, exact-ID Codex Desktop readback,
+healthy-account same-thread continuation, Context-Pack mechanics, explicit archive
+readback, live schema negotiation, native run-local collaboration shape, and the
+duration-typed quota decision table.
+
+The full visibility gate remains failed: the persistent probe thread was returned by
+app-server `thread/list(searchTerm=...)` and was readable by exact ID through Codex
+Desktop, but app-server `thread/search` and Codex Desktop global title query did not
+return it during the experiment. Dependent implementation must not equate rollout/list
+visibility with sidebar/global-search discovery. A desktop restart/indexing proof that
+finds the retained title is required before this sub-gate is accepted.
+
+The generated schema also advertised paginated thread history while live
+`thread/start(historyMode=paginated)` returned JSON-RPC `-32601`; adapter capability is
+therefore a negotiated live result keyed by Codex build, not a schema-only inference.
+The full XY-1262 gate also remains failed because the available accounts were not
+depleted: no real quota-failure exclusion/failover was observed, and the Context-Pack
+fallback followed an authentication rejection rather than a same-thread resume denial.
+
 ## Cutover gate
 
 Cutover may occur only after replacement behavior has accepted tests and the v0.2

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,3 +6,5 @@ This directory contains executable repository helpers.
   assets.
 - `scripts/macos/` owns macOS-only app packaging and local bundle verification
   helpers.
+- `scripts/vnext/` owns gate-scoped vNext feasibility probes; these scripts produce
+  redacted evidence and are not production adapters.

--- a/scripts/vnext/codex_app_server_probe.py
+++ b/scripts/vnext/codex_app_server_probe.py
@@ -1,0 +1,720 @@
+#!/usr/bin/env python3
+"""Run redacted XY-1262 probes against the real Codex app-server.
+
+The probe intentionally uses the normal shared Codex home. Stored account tokens are
+read only long enough to perform process-scoped ``account/login/start`` requests and
+are never written to stdout, stderr, or the receipt. The normal ``auth.json`` is
+hashed before and after each run so credential-state mutation is observable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import select
+import subprocess
+import tempfile
+import time
+from typing import Any
+
+
+PROBE_SCHEMA = "decodex/vnext-codex-proof/1"
+CLIENT_INFO = {"name": "decodex-xy-1262-probe", "version": "1"}
+DEFAULT_TIMEOUT = 90.0
+
+
+class ProtocolError(RuntimeError):
+    pass
+
+
+class AppServer:
+    def __init__(self, codex: str, cwd: Path) -> None:
+        self.process = subprocess.Popen(
+            [codex, "app-server", "--stdio"],
+            cwd=cwd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        self.next_id = 1
+        self.notifications: list[dict[str, Any]] = []
+        self.capability_observations: list[dict[str, Any]] = []
+        self.initialize()
+
+    def send(self, message: dict[str, Any]) -> None:
+        if self.process.stdin is None:
+            raise ProtocolError("app-server stdin is unavailable")
+        self.process.stdin.write(json.dumps(message, separators=(",", ":")) + "\n")
+        self.process.stdin.flush()
+
+    def receive(self, timeout: float = DEFAULT_TIMEOUT) -> dict[str, Any]:
+        if self.process.stdout is None:
+            raise ProtocolError("app-server stdout is unavailable")
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            remaining = max(0.0, deadline - time.monotonic())
+            ready, _, _ = select.select([self.process.stdout], [], [], remaining)
+            if not ready:
+                break
+            line = self.process.stdout.readline()
+            if not line:
+                raise ProtocolError(f"app-server exited with {self.process.poll()}")
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ProtocolError("app-server emitted non-JSON stdout") from error
+        raise ProtocolError("timed out waiting for app-server message")
+
+    def request(
+        self, method: str, params: Any | None = None, timeout: float = DEFAULT_TIMEOUT
+    ) -> Any:
+        request_id = self.next_id
+        self.next_id += 1
+        message: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
+        if params is not None:
+            message["params"] = params
+        self.send(message)
+        while True:
+            incoming = self.receive(timeout)
+            if incoming.get("id") == request_id:
+                if "error" in incoming:
+                    error = incoming["error"]
+                    raise ProtocolError(
+                        f"{method} failed: code={error.get('code')} message={error.get('message')}"
+                    )
+                return incoming.get("result")
+            if "method" in incoming and "id" not in incoming:
+                self.notifications.append(incoming)
+                continue
+            if "method" in incoming and "id" in incoming:
+                self.send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": incoming["id"],
+                        "error": {
+                            "code": -32601,
+                            "message": "XY-1262 probe does not service server requests",
+                        },
+                    }
+                )
+
+    def wait_notification(
+        self, method: str, predicate=lambda _params: True, timeout: float = DEFAULT_TIMEOUT
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            for index, notification in enumerate(self.notifications):
+                if notification.get("method") == method and predicate(
+                    notification.get("params", {})
+                ):
+                    return self.notifications.pop(index)
+            incoming = self.receive(max(0.1, deadline - time.monotonic()))
+            if "method" in incoming and "id" not in incoming:
+                self.notifications.append(incoming)
+            elif "method" in incoming and "id" in incoming:
+                self.send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": incoming["id"],
+                        "error": {
+                            "code": -32601,
+                            "message": "XY-1262 probe does not service server requests",
+                        },
+                    }
+                )
+        raise ProtocolError(f"timed out waiting for notification {method}")
+
+    def initialize(self) -> None:
+        self.initialize_result = self.request(
+            "initialize",
+            {
+                "clientInfo": CLIENT_INFO,
+                "capabilities": {"experimentalApi": True},
+            },
+        )
+        self.send({"jsonrpc": "2.0", "method": "initialized"})
+
+    def login(self, account: dict[str, str]) -> None:
+        self.request(
+            "account/login/start",
+            {
+                "type": "chatgptAuthTokens",
+                "accessToken": account["access_token"],
+                "chatgptAccountId": account["account_id"],
+                "chatgptPlanType": account.get("plan_type"),
+            },
+        )
+
+    def close(self, crash: bool = False) -> None:
+        if self.process.poll() is not None:
+            return
+        if crash:
+            self.process.kill()
+        else:
+            self.process.terminate()
+        try:
+            self.process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            self.process.wait(timeout=10)
+
+
+def sha256_file(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sha256_canonical_json(path: Path) -> str:
+    value = json.loads(path.read_text())
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def read_accounts(path: Path) -> list[dict[str, Any]]:
+    accounts = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if line.strip():
+                accounts.append(json.loads(line))
+    return accounts
+
+
+def account_login(accounts: list[dict[str, Any]], selector: str) -> dict[str, str]:
+    for account in accounts:
+        tokens = account.get("tokens") or {}
+        candidates = {
+            account.get("email"),
+            tokens.get("email"),
+            tokens.get("account_id"),
+        }
+        if selector not in candidates:
+            continue
+        access_token = tokens.get("access_token")
+        account_id = tokens.get("account_id")
+        if not access_token or not account_id:
+            raise ProtocolError("selected account lacks usable tokens")
+        return {
+            "access_token": access_token,
+            "account_id": account_id,
+            "plan_type": tokens.get("plan_type"),
+        }
+    raise ProtocolError("account selector was not found")
+
+
+def thread_id(result: dict[str, Any]) -> str:
+    return result["thread"]["id"]
+
+
+def start_named_thread(server: AppServer, cwd: Path, name: str) -> str:
+    params = {
+        "cwd": str(cwd),
+        "ephemeral": False,
+        "historyMode": "paginated",
+        "developerInstructions": (
+            "This is a read-only Decodex XY-1262 protocol probe. Do not call tools, "
+            "change files, or create side effects. Reply only with the requested marker."
+        ),
+        "threadSource": "decodex.xy1262.probe",
+    }
+    try:
+        result = server.request("thread/start", params)
+        server.capability_observations.append(
+            {"capability": "paginated_threads", "result": "supported"}
+        )
+    except ProtocolError as error:
+        if "paginated_threads is not supported yet" not in str(error):
+            raise
+        server.capability_observations.append(
+            {
+                "capability": "paginated_threads",
+                "result": "schema_advertised_live_rejected",
+                "error_code": -32601,
+            }
+        )
+        params["historyMode"] = "legacy"
+        result = server.request("thread/start", params)
+    identifier = thread_id(result)
+    server.request("thread/name/set", {"threadId": identifier, "name": name})
+    return identifier
+
+
+def run_turn(server: AppServer, identifier: str, prompt: str) -> dict[str, Any]:
+    response = server.request(
+        "turn/start",
+        {
+            "threadId": identifier,
+            "input": [{"type": "text", "text": prompt}],
+        },
+    )
+    turn_identifier = response["turn"]["id"]
+    deadline = time.monotonic() + 45.0
+    while time.monotonic() < deadline:
+        for index, notification in enumerate(server.notifications):
+            method = notification.get("method")
+            params = notification.get("params", {})
+            if params.get("threadId") != identifier:
+                continue
+            if method == "turn/completed" and params.get("turn", {}).get("id") == turn_identifier:
+                server.notifications.pop(index)
+                return params["turn"]
+            if method == "error" and params.get("turnId") in (None, turn_identifier):
+                server.notifications.pop(index)
+                error = params.get("error", {})
+                info = error.get("codexErrorInfo")
+                if isinstance(info, dict):
+                    info = info.get("type")
+                raise ProtocolError(f"turn failed: codex_error_info={info or 'unknown'}")
+        incoming = server.receive(max(0.1, deadline - time.monotonic()))
+        if "method" in incoming and "id" not in incoming:
+            server.notifications.append(incoming)
+        elif "method" in incoming and "id" in incoming:
+            server.send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": incoming["id"],
+                    "error": {
+                        "code": -32601,
+                        "message": "XY-1262 probe does not service server requests",
+                    },
+                }
+            )
+    raise ProtocolError("timed out waiting for turn terminal event")
+
+
+def rate_limit_windows(server: AppServer) -> list[dict[str, Any]]:
+    result = server.request("account/rateLimits/read")
+    buckets = result.get("rateLimitsByLimitId") or {"legacy": result.get("rateLimits", {})}
+    windows = []
+    for limit_id, bucket in sorted(buckets.items()):
+        for field in ("primary", "secondary"):
+            window = bucket.get(field)
+            if not window:
+                continue
+            windows.append(
+                {
+                    "limit_id": limit_id,
+                    "source_field": field,
+                    "duration_minutes": window.get("windowDurationMins"),
+                    "used_percent": window.get("usedPercent"),
+                    "resets_at": window.get("resetsAt"),
+                }
+            )
+    return windows
+
+
+def summarize_thread(thread: dict[str, Any]) -> dict[str, Any]:
+    turns = thread.get("turns", [])
+    return {
+        "id": thread.get("id"),
+        "name": thread.get("name"),
+        "cwd": thread.get("cwd"),
+        "ephemeral": thread.get("ephemeral"),
+        "source": thread.get("source"),
+        "thread_source": thread.get("threadSource"),
+        "history_mode": thread.get("historyMode"),
+        "parent_thread_id": thread.get("parentThreadId"),
+        "turn_count": len(turns),
+        "turn_item_types": sorted(
+            {
+                item.get("type", "unknown")
+                for turn in turns
+                for item in turn.get("items", [])
+            }
+        ),
+    }
+
+
+def live_probe(args: argparse.Namespace) -> dict[str, Any]:
+    codex_home = Path(args.codex_home).expanduser().resolve()
+    auth_path = codex_home / "auth.json"
+    accounts_path = Path(args.accounts_file).expanduser().resolve()
+    accounts = read_accounts(accounts_path)
+    account_a = account_login(accounts, args.account_a)
+    account_b = account_login(accounts, args.account_b)
+    if account_a["account_id"] == account_b["account_id"]:
+        raise ProtocolError("account A and account B resolve to the same account")
+
+    receipt: dict[str, Any] = {
+        "schema": PROBE_SCHEMA,
+        "observed_at_unix": int(time.time()),
+        "codex_cli": subprocess.check_output(
+            [args.codex, "--version"], text=True
+        ).strip(),
+        "repository_head": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=args.cwd, text=True
+        ).strip(),
+        "shared_home": "~/.codex",
+        "per_run_codex_home": False,
+        "account_aliases": ["A", "B"],
+        "experiments": {},
+    }
+
+    name = f"Decodex XY-1262 shared-home proof {int(time.time())}"
+    server_a = AppServer(args.codex, args.cwd)
+    try:
+        server_a.login(account_a)
+        identifier = start_named_thread(server_a, args.cwd, name)
+        run_turn(server_a, identifier, "Reply exactly XY1262_ACCOUNT_A_DURABLE.")
+        receipt["initialize"] = server_a.initialize_result
+        receipt["capability_negotiation"] = server_a.capability_observations
+        receipt["account_a_windows"] = rate_limit_windows(server_a)
+        receipt["experiments"]["account_a_created"] = True
+    finally:
+        server_a.close(crash=True)
+
+    server_b = AppServer(args.codex, args.cwd)
+    try:
+        server_b.login(account_b)
+        listed = server_b.request(
+            "thread/list",
+            {"cwd": str(args.cwd), "searchTerm": name, "limit": 20},
+        )
+        cwd_threads = server_b.request(
+            "thread/list", {"cwd": str(args.cwd), "limit": 100}
+        ).get("data", [])
+        searched = server_b.request("thread/search", {"searchTerm": name, "limit": 20})
+        read_before = server_b.request(
+            "thread/read", {"threadId": identifier, "includeTurns": True}
+        )["thread"]
+        resumed = server_b.request("thread/resume", {"threadId": identifier})["thread"]
+        receipt["account_b_windows"] = rate_limit_windows(server_b)
+        try:
+            run_turn(server_b, identifier, "Reply exactly XY1262_ACCOUNT_B_CONTINUED.")
+            receipt["experiments"]["cross_account_turn_continuation"] = True
+        except ProtocolError as error:
+            receipt["experiments"]["cross_account_turn_continuation"] = {
+                "result": "failed",
+                "error_class": type(error).__name__,
+                "error": str(error),
+            }
+        read_after = server_b.request(
+            "thread/read", {"threadId": identifier, "includeTurns": True}
+        )["thread"]
+        receipt["experiments"]["restart_list_match"] = any(
+            item.get("id") == identifier for item in listed.get("data", [])
+        )
+        receipt["experiments"]["restart_search_match"] = any(
+            item.get("id") == identifier for item in searched.get("data", [])
+        )
+        receipt["experiments"]["ownership_isolation"] = {
+            "listed_thread_count_for_cwd": len(cwd_threads),
+            "decodex_mapped_count": 1,
+            "ignored_non_decodex_count": sum(
+                item.get("id") != identifier for item in cwd_threads
+            ),
+            "mapping_source": "thread_id_returned_by_decodex_thread_start_only",
+        }
+        receipt["experiments"]["cross_account_same_thread_resume"] = (
+            resumed.get("id") == identifier
+        )
+        receipt["experiments"]["read_before"] = summarize_thread(read_before)
+        receipt["experiments"]["read_after"] = summarize_thread(read_after)
+    finally:
+        server_b.close(crash=True)
+
+    # A process-scoped bad token proves the auth-failed boundary without changing the
+    # account pool or normal auth.json. Resume may load local history; a real turn must
+    # fail authentication before any fallback session is created.
+    auth_failed = AppServer(args.codex, args.cwd)
+    try:
+        try:
+            auth_failed.login(
+                {
+                    "access_token": "xy1262-invalid-process-token",
+                    "account_id": "xy1262-invalid-process-account",
+                }
+            )
+            receipt["experiments"]["auth_failed_boundary"] = "unexpected_login_success"
+        except ProtocolError as error:
+            receipt["experiments"]["auth_failed_boundary"] = {
+                "result": "login_rejected_before_resume_or_turn",
+                "error_class": type(error).__name__,
+                "error_code": -32603,
+            }
+    finally:
+        auth_failed.close(crash=True)
+
+    fallback = AppServer(args.codex, args.cwd)
+    try:
+        fallback.login(account_a)
+        fallback_name = f"{name} context-pack fallback"
+        fallback_id = start_named_thread(fallback, args.cwd, fallback_name)
+        context_pack = (
+            "Context Pack v1: prior_runtime_session="
+            + identifier
+            + "; durable_marker=XY1262_ACCOUNT_A_DURABLE; "
+            "possible_side_effects=none; reconciliation=thread/read plus repository HEAD. "
+            "Reply exactly XY1262_CONTEXT_PACK_CONTINUED."
+        )
+        run_turn(fallback, fallback_id, context_pack)
+        fallback_read = fallback.request(
+            "thread/read", {"threadId": fallback_id, "includeTurns": True}
+        )["thread"]
+        fallback.request("thread/archive", {"threadId": fallback_id})
+        archived = fallback.request(
+            "thread/list", {"archived": True, "searchTerm": fallback_name, "limit": 20}
+        )
+        archive_visible = any(
+            item.get("id") == fallback_id for item in archived.get("data", [])
+        )
+        fallback.request("thread/unarchive", {"threadId": fallback_id})
+        receipt["experiments"]["context_pack_fallback"] = {
+            "new_runtime_session": fallback_id != identifier,
+            "thread": summarize_thread(fallback_read),
+            "side_effect_reconciliation": "none_declared_and_repository_head_pinned",
+            "explicit_archive_round_trip": archive_visible,
+        }
+    finally:
+        fallback.close(crash=False)
+
+    if sha256_file(auth_path) != args.auth_sha256_before:
+        raise ProtocolError("normal Codex auth state changed during the process-scoped probe")
+    receipt["auth_state_unchanged"] = True
+    receipt["credentials_emitted"] = False
+    return receipt
+
+
+def schema_receipt(args: argparse.Namespace) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="xy1262-schema-") as directory:
+        out = Path(directory)
+        subprocess.run(
+            [
+                args.codex,
+                "app-server",
+                "generate-json-schema",
+                "--experimental",
+                "--out",
+                str(out),
+            ],
+            check=True,
+        )
+        client_request = json.loads((out / "ClientRequest.json").read_text())
+        server_notification = json.loads((out / "ServerNotification.json").read_text())
+
+        def methods(schema: dict[str, Any]) -> list[str]:
+            found = []
+            for variant in schema.get("oneOf", []):
+                values = variant.get("properties", {}).get("method", {}).get("enum", [])
+                found.extend(value for value in values if isinstance(value, str))
+            return sorted(found)
+
+        request_methods = methods(client_request)
+        notification_methods = methods(server_notification)
+        collaboration_schema = (out / "v2/ThreadReadResponse.json").read_text()
+        required_requests = [
+            "initialize",
+            "thread/start",
+            "thread/list",
+            "thread/search",
+            "thread/read",
+            "thread/resume",
+            "thread/name/set",
+            "turn/start",
+            "account/rateLimits/read",
+            "collaborationMode/list",
+        ]
+        required_notifications = [
+            "thread/started",
+            "turn/started",
+            "item/started",
+            "item/completed",
+            "turn/completed",
+        ]
+        missing = sorted(
+            set(required_requests) - set(request_methods)
+            | set(required_notifications) - set(notification_methods)
+        )
+        if missing:
+            raise ProtocolError(f"generated schema lacks required methods: {missing}")
+        collaboration_markers = [
+            "collabAgentToolCall",
+            "parentThreadId",
+            "agentNickname",
+            "agentRole",
+            "subAgentActivity",
+        ]
+        missing_collaboration = sorted(
+            marker for marker in collaboration_markers if marker not in collaboration_schema
+        )
+        if missing_collaboration:
+            raise ProtocolError(
+                f"generated schema lacks collaboration markers: {missing_collaboration}"
+            )
+        return {
+            "schema": "decodex/vnext-codex-schema-receipt/1",
+            "observed_at_unix": int(time.time()),
+            "codex_cli": subprocess.check_output(
+                [args.codex, "--version"], text=True
+            ).strip(),
+            "experimental": True,
+            "bundle_sha256": {
+                name: sha256_canonical_json(out / name)
+                for name in (
+                    "ClientRequest.json",
+                    "ServerNotification.json",
+                    "codex_app_server_protocol.v2.schemas.json",
+                )
+            },
+            "required_request_methods": required_requests,
+            "required_notification_methods": required_notifications,
+            "validated_collaboration_markers": collaboration_markers,
+            "subagent_thread_fields": [
+                "parentThreadId",
+                "agentNickname",
+                "agentRole",
+            ],
+            "quota_window_identity_field": "windowDurationMins",
+            "positional_window_fields_are_identity": False,
+            "missing": missing,
+        }
+
+
+def classify_quota_case(case: dict[str, Any]) -> dict[str, Any]:
+    inputs = case["input"]
+    if "accounts" in inputs:
+        ready = {
+            account["id"]: max(account["depleted_resets_at"])
+            for account in inputs["accounts"]
+        }
+        return {
+            "state": "depleted",
+            "decision": "waiting_usage",
+            "account_ready_at": ready,
+            "earliest_ready_at": min(ready.values()),
+        }
+    if inputs.get("auth") == "failed":
+        return {"state": "auth_failed", "decision": "excluded_auth", "ready_at": None}
+    stale_after = inputs.get("stale_after_seconds")
+    if stale_after is not None and inputs["now"] - inputs["observed_at"] > stale_after:
+        return {"state": "unknown", "decision": "probe_required", "ready_at": None}
+
+    by_duration = {window["duration_minutes"]: window for window in inputs["windows"]}
+    if 300 not in by_duration or 10080 not in by_duration:
+        return {"state": "unknown", "decision": "probe_required", "ready_at": None}
+    classified = {
+        "five_hour_source": by_duration[300]["source_field"],
+        "seven_day_source": by_duration[10080]["source_field"],
+    }
+    depleted = [
+        window for window in by_duration.values() if window["remaining_percent"] == 0
+    ]
+    if depleted and any(window["reset_at"] <= inputs["now"] for window in depleted):
+        return {
+            "state": "unknown",
+            "decision": "probe_required",
+            "ready_at": None,
+            "classified": classified,
+        }
+    result: dict[str, Any]
+    if depleted:
+        result = {
+            "state": "depleted",
+            "decision": "excluded_usage",
+            "ready_at": max(window["reset_at"] for window in depleted),
+        }
+    else:
+        result = {"state": "available", "decision": "usable", "ready_at": inputs["now"]}
+    result["classified"] = classified
+    return result
+
+
+def validate_checked_receipts(repository: Path) -> dict[str, Any]:
+    fixture_dir = repository / "openwiki/evidence/fixtures"
+    bundle = json.loads((fixture_dir / "xy-1262-live-receipt.json").read_text())
+    collaboration = json.loads(
+        (fixture_dir / "xy-1262-native-collaboration.json").read_text()
+    )
+    quota = json.loads((fixture_dir / "xy-1262-quota-matrix.json").read_text())
+    if bundle.get("schema") != "decodex/vnext-codex-evidence-bundle/1":
+        raise ProtocolError("checked live evidence bundle has the wrong schema")
+    if bundle.get("overall_acceptance") is not False:
+        raise ProtocolError("XY-1262 checked evidence must retain the failed gate verdict")
+
+    forbidden_keys = {"access_token", "refresh_token", "id_token", "email", "auth_sha256"}
+
+    def check_redaction(value: Any) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if key.lower() in forbidden_keys or "token" in key.lower():
+                    raise ProtocolError(f"credential-shaped key in evidence bundle: {key}")
+                check_redaction(child)
+        elif isinstance(value, list):
+            for child in value:
+                check_redaction(child)
+        elif isinstance(value, str) and "@" in value:
+            raise ProtocolError("account-like identity in evidence bundle")
+
+    check_redaction(bundle)
+    check_redaction(collaboration)
+    if collaboration.get("readbacks", {}).get("thread_list_ancestor", {}).get(
+        "parent_thread_id_matches"
+    ) is not True:
+        raise ProtocolError("native collaboration receipt lacks parent/child readback")
+    mismatches = []
+    for case in quota["cases"]:
+        actual = classify_quota_case(case)
+        if any(actual.get(key) != value for key, value in case["expect"].items()):
+            mismatches.append({"id": case["id"], "actual": actual, "expect": case["expect"]})
+    if mismatches:
+        raise ProtocolError(f"quota matrix mismatch: {mismatches}")
+    return {
+        "schema": "decodex/vnext-codex-evidence-validation/1",
+        "live_bundle_redacted": True,
+        "quota_cases_validated": len(quota["cases"]),
+        "overall_acceptance": False,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=("schema", "live", "validate"))
+    parser.add_argument("--codex", default="codex")
+    parser.add_argument("--cwd", type=Path, default=Path.cwd())
+    parser.add_argument("--codex-home", default=str(Path.home() / ".codex"))
+    parser.add_argument(
+        "--accounts-file", default=str(Path.home() / ".codex/decodex/accounts.jsonl")
+    )
+    parser.add_argument("--account-a")
+    parser.add_argument("--account-b")
+    args = parser.parse_args()
+    args.cwd = args.cwd.resolve()
+    args.auth_sha256_before = sha256_file(
+        Path(args.codex_home).expanduser().resolve() / "auth.json"
+    )
+    if args.mode == "live" and (not args.account_a or not args.account_b):
+        parser.error("live mode requires --account-a and --account-b")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    auth_path = Path(args.codex_home).expanduser().resolve() / "auth.json"
+    try:
+        if args.mode == "schema":
+            receipt = schema_receipt(args)
+        elif args.mode == "live":
+            receipt = live_probe(args)
+        else:
+            receipt = validate_checked_receipts(args.cwd)
+    except (OSError, subprocess.SubprocessError, ProtocolError, KeyError) as error:
+        if args.mode == "live" and sha256_file(auth_path) != args.auth_sha256_before:
+            error = ProtocolError(
+                "normal Codex auth state changed during a failed process-scoped probe"
+            )
+        print(json.dumps({"schema": PROBE_SCHEMA, "status": "failed", "error": str(error)}))
+        return 1
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_codex_app_server_probe.py
+++ b/tests/scripts/test_codex_app_server_probe.py
@@ -1,0 +1,158 @@
+import importlib.util
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROBE_PATH = ROOT / "scripts/vnext/codex_app_server_probe.py"
+QUOTA_PATH = ROOT / "openwiki/evidence/fixtures/xy-1262-quota-matrix.json"
+
+
+def load_probe():
+    spec = importlib.util.spec_from_file_location("codex_app_server_probe", PROBE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class CodexAppServerProbeTests(unittest.TestCase):
+    def test_account_selection_does_not_emit_credentials(self):
+        probe = load_probe()
+        secret = "header.payload.signature"
+        account_id = "account-private-id"
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "accounts.jsonl"
+            path.write_text(
+                json.dumps(
+                    {
+                        "email": "account-a@example.invalid",
+                        "tokens": {
+                            "access_token": secret,
+                            "account_id": account_id,
+                            "plan_type": "test",
+                        },
+                    }
+                )
+                + "\n"
+            )
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                selected = probe.account_login(
+                    probe.read_accounts(path), "account-a@example.invalid"
+                )
+
+        self.assertEqual(selected["access_token"], secret)
+        self.assertEqual(selected["account_id"], account_id)
+        self.assertNotIn(secret, stdout.getvalue() + stderr.getvalue())
+        self.assertNotIn(account_id, stdout.getvalue() + stderr.getvalue())
+
+    def test_quota_matrix_is_duration_typed_and_covers_required_states(self):
+        probe = load_probe()
+        fixture = json.loads(QUOTA_PATH.read_text())
+        cases = {case["id"]: case for case in fixture["cases"]}
+
+        self.assertEqual(
+            fixture["window_identity"],
+            {
+                "five_hour": {"duration_minutes": 300},
+                "seven_day": {"duration_minutes": 10080},
+            },
+        )
+        self.assertFalse(fixture["rules"]["positional_fields_are_identity"])
+        self.assertLessEqual(
+            {
+                "available_both_windows",
+                "depleted_five_hour",
+                "depleted_seven_day",
+                "unknown_missing_five_hour",
+                "stale_observation",
+                "reversed_positional_fields",
+                "depletion_reset_elapsed",
+                "auth_failed",
+                "all_accounts_depleted",
+            },
+            cases.keys(),
+        )
+
+        reversed_case = cases["reversed_positional_fields"]
+        self.assertEqual(
+            reversed_case["expect"]["classified"],
+            {"five_hour_source": "secondary", "seven_day_source": "primary"},
+        )
+        self.assertEqual(reversed_case["expect"]["ready_at"], 9000)
+
+        all_depleted = cases["all_accounts_depleted"]["expect"]
+        self.assertEqual(all_depleted["account_ready_at"], {"A": 9000, "B": 3000})
+        self.assertEqual(all_depleted["earliest_ready_at"], 3000)
+        for case in fixture["cases"]:
+            actual = probe.classify_quota_case(case)
+            for key, value in case["expect"].items():
+                self.assertEqual(actual.get(key), value, case["id"])
+
+    def test_checked_receipts_are_redacted_and_keep_failed_verdict(self):
+        probe = load_probe()
+
+        result = probe.validate_checked_receipts(ROOT)
+
+        self.assertTrue(result["live_bundle_redacted"])
+        self.assertEqual(result["quota_cases_validated"], 9)
+        self.assertFalse(result["overall_acceptance"])
+
+    def test_missing_selector_error_does_not_repeat_identity(self):
+        probe = load_probe()
+        identity = "private-account@example.invalid"
+
+        with self.assertRaises(probe.ProtocolError) as raised:
+            probe.account_login([], identity)
+
+        self.assertNotIn(identity, str(raised.exception))
+
+    def test_schema_digest_ignores_json_object_order(self):
+        probe = load_probe()
+        with tempfile.TemporaryDirectory() as directory:
+            first = Path(directory) / "first.json"
+            second = Path(directory) / "second.json"
+            first.write_text('{"b":2,"a":{"d":4,"c":3}}')
+            second.write_text('{"a":{"c":3,"d":4},"b":2}')
+
+            self.assertEqual(
+                probe.sha256_canonical_json(first), probe.sha256_canonical_json(second)
+            )
+
+    def test_thread_summary_keeps_only_normalization_fields(self):
+        probe = load_probe()
+        summary = probe.summarize_thread(
+            {
+                "id": "thread-1",
+                "name": "owned",
+                "cwd": "/repo",
+                "ephemeral": False,
+                "source": "vscode",
+                "threadSource": "decodex.xy1262.probe",
+                "historyMode": "legacy",
+                "parentThreadId": None,
+                "turns": [
+                    {
+                        "items": [
+                            {"type": "userMessage", "text": "private input"},
+                            {"type": "agentMessage", "text": "private output"},
+                        ]
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(summary["turn_item_types"], ["agentMessage", "userMessage"])
+        self.assertEqual(summary["turn_count"], 1)
+        self.assertNotIn("private input", json.dumps(summary))
+        self.assertNotIn("private output", json.dumps(summary))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- record live Codex app-server capability, thread persistence, ownership, continuation, quota, archive, and native collaboration evidence
- add a redacted reproducible probe, fixtures, and focused tests
- preserve the failed gate verdict without claiming unrun quota or denial paths

## Proven
- shared-home persistent exact-ID/list/readback
- healthy Account A to Account B same-thread continuation
- ownership only from Decodex's own creation receipts
- schema/live capability contradiction: paginated advertised, live call rejected with -32601, legacy works
- native reviewer parent/child and subAgentActivity shape
- duration-typed executable 5-hour/7-day quota decisions
- Context Pack mechanics after authentication rejection

## Still failed
- global title discovery after restart/indexing
- actual quota-depletion exclusion and failover
- Context-Pack fallback after real same-thread resume denial
- production ManagedRun divergence transition

This PR records a failed M0 gate. It does not unblock account routing or other dependent implementation.

## Review
Independent reviewer `/root/xy1262_reviewer` initially rejected six overclaims and later two evidence-quality defects. All valid findings were repaired. Final review accepts the focused failed-gate evidence with no remaining blockers.

## Validation
- schema generation with canonical digest reproduction
- evidence validation: 9 quota cases, `overall_acceptance=false`
- 6 unit tests
- credential/redaction and auth-state integrity checks
- `git diff --check`
- Manager rebase and signed commit verification

Rebased commit: `2ce84a7a4fc086bd50cd8d8bfa1080a1dbecbcce`