### PR TITLE
Persist versioned project policy authority

### DIFF
--- a/crates/decodex-core/src/lib.rs
+++ b/crates/decodex-core/src/lib.rs
@@ -9,6 +9,7 @@ mod conversation;
 mod identity;
 #[cfg(unix)] mod path_unix;
 mod paths;
+mod policy;
 mod project;
 mod quota;
 mod storage;
@@ -48,6 +49,12 @@ pub use self::{
 	},
 	identity::ServerIdentity,
 	paths::{DecodexPaths, DecodexRoot, PathError},
+	policy::{
+		AcceptedPolicyRevision, MAX_POLICY_PROVENANCE_BYTES, MAX_POLICY_SNAPSHOT_FIELDS,
+		MAX_POLICY_SNAPSHOT_KEY_BYTES, MAX_POLICY_SNAPSHOT_VALUE_BYTES, Policy, PolicyError,
+		PolicyId, PolicyProvenance, PolicyRepository, PolicyRevision, PolicyRevisionAcceptance,
+		PolicyRevisionId, PolicySnapshot, PolicySnapshotValue, PolicyStatus, PolicyTimestamp,
+	},
 	project::{
 		MAX_PROJECT_METADATA_FIELDS, MAX_PROJECT_METADATA_KEY_BYTES,
 		MAX_PROJECT_METADATA_VALUE_BYTES, MAX_PROJECT_PATH_BYTES, MAX_REPOSITORY_IDENTITY_BYTES,

--- a/crates/decodex-core/src/policy.rs
+++ b/crates/decodex-core/src/policy.rs
@@ -1,0 +1,566 @@
+use std::{
+	collections::BTreeMap,
+	error::Error,
+	fmt::{Debug, Display, Formatter},
+	future::Future,
+};
+
+use crate::{AgentId, ProjectId};
+
+/// Maximum UTF-8 bytes in one inert policy provenance value.
+pub const MAX_POLICY_PROVENANCE_BYTES: usize = 256;
+/// Maximum fields in one inert policy snapshot.
+pub const MAX_POLICY_SNAPSHOT_FIELDS: usize = 32;
+/// Maximum UTF-8 bytes in one policy snapshot key.
+pub const MAX_POLICY_SNAPSHOT_KEY_BYTES: usize = 64;
+/// Maximum UTF-8 bytes in one policy snapshot text value.
+pub const MAX_POLICY_SNAPSHOT_VALUE_BYTES: usize = 256;
+
+/// Application port for immutable Project policy authority.
+pub trait PolicyRepository {
+	/// Adapter-owned error.
+	type Error: Error + Send + Sync + 'static;
+
+	/// Idempotently create one Project-owned policy identity.
+	fn create_policy(
+		&self,
+		id: PolicyId,
+		project_id: ProjectId,
+	) -> impl Future<Output = Result<Policy, Self::Error>> + Send;
+
+	/// Accept one exact immutable policy revision.
+	fn accept_policy_revision(
+		&self,
+		acceptance: PolicyRevisionAcceptance,
+	) -> impl Future<Output = Result<AcceptedPolicyRevision, Self::Error>> + Send;
+
+	/// Read one exact immutable policy revision.
+	fn policy_revision(
+		&self,
+		id: &PolicyRevisionId,
+	) -> impl Future<Output = Result<Option<AcceptedPolicyRevision>, Self::Error>> + Send;
+
+	/// List Policy identities for one Project in stable identity order.
+	fn policies_for_project(
+		&self,
+		project_id: &ProjectId,
+	) -> impl Future<Output = Result<Vec<Policy>, Self::Error>> + Send;
+}
+
+/// Stable canonical Policy identity owned only by this module.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PolicyId(String);
+impl PolicyId {
+	/// Parse one canonical lowercase RFC 9562 UUID version 4 identity.
+	pub fn new(value: impl Into<String>) -> Result<Self, PolicyError> {
+		let value = value.into();
+
+		if !is_canonical_uuid_v4(&value) {
+			return Err(PolicyError::InvalidPolicyId);
+		}
+
+		Ok(Self(value))
+	}
+
+	/// Borrow the canonical Policy identity.
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+
+impl Display for PolicyId {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(&self.0)
+	}
+}
+
+/// Positive immutable revision number within one Policy.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PolicyRevision(u64);
+impl PolicyRevision {
+	/// Validate one positive policy revision.
+	pub const fn new(value: u64) -> Result<Self, PolicyError> {
+		if value == 0 { Err(PolicyError::InvalidRevision) } else { Ok(Self(value)) }
+	}
+
+	/// Read the positive revision number.
+	pub const fn get(self) -> u64 {
+		self.0
+	}
+}
+
+/// Exact Project-owned Policy revision identity imported by downstream domains.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PolicyRevisionId {
+	project_id: ProjectId,
+	policy_id: PolicyId,
+	revision: PolicyRevision,
+}
+impl PolicyRevisionId {
+	/// Bind an exact revision to its authoritative Project and Policy identities.
+	pub const fn new(project_id: ProjectId, policy_id: PolicyId, revision: PolicyRevision) -> Self {
+		Self { project_id, policy_id, revision }
+	}
+
+	/// Owning Project identity.
+	pub const fn project_id(&self) -> &ProjectId {
+		&self.project_id
+	}
+
+	/// Owning Policy identity.
+	pub const fn policy_id(&self) -> &PolicyId {
+		&self.policy_id
+	}
+
+	/// Exact positive revision.
+	pub const fn revision(&self) -> PolicyRevision {
+		self.revision
+	}
+}
+
+/// Database-authored timestamp represented as Unix epoch microseconds.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PolicyTimestamp(i64);
+impl PolicyTimestamp {
+	/// Validate deterministic persistence readback.
+	pub const fn from_unix_microseconds(value: i64) -> Result<Self, PolicyError> {
+		if value < 0 { Err(PolicyError::InvalidChronology) } else { Ok(Self(value)) }
+	}
+
+	/// Read Unix epoch microseconds.
+	pub const fn unix_microseconds(self) -> i64 {
+		self.0
+	}
+}
+
+/// Minimal Project-owned policy identity and current accepted revision pointer.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Policy {
+	id: PolicyId,
+	project_id: ProjectId,
+	created_at: PolicyTimestamp,
+	current_revision: Option<PolicyRevision>,
+}
+impl Policy {
+	/// Validate deterministic persistence readback.
+	pub const fn from_stored(
+		id: PolicyId,
+		project_id: ProjectId,
+		created_at: PolicyTimestamp,
+		current_revision: Option<PolicyRevision>,
+	) -> Self {
+		Self { id, project_id, created_at, current_revision }
+	}
+
+	/// Stable Policy identity.
+	pub const fn id(&self) -> &PolicyId {
+		&self.id
+	}
+
+	/// Owning Project identity.
+	pub const fn project_id(&self) -> &ProjectId {
+		&self.project_id
+	}
+
+	/// Database-authored identity creation time.
+	pub const fn created_at(&self) -> PolicyTimestamp {
+		self.created_at
+	}
+
+	/// Latest accepted revision, when one exists.
+	pub const fn current_revision(&self) -> Option<PolicyRevision> {
+		self.current_revision
+	}
+
+	/// Minimal inert lifecycle derived from whether an accepted revision exists.
+	pub const fn status(&self) -> PolicyStatus {
+		if self.current_revision.is_some() {
+			PolicyStatus::Accepted
+		} else {
+			PolicyStatus::Unaccepted
+		}
+	}
+}
+
+/// Minimal inert Policy lifecycle. It enables no effective resolution or behavior.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PolicyStatus {
+	/// Stable identity exists but has no accepted revision.
+	Unaccepted,
+	/// At least one immutable accepted revision exists.
+	Accepted,
+}
+
+/// Bounded credential-negative provenance retained with an accepted revision.
+#[derive(Clone, Eq, PartialEq)]
+pub struct PolicyProvenance(String);
+impl PolicyProvenance {
+	/// Validate one ordinary opaque provenance value.
+	pub fn new(value: impl Into<String>) -> Result<Self, PolicyError> {
+		let value = value.into();
+
+		if value.is_empty()
+			|| value.len() > MAX_POLICY_PROVENANCE_BYTES
+			|| value.chars().any(char::is_control)
+		{
+			return Err(PolicyError::InvalidProvenance);
+		}
+		if crate::contains_credential_material(&value) {
+			return Err(PolicyError::CredentialRejected);
+		}
+
+		Ok(Self(value))
+	}
+
+	/// Borrow the opaque provenance value.
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+
+impl Debug for PolicyProvenance {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str("PolicyProvenance(<redacted>)")
+	}
+}
+
+/// Closed scalar in an inert policy snapshot. Values have no effective semantics here.
+#[derive(Clone, Eq, PartialEq)]
+pub enum PolicySnapshotValue {
+	/// Bounded ordinary text.
+	Text(String),
+	/// Non-secret boolean fact.
+	Boolean(bool),
+}
+impl Debug for PolicySnapshotValue {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::Text(_) => formatter.write_str("Text(<redacted>)"),
+			Self::Boolean(value) => formatter.debug_tuple("Boolean").field(value).finish(),
+		}
+	}
+}
+
+/// Bounded deterministic inert snapshot with no resolver or effects.
+#[derive(Clone, Default, Eq, PartialEq)]
+pub struct PolicySnapshot(BTreeMap<String, PolicySnapshotValue>);
+impl PolicySnapshot {
+	/// Validate one closed credential-negative snapshot.
+	pub fn new(values: BTreeMap<String, PolicySnapshotValue>) -> Result<Self, PolicyError> {
+		if values.len() > MAX_POLICY_SNAPSHOT_FIELDS {
+			return Err(PolicyError::InvalidSnapshot);
+		}
+
+		for (key, value) in &values {
+			if key.is_empty()
+				|| key.len() > MAX_POLICY_SNAPSHOT_KEY_BYTES
+				|| !key.bytes().enumerate().all(|(index, byte)| {
+					if index == 0 {
+						byte.is_ascii_lowercase()
+					} else {
+						byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'
+					}
+				}) {
+				return Err(PolicyError::InvalidSnapshot);
+			}
+			if crate::is_credential_metadata_key(key) {
+				return Err(PolicyError::CredentialRejected);
+			}
+
+			if let PolicySnapshotValue::Text(text) = value {
+				if text.len() > MAX_POLICY_SNAPSHOT_VALUE_BYTES
+					|| text.chars().any(char::is_control)
+				{
+					return Err(PolicyError::InvalidSnapshot);
+				}
+				if crate::contains_credential_material(text) {
+					return Err(PolicyError::CredentialRejected);
+				}
+			}
+		}
+
+		Ok(Self(values))
+	}
+
+	/// Empty inert snapshot.
+	pub const fn empty() -> Self {
+		Self(BTreeMap::new())
+	}
+
+	/// Borrow fields in canonical key order.
+	pub const fn as_map(&self) -> &BTreeMap<String, PolicySnapshotValue> {
+		&self.0
+	}
+}
+
+impl Debug for PolicySnapshot {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter
+			.debug_struct("PolicySnapshot")
+			.field("field_count", &self.0.len())
+			.finish_non_exhaustive()
+	}
+}
+
+/// Proposed immutable bytes for one acceptance transaction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PolicyRevisionAcceptance {
+	/// Exact Project-owned revision identity.
+	pub id: PolicyRevisionId,
+	/// Opaque bounded provenance.
+	pub provenance: PolicyProvenance,
+	/// Inert bounded snapshot.
+	pub snapshot: PolicySnapshot,
+	/// Stable Agent identity whose active same-Project Lead authority is checked by storage.
+	pub accepted_by: AgentId,
+	/// Exact prior revision replaced by this acceptance.
+	pub supersedes: Option<PolicyRevisionId>,
+}
+impl PolicyRevisionAcceptance {
+	/// Validate typed first-revision or exact immediate-predecessor lineage.
+	pub fn validate(&self) -> Result<(), PolicyError> {
+		match (&self.supersedes, self.id.revision().get()) {
+			(None, 1) => Ok(()),
+			(Some(previous), revision)
+				if previous.project_id() == self.id.project_id()
+					&& previous.policy_id() == self.id.policy_id()
+					&& previous.revision().get().checked_add(1) == Some(revision) =>
+				Ok(()),
+			_ => Err(PolicyError::InvalidSupersession),
+		}
+	}
+}
+
+/// Exact immutable accepted policy revision readback.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptedPolicyRevision {
+	id: PolicyRevisionId,
+	provenance: PolicyProvenance,
+	snapshot: PolicySnapshot,
+	accepted_by: AgentId,
+	policy_created_at: PolicyTimestamp,
+	accepted_at: PolicyTimestamp,
+	supersedes: Option<PolicyRevisionId>,
+}
+impl AcceptedPolicyRevision {
+	/// Validate deterministic persistence readback and chronology.
+	pub fn from_stored(
+		acceptance: PolicyRevisionAcceptance,
+		policy_created_at: PolicyTimestamp,
+		accepted_at: PolicyTimestamp,
+	) -> Result<Self, PolicyError> {
+		acceptance.validate()?;
+
+		if accepted_at < policy_created_at {
+			return Err(PolicyError::InvalidChronology);
+		}
+
+		Ok(Self {
+			id: acceptance.id,
+			provenance: acceptance.provenance,
+			snapshot: acceptance.snapshot,
+			accepted_by: acceptance.accepted_by,
+			policy_created_at,
+			accepted_at,
+			supersedes: acceptance.supersedes,
+		})
+	}
+
+	/// Exact Project-owned revision identity.
+	pub const fn id(&self) -> &PolicyRevisionId {
+		&self.id
+	}
+
+	/// Opaque bounded provenance.
+	pub const fn provenance(&self) -> &PolicyProvenance {
+		&self.provenance
+	}
+
+	/// Inert immutable snapshot.
+	pub const fn snapshot(&self) -> &PolicySnapshot {
+		&self.snapshot
+	}
+
+	/// Accepting stable Agent identity.
+	pub const fn accepted_by(&self) -> &AgentId {
+		&self.accepted_by
+	}
+
+	/// Database-authored Policy identity creation time.
+	pub const fn policy_created_at(&self) -> PolicyTimestamp {
+		self.policy_created_at
+	}
+
+	/// Database-authored acceptance time.
+	pub const fn accepted_at(&self) -> PolicyTimestamp {
+		self.accepted_at
+	}
+
+	/// Typed exact supersession lineage.
+	pub const fn supersedes(&self) -> Option<&PolicyRevisionId> {
+		self.supersedes.as_ref()
+	}
+}
+
+/// Closed Policy-domain validation failure without caller-controlled text.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PolicyError {
+	/// Policy identity was not one canonical UUID version 4.
+	InvalidPolicyId,
+	/// Revision was not positive.
+	InvalidRevision,
+	/// Provenance was empty, unbounded, or contained control text.
+	InvalidProvenance,
+	/// Snapshot exceeded its closed field, key, or value bounds.
+	InvalidSnapshot,
+	/// Provenance or snapshot contained credential-shaped material.
+	CredentialRejected,
+	/// Supersession did not name the exact same-Project immediate predecessor.
+	InvalidSupersession,
+	/// Stored database-authored timestamps were malformed or reversed.
+	InvalidChronology,
+}
+impl Error for PolicyError {}
+
+impl Display for PolicyError {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(match self {
+			Self::InvalidPolicyId => "invalid Policy identity",
+			Self::InvalidRevision => "invalid Policy revision",
+			Self::InvalidProvenance => "invalid Policy provenance",
+			Self::InvalidSnapshot => "invalid Policy snapshot",
+			Self::CredentialRejected => "credential-bearing Policy data rejected",
+			Self::InvalidSupersession => "invalid Policy supersession lineage",
+			Self::InvalidChronology => "invalid Policy chronology",
+		})
+	}
+}
+
+fn is_canonical_uuid_v4(value: &str) -> bool {
+	let bytes = value.as_bytes();
+
+	bytes.len() == 36
+		&& bytes[8] == b'-'
+		&& bytes[13] == b'-'
+		&& bytes[18] == b'-'
+		&& bytes[23] == b'-'
+		&& bytes[14] == b'4'
+		&& matches!(bytes[19], b'8' | b'9' | b'a' | b'b')
+		&& bytes.iter().enumerate().all(|(index, byte)| {
+			matches!(index, 8 | 13 | 18 | 23)
+				|| byte.is_ascii_digit()
+				|| matches!(byte, b'a'..=b'f')
+		})
+}
+
+#[cfg(test)]
+mod tests {
+	use std::collections::BTreeMap;
+
+	use crate::{
+		AcceptedPolicyRevision, AgentId, PolicyError, PolicyId, PolicyProvenance, PolicyRevision,
+		PolicyRevisionAcceptance, PolicyRevisionId, PolicySnapshot, PolicySnapshotValue,
+		PolicyTimestamp, ProjectId,
+	};
+
+	fn revision(number: u64) -> PolicyRevisionId {
+		PolicyRevisionId::new(
+			ProjectId::new("10000000-0000-4000-8000-000000000001").unwrap(),
+			PolicyId::new("30000000-0000-4000-8000-000000000001").unwrap(),
+			PolicyRevision::new(number).unwrap(),
+		)
+	}
+
+	fn acceptance(number: u64) -> PolicyRevisionAcceptance {
+		PolicyRevisionAcceptance {
+			id: revision(number),
+			provenance: PolicyProvenance::new("user-accepted baseline").unwrap(),
+			snapshot: PolicySnapshot::new(BTreeMap::from([
+				("note".into(), PolicySnapshotValue::Text("inert only".into())),
+				("reviewed".into(), PolicySnapshotValue::Boolean(true)),
+			]))
+			.unwrap(),
+			accepted_by: AgentId::new("20000000-0000-4000-8000-000000000001").unwrap(),
+			supersedes: (number > 1).then(|| revision(number - 1)),
+		}
+	}
+
+	#[test]
+	fn policy_ids_and_revisions_are_canonical_and_positive() {
+		for value in [
+			"",
+			"30000000-0000-4000-8000-00000000000A",
+			"30000000-0000-5000-8000-000000000001",
+			"not-a-policy-id",
+		] {
+			assert_eq!(PolicyId::new(value), Err(PolicyError::InvalidPolicyId));
+		}
+
+		assert_eq!(PolicyRevision::new(0), Err(PolicyError::InvalidRevision));
+	}
+
+	#[test]
+	fn policy_payloads_are_bounded_credential_negative_and_debug_redacted() {
+		assert_eq!(
+			PolicyProvenance::new("Bearer abcdefghijklmnop"),
+			Err(PolicyError::CredentialRejected)
+		);
+		assert_eq!(
+			PolicySnapshot::new(BTreeMap::from([(
+				"refresh_token".into(),
+				PolicySnapshotValue::Text("ordinary".into()),
+			)])),
+			Err(PolicyError::CredentialRejected)
+		);
+
+		let provenance = PolicyProvenance::new("private marker").unwrap();
+		let snapshot = PolicySnapshot::new(BTreeMap::from([(
+			"note".into(),
+			PolicySnapshotValue::Text("private marker".into()),
+		)]))
+		.unwrap();
+
+		assert!(!format!("{provenance:?}").contains("private marker"));
+		assert!(!format!("{snapshot:?}").contains("private marker"));
+	}
+
+	#[test]
+	fn supersession_is_exact_same_project_immediate_lineage() {
+		assert!(acceptance(1).validate().is_ok());
+		assert!(acceptance(2).validate().is_ok());
+
+		let mut malformed = acceptance(2);
+
+		malformed.supersedes = Some(revision(2));
+
+		assert_eq!(malformed.validate(), Err(PolicyError::InvalidSupersession));
+
+		let mut malformed = acceptance(1);
+
+		malformed.supersedes = Some(revision(1));
+
+		assert_eq!(malformed.validate(), Err(PolicyError::InvalidSupersession));
+	}
+
+	#[test]
+	fn immutable_readback_rejects_malformed_chronology() {
+		let accepted = AcceptedPolicyRevision::from_stored(
+			acceptance(1),
+			PolicyTimestamp::from_unix_microseconds(10).unwrap(),
+			PolicyTimestamp::from_unix_microseconds(11).unwrap(),
+		)
+		.unwrap();
+
+		assert_eq!(accepted.id(), &revision(1));
+		assert_eq!(accepted.supersedes(), None);
+		assert_eq!(accepted.accepted_at().unix_microseconds(), 11);
+		assert_eq!(
+			AcceptedPolicyRevision::from_stored(
+				acceptance(1),
+				PolicyTimestamp::from_unix_microseconds(11).unwrap(),
+				PolicyTimestamp::from_unix_microseconds(10).unwrap(),
+			),
+			Err(PolicyError::InvalidChronology)
+		);
+	}
+}

