### PR TITLE
XY-1266: implement vNext loopback WebSocket protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +202,15 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -206,7 +270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -332,11 +396,30 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -356,6 +439,12 @@ checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deadpool"
@@ -429,6 +518,8 @@ name = "decodex-protocol"
 version = "0.2.0"
 dependencies = [
  "decodex-core",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -447,10 +538,15 @@ dependencies = [
 name = "decodex-runtime"
 version = "0.2.0"
 dependencies = [
+ "axum",
  "decodex-codex",
  "decodex-core",
  "decodex-postgres",
  "decodex-protocol",
+ "futures-util",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
 ]
 
 [[package]]
@@ -470,6 +566,7 @@ name = "decodexd"
 version = "0.2.0"
 dependencies = [
  "decodex-runtime",
+ "tokio",
 ]
 
 [[package]]
@@ -480,13 +577,23 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -613,6 +720,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,11 +750,22 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -740,7 +869,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -783,6 +912,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +939,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1136,13 +1272,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1150,6 +1292,12 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1785,6 +1933,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,14 +2035,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2182,6 +2370,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2407,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2245,6 +2446,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2297,6 +2499,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror",
+]
 
 [[package]]
 name = "typenum"
@@ -2378,6 +2596,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,11 @@ decodex-postgres = { path = "crates/decodex-postgres" }
 decodex-protocol = { path = "crates/decodex-protocol" }
 decodex-runtime  = { path = "crates/decodex-runtime" }
 
+axum               = { version = "0.8.9", features = ["ws"] }
 base64             = { version = "0.22" }
 clap               = { version = "4.6", features = ["derive"] }
 color-eyre         = { version = "0.6" }
+futures-util       = { version = "0.3.32" }
 globset            = { version = "0.4" }
 libc               = { version = "0.2" }
 regex              = { version = "1.12" }
@@ -50,6 +52,8 @@ sha1               = { version = "0.11" }
 sha2               = { version = "0.11" }
 tempfile           = { version = "3.27" }
 time               = { version = "0.3", features = ["formatting"] }
+tokio              = { version = "1.52.3", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio-tungstenite  = { version = "0.29" }
 toml               = { version = "1.1" }
 toml_edit          = { version = "0.25" }
 tracing            = { version = "0.1" }

--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@ Local-first agent workspace orchestration.
 
 ## vNext foundation status
 
-The active Rust workspace is the product-incomplete vNext foundation. `decodexd`, the
-`decodex` client, and the GPUI composition root compile, but PostgreSQL, Codex,
-WebSocket, CLI operations, and product UI behavior are deliberately unavailable until
-their owning implementation slices land. The frozen v0.2 source remains under
-`apps/decodex/` as provenance and is excluded from the active Cargo workspace; it is
-not a compatibility runtime.
+The active Rust workspace is the product-incomplete vNext foundation. `decodexd` now
+serves the versioned structured-JSON WebSocket protocol at loopback-only
+`ws://127.0.0.1:49152/v1/ws`. It negotiates protocol V1 current/previous minor,
+publishes bounded snapshots and resumable ordered events, deduplicates commands for one
+server lifetime in a fixed-capacity ledger, and disconnects clients whose bounded
+outbound queue fills. PostgreSQL,
+Codex, CLI operations, authentication/TLS, remote binding, and product UI behavior are
+still unavailable until their owning slices land. The frozen v0.2 source remains under
+`apps/decodex/` as provenance and is excluded from the active Cargo workspace; it is not
+a compatibility runtime.
 
 ## Frozen v0.2 runtime reference
 
@@ -76,7 +80,8 @@ runtime.
   `crates/decodex-codex/`, and `crates/decodex-runtime/` are the five active vNext
   library owners.
 - `apps/decodexd/`, `apps/decodex-cli/`, and `apps/decodex-gpui/` are the active vNext
-  composition roots; all currently report unavailable or disabled capability.
+  composition roots. `decodexd` owns the loopback server; the client roots still report
+  unavailable or disabled capability.
 - `apps/decodex/` preserves the frozen v0.2 package outside the active Cargo workspace.
 - `apps/radar/` owns the standalone Radar auxiliary tool for upstream evidence,
   release-delta, signal rendering, validation, and local ledger workflows.
@@ -91,11 +96,13 @@ runtime.
   are the portable Codex app automation source; install live local configs from a
   clone with `python3 automations/decodex/scripts/config/sync_automations.py --apply`.
 
-No vNext product-state runtime is active yet. PostgreSQL becomes product-state authority
-under XY-1267, the Decodex-owned local layout moves under `~/.decodex` under XY-1268,
-and shared `~/.codex` remains Codex-owned. OpenWiki explains those contracts for
-maintainers and agents but is not a runtime input. Public site authority stays in
-`site/`.
+No vNext product-state runtime is active yet. The protocol's foundation application
+returns an explicit unavailable result and uses only bounded in-memory replay/idempotency state;
+a changed server ID after restart forces snapshot fallback. PostgreSQL becomes
+product-state authority under XY-1267, the Decodex-owned local layout moves under
+`~/.decodex` under XY-1268, and shared `~/.codex` remains Codex-owned. OpenWiki explains
+those contracts for maintainers and agents but is not a runtime input. Public site
+authority stays in `site/`.
 
 ## Frozen v0.2 runtime platform support
 

--- a/apps/decodex-cli/src/main.rs
+++ b/apps/decodex-cli/src/main.rs
@@ -1,12 +1,12 @@
 //! Default-unavailable Decodex vNext command-line client composition root.
 
-use decodex_protocol::ProtocolVersion;
+use decodex_protocol::CURRENT_VERSION;
 
 fn main() {
-	let version = ProtocolVersion::V1;
+	let version = CURRENT_VERSION;
 
 	println!(
-		"decodex v{}.{} client unavailable: API transport belongs to XY-1266/XY-1268",
+		"decodex v{}.{} client unavailable: client transport belongs to XY-1268",
 		version.major, version.minor
 	);
 }

--- a/apps/decodex-gpui/src/main.rs
+++ b/apps/decodex-gpui/src/main.rs
@@ -1,9 +1,9 @@
 //! Default-disabled Decodex vNext GPUI client composition root.
 
-use decodex_protocol::ProtocolVersion;
+use decodex_protocol::CURRENT_VERSION;
 
 fn main() {
-	let version = ProtocolVersion::V1;
+	let version = CURRENT_VERSION;
 
 	println!(
 		"Decodex GPUI v{}.{} is disabled: XY-1263 accessibility gate remains failed",

--- a/apps/decodexd/Cargo.toml
+++ b/apps/decodexd/Cargo.toml
@@ -10,3 +10,4 @@ version.workspace    = true
 
 [dependencies]
 decodex-runtime = { workspace = true }
+tokio           = { workspace = true }

--- a/apps/decodexd/src/main.rs
+++ b/apps/decodexd/src/main.rs
@@ -1,12 +1,27 @@
-//! Decodex vNext service composition root.
+//! Sole Decodex vNext server composition root.
 
-use decodex_runtime::ServiceComposition;
+use std::{
+	error::Error,
+	net::{Ipv4Addr, SocketAddr},
+	process,
+	time::{SystemTime, UNIX_EPOCH},
+};
 
-fn main() {
-	let announcement = ServiceComposition::foundation().boot();
+use decodex_runtime::{ServerConfig, ServerId, ServiceComposition};
 
-	println!(
-		"decodexd v{}.{} foundation wired; service unavailable and no endpoint selected",
-		announcement.version.major, announcement.version.minor
-	);
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+	let address = SocketAddr::from((Ipv4Addr::LOCALHOST, 49_152));
+	let epoch_nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+	let server_id = ServerId::new(format!("server-{}-{epoch_nanos}", process::id()))
+		.expect("generated server ID is bounded");
+
+	println!("decodexd listening on ws://{address}/v1/ws (loopback only; auth/TLS disabled)");
+
+	ServiceComposition::foundation()
+		.protocol_server(server_id, ServerConfig::default())
+		.run(address)
+		.await?;
+
+	Ok(())
 }

--- a/crates/decodex-protocol/Cargo.toml
+++ b/crates/decodex-protocol/Cargo.toml
@@ -10,3 +10,5 @@ version.workspace    = true
 
 [dependencies]
 decodex-core = { workspace = true }
+serde        = { workspace = true }
+serde_json   = { workspace = true }

--- a/crates/decodex-protocol/src/lib.rs
+++ b/crates/decodex-protocol/src/lib.rs
@@ -1,4 +1,16 @@
-//! Version and network-boundary contracts shared by vNext clients and `decodexd`.
+//! Typed vNext wire contracts and loopback endpoint policy shared by clients and
+//! `decodexd`.
+
+mod wire;
+
+pub use wire::{
+	CausationId, Channel, ClientCommandId, ClientHello, ClientMessage, CommandEnvelope,
+	CommandError, CommandOutcome, CommandPayload, CommandReceipt, CommandResultEnvelope,
+	CorrelationId, Cursor, EntityId, EntityRevision, EventEnvelope, EventPayload, IdempotencyKey,
+	MAX_WIRE_TEXT_BYTES, ReceiptDisposition, ReconnectMode, Refusal, RefusalEnvelope,
+	ResultPayload, ResumeCursor, ServerId, ServerMessage, ServerWelcome, SnapshotEnvelope,
+	SnapshotItem, WireScalarTooLong, WireText, decode_client_message, encode_server_message,
+};
 
 use std::{
 	error::Error,
@@ -6,10 +18,17 @@ use std::{
 	net::SocketAddr,
 };
 
+use serde::{Deserialize, Serialize};
+
 use decodex_core::FoundationStatus;
 
-/// The first vNext application-protocol version.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Current protocol generation and minor revision.
+pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 1, minor: 1 };
+/// Oldest protocol revision accepted during a rolling client/server update.
+pub const PREVIOUS_MINOR_VERSION: ProtocolVersion = ProtocolVersion { major: 1, minor: 0 };
+
+/// A version of the Decodex application protocol.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub struct ProtocolVersion {
 	/// Breaking protocol generation.
 	pub major: u16,
@@ -17,15 +36,51 @@ pub struct ProtocolVersion {
 	pub minor: u16,
 }
 impl ProtocolVersion {
-	/// Initial vNext protocol identifier.
-	pub const V1: Self = Self { major: 1, minor: 0 };
+	/// Negotiate this client version against the server's exact supported window.
+	pub fn negotiate(self) -> Result<Self, VersionRefusal> {
+		if self.major != CURRENT_VERSION.major {
+			return Err(VersionRefusal::MajorMismatch {
+				requested: self,
+				supported: SupportedVersions::current(),
+			});
+		}
+		if !(PREVIOUS_MINOR_VERSION.minor..=CURRENT_VERSION.minor).contains(&self.minor) {
+			return Err(VersionRefusal::UnsupportedMinor {
+				requested: self,
+				supported: SupportedVersions::current(),
+			});
+		}
+
+		Ok(self)
+	}
 }
 
-/// A local endpoint that has passed the V1 loopback-only policy.
+/// The server's contiguous compatibility window.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct SupportedVersions {
+	/// Required protocol generation.
+	pub major: u16,
+	/// Oldest accepted minor revision.
+	pub minimum_minor: u16,
+	/// Newest accepted minor revision.
+	pub maximum_minor: u16,
+}
+impl SupportedVersions {
+	/// Return the compatibility window implemented by this build.
+	pub const fn current() -> Self {
+		Self {
+			major: CURRENT_VERSION.major,
+			minimum_minor: PREVIOUS_MINOR_VERSION.minor,
+			maximum_minor: CURRENT_VERSION.minor,
+		}
+	}
+}
+
+/// A local endpoint that has passed the loopback-only policy.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct LoopbackEndpoint(SocketAddr);
 impl LoopbackEndpoint {
-	/// Validate an address against the V1 loopback-only policy.
+	/// Validate an address before any socket is opened.
 	pub fn new(address: SocketAddr) -> Result<Self, EndpointPolicyError> {
 		if address.ip().is_loopback() {
 			Ok(Self(address))
@@ -40,8 +95,8 @@ impl LoopbackEndpoint {
 	}
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 /// Error returned when a composition root selects a non-loopback address.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct EndpointPolicyError {
 	address: SocketAddr,
 }
@@ -53,7 +108,7 @@ impl Display for EndpointPolicyError {
 	}
 }
 
-/// The compile-time service announcement; no transport is implemented in XY-1265.
+/// The compile-time service announcement used before a socket is selected.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ServiceAnnouncement {
 	/// Application protocol version selected by the service.
@@ -62,14 +117,60 @@ pub struct ServiceAnnouncement {
 	pub foundation: FoundationStatus,
 }
 
+/// A precise version-negotiation refusal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "reason", rename_all = "snake_case")]
+pub enum VersionRefusal {
+	/// The breaking generations differ.
+	MajorMismatch {
+		/// Version requested by the client.
+		requested: ProtocolVersion,
+		/// Versions supported by the server.
+		supported: SupportedVersions,
+	},
+	/// The generation matches but the minor is outside the rolling window.
+	UnsupportedMinor {
+		/// Version requested by the client.
+		requested: ProtocolVersion,
+		/// Versions supported by the server.
+		supported: SupportedVersions,
+	},
+}
+
 #[cfg(test)]
 mod tests {
 	use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-	use crate::LoopbackEndpoint;
+	use crate::{
+		CURRENT_VERSION, LoopbackEndpoint, PREVIOUS_MINOR_VERSION, ProtocolVersion,
+		SupportedVersions, VersionRefusal,
+	};
 
 	#[test]
-	fn loopback_endpoint_accepts_local_v1_composition() {
+	fn current_and_previous_minor_versions_are_accepted_exactly() {
+		assert_eq!(CURRENT_VERSION.negotiate(), Ok(CURRENT_VERSION));
+		assert_eq!(PREVIOUS_MINOR_VERSION.negotiate(), Ok(PREVIOUS_MINOR_VERSION));
+		assert!(matches!(
+			ProtocolVersion { major: 1, minor: 2 }.negotiate(),
+			Err(VersionRefusal::UnsupportedMinor { .. })
+		));
+	}
+
+	#[test]
+	fn a_major_mismatch_is_distinct_from_minor_incompatibility() {
+		let requested = ProtocolVersion { major: 2, minor: 0 };
+
+		assert_eq!(
+			requested.negotiate(),
+			Err(VersionRefusal::MajorMismatch {
+				requested,
+				supported: SupportedVersions::current(),
+			})
+		);
+	}
+
+	#[test]
+	fn loopback_endpoint_accepts_local_composition() {
 		let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 49_152);
 
 		assert_eq!(LoopbackEndpoint::new(address).unwrap().address(), address);

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -1,0 +1,561 @@
+//! Structured JSON envelopes for the V1 WebSocket connection.
+
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
+use serde_json::Error;
+
+use crate::{ProtocolVersion, SupportedVersions, VersionRefusal};
+
+/// Maximum UTF-8 size of any human-readable text carried by V1.
+pub const MAX_WIRE_TEXT_BYTES: usize = 4_096;
+
+/// Bounded human-readable wire text; artifact content cannot inhabit this type.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct WireText(String);
+impl WireText {
+	/// Validate and construct bounded wire text.
+	pub fn new(value: impl Into<String>) -> Result<Self, WireScalarTooLong> {
+		let value = value.into();
+
+		if value.len() > MAX_WIRE_TEXT_BYTES {
+			return Err(WireScalarTooLong { actual_bytes: value.len() });
+		}
+
+		Ok(Self(value))
+	}
+
+	/// Borrow the validated UTF-8 text.
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+impl<'de> Deserialize<'de> for WireText {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let value = String::deserialize(deserializer)?;
+
+		Self::new(value).map_err(D::Error::custom)
+	}
+}
+
+/// A string-backed wire scalar exceeded the V1 byte limit.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WireScalarTooLong {
+	actual_bytes: usize,
+}
+impl Display for WireScalarTooLong {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		write!(
+			formatter,
+			"wire scalar is {} bytes; maximum is {MAX_WIRE_TEXT_BYTES}",
+			self.actual_bytes
+		)
+	}
+}
+
+/// Identity generated for one server lifetime.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct ServerId(String);
+impl ServerId {
+	/// Validate and construct a bounded server identity.
+	pub fn new(value: impl Into<String>) -> Result<Self, WireScalarTooLong> {
+		WireText::new(value).map(|value| Self(value.0))
+	}
+}
+impl<'de> Deserialize<'de> for ServerId {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		WireText::deserialize(deserializer).map(|value| Self(value.0))
+	}
+}
+
+/// Client-generated identity for one command attempt.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct ClientCommandId(String);
+impl ClientCommandId {
+	/// Validate and construct a bounded client command identity.
+	pub fn new(value: impl Into<String>) -> Result<Self, WireScalarTooLong> {
+		WireText::new(value).map(|value| Self(value.0))
+	}
+}
+impl<'de> Deserialize<'de> for ClientCommandId {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		WireText::deserialize(deserializer).map(|value| Self(value.0))
+	}
+}
+
+/// Stable key used to deduplicate a logical command.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct IdempotencyKey(String);
+impl IdempotencyKey {
+	/// Validate and construct a bounded idempotency key.
+	pub fn new(value: impl Into<String>) -> Result<Self, WireScalarTooLong> {
+		WireText::new(value).map(|value| Self(value.0))
+	}
+}
+impl<'de> Deserialize<'de> for IdempotencyKey {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		WireText::deserialize(deserializer).map(|value| Self(value.0))
+	}
+}
+
+/// Stable identity of the entity observed or changed.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct EntityId(String);
+impl EntityId {
+	/// Validate and construct a bounded entity identity.
+	pub fn new(value: impl Into<String>) -> Result<Self, WireScalarTooLong> {
+		WireText::new(value).map(|value| Self(value.0))
+	}
+}
+impl<'de> Deserialize<'de> for EntityId {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		WireText::deserialize(deserializer).map(|value| Self(value.0))
+	}
+}
+
+/// Identity shared by related protocol activity.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct CorrelationId(String);
+impl CorrelationId {
+	/// Validate and construct a bounded correlation identity.
+	pub fn new(value: impl Into<String>) -> Result<Self, WireScalarTooLong> {
+		WireText::new(value).map(|value| Self(value.0))
+	}
+}
+impl<'de> Deserialize<'de> for CorrelationId {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		WireText::deserialize(deserializer).map(|value| Self(value.0))
+	}
+}
+
+/// Identity of the direct causal predecessor.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct CausationId(String);
+impl CausationId {
+	/// Validate and construct a bounded causation identity.
+	pub fn new(value: impl Into<String>) -> Result<Self, WireScalarTooLong> {
+		WireText::new(value).map(|value| Self(value.0))
+	}
+}
+impl<'de> Deserialize<'de> for CausationId {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		WireText::deserialize(deserializer).map(|value| Self(value.0))
+	}
+}
+
+/// Monotonic cursor in one server lifetime.
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct Cursor(pub u64);
+
+/// Optimistic entity revision.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct EntityRevision(pub u64);
+
+/// A client-to-server WebSocket message.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "type", content = "body", rename_all = "snake_case")]
+pub enum ClientMessage {
+	/// Must be the first message on a connection.
+	Hello(ClientHello),
+	/// Execute one typed application command after negotiation.
+	Command(CommandEnvelope),
+}
+
+/// First client message and optional reconnect position.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct ClientHello {
+	/// Client protocol revision.
+	pub version: ProtocolVersion,
+	/// Previously observed server/cursor pair, when reconnecting.
+	pub resume: Option<ResumeCursor>,
+}
+
+/// A cursor is meaningful only for the server lifetime that issued it.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct ResumeCursor {
+	/// Server lifetime that issued the cursor.
+	pub server_id: ServerId,
+	/// Last snapshot or event cursor fully applied by the client.
+	///
+	/// A welcome high-water mark is informational and is not an applied checkpoint.
+	pub cursor: Cursor,
+}
+
+/// A typed command envelope.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct CommandEnvelope {
+	/// Negotiated protocol revision.
+	pub version: ProtocolVersion,
+	/// Identity of this command attempt.
+	pub client_command_id: ClientCommandId,
+	/// Stable logical-command deduplication key.
+	pub idempotency_key: IdempotencyKey,
+	/// Optional optimistic concurrency guard.
+	pub expected_revision: Option<EntityRevision>,
+	/// Identity shared by related activity.
+	pub correlation_id: CorrelationId,
+	/// Optional identity of the direct causal predecessor.
+	pub causation_id: Option<CausationId>,
+	/// Typed application command.
+	pub payload: CommandPayload,
+}
+
+/// Commands available before product-specific application services land.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "name", content = "arguments", rename_all = "snake_case")]
+pub enum CommandPayload {
+	/// Refresh a bounded system-health observation through the common application boundary.
+	RefreshSystemObservation {
+		/// Foundation entity to observe.
+		entity_id: EntityId,
+	},
+}
+
+/// A server-to-client WebSocket message.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "type", content = "body", rename_all = "snake_case")]
+pub enum ServerMessage {
+	/// Successful session negotiation.
+	Welcome(ServerWelcome),
+	/// Bounded current-state projection.
+	Snapshot(SnapshotEnvelope),
+	/// Ordered resumable publication.
+	Event(EventEnvelope),
+	/// Server-lifetime command-attempt receipt.
+	CommandReceipt(CommandReceipt),
+	/// Deterministic command result.
+	CommandResult(CommandResultEnvelope),
+	/// Explicit protocol refusal.
+	Refusal(RefusalEnvelope),
+}
+
+/// Negotiated session metadata.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct ServerWelcome {
+	/// Negotiated protocol revision.
+	pub version: ProtocolVersion,
+	/// Server compatibility window.
+	pub supported: SupportedVersions,
+	/// Identity of this server lifetime.
+	pub server_id: ServerId,
+	/// Informational server high-water mark; never a client resume checkpoint by itself.
+	pub cursor: Cursor,
+	/// Reconnect strategy selected by the server.
+	pub reconnect: ReconnectMode,
+}
+
+/// How the server fulfilled a reconnect request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconnectMode {
+	/// A new session receives a current snapshot.
+	Snapshot,
+	/// A known cursor receives retained deltas.
+	Resume,
+	/// An unknown or stale cursor receives a current snapshot.
+	SnapshotFallback,
+}
+
+/// A bounded current-state snapshot. Large artifacts have no representation here.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct SnapshotEnvelope {
+	/// Negotiated protocol revision.
+	pub version: ProtocolVersion,
+	/// Identity of the server lifetime producing the snapshot.
+	pub server_id: ServerId,
+	/// Cursor represented by the snapshot.
+	pub cursor: Cursor,
+	/// Bounded current-state items.
+	pub items: Vec<SnapshotItem>,
+}
+
+/// Small state shapes allowed in a WebSocket snapshot.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "kind", content = "state", rename_all = "snake_case")]
+pub enum SnapshotItem {
+	/// Bounded system-health state.
+	SystemState {
+		/// Stable identity of the observed system.
+		entity_id: EntityId,
+		/// Revision represented by this state.
+		revision: EntityRevision,
+		/// Small human-readable foundation status.
+		status: WireText,
+	},
+}
+
+/// Logical channels multiplexed on the single connection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Channel {
+	/// Connection and session control.
+	Control,
+	/// Streaming conversation content.
+	ConversationStream,
+	/// Project and work-item state.
+	ProjectWork,
+	/// Run and process activity.
+	RunActivity,
+	/// Agent-authored messages.
+	AgentMessage,
+	/// Automation schedule activity.
+	AutomationFiring,
+	/// Account and credential health.
+	AccountsHealth,
+	/// Server and system health.
+	SystemHealth,
+}
+
+/// One resumable, ordered publication.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct EventEnvelope {
+	/// Negotiated protocol revision.
+	pub version: ProtocolVersion,
+	/// Identity of the publishing server lifetime.
+	pub server_id: ServerId,
+	/// Monotonic publication cursor.
+	pub cursor: Cursor,
+	/// Logical publication channel.
+	pub channel: Channel,
+	/// Stable identity of the affected entity.
+	pub entity_id: EntityId,
+	/// Revision of the affected entity after publication.
+	pub entity_revision: EntityRevision,
+	/// Identity shared by related activity.
+	pub correlation_id: CorrelationId,
+	/// Optional identity of the direct causal predecessor.
+	pub causation_id: Option<CausationId>,
+	/// Typed event data.
+	pub payload: EventPayload,
+}
+
+/// Event payloads available in this foundation slice.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "name", content = "data", rename_all = "snake_case")]
+pub enum EventPayload {
+	/// A foundation system observation was refreshed.
+	SystemObservationRefreshed {
+		/// Small human-readable foundation status.
+		status: WireText,
+	},
+}
+
+/// Server-lifetime receipt disposition for one command attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReceiptDisposition {
+	/// The command was executed for the first time.
+	Executed,
+	/// The command reused a previously recorded logical command.
+	Duplicate,
+	/// The command was refused before application execution.
+	Refused,
+}
+
+/// Server-lifetime receipt returned before deterministic result readback.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct CommandReceipt {
+	/// Negotiated protocol revision.
+	pub version: ProtocolVersion,
+	/// Identity of the receiving server lifetime.
+	pub server_id: ServerId,
+	/// Identity of this command attempt.
+	pub client_command_id: ClientCommandId,
+	/// Stable logical-command deduplication key.
+	pub idempotency_key: IdempotencyKey,
+	/// Whether execution was new or deduplicated.
+	pub disposition: ReceiptDisposition,
+	/// Identity of the command attempt that first used the key.
+	pub original_client_command_id: ClientCommandId,
+}
+
+/// Deterministic command outcome.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct CommandResultEnvelope {
+	/// Negotiated protocol revision.
+	pub version: ProtocolVersion,
+	/// Identity of the receiving server lifetime.
+	pub server_id: ServerId,
+	/// Identity of this command attempt.
+	pub client_command_id: ClientCommandId,
+	/// Stable logical-command deduplication key.
+	pub idempotency_key: IdempotencyKey,
+	/// Success or rejection classification.
+	pub outcome: CommandOutcome,
+	/// Resulting entity revision, when execution succeeded.
+	pub entity_revision: Option<EntityRevision>,
+	/// Typed success result, when execution succeeded.
+	pub payload: Option<ResultPayload>,
+	/// Typed rejection, when execution was rejected.
+	pub error: Option<CommandError>,
+}
+
+/// High-level command outcome classification.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandOutcome {
+	/// Application execution completed successfully.
+	Succeeded,
+	/// Protocol or application guards rejected execution.
+	Rejected,
+}
+
+/// Typed successful command results.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "name", content = "data", rename_all = "snake_case")]
+pub enum ResultPayload {
+	/// A foundation system observation was refreshed.
+	SystemObservationRefreshed {
+		/// Small human-readable foundation status.
+		status: WireText,
+	},
+}
+
+/// Typed command rejection details.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "reason", rename_all = "snake_case")]
+pub enum CommandError {
+	/// The optimistic concurrency guard did not match current state.
+	ExpectedRevisionMismatch {
+		/// Revision supplied by the client.
+		expected: EntityRevision,
+		/// Current entity revision.
+		actual: EntityRevision,
+	},
+	/// An idempotency key was reused for a different logical command.
+	IdempotencyConflict,
+	/// The fixed-lifetime idempotency ledger cannot accept a new key.
+	IdempotencyCapacityExceeded {
+		/// Configured maximum number of retained logical commands.
+		capacity: usize,
+	},
+	/// The application owner required for the command is not enabled.
+	ApplicationUnavailable {
+		/// Bounded operator-facing explanation.
+		message: WireText,
+	},
+}
+
+/// A refusal that leaves no ambiguous application mutation.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct RefusalEnvelope {
+	/// Identity of the refusing server lifetime.
+	pub server_id: ServerId,
+	/// Typed refusal detail.
+	pub refusal: Refusal,
+}
+
+/// Protocol-level refusal that guarantees no application mutation.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "kind", content = "detail", rename_all = "snake_case")]
+pub enum Refusal {
+	/// The requested version falls outside the compatibility window.
+	UnsupportedVersion(VersionRefusal),
+	/// The client violated connection or message ordering rules.
+	ProtocolViolation {
+		/// Bounded explanation of the violated rule.
+		message: WireText,
+	},
+	/// The bounded outbound queue could not accept more work.
+	Backpressure {
+		/// Configured outbound message capacity.
+		queue_capacity: usize,
+	},
+}
+
+/// Serialize a message using the only V1 wire encoding.
+pub fn encode_server_message(message: &ServerMessage) -> Result<String, Error> {
+	serde_json::to_string(message)
+}
+
+/// Parse a client message using the only V1 wire encoding.
+pub fn decode_client_message(message: &str) -> Result<ClientMessage, Error> {
+	serde_json::from_str(message)
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::{
+		CURRENT_VERSION, CausationId, ClientCommandId, CorrelationId, EntityId, IdempotencyKey,
+		MAX_WIRE_TEXT_BYTES, ServerId, WireText,
+		wire::{
+			ClientHello, ClientMessage, CommandEnvelope, CommandPayload, Cursor, EntityRevision,
+			ResumeCursor,
+		},
+	};
+
+	#[test]
+	fn command_wire_shape_is_structured_and_round_trips() {
+		let message = ClientMessage::Command(CommandEnvelope {
+			version: CURRENT_VERSION,
+			client_command_id: ClientCommandId::new("command-1").expect("bounded fixture ID"),
+			idempotency_key: IdempotencyKey::new("dedupe-1").expect("bounded fixture key"),
+			expected_revision: Some(EntityRevision(4)),
+			correlation_id: CorrelationId::new("correlation-1").expect("bounded fixture ID"),
+			causation_id: Some(CausationId::new("cause-1").expect("bounded fixture ID")),
+			payload: CommandPayload::RefreshSystemObservation {
+				entity_id: EntityId::new("system").expect("bounded fixture ID"),
+			},
+		});
+		let encoded = serde_json::to_string(&message).unwrap();
+
+		assert!(encoded.contains("\"type\":\"command\""));
+		assert!(encoded.contains("\"name\":\"refresh_system_observation\""));
+		assert_eq!(serde_json::from_str::<ClientMessage>(&encoded).unwrap(), message);
+	}
+
+	#[test]
+	fn hello_wire_shape_is_a_stable_json_golden() {
+		let message = ClientMessage::Hello(ClientHello {
+			version: CURRENT_VERSION,
+			resume: Some(ResumeCursor {
+				server_id: ServerId::new("server-a").expect("bounded fixture ID"),
+				cursor: Cursor(42),
+			}),
+		});
+
+		assert_eq!(
+			serde_json::to_string(&message).unwrap(),
+			concat!(
+				r#"{"type":"hello","body":{"version":{"major":1,"minor":1},"#,
+				r#""resume":{"server_id":"server-a","cursor":42}}}"#,
+			)
+		);
+	}
+
+	#[test]
+	fn human_readable_wire_text_is_mechanically_bounded() {
+		assert!(WireText::new("x".repeat(MAX_WIRE_TEXT_BYTES)).is_ok());
+		assert!(WireText::new("x".repeat(MAX_WIRE_TEXT_BYTES + 1)).is_err());
+	}
+}

