### PR TITLE
Implement account-bound Codex exact-ID reconciliation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/decodex-codex/Cargo.toml
+++ b/crates/decodex-codex/Cargo.toml
@@ -16,6 +16,7 @@ decodex-core = { workspace = true }
 serde        = { workspace = true }
 serde_json   = { workspace = true }
 sha2         = { workspace = true }
+zeroize      = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/decodex-codex/src/lib.rs
+++ b/crates/decodex-codex/src/lib.rs
@@ -32,7 +32,14 @@ pub use self::{
 		CollaborationToolStatus, EventDecodeError, NormalizedEvent, NormalizedItemKind, OpaqueId,
 		RunLocalActor, ThreadStatus, TurnStatus, normalize_event,
 	},
-	protocol::{BuildId, ThreadId, ThreadSummary},
+	protocol::{
+		ArchiveReconciliationOutcome, ArchiveUnverifiedReason, BuildId, DecodexThreadSearchTerm,
+		ExactThreadFacts, ExactThreadId, ExactThreadListFilter, ExactThreadListResult,
+		ExactThreadReadResult, LossyThreadHistory, MAX_EXACT_THREAD_ID_BYTES,
+		MAX_EXACT_THREAD_LIST_RESULTS, MAX_THREAD_CWD_BYTES, MAX_THREAD_PROVENANCE_BYTES,
+		MAX_THREAD_SEARCH_TERM_BYTES, MAX_THREAD_TITLE_BYTES, ThreadArchivedFilter,
+		ThreadCreatedAt, ThreadCwd, ThreadId, ThreadProvenance, ThreadSummary, ThreadTitle,
+	},
 	schema::{
 		ACCEPTED_SCHEMA_RECEIPT, REQUIRED_NOTIFICATION_METHODS, REQUIRED_REQUEST_METHODS,
 		SchemaContract, SchemaMarker,

--- a/crates/decodex-codex/src/protocol.rs
+++ b/crates/decodex-codex/src/protocol.rs
@@ -1,7 +1,26 @@
-use serde::Serialize;
+use std::{
+	cmp::Ordering,
+	fmt::{Debug, Formatter},
+};
+
+use serde::{Serialize, Serializer};
 use sha2::{Digest as _, Sha256};
+use zeroize::Zeroizing;
 
 pub(crate) const MAX_APP_SERVER_FRAME_BYTES: usize = 1_024 * 1_024;
+
+/// Maximum UTF-8 bytes in an executable Codex thread identifier.
+pub const MAX_EXACT_THREAD_ID_BYTES: usize = 1_024;
+/// Maximum UTF-8 bytes in a Decodex-owned list search term.
+pub const MAX_THREAD_SEARCH_TERM_BYTES: usize = 512;
+/// Maximum UTF-8 bytes in a Codex thread title.
+pub const MAX_THREAD_TITLE_BYTES: usize = 512;
+/// Maximum UTF-8 bytes in a Codex thread working directory.
+pub const MAX_THREAD_CWD_BYTES: usize = 4 * 1_024;
+/// Maximum UTF-8 bytes in a Codex thread provenance marker.
+pub const MAX_THREAD_PROVENANCE_BYTES: usize = 256;
+/// Maximum number of exact list results accepted from Codex.
+pub const MAX_EXACT_THREAD_LIST_RESULTS: usize = 100;
 
 /// Exact Codex CLI build identity used as capability-cache authority.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
@@ -70,6 +89,277 @@ impl ThreadId {
 	}
 }
 
+/// Exact executable Codex thread identifier.
+///
+/// Unlike [`ThreadId`], this value is never hashed or normalized. It is the only thread
+/// identity in this crate that may be serialized into an exact-ID app-server request.
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct ExactThreadId(ZeroizingText);
+impl ExactThreadId {
+	/// Validate and retain one exact protocol identifier byte-for-byte.
+	pub fn new(value: impl Into<String>) -> Result<Self, &'static str> {
+		let value = ZeroizingText::new(value.into());
+
+		validate_exact_thread_id(value.as_str())?;
+
+		Ok(Self(value))
+	}
+
+	/// Return the exact identifier for an app-server request or equality check.
+	pub fn as_str(&self) -> &str {
+		self.0.as_str()
+	}
+}
+impl Debug for ExactThreadId {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str("ExactThreadId([REDACTED])")
+	}
+}
+
+/// Bounded Decodex-owned provenance/title search term for `thread/list`.
+#[derive(Clone, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct DecodexThreadSearchTerm(String);
+impl DecodexThreadSearchTerm {
+	/// Retain an exact Decodex title marker used to read back an already-owned thread.
+	pub fn new(value: impl Into<String>) -> Result<Self, &'static str> {
+		let value = value.into();
+
+		validate_bounded_text(
+			&value,
+			MAX_THREAD_SEARCH_TERM_BYTES,
+			"Codex thread search term is invalid",
+		)?;
+
+		if !value.starts_with("Decodex ") {
+			return Err("Codex thread search term is not Decodex-owned");
+		}
+
+		Ok(Self(value))
+	}
+
+	/// Return the exact bounded term for `thread/list`.
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+impl Debug for DecodexThreadSearchTerm {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str("DecodexThreadSearchTerm([REDACTED])")
+	}
+}
+
+/// Archived-state predicate for one bounded exact list request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ThreadArchivedFilter {
+	/// Return only non-archived threads.
+	Current,
+	/// Return only archived threads.
+	Archived,
+}
+impl ThreadArchivedFilter {
+	/// App-server boolean representation.
+	pub const fn as_bool(self) -> bool {
+		matches!(self, Self::Archived)
+	}
+}
+
+/// Closed exact-list filter: Decodex provenance/title plus archived state only.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExactThreadListFilter {
+	/// Exact bounded Decodex-owned provenance/title term.
+	pub search_term: DecodexThreadSearchTerm,
+	/// Required archived-state predicate.
+	pub archived: ThreadArchivedFilter,
+}
+
+/// Bounded exact Codex thread title fact.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ThreadTitle(ZeroizingText);
+impl ThreadTitle {
+	#[doc(hidden)]
+	pub fn from_protocol(value: impl Into<String>) -> Result<Self, &'static str> {
+		let value = ZeroizingText::new(value.into());
+
+		validate_bounded_text(
+			value.as_str(),
+			MAX_THREAD_TITLE_BYTES,
+			"Codex thread title is invalid",
+		)?;
+
+		Ok(Self(value))
+	}
+
+	/// Return the exact bounded title.
+	pub fn as_str(&self) -> &str {
+		self.0.as_str()
+	}
+}
+impl Debug for ThreadTitle {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str("ThreadTitle([REDACTED])")
+	}
+}
+
+/// Bounded exact Codex thread working-directory fact.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ThreadCwd(ZeroizingText);
+impl ThreadCwd {
+	#[doc(hidden)]
+	pub fn from_protocol(value: impl Into<String>) -> Result<Self, &'static str> {
+		let value = ZeroizingText::new(value.into());
+
+		validate_bounded_text(value.as_str(), MAX_THREAD_CWD_BYTES, "Codex thread cwd is invalid")?;
+
+		if !value.as_str().starts_with('/') {
+			return Err("Codex thread cwd is not absolute");
+		}
+
+		Ok(Self(value))
+	}
+
+	/// Return the exact bounded working directory.
+	pub fn as_str(&self) -> &str {
+		self.0.as_str()
+	}
+}
+impl Debug for ThreadCwd {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str("ThreadCwd([REDACTED])")
+	}
+}
+
+/// Bounded Decodex thread-source provenance fact.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ThreadProvenance(ZeroizingText);
+impl ThreadProvenance {
+	#[doc(hidden)]
+	pub fn from_protocol(value: impl Into<String>) -> Result<Self, &'static str> {
+		let value = ZeroizingText::new(value.into());
+
+		validate_bounded_text(
+			value.as_str(),
+			MAX_THREAD_PROVENANCE_BYTES,
+			"Codex thread provenance is invalid",
+		)?;
+
+		if !value.as_str().starts_with("decodex.") {
+			return Err("Codex thread provenance is not Decodex-owned");
+		}
+
+		Ok(Self(value))
+	}
+
+	/// Return the exact bounded provenance marker.
+	pub fn as_str(&self) -> &str {
+		self.0.as_str()
+	}
+}
+impl Debug for ThreadProvenance {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str("ThreadProvenance([REDACTED])")
+	}
+}
+
+/// Valid non-negative app-server creation timestamp.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ThreadCreatedAt(i64);
+impl ThreadCreatedAt {
+	#[doc(hidden)]
+	pub const fn from_protocol(value: i64) -> Result<Self, &'static str> {
+		if value < 0 {
+			return Err("Codex thread creation timestamp is invalid");
+		}
+
+		Ok(Self(value))
+	}
+
+	/// Return Unix seconds reported by Codex.
+	pub const fn unix_seconds(self) -> i64 {
+		self.0
+	}
+}
+
+/// Exact bounded facts available from list/read reconciliation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExactThreadFacts {
+	/// Exact executable protocol identity.
+	pub id: ExactThreadId,
+	/// Optional retained Decodex thread-source marker.
+	pub provenance: Option<ThreadProvenance>,
+	/// App-server creation timestamp in Unix seconds.
+	pub created_at: ThreadCreatedAt,
+	/// Optional retained title.
+	pub title: Option<ThreadTitle>,
+	/// Exact bounded working directory.
+	pub cwd: ThreadCwd,
+	/// Current archived fact.
+	pub archived: bool,
+}
+
+/// Bounded exact-list response.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExactThreadListResult {
+	/// Matching exact thread facts, in app-server order.
+	threads: Vec<ExactThreadFacts>,
+}
+impl ExactThreadListResult {
+	#[doc(hidden)]
+	pub fn from_protocol(threads: Vec<ExactThreadFacts>) -> Result<Self, &'static str> {
+		if threads.len() > MAX_EXACT_THREAD_LIST_RESULTS {
+			return Err("Codex exact thread list exceeds the result bound");
+		}
+
+		Ok(Self { threads })
+	}
+
+	/// Return the bounded exact results in app-server order.
+	pub fn threads(&self) -> &[ExactThreadFacts] {
+		&self.threads
+	}
+}
+
+/// Explicit epistemic limit of `thread/read(includeTurns=true)`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LossyThreadHistory {
+	/// Visible turns were requested, but the response is not complete-history or replay authority.
+	IncludeTurnsReadback,
+}
+
+/// Exact readback facts without a replay-authorizing history projection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExactThreadReadResult {
+	/// Exact bounded thread facts.
+	pub facts: ExactThreadFacts,
+	/// Mandatory lossy-history marker.
+	pub history: LossyThreadHistory,
+}
+
+/// Closed reason an archive mutation could not be verified.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ArchiveUnverifiedReason {
+	/// The exact build does not support `thread/archive`.
+	MethodUnsupported,
+	/// The mutation response was ambiguous and exact readback did not confirm the desired state.
+	AmbiguousMutation,
+	/// Exact readback was missing, malformed, mismatched, or contradicted the desired state.
+	ReadbackFailed,
+	/// The immutable account binding changed during reconciliation.
+	AccountBindingChanged,
+}
+
+/// Same-process desired-state archive reconciliation outcome.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ArchiveReconciliationOutcome {
+	/// This call issued archive and exact readback confirmed the archived state.
+	Archived,
+	/// Exact pre-read showed the thread was already archived; no mutation was issued.
+	AlreadyArchived,
+	/// Desired state was not safely confirmed.
+	Unverified(ArchiveUnverifiedReason),
+}
+
 /// Redacted read-only thread-list projection.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ThreadSummary {
