### PR TITLE
XY-1262: split foundation and live-routing gates

### DIFF
--- a/openwiki/decisions/vnext-authority.md
+++ b/openwiki/decisions/vnext-authority.md
@@ -6,6 +6,12 @@ Tracking issue: [XY-1260](https://linear.app/hack-ink/issue/XY-1260/promote-the-
 
 Source planning record: [Decodex vNext Design Baseline](https://linear.app/hack-ink/document/decodex-vnext-design-baseline-681f7d8ad284), accepted 2026-07-12 against repository snapshot `5546dcb3b2eb0a8aecf7d6a3b117d2605ea315b8`.
 
+Authority amendment: Manager decision accepted 2026-07-13. The decision accepts the
+conceptual XY-1262 foundation/live-enablement split proposed by merged PR #1098 at
+`687605583817eca32cbdfb1107f3ee18d3106cea`, but only through this independently
+reviewed normative amendment. The merged proposal was evidence, not authority by
+itself. Repository authority remains normative; Linear is planning metadata.
+
 ## Decision
 
 Decodex vNext is a rebuild of the agent workspace, not an incremental extension of the
@@ -71,6 +77,24 @@ vNext owner and a focused gate/test make that behavior authoritative.
   merge, budget, approval, parallelism, and quiet-period limits remain hard stops.
 - Work lands through focused task branches/PRs directly to `main`; there is no long-lived
   vNext branch.
+
+## XY-1262 gate split
+
+The XY-1262 foundation gate is accepted only for the evidence scope enumerated in the
+[gate manifest](../specs/vnext-gates.md): shared-home and one-account-per-process
+boundaries, creation-receipt ownership, negotiated app-server contracts, supported
+exact-ID/list/read/archive operations, lossy-read/divergence policy, native run-local
+collaboration normalization, process-scoped authentication/redaction, read-only
+plugin/skill inventory, and pure duration-typed quota policy. This acceptance does not
+claim global Codex title search, live quota-driven routing, automatic continuation, or
+release readiness.
+
+The separate [XY-1262 live account-routing enablement gate](https://linear.app/hack-ink/issue/XY-1304)
+remains failed and fail-closed. The bounded foundation work named by the manifest may
+proceed after its own dependencies, but no live-routing, managed production execution,
+dogfood, cutover, or release path may use the disabled capabilities until that later gate
+passes through another explicit repository authority amendment. Unknown or stale quota
+facts never establish eligibility.
 
 ## Rejected alternatives and falsifiers
 

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -84,10 +84,13 @@ protocol security gate.
 ## Conversation, context, and communication
 
 Every meaningful Decodex-created thread uses `ephemeral=false`, the shared normal
-`~/.codex`, the repository `cwd`, and discoverable title/provenance. Advisor and Lead
-threads are never auto-archived. Task/Reviewer threads remain searchable and are archived
-only by explicit retention policy; probes may be ephemeral. Decodex never imports
-Codex-created threads and persists mappings only for Decodex-created threads.
+`~/.codex`, the repository `cwd`, and a title/provenance marker retained for supported
+exact-ID and filtered-list ownership readback. Advisor and Lead threads are never
+auto-archived. Task/Reviewer threads remain discoverable through that supported boundary
+and are archived only by explicit retention policy; probes may be ephemeral. Decodex
+never imports Codex-created threads and persists mappings only for Decodex-created
+threads. No global Codex or Codex Desktop title-search/indexing contract is claimed until
+the separate live enablement gate records the required supported discovery readback.
 
 A logical Conversation may span RuntimeSessions when size, resume latency, compatibility,
 or account failure requires it. Each mapping records conversation, session, Codex thread,
@@ -133,6 +136,27 @@ Cross-account resume of the same Codex thread is allowed only after the two-acco
 gate. Otherwise start a new RuntimeSession from a Context Pack while preserving the
 Conversation and ManagedRun. Never replay a possibly side-effecting turn without receipt,
 worktree/Git, and artifact reconciliation.
+
+Those paragraphs define the target behavior, not current enablement. Until the separate
+[XY-1262 live account-routing enablement gate](https://linear.app/hack-ink/issue/XY-1304)
+passes and repository authority explicitly enables it, all of the following are hard
+default-disabled in every production, dogfood, cutover, and release configuration:
+
+- sticky-account assignment and policy-based account assignment;
+- a quota-driven exclusion causing selection or assignment of another account;
+- `waiting_usage` scheduling or wakeup;
+- automatic same-thread continuation on another account;
+- automatic creation or dispatch of a Context-Pack fallback RuntimeSession; and
+- replay of a turn after an ambiguous outcome or any possible side effect.
+
+Foundation code may represent these states, persist inert metadata, calculate pure
+decisions, and test transactions with synthetic fixtures only where the gate manifest
+permits it. It must not submit a turn, assign a fallback runner, schedule a wake, or
+transition a live ManagedRun through these paths. Unknown, missing-duration, stale,
+low-confidence, auth-failed, plugin-unready, and disabled account/quota facts never imply
+availability. In particular, unknown or stale quota is fail-closed: no assignment and no
+automatic fallback is permitted; the unavailable/unknown condition must be surfaced for
+human resolution or bounded observation.
 
 Users exclusively select the four global RoleProfiles. Runtime cannot alter model,
 reasoning, or service tier. Each RuntimeSession snapshots its profile. Decodex keeps a

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -17,9 +17,9 @@ its dependent implementation uses the result.
 
 | Range | Accepted downstream ownership |
 | --- | --- |
-| [XY-1261](https://linear.app/hack-ink/issue/XY-1261)-[XY-1264](https://linear.app/hack-ink/issue/XY-1264) | Freeze v0.2; prove Codex ownership/continuation, pinned GPUI, and PostgreSQL/blob/cache operation. These are the M0 prerequisites. |
+| [XY-1261](https://linear.app/hack-ink/issue/XY-1261)-[XY-1264](https://linear.app/hack-ink/issue/XY-1264), with live continuation moved to [XY-1304](https://linear.app/hack-ink/issue/XY-1304) | v0.2 freeze and PostgreSQL/blob/cache proof are accepted; the XY-1262 foundation is accepted, live continuation remains failed in XY-1304, and GPUI remains failed on the separate XY-1263 accessibility gate. |
 | [XY-1265](https://linear.app/hack-ink/issue/XY-1265)-[XY-1269](https://linear.app/hack-ink/issue/XY-1269) | Workspace ownership boundaries, `decodexd` protocol, PostgreSQL persistence, `~/.decodex`/API-only CLI, and GPUI shell/cache. |
-| [XY-1270](https://linear.app/hack-ink/issue/XY-1270)-[XY-1276](https://linear.app/hack-ink/issue/XY-1276) | Typed app-server adapter; Conversations/RuntimeSessions/history; shared-home reconciliation; account vault/runner pool; typed quota failover; user profiles/plugin readiness; Quick Task slice. |
+| [XY-1270](https://linear.app/hack-ink/issue/XY-1270)-[XY-1276](https://linear.app/hack-ink/issue/XY-1276), plus [XY-1304](https://linear.app/hack-ink/issue/XY-1304) | Typed app-server, Conversation/RuntimeSession/history, shared-home, vault/runner-binding, quota-calculation, and profile/readiness foundations; XY-1304 separately owns live routing enablement and blocks the Quick Task slice. |
 | [XY-1277](https://linear.app/hack-ink/issue/XY-1277)-[XY-1286](https://linear.app/hack-ink/issue/XY-1286) | Projects/Advisor/Lead, context, messages/collaboration, decision queues, Programs/Objectives, WorkItems, ManagedRuns, repository services, Task-owned independent review/repair/landing, and Project/Program authority policy. |
 | [XY-1287](https://linear.app/hack-ink/issue/XY-1287)-[XY-1290](https://linear.app/hack-ink/issue/XY-1290) | Automation definitions/firings, materiality/loop safety, removal of manager agents, and PubFi/SEO/GEO/Radar/Publisher dogfood. |
 | [XY-1291](https://linear.app/hack-ink/issue/XY-1291)-[XY-1297](https://linear.app/hack-ink/issue/XY-1297) | GPUI conversations, project/run workspace, graph/timeline, operational surfaces, multi-GB pagination/cache/search, thin menubar, and accessibility/interaction gates. |
@@ -32,54 +32,122 @@ planning metadata, not product/runtime identity.
 ## Required architecture and implementation gates
 
 1. GPUI exact-revision build/package/test/accessibility spike (XY-1263).
-2. Shared-home persistent thread visibility in Codex (XY-1262).
-3. Ownership isolation between Codex-created and Decodex-created threads (XY-1262).
-4. Real two-account continuation after quota failure, including crash points (XY-1262).
-5. Typed 5h/7d quota matrix with unknown, stale, and reversed windows (XY-1262).
-6. App-server capability/schema negotiation, thread read/list, and native collaboration
-   behavior (XY-1262).
-7. Empty PostgreSQL bootstrap, backup/rollback, and concurrent lease/outbox tests
+2. The accepted XY-1262 foundation gate: shared-home/process isolation,
+   creation-receipt ownership, negotiated app-server contracts, supported
+   exact-ID/list/read/archive behavior, lossy-read/divergence policy, native run-local
+   collaboration normalization, process-scoped authentication/redaction, read-only
+   plugin/skill inventory, and pure duration-typed quota policy.
+3. The separate failed XY-1262 live account-routing enablement gate (XY-1304): natural
+   quota depletion, durable exclusion before fallback, crash-safe exactly-one
+   continuation, real resume-denied Context-Pack fallback, all-depleted wait/wakeup
+   readback, side-effect reconciliation, and supported Codex Desktop title discovery.
+4. Empty PostgreSQL bootstrap, backup/rollback, and concurrent lease/outbox tests
    (XY-1264). The scoped proof choices, measurements, recovery procedure, and downstream
    boundary are recorded in [vNext storage feasibility evidence](../evidence/vnext-storage-feasibility.md).
-8. WebSocket reconnect, cursor resume, command idempotency, and current/previous-minor
+5. WebSocket reconnect, cursor resume, command idempotency, and current/previous-minor
    compatibility tests (XY-1266 and regression owner XY-1300).
-9. Large-history pagination/cache test proving multi-GB history is never eagerly loaded
+6. Large-history pagination/cache test proving multi-GB history is never eagerly loaded
    (XY-1263, implementation XY-1295, and regression owner XY-1300).
-10. ManagedRun restart and side-effect reconciliation fault injection, including the
+7. ManagedRun restart and side-effect reconciliation fault injection, including the
     Task-owned independent review loop and typed reviewer wait/failure states (XY-1283,
     XY-1285, and regression owner XY-1300).
-11. Real Program/Automation/Lead/Task/Reviewer dogfood, using PubFi or equivalent
+8. Real Program/Automation/Lead/Task/Reviewer dogfood, using PubFi or equivalent
     (XY-1290 and release dogfood owner XY-1303).
-12. Remote binding stays disabled until authentication, TLS, authorization, and
+9. Remote binding stays disabled until authentication, TLS, authorization, and
     redaction gates pass (XY-1299).
 
-### XY-1262 evidence status
+### XY-1262 foundation acceptance
 
-The [Codex runtime proof](../evidence/vnext-codex-runtime-proof.md) at
-`f9d6c4e70198e94e5b9461b8cac7518ae14d41ef` supplies partial evidence for shared-home
-persistence, creation-receipt ownership isolation, exact-ID Codex Desktop readback,
-healthy-account same-thread continuation, Context-Pack mechanics, explicit archive
-readback, live schema negotiation, native run-local collaboration shape, and the
-duration-typed quota decision table.
+Manager accepted this split on 2026-07-13. The decision provenance is merged PR #1098 at
+`687605583817eca32cbdfb1107f3ee18d3106cea`; that proposal becomes authority only through
+this independently reviewed amendment. Repository authority is normative and Linear is
+planning metadata.
 
-The full visibility gate remains failed: the persistent probe thread was returned by
-app-server `thread/list(searchTerm=...)` and was readable by exact ID through Codex
-Desktop, but app-server `thread/search` and Codex Desktop global title query did not
-return it during the experiment. Dependent implementation must not equate rollout/list
-visibility with sidebar/global-search discovery. A desktop restart/indexing proof that
-finds the retained title is required before this sub-gate is accepted.
+The [Codex runtime proof](../evidence/vnext-codex-runtime-proof.md), including the merged
+reconciliation receipt, accepts the foundation gate for exactly these observed or pure
+evidence boundaries:
 
-The generated schema also advertised paginated thread history while live
-`thread/start(historyMode=paginated)` returned JSON-RPC `-32601`; adapter capability is
-therefore a negotiated live result keyed by Codex build, not a schema-only inference.
-The full XY-1262 gate also remains failed because the available accounts were not
-depleted: no real quota-failure exclusion/failover was observed, and the Context-Pack
-fallback followed an authentication rejection rather than a same-thread resume denial.
+- one shared normal `~/.codex`, with each app-server process bound to one account and no
+  credential switching under a live process;
+- Decodex ownership only from a durable creation receipt, never from arbitrary Codex
+  history;
+- generated typed schema plus negotiated live method results keyed by the Codex build;
+- persistent exact-ID, filtered-list, read, explicit archive, and restart readback;
+- lossy `thread/read` handling and a fail-closed ManagedRun `diverged` policy;
+- native collaboration/subagent events normalized only as run-local actors;
+- process-scoped authentication, redaction, and integrity-preserving read-only
+  plugin/skill inventory; and
+- pure quota decisions keyed by duration 300/10080, including unknown, stale, reversed,
+  and all-depleted synthetic cases.
+
+Healthy-account same-thread continuation and a manually started Context-Pack session are
+mechanism evidence only. They do not accept automatic cross-account routing or fallback.
+No global Codex title-search contract is accepted: exact-ID and filtered-list ownership
+readback are the supported boundary.
+
+### Permitted foundation work
+
+Permission is issue-scoped and does not bypass each issue's own dependencies:
+
+| Issue | Permitted boundary |
+| --- | --- |
+| XY-1265 | Workspace ownership cutover and composition roots; no compatibility facade. |
+| XY-1266 | Loopback protocol, idempotency, reconnect, backpressure, and non-loopback refusal. |
+| XY-1267 | PostgreSQL transactions, leases, outbox, and inert account/window schemas. |
+| XY-1268 | Owned `~/.decodex` paths and API-only diagnostics that report unavailable/unknown honestly. |
+| XY-1269 | No work while the separate GPUI accessibility gate in XY-1263 is failed; this is its sole feasibility blocker. |
+| XY-1270 | Generated typed app-server contracts, live capability negotiation, redaction, and one-account-per-process supervision; no task scheduling or account choice. |
+| XY-1271 | Conversation/RuntimeSession/history and inspectable Context-Pack persistence; no automatic rollover, assignment, or fallback dispatch. |
+| XY-1272 | Transactional creation mappings, exact-ID/list reconciliation, explicit retention, and the ManagedRun `diverged` stop transition; no global title-search claim. |
+| XY-1273 | Credential-vault metadata and immutable runner/account binding; no sticky or policy assignment. |
+| XY-1274 | Pure duration-typed quota/wake calculations and durable exclusion transaction tests using synthetic fixtures only; no live exclusion, fallback assignment, or wake scheduling. |
+| XY-1275 | User-owned profile snapshots and read-only plugin readiness audits; no installation or routing decision. |
+
+All XY-1270-XY-1275 capabilities must be mechanically inert or default-disabled at their
+live boundary. Synthetic fixtures can validate representation, calculation, and
+transaction ordering but cannot satisfy the live gate.
+
+### Failed live account-routing enablement gate
+
+The [live gate issue](https://linear.app/hack-ink/issue/XY-1304) remains failed and
+fail-closed. Before any gated capability is enabled, an account must become **naturally
+depleted**; quota must not be deliberately consumed to manufacture acceptance. A fixed
+no-tool marker must then return a typed provider quota failure. Durable readback must
+show the submitted turn and unknown side-effect state, followed by the specific
+duration-typed 300/10080 account/window exclusion committed and crash-recoverable before
+any fallback assignment.
+
+A different fresh eligible account must produce exactly one useful continuation on the
+same thread when supported. Otherwise, a real denied/incompatible response must end the
+old RuntimeSession and create exactly one Context-Pack RuntimeSession. Injected crashes
+at each exclusion, assignment, resume, and fallback boundary must read back exactly one
+continuation, correct `waiting_usage` plus the earliest ready time when all accounts are
+freshly depleted, and no duplicate tool, worktree, Git, or artifact effect. Normal auth,
+account-pool, and installed/enabled plugin state must remain unchanged. Separately, the
+retained title must be returned by supported Codex Desktop discovery after normal
+indexing before any global visibility claim.
+
+Until all of that evidence passes and a later explicit repository amendment enables the
+path, sticky or policy assignment, quota-driven exclusion causing another assignment,
+`waiting_usage` scheduling/wakeup, automatic cross-account same-thread resume, automatic
+Context-Pack fallback, and replay after an ambiguous or possibly side-effecting outcome
+are hard default-disabled. Unknown, missing-duration, stale, or low-confidence quota is
+not eligibility evidence and remains fail-closed.
+
+XY-1276 remains blocked by XY-1304. The same direct live-gate block is required for later
+issues whose stated acceptance would exercise live routing: XY-1277-XY-1280, XY-1283,
+XY-1285, XY-1287, XY-1289-XY-1292, XY-1300, XY-1302, and XY-1303. Their presence in a
+later milestone, a synthetic test, or an otherwise completed dependency cannot authorize
+managed production routing. Other later foundation or UI work may proceed only when its
+own scope can remain inert and its other gates pass; it cannot claim live-routing,
+dogfood, cutover, or release acceptance.
+
 
 ## Cutover gate
 
-Cutover may occur only after replacement behavior has accepted tests and the v0.2
-inventory is frozen. The accepted procedure stops v0.2, verifies the trusted tag/cold
+Cutover may occur only after replacement behavior has accepted tests, XY-1304 has passed
+through explicit repository authority, and the v0.2 inventory is frozen. The accepted
+procedure stops v0.2, verifies the trusted tag/cold
 backup, initializes empty PostgreSQL state, explicitly recreates selected Projects and
 Automations, and starts only vNext. It imports no legacy execution history and enables no
 dual authority. Removal of old Linear/SQLite/Goal/operator transport follows replacement


### PR DESCRIPTION
## Summary\n- accept only the proven XY-1262 foundation boundary\n- keep live multi-account routing fail-closed behind new gate XY-1304\n- reconcile M1/M2 and later live-routing dependencies in Linear\n\n## Validation\n- cargo make fmt-check\n- 11 XY-1262 probe tests\n- cargo make lint-vstyle-rust\n- cargo make test-vnext-storage-proof\n- git diff --check\n- three independent skeptic passes; final reviewer PASS\n\n## Authority\nRepository authority remains normative. No production runtime or UI implementation is enabled by this change.