### PR TITLE
XY-1306: add typed Decodex config and storage foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,6 +503,14 @@ dependencies = [
 [[package]]
 name = "decodex-core"
 version = "0.2.0"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+ "serde",
+ "sha2",
+ "tempfile",
+ "toml",
+]
 
 [[package]]
 name = "decodex-gpui"
@@ -2059,6 +2067,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2406,6 +2423,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2978,6 +3034,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ base64             = { version = "0.22" }
 clap               = { version = "4.6", features = ["derive"] }
 color-eyre         = { version = "0.6" }
 futures-util       = { version = "0.3.32" }
+getrandom          = { version = "=0.4.2" }
 globset            = { version = "0.4" }
 libc               = { version = "0.2" }
 regex              = { version = "1.12" }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ publishes bounded snapshots and resumable ordered events, deduplicates commands 
 server lifetime in a fixed-capacity ledger, and disconnects clients whose bounded
 outbound queue fills. PostgreSQL,
 Codex, CLI operations, authentication/TLS, remote binding, and product UI behavior are
-still unavailable until their owning slices land. The frozen v0.2 source remains under
+still unavailable until their owning slices land. `decodex-core` now owns the typed
+`~/.decodex` config/log/blob/cache/server-identity foundation, including explicit
+local/remote profiles and inert PostgreSQL connection data; it does not wire the daemon
+or CLI. The frozen v0.2 source remains under
 `apps/decodex/` as provenance and is excluded from the active Cargo workspace; it is not
 a compatibility runtime.
 
@@ -237,7 +240,9 @@ Project contracts are managed outside checkouts under
 - `project.toml` for service paths and credential environment-variable names
 - `WORKFLOW.md` for execution policy
 
-The redacted template for a project config lives at `decodex.example.toml`.
+At freeze, the redacted project-config template occupied `decodex.example.toml`. The
+current checked-in file is the vNext global `~/.decodex/config.toml` template and must
+not be used as a compatibility template for this frozen flow.
 Decodex autonomy is objective-driven project autonomy, not a hidden runtime repair
 loop. `[autonomy]` defaults to latent-only: objective drafts, signal audits, and
 proposal dry-runs may produce evidence, but unattended promotion or intake requires an

--- a/crates/decodex-core/Cargo.toml
+++ b/crates/decodex-core/Cargo.toml
@@ -1,9 +1,21 @@
 [package]
 authors.workspace    = true
-description          = "Pure Decodex vNext domain and application contracts."
+description          = "Decodex vNext domain, configuration, and local-storage foundations."
 edition.workspace    = true
 homepage.workspace   = true
 license.workspace    = true
 name                 = "decodex-core"
 repository.workspace = true
 version.workspace    = true
+
+[dependencies]
+getrandom = { workspace = true }
+serde     = { workspace = true }
+sha2      = { workspace = true }
+toml      = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/decodex-core/src/blob.rs
+++ b/crates/decodex-core/src/blob.rs
@@ -1,0 +1,148 @@
+use std::{
+	fmt::{Debug, Display, Formatter},
+	path::{Path, PathBuf},
+};
+
+use sha2::{Digest as _, Sha256};
+
+use crate::{DecodexPaths, PathError, StorageError, paths};
+
+/// Maximum byte size of one content-addressed blob accepted by this in-memory API.
+pub const MAX_BLOB_BYTES: usize = 64 * 1_024 * 1_024;
+
+/// Canonical lowercase SHA-256 content identity.
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct BlobHash([u8; 32]);
+impl BlobHash {
+	/// Hash bytes through the vetted SHA-256 implementation selected by the workspace.
+	pub fn digest(bytes: &[u8]) -> Self {
+		Self(Sha256::digest(bytes).into())
+	}
+
+	/// Parse exactly 64 lowercase hexadecimal characters.
+	pub fn parse(value: &str) -> Result<Self, StorageError> {
+		if value.len() != 64
+			|| !value.bytes().all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+		{
+			return Err(StorageError::InvalidBlobHash);
+		}
+
+		let mut bytes = [0_u8; 32];
+
+		for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+			bytes[index] = (decode_hex(pair[0])? << 4) | decode_hex(pair[1])?;
+		}
+
+		Ok(Self(bytes))
+	}
+
+	/// Canonical lowercase hexadecimal text.
+	pub fn to_hex(self) -> String {
+		hex(&self.0)
+	}
+}
+
+impl Debug for BlobHash {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.debug_tuple("BlobHash").field(&self.to_hex()).finish()
+	}
+}
+
+impl Display for BlobHash {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(&self.to_hex())
+	}
+}
+
+/// Atomic, content-addressed, integrity-verifying local blob owner.
+#[derive(Clone, Debug)]
+pub struct BlobStore {
+	paths: DecodexPaths,
+}
+impl BlobStore {
+	/// Bind the store to the typed Decodex root and verify its fixed layout.
+	pub fn open(paths: DecodexPaths) -> Result<Self, StorageError> {
+		paths.ensure_layout()?;
+
+		Ok(Self { paths })
+	}
+
+	/// Atomically persist bounded bytes by SHA-256. Existing bytes are accepted only
+	/// after full integrity verification.
+	pub fn put(&self, bytes: &[u8]) -> Result<BlobHash, StorageError> {
+		if bytes.len() > MAX_BLOB_BYTES {
+			return Err(StorageError::BlobTooLarge { limit: MAX_BLOB_BYTES });
+		}
+
+		let hash = BlobHash::digest(bytes);
+		let (relative_directory, path) = self.blob_path(hash);
+
+		self.paths.ensure_owned_directory(&relative_directory)?;
+
+		match paths::atomic_write_new(&self.paths, &path, bytes, MAX_BLOB_BYTES) {
+			Ok(()) => {},
+			Err(PathError::AlreadyExists) => self.verify_existing(hash, &path)?,
+			Err(error) => return Err(error.into()),
+		}
+
+		Ok(hash)
+	}
+
+	/// Read bounded bytes and verify that their SHA-256 identity still matches the
+	/// requested content address.
+	pub fn read(&self, hash: BlobHash) -> Result<Vec<u8>, StorageError> {
+		let (_, path) = self.blob_path(hash);
+		let bytes = paths::read_private_file(&self.paths, &path, MAX_BLOB_BYTES)?;
+
+		if BlobHash::digest(&bytes) != hash {
+			return Err(StorageError::BlobIntegrityMismatch);
+		}
+
+		Ok(bytes)
+	}
+
+	/// Absolute owned path for PostgreSQL artifact metadata. The path is derived only
+	/// from the validated root and digest, never from caller path text.
+	pub fn path_for(&self, hash: BlobHash) -> PathBuf {
+		self.blob_path(hash).1
+	}
+
+	fn verify_existing(&self, hash: BlobHash, path: &Path) -> Result<(), StorageError> {
+		let bytes = paths::read_private_file(&self.paths, path, MAX_BLOB_BYTES)?;
+
+		if BlobHash::digest(&bytes) != hash {
+			return Err(StorageError::BlobIntegrityMismatch);
+		}
+
+		Ok(())
+	}
+
+	fn blob_path(&self, hash: BlobHash) -> (PathBuf, PathBuf) {
+		let encoded = hash.to_hex();
+		let relative_directory = PathBuf::from("blobs/sha256").join(&encoded[..2]);
+		let path = self.paths.join(&relative_directory).join(encoded);
+
+		(relative_directory, path)
+	}
+}
+
+fn decode_hex(value: u8) -> Result<u8, StorageError> {
+	match value {
+		b'0'..=b'9' => Ok(value - b'0'),
+		b'a'..=b'f' => Ok(value - b'a' + 10),
+		_ => Err(StorageError::InvalidBlobHash),
+	}
+}
+
+fn hex(bytes: &[u8]) -> String {
+	const HEX: &[u8; 16] = b"0123456789abcdef";
+
+	let mut encoded = String::with_capacity(bytes.len() * 2);
+
+	for &byte in bytes {
+		encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+		encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+	}
+
+	encoded
+}

--- a/crates/decodex-core/src/cache.rs
+++ b/crates/decodex-core/src/cache.rs
@@ -1,0 +1,241 @@
+use std::{
+	io::ErrorKind,
+	path::{Path, PathBuf},
+	time::SystemTime,
+};
+
+use crate::{
+	BlobHash, DecodexPaths, PathError, StorageError,
+	paths::{self, IoOperation},
+};
+
+/// Hard ceiling for configured disposable-cache entries.
+pub const MAX_CACHE_ENTRIES: usize = 10_000;
+/// Hard ceiling for configured disposable-cache bytes.
+pub const MAX_CACHE_BYTES: usize = 512 * 1_024 * 1_024;
+/// Hard ceiling for one disposable cache entry.
+pub const MAX_CACHE_ENTRY_BYTES: usize = 16 * 1_024 * 1_024;
+
+const MAX_CACHE_KEY_BYTES: usize = 1_024;
+
+/// Mechanical limits for disposable, non-authoritative cache bytes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CacheLimits {
+	max_entries: usize,
+	max_bytes: usize,
+	max_entry_bytes: usize,
+}
+impl CacheLimits {
+	/// Validate non-zero limits against hard process ceilings.
+	pub fn new(
+		max_entries: usize,
+		max_bytes: usize,
+		max_entry_bytes: usize,
+	) -> Result<Self, StorageError> {
+		if max_entries == 0
+			|| max_entries > MAX_CACHE_ENTRIES
+			|| max_bytes == 0
+			|| max_bytes > MAX_CACHE_BYTES
+			|| max_entry_bytes == 0
+			|| max_entry_bytes > MAX_CACHE_ENTRY_BYTES
+			|| max_entry_bytes > max_bytes
+		{
+			return Err(StorageError::InvalidCacheLimits);
+		}
+
+		Ok(Self { max_entries, max_bytes, max_entry_bytes })
+	}
+
+	/// Entry-count ceiling.
+	pub const fn max_entries(self) -> usize {
+		self.max_entries
+	}
+
+	/// Aggregate byte ceiling.
+	pub const fn max_bytes(self) -> usize {
+		self.max_bytes
+	}
+
+	/// Per-entry byte ceiling.
+	pub const fn max_entry_bytes(self) -> usize {
+		self.max_entry_bytes
+	}
+}
+
+/// Current mechanically verified cache usage.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CacheUsage {
+	/// Retained regular-file entries.
+	pub entries: usize,
+	/// Retained aggregate bytes.
+	pub bytes: usize,
+}
+
+/// Disposable, byte-and-entry-bounded cache. It exposes no authority contract and
+/// may always be cleared and rebuilt from PostgreSQL/blob authority.
+#[derive(Clone, Debug)]
+pub struct BoundedCache {
+	paths: DecodexPaths,
+	limits: CacheLimits,
+}
+impl BoundedCache {
+	/// Open the cache, reject unsafe file kinds, and immediately enforce both bounds.
+	pub fn open(paths: DecodexPaths, limits: CacheLimits) -> Result<Self, StorageError> {
+		paths.ensure_layout()?;
+
+		let cache = Self { paths, limits };
+
+		cache.enforce_bounds()?;
+
+		Ok(cache)
+	}
+
+	/// Atomically write one disposable entry and evict the oldest entries until both
+	/// caps hold. Caller keys are hashed and never enter filenames or errors.
+	pub fn put(&self, key: &str, bytes: &[u8]) -> Result<CacheUsage, StorageError> {
+		if key.is_empty() || key.len() > MAX_CACHE_KEY_BYTES {
+			return Err(StorageError::InvalidCacheKey);
+		}
+		if bytes.len() > self.limits.max_entry_bytes {
+			return Err(StorageError::CacheEntryTooLarge { limit: self.limits.max_entry_bytes });
+		}
+
+		self.enforce_bounds()?;
+
+		let path = self.entry_path(key);
+
+		paths::atomic_write_replace(&self.paths, &path, bytes, self.limits.max_entry_bytes)?;
+
+		self.enforce_bounds()
+	}
+
+	/// Read one bounded disposable entry. Missing entries are ordinary cache misses.
+	pub fn get(&self, key: &str) -> Result<Option<Vec<u8>>, StorageError> {
+		if key.is_empty() || key.len() > MAX_CACHE_KEY_BYTES {
+			return Err(StorageError::InvalidCacheKey);
+		}
+
+		self.enforce_bounds()?;
+
+		let path = self.entry_path(key);
+
+		match paths::read_private_file(&self.paths, &path, self.limits.max_entry_bytes) {
+			Ok(bytes) => Ok(Some(bytes)),
+			Err(PathError::Io { kind: ErrorKind::NotFound, .. }) => Ok(None),
+			Err(error) => Err(error.into()),
+		}
+	}
+
+	/// Delete every validated cache entry without touching PostgreSQL or blobs.
+	pub fn clear(&self) -> Result<(), StorageError> {
+		paths::visit_private_files(
+			&self.paths,
+			&self.paths.cache_dir(),
+			|path, _| -> Result<(), StorageError> {
+				if paths::is_atomic_temporary_file(&path) {
+					Ok(())
+				} else {
+					validate_cache_filename(&path)
+				}
+			},
+		)?;
+		paths::visit_private_files(
+			&self.paths,
+			&self.paths.cache_dir(),
+			|path, _| -> Result<(), StorageError> {
+				paths::remove_private_file(&self.paths, &path).map_err(Into::into)
+			},
+		)?;
+
+		Ok(())
+	}
+
+	/// Re-scan disk, reject unsafe entries, and return verified bounded usage.
+	pub fn usage(&self) -> Result<CacheUsage, StorageError> {
+		self.enforce_bounds()
+	}
+
+	fn enforce_bounds(&self) -> Result<CacheUsage, StorageError> {
+		let mut retained = Vec::new();
+		let mut total_bytes = 0_usize;
+
+		paths::visit_private_files(
+			&self.paths,
+			&self.paths.cache_dir(),
+			|path, metadata| -> Result<(), StorageError> {
+				if paths::is_atomic_temporary_file(&path) {
+					paths::remove_private_file(&self.paths, &path)?;
+
+					return Ok(());
+				}
+
+				validate_cache_filename(&path)?;
+
+				let bytes = usize::try_from(metadata.len())
+					.map_err(|_| StorageError::CacheBoundOverflow)?;
+
+				if bytes > self.limits.max_entry_bytes || retained.len() >= MAX_CACHE_ENTRIES {
+					paths::remove_private_file(&self.paths, &path)?;
+
+					return Ok(());
+				}
+
+				total_bytes =
+					total_bytes.checked_add(bytes).ok_or(StorageError::CacheBoundOverflow)?;
+
+				let modified = metadata.modified().map_err(|error| {
+					StorageError::Path(PathError::Io {
+						operation: IoOperation::Inspect,
+						kind: error.kind(),
+					})
+				})?;
+
+				retained.push(CacheEntry { path, bytes, modified });
+
+				Ok(())
+			},
+		)?;
+
+		retained.sort_by(|left, right| {
+			left.modified.cmp(&right.modified).then_with(|| left.path.cmp(&right.path))
+		});
+
+		let mut retained_entries = retained.len();
+
+		for entry in retained {
+			if retained_entries <= self.limits.max_entries && total_bytes <= self.limits.max_bytes {
+				break;
+			}
+
+			paths::remove_private_file(&self.paths, &entry.path)?;
+
+			retained_entries -= 1;
+			total_bytes -= entry.bytes;
+		}
+
+		Ok(CacheUsage { entries: retained_entries, bytes: total_bytes })
+	}
+
+	fn entry_path(&self, key: &str) -> PathBuf {
+		let digest = BlobHash::digest(key.as_bytes()).to_hex();
+
+		self.paths.cache_dir().join(format!("{digest}.cache"))
+	}
+}
+
+struct CacheEntry {
+	path: PathBuf,
+	bytes: usize,
+	modified: SystemTime,
+}
+
+fn validate_cache_filename(path: &Path) -> Result<(), StorageError> {
+	let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+		return Err(StorageError::InvalidCacheEntry);
+	};
+	let Some(hash) = name.strip_suffix(".cache") else {
+		return Err(StorageError::InvalidCacheEntry);
+	};
+
+	BlobHash::parse(hash).map(|_| ()).map_err(|_| StorageError::InvalidCacheEntry)
+}

