### PR TITLE
Persist exact-microsecond quota observations and inert exclusions

### DIFF
--- a/crates/decodex-postgres/migrations/V8__quota_exclusions.sql
+++ b/crates/decodex-postgres/migrations/V8__quota_exclusions.sql
@@ -1,0 +1,205 @@
+-- XY-1274 exact-microsecond quota persistence and locked zero-state boundary.
+LOCK TABLE decodex.command_receipts IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE decodex.quota_windows IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE decodex.activity IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE decodex.outbox IN ACCESS EXCLUSIVE MODE;
+
+DO $$
+BEGIN
+	IF EXISTS (SELECT 1 FROM decodex.quota_windows)
+		OR EXISTS (
+			SELECT 1 FROM decodex.command_receipts
+			WHERE operation = 'mutate_quota_window' OR scope_id = 'quota_windows'
+		)
+		OR EXISTS (
+			SELECT 1 FROM decodex.activity
+			WHERE aggregate_kind = 'quota_window'
+				OR event_kind IN (
+					'quota_window_created', 'quota_window_updated', 'quota_window_excluded'
+				)
+				OR (
+					pg_catalog.jsonb_typeof(payload) = 'object'
+					AND (
+						payload->>'kind' IN ('quota_window', 'quota_exclusion')
+						OR payload OPERATOR(pg_catalog.?) 'window_class'
+						OR payload OPERATOR(pg_catalog.?) 'duration_seconds'
+						OR payload OPERATOR(pg_catalog.?) 'duration_minutes'
+					)
+				)
+		)
+		OR EXISTS (
+			SELECT 1 FROM decodex.outbox
+			WHERE aggregate_kind = 'quota_window'
+				OR (
+					pg_catalog.jsonb_typeof(payload) = 'object'
+					AND (
+						payload->>'aggregate_kind' = 'quota_window'
+						OR payload->>'event_kind' IN (
+							'quota_window_created', 'quota_window_updated', 'quota_window_excluded'
+						)
+						OR payload->'payload'->>'kind' IN ('quota_window', 'quota_exclusion')
+						OR payload->'payload' OPERATOR(pg_catalog.?) 'window_class'
+						OR payload->'payload' OPERATOR(pg_catalog.?) 'duration_seconds'
+						OR payload->'payload' OPERATOR(pg_catalog.?) 'duration_minutes'
+					)
+				)
+		)
+		OR EXISTS (
+			SELECT 1
+			FROM decodex.outbox AS candidate
+			JOIN decodex.activity AS linked
+				ON candidate.payload @> pg_catalog.jsonb_build_object(
+					'activity_sequence', linked.sequence
+				)
+			WHERE linked.aggregate_kind = 'quota_window'
+				OR linked.event_kind IN (
+					'quota_window_created', 'quota_window_updated', 'quota_window_excluded'
+				)
+				OR linked.payload->>'kind' IN ('quota_window', 'quota_exclusion')
+				OR linked.payload OPERATOR(pg_catalog.?) 'window_class'
+				OR linked.payload OPERATOR(pg_catalog.?) 'duration_seconds'
+				OR linked.payload OPERATOR(pg_catalog.?) 'duration_minutes'
+		)
+	THEN
+		RAISE EXCEPTION 'V8 requires empty pre-release quota state'
+			USING ERRCODE = '55000', CONSTRAINT = 'quota_v8_zero_state';
+	END IF;
+END
+$$;
+
+CREATE TYPE decodex.quota_window_class AS ENUM ('five_hour', 'seven_day');
+CREATE TYPE decodex.observation_confidence AS ENUM ('unknown', 'low', 'high');
+
+CREATE FUNCTION decodex.enforce_quota_observation_monotonicity()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+BEGIN
+	IF NEW.observed_at < OLD.observed_at THEN
+		RAISE EXCEPTION 'quota observations cannot move backward in time'
+			USING ERRCODE = '23514', CONSTRAINT = 'quota_windows_observed_at_monotonic';
+	END IF;
+	RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION decodex.enforce_quota_observation_monotonicity() FROM PUBLIC;
+
+ALTER TABLE decodex.quota_windows
+	DROP CONSTRAINT quota_windows_pkey,
+	DROP CONSTRAINT quota_windows_window_class_check,
+	DROP CONSTRAINT quota_windows_duration_seconds_check,
+	DROP CONSTRAINT quota_windows_remaining_amount_check,
+	DROP CONSTRAINT quota_windows_confidence_check,
+	DROP CONSTRAINT quota_windows_finite_timestamps,
+	DROP CONSTRAINT quota_windows_no_credentials,
+	ALTER COLUMN window_class DROP DEFAULT,
+	ALTER COLUMN window_class TYPE decodex.quota_window_class
+		USING 'five_hour'::decodex.quota_window_class;
+
+ALTER TABLE decodex.quota_windows
+	RENAME COLUMN duration_seconds TO duration_minutes;
+
+ALTER TABLE decodex.quota_windows
+	ALTER COLUMN duration_minutes TYPE smallint USING 300::smallint;
+
+ALTER TABLE decodex.quota_windows
+	RENAME COLUMN remaining_amount TO remaining_percent;
+
+ALTER TABLE decodex.quota_windows
+	ALTER COLUMN remaining_percent TYPE smallint USING NULL::smallint;
+
+ALTER TABLE decodex.quota_windows
+	ALTER COLUMN confidence TYPE decodex.observation_confidence
+		USING 'unknown'::decodex.observation_confidence,
+	ADD CONSTRAINT quota_windows_pkey
+		PRIMARY KEY (account_id, window_class, duration_minutes),
+	ADD CONSTRAINT quota_windows_duration_identity CHECK (
+		(window_class = 'five_hour' AND duration_minutes = 300)
+		OR (window_class = 'seven_day' AND duration_minutes = 10080)
+	),
+	ADD CONSTRAINT quota_windows_remaining_percent CHECK (
+		remaining_percent IS NULL OR remaining_percent BETWEEN 0 AND 100
+	),
+	ADD CONSTRAINT quota_windows_timestamp_range CHECK (
+		observed_at >= TIMESTAMPTZ '1970-01-01 00:00:00+00'
+		AND observed_at <= TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+		AND (
+			resets_at IS NULL
+			OR resets_at >= observed_at
+				AND resets_at <= TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+		)
+	),
+	ADD CONSTRAINT quota_windows_finite_timestamps CHECK (
+		isfinite(observed_at)
+		AND (resets_at IS NULL OR isfinite(resets_at))
+		AND isfinite(updated_at)
+	),
+	ADD CONSTRAINT quota_windows_no_credentials CHECK (
+		NOT decodex.has_credential_material(metadata)
+	);
+
+CREATE TRIGGER quota_windows_observed_at_monotonic
+BEFORE UPDATE ON decodex.quota_windows
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_quota_observation_monotonicity();
+
+CREATE TABLE decodex.quota_exclusions (
+	account_id uuid NOT NULL,
+	window_class decodex.quota_window_class NOT NULL,
+	duration_minutes smallint NOT NULL,
+	observation_revision bigint NOT NULL CHECK (observation_revision > 0),
+	remaining_percent smallint NOT NULL,
+	confidence decodex.observation_confidence NOT NULL,
+	observation_metadata jsonb NOT NULL,
+	observed_at_micros bigint NOT NULL,
+	resets_at_micros bigint NOT NULL,
+	excluded_at_micros bigint NOT NULL,
+	maximum_age_micros bigint NOT NULL,
+	mutation_sha256 text NOT NULL,
+	mutation_length bigint NOT NULL,
+	dispatch_enabled boolean NOT NULL DEFAULT false,
+	created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+	CONSTRAINT quota_exclusions_pkey PRIMARY KEY (
+		account_id, window_class, duration_minutes, observation_revision
+	),
+	CONSTRAINT quota_exclusions_window_fk FOREIGN KEY (
+		account_id, window_class, duration_minutes
+	) REFERENCES decodex.quota_windows (
+		account_id, window_class, duration_minutes
+	) ON DELETE CASCADE,
+	CONSTRAINT quota_exclusions_duration_identity CHECK (
+		(window_class = 'five_hour' AND duration_minutes = 300)
+		OR (window_class = 'seven_day' AND duration_minutes = 10080)
+	),
+	CONSTRAINT quota_exclusions_depleted_high_confidence CHECK (
+		remaining_percent = 0 AND confidence = 'high'
+	),
+	CONSTRAINT quota_exclusions_timestamp_range CHECK (
+		observed_at_micros >= 0
+		AND observed_at_micros <= 253402300799999999
+		AND excluded_at_micros >= observed_at_micros
+		AND excluded_at_micros <= 253402300799999999
+		AND resets_at_micros >= excluded_at_micros + 1
+		AND resets_at_micros <= 253402300799999999
+	),
+	CONSTRAINT quota_exclusions_freshness CHECK (
+		maximum_age_micros = 300000000
+		AND excluded_at_micros - observed_at_micros <= maximum_age_micros
+	),
+	CONSTRAINT quota_exclusions_mutation_identity CHECK (
+		mutation_sha256 COLLATE pg_catalog."C" ~ '^[0-9a-f]{64}$'
+		AND mutation_length BETWEEN 1 AND 67108864
+	),
+	CONSTRAINT quota_exclusions_inert CHECK (NOT dispatch_enabled),
+	CONSTRAINT quota_exclusions_finite_created_at CHECK (isfinite(created_at)),
+	CONSTRAINT quota_exclusions_no_credentials CHECK (
+		NOT decodex.has_credential_material(observation_metadata)
+	)
+);
+
+CREATE INDEX quota_exclusions_reset_idx
+	ON decodex.quota_exclusions (account_id, resets_at_micros);
+
+REVOKE ALL ON TABLE decodex.quota_exclusions FROM PUBLIC;
+REVOKE ALL ON TYPE decodex.quota_window_class, decodex.observation_confidence FROM PUBLIC;

--- a/crates/decodex-postgres/src/accounts.rs
+++ b/crates/decodex-postgres/src/accounts.rs
@@ -2,13 +2,12 @@ use std::time::Duration;
 
 use deadpool_postgres::{Client, Transaction};
 use serde_json::{self, Value};
-use time::{OffsetDateTime, format_description::well_known::Rfc3339};
-use tokio::time::Instant;
+use tokio::time::{self, Instant};
 use tokio_postgres::Row;
 
 use crate::{
 	AccountId, AccountMetadata, AccountMutation, AccountState, ActivityRecord, CommandIdentity,
-	PostgresStore, QuotaWindow, QuotaWindowMutation, StoreError,
+	PostgresStore, StoreError,
 };
 
 /// Immutable identity bound to one durable command receipt before side effects begin.
@@ -28,12 +27,6 @@ pub(crate) struct CommandReservation {
 	key: String,
 	request_hash: String,
 	claim_token: String,
-}
-
-struct PersistedWindowTimestamps {
-	revision: i64,
-	resets_at: Option<String>,
-	observed_at: String,
 }
 
 /// A reservation either owns the pending saga or replays its exact completed response bytes.
@@ -137,84 +130,6 @@ impl PostgresStore {
 		transaction.commit().await?;
 
 		account_from_response(response)
-	}
-
-	/// Apply one inert duration-typed quota-window mutation. No eligibility, assignment,
-	/// fallback, or wake decision is exposed by this storage boundary.
-	pub async fn mutate_quota_window(
-		&self,
-		command: &CommandIdentity,
-		mutation: &QuotaWindowMutation,
-	) -> Result<QuotaWindow, StoreError> {
-		validate_window(mutation)?;
-
-		let mut client = self.pool().get().await?;
-		let entity_id = format!(
-			"{}:{}/{}",
-			mutation.account_id, mutation.window_class, mutation.duration_seconds
-		);
-		let descriptor = CommandDescriptor {
-			protocol_version: "decodex/store-command/1",
-			operation: "mutate_quota_window",
-			project_scope: "global",
-			scope_id: "quota_windows".into(),
-			entity_id: entity_id.clone(),
-			expected_revision: mutation.expected_revision,
-			payload_hash: None,
-			payload_length: None,
-		};
-		let reservation = match reserve_command(&mut client, command, &descriptor).await? {
-			CommandClaim::Completed(response) => return window_from_response(response),
-			CommandClaim::Owned(reservation) => reservation,
-		};
-		let transaction = client.transaction().await?;
-		let persisted = match mutation.expected_revision {
-			None => create_window(&transaction, mutation).await?,
-			Some(expected) => update_window(&transaction, mutation, expected).await?,
-		};
-		let revision = persisted.revision;
-		let aggregate_id = format!(
-			"{}:{}/{}",
-			mutation.account_id, mutation.window_class, mutation.duration_seconds
-		);
-		let event_kind =
-			if revision == 1 { "quota_window_created" } else { "quota_window_updated" };
-		let payload = serde_json::json!({
-			"account_id": mutation.account_id.as_str(),
-			"window_class": mutation.window_class,
-			"duration_seconds": mutation.duration_seconds,
-			"revision": revision,
-		});
-
-		append_activity_and_outbox(
-			&transaction,
-			"quota_window",
-			&aggregate_id,
-			revision,
-			event_kind,
-			&command.key,
-			&payload,
-		)
-		.await?;
-
-		let response = serde_json::json!({
-			"kind": "quota_window",
-			"account_id": mutation.account_id.as_str(),
-			"window_class": mutation.window_class,
-			"duration_seconds": mutation.duration_seconds,
-			"remaining_amount": mutation.remaining_amount,
-			"resets_at": persisted.resets_at,
-			"observed_at": persisted.observed_at,
-			"confidence": mutation.confidence,
-			"metadata": mutation.metadata,
-			"revision": revision,
-		});
-
-		finish_command(&transaction, &reservation, &response).await?;
-
-		transaction.commit().await?;
-
-		window_from_response(response)
 	}
 
 	/// Read account metadata without providing an eligibility or selection query.
@@ -359,7 +274,7 @@ pub(crate) async fn reserve_command(
 				return Err(StoreError::OwnershipLost("command receipt claim is active"));
 			}
 
-			tokio::time::sleep(Duration::from_millis(10)).await;
+			time::sleep(Duration::from_millis(10)).await;
 
 			continue;
 		}
@@ -383,6 +298,47 @@ pub(crate) async fn reserve_command(
 			claim_token,
 		}));
 	}
+}
+
+pub(crate) async fn replay_completed_command(
+	client: &Client,
+	command: &CommandIdentity,
+	descriptor: &CommandDescriptor,
+) -> Result<Option<Value>, StoreError> {
+	let Some(row) = client
+		.query_opt(
+			"SELECT request_hash, protocol_version, operation, project_scope, scope_id, entity_id, \
+			 expected_revision, payload_hash, payload_length, receipt_state::text, response_bytes, \
+			 response FROM decodex.command_receipts WHERE idempotency_key=$1",
+			&[&command.key],
+		)
+		.await?
+	else {
+		return Ok(None);
+	};
+
+	if !receipt_descriptor_matches(&row, command, descriptor) {
+		return Err(StoreError::IdempotencyConflict);
+	}
+	if row.get::<_, &str>(9) != "completed" {
+		return Ok(None);
+	}
+
+	let bytes = row.get::<_, Option<Vec<u8>>>(10).ok_or_else(|| {
+		StoreError::Incompatible("completed command receipt lost response bytes".into())
+	})?;
+	let response: Value = serde_json::from_slice(&bytes).map_err(|_| {
+		StoreError::Incompatible("completed command response bytes are invalid".into())
+	})?;
+	let stored_response: Value = row.get(11);
+
+	if response != stored_response {
+		return Err(StoreError::Incompatible(
+			"completed command response bytes differ from committed response".into(),
+		));
+	}
+
+	Ok(Some(response))
 }
 
 pub(crate) async fn finish_command(
@@ -508,50 +464,6 @@ fn validate_account(mutation: &AccountMutation) -> Result<(), StoreError> {
 	Ok(())
 }
 
-fn validate_window(mutation: &QuotaWindowMutation) -> Result<(), StoreError> {
-	if mutation.duration_seconds <= 0 {
-		return Err(StoreError::InvalidInput("quota window duration must be positive"));
-	}
-	if !(0.0..=1.0).contains(&mutation.confidence) || !mutation.confidence.is_finite() {
-		return Err(StoreError::InvalidInput("quota confidence must be finite and within 0..=1"));
-	}
-	if mutation.remaining_amount.is_some_and(|remaining| remaining < 0.0 || !remaining.is_finite())
-	{
-		return Err(StoreError::InvalidInput(
-			"quota remaining amount must be finite and non-negative",
-		));
-	}
-	if mutation.expected_revision.is_some_and(|revision| revision < 1) {
-		return Err(StoreError::InvalidInput("expected revision must be positive"));
-	}
-
-	validate_rfc3339(&mutation.observed_at, "quota observed_at must be RFC 3339")?;
-
-	if let Some(resets_at) = &mutation.resets_at {
-		validate_rfc3339(resets_at, "quota resets_at must be RFC 3339")?;
-	}
-
-	crate::ensure_credential_negative_text(&mutation.window_class)?;
-	crate::ensure_credential_negative_json(&mutation.metadata)?;
-
-	Ok(())
-}
-
-fn validate_rfc3339(value: &str, error: &'static str) -> Result<(), StoreError> {
-	if value.as_bytes().get(10) != Some(&b'T') {
-		return Err(StoreError::InvalidInput(error));
-	}
-
-	let parsed =
-		OffsetDateTime::parse(value, &Rfc3339).map_err(|_| StoreError::InvalidInput(error))?;
-
-	if parsed.year() < 1 {
-		return Err(StoreError::InvalidInput(error));
-	}
-
-	Ok(())
-}
-
 fn account_from_row(row: Row) -> Result<AccountMetadata, StoreError> {
 	Ok(AccountMetadata {
 		account_id: stored_account_id(row.get::<_, String>(0))?,
@@ -575,30 +487,6 @@ fn account_from_response(response: Value) -> Result<AccountMetadata, StoreError>
 			.get("metadata")
 			.cloned()
 			.ok_or(StoreError::Incompatible("account response missing metadata".into()))?,
-		revision: required_i64(&response, "revision")?,
-	})
-}
-
-fn window_from_response(response: Value) -> Result<QuotaWindow, StoreError> {
-	if response.get("kind").and_then(Value::as_str) != Some("quota_window") {
-		return Err(StoreError::IdempotencyConflict);
-	}
-
-	Ok(QuotaWindow {
-		account_id: stored_account_id(required_str(&response, "account_id")?)?,
-		window_class: required_str(&response, "window_class")?.to_owned(),
-		duration_seconds: required_i64(&response, "duration_seconds")?,
-		remaining_amount: response.get("remaining_amount").and_then(Value::as_f64),
-		resets_at: response.get("resets_at").and_then(Value::as_str).map(str::to_owned),
-		observed_at: required_str(&response, "observed_at")?.to_owned(),
-		confidence: response
-			.get("confidence")
-			.and_then(Value::as_f64)
-			.ok_or(StoreError::Incompatible("quota response missing confidence".into()))?,
-		metadata: response
-			.get("metadata")
-			.cloned()
-			.ok_or(StoreError::Incompatible("quota response missing metadata".into()))?,
 		revision: required_i64(&response, "revision")?,
 	})
 }
@@ -698,104 +586,6 @@ async fn account_revision(
 		)
 		.await?
 		.map(|row| row.get(0)))
