### PR TITLE
XY-1265: cut over Rust workspace to vNext skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,41 +158,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bon"
-version = "3.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
-dependencies = [
- "bon-macros",
- "rustversion",
-]
-
-[[package]]
-name = "bon-macros"
-version = "3.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
-dependencies = [
- "darling",
- "ident_case",
- "prettyplease",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,21 +340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,40 +355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
-]
-
-[[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -477,28 +393,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "decodex"
+name = "decodex-cli"
 version = "0.2.0"
 dependencies = [
- "base64",
- "clap",
- "color-eyre",
- "globset",
- "libc",
- "reqwest",
- "rusqlite",
- "serde",
- "serde_json",
- "sha1",
- "sha2",
- "tempfile",
- "time",
- "toml",
- "toml_edit",
- "tracing",
- "tracing-appender",
- "tracing-subscriber",
- "vergen-gitcl",
+ "decodex-protocol",
+]
+
+[[package]]
+name = "decodex-codex"
+version = "0.2.0"
+dependencies = [
+ "decodex-core",
+]
+
+[[package]]
+name = "decodex-core"
+version = "0.2.0"
+
+[[package]]
+name = "decodex-gpui"
+version = "0.2.0"
+dependencies = [
+ "decodex-protocol",
+]
+
+[[package]]
+name = "decodex-postgres"
+version = "0.2.0"
+dependencies = [
+ "decodex-core",
+]
+
+[[package]]
+name = "decodex-protocol"
+version = "0.2.0"
+dependencies = [
+ "decodex-core",
 ]
 
 [[package]]
@@ -514,6 +444,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "decodex-runtime"
+version = "0.2.0"
+dependencies = [
+ "decodex-codex",
+ "decodex-core",
+ "decodex-postgres",
+ "decodex-protocol",
+]
+
+[[package]]
 name = "decodex-vnext-storage-proof"
 version = "0.2.0"
 dependencies = [
@@ -523,6 +463,13 @@ dependencies = [
  "sha2",
  "tokio",
  "tokio-postgres",
+]
+
+[[package]]
+name = "decodexd"
+version = "0.2.0"
+dependencies = [
+ "decodex-runtime",
 ]
 
 [[package]]
@@ -738,19 +685,6 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
-name = "globset"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1004,12 +938,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,15 +1136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "matchers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,15 +1172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,15 +1184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
  "libc",
 ]
 
@@ -1980,26 +1881,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "sha1"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,12 +1992,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "symlink"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
-
-[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,9 +2071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -2322,58 +2195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow",
-]
-
-[[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,19 +2251,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-appender"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
-dependencies = [
- "crossbeam-channel",
- "symlink",
- "thiserror",
- "time",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,32 +2282,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex-automata",
  "sharded-slab",
- "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -2588,43 +2378,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vergen"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdf18a54cf91b4d98a8e8b67f6321606539fbcdcac02536286ad1de37b53fd2"
-dependencies = [
- "anyhow",
- "bon",
- "rustversion",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-gitcl"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4961429ed12888cb3c6dd20f7dc9508c821091a3ba5fec0156ed5a654c1c4572"
-dependencies = [
- "anyhow",
- "bon",
- "rustversion",
- "time",
- "vergen",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910e8471e27130bbc019e9bfa6bda16dfc4c6dd7c5d0793da70a9256caeae984"
-dependencies = [
- "anyhow",
- "bon",
- "rustversion",
-]
 
 [[package]]
 name = "walkdir"
@@ -2988,15 +2741,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,22 @@
 [workspace]
-exclude  = ["apps/decodex-app", "spikes/gpui"]
-members  = ["apps/*", "spikes/vnext-storage"]
+exclude = [
+	"apps/decodex",
+	"apps/decodex-app",
+	"spikes/gpui",
+]
+members = [
+	"apps/decodex-cli",
+	"apps/decodex-gpui",
+	"apps/decodex-publisher",
+	"apps/decodexd",
+	"apps/radar",
+	"crates/decodex-codex",
+	"crates/decodex-core",
+	"crates/decodex-postgres",
+	"crates/decodex-protocol",
+	"crates/decodex-runtime",
+	"spikes/vnext-storage",
+]
 resolver = "3"
 
 [workspace.package]
@@ -13,6 +29,12 @@ repository  = "https://github.com/hack-ink/decodex"
 version     = "0.2.0"
 
 [workspace.dependencies]
+decodex-codex    = { path = "crates/decodex-codex" }
+decodex-core     = { path = "crates/decodex-core" }
+decodex-postgres = { path = "crates/decodex-postgres" }
+decodex-protocol = { path = "crates/decodex-protocol" }
+decodex-runtime  = { path = "crates/decodex-runtime" }
+
 base64             = { version = "0.22" }
 clap               = { version = "4.6", features = ["derive"] }
 color-eyre         = { version = "0.6" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -242,6 +242,7 @@ args = [
 # | ------------------------ | --------- | --- |
 # | test                     | composite |     |
 # | test-rust                | command   |     |
+# | test-vnext-architecture  | command   |     |
 # | test-vnext-storage-proof | command   |     |
 
 [tasks.test]
@@ -249,6 +250,7 @@ clear = true
 workspace = false
 dependencies = [
 	"test-rust",
+	"test-vnext-architecture",
 ]
 
 [tasks.test-rust]
@@ -260,6 +262,15 @@ args = [
 	"--workspace",
 	"--all-targets",
 	"--all-features",
+]
+
+[tasks.test-vnext-architecture]
+workspace = false
+command = "python3"
+args = [
+	"-m",
+	"unittest",
+	"tests/scripts/test_vnext_architecture.py",
 ]
 
 [tasks.test-vnext-storage-proof]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Decodex
 
-Repo-native agent orchestration, retained lanes, and local operator control.
+Local-first agent workspace orchestration.
 
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/hack-ink/decodex)](https://github.com/hack-ink/decodex/tags)
@@ -11,7 +11,24 @@ Repo-native agent orchestration, retained lanes, and local operator control.
 
 </div>
 
-## Feature Highlights
+## vNext foundation status
+
+The active Rust workspace is the product-incomplete vNext foundation. `decodexd`, the
+`decodex` client, and the GPUI composition root compile, but PostgreSQL, Codex,
+WebSocket, CLI operations, and product UI behavior are deliberately unavailable until
+their owning implementation slices land. The frozen v0.2 source remains under
+`apps/decodex/` as provenance and is excluded from the active Cargo workspace; it is
+not a compatibility runtime.
+
+## Frozen v0.2 runtime reference
+
+All runtime, operator, CLI, configuration, and path claims below that describe
+retained lanes, Linear, SQLite, `apps/decodex/`, `~/.codex/decodex`, or
+`decodex serve` are frozen v0.2 reference material regardless of present-tense wording
+or heading level. They are not active vNext capability, authority, aliases, or fallback
+behavior.
+
+### Feature highlights at freeze
 
 - Rust CLI and runtime for repo-native retained coding-agent lanes.
 - Natural-language-first loop-runtime contract with accepted decision intake,
@@ -30,7 +47,7 @@ Repo-native agent orchestration, retained lanes, and local operator control.
 - OpenWiki-backed project knowledge under `openwiki/`, split by architecture,
   workflows, contracts, operations, and integrations.
 
-## Status
+## Frozen v0.2 status
 
 Prototype / in active development.
 
@@ -55,7 +72,12 @@ runtime.
 
 ## Workspace posture
 
-- `apps/decodex/` owns the Rust package that builds the `decodex` CLI and runtime.
+- `crates/decodex-core/`, `crates/decodex-protocol/`, `crates/decodex-postgres/`,
+  `crates/decodex-codex/`, and `crates/decodex-runtime/` are the five active vNext
+  library owners.
+- `apps/decodexd/`, `apps/decodex-cli/`, and `apps/decodex-gpui/` are the active vNext
+  composition roots; all currently report unavailable or disabled capability.
+- `apps/decodex/` preserves the frozen v0.2 package outside the active Cargo workspace.
 - `apps/radar/` owns the standalone Radar auxiliary tool for upstream evidence,
   release-delta, signal rendering, validation, and local ledger workflows.
 - `apps/decodex-publisher/` owns the standalone Publisher auxiliary tool for social
@@ -69,12 +91,13 @@ runtime.
   are the portable Codex app automation source; install live local configs from a
   clone with `python3 automations/decodex/scripts/config/sync_automations.py --apply`.
 
-Runtime authority stays in `apps/decodex/src/`, registered project contracts under
-`~/.codex/decodex/projects/<service-id>/`, and local runtime state. OpenWiki explains
-those contracts for maintainers and agents but is not a runtime input. Public site
-authority stays in `site/`.
+No vNext product-state runtime is active yet. PostgreSQL becomes product-state authority
+under XY-1267, the Decodex-owned local layout moves under `~/.decodex` under XY-1268,
+and shared `~/.codex` remains Codex-owned. OpenWiki explains those contracts for
+maintainers and agents but is not a runtime input. Public site authority stays in
+`site/`.
 
-## Runtime platform support
+## Frozen v0.2 runtime platform support
 
 - The Decodex runtime contract is Unix-only: macOS and Linux.
 - Windows is outside the runtime contract.
@@ -87,7 +110,7 @@ authority stays in `site/`.
   future dispatch rather than deleting visibility or ownership. It does not scan Codex
   history, repo-local config files, or currently open worktrees to infer projects.
 
-## Usage
+## Frozen v0.2 usage
 
 ### Runtime CLI
 
@@ -284,7 +307,7 @@ The static-site boundary and GitHub Pages setup for `https://decodex.space`, inc
 the external automation boundary, are summarized in
 [`openwiki/integrations/plugins-automations-and-auxiliary-tools.md`](openwiki/integrations/plugins-automations-and-auxiliary-tools.md).
 
-## Operator Listener
+## Frozen v0.2 operator listener
 
 `decodex serve` owns the local operator listener. Published snapshots,
 current-lane updates, and local operator controls flow through the
@@ -370,7 +393,10 @@ cargo make build-node
 
 The tracked workspace currently keeps:
 
-- `apps/decodex/` as the Rust package that builds the `decodex` CLI and runtime
+- `crates/decodex-*/` as the five active vNext library owners
+- `apps/decodexd/`, `apps/decodex-cli/`, and `apps/decodex-gpui/` as active vNext
+  composition roots
+- `apps/decodex/` as frozen v0.2 provenance excluded from the active Cargo workspace
 - `site/` as the Astro static site for the public Decodex product surface
 - `plugins/decodex/` as the canonical installable Decodex plugin source
 - `openwiki/` as the repo-local project knowledge and agent context surface

--- a/apps/decodex-cli/Cargo.toml
+++ b/apps/decodex-cli/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+authors.workspace    = true
+description          = "Decodex vNext command-line client composition root."
+edition.workspace    = true
+homepage.workspace   = true
+license.workspace    = true
+name                 = "decodex-cli"
+repository.workspace = true
+version.workspace    = true
+
+[[bin]]
+name = "decodex"
+path = "src/main.rs"
+
+[dependencies]
+decodex-protocol = { workspace = true }

--- a/apps/decodex-cli/src/main.rs
+++ b/apps/decodex-cli/src/main.rs
@@ -1,0 +1,12 @@
+//! Default-unavailable Decodex vNext command-line client composition root.
+
+use decodex_protocol::ProtocolVersion;
+
+fn main() {
+	let version = ProtocolVersion::V1;
+
+	println!(
+		"decodex v{}.{} client unavailable: API transport belongs to XY-1266/XY-1268",
+		version.major, version.minor
+	);
+}

--- a/apps/decodex-gpui/Cargo.toml
+++ b/apps/decodex-gpui/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors.workspace    = true
+description          = "Default-disabled GPUI client composition root for Decodex vNext."
+edition.workspace    = true
+homepage.workspace   = true
+license.workspace    = true
+name                 = "decodex-gpui"
+repository.workspace = true
+version.workspace    = true
+
+[dependencies]
+decodex-protocol = { workspace = true }

--- a/apps/decodex-gpui/src/main.rs
+++ b/apps/decodex-gpui/src/main.rs
@@ -1,0 +1,12 @@
+//! Default-disabled Decodex vNext GPUI client composition root.
+
+use decodex_protocol::ProtocolVersion;
+
+fn main() {
+	let version = ProtocolVersion::V1;
+
+	println!(
+		"Decodex GPUI v{}.{} is disabled: XY-1263 accessibility gate remains failed",
+		version.major, version.minor
+	);
+}

--- a/apps/decodexd/Cargo.toml
+++ b/apps/decodexd/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors.workspace    = true
+description          = "Decodex vNext service composition root."
+edition.workspace    = true
+homepage.workspace   = true
+license.workspace    = true
+name                 = "decodexd"
+repository.workspace = true
+version.workspace    = true
+
+[dependencies]
+decodex-runtime = { workspace = true }

--- a/apps/decodexd/src/main.rs
+++ b/apps/decodexd/src/main.rs
@@ -1,0 +1,12 @@
+//! Decodex vNext service composition root.
+
+use decodex_runtime::ServiceComposition;
+
+fn main() {
+	let announcement = ServiceComposition::foundation().boot();
+
+	println!(
+		"decodexd v{}.{} foundation wired; service unavailable and no endpoint selected",
+		announcement.version.major, announcement.version.minor
+	);
+}

--- a/crates/decodex-codex/Cargo.toml
+++ b/crates/decodex-codex/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors.workspace    = true
+description          = "Codex app-server adapter boundary for Decodex vNext."
+edition.workspace    = true
+homepage.workspace   = true
+license.workspace    = true
+name                 = "decodex-codex"
+repository.workspace = true
+version.workspace    = true
+
+[dependencies]
+decodex-core = { workspace = true }

--- a/crates/decodex-codex/src/lib.rs
+++ b/crates/decodex-codex/src/lib.rs
@@ -1,0 +1,50 @@
+//! Codex app-server adapter boundary.
+//!
+//! XY-1265 preserves the shared normal `~/.codex` contract without spawning a runner.
+
+use decodex_core::{Availability, ConversationRuntime};
+
+/// Continuation-home policy selected by this infrastructure owner.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CodexContinuity {
+	/// The user's ordinary shared `~/.codex`, never a per-run home.
+	SharedNormalHome,
+}
+
+/// Stable unavailable reason while Codex process supervision remains outside XY-1265.
+pub const NOT_IMPLEMENTED: &str = "Codex adapter is unavailable until XY-1270";
+
+/// The sole Codex adapter selected by the vNext composition root.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CodexAdapter;
+
+impl CodexAdapter {
+	/// Construct the explicit XY-1265 unavailable adapter.
+	pub const fn unavailable() -> Self {
+		Self
+	}
+
+	/// Report the continuation policy owned by this adapter.
+	pub const fn continuity(self) -> CodexContinuity {
+		CodexContinuity::SharedNormalHome
+	}
+}
+
+impl ConversationRuntime for CodexAdapter {
+	fn availability(&self) -> Availability {
+		Availability::Unavailable { reason: NOT_IMPLEMENTED }
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn adapter_preserves_shared_home_and_is_explicitly_unavailable() {
+		let adapter = CodexAdapter::unavailable();
+
+		assert_eq!(adapter.continuity(), CodexContinuity::SharedNormalHome);
+		assert_eq!(adapter.availability(), Availability::Unavailable { reason: NOT_IMPLEMENTED });
+	}
+}

--- a/crates/decodex-codex/src/lib.rs
+++ b/crates/decodex-codex/src/lib.rs
@@ -4,6 +4,9 @@
 
 use decodex_core::{Availability, ConversationRuntime};
 
+/// Stable unavailable reason while Codex process supervision remains outside XY-1265.
+pub const NOT_IMPLEMENTED: &str = "Codex adapter is unavailable until XY-1270";
+
 /// Continuation-home policy selected by this infrastructure owner.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CodexContinuity {
@@ -11,13 +14,9 @@ pub enum CodexContinuity {
 	SharedNormalHome,
 }
 
-/// Stable unavailable reason while Codex process supervision remains outside XY-1265.
-pub const NOT_IMPLEMENTED: &str = "Codex adapter is unavailable until XY-1270";
-
 /// The sole Codex adapter selected by the vNext composition root.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct CodexAdapter;
-
 impl CodexAdapter {
 	/// Construct the explicit XY-1265 unavailable adapter.
 	pub const fn unavailable() -> Self {
@@ -38,7 +37,8 @@ impl ConversationRuntime for CodexAdapter {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+	use crate::{CodexAdapter, CodexContinuity, NOT_IMPLEMENTED};
+	use decodex_core::{Availability, ConversationRuntime};
 
 	#[test]
 	fn adapter_preserves_shared_home_and_is_explicitly_unavailable() {

--- a/crates/decodex-core/Cargo.toml
+++ b/crates/decodex-core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+authors.workspace    = true
+description          = "Pure Decodex vNext domain and application contracts."
+edition.workspace    = true
+homepage.workspace   = true
+license.workspace    = true
+name                 = "decodex-core"
+repository.workspace = true
+version.workspace    = true

--- a/crates/decodex-core/src/lib.rs
+++ b/crates/decodex-core/src/lib.rs
@@ -1,0 +1,89 @@
+//! Pure domain and application contracts for Decodex vNext.
+
+/// Whether an owned subsystem can currently serve requests.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Availability {
+	/// The subsystem can serve its owned application contract.
+	Available,
+	/// The subsystem is intentionally unable to serve its owned application contract.
+	Unavailable {
+		/// Stable human-readable explanation of the unavailable boundary.
+		reason: &'static str,
+	},
+}
+
+/// Application-facing product-state port.
+pub trait ProductState {
+	/// Report whether the adapter can currently serve product-state requests.
+	fn availability(&self) -> Availability;
+}
+
+/// Application-facing conversation execution port.
+pub trait ConversationRuntime {
+	/// Report whether the adapter can currently serve conversation requests.
+	fn availability(&self) -> Availability;
+}
+
+/// Validated status of the two authority-bearing vNext foundations.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FoundationStatus {
+	product_state: Availability,
+	conversation_runtime: Availability,
+}
+
+impl FoundationStatus {
+	/// Assemble the application status through its owned ports.
+	pub fn assemble(
+		product_state: &impl ProductState,
+		conversation_runtime: &impl ConversationRuntime,
+	) -> Self {
+		Self {
+			product_state: product_state.availability(),
+			conversation_runtime: conversation_runtime.availability(),
+		}
+	}
+
+	/// Report product-state adapter availability.
+	pub const fn product_state(self) -> Availability {
+		self.product_state
+	}
+
+	/// Report conversation runtime availability.
+	pub const fn conversation_runtime(self) -> Availability {
+		self.conversation_runtime
+	}
+
+	/// Return true only when both required authority-bearing adapters are available.
+	pub const fn is_operational(self) -> bool {
+		matches!(self.product_state, Availability::Available)
+			&& matches!(self.conversation_runtime, Availability::Available)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	struct Store;
+
+	impl ProductState for Store {
+		fn availability(&self) -> Availability {
+			Availability::Unavailable { reason: "not wired" }
+		}
+	}
+
+	struct Conversation;
+
+	impl ConversationRuntime for Conversation {
+		fn availability(&self) -> Availability {
+			Availability::Unavailable { reason: "not wired" }
+		}
+	}
+
+	#[test]
+	fn foundation_is_not_operational_until_both_owned_ports_are_available() {
+		let status = FoundationStatus::assemble(&Store, &Conversation);
+
+		assert!(!status.is_operational());
+	}
+}

--- a/crates/decodex-core/src/lib.rs
+++ b/crates/decodex-core/src/lib.rs
@@ -1,17 +1,5 @@
 //! Pure domain and application contracts for Decodex vNext.
 
-/// Whether an owned subsystem can currently serve requests.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Availability {
-	/// The subsystem can serve its owned application contract.
-	Available,
-	/// The subsystem is intentionally unable to serve its owned application contract.
-	Unavailable {
-		/// Stable human-readable explanation of the unavailable boundary.
-		reason: &'static str,
-	},
-}
-
 /// Application-facing product-state port.
 pub trait ProductState {
 	/// Report whether the adapter can currently serve product-state requests.
@@ -24,13 +12,24 @@ pub trait ConversationRuntime {
 	fn availability(&self) -> Availability;
 }
 
+/// Whether an owned subsystem can currently serve requests.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Availability {
+	/// The subsystem can serve its owned application contract.
+	Available,
+	/// The subsystem is intentionally unable to serve its owned application contract.
+	Unavailable {
+		/// Stable human-readable explanation of the unavailable boundary.
+		reason: &'static str,
+	},
+}
+
 /// Validated status of the two authority-bearing vNext foundations.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FoundationStatus {
 	product_state: Availability,
 	conversation_runtime: Availability,
 }
-
 impl FoundationStatus {
 	/// Assemble the application status through its owned ports.
 	pub fn assemble(
@@ -62,7 +61,7 @@ impl FoundationStatus {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+	use crate::{Availability, ConversationRuntime, FoundationStatus, ProductState};
 
 	struct Store;
 

--- a/crates/decodex-postgres/Cargo.toml
+++ b/crates/decodex-postgres/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors.workspace    = true
+description          = "PostgreSQL product-state adapter boundary for Decodex vNext."
+edition.workspace    = true
+homepage.workspace   = true
+license.workspace    = true
+name                 = "decodex-postgres"
+repository.workspace = true
+version.workspace    = true
+
+[dependencies]
+decodex-core = { workspace = true }

--- a/crates/decodex-postgres/src/lib.rs
+++ b/crates/decodex-postgres/src/lib.rs
@@ -4,6 +4,9 @@
 
 use decodex_core::{Availability, ProductState};
 
+/// Stable unavailable reason while production persistence remains outside XY-1265.
+pub const NOT_IMPLEMENTED: &str = "PostgreSQL store is unavailable until XY-1267";
+
 /// Product-state authority selected by this infrastructure owner.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProductStateAuthority {
@@ -11,13 +14,9 @@ pub enum ProductStateAuthority {
 	Postgres,
 }
 
-/// Stable unavailable reason while production persistence remains outside XY-1265.
-pub const NOT_IMPLEMENTED: &str = "PostgreSQL store is unavailable until XY-1267";
-
 /// The sole product-state adapter selected by the vNext composition root.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct PostgresStore;
-
 impl PostgresStore {
 	/// Construct the explicit XY-1265 unavailable adapter.
 	pub const fn unavailable() -> Self {
@@ -38,7 +37,8 @@ impl ProductState for PostgresStore {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+	use crate::{NOT_IMPLEMENTED, PostgresStore, ProductStateAuthority};
+	use decodex_core::{Availability, ProductState};
 
 	#[test]
 	fn adapter_is_postgres_owned_and_explicitly_unavailable() {

--- a/crates/decodex-postgres/src/lib.rs
+++ b/crates/decodex-postgres/src/lib.rs
@@ -1,0 +1,50 @@
+//! PostgreSQL product-state adapter boundary.
+//!
+//! XY-1265 deliberately supplies no connection, schema, migration, or fallback store.
+
+use decodex_core::{Availability, ProductState};
+
+/// Product-state authority selected by this infrastructure owner.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProductStateAuthority {
+	/// PostgreSQL domain tables and their transactional mechanisms.
+	Postgres,
+}
+
+/// Stable unavailable reason while production persistence remains outside XY-1265.
+pub const NOT_IMPLEMENTED: &str = "PostgreSQL store is unavailable until XY-1267";
+
+/// The sole product-state adapter selected by the vNext composition root.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PostgresStore;
+
+impl PostgresStore {
+	/// Construct the explicit XY-1265 unavailable adapter.
+	pub const fn unavailable() -> Self {
+		Self
+	}
+
+	/// Report the concrete authority owned by this adapter.
+	pub const fn authority(self) -> ProductStateAuthority {
+		ProductStateAuthority::Postgres
+	}
+}
+
+impl ProductState for PostgresStore {
+	fn availability(&self) -> Availability {
+		Availability::Unavailable { reason: NOT_IMPLEMENTED }
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn adapter_is_postgres_owned_and_explicitly_unavailable() {
+		let store = PostgresStore::unavailable();
+
+		assert_eq!(store.authority(), ProductStateAuthority::Postgres);
+		assert_eq!(store.availability(), Availability::Unavailable { reason: NOT_IMPLEMENTED });
+	}
+}

--- a/crates/decodex-protocol/Cargo.toml
+++ b/crates/decodex-protocol/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors.workspace    = true
+description          = "Version and network-boundary contracts for Decodex vNext clients."
+edition.workspace    = true
+homepage.workspace   = true
+license.workspace    = true
+name                 = "decodex-protocol"
+repository.workspace = true
+version.workspace    = true
+
+[dependencies]
+decodex-core = { workspace = true }

--- a/crates/decodex-protocol/src/lib.rs
+++ b/crates/decodex-protocol/src/lib.rs
@@ -1,0 +1,86 @@
+//! Version and network-boundary contracts shared by vNext clients and `decodexd`.
+
+use std::{error::Error, fmt, net::SocketAddr};
+
+use decodex_core::FoundationStatus;
+
+/// The first vNext application-protocol version.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProtocolVersion {
+	/// Breaking protocol generation.
+	pub major: u16,
+	/// Compatible protocol revision within a generation.
+	pub minor: u16,
+}
+
+impl ProtocolVersion {
+	/// Initial vNext protocol identifier.
+	pub const V1: Self = Self { major: 1, minor: 0 };
+}
+
+/// A local endpoint that has passed the V1 loopback-only policy.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LoopbackEndpoint(SocketAddr);
+
+impl LoopbackEndpoint {
+	/// Validate an address against the V1 loopback-only policy.
+	pub fn new(address: SocketAddr) -> Result<Self, EndpointPolicyError> {
+		if address.ip().is_loopback() {
+			Ok(Self(address))
+		} else {
+			Err(EndpointPolicyError { address })
+		}
+	}
+
+	/// Return the validated socket address.
+	pub const fn address(self) -> SocketAddr {
+		self.0
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Error returned when a composition root selects a non-loopback address.
+pub struct EndpointPolicyError {
+	address: SocketAddr,
+}
+
+impl fmt::Display for EndpointPolicyError {
+	fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(formatter, "non-loopback endpoint is disabled: {}", self.address)
+	}
+}
+
+impl Error for EndpointPolicyError {}
+
+/// The compile-time service announcement; no transport is implemented in XY-1265.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ServiceAnnouncement {
+	/// Application protocol version selected by the service.
+	pub version: ProtocolVersion,
+	/// Current authority-bearing adapter status.
+	pub foundation: FoundationStatus,
+}
+
+#[cfg(test)]
+mod tests {
+	use std::net::{IpAddr, Ipv4Addr};
+
+	use super::*;
+
+	#[test]
+	fn loopback_endpoint_accepts_local_v1_composition() {
+		let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 49_152);
+
+		assert_eq!(LoopbackEndpoint::new(address).unwrap().address(), address);
+	}
+
+	#[test]
+	fn loopback_endpoint_refuses_remote_binding() {
+		let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 49_152);
+
+		assert_eq!(
+			LoopbackEndpoint::new(address).unwrap_err().to_string(),
+			"non-loopback endpoint is disabled: 0.0.0.0:49152"
+		);
+	}
+}

--- a/crates/decodex-protocol/src/lib.rs
+++ b/crates/decodex-protocol/src/lib.rs
@@ -1,6 +1,10 @@
 //! Version and network-boundary contracts shared by vNext clients and `decodexd`.
 
-use std::{error::Error, fmt, net::SocketAddr};
+use std::{
+	error::Error,
+	fmt::{Display, Formatter},
+	net::SocketAddr,
+};
 
 use decodex_core::FoundationStatus;
 
@@ -12,7 +16,6 @@ pub struct ProtocolVersion {
 	/// Compatible protocol revision within a generation.
 	pub minor: u16,
 }
-
 impl ProtocolVersion {
 	/// Initial vNext protocol identifier.
 	pub const V1: Self = Self { major: 1, minor: 0 };
@@ -21,7 +24,6 @@ impl ProtocolVersion {
 /// A local endpoint that has passed the V1 loopback-only policy.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct LoopbackEndpoint(SocketAddr);
-
 impl LoopbackEndpoint {
 	/// Validate an address against the V1 loopback-only policy.
 	pub fn new(address: SocketAddr) -> Result<Self, EndpointPolicyError> {
@@ -43,14 +45,13 @@ impl LoopbackEndpoint {
 pub struct EndpointPolicyError {
 	address: SocketAddr,
 }
+impl Error for EndpointPolicyError {}
 
-impl fmt::Display for EndpointPolicyError {
-	fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Display for EndpointPolicyError {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
 		write!(formatter, "non-loopback endpoint is disabled: {}", self.address)
 	}
 }
-
-impl Error for EndpointPolicyError {}
 
 /// The compile-time service announcement; no transport is implemented in XY-1265.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -63,9 +64,9 @@ pub struct ServiceAnnouncement {
 
 #[cfg(test)]
 mod tests {
-	use std::net::{IpAddr, Ipv4Addr};
+	use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-	use super::*;
+	use crate::LoopbackEndpoint;
 
 	#[test]
 	fn loopback_endpoint_accepts_local_v1_composition() {

--- a/crates/decodex-runtime/Cargo.toml
+++ b/crates/decodex-runtime/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+authors.workspace    = true
+description          = "Service lifecycle and adapter composition for Decodex vNext."
+edition.workspace    = true
+homepage.workspace   = true
+license.workspace    = true
+name                 = "decodex-runtime"
+repository.workspace = true
+version.workspace    = true
+
+[dependencies]
+decodex-codex    = { workspace = true }
+decodex-core     = { workspace = true }
+decodex-postgres = { workspace = true }
+decodex-protocol = { workspace = true }

--- a/crates/decodex-runtime/src/lib.rs
+++ b/crates/decodex-runtime/src/lib.rs
@@ -1,0 +1,56 @@
+//! `decodexd` lifecycle assembly.
+//!
+//! This owner wires the accepted adapters and validates the service boundary. It does
+//! not open sockets, connect to PostgreSQL, or spawn Codex in XY-1265.
+
+use decodex_codex::CodexAdapter;
+use decodex_core::FoundationStatus;
+use decodex_postgres::PostgresStore;
+use decodex_protocol::{ProtocolVersion, ServiceAnnouncement};
+
+/// The vNext service assembly selected by the `decodexd` composition root.
+#[derive(Clone, Copy, Debug)]
+pub struct ServiceComposition {
+	store: PostgresStore,
+	codex: CodexAdapter,
+}
+
+impl ServiceComposition {
+	/// Select the accepted vNext adapters without selecting a transport or endpoint.
+	pub const fn foundation() -> Self {
+		Self { store: PostgresStore::unavailable(), codex: CodexAdapter::unavailable() }
+	}
+
+	/// Validate and describe the assembled service without enabling later slices.
+	pub fn boot(self) -> ServiceAnnouncement {
+		ServiceAnnouncement {
+			version: ProtocolVersion::V1,
+			foundation: FoundationStatus::assemble(&self.store, &self.codex),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use decodex_codex::NOT_IMPLEMENTED as CODEX_NOT_IMPLEMENTED;
+	use decodex_core::Availability;
+	use decodex_postgres::NOT_IMPLEMENTED as POSTGRES_NOT_IMPLEMENTED;
+
+	use super::*;
+
+	#[test]
+	fn service_boot_wires_v1_without_enabling_unimplemented_adapters() {
+		let announcement = ServiceComposition::foundation().boot();
+
+		assert_eq!(announcement.version, ProtocolVersion::V1);
+		assert_eq!(
+			announcement.foundation.product_state(),
+			Availability::Unavailable { reason: POSTGRES_NOT_IMPLEMENTED }
+		);
+		assert_eq!(
+			announcement.foundation.conversation_runtime(),
+			Availability::Unavailable { reason: CODEX_NOT_IMPLEMENTED }
+		);
+		assert!(!announcement.foundation.is_operational());
+	}
+}

--- a/crates/decodex-runtime/src/lib.rs
+++ b/crates/decodex-runtime/src/lib.rs
@@ -14,7 +14,6 @@ pub struct ServiceComposition {
 	store: PostgresStore,
 	codex: CodexAdapter,
 }
-
 impl ServiceComposition {
 	/// Select the accepted vNext adapters without selecting a transport or endpoint.
 	pub const fn foundation() -> Self {
@@ -32,11 +31,9 @@ impl ServiceComposition {
 
 #[cfg(test)]
 mod tests {
-	use decodex_codex::NOT_IMPLEMENTED as CODEX_NOT_IMPLEMENTED;
+	use crate::ServiceComposition;
 	use decodex_core::Availability;
-	use decodex_postgres::NOT_IMPLEMENTED as POSTGRES_NOT_IMPLEMENTED;
-
-	use super::*;
+	use decodex_protocol::ProtocolVersion;
 
 	#[test]
 	fn service_boot_wires_v1_without_enabling_unimplemented_adapters() {
@@ -45,11 +42,11 @@ mod tests {
 		assert_eq!(announcement.version, ProtocolVersion::V1);
 		assert_eq!(
 			announcement.foundation.product_state(),
-			Availability::Unavailable { reason: POSTGRES_NOT_IMPLEMENTED }
+			Availability::Unavailable { reason: decodex_postgres::NOT_IMPLEMENTED }
 		);
 		assert_eq!(
 			announcement.foundation.conversation_runtime(),
-			Availability::Unavailable { reason: CODEX_NOT_IMPLEMENTED }
+			Availability::Unavailable { reason: decodex_codex::NOT_IMPLEMENTED }
 		);
 		assert!(!announcement.foundation.is_operational());
 	}

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -1,14 +1,40 @@
 # Runtime Architecture
 
-This page explains how the Decodex runtime is wired so future agents can change it without rediscovering every module. It focuses on current source behavior and uses OpenWiki as a navigation layer over checked-in authority.
+This page explains the active vNext ownership skeleton and preserves a map of the
+excluded v0.2 source for provenance. Checked-in manifests, source, tests, and the vNext
+authority documents remain authoritative.
 
 ## Workspace shape
 
-The Rust workspace includes `apps/*` except `apps/decodex-app` (`Cargo.toml`). The main runtime package is `apps/decodex`, with dependencies on `clap`, `rusqlite`, `reqwest`, `serde`, `toml`, tracing, and hash/time utilities (`apps/decodex/Cargo.toml`). Radar and Publisher are independent Rust CLIs in the same workspace (`apps/radar/Cargo.toml`, `apps/decodex-publisher/Cargo.toml`).
+The root manifest enumerates the active members explicitly. Five library owners form the
+vNext runtime boundary:
 
-The `decodex` crate exposes only a few public modules (`app_bridge`, `config`, `state`, `workflow`) and keeps most runtime machinery private (`apps/decodex/src/lib.rs`). That is intentional: the binary is an operator/runtime control plane, not a general library API.
+- `decodex-core`: pure domain/application contracts and ports; no dependencies.
+- `decodex-protocol`: V1 version and loopback endpoint policy; depends only on core.
+- `decodex-postgres`: the product-state adapter boundary; depends only on core and is
+  unavailable until XY-1267.
+- `decodex-codex`: the shared-normal-home adapter boundary; depends only on core and is
+  unavailable until XY-1270.
+- `decodex-runtime`: service lifecycle/composition; depends on the other four owners.
 
-## CLI bootstrap
+`apps/decodexd` depends only on runtime. The `apps/decodex-cli` and
+`apps/decodex-gpui` client roots depend only on protocol, so they cannot reach stores,
+Codex, repositories, or orchestration directly. Radar and Publisher remain independent
+auxiliary workspace members. `tests/scripts/test_vnext_architecture.py` checks the exact
+dependency graph and exclusion of the legacy package through Cargo metadata.
+
+The current `decodexd` assembly returns a typed V1 foundation announcement without
+selecting an endpoint. The protocol owner exposes a loopback-only endpoint seam for
+XY-1266, but XY-1265 opens no transport and defines no default address. Both
+infrastructure adapters are explicitly unavailable. The CLI has no operational
+commands, and the GPUI root is default-disabled because the XY-1263 accessibility gate
+remains failed.
+
+## Frozen v0.2 runtime provenance
+
+Everything below this heading maps the preserved `apps/decodex/` source. That package
+is excluded from the active Cargo workspace and is not a runtime, fallback, compatibility
+facade, or implementation authority for vNext.
 
 `apps/decodex/src/main.rs` calls `decodex::run()`. `run()` does four things (`apps/decodex/src/lib.rs`):
 

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -19,6 +19,7 @@ It depends on build, node checks, Rust checks, formatting, lint, and tests (`Mak
 | Broad repo check | `cargo make check` |
 | Rust type check | `cargo make check-rust` or `cargo check --all-features --all-targets --workspace` |
 | Rust tests | `cargo make test` or `cargo nextest run --workspace --all-targets --all-features` |
+| vNext dependency architecture | `cargo make test-vnext-architecture` |
 | vNext storage feasibility proof | `cargo make test-vnext-storage-proof` |
 | Rust formatting | `cargo make fmt-rust-check` |
 | TOML formatting | `cargo make fmt-toml-check` |
@@ -27,7 +28,7 @@ It depends on build, node checks, Rust checks, formatting, lint, and tests (`Mak
 | Site type check | `cargo make check-node` or `npm --prefix site run check` |
 | Site build | `cargo make build` or `npm --prefix site run build` |
 
-`cargo make test` uses `cargo nextest run --workspace --all-targets --all-features` (`Makefile.toml`). The XY-1264 storage command is intentionally separate: it requires an intended macOS host with one PostgreSQL 18 distribution providing matching `postgres`, `initdb`, `pg_ctl`, `psql`, `pg_dump`, and `pg_restore` binaries. It creates and removes an isolated temporary checksummed cluster with TCP disabled; a passing run is scoped feasibility evidence, not the broad repository gate or a production performance result (`spikes/vnext-storage/proof.py`, `spikes/vnext-storage/README.md`).
+`cargo make test` runs both `cargo nextest run --workspace --all-targets --all-features` and the vNext architecture test (`Makefile.toml`). The XY-1264 storage command is intentionally separate: it requires an intended macOS host with one PostgreSQL 18 distribution providing matching `postgres`, `initdb`, `pg_ctl`, `psql`, `pg_dump`, and `pg_restore` binaries. It creates and removes an isolated temporary checksummed cluster with TCP disabled; a passing run is scoped feasibility evidence, not the broad repository gate or a production performance result (`spikes/vnext-storage/proof.py`, `spikes/vnext-storage/README.md`).
 
 ## Validation scope selection
 
@@ -39,7 +40,13 @@ Good targeted scopes are contract-shaped rather than file-shaped: CLI parsing/ou
 
 Use the owner path to choose the first validation surface:
 
-- `apps/decodex/`: Decodex Rust CLI, runtime, orchestration, tracker/app-server integration, MCP, state, recovery, and operator control-plane behavior.
+- `crates/decodex-core/`: pure vNext domain/application contracts and authority ports.
+- `crates/decodex-protocol/`: version and loopback network boundary shared by service and clients.
+- `crates/decodex-postgres/`: default-unavailable PostgreSQL product-state adapter boundary.
+- `crates/decodex-codex/`: default-unavailable shared-home Codex adapter boundary.
+- `crates/decodex-runtime/`: `decodexd` lifecycle assembly over the four narrow owners.
+- `apps/decodexd/`, `apps/decodex-cli/`, and `apps/decodex-gpui/`: active vNext composition roots.
+- `apps/decodex/`: frozen v0.2 source excluded from the workspace; provenance only.
 - `apps/radar/`: Radar auxiliary tool for upstream evidence, release deltas, signal rendering, artifact validation, and ledger workflows.
 - `apps/decodex-publisher/`: Publisher auxiliary tool for social candidate, reservation, post validation, and publication handoff workflows.
 - `plugins/decodex/`: installable Decodex runtime/operator plugin source, including planning, runtime ops, commit, and landing skills/hooks.
@@ -57,12 +64,15 @@ Common targeted commands:
 ```sh
 cargo check --all-features --all-targets --workspace
 cargo nextest run --workspace --all-targets --all-features
-cargo test -p decodex <filter>
+cargo make test-vnext-architecture
+cargo test -p decodex-core -p decodex-protocol -p decodex-postgres -p decodex-codex -p decodex-runtime
 cargo test -p radar <filter>
 cargo test -p decodex-publisher <filter>
 ```
 
-Prefer targeted filters while iterating, then run a broader gate before handoff when the change touches shared runtime behavior. Choose filters from the behavior family or module path that owns the observable contract: `review_landing` for merge/review state, `tracker_tool_bridge` for Linear writes and continuation guards, `app_server` or `json_rpc` for protocol payloads, `state` for leases/migrations/runtime rows, `mcp` for operator control tools, `manual`/`github`/`worktree`/`recovery` for Git and landing helpers, and CLI parser names for command output. If one change crosses families, run one focused filter per family rather than a single file-shaped smoke test.
+The remaining test map on this page describes frozen v0.2 provenance and remains useful
+only when later removal work audits preserved behavior. It is not an active vNext test
+surface.
 
 ## Test map
 

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -1,6 +1,11 @@
 # OpenWiki Quickstart
 
-Decodex is a Rust workspace for repo-native coding-agent orchestration: a `decodex` CLI/runtime, retained Linear issue lanes, local operator control, MCP access, a macOS account-pool app, an Astro public site, an installable Decodex Codex plugin, and auxiliary Radar/Publisher tooling. The root workspace manifest describes the package as "Decodex runtime, static site, and local operator tooling" (`Cargo.toml`). The README summarizes the product as "Repo-native agent orchestration, retained lanes, and local operator control" (`README.md`).
+Decodex is cutting over to the accepted vNext agent-workspace architecture. The active
+Rust workspace currently contains the ownership skeleton and explicitly unavailable
+composition roots; it does not provide the old Linear/SQLite runtime. The v0.2 source is
+preserved under `apps/decodex/` as frozen provenance and is excluded from the active
+workspace. Radar, Publisher, the static site, plugins, and automation source remain
+outside the runtime rewrite until their owners adopt them.
 
 OpenWiki is the repo-local project knowledge surface for agents and maintainers. Runtime authority lives in source, project contracts, tests, manifests, and local runtime state; OpenWiki explains where to start and what to watch before editing.
 
@@ -29,7 +34,13 @@ OpenWiki is the repo-local project knowledge surface for agents and maintainers.
 
 ## Repository map
 
-- `apps/decodex/` builds the `decodex` CLI/runtime package (`apps/decodex/Cargo.toml`). Its public bootstrap is `apps/decodex/src/lib.rs`; the CLI surface is `apps/decodex/src/cli.rs`.
+- `crates/decodex-core/` owns pure domain/application authority contracts and ports; it has no dependencies.
+- `crates/decodex-protocol/` owns the vNext version and loopback-only endpoint contract shared with clients.
+- `crates/decodex-postgres/` owns the PostgreSQL product-state adapter boundary; its production implementation remains unavailable until XY-1267.
+- `crates/decodex-codex/` owns the shared-normal-`~/.codex` adapter boundary; runner behavior remains unavailable until XY-1270.
+- `crates/decodex-runtime/` owns `decodexd` service assembly and is the only library owner that composes protocol and infrastructure adapters.
+- `apps/decodexd/`, `apps/decodex-cli/`, and `apps/decodex-gpui/` are composition roots. The client roots depend only on the protocol crate; the GPUI binary remains a disabled print-and-exit stub while XY-1263 is failed.
+- `apps/decodex/` is the frozen v0.2 package. It remains in Git for provenance but is excluded from Cargo workspace membership and must not be used by vNext.
 - `apps/radar/` is the Radar auxiliary tool for upstream review queues, release deltas, artifact validation, signal rendering, and bundle generation (`apps/radar/README.md`, `apps/radar/src/lib.rs`).
 - `apps/decodex-publisher/` validates and reserves Decodex-owned social artifacts (`apps/decodex-publisher/README.md`, `apps/decodex-publisher/src/lib.rs`).
 - `apps/decodex-app/` is a native macOS UI over local Decodex account-pool state and may launch `decodex serve` when no default local server is available (`apps/decodex-app/README.md`).
@@ -37,40 +48,54 @@ OpenWiki is the repo-local project knowledge surface for agents and maintainers.
 - `plugins/decodex/` contains the installable Decodex plugin, narrow routing skills, and lifecycle guardrail hooks (`plugins/decodex/.codex-plugin/plugin.json`).
 - `automations/decodex/` and `automations/radar/` contain portable Codex App automation source; live machine-local configs are generated from these manifests (`automations/decodex/README.md`, `automations/radar/README.md`).
 - `scripts/` contains repo maintenance helpers including plugin sync and macOS app staging.
-- `tests/` currently contains Python tests for script-level plugin sync behavior (`tests/scripts/test_sync_installable_plugins.py`). Most Rust tests live in each app crate under `src/**/tests*`.
+- `tests/scripts/test_vnext_architecture.py` enforces the exact vNext dependency graph, client isolation, and exclusion-with-preservation of the legacy package.
 
 ## Runtime in one minute
 
-`apps/decodex/src/main.rs` only calls `decodex::run()`. The library bootstrap initializes error reporting, daily file tracing under `~/.codex/decodex/logs`, a panic-abort hook, and then runs `Cli::parse().run()` (`apps/decodex/src/lib.rs`). The CLI supports project registry, run/serve, status, lane control, MCP, intake, recovery, commit/land, account pool, app launch, probe, and validation status publishing (`apps/decodex/src/cli.rs`).
+`apps/decodexd` composes the PostgreSQL and Codex adapter boundaries through
+`decodex-runtime` and reports both adapters as unavailable. It selects no endpoint and
+opens no socket, database, repository, or Codex process. The protocol crate owns the
+loopback-only endpoint seam for XY-1266. The `decodex` and GPUI roots compile against
+`decodex-protocol` only and report their unsupported or disabled state.
 
-Local runtime state is under `~/.codex/decodex`: global config, `accounts.jsonl`, `projects/`, `logs/`, `agent-evidence/`, and `runtime.sqlite3` (`apps/decodex/src/runtime/paths.rs`). Project contracts are outside checkouts under `~/.codex/decodex/projects/<service-id>/` and use fixed `project.toml` plus `WORKFLOW.md` files (`apps/decodex/src/config/service.rs`, `decodex.example.toml`).
+No vNext product state is persisted yet. PostgreSQL is the accepted future product-state
+authority, `~/.codex` remains Codex-owned shared continuation state, and the accepted
+Decodex-owned target is `~/.decodex`. XY-1267 and XY-1268 own those implementations.
+The legacy `~/.codex/decodex` SQLite/config layout is frozen provenance, not a vNext
+input or fallback.
 
-`decodex run` opens the runtime store, resolves/registers a project config, loads workflow policy, checks tracker backoff, and dispatches through `orchestrator::run_configured_cycle` (`apps/decodex/src/orchestrator/entrypoints/run.rs`). `decodex serve` is the long-running local control plane; each daemon tick reconciles active children, idle recovery, post-review orchestration, archive backlog, and due child spawns (`apps/decodex/src/orchestrator/daemon.rs`).
+There is no active scheduling, WebSocket, CLI operation, account routing, Codex adapter,
+PostgreSQL store, or GPUI product behavior in this slice.
 
 ## First commands
 
 Use these as discovery and validation entrypoints:
 
 ```sh
-decodex --help
-decodex project list
-decodex status --live
-decodex run --dry-run --explain
-decodex serve --listen-address 127.0.0.1:8192
-decodex mcp serve --transport stdio
+cargo run -p decodexd
+cargo run -p decodex-cli
+cargo run -p decodex-gpui
+cargo make test-vnext-architecture
 cargo make check
 ```
 
-For a source checkout without installed binaries, run Rust commands through Cargo, for example `cargo run -p decodex -- status`. For a targeted Rust gate, prefer `cargo check --all-features --all-targets --workspace` or `cargo nextest run --workspace --all-targets --all-features` (`Makefile.toml`, `openwiki/operations/commands-and-validation.md`).
+The three binaries report foundation/unavailability state and exit; they do not start a
+production service. For a targeted Rust gate, prefer
+`cargo check --all-features --all-targets --workspace` or
+`cargo nextest run --workspace --all-targets --all-features` (`Makefile.toml`,
+`openwiki/operations/commands-and-validation.md`).
 
 ## Authority and safety rules
 
 - Do not read `.env` files or live secret-bearing config. `decodex.example.toml` is the redacted setup model and uses credential environment-variable names, not token values.
-- Do not hand-edit `~/.codex/decodex/runtime.sqlite3`, runtime DB rows, hidden child process state, Linear labels, GitHub merges, or internal Program graph ids to simulate lifecycle controls.
+- Do not route vNext through `apps/decodex`, legacy SQLite, Linear lanes, or the legacy operator transport.
 - Use `decodex commit` and `decodex land` for Decodex-owned commit/landing authority; the installable plugin hook blocks raw `git commit` and `gh pr merge` inside Decodex scope (`plugins/decodex/scripts/decodex_lifecycle_hook`).
-- Treat Linear and GitHub as collaboration mirrors. The local runtime SQLite store is the single-machine source of truth for leases, attempts, protocol summaries, private execution events, Program Intake, review lifecycle records, run control, and connector backoff (`openwiki/specs/contracts-and-data.md`, `apps/decodex/src/state/sqlite_store/schema.rs`).
+- PostgreSQL becomes vNext product-state authority only when its owning gate lands. Until then, unavailable is the only supported service state; there is no fallback authority.
 - For project knowledge work, update OpenWiki directly and keep it aligned with source, tests, and manifests.
 
 ## Recent development context
 
-Recent history shows active work around lifecycle hook guardrails, automation reasoning effort, baseline canonicalization before dispatch, local validation landing status gates, and review/landing lifecycle hardening. The important current themes are: keep Decodex-owned lifecycle actions behind typed commands, protect baseline canonicalization before normal/program/retry dispatch, preserve local validation evidence for landing, and avoid letting stale knowledge or plugin skills become runtime authority.
+XY-1265 establishes compile-time ownership and composition only. XY-1266 may implement
+the loopback protocol, XY-1267 the PostgreSQL store, and XY-1268 the API-only CLI/path
+cutover after this foundation merges. Codex behavior, account routing, and GPUI product
+work remain with their later owners and gates.

--- a/tests/scripts/test_vnext_architecture.py
+++ b/tests/scripts/test_vnext_architecture.py
@@ -1,0 +1,101 @@
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+EXPECTED_DEPENDENCIES = {
+    "decodex-core": set(),
+    "decodex-protocol": {"decodex-core"},
+    "decodex-postgres": {"decodex-core"},
+    "decodex-codex": {"decodex-core"},
+    "decodex-runtime": {
+        "decodex-codex",
+        "decodex-core",
+        "decodex-postgres",
+        "decodex-protocol",
+    },
+    "decodexd": {"decodex-runtime"},
+    "decodex-cli": {"decodex-protocol"},
+    "decodex-gpui": {"decodex-protocol"},
+}
+
+EXPECTED_WORKSPACE_MANIFESTS = {
+    "apps/decodex-cli/Cargo.toml",
+    "apps/decodex-gpui/Cargo.toml",
+    "apps/decodex-publisher/Cargo.toml",
+    "apps/decodexd/Cargo.toml",
+    "apps/radar/Cargo.toml",
+    "crates/decodex-codex/Cargo.toml",
+    "crates/decodex-core/Cargo.toml",
+    "crates/decodex-postgres/Cargo.toml",
+    "crates/decodex-protocol/Cargo.toml",
+    "crates/decodex-runtime/Cargo.toml",
+    "spikes/vnext-storage/Cargo.toml",
+}
+
+
+class VnextArchitectureTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        result = subprocess.run(
+            ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        cls.metadata = json.loads(result.stdout)
+        cls.packages = {package["name"]: package for package in cls.metadata["packages"]}
+        cls.packages_by_id = {
+            package["id"]: package for package in cls.metadata["packages"]
+        }
+
+    def test_vnext_dependency_direction_is_exact(self):
+        for package_name, expected in EXPECTED_DEPENDENCIES.items():
+            with self.subTest(package=package_name):
+                actual = {
+                    dependency["name"]
+                    for dependency in self.packages[package_name]["dependencies"]
+                }
+                self.assertEqual(actual, expected)
+
+    def test_workspace_owner_set_is_exact(self):
+        actual = {
+            str(
+                Path(self.packages_by_id[package_id]["manifest_path"])
+                .resolve()
+                .relative_to(ROOT)
+            )
+            for package_id in self.metadata["workspace_members"]
+        }
+
+        self.assertEqual(actual, EXPECTED_WORKSPACE_MANIFESTS)
+
+    def test_legacy_runtime_is_preserved_but_not_an_active_workspace_member(self):
+        member_manifests = {
+            Path(package["manifest_path"]).resolve()
+            for package in self.metadata["packages"]
+            if package["id"] in self.metadata["workspace_members"]
+        }
+        legacy_manifest = (ROOT / "apps/decodex/Cargo.toml").resolve()
+
+        self.assertTrue(legacy_manifest.is_file())
+        self.assertNotIn(legacy_manifest, member_manifests)
+        self.assertNotIn("decodex", self.packages)
+
+    def test_clients_cannot_reach_runtime_or_infrastructure_owners(self):
+        forbidden = {"decodex-runtime", "decodex-postgres", "decodex-codex"}
+
+        for package_name in ("decodex-cli", "decodex-gpui"):
+            dependencies = {
+                dependency["name"]
+                for dependency in self.packages[package_name]["dependencies"]
+            }
+            self.assertTrue(dependencies.isdisjoint(forbidden))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace the active Rust workspace with five vNext library owners and three composition roots
- exclude the frozen v0.2 runtime from workspace authority without adding compatibility paths
- add executable architecture tests for exact membership, dependency direction, client isolation, and legacy exclusion
- align README and OpenWiki with the clean-break foundation state

## Deliberate non-goals

No WebSocket transport, production PostgreSQL store, path cutover, Codex supervision, account routing, or GPUI product UI is enabled by this slice.

## Verification

- cargo make lint-vstyle-rust
- cargo make fmt-check
- cargo make test-vnext-architecture
- cargo make check-rust
- cargo make test
- cargo make lint-rust
- cargo run --quiet -p decodexd
- cargo run --quiet -p decodex-cli
- cargo run --quiet -p decodex-gpui
- git diff --check main...HEAD

39 Rust tests and 4 architecture tests pass. Independent reviewers found and verified repairs for core semantic leakage, incomplete owner-set enforcement, premature legacy-port selection, README authority drift, and repository style violations. The fresh final follow-up reviewer returned PASS with zero findings.

Linear: XY-1265