--- a/crates/decodex-core/src/config.rs
+++ b/crates/decodex-core/src/config.rs
@@ -1,0 +1,617 @@
+use std::{
+	collections::BTreeMap,
+	fmt::{Debug, Display, Formatter},
+	net::{IpAddr, SocketAddr},
+	path::{Component, Path, PathBuf},
+	str,
+};
+
+use serde::{Deserialize, Deserializer};
+
+use crate::{CacheLimits, DecodexPaths, PathError, ServerIdentity, paths};
+
+/// Maximum accepted UTF-8 configuration input.
+pub const MAX_CONFIG_BYTES: usize = 64 * 1_024;
+
+const CONFIG_VERSION: u32 = 1;
+const MAX_NAME_BYTES: usize = 64;
+const MAX_HOST_BYTES: usize = 253;
+const MAX_DATABASE_FIELD_BYTES: usize = 128;
+const MAX_SERVER_HOST_PATH_BYTES: usize = 4 * 1_024;
+
+/// Fully validated Decodex vNext configuration.
+#[derive(Clone)]
+pub struct DecodexConfig {
+	version: u32,
+	active_profile: ProfileName,
+	profiles: BTreeMap<ProfileName, ServerProfile>,
+	server_host: ServerHostConfig,
+	postgres: PostgresConnectionConfig,
+	cache: CacheConfig,
+}
+impl DecodexConfig {
+	/// Parse bounded UTF-8 TOML. Parser details and input excerpts are deliberately
+	/// discarded so secret-bearing malformed input cannot enter errors or logs.
+	pub fn parse(bytes: &[u8]) -> Result<Self, ConfigError> {
+		if bytes.len() > MAX_CONFIG_BYTES {
+			return Err(ConfigError::Oversized { limit: MAX_CONFIG_BYTES });
+		}
+
+		let input = str::from_utf8(bytes).map_err(|_| ConfigError::Malformed)?;
+		let raw: RawConfig = toml::from_str(input).map_err(|_| ConfigError::Malformed)?;
+
+		if raw.version != CONFIG_VERSION {
+			return Err(ConfigError::UnsupportedVersion);
+		}
+
+		let profiles = raw
+			.profiles
+			.into_iter()
+			.map(|(name, profile)| profile.validate().map(|profile| (name, profile)))
+			.collect::<Result<BTreeMap<_, _>, _>>()?;
+
+		if !profiles.contains_key(&raw.active_profile) {
+			return Err(ConfigError::MissingActiveProfile);
+		}
+
+		Ok(Self {
+			version: raw.version,
+			active_profile: raw.active_profile,
+			profiles,
+			server_host: raw.server_host.validate()?,
+			postgres: raw.postgres.validate()?,
+			cache: raw.cache.validate()?,
+		})
+	}
+
+	/// Read and parse the private root configuration file through the bounded,
+	/// no-symlink path owner.
+	pub fn load(paths: &DecodexPaths) -> Result<Self, ConfigError> {
+		let bytes = paths::read_private_file(paths, &paths.config_file(), MAX_CONFIG_BYTES)?;
+
+		Self::parse(&bytes)
+	}
+
+	/// Schema version accepted by this build.
+	pub const fn version(&self) -> u32 {
+		self.version
+	}
+
+	/// Explicitly selected profile name.
+	pub fn active_profile_name(&self) -> &ProfileName {
+		&self.active_profile
+	}
+
+	/// Explicitly selected local or remote profile.
+	pub fn active_profile(&self) -> &ServerProfile {
+		self.profiles.get(&self.active_profile).expect("validated active profile is present")
+	}
+
+	/// All explicit profiles.
+	pub fn profiles(&self) -> &BTreeMap<ProfileName, ServerProfile> {
+		&self.profiles
+	}
+
+	/// Server-host-only repository configuration.
+	pub fn server_host(&self) -> &ServerHostConfig {
+		&self.server_host
+	}
+
+	/// Explicit PostgreSQL connection configuration as inert data.
+	pub fn postgres(&self) -> &PostgresConnectionConfig {
+		&self.postgres
+	}
+
+	/// Disposable cache bounds.
+	pub const fn cache(&self) -> CacheConfig {
+		self.cache
+	}
+}
+
+impl Debug for DecodexConfig {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter
+			.debug_struct("DecodexConfig")
+			.field("version", &self.version)
+			.field("active_profile", &self.active_profile)
+			.field("profile_count", &self.profiles.len())
+			.field("server_host", &self.server_host)
+			.field("postgres", &self.postgres)
+			.field("cache", &self.cache)
+			.finish()
+	}
+}
+
+/// Validated profile-map key.
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ProfileName(String);
+impl ProfileName {
+	/// Validated profile name text.
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+
+impl Debug for ProfileName {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str("ProfileName(<redacted>)")
+	}
+}
+
+impl<'de> Deserialize<'de> for ProfileName {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let value = String::deserialize(deserializer)?;
+
+		Self::try_from(value).map_err(serde::de::Error::custom)
+	}
+}
+
+impl TryFrom<String> for ProfileName {
+	type Error = &'static str;
+
+	fn try_from(value: String) -> Result<Self, Self::Error> {
+		validate_name(&value).map_err(|_| "invalid profile name")?;
+
+		Ok(Self(value))
+	}
+}
+
+/// Explicit local or remote server selection. Neither variant carries a repository
+/// path; repository paths are server-host-only data owned by `ServerHostConfig`.
+#[derive(Clone)]
+pub enum ServerProfile {
+	/// Loopback client and server live on the same host.
+	Local(LocalProfile),
+	/// Client and server live on different hosts.
+	Remote(RemoteProfile),
+}
+impl Debug for ServerProfile {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::Local(profile) => profile.fmt(formatter),
+			Self::Remote(profile) => profile.fmt(formatter),
+		}
+	}
+}
+
+/// Validated local profile. Only a loopback socket address is representable.
+#[derive(Clone, Eq, PartialEq)]
+pub struct LocalProfile {
+	address: SocketAddr,
+	expected_server_identity: Option<ServerIdentity>,
+}
+impl LocalProfile {
+	/// Loopback daemon address.
+	pub const fn address(&self) -> SocketAddr {
+		self.address
+	}
+
+	/// Optional identity pin for a known local server.
+	pub fn expected_server_identity(&self) -> Option<&ServerIdentity> {
+		self.expected_server_identity.as_ref()
+	}
+}
+
+impl Debug for LocalProfile {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter
+			.debug_struct("LocalProfile")
+			.field("address", &"<loopback>")
+			.field("identity_pinned", &self.expected_server_identity.is_some())
+			.finish()
+	}
+}
+
+/// Validated remote profile. Host and port are data only; this type does not enable
+/// non-loopback transport, authentication, or TLS.
+#[derive(Clone, Eq, PartialEq)]
+pub struct RemoteProfile {
+	host: String,
+	port: u16,
+	expected_server_identity: ServerIdentity,
+}
+impl RemoteProfile {
+	/// Remote DNS name or IP literal, stored separately from credentials and paths.
+	pub fn host(&self) -> &str {
+		&self.host
+	}
+
+	/// Remote service port.
+	pub const fn port(&self) -> u16 {
+		self.port
+	}
+
+	/// Required stable identity pin for the server host.
+	pub fn expected_server_identity(&self) -> &ServerIdentity {
+		&self.expected_server_identity
+	}
+}
+
+impl Debug for RemoteProfile {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter
+			.debug_struct("RemoteProfile")
+			.field("host", &"<redacted>")
+			.field("port", &self.port)
+			.field("expected_server_identity", &self.expected_server_identity)
+			.finish()
+	}
+}
+
+/// Validated server-host repository name.
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub struct RepositoryName(String);
+impl RepositoryName {
+	/// Repository key text.
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+
+impl Debug for RepositoryName {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str("RepositoryName(<redacted>)")
+	}
+}
+
+impl<'de> Deserialize<'de> for RepositoryName {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let value = String::deserialize(deserializer)?;
+
+		validate_name(&value).map_err(serde::de::Error::custom)?;
+
+		Ok(Self(value))
+	}
+}
+
+/// Absolute repository path meaningful only on the server host.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ServerRepositoryPath(PathBuf);
+impl ServerRepositoryPath {
+	/// Access the path explicitly as a server-host path.
+	pub fn as_server_path(&self) -> &Path {
+		&self.0
+	}
+}
+
+impl Debug for ServerRepositoryPath {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str("ServerRepositoryPath(<server-host-only>)")
+	}
+}
+
+/// Repository roots owned by the server host, structurally separate from client
+/// profiles so a remote client cannot interpret them as local paths.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ServerHostConfig {
+	repositories: BTreeMap<RepositoryName, ServerRepositoryPath>,
+}
+impl ServerHostConfig {
+	/// Server-host repository roots.
+	pub fn repositories(&self) -> &BTreeMap<RepositoryName, ServerRepositoryPath> {
+		&self.repositories
+	}
+}
+
+impl Debug for ServerHostConfig {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter
+			.debug_struct("ServerHostConfig")
+			.field("repository_count", &self.repositories.len())
+			.finish()
+	}
+}
+
+/// Explicit PostgreSQL Unix-socket connection configuration as data only.
+#[derive(Clone, Eq, PartialEq)]
+pub struct PostgresConnectionConfig {
+	socket_directory: PathBuf,
+	database: String,
+	user: String,
+	credential_env_var: Option<String>,
+}
+impl PostgresConnectionConfig {
+	/// Absolute server-host Unix socket directory.
+	pub fn socket_directory(&self) -> &Path {
+		&self.socket_directory
+	}
+
+	/// Explicit database name.
+	pub fn database(&self) -> &str {
+		&self.database
+	}
+
+	/// Explicit database role.
+	pub fn user(&self) -> &str {
+		&self.user
+	}
+
+	/// Optional environment-variable reference. Configuration never stores its value.
+	pub fn credential_env_var(&self) -> Option<&str> {
+		self.credential_env_var.as_deref()
+	}
+}
+
+impl Debug for PostgresConnectionConfig {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter
+			.debug_struct("PostgresConnectionConfig")
+			.field("socket_directory", &"<server-host-only>")
+			.field("database", &"<redacted>")
+			.field("user", &"<redacted>")
+			.field("credential_reference", &self.credential_env_var.is_some())
+			.finish()
+	}
+}
+
+/// Validated disposable-cache configuration.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CacheConfig {
+	limits: CacheLimits,
+}
+impl CacheConfig {
+	/// Mechanical byte and entry bounds.
+	pub const fn limits(self) -> CacheLimits {
+		self.limits
+	}
+}
+
+/// Typed redacted configuration failures.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConfigError {
+	/// Input exceeded the parser limit.
+	Oversized {
+		/// Maximum accepted configuration bytes.
+		limit: usize,
+	},
+	/// TOML, UTF-8, unknown fields, or shape was invalid.
+	Malformed,
+	/// Configuration schema version is unsupported.
+	UnsupportedVersion,
+	/// The selected profile was not declared.
+	MissingActiveProfile,
+	/// A local or remote profile violated its closed contract.
+	InvalidProfile,
+	/// A server identity was not canonical UUID version 4 text.
+	InvalidServerIdentity,
+	/// A server-host repository path was unsafe or relative.
+	InvalidServerHostPath,
+	/// PostgreSQL connection data was missing, unsafe, or unbounded.
+	InvalidPostgres,
+	/// Cache bounds were invalid or exceeded hard limits.
+	InvalidCache,
+	/// The operating-system random source failed.
+	RandomnessUnavailable,
+	/// Private owned-path validation or I/O failed.
+	Path(PathError),
+}
+impl Display for ConfigError {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::Oversized { limit } => write!(formatter, "configuration exceeds {limit} bytes"),
+			Self::Malformed => formatter.write_str("configuration is malformed"),
+			Self::UnsupportedVersion => formatter.write_str("configuration version is unsupported"),
+			Self::MissingActiveProfile => formatter.write_str("active profile is not declared"),
+			Self::InvalidProfile => formatter.write_str("server profile is invalid"),
+			Self::InvalidServerIdentity => formatter.write_str("server identity is invalid"),
+			Self::InvalidServerHostPath => formatter.write_str("server-host path is invalid"),
+			Self::InvalidPostgres => formatter.write_str("PostgreSQL configuration is invalid"),
+			Self::InvalidCache => formatter.write_str("cache configuration is invalid"),
+			Self::RandomnessUnavailable =>
+				formatter.write_str("operating-system randomness is unavailable"),
+			Self::Path(error) => Display::fmt(error, formatter),
+		}
+	}
+}
+
+impl std::error::Error for ConfigError {}
+
+impl From<PathError> for ConfigError {
+	fn from(error: PathError) -> Self {
+		Self::Path(error)
+	}
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawConfig {
+	version: u32,
+	active_profile: ProfileName,
+	profiles: BTreeMap<ProfileName, RawProfile>,
+	server_host: RawServerHostConfig,
+	postgres: RawPostgresConnectionConfig,
+	cache: RawCacheConfig,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum RawProfile {
+	Local { address: SocketAddr, expected_server_identity: Option<ServerIdentity> },
+	Remote { host: String, port: u16, expected_server_identity: ServerIdentity },
+}
+impl RawProfile {
+	fn validate(self) -> Result<ServerProfile, ConfigError> {
+		match self {
+			Self::Local { address, expected_server_identity } => {
+				if !address.ip().is_loopback() || address.port() == 0 {
+					return Err(ConfigError::InvalidProfile);
+				}
+
+				Ok(ServerProfile::Local(LocalProfile { address, expected_server_identity }))
+			},
+			Self::Remote { host, port, expected_server_identity } => {
+				if !valid_remote_host(&host) || port == 0 {
+					return Err(ConfigError::InvalidProfile);
+				}
+
+				Ok(ServerProfile::Remote(RemoteProfile { host, port, expected_server_identity }))
+			},
+		}
+	}
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawServerHostConfig {
+	repositories: BTreeMap<RepositoryName, RawServerRepository>,
+}
+impl RawServerHostConfig {
+	fn validate(self) -> Result<ServerHostConfig, ConfigError> {
+		let repositories = self
+			.repositories
+			.into_iter()
+			.map(|(name, repository)| {
+				let host_path = normalize_absolute_host_path(repository.host_path)?;
+
+				Ok((name, ServerRepositoryPath(host_path)))
+			})
+			.collect::<Result<BTreeMap<_, _>, ConfigError>>()?;
+
+		if repositories.is_empty() {
+			return Err(ConfigError::InvalidServerHostPath);
+		}
+
+		Ok(ServerHostConfig { repositories })
+	}
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawServerRepository {
+	host_path: PathBuf,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawPostgresConnectionConfig {
+	socket_directory: PathBuf,
+	database: String,
+	user: String,
+
+	credential_env_var: Option<String>,
+}
+impl RawPostgresConnectionConfig {
+	fn validate(self) -> Result<PostgresConnectionConfig, ConfigError> {
+		let socket_directory = normalize_absolute_host_path(self.socket_directory)
+			.map_err(|_| ConfigError::InvalidPostgres)?;
+
+		if !valid_database_field(&self.database) || !valid_database_field(&self.user) {
+			return Err(ConfigError::InvalidPostgres);
+		}
+		if self.credential_env_var.as_deref().is_some_and(|value| !valid_environment_name(value)) {
+			return Err(ConfigError::InvalidPostgres);
+		}
+
+		Ok(PostgresConnectionConfig {
+			socket_directory,
+			database: self.database,
+			user: self.user,
+			credential_env_var: self.credential_env_var,
+		})
+	}
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawCacheConfig {
+	max_entries: usize,
+	max_bytes: usize,
+	max_entry_bytes: usize,
+}
+impl RawCacheConfig {
+	fn validate(self) -> Result<CacheConfig, ConfigError> {
+		let limits = CacheLimits::new(self.max_entries, self.max_bytes, self.max_entry_bytes)
+			.map_err(|_| ConfigError::InvalidCache)?;
+
+		Ok(CacheConfig { limits })
+	}
+}
+
+fn validate_name(value: &str) -> Result<(), ConfigError> {
+	if value.is_empty()
+		|| value.len() > MAX_NAME_BYTES
+		|| !value.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+	{
+		return Err(ConfigError::Malformed);
+	}
+
+	Ok(())
+}
+
+fn normalize_absolute_host_path(path: PathBuf) -> Result<PathBuf, ConfigError> {
+	let encoded = path.as_os_str().as_encoded_bytes();
+
+	if encoded.len() > MAX_SERVER_HOST_PATH_BYTES
+		|| encoded.contains(&0)
+		|| !path.is_absolute()
+		|| path.parent().is_none()
+	{
+		return Err(ConfigError::InvalidServerHostPath);
+	}
+
+	let mut normalized = PathBuf::new();
+
+	for component in path.components() {
+		match component {
+			Component::ParentDir => return Err(ConfigError::InvalidServerHostPath),
+			Component::CurDir => {},
+			Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+				normalized.push(component.as_os_str());
+			},
+		}
+	}
+
+	if normalized.parent().is_none() {
+		return Err(ConfigError::InvalidServerHostPath);
+	}
+
+	Ok(normalized)
+}
+
+fn valid_remote_host(host: &str) -> bool {
+	if host.is_empty()
+		|| host.len() > MAX_HOST_BYTES
+		|| host
+			.bytes()
+			.any(|byte| byte.is_ascii_whitespace() || matches!(byte, b'/' | b'\\' | b'@'))
+	{
+		return false;
+	}
+
+	if let Ok(address) = host.parse::<IpAddr>() {
+		return !address.is_loopback();
+	}
+
+	if host.eq_ignore_ascii_case("localhost") || !host.is_ascii() {
+		return false;
+	}
+
+	host.split('.').all(|label| {
+		!label.is_empty()
+			&& label.len() <= 63
+			&& !label.starts_with('-')
+			&& !label.ends_with('-')
+			&& label.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+	})
+}
+
+fn valid_database_field(value: &str) -> bool {
+	!value.is_empty()
+		&& value.len() <= MAX_DATABASE_FIELD_BYTES
+		&& value.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+}
+
+fn valid_environment_name(value: &str) -> bool {
+	let mut bytes = value.bytes();
+	let Some(first) = bytes.next() else { return false };
+
+	(first.is_ascii_alphabetic() || first == b'_')
+		&& value.len() <= MAX_DATABASE_FIELD_BYTES
+		&& bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}

--- a/crates/decodex-core/src/identity.rs
+++ b/crates/decodex-core/src/identity.rs
@@ -1,0 +1,144 @@
+use std::{
+	fmt::{Debug, Display, Formatter},
+	io::ErrorKind,
+	str,
+};
+
+use serde::{Deserialize, Deserializer, de::Error};
+
+use crate::{ConfigError, DecodexPaths, PathError, paths};
+
+const MAX_IDENTITY_BYTES: usize = 64;
+
+/// Standard RFC 9562 UUID version 4 server identity.
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ServerIdentity(String);
+impl ServerIdentity {
+	/// Parse the canonical lowercase UUID version 4 representation.
+	pub fn parse(value: impl Into<String>) -> Result<Self, ConfigError> {
+		let value = value.into();
+
+		if !valid_uuid_v4(&value) {
+			return Err(ConfigError::InvalidServerIdentity);
+		}
+
+		Ok(Self(value))
+	}
+
+	/// Generate a standard UUID version 4 using the operating-system random source.
+	pub fn generate() -> Result<Self, ConfigError> {
+		let mut bytes = [0_u8; 16];
+
+		getrandom::fill(&mut bytes).map_err(|_| ConfigError::RandomnessUnavailable)?;
+
+		bytes[6] = (bytes[6] & 0x0f) | 0x40;
+		bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+		let encoded = format!(
+			"{}-{}-{}-{}-{}",
+			hex(&bytes[0..4]),
+			hex(&bytes[4..6]),
+			hex(&bytes[6..8]),
+			hex(&bytes[8..10]),
+			hex(&bytes[10..16]),
+		);
+
+		Self::parse(encoded)
+	}
+
+	/// Load the stable server-host identity or atomically create it exactly once.
+	pub fn load_or_create(paths: &DecodexPaths) -> Result<Self, ConfigError> {
+		paths.ensure_layout()?;
+
+		let path = paths.server_identity_file();
+
+		match Self::load(paths) {
+			Ok(identity) => return Ok(identity),
+			Err(ConfigError::Path(PathError::Io { kind: ErrorKind::NotFound, .. })) => {},
+			Err(error) => return Err(error),
+		}
+
+		let generated = Self::generate()?;
+		let body = format!("{generated}\n");
+
+		match paths::atomic_write_new(paths, &path, body.as_bytes(), MAX_IDENTITY_BYTES) {
+			Ok(()) => Ok(generated),
+			Err(PathError::AlreadyExists) => Self::load(paths),
+			Err(error) => Err(error.into()),
+		}
+	}
+
+	/// Load and validate an existing stable identity.
+	pub fn load(paths: &DecodexPaths) -> Result<Self, ConfigError> {
+		let bytes =
+			paths::read_private_file(paths, &paths.server_identity_file(), MAX_IDENTITY_BYTES)?;
+		let value = match bytes.as_slice() {
+			bytes if bytes.len() == 36 => bytes,
+			bytes if bytes.len() == 37 && bytes.last() == Some(&b'\n') => &bytes[..36],
+			_ => return Err(ConfigError::InvalidServerIdentity),
+		};
+		let value = str::from_utf8(value).map_err(|_| ConfigError::InvalidServerIdentity)?;
+
+		Self::parse(value.to_owned())
+	}
+
+	/// Canonical UUID text.
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+
+impl Debug for ServerIdentity {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.debug_tuple("ServerIdentity").field(&self.0).finish()
+	}
+}
+
+impl Display for ServerIdentity {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(&self.0)
+	}
+}
+
+impl<'de> Deserialize<'de> for ServerIdentity {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let value = String::deserialize(deserializer)?;
+
+		Self::parse(value).map_err(Error::custom)
+	}
+}
+
+fn valid_uuid_v4(value: &str) -> bool {
+	let bytes = value.as_bytes();
+
+	if bytes.len() != 36
+		|| bytes[8] != b'-'
+		|| bytes[13] != b'-'
+		|| bytes[18] != b'-'
+		|| bytes[23] != b'-'
+		|| bytes[14] != b'4'
+		|| !matches!(bytes[19], b'8' | b'9' | b'a' | b'b')
+	{
+		return false;
+	}
+
+	bytes.iter().enumerate().all(|(index, byte)| {
+		matches!(index, 8 | 13 | 18 | 23) || byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')
+	})
+}
+
+fn hex(bytes: &[u8]) -> String {
+	const HEX: &[u8; 16] = b"0123456789abcdef";
+
+	let mut encoded = String::with_capacity(bytes.len() * 2);
+
+	for &byte in bytes {
+		encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+		encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+	}
+
+	encoded
+}

--- a/crates/decodex-core/src/lib.rs
+++ b/crates/decodex-core/src/lib.rs
@@ -1,4 +1,30 @@
-//! Pure domain and application contracts for Decodex vNext.
+//! Domain, application, configuration, and owned local-storage foundations for Decodex vNext.
+
+mod blob;
+mod cache;
+mod config;
+mod identity;
+#[cfg(unix)] mod path_unix;
+mod paths;
+mod storage;
+
+pub use self::{
+	blob::{BlobHash, BlobStore, MAX_BLOB_BYTES},
+	cache::{
+		BoundedCache, CacheLimits, CacheUsage, MAX_CACHE_BYTES, MAX_CACHE_ENTRIES,
+		MAX_CACHE_ENTRY_BYTES,
+	},
+	config::{
+		CacheConfig, ConfigError, DecodexConfig, LocalProfile, MAX_CONFIG_BYTES,
+		PostgresConnectionConfig, ProfileName, RemoteProfile, RepositoryName, ServerHostConfig,
+		ServerProfile, ServerRepositoryPath,
+	},
+	identity::ServerIdentity,
+	paths::{DecodexPaths, DecodexRoot, PathError},
+	storage::StorageError,
+};
+
+#[cfg(test)] use tempfile as _;
 
 /// Application-facing product-state port.
 pub trait ProductState {

--- a/crates/decodex-core/src/path_unix.rs
+++ b/crates/decodex-core/src/path_unix.rs
@@ -1,0 +1,635 @@
+//! Descriptor-anchored Unix filesystem operations for Decodex-owned state.
+//!
+//! Every component is opened relative to an already validated directory descriptor.
+//! Final operations therefore cannot be redirected by swapping an ancestor path for a
+//! symbolic link between validation and I/O.
+
+use std::{
+	ffi::{CStr, CString, OsStr, OsString},
+	fs::{File, Metadata},
+	io::{self, ErrorKind, Read, Write},
+	mem::MaybeUninit,
+	os::{
+		fd::{AsRawFd as _, FromRawFd as _, RawFd},
+		unix::{
+			ffi::{OsStrExt as _, OsStringExt as _},
+			fs::MetadataExt as _,
+		},
+	},
+	path::{Component, Path, PathBuf},
+};
+
+use libc::{
+	AT_SYMLINK_NOFOLLOW, DIR, F_DUPFD_CLOEXEC, O_CLOEXEC, O_CREAT, O_DIRECTORY, O_EXCL, O_NOFOLLOW,
+	O_NONBLOCK, O_RDONLY, O_WRONLY, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG, c_uint, mode_t, stat, uid_t,
+};
+
+use crate::{
+	DecodexPaths, PathError,
+	paths::{self, AtomicMode, IoOperation, PRIVATE_DIRECTORY_MODE, PRIVATE_FILE_MODE},
+};
+
+const ROOT_PATH: &[u8] = b"/\0";
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ExpectedKind {
+	Directory,
+	File,
+}
+
+struct DirectoryStream(*mut DIR);
+impl DirectoryStream {
+	fn open(directory: &File) -> Result<Self, PathError> {
+		// SAFETY: `fcntl` duplicates an open descriptor and does not retain pointers.
+		let descriptor = unsafe { libc::fcntl(directory.as_raw_fd(), F_DUPFD_CLOEXEC, 0) };
+
+		if descriptor == -1 {
+			return Err(paths::io_error(IoOperation::List, io::Error::last_os_error()));
+		}
+
+		// SAFETY: `descriptor` is a fresh directory descriptor. On success, `fdopendir`
+		// assumes ownership; on failure, this function closes it below.
+		let stream = unsafe { libc::fdopendir(descriptor) };
+
+		if stream.is_null() {
+			let error = io::Error::last_os_error();
+
+			// SAFETY: ownership was not transferred when `fdopendir` returned null.
+			unsafe { libc::close(descriptor) };
+
+			return Err(paths::io_error(IoOperation::List, error));
+		}
+
+		Ok(Self(stream))
+	}
+
+	fn next_name(&mut self) -> Result<Option<OsString>, PathError> {
+		loop {
+			clear_errno();
+
+			// SAFETY: `self.0` remains an open `DIR` until `Drop`; `readdir` owns the
+			// returned entry storage until the next call on this stream.
+			let entry = unsafe { libc::readdir(self.0) };
+
+			if entry.is_null() {
+				let error = current_errno();
+
+				return if error == 0 {
+					Ok(None)
+				} else {
+					Err(paths::io_error(IoOperation::List, io::Error::from_raw_os_error(error)))
+				};
+			}
+
+			// SAFETY: a non-null `dirent` from `readdir` contains a NUL-terminated
+			// `d_name` valid until the next call on this stream.
+			let bytes = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) }.to_bytes();
+
+			if matches!(bytes, b"." | b"..") {
+				continue;
+			}
+
+			return Ok(Some(OsString::from_vec(bytes.to_vec())));
+		}
+	}
+}
+
+impl Drop for DirectoryStream {
+	fn drop(&mut self) {
+		// SAFETY: `self.0` is a non-null `DIR` uniquely owned by this guard.
+		unsafe { libc::closedir(self.0) };
+	}
+}
+
+pub(crate) fn ensure_layout(paths: &DecodexPaths) -> Result<(), PathError> {
+	open_root(paths, true)?;
+
+	for relative in ["logs", "blobs", "blobs/sha256", "cache", "server"] {
+		ensure_owned_directory(paths, Path::new(relative))?;
+	}
+
+	Ok(())
+}
+
+pub(crate) fn ensure_owned_directory(
+	paths: &DecodexPaths,
+	relative: &Path,
+) -> Result<PathBuf, PathError> {
+	paths::validate_relative(relative)?;
+
+	let mut directory = open_root(paths, true)?;
+	let mut result = paths.root().as_path().to_path_buf();
+
+	for component in relative.components() {
+		let Component::Normal(name) = component else {
+			return Err(PathError::Escape);
+		};
+
+		directory = ensure_private_directory_at(&directory, name)?;
+
+		result.push(name);
+	}
+
+	Ok(result)
+}
+
+pub(crate) fn read_private_file(
+	paths: &DecodexPaths,
+	path: &Path,
+	maximum_bytes: usize,
+) -> Result<Vec<u8>, PathError> {
+	let (parent, name) = open_file_parent(paths, path)?;
+	let file = open_private_file_at(&parent, &name)?;
+	let metadata = file.metadata().map_err(|error| paths::io_error(IoOperation::Inspect, error))?;
+
+	if metadata.len() > u64::try_from(maximum_bytes).unwrap_or(u64::MAX) {
+		return Err(PathError::Oversized { limit: maximum_bytes });
+	}
+
+	let mut bytes = Vec::with_capacity(metadata.len().min(maximum_bytes as u64) as usize);
+
+	file.take((maximum_bytes as u64).saturating_add(1))
+		.read_to_end(&mut bytes)
+		.map_err(|error| paths::io_error(IoOperation::Read, error))?;
+
+	if bytes.len() > maximum_bytes {
+		return Err(PathError::Oversized { limit: maximum_bytes });
+	}
+
+	Ok(bytes)
+}
+
+pub(crate) fn atomic_write(
+	paths: &DecodexPaths,
+	path: &Path,
+	bytes: &[u8],
+	maximum_bytes: usize,
+	mode: AtomicMode,
+) -> Result<(), PathError> {
+	if bytes.len() > maximum_bytes {
+		return Err(PathError::Oversized { limit: maximum_bytes });
+	}
+
+	let (parent, target_name) = open_file_parent(paths, path)?;
+
+	match open_private_file_at(&parent, &target_name) {
+		Ok(_) if mode == AtomicMode::CreateOnly => return Err(PathError::AlreadyExists),
+		Ok(_) => {},
+		Err(PathError::Io { kind: ErrorKind::NotFound, .. }) => {},
+		Err(error) => return Err(error),
+	}
+
+	let (temporary_name, mut temporary_file) = create_temporary_file(&parent)?;
+	let result = (|| {
+		temporary_file
+			.write_all(bytes)
+			.map_err(|error| paths::io_error(IoOperation::Write, error))?;
+		temporary_file.sync_all().map_err(|error| paths::io_error(IoOperation::Sync, error))?;
+
+		verify_private_file_metadata(
+			&temporary_file
+				.metadata()
+				.map_err(|error| paths::io_error(IoOperation::Inspect, error))?,
+		)?;
+
+		match mode {
+			AtomicMode::Replace => rename_at(&parent, &temporary_name, &target_name)?,
+			AtomicMode::CreateOnly => {
+				link_at(&parent, &temporary_name, &target_name)?;
+				unlink_at(&parent, &temporary_name)?;
+			},
+		}
+
+		parent.sync_all().map_err(|error| paths::io_error(IoOperation::Sync, error))
+	})();
+
+	if result.is_err() {
+		let _ = unlink_at(&parent, &temporary_name);
+	}
+
+	result
+}
+
+pub(crate) fn remove_private_file(paths: &DecodexPaths, path: &Path) -> Result<(), PathError> {
+	let (parent, name) = open_file_parent(paths, path)?;
+	let file = open_private_file_at(&parent, &name)?;
+
+	unlink_at(&parent, &name)?;
+	drop(file);
+
+	parent.sync_all().map_err(|error| paths::io_error(IoOperation::Sync, error))
+}
+
+pub(crate) fn visit_private_files<E>(
+	paths: &DecodexPaths,
+	directory: &Path,
+	mut visitor: impl FnMut(PathBuf, Metadata) -> Result<(), E>,
+) -> Result<(), E>
+where
+	E: From<PathError>,
+{
+	let directory_file = open_owned_directory(paths, directory).map_err(E::from)?;
+	let mut stream = DirectoryStream::open(&directory_file).map_err(E::from)?;
+
+	while let Some(name) = stream.next_name().map_err(E::from)? {
+		let file = open_private_file_at(&directory_file, &name).map_err(E::from)?;
+		let metadata = file
+			.metadata()
+			.map_err(|error| E::from(paths::io_error(IoOperation::Inspect, error)))?;
+
+		visitor(directory.join(name), metadata)?;
+	}
+
+	Ok(())
+}
+
+fn open_root(paths: &DecodexPaths, create: bool) -> Result<File, PathError> {
+	let root = paths.root().as_path();
+	let components = root
+		.components()
+		.filter_map(|component| match component {
+			Component::Normal(name) => Some(name),
+			_ => None,
+		})
+		.collect::<Vec<_>>();
+	let Some((last, ancestors)) = components.split_last() else {
+		return Err(PathError::UnsafeRoot);
+	};
+	let mut directory = open_filesystem_root()?;
+
+	for name in ancestors {
+		directory = open_directory_at(&directory, name)?;
+	}
+
+	let root = if create {
+		ensure_private_directory_at(&directory, last)?
+	} else {
+		let root = open_directory_at(&directory, last)?;
+
+		verify_private_directory_metadata(
+			&root.metadata().map_err(|error| paths::io_error(IoOperation::Inspect, error))?,
+		)?;
+
+		root
+	};
+
+	Ok(root)
+}
+
+fn open_filesystem_root() -> Result<File, PathError> {
+	let path = CStr::from_bytes_with_nul(ROOT_PATH).map_err(|_| PathError::UnsafeRoot)?;
+	// SAFETY: `path` is a valid NUL-terminated C string and successful `open` returns
+	// a new descriptor owned by the caller.
+	let descriptor = unsafe { libc::open(path.as_ptr(), O_RDONLY | O_DIRECTORY | O_CLOEXEC) };
+
+	file_from_descriptor(descriptor, IoOperation::Open)
+}
+
+fn open_owned_directory(paths: &DecodexPaths, path: &Path) -> Result<File, PathError> {
+	let relative = path.strip_prefix(paths.root().as_path()).map_err(|_| PathError::Escape)?;
+
+	paths::validate_relative(relative)?;
+
+	let mut directory = open_root(paths, false)?;
+
+	for component in relative.components() {
+		let Component::Normal(name) = component else {
+			return Err(PathError::Escape);
+		};
+
+		directory = open_directory_at(&directory, name)?;
+
+		verify_private_directory_metadata(
+			&directory.metadata().map_err(|error| paths::io_error(IoOperation::Inspect, error))?,
+		)?;
+	}
+
+	Ok(directory)
+}
+
+fn open_file_parent(paths: &DecodexPaths, path: &Path) -> Result<(File, OsString), PathError> {
+	let relative = path.strip_prefix(paths.root().as_path()).map_err(|_| PathError::Escape)?;
+
+	paths::validate_relative(relative)?;
+
+	let mut components = relative.components().peekable();
+	let mut directory = open_root(paths, false)?;
+
+	while let Some(component) = components.next() {
+		let Component::Normal(name) = component else {
+			return Err(PathError::Escape);
+		};
+
+		if components.peek().is_none() {
+			return Ok((directory, name.to_os_string()));
+		}
+
+		directory = open_directory_at(&directory, name)?;
+
+		verify_private_directory_metadata(
+			&directory.metadata().map_err(|error| paths::io_error(IoOperation::Inspect, error))?,
+		)?;
+	}
+
+	Err(PathError::Escape)
+}
+
+fn ensure_private_directory_at(parent: &File, name: &OsStr) -> Result<File, PathError> {
+	let name = c_name(name)?;
+
+	match open_directory_at_c(parent, &name) {
+		Ok(directory) => {
+			verify_private_directory_metadata(
+				&directory
+					.metadata()
+					.map_err(|error| paths::io_error(IoOperation::Inspect, error))?,
+			)?;
+
+			Ok(directory)
+		},
+		Err(PathError::Io { kind: ErrorKind::NotFound, .. }) => {
+			// SAFETY: `parent` is open, `name` is NUL-terminated, and `mkdirat` does
+			// not retain either pointer.
+			let result = unsafe {
+				libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), PRIVATE_DIRECTORY_MODE as mode_t)
+			};
+
+			if result == -1 {
+				let error = io::Error::last_os_error();
+
+				if error.kind() != ErrorKind::AlreadyExists {
+					return Err(paths::io_error(IoOperation::CreateDirectory, error));
+				}
+			}
+
+			let directory = open_directory_at_c(parent, &name)?;
+
+			verify_private_directory_metadata(
+				&directory
+					.metadata()
+					.map_err(|error| paths::io_error(IoOperation::Inspect, error))?,
+			)?;
+
+			Ok(directory)
+		},
+		Err(error) => Err(error),
+	}
+}
+
+fn open_directory_at(parent: &File, name: &OsStr) -> Result<File, PathError> {
+	open_directory_at_c(parent, &c_name(name)?)
+}
+
+fn open_directory_at_c(parent: &File, name: &CStr) -> Result<File, PathError> {
+	// SAFETY: `parent` is an open directory, `name` is NUL-terminated, and a
+	// successful `openat` returns a new descriptor owned by the caller.
+	let descriptor = unsafe {
+		libc::openat(
+			parent.as_raw_fd(),
+			name.as_ptr(),
+			O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC,
+		)
+	};
+
+	if descriptor == -1 {
+		let error = io::Error::last_os_error();
+
+		return Err(classify_at_error(parent, name, error, ExpectedKind::Directory));
+	}
+
+	file_from_descriptor(descriptor, IoOperation::Open)
+}
+
+fn open_private_file_at(parent: &File, name: &OsStr) -> Result<File, PathError> {
+	let name = c_name(name)?;
+	// `O_NONBLOCK` prevents a hostile FIFO in a file position from blocking before
+	// `fstat` can reject its kind.
+	// SAFETY: `parent` is an open directory, `name` is NUL-terminated, and a
+	// successful `openat` returns a new descriptor owned by the caller.
+	let descriptor = unsafe {
+		libc::openat(
+			parent.as_raw_fd(),
+			name.as_ptr(),
+			O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC,
+		)
+	};
+
+	if descriptor == -1 {
+		let error = io::Error::last_os_error();
+
+		return Err(classify_at_error(parent, &name, error, ExpectedKind::File));
+	}
+
+	let file = file_from_descriptor(descriptor, IoOperation::Open)?;
+
+	verify_private_file_metadata(
+		&file.metadata().map_err(|error| paths::io_error(IoOperation::Inspect, error))?,
+	)?;
+
+	Ok(file)
+}
+
+fn create_temporary_file(parent: &File) -> Result<(OsString, File), PathError> {
+	for _ in 0..8 {
+		let mut random = [0_u8; 16];
+
+		getrandom::fill(&mut random).map_err(|_| PathError::RandomnessUnavailable)?;
+
+		let name = OsString::from(format!("{}{}", paths::ATOMIC_TEMPORARY_PREFIX, hex(&random)));
+		let c_name = c_name(&name)?;
+		// SAFETY: `parent` is an open directory, `c_name` is NUL-terminated, and a
+		// successful `openat` returns a new descriptor owned by the caller.
+		let descriptor = unsafe {
+			libc::openat(
+				parent.as_raw_fd(),
+				c_name.as_ptr(),
+				O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+				PRIVATE_FILE_MODE as c_uint,
+			)
+		};
+
+		if descriptor != -1 {
+			return file_from_descriptor(descriptor, IoOperation::Open).map(|file| (name, file));
+		}
+
+		let error = io::Error::last_os_error();
+
+		if error.kind() != ErrorKind::AlreadyExists {
+			return Err(paths::io_error(IoOperation::Open, error));
+		}
+	}
+
+	Err(PathError::AlreadyExists)
+}
+
+fn rename_at(parent: &File, source: &OsStr, target: &OsStr) -> Result<(), PathError> {
+	let source = c_name(source)?;
+	let target = c_name(target)?;
+	// SAFETY: both names are valid C strings and both are resolved relative to the
+	// same open directory descriptor.
+	let result = unsafe {
+		libc::renameat(parent.as_raw_fd(), source.as_ptr(), parent.as_raw_fd(), target.as_ptr())
+	};
+
+	zero_result(result, IoOperation::Rename)
+}
+
+fn link_at(parent: &File, source: &OsStr, target: &OsStr) -> Result<(), PathError> {
+	let source = c_name(source)?;
+	let target = c_name(target)?;
+	// SAFETY: both names are valid C strings and both are resolved relative to the
+	// same open directory descriptor. Flags are zero, so no symbolic link is followed.
+	let result = unsafe {
+		libc::linkat(parent.as_raw_fd(), source.as_ptr(), parent.as_raw_fd(), target.as_ptr(), 0)
+	};
+
+	if result == -1 {
+		let error = io::Error::last_os_error();
+
+		if error.kind() == ErrorKind::AlreadyExists {
+			return Err(PathError::AlreadyExists);
+		}
+
+		return Err(paths::io_error(IoOperation::Link, error));
+	}
+
+	Ok(())
+}
+
+fn unlink_at(parent: &File, name: &OsStr) -> Result<(), PathError> {
+	let name = c_name(name)?;
+	// SAFETY: `name` is a valid C string resolved relative to the open directory;
+	// flags are zero, so only a non-directory entry itself is removed.
+	let result = unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), 0) };
+
+	zero_result(result, IoOperation::Remove)
+}
+
+fn classify_at_error(
+	parent: &File,
+	name: &CStr,
+	error: io::Error,
+	expected: ExpectedKind,
+) -> PathError {
+	let mut status = MaybeUninit::<stat>::uninit();
+	// SAFETY: `parent` and `name` are valid for this call; `status` points to enough
+	// writable memory and is read only when `fstatat` reports success.
+	let result = unsafe {
+		libc::fstatat(parent.as_raw_fd(), name.as_ptr(), status.as_mut_ptr(), AT_SYMLINK_NOFOLLOW)
+	};
+
+	if result == 0 {
+		// SAFETY: successful `fstatat` initialized the complete `stat` value.
+		let status = unsafe { status.assume_init() };
+		let kind = status.st_mode & S_IFMT;
+
+		if kind == S_IFLNK {
+			return PathError::Symlink;
+		}
+		if expected == ExpectedKind::Directory && kind != S_IFDIR {
+			return PathError::UnexpectedDirectoryKind;
+		}
+		if expected == ExpectedKind::File && kind != S_IFREG {
+			return PathError::UnexpectedFileKind;
+		}
+	}
+
+	paths::io_error(IoOperation::Open, error)
+}
+
+fn verify_private_directory_metadata(metadata: &Metadata) -> Result<(), PathError> {
+	if !metadata.is_dir() {
+		return Err(PathError::UnexpectedDirectoryKind);
+	}
+
+	let mode = metadata.mode() & 0o777;
+
+	if metadata.uid() != effective_user_id() || mode != PRIVATE_DIRECTORY_MODE {
+		return Err(PathError::InsecurePermissions);
+	}
+
+	Ok(())
+}
+
+fn verify_private_file_metadata(metadata: &Metadata) -> Result<(), PathError> {
+	if !metadata.is_file() {
+		return Err(PathError::UnexpectedFileKind);
+	}
+
+	let mode = metadata.mode() & 0o777;
+
+	if metadata.uid() != effective_user_id()
+		|| mode & 0o077 != 0
+		|| mode & 0o400 == 0
+		|| mode & 0o111 != 0
+	{
+		return Err(PathError::InsecurePermissions);
+	}
+
+	Ok(())
+}
+
+fn effective_user_id() -> uid_t {
+	// SAFETY: `geteuid` takes no pointers and has no preconditions.
+	unsafe { libc::geteuid() }
+}
+
+fn file_from_descriptor(descriptor: RawFd, operation: IoOperation) -> Result<File, PathError> {
+	if descriptor == -1 {
+		return Err(paths::io_error(operation, io::Error::last_os_error()));
+	}
+
+	// SAFETY: every caller passes a newly returned, successful descriptor and transfers
+	// sole ownership to this `File`.
+	Ok(unsafe { File::from_raw_fd(descriptor) })
+}
+
+fn zero_result(result: i32, operation: IoOperation) -> Result<(), PathError> {
+	if result == -1 {
+		return Err(paths::io_error(operation, io::Error::last_os_error()));
+	}
+
+	Ok(())
+}
+
+fn c_name(name: &OsStr) -> Result<CString, PathError> {
+	CString::new(name.as_bytes()).map_err(|_| PathError::Escape)
+}
+
+#[cfg(target_vendor = "apple")]
+fn clear_errno() {
+	// SAFETY: `__error` returns the calling thread's errno slot.
+	unsafe { *libc::__error() = 0 };
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+fn clear_errno() {
+	// SAFETY: `__errno_location` returns the calling thread's errno slot.
+	unsafe { *libc::__errno_location() = 0 };
+}
+
+#[cfg(not(any(target_vendor = "apple", target_os = "android", target_os = "linux")))]
+fn clear_errno() {}
+
+#[cfg(any(target_vendor = "apple", target_os = "android", target_os = "linux"))]
+fn current_errno() -> i32 {
+	io::Error::last_os_error().raw_os_error().unwrap_or(0)
+}
+
+#[cfg(not(any(target_vendor = "apple", target_os = "android", target_os = "linux")))]
+fn current_errno() -> i32 {
+	0
+}
+
+fn hex(bytes: &[u8]) -> String {
+	const HEX: &[u8; 16] = b"0123456789abcdef";
+
+	let mut encoded = String::with_capacity(bytes.len() * 2);
+
+	for &byte in bytes {
+		encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+		encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+	}
+
+	encoded
+}

--- a/crates/decodex-core/src/paths.rs
+++ b/crates/decodex-core/src/paths.rs
@@ -1,0 +1,723 @@
+#[cfg(not(any(unix, windows)))] use std::ffi::OsString;
+use std::{
+	env,
+	ffi::OsStr,
+	fmt::{Debug, Display, Formatter},
+	fs::Metadata,
+	io,
+	path::{Component, Path, PathBuf},
+};
+#[cfg(not(unix))] use std::{
+	fs::{self, DirBuilder, OpenOptions},
+	io::{Read, Write},
+};
+
+use crate::path_unix;
+
+pub(crate) const PRIVATE_DIRECTORY_MODE: u32 = 0o700;
+pub(crate) const PRIVATE_FILE_MODE: u32 = 0o600;
+pub(crate) const ATOMIC_TEMPORARY_PREFIX: &str = ".tmp-";
+
+const MAX_ROOT_PATH_BYTES: usize = 4 * 1_024;
+
+/// Typed Decodex-owned root. All product-owned paths are derived from this value.
+#[derive(Clone, Eq, PartialEq)]
+pub struct DecodexRoot(PathBuf);
+impl DecodexRoot {
+	/// Validate an explicitly configured Decodex root.
+	///
+	/// The root must be absolute, distinct from the filesystem root, and outside every
+	/// `.codex` subtree. Accepted lexical `.` and repeated-separator forms are stored in
+	/// one normalized representation; parent traversal is rejected. The `.codex` guard
+	/// prevents vNext product state from entering Codex-owned storage.
+	pub fn new(path: impl Into<PathBuf>) -> Result<Self, PathError> {
+		let path = path.into();
+		let encoded = path.as_os_str().as_encoded_bytes();
+
+		if encoded.len() > MAX_ROOT_PATH_BYTES || encoded.contains(&0) {
+			return Err(PathError::UnsafeRoot);
+		}
+
+		let path = normalize_absolute(path)?;
+
+		for component in path.components() {
+			match component {
+				Component::ParentDir | Component::CurDir => return Err(PathError::UnsafeRoot),
+				Component::Normal(value) if is_codex_component(value) => {
+					return Err(PathError::CodexOwnedRoot);
+				},
+				_ => {},
+			}
+		}
+
+		Ok(Self(path))
+	}
+
+	/// Derive the canonical Decodex root below an explicit platform home directory.
+	pub fn from_home(home: impl AsRef<Path>) -> Result<Self, PathError> {
+		let home = home.as_ref();
+
+		if !home.is_absolute() || home.parent().is_none() {
+			return Err(PathError::UnsafeRoot);
+		}
+
+		Self::new(home.join(".decodex"))
+	}
+
+	/// Resolve the platform home and derive its canonical `~/.decodex` root.
+	pub fn platform_default() -> Result<Self, PathError> {
+		#[cfg(unix)]
+		let home = env::var_os("HOME");
+		#[cfg(windows)]
+		let home = env::var_os("USERPROFILE");
+		#[cfg(not(any(unix, windows)))]
+		let home: Option<OsString> = None;
+		let home = home.filter(|value| !value.is_empty()).ok_or(PathError::HomeUnavailable)?;
+
+		Self::from_home(PathBuf::from(home))
+	}
+
+	/// Absolute root path.
+	pub fn as_path(&self) -> &Path {
+		&self.0
+	}
+
+	/// Derive the complete owned path layout.
+	pub fn paths(&self) -> DecodexPaths {
+		DecodexPaths { root: self.clone() }
+	}
+}
+
+impl Debug for DecodexRoot {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str("DecodexRoot(<redacted>)")
+	}
+}
+
+/// Fixed, typed path layout for Decodex-owned vNext files.
+#[derive(Clone, Eq, PartialEq)]
+pub struct DecodexPaths {
+	root: DecodexRoot,
+}
+impl DecodexPaths {
+	/// Configured Decodex-owned root.
+	pub fn root(&self) -> &DecodexRoot {
+		&self.root
+	}
+
+	/// Bounded operator configuration file.
+	pub fn config_file(&self) -> PathBuf {
+		self.join("config.toml")
+	}
+
+	/// Decodex-owned log directory.
+	pub fn logs_dir(&self) -> PathBuf {
+		self.join("logs")
+	}
+
+	/// Content-addressed SHA-256 blob directory.
+	pub fn blobs_dir(&self) -> PathBuf {
+		self.join("blobs/sha256")
+	}
+
+	/// Disposable bounded cache directory.
+	pub fn cache_dir(&self) -> PathBuf {
+		self.join("cache")
+	}
+
+	/// Server-host-only state directory.
+	pub fn server_dir(&self) -> PathBuf {
+		self.join("server")
+	}
+
+	/// Stable server identity file.
+	pub fn server_identity_file(&self) -> PathBuf {
+		self.join("server/identity")
+	}
+
+	/// Create and verify the private fixed directory layout.
+	pub fn ensure_layout(&self) -> Result<(), PathError> {
+		#[cfg(unix)]
+		{
+			path_unix::ensure_layout(self)
+		}
+
+		#[cfg(not(unix))]
+		{
+			verify_existing_ancestors(self.root.as_path())?;
+			ensure_private_directory(self.root.as_path())?;
+
+			for relative in ["logs", "blobs", "blobs/sha256", "cache", "server"] {
+				self.ensure_owned_directory(Path::new(relative))?;
+			}
+
+			Ok(())
+		}
+	}
+
+	pub(crate) fn join(&self, relative: impl AsRef<Path>) -> PathBuf {
+		self.root.as_path().join(relative)
+	}
+
+	pub(crate) fn ensure_owned_directory(&self, relative: &Path) -> Result<PathBuf, PathError> {
+		#[cfg(unix)]
+		{
+			path_unix::ensure_owned_directory(self, relative)
+		}
+
+		#[cfg(not(unix))]
+		{
+			validate_relative(relative)?;
+			verify_existing_ancestors(self.root.as_path())?;
+			ensure_private_directory(self.root.as_path())?;
+
+			let mut current = self.root.as_path().to_path_buf();
+
+			for component in relative.components() {
+				let Component::Normal(component) = component else {
+					return Err(PathError::Escape);
+				};
+
+				current.push(component);
+
+				ensure_private_directory(&current)?;
+			}
+
+			Ok(current)
+		}
+	}
+
+	#[cfg(not(unix))]
+	pub(crate) fn validate_file_parent(&self, path: &Path) -> Result<(), PathError> {
+		let parent = path.parent().ok_or(PathError::Escape)?;
+		let relative = parent.strip_prefix(self.root.as_path()).map_err(|_| PathError::Escape)?;
+
+		validate_relative(relative)?;
+		verify_existing_ancestors(self.root.as_path())?;
+		verify_private_directory(self.root.as_path())?;
+
+		let mut current = self.root.as_path().to_path_buf();
+
+		for component in relative.components() {
+			let Component::Normal(component) = component else {
+				return Err(PathError::Escape);
+			};
+
+			current.push(component);
+
+			verify_private_directory(&current)?;
+		}
+
+		Ok(())
+	}
+}
+
+impl Debug for DecodexPaths {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str("DecodexPaths(<redacted>)")
+	}
+}
+
+/// Typed fail-closed filesystem error. It intentionally stores no file contents or
+/// underlying error strings, so malformed secret-bearing input cannot leak through
+/// `Display` or `Debug`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PathError {
+	/// Root was relative, used parent traversal, or was the filesystem root.
+	UnsafeRoot,
+	/// Root was placed below Codex-owned `.codex` storage.
+	CodexOwnedRoot,
+	/// The platform home directory was unavailable.
+	HomeUnavailable,
+	/// A caller-supplied path escaped its typed owner.
+	Escape,
+	/// A symbolic link appeared at an owned boundary.
+	Symlink,
+	/// A directory was expected but another file kind was present.
+	UnexpectedDirectoryKind,
+	/// A regular file was expected but another file kind was present.
+	UnexpectedFileKind,
+	/// Group/other access, executable file bits, or missing owner access was present.
+	InsecurePermissions,
+	/// An input exceeded its explicit byte limit.
+	Oversized {
+		/// Maximum accepted bytes.
+		limit: usize,
+	},
+	/// A create-only atomic target already exists.
+	AlreadyExists,
+	/// The operating system randomness source was unavailable.
+	RandomnessUnavailable,
+	/// A bounded I/O operation failed without retaining potentially sensitive details.
+	Io {
+		/// Stable operation category.
+		operation: IoOperation,
+		/// Redacted standard-library error category.
+		kind: io::ErrorKind,
+	},
+}
+impl Display for PathError {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::UnsafeRoot => formatter.write_str("unsafe Decodex root"),
+			Self::CodexOwnedRoot => formatter.write_str("Decodex root cannot be inside .codex"),
+			Self::HomeUnavailable => formatter.write_str("platform home directory is unavailable"),
+			Self::Escape => formatter.write_str("path escapes its Decodex owner"),
+			Self::Symlink => formatter.write_str("symbolic links are forbidden in Decodex storage"),
+			Self::UnexpectedDirectoryKind => formatter.write_str("expected a private directory"),
+			Self::UnexpectedFileKind => formatter.write_str("expected a private regular file"),
+			Self::InsecurePermissions => formatter.write_str("insecure Decodex file permissions"),
+			Self::Oversized { limit } => write!(formatter, "input exceeds the {limit}-byte limit"),
+			Self::AlreadyExists => formatter.write_str("atomic target already exists"),
+			Self::RandomnessUnavailable =>
+				formatter.write_str("operating system randomness is unavailable"),
+			Self::Io { operation, kind } => write!(formatter, "{operation:?} failed: {kind:?}"),
+		}
+	}
+}
+
+impl std::error::Error for PathError {}
+
+/// Stable operation labels for redacted filesystem errors.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IoOperation {
+	CreateDirectory,
+	Inspect,
+	Open,
+	Read,
+	Write,
+	Sync,
+	Link,
+	Rename,
+	Remove,
+	List,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) enum AtomicMode {
+	CreateOnly,
+	Replace,
+}
+
+pub(crate) fn is_atomic_temporary_file(path: &Path) -> bool {
+	let Some(name) = path.file_name().and_then(OsStr::to_str) else { return false };
+	let Some(random) = name.strip_prefix(ATOMIC_TEMPORARY_PREFIX) else { return false };
+
+	random.len() == 32
+		&& random.bytes().all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+pub(crate) fn read_private_file(
+	paths: &DecodexPaths,
+	path: &Path,
+	maximum_bytes: usize,
+) -> Result<Vec<u8>, PathError> {
+	#[cfg(unix)]
+	{
+		path_unix::read_private_file(paths, path, maximum_bytes)
+	}
+
+	#[cfg(not(unix))]
+	paths.validate_file_parent(path)?;
+
+	#[cfg(not(unix))]
+	{
+		let metadata = private_file_metadata(path)?;
+
+		if metadata.len() > u64::try_from(maximum_bytes).unwrap_or(u64::MAX) {
+			return Err(PathError::Oversized { limit: maximum_bytes });
+		}
+
+		let mut options = OpenOptions::new();
+
+		options.read(true);
+
+		apply_no_follow(&mut options);
+
+		let file = options.open(path).map_err(|error| io_error(IoOperation::Open, error))?;
+
+		verify_private_file_metadata(
+			&file.metadata().map_err(|error| io_error(IoOperation::Inspect, error))?,
+		)?;
+
+		let mut bytes = Vec::with_capacity(metadata.len().min(maximum_bytes as u64) as usize);
+
+		file.take((maximum_bytes as u64).saturating_add(1))
+			.read_to_end(&mut bytes)
+			.map_err(|error| io_error(IoOperation::Read, error))?;
+
+		if bytes.len() > maximum_bytes {
+			return Err(PathError::Oversized { limit: maximum_bytes });
+		}
+
+		Ok(bytes)
+	}
+}
+
+pub(crate) fn atomic_write_new(
+	paths: &DecodexPaths,
+	path: &Path,
+	bytes: &[u8],
+	maximum_bytes: usize,
+) -> Result<(), PathError> {
+	#[cfg(unix)]
+	{
+		path_unix::atomic_write(paths, path, bytes, maximum_bytes, AtomicMode::CreateOnly)
+	}
+	#[cfg(not(unix))]
+	{
+		atomic_write(paths, path, bytes, maximum_bytes, AtomicMode::CreateOnly)
+	}
+}
+
+pub(crate) fn atomic_write_replace(
+	paths: &DecodexPaths,
+	path: &Path,
+	bytes: &[u8],
+	maximum_bytes: usize,
+) -> Result<(), PathError> {
+	#[cfg(unix)]
+	{
+		path_unix::atomic_write(paths, path, bytes, maximum_bytes, AtomicMode::Replace)
+	}
+	#[cfg(not(unix))]
+	{
+		atomic_write(paths, path, bytes, maximum_bytes, AtomicMode::Replace)
+	}
+}
+
+pub(crate) fn remove_private_file(paths: &DecodexPaths, path: &Path) -> Result<(), PathError> {
+	#[cfg(unix)]
+	{
+		path_unix::remove_private_file(paths, path)
+	}
+
+	#[cfg(not(unix))]
+	{
+		paths.validate_file_parent(path)?;
+
+		private_file_metadata(path)?;
+
+		fs::remove_file(path).map_err(|error| io_error(IoOperation::Remove, error))?;
+
+		sync_directory(path.parent().ok_or(PathError::Escape)?)
+	}
+}
+
+pub(crate) fn visit_private_files<E>(
+	paths: &DecodexPaths,
+	directory: &Path,
+	visitor: impl FnMut(PathBuf, Metadata) -> Result<(), E>,
+) -> Result<(), E>
+where
+	E: From<PathError>,
+{
+	#[cfg(unix)]
+	{
+		path_unix::visit_private_files(paths, directory, visitor)
+	}
+
+	#[cfg(not(unix))]
+	{
+		let relative =
+			directory.strip_prefix(paths.root.as_path()).map_err(|_| PathError::Escape.into())?;
+
+		validate_relative(relative).map_err(E::from)?;
+		verify_existing_ancestors(paths.root.as_path()).map_err(E::from)?;
+		verify_private_directory(directory).map_err(E::from)?;
+
+		let entries =
+			fs::read_dir(directory).map_err(|error| E::from(io_error(IoOperation::List, error)))?;
+		let mut visitor = visitor;
+
+		for entry in entries {
+			let entry = entry.map_err(|error| E::from(io_error(IoOperation::List, error)))?;
+			let path = entry.path();
+			let metadata = fs::symlink_metadata(&path)
+				.map_err(|error| E::from(io_error(IoOperation::Inspect, error)))?;
+			let file_type = entry
+				.file_type()
+				.map_err(|error| E::from(io_error(IoOperation::Inspect, error)))?;
+
+			if file_type.is_symlink() {
+				return Err(PathError::Symlink.into());
+			}
+			if !file_type.is_file() {
+				return Err(PathError::UnexpectedFileKind.into());
+			}
+
+			verify_private_file_metadata(&metadata).map_err(E::from)?;
+			visitor(path, metadata)?;
+		}
+
+		Ok(())
+	}
+}
+
+pub(crate) fn validate_relative(path: &Path) -> Result<(), PathError> {
+	if path.is_absolute() {
+		return Err(PathError::Escape);
+	}
+
+	for component in path.components() {
+		if !matches!(component, Component::Normal(_)) {
+			return Err(PathError::Escape);
+		}
+	}
+
+	Ok(())
+}
+
+#[cfg(not(unix))]
+pub(crate) fn verify_directory_permissions(_metadata: &Metadata) -> Result<(), PathError> {
+	Ok(())
+}
+
+#[cfg(not(unix))]
+pub(crate) fn verify_file_permissions(_metadata: &Metadata) -> Result<(), PathError> {
+	Ok(())
+}
+
+pub(crate) fn io_error(operation: IoOperation, error: io::Error) -> PathError {
+	PathError::Io { operation, kind: error.kind() }
+}
+
+#[cfg(not(unix))]
+fn atomic_write(
+	paths: &DecodexPaths,
+	path: &Path,
+	bytes: &[u8],
+	maximum_bytes: usize,
+	mode: AtomicMode,
+) -> Result<(), PathError> {
+	if bytes.len() > maximum_bytes {
+		return Err(PathError::Oversized { limit: maximum_bytes });
+	}
+
+	paths.validate_file_parent(path)?;
+
+	match fs::symlink_metadata(path) {
+		Ok(metadata) => {
+			if metadata.file_type().is_symlink() {
+				return Err(PathError::Symlink);
+			}
+
+			verify_private_file_metadata(&metadata)?;
+
+			if mode == AtomicMode::CreateOnly {
+				return Err(PathError::AlreadyExists);
+			}
+		},
+		Err(error) if error.kind() == io::ErrorKind::NotFound => {},
+		Err(error) => return Err(io_error(IoOperation::Inspect, error)),
+	}
+
+	let parent = path.parent().ok_or(PathError::Escape)?;
+	let temporary = unique_temporary_path(parent)?;
+	let result = (|| {
+		let mut options = OpenOptions::new();
+
+		options.write(true).create_new(true);
+
+		apply_private_create(&mut options);
+
+		let mut file =
+			options.open(&temporary).map_err(|error| io_error(IoOperation::Open, error))?;
+
+		file.write_all(bytes).map_err(|error| io_error(IoOperation::Write, error))?;
+		file.sync_all().map_err(|error| io_error(IoOperation::Sync, error))?;
+
+		verify_private_file_metadata(
+			&file.metadata().map_err(|error| io_error(IoOperation::Inspect, error))?,
+		)?;
+		drop(file);
+
+		match mode {
+			AtomicMode::Replace => fs::rename(&temporary, path)
+				.map_err(|error| io_error(IoOperation::Rename, error))?,
+			AtomicMode::CreateOnly => match fs::hard_link(&temporary, path) {
+				Ok(()) => fs::remove_file(&temporary)
+					.map_err(|error| io_error(IoOperation::Remove, error))?,
+				Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+					return Err(PathError::AlreadyExists);
+				},
+				Err(error) => return Err(io_error(IoOperation::Link, error)),
+			},
+		}
+
+		sync_directory(parent)
+	})();
+
+	if temporary.exists() {
+		let _ = fs::remove_file(&temporary);
+	}
+
+	result
+}
+
+#[cfg(not(unix))]
+fn unique_temporary_path(parent: &Path) -> Result<PathBuf, PathError> {
+	for _ in 0..8 {
+		let mut random = [0_u8; 16];
+
+		getrandom::fill(&mut random).map_err(|_| PathError::RandomnessUnavailable)?;
+
+		let name = format!("{ATOMIC_TEMPORARY_PREFIX}{}", hex(&random));
+		let candidate = parent.join(name);
+
+		if !candidate.exists() {
+			return Ok(candidate);
+		}
+	}
+
+	Err(PathError::AlreadyExists)
+}
+
+fn normalize_absolute(path: PathBuf) -> Result<PathBuf, PathError> {
+	if !path.is_absolute() || path.parent().is_none() {
+		return Err(PathError::UnsafeRoot);
+	}
+
+	let mut normalized = PathBuf::new();
+
+	for component in path.components() {
+		match component {
+			Component::ParentDir => return Err(PathError::UnsafeRoot),
+			Component::CurDir => {},
+			Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+				normalized.push(component.as_os_str());
+			},
+		}
+	}
+
+	if normalized.parent().is_none() {
+		return Err(PathError::UnsafeRoot);
+	}
+
+	Ok(normalized)
+}
+
+#[cfg(not(unix))]
+fn verify_existing_ancestors(path: &Path) -> Result<(), PathError> {
+	let parent = path.parent().ok_or(PathError::UnsafeRoot)?;
+	let mut current = PathBuf::new();
+
+	for component in parent.components() {
+		current.push(component.as_os_str());
+
+		match fs::symlink_metadata(&current) {
+			Ok(metadata) => {
+				if metadata.file_type().is_symlink() {
+					return Err(PathError::Symlink);
+				}
+				if !metadata.is_dir() {
+					return Err(PathError::UnexpectedDirectoryKind);
+				}
+			},
+			Err(error) if error.kind() == io::ErrorKind::NotFound => break,
+			Err(error) => return Err(io_error(IoOperation::Inspect, error)),
+		}
+	}
+
+	Ok(())
+}
+
+fn is_codex_component(value: &OsStr) -> bool {
+	value.to_string_lossy().eq_ignore_ascii_case(".codex")
+}
+
+#[cfg(not(unix))]
+fn ensure_private_directory(path: &Path) -> Result<(), PathError> {
+	match fs::symlink_metadata(path) {
+		Ok(metadata) => verify_private_directory_metadata(&metadata),
+		Err(error) if error.kind() == io::ErrorKind::NotFound => {
+			let mut builder = DirBuilder::new();
+
+			#[cfg(unix)]
+			builder.mode(PRIVATE_DIRECTORY_MODE);
+
+			match builder.create(path) {
+				Ok(()) => {},
+				Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {},
+				Err(error) => return Err(io_error(IoOperation::CreateDirectory, error)),
+			}
+
+			verify_private_directory(path)
+		},
+		Err(error) => Err(io_error(IoOperation::Inspect, error)),
+	}
+}
+
+#[cfg(not(unix))]
+fn verify_private_directory(path: &Path) -> Result<(), PathError> {
+	let metadata =
+		fs::symlink_metadata(path).map_err(|error| io_error(IoOperation::Inspect, error))?;
+
+	verify_private_directory_metadata(&metadata)
+}
+
+#[cfg(not(unix))]
+fn verify_private_directory_metadata(metadata: &Metadata) -> Result<(), PathError> {
+	if metadata.file_type().is_symlink() {
+		return Err(PathError::Symlink);
+	}
+	if !metadata.is_dir() {
+		return Err(PathError::UnexpectedDirectoryKind);
+	}
+
+	verify_directory_permissions(metadata)
+}
+
+#[cfg(not(unix))]
+fn private_file_metadata(path: &Path) -> Result<Metadata, PathError> {
+	let metadata =
+		fs::symlink_metadata(path).map_err(|error| io_error(IoOperation::Inspect, error))?;
+
+	if metadata.file_type().is_symlink() {
+		return Err(PathError::Symlink);
+	}
+
+	verify_private_file_metadata(&metadata)?;
+
+	Ok(metadata)
+}
+
+#[cfg(not(unix))]
+fn verify_private_file_metadata(metadata: &Metadata) -> Result<(), PathError> {
+	if !metadata.is_file() {
+		return Err(PathError::UnexpectedFileKind);
+	}
+
+	verify_file_permissions(metadata)
+}
+
+#[cfg(not(unix))]
+fn sync_directory(path: &Path) -> Result<(), PathError> {
+	let mut options = OpenOptions::new();
+
+	options.read(true);
+
+	let directory = options.open(path).map_err(|error| io_error(IoOperation::Open, error))?;
+
+	directory.sync_all().map_err(|error| io_error(IoOperation::Sync, error))
+}
+
+#[cfg(not(unix))]
+fn apply_private_create(_options: &mut OpenOptions) {}
+
+#[cfg(not(unix))]
+fn apply_no_follow(_options: &mut OpenOptions) {}
+
+#[cfg(not(unix))]
+fn hex(bytes: &[u8]) -> String {
+	const HEX: &[u8; 16] = b"0123456789abcdef";
+
+	let mut encoded = String::with_capacity(bytes.len() * 2);
+
+	for &byte in bytes {
+		encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+		encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+	}
+
+	encoded
+}