-}
-
-async fn create_window(
-	transaction: &Transaction<'_>,
-	mutation: &QuotaWindowMutation,
-) -> Result<PersistedWindowTimestamps, StoreError> {
-	let row = transaction
-		.query_opt(
-			"INSERT INTO decodex.quota_windows \
-			 (account_id, window_class, duration_seconds, remaining_amount, resets_at, observed_at, confidence, metadata) \
-			 VALUES ($1::text::uuid, $2, $3, $4, $5::text::timestamptz, $6::text::timestamptz, $7, $8) \
-				 ON CONFLICT DO NOTHING RETURNING revision, \
-				 CASE WHEN resets_at IS NULL THEN NULL ELSE decodex.rfc3339_utc(resets_at) END, \
-				 decodex.rfc3339_utc(observed_at)",
-			&[
-				&mutation.account_id.as_str(),
-				&mutation.window_class,
-				&mutation.duration_seconds,
-				&mutation.remaining_amount,
-				&mutation.resets_at,
-				&mutation.observed_at,
-				&mutation.confidence,
-				&mutation.metadata,
-			],
-		)
-		.await?;
-
-	if let Some(row) = row {
-		return Ok(PersistedWindowTimestamps {
-			revision: row.get(0),
-			resets_at: row.get(1),
-			observed_at: row.get(2),
-		});
-	}
-
-	Err(window_revision_error(transaction, mutation, None).await?)
-}
-
-async fn update_window(
-	transaction: &Transaction<'_>,
-	mutation: &QuotaWindowMutation,
-	expected: i64,
-) -> Result<PersistedWindowTimestamps, StoreError> {
-	let row = transaction
-		.query_opt(
-			"UPDATE decodex.quota_windows SET remaining_amount = $4, resets_at = $5::timestamptz, \
-			 observed_at = $6::timestamptz, confidence = $7, metadata = $8, revision = revision + 1, \
-			 updated_at = clock_timestamp() WHERE account_id = $1::text::uuid AND window_class = $2 \
-				 AND duration_seconds = $3 AND revision = $9 RETURNING revision, \
-				 CASE WHEN resets_at IS NULL THEN NULL ELSE decodex.rfc3339_utc(resets_at) END, \
-				 decodex.rfc3339_utc(observed_at)",
-			&[
-				&mutation.account_id.as_str(),
-				&mutation.window_class,
-				&mutation.duration_seconds,
-				&mutation.remaining_amount,
-				&mutation.resets_at,
-				&mutation.observed_at,
-				&mutation.confidence,
-				&mutation.metadata,
-				&expected,
-			],
-		)
-		.await?;
-
-	if let Some(row) = row {
-		return Ok(PersistedWindowTimestamps {
-			revision: row.get(0),
-			resets_at: row.get(1),
-			observed_at: row.get(2),
-		});
-	}
-
-	Err(window_revision_error(transaction, mutation, Some(expected)).await?)
-}
-
-async fn window_revision_error(
-	transaction: &Transaction<'_>,
-	mutation: &QuotaWindowMutation,
-	expected: Option<i64>,
-) -> Result<StoreError, StoreError> {
-	let actual = transaction
-		.query_opt(
-			"SELECT revision FROM decodex.quota_windows WHERE account_id = $1::text::uuid \
-			 AND window_class = $2 AND duration_seconds = $3",
-			&[&mutation.account_id.as_str(), &mutation.window_class, &mutation.duration_seconds],
-		)
-		.await?
-		.map(|row| row.get(0));
-
-	Ok(StoreError::RevisionConflict {
-		entity: format!(
-			"quota_window/{}:{}/{}",
-			mutation.account_id, mutation.window_class, mutation.duration_seconds
-		),
-		expected,
-		actual,
-	})
 }
 
 #[cfg(test)]

