### PR TITLE
Clarify passive readiness and XY-1304 integrity authority

### DIFF
--- a/openwiki/decisions/vnext-authority.md
+++ b/openwiki/decisions/vnext-authority.md
@@ -20,6 +20,14 @@ receipt-first, fenced, exact-response saga and dedicated session-level hash plus
 coordination around create-only synchronized CAS publication. Arbitrary/manual use of the private
 runtime credential is unsupported and equivalent to daemon compromise.
 
+Readiness authority correction accepted 2026-07-16: Codex 0.144.2 and 0.144.4 expose
+no stable passive complete account-owned plugin, skill, and MCP readiness receipt. Passive
+inventory is therefore withdrawn from the accepted XY-1262 foundation evidence. Host files,
+manifests, configuration, remote catalogs, process binding, and user declarations do not become
+observed account readiness. The first-release doctor result remains typed `unknown` for plugins;
+`plugin_unready` is inert reserved state. XY-1336 tracks the upstream receipt gap outside the
+vNext critical path and neither closes nor blocks XY-1275.
+
 ## Decision
 
 Decodex vNext is a rebuild of the agent workspace, not an incremental extension of the
@@ -93,7 +101,7 @@ The XY-1262 foundation gate is accepted only for the evidence scope enumerated i
 boundaries, creation-receipt ownership, negotiated app-server contracts, supported
 exact-ID/list/read/archive operations, lossy-read/divergence policy, native run-local
 collaboration normalization, process-scoped authentication/redaction, read-only
-plugin/skill inventory, and pure duration-typed quota policy. This acceptance does not
+integrity evidence, and pure duration-typed quota policy. This acceptance does not
 claim global Codex title search, live quota-driven routing, automatic continuation, or
 release readiness.
 