--- a/crates/decodex-core/src/storage.rs
+++ b/crates/decodex-core/src/storage.rs
@@ -1,0 +1,61 @@
+use std::{
+	error::Error,
+	fmt::{Display, Formatter},
+};
+
+use crate::PathError;
+
+/// Typed storage failures with no caller keys, contents, or underlying error text.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StorageError {
+	/// Owned path validation or redacted I/O failed.
+	Path(PathError),
+	/// Blob hash text was not canonical lowercase SHA-256.
+	InvalidBlobHash,
+	/// Stored bytes no longer match their content address.
+	BlobIntegrityMismatch,
+	/// Blob input exceeded the public bound.
+	BlobTooLarge {
+		/// Maximum accepted blob bytes.
+		limit: usize,
+	},
+	/// Cache limits were zero, inconsistent, or above hard ceilings.
+	InvalidCacheLimits,
+	/// Cache key was empty or oversized.
+	InvalidCacheKey,
+	/// One cache entry exceeded its configured bound.
+	CacheEntryTooLarge {
+		/// Maximum accepted entry bytes.
+		limit: usize,
+	},
+	/// Existing cache usage could not be represented safely.
+	CacheBoundOverflow,
+	/// An unexpected filename appeared in the owned cache directory.
+	InvalidCacheEntry,
+}
+impl Display for StorageError {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::Path(error) => Display::fmt(error, formatter),
+			Self::InvalidBlobHash => formatter.write_str("invalid SHA-256 blob identity"),
+			Self::BlobIntegrityMismatch =>
+				formatter.write_str("blob integrity verification failed"),
+			Self::BlobTooLarge { limit } => write!(formatter, "blob exceeds {limit} bytes"),
+			Self::InvalidCacheLimits => formatter.write_str("invalid disposable-cache limits"),
+			Self::InvalidCacheKey => formatter.write_str("invalid disposable-cache key"),
+			Self::CacheEntryTooLarge { limit } => {
+				write!(formatter, "cache entry exceeds {limit} bytes")
+			},
+			Self::CacheBoundOverflow => formatter.write_str("cache usage exceeds numeric bounds"),
+			Self::InvalidCacheEntry => formatter.write_str("invalid disposable-cache entry"),
+		}
+	}
+}
+
+impl Error for StorageError {}
+
+impl From<PathError> for StorageError {
+	fn from(error: PathError) -> Self {
+		Self::Path(error)
+	}
+}