--- a/crates/decodex-postgres/src/authority.rs
+++ b/crates/decodex-postgres/src/authority.rs
@@ -11,7 +11,8 @@ const PROJECT_AGENT_MIGRATION: &str = include_str!("../migrations/V5__project_ag
 const POLICY_MIGRATION: &str = include_str!("../migrations/V6__project_policy_authority.sql");
 const PROGRAM_OBJECTIVE_MIGRATION: &str =
 	include_str!("../migrations/V7__program_objective_authority.sql");
-const FUNCTION_CONTRACTS: [FunctionContract; 57] = [
+const QUOTA_MIGRATION: &str = include_str!("../migrations/V8__quota_exclusions.sql");
+const FUNCTION_CONTRACTS: [FunctionContract; 58] = [
 	FunctionContract {
 		name: "is_canonical_media_type",
 		lookup_signature: "decodex.is_canonical_media_type(pg_catalog.text)",
@@ -136,6 +137,18 @@ const FUNCTION_CONTRACTS: [FunctionContract; 57] = [
 		name: "enforce_outbox_operation_time",
 		lookup_signature: "decodex.enforce_outbox_operation_time()",
 		migration_signature: "enforce_outbox_operation_time()",
+		arguments: "",
+		result: "trigger",
+		language: "plpgsql",
+		volatility: "v",
+		strict: false,
+		returns_set: false,
+		rows: 0.0,
+	},
+	FunctionContract {
+		name: "enforce_quota_observation_monotonicity",
+		lookup_signature: "decodex.enforce_quota_observation_monotonicity()",
+		migration_signature: "enforce_quota_observation_monotonicity()",
 		arguments: "",
 		result: "trigger",
 		language: "plpgsql",
@@ -529,9 +542,10 @@ const RUNTIME_EXECUTE_FUNCTIONS: [&str; 26] = [
 	"decodex.transition_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.objective_state,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.text)",
 	"decodex.achieve_objective(decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,pg_catalog.text,decodex.canonical_uuid_v4_text,pg_catalog.int8,pg_catalog.text,decodex.canonical_uuid_v4_text)",
 ];
-const SAFETY_FUNCTIONS: [&str; 25] = [
+const SAFETY_FUNCTIONS: [&str; 26] = [
 	"enforce_lease_operation_time",
 	"enforce_outbox_operation_time",
+	"enforce_quota_observation_monotonicity",
 	"forbid_mutation_of_activity",
 	"enforce_outbox_terminal_retention",
 	"forbid_outbox_truncate",
@@ -556,7 +570,7 @@ const SAFETY_FUNCTIONS: [&str; 25] = [
 	"forbid_objective_evidence_mutation",
 	"enforce_objective_completion_coherence",
 ];
-const SAFETY_TRIGGER_COUNT: usize = 41;
+const SAFETY_TRIGGER_COUNT: usize = 42;
 // PostgreSQL 18 catalogs with an owner and a containing namespace, plus the namespace
 // itself. Namespace-scoped catalogs without an independent owner (constraints, triggers,
 // text-search parsers/templates, and dependent rows) inherit authority from one of these.
@@ -710,6 +724,7 @@ WITH set_roles AS (
 ), expected(table_name, can_select, can_insert, can_update, can_delete) AS (VALUES
   ('accounts', true, true, true, false),
   ('quota_windows', true, true, true, false),
+  ('quota_exclusions', true, true, false, false),
   ('command_receipts', true, true, true, false),
   ('activity', true, true, false, false),
   ('leases', true, true, true, false),
@@ -743,7 +758,7 @@ WITH set_roles AS (
   WHERE namespace.nspname = 'decodex' AND class.relkind IN ('r', 'p')
 )
 SELECT
-  (SELECT count(*) FROM tables WHERE table_name IS NOT NULL) = 27
+  (SELECT count(*) FROM tables WHERE table_name IS NOT NULL) = 28
     AND COALESCE((
       SELECT pg_catalog.bool_and(
         pg_catalog.has_table_privilege(session_user, oid, 'SELECT') = can_select
@@ -901,6 +916,7 @@ const TRIGGER_CONTRACT_SQL: &str = r#"
 WITH expected(table_name, trigger_name, function_name, trigger_type) AS (VALUES
   ('leases', 'leases_operation_time', 'enforce_lease_operation_time', 23),
   ('outbox', 'outbox_operation_time', 'enforce_outbox_operation_time', 23),
+	('quota_windows', 'quota_windows_observed_at_monotonic', 'enforce_quota_observation_monotonicity', 19),
   ('activity', 'activity_append_only', 'forbid_mutation_of_activity', 27),
   ('outbox', 'outbox_terminal_retention', 'enforce_outbox_terminal_retention', 27),
   ('outbox', 'outbox_truncate_forbidden', 'forbid_outbox_truncate', 34),
@@ -1059,6 +1075,7 @@ WITH catalog_context AS MATERIALIZED (
 ), expected_triggers(table_name, trigger_name, function_signature) AS (VALUES
   ('leases', 'leases_operation_time', 'decodex.enforce_lease_operation_time()'),
   ('outbox', 'outbox_operation_time', 'decodex.enforce_outbox_operation_time()'),
+	('quota_windows', 'quota_windows_observed_at_monotonic', 'decodex.enforce_quota_observation_monotonicity()'),
   ('activity', 'activity_append_only', 'decodex.forbid_mutation_of_activity()'),
   ('outbox', 'outbox_terminal_retention', 'decodex.enforce_outbox_terminal_retention()'),
   ('outbox', 'outbox_truncate_forbidden', 'decodex.forbid_outbox_truncate()'),
@@ -1567,8 +1584,8 @@ SELECT pg_catalog.jsonb_agg(
 FROM contract_rows
 "#;
 const SCHEMA_CONTRACT_SHA256: [u8; 32] = [
-	0xc7, 0x92, 0xa5, 0x97, 0x5b, 0xf3, 0x0b, 0xcb, 0x2c, 0xcf, 0x14, 0xf2, 0x6b, 0x12, 0xa5, 0x8b,
-	0x38, 0x3c, 0x92, 0xd6, 0x66, 0x73, 0xa6, 0x12, 0x85, 0xec, 0x89, 0x92, 0x4a, 0x3a, 0x28, 0x4e,
+	0xae, 0x1f, 0xb7, 0x45, 0x9f, 0xf8, 0x07, 0x19, 0x10, 0x16, 0x9f, 0xa1, 0x48, 0x31, 0x11, 0xdc,
+	0xf0, 0xc8, 0xc8, 0xe7, 0xc8, 0x15, 0x59, 0xe0, 0x3d, 0xf7, 0x69, 0x2d, 0x1a, 0xca, 0x9c, 0x7e,
 ];
 const EXTENSION_AUTHORITY_SQL: &str = r#"
 WITH set_roles AS (
@@ -1705,6 +1722,11 @@ struct FunctionContract {
 	rows: f32,
 }
 
+#[cfg(feature = "test-support")]
+pub(crate) const fn schema_contract_sql_fixture() -> &'static str {
+	SCHEMA_CONTRACT_SQL
+}
+
 pub(crate) async fn verify_runtime(client: &Client) -> Result<(), StoreError> {
 	verify_forbidden_authority(client).await?;
 	verify_identity_cast_authority(client).await?;
@@ -1795,6 +1817,7 @@ fn canonical_function_source(contract: &FunctionContract) -> Option<&'static str
 		PROJECT_AGENT_MIGRATION,
 		POLICY_MIGRATION,
 		PROGRAM_OBJECTIVE_MIGRATION,
+		QUOTA_MIGRATION,
 	]
 	.into_iter()
 	.find(|migration| migration.contains(&declaration))?;
@@ -2071,8 +2094,8 @@ mod tests {
 	use crate::authority::{
 		CONVERSATION_MIGRATION, FOUNDATION_MIGRATION, FUNCTION_CONTRACTS,
 		IDENTITY_CAST_AUTHORITY_SQL, OWNED_OBJECT_CATALOGS, POLICY_MIGRATION,
-		PROGRAM_OBJECTIVE_MIGRATION, PROJECT_AGENT_MIGRATION, ROLE_AUTHORITY_SQL, SAFETY_FUNCTIONS,
-		SCHEMA_CONTRACT_SHA256, SCHEMA_CONTRACT_SQL,
+		PROGRAM_OBJECTIVE_MIGRATION, PROJECT_AGENT_MIGRATION, QUOTA_MIGRATION, ROLE_AUTHORITY_SQL,
+		SAFETY_FUNCTIONS, SCHEMA_CONTRACT_SHA256, SCHEMA_CONTRACT_SQL,
 	};
 
 	#[test]
@@ -2125,6 +2148,7 @@ mod tests {
 				PROJECT_AGENT_MIGRATION,
 				POLICY_MIGRATION,
 				PROGRAM_OBJECTIVE_MIGRATION,
+				QUOTA_MIGRATION,
 			]
 			.into_iter()
 			.map(|migration| migration.matches("CREATE FUNCTION decodex.").count())
@@ -2143,6 +2167,7 @@ mod tests {
 					PROJECT_AGENT_MIGRATION,
 					POLICY_MIGRATION,
 					PROGRAM_OBJECTIVE_MIGRATION,
+					QUOTA_MIGRATION,
 				]
 				.into_iter()
 				.map(|migration| migration

--- a/crates/decodex-postgres/src/lib.rs
+++ b/crates/decodex-postgres/src/lib.rs
@@ -16,6 +16,7 @@ mod outbox;
 mod policies;
 mod programs;
 mod project_agents;
+mod quota;
 #[cfg(unix)] mod socket;
 mod types;
 
@@ -30,7 +31,8 @@ pub use self::{
 	programs::{ObjectiveRecord, ProgramRecord, UpdateProgramContext},
 	types::{
 		AccountMetadata, AccountMutation, ActivityRecord, CommandIdentity, CreateProject,
-		LeaseClaim, OutboxClaim, OutboxReconciliation, OutboxState, QuotaWindow,
+		HypotheticalFallbackFact, LeaseClaim, OutboxClaim, OutboxReconciliation, OutboxState,
+		QuotaExclusionMutation, QuotaExclusionReceipt, QuotaTimestampMicros, QuotaWindow,
 		QuotaWindowMutation, ReconciliationOutcome,
 	},
 };
@@ -44,6 +46,7 @@ pub use decodex_core::{
 	Project, ProjectAuthority, ProjectId, ProjectMetadata, ProjectMetadataValue,
 	ProjectRepositoryBinding, ProjectStatus, RepositoryIdentity, ReviewCadence,
 };
+pub use quota::parse_quota_timestamp_rfc3339;
 
 use std::{sync::Arc, time::Duration};
 
@@ -85,6 +88,13 @@ pub struct PostgresStore {
 	connector: VerifiedSocketConnect,
 }
 impl PostgresStore {
+	/// Return the exact schema-manifest query for isolated dump/restore fixtures.
+	#[cfg(feature = "test-support")]
+	#[doc(hidden)]
+	pub const fn schema_contract_sql_fixture() -> &'static str {
+		authority::schema_contract_sql_fixture()
+	}
+
 	/// Run migration/verification through the migration identity, close it, then retain
 	/// only a separately verified least-privilege runtime pool.
 	pub async fn connect_explicit(
@@ -176,6 +186,32 @@ impl PostgresStore {
 		let connector = verified_socket_connect(&config, expected_peer_uid)?;
 
 		Self::migrate_with_connector(config, connector).await
+	}
+
+	/// Apply the immutable migration ledger only through V7 for V8 boundary fixtures.
+	#[cfg(all(unix, feature = "test-support"))]
+	#[doc(hidden)]
+	pub async fn migrate_fixture_through_v7(
+		config: Config,
+		expected_peer_uid: u32,
+	) -> Result<(), StoreError> {
+		validate_connection(&config)?;
+
+		let connector = verified_socket_connect(&config, expected_peer_uid)?;
+		let manager = Manager::from_connect(
+			config,
+			connector.clone(),
+			ManagerConfig { recycling_method: RecyclingMethod::Fast },
+		);
+		let pool = Pool::builder(manager).max_size(1).build()?;
+		let mut client = checkout(&pool, &connector).await?;
+		let result = migrations::run_through_v7(&mut client).await;
+
+		drop(client);
+
+		pool.close();
+
+		result
 	}
 
 	#[cfg(not(unix))]

--- a/crates/decodex-postgres/src/migrations.rs
+++ b/crates/decodex-postgres/src/migrations.rs
@@ -3,14 +3,22 @@ mod embedded {
 }
 
 use deadpool_postgres::Client;
+#[cfg(feature = "test-support")] use refinery::Target;
 
 use crate::{REQUIRED_POSTGRES_MAJOR, StoreError};
 use embedded::migrations;
 
-const EXPECTED_LATEST_MIGRATION_VERSION: i32 = 7;
+const EXPECTED_LATEST_MIGRATION_VERSION: i32 = 8;
 
 pub(crate) async fn run(client: &mut Client) -> Result<(), StoreError> {
 	migrations::runner().run_async(&mut ***client).await?;
+
+	Ok(())
+}
+
+#[cfg(feature = "test-support")]
+pub(crate) async fn run_through_v7(client: &mut Client) -> Result<(), StoreError> {
+	migrations::runner().set_target(Target::Version(7)).run_async(&mut ***client).await?;
 
 	Ok(())
 }
@@ -58,7 +66,7 @@ pub(crate) async fn verify(client: &Client) -> Result<(), StoreError> {
 		!= Some(EXPECTED_LATEST_MIGRATION_VERSION)
 	{
 		return Err(StoreError::Incompatible(
-			"embedded migration inventory does not end at the canonical V7 ledger".into(),
+			"embedded migration inventory does not end at the canonical V8 ledger".into(),
 		));
 	}
 	if actual.len() != expected.len() {

--- a/crates/decodex-postgres/src/quota.rs
+++ b/crates/decodex-postgres/src/quota.rs
@@ -1,0 +1,515 @@
+mod identity;
+mod response;
+mod validation;
+
+pub use crate::quota::validation::parse_quota_timestamp_rfc3339;
+
+#[cfg(feature = "test-support")] use std::sync::atomic::Ordering;
+
+use deadpool_postgres::{Client, Transaction};
+
+use crate::{
+	CommandIdentity, PostgresStore, QuotaExclusionMutation, QuotaExclusionReceipt,
+	QuotaTimestampMicros, QuotaWindow, QuotaWindowMutation, StoreError,
+	accounts::{self, CommandClaim, CommandDescriptor},
+	quota::{identity::CanonicalMutationIdentity, validation::MAXIMUM_OBSERVATION_AGE_MICROS},
+};
+
+#[cfg(feature = "test-support")]
+static FAIL_EXCLUSION_AFTER_RESERVATION: std::sync::atomic::AtomicBool =
+	std::sync::atomic::AtomicBool::new(false);
+#[cfg(feature = "test-support")]
+static FAIL_QUOTA_UNLOCK: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+#[cfg(feature = "test-support")]
+static QUOTA_LOCK_EVICTIONS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+struct QuotaWindowLock {
+	client: Option<Client>,
+	key: String,
+	possibly_locked: bool,
+}
+impl QuotaWindowLock {
+	async fn acquire(client: Client, mutation: &QuotaWindowMutation) -> Result<Self, StoreError> {
+		let guard = Self {
+			client: Some(client),
+			key: response::quota_aggregate_id(mutation),
+			possibly_locked: true,
+		};
+
+		guard
+			.client()
+			.query_one("SELECT pg_advisory_lock(hashtextextended($1,0))", &[&guard.key])
+			.await?;
+
+		Ok(guard)
+	}
+
+	fn client(&self) -> &Client {
+		self.client.as_ref().expect("quota lock retains its client")
+	}
+
+	fn client_mut(&mut self) -> &mut Client {
+		self.client.as_mut().expect("quota lock retains its client")
+	}
+
+	async fn complete<T>(mut self, operation: Result<T, StoreError>) -> Result<T, StoreError> {
+		let cleanup = self.unlock().await;
+		let result = operation_result_precedes_cleanup(operation, cleanup);
+
+		drop(self);
+
+		result
+	}
+
+	async fn unlock(&mut self) -> Result<(), StoreError> {
+		#[cfg(feature = "test-support")]
+		if FAIL_QUOTA_UNLOCK.swap(false, Ordering::SeqCst) {
+			return Err(StoreError::CapacityExhausted("injected quota unlock failure"));
+		}
+
+		let unlocked: bool = self
+			.client()
+			.query_one("SELECT pg_advisory_unlock(hashtextextended($1,0))", &[&self.key])
+			.await?
+			.get(0);
+
+		if !unlocked {
+			return Err(StoreError::Incompatible(
+				"quota window serialization lock was not owned".into(),
+			));
+		}
+
+		self.possibly_locked = false;
+
+		Ok(())
+	}
+}
+
+impl Drop for QuotaWindowLock {
+	fn drop(&mut self) {
+		if self.possibly_locked
+			&& let Some(client) = self.client.take()
+		{
+			#[cfg(feature = "test-support")]
+			QUOTA_LOCK_EVICTIONS.fetch_add(1, Ordering::SeqCst);
+
+			drop(Client::take(client));
+		}
+	}
+}
+
+impl PostgresStore {
+	/// Inject one synthetic process failure after durable exclusion receipt reservation.
+	#[cfg(feature = "test-support")]
+	#[doc(hidden)]
+	pub fn fail_next_exclusion_after_reservation_fixture() {
+		FAIL_EXCLUSION_AFTER_RESERVATION.store(true, Ordering::SeqCst);
+	}
+
+	/// Inject one synthetic advisory-unlock failure after an authoritative quota operation.
+	#[cfg(feature = "test-support")]
+	#[doc(hidden)]
+	pub fn fail_next_quota_unlock_fixture() {
+		FAIL_QUOTA_UNLOCK.store(true, Ordering::SeqCst);
+	}
+
+	/// Return the process-local count of possibly locked quota sessions evicted from the pool.
+	#[cfg(feature = "test-support")]
+	#[doc(hidden)]
+	pub fn quota_lock_evictions_fixture() -> u64 {
+		QUOTA_LOCK_EVICTIONS.load(Ordering::SeqCst)
+	}
+
+	/// Persist one exact, duration-typed observation without exposing routing authority.
+	pub async fn mutate_quota_window(
+		&self,
+		command: &CommandIdentity,
+		mutation: &QuotaWindowMutation,
+	) -> Result<QuotaWindow, StoreError> {
+		validation::validate_window(mutation)?;
+
+		let identity = identity::quota_window_mutation_identity(mutation)?;
+		let derived_command = identity::derived_command(command, &identity);
+		let descriptor = identity::command_descriptor("mutate_quota_window", mutation, &identity);
+		let mut guard = QuotaWindowLock::acquire(self.pool().get().await?, mutation).await?;
+		let result = mutate_quota_window_locked(
+			guard.client_mut(),
+			command,
+			mutation,
+			&derived_command,
+			&descriptor,
+		)
+		.await;
+
+		guard.complete(result).await
+	}
+
+	/// Commit an exact account/window exclusion before returning inert fallback evidence.
+	pub async fn persist_quota_exclusion(
+		&self,
+		command: &CommandIdentity,
+		mutation: &QuotaExclusionMutation,
+	) -> Result<QuotaExclusionReceipt, StoreError> {
+		validation::validate_exclusion(mutation)?;
+
+		let identity = identity::quota_exclusion_mutation_identity(mutation)?;
+		let derived_command = identity::derived_command(command, &identity);
+		let descriptor = identity::exclusion_command_descriptor(mutation, &identity);
+		let mut guard =
+			QuotaWindowLock::acquire(self.pool().get().await?, &mutation.observation).await?;
+		let result = persist_quota_exclusion_locked(
+			guard.client_mut(),
+			command,
+			mutation,
+			&identity,
+			&derived_command,
+			&descriptor,
+		)
+		.await;
+
+		guard.complete(result).await
+	}
+}
+
+fn operation_result_precedes_cleanup<T>(
+	operation: Result<T, StoreError>,
+	_cleanup: Result<(), StoreError>,
+) -> Result<T, StoreError> {
+	operation
+}
+
+async fn mutate_quota_window_locked(
+	client: &mut Client,
+	command: &CommandIdentity,
+	mutation: &QuotaWindowMutation,
+	derived_command: &CommandIdentity,
+	descriptor: &CommandDescriptor,
+) -> Result<QuotaWindow, StoreError> {
+	if let Some(response) =
+		accounts::replay_completed_command(client, derived_command, descriptor).await?
+	{
+		return response::window_from_response(response);
+	}
+
+	preflight_window_write(client, mutation).await?;
+
+	let reservation = match accounts::reserve_command(client, derived_command, descriptor).await? {
+		CommandClaim::Completed(response) => return response::window_from_response(response),
+		CommandClaim::Owned(reservation) => reservation,
+	};
+	let transaction = client.transaction().await?;
+	let window = persist_window(&transaction, mutation).await?;
+	let aggregate_id = response::quota_aggregate_id(mutation);
+	let event_kind =
+		if window.revision == 1 { "quota_window_created" } else { "quota_window_updated" };
+	let payload = response::window_response(&window);
+
+	accounts::append_activity_and_outbox(
+		&transaction,
+		"quota_window",
+		&aggregate_id,
+		window.revision,
+		event_kind,
+		&command.key,
+		&payload,
+	)
+	.await?;
+	accounts::finish_command(&transaction, &reservation, &payload).await?;
+
+	transaction.commit().await?;
+
+	Ok(window)
+}
+
+async fn persist_quota_exclusion_locked(
+	client: &mut Client,
+	command: &CommandIdentity,
+	mutation: &QuotaExclusionMutation,
+	identity: &CanonicalMutationIdentity,
+	derived_command: &CommandIdentity,
+	descriptor: &CommandDescriptor,
+) -> Result<QuotaExclusionReceipt, StoreError> {
+	if let Some(response) =
+		accounts::replay_completed_command(client, derived_command, descriptor).await?
+	{
+		return response::exclusion_from_response(response);
+	}
+
+	preflight_window_write(client, &mutation.observation).await?;
+
+	let reservation = match accounts::reserve_command(client, derived_command, descriptor).await? {
+		CommandClaim::Completed(response) => return response::exclusion_from_response(response),
+		CommandClaim::Owned(reservation) => reservation,
+	};
+
+	#[cfg(feature = "test-support")]
+	if FAIL_EXCLUSION_AFTER_RESERVATION.swap(false, Ordering::SeqCst) {
+		return Err(StoreError::CapacityExhausted(
+			"injected quota exclusion failure after receipt reservation",
+		));
+	}
+
+	let transaction = client.transaction().await?;
+	let window = persist_window(&transaction, &mutation.observation).await?;
+	let inserted = insert_exclusion(&transaction, mutation, &window, identity).await?;
+	let receipt = response::exclusion_receipt(mutation, window.revision, identity)?;
+	let response = response::exclusion_response(&receipt);
+
+	if inserted {
+		accounts::append_activity_and_outbox(
+			&transaction,
+			"quota_window",
+			&response::quota_aggregate_id(&mutation.observation),
+			window.revision,
+			"quota_window_excluded",
+			&command.key,
+			&response,
+		)
+		.await?;
+	}
+
+	accounts::finish_command(&transaction, &reservation, &response).await?;
+
+	transaction.commit().await?;
+
+	Ok(receipt)
+}
+
+async fn preflight_window_write(
+	client: &Client,
+	mutation: &QuotaWindowMutation,
+) -> Result<(), StoreError> {
+	let row = client
+		.query_opt(
+			"SELECT revision, observed_at > TIMESTAMPTZ '1970-01-01 00:00:00+00' \
+			  + ($4::bigint / 1000000) * INTERVAL '1 second' \
+			  + ($4::bigint % 1000000) * INTERVAL '1 microsecond' \
+			 FROM decodex.quota_windows WHERE account_id=$1::text::uuid \
+			 AND window_class=$2::text::decodex.quota_window_class AND duration_minutes=$3",
+			&[
+				&mutation.account_id.as_str(),
+				&response::window_class_sql(mutation.window),
+				&i16::try_from(mutation.window.duration_minutes())
+					.expect("closed quota durations fit PostgreSQL smallint"),
+				&mutation.observed_at.get(),
+			],
+		)
+		.await?;
+
+	match (row, mutation.expected_revision) {
+		(None, None) => Ok(()),
+		(Some(row), Some(expected)) if row.get::<_, i64>(0) == expected => {
+			if row.get::<_, bool>(1) {
+				Err(StoreError::InvalidInput("quota observation cannot move backward in time"))
+			} else {
+				Ok(())
+			}
+		},
+		(row, expected) => Err(StoreError::RevisionConflict {
+			entity: format!(
+				"quota_window/{}:{}",
+				mutation.account_id,
+				response::window_class_sql(mutation.window)
+			),
+			expected,
+			actual: row.map(|row| row.get(0)),
+		}),
+	}
+}
+
+async fn persist_window(
+	transaction: &Transaction<'_>,
+	mutation: &QuotaWindowMutation,
+) -> Result<QuotaWindow, StoreError> {
+	let duration = i16::try_from(mutation.window.duration_minutes())
+		.expect("closed quota durations fit PostgreSQL smallint");
+	let remaining = mutation.remaining_percent.map(|value| i16::from(value.get()));
+	let resets_at = mutation.resets_at.map(QuotaTimestampMicros::get);
+	let row = match mutation.expected_revision {
+		None =>
+			transaction
+				.query_opt(
+					"INSERT INTO decodex.quota_windows \
+					 (account_id,window_class,duration_minutes,remaining_percent,resets_at, \
+					  observed_at,confidence,metadata) \
+					 VALUES ($1::text::uuid,$2::text::decodex.quota_window_class,$3,$4, \
+					  CASE WHEN $5::bigint IS NULL THEN NULL ELSE \
+					   TIMESTAMPTZ '1970-01-01 00:00:00+00' + ($5::bigint / 1000000) * INTERVAL '1 second' \
+					   + ($5::bigint % 1000000) * INTERVAL '1 microsecond' END, \
+					  TIMESTAMPTZ '1970-01-01 00:00:00+00' + ($6::bigint / 1000000) * INTERVAL '1 second' \
+					   + ($6::bigint % 1000000) * INTERVAL '1 microsecond', \
+					  $7::text::decodex.observation_confidence,$8) \
+					 ON CONFLICT DO NOTHING RETURNING revision",
+					&[
+						&mutation.account_id.as_str(),
+						&response::window_class_sql(mutation.window),
+						&duration,
+						&remaining,
+						&resets_at,
+						&mutation.observed_at.get(),
+						&response::confidence_sql(mutation.confidence),
+						&mutation.metadata,
+					],
+				)
+				.await?,
+		Some(expected) =>
+			transaction
+				.query_opt(
+					"UPDATE decodex.quota_windows SET remaining_percent=$4, \
+					 resets_at=CASE WHEN $5::bigint IS NULL THEN NULL ELSE \
+					  TIMESTAMPTZ '1970-01-01 00:00:00+00' + ($5::bigint / 1000000) * INTERVAL '1 second' \
+					  + ($5::bigint % 1000000) * INTERVAL '1 microsecond' END, \
+					 observed_at=TIMESTAMPTZ '1970-01-01 00:00:00+00' \
+					  + ($6::bigint / 1000000) * INTERVAL '1 second' \
+					  + ($6::bigint % 1000000) * INTERVAL '1 microsecond', \
+					 confidence=$7::text::decodex.observation_confidence, \
+					 metadata=$8,revision=revision+1,updated_at=clock_timestamp() \
+					 WHERE account_id=$1::text::uuid \
+					 AND window_class=$2::text::decodex.quota_window_class \
+					 AND duration_minutes=$3 AND revision=$9 \
+					 AND observed_at <= TIMESTAMPTZ '1970-01-01 00:00:00+00' \
+					  + ($6::bigint / 1000000) * INTERVAL '1 second' \
+					  + ($6::bigint % 1000000) * INTERVAL '1 microsecond' \
+					 RETURNING revision",
+					&[
+						&mutation.account_id.as_str(),
+						&response::window_class_sql(mutation.window),
+						&duration,
+						&remaining,
+						&resets_at,
+						&mutation.observed_at.get(),
+						&response::confidence_sql(mutation.confidence),
+						&mutation.metadata,
+						&expected,
+					],
+				)
+				.await?,
+	};
+	let Some(row) = row else {
+		return Err(window_write_error(transaction, mutation).await?);
+	};
+
+	Ok(QuotaWindow {
+		account_id: mutation.account_id.clone(),
+		window: mutation.window,
+		remaining_percent: mutation.remaining_percent,
+		resets_at: mutation.resets_at,
+		observed_at: mutation.observed_at,
+		confidence: mutation.confidence,
+		metadata: mutation.metadata.clone(),
+		revision: row.get(0),
+	})
+}
+
+async fn window_write_error(
+	transaction: &Transaction<'_>,
+	mutation: &QuotaWindowMutation,
+) -> Result<StoreError, StoreError> {
+	let row = transaction
+		.query_opt(
+			"SELECT revision, observed_at > TIMESTAMPTZ '1970-01-01 00:00:00+00' \
+			  + ($4::bigint / 1000000) * INTERVAL '1 second' \
+			  + ($4::bigint % 1000000) * INTERVAL '1 microsecond' \
+			 FROM decodex.quota_windows \
+			 WHERE account_id=$1::text::uuid \
+			 AND window_class=$2::text::decodex.quota_window_class AND duration_minutes=$3",
+			&[
+				&mutation.account_id.as_str(),
+				&response::window_class_sql(mutation.window),
+				&i16::try_from(mutation.window.duration_minutes())
+					.expect("closed quota durations fit PostgreSQL smallint"),
+				&mutation.observed_at.get(),
+			],
+		)
+		.await?;
+
+	if let Some(row) = &row
+		&& mutation.expected_revision == Some(row.get(0))
+		&& row.get::<_, bool>(1)
+	{
+		return Ok(StoreError::InvalidInput("quota observation cannot move backward in time"));
+	}
+
+	Ok(StoreError::RevisionConflict {
+		entity: format!(
+			"quota_window/{}:{}",
+			mutation.account_id,
+			response::window_class_sql(mutation.window)
+		),
+		expected: mutation.expected_revision,
+		actual: row.map(|row| row.get(0)),
+	})
+}
+
+async fn insert_exclusion(
+	transaction: &Transaction<'_>,
+	mutation: &QuotaExclusionMutation,
+	window: &QuotaWindow,
+	identity: &CanonicalMutationIdentity,
+) -> Result<bool, StoreError> {
+	let inserted = transaction
+		.execute(
+			"INSERT INTO decodex.quota_exclusions \
+			 (account_id,window_class,duration_minutes,observation_revision,remaining_percent, \
+			  confidence,observation_metadata,observed_at_micros,resets_at_micros, \
+			  excluded_at_micros,maximum_age_micros,mutation_sha256,mutation_length) \
+			 VALUES ($1::text::uuid,$2::text::decodex.quota_window_class,$3,$4,$5, \
+			  $6::text::decodex.observation_confidence,$7,$8,$9,$10,$11,$12,$13) \
+			 ON CONFLICT DO NOTHING",
+			&[
+				&mutation.observation.account_id.as_str(),
+				&response::window_class_sql(mutation.observation.window),
+				&i16::try_from(mutation.observation.window.duration_minutes())
+					.expect("closed quota durations fit PostgreSQL smallint"),
+				&window.revision,
+				&i16::from(
+					mutation
+						.observation
+						.remaining_percent
+						.expect("validated exclusion has remaining evidence")
+						.get(),
+				),
+				&response::confidence_sql(mutation.observation.confidence),
+				&mutation.observation.metadata,
+				&mutation.observation.observed_at.get(),
+				&mutation
+					.observation
+					.resets_at
+					.expect("validated exclusion has reset evidence")
+					.get(),
+				&mutation.excluded_at.get(),
+				&i64::try_from(MAXIMUM_OBSERVATION_AGE_MICROS)
+					.expect("maximum age fits PostgreSQL bigint"),
+				&identity.sha256,
+				&identity.length,
+			],
+		)
+		.await?;
+
+	if inserted == 1 {
+		return Ok(true);
+	}
+
+	let matching: bool = transaction
+		.query_one(
+			"SELECT mutation_sha256=$5 AND mutation_length=$6 \
+			 FROM decodex.quota_exclusions WHERE account_id=$1::text::uuid \
+			 AND window_class=$2::text::decodex.quota_window_class \
+			 AND duration_minutes=$3 AND observation_revision=$4",
+			&[
+				&mutation.observation.account_id.as_str(),
+				&response::window_class_sql(mutation.observation.window),
+				&i16::try_from(mutation.observation.window.duration_minutes())
+					.expect("closed quota durations fit PostgreSQL smallint"),
+				&window.revision,
+				&identity.sha256,
+				&identity.length,
+			],
+		)
+		.await?
+		.get(0);
+
+	if matching { Ok(false) } else { Err(StoreError::IdempotencyConflict) }
+}
+
+#[cfg(test)] mod tests;

--- a/crates/decodex-postgres/src/quota/identity.rs
+++ b/crates/decodex-postgres/src/quota/identity.rs
@@ -1,0 +1,124 @@
+use serde_json::{Map, Value};
+use sha2::{Digest as _, Sha256};
+
+use crate::{
+	CommandIdentity, QuotaExclusionMutation, QuotaTimestampMicros, QuotaWindowMutation, StoreError,
+	accounts::CommandDescriptor,
+	quota::{response, validation},
+};
+use decodex_core::RemainingPercent;
+
+const QUOTA_WINDOW_SCHEMA: &str = "decodex/quota-window-mutation/2";
+const QUOTA_EXCLUSION_SCHEMA: &str = "decodex/quota-exclusion-mutation/2";
+
+pub(super) struct CanonicalMutationIdentity {
+	pub(super) sha256: String,
+	pub(super) length: i64,
+}
+
+pub(super) fn quota_window_mutation_identity(
+	mutation: &QuotaWindowMutation,
+) -> Result<CanonicalMutationIdentity, StoreError> {
+	canonical_mutation_identity(&quota_window_mutation_document(mutation))
+}
+
+pub(super) fn quota_exclusion_mutation_identity(
+	mutation: &QuotaExclusionMutation,
+) -> Result<CanonicalMutationIdentity, StoreError> {
+	canonical_mutation_identity(&serde_json::json!({
+		"schema": QUOTA_EXCLUSION_SCHEMA,
+		"observation": quota_window_mutation_document(&mutation.observation),
+		"excluded_at_micros": mutation.excluded_at.get(),
+		"maximum_age_micros": validation::MAXIMUM_OBSERVATION_AGE_MICROS,
+	}))
+}
+
+pub(super) fn quota_window_mutation_document(mutation: &QuotaWindowMutation) -> Value {
+	serde_json::json!({
+		"schema": QUOTA_WINDOW_SCHEMA,
+		"account_id": mutation.account_id.as_str(),
+		"window_class": response::window_class_sql(mutation.window),
+		"duration_minutes": mutation.window.duration_minutes(),
+		"remaining_percent": mutation.remaining_percent.map(RemainingPercent::get),
+		"resets_at_micros": mutation.resets_at.map(QuotaTimestampMicros::get),
+		"observed_at_micros": mutation.observed_at.get(),
+		"confidence": response::confidence_sql(mutation.confidence),
+		"metadata": mutation.metadata,
+		"expected_revision": mutation.expected_revision,
+	})
+}
+
+pub(super) fn canonical_mutation_identity(
+	document: &Value,
+) -> Result<CanonicalMutationIdentity, StoreError> {
+	let bytes = canonical_mutation_bytes(document)?;
+	let length = i64::try_from(bytes.len())
+		.map_err(|_| StoreError::InvalidInput("quota mutation is too large"))?;
+	let sha256 = Sha256::digest(&bytes).iter().map(|byte| format!("{byte:02x}")).collect();
+
+	Ok(CanonicalMutationIdentity { sha256, length })
+}
+
+pub(super) fn canonical_mutation_bytes(document: &Value) -> Result<Vec<u8>, StoreError> {
+	serde_json::to_vec(&canonical_json(document))
+		.map_err(|_| StoreError::InvalidInput("quota mutation cannot be serialized"))
+}
+
+pub(super) fn canonical_json(value: &Value) -> Value {
+	match value {
+		Value::Array(values) => Value::Array(values.iter().map(canonical_json).collect()),
+		Value::Object(document) => {
+			let mut entries = document.iter().collect::<Vec<_>>();
+
+			entries.sort_unstable_by(|(left, _), (right, _)| left.as_bytes().cmp(right.as_bytes()));
+
+			Value::Object(
+				entries
+					.into_iter()
+					.map(|(key, value)| (key.clone(), canonical_json(value)))
+					.collect::<Map<_, _>>(),
+			)
+		},
+		Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => value.clone(),
+	}
+}
+
+pub(super) fn derived_command(
+	command: &CommandIdentity,
+	identity: &CanonicalMutationIdentity,
+) -> CommandIdentity {
+	CommandIdentity { key: command.key.clone(), request_hash: identity.sha256.clone() }
+}
+
+pub(super) fn command_descriptor(
+	operation: &'static str,
+	mutation: &QuotaWindowMutation,
+	identity: &CanonicalMutationIdentity,
+) -> CommandDescriptor {
+	CommandDescriptor {
+		protocol_version: "decodex/store-command/1",
+		operation,
+		project_scope: "global",
+		scope_id: "quota_windows".into(),
+		entity_id: response::quota_aggregate_id(mutation),
+		expected_revision: mutation.expected_revision,
+		payload_hash: Some(identity.sha256.clone()),
+		payload_length: Some(identity.length),
+	}
+}
+
+pub(super) fn exclusion_command_descriptor(
+	mutation: &QuotaExclusionMutation,
+	identity: &CanonicalMutationIdentity,
+) -> CommandDescriptor {
+	CommandDescriptor {
+		protocol_version: "decodex/store-command/1",
+		operation: "persist_quota_exclusion",
+		project_scope: "global",
+		scope_id: "quota_exclusions".into(),
+		entity_id: response::quota_aggregate_id(&mutation.observation),
+		expected_revision: mutation.observation.expected_revision,
+		payload_hash: Some(identity.sha256.clone()),
+		payload_length: Some(identity.length),
+	}
+}

--- a/crates/decodex-postgres/src/quota/response.rs
+++ b/crates/decodex-postgres/src/quota/response.rs
@@ -1,0 +1,215 @@
+use serde_json::Value;
+
+use crate::{
+	AccountId, HypotheticalFallbackFact, QuotaExclusionMutation, QuotaExclusionReceipt,
+	QuotaTimestampMicros, QuotaWindow, QuotaWindowMutation, StoreError,
+	quota::identity::CanonicalMutationIdentity,
+};
+use decodex_core::{ObservationConfidence, QuotaWindowClass, RemainingPercent};
+
+pub(super) fn exclusion_receipt(
+	mutation: &QuotaExclusionMutation,
+	revision: i64,
+	identity: &CanonicalMutationIdentity,
+) -> Result<QuotaExclusionReceipt, StoreError> {
+	Ok(QuotaExclusionReceipt {
+		account_id: mutation.observation.account_id.clone(),
+		window: mutation.observation.window,
+		observation_revision: revision,
+		remaining_percent: mutation
+			.observation
+			.remaining_percent
+			.ok_or(StoreError::InvalidInput("quota exclusion lost remaining evidence"))?,
+		resets_at: mutation
+			.observation
+			.resets_at
+			.ok_or(StoreError::InvalidInput("quota exclusion lost reset evidence"))?,
+		observed_at: mutation.observation.observed_at,
+		excluded_at: mutation.excluded_at,
+		confidence: mutation.observation.confidence,
+		metadata: mutation.observation.metadata.clone(),
+		mutation_sha256: identity.sha256.clone(),
+		mutation_length: identity.length,
+		hypothetical_fallback: HypotheticalFallbackFact,
+	})
+}
+
+pub(super) fn window_response(window: &QuotaWindow) -> Value {
+	serde_json::json!({
+		"kind": "quota_window",
+		"account_id": window.account_id.as_str(),
+		"window_class": window_class_sql(window.window),
+		"duration_minutes": window.window.duration_minutes(),
+		"remaining_percent": window.remaining_percent.map(RemainingPercent::get),
+		"resets_at_micros": window.resets_at.map(QuotaTimestampMicros::get),
+		"observed_at_micros": window.observed_at.get(),
+		"confidence": confidence_sql(window.confidence),
+		"metadata": window.metadata,
+		"revision": window.revision,
+	})
+}
+
+pub(super) fn exclusion_response(receipt: &QuotaExclusionReceipt) -> Value {
+	serde_json::json!({
+		"kind": "quota_exclusion",
+		"account_id": receipt.account_id.as_str(),
+		"window_class": window_class_sql(receipt.window),
+		"duration_minutes": receipt.window.duration_minutes(),
+		"observation_revision": receipt.observation_revision,
+		"remaining_percent": receipt.remaining_percent.get(),
+		"resets_at_micros": receipt.resets_at.get(),
+		"observed_at_micros": receipt.observed_at.get(),
+		"excluded_at_micros": receipt.excluded_at.get(),
+		"confidence": confidence_sql(receipt.confidence),
+		"metadata": receipt.metadata,
+		"mutation_sha256": receipt.mutation_sha256,
+		"mutation_length": receipt.mutation_length,
+		"dispatch_enabled": receipt.hypothetical_fallback.dispatch_enabled(),
+	})
+}
+
+pub(super) fn window_from_response(response: Value) -> Result<QuotaWindow, StoreError> {
+	if response.get("kind").and_then(Value::as_str) != Some("quota_window") {
+		return Err(StoreError::IdempotencyConflict);
+	}
+
+	Ok(QuotaWindow {
+		account_id: stored_account_id(required_str(&response, "account_id")?)?,
+		window: window_class_from_sql(required_str(&response, "window_class")?)?,
+		remaining_percent: optional_remaining(&response, "remaining_percent")?,
+		resets_at: optional_timestamp(&response, "resets_at_micros")?,
+		observed_at: required_timestamp(&response, "observed_at_micros")?,
+		confidence: confidence_from_sql(required_str(&response, "confidence")?)?,
+		metadata: required_value(&response, "metadata")?,
+		revision: required_i64(&response, "revision")?,
+	})
+}
+
+pub(super) fn exclusion_from_response(
+	response: Value,
+) -> Result<QuotaExclusionReceipt, StoreError> {
+	if response.get("kind").and_then(Value::as_str) != Some("quota_exclusion")
+		|| response.get("dispatch_enabled").and_then(Value::as_bool) != Some(false)
+	{
+		return Err(StoreError::IdempotencyConflict);
+	}
+
+	Ok(QuotaExclusionReceipt {
+		account_id: stored_account_id(required_str(&response, "account_id")?)?,
+		window: window_class_from_sql(required_str(&response, "window_class")?)?,
+		observation_revision: required_i64(&response, "observation_revision")?,
+		remaining_percent: required_remaining(&response, "remaining_percent")?,
+		resets_at: required_timestamp(&response, "resets_at_micros")?,
+		observed_at: required_timestamp(&response, "observed_at_micros")?,
+		excluded_at: required_timestamp(&response, "excluded_at_micros")?,
+		confidence: confidence_from_sql(required_str(&response, "confidence")?)?,
+		metadata: required_value(&response, "metadata")?,
+		mutation_sha256: required_str(&response, "mutation_sha256")?.to_owned(),
+		mutation_length: required_i64(&response, "mutation_length")?,
+		hypothetical_fallback: HypotheticalFallbackFact,
+	})
+}
+
+pub(super) fn quota_aggregate_id(mutation: &QuotaWindowMutation) -> String {
+	format!("{}:{}", mutation.account_id, window_class_sql(mutation.window))
+}
+
+pub(super) const fn window_class_sql(window: QuotaWindowClass) -> &'static str {
+	match window {
+		QuotaWindowClass::FiveHour => "five_hour",
+		QuotaWindowClass::SevenDay => "seven_day",
+	}
+}
+
+pub(super) const fn confidence_sql(confidence: ObservationConfidence) -> &'static str {
+	match confidence {
+		ObservationConfidence::Unknown => "unknown",
+		ObservationConfidence::Low => "low",
+		ObservationConfidence::High => "high",
+	}
+}
+
+fn window_class_from_sql(value: &str) -> Result<QuotaWindowClass, StoreError> {
+	match value {
+		"five_hour" => Ok(QuotaWindowClass::FiveHour),
+		"seven_day" => Ok(QuotaWindowClass::SevenDay),
+		_ => Err(StoreError::Incompatible("stored quota window class is invalid".into())),
+	}
+}
+
+fn confidence_from_sql(value: &str) -> Result<ObservationConfidence, StoreError> {
+	match value {
+		"unknown" => Ok(ObservationConfidence::Unknown),
+		"low" => Ok(ObservationConfidence::Low),
+		"high" => Ok(ObservationConfidence::High),
+		_ => Err(StoreError::Incompatible("stored quota confidence is invalid".into())),
+	}
+}
+
+fn required_str<'a>(value: &'a Value, key: &str) -> Result<&'a str, StoreError> {
+	value
+		.get(key)
+		.and_then(Value::as_str)
+		.ok_or_else(|| StoreError::Incompatible(format!("quota response missing {key}")))
+}
+
+fn required_i64(value: &Value, key: &str) -> Result<i64, StoreError> {
+	value
+		.get(key)
+		.and_then(Value::as_i64)
+		.ok_or_else(|| StoreError::Incompatible(format!("quota response missing {key}")))
+}
+
+fn required_value(value: &Value, key: &str) -> Result<Value, StoreError> {
+	value
+		.get(key)
+		.cloned()
+		.ok_or_else(|| StoreError::Incompatible(format!("quota response missing {key}")))
+}
+
+fn required_timestamp(value: &Value, key: &str) -> Result<QuotaTimestampMicros, StoreError> {
+	QuotaTimestampMicros::new(required_i64(value, key)?)
+		.map_err(|_| StoreError::Incompatible(format!("quota response has invalid {key}")))
+}
+
+fn optional_timestamp(
+	value: &Value,
+	key: &str,
+) -> Result<Option<QuotaTimestampMicros>, StoreError> {
+	match value.get(key) {
+		Some(Value::Null) => Ok(None),
+		Some(value) => value
+			.as_i64()
+			.ok_or_else(|| StoreError::Incompatible(format!("quota response has invalid {key}")))
+			.and_then(|value| {
+				QuotaTimestampMicros::new(value).map(Some).map_err(|_| {
+					StoreError::Incompatible(format!("quota response has invalid {key}"))
+				})
+			}),
+		None => Err(StoreError::Incompatible(format!("quota response missing {key}"))),
+	}
+}
+
+fn required_remaining(value: &Value, key: &str) -> Result<RemainingPercent, StoreError> {
+	let raw = value
+		.get(key)
+		.and_then(Value::as_u64)
+		.and_then(|value| u16::try_from(value).ok())
+		.ok_or_else(|| StoreError::Incompatible(format!("quota response has invalid {key}")))?;
+
+	RemainingPercent::new(raw)
+		.map_err(|_| StoreError::Incompatible(format!("quota response has invalid {key}")))
+}
+
+fn optional_remaining(value: &Value, key: &str) -> Result<Option<RemainingPercent>, StoreError> {
+	match value.get(key) {
+		Some(Value::Null) => Ok(None),
+		Some(_) => required_remaining(value, key).map(Some),
+		None => Err(StoreError::Incompatible(format!("quota response missing {key}"))),
+	}
+}
+
+fn stored_account_id(value: impl Into<String>) -> Result<AccountId, StoreError> {
+	AccountId::new(value)
+		.map_err(|_| StoreError::Incompatible("stored account identity is invalid".into()))
+}

--- a/crates/decodex-postgres/src/quota/tests.rs
+++ b/crates/decodex-postgres/src/quota/tests.rs
@@ -1,0 +1,262 @@
+#![cfg(test)]
+
+use serde_json::Value;
+
+use crate::{
+	AccountId, QuotaExclusionMutation, QuotaTimestampMicros, QuotaWindowMutation, StoreError,
+	quota::{identity, validation},
+};
+use decodex_core::{ObservationConfidence, QuotaWindowClass, RemainingPercent};
+
+#[test]
+fn authoritative_operation_result_precedes_every_cleanup_outcome() {
+	let successful_operation = || Ok::<_, StoreError>(41);
+	let failed_operation =
+		|| Err::<u8, _>(StoreError::InvalidInput("authoritative operation failed"));
+	let successful_cleanup = || Ok::<_, StoreError>(());
+	let failed_cleanup = || Err::<(), _>(StoreError::CapacityExhausted("advisory unlock failed"));
+
+	assert_eq!(
+		super::operation_result_precedes_cleanup(successful_operation(), successful_cleanup())
+			.unwrap(),
+		41
+	);
+	assert_eq!(
+		super::operation_result_precedes_cleanup(successful_operation(), failed_cleanup()).unwrap(),
+		41
+	);
+	assert!(matches!(
+		super::operation_result_precedes_cleanup(failed_operation(), successful_cleanup()),
+		Err(StoreError::InvalidInput("authoritative operation failed"))
+	));
+	assert!(matches!(
+		super::operation_result_precedes_cleanup(failed_operation(), failed_cleanup()),
+		Err(StoreError::InvalidInput("authoritative operation failed"))
+	));
+}
+
+fn timestamp(value: i64) -> QuotaTimestampMicros {
+	QuotaTimestampMicros::new(value).expect("test timestamp is valid")
+}
+
+fn mutation(metadata: Value) -> QuotaWindowMutation {
+	QuotaWindowMutation {
+		account_id: AccountId::new("10000000-0000-4000-8000-000000000001")
+			.expect("test account identity is valid"),
+		window: QuotaWindowClass::FiveHour,
+		remaining_percent: Some(RemainingPercent::new(0).expect("zero is valid")),
+		resets_at: Some(timestamp(1_800_000_000_000_000)),
+		observed_at: timestamp(1_700_000_000_000_000),
+		confidence: ObservationConfidence::High,
+		metadata,
+		expected_revision: Some(4),
+	}
+}
+
+#[test]
+fn exact_rfc3339_ingress_normalizes_offsets_without_quantization() {
+	let utc = super::parse_quota_timestamp_rfc3339("2026-07-16T10:30:00.123456Z").unwrap();
+	let offset = super::parse_quota_timestamp_rfc3339("2026-07-16T06:30:00.123456-04:00").unwrap();
+	let lowercase = super::parse_quota_timestamp_rfc3339("2026-07-16t10:30:00.123456z").unwrap();
+
+	assert_eq!(utc, offset);
+	assert_eq!(utc, lowercase);
+	assert_eq!(QuotaTimestampMicros::new(0).unwrap().get(), 0);
+	assert_eq!(super::parse_quota_timestamp_rfc3339("1970-01-01T00:00:00Z").unwrap().get(), 0);
+	assert_eq!(
+		QuotaTimestampMicros::new(QuotaTimestampMicros::MAX).unwrap().get(),
+		QuotaTimestampMicros::MAX
+	);
+	assert_eq!(
+		super::parse_quota_timestamp_rfc3339("9999-12-31T23:59:59.999999Z").unwrap().get(),
+		QuotaTimestampMicros::MAX
+	);
+
+	for invalid in [
+		"2026-07-16T10:30:00.1234567Z",
+		"9999-12-31T23:59:59.9999995Z",
+		"9999-12-31T23:59:59.999999-00:01",
+		"1969-12-31T23:59:59.999999Z",
+		"1970-01-01T00:00:00+00:01",
+		"10000-01-01T00:00:00Z",
+		"2026-12-31T23:59:60Z",
+		"infinity",
+		"2026-07-16 10:30:00Z",
+	] {
+		assert!(super::parse_quota_timestamp_rfc3339(invalid).is_err(), "{invalid}");
+	}
+
+	assert!(QuotaTimestampMicros::new(-1).is_err());
+	assert!(QuotaTimestampMicros::new(QuotaTimestampMicros::MAX + 1).is_err());
+}
+
+#[test]
+fn freshness_is_exact_in_integer_microseconds() {
+	let observed = timestamp(1_700_000_000_000_000);
+
+	for age in [0, 299_999_999, 300_000_000] {
+		assert_eq!(
+			timestamp(observed.get() + age).checked_duration_since(observed).unwrap(),
+			age as u64
+		);
+	}
+
+	assert_eq!(
+		timestamp(observed.get() + 300_000_001).checked_duration_since(observed).unwrap(),
+		300_000_001
+	);
+	assert!(observed.checked_duration_since(timestamp(observed.get() + 1)).is_err());
+
+	for age in [0, 299_999_999, 300_000_000] {
+		let exclusion = QuotaExclusionMutation {
+			observation: mutation(serde_json::json!({})),
+			excluded_at: timestamp(observed.get() + age),
+		};
+
+		assert!(validation::validate_exclusion(&exclusion).is_ok(), "age {age}");
+	}
+
+	let stale = QuotaExclusionMutation {
+		observation: mutation(serde_json::json!({})),
+		excluded_at: timestamp(observed.get() + 300_000_001),
+	};
+
+	assert!(matches!(validation::validate_exclusion(&stale), Err(StoreError::InvalidInput(_))));
+	assert_eq!(
+		timestamp(QuotaTimestampMicros::MAX).checked_duration_since(timestamp(0)).unwrap(),
+		QuotaTimestampMicros::MAX as u64
+	);
+}
+
+#[test]
+fn canonical_identity_recursively_sorts_objects_and_preserves_value_distinctions() {
+	let first = mutation(
+		serde_json::from_str(r#"{"z":{"beta":2,"alpha":1},"array":[{"d":4,"c":3},true]}"#).unwrap(),
+	);
+	let reordered = mutation(
+		serde_json::from_str(r#"{"array":[{"c":3,"d":4},true],"z":{"alpha":1,"beta":2}}"#).unwrap(),
+	);
+	let first_identity = identity::quota_window_mutation_identity(&first).unwrap();
+	let reordered_identity = identity::quota_window_mutation_identity(&reordered).unwrap();
+	let canonical = String::from_utf8(
+		identity::canonical_mutation_bytes(&identity::quota_window_mutation_document(&first))
+			.unwrap(),
+	)
+	.unwrap();
+
+	assert_eq!(first_identity.sha256, reordered_identity.sha256);
+	assert_eq!(first_identity.length, reordered_identity.length);
+	assert_eq!(
+		first_identity.sha256,
+		"02a31a80e82869eabd247007781a5eb5fadb2c0d259ef04f293bf8c3b69ace15"
+	);
+	assert_eq!(first_identity.length, 351);
+	assert_eq!(
+		canonical,
+		r#"{"account_id":"10000000-0000-4000-8000-000000000001","confidence":"high","duration_minutes":300,"expected_revision":4,"metadata":{"array":[{"c":3,"d":4},true],"z":{"alpha":1,"beta":2}},"observed_at_micros":1700000000000000,"remaining_percent":0,"resets_at_micros":1800000000000000,"schema":"decodex/quota-window-mutation/2","window_class":"five_hour"}"#
+	);
+
+	for metadata in [
+		serde_json::json!({"array": [true, {"c": 3, "d": 4}], "z": {"alpha": 1, "beta": 2}}),
+		serde_json::json!({"array": [{"c": "3", "d": 4}, true], "z": {"alpha": 1, "beta": 2}}),
+		serde_json::json!({"array": [{"c": 3.0, "d": 4}, true], "z": {"alpha": 1, "beta": 2}}),
+	] {
+		assert_ne!(
+			identity::quota_window_mutation_identity(&mutation(metadata)).unwrap().sha256,
+			first_identity.sha256
+		);
+	}
+}
+
+#[test]
+fn canonical_identity_changes_for_every_authoritative_field() {
+	let first = mutation(
+		serde_json::from_str(r#"{"z":{"beta":2,"alpha":1},"array":[{"d":4,"c":3},true]}"#)
+			.expect("canonical identity fixture is valid JSON"),
+	);
+	let first_identity = identity::quota_window_mutation_identity(&first)
+		.expect("canonical identity fixture is valid");
+	let original = first_identity.sha256;
+	let mut variants = Vec::new();
+	let mut changed = first.clone();
+
+	changed.account_id = AccountId::new("10000000-0000-4000-8000-000000000002").unwrap();
+
+	variants.push(changed);
+
+	let mut changed = first.clone();
+
+	changed.window = QuotaWindowClass::SevenDay;
+
+	variants.push(changed);
+
+	let mut changed = first.clone();
+
+	changed.remaining_percent = Some(RemainingPercent::new(1).unwrap());
+
+	variants.push(changed);
+
+	let mut changed = first.clone();
+
+	changed.resets_at = Some(timestamp(1_800_000_000_000_001));
+
+	variants.push(changed);
+
+	let mut changed = first.clone();
+
+	changed.observed_at = timestamp(1_700_000_000_000_001);
+
+	variants.push(changed);
+
+	let mut changed = first.clone();
+
+	changed.confidence = ObservationConfidence::Low;
+
+	variants.push(changed);
+
+	let mut changed = first.clone();
+
+	changed.metadata = serde_json::json!({"changed": true});
+
+	variants.push(changed);
+
+	let mut changed = first.clone();
+
+	changed.expected_revision = Some(5);
+
+	variants.push(changed);
+
+	let exclusion = QuotaExclusionMutation {
+		observation: first,
+		excluded_at: timestamp(1_700_000_300_000_000),
+	};
+	let exclusion_identity = identity::quota_exclusion_mutation_identity(&exclusion).unwrap();
+
+	for changed in variants {
+		assert_ne!(identity::quota_window_mutation_identity(&changed).unwrap().sha256, original);
+		assert_ne!(
+			identity::quota_exclusion_mutation_identity(&QuotaExclusionMutation {
+				observation: changed,
+				excluded_at: exclusion.excluded_at,
+			})
+			.unwrap()
+			.sha256,
+			exclusion_identity.sha256
+		);
+	}
+
+	assert_eq!(
+		exclusion_identity.sha256,
+		"01aa6017334f2e612bb3988a0868aadf915f16cb57ff668e9ae448c0c2f210f4"
+	);
+	assert_eq!(exclusion_identity.length, 482);
+
+	let mut changed_exclusion = exclusion;
+
+	changed_exclusion.excluded_at = timestamp(1_700_000_299_999_999);
+
+	assert_ne!(
+		identity::quota_exclusion_mutation_identity(&changed_exclusion).unwrap().sha256,
+		exclusion_identity.sha256
+	);
+}

--- a/crates/decodex-postgres/src/quota/validation.rs
+++ b/crates/decodex-postgres/src/quota/validation.rs
@@ -1,0 +1,75 @@
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::{QuotaExclusionMutation, QuotaTimestampMicros, QuotaWindowMutation, StoreError};
+use decodex_core::ObservationConfidence;
+
+pub(super) const MAXIMUM_OBSERVATION_AGE_MICROS: u64 = 300_000_000;
+
+/// Parse raw RFC 3339 ingress without rounding or truncation.
+pub fn parse_quota_timestamp_rfc3339(value: &str) -> Result<QuotaTimestampMicros, StoreError> {
+	if !matches!(value.as_bytes().get(10), Some(b'T' | b't')) {
+		return Err(StoreError::InvalidInput("quota timestamp must be exact RFC 3339"));
+	}
+
+	let parsed = OffsetDateTime::parse(value, &Rfc3339)
+		.map_err(|_| StoreError::InvalidInput("quota timestamp must be exact RFC 3339"))?;
+	let nanos = parsed.unix_timestamp_nanos();
+
+	if nanos % 1_000 != 0 {
+		return Err(StoreError::InvalidInput(
+			"quota timestamp must be exactly microsecond aligned",
+		));
+	}
+
+	let micros = nanos / 1_000;
+	let value = i64::try_from(micros)
+		.map_err(|_| StoreError::InvalidInput("quota timestamp is outside the product range"))?;
+
+	QuotaTimestampMicros::new(value)
+}
+
+pub(super) fn validate_window(mutation: &QuotaWindowMutation) -> Result<(), StoreError> {
+	if mutation.expected_revision.is_some_and(|revision| revision < 1) {
+		return Err(StoreError::InvalidInput("expected revision must be positive"));
+	}
+	if mutation.resets_at.is_some_and(|reset| reset < mutation.observed_at) {
+		return Err(StoreError::InvalidInput("quota reset precedes its observation"));
+	}
+
+	crate::ensure_credential_negative_json(&mutation.metadata)
+}
+
+pub(super) fn validate_exclusion(mutation: &QuotaExclusionMutation) -> Result<(), StoreError> {
+	validate_window(&mutation.observation)?;
+
+	let Some(remaining) = mutation.observation.remaining_percent else {
+		return Err(StoreError::InvalidInput(
+			"quota exclusion requires a known remaining percentage",
+		));
+	};
+
+	if !remaining.is_depleted() {
+		return Err(StoreError::InvalidInput("quota exclusion requires a depleted observation"));
+	}
+	if mutation.observation.confidence != ObservationConfidence::High {
+		return Err(StoreError::InvalidInput("quota exclusion requires high-confidence evidence"));
+	}
+
+	let Some(reset) = mutation.observation.resets_at else {
+		return Err(StoreError::InvalidInput("quota exclusion requires an exact reset"));
+	};
+
+	if reset <= mutation.excluded_at {
+		return Err(StoreError::InvalidInput("quota exclusion reset must remain in the future"));
+	}
+
+	let age = mutation.excluded_at.checked_duration_since(mutation.observation.observed_at)?;
+
+	if age > MAXIMUM_OBSERVATION_AGE_MICROS {
+		return Err(StoreError::InvalidInput(
+			"quota exclusion requires an observation no more than 300 seconds old",
+		));
+	}
+
+	Ok(())
+}

--- a/crates/decodex-postgres/src/types.rs
+++ b/crates/decodex-postgres/src/types.rs
@@ -4,7 +4,10 @@ use serde_json::Value;
 use sha2::{Digest as _, Sha256};
 
 use crate::StoreError;
-use decodex_core::{AccountId, AccountState, Agent, Project};
+use decodex_core::{
+	AccountId, AccountState, Agent, ObservationConfidence, Project, QuotaWindowClass,
+	RemainingPercent,
+};
 
 /// Transactional creation input for one Project and its canonical Lead.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -65,50 +68,126 @@ impl Debug for AccountMetadata {
 	}
 }
 
-/// Idempotent optimistic quota-window metadata mutation.
-#[derive(Clone, Debug)]
+/// Exact UTC Unix-microsecond timestamp accepted by quota storage.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct QuotaTimestampMicros(i64);
+impl QuotaTimestampMicros {
+	/// Unix epoch through the final microsecond of year 9999.
+	pub const MAX: i64 = 253_402_300_799_999_999;
+
+	/// Construct an exact product-valid timestamp without normalization.
+	pub const fn new(value: i64) -> Result<Self, StoreError> {
+		if value < 0 || value > Self::MAX {
+			Err(StoreError::InvalidInput("quota timestamp is outside the product range"))
+		} else {
+			Ok(Self(value))
+		}
+	}
+
+	/// Return the canonical UTC Unix-microsecond value.
+	pub const fn get(self) -> i64 {
+		self.0
+	}
+
+	/// Compute a nonnegative elapsed duration without wrapping.
+	pub const fn checked_duration_since(self, earlier: Self) -> Result<u64, StoreError> {
+		match self.0.checked_sub(earlier.0) {
+			Some(value) if value >= 0 => Ok(value as u64),
+			_ => Err(StoreError::InvalidInput(
+				"quota timestamp chronology is reversed or unrepresentable",
+			)),
+		}
+	}
+}
+
+/// Idempotent optimistic mutation of one duration-typed quota observation.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct QuotaWindowMutation {
 	/// Owning account.
 	pub account_id: AccountId,
-	/// Provider-independent window class such as `usage`.
-	pub window_class: String,
-	/// Exact duration, never inferred from primary/secondary position.
-	pub duration_seconds: i64,
-	/// Provider-reported remaining amount, when known.
-	pub remaining_amount: Option<f64>,
-	/// Provider reset timestamp as RFC 3339 text, when known.
-	pub resets_at: Option<String>,
-	/// Observation timestamp as RFC 3339 text.
-	pub observed_at: String,
-	/// Confidence in the observation in the closed range 0..=1.
-	pub confidence: f64,
+	/// Exact five-hour or seven-day duration identity.
+	pub window: QuotaWindowClass,
+	/// Provider-reported remaining percentage, when known.
+	pub remaining_percent: Option<RemainingPercent>,
+	/// Exact reset timestamp, when known.
+	pub resets_at: Option<QuotaTimestampMicros>,
+	/// Exact observation timestamp.
+	pub observed_at: QuotaTimestampMicros,
+	/// Closed confidence classification.
+	pub confidence: ObservationConfidence,
 	/// Ordinary credential-negative metadata.
 	pub metadata: Value,
 	/// `None` creates revision 1; `Some` updates only that exact revision.
 	pub expected_revision: Option<i64>,
 }
 
-/// Stored inert quota-window metadata readback.
-#[derive(Clone, Debug, PartialEq)]
+/// Stored inert quota-window observation readback.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct QuotaWindow {
 	/// Owning account.
 	pub account_id: AccountId,
-	/// Provider-independent window class.
-	pub window_class: String,
-	/// Exact duration.
-	pub duration_seconds: i64,
-	/// Provider-reported remaining amount.
-	pub remaining_amount: Option<f64>,
-	/// Provider reset timestamp.
-	pub resets_at: Option<String>,
-	/// Observation timestamp.
-	pub observed_at: String,
+	/// Exact duration-owned window identity.
+	pub window: QuotaWindowClass,
+	/// Provider-reported remaining percentage.
+	pub remaining_percent: Option<RemainingPercent>,
+	/// Exact reset timestamp.
+	pub resets_at: Option<QuotaTimestampMicros>,
+	/// Exact observation timestamp.
+	pub observed_at: QuotaTimestampMicros,
 	/// Observation confidence.
-	pub confidence: f64,
+	pub confidence: ObservationConfidence,
 	/// Ordinary metadata.
 	pub metadata: Value,
 	/// Monotonic optimistic revision.
 	pub revision: i64,
+}
+
+/// One exact depleted observation to exclude inertly.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QuotaExclusionMutation {
+	/// Observation committed by the same transaction as the exclusion.
+	pub observation: QuotaWindowMutation,
+	/// Exact command time used for freshness and reset checks.
+	pub excluded_at: QuotaTimestampMicros,
+}
+
+/// Mechanically inert hypothetical fallback evidence.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HypotheticalFallbackFact;
+impl HypotheticalFallbackFact {
+	/// This persistence slice can never authorize dispatch.
+	pub const fn dispatch_enabled(self) -> bool {
+		false
+	}
+}
+
+/// Exact committed result of an inert exclusion transaction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QuotaExclusionReceipt {
+	/// Owning account.
+	pub account_id: AccountId,
+	/// Exact duration-owned window identity.
+	pub window: QuotaWindowClass,
+	/// Revision of the committed observation evidence.
+	pub observation_revision: i64,
+	/// Exact depleted amount.
+	pub remaining_percent: RemainingPercent,
+	/// Exact reset timestamp.
+	pub resets_at: QuotaTimestampMicros,
+	/// Exact observation timestamp.
+	pub observed_at: QuotaTimestampMicros,
+	/// Exact exclusion timestamp.
+	pub excluded_at: QuotaTimestampMicros,
+	/// Closed confidence classification.
+	pub confidence: ObservationConfidence,
+	/// Immutable credential-negative observation metadata.
+	pub metadata: Value,
+	/// Canonical `/2` mutation digest.
+	pub mutation_sha256: String,
+	/// Canonical `/2` mutation byte length.
+	pub mutation_length: i64,
+	/// Persisted fact that cannot authorize routing.
+	pub hypothetical_fallback: HypotheticalFallbackFact,
 }
 
 /// Caller-chosen idempotency key plus a stable hash of the logical request bytes.

--- a/crates/decodex-postgres/tests/postgres_store.rs
+++ b/crates/decodex-postgres/tests/postgres_store.rs
@@ -1,10 +1,12 @@
 //! Real PostgreSQL contract coverage for the XY-1267 persistence foundation.
 
+#[path = "postgres_store/quota.rs"] mod quota;
+
 use std::{
 	collections::{BTreeMap, HashSet},
 	env,
 	fs::{self, Permissions},
-	os::unix::fs::PermissionsExt as _,
+	os::unix::fs::PermissionsExt,
 	path::{Path, PathBuf},
 	str::FromStr as _,
 	time::Duration,
@@ -40,8 +42,7 @@ use decodex_postgres::{
 	CommandIdentity, ContextPackRecord, CreateArtifact, CreateConversation, CreateProject,
 	CreateRuntimeSession, HistoryCursor, MAX_OPERATION_DURATION_MILLISECONDS, OutboxClaim,
 	OutboxReconciliation, PersistContextPack, PostgresStore, ProposeTransition,
-	QuotaWindowMutation, ReconciliationOutcome, RecordHistoryItem, StoreError,
-	UpdateProgramContext,
+	ReconciliationOutcome, RecordHistoryItem, StoreError, UpdateProgramContext,
 };
 
 const ACCOUNT_ID: &str = "10000000-0000-0000-0000-000000000001";
@@ -311,6 +312,279 @@ async fn postgres_migration_contract() -> Result<(), Box<dyn std::error::Error>>
 	Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires an isolated PostgreSQL 18 schema-manifest database"]
+#[cfg(feature = "test-support")]
+async fn postgres_schema_manifest_dump_fixture() -> Result<(), Box<dyn std::error::Error>> {
+	let path = env::var("DECODEX_SCHEMA_MANIFEST_PATH")?;
+	let (migration, _) = separated_configs("DECODEX_TEST")?;
+	let (client, connection) = migration.connect(NoTls).await?;
+	let connection_task = tokio::spawn(connection);
+	let manifest: String =
+		client.query_one(PostgresStore::schema_contract_sql_fixture(), &[]).await?.get(0);
+
+	fs::write(path, manifest)?;
+
+	drop(client);
+
+	connection_task.await??;
+
+	Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a fresh isolated PostgreSQL 18 V8 migration database"]
+#[cfg(feature = "test-support")]
+async fn postgres_v8_empty_boundary_contract() -> Result<(), Box<dyn std::error::Error>> {
+	let (migration, _) = separated_configs("DECODEX_TEST")?;
+
+	PostgresStore::migrate_fixture_through_v7(migration.clone(), expected_peer_uid()).await?;
+
+	let (client, connection) = migration.clone().connect(NoTls).await?;
+	let connection_task = tokio::spawn(connection);
+	let before = quota_v7_identity(&client).await?;
+
+	PostgresStore::migrate(migration, expected_peer_uid()).await?;
+
+	assert_eq!(quota_v7_identity(&client).await?, before);
+
+	let row = client
+		.query_one(
+			"SELECT (SELECT count(*)=0 FROM decodex.quota_windows), \
+			 (SELECT count(*)=0 FROM decodex.quota_exclusions), \
+			 (SELECT data_type='USER-DEFINED' AND udt_name='quota_window_class' \
+			  FROM information_schema.columns WHERE table_schema='decodex' \
+			  AND table_name='quota_windows' AND column_name='window_class'), \
+			 (SELECT count(*)=8 FROM public.refinery_schema_history)",
+			&[],
+		)
+		.await?;
+
+	for index in 0..4 {
+		assert!(row.get::<_, bool>(index), "V8 empty-state assertion {index}");
+	}
+
+	drop(client);
+
+	connection_task.await??;
+
+	Ok(())
+}
+
+#[cfg(feature = "test-support")]
+async fn quota_v7_identity(
+	client: &Client,
+) -> Result<(u32, u32, u32, Option<String>), tokio_postgres::Error> {
+	let row = client
+		.query_one(
+			"SELECT 'decodex.quota_windows'::regclass::oid, \
+			 'decodex.quota_windows_observation_idx'::regclass::oid, \
+			 (SELECT oid FROM pg_constraint WHERE conrelid='decodex.quota_windows'::regclass \
+			  AND contype='f' AND confrelid='decodex.accounts'::regclass), \
+			 (SELECT relacl::text FROM pg_class WHERE oid='decodex.quota_windows'::regclass)",
+			&[],
+		)
+		.await?;
+
+	Ok((row.get(0), row.get(1), row.get(2), row.get(3)))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a fresh isolated PostgreSQL 18 V8 rejection database"]
+#[cfg(feature = "test-support")]
+async fn postgres_v8_rejects_classified_prior_state() -> Result<(), Box<dyn std::error::Error>> {
+	let variant = env::var("DECODEX_V8_PRIOR_STATE")?;
+	let (migration, _) = separated_configs("DECODEX_TEST")?;
+
+	PostgresStore::migrate_fixture_through_v7(migration.clone(), expected_peer_uid()).await?;
+
+	let (client, connection) = migration.clone().connect(NoTls).await?;
+	let connection_task = tokio::spawn(connection);
+
+	insert_v7_prior_state(&client, &variant).await?;
+
+	let error = PostgresStore::migrate(migration, expected_peer_uid())
+		.await
+		.expect_err("classified V7 state must reject V8 atomically");
+	let state = client
+		.query_one(
+			"SELECT (SELECT count(*)=7 FROM public.refinery_schema_history), \
+			 to_regclass('decodex.quota_exclusions') IS NULL, \
+			 (SELECT data_type='text' FROM information_schema.columns \
+			  WHERE table_schema='decodex' AND table_name='quota_windows' \
+			  AND column_name='window_class')",
+			&[],
+		)
+		.await?;
+
+	assert!(format!("{error:?}").contains("V8 requires empty pre-release quota state"));
+
+	for index in 0..3 {
+		assert!(state.get::<_, bool>(index), "variant {variant}, field {index}");
+	}
+
+	drop(client);
+
+	connection_task.await??;
+
+	Ok(())
+}
+
+#[cfg(feature = "test-support")]
+async fn insert_v7_prior_state(
+	client: &Client,
+	variant: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let statement = match variant {
+		"quota_row" =>
+			"INSERT INTO decodex.accounts (account_id,display_label) VALUES \
+			 ('10000000-0000-0000-0000-000000000091','V7 quota fixture'); \
+			 INSERT INTO decodex.quota_windows \
+			 (account_id,window_class,duration_seconds,observed_at,confidence) VALUES \
+			 ('10000000-0000-0000-0000-000000000091','five_hour',18000, \
+			  '2026-07-16T10:00:00Z',1)",
+		"receipt_operation" =>
+			"INSERT INTO decodex.command_receipts \
+			 (idempotency_key,request_hash,operation,claim_token,claim_expires_at) VALUES \
+			 ('v7-operation',repeat('a',64),'mutate_quota_window',gen_random_uuid(), \
+			  clock_timestamp()+interval '4 minutes')",
+		"receipt_scope" =>
+			"INSERT INTO decodex.command_receipts \
+			 (idempotency_key,request_hash,scope_id,claim_token,claim_expires_at) VALUES \
+			 ('v7-scope',repeat('b',64),'quota_windows',gen_random_uuid(), \
+			  clock_timestamp()+interval '4 minutes')",
+		"receipt_completed" =>
+			"INSERT INTO decodex.command_receipts \
+			 (idempotency_key,request_hash,operation,claim_token,claim_expires_at) VALUES \
+			 ('v7-completed',repeat('c',64),'mutate_quota_window',gen_random_uuid(), \
+			  clock_timestamp()+interval '4 minutes'); \
+			 UPDATE decodex.command_receipts SET receipt_state='completed',response='{}', \
+			 response_bytes=convert_to('{}','UTF8'),completion_claim_token=claim_token, \
+			 completed_at=clock_timestamp(),claim_token=NULL,claim_expires_at=NULL \
+			 WHERE idempotency_key='v7-completed'",
+		"activity_aggregate" =>
+			"INSERT INTO decodex.activity \
+			 (aggregate_kind,aggregate_id,revision,event_kind,correlation_key,payload) VALUES \
+			 ('quota_window','v7',1,'observed','v7-activity-aggregate','{}')",
+		"activity_event" =>
+			"INSERT INTO decodex.activity \
+			 (aggregate_kind,aggregate_id,revision,event_kind,correlation_key,payload) VALUES \
+			 ('account','v7',1,'quota_window_updated','v7-activity-event','{}')",
+		"activity_payload_window" =>
+			"INSERT INTO decodex.activity \
+			 (aggregate_kind,aggregate_id,revision,event_kind,correlation_key,payload) VALUES \
+			 ('account','v7',1,'observed','v7-activity-payload', \
+			  '{\"nested\":true,\"window_class\":\"five_hour\"}')",
+		"activity_payload_kind" =>
+			"INSERT INTO decodex.activity \
+			 (aggregate_kind,aggregate_id,revision,event_kind,correlation_key,payload) VALUES \
+			 ('account','v7',1,'observed','v7-activity-kind','{\"kind\":\"quota_exclusion\"}')",
+		"activity_payload_seconds" =>
+			"INSERT INTO decodex.activity \
+			 (aggregate_kind,aggregate_id,revision,event_kind,correlation_key,payload) VALUES \
+			 ('account','v7',1,'observed','v7-activity-seconds','{\"duration_seconds\":18000}')",
+		"activity_payload_minutes" =>
+			"INSERT INTO decodex.activity \
+			 (aggregate_kind,aggregate_id,revision,event_kind,correlation_key,payload) VALUES \
+			 ('account','v7',1,'observed','v7-activity-minutes','{\"duration_minutes\":300}')",
+		"outbox_aggregate" =>
+			"INSERT INTO decodex.outbox \
+			 (effect_key,aggregate_kind,aggregate_id,aggregate_revision,payload) VALUES \
+			 ('v7-outbox-aggregate','quota_window','v7',1,'{}')",
+		"outbox_envelope" =>
+			"INSERT INTO decodex.outbox \
+			 (effect_key,aggregate_kind,aggregate_id,aggregate_revision,payload) VALUES \
+			 ('v7-outbox-envelope','account','v7',1, \
+			  '{\"payload\":{\"duration_minutes\":300}}')",
+		"outbox_envelope_aggregate" =>
+			"INSERT INTO decodex.outbox \
+			 (effect_key,aggregate_kind,aggregate_id,aggregate_revision,payload) VALUES \
+			 ('v7-outbox-envelope-aggregate','account','v7',1, \
+			  '{\"aggregate_kind\":\"quota_window\"}')",
+		"outbox_envelope_event" =>
+			"INSERT INTO decodex.outbox \
+			 (effect_key,aggregate_kind,aggregate_id,aggregate_revision,payload) VALUES \
+			 ('v7-outbox-envelope-event','account','v7',1, \
+			  '{\"event_kind\":\"quota_window_excluded\"}')",
+		"outbox_envelope_kind" =>
+			"INSERT INTO decodex.outbox \
+			 (effect_key,aggregate_kind,aggregate_id,aggregate_revision,payload) VALUES \
+			 ('v7-outbox-envelope-kind','account','v7',1, \
+			  '{\"payload\":{\"kind\":\"quota_window\"}}')",
+		"outbox_envelope_window" =>
+			"INSERT INTO decodex.outbox \
+			 (effect_key,aggregate_kind,aggregate_id,aggregate_revision,payload) VALUES \
+			 ('v7-outbox-envelope-window','account','v7',1, \
+			  '{\"payload\":{\"window_class\":\"five_hour\"}}')",
+		"outbox_envelope_seconds" =>
+			"INSERT INTO decodex.outbox \
+			 (effect_key,aggregate_kind,aggregate_id,aggregate_revision,payload) VALUES \
+			 ('v7-outbox-envelope-seconds','account','v7',1, \
+			  '{\"payload\":{\"duration_seconds\":18000}}')",
+		"outbox_link" =>
+			"WITH event AS (INSERT INTO decodex.activity \
+			 (aggregate_kind,aggregate_id,revision,event_kind,correlation_key,payload) VALUES \
+			 ('quota_window','v7-link',1,'observed','v7-link','{}') RETURNING sequence) \
+			 INSERT INTO decodex.outbox \
+			 (effect_key,aggregate_kind,aggregate_id,aggregate_revision,payload) \
+			 SELECT 'v7-outbox-link','account','v7-link',1, \
+			 jsonb_build_object('activity_sequence',sequence) FROM event",
+		"outbox_orphan" =>
+			"INSERT INTO decodex.outbox \
+			 (effect_key,aggregate_kind,aggregate_id,aggregate_revision,payload) VALUES \
+			 ('v7-outbox-orphan','account','v7',1, \
+			  '{\"payload\":{\"kind\":\"quota_exclusion\"},\"activity_sequence\":9223372036854775807}')",
+		_ => return Err(format!("unknown V8 prior-state fixture {variant}").into()),
+	};
+
+	client.batch_execute(statement).await?;
+
+	Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a fresh isolated PostgreSQL 18 V8 lock-fencing database"]
+#[cfg(feature = "test-support")]
+async fn postgres_v8_fences_concurrent_prior_writer() -> Result<(), Box<dyn std::error::Error>> {
+	let (migration, _) = separated_configs("DECODEX_TEST")?;
+
+	PostgresStore::migrate_fixture_through_v7(migration.clone(), expected_peer_uid()).await?;
+
+	let (mut client, connection) = migration.clone().connect(NoTls).await?;
+	let connection_task = tokio::spawn(connection);
+	let transaction = client.transaction().await?;
+
+	transaction
+		.batch_execute(
+			"INSERT INTO decodex.accounts (account_id,display_label) VALUES \
+			 ('10000000-0000-0000-0000-000000000092','V7 concurrent fixture'); \
+			 INSERT INTO decodex.quota_windows \
+			 (account_id,window_class,duration_seconds,observed_at,confidence) VALUES \
+			 ('10000000-0000-0000-0000-000000000092','seven_day',604800, \
+			  '2026-07-16T10:00:00Z',1)",
+		)
+		.await?;
+
+	let migration_task =
+		tokio::spawn(async move { PostgresStore::migrate(migration, expected_peer_uid()).await });
+
+	time::sleep(Duration::from_millis(200)).await;
+
+	assert!(!migration_task.is_finished(), "V8 must wait behind the prior writer");
+
+	transaction.commit().await?;
+
+	let error = migration_task.await?.expect_err("committed prior quota state rejects V8");
+
+	assert!(format!("{error:?}").contains("V8 requires empty pre-release quota state"));
+
+	drop(client);
+
+	connection_task.await??;
+
+	Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[ignore = "requires the isolated PostgreSQL 18 harness"]
 async fn postgres_store_contract() -> Result<(), Box<dyn std::error::Error>> {
@@ -332,7 +606,9 @@ async fn postgres_store_contract() -> Result<(), Box<dyn std::error::Error>> {
 	assert_account_idempotency_and_revision(&store, &client).await?;
 	assert_receipt_first_saga(&store, &client).await?;
 	assert_concurrent_shard_capacity(&store, &client).await?;
-	assert_inert_window_and_credential_boundary(&store, &client).await?;
+
+	quota::assert_inert_window_and_credential_boundary(&store, &client).await?;
+
 	assert_conversation_history_context_and_blob_contract(&store, &client, &runtime_client).await?;
 	assert_concurrent_hierarchy_serialization(&store, &client, &runtime).await?;
 	assert_duration_validation(&store, &client).await?;
@@ -2065,7 +2341,7 @@ async fn assert_bootstrap_and_history(client: &Client) -> Result<(), Box<dyn std
 
 	assert_eq!(version, 18);
 	assert_eq!(checksums, "on");
-	assert_eq!(history.len(), 7);
+	assert_eq!(history.len(), 8);
 	assert_eq!(history[0].0, 1);
 	assert_eq!(history[0].1, "persistence_foundation");
 	assert!(!history[0].2.is_empty());
@@ -2087,6 +2363,9 @@ async fn assert_bootstrap_and_history(client: &Client) -> Result<(), Box<dyn std
 	assert_eq!(history[6].0, 7);
 	assert_eq!(history[6].1, "program_objective_authority");
 	assert!(!history[6].2.is_empty());
+	assert_eq!(history[7].0, 8);
+	assert_eq!(history[7].1, "quota_exclusions");
+	assert!(!history[7].2.is_empty());
 
 	let (migration, runtime) = separated_configs("DECODEX_TEST")?;
 
@@ -4534,263 +4813,6 @@ async fn assert_account_launch_authority(
 	Ok(())
 }
 
-async fn assert_inert_window_and_credential_boundary(
-	store: &PostgresStore,
-	client: &Client,
-) -> Result<(), Box<dyn std::error::Error>> {
-	let mutation = QuotaWindowMutation {
-		account_id: AccountId::new(ACCOUNT_ID)?,
-		window_class: "usage".into(),
-		duration_seconds: 300,
-		remaining_amount: None,
-		resets_at: None,
-		observed_at: "2026-07-13T07:00:00Z".into(),
-		confidence: 0.0,
-		metadata: serde_json::json!({
-			"observation": "unknown",
-			"token_budget": 8_192,
-			"session_id": "ordinary-session-id",
-		}),
-		expected_revision: None,
-	};
-	let command = CommandIdentity::new("window-create", b"window-create-v1")?;
-	let window = store.mutate_quota_window(&command, &mutation).await?;
-
-	assert_eq!(window.duration_seconds, 300);
-	assert_eq!(window.remaining_amount, None);
-	assert_eq!(window.confidence, 0.0);
-	assert!(CommandIdentity::new("token_budget/session_id", b"ordinary-id").is_ok());
-
-	assert_api_credential_boundary(store, &mutation).await?;
-	assert_quota_timestamp_validation(store, client, &mutation).await?;
-
-	for (key, command_key) in [
-		("refresh_token", "window-credential"),
-		("password", "account-credential"),
-		("Authorization", "authorization-credential"),
-		("session-token", "session-credential"),
-		("accessToken", "camel-token-credential"),
-		("bearer", "bearer-credential"),
-		("value", "secret-value-credential"),
-		("header", "bearer-value-credential"),
-		("header", "basic-value-credential"),
-		("value", "slack-value-credential"),
-		("value", "gitlab-value-credential"),
-		("value", "npm-value-credential"),
-	] {
-		if key != "password" {
-			let mut forbidden = mutation.clone();
-
-			forbidden.duration_seconds = 10_080;
-			forbidden.metadata = match command_key {
-				"secret-value-credential" => serde_json::json!({key: "sk-proj-0123456789abcdef"}),
-				"bearer-value-credential" => serde_json::json!({key: "Bearer abcdefghijklmnop"}),
-				"basic-value-credential" => serde_json::json!({key: "Basic dXNlcjpwYXNz"}),
-				"slack-value-credential" => serde_json::json!({key: "xoxb-1234567890-abcdef"}),
-				"gitlab-value-credential" => serde_json::json!({key: "glpat-1234567890abcdef"}),
-				"npm-value-credential" => serde_json::json!({key: "npm_1234567890abcdef"}),
-				_ => serde_json::json!({key: "forbidden"}),
-			};
-
-			let command = CommandIdentity::new(command_key, command_key.as_bytes())?;
-
-			assert!(matches!(
-				store.mutate_quota_window(&command, &forbidden).await,
-				Err(StoreError::CredentialRejected)
-			));
-		} else {
-			let forbidden = AccountMutation {
-				account_id: AccountId::new("10000000-0000-0000-0000-000000000002")?,
-				display_label: "Forbidden metadata".into(),
-				state: AccountState::Unknown,
-				metadata: serde_json::json!({key: "forbidden"}),
-				expected_revision: None,
-			};
-			let command = CommandIdentity::new(command_key, command_key.as_bytes())?;
-
-			assert!(matches!(
-				store.mutate_account(&command, &forbidden).await,
-				Err(StoreError::CredentialRejected)
-			));
-		}
-	}
-
-	assert_direct_credential_and_scope_boundary(store, client).await
-}
-
-async fn assert_api_credential_boundary(
-	store: &PostgresStore,
-	mutation: &QuotaWindowMutation,
-) -> Result<(), Box<dyn std::error::Error>> {
-	for value in CREDENTIAL_VALUE_VECTORS {
-		assert!(matches!(
-			CommandIdentity::new(*value, b"forbidden"),
-			Err(StoreError::CredentialRejected)
-		));
-	}
-
-	let forbidden_label = AccountMutation {
-		account_id: AccountId::new("10000000-0000-0000-0000-000000000002")?,
-		display_label: "Basic dXNlcjpwYXNz".into(),
-		state: AccountState::Unknown,
-		metadata: serde_json::json!({}),
-		expected_revision: None,
-	};
-	let safe_command = CommandIdentity::new("forbidden-label", b"forbidden-label")?;
-
-	assert!(matches!(
-		store.mutate_account(&safe_command, &forbidden_label).await,
-		Err(StoreError::CredentialRejected)
-	));
-
-	let mut forbidden_window_class = mutation.clone();
-
-	forbidden_window_class.window_class = "sk_proj_0123456789".into();
-
-	assert!(matches!(
-		store.mutate_quota_window(&safe_command, &forbidden_window_class).await,
-		Err(StoreError::CredentialRejected)
-	));
-	assert!(matches!(
-		store
-			.try_acquire_lease("Bearer abcdefghijklmnop", HOLDER_A, Duration::from_millis(1),)
-			.await,
-		Err(StoreError::CredentialRejected)
-	));
-	assert!(matches!(
-		store
-			.retry_outbox_before_effect(
-				0,
-				WORKER_A,
-				WORKER_A,
-				"sk_proj_0123456789",
-				Duration::from_millis(1),
-			)
-			.await,
-		Err(StoreError::CredentialRejected)
-	));
-
-	Ok(())
-}
-
-async fn assert_quota_timestamp_validation(
-	store: &PostgresStore,
-	client: &Client,
-	base: &QuotaWindowMutation,
-) -> Result<(), Box<dyn std::error::Error>> {
-	for (index, (observed_at, resets_at, expected_observed_at, expected_resets_at)) in [
-		(
-			"2026-07-13T07:00:00.123456789Z",
-			Some("2026-07-13T09:30:00.25+02:30"),
-			"2026-07-13T07:00:00.123457Z",
-			Some("2026-07-13T07:00:00.250000Z"),
-		),
-		("2026-07-13T01:30:00-05:30", None, "2026-07-13T07:00:00.000000Z", None),
-	]
-	.into_iter()
-	.enumerate()
-	{
-		let mut valid = base.clone();
-
-		valid.duration_seconds = 301 + i64::try_from(index)?;
-		valid.observed_at = observed_at.into();
-		valid.resets_at = resets_at.map(str::to_owned);
-
-		let key = format!("window-valid-timestamp-{index}");
-		let command = CommandIdentity::new(&key, key.as_bytes())?;
-		let stored = store.mutate_quota_window(&command, &valid).await?;
-
-		assert_eq!(stored.observed_at, expected_observed_at);
-		assert_eq!(stored.resets_at.as_deref(), expected_resets_at);
-
-		let duplicate = store.mutate_quota_window(&command, &valid).await?;
-
-		assert_eq!(duplicate, stored);
-
-		let persisted_row = client
-			.query_one(
-				"SELECT decodex.rfc3339_utc(observed_at), \
-				 CASE WHEN resets_at IS NULL THEN NULL ELSE decodex.rfc3339_utc(resets_at) END \
-				 FROM decodex.quota_windows WHERE account_id = $1::text::uuid \
-				 AND window_class = $2 AND duration_seconds = $3",
-				&[&ACCOUNT_ID, &valid.window_class, &valid.duration_seconds],
-			)
-			.await?;
-		let persisted: (String, Option<String>) = (persisted_row.get(0), persisted_row.get(1));
-		let receipt: Value = client
-			.query_one(
-				"SELECT response FROM decodex.command_receipts WHERE idempotency_key = $1",
-				&[&key],
-			)
-			.await?
-			.get(0);
-
-		assert_eq!(persisted.0, expected_observed_at);
-		assert_eq!(persisted.1.as_deref(), expected_resets_at);
-		assert_eq!(receipt["observed_at"], expected_observed_at);
-		assert_eq!(receipt.get("resets_at").and_then(Value::as_str), expected_resets_at);
-	}
-	for (index, (observed_at, resets_at)) in [
-		("infinity", None),
-		("tomorrow", None),
-		("2026-07-13 07:00:00Z", None),
-		("2026-07-13T07:00:00", None),
-		("2026-07-13", None),
-		("0000-01-01T00:00:00Z", None),
-		("2026-07-13T07:00:00Z", Some("infinity")),
-		("2026-07-13T07:00:00Z", Some("next monday")),
-	]
-	.into_iter()
-	.enumerate()
-	{
-		let mut invalid = base.clone();
-
-		invalid.duration_seconds = 400 + i64::try_from(index)?;
-		invalid.observed_at = observed_at.into();
-		invalid.resets_at = resets_at.map(str::to_owned);
-
-		let key = format!("window-invalid-timestamp-{index}");
-		let command = CommandIdentity::new(&key, key.as_bytes())?;
-		let result = store.mutate_quota_window(&command, &invalid).await;
-
-		assert!(
-			matches!(&result, Err(StoreError::InvalidInput(_))),
-			"invalid timestamp vector {index} was accepted: {result:?}"
-		);
-
-		let receipt_count: i64 = client
-			.query_one(
-				"SELECT count(*) FROM decodex.command_receipts WHERE idempotency_key = $1",
-				&[&key],
-			)
-			.await?
-			.get(0);
-
-		assert_eq!(receipt_count, 0);
-	}
-	for statement in [
-		"UPDATE decodex.quota_windows SET observed_at = 'infinity' \
-		 WHERE account_id = '10000000-0000-0000-0000-000000000001' \
-		 AND window_class = 'usage' AND duration_seconds = 300",
-		"UPDATE decodex.quota_windows SET resets_at = '-infinity' \
-		 WHERE account_id = '10000000-0000-0000-0000-000000000001' \
-		 AND window_class = 'usage' AND duration_seconds = 300",
-		"UPDATE decodex.quota_windows SET updated_at = 'infinity' \
-		 WHERE account_id = '10000000-0000-0000-0000-000000000001' \
-		 AND window_class = 'usage' AND duration_seconds = 300",
-	] {
-		let error =
-			client.execute(statement, &[]).await.expect_err("infinite quota timestamp rejected");
-
-		assert_eq!(
-			error.as_db_error().and_then(|error| error.constraint()),
-			Some("quota_windows_finite_timestamps")
-		);
-	}
-
-	Ok(())
-}
-
 async fn assert_direct_credential_and_scope_boundary(
 	store: &PostgresStore,
 	client: &Client,
@@ -4857,7 +4879,7 @@ async fn assert_direct_credential_rows(client: &Client) -> Result<(), Box<dyn st
 			"accounts_no_credentials",
 		),
 		(
-			"INSERT INTO decodex.quota_windows (account_id, window_class, duration_seconds, observed_at, confidence) VALUES ('10000000-0000-0000-0000-000000000001', 'sk_proj_0123456789', 60, clock_timestamp(), 1)",
+			"INSERT INTO decodex.quota_windows (account_id,window_class,duration_minutes,observed_at,confidence,metadata) VALUES ('10000000-0000-0000-0000-000000000001','seven_day',10080,TIMESTAMPTZ '1970-01-01 00:00:00+00','unknown','{\"api_key\":\"forbidden\"}')",
 			"quota_windows_no_credentials",
 		),
 		(
@@ -7690,24 +7712,7 @@ async fn assert_closed_pool_behavior(
 		Err(StoreError::Pool(_))
 	));
 	assert!(matches!(store.prune_delivered_outbox(1).await, Err(StoreError::Pool(_))));
-
-	let invalid_timestamp = QuotaWindowMutation {
-		account_id: AccountId::new(ACCOUNT_ID)?,
-		window_class: "closed_validation".into(),
-		duration_seconds: 1,
-		remaining_amount: None,
-		resets_at: None,
-		observed_at: "infinity".into(),
-		confidence: 0.0,
-		metadata: serde_json::json!({}),
-		expected_revision: None,
-	};
-	let command = CommandIdentity::new("closed-invalid-timestamp", b"closed-invalid-timestamp")?;
-
-	assert!(matches!(
-		store.mutate_quota_window(&command, &invalid_timestamp).await,
-		Err(StoreError::InvalidInput("quota observed_at must be RFC 3339"))
-	));
+	assert!(decodex_postgres::parse_quota_timestamp_rfc3339("infinity").is_err());
 
 	Ok(())
 }

--- a/crates/decodex-postgres/tests/postgres_store/quota.rs
+++ b/crates/decodex-postgres/tests/postgres_store/quota.rs
@@ -1,0 +1,626 @@
+use std::{error::Error, time::Duration};
+
+use tokio::task::JoinSet;
+#[cfg(feature = "test-support")] use tokio::time;
+use tokio_postgres::Client;
+
+use crate::{ACCOUNT_ID, CREDENTIAL_VALUE_VECTORS, HOLDER_A, WORKER_A};
+use decodex_core::{ObservationConfidence, QuotaWindowClass, RemainingPercent};
+use decodex_postgres::{
+	AccountId, AccountMutation, AccountState, CommandIdentity, PostgresStore,
+	QuotaExclusionMutation, QuotaExclusionReceipt, QuotaTimestampMicros, QuotaWindowMutation,
+	StoreError,
+};
+
+pub(super) async fn assert_inert_window_and_credential_boundary(
+	store: &PostgresStore,
+	client: &Client,
+) -> Result<(), Box<dyn Error>> {
+	let mutation = QuotaWindowMutation {
+		account_id: AccountId::new(ACCOUNT_ID)?,
+		window: QuotaWindowClass::FiveHour,
+		remaining_percent: None,
+		resets_at: None,
+		observed_at: quota_timestamp("2026-07-13T07:00:00Z")?,
+		confidence: ObservationConfidence::Unknown,
+		metadata: serde_json::json!({
+			"observation": "unknown",
+			"token_budget": 8_192,
+			"session_id": "ordinary-session-id",
+		}),
+		expected_revision: None,
+	};
+	let command = CommandIdentity::new("window-create", b"window-create-v1")?;
+	#[cfg(feature = "test-support")]
+	let initial_evictions = PostgresStore::quota_lock_evictions_fixture();
+
+	#[cfg(feature = "test-support")]
+	PostgresStore::fail_next_quota_unlock_fixture();
+
+	let window = store.mutate_quota_window(&command, &mutation).await?;
+
+	#[cfg(feature = "test-support")]
+	assert_eq!(PostgresStore::quota_lock_evictions_fixture(), initial_evictions + 1);
+	assert_eq!(window.window, QuotaWindowClass::FiveHour);
+	assert_eq!(window.remaining_percent, None);
+	assert_eq!(window.confidence, ObservationConfidence::Unknown);
+	assert!(CommandIdentity::new("token_budget/session_id", b"ordinary-id").is_ok());
+
+	assert_api_credential_boundary(store, &mutation).await?;
+	assert_quota_timestamp_validation(client).await?;
+	assert_inert_exclusion_transactions(store, client, &mutation).await?;
+
+	for (key, command_key) in [
+		("refresh_token", "window-credential"),
+		("password", "account-credential"),
+		("Authorization", "authorization-credential"),
+		("session-token", "session-credential"),
+		("accessToken", "camel-token-credential"),
+		("bearer", "bearer-credential"),
+		("value", "secret-value-credential"),
+		("header", "bearer-value-credential"),
+		("header", "basic-value-credential"),
+		("value", "slack-value-credential"),
+		("value", "gitlab-value-credential"),
+		("value", "npm-value-credential"),
+	] {
+		if key != "password" {
+			let mut forbidden = mutation.clone();
+
+			forbidden.window = QuotaWindowClass::SevenDay;
+			forbidden.metadata = match command_key {
+				"secret-value-credential" => serde_json::json!({key: "sk-proj-0123456789abcdef"}),
+				"bearer-value-credential" => serde_json::json!({key: "Bearer abcdefghijklmnop"}),
+				"basic-value-credential" => serde_json::json!({key: "Basic dXNlcjpwYXNz"}),
+				"slack-value-credential" => serde_json::json!({key: "xoxb-1234567890-abcdef"}),
+				"gitlab-value-credential" => serde_json::json!({key: "glpat-1234567890abcdef"}),
+				"npm-value-credential" => serde_json::json!({key: "npm_1234567890abcdef"}),
+				_ => serde_json::json!({key: "forbidden"}),
+			};
+
+			let command = CommandIdentity::new(command_key, command_key.as_bytes())?;
+
+			assert!(matches!(
+				store.mutate_quota_window(&command, &forbidden).await,
+				Err(StoreError::CredentialRejected)
+			));
+		} else {
+			let forbidden = AccountMutation {
+				account_id: AccountId::new("10000000-0000-0000-0000-000000000002")?,
+				display_label: "Forbidden metadata".into(),
+				state: AccountState::Unknown,
+				metadata: serde_json::json!({key: "forbidden"}),
+				expected_revision: None,
+			};
+			let command = CommandIdentity::new(command_key, command_key.as_bytes())?;
+
+			assert!(matches!(
+				store.mutate_account(&command, &forbidden).await,
+				Err(StoreError::CredentialRejected)
+			));
+		}
+	}
+
+	crate::assert_direct_credential_and_scope_boundary(store, client).await
+}
+
+fn quota_timestamp(value: &str) -> Result<QuotaTimestampMicros, StoreError> {
+	decodex_postgres::parse_quota_timestamp_rfc3339(value)
+}
+
+async fn assert_api_credential_boundary(
+	store: &PostgresStore,
+	mutation: &QuotaWindowMutation,
+) -> Result<(), Box<dyn Error>> {
+	for value in CREDENTIAL_VALUE_VECTORS {
+		assert!(matches!(
+			CommandIdentity::new(*value, b"forbidden"),
+			Err(StoreError::CredentialRejected)
+		));
+	}
+
+	let forbidden_label = AccountMutation {
+		account_id: AccountId::new("10000000-0000-0000-0000-000000000002")?,
+		display_label: "Basic dXNlcjpwYXNz".into(),
+		state: AccountState::Unknown,
+		metadata: serde_json::json!({}),
+		expected_revision: None,
+	};
+	let safe_command = CommandIdentity::new("forbidden-label", b"forbidden-label")?;
+
+	assert!(matches!(
+		store.mutate_account(&safe_command, &forbidden_label).await,
+		Err(StoreError::CredentialRejected)
+	));
+
+	let mut forbidden_metadata = mutation.clone();
+
+	forbidden_metadata.metadata = serde_json::json!({"api_key": "forbidden"});
+
+	assert!(matches!(
+		store.mutate_quota_window(&safe_command, &forbidden_metadata).await,
+		Err(StoreError::CredentialRejected)
+	));
+	assert!(matches!(
+		store
+			.try_acquire_lease("Bearer abcdefghijklmnop", HOLDER_A, Duration::from_millis(1),)
+			.await,
+		Err(StoreError::CredentialRejected)
+	));
+	assert!(matches!(
+		store
+			.retry_outbox_before_effect(
+				0,
+				WORKER_A,
+				WORKER_A,
+				"sk_proj_0123456789",
+				Duration::from_millis(1),
+			)
+			.await,
+		Err(StoreError::CredentialRejected)
+	));
+
+	Ok(())
+}
+
+async fn assert_quota_timestamp_validation(client: &Client) -> Result<(), Box<dyn Error>> {
+	let utc = quota_timestamp("2026-07-13T07:00:00.123456Z")?;
+	let offset = quota_timestamp("2026-07-13T09:30:00.123456+02:30")?;
+
+	assert_eq!(utc, offset);
+
+	for (index, invalid) in [
+		"2026-07-13T07:00:00.123456789Z",
+		"1969-12-31T23:59:59.999999Z",
+		"10000-01-01T00:00:00Z",
+		"2026-12-31T23:59:60Z",
+		"infinity",
+		"tomorrow",
+		"2026-07-13 07:00:00Z",
+	]
+	.into_iter()
+	.enumerate()
+	{
+		let key = format!("window-invalid-timestamp-{index}");
+
+		assert!(decodex_postgres::parse_quota_timestamp_rfc3339(invalid).is_err(), "{invalid}");
+
+		let receipt_count: i64 = client
+			.query_one(
+				"SELECT count(*) FROM decodex.command_receipts WHERE idempotency_key=$1",
+				&[&key],
+			)
+			.await?
+			.get(0);
+
+		assert_eq!(receipt_count, 0);
+	}
+	for value in [-1_i64, QuotaTimestampMicros::MAX + 1] {
+		assert!(QuotaTimestampMicros::new(value).is_err());
+	}
+
+	Ok(())
+}
+
+async fn assert_inert_exclusion_transactions(
+	store: &PostgresStore,
+	client: &Client,
+	baseline: &QuotaWindowMutation,
+) -> Result<(), Box<dyn Error>> {
+	let observed = quota_timestamp("2026-07-13T07:05:00Z")?;
+	let mut depleted = baseline.clone();
+
+	depleted.remaining_percent = Some(RemainingPercent::new(0).expect("zero is valid"));
+	depleted.resets_at = Some(quota_timestamp("2026-07-13T08:00:00Z")?);
+	depleted.observed_at = observed;
+	depleted.confidence = ObservationConfidence::High;
+	depleted.metadata = serde_json::json!({
+		"source": "synthetic_exact_microsecond_fixture",
+		"nested": {"zeta": 2, "alpha": 1},
+		"array": [1, "1", true],
+	});
+	depleted.expected_revision = Some(1);
+
+	let exclusion = QuotaExclusionMutation {
+		observation: depleted,
+		excluded_at: QuotaTimestampMicros::new(observed.get() + 300_000_000)?,
+	};
+	let command =
+		CommandIdentity::new("quota-exclusion-create", b"caller-bytes-are-not-authority")?;
+	#[cfg(feature = "test-support")]
+	let evictions_before_exclusion = PostgresStore::quota_lock_evictions_fixture();
+
+	#[cfg(feature = "test-support")]
+	PostgresStore::fail_next_quota_unlock_fixture();
+
+	let receipt = store.persist_quota_exclusion(&command, &exclusion).await?;
+
+	#[cfg(feature = "test-support")]
+	assert_eq!(PostgresStore::quota_lock_evictions_fixture(), evictions_before_exclusion + 1);
+	assert_eq!(receipt.observation_revision, 2);
+	assert!(!receipt.hypothetical_fallback.dispatch_enabled());
+	assert_eq!(store.persist_quota_exclusion(&command, &exclusion).await?, receipt);
+	assert_eq!(
+		store
+			.persist_quota_exclusion(
+				&CommandIdentity::new("quota-exclusion-create", b"different-caller-bytes")?,
+				&exclusion,
+			)
+			.await?,
+		receipt
+	);
+
+	let mut reordered = exclusion.clone();
+
+	reordered.observation.metadata = serde_json::from_str(
+		r#"{"array":[1,"1",true],"nested":{"alpha":1,"zeta":2},"source":"synthetic_exact_microsecond_fixture"}"#,
+	)?;
+
+	assert_eq!(store.persist_quota_exclusion(&command, &reordered).await?, receipt);
+
+	let mut changed = exclusion.clone();
+
+	changed.excluded_at = QuotaTimestampMicros::new(changed.excluded_at.get() - 1)?;
+
+	assert!(matches!(
+		store.persist_quota_exclusion(&command, &changed).await,
+		Err(StoreError::IdempotencyConflict)
+	));
+
+	let mut stale = exclusion.clone();
+
+	stale.observation.expected_revision = Some(2);
+	stale.observation.observed_at = QuotaTimestampMicros::new(observed.get() + 1_000_000)?;
+	stale.excluded_at =
+		QuotaTimestampMicros::new(stale.observation.observed_at.get() + 300_000_001)?;
+
+	let stale_key = "quota-exclusion-stale-by-one-microsecond";
+
+	assert!(matches!(
+		store
+			.persist_quota_exclusion(
+				&CommandIdentity::new(stale_key, b"invalid-before-receipt")?,
+				&stale,
+			)
+			.await,
+		Err(StoreError::InvalidInput(_))
+	));
+
+	let stale_side_effects = client
+		.query_one(
+			"SELECT \
+			 (SELECT count(*) FROM decodex.command_receipts WHERE idempotency_key=$1), \
+			 (SELECT count(*) FROM decodex.activity WHERE correlation_key=$1), \
+			 (SELECT count(*) FROM decodex.outbox AS work JOIN decodex.activity AS event \
+			  ON work.payload @> jsonb_build_object('activity_sequence',event.sequence) \
+			  WHERE event.correlation_key=$1), \
+			 (SELECT count(*) FROM decodex.quota_exclusions WHERE observation_revision > 2)",
+			&[&stale_key],
+		)
+		.await?;
+
+	for index in 0..4 {
+		assert_eq!(stale_side_effects.get::<_, i64>(index), 0);
+	}
+
+	assert_exclusion_rows_are_inert(client, &receipt).await?;
+	assert_monotonic_quota_observations(store, client, &exclusion.observation).await?;
+	assert_concurrent_quota_writers(store, client, &exclusion.observation).await?;
+	#[cfg(feature = "test-support")]
+	assert_exclusion_crash_retry(store, client, baseline).await?;
+
+	Ok(())
+}
+
+async fn assert_exclusion_rows_are_inert(
+	client: &Client,
+	receipt: &QuotaExclusionReceipt,
+) -> Result<(), Box<dyn Error>> {
+	let row = client
+		.query_one(
+			"SELECT count(*),bool_and(NOT dispatch_enabled),bool_and(maximum_age_micros=300000000), \
+			 bool_and(mutation_sha256=$1),bool_and(mutation_length=$2) \
+			 FROM decodex.quota_exclusions WHERE account_id=$3::text::uuid \
+			 AND window_class='five_hour' AND duration_minutes=300",
+			&[&receipt.mutation_sha256, &receipt.mutation_length, &ACCOUNT_ID],
+		)
+		.await?;
+
+	assert_eq!(row.get::<_, i64>(0), 1);
+	assert!(row.get::<_, bool>(1));
+	assert!(row.get::<_, bool>(2));
+	assert!(row.get::<_, bool>(3));
+	assert!(row.get::<_, bool>(4));
+
+	assert_sql_exclusion_freshness_boundaries(client).await?;
+
+	Ok(())
+}
+
+async fn assert_sql_exclusion_freshness_boundaries(client: &Client) -> Result<(), Box<dyn Error>> {
+	client.batch_execute("BEGIN").await?;
+	client
+		.batch_execute(
+			"INSERT INTO decodex.accounts (account_id,display_label) VALUES \
+			 ('10000000-0000-0000-0000-000000000093','Quota maximum fixture'); \
+			 INSERT INTO decodex.quota_windows \
+			 (account_id,window_class,duration_minutes,observed_at,confidence,metadata) VALUES \
+			 ('10000000-0000-0000-0000-000000000093','five_hour',300, \
+			  TIMESTAMPTZ '1970-01-01 00:00:00+00' \
+			  + (253402300799999999::bigint / 1000000) * INTERVAL '1 second' \
+			  + (253402300799999999::bigint % 1000000) * INTERVAL '1 microsecond', \
+			  'unknown','{}')",
+		)
+		.await?;
+
+	let maximum: i64 = client
+		.query_one(
+			"SELECT (extract(epoch FROM observed_at)::numeric * 1000000)::bigint \
+			 FROM decodex.quota_windows \
+			 WHERE account_id='10000000-0000-0000-0000-000000000093'",
+			&[],
+		)
+		.await?
+		.get(0);
+
+	assert_eq!(maximum, QuotaTimestampMicros::MAX);
+
+	for (revision, age) in [(900_i64, 0_i64), (901, 299_999_999), (902, 300_000_000)] {
+		client
+			.execute(
+				"INSERT INTO decodex.quota_exclusions \
+				 (account_id,window_class,duration_minutes,observation_revision,remaining_percent, \
+				  confidence,observation_metadata,observed_at_micros,resets_at_micros, \
+				  excluded_at_micros,maximum_age_micros,mutation_sha256,mutation_length) VALUES \
+				 ($1::text::uuid,'five_hour',300,$2,0,'high','{}',1700000000000000, \
+				  1800000000000000,1700000000000000+$3,300000000,repeat('a',64),1)",
+				&[&ACCOUNT_ID, &revision, &age],
+			)
+			.await?;
+	}
+
+	client.batch_execute("SAVEPOINT stale_freshness").await?;
+
+	let error = client
+		.execute(
+			"INSERT INTO decodex.quota_exclusions \
+			 (account_id,window_class,duration_minutes,observation_revision,remaining_percent, \
+			  confidence,observation_metadata,observed_at_micros,resets_at_micros, \
+			  excluded_at_micros,maximum_age_micros,mutation_sha256,mutation_length) VALUES \
+			 ($1::text::uuid,'five_hour',300,903,0,'high','{}',1700000000000000, \
+			  1800000000000000,1700000300000001,300000000,repeat('b',64),1)",
+			&[&ACCOUNT_ID],
+		)
+		.await
+		.expect_err("300 seconds plus one microsecond is stale in PostgreSQL");
+
+	assert_eq!(
+		error.as_db_error().and_then(|database| database.constraint()),
+		Some("quota_exclusions_freshness")
+	);
+
+	client.batch_execute("ROLLBACK TO stale_freshness; ROLLBACK").await?;
+
+	Ok(())
+}
+
+async fn assert_monotonic_quota_observations(
+	store: &PostgresStore,
+	client: &Client,
+	baseline: &QuotaWindowMutation,
+) -> Result<(), Box<dyn Error>> {
+	let mut stale = baseline.clone();
+
+	stale.expected_revision = Some(2);
+	stale.observed_at = QuotaTimestampMicros::new(baseline.observed_at.get() - 1)?;
+
+	let key = "quota-window-stale-observation";
+	let result =
+		store.mutate_quota_window(&CommandIdentity::new(key, b"stale-observation")?, &stale).await;
+
+	assert!(matches!(
+		result,
+		Err(StoreError::InvalidInput("quota observation cannot move backward in time"))
+	));
+
+	let state = client
+		.query_one(
+			"SELECT revision,(extract(epoch FROM observed_at)::numeric * 1000000)::bigint, \
+			 (SELECT count(*) FROM decodex.command_receipts WHERE idempotency_key=$1), \
+			 (SELECT count(*) FROM decodex.activity WHERE correlation_key=$1), \
+			 (SELECT count(*) FROM decodex.outbox AS work JOIN decodex.activity AS event \
+			  ON work.payload @> jsonb_build_object('activity_sequence',event.sequence) \
+			  WHERE event.correlation_key=$1) \
+			 FROM decodex.quota_windows WHERE account_id=$2::text::uuid \
+			 AND window_class='five_hour' AND duration_minutes=300",
+			&[&key, &ACCOUNT_ID],
+		)
+		.await?;
+
+	assert_eq!(state.get::<_, i64>(0), 2);
+	assert_eq!(state.get::<_, i64>(1), baseline.observed_at.get());
+	assert_eq!(state.get::<_, i64>(2), 0);
+	assert_eq!(state.get::<_, i64>(3), 0);
+	assert_eq!(state.get::<_, i64>(4), 0);
+	assert_eq!(
+		client
+			.execute(
+				"UPDATE decodex.quota_windows SET observed_at=observed_at \
+				 WHERE account_id=$1::text::uuid AND window_class='five_hour'",
+				&[&ACCOUNT_ID],
+			)
+			.await?,
+		1
+	);
+
+	let direct_stale = client
+		.execute(
+			"UPDATE decodex.quota_windows SET observed_at=observed_at-interval '1 microsecond' \
+			 WHERE account_id=$1::text::uuid AND window_class='five_hour'",
+			&[&ACCOUNT_ID],
+		)
+		.await
+		.expect_err("database boundary rejects a regressing observation");
+
+	assert_eq!(
+		direct_stale.as_db_error().and_then(|database| database.constraint()),
+		Some("quota_windows_observed_at_monotonic")
+	);
+
+	Ok(())
+}
+
+async fn assert_concurrent_quota_writers(
+	store: &PostgresStore,
+	client: &Client,
+	baseline: &QuotaWindowMutation,
+) -> Result<(), Box<dyn Error>> {
+	let mut attempts = JoinSet::new();
+
+	for index in 0..8 {
+		let store = store.clone();
+		let mut mutation = baseline.clone();
+
+		mutation.expected_revision = Some(2);
+		mutation.metadata = serde_json::json!({"concurrent_writer": index});
+
+		attempts.spawn(async move {
+			store
+				.mutate_quota_window(
+					&CommandIdentity::new(
+						format!("quota-concurrent-{index}"),
+						format!("caller-{index}").as_bytes(),
+					)?,
+					&mutation,
+				)
+				.await
+		});
+	}
+
+	let mut successes = 0;
+	let mut conflicts = 0;
+
+	while let Some(result) = attempts.join_next().await {
+		match result? {
+			Ok(_) => successes += 1,
+			Err(StoreError::RevisionConflict { expected: Some(2), actual: Some(3), .. }) => {
+				conflicts += 1;
+			},
+			Err(error) => return Err(error.into()),
+		}
+	}
+
+	assert_eq!((successes, conflicts), (1, 7));
+
+	let receipt_count: i64 = client
+		.query_one(
+			"SELECT count(*) FROM decodex.command_receipts \
+			 WHERE idempotency_key LIKE 'quota-concurrent-%'",
+			&[],
+		)
+		.await?
+		.get(0);
+
+	assert_eq!(receipt_count, 1);
+
+	Ok(())
+}
+
+#[cfg(feature = "test-support")]
+async fn assert_exclusion_crash_retry(
+	store: &PostgresStore,
+	client: &Client,
+	baseline: &QuotaWindowMutation,
+) -> Result<(), Box<dyn Error>> {
+	let mut observation = baseline.clone();
+
+	observation.window = QuotaWindowClass::SevenDay;
+	observation.remaining_percent = Some(RemainingPercent::new(0).expect("zero is valid"));
+	observation.resets_at = Some(quota_timestamp("2026-07-14T08:00:00Z")?);
+	observation.observed_at = quota_timestamp("2026-07-14T07:00:00Z")?;
+	observation.confidence = ObservationConfidence::High;
+	observation.metadata = serde_json::json!({"crash_fixture": "after_reservation"});
+	observation.expected_revision = None;
+
+	let exclusion = QuotaExclusionMutation {
+		excluded_at: QuotaTimestampMicros::new(observation.observed_at.get() + 299_999_999)?,
+		observation,
+	};
+	let key = "quota-exclusion-crash-after-reservation";
+	let command = CommandIdentity::new(key, b"caller-bytes-not-authority")?;
+
+	PostgresStore::fail_next_exclusion_after_reservation_fixture();
+
+	assert!(matches!(
+		store.persist_quota_exclusion(&command, &exclusion).await,
+		Err(StoreError::CapacityExhausted(_))
+	));
+
+	let state = client
+		.query_one(
+			"SELECT \
+			 (SELECT count(*) FROM decodex.command_receipts WHERE idempotency_key=$1), \
+			 (SELECT count(*) FROM decodex.quota_windows WHERE account_id=$2::text::uuid \
+			  AND window_class='seven_day'), \
+			 (SELECT count(*) FROM decodex.quota_exclusions WHERE account_id=$2::text::uuid \
+			  AND window_class='seven_day'), \
+			 (SELECT count(*) FROM decodex.activity WHERE correlation_key=$1), \
+			 (SELECT count(*) FROM decodex.outbox AS work JOIN decodex.activity AS event \
+			  ON work.payload @> jsonb_build_object('activity_sequence',event.sequence) \
+			  WHERE event.correlation_key=$1)",
+			&[&key, &ACCOUNT_ID],
+		)
+		.await?;
+
+	assert_eq!(state.get::<_, i64>(0), 1);
+
+	for index in 1..5 {
+		assert_eq!(state.get::<_, i64>(index), 0);
+	}
+
+	let retry_store = store.clone();
+	let retry_command = command.clone();
+	let retry_exclusion = exclusion.clone();
+	let retry = tokio::spawn(async move {
+		retry_store.persist_quota_exclusion(&retry_command, &retry_exclusion).await
+	});
+
+	time::sleep(Duration::from_millis(100)).await;
+
+	retry.abort();
+
+	assert!(retry.await.expect_err("retry task is cancelled").is_cancelled());
+
+	let mut changed = exclusion.clone();
+
+	changed.observation.metadata = serde_json::json!({"crash_fixture": "changed"});
+
+	assert!(matches!(
+		time::timeout(Duration::from_secs(1), store.persist_quota_exclusion(&command, &changed),)
+			.await
+			.expect("cancelled quota lock is released"),
+		Err(StoreError::IdempotencyConflict)
+	));
+
+	client
+		.batch_execute(
+			"ALTER TABLE decodex.command_receipts DISABLE TRIGGER command_receipts_state_guard; \
+			 UPDATE decodex.command_receipts SET created_at=clock_timestamp()-interval '10 minutes', \
+			 claim_expires_at=clock_timestamp()-interval '1 second' \
+			 WHERE idempotency_key='quota-exclusion-crash-after-reservation'; \
+			 ALTER TABLE decodex.command_receipts ENABLE TRIGGER command_receipts_state_guard",
+		)
+		.await?;
+
+	let receipt = store.persist_quota_exclusion(&command, &exclusion).await?;
+
+	assert_eq!(receipt.window, QuotaWindowClass::SevenDay);
+	assert_eq!(receipt.excluded_at.get() - receipt.observed_at.get(), 299_999_999);
+	assert_eq!(store.persist_quota_exclusion(&command, &exclusion).await?, receipt);
+	assert!(matches!(
+		store.persist_quota_exclusion(&command, &changed).await,
+		Err(StoreError::IdempotencyConflict)
+	));
+
+	Ok(())
+}

--- a/scripts/vnext/postgres_store_test.py
+++ b/scripts/vnext/postgres_store_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from enum import Enum
+import json
 import os
 from pathlib import Path
 import shutil
@@ -31,6 +32,8 @@ IDENTITY_CAST_DATABASE = "decodex_xy1315_identity_cast"
 EXTERNAL_CASCADE_DATABASE = "decodex_xy1307_external_cascade"
 LEDGER_TAMPER_DATABASE = "decodex_xy1307_ledger_tamper"
 MISSING_EXTENSION_DATABASE = "decodex_xy1307_missing_extension"
+V8_EMPTY_DATABASE = "decodex_xy1274_v8_empty"
+V8_LOCK_DATABASE = "decodex_xy1274_v8_lock"
 MIGRATION_ROLE = "decodex_migration"
 RUNTIME_ROLE = "decodex_runtime"
 FUNCTION_OWNER_ROLE = "decodex_function_owner"
@@ -96,6 +99,7 @@ RUNTIME_EXECUTE_SIGNATURES = (
 TRIGGER_ONLY_SIGNATURES = (
 	"decodex.enforce_lease_operation_time()",
 	"decodex.enforce_outbox_operation_time()",
+	"decodex.enforce_quota_observation_monotonicity()",
 	"decodex.forbid_mutation_of_activity()",
 	"decodex.enforce_outbox_terminal_retention()",
 	"decodex.forbid_outbox_truncate()",
@@ -142,6 +146,8 @@ RUNTIME_TYPE_NAMES = (
 	"decodex.agent_status",
 	"decodex.program_state",
 	"decodex.objective_state",
+	"decodex.quota_window_class",
+	"decodex.observation_confidence",
 )
 
 
@@ -390,6 +396,87 @@ def run_migration(env: dict[str, str]) -> str:
 	)
 
 
+def dump_schema_manifest(path: Path, env: dict[str, str]) -> str:
+	manifest_env = env.copy()
+	manifest_env["DECODEX_SCHEMA_MANIFEST_PATH"] = str(path)
+	return run(
+		["cargo", "nextest", "run", "-p", "decodex-postgres", "--features",
+		 "test-support", "--test", "postgres_store", "--run-ignored", "all", "--",
+		 "postgres_schema_manifest_dump_fixture", "--exact"],
+		manifest_env,
+	)
+
+
+def quota_authority_snapshot(database: str, env: dict[str, str]) -> str:
+	return psql(
+		database,
+		"SELECT jsonb_build_object("
+		"'windows',coalesce((SELECT jsonb_agg(to_jsonb(row) ORDER BY row.account_id,row.window_class) "
+		"FROM (SELECT account_id::text,window_class::text,duration_minutes,remaining_percent,"
+		"(extract(epoch FROM resets_at)::numeric*1000000)::bigint AS resets_at_micros,"
+		"(extract(epoch FROM observed_at)::numeric*1000000)::bigint AS observed_at_micros,"
+		"confidence::text,metadata,revision,updated_at FROM decodex.quota_windows) AS row),'[]'),"
+		"'exclusions',coalesce((SELECT jsonb_agg(to_jsonb(row) ORDER BY row.account_id,row.window_class) "
+		"FROM (SELECT account_id::text,window_class::text,duration_minutes,observation_revision,"
+		"remaining_percent,confidence::text,observation_metadata,observed_at_micros,resets_at_micros,"
+		"excluded_at_micros,maximum_age_micros,mutation_sha256,mutation_length,dispatch_enabled,"
+		"created_at FROM decodex.quota_exclusions) AS row),'[]'),"
+		"'receipts',coalesce((SELECT jsonb_agg(to_jsonb(row) ORDER BY row.idempotency_key) "
+		"FROM (SELECT idempotency_key,request_hash,operation,scope_id,entity_id,expected_revision,"
+		"payload_hash,payload_length,receipt_state::text,response,encode(response_bytes,'hex') AS response_hex,"
+		"created_at,completed_at FROM decodex.command_receipts WHERE operation IN "
+		"('mutate_quota_window','persist_quota_exclusion') OR scope_id IN ('quota_windows','quota_exclusions')) AS row),'[]'),"
+		"'activity',coalesce((SELECT jsonb_agg(to_jsonb(row) ORDER BY row.sequence) "
+		"FROM (SELECT sequence,aggregate_kind,aggregate_id,revision,event_kind,correlation_key,payload,created_at "
+		"FROM decodex.activity WHERE aggregate_kind='quota_window') AS row),'[]'),"
+		"'outbox',coalesce((SELECT jsonb_agg(to_jsonb(row) ORDER BY row.id) FROM "
+		"(SELECT work.id,work.effect_key,work.aggregate_kind,work.aggregate_id,work.aggregate_revision,"
+		"work.payload,work.state::text,work.effect_state::text,work.created_at FROM decodex.outbox AS work "
+		"JOIN decodex.activity AS event ON work.payload @> jsonb_build_object('activity_sequence',event.sequence) "
+		"WHERE event.aggregate_kind='quota_window') AS row),'[]'))",
+		env,
+	)
+
+
+def run_v8_migration_boundary_contracts(
+	env: dict[str, str], socket_dir: Path, port: int
+) -> str:
+	outputs: list[str] = []
+	tests = ((V8_EMPTY_DATABASE, "postgres_v8_empty_boundary_contract"),
+	         (V8_LOCK_DATABASE, "postgres_v8_fences_concurrent_prior_writer"))
+	for database, test in tests:
+		create_database(database, env)
+		set_contract_urls(env, socket_dir, port, database, RUNTIME_ROLE)
+		outputs.append(run(
+			["cargo", "nextest", "run", "-p", "decodex-postgres", "--features",
+			 "test-support", "--test", "postgres_store", "--run-ignored", "all", "--",
+			 test, "--exact"],
+			env,
+		))
+
+	for variant in (
+		"quota_row", "receipt_operation", "receipt_scope", "receipt_completed",
+		"activity_aggregate", "activity_event", "activity_payload_window",
+		"activity_payload_kind", "activity_payload_seconds", "activity_payload_minutes",
+		"outbox_aggregate", "outbox_envelope", "outbox_envelope_aggregate",
+		"outbox_envelope_event", "outbox_envelope_kind", "outbox_envelope_window",
+		"outbox_envelope_seconds", "outbox_link", "outbox_orphan",
+	):
+		database = f"decodex_xy1274_v8_{variant}"
+		create_database(database, env)
+		set_contract_urls(env, socket_dir, port, database, RUNTIME_ROLE)
+		variant_env = env.copy()
+		variant_env["DECODEX_V8_PRIOR_STATE"] = variant
+		outputs.append(run(
+			["cargo", "nextest", "run", "-p", "decodex-postgres", "--features",
+			 "test-support", "--test", "postgres_store", "--run-ignored", "all", "--",
+			 "postgres_v8_rejects_classified_prior_state", "--exact"],
+			variant_env,
+		))
+
+	return "\n".join(outputs)
+
+
 def provision_runtime(database: str, role: str, env: dict[str, str]) -> None:
 	execute_signatures = ", ".join(RUNTIME_EXECUTE_SIGNATURES)
 	trigger_signatures = ", ".join(TRIGGER_ONLY_SIGNATURES)
@@ -404,6 +491,7 @@ def provision_runtime(database: str, role: str, env: dict[str, str]) -> None:
 		f"decodex.accounts, decodex.quota_windows, decodex.command_receipts, "
 		f"decodex.leases, decodex.conversations, decodex.runtime_sessions, "
 		f"decodex.artifacts, decodex.turns, decodex.history_items TO {role}; "
+		f"GRANT SELECT, INSERT ON TABLE decodex.quota_exclusions TO {role}; "
 		f"GRANT SELECT, INSERT ON TABLE decodex.profile_snapshots, "
 		f"decodex.account_snapshots, decodex.blob_objects, decodex.artifact_revisions, decodex.context_packs, "
 		f"decodex.context_pack_sources, decodex.transition_proposals TO {role}; "
@@ -547,6 +635,8 @@ def main() -> int:
 		set_contract_urls(env, socket_dir, port, DATABASE, RUNTIME_ROLE)
 		migration_output = run_migration(env)
 		provision_runtime(DATABASE, RUNTIME_ROLE, env)
+		v8_boundary_output = run_v8_migration_boundary_contracts(env, socket_dir, port)
+		set_contract_urls(env, socket_dir, port, DATABASE, RUNTIME_ROLE)
 		restart_output = run_blob_session_restart_contract(
 			data_dir, log_path, socket_dir, port, work, env
 		)
@@ -573,6 +663,8 @@ def main() -> int:
 				"run",
 				"-p",
 				"decodex-postgres",
+				"--features",
+				"test-support",
 				"--test",
 				"postgres_store",
 				"--run-ignored",
@@ -979,7 +1071,7 @@ def main() -> int:
 			f"AND (SELECT count(*) FROM pg_catalog.pg_proc AS inventory "
 			f"JOIN pg_catalog.pg_namespace AS inventory_namespace "
 			f"ON inventory_namespace.oid = inventory.pronamespace "
-			f"WHERE inventory_namespace.nspname = 'decodex') = 58",
+			f"WHERE inventory_namespace.nspname = 'decodex') = 59",
 			env,
 		) != "t|t|t|t|t|t|t|t":
 			raise TestFailure("additional privileged-function fixture is vacuous")
@@ -1357,7 +1449,7 @@ def main() -> int:
 			"SELECT count(*), count(*) FILTER (WHERE name LIKE '%_tampered') "
 			"FROM public.refinery_schema_history",
 			env,
-		) != "7|1":
+		) != "8|1":
 			raise TestFailure("migration-ledger tamper did not preserve the row count")
 
 		create_database(MISSING_EXTENSION_DATABASE, env)
@@ -1481,11 +1573,37 @@ def main() -> int:
 			env,
 		)
 
+		live_manifest_path = work / "schema-manifest-live.json"
+		set_contract_urls(env, socket_dir, port, DATABASE, RUNTIME_ROLE)
+		dump_schema_manifest(live_manifest_path, env)
+		live_quota_snapshot = quota_authority_snapshot(DATABASE, env)
+		live_quota = json.loads(live_quota_snapshot)
+		if len(live_quota["windows"]) != 2 or len(live_quota["exclusions"]) != 2:
+			raise TestFailure("live quota snapshot is not the populated two-window fixture")
+		if any(row["dispatch_enabled"] for row in live_quota["exclusions"]):
+			raise TestFailure("live quota exclusion unexpectedly enables dispatch")
 		dump_path = work / "decodex_xy1267.dump"
 		run(["pg_dump", "-Fc", "-f", str(dump_path), DATABASE], env)
 		create_database(RESTORE_DATABASE, env)
 		run(["pg_restore", "--exit-on-error", "-d", RESTORE_DATABASE, str(dump_path)], env)
 		set_contract_urls(env, socket_dir, port, RESTORE_DATABASE, RUNTIME_ROLE)
+		restored_manifest_path = work / "schema-manifest-restored.json"
+		dump_schema_manifest(restored_manifest_path, env)
+		restored_quota_snapshot = quota_authority_snapshot(RESTORE_DATABASE, env)
+		if restored_quota_snapshot != live_quota_snapshot:
+			raise TestFailure("dump/restore changed immutable quota authority evidence")
+		live_manifest = live_manifest_path.read_text()
+		restored_manifest = restored_manifest_path.read_text()
+		if live_manifest != restored_manifest:
+			live_rows = json.loads(live_manifest)
+			restored_rows = json.loads(restored_manifest)
+			only_live = [row for row in live_rows if row not in restored_rows]
+			only_restored = [row for row in restored_rows if row not in live_rows]
+			raise TestFailure(
+				"dump/restore schema manifest changed\n"
+				f"only live: {json.dumps(only_live[:8], indent=2)}\n"
+				f"only restored: {json.dumps(only_restored[:8], indent=2)}"
+			)
 		restore_output = run(
 			[
 				"cargo",
@@ -1493,6 +1611,8 @@ def main() -> int:
 				"run",
 				"-p",
 				"decodex-postgres",
+				"--features",
+				"test-support",
 				"--test",
 				"postgres_store",
 				"--run-ignored",
@@ -1575,6 +1695,7 @@ def main() -> int:
 		)
 		print(migration_output)
 		print(restart_output)
+		print(v8_boundary_output)
 		print(contract_output)
 		print(account_composition_output)
 		print(bootstrap_output)


### PR DESCRIPTION
## Summary

- persist exact-microsecond five-hour and seven-day quota observations
- add inert account/window exclusion transactions with durable idempotent receipts
- fail closed on malformed, stale, ambiguous, or low-confidence quota facts

## Migration

- breaking V8 pre-release schema transition; populated V7 quota state requires disposable-database recreation

## Verification

- fresh exact-candidate reviewer verdict: APPROVED/READY
- owner validation: 24 Rust tests, PostgreSQL 18 harness 38/38, architecture/gate/audit tests, strict Clippy, pinned rustfmt, and diff check
- Manager independently verified signed commit 3eec9e5579ddff411eb79ed59fa28d8d4b09d96f and exact 14-file frozen tree

Linear: XY-1274