### PR TITLE
Establish Project and Agent identity authority

### DIFF
--- a/crates/decodex-core/src/agent.rs
+++ b/crates/decodex-core/src/agent.rs
@@ -1,0 +1,287 @@
+use std::{
+	error::Error,
+	fmt::{Display, Formatter},
+	future::Future,
+};
+
+use crate::{ProjectId, ProjectStatus};
+
+/// Application port for the one global Advisor authority.
+pub trait AgentRepository {
+	/// Adapter-owned error.
+	type Error: Error + Send + Sync + 'static;
+
+	/// Idempotently bootstrap or deterministically read the one global Advisor.
+	fn bootstrap_advisor(
+		&self,
+		advisor: Agent,
+	) -> impl Future<Output = Result<Agent, Self::Error>> + Send;
+
+	/// Deterministically read the global Advisor, when bootstrapped.
+	fn advisor(&self) -> impl Future<Output = Result<Option<Agent>, Self::Error>> + Send;
+
+	/// Deterministically read one stable Agent identity.
+	fn agent(
+		&self,
+		id: &AgentId,
+	) -> impl Future<Output = Result<Option<Agent>, Self::Error>> + Send;
+}
+
+/// Stable canonical Agent identity.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct AgentId(String);
+impl AgentId {
+	/// Parse one canonical lowercase RFC 9562 UUID version 4 identity.
+	pub fn new(value: impl Into<String>) -> Result<Self, AgentError> {
+		let value = value.into();
+
+		if !is_canonical_uuid_v4(&value) {
+			return Err(AgentError::InvalidAgentId);
+		}
+
+		Ok(Self(value))
+	}
+
+	/// Borrow the canonical Agent identity.
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+
+impl Display for AgentId {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(&self.0)
+	}
+}
+
+/// Stable inert Agent authority with no behavior or Conversation binding.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Agent {
+	id: AgentId,
+	role: AgentRole,
+	project_id: Option<ProjectId>,
+	status: AgentStatus,
+	revision: u64,
+}
+impl Agent {
+	/// Create revision one of the global active Advisor identity.
+	pub fn advisor(id: AgentId) -> Self {
+		Self {
+			id,
+			role: AgentRole::Advisor,
+			project_id: None,
+			status: AgentStatus::Active,
+			revision: 1,
+		}
+	}
+
+	/// Create revision one of one Project's canonical active Lead identity.
+	pub fn lead(id: AgentId, project_id: ProjectId) -> Self {
+		Self {
+			id,
+			role: AgentRole::Lead,
+			project_id: Some(project_id),
+			status: AgentStatus::Active,
+			revision: 1,
+		}
+	}
+
+	/// Validate deterministic persistence readback without enabling arbitrary roles.
+	pub fn from_stored(
+		id: AgentId,
+		role: AgentRole,
+		project_id: Option<ProjectId>,
+		status: AgentStatus,
+		revision: u64,
+	) -> Result<Self, AgentError> {
+		if revision == 0 {
+			return Err(AgentError::InvalidRevision);
+		}
+		if !matches!(
+			(role, project_id.as_ref()),
+			(AgentRole::Advisor, None) | (AgentRole::Lead, Some(_))
+		) {
+			return Err(AgentError::InvalidRoleProjectBinding);
+		}
+
+		Ok(Self { id, role, project_id, status, revision })
+	}
+
+	/// Stable identity.
+	pub const fn id(&self) -> &AgentId {
+		&self.id
+	}
+
+	/// Closed role.
+	pub const fn role(&self) -> AgentRole {
+		self.role
+	}
+
+	/// Owning Project for a Lead; always absent for the global Advisor.
+	pub const fn project_id(&self) -> Option<&ProjectId> {
+		self.project_id.as_ref()
+	}
+
+	/// Current inert lifecycle.
+	pub const fn status(&self) -> AgentStatus {
+		self.status
+	}
+
+	/// Positive optimistic revision.
+	pub const fn revision(&self) -> u64 {
+		self.revision
+	}
+
+	/// Apply one legal expected-revision lifecycle transition.
+	pub fn transition(
+		&mut self,
+		expected_revision: u64,
+		status: AgentStatus,
+	) -> Result<(), AgentError> {
+		if expected_revision == 0 || expected_revision != self.revision {
+			return Err(AgentError::RevisionConflict);
+		}
+		if status == self.status
+			|| !matches!(
+				(self.status, status),
+				(AgentStatus::Active, AgentStatus::Paused | AgentStatus::Retired)
+					| (AgentStatus::Paused, AgentStatus::Active | AgentStatus::Retired)
+			) {
+			return Err(AgentError::InvalidLifecycle);
+		}
+
+		self.revision = self.revision.checked_add(1).ok_or(AgentError::InvalidRevision)?;
+		self.status = status;
+
+		Ok(())
+	}
+}
+
+/// Closed stable Agent role authority.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AgentRole {
+	/// One global advisory-only identity with no Project binding.
+	Advisor,
+	/// One canonical identity bound to one Project.
+	Lead,
+}
+
+/// Inert Agent lifecycle.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AgentStatus {
+	/// Identity is current for its role.
+	Active,
+	/// Identity is retained but temporarily inactive.
+	Paused,
+	/// Identity is terminal and retained for readback.
+	Retired,
+}
+
+/// Closed Agent-domain validation failure without caller-controlled text.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AgentError {
+	/// Agent identity was not one canonical UUID version 4.
+	InvalidAgentId,
+	/// Advisor or Lead Project binding violated the closed role invariant.
+	InvalidRoleProjectBinding,
+	/// Persisted or incremented revision was outside its positive domain.
+	InvalidRevision,
+	/// Expected revision did not match current authority.
+	RevisionConflict,
+	/// Lifecycle transition was not legal.
+	InvalidLifecycle,
+}
+impl Error for AgentError {}
+
+impl Display for AgentError {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(match self {
+			Self::InvalidAgentId => "invalid Agent identity",
+			Self::InvalidRoleProjectBinding => "invalid Agent role and Project binding",
+			Self::InvalidRevision => "invalid Agent revision",
+			Self::RevisionConflict => "Agent revision conflict",
+			Self::InvalidLifecycle => "invalid Agent lifecycle transition",
+		})
+	}
+}
+
+/// Map one Project lifecycle to the required canonical Lead lifecycle.
+pub const fn lead_status_for_project(status: ProjectStatus) -> AgentStatus {
+	match status {
+		ProjectStatus::Active => AgentStatus::Active,
+		ProjectStatus::Paused => AgentStatus::Paused,
+		ProjectStatus::Archived => AgentStatus::Retired,
+	}
+}
+
+fn is_canonical_uuid_v4(value: &str) -> bool {
+	let bytes = value.as_bytes();
+
+	bytes.len() == 36
+		&& bytes[8] == b'-'
+		&& bytes[13] == b'-'
+		&& bytes[18] == b'-'
+		&& bytes[23] == b'-'
+		&& bytes[14] == b'4'
+		&& matches!(bytes[19], b'8' | b'9' | b'a' | b'b')
+		&& bytes.iter().enumerate().all(|(index, byte)| {
+			matches!(index, 8 | 13 | 18 | 23)
+				|| byte.is_ascii_digit()
+				|| matches!(byte, b'a'..=b'f')
+		})
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::{Agent, AgentError, AgentId, AgentRole, AgentStatus, ProjectId};
+
+	#[test]
+	fn agent_ids_reject_noncanonical_uuid_shapes_versions_and_placeholders() {
+		for value in [
+			"",
+			"20000000-0000-4000-8000-00000000000A",
+			"20000000000040008000000000000001",
+			"20000000-0000-5000-8000-000000000001",
+			"20000000-0000-4000-c000-000000000001",
+			"not-a-canonical-agent-id",
+		] {
+			assert_eq!(AgentId::new(value), Err(AgentError::InvalidAgentId));
+		}
+	}
+
+	#[test]
+	fn advisor_is_global_and_lead_requires_exactly_one_project() {
+		let advisor_id = AgentId::new("20000000-0000-4000-8000-000000000001").unwrap();
+		let lead_id = AgentId::new("20000000-0000-4000-8000-000000000002").unwrap();
+		let project_id = ProjectId::new("10000000-0000-4000-8000-000000000001").unwrap();
+		let advisor = Agent::advisor(advisor_id.clone());
+		let lead = Agent::lead(lead_id, project_id.clone());
+
+		assert_eq!(advisor.role(), AgentRole::Advisor);
+		assert_eq!(advisor.project_id(), None);
+		assert_eq!(lead.project_id(), Some(&project_id));
+		assert_eq!(
+			Agent::from_stored(
+				advisor_id,
+				AgentRole::Advisor,
+				Some(project_id),
+				AgentStatus::Active,
+				1,
+			),
+			Err(AgentError::InvalidRoleProjectBinding)
+		);
+	}
+
+	#[test]
+	fn retired_agent_is_terminal_and_revisions_are_optimistic() {
+		let mut advisor =
+			Agent::advisor(AgentId::new("20000000-0000-4000-8000-000000000001").unwrap());
+
+		assert_eq!(advisor.transition(2, AgentStatus::Retired), Err(AgentError::RevisionConflict));
+
+		advisor.transition(1, AgentStatus::Retired).unwrap();
+
+		assert_eq!(advisor.revision(), 2);
+		assert_eq!(advisor.transition(2, AgentStatus::Active), Err(AgentError::InvalidLifecycle));
+	}
+}

--- a/crates/decodex-core/src/lib.rs
+++ b/crates/decodex-core/src/lib.rs
@@ -1,6 +1,7 @@
 //! Domain, application, configuration, and owned local-storage foundations for Decodex vNext.
 
 mod account;
+mod agent;
 mod blob;
 mod cache;
 mod config;
@@ -8,10 +9,15 @@ mod conversation;
 mod identity;
 #[cfg(unix)] mod path_unix;
 mod paths;
