### PR TITLE
Compose the GPUI client lifecycle and connection state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/apps/decodex-gpui/Cargo.toml
+++ b/apps/decodex-gpui/Cargo.toml
@@ -13,6 +13,7 @@ decodex-protocol = { workspace = true }
 serde            = { workspace = true }
 serde_json       = { workspace = true }
 sha2             = { workspace = true }
+tokio             = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/apps/decodex-gpui/src/client_lifecycle.rs
+++ b/apps/decodex-gpui/src/client_lifecycle.rs
@@ -1,0 +1,910 @@
+//! Private bounded composition of the retained session and disposable client cache.
+
+use std::{
+	collections::{HashMap, HashSet},
+	path::{Path, PathBuf},
+	sync::{
+		Arc,
+		atomic::{AtomicBool, Ordering},
+	},
+	time::Duration,
+};
+
+use tokio::sync::Notify;
+
+use decodex_protocol::{
+	ApplicationConfirmation, CURRENT_VERSION, Cursor, EntityId, EntityRevision, EventEnvelope,
+	RetainedSession, RetainedSessionConfig, RetainedSessionFailure, ServerId, SessionCancellation,
+	SessionCheckpoint, SessionDelivery, SnapshotEnvelope, SnapshotItem,
+};
+
+use crate::client_cache::{
+	CacheAuthority, CacheError, CacheLimits, ClientCache, GenerationInspection, ObjectCertainty,
+	ObjectInput,
+};
+
+const RETRY_DELAYS: [Duration; 4] = [
+	Duration::from_millis(100),
+	Duration::from_millis(250),
+	Duration::from_millis(500),
+	Duration::from_secs(1),
+];
+const MAX_CONNECTION_ATTEMPTS: u8 = 5;
+
+/// State rendered by the later shell without exposing transport or cache internals.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ConnectionView {
+	/// One caller-owned connection attempt is in progress.
+	Connecting { attempt: u8 },
+	/// A verified retained session is online.
+	Online { generation: u64, applied: Option<Cursor> },
+	/// A transient failure is waiting for its deterministic retry.
+	OfflineRetrying { next_attempt: u8, delay: Duration },
+	/// Protocol compatibility is closed until client or server replacement.
+	Incompatible(CompatibilityReason),
+	/// Data or identity is isolated under an explicit recovery lifetime.
+	Quarantined { reason: QuarantineReason, recovery: QuarantineRecovery },
+	/// Cooperative terminal shutdown is closing the owned session.
+	ShuttingDown,
+	/// No connection attempt or retained session remains owned.
+	Stopped,
+}
+
+/// Closed compatibility states that deterministic retry cannot repair.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CompatibilityReason {
+	InvalidEndpoint,
+	ProtocolMajor,
+	ProtocolMinor,
+	PublicationIdentityUnavailable,
+}
+
+/// Why checkpoint and cache reuse lost authority.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum QuarantineReason {
+	StableServerIdentity,
+	AuthorityChanged,
+	PublicationInstanceChanged,
+	CheckpointMismatch,
+	CacheCorrupt,
+	CacheRootUnsafe,
+	ContentAttestation,
+	ApplicationOrder,
+	ApplicationConfirmation,
+	StaleConnectionGeneration,
+}
+
+/// Exact lifetime and replacement rule for quarantined material.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum QuarantineRecovery {
+	/// Keep the old immutable generation for inspection, but never reuse its checkpoint.
+	VerifiedSnapshotReplacement,
+	/// The complete disposable cache was removed before an empty rebuild.
+	DisposedBeforeRebuild,
+	/// The filesystem root or stable identity is unsafe and requires operator replacement.
+	OperatorRequired,
+}
+
+/// Terminal result of the caller-owned lifecycle future.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RunResult {
+	Stopped,
+	RetryExhausted,
+	Incompatible,
+	Quarantined,
+}
+
+/// Construction failures that occur before any connection attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LifecycleBuildError {
+	Session(RetainedSessionFailure),
+	Cache(CacheError),
+}
+
+/// Cloneable cooperative shutdown handle for the one caller-owned run future.
+#[derive(Clone, Debug)]
+pub(crate) struct LifecycleCancellation {
+	inner: Arc<CancellationInner>,
+}
+
+#[derive(Debug)]
+struct CancellationInner {
+	cancelled: AtomicBool,
+	notify: Notify,
+	session: SessionCancellation,
+}
+
+impl LifecycleCancellation {
+	fn new() -> Self {
+		Self {
+			inner: Arc::new(CancellationInner {
+				cancelled: AtomicBool::new(false),
+				notify: Notify::new(),
+				session: SessionCancellation::new(),
+			}),
+		}
+	}
+
+	/// Request terminal shutdown during connect, receive, or backoff.
+	pub(crate) fn cancel(&self) {
+		if !self.inner.cancelled.swap(true, Ordering::AcqRel) {
+			self.inner.session.cancel();
+			self.inner.notify.notify_waiters();
+		}
+	}
+
+	fn is_cancelled(&self) -> bool {
+		self.inner.cancelled.load(Ordering::Acquire)
+	}
+
+	fn session(&self) -> SessionCancellation {
+		self.inner.session.clone()
+	}
+
+	async fn cancelled(&self) {
+		loop {
+			let notified = self.inner.notify.notified();
+
+			if self.is_cancelled() {
+				return;
+			}
+
+			notified.await;
+		}
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AppliedEntity {
+	entity_id: EntityId,
+	revision: EntityRevision,
+	bytes: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CacheBinding {
+	checkpoint: SessionCheckpoint,
+	generation: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Quarantine {
+	reason: QuarantineReason,
+	recovery: QuarantineRecovery,
+}
+
+struct CachedFact {
+	entity_id: EntityId,
+	revision: EntityRevision,
+	bytes: Vec<u8>,
+}
+
+enum Delivery<C> {
+	Snapshot { snapshot: SnapshotEnvelope, confirmation: C },
+	Event { event: EventEnvelope, confirmation: C },
+	Other,
+}
+
+/// The single private seam around retained-session operations and retry time.
+trait LifecycleIo {
+	type Confirmation;
+
+	async fn connect(
+		&mut self,
+		config: &RetainedSessionConfig,
+		checkpoint: Option<SessionCheckpoint>,
+		cancellation: &LifecycleCancellation,
+	) -> Result<Option<SessionCheckpoint>, RetainedSessionFailure>;
+	async fn next(&mut self) -> Result<Delivery<Self::Confirmation>, RetainedSessionFailure>;
+	fn confirm_applied(
+		&mut self,
+		confirmation: Self::Confirmation,
+	) -> Result<SessionCheckpoint, RetainedSessionFailure>;
+	async fn close(&mut self) -> Result<(), RetainedSessionFailure>;
+
+	async fn backoff(
+		&mut self,
+		delay: Duration,
+		cancellation: &LifecycleCancellation,
+	) -> Result<(), RetainedSessionFailure>;
+}
+
+struct TokioIo {
+	session: Option<RetainedSession>,
+}
+
+impl LifecycleIo for TokioIo {
+	type Confirmation = ApplicationConfirmation;
+
+	async fn connect(
+		&mut self,
+		config: &RetainedSessionConfig,
+		checkpoint: Option<SessionCheckpoint>,
+		cancellation: &LifecycleCancellation,
+	) -> Result<Option<SessionCheckpoint>, RetainedSessionFailure> {
+		let session =
+			RetainedSession::connect(config.clone(), checkpoint, cancellation.session()).await?;
+		let checkpoint = session.checkpoint().cloned();
+
+		self.session = Some(session);
+
+		Ok(checkpoint)
+	}
+
+	async fn next(&mut self) -> Result<Delivery<Self::Confirmation>, RetainedSessionFailure> {
+		match self.session.as_mut().ok_or(RetainedSessionFailure::Closed)?.next().await? {
+			SessionDelivery::Snapshot { snapshot, confirmation } => {
+				Ok(Delivery::Snapshot { snapshot, confirmation })
+			},
+			SessionDelivery::Event { event, confirmation } => {
+				Ok(Delivery::Event { event, confirmation })
+			},
+			SessionDelivery::CommandReceipt(_)
+			| SessionDelivery::CommandResult(_)
+			| SessionDelivery::QueryResult(_) => Ok(Delivery::Other),
+		}
+	}
+
+	fn confirm_applied(
+		&mut self,
+		confirmation: Self::Confirmation,
+	) -> Result<SessionCheckpoint, RetainedSessionFailure> {
+		self.session
+			.as_mut()
+			.ok_or(RetainedSessionFailure::Closed)?
+			.confirm_applied(confirmation)
+			.cloned()
+	}
+
+	async fn close(&mut self) -> Result<(), RetainedSessionFailure> {
+		let Some(session) = self.session.take() else {
+			return Ok(());
+		};
+
+		session.close().await
+	}
+
+	async fn backoff(
+		&mut self,
+		delay: Duration,
+		cancellation: &LifecycleCancellation,
+	) -> Result<(), RetainedSessionFailure> {
+		tokio::select! {
+			() = tokio::time::sleep(delay) => Ok(()),
+			() = cancellation.cancelled() => Err(RetainedSessionFailure::Cancelled),
+		}
+	}
+}
+
+/// Private lifecycle owner. The disabled composition root does not construct it yet.
+pub(crate) struct ClientLifecycle {
+	config: RetainedSessionConfig,
+	server_id: ServerId,
+	cache_root: PathBuf,
+	cache_limits: CacheLimits,
+	cache_authority: CacheAuthority,
+	cache: Option<ClientCache>,
+	state: HashMap<String, AppliedEntity>,
+	last_cursor: Option<Cursor>,
+	binding: Option<CacheBinding>,
+	quarantine: Option<Quarantine>,
+	connection_generation: u64,
+	view: ConnectionView,
+	cancellation: LifecycleCancellation,
+}
+
+impl ClientLifecycle {
+	/// Bind the lifecycle to one exact stable server, protocol/schema generation, and cache root.
+	pub(crate) fn new(
+		endpoint: impl AsRef<str>,
+		server_id: ServerId,
+		cache_root: impl Into<PathBuf>,
+		cache_limits: CacheLimits,
+		schema_generation: u64,
+	) -> Result<Self, LifecycleBuildError> {
+		let config = RetainedSessionConfig::new(endpoint, server_id.clone())
+			.map_err(LifecycleBuildError::Session)?;
+		let cache_authority = CacheAuthority::new(&server_id, CURRENT_VERSION, schema_generation)
+			.map_err(LifecycleBuildError::Cache)?;
+		let cache_root = cache_root.into();
+		let (cache, quarantine) =
+			initialize_cache(&cache_root, cache_limits, cache_authority.clone());
+		let view = quarantine.map_or(ConnectionView::Stopped, |quarantine| {
+			ConnectionView::Quarantined { reason: quarantine.reason, recovery: quarantine.recovery }
+		});
+
+		Ok(Self {
+			config,
+			server_id,
+			cache_root,
+			cache_limits,
+			cache_authority,
+			cache,
+			state: HashMap::new(),
+			last_cursor: None,
+			binding: None,
+			quarantine,
+			connection_generation: 0,
+			view,
+			cancellation: LifecycleCancellation::new(),
+		})
+	}
+
+	/// Current narrow shell-facing state.
+	pub(crate) const fn view(&self) -> ConnectionView {
+		self.view
+	}
+
+	/// Cooperative handle that can terminate the caller-owned run future.
+	pub(crate) fn cancellation(&self) -> LifecycleCancellation {
+		self.cancellation.clone()
+	}
+
+	/// Run the bounded lifecycle without spawning or detaching any work.
+	pub(crate) async fn run(&mut self) -> RunResult {
+		self.run_with_io(&mut TokioIo { session: None }).await
+	}
+
+	async fn run_with_io<I>(&mut self, io: &mut I) -> RunResult
+	where
+		I: LifecycleIo,
+	{
+		if self.cache.is_none() {
+			return RunResult::Quarantined;
+		}
+		if self.cancellation.is_cancelled() {
+			return self.finish_shutdown().await;
+		}
+
+		for attempt in 1..=MAX_CONNECTION_ATTEMPTS {
+			let generation = match self.begin_attempt(attempt) {
+				Ok(generation) => generation,
+				Err(()) => return RunResult::Quarantined,
+			};
+			let checkpoint = self.reusable_checkpoint();
+			let requested_checkpoint = checkpoint.clone();
+			let connected_checkpoint =
+				io.connect(&self.config, checkpoint, &self.cancellation).await;
+
+			if self.ensure_generation(generation).is_err() {
+				return RunResult::Quarantined;
+			}
+
+			let connected_checkpoint = match connected_checkpoint {
+				Ok(checkpoint) => checkpoint,
+				Err(failure) => {
+					if let Some(result) = self.closed_failure(failure) {
+						return result;
+					}
+
+					if !self.retry(io, attempt, generation).await {
+						return self.retry_terminal(attempt);
+					}
+
+					continue;
+				},
+			};
+
+			self.connection_established(
+				generation,
+				requested_checkpoint.is_some(),
+				connected_checkpoint.as_ref(),
+			);
+			let mut requires_snapshot = connected_checkpoint.is_none();
+
+			let failure = loop {
+				let delivery = io.next().await;
+
+				if self.ensure_generation(generation).is_err() {
+					break RetainedSessionFailure::PublicationOrder;
+				}
+
+				match delivery {
+					Ok(Delivery::Snapshot { snapshot, confirmation }) => {
+						let cursor = snapshot.cursor;
+						let inspection = match self.apply_snapshot(generation, snapshot) {
+							Ok(inspection) => inspection,
+							Err(failure) => break failure,
+						};
+						let checkpoint = match io.confirm_applied(confirmation) {
+							Ok(checkpoint) => checkpoint,
+							Err(_) => break self.confirmation_failure(),
+						};
+
+						if self.bind_checkpoint(generation, cursor, checkpoint, inspection).is_err()
+						{
+							break RetainedSessionFailure::ApplicationConfirmationMismatch;
+						}
+						requires_snapshot = false;
+					},
+					Ok(Delivery::Event { event, confirmation }) => {
+						if requires_snapshot {
+							self.enter_quarantine(
+								QuarantineReason::ApplicationOrder,
+								QuarantineRecovery::VerifiedSnapshotReplacement,
+							);
+
+							break RetainedSessionFailure::PublicationOrder;
+						}
+						let cursor = event.cursor;
+						let inspection = match self.apply_event(generation, event) {
+							Ok(inspection) => inspection,
+							Err(failure) => break failure,
+						};
+						let checkpoint = match io.confirm_applied(confirmation) {
+							Ok(checkpoint) => checkpoint,
+							Err(_) => break self.confirmation_failure(),
+						};
+
+						if self.bind_checkpoint(generation, cursor, checkpoint, inspection).is_err()
+						{
+							break RetainedSessionFailure::ApplicationConfirmationMismatch;
+						}
+					},
+					Ok(Delivery::Other) => {},
+					Err(failure) => break failure,
+				}
+			};
+
+			if self.quarantine.is_none() {
+				self.view = ConnectionView::ShuttingDown;
+			}
+			let _ = io.close().await;
+
+			if self.ensure_generation(generation).is_err() {
+				return RunResult::Quarantined;
+			}
+			if let Some(result) = self.closed_failure(failure) {
+				return result;
+			}
+			if !self.retry(io, attempt, generation).await {
+				return self.retry_terminal(attempt);
+			}
+		}
+
+		if self.quarantine.is_some() {
+			RunResult::Quarantined
+		} else {
+			self.view = ConnectionView::Stopped;
+
+			RunResult::RetryExhausted
+		}
+	}
+
+	fn begin_attempt(&mut self, attempt: u8) -> Result<u64, ()> {
+		self.connection_generation =
+			self.connection_generation.checked_add(1).ok_or_else(|| {
+				self.enter_quarantine(
+					QuarantineReason::StaleConnectionGeneration,
+					QuarantineRecovery::OperatorRequired,
+				);
+			})?;
+		if self.quarantine.is_none() {
+			self.view = ConnectionView::Connecting { attempt };
+		}
+
+		Ok(self.connection_generation)
+	}
+
+	fn connection_established(
+		&mut self,
+		generation: u64,
+		requested_checkpoint: bool,
+		connected_checkpoint: Option<&SessionCheckpoint>,
+	) {
+		if requested_checkpoint && connected_checkpoint.is_none() {
+			self.enter_quarantine(
+				QuarantineReason::PublicationInstanceChanged,
+				QuarantineRecovery::VerifiedSnapshotReplacement,
+			);
+		}
+		if self.quarantine.is_none() {
+			self.view = ConnectionView::Online {
+				generation,
+				applied: connected_checkpoint.map(SessionCheckpoint::cursor),
+			};
+		}
+	}
+
+	fn reusable_checkpoint(&mut self) -> Option<SessionCheckpoint> {
+		let binding = self.binding.clone()?;
+		let inspection = self.cache.as_ref()?.inspect_current();
+
+		match inspection {
+			Ok(Some(inspection))
+				if inspection.generation == binding.generation
+					&& inspection.authority == self.cache_authority =>
+			{
+				Some(binding.checkpoint)
+			},
+			_ => {
+				self.enter_quarantine(
+					QuarantineReason::ContentAttestation,
+					QuarantineRecovery::VerifiedSnapshotReplacement,
+				);
+
+				None
+			},
+		}
+	}
+
+	fn apply_snapshot(
+		&mut self,
+		generation: u64,
+		snapshot: SnapshotEnvelope,
+	) -> Result<GenerationInspection, RetainedSessionFailure> {
+		self.ensure_generation(generation)?;
+		if snapshot.version != CURRENT_VERSION || snapshot.server_id != self.server_id {
+			return self.application_failure(QuarantineReason::ApplicationOrder);
+		}
+
+		let mut seen = HashSet::new();
+		let mut next_state = HashMap::new();
+		let mut facts = Vec::with_capacity(snapshot.items.len());
+
+		for item in snapshot.items {
+			let (entity_id, revision) = snapshot_identity(&item);
+			if !seen.insert(entity_id.as_str().to_owned()) {
+				return self.application_failure(QuarantineReason::ApplicationOrder);
+			}
+			let bytes = serde_json::to_vec(&item).map_err(|_| RetainedSessionFailure::Malformed)?;
+
+			next_state.insert(
+				entity_id.as_str().to_owned(),
+				AppliedEntity { entity_id: entity_id.clone(), revision, bytes: bytes.clone() },
+			);
+			facts.push(CachedFact { entity_id, revision, bytes });
+		}
+
+		let inspection = self.publish(&facts)?;
+
+		self.state = next_state;
+		self.last_cursor = Some(snapshot.cursor);
+
+		Ok(inspection)
+	}
+
+	fn apply_event(
+		&mut self,
+		generation: u64,
+		event: EventEnvelope,
+	) -> Result<GenerationInspection, RetainedSessionFailure> {
+		self.ensure_generation(generation)?;
+		if event.version != CURRENT_VERSION
+			|| event.server_id != self.server_id
+			|| self.last_cursor.and_then(next_cursor) != Some(event.cursor)
+			|| self
+				.state
+				.get(event.entity_id.as_str())
+				.is_some_and(|current| event.entity_revision <= current.revision)
+		{
+			return self.application_failure(QuarantineReason::ApplicationOrder);
+		}
+
+		let bytes =
+			serde_json::to_vec(&event.payload).map_err(|_| RetainedSessionFailure::Malformed)?;
+		let mut next_state = self.state.clone();
+
+		next_state.insert(
+			event.entity_id.as_str().to_owned(),
+			AppliedEntity { entity_id: event.entity_id, revision: event.entity_revision, bytes },
+		);
+		let facts = next_state
+			.values()
+			.map(|entity| CachedFact {
+				entity_id: entity.entity_id.clone(),
+				revision: entity.revision,
+				bytes: entity.bytes.clone(),
+			})
+			.collect::<Vec<_>>();
+		let inspection = self.publish(&facts)?;
+
+		self.state = next_state;
+		self.last_cursor = Some(event.cursor);
+
+		Ok(inspection)
+	}
+
+	fn publish(
+		&mut self,
+		facts: &[CachedFact],
+	) -> Result<GenerationInspection, RetainedSessionFailure> {
+		let inputs = facts
+			.iter()
+			.map(|fact| {
+				ObjectInput::new(
+					&fact.entity_id,
+					fact.revision,
+					&fact.bytes,
+					ObjectCertainty::Authoritative,
+				)
+			})
+			.collect::<Vec<_>>();
+		let result =
+			self.cache.as_ref().ok_or(RetainedSessionFailure::Closed)?.publish(&inputs, &[]);
+
+		match result {
+			Ok(inspection) => Ok(inspection),
+			Err(error) => {
+				self.handle_cache_failure(error);
+
+				Err(RetainedSessionFailure::Malformed)
+			},
+		}
+	}
+
+	fn bind_checkpoint(
+		&mut self,
+		generation: u64,
+		cursor: Cursor,
+		checkpoint: SessionCheckpoint,
+		inspection: GenerationInspection,
+	) -> Result<(), RetainedSessionFailure> {
+		self.ensure_generation(generation)?;
+		if checkpoint.server_id() != &self.server_id
+			|| checkpoint.cursor() != cursor
+			|| inspection.authority != self.cache_authority
+			|| self
+				.cache
+				.as_ref()
+				.and_then(|cache| cache.inspect_current().ok().flatten())
+				.as_ref()
+				.is_none_or(|current| current.generation != inspection.generation)
+		{
+			return self.application_failure(QuarantineReason::ContentAttestation);
+		}
+
+		self.binding = Some(CacheBinding { checkpoint, generation: inspection.generation });
+		self.quarantine = None;
+		self.view = ConnectionView::Online { generation, applied: Some(cursor) };
+
+		Ok(())
+	}
+
+	fn ensure_generation(&mut self, generation: u64) -> Result<(), RetainedSessionFailure> {
+		if generation == self.connection_generation {
+			return Ok(());
+		}
+
+		self.enter_quarantine(
+			QuarantineReason::StaleConnectionGeneration,
+			QuarantineRecovery::VerifiedSnapshotReplacement,
+		);
+
+		Err(RetainedSessionFailure::PublicationOrder)
+	}
+
+	fn application_failure<T>(
+		&mut self,
+		reason: QuarantineReason,
+	) -> Result<T, RetainedSessionFailure> {
+		self.enter_quarantine(reason, QuarantineRecovery::VerifiedSnapshotReplacement);
+
+		Err(RetainedSessionFailure::PublicationOrder)
+	}
+
+	fn confirmation_failure(&mut self) -> RetainedSessionFailure {
+		self.enter_quarantine(
+			QuarantineReason::ApplicationConfirmation,
+			QuarantineRecovery::VerifiedSnapshotReplacement,
+		);
+
+		RetainedSessionFailure::ApplicationConfirmationMismatch
+	}
+
+	fn enter_quarantine(&mut self, reason: QuarantineReason, recovery: QuarantineRecovery) {
+		self.binding = None;
+		self.quarantine = Some(Quarantine { reason, recovery });
+		self.view = ConnectionView::Quarantined { reason, recovery };
+	}
+
+	fn handle_cache_failure(&mut self, error: CacheError) {
+		let recovery = if is_disposable_corruption(error)
+			&& ClientCache::dispose_all(&self.cache_root).is_ok()
+		{
+			match ClientCache::open(
+				&self.cache_root,
+				self.cache_limits,
+				self.cache_authority.clone(),
+			) {
+				Ok(cache) => {
+					self.cache = Some(cache);
+
+					QuarantineRecovery::DisposedBeforeRebuild
+				},
+				Err(_) => {
+					self.cache = None;
+
+					QuarantineRecovery::OperatorRequired
+				},
+			}
+		} else {
+			self.cache = None;
+
+			QuarantineRecovery::OperatorRequired
+		};
+
+		self.enter_quarantine(QuarantineReason::CacheCorrupt, recovery);
+	}
+
+	fn closed_failure(&mut self, failure: RetainedSessionFailure) -> Option<RunResult> {
+		match failure {
+			RetainedSessionFailure::Cancelled => Some(self.finish_shutdown_now()),
+			RetainedSessionFailure::InvalidEndpoint => {
+				self.view = ConnectionView::Incompatible(CompatibilityReason::InvalidEndpoint);
+
+				Some(RunResult::Incompatible)
+			},
+			RetainedSessionFailure::ProtocolMajorMismatch => {
+				self.view = ConnectionView::Incompatible(CompatibilityReason::ProtocolMajor);
+
+				Some(RunResult::Incompatible)
+			},
+			RetainedSessionFailure::ProtocolMinorMismatch => {
+				self.view = ConnectionView::Incompatible(CompatibilityReason::ProtocolMinor);
+
+				Some(RunResult::Incompatible)
+			},
+			RetainedSessionFailure::PublicationIdentityUnavailable => {
+				self.view = ConnectionView::Incompatible(
+					CompatibilityReason::PublicationIdentityUnavailable,
+				);
+
+				Some(RunResult::Incompatible)
+			},
+			RetainedSessionFailure::ServerIdentityMismatch => {
+				self.enter_quarantine(
+					QuarantineReason::StableServerIdentity,
+					QuarantineRecovery::OperatorRequired,
+				);
+
+				Some(RunResult::Quarantined)
+			},
+			RetainedSessionFailure::CheckpointIdentityMismatch => {
+				self.enter_quarantine(
+					QuarantineReason::CheckpointMismatch,
+					QuarantineRecovery::VerifiedSnapshotReplacement,
+				);
+
+				None
+			},
+			RetainedSessionFailure::Malformed
+			| RetainedSessionFailure::ProtocolViolation
+			| RetainedSessionFailure::PublicationOrder
+			| RetainedSessionFailure::ApplicationConfirmationRequired
+			| RetainedSessionFailure::ApplicationConfirmationMismatch => {
+				if self.quarantine.is_none() {
+					self.enter_quarantine(
+						QuarantineReason::ApplicationOrder,
+						QuarantineRecovery::VerifiedSnapshotReplacement,
+					);
+				}
+
+				None
+			},
+			RetainedSessionFailure::OperationTimeout
+			| RetainedSessionFailure::Closed
+			| RetainedSessionFailure::Disconnected
+			| RetainedSessionFailure::Backpressure => None,
+		}
+	}
+
+	async fn retry<I>(&mut self, io: &mut I, attempt: u8, generation: u64) -> bool
+	where
+		I: LifecycleIo,
+	{
+		if attempt >= MAX_CONNECTION_ATTEMPTS {
+			return false;
+		}
+		let delay = RETRY_DELAYS[usize::from(attempt - 1)];
+
+		if self.quarantine.is_none() {
+			self.view = ConnectionView::OfflineRetrying { next_attempt: attempt + 1, delay };
+		}
+
+		io.backoff(delay, &self.cancellation).await.is_ok()
+			&& self.ensure_generation(generation).is_ok()
+	}
+
+	fn retry_terminal(&mut self, attempt: u8) -> RunResult {
+		if self.cancellation.is_cancelled() {
+			return self.finish_shutdown_now();
+		}
+		if self.quarantine.is_some() {
+			return RunResult::Quarantined;
+		}
+		if attempt >= MAX_CONNECTION_ATTEMPTS {
+			self.view = ConnectionView::Stopped;
+
+			return RunResult::RetryExhausted;
+		}
+
+		RunResult::Quarantined
+	}
+
+	async fn finish_shutdown(&mut self) -> RunResult {
+		self.finish_shutdown_now()
+	}
+
+	fn finish_shutdown_now(&mut self) -> RunResult {
+		if self.quarantine.is_some() {
+			return RunResult::Quarantined;
+		}
+		self.view = ConnectionView::ShuttingDown;
+		self.view = ConnectionView::Stopped;
+
+		RunResult::Stopped
+	}
+}
+
+fn initialize_cache(
+	root: &Path,
+	limits: CacheLimits,
+	authority: CacheAuthority,
+) -> (Option<ClientCache>, Option<Quarantine>) {
+	match ClientCache::open(root, limits, authority.clone()) {
+		Ok(cache) => (Some(cache), None),
+		Err(CacheError::AuthorityMismatch) => {
+			match ClientCache::prepare_authority_switch(root, limits, authority) {
+				Ok(cache) => (
+					Some(cache),
+					Some(Quarantine {
+						reason: QuarantineReason::AuthorityChanged,
+						recovery: QuarantineRecovery::VerifiedSnapshotReplacement,
+					}),
+				),
+				Err(_) => unsafe_cache_quarantine(),
+			}
+		},
+		Err(error) if is_disposable_corruption(error) => {
+			if ClientCache::dispose_all(root).is_ok() {
+				match ClientCache::open(root, limits, authority) {
+					Ok(cache) => (
+						Some(cache),
+						Some(Quarantine {
+							reason: QuarantineReason::CacheCorrupt,
+							recovery: QuarantineRecovery::DisposedBeforeRebuild,
+						}),
+					),
+					Err(_) => unsafe_cache_quarantine(),
+				}
+			} else {
+				unsafe_cache_quarantine()
+			}
+		},
+		Err(_) => unsafe_cache_quarantine(),
+	}
+}
+
+fn unsafe_cache_quarantine() -> (Option<ClientCache>, Option<Quarantine>) {
+	(
+		None,
+		Some(Quarantine {
+			reason: QuarantineReason::CacheRootUnsafe,
+			recovery: QuarantineRecovery::OperatorRequired,
+		}),
+	)
+}
+
+fn is_disposable_corruption(error: CacheError) -> bool {
+	matches!(
+		error,
+		CacheError::CrashRemnant
+			| CacheError::InvalidMetadata
+			| CacheError::IntegrityMismatch
+			| CacheError::OrphanGeneration
+	)
+}
+
+fn snapshot_identity(item: &SnapshotItem) -> (EntityId, EntityRevision) {
+	match item {
+		SnapshotItem::SystemState { entity_id, revision, .. } => (entity_id.clone(), *revision),
+	}
+}
+
+fn next_cursor(cursor: Cursor) -> Option<Cursor> {
+	cursor.0.checked_add(1).map(Cursor)
+}
+
+#[cfg(test)]
+mod tests;

--- a/apps/decodex-gpui/src/client_lifecycle/tests.rs
+++ b/apps/decodex-gpui/src/client_lifecycle/tests.rs
@@ -1,0 +1,888 @@
+//! Deterministic lifecycle tests over the one private session/time seam.
+
+use std::{
+	collections::VecDeque,
+	fs,
+	path::{Path, PathBuf},
+	sync::{Arc, Mutex},
+	time::Duration,
+};
+
+use tempfile::TempDir;
+
+use decodex_protocol::{
+	CURRENT_VERSION, Channel, CorrelationId, Cursor, EntityId, EntityRevision, EventEnvelope,
+	EventPayload, RetainedSessionFailure, ServerId, ServerInstanceId, SessionCheckpoint,
+	SnapshotEnvelope, SnapshotItem, WireText,
+};
+
+use crate::client_lifecycle::{
+	AppliedEntity, CacheLimits, ClientCache, ClientLifecycle, CompatibilityReason, ConnectionView,
+	Delivery, LifecycleCancellation, LifecycleIo, QuarantineReason, QuarantineRecovery, RunResult,
+};
+
+const SERVER: &str = "server-a";
+const INSTANCE: &str = "publication-a";
+
+#[derive(Clone, Debug)]
+struct FakeConfirmation {
+	cursor: Cursor,
+	cache_root: PathBuf,
+	previous_current: Option<Vec<u8>>,
+}
+
+enum SessionAction {
+	Snapshot(SnapshotEnvelope),
+	Event(EventEnvelope),
+	Fail(RetainedSessionFailure),
+	Cancel,
+}
+
+struct FakeSession {
+	actions: VecDeque<SessionAction>,
+	checkpoint: Option<SessionCheckpoint>,
+	cancellation: LifecycleCancellation,
+	closed: Arc<Mutex<usize>>,
+	confirmations: Arc<Mutex<Vec<Cursor>>>,
+	cache_root: PathBuf,
+	server_id: ServerId,
+	instance_id: ServerInstanceId,
+}
+
+impl FakeSession {
+	async fn next(&mut self) -> Result<Delivery<FakeConfirmation>, RetainedSessionFailure> {
+		match self.actions.pop_front().expect("fake session action is scripted") {
+			SessionAction::Snapshot(snapshot) => {
+				let confirmation = FakeConfirmation {
+					cursor: snapshot.cursor,
+					cache_root: self.cache_root.clone(),
+					previous_current: None,
+				};
+
+				Ok(Delivery::Snapshot { snapshot, confirmation })
+			},
+			SessionAction::Event(event) => {
+				let confirmation = FakeConfirmation {
+					cursor: event.cursor,
+					previous_current: fs::read(self.cache_root.join("current")).ok(),
+					cache_root: self.cache_root.clone(),
+				};
+
+				Ok(Delivery::Event { event, confirmation })
+			},
+			SessionAction::Fail(failure) => Err(failure),
+			SessionAction::Cancel => {
+				self.cancellation.cancel();
+
+				Err(RetainedSessionFailure::Cancelled)
+			},
+		}
+	}
+
+	fn confirm_applied(
+		&mut self,
+		confirmation: FakeConfirmation,
+	) -> Result<SessionCheckpoint, RetainedSessionFailure> {
+		assert!(
+			confirmation.cache_root.join("current").is_file(),
+			"cache publication must complete before confirmation"
+		);
+		if let Some(previous) = confirmation.previous_current {
+			assert_ne!(
+				fs::read(confirmation.cache_root.join("current"))
+					.expect("event generation pointer is readable"),
+				previous,
+				"event generation must publish before confirmation"
+			);
+		}
+		self.confirmations.lock().expect("confirmation log is available").push(confirmation.cursor);
+		let checkpoint = SessionCheckpoint::new(
+			self.server_id.clone(),
+			self.instance_id.clone(),
+			confirmation.cursor,
+		);
+
+		self.checkpoint = Some(checkpoint.clone());
+
+		Ok(checkpoint)
+	}
+
+	async fn close(self) -> Result<(), RetainedSessionFailure> {
+		*self.closed.lock().expect("close count is available") += 1;
+
+		Ok(())
+	}
+}
+
+enum ConnectAction {
+	Session {
+		actions: VecDeque<SessionAction>,
+		checkpoint: Option<SessionCheckpoint>,
+		server_id: &'static str,
+		instance_id: &'static str,
+	},
+	Fail(RetainedSessionFailure),
+	Cancel,
+}
+
+struct FakeIo {
+	connections: VecDeque<ConnectAction>,
+	delays: Vec<Duration>,
+	attempts: usize,
+	active: usize,
+	maximum_active: usize,
+	closed: Arc<Mutex<usize>>,
+	confirmations: Arc<Mutex<Vec<Cursor>>>,
+	cache_root: PathBuf,
+	cancel_backoff: bool,
+	session: Option<FakeSession>,
+	requested_checkpoints: Vec<Option<SessionCheckpoint>>,
+}
+
+impl FakeIo {
+	fn new(cache_root: PathBuf, connections: Vec<ConnectAction>) -> Self {
+		Self {
+			connections: connections.into(),
+			delays: Vec::new(),
+			attempts: 0,
+			active: 0,
+			maximum_active: 0,
+			closed: Arc::new(Mutex::new(0)),
+			confirmations: Arc::new(Mutex::new(Vec::new())),
+			cache_root,
+			cancel_backoff: false,
+			session: None,
+			requested_checkpoints: Vec::new(),
+		}
+	}
+}
+
+impl LifecycleIo for FakeIo {
+	type Confirmation = FakeConfirmation;
+
+	async fn connect(
+		&mut self,
+		_config: &decodex_protocol::RetainedSessionConfig,
+		checkpoint: Option<SessionCheckpoint>,
+		cancellation: &LifecycleCancellation,
+	) -> Result<Option<SessionCheckpoint>, RetainedSessionFailure> {
+		assert!(self.session.is_none(), "one caller-owned session must close before replacement");
+		self.attempts += 1;
+		self.active += 1;
+		self.maximum_active = self.maximum_active.max(self.active);
+		self.requested_checkpoints.push(checkpoint);
+		let action = self.connections.pop_front().expect("fake connection is scripted");
+		self.active -= 1;
+
+		match action {
+			ConnectAction::Session { actions, checkpoint, server_id, instance_id } => {
+				let initial_checkpoint = checkpoint.clone();
+
+				self.session = Some(FakeSession {
+					actions,
+					checkpoint,
+					cancellation: cancellation.clone(),
+					closed: self.closed.clone(),
+					confirmations: self.confirmations.clone(),
+					cache_root: self.cache_root.clone(),
+					server_id: server(server_id),
+					instance_id: ServerInstanceId::new(instance_id)
+						.expect("instance identity is bounded"),
+				});
+
+				Ok(initial_checkpoint)
+			},
+			ConnectAction::Fail(failure) => Err(failure),
+			ConnectAction::Cancel => {
+				cancellation.cancel();
+
+				Err(RetainedSessionFailure::Cancelled)
+			},
+		}
+	}
+
+	async fn next(&mut self) -> Result<Delivery<Self::Confirmation>, RetainedSessionFailure> {
+		self.session.as_mut().expect("fake session is connected").next().await
+	}
+
+	fn confirm_applied(
+		&mut self,
+		confirmation: Self::Confirmation,
+	) -> Result<SessionCheckpoint, RetainedSessionFailure> {
+		self.session.as_mut().expect("fake session is connected").confirm_applied(confirmation)
+	}
+
+	async fn close(&mut self) -> Result<(), RetainedSessionFailure> {
+		let Some(session) = self.session.take() else {
+			return Ok(());
+		};
+
+		session.close().await
+	}
+
+	async fn backoff(
+		&mut self,
+		delay: Duration,
+		cancellation: &LifecycleCancellation,
+	) -> Result<(), RetainedSessionFailure> {
+		self.delays.push(delay);
+		if self.cancel_backoff {
+			cancellation.cancel();
+
+			return Err(RetainedSessionFailure::Cancelled);
+		}
+
+		Ok(())
+	}
+}
+
+fn connected(actions: Vec<SessionAction>, checkpoint: Option<SessionCheckpoint>) -> ConnectAction {
+	ConnectAction::Session {
+		actions: actions.into(),
+		checkpoint,
+		server_id: SERVER,
+		instance_id: INSTANCE,
+	}
+}
+
+fn server(value: &str) -> ServerId {
+	ServerId::new(value).expect("server identity is bounded")
+}
+
+fn checkpoint(instance: &str, cursor: u64) -> SessionCheckpoint {
+	SessionCheckpoint::new(
+		server(SERVER),
+		ServerInstanceId::new(instance).expect("instance identity is bounded"),
+		Cursor(cursor),
+	)
+}
+
+fn entity(value: &str) -> EntityId {
+	EntityId::new(value).expect("entity identity is bounded")
+}
+
+fn snapshot(cursor: u64, entity_id: &str, revision: u64) -> SnapshotEnvelope {
+	snapshot_for(SERVER, cursor, entity_id, revision)
+}
+
+fn snapshot_for(server_id: &str, cursor: u64, entity_id: &str, revision: u64) -> SnapshotEnvelope {
+	SnapshotEnvelope {
+		version: CURRENT_VERSION,
+		server_id: server(server_id),
+		cursor: Cursor(cursor),
+		items: vec![SnapshotItem::SystemState {
+			entity_id: entity(entity_id),
+			revision: EntityRevision(revision),
+			status: WireText::new("ready").expect("status is bounded"),
+		}],
+	}
+}
+
+fn event(cursor: u64, entity_id: &str, revision: u64) -> EventEnvelope {
+	EventEnvelope {
+		version: CURRENT_VERSION,
+		server_id: server(SERVER),
+		cursor: Cursor(cursor),
+		channel: Channel::SystemHealth,
+		entity_id: entity(entity_id),
+		entity_revision: EntityRevision(revision),
+		correlation_id: CorrelationId::new("correlation").expect("correlation is bounded"),
+		causation_id: None,
+		payload: EventPayload::SystemObservationRefreshed {
+			status: WireText::new("updated").expect("status is bounded"),
+		},
+	}
+}
+
+fn cache_root(temporary: &TempDir) -> PathBuf {
+	temporary.path().canonicalize().expect("temporary root canonicalizes").join("cache")
+}
+
+fn lifecycle(root: &Path) -> ClientLifecycle {
+	lifecycle_for(root, SERVER, 1)
+}
+
+fn lifecycle_for(root: &Path, server_id: &str, schema_generation: u64) -> ClientLifecycle {
+	ClientLifecycle::new(
+		"ws://127.0.0.1:49152/v1/ws",
+		server(server_id),
+		root,
+		CacheLimits::new(2 * 1_024 * 1_024, 32, 16).expect("limits are valid"),
+		schema_generation,
+	)
+	.expect("lifecycle constructs")
+}
+
+#[tokio::test]
+async fn retry_progression_is_capped_and_uses_only_fake_time() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	let failures =
+		(0..5).map(|_| ConnectAction::Fail(RetainedSessionFailure::Disconnected)).collect();
+	let mut io = FakeIo::new(root, failures);
+
+	assert_eq!(lifecycle.run_with_io(&mut io).await, RunResult::RetryExhausted);
+	assert_eq!(io.attempts, 5);
+	assert_eq!(io.maximum_active, 1);
+	assert_eq!(
+		io.delays,
+		vec![
+			Duration::from_millis(100),
+			Duration::from_millis(250),
+			Duration::from_millis(500),
+			Duration::from_secs(1),
+		]
+	);
+	assert_eq!(lifecycle.view(), ConnectionView::Stopped);
+}
+
+#[tokio::test]
+async fn cancellation_is_terminal_during_connect_backoff_and_receive() {
+	let connect_temporary = TempDir::new().expect("temporary directory is available");
+	let connect_root = cache_root(&connect_temporary);
+	let mut connect_lifecycle = lifecycle(&connect_root);
+	let mut connect_io = FakeIo::new(connect_root, vec![ConnectAction::Cancel]);
+
+	assert_eq!(connect_lifecycle.run_with_io(&mut connect_io).await, RunResult::Stopped);
+	assert_eq!(connect_lifecycle.view(), ConnectionView::Stopped);
+
+	let backoff_temporary = TempDir::new().expect("temporary directory is available");
+	let backoff_root = cache_root(&backoff_temporary);
+	let mut backoff_lifecycle = lifecycle(&backoff_root);
+	let mut backoff_io =
+		FakeIo::new(backoff_root, vec![ConnectAction::Fail(RetainedSessionFailure::Disconnected)]);
+	backoff_io.cancel_backoff = true;
+
+	assert_eq!(backoff_lifecycle.run_with_io(&mut backoff_io).await, RunResult::Stopped);
+
+	let receive_temporary = TempDir::new().expect("temporary directory is available");
+	let receive_root = cache_root(&receive_temporary);
+	let mut receive_lifecycle = lifecycle(&receive_root);
+	let mut receive_io =
+		FakeIo::new(receive_root, vec![connected(vec![SessionAction::Cancel], None)]);
+
+	assert_eq!(receive_lifecycle.run_with_io(&mut receive_io).await, RunResult::Stopped);
+	assert_eq!(*receive_io.closed.lock().expect("close count is available"), 1);
+}
+
+#[tokio::test]
+async fn cache_and_state_application_precede_checkpoint_confirmation() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	let mut io = FakeIo::new(
+		root.clone(),
+		vec![connected(
+			vec![SessionAction::Snapshot(snapshot(7, "system", 3)), SessionAction::Cancel],
+			None,
+		)],
+	);
+
+	assert_eq!(lifecycle.run_with_io(&mut io).await, RunResult::Stopped);
+	assert!(root.join("current").is_file());
+	assert_eq!(lifecycle.last_cursor, Some(Cursor(7)));
+	assert_eq!(lifecycle.state["system"].revision, EntityRevision(3));
+	assert_eq!(*io.confirmations.lock().expect("confirmation log is available"), vec![Cursor(7)]);
+	assert_eq!(
+		lifecycle.binding.as_ref().expect("checkpoint is bound").checkpoint.cursor(),
+		Cursor(7)
+	);
+}
+
+#[tokio::test]
+async fn event_publication_retains_the_complete_authoritative_state_before_confirmation() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	let snapshot = SnapshotEnvelope {
+		version: CURRENT_VERSION,
+		server_id: server(SERVER),
+		cursor: Cursor(5),
+		items: vec![
+			SnapshotItem::SystemState {
+				entity_id: entity("first"),
+				revision: EntityRevision(1),
+				status: WireText::new("first").expect("status is bounded"),
+			},
+			SnapshotItem::SystemState {
+				entity_id: entity("second"),
+				revision: EntityRevision(2),
+				status: WireText::new("second").expect("status is bounded"),
+			},
+		],
+	};
+	let mut io = FakeIo::new(
+		root,
+		vec![connected(
+			vec![
+				SessionAction::Snapshot(snapshot),
+				SessionAction::Event(event(6, "first", 3)),
+				SessionAction::Cancel,
+			],
+			None,
+		)],
+	);
+
+	assert_eq!(lifecycle.run_with_io(&mut io).await, RunResult::Stopped);
+	assert_eq!(lifecycle.state.len(), 2);
+	assert_eq!(lifecycle.state["first"].revision, EntityRevision(3));
+	assert_eq!(lifecycle.state["second"].revision, EntityRevision(2));
+	assert_eq!(lifecycle.cache.as_ref().unwrap().inspect_current().unwrap().unwrap().records, 2);
+	assert_eq!(
+		*io.confirmations.lock().expect("confirmation log is available"),
+		vec![Cursor(5), Cursor(6)]
+	);
+}
+
+#[tokio::test]
+async fn resume_reuses_only_the_attested_checkpoint_and_fallback_rebuilds_state() {
+	let resume_temporary = TempDir::new().expect("temporary directory is available");
+	let resume_root = cache_root(&resume_temporary);
+	let mut resumed = lifecycle(&resume_root);
+	let mut resume_io = FakeIo::new(
+		resume_root,
+		vec![
+			connected(
+				vec![
+					SessionAction::Snapshot(snapshot(7, "system", 3)),
+					SessionAction::Fail(RetainedSessionFailure::Disconnected),
+				],
+				None,
+			),
+			connected(
+				vec![SessionAction::Event(event(8, "system", 4)), SessionAction::Cancel],
+				Some(checkpoint(INSTANCE, 7)),
+			),
+		],
+	);
+
+	assert_eq!(resumed.run_with_io(&mut resume_io).await, RunResult::Stopped);
+	assert_eq!(resume_io.requested_checkpoints[0], None);
+	assert_eq!(
+		resume_io.requested_checkpoints[1].as_ref().map(SessionCheckpoint::cursor),
+		Some(Cursor(7))
+	);
+	assert_eq!(resumed.last_cursor, Some(Cursor(8)));
+	assert_eq!(resumed.state["system"].revision, EntityRevision(4));
+
+	let fallback_temporary = TempDir::new().expect("temporary directory is available");
+	let fallback_root = cache_root(&fallback_temporary);
+	let mut fallback = lifecycle(&fallback_root);
+	let mut fallback_io = FakeIo::new(
+		fallback_root,
+		vec![
+			connected(
+				vec![
+					SessionAction::Snapshot(snapshot(3, "old", 1)),
+					SessionAction::Fail(RetainedSessionFailure::Disconnected),
+				],
+				None,
+			),
+			ConnectAction::Session {
+				actions: vec![
+					SessionAction::Snapshot(snapshot(9, "replacement", 1)),
+					SessionAction::Cancel,
+				]
+				.into(),
+				checkpoint: None,
+				server_id: SERVER,
+				instance_id: "publication-b",
+			},
+		],
+	);
+
+	assert_eq!(fallback.run_with_io(&mut fallback_io).await, RunResult::Stopped);
+	assert_eq!(
+		fallback_io.requested_checkpoints[1].as_ref().map(SessionCheckpoint::cursor),
+		Some(Cursor(3))
+	);
+	assert!(!fallback.state.contains_key("old"));
+	assert_eq!(fallback.state["replacement"].revision, EntityRevision(1));
+	assert_eq!(
+		fallback
+			.binding
+			.as_ref()
+			.expect("replacement checkpoint is bound")
+			.checkpoint
+			.instance_id(),
+		&ServerInstanceId::new("publication-b").expect("instance identity is bounded")
+	);
+	assert_eq!(
+		fallback
+			.cache
+			.as_ref()
+			.expect("cache is available")
+			.inspect_current()
+			.unwrap()
+			.unwrap()
+			.records,
+		1
+	);
+}
+
+#[tokio::test]
+async fn checkpoint_mismatch_quarantines_then_recovers_only_from_a_fresh_snapshot() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	let mut io = FakeIo::new(
+		root,
+		vec![
+			connected(
+				vec![
+					SessionAction::Snapshot(snapshot(2, "old", 1)),
+					SessionAction::Fail(RetainedSessionFailure::Disconnected),
+				],
+				None,
+			),
+			ConnectAction::Fail(RetainedSessionFailure::CheckpointIdentityMismatch),
+			connected(
+				vec![SessionAction::Snapshot(snapshot(7, "replacement", 1)), SessionAction::Cancel],
+				None,
+			),
+		],
+	);
+
+	assert_eq!(lifecycle.run_with_io(&mut io).await, RunResult::Stopped);
+	assert_eq!(
+		io.requested_checkpoints[1].as_ref().map(SessionCheckpoint::cursor),
+		Some(Cursor(2))
+	);
+	assert_eq!(io.requested_checkpoints[2], None);
+	assert!(!lifecycle.state.contains_key("old"));
+	assert!(lifecycle.state.contains_key("replacement"));
+	assert!(lifecycle.quarantine.is_none());
+}
+
+#[tokio::test]
+async fn snapshot_fallback_rejects_events_until_verified_rebuild_completes() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	let mut io = FakeIo::new(
+		root,
+		vec![
+			connected(
+				vec![
+					SessionAction::Snapshot(snapshot(2, "old", 1)),
+					SessionAction::Fail(RetainedSessionFailure::Disconnected),
+				],
+				None,
+			),
+			ConnectAction::Session {
+				actions: vec![SessionAction::Event(event(3, "old", 2))].into(),
+				checkpoint: None,
+				server_id: SERVER,
+				instance_id: "publication-b",
+			},
+			ConnectAction::Session {
+				actions: vec![
+					SessionAction::Snapshot(snapshot(5, "replacement", 1)),
+					SessionAction::Cancel,
+				]
+				.into(),
+				checkpoint: None,
+				server_id: SERVER,
+				instance_id: "publication-b",
+			},
+		],
+	);
+
+	assert_eq!(lifecycle.run_with_io(&mut io).await, RunResult::Stopped);
+	assert_eq!(
+		*io.confirmations.lock().expect("confirmation log is available"),
+		vec![Cursor(2), Cursor(5)]
+	);
+	assert!(!lifecycle.state.contains_key("old"));
+	assert!(lifecycle.state.contains_key("replacement"));
+}
+
+#[tokio::test]
+async fn material_failure_exhaustion_preserves_quarantine_authority_state() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	let failures = (0..5)
+		.map(|_| ConnectAction::Fail(RetainedSessionFailure::CheckpointIdentityMismatch))
+		.collect();
+	let mut io = FakeIo::new(root, failures);
+
+	assert_eq!(lifecycle.run_with_io(&mut io).await, RunResult::Quarantined);
+	assert_eq!(
+		lifecycle.view(),
+		ConnectionView::Quarantined {
+			reason: QuarantineReason::CheckpointMismatch,
+			recovery: QuarantineRecovery::VerifiedSnapshotReplacement,
+		}
+	);
+}
+
+#[test]
+fn snapshot_fallback_stays_quarantined_until_checkpoint_binding() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	lifecycle.connection_generation = 1;
+	lifecycle.connection_established(1, true, None);
+
+	assert_eq!(
+		lifecycle.view(),
+		ConnectionView::Quarantined {
+			reason: QuarantineReason::PublicationInstanceChanged,
+			recovery: QuarantineRecovery::VerifiedSnapshotReplacement,
+		}
+	);
+
+	let inspection = lifecycle
+		.apply_snapshot(1, snapshot(8, "replacement", 1))
+		.expect("verified replacement publishes");
+	assert!(matches!(lifecycle.view(), ConnectionView::Quarantined { .. }));
+	lifecycle
+		.bind_checkpoint(1, Cursor(8), checkpoint("publication-b", 8), inspection)
+		.expect("verified replacement checkpoint binds");
+
+	assert_eq!(
+		lifecycle.view(),
+		ConnectionView::Online { generation: 1, applied: Some(Cursor(8)) }
+	);
+}
+
+#[tokio::test]
+async fn stable_server_and_schema_switches_require_verified_snapshot_replacement() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut original = lifecycle(&root);
+	original.connection_generation = 1;
+	let original_inspection =
+		original.apply_snapshot(1, snapshot(1, "old", 1)).expect("original snapshot publishes");
+	original
+		.bind_checkpoint(1, Cursor(1), checkpoint(INSTANCE, 1), original_inspection.clone())
+		.expect("original checkpoint binds");
+	drop(original);
+
+	let mut server_switched = lifecycle_for(&root, "server-b", 1);
+	assert_eq!(
+		server_switched.view(),
+		ConnectionView::Quarantined {
+			reason: QuarantineReason::AuthorityChanged,
+			recovery: QuarantineRecovery::VerifiedSnapshotReplacement,
+		}
+	);
+	let mut switch_io = FakeIo::new(
+		root.clone(),
+		vec![ConnectAction::Session {
+			actions: vec![
+				SessionAction::Snapshot(snapshot_for("server-b", 2, "new", 1)),
+				SessionAction::Cancel,
+			]
+			.into(),
+			checkpoint: None,
+			server_id: "server-b",
+			instance_id: "publication-b",
+		}],
+	);
+
+	assert_eq!(server_switched.run_with_io(&mut switch_io).await, RunResult::Stopped);
+	assert!(server_switched.quarantine.is_none());
+	assert!(!server_switched.state.contains_key("old"));
+	assert_eq!(server_switched.state["new"].revision, EntityRevision(1));
+	assert!(
+		server_switched
+			.cache
+			.as_ref()
+			.expect("cache is available")
+			.inspect_generation(&original_inspection.generation)
+			.is_ok(),
+		"old authority remains inspection-only"
+	);
+	drop(server_switched);
+
+	let schema_switched = lifecycle_for(&root, "server-b", 2);
+	assert_eq!(
+		schema_switched.view(),
+		ConnectionView::Quarantined {
+			reason: QuarantineReason::AuthorityChanged,
+			recovery: QuarantineRecovery::VerifiedSnapshotReplacement,
+		}
+	);
+}
+
+#[test]
+fn corrupt_cache_is_disposed_and_rebuilt_while_unsafe_root_requires_an_operator() {
+	let corrupt_temporary = TempDir::new().expect("temporary directory is available");
+	let corrupt_root = cache_root(&corrupt_temporary);
+	let mut original = lifecycle(&corrupt_root);
+	original.connection_generation = 1;
+	original.apply_snapshot(1, snapshot(1, "system", 1)).expect("cache publishes");
+	let generation = fs::read_dir(corrupt_root.join("generations"))
+		.expect("generation directory is readable")
+		.next()
+		.expect("one generation exists")
+		.expect("generation entry is readable")
+		.path();
+	let object = fs::read_dir(generation.join("objects"))
+		.expect("object directory is readable")
+		.next()
+		.expect("one object exists")
+		.expect("object entry is readable")
+		.path();
+	fs::write(object, b"tampered").expect("test corrupts cache content");
+	drop(original);
+
+	let rebuilt = lifecycle(&corrupt_root);
+	assert_eq!(
+		rebuilt.view(),
+		ConnectionView::Quarantined {
+			reason: QuarantineReason::CacheCorrupt,
+			recovery: QuarantineRecovery::DisposedBeforeRebuild,
+		}
+	);
+	assert_eq!(
+		rebuilt.cache.as_ref().expect("rebuilt cache is available").inspect_current().unwrap(),
+		None
+	);
+
+	let unsafe_temporary = TempDir::new().expect("temporary directory is available");
+	let unsafe_root = unsafe_temporary.path().canonicalize().unwrap().join("cache");
+	fs::write(&unsafe_root, b"not a directory").expect("unsafe cache root is created");
+	let unsafe_lifecycle = lifecycle(&unsafe_root);
+	assert_eq!(
+		unsafe_lifecycle.view(),
+		ConnectionView::Quarantined {
+			reason: QuarantineReason::CacheRootUnsafe,
+			recovery: QuarantineRecovery::OperatorRequired,
+		}
+	);
+	assert!(unsafe_lifecycle.cache.is_none());
+}
+
+#[test]
+fn checkpoint_reuse_requires_current_content_attestation() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	lifecycle.connection_generation = 1;
+	let inspection =
+		lifecycle.apply_snapshot(1, snapshot(4, "system", 2)).expect("snapshot publishes");
+	lifecycle
+		.bind_checkpoint(1, Cursor(4), checkpoint(INSTANCE, 4), inspection)
+		.expect("checkpoint binds");
+	fs::write(root.join("current"), b"corrupt").expect("current attestation is corrupted");
+
+	assert_eq!(lifecycle.reusable_checkpoint(), None);
+	assert_eq!(
+		lifecycle.view(),
+		ConnectionView::Quarantined {
+			reason: QuarantineReason::ContentAttestation,
+			recovery: QuarantineRecovery::VerifiedSnapshotReplacement,
+		}
+	);
+}
+
+#[test]
+fn complete_cache_deletion_cannot_remove_applied_product_state() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	lifecycle.connection_generation = 1;
+	lifecycle.apply_snapshot(1, snapshot(1, "system", 5)).expect("snapshot publishes");
+
+	ClientCache::dispose_all(&root).expect("disposable cache is removed");
+
+	assert!(!root.exists());
+	assert_eq!(lifecycle.state["system"].revision, EntityRevision(5));
+	assert_eq!(lifecycle.last_cursor, Some(Cursor(1)));
+}
+
+#[test]
+fn event_order_revision_and_connection_generation_are_fenced() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+
+	lifecycle.connection_generation = 2;
+	lifecycle.last_cursor = Some(Cursor(4));
+	lifecycle.state.insert(
+		"system".to_owned(),
+		AppliedEntity {
+			entity_id: entity("system"),
+			revision: EntityRevision(2),
+			bytes: Vec::new(),
+		},
+	);
+
+	assert_eq!(
+		lifecycle.apply_event(1, event(5, "system", 3)),
+		Err(RetainedSessionFailure::PublicationOrder)
+	);
+	assert_eq!(
+		lifecycle.view(),
+		ConnectionView::Quarantined {
+			reason: QuarantineReason::StaleConnectionGeneration,
+			recovery: QuarantineRecovery::VerifiedSnapshotReplacement,
+		}
+	);
+
+	lifecycle.connection_generation = 3;
+	lifecycle.last_cursor = Some(Cursor(4));
+	assert_eq!(
+		lifecycle.apply_event(3, event(5, "system", 2)),
+		Err(RetainedSessionFailure::PublicationOrder)
+	);
+}
+
+#[tokio::test]
+async fn transient_incompatible_and_stable_identity_failures_are_distinct() {
+	let incompatible_temporary = TempDir::new().expect("temporary directory is available");
+	let incompatible_root = cache_root(&incompatible_temporary);
+	let mut incompatible = lifecycle(&incompatible_root);
+	let mut incompatible_io = FakeIo::new(
+		incompatible_root,
+		vec![ConnectAction::Fail(RetainedSessionFailure::ProtocolMajorMismatch)],
+	);
+
+	assert_eq!(incompatible.run_with_io(&mut incompatible_io).await, RunResult::Incompatible);
+	assert_eq!(
+		incompatible.view(),
+		ConnectionView::Incompatible(CompatibilityReason::ProtocolMajor)
+	);
+
+	let identity_temporary = TempDir::new().expect("temporary directory is available");
+	let identity_root = cache_root(&identity_temporary);
+	let mut identity = lifecycle(&identity_root);
+	let mut identity_io = FakeIo::new(
+		identity_root,
+		vec![ConnectAction::Fail(RetainedSessionFailure::ServerIdentityMismatch)],
+	);
+
+	assert_eq!(identity.run_with_io(&mut identity_io).await, RunResult::Quarantined);
+	assert_eq!(
+		identity.view(),
+		ConnectionView::Quarantined {
+			reason: QuarantineReason::StableServerIdentity,
+			recovery: QuarantineRecovery::OperatorRequired,
+		}
+	);
+}
+
+#[test]
+fn publication_instances_are_part_of_checkpoint_identity() {
+	assert_ne!(checkpoint(INSTANCE, 1), checkpoint("publication-b", 1));
+}
+
+#[test]
+fn test_fixture_uses_only_typed_bounded_cache_content() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+
+	lifecycle.connection_generation = 1;
+	let inspection = lifecycle
+		.apply_snapshot(1, snapshot(1, "../../not-a-path", 1))
+		.expect("typed snapshot publishes");
+
+	assert_eq!(inspection.records, 1);
+	assert!(!temporary.path().join("not-a-path").exists());
+	assert!(fs::read(root.join("current")).is_ok());
+}