--- a/crates/decodex-runtime/Cargo.toml
+++ b/crates/decodex-runtime/Cargo.toml
@@ -9,7 +9,14 @@ repository.workspace = true
 version.workspace    = true
 
 [dependencies]
+axum             = { workspace = true }
 decodex-codex    = { workspace = true }
 decodex-core     = { workspace = true }
 decodex-postgres = { workspace = true }
 decodex-protocol = { workspace = true }
+futures-util     = { workspace = true }
+serde_json       = { workspace = true }
+tokio            = { workspace = true }
+
+[dev-dependencies]
+tokio-tungstenite = { workspace = true }

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -1,0 +1,62 @@
+//! Application-service seam used by the transport without exposing infrastructure.
+
+use std::future::{self, Future};
+
+use decodex_protocol::{
+	Channel, CommandEnvelope, CommandError, EntityId, EntityRevision, EventPayload, ResultPayload,
+	SnapshotItem, WireText,
+};
+
+/// The only mutation/observation seam reachable from the WebSocket server.
+///
+/// PostgreSQL-backed services can implement this async owner in XY-1267 without moving
+/// command execution into the transport.
+pub trait Application: Send + Sync + 'static {
+	/// Return a bounded small-state snapshot. Artifact bytes are not representable.
+	fn snapshot(&self) -> impl Future<Output = Vec<SnapshotItem>> + Send;
+
+	/// Execute one typed command under the application's revision policy.
+	fn execute<'a>(
+		&'a self,
+		command: &'a CommandEnvelope,
+	) -> impl Future<Output = Result<ApplicationPublication, CommandError>> + Send + 'a;
+}
+
+/// A successful application execution ready for result and event publication.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ApplicationPublication {
+	/// Logical channel for the resulting event.
+	pub channel: Channel,
+	/// Stable identity of the changed entity.
+	pub entity_id: EntityId,
+	/// Entity revision after execution.
+	pub entity_revision: EntityRevision,
+	/// Typed success result returned to the caller.
+	pub result: ResultPayload,
+	/// Typed event published to connected sessions.
+	pub event: EventPayload,
+}
+
+/// Honest application boundary while the PostgreSQL slice is unavailable.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FoundationApplication;
+impl Application for FoundationApplication {
+	fn snapshot(&self) -> impl Future<Output = Vec<SnapshotItem>> + Send {
+		future::ready(vec![SnapshotItem::SystemState {
+			entity_id: EntityId::new("decodexd").expect("foundation entity ID is bounded"),
+			revision: EntityRevision(0),
+			status: WireText::new("product state unavailable until XY-1267")
+				.expect("foundation status is bounded"),
+		}])
+	}
+
+	fn execute<'a>(
+		&'a self,
+		_command: &'a CommandEnvelope,
+	) -> impl Future<Output = Result<ApplicationPublication, CommandError>> + Send + 'a {
+		future::ready(Err(CommandError::ApplicationUnavailable {
+			message: WireText::new("product state unavailable until XY-1267")
+				.expect("foundation message is bounded"),
+		}))
+	}
+}

