### PR TITLE
Fix GPUI spike TOML formatting

### DIFF
--- a/spikes/gpui/Cargo.toml
+++ b/spikes/gpui/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "decodex-gpui-spike"
-version = "0.0.0"
 edition = "2024"
-publish = false
 license = "GPL-3.0"
+name    = "decodex-gpui-spike"
+publish = false
+version = "0.0.0"
 
 [workspace]
 
 [dependencies]
-gpui = { git = "https://github.com/zed-industries/zed.git", rev = "aeeacf5439b2d30d01e38d65d767e6f31b255ecc", default-features = false }
-gpui_platform = { git = "https://github.com/zed-industries/zed.git", rev = "aeeacf5439b2d30d01e38d65d767e6f31b255ecc", default-features = false, features = ["font-kit"] }
+gpui                 = { git = "https://github.com/zed-industries/zed.git", rev = "aeeacf5439b2d30d01e38d65d767e6f31b255ecc", default-features = false }
+gpui_platform        = { git = "https://github.com/zed-industries/zed.git", rev = "aeeacf5439b2d30d01e38d65d767e6f31b255ecc", default-features = false, features = ["font-kit"] }
 unicode-segmentation = "=1.12.0"
 
 [dev-dependencies]
@@ -19,8 +19,8 @@ gpui = { git = "https://github.com/zed-industries/zed.git", rev = "aeeacf5439b2d
 visual-probe = ["gpui/test-support", "gpui_platform/test-support"]
 
 [[bin]]
-name = "render_probe"
-path = "src/bin/render_probe.rs"
+name              = "render_probe"
+path              = "src/bin/render_probe.rs"
 required-features = ["visual-probe"]
 
 [profile.release]

--- a/spikes/gpui/rust-toolchain.toml
+++ b/spikes/gpui/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.97.0"
+channel    = "1.97.0"
 components = ["cargo", "clippy", "rustc", "rustfmt"]
-profile = "minimal"
+profile    = "minimal"


### PR DESCRIPTION
## Summary\n\n- format the two GPUI spike TOML files with the repository Taplo policy\n- restore repository-wide [cargo-make] INFO - cargo make 0.37.24
[cargo-make] INFO - 
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: fmt-check
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Execute Command: "rustup" "run" "nightly" "cargo" "fmt" "--all" "--" "--check"
[cargo-make] INFO - Execute Command: "taplo" "fmt" "--check"
[cargo-make] INFO - Build Done in 1.95 seconds.\n- preserve all dependency values and GPUI behavior\n\n## Verification\n\n- [cargo-make] INFO - cargo make 0.37.24
[cargo-make] INFO - 
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: fmt-check
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Execute Command: "rustup" "run" "nightly" "cargo" "fmt" "--all" "--" "--check"
[cargo-make] INFO - Execute Command: "taplo" "fmt" "--check"
[cargo-make] INFO - Build Done in 1.92 seconds.\n- \n- independent read-only reviewer: approved with no findings\n