### PR TITLE
XY-1328: Stabilize generated-schema preflight tests

### DIFF
--- a/crates/decodex-runtime/src/account_launch/process.rs
+++ b/crates/decodex-runtime/src/account_launch/process.rs
@@ -3481,12 +3481,15 @@ mod tests {
 				fake_command(mode, temp.path(), Some(&marker_path)),
 				binding(),
 				SchemaMarker::accepted(),
-				Duration::from_secs(2),
+				Duration::from_secs(5),
 			)
 			.run(&mut CapabilityCache::default())
 			.unwrap_err();
 
-			assert!(matches!(error, ProbeError::SchemaMissing { .. }));
+			assert!(
+				matches!(error, ProbeError::SchemaMissing { .. }),
+				"{mode} returned an unexpected error: {error:?}"
+			);
 			assert!(!marker_path.exists());
 		}
 	}


### PR DESCRIPTION
Resolves XY-1328.

## Summary
- calibrates the file-heavy generated-schema adversarial test to a bounded five-second synthetic budget
- reports the exact mode and typed error on a strict SchemaMissing mismatch
- leaves production supervision, timeouts, cleanup, quarantine, and fail-closed behavior unchanged

## Evidence
- deterministically reproduced Supervision(PreflightFailed) under bounded contention on the former two-second test budget
- focused test and bounded adversarial replay passed
- process supervision suite passed
- formatting, strict clippy, architecture, and read-only vstyle passed
- exact canonical cargo make check passed twice unchanged: 267/267 workspace tests, 11/11 architecture tests, 3/3 CLI diagnostics
- independent gpt-5.6-sol medium reviewer approved exact diff SHA-256 311605d43d8e96f3f44acc8c8ca273cfb3f8503fd1897b20272c2887d3297d06