--- a/crates/decodex-postgres/migrations/V6__project_policy_authority.sql
+++ b/crates/decodex-postgres/migrations/V6__project_policy_authority.sql
@@ -1,0 +1,313 @@
+-- XY-1316 persists inert Project-owned policy identity and immutable accepted revisions only.
+CREATE FUNCTION decodex.is_policy_snapshot(document jsonb)
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+AS $$
+DECLARE entry record;
+DECLARE field_count bigint;
+BEGIN
+	IF pg_catalog.jsonb_typeof(document) <> 'object' THEN
+		RETURN false;
+	END IF;
+	SELECT count(*) INTO field_count FROM pg_catalog.jsonb_object_keys(document);
+	IF field_count > 32 THEN RETURN false; END IF;
+	FOR entry IN SELECT key, value FROM pg_catalog.jsonb_each(document)
+	LOOP
+		IF pg_catalog.octet_length(entry.key) NOT BETWEEN 1 AND 64
+			OR entry.key COLLATE pg_catalog."C" !~ '^[a-z][a-z0-9_]*$'
+			OR pg_catalog.jsonb_typeof(entry.value) NOT IN ('string', 'boolean')
+			OR (
+				pg_catalog.jsonb_typeof(entry.value) = 'string'
+				AND (
+					pg_catalog.octet_length(entry.value OPERATOR(pg_catalog.#>>) '{}') > 256
+					OR (entry.value OPERATOR(pg_catalog.#>>) '{}') COLLATE pg_catalog."C" ~ '[[:cntrl:]]'
+					OR (entry.value OPERATOR(pg_catalog.#>>) '{}') COLLATE pg_catalog."C" ~ U&'[\0080-\009F]'
+				)
+			)
+		THEN
+			RETURN false;
+		END IF;
+	END LOOP;
+	RETURN true;
+END
+$$;
+
+ALTER TABLE decodex.agents
+	ADD CONSTRAINT agents_id_project_unique UNIQUE (agent_id, project_id);
+
+CREATE TABLE decodex.policies (
+	policy_id uuid PRIMARY KEY,
+	project_id uuid NOT NULL REFERENCES decodex.projects(project_id) ON DELETE RESTRICT,
+	created_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	current_revision bigint CHECK (current_revision > 0),
+	CONSTRAINT policies_id_canonical_uuid_v4 CHECK (
+		policy_id::pg_catalog.text COLLATE pg_catalog."C" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	),
+	CONSTRAINT policies_identity_project_unique UNIQUE (policy_id, project_id),
+	CONSTRAINT policies_finite_timestamp CHECK (pg_catalog.isfinite(created_at))
+);
+
+CREATE TABLE decodex.policy_revisions (
+	policy_id uuid NOT NULL,
+	project_id uuid NOT NULL,
+	revision bigint NOT NULL CHECK (revision > 0),
+	provenance text NOT NULL,
+	snapshot jsonb NOT NULL,
+	accepted_by uuid NOT NULL,
+	accepted_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	supersedes_revision bigint,
+	CONSTRAINT policy_revisions_primary PRIMARY KEY (policy_id, revision),
+	CONSTRAINT policy_revisions_project_identity_unique UNIQUE (policy_id, project_id, revision),
+	CONSTRAINT policy_revisions_policy_project_fk FOREIGN KEY (policy_id, project_id)
+		REFERENCES decodex.policies(policy_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT policy_revisions_accepting_agent_project_fk FOREIGN KEY (accepted_by, project_id)
+		REFERENCES decodex.agents(agent_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT policy_revisions_supersedes_fk FOREIGN KEY (policy_id, supersedes_revision)
+		REFERENCES decodex.policy_revisions(policy_id, revision) ON DELETE RESTRICT,
+	CONSTRAINT policy_revisions_lineage CHECK (
+		(revision = 1 AND supersedes_revision IS NULL)
+		OR (revision > 1 AND supersedes_revision = revision - 1)
+	),
+	CONSTRAINT policy_revisions_provenance_bounded CHECK (
+		pg_catalog.octet_length(provenance) >= 1
+		AND pg_catalog.octet_length(provenance) <= 256
+		AND provenance COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND provenance COLLATE pg_catalog."C" !~ U&'[\0080-\009F]'
+	),
+	CONSTRAINT policy_revisions_provenance_no_credentials CHECK (
+		NOT decodex.has_credential_material(provenance)
+	),
+	CONSTRAINT policy_revisions_snapshot_bounded CHECK (decodex.is_policy_snapshot(snapshot)),
+	CONSTRAINT policy_revisions_snapshot_no_credentials CHECK (
+		NOT decodex.has_credential_material(snapshot)
+	),
+	CONSTRAINT policy_revisions_finite_timestamp CHECK (pg_catalog.isfinite(accepted_at))
+);
+
+ALTER TABLE decodex.policies
+	ADD CONSTRAINT policies_current_revision_fk
+	FOREIGN KEY (policy_id, project_id, current_revision)
+	REFERENCES decodex.policy_revisions(policy_id, project_id, revision)
+	ON DELETE RESTRICT;
+
+CREATE FUNCTION decodex.enforce_policy_identity_state()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+	IF TG_OP = 'TRUNCATE' OR TG_OP = 'DELETE' THEN
+		RAISE EXCEPTION 'Policy identities are retained'
+			USING ERRCODE = '55000', CONSTRAINT = 'policies_retained';
+	END IF;
+	IF NEW.policy_id IS DISTINCT FROM OLD.policy_id
+		OR NEW.project_id IS DISTINCT FROM OLD.project_id
+		OR NEW.created_at IS DISTINCT FROM OLD.created_at
+		OR NEW.current_revision IS NULL
+		OR NEW.current_revision IS DISTINCT FROM coalesce(OLD.current_revision, 0) + 1
+	THEN
+		RAISE EXCEPTION 'Policy identity mutation is not a legal revision advance'
+			USING ERRCODE = '23514', CONSTRAINT = 'policies_revision_advance';
+	END IF;
+	RETURN NEW;
+END
+$$;
+
+CREATE FUNCTION decodex.forbid_policy_revision_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+	RAISE EXCEPTION 'accepted Policy revisions are immutable'
+		USING ERRCODE = '55000', CONSTRAINT = 'policy_revisions_immutable';
+END
+$$;
+
+CREATE TRIGGER policies_state_guard
+BEFORE UPDATE OR DELETE ON decodex.policies
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_policy_identity_state();
+CREATE TRIGGER policies_truncate_forbidden
+BEFORE TRUNCATE ON decodex.policies
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_policy_identity_state();
+CREATE TRIGGER policy_revisions_immutable
+BEFORE UPDATE OR DELETE ON decodex.policy_revisions
+FOR EACH ROW EXECUTE FUNCTION decodex.forbid_policy_revision_mutation();
+CREATE TRIGGER policy_revisions_truncate_forbidden
+BEFORE TRUNCATE ON decodex.policy_revisions
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.forbid_policy_revision_mutation();
+
+CREATE FUNCTION decodex.create_policy(
+	p_policy_id decodex.canonical_uuid_v4_text,
+	p_project_id decodex.canonical_uuid_v4_text
+)
+RETURNS TABLE (
+	policy_id uuid, project_id uuid, created_at timestamptz, current_revision bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+CALLED ON NULL INPUT
+AS $$
+DECLARE canonical_policy_id pg_catalog.uuid;
+DECLARE canonical_project_id pg_catalog.uuid;
+DECLARE stored_project_id pg_catalog.uuid;
+BEGIN
+	IF p_policy_id IS NULL OR p_project_id IS NULL THEN
+		RAISE EXCEPTION 'identity ingress requires canonical UUID-v4 text'
+			USING ERRCODE = '23514', CONSTRAINT = 'canonical_uuid_v4_text_ingress';
+	END IF;
+	canonical_policy_id := p_policy_id::pg_catalog.text::pg_catalog.uuid;
+	canonical_project_id := p_project_id::pg_catalog.text::pg_catalog.uuid;
+	PERFORM 1 FROM decodex.projects AS project
+		WHERE project.project_id = canonical_project_id FOR KEY SHARE;
+	IF NOT FOUND THEN
+		RAISE EXCEPTION 'Policy requires an authoritative Project'
+			USING ERRCODE = '23503', CONSTRAINT = 'policies_project_id_fkey';
+	END IF;
+	INSERT INTO decodex.policies (policy_id, project_id)
+	VALUES (canonical_policy_id, canonical_project_id)
+	ON CONFLICT ON CONSTRAINT policies_pkey DO NOTHING;
+	SELECT stored.project_id INTO stored_project_id
+	FROM decodex.policies AS stored
+	WHERE stored.policy_id = canonical_policy_id
+	FOR SHARE;
+	IF stored_project_id IS DISTINCT FROM canonical_project_id THEN
+		RAISE EXCEPTION 'Policy identity is already bound to another Project'
+			USING ERRCODE = '23505', CONSTRAINT = 'policies_identity_project';
+	END IF;
+	RETURN QUERY
+	SELECT stored.policy_id, stored.project_id, stored.created_at, stored.current_revision
+	FROM decodex.policies AS stored
+	WHERE stored.policy_id = canonical_policy_id;
+END
+$$;
+
+CREATE FUNCTION decodex.accept_policy_revision(
+	p_policy_id decodex.canonical_uuid_v4_text,
+	p_project_id decodex.canonical_uuid_v4_text,
+	p_revision bigint,
+	p_provenance text,
+	p_snapshot jsonb,
+	p_accepted_by decodex.canonical_uuid_v4_text,
+	p_supersedes_revision bigint
+)
+RETURNS TABLE (
+	policy_id uuid, project_id uuid, revision bigint, provenance text, snapshot jsonb,
+	accepted_by uuid, policy_created_at timestamptz, accepted_at timestamptz,
+	supersedes_revision bigint, revision_accepted boolean, actual_revision bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+CALLED ON NULL INPUT
+AS $$
+DECLARE canonical_policy_id pg_catalog.uuid;
+DECLARE canonical_project_id pg_catalog.uuid;
+DECLARE canonical_accepting_agent_id pg_catalog.uuid;
+DECLARE policy_row decodex.policies%ROWTYPE;
+DECLARE existing decodex.policy_revisions%ROWTYPE;
+DECLARE acceptance_time pg_catalog.timestamptz;
+BEGIN
+	IF p_policy_id IS NULL OR p_project_id IS NULL OR p_accepted_by IS NULL THEN
+		RAISE EXCEPTION 'identity ingress requires canonical UUID-v4 text'
+			USING ERRCODE = '23514', CONSTRAINT = 'canonical_uuid_v4_text_ingress';
+	END IF;
+	canonical_policy_id := p_policy_id::pg_catalog.text::pg_catalog.uuid;
+	canonical_project_id := p_project_id::pg_catalog.text::pg_catalog.uuid;
+	canonical_accepting_agent_id := p_accepted_by::pg_catalog.text::pg_catalog.uuid;
+	SELECT stored.* INTO policy_row
+	FROM decodex.policies AS stored
+	WHERE stored.policy_id = canonical_policy_id
+	FOR UPDATE;
+	IF NOT FOUND THEN
+		RAISE EXCEPTION 'Policy identity does not exist'
+			USING ERRCODE = '23503', CONSTRAINT = 'policy_revisions_policy_project_fk';
+	END IF;
+	IF policy_row.project_id IS DISTINCT FROM canonical_project_id THEN
+		RAISE EXCEPTION 'Policy revision cannot attach across Projects'
+			USING ERRCODE = '23514', CONSTRAINT = 'policy_revisions_project_scope';
+	END IF;
+	SELECT stored.* INTO existing
+	FROM decodex.policy_revisions AS stored
+	WHERE stored.policy_id = canonical_policy_id AND stored.revision = p_revision;
+	IF FOUND THEN
+		IF existing.project_id = canonical_project_id
+			AND existing.provenance = p_provenance
+			AND existing.snapshot = p_snapshot
+			AND existing.accepted_by = canonical_accepting_agent_id
+			AND existing.supersedes_revision IS NOT DISTINCT FROM p_supersedes_revision
+		THEN
+			RETURN QUERY
+			SELECT existing.policy_id, existing.project_id, existing.revision,
+				existing.provenance, existing.snapshot, existing.accepted_by,
+				policy_row.created_at, existing.accepted_at, existing.supersedes_revision,
+				true, NULL::bigint;
+			RETURN;
+		END IF;
+		RAISE EXCEPTION 'Policy revision identity was reused with conflicting immutable bytes'
+			USING ERRCODE = '23505', CONSTRAINT = 'policy_revisions_conflicting_replay';
+	END IF;
+	IF p_revision IS NULL OR p_revision <= 0
+		OR p_revision IS DISTINCT FROM coalesce(policy_row.current_revision, 0) + 1
+		OR p_supersedes_revision IS DISTINCT FROM policy_row.current_revision
+	THEN
+		RETURN QUERY
+		SELECT canonical_policy_id, canonical_project_id, NULL::bigint, NULL::text,
+			NULL::jsonb, NULL::uuid, policy_row.created_at, NULL::timestamptz,
+			NULL::bigint, false, policy_row.current_revision;
+		RETURN;
+	END IF;
+	PERFORM 1 FROM decodex.projects AS project
+	WHERE project.project_id = canonical_project_id AND project.status = 'active'
+	FOR KEY SHARE;
+	IF NOT FOUND THEN
+		RAISE EXCEPTION 'Policy acceptance requires an active Project'
+			USING ERRCODE = '23514', CONSTRAINT = 'policy_revisions_active_project';
+	END IF;
+	PERFORM 1 FROM decodex.agents AS accepting_agent
+	WHERE accepting_agent.agent_id = canonical_accepting_agent_id
+		AND accepting_agent.project_id = canonical_project_id
+		AND accepting_agent.role = 'lead'
+		AND accepting_agent.status = 'active'
+	FOR KEY SHARE;
+	IF NOT FOUND THEN
+		RAISE EXCEPTION 'Policy acceptance requires the active canonical Project Lead'
+			USING ERRCODE = '23514', CONSTRAINT = 'policy_revisions_accepting_authority';
+	END IF;
+	acceptance_time := pg_catalog.clock_timestamp();
+	IF acceptance_time < policy_row.created_at THEN
+		RAISE EXCEPTION 'Policy acceptance chronology is invalid'
+			USING ERRCODE = '23514', CONSTRAINT = 'policy_revisions_chronology';
+	END IF;
+	INSERT INTO decodex.policy_revisions (
+		policy_id, project_id, revision, provenance, snapshot, accepted_by,
+		accepted_at, supersedes_revision
+	) VALUES (
+		canonical_policy_id, canonical_project_id, p_revision, p_provenance, p_snapshot,
+		canonical_accepting_agent_id, acceptance_time, p_supersedes_revision
+	);
+	UPDATE decodex.policies AS stored
+	SET current_revision = p_revision
+	WHERE stored.policy_id = canonical_policy_id;
+	RETURN QUERY
+	SELECT stored.policy_id, stored.project_id, stored.revision, stored.provenance,
+		stored.snapshot, stored.accepted_by, policy_row.created_at, stored.accepted_at,
+		stored.supersedes_revision, true, NULL::bigint
+	FROM decodex.policy_revisions AS stored
+	WHERE stored.policy_id = canonical_policy_id AND stored.revision = p_revision;
+END
+$$;
+
+ALTER FUNCTION decodex.is_policy_snapshot(jsonb) SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.enforce_policy_identity_state() SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.forbid_policy_revision_mutation() SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.create_policy(decodex.canonical_uuid_v4_text, decodex.canonical_uuid_v4_text)
+	SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.accept_policy_revision(
+	decodex.canonical_uuid_v4_text, decodex.canonical_uuid_v4_text, bigint, text, jsonb,
+	decodex.canonical_uuid_v4_text, bigint
+) SET search_path = pg_catalog, decodex;
+
+REVOKE ALL ON TABLE decodex.policies, decodex.policy_revisions FROM PUBLIC;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA decodex FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON TYPES FROM PUBLIC;

--- a/crates/decodex-postgres/src/authority.rs
+++ b/crates/decodex-postgres/src/authority.rs
@@ -8,7 +8,8 @@ use crate::StoreError;
 const FOUNDATION_MIGRATION: &str = include_str!("../migrations/V1__persistence_foundation.sql");
 const CONVERSATION_MIGRATION: &str = include_str!("../migrations/V3__conversation_history.sql");
 const PROJECT_AGENT_MIGRATION: &str = include_str!("../migrations/V5__project_agent_authority.sql");
-const FUNCTION_CONTRACTS: [FunctionContract; 38] = [
+const POLICY_MIGRATION: &str = include_str!("../migrations/V6__project_policy_authority.sql");
+const FUNCTION_CONTRACTS: [FunctionContract; 43] = [
 	FunctionContract {
 		name: "is_canonical_media_type",
 		lookup_signature: "decodex.is_canonical_media_type(pg_catalog.text)",
@@ -363,8 +364,54 @@ const FUNCTION_CONTRACTS: [FunctionContract; 38] = [
 		returns_set: true,
 		rows: 1_000.0,
 	},
+	FunctionContract {
+		name: "is_policy_snapshot",
+		lookup_signature: "decodex.is_policy_snapshot(pg_catalog.jsonb)",
+		migration_signature: "is_policy_snapshot(document jsonb)",
+		arguments: "document jsonb",
+		result: "boolean",
+		language: "plpgsql",
+		volatility: "i",
+		strict: true,
+		returns_set: false,
+		rows: 0.0,
+	},
+	trigger_contract(
+		"enforce_policy_identity_state",
+		"decodex.enforce_policy_identity_state()",
+		"enforce_policy_identity_state()",
+	),
+	trigger_contract(
+		"forbid_policy_revision_mutation",
+		"decodex.forbid_policy_revision_mutation()",
+		"forbid_policy_revision_mutation()",
+	),
+	FunctionContract {
+		name: "create_policy",
+		lookup_signature: "decodex.create_policy(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text)",
+		migration_signature: "create_policy(\n\tp_policy_id decodex.canonical_uuid_v4_text,\n\tp_project_id decodex.canonical_uuid_v4_text\n)",
+		arguments: "p_policy_id decodex.canonical_uuid_v4_text, p_project_id decodex.canonical_uuid_v4_text",
+		result: "TABLE(policy_id uuid, project_id uuid, created_at timestamp with time zone, current_revision bigint)",
+		language: "plpgsql",
+		volatility: "v",
+		strict: false,
+		returns_set: true,
+		rows: 1_000.0,
+	},
+	FunctionContract {
+		name: "accept_policy_revision",
+		lookup_signature: "decodex.accept_policy_revision(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,pg_catalog.int8)",
+		migration_signature: "accept_policy_revision(\n\tp_policy_id decodex.canonical_uuid_v4_text,\n\tp_project_id decodex.canonical_uuid_v4_text,\n\tp_revision bigint,\n\tp_provenance text,\n\tp_snapshot jsonb,\n\tp_accepted_by decodex.canonical_uuid_v4_text,\n\tp_supersedes_revision bigint\n)",
+		arguments: "p_policy_id decodex.canonical_uuid_v4_text, p_project_id decodex.canonical_uuid_v4_text, p_revision bigint, p_provenance text, p_snapshot jsonb, p_accepted_by decodex.canonical_uuid_v4_text, p_supersedes_revision bigint",
+		result: "TABLE(policy_id uuid, project_id uuid, revision bigint, provenance text, snapshot jsonb, accepted_by uuid, policy_created_at timestamp with time zone, accepted_at timestamp with time zone, supersedes_revision bigint, revision_accepted boolean, actual_revision bigint)",
+		language: "plpgsql",
+		volatility: "v",
+		strict: false,
+		returns_set: true,
+		rows: 1_000.0,
+	},
 ];
-const RUNTIME_EXECUTE_FUNCTIONS: [&str; 18] = [
+const RUNTIME_EXECUTE_FUNCTIONS: [&str; 20] = [
 	"decodex.is_canonical_media_type(pg_catalog.text)",
 	"decodex.is_history_metadata_projection(pg_catalog.jsonb)",
 	"decodex.normalize_unicode_whitespace(pg_catalog.text)",
@@ -383,8 +430,10 @@ const RUNTIME_EXECUTE_FUNCTIONS: [&str; 18] = [
 	"decodex.bootstrap_advisor(decodex.canonical_uuid_v4_text)",
 	"decodex.create_project(decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text)",
 	"decodex.transition_project(decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.project_status)",
+	"decodex.create_policy(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text)",
+	"decodex.accept_policy_revision(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,pg_catalog.int8)",
 ];
-const SAFETY_FUNCTIONS: [&str; 19] = [
+const SAFETY_FUNCTIONS: [&str; 21] = [
 	"enforce_lease_operation_time",
 	"enforce_outbox_operation_time",
 	"forbid_mutation_of_activity",
@@ -404,8 +453,10 @@ const SAFETY_FUNCTIONS: [&str; 19] = [
 	"enforce_context_pack_state",
 	"enforce_context_pack_source_state",
 	"enforce_history_cursor_state",
+	"enforce_policy_identity_state",
+	"forbid_policy_revision_mutation",
 ];
-const SAFETY_TRIGGER_COUNT: usize = 29;
+const SAFETY_TRIGGER_COUNT: usize = 33;
 // PostgreSQL 18 catalogs with an owner and a containing namespace, plus the namespace
 // itself. Namespace-scoped catalogs without an independent owner (constraints, triggers,
 // text-search parsers/templates, and dependent rows) inherit authority from one of these.
@@ -578,7 +629,9 @@ WITH set_roles AS (
   ('context_pack_sources', true, true, false, false),
   ('transition_proposals', true, true, false, false),
   ('projects', true, false, false, false),
-  ('agents', true, false, false, false)
+  ('agents', true, false, false, false),
+  ('policies', true, false, false, false),
+  ('policy_revisions', true, false, false, false)
 ), tables AS (
   SELECT class.oid, class.relname, expected.*
   FROM pg_catalog.pg_class AS class
@@ -587,7 +640,7 @@ WITH set_roles AS (
   WHERE namespace.nspname = 'decodex' AND class.relkind IN ('r', 'p')
 )
 SELECT
-  (SELECT count(*) FROM tables WHERE table_name IS NOT NULL) = 22
+  (SELECT count(*) FROM tables WHERE table_name IS NOT NULL) = 24
     AND COALESCE((
       SELECT pg_catalog.bool_and(
         pg_catalog.has_table_privilege(session_user, oid, 'SELECT') = can_select
@@ -771,7 +824,11 @@ WITH expected(table_name, trigger_name, function_name, trigger_type) AS (VALUES
   ('context_pack_sources', 'context_pack_sources_state_guard', 'enforce_context_pack_source_state', 31),
   ('context_pack_sources', 'context_pack_sources_coordinator', 'acquire_hierarchy_coordinator', 30),
   ('transition_proposals', 'transition_proposals_created_at_guard', 'canonicalize_created_at', 7),
-  ('transition_proposals', 'transition_proposals_coordinator', 'acquire_hierarchy_coordinator', 30)
+  ('transition_proposals', 'transition_proposals_coordinator', 'acquire_hierarchy_coordinator', 30),
+  ('policies', 'policies_state_guard', 'enforce_policy_identity_state', 27),
+  ('policies', 'policies_truncate_forbidden', 'enforce_policy_identity_state', 34),
+  ('policy_revisions', 'policy_revisions_immutable', 'forbid_policy_revision_mutation', 27),
+  ('policy_revisions', 'policy_revisions_truncate_forbidden', 'forbid_policy_revision_mutation', 34)
 )
 SELECT
   expected.function_name,
@@ -911,7 +968,11 @@ WITH catalog_context AS MATERIALIZED (
   ('context_pack_sources', 'context_pack_sources_state_guard', 'decodex.enforce_context_pack_source_state()'),
   ('context_pack_sources', 'context_pack_sources_coordinator', 'decodex.acquire_hierarchy_coordinator()'),
   ('transition_proposals', 'transition_proposals_created_at_guard', 'decodex.canonicalize_created_at()'),
-  ('transition_proposals', 'transition_proposals_coordinator', 'decodex.acquire_hierarchy_coordinator()')
+  ('transition_proposals', 'transition_proposals_coordinator', 'decodex.acquire_hierarchy_coordinator()'),
+  ('policies', 'policies_state_guard', 'decodex.enforce_policy_identity_state()'),
+  ('policies', 'policies_truncate_forbidden', 'decodex.enforce_policy_identity_state()'),
+  ('policy_revisions', 'policy_revisions_immutable', 'decodex.forbid_policy_revision_mutation()'),
+  ('policy_revisions', 'policy_revisions_truncate_forbidden', 'decodex.forbid_policy_revision_mutation()')
 ), actual_triggers AS (
   SELECT
     class.relname AS table_name,
@@ -1381,8 +1442,8 @@ SELECT pg_catalog.jsonb_agg(
 FROM contract_rows
 "#;
 const SCHEMA_CONTRACT_SHA256: [u8; 32] = [
-	0xec, 0x75, 0x7d, 0x18, 0x5f, 0x79, 0xcc, 0x33, 0xdc, 0x51, 0xa8, 0xde, 0x42, 0x6a, 0xb7, 0x45,
-	0x15, 0x3b, 0xb2, 0x66, 0x8d, 0xfe, 0xcd, 0x8e, 0xd0, 0x93, 0x31, 0x6b, 0x58, 0x42, 0x07, 0x88,
+	0xfa, 0xd2, 0x50, 0x40, 0x49, 0x0b, 0xda, 0x15, 0x02, 0xfb, 0xa7, 0x3a, 0x53, 0x7c, 0xc3, 0xce,
+	0x7b, 0xc8, 0x1c, 0x88, 0x1d, 0x90, 0xd6, 0x63, 0xc9, 0xc9, 0x2b, 0x4b, 0xee, 0x1d, 0x75, 0x72,
 ];
 const EXTENSION_AUTHORITY_SQL: &str = r#"
 WITH set_roles AS (
@@ -1561,9 +1622,10 @@ fn canonical_safety_function_source(function_name: &str) -> Option<&'static str>
 
 fn canonical_function_source(contract: &FunctionContract) -> Option<&'static str> {
 	let declaration = format!("CREATE FUNCTION decodex.{}", contract.migration_signature);
-	let migration = [FOUNDATION_MIGRATION, CONVERSATION_MIGRATION, PROJECT_AGENT_MIGRATION]
-		.into_iter()
-		.find(|migration| migration.contains(&declaration))?;
+	let migration =
+		[FOUNDATION_MIGRATION, CONVERSATION_MIGRATION, PROJECT_AGENT_MIGRATION, POLICY_MIGRATION]
+			.into_iter()
+			.find(|migration| migration.contains(&declaration))?;
 	let (_, declaration_and_tail) = migration.split_once(&declaration)?;
 	let (_, source_and_tail) = declaration_and_tail.split_once("\nAS $$")?;
 	let (source, _) = source_and_tail.split_once("$$;")?;
@@ -1676,6 +1738,8 @@ async fn verify_function_contract(client: &Client) -> Result<(), StoreError> {
 				| "bootstrap_advisor"
 				| "create_project"
 				| "transition_project"
+				| "create_policy"
+				| "accept_policy_revision"
 		);
 		let expected_executable = RUNTIME_EXECUTE_FUNCTIONS.contains(&contract.lookup_signature);
 		let expected_settings = vec!["search_path=pg_catalog, decodex".to_owned()];
@@ -1828,8 +1892,9 @@ mod tests {
 
 	use crate::authority::{
 		CONVERSATION_MIGRATION, FOUNDATION_MIGRATION, FUNCTION_CONTRACTS,
-		IDENTITY_CAST_AUTHORITY_SQL, OWNED_OBJECT_CATALOGS, PROJECT_AGENT_MIGRATION,
-		ROLE_AUTHORITY_SQL, SAFETY_FUNCTIONS, SCHEMA_CONTRACT_SHA256, SCHEMA_CONTRACT_SQL,
+		IDENTITY_CAST_AUTHORITY_SQL, OWNED_OBJECT_CATALOGS, POLICY_MIGRATION,
+		PROJECT_AGENT_MIGRATION, ROLE_AUTHORITY_SQL, SAFETY_FUNCTIONS, SCHEMA_CONTRACT_SHA256,
+		SCHEMA_CONTRACT_SQL,
 	};
 
 	#[test]
@@ -1876,10 +1941,15 @@ mod tests {
 	#[test]
 	fn canonical_inventory_covers_every_shipped_decodex_function_once() {
 		assert_eq!(
-			[FOUNDATION_MIGRATION, CONVERSATION_MIGRATION, PROJECT_AGENT_MIGRATION]
-				.into_iter()
-				.map(|migration| migration.matches("CREATE FUNCTION decodex.").count())
-				.sum::<usize>(),
+			[
+				FOUNDATION_MIGRATION,
+				CONVERSATION_MIGRATION,
+				PROJECT_AGENT_MIGRATION,
+				POLICY_MIGRATION,
+			]
+			.into_iter()
+			.map(|migration| migration.matches("CREATE FUNCTION decodex.").count())
+			.sum::<usize>(),
 			FUNCTION_CONTRACTS.len()
 		);
 
@@ -1888,15 +1958,17 @@ mod tests {
 		for contract in FUNCTION_CONTRACTS {
 			assert!(lookup_signatures.insert(contract.lookup_signature));
 			assert_eq!(
-				[FOUNDATION_MIGRATION, CONVERSATION_MIGRATION, PROJECT_AGENT_MIGRATION]
-					.into_iter()
-					.map(|migration| migration
-						.matches(&format!(
-							"CREATE FUNCTION decodex.{}",
-							contract.migration_signature
-						))
-						.count())
-					.sum::<usize>(),
+				[
+					FOUNDATION_MIGRATION,
+					CONVERSATION_MIGRATION,
+					PROJECT_AGENT_MIGRATION,
+					POLICY_MIGRATION,
+				]
+				.into_iter()
+				.map(|migration| migration
+					.matches(&format!("CREATE FUNCTION decodex.{}", contract.migration_signature))
+					.count())
+				.sum::<usize>(),
 				1
 			);
 
@@ -1911,7 +1983,13 @@ mod tests {
 
 	#[test]
 	fn identity_mutators_share_one_first_statement_null_guard_and_cast_audit() {
-		for name in ["bootstrap_advisor", "create_project", "transition_project"] {
+		for name in [
+			"bootstrap_advisor",
+			"create_project",
+			"transition_project",
+			"create_policy",
+			"accept_policy_revision",
+		] {
 			let contract = FUNCTION_CONTRACTS
 				.iter()
 				.find(|contract| contract.name == name)

--- a/crates/decodex-postgres/src/lib.rs
+++ b/crates/decodex-postgres/src/lib.rs
@@ -13,6 +13,7 @@ mod error;
 mod leases;
 mod migrations;
 mod outbox;
+mod policies;
 mod project_agents;
 #[cfg(unix)] mod socket;
 mod types;
@@ -32,7 +33,9 @@ pub use self::{
 	},
 };
 pub use decodex_core::{
-	AccountId, AccountState, Agent, AgentId, AgentRole, AgentStatus, Project, ProjectAuthority,
+	AcceptedPolicyRevision, AccountId, AccountState, Agent, AgentId, AgentRole, AgentStatus,
+	Policy, PolicyId, PolicyProvenance, PolicyRevision, PolicyRevisionAcceptance, PolicyRevisionId,
+	PolicySnapshot, PolicySnapshotValue, PolicyStatus, PolicyTimestamp, Project, ProjectAuthority,
 	ProjectId, ProjectMetadata, ProjectMetadataValue, ProjectRepositoryBinding, ProjectStatus,
 	RepositoryIdentity,
 };

--- a/crates/decodex-postgres/src/migrations.rs
+++ b/crates/decodex-postgres/src/migrations.rs
@@ -7,7 +7,7 @@ use deadpool_postgres::Client;
 use crate::{REQUIRED_POSTGRES_MAJOR, StoreError};
 use embedded::migrations;
 
-const EXPECTED_LATEST_MIGRATION_VERSION: i32 = 5;
+const EXPECTED_LATEST_MIGRATION_VERSION: i32 = 6;
 
 pub(crate) async fn run(client: &mut Client) -> Result<(), StoreError> {
 	migrations::runner().run_async(&mut ***client).await?;
@@ -58,7 +58,7 @@ pub(crate) async fn verify(client: &Client) -> Result<(), StoreError> {
 		!= Some(EXPECTED_LATEST_MIGRATION_VERSION)
 	{
 		return Err(StoreError::Incompatible(
-			"embedded migration inventory does not end at the canonical V5 ledger".into(),
+			"embedded migration inventory does not end at the canonical V6 ledger".into(),
 		));
 	}
 	if actual.len() != expected.len() {

--- a/crates/decodex-postgres/src/policies.rs
+++ b/crates/decodex-postgres/src/policies.rs
@@ -1,0 +1,294 @@
+use std::{collections::BTreeMap, fmt::Display};
+
+use serde_json::{Map, Value};
+use tokio_postgres::{Error, Row, error::DbError};
+
+use crate::{PostgresStore, StoreError};
+use decodex_core::{
+	AcceptedPolicyRevision, AgentId, Policy, PolicyId, PolicyProvenance, PolicyRepository,
+	PolicyRevision, PolicyRevisionAcceptance, PolicyRevisionId, PolicySnapshot,
+	PolicySnapshotValue, PolicyTimestamp, ProjectId,
+};
+
+impl PostgresStore {
+	/// Idempotently create one Project-owned inert Policy identity.
+	pub async fn create_policy(
+		&self,
+		id: PolicyId,
+		project_id: ProjectId,
+	) -> Result<Policy, StoreError> {
+		let client = crate::checkout(self.pool(), &self.connector).await?;
+		let row = client
+			.query_one(
+				"SELECT policy_id::text,project_id::text,\
+				 (EXTRACT(EPOCH FROM created_at)*1000000)::bigint,current_revision \
+				 FROM decodex.create_policy(\
+				 $1::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+				 $2::pg_catalog.text::decodex.canonical_uuid_v4_text)",
+				&[&id.as_str(), &project_id.as_str()],
+			)
+			.await
+			.map_err(policy_database_error)?;
+
+		decode_policy(&row)
+	}
+
+	/// Accept one exact immutable Policy revision under database-verified Lead authority.
+	pub async fn accept_policy_revision(
+		&self,
+		acceptance: PolicyRevisionAcceptance,
+	) -> Result<AcceptedPolicyRevision, StoreError> {
+		acceptance.validate().map_err(|_| {
+			StoreError::InvalidInput("Policy acceptance requires exact immediate supersession")
+		})?;
+
+		let revision = i64::try_from(acceptance.id.revision().get())
+			.map_err(|_| StoreError::InvalidInput("Policy revision exceeds PostgreSQL bigint"))?;
+		let supersedes_revision = acceptance
+			.supersedes
+			.as_ref()
+			.map(|id| i64::try_from(id.revision().get()))
+			.transpose()
+			.map_err(|_| StoreError::InvalidInput("Policy revision exceeds PostgreSQL bigint"))?;
+		let snapshot = encode_snapshot(&acceptance.snapshot);
+
+		crate::ensure_credential_negative_text(acceptance.provenance.as_str())?;
+		crate::ensure_credential_negative_json(&snapshot)?;
+
+		let mut client = crate::checkout(self.pool(), &self.connector).await?;
+		let transaction = client.transaction().await?;
+		let row = transaction
+			.query_one(
+				"SELECT policy_id::text,project_id::text,revision,provenance,snapshot,\
+				 accepted_by::text,(EXTRACT(EPOCH FROM policy_created_at)*1000000)::bigint,\
+				 (EXTRACT(EPOCH FROM accepted_at)*1000000)::bigint,supersedes_revision,\
+				 revision_accepted,actual_revision \
+				 FROM decodex.accept_policy_revision(\
+				 $1::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+				 $2::pg_catalog.text::decodex.canonical_uuid_v4_text,$3,$4,$5,\
+				 $6::pg_catalog.text::decodex.canonical_uuid_v4_text,$7)",
+				&[
+					&acceptance.id.policy_id().as_str(),
+					&acceptance.id.project_id().as_str(),
+					&revision,
+					&acceptance.provenance.as_str(),
+					&snapshot,
+					&acceptance.accepted_by.as_str(),
+					&supersedes_revision,
+				],
+			)
+			.await
+			.map_err(policy_acceptance_database_error)?;
+		let revision_accepted: bool = row.get(9);
+
+		if !revision_accepted {
+			let conflict = StoreError::RevisionConflict {
+				entity: acceptance.id.policy_id().to_string(),
+				expected: Some(revision),
+				actual: row.get(10),
+			};
+
+			transaction.rollback().await?;
+
+			return Err(conflict);
+		}
+
+		let accepted = decode_accepted_revision(&row)?;
+
+		transaction.commit().await?;
+
+		Ok(accepted)
+	}
+
+	/// Read one exact immutable Project-owned Policy revision.
+	pub async fn policy_revision(
+		&self,
+		id: &PolicyRevisionId,
+	) -> Result<Option<AcceptedPolicyRevision>, StoreError> {
+		let revision = i64::try_from(id.revision().get())
+			.map_err(|_| StoreError::InvalidInput("Policy revision exceeds PostgreSQL bigint"))?;
+		let client = crate::checkout(self.pool(), &self.connector).await?;
+		let row = client
+			.query_opt(
+				"SELECT revision.policy_id::text,revision.project_id::text,revision.revision,\
+				 revision.provenance,revision.snapshot,revision.accepted_by::text,\
+				 (EXTRACT(EPOCH FROM policy.created_at)*1000000)::bigint,\
+				 (EXTRACT(EPOCH FROM revision.accepted_at)*1000000)::bigint,\
+				 revision.supersedes_revision \
+				 FROM decodex.policy_revisions AS revision \
+				 JOIN decodex.policies AS policy ON policy.policy_id=revision.policy_id \
+				 WHERE revision.project_id=$1::text::uuid AND revision.policy_id=$2::text::uuid \
+				 AND revision.revision=$3",
+				&[&id.project_id().as_str(), &id.policy_id().as_str(), &revision],
+			)
+			.await?;
+
+		row.as_ref().map(decode_accepted_revision).transpose()
+	}
+
+	/// List Policy identities for one Project in stable identity order.
+	pub async fn policies_for_project(
+		&self,
+		project_id: &ProjectId,
+	) -> Result<Vec<Policy>, StoreError> {
+		let client = crate::checkout(self.pool(), &self.connector).await?;
+		let rows = client
+			.query(
+				"SELECT policy_id::text,project_id::text,\
+				 (EXTRACT(EPOCH FROM created_at)*1000000)::bigint,current_revision \
+				 FROM decodex.policies WHERE project_id=$1::text::uuid ORDER BY policy_id",
+				&[&project_id.as_str()],
+			)
+			.await?;
+
+		rows.iter().map(decode_policy).collect()
+	}
+}
+
+impl PolicyRepository for PostgresStore {
+	type Error = StoreError;
+
+	async fn create_policy(
+		&self,
+		id: PolicyId,
+		project_id: ProjectId,
+	) -> Result<Policy, Self::Error> {
+		Self::create_policy(self, id, project_id).await
+	}
+
+	async fn accept_policy_revision(
+		&self,
+		acceptance: PolicyRevisionAcceptance,
+	) -> Result<AcceptedPolicyRevision, Self::Error> {
+		Self::accept_policy_revision(self, acceptance).await
+	}
+
+	async fn policy_revision(
+		&self,
+		id: &PolicyRevisionId,
+	) -> Result<Option<AcceptedPolicyRevision>, Self::Error> {
+		Self::policy_revision(self, id).await
+	}
+
+	async fn policies_for_project(
+		&self,
+		project_id: &ProjectId,
+	) -> Result<Vec<Policy>, Self::Error> {
+		Self::policies_for_project(self, project_id).await
+	}
+}
+
+fn decode_policy(row: &Row) -> Result<Policy, StoreError> {
+	let current_revision = row
+		.get::<_, Option<i64>>(3)
+		.map(|value| {
+			u64::try_from(value)
+				.map_err(|_| incompatible())
+				.and_then(|value| PolicyRevision::new(value).map_err(incompatible_core))
+		})
+		.transpose()?;
+
+	Ok(Policy::from_stored(
+		PolicyId::new(row.get::<_, String>(0)).map_err(incompatible_core)?,
+		ProjectId::new(row.get::<_, String>(1)).map_err(incompatible_core)?,
+		PolicyTimestamp::from_unix_microseconds(row.get(2)).map_err(incompatible_core)?,
+		current_revision,
+	))
+}
+
+fn decode_accepted_revision(row: &Row) -> Result<AcceptedPolicyRevision, StoreError> {
+	let project_id = ProjectId::new(row.get::<_, String>(1)).map_err(incompatible_core)?;
+	let policy_id = PolicyId::new(row.get::<_, String>(0)).map_err(incompatible_core)?;
+	let revision =
+		PolicyRevision::new(u64::try_from(row.get::<_, i64>(2)).map_err(|_| incompatible())?)
+			.map_err(incompatible_core)?;
+	let supersedes = row
+		.get::<_, Option<i64>>(8)
+		.map(|value| {
+			let revision = PolicyRevision::new(u64::try_from(value).map_err(|_| incompatible())?)
+				.map_err(incompatible_core)?;
+
+			Ok::<_, StoreError>(PolicyRevisionId::new(
+				project_id.clone(),
+				policy_id.clone(),
+				revision,
+			))
+		})
+		.transpose()?;
+	let acceptance = PolicyRevisionAcceptance {
+		id: PolicyRevisionId::new(project_id, policy_id, revision),
+		provenance: PolicyProvenance::new(row.get::<_, String>(3)).map_err(incompatible_core)?,
+		snapshot: decode_snapshot(row.get(4))?,
+		accepted_by: AgentId::new(row.get::<_, String>(5)).map_err(incompatible_core)?,
+		supersedes,
+	};
+
+	AcceptedPolicyRevision::from_stored(
+		acceptance,
+		PolicyTimestamp::from_unix_microseconds(row.get(6)).map_err(incompatible_core)?,
+		PolicyTimestamp::from_unix_microseconds(row.get(7)).map_err(incompatible_core)?,
+	)
+	.map_err(incompatible_core)
+}
+
+fn encode_snapshot(snapshot: &PolicySnapshot) -> Value {
+	Value::Object(
+		snapshot
+			.as_map()
+			.iter()
+			.map(|(key, value)| {
+				let value = match value {
+					PolicySnapshotValue::Text(value) => Value::String(value.clone()),
+					PolicySnapshotValue::Boolean(value) => Value::Bool(*value),
+				};
+
+				(key.clone(), value)
+			})
+			.collect::<Map<_, _>>(),
+	)
+}
+
+fn decode_snapshot(value: Value) -> Result<PolicySnapshot, StoreError> {
+	let Value::Object(value) = value else { return Err(incompatible()) };
+	let values = value
+		.into_iter()
+		.map(|(key, value)| {
+			let value = match value {
+				Value::String(value) => PolicySnapshotValue::Text(value),
+				Value::Bool(value) => PolicySnapshotValue::Boolean(value),
+				_ => return Err(incompatible()),
+			};
+
+			Ok((key, value))
+		})
+		.collect::<Result<BTreeMap<_, _>, StoreError>>()?;
+
+	PolicySnapshot::new(values).map_err(incompatible_core)
+}
+
+fn incompatible_core(error: impl Display) -> StoreError {
+	StoreError::Incompatible(format!("invalid stored Project policy authority: {error}"))
+}
+
+fn incompatible() -> StoreError {
+	StoreError::Incompatible("invalid stored Project policy authority".into())
+}
+
+fn policy_database_error(error: Error) -> StoreError {
+	match error.as_db_error().and_then(DbError::constraint) {
+		Some("policies_identity_project") =>
+			StoreError::InvalidInput("Policy identity is already bound to another Project"),
+		_ => StoreError::from(error),
+	}
+}
+
+fn policy_acceptance_database_error(error: Error) -> StoreError {
+	match error.as_db_error().and_then(DbError::constraint) {
+		Some("policy_revisions_conflicting_replay") => StoreError::IdempotencyConflict,
+		Some("policy_revisions_project_scope") =>
+			StoreError::InvalidInput("Policy revision cannot attach across Projects"),
+		Some("policy_revisions_accepting_authority") | Some("policy_revisions_active_project") =>
+			StoreError::InvalidInput("Policy acceptance requires active Project Lead authority"),
+		_ => StoreError::from(error),
+	}
+}

--- a/crates/decodex-postgres/tests/postgres_store.rs
+++ b/crates/decodex-postgres/tests/postgres_store.rs
@@ -22,13 +22,15 @@ use tokio::{
 use tokio_postgres::{Client, Config, NoTls, types::ToSql};
 
 use decodex_core::{
-	self, AccountSnapshot, ArtifactId, ArtifactStatus, Availability, BlobHash, BlobStore,
-	ContextPack, ContextPackInput, ContextPackPolicy, ContextPackSource, ContextSourceKind,
-	ConversationId, DecodexRoot, HistoryItemId, HistoryItemKind, HistoryMediaType, HistoryMetadata,
-	HistoryMetadataValue, ItemStatus, PinnedContextSource, PossibleSideEffects, ProductState as _,
-	ProfileSnapshot, Project, ProjectId, ProjectMetadata, ProjectMetadataValue,
-	ProjectRepositoryBinding, ProjectStatus, ProposedTransitionKind, RepositoryIdentity,
-	RuntimeSessionId, RuntimeSessionState, TurnId, TurnRole, TurnStatus,
+	self, AcceptedPolicyRevision, AccountSnapshot, ArtifactId, ArtifactStatus, Availability,
+	BlobHash, BlobStore, ContextPack, ContextPackInput, ContextPackPolicy, ContextPackSource,
+	ContextSourceKind, ConversationId, DecodexRoot, HistoryItemId, HistoryItemKind,
+	HistoryMediaType, HistoryMetadata, HistoryMetadataValue, ItemStatus, PinnedContextSource,
+	PolicyId, PolicyProvenance, PolicyRevision, PolicyRevisionAcceptance, PolicyRevisionId,
+	PolicySnapshot, PolicySnapshotValue, PossibleSideEffects, ProductState as _, ProfileSnapshot,
+	Project, ProjectId, ProjectMetadata, ProjectMetadataValue, ProjectRepositoryBinding,
+	ProjectStatus, ProposedTransitionKind, RepositoryIdentity, RuntimeSessionId,
+	RuntimeSessionState, TurnId, TurnRole, TurnStatus,
 };
 use decodex_postgres::{
 	AccountId, AccountMutation, AccountState, Agent, AgentId, AgentRole, AgentStatus, CLOSED,
@@ -83,6 +85,8 @@ const RUNTIME_EXECUTE_SIGNATURES: &[&str] = &[
 	"decodex.bootstrap_advisor(decodex.canonical_uuid_v4_text)",
 	"decodex.create_project(decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text)",
 	"decodex.transition_project(decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.project_status)",
+	"decodex.create_policy(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text)",
+	"decodex.accept_policy_revision(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,pg_catalog.int8)",
 ];
 const TRIGGER_ONLY_SIGNATURES: &[&str] = &[
 	"decodex.enforce_lease_operation_time()",
@@ -104,6 +108,8 @@ const TRIGGER_ONLY_SIGNATURES: &[&str] = &[
 	"decodex.enforce_context_pack_state()",
 	"decodex.enforce_context_pack_source_state()",
 	"decodex.enforce_history_cursor_state()",
+	"decodex.enforce_policy_identity_state()",
+	"decodex.forbid_policy_revision_mutation()",
 ];
 const INVALID_PROJECT_AGENT_SQL_CALLS: &[(&str, &str)] = &[
 	(
@@ -250,6 +256,37 @@ fn project_request(
 	CreateProject { project, lead }
 }
 
+fn policy_acceptance(
+	project_id: &ProjectId,
+	policy_id: &PolicyId,
+	accepted_by: &AgentId,
+	revision: u64,
+	marker: &str,
+) -> PolicyRevisionAcceptance {
+	let revision_number = PolicyRevision::new(revision).expect("Policy revision is positive");
+	let id = PolicyRevisionId::new(project_id.clone(), policy_id.clone(), revision_number);
+	let supersedes = revision.checked_sub(1).filter(|value| *value > 0).map(|previous| {
+		PolicyRevisionId::new(
+			project_id.clone(),
+			policy_id.clone(),
+			PolicyRevision::new(previous).expect("previous Policy revision is positive"),
+		)
+	});
+
+	PolicyRevisionAcceptance {
+		id,
+		provenance: PolicyProvenance::new(format!("accepted fixture {marker}"))
+			.expect("Policy provenance is bounded"),
+		snapshot: PolicySnapshot::new(BTreeMap::from([
+			("marker".into(), PolicySnapshotValue::Text(marker.into())),
+			("reviewed".into(), PolicySnapshotValue::Boolean(true)),
+		]))
+		.expect("Policy snapshot is bounded"),
+		accepted_by: accepted_by.clone(),
+		supersedes,
+	}
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires the isolated PostgreSQL 18 migration harness"]
 async fn postgres_migration_contract() -> Result<(), Box<dyn std::error::Error>> {
@@ -276,6 +313,7 @@ async fn postgres_store_contract() -> Result<(), Box<dyn std::error::Error>> {
 	assert_bootstrap_and_history(&client).await?;
 	assert_runtime_is_least_privilege(&runtime_client).await?;
 	assert_project_agent_authority(&store, &client, &migration, &runtime).await?;
+	assert_policy_authority(&store, &client, &migration, &runtime).await?;
 	assert_account_idempotency_and_revision(&store, &client).await?;
 	assert_receipt_first_saga(&store, &client).await?;
 	assert_concurrent_shard_capacity(&store, &client).await?;
@@ -1730,6 +1768,10 @@ async fn assert_runtime_is_least_privilege(
 		 ('10000000-0000-4000-8000-000000000099','forbidden/project','/srv/forbidden','/srv/forbidden')",
 		"INSERT INTO decodex.agents (agent_id,role) VALUES \
 		 ('20000000-0000-4000-8000-000000000099','advisor')",
+		"INSERT INTO decodex.policies (policy_id,project_id) VALUES \
+		 ('31000000-0000-4000-8000-000000000099',\
+		  '11000000-0000-4000-8000-000000000050')",
+		"UPDATE decodex.policy_revisions SET provenance='forbidden' WHERE revision=1",
 	] {
 		let error = client
 			.batch_execute(statement)
@@ -1821,6 +1863,8 @@ async fn postgres_store_restored_contract() -> Result<(), Box<dyn std::error::Er
 
 	assert!(restored_fk);
 
+	assert_restored_policy_authority(&store).await?;
+
 	let ordinary_rows: i64 = client
 		.query_one(
 			"SELECT (SELECT count(*) FROM decodex.accounts) \
@@ -1841,6 +1885,33 @@ async fn postgres_store_restored_contract() -> Result<(), Box<dyn std::error::Er
 	drop(client);
 
 	connection_task.await??;
+
+	Ok(())
+}
+
+async fn assert_restored_policy_authority(
+	store: &PostgresStore,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let policy_id = PolicyId::new("31000000-0000-4000-8000-000000000001")?;
+	let project_id = ProjectId::new("11000000-0000-4000-8000-000000000050")?;
+	let policies = store.policies_for_project(&project_id).await?;
+	let first_id =
+		PolicyRevisionId::new(project_id.clone(), policy_id.clone(), PolicyRevision::new(1)?);
+	let second_id = PolicyRevisionId::new(project_id, policy_id.clone(), PolicyRevision::new(2)?);
+	let first = store.policy_revision(&first_id).await?.expect("revision one restored");
+	let second = store.policy_revision(&second_id).await?.expect("revision two restored");
+
+	assert_eq!(policies.len(), 1);
+	assert_eq!(policies[0].id(), &policy_id);
+	assert_eq!(policies[0].current_revision(), Some(PolicyRevision::new(2)?));
+	assert_eq!(first.supersedes(), None);
+	assert_eq!(second.supersedes(), Some(first.id()));
+	assert!(
+		[&first, &second]
+			.into_iter()
+			.all(|revision| revision.accepted_at() >= revision.policy_created_at())
+	);
+	assert_eq!(store.policy_revision(&second_id).await?, Some(second));
 
 	Ok(())
 }
@@ -1950,7 +2021,7 @@ async fn assert_bootstrap_and_history(client: &Client) -> Result<(), Box<dyn std
 
 	assert_eq!(version, 18);
 	assert_eq!(checksums, "on");
-	assert_eq!(history.len(), 5);
+	assert_eq!(history.len(), 6);
 	assert_eq!(history[0].0, 1);
 	assert_eq!(history[0].1, "persistence_foundation");
 	assert!(!history[0].2.is_empty());
@@ -1966,6 +2037,9 @@ async fn assert_bootstrap_and_history(client: &Client) -> Result<(), Box<dyn std
 	assert_eq!(history[4].0, 5);
 	assert_eq!(history[4].1, "project_agent_authority");
 	assert!(!history[4].2.is_empty());
+	assert_eq!(history[5].0, 6);
+	assert_eq!(history[5].1, "project_policy_authority");
+	assert!(!history[5].2.is_empty());
 
 	let (migration, runtime) = separated_configs("DECODEX_TEST")?;
 
@@ -2105,6 +2179,247 @@ async fn assert_project_agent_authority(
 
 	assert_eq!(restarted.project(paused.project.id()).await?, Some(paused));
 	assert_eq!(restarted.advisor().await?, store.advisor().await?);
+
+	Ok(())
+}
+
+async fn assert_policy_authority(
+	store: &PostgresStore,
+	client: &Client,
+	migration: &Config,
+	runtime: &Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let primary = project_request(
+		"11000000-0000-4000-8000-000000000050",
+		"22000000-0000-4000-8000-000000000050",
+		"hack-ink/policy-authority-a",
+		"/srv/repos/policy-authority-a",
+	);
+	let secondary = project_request(
+		"11000000-0000-4000-8000-000000000051",
+		"22000000-0000-4000-8000-000000000051",
+		"hack-ink/policy-authority-b",
+		"/srv/repos/policy-authority-b",
+	);
+	let primary_authority = store.create_project(primary).await?;
+	let secondary_authority = store.create_project(secondary).await?;
+	let project_id = primary_authority.project.id().clone();
+	let lead_id = primary_authority.lead.id().clone();
+	let policy_id = PolicyId::new("31000000-0000-4000-8000-000000000001")?;
+	let policy = store.create_policy(policy_id.clone(), project_id.clone()).await?;
+
+	assert_eq!(policy.id(), &policy_id);
+	assert_eq!(policy.project_id(), &project_id);
+	assert_eq!(policy.current_revision(), None);
+	assert_eq!(policy.status(), decodex_core::PolicyStatus::Unaccepted);
+	assert_eq!(store.policies_for_project(&project_id).await?, vec![policy.clone()]);
+	assert_eq!(store.create_policy(policy_id.clone(), project_id.clone()).await?, policy,);
+	assert!(matches!(
+		store.create_policy(policy_id.clone(), secondary_authority.project.id().clone()).await,
+		Err(StoreError::InvalidInput("Policy identity is already bound to another Project"))
+	));
+
+	let first_request = policy_acceptance(&project_id, &policy_id, &lead_id, 1, "first");
+	let first = store.accept_policy_revision(first_request.clone()).await?;
+
+	assert_eq!(first.id(), &first_request.id);
+	assert_eq!(first.supersedes(), None);
+	assert!(first.accepted_at() >= first.policy_created_at());
+	assert_eq!(store.accept_policy_revision(first_request.clone()).await?, first);
+
+	let mut conflicting_first = first_request;
+
+	conflicting_first.provenance = PolicyProvenance::new("accepted fixture conflicting")?;
+
+	assert!(matches!(
+		store.accept_policy_revision(conflicting_first).await,
+		Err(StoreError::IdempotencyConflict)
+	));
+
+	let cross_project = policy_acceptance(
+		secondary_authority.project.id(),
+		&policy_id,
+		secondary_authority.lead.id(),
+		2,
+		"cross-project",
+	);
+
+	assert!(matches!(
+		store.accept_policy_revision(cross_project).await,
+		Err(StoreError::InvalidInput("Policy revision cannot attach across Projects"))
+	));
+
+	let wrong_authority = policy_acceptance(
+		&project_id,
+		&policy_id,
+		secondary_authority.lead.id(),
+		2,
+		"wrong-authority",
+	);
+
+	assert!(matches!(
+		store.accept_policy_revision(wrong_authority).await,
+		Err(StoreError::InvalidInput("Policy acceptance requires active Project Lead authority"))
+	));
+
+	let (winner_request, winner_revision) = accept_concurrent_policy_revision(
+		store,
+		[
+			policy_acceptance(&project_id, &policy_id, &lead_id, 2, "candidate-a"),
+			policy_acceptance(&project_id, &policy_id, &lead_id, 2, "candidate-b"),
+		],
+	)
+	.await?;
+
+	assert_eq!(store.accept_policy_revision(winner_request.clone()).await?, winner_revision);
+	assert_eq!(store.policy_revision(winner_revision.id()).await?, Some(winner_revision.clone()));
+	assert_policy_revision_conflicts(
+		store,
+		client,
+		&project_id,
+		&policy_id,
+		&lead_id,
+		&winner_request,
+		&winner_revision,
+	)
+	.await?;
+
+	let listed = store.policies_for_project(&project_id).await?;
+
+	assert_eq!(listed.len(), 1);
+	assert_eq!(listed[0].id(), &policy_id);
+	assert_eq!(listed[0].current_revision(), Some(PolicyRevision::new(2)?));
+	assert_eq!(listed[0].status(), decodex_core::PolicyStatus::Accepted);
+	assert!(store.policies_for_project(secondary_authority.project.id()).await?.is_empty());
+
+	assert_policy_database_guards(store, client, &project_id, &policy_id, &lead_id).await?;
+
+	let restarted =
+		PostgresStore::connect(migration.clone(), runtime.clone(), expected_peer_uid()).await?;
+
+	assert_eq!(restarted.policy_revision(winner_revision.id()).await?, Some(winner_revision));
+
+	Ok(())
+}
+
+async fn assert_policy_revision_conflicts(
+	store: &PostgresStore,
+	client: &Client,
+	project_id: &ProjectId,
+	policy_id: &PolicyId,
+	lead_id: &AgentId,
+	winner_request: &PolicyRevisionAcceptance,
+	winner_revision: &AcceptedPolicyRevision,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let stale = client
+		.query_one(
+			"SELECT revision_accepted,actual_revision \
+			 FROM decodex.accept_policy_revision(\
+			 $1::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+			 $2::pg_catalog.text::decodex.canonical_uuid_v4_text,3,'stale','{}'::jsonb,\
+			 $3::pg_catalog.text::decodex.canonical_uuid_v4_text,1)",
+			&[&policy_id.as_str(), &project_id.as_str(), &lead_id.as_str()],
+		)
+		.await?;
+
+	assert!(!stale.get::<_, bool>(0));
+	assert_eq!(stale.get::<_, Option<i64>>(1), Some(2));
+
+	let gapped_request = policy_acceptance(project_id, policy_id, lead_id, 4, "gapped");
+
+	assert!(matches!(
+		store.accept_policy_revision(gapped_request).await,
+		Err(StoreError::RevisionConflict {
+			ref entity,
+			expected: Some(4),
+			actual: Some(2),
+		}) if entity == policy_id.as_str()
+	));
+	assert_eq!(store.policy_revision(winner_revision.id()).await?, Some(winner_revision.clone()));
+	assert_eq!(
+		store.accept_policy_revision(winner_request.clone()).await?,
+		winner_revision.clone()
+	);
+
+	Ok(())
+}
+
+async fn accept_concurrent_policy_revision(
+	store: &PostgresStore,
+	candidates: [PolicyRevisionAcceptance; 2],
+) -> Result<(PolicyRevisionAcceptance, AcceptedPolicyRevision), Box<dyn std::error::Error>> {
+	let mut tasks = JoinSet::new();
+
+	for candidate in candidates {
+		let store = store.clone();
+
+		tasks.spawn(async move {
+			let result = store.accept_policy_revision(candidate.clone()).await;
+
+			(candidate, result)
+		});
+	}
+
+	let mut winner = None;
+	let mut conflicts = 0;
+
+	while let Some(result) = tasks.join_next().await {
+		let (candidate, result) = result?;
+
+		match result {
+			Ok(accepted) => winner = Some((candidate, accepted)),
+			Err(StoreError::IdempotencyConflict) => conflicts += 1,
+			Err(error) => return Err(error.into()),
+		}
+	}
+
+	let (winner_request, winner_revision) = winner.expect("one concurrent acceptance wins");
+
+	assert_eq!(conflicts, 1);
+
+	Ok((winner_request, winner_revision))
+}
+
+async fn assert_policy_database_guards(
+	store: &PostgresStore,
+	client: &Client,
+	project_id: &ProjectId,
+	policy_id: &PolicyId,
+	lead_id: &AgentId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	for statement in [
+		"UPDATE decodex.policy_revisions SET provenance='changed' \
+		 WHERE policy_id='31000000-0000-4000-8000-000000000001' AND revision=1",
+		"DELETE FROM decodex.policy_revisions \
+		 WHERE policy_id='31000000-0000-4000-8000-000000000001' AND revision=1",
+		"UPDATE decodex.policies SET created_at=created_at+interval '1 second' \
+		 WHERE policy_id='31000000-0000-4000-8000-000000000001'",
+	] {
+		client
+			.batch_execute(statement)
+			.await
+			.expect_err("accepted Policy authority rejects retroactive mutation");
+	}
+
+	client
+		.batch_execute(
+			"INSERT INTO decodex.policy_revisions \
+			 (policy_id,project_id,revision,provenance,snapshot,accepted_by,supersedes_revision) VALUES \
+			 ('31000000-0000-4000-8000-000000000001',\
+			  '11000000-0000-4000-8000-000000000050',3,'cross-agent','{}',\
+			  '22000000-0000-4000-8000-000000000051',2)",
+		)
+		.await
+		.expect_err("cross-Project accepting Agent foreign key rejects attachment");
+
+	store.transition_project(project_id, 1, ProjectStatus::Paused).await?;
+
+	let paused_acceptance = policy_acceptance(project_id, policy_id, lead_id, 3, "paused-project");
+
+	assert!(matches!(
+		store.accept_policy_revision(paused_acceptance).await,
+		Err(StoreError::InvalidInput("Policy acceptance requires active Project Lead authority"))
+	));
 
 	Ok(())
 }

--- a/scripts/vnext/postgres_store_test.py
+++ b/scripts/vnext/postgres_store_test.py
@@ -84,6 +84,8 @@ RUNTIME_EXECUTE_SIGNATURES = (
 	"decodex.bootstrap_advisor(decodex.canonical_uuid_v4_text)",
 	"decodex.create_project(decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text)",
 	"decodex.transition_project(decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.project_status)",
+	"decodex.create_policy(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text)",
+	"decodex.accept_policy_revision(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,pg_catalog.int8)",
 )
 TRIGGER_ONLY_SIGNATURES = (
 	"decodex.enforce_lease_operation_time()",
@@ -105,6 +107,8 @@ TRIGGER_ONLY_SIGNATURES = (
 	"decodex.enforce_context_pack_state()",
 	"decodex.enforce_context_pack_source_state()",
 	"decodex.enforce_history_cursor_state()",
+	"decodex.enforce_policy_identity_state()",
+	"decodex.forbid_policy_revision_mutation()",
 )
 RUNTIME_TYPE_NAMES = (
 	"decodex.account_state",
@@ -392,7 +396,8 @@ def provision_runtime(database: str, role: str, env: dict[str, str]) -> None:
 		f"decodex.account_snapshots, decodex.blob_objects, decodex.artifact_revisions, decodex.context_packs, "
 		f"decodex.context_pack_sources, decodex.transition_proposals TO {role}; "
 		f"GRANT SELECT ON TABLE decodex.history_cursors, decodex.history_item_versions TO {role}; "
-		f"GRANT SELECT ON TABLE decodex.projects, decodex.agents TO {role}; "
+		f"GRANT SELECT ON TABLE decodex.projects, decodex.agents, "
+		f"decodex.policies, decodex.policy_revisions TO {role}; "
 		f"GRANT DELETE ON TABLE decodex.blob_objects TO {role}; "
 		f"GRANT SELECT, INSERT ON TABLE decodex.activity TO {role}; "
 		f"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE decodex.outbox TO {role}; "
@@ -960,7 +965,7 @@ def main() -> int:
 			f"AND (SELECT count(*) FROM pg_catalog.pg_proc AS inventory "
 			f"JOIN pg_catalog.pg_namespace AS inventory_namespace "
 			f"ON inventory_namespace.oid = inventory.pronamespace "
-			f"WHERE inventory_namespace.nspname = 'decodex') = 39",
+			f"WHERE inventory_namespace.nspname = 'decodex') = 44",
 			env,
 		) != "t|t|t|t|t|t|t|t":
 			raise TestFailure("additional privileged-function fixture is vacuous")
@@ -1338,7 +1343,7 @@ def main() -> int:
 			"SELECT count(*), count(*) FILTER (WHERE name LIKE '%_tampered') "
 			"FROM public.refinery_schema_history",
 			env,
-		) != "5|1":
+		) != "6|1":
 			raise TestFailure("migration-ledger tamper did not preserve the row count")
 
 		create_database(MISSING_EXTENSION_DATABASE, env)

--- a/tests/scripts/test_vnext_architecture.py
+++ b/tests/scripts/test_vnext_architecture.py
@@ -371,5 +371,77 @@ class VnextArchitectureTests(unittest.TestCase):
         ):
             self.assertNotIn(conversation_surface, migration)
 
+    def test_project_policy_identity_and_exact_revision_have_one_inert_owner(self):
+        core_lib = (ROOT / "crates/decodex-core/src/lib.rs").read_text()
+        policy = (ROOT / "crates/decodex-core/src/policy.rs").read_text()
+        postgres = (ROOT / "crates/decodex-postgres/src/policies.rs").read_text()
+        migration = (
+            ROOT
+            / "crates/decodex-postgres/migrations/V6__project_policy_authority.sql"
+        ).read_text()
+
+        self.assertIn("PolicyId", core_lib)
+        self.assertIn("PolicyRevisionId", core_lib)
+        self.assertIn("pub struct PolicyId", policy)
+        self.assertIn("pub struct PolicyRevisionId", policy)
+        self.assertIn("use decodex_core", postgres)
+        self.assertNotIn("pub struct PolicyId", postgres)
+        self.assertNotIn("pub struct PolicyRevisionId", postgres)
+        self.assertIn("CREATE TABLE decodex.policies", migration)
+        self.assertIn("CREATE TABLE decodex.policy_revisions", migration)
+        self.assertIn("policy_revisions_policy_project_fk", migration)
+        self.assertIn("policy_revisions_accepting_agent_project_fk", migration)
+        self.assertIn("policy_revisions_supersedes_fk", migration)
+        self.assertIn("policy_revisions_immutable", migration)
+        self.assertEqual(migration.count("CREATE FUNCTION decodex.create_policy("), 1)
+        self.assertEqual(
+            migration.count("CREATE FUNCTION decodex.accept_policy_revision("), 1
+        )
+
+        for path in (ROOT / "crates").rglob("*.rs"):
+            if path == ROOT / "crates/decodex-core/src/policy.rs":
+                continue
+            self.assertNotIn("pub struct PolicyId", path.read_text(), str(path))
+            self.assertNotIn("pub struct PolicyRevisionId", path.read_text(), str(path))
+
+    def test_project_policy_slice_enables_no_effective_policy_behavior(self):
+        live_roots = [
+            ROOT / "crates/decodex-codex/src",
+            ROOT / "crates/decodex-protocol/src",
+            ROOT / "crates/decodex-runtime/src",
+            ROOT / "apps/decodexd/src",
+            ROOT / "apps/decodex-cli/src",
+            ROOT / "apps/decodex-gpui/src",
+        ]
+        source = "\n".join(
+            path.read_text()
+            for root in live_roots
+            for path in sorted(root.rglob("*.rs"))
+        )
+
+        for token in (
+            "PolicyRepository",
+            "accept_policy_revision",
+            "policies_for_project",
+        ):
+            self.assertNotIn(token, source)
+
+        migration = (
+            ROOT
+            / "crates/decodex-postgres/migrations/V6__project_policy_authority.sql"
+        ).read_text().lower()
+        for live_token in (
+            "approval routing",
+            "budget enforcement",
+            "quiet period",
+            "tool enforcement",
+            "path enforcement",
+            "network enforcement",
+            "dispatch",
+            "wakeup",
+            "codex process",
+        ):
+            self.assertNotIn(live_token, migration)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add canonical Project-owned policy identity and immutable revisions
- enforce PostgreSQL authority, idempotency, supersession, and concurrency invariants
- extend migration, restore, architecture, and repository coverage

## Validation
- focused core and PostgreSQL tests
- PostgreSQL migration/restore/concurrency harness
- vNext architecture tests
- strict formatting and diff hygiene
- independent review: APPROVE

Manual Decodex landing; CI wait is intentionally not required.