+mod project;
 mod storage;
 
 pub use self::{
 	account::{AccountError, AccountId, AccountState},
+	agent::{
+		Agent, AgentError, AgentId, AgentRepository, AgentRole, AgentStatus,
+		lead_status_for_project,
+	},
 	blob::{
 		BlobHash, BlobInventoryCursor, BlobInventoryEntry, BlobInventoryPage, BlobStore,
 		MAX_BLOB_BYTES,
@@ -41,6 +47,13 @@ pub use self::{
 	},
 	identity::ServerIdentity,
 	paths::{DecodexPaths, DecodexRoot, PathError},
+	project::{
+		MAX_PROJECT_METADATA_FIELDS, MAX_PROJECT_METADATA_KEY_BYTES,
+		MAX_PROJECT_METADATA_VALUE_BYTES, MAX_PROJECT_PATH_BYTES, MAX_REPOSITORY_IDENTITY_BYTES,
+		Project, ProjectAuthority, ProjectError, ProjectId, ProjectMetadata, ProjectMetadataValue,
+		ProjectRepository, ProjectRepositoryBinding, ProjectStatus, RepositoryIdentity,
+		ServerProjectPath,
+	},
 	storage::StorageError,
 };
 

--- a/crates/decodex-core/src/project.rs
+++ b/crates/decodex-core/src/project.rs
@@ -1,0 +1,677 @@
+use std::{
+	collections::BTreeMap,
+	error::Error,
+	ffi::OsStr,
+	fmt::{Debug, Display, Formatter},
+	future::Future,
+	path::{Component, Path, PathBuf},
+};
+
+use crate::{Agent, AgentRole, AgentStatus};
+
+/// Maximum UTF-8 bytes in one stable repository identity.
+pub const MAX_REPOSITORY_IDENTITY_BYTES: usize = 128;
+/// Maximum encoded bytes in one server-host Project path.
+pub const MAX_PROJECT_PATH_BYTES: usize = 4_096;
+/// Maximum fields in one Project metadata projection.
+pub const MAX_PROJECT_METADATA_FIELDS: usize = 32;
+/// Maximum bytes in one Project metadata key.
+pub const MAX_PROJECT_METADATA_KEY_BYTES: usize = 64;
+/// Maximum bytes in one Project metadata string value.
+pub const MAX_PROJECT_METADATA_VALUE_BYTES: usize = 256;
+
+/// Application port for transactional Project authority operations.
+pub trait ProjectRepository {
+	/// Adapter-owned error.
+	type Error: Error + Send + Sync + 'static;
+
+	/// Atomically create an active Project and its one canonical active Lead.
+	fn create_project(
+		&self,
+		project: Project,
+		lead: Agent,
+	) -> impl Future<Output = Result<ProjectAuthority, Self::Error>> + Send;
+
+	/// Deterministically read one Project with its canonical Lead.
+	fn project(
+		&self,
+		id: &ProjectId,
+	) -> impl Future<Output = Result<Option<ProjectAuthority>, Self::Error>> + Send;
+
+	/// Atomically transition a Project and canonical Lead at one expected revision.
+	fn transition_project(
+		&self,
+		id: &ProjectId,
+		expected_revision: u64,
+		status: ProjectStatus,
+	) -> impl Future<Output = Result<ProjectAuthority, Self::Error>> + Send;
+}
+
+/// Stable canonical Project identity.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ProjectId(String);
+impl ProjectId {
+	/// Parse one canonical lowercase RFC 9562 UUID version 4 identity.
+	pub fn new(value: impl Into<String>) -> Result<Self, ProjectError> {
+		let value = value.into();
+
+		if !is_canonical_uuid_v4(&value) {
+			return Err(ProjectError::InvalidProjectId);
+		}
+
+		Ok(Self(value))
+	}
+
+	/// Borrow the canonical Project identity.
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+
+impl Display for ProjectId {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(&self.0)
+	}
+}
+
+/// Stable repository identity independent from its current server-host root.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct RepositoryIdentity(String);
+impl RepositoryIdentity {
+	/// Parse bounded canonical lowercase repository identity text.
+	pub fn new(value: impl Into<String>) -> Result<Self, ProjectError> {
+		let value = value.into();
+
+		if !is_canonical_repository_identity(&value) {
+			return Err(ProjectError::InvalidRepositoryIdentity);
+		}
+
+		Ok(Self(value))
+	}
+
+	/// Borrow the canonical repository identity.
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+
+impl Display for RepositoryIdentity {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(&self.0)
+	}
+}
+
+/// Absolute path meaningful only on the Decodex server host.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ServerProjectPath(PathBuf);
+impl ServerProjectPath {
+	fn new(value: PathBuf) -> Result<Self, ProjectError> {
+		if !is_normalized_absolute_host_path(&value) {
+			return Err(ProjectError::InvalidServerHostPath);
+		}
+
+		Ok(Self(value))
+	}
+
+	/// Access the path explicitly as a server-host-only value.
+	pub fn as_server_path(&self) -> &Path {
+		&self.0
+	}
+}
+
+impl Debug for ServerProjectPath {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str("ServerProjectPath(<server-host-only>)")
+	}
+}
+
+/// Stable repository binding and default working directory for one Project.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ProjectRepositoryBinding {
+	identity: RepositoryIdentity,
+	root: ServerProjectPath,
+	default_cwd: ServerProjectPath,
+}
+impl ProjectRepositoryBinding {
+	/// Bind a repository identity to an absolute server-host root and contained default cwd.
+	pub fn new(
+		identity: RepositoryIdentity,
+		root: PathBuf,
+		default_cwd: PathBuf,
+	) -> Result<Self, ProjectError> {
+		let root = ServerProjectPath::new(root)?;
+		let default_cwd = ServerProjectPath::new(default_cwd)?;
+
+		if !default_cwd.as_server_path().starts_with(root.as_server_path()) {
+			return Err(ProjectError::DefaultCwdOutsideRepository);
+		}
+
+		Ok(Self { identity, root, default_cwd })
+	}
+
+	/// Stable repository identity.
+	pub const fn identity(&self) -> &RepositoryIdentity {
+		&self.identity
+	}
+
+	/// Absolute root on the server host.
+	pub const fn root(&self) -> &ServerProjectPath {
+		&self.root
+	}
+
+	/// Absolute default cwd on the server host, contained by the root.
+	pub const fn default_cwd(&self) -> &ServerProjectPath {
+		&self.default_cwd
+	}
+}
+
+impl Debug for ProjectRepositoryBinding {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter
+			.debug_struct("ProjectRepositoryBinding")
+			.field("identity", &self.identity)
+			.field("root", &self.root)
+			.field("default_cwd", &self.default_cwd)
+			.finish()
+	}
+}
+
+/// Bounded deterministic Project metadata projection.
+#[derive(Clone, Default, Eq, PartialEq)]
+pub struct ProjectMetadata(BTreeMap<String, ProjectMetadataValue>);
+impl ProjectMetadata {
+	/// Validate one closed metadata projection.
+	pub fn new(values: BTreeMap<String, ProjectMetadataValue>) -> Result<Self, ProjectError> {
+		if values.len() > MAX_PROJECT_METADATA_FIELDS {
+			return Err(ProjectError::InvalidMetadata);
+		}
+
+		for (key, value) in &values {
+			if key.is_empty()
+				|| key.len() > MAX_PROJECT_METADATA_KEY_BYTES
+				|| !key.bytes().enumerate().all(|(index, byte)| {
+					if index == 0 {
+						byte.is_ascii_lowercase()
+					} else {
+						byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'
+					}
+				}) {
+				return Err(ProjectError::InvalidMetadata);
+			}
+			if crate::is_credential_metadata_key(key) {
+				return Err(ProjectError::CredentialRejected);
+			}
+			if matches!(value, ProjectMetadataValue::Text(text) if text.len() > MAX_PROJECT_METADATA_VALUE_BYTES || text.chars().any(char::is_control))
+			{
+				return Err(ProjectError::InvalidMetadata);
+			}
+			if matches!(value, ProjectMetadataValue::Text(text) if crate::contains_credential_material(text))
+			{
+				return Err(ProjectError::CredentialRejected);
+			}
+		}
+
+		Ok(Self(values))
+	}
+
+	/// Empty metadata.
+	pub const fn empty() -> Self {
+		Self(BTreeMap::new())
+	}
+
+	/// Borrow metadata in canonical key order.
+	pub const fn as_map(&self) -> &BTreeMap<String, ProjectMetadataValue> {
+		&self.0
+	}
+}
+
+impl Debug for ProjectMetadata {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter
+			.debug_struct("ProjectMetadata")
+			.field("field_count", &self.0.len())
+			.finish_non_exhaustive()
+	}
+}
+
+/// Canonical inert Project authority.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Project {
+	id: ProjectId,
+	repository: ProjectRepositoryBinding,
+	status: ProjectStatus,
+	metadata: ProjectMetadata,
+	revision: u64,
+}
+impl Project {
+	/// Create revision one of an active Project.
+	pub fn new(
+		id: ProjectId,
+		repository: ProjectRepositoryBinding,
+		metadata: ProjectMetadata,
+	) -> Self {
+		Self { id, repository, status: ProjectStatus::Active, metadata, revision: 1 }
+	}
+
+	/// Validate deterministic persistence readback.
+	pub fn from_stored(
+		id: ProjectId,
+		repository: ProjectRepositoryBinding,
+		status: ProjectStatus,
+		metadata: ProjectMetadata,
+		revision: u64,
+	) -> Result<Self, ProjectError> {
+		if revision == 0 {
+			return Err(ProjectError::InvalidRevision);
+		}
+
+		Ok(Self { id, repository, status, metadata, revision })
+	}
+
+	/// Stable identity.
+	pub const fn id(&self) -> &ProjectId {
+		&self.id
+	}
+
+	/// Stable repository and host-path binding.
+	pub const fn repository(&self) -> &ProjectRepositoryBinding {
+		&self.repository
+	}
+
+	/// Current inert lifecycle.
+	pub const fn status(&self) -> ProjectStatus {
+		self.status
+	}
+
+	/// Bounded metadata.
+	pub const fn metadata(&self) -> &ProjectMetadata {
+		&self.metadata
+	}
+
+	/// Positive optimistic revision.
+	pub const fn revision(&self) -> u64 {
+		self.revision
+	}
+
+	/// Apply one legal expected-revision lifecycle transition.
+	pub fn transition(
+		&mut self,
+		expected_revision: u64,
+		status: ProjectStatus,
+	) -> Result<(), ProjectError> {
+		if expected_revision == 0 || expected_revision != self.revision {
+			return Err(ProjectError::RevisionConflict);
+		}
+		if status == self.status
+			|| !matches!(
+				(self.status, status),
+				(ProjectStatus::Active, ProjectStatus::Paused | ProjectStatus::Archived)
+					| (ProjectStatus::Paused, ProjectStatus::Active | ProjectStatus::Archived)
+			) {
+			return Err(ProjectError::InvalidLifecycle);
+		}
+
+		self.revision = self.revision.checked_add(1).ok_or(ProjectError::InvalidRevision)?;
+		self.status = status;
+
+		Ok(())
+	}
+}
+
+/// Project plus its one canonical Lead deterministic readback.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectAuthority {
+	/// Canonical Project aggregate.
+	pub project: Project,
+	/// Canonical Lead for the Project.
+	pub lead: Agent,
+}
+impl ProjectAuthority {
+	/// Validate the Project/Lead identity, role, lifecycle, and revision invariant.
+	pub fn new(project: Project, lead: Agent) -> Result<Self, ProjectError> {
+		if lead.role() != AgentRole::Lead || lead.project_id() != Some(project.id()) {
+			return Err(ProjectError::InvalidLead);
+		}
+
+		let lifecycle_matches = match project.status() {
+			ProjectStatus::Active => lead.status() == AgentStatus::Active,
+			ProjectStatus::Paused => lead.status() == AgentStatus::Paused,
+			ProjectStatus::Archived => lead.status() == AgentStatus::Retired,
+		};
+
+		if !lifecycle_matches || lead.revision() != project.revision() {
+			return Err(ProjectError::InvalidLead);
+		}
+
+		Ok(Self { project, lead })
+	}
+}
+
+/// Closed scalar retained in bounded Project metadata.
+#[derive(Clone, Eq, PartialEq)]
+pub enum ProjectMetadataValue {
+	/// Bounded ordinary text.
+	Text(String),
+	/// Non-secret boolean fact.
+	Boolean(bool),
+}
+impl Debug for ProjectMetadataValue {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::Text(_) => formatter.write_str("Text(<redacted>)"),
+			Self::Boolean(value) => formatter.debug_tuple("Boolean").field(value).finish(),
+		}
+	}
+}
+
+/// Inert Project lifecycle.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProjectStatus {
+	/// Project owns one active canonical Lead.
+	Active,
+	/// Project is retained but temporarily inactive.
+	Paused,
+	/// Project is terminal and retained for readback.
+	Archived,
+}
+
+/// Closed Project-domain validation failure without caller-controlled text.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProjectError {
+	/// Project identity was not one canonical UUID version 4.
+	InvalidProjectId,
+	/// Repository identity was empty, unbounded, or noncanonical.
+	InvalidRepositoryIdentity,
+	/// Root or cwd was not a bounded normalized absolute server-host path.
+	InvalidServerHostPath,
+	/// Default cwd was not contained by the repository root.
+	DefaultCwdOutsideRepository,
+	/// Metadata exceeded its closed field, key, or value bounds.
+	InvalidMetadata,
+	/// Metadata contained a credential-shaped key or concrete credential value.
+	CredentialRejected,
+	/// Persisted or incremented revision was outside its positive domain.
+	InvalidRevision,
+	/// Expected revision did not match current authority.
+	RevisionConflict,
+	/// Lifecycle transition was not legal.
+	InvalidLifecycle,
+	/// Canonical Lead did not match the Project invariant.
+	InvalidLead,
+}
+impl Error for ProjectError {}
+
+impl Display for ProjectError {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(match self {
+			Self::InvalidProjectId => "invalid Project identity",
+			Self::InvalidRepositoryIdentity => "invalid repository identity",
+			Self::InvalidServerHostPath => "invalid server-host Project path",
+			Self::DefaultCwdOutsideRepository => "default cwd is outside the repository root",
+			Self::InvalidMetadata => "invalid Project metadata",
+			Self::CredentialRejected => "credential-bearing Project metadata rejected",
+			Self::InvalidRevision => "invalid Project revision",
+			Self::RevisionConflict => "Project revision conflict",
+			Self::InvalidLifecycle => "invalid Project lifecycle transition",
+			Self::InvalidLead => "invalid canonical Project Lead",
+		})
+	}
+}
+
+fn is_canonical_uuid_v4(value: &str) -> bool {
+	let bytes = value.as_bytes();
+
+	bytes.len() == 36
+		&& bytes[8] == b'-'
+		&& bytes[13] == b'-'
+		&& bytes[18] == b'-'
+		&& bytes[23] == b'-'
+		&& bytes[14] == b'4'
+		&& matches!(bytes[19], b'8' | b'9' | b'a' | b'b')
+		&& bytes.iter().enumerate().all(|(index, byte)| {
+			matches!(index, 8 | 13 | 18 | 23)
+				|| byte.is_ascii_digit()
+				|| matches!(byte, b'a'..=b'f')
+		})
+}
+
+fn is_canonical_repository_identity(value: &str) -> bool {
+	!value.is_empty()
+		&& value.len() <= MAX_REPOSITORY_IDENTITY_BYTES
+		&& value.bytes().all(|byte| {
+			byte.is_ascii_lowercase()
+				|| byte.is_ascii_digit()
+				|| matches!(byte, b'-' | b'_' | b'.' | b'/')
+		}) && value.split('/').all(|segment| {
+		!segment.is_empty()
+			&& !matches!(segment, "." | "..")
+			&& segment.as_bytes().first().is_some_and(u8::is_ascii_alphanumeric)
+			&& segment.as_bytes().last().is_some_and(u8::is_ascii_alphanumeric)
+	})
+}
+
+fn is_normalized_absolute_host_path(path: &Path) -> bool {
+	let encoded = os_bytes(path.as_os_str());
+	let lexical_segments_are_canonical =
+		encoded.split(|byte| *byte == b'/').all(|segment| segment != b"." && segment != b"..");
+	let text_is_control_free =
+		path.to_str().is_some_and(|value| !value.chars().any(char::is_control));
+
+	!encoded.is_empty()
+		&& encoded.len() <= MAX_PROJECT_PATH_BYTES
+		&& text_is_control_free
+		&& !encoded.contains(&b'\\')
+		&& !encoded.windows(2).any(|pair| pair == b"//")
+		&& encoded.last() != Some(&b'/')
+		&& lexical_segments_are_canonical
+		&& path.is_absolute()
+		&& path.parent().is_some()
+		&& path
+			.components()
+			.all(|component| matches!(component, Component::RootDir | Component::Normal(_)))
+}
+
+fn os_bytes(value: &OsStr) -> &[u8] {
+	value.as_encoded_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{collections::BTreeMap, path::PathBuf};
+
+	use crate::{
+		Agent, AgentId, AgentStatus, MAX_PROJECT_METADATA_FIELDS, MAX_PROJECT_METADATA_KEY_BYTES,
+		MAX_PROJECT_METADATA_VALUE_BYTES, Project, ProjectAuthority, ProjectError, ProjectId,
+		ProjectMetadata, ProjectMetadataValue, ProjectRepositoryBinding, ProjectStatus,
+		RepositoryIdentity,
+	};
+
+	fn binding() -> ProjectRepositoryBinding {
+		ProjectRepositoryBinding::new(
+			RepositoryIdentity::new("hack-ink/decodex").unwrap(),
+			PathBuf::from("/srv/repos/decodex"),
+			PathBuf::from("/srv/repos/decodex/crates"),
+		)
+		.unwrap()
+	}
+
+	#[test]
+	fn project_ids_reject_noncanonical_uuid_shapes_and_versions() {
+		for value in [
+			"",
+			"10000000-0000-4000-8000-00000000000A",
+			"10000000000040008000000000000001",
+			"10000000-0000-5000-8000-000000000001",
+			"10000000-0000-4000-7000-000000000001",
+			"not-a-canonical-project-id",
+		] {
+			assert_eq!(ProjectId::new(value), Err(ProjectError::InvalidProjectId));
+		}
+	}
+
+	#[test]
+	fn repository_binding_is_canonical_server_host_authority() {
+		assert_eq!(binding().identity().as_str(), "hack-ink/decodex");
+		assert!(
+			ProjectRepositoryBinding::new(
+				RepositoryIdentity::new("hack-ink/international").unwrap(),
+				PathBuf::from("/srv/répos/décodex"),
+				PathBuf::from("/srv/répos/décodex/crates"),
+			)
+			.is_ok()
+		);
+
+		for identity in ["", "Hack-Ink/decodex", "hack-ink//decodex", "../decodex"] {
+			assert_eq!(
+				RepositoryIdentity::new(identity),
+				Err(ProjectError::InvalidRepositoryIdentity)
+			);
+		}
+		for (root, cwd, error) in [
+			("relative", "/srv/repos/decodex", ProjectError::InvalidServerHostPath),
+			("/srv/repos/../decodex", "/srv/decodex", ProjectError::InvalidServerHostPath),
+			("/srv/repos/decodex", "/srv/repos/other", ProjectError::DefaultCwdOutsideRepository),
+		] {
+			assert_eq!(
+				ProjectRepositoryBinding::new(
+					RepositoryIdentity::new("hack-ink/decodex").unwrap(),
+					PathBuf::from(root),
+					PathBuf::from(cwd),
+				),
+				Err(error)
+			);
+		}
+		for path in [
+			"/srv/./repo",
+			"/srv/repos/../repo",
+			"/srv/repos/line\nfeed",
+			"/srv/repos/delete\u{7f}control",
+			"/srv/repos/c1\u{85}control",
+		] {
+			let identity = || RepositoryIdentity::new("hack-ink/decodex").unwrap();
+
+			assert_eq!(
+				ProjectRepositoryBinding::new(
+					identity(),
+					PathBuf::from(path),
+					PathBuf::from("/srv/repos/decodex"),
+				),
+				Err(ProjectError::InvalidServerHostPath),
+			);
+			assert_eq!(
+				ProjectRepositoryBinding::new(
+					identity(),
+					PathBuf::from("/srv/repos/decodex"),
+					PathBuf::from(path),
+				),
+				Err(ProjectError::InvalidServerHostPath),
+			);
+		}
+	}
+
+	#[test]
+	fn project_metadata_enforces_closed_bounds() {
+		let maximum = (0..MAX_PROJECT_METADATA_FIELDS)
+			.map(|index| (format!("field_{index}"), ProjectMetadataValue::Boolean(true)))
+			.collect();
+
+		assert!(ProjectMetadata::new(maximum).is_ok());
+		assert_eq!(
+			ProjectMetadata::new(BTreeMap::from([(
+				"x".repeat(MAX_PROJECT_METADATA_KEY_BYTES + 1),
+				ProjectMetadataValue::Boolean(true),
+			)])),
+			Err(ProjectError::InvalidMetadata)
+		);
+		assert_eq!(
+			ProjectMetadata::new(BTreeMap::from([(
+				"description".into(),
+				ProjectMetadataValue::Text("é".repeat(MAX_PROJECT_METADATA_VALUE_BYTES / 2 + 1)),
+			)])),
+			Err(ProjectError::InvalidMetadata)
+		);
+	}
+
+	#[test]
+	fn project_metadata_is_credential_negative_and_debug_redacted() {
+		for key in ["refresh_token", "password", "authorization", "session_token"] {
+			assert_eq!(
+				ProjectMetadata::new(BTreeMap::from([(
+					key.into(),
+					ProjectMetadataValue::Text("ordinary".into()),
+				)])),
+				Err(ProjectError::CredentialRejected),
+			);
+		}
+		for value in [
+			"Bearer abcdefghijklmnop",
+			"sk-proj-0123456789abcdef",
+			"password=not-for-storage",
+			"xoxb-1234567890-abcdef",
+		] {
+			assert_eq!(
+				ProjectMetadata::new(BTreeMap::from([(
+					"note".into(),
+					ProjectMetadataValue::Text(value.into()),
+				)])),
+				Err(ProjectError::CredentialRejected),
+			);
+		}
+
+		assert_eq!(
+			ProjectMetadata::new(BTreeMap::from([(
+				"note".into(),
+				ProjectMetadataValue::Text("before\u{85}after".into()),
+			)])),
+			Err(ProjectError::InvalidMetadata),
+		);
+
+		let metadata = ProjectMetadata::new(BTreeMap::from([
+			("note".into(), ProjectMetadataValue::Text("secret sauce".into())),
+			("summary".into(), ProjectMetadataValue::Text("token budget".into())),
+			("visible".into(), ProjectMetadataValue::Boolean(true)),
+		]))
+		.expect("ordinary credential-negative metadata remains usable");
+		let debug = format!("{metadata:?}");
+
+		assert!(!debug.contains("secret sauce"));
+		assert!(!debug.contains("token budget"));
+		assert_eq!(
+			format!("{:?}", ProjectMetadataValue::Text("private".into())),
+			"Text(<redacted>)"
+		);
+	}
+
+	#[test]
+	fn project_and_lead_lifecycle_and_revisions_move_together() {
+		let project_id = ProjectId::new("10000000-0000-4000-8000-000000000001").unwrap();
+		let mut project = Project::new(project_id.clone(), binding(), ProjectMetadata::empty());
+		let mut lead =
+			Agent::lead(AgentId::new("20000000-0000-4000-8000-000000000001").unwrap(), project_id);
+
+		assert!(ProjectAuthority::new(project.clone(), lead.clone()).is_ok());
+		assert_eq!(
+			project.transition(0, ProjectStatus::Paused),
+			Err(ProjectError::RevisionConflict)
+		);
+
+		project.transition(1, ProjectStatus::Paused).unwrap();
+		lead.transition(1, AgentStatus::Paused).unwrap();
+
+		assert_eq!(project.revision(), 2);
+		assert!(ProjectAuthority::new(project.clone(), lead.clone()).is_ok());
+		assert_eq!(
+			project.transition(2, ProjectStatus::Paused),
+			Err(ProjectError::InvalidLifecycle)
+		);
+
+		project.transition(2, ProjectStatus::Archived).unwrap();
+		lead.transition(2, AgentStatus::Retired).unwrap();
+
+		assert!(ProjectAuthority::new(project.clone(), lead).is_ok());
+		assert_eq!(
+			project.transition(3, ProjectStatus::Active),
+			Err(ProjectError::InvalidLifecycle)
+		);
+	}
+}

