### PR TITLE
XY-1340 Restore deterministic canonical formatting and style-gate authority

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,5 +1,17 @@
 # Decodex workspace tasks.
 
+# Audit
+# | task              | type    | cwd |
+# | ----------------- | ------- | --- |
+# | audit-vstyle-rust | command |     |
+
+[tasks.audit-vstyle-rust]
+workspace = false
+command = "python3"
+args = [
+	"scripts/vstyle_audit.py",
+]
+
 # Check
 # | task              | type      | cwd  |
 # | ----------------- | --------- | ---- |
@@ -96,7 +108,7 @@ workspace = false
 command = "rustup"
 args = [
 	"run",
-	"nightly",
+	"nightly-2026-07-16",
 	"cargo",
 	"fmt",
 	"--all",
@@ -106,7 +118,7 @@ args = [
 extend = "fmt-rust"
 args = [
 	"run",
-	"nightly",
+	"nightly-2026-07-16",
 	"cargo",
 	"fmt",
 	"--all",
@@ -129,17 +141,15 @@ args = [
 ]
 
 # Lint
-# | task              | type      | cwd |
-# | ----------------- | --------- | --- |
-# | lint              | composite |     |
-# | lint-rust         | command   |     |
-# | lint-vstyle-rust  | command   |     |
+# | task      | type      | cwd |
+# | --------- | --------- | --- |
+# | lint      | composite |     |
+# | lint-rust | command   |     |
 
 [tasks.lint]
 workspace = false
 dependencies = [
 	"lint-rust",
-	"lint-vstyle-rust",
 ]
 
 [tasks.lint-rust]
@@ -169,30 +179,16 @@ args = [
 	"warnings",
 ]
 
-[tasks.lint-vstyle-rust]
-workspace = false
-command = "cargo"
-args = [
-	"vstyle",
-	"curate",
-	"--language",
-	"rust",
-	"--workspace",
-	"--all-features",
-]
-
 # Fix
-# | task             | type      | cwd |
-# | ---------------- | --------- | --- |
-# | lint-fix         | composite |     |
-# | lint-rust-fix    | command   |     |
-# | lint-vstyle-fix  | command   |     |
+# | task          | type      | cwd |
+# | ------------- | --------- | --- |
+# | lint-fix      | composite |     |
+# | lint-rust-fix | command   |     |
 
 [tasks.lint-fix]
 workspace = false
 dependencies = [
 	"lint-rust-fix",
-	"lint-vstyle-fix",
 ]
 
 [tasks.lint-rust-fix]
@@ -224,36 +220,35 @@ args = [
 	"warnings",
 ]
 
-[tasks.lint-vstyle-fix]
-workspace = false
-command = "cargo"
-args = [
-	"vstyle",
-	"tune",
-	"--language",
-	"rust",
-	"--workspace",
-	"--all-features",
-	"--strict",
-]
-
 # Test
-# | task                     | type      | cwd |
-# | ------------------------ | --------- | --- |
+# | task                       | type      | cwd |
+# | -------------------------- | --------- | --- |
 # | test                       | composite |     |
+# | test-gate-contract         | command   |     |
 # | test-rust                  | command   |     |
 # | test-vnext-architecture    | command   |     |
 # | test-vnext-cli-diagnostics | command   |     |
-# | test-vnext-postgres-store | command   |     |
-# | test-vnext-storage-proof  | command   |     |
+# | test-vnext-postgres-store  | command   |     |
+# | test-vnext-storage-proof   | command   |     |
 
 [tasks.test]
 clear = true
 workspace = false
 dependencies = [
+	"test-gate-contract",
 	"test-rust",
 	"test-vnext-architecture",
 	"test-vnext-cli-diagnostics",
+]
+
+[tasks.test-gate-contract]
+workspace = false
+command = "python3"
+args = [
+	"-m",
+	"unittest",
+	"tests/scripts/test_gate_contract.py",
+	"tests/scripts/test_vstyle_audit.py",
 ]
 
 [tasks.test-rust]

--- a/apps/decodex-gpui/Cargo.toml
+++ b/apps/decodex-gpui/Cargo.toml
@@ -15,7 +15,7 @@ gpui_platform    = { workspace = true }
 serde            = { workspace = true }
 serde_json       = { workspace = true }
 sha2             = { workspace = true }
-tokio             = { workspace = true }
+tokio            = { workspace = true }
 
 [dev-dependencies]
 gpui     = { workspace = true, features = ["test-support"] }

--- a/apps/decodex-gpui/src/client_cache.rs
+++ b/apps/decodex-gpui/src/client_cache.rs
@@ -763,9 +763,8 @@ impl ClientCache {
 		ensure_absolute_normalized(root)?;
 
 		match fs::symlink_metadata(root) {
-			Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
-				Err(CacheError::UnsafeRoot)
-			},
+			Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() =>
+				Err(CacheError::UnsafeRoot),
 			Ok(_) => {
 				validate_existing_directory_chain(root)?;
 
@@ -1791,5 +1790,4 @@ fn remove_tree_without_following(path: &Path) -> Result<(), CacheError> {
 	Ok(())
 }
 
-#[cfg(test)]
-mod tests;
+#[cfg(test)] mod tests;

--- a/apps/decodex-gpui/src/client_lifecycle.rs
+++ b/apps/decodex-gpui/src/client_lifecycle.rs
@@ -237,12 +237,10 @@ impl LifecycleIo for TokioIo {
 
 	async fn next(&mut self) -> Result<Delivery<Self::Confirmation>, RetainedSessionFailure> {
 		match self.session.as_mut().ok_or(RetainedSessionFailure::Closed)?.next().await? {
-			SessionDelivery::Snapshot { snapshot, confirmation } => {
-				Ok(Delivery::Snapshot { snapshot, confirmation })
-			},
-			SessionDelivery::Event { event, confirmation } => {
-				Ok(Delivery::Event { event, confirmation })
-			},
+			SessionDelivery::Snapshot { snapshot, confirmation } =>
+				Ok(Delivery::Snapshot { snapshot, confirmation }),
+			SessionDelivery::Event { event, confirmation } =>
+				Ok(Delivery::Event { event, confirmation }),
 			SessionDelivery::CommandReceipt(_)
 			| SessionDelivery::CommandResult(_)
 			| SessionDelivery::QueryResult(_) => Ok(Delivery::Other),
@@ -541,9 +539,7 @@ impl ClientLifecycle {
 			Ok(Some(inspection))
 				if inspection.generation == binding.generation
 					&& inspection.authority == self.cache_authority =>
-			{
-				Some(binding.checkpoint)
-			},
+				Some(binding.checkpoint),
 			_ => {
 				self.enter_quarantine(
 					QuarantineReason::ContentAttestation,
@@ -890,7 +886,7 @@ fn initialize_cache(
 				Err(_) => unsafe_cache_quarantine(),
 			}
 		},
-		Err(error) if is_disposable_corruption(error) => {
+		Err(error) if is_disposable_corruption(error) =>
 			if ClientCache::dispose_all(root).is_ok() {
 				match ClientCache::open(root, limits, authority) {
 					Ok(cache) => (
@@ -904,8 +900,7 @@ fn initialize_cache(
 				}
 			} else {
 				unsafe_cache_quarantine()
-			}
-		},
+			},
 		Err(_) => unsafe_cache_quarantine(),
 	}
 }
@@ -940,5 +935,4 @@ fn next_cursor(cursor: Cursor) -> Option<Cursor> {
 	cursor.0.checked_add(1).map(Cursor)
 }
 
-#[cfg(test)]
-mod tests;
+#[cfg(test)] mod tests;

--- a/config/vstyle-rust-audit.json
+++ b/config/vstyle-rust-audit.json
@@ -1,0 +1,454 @@
+{
+  "schema": "decodex/vstyle-rust-audit/1",
+  "governance": {
+    "owner": "Decodex repository maintainers",
+    "accepted_by": "XY-1340",
+    "accepted_on": "2026-07-16",
+    "review_by": "2026-08-15",
+    "reevaluate_on": [
+      "vstyle executable identity changes",
+      "implemented Rust rule inventory changes",
+      "the accepted finding baseline changes",
+      "before any scope is promoted to blocking"
+    ]
+  },
+  "tool": {
+    "package": "vibe-style",
+    "version": "0.2.3",
+    "source": "https://github.com/hack-ink/vibe-style.git",
+    "commit": "3a0959eac5363c4c427382bae1d80d87ecadb702",
+    "git_short": "3a0959e",
+    "install": "cargo install --git https://github.com/hack-ink/vibe-style.git --rev 3a0959eac5363c4c427382bae1d80d87ecadb702 --locked --force vibe-style"
+  },
+  "accepted_baseline": {
+    "checked_files": 227,
+    "findings": 184,
+    "manual": 7
+  },
+  "rust_rules": [
+    "RUST-STYLE-FILE-001",
+    "RUST-STYLE-GENERICS-001",
+    "RUST-STYLE-GENERICS-002",
+    "RUST-STYLE-GENERICS-003",
+    "RUST-STYLE-IMPL-001",
+    "RUST-STYLE-IMPL-003",
+    "RUST-STYLE-IMPORT-001",
+    "RUST-STYLE-IMPORT-002",
+    "RUST-STYLE-IMPORT-003",
+    "RUST-STYLE-IMPORT-004",
+    "RUST-STYLE-IMPORT-005",
+    "RUST-STYLE-IMPORT-006",
+    "RUST-STYLE-IMPORT-007",
+    "RUST-STYLE-IMPORT-008",
+    "RUST-STYLE-IMPORT-009",
+    "RUST-STYLE-IMPORT-010",
+    "RUST-STYLE-IMPORT-011",
+    "RUST-STYLE-IMPORT-012",
+    "RUST-STYLE-LET-001",
+    "RUST-STYLE-LOG-002",
+    "RUST-STYLE-MOD-001",
+    "RUST-STYLE-MOD-002",
+    "RUST-STYLE-MOD-003",
+    "RUST-STYLE-MOD-004",
+    "RUST-STYLE-MOD-005",
+    "RUST-STYLE-MOD-007",
+    "RUST-STYLE-NUM-001",
+    "RUST-STYLE-NUM-002",
+    "RUST-STYLE-READ-002",
+    "RUST-STYLE-RUNTIME-001",
+    "RUST-STYLE-RUNTIME-002",
+    "RUST-STYLE-SERDE-001",
+    "RUST-STYLE-SPACE-003",
+    "RUST-STYLE-SPACE-004",
+    "RUST-STYLE-TEST-001",
+    "RUST-STYLE-TEST-002",
+    "RUST-STYLE-TYPE-001"
+  ],
+  "baseline": [
+    {
+      "count": 11,
+      "fixable": true,
+      "message": "Prefer importing non-function, non-macro symbols and using short paths when unambiguous.",
+      "path": "apps/decodex-gpui/src/client_cache.rs",
+      "rule": "RUST-STYLE-IMPORT-008"
+    },
+    {
+      "count": 6,
+      "fixable": true,
+      "message": "Do not insert blank lines within the same statement type.",
+      "path": "apps/decodex-gpui/src/client_cache.rs",
+      "rule": "RUST-STYLE-SPACE-003"
+    },
+    {
+      "count": 1,
+      "fixable": false,
+      "message": "Insert exactly one blank line between different statement types.",
+      "path": "apps/decodex-gpui/src/client_cache.rs",
+      "rule": "RUST-STYLE-SPACE-003"
+    },
+    {
+      "count": 2,
+      "fixable": true,
+      "message": "Insert exactly one blank line between different statement types.",
+      "path": "apps/decodex-gpui/src/client_cache.rs",
+      "rule": "RUST-STYLE-SPACE-003"
+    },
+    {
+      "count": 2,
+      "fixable": true,
+      "message": "Insert exactly one blank line before the final tail expression.",
+      "path": "apps/decodex-gpui/src/client_cache.rs",
+      "rule": "RUST-STYLE-SPACE-004"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Top-level module item order does not match rust.md order.",
+      "path": "apps/decodex-gpui/src/client_cache/tests.rs",
+      "rule": "RUST-STYLE-MOD-001"
+    },
+    {
+      "count": 2,
+      "fixable": true,
+      "message": "Do not insert blank lines within the same statement type.",
+      "path": "apps/decodex-gpui/src/client_cache/tests.rs",
+      "rule": "RUST-STYLE-SPACE-003"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not place blank lines inside an import group.",
+      "path": "apps/decodex-gpui/src/client_lifecycle.rs",
+      "rule": "RUST-STYLE-IMPORT-002"
+    },
+    {
+      "count": 2,
+      "fixable": true,
+      "message": "Prefer parent-module qualified free-function paths when unambiguous.",
+      "path": "apps/decodex-gpui/src/client_lifecycle.rs",
+      "rule": "RUST-STYLE-IMPORT-004"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Top-level module item order does not match rust.md order.",
+      "path": "apps/decodex-gpui/src/client_lifecycle.rs",
+      "rule": "RUST-STYLE-MOD-001"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Place pub items before non-pub items within the same group.",
+      "path": "apps/decodex-gpui/src/client_lifecycle.rs",
+      "rule": "RUST-STYLE-MOD-002"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not insert blank lines between `ClientLifecycle` and its first impl block.",
+      "path": "apps/decodex-gpui/src/client_lifecycle.rs",
+      "rule": "RUST-STYLE-MOD-005"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not insert blank lines between `TokioIo` and its first impl block.",
+      "path": "apps/decodex-gpui/src/client_lifecycle.rs",
+      "rule": "RUST-STYLE-MOD-005"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Keep `LifecycleCancellation` definitions and related impl blocks adjacent.",
+      "path": "apps/decodex-gpui/src/client_lifecycle.rs",
+      "rule": "RUST-STYLE-MOD-005"
+    },
+    {
+      "count": 1,
+      "fixable": false,
+      "message": "Function body has 122 lines; keep functions at or under 120 lines.",
+      "path": "apps/decodex-gpui/src/client_lifecycle.rs",
+      "rule": "RUST-STYLE-READ-002"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not insert blank lines within the same statement type.",
+      "path": "apps/decodex-gpui/src/client_lifecycle.rs",
+      "rule": "RUST-STYLE-SPACE-003"
+    },
+    {
+      "count": 19,
+      "fixable": true,
+      "message": "Insert exactly one blank line between different statement types.",
+      "path": "apps/decodex-gpui/src/client_lifecycle.rs",
+      "rule": "RUST-STYLE-SPACE-003"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not place blank lines inside an import group.",
+      "path": "apps/decodex-gpui/src/client_lifecycle/tests.rs",
+      "rule": "RUST-STYLE-IMPORT-002"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Use items must appear only at file top level or module top level.",
+      "path": "apps/decodex-gpui/src/client_lifecycle/tests.rs",
+      "rule": "RUST-STYLE-IMPORT-006"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Prefer importing non-function, non-macro symbols and using short paths when unambiguous.",
+      "path": "apps/decodex-gpui/src/client_lifecycle/tests.rs",
+      "rule": "RUST-STYLE-IMPORT-008"
+    },
+    {
+      "count": 3,
+      "fixable": true,
+      "message": "Place immutable `let` bindings before mutable ones.",
+      "path": "apps/decodex-gpui/src/client_lifecycle/tests.rs",
+      "rule": "RUST-STYLE-LET-001"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Top-level module item order does not match rust.md order.",
+      "path": "apps/decodex-gpui/src/client_lifecycle/tests.rs",
+      "rule": "RUST-STYLE-MOD-001"
+    },
+    {
+      "count": 7,
+      "fixable": true,
+      "message": "Place non-async functions before async functions at the same visibility.",
+      "path": "apps/decodex-gpui/src/client_lifecycle/tests.rs",
+      "rule": "RUST-STYLE-MOD-003"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not insert blank lines between `FakeIo` and its first impl block.",
+      "path": "apps/decodex-gpui/src/client_lifecycle/tests.rs",
+      "rule": "RUST-STYLE-MOD-005"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not insert blank lines between `FakeSession` and its first impl block.",
+      "path": "apps/decodex-gpui/src/client_lifecycle/tests.rs",
+      "rule": "RUST-STYLE-MOD-005"
+    },
+    {
+      "count": 42,
+      "fixable": true,
+      "message": "Insert exactly one blank line between different statement types.",
+      "path": "apps/decodex-gpui/src/client_lifecycle/tests.rs",
+      "rule": "RUST-STYLE-SPACE-003"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not place blank lines inside an import group.",
+      "path": "apps/decodex-gpui/src/main.rs",
+      "rule": "RUST-STYLE-IMPORT-002"
+    },
+    {
+      "count": 3,
+      "fixable": true,
+      "message": "Do not import free functions or macros into scope; prefer qualified module paths.",
+      "path": "apps/decodex-gpui/src/main.rs",
+      "rule": "RUST-STYLE-IMPORT-004"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Prefer importing non-function, non-macro symbols and using short paths when unambiguous.",
+      "path": "apps/decodex-gpui/src/main.rs",
+      "rule": "RUST-STYLE-IMPORT-008"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Integers with more than three digits must use underscore separators.",
+      "path": "apps/decodex-gpui/src/main.rs",
+      "rule": "RUST-STYLE-NUM-002"
+    },
+    {
+      "count": 3,
+      "fixable": true,
+      "message": "Insert exactly one blank line between different statement types.",
+      "path": "apps/decodex-gpui/src/main.rs",
+      "rule": "RUST-STYLE-SPACE-003"
+    },
+    {
+      "count": 2,
+      "fixable": false,
+      "message": "Inline trait bounds are not allowed. Move bounds into a where clause.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-GENERICS-001"
+    },
+    {
+      "count": 1,
+      "fixable": false,
+      "message": "impl blocks for `Shell` must be contiguous.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-IMPL-003"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not place blank lines inside an import group.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-IMPORT-002"
+    },
+    {
+      "count": 5,
+      "fixable": true,
+      "message": "Do not import free functions or macros into scope; prefer qualified module paths.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-IMPORT-004"
+    },
+    {
+      "count": 1,
+      "fixable": false,
+      "message": "Glob imports are not allowed; import explicit symbols.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-IMPORT-007"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Glob imports are not allowed; import explicit symbols.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-IMPORT-007"
+    },
+    {
+      "count": 2,
+      "fixable": true,
+      "message": "Prefer importing non-function, non-macro symbols and using short paths when unambiguous.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-IMPORT-008"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not use `super` imports; use crate-absolute imports.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-IMPORT-010"
+    },
+    {
+      "count": 3,
+      "fixable": true,
+      "message": "Top-level module item order does not match rust.md order.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-MOD-001"
+    },
+    {
+      "count": 7,
+      "fixable": true,
+      "message": "Place pub items before non-pub items within the same group.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-MOD-002"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not insert blank lines between `Destination` and its first impl block.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-MOD-005"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not insert blank lines between `LifecycleOwnerGlobal` and its first impl block.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-MOD-005"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not insert blank lines between `LifecycleOwner` and its first impl block.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-MOD-005"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not insert blank lines between `Shell` and its first impl block.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-MOD-005"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Integers with more than three digits must use underscore separators.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-NUM-002"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not insert blank lines within the same statement type.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-SPACE-003"
+    },
+    {
+      "count": 1,
+      "fixable": false,
+      "message": "Insert exactly one blank line between different statement types.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-SPACE-003"
+    },
+    {
+      "count": 24,
+      "fixable": true,
+      "message": "Insert exactly one blank line between different statement types.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-SPACE-003"
+    },
+    {
+      "count": 2,
+      "fixable": true,
+      "message": "Insert exactly one blank line before the final tail expression.",
+      "path": "apps/decodex-gpui/src/shell.rs",
+      "rule": "RUST-STYLE-SPACE-004"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Prefer importing non-function, non-macro symbols and using short paths when unambiguous.",
+      "path": "crates/decodex-postgres/tests/postgres_store.rs",
+      "rule": "RUST-STYLE-IMPORT-008"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Top-level module item order does not match rust.md order.",
+      "path": "crates/decodex-postgres/tests/postgres_store.rs",
+      "rule": "RUST-STYLE-MOD-001"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Place non-async functions before async functions at the same visibility.",
+      "path": "crates/decodex-postgres/tests/postgres_store.rs",
+      "rule": "RUST-STYLE-MOD-003"
+    },
+    {
+      "count": 1,
+      "fixable": true,
+      "message": "Do not insert blank lines within the same statement type.",
+      "path": "crates/decodex-postgres/tests/postgres_store.rs",
+      "rule": "RUST-STYLE-SPACE-003"
+    },
+    {
+      "count": 2,
+      "fixable": true,
+      "message": "Insert exactly one blank line between different statement types.",
+      "path": "crates/decodex-postgres/tests/postgres_store.rs",
+      "rule": "RUST-STYLE-SPACE-003"
+    }
+  ]
+}

--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -377,9 +377,8 @@ fn map_config_error(error: ConfigError) -> ClientFailure {
 	match error {
 		ConfigError::UnsupportedVersion => ClientFailure::ConfigurationVersion,
 		ConfigError::MissingProfile => ClientFailure::ProfileMissing,
-		ConfigError::Path(PathError::Io { kind: ErrorKind::NotFound, .. }) => {
-			ClientFailure::ConfigurationMissing
-		},
+		ConfigError::Path(PathError::Io { kind: ErrorKind::NotFound, .. }) =>
+			ClientFailure::ConfigurationMissing,
 		ConfigError::Path(_) => ClientFailure::UnsafeHostPath,
 		_ => ClientFailure::ConfigurationMalformed,
 	}
@@ -415,12 +414,10 @@ fn map_receive_error(error: tokio_tungstenite::tungstenite::Error) -> ClientFail
 
 fn map_refusal(refusal: Refusal) -> ClientFailure {
 	match refusal {
-		Refusal::UnsupportedVersion(VersionRefusal::MajorMismatch { .. }) => {
-			ClientFailure::ProtocolMajorMismatch
-		},
-		Refusal::UnsupportedVersion(VersionRefusal::UnsupportedMinor { .. }) => {
-			ClientFailure::ProtocolMinorMismatch
-		},
+		Refusal::UnsupportedVersion(VersionRefusal::MajorMismatch { .. }) =>
+			ClientFailure::ProtocolMajorMismatch,
+		Refusal::UnsupportedVersion(VersionRefusal::UnsupportedMinor { .. }) =>
+			ClientFailure::ProtocolMinorMismatch,
 		Refusal::ServerIdentityMismatch { .. } => ClientFailure::ServerIdentityMismatch,
 		Refusal::ProtocolViolation { .. } => ClientFailure::ProtocolViolation,
 		Refusal::Backpressure { .. } => ClientFailure::ProtocolBackpressure,
@@ -437,8 +434,7 @@ fn version_failure(version: ProtocolVersion) -> ClientFailure {
 
 #[cfg(test)]
 mod tests {
-	#[cfg(unix)]
-	use std::os::unix::fs::PermissionsExt as _;
+	#[cfg(unix)] use std::os::unix::fs::PermissionsExt as _;
 	use std::{fs, net::Ipv4Addr, time::Duration};
 
 	use futures_util::{SinkExt as _, StreamExt as _};

--- a/crates/decodex-protocol/src/retained_session.rs
+++ b/crates/decodex-protocol/src/retained_session.rs
@@ -232,9 +232,7 @@ impl RetainedSession {
 				(Some(checkpoint), ReconnectMode::Resume)
 					if checkpoint.instance_id == instance_id
 						&& checkpoint.cursor <= welcome.cursor =>
-				{
-					(Some(welcome.cursor), Some(checkpoint.clone()), false)
-				},
+					(Some(welcome.cursor), Some(checkpoint.clone()), false),
 				(Some(_), ReconnectMode::Resume) => {
 					return Err(RetainedSessionFailure::CheckpointIdentityMismatch);
 				},
@@ -348,12 +346,10 @@ impl RetainedSession {
 
 				Ok(SessionDelivery::QueryResult(result))
 			},
-			ServerMessage::Refusal(refusal) => {
-				Err(refusal_failure(&self.expected_server_id, refusal))
-			},
-			ServerMessage::Welcome(_) | ServerMessage::Snapshot(_) => {
-				Err(RetainedSessionFailure::Malformed)
-			},
+			ServerMessage::Refusal(refusal) =>
+				Err(refusal_failure(&self.expected_server_id, refusal)),
+			ServerMessage::Welcome(_) | ServerMessage::Snapshot(_) =>
+				Err(RetainedSessionFailure::Malformed),
 		}
 		.inspect_err(|_| {
 			self.terminate();
@@ -390,9 +386,8 @@ impl RetainedSession {
 			while let Some(message) = socket.next().await {
 				match message.map_err(map_transport_error)? {
 					Message::Close(_) => return Ok(()),
-					Message::Ping(payload) => {
-						socket.send(Message::Pong(payload)).await.map_err(map_transport_error)?
-					},
+					Message::Ping(payload) =>
+						socket.send(Message::Pong(payload)).await.map_err(map_transport_error)?,
 					Message::Pong(_) => {},
 					Message::Text(_) | Message::Binary(_) | Message::Frame(_) => {
 						return Err(RetainedSessionFailure::Malformed);
@@ -593,22 +588,18 @@ impl Display for RetainedSessionFailure {
 			Self::ProtocolMajorMismatch => "retained session protocol major does not match",
 			Self::ProtocolMinorMismatch => "retained session protocol minor is unsupported",
 			Self::ServerIdentityMismatch => "retained session server identity does not match",
-			Self::PublicationIdentityUnavailable => {
-				"retained session publication identity is unavailable"
-			},
-			Self::CheckpointIdentityMismatch => {
-				"retained session checkpoint identity does not match"
-			},
+			Self::PublicationIdentityUnavailable =>
+				"retained session publication identity is unavailable",
+			Self::CheckpointIdentityMismatch =>
+				"retained session checkpoint identity does not match",
 			Self::Malformed => "retained session protocol response is malformed",
 			Self::ProtocolViolation => "retained session protocol operation was refused",
 			Self::Backpressure => "retained session backpressure limit was reached",
 			Self::PublicationOrder => "retained session publication order is invalid",
-			Self::ApplicationConfirmationRequired => {
-				"retained session delivery requires application confirmation"
-			},
-			Self::ApplicationConfirmationMismatch => {
-				"retained session application confirmation does not match"
-			},
+			Self::ApplicationConfirmationRequired =>
+				"retained session delivery requires application confirmation",
+			Self::ApplicationConfirmationMismatch =>
+				"retained session application confirmation does not match",
 		})
 	}
 }
@@ -660,12 +651,10 @@ fn refusal_failure(
 	}
 
 	match refusal.refusal {
-		Refusal::UnsupportedVersion(VersionRefusal::MajorMismatch { .. }) => {
-			RetainedSessionFailure::ProtocolMajorMismatch
-		},
-		Refusal::UnsupportedVersion(VersionRefusal::UnsupportedMinor { .. }) => {
-			RetainedSessionFailure::ProtocolMinorMismatch
-		},
+		Refusal::UnsupportedVersion(VersionRefusal::MajorMismatch { .. }) =>
+			RetainedSessionFailure::ProtocolMajorMismatch,
+		Refusal::UnsupportedVersion(VersionRefusal::UnsupportedMinor { .. }) =>
+			RetainedSessionFailure::ProtocolMinorMismatch,
 		Refusal::ServerIdentityMismatch { .. } => RetainedSessionFailure::ServerIdentityMismatch,
 		Refusal::ProtocolViolation { .. } => RetainedSessionFailure::ProtocolViolation,
 		Refusal::Backpressure { .. } => RetainedSessionFailure::Backpressure,
@@ -821,11 +810,10 @@ where
 					return serde_json::from_str(&text)
 						.map_err(|_| RetainedSessionFailure::Malformed);
 				},
-				Message::Ping(payload) => {
+				Message::Ping(payload) =>
 					bounded(cancellation, timeout, socket.send(Message::Pong(payload)))
 						.await?
-						.map_err(map_transport_error)?
-				},
+						.map_err(map_transport_error)?,
 				Message::Pong(_) => {},
 				Message::Close(_) => return Err(RetainedSessionFailure::Disconnected),
 				Message::Binary(_) | Message::Frame(_) => {

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -26,14 +26,60 @@ It depends on build, node checks, Rust checks, formatting, lint, and tests (`Mak
 | vNext PostgreSQL store, Conversation history, blobs, and Context Packs | `cargo make test-vnext-postgres-store` |
 | vNext storage feasibility proof | `cargo make test-vnext-storage-proof` |
 | Rust formatting | `cargo make fmt-rust-check` |
+| Canonical gate contract | `cargo make test-gate-contract` |
 | TOML formatting | `cargo make fmt-toml-check` |
 | Rust lint | `cargo make lint-rust` |
-| Vstyle lint | `cargo make lint-vstyle-rust` |
+| Read-only Vstyle audit | `cargo make audit-vstyle-rust` |
 | Site type check | `cargo make check-node` or `npm --prefix site run check` |
 | Site build | `cargo make build` or `npm --prefix site run build` |
 
 `cargo make test` runs `cargo nextest run --workspace --all-targets --all-features`, the
-vNext architecture test, and the XY-1308 CLI diagnostic process matrix (`Makefile.toml`).
+canonical gate contract tests, the vNext architecture test, and the XY-1308 CLI
+diagnostic process matrix (`Makefile.toml`). Rust compilation remains pinned by
+`rust-toolchain.toml` to `1.97.0`. The formatting tasks separately invoke
+`rustup run nightly-2026-07-16 cargo fmt`, which preserves the nightly-only options in
+`.rustfmt.toml` without depending on the mutable `nightly` alias. Supported hosts install
+that exact formatter toolchain once; formatting fails closed when it is unavailable:
+
+```sh
+rustup toolchain install nightly-2026-07-16 --profile minimal --component cargo --component rustfmt
+```
+
+## Vstyle audit authority
+
+Vstyle is an explicit read-only audit and is not part of the blocking `lint` or `check`
+aggregates. The ordinary `lint-fix` aggregate contains only Clippy fixing; the repository
+provides no Vstyle mutation task. Run the governed audit directly:
+
+```sh
+cargo make audit-vstyle-rust
+```
+
+`config/vstyle-rust-audit.json` pins `vibe-style` 0.2.3 to source commit
+`3a0959eac5363c4c427382bae1d80d87ecadb702`, attests the complete implemented Rust rule
+inventory, and records the reviewed current baseline of 184 findings, including seven
+manual findings. Supported hosts install that exact revision:
+
+```sh
+cargo install --git https://github.com/hack-ink/vibe-style.git \
+  --rev 3a0959eac5363c4c427382bae1d80d87ecadb702 \
+  --locked --force vibe-style
+```
+
+The audit fails closed when the executable version, source revision, build target, rule
+inventory, output grammar, or governance deadline differs from the contract. It also fails
+when normalized finding counts increase. Resolved baseline findings are reported without
+blocking so maintainers can refresh the baseline through review.
+
+Vstyle 0.2.3 does not expose structured curate output. The smallest repository-owned
+boundary therefore accepts only its exact finding and summary line grammar and rejects
+every unexpected nonempty line. Finding identity is normalized by path, rule, message,
+fixability, and multiplicity; line and column numbers are deliberately excluded so an
+unrelated line shift does not appear as a regression. The baseline owner is the Decodex
+repository maintainers. It must be reevaluated by 2026-08-15, whenever executable or rule
+identity changes, whenever the accepted baseline changes, and before any scope is promoted
+to blocking.
+
 The CLI matrix builds the real `decodex` binary, binds the real runtime to an isolated
 OS-selected loopback port, and proves status/doctor, stable identity mismatch,
 disconnection, malformed/missing profile configuration, unsafe server-host paths,

--- a/scripts/vstyle_audit.py
+++ b/scripts/vstyle_audit.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Attest and compare the read-only Rust vstyle audit against its accepted baseline."""
+
+from collections import Counter
+from datetime import date
+import json
+from pathlib import Path, PurePosixPath
+import re
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = REPO_ROOT / "config" / "vstyle-rust-audit.json"
+FINDING_PATTERN = re.compile(
+    r"^(?P<path>.+?):(?P<line>[1-9][0-9]*):(?P<column>[1-9][0-9]*): "
+    r"\[(?P<rule>RUST-STYLE-[A-Z0-9-]+)\] (?P<message>.+)$"
+)
+CHECKED_PATTERN = re.compile(r"^Checked (?P<count>[0-9]+) file\(s\)\.$")
+MANUAL_PATTERN = re.compile(r"^(?P<count>[0-9]+) violation\(s\) require manual fixes\.$")
+FOUND_PATTERN = re.compile(r"^Found (?P<count>[0-9]+) style violation\(s\)\.$")
+
+
+class AuditError(RuntimeError):
+    """The audit input or provenance did not satisfy the closed contract."""
+
+
+def load_contract(path=CONTRACT_PATH):
+    """Load the checked-in audit contract."""
+    with Path(path).open(encoding="utf-8") as contract_file:
+        contract = json.load(contract_file)
+    if contract.get("schema") != "decodex/vstyle-rust-audit/1":
+        raise AuditError("unsupported vstyle audit contract schema")
+    tool = contract["tool"]
+    if not re.fullmatch(r"[0-9a-f]{40}", tool["commit"]):
+        raise AuditError("vstyle source commit is not a full Git object ID")
+    if tool["git_short"] != tool["commit"][:7] or tool["commit"] not in tool["install"]:
+        raise AuditError("vstyle install and version identities do not match the pinned commit")
+    if contract["rust_rules"] != sorted(set(contract["rust_rules"])):
+        raise AuditError("vstyle Rust rule contract is not sorted and unique")
+    baseline = baseline_counter(contract)
+    accepted = contract["accepted_baseline"]
+    findings = sum(baseline.values())
+    manual = sum(count for (*_, fixable), count in baseline.items() if not fixable)
+    if findings != accepted["findings"] or manual != accepted["manual"]:
+        raise AuditError(
+            "checked-in vstyle baseline summary mismatch: "
+            f"normalized={findings}/{manual}, accepted={accepted['findings']}/{accepted['manual']}"
+        )
+    return contract
+
+
+def validate_governance(contract, today=None):
+    """Fail when the accepted baseline has passed its mandatory review date."""
+    review_by = date.fromisoformat(contract["governance"]["review_by"])
+    if (today or date.today()) > review_by:
+        raise AuditError(f"vstyle audit baseline review expired on {review_by.isoformat()}")
+
+
+def parse_host(rustc_output):
+    """Extract the active Rust host triple."""
+    for line in rustc_output.splitlines():
+        if line.startswith("host: "):
+            return line.removeprefix("host: ")
+    raise AuditError("rustc did not report a host triple")
+
+
+def validate_version(actual, contract, host):
+    """Attest the exact package version, source revision, and build target."""
+    tool = contract["tool"]
+    expected = f"vibe-style {tool['version']}-{tool['git_short']}-{host}"
+    if actual.strip() != expected:
+        raise AuditError(f"vstyle identity mismatch: expected {expected!r}, got {actual.strip()!r}")
+
+
+def parse_coverage(output):
+    """Normalize the implemented Rust rule inventory."""
+    rules = []
+    for line in output.splitlines():
+        if not line:
+            continue
+        fields = line.split("\t")
+        if len(fields) != 2 or fields[1] != "implemented":
+            raise AuditError(f"unexpected vstyle coverage output: {line!r}")
+        if fields[0].startswith("RUST-"):
+            rules.append(fields[0])
+    if len(rules) != len(set(rules)):
+        raise AuditError("vstyle coverage contains duplicate Rust rules")
+    return sorted(rules)
+
+
+def validate_rules(actual, contract):
+    """Attest the complete implemented Rust rule inventory."""
+    expected = sorted(contract["rust_rules"])
+    if actual != expected:
+        missing = sorted(set(expected) - set(actual))
+        added = sorted(set(actual) - set(expected))
+        raise AuditError(f"vstyle Rust rule inventory mismatch: missing={missing}, added={added}")
+
+
+def finding_key(path, rule, message, fixable):
+    """Build a location-stable finding signature."""
+    return (path, rule, message, fixable)
+
+
+def parse_curate(output, allowed_rules):
+    """Parse vstyle's text boundary and normalize findings as a multiset."""
+    findings = Counter()
+    checked_files = None
+    manual_summary = 0
+    found_summary = None
+    for line in output.splitlines():
+        if not line:
+            continue
+        match = FINDING_PATTERN.match(line)
+        if match:
+            path = PurePosixPath(match["path"])
+            if path.is_absolute() or ".." in path.parts:
+                raise AuditError(f"vstyle reported an unsafe path: {match['path']!r}")
+            if match["rule"] not in allowed_rules:
+                raise AuditError(f"vstyle reported an unattested rule: {match['rule']}")
+            message = match["message"]
+            fixable = message.endswith(" (fixable)")
+            if fixable:
+                message = message.removesuffix(" (fixable)")
+            findings[finding_key(path.as_posix(), match["rule"], message, fixable)] += 1
+            continue
+        match = CHECKED_PATTERN.match(line)
+        if match:
+            checked_files = int(match["count"])
+            continue
+        match = MANUAL_PATTERN.match(line)
+        if match:
+            manual_summary = int(match["count"])
+            continue
+        match = FOUND_PATTERN.match(line)
+        if match:
+            found_summary = int(match["count"])
+            continue
+        raise AuditError(f"unexpected vstyle curate output: {line!r}")
+    total = sum(findings.values())
+    manual = sum(count for (*_, fixable), count in findings.items() if not fixable)
+    if checked_files is None or found_summary is None:
+        raise AuditError("vstyle curate output omitted its summary")
+    if total != found_summary or manual != manual_summary:
+        raise AuditError(
+            "vstyle curate summary mismatch: "
+            f"parsed total/manual={total}/{manual}, reported={found_summary}/{manual_summary}"
+        )
+    return findings, {"checked_files": checked_files, "total": total, "manual": manual}
+
+
+def baseline_counter(contract):
+    """Load the reviewed baseline as a multiset."""
+    baseline = Counter()
+    for finding in contract["baseline"]:
+        key = finding_key(
+            finding["path"],
+            finding["rule"],
+            finding["message"],
+            finding["fixable"],
+        )
+        baseline[key] += finding["count"]
+    return baseline
+
+
+def compare_findings(current, baseline):
+    """Return new regressions and resolved baseline findings."""
+    return current - baseline, baseline - current
+
+
+def render_delta(prefix, delta):
+    """Render a deterministic normalized delta."""
+    lines = []
+    for (path, rule, message, fixable), count in sorted(delta.items()):
+        disposition = "fixable" if fixable else "manual"
+        lines.append(f"{prefix} {count}x {path} [{rule}] ({disposition}) {message}")
+    return lines
+
+
+def run(command):
+    """Run one read-only tool command from the repository root."""
+    return subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def audit():
+    """Execute the closed read-only audit contract."""
+    contract = load_contract()
+    validate_governance(contract)
+
+    rustc = run(["rustc", "-vV"])
+    if rustc.returncode != 0:
+        raise AuditError(f"rustc host query failed: {rustc.stderr.strip()}")
+    host = parse_host(rustc.stdout)
+
+    version = run(["cargo", "vstyle", "--version"])
+    if version.returncode != 0:
+        raise AuditError(f"vstyle version query failed: {version.stderr.strip()}")
+    validate_version(version.stdout, contract, host)
+
+    coverage = run(["cargo", "vstyle", "coverage"])
+    if coverage.returncode != 0:
+        raise AuditError(f"vstyle coverage query failed: {coverage.stderr.strip()}")
+    rules = parse_coverage(coverage.stdout)
+    validate_rules(rules, contract)
+
+    curate = run(
+        [
+            "cargo",
+            "vstyle",
+            "curate",
+            "--language",
+            "rust",
+            "--workspace",
+            "--all-features",
+        ]
+    )
+    if curate.returncode not in {0, 1}:
+        raise AuditError(f"vstyle curate failed unexpectedly: {curate.stderr.strip()}")
+    findings, summary = parse_curate(curate.stdout + curate.stderr, set(rules))
+    if summary["checked_files"] < contract["accepted_baseline"]["checked_files"]:
+        raise AuditError(
+            "vstyle audit scope shrank: "
+            f"checked {summary['checked_files']} files, "
+            f"accepted at least {contract['accepted_baseline']['checked_files']}"
+        )
+    added, resolved = compare_findings(findings, baseline_counter(contract))
+
+    print(
+        "vstyle audit: "
+        f"{version.stdout.strip()}; {len(rules)} Rust rules; "
+        f"{summary['checked_files']} files; {summary['total']} findings; "
+        f"{summary['manual']} manual"
+    )
+    for line in render_delta("-", resolved):
+        print(line)
+    for line in render_delta("+", added):
+        print(line)
+    if added:
+        print(f"vstyle audit: FAILED with {sum(added.values())} new regression(s)")
+        return 1
+    if resolved:
+        print(
+            "vstyle audit: baseline has "
+            f"{sum(resolved.values())} resolved finding(s); reviewed refresh required"
+        )
+    else:
+        print("vstyle audit: accepted baseline matched exactly")
+    return 0
+
+
+def main():
+    """CLI entrypoint."""
+    try:
+        return audit()
+    except (AuditError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        print(f"vstyle audit: provenance or contract failure: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_gate_contract.py
+++ b/tests/scripts/test_gate_contract.py
@@ -1,0 +1,89 @@
+"""Regression tests for the repository's canonical validation task graph."""
+
+from pathlib import Path
+import json
+import tomllib
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FORMATTER_TOOLCHAIN = "nightly-2026-07-16"
+
+
+class GateContractTests(unittest.TestCase):
+    """Keep canonical checks explicit, deterministic, and non-overlapping."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        with (REPO_ROOT / "Makefile.toml").open("rb") as makefile:
+            cls.tasks = tomllib.load(makefile)["tasks"]
+
+    def test_rust_format_tasks_use_the_same_pinned_nightly(self) -> None:
+        expected_args = {
+            "fmt-rust": ["run", FORMATTER_TOOLCHAIN, "cargo", "fmt", "--all"],
+            "fmt-rust-check": [
+                "run",
+                FORMATTER_TOOLCHAIN,
+                "cargo",
+                "fmt",
+                "--all",
+                "--",
+                "--check",
+            ],
+        }
+        self.assertEqual(self.tasks["fmt-rust"]["command"], "rustup")
+        self.assertEqual(self.tasks["fmt-rust-check"]["extend"], "fmt-rust")
+        for task_name, args in expected_args.items():
+            with self.subTest(task=task_name):
+                self.assertEqual(self.tasks[task_name]["args"], args)
+
+    def test_workspace_compiler_remains_separately_pinned(self) -> None:
+        with (REPO_ROOT / "rust-toolchain.toml").open("rb") as toolchain_file:
+            toolchain = tomllib.load(toolchain_file)["toolchain"]
+
+        self.assertEqual(toolchain["channel"], "1.97.0")
+        self.assertIn("rustfmt", toolchain["components"])
+        self.assertNotEqual(toolchain["channel"], FORMATTER_TOOLCHAIN)
+
+    def test_blocking_aggregates_retain_every_non_vstyle_gate(self) -> None:
+        self.assertEqual(
+            self.tasks["check"]["dependencies"],
+            ["build", "check-node", "check-rust", "fmt-check", "lint", "test"],
+        )
+        self.assertEqual(self.tasks["lint"]["dependencies"], ["lint-rust"])
+        self.assertEqual(self.tasks["lint-fix"]["dependencies"], ["lint-rust-fix"])
+
+    def test_vstyle_is_a_read_only_explicit_audit(self) -> None:
+        self.assertEqual(
+            self.tasks["audit-vstyle-rust"],
+            {
+                "workspace": False,
+                "command": "python3",
+                "args": ["scripts/vstyle_audit.py"],
+            },
+        )
+        serialized_tasks = json.dumps(self.tasks, sort_keys=True)
+        self.assertNotIn("tune", serialized_tasks)
+        self.assertNotIn("lint-vstyle-fix", self.tasks)
+        self.assertNotIn("lint-vstyle-rust", self.tasks)
+
+    def test_checked_in_vstyle_contract_pins_identity_and_baseline(self) -> None:
+        with (REPO_ROOT / "config" / "vstyle-rust-audit.json").open(encoding="utf-8") as file:
+            contract = json.load(file)
+
+        self.assertEqual(contract["schema"], "decodex/vstyle-rust-audit/1")
+        self.assertEqual(
+            contract["tool"]["commit"],
+            "3a0959eac5363c4c427382bae1d80d87ecadb702",
+        )
+        self.assertEqual(len(contract["rust_rules"]), 37)
+        self.assertEqual(contract["accepted_baseline"], {
+            "checked_files": 227,
+            "findings": 184,
+            "manual": 7,
+        })
+        self.assertEqual(sum(item["count"] for item in contract["baseline"]), 184)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_vstyle_audit.py
+++ b/tests/scripts/test_vstyle_audit.py
@@ -1,0 +1,101 @@
+"""Focused tests for the deterministic vstyle audit boundary."""
+
+from collections import Counter
+from datetime import date
+from pathlib import Path
+import sys
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import vstyle_audit  # noqa: E402
+
+
+RULE = "RUST-STYLE-SPACE-003"
+MESSAGE = "Insert exactly one blank line between different statement types."
+OUTPUT = f"""src/lib.rs:10:1: [{RULE}] {MESSAGE} (fixable)
+
+Checked 1 file(s).
+
+Found 1 style violation(s).
+"""
+
+
+class VstyleAuditTests(unittest.TestCase):
+    """Prove provenance failure and stable baseline-delta behavior."""
+
+    def setUp(self) -> None:
+        self.contract = {
+            "schema": "decodex/vstyle-rust-audit/1",
+            "governance": {"review_by": "2026-08-15"},
+            "tool": {"version": "0.2.3", "git_short": "3a0959e"},
+            "accepted_baseline": {"checked_files": 1, "findings": 1, "manual": 0},
+            "rust_rules": [RULE],
+            "baseline": [
+                {
+                    "path": "src/lib.rs",
+                    "rule": RULE,
+                    "message": MESSAGE,
+                    "fixable": True,
+                    "count": 1,
+                }
+            ],
+        }
+
+    def test_version_and_rule_mismatches_fail_closed(self) -> None:
+        with self.assertRaises(vstyle_audit.AuditError):
+            vstyle_audit.validate_version(
+                "vibe-style 0.2.3-wrong-aarch64-apple-darwin",
+                self.contract,
+                "aarch64-apple-darwin",
+            )
+        with self.assertRaises(vstyle_audit.AuditError):
+            vstyle_audit.validate_rules([RULE, "RUST-STYLE-NEW-001"], self.contract)
+
+    def test_governance_deadline_fails_closed(self) -> None:
+        with self.assertRaises(vstyle_audit.AuditError):
+            vstyle_audit.validate_governance(self.contract, date(2026, 8, 16))
+
+    def test_exact_baseline_and_location_shift_have_no_delta(self) -> None:
+        current, summary = vstyle_audit.parse_curate(OUTPUT, {RULE})
+        baseline = vstyle_audit.baseline_counter(self.contract)
+        self.assertEqual(summary, {"checked_files": 1, "total": 1, "manual": 0})
+        self.assertEqual(vstyle_audit.compare_findings(current, baseline), (Counter(), Counter()))
+
+        shifted = OUTPUT.replace("src/lib.rs:10:1", "src/lib.rs:99:7")
+        current, _ = vstyle_audit.parse_curate(shifted, {RULE})
+        self.assertEqual(vstyle_audit.compare_findings(current, baseline), (Counter(), Counter()))
+
+    def test_new_regression_and_resolved_finding_are_distinct(self) -> None:
+        doubled = OUTPUT.replace(
+            "\n\nChecked",
+            f"\nsrc/lib.rs:20:1: [{RULE}] {MESSAGE} (fixable)\n\nChecked",
+        ).replace("Found 1", "Found 2")
+        current, _ = vstyle_audit.parse_curate(doubled, {RULE})
+        added, resolved = vstyle_audit.compare_findings(
+            current,
+            vstyle_audit.baseline_counter(self.contract),
+        )
+        self.assertEqual(sum(added.values()), 1)
+        self.assertEqual(sum(resolved.values()), 0)
+
+        current, _ = vstyle_audit.parse_curate(
+            "Checked 1 file(s).\n\nFound 0 style violation(s).\n",
+            {RULE},
+        )
+        added, resolved = vstyle_audit.compare_findings(
+            current,
+            vstyle_audit.baseline_counter(self.contract),
+        )
+        self.assertEqual(sum(added.values()), 0)
+        self.assertEqual(sum(resolved.values()), 1)
+
+    def test_unstructured_output_is_rejected(self) -> None:
+        with self.assertRaises(vstyle_audit.AuditError):
+            vstyle_audit.parse_curate("warning: changed output contract", {RULE})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- pin the Rust formatter toolchain and restore the mechanical formatting baseline
- remove Vstyle from blocking/fixing aggregates and retain a governed read-only audit
- add provenance, baseline/delta, task-graph tests, and command authority documentation

## Validation

- `cargo make test-gate-contract`
- `cargo make audit-vstyle-rust`
- `cargo make fmt-rust-check`
- `cargo make fmt-toml-check`
- `cargo make lint-rust`
- `cargo make test`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer RUSTC_WRAPPER= cargo make check`

Independent visible review: `NO_BLOCKING_FINDINGS` for candidate fingerprint `0690fa108f140399d02af294e3d79ae7530f3793dcc6df541abe4d5dae62b7d0`.