--- a/openwiki/evidence/vnext-codex-runtime-proof.md
+++ b/openwiki/evidence/vnext-codex-runtime-proof.md
@@ -5,6 +5,38 @@ Status: gate evidence at repository revision `f9d6c4e70198e94e5b9461b8cac7518ae1
 Observed: 2026-07-13 using `codex-cli 0.144.0-alpha.4` and the normal shared
 `~/.codex`. This is a proof spike, not the vNext adapter.
 
+## Superseding readiness interpretation
+
+Accepted 2026-07-16 after follow-up protocol research and skeptic review. Historical
+observations and receipts below remain evidence of what those probes returned, including
+their negative provenance and before/after integrity hashes. They no longer establish
+passive or account-owned plugin, skill, or MCP readiness. Codex 0.144.2 and 0.144.4 expose
+no stable passive complete account-owned readiness receipt. Host files, manifests,
+configuration, remote catalogs, process binding, user declarations, inventory counts,
+and catalog usability are not substitutes for that receipt; account-owned readiness
+therefore remains typed `unknown`.
+
+Passive plugin and skill inventory is withdrawn from the accepted XY-1262 foundation
+interpretation. XY-1336 is upstream-blocked tracking outside the vNext critical path and
+neither closes nor blocks XY-1275. XY-1304 instead requires experiment-scoped causal
+no-mutation evidence: its protocol trace and admitted Decodex control-plane method set
+must contain no plugin, skill, MCP, or marketplace inventory or management call and no
+install, enable, disable, update, remove, login-management, or OAuth-management call.
+Normal process-scoped `account/login/start` authentication and ordinary execution of an
+already-enabled tool inside a turn are not control-plane inventory or management calls.
+Where the host supports exact receipts for named non-transient surfaces, the receipt
+manifest must enumerate each supported surface and before/after equality remains required
+for normal `~/.codex/auth.json`, the Decodex account pool, and shared plugin files or
+configuration. That host-artifact equality is causal integrity evidence only, never
+account readiness.
+Account-owned installed/enabled state remains unobserved and `unknown`; it is not an
+XY-1304 acceptance fact. An external or cloud change outside Decodex causal authority is
+not a Decodex mutation merely because it overlaps the experiment. These constraints must
+not be replaced by `plugin/list`, `skills/list`, `mcpServerStatus/list`, `app/list`, a
+catalog scan, or an active diagnostic. Any future operator-triggered active diagnostic
+requires a separate decision and cannot authorize routing. The later historical proposal
+is preserved as provenance and is superseded on these points.
+
 ## Reproduce
 
 The probe reads two explicitly selected records from the existing Decodex account pool,

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -169,6 +169,13 @@ state is `unavailable`, `available`, `depleted`, `unknown`, `auth_failed`,
 observation time, and confidence; 5-hour and 7-day windows are never inferred from
 positional primary/secondary ordering.
 
+`plugin_unready` is inert reserved state; no first-release passive probe sets it.
+Codex 0.144.2 and 0.144.4 expose no stable passive complete account-owned plugin,
+skill, and MCP readiness receipt, so account-owned readiness remains typed `unknown`.
+Host files, desired manifests, configuration, remote catalogs, process/account binding,
+and user declarations may be integrity or provenance inputs, but they do not become
+observed readiness and cannot prove either readiness or unreadiness.
+
 The dormant manual account observation path checks an exact PostgreSQL account revision in the
 `available` state before mechanics and checks the same predicate again after cleanup. Each check
 releases its row and pooled client before arbitrary caller, vault, or process work. The result is a
@@ -227,11 +234,15 @@ availability. In particular, unknown or stale quota is fail-closed: no assignmen
 automatic fallback is permitted; the unavailable/unknown condition must be surfaced for
 human resolution or bounded observation.
 
+Readiness cannot authorize account eligibility, assignment, reassignment, fallback,
+scheduling, wakeup, continuation, or production routing. A future operator-triggered
+active diagnostic requires a separate authority decision and remains non-routing evidence.
+
 Users exclusively select the four global RoleProfiles. Runtime cannot alter model,
 reasoning, or service tier. Each RuntimeSession snapshots its profile. Decodex keeps a
-desired plugin manifest and audits account inventories; V1 reports readiness differences
-and guides supported login/install/OAuth work rather than claiming file replacement can
-install cloud-bound plugins.
+user-owned desired inventory only as intent. Until a stable passive account-owned receipt
+exists, V1 reports plugin readiness as `unknown` and does not compare host facts into an
+account-readiness conclusion or guide mutation from such a conclusion.
 
 ## Automation and protocol
 
@@ -253,7 +264,8 @@ remains disabled until authentication, TLS, authorization, and redaction gates p
 GPUI is the primary workspace and exposes the Advisor inbox; Projects with persistent
 Lead Conversations; Quick Tasks; Program/Objective/WorkItem board; Run, review, repair,
 and landing state; agent/thread/automation graph and causal timeline; accounts, plugin
-readiness, global RoleProfiles, and system health. Users can always talk to Advisor or a
+readiness (typed `unknown` in the first release), global RoleProfiles, and system health.
+Users can always talk to Advisor or a
 Project Lead, start Quick Tasks, intervene in WorkItems/ManagedRuns, and inspect all
 agent/message/automation relationships. SwiftUI is a thin accounts/run-health menubar
 client over the restricted protocol. GPUI caches are bounded, disposable,

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -19,7 +19,7 @@ its dependent implementation uses the result.
 | --- | --- |
 | [XY-1261](https://linear.app/hack-ink/issue/XY-1261)-[XY-1264](https://linear.app/hack-ink/issue/XY-1264), with live continuation moved to [XY-1304](https://linear.app/hack-ink/issue/XY-1304) | v0.2 freeze and PostgreSQL/blob/cache proof are accepted; the XY-1262 foundation is accepted, live continuation remains failed in XY-1304, and XY-1263 accepts only the isolated pinned GPUI foundation. |
 | [XY-1265](https://linear.app/hack-ink/issue/XY-1265)-[XY-1269](https://linear.app/hack-ink/issue/XY-1269) | Workspace ownership boundaries, `decodexd` protocol, PostgreSQL persistence, `~/.decodex`/API-only CLI, and the serial P/K/L/S GPUI client decomposition defined below. |
-| [XY-1270](https://linear.app/hack-ink/issue/XY-1270)-[XY-1276](https://linear.app/hack-ink/issue/XY-1276), plus [XY-1304](https://linear.app/hack-ink/issue/XY-1304) | Typed app-server, Conversation/RuntimeSession/history, shared-home, vault/runner-binding, quota-calculation, and profile/readiness foundations; XY-1304 separately owns live routing enablement and blocks the Quick Task slice. |
+| [XY-1270](https://linear.app/hack-ink/issue/XY-1270)-[XY-1276](https://linear.app/hack-ink/issue/XY-1276), plus [XY-1304](https://linear.app/hack-ink/issue/XY-1304) | Typed app-server, Conversation/RuntimeSession/history, shared-home, vault/runner-binding, quota-calculation, and profile foundations; XY-1304 separately owns live routing enablement and blocks the Quick Task slice. XY-1336 is upstream-blocked tracking outside this critical path. |
 | [XY-1277](https://linear.app/hack-ink/issue/XY-1277)-[XY-1286](https://linear.app/hack-ink/issue/XY-1286) | Projects/Advisor/Lead, context, messages/collaboration, decision queues, Programs/Objectives, WorkItems, ManagedRuns, repository services, Task-owned independent review/repair/landing, and Project/Program authority policy. |
 | [XY-1287](https://linear.app/hack-ink/issue/XY-1287)-[XY-1290](https://linear.app/hack-ink/issue/XY-1290) | Automation definitions/firings, materiality/loop safety, removal of manager agents, and PubFi/SEO/GEO/Radar/Publisher dogfood. |
 | [XY-1291](https://linear.app/hack-ink/issue/XY-1291)-[XY-1297](https://linear.app/hack-ink/issue/XY-1297) | GPUI conversations, project/run workspace, graph/timeline, operational surfaces, multi-GB pagination/cache/search, thin menubar, and accessibility/interaction gates. |
@@ -37,7 +37,7 @@ planning metadata, not product/runtime identity.
    creation-receipt ownership, negotiated app-server contracts, supported
    exact-ID/list/read/archive behavior, lossy-read/divergence policy, native run-local
    collaboration normalization, process-scoped authentication/redaction, read-only
-   plugin/skill inventory, and pure duration-typed quota policy.
+   integrity evidence, and pure duration-typed quota policy.
 3. The separate failed XY-1262 live account-routing enablement gate (XY-1304): natural
    quota depletion, durable exclusion before fallback, crash-safe exactly-one
    continuation, real resume-denied Context-Pack fallback, all-depleted wait/wakeup
@@ -76,8 +76,7 @@ evidence boundaries:
 - persistent exact-ID, filtered-list, read, explicit archive, and restart readback;
 - lossy `thread/read` handling and a fail-closed ManagedRun `diverged` policy;
 - native collaboration/subagent events normalized only as run-local actors;
-- process-scoped authentication, redaction, and integrity-preserving read-only
-  plugin/skill inventory; and
+- process-scoped authentication, redaction, and no-mutation integrity evidence; and
 - pure quota decisions keyed by duration 300/10080, including unknown, stale, reversed,
   and all-depleted synthetic cases.
 
@@ -102,7 +101,12 @@ Permission is issue-scoped and does not bypass each issue's own dependencies:
 | XY-1272 | Transactional creation mappings, exact-ID/list reconciliation, explicit retention, and the ManagedRun `diverged` stop transition; no global title-search claim. |
 | XY-1273 | Credential-vault metadata and immutable runner/account binding; no sticky or policy assignment. |
 | XY-1274 | Pure duration-typed quota/wake calculations and durable exclusion transaction tests using synthetic fixtures only; no live exclusion, fallback assignment, or wake scheduling. |
-| XY-1275 | User-owned profile snapshots and read-only plugin readiness audits; no installation or routing decision. |
+| XY-1275 | User-owned profile persistence and RuntimeSession snapshots. Account-owned plugin, skill, and MCP readiness remains typed `unknown`; XY-1336 neither closes nor blocks this issue. |
+
+XY-1336 is an upstream-blocked tracking issue outside the M2 critical path. A host file,
+manifest, configuration value, remote catalog entry, process binding, or user declaration
+cannot close the missing account-owned receipt. Existing doctor `unknown(plugin)` is the
+first-release result, and `plugin_unready` remains inert reserved state.
 
 ### XY-1263 acceptance and XY-1269 clean-slice reset
 
@@ -462,7 +466,9 @@ amendment.
 
 All XY-1270-XY-1275 capabilities must be mechanically inert or default-disabled at their
 live boundary. Synthetic fixtures can validate representation, calculation, and
-transaction ordering but cannot satisfy the live gate.
+transaction ordering but cannot satisfy the live gate. Readiness cannot authorize
+eligibility, assignment, reassignment, fallback, scheduling, wakeup, continuation, or
+production routing.
 
 ### Failed live account-routing enablement gate
 
@@ -479,10 +485,25 @@ same thread when supported. Otherwise, a real denied/incompatible response must 
 old RuntimeSession and create exactly one Context-Pack RuntimeSession. Injected crashes
 at each exclusion, assignment, resume, and fallback boundary must read back exactly one
 continuation, correct `waiting_usage` plus the earliest ready time when all accounts are
-freshly depleted, and no duplicate tool, worktree, Git, or artifact effect. Normal auth,
-account-pool, and installed/enabled plugin state must remain unchanged. Separately, the
-retained title must be returned by supported Codex Desktop discovery after normal
-indexing before any global visibility claim.
+freshly depleted, and no duplicate tool, worktree, Git, or artifact effect. Normal
+`~/.codex/auth.json`, the Decodex account pool, and supported shared plugin files or
+configuration must have exact before/after equality receipts. The receipt manifest must
+name each supported host-owned, non-transient surface. These receipts are causal integrity
+evidence only, never account readiness. The experiment's protocol trace
+and admitted Decodex control-plane method set must contain no plugin, skill, MCP, or
+marketplace inventory or management call and no install, enable, disable, update, remove,
+login-management, or OAuth-management call. Normal process-scoped
+`account/login/start` authentication and ordinary execution of an already-enabled tool
+inside a turn are not control-plane inventory or management calls. Account-owned
+installed/enabled state remains unobserved and `unknown`; it is not an XY-1304 acceptance
+fact. An external or cloud change outside Decodex causal
+authority is not a Decodex mutation merely because it overlaps the experiment. Neither
+`plugin/list`, `skills/list`, `mcpServerStatus/list`, `app/list`, a catalog scan, nor an
+active diagnostic may substitute for this evidence; any future operator-triggered active
+diagnostic requires separate authority and remains non-routing.
+
+Separately, the retained title must be returned by supported Codex Desktop discovery
+after normal indexing before any global visibility claim.
 
 Until all of that evidence passes and a later explicit repository amendment enables the
 path, sticky or policy assignment, quota-driven exclusion causing another assignment,


### PR DESCRIPTION
## Summary

- define passive account-owned plugin readiness as Unknown until Codex exposes a complete non-mutating receipt
- separate XY-1304 no-mutation/integrity evidence from readiness authority
- align vNext authority, gates, and runtime proof documentation

## Validation

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer RUSTC_WRAPPER= cargo make check`
- `cargo make test-vnext-architecture`
- focused authority scans and `git diff --check main...HEAD`
- independent exact-candidate review: `NO_BLOCKING_FINDINGS` for fingerprint `f91708c87255f7612864a23b1d125c876c3885238045ae5cb0dcda6a39577288`

## Tracking

Related to XY-1336. This PR records current authority; it does not claim passive readiness is implemented or close the tracking issue.