--- a/crates/decodex-core/tests/config.rs
+++ b/crates/decodex-core/tests/config.rs
@@ -1,0 +1,304 @@
+//! XY-1306 configuration, profile, redaction, and identity adversarial coverage.
+
+#[path = "support/test_root.rs"] mod support;
+
+use std::{fs, sync::Arc, thread};
+
+use getrandom as _;
+#[cfg(unix)] use libc as _;
+use serde as _;
+use sha2 as _;
+use tempfile::NamedTempFile;
+use toml as _;
+
+use decodex_core::{
+	ConfigError, DecodexConfig, MAX_CONFIG_BYTES, PathError, ServerIdentity, ServerProfile,
+};
+use support::{SERVER_ID, TestRoot};
+
+#[test]
+fn checked_in_example_matches_the_bounded_vnext_schema() {
+	let example = include_bytes!("../../../decodex.example.toml");
+	let config = DecodexConfig::parse(example).expect("checked-in example parses");
+
+	assert_eq!(config.version(), 1);
+	assert!(matches!(config.active_profile(), ServerProfile::Local(_)));
+	assert!(config.profiles().values().any(|profile| matches!(profile, ServerProfile::Remote(_))));
+}
+
+#[test]
+fn valid_configuration_keeps_profiles_and_server_host_paths_explicit() {
+	let config =
+		DecodexConfig::parse(support::valid_config().as_bytes()).expect("valid configuration");
+
+	assert_eq!(config.version(), 1);
+	assert_eq!(config.active_profile_name().as_str(), "local");
+	assert!(matches!(config.active_profile(), ServerProfile::Local(_)));
+
+	let remote = config
+		.profiles()
+		.iter()
+		.find(|(name, _)| name.as_str() == "remote")
+		.map(|(_, profile)| profile)
+		.expect("remote profile");
+	let ServerProfile::Remote(remote) = remote else { panic!("explicit remote profile") };
+
+	assert_eq!(remote.host(), "server.example.test");
+	assert_eq!(remote.port(), 49_152);
+	assert_eq!(remote.expected_server_identity().as_str(), SERVER_ID);
+
+	let repository = config
+		.server_host()
+		.repositories()
+		.iter()
+		.find(|(name, _)| name.as_str() == "decodex")
+		.map(|(_, path)| path)
+		.expect("server-host repository");
+
+	assert_eq!(repository.as_server_path().to_str(), Some("/srv/repos/decodex"));
+	assert_eq!(config.postgres().socket_directory().to_str(), Some("/var/run/postgresql"));
+	assert_eq!(config.postgres().database(), "decodex");
+	assert_eq!(config.postgres().user(), "decodex");
+	assert_eq!(config.postgres().credential_env_var(), Some("DECODEX_POSTGRES_PASSWORD"));
+	assert_eq!(config.cache().limits().max_entries(), 128);
+}
+
+#[test]
+fn remote_profiles_have_no_client_local_repository_path_field() {
+	let input = support::valid_config().replace(
+		"expected_server_identity = \"018f0f9e-7b6e-4a31-8f4c-1d2e3f405162\"",
+		"expected_server_identity = \"018f0f9e-7b6e-4a31-8f4c-1d2e3f405162\"\nrepository_path = \"/client/must-not-be-used\"",
+	);
+
+	assert_eq!(DecodexConfig::parse(input.as_bytes()).unwrap_err(), ConfigError::Malformed);
+}
+
+#[test]
+fn local_and_remote_profile_boundaries_fail_closed() {
+	let non_loopback = support::valid_config().replace("127.0.0.1:49152", "192.0.2.8:49152");
+
+	assert_eq!(
+		DecodexConfig::parse(non_loopback.as_bytes()).unwrap_err(),
+		ConfigError::InvalidProfile,
+	);
+
+	let remote_loopback = support::valid_config().replace("server.example.test", "127.0.0.1");
+
+	assert_eq!(
+		DecodexConfig::parse(remote_loopback.as_bytes()).unwrap_err(),
+		ConfigError::InvalidProfile,
+	);
+
+	let credential_endpoint =
+		support::valid_config().replace("server.example.test", "user@server.test");
+
+	assert_eq!(
+		DecodexConfig::parse(credential_endpoint.as_bytes()).unwrap_err(),
+		ConfigError::InvalidProfile,
+	);
+}
+
+#[test]
+fn relative_or_escaping_server_host_paths_are_rejected() {
+	let relative_repository = support::valid_config()
+		.replace("host_path = \"/srv/repos/decodex\"", "host_path = \"../repos/decodex\"");
+
+	assert_eq!(
+		DecodexConfig::parse(relative_repository.as_bytes()).unwrap_err(),
+		ConfigError::InvalidServerHostPath,
+	);
+
+	let relative_socket = support::valid_config().replace(
+		"socket_directory = \"/var/run/postgresql\"",
+		"socket_directory = \"../postgresql\"",
+	);
+
+	assert_eq!(
+		DecodexConfig::parse(relative_socket.as_bytes()).unwrap_err(),
+		ConfigError::InvalidPostgres,
+	);
+
+	let oversized_repository = support::valid_config()
+		.replace("/srv/repos/decodex", &format!("/srv/{}", "x".repeat(4 * 1_024)));
+
+	assert_eq!(
+		DecodexConfig::parse(oversized_repository.as_bytes()).unwrap_err(),
+		ConfigError::InvalidServerHostPath,
+	);
+
+	let oversized_socket = support::valid_config()
+		.replace("/var/run/postgresql", &format!("/var/{}", "x".repeat(4 * 1_024)));
+
+	assert_eq!(
+		DecodexConfig::parse(oversized_socket.as_bytes()).unwrap_err(),
+		ConfigError::InvalidPostgres,
+	);
+}
+
+#[test]
+fn accepted_server_host_paths_are_stored_in_one_lexically_normalized_form() {
+	let input = support::valid_config()
+		.replace("/srv/repos/decodex", "/srv//repos/./decodex")
+		.replace("/var/run/postgresql", "/var//run/./postgresql");
+	let config = DecodexConfig::parse(input.as_bytes()).expect("normalizable host paths");
+	let repository =
+		config.server_host().repositories().values().next().expect("server-host repository");
+
+	assert_eq!(repository.as_server_path(), std::path::Path::new("/srv/repos/decodex"));
+	assert_eq!(config.postgres().socket_directory(), std::path::Path::new("/var/run/postgresql"),);
+}
+
+#[test]
+fn malformed_unknown_and_oversized_configuration_are_bounded_and_redacted() {
+	let marker = "xy1306-super-sensitive-marker";
+	let malformed = format!("{}\nraw_password = \"{marker}\"\n", support::valid_config());
+	let error = DecodexConfig::parse(malformed.as_bytes()).unwrap_err();
+
+	assert_eq!(error, ConfigError::Malformed);
+	assert!(!format!("{error}").contains(marker));
+	assert!(!format!("{error:?}").contains(marker));
+
+	let oversized = vec![b'x'; MAX_CONFIG_BYTES + 1];
+
+	assert_eq!(
+		DecodexConfig::parse(&oversized).unwrap_err(),
+		ConfigError::Oversized { limit: MAX_CONFIG_BYTES },
+	);
+}
+
+#[test]
+fn successful_config_debug_redacts_operator_strings() {
+	let input = support::valid_config()
+		.replace("server.example.test", "xy1306-secret-marker.example")
+		.replace("/srv/repos/decodex", "/srv/xy1306-secret-marker")
+		.replace("database = \"decodex\"", "database = \"xy1306_secret_marker\"")
+		.replace("user = \"decodex\"", "user = \"xy1306_secret_user\"");
+	let config = DecodexConfig::parse(input.as_bytes()).expect("valid marked configuration");
+	let debug = format!("{config:?}");
+
+	assert!(!debug.contains("xy1306-secret-marker"));
+	assert!(!debug.contains("xy1306_secret_marker"));
+	assert!(!debug.contains("xy1306_secret_user"));
+}
+
+#[test]
+fn file_loading_enforces_input_size_before_parsing() {
+	let fixture = TestRoot::new();
+
+	support::write_private_config(&fixture, &vec![b'x'; MAX_CONFIG_BYTES + 1]);
+
+	assert!(matches!(
+		DecodexConfig::load(&fixture.paths),
+		Err(ConfigError::Path(PathError::Oversized { limit: MAX_CONFIG_BYTES })),
+	));
+}
+
+#[cfg(unix)]
+#[test]
+fn group_readable_configuration_is_rejected() {
+	let fixture = TestRoot::new();
+
+	support::write_private_config(&fixture, support::valid_config().as_bytes());
+	support::set_mode(&fixture.paths.config_file(), 0o640);
+
+	assert!(matches!(
+		DecodexConfig::load(&fixture.paths),
+		Err(ConfigError::Path(PathError::InsecurePermissions)),
+	));
+}
+
+#[test]
+fn stable_server_identity_is_standard_atomic_and_concurrent() {
+	let fixture = TestRoot::new();
+
+	fixture.paths.ensure_layout().expect("private layout");
+
+	let paths = Arc::new(fixture.paths.clone());
+	let mut workers = Vec::new();
+
+	for _ in 0..16 {
+		let paths = Arc::clone(&paths);
+
+		workers.push(thread::spawn(move || {
+			ServerIdentity::load_or_create(&paths).expect("stable identity")
+		}));
+	}
+
+	let identities = workers
+		.into_iter()
+		.map(|worker| worker.join().expect("identity worker"))
+		.collect::<Vec<_>>();
+
+	assert!(identities.windows(2).all(|pair| pair[0] == pair[1]));
+
+	let identity = &identities[0];
+
+	assert_eq!(identity.as_str().len(), 36);
+	assert_eq!(identity.as_str().as_bytes()[14], b'4');
+	assert!(matches!(identity.as_str().as_bytes()[19], b'8' | b'9' | b'a' | b'b'));
+	assert_eq!(ServerIdentity::load(&paths).expect("identity readback"), identity.clone());
+
+	let names = support::private_file_names(&paths.server_dir());
+
+	assert_eq!(names, vec![paths.server_identity_file()]);
+}
+
+#[cfg(unix)]
+#[test]
+fn identity_permissions_and_symlinks_fail_closed() {
+	let fixture = TestRoot::new();
+	let identity = ServerIdentity::load_or_create(&fixture.paths).expect("stable identity");
+
+	support::set_mode(&fixture.paths.server_identity_file(), 0o644);
+
+	assert!(matches!(
+		ServerIdentity::load(&fixture.paths),
+		Err(ConfigError::Path(PathError::InsecurePermissions)),
+	));
+
+	fs::remove_file(fixture.paths.server_identity_file()).expect("remove identity");
+
+	let outside = NamedTempFile::new().expect("outside identity");
+
+	std::os::unix::fs::symlink(outside.path(), fixture.paths.server_identity_file())
+		.expect("identity symlink");
+
+	assert!(matches!(
+		ServerIdentity::load_or_create(&fixture.paths),
+		Err(ConfigError::Path(PathError::Symlink)),
+	));
+	assert_eq!(identity.as_str().len(), 36);
+}
+
+#[test]
+fn malformed_identity_errors_never_echo_file_contents() {
+	let marker = "xy1306-sensitive-identity-marker";
+	let fixture = TestRoot::new();
+
+	fixture.paths.ensure_layout().expect("private layout");
+
+	support::write_private(&fixture.paths.server_identity_file(), marker.as_bytes());
+
+	let error = ServerIdentity::load(&fixture.paths).unwrap_err();
+
+	assert_eq!(error, ConfigError::InvalidServerIdentity);
+	assert!(!format!("{error}").contains(marker));
+	assert!(!format!("{error:?}").contains(marker));
+}
+
+#[test]
+fn identity_file_accepts_only_canonical_text_and_one_optional_newline() {
+	let fixture = TestRoot::new();
+
+	fixture.paths.ensure_layout().expect("private layout");
+
+	support::write_private(
+		&fixture.paths.server_identity_file(),
+		format!("{SERVER_ID}\n\n").as_bytes(),
+	);
+
+	assert_eq!(
+		ServerIdentity::load(&fixture.paths).unwrap_err(),
+		ConfigError::InvalidServerIdentity,
+	);
+}