@@ -81,6 +371,154 @@ pub struct ThreadSummary {
 	pub parent_thread_id: Option<ThreadId>,
 }
 
+/// Private owned UTF-8 protected by the workspace's established zeroization authority.
+///
+/// The constructor is private and all exposed access remains borrowed. `Zeroizing` owns clearing
+/// the allocation on drop, including independently cloned owners.
+#[derive(Clone, Eq, PartialEq)]
+struct ZeroizingText(Zeroizing<String>);
+impl ZeroizingText {
+	fn new(value: String) -> Self {
+		Self(Zeroizing::new(value))
+	}
+
+	fn as_str(&self) -> &str {
+		self.0.as_str()
+	}
+}
+impl Ord for ZeroizingText {
+	fn cmp(&self, other: &Self) -> Ordering {
+		self.as_str().cmp(other.as_str())
+	}
+}
+impl PartialOrd for ZeroizingText {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
+}
+impl Serialize for ZeroizingText {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serializer.serialize_str(self.as_str())
+	}
+}
+
+fn validate_exact_thread_id(value: &str) -> Result<(), &'static str> {
+	const MESSAGE: &str = "Codex thread ID is invalid";
+
+	validate_bounded_text(value, MAX_EXACT_THREAD_ID_BYTES, MESSAGE)?;
+
+	// The private inbound validator deliberately rejects JSON escape syntax before Serde can create
+	// untracked scratch strings. Close the executable-ID domain at its public constructor so every
+	// accepted ID has the same unescaped JSON representation in requests and readback responses.
+	if value.contains(['"', '\\']) {
+		return Err(MESSAGE);
+	}
+
+	Ok(())
+}
+
+fn validate_bounded_text(
+	value: &str,
+	max_bytes: usize,
+	message: &'static str,
+) -> Result<(), &'static str> {
+	if value.is_empty()
+		|| value.len() > max_bytes
+		|| value.chars().any(|character| character.is_control())
+	{
+		return Err(message);
+	}
+
+	Ok(())
+}
+
 fn hex_digest(bytes: &[u8]) -> String {
 	bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+	use std::cmp::Ordering;
+
+	use crate::protocol::{
+		DecodexThreadSearchTerm, ExactThreadId, MAX_EXACT_THREAD_ID_BYTES, ThreadCwd, ThreadId,
+		ThreadProvenance, ThreadTitle, ZeroizingText,
+	};
+
+	#[test]
+	fn exact_and_observation_identities_are_distinct_and_exact_debug_is_redacted() {
+		let raw = "thread:non-uuid/Case-Sensitive_01";
+		let exact = ExactThreadId::new(raw).unwrap();
+		let observed = ThreadId::from_protocol(raw);
+
+		assert_eq!(exact.as_str(), raw);
+		assert_ne!(observed.as_str(), raw);
+		assert_eq!(serde_json::to_string(&exact).unwrap(), format!("\"{raw}\""));
+		assert_eq!(format!("{exact:?}"), "ExactThreadId([REDACTED])");
+		assert!(!format!("{exact:?}").contains(raw));
+	}
+
+	#[test]
+	fn exact_identifier_validation_is_bounded_without_normalization() {
+		assert!(ExactThreadId::new("").is_err());
+		assert!(ExactThreadId::new("line\nbreak").is_err());
+		assert!(ExactThreadId::new("thread:\u{1b}escape").is_err());
+		assert!(ExactThreadId::new("thread:\"quote").is_err());
+		assert!(ExactThreadId::new(r"thread:\backslash").is_err());
+		assert!(ExactThreadId::new("x".repeat(MAX_EXACT_THREAD_ID_BYTES + 1)).is_err());
+
+		let boundary = "x".repeat(MAX_EXACT_THREAD_ID_BYTES);
+
+		assert_eq!(ExactThreadId::new(boundary.clone()).unwrap().as_str(), boundary);
+
+		let punctuation = "thread:MiXeD-id/._~:@+$,;=[]{}()!%&'*? #";
+		let exact = ExactThreadId::new(punctuation).unwrap();
+
+		assert_eq!(exact.as_str(), punctuation);
+		assert_eq!(serde_json::to_string(&exact).unwrap(), format!("\"{punctuation}\""));
+	}
+
+	#[test]
+	fn exact_fact_text_owners_clone_as_zeroizing_borrowed_values_and_keep_debug_redacted() {
+		let raw = "thread:private-exact-id";
+		let exact = ExactThreadId::new(raw).unwrap();
+		let exact_clone = exact.clone();
+		let title = ThreadTitle::from_protocol("Decodex private title").unwrap();
+		let cwd = ThreadCwd::from_protocol("/tmp/private-repository").unwrap();
+		let provenance = ThreadProvenance::from_protocol("decodex.private").unwrap();
+
+		assert_eq!(exact_clone.as_str(), raw);
+		assert_eq!(exact, exact_clone);
+		assert_eq!(exact.cmp(&exact_clone), Ordering::Equal);
+		assert_eq!(format!("{exact:?}"), "ExactThreadId([REDACTED])");
+		assert!(!format!("{exact:?} {title:?} {cwd:?} {provenance:?}").contains("private"));
+	}
+
+	#[test]
+	fn zeroizing_text_serializes_borrowed_utf8_without_exposing_debug() {
+		let owner = ZeroizingText::new("exact-protocol-text".to_owned());
+
+		assert_eq!(owner.as_str(), "exact-protocol-text");
+		assert_eq!(serde_json::to_string(&owner).unwrap(), "\"exact-protocol-text\"");
+	}
+
+	#[test]
+	fn list_and_read_text_facts_are_bounded_and_redacted() {
+		let search = DecodexThreadSearchTerm::new("Decodex XY-1317 exact marker").unwrap();
+		let title = ThreadTitle::from_protocol("Decodex XY-1317 exact marker").unwrap();
+		let cwd = ThreadCwd::from_protocol("/tmp/private-repository").unwrap();
+		let provenance = ThreadProvenance::from_protocol("decodex.xy1317.fixture").unwrap();
+
+		assert!(DecodexThreadSearchTerm::new("arbitrary global title").is_err());
+		assert_eq!(search.as_str(), "Decodex XY-1317 exact marker");
+		assert_eq!(title.as_str(), search.as_str());
+		assert_eq!(cwd.as_str(), "/tmp/private-repository");
+		assert_eq!(provenance.as_str(), "decodex.xy1317.fixture");
+		assert!(
+			!format!("{search:?} {title:?} {cwd:?} {provenance:?}").contains("private-repository")
+		);
+	}
 }