--- a/crates/decodex-runtime/src/lib.rs
+++ b/crates/decodex-runtime/src/lib.rs
@@ -1,12 +1,18 @@
-//! `decodexd` lifecycle assembly.
-//!
-//! This owner wires the accepted adapters and validates the service boundary. It does
-//! not open sockets, connect to PostgreSQL, or spawn Codex in XY-1265.
+//! `decodexd` lifecycle assembly and the loopback V1 connection owner.
+
+mod application;
+mod websocket;
+
+pub use application::{Application, ApplicationPublication, FoundationApplication};
+pub use decodex_protocol::ServerId;
+pub use websocket::{BoundServer, ProtocolServer, ServerConfig, ServerError};
+
+#[cfg(test)] use tokio_tungstenite as _;
 
 use decodex_codex::CodexAdapter;
 use decodex_core::FoundationStatus;
 use decodex_postgres::PostgresStore;
-use decodex_protocol::{ProtocolVersion, ServiceAnnouncement};
+use decodex_protocol::{CURRENT_VERSION, ServiceAnnouncement};
 
 /// The vNext service assembly selected by the `decodexd` composition root.
 #[derive(Clone, Copy, Debug)]
@@ -15,17 +21,28 @@ pub struct ServiceComposition {
 	codex: CodexAdapter,
 }
 impl ServiceComposition {
-	/// Select the accepted vNext adapters without selecting a transport or endpoint.
+	/// Select the accepted adapters without enabling either unavailable implementation.
 	pub const fn foundation() -> Self {
 		Self { store: PostgresStore::unavailable(), codex: CodexAdapter::unavailable() }
 	}
 
-	/// Validate and describe the assembled service without enabling later slices.
+	/// Validate and describe the assembled service.
 	pub fn boot(self) -> ServiceAnnouncement {
 		ServiceAnnouncement {
-			version: ProtocolVersion::V1,
+			version: CURRENT_VERSION,
 			foundation: FoundationStatus::assemble(&self.store, &self.codex),
 		}
+	}
+
+	/// Compose the sole V1 server root while later adapters remain unavailable.
+	pub fn protocol_server(
+		self,
+		server_id: ServerId,
+		config: ServerConfig,
+	) -> ProtocolServer<FoundationApplication> {
+		let _ = self.boot();
+
+		ProtocolServer::new(server_id, FoundationApplication, config)
 	}
 }
 