--- a/crates/decodex-postgres/migrations/V5__project_agent_authority.sql
+++ b/crates/decodex-postgres/migrations/V5__project_agent_authority.sql
@@ -1,0 +1,303 @@
+-- XY-1315 establishes inert Project and Agent identity authority only.
+CREATE DOMAIN decodex.canonical_uuid_v4_text AS pg_catalog.text
+COLLATE pg_catalog."C"
+CONSTRAINT canonical_uuid_v4_text_exact CHECK (
+	VALUE COLLATE pg_catalog."C" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+);
+
+CREATE TYPE decodex.project_status AS ENUM ('active', 'paused', 'archived');
+CREATE TYPE decodex.agent_role AS ENUM ('advisor', 'lead');
+CREATE TYPE decodex.agent_status AS ENUM ('active', 'paused', 'retired');
+
+CREATE FUNCTION decodex.is_project_metadata(document jsonb)
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+AS $$
+DECLARE entry record;
+DECLARE field_count bigint;
+BEGIN
+	IF jsonb_typeof(document) <> 'object' THEN
+		RETURN false;
+	END IF;
+	SELECT count(*) INTO field_count FROM jsonb_object_keys(document);
+	IF field_count > 32 THEN RETURN false; END IF;
+	FOR entry IN SELECT key, value FROM jsonb_each(document)
+	LOOP
+		IF pg_catalog.octet_length(entry.key) NOT BETWEEN 1 AND 64
+			OR entry.key COLLATE "C" !~ '^[a-z][a-z0-9_]*$'
+			OR pg_catalog.jsonb_typeof(entry.value) NOT IN ('string', 'boolean')
+			OR (
+				pg_catalog.jsonb_typeof(entry.value) = 'string'
+				AND (
+					pg_catalog.octet_length(entry.value OPERATOR(pg_catalog.#>>) '{}') > 256
+					OR (entry.value OPERATOR(pg_catalog.#>>) '{}') COLLATE "C" ~ '[[:cntrl:]]'
+					OR (entry.value OPERATOR(pg_catalog.#>>) '{}') COLLATE "C" ~ U&'[\0080-\009F]'
+				)
+			)
+		THEN
+			RETURN false;
+		END IF;
+	END LOOP;
+	RETURN true;
+END
+$$;
+
+CREATE TABLE decodex.projects (
+	project_id uuid PRIMARY KEY,
+	repository_identity text NOT NULL UNIQUE,
+	repository_root text NOT NULL UNIQUE,
+	default_cwd text NOT NULL,
+	status decodex.project_status NOT NULL DEFAULT 'active',
+	metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+	revision bigint NOT NULL DEFAULT 1 CHECK (revision > 0),
+	created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+	updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+	CONSTRAINT projects_repository_identity_canonical CHECK (
+		length(repository_identity) >= 1
+		AND length(repository_identity) <= 128
+		AND repository_identity COLLATE "C" ~ '^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?(?:/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?)*$'
+	),
+	CONSTRAINT projects_id_canonical_uuid_v4 CHECK (
+		project_id::text COLLATE "C" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	),
+	CONSTRAINT projects_paths_bounded_absolute CHECK (
+		pg_catalog.octet_length(repository_root) >= 2
+		AND pg_catalog.octet_length(repository_root) <= 4096
+		AND pg_catalog.octet_length(default_cwd) >= 2
+		AND pg_catalog.octet_length(default_cwd) <= 4096
+		AND left(repository_root, 1) = '/'
+		AND left(default_cwd, 1) = '/'
+		AND repository_root !~ '(^|/)(\.|\.\.)(/|$)'
+		AND default_cwd !~ '(^|/)(\.|\.\.)(/|$)'
+		AND repository_root NOT LIKE '%//%'
+		AND default_cwd NOT LIKE '%//%'
+		AND pg_catalog.strpos(repository_root, E'\\') = 0
+		AND pg_catalog.strpos(default_cwd, E'\\') = 0
+		AND repository_root COLLATE "C" !~ '[[:cntrl:]]'
+		AND default_cwd COLLATE "C" !~ '[[:cntrl:]]'
+		AND repository_root COLLATE "C" !~ U&'[\0080-\009F]'
+		AND default_cwd COLLATE "C" !~ U&'[\0080-\009F]'
+		AND right(repository_root, 1) <> '/'
+		AND right(default_cwd, 1) <> '/'
+	),
+	CONSTRAINT projects_default_cwd_contained CHECK (
+		default_cwd = repository_root
+		OR (
+			left(default_cwd, length(repository_root)) = repository_root
+			AND substring(default_cwd FROM length(repository_root) + 1 FOR 1) = '/'
+		)
+	),
+	CONSTRAINT projects_metadata_bounded CHECK (decodex.is_project_metadata(metadata)),
+	CONSTRAINT projects_metadata_no_credentials CHECK (NOT decodex.has_credential_material(metadata)),
+	CONSTRAINT projects_finite_timestamps CHECK (isfinite(created_at) AND isfinite(updated_at))
+);
+
+CREATE TABLE decodex.agents (
+	agent_id uuid PRIMARY KEY,
+	role decodex.agent_role NOT NULL,
+	project_id uuid REFERENCES decodex.projects(project_id) ON DELETE RESTRICT,
+	status decodex.agent_status NOT NULL DEFAULT 'active',
+	revision bigint NOT NULL DEFAULT 1 CHECK (revision > 0),
+	created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+	updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+	CONSTRAINT agents_role_project_shape CHECK (
+		(role = 'advisor' AND project_id IS NULL)
+		OR (role = 'lead' AND project_id IS NOT NULL)
+	),
+	CONSTRAINT agents_id_canonical_uuid_v4 CHECK (
+		agent_id::text COLLATE "C" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	),
+	CONSTRAINT agents_finite_timestamps CHECK (isfinite(created_at) AND isfinite(updated_at))
+);
+
+CREATE UNIQUE INDEX agents_one_global_advisor_idx ON decodex.agents (role) WHERE role = 'advisor';
+CREATE UNIQUE INDEX agents_one_lead_per_project_idx ON decodex.agents (project_id) WHERE role = 'lead';
+
+CREATE FUNCTION decodex.bootstrap_advisor(p_agent_id decodex.canonical_uuid_v4_text)
+RETURNS TABLE (agent_id uuid, role decodex.agent_role, project_id uuid, status decodex.agent_status, revision bigint)
+LANGUAGE plpgsql
+SECURITY DEFINER
+CALLED ON NULL INPUT
+AS $$
+DECLARE canonical_agent_id pg_catalog.uuid;
+BEGIN
+	IF p_agent_id IS NULL THEN
+		RAISE EXCEPTION 'identity ingress requires canonical UUID-v4 text'
+			USING ERRCODE = '23514', CONSTRAINT = 'canonical_uuid_v4_text_ingress';
+	END IF;
+	canonical_agent_id := p_agent_id::pg_catalog.text::pg_catalog.uuid;
+	PERFORM pg_catalog.pg_advisory_xact_lock(1315, 1);
+	INSERT INTO decodex.agents (agent_id, role) VALUES (canonical_agent_id, 'advisor')
+	ON CONFLICT DO NOTHING;
+	RETURN QUERY
+	SELECT stored.agent_id, stored.role, stored.project_id, stored.status, stored.revision
+	FROM decodex.agents AS stored WHERE stored.role = 'advisor';
+END
+$$;
+
+CREATE FUNCTION decodex.create_project(
+	p_project_id decodex.canonical_uuid_v4_text,
+	p_repository_identity text,
+	p_repository_root text,
+	p_default_cwd text,
+	p_metadata jsonb,
+	p_lead_id decodex.canonical_uuid_v4_text
+)
+RETURNS TABLE (
+	project_id uuid, repository_identity text, repository_root text, default_cwd text,
+	project_status decodex.project_status, metadata jsonb, project_revision bigint,
+	agent_id uuid, agent_role decodex.agent_role, agent_status decodex.agent_status, agent_revision bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+CALLED ON NULL INPUT
+AS $$
+DECLARE canonical_project_id pg_catalog.uuid;
+DECLARE canonical_lead_id pg_catalog.uuid;
+DECLARE identity_project_id uuid;
+DECLARE repository_project_id uuid;
+DECLARE selected_project_id uuid;
+DECLARE lead_count bigint;
+BEGIN
+	IF p_project_id IS NULL OR p_lead_id IS NULL THEN
+		RAISE EXCEPTION 'identity ingress requires canonical UUID-v4 text'
+			USING ERRCODE = '23514', CONSTRAINT = 'canonical_uuid_v4_text_ingress';
+	END IF;
+	canonical_project_id := p_project_id::pg_catalog.text::pg_catalog.uuid;
+	canonical_lead_id := p_lead_id::pg_catalog.text::pg_catalog.uuid;
+	PERFORM pg_catalog.pg_advisory_xact_lock(1315, pg_catalog.hashtext(p_repository_identity));
+	INSERT INTO decodex.projects (
+		project_id, repository_identity, repository_root, default_cwd, metadata
+	) VALUES (
+		canonical_project_id, p_repository_identity, p_repository_root, p_default_cwd, p_metadata
+	) ON CONFLICT DO NOTHING;
+
+	SELECT stored.project_id INTO identity_project_id
+	FROM decodex.projects AS stored
+	WHERE stored.project_id = canonical_project_id;
+	SELECT stored.project_id INTO repository_project_id
+	FROM decodex.projects AS stored
+	WHERE stored.repository_identity = p_repository_identity;
+
+	IF identity_project_id IS NOT NULL AND identity_project_id = repository_project_id THEN
+		selected_project_id := identity_project_id;
+	ELSIF identity_project_id IS NULL AND repository_project_id IS NOT NULL THEN
+		selected_project_id := repository_project_id;
+	ELSE
+		RAISE EXCEPTION 'Project and repository identities are already bound differently'
+			USING ERRCODE = '23505', CONSTRAINT = 'projects_identity_pair';
+	END IF;
+
+	IF selected_project_id = canonical_project_id THEN
+		INSERT INTO decodex.agents (agent_id, role, project_id)
+		VALUES (canonical_lead_id, 'lead', selected_project_id)
+		ON CONFLICT DO NOTHING;
+	END IF;
+	SELECT count(*) INTO lead_count
+	FROM decodex.agents AS lead
+	WHERE lead.project_id = selected_project_id AND lead.role = 'lead';
+	IF lead_count <> 1 THEN
+		RAISE EXCEPTION 'Project requires exactly one canonical Lead'
+			USING ERRCODE = '23514', CONSTRAINT = 'project_canonical_lead';
+	END IF;
+
+	RETURN QUERY
+	SELECT project.project_id, project.repository_identity, project.repository_root,
+		project.default_cwd, project.status, project.metadata, project.revision,
+		lead.agent_id, lead.role, lead.status, lead.revision
+	FROM decodex.projects AS project
+	JOIN decodex.agents AS lead ON lead.project_id = project.project_id AND lead.role = 'lead'
+	WHERE project.project_id = selected_project_id;
+END
+$$;
+
+CREATE FUNCTION decodex.transition_project(
+	p_project_id decodex.canonical_uuid_v4_text,
+	p_expected_revision bigint,
+	p_status decodex.project_status
+)
+RETURNS TABLE (
+	project_id uuid, repository_identity text, repository_root text, default_cwd text,
+	project_status decodex.project_status, metadata jsonb, project_revision bigint,
+	agent_id uuid, agent_role decodex.agent_role, agent_status decodex.agent_status, agent_revision bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+CALLED ON NULL INPUT
+AS $$
+DECLARE canonical_project_id pg_catalog.uuid;
+DECLARE changed bigint;
+BEGIN
+	IF p_project_id IS NULL THEN
+		RAISE EXCEPTION 'identity ingress requires canonical UUID-v4 text'
+			USING ERRCODE = '23514', CONSTRAINT = 'canonical_uuid_v4_text_ingress';
+	END IF;
+	canonical_project_id := p_project_id::pg_catalog.text::pg_catalog.uuid;
+	UPDATE decodex.projects AS project
+	SET status = p_status, revision = project.revision + 1, updated_at = clock_timestamp()
+	WHERE project.project_id = canonical_project_id
+		AND project.revision = p_expected_revision
+		AND (
+			(project.status = 'active' AND p_status IN ('paused', 'archived'))
+			OR (project.status = 'paused' AND p_status IN ('active', 'archived'))
+		);
+	GET DIAGNOSTICS changed = ROW_COUNT;
+	IF changed <> 1 THEN RETURN; END IF;
+
+	UPDATE decodex.agents AS lead
+	SET status = CASE p_status
+		WHEN 'active' THEN 'active'::decodex.agent_status
+		WHEN 'paused' THEN 'paused'::decodex.agent_status
+		WHEN 'archived' THEN 'retired'::decodex.agent_status
+	END,
+		revision = lead.revision + 1,
+		updated_at = clock_timestamp()
+	WHERE lead.project_id = canonical_project_id AND lead.role = 'lead' AND lead.revision = p_expected_revision;
+	GET DIAGNOSTICS changed = ROW_COUNT;
+	IF changed <> 1 THEN
+		RAISE EXCEPTION 'Project canonical Lead revision differs'
+			USING ERRCODE = '40001';
+	END IF;
+
+	RETURN QUERY
+	SELECT project.project_id, project.repository_identity, project.repository_root,
+		project.default_cwd, project.status, project.metadata, project.revision,
+		lead.agent_id, lead.role, lead.status, lead.revision
+	FROM decodex.projects AS project
+	JOIN decodex.agents AS lead ON lead.project_id = project.project_id AND lead.role = 'lead'
+	WHERE project.project_id = canonical_project_id;
+END
+$$;
+
+ALTER FUNCTION decodex.is_project_metadata(jsonb) SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.bootstrap_advisor(decodex.canonical_uuid_v4_text) SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.create_project(decodex.canonical_uuid_v4_text, text, text, text, jsonb, decodex.canonical_uuid_v4_text) SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.transition_project(decodex.canonical_uuid_v4_text, bigint, decodex.project_status) SET search_path = pg_catalog, decodex;
+
+REVOKE ALL ON TABLE decodex.projects, decodex.agents FROM PUBLIC;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA decodex FROM PUBLIC;
+REVOKE ALL ON TYPE
+	decodex.account_state,
+	decodex.outbox_state,
+	decodex.effect_state,
+	decodex.conversation_status,
+	decodex.runtime_session_state,
+	decodex.turn_role,
+	decodex.side_effect_state,
+	decodex.history_item_kind,
+	decodex.history_item_status,
+	decodex.turn_status,
+	decodex.artifact_status,
+	decodex.context_source_kind,
+	decodex.transition_kind,
+	decodex.context_source_disposition,
+	decodex.command_receipt_state,
+	decodex.canonical_uuid_v4_text,
+	decodex.project_status,
+	decodex.agent_role,
+	decodex.agent_status
+FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON TYPES FROM PUBLIC;

--- a/crates/decodex-postgres/src/authority.rs
+++ b/crates/decodex-postgres/src/authority.rs
@@ -7,7 +7,8 @@ use crate::StoreError;
 
 const FOUNDATION_MIGRATION: &str = include_str!("../migrations/V1__persistence_foundation.sql");
 const CONVERSATION_MIGRATION: &str = include_str!("../migrations/V3__conversation_history.sql");
-const FUNCTION_CONTRACTS: [FunctionContract; 34] = [
+const PROJECT_AGENT_MIGRATION: &str = include_str!("../migrations/V5__project_agent_authority.sql");
+const FUNCTION_CONTRACTS: [FunctionContract; 38] = [
 	FunctionContract {
 		name: "is_canonical_media_type",
 		lookup_signature: "decodex.is_canonical_media_type(pg_catalog.text)",
@@ -314,6 +315,74 @@ const FUNCTION_CONTRACTS: [FunctionContract; 34] = [
 		"decodex.enforce_history_cursor_state()",
 		"enforce_history_cursor_state()",
 	),
+	FunctionContract {
+		name: "is_project_metadata",
+		lookup_signature: "decodex.is_project_metadata(pg_catalog.jsonb)",
+		migration_signature: "is_project_metadata(document jsonb)",
+		arguments: "document jsonb",
+		result: "boolean",
+		language: "plpgsql",
+		volatility: "i",
+		strict: true,
+		returns_set: false,
+		rows: 0.0,
+	},
+	FunctionContract {
+		name: "bootstrap_advisor",
+		lookup_signature: "decodex.bootstrap_advisor(decodex.canonical_uuid_v4_text)",
+		migration_signature: "bootstrap_advisor(p_agent_id decodex.canonical_uuid_v4_text)",
+		arguments: "p_agent_id decodex.canonical_uuid_v4_text",
+		result: "TABLE(agent_id uuid, role decodex.agent_role, project_id uuid, status decodex.agent_status, revision bigint)",
+		language: "plpgsql",
+		volatility: "v",
+		strict: false,
+		returns_set: true,
+		rows: 1_000.0,
+	},
+	FunctionContract {
+		name: "create_project",
+		lookup_signature: "decodex.create_project(decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text)",
+		migration_signature: "create_project(\n\tp_project_id decodex.canonical_uuid_v4_text,\n\tp_repository_identity text,\n\tp_repository_root text,\n\tp_default_cwd text,\n\tp_metadata jsonb,\n\tp_lead_id decodex.canonical_uuid_v4_text\n)",
+		arguments: "p_project_id decodex.canonical_uuid_v4_text, p_repository_identity text, p_repository_root text, p_default_cwd text, p_metadata jsonb, p_lead_id decodex.canonical_uuid_v4_text",
+		result: "TABLE(project_id uuid, repository_identity text, repository_root text, default_cwd text, project_status decodex.project_status, metadata jsonb, project_revision bigint, agent_id uuid, agent_role decodex.agent_role, agent_status decodex.agent_status, agent_revision bigint)",
+		language: "plpgsql",
+		volatility: "v",
+		strict: false,
+		returns_set: true,
+		rows: 1_000.0,
+	},
+	FunctionContract {
+		name: "transition_project",
+		lookup_signature: "decodex.transition_project(decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.project_status)",
+		migration_signature: "transition_project(\n\tp_project_id decodex.canonical_uuid_v4_text,\n\tp_expected_revision bigint,\n\tp_status decodex.project_status\n)",
+		arguments: "p_project_id decodex.canonical_uuid_v4_text, p_expected_revision bigint, p_status decodex.project_status",
+		result: "TABLE(project_id uuid, repository_identity text, repository_root text, default_cwd text, project_status decodex.project_status, metadata jsonb, project_revision bigint, agent_id uuid, agent_role decodex.agent_role, agent_status decodex.agent_status, agent_revision bigint)",
+		language: "plpgsql",
+		volatility: "v",
+		strict: false,
+		returns_set: true,
+		rows: 1_000.0,
+	},
+];
+const RUNTIME_EXECUTE_FUNCTIONS: [&str; 18] = [
+	"decodex.is_canonical_media_type(pg_catalog.text)",
+	"decodex.is_history_metadata_projection(pg_catalog.jsonb)",
+	"decodex.normalize_unicode_whitespace(pg_catalog.text)",
+	"decodex.ascii_lower(pg_catalog.text)",
+	"decodex.has_credential_material(pg_catalog.text)",
+	"decodex.has_credential_material(pg_catalog.jsonb)",
+	"decodex.is_meaningful_evidence(pg_catalog.jsonb)",
+	"decodex.rfc3339_utc(pg_catalog.timestamptz)",
+	"decodex.is_valid_operation_duration(pg_catalog.interval)",
+	"decodex.lease_ttl_milliseconds(pg_catalog.interval)",
+	"decodex.try_acquire_lease(pg_catalog.text,pg_catalog.uuid,pg_catalog.interval)",
+	"decodex.renew_lease(pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.interval)",
+	"decodex.release_lease(pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid)",
+	"decodex.prune_history_snapshots()",
+	"decodex.issue_history_cursor(pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int4)",
+	"decodex.bootstrap_advisor(decodex.canonical_uuid_v4_text)",
+	"decodex.create_project(decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text)",
+	"decodex.transition_project(decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.project_status)",
 ];
 const SAFETY_FUNCTIONS: [&str; 19] = [
 	"enforce_lease_operation_time",
@@ -507,7 +576,9 @@ WITH set_roles AS (
   ('history_cursors', true, false, false, false),
   ('context_packs', true, true, false, false),
   ('context_pack_sources', true, true, false, false),
-  ('transition_proposals', true, true, false, false)
+  ('transition_proposals', true, true, false, false),
+  ('projects', true, false, false, false),
+  ('agents', true, false, false, false)
 ), tables AS (
   SELECT class.oid, class.relname, expected.*
   FROM pg_catalog.pg_class AS class
@@ -516,7 +587,7 @@ WITH set_roles AS (
   WHERE namespace.nspname = 'decodex' AND class.relkind IN ('r', 'p')
 )
 SELECT
-  (SELECT count(*) FROM tables WHERE table_name IS NOT NULL) = 20
+  (SELECT count(*) FROM tables WHERE table_name IS NOT NULL) = 22
     AND COALESCE((
       SELECT pg_catalog.bool_and(
         pg_catalog.has_table_privilege(session_user, oid, 'SELECT') = can_select
@@ -773,14 +844,30 @@ SELECT
     OR proc.pronargdefaults <> 0
     OR proc.proargdefaults IS NOT NULL,
   proc.prosecdef,
-  proc.proconfig,
-  proc.prosrc,
-  pg_catalog.has_function_privilege(session_user, proc.oid, 'EXECUTE')
+	proc.proconfig,
+	proc.prosrc,
+	pg_catalog.has_function_privilege(session_user, proc.oid, 'EXECUTE'),
+	EXISTS (
+	  SELECT 1
+	  FROM pg_catalog.aclexplode(
+	    COALESCE(proc.proacl, pg_catalog.acldefault('f', proc.proowner))
+	  ) AS privilege
+	  WHERE privilege.grantee = 0 AND privilege.privilege_type = 'EXECUTE'
+	)
 FROM pg_catalog.pg_proc AS proc
 JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = proc.pronamespace
 JOIN pg_catalog.pg_language AS language ON language.oid = proc.prolang
 WHERE namespace.nspname = 'decodex'
   AND proc.oid = pg_catalog.to_regprocedure($1)
+"#;
+const IDENTITY_CAST_AUTHORITY_SQL: &str = r#"
+SELECT NOT EXISTS (
+  SELECT 1
+  FROM pg_catalog.pg_cast AS conversion
+  WHERE conversion.castsource = 'pg_catalog.uuid'::pg_catalog.regtype
+    AND conversion.casttarget = 'pg_catalog.text'::pg_catalog.regtype
+    AND conversion.castcontext = 'i'
+)
 "#;
 const EXECUTION_PATH_CONTRACT_SQL: &str = r#"
 WITH catalog_context AS MATERIALIZED (
@@ -910,7 +997,7 @@ const SCHEMA_CONTRACT_SQL: &str = r#"
 WITH catalog_context AS MATERIALIZED (
   SELECT pg_catalog.set_config('search_path', 'pg_catalog', true)
 ), decodex_namespace AS (
-  SELECT namespace.oid
+  SELECT namespace.oid, namespace.nspowner
   FROM pg_catalog.pg_namespace AS namespace
   CROSS JOIN catalog_context
   WHERE namespace.nspname = 'decodex'
@@ -932,6 +1019,39 @@ WITH catalog_context AS MATERIALIZED (
       trigger.tgrelid IN (SELECT oid FROM decodex_relations)
       OR trigger.tgconstraint IN (SELECT oid FROM touching_constraints)
     )
+), decodex_functions AS (
+  SELECT proc.*
+  FROM pg_catalog.pg_proc AS proc
+  WHERE proc.pronamespace IN (SELECT oid FROM decodex_namespace)
+), decodex_types AS (
+  SELECT type.*
+  FROM pg_catalog.pg_type AS type
+  WHERE type.typnamespace IN (SELECT oid FROM decodex_namespace)
+), runtime_role AS (
+  SELECT role.oid
+  FROM pg_catalog.pg_roles AS role
+  WHERE role.rolname = session_user
+), authority_dependency_targets(kind, identity, classid, objid, objsubid) AS (
+  SELECT
+    'function_dependency',
+    pg_catalog.format(
+      '%I.%I(%s)', namespace.nspname, proc.proname,
+      pg_catalog.pg_get_function_identity_arguments(proc.oid)
+    ),
+    'pg_catalog.pg_proc'::pg_catalog.regclass,
+    proc.oid,
+    0
+  FROM decodex_functions AS proc
+  JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = proc.pronamespace
+  UNION ALL
+  SELECT
+    'type_dependency',
+    pg_catalog.format('%I.%I', namespace.nspname, type.typname),
+    'pg_catalog.pg_type'::pg_catalog.regclass,
+    type.oid,
+    0
+  FROM decodex_types AS type
+  JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = type.typnamespace
 ), dependency_targets(kind, identity, classid, objid, objsubid) AS (
   SELECT
     'default',
@@ -1097,6 +1217,138 @@ WITH catalog_context AS MATERIALIZED (
     ON index_namespace.oid = constraint_index.relnamespace
   UNION ALL
   SELECT
+    'type',
+    pg_catalog.format('%I.%I', namespace.nspname, type.typname),
+    pg_catalog.jsonb_build_array(
+      type.typtype,
+      type.typcategory,
+      pg_catalog.format_type(type.typbasetype, type.typtypmod),
+      type.typnotnull,
+      collation_namespace.nspname,
+      coll.collname,
+      CASE WHEN type.typowner = namespace.nspowner
+        THEN 'owner'
+        ELSE 'other:' || pg_catalog.pg_get_userbyid(type.typowner)
+      END,
+      COALESCE((
+        SELECT pg_catalog.jsonb_agg(
+          pg_catalog.jsonb_build_array(
+            CASE
+              WHEN privilege.grantee = 0 THEN 'PUBLIC'
+              WHEN privilege.grantee = type.typowner THEN 'owner'
+              WHEN privilege.grantee = (SELECT oid FROM runtime_role) THEN 'runtime'
+              ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantee)
+            END,
+            privilege.privilege_type,
+            privilege.is_grantable
+          ) ORDER BY privilege.grantee, privilege.privilege_type
+        )
+        FROM pg_catalog.aclexplode(
+          COALESCE(type.typacl, pg_catalog.acldefault('T', type.typowner))
+        ) AS privilege
+      ), '[]'::pg_catalog.jsonb)
+    )::pg_catalog.text
+  FROM decodex_types AS type
+  JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = type.typnamespace
+  LEFT JOIN pg_catalog.pg_collation AS coll ON coll.oid = type.typcollation
+  LEFT JOIN pg_catalog.pg_namespace AS collation_namespace
+    ON collation_namespace.oid = coll.collnamespace
+  UNION ALL
+  SELECT
+    'domain_constraint',
+    pg_catalog.format('%I.%I.%I', namespace.nspname, type.typname, con.conname),
+    pg_catalog.jsonb_build_array(
+      pg_catalog.pg_get_constraintdef(con.oid, false),
+      con.convalidated,
+      con.conenforced
+    )::pg_catalog.text
+  FROM pg_catalog.pg_constraint AS con
+  JOIN decodex_types AS type ON type.oid = con.contypid
+  JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = type.typnamespace
+  UNION ALL
+  SELECT
+    'function',
+    pg_catalog.format(
+      '%I.%I(%s)', namespace.nspname, proc.proname,
+      pg_catalog.pg_get_function_identity_arguments(proc.oid)
+    ),
+    pg_catalog.jsonb_build_array(
+      pg_catalog.pg_get_function_arguments(proc.oid),
+      pg_catalog.pg_get_function_result(proc.oid),
+      language.lanname,
+      proc.provolatile,
+      proc.proparallel,
+      proc.proisstrict,
+      proc.prosecdef,
+      proc.proleakproof,
+      proc.proconfig,
+      proc.prosrc,
+      CASE WHEN proc.proowner = namespace.nspowner
+        THEN 'owner'
+        ELSE 'other:' || pg_catalog.pg_get_userbyid(proc.proowner)
+      END,
+      COALESCE((
+        SELECT pg_catalog.jsonb_agg(
+          pg_catalog.jsonb_build_array(
+            CASE
+              WHEN privilege.grantee = 0 THEN 'PUBLIC'
+              WHEN privilege.grantee = proc.proowner THEN 'owner'
+              WHEN privilege.grantee = (SELECT oid FROM runtime_role) THEN 'runtime'
+              ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantee)
+            END,
+            privilege.privilege_type,
+            privilege.is_grantable
+          ) ORDER BY privilege.grantee, privilege.privilege_type
+        )
+        FROM pg_catalog.aclexplode(
+          COALESCE(proc.proacl, pg_catalog.acldefault('f', proc.proowner))
+        ) AS privilege
+      ), '[]'::pg_catalog.jsonb)
+    )::pg_catalog.text
+  FROM decodex_functions AS proc
+  JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = proc.pronamespace
+  JOIN pg_catalog.pg_language AS language ON language.oid = proc.prolang
+  UNION ALL
+  SELECT
+    target.kind,
+    target.identity,
+    pg_catalog.jsonb_build_array(
+      dependency.deptype,
+      pg_catalog.pg_describe_object(
+        dependency.refclassid,
+        dependency.refobjid,
+        dependency.refobjsubid
+      )
+    )::pg_catalog.text
+  FROM authority_dependency_targets AS target
+  JOIN pg_catalog.pg_depend AS dependency
+    ON dependency.classid = target.classid
+   AND dependency.objid = target.objid
+   AND dependency.objsubid = target.objsubid
+  UNION ALL
+  SELECT
+    'default_acl',
+    pg_catalog.format('%s:%s', default_acl.defaclnamespace, default_acl.defaclobjtype),
+    COALESCE((
+      SELECT pg_catalog.jsonb_agg(
+        pg_catalog.jsonb_build_array(
+          CASE
+            WHEN privilege.grantee = 0 THEN 'PUBLIC'
+            WHEN privilege.grantee = default_acl.defaclrole THEN 'owner'
+            ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantee)
+          END,
+          privilege.privilege_type,
+          privilege.is_grantable
+        ) ORDER BY privilege.grantee, privilege.privilege_type
+      )
+      FROM pg_catalog.aclexplode(default_acl.defaclacl) AS privilege
+    ), '[]'::pg_catalog.jsonb)::pg_catalog.text
+  FROM pg_catalog.pg_default_acl AS default_acl
+  JOIN decodex_namespace AS namespace ON namespace.nspowner = default_acl.defaclrole
+  WHERE default_acl.defaclnamespace IN (0, namespace.oid)
+    AND default_acl.defaclobjtype IN ('f', 'T')
+  UNION ALL
+  SELECT
     'dependency',
     target.kind || ':' || target.identity,
     pg_catalog.jsonb_build_array(
@@ -1129,8 +1381,8 @@ SELECT pg_catalog.jsonb_agg(
 FROM contract_rows
 "#;
 const SCHEMA_CONTRACT_SHA256: [u8; 32] = [
-	0x83, 0xed, 0x77, 0x06, 0x6f, 0x83, 0x2e, 0xa2, 0x1d, 0x78, 0xcb, 0x4a, 0x5e, 0x42, 0xe6, 0xc0,
-	0xfa, 0xe1, 0x78, 0x4b, 0xd8, 0x48, 0x6c, 0xaa, 0x4d, 0x8f, 0x86, 0xcb, 0x7a, 0xa1, 0xd8, 0xf9,
+	0xec, 0x75, 0x7d, 0x18, 0x5f, 0x79, 0xcc, 0x33, 0xdc, 0x51, 0xa8, 0xde, 0x42, 0x6a, 0xb7, 0x45,
+	0x15, 0x3b, 0xb2, 0x66, 0x8d, 0xfe, 0xcd, 0x8e, 0xd0, 0x93, 0x31, 0x6b, 0x58, 0x42, 0x07, 0x88,
 ];
 const EXTENSION_AUTHORITY_SQL: &str = r#"
 WITH set_roles AS (
@@ -1269,6 +1521,7 @@ struct FunctionContract {
 
 pub(crate) async fn verify_runtime(client: &Client) -> Result<(), StoreError> {
 	verify_forbidden_authority(client).await?;
+	verify_identity_cast_authority(client).await?;
 	verify_execution_path_contract(client).await?;
 	verify_retention_contract(client).await?;
 	verify_function_contract(client).await?;
@@ -1308,7 +1561,7 @@ fn canonical_safety_function_source(function_name: &str) -> Option<&'static str>
 
 fn canonical_function_source(contract: &FunctionContract) -> Option<&'static str> {
 	let declaration = format!("CREATE FUNCTION decodex.{}", contract.migration_signature);
-	let migration = [FOUNDATION_MIGRATION, CONVERSATION_MIGRATION]
+	let migration = [FOUNDATION_MIGRATION, CONVERSATION_MIGRATION, PROJECT_AGENT_MIGRATION]
 		.into_iter()
 		.find(|migration| migration.contains(&declaration))?;
 	let (_, declaration_and_tail) = migration.split_once(&declaration)?;
@@ -1316,6 +1569,18 @@ fn canonical_function_source(contract: &FunctionContract) -> Option<&'static str
 	let (source, _) = source_and_tail.split_once("$$;")?;
 
 	Some(source)
+}
+
+async fn verify_identity_cast_authority(client: &Client) -> Result<(), StoreError> {
+	let closed: bool = client.query_one(IDENTITY_CAST_AUTHORITY_SQL, &[]).await?.get(0);
+
+	if !closed {
+		return Err(StoreError::UnsafeAuthority(
+			"PostgreSQL permits an implicit UUID-to-text identity conversion",
+		));
+	}
+
+	Ok(())
 }
 
 async fn verify_schema_contract(client: &Client) -> Result<(), StoreError> {
@@ -1402,11 +1667,17 @@ async fn verify_function_contract(client: &Client) -> Result<(), StoreError> {
 		let settings: Option<Vec<String>> = row.get(11);
 		let installed_source: String = row.get(12);
 		let executable: bool = row.get(13);
+		let public_executable: bool = row.get(14);
 		let expected_security_definer = matches!(
 			contract.name,
-			"issue_history_cursor" | "prune_history_snapshots" | "capture_history_item_version"
+			"issue_history_cursor"
+				| "prune_history_snapshots"
+				| "capture_history_item_version"
+				| "bootstrap_advisor"
+				| "create_project"
+				| "transition_project"
 		);
-		let expected_executable = contract.name != "capture_history_item_version";
+		let expected_executable = RUNTIME_EXECUTE_FUNCTIONS.contains(&contract.lookup_signature);
 		let expected_settings = vec!["search_path=pg_catalog, decodex".to_owned()];
 
 		if unsafe_metadata
@@ -1436,7 +1707,7 @@ async fn verify_function_contract(client: &Client) -> Result<(), StoreError> {
 				"PostgreSQL function semantics differ from the shipped migration".into(),
 			));
 		}
-		if executable != expected_executable {
+		if executable != expected_executable || public_executable {
 			return Err(StoreError::Incompatible(
 				"runtime identity has an incorrect PostgreSQL function privilege".into(),
 			));
@@ -1556,7 +1827,8 @@ mod tests {
 	use std::collections::HashSet;
 
 	use crate::authority::{
-		CONVERSATION_MIGRATION, FOUNDATION_MIGRATION, FUNCTION_CONTRACTS, OWNED_OBJECT_CATALOGS,
+		CONVERSATION_MIGRATION, FOUNDATION_MIGRATION, FUNCTION_CONTRACTS,
+		IDENTITY_CAST_AUTHORITY_SQL, OWNED_OBJECT_CATALOGS, PROJECT_AGENT_MIGRATION,
 		ROLE_AUTHORITY_SQL, SAFETY_FUNCTIONS, SCHEMA_CONTRACT_SHA256, SCHEMA_CONTRACT_SQL,
 	};
 
@@ -1594,9 +1866,17 @@ mod tests {
 	}
 
 	#[test]
+	fn schema_manifest_attests_global_and_decodex_scoped_owner_default_acls() {
+		assert!(SCHEMA_CONTRACT_SQL.contains(
+			"default_acl.defaclnamespace IN (0, namespace.oid)\n    AND default_acl.defaclobjtype IN ('f', 'T')"
+		));
+		assert!(!SCHEMA_CONTRACT_SQL.contains("default_acl.defaclnamespace = 0"));
+	}
+
+	#[test]
 	fn canonical_inventory_covers_every_shipped_decodex_function_once() {
 		assert_eq!(
-			[FOUNDATION_MIGRATION, CONVERSATION_MIGRATION]
+			[FOUNDATION_MIGRATION, CONVERSATION_MIGRATION, PROJECT_AGENT_MIGRATION]
 				.into_iter()
 				.map(|migration| migration.matches("CREATE FUNCTION decodex.").count())
 				.sum::<usize>(),
@@ -1608,7 +1888,7 @@ mod tests {
 		for contract in FUNCTION_CONTRACTS {
 			assert!(lookup_signatures.insert(contract.lookup_signature));
 			assert_eq!(
-				[FOUNDATION_MIGRATION, CONVERSATION_MIGRATION]
+				[FOUNDATION_MIGRATION, CONVERSATION_MIGRATION, PROJECT_AGENT_MIGRATION]
 					.into_iter()
 					.map(|migration| migration
 						.matches(&format!(
@@ -1627,6 +1907,27 @@ mod tests {
 			assert!(source.ends_with('\n'));
 			assert!(!source.trim().is_empty());
 		}
+	}
+
+	#[test]
+	fn identity_mutators_share_one_first_statement_null_guard_and_cast_audit() {
+		for name in ["bootstrap_advisor", "create_project", "transition_project"] {
+			let contract = FUNCTION_CONTRACTS
+				.iter()
+				.find(|contract| contract.name == name)
+				.expect("identity mutator is in the closed function inventory");
+			let source = super::canonical_function_source(contract)
+				.expect("identity mutator has canonical migration source");
+			let first_statement =
+				source.split_once("BEGIN\n").expect("PL/pgSQL body begins").1.trim_start();
+
+			assert!(first_statement.starts_with("IF p_"), "{name}");
+			assert!(first_statement.contains("identity ingress requires canonical UUID-v4 text"));
+			assert!(first_statement.contains("CONSTRAINT = 'canonical_uuid_v4_text_ingress'"));
+		}
+
+		assert!(IDENTITY_CAST_AUTHORITY_SQL.contains("pg_catalog.pg_cast"));
+		assert!(IDENTITY_CAST_AUTHORITY_SQL.contains("conversion.castcontext = 'i'"));
 	}
 
 	#[test]

--- a/crates/decodex-postgres/src/lib.rs
+++ b/crates/decodex-postgres/src/lib.rs
@@ -13,6 +13,7 @@ mod error;
 mod leases;
 mod migrations;
 mod outbox;
+mod project_agents;
 #[cfg(unix)] mod socket;
 mod types;
 
@@ -25,11 +26,16 @@ pub use self::{
 	},
 	error::{BootstrapFailure, StoreError},
 	types::{
-		AccountMetadata, AccountMutation, ActivityRecord, CommandIdentity, LeaseClaim, OutboxClaim,
-		OutboxReconciliation, OutboxState, QuotaWindow, QuotaWindowMutation, ReconciliationOutcome,
+		AccountMetadata, AccountMutation, ActivityRecord, CommandIdentity, CreateProject,
+		LeaseClaim, OutboxClaim, OutboxReconciliation, OutboxState, QuotaWindow,
+		QuotaWindowMutation, ReconciliationOutcome,
 	},
 };
-pub use decodex_core::{AccountId, AccountState};
+pub use decodex_core::{
+	AccountId, AccountState, Agent, AgentId, AgentRole, AgentStatus, Project, ProjectAuthority,
+	ProjectId, ProjectMetadata, ProjectMetadataValue, ProjectRepositoryBinding, ProjectStatus,
+	RepositoryIdentity,
+};
 
 use std::{sync::Arc, time::Duration};
 

--- a/crates/decodex-postgres/src/migrations.rs
+++ b/crates/decodex-postgres/src/migrations.rs
@@ -7,6 +7,8 @@ use deadpool_postgres::Client;
 use crate::{REQUIRED_POSTGRES_MAJOR, StoreError};
 use embedded::migrations;
 
+const EXPECTED_LATEST_MIGRATION_VERSION: i32 = 5;
+
 pub(crate) async fn run(client: &mut Client) -> Result<(), StoreError> {
 	migrations::runner().run_async(&mut ***client).await?;
 
@@ -52,6 +54,13 @@ pub(crate) async fn verify(client: &Client) -> Result<(), StoreError> {
 
 	expected.sort_by_key(|migration| migration.version());
 
+	if expected.last().map(|migration| migration.version())
+		!= Some(EXPECTED_LATEST_MIGRATION_VERSION)
+	{
+		return Err(StoreError::Incompatible(
+			"embedded migration inventory does not end at the canonical V5 ledger".into(),
+		));
+	}
 	if actual.len() != expected.len() {
 		return Err(StoreError::Incompatible(format!(
 			"expected {} migration history entries, found {}",

--- a/crates/decodex-postgres/src/project_agents.rs
+++ b/crates/decodex-postgres/src/project_agents.rs
@@ -1,0 +1,354 @@
+use std::{collections::BTreeMap, fmt::Display, path::PathBuf};
+
+use serde_json::{Map, Value};
+use tokio_postgres::{Error, Row, error::DbError};
+
+use crate::{CreateProject, PostgresStore, StoreError};
+use decodex_core::{
+	Agent, AgentId, AgentRepository, AgentRole, AgentStatus, Project, ProjectAuthority, ProjectId,
+	ProjectMetadata, ProjectMetadataValue, ProjectRepository, ProjectRepositoryBinding,
+	ProjectStatus, RepositoryIdentity,
+};
+
+impl PostgresStore {
+	/// Idempotently bootstrap or read the one global inert Advisor identity.
+	pub async fn bootstrap_advisor(&self, advisor: Agent) -> Result<Agent, StoreError> {
+		if advisor.role() != AgentRole::Advisor
+			|| advisor.project_id().is_some()
+			|| advisor.status() != AgentStatus::Active
+			|| advisor.revision() != 1
+		{
+			return Err(StoreError::InvalidInput(
+				"Advisor bootstrap requires revision-one global active authority",
+			));
+		}
+
+		let client = crate::checkout(self.pool(), &self.connector).await?;
+		let row = client
+			.query_one(
+				"SELECT agent_id::text, role::text, project_id::text, status::text, revision \
+				 FROM decodex.bootstrap_advisor(\
+				 $1::pg_catalog.text::decodex.canonical_uuid_v4_text)",
+				&[&advisor.id().as_str()],
+			)
+			.await?;
+
+		decode_agent(&row, 0)
+	}
+
+	/// Atomically create an active Project and its one canonical active Lead.
+	pub async fn create_project(
+		&self,
+		request: CreateProject,
+	) -> Result<ProjectAuthority, StoreError> {
+		let CreateProject { project, lead } = request;
+
+		ProjectAuthority::new(project.clone(), lead.clone()).map_err(|_| {
+			StoreError::InvalidInput("Project creation requires matching revision-one active Lead")
+		})?;
+
+		if project.status() != ProjectStatus::Active || project.revision() != 1 {
+			return Err(StoreError::InvalidInput(
+				"Project creation requires revision-one active authority",
+			));
+		}
+
+		let root = project
+			.repository()
+			.root()
+			.as_server_path()
+			.to_str()
+			.ok_or(StoreError::InvalidInput("Project paths must be UTF-8"))?;
+		let cwd = project
+			.repository()
+			.default_cwd()
+			.as_server_path()
+			.to_str()
+			.ok_or(StoreError::InvalidInput("Project paths must be UTF-8"))?;
+		let metadata = encode_metadata(project.metadata());
+
+		crate::ensure_credential_negative_json(&metadata)?;
+
+		let client = crate::checkout(self.pool(), &self.connector).await?;
+		let row = client
+			.query_one(
+				"SELECT project_id::text, repository_identity, repository_root, default_cwd, \
+				 project_status::text, metadata, project_revision, agent_id::text, \
+				 agent_role::text, agent_status::text, agent_revision \
+				 FROM decodex.create_project(\
+				 $1::pg_catalog.text::decodex.canonical_uuid_v4_text,$2,$3,$4,$5,\
+				 $6::pg_catalog.text::decodex.canonical_uuid_v4_text)",
+				&[
+					&project.id().as_str(),
+					&project.repository().identity().as_str(),
+					&root,
+					&cwd,
+					&metadata,
+					&lead.id().as_str(),
+				],
+			)
+			.await
+			.map_err(project_agent_database_error)?;
+
+		decode_project_authority(&row)
+	}
+
+	/// Deterministically read one Project with its canonical Lead.
+	pub async fn project(&self, id: &ProjectId) -> Result<Option<ProjectAuthority>, StoreError> {
+		let client = crate::checkout(self.pool(), &self.connector).await?;
+		let row = client
+			.query_opt(
+				"SELECT project.project_id::text, project.repository_identity, \
+				 project.repository_root, project.default_cwd, project.status::text, \
+				 project.metadata, project.revision, lead.agent_id::text, lead.role::text, \
+				 lead.status::text, lead.revision \
+				 FROM decodex.projects AS project \
+				 JOIN decodex.agents AS lead ON lead.project_id=project.project_id AND lead.role='lead' \
+				 WHERE project.project_id=$1::text::uuid",
+				&[&id.as_str()],
+			)
+			.await?;
+
+		row.as_ref().map(decode_project_authority).transpose()
+	}
+
+	/// Atomically transition one Project and its canonical Lead.
+	pub async fn transition_project(
+		&self,
+		id: &ProjectId,
+		expected_revision: u64,
+		status: ProjectStatus,
+	) -> Result<ProjectAuthority, StoreError> {
+		let expected_revision = i64::try_from(expected_revision)
+			.map_err(|_| StoreError::InvalidInput("Project revision exceeds PostgreSQL bigint"))?;
+		let client = crate::checkout(self.pool(), &self.connector).await?;
+		let row = client
+			.query_opt(
+				"SELECT project_id::text, repository_identity, repository_root, default_cwd, \
+				 project_status::text, metadata, project_revision, agent_id::text, \
+				 agent_role::text, agent_status::text, agent_revision \
+				 FROM decodex.transition_project(\
+				 $1::pg_catalog.text::decodex.canonical_uuid_v4_text,$2,\
+				 $3::text::decodex.project_status)",
+				&[&id.as_str(), &expected_revision, &project_status_text(status)],
+			)
+			.await?;
+
+		if let Some(row) = row {
+			return decode_project_authority(&row);
+		}
+
+		let actual = client
+			.query_opt(
+				"SELECT revision FROM decodex.projects WHERE project_id=$1::text::uuid",
+				&[&id.as_str()],
+			)
+			.await?
+			.map(|row| row.get(0));
+
+		Err(StoreError::RevisionConflict {
+			entity: id.to_string(),
+			expected: Some(expected_revision),
+			actual,
+		})
+	}
+
+	/// Deterministically read the global Advisor.
+	pub async fn advisor(&self) -> Result<Option<Agent>, StoreError> {
+		let client = crate::checkout(self.pool(), &self.connector).await?;
+		let row = client
+			.query_opt(
+				"SELECT agent_id::text, role::text, project_id::text, status::text, revision \
+				 FROM decodex.agents WHERE role='advisor'",
+				&[],
+			)
+			.await?;
+
+		row.as_ref().map(|row| decode_agent(row, 0)).transpose()
+	}
+
+	/// Deterministically read one stable Agent identity.
+	pub async fn agent(&self, id: &AgentId) -> Result<Option<Agent>, StoreError> {
+		let client = crate::checkout(self.pool(), &self.connector).await?;
+		let row = client
+			.query_opt(
+				"SELECT agent_id::text, role::text, project_id::text, status::text, revision \
+				 FROM decodex.agents WHERE agent_id=$1::text::uuid",
+				&[&id.as_str()],
+			)
+			.await?;
+
+		row.as_ref().map(|row| decode_agent(row, 0)).transpose()
+	}
+}
+
+impl ProjectRepository for PostgresStore {
+	type Error = StoreError;
+
+	async fn create_project(
+		&self,
+		project: Project,
+		lead: Agent,
+	) -> Result<ProjectAuthority, Self::Error> {
+		Self::create_project(self, CreateProject { project, lead }).await
+	}
+
+	async fn project(&self, id: &ProjectId) -> Result<Option<ProjectAuthority>, Self::Error> {
+		Self::project(self, id).await
+	}
+
+	async fn transition_project(
+		&self,
+		id: &ProjectId,
+		expected_revision: u64,
+		status: ProjectStatus,
+	) -> Result<ProjectAuthority, Self::Error> {
+		Self::transition_project(self, id, expected_revision, status).await
+	}
+}
+
+impl AgentRepository for PostgresStore {
+	type Error = StoreError;
+
+	async fn bootstrap_advisor(&self, advisor: Agent) -> Result<Agent, Self::Error> {
+		Self::bootstrap_advisor(self, advisor).await
+	}
+
+	async fn advisor(&self) -> Result<Option<Agent>, Self::Error> {
+		Self::advisor(self).await
+	}
+
+	async fn agent(&self, id: &AgentId) -> Result<Option<Agent>, Self::Error> {
+		Self::agent(self, id).await
+	}
+}
+
+fn decode_project_authority(row: &Row) -> Result<ProjectAuthority, StoreError> {
+	let project_id = ProjectId::new(row.get::<_, String>(0)).map_err(incompatible_core)?;
+	let repository = ProjectRepositoryBinding::new(
+		RepositoryIdentity::new(row.get::<_, String>(1)).map_err(incompatible_core)?,
+		PathBuf::from(row.get::<_, String>(2)),
+		PathBuf::from(row.get::<_, String>(3)),
+	)
+	.map_err(incompatible_core)?;
+	let project = Project::from_stored(
+		project_id.clone(),
+		repository,
+		decode_project_status(row.get(4))?,
+		decode_metadata(row.get(5))?,
+		u64::try_from(row.get::<_, i64>(6)).map_err(|_| incompatible())?,
+	)
+	.map_err(incompatible_core)?;
+	let lead = Agent::from_stored(
+		AgentId::new(row.get::<_, String>(7)).map_err(incompatible_core)?,
+		decode_agent_role(row.get(8))?,
+		Some(project_id),
+		decode_agent_status(row.get(9))?,
+		u64::try_from(row.get::<_, i64>(10)).map_err(|_| incompatible())?,
+	)
+	.map_err(incompatible_core)?;
+
+	ProjectAuthority::new(project, lead).map_err(incompatible_core)
+}
+
+fn decode_agent(row: &Row, offset: usize) -> Result<Agent, StoreError> {
+	let project_id = row
+		.get::<_, Option<String>>(offset + 2)
+		.map(ProjectId::new)
+		.transpose()
+		.map_err(incompatible_core)?;
+
+	Agent::from_stored(
+		AgentId::new(row.get::<_, String>(offset)).map_err(incompatible_core)?,
+		decode_agent_role(row.get(offset + 1))?,
+		project_id,
+		decode_agent_status(row.get(offset + 3))?,
+		u64::try_from(row.get::<_, i64>(offset + 4)).map_err(|_| incompatible())?,
+	)
+	.map_err(incompatible_core)
+}
+
+fn encode_metadata(metadata: &ProjectMetadata) -> Value {
+	Value::Object(
+		metadata
+			.as_map()
+			.iter()
+			.map(|(key, value)| {
+				let value = match value {
+					ProjectMetadataValue::Text(value) => Value::String(value.clone()),
+					ProjectMetadataValue::Boolean(value) => Value::Bool(*value),
+				};
+
+				(key.clone(), value)
+			})
+			.collect::<Map<_, _>>(),
+	)
+}
+
+fn decode_metadata(value: Value) -> Result<ProjectMetadata, StoreError> {
+	let Value::Object(value) = value else { return Err(incompatible()) };
+	let values = value
+		.into_iter()
+		.map(|(key, value)| {
+			let value = match value {
+				Value::String(value) => ProjectMetadataValue::Text(value),
+				Value::Bool(value) => ProjectMetadataValue::Boolean(value),
+				_ => return Err(incompatible()),
+			};
+
+			Ok((key, value))
+		})
+		.collect::<Result<BTreeMap<_, _>, StoreError>>()?;
+
+	ProjectMetadata::new(values).map_err(incompatible_core)
+}
+
+fn decode_project_status(value: &str) -> Result<ProjectStatus, StoreError> {
+	match value {
+		"active" => Ok(ProjectStatus::Active),
+		"paused" => Ok(ProjectStatus::Paused),
+		"archived" => Ok(ProjectStatus::Archived),
+		_ => Err(incompatible()),
+	}
+}
+
+const fn project_status_text(value: ProjectStatus) -> &'static str {
+	match value {
+		ProjectStatus::Active => "active",
+		ProjectStatus::Paused => "paused",
+		ProjectStatus::Archived => "archived",
+	}
+}
+
+fn decode_agent_role(value: &str) -> Result<AgentRole, StoreError> {
+	match value {
+		"advisor" => Ok(AgentRole::Advisor),
+		"lead" => Ok(AgentRole::Lead),
+		_ => Err(incompatible()),
+	}
+}
+
+fn decode_agent_status(value: &str) -> Result<AgentStatus, StoreError> {
+	match value {
+		"active" => Ok(AgentStatus::Active),
+		"paused" => Ok(AgentStatus::Paused),
+		"retired" => Ok(AgentStatus::Retired),
+		_ => Err(incompatible()),
+	}
+}
+
+fn incompatible_core(error: impl Display) -> StoreError {
+	StoreError::Incompatible(format!("invalid stored Project/Agent authority: {error}"))
+}
+
+fn incompatible() -> StoreError {
+	StoreError::Incompatible("invalid stored Project/Agent authority".into())
+}
+
+fn project_agent_database_error(error: Error) -> StoreError {
+	if error.as_db_error().and_then(DbError::constraint) == Some("projects_identity_pair") {
+		StoreError::InvalidInput("Project and repository identities are already bound differently")
+	} else {
+		StoreError::from(error)
+	}
+}

--- a/crates/decodex-postgres/src/types.rs
+++ b/crates/decodex-postgres/src/types.rs
@@ -4,7 +4,16 @@ use serde_json::Value;
 use sha2::{Digest as _, Sha256};
 
 use crate::StoreError;
-use decodex_core::{AccountId, AccountState};
+use decodex_core::{AccountId, AccountState, Agent, Project};
+
+/// Transactional creation input for one Project and its canonical Lead.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreateProject {
+	/// Revision-one active Project authority.
+	pub project: Project,
+	/// Matching revision-one active canonical Lead.
+	pub lead: Agent,
+}
 
 /// Idempotent optimistic account metadata mutation.
 #[derive(Clone)]

--- a/crates/decodex-postgres/tests/postgres_store.rs
+++ b/crates/decodex-postgres/tests/postgres_store.rs
@@ -1,7 +1,7 @@
 //! Real PostgreSQL contract coverage for the XY-1267 persistence foundation.
 
 use std::{
-	collections::HashSet,
+	collections::{BTreeMap, HashSet},
 	env,
 	fs::{self, Permissions},
 	os::unix::fs::PermissionsExt as _,
@@ -26,15 +26,16 @@ use decodex_core::{
 	ContextPack, ContextPackInput, ContextPackPolicy, ContextPackSource, ContextSourceKind,
 	ConversationId, DecodexRoot, HistoryItemId, HistoryItemKind, HistoryMediaType, HistoryMetadata,
 	HistoryMetadataValue, ItemStatus, PinnedContextSource, PossibleSideEffects, ProductState as _,
-	ProfileSnapshot, ProposedTransitionKind, RuntimeSessionId, RuntimeSessionState, TurnId,
-	TurnRole, TurnStatus,
+	ProfileSnapshot, Project, ProjectId, ProjectMetadata, ProjectMetadataValue,
+	ProjectRepositoryBinding, ProjectStatus, ProposedTransitionKind, RepositoryIdentity,
+	RuntimeSessionId, RuntimeSessionState, TurnId, TurnRole, TurnStatus,
 };
 use decodex_postgres::{
-	AccountId, AccountMutation, AccountState, CLOSED, CommandIdentity, ContextPackRecord,
-	CreateArtifact, CreateConversation, CreateRuntimeSession, HistoryCursor,
-	MAX_OPERATION_DURATION_MILLISECONDS, OutboxClaim, OutboxReconciliation, PersistContextPack,
-	PostgresStore, ProposeTransition, QuotaWindowMutation, ReconciliationOutcome,
-	RecordHistoryItem, StoreError,
+	AccountId, AccountMutation, AccountState, Agent, AgentId, AgentRole, AgentStatus, CLOSED,
+	CommandIdentity, ContextPackRecord, CreateArtifact, CreateConversation, CreateProject,
+	CreateRuntimeSession, HistoryCursor, MAX_OPERATION_DURATION_MILLISECONDS, OutboxClaim,
+	OutboxReconciliation, PersistContextPack, PostgresStore, ProposeTransition,
+	QuotaWindowMutation, ReconciliationOutcome, RecordHistoryItem, StoreError,
 };
 
 const ACCOUNT_ID: &str = "10000000-0000-0000-0000-000000000001";
@@ -63,6 +64,125 @@ const CREDENTIAL_VALUE_VECTORS: &[&str] = &[
 	"AKIA0123456789ABCDEF",
 ];
 const UNICODE_WHITESPACE_VECTORS: &[&str] = &["\u{a0}", "\u{85}", "\u{202f}", "\u{3000}"];
+const RUNTIME_EXECUTE_SIGNATURES: &[&str] = &[
+	"decodex.is_canonical_media_type(pg_catalog.text)",
+	"decodex.is_history_metadata_projection(pg_catalog.jsonb)",
+	"decodex.normalize_unicode_whitespace(pg_catalog.text)",
+	"decodex.ascii_lower(pg_catalog.text)",
+	"decodex.has_credential_material(pg_catalog.text)",
+	"decodex.has_credential_material(pg_catalog.jsonb)",
+	"decodex.is_meaningful_evidence(pg_catalog.jsonb)",
+	"decodex.rfc3339_utc(pg_catalog.timestamptz)",
+	"decodex.is_valid_operation_duration(pg_catalog.interval)",
+	"decodex.lease_ttl_milliseconds(pg_catalog.interval)",
+	"decodex.try_acquire_lease(pg_catalog.text,pg_catalog.uuid,pg_catalog.interval)",
+	"decodex.renew_lease(pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.interval)",
+	"decodex.release_lease(pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid)",
+	"decodex.prune_history_snapshots()",
+	"decodex.issue_history_cursor(pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int4)",
+	"decodex.bootstrap_advisor(decodex.canonical_uuid_v4_text)",
+	"decodex.create_project(decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text)",
+	"decodex.transition_project(decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.project_status)",
+];
+const TRIGGER_ONLY_SIGNATURES: &[&str] = &[
+	"decodex.enforce_lease_operation_time()",
+	"decodex.enforce_outbox_operation_time()",
+	"decodex.forbid_mutation_of_activity()",
+	"decodex.enforce_outbox_terminal_retention()",
+	"decodex.forbid_outbox_truncate()",
+	"decodex.enforce_command_receipt_state()",
+	"decodex.acquire_hierarchy_coordinator()",
+	"decodex.canonicalize_created_at()",
+	"decodex.enforce_blob_object_state()",
+	"decodex.enforce_conversation_state()",
+	"decodex.enforce_runtime_session_state()",
+	"decodex.enforce_turn_state()",
+	"decodex.enforce_history_item_state()",
+	"decodex.capture_history_item_version()",
+	"decodex.enforce_artifact_state()",
+	"decodex.enforce_artifact_revision_state()",
+	"decodex.enforce_context_pack_state()",
+	"decodex.enforce_context_pack_source_state()",
+	"decodex.enforce_history_cursor_state()",
+];
+const INVALID_PROJECT_AGENT_SQL_CALLS: &[(&str, &str)] = &[
+	(
+		"SELECT * FROM decodex.bootstrap_advisor('00000000-0000-0000-0000-000000000000')",
+		"canonical_uuid_v4_text_exact",
+	),
+	(
+		"SELECT * FROM decodex.bootstrap_advisor('21000000-0000-1000-8000-000000000099')",
+		"canonical_uuid_v4_text_exact",
+	),
+	(
+		"SELECT * FROM decodex.create_project('00000000-0000-0000-0000-000000000000',\
+		 'hack-ink/invalid-project-id','/srv/repos/invalid-project-id',\
+		 '/srv/repos/invalid-project-id','{}','22000000-0000-4000-8000-000000000020')",
+		"canonical_uuid_v4_text_exact",
+	),
+	(
+		"SELECT * FROM decodex.create_project('11000000-0000-4000-8000-000000000021',\
+		 'hack-ink/invalid-lead-id','/srv/repos/invalid-lead-id',\
+		 '/srv/repos/invalid-lead-id','{}','22000000-0000-1000-8000-000000000021')",
+		"canonical_uuid_v4_text_exact",
+	),
+	(
+		"SELECT * FROM decodex.create_project('11000000-0000-4000-8000-000000000022',\
+		 'hack-ink/backslash-path',E'/srv/repos/bad\\\\path',E'/srv/repos/bad\\\\path',\
+		 '{}','22000000-0000-4000-8000-000000000022')",
+		"projects_paths_bounded_absolute",
+	),
+	(
+		"SELECT * FROM decodex.create_project('11000000-0000-4000-8000-000000000023',\
+		 'hack-ink/dot-dot-path','/srv/repos/canonical','/srv/repos/canonical/../bad',\
+		 '{}','22000000-0000-4000-8000-000000000023')",
+		"projects_paths_bounded_absolute",
+	),
+	(
+		"SELECT * FROM decodex.create_project('11000000-0000-4000-8000-000000000030',\
+		 'hack-ink/dot-path','/srv/./repos/dot','/srv/./repos/dot',\
+		 '{}','22000000-0000-4000-8000-000000000030')",
+		"projects_paths_bounded_absolute",
+	),
+	(
+		"SELECT * FROM decodex.create_project('11000000-0000-4000-8000-000000000031',\
+		 'hack-ink/lf-path',E'/srv/repos/line\\nfeed',E'/srv/repos/line\\nfeed',\
+		 '{}','22000000-0000-4000-8000-000000000031')",
+		"projects_paths_bounded_absolute",
+	),
+	(
+		"SELECT * FROM decodex.create_project('11000000-0000-4000-8000-000000000032',\
+		 'hack-ink/del-path',U&'/srv/repos/del\\007Fcontrol',U&'/srv/repos/del\\007Fcontrol',\
+		 '{}','22000000-0000-4000-8000-000000000032')",
+		"projects_paths_bounded_absolute",
+	),
+	(
+		"SELECT * FROM decodex.create_project('11000000-0000-4000-8000-000000000033',\
+		 'hack-ink/c1-path',U&'/srv/repos/c1\\0085control',U&'/srv/repos/c1\\0085control',\
+		 '{}','22000000-0000-4000-8000-000000000033')",
+		"projects_paths_bounded_absolute",
+	),
+	(
+		"SELECT * FROM decodex.create_project('11000000-0000-4000-8000-000000000024',\
+		 'hack-ink/unicode-path','/' || repeat('é',2048),\
+		 '/' || repeat('é',2048),'{}','22000000-0000-4000-8000-000000000024')",
+		"projects_paths_bounded_absolute",
+	),
+	(
+		"SELECT * FROM decodex.create_project('11000000-0000-4000-8000-000000000025',\
+		 'hack-ink/control-metadata','/srv/repos/control-metadata',\
+		 '/srv/repos/control-metadata',jsonb_build_object('note',E'line\\nfeed'),\
+		 '22000000-0000-4000-8000-000000000025')",
+		"projects_metadata_bounded",
+	),
+	(
+		"SELECT * FROM decodex.create_project('11000000-0000-4000-8000-000000000027',\
+		 'hack-ink/unicode-control-metadata','/srv/repos/unicode-control-metadata',\
+		 '/srv/repos/unicode-control-metadata',jsonb_build_object('note',U&'before\\0085after'),\
+		 '22000000-0000-4000-8000-000000000027')",
+		"projects_metadata_bounded",
+	),
+];
 
 struct ConversationFixture {
 	blob_store: BlobStore,
@@ -106,6 +226,30 @@ fn blob_shard_path(blob_store: &BlobStore, hash: BlobHash) -> Result<PathBuf, st
 		.ok_or_else(|| std::io::Error::other("blob path has no shard parent"))
 }
 
+fn project_request(
+	project_id: &str,
+	lead_id: &str,
+	repository_identity: &str,
+	repository_root: &str,
+) -> CreateProject {
+	let project_id = ProjectId::new(project_id).expect("Project fixture ID is canonical");
+	let project = Project::new(
+		project_id.clone(),
+		ProjectRepositoryBinding::new(
+			RepositoryIdentity::new(repository_identity)
+				.expect("repository fixture identity is canonical"),
+			PathBuf::from(repository_root),
+			PathBuf::from(repository_root),
+		)
+		.expect("repository fixture paths are canonical"),
+		ProjectMetadata::empty(),
+	);
+	let lead =
+		Agent::lead(AgentId::new(lead_id).expect("Lead fixture ID is canonical"), project_id);
+
+	CreateProject { project, lead }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires the isolated PostgreSQL 18 migration harness"]
 async fn postgres_migration_contract() -> Result<(), Box<dyn std::error::Error>> {
@@ -131,6 +275,7 @@ async fn postgres_store_contract() -> Result<(), Box<dyn std::error::Error>> {
 
 	assert_bootstrap_and_history(&client).await?;
 	assert_runtime_is_least_privilege(&runtime_client).await?;
+	assert_project_agent_authority(&store, &client, &migration, &runtime).await?;
 	assert_account_idempotency_and_revision(&store, &client).await?;
 	assert_receipt_first_saga(&store, &client).await?;
 	assert_concurrent_shard_capacity(&store, &client).await?;
@@ -1580,6 +1725,11 @@ async fn assert_runtime_is_least_privilege(
 		 (conversation_id,snapshot_high_water,page_size,last_position,history_item_id) VALUES \
 		 ('40000000-0000-4000-8000-000000000001',1,1,1, \
 		 '44000000-0000-4000-8000-000000000001')",
+		"INSERT INTO decodex.projects \
+		 (project_id,repository_identity,repository_root,default_cwd) VALUES \
+		 ('10000000-0000-4000-8000-000000000099','forbidden/project','/srv/forbidden','/srv/forbidden')",
+		"INSERT INTO decodex.agents (agent_id,role) VALUES \
+		 ('20000000-0000-4000-8000-000000000099','advisor')",
 	] {
 		let error = client
 			.batch_execute(statement)
@@ -1610,6 +1760,67 @@ async fn postgres_store_restored_contract() -> Result<(), Box<dyn std::error::Er
 
 	assert!(store.account(&AccountId::new(ACCOUNT_ID)?).await?.is_some());
 
+	let advisor = store.advisor().await?.expect("restored global Advisor exists");
+
+	assert!(matches!(
+		advisor.id().as_str(),
+		"21000000-0000-4000-8000-000000000001" | "21000000-0000-4000-8000-000000000002"
+	));
+	assert_eq!(advisor.role(), AgentRole::Advisor);
+	assert_eq!(advisor.project_id(), None);
+	assert_eq!(advisor.status(), AgentStatus::Active);
+	assert_eq!(advisor.revision(), 1);
+
+	let restored_project_id: String = client
+		.query_one(
+			"SELECT project_id::text FROM decodex.projects \
+			 WHERE repository_identity='hack-ink/decodex'",
+			&[],
+		)
+		.await?
+		.get(0);
+	let restored = store
+		.project(&ProjectId::new(restored_project_id)?)
+		.await?
+		.expect("restored Project and canonical Lead exist");
+
+	assert!(matches!(
+		restored.project.id().as_str(),
+		"11000000-0000-4000-8000-000000000001" | "11000000-0000-4000-8000-000000000002"
+	));
+	assert_eq!(restored.project.repository().identity().as_str(), "hack-ink/decodex");
+	assert_eq!(
+		restored.project.repository().root().as_server_path(),
+		Path::new("/srv/repos/decodex")
+	);
+	assert_eq!(
+		restored.project.repository().default_cwd().as_server_path(),
+		Path::new("/srv/repos/decodex")
+	);
+	assert_eq!(
+		restored.project.metadata().as_map().get("managed"),
+		Some(&ProjectMetadataValue::Boolean(true))
+	);
+	assert_eq!(restored.project.status(), ProjectStatus::Paused);
+	assert_eq!(restored.project.revision(), 2);
+	assert_eq!(restored.lead.role(), AgentRole::Lead);
+	assert_eq!(restored.lead.project_id(), Some(restored.project.id()));
+	assert_eq!(restored.lead.status(), AgentStatus::Paused);
+	assert_eq!(restored.lead.revision(), 2);
+
+	let restored_fk: bool = client
+		.query_one(
+			"SELECT lead.project_id = project.project_id \
+			 FROM decodex.projects AS project \
+			 JOIN decodex.agents AS lead ON lead.project_id=project.project_id AND lead.role='lead' \
+			 WHERE project.project_id=$1::text::uuid",
+			&[&restored.project.id().as_str()],
+		)
+		.await?
+		.get(0);
+
+	assert!(restored_fk);
+
 	let ordinary_rows: i64 = client
 		.query_one(
 			"SELECT (SELECT count(*) FROM decodex.accounts) \
@@ -1632,6 +1843,32 @@ async fn postgres_store_restored_contract() -> Result<(), Box<dyn std::error::Er
 	connection_task.await??;
 
 	Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires the isolated PostgreSQL 18 populated restore harness"]
+async fn postgres_store_rejects_schema_scoped_default_acl_restore()
+-> Result<(), Box<dyn std::error::Error>> {
+	let (migration, runtime) = separated_configs("DECODEX_TEST")?;
+
+	match PostgresStore::connect(migration, runtime, expected_peer_uid()).await {
+		Err(StoreError::Incompatible(_)) => Ok(()),
+		Err(error) => panic!("unexpected schema-scoped default-ACL restore error: {error:?}"),
+		Ok(_) => panic!("schema-scoped default-ACL restore was accepted"),
+	}
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires the isolated PostgreSQL 18 authority harness"]
+async fn postgres_store_rejects_implicit_uuid_to_text_cast()
+-> Result<(), Box<dyn std::error::Error>> {
+	let (migration, runtime) = separated_configs("DECODEX_TEST")?;
+
+	match PostgresStore::connect(migration, runtime, expected_peer_uid()).await {
+		Err(StoreError::UnsafeAuthority(_)) => Ok(()),
+		Err(error) => panic!("unexpected implicit UUID-to-text cast error: {error:?}"),
+		Ok(_) => panic!("implicit UUID-to-text cast authority was accepted"),
+	}
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1713,7 +1950,7 @@ async fn assert_bootstrap_and_history(client: &Client) -> Result<(), Box<dyn std
 
 	assert_eq!(version, 18);
 	assert_eq!(checksums, "on");
-	assert_eq!(history.len(), 4);
+	assert_eq!(history.len(), 5);
 	assert_eq!(history[0].0, 1);
 	assert_eq!(history[0].1, "persistence_foundation");
 	assert!(!history[0].2.is_empty());
@@ -1726,6 +1963,9 @@ async fn assert_bootstrap_and_history(client: &Client) -> Result<(), Box<dyn std
 	assert_eq!(history[3].0, 4);
 	assert_eq!(history[3].1, "account_readiness");
 	assert!(!history[3].2.is_empty());
+	assert_eq!(history[4].0, 5);
+	assert_eq!(history[4].1, "project_agent_authority");
+	assert!(!history[4].2.is_empty());
 
 	let (migration, runtime) = separated_configs("DECODEX_TEST")?;
 
@@ -1752,6 +1992,580 @@ async fn assert_bootstrap_and_history(client: &Client) -> Result<(), Box<dyn std
 	));
 
 	Ok(())
+}
+
+async fn assert_project_agent_authority(
+	store: &PostgresStore,
+	client: &Client,
+	migration: &Config,
+	runtime: &Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let advisor_ids =
+		["21000000-0000-4000-8000-000000000001", "21000000-0000-4000-8000-000000000002"];
+	let mut advisor_tasks = JoinSet::new();
+
+	for id in advisor_ids {
+		let store = store.clone();
+
+		advisor_tasks.spawn(async move {
+			store
+				.bootstrap_advisor(Agent::advisor(
+					AgentId::new(id).expect("Advisor fixture ID is canonical"),
+				))
+				.await
+		});
+	}
+
+	let mut advisors = Vec::new();
+
+	while let Some(result) = advisor_tasks.join_next().await {
+		advisors.push(result??);
+	}
+
+	assert_eq!(advisors[0], advisors[1]);
+	assert_eq!(store.advisor().await?, Some(advisors[0].clone()));
+
+	let candidates = [
+		("11000000-0000-4000-8000-000000000001", "22000000-0000-4000-8000-000000000001"),
+		("11000000-0000-4000-8000-000000000002", "22000000-0000-4000-8000-000000000002"),
+	];
+	let mut project_tasks = JoinSet::new();
+
+	for (project_id, lead_id) in candidates {
+		let store = store.clone();
+
+		project_tasks.spawn(async move {
+			let project_id = ProjectId::new(project_id).expect("Project fixture ID is canonical");
+			let project = Project::new(
+				project_id.clone(),
+				ProjectRepositoryBinding::new(
+					RepositoryIdentity::new("hack-ink/decodex")
+						.expect("repository fixture identity is canonical"),
+					PathBuf::from("/srv/repos/decodex"),
+					PathBuf::from("/srv/repos/decodex"),
+				)
+				.expect("repository fixture paths are canonical"),
+				ProjectMetadata::new(BTreeMap::from([(
+					"managed".into(),
+					ProjectMetadataValue::Boolean(true),
+				)]))
+				.expect("Project metadata fixture is bounded"),
+			);
+			let lead = Agent::lead(
+				AgentId::new(lead_id).expect("Lead fixture ID is canonical"),
+				project_id,
+			);
+
+			store.create_project(CreateProject { project, lead }).await
+		});
+	}
+
+	let mut authorities = Vec::new();
+
+	while let Some(result) = project_tasks.join_next().await {
+		authorities.push(result??);
+	}
+
+	assert_eq!(authorities[0], authorities[1]);
+
+	let winner = authorities.pop().expect("concurrent Project creation returned a winner");
+
+	assert_eq!(store.project(winner.project.id()).await?, Some(winner.clone()));
+
+	let paused = store.transition_project(winner.project.id(), 1, ProjectStatus::Paused).await?;
+
+	assert_eq!(paused.project.revision(), 2);
+	assert_eq!(paused.lead.revision(), 2);
+	assert!(matches!(
+		store.transition_project(winner.project.id(), 1, ProjectStatus::Archived).await,
+		Err(StoreError::RevisionConflict { actual: Some(2), .. })
+	));
+
+	assert_project_agent_canonical_sql_boundary(client, runtime).await?;
+	assert_project_identity_pair_conflicts(store, client, runtime).await?;
+
+	client
+		.batch_execute(
+			"INSERT INTO decodex.agents (agent_id,role,project_id) VALUES \
+			 ('22000000-0000-4000-8000-000000000099','lead', \
+			 '11000000-0000-4000-8000-000000000099')",
+		)
+		.await
+		.expect_err("Lead foreign key rejects an unknown Project");
+	client
+		.batch_execute(
+			"INSERT INTO decodex.agents (agent_id,role) VALUES \
+			 ('21000000-0000-4000-8000-000000000099','advisor')",
+		)
+		.await
+		.expect_err("global Advisor uniqueness is durable");
+
+	let restarted =
+		PostgresStore::connect(migration.clone(), runtime.clone(), expected_peer_uid()).await?;
+
+	assert_eq!(restarted.project(paused.project.id()).await?, Some(paused));
+	assert_eq!(restarted.advisor().await?, store.advisor().await?);
+
+	Ok(())
+}
+
+async fn assert_project_identity_pair_conflicts(
+	store: &PostgresStore,
+	client: &Client,
+	runtime: &Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let first = project_request(
+		"11000000-0000-4000-8000-000000000010",
+		"22000000-0000-4000-8000-000000000010",
+		"hack-ink/identity-a",
+		"/srv/repos/identity-a",
+	);
+	let second = project_request(
+		"11000000-0000-4000-8000-000000000011",
+		"22000000-0000-4000-8000-000000000011",
+		"hack-ink/identity-b",
+		"/srv/repos/identity-b",
+	);
+
+	store.create_project(first.clone()).await?;
+	store.create_project(second.clone()).await?;
+
+	let rows_before: i64 = client
+		.query_one(
+			"SELECT (SELECT count(*) FROM decodex.projects) + (SELECT count(*) FROM decodex.agents)",
+			&[],
+		)
+		.await?
+		.get(0);
+	let split_pair = project_request(
+		first.project.id().as_str(),
+		"22000000-0000-4000-8000-000000000012",
+		second.project.repository().identity().as_str(),
+		"/srv/repos/identity-b",
+	);
+	let rebound_id = project_request(
+		first.project.id().as_str(),
+		"22000000-0000-4000-8000-000000000013",
+		"hack-ink/identity-c",
+		"/srv/repos/identity-c",
+	);
+
+	for request in [split_pair, rebound_id] {
+		assert!(matches!(
+			store.create_project(request).await,
+			Err(StoreError::InvalidInput(
+				"Project and repository identities are already bound differently"
+			))
+		));
+	}
+
+	let (runtime_client, runtime_connection) = runtime.connect(NoTls).await?;
+	let runtime_task = tokio::spawn(runtime_connection);
+	let error = runtime_client
+		.query(
+			"SELECT * FROM decodex.create_project(\
+			 '11000000-0000-4000-8000-000000000010','hack-ink/identity-b',\
+			 '/srv/repos/identity-b','/srv/repos/identity-b','{}',\
+			 '22000000-0000-4000-8000-000000000014')",
+			&[],
+		)
+		.await
+		.expect_err("direct SQL rejects a split Project/repository identity pair");
+
+	assert_eq!(
+		error.as_db_error().and_then(tokio_postgres::error::DbError::constraint),
+		Some("projects_identity_pair")
+	);
+
+	drop(runtime_client);
+
+	runtime_task.await??;
+
+	let rows_after: i64 = client
+		.query_one(
+			"SELECT (SELECT count(*) FROM decodex.projects) + (SELECT count(*) FROM decodex.agents)",
+			&[],
+		)
+		.await?
+		.get(0);
+
+	assert_eq!(rows_after, rows_before, "identity conflicts commit no partial rows");
+
+	Ok(())
+}
+
+async fn assert_project_metadata_credential_sql_boundary(
+	runtime_client: &Client,
+) -> Result<(), Box<dyn std::error::Error>> {
+	for (statement, exposed_value) in [
+		(
+			"SELECT * FROM decodex.create_project('11000000-0000-4000-8000-000000000026',\
+			 'hack-ink/credential-key','/srv/repos/credential-key','/srv/repos/credential-key',\
+			 '{\"refresh_token\":\"sk-proj-0123456789abcdef\"}',\
+			 '22000000-0000-4000-8000-000000000026')",
+			"sk-proj",
+		),
+		(
+			"SELECT * FROM decodex.create_project('11000000-0000-4000-8000-000000000028',\
+			 'hack-ink/credential-value','/srv/repos/credential-value',\
+			 '/srv/repos/credential-value','{\"note\":\"Bearer abcdefghijklmnop\"}',\
+			 '22000000-0000-4000-8000-000000000028')",
+			"Bearer",
+		),
+	] {
+		let error = runtime_client
+			.query(statement, &[])
+			.await
+			.expect_err("credential-shaped Project metadata is rejected");
+
+		assert_eq!(
+			error.as_db_error().and_then(tokio_postgres::error::DbError::constraint),
+			Some("projects_metadata_no_credentials"),
+		);
+
+		let closed_error = StoreError::from(error);
+
+		assert!(matches!(closed_error, StoreError::CredentialRejected));
+		assert!(!closed_error.to_string().contains(exposed_value));
+	}
+
+	Ok(())
+}
+
+async fn assert_project_path_sql_acceptance(
+	runtime_client: &Client,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let row = runtime_client
+		.query_one(
+			"SELECT repository_root,default_cwd FROM decodex.create_project(\
+			 '11000000-0000-4000-8000-000000000029','hack-ink/international-path',\
+			 '/srv/répos/décodex','/srv/répos/décodex/crates','{}',\
+			 '22000000-0000-4000-8000-000000000029')",
+			&[],
+		)
+		.await?;
+
+	assert_eq!(row.get::<_, &str>(0), "/srv/répos/décodex");
+	assert_eq!(row.get::<_, &str>(1), "/srv/répos/décodex/crates");
+
+	Ok(())
+}
+
+async fn assert_project_agent_canonical_sql_boundary(
+	client: &Client,
+	runtime: &Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let (runtime_client, runtime_connection) = runtime.connect(NoTls).await?;
+	let runtime_task = tokio::spawn(runtime_connection);
+
+	assert_identity_ingress_authority(&runtime_client).await?;
+	assert_project_path_sql_acceptance(&runtime_client).await?;
+
+	let rows_before: i64 = client
+		.query_one(
+			"SELECT (SELECT count(*) FROM decodex.projects) + (SELECT count(*) FROM decodex.agents)",
+			&[],
+		)
+		.await?
+		.get(0);
+
+	for &(statement, constraint) in INVALID_PROJECT_AGENT_SQL_CALLS {
+		let error = runtime_client
+			.query(statement, &[])
+			.await
+			.expect_err("canonical SQL authority rejects invalid Project/Agent input");
+
+		assert_eq!(
+			error.as_db_error().and_then(tokio_postgres::error::DbError::constraint),
+			Some(constraint),
+			"statement: {statement}",
+		);
+	}
+
+	assert_project_metadata_credential_sql_boundary(&runtime_client).await?;
+	drop(runtime_client);
+
+	runtime_task.await??;
+
+	let rows_after: i64 = client
+		.query_one(
+			"SELECT (SELECT count(*) FROM decodex.projects) + (SELECT count(*) FROM decodex.agents)",
+			&[],
+		)
+		.await?
+		.get(0);
+
+	assert_eq!(rows_after, rows_before, "invalid SQL calls commit no partial rows");
+
+	Ok(())
+}
+
+async fn assert_identity_ingress_authority(
+	runtime: &Client,
+) -> Result<(), Box<dyn std::error::Error>> {
+	assert_identity_ingress_catalog(runtime).await?;
+	assert_identity_ingress_exact_domain(runtime).await;
+	assert_identity_ingress_unknown_literal(runtime).await;
+	assert_identity_ingress_explicit_text(runtime).await;
+	assert_identity_ingress_prepared_bound_text(runtime).await;
+	assert_identity_ingress_invalid_text(runtime).await;
+	assert_identity_ingress_null(runtime).await;
+	assert_identity_ingress_bare_uuid(runtime).await;
+	assert_identity_ingress_explicit_normalization(runtime).await;
+
+	let exact_execute_count: i64 = runtime
+		.query_one(
+			"SELECT count(*) FROM pg_catalog.pg_proc AS proc
+			 JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid=proc.pronamespace
+			 WHERE namespace.nspname='decodex'
+			 AND pg_catalog.has_function_privilege(session_user,proc.oid,'EXECUTE')",
+			&[],
+		)
+		.await?
+		.get(0);
+
+	assert_eq!(exact_execute_count, RUNTIME_EXECUTE_SIGNATURES.len() as i64);
+
+	for signature in RUNTIME_EXECUTE_SIGNATURES {
+		let executable: bool = runtime
+			.query_one(
+				"SELECT pg_catalog.has_function_privilege(
+				 session_user,pg_catalog.to_regprocedure($1),'EXECUTE')",
+				&[signature],
+			)
+			.await?
+			.get(0);
+
+		assert!(executable, "runtime lacks {signature}");
+	}
+	for signature in TRIGGER_ONLY_SIGNATURES {
+		let executable: bool = runtime
+			.query_one(
+				"SELECT pg_catalog.has_function_privilege(
+				 session_user,pg_catalog.to_regprocedure($1),'EXECUTE')",
+				&[signature],
+			)
+			.await?
+			.get(0);
+
+		assert!(!executable, "runtime executes trigger-only {signature}");
+	}
+
+	let public_and_defaults_closed: bool = runtime
+		.query_one(
+			"SELECT
+			 NOT EXISTS (
+			  SELECT 1 FROM pg_catalog.pg_proc AS proc
+			  JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid=proc.pronamespace
+			  CROSS JOIN LATERAL pg_catalog.aclexplode(
+			   COALESCE(proc.proacl,pg_catalog.acldefault('f',proc.proowner))) AS privilege
+			  WHERE namespace.nspname='decodex' AND privilege.grantee=0
+			   AND privilege.privilege_type='EXECUTE')
+			 AND NOT EXISTS (
+			  SELECT 1 FROM pg_catalog.pg_type AS type
+			  JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid=type.typnamespace
+			  CROSS JOIN LATERAL pg_catalog.aclexplode(
+			   COALESCE(type.typacl,pg_catalog.acldefault('T',type.typowner))) AS privilege
+			  WHERE namespace.nspname='decodex' AND type.typtype IN ('e','d')
+			   AND privilege.grantee=0
+			   AND privilege.privilege_type='USAGE')
+			 AND (
+			  SELECT count(*)=2
+			   AND bool_and(default_acl.defaclnamespace=0)
+			   AND count(*) FILTER (WHERE default_acl.defaclobjtype='f')=1
+			   AND count(*) FILTER (WHERE default_acl.defaclobjtype='T')=1
+			   AND bool_and(NOT EXISTS (
+			    SELECT 1 FROM pg_catalog.aclexplode(default_acl.defaclacl) AS privilege
+			    WHERE privilege.grantee=0))
+			  FROM pg_catalog.pg_default_acl AS default_acl
+			  JOIN pg_catalog.pg_namespace AS namespace ON namespace.nspowner=default_acl.defaclrole
+			  WHERE default_acl.defaclnamespace IN (0,namespace.oid)
+			   AND default_acl.defaclobjtype IN ('f','T'))",
+			&[],
+		)
+		.await?
+		.get(0);
+
+	assert!(public_and_defaults_closed);
+
+	Ok(())
+}
+
+async fn assert_identity_ingress_catalog(
+	runtime: &Client,
+) -> Result<(), Box<dyn std::error::Error>> {
+	const SQL: &str = "SELECT
+	 pg_catalog.to_regprocedure('decodex.bootstrap_advisor(decodex.canonical_uuid_v4_text)') IS NOT NULL
+	 AND pg_catalog.to_regprocedure('decodex.bootstrap_advisor(pg_catalog.uuid)') IS NULL
+	 AND pg_catalog.to_regprocedure('decodex.bootstrap_advisor(pg_catalog.text)') IS NULL
+	 AND pg_catalog.to_regprocedure('decodex.create_project(decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text)') IS NOT NULL
+	 AND pg_catalog.to_regprocedure('decodex.create_project(pg_catalog.uuid,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.jsonb,pg_catalog.uuid)') IS NULL
+	 AND pg_catalog.to_regprocedure('decodex.create_project(pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.jsonb,pg_catalog.text)') IS NULL
+	 AND pg_catalog.to_regprocedure('decodex.transition_project(decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.project_status)') IS NOT NULL
+	 AND pg_catalog.to_regprocedure('decodex.transition_project(pg_catalog.uuid,pg_catalog.int8,decodex.project_status)') IS NULL
+	 AND pg_catalog.to_regprocedure('decodex.transition_project(pg_catalog.text,pg_catalog.int8,decodex.project_status)') IS NULL
+	 AND NOT EXISTS (
+	  SELECT 1 FROM pg_catalog.pg_cast AS conversion
+	  WHERE conversion.castsource='pg_catalog.uuid'::pg_catalog.regtype
+	   AND conversion.casttarget='pg_catalog.text'::pg_catalog.regtype
+	   AND conversion.castcontext='i')";
+
+	let signatures_are_domain_only: bool = runtime.query_one(SQL, &[]).await?.get(0);
+
+	assert!(signatures_are_domain_only, "catalog identity contract; SQL: {SQL}");
+
+	Ok(())
+}
+
+async fn assert_identity_ingress_exact_domain(runtime: &Client) {
+	const SQL: &str = "SELECT * FROM decodex.bootstrap_advisor(
+	 '21000000-0000-4000-8000-000000000040'::decodex.canonical_uuid_v4_text)";
+
+	let result = runtime.query(SQL, &[]).await;
+
+	assert!(result.is_ok(), "exact-domain expression; SQL: {SQL}; result: {result:?}");
+}
+
+async fn assert_identity_ingress_unknown_literal(runtime: &Client) {
+	const SQL: &str = "SELECT * FROM decodex.bootstrap_advisor(
+	 '21000000-0000-4000-8000-000000000040')";
+
+	let result = runtime.query(SQL, &[]).await;
+
+	assert!(result.is_ok(), "unknown-literal expression; SQL: {SQL}; result: {result:?}");
+}
+
+async fn assert_identity_ingress_explicit_text(runtime: &Client) {
+	const SQL: &str = "SELECT * FROM decodex.bootstrap_advisor(
+	 '21000000-0000-4000-8000-000000000040'::pg_catalog.text)";
+
+	let result = runtime.query(SQL, &[]).await;
+
+	assert!(result.is_ok(), "explicit-text expression; SQL: {SQL}; result: {result:?}");
+}
+
+async fn assert_identity_ingress_prepared_bound_text(runtime: &Client) {
+	const SQL: &str = "SELECT * FROM decodex.bootstrap_advisor($1::pg_catalog.text)";
+
+	let id = "21000000-0000-4000-8000-000000000040";
+	let result = runtime.query(SQL, &[&id]).await;
+
+	assert!(
+		result.is_ok(),
+		"prepared/bound-text expression; SQL: {SQL}; bound value: canonical UUID-v4; result: {result:?}"
+	);
+}
+
+async fn assert_identity_ingress_invalid_text(runtime: &Client) {
+	const SQL: &str = "SELECT * FROM decodex.bootstrap_advisor($1::pg_catalog.text)";
+
+	for invalid in [
+		"21000000-0000-4000-8000-0000000000AA",
+		"00000000-0000-0000-0000-000000000000",
+		"21000000-0000-1000-8000-000000000099",
+		"21000000000040008000000000000099",
+	] {
+		let error = runtime
+			.query(SQL, &[&invalid])
+			.await
+			.expect_err(&format!("invalid-text expression; SQL: {SQL}; input: {invalid}"));
+		let database = error.as_db_error().expect("invalid-text expression has PostgreSQL detail");
+
+		assert_eq!(
+			database.code(),
+			&tokio_postgres::error::SqlState::CHECK_VIOLATION,
+			"invalid-text expression; SQL: {SQL}; input: {invalid}"
+		);
+		assert_eq!(
+			database.constraint(),
+			Some("canonical_uuid_v4_text_exact"),
+			"invalid-text expression; SQL: {SQL}; input: {invalid}"
+		);
+	}
+}
+
+async fn assert_identity_ingress_null(runtime: &Client) {
+	for (case, statement) in [
+		(
+			"bootstrap Advisor empty scalar subquery",
+			"SELECT * FROM decodex.bootstrap_advisor(
+			 (SELECT value FROM (VALUES(NULL::decodex.canonical_uuid_v4_text)) AS empty(value)
+			  WHERE false))",
+		),
+		(
+			"create Project empty project-ID scalar subquery",
+			"SELECT * FROM decodex.create_project(
+			 (SELECT value FROM (VALUES(NULL::decodex.canonical_uuid_v4_text)) AS empty(value)
+			  WHERE false),
+			 'hack-ink/null-project','/srv/repos/null-project','/srv/repos/null-project','{}',
+			 '22000000-0000-4000-8000-000000000040'::pg_catalog.text::decodex.canonical_uuid_v4_text)",
+		),
+		(
+			"create Project empty Lead-ID scalar subquery",
+			"SELECT * FROM decodex.create_project(
+			 '11000000-0000-4000-8000-000000000040'::pg_catalog.text::decodex.canonical_uuid_v4_text,
+			 'hack-ink/null-lead','/srv/repos/null-lead','/srv/repos/null-lead','{}',
+			 (SELECT value FROM (VALUES(NULL::decodex.canonical_uuid_v4_text)) AS empty(value)
+			  WHERE false))",
+		),
+		(
+			"transition Project empty project-ID scalar subquery",
+			"SELECT * FROM decodex.transition_project(
+			 (SELECT value FROM (VALUES(NULL::decodex.canonical_uuid_v4_text)) AS empty(value)
+			  WHERE false),1,'paused')",
+		),
+	] {
+		let error = runtime
+			.query(statement, &[])
+			.await
+			.expect_err(&format!("null expression case: {case}; SQL: {statement}"));
+		let database = error.as_db_error().expect("null expression has PostgreSQL detail");
+
+		assert_eq!(
+			database.code(),
+			&tokio_postgres::error::SqlState::CHECK_VIOLATION,
+			"null expression case: {case}; SQL: {statement}"
+		);
+		assert_eq!(
+			database.constraint(),
+			Some("canonical_uuid_v4_text_ingress"),
+			"null expression case: {case}; SQL: {statement}"
+		);
+		assert_eq!(
+			database.message(),
+			"identity ingress requires canonical UUID-v4 text",
+			"null expression case: {case}; SQL: {statement}"
+		);
+	}
+}
+
+async fn assert_identity_ingress_bare_uuid(runtime: &Client) {
+	const SQL: &str = "SELECT * FROM decodex.bootstrap_advisor(
+	 '21000000-0000-4000-8000-000000000040'::pg_catalog.uuid)";
+
+	let error = runtime
+		.query(SQL, &[])
+		.await
+		.expect_err(&format!("bare-UUID expression must not resolve; SQL: {SQL}"));
+
+	assert_eq!(
+		error.as_db_error().map(tokio_postgres::error::DbError::code),
+		Some(&tokio_postgres::error::SqlState::UNDEFINED_FUNCTION),
+		"bare-UUID expression; SQL: {SQL}"
+	);
+}
+
+async fn assert_identity_ingress_explicit_normalization(runtime: &Client) {
+	const SQL: &str = "SET search_path=pg_temp,public;
+	 SELECT * FROM decodex.bootstrap_advisor(
+	 '21000000-0000-4000-8000-000000000040'::pg_catalog.uuid::pg_catalog.text::decodex.canonical_uuid_v4_text)";
+
+	let result = runtime.batch_execute(SQL).await;
+
+	assert!(
+		result.is_ok(),
+		"explicit uuid::text::domain normalization; SQL: {SQL}; result: {result:?}"
+	);
 }
 
 async fn assert_account_idempotency_and_revision(

--- a/scripts/vnext/postgres_store_test.py
+++ b/scripts/vnext/postgres_store_test.py
@@ -17,6 +17,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DATABASE = "decodex_xy1267"
 COLLATION_DATABASE = "decodex_xy1267_tr"
 RESTORE_DATABASE = "decodex_xy1267_restore"
+DEFAULT_ACL_TAMPER_DATABASE = "decodex_xy1315_default_acl_tamper"
+DEFAULT_ACL_RESTORE_DATABASE = "decodex_xy1315_default_acl_restore"
 AUTHORITY_DATABASE = "decodex_xy1307_authority"
 TRIGGER_DATABASE = "decodex_xy1307_trigger_contract"
 FUNCTION_DATABASE = "decodex_xy1307_function_contract"
@@ -25,6 +27,7 @@ TRIGGER_ESCAPE_DATABASE = "decodex_xy1307_trigger_escape"
 EXTENSION_CONTROL_DATABASE = "decodex_xy1307_extension_control"
 HOSTILE_SEARCH_DATABASE = "decodex_xy1307_hostile_search"
 CONSTRAINT_DRIFT_DATABASE = "decodex_xy1307_constraint_drift"
+IDENTITY_CAST_DATABASE = "decodex_xy1315_identity_cast"
 EXTERNAL_CASCADE_DATABASE = "decodex_xy1307_external_cascade"
 LEDGER_TAMPER_DATABASE = "decodex_xy1307_ledger_tamper"
 MISSING_EXTENSION_DATABASE = "decodex_xy1307_missing_extension"
@@ -62,6 +65,68 @@ UNSAFE_ROLES = {
 	"membership-admin": "decodex_unsafe_membership_admin",
 	"superuser": "decodex_unsafe_superuser",
 }
+RUNTIME_EXECUTE_SIGNATURES = (
+	"decodex.is_canonical_media_type(pg_catalog.text)",
+	"decodex.is_history_metadata_projection(pg_catalog.jsonb)",
+	"decodex.normalize_unicode_whitespace(pg_catalog.text)",
+	"decodex.ascii_lower(pg_catalog.text)",
+	"decodex.has_credential_material(pg_catalog.text)",
+	"decodex.has_credential_material(pg_catalog.jsonb)",
+	"decodex.is_meaningful_evidence(pg_catalog.jsonb)",
+	"decodex.rfc3339_utc(pg_catalog.timestamptz)",
+	"decodex.is_valid_operation_duration(pg_catalog.interval)",
+	"decodex.lease_ttl_milliseconds(pg_catalog.interval)",
+	"decodex.try_acquire_lease(pg_catalog.text,pg_catalog.uuid,pg_catalog.interval)",
+	"decodex.renew_lease(pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.interval)",
+	"decodex.release_lease(pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid)",
+	"decodex.prune_history_snapshots()",
+	"decodex.issue_history_cursor(pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int4)",
+	"decodex.bootstrap_advisor(decodex.canonical_uuid_v4_text)",
+	"decodex.create_project(decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text)",
+	"decodex.transition_project(decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.project_status)",
+)
+TRIGGER_ONLY_SIGNATURES = (
+	"decodex.enforce_lease_operation_time()",
+	"decodex.enforce_outbox_operation_time()",
+	"decodex.forbid_mutation_of_activity()",
+	"decodex.enforce_outbox_terminal_retention()",
+	"decodex.forbid_outbox_truncate()",
+	"decodex.enforce_command_receipt_state()",
+	"decodex.acquire_hierarchy_coordinator()",
+	"decodex.canonicalize_created_at()",
+	"decodex.enforce_blob_object_state()",
+	"decodex.enforce_conversation_state()",
+	"decodex.enforce_runtime_session_state()",
+	"decodex.enforce_turn_state()",
+	"decodex.enforce_history_item_state()",
+	"decodex.capture_history_item_version()",
+	"decodex.enforce_artifact_state()",
+	"decodex.enforce_artifact_revision_state()",
+	"decodex.enforce_context_pack_state()",
+	"decodex.enforce_context_pack_source_state()",
+	"decodex.enforce_history_cursor_state()",
+)
+RUNTIME_TYPE_NAMES = (
+	"decodex.account_state",
+	"decodex.outbox_state",
+	"decodex.effect_state",
+	"decodex.conversation_status",
+	"decodex.runtime_session_state",
+	"decodex.turn_role",
+	"decodex.side_effect_state",
+	"decodex.history_item_kind",
+	"decodex.history_item_status",
+	"decodex.turn_status",
+	"decodex.artifact_status",
+	"decodex.context_source_kind",
+	"decodex.transition_kind",
+	"decodex.context_source_disposition",
+	"decodex.command_receipt_state",
+	"decodex.canonical_uuid_v4_text",
+	"decodex.project_status",
+	"decodex.agent_role",
+	"decodex.agent_status",
+)
 
 
 class TestFailure(RuntimeError):
@@ -310,6 +375,10 @@ def run_migration(env: dict[str, str]) -> str:
 
 
 def provision_runtime(database: str, role: str, env: dict[str, str]) -> None:
+	execute_signatures = ", ".join(RUNTIME_EXECUTE_SIGNATURES)
+	trigger_signatures = ", ".join(TRIGGER_ONLY_SIGNATURES)
+	type_names = ", ".join(RUNTIME_TYPE_NAMES)
+
 	psql(
 		database,
 		f"GRANT CONNECT ON DATABASE {database} TO {role}; "
@@ -323,12 +392,14 @@ def provision_runtime(database: str, role: str, env: dict[str, str]) -> None:
 		f"decodex.account_snapshots, decodex.blob_objects, decodex.artifact_revisions, decodex.context_packs, "
 		f"decodex.context_pack_sources, decodex.transition_proposals TO {role}; "
 		f"GRANT SELECT ON TABLE decodex.history_cursors, decodex.history_item_versions TO {role}; "
+		f"GRANT SELECT ON TABLE decodex.projects, decodex.agents TO {role}; "
 		f"GRANT DELETE ON TABLE decodex.blob_objects TO {role}; "
 		f"GRANT SELECT, INSERT ON TABLE decodex.activity TO {role}; "
 		f"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE decodex.outbox TO {role}; "
 		f"GRANT USAGE ON SEQUENCE decodex.activity_sequence_seq, decodex.outbox_id_seq TO {role}; "
-		f"GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA decodex TO {role}; "
-		f"REVOKE ALL ON FUNCTION decodex.capture_history_item_version() FROM {role}",
+		f"GRANT USAGE ON TYPE {type_names} TO {role}; "
+		f"GRANT EXECUTE ON FUNCTION {execute_signatures} TO {role}; "
+		f"REVOKE ALL ON FUNCTION {trigger_signatures} FROM {role}, PUBLIC",
 		env,
 	)
 
@@ -889,7 +960,7 @@ def main() -> int:
 			f"AND (SELECT count(*) FROM pg_catalog.pg_proc AS inventory "
 			f"JOIN pg_catalog.pg_namespace AS inventory_namespace "
 			f"ON inventory_namespace.oid = inventory.pronamespace "
-			f"WHERE inventory_namespace.nspname = 'decodex') = 35",
+			f"WHERE inventory_namespace.nspname = 'decodex') = 39",
 			env,
 		) != "t|t|t|t|t|t|t|t":
 			raise TestFailure("additional privileged-function fixture is vacuous")
@@ -1157,6 +1228,37 @@ def main() -> int:
 			RUNTIME_ROLE,
 		)
 
+		create_database(IDENTITY_CAST_DATABASE, env)
+		set_contract_urls(env, socket_dir, port, IDENTITY_CAST_DATABASE, RUNTIME_ROLE)
+		run_migration(env)
+		provision_runtime(IDENTITY_CAST_DATABASE, RUNTIME_ROLE, env)
+		psql(
+			IDENTITY_CAST_DATABASE,
+			"CREATE FUNCTION public.xy1315_uuid_to_text(pg_catalog.uuid) "
+			"RETURNS pg_catalog.text LANGUAGE sql IMMUTABLE STRICT "
+			"AS 'SELECT $1::pg_catalog.text'; "
+			"CREATE CAST (pg_catalog.uuid AS pg_catalog.text) "
+			"WITH FUNCTION public.xy1315_uuid_to_text(pg_catalog.uuid) AS IMPLICIT",
+			env,
+		)
+		if psql(
+			IDENTITY_CAST_DATABASE,
+			"SELECT count(*) FROM pg_catalog.pg_cast AS conversion "
+			"WHERE conversion.castsource='pg_catalog.uuid'::pg_catalog.regtype "
+			"AND conversion.casttarget='pg_catalog.text'::pg_catalog.regtype "
+			"AND conversion.castcontext='i'",
+			env,
+		) != "1":
+			raise TestFailure("implicit UUID-to-text cast fixture is vacuous")
+		identity_cast_output = run(
+			[
+				"cargo", "nextest", "run", "-p", "decodex-postgres", "--test",
+				"postgres_store", "--run-ignored", "all", "--",
+				"postgres_store_rejects_implicit_uuid_to_text_cast", "--exact",
+			],
+			env,
+		)
+
 		create_database(EXTERNAL_CASCADE_DATABASE, env)
 		set_contract_urls(env, socket_dir, port, EXTERNAL_CASCADE_DATABASE, RUNTIME_ROLE)
 		run_migration(env)
@@ -1236,7 +1338,7 @@ def main() -> int:
 			"SELECT count(*), count(*) FILTER (WHERE name LIKE '%_tampered') "
 			"FROM public.refinery_schema_history",
 			env,
-		) != "4|1":
+		) != "5|1":
 			raise TestFailure("migration-ledger tamper did not preserve the row count")
 
 		create_database(MISSING_EXTENSION_DATABASE, env)
@@ -1382,6 +1484,76 @@ def main() -> int:
 			],
 			env,
 		)
+
+		create_database(DEFAULT_ACL_TAMPER_DATABASE, env)
+		run(
+			[
+				"pg_restore", "--exit-on-error", "-d",
+				DEFAULT_ACL_TAMPER_DATABASE, str(dump_path),
+			],
+			env,
+		)
+		default_acl_tamper_root = work / "decodex-incompatible-schema-default-acl"
+		write_bootstrap_config(
+			default_acl_tamper_root,
+			socket_dir,
+			port,
+			DEFAULT_ACL_TAMPER_DATABASE,
+			MIGRATION_ROLE,
+			RUNTIME_ROLE,
+		)
+		default_acl_live_doctor_output = run_live_doctor_mutation(
+			default_acl_tamper_root,
+			DEFAULT_ACL_TAMPER_DATABASE,
+			f"ALTER DEFAULT PRIVILEGES FOR ROLE {MIGRATION_ROLE} IN SCHEMA decodex "
+			"GRANT EXECUTE ON FUNCTIONS TO PUBLIC",
+			"schema-default-acl",
+			work,
+			env,
+		)
+		default_acl_probe = (
+			"SELECT count(*) "
+			"FROM pg_catalog.pg_default_acl AS default_acl "
+			"JOIN pg_catalog.pg_namespace AS namespace "
+			"ON namespace.oid=default_acl.defaclnamespace "
+			f"WHERE default_acl.defaclrole='{MIGRATION_ROLE}'::pg_catalog.regrole "
+			"AND namespace.nspname='decodex' AND default_acl.defaclobjtype='f' "
+			"AND EXISTS (SELECT 1 FROM pg_catalog.aclexplode(default_acl.defaclacl) "
+			"AS privilege WHERE privilege.grantee=0 "
+			"AND privilege.privilege_type='EXECUTE')"
+		)
+		if psql(DEFAULT_ACL_TAMPER_DATABASE, default_acl_probe, env) != "1":
+			raise TestFailure("schema-scoped PUBLIC default-ACL fixture is vacuous")
+
+		default_acl_dump_path = work / "decodex_xy1315_default_acl.dump"
+		run(
+			[
+				"pg_dump", "-Fc", "-f", str(default_acl_dump_path),
+				DEFAULT_ACL_TAMPER_DATABASE,
+			],
+			env,
+		)
+		create_database(DEFAULT_ACL_RESTORE_DATABASE, env)
+		run(
+			[
+				"pg_restore", "--exit-on-error", "-d",
+				DEFAULT_ACL_RESTORE_DATABASE, str(default_acl_dump_path),
+			],
+			env,
+		)
+		if psql(DEFAULT_ACL_RESTORE_DATABASE, default_acl_probe, env) != "1":
+			raise TestFailure("populated restore lost the schema-scoped PUBLIC default ACL")
+		set_contract_urls(
+			env, socket_dir, port, DEFAULT_ACL_RESTORE_DATABASE, RUNTIME_ROLE
+		)
+		default_acl_restore_output = run(
+			[
+				"cargo", "nextest", "run", "-p", "decodex-postgres", "--test",
+				"postgres_store", "--run-ignored", "all", "--",
+				"postgres_store_rejects_schema_scoped_default_acl_restore", "--exact",
+			],
+			env,
+		)
 		print(migration_output)
 		print(restart_output)
 		print(contract_output)
@@ -1393,9 +1565,12 @@ def main() -> int:
 		print(unsafe_authority_output)
 		print(ledger_live_doctor_output)
 		print(missing_extension_live_doctor_output)
+		print(identity_cast_output)
 		print(incompatible_authority_output)
 		print(hostile_search_output)
 		print(restore_output)
+		print(default_acl_live_doctor_output)
+		print(default_acl_restore_output)
 		return 0
 	finally:
 		stop_error: Exception | None = None

--- a/tests/scripts/test_vnext_architecture.py
+++ b/tests/scripts/test_vnext_architecture.py
@@ -271,6 +271,96 @@ class VnextArchitectureTests(unittest.TestCase):
 
         self.assertEqual({token for token in forbidden if token in source}, set())
 
+    def test_project_and_agent_identity_have_one_canonical_inert_authority(self):
+        core_lib = (ROOT / "crates/decodex-core/src/lib.rs").read_text()
+        project = (ROOT / "crates/decodex-core/src/project.rs").read_text()
+        agent = (ROOT / "crates/decodex-core/src/agent.rs").read_text()
+        postgres = (ROOT / "crates/decodex-postgres/src/project_agents.rs").read_text()
+        migration = (
+            ROOT
+            / "crates/decodex-postgres/migrations/V5__project_agent_authority.sql"
+        ).read_text()
+
+        self.assertIn("ProjectId", core_lib)
+        self.assertIn("AgentId", core_lib)
+        self.assertIn("use decodex_core", postgres)
+        self.assertNotIn("pub struct ProjectId", postgres)
+        self.assertNotIn("pub struct AgentId", postgres)
+        self.assertIn("CREATE TABLE decodex.projects", migration)
+        self.assertIn("CREATE TABLE decodex.agents", migration)
+        self.assertIn("agents_one_global_advisor_idx", migration)
+        self.assertIn("agents_one_lead_per_project_idx", migration)
+        self.assertEqual(
+            postgres.count(
+                "::pg_catalog.text::decodex.canonical_uuid_v4_text"
+            ),
+            4,
+        )
+        self.assertNotIn("::text::decodex.canonical_uuid_v4_text", postgres)
+        self.assertEqual(
+            migration.count("CREATE FUNCTION decodex.bootstrap_advisor("), 1
+        )
+        self.assertEqual(
+            migration.count("CREATE FUNCTION decodex.create_project("), 1
+        )
+        self.assertEqual(
+            migration.count("CREATE FUNCTION decodex.transition_project("), 1
+        )
+
+        production = project.split("#[cfg(test)]", 1)[0] + agent.split("#[cfg(test)]", 1)[0]
+        for placeholder in (
+            "project-placeholder",
+            "lead-placeholder",
+            "agent-placeholder",
+            "00000000-0000-0000-0000-000000000000",
+        ):
+            self.assertNotIn(placeholder, production)
+            self.assertNotIn(placeholder, migration)
+
+    def test_project_and_agent_slice_enables_no_live_behavior(self):
+        live_roots = [
+            ROOT / "crates/decodex-codex/src",
+            ROOT / "crates/decodex-protocol/src",
+            ROOT / "crates/decodex-runtime/src",
+            ROOT / "apps/decodexd/src",
+            ROOT / "apps/decodex-cli/src",
+            ROOT / "apps/decodex-gpui/src",
+        ]
+        source = "\n".join(
+            path.read_text()
+            for root in live_roots
+            for path in sorted(root.rglob("*.rs"))
+        )
+        forbidden = {
+            "bootstrap_advisor",
+            "create_project",
+            "ProjectAuthority",
+            "ProjectRepository",
+            "AgentRepository",
+        }
+
+        self.assertEqual({token for token in forbidden if token in source}, set())
+
+        migration = (
+            ROOT
+            / "crates/decodex-postgres/migrations/V5__project_agent_authority.sql"
+        ).read_text().lower()
+        for live_token in (
+            "prompt",
+            "model",
+            "delegate",
+            "schedule",
+            "wakeup",
+            "message",
+        ):
+            self.assertNotIn(live_token, migration)
+        for conversation_surface in (
+            "create table decodex.conversations",
+            "insert into decodex.conversations",
+            "conversation_id",
+        ):
+            self.assertNotIn(conversation_surface, migration)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implements XY-1315.

- Adds canonical Project and Agent identity/domain authority.
- Persists the authority in PostgreSQL with deterministic readback and concurrency invariants.
- Extends migration and runtime authority attestation, including schema-scoped default ACL tamper rejection.

Validation:
- PostgreSQL 18 clean install, restart, tamper, logical restore, and concurrency harness
- vNext architecture tests
- canonical cargo make check (277 passed, 19 skipped)
- independent acceptance review: APPROVED / NO_BLOCKING_FINDINGS

Linear: XY-1315