--- a/apps/decodex-gpui/src/main.rs
+++ b/apps/decodex-gpui/src/main.rs
@@ -1,7 +1,12 @@
 //! Default-disabled Decodex vNext GPUI client composition root.
 
-#[allow(dead_code, reason = "XY-1333 will compose the accepted private cache module")]
+#[allow(
+	dead_code,
+	reason = "XY-1334 will classify and remove or replace remaining future-shell/test-only cache API allowances when the shell constructs the lifecycle"
+)]
 mod client_cache;
+#[allow(dead_code, reason = "XY-1334 will connect the accepted lifecycle to the GPUI shell")]
+mod client_lifecycle;
 
 use decodex_protocol::CURRENT_VERSION;
 
@@ -9,7 +14,7 @@ fn main() {
 	let version = CURRENT_VERSION;
 
 	println!(
-		"Decodex GPUI v{}.{} is disabled: XY-1263 foundation accepted; P/K/L/S product slices remain disabled",
+		"Decodex GPUI v{}.{} is disabled: client lifecycle composed; S shell slice remains pending",
 		version.major, version.minor
 	);
 }


### PR DESCRIPTION
## Summary
- compose retained WebSocket sessions and the disposable client cache into one caller-owned lifecycle
- enforce bounded retry, generation fencing, quarantine recovery, and cache-before-confirm ordering
- publish complete authoritative event state and cover lifecycle recovery paths with focused tests

## Validation
- cargo test -p decodex-gpui (34 passed)
- cargo clippy -p decodex-gpui --all-targets --all-features -- -D warnings
- cargo test -p decodex-core --test vnext_architecture (13 passed)
- cargo check -p decodex-gpui --all-targets --all-features
- cargo metadata --locked --no-deps
- git diff --check

Independent lifecycle review: approved.

Linear: XY-1333