--- a/crates/decodex-runtime/src/account_launch.rs
+++ b/crates/decodex-runtime/src/account_launch.rs
@@ -13,7 +13,9 @@ use std::{
 };
 
 use crate::account_launch::process::{
-	CredentialVault, ProbeError, QuarantineSlotLease, ReadOnlyProbe, ReadOnlyProbeResult,
+	CredentialVault, ExactThreadReconciler, ExactThreadReconciliation,
+	ExactThreadReconciliationFailure, ExactThreadReconciliationResult, ProbeError,
+	QuarantineSlotLease, ReadOnlyProbe, ReadOnlyProbeResult,
 };
 use decodex_codex::CapabilityCache;
 use decodex_core::AccountId;
@@ -97,6 +99,52 @@ impl ManualAccountLauncher {
 		Ok(ManualAccountLaunchResult { observation, account_revision: expected_revision })
 	}
 
+	/// Execute one exact reconciliation under an explicitly selected ready account.
+	///
+	/// This private composition performs no selection, persistence, turn dispatch, or restart
+	/// replay. PostgreSQL authority is checked before process mechanics and again after bounded
+	/// cleanup.
+	async fn reconcile_bound(
+		&self,
+		request: ManualReconciliationRequest,
+		vault: &dyn CredentialVault,
+		cache: &mut CapabilityCache,
+	) -> Result<ManualReconciliationResult, ManualAccountLaunchError> {
+		let ManualReconciliationRequest { account_id, expected_revision, reconciler, operation } =
+			request;
+
+		if reconciler.account_id() != &account_id {
+			return Err(ManualAccountLaunchError::BindingMismatch);
+		}
+		if !self
+			.store
+			.account_is_ready_at_revision(&account_id, expected_revision)
+			.await
+			.map_err(|_| ManualAccountLaunchError::ProductStateUnavailable)?
+		{
+			return Err(ManualAccountLaunchError::ReadinessRejected);
+		}
+
+		let guard = self
+			.capacity
+			.reserve(account_id.clone(), expected_revision)
+			.map_err(|_| ManualAccountLaunchError::CapacityExhausted)?;
+		let result = reconciler
+			.run_mechanical_with_lifetime_guard(vault, cache, guard, operation)
+			.map_err(ManualAccountLaunchError::Reconciliation)?;
+
+		if !self
+			.store
+			.account_is_ready_at_revision(&account_id, expected_revision)
+			.await
+			.map_err(|_| ManualAccountLaunchError::ProductStateUnavailable)?
+		{
+			return Err(ManualAccountLaunchError::ReadinessRejected);
+		}
+
+		Ok(ManualReconciliationResult { result, account_id, account_revision: expected_revision })
+	}
+
 	#[cfg(test)]
 	fn active_capacity(&self) -> u16 {
 		self.capacity.active()
@@ -124,6 +172,27 @@ impl ManualAccountLaunchRequest {
 	}
 }
 
+/// Exact caller-provided account authority and one closed reconciliation operation.
+struct ManualReconciliationRequest {
+	account_id: AccountId,
+	expected_revision: i64,
+	reconciler: ExactThreadReconciler,
+	operation: ExactThreadReconciliation,
+}
+impl ManualReconciliationRequest {
+	fn new(
+		account_id: AccountId,
+		expected_revision: i64,
+		reconciler: ExactThreadReconciler,
+		operation: ExactThreadReconciliation,
+	) -> Result<Self, ManualAccountLaunchError> {
+		if expected_revision < 1 {
+			return Err(ManualAccountLaunchError::ReadinessRejected);
+		}
+
+		Ok(Self { account_id, expected_revision, reconciler, operation })
+	}
+}
 /// Non-live observation produced only after exact final PostgreSQL revalidation and cleanup.
 struct ManualAccountLaunchResult {
 	observation: ReadOnlyProbeResult,
@@ -151,6 +220,28 @@ impl Debug for ManualAccountLaunchResult {
 	}
 }
 
