### PR TITLE
Fix deterministic WebSocket overflow close delivery

### DIFF
--- a/crates/decodex-runtime/src/websocket.rs
+++ b/crates/decodex-runtime/src/websocket.rs
@@ -57,7 +57,7 @@ pub struct ServerConfig {
 	pub maximum_message_bytes: usize,
 	/// Time allowed for the mandatory first hello message.
 	pub hello_timeout: Duration,
-	/// Time allowed for one WebSocket write.
+	/// Time allowed for one WebSocket write or a peer response to a server-initiated close.
 	pub write_timeout: Duration,
 }
 impl Default for ServerConfig {
@@ -226,19 +226,27 @@ where
 			}
 		}
 
-		let (socket_sender, socket_receiver) = socket.split();
-		let reader = self.read_commands(socket_receiver, connection_id, negotiated);
-		let writer = self.write_messages(socket_sender, receiver);
+		let (mut socket_sender, mut socket_receiver) = socket.split();
+		let close_sent = {
+			let reader = self.read_commands(&mut socket_receiver, connection_id, negotiated);
+			let writer = self.write_messages(&mut socket_sender, receiver);
 
-		tokio::pin!(reader, writer);
+			tokio::pin!(reader, writer);
 
-		tokio::select! {
-			() = &mut writer => {},
-			backpressure = &mut reader => {
-				if backpressure {
-					writer.await;
-				}
-			},
+			tokio::select! {
+				close_sent = &mut writer => close_sent,
+				backpressure = &mut reader => {
+					if backpressure {
+						writer.await
+					} else {
+						false
+					}
+				},
+			}
+		};
+
+		if close_sent {
+			self.await_peer_close(&mut socket_receiver).await;
 		}
 
 		self.remove_subscriber(connection_id).await;
@@ -364,7 +372,7 @@ where
 
 	async fn read_commands(
 		&self,
-		mut receiver: SplitStream<WebSocket>,
+		receiver: &mut SplitStream<WebSocket>,
 		connection_id: u64,
 		negotiated: ProtocolVersion,
 	) -> bool {
@@ -600,19 +608,18 @@ where
 
 	async fn write_messages(
 		&self,
-		mut sender: SplitSink<WebSocket, Message>,
+		sender: &mut SplitSink<WebSocket, Message>,
 		mut receiver: Receiver<ServerMessage>,
-	) {
+	) -> bool {
 		while let Some(message) = receiver.recv().await {
 			let Ok(encoded) = decodex_protocol::encode_server_message(&message) else {
-				return;
+				return false;
 			};
 
 			if encoded.len() > self.inner.config.maximum_message_bytes {
-				self.send_split_close(&mut sender, 1_009, "outbound message exceeds bounded size")
+				return self
+					.send_split_close(sender, 1_009, "outbound message exceeds bounded size")
 					.await;
-
-				return;
 			}
 
 			let write_result = time::timeout(
@@ -622,11 +629,22 @@ where
 			.await;
 
 			if !matches!(write_result, Ok(Ok(()))) {
-				return;
+				return false;
 			}
 		}
 
-		self.send_split_close(&mut sender, 1_013, "bounded outbound queue exceeded").await;
+		self.send_split_close(sender, 1_013, "bounded outbound queue exceeded").await
+	}
+
+	async fn await_peer_close(&self, receiver: &mut SplitStream<WebSocket>) {
+		let handshake = async {
+			while let Some(message) = receiver.next().await {
+				if matches!(message, Ok(Message::Close(_)) | Err(_)) {
+					return;
+				}
+			}
+		};
+		let _ = time::timeout(self.inner.config.write_timeout, handshake).await;
 	}
 
 	async fn send_direct(&self, socket: &mut WebSocket, message: ServerMessage) -> bool {
@@ -650,9 +668,12 @@ where
 		sender: &mut SplitSink<WebSocket, Message>,
 		code: u16,
 		reason: &'static str,
-	) {
+	) -> bool {
 		let close = sender.send(Message::Close(Some(CloseFrame { code, reason: reason.into() })));
-		let _ = time::timeout(self.inner.config.write_timeout, close).await;
+
+		time::timeout(self.inner.config.write_timeout, close)
+			.await
+			.is_ok_and(|result| result.is_ok())
 	}
 
 	async fn send_socket_close(&self, socket: &mut WebSocket, code: u16, reason: &'static str) {

--- a/crates/decodex-runtime/tests/websocket_protocol.rs
+++ b/crates/decodex-runtime/tests/websocket_protocol.rs
@@ -10,7 +10,10 @@ use std::{
 
 use futures_util::{SinkExt as _, StreamExt as _};
 use tokio::{net::TcpStream, time};
-use tokio_tungstenite::{self, MaybeTlsStream, WebSocketStream, tungstenite::Message};
+use tokio_tungstenite::{
+	self, MaybeTlsStream, WebSocketStream,
+	tungstenite::{Message, protocol::frame::coding::CloseCode},
+};
 
 use decodex_protocol::{
 	CURRENT_VERSION, CausationId, Channel, ClientCommandId, ClientHello, ClientMessage,
@@ -22,6 +25,8 @@ use decodex_protocol::{
 use decodex_runtime::{Application, ApplicationPublication, ProtocolServer, ServerConfig};
 
 type Client = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+const OVERFLOW_STRESS_RUNS: u64 = 16;
 
 #[derive(Clone, Default)]
 struct FixtureApplication {
@@ -169,6 +174,22 @@ async fn receive(client: &mut Client) -> ServerMessage {
 	};
 
 	serde_json::from_str(&text).expect("decode typed server message")
+}
+
+async fn receive_close_code(client: &mut Client) -> Option<CloseCode> {
+	time::timeout(Duration::from_secs(3), async {
+		while let Some(message) = client.next().await {
+			match message {
+				Ok(Message::Close(frame)) => return frame.map(|frame| frame.code),
+				Ok(_) => {},
+				Err(_) => return None,
+			}
+		}
+
+		None
+	})
+	.await
+	.expect("overflow did not close the connection")
 }
 
 async fn receive_initial(client: &mut Client) -> (ServerId, Cursor, ReconnectMode) {
@@ -445,33 +466,25 @@ async fn reconnect_resumes_ordered_deltas_and_falls_back_to_a_snapshot() {
 
 #[tokio::test]
 async fn bounded_outbound_queue_disconnects_a_slow_real_client() {
+	for run in 0..OVERFLOW_STRESS_RUNS {
+		assert_initiator_overflow(run).await;
+	}
+}
+
+async fn assert_initiator_overflow(run: u64) {
 	let config = ServerConfig { outbound_queue_capacity: 1, ..ServerConfig::default() };
 	let application = FixtureApplication::default();
-	let bound = server("backpressure-server", application.clone(), config)
+	let server_id = format!("backpressure-server-{run}");
+	let bound = server(&server_id, application.clone(), config)
 		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
 		.await
-		.unwrap();
+		.expect("bind initiator-overflow server");
 	let mut client = connect(bound.address(), CURRENT_VERSION).await;
 	let (server_id, cursor, _) = receive_initial(&mut client).await;
 
 	send(&mut client, command(CURRENT_VERSION, 1, "slow-1")).await;
 
-	let close_code = time::timeout(Duration::from_secs(3), async {
-		while let Some(message) = client.next().await {
-			if let Ok(Message::Close(frame)) = message {
-				return frame.map(|frame| frame.code);
-			}
-		}
-
-		None
-	})
-	.await
-	.unwrap();
-
-	assert_eq!(
-		close_code,
-		Some(tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Again)
-	);
+	assert_eq!(receive_close_code(&mut client).await, Some(CloseCode::Again));
 	assert_eq!(application.executions(), 1);
 
 	drop(client);
@@ -492,14 +505,21 @@ async fn bounded_outbound_queue_disconnects_a_slow_real_client() {
 
 	drop(resumed);
 
-	bound.shutdown().await.unwrap();
+	bound.shutdown().await.expect("shutdown initiator-overflow server");
 }
 
 #[tokio::test]
 async fn event_overflow_stops_pipelined_commands_and_retains_the_first_event() {
+	for run in 0..OVERFLOW_STRESS_RUNS {
+		assert_event_overflow(run).await;
+	}
+}
+
+async fn assert_event_overflow(run: u64) {
 	let config = ServerConfig { outbound_queue_capacity: 2, ..ServerConfig::default() };
 	let application = FixtureApplication::default();
-	let bound = server("event-overflow", application.clone(), config)
+	let server_id = format!("event-overflow-{run}");
+	let bound = server(&server_id, application.clone(), config)
 		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
 		.await
 		.expect("bind event-overflow server");
@@ -509,22 +529,7 @@ async fn event_overflow_stops_pipelined_commands_and_retains_the_first_event() {
 	send(&mut client, command(CURRENT_VERSION, 1, "overflow-first")).await;
 	send(&mut client, command(CURRENT_VERSION, 2, "must-not-execute")).await;
 
-	let close_code = time::timeout(Duration::from_secs(3), async {
-		while let Some(message) = client.next().await {
-			if let Ok(Message::Close(frame)) = message {
-				return frame.map(|frame| frame.code);
-			}
-		}
-
-		None
-	})
-	.await
-	.expect("event overflow did not close");
-
-	assert_eq!(
-		close_code,
-		Some(tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Again)
-	);
+	assert_eq!(receive_close_code(&mut client).await, Some(CloseCode::Again));
 	assert_eq!(application.executions(), 1);
 
 	drop(client);


### PR DESCRIPTION
## Summary
- preserve the split reader while sending a server-initiated overflow close
- drain buffered inbound frames without executing them until peer close or the bounded timeout
- stress both queue-overflow paths across 16 scenarios per test

## Validation
- `cargo make check`
- `cargo make test` (56/56)
- strict clippy, rustfmt, vstyle
- 30 isolated invocations of the event-overflow test (480/480 scenarios)
- independent skeptic review; one documentation finding repaired

Linear: XY-1305