--- a/crates/decodex-core/tests/paths.rs
+++ b/crates/decodex-core/tests/paths.rs
@@ -1,0 +1,191 @@
+//! XY-1306 owned-root, containment, file-kind, symlink, and permission coverage.
+
+#[path = "support/test_root.rs"] mod support;
+
+use std::{fs, path::Path};
+
+use getrandom as _;
+#[cfg(unix)] use libc as _;
+use serde as _;
+use sha2 as _;
+use tempfile::NamedTempFile;
+use toml as _;
+
+use decodex_core::{ConfigError, DecodexConfig, DecodexRoot, PathError};
+use support::TestRoot;
+
+#[test]
+fn every_owned_path_is_derived_below_the_decodex_root() {
+	let fixture = TestRoot::new();
+	let root = fixture.paths.root().as_path();
+
+	for path in [
+		fixture.paths.config_file(),
+		fixture.paths.logs_dir(),
+		fixture.paths.blobs_dir(),
+		fixture.paths.cache_dir(),
+		fixture.paths.server_dir(),
+		fixture.paths.server_identity_file(),
+	] {
+		assert!(path.starts_with(root));
+		assert!(!path.components().any(|component| component.as_os_str() == ".codex"));
+	}
+}
+
+#[test]
+fn root_and_layout_debug_never_expose_path_text() {
+	let root = DecodexRoot::new("/private/xy1306-sensitive-root/.decodex")
+		.expect("lexically valid marked root");
+
+	assert!(!format!("{root:?}").contains("xy1306-sensitive-root"));
+	assert!(!format!("{:?}", root.paths()).contains("xy1306-sensitive-root"));
+}
+
+#[test]
+fn unsafe_ambiguous_and_codex_owned_roots_fail_before_writes() {
+	assert_eq!(DecodexRoot::new("relative/.decodex"), Err(PathError::UnsafeRoot));
+	assert_eq!(DecodexRoot::new(Path::new("/")), Err(PathError::UnsafeRoot));
+	assert_eq!(DecodexRoot::new(Path::new("/tmp/parent/../.decodex")), Err(PathError::UnsafeRoot),);
+	assert_eq!(DecodexRoot::new("/tmp/nul\0root"), Err(PathError::UnsafeRoot));
+	assert_eq!(
+		DecodexRoot::new(format!("/tmp/{}", "x".repeat(4 * 1_024))),
+		Err(PathError::UnsafeRoot),
+	);
+
+	for root in ["/tmp/.codex/decodex", "/tmp/.Codex/decodex", "/tmp/.CODEX/decodex"] {
+		assert_eq!(DecodexRoot::new(Path::new(root)), Err(PathError::CodexOwnedRoot));
+	}
+}
+
+#[test]
+fn accepted_roots_are_stored_in_one_lexically_normalized_form() {
+	let root = DecodexRoot::new("/tmp/xy1306-root//nested/./.decodex")
+		.expect("absolute root without parent traversal");
+
+	assert_eq!(root.as_path(), Path::new("/tmp/xy1306-root/nested/.decodex"));
+}
+
+#[test]
+fn rejecting_a_codex_owned_root_leaves_codex_home_untouched() {
+	let home = tempfile::tempdir().expect("temporary home");
+	let codex_home = home.path().join(".codex");
+
+	fs::create_dir(&codex_home).expect("Codex-owned directory fixture");
+
+	assert_eq!(DecodexRoot::new(codex_home.join("decodex")), Err(PathError::CodexOwnedRoot),);
+	assert_eq!(fs::read_dir(&codex_home).expect("read Codex home").count(), 0);
+}
+
+#[test]
+fn normal_layout_creation_never_writes_to_the_neighboring_codex_home() {
+	let home = tempfile::tempdir().expect("temporary home");
+	let canonical_home = home.path().canonicalize().expect("canonical temporary home");
+	let codex_home = canonical_home.join(".codex");
+	let sentinel = codex_home.join("codex-owned-sentinel");
+
+	fs::create_dir(&codex_home).expect("Codex-owned directory fixture");
+	fs::write(&sentinel, b"Codex-owned").expect("Codex-owned sentinel fixture");
+
+	let paths = DecodexRoot::from_home(&canonical_home).expect("safe sibling Decodex root").paths();
+
+	paths.ensure_layout().expect("Decodex-owned layout");
+
+	assert_eq!(fs::read(&sentinel).expect("unchanged Codex sentinel"), b"Codex-owned");
+	assert_eq!(fs::read_dir(&codex_home).expect("read Codex home").count(), 1);
+	assert!(paths.root().as_path().starts_with(&canonical_home));
+	assert!(!paths.root().as_path().starts_with(&codex_home));
+}
+
+#[test]
+fn fixed_layout_creation_is_idempotent() {
+	let fixture = TestRoot::new();
+
+	fixture.paths.ensure_layout().expect("first layout creation");
+	fixture.paths.ensure_layout().expect("second layout verification");
+
+	for directory in [
+		fixture.paths.root().as_path().to_path_buf(),
+		fixture.paths.logs_dir(),
+		fixture.paths.blobs_dir(),
+		fixture.paths.cache_dir(),
+		fixture.paths.server_dir(),
+	] {
+		assert!(directory.is_dir());
+	}
+}
+
+#[test]
+fn unexpected_config_file_kind_fails_closed() {
+	let fixture = TestRoot::new();
+
+	fixture.paths.ensure_layout().expect("private layout");
+
+	fs::create_dir(fixture.paths.config_file()).expect("directory in file position");
+
+	assert!(matches!(
+		DecodexConfig::load(&fixture.paths),
+		Err(ConfigError::Path(PathError::UnexpectedFileKind)),
+	));
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_owned_directory_fails_closed() {
+	let fixture = TestRoot::new();
+
+	fixture.paths.ensure_layout().expect("private layout");
+
+	let outside = tempfile::tempdir().expect("outside target");
+
+	fs::remove_dir(fixture.paths.cache_dir()).expect("remove empty cache directory");
+	std::os::unix::fs::symlink(outside.path(), fixture.paths.cache_dir())
+		.expect("cache symlink fixture");
+
+	assert_eq!(fixture.paths.ensure_layout(), Err(PathError::Symlink));
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_root_ancestor_cannot_redirect_writes_into_codex_home() {
+	let home = tempfile::tempdir().expect("temporary home");
+	let codex_home = home.path().join(".codex");
+	let alias = home.path().join("state-alias");
+
+	fs::create_dir(&codex_home).expect("Codex home fixture");
+	std::os::unix::fs::symlink(&codex_home, &alias).expect("ancestor symlink fixture");
+
+	let root = DecodexRoot::new(alias.join("decodex-state")).expect("lexically separate root");
+
+	assert_eq!(root.paths().ensure_layout(), Err(PathError::Symlink));
+	assert_eq!(fs::read_dir(&codex_home).expect("read Codex home").count(), 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn insecure_root_permissions_fail_closed() {
+	let fixture = TestRoot::new();
+
+	fixture.paths.ensure_layout().expect("private layout");
+
+	support::set_mode(fixture.paths.root().as_path(), 0o755);
+
+	assert_eq!(fixture.paths.ensure_layout(), Err(PathError::InsecurePermissions));
+}
+
+#[cfg(unix)]
+#[test]
+fn a_symlinked_config_file_is_never_followed() {
+	let fixture = TestRoot::new();
+
+	fixture.paths.ensure_layout().expect("private layout");
+
+	let outside = NamedTempFile::new().expect("outside config");
+
+	std::os::unix::fs::symlink(outside.path(), fixture.paths.config_file())
+		.expect("config symlink fixture");
+
+	assert!(matches!(
+		DecodexConfig::load(&fixture.paths),
+		Err(ConfigError::Path(PathError::Symlink)),
+	));
+}

--- a/crates/decodex-core/tests/storage.rs
+++ b/crates/decodex-core/tests/storage.rs
@@ -1,0 +1,325 @@
+//! XY-1306 atomic blob-integrity and disposable cache-bound coverage.
+
+#[path = "support/test_root.rs"] mod support;
+
+use std::fs;
+
+use getrandom as _;
+#[cfg(unix)] use libc as _;
+use serde as _;
+use sha2 as _;
+use tempfile::NamedTempFile;
+use toml as _;
+
+use decodex_core::{
+	BlobHash, BlobStore, BoundedCache, CacheLimits, DecodexRoot, MAX_BLOB_BYTES, MAX_CACHE_BYTES,
+	MAX_CACHE_ENTRIES, MAX_CACHE_ENTRY_BYTES, PathError, StorageError,
+};
+use support::TestRoot;
+
+#[test]
+fn blob_writes_are_content_addressed_atomic_contained_and_verified() {
+	let fixture = TestRoot::new();
+	let store = BlobStore::open(fixture.paths.clone()).expect("blob store");
+	let hash = store.put(b"abc").expect("blob write");
+
+	assert_eq!(hash.to_hex(), "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",);
+	assert!(store.path_for(hash).starts_with(fixture.paths.root().as_path()));
+	assert_eq!(store.read(hash).expect("verified read"), b"abc");
+
+	let blob_path = store.path_for(hash);
+	let shard = blob_path.parent().expect("blob shard");
+	let names = support::private_file_names(shard);
+
+	assert_eq!(names, vec![store.path_for(hash)]);
+	assert!(!names.iter().any(|path| {
+		path.file_name()
+			.and_then(|name| name.to_str())
+			.is_some_and(|name| name.starts_with(".tmp-"))
+	}));
+}
+
+#[test]
+fn tampered_blob_bytes_fail_integrity_verification() {
+	let fixture = TestRoot::new();
+	let store = BlobStore::open(fixture.paths.clone()).expect("blob store");
+	let hash = store.put(b"authoritative evidence").expect("blob write");
+
+	support::write_private(&store.path_for(hash), b"tampered evidence!!!");
+
+	assert_eq!(store.read(hash).unwrap_err(), StorageError::BlobIntegrityMismatch);
+	assert_eq!(
+		store.put(b"authoritative evidence").unwrap_err(),
+		StorageError::BlobIntegrityMismatch,
+	);
+}
+
+#[test]
+fn blob_inputs_and_hash_text_are_mechanically_bounded() {
+	assert_eq!(BlobHash::parse("../../escape").unwrap_err(), StorageError::InvalidBlobHash);
+	assert_eq!(BlobHash::parse(&"A".repeat(64)).unwrap_err(), StorageError::InvalidBlobHash);
+
+	let fixture = TestRoot::new();
+	let store = BlobStore::open(fixture.paths.clone()).expect("blob store");
+	let oversized = vec![0_u8; MAX_BLOB_BYTES + 1];
+
+	assert_eq!(
+		store.put(&oversized).unwrap_err(),
+		StorageError::BlobTooLarge { limit: MAX_BLOB_BYTES },
+	);
+}
+
+#[cfg(unix)]
+#[test]
+fn blob_symlinks_and_unexpected_file_kinds_fail_closed() {
+	let fixture = TestRoot::new();
+	let store = BlobStore::open(fixture.paths.clone()).expect("blob store");
+	let hash = BlobHash::digest(b"symlink target");
+	let path = store.path_for(hash);
+	let shard = path.parent().expect("blob shard");
+
+	fs::create_dir(shard).expect("blob shard fixture");
+	support::set_mode(shard, 0o700);
+
+	let outside = NamedTempFile::new().expect("outside blob");
+
+	std::os::unix::fs::symlink(outside.path(), &path).expect("blob symlink fixture");
+
+	assert!(matches!(store.read(hash), Err(StorageError::Path(PathError::Symlink))));
+	assert!(matches!(store.put(b"symlink target"), Err(StorageError::Path(PathError::Symlink))));
+
+	fs::remove_file(&path).expect("remove symlink");
+	fs::create_dir(&path).expect("directory in blob position");
+
+	assert!(matches!(store.read(hash), Err(StorageError::Path(PathError::UnexpectedFileKind)),));
+}
+
+#[test]
+fn cache_limits_have_non_bypassable_hard_ceilings() {
+	assert_eq!(CacheLimits::new(0, 1, 1), Err(StorageError::InvalidCacheLimits));
+	assert_eq!(
+		CacheLimits::new(MAX_CACHE_ENTRIES + 1, 1, 1),
+		Err(StorageError::InvalidCacheLimits),
+	);
+	assert_eq!(CacheLimits::new(1, MAX_CACHE_BYTES + 1, 1), Err(StorageError::InvalidCacheLimits),);
+	assert_eq!(
+		CacheLimits::new(1, MAX_CACHE_ENTRY_BYTES, MAX_CACHE_ENTRY_BYTES + 1),
+		Err(StorageError::InvalidCacheLimits),
+	);
+	assert_eq!(CacheLimits::new(1, 8, 9), Err(StorageError::InvalidCacheLimits));
+}
+
+#[test]
+fn cache_is_bounded_replaceable_disposable_and_non_authoritative() {
+	let fixture = TestRoot::new();
+	let blob_store = BlobStore::open(fixture.paths.clone()).expect("blob store");
+	let blob_hash = blob_store.put(b"authoritative blob").expect("blob write");
+	let limits = CacheLimits::new(2, 8, 6).expect("cache limits");
+	let cache = BoundedCache::open(fixture.paths.clone(), limits).expect("cache");
+
+	cache.put("one", b"1111").expect("cache one");
+	cache.put("two", b"2222").expect("cache two");
+
+	let usage = cache.put("three", b"3333").expect("cache eviction");
+
+	assert_eq!(usage.entries, 2);
+	assert_eq!(usage.bytes, 8);
+
+	let hits = ["one", "two", "three"]
+		.into_iter()
+		.filter(|key| cache.get(key).expect("cache read").is_some())
+		.count();
+
+	assert_eq!(hits, 2);
+
+	let usage = cache.put("three", b"33").expect("cache replacement");
+
+	assert!(usage.entries <= 2);
+	assert!(usage.bytes <= 8);
+	assert_eq!(cache.get("three").expect("replacement read"), Some(b"33".to_vec()));
+
+	cache.clear().expect("disposable clear");
+
+	assert_eq!(cache.usage().expect("empty usage").entries, 0);
+	assert_eq!(
+		blob_store.read(blob_hash).expect("blob survives cache clear"),
+		b"authoritative blob"
+	);
+}
+
+#[test]
+fn oversized_cache_entry_is_rejected_before_any_write() {
+	let fixture = TestRoot::new();
+	let limits = CacheLimits::new(2, 8, 4).expect("cache limits");
+	let cache = BoundedCache::open(fixture.paths.clone(), limits).expect("cache");
+
+	assert_eq!(
+		cache.put("oversized", b"12345").unwrap_err(),
+		StorageError::CacheEntryTooLarge { limit: 4 },
+	);
+	assert_eq!(cache.usage().expect("empty cache").entries, 0);
+}
+
+#[test]
+fn preexisting_oversized_disposable_cache_file_is_evicted_on_open() {
+	let fixture = TestRoot::new();
+
+	fixture.paths.ensure_layout().expect("private layout");
+
+	let name = format!("{}.cache", BlobHash::digest(b"oversized").to_hex());
+
+	support::write_private(&fixture.paths.cache_dir().join(name), b"12345");
+
+	let limits = CacheLimits::new(2, 8, 4).expect("cache limits");
+	let cache = BoundedCache::open(fixture.paths.clone(), limits).expect("bounded cache");
+
+	assert_eq!(cache.usage().expect("usage").entries, 0);
+}
+
+#[test]
+fn interrupted_atomic_cache_temporary_files_are_discarded_and_clearable() {
+	let fixture = TestRoot::new();
+	let limits = CacheLimits::new(2, 8, 4).expect("cache limits");
+	let cache = BoundedCache::open(fixture.paths.clone(), limits).expect("bounded cache");
+	let temporary = fixture.paths.cache_dir().join(format!(".tmp-{}", "a".repeat(32)));
+
+	support::write_private(&temporary, b"interrupted bytes outside configured entry limit");
+
+	cache.clear().expect("clear interrupted temporary file");
+
+	assert!(support::private_file_names(&fixture.paths.cache_dir()).is_empty());
+
+	support::write_private(&temporary, b"another interrupted write");
+
+	let reopened =
+		BoundedCache::open(fixture.paths.clone(), limits).expect("recover cache on open");
+
+	assert_eq!(reopened.usage().expect("recovered usage").entries, 0);
+	assert!(support::private_file_names(&fixture.paths.cache_dir()).is_empty());
+}
+
+#[test]
+fn oversized_newer_cache_entry_is_evicted_even_when_older_entry_is_small() {
+	let fixture = TestRoot::new();
+
+	fixture.paths.ensure_layout().expect("private layout");
+
+	let small = format!("{}.cache", BlobHash::digest(b"small").to_hex());
+	let large = format!("{}.cache", BlobHash::digest(b"large").to_hex());
+
+	support::write_private(&fixture.paths.cache_dir().join(small), b"1234");
+	support::write_private(&fixture.paths.cache_dir().join(large), b"12345");
+
+	let limits = CacheLimits::new(2, 16, 4).expect("cache limits");
+	let cache = BoundedCache::open(fixture.paths.clone(), limits).expect("bounded cache");
+
+	assert_eq!(cache.usage().expect("usage").entries, 1);
+	assert_eq!(cache.usage().expect("usage").bytes, 4);
+}
+
+#[test]
+fn unexpected_cache_names_and_file_kinds_fail_closed() {
+	let fixture = TestRoot::new();
+
+	fixture.paths.ensure_layout().expect("private layout");
+
+	support::write_private(&fixture.paths.cache_dir().join("not-a-content-key.cache"), b"cache");
+
+	let limits = CacheLimits::new(2, 16, 8).expect("cache limits");
+
+	assert_eq!(
+		BoundedCache::open(fixture.paths.clone(), limits).unwrap_err(),
+		StorageError::InvalidCacheEntry,
+	);
+
+	fs::remove_file(fixture.paths.cache_dir().join("not-a-content-key.cache"))
+		.expect("remove invalid cache file");
+	support::write_private(
+		&fixture.paths.cache_dir().join(".tmp-not-an-exact-atomic-name"),
+		b"cache",
+	);
+
+	assert_eq!(
+		BoundedCache::open(fixture.paths.clone(), limits).unwrap_err(),
+		StorageError::InvalidCacheEntry,
+	);
+
+	fs::remove_file(fixture.paths.cache_dir().join(".tmp-not-an-exact-atomic-name"))
+		.expect("remove invalid temporary name");
+	fs::create_dir(fixture.paths.cache_dir().join("directory.cache"))
+		.expect("directory cache fixture");
+
+	assert!(matches!(
+		BoundedCache::open(fixture.paths.clone(), limits),
+		Err(StorageError::Path(PathError::UnexpectedFileKind)),
+	));
+}
+
+#[cfg(unix)]
+#[test]
+fn cache_symlinks_and_insecure_permissions_fail_closed() {
+	let fixture = TestRoot::new();
+
+	fixture.paths.ensure_layout().expect("private layout");
+
+	let limits = CacheLimits::new(2, 16, 8).expect("cache limits");
+	let valid_name = format!("{}.cache", BlobHash::digest(b"entry").to_hex());
+	let path = fixture.paths.cache_dir().join(valid_name);
+	let outside = NamedTempFile::new().expect("outside cache");
+
+	std::os::unix::fs::symlink(outside.path(), &path).expect("cache symlink fixture");
+
+	assert!(matches!(
+		BoundedCache::open(fixture.paths.clone(), limits),
+		Err(StorageError::Path(PathError::Symlink)),
+	));
+
+	fs::remove_file(&path).expect("remove cache symlink");
+	support::write_private(&path, b"cache");
+	support::set_mode(&path, 0o644);
+
+	assert!(matches!(
+		BoundedCache::open(fixture.paths.clone(), limits),
+		Err(StorageError::Path(PathError::InsecurePermissions)),
+	));
+}
+
+#[cfg(unix)]
+#[test]
+fn replacing_a_root_ancestor_after_open_cannot_redirect_cache_io_into_codex_home() {
+	let home = tempfile::tempdir().expect("temporary home");
+	let canonical_home = home.path().canonicalize().expect("canonical temporary home");
+	let anchor = canonical_home.join("owned-parent");
+
+	fs::create_dir(&anchor).expect("owned parent fixture");
+	support::set_mode(&anchor, 0o700);
+
+	let paths = DecodexRoot::new(anchor.join(".decodex")).expect("safe root").paths();
+	let limits = CacheLimits::new(2, 16, 8).expect("cache limits");
+	let cache = BoundedCache::open(paths, limits).expect("open cache before ancestor swap");
+	let original = canonical_home.join("original-owned-parent");
+
+	fs::rename(&anchor, &original).expect("move original root ancestor");
+
+	let codex_home = canonical_home.join(".codex");
+	let redirected_root = codex_home.join(".decodex");
+	let redirected_cache = redirected_root.join("cache");
+
+	for directory in [&codex_home, &redirected_root, &redirected_cache] {
+		fs::create_dir(directory).expect("prepared redirected tree");
+		support::set_mode(directory, 0o700);
+	}
+
+	std::os::unix::fs::symlink(&codex_home, &anchor).expect("swapped ancestor symlink");
+
+	for result in [
+		cache.put("redirect-attempt", b"blocked").map(|_| ()),
+		cache.get("redirect-attempt").map(|_| ()),
+		cache.usage().map(|_| ()),
+		cache.clear(),
+	] {
+		assert!(matches!(result, Err(StorageError::Path(PathError::Symlink))));
+	}
+
+	assert_eq!(fs::read_dir(redirected_cache).expect("read redirected cache").count(), 0);
+}

--- a/crates/decodex-core/tests/support/test_root.rs
+++ b/crates/decodex-core/tests/support/test_root.rs
@@ -1,0 +1,95 @@
+#![allow(dead_code)]
+
+#[cfg(unix)] use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+use std::{
+	fs::{self, OpenOptions, Permissions},
+	io::Write as _,
+	path::{Path, PathBuf},
+};
+
+use tempfile::TempDir;
+
+use decodex_core::{DecodexPaths, DecodexRoot};
+
+pub const SERVER_ID: &str = "018f0f9e-7b6e-4a31-8f4c-1d2e3f405162";
+
+pub struct TestRoot {
+	_temp: TempDir,
+	pub paths: DecodexPaths,
+}
+impl TestRoot {
+	pub fn new() -> Self {
+		let temp = tempfile::tempdir().expect("temporary home");
+		let canonical_home = temp.path().canonicalize().expect("canonical temporary home");
+		let root = DecodexRoot::from_home(canonical_home).expect("safe temporary Decodex root");
+		let paths = root.paths();
+
+		Self { _temp: temp, paths }
+	}
+}
+
+pub fn valid_config() -> String {
+	format!(
+		r#"version = 1
+active_profile = "local"
+
+[profiles.local]
+kind = "local"
+address = "127.0.0.1:49152"
+
+[profiles.remote]
+kind = "remote"
+host = "server.example.test"
+port = 49152
+expected_server_identity = "{SERVER_ID}"
+
+[server_host.repositories.decodex]
+host_path = "/srv/repos/decodex"
+
+[postgres]
+socket_directory = "/var/run/postgresql"
+database = "decodex"
+user = "decodex"
+credential_env_var = "DECODEX_POSTGRES_PASSWORD"
+
+[cache]
+max_entries = 128
+max_bytes = 1048576
+max_entry_bytes = 65536
+"#,
+	)
+}
+
+pub fn write_private(path: &Path, bytes: &[u8]) {
+	let mut options = OpenOptions::new();
+
+	options.write(true).create(true).truncate(true);
+	#[cfg(unix)]
+	options.mode(0o600);
+
+	let mut file = options.open(path).expect("private fixture file");
+
+	file.write_all(bytes).expect("write private fixture");
+}
+
+pub fn write_private_config(root: &TestRoot, bytes: &[u8]) {
+	root.paths.ensure_layout().expect("private layout");
+
+	write_private(&root.paths.config_file(), bytes);
+}
+
+pub fn private_file_names(directory: &Path) -> Vec<PathBuf> {
+	let mut names = fs::read_dir(directory)
+		.expect("read private directory")
+		.map(|entry| entry.expect("directory entry").path())
+		.collect::<Vec<_>>();
+
+	names.sort();
+
+	names
+}
+
+#[cfg(unix)]
+pub fn set_mode(path: &Path, mode: u32) {
+	fs::set_permissions(path, Permissions::from_mode(mode)).expect("set fixture mode");
+}

--- a/decodex.example.toml
+++ b/decodex.example.toml
@@ -1,70 +1,46 @@
-service_id = "your-service-id"
-
-[tracker]
-api_key_env_var = "LINEAR_API_KEY"
-
-[github]
-token_env_var = "GITHUB_TOKEN"
-# Optional explicit GitHub CLI authority. Use an absolute path when GUI-launched
-# Decodex processes do not inherit the shell PATH that contains `gh`.
-# command_path = "/opt/homebrew/bin/gh"
+# Decodex vNext global configuration.
 #
-# Landing mode defaults to "standard", which waits for the GitHub status rollup and
-# ordinary merge gates. "fast" trusts Decodex's local full-check status
-# (`decodex/local-full-check`) and allows the listed GitHub actors to execute
-# ruleset bypass landing after local validation passes.
-# landing_mode = "standard"
-# landing_mode = "fast"
-# landing_actors = ["decodex-bot"]
+# Install as ~/.decodex/config.toml with mode 0600. Decodex creates its root and
+# owned directories with mode 0700. Shared ~/.codex remains Codex-owned and must
+# not contain any Decodex vNext configuration, logs, blobs, cache, or identity.
+active_profile = "local"
+version        = 1
 
-# Optional Codex-specific runtime policy.
-# Omit this block to use `review = "strict"`.
-[codex]
-review = "strict"
+# Local means the client and decodexd share one host. The address must be loopback.
+[profiles.local]
+address = "127.0.0.1:49152"
+kind    = "local"
+# Optional pin after this host has created ~/.decodex/server/identity.
+# expected_server_identity = "018f0f9e-7b6e-4a31-8f4c-1d2e3f405162"
 
-# Optional Decodex autonomy references. Defaults are latent-only: objective drafts,
-# signal audits, and proposal dry-runs may produce evidence, but serve will not
-# promote proposals or create Program Intake without references to accepted runtime
-# Objective Contract and project-policy authority records.
-# [autonomy]
-# auto_promote = false
-# auto_intake  = false
+# Remote is an explicit data model for a different server host. It contains no
+# repository path and always requires a stable server-identity pin. This profile
+# does not enable a non-loopback listener, authentication, or TLS; those remain
+# gated future work.
+[profiles.remote]
+expected_server_identity = "018f0f9e-7b6e-4a31-8f4c-1d2e3f405162"
+host                     = "decodex-server.example.test"
+kind                     = "remote"
+port                     = 49152
 
-# Required only when `auto_promote = true`. This references-only binding is not
-# authority by itself. An operator must run interactive
-# `decodex project accept-runtime-policy <SERVICE_ID> --public-non-goal <TEXT>...`,
-# inspect the exact candidate digest, and type the digest confirmation. That command
-# issues and atomically consumes a server-stored, principal-bound, single-use
-# 10-minute receipt into the immutable accepted record. MCP can preview the candidate
-# but cannot perform acceptance, including from the default Admin stdio profile.
-# `autonomy_apply_runtime_policy` then runs Decodex's internal challenge and may
-# promote a matching ready proposal; it never performs Program Intake.
-# `team_issue_identifier` is required when `auto_intake = true` so a separate
-# `intake_goal` dry-run/apply sequence can use the registered tracker anchor.
-# [autonomy.runtime_policy]
-# accepted_objective_id = "quality-autonomy"
-# accepted_objective_version = "1"
-# accepted_policy_id = "your-service-autonomy-policy"
-# accepted_policy_version = "1"
-# policy_authority_ref = "decodex.runtime_policy:your-service-autonomy-policy@1"
-# team_issue_identifier = "XY-1000"
+# Repository paths are absolute paths on the decodexd host. They are structurally
+# separate from client profiles and must never be interpreted as client-local paths.
+[server_host.repositories.decodex]
+host_path = "/absolute/path/on/server/to/decodex"
 
-# Optional shared Codex account pool.
-# Uncomment the block to use the global `~/.codex/decodex/accounts.jsonl` pool.
-# Fixed-account mode is global. To pin all account-pool runs, set
-# `[codex.accounts].fixed_account` in `~/.codex/decodex/config.toml`.
-# [codex.accounts]
+# Explicit PostgreSQL connection data for the server host. This issue parses and
+# validates the data only; it does not connect, migrate, install, initialize, start,
+# or provision PostgreSQL. Store no password here: this is only an environment-
+# variable reference for a later credential boundary.
+[postgres]
+credential_env_var = "DECODEX_POSTGRES_PASSWORD"
+database           = "decodex"
+socket_directory   = "/var/run/postgresql"
+user               = "decodex"
 
-# Optional local-only classifier for Linear public projection text.
-# The classifier is a secondary guard; schema-controlled public projections remain
-# the primary privacy boundary. Omit this block to disable classifier calls.
-# [privacy_classifier]
-# endpoint   = "http://127.0.0.1:9123/classify"
-# timeout_ms = 1000
-
-# Required project paths. Project configs are managed outside checkouts, for example under
-# `~/.codex/decodex/projects/<service-id>/project.toml`.
-# Omit `worktree_root` to use `<repo_root>/.worktrees`.
-[paths]
-repo_root     = "/absolute/path/to/target/repo"
-worktree_root = ".worktrees"
+# Disposable cache limits. Cache bytes are never authoritative and may be deleted
+# and rebuilt. Hard ceilings are 10,000 entries, 512 MiB total, and 16 MiB per entry.
+[cache]
+max_bytes       = 134217728
+max_entries     = 2048
+max_entry_bytes = 4194304

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -9,7 +9,11 @@ authority documents remain authoritative.
 The root manifest enumerates the active members explicitly. Five library owners form the
 vNext runtime boundary:
 
-- `decodex-core`: pure domain/application contracts and ports; no dependencies.
+- `decodex-core`: domain/application contracts and ports plus the XY-1306 typed
+  `~/.decodex` path, configuration, stable-identity, blob, and disposable-cache
+  foundation. Its external dependency set is architecture-tested and limited to
+  bounded TOML/Serde parsing, SHA-256, OS randomness/no-follow filesystem support, and
+  test-only temporary storage.
 - `decodex-protocol`: V1 typed wire contracts, current/previous-minor negotiation, and
   loopback endpoint policy; depends only on core plus structured serialization.
 - `decodex-postgres`: the PostgreSQL 18 product-state adapter; depends on core plus the
@@ -57,8 +61,9 @@ types contain only small state and cannot carry artifact bytes.
 This slice deliberately keeps its replay/idempotency ledger in memory. A daemon restart
 changes server identity, loses that transient ledger, and forces snapshot fallback;
 durable PostgreSQL product-state and transaction primitives live in `decodex-postgres`,
-but the active composition supplies no connection until XY-1268 owns bootstrap and path
-integration. The foundation application therefore reports product state unavailable
+but the active composition supplies no connection. XY-1306 represents explicit
+PostgreSQL Unix-socket connection data without connecting; XY-1307 owns verified daemon
+bootstrap and integration. The foundation application therefore reports product state unavailable
 rather than inventing product entities. PostgreSQL reports available only after an
 explicit connection passes PostgreSQL 18, checksum, extension, and migration checks.
 The composition also reports conversation execution unavailable. Authentication, TLS,
@@ -96,6 +101,48 @@ case-sensitive regular expressions under the built-in `C` collation. The integra
 repeats credential vectors in a Turkish ICU database so database-default case rules cannot
 weaken the direct-SQL boundary; this crate exposes no
 eligibility, account selection, fallback, wake scheduling, or credential storage.
+
+## Owned vNext paths, configuration, blobs, and cache
+
+`crates/decodex-core/src/paths.rs` owns one absolute, lexically normalized Decodex root
+and the typed private-filesystem contract. On Unix, `path_unix.rs` implements that
+contract by opening every component relative to an already validated directory
+descriptor; reads, listing, removal, temporary-file publication, and synchronization
+therefore cannot be redirected by an ancestor rename or symlink swap. `identity.rs`,
+`blob.rs`, and `cache.rs` own their independent persistence/integrity/bounding policies;
+`storage.rs` owns only their shared redacted error contract.
+The platform default is `~/.decodex`; configured roots are bounded to 4 KiB and roots
+below any `.codex` component are rejected before I/O. Existing root ancestors, the root,
+and every owned descendant reject
+symlinks and unexpected file kinds. On Unix, every owned directory and file must belong
+to the effective OS user; directories must be private mode 0700 and files must deny
+group/other and executable access. Owned writes use same-directory
+private temporary files, file and directory synchronization, and atomic rename or
+create-only hard-link publication. Root layout is fixed:
+
+- `config.toml`: at most 64 KiB, UTF-8 TOML, owner-readable and non-executable with
+  no group/other access (normally mode 0600; mode 0400 is also accepted);
+- `logs/`: Decodex log ownership only; no logging runtime is added by XY-1306;
+- `blobs/sha256/<prefix>/<digest>`: at most 64 MiB per in-memory write, atomically
+  published and fully SHA-256-verified on existing writes and reads;
+- `cache/`: disposable hashed entries bounded simultaneously by configured per-entry,
+  aggregate-byte, and entry-count caps under hard ceilings; recovery removes only exact
+  private `.tmp-<32 lowercase hex>` artifacts left by interrupted atomic writes; and
+- `server/identity`: one canonical RFC 9562 UUID version 4 generated from OS randomness,
+  persisted create-only, and stable across concurrent initialization.
+
+`crates/decodex-core/src/config.rs` denies unknown fields and discards parser details and
+input excerpts from typed errors. Debug implementations redact operator-provided profile,
+host, repository, database, role, and credential-reference strings. Profiles are a closed
+`local`/`remote` enum: local addresses must be loopback; remote profiles carry only a
+bounded host, port, and required expected server identity. Repository roots exist only in
+`ServerHostConfig` as absolute, normalized, at-most-4-KiB `ServerRepositoryPath` values,
+so a remote profile has no client-local repository-path field. PostgreSQL configuration
+is explicit bounded Unix-socket directory/database/user plus an optional credential
+environment-variable reference; it is inert data and opens no database.
+`decodex.example.toml` is the redacted canonical shape. No CLI, doctor/status protocol,
+daemon bootstrap, remote listener/security, or credential-vault implementation is part
+of this foundation.
 
 ## Active Codex adapter foundation
 
@@ -192,7 +239,9 @@ A project is not discovered from a checkout. It is explicitly registered from a 
 - optional `[privacy_classifier]`
 - `[paths]`
 
-`decodex.example.toml` is the safe redacted model. It stores env-var names such as `LINEAR_API_KEY` and `GITHUB_TOKEN`, not token values.
+At the v0.2 freeze, `decodex.example.toml` was the safe project-config model. The current
+checked-in file now owns the vNext global config shape above and is not an input or
+compatibility template for the frozen package.
 
 ## One-shot run flow
 

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -19,6 +19,7 @@ It depends on build, node checks, Rust checks, formatting, lint, and tests (`Mak
 | Broad repo check | `cargo make check` |
 | Rust type check | `cargo make check-rust` or `cargo check --all-features --all-targets --workspace` |
 | Rust tests | `cargo make test` or `cargo nextest run --workspace --all-targets --all-features` |
+| XY-1306 path/config/blob/cache foundation | `cargo test -p decodex-core --all-targets --all-features` |
 | vNext dependency architecture | `cargo make test-vnext-architecture` |
 | vNext PostgreSQL store integration | `cargo make test-vnext-postgres-store` |
 | vNext storage feasibility proof | `cargo make test-vnext-storage-proof` |
@@ -49,7 +50,9 @@ Good targeted scopes are contract-shaped rather than file-shaped: CLI parsing/ou
 
 Use the owner path to choose the first validation surface:
 
-- `crates/decodex-core/`: pure vNext domain/application contracts and authority ports.
+- `crates/decodex-core/`: vNext domain/application contracts and authority ports plus
+  the typed `~/.decodex` root, bounded/redacted config, stable server identity,
+  integrity-verifying blobs, and disposable bounded cache.
 - `crates/decodex-protocol/`: version and loopback network boundary shared by service and clients.
 - `crates/decodex-postgres/`: explicit PostgreSQL product-state adapter and isolated real-PostgreSQL integration tests; the runtime composition seam remains unavailable until configured by its later owner.
 - `crates/decodex-codex/`: typed shared-home Codex adapter foundation; live dispatch is
@@ -75,6 +78,7 @@ Common targeted commands:
 cargo check --all-features --all-targets --workspace
 cargo nextest run --workspace --all-targets --all-features
 cargo make test-vnext-architecture
+cargo test -p decodex-core --all-targets --all-features
 cargo test -p decodex-core -p decodex-protocol -p decodex-postgres -p decodex-codex -p decodex-runtime
 cargo test -p radar <filter>
 cargo test -p decodex-publisher <filter>
@@ -127,7 +131,9 @@ Important source modules:
 
 ## Local validation status gate
 
-Projects choose `[github].landing_mode` in `project.toml` (`decodex.example.toml`).
+Frozen v0.2 projects choose `[github].landing_mode` in their `project.toml`. The current
+`decodex.example.toml` is the vNext global path/config template and no longer models this
+frozen project setting.
 The default `standard` mode waits for GitHub's status rollup and ordinary merge
 gates. `fast` mode trusts the Decodex local full-check status
 `decodex/local-full-check`, requires `landing_actors`, and allows those actors to

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -34,13 +34,15 @@ OpenWiki is the repo-local project knowledge surface for agents and maintainers.
 
 ## Repository map
 
-- `crates/decodex-core/` owns pure domain/application authority contracts and ports; it has no dependencies.
+- `crates/decodex-core/` owns domain/application authority contracts plus the XY-1306
+  typed `~/.decodex` root, bounded/redacted config profiles, stable server identity,
+  content-addressed blobs, and disposable bounded cache foundation.
 - `crates/decodex-protocol/` owns the vNext version and loopback-only endpoint contract shared with clients.
 - `crates/decodex-postgres/` owns the PostgreSQL product-state adapter: explicit
   connection configuration, embedded immutable migrations, optimistic transactions,
   leases, append-only activity, transactional outbox delivery, and inert account/window
-  metadata. The composition root remains fail-closed until XY-1268 supplies owned paths
-  and explicit configuration.
+  metadata. XY-1306 now supplies typed owned paths and explicit connection data, but the
+  composition root remains fail-closed until XY-1307 performs verified bootstrap wiring.
 - `crates/decodex-codex/` owns typed app-server contracts, exact-build capability profiles, redacted normalized events, fixed and bounded read-only launch/probe behavior, and immutable one-account process supervision. Its live dispatch guard remains fail-closed on XY-1304.
 - `crates/decodex-runtime/` owns `decodexd` service assembly and is the only library owner that composes protocol and infrastructure adapters.
 - `apps/decodexd/`, `apps/decodex-cli/`, and `apps/decodex-gpui/` are composition roots. The client roots depend only on the protocol crate; the GPUI binary remains a disabled print-and-exit stub while XY-1263 is failed.
@@ -66,10 +68,11 @@ against `decodex-protocol` only
 and still report their unsupported or disabled state.
 
 The PostgreSQL adapter can persist its XY-1267 foundation when a caller supplies explicit,
-verified PostgreSQL 18 configuration. The active composition root still supplies no
-connection configuration and persists nothing. `~/.codex` remains Codex-owned shared
-continuation state, and the accepted Decodex-owned target is `~/.decodex`; XY-1268 owns
-that path and bootstrap integration.
+verified PostgreSQL 18 configuration. XY-1306 now parses bounded PostgreSQL Unix-socket
+connection data but opens no connection, and the active composition root still supplies
+none and persists nothing. `~/.codex` remains Codex-owned shared continuation state.
+`decodex-core` now owns the typed `~/.decodex` layout for `config.toml`, logs,
+SHA-256 blobs, disposable cache, and atomic server identity; XY-1307 owns daemon bootstrap.
 The legacy `~/.codex/decodex` SQLite/config layout is frozen provenance, not a vNext
 input or fallback.
 
@@ -86,6 +89,7 @@ Use these as discovery and validation entrypoints:
 cargo run -p decodexd
 cargo run -p decodex-cli
 cargo run -p decodex-gpui
+cargo test -p decodex-core --all-targets --all-features
 cargo make test-vnext-architecture
 cargo make test-vnext-postgres-store
 cargo make check
@@ -100,7 +104,9 @@ prefer
 
 ## Authority and safety rules
 
-- Do not read `.env` files or live secret-bearing config. `decodex.example.toml` is the redacted setup model and uses credential environment-variable names, not token values.
+- Do not read `.env` files or live secret-bearing config. `decodex.example.toml` is the
+  bounded vNext setup model and stores only a PostgreSQL credential environment-variable
+  name, never its value.
 - Do not route vNext through `apps/decodex`, legacy SQLite, Linear lanes, or the legacy operator transport.
 - Use `decodex commit` and `decodex land` for Decodex-owned commit/landing authority; the installable plugin hook blocks raw `git commit` and `gh pr merge` inside Decodex scope (`plugins/decodex/scripts/decodex_lifecycle_hook`).
 - PostgreSQL is the vNext product-state authority when explicitly configured; unavailable is the only supported service state otherwise, with no fallback authority.
@@ -111,5 +117,7 @@ prefer
 XY-1265 established compile-time ownership and composition. XY-1266 established the
 loopback protocol foundation; XY-1270 implements the bounded Codex adapter foundation
 without live dispatch. XY-1267 established PostgreSQL-backed product state and durable
-transactions, and XY-1268 owns the API-only CLI/path cutover. Account routing, remote
-security, HTTP artifacts, and GPUI product work remain with their later owners and gates.
+transactions. XY-1306 establishes the typed `~/.decodex` path/config/blob/cache child of
+XY-1268; XY-1307 and XY-1308 still own daemon bootstrap/doctor and the API-only CLI.
+Account routing, remote security, HTTP artifacts, and GPUI product work remain with their
+later owners and gates.

--- a/openwiki/specs/contracts-and-data.md
+++ b/openwiki/specs/contracts-and-data.md
@@ -8,7 +8,10 @@ This page is the primary map for Decodex contracts and data boundaries. Use it t
 
 ## Project contract
 
-A registered project directory contains `project.toml` and `WORKFLOW.md` (`apps/decodex/src/config/service.rs`). The project config parser denies unknown fields (`apps/decodex/src/config/document.rs`). The safe setup model is `decodex.example.toml`.
+A registered project directory contains `project.toml` and `WORKFLOW.md`
+(`apps/decodex/src/config/service.rs`). The project config parser denies unknown fields
+(`apps/decodex/src/config/document.rs`). At freeze, `decodex.example.toml` modeled this
+project config; the current checked-in file now owns the vNext global config shape.
 
 Current `project.toml` shape:
 
@@ -30,7 +33,16 @@ repo_root = "/absolute/path/to/target/repo"
 worktree_root = ".worktrees"
 ```
 
-Optional blocks include `[autonomy]`, `[autonomy.runtime_policy]`, `[codex.accounts]`, and `[privacy_classifier]` (`decodex.example.toml`). Config stores names of environment variables and authority references; it does not embed live credentials, an Objective body, or accepted policy authority. Interactive `decodex project accept-runtime-policy` binds the OS-resolved principal, exact Objective digest, public non-goals, and current RFC3339 timestamp to a typed digest confirmation, then issues and atomically consumes a short-lived single-use receipt into one immutable record keyed by project, policy id, and policy version. MCP may preview but cannot perform acceptance, including through default Admin stdio. An exact accepted-record replay is idempotent and a conflicting replay is refused.
+Optional frozen blocks include `[autonomy]`, `[autonomy.runtime_policy]`,
+`[codex.accounts]`, and `[privacy_classifier]`. Config stores names of environment
+variables and authority references; it does not embed live credentials, an Objective
+body, or accepted policy authority. Interactive `decodex project accept-runtime-policy`
+binds the OS-resolved principal, exact Objective digest, public non-goals, and current
+RFC3339 timestamp to a typed digest confirmation, then issues and atomically consumes a
+short-lived single-use receipt into one immutable record keyed by project, policy id,
+and policy version. MCP may preview but cannot perform acceptance, including through
+default Admin stdio. An exact accepted-record replay is idempotent and a conflicting
+replay is refused.
 `github.landing_mode` defaults to `standard`, which waits for GitHub's status
 rollup. `fast` mode uses the stable `decodex/local-full-check` status and requires
 `github.landing_actors` to name the trusted GitHub users or Apps that can publish and

--- a/openwiki/specs/runtime-contracts.md
+++ b/openwiki/specs/runtime-contracts.md
@@ -112,7 +112,9 @@ Retained review lanes require exact lifecycle authority. Missing or mismatched l
 
 When changing these contracts, validate both source and behavior:
 
-- Project/config parsing: `apps/decodex/src/config/service.rs`, `apps/decodex/src/config/document.rs`, `decodex.example.toml`.
+- Frozen project/config parsing: `apps/decodex/src/config/service.rs` and
+  `apps/decodex/src/config/document.rs`; use the trusted v0.2 tag for its historical
+  example because the current `decodex.example.toml` now owns vNext global config.
 - Workflow parsing and gate policy: `apps/decodex/src/workflow/document.rs`, `apps/decodex/src/workflow/frontmatter.rs`, `apps/decodex/src/workflow/execution.rs`, `apps/decodex/src/workflow/tracker.rs`, and workflow tests under `apps/decodex/src/workflow/tests/`.
 - Runtime state and protocol persistence: `apps/decodex/src/runtime/paths.rs`, `apps/decodex/src/state/sqlite_store/schema.rs`, `apps/decodex/src/state/store.rs`, `apps/decodex/src/state/protocol_events/archive.rs`.
 - App-server compatibility: `apps/decodex/src/agent/app_server/run.rs`, `apps/decodex/src/agent/app_server/preflight.rs`, `apps/decodex/src/agent/app_server/schema_probe/constants.rs`, `apps/decodex/src/agent/app_server/tests/`, and `decodex probe stdio://`.

--- a/openwiki/workflows/runtime-operator-workflows.md
+++ b/openwiki/workflows/runtime-operator-workflows.md
@@ -9,7 +9,9 @@ Project configs live outside target checkouts under `~/.codex/decodex/projects/<
 - `project.toml` for service id, tracker/GitHub credential env-var names, optional Codex/autonomy/privacy settings, and repo/worktree paths.
 - `WORKFLOW.md` for execution policy.
 
-Use the redacted example as the setup shape (`decodex.example.toml`). Do not document or read live token values.
+This is frozen v0.2 workflow provenance. The current `decodex.example.toml` now models
+vNext global configuration, not this legacy project shape; inspect the trusted v0.2 tag
+when auditing the historical template. Do not document or read live token values.
 
 Commands (`apps/decodex/src/cli/control_commands/project.rs`):
 

--- a/tests/scripts/test_vnext_architecture.py
+++ b/tests/scripts/test_vnext_architecture.py
@@ -33,6 +33,15 @@ EXPECTED_POSTGRES_EXTERNAL_DEPENDENCIES = {
     "tokio-postgres",
 }
 
+EXPECTED_CORE_EXTERNAL_DEPENDENCIES = {
+    "getrandom",
+    "libc",
+    "serde",
+    "sha2",
+    "tempfile",
+    "toml",
+}
+
 EXPECTED_WORKSPACE_MANIFESTS = {
     "apps/decodex-cli/Cargo.toml",
     "apps/decodex-gpui/Cargo.toml",
@@ -84,6 +93,16 @@ class VnextArchitectureTests(unittest.TestCase):
         }
 
         self.assertEqual(actual, EXPECTED_POSTGRES_EXTERNAL_DEPENDENCIES)
+
+    def test_core_configuration_and_storage_dependencies_are_exact(self):
+        owned_packages = set(EXPECTED_OWNER_DEPENDENCIES)
+        actual = {
+            dependency["name"]
+            for dependency in self.packages["decodex-core"]["dependencies"]
+            if dependency["name"] not in owned_packages
+        }
+
+        self.assertEqual(actual, EXPECTED_CORE_EXTERNAL_DEPENDENCIES)
 
     def test_workspace_owner_set_is_exact(self):
         actual = {


### PR DESCRIPTION
## Summary
- add typed, bounded `~/.decodex` paths and explicit local/remote profiles
- add descriptor-anchored Unix storage, stable server identity, content-addressed blobs, and disposable bounded cache
- add adversarial tests and align the example configuration and OpenWiki

## Validation
- `SCCACHE_DISABLE=1 cargo make check` (154/154 tests passed; 4 skipped)
- `cargo test -p decodex-core --all-targets --all-features` (40/40)
- Linux all-targets/all-features core check
- user-visible independent review: `gpt-5.6-sol` / medium, `APPROVED/READY` for exact candidate fingerprint `1f602e3f7e9127ce05f6c58943345b4ae07e150fc16de5933f6c30f7c7459c31`

Linear: XY-1306