+/// Non-live reconciliation result released only after exact final account revalidation.
+struct ManualReconciliationResult {
+	result: ExactThreadReconciliationResult,
+	account_id: AccountId,
+	account_revision: i64,
+}
+impl Debug for ManualReconciliationResult {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		let operation = match self.result {
+			ExactThreadReconciliationResult::List(_) => "list",
+			ExactThreadReconciliationResult::Read(_) => "read",
+			ExactThreadReconciliationResult::Archive(_) => "archive",
+		};
+
+		formatter
+			.debug_struct("ManualReconciliationResult")
+			.field("account_id", &self.account_id)
+			.field("account_revision", &self.account_revision)
+			.field("operation", &operation)
+			.finish_non_exhaustive()
+	}
+}
 /// Closed manual launch failure without database, account, credential, or provider text.
 #[derive(Debug)]
 enum ManualAccountLaunchError {
@@ -164,11 +255,14 @@ enum ManualAccountLaunchError {
 	BindingMismatch,
 	/// Bounded process mechanics failed.
 	Probe(ProbeError),
+	/// Exact reconciliation mechanics failed closed.
+	Reconciliation(ExactThreadReconciliationFailure),
 }
 impl Display for ManualAccountLaunchError {
 	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
 		match self {
 			Self::Probe(error) => Display::fmt(error, formatter),
+			Self::Reconciliation(error) => write!(formatter, "{error:?}"),
 			_ => write!(formatter, "{self:?}"),
 		}
 	}

--- a/crates/decodex-runtime/src/account_launch/process.rs
+++ b/crates/decodex-runtime/src/account_launch/process.rs
@@ -2,7 +2,7 @@
 #[cfg(test)] use std::sync::atomic::AtomicU32;
 use std::{
 	cell::UnsafeCell,
-	collections::BTreeMap,
+	collections::{BTreeMap, BTreeSet},
 	env,
 	ffi::{OsStr, OsString},
 	fmt::{Debug, Display, Formatter},
@@ -57,15 +57,18 @@ use {
 use crate::account_launch::{
 	RunnerPermit,
 	protocol::{
-		AccountReadResponse, ClientInfo, InitializeCapabilities, InitializeParams,
-		InitializeResponse, JsonRpcResponse, MAX_APP_SERVER_FRAME_BYTES, ThreadListParams,
+		AccountReadResponse, ClientInfo, ExactThreadListParams, ExactThreadReadParams,
+		InitializeCapabilities, InitializeParams, InitializeResponse, JsonRpcResponse,
+		MAX_APP_SERVER_FRAME_BYTES, ThreadArchiveParams, ThreadArchiveResponse, ThreadListParams,
 		ThreadListResponse, ThreadReadParams, ThreadReadResponse, ThreadSearchParams,
 		ThreadSearchResponse,
 	},
 };
 use decodex_codex::{
-	BuildId, Capability, CapabilityCache, CapabilityProfile, LiveMethodOutcome, MethodObservation,
-	ThreadSummary, UnavailableReason,
+	ArchiveReconciliationOutcome, ArchiveUnverifiedReason, BuildId, Capability, CapabilityCache,
+	CapabilityProfile, ExactThreadFacts, ExactThreadId, ExactThreadListFilter,
+	ExactThreadListResult, ExactThreadReadResult, LiveMethodOutcome, LossyThreadHistory,
+	MAX_EXACT_THREAD_LIST_RESULTS, MethodObservation, ThreadSummary, UnavailableReason,
 	schema::{GeneratedSchemaEvidence, MAX_SCHEMA_FILE_BYTES, SchemaContract, SchemaMarker},
 };
 use decodex_core::AccountId;
@@ -542,6 +545,7 @@ pub(super) struct SupervisedProcess {
 	command: AppServerCommand,
 	expected_account_identity: Option<AccountIdentity>,
 	next_request_id: u64,
+	abandoned_request_ids: BTreeSet<u64>,
 }
 impl SupervisedProcess {
 	#[cfg(test)]
@@ -606,6 +610,7 @@ impl SupervisedProcess {
 			command,
 			expected_account_identity: None,
 			next_request_id: 1,
+			abandoned_request_ids: BTreeSet::new(),
 		})
 	}
 
@@ -642,16 +647,31 @@ impl SupervisedProcess {
 		P: Serialize,
 		R: DeserializeOwned,
 	{
+		self.request_rpc(method.as_str(), params, timeout).map_err(|error| match error {
+			RpcError::Supervision(error) => ProbeError::Supervision(error),
+			RpcError::MethodRejected(code) => ProbeError::MethodRejected { method, code },
+		})
+	}
+
+	fn request_rpc<P, R>(
+		&mut self,
+		method: &'static str,
+		params: &P,
+		timeout: Duration,
+	) -> Result<R, RpcError>
+	where
+		P: Serialize,
+		R: DeserializeOwned,
+	{
 		let request_id = self.next_request_id;
 
-		self.next_request_id += 1;
+		self.next_request_id = self
+			.next_request_id
+			.checked_add(1)
+			.ok_or(RpcError::Supervision(SupervisionError::ProtocolLimitExceeded))?;
 
-		self.write_json(&OutboundRequest {
-			jsonrpc: "2.0",
-			id: request_id,
-			method: method.as_str(),
-			params,
-		})?;
+		self.write_json(&OutboundRequest { jsonrpc: "2.0", id: request_id, method, params })
+			.map_err(rpc_supervision)?;
 
 		let deadline = Instant::now() + timeout;
 
@@ -659,13 +679,17 @@ impl SupervisedProcess {
 			let remaining = deadline.saturating_duration_since(Instant::now());
 
 			if remaining.is_zero() {
-				return Err(ProbeError::Supervision(SupervisionError::ResponseTimeout));
+				self.abandon_request(request_id)?;
+
+				return Err(RpcError::Supervision(SupervisionError::ResponseTimeout));
 			}
 
 			let line = match self.stdout.recv_timeout(remaining) {
 				Ok(line) => line.into_contiguous(),
 				Err(RecvTimeoutError::Timeout) => {
-					return Err(ProbeError::Supervision(SupervisionError::ResponseTimeout));
+					self.abandon_request(request_id)?;
+
+					return Err(RpcError::Supervision(SupervisionError::ResponseTimeout));
 				},
 				Err(RecvTimeoutError::Disconnected) => {
 					let error = if self.protocol_limit_exceeded.load(Ordering::Acquire) {
@@ -674,42 +698,66 @@ impl SupervisedProcess {
 						SupervisionError::ProcessExited
 					};
 
-					return Err(ProbeError::Supervision(error));
+					self.abandon_request(request_id)?;
+
+					return Err(RpcError::Supervision(error));
 				},
 			};
 
 			Self::validate_zero_scratch_json(&line)
-				.map_err(|_| ProbeError::Supervision(SupervisionError::InvalidProtocol))?;
+				.map_err(|()| RpcError::Supervision(SupervisionError::InvalidProtocol))?;
 
 			let header: InboundHeader = serde_json::from_slice(&line)
-				.map_err(|_| ProbeError::Supervision(SupervisionError::InvalidProtocol))?;
+				.map_err(|_| RpcError::Supervision(SupervisionError::InvalidProtocol))?;
 
 			if header.id == Some(request_id) {
 				let response: JsonRpcResponse<R> = serde_json::from_slice(&line)
-					.map_err(|_| ProbeError::Supervision(SupervisionError::InvalidProtocol))?;
+					.map_err(|_| RpcError::Supervision(SupervisionError::InvalidProtocol))?;
 
 				if response.id != request_id {
-					return Err(ProbeError::Supervision(SupervisionError::InvalidProtocol));
+					return Err(RpcError::Supervision(SupervisionError::InvalidProtocol));
+				}
+				if response.jsonrpc.as_str() != "2.0" {
+					return Err(RpcError::Supervision(SupervisionError::InvalidProtocol));
 				}
 
-				if let Some(error) = response.error {
-					return Err(ProbeError::MethodRejected { method, code: error.code });
-				}
-
-				return response
-					.result
-					.ok_or(ProbeError::Supervision(SupervisionError::InvalidProtocol));
+				return match (response.result, response.error) {
+					(Some(result), None) => Ok(result),
+					(None, Some(error)) => Err(RpcError::MethodRejected(error.code)),
+					_ => Err(RpcError::Supervision(SupervisionError::InvalidProtocol)),
+				};
 			}
+
+			if let Some(id) = header.id {
+				if self.abandoned_request_ids.remove(&id) {
+					continue;
+				}
+				if header.method.is_none() {
+					return Err(RpcError::Supervision(SupervisionError::InvalidProtocol));
+				}
+			}
+
 			if header.method.is_some()
 				&& let Some(id) = header.id
 			{
 				self.write_json(&serde_json::json!({
 					"jsonrpc": "2.0",
 					"id": id,
-					"error": {"code": -32_601, "message": "read-only probe does not service requests"}
-				}))?;
+					"error": {"code": -32_601, "message": "account-bound adapter does not service requests"}
+				}))
+				.map_err(rpc_supervision)?;
 			}
 		}
+	}
+
+	fn abandon_request(&mut self, request_id: u64) -> Result<(), RpcError> {
+		if self.abandoned_request_ids.len() >= PROTOCOL_QUEUE_CAPACITY {
+			return Err(RpcError::Supervision(SupervisionError::ProtocolLimitExceeded));
+		}
+
+		self.abandoned_request_ids.insert(request_id);
+
+		Ok(())
 	}
 
 	fn notify<P>(&mut self, method: &str, params: &P) -> Result<(), ProbeError>
@@ -740,6 +788,126 @@ impl SupervisedProcess {
 		self.expected_account_identity = Some(identity.clone());
 
 		Ok(identity)
+	}
+
+	fn list_exact_threads(
+		&mut self,
+		filter: &ExactThreadListFilter,
+		timeout: Duration,
+	) -> Result<ExactThreadListResult, ExactReconciliationError> {
+		self.re_attest_exact_account(timeout)?;
+
+		let response = self
+			.request_rpc::<_, ThreadListResponse>(
+				"thread/list",
+				&ExactThreadListParams {
+					search_term: &filter.search_term,
+					archived: filter.archived.as_bool(),
+					limit: MAX_EXACT_THREAD_LIST_RESULTS as u32,
+				},
+				timeout,
+			)
+			.map_err(ExactReconciliationError::from_rpc)?;
+
+		if response.data.len() > MAX_EXACT_THREAD_LIST_RESULTS {
+			return Err(ExactReconciliationError::InvalidResult);
+		}
+
+		let threads = response
+			.data
+			.iter()
+			.map(ExactThreadFacts::try_from)
+			.collect::<Result<Vec<_>, _>>()
+			.map_err(|_| ExactReconciliationError::InvalidResult)?;
+
+		if threads.iter().any(|thread| {
+			thread.archived != filter.archived.as_bool()
+				|| thread.title.as_ref().map(|title| title.as_str())
+					!= Some(filter.search_term.as_str())
+		}) {
+			return Err(ExactReconciliationError::InvalidResult);
+		}
+
+		self.re_attest_exact_account(timeout)?;
+
+		ExactThreadListResult::from_protocol(threads)
+			.map_err(|_| ExactReconciliationError::InvalidResult)
+	}
+
+	fn read_exact_thread(
+		&mut self,
+		thread_id: &ExactThreadId,
+		timeout: Duration,
+	) -> Result<ExactThreadReadResult, ExactReconciliationError> {
+		self.re_attest_exact_account(timeout)?;
+
+		let response = self
+			.request_rpc::<_, ThreadReadResponse>(
+				"thread/read",
+				&ExactThreadReadParams { thread_id, include_turns: true },
+				timeout,
+			)
+			.map_err(ExactReconciliationError::from_rpc)?;
+		let facts = ExactThreadFacts::try_from(&response.thread)
+			.map_err(|_| ExactReconciliationError::InvalidResult)?;
+
+		if &facts.id != thread_id {
+			return Err(ExactReconciliationError::InvalidResult);
+		}
+
+		self.re_attest_exact_account(timeout)?;
+
+		Ok(ExactThreadReadResult { facts, history: LossyThreadHistory::IncludeTurnsReadback })
+	}
+
+	fn reconcile_archive(
+		&mut self,
+		thread_id: &ExactThreadId,
+		timeout: Duration,
+	) -> ArchiveReconciliationOutcome {
+		let before = match self.read_exact_thread(thread_id, timeout) {
+			Ok(readback) => readback,
+			Err(error) => return error.archive_outcome(),
+		};
+
+		if before.facts.archived {
+			return ArchiveReconciliationOutcome::AlreadyArchived;
+		}
+
+		let mutation = self.request_rpc::<_, ThreadArchiveResponse>(
+			"thread/archive",
+			&ThreadArchiveParams { thread_id },
+			timeout,
+		);
+
+		if matches!(mutation, Err(RpcError::MethodRejected(-32_601))) {
+			return ArchiveReconciliationOutcome::Unverified(
+				ArchiveUnverifiedReason::MethodUnsupported,
+			);
+		}
+
+		let mutation_confirmed = mutation.is_ok();
+
+		match self.read_exact_thread(thread_id, timeout) {
+			Ok(readback) if readback.facts.archived => ArchiveReconciliationOutcome::Archived,
+			Ok(_) if mutation_confirmed =>
+				ArchiveReconciliationOutcome::Unverified(ArchiveUnverifiedReason::ReadbackFailed),
+			Ok(_) =>
+				ArchiveReconciliationOutcome::Unverified(ArchiveUnverifiedReason::AmbiguousMutation),
+			Err(error) => error.archive_outcome(),
+		}
+	}
+
+	fn re_attest_exact_account(
+		&mut self,
+		timeout: Duration,
+	) -> Result<(), ExactReconciliationError> {
+		self.read_account_identity(timeout).map(|_| ()).map_err(|error| match error {
+			ProbeError::Supervision(
+				SupervisionError::AccountChanged | SupervisionError::ShutdownFailed,
+			) => ExactReconciliationError::AccountBindingChanged,
+			_ => ExactReconciliationError::Transport,
+		})
 	}
 
 	fn write_json<T>(&mut self, value: &T) -> Result<(), ProbeError>
@@ -922,6 +1090,167 @@ impl ReadOnlyProbe {
 			account_id,
 			process_id,
 		})
