### PR TITLE
XY-1281: Establish Program and Objective authority semantics

### DIFF
--- a/crates/decodex-core/src/lib.rs
+++ b/crates/decodex-core/src/lib.rs
@@ -10,6 +10,7 @@ mod identity;
 #[cfg(unix)] mod path_unix;
 mod paths;
 mod policy;
+mod program;
 mod project;
 mod quota;
 mod storage;
@@ -54,6 +55,16 @@ pub use self::{
 		MAX_POLICY_SNAPSHOT_KEY_BYTES, MAX_POLICY_SNAPSHOT_VALUE_BYTES, Policy, PolicyError,
 		PolicyId, PolicyProvenance, PolicyRepository, PolicyRevision, PolicyRevisionAcceptance,
 		PolicyRevisionId, PolicySnapshot, PolicySnapshotValue, PolicyStatus, PolicyTimestamp,
+	},
+	program::{
+		MAX_OBJECTIVE_CRITERIA, MAX_PROGRAM_CONTEXT_BYTES, MAX_PROGRAM_CONTEXT_DECISIONS,
+		MAX_PROGRAM_NAME_BYTES, MAX_PROGRAM_OBSERVATIONS, MAX_PROGRAM_TEXT_BYTES,
+		MAX_PROGRAM_TIMESTAMP_MICROSECONDS, MAX_REVIEW_CADENCE_DAYS, Objective,
+		ObjectiveCompletionEvidence, ObjectiveEvidenceId, ObjectiveId, ObjectiveState, Program,
+		ProgramContext, ProgramContextDecision, ProgramContextInput, ProgramCorrelationId,
+		ProgramError, ProgramId, ProgramMetric, ProgramObservationId, ProgramObservationProvenance,
+		ProgramProvenance, ProgramQuietPeriod, ProgramSignal, ProgramState, ProgramTimestamp,
+		ReviewCadence, compile_program_context,
 	},
 	project::{
 		MAX_PROJECT_METADATA_FIELDS, MAX_PROJECT_METADATA_KEY_BYTES,

--- a/crates/decodex-core/src/program.rs
+++ b/crates/decodex-core/src/program.rs
@@ -1,0 +1,1552 @@
+//! Open-ended Program and finite Objective domain authority.
+
+use std::{
+	collections::HashSet,
+	error::Error,
+	fmt::{Debug, Display, Formatter},
+};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+use sha2::{Digest as _, Sha256};
+
+use crate::{AgentId, PolicyRevisionId, ProjectId};
+
+macro_rules! stable_id {
+	($name:ident, $error:ident, $label:literal) => {
+		#[doc = concat!("Stable canonical ", $label, " identity.")]
+		#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+		pub struct $name(String);
+		impl $name {
+			#[doc = concat!("Parse one canonical lowercase RFC 9562 UUID-v4 ", $label, " identity.")]
+			pub fn new(value: impl Into<String>) -> Result<Self, ProgramError> {
+				let value = value.into();
+
+				if !is_canonical_uuid_v4(&value) {
+					return Err(ProgramError::$error);
+				}
+
+				Ok(Self(value))
+			}
+
+			#[doc = concat!("Borrow the canonical ", $label, " identity.")]
+			pub fn as_str(&self) -> &str {
+				&self.0
+			}
+		}
+		impl Display for $name {
+			fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+				formatter.write_str(&self.0)
+			}
+		}
+		impl Serialize for $name {
+			fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+			where
+				S: Serializer,
+			{
+				serializer.serialize_str(&self.0)
+			}
+		}
+		impl<'de> Deserialize<'de> for $name {
+			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+			where
+				D: Deserializer<'de>,
+			{
+				Self::new(String::deserialize(deserializer)?).map_err(D::Error::custom)
+			}
+		}
+	};
+}
+
+stable_id!(ProgramId, InvalidProgramId, "Program");
+stable_id!(ObjectiveId, InvalidObjectiveId, "Objective");
+stable_id!(ObjectiveEvidenceId, InvalidEvidenceId, "Objective evidence");
+stable_id!(ProgramCorrelationId, InvalidCorrelationId, "Program correlation");
+stable_id!(ProgramObservationId, InvalidObservationId, "Program observation");
+
+/// Maximum bytes in a Program or Objective display name.
+pub const MAX_PROGRAM_NAME_BYTES: usize = 256;
+/// Maximum bytes in an ordinary Program/Objective text field.
+pub const MAX_PROGRAM_TEXT_BYTES: usize = 4_096;
+/// Maximum criteria on one finite Objective.
+pub const MAX_OBJECTIVE_CRITERIA: usize = 32;
+/// Maximum metrics or signals on one Program.
+pub const MAX_PROGRAM_OBSERVATIONS: usize = 64;
+/// Maximum recent decisions in one compiled Program context.
+pub const MAX_PROGRAM_CONTEXT_DECISIONS: usize = 64;
+/// Maximum deterministic compiled Program-context bytes.
+pub const MAX_PROGRAM_CONTEXT_BYTES: usize = 256 * 1_024;
+/// Maximum accepted interval for an explicit Program review cadence.
+pub const MAX_REVIEW_CADENCE_DAYS: u16 = 365;
+/// Latest finite timestamp representable by PostgreSQL and RFC 3339, in Unix microseconds.
+pub const MAX_PROGRAM_TIMESTAMP_MICROSECONDS: i64 = 253_402_300_799_999_999;
+
+/// Closed Program-domain validation failure without caller-controlled text.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProgramError {
+	/// Program identity was not canonical UUID-v4 text.
+	InvalidProgramId,
+	/// Objective identity was not canonical UUID-v4 text.
+	InvalidObjectiveId,
+	/// Objective completion-evidence identity was not canonical UUID-v4 text.
+	InvalidEvidenceId,
+	/// Mutation correlation identity was not canonical UUID-v4 text.
+	InvalidCorrelationId,
+	/// Metric, signal, or context-decision identity was not canonical UUID-v4 text.
+	InvalidObservationId,
+	/// A bounded ordinary text value was empty, oversized, or contained controls.
+	InvalidText,
+	/// A symbolic key was not canonical lowercase snake case.
+	InvalidSymbol,
+	/// A collection was empty, oversized, or repeated a stable key.
+	InvalidCollection,
+	/// A persisted or incremented revision was outside its positive domain.
+	InvalidRevision,
+	/// A timestamp was negative, unbounded, or chronologically inconsistent.
+	InvalidChronology,
+	/// Review cadence was outside its supported interval.
+	InvalidReviewCadence,
+	/// Requested lifecycle transition was not legal.
+	InvalidLifecycle,
+	/// Completion evidence did not bind the exact Objective revision and Project.
+	InvalidCompletion,
+	/// Program context exceeded its deterministic bound.
+	ContextTooLarge,
+	/// Ordinary domain data contained concrete credential material.
+	CredentialRejected,
+}
+impl Error for ProgramError {}
+
+impl Display for ProgramError {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(match self {
+			Self::InvalidProgramId => "invalid Program identity",
+			Self::InvalidObjectiveId => "invalid Objective identity",
+			Self::InvalidEvidenceId => "invalid Objective evidence identity",
+			Self::InvalidCorrelationId => "invalid Program correlation identity",
+			Self::InvalidObservationId => "invalid Program observation identity",
+			Self::InvalidText => "invalid bounded Program text",
+			Self::InvalidSymbol => "invalid canonical Program symbol",
+			Self::InvalidCollection => "invalid bounded Program collection",
+			Self::InvalidRevision => "invalid Program or Objective revision",
+			Self::InvalidChronology => "invalid Program or Objective chronology",
+			Self::InvalidReviewCadence => "invalid Program review cadence",
+			Self::InvalidLifecycle => "invalid Program or Objective lifecycle transition",
+			Self::InvalidCompletion => "invalid Objective completion evidence",
+			Self::ContextTooLarge => "compiled Program context exceeds its byte bound",
+			Self::CredentialRejected => "credential-bearing Program data rejected",
+		})
+	}
+}
+
+/// Database-compatible finite time represented as Unix epoch microseconds.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ProgramTimestamp(i64);
+impl ProgramTimestamp {
+	/// Validate one finite non-negative timestamp.
+	pub const fn from_unix_microseconds(value: i64) -> Result<Self, ProgramError> {
+		if value < 0 || value > MAX_PROGRAM_TIMESTAMP_MICROSECONDS {
+			Err(ProgramError::InvalidChronology)
+		} else {
+			Ok(Self(value))
+		}
+	}
+
+	/// Read Unix epoch microseconds.
+	pub const fn unix_microseconds(self) -> i64 {
+		self.0
+	}
+}
+
+/// Open-ended Program lifecycle.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProgramState {
+	/// Responsibility is operating normally.
+	Active,
+	/// Responsibility requires Lead review without pretending it is complete.
+	NeedsAttention,
+	/// Responsibility cannot currently progress.
+	Blocked,
+	/// Responsibility is intentionally inactive but resumable.
+	Paused,
+	/// Responsibility is permanently closed and retained for readback.
+	Retired,
+}
+impl ProgramState {
+	/// Canonical persistence spelling.
+	pub const fn as_str(self) -> &'static str {
+		match self {
+			Self::Active => "active",
+			Self::NeedsAttention => "needs_attention",
+			Self::Blocked => "blocked",
+			Self::Paused => "paused",
+			Self::Retired => "retired",
+		}
+	}
+
+	/// Whether this state can transition to `next`.
+	pub const fn can_transition_to(self, next: Self) -> bool {
+		match self {
+			Self::Active =>
+				matches!(next, Self::NeedsAttention | Self::Blocked | Self::Paused | Self::Retired),
+			Self::NeedsAttention =>
+				matches!(next, Self::Active | Self::Blocked | Self::Paused | Self::Retired),
+			Self::Blocked =>
+				matches!(next, Self::Active | Self::NeedsAttention | Self::Paused | Self::Retired),
+			Self::Paused => matches!(next, Self::Active | Self::Retired),
+			Self::Retired => false,
+		}
+	}
+}
+
+/// Finite Objective lifecycle.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectiveState {
+	/// Outcome is defined but has not begun.
+	Proposed,
+	/// Work toward the finite outcome is active.
+	Active,
+	/// Progress toward the outcome is temporarily blocked.
+	Blocked,
+	/// Immutable acceptance and validation evidence established the outcome.
+	Achieved,
+	/// Outcome ended intentionally without achievement.
+	Abandoned,
+}
+impl ObjectiveState {
+	/// Canonical persistence spelling.
+	pub const fn as_str(self) -> &'static str {
+		match self {
+			Self::Proposed => "proposed",
+			Self::Active => "active",
+			Self::Blocked => "blocked",
+			Self::Achieved => "achieved",
+			Self::Abandoned => "abandoned",
+		}
+	}
+
+	/// Whether an ordinary lifecycle command may perform this transition.
+	pub const fn can_transition_to(self, next: Self) -> bool {
+		matches!(
+			(self, next),
+			(Self::Proposed, Self::Active | Self::Abandoned)
+				| (Self::Active, Self::Blocked | Self::Abandoned)
+				| (Self::Blocked, Self::Active | Self::Abandoned)
+		)
+	}
+}
+
+/// Bounded provenance supplied for every Program/Objective mutation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProgramProvenance {
+	actor_id: AgentId,
+	correlation_id: ProgramCorrelationId,
+	summary: String,
+}
+impl ProgramProvenance {
+	/// Construct credential-negative active-Lead provenance.
+	///
+	/// Storage verifies the Agent role, state, and Project scope transactionally.
+	pub fn new(
+		actor_id: AgentId,
+		correlation_id: ProgramCorrelationId,
+		summary: impl Into<String>,
+	) -> Result<Self, ProgramError> {
+		let summary = summary.into();
+
+		validate_text(&summary, MAX_PROGRAM_TEXT_BYTES)?;
+
+		Ok(Self { actor_id, correlation_id, summary })
+	}
+
+	/// Stable canonical Agent whose authority storage verifies.
+	pub const fn actor_id(&self) -> &AgentId {
+		&self.actor_id
+	}
+
+	/// Stable correlation identity.
+	pub const fn correlation_id(&self) -> &ProgramCorrelationId {
+		&self.correlation_id
+	}
+
+	/// Opaque bounded provenance summary.
+	pub fn summary(&self) -> &str {
+		&self.summary
+	}
+}
+
+/// Bounded recurring review schedule for an open-ended Program.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ReviewCadence {
+	interval_days: u16,
+	next_review_at: ProgramTimestamp,
+}
+impl ReviewCadence {
+	/// Construct a cadence with an explicit next review.
+	pub const fn new(
+		interval_days: u16,
+		next_review_at: ProgramTimestamp,
+	) -> Result<Self, ProgramError> {
+		if interval_days == 0 || interval_days > MAX_REVIEW_CADENCE_DAYS {
+			return Err(ProgramError::InvalidReviewCadence);
+		}
+
+		Ok(Self { interval_days, next_review_at })
+	}
+
+	/// Whole days between reviews.
+	pub const fn interval_days(self) -> u16 {
+		self.interval_days
+	}
+
+	/// Explicit next review time.
+	pub const fn next_review_at(self) -> ProgramTimestamp {
+		self.next_review_at
+	}
+}
+
+/// Source and observation time for a metric, signal, or context decision.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct ProgramObservationProvenance {
+	source: String,
+	observed_at_microseconds: i64,
+}
+impl ProgramObservationProvenance {
+	/// Construct bounded inspectable observation provenance.
+	pub fn new(
+		source: impl Into<String>,
+		observed_at: ProgramTimestamp,
+	) -> Result<Self, ProgramError> {
+		let source = source.into();
+
+		validate_text(&source, MAX_PROGRAM_NAME_BYTES)?;
+
+		Ok(Self { source, observed_at_microseconds: observed_at.unix_microseconds() })
+	}
+
+	/// Inspectable source text; ordinary thread/conversation mentions remain data.
+	pub fn source(&self) -> &str {
+		&self.source
+	}
+
+	/// Observation time.
+	pub fn observed_at(&self) -> ProgramTimestamp {
+		ProgramTimestamp(self.observed_at_microseconds)
+	}
+
+	fn validate(&self) -> Result<(), ProgramError> {
+		validate_text(&self.source, MAX_PROGRAM_NAME_BYTES)?;
+
+		ProgramTimestamp::from_unix_microseconds(self.observed_at_microseconds)?;
+
+		Ok(())
+	}
+}
+
+/// One bounded provenance-bearing Program metric.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct ProgramMetric {
+	key: String,
+	value: String,
+	unit: String,
+	provenance: ProgramObservationProvenance,
+}
+impl ProgramMetric {
+	/// Construct one canonical metric.
+	pub fn new(
+		key: impl Into<String>,
+		value: impl Into<String>,
+		unit: impl Into<String>,
+		provenance: ProgramObservationProvenance,
+	) -> Result<Self, ProgramError> {
+		let metric = Self { key: key.into(), value: value.into(), unit: unit.into(), provenance };
+
+		metric.validate()?;
+
+		Ok(metric)
+	}
+
+	/// Stable lowercase metric key.
+	pub fn key(&self) -> &str {
+		&self.key
+	}
+
+	/// Bounded metric value.
+	pub fn value(&self) -> &str {
+		&self.value
+	}
+
+	/// Bounded metric unit.
+	pub fn unit(&self) -> &str {
+		&self.unit
+	}
+
+	/// Inspectable observation provenance.
+	pub const fn provenance(&self) -> &ProgramObservationProvenance {
+		&self.provenance
+	}
+
+	fn validate(&self) -> Result<(), ProgramError> {
+		validate_symbol(&self.key)?;
+		validate_text(&self.value, MAX_PROGRAM_NAME_BYTES)?;
+		validate_text(&self.unit, 64)?;
+
+		self.provenance.validate()
+	}
+}
+
+/// One bounded provenance-bearing Program signal.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct ProgramSignal {
+	id: ProgramObservationId,
+	kind: String,
+	summary: String,
+	provenance: ProgramObservationProvenance,
+}
+impl ProgramSignal {
+	/// Construct one canonical signal.
+	pub fn new(
+		id: ProgramObservationId,
+		kind: impl Into<String>,
+		summary: impl Into<String>,
+		provenance: ProgramObservationProvenance,
+	) -> Result<Self, ProgramError> {
+		let signal = Self { id, kind: kind.into(), summary: summary.into(), provenance };
+
+		signal.validate()?;
+
+		Ok(signal)
+	}
+
+	/// Stable signal identity.
+	pub const fn id(&self) -> &ProgramObservationId {
+		&self.id
+	}
+
+	/// Canonical signal kind.
+	pub fn kind(&self) -> &str {
+		&self.kind
+	}
+
+	/// Inspectable bounded signal summary.
+	pub fn summary(&self) -> &str {
+		&self.summary
+	}
+
+	/// Inspectable observation provenance.
+	pub const fn provenance(&self) -> &ProgramObservationProvenance {
+		&self.provenance
+	}
+
+	fn validate(&self) -> Result<(), ProgramError> {
+		validate_symbol(&self.kind)?;
+		validate_text(&self.summary, MAX_PROGRAM_TEXT_BYTES)?;
+
+		self.provenance.validate()
+	}
+}
+
+/// Open-ended responsibility owned by one canonical Project Lead under exact policy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Program {
+	id: ProgramId,
+	project_id: ProjectId,
+	owner_agent_id: AgentId,
+	name: String,
+	responsibility: String,
+	state: ProgramState,
+	policy_revision_id: PolicyRevisionId,
+	review_cadence: ReviewCadence,
+	metrics: Vec<ProgramMetric>,
+	signals: Vec<ProgramSignal>,
+	revision: u64,
+}
+impl Program {
+	/// Create revision one of an active open-ended responsibility.
+	pub fn new(
+		id: ProgramId,
+		project_id: ProjectId,
+		owner_agent_id: AgentId,
+		name: impl Into<String>,
+		responsibility: impl Into<String>,
+		policy_revision_id: PolicyRevisionId,
+		review_cadence: ReviewCadence,
+	) -> Result<Self, ProgramError> {
+		Self::from_stored(
+			id,
+			project_id,
+			owner_agent_id,
+			name.into(),
+			responsibility.into(),
+			ProgramState::Active,
+			policy_revision_id,
+			review_cadence,
+			Vec::new(),
+			Vec::new(),
+			1,
+		)
+	}
+
+	/// Validate deterministic persistence readback.
+	#[allow(clippy::too_many_arguments)]
+	pub fn from_stored(
+		id: ProgramId,
+		project_id: ProjectId,
+		owner_agent_id: AgentId,
+		name: String,
+		responsibility: String,
+		state: ProgramState,
+		policy_revision_id: PolicyRevisionId,
+		review_cadence: ReviewCadence,
+		metrics: Vec<ProgramMetric>,
+		signals: Vec<ProgramSignal>,
+		revision: u64,
+	) -> Result<Self, ProgramError> {
+		validate_text(&name, MAX_PROGRAM_NAME_BYTES)?;
+		validate_text(&responsibility, MAX_PROGRAM_TEXT_BYTES)?;
+
+		if policy_revision_id.project_id() != &project_id || revision == 0 {
+			return Err(ProgramError::InvalidRevision);
+		}
+
+		validate_observations(&metrics, &signals)?;
+
+		Ok(Self {
+			id,
+			project_id,
+			owner_agent_id,
+			name,
+			responsibility,
+			state,
+			policy_revision_id,
+			review_cadence,
+			metrics,
+			signals,
+			revision,
+		})
+	}
+
+	/// Apply one legal expected-revision lifecycle transition.
+	pub fn transition(
+		&mut self,
+		expected_revision: u64,
+		state: ProgramState,
+	) -> Result<(), ProgramError> {
+		self.require_revision(expected_revision)?;
+
+		if !self.state.can_transition_to(state) {
+			return Err(ProgramError::InvalidLifecycle);
+		}
+
+		self.advance_revision()?;
+
+		self.state = state;
+
+		Ok(())
+	}
+
+	/// Replace mutable metric/signal/review context at one expected revision.
+	pub fn replace_context(
+		&mut self,
+		expected_revision: u64,
+		review_cadence: ReviewCadence,
+		metrics: Vec<ProgramMetric>,
+		signals: Vec<ProgramSignal>,
+	) -> Result<(), ProgramError> {
+		self.require_revision(expected_revision)?;
+
+		if self.state == ProgramState::Retired {
+			return Err(ProgramError::InvalidLifecycle);
+		}
+
+		validate_observations(&metrics, &signals)?;
+
+		if self.review_cadence == review_cadence
+			&& self.metrics == metrics
+			&& self.signals == signals
+		{
+			return Err(ProgramError::InvalidLifecycle);
+		}
+
+		self.advance_revision()?;
+
+		self.review_cadence = review_cadence;
+		self.metrics = metrics;
+		self.signals = signals;
+
+		Ok(())
+	}
+
+	fn require_revision(&self, expected_revision: u64) -> Result<(), ProgramError> {
+		if expected_revision == 0 || expected_revision != self.revision {
+			Err(ProgramError::InvalidRevision)
+		} else {
+			Ok(())
+		}
+	}
+
+	fn advance_revision(&mut self) -> Result<(), ProgramError> {
+		self.revision = self.revision.checked_add(1).ok_or(ProgramError::InvalidRevision)?;
+
+		Ok(())
+	}
+
+	/// Stable Program identity.
+	pub const fn id(&self) -> &ProgramId {
+		&self.id
+	}
+
+	/// Owning canonical Project.
+	pub const fn project_id(&self) -> &ProjectId {
+		&self.project_id
+	}
+
+	/// Canonical Agent identity assigned as owner.
+	pub const fn owner_agent_id(&self) -> &AgentId {
+		&self.owner_agent_id
+	}
+
+	/// Bounded display name.
+	pub fn name(&self) -> &str {
+		&self.name
+	}
+
+	/// Open-ended responsibility statement.
+	pub fn responsibility(&self) -> &str {
+		&self.responsibility
+	}
+
+	/// Current open-ended lifecycle.
+	pub const fn state(&self) -> ProgramState {
+		self.state
+	}
+
+	/// Exact accepted Project-owned Policy revision.
+	pub const fn policy_revision_id(&self) -> &PolicyRevisionId {
+		&self.policy_revision_id
+	}
+
+	/// Explicit review cadence.
+	pub const fn review_cadence(&self) -> ReviewCadence {
+		self.review_cadence
+	}
+
+	/// Bounded metrics.
+	pub fn metrics(&self) -> &[ProgramMetric] {
+		&self.metrics
+	}
+
+	/// Bounded signals.
+	pub fn signals(&self) -> &[ProgramSignal] {
+		&self.signals
+	}
+
+	/// Positive optimistic revision.
+	pub const fn revision(&self) -> u64 {
+		self.revision
+	}
+}
+
+/// Immutable Objective-level acceptance and validation evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ObjectiveCompletionEvidence {
+	id: ObjectiveEvidenceId,
+	objective_id: ObjectiveId,
+	project_id: ProjectId,
+	objective_revision: u64,
+	objective_updated_at: Option<ProgramTimestamp>,
+	acceptance_result: String,
+	accepted_by: AgentId,
+	accepted_at: ProgramTimestamp,
+	acceptance_provenance: String,
+	validation_result: String,
+	validated_by: AgentId,
+	validated_at: ProgramTimestamp,
+	validation_provenance: String,
+	correlation_id: ProgramCorrelationId,
+	recorded_at: ProgramTimestamp,
+}
+impl ObjectiveCompletionEvidence {
+	/// Construct proposed evidence; storage authors `recorded_at` after authority checks.
+	#[allow(clippy::too_many_arguments)]
+	pub fn proposed(
+		id: ObjectiveEvidenceId,
+		objective_id: ObjectiveId,
+		project_id: ProjectId,
+		objective_revision: u64,
+		acceptance_result: impl Into<String>,
+		accepted_by: AgentId,
+		accepted_at: ProgramTimestamp,
+		acceptance_provenance: impl Into<String>,
+		validation_result: impl Into<String>,
+		validated_by: AgentId,
+		validated_at: ProgramTimestamp,
+		validation_provenance: impl Into<String>,
+		correlation_id: ProgramCorrelationId,
+	) -> Result<Self, ProgramError> {
+		Self::from_stored(
+			id,
+			objective_id,
+			project_id,
+			objective_revision,
+			None,
+			acceptance_result.into(),
+			accepted_by,
+			accepted_at,
+			acceptance_provenance.into(),
+			validation_result.into(),
+			validated_by,
+			validated_at,
+			validation_provenance.into(),
+			correlation_id,
+			validated_at,
+		)
+	}
+
+	/// Validate exact immutable persistence readback and chronology.
+	#[allow(clippy::too_many_arguments)]
+	pub fn from_stored(
+		id: ObjectiveEvidenceId,
+		objective_id: ObjectiveId,
+		project_id: ProjectId,
+		objective_revision: u64,
+		objective_updated_at: Option<ProgramTimestamp>,
+		acceptance_result: String,
+		accepted_by: AgentId,
+		accepted_at: ProgramTimestamp,
+		acceptance_provenance: String,
+		validation_result: String,
+		validated_by: AgentId,
+		validated_at: ProgramTimestamp,
+		validation_provenance: String,
+		correlation_id: ProgramCorrelationId,
+		recorded_at: ProgramTimestamp,
+	) -> Result<Self, ProgramError> {
+		if objective_revision == 0
+			|| objective_updated_at.is_some_and(|updated_at| updated_at > accepted_at)
+			|| accepted_at > validated_at
+			|| validated_at > recorded_at
+		{
+			return Err(ProgramError::InvalidCompletion);
+		}
+
+		for value in
+			[&acceptance_result, &acceptance_provenance, &validation_result, &validation_provenance]
+		{
+			validate_text(value, MAX_PROGRAM_TEXT_BYTES)?;
+		}
+
+		Ok(Self {
+			id,
+			objective_id,
+			project_id,
+			objective_revision,
+			objective_updated_at,
+			acceptance_result,
+			accepted_by,
+			accepted_at,
+			acceptance_provenance,
+			validation_result,
+			validated_by,
+			validated_at,
+			validation_provenance,
+			correlation_id,
+			recorded_at,
+		})
+	}
+
+	/// Stable immutable evidence identity.
+	pub const fn id(&self) -> &ObjectiveEvidenceId {
+		&self.id
+	}
+
+	/// Exact Objective identity.
+	pub const fn objective_id(&self) -> &ObjectiveId {
+		&self.objective_id
+	}
+
+	/// Exact owning Project identity.
+	pub const fn project_id(&self) -> &ProjectId {
+		&self.project_id
+	}
+
+	/// Exact pre-achievement Objective revision.
+	pub const fn objective_revision(&self) -> u64 {
+		self.objective_revision
+	}
+
+	/// Database-authored timestamp of the exact pre-achievement Objective revision.
+	pub const fn objective_updated_at(&self) -> Option<ProgramTimestamp> {
+		self.objective_updated_at
+	}
+
+	/// Non-empty acceptance result.
+	pub fn acceptance_result(&self) -> &str {
+		&self.acceptance_result
+	}
+
+	/// Canonical accepting Agent.
+	pub const fn accepted_by(&self) -> &AgentId {
+		&self.accepted_by
+	}
+
+	/// Acceptance observation time.
+	pub const fn accepted_at(&self) -> ProgramTimestamp {
+		self.accepted_at
+	}
+
+	/// Inspectable acceptance provenance.
+	pub fn acceptance_provenance(&self) -> &str {
+		&self.acceptance_provenance
+	}
+
+	/// Non-empty validation result.
+	pub fn validation_result(&self) -> &str {
+		&self.validation_result
+	}
+
+	/// Canonical validating Agent.
+	pub const fn validated_by(&self) -> &AgentId {
+		&self.validated_by
+	}
+
+	/// Validation observation time.
+	pub const fn validated_at(&self) -> ProgramTimestamp {
+		self.validated_at
+	}
+
+	/// Inspectable validation provenance.
+	pub fn validation_provenance(&self) -> &str {
+		&self.validation_provenance
+	}
+
+	/// Stable correlation identity.
+	pub const fn correlation_id(&self) -> &ProgramCorrelationId {
+		&self.correlation_id
+	}
+
+	/// Database-authored persistence time.
+	pub const fn recorded_at(&self) -> ProgramTimestamp {
+		self.recorded_at
+	}
+}
+
+/// Finite outcome attached directly to a Project and optionally one same-Project Program.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Objective {
+	id: ObjectiveId,
+	project_id: ProjectId,
+	program_id: Option<ProgramId>,
+	outcome: String,
+	acceptance_criteria: Vec<String>,
+	validation_criteria: Vec<String>,
+	target_at: ProgramTimestamp,
+	state: ObjectiveState,
+	revision: u64,
+	completion: Option<ObjectiveCompletionEvidence>,
+}
+impl Objective {
+	/// Create revision one of a finite proposed Objective.
+	pub fn new(
+		id: ObjectiveId,
+		project_id: ProjectId,
+		program_id: Option<ProgramId>,
+		outcome: impl Into<String>,
+		acceptance_criteria: Vec<String>,
+		validation_criteria: Vec<String>,
+		target_at: ProgramTimestamp,
+	) -> Result<Self, ProgramError> {
+		Self::from_stored(
+			id,
+			project_id,
+			program_id,
+			outcome.into(),
+			acceptance_criteria,
+			validation_criteria,
+			target_at,
+			ObjectiveState::Proposed,
+			1,
+			None,
+		)
+	}
+
+	/// Validate deterministic persistence readback.
+	#[allow(clippy::too_many_arguments)]
+	pub fn from_stored(
+		id: ObjectiveId,
+		project_id: ProjectId,
+		program_id: Option<ProgramId>,
+		outcome: String,
+		acceptance_criteria: Vec<String>,
+		validation_criteria: Vec<String>,
+		target_at: ProgramTimestamp,
+		state: ObjectiveState,
+		revision: u64,
+		completion: Option<ObjectiveCompletionEvidence>,
+	) -> Result<Self, ProgramError> {
+		validate_text(&outcome, MAX_PROGRAM_TEXT_BYTES)?;
+		validate_criteria(&acceptance_criteria)?;
+		validate_criteria(&validation_criteria)?;
+
+		if revision == 0 {
+			return Err(ProgramError::InvalidRevision);
+		}
+
+		match (&completion, state) {
+			(Some(evidence), ObjectiveState::Achieved)
+				if evidence.objective_id() == &id
+					&& evidence.project_id() == &project_id
+					&& evidence.objective_revision().checked_add(1) == Some(revision) => {},
+			(None, state) if state != ObjectiveState::Achieved => {},
+			_ => return Err(ProgramError::InvalidCompletion),
+		}
+
+		Ok(Self {
+			id,
+			project_id,
+			program_id,
+			outcome,
+			acceptance_criteria,
+			validation_criteria,
+			target_at,
+			state,
+			revision,
+			completion,
+		})
+	}
+
+	/// Apply one ordinary legal expected-revision transition; achievement is separate.
+	pub fn transition(
+		&mut self,
+		expected_revision: u64,
+		state: ObjectiveState,
+	) -> Result<(), ProgramError> {
+		self.require_revision(expected_revision)?;
+
+		if !self.state.can_transition_to(state) {
+			return Err(ProgramError::InvalidLifecycle);
+		}
+
+		self.revision = self.revision.checked_add(1).ok_or(ProgramError::InvalidRevision)?;
+		self.state = state;
+
+		Ok(())
+	}
+
+	/// Achieve only through exact revision-bound acceptance and validation evidence.
+	pub fn achieve(
+		&mut self,
+		expected_revision: u64,
+		evidence: ObjectiveCompletionEvidence,
+	) -> Result<(), ProgramError> {
+		self.require_revision(expected_revision)?;
+
+		if !matches!(self.state, ObjectiveState::Active | ObjectiveState::Blocked)
+			|| evidence.objective_id() != &self.id
+			|| evidence.project_id() != &self.project_id
+			|| evidence.objective_revision() != expected_revision
+		{
+			return Err(ProgramError::InvalidCompletion);
+		}
+
+		self.revision = self.revision.checked_add(1).ok_or(ProgramError::InvalidRevision)?;
+		self.state = ObjectiveState::Achieved;
+		self.completion = Some(evidence);
+
+		Ok(())
+	}
+
+	fn require_revision(&self, expected_revision: u64) -> Result<(), ProgramError> {
+		if expected_revision == 0 || expected_revision != self.revision {
+			Err(ProgramError::InvalidRevision)
+		} else {
+			Ok(())
+		}
+	}
+
+	/// Stable Objective identity.
+	pub const fn id(&self) -> &ObjectiveId {
+		&self.id
+	}
+
+	/// Owning canonical Project.
+	pub const fn project_id(&self) -> &ProjectId {
+		&self.project_id
+	}
+
+	/// Optional same-Project open-ended Program context.
+	pub const fn program_id(&self) -> Option<&ProgramId> {
+		self.program_id.as_ref()
+	}
+
+	/// Finite outcome statement.
+	pub fn outcome(&self) -> &str {
+		&self.outcome
+	}
+
+	/// Explicit acceptance criteria.
+	pub fn acceptance_criteria(&self) -> &[String] {
+		&self.acceptance_criteria
+	}
+
+	/// Explicit validation criteria.
+	pub fn validation_criteria(&self) -> &[String] {
+		&self.validation_criteria
+	}
+
+	/// Finite target horizon.
+	pub const fn target_at(&self) -> ProgramTimestamp {
+		self.target_at
+	}
+
+	/// Current finite lifecycle.
+	pub const fn state(&self) -> ObjectiveState {
+		self.state
+	}
+
+	/// Positive optimistic revision.
+	pub const fn revision(&self) -> u64 {
+		self.revision
+	}
+
+	/// Immutable outcome evidence, present only when achieved.
+	pub const fn completion(&self) -> Option<&ObjectiveCompletionEvidence> {
+		self.completion.as_ref()
+	}
+}
+
+/// One bounded recent decision included as pure Program context data.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProgramContextDecision {
+	id: ProgramObservationId,
+	summary: String,
+	provenance: ProgramObservationProvenance,
+}
+impl ProgramContextDecision {
+	/// Construct a bounded inspectable decision.
+	pub fn new(
+		id: ProgramObservationId,
+		summary: impl Into<String>,
+		provenance: ProgramObservationProvenance,
+	) -> Result<Self, ProgramError> {
+		let summary = summary.into();
+
+		validate_text(&summary, MAX_PROGRAM_TEXT_BYTES)?;
+
+		provenance.validate()?;
+
+		Ok(Self { id, summary, provenance })
+	}
+}
+
+/// Closed optional automation quiet period retained only as context data.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProgramQuietPeriod {
+	start: ProgramTimestamp,
+	end: ProgramTimestamp,
+}
+impl ProgramQuietPeriod {
+	/// Construct a finite ordered period.
+	pub const fn new(start: ProgramTimestamp, end: ProgramTimestamp) -> Result<Self, ProgramError> {
+		if start.0 >= end.0 {
+			Err(ProgramError::InvalidChronology)
+		} else {
+			Ok(Self { start, end })
+		}
+	}
+}
+
+/// Pure bounded inputs for deterministic Program-context compilation.
+pub struct ProgramContextInput<'a> {
+	/// Authoritative Program snapshot.
+	pub program: &'a Program,
+	/// Recent inspectable decisions.
+	pub recent_decisions: Vec<ProgramContextDecision>,
+	/// Optional data-only quiet period.
+	pub quiet_period: Option<ProgramQuietPeriod>,
+}
+
+/// Deterministic Program data with no runtime, thread, session, or conversation identity.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ProgramContext {
+	program_id: ProgramId,
+	program_revision: u64,
+	bytes: Vec<u8>,
+	digest: [u8; 32],
+}
+impl ProgramContext {
+	/// Source Program identity.
+	pub const fn program_id(&self) -> &ProgramId {
+		&self.program_id
+	}
+
+	/// Exact source Program revision.
+	pub const fn program_revision(&self) -> u64 {
+		self.program_revision
+	}
+
+	/// Canonical bounded context encoding.
+	pub fn bytes(&self) -> &[u8] {
+		&self.bytes
+	}
+
+	/// SHA-256 of the canonical context encoding.
+	pub const fn digest(&self) -> [u8; 32] {
+		self.digest
+	}
+}
+impl Debug for ProgramContext {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter
+			.debug_struct("ProgramContext")
+			.field("program_id", &self.program_id)
+			.field("program_revision", &self.program_revision)
+			.field("byte_length", &self.bytes.len())
+			.field("digest", &self.digest)
+			.finish()
+	}
+}
+
+/// Compile bounded Program data without creating or owning any runtime identity.
+pub fn compile_program_context(
+	mut input: ProgramContextInput<'_>,
+) -> Result<ProgramContext, ProgramError> {
+	if input.recent_decisions.len() > MAX_PROGRAM_CONTEXT_DECISIONS {
+		return Err(ProgramError::InvalidCollection);
+	}
+
+	input.recent_decisions.sort_by(|left, right| left.id.cmp(&right.id));
+
+	if input.recent_decisions.windows(2).any(|pair| pair[0].id == pair[1].id) {
+		return Err(ProgramError::InvalidCollection);
+	}
+
+	let mut metrics = input.program.metrics.clone();
+	let mut signals = input.program.signals.clone();
+
+	metrics.sort_by(|left, right| left.key.cmp(&right.key));
+	signals.sort_by(|left, right| left.id.cmp(&right.id));
+
+	let mut bytes = b"decodex/program-context/1\0".to_vec();
+
+	push_text(&mut bytes, input.program.id.as_str())?;
+	push_u64(&mut bytes, input.program.revision);
+	push_text(&mut bytes, input.program.project_id.as_str())?;
+	push_text(&mut bytes, input.program.owner_agent_id.as_str())?;
+	push_text(&mut bytes, input.program.name())?;
+	push_text(&mut bytes, input.program.responsibility())?;
+	push_text(&mut bytes, input.program.state.as_str())?;
+	push_text(&mut bytes, input.program.policy_revision_id.policy_id().as_str())?;
+	push_u64(&mut bytes, input.program.policy_revision_id.revision().get());
+	push_u64(&mut bytes, u64::from(input.program.review_cadence.interval_days()));
+	push_i64(&mut bytes, input.program.review_cadence.next_review_at().unix_microseconds());
+	push_u64(&mut bytes, metrics.len() as u64);
+
+	for metric in metrics {
+		push_text(&mut bytes, metric.key())?;
+		push_text(&mut bytes, metric.value())?;
+		push_text(&mut bytes, metric.unit())?;
+		push_observation_provenance(&mut bytes, metric.provenance())?;
+	}
+
+	push_u64(&mut bytes, signals.len() as u64);
+
+	for signal in signals {
+		push_text(&mut bytes, signal.id().as_str())?;
+		push_text(&mut bytes, signal.kind())?;
+		push_text(&mut bytes, signal.summary())?;
+		push_observation_provenance(&mut bytes, signal.provenance())?;
+	}
+
+	push_u64(&mut bytes, input.recent_decisions.len() as u64);
+
+	for decision in input.recent_decisions {
+		push_text(&mut bytes, decision.id.as_str())?;
+		push_text(&mut bytes, &decision.summary)?;
+		push_observation_provenance(&mut bytes, &decision.provenance)?;
+	}
+
+	match input.quiet_period {
+		Some(period) => {
+			bytes.push(1);
+
+			push_i64(&mut bytes, period.start.unix_microseconds());
+			push_i64(&mut bytes, period.end.unix_microseconds());
+		},
+		None => bytes.push(0),
+	}
+
+	if bytes.len() > MAX_PROGRAM_CONTEXT_BYTES {
+		return Err(ProgramError::ContextTooLarge);
+	}
+
+	let digest = Sha256::digest(&bytes).into();
+
+	Ok(ProgramContext {
+		program_id: input.program.id.clone(),
+		program_revision: input.program.revision,
+		bytes,
+		digest,
+	})
+}
+
+fn validate_observations(
+	metrics: &[ProgramMetric],
+	signals: &[ProgramSignal],
+) -> Result<(), ProgramError> {
+	if metrics.len() > MAX_PROGRAM_OBSERVATIONS || signals.len() > MAX_PROGRAM_OBSERVATIONS {
+		return Err(ProgramError::InvalidCollection);
+	}
+
+	let mut metric_keys = HashSet::new();
+
+	for metric in metrics {
+		metric.validate()?;
+
+		if !metric_keys.insert(metric.key()) {
+			return Err(ProgramError::InvalidCollection);
+		}
+	}
+
+	let mut signal_ids = HashSet::new();
+
+	for signal in signals {
+		signal.validate()?;
+
+		if !signal_ids.insert(signal.id()) {
+			return Err(ProgramError::InvalidCollection);
+		}
+	}
+
+	Ok(())
+}
+
+fn validate_criteria(values: &[String]) -> Result<(), ProgramError> {
+	if values.is_empty() || values.len() > MAX_OBJECTIVE_CRITERIA {
+		return Err(ProgramError::InvalidCollection);
+	}
+
+	let mut unique = HashSet::new();
+
+	for value in values {
+		validate_text(value, MAX_PROGRAM_TEXT_BYTES)?;
+
+		if !unique.insert(value) {
+			return Err(ProgramError::InvalidCollection);
+		}
+	}
+
+	Ok(())
+}
+
+fn validate_symbol(value: &str) -> Result<(), ProgramError> {
+	if value.is_empty()
+		|| value.len() > 64
+		|| !value.bytes().enumerate().all(|(index, byte)| {
+			if index == 0 {
+				byte.is_ascii_lowercase()
+			} else {
+				byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'
+			}
+		}) {
+		return Err(ProgramError::InvalidSymbol);
+	}
+
+	Ok(())
+}
+
+fn validate_text(value: &str, maximum: usize) -> Result<(), ProgramError> {
+	if value.is_empty() || value.len() > maximum || value.chars().any(char::is_control) {
+		return Err(ProgramError::InvalidText);
+	}
+	if crate::contains_credential_material(value) {
+		return Err(ProgramError::CredentialRejected);
+	}
+
+	Ok(())
+}
+
+fn push_observation_provenance(
+	bytes: &mut Vec<u8>,
+	provenance: &ProgramObservationProvenance,
+) -> Result<(), ProgramError> {
+	push_text(bytes, provenance.source())?;
+	push_i64(bytes, provenance.observed_at().unix_microseconds());
+
+	Ok(())
+}
+
+fn push_text(bytes: &mut Vec<u8>, value: &str) -> Result<(), ProgramError> {
+	let length = u32::try_from(value.len()).map_err(|_| ProgramError::ContextTooLarge)?;
+
+	bytes.extend_from_slice(&length.to_be_bytes());
+	bytes.extend_from_slice(value.as_bytes());
+
+	Ok(())
+}
+
+fn push_u64(bytes: &mut Vec<u8>, value: u64) {
+	bytes.extend_from_slice(&value.to_be_bytes());
+}
+
+fn push_i64(bytes: &mut Vec<u8>, value: i64) {
+	bytes.extend_from_slice(&value.to_be_bytes());
+}
+
+fn is_canonical_uuid_v4(value: &str) -> bool {
+	let bytes = value.as_bytes();
+
+	bytes.len() == 36
+		&& bytes[8] == b'-'
+		&& bytes[13] == b'-'
+		&& bytes[18] == b'-'
+		&& bytes[23] == b'-'
+		&& bytes[14] == b'4'
+		&& matches!(bytes[19], b'8' | b'9' | b'a' | b'b')
+		&& bytes.iter().enumerate().all(|(index, byte)| {
+			matches!(index, 8 | 13 | 18 | 23)
+				|| byte.is_ascii_digit()
+				|| matches!(byte, b'a'..=b'f')
+		})
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::{
+		AgentId, Objective, ObjectiveCompletionEvidence, ObjectiveEvidenceId, ObjectiveId,
+		ObjectiveState, PolicyId, PolicyRevision, PolicyRevisionId, Program,
+		ProgramContextDecision, ProgramContextInput, ProgramCorrelationId, ProgramError, ProgramId,
+		ProgramMetric, ProgramObservationId, ProgramObservationProvenance, ProgramQuietPeriod,
+		ProgramSignal, ProgramState, ProgramTimestamp, ProjectId, ReviewCadence,
+	};
+
+	fn timestamp(value: i64) -> ProgramTimestamp {
+		ProgramTimestamp::from_unix_microseconds(value).unwrap()
+	}
+
+	fn project_id() -> ProjectId {
+		ProjectId::new("10000000-0000-4000-8000-000000000001").unwrap()
+	}
+
+	fn agent_id(suffix: &str) -> AgentId {
+		AgentId::new(format!("20000000-0000-4000-8000-{suffix}")).unwrap()
+	}
+
+	fn program_id() -> ProgramId {
+		ProgramId::new("30000000-0000-4000-8000-000000000001").unwrap()
+	}
+
+	fn policy_revision() -> PolicyRevisionId {
+		PolicyRevisionId::new(
+			project_id(),
+			PolicyId::new("40000000-0000-4000-8000-000000000001").unwrap(),
+			PolicyRevision::new(1).unwrap(),
+		)
+	}
+
+	fn program() -> Program {
+		Program::new(
+			program_id(),
+			project_id(),
+			agent_id("000000000001"),
+			"Search visibility",
+			"Sustain SEO and GEO quality without fake completion",
+			policy_revision(),
+			ReviewCadence::new(7, timestamp(10_000_000)).unwrap(),
+		)
+		.unwrap()
+	}
+
+	fn objective() -> Objective {
+		Objective::new(
+			ObjectiveId::new("50000000-0000-4000-8000-000000000001").unwrap(),
+			project_id(),
+			Some(program_id()),
+			"Publish the finite Q3 search baseline",
+			vec!["Baseline is accepted".into()],
+			vec!["Independent query fixture passes".into()],
+			timestamp(20_000_000),
+		)
+		.unwrap()
+	}
+
+	fn evidence(revision: u64) -> ObjectiveCompletionEvidence {
+		ObjectiveCompletionEvidence::from_stored(
+			ObjectiveEvidenceId::new("60000000-0000-4000-8000-000000000001").unwrap(),
+			ObjectiveId::new("50000000-0000-4000-8000-000000000001").unwrap(),
+			project_id(),
+			revision,
+			Some(timestamp(14_000_000)),
+			"Acceptance criteria satisfied".into(),
+			agent_id("000000000001"),
+			timestamp(15_000_000),
+			"Lead acceptance record".into(),
+			"Validation criteria satisfied".into(),
+			agent_id("000000000002"),
+			timestamp(16_000_000),
+			"Lead validation record".into(),
+			ProgramCorrelationId::new("70000000-0000-4000-8000-000000000001").unwrap(),
+			timestamp(17_000_000),
+		)
+		.unwrap()
+	}
+
+	#[test]
+	fn program_is_open_ended_and_retirement_is_terminal() {
+		let mut program = program();
+
+		program.transition(1, ProgramState::NeedsAttention).unwrap();
+		program.transition(2, ProgramState::Blocked).unwrap();
+		program.transition(3, ProgramState::Paused).unwrap();
+		program.transition(4, ProgramState::Active).unwrap();
+		program.transition(5, ProgramState::Retired).unwrap();
+
+		assert_eq!(program.revision(), 6);
+		assert_eq!(program.state(), ProgramState::Retired);
+		assert_eq!(
+			program.transition(6, ProgramState::Active),
+			Err(ProgramError::InvalidLifecycle)
+		);
+	}
+
+	#[test]
+	fn objective_achievement_requires_exact_revision_bound_evidence() {
+		let mut objective = objective();
+
+		assert_eq!(objective.achieve(1, evidence(1)), Err(ProgramError::InvalidCompletion));
+
+		objective.transition(1, ObjectiveState::Active).unwrap();
+
+		assert_eq!(objective.achieve(2, evidence(1)), Err(ProgramError::InvalidCompletion));
+
+		objective.achieve(2, evidence(2)).unwrap();
+
+		assert_eq!(objective.state(), ObjectiveState::Achieved);
+		assert_eq!(objective.revision(), 3);
+		assert_eq!(objective.completion().unwrap().objective_revision(), 2);
+		assert_eq!(
+			objective.transition(3, ObjectiveState::Abandoned),
+			Err(ProgramError::InvalidLifecycle)
+		);
+	}
+
+	#[test]
+	fn finite_objectives_can_be_abandoned_independently() {
+		let mut first = objective();
+		let mut second = Objective::new(
+			ObjectiveId::new("50000000-0000-4000-8000-000000000002").unwrap(),
+			project_id(),
+			Some(program_id()),
+			"Ship another finite baseline",
+			vec!["Accepted".into()],
+			vec!["Validated".into()],
+			timestamp(30_000_000),
+		)
+		.unwrap();
+
+		first.transition(1, ObjectiveState::Abandoned).unwrap();
+		second.transition(1, ObjectiveState::Active).unwrap();
+
+		assert_eq!(first.state(), ObjectiveState::Abandoned);
+		assert_eq!(second.state(), ObjectiveState::Active);
+		assert_eq!(program().state(), ProgramState::Active);
+	}
+
+	#[test]
+	fn program_context_is_deterministic_data_and_preserves_inspectable_text() {
+		let observation = ProgramObservationProvenance::new(
+			"conversation thread mentioned only as provenance text",
+			timestamp(8_000_000),
+		)
+		.unwrap();
+		let metric =
+			ProgramMetric::new("organic_clicks", "12", "count", observation.clone()).unwrap();
+		let signal = ProgramSignal::new(
+			ProgramObservationId::new("80000000-0000-4000-8000-000000000001").unwrap(),
+			"trend",
+			"Search visibility increased",
+			observation.clone(),
+		)
+		.unwrap();
+		let decision = ProgramContextDecision::new(
+			ProgramObservationId::new("80000000-0000-4000-8000-000000000002").unwrap(),
+			"Keep the responsibility active",
+			observation,
+		)
+		.unwrap();
+		let mut program = program();
+
+		program
+			.replace_context(
+				1,
+				ReviewCadence::new(7, timestamp(11_000_000)).unwrap(),
+				vec![metric],
+				vec![signal],
+			)
+			.unwrap();
+
+		let compile = || {
+			crate::compile_program_context(ProgramContextInput {
+				program: &program,
+				recent_decisions: vec![decision.clone()],
+				quiet_period: Some(
+					ProgramQuietPeriod::new(timestamp(12_000_000), timestamp(13_000_000)).unwrap(),
+				),
+			})
+			.unwrap()
+		};
+		let first = compile();
+		let second = compile();
+
+		assert_eq!(first, second);
+		assert!(
+			String::from_utf8_lossy(first.bytes())
+				.contains("conversation thread mentioned only as provenance text")
+		);
+		assert_eq!(first.program_revision(), 2);
+	}
+
+	#[test]
+	fn criteria_observations_and_evidence_are_closed_and_bounded() {
+		assert_eq!(
+			Objective::new(
+				ObjectiveId::new("50000000-0000-4000-8000-000000000003").unwrap(),
+				project_id(),
+				None,
+				"Finite outcome",
+				Vec::new(),
+				vec!["Validated".into()],
+				timestamp(30_000_000),
+			),
+			Err(ProgramError::InvalidCollection)
+		);
+		assert!(matches!(
+			ProgramMetric::new(
+				"NotCanonical",
+				"1",
+				"count",
+				ProgramObservationProvenance::new("source", timestamp(1)).unwrap(),
+			),
+			Err(ProgramError::InvalidSymbol)
+		));
+		assert!(matches!(
+			ObjectiveCompletionEvidence::proposed(
+				ObjectiveEvidenceId::new("60000000-0000-4000-8000-000000000004").unwrap(),
+				ObjectiveId::new("50000000-0000-4000-8000-000000000004").unwrap(),
+				project_id(),
+				1,
+				"",
+				agent_id("000000000001"),
+				timestamp(1),
+				"accepted",
+				"validated",
+				agent_id("000000000002"),
+				timestamp(2),
+				"validated",
+				ProgramCorrelationId::new("70000000-0000-4000-8000-000000000004").unwrap(),
+			),
+			Err(ProgramError::InvalidText)
+		));
+	}
+}