@@ -33,13 +50,13 @@ impl ServiceComposition {
 mod tests {
 	use crate::ServiceComposition;
 	use decodex_core::Availability;
-	use decodex_protocol::ProtocolVersion;
+	use decodex_protocol::CURRENT_VERSION;
 
 	#[test]
 	fn service_boot_wires_v1_without_enabling_unimplemented_adapters() {
 		let announcement = ServiceComposition::foundation().boot();
 
-		assert_eq!(announcement.version, ProtocolVersion::V1);
+		assert_eq!(announcement.version, CURRENT_VERSION);
 		assert_eq!(
 			announcement.foundation.product_state(),
 			Availability::Unavailable { reason: decodex_postgres::NOT_IMPLEMENTED }

--- a/crates/decodex-runtime/src/websocket.rs
+++ b/crates/decodex-runtime/src/websocket.rs
@@ -1,0 +1,800 @@
+//! Maintained Axum WebSocket transport, resumable publication, and session policy.
+
+use std::{
+	collections::{HashMap, VecDeque},
+	fmt::{Display, Formatter},
+	net::SocketAddr,
+	sync::{
+		Arc,
+		atomic::{AtomicU64, Ordering},
+	},
+	time::Duration,
+};
+
+use axum::{
+	Router,
+	extract::{
+		State,
+		ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade},
+	},
+	response::Response,
+	routing,
+};
+use futures_util::{
+	SinkExt as _, StreamExt as _,
+	stream::{SplitSink, SplitStream},
+};
+use tokio::{
+	net::TcpListener,
+	sync::{Mutex, mpsc, mpsc::Receiver, oneshot},
+	task::{JoinError, JoinHandle},
+	time,
+};
+
+use crate::{Application, ApplicationPublication};
+use decodex_protocol::{
+	self, CausationId, ClientCommandId, ClientHello, ClientMessage, CommandEnvelope, CommandError,
+	CommandOutcome, CommandReceipt, CommandResultEnvelope, CorrelationId, Cursor,
+	EndpointPolicyError, EventEnvelope, IdempotencyKey, LoopbackEndpoint, ProtocolVersion,
+	ReceiptDisposition, ReconnectMode, Refusal, RefusalEnvelope, ResumeCursor, ServerId,
+	ServerMessage, ServerWelcome, SnapshotEnvelope, SnapshotItem, SupportedVersions, WireText,
+};
+
+const WS_PATH: &str = "/v1/ws";
+
+/// Bounded transport settings. None of these enable remote binding.
+#[derive(Clone, Debug)]
+pub struct ServerConfig {
+	/// Maximum number of events retained for cursor resume.
+	pub replay_capacity: usize,
+	/// Maximum number of pending messages for one client.
+	pub outbound_queue_capacity: usize,
+	/// Maximum number of logical commands retained for lifetime deduplication.
+	pub receipt_capacity: usize,
+	/// Maximum number of small-state items in one snapshot.
+	pub maximum_snapshot_items: usize,
+	/// Maximum accepted UTF-8 message size.
+	pub maximum_message_bytes: usize,
+	/// Time allowed for the mandatory first hello message.
+	pub hello_timeout: Duration,
+	/// Time allowed for one WebSocket write.
+	pub write_timeout: Duration,
+}
+impl Default for ServerConfig {
+	fn default() -> Self {
+		Self {
+			replay_capacity: 1_024,
+			outbound_queue_capacity: 64,
+			receipt_capacity: 4_096,
+			maximum_snapshot_items: 1_024,
+			maximum_message_bytes: 256 * 1_024,
+			hello_timeout: Duration::from_secs(5),
+			write_timeout: Duration::from_secs(5),
+		}
+	}
+}
+
+/// A running loopback server and its graceful-shutdown handle.
+pub struct BoundServer {
+	address: SocketAddr,
+	shutdown_sender: Option<oneshot::Sender<()>>,
+	task: Option<JoinHandle<Result<(), ServerError>>>,
+}
+impl BoundServer {
+	/// Return the operating-system-selected listening address.
+	pub const fn address(&self) -> SocketAddr {
+		self.address
+	}
+
+	/// Request graceful shutdown and wait for the server task.
+	pub async fn shutdown(mut self) -> Result<(), ServerError> {
+		if let Some(sender) = self.shutdown_sender.take() {
+			let _ = sender.send(());
+		}
+
+		self.wait_task().await?;
+
+		Ok(())
+	}
+
+	async fn wait(mut self) -> Result<(), ServerError> {
+		self.wait_task().await
+	}
+
+	async fn wait_task(&mut self) -> Result<(), ServerError> {
+		let task = self.task.take().expect("bound server task already consumed");
+
+		task.await.map_err(ServerError::Join)??;
+
+		Ok(())
+	}
+}
+
+impl Drop for BoundServer {
+	fn drop(&mut self) {
+		if let Some(sender) = self.shutdown_sender.take() {
+			let _ = sender.send(());
+		}
+	}
+}
+
+/// A loopback WebSocket server over one application-service implementation.
+pub struct ProtocolServer<A>
+where
+	A: Application,
+{
+	inner: Arc<ServerInner<A>>,
+}
+impl<A> ProtocolServer<A>
+where
+	A: Application,
+{
+	/// Build a server with one lifetime identity and application owner.
+	pub fn new(server_id: ServerId, application: A, config: ServerConfig) -> Self {
+		assert!(config.replay_capacity > 0, "replay capacity must be non-zero");
+		assert!(config.outbound_queue_capacity > 0, "outbound queue capacity must be non-zero");
+		assert!(config.receipt_capacity > 0, "receipt capacity must be non-zero");
+
+		Self {
+			inner: Arc::new(ServerInner {
+				server_id,
+				application,
+				config,
+				connection_ids: AtomicU64::new(1),
+				state: Mutex::new(PublicationState::default()),
+			}),
+		}
+	}
+
+	/// Bind and spawn the service after validating the address as loopback.
+	pub async fn bind(self, address: SocketAddr) -> Result<BoundServer, ServerError> {
+		let endpoint = LoopbackEndpoint::new(address).map_err(ServerError::EndpointPolicy)?;
+		let listener = TcpListener::bind(endpoint.address()).await.map_err(ServerError::Io)?;
+		let local_address = listener.local_addr().map_err(ServerError::Io)?;
+		let router = Router::new().route(WS_PATH, routing::any(upgrade::<A>)).with_state(self);
+		let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+		let task = tokio::spawn(async move {
+			axum::serve(listener, router)
+				.with_graceful_shutdown(async {
+					let _ = shutdown_receiver.await;
+				})
+				.await
+				.map_err(ServerError::Io)
+		});
+
+		Ok(BoundServer {
+			address: local_address,
+			shutdown_sender: Some(shutdown_sender),
+			task: Some(task),
+		})
+	}
+
+	/// Run the service until it is externally stopped.
+	pub async fn run(self, address: SocketAddr) -> Result<(), ServerError> {
+		self.bind(address).await?.wait().await
+	}
+}
+
+impl<A> ProtocolServer<A>
+where
+	A: Application,
+{
+	async fn handle_connection(&self, mut socket: WebSocket) {
+		let Some(hello) = self.receive_hello(&mut socket).await else {
+			return;
+		};
+		let negotiated = match hello.version.negotiate() {
+			Ok(version) => version,
+			Err(refusal) => {
+				let _ = self
+					.send_direct(
+						&mut socket,
+						ServerMessage::Refusal(RefusalEnvelope {
+							server_id: self.inner.server_id.clone(),
+							refusal: Refusal::UnsupportedVersion(refusal),
+						}),
+					)
+					.await;
+
+				return;
+			},
+		};
+		let connection_id = self.inner.connection_ids.fetch_add(1, Ordering::Relaxed);
+		let (sender, receiver) = mpsc::channel(self.inner.config.outbound_queue_capacity);
+		let initial = match self.prepare_session(connection_id, sender, hello, negotiated).await {
+			Ok(messages) => messages,
+			Err(refusal) => {
+				let _ = self
+					.send_direct(
+						&mut socket,
+						ServerMessage::Refusal(RefusalEnvelope {
+							server_id: self.inner.server_id.clone(),
+							refusal,
+						}),
+					)
+					.await;
+
+				return;
+			},
+		};
+
+		for message in initial {
+			if !self.send_direct(&mut socket, message).await {
+				self.remove_subscriber(connection_id).await;
+
+				return;
+			}
+		}
+
+		let (socket_sender, socket_receiver) = socket.split();
+		let reader = self.read_commands(socket_receiver, connection_id, negotiated);
+		let writer = self.write_messages(socket_sender, receiver);
+
+		tokio::pin!(reader, writer);
+
+		tokio::select! {
+			() = &mut writer => {},
+			backpressure = &mut reader => {
+				if backpressure {
+					writer.await;
+				}
+			},
+		}
+
+		self.remove_subscriber(connection_id).await;
+	}
+
+	async fn receive_hello(&self, socket: &mut WebSocket) -> Option<ClientHello> {
+		let received =
+			time::timeout(self.inner.config.hello_timeout, socket.recv()).await.ok()??;
+		let message = received.ok()?;
+		let Message::Text(text) = message else {
+			let refusal =
+				protocol_refusal(&self.inner.server_id, "first message must be text hello");
+			let _ = self.send_direct(socket, refusal).await;
+
+			return None;
+		};
+
+		match decodex_protocol::decode_client_message(&text) {
+			Ok(ClientMessage::Hello(hello)) => Some(hello),
+			Ok(ClientMessage::Command(_)) => {
+				let refusal =
+					protocol_refusal(&self.inner.server_id, "hello is required before command");
+				let _ = self.send_direct(socket, refusal).await;
+
+				None
+			},
+			Err(_) => {
+				let refusal = protocol_refusal(
+					&self.inner.server_id,
+					"message is not a valid client envelope",
+				);
+				let _ = self.send_direct(socket, refusal).await;
+
+				None
+			},
+		}
+	}
+
+	async fn prepare_session(
+		&self,
+		connection_id: u64,
+		sender: mpsc::Sender<ServerMessage>,
+		hello: ClientHello,
+		negotiated: ProtocolVersion,
+	) -> Result<Vec<ServerMessage>, Refusal> {
+		let state = self.inner.state.lock().await;
+		let snapshot_items = self.inner.application.snapshot().await;
+		let mut state = state;
+
+		if snapshot_items.len() > self.inner.config.maximum_snapshot_items {
+			return Err(Refusal::ProtocolViolation {
+				message: bounded_text("application snapshot exceeds the bounded item limit"),
+			});
+		}
+
+		let (reconnect, mut messages) =
+			self.reconnect_messages(&state, hello.resume.as_ref(), negotiated, snapshot_items);
+
+		messages.insert(
+			0,
+			ServerMessage::Welcome(ServerWelcome {
+				version: negotiated,
+				supported: SupportedVersions::current(),
+				server_id: self.inner.server_id.clone(),
+				cursor: state.cursor,
+				reconnect,
+			}),
+		);
+		state.subscribers.insert(connection_id, Subscriber { sender, version: negotiated });
+
+		Ok(messages)
+	}
+
+	fn reconnect_messages(
+		&self,
+		state: &PublicationState,
+		resume: Option<&ResumeCursor>,
+		version: ProtocolVersion,
+		snapshot_items: Vec<SnapshotItem>,
+	) -> (ReconnectMode, Vec<ServerMessage>) {
+		let can_resume = resume.is_some_and(|resume| {
+			resume.server_id == self.inner.server_id
+				&& resume.cursor <= state.cursor
+				&& state
+					.events
+					.front()
+					.is_none_or(|oldest| resume.cursor.0.saturating_add(1) >= oldest.cursor.0)
+		});
+
+		if can_resume {
+			let cursor = resume.expect("checked above").cursor;
+			let deltas = state
+				.events
+				.iter()
+				.filter(|event| event.cursor > cursor)
+				.cloned()
+				.map(|mut event| {
+					event.version = version;
+
+					ServerMessage::Event(event)
+				})
+				.collect();
+
+			return (ReconnectMode::Resume, deltas);
+		}
+
+		let reconnect = if resume.is_some() {
+			ReconnectMode::SnapshotFallback
+		} else {
+			ReconnectMode::Snapshot
+		};
+
+		(
+			reconnect,
+			vec![ServerMessage::Snapshot(SnapshotEnvelope {
+				version,
+				server_id: self.inner.server_id.clone(),
+				cursor: state.cursor,
+				items: snapshot_items,
+			})],
+		)
+	}
+
+	async fn read_commands(
+		&self,
+		mut receiver: SplitStream<WebSocket>,
+		connection_id: u64,
+		negotiated: ProtocolVersion,
+	) -> bool {
+		while let Some(Ok(message)) = receiver.next().await {
+			let Message::Text(text) = message else {
+				if matches!(message, Message::Close(_)) {
+					return false;
+				}
+
+				continue;
+			};
+			let Ok(client_message) = decodex_protocol::decode_client_message(&text) else {
+				if !self
+					.enqueue(
+						connection_id,
+						protocol_refusal(
+							&self.inner.server_id,
+							"message is not a valid client envelope",
+						),
+					)
+					.await
+				{
+					return true;
+				}
+
+				continue;
+			};
+
+			match client_message {
+				ClientMessage::Hello(_) => {
+					if !self
+						.enqueue(
+							connection_id,
+							protocol_refusal(&self.inner.server_id, "hello may be sent only once"),
+						)
+						.await
+					{
+						return true;
+					}
+				},
+				ClientMessage::Command(command) => {
+					if command.version != negotiated {
+						if !self
+							.enqueue(
+								connection_id,
+								protocol_refusal(
+									&self.inner.server_id,
+									"command version differs from negotiated version",
+								),
+							)
+							.await
+						{
+							return true;
+						}
+
+						continue;
+					}
+					if !self.execute_command(connection_id, command, negotiated).await {
+						return true;
+					}
+				},
+			}
+		}
+
+		false
+	}
+
+	async fn execute_command(
+		&self,
+		connection_id: u64,
+		command: CommandEnvelope,
+		version: ProtocolVersion,
+	) -> bool {
+		let server = self.clone();
+		let task = tokio::spawn(async move {
+			server.execute_command_owned(connection_id, command, version).await
+		});
+
+		task.await.is_ok_and(|delivered| delivered)
+	}
+
+	async fn execute_command_owned(
+		&self,
+		connection_id: u64,
+		command: CommandEnvelope,
+		version: ProtocolVersion,
+	) -> bool {
+		let fingerprint = serde_json::to_vec(&(&command.expected_revision, &command.payload))
+			.expect("typed command serialization cannot fail");
+		let mut state = self.inner.state.lock().await;
+
+		if let Some(stored) = state.receipts.get(&command.idempotency_key).cloned() {
+			let receipt = CommandReceipt {
+				version,
+				server_id: self.inner.server_id.clone(),
+				client_command_id: command.client_command_id.clone(),
+				idempotency_key: command.idempotency_key.clone(),
+				disposition: ReceiptDisposition::Duplicate,
+				original_client_command_id: stored.original_client_command_id,
+			};
+			let mut result = stored.result;
+
+			result.version = version;
+			result.client_command_id = command.client_command_id;
+
+			if stored.fingerprint != fingerprint {
+				result.outcome = CommandOutcome::Rejected;
+				result.entity_revision = None;
+				result.payload = None;
+				result.error = Some(CommandError::IdempotencyConflict);
+			}
+
+			return enqueue_locked(
+				&mut state,
+				connection_id,
+				ServerMessage::CommandReceipt(receipt),
+			) && enqueue_locked(
+				&mut state,
+				connection_id,
+				ServerMessage::CommandResult(result),
+			);
+		}
+
+		if state.receipts.len() >= self.inner.config.receipt_capacity {
+			let receipt = CommandReceipt {
+				version,
+				server_id: self.inner.server_id.clone(),
+				client_command_id: command.client_command_id.clone(),
+				idempotency_key: command.idempotency_key.clone(),
+				disposition: ReceiptDisposition::Refused,
+				original_client_command_id: command.client_command_id.clone(),
+			};
+			let result = CommandResultEnvelope {
+				version,
+				server_id: self.inner.server_id.clone(),
+				client_command_id: command.client_command_id,
+				idempotency_key: command.idempotency_key,
+				outcome: CommandOutcome::Rejected,
+				entity_revision: None,
+				payload: None,
+				error: Some(CommandError::IdempotencyCapacityExceeded {
+					capacity: self.inner.config.receipt_capacity,
+				}),
+			};
+
+			return enqueue_locked(
+				&mut state,
+				connection_id,
+				ServerMessage::CommandReceipt(receipt),
+			) && enqueue_locked(
+				&mut state,
+				connection_id,
+				ServerMessage::CommandResult(result),
+			);
+		}
+
+		let correlation = (command.correlation_id.clone(), command.causation_id.clone());
+		let execution = self.inner.application.execute(&command).await;
+		let (result, publication) =
+			result_from_execution(&self.inner.server_id, &command, version, execution);
+		let stored = StoredCommand {
+			fingerprint,
+			original_client_command_id: command.client_command_id.clone(),
+			result: result.clone(),
+		};
+
+		state.receipts.insert(command.idempotency_key.clone(), stored);
+
+		let receipt = CommandReceipt {
+			version,
+			server_id: self.inner.server_id.clone(),
+			client_command_id: command.client_command_id,
+			idempotency_key: command.idempotency_key,
+			disposition: ReceiptDisposition::Executed,
+			original_client_command_id: result.client_command_id.clone(),
+		};
+		let delivered =
+			enqueue_locked(&mut state, connection_id, ServerMessage::CommandReceipt(receipt))
+				&& enqueue_locked(&mut state, connection_id, ServerMessage::CommandResult(result));
+
+		if let Some(publication) = publication {
+			self.publish_locked(&mut state, version, correlation, publication);
+		}
+
+		delivered && state.subscribers.contains_key(&connection_id)
+	}
+
+	fn publish_locked(
+		&self,
+		state: &mut PublicationState,
+		version: ProtocolVersion,
+		correlation: (CorrelationId, Option<CausationId>),
+		publication: ApplicationPublication,
+	) {
+		state.cursor.0 = state.cursor.0.checked_add(1).expect("protocol cursor exhausted");
+
+		let event = EventEnvelope {
+			version,
+			server_id: self.inner.server_id.clone(),
+			cursor: state.cursor,
+			channel: publication.channel,
+			entity_id: publication.entity_id,
+			entity_revision: publication.entity_revision,
+			correlation_id: correlation.0,
+			causation_id: correlation.1,
+			payload: publication.event,
+		};
+
+		state.events.push_back(event.clone());
+
+		while state.events.len() > self.inner.config.replay_capacity {
+			state.events.pop_front();
+		}
+
+		state.subscribers.retain(|_, subscriber| {
+			let mut event = event.clone();
+
+			event.version = subscriber.version;
+
+			subscriber.sender.try_send(ServerMessage::Event(event)).is_ok()
+		});
+	}
+
+	async fn enqueue(&self, connection_id: u64, message: ServerMessage) -> bool {
+		let mut state = self.inner.state.lock().await;
+
+		enqueue_locked(&mut state, connection_id, message)
+	}
+
+	async fn remove_subscriber(&self, connection_id: u64) {
+		self.inner.state.lock().await.subscribers.remove(&connection_id);
+	}
+
+	async fn write_messages(
+		&self,
+		mut sender: SplitSink<WebSocket, Message>,
+		mut receiver: Receiver<ServerMessage>,
+	) {
+		while let Some(message) = receiver.recv().await {
+			let Ok(encoded) = decodex_protocol::encode_server_message(&message) else {
+				return;
+			};
+
+			if encoded.len() > self.inner.config.maximum_message_bytes {
+				self.send_split_close(&mut sender, 1_009, "outbound message exceeds bounded size")
+					.await;
+
+				return;
+			}
+
+			let write_result = time::timeout(
+				self.inner.config.write_timeout,
+				sender.send(Message::Text(encoded.into())),
+			)
+			.await;
+
+			if !matches!(write_result, Ok(Ok(()))) {
+				return;
+			}
+		}
+
+		self.send_split_close(&mut sender, 1_013, "bounded outbound queue exceeded").await;
+	}
+
+	async fn send_direct(&self, socket: &mut WebSocket, message: ServerMessage) -> bool {
+		let Ok(encoded) = decodex_protocol::encode_server_message(&message) else {
+			return false;
+		};
+
+		if encoded.len() > self.inner.config.maximum_message_bytes {
+			self.send_socket_close(socket, 1_009, "outbound message exceeds bounded size").await;
+
+			return false;
+		}
+
+		time::timeout(self.inner.config.write_timeout, socket.send(Message::Text(encoded.into())))
+			.await
+			.is_ok_and(|result| result.is_ok())
+	}
+
+	async fn send_split_close(
+		&self,
+		sender: &mut SplitSink<WebSocket, Message>,
+		code: u16,
+		reason: &'static str,
+	) {
+		let close = sender.send(Message::Close(Some(CloseFrame { code, reason: reason.into() })));
+		let _ = time::timeout(self.inner.config.write_timeout, close).await;
+	}
+
+	async fn send_socket_close(&self, socket: &mut WebSocket, code: u16, reason: &'static str) {
+		let close = socket.send(Message::Close(Some(CloseFrame { code, reason: reason.into() })));
+		let _ = time::timeout(self.inner.config.write_timeout, close).await;
+	}
+}
+
+impl<A> Clone for ProtocolServer<A>
+where
+	A: Application,
+{
+	fn clone(&self) -> Self {
+		Self { inner: Arc::clone(&self.inner) }
+	}
+}
+
+struct ServerInner<A>
+where
+	A: Application,
+{
+	server_id: ServerId,
+	application: A,
+	config: ServerConfig,
+	connection_ids: AtomicU64,
+	state: Mutex<PublicationState>,
+}
+
+#[derive(Default)]
+struct PublicationState {
+	cursor: Cursor,
+	events: VecDeque<EventEnvelope>,
+	receipts: HashMap<IdempotencyKey, StoredCommand>,
+	subscribers: HashMap<u64, Subscriber>,
+}
+
+struct Subscriber {
+	sender: mpsc::Sender<ServerMessage>,
+	version: ProtocolVersion,
+}
+
+#[derive(Clone)]
+struct StoredCommand {
+	fingerprint: Vec<u8>,
+	original_client_command_id: ClientCommandId,
+	result: CommandResultEnvelope,
+}
+
+/// Failure to validate, bind, run, or join the loopback server.
+#[derive(Debug)]
+pub enum ServerError {
+	/// The requested listener was outside the loopback boundary.
+	EndpointPolicy(EndpointPolicyError),
+	/// Socket or serving I/O failed.
+	Io(std::io::Error),
+	/// The spawned server task failed to join.
+	Join(JoinError),
+}
+impl std::error::Error for ServerError {}
+
+impl Display for ServerError {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::EndpointPolicy(error) => Display::fmt(error, formatter),
+			Self::Io(error) => write!(formatter, "loopback server I/O failed: {error}"),
+			Self::Join(error) => write!(formatter, "loopback server task failed: {error}"),
+		}
+	}
+}
+
+fn result_from_execution(
+	server_id: &ServerId,
+	command: &CommandEnvelope,
+	version: ProtocolVersion,
+	execution: Result<ApplicationPublication, CommandError>,
+) -> (CommandResultEnvelope, Option<ApplicationPublication>) {
+	match execution {
+		Ok(publication) => (
+			CommandResultEnvelope {
+				version,
+				server_id: server_id.clone(),
+				client_command_id: command.client_command_id.clone(),
+				idempotency_key: command.idempotency_key.clone(),
+				outcome: CommandOutcome::Succeeded,
+				entity_revision: Some(publication.entity_revision),
+				payload: Some(publication.result.clone()),
+				error: None,
+			},
+			Some(publication),
+		),
+		Err(error) => (
+			CommandResultEnvelope {
+				version,
+				server_id: server_id.clone(),
+				client_command_id: command.client_command_id.clone(),
+				idempotency_key: command.idempotency_key.clone(),
+				outcome: CommandOutcome::Rejected,
+				entity_revision: None,
+				payload: None,
+				error: Some(error),
+			},
+			None,
+		),
+	}
+}
+
+fn enqueue_locked(
+	state: &mut PublicationState,
+	connection_id: u64,
+	message: ServerMessage,
+) -> bool {
+	let Some(subscriber) = state.subscribers.get(&connection_id) else {
+		return false;
+	};
+
+	if subscriber.sender.try_send(message).is_ok() {
+		true
+	} else {
+		state.subscribers.remove(&connection_id);
+
+		false
+	}
+}
+
+fn protocol_refusal(server_id: &ServerId, message: &str) -> ServerMessage {
+	ServerMessage::Refusal(RefusalEnvelope {
+		server_id: server_id.clone(),
+		refusal: Refusal::ProtocolViolation { message: bounded_text(message) },
+	})
+}
+
+fn bounded_text(message: &str) -> WireText {
+	WireText::new(message).expect("internal protocol message is bounded")
+}
+
+async fn upgrade<A>(ws: WebSocketUpgrade, State(server): State<ProtocolServer<A>>) -> Response
+where
+	A: Application,
+{
+	let maximum = server.inner.config.maximum_message_bytes;
+
+	ws.max_message_size(maximum)
+		.max_frame_size(maximum)
+		.on_upgrade(move |socket| async move { server.handle_connection(socket).await })
+}

--- a/crates/decodex-runtime/tests/websocket_protocol.rs
+++ b/crates/decodex-runtime/tests/websocket_protocol.rs
@@ -1,0 +1,752 @@
+//! End-to-end loopback WebSocket protocol acceptance tests.
+#![allow(unused_crate_dependencies)]
+
+use std::{
+	future::{self, Future},
+	net::{Ipv4Addr, SocketAddr},
+	sync::{Arc, Mutex},
+	time::Duration,
+};
+
+use futures_util::{SinkExt as _, StreamExt as _};
+use tokio::{net::TcpStream, time};
+use tokio_tungstenite::{self, MaybeTlsStream, WebSocketStream, tungstenite::Message};
+
+use decodex_protocol::{
+	CURRENT_VERSION, CausationId, Channel, ClientCommandId, ClientHello, ClientMessage,
+	CommandEnvelope, CommandError, CommandPayload, CorrelationId, Cursor, EntityId, EntityRevision,
+	EventPayload, IdempotencyKey, PREVIOUS_MINOR_VERSION, ProtocolVersion, ReceiptDisposition,
+	ReconnectMode, Refusal, ResultPayload, ResumeCursor, ServerId, ServerMessage, SnapshotItem,
+	VersionRefusal, WireText,
+};
+use decodex_runtime::{Application, ApplicationPublication, ProtocolServer, ServerConfig};
+
+type Client = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+#[derive(Clone, Default)]
+struct FixtureApplication {
+	state: Arc<Mutex<FixtureState>>,
+	execution_delay: Duration,
+}
+impl FixtureApplication {
+	fn executions(&self) -> u64 {
+		self.state.lock().expect("test state mutex poisoned").executions
+	}
+
+	fn with_status(status: WireText) -> Self {
+		Self {
+			state: Arc::new(Mutex::new(FixtureState { status, ..FixtureState::default() })),
+			..Self::default()
+		}
+	}
+
+	fn with_delay(execution_delay: Duration) -> Self {
+		Self { execution_delay, ..Self::default() }
+	}
+}
+
+impl Application for FixtureApplication {
+	fn snapshot(&self) -> impl Future<Output = Vec<SnapshotItem>> + Send {
+		let state = self.state.lock().expect("test state mutex poisoned");
+
+		future::ready(vec![SnapshotItem::SystemState {
+			entity_id: EntityId::new("fixture-system").expect("bounded fixture ID"),
+			revision: EntityRevision(state.revision),
+			status: state.status.clone(),
+		}])
+	}
+
+	async fn execute<'a>(
+		&'a self,
+		command: &'a CommandEnvelope,
+	) -> Result<ApplicationPublication, CommandError> {
+		if !self.execution_delay.is_zero() {
+			time::sleep(self.execution_delay).await;
+		}
+
+		let CommandPayload::RefreshSystemObservation { entity_id } = &command.payload;
+		let mut state = self.state.lock().expect("test state mutex poisoned");
+
+		if let Some(expected) = command.expected_revision
+			&& expected != EntityRevision(state.revision)
+		{
+			return Err(CommandError::ExpectedRevisionMismatch {
+				expected,
+				actual: EntityRevision(state.revision),
+			});
+		}
+
+		state.revision += 1;
+		state.executions += 1;
+		state.status = WireText::new(format!("observation-{}", state.executions))
+			.expect("fixture status is bounded");
+
+		Ok(ApplicationPublication {
+			channel: Channel::SystemHealth,
+			entity_id: entity_id.clone(),
+			entity_revision: EntityRevision(state.revision),
+			result: ResultPayload::SystemObservationRefreshed { status: state.status.clone() },
+			event: EventPayload::SystemObservationRefreshed { status: state.status.clone() },
+		})
+	}
+}
+
+struct FixtureState {
+	revision: u64,
+	executions: u64,
+	status: WireText,
+}
+impl Default for FixtureState {
+	fn default() -> Self {
+		Self {
+			revision: 0,
+			executions: 0,
+			status: WireText::new("").expect("empty fixture status is bounded"),
+		}
+	}
+}
+
+fn server(
+	id: &str,
+	application: FixtureApplication,
+	config: ServerConfig,
+) -> ProtocolServer<FixtureApplication> {
+	ProtocolServer::new(ServerId::new(id).expect("bounded fixture server ID"), application, config)
+}
+
+fn command(version: ProtocolVersion, number: u64, key: &str) -> ClientMessage {
+	ClientMessage::Command(CommandEnvelope {
+		version,
+		client_command_id: ClientCommandId::new(format!("command-{number}"))
+			.expect("bounded fixture command ID"),
+		idempotency_key: IdempotencyKey::new(key).expect("bounded fixture key"),
+		expected_revision: None,
+		correlation_id: CorrelationId::new(format!("correlation-{number}"))
+			.expect("bounded fixture correlation ID"),
+		causation_id: Some(
+			CausationId::new(format!("cause-{number}")).expect("bounded fixture causation ID"),
+		),
+		payload: CommandPayload::RefreshSystemObservation {
+			entity_id: EntityId::new("fixture-system").expect("bounded fixture entity ID"),
+		},
+	})
+}
+
+async fn connect(address: SocketAddr, version: ProtocolVersion) -> Client {
+	let (mut client, _) = tokio_tungstenite::connect_async(format!("ws://{address}/v1/ws"))
+		.await
+		.expect("connect real WebSocket client");
+
+	send(&mut client, ClientMessage::Hello(ClientHello { version, resume: None })).await;
+
+	client
+}
+
+async fn reconnect(address: SocketAddr, version: ProtocolVersion, cursor: ResumeCursor) -> Client {
+	let (mut client, _) = tokio_tungstenite::connect_async(format!("ws://{address}/v1/ws"))
+		.await
+		.expect("connect real slow WebSocket client");
+
+	send(&mut client, ClientMessage::Hello(ClientHello { version, resume: Some(cursor) })).await;
+
+	client
+}
+
+async fn send(client: &mut Client, message: ClientMessage) {
+	let encoded = serde_json::to_string(&message).expect("serialize client message");
+
+	client.send(Message::Text(encoded.into())).await.expect("send client message");
+}
+
+async fn receive(client: &mut Client) -> ServerMessage {
+	let message = time::timeout(Duration::from_secs(3), client.next())
+		.await
+		.expect("server response timed out")
+		.expect("server closed before response")
+		.expect("websocket response failed");
+	let Message::Text(text) = message else {
+		panic!("expected text response, got {message:?}");
+	};
+
+	serde_json::from_str(&text).expect("decode typed server message")
+}
+
+async fn receive_initial(client: &mut Client) -> (ServerId, Cursor, ReconnectMode) {
+	let ServerMessage::Welcome(welcome) = receive(client).await else {
+		panic!("expected welcome");
+	};
+
+	assert!(matches!(receive(client).await, ServerMessage::Snapshot(_)));
+
+	(welcome.server_id, welcome.cursor, welcome.reconnect)
+}
+
+async fn execute_and_receive_event(
+	client: &mut Client,
+	version: ProtocolVersion,
+	number: u64,
+) -> Cursor {
+	send(client, command(version, number, &format!("key-{number}"))).await;
+
+	assert!(matches!(receive(client).await, ServerMessage::CommandReceipt(_)));
+	assert!(matches!(receive(client).await, ServerMessage::CommandResult(_)));
+
+	let ServerMessage::Event(event) = receive(client).await else {
+		panic!("expected event");
+	};
+
+	assert_eq!(event.version, version);
+	assert_eq!(event.channel, Channel::SystemHealth);
+	assert_eq!(
+		event.entity_id,
+		EntityId::new("fixture-system").expect("bounded fixture entity ID")
+	);
+	assert_eq!(event.entity_revision, EntityRevision(number));
+	assert_eq!(
+		event.correlation_id,
+		CorrelationId::new(format!("correlation-{number}"))
+			.expect("bounded fixture correlation ID")
+	);
+	assert_eq!(
+		event.causation_id,
+		Some(CausationId::new(format!("cause-{number}")).expect("bounded fixture causation ID"))
+	);
+
+	event.cursor
+}
+
+#[tokio::test]
+async fn current_previous_minor_and_exact_major_refusal_use_real_websockets() {
+	let bound = server("version-server", FixtureApplication::default(), ServerConfig::default())
+		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+		.await
+		.unwrap();
+
+	for (index, version) in [PREVIOUS_MINOR_VERSION, CURRENT_VERSION].into_iter().enumerate() {
+		let mut client = connect(bound.address(), version).await;
+		let ServerMessage::Welcome(welcome) = receive(&mut client).await else {
+			panic!("expected welcome");
+		};
+
+		assert_eq!(welcome.version, version);
+		assert!(matches!(receive(&mut client).await, ServerMessage::Snapshot(_)));
+
+		execute_and_receive_event(&mut client, version, index as u64 + 1).await;
+
+		client.close(None).await.unwrap();
+	}
+
+	let mut client = connect(bound.address(), ProtocolVersion { major: 2, minor: 0 }).await;
+	let ServerMessage::Refusal(refusal) = receive(&mut client).await else {
+		panic!("expected version refusal");
+	};
+
+	assert!(matches!(
+		refusal.refusal,
+		Refusal::UnsupportedVersion(VersionRefusal::MajorMismatch { .. })
+	));
+
+	drop(client);
+
+	let mut client = connect(bound.address(), ProtocolVersion { major: 1, minor: 9 }).await;
+	let ServerMessage::Refusal(refusal) = receive(&mut client).await else {
+		panic!("expected minor-version refusal");
+	};
+
+	assert!(matches!(
+		refusal.refusal,
+		Refusal::UnsupportedVersion(VersionRefusal::UnsupportedMinor { .. })
+	));
+
+	drop(client);
+
+	bound.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn duplicate_command_returns_the_original_receipt_and_mutates_once() {
+	let application = FixtureApplication::default();
+	let bound = server("idempotency-server", application.clone(), ServerConfig::default())
+		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+		.await
+		.unwrap();
+	let mut client = connect(bound.address(), CURRENT_VERSION).await;
+
+	receive_initial(&mut client).await;
+	send(&mut client, command(CURRENT_VERSION, 1, "same-key")).await;
+
+	let ServerMessage::CommandReceipt(first) = receive(&mut client).await else {
+		panic!("expected receipt");
+	};
+
+	assert_eq!(first.disposition, ReceiptDisposition::Executed);
+
+	let first_result = receive(&mut client).await;
+	let first_event = receive(&mut client).await;
+
+	assert!(matches!(first_result, ServerMessage::CommandResult(_)));
+
+	let ServerMessage::Event(first_event) = first_event else {
+		panic!("expected first event");
+	};
+	let server_id = first_event.server_id.clone();
+	let cursor = first_event.cursor;
+
+	drop(client);
+
+	let mut client =
+		reconnect(bound.address(), CURRENT_VERSION, ResumeCursor { server_id, cursor }).await;
+	let ServerMessage::Welcome(welcome) = receive(&mut client).await else {
+		panic!("expected reconnect welcome");
+	};
+
+	assert_eq!(welcome.reconnect, ReconnectMode::Resume);
+
+	send(&mut client, command(CURRENT_VERSION, 2, "same-key")).await;
+
+	let ServerMessage::CommandReceipt(receipt) = receive(&mut client).await else {
+		panic!("expected duplicate receipt");
+	};
+
+	assert_eq!(receipt.disposition, ReceiptDisposition::Duplicate);
+	assert_eq!(
+		receipt.original_client_command_id,
+		ClientCommandId::new("command-1").expect("bounded fixture command ID")
+	);
+
+	let ServerMessage::CommandResult(result) = receive(&mut client).await else {
+		panic!("expected duplicate result readback");
+	};
+
+	assert_eq!(
+		result.client_command_id,
+		ClientCommandId::new("command-2").expect("bounded fixture command ID")
+	);
+	assert_eq!(application.executions(), 1);
+	assert!(time::timeout(Duration::from_millis(100), client.next()).await.is_err());
+
+	drop(client);
+
+	bound.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn expected_revision_mismatch_is_rejected_without_publication() {
+	let application = FixtureApplication::default();
+	let bound = server("revision-server", application.clone(), ServerConfig::default())
+		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+		.await
+		.unwrap();
+	let mut client = connect(bound.address(), CURRENT_VERSION).await;
+
+	receive_initial(&mut client).await;
+
+	let mut message = command(CURRENT_VERSION, 1, "revision-key");
+	let ClientMessage::Command(ref mut command) = message else { unreachable!() };
+
+	command.expected_revision = Some(EntityRevision(7));
+
+	send(&mut client, message).await;
+
+	assert!(matches!(receive(&mut client).await, ServerMessage::CommandReceipt(_)));
+
+	let ServerMessage::CommandResult(result) = receive(&mut client).await else {
+		panic!("expected rejected result");
+	};
+
+	assert_eq!(result.outcome, decodex_protocol::CommandOutcome::Rejected);
+	assert!(matches!(
+		result.error,
+		Some(CommandError::ExpectedRevisionMismatch {
+			expected: EntityRevision(7),
+			actual: EntityRevision(0),
+		})
+	));
+	assert_eq!(application.executions(), 0);
+	assert!(time::timeout(Duration::from_millis(100), client.next()).await.is_err());
+
+	drop(client);
+
+	bound.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn reconnect_resumes_ordered_deltas_and_falls_back_to_a_snapshot() {
+	let config = ServerConfig { replay_capacity: 2, ..ServerConfig::default() };
+	let bound = server("resume-server", FixtureApplication::default(), config)
+		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+		.await
+		.unwrap();
+	let mut first = connect(bound.address(), CURRENT_VERSION).await;
+	let (server_id, _, _) = receive_initial(&mut first).await;
+	let persisted = execute_and_receive_event(&mut first, CURRENT_VERSION, 1).await;
+
+	execute_and_receive_event(&mut first, CURRENT_VERSION, 2).await;
+	execute_and_receive_event(&mut first, CURRENT_VERSION, 3).await;
+	drop(first);
+
+	let mut resumed = reconnect(
+		bound.address(),
+		CURRENT_VERSION,
+		ResumeCursor { server_id: server_id.clone(), cursor: persisted },
+	)
+	.await;
+	let ServerMessage::Welcome(welcome) = receive(&mut resumed).await else {
+		panic!("expected resume welcome");
+	};
+
+	assert_eq!(welcome.reconnect, ReconnectMode::Resume);
+	assert_eq!(welcome.cursor, Cursor(3));
+
+	drop(resumed);
+
+	let mut resumed = reconnect(
+		bound.address(),
+		CURRENT_VERSION,
+		ResumeCursor { server_id: server_id.clone(), cursor: persisted },
+	)
+	.await;
+	let ServerMessage::Welcome(welcome) = receive(&mut resumed).await else {
+		panic!("expected repeated resume welcome");
+	};
+
+	assert_eq!(welcome.reconnect, ReconnectMode::Resume);
+
+	let ServerMessage::Event(second) = receive(&mut resumed).await else {
+		panic!("expected second event");
+	};
+	let ServerMessage::Event(third) = receive(&mut resumed).await else {
+		panic!("expected third event");
+	};
+
+	assert_eq!((second.cursor, third.cursor), (Cursor(2), Cursor(3)));
+
+	drop(resumed);
+
+	let mut stale =
+		reconnect(bound.address(), CURRENT_VERSION, ResumeCursor { server_id, cursor: Cursor(0) })
+			.await;
+	let ServerMessage::Welcome(welcome) = receive(&mut stale).await else {
+		panic!("expected fallback welcome");
+	};
+
+	assert_eq!(welcome.reconnect, ReconnectMode::SnapshotFallback);
+
+	let ServerMessage::Snapshot(snapshot) = receive(&mut stale).await else {
+		panic!("expected fallback snapshot");
+	};
+
+	assert_eq!(snapshot.cursor, Cursor(3));
+
+	drop(stale);
+
+	bound.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn bounded_outbound_queue_disconnects_a_slow_real_client() {
+	let config = ServerConfig { outbound_queue_capacity: 1, ..ServerConfig::default() };
+	let application = FixtureApplication::default();
+	let bound = server("backpressure-server", application.clone(), config)
+		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+		.await
+		.unwrap();
+	let mut client = connect(bound.address(), CURRENT_VERSION).await;
+	let (server_id, cursor, _) = receive_initial(&mut client).await;
+
+	send(&mut client, command(CURRENT_VERSION, 1, "slow-1")).await;
+
+	let close_code = time::timeout(Duration::from_secs(3), async {
+		while let Some(message) = client.next().await {
+			if let Ok(Message::Close(frame)) = message {
+				return frame.map(|frame| frame.code);
+			}
+		}
+
+		None
+	})
+	.await
+	.unwrap();
+
+	assert_eq!(
+		close_code,
+		Some(tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Again)
+	);
+	assert_eq!(application.executions(), 1);
+
+	drop(client);
+
+	let mut resumed =
+		reconnect(bound.address(), CURRENT_VERSION, ResumeCursor { server_id, cursor }).await;
+	let ServerMessage::Welcome(welcome) = receive(&mut resumed).await else {
+		panic!("expected resume welcome after initiator overflow");
+	};
+
+	assert_eq!(welcome.reconnect, ReconnectMode::Resume);
+
+	let ServerMessage::Event(event) = receive(&mut resumed).await else {
+		panic!("expected retained event after initiator overflow");
+	};
+
+	assert_eq!(event.cursor, Cursor(1));
+
+	drop(resumed);
+
+	bound.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn event_overflow_stops_pipelined_commands_and_retains_the_first_event() {
+	let config = ServerConfig { outbound_queue_capacity: 2, ..ServerConfig::default() };
+	let application = FixtureApplication::default();
+	let bound = server("event-overflow", application.clone(), config)
+		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+		.await
+		.expect("bind event-overflow server");
+	let mut client = connect(bound.address(), CURRENT_VERSION).await;
+	let (server_id, cursor, _) = receive_initial(&mut client).await;
+
+	send(&mut client, command(CURRENT_VERSION, 1, "overflow-first")).await;
+	send(&mut client, command(CURRENT_VERSION, 2, "must-not-execute")).await;
+
+	let close_code = time::timeout(Duration::from_secs(3), async {
+		while let Some(message) = client.next().await {
+			if let Ok(Message::Close(frame)) = message {
+				return frame.map(|frame| frame.code);
+			}
+		}
+
+		None
+	})
+	.await
+	.expect("event overflow did not close");
+
+	assert_eq!(
+		close_code,
+		Some(tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Again)
+	);
+	assert_eq!(application.executions(), 1);
+
+	drop(client);
+
+	let mut resumed =
+		reconnect(bound.address(), CURRENT_VERSION, ResumeCursor { server_id, cursor }).await;
+
+	assert!(matches!(receive(&mut resumed).await, ServerMessage::Welcome(_)));
+
+	let ServerMessage::Event(event) = receive(&mut resumed).await else {
+		panic!("expected retained first event after overflow");
+	};
+
+	assert_eq!(event.cursor, Cursor(1));
+	assert_eq!(application.executions(), 1);
+
+	drop(resumed);
+
+	bound.shutdown().await.expect("shutdown event-overflow server");
+}
+
+#[tokio::test]
+async fn disconnected_delayed_command_finishes_and_deduplicates_on_reconnect() {
+	let application = FixtureApplication::with_delay(Duration::from_millis(200));
+	let bound = server("disconnect-shield", application.clone(), ServerConfig::default())
+		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+		.await
+		.expect("bind disconnect-shield server");
+	let mut first = connect(bound.address(), CURRENT_VERSION).await;
+
+	receive_initial(&mut first).await;
+	send(&mut first, command(CURRENT_VERSION, 1, "disconnect-key")).await;
+
+	time::sleep(Duration::from_millis(25)).await;
+
+	drop(first);
+
+	time::sleep(Duration::from_millis(300)).await;
+
+	assert_eq!(application.executions(), 1);
+
+	let mut reconnected = connect(bound.address(), CURRENT_VERSION).await;
+
+	receive_initial(&mut reconnected).await;
+	send(&mut reconnected, command(CURRENT_VERSION, 2, "disconnect-key")).await;
+
+	let ServerMessage::CommandReceipt(receipt) = receive(&mut reconnected).await else {
+		panic!("expected duplicate receipt after disconnect");
+	};
+
+	assert_eq!(receipt.disposition, ReceiptDisposition::Duplicate);
+	assert!(matches!(receive(&mut reconnected).await, ServerMessage::CommandResult(_)));
+	assert_eq!(application.executions(), 1);
+
+	drop(reconnected);
+
+	bound.shutdown().await.expect("shutdown disconnect-shield server");
+}
+
+#[tokio::test]
+async fn full_idempotency_ledger_keeps_duplicates_and_refuses_new_keys() {
+	let config = ServerConfig { receipt_capacity: 1, ..ServerConfig::default() };
+	let application = FixtureApplication::default();
+	let bound = server("receipt-capacity", application.clone(), config)
+		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+		.await
+		.expect("bind receipt-capacity server");
+	let mut client = connect(bound.address(), CURRENT_VERSION).await;
+
+	receive_initial(&mut client).await;
+	execute_and_receive_event(&mut client, CURRENT_VERSION, 1).await;
+	send(&mut client, command(CURRENT_VERSION, 2, "key-1")).await;
+
+	let ServerMessage::CommandReceipt(duplicate) = receive(&mut client).await else {
+		panic!("expected duplicate receipt at capacity");
+	};
+
+	assert_eq!(duplicate.disposition, ReceiptDisposition::Duplicate);
+	assert!(matches!(receive(&mut client).await, ServerMessage::CommandResult(_)));
+
+	send(&mut client, command(CURRENT_VERSION, 3, "new-key-at-capacity")).await;
+
+	let ServerMessage::CommandReceipt(refused) = receive(&mut client).await else {
+		panic!("expected capacity refusal receipt");
+	};
+	let ServerMessage::CommandResult(result) = receive(&mut client).await else {
+		panic!("expected capacity refusal result");
+	};
+
+	assert_eq!(refused.disposition, ReceiptDisposition::Refused);
+	assert!(matches!(
+		result.error,
+		Some(CommandError::IdempotencyCapacityExceeded { capacity: 1 })
+	));
+	assert_eq!(application.executions(), 1);
+	assert!(time::timeout(Duration::from_millis(100), client.next()).await.is_err());
+
+	drop(client);
+
+	bound.shutdown().await.expect("shutdown receipt-capacity server");
+}
+
+#[tokio::test]
+async fn oversized_outbound_snapshot_is_closed_before_transmission() {
+	let config = ServerConfig { maximum_message_bytes: 512, ..ServerConfig::default() };
+	let application = FixtureApplication::with_status(
+		WireText::new("x".repeat(1_024)).expect("fixture remains below scalar limit"),
+	);
+	let bound = server("snapshot-size", application, config)
+		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+		.await
+		.expect("bind snapshot-size server");
+	let mut client = connect(bound.address(), CURRENT_VERSION).await;
+
+	assert!(matches!(receive(&mut client).await, ServerMessage::Welcome(_)));
+
+	let close = time::timeout(Duration::from_secs(3), client.next())
+		.await
+		.expect("oversized outbound snapshot did not close")
+		.expect("server ended without close frame")
+		.expect("websocket close read failed");
+	let Message::Close(Some(frame)) = close else {
+		panic!("expected close frame for oversized snapshot, got {close:?}");
+	};
+
+	assert_eq!(
+		frame.code,
+		tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Size
+	);
+
+	drop(client);
+
+	bound.shutdown().await.expect("shutdown snapshot-size server");
+}
+
+#[tokio::test]
+async fn oversized_wire_identifier_is_refused_without_execution() {
+	let application = FixtureApplication::default();
+	let bound = server("bounded-identifiers", application.clone(), ServerConfig::default())
+		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+		.await
+		.expect("bind bounded-identifiers server");
+	let mut client = connect(bound.address(), CURRENT_VERSION).await;
+
+	receive_initial(&mut client).await;
+
+	let raw = serde_json::json!({
+		"type": "command",
+		"body": {
+			"version": { "major": 1, "minor": 1 },
+			"client_command_id": "x".repeat(decodex_protocol::MAX_WIRE_TEXT_BYTES + 1),
+			"idempotency_key": "bounded-key",
+			"expected_revision": null,
+			"correlation_id": "bounded-correlation",
+			"causation_id": null,
+			"payload": {
+				"name": "refresh_system_observation",
+				"arguments": { "entity_id": "fixture-system" }
+			}
+		}
+	})
+	.to_string();
+
+	client.send(Message::Text(raw.into())).await.expect("send oversized identifier command");
+
+	let ServerMessage::Refusal(refusal) = receive(&mut client).await else {
+		panic!("expected protocol refusal for oversized identifier");
+	};
+
+	assert!(matches!(refusal.refusal, Refusal::ProtocolViolation { .. }));
+	assert_eq!(application.executions(), 0);
+
+	drop(client);
+
+	bound.shutdown().await.expect("shutdown bounded-identifiers server");
+}
+
+#[tokio::test]
+async fn restart_changes_server_identity_and_forces_snapshot_fallback() {
+	let application = FixtureApplication::default();
+	let first = server("before-restart", application.clone(), ServerConfig::default())
+		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+		.await
+		.unwrap();
+	let address = first.address();
+	let mut client = connect(address, CURRENT_VERSION).await;
+	let (server_id, _, _) = receive_initial(&mut client).await;
+	let cursor = execute_and_receive_event(&mut client, CURRENT_VERSION, 1).await;
+
+	drop(client);
+
+	first.shutdown().await.unwrap();
+
+	let restarted =
+		server("after-restart", application, ServerConfig::default()).bind(address).await.unwrap();
+	let mut client =
+		reconnect(restarted.address(), CURRENT_VERSION, ResumeCursor { server_id, cursor }).await;
+	let ServerMessage::Welcome(welcome) = receive(&mut client).await else {
+		panic!("expected restart welcome");
+	};
+
+	assert_eq!(
+		welcome.server_id,
+		ServerId::new("after-restart").expect("bounded fixture server ID")
+	);
+	assert_eq!(welcome.reconnect, ReconnectMode::SnapshotFallback);
+	assert!(matches!(receive(&mut client).await, ServerMessage::Snapshot(_)));
+
+	drop(client);
+
+	restarted.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn non_loopback_binding_is_refused_before_opening_a_socket() {
+	let result = server("remote-refusal", FixtureApplication::default(), ServerConfig::default())
+		.bind(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 49_152)))
+		.await;
+	let error = match result {
+		Ok(_) => panic!("non-loopback bind unexpectedly succeeded"),
+		Err(error) => error,
+	};
+
+	assert_eq!(error.to_string(), "non-loopback endpoint is disabled: 0.0.0.0:49152");
+}

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -10,12 +10,15 @@ The root manifest enumerates the active members explicitly. Five library owners 
 vNext runtime boundary:
 
 - `decodex-core`: pure domain/application contracts and ports; no dependencies.
-- `decodex-protocol`: V1 version and loopback endpoint policy; depends only on core.
+- `decodex-protocol`: V1 typed wire contracts, current/previous-minor negotiation, and
+  loopback endpoint policy; depends only on core plus structured serialization.
 - `decodex-postgres`: the product-state adapter boundary; depends only on core and is
   unavailable until XY-1267.
 - `decodex-codex`: the shared-normal-home adapter boundary; depends only on core and is
   unavailable until XY-1270.
-- `decodex-runtime`: service lifecycle/composition; depends on the other four owners.
+- `decodex-runtime`: service lifecycle, connection/session execution, resumable event
+  publication, idempotency receipts, and adapter composition; depends on the other four
+  owners plus the maintained Axum/Tokio transport stack.
 
 `apps/decodexd` depends only on runtime. The `apps/decodex-cli` and
 `apps/decodex-gpui` client roots depend only on protocol, so they cannot reach stores,
@@ -23,12 +26,38 @@ Codex, repositories, or orchestration directly. Radar and Publisher remain indep
 auxiliary workspace members. `tests/scripts/test_vnext_architecture.py` checks the exact
 dependency graph and exclusion of the legacy package through Cargo metadata.
 
-The current `decodexd` assembly returns a typed V1 foundation announcement without
-selecting an endpoint. The protocol owner exposes a loopback-only endpoint seam for
-XY-1266, but XY-1265 opens no transport and defines no default address. Both
-infrastructure adapters are explicitly unavailable. The CLI has no operational
-commands, and the GPUI root is default-disabled because the XY-1263 accessibility gate
-remains failed.
+`decodexd` is the only V1 server composition root. It binds
+`ws://127.0.0.1:49152/v1/ws`, and the endpoint type refuses every non-loopback address
+before opening a socket. The single physical WebSocket uses structured JSON and typed
+hello, command, receipt, result, snapshot, event, and refusal envelopes. Major versions
+must match exactly; this build accepts minors 1 and 0. Events carry server ID, monotonic
+cursor, entity revision, correlation, and causation. A reconnect to the same server ID
+resumes retained ordered deltas; a stale cursor or changed server ID receives a bounded
+snapshot fallback. Only a snapshot or event cursor fully applied by the client is a
+resume checkpoint; the Welcome cursor is an informational server high-water mark and
+must not advance client progress before following replay deltas are applied.
+
+Runtime idempotency is keyed by the command's idempotency key plus its typed payload and
+optional expected revision. A duplicate returns the original command identity and the
+same stored result without a second application execution; conflicting reuse is
+rejected. The receipt ledger has a fixed lifetime capacity: accepted keys are never
+evicted, duplicates remain readable at capacity, and new keys are refused before
+application execution once full. Replay buffers, snapshot item counts, human-readable
+wire scalars, inbound and outbound message sizes, writes, and per-client outbound queues
+are bounded. Queue overflow disconnects that client with WebSocket close code 1013;
+an oversized outbound frame closes with code 1009. A successful application publication
+is retained even if its initiating client overflows, so cursor resume cannot lose the
+mutation. Once accepted, command execution is shielded from connection-task cancellation;
+a disconnect can suppress delivery but cannot cancel receipt/event recording. Snapshot
+types contain only small state and cannot carry artifact bytes.
+
+This slice deliberately keeps its replay/idempotency ledger in memory. A daemon restart
+changes server identity, loses that transient ledger, and forces snapshot fallback;
+XY-1267 owns durable PostgreSQL product-state and transaction integration. The current
+foundation application reports product state unavailable rather than inventing product
+entities. Authentication, TLS, remote binding, HTTP artifact transfer, MCP, scheduling,
+Codex execution, CLI operations, and GPUI behavior remain disabled and belong to later
+issues.
 
 ## Frozen v0.2 runtime provenance
 

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -53,10 +53,13 @@ OpenWiki is the repo-local project knowledge surface for agents and maintainers.
 ## Runtime in one minute
 
 `apps/decodexd` composes the PostgreSQL and Codex adapter boundaries through
-`decodex-runtime` and reports both adapters as unavailable. It selects no endpoint and
-opens no socket, database, repository, or Codex process. The protocol crate owns the
-loopback-only endpoint seam for XY-1266. The `decodex` and GPUI roots compile against
-`decodex-protocol` only and report their unsupported or disabled state.
+`decodex-runtime` and serves the typed V1 protocol at loopback-only
+`ws://127.0.0.1:49152/v1/ws`. It opens no database, repository, or Codex process. The
+protocol supports current/previous-minor negotiation, typed command receipt/result and
+event envelopes, bounded snapshots/queues/wire text, fixed-capacity in-lifetime
+idempotency, cursor resume, and snapshot fallback. The `decodex` and GPUI roots compile
+against `decodex-protocol` only
+and still report their unsupported or disabled state.
 
 No vNext product state is persisted yet. PostgreSQL is the accepted future product-state
 authority, `~/.codex` remains Codex-owned shared continuation state, and the accepted
@@ -64,8 +67,10 @@ Decodex-owned target is `~/.decodex`. XY-1267 and XY-1268 own those implementati
 The legacy `~/.codex/decodex` SQLite/config layout is frozen provenance, not a vNext
 input or fallback.
 
-There is no active scheduling, WebSocket, CLI operation, account routing, Codex adapter,
-PostgreSQL store, or GPUI product behavior in this slice.
+There is no active scheduling, CLI operation, account routing, Codex adapter, PostgreSQL
+store, authenticated HTTP artifact path, remote binding, or GPUI product behavior in
+this slice. Authentication and TLS are disabled; loopback refusal is the enforced
+network boundary until the later remote-security gate.
 
 ## First commands
 
@@ -79,8 +84,9 @@ cargo make test-vnext-architecture
 cargo make check
 ```
 
-The three binaries report foundation/unavailability state and exit; they do not start a
-production service. For a targeted Rust gate, prefer
+`decodexd` starts the loopback protocol service and runs until stopped. The client and
+GPUI binaries report foundation/unavailability state and exit. For a targeted Rust gate,
+prefer
 `cargo check --all-features --all-targets --workspace` or
 `cargo nextest run --workspace --all-targets --all-features` (`Makefile.toml`,
 `openwiki/operations/commands-and-validation.md`).
@@ -95,7 +101,8 @@ production service. For a targeted Rust gate, prefer
 
 ## Recent development context
 
-XY-1265 establishes compile-time ownership and composition only. XY-1266 may implement
-the loopback protocol, XY-1267 the PostgreSQL store, and XY-1268 the API-only CLI/path
-cutover after this foundation merges. Codex behavior, account routing, and GPUI product
-work remain with their later owners and gates.
+XY-1265 established compile-time ownership and composition. XY-1266 implements the
+loopback protocol foundation; XY-1267 owns PostgreSQL-backed product state and durable
+transactions, and XY-1268 owns the API-only CLI/path cutover. Codex behavior, account
+routing, remote security, HTTP artifacts, and GPUI product work remain with their later
+owners and gates.

--- a/tests/scripts/test_vnext_architecture.py
+++ b/tests/scripts/test_vnext_architecture.py
@@ -54,11 +54,13 @@ class VnextArchitectureTests(unittest.TestCase):
         }
 
     def test_vnext_dependency_direction_is_exact(self):
+        owned_packages = set(EXPECTED_DEPENDENCIES)
         for package_name, expected in EXPECTED_DEPENDENCIES.items():
             with self.subTest(package=package_name):
                 actual = {
                     dependency["name"]
                     for dependency in self.packages[package_name]["dependencies"]
+                    if dependency["name"] in owned_packages
                 }
                 self.assertEqual(actual, expected)
 


### PR DESCRIPTION
## Summary
- add typed v1.1/current-previous-minor WebSocket contracts and bounded identifiers
- add loopback-only server execution with idempotency, resumable cursors, snapshot fallback, and bounded backpressure
- add real socket coverage for reconnect, refusal, duplicate commands, overflow, restart, and disconnect completion

## Validation
- `cargo make fmt-check`
- `cargo make lint-vstyle-rust`
- `cargo make check-rust`
- `cargo make test` (56/56 plus architecture 4/4)
- `cargo make lint-rust`
- `cargo test -p decodex-runtime --test websocket_protocol -- --nocapture` (12/12)
- CLI/GPUI/daemon composition-root smoke

Linear: XY-1266
Impact: breaking vNext foundation; remote bind/auth/TLS and client transport remain disabled.