+	}
+}
+
+/// Private account-bound exact reconciliation configuration.
+///
+/// This is deliberately separate from [`ReadOnlyProbe`]: archive is never part of capability-probe
+/// execution, and no public caller can construct or dispatch this owner.
+pub(super) struct ExactThreadReconciler {
+	command: AppServerCommand,
+	binding: AccountBinding,
+	schema_marker: SchemaMarker,
+	enforce_generated_digests: bool,
+	timeout: Duration,
+}
+impl ExactThreadReconciler {
+	pub(super) fn new(
+		command: AppServerCommand,
+		binding: AccountBinding,
+		timeout: Duration,
+	) -> Self {
+		Self {
+			command,
+			binding,
+			schema_marker: SchemaMarker::accepted(),
+			enforce_generated_digests: true,
+			timeout,
+		}
+	}
+
+	pub(super) fn account_id(&self) -> &AccountId {
+		self.binding.account_id()
+	}
+
+	#[cfg(test)]
+	fn fixture(command: AppServerCommand, binding: AccountBinding, timeout: Duration) -> Self {
+		Self {
+			command,
+			binding,
+			schema_marker: SchemaMarker::accepted(),
+			enforce_generated_digests: false,
+			timeout,
+		}
+	}
+
+	pub(super) fn run_mechanical_with_lifetime_guard(
+		self,
+		vault: &dyn CredentialVault,
+		cache: &mut CapabilityCache,
+		guard: RunnerPermit,
+		operation: ExactThreadReconciliation,
+	) -> Result<ExactThreadReconciliationResult, ExactThreadReconciliationFailure> {
+		SchemaContract::validate(self.schema_marker.clone()).map_err(|markers| {
+			ExactThreadReconciliationFailure::Probe(ProbeError::SchemaMissing { markers })
+		})?;
+
+		let expected_digests =
+			self.enforce_generated_digests.then_some(self.schema_marker.canonical_digests());
+		let (build, generated, guard) = attest_executable(
+			&self.command,
+			&self.binding,
+			expected_digests,
+			self.timeout,
+			Some(guard),
+		)
+		.map_err(ExactThreadReconciliationFailure::Probe)?;
+		let required_method = match &operation {
+			ExactThreadReconciliation::List(_) => "thread/list",
+			ExactThreadReconciliation::Read(_) => "thread/read",
+			ExactThreadReconciliation::Archive(_) => "thread/archive",
+		};
+
+		if !generated.contract().advertises_request(required_method) {
+			return match operation {
+				ExactThreadReconciliation::Archive(_) =>
+					Ok(ExactThreadReconciliationResult::Archive(
+						ArchiveReconciliationOutcome::Unverified(
+							ArchiveUnverifiedReason::MethodUnsupported,
+						),
+					)),
+				_ => Err(ExactThreadReconciliationFailure::Operation(
+					ExactReconciliationError::MethodUnsupported,
+				)),
+			};
+		}
+
+		let guard = guard
+			.ok_or(ExactThreadReconciliationFailure::Probe(SupervisionError::SpawnFailed.into()))?;
+		let mut negotiation = ProbeNegotiation::new(cache, &build, &generated);
+		let mut process = SupervisedProcess::spawn_bound(self.command, self.binding, guard)
+			.map_err(|error| ExactThreadReconciliationFailure::Probe(error.into()))?;
+
+		initialize_probe(&mut process, Some(vault), self.timeout, &mut negotiation)
+			.map_err(ExactThreadReconciliationFailure::Probe)?;
+
+		let result = match operation {
+			ExactThreadReconciliation::List(filter) => ExactThreadReconciliationResult::List(
+				process
+					.list_exact_threads(&filter, self.timeout)
+					.map_err(ExactThreadReconciliationFailure::Operation)?,
+			),
+			ExactThreadReconciliation::Read(thread_id) => ExactThreadReconciliationResult::Read(
+				process
+					.read_exact_thread(&thread_id, self.timeout)
+					.map_err(ExactThreadReconciliationFailure::Operation)?,
+			),
+			ExactThreadReconciliation::Archive(thread_id) =>
+				ExactThreadReconciliationResult::Archive(
+					process.reconcile_archive(&thread_id, self.timeout),
+				),
+		};
+
+		process
+			.shutdown(Duration::from_secs(1))
+			.map_err(ExactThreadReconciliationFailure::Shutdown)?;
+
+		Ok(result)
+	}
+}
+
+pub(super) enum ExactThreadReconciliation {
+	List(ExactThreadListFilter),
+	Read(ExactThreadId),
+	Archive(ExactThreadId),
+}
+
+pub(super) enum ExactThreadReconciliationResult {
+	List(ExactThreadListResult),
+	Read(ExactThreadReadResult),
+	Archive(ArchiveReconciliationOutcome),
+}
+
+#[derive(Debug)]
+pub(super) enum ExactThreadReconciliationFailure {
+	Probe(ProbeError),
+	Operation(ExactReconciliationError),
+	Shutdown(SupervisionError),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ExactReconciliationError {
+	Transport,
+	MethodUnsupported,
+	InvalidResult,
+	AccountBindingChanged,
+}
+impl ExactReconciliationError {
+	fn from_rpc(error: RpcError) -> Self {
+		match error {
+			RpcError::MethodRejected(-32_601) => Self::MethodUnsupported,
+			RpcError::MethodRejected(_) | RpcError::Supervision(_) => Self::Transport,
+		}
+	}
+
+	const fn archive_outcome(self) -> ArchiveReconciliationOutcome {
+		let reason = match self {
+			Self::MethodUnsupported => ArchiveUnverifiedReason::MethodUnsupported,
+			Self::AccountBindingChanged => ArchiveUnverifiedReason::AccountBindingChanged,
+			Self::Transport | Self::InvalidResult => ArchiveUnverifiedReason::ReadbackFailed,
+		};
+
+		ArchiveReconciliationOutcome::Unverified(reason)
 	}
 }
 
@@ -1589,6 +1918,12 @@ impl Drop for ProcessQuarantine {
 	}
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum RpcError {
+	Supervision(SupervisionError),
+	MethodRejected(i64),
+}
+
 struct ProcessQuarantineState {
 	slots: Box<[QuarantineSlot]>,
 	ready: Condvar,
@@ -1863,6 +2198,13 @@ impl Write for ZeroizingOutboundFrame {
 
 	fn flush(&mut self) -> io::Result<()> {
 		Ok(())
+	}
+}
+
+fn rpc_supervision(error: ProbeError) -> RpcError {
+	match error {
+		ProbeError::Supervision(error) => RpcError::Supervision(error),
+		_ => RpcError::Supervision(SupervisionError::InvalidProtocol),
 	}
 }
 
@@ -2866,9 +3208,10 @@ mod tests {
 		RunnerCapacity, RunnerPermit,
 		process::{
 			self, AccountBinding, AccountIdentity, AppServerCommand, CredentialProjection,
-			CredentialVault, CredentialVaultError, PROTOCOL_QUEUE_CAPACITY, ProbeError,
-			ProcessQuarantine, ReadOnlyMethod, ReadOnlyProbe, ShutdownOutcome, SupervisedProcess,
-			SupervisionError, UnavailableCredentialVault,
+			CredentialVault, CredentialVaultError, ExactThreadReconciler,
+			ExactThreadReconciliation, ExactThreadReconciliationResult, PROTOCOL_QUEUE_CAPACITY,
+			ProbeError, ProcessQuarantine, ReadOnlyMethod, ReadOnlyProbe, ShutdownOutcome,
+			SupervisedProcess, SupervisionError, UnavailableCredentialVault,
 		},
 		protocol::{
 			self, ClientInfo, InitializeCapabilities, InitializeParams, InitializeResponse,
@@ -2876,8 +3219,9 @@ mod tests {
 		},
 	};
 	use decodex_codex::{
-		Capability, CapabilityCache, CapabilityState, SchemaMarker, UnavailableReason,
-		UnsupportedReason,
+		ArchiveReconciliationOutcome, ArchiveUnverifiedReason, Capability, CapabilityCache,
+		CapabilityState, DecodexThreadSearchTerm, ExactThreadId, ExactThreadListFilter,
+		SchemaMarker, ThreadArchivedFilter, UnavailableReason, UnsupportedReason,
 	};
 	use decodex_core::AccountId;
 
@@ -3358,7 +3702,7 @@ mod tests {
 		.unwrap_err();
 
 		assert_eq!(error, ProbeError::Supervision(SupervisionError::InvalidProtocol));
-		assert_eq!(protocol::sensitive_string_drops(), 3);
+		assert_eq!(protocol::sensitive_string_drops(), 4);
 		assert!(process::ZEROIZED_INBOUND_BLOCKS.load(Ordering::Acquire) > before);
 	}
 
@@ -4681,5 +5025,224 @@ mod tests {
 		process::validate_initialize(&initialize, &process.binding).unwrap();
 
 		process.notify("initialized", &serde_json::json!({})).unwrap();
+	}
+
+	fn exact_filter(archived: ThreadArchivedFilter) -> ExactThreadListFilter {
+		ExactThreadListFilter {
+			search_term: DecodexThreadSearchTerm::new("Decodex XY-1317 exact reconciliation")
+				.unwrap(),
+			archived,
+		}
+	}
+
+	fn exact_thread_id() -> ExactThreadId {
+		ExactThreadId::new("thread:XY-1317/non-uuid_Case-Sensitive._~:@+$,;=[]{}()!%&'*? #")
+			.unwrap()
+	}
+
+	fn initialized_bound_process(mode: &str) -> (TempDir, SupervisedProcess) {
+		let temp = TempDir::new().unwrap();
+		let timeout = Duration::from_secs(2);
+		let mut process =
+			SupervisedProcess::spawn(fake_command(mode, temp.path(), None), binding()).unwrap();
+
+		initialize_test_process(&mut process, timeout);
+
+		let expected = {
+			let vault = FixtureVault::matching();
+			let account_id = process.binding.account_id().clone();
+			let mut projection =
+				CredentialProjection { process: &mut process, timeout, used: false };
+
+			vault.project(&account_id, &mut projection).unwrap()
+		};
+
+		process.expected_account_identity = Some(expected);
+
+		process.read_account_identity(timeout).unwrap();
+
+		(temp, process)
+	}
+
+	#[test]
+	fn exact_non_uuid_identity_round_trips_through_list_read_archive_and_readback() {
+		let (_temp, mut process) = initialized_bound_process("exact");
+		let timeout = Duration::from_secs(2);
+		let exact = exact_thread_id();
+		let listed = process
+			.list_exact_threads(&exact_filter(ThreadArchivedFilter::Current), timeout)
+			.unwrap();
+
+		assert_eq!(listed.threads().len(), 1);
+		assert_eq!(listed.threads()[0].id, exact);
+		assert_eq!(listed.threads()[0].created_at.unix_seconds(), 1_784_073_600);
+		assert_eq!(
+			listed.threads()[0].title.as_ref().unwrap().as_str(),
+			"Decodex XY-1317 exact reconciliation"
+		);
+		assert_eq!(listed.threads()[0].cwd.as_str(), "/tmp/xy-1317-repository");
+		assert_eq!(
+			listed.threads()[0].provenance.as_ref().unwrap().as_str(),
+			"decodex.xy1317.fixture"
+		);
+		assert!(!listed.threads()[0].archived);
+
+		let read = process.read_exact_thread(&exact, timeout).unwrap();
+
+		assert_eq!(read.facts.id, exact);
+		assert_eq!(read.history, decodex_codex::LossyThreadHistory::IncludeTurnsReadback);
+		assert_eq!(
+			process.reconcile_archive(&exact, timeout),
+			ArchiveReconciliationOutcome::Archived
+		);
+		assert_eq!(process.read_exact_thread(&exact, timeout).unwrap().facts.id, exact);
+		assert_eq!(
+			process
+				.list_exact_threads(&exact_filter(ThreadArchivedFilter::Archived), timeout)
+				.unwrap()
+				.threads()[0]
+				.id,
+			exact
+		);
+		assert_eq!(
+			process.reconcile_archive(&exact, timeout),
+			ArchiveReconciliationOutcome::AlreadyArchived
+		);
+	}
+
+	#[test]
+	fn private_reconciliation_owner_runs_under_one_concrete_account_capacity_guard() {
+		let temp = TempDir::new().unwrap();
+		let binding = binding();
+		let account_id = binding.account_id().clone();
+		let capacity = TestCapacity::new(1);
+		let result = ExactThreadReconciler::fixture(
+			fake_command("exact", temp.path(), None),
+			binding,
+			Duration::from_secs(2),
+		)
+		.run_mechanical_with_lifetime_guard(
+			&FixtureVault::matching(),
+			&mut CapabilityCache::default(),
+			capacity.inner.reserve(account_id, 1).unwrap(),
+			ExactThreadReconciliation::List(exact_filter(ThreadArchivedFilter::Current)),
+		)
+		.unwrap();
+		let ExactThreadReconciliationResult::List(list) = result else {
+			panic!("private list operation returned a different closed result variant");
+		};
+
+		assert_eq!(list.threads()[0].id, exact_thread_id());
+		assert_eq!(capacity.active(), 0);
+	}
+
+	#[test]
+	fn abandoned_request_correlation_state_is_hard_bounded() {
+		let (_temp, mut process) = initialized_bound_process("exact");
+
+		for request_id in 1..=PROTOCOL_QUEUE_CAPACITY as u64 {
+			process.abandon_request(request_id).unwrap();
+		}
+
+		assert_eq!(
+			process.abandon_request(PROTOCOL_QUEUE_CAPACITY as u64 + 1),
+			Err(super::RpcError::Supervision(SupervisionError::ProtocolLimitExceeded))
+		);
+	}
+
+	#[test]
+	fn dropped_archive_response_is_resolved_only_by_same_process_exact_readback() {
+		let (_temp, mut process) = initialized_bound_process("exact-drop-after-apply");
+		let exact = exact_thread_id();
+
+		assert_eq!(
+			process.reconcile_archive(&exact, Duration::from_millis(100)),
+			ArchiveReconciliationOutcome::Archived
+		);
+	}
+
+	#[test]
+	fn contradictory_archive_readback_never_reports_success() {
+		let (_temp, mut process) = initialized_bound_process("exact-contradictory-readback");
+		let exact = exact_thread_id();
+
+		assert_eq!(
+			process.reconcile_archive(&exact, Duration::from_secs(2)),
+			ArchiveReconciliationOutcome::Unverified(ArchiveUnverifiedReason::ReadbackFailed)
+		);
+	}
+
+	#[test]
+	fn missing_mismatched_and_still_ambiguous_archive_readback_fail_closed() {
+		let exact = exact_thread_id();
+
+		for (mode, reason) in [
+			("exact-missing-post-archive-read", ArchiveUnverifiedReason::ReadbackFailed),
+			("exact-mismatched-post-archive-read", ArchiveUnverifiedReason::ReadbackFailed),
+			("exact-ambiguous-unapplied", ArchiveUnverifiedReason::AmbiguousMutation),
+		] {
+			let (_temp, mut process) = initialized_bound_process(mode);
+
+			assert_eq!(
+				process.reconcile_archive(&exact, Duration::from_millis(100)),
+				ArchiveReconciliationOutcome::Unverified(reason),
+				"mode {mode} did not fail closed"
+			);
+		}
+	}
+
+	#[test]
+	fn unsupported_archive_is_a_closed_unverified_outcome() {
+		let (_temp, mut process) = initialized_bound_process("exact-unsupported-archive");
+		let exact = exact_thread_id();
+
+		assert_eq!(
+			process.reconcile_archive(&exact, Duration::from_secs(2)),
+			ArchiveReconciliationOutcome::Unverified(ArchiveUnverifiedReason::MethodUnsupported)
+		);
+	}
+
+	#[test]
+	fn exact_list_rejects_malformed_wrong_correlation_and_missing_result() {
+		for mode in ["exact-malformed-list", "exact-wrong-correlation", "exact-missing-result"] {
+			let (_temp, mut process) = initialized_bound_process(mode);
+
+			assert!(
+				process
+					.list_exact_threads(
+						&exact_filter(ThreadArchivedFilter::Current),
+						Duration::from_secs(2),
+					)
+					.is_err(),
+				"mode {mode} unexpectedly succeeded"
+			);
+		}
+	}
+
+	#[test]
+	fn exact_read_rejects_malformed_oversized_and_mismatched_results() {
+		let exact = exact_thread_id();
+
+		for mode in ["exact-malformed-read", "exact-oversized-read", "exact-mismatched-id"] {
+			let (_temp, mut process) = initialized_bound_process(mode);
+
+			assert!(
+				process.read_exact_thread(&exact, Duration::from_millis(500)).is_err(),
+				"mode {mode} unexpectedly succeeded"
+			);
+		}
+	}
+
+	#[test]
+	fn exact_reconciliation_stops_on_account_binding_contradiction() {
+		let (_temp, mut process) = initialized_bound_process("account-switch");
+
+		assert_eq!(
+			process.list_exact_threads(
+				&exact_filter(ThreadArchivedFilter::Current),
+				Duration::from_secs(2),
+			),
+			Err(super::ExactReconciliationError::AccountBindingChanged)
+		);
 	}
 }

--- a/crates/decodex-runtime/src/account_launch/protocol.rs
+++ b/crates/decodex-runtime/src/account_launch/protocol.rs
@@ -6,7 +6,10 @@ use std::{
 use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize as _, Zeroizing};
 
-use decodex_codex::{ThreadId, ThreadSummary};
+use decodex_codex::{
+	DecodexThreadSearchTerm, ExactThreadFacts, ExactThreadId, ThreadCreatedAt, ThreadCwd, ThreadId,
+	ThreadProvenance, ThreadSummary, ThreadTitle,
+};
 
 #[doc(hidden)]
 pub const MAX_APP_SERVER_FRAME_BYTES: usize = 1_024 * 1_024;
@@ -18,6 +21,29 @@ impl From<&ProtocolThread> for ThreadSummary {
 			archived: value.archived,
 			parent_thread_id: value.parent_thread_id.as_deref().map(ThreadId::from_protocol),
 		}
+	}
+}
+
+impl TryFrom<&ProtocolThread> for ExactThreadFacts {
+	type Error = &'static str;
+
+	fn try_from(value: &ProtocolThread) -> Result<Self, Self::Error> {
+		Ok(Self {
+			id: ExactThreadId::new(value.id.as_str())?,
+			provenance: value
+				.thread_source
+				.as_deref()
+				.map(ThreadProvenance::from_protocol)
+				.transpose()?,
+			created_at: ThreadCreatedAt::from_protocol(
+				value.created_at.ok_or("Codex thread creation timestamp is missing")?,
+			)?,
+			title: value.name.as_deref().map(ThreadTitle::from_protocol).transpose()?,
+			cwd: ThreadCwd::from_protocol(
+				value.cwd.as_deref().ok_or("Codex thread cwd is missing")?,
+			)?,
+			archived: value.archived,
+		})
 	}
 }
 