--- a/crates/decodex-postgres/migrations/V7__program_objective_authority.sql
+++ b/crates/decodex-postgres/migrations/V7__program_objective_authority.sql
@@ -1,0 +1,1015 @@
+-- XY-1281 persists open-ended Program and finite Objective authority only.
+CREATE TYPE decodex.program_state AS ENUM (
+	'active', 'needs_attention', 'blocked', 'paused', 'retired'
+);
+CREATE TYPE decodex.objective_state AS ENUM (
+	'proposed', 'active', 'blocked', 'achieved', 'abandoned'
+);
+
+CREATE FUNCTION decodex.program_timestamp(value bigint)
+RETURNS timestamptz
+LANGUAGE sql
+IMMUTABLE
+STRICT
+AS $$
+	SELECT CASE WHEN value BETWEEN 0 AND 253402300799999999 THEN
+		TIMESTAMPTZ 'epoch'
+			+ (value / 1000000) * INTERVAL '1 second'
+			+ (value % 1000000) * INTERVAL '1 microsecond'
+	END
+$$;
+
+CREATE FUNCTION decodex.is_program_metrics(document jsonb)
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+AS $$
+DECLARE item jsonb;
+DECLARE item_count bigint;
+DECLARE metric_keys text[] := ARRAY[]::text[];
+BEGIN
+	IF pg_catalog.jsonb_typeof(document) <> 'array' THEN RETURN false; END IF;
+	SELECT pg_catalog.count(*) INTO item_count FROM pg_catalog.jsonb_array_elements(document);
+	IF item_count > 64 THEN RETURN false; END IF;
+	FOR item IN SELECT value FROM pg_catalog.jsonb_array_elements(document)
+	LOOP
+		IF pg_catalog.jsonb_typeof(item) <> 'object'
+			OR (SELECT pg_catalog.count(*) FROM pg_catalog.jsonb_object_keys(item)) <> 4
+			OR NOT item OPERATOR(pg_catalog.?&) ARRAY['key','value','unit','provenance']
+			OR pg_catalog.jsonb_typeof(item->'key') <> 'string'
+			OR pg_catalog.jsonb_typeof(item->'value') <> 'string'
+			OR pg_catalog.jsonb_typeof(item->'unit') <> 'string'
+			OR pg_catalog.jsonb_typeof(item->'provenance') <> 'object'
+			OR (SELECT pg_catalog.count(*) FROM pg_catalog.jsonb_object_keys(item->'provenance')) <> 2
+			OR NOT (item->'provenance') OPERATOR(pg_catalog.?&) ARRAY['source','observed_at_microseconds']
+			OR pg_catalog.jsonb_typeof(item->'provenance'->'source') <> 'string'
+			OR pg_catalog.jsonb_typeof(item->'provenance'->'observed_at_microseconds') <> 'number'
+			OR (item->>'key') COLLATE pg_catalog."C" !~ '^[a-z][a-z0-9_]{0,63}$'
+			OR pg_catalog.octet_length(item->>'value') NOT BETWEEN 1 AND 256
+			OR pg_catalog.octet_length(item->>'unit') NOT BETWEEN 1 AND 64
+			OR pg_catalog.octet_length(item->'provenance'->>'source') NOT BETWEEN 1 AND 256
+			OR (item->>'value') COLLATE pg_catalog."C" ~ '[[:cntrl:]]'
+			OR (item->>'unit') COLLATE pg_catalog."C" ~ '[[:cntrl:]]'
+			OR (item->'provenance'->>'source') COLLATE pg_catalog."C" ~ '[[:cntrl:]]'
+			OR (item->>'value') COLLATE pg_catalog."C" ~ U&'[\0080-\009F]'
+			OR (item->>'unit') COLLATE pg_catalog."C" ~ U&'[\0080-\009F]'
+			OR (item->'provenance'->>'source') COLLATE pg_catalog."C" ~ U&'[\0080-\009F]'
+			OR (item->'provenance'->>'observed_at_microseconds') COLLATE pg_catalog."C" !~ '^(0|[1-9][0-9]{0,17})$'
+			OR (item->'provenance'->>'observed_at_microseconds')::numeric > 253402300799999999
+			OR (item->>'key') = ANY(metric_keys)
+			OR decodex.has_credential_material(item)
+		THEN RETURN false; END IF;
+		metric_keys := pg_catalog.array_append(metric_keys, item->>'key');
+	END LOOP;
+	RETURN true;
+END
+$$;
+
+CREATE FUNCTION decodex.is_program_signals(document jsonb)
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+AS $$
+DECLARE item jsonb;
+DECLARE item_count bigint;
+DECLARE signal_ids text[] := ARRAY[]::text[];
+BEGIN
+	IF pg_catalog.jsonb_typeof(document) <> 'array' THEN RETURN false; END IF;
+	SELECT pg_catalog.count(*) INTO item_count FROM pg_catalog.jsonb_array_elements(document);
+	IF item_count > 64 THEN RETURN false; END IF;
+	FOR item IN SELECT value FROM pg_catalog.jsonb_array_elements(document)
+	LOOP
+		IF pg_catalog.jsonb_typeof(item) <> 'object'
+			OR (SELECT pg_catalog.count(*) FROM pg_catalog.jsonb_object_keys(item)) <> 4
+			OR NOT item OPERATOR(pg_catalog.?&) ARRAY['id','kind','summary','provenance']
+			OR pg_catalog.jsonb_typeof(item->'id') <> 'string'
+			OR pg_catalog.jsonb_typeof(item->'kind') <> 'string'
+			OR pg_catalog.jsonb_typeof(item->'summary') <> 'string'
+			OR pg_catalog.jsonb_typeof(item->'provenance') <> 'object'
+			OR (SELECT pg_catalog.count(*) FROM pg_catalog.jsonb_object_keys(item->'provenance')) <> 2
+			OR NOT (item->'provenance') OPERATOR(pg_catalog.?&) ARRAY['source','observed_at_microseconds']
+			OR pg_catalog.jsonb_typeof(item->'provenance'->'source') <> 'string'
+			OR pg_catalog.jsonb_typeof(item->'provenance'->'observed_at_microseconds') <> 'number'
+			OR (item->>'id') COLLATE pg_catalog."C" !~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+			OR (item->>'kind') COLLATE pg_catalog."C" !~ '^[a-z][a-z0-9_]{0,63}$'
+			OR pg_catalog.octet_length(item->>'summary') NOT BETWEEN 1 AND 4096
+			OR pg_catalog.octet_length(item->'provenance'->>'source') NOT BETWEEN 1 AND 256
+			OR (item->>'summary') COLLATE pg_catalog."C" ~ '[[:cntrl:]]'
+			OR (item->'provenance'->>'source') COLLATE pg_catalog."C" ~ '[[:cntrl:]]'
+			OR (item->>'summary') COLLATE pg_catalog."C" ~ U&'[\0080-\009F]'
+			OR (item->'provenance'->>'source') COLLATE pg_catalog."C" ~ U&'[\0080-\009F]'
+			OR (item->'provenance'->>'observed_at_microseconds') COLLATE pg_catalog."C" !~ '^(0|[1-9][0-9]{0,17})$'
+			OR (item->'provenance'->>'observed_at_microseconds')::numeric > 253402300799999999
+			OR (item->>'id') = ANY(signal_ids)
+			OR decodex.has_credential_material(item)
+		THEN RETURN false; END IF;
+		signal_ids := pg_catalog.array_append(signal_ids, item->>'id');
+	END LOOP;
+	RETURN true;
+END
+$$;
+
+CREATE FUNCTION decodex.is_objective_criteria(document text[])
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+AS $$
+DECLARE item text;
+BEGIN
+	IF pg_catalog.array_ndims(document) <> 1
+		OR pg_catalog.cardinality(document) NOT BETWEEN 1 AND 32
+	THEN RETURN false; END IF;
+	FOREACH item IN ARRAY document
+	LOOP
+		IF item IS NULL
+			OR pg_catalog.octet_length(item) NOT BETWEEN 1 AND 4096
+			OR item COLLATE pg_catalog."C" ~ '[[:cntrl:]]'
+			OR item COLLATE pg_catalog."C" ~ U&'[\0080-\009F]'
+			OR decodex.has_credential_material(item)
+		THEN RETURN false; END IF;
+	END LOOP;
+	RETURN pg_catalog.cardinality(document) = (
+		SELECT pg_catalog.count(DISTINCT criterion)
+		FROM pg_catalog.unnest(document) AS criterion
+	);
+END
+$$;
+
+CREATE TABLE decodex.programs (
+	program_id uuid PRIMARY KEY,
+	project_id uuid NOT NULL REFERENCES decodex.projects(project_id) ON DELETE RESTRICT,
+	owner_agent_id uuid NOT NULL,
+	name text NOT NULL,
+	responsibility text NOT NULL,
+	state decodex.program_state NOT NULL DEFAULT 'active',
+	policy_id uuid NOT NULL,
+	policy_revision bigint NOT NULL CHECK (policy_revision > 0),
+	review_interval_days integer NOT NULL CHECK (review_interval_days BETWEEN 1 AND 365),
+	next_review_at timestamptz NOT NULL,
+	metrics jsonb NOT NULL DEFAULT '[]'::jsonb,
+	signals jsonb NOT NULL DEFAULT '[]'::jsonb,
+	revision bigint NOT NULL DEFAULT 1 CHECK (revision > 0),
+	last_changed_by uuid NOT NULL,
+	last_correlation_id uuid NOT NULL,
+	last_provenance text NOT NULL,
+	created_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	updated_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	CONSTRAINT programs_identity_project_unique UNIQUE (program_id, project_id),
+	CONSTRAINT programs_owner_project_fk FOREIGN KEY (owner_agent_id, project_id)
+		REFERENCES decodex.agents(agent_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT programs_policy_revision_fk FOREIGN KEY (policy_id, project_id, policy_revision)
+		REFERENCES decodex.policy_revisions(policy_id, project_id, revision) ON DELETE RESTRICT,
+	CONSTRAINT programs_last_actor_project_fk FOREIGN KEY (last_changed_by, project_id)
+		REFERENCES decodex.agents(agent_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT programs_ids_canonical CHECK (
+		program_id::text COLLATE pg_catalog."C" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+		AND last_correlation_id::text COLLATE pg_catalog."C" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	),
+	CONSTRAINT programs_text_bounded CHECK (
+		pg_catalog.octet_length(name) >= 1 AND pg_catalog.octet_length(name) <= 256
+		AND pg_catalog.octet_length(responsibility) >= 1
+		AND pg_catalog.octet_length(responsibility) <= 4096
+		AND pg_catalog.octet_length(last_provenance) >= 1
+		AND pg_catalog.octet_length(last_provenance) <= 4096
+		AND name COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND responsibility COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND last_provenance COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND name COLLATE pg_catalog."C" !~ U&'[\0080-\009F]'
+		AND responsibility COLLATE pg_catalog."C" !~ U&'[\0080-\009F]'
+		AND last_provenance COLLATE pg_catalog."C" !~ U&'[\0080-\009F]'
+	),
+	CONSTRAINT programs_observations_bounded CHECK (
+		decodex.is_program_metrics(metrics) AND decodex.is_program_signals(signals)
+	),
+	CONSTRAINT programs_finite_timestamps CHECK (
+		pg_catalog.isfinite(next_review_at) AND pg_catalog.isfinite(created_at)
+		AND pg_catalog.isfinite(updated_at) AND updated_at >= created_at
+		AND next_review_at >= TIMESTAMPTZ 'epoch'
+		AND next_review_at <= TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+		AND created_at >= TIMESTAMPTZ 'epoch'
+		AND created_at <= TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+		AND updated_at >= TIMESTAMPTZ 'epoch'
+		AND updated_at <= TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+	),
+	CONSTRAINT programs_no_credentials CHECK (
+		NOT decodex.has_credential_material(name)
+		AND NOT decodex.has_credential_material(responsibility)
+		AND NOT decodex.has_credential_material(last_provenance)
+		AND NOT decodex.has_credential_material(metrics)
+		AND NOT decodex.has_credential_material(signals)
+	)
+);
+
+CREATE TABLE decodex.objectives (
+	objective_id uuid PRIMARY KEY,
+	project_id uuid NOT NULL REFERENCES decodex.projects(project_id) ON DELETE RESTRICT,
+	program_id uuid,
+	outcome text NOT NULL,
+	acceptance_criteria text[] NOT NULL,
+	validation_criteria text[] NOT NULL,
+	target_at timestamptz NOT NULL,
+	state decodex.objective_state NOT NULL DEFAULT 'proposed',
+	revision bigint NOT NULL DEFAULT 1 CHECK (revision > 0),
+	completion_evidence_id uuid,
+	last_changed_by uuid NOT NULL,
+	last_correlation_id uuid NOT NULL,
+	last_provenance text NOT NULL,
+	created_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	updated_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	CONSTRAINT objectives_identity_project_unique UNIQUE (objective_id, project_id),
+	CONSTRAINT objectives_program_project_fk FOREIGN KEY (program_id, project_id)
+		REFERENCES decodex.programs(program_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT objectives_last_actor_project_fk FOREIGN KEY (last_changed_by, project_id)
+		REFERENCES decodex.agents(agent_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT objectives_ids_canonical CHECK (
+		objective_id::text COLLATE pg_catalog."C" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+		AND last_correlation_id::text COLLATE pg_catalog."C" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	),
+	CONSTRAINT objectives_text_bounded CHECK (
+		pg_catalog.octet_length(outcome) >= 1 AND pg_catalog.octet_length(outcome) <= 4096
+		AND pg_catalog.octet_length(last_provenance) >= 1
+		AND pg_catalog.octet_length(last_provenance) <= 4096
+		AND outcome COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND last_provenance COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND outcome COLLATE pg_catalog."C" !~ U&'[\0080-\009F]'
+		AND last_provenance COLLATE pg_catalog."C" !~ U&'[\0080-\009F]'
+	),
+	CONSTRAINT objectives_criteria_bounded CHECK (
+		decodex.is_objective_criteria(acceptance_criteria)
+		AND decodex.is_objective_criteria(validation_criteria)
+	),
+	CONSTRAINT objectives_completion_state CHECK (
+		(state = 'achieved') = (completion_evidence_id IS NOT NULL)
+	),
+	CONSTRAINT objectives_finite_timestamps CHECK (
+		pg_catalog.isfinite(target_at) AND pg_catalog.isfinite(created_at)
+		AND pg_catalog.isfinite(updated_at) AND updated_at >= created_at
+		AND target_at >= TIMESTAMPTZ 'epoch'
+		AND target_at <= TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+		AND created_at >= TIMESTAMPTZ 'epoch'
+		AND created_at <= TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+		AND updated_at >= TIMESTAMPTZ 'epoch'
+		AND updated_at <= TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+	),
+	CONSTRAINT objectives_no_credentials CHECK (
+		NOT decodex.has_credential_material(outcome)
+		AND NOT decodex.has_credential_material(pg_catalog.to_jsonb(acceptance_criteria))
+		AND NOT decodex.has_credential_material(pg_catalog.to_jsonb(validation_criteria))
+		AND NOT decodex.has_credential_material(last_provenance)
+	)
+);
+
+CREATE TABLE decodex.objective_completion_evidence (
+	evidence_id uuid PRIMARY KEY,
+	objective_id uuid NOT NULL,
+	project_id uuid NOT NULL,
+	objective_revision bigint NOT NULL CHECK (objective_revision > 0),
+	objective_updated_at timestamptz NOT NULL,
+	acceptance_result text NOT NULL,
+	accepted_by uuid NOT NULL,
+	accepted_at timestamptz NOT NULL,
+	acceptance_provenance text NOT NULL,
+	validation_result text NOT NULL,
+	validated_by uuid NOT NULL,
+	validated_at timestamptz NOT NULL,
+	validation_provenance text NOT NULL,
+	correlation_id uuid NOT NULL,
+	recorded_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	CONSTRAINT objective_evidence_identity_scope_unique UNIQUE (evidence_id, objective_id, project_id),
+	CONSTRAINT objective_evidence_one_per_objective UNIQUE (objective_id),
+	CONSTRAINT objective_evidence_objective_project_fk FOREIGN KEY (objective_id, project_id)
+		REFERENCES decodex.objectives(objective_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT objective_evidence_accepting_agent_project_fk FOREIGN KEY (accepted_by, project_id)
+		REFERENCES decodex.agents(agent_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT objective_evidence_validating_agent_project_fk FOREIGN KEY (validated_by, project_id)
+		REFERENCES decodex.agents(agent_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT objective_evidence_ids_canonical CHECK (
+		evidence_id::text COLLATE pg_catalog."C" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+		AND correlation_id::text COLLATE pg_catalog."C" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	),
+	CONSTRAINT objective_evidence_text_bounded CHECK (
+		pg_catalog.octet_length(acceptance_result) >= 1
+		AND pg_catalog.octet_length(acceptance_result) <= 4096
+		AND pg_catalog.octet_length(acceptance_provenance) >= 1
+		AND pg_catalog.octet_length(acceptance_provenance) <= 4096
+		AND pg_catalog.octet_length(validation_result) >= 1
+		AND pg_catalog.octet_length(validation_result) <= 4096
+		AND pg_catalog.octet_length(validation_provenance) >= 1
+		AND pg_catalog.octet_length(validation_provenance) <= 4096
+		AND acceptance_result COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND acceptance_provenance COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND validation_result COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND validation_provenance COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND acceptance_result COLLATE pg_catalog."C" !~ U&'[\0080-\009F]'
+		AND acceptance_provenance COLLATE pg_catalog."C" !~ U&'[\0080-\009F]'
+		AND validation_result COLLATE pg_catalog."C" !~ U&'[\0080-\009F]'
+		AND validation_provenance COLLATE pg_catalog."C" !~ U&'[\0080-\009F]'
+	),
+	CONSTRAINT objective_evidence_chronology CHECK (
+		pg_catalog.isfinite(objective_updated_at) AND pg_catalog.isfinite(accepted_at)
+		AND pg_catalog.isfinite(validated_at) AND pg_catalog.isfinite(recorded_at)
+		AND objective_updated_at >= TIMESTAMPTZ 'epoch'
+		AND recorded_at <= TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+		AND objective_updated_at <= accepted_at AND accepted_at <= validated_at
+		AND validated_at <= recorded_at
+	),
+	CONSTRAINT objective_evidence_no_credentials CHECK (
+		NOT decodex.has_credential_material(acceptance_result)
+		AND NOT decodex.has_credential_material(acceptance_provenance)
+		AND NOT decodex.has_credential_material(validation_result)
+		AND NOT decodex.has_credential_material(validation_provenance)
+	)
+);
+
+ALTER TABLE decodex.objectives
+	ADD CONSTRAINT objectives_completion_evidence_fk
+	FOREIGN KEY (completion_evidence_id, objective_id, project_id)
+	REFERENCES decodex.objective_completion_evidence(evidence_id, objective_id, project_id)
+	ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED;
+
+CREATE FUNCTION decodex.enforce_program_state()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+	IF TG_OP = 'TRUNCATE' OR TG_OP = 'DELETE' THEN
+		RAISE EXCEPTION 'Programs are retained'
+			USING ERRCODE = '55000', CONSTRAINT = 'programs_retained';
+	END IF;
+	IF TG_OP = 'INSERT' THEN
+		IF NEW.state <> 'active' OR NEW.revision <> 1 OR NEW.updated_at <> NEW.created_at THEN
+			RAISE EXCEPTION 'Program insertion must be canonical active revision one'
+				USING ERRCODE = '23514', CONSTRAINT = 'programs_canonical_insert';
+		END IF;
+		RETURN NEW;
+	END IF;
+	IF OLD.state = 'retired' THEN
+		RAISE EXCEPTION 'retired Program is immutable'
+			USING ERRCODE = '55000', CONSTRAINT = 'programs_retired_terminal';
+	END IF;
+	IF NEW.program_id IS DISTINCT FROM OLD.program_id
+		OR NEW.project_id IS DISTINCT FROM OLD.project_id
+		OR NEW.owner_agent_id IS DISTINCT FROM OLD.owner_agent_id
+		OR NEW.name IS DISTINCT FROM OLD.name
+		OR NEW.responsibility IS DISTINCT FROM OLD.responsibility
+		OR NEW.policy_id IS DISTINCT FROM OLD.policy_id
+		OR NEW.policy_revision IS DISTINCT FROM OLD.policy_revision
+		OR NEW.created_at IS DISTINCT FROM OLD.created_at
+		OR NEW.revision IS DISTINCT FROM OLD.revision + 1
+		OR NEW.updated_at < OLD.updated_at
+	THEN
+		RAISE EXCEPTION 'Program identity or revision mutation is invalid'
+			USING ERRCODE = '23514', CONSTRAINT = 'programs_identity_revision';
+	END IF;
+	IF NEW.state IS DISTINCT FROM OLD.state THEN
+		IF NOT (
+			(OLD.state = 'active' AND NEW.state IN ('needs_attention','blocked','paused','retired'))
+			OR (OLD.state = 'needs_attention' AND NEW.state IN ('active','blocked','paused','retired'))
+			OR (OLD.state = 'blocked' AND NEW.state IN ('active','needs_attention','paused','retired'))
+			OR (OLD.state = 'paused' AND NEW.state IN ('active','retired'))
+		) OR NEW.review_interval_days IS DISTINCT FROM OLD.review_interval_days
+			OR NEW.next_review_at IS DISTINCT FROM OLD.next_review_at
+			OR NEW.metrics IS DISTINCT FROM OLD.metrics OR NEW.signals IS DISTINCT FROM OLD.signals
+		THEN
+			RAISE EXCEPTION 'Program lifecycle transition is invalid'
+				USING ERRCODE = '23514', CONSTRAINT = 'programs_invalid_transition';
+		END IF;
+	ELSIF NEW.review_interval_days IS NOT DISTINCT FROM OLD.review_interval_days
+		AND NEW.next_review_at IS NOT DISTINCT FROM OLD.next_review_at
+		AND NEW.metrics IS NOT DISTINCT FROM OLD.metrics
+		AND NEW.signals IS NOT DISTINCT FROM OLD.signals
+	THEN
+		RAISE EXCEPTION 'Program context update is empty'
+			USING ERRCODE = '23514', CONSTRAINT = 'programs_noop_update';
+	END IF;
+	RETURN NEW;
+END
+$$;
+
+CREATE FUNCTION decodex.enforce_objective_state()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE evidence_row decodex.objective_completion_evidence%ROWTYPE;
+BEGIN
+	IF TG_OP = 'TRUNCATE' OR TG_OP = 'DELETE' THEN
+		RAISE EXCEPTION 'Objectives are retained'
+			USING ERRCODE = '55000', CONSTRAINT = 'objectives_retained';
+	END IF;
+	IF TG_OP = 'INSERT' THEN
+		IF NEW.state <> 'proposed' OR NEW.revision <> 1
+			OR NEW.completion_evidence_id IS NOT NULL OR NEW.updated_at <> NEW.created_at
+		THEN
+			RAISE EXCEPTION 'Objective insertion must be canonical proposed revision one'
+				USING ERRCODE = '23514', CONSTRAINT = 'objectives_canonical_insert';
+		END IF;
+		RETURN NEW;
+	END IF;
+	IF OLD.state IN ('achieved','abandoned') THEN
+		RAISE EXCEPTION 'terminal Objective is immutable'
+			USING ERRCODE = '55000', CONSTRAINT = 'objectives_terminal';
+	END IF;
+	IF NEW.objective_id IS DISTINCT FROM OLD.objective_id
+		OR NEW.project_id IS DISTINCT FROM OLD.project_id
+		OR NEW.program_id IS DISTINCT FROM OLD.program_id
+		OR NEW.outcome IS DISTINCT FROM OLD.outcome
+		OR NEW.acceptance_criteria IS DISTINCT FROM OLD.acceptance_criteria
+		OR NEW.validation_criteria IS DISTINCT FROM OLD.validation_criteria
+		OR NEW.target_at IS DISTINCT FROM OLD.target_at
+		OR NEW.created_at IS DISTINCT FROM OLD.created_at
+		OR NEW.revision IS DISTINCT FROM OLD.revision + 1
+		OR NEW.updated_at < OLD.updated_at
+	THEN
+		RAISE EXCEPTION 'Objective identity or revision mutation is invalid'
+			USING ERRCODE = '23514', CONSTRAINT = 'objectives_identity_revision';
+	END IF;
+	IF NEW.state = 'achieved' THEN
+		SELECT stored.* INTO evidence_row
+		FROM decodex.objective_completion_evidence AS stored
+		WHERE stored.evidence_id = NEW.completion_evidence_id;
+		IF NOT FOUND OR evidence_row.objective_id <> OLD.objective_id
+			OR evidence_row.project_id <> OLD.project_id
+			OR evidence_row.objective_revision <> OLD.revision
+			OR evidence_row.objective_updated_at <> OLD.updated_at
+			OR evidence_row.accepted_at < OLD.updated_at
+		THEN
+			RAISE EXCEPTION 'Objective achievement evidence must follow its exact prior revision'
+				USING ERRCODE = '23514', CONSTRAINT = 'objective_evidence_prior_revision_time';
+		END IF;
+	END IF;
+	IF NOT (
+		(OLD.state = 'proposed' AND NEW.state IN ('active','abandoned'))
+		OR (OLD.state = 'active' AND NEW.state IN ('blocked','achieved','abandoned'))
+		OR (OLD.state = 'blocked' AND NEW.state IN ('active','achieved','abandoned'))
+	) THEN
+		RAISE EXCEPTION 'Objective lifecycle transition is invalid'
+			USING ERRCODE = '23514', CONSTRAINT = 'objectives_invalid_transition';
+	END IF;
+	RETURN NEW;
+END
+$$;
+
+CREATE FUNCTION decodex.forbid_objective_evidence_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+	RAISE EXCEPTION 'Objective completion evidence is immutable'
+		USING ERRCODE = '55000', CONSTRAINT = 'objective_evidence_immutable';
+END
+$$;
+
+CREATE FUNCTION decodex.enforce_objective_completion_coherence()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE objective_row decodex.objectives%ROWTYPE;
+DECLARE evidence_row decodex.objective_completion_evidence%ROWTYPE;
+BEGIN
+	IF TG_TABLE_NAME = 'objectives' THEN
+		IF NEW.state <> 'achieved' THEN RETURN NEW; END IF;
+		SELECT stored.* INTO evidence_row FROM decodex.objective_completion_evidence AS stored
+		WHERE stored.evidence_id = NEW.completion_evidence_id;
+		IF NOT FOUND OR evidence_row.objective_id <> NEW.objective_id
+			OR evidence_row.project_id <> NEW.project_id
+			OR evidence_row.objective_revision + 1 <> NEW.revision
+		THEN
+			RAISE EXCEPTION 'achieved Objective requires exact prior-revision evidence'
+				USING ERRCODE = '23514', CONSTRAINT = 'objective_completion_coherence';
+		END IF;
+		RETURN NEW;
+	END IF;
+	SELECT stored.* INTO objective_row FROM decodex.objectives AS stored
+	WHERE stored.objective_id = NEW.objective_id;
+	IF NOT FOUND OR objective_row.project_id <> NEW.project_id
+		OR objective_row.state <> 'achieved'
+		OR objective_row.completion_evidence_id <> NEW.evidence_id
+		OR objective_row.revision <> NEW.objective_revision + 1
+	THEN
+		RAISE EXCEPTION 'Objective evidence must establish one exact achieved revision'
+			USING ERRCODE = '23514', CONSTRAINT = 'objective_completion_coherence';
+	END IF;
+	RETURN NEW;
+END
+$$;
+
+CREATE TRIGGER programs_state_guard
+BEFORE INSERT OR UPDATE OR DELETE ON decodex.programs
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_program_state();
+CREATE TRIGGER programs_truncate_forbidden
+BEFORE TRUNCATE ON decodex.programs
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_program_state();
+CREATE TRIGGER objectives_state_guard
+BEFORE INSERT OR UPDATE OR DELETE ON decodex.objectives
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_objective_state();
+CREATE TRIGGER objectives_truncate_forbidden
+BEFORE TRUNCATE ON decodex.objectives
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_objective_state();
+CREATE TRIGGER objective_evidence_immutable
+BEFORE UPDATE OR DELETE ON decodex.objective_completion_evidence
+FOR EACH ROW EXECUTE FUNCTION decodex.forbid_objective_evidence_mutation();
+CREATE TRIGGER objective_evidence_truncate_forbidden
+BEFORE TRUNCATE ON decodex.objective_completion_evidence
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.forbid_objective_evidence_mutation();
+CREATE CONSTRAINT TRIGGER objectives_completion_coherence
+AFTER INSERT OR UPDATE ON decodex.objectives DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_objective_completion_coherence();
+CREATE CONSTRAINT TRIGGER objective_evidence_completion_coherence
+AFTER INSERT ON decodex.objective_completion_evidence DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_objective_completion_coherence();
+
+CREATE FUNCTION decodex.create_program(
+	p_program_id decodex.canonical_uuid_v4_text,
+	p_project_id decodex.canonical_uuid_v4_text,
+	p_owner_agent_id decodex.canonical_uuid_v4_text,
+	p_name text,
+	p_responsibility text,
+	p_policy_id decodex.canonical_uuid_v4_text,
+	p_policy_revision bigint,
+	p_review_interval_days integer,
+	p_next_review_at bigint,
+	p_metrics jsonb,
+	p_signals jsonb,
+	p_correlation_id decodex.canonical_uuid_v4_text,
+	p_provenance text
+)
+RETURNS TABLE (result_code text, actual_revision bigint, changed boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+CALLED ON NULL INPUT
+AS $$
+DECLARE canonical_program_id uuid;
+DECLARE canonical_project_id uuid;
+DECLARE canonical_owner_agent_id uuid;
+DECLARE canonical_policy_id uuid;
+DECLARE canonical_correlation_id uuid;
+DECLARE existing decodex.programs%ROWTYPE;
+DECLARE write_time timestamptz;
+DECLARE inserted boolean := false;
+BEGIN
+	IF p_program_id IS NULL OR p_project_id IS NULL OR p_owner_agent_id IS NULL
+		OR p_policy_id IS NULL OR p_correlation_id IS NULL THEN
+		RAISE EXCEPTION 'identity ingress requires canonical UUID-v4 text'
+			USING ERRCODE = '23514', CONSTRAINT = 'canonical_uuid_v4_text_ingress';
+	END IF;
+	canonical_program_id := p_program_id::text::uuid;
+	canonical_project_id := p_project_id::text::uuid;
+	canonical_owner_agent_id := p_owner_agent_id::text::uuid;
+	canonical_policy_id := p_policy_id::text::uuid;
+	canonical_correlation_id := p_correlation_id::text::uuid;
+	PERFORM 1 FROM decodex.projects AS project
+	JOIN decodex.agents AS lead ON lead.project_id=project.project_id AND lead.role='lead'
+	WHERE project.project_id=canonical_project_id AND project.status='active'
+		AND lead.agent_id=canonical_owner_agent_id AND lead.status='active' FOR KEY SHARE OF project, lead;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'invalid_authority', NULL::bigint, false; RETURN; END IF;
+	PERFORM 1 FROM decodex.policy_revisions AS revision
+	WHERE revision.policy_id=canonical_policy_id AND revision.project_id=canonical_project_id
+		AND revision.revision=p_policy_revision FOR KEY SHARE;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'invalid_policy', NULL::bigint, false; RETURN; END IF;
+	write_time := pg_catalog.clock_timestamp();
+	INSERT INTO decodex.programs (
+		program_id,project_id,owner_agent_id,name,responsibility,policy_id,policy_revision,
+		review_interval_days,next_review_at,metrics,signals,last_changed_by,last_correlation_id,
+		last_provenance,created_at,updated_at
+	) VALUES (
+		canonical_program_id,canonical_project_id,canonical_owner_agent_id,p_name,p_responsibility,
+		canonical_policy_id,p_policy_revision,p_review_interval_days,
+		decodex.program_timestamp(p_next_review_at),p_metrics,p_signals,
+		canonical_owner_agent_id,canonical_correlation_id,p_provenance,
+		write_time,write_time
+	) ON CONFLICT DO NOTHING
+	RETURNING true INTO inserted;
+	IF inserted IS NULL THEN inserted := false; END IF;
+	SELECT stored.* INTO existing FROM decodex.programs AS stored
+	WHERE stored.program_id=canonical_program_id FOR UPDATE;
+	IF existing.project_id=canonical_project_id AND existing.owner_agent_id=canonical_owner_agent_id
+		AND existing.name=p_name AND existing.responsibility=p_responsibility
+		AND existing.policy_id=canonical_policy_id AND existing.policy_revision=p_policy_revision
+		AND existing.review_interval_days=p_review_interval_days
+		AND existing.next_review_at=decodex.program_timestamp(p_next_review_at)
+		AND existing.metrics=p_metrics AND existing.signals=p_signals
+	THEN RETURN QUERY SELECT 'ok', existing.revision, inserted; RETURN; END IF;
+	RETURN QUERY SELECT 'conflicting_identity', existing.revision, false;
+END
+$$;
+
+CREATE FUNCTION decodex.update_program_context(
+	p_program_id decodex.canonical_uuid_v4_text,
+	p_project_id decodex.canonical_uuid_v4_text,
+	p_expected_revision bigint,
+	p_review_interval_days integer,
+	p_next_review_at bigint,
+	p_metrics jsonb,
+	p_signals jsonb,
+	p_actor_id decodex.canonical_uuid_v4_text,
+	p_correlation_id decodex.canonical_uuid_v4_text,
+	p_provenance text
+)
+RETURNS TABLE (result_code text, actual_revision bigint, changed boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+CALLED ON NULL INPUT
+AS $$
+DECLARE canonical_program_id uuid;
+DECLARE canonical_project_id uuid;
+DECLARE canonical_actor_id uuid;
+DECLARE canonical_correlation_id uuid;
+DECLARE stored decodex.programs%ROWTYPE;
+BEGIN
+	IF p_program_id IS NULL OR p_project_id IS NULL OR p_actor_id IS NULL
+		OR p_correlation_id IS NULL THEN
+		RAISE EXCEPTION 'identity ingress requires canonical UUID-v4 text'
+			USING ERRCODE = '23514', CONSTRAINT = 'canonical_uuid_v4_text_ingress';
+	END IF;
+	canonical_program_id := p_program_id::text::uuid;
+	canonical_project_id := p_project_id::text::uuid;
+	canonical_actor_id := p_actor_id::text::uuid;
+	canonical_correlation_id := p_correlation_id::text::uuid;
+	SELECT current.* INTO stored FROM decodex.programs AS current
+	WHERE current.program_id=canonical_program_id FOR UPDATE;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'not_found', NULL::bigint, false; RETURN; END IF;
+	IF stored.project_id<>canonical_project_id THEN
+		RETURN QUERY SELECT 'invalid_project', NULL::bigint, false; RETURN;
+	END IF;
+	IF stored.revision IS DISTINCT FROM p_expected_revision THEN
+		RETURN QUERY SELECT 'revision_conflict', stored.revision, false; RETURN;
+	END IF;
+	PERFORM 1 FROM decodex.projects AS project JOIN decodex.agents AS lead
+		ON lead.project_id=project.project_id AND lead.role='lead'
+	WHERE project.project_id=canonical_project_id AND project.status='active'
+		AND lead.agent_id=canonical_actor_id AND lead.agent_id=stored.owner_agent_id
+		AND lead.status='active' FOR KEY SHARE OF project, lead;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'invalid_authority', stored.revision, false; RETURN; END IF;
+	IF stored.state='retired' THEN RETURN QUERY SELECT 'invalid_transition', stored.revision, false; RETURN; END IF;
+	IF stored.review_interval_days=p_review_interval_days
+		AND stored.next_review_at=decodex.program_timestamp(p_next_review_at)
+		AND stored.metrics=p_metrics AND stored.signals=p_signals
+	THEN RETURN QUERY SELECT 'invalid_transition', stored.revision, false; RETURN; END IF;
+	UPDATE decodex.programs SET review_interval_days=p_review_interval_days,
+		next_review_at=decodex.program_timestamp(p_next_review_at),metrics=p_metrics,
+		signals=p_signals,revision=revision+1,
+		last_changed_by=canonical_actor_id,last_correlation_id=canonical_correlation_id,
+		last_provenance=p_provenance,updated_at=pg_catalog.clock_timestamp()
+	WHERE program_id=canonical_program_id;
+	RETURN QUERY SELECT 'ok', stored.revision+1, true;
+END
+$$;
+
+CREATE FUNCTION decodex.transition_program(
+	p_program_id decodex.canonical_uuid_v4_text,
+	p_project_id decodex.canonical_uuid_v4_text,
+	p_expected_revision bigint,
+	p_state decodex.program_state,
+	p_actor_id decodex.canonical_uuid_v4_text,
+	p_correlation_id decodex.canonical_uuid_v4_text,
+	p_provenance text
+)
+RETURNS TABLE (result_code text, actual_revision bigint, changed boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+CALLED ON NULL INPUT
+AS $$
+DECLARE canonical_program_id uuid;
+DECLARE canonical_project_id uuid;
+DECLARE canonical_actor_id uuid;
+DECLARE canonical_correlation_id uuid;
+DECLARE stored decodex.programs%ROWTYPE;
+BEGIN
+	IF p_program_id IS NULL OR p_project_id IS NULL OR p_actor_id IS NULL
+		OR p_correlation_id IS NULL THEN
+		RAISE EXCEPTION 'identity ingress requires canonical UUID-v4 text'
+			USING ERRCODE = '23514', CONSTRAINT = 'canonical_uuid_v4_text_ingress';
+	END IF;
+	canonical_program_id := p_program_id::text::uuid;
+	canonical_project_id := p_project_id::text::uuid;
+	canonical_actor_id := p_actor_id::text::uuid;
+	canonical_correlation_id := p_correlation_id::text::uuid;
+	SELECT current.* INTO stored FROM decodex.programs AS current
+	WHERE current.program_id=canonical_program_id FOR UPDATE;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'not_found', NULL::bigint, false; RETURN; END IF;
+	IF stored.project_id<>canonical_project_id THEN
+		RETURN QUERY SELECT 'invalid_project', NULL::bigint, false; RETURN;
+	END IF;
+	IF stored.revision IS DISTINCT FROM p_expected_revision THEN
+		RETURN QUERY SELECT 'revision_conflict', stored.revision, false; RETURN;
+	END IF;
+	PERFORM 1 FROM decodex.projects AS project JOIN decodex.agents AS lead
+		ON lead.project_id=project.project_id AND lead.role='lead'
+	WHERE project.project_id=canonical_project_id AND project.status='active'
+		AND lead.agent_id=canonical_actor_id AND lead.agent_id=stored.owner_agent_id
+		AND lead.status='active' FOR KEY SHARE OF project, lead;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'invalid_authority', stored.revision, false; RETURN; END IF;
+	IF NOT (
+		(stored.state='active' AND p_state IN ('needs_attention','blocked','paused','retired'))
+		OR (stored.state='needs_attention' AND p_state IN ('active','blocked','paused','retired'))
+		OR (stored.state='blocked' AND p_state IN ('active','needs_attention','paused','retired'))
+		OR (stored.state='paused' AND p_state IN ('active','retired'))
+	) THEN RETURN QUERY SELECT 'invalid_transition', stored.revision, false; RETURN; END IF;
+	UPDATE decodex.programs SET state=p_state,revision=revision+1,
+		last_changed_by=canonical_actor_id,last_correlation_id=canonical_correlation_id,
+		last_provenance=p_provenance,updated_at=pg_catalog.clock_timestamp()
+	WHERE program_id=canonical_program_id;
+	RETURN QUERY SELECT 'ok', stored.revision+1, true;
+END
+$$;
+
+CREATE FUNCTION decodex.create_objective(
+	p_objective_id decodex.canonical_uuid_v4_text,
+	p_project_id decodex.canonical_uuid_v4_text,
+	p_program_id decodex.canonical_uuid_v4_text,
+	p_outcome text,
+	p_acceptance_criteria text[],
+	p_validation_criteria text[],
+	p_target_at bigint,
+	p_actor_id decodex.canonical_uuid_v4_text,
+	p_correlation_id decodex.canonical_uuid_v4_text,
+	p_provenance text
+)
+RETURNS TABLE (result_code text, actual_revision bigint, changed boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+CALLED ON NULL INPUT
+AS $$
+DECLARE canonical_objective_id uuid;
+DECLARE canonical_project_id uuid;
+DECLARE canonical_program_id uuid;
+DECLARE canonical_actor_id uuid;
+DECLARE canonical_correlation_id uuid;
+DECLARE existing decodex.objectives%ROWTYPE;
+DECLARE write_time timestamptz;
+DECLARE inserted boolean := false;
+BEGIN
+	IF p_objective_id IS NULL OR p_project_id IS NULL OR p_actor_id IS NULL
+		OR p_correlation_id IS NULL THEN
+		RAISE EXCEPTION 'identity ingress requires canonical UUID-v4 text'
+			USING ERRCODE = '23514', CONSTRAINT = 'canonical_uuid_v4_text_ingress';
+	END IF;
+	canonical_objective_id := p_objective_id::text::uuid;
+	canonical_project_id := p_project_id::text::uuid;
+	canonical_program_id := CASE WHEN p_program_id IS NULL THEN NULL ELSE p_program_id::text::uuid END;
+	canonical_actor_id := p_actor_id::text::uuid;
+	canonical_correlation_id := p_correlation_id::text::uuid;
+	PERFORM 1 FROM decodex.projects AS project JOIN decodex.agents AS lead
+		ON lead.project_id=project.project_id AND lead.role='lead'
+	WHERE project.project_id=canonical_project_id AND project.status='active'
+		AND lead.agent_id=canonical_actor_id AND lead.status='active' FOR KEY SHARE OF project, lead;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'invalid_authority', NULL::bigint, false; RETURN; END IF;
+	IF canonical_program_id IS NOT NULL AND NOT EXISTS (
+		SELECT 1 FROM decodex.programs AS program
+		WHERE program.program_id=canonical_program_id AND program.project_id=canonical_project_id
+	) THEN RETURN QUERY SELECT 'invalid_program', NULL::bigint, false; RETURN; END IF;
+	IF decodex.program_timestamp(p_target_at) IS NULL
+		OR decodex.program_timestamp(p_target_at) <= pg_catalog.clock_timestamp()
+	THEN RETURN QUERY SELECT 'invalid_horizon', NULL::bigint, false; RETURN; END IF;
+	write_time := pg_catalog.clock_timestamp();
+	INSERT INTO decodex.objectives (
+		objective_id,project_id,program_id,outcome,acceptance_criteria,validation_criteria,
+		target_at,last_changed_by,last_correlation_id,last_provenance,created_at,updated_at
+	) VALUES (
+		canonical_objective_id,canonical_project_id,canonical_program_id,p_outcome,
+		p_acceptance_criteria,p_validation_criteria,decodex.program_timestamp(p_target_at),
+		canonical_actor_id,
+		canonical_correlation_id,p_provenance,write_time,write_time
+	) ON CONFLICT DO NOTHING
+	RETURNING true INTO inserted;
+	IF inserted IS NULL THEN inserted := false; END IF;
+	SELECT stored.* INTO existing FROM decodex.objectives AS stored
+	WHERE stored.objective_id=canonical_objective_id FOR UPDATE;
+	IF existing.project_id=canonical_project_id
+		AND existing.program_id IS NOT DISTINCT FROM canonical_program_id
+		AND existing.outcome=p_outcome AND existing.acceptance_criteria=p_acceptance_criteria
+		AND existing.validation_criteria=p_validation_criteria
+		AND existing.target_at=decodex.program_timestamp(p_target_at)
+	THEN RETURN QUERY SELECT 'ok', existing.revision, inserted; RETURN; END IF;
+	RETURN QUERY SELECT 'conflicting_identity', existing.revision, false;
+END
+$$;
+
+CREATE FUNCTION decodex.transition_objective(
+	p_objective_id decodex.canonical_uuid_v4_text,
+	p_project_id decodex.canonical_uuid_v4_text,
+	p_expected_revision bigint,
+	p_state decodex.objective_state,
+	p_actor_id decodex.canonical_uuid_v4_text,
+	p_correlation_id decodex.canonical_uuid_v4_text,
+	p_provenance text
+)
+RETURNS TABLE (result_code text, actual_revision bigint, changed boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+CALLED ON NULL INPUT
+AS $$
+DECLARE canonical_objective_id uuid;
+DECLARE canonical_project_id uuid;
+DECLARE canonical_actor_id uuid;
+DECLARE canonical_correlation_id uuid;
+DECLARE stored decodex.objectives%ROWTYPE;
+BEGIN
+	IF p_objective_id IS NULL OR p_project_id IS NULL OR p_actor_id IS NULL
+		OR p_correlation_id IS NULL THEN
+		RAISE EXCEPTION 'identity ingress requires canonical UUID-v4 text'
+			USING ERRCODE = '23514', CONSTRAINT = 'canonical_uuid_v4_text_ingress';
+	END IF;
+	canonical_objective_id := p_objective_id::text::uuid;
+	canonical_project_id := p_project_id::text::uuid;
+	canonical_actor_id := p_actor_id::text::uuid;
+	canonical_correlation_id := p_correlation_id::text::uuid;
+	SELECT current.* INTO stored FROM decodex.objectives AS current
+	WHERE current.objective_id=canonical_objective_id FOR UPDATE;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'not_found', NULL::bigint, false; RETURN; END IF;
+	IF stored.project_id<>canonical_project_id THEN
+		RETURN QUERY SELECT 'invalid_project', NULL::bigint, false; RETURN;
+	END IF;
+	IF stored.revision IS DISTINCT FROM p_expected_revision THEN
+		RETURN QUERY SELECT 'revision_conflict', stored.revision, false; RETURN;
+	END IF;
+	PERFORM 1 FROM decodex.projects AS project JOIN decodex.agents AS lead
+		ON lead.project_id=project.project_id AND lead.role='lead'
+	WHERE project.project_id=canonical_project_id AND project.status='active'
+		AND lead.agent_id=canonical_actor_id AND lead.status='active' FOR KEY SHARE OF project, lead;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'invalid_authority', stored.revision, false; RETURN; END IF;
+	IF NOT (
+		(stored.state='proposed' AND p_state IN ('active','abandoned'))
+		OR (stored.state='active' AND p_state IN ('blocked','abandoned'))
+		OR (stored.state='blocked' AND p_state IN ('active','abandoned'))
+	) THEN RETURN QUERY SELECT 'invalid_transition', stored.revision, false; RETURN; END IF;
+	UPDATE decodex.objectives SET state=p_state,revision=revision+1,
+		last_changed_by=canonical_actor_id,last_correlation_id=canonical_correlation_id,
+		last_provenance=p_provenance,updated_at=pg_catalog.clock_timestamp()
+	WHERE objective_id=canonical_objective_id;
+	RETURN QUERY SELECT 'ok', stored.revision+1, true;
+END
+$$;
+
+CREATE FUNCTION decodex.achieve_objective(
+	p_evidence_id decodex.canonical_uuid_v4_text,
+	p_objective_id decodex.canonical_uuid_v4_text,
+	p_project_id decodex.canonical_uuid_v4_text,
+	p_objective_revision bigint,
+	p_acceptance_result text,
+	p_accepted_by decodex.canonical_uuid_v4_text,
+	p_accepted_at bigint,
+	p_acceptance_provenance text,
+	p_validation_result text,
+	p_validated_by decodex.canonical_uuid_v4_text,
+	p_validated_at bigint,
+	p_validation_provenance text,
+	p_correlation_id decodex.canonical_uuid_v4_text
+)
+RETURNS TABLE (result_code text, actual_revision bigint, changed boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+CALLED ON NULL INPUT
+AS $$
+DECLARE canonical_evidence_id uuid;
+DECLARE canonical_objective_id uuid;
+DECLARE canonical_project_id uuid;
+DECLARE canonical_accepted_by uuid;
+DECLARE canonical_validated_by uuid;
+DECLARE canonical_correlation_id uuid;
+DECLARE stored decodex.objectives%ROWTYPE;
+DECLARE existing decodex.objective_completion_evidence%ROWTYPE;
+DECLARE record_time timestamptz;
+DECLARE inserted boolean;
+BEGIN
+	IF p_evidence_id IS NULL OR p_objective_id IS NULL OR p_project_id IS NULL
+		OR p_accepted_by IS NULL OR p_validated_by IS NULL OR p_correlation_id IS NULL THEN
+		RAISE EXCEPTION 'identity ingress requires canonical UUID-v4 text'
+			USING ERRCODE = '23514', CONSTRAINT = 'canonical_uuid_v4_text_ingress';
+	END IF;
+	canonical_evidence_id := p_evidence_id::text::uuid;
+	canonical_objective_id := p_objective_id::text::uuid;
+	canonical_project_id := p_project_id::text::uuid;
+	canonical_accepted_by := p_accepted_by::text::uuid;
+	canonical_validated_by := p_validated_by::text::uuid;
+	canonical_correlation_id := p_correlation_id::text::uuid;
+	SELECT current.* INTO stored FROM decodex.objectives AS current
+	WHERE current.objective_id=canonical_objective_id FOR UPDATE;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'not_found', NULL::bigint, false; RETURN; END IF;
+	SELECT evidence.* INTO existing FROM decodex.objective_completion_evidence AS evidence
+	WHERE evidence.evidence_id=canonical_evidence_id;
+	IF FOUND THEN
+		IF existing.objective_id=canonical_objective_id AND existing.project_id=canonical_project_id
+			AND existing.objective_revision=p_objective_revision
+			AND existing.acceptance_result=p_acceptance_result
+			AND existing.accepted_by=canonical_accepted_by
+			AND existing.accepted_at=decodex.program_timestamp(p_accepted_at)
+			AND existing.acceptance_provenance=p_acceptance_provenance
+			AND existing.validation_result=p_validation_result
+			AND existing.validated_by=canonical_validated_by
+			AND existing.validated_at=decodex.program_timestamp(p_validated_at)
+			AND existing.validation_provenance=p_validation_provenance
+			AND existing.correlation_id=canonical_correlation_id
+		THEN RETURN QUERY SELECT 'ok', stored.revision, false; RETURN; END IF;
+		RETURN QUERY SELECT 'conflicting_identity', stored.revision, false; RETURN;
+	END IF;
+	IF stored.project_id<>canonical_project_id THEN
+		RETURN QUERY SELECT 'invalid_project', stored.revision, false; RETURN;
+	END IF;
+	IF stored.revision IS DISTINCT FROM p_objective_revision THEN
+		RETURN QUERY SELECT 'revision_conflict', stored.revision, false; RETURN;
+	END IF;
+	IF stored.state NOT IN ('active','blocked') THEN
+		RETURN QUERY SELECT 'invalid_transition', stored.revision, false; RETURN;
+	END IF;
+	PERFORM 1 FROM decodex.projects AS project WHERE project.project_id=canonical_project_id
+		AND project.status='active' FOR KEY SHARE;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'invalid_authority', stored.revision, false; RETURN; END IF;
+	PERFORM 1 FROM decodex.agents AS agent WHERE agent.project_id=canonical_project_id
+		AND agent.role='lead' AND agent.status='active'
+		AND agent.agent_id IN (canonical_accepted_by,canonical_validated_by)
+	GROUP BY agent.project_id HAVING pg_catalog.count(DISTINCT agent.agent_id)
+		= CASE WHEN canonical_accepted_by=canonical_validated_by THEN 1 ELSE 2 END;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'invalid_authority', stored.revision, false; RETURN; END IF;
+	record_time := pg_catalog.clock_timestamp();
+	IF decodex.program_timestamp(p_accepted_at) IS NULL
+		OR decodex.program_timestamp(p_validated_at) IS NULL
+		OR decodex.program_timestamp(p_accepted_at)<stored.updated_at
+		OR decodex.program_timestamp(p_accepted_at)>decodex.program_timestamp(p_validated_at)
+		OR decodex.program_timestamp(p_validated_at)>record_time
+	THEN RETURN QUERY SELECT 'invalid_evidence', stored.revision, false; RETURN; END IF;
+	INSERT INTO decodex.objective_completion_evidence (
+		evidence_id,objective_id,project_id,objective_revision,objective_updated_at,
+		acceptance_result,accepted_by,
+		accepted_at,acceptance_provenance,validation_result,validated_by,validated_at,
+		validation_provenance,correlation_id,recorded_at
+	) VALUES (
+		canonical_evidence_id,canonical_objective_id,canonical_project_id,p_objective_revision,
+		stored.updated_at,p_acceptance_result,canonical_accepted_by,
+		decodex.program_timestamp(p_accepted_at),
+		p_acceptance_provenance,p_validation_result,canonical_validated_by,
+		decodex.program_timestamp(p_validated_at),p_validation_provenance,
+		canonical_correlation_id,record_time
+	) ON CONFLICT DO NOTHING
+	RETURNING true INTO inserted;
+	IF inserted IS DISTINCT FROM true THEN
+		SELECT evidence.* INTO existing FROM decodex.objective_completion_evidence AS evidence
+		WHERE evidence.evidence_id=canonical_evidence_id;
+		IF FOUND AND existing.objective_id=canonical_objective_id
+			AND existing.project_id=canonical_project_id
+			AND existing.objective_revision=p_objective_revision
+			AND existing.acceptance_result=p_acceptance_result
+			AND existing.accepted_by=canonical_accepted_by
+			AND existing.accepted_at=decodex.program_timestamp(p_accepted_at)
+			AND existing.acceptance_provenance=p_acceptance_provenance
+			AND existing.validation_result=p_validation_result
+			AND existing.validated_by=canonical_validated_by
+			AND existing.validated_at=decodex.program_timestamp(p_validated_at)
+			AND existing.validation_provenance=p_validation_provenance
+			AND existing.correlation_id=canonical_correlation_id
+		THEN RETURN QUERY SELECT 'ok', stored.revision, false; RETURN; END IF;
+		RETURN QUERY SELECT 'conflicting_identity', stored.revision, false; RETURN;
+	END IF;
+	UPDATE decodex.objectives SET state='achieved',revision=revision+1,
+		completion_evidence_id=canonical_evidence_id,last_changed_by=canonical_validated_by,
+		last_correlation_id=canonical_correlation_id,last_provenance=p_validation_provenance,
+		updated_at=record_time WHERE objective_id=canonical_objective_id;
+	RETURN QUERY SELECT 'ok', stored.revision+1, true;
+END
+$$;
+
+ALTER FUNCTION decodex.program_timestamp(bigint) SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.is_program_metrics(jsonb) SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.is_program_signals(jsonb) SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.is_objective_criteria(text[]) SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.enforce_program_state() SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.enforce_objective_state() SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.forbid_objective_evidence_mutation() SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.enforce_objective_completion_coherence() SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.create_program(
+	decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,
+	decodex.canonical_uuid_v4_text,text,text,decodex.canonical_uuid_v4_text,bigint,integer,
+	bigint,jsonb,jsonb,decodex.canonical_uuid_v4_text,text
+) SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.update_program_context(
+	decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,bigint,integer,bigint,jsonb,jsonb,
+	decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,text
+) SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.transition_program(
+	decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,bigint,decodex.program_state,
+	decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,text
+) SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.create_objective(
+	decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,
+	decodex.canonical_uuid_v4_text,text,text[],text[],bigint,
+	decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,text
+) SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.transition_objective(
+	decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,bigint,decodex.objective_state,
+	decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,text
+) SET search_path = pg_catalog, decodex;
+ALTER FUNCTION decodex.achieve_objective(
+	decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,
+	decodex.canonical_uuid_v4_text,bigint,text,decodex.canonical_uuid_v4_text,bigint,text,
+	text,decodex.canonical_uuid_v4_text,bigint,text,decodex.canonical_uuid_v4_text
+) SET search_path = pg_catalog, decodex;
+
+REVOKE ALL ON TABLE decodex.programs, decodex.objectives,
+	decodex.objective_completion_evidence FROM PUBLIC;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA decodex FROM PUBLIC;
+REVOKE ALL ON TYPE decodex.program_state, decodex.objective_state FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON TYPES FROM PUBLIC;

--- a/crates/decodex-postgres/src/authority.rs
+++ b/crates/decodex-postgres/src/authority.rs
@@ -9,7 +9,9 @@ const FOUNDATION_MIGRATION: &str = include_str!("../migrations/V1__persistence_f
 const CONVERSATION_MIGRATION: &str = include_str!("../migrations/V3__conversation_history.sql");
 const PROJECT_AGENT_MIGRATION: &str = include_str!("../migrations/V5__project_agent_authority.sql");
 const POLICY_MIGRATION: &str = include_str!("../migrations/V6__project_policy_authority.sql");
-const FUNCTION_CONTRACTS: [FunctionContract; 43] = [
+const PROGRAM_OBJECTIVE_MIGRATION: &str =
+	include_str!("../migrations/V7__program_objective_authority.sql");
+const FUNCTION_CONTRACTS: [FunctionContract; 57] = [
 	FunctionContract {
 		name: "is_canonical_media_type",
 		lookup_signature: "decodex.is_canonical_media_type(pg_catalog.text)",
@@ -410,8 +412,96 @@ const FUNCTION_CONTRACTS: [FunctionContract; 43] = [
 		returns_set: true,
 		rows: 1_000.0,
 	},
+	immutable_function_contract(
+		"program_timestamp",
+		"decodex.program_timestamp(pg_catalog.int8)",
+		"program_timestamp(value bigint)",
+		"value bigint",
+		"timestamp with time zone",
+		"sql",
+	),
+	immutable_function_contract(
+		"is_program_metrics",
+		"decodex.is_program_metrics(pg_catalog.jsonb)",
+		"is_program_metrics(document jsonb)",
+		"document jsonb",
+		"boolean",
+		"plpgsql",
+	),
+	immutable_function_contract(
+		"is_program_signals",
+		"decodex.is_program_signals(pg_catalog.jsonb)",
+		"is_program_signals(document jsonb)",
+		"document jsonb",
+		"boolean",
+		"plpgsql",
+	),
+	immutable_function_contract(
+		"is_objective_criteria",
+		"decodex.is_objective_criteria(pg_catalog._text)",
+		"is_objective_criteria(document text[])",
+		"document text[]",
+		"boolean",
+		"plpgsql",
+	),
+	trigger_contract(
+		"enforce_program_state",
+		"decodex.enforce_program_state()",
+		"enforce_program_state()",
+	),
+	trigger_contract(
+		"enforce_objective_state",
+		"decodex.enforce_objective_state()",
+		"enforce_objective_state()",
+	),
+	trigger_contract(
+		"forbid_objective_evidence_mutation",
+		"decodex.forbid_objective_evidence_mutation()",
+		"forbid_objective_evidence_mutation()",
+	),
+	trigger_contract(
+		"enforce_objective_completion_coherence",
+		"decodex.enforce_objective_completion_coherence()",
+		"enforce_objective_completion_coherence()",
+	),
+	mutator_contract(
+		"create_program",
+		"decodex.create_program(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.int4,pg_catalog.int8,pg_catalog.jsonb,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+		"create_program(\n\tp_program_id decodex.canonical_uuid_v4_text,\n\tp_project_id decodex.canonical_uuid_v4_text,\n\tp_owner_agent_id decodex.canonical_uuid_v4_text,\n\tp_name text,\n\tp_responsibility text,\n\tp_policy_id decodex.canonical_uuid_v4_text,\n\tp_policy_revision bigint,\n\tp_review_interval_days integer,\n\tp_next_review_at bigint,\n\tp_metrics jsonb,\n\tp_signals jsonb,\n\tp_correlation_id decodex.canonical_uuid_v4_text,\n\tp_provenance text\n)",
+		"p_program_id decodex.canonical_uuid_v4_text, p_project_id decodex.canonical_uuid_v4_text, p_owner_agent_id decodex.canonical_uuid_v4_text, p_name text, p_responsibility text, p_policy_id decodex.canonical_uuid_v4_text, p_policy_revision bigint, p_review_interval_days integer, p_next_review_at bigint, p_metrics jsonb, p_signals jsonb, p_correlation_id decodex.canonical_uuid_v4_text, p_provenance text",
+	),
+	mutator_contract(
+		"update_program_context",
+		"decodex.update_program_context(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.int4,pg_catalog.int8,pg_catalog.jsonb,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+		"update_program_context(\n\tp_program_id decodex.canonical_uuid_v4_text,\n\tp_project_id decodex.canonical_uuid_v4_text,\n\tp_expected_revision bigint,\n\tp_review_interval_days integer,\n\tp_next_review_at bigint,\n\tp_metrics jsonb,\n\tp_signals jsonb,\n\tp_actor_id decodex.canonical_uuid_v4_text,\n\tp_correlation_id decodex.canonical_uuid_v4_text,\n\tp_provenance text\n)",
+		"p_program_id decodex.canonical_uuid_v4_text, p_project_id decodex.canonical_uuid_v4_text, p_expected_revision bigint, p_review_interval_days integer, p_next_review_at bigint, p_metrics jsonb, p_signals jsonb, p_actor_id decodex.canonical_uuid_v4_text, p_correlation_id decodex.canonical_uuid_v4_text, p_provenance text",
+	),
+	mutator_contract(
+		"transition_program",
+		"decodex.transition_program(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.program_state,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+		"transition_program(\n\tp_program_id decodex.canonical_uuid_v4_text,\n\tp_project_id decodex.canonical_uuid_v4_text,\n\tp_expected_revision bigint,\n\tp_state decodex.program_state,\n\tp_actor_id decodex.canonical_uuid_v4_text,\n\tp_correlation_id decodex.canonical_uuid_v4_text,\n\tp_provenance text\n)",
+		"p_program_id decodex.canonical_uuid_v4_text, p_project_id decodex.canonical_uuid_v4_text, p_expected_revision bigint, p_state decodex.program_state, p_actor_id decodex.canonical_uuid_v4_text, p_correlation_id decodex.canonical_uuid_v4_text, p_provenance text",
+	),
+	mutator_contract(
+		"create_objective",
+		"decodex.create_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog._text,pg_catalog._text,pg_catalog.int8,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+		"create_objective(\n\tp_objective_id decodex.canonical_uuid_v4_text,\n\tp_project_id decodex.canonical_uuid_v4_text,\n\tp_program_id decodex.canonical_uuid_v4_text,\n\tp_outcome text,\n\tp_acceptance_criteria text[],\n\tp_validation_criteria text[],\n\tp_target_at bigint,\n\tp_actor_id decodex.canonical_uuid_v4_text,\n\tp_correlation_id decodex.canonical_uuid_v4_text,\n\tp_provenance text\n)",
+		"p_objective_id decodex.canonical_uuid_v4_text, p_project_id decodex.canonical_uuid_v4_text, p_program_id decodex.canonical_uuid_v4_text, p_outcome text, p_acceptance_criteria text[], p_validation_criteria text[], p_target_at bigint, p_actor_id decodex.canonical_uuid_v4_text, p_correlation_id decodex.canonical_uuid_v4_text, p_provenance text",
+	),
+	mutator_contract(
+		"transition_objective",
+		"decodex.transition_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.objective_state,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+		"transition_objective(\n\tp_objective_id decodex.canonical_uuid_v4_text,\n\tp_project_id decodex.canonical_uuid_v4_text,\n\tp_expected_revision bigint,\n\tp_state decodex.objective_state,\n\tp_actor_id decodex.canonical_uuid_v4_text,\n\tp_correlation_id decodex.canonical_uuid_v4_text,\n\tp_provenance text\n)",
+		"p_objective_id decodex.canonical_uuid_v4_text, p_project_id decodex.canonical_uuid_v4_text, p_expected_revision bigint, p_state decodex.objective_state, p_actor_id decodex.canonical_uuid_v4_text, p_correlation_id decodex.canonical_uuid_v4_text, p_provenance text",
+	),
+	mutator_contract(
+		"achieve_objective",
+		"decodex.achieve_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,decodex.canonical_uuid_v4_text)",
+		"achieve_objective(\n\tp_evidence_id decodex.canonical_uuid_v4_text,\n\tp_objective_id decodex.canonical_uuid_v4_text,\n\tp_project_id decodex.canonical_uuid_v4_text,\n\tp_objective_revision bigint,\n\tp_acceptance_result text,\n\tp_accepted_by decodex.canonical_uuid_v4_text,\n\tp_accepted_at bigint,\n\tp_acceptance_provenance text,\n\tp_validation_result text,\n\tp_validated_by decodex.canonical_uuid_v4_text,\n\tp_validated_at bigint,\n\tp_validation_provenance text,\n\tp_correlation_id decodex.canonical_uuid_v4_text\n)",
+		"p_evidence_id decodex.canonical_uuid_v4_text, p_objective_id decodex.canonical_uuid_v4_text, p_project_id decodex.canonical_uuid_v4_text, p_objective_revision bigint, p_acceptance_result text, p_accepted_by decodex.canonical_uuid_v4_text, p_accepted_at bigint, p_acceptance_provenance text, p_validation_result text, p_validated_by decodex.canonical_uuid_v4_text, p_validated_at bigint, p_validation_provenance text, p_correlation_id decodex.canonical_uuid_v4_text",
+	),
 ];
-const RUNTIME_EXECUTE_FUNCTIONS: [&str; 20] = [
+const RUNTIME_EXECUTE_FUNCTIONS: [&str; 26] = [
 	"decodex.is_canonical_media_type(pg_catalog.text)",
 	"decodex.is_history_metadata_projection(pg_catalog.jsonb)",
 	"decodex.normalize_unicode_whitespace(pg_catalog.text)",
@@ -432,8 +522,14 @@ const RUNTIME_EXECUTE_FUNCTIONS: [&str; 20] = [
 	"decodex.transition_project(decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.project_status)",
 	"decodex.create_policy(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text)",
 	"decodex.accept_policy_revision(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,pg_catalog.int8)",
+	"decodex.create_program(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.int4,pg_catalog.int8,pg_catalog.jsonb,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.update_program_context(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.int4,pg_catalog.int8,pg_catalog.jsonb,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.transition_program(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.program_state,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.create_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog._text,pg_catalog._text,pg_catalog.int8,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.transition_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.objective_state,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.achieve_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,decodex.canonical_uuid_v4_text)",
 ];
-const SAFETY_FUNCTIONS: [&str; 21] = [
+const SAFETY_FUNCTIONS: [&str; 25] = [
 	"enforce_lease_operation_time",
 	"enforce_outbox_operation_time",
 	"forbid_mutation_of_activity",
@@ -455,8 +551,12 @@ const SAFETY_FUNCTIONS: [&str; 21] = [
 	"enforce_history_cursor_state",
 	"enforce_policy_identity_state",
 	"forbid_policy_revision_mutation",
+	"enforce_program_state",
+	"enforce_objective_state",
+	"forbid_objective_evidence_mutation",
+	"enforce_objective_completion_coherence",
 ];
-const SAFETY_TRIGGER_COUNT: usize = 33;
+const SAFETY_TRIGGER_COUNT: usize = 41;
 // PostgreSQL 18 catalogs with an owner and a containing namespace, plus the namespace
 // itself. Namespace-scoped catalogs without an independent owner (constraints, triggers,
 // text-search parsers/templates, and dependent rows) inherit authority from one of these.
@@ -631,7 +731,10 @@ WITH set_roles AS (
   ('projects', true, false, false, false),
   ('agents', true, false, false, false),
   ('policies', true, false, false, false),
-  ('policy_revisions', true, false, false, false)
+  ('policy_revisions', true, false, false, false),
+  ('programs', true, false, false, false),
+  ('objectives', true, false, false, false),
+  ('objective_completion_evidence', true, false, false, false)
 ), tables AS (
   SELECT class.oid, class.relname, expected.*
   FROM pg_catalog.pg_class AS class
@@ -640,7 +743,7 @@ WITH set_roles AS (
   WHERE namespace.nspname = 'decodex' AND class.relkind IN ('r', 'p')
 )
 SELECT
-  (SELECT count(*) FROM tables WHERE table_name IS NOT NULL) = 24
+  (SELECT count(*) FROM tables WHERE table_name IS NOT NULL) = 27
     AND COALESCE((
       SELECT pg_catalog.bool_and(
         pg_catalog.has_table_privilege(session_user, oid, 'SELECT') = can_select
@@ -828,7 +931,15 @@ WITH expected(table_name, trigger_name, function_name, trigger_type) AS (VALUES
   ('policies', 'policies_state_guard', 'enforce_policy_identity_state', 27),
   ('policies', 'policies_truncate_forbidden', 'enforce_policy_identity_state', 34),
   ('policy_revisions', 'policy_revisions_immutable', 'forbid_policy_revision_mutation', 27),
-  ('policy_revisions', 'policy_revisions_truncate_forbidden', 'forbid_policy_revision_mutation', 34)
+  ('policy_revisions', 'policy_revisions_truncate_forbidden', 'forbid_policy_revision_mutation', 34),
+  ('programs', 'programs_state_guard', 'enforce_program_state', 31),
+  ('programs', 'programs_truncate_forbidden', 'enforce_program_state', 34),
+  ('objectives', 'objectives_state_guard', 'enforce_objective_state', 31),
+  ('objectives', 'objectives_truncate_forbidden', 'enforce_objective_state', 34),
+  ('objective_completion_evidence', 'objective_evidence_immutable', 'forbid_objective_evidence_mutation', 27),
+  ('objective_completion_evidence', 'objective_evidence_truncate_forbidden', 'forbid_objective_evidence_mutation', 34),
+  ('objectives', 'objectives_completion_coherence', 'enforce_objective_completion_coherence', 21),
+  ('objective_completion_evidence', 'objective_evidence_completion_coherence', 'enforce_objective_completion_coherence', 5)
 )
 SELECT
   expected.function_name,
@@ -836,11 +947,17 @@ SELECT
     AND trigger.tgenabled = 'O'
     AND trigger.tgtype = expected.trigger_type
     AND trigger.tgparentid = 0
-    AND trigger.tgconstraint = 0
+    AND (trigger.tgconstraint <> 0) = (
+      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence')
+    )
     AND trigger.tgconstrrelid = 0
     AND trigger.tgconstrindid = 0
-    AND NOT trigger.tgdeferrable
-    AND NOT trigger.tginitdeferred
+    AND trigger.tgdeferrable = (
+      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence')
+    )
+    AND trigger.tginitdeferred = (
+      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence')
+    )
     AND trigger.tgnargs = 0
     AND trigger.tgattr = ''::pg_catalog.int2vector
     AND trigger.tgqual IS NULL
@@ -972,7 +1089,15 @@ WITH catalog_context AS MATERIALIZED (
   ('policies', 'policies_state_guard', 'decodex.enforce_policy_identity_state()'),
   ('policies', 'policies_truncate_forbidden', 'decodex.enforce_policy_identity_state()'),
   ('policy_revisions', 'policy_revisions_immutable', 'decodex.forbid_policy_revision_mutation()'),
-  ('policy_revisions', 'policy_revisions_truncate_forbidden', 'decodex.forbid_policy_revision_mutation()')
+  ('policy_revisions', 'policy_revisions_truncate_forbidden', 'decodex.forbid_policy_revision_mutation()'),
+  ('programs', 'programs_state_guard', 'decodex.enforce_program_state()'),
+  ('programs', 'programs_truncate_forbidden', 'decodex.enforce_program_state()'),
+  ('objectives', 'objectives_state_guard', 'decodex.enforce_objective_state()'),
+  ('objectives', 'objectives_truncate_forbidden', 'decodex.enforce_objective_state()'),
+  ('objective_completion_evidence', 'objective_evidence_immutable', 'decodex.forbid_objective_evidence_mutation()'),
+  ('objective_completion_evidence', 'objective_evidence_truncate_forbidden', 'decodex.forbid_objective_evidence_mutation()'),
+  ('objectives', 'objectives_completion_coherence', 'decodex.enforce_objective_completion_coherence()'),
+  ('objective_completion_evidence', 'objective_evidence_completion_coherence', 'decodex.enforce_objective_completion_coherence()')
 ), actual_triggers AS (
   SELECT
     class.relname AS table_name,
@@ -1442,8 +1567,8 @@ SELECT pg_catalog.jsonb_agg(
 FROM contract_rows
 "#;
 const SCHEMA_CONTRACT_SHA256: [u8; 32] = [
-	0xfa, 0xd2, 0x50, 0x40, 0x49, 0x0b, 0xda, 0x15, 0x02, 0xfb, 0xa7, 0x3a, 0x53, 0x7c, 0xc3, 0xce,
-	0x7b, 0xc8, 0x1c, 0x88, 0x1d, 0x90, 0xd6, 0x63, 0xc9, 0xc9, 0x2b, 0x4b, 0xee, 0x1d, 0x75, 0x72,
+	0xc7, 0x92, 0xa5, 0x97, 0x5b, 0xf3, 0x0b, 0xcb, 0x2c, 0xcf, 0x14, 0xf2, 0x6b, 0x12, 0xa5, 0x8b,
+	0x38, 0x3c, 0x92, 0xd6, 0x66, 0x73, 0xa6, 0x12, 0x85, 0xec, 0x89, 0x92, 0x4a, 0x3a, 0x28, 0x4e,
 ];
 const EXTENSION_AUTHORITY_SQL: &str = r#"
 WITH set_roles AS (
@@ -1610,6 +1735,48 @@ const fn trigger_contract(
 	}
 }
 
+const fn immutable_function_contract(
+	name: &'static str,
+	lookup_signature: &'static str,
+	migration_signature: &'static str,
+	arguments: &'static str,
+	result: &'static str,
+	language: &'static str,
+) -> FunctionContract {
+	FunctionContract {
+		name,
+		lookup_signature,
+		migration_signature,
+		arguments,
+		result,
+		language,
+		volatility: "i",
+		strict: true,
+		returns_set: false,
+		rows: 0.0,
+	}
+}
+
+const fn mutator_contract(
+	name: &'static str,
+	lookup_signature: &'static str,
+	migration_signature: &'static str,
+	arguments: &'static str,
+) -> FunctionContract {
+	FunctionContract {
+		name,
+		lookup_signature,
+		migration_signature,
+		arguments,
+		result: "TABLE(result_code text, actual_revision bigint, changed boolean)",
+		language: "plpgsql",
+		volatility: "v",
+		strict: false,
+		returns_set: true,
+		rows: 1_000.0,
+	}
+}
+
 fn canonical_safety_function_source(function_name: &str) -> Option<&'static str> {
 	if !SAFETY_FUNCTIONS.contains(&function_name) {
 		return None;
@@ -1622,10 +1789,15 @@ fn canonical_safety_function_source(function_name: &str) -> Option<&'static str>
 
 fn canonical_function_source(contract: &FunctionContract) -> Option<&'static str> {
 	let declaration = format!("CREATE FUNCTION decodex.{}", contract.migration_signature);
-	let migration =
-		[FOUNDATION_MIGRATION, CONVERSATION_MIGRATION, PROJECT_AGENT_MIGRATION, POLICY_MIGRATION]
-			.into_iter()
-			.find(|migration| migration.contains(&declaration))?;
+	let migration = [
+		FOUNDATION_MIGRATION,
+		CONVERSATION_MIGRATION,
+		PROJECT_AGENT_MIGRATION,
+		POLICY_MIGRATION,
+		PROGRAM_OBJECTIVE_MIGRATION,
+	]
+	.into_iter()
+	.find(|migration| migration.contains(&declaration))?;
 	let (_, declaration_and_tail) = migration.split_once(&declaration)?;
 	let (_, source_and_tail) = declaration_and_tail.split_once("\nAS $$")?;
 	let (source, _) = source_and_tail.split_once("$$;")?;
@@ -1740,6 +1912,12 @@ async fn verify_function_contract(client: &Client) -> Result<(), StoreError> {
 				| "transition_project"
 				| "create_policy"
 				| "accept_policy_revision"
+				| "create_program"
+				| "update_program_context"
+				| "transition_program"
+				| "create_objective"
+				| "transition_objective"
+				| "achieve_objective"
 		);
 		let expected_executable = RUNTIME_EXECUTE_FUNCTIONS.contains(&contract.lookup_signature);
 		let expected_settings = vec!["search_path=pg_catalog, decodex".to_owned()];
@@ -1893,8 +2071,8 @@ mod tests {
 	use crate::authority::{
 		CONVERSATION_MIGRATION, FOUNDATION_MIGRATION, FUNCTION_CONTRACTS,
 		IDENTITY_CAST_AUTHORITY_SQL, OWNED_OBJECT_CATALOGS, POLICY_MIGRATION,
-		PROJECT_AGENT_MIGRATION, ROLE_AUTHORITY_SQL, SAFETY_FUNCTIONS, SCHEMA_CONTRACT_SHA256,
-		SCHEMA_CONTRACT_SQL,
+		PROGRAM_OBJECTIVE_MIGRATION, PROJECT_AGENT_MIGRATION, ROLE_AUTHORITY_SQL, SAFETY_FUNCTIONS,
+		SCHEMA_CONTRACT_SHA256, SCHEMA_CONTRACT_SQL,
 	};
 
 	#[test]
@@ -1946,6 +2124,7 @@ mod tests {
 				CONVERSATION_MIGRATION,
 				PROJECT_AGENT_MIGRATION,
 				POLICY_MIGRATION,
+				PROGRAM_OBJECTIVE_MIGRATION,
 			]
 			.into_iter()
 			.map(|migration| migration.matches("CREATE FUNCTION decodex.").count())
@@ -1963,6 +2142,7 @@ mod tests {
 					CONVERSATION_MIGRATION,
 					PROJECT_AGENT_MIGRATION,
 					POLICY_MIGRATION,
+					PROGRAM_OBJECTIVE_MIGRATION,
 				]
 				.into_iter()
 				.map(|migration| migration
@@ -1989,6 +2169,12 @@ mod tests {
 			"transition_project",
 			"create_policy",
 			"accept_policy_revision",
+			"create_program",
+			"update_program_context",
+			"transition_program",
+			"create_objective",
+			"transition_objective",
+			"achieve_objective",
 		] {
 			let contract = FUNCTION_CONTRACTS
 				.iter()

--- a/crates/decodex-postgres/src/lib.rs
+++ b/crates/decodex-postgres/src/lib.rs
@@ -14,6 +14,7 @@ mod leases;
 mod migrations;
 mod outbox;
 mod policies;
+mod programs;
 mod project_agents;
 #[cfg(unix)] mod socket;
 mod types;
@@ -26,6 +27,7 @@ pub use self::{
 		StoredRuntimeSession,
 	},
 	error::{BootstrapFailure, StoreError},
+	programs::{ObjectiveRecord, ProgramRecord, UpdateProgramContext},
 	types::{
 		AccountMetadata, AccountMutation, ActivityRecord, CommandIdentity, CreateProject,
 		LeaseClaim, OutboxClaim, OutboxReconciliation, OutboxState, QuotaWindow,
@@ -34,10 +36,13 @@ pub use self::{
 };
 pub use decodex_core::{
 	AcceptedPolicyRevision, AccountId, AccountState, Agent, AgentId, AgentRole, AgentStatus,
+	Objective, ObjectiveCompletionEvidence, ObjectiveEvidenceId, ObjectiveId, ObjectiveState,
 	Policy, PolicyId, PolicyProvenance, PolicyRevision, PolicyRevisionAcceptance, PolicyRevisionId,
-	PolicySnapshot, PolicySnapshotValue, PolicyStatus, PolicyTimestamp, Project, ProjectAuthority,
-	ProjectId, ProjectMetadata, ProjectMetadataValue, ProjectRepositoryBinding, ProjectStatus,
-	RepositoryIdentity,
+	PolicySnapshot, PolicySnapshotValue, PolicyStatus, PolicyTimestamp, Program,
+	ProgramCorrelationId, ProgramError, ProgramId, ProgramMetric, ProgramObservationId,
+	ProgramObservationProvenance, ProgramProvenance, ProgramSignal, ProgramState, ProgramTimestamp,
+	Project, ProjectAuthority, ProjectId, ProjectMetadata, ProjectMetadataValue,
+	ProjectRepositoryBinding, ProjectStatus, RepositoryIdentity, ReviewCadence,
 };
 
 use std::{sync::Arc, time::Duration};

--- a/crates/decodex-postgres/src/migrations.rs
+++ b/crates/decodex-postgres/src/migrations.rs
@@ -7,7 +7,7 @@ use deadpool_postgres::Client;
 use crate::{REQUIRED_POSTGRES_MAJOR, StoreError};
 use embedded::migrations;
 
-const EXPECTED_LATEST_MIGRATION_VERSION: i32 = 6;
+const EXPECTED_LATEST_MIGRATION_VERSION: i32 = 7;
 
 pub(crate) async fn run(client: &mut Client) -> Result<(), StoreError> {
 	migrations::runner().run_async(&mut ***client).await?;
@@ -58,7 +58,7 @@ pub(crate) async fn verify(client: &Client) -> Result<(), StoreError> {
 		!= Some(EXPECTED_LATEST_MIGRATION_VERSION)
 	{
 		return Err(StoreError::Incompatible(
-			"embedded migration inventory does not end at the canonical V6 ledger".into(),
+			"embedded migration inventory does not end at the canonical V7 ledger".into(),
 		));
 	}
 	if actual.len() != expected.len() {

--- a/crates/decodex-postgres/src/programs.rs
+++ b/crates/decodex-postgres/src/programs.rs
@@ -1,0 +1,1275 @@
+//! Transactional PostgreSQL authority for open-ended Programs and finite Objectives.
+
+use std::fmt::Display;
+
+use deadpool_postgres::Transaction;
+use serde_json::Value;
+use tokio_postgres::Row;
+
+use crate::{CommandIdentity, PostgresStore, StoreError, accounts};
+use decodex_core::{
+	AgentId, Objective, ObjectiveCompletionEvidence, ObjectiveEvidenceId, ObjectiveId,
+	ObjectiveState, PolicyId, PolicyRevision, PolicyRevisionId, Program, ProgramCorrelationId,
+	ProgramId, ProgramMetric, ProgramProvenance, ProgramSignal, ProgramState, ProgramTimestamp,
+	ProjectId, ReviewCadence,
+};
+
+const PROGRAM_SELECT: &str = concat!(
+	"SELECT program_id::text,project_id::text,owner_agent_id::text,name,",
+	"responsibility,state::text,policy_id::text,policy_revision,review_interval_days,",
+	"(EXTRACT(EPOCH FROM next_review_at)*1000000)::bigint,metrics,signals,revision,",
+	"last_changed_by::text,last_correlation_id::text,last_provenance ",
+	"FROM decodex.programs WHERE program_id=$1::text::uuid",
+);
+const OBJECTIVE_SELECT: &str = concat!(
+	"SELECT objective.objective_id::text,objective.project_id::text,",
+	"objective.program_id::text,objective.outcome,objective.acceptance_criteria,",
+	"objective.validation_criteria,(EXTRACT(EPOCH FROM objective.target_at)*1000000)::bigint,",
+	"objective.state::text,objective.revision,objective.completion_evidence_id::text,",
+	"objective.last_changed_by::text,objective.last_correlation_id::text,objective.last_provenance,",
+	"evidence.evidence_id::text,evidence.objective_revision,",
+	"(EXTRACT(EPOCH FROM evidence.objective_updated_at)*1000000)::bigint,",
+	"evidence.acceptance_result,",
+	"evidence.accepted_by::text,(EXTRACT(EPOCH FROM evidence.accepted_at)*1000000)::bigint,",
+	"evidence.acceptance_provenance,evidence.validation_result,evidence.validated_by::text,",
+	"(EXTRACT(EPOCH FROM evidence.validated_at)*1000000)::bigint,evidence.validation_provenance,",
+	"evidence.correlation_id::text,(EXTRACT(EPOCH FROM evidence.recorded_at)*1000000)::bigint ",
+	"FROM decodex.objectives AS objective ",
+	"LEFT JOIN decodex.objective_completion_evidence AS evidence ",
+	"ON evidence.evidence_id=objective.completion_evidence_id ",
+	"WHERE objective.objective_id=$1::text::uuid",
+);
+
+/// Persisted Program plus provenance for its latest committed revision.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProgramRecord {
+	/// Open-ended Program authority.
+	pub program: Program,
+	/// Provenance for the current revision.
+	pub last_change: ProgramProvenance,
+}
+
+/// Persisted Objective plus provenance for its latest committed revision.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ObjectiveRecord {
+	/// Finite Objective authority.
+	pub objective: Objective,
+	/// Provenance for the current revision.
+	pub last_change: ProgramProvenance,
+}
+
+/// Optimistically guarded replacement of mutable Program review/observation context.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpdateProgramContext {
+	/// Program to update.
+	pub program_id: ProgramId,
+	/// Canonical request-authority Project scope.
+	pub project_id: ProjectId,
+	/// Exact current revision.
+	pub expected_revision: u64,
+	/// Replacement review cadence.
+	pub review_cadence: ReviewCadence,
+	/// Replacement bounded metrics.
+	pub metrics: Vec<ProgramMetric>,
+	/// Replacement bounded signals.
+	pub signals: Vec<ProgramSignal>,
+}
+
+struct ProgramCommandDescriptor {
+	operation: &'static str,
+	project_id: String,
+	entity_id: String,
+	expected_revision: Option<i64>,
+}
+
+struct ProgramCommandReservation {
+	key: String,
+	request_hash: String,
+	claim_token: String,
+}
+
+enum ProgramCommandClaim {
+	Owned(ProgramCommandReservation),
+	Completed(Value),
+}
+
+enum ProgramMutation<'a> {
+	Update {
+		update: &'a UpdateProgramContext,
+		expected_revision: i64,
+		metrics: Value,
+		signals: Value,
+		provenance: &'a ProgramProvenance,
+	},
+	Transition {
+		project_id: &'a ProjectId,
+		program_id: &'a ProgramId,
+		expected_revision: i64,
+		state: ProgramState,
+		provenance: &'a ProgramProvenance,
+	},
+}
+
+enum ObjectiveMutation<'a> {
+	Transition {
+		project_id: &'a ProjectId,
+		objective_id: &'a ObjectiveId,
+		expected_revision: i64,
+		state: ObjectiveState,
+		provenance: &'a ProgramProvenance,
+	},
+	Achieve {
+		evidence: &'a ObjectiveCompletionEvidence,
+		expected_revision: i64,
+	},
+}
+
+#[derive(Debug)]
+enum Rejection {
+	RevisionConflict { entity: String, expected: Option<i64>, actual: Option<i64> },
+	NotFound,
+	InvalidAuthority,
+	InvalidPolicy,
+	InvalidProgram,
+	InvalidHorizon,
+	InvalidTransition,
+	InvalidEvidence,
+	InvalidProject,
+	ConflictingIdentity,
+}
+
+impl PostgresStore {
+	/// Create one active Program under canonical Project Lead and exact Policy authority.
+	pub async fn create_program(
+		&self,
+		command: &CommandIdentity,
+		program: &Program,
+		provenance: &ProgramProvenance,
+	) -> Result<ProgramRecord, StoreError> {
+		if program.state() != ProgramState::Active || program.revision() != 1 {
+			return Err(StoreError::InvalidInput("new Program must be active at revision one"));
+		}
+		if program.owner_agent_id() != provenance.actor_id() {
+			return Err(StoreError::InvalidInput(
+				"Program creation provenance must be the assigned owner",
+			));
+		}
+
+		let metrics = serde_json::to_value(program.metrics())
+			.map_err(|_| StoreError::InvalidInput("Program metrics cannot be serialized"))?;
+		let signals = serde_json::to_value(program.signals())
+			.map_err(|_| StoreError::InvalidInput("Program signals cannot be serialized"))?;
+
+		crate::ensure_credential_negative_json(&metrics)?;
+		crate::ensure_credential_negative_json(&signals)?;
+		crate::ensure_credential_negative_text(provenance.summary())?;
+
+		let descriptor = ProgramCommandDescriptor {
+			operation: "create_program",
+			project_id: program.project_id().to_string(),
+			entity_id: program.id().to_string(),
+			expected_revision: None,
+		};
+		let mut client = crate::checkout(self.pool(), &self.connector).await?;
+		let transaction = client.transaction().await?;
+		let reservation = match reserve_program_command(&transaction, command, &descriptor).await? {
+			ProgramCommandClaim::Completed(response) => {
+				transaction.commit().await?;
+
+				return program_result_from_response(response);
+			},
+			ProgramCommandClaim::Owned(reservation) => reservation,
+		};
+		let row = transaction
+			.query_one(
+				"SELECT result_code,actual_revision,changed FROM decodex.create_program(\
+				 $1::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+				 $2::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+				 $3::pg_catalog.text::decodex.canonical_uuid_v4_text,$4,$5,\
+				 $6::pg_catalog.text::decodex.canonical_uuid_v4_text,$7,$8,$9,$10,$11,\
+				 $12::pg_catalog.text::decodex.canonical_uuid_v4_text,$13)",
+				&[
+					&program.id().as_str(),
+					&program.project_id().as_str(),
+					&program.owner_agent_id().as_str(),
+					&program.name(),
+					&program.responsibility(),
+					&program.policy_revision_id().policy_id().as_str(),
+					&to_i64(program.policy_revision_id().revision().get())?,
+					&i32::from(program.review_cadence().interval_days()),
+					&program.review_cadence().next_review_at().unix_microseconds(),
+					&metrics,
+					&signals,
+					&provenance.correlation_id().as_str(),
+					&provenance.summary(),
+				],
+			)
+			.await?;
+		let result = command_result(&row, &descriptor)?;
+		let response = if result.is_ok() {
+			let record =
+				read_program(&transaction, program.id()).await?.ok_or_else(incompatible)?;
+
+			if row.get(2) {
+				append_program_activity(
+					&transaction,
+					"program",
+					program.id().as_str(),
+					record.program.revision(),
+					"program_created",
+					command,
+					serde_json::json!({"project_id":program.project_id().as_str(),"state":"active"}),
+				)
+				.await?;
+			}
+
+			program_response(&record)?
+		} else {
+			error_response(result.expect_err("checked error"), &descriptor)
+		};
+
+		finish_program_command(&transaction, &reservation, &response).await?;
+
+		transaction.commit().await?;
+
+		program_result_from_response(response)
+	}
+
+	/// Replace mutable Program review/observation context under optimistic concurrency.
+	pub async fn update_program_context(
+		&self,
+		command: &CommandIdentity,
+		update: &UpdateProgramContext,
+		provenance: &ProgramProvenance,
+	) -> Result<ProgramRecord, StoreError> {
+		let expected_revision = to_i64(update.expected_revision)?;
+		let metrics = serde_json::to_value(&update.metrics)
+			.map_err(|_| StoreError::InvalidInput("Program metrics cannot be serialized"))?;
+		let signals = serde_json::to_value(&update.signals)
+			.map_err(|_| StoreError::InvalidInput("Program signals cannot be serialized"))?;
+
+		crate::ensure_credential_negative_json(&metrics)?;
+		crate::ensure_credential_negative_json(&signals)?;
+		crate::ensure_credential_negative_text(provenance.summary())?;
+
+		let descriptor = ProgramCommandDescriptor {
+			operation: "update_program_context",
+			project_id: update.project_id.to_string(),
+			entity_id: update.program_id.to_string(),
+			expected_revision: Some(expected_revision),
+		};
+
+		self.execute_program_mutation(
+			command,
+			descriptor,
+			ProgramMutation::Update { update, expected_revision, metrics, signals, provenance },
+		)
+		.await
+	}
+
+	/// Transition one Program lifecycle under optimistic concurrency.
+	pub async fn transition_program(
+		&self,
+		command: &CommandIdentity,
+		project_id: &ProjectId,
+		program_id: &ProgramId,
+		expected_revision: u64,
+		state: ProgramState,
+		provenance: &ProgramProvenance,
+	) -> Result<ProgramRecord, StoreError> {
+		let expected_revision = to_i64(expected_revision)?;
+		let descriptor = ProgramCommandDescriptor {
+			operation: "transition_program",
+			project_id: project_id.to_string(),
+			entity_id: program_id.to_string(),
+			expected_revision: Some(expected_revision),
+		};
+
+		self.execute_program_mutation(
+			command,
+			descriptor,
+			ProgramMutation::Transition {
+				project_id,
+				program_id,
+				expected_revision,
+				state,
+				provenance,
+			},
+		)
+		.await
+	}
+
+	/// Deterministically read one Program and its current-revision provenance.
+	pub async fn program(&self, id: &ProgramId) -> Result<Option<ProgramRecord>, StoreError> {
+		let client = crate::checkout(self.pool(), &self.connector).await?;
+		let row = client.query_opt(PROGRAM_SELECT, &[&id.as_str()]).await?;
+
+		row.map(program_from_row).transpose()
+	}
+
+	/// Create one finite proposed Objective under canonical active Lead authority.
+	pub async fn create_objective(
+		&self,
+		command: &CommandIdentity,
+		objective: &Objective,
+		provenance: &ProgramProvenance,
+	) -> Result<ObjectiveRecord, StoreError> {
+		if objective.state() != ObjectiveState::Proposed || objective.revision() != 1 {
+			return Err(StoreError::InvalidInput("new Objective must be proposed at revision one"));
+		}
+
+		crate::ensure_credential_negative_text(provenance.summary())?;
+
+		let descriptor = ProgramCommandDescriptor {
+			operation: "create_objective",
+			project_id: objective.project_id().to_string(),
+			entity_id: objective.id().to_string(),
+			expected_revision: None,
+		};
+		let mut client = crate::checkout(self.pool(), &self.connector).await?;
+		let transaction = client.transaction().await?;
+		let reservation = match reserve_program_command(&transaction, command, &descriptor).await? {
+			ProgramCommandClaim::Completed(response) => {
+				transaction.commit().await?;
+
+				return objective_result_from_response(response);
+			},
+			ProgramCommandClaim::Owned(reservation) => reservation,
+		};
+		let row = transaction
+			.query_one(
+				"SELECT result_code,actual_revision,changed FROM decodex.create_objective(\
+				 $1::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+				 $2::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+				 $3::pg_catalog.text::decodex.canonical_uuid_v4_text,$4,$5,$6,$7,\
+				 $8::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+				 $9::pg_catalog.text::decodex.canonical_uuid_v4_text,$10)",
+				&[
+					&objective.id().as_str(),
+					&objective.project_id().as_str(),
+					&objective.program_id().map(ProgramId::as_str),
+					&objective.outcome(),
+					&objective.acceptance_criteria(),
+					&objective.validation_criteria(),
+					&objective.target_at().unix_microseconds(),
+					&provenance.actor_id().as_str(),
+					&provenance.correlation_id().as_str(),
+					&provenance.summary(),
+				],
+			)
+			.await?;
+		let result = command_result(&row, &descriptor)?;
+		let response = if result.is_ok() {
+			let record =
+				read_objective(&transaction, objective.id()).await?.ok_or_else(incompatible)?;
+
+			if row.get(2) {
+				append_program_activity(
+					&transaction,
+					"objective",
+					objective.id().as_str(),
+					record.objective.revision(),
+					"objective_created",
+					command,
+					serde_json::json!({"project_id":objective.project_id().as_str(),"state":"proposed"}),
+				)
+				.await?;
+			}
+
+			objective_response(&record)?
+		} else {
+			error_response(result.expect_err("checked error"), &descriptor)
+		};
+
+		finish_program_command(&transaction, &reservation, &response).await?;
+
+		transaction.commit().await?;
+
+		objective_result_from_response(response)
+	}
+
+	/// Transition one finite Objective without permitting bare achievement.
+	pub async fn transition_objective(
+		&self,
+		command: &CommandIdentity,
+		project_id: &ProjectId,
+		objective_id: &ObjectiveId,
+		expected_revision: u64,
+		state: ObjectiveState,
+		provenance: &ProgramProvenance,
+	) -> Result<ObjectiveRecord, StoreError> {
+		let expected_revision = to_i64(expected_revision)?;
+		let descriptor = ProgramCommandDescriptor {
+			operation: "transition_objective",
+			project_id: project_id.to_string(),
+			entity_id: objective_id.to_string(),
+			expected_revision: Some(expected_revision),
+		};
+
+		self.execute_objective_mutation(
+			command,
+			descriptor,
+			ObjectiveMutation::Transition {
+				project_id,
+				objective_id,
+				expected_revision,
+				state,
+				provenance,
+			},
+		)
+		.await
+	}
+
+	/// Achieve one Objective only by persisting exact immutable acceptance and validation evidence.
+	pub async fn achieve_objective(
+		&self,
+		command: &CommandIdentity,
+		evidence: &ObjectiveCompletionEvidence,
+	) -> Result<ObjectiveRecord, StoreError> {
+		let expected_revision = to_i64(evidence.objective_revision())?;
+		let descriptor = ProgramCommandDescriptor {
+			operation: "achieve_objective",
+			project_id: evidence.project_id().to_string(),
+			entity_id: evidence.objective_id().to_string(),
+			expected_revision: Some(expected_revision),
+		};
+
+		self.execute_objective_mutation(
+			command,
+			descriptor,
+			ObjectiveMutation::Achieve { evidence, expected_revision },
+		)
+		.await
+	}
+
+	/// Deterministically read one Objective, completion evidence, and current provenance.
+	pub async fn objective(&self, id: &ObjectiveId) -> Result<Option<ObjectiveRecord>, StoreError> {
+		let client = crate::checkout(self.pool(), &self.connector).await?;
+		let row = client.query_opt(OBJECTIVE_SELECT, &[&id.as_str()]).await?;
+
+		row.map(objective_from_row).transpose()
+	}
+
+	async fn execute_program_mutation(
+		&self,
+		command: &CommandIdentity,
+		descriptor: ProgramCommandDescriptor,
+		mutation: ProgramMutation<'_>,
+	) -> Result<ProgramRecord, StoreError> {
+		let mut client = crate::checkout(self.pool(), &self.connector).await?;
+		let transaction = client.transaction().await?;
+		let reservation = match reserve_program_command(&transaction, command, &descriptor).await? {
+			ProgramCommandClaim::Completed(response) => {
+				transaction.commit().await?;
+
+				return program_result_from_response(response);
+			},
+			ProgramCommandClaim::Owned(reservation) => reservation,
+		};
+		let (row, program_id, event_kind) = match mutation {
+			ProgramMutation::Update { update, expected_revision, metrics, signals, provenance } => {
+				let row = transaction
+					.query_one(
+						"SELECT result_code,actual_revision,changed FROM decodex.update_program_context(\
+						 $1::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+						 $2::pg_catalog.text::decodex.canonical_uuid_v4_text,$3,$4,$5,$6,$7,\
+						 $8::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+						 $9::pg_catalog.text::decodex.canonical_uuid_v4_text,$10)",
+						&[
+							&update.program_id.as_str(),
+							&update.project_id.as_str(),
+							&expected_revision,
+							&i32::from(update.review_cadence.interval_days()),
+							&update.review_cadence.next_review_at().unix_microseconds(),
+							&metrics,
+							&signals,
+							&provenance.actor_id().as_str(),
+							&provenance.correlation_id().as_str(),
+							&provenance.summary(),
+						],
+					)
+					.await?;
+
+				(row, update.program_id.clone(), "program_context_updated")
+			},
+			ProgramMutation::Transition {
+				project_id,
+				program_id,
+				expected_revision,
+				state,
+				provenance,
+			} => {
+				let row = transaction
+					.query_one(
+						"SELECT result_code,actual_revision,changed FROM decodex.transition_program(\
+						 $1::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+						 $2::pg_catalog.text::decodex.canonical_uuid_v4_text,$3,\
+						 $4::pg_catalog.text::decodex.program_state,\
+						 $5::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+						 $6::pg_catalog.text::decodex.canonical_uuid_v4_text,$7)",
+						&[
+							&program_id.as_str(),
+							&project_id.as_str(),
+							&expected_revision,
+							&program_state_text(state),
+							&provenance.actor_id().as_str(),
+							&provenance.correlation_id().as_str(),
+							&provenance.summary(),
+						],
+					)
+					.await?;
+
+				(row, program_id.clone(), "program_transitioned")
+			},
+		};
+		let result = command_result(&row, &descriptor)?;
+		let response = if result.is_ok() {
+			let record = read_program(&transaction, &program_id).await?.ok_or_else(incompatible)?;
+
+			if row.get(2) {
+				append_program_activity(
+					&transaction,
+					"program",
+					program_id.as_str(),
+					record.program.revision(),
+					event_kind,
+					command,
+					serde_json::json!({"project_id":record.program.project_id().as_str(),"state":record.program.state().as_str()}),
+				)
+				.await?;
+			}
+
+			program_response(&record)?
+		} else {
+			error_response(result.expect_err("checked error"), &descriptor)
+		};
+
+		finish_program_command(&transaction, &reservation, &response).await?;
+
+		transaction.commit().await?;
+
+		program_result_from_response(response)
+	}
+
+	async fn execute_objective_mutation(
+		&self,
+		command: &CommandIdentity,
+		descriptor: ProgramCommandDescriptor,
+		mutation: ObjectiveMutation<'_>,
+	) -> Result<ObjectiveRecord, StoreError> {
+		let mut client = crate::checkout(self.pool(), &self.connector).await?;
+		let transaction = client.transaction().await?;
+		let reservation = match reserve_program_command(&transaction, command, &descriptor).await? {
+			ProgramCommandClaim::Completed(response) => {
+				transaction.commit().await?;
+
+				return objective_result_from_response(response);
+			},
+			ProgramCommandClaim::Owned(reservation) => reservation,
+		};
+		let (row, objective_id, event_kind) = match mutation {
+			ObjectiveMutation::Transition {
+				project_id,
+				objective_id,
+				expected_revision,
+				state,
+				provenance,
+			} => {
+				let row = transaction
+					.query_one(
+						"SELECT result_code,actual_revision,changed FROM decodex.transition_objective(\
+						 $1::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+						 $2::pg_catalog.text::decodex.canonical_uuid_v4_text,$3,\
+						 $4::pg_catalog.text::decodex.objective_state,\
+						 $5::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+						 $6::pg_catalog.text::decodex.canonical_uuid_v4_text,$7)",
+						&[
+							&objective_id.as_str(),
+							&project_id.as_str(),
+							&expected_revision,
+							&objective_state_text(state),
+							&provenance.actor_id().as_str(),
+							&provenance.correlation_id().as_str(),
+							&provenance.summary(),
+						],
+					)
+					.await?;
+
+				(row, objective_id.clone(), "objective_transitioned")
+			},
+			ObjectiveMutation::Achieve { evidence, expected_revision } => {
+				let row = transaction
+					.query_one(
+						"SELECT result_code,actual_revision,changed FROM decodex.achieve_objective(\
+					 $1::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+					 $2::pg_catalog.text::decodex.canonical_uuid_v4_text,\
+					 $3::pg_catalog.text::decodex.canonical_uuid_v4_text,$4,$5,\
+					 $6::pg_catalog.text::decodex.canonical_uuid_v4_text,$7,$8,$9,\
+					 $10::pg_catalog.text::decodex.canonical_uuid_v4_text,$11,$12,\
+					 $13::pg_catalog.text::decodex.canonical_uuid_v4_text)",
+						&[
+							&evidence.id().as_str(),
+							&evidence.objective_id().as_str(),
+							&evidence.project_id().as_str(),
+							&expected_revision,
+							&evidence.acceptance_result(),
+							&evidence.accepted_by().as_str(),
+							&evidence.accepted_at().unix_microseconds(),
+							&evidence.acceptance_provenance(),
+							&evidence.validation_result(),
+							&evidence.validated_by().as_str(),
+							&evidence.validated_at().unix_microseconds(),
+							&evidence.validation_provenance(),
+							&evidence.correlation_id().as_str(),
+						],
+					)
+					.await?;
+
+				(row, evidence.objective_id().clone(), "objective_achieved")
+			},
+		};
+		let result = command_result(&row, &descriptor)?;
+		let response = if result.is_ok() {
+			let record =
+				read_objective(&transaction, &objective_id).await?.ok_or_else(incompatible)?;
+
+			if row.get(2) {
+				append_program_activity(
+					&transaction,
+					"objective",
+					objective_id.as_str(),
+					record.objective.revision(),
+					event_kind,
+					command,
+					serde_json::json!({"project_id":record.objective.project_id().as_str(),"state":record.objective.state().as_str()}),
+				)
+				.await?;
+			}
+
+			objective_response(&record)?
+		} else {
+			error_response(result.expect_err("checked error"), &descriptor)
+		};
+
+		finish_program_command(&transaction, &reservation, &response).await?;
+
+		transaction.commit().await?;
+
+		objective_result_from_response(response)
+	}
+}
+
+fn program_from_row(row: Row) -> Result<ProgramRecord, StoreError> {
+	let project_id = ProjectId::new(row.get::<_, String>(1)).map_err(domain_error)?;
+	let policy_revision_id = PolicyRevisionId::new(
+		project_id.clone(),
+		PolicyId::new(row.get::<_, String>(6)).map_err(domain_error)?,
+		PolicyRevision::new(to_u64(row.get(7))?).map_err(domain_error)?,
+	);
+	let metrics = serde_json::from_value(row.get(10))
+		.map_err(|_| StoreError::Incompatible("stored Program metrics are invalid".into()))?;
+	let signals = serde_json::from_value(row.get(11))
+		.map_err(|_| StoreError::Incompatible("stored Program signals are invalid".into()))?;
+	let program = Program::from_stored(
+		ProgramId::new(row.get::<_, String>(0)).map_err(domain_error)?,
+		project_id,
+		AgentId::new(row.get::<_, String>(2)).map_err(domain_error)?,
+		row.get(3),
+		row.get(4),
+		program_state(row.get(5))?,
+		policy_revision_id,
+		ReviewCadence::new(
+			u16::try_from(row.get::<_, i32>(8)).map_err(|_| incompatible())?,
+			ProgramTimestamp::from_unix_microseconds(row.get(9)).map_err(domain_error)?,
+		)
+		.map_err(domain_error)?,
+		metrics,
+		signals,
+		to_u64(row.get(12))?,
+	)
+	.map_err(domain_error)?;
+	let last_change = provenance_from_values(row.get(13), row.get(14), row.get(15))?;
+
+	Ok(ProgramRecord { program, last_change })
+}
+
+fn objective_from_row(row: Row) -> Result<ObjectiveRecord, StoreError> {
+	let objective_id = ObjectiveId::new(row.get::<_, String>(0)).map_err(domain_error)?;
+	let project_id = ProjectId::new(row.get::<_, String>(1)).map_err(domain_error)?;
+	let completion = row
+		.get::<_, Option<String>>(13)
+		.map(|evidence_id| {
+			ObjectiveCompletionEvidence::from_stored(
+				ObjectiveEvidenceId::new(evidence_id).map_err(domain_error)?,
+				objective_id.clone(),
+				project_id.clone(),
+				to_u64(row.get::<_, Option<i64>>(14).ok_or_else(incompatible)?)?,
+				Some(
+					ProgramTimestamp::from_unix_microseconds(
+						row.get::<_, Option<i64>>(15).ok_or_else(incompatible)?,
+					)
+					.map_err(domain_error)?,
+				),
+				row.get::<_, Option<String>>(16).ok_or_else(incompatible)?,
+				AgentId::new(row.get::<_, Option<String>>(17).ok_or_else(incompatible)?)
+					.map_err(domain_error)?,
+				ProgramTimestamp::from_unix_microseconds(
+					row.get::<_, Option<i64>>(18).ok_or_else(incompatible)?,
+				)
+				.map_err(domain_error)?,
+				row.get::<_, Option<String>>(19).ok_or_else(incompatible)?,
+				row.get::<_, Option<String>>(20).ok_or_else(incompatible)?,
+				AgentId::new(row.get::<_, Option<String>>(21).ok_or_else(incompatible)?)
+					.map_err(domain_error)?,
+				ProgramTimestamp::from_unix_microseconds(
+					row.get::<_, Option<i64>>(22).ok_or_else(incompatible)?,
+				)
+				.map_err(domain_error)?,
+				row.get::<_, Option<String>>(23).ok_or_else(incompatible)?,
+				ProgramCorrelationId::new(
+					row.get::<_, Option<String>>(24).ok_or_else(incompatible)?,
+				)
+				.map_err(domain_error)?,
+				ProgramTimestamp::from_unix_microseconds(
+					row.get::<_, Option<i64>>(25).ok_or_else(incompatible)?,
+				)
+				.map_err(domain_error)?,
+			)
+			.map_err(domain_error)
+		})
+		.transpose()?;
+	let objective = Objective::from_stored(
+		objective_id,
+		project_id,
+		row.get::<_, Option<String>>(2).map(ProgramId::new).transpose().map_err(domain_error)?,
+		row.get(3),
+		row.get(4),
+		row.get(5),
+		ProgramTimestamp::from_unix_microseconds(row.get(6)).map_err(domain_error)?,
+		objective_state(row.get(7))?,
+		to_u64(row.get(8))?,
+		completion,
+	)
+	.map_err(domain_error)?;
+	let last_change = provenance_from_values(row.get(10), row.get(11), row.get(12))?;
+
+	Ok(ObjectiveRecord { objective, last_change })
+}
+
+fn provenance_from_values(
+	actor_id: String,
+	correlation_id: String,
+	summary: String,
+) -> Result<ProgramProvenance, StoreError> {
+	ProgramProvenance::new(
+		AgentId::new(actor_id).map_err(domain_error)?,
+		ProgramCorrelationId::new(correlation_id).map_err(domain_error)?,
+		summary,
+	)
+	.map_err(domain_error)
+}
+
+fn program_response(record: &ProgramRecord) -> Result<Value, StoreError> {
+	Ok(serde_json::json!({
+		"kind":"program","result":"ok","program_id":record.program.id().as_str(),
+		"project_id":record.program.project_id().as_str(),
+		"owner_agent_id":record.program.owner_agent_id().as_str(),"name":record.program.name(),
+		"responsibility":record.program.responsibility(),"state":record.program.state().as_str(),
+		"policy_id":record.program.policy_revision_id().policy_id().as_str(),
+		"policy_revision":record.program.policy_revision_id().revision().get(),
+		"review_interval_days":record.program.review_cadence().interval_days(),
+		"next_review_at_microseconds":record.program.review_cadence().next_review_at().unix_microseconds(),
+		"metrics":serde_json::to_value(record.program.metrics()).map_err(|_| incompatible())?,
+		"signals":serde_json::to_value(record.program.signals()).map_err(|_| incompatible())?,
+		"revision":record.program.revision(),"last_changed_by":record.last_change.actor_id().as_str(),
+		"last_correlation_id":record.last_change.correlation_id().as_str(),
+		"last_provenance":record.last_change.summary()
+	}))
+}
+
+fn objective_response(record: &ObjectiveRecord) -> Result<Value, StoreError> {
+	let completion = record.objective.completion().map(|evidence| {
+		let objective_updated_at = evidence.objective_updated_at().ok_or_else(incompatible)?;
+
+		Ok::<_, StoreError>(serde_json::json!({
+			"evidence_id":evidence.id().as_str(),"objective_revision":evidence.objective_revision(),
+			"objective_updated_at_microseconds":objective_updated_at.unix_microseconds(),
+			"acceptance_result":evidence.acceptance_result(),"accepted_by":evidence.accepted_by().as_str(),
+			"accepted_at_microseconds":evidence.accepted_at().unix_microseconds(),
+			"acceptance_provenance":evidence.acceptance_provenance(),
+			"validation_result":evidence.validation_result(),"validated_by":evidence.validated_by().as_str(),
+			"validated_at_microseconds":evidence.validated_at().unix_microseconds(),
+			"validation_provenance":evidence.validation_provenance(),
+			"correlation_id":evidence.correlation_id().as_str(),
+			"recorded_at_microseconds":evidence.recorded_at().unix_microseconds()
+		}))
+	}).transpose()?;
+
+	Ok(serde_json::json!({
+		"kind":"objective","result":"ok","objective_id":record.objective.id().as_str(),
+		"project_id":record.objective.project_id().as_str(),
+		"program_id":record.objective.program_id().map(ProgramId::as_str),
+		"outcome":record.objective.outcome(),"acceptance_criteria":record.objective.acceptance_criteria(),
+		"validation_criteria":record.objective.validation_criteria(),
+		"target_at_microseconds":record.objective.target_at().unix_microseconds(),
+		"state":record.objective.state().as_str(),"revision":record.objective.revision(),
+		"completion":completion,"last_changed_by":record.last_change.actor_id().as_str(),
+		"last_correlation_id":record.last_change.correlation_id().as_str(),
+		"last_provenance":record.last_change.summary()
+	}))
+}
+
+fn program_result_from_response(response: Value) -> Result<ProgramRecord, StoreError> {
+	if let Some(error) = rejection_from_response(&response)? {
+		return Err(error);
+	}
+
+	if required_str(&response, "kind")? != "program" {
+		return Err(StoreError::IdempotencyConflict);
+	}
+
+	let project_id =
+		ProjectId::new(required_str(&response, "project_id")?).map_err(domain_error)?;
+	let policy_revision_id = PolicyRevisionId::new(
+		project_id.clone(),
+		PolicyId::new(required_str(&response, "policy_id")?).map_err(domain_error)?,
+		PolicyRevision::new(required_u64(&response, "policy_revision")?).map_err(domain_error)?,
+	);
+	let program = Program::from_stored(
+		ProgramId::new(required_str(&response, "program_id")?).map_err(domain_error)?,
+		project_id,
+		AgentId::new(required_str(&response, "owner_agent_id")?).map_err(domain_error)?,
+		required_str(&response, "name")?.into(),
+		required_str(&response, "responsibility")?.into(),
+		program_state(required_str(&response, "state")?)?,
+		policy_revision_id,
+		ReviewCadence::new(
+			u16::try_from(required_u64(&response, "review_interval_days")?)
+				.map_err(|_| incompatible())?,
+			ProgramTimestamp::from_unix_microseconds(required_i64(
+				&response,
+				"next_review_at_microseconds",
+			)?)
+			.map_err(domain_error)?,
+		)
+		.map_err(domain_error)?,
+		serde_json::from_value(required(&response, "metrics")?.clone())
+			.map_err(|_| incompatible())?,
+		serde_json::from_value(required(&response, "signals")?.clone())
+			.map_err(|_| incompatible())?,
+		required_u64(&response, "revision")?,
+	)
+	.map_err(domain_error)?;
+	let last_change = provenance_from_values(
+		required_str(&response, "last_changed_by")?.into(),
+		required_str(&response, "last_correlation_id")?.into(),
+		required_str(&response, "last_provenance")?.into(),
+	)?;
+
+	Ok(ProgramRecord { program, last_change })
+}
+
+fn objective_result_from_response(response: Value) -> Result<ObjectiveRecord, StoreError> {
+	if let Some(error) = rejection_from_response(&response)? {
+		return Err(error);
+	}
+
+	if required_str(&response, "kind")? != "objective" {
+		return Err(StoreError::IdempotencyConflict);
+	}
+
+	let objective_id =
+		ObjectiveId::new(required_str(&response, "objective_id")?).map_err(domain_error)?;
+	let project_id =
+		ProjectId::new(required_str(&response, "project_id")?).map_err(domain_error)?;
+	let completion = response
+		.get("completion")
+		.filter(|value| !value.is_null())
+		.map(|value| {
+			ObjectiveCompletionEvidence::from_stored(
+				ObjectiveEvidenceId::new(required_str(value, "evidence_id")?)
+					.map_err(domain_error)?,
+				objective_id.clone(),
+				project_id.clone(),
+				required_u64(value, "objective_revision")?,
+				Some(
+					ProgramTimestamp::from_unix_microseconds(required_i64(
+						value,
+						"objective_updated_at_microseconds",
+					)?)
+					.map_err(domain_error)?,
+				),
+				required_str(value, "acceptance_result")?.into(),
+				AgentId::new(required_str(value, "accepted_by")?).map_err(domain_error)?,
+				ProgramTimestamp::from_unix_microseconds(required_i64(
+					value,
+					"accepted_at_microseconds",
+				)?)
+				.map_err(domain_error)?,
+				required_str(value, "acceptance_provenance")?.into(),
+				required_str(value, "validation_result")?.into(),
+				AgentId::new(required_str(value, "validated_by")?).map_err(domain_error)?,
+				ProgramTimestamp::from_unix_microseconds(required_i64(
+					value,
+					"validated_at_microseconds",
+				)?)
+				.map_err(domain_error)?,
+				required_str(value, "validation_provenance")?.into(),
+				ProgramCorrelationId::new(required_str(value, "correlation_id")?)
+					.map_err(domain_error)?,
+				ProgramTimestamp::from_unix_microseconds(required_i64(
+					value,
+					"recorded_at_microseconds",
+				)?)
+				.map_err(domain_error)?,
+			)
+			.map_err(domain_error)
+		})
+		.transpose()?;
+	let objective = Objective::from_stored(
+		objective_id,
+		project_id,
+		response
+			.get("program_id")
+			.and_then(Value::as_str)
+			.map(ProgramId::new)
+			.transpose()
+			.map_err(domain_error)?,
+		required_str(&response, "outcome")?.into(),
+		serde_json::from_value(required(&response, "acceptance_criteria")?.clone())
+			.map_err(|_| incompatible())?,
+		serde_json::from_value(required(&response, "validation_criteria")?.clone())
+			.map_err(|_| incompatible())?,
+		ProgramTimestamp::from_unix_microseconds(required_i64(
+			&response,
+			"target_at_microseconds",
+		)?)
+		.map_err(domain_error)?,
+		objective_state(required_str(&response, "state")?)?,
+		required_u64(&response, "revision")?,
+		completion,
+	)
+	.map_err(domain_error)?;
+	let last_change = provenance_from_values(
+		required_str(&response, "last_changed_by")?.into(),
+		required_str(&response, "last_correlation_id")?.into(),
+		required_str(&response, "last_provenance")?.into(),
+	)?;
+
+	Ok(ObjectiveRecord { objective, last_change })
+}
+
+fn command_result(
+	row: &Row,
+	descriptor: &ProgramCommandDescriptor,
+) -> Result<Result<(), Rejection>, StoreError> {
+	let code = row.get::<_, &str>(0);
+	let actual = row.get::<_, Option<i64>>(1);
+
+	Ok(match code {
+		"ok" => Ok(()),
+		"revision_conflict" => Err(Rejection::RevisionConflict {
+			entity: descriptor.entity_id.clone(),
+			expected: descriptor.expected_revision,
+			actual,
+		}),
+		"not_found" => Err(Rejection::NotFound),
+		"invalid_authority" => Err(Rejection::InvalidAuthority),
+		"invalid_policy" => Err(Rejection::InvalidPolicy),
+		"invalid_program" => Err(Rejection::InvalidProgram),
+		"invalid_horizon" => Err(Rejection::InvalidHorizon),
+		"invalid_transition" => Err(Rejection::InvalidTransition),
+		"invalid_evidence" => Err(Rejection::InvalidEvidence),
+		"invalid_project" => Err(Rejection::InvalidProject),
+		"conflicting_identity" => Err(Rejection::ConflictingIdentity),
+		_ => return Err(incompatible()),
+	})
+}
+
+fn error_response(error: Rejection, descriptor: &ProgramCommandDescriptor) -> Value {
+	match error {
+		Rejection::RevisionConflict { entity, expected, actual } => serde_json::json!({
+			"kind":"program_error","code":"revision_conflict","entity":entity,
+			"expected":expected,"actual":actual
+		}),
+		other => serde_json::json!({
+			"kind":"program_error","code":match other {
+				Rejection::NotFound => "not_found",
+				Rejection::InvalidAuthority => "invalid_authority",
+				Rejection::InvalidPolicy => "invalid_policy",
+				Rejection::InvalidProgram => "invalid_program",
+				Rejection::InvalidHorizon => "invalid_horizon",
+				Rejection::InvalidTransition => "invalid_transition",
+				Rejection::InvalidEvidence => "invalid_evidence",
+				Rejection::InvalidProject => "invalid_project",
+				Rejection::ConflictingIdentity => "conflicting_identity",
+				Rejection::RevisionConflict { .. } => unreachable!(),
+			},
+			"entity":descriptor.entity_id
+		}),
+	}
+}
+
+fn rejection_from_response(value: &Value) -> Result<Option<StoreError>, StoreError> {
+	if value.get("kind").and_then(Value::as_str) != Some("program_error") {
+		return Ok(None);
+	}
+
+	let error = match required_str(value, "code")? {
+		"revision_conflict" => StoreError::RevisionConflict {
+			entity: required_str(value, "entity")?.into(),
+			expected: optional_i64(value, "expected")?,
+			actual: optional_i64(value, "actual")?,
+		},
+		"not_found" => StoreError::RevisionConflict {
+			entity: required_str(value, "entity")?.into(),
+			expected: None,
+			actual: None,
+		},
+		"invalid_authority" => StoreError::InvalidInput(
+			"Program/Objective mutation requires active same-Project Lead authority",
+		),
+		"invalid_policy" => StoreError::InvalidInput(
+			"Program requires an exact accepted same-Project Policy revision",
+		),
+		"invalid_program" =>
+			StoreError::InvalidInput("Objective Program link is not same-Project authority"),
+		"invalid_horizon" =>
+			StoreError::InvalidInput("Objective target must be a future finite horizon"),
+		"invalid_transition" =>
+			StoreError::InvalidInput("Program/Objective lifecycle transition is invalid"),
+		"invalid_evidence" => StoreError::InvalidInput(
+			"Objective achievement requires chronological acceptance and validation evidence",
+		),
+		"invalid_project" => StoreError::InvalidInput(
+			"Program/Objective request Project does not match stored authority",
+		),
+		"conflicting_identity" => StoreError::IdempotencyConflict,
+		_ => return Err(incompatible()),
+	};
+
+	Ok(Some(error))
+}
+
+fn program_state(value: &str) -> Result<ProgramState, StoreError> {
+	match value {
+		"active" => Ok(ProgramState::Active),
+		"needs_attention" => Ok(ProgramState::NeedsAttention),
+		"blocked" => Ok(ProgramState::Blocked),
+		"paused" => Ok(ProgramState::Paused),
+		"retired" => Ok(ProgramState::Retired),
+		_ => Err(incompatible()),
+	}
+}
+
+const fn program_state_text(value: ProgramState) -> &'static str {
+	value.as_str()
+}
+
+fn objective_state(value: &str) -> Result<ObjectiveState, StoreError> {
+	match value {
+		"proposed" => Ok(ObjectiveState::Proposed),
+		"active" => Ok(ObjectiveState::Active),
+		"blocked" => Ok(ObjectiveState::Blocked),
+		"achieved" => Ok(ObjectiveState::Achieved),
+		"abandoned" => Ok(ObjectiveState::Abandoned),
+		_ => Err(incompatible()),
+	}
+}
+
+const fn objective_state_text(value: ObjectiveState) -> &'static str {
+	value.as_str()
+}
+
+fn required<'a>(value: &'a Value, key: &str) -> Result<&'a Value, StoreError> {
+	value.get(key).ok_or_else(incompatible)
+}
+
+fn required_str<'a>(value: &'a Value, key: &str) -> Result<&'a str, StoreError> {
+	required(value, key)?.as_str().ok_or_else(incompatible)
+}
+
+fn required_i64(value: &Value, key: &str) -> Result<i64, StoreError> {
+	required(value, key)?.as_i64().ok_or_else(incompatible)
+}
+
+fn required_u64(value: &Value, key: &str) -> Result<u64, StoreError> {
+	required(value, key)?.as_u64().ok_or_else(incompatible)
+}
+
+fn optional_i64(value: &Value, key: &str) -> Result<Option<i64>, StoreError> {
+	match required(value, key)? {
+		Value::Null => Ok(None),
+		value => value.as_i64().map(Some).ok_or_else(incompatible),
+	}
+}
+
+fn to_i64(value: u64) -> Result<i64, StoreError> {
+	i64::try_from(value).map_err(|_| {
+		StoreError::InvalidInput("Program/Objective revision exceeds PostgreSQL bigint")
+	})
+}
+
+fn to_u64(value: i64) -> Result<u64, StoreError> {
+	u64::try_from(value).map_err(|_| incompatible())
+}
+
+fn domain_error(error: impl Display) -> StoreError {
+	StoreError::Incompatible(format!("invalid stored Program/Objective authority: {error}"))
+}
+
+fn incompatible() -> StoreError {
+	StoreError::Incompatible("invalid stored Program/Objective authority".into())
+}
+
+async fn reserve_program_command(
+	transaction: &Transaction<'_>,
+	command: &CommandIdentity,
+	descriptor: &ProgramCommandDescriptor,
+) -> Result<ProgramCommandClaim, StoreError> {
+	let inserted = transaction
+		.query_opt(
+			"INSERT INTO decodex.command_receipts\
+			 (idempotency_key,request_hash,protocol_version,operation,project_scope,scope_id,\
+			 entity_id,expected_revision,receipt_state,claim_token,claim_expires_at)\
+			 VALUES ($1,$2,'decodex/store-command/1',$3,'project',$4,$5,$6,'pending',\
+			 pg_catalog.gen_random_uuid(),pg_catalog.clock_timestamp()+interval '5 minutes')\
+			 ON CONFLICT DO NOTHING RETURNING claim_token::text",
+			&[
+				&command.key,
+				&command.request_hash,
+				&descriptor.operation,
+				&descriptor.project_id,
+				&descriptor.entity_id,
+				&descriptor.expected_revision,
+			],
+		)
+		.await?;
+
+	if let Some(row) = inserted {
+		return Ok(ProgramCommandClaim::Owned(ProgramCommandReservation {
+			key: command.key.clone(),
+			request_hash: command.request_hash.clone(),
+			claim_token: row.get(0),
+		}));
+	}
+
+	let row = transaction
+		.query_one(
+			"SELECT request_hash,operation,project_scope,scope_id,entity_id,expected_revision,\
+			 receipt_state::text,response,response_bytes FROM decodex.command_receipts \
+			 WHERE idempotency_key=$1 FOR UPDATE",
+			&[&command.key],
+		)
+		.await?;
+
+	if row.get::<_, String>(0) != command.request_hash
+		|| row.get::<_, String>(1) != descriptor.operation
+		|| row.get::<_, String>(2) != "project"
+		|| row.get::<_, String>(3) != descriptor.project_id
+		|| row.get::<_, String>(4) != descriptor.entity_id
+		|| row.get::<_, Option<i64>>(5) != descriptor.expected_revision
+	{
+		return Err(StoreError::IdempotencyConflict);
+	}
+	if row.get::<_, &str>(6) != "completed" {
+		return Err(StoreError::Incompatible(
+			"Program/Objective command exposed a committed pending receipt".into(),
+		));
+	}
+
+	let response: Value = row.get(7);
+	let response_bytes = row.get::<_, Option<Vec<u8>>>(8).ok_or_else(incompatible)?;
+	let decoded: Value = serde_json::from_slice(&response_bytes).map_err(|_| incompatible())?;
+
+	if response != decoded {
+		return Err(StoreError::Incompatible(
+			"Program/Objective receipt bytes differ from its response".into(),
+		));
+	}
+
+	Ok(ProgramCommandClaim::Completed(response))
+}
+
+async fn finish_program_command(
+	transaction: &Transaction<'_>,
+	reservation: &ProgramCommandReservation,
+	response: &Value,
+) -> Result<(), StoreError> {
+	let response_bytes = serde_json::to_vec(response)
+		.map_err(|_| StoreError::InvalidInput("Program command response cannot be serialized"))?;
+	let updated = transaction
+		.execute(
+			"UPDATE decodex.command_receipts SET response=$2,response_bytes=$3,\
+			 receipt_state='completed',completed_at=pg_catalog.clock_timestamp(),\
+			 completion_claim_token=$5::text::uuid,claim_token=NULL,claim_expires_at=NULL \
+			 WHERE idempotency_key=$1 AND request_hash=$4 AND receipt_state='pending' \
+			 AND claim_token=$5::text::uuid AND claim_expires_at>pg_catalog.clock_timestamp()",
+			&[
+				&reservation.key,
+				response,
+				&response_bytes,
+				&reservation.request_hash,
+				&reservation.claim_token,
+			],
+		)
+		.await?;
+
+	if updated == 1 {
+		Ok(())
+	} else {
+		Err(StoreError::OwnershipLost("Program/Objective command receipt"))
+	}
+}
+
+async fn append_program_activity(
+	transaction: &Transaction<'_>,
+	aggregate_kind: &str,
+	aggregate_id: &str,
+	revision: u64,
+	event_kind: &str,
+	command: &CommandIdentity,
+	payload: Value,
+) -> Result<(), StoreError> {
+	accounts::append_activity_and_outbox(
+		transaction,
+		aggregate_kind,
+		aggregate_id,
+		to_i64(revision)?,
+		event_kind,
+		&command.key,
+		&payload,
+	)
+	.await
+}
+
+async fn read_program(
+	transaction: &Transaction<'_>,
+	id: &ProgramId,
+) -> Result<Option<ProgramRecord>, StoreError> {
+	transaction.query_opt(PROGRAM_SELECT, &[&id.as_str()]).await?.map(program_from_row).transpose()
+}
+
+async fn read_objective(
+	transaction: &Transaction<'_>,
+	id: &ObjectiveId,
+) -> Result<Option<ObjectiveRecord>, StoreError> {
+	transaction
+		.query_opt(OBJECTIVE_SELECT, &[&id.as_str()])
+		.await?
+		.map(objective_from_row)
+		.transpose()
+}
+
+#[cfg(test)]
+mod tests {
+	use decodex_core::{ObjectiveState, ProgramState};
+
+	#[test]
+	fn closed_state_decoders_refuse_unknown_values() {
+		assert_eq!(super::program_state("needs_attention").unwrap(), ProgramState::NeedsAttention);
+		assert_eq!(super::objective_state("achieved").unwrap(), ObjectiveState::Achieved);
+		assert!(super::program_state("complete").is_err());
+		assert!(super::objective_state("perpetual").is_err());
+	}
+}

--- a/crates/decodex-postgres/tests/postgres_store.rs
+++ b/crates/decodex-postgres/tests/postgres_store.rs
@@ -19,18 +19,21 @@ use tokio::{
 	task::{self, JoinSet},
 	time,
 };
-use tokio_postgres::{Client, Config, NoTls, types::ToSql};
+use tokio_postgres::{Client, Config, NoTls, Row, types::ToSql};
 
 use decodex_core::{
 	self, AcceptedPolicyRevision, AccountSnapshot, ArtifactId, ArtifactStatus, Availability,
 	BlobHash, BlobStore, ContextPack, ContextPackInput, ContextPackPolicy, ContextPackSource,
 	ContextSourceKind, ConversationId, DecodexRoot, HistoryItemId, HistoryItemKind,
-	HistoryMediaType, HistoryMetadata, HistoryMetadataValue, ItemStatus, PinnedContextSource,
-	PolicyId, PolicyProvenance, PolicyRevision, PolicyRevisionAcceptance, PolicyRevisionId,
-	PolicySnapshot, PolicySnapshotValue, PossibleSideEffects, ProductState as _, ProfileSnapshot,
-	Project, ProjectId, ProjectMetadata, ProjectMetadataValue, ProjectRepositoryBinding,
-	ProjectStatus, ProposedTransitionKind, RepositoryIdentity, RuntimeSessionId,
-	RuntimeSessionState, TurnId, TurnRole, TurnStatus,
+	HistoryMediaType, HistoryMetadata, HistoryMetadataValue, ItemStatus, Objective,
+	ObjectiveCompletionEvidence, ObjectiveEvidenceId, ObjectiveId, ObjectiveState,
+	PinnedContextSource, PolicyId, PolicyProvenance, PolicyRevision, PolicyRevisionAcceptance,
+	PolicyRevisionId, PolicySnapshot, PolicySnapshotValue, PossibleSideEffects, ProductState as _,
+	ProfileSnapshot, Program, ProgramContextInput, ProgramCorrelationId, ProgramId, ProgramMetric,
+	ProgramObservationId, ProgramObservationProvenance, ProgramProvenance, ProgramSignal,
+	ProgramState, ProgramTimestamp, Project, ProjectId, ProjectMetadata, ProjectMetadataValue,
+	ProjectRepositoryBinding, ProjectStatus, ProposedTransitionKind, RepositoryIdentity,
+	ReviewCadence, RuntimeSessionId, RuntimeSessionState, TurnId, TurnRole, TurnStatus,
 };
 use decodex_postgres::{
 	AccountId, AccountMutation, AccountState, Agent, AgentId, AgentRole, AgentStatus, CLOSED,
@@ -38,6 +41,7 @@ use decodex_postgres::{
 	CreateRuntimeSession, HistoryCursor, MAX_OPERATION_DURATION_MILLISECONDS, OutboxClaim,
 	OutboxReconciliation, PersistContextPack, PostgresStore, ProposeTransition,
 	QuotaWindowMutation, ReconciliationOutcome, RecordHistoryItem, StoreError,
+	UpdateProgramContext,
 };
 
 const ACCOUNT_ID: &str = "10000000-0000-0000-0000-000000000001";
@@ -87,6 +91,12 @@ const RUNTIME_EXECUTE_SIGNATURES: &[&str] = &[
 	"decodex.transition_project(decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.project_status)",
 	"decodex.create_policy(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text)",
 	"decodex.accept_policy_revision(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,pg_catalog.int8)",
+	"decodex.create_program(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.int4,pg_catalog.int8,pg_catalog.jsonb,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.update_program_context(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.int4,pg_catalog.int8,pg_catalog.jsonb,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.transition_program(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.program_state,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.create_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog._text,pg_catalog._text,pg_catalog.int8,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.transition_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.objective_state,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.achieve_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,decodex.canonical_uuid_v4_text)",
 ];
 const TRIGGER_ONLY_SIGNATURES: &[&str] = &[
 	"decodex.enforce_lease_operation_time()",
@@ -110,6 +120,10 @@ const TRIGGER_ONLY_SIGNATURES: &[&str] = &[
 	"decodex.enforce_history_cursor_state()",
 	"decodex.enforce_policy_identity_state()",
 	"decodex.forbid_policy_revision_mutation()",
+	"decodex.enforce_program_state()",
+	"decodex.enforce_objective_state()",
+	"decodex.forbid_objective_evidence_mutation()",
+	"decodex.enforce_objective_completion_coherence()",
 ];
 const INVALID_PROJECT_AGENT_SQL_CALLS: &[(&str, &str)] = &[
 	(
@@ -314,6 +328,7 @@ async fn postgres_store_contract() -> Result<(), Box<dyn std::error::Error>> {
 	assert_runtime_is_least_privilege(&runtime_client).await?;
 	assert_project_agent_authority(&store, &client, &migration, &runtime).await?;
 	assert_policy_authority(&store, &client, &migration, &runtime).await?;
+	assert_program_objective_authority(&store, &client, &migration, &runtime).await?;
 	assert_account_idempotency_and_revision(&store, &client).await?;
 	assert_receipt_first_saga(&store, &client).await?;
 	assert_concurrent_shard_capacity(&store, &client).await?;
@@ -1864,6 +1879,7 @@ async fn postgres_store_restored_contract() -> Result<(), Box<dyn std::error::Er
 	assert!(restored_fk);
 
 	assert_restored_policy_authority(&store).await?;
+	assert_restored_program_objective_authority(&store).await?;
 
 	let ordinary_rows: i64 = client
 		.query_one(
@@ -1912,6 +1928,34 @@ async fn assert_restored_policy_authority(
 			.all(|revision| revision.accepted_at() >= revision.policy_created_at())
 	);
 	assert_eq!(store.policy_revision(&second_id).await?, Some(second));
+
+	Ok(())
+}
+
+async fn assert_restored_program_objective_authority(
+	store: &PostgresStore,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let program_id = ProgramId::new("41000000-0000-4000-8000-000000000060")?;
+	let achieved_id = ObjectiveId::new("71000000-0000-4000-8000-000000000060")?;
+	let abandoned_id = ObjectiveId::new("71000000-0000-4000-8000-000000000061")?;
+	let program = store.program(&program_id).await?.expect("Program restored");
+	let achieved = store.objective(&achieved_id).await?.expect("achieved Objective restored");
+	let abandoned = store.objective(&abandoned_id).await?.expect("abandoned Objective restored");
+
+	assert_eq!(program.program.revision(), 3);
+	assert!(matches!(program.program.state(), ProgramState::Blocked | ProgramState::Paused));
+	assert_eq!(achieved.objective.state(), ObjectiveState::Achieved);
+	assert_eq!(achieved.objective.revision(), 3);
+
+	let evidence = achieved.objective.completion().expect("achievement evidence restored");
+	let objective_updated_at =
+		evidence.objective_updated_at().expect("prior Objective timestamp restored");
+
+	assert!(objective_updated_at <= evidence.accepted_at());
+	assert!(evidence.accepted_at() <= evidence.validated_at());
+	assert!(evidence.validated_at() <= evidence.recorded_at());
+	assert_eq!(abandoned.objective.state(), ObjectiveState::Abandoned);
+	assert_eq!(abandoned.objective.revision(), 2);
 
 	Ok(())
 }
@@ -2021,7 +2065,7 @@ async fn assert_bootstrap_and_history(client: &Client) -> Result<(), Box<dyn std
 
 	assert_eq!(version, 18);
 	assert_eq!(checksums, "on");
-	assert_eq!(history.len(), 6);
+	assert_eq!(history.len(), 7);
 	assert_eq!(history[0].0, 1);
 	assert_eq!(history[0].1, "persistence_foundation");
 	assert!(!history[0].2.is_empty());
@@ -2040,6 +2084,9 @@ async fn assert_bootstrap_and_history(client: &Client) -> Result<(), Box<dyn std
 	assert_eq!(history[5].0, 6);
 	assert_eq!(history[5].1, "project_policy_authority");
 	assert!(!history[5].2.is_empty());
+	assert_eq!(history[6].0, 7);
+	assert_eq!(history[6].1, "program_objective_authority");
+	assert!(!history[6].2.is_empty());
 
 	let (migration, runtime) = separated_configs("DECODEX_TEST")?;
 
@@ -2273,6 +2320,7 @@ async fn assert_policy_authority(
 
 	assert_eq!(store.accept_policy_revision(winner_request.clone()).await?, winner_revision);
 	assert_eq!(store.policy_revision(winner_revision.id()).await?, Some(winner_revision.clone()));
+
 	assert_policy_revision_conflicts(
 		store,
 		client,
@@ -2298,6 +2346,1439 @@ async fn assert_policy_authority(
 		PostgresStore::connect(migration.clone(), runtime.clone(), expected_peer_uid()).await?;
 
 	assert_eq!(restarted.policy_revision(winner_revision.id()).await?, Some(winner_revision));
+
+	Ok(())
+}
+
+async fn assert_program_objective_authority(
+	store: &PostgresStore,
+	client: &Client,
+	migration: &Config,
+	runtime: &Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let authority = store
+		.create_project(project_request(
+			"11000000-0000-4000-8000-000000000060",
+			"22000000-0000-4000-8000-000000000060",
+			"hack-ink/program-objective-authority",
+			"/srv/repos/program-objective-authority",
+		))
+		.await?;
+	let project_id = authority.project.id().clone();
+	let lead_id = authority.lead.id().clone();
+	let policy_id = PolicyId::new("31000000-0000-4000-8000-000000000060")?;
+
+	store.create_policy(policy_id.clone(), project_id.clone()).await?;
+
+	let accepted_policy = store
+		.accept_policy_revision(policy_acceptance(
+			&project_id,
+			&policy_id,
+			&lead_id,
+			1,
+			"program-objective",
+		))
+		.await?;
+	let program_id = ProgramId::new("41000000-0000-4000-8000-000000000060")?;
+	let program = Program::new(
+		program_id.clone(),
+		project_id.clone(),
+		lead_id.clone(),
+		"SEO and GEO operations",
+		"Operate search visibility continuously; a conversation mention remains ordinary data",
+		accepted_policy.id().clone(),
+		ReviewCadence::new(30, ProgramTimestamp::from_unix_microseconds(2_000_000_000_000_000)?)?,
+	)?;
+	let create_provenance = ProgramProvenance::new(
+		lead_id.clone(),
+		ProgramCorrelationId::new("51000000-0000-4000-8000-000000000060")?,
+		"Lead established the ongoing responsibility",
+	)?;
+	let create_command = CommandIdentity::new("program-create-60", b"program-create-60")?;
+	let created = store.create_program(&create_command, &program, &create_provenance).await?;
+
+	assert_eq!(created.program.state(), ProgramState::Active);
+	assert_eq!(
+		created.program,
+		store.create_program(&create_command, &program, &create_provenance).await?.program
+	);
+
+	assert_program_objective_creation_races(
+		store,
+		client,
+		migration,
+		&project_id,
+		&lead_id,
+		accepted_policy.id(),
+		&program_id,
+	)
+	.await?;
+
+	let observed_at = ProgramTimestamp::from_unix_microseconds(1_900_000_000_000_000)?;
+	let observation = ProgramObservationProvenance::new(
+		"analytics conversation export retained only as inspectable data",
+		observed_at,
+	)?;
+	let metric = ProgramMetric::new("organic_sessions", "1200", "sessions", observation.clone())?;
+	let signal = ProgramSignal::new(
+		ProgramObservationId::new("61000000-0000-4000-8000-000000000060")?,
+		"visibility_change",
+		"Search visibility increased",
+		observation,
+	)?;
+	let update = UpdateProgramContext {
+		program_id: program_id.clone(),
+		project_id: project_id.clone(),
+		expected_revision: 1,
+		review_cadence: ReviewCadence::new(
+			14,
+			ProgramTimestamp::from_unix_microseconds(2_000_100_000_000_000)?,
+		)?,
+		metrics: vec![metric],
+		signals: vec![signal],
+	};
+	let update_provenance = ProgramProvenance::new(
+		lead_id.clone(),
+		ProgramCorrelationId::new("51000000-0000-4000-8000-000000000061")?,
+		"Lead refreshed Program observations",
+	)?;
+	let update_command = CommandIdentity::new("program-update-60", b"program-update-60")?;
+	let updated =
+		store.update_program_context(&update_command, &update, &update_provenance).await?;
+
+	assert_eq!(updated.program.revision(), 2);
+	assert_eq!(
+		updated,
+		store.update_program_context(&update_command, &update, &update_provenance).await?,
+	);
+
+	assert_program_context_compilation_is_pure(client, &updated.program, &program_id).await?;
+	assert_program_transition_replay(
+		store,
+		client,
+		migration,
+		runtime,
+		&project_id,
+		&program_id,
+		&lead_id,
+	)
+	.await?;
+	assert_hostile_program_objective_sql(client, &project_id, &lead_id, &policy_id).await?;
+	assert_objective_lifecycle(store, client, &project_id, &lead_id, &program_id).await?;
+
+	Ok(())
+}
+
+async fn assert_program_objective_creation_races(
+	store: &PostgresStore,
+	client: &Client,
+	migration: &Config,
+	project_id: &ProjectId,
+	lead_id: &AgentId,
+	policy_revision_id: &PolicyRevisionId,
+	program_id: &ProgramId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	assert_program_create_race(store, client, project_id, lead_id, policy_revision_id).await?;
+	assert_objective_create_race(store, client, project_id, lead_id, program_id).await?;
+	assert_objective_evidence_race(store, client, project_id, lead_id, program_id).await?;
+	assert_cross_objective_evidence_identity_race(
+		store, client, migration, project_id, lead_id, program_id,
+	)
+	.await?;
+
+	let pending: i64 = client
+		.query_one(
+			"SELECT count(*) FROM decodex.command_receipts WHERE receipt_state='pending'\
+			 AND operation IN ('create_program','transition_program','create_objective',\
+			 'transition_objective','achieve_objective')",
+			&[],
+		)
+		.await?
+		.get(0);
+
+	assert_eq!(pending, 0);
+
+	Ok(())
+}
+
+async fn assert_program_create_race(
+	store: &PostgresStore,
+	client: &Client,
+	project_id: &ProjectId,
+	lead_id: &AgentId,
+	policy_revision_id: &PolicyRevisionId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let program_id = ProgramId::new("41000000-0000-4000-8000-000000000080")?;
+	let program = Program::new(
+		program_id.clone(),
+		project_id.clone(),
+		lead_id.clone(),
+		"Concurrent Program",
+		"One canonical responsibility",
+		policy_revision_id.clone(),
+		ReviewCadence::new(30, ProgramTimestamp::from_unix_microseconds(2_000_000_000_000_000)?)?,
+	)?;
+	let provenance = ProgramProvenance::new(
+		lead_id.clone(),
+		ProgramCorrelationId::new("51000000-0000-4000-8000-000000000080")?,
+		"Concurrent Program creation",
+	)?;
+	let commands = [
+		CommandIdentity::new("program-create-race-a-80", b"program-create-race-a-80")?,
+		CommandIdentity::new("program-create-race-b-80", b"program-create-race-b-80")?,
+	];
+	let mut tasks = JoinSet::new();
+
+	for command in commands.clone() {
+		let store = store.clone();
+		let program = program.clone();
+		let provenance = provenance.clone();
+
+		tasks.spawn(async move {
+			let result = store.create_program(&command, &program, &provenance).await;
+
+			(command, result)
+		});
+	}
+
+	while let Some(result) = tasks.join_next().await {
+		let (command, result) = result?;
+
+		assert_eq!(result?, store.create_program(&command, &program, &provenance).await?);
+	}
+
+	assert_single_domain_activity(client, "program", program_id.as_str(), "program_created")
+		.await?;
+	assert_program_missing_replay(
+		store,
+		client,
+		project_id,
+		lead_id,
+		policy_revision_id,
+		&provenance,
+	)
+	.await?;
+
+	Ok(())
+}
+
+async fn assert_program_missing_replay(
+	store: &PostgresStore,
+	client: &Client,
+	project_id: &ProjectId,
+	lead_id: &AgentId,
+	policy_revision_id: &PolicyRevisionId,
+	provenance: &ProgramProvenance,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let race_id = ProgramId::new("41000000-0000-4000-8000-000000000081")?;
+	let race_program = Program::new(
+		race_id.clone(),
+		project_id.clone(),
+		lead_id.clone(),
+		"Mutation race Program",
+		"Request-scoped mutation authority",
+		policy_revision_id.clone(),
+		ReviewCadence::new(30, ProgramTimestamp::from_unix_microseconds(2_000_000_000_000_000)?)?,
+	)?;
+	let transition =
+		CommandIdentity::new("program-absent-transition-81", b"program-absent-transition-81")?;
+
+	assert!(store.program(&race_id).await?.is_none());
+
+	let first = store
+		.transition_program(
+			&transition,
+			project_id,
+			&race_id,
+			1,
+			ProgramState::NeedsAttention,
+			provenance,
+		)
+		.await;
+
+	assert!(matches!(first, Err(StoreError::RevisionConflict { actual: None, .. })));
+
+	store
+		.create_program(
+			&CommandIdentity::new("program-create-after-miss-81", b"program-create-after-miss-81")?,
+			&race_program,
+			provenance,
+		)
+		.await?;
+
+	assert!(matches!(
+		store
+			.transition_program(
+				&transition,
+				project_id,
+				&race_id,
+				1,
+				ProgramState::NeedsAttention,
+				provenance,
+			)
+			.await,
+		Err(StoreError::RevisionConflict { actual: None, .. })
+	));
+
+	let receipt_scope: String = client
+		.query_one(
+			"SELECT scope_id FROM decodex.command_receipts WHERE idempotency_key=$1",
+			&[&"program-absent-transition-81"],
+		)
+		.await?
+		.get(0);
+
+	assert_eq!(receipt_scope, project_id.as_str());
+
+	let fresh_transition = CommandIdentity::new(
+		"program-create-between-read-transition-81",
+		b"program-create-between-read-transition-81",
+	)?;
+	let transitioned = store
+		.transition_program(
+			&fresh_transition,
+			project_id,
+			&race_id,
+			1,
+			ProgramState::NeedsAttention,
+			provenance,
+		)
+		.await?;
+
+	assert_eq!(transitioned.program.state(), ProgramState::NeedsAttention);
+	assert_eq!(
+		transitioned,
+		store
+			.transition_program(
+				&fresh_transition,
+				project_id,
+				&race_id,
+				1,
+				ProgramState::NeedsAttention,
+				provenance,
+			)
+			.await?
+	);
+
+	Ok(())
+}
+
+async fn assert_objective_create_race(
+	store: &PostgresStore,
+	client: &Client,
+	project_id: &ProjectId,
+	lead_id: &AgentId,
+	program_id: &ProgramId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let objective_id = ObjectiveId::new("71000000-0000-4000-8000-000000000080")?;
+	let objective = Objective::new(
+		objective_id.clone(),
+		project_id.clone(),
+		Some(program_id.clone()),
+		"Resolve one concurrent creation",
+		vec!["Accepted once".into()],
+		vec!["Validated once".into()],
+		ProgramTimestamp::from_unix_microseconds(2_000_000_000_000_000)?,
+	)?;
+	let provenance = ProgramProvenance::new(
+		lead_id.clone(),
+		ProgramCorrelationId::new("51000000-0000-4000-8000-000000000082")?,
+		"Concurrent Objective creation",
+	)?;
+	let commands = [
+		CommandIdentity::new("objective-create-race-a-80", b"objective-create-race-a-80")?,
+		CommandIdentity::new("objective-create-race-b-80", b"objective-create-race-b-80")?,
+	];
+	let mut tasks = JoinSet::new();
+
+	for command in commands.clone() {
+		let store = store.clone();
+		let objective = objective.clone();
+		let provenance = provenance.clone();
+
+		tasks.spawn(async move {
+			let result = store.create_objective(&command, &objective, &provenance).await;
+
+			(command, result)
+		});
+	}
+
+	while let Some(result) = tasks.join_next().await {
+		let (command, result) = result?;
+
+		assert_eq!(result?, store.create_objective(&command, &objective, &provenance).await?);
+	}
+
+	assert_single_domain_activity(client, "objective", objective_id.as_str(), "objective_created")
+		.await?;
+	assert_objective_missing_replay(store, client, project_id, program_id, &provenance).await?;
+
+	Ok(())
+}
+
+async fn assert_objective_missing_replay(
+	store: &PostgresStore,
+	client: &Client,
+	project_id: &ProjectId,
+	program_id: &ProgramId,
+	provenance: &ProgramProvenance,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let race_id = ObjectiveId::new("71000000-0000-4000-8000-000000000081")?;
+	let race_objective = Objective::new(
+		race_id.clone(),
+		project_id.clone(),
+		Some(program_id.clone()),
+		"Create after a deterministic miss",
+		vec!["Accepted".into()],
+		vec!["Validated".into()],
+		ProgramTimestamp::from_unix_microseconds(2_000_000_000_000_000)?,
+	)?;
+	let transition =
+		CommandIdentity::new("objective-absent-transition-81", b"objective-absent-transition-81")?;
+
+	assert!(store.objective(&race_id).await?.is_none());
+	assert!(matches!(
+		store
+			.transition_objective(
+				&transition,
+				project_id,
+				&race_id,
+				1,
+				ObjectiveState::Active,
+				provenance,
+			)
+			.await,
+		Err(StoreError::RevisionConflict { actual: None, .. })
+	));
+
+	store
+		.create_objective(
+			&CommandIdentity::new(
+				"objective-create-after-miss-81",
+				b"objective-create-after-miss-81",
+			)?,
+			&race_objective,
+			provenance,
+		)
+		.await?;
+
+	assert!(matches!(
+		store
+			.transition_objective(
+				&transition,
+				project_id,
+				&race_id,
+				1,
+				ObjectiveState::Active,
+				provenance,
+			)
+			.await,
+		Err(StoreError::RevisionConflict { actual: None, .. })
+	));
+
+	let receipt_scope: String = client
+		.query_one(
+			"SELECT scope_id FROM decodex.command_receipts WHERE idempotency_key=$1",
+			&[&"objective-absent-transition-81"],
+		)
+		.await?
+		.get(0);
+
+	assert_eq!(receipt_scope, project_id.as_str());
+
+	let fresh_transition = CommandIdentity::new(
+		"objective-create-between-read-transition-81",
+		b"objective-create-between-read-transition-81",
+	)?;
+	let transitioned = store
+		.transition_objective(
+			&fresh_transition,
+			project_id,
+			&race_id,
+			1,
+			ObjectiveState::Active,
+			provenance,
+		)
+		.await?;
+
+	assert_eq!(transitioned.objective.state(), ObjectiveState::Active);
+	assert_eq!(
+		transitioned,
+		store
+			.transition_objective(
+				&fresh_transition,
+				project_id,
+				&race_id,
+				1,
+				ObjectiveState::Active,
+				provenance,
+			)
+			.await?
+	);
+
+	Ok(())
+}
+
+async fn assert_objective_evidence_race(
+	store: &PostgresStore,
+	client: &Client,
+	project_id: &ProjectId,
+	lead_id: &AgentId,
+	program_id: &ProgramId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let objective_id = ObjectiveId::new("71000000-0000-4000-8000-000000000082")?;
+	let provenance = ProgramProvenance::new(
+		lead_id.clone(),
+		ProgramCorrelationId::new("51000000-0000-4000-8000-000000000084")?,
+		"Concurrent evidence fixture",
+	)?;
+	let objective = Objective::new(
+		objective_id.clone(),
+		project_id.clone(),
+		Some(program_id.clone()),
+		"Accept one finite concurrent result",
+		vec!["Accepted".into()],
+		vec!["Validated".into()],
+		ProgramTimestamp::from_unix_microseconds(2_000_000_000_000_000)?,
+	)?;
+
+	store
+		.create_objective(
+			&CommandIdentity::new("objective-create-evidence-82", b"objective-create-evidence-82")?,
+			&objective,
+			&provenance,
+		)
+		.await?;
+	store
+		.transition_objective(
+			&CommandIdentity::new(
+				"objective-activate-evidence-82",
+				b"objective-activate-evidence-82",
+			)?,
+			project_id,
+			&objective_id,
+			1,
+			ObjectiveState::Active,
+			&provenance,
+		)
+		.await?;
+
+	let prior_updated_at: i64 = client
+		.query_one(
+			"SELECT (EXTRACT(epoch FROM updated_at)*1000000)::bigint \
+			 FROM decodex.objectives WHERE objective_id=$1::text::uuid",
+			&[&objective_id.as_str()],
+		)
+		.await?
+		.get(0);
+	let timestamp = ProgramTimestamp::from_unix_microseconds(prior_updated_at)?;
+	let evidence = ObjectiveCompletionEvidence::proposed(
+		ObjectiveEvidenceId::new("81000000-0000-4000-8000-000000000082")?,
+		objective_id.clone(),
+		project_id.clone(),
+		2,
+		"Accepted concurrent result",
+		lead_id.clone(),
+		timestamp,
+		"Acceptance retained",
+		"Validated concurrent result",
+		lead_id.clone(),
+		timestamp,
+		"Validation retained",
+		ProgramCorrelationId::new("51000000-0000-4000-8000-000000000085")?,
+	)?;
+	let commands = [
+		CommandIdentity::new("objective-evidence-race-a-82", b"objective-evidence-race-a-82")?,
+		CommandIdentity::new("objective-evidence-race-b-82", b"objective-evidence-race-b-82")?,
+	];
+	let mut tasks = JoinSet::new();
+
+	for command in commands.clone() {
+		let store = store.clone();
+		let evidence = evidence.clone();
+
+		tasks.spawn(async move {
+			let result = store.achieve_objective(&command, &evidence).await;
+
+			(command, result)
+		});
+	}
+
+	while let Some(result) = tasks.join_next().await {
+		let (command, result) = result?;
+
+		assert_eq!(result?, store.achieve_objective(&command, &evidence).await?);
+	}
+
+	assert_single_domain_activity(client, "objective", objective_id.as_str(), "objective_achieved")
+		.await?;
+
+	Ok(())
+}
+
+async fn assert_cross_objective_evidence_identity_race(
+	store: &PostgresStore,
+	client: &Client,
+	migration: &Config,
+	project_id: &ProjectId,
+	lead_id: &AgentId,
+	program_id: &ProgramId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let (objective_a, timestamp_a) = create_active_evidence_objective(
+		store,
+		client,
+		project_id,
+		lead_id,
+		program_id,
+		ActiveEvidenceObjectiveFixture {
+			objective_id: "71000000-0000-4000-8000-000000000083",
+			correlation_id: "51000000-0000-4000-8000-000000000086",
+			create_key: "objective-create-evidence-83",
+			activate_key: "objective-activate-evidence-83",
+		},
+	)
+	.await?;
+	let (objective_b, timestamp_b) = create_active_evidence_objective(
+		store,
+		client,
+		project_id,
+		lead_id,
+		program_id,
+		ActiveEvidenceObjectiveFixture {
+			objective_id: "71000000-0000-4000-8000-000000000084",
+			correlation_id: "51000000-0000-4000-8000-000000000087",
+			create_key: "objective-create-evidence-84",
+			activate_key: "objective-activate-evidence-84",
+		},
+	)
+	.await?;
+	let accepted_at = if timestamp_a >= timestamp_b { timestamp_a } else { timestamp_b };
+	let evidence_id = ObjectiveEvidenceId::new("81000000-0000-4000-8000-000000000083")?;
+	let cases = [
+		(
+			CommandIdentity::new("objective-evidence-cross-race-a-83", b"cross-race-a-83")?,
+			cross_objective_evidence(
+				evidence_id.clone(),
+				objective_a,
+				project_id,
+				lead_id,
+				accepted_at,
+				"51000000-0000-4000-8000-000000000088",
+			)?,
+		),
+		(
+			CommandIdentity::new("objective-evidence-cross-race-b-83", b"cross-race-b-83")?,
+			cross_objective_evidence(
+				evidence_id,
+				objective_b,
+				project_id,
+				lead_id,
+				accepted_at,
+				"51000000-0000-4000-8000-000000000089",
+			)?,
+		),
+	];
+
+	let (mut blocker, blocker_connection) = migration.clone().connect(NoTls).await?;
+	let blocker_task = task::spawn(blocker_connection);
+	let blocker_transaction = blocker.transaction().await?;
+
+	blocker_transaction
+		.batch_execute("LOCK TABLE decodex.activity IN ACCESS EXCLUSIVE MODE")
+		.await?;
+
+	let mut tasks = JoinSet::new();
+
+	for (command, evidence) in cases {
+		let store = store.clone();
+
+		tasks.spawn(async move {
+			let result = store.achieve_objective(&command, &evidence).await;
+
+			(command, evidence, result)
+		});
+	}
+
+	let contention = wait_for_cross_objective_evidence_contention(client).await;
+
+	blocker_transaction.rollback().await?;
+	drop(blocker);
+	blocker_task.await??;
+
+	if let Err(error) = contention {
+		tasks.abort_all();
+
+		while tasks.join_next().await.is_some() {}
+
+		return Err(error);
+	}
+
+	let mut results = Vec::new();
+
+	while let Some(joined) = tasks.join_next().await {
+		results.push(joined?);
+	}
+
+	assert_cross_objective_evidence_results(store, client, results).await
+}
+
+struct ActiveEvidenceObjectiveFixture<'a> {
+	objective_id: &'a str,
+	correlation_id: &'a str,
+	create_key: &'a str,
+	activate_key: &'a str,
+}
+
+async fn create_active_evidence_objective(
+	store: &PostgresStore,
+	client: &Client,
+	project_id: &ProjectId,
+	lead_id: &AgentId,
+	program_id: &ProgramId,
+	fixture: ActiveEvidenceObjectiveFixture<'_>,
+) -> Result<(ObjectiveId, ProgramTimestamp), Box<dyn std::error::Error>> {
+	let objective_id = ObjectiveId::new(fixture.objective_id)?;
+	let provenance = ProgramProvenance::new(
+		lead_id.clone(),
+		ProgramCorrelationId::new(fixture.correlation_id)?,
+		"Cross-Objective evidence identity race fixture",
+	)?;
+	let objective = Objective::new(
+		objective_id.clone(),
+		project_id.clone(),
+		Some(program_id.clone()),
+		"Accept one identity-race outcome",
+		vec!["Accepted".into()],
+		vec!["Validated".into()],
+		ProgramTimestamp::from_unix_microseconds(2_000_000_000_000_000)?,
+	)?;
+
+	store
+		.create_objective(
+			&CommandIdentity::new(fixture.create_key, fixture.create_key.as_bytes())?,
+			&objective,
+			&provenance,
+		)
+		.await?;
+	store
+		.transition_objective(
+			&CommandIdentity::new(fixture.activate_key, fixture.activate_key.as_bytes())?,
+			project_id,
+			&objective_id,
+			1,
+			ObjectiveState::Active,
+			&provenance,
+		)
+		.await?;
+
+	let updated_at: i64 = client
+		.query_one(
+			"SELECT (EXTRACT(epoch FROM updated_at)*1000000)::bigint \
+			 FROM decodex.objectives WHERE objective_id=$1::text::uuid",
+			&[&objective_id.as_str()],
+		)
+		.await?
+		.get(0);
+
+	Ok((objective_id, ProgramTimestamp::from_unix_microseconds(updated_at)?))
+}
+
+fn cross_objective_evidence(
+	evidence_id: ObjectiveEvidenceId,
+	objective_id: ObjectiveId,
+	project_id: &ProjectId,
+	lead_id: &AgentId,
+	timestamp: ProgramTimestamp,
+	correlation_id: &str,
+) -> Result<ObjectiveCompletionEvidence, Box<dyn std::error::Error>> {
+	Ok(ObjectiveCompletionEvidence::proposed(
+		evidence_id,
+		objective_id,
+		project_id.clone(),
+		2,
+		"Accepted identity-race result",
+		lead_id.clone(),
+		timestamp,
+		"Acceptance identity retained",
+		"Validated identity-race result",
+		lead_id.clone(),
+		timestamp,
+		"Validation identity retained",
+		ProgramCorrelationId::new(correlation_id)?,
+	)?)
+}
+
+async fn wait_for_cross_objective_evidence_contention(
+	client: &Client,
+) -> Result<(), Box<dyn std::error::Error>> {
+	for _ in 0..500 {
+		let row = client
+			.query_one(
+				r#"SELECT
+				 count(*) FILTER (WHERE locks.locktype = 'relation'
+				 AND locks.relation = 'decodex.activity'::pg_catalog.regclass
+				 AND locks.mode = 'RowExclusiveLock' AND locks.granted IS FALSE),
+				 count(*) FILTER (WHERE locks.locktype = 'transactionid'
+				 AND locks.mode = 'ShareLock' AND locks.granted IS FALSE)
+				 FROM pg_catalog.pg_locks AS locks"#,
+				&[],
+			)
+			.await?;
+		let waiting_activity: i64 = row.get(0);
+		let waiting_evidence: i64 = row.get(1);
+
+		if waiting_activity >= 1 && waiting_evidence >= 1 {
+			return Ok(());
+		}
+
+		time::sleep(Duration::from_millis(10)).await;
+	}
+
+	Err(std::io::Error::other("cross-Objective evidence commands did not reach both lock waits")
+		.into())
+}
+
+async fn assert_cross_objective_evidence_results(
+	store: &PostgresStore,
+	client: &Client,
+	results: Vec<(
+		CommandIdentity,
+		ObjectiveCompletionEvidence,
+		Result<decodex_postgres::ObjectiveRecord, StoreError>,
+	)>,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let mut winners = 0;
+	let mut losers = 0;
+
+	for (command, evidence, result) in results {
+		match result {
+			Ok(record) => {
+				winners += 1;
+
+				assert_eq!(record, store.achieve_objective(&command, &evidence).await?);
+			},
+			Err(StoreError::IdempotencyConflict) => {
+				losers += 1;
+
+				assert!(matches!(
+					store.achieve_objective(&command, &evidence).await,
+					Err(StoreError::IdempotencyConflict)
+				));
+			},
+			Err(error) => return Err(error.into()),
+		}
+	}
+
+	assert_eq!((winners, losers), (1, 1));
+
+	let authority = client
+		.query_one(
+			r#"SELECT
+			 (SELECT count(*) FROM decodex.objectives WHERE objective_id IN
+			 ('71000000-0000-4000-8000-000000000083','71000000-0000-4000-8000-000000000084')
+			 AND state='achieved'),
+			 (SELECT count(*) FROM decodex.objective_completion_evidence
+			 WHERE evidence_id='81000000-0000-4000-8000-000000000083'),
+			 (SELECT count(*) FROM decodex.activity WHERE aggregate_kind='objective'
+			 AND aggregate_id IN ('71000000-0000-4000-8000-000000000083',
+			 '71000000-0000-4000-8000-000000000084') AND event_kind='objective_achieved'),
+			 (SELECT count(*) FROM decodex.command_receipts WHERE idempotency_key IN
+			 ('objective-evidence-cross-race-a-83','objective-evidence-cross-race-b-83')
+			 AND receipt_state='completed'),
+			 (SELECT count(*) FROM decodex.command_receipts WHERE idempotency_key IN
+			 ('objective-evidence-cross-race-a-83','objective-evidence-cross-race-b-83')
+			 AND receipt_state='pending')"#,
+			&[],
+		)
+		.await?;
+
+	assert_eq!(authority.get::<_, i64>(0), 1);
+	assert_eq!(authority.get::<_, i64>(1), 1);
+	assert_eq!(authority.get::<_, i64>(2), 1);
+	assert_eq!(authority.get::<_, i64>(3), 2);
+	assert_eq!(authority.get::<_, i64>(4), 0);
+
+	Ok(())
+}
+
+async fn assert_single_domain_activity(
+	client: &Client,
+	aggregate_kind: &str,
+	aggregate_id: &str,
+	event_kind: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let count: i64 = client
+		.query_one(
+			"SELECT count(*) FROM decodex.activity WHERE aggregate_kind=$1 \
+			 AND aggregate_id=$2 AND event_kind=$3",
+			&[&aggregate_kind, &aggregate_id, &event_kind],
+		)
+		.await?
+		.get(0);
+
+	assert_eq!(count, 1);
+
+	Ok(())
+}
+
+async fn assert_program_context_compilation_is_pure(
+	client: &Client,
+	program: &Program,
+	program_id: &ProgramId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let counts = |row: Row| {
+		(row.get::<_, i64>(0), row.get::<_, i64>(1), row.get::<_, i64>(2), row.get::<_, i64>(3))
+	};
+	let query = "SELECT (SELECT count(*) FROM decodex.agents),\
+		 (SELECT count(*) FROM decodex.conversations),\
+		 (SELECT count(*) FROM decodex.runtime_sessions),\
+		 (SELECT count(*) FROM decodex.programs)";
+	let before = counts(client.query_one(query, &[]).await?);
+	let context = decodex_core::compile_program_context(ProgramContextInput {
+		program,
+		recent_decisions: Vec::new(),
+		quiet_period: None,
+	})?;
+	let after = counts(client.query_one(query, &[]).await?);
+
+	assert_eq!(before, after);
+	assert_eq!(context.program_id(), program_id);
+	assert!(!context.bytes().is_empty());
+
+	Ok(())
+}
+
+async fn assert_program_transition_replay(
+	store: &PostgresStore,
+	client: &Client,
+	migration: &Config,
+	runtime: &Config,
+	project_id: &ProjectId,
+	program_id: &ProgramId,
+	lead_id: &AgentId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let provenance = ProgramProvenance::new(
+		lead_id.clone(),
+		ProgramCorrelationId::new("51000000-0000-4000-8000-000000000062")?,
+		"Lead classified current attention",
+	)?;
+	let candidates = [
+		(CommandIdentity::new("program-race-blocked-60", b"blocked")?, ProgramState::Blocked),
+		(CommandIdentity::new("program-race-paused-60", b"paused")?, ProgramState::Paused),
+	];
+	let mut tasks = JoinSet::new();
+
+	for (command, state) in candidates {
+		let store = store.clone();
+		let project_id = project_id.clone();
+		let program_id = program_id.clone();
+		let provenance = provenance.clone();
+
+		tasks.spawn(async move {
+			let result = store
+				.transition_program(&command, &project_id, &program_id, 2, state, &provenance)
+				.await;
+
+			(command, state, result)
+		});
+	}
+
+	let mut loser = None;
+	let mut winner_count = 0;
+
+	while let Some(result) = tasks.join_next().await {
+		let (command, state, result) = result?;
+
+		match result {
+			Ok(_) => winner_count += 1,
+			Err(StoreError::RevisionConflict { actual: Some(3), .. }) =>
+				loser = Some((command, state)),
+			Err(error) => return Err(error.into()),
+		}
+	}
+
+	assert_eq!(winner_count, 1);
+
+	let (loser, loser_state) = loser.expect("one optimistic Program transition loses");
+
+	assert!(matches!(
+		store.transition_program(&loser, project_id, program_id, 2, loser_state, &provenance).await,
+		Err(StoreError::RevisionConflict { actual: Some(3), .. })
+	));
+
+	let pending: i64 = client
+		.query_one(
+			"SELECT count(*) FROM decodex.command_receipts WHERE receipt_state='pending'\
+			 AND operation IN ('create_program','update_program_context','transition_program',\
+			 'create_objective','transition_objective','achieve_objective')",
+			&[],
+		)
+		.await?
+		.get(0);
+
+	assert_eq!(pending, 0);
+
+	let reopened =
+		PostgresStore::connect(migration.clone(), runtime.clone(), expected_peer_uid()).await?;
+
+	assert_eq!(reopened.program(program_id).await?, store.program(program_id).await?);
+	assert!(matches!(
+		reopened
+			.transition_program(&loser, project_id, program_id, 2, loser_state, &provenance)
+			.await,
+		Err(StoreError::RevisionConflict { actual: Some(3), .. })
+	));
+
+	reopened.close();
+
+	Ok(())
+}
+
+async fn assert_hostile_program_objective_sql(
+	client: &Client,
+	project_id: &ProjectId,
+	lead_id: &AgentId,
+	policy_id: &PolicyId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let boundary_metrics = serde_json::json!([{
+		"key":"metric_1","value":"x".repeat(256),"unit":"u".repeat(64),
+		"provenance":{"source":"s".repeat(256),"observed_at_microseconds":253_402_300_799_999_999_i64}
+	}]);
+	let boundary_signals = serde_json::json!([{
+		"id":"61000000-0000-4000-8000-000000000098","kind":"k".repeat(64),
+		"summary":"x".repeat(4_096),
+		"provenance":{"source":"s".repeat(256),"observed_at_microseconds":253_402_300_799_999_999_i64}
+	}]);
+	let boundary_criteria =
+		(0..32).map(|index| format!("{index:02}{}", "x".repeat(4_094))).collect::<Vec<_>>();
+	let boundary = client
+		.query_one(
+			"SELECT decodex.is_program_metrics($1),decodex.is_program_signals($2),\
+			 decodex.is_objective_criteria($3)",
+			&[&boundary_metrics, &boundary_signals, &boundary_criteria],
+		)
+		.await?;
+
+	assert!(boundary.get::<_, bool>(0));
+	assert!(boundary.get::<_, bool>(1));
+	assert!(boundary.get::<_, bool>(2));
+
+	client
+		.execute(
+			"WITH written AS (SELECT clock_timestamp() AS at)\
+			 INSERT INTO decodex.objectives (objective_id,project_id,outcome,\
+			 acceptance_criteria,validation_criteria,target_at,last_changed_by,\
+			 last_correlation_id,last_provenance,created_at,updated_at)\
+			 SELECT '71000000-0000-4000-8000-000000000097',$1::text::uuid,\
+			 'valid maximum criteria',$3,$3,to_timestamp(2000000000),$2::text::uuid,\
+			 gen_random_uuid(),'direct valid boundary fixture',written.at,written.at FROM written",
+			&[&project_id.as_str(), &lead_id.as_str(), &boundary_criteria],
+		)
+		.await?;
+
+	for document in [
+		serde_json::json!([null]),
+		serde_json::json!([{}]),
+		serde_json::json!([{"key":"metric","value":"","unit":"count","provenance":{"source":"fixture","observed_at_microseconds":1}}]),
+		serde_json::json!([{"key":"metric","value":"1","unit":"count","provenance":{"source":"fixture"}}]),
+		serde_json::json!([{"key":"metric","value":"1","unit":"count","provenance":{"source":"fixture","observed_at_microseconds":1}}, {"key":"metric","value":"2","unit":"count","provenance":{"source":"fixture","observed_at_microseconds":2}}]),
+	] {
+		client
+			.execute(
+				"UPDATE decodex.programs SET metrics=$1,revision=revision+1,\
+				 last_correlation_id=gen_random_uuid(),last_provenance='hostile SQL fixture',\
+				 updated_at=clock_timestamp()\
+				 WHERE program_id='41000000-0000-4000-8000-000000000060'",
+				&[&document],
+			)
+			.await
+			.expect_err("PostgreSQL rejects Rust-invalid Program metric JSON");
+	}
+	for document in [
+		serde_json::json!([null]),
+		serde_json::json!([{"id":"61000000-0000-4000-8000-000000000099","kind":"bad-kind","summary":"x","provenance":{"source":"fixture","observed_at_microseconds":1}}]),
+		serde_json::json!([{"id":"61000000-0000-4000-8000-000000000099","kind":"signal","summary":"","provenance":{"source":"fixture","observed_at_microseconds":1}}]),
+	] {
+		client
+			.execute(
+				"UPDATE decodex.programs SET signals=$1,revision=revision+1,\
+				 last_correlation_id=gen_random_uuid(),last_provenance='hostile SQL fixture',\
+				 updated_at=clock_timestamp()\
+				 WHERE program_id='41000000-0000-4000-8000-000000000060'",
+				&[&document],
+			)
+			.await
+			.expect_err("PostgreSQL rejects Rust-invalid Program signal JSON");
+	}
+
+	let program_timestamp_error = client
+		.execute(
+			"UPDATE decodex.programs SET next_review_at=TIMESTAMPTZ '10000-01-01 00:00:00+00',\
+			 revision=revision+1,last_correlation_id=gen_random_uuid(),\
+			 last_provenance='hostile timestamp fixture',updated_at=clock_timestamp()\
+			 WHERE program_id='41000000-0000-4000-8000-000000000060'",
+			&[],
+		)
+		.await
+		.expect_err("PostgreSQL rejects timestamps outside ProgramTimestamp");
+
+	assert_eq!(
+		program_timestamp_error.as_db_error().and_then(|error| error.constraint()),
+		Some("programs_finite_timestamps")
+	);
+
+	let timestamp_boundaries = client
+		.query_one(
+			"SELECT decodex.program_timestamp(0) IS NOT NULL,\
+			 decodex.program_timestamp(253402300799999999) IS NOT NULL,\
+			 decodex.program_timestamp(-1) IS NULL,\
+			 decodex.program_timestamp(253402300800000000) IS NULL",
+			&[],
+		)
+		.await?;
+
+	assert!(timestamp_boundaries.get::<_, bool>(0));
+	assert!(timestamp_boundaries.get::<_, bool>(1));
+	assert!(timestamp_boundaries.get::<_, bool>(2));
+	assert!(timestamp_boundaries.get::<_, bool>(3));
+
+	assert_hostile_objective_sql(client, project_id, lead_id).await?;
+
+	let exact_policy_reference: bool = client
+		.query_one(
+			"SELECT EXISTS (SELECT 1 FROM decodex.programs WHERE project_id=$1::text::uuid \
+			 AND policy_id=$2::text::uuid AND policy_revision=1)",
+			&[&project_id.as_str(), &policy_id.as_str()],
+		)
+		.await?
+		.get(0);
+
+	assert!(exact_policy_reference);
+
+	Ok(())
+}
+
+async fn assert_hostile_objective_sql(
+	client: &Client,
+	project_id: &ProjectId,
+	lead_id: &AgentId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	for criteria in [
+		Vec::<String>::new(),
+		vec![String::new()],
+		vec!["duplicate".into(), "duplicate".into()],
+		vec!["x".repeat(4_097)],
+	] {
+		client
+			.execute(
+				"WITH written AS (SELECT clock_timestamp() AS at)\
+				 INSERT INTO decodex.objectives (objective_id,project_id,outcome,\
+				 acceptance_criteria,validation_criteria,target_at,last_changed_by,\
+				 last_correlation_id,last_provenance,created_at,updated_at)\
+				 SELECT gen_random_uuid(),$1::text::uuid,'hostile criteria',$3,$3,\
+				 to_timestamp(2000000000),$2::text::uuid,gen_random_uuid(),\
+				 'hostile SQL fixture',written.at,written.at FROM written",
+				&[&project_id.as_str(), &lead_id.as_str(), &criteria],
+			)
+			.await
+			.expect_err("PostgreSQL rejects Rust-invalid Objective criteria");
+	}
+
+	let objective_timestamp_error = client
+		.execute(
+			"WITH written AS (SELECT clock_timestamp() AS at)\
+			 INSERT INTO decodex.objectives (objective_id,project_id,outcome,\
+			 acceptance_criteria,validation_criteria,target_at,last_changed_by,\
+			 last_correlation_id,last_provenance,created_at,updated_at)\
+			 SELECT '71000000-0000-4000-8000-000000000096',$1::text::uuid,\
+			 'hostile timestamp',ARRAY['accepted'],ARRAY['validated'],\
+			 TIMESTAMPTZ '10000-01-01 00:00:00+00',$2::text::uuid,gen_random_uuid(),\
+			 'hostile timestamp fixture',written.at,written.at FROM written",
+			&[&project_id.as_str(), &lead_id.as_str()],
+		)
+		.await
+		.expect_err("PostgreSQL rejects Objective timestamps outside ProgramTimestamp");
+
+	assert_eq!(
+		objective_timestamp_error.as_db_error().and_then(|error| error.constraint()),
+		Some("objectives_finite_timestamps")
+	);
+
+	let direct_objective = "71000000-0000-4000-8000-000000000099";
+	let row = client
+		.query_one(
+			"SELECT result_code FROM decodex.create_objective(\
+			 $1::text::decodex.canonical_uuid_v4_text,\
+			 $2::text::decodex.canonical_uuid_v4_text,NULL,'direct SQL objective',\
+			 ARRAY['accepted'],ARRAY['validated'],2000000000000000,\
+			 $3::text::decodex.canonical_uuid_v4_text,\
+			 '51000000-0000-4000-8000-000000000099'::decodex.canonical_uuid_v4_text,\
+			 'direct SQL fixture')",
+			&[&direct_objective, &project_id.as_str(), &lead_id.as_str()],
+		)
+		.await?;
+
+	assert_eq!(row.get::<_, &str>(0), "ok");
+
+	client
+		.query_one(
+			"SELECT result_code FROM decodex.transition_objective(\
+			 $1::text::decodex.canonical_uuid_v4_text,\
+			 $2::text::decodex.canonical_uuid_v4_text,1,'active',\
+			 $3::text::decodex.canonical_uuid_v4_text,\
+			 '51000000-0000-4000-8000-000000000098'::decodex.canonical_uuid_v4_text,\
+			 'activate direct SQL fixture')",
+			&[&direct_objective, &project_id.as_str(), &lead_id.as_str()],
+		)
+		.await?;
+
+	assert_hostile_objective_evidence(client).await?;
+
+	let prior_revision_error = client
+		.execute(
+			"WITH evidence AS (INSERT INTO decodex.objective_completion_evidence\
+			 (evidence_id,objective_id,project_id,objective_revision,objective_updated_at,\
+			 acceptance_result,accepted_by,accepted_at,acceptance_provenance,validation_result,\
+			 validated_by,validated_at,validation_provenance,correlation_id) VALUES\
+			 ('81000000-0000-4000-8000-000000000099','71000000-0000-4000-8000-000000000099',\
+			 '11000000-0000-4000-8000-000000000060',2,to_timestamp(1700000000),\
+			 'accepted','22000000-0000-4000-8000-000000000060',to_timestamp(1700000000),\
+			 'accepted','validated','22000000-0000-4000-8000-000000000060',\
+			 to_timestamp(1700000001),'validated','51000000-0000-4000-8000-000000000097')\
+			 RETURNING evidence_id)\
+			 UPDATE decodex.objectives SET state='achieved',revision=revision+1,\
+			 completion_evidence_id='81000000-0000-4000-8000-000000000099',\
+			 last_changed_by='22000000-0000-4000-8000-000000000060',\
+			 last_correlation_id='51000000-0000-4000-8000-000000000097',\
+			 last_provenance='hostile stale achievement',updated_at=clock_timestamp()\
+			 FROM evidence WHERE objective_id='71000000-0000-4000-8000-000000000099'",
+			&[],
+		)
+		.await
+		.expect_err("achievement evidence cannot predate the exact prior Objective revision");
+
+	assert_eq!(
+		prior_revision_error.as_db_error().and_then(|error| error.constraint()),
+		Some("objective_evidence_prior_revision_time")
+	);
+
+	client
+		.execute(
+			"UPDATE decodex.objectives SET state='achieved',revision=revision+1,\
+			 completion_evidence_id=gen_random_uuid(),last_changed_by=$2::text::uuid,\
+			 last_correlation_id=gen_random_uuid(),last_provenance='bare achievement',\
+			 updated_at=clock_timestamp() WHERE objective_id=$1::text::uuid",
+			&[&direct_objective, &lead_id.as_str()],
+		)
+		.await
+		.expect_err("bare Objective achievement without exact evidence is impossible");
+
+	Ok(())
+}
+
+async fn assert_hostile_objective_evidence(
+	client: &Client,
+) -> Result<(), Box<dyn std::error::Error>> {
+	for (statement, expected_constraint) in [
+		(
+			"INSERT INTO decodex.objective_completion_evidence\
+			 (evidence_id,objective_id,project_id,objective_revision,objective_updated_at,acceptance_result,\
+			 accepted_by,accepted_at,acceptance_provenance,validation_result,validated_by,\
+			 validated_at,validation_provenance,correlation_id) VALUES\
+			 (gen_random_uuid(),'71000000-0000-4000-8000-000000000099',\
+			 '11000000-0000-4000-8000-000000000060',2,to_timestamp(1700000000),'',\
+			 '22000000-0000-4000-8000-000000000060',to_timestamp(1700000000),'accepted',\
+			 'validated','22000000-0000-4000-8000-000000000060',\
+			 to_timestamp(1700000001),'validated',gen_random_uuid())",
+			"objective_evidence_text_bounded",
+		),
+		(
+			"INSERT INTO decodex.objective_completion_evidence\
+			 (evidence_id,objective_id,project_id,objective_revision,objective_updated_at,acceptance_result,\
+			 accepted_by,accepted_at,acceptance_provenance,validation_result,validated_by,\
+			 validated_at,validation_provenance,correlation_id) VALUES\
+			 (gen_random_uuid(),'71000000-0000-4000-8000-000000000099',\
+			 '11000000-0000-4000-8000-000000000060',2,to_timestamp(1700000000),'accepted',\
+			 '22000000-0000-4000-8000-000000000099',to_timestamp(1700000000),'accepted',\
+			 'validated','22000000-0000-4000-8000-000000000060',\
+			 to_timestamp(1700000001),'validated',gen_random_uuid())",
+			"objective_evidence_accepting_agent_project_fk",
+		),
+		(
+			"INSERT INTO decodex.objective_completion_evidence\
+			 (evidence_id,objective_id,project_id,objective_revision,objective_updated_at,acceptance_result,\
+			 accepted_by,accepted_at,acceptance_provenance,validation_result,validated_by,\
+			 validated_at,validation_provenance,correlation_id) VALUES\
+			 (gen_random_uuid(),'71000000-0000-4000-8000-000000000099',\
+			 '11000000-0000-4000-8000-000000000060',2,to_timestamp(1700000000),'accepted',\
+			 '22000000-0000-4000-8000-000000000060',to_timestamp(1700000002),'accepted',\
+			 'validated','22000000-0000-4000-8000-000000000060',\
+			 to_timestamp(1700000001),'validated',gen_random_uuid())",
+			"objective_evidence_chronology",
+		),
+		(
+			"INSERT INTO decodex.objective_completion_evidence\
+			 (evidence_id,objective_id,project_id,objective_revision,objective_updated_at,acceptance_result,\
+			 accepted_by,accepted_at,acceptance_provenance,validation_result,validated_by,\
+			 validated_at,validation_provenance,correlation_id) VALUES\
+			 (gen_random_uuid(),'71000000-0000-4000-8000-000000000099',\
+			 '11000000-0000-4000-8000-000000000060',2,to_timestamp(-1),'accepted',\
+			 '22000000-0000-4000-8000-000000000060',to_timestamp(0),'accepted',\
+			 'validated','22000000-0000-4000-8000-000000000060',\
+			 to_timestamp(1),'validated',gen_random_uuid())",
+			"objective_evidence_chronology",
+		),
+	] {
+		let error = client
+			.batch_execute(statement)
+			.await
+			.expect_err("hostile direct Objective evidence is rejected");
+
+		assert_eq!(
+			error.as_db_error().and_then(|error| error.constraint()),
+			Some(expected_constraint)
+		);
+	}
+
+	Ok(())
+}
+
+async fn assert_objective_lifecycle(
+	store: &PostgresStore,
+	client: &Client,
+	project_id: &ProjectId,
+	lead_id: &AgentId,
+	program_id: &ProgramId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let achieved_id = ObjectiveId::new("71000000-0000-4000-8000-000000000060")?;
+	let achieved = Objective::new(
+		achieved_id.clone(),
+		project_id.clone(),
+		Some(program_id.clone()),
+		"Publish the finite Q3 search brief",
+		vec!["Lead accepts the brief".into()],
+		vec!["Independent checks pass".into()],
+		ProgramTimestamp::from_unix_microseconds(2_000_000_000_000_000)?,
+	)?;
+	let create_provenance = ProgramProvenance::new(
+		lead_id.clone(),
+		ProgramCorrelationId::new("51000000-0000-4000-8000-000000000070")?,
+		"Lead proposed a finite Objective",
+	)?;
+	let create_command = CommandIdentity::new("objective-create-60", b"objective-create-60")?;
+
+	assert_eq!(
+		store.create_objective(&create_command, &achieved, &create_provenance).await?,
+		store.create_objective(&create_command, &achieved, &create_provenance).await?,
+	);
+
+	let activate_command = CommandIdentity::new("objective-activate-60", b"objective-activate-60")?;
+	let active = store
+		.transition_objective(
+			&activate_command,
+			project_id,
+			&achieved_id,
+			1,
+			ObjectiveState::Active,
+			&create_provenance,
+		)
+		.await?;
+
+	assert_eq!(active.objective.revision(), 2);
+
+	let prior_updated_at: i64 = client
+		.query_one(
+			"SELECT (EXTRACT(epoch FROM updated_at)*1000000)::bigint \
+			 FROM decodex.objectives WHERE objective_id=$1::text::uuid",
+			&[&achieved_id.as_str()],
+		)
+		.await?
+		.get(0);
+	let accepted_at = ProgramTimestamp::from_unix_microseconds(prior_updated_at)?;
+
+	assert_bare_achievement_replays(store, project_id, &achieved_id, &create_provenance).await?;
+
+	let evidence = ObjectiveCompletionEvidence::proposed(
+		ObjectiveEvidenceId::new("81000000-0000-4000-8000-000000000060")?,
+		achieved_id.clone(),
+		project_id.clone(),
+		2,
+		"Lead accepted the bounded outcome",
+		lead_id.clone(),
+		accepted_at,
+		"Acceptance checklist retained",
+		"Validation criteria passed",
+		lead_id.clone(),
+		accepted_at,
+		"Validation record retained",
+		ProgramCorrelationId::new("51000000-0000-4000-8000-000000000071")?,
+	)?;
+	let achieve_command = CommandIdentity::new("objective-achieve-60", b"objective-achieve-60")?;
+	let completed = store.achieve_objective(&achieve_command, &evidence).await?;
+
+	assert_eq!(completed.objective.state(), ObjectiveState::Achieved);
+	assert_eq!(completed.objective.revision(), 3);
+
+	let completion = completed.objective.completion().expect("achievement evidence");
+
+	assert_eq!(completion.id(), evidence.id());
+	assert_eq!(completion.objective_updated_at(), Some(accepted_at));
+	assert_eq!(completed, store.achieve_objective(&achieve_command, &evidence).await?);
+
+	let abandoned_id = ObjectiveId::new("71000000-0000-4000-8000-000000000061")?;
+	let abandoned = Objective::new(
+		abandoned_id.clone(),
+		project_id.clone(),
+		Some(program_id.clone()),
+		"Evaluate one finite channel experiment",
+		vec!["Decision documented".into()],
+		vec!["Experiment data reviewed".into()],
+		ProgramTimestamp::from_unix_microseconds(2_000_000_000_000_000)?,
+	)?;
+	let abandoned_create = CommandIdentity::new("objective-create-61", b"objective-create-61")?;
+
+	store.create_objective(&abandoned_create, &abandoned, &create_provenance).await?;
+
+	let abandoned_record = store
+		.transition_objective(
+			&CommandIdentity::new("objective-abandon-61", b"objective-abandon-61")?,
+			project_id,
+			&abandoned_id,
+			1,
+			ObjectiveState::Abandoned,
+			&create_provenance,
+		)
+		.await?;
+
+	assert_eq!(abandoned_record.objective.state(), ObjectiveState::Abandoned);
+	assert_eq!(store.objective(&achieved_id).await?, Some(completed));
+
+	Ok(())
+}
+
+async fn assert_bare_achievement_replays(
+	store: &PostgresStore,
+	project_id: &ProjectId,
+	objective_id: &ObjectiveId,
+	provenance: &ProgramProvenance,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let command = CommandIdentity::new("objective-bare-achieve-60", b"bare-achieve")?;
+
+	for _ in 0..2 {
+		assert!(matches!(
+			store
+				.transition_objective(
+					&command,
+					project_id,
+					objective_id,
+					2,
+					ObjectiveState::Achieved,
+					provenance,
+				)
+				.await,
+			Err(StoreError::InvalidInput("Program/Objective lifecycle transition is invalid"))
+		));
+	}
 
 	Ok(())
 }
@@ -2411,7 +3892,6 @@ async fn assert_policy_database_guards(
 		)
 		.await
 		.expect_err("cross-Project accepting Agent foreign key rejects attachment");
-
 	store.transition_project(project_id, 1, ProjectStatus::Paused).await?;
 
 	let paused_acceptance = policy_acceptance(project_id, policy_id, lead_id, 3, "paused-project");

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -28,6 +28,25 @@ product entity in V1. Task and Reviewer agents are execution-scoped. Codex-nativ
 subagents are run-local runtime actors normalized into the same activity/message graph;
 durable cross-run and cross-project routing belongs to Decodex.
 
+Program owns an open-ended Project responsibility, its active canonical Lead owner, an
+exact accepted Project Policy revision, review cadence, and bounded provenance-bearing
+metrics/signals. Program context compilation is a pure deterministic data operation: it
+may preserve ordinary text that mentions a conversation or thread, but it has no typed
+Conversation, RuntimeSession, thread, or agent-creation field and performs no such side
+effect. Objective owns a finite Project outcome, optional same-Project Program relation,
+criteria, target horizon, lifecycle, and optimistic revision. `achieved` is available only
+through one immutable Objective-level acceptance-and-validation record bound to the exact
+Objective, Project, prior Objective revision, canonical accepting/validating Agent authority,
+provenance, and chronology. That record establishes Objective outcome acceptance only; it
+does not claim WorkItem or ManagedRun success. Objective abandonment remains independent.
+ManagedRun may reach successful terminal completion only from explicit authoritative
+WorkItem acceptance and validation. Objective achievement or evidence and any external
+Codex Goal state cannot establish WorkItem acceptance or ManagedRun success.
+The evidence persists the exact prior Objective `updated_at`; acceptance cannot predate that
+revision, including through direct SQL. Program and Objective mutation receipts are scoped
+from the caller's canonical Project authority and PostgreSQL verifies the stored Project
+match, so not-found replay remains deterministic even if the identity is created later.
+
 ## Interaction and work
 
 Advisor is the global default, owns consultation and cross-project recommendations, and

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -351,6 +351,27 @@ foreign-key backed, must resolve to the same Project, and must reject cross-Proj
 links. A `uuid[]`, JSON array, unconstrained UUID, placeholder identity, or equivalent
 denormalized shortcut is not authorized.
 
+XY-1281 owns the forward-only V7 schema after canonical V5 Project/Agent and V6 Policy.
+V7 contains no WorkItem identity or denormalized WorkItem relation. Program mutations
+verify the same active Project and canonical active Lead plus the exact accepted Policy
+revision. Objective achievement is not a bare lifecycle update: one immutable, exact
+prior-revision acceptance-and-validation record and the achieved revision are committed
+coherently. This evidence is Objective outcome authority only. Every new command reserves,
+mutates or records a typed deterministic rejection, appends activity/outbox when changed,
+and completes its exact response receipt in one transaction, so rollback cannot expose a
+pending receipt and exact retry/reopen returns the same typed result.
+ManagedRun may reach successful terminal completion only from explicit authoritative
+WorkItem acceptance and validation. Objective achievement or evidence and any external
+Codex Goal state cannot establish WorkItem acceptance or ManagedRun success; XY-1282 and
+later managed-execution owners must implement that positive authority.
+Mutation receipt scope comes only from the canonical Project ID in the request; a missing
+aggregate never substitutes an invented scope, and PostgreSQL independently compares that
+request scope with stored authority before mutation. Concurrent commands for one absent
+Program, Objective, or Objective evidence identity converge without leaking a uniqueness
+error: every command completes and replays while only the inserting command emits activity.
+Achievement chronology is anchored to the exact prior Objective revision `updated_at`, and
+all persisted Program/Objective timestamps share the closed `ProgramTimestamp` range.
+
 The executable dependency edges that mirror this order are XY-1273 -> XY-1314;
 XY-1314 -> XY-1315, XY-1317, and XY-1318; XY-1315 -> XY-1316; XY-1315 and XY-1316 ->
 XY-1281; the additional direct edge XY-1273 -> XY-1281; and XY-1315, XY-1316, and

--- a/scripts/vnext/postgres_store_test.py
+++ b/scripts/vnext/postgres_store_test.py
@@ -86,6 +86,12 @@ RUNTIME_EXECUTE_SIGNATURES = (
 	"decodex.transition_project(decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.project_status)",
 	"decodex.create_policy(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text)",
 	"decodex.accept_policy_revision(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,pg_catalog.int8)",
+	"decodex.create_program(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.int4,pg_catalog.int8,pg_catalog.jsonb,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.update_program_context(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.int4,pg_catalog.int8,pg_catalog.jsonb,pg_catalog.jsonb,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.transition_program(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.program_state,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.create_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog._text,pg_catalog._text,pg_catalog.int8,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.transition_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.objective_state,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
+	"decodex.achieve_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,decodex.canonical_uuid_v4_text)",
 )
 TRIGGER_ONLY_SIGNATURES = (
 	"decodex.enforce_lease_operation_time()",
@@ -109,6 +115,10 @@ TRIGGER_ONLY_SIGNATURES = (
 	"decodex.enforce_history_cursor_state()",
 	"decodex.enforce_policy_identity_state()",
 	"decodex.forbid_policy_revision_mutation()",
+	"decodex.enforce_program_state()",
+	"decodex.enforce_objective_state()",
+	"decodex.forbid_objective_evidence_mutation()",
+	"decodex.enforce_objective_completion_coherence()",
 )
 RUNTIME_TYPE_NAMES = (
 	"decodex.account_state",
@@ -130,6 +140,8 @@ RUNTIME_TYPE_NAMES = (
 	"decodex.project_status",
 	"decodex.agent_role",
 	"decodex.agent_status",
+	"decodex.program_state",
+	"decodex.objective_state",
 )
 
 
@@ -398,6 +410,8 @@ def provision_runtime(database: str, role: str, env: dict[str, str]) -> None:
 		f"GRANT SELECT ON TABLE decodex.history_cursors, decodex.history_item_versions TO {role}; "
 		f"GRANT SELECT ON TABLE decodex.projects, decodex.agents, "
 		f"decodex.policies, decodex.policy_revisions TO {role}; "
+		f"GRANT SELECT ON TABLE decodex.programs, decodex.objectives, "
+		f"decodex.objective_completion_evidence TO {role}; "
 		f"GRANT DELETE ON TABLE decodex.blob_objects TO {role}; "
 		f"GRANT SELECT, INSERT ON TABLE decodex.activity TO {role}; "
 		f"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE decodex.outbox TO {role}; "
@@ -965,7 +979,7 @@ def main() -> int:
 			f"AND (SELECT count(*) FROM pg_catalog.pg_proc AS inventory "
 			f"JOIN pg_catalog.pg_namespace AS inventory_namespace "
 			f"ON inventory_namespace.oid = inventory.pronamespace "
-			f"WHERE inventory_namespace.nspname = 'decodex') = 44",
+			f"WHERE inventory_namespace.nspname = 'decodex') = 58",
 			env,
 		) != "t|t|t|t|t|t|t|t":
 			raise TestFailure("additional privileged-function fixture is vacuous")
@@ -1343,7 +1357,7 @@ def main() -> int:
 			"SELECT count(*), count(*) FILTER (WHERE name LIKE '%_tampered') "
 			"FROM public.refinery_schema_history",
 			env,
-		) != "6|1":
+		) != "7|1":
 			raise TestFailure("migration-ledger tamper did not preserve the row count")
 
 		create_database(MISSING_EXTENSION_DATABASE, env)

--- a/tests/scripts/test_vnext_architecture.py
+++ b/tests/scripts/test_vnext_architecture.py
@@ -1,10 +1,59 @@
 import json
+import re
 import subprocess
 import unittest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
+
+VNEXT_CONTRACT_ROOTS = (
+    ROOT / "crates/decodex-core/src",
+    ROOT / "crates/decodex-postgres/src",
+    ROOT / "crates/decodex-postgres/migrations",
+    ROOT / "crates/decodex-protocol/src",
+    ROOT / "crates/decodex-runtime/src",
+    ROOT / "apps/decodexd/src",
+    ROOT / "apps/decodex-cli/src",
+    ROOT / "apps/decodex-gpui/src",
+)
+CONTRACT_SUFFIXES = {".rs", ".sql", ".proto", ".json"}
+GOAL_IDENTIFIER = re.compile(
+    r"\b(?:goal|goals|goal_[A-Za-z0-9_]*|[A-Za-z0-9_]*Goal[A-Za-z0-9_]*)\b",
+    re.IGNORECASE,
+)
+RUST_CONTRACT_STRING = re.compile(
+    r"(?:serde\s*\([^)]*(?:rename|alias)|route|path|operation_id|schema)"
+    r"[^\n]*[\"'][^\"']*\bgoals?\b",
+    re.IGNORECASE,
+)
+
+
+def _strip_rust_prose(source):
+    source = re.sub(r"/\*.*?\*/", " ", source, flags=re.DOTALL)
+    source = re.sub(r"//[^\n]*", " ", source)
+    return re.sub(r'r#*".*?"#*|"(?:\\.|[^"\\])*"', '""', source, flags=re.DOTALL)
+
+
+def _strip_sql_prose(source):
+    source = re.sub(r"--[^\n]*", " ", source)
+    source = re.sub(r"/\*.*?\*/", " ", source, flags=re.DOTALL)
+    return re.sub(r"'(?:''|[^'])*'", "''", source, flags=re.DOTALL)
+
+
+def forbidden_goal_contracts(source, suffix, ownership="active_vnext"):
+    """Return product Goal authority, not ordinary prose or bounded external ownership."""
+    if ownership in {"frozen_legacy", "external_codex_adapter"}:
+        return []
+    findings = []
+    if suffix == ".rs":
+        findings.extend(match.group(0) for match in GOAL_IDENTIFIER.finditer(_strip_rust_prose(source)))
+        findings.extend(match.group(0) for match in RUST_CONTRACT_STRING.finditer(source))
+    elif suffix == ".sql":
+        findings.extend(match.group(0) for match in GOAL_IDENTIFIER.finditer(_strip_sql_prose(source)))
+    elif suffix in {".proto", ".json"}:
+        findings.extend(match.group(0) for match in GOAL_IDENTIFIER.finditer(source))
+    return findings
 
 EXPECTED_OWNER_DEPENDENCIES = {
     "decodex-core": set(),
@@ -442,6 +491,117 @@ class VnextArchitectureTests(unittest.TestCase):
             "codex process",
         ):
             self.assertNotIn(live_token, migration)
+
+    def test_program_objective_identity_and_effect_boundaries_are_exact(self):
+        core = (ROOT / "crates/decodex-core/src/program.rs").read_text()
+        core_lib = (ROOT / "crates/decodex-core/src/lib.rs").read_text()
+        postgres = (ROOT / "crates/decodex-postgres/src/programs.rs").read_text()
+        migration = (
+            ROOT
+            / "crates/decodex-postgres/migrations/V7__program_objective_authority.sql"
+        ).read_text()
+
+        self.assertIn("stable_id!(ProgramId", core)
+        self.assertIn("stable_id!(ObjectiveId", core)
+        self.assertIn("mod program", core_lib)
+        self.assertIn("ProgramContextInput", core_lib)
+        self.assertIn("use decodex_core", postgres)
+        for parallel_identity in (
+            "struct ProjectId",
+            "struct LeadId",
+            "struct PolicyId",
+            "struct WorkItemId",
+            "work_item_ids",
+        ):
+            self.assertNotIn(parallel_identity, core)
+            self.assertNotIn(parallel_identity, postgres)
+            self.assertNotIn(parallel_identity, migration)
+        for runtime_identity in (
+            "RuntimeSessionId",
+            "ConversationId",
+            "ThreadId",
+            "create_conversation",
+            "create_runtime_session",
+        ):
+            self.assertNotIn(runtime_identity, core)
+            self.assertNotIn(runtime_identity, postgres)
+            self.assertNotIn(runtime_identity, migration)
+
+        self.assertIn("REFERENCES decodex.projects", migration)
+        self.assertIn("REFERENCES decodex.agents(agent_id, project_id)", migration)
+        self.assertIn("REFERENCES decodex.policy_revisions", migration)
+        self.assertIn("objective_completion_evidence", migration)
+        self.assertIn("DEFERRABLE INITIALLY DEFERRED", migration)
+        self.assertIn("p_project_id decodex.canonical_uuid_v4_text", migration)
+        self.assertIn("stored.project_id<>canonical_project_id", migration)
+        self.assertIn("evidence_row.objective_updated_at <> OLD.updated_at", migration)
+        self.assertIn("ON CONFLICT DO NOTHING", migration)
+        self.assertNotIn("WorkItem", migration)
+
+    def test_active_vnext_contracts_have_no_product_goal_authority(self):
+        findings = {}
+        for root in VNEXT_CONTRACT_ROOTS:
+            for path in sorted(root.rglob("*")):
+                if path.is_file() and path.suffix in CONTRACT_SUFFIXES:
+                    path_findings = forbidden_goal_contracts(
+                        path.read_text(), path.suffix
+                    )
+                    if path_findings:
+                        findings[str(path.relative_to(ROOT))] = path_findings
+
+        self.assertEqual(findings, {})
+
+    def test_managed_run_success_requires_work_item_acceptance_authority(self):
+        required = (
+            "ManagedRun may reach successful terminal completion only from explicit "
+            "authoritative\nWorkItem acceptance and validation"
+        )
+        exclusions = (
+            "Objective achievement or evidence",
+            "Codex Goal state cannot establish WorkItem acceptance or ManagedRun success",
+        )
+        for relative in (
+            "openwiki/specs/vnext-authority.md",
+            "openwiki/specs/vnext-gates.md",
+        ):
+            contract = (ROOT / relative).read_text()
+
+            self.assertIn(required, contract)
+            for exclusion in exclusions:
+                self.assertIn(exclusion, contract)
+
+    def test_goal_vocabulary_audit_is_contract_aware_and_adversarial(self):
+        forbidden = {
+            ".rs": [
+                "pub struct Goal { id: GoalId }",
+                "pub goal_id: String",
+                '#[serde(rename = "goal")] pub objective: String',
+                'route("/vnext/goals")',
+            ],
+            ".sql": [
+                "CREATE TABLE decodex.goals (goal_id uuid PRIMARY KEY);",
+                'CREATE TYPE decodex."GoalState" AS ENUM (\'active\');',
+            ],
+            ".proto": ["message Goal { string goal_id = 1; }"],
+            ".json": ['{"properties":{"goal":{"type":"string"}}}'],
+        }
+        for suffix, fixtures in forbidden.items():
+            for fixture in fixtures:
+                with self.subTest(suffix=suffix, fixture=fixture):
+                    self.assertTrue(forbidden_goal_contracts(fixture, suffix))
+
+        allowed = [
+            ("// Current non-goals remain explicit.", ".rs", "active_vnext"),
+            ('let prose = "ordinary goals and non-goals";', ".rs", "active_vnext"),
+            ("-- ordinary goals are discussed here", ".sql", "active_vnext"),
+            ("pub struct GoalHandle;", ".rs", "external_codex_adapter"),
+            ("CREATE TABLE legacy_goals(id uuid);", ".sql", "frozen_legacy"),
+        ]
+        for fixture, suffix, ownership in allowed:
+            with self.subTest(suffix=suffix, ownership=ownership):
+                self.assertEqual(
+                    forbidden_goal_contracts(fixture, suffix, ownership), []
+                )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- introduce authoritative Program and finite Objective domain semantics
- remove Goal from the vNext product/database authority path
- enforce request-scoped receipts, concurrent identity convergence, revision-bound completion evidence, and PostgreSQL/Rust timestamp alignment
- define successful ManagedRun completion through explicit WorkItem acceptance and validation

## Verification
- cargo test -p decodex-core -p decodex-postgres --all-targets --all-features
- python3 tests/scripts/test_vnext_architecture.py
- SCCACHE_DISABLE=1 python3 scripts/vnext/postgres_store_test.py

Breaking vNext authority change. Linear: XY-1281