@@ -88,6 +114,14 @@ pub struct ThreadListParams {
 	pub use_state_db_only: bool,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExactThreadListParams<'a> {
+	pub search_term: &'a DecodexThreadSearchTerm,
+	pub archived: bool,
+	pub limit: u32,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadListResponse {
@@ -103,10 +137,27 @@ pub struct ThreadReadParams<'a> {
 	pub include_turns: bool,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExactThreadReadParams<'a> {
+	pub thread_id: &'a ExactThreadId,
+	pub include_turns: bool,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ThreadReadResponse {
 	pub thread: ProtocolThread,
 }
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadArchiveParams<'a> {
+	pub thread_id: &'a ExactThreadId,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ThreadArchiveResponse {}
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -141,9 +192,12 @@ pub struct ProtocolAccount {
 #[serde(rename_all = "camelCase")]
 pub struct ProtocolThread {
 	pub id: SensitiveString,
-	#[serde(default)]
 	pub archived: bool,
 	pub parent_thread_id: Option<SensitiveString>,
+	pub created_at: Option<i64>,
+	pub name: Option<SensitiveString>,
+	pub cwd: Option<SensitiveString>,
+	pub thread_source: Option<SensitiveString>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -153,6 +207,7 @@ pub struct JsonRpcError {
 
 #[derive(Debug, Deserialize)]
 pub struct JsonRpcResponse<T> {
+	pub jsonrpc: SensitiveString,
 	pub id: u64,
 	pub result: Option<T>,
 	pub error: Option<JsonRpcError>,
@@ -195,10 +250,10 @@ mod sensitive_string_test_counter {
 #[cfg(test)]
 mod tests {
 	use crate::account_launch::protocol::{
-		AccountReadResponse, InitializeResponse, JsonRpcResponse, ThreadListResponse,
-		ThreadReadResponse,
+		AccountReadResponse, ExactThreadReadParams, InitializeResponse, JsonRpcResponse,
+		ThreadArchiveParams, ThreadListResponse, ThreadReadResponse,
 	};
-	use decodex_codex::BuildId;
+	use decodex_codex::{BuildId, ExactThreadFacts, ExactThreadId};
 
 	#[test]
 	fn build_identity_is_opaque_and_never_exports_credential_shaped_output() {
@@ -225,6 +280,41 @@ mod tests {
 		let second = BuildId::from_attestation("codex-cli 1", &[2; 32]).unwrap();
 
 		assert_ne!(first, second);
+	}
+
+	#[test]
+	fn exact_id_request_params_preserve_every_supported_punctuation_byte() {
+		let raw = "thread:XY-1317/non-uuid_Case-Sensitive._~:@+$,;=[]{}()!%&'*? #";
+		let exact = ExactThreadId::new(raw).unwrap();
+		let read =
+			serde_json::to_value(ExactThreadReadParams { thread_id: &exact, include_turns: true })
+				.unwrap();
+		let archive = serde_json::to_value(ThreadArchiveParams { thread_id: &exact }).unwrap();
+
+		assert_eq!(read["threadId"], raw);
+		assert_eq!(read["includeTurns"], true);
+		assert_eq!(archive["threadId"], raw);
+		assert!(!serde_json::to_string(&read).unwrap().contains("\\\\"));
+	}
+
+	#[test]
+	fn exact_fact_conversion_retains_zeroizing_redacted_owned_text() {
+		super::reset_sensitive_string_drops();
+
+		let response: ThreadReadResponse = serde_json::from_slice(
+			br#"{"thread":{"id":"thread:private-id","archived":false,"parentThreadId":null,"createdAt":1784073600,"name":"Decodex private title","cwd":"/tmp/private-repository","threadSource":"decodex.private"}}"#,
+		)
+		.unwrap();
+		let facts = ExactThreadFacts::try_from(&response.thread).unwrap();
+
+		drop(response);
+
+		assert_eq!(super::sensitive_string_drops(), 4);
+		assert_eq!(facts.id.as_str(), "thread:private-id");
+		assert_eq!(facts.title.as_ref().unwrap().as_str(), "Decodex private title");
+		assert_eq!(facts.cwd.as_str(), "/tmp/private-repository");
+		assert_eq!(facts.provenance.as_ref().unwrap().as_str(), "decodex.private");
+		assert!(!format!("{facts:?}").contains("private"));
 	}
 
 	#[test]
@@ -267,10 +357,10 @@ mod tests {
 	fn completed_thread_read_fields_zeroize_when_json_rpc_tail_fails() {
 		super::reset_sensitive_string_drops();
 
-		let json = br#"{"id":7,"result":{"thread":{"id":"thread\u002did","archived":false,"parentThreadId":"parent\u002did"}},"error":"wrong"}"#;
+		let json = br#"{"jsonrpc":"2.0","id":7,"result":{"thread":{"id":"thread\u002did","archived":false,"parentThreadId":"parent\u002did"}},"error":"wrong"}"#;
 
 		assert!(serde_json::from_slice::<JsonRpcResponse<ThreadReadResponse>>(json).is_err());
-		assert_eq!(super::sensitive_string_drops(), 2);
+		assert_eq!(super::sensitive_string_drops(), 3);
 	}
 
 	#[test]

--- a/crates/decodex-runtime/tests/fixtures/fake_app_server.py
+++ b/crates/decodex-runtime/tests/fixtures/fake_app_server.py
@@ -151,6 +151,17 @@ if mode == "crash":
     raise SystemExit(17)
 
 account_reads = 0
+exact_thread_id = "thread:XY-1317/non-uuid_Case-Sensitive._~:@+$,;=[]{}()!%&'*? #"
+exact_thread = {
+    "id": exact_thread_id,
+    "archived": False,
+    "parentThreadId": None,
+    "createdAt": 1784073600,
+    "name": "Decodex XY-1317 exact reconciliation",
+    "cwd": "/tmp/xy-1317-repository",
+    "threadSource": "decodex.xy1317.fixture",
+}
+exact_thread_reads = 0
 for line in sys.stdin:
     message = json.loads(line)
     if mode == "hang":
@@ -203,21 +214,56 @@ for line in sys.stdin:
             else {}
         )
     elif method == "thread/list":
-        assert message["params"]["useStateDbOnly"] is True
-        count = 101 if mode == "oversized-thread-list" else 1
-        result = {
-            "data": [{"id": f"00000000-0000-4000-8000-{index:012d}", "archived": False, "parentThreadId": None} for index in range(1, count + 1)],
-            "nextCursor": None,
-        }
-    elif method == "thread/read" and mode != "optional-unsupported":
-        assert message["params"]["includeTurns"] is False
-        result = {
-            "thread": {
-                "id": message["params"]["threadId"],
-                "archived": False,
-                "parentThreadId": None,
+        if "searchTerm" in message["params"]:
+            assert set(message["params"]) == {"archived", "limit", "searchTerm"}
+            assert message["params"]["searchTerm"] == exact_thread["name"]
+            assert message["params"]["limit"] <= 100
+            matches_archive = message["params"]["archived"] == exact_thread["archived"]
+            data = [dict(exact_thread)] if matches_archive else []
+            if mode == "exact-malformed-list":
+                data = [{**exact_thread, "createdAt": "not-a-timestamp"}]
+            result = {"data": data, "nextCursor": None}
+        else:
+            assert message["params"]["useStateDbOnly"] is True
+            count = 101 if mode == "oversized-thread-list" else 1
+            result = {
+                "data": [{"id": f"00000000-0000-4000-8000-{index:012d}", "archived": False, "parentThreadId": None} for index in range(1, count + 1)],
+                "nextCursor": None,
             }
-        }
+    elif method == "thread/read" and mode != "optional-unsupported":
+        if message["params"]["includeTurns"]:
+            exact_thread_reads += 1
+            if mode == "exact-missing-post-archive-read" and exact_thread_reads > 1:
+                print(json.dumps({"jsonrpc": "2.0", "id": message["id"]}), flush=True)
+                continue
+            if mode == "exact-oversized-read":
+                sys.stdout.write("{" + ("x" * (1024 * 1024 + 1)))
+                sys.stdout.flush()
+                time.sleep(60)
+            readback = dict(exact_thread)
+            if mode == "exact-mismatched-id" or (mode == "exact-mismatched-post-archive-read" and exact_thread_reads > 1):
+                readback["id"] = "thread:different"
+            if mode == "exact-malformed-read":
+                readback["cwd"] = {"not": "text"}
+            result = {"thread": readback}
+        else:
+            result = {
+                "thread": {
+                    "id": message["params"]["threadId"],
+                    "archived": False,
+                    "parentThreadId": None,
+                }
+            }
+    elif method == "thread/archive":
+        assert message["params"] == {"threadId": exact_thread_id}
+        if mode == "exact-unsupported-archive":
+            print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "error": {"code": -32601, "message": "unsupported"}}), flush=True)
+            continue
+        if mode not in ("exact-ambiguous-unapplied", "exact-contradictory-readback"):
+            exact_thread["archived"] = True
+        if mode in ("exact-ambiguous-unapplied", "exact-drop-after-apply"):
+            continue
+        result = {}
     elif method == "thread/search" and mode != "optional-unsupported":
         assert message["params"]["limit"] <= 10
         assert message["params"]["searchTerm"].startswith("decodex-capability-probe-")
@@ -227,4 +273,9 @@ for line in sys.stdin:
     else:
         print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "error": {"code": -32601, "message": "unsupported"}}), flush=True)
         continue
-    print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}), flush=True)
+    if mode == "exact-wrong-correlation" and method == "thread/list" and "searchTerm" in message["params"]:
+        print(json.dumps({"jsonrpc": "2.0", "id": message["id"] + 1, "result": result}), flush=True)
+    elif mode == "exact-missing-result" and method == "thread/list" and "searchTerm" in message["params"]:
+        print(json.dumps({"jsonrpc": "2.0", "id": message["id"]}), flush=True)
+    else:
+        print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}), flush=True)


### PR DESCRIPTION
Implements XY-1317.\n\n- Adds bounded exact Codex thread identity and typed list/read/archive reconciliation.\n- Keeps exact executable IDs separate from redacted observation identity.\n- Adds account-bound request correlation, bounded transport, ambiguous-mutation readback, and deterministic fixture coverage.\n- Adds the existing workspace zeroize edge for owned exact-thread facts without version or transitive drift.\n\nValidation:\n- decodex-codex 34/34\n- focused runtime reconciliation, archive/readback, correlation, cleanup, and account-isolation suites\n- vNext architecture 13/13, formatting, strict clippy, read-only vstyle, and diff hygiene\n- canonical cargo make check (294 passed, 19 skipped)\n- independent acceptance review: APPROVED / NO_BLOCKING_FINDINGS\n\nLinear: XY-1317