### PR TITLE
XY-1272: Close PostgreSQL configured-principal and ACL authority

### DIFF
--- a/crates/decodex-postgres/src/authority.rs
+++ b/crates/decodex-postgres/src/authority.rs
@@ -1587,6 +1587,486 @@ const SCHEMA_CONTRACT_SHA256: [u8; 32] = [
 	0xae, 0x1f, 0xb7, 0x45, 0x9f, 0xf8, 0x07, 0x19, 0x10, 0x16, 0x9f, 0xa1, 0x48, 0x31, 0x11, 0xdc,
 	0xf0, 0xc8, 0xc8, 0xe7, 0xc8, 0x15, 0x59, 0xe0, 0x3d, 0xf7, 0x69, 0x2d, 0x1a, 0xca, 0x9c, 0x7e,
 ];
+// The shipped authority permits no role settings. Record only cardinality so any setting
+// fails closed without copying an arbitrary custom-GUC value into the manifest or digest input.
+const CONFIGURED_AUTHORITY_SQL: &str = r#"
+WITH RECURSIVE configured_principals(label, role_name) AS (
+  VALUES ('migration'::pg_catalog.text, $1::pg_catalog.name),
+         ('runtime'::pg_catalog.text, $2::pg_catalog.name)
+), configured_roles AS (
+  SELECT
+    configured.label, configured.role_name, role.oid, role.rolname,
+    role.rolsuper, role.rolinherit, role.rolcreaterole, role.rolcreatedb,
+    role.rolcanlogin, role.rolreplication, role.rolconnlimit, role.rolvaliduntil,
+    role.rolbypassrls, role.rolconfig
+  FROM configured_principals AS configured
+  LEFT JOIN pg_catalog.pg_roles AS role ON role.rolname = configured.role_name
+), membership_roles(oid) AS (
+  SELECT oid FROM configured_roles WHERE oid IS NOT NULL
+  UNION
+  SELECT endpoint.oid
+  FROM membership_roles AS reached
+  JOIN pg_catalog.pg_auth_members AS membership
+    ON membership.roleid = reached.oid OR membership.member = reached.oid
+  CROSS JOIN LATERAL (
+    VALUES (membership.roleid), (membership.member)
+  ) AS endpoint(oid)
+), relevant_roles AS (
+  SELECT
+    role.oid, role.rolname, role.rolsuper, role.rolinherit, role.rolcreaterole,
+    role.rolcreatedb, role.rolcanlogin, role.rolreplication, role.rolconnlimit,
+    role.rolvaliduntil, role.rolbypassrls, role.rolconfig
+  FROM pg_catalog.pg_roles AS role
+  WHERE role.oid IN (SELECT oid FROM membership_roles)
+), configured_database AS (
+  SELECT database.*
+  FROM pg_catalog.pg_database AS database
+  WHERE database.datname = pg_catalog.current_database()
+), relevant_namespaces AS (
+  SELECT namespace.*
+  FROM pg_catalog.pg_namespace AS namespace
+  WHERE namespace.nspname IN ('decodex', 'public')
+), decodex_classes AS (
+  SELECT class.*, namespace.nspname
+  FROM pg_catalog.pg_class AS class
+  JOIN relevant_namespaces AS namespace
+    ON namespace.oid = class.relnamespace AND namespace.nspname = 'decodex'
+), ledger_class AS (
+  SELECT class.*, namespace.nspname
+  FROM pg_catalog.pg_class AS class
+  JOIN relevant_namespaces AS namespace
+    ON namespace.oid = class.relnamespace AND namespace.nspname = 'public'
+  WHERE class.relname = 'refinery_schema_history' AND class.relkind IN ('r', 'p')
+), authority_classes AS (
+  SELECT * FROM decodex_classes
+  UNION ALL
+  SELECT * FROM ledger_class
+), authority_objects(kind, identity, owner_oid, acl) AS (
+  SELECT
+    'database', 'configured_database', database.datdba,
+    COALESCE(database.datacl, pg_catalog.acldefault('d', database.datdba))
+  FROM configured_database AS database
+  UNION ALL
+  SELECT
+    'namespace', namespace.nspname, namespace.nspowner,
+    COALESCE(namespace.nspacl, pg_catalog.acldefault('n', namespace.nspowner))
+  FROM relevant_namespaces AS namespace
+  UNION ALL
+  SELECT
+    CASE WHEN class.relkind = 'S' THEN 'sequence' ELSE 'relation' END,
+    pg_catalog.format('%I.%I', class.nspname, class.relname), class.relowner,
+    COALESCE(
+      class.relacl,
+      pg_catalog.acldefault(
+        (CASE WHEN class.relkind = 'S' THEN 's' ELSE 'r' END)::pg_catalog."char",
+        class.relowner
+      )
+    )
+  FROM decodex_classes AS class
+  WHERE class.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
+  UNION ALL
+  SELECT
+    'migration_ledger', pg_catalog.format('%I.%I', class.nspname, class.relname),
+    class.relowner, COALESCE(class.relacl, pg_catalog.acldefault('r', class.relowner))
+  FROM ledger_class AS class
+  UNION ALL
+  SELECT
+    'type', pg_catalog.format('%I.%I', namespace.nspname, type.typname), type.typowner,
+    COALESCE(type.typacl, pg_catalog.acldefault('T', type.typowner))
+  FROM pg_catalog.pg_type AS type
+  JOIN relevant_namespaces AS namespace
+    ON namespace.oid = type.typnamespace AND namespace.nspname = 'decodex'
+  UNION ALL
+  SELECT
+    'function',
+    pg_catalog.format(
+      '%I.%I(%s)', namespace.nspname, proc.proname,
+      pg_catalog.pg_get_function_identity_arguments(proc.oid)
+    ),
+    proc.proowner, COALESCE(proc.proacl, pg_catalog.acldefault('f', proc.proowner))
+  FROM pg_catalog.pg_proc AS proc
+  JOIN relevant_namespaces AS namespace
+    ON namespace.oid = proc.pronamespace AND namespace.nspname = 'decodex'
+), contract_rows(kind, identity, contract) AS (
+  SELECT
+    'principal',
+    configured.label,
+    pg_catalog.jsonb_build_array(
+      configured.oid IS NOT NULL,
+      configured.rolsuper,
+      configured.rolinherit,
+      configured.rolcreaterole,
+      configured.rolcreatedb,
+      configured.rolcanlogin,
+      configured.rolreplication,
+      configured.rolconnlimit,
+      CASE WHEN configured.rolvaliduntil IS NULL THEN NULL ELSE
+        pg_catalog.to_char(
+          configured.rolvaliduntil AT TIME ZONE 'UTC',
+          'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+        )
+      END,
+      configured.rolbypassrls,
+      COALESCE(pg_catalog.cardinality(configured.rolconfig), 0)
+    )::pg_catalog.text
+  FROM configured_roles AS configured
+  UNION ALL
+  SELECT
+    'reachable_principal',
+    'other:' || role.rolname,
+    pg_catalog.jsonb_build_array(
+      role.rolsuper, role.rolinherit, role.rolcreaterole, role.rolcreatedb,
+      role.rolcanlogin, role.rolreplication, role.rolconnlimit,
+      CASE WHEN role.rolvaliduntil IS NULL THEN NULL ELSE
+        pg_catalog.to_char(
+          role.rolvaliduntil AT TIME ZONE 'UTC',
+          'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+        )
+      END,
+      role.rolbypassrls,
+      COALESCE(pg_catalog.cardinality(role.rolconfig), 0)
+    )::pg_catalog.text
+  FROM relevant_roles AS role
+  WHERE role.oid NOT IN (SELECT oid FROM configured_roles WHERE oid IS NOT NULL)
+  UNION ALL
+  SELECT
+    'role_membership',
+    pg_catalog.format(
+      '%s->%s',
+      CASE
+        WHEN membership.roleid = (SELECT oid FROM configured_roles WHERE label = 'migration')
+          THEN 'migration'
+        WHEN membership.roleid = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+          THEN 'runtime'
+        ELSE 'other:' || pg_catalog.pg_get_userbyid(membership.roleid)
+      END,
+      CASE
+        WHEN membership.member = (SELECT oid FROM configured_roles WHERE label = 'migration')
+          THEN 'migration'
+        WHEN membership.member = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+          THEN 'runtime'
+        ELSE 'other:' || pg_catalog.pg_get_userbyid(membership.member)
+      END
+    ),
+    pg_catalog.jsonb_build_array(
+      CASE
+        WHEN membership.grantor = (SELECT oid FROM configured_roles WHERE label = 'migration')
+          THEN 'migration'
+        WHEN membership.grantor = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+          THEN 'runtime'
+        ELSE 'other:' || pg_catalog.pg_get_userbyid(membership.grantor)
+      END,
+      membership.admin_option,
+      membership.inherit_option,
+      membership.set_option
+    )::pg_catalog.text
+  FROM pg_catalog.pg_auth_members AS membership
+  WHERE membership.roleid IN (SELECT oid FROM membership_roles)
+    AND membership.member IN (SELECT oid FROM membership_roles)
+  UNION ALL
+  SELECT
+    'role_setting',
+    pg_catalog.format(
+      '%s:%s',
+      CASE
+        WHEN setting.setrole = 0 THEN 'ALL'
+        WHEN setting.setrole = (SELECT oid FROM configured_roles WHERE label = 'migration')
+          THEN 'migration'
+        WHEN setting.setrole = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+          THEN 'runtime'
+        ELSE 'other:' || pg_catalog.pg_get_userbyid(setting.setrole)
+      END,
+      CASE WHEN setting.setdatabase = 0 THEN 'global' ELSE 'configured_database' END
+    ),
+    pg_catalog.jsonb_build_array(
+      COALESCE(pg_catalog.cardinality(setting.setconfig), 0)
+    )::pg_catalog.text
+  FROM pg_catalog.pg_db_role_setting AS setting
+  WHERE (
+      setting.setrole IN (SELECT oid FROM membership_roles)
+      AND setting.setdatabase IN (0, (SELECT oid FROM configured_database))
+    ) OR (
+      setting.setrole = 0 AND setting.setdatabase = (SELECT oid FROM configured_database)
+    )
+  UNION ALL
+  SELECT
+    object.kind,
+    object.identity,
+    pg_catalog.jsonb_build_array(
+      CASE
+        WHEN object.owner_oid = (SELECT oid FROM configured_roles WHERE label = 'migration')
+          THEN 'migration'
+        WHEN object.owner_oid = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+          THEN 'runtime'
+        ELSE 'other:' || pg_catalog.pg_get_userbyid(object.owner_oid)
+      END,
+      COALESCE((
+        SELECT pg_catalog.jsonb_agg(
+          pg_catalog.jsonb_build_array(
+            CASE
+              WHEN privilege.grantor = (SELECT oid FROM configured_roles WHERE label = 'migration')
+                THEN 'migration'
+              WHEN privilege.grantor = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+                THEN 'runtime'
+              ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantor)
+            END,
+            CASE
+              WHEN privilege.grantee = 0 THEN 'PUBLIC'
+              WHEN privilege.grantee = (SELECT oid FROM configured_roles WHERE label = 'migration')
+                THEN 'migration'
+              WHEN privilege.grantee = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+                THEN 'runtime'
+              ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantee)
+            END,
+            privilege.privilege_type,
+            privilege.is_grantable
+          ) ORDER BY
+            CASE
+              WHEN privilege.grantor = (SELECT oid FROM configured_roles WHERE label = 'migration')
+                THEN 'migration'
+              WHEN privilege.grantor = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+                THEN 'runtime'
+              ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantor)
+            END,
+            CASE
+              WHEN privilege.grantee = 0 THEN 'PUBLIC'
+              WHEN privilege.grantee = (SELECT oid FROM configured_roles WHERE label = 'migration')
+                THEN 'migration'
+              WHEN privilege.grantee = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+                THEN 'runtime'
+              ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantee)
+            END,
+            privilege.privilege_type,
+            privilege.is_grantable
+        )
+        FROM pg_catalog.aclexplode(object.acl) AS privilege
+      ), '[]'::pg_catalog.jsonb)
+    )::pg_catalog.text
+  FROM authority_objects AS object
+  UNION ALL
+  SELECT
+    'relation_mode',
+    pg_catalog.format('%I.%I', class.nspname, class.relname),
+    pg_catalog.jsonb_build_array(
+      class.relkind, class.relpersistence, class.relrowsecurity,
+      class.relforcerowsecurity, class.relreplident
+    )::pg_catalog.text
+  FROM authority_classes AS class
+  WHERE class.relkind IN ('r', 'p', 'v', 'm', 'f')
+  UNION ALL
+  SELECT
+    'column_acl',
+    pg_catalog.format('%I.%I.%I', class.nspname, class.relname, attribute.attname),
+    COALESCE((
+      SELECT pg_catalog.jsonb_agg(
+        pg_catalog.jsonb_build_array(
+          CASE
+            WHEN privilege.grantor = (SELECT oid FROM configured_roles WHERE label = 'migration')
+              THEN 'migration'
+            WHEN privilege.grantor = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+              THEN 'runtime'
+            ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantor)
+          END,
+          CASE
+            WHEN privilege.grantee = 0 THEN 'PUBLIC'
+            WHEN privilege.grantee = (SELECT oid FROM configured_roles WHERE label = 'migration')
+              THEN 'migration'
+            WHEN privilege.grantee = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+              THEN 'runtime'
+            ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantee)
+          END,
+          privilege.privilege_type,
+          privilege.is_grantable
+        ) ORDER BY
+          CASE
+            WHEN privilege.grantor = (SELECT oid FROM configured_roles WHERE label = 'migration')
+              THEN 'migration'
+            WHEN privilege.grantor = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+              THEN 'runtime'
+            ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantor)
+          END,
+          CASE
+            WHEN privilege.grantee = 0 THEN 'PUBLIC'
+            WHEN privilege.grantee = (SELECT oid FROM configured_roles WHERE label = 'migration')
+              THEN 'migration'
+            WHEN privilege.grantee = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+              THEN 'runtime'
+            ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantee)
+          END,
+          privilege.privilege_type,
+          privilege.is_grantable
+      )
+      FROM pg_catalog.aclexplode(
+        COALESCE(attribute.attacl, pg_catalog.acldefault('c', class.relowner))
+      ) AS privilege
+    ), '[]'::pg_catalog.jsonb)::pg_catalog.text
+  FROM pg_catalog.pg_attribute AS attribute
+  JOIN authority_classes AS class ON class.oid = attribute.attrelid
+  WHERE attribute.attnum > 0 AND NOT attribute.attisdropped
+  UNION ALL
+  SELECT
+    'trigger_definition',
+    pg_catalog.format('%I.%I.%I', class.nspname, class.relname, trigger.tgname),
+    pg_catalog.jsonb_build_array(
+      pg_catalog.pg_get_triggerdef(trigger.oid, false),
+      trigger.tgenabled,
+      CASE
+        WHEN class.relowner = (SELECT oid FROM configured_roles WHERE label = 'migration')
+          THEN 'migration'
+        WHEN class.relowner = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+          THEN 'runtime'
+        ELSE 'other:' || pg_catalog.pg_get_userbyid(class.relowner)
+      END,
+      pg_catalog.format(
+        '%I.%I(%s)', function_namespace.nspname, proc.proname,
+        pg_catalog.pg_get_function_identity_arguments(proc.oid)
+      ),
+      CASE
+        WHEN proc.proowner = (SELECT oid FROM configured_roles WHERE label = 'migration')
+          THEN 'migration'
+        WHEN proc.proowner = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+          THEN 'runtime'
+        ELSE 'other:' || pg_catalog.pg_get_userbyid(proc.proowner)
+      END
+    )::pg_catalog.text
+  FROM pg_catalog.pg_trigger AS trigger
+  JOIN authority_classes AS class ON class.oid = trigger.tgrelid
+  JOIN pg_catalog.pg_proc AS proc ON proc.oid = trigger.tgfoid
+  JOIN pg_catalog.pg_namespace AS function_namespace ON function_namespace.oid = proc.pronamespace
+  WHERE NOT trigger.tgisinternal
+     OR trigger.tgrelid IN (SELECT oid FROM ledger_class)
+  UNION ALL
+  SELECT
+    'rule_definition',
+    pg_catalog.format('%I.%I.%I', class.nspname, class.relname, rewrite.rulename),
+    pg_catalog.jsonb_build_array(
+      pg_catalog.pg_get_ruledef(rewrite.oid, false),
+      CASE
+        WHEN class.relowner = (SELECT oid FROM configured_roles WHERE label = 'migration')
+          THEN 'migration'
+        WHEN class.relowner = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+          THEN 'runtime'
+        ELSE 'other:' || pg_catalog.pg_get_userbyid(class.relowner)
+      END
+    )::pg_catalog.text
+  FROM pg_catalog.pg_rewrite AS rewrite
+  JOIN authority_classes AS class ON class.oid = rewrite.ev_class
+  UNION ALL
+  SELECT
+    'policy_definition',
+    pg_catalog.format('%I.%I.%I', class.nspname, class.relname, policy.polname),
+    pg_catalog.jsonb_build_array(
+      policy.polcmd,
+      policy.polpermissive,
+      COALESCE((
+        SELECT pg_catalog.jsonb_agg(
+          CASE
+            WHEN policy_role = 0 THEN 'PUBLIC'
+            WHEN policy_role = (SELECT oid FROM configured_roles WHERE label = 'migration')
+              THEN 'migration'
+            WHEN policy_role = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+              THEN 'runtime'
+            ELSE 'other:' || pg_catalog.pg_get_userbyid(policy_role)
+          END ORDER BY
+          CASE
+            WHEN policy_role = 0 THEN 'PUBLIC'
+            WHEN policy_role = (SELECT oid FROM configured_roles WHERE label = 'migration')
+              THEN 'migration'
+            WHEN policy_role = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+              THEN 'runtime'
+            ELSE 'other:' || pg_catalog.pg_get_userbyid(policy_role)
+          END
+        )
+        FROM pg_catalog.unnest(policy.polroles) AS policy_role
+      ), '[]'::pg_catalog.jsonb),
+      pg_catalog.pg_get_expr(policy.polqual, policy.polrelid),
+      pg_catalog.pg_get_expr(policy.polwithcheck, policy.polrelid),
+      CASE
+        WHEN class.relowner = (SELECT oid FROM configured_roles WHERE label = 'migration')
+          THEN 'migration'
+        WHEN class.relowner = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+          THEN 'runtime'
+        ELSE 'other:' || pg_catalog.pg_get_userbyid(class.relowner)
+      END
+    )::pg_catalog.text
+  FROM pg_catalog.pg_policy AS policy
+  JOIN authority_classes AS class ON class.oid = policy.polrelid
+  UNION ALL
+  SELECT
+    'default_acl',
+    pg_catalog.format(
+      '%s:%s:%s',
+      CASE
+        WHEN default_acl.defaclrole = (SELECT oid FROM configured_roles WHERE label = 'migration')
+          THEN 'migration'
+        WHEN default_acl.defaclrole = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+          THEN 'runtime'
+        ELSE 'other:' || pg_catalog.pg_get_userbyid(default_acl.defaclrole)
+      END,
+      CASE
+        WHEN default_acl.defaclnamespace = 0 THEN 'global'
+        ELSE namespace.nspname
+      END,
+      default_acl.defaclobjtype
+    ),
+    COALESCE((
+      SELECT pg_catalog.jsonb_agg(
+        pg_catalog.jsonb_build_array(
+          CASE
+            WHEN privilege.grantor = (SELECT oid FROM configured_roles WHERE label = 'migration')
+              THEN 'migration'
+            WHEN privilege.grantor = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+              THEN 'runtime'
+            ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantor)
+          END,
+          CASE
+            WHEN privilege.grantee = 0 THEN 'PUBLIC'
+            WHEN privilege.grantee = (SELECT oid FROM configured_roles WHERE label = 'migration')
+              THEN 'migration'
+            WHEN privilege.grantee = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+              THEN 'runtime'
+            ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantee)
+          END,
+          privilege.privilege_type,
+          privilege.is_grantable
+        ) ORDER BY
+          CASE
+            WHEN privilege.grantor = (SELECT oid FROM configured_roles WHERE label = 'migration')
+              THEN 'migration'
+            WHEN privilege.grantor = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+              THEN 'runtime'
+            ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantor)
+          END,
+          CASE
+            WHEN privilege.grantee = 0 THEN 'PUBLIC'
+            WHEN privilege.grantee = (SELECT oid FROM configured_roles WHERE label = 'migration')
+              THEN 'migration'
+            WHEN privilege.grantee = (SELECT oid FROM configured_roles WHERE label = 'runtime')
+              THEN 'runtime'
+            ELSE 'other:' || pg_catalog.pg_get_userbyid(privilege.grantee)
+          END,
+          privilege.privilege_type,
+          privilege.is_grantable
+      )
+      FROM pg_catalog.aclexplode(default_acl.defaclacl) AS privilege
+    ), '[]'::pg_catalog.jsonb)::pg_catalog.text
+  FROM pg_catalog.pg_default_acl AS default_acl
+  LEFT JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = default_acl.defaclnamespace
+  WHERE (
+      default_acl.defaclrole IN (SELECT oid FROM configured_roles WHERE oid IS NOT NULL)
+      AND (default_acl.defaclnamespace = 0 OR namespace.nspname IN ('decodex', 'public'))
+    ) OR namespace.nspname IN ('decodex', 'public')
+)
+SELECT pg_catalog.jsonb_agg(
+  pg_catalog.jsonb_build_array(kind, identity, contract)
+  ORDER BY kind, identity, contract
+)::pg_catalog.text
+FROM contract_rows
+"#;
+const CONFIGURED_AUTHORITY_SHA256: [u8; 32] = [
+	0x9d, 0x90, 0xe4, 0xc8, 0x30, 0x19, 0xe5, 0x53, 0xa0, 0xe4, 0xa9, 0x38, 0x39, 0x1a, 0x84, 0xf2,
+	0x95, 0x03, 0x9f, 0x58, 0x37, 0x9e, 0x81, 0x24, 0xe0, 0x58, 0x51, 0xbc, 0x3c, 0x2c, 0x8a, 0x3a,
+];
 const EXTENSION_AUTHORITY_SQL: &str = r#"
 WITH set_roles AS (
   SELECT role.oid
@@ -1727,7 +2207,17 @@ pub(crate) const fn schema_contract_sql_fixture() -> &'static str {
 	SCHEMA_CONTRACT_SQL
 }
 
-pub(crate) async fn verify_runtime(client: &Client) -> Result<(), StoreError> {
+#[cfg(feature = "test-support")]
+pub(crate) const fn configured_authority_sql_fixture() -> &'static str {
+	CONFIGURED_AUTHORITY_SQL
+}
+
+pub(crate) async fn verify_runtime(
+	client: &Client,
+	migration_role: &str,
+	runtime_role: &str,
+) -> Result<(), StoreError> {
+	verify_configured_authority(client, migration_role, runtime_role).await?;
 	verify_forbidden_authority(client).await?;
 	verify_identity_cast_authority(client).await?;
 	verify_execution_path_contract(client).await?;
@@ -1853,6 +2343,41 @@ async fn verify_schema_contract(client: &Client) -> Result<(), StoreError> {
 		return Err(StoreError::Incompatible(format!(
 			"PostgreSQL Decodex schema contract differs from the shipped PG18 inventory ({actual})"
 		)));
+	}
+
+	Ok(())
+}
+
+async fn verify_configured_authority(
+	client: &Client,
+	migration_role: &str,
+	runtime_role: &str,
+) -> Result<(), StoreError> {
+	let session_is_runtime: bool = client
+		.query_one(
+			"SELECT session_user = $1::pg_catalog.name AND current_user = $1::pg_catalog.name",
+			&[&runtime_role],
+		)
+		.await?
+		.get(0);
+
+	if !session_is_runtime {
+		return Err(StoreError::UnsafeAuthority(
+			"PostgreSQL session identity differs from the configured runtime principal",
+		));
+	}
+
+	let manifest: Option<String> =
+		client.query_one(CONFIGURED_AUTHORITY_SQL, &[&migration_role, &runtime_role]).await?.get(0);
+	let manifest = manifest.ok_or_else(|| {
+		StoreError::Incompatible("PostgreSQL configured authority inventory is empty".into())
+	})?;
+	let digest = Sha256::digest(manifest.as_bytes());
+
+	if digest.as_slice() != CONFIGURED_AUTHORITY_SHA256 {
+		return Err(StoreError::UnsafeAuthority(
+			"PostgreSQL configured principal or ACL authority differs from the shipped PG18 inventory",
+		));
 	}
 
 	Ok(())
@@ -2092,11 +2617,91 @@ mod tests {
 	use std::collections::HashSet;
 
 	use crate::authority::{
-		CONVERSATION_MIGRATION, FOUNDATION_MIGRATION, FUNCTION_CONTRACTS,
-		IDENTITY_CAST_AUTHORITY_SQL, OWNED_OBJECT_CATALOGS, POLICY_MIGRATION,
-		PROGRAM_OBJECTIVE_MIGRATION, PROJECT_AGENT_MIGRATION, QUOTA_MIGRATION, ROLE_AUTHORITY_SQL,
-		SAFETY_FUNCTIONS, SCHEMA_CONTRACT_SHA256, SCHEMA_CONTRACT_SQL,
+		CONFIGURED_AUTHORITY_SHA256, CONFIGURED_AUTHORITY_SQL, CONVERSATION_MIGRATION,
+		FOUNDATION_MIGRATION, FUNCTION_CONTRACTS, IDENTITY_CAST_AUTHORITY_SQL,
+		OWNED_OBJECT_CATALOGS, POLICY_MIGRATION, PROGRAM_OBJECTIVE_MIGRATION,
+		PROJECT_AGENT_MIGRATION, QUOTA_MIGRATION, ROLE_AUTHORITY_SQL, SAFETY_FUNCTIONS,
+		SCHEMA_CONTRACT_SHA256, SCHEMA_CONTRACT_SQL,
 	};
+
+	#[test]
+	fn configured_authority_manifest_closes_postgres_18_principals_and_memberships() {
+		for required in [
+			"$1::pg_catalog.name",
+			"$2::pg_catalog.name",
+			"configured.rolsuper",
+			"configured.rolinherit",
+			"configured.rolcreaterole",
+			"configured.rolcreatedb",
+			"configured.rolcanlogin",
+			"configured.rolreplication",
+			"configured.rolconnlimit",
+			"configured.rolvaliduntil",
+			"configured.rolbypassrls",
+			"configured.rolconfig",
+			"membership.grantor",
+			"membership.admin_option",
+			"membership.inherit_option",
+			"membership.set_option",
+			"pg_catalog.pg_db_role_setting",
+		] {
+			assert!(CONFIGURED_AUTHORITY_SQL.contains(required), "{required}");
+		}
+
+		assert!(!CONFIGURED_AUTHORITY_SQL.contains("rolpassword"));
+		assert!(!CONFIGURED_AUTHORITY_SQL.contains("pg_authid"));
+		assert_ne!(CONFIGURED_AUTHORITY_SHA256, [0; 32]);
+	}
+
+	#[test]
+	fn configured_authority_never_serializes_role_setting_values() {
+		assert!(!CONFIGURED_AUTHORITY_SQL.contains("unnest(configured.rolconfig)"));
+		assert!(!CONFIGURED_AUTHORITY_SQL.contains("unnest(role.rolconfig)"));
+		assert!(!CONFIGURED_AUTHORITY_SQL.contains("unnest(setting.setconfig)"));
+		assert!(CONFIGURED_AUTHORITY_SQL.contains("cardinality(configured.rolconfig)"));
+		assert!(CONFIGURED_AUTHORITY_SQL.contains("cardinality(role.rolconfig)"));
+		assert!(CONFIGURED_AUTHORITY_SQL.contains("cardinality(setting.setconfig)"));
+	}
+
+	#[test]
+	fn configured_authority_manifest_closes_owned_objects_and_acl_grantors() {
+		for required in [
+			"'database', 'configured_database'",
+			"'namespace', namespace.nspname",
+			"'migration_ledger'",
+			"authority_classes AS (",
+			"JOIN authority_classes AS class ON class.oid = attribute.attrelid",
+			"JOIN authority_classes AS class ON class.oid = trigger.tgrelid",
+			"trigger.tgrelid IN (SELECT oid FROM ledger_class)",
+			"JOIN authority_classes AS class ON class.oid = rewrite.ev_class",
+			"JOIN authority_classes AS class ON class.oid = policy.polrelid",
+			"'relation_mode'",
+			"'column_acl'",
+			"'trigger_definition'",
+			"'rule_definition'",
+			"'policy_definition'",
+			"'default_acl'",
+			"class.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')",
+			"COALESCE(type.typacl, pg_catalog.acldefault('T', type.typowner))",
+			"COALESCE(proc.proacl, pg_catalog.acldefault('f', proc.proowner))",
+			"privilege.grantor",
+			"privilege.grantee",
+			"privilege.is_grantable",
+			"NOT trigger.tgisinternal",
+			"default_acl.defaclobjtype",
+		] {
+			assert!(CONFIGURED_AUTHORITY_SQL.contains(required), "{required}");
+		}
+	}
+
+	#[test]
+	fn configured_authority_semantic_labels_are_closed_to_configured_roles_and_public() {
+		assert_eq!(CONFIGURED_AUTHORITY_SQL.matches("VALUES ('migration'").count(), 1);
+		assert_eq!(CONFIGURED_AUTHORITY_SQL.matches("('runtime'").count(), 1);
+		assert!(CONFIGURED_AUTHORITY_SQL.contains("THEN 'PUBLIC'"));
+		assert!(CONFIGURED_AUTHORITY_SQL.contains("ELSE 'other:' ||"));
+		assert!(!CONFIGURED_AUTHORITY_SQL.contains("password"));
+	}
 
 	#[test]
 	fn postgres_18_owned_object_inventory_is_closed_in_one_authority_query() {

--- a/crates/decodex-postgres/src/lib.rs
+++ b/crates/decodex-postgres/src/lib.rs
@@ -72,6 +72,9 @@ pub const MAX_OPERATION_DURATION_MILLISECONDS: u64 = 365 * 24 * 60 * 60 * 1_000;
 const INVALID_DURATION: &str =
 	"duration must be a positive whole number of milliseconds no greater than 365 days";
 const INVALID_EVIDENCE: &str = "outbox evidence must contain a non-empty JSON value";
+// Omitting pg_catalog makes PostgreSQL search it implicitly before the explicitly configured
+// public ledger namespace, while leaving unqualified migration DDL targeted at public.
+const TRUSTED_SESSION_OPTIONS: &str = "-csearch_path=public";
 
 /// Product-state authority selected by this infrastructure owner.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -86,6 +89,8 @@ pub struct PostgresStore {
 	pool: Arc<Pool>,
 	#[cfg(unix)]
 	connector: VerifiedSocketConnect,
+	configured_migration_role: Arc<str>,
+	configured_runtime_role: Arc<str>,
 }
 impl PostgresStore {
 	/// Return the exact schema-manifest query for isolated dump/restore fixtures.
@@ -93,6 +98,20 @@ impl PostgresStore {
 	#[doc(hidden)]
 	pub const fn schema_contract_sql_fixture() -> &'static str {
 		authority::schema_contract_sql_fixture()
+	}
+
+	/// Return the configured-principal and ACL manifest query for isolated restore fixtures.
+	#[cfg(feature = "test-support")]
+	#[doc(hidden)]
+	pub const fn configured_authority_sql_fixture() -> &'static str {
+		authority::configured_authority_sql_fixture()
+	}
+
+	/// Apply the production connection-startup invariant to an isolated raw fixture.
+	#[cfg(feature = "test-support")]
+	#[doc(hidden)]
+	pub fn pin_session_search_path_fixture(config: &mut Config) {
+		pin_session_search_path(config);
 	}
 
 	/// Run migration/verification through the migration identity, close it, then retain
@@ -133,7 +152,7 @@ impl PostgresStore {
 	#[cfg(unix)]
 	async fn connect_with_pool_size(
 		migration: Config,
-		runtime: Config,
+		mut runtime: Config,
 		expected_peer_uid: u32,
 		pool_size: usize,
 	) -> Result<Self, StoreError> {
@@ -141,9 +160,17 @@ impl PostgresStore {
 		validate_connection(&runtime)?;
 		validate_separation(&migration, &runtime)?;
 
+		let configured_migration_role = Arc::<str>::from(
+			migration.get_user().ok_or(StoreError::InvalidInput("migration role is absent"))?,
+		);
+		let configured_runtime_role = Arc::<str>::from(
+			runtime.get_user().ok_or(StoreError::InvalidInput("runtime role is absent"))?,
+		);
 		let connector = verified_socket_connect(&migration, expected_peer_uid)?;
 
 		Self::migrate_with_connector(migration, connector.clone()).await?;
+
+		pin_session_search_path(&mut runtime);
 
 		let manager = Manager::from_connect(
 			runtime,
@@ -153,7 +180,8 @@ impl PostgresStore {
 		let pool = Pool::builder(manager).max_size(pool_size).build()?;
 		let client = checkout(&pool, &connector).await?;
 
-		authority::verify_runtime(&client).await?;
+		authority::verify_runtime(&client, &configured_migration_role, &configured_runtime_role)
+			.await?;
 		migrations::verify(&client).await?;
 
 		drop(client);
@@ -165,7 +193,12 @@ impl PostgresStore {
 			drop((first, second));
 		}
 
-		Ok(Self { pool: Arc::new(pool), connector })
+		Ok(Self {
+			pool: Arc::new(pool),
+			connector,
+			configured_migration_role,
+			configured_runtime_role,
+		})
 	}
 
 	#[cfg(not(unix))]
@@ -192,12 +225,15 @@ impl PostgresStore {
 	#[cfg(all(unix, feature = "test-support"))]
 	#[doc(hidden)]
 	pub async fn migrate_fixture_through_v7(
-		config: Config,
+		mut config: Config,
 		expected_peer_uid: u32,
 	) -> Result<(), StoreError> {
 		validate_connection(&config)?;
 
 		let connector = verified_socket_connect(&config, expected_peer_uid)?;
+
+		pin_session_search_path(&mut config);
+
 		let manager = Manager::from_connect(
 			config,
 			connector.clone(),
@@ -221,9 +257,11 @@ impl PostgresStore {
 
 	#[cfg(unix)]
 	async fn migrate_with_connector(
-		config: Config,
+		mut config: Config,
 		connector: VerifiedSocketConnect,
 	) -> Result<(), StoreError> {
+		pin_session_search_path(&mut config);
+
 		let manager = Manager::from_connect(
 			config,
 			connector.clone(),
@@ -263,7 +301,12 @@ impl PostgresStore {
 
 		client.simple_query("SELECT 1").await?;
 
-		authority::verify_runtime(&client).await?;
+		authority::verify_runtime(
+			&client,
+			&self.configured_migration_role,
+			&self.configured_runtime_role,
+		)
+		.await?;
 		migrations::verify(&client).await?;
 
 		self.connector.verify()?;
@@ -369,6 +412,13 @@ pub(crate) fn ensure_credential_negative_json(value: &Value) -> Result<(), Store
 	}
 
 	Ok(())
+}
+
+fn pin_session_search_path(config: &mut Config) {
+	// Startup-packet options are applied by PostgreSQL before it parses the first query.
+	// Replacing caller-provided options prevents role/database defaults from influencing
+	// migration, identity, schema, or configured-authority verification.
+	config.options(TRUSTED_SESSION_OPTIONS);
 }
 
 #[cfg(unix)]

--- a/crates/decodex-postgres/tests/postgres_store.rs
+++ b/crates/decodex-postgres/tests/postgres_store.rs
@@ -313,15 +313,61 @@ async fn postgres_migration_contract() -> Result<(), Box<dyn std::error::Error>>
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires the isolated PostgreSQL 18 hostile-search-path harness"]
+#[cfg(feature = "test-support")]
+async fn postgres_session_search_path_startup_fixture() -> Result<(), Box<dyn std::error::Error>> {
+	let (_, mut runtime) = separated_configs("DECODEX_TEST")?;
+
+	PostgresStore::pin_session_search_path_fixture(&mut runtime);
+
+	let (client, connection) = runtime.connect(NoTls).await?;
+	let connection_task = tokio::spawn(connection);
+	let path = client
+		.query_one(
+			"SELECT pg_catalog.current_setting('search_path'), \
+			 pg_catalog.current_schemas(true) = ARRAY['pg_catalog','public']::pg_catalog.name[]",
+			&[],
+		)
+		.await?;
+	let search_path: String = path.get(0);
+	let catalogs_first: bool = path.get(1);
+
+	assert_eq!(search_path, "public");
+	assert!(catalogs_first);
+
+	drop(client);
+
+	connection_task.await??;
+
+	Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires an isolated PostgreSQL 18 schema-manifest database"]
 #[cfg(feature = "test-support")]
 async fn postgres_schema_manifest_dump_fixture() -> Result<(), Box<dyn std::error::Error>> {
 	let path = env::var("DECODEX_SCHEMA_MANIFEST_PATH")?;
-	let (migration, _) = separated_configs("DECODEX_TEST")?;
+	let (mut migration, runtime) = separated_configs("DECODEX_TEST")?;
+	let migration_role = migration.get_user().ok_or("migration role is absent")?.to_owned();
+	let runtime_role = runtime.get_user().ok_or("runtime role is absent")?.to_owned();
+
+	PostgresStore::pin_session_search_path_fixture(&mut migration);
+
 	let (client, connection) = migration.connect(NoTls).await?;
 	let connection_task = tokio::spawn(connection);
-	let manifest: String =
+	let schema: String =
 		client.query_one(PostgresStore::schema_contract_sql_fixture(), &[]).await?.get(0);
+	let authority: String = client
+		.query_one(
+			PostgresStore::configured_authority_sql_fixture(),
+			&[&migration_role, &runtime_role],
+		)
+		.await?
+		.get(0);
+	let manifest = serde_json::to_string(&serde_json::json!({
+		"authority": authority,
+		"schema": schema,
+	}))?;
 
 	fs::write(path, manifest)?;
 
@@ -2243,7 +2289,7 @@ async fn postgres_store_rejects_schema_scoped_default_acl_restore()
 	let (migration, runtime) = separated_configs("DECODEX_TEST")?;
 
 	match PostgresStore::connect(migration, runtime, expected_peer_uid()).await {
-		Err(StoreError::Incompatible(_)) => Ok(()),
+		Err(StoreError::UnsafeAuthority(_)) => Ok(()),
 		Err(error) => panic!("unexpected schema-scoped default-ACL restore error: {error:?}"),
 		Ok(_) => panic!("schema-scoped default-ACL restore was accepted"),
 	}

--- a/crates/decodex-runtime/tests/bootstrap_doctor.rs
+++ b/crates/decodex-runtime/tests/bootstrap_doctor.rs
@@ -987,7 +987,7 @@ async fn isolated_postgres_live_doctor_rejects_replaced_endpoint() {
 
 #[tokio::test]
 #[ignore = "requires the isolated PostgreSQL 18 bootstrap harness"]
-async fn isolated_postgres_live_doctor_detects_database_incompatibility() {
+async fn isolated_postgres_live_doctor_detects_database_drift() {
 	let root_path = PathBuf::from(
 		env::var("DECODEX_TEST_LIVE_INCOMPATIBLE_ROOT")
 			.expect("live-incompatible bootstrap root environment"),
@@ -1059,7 +1059,11 @@ async fn isolated_postgres_live_doctor_detects_database_incompatibility() {
 
 	assert_eq!(
 		changed.check(DoctorComponent::Database).expect("database check").status,
-		DoctorStatus::Unavailable(DoctorIssue::DatabaseIncompatible)
+		DoctorStatus::Unavailable(if env::var_os("DECODEX_TEST_LIVE_EXPECTED_UNSAFE").is_some() {
+			DoctorIssue::UnsafeDatabaseAuthority
+		} else {
+			DoctorIssue::DatabaseIncompatible
+		},)
 	);
 
 	drop(client);
@@ -1094,7 +1098,7 @@ async fn isolated_postgres_overprivileged_runtime_is_unavailable() {
 	)
 	.collect::<Vec<_>>();
 
-	assert_eq!(roots.len(), 27);
+	assert_eq!(roots.len(), 28);
 
 	for root_path in roots {
 		let bootstrap = ServiceComposition::bootstrap(
@@ -1124,7 +1128,7 @@ async fn isolated_postgres_incompatible_runtime_is_unavailable() {
 	)
 	.collect::<Vec<_>>();
 
-	assert_eq!(roots.len(), 6);
+	assert_eq!(roots.len(), 5);
 
 	for root_path in roots {
 		let bootstrap = ServiceComposition::bootstrap(
@@ -1145,7 +1149,7 @@ async fn isolated_postgres_incompatible_runtime_is_unavailable() {
 
 #[tokio::test]
 #[ignore = "requires the isolated PostgreSQL 18 bootstrap harness"]
-async fn isolated_postgres_hostile_search_path_is_available() {
+async fn isolated_postgres_hostile_search_path_is_unavailable() {
 	let root_path = PathBuf::from(
 		env::var("DECODEX_TEST_HOSTILE_SEARCH_ROOT")
 			.expect("isolated hostile-search root environment"),
@@ -1155,52 +1159,14 @@ async fn isolated_postgres_hostile_search_path_is_available() {
 	)
 	.await;
 
-	assert_eq!(status(&bootstrap, DoctorComponent::Database), DoctorStatus::Ready);
-	assert_eq!(bootstrap.product_state_availability(), Availability::Available);
-
-	let server_id = bootstrap.server_id().clone();
-	let bound = bootstrap
-		.bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)), ServerConfig::default())
-		.await
-		.expect("bind hostile-search daemon fixture");
-	let url = format!("ws://{}/v1/ws", bound.address());
-	let (mut client, _) =
-		tokio_tungstenite::connect_async(&url).await.expect("connect hostile-search client");
-
-	send(
-		&mut client,
-		ClientMessage::Hello(ClientHello {
-			version: CURRENT_VERSION,
-			expected_server_id: Some(server_id),
-			resume: None,
-		}),
-	)
-	.await;
-
-	assert!(matches!(receive(&mut client).await, ServerMessage::Welcome(_)));
-	assert!(matches!(receive(&mut client).await, ServerMessage::Snapshot(_)));
-
-	send(
-		&mut client,
-		ClientMessage::Query(doctor_query(CURRENT_VERSION, "hostile-catalog-doctor")),
-	)
-	.await;
-
-	let ServerMessage::QueryResult(result) = receive(&mut client).await else {
-		panic!("expected hostile-search doctor result");
-	};
-	let QueryResultPayload::DoctorStatus(report) = result.payload else {
-		panic!("expected doctor result");
-	};
-
 	assert_eq!(
-		report.check(DoctorComponent::Database).expect("database status is present").status,
-		DoctorStatus::Ready
+		status(&bootstrap, DoctorComponent::Database),
+		DoctorStatus::Unavailable(DoctorIssue::UnsafeDatabaseAuthority)
 	);
-
-	drop(client);
-
-	bound.shutdown().await.expect("shutdown hostile-search daemon fixture");
+	assert_eq!(
+		bootstrap.product_state_availability(),
+		Availability::Unavailable { reason: "configured PostgreSQL runtime authority is unsafe" }
+	);
 }
 
 async fn send<S>(client: &mut WebSocketStream<S>, message: ClientMessage)

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -365,7 +365,9 @@ insert/update/delete poisoning while the deferred parent reference prevents orph
 rollover/fallback rows are proposals only: their schema
 forces dispatch disabled. This slice exposes no account selection, live turn start/resume/steer,
 automatic rollover, Context-Pack dispatch, ambiguous replay, or scheduler wake; XY-1304 remains the
-separate failed enablement gate and XY-1272 owns thread-ownership reconciliation.
+separate failed enablement gate. XY-1304 owns experiment creation and positive observation
+acquisition; XY-1276 owns production Quick Task creation. XY-1272 owns only PostgreSQL
+configured-principal and ACL authority closure against V8, while XY-1337 owns the expected V9.
 
 The composition also reports conversation execution unavailable. Authentication, TLS,
 remote binding, HTTP artifact transfer, MCP, scheduling, live Codex execution, mutating

--- a/openwiki/decisions/vnext-authority.md
+++ b/openwiki/decisions/vnext-authority.md
@@ -41,6 +41,14 @@ reopens the architecture around PostgreSQL-in-transaction canonicalization. The 
 details and proof gates live in the authority contract and gate manifest; the three rejected
 old-boundary candidates remain historical provenance in the runtime proof.
 
+XY-1272 PostgreSQL-authority reset accepted 2026-07-16: XY-1272 owns only configured-principal
+and ACL manifest/readiness closure against landed V8. It owns no migration or Codex creation,
+mapping, or reconciliation surface. XY-1337 owns the expected V9; XY-1304 owns experiment creation
+and positive observation acquisition; XY-1276 owns production Quick Task creation. Lossy or
+paginated Codex evidence cannot authorize negative `Present`, `Complete`, or context-free `Absent`
+authority. A future configured PostgreSQL role must atomically extend configuration, bootstrap,
+manifest/readiness, and negative tests.
+
 ## Decision
 
 Decodex vNext is a rebuild of the agent workspace, not an incremental extension of the

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -139,10 +139,13 @@ authorization schemes, known token/key formats, credential assignments, embedded
 private-key headers. Ordinary prose containing words such as `secret`, `token`, or `session` is not
 credential material. PostgreSQL enforces the equivalent closed predicate. Nested/raw app-server JSON
 and unsupported, oversized, or credential-shaped forms are rejected.
-`thread/read(includeTurns=true)` is a lossy reconciliation source. External Codex activity
-may be provenance-imported for ordinary Quick/Advisor/Lead conversations; on an active
-ManagedRun it marks the session `diverged` and blocks side effects until tool/repository
-readback reconciles them.
+`thread/read(includeTurns=true)` and paginated/list evidence are lossy reconciliation sources.
+They may support positive observations, but never authorize a negative `Present`, `Complete`, or
+context-free `Absent` conclusion. Missing, truncated, or unobserved evidence remains unknown.
+Experiment creation and positive observation acquisition belong to XY-1304; production Quick Task
+creation belongs to XY-1276. External Codex activity may be provenance-imported for ordinary
+Quick/Advisor/Lead conversations; on an active ManagedRun it marks the session `diverged` and blocks
+side effects until tool/repository readback reconciles them.
 
 Long-term context consists of immutable Project, Advisor, and Program revisions. Project
 context records decisions, constraints, repository facts, active Programs/Objectives,

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -98,10 +98,13 @@ Permission is issue-scoped and does not bypass each issue's own dependencies:
 | XY-1269 | P and K may proceed independently under their own dependencies; L waits for P and K, and S waits for L. P, K, and L remain non-production and default-disabled. Only S owns production shell and exact final-artifact qualification. |
 | XY-1270 | Generated typed app-server contracts, live capability negotiation, redaction, and one-account-per-process supervision; no task scheduling or account choice. |
 | XY-1271 | Conversation/RuntimeSession/history and inspectable Context-Pack persistence; no automatic rollover, assignment, or fallback dispatch. |
-| XY-1272 | Transactional creation mappings, exact-ID/list reconciliation, explicit retention, and the ManagedRun `diverged` stop transition; no global title-search claim. |
+| XY-1272 | PostgreSQL configured-principal and ACL authority manifest/readiness closure against V8; no migration or Codex creation/reconciliation surface. Any future configured role must atomically extend configuration, bootstrap, manifest/readiness, and negative tests. |
 | XY-1273 | Credential-vault metadata and immutable runner/account binding; no sticky or policy assignment. |
 | XY-1274 | Exact-microsecond quota persistence, `/2` canonical mutation identity, atomic V8 zero-state migration, and durable exclusion transaction tests using synthetic fixtures only; no live exclusion, fallback assignment, or wake scheduling. |
 | XY-1275 | User-owned profile persistence and RuntimeSession snapshots. Account-owned plugin, skill, and MCP readiness remains typed `unknown`; XY-1336 neither closes nor blocks this issue. |
+| XY-1276 | Production Quick Task creation; remains blocked by XY-1304. |
+| XY-1304 | Experiment thread creation and positive observation acquisition, plus live routing enablement. Lossy or paginated evidence cannot authorize negative `Present`, `Complete`, or context-free `Absent` conclusions. |
+| XY-1337 | The next PostgreSQL migration, expected V9; V8 remains final until this owner lands it. |
 
 XY-1336 is an upstream-blocked tracking issue outside the M2 critical path. A host file,
 manifest, configuration value, remote catalog entry, process binding, or user declaration

--- a/scripts/vnext/postgres_store_test.py
+++ b/scripts/vnext/postgres_store_test.py
@@ -4,9 +4,12 @@
 from __future__ import annotations
 
 from enum import Enum
+import hashlib
 import json
 import os
 from pathlib import Path
+import secrets
+import select
 import shutil
 import subprocess
 import sys
@@ -251,6 +254,11 @@ def run_live_doctor_mutation(
 	case: str,
 	work: Path,
 	env: dict[str, str],
+	*,
+	unsafe_authority: bool = False,
+	cluster_authority: bool = False,
+	secret_sql: bool = False,
+	mutation_probe: str | None = None,
 ) -> str:
 	"""Coordinate a real daemon query around an adapter-owned database mutation."""
 	sync = work / f"live-doctor-{case}"
@@ -258,10 +266,12 @@ def run_live_doctor_mutation(
 	test_env = env.copy()
 	test_env["DECODEX_TEST_LIVE_INCOMPATIBLE_ROOT"] = str(root)
 	test_env["DECODEX_TEST_LIVE_INCOMPATIBLE_SYNC"] = str(sync)
+	if unsafe_authority:
+		test_env["DECODEX_TEST_LIVE_EXPECTED_UNSAFE"] = "1"
 	command = [
 		"cargo", "nextest", "run", "-p", "decodex-runtime", "--test",
 		"bootstrap_doctor", "--run-ignored", "all", "--",
-		"isolated_postgres_live_doctor_detects_database_incompatibility", "--exact",
+		"isolated_postgres_live_doctor_detects_database_drift", "--exact",
 	]
 	process = subprocess.Popen(
 		command,
@@ -276,33 +286,88 @@ def run_live_doctor_mutation(
 	while not (sync / "ready").exists():
 		if process.poll() is not None:
 			stdout, stderr = process.communicate()
+			if secret_sql:
+				raise TestFailure("live doctor exited before secret-bearing mutation")
 			raise TestFailure(
 				f"live doctor exited before {case} mutation\nstdout:\n{stdout}\nstderr:\n{stderr}"
 			)
 		if time.monotonic() >= deadline:
 			process.kill()
 			stdout, stderr = process.communicate()
+			if secret_sql:
+				raise TestFailure("live doctor did not reach the secret-bearing mutation barrier")
 			raise TestFailure(
 				f"live doctor did not reach {case} barrier\nstdout:\n{stdout}\nstderr:\n{stderr}"
 			)
 		time.sleep(0.01)
 
-	psql_as(MIGRATION_ROLE, database, sql, env)
+	if cluster_authority:
+		if secret_sql:
+			psql_secret(database, sql, env)
+		else:
+			psql(database, sql, env)
+	else:
+		psql_as(MIGRATION_ROLE, database, sql, env)
+	if mutation_probe is not None and psql(database, mutation_probe, env) != "t":
+		process.terminate()
+		process.communicate(timeout=10)
+		raise TestFailure(f"{case} authority mutation probe is vacuous")
 	(sync / "mutated").write_text("mutated", encoding="utf-8")
 	try:
 		stdout, stderr = process.communicate(timeout=30)
 	except subprocess.TimeoutExpired as error:
 		process.kill()
 		stdout, stderr = process.communicate()
+		if secret_sql:
+			raise TestFailure("live doctor did not finish the secret-bearing drift check") from error
 		raise TestFailure(
 			f"live doctor did not finish {case}\nstdout:\n{stdout}\nstderr:\n{stderr}"
 		) from error
 	if process.returncode != 0:
+		if secret_sql:
+			raise TestFailure("live doctor failed after the secret-bearing mutation")
 		raise TestFailure(
 			f"live doctor failed after {case} mutation\nstdout:\n{stdout}\nstderr:\n{stderr}"
 		)
 
 	return stdout.strip() or stderr.strip()
+
+
+def run_authority_drift_case(
+	root: Path,
+	database: str,
+	mutation: str,
+	restore: str,
+	case: str,
+	work: Path,
+	env: dict[str, str],
+	*,
+	cluster_authority: bool = False,
+	secret_sql: bool = False,
+	mutation_probe: str | None = None,
+) -> str:
+	"""Prove one live authority drift and restore the shared fixture exactly."""
+	try:
+		return run_live_doctor_mutation(
+			root,
+			database,
+			mutation,
+			case,
+			work,
+			env,
+			unsafe_authority=True,
+			cluster_authority=cluster_authority,
+			secret_sql=secret_sql,
+			mutation_probe=mutation_probe,
+		)
+	finally:
+		if cluster_authority:
+			if secret_sql:
+				psql_secret(database, restore, env)
+			else:
+				psql(database, restore, env)
+		else:
+			psql_as(MIGRATION_ROLE, database, restore, env)
 
 
 def postgres_status(data_dir: Path, env: dict[str, str]) -> ClusterStatus:
@@ -333,10 +398,116 @@ def psql(database: str, sql: str, env: dict[str, str]) -> str:
 	)
 
 
+def psql_secret(
+	database: str, sql: str, env: dict[str, str], *, expect_failure: bool = False
+) -> str:
+	"""Execute secret-bearing SQL only after one live session disables statement logging."""
+	ready_marker = "XY1272_SECRET_LOGGING_READY"
+	done_marker = "XY1272_SECRET_SQL_DONE"
+	process = subprocess.Popen(
+		["psql", "-X", "-qAt", "-v", "ON_ERROR_STOP=1", "-d", database],
+		text=True,
+		bufsize=1,
+		stdin=subprocess.PIPE,
+		stdout=subprocess.PIPE,
+		stderr=subprocess.PIPE,
+		env=env,
+		cwd=REPO_ROOT,
+	)
+	if process.stdin is None or process.stdout is None or process.stderr is None:
+		raise TestFailure("secret-bearing PostgreSQL fixture pipes are unavailable")
+	try:
+		process.stdin.write(
+			"SET log_min_error_statement=PANIC;\n"
+			"SET log_min_messages=PANIC;\n"
+			"SET log_statement=none;\n"
+			"SET log_duration=off;\n"
+			"SET log_min_duration_statement=-1;\n"
+			"SET log_min_duration_sample=-1;\n"
+			"SET log_statement_sample_rate=0;\n"
+			"SET log_transaction_sample_rate=0;\n"
+			"SET log_parameter_max_length=0;\n"
+			"SET log_parameter_max_length_on_error=0;\n"
+			"SET debug_print_parse=off;\n"
+			"SET debug_print_rewritten=off;\n"
+			"SET debug_print_plan=off;\n"
+			"SET log_parser_stats=off;\n"
+			"SET log_planner_stats=off;\n"
+			"SET log_executor_stats=off;\n"
+			"SET log_statement_stats=off;\n"
+			"SELECT pg_catalog.concat_ws('|',"
+			"pg_catalog.current_setting('log_min_error_statement'),"
+			"pg_catalog.current_setting('log_min_messages'),"
+			"pg_catalog.current_setting('log_statement'),"
+			"pg_catalog.current_setting('log_duration'),"
+			"pg_catalog.current_setting('log_min_duration_statement'),"
+			"pg_catalog.current_setting('log_min_duration_sample'),"
+			"pg_catalog.current_setting('log_statement_sample_rate'),"
+			"pg_catalog.current_setting('log_transaction_sample_rate'),"
+			"pg_catalog.current_setting('log_parameter_max_length'),"
+			"pg_catalog.current_setting('log_parameter_max_length_on_error'),"
+			"pg_catalog.current_setting('debug_print_parse'),"
+			"pg_catalog.current_setting('debug_print_rewritten'),"
+			"pg_catalog.current_setting('debug_print_plan'),"
+			"pg_catalog.current_setting('log_parser_stats'),"
+			"pg_catalog.current_setting('log_planner_stats'),"
+			"pg_catalog.current_setting('log_executor_stats'),"
+			"pg_catalog.current_setting('log_statement_stats'),"
+			"pg_catalog.current_setting('logging_collector'),"
+			"pg_catalog.current_setting('log_destination'));\n"
+			f"\\echo {ready_marker}\n"
+		)
+		process.stdin.flush()
+		ready, _, _ = select.select([process.stdout], [], [], 10)
+		if not ready:
+			raise TestFailure("secret-bearing PostgreSQL fixture logging check timed out")
+		settings = process.stdout.readline().strip()
+		if process.stdout.readline().strip() != ready_marker:
+			raise TestFailure("secret-bearing PostgreSQL fixture logging check did not complete")
+		expected = "panic|panic|none|off|-1|-1|0|0|0|0|off|off|off|off|off|off|off|off|stderr"
+		if settings != expected:
+			raise TestFailure("secret-bearing PostgreSQL fixture logging is not fail-closed")
+
+		process.stdin.write("\\set VERBOSITY terse\n")
+		if expect_failure:
+			process.stdin.write("\\set ON_ERROR_STOP off\n")
+		process.stdin.write(sql)
+		if not sql.rstrip().endswith(";"):
+			process.stdin.write(";")
+		process.stdin.write(f"\n\\echo {done_marker}\n\\quit\n")
+		process.stdin.flush()
+		stdout, stderr = process.communicate(timeout=10)
+		lines = stdout.splitlines()
+		if process.returncode != 0 or done_marker not in lines:
+			raise TestFailure("secret-bearing PostgreSQL fixture command failed")
+		if expect_failure:
+			if "ERROR:" not in stderr:
+				raise TestFailure("secret-bearing PostgreSQL failure probe unexpectedly succeeded")
+			return ""
+		if stderr:
+			raise TestFailure("secret-bearing PostgreSQL fixture emitted diagnostics")
+		return "\n".join(line for line in lines if line != done_marker).strip()
+	except subprocess.TimeoutExpired as error:
+		process.kill()
+		process.communicate()
+		raise TestFailure("secret-bearing PostgreSQL fixture command timed out") from error
+	finally:
+		if process.poll() is None:
+			process.terminate()
+			process.wait(timeout=10)
+
+
 def psql_as(role: str, database: str, sql: str, env: dict[str, str]) -> str:
 	role_env = env.copy()
 	role_env["PGUSER"] = role
 	return psql(database, sql, role_env)
+
+
+def assert_postgres_logs_redact(log_paths: tuple[Path, ...], markers: tuple[str, ...]) -> None:
+	for log_path in log_paths:
+		contents = log_path.read_bytes()
+		if any(marker.encode("utf-8") in contents for marker in markers):
+			raise TestFailure("PostgreSQL server log disclosed secret-bearing canary material")
 
 
 def assert_psql_rejected(
@@ -373,14 +544,16 @@ def create_database(database: str, env: dict[str, str], *, locale: str | None = 
 		locale_clause = f" LOCALE_PROVIDER icu ICU_LOCALE '{locale}'"
 	psql(
 		"postgres",
-		f"CREATE DATABASE {database} WITH TEMPLATE template0 ENCODING 'UTF8'{locale_clause}",
+		f"CREATE DATABASE {database} WITH TEMPLATE template0 ENCODING 'UTF8' "
+		f"OWNER {MIGRATION_ROLE}{locale_clause}",
 		env,
 	)
 	psql(database, f"GRANT USAGE, CREATE ON SCHEMA public TO {MIGRATION_ROLE}", env)
 	psql(
 		"postgres",
 		f"REVOKE CREATE ON DATABASE {database} FROM PUBLIC; "
-		f"GRANT CONNECT, CREATE ON DATABASE {database} TO {MIGRATION_ROLE}",
+		f"GRANT CONNECT, CREATE ON DATABASE {database} TO {MIGRATION_ROLE}; "
+		f"GRANT CONNECT ON DATABASE {database} TO {RUNTIME_ROLE}",
 		env,
 	)
 
@@ -563,6 +736,8 @@ def main() -> int:
 	socket_dir.mkdir()
 	# TCP is disabled; the port only distinguishes the socket filename inside this unique directory.
 	port = 55_432
+	role_setting_canary_guc = f"xy1272.canary_{secrets.token_hex(16)}"
+	role_setting_secret_canary = secrets.token_hex(32)
 	env = os.environ.copy()
 	initdb_path = Path(shutil.which("initdb") or "initdb").resolve()
 	postgres_share = initdb_path.parent.parent / "share" / "postgresql"
@@ -625,6 +800,8 @@ def main() -> int:
 				MEMBERSHIP_ADMIN_ROLE,
 			}
 			attributes = "" if role in group_roles else " LOGIN"
+			if role in {MIGRATION_ROLE, RUNTIME_ROLE}:
+				attributes += " NOINHERIT VALID UNTIL 'infinity'"
 			if role == UNSAFE_ROLES["bypassrls"]:
 				attributes += " BYPASSRLS"
 			elif role == UNSAFE_ROLES["superuser"]:
@@ -995,6 +1172,16 @@ def main() -> int:
 				unsafe_root, socket_dir, port, AUTHORITY_DATABASE, MIGRATION_ROLE, role
 			)
 			unsafe_roots.append(unsafe_root)
+		missing_select_root = work / "decodex-unsafe-missing-history-select"
+		write_bootstrap_config(
+			missing_select_root,
+			socket_dir,
+			port,
+			AUTHORITY_DATABASE,
+			MIGRATION_ROLE,
+			MISSING_SELECT_ROLE,
+		)
+		unsafe_roots.append(missing_select_root)
 
 		create_database(TRIGGER_DATABASE, env)
 		set_contract_urls(env, socket_dir, port, TRIGGER_DATABASE, RUNTIME_ROLE)
@@ -1278,15 +1465,6 @@ def main() -> int:
 		) != "t":
 			raise TestFailure("same-metadata no-op retention fixture is vacuous")
 
-		missing_select_root = work / "decodex-incompatible-missing-history-select"
-		write_bootstrap_config(
-			missing_select_root,
-			socket_dir,
-			port,
-			AUTHORITY_DATABASE,
-			MIGRATION_ROLE,
-			MISSING_SELECT_ROLE,
-		)
 		function_contract_root = work / "decodex-incompatible-function-contract"
 		write_bootstrap_config(
 			function_contract_root,
@@ -1481,7 +1659,6 @@ def main() -> int:
 			raise TestFailure("missing-pgcrypto fixture retained the extension")
 		env["DECODEX_TEST_INCOMPATIBLE_AUTHORITY_ROOTS"] = os.pathsep.join(
 			[
-				str(missing_select_root),
 				str(function_contract_root),
 				str(constraint_drift_root),
 				str(external_cascade_root),
@@ -1543,6 +1720,14 @@ def main() -> int:
 			env,
 		) != "t|t|t":
 			raise TestFailure("secure Decodex function path did not resist callable shadowing")
+		hostile_startup_path_output = run(
+			[
+				"cargo", "nextest", "run", "-p", "decodex-postgres", "--features",
+				"test-support", "--test", "postgres_store", "--run-ignored", "all", "--",
+				"postgres_session_search_path_startup_fixture", "--exact",
+			],
+			env,
+		)
 		if psql_as(
 			HOSTILE_SEARCH_ROLE,
 			HOSTILE_SEARCH_DATABASE,
@@ -1568,7 +1753,7 @@ def main() -> int:
 			[
 				"cargo", "nextest", "run", "-p", "decodex-runtime", "--test",
 				"bootstrap_doctor", "--run-ignored", "all", "--",
-				"isolated_postgres_hostile_search_path_is_available", "--exact",
+				"isolated_postgres_hostile_search_path_is_unavailable", "--exact",
 			],
 			env,
 		)
@@ -1595,12 +1780,20 @@ def main() -> int:
 		live_manifest = live_manifest_path.read_text()
 		restored_manifest = restored_manifest_path.read_text()
 		if live_manifest != restored_manifest:
-			live_rows = json.loads(live_manifest)
-			restored_rows = json.loads(restored_manifest)
+			live_document = json.loads(live_manifest)
+			restored_document = json.loads(restored_manifest)
+			changed = [
+				component for component in ("authority", "schema")
+				if live_document[component] != restored_document[component]
+			]
+			component = changed[0]
+			live_rows = json.loads(live_document[component])
+			restored_rows = json.loads(restored_document[component])
 			only_live = [row for row in live_rows if row not in restored_rows]
 			only_restored = [row for row in restored_rows if row not in live_rows]
 			raise TestFailure(
 				"dump/restore schema manifest changed\n"
+				f"component: {component}\n"
 				f"only live: {json.dumps(only_live[:8], indent=2)}\n"
 				f"only restored: {json.dumps(only_restored[:8], indent=2)}"
 			)
@@ -1622,6 +1815,68 @@ def main() -> int:
 				"--exact",
 			],
 			env,
+		)
+		canary_manifest_path = work / "schema-manifest-role-setting-canary.json"
+		canary_markers = (role_setting_canary_guc, role_setting_secret_canary)
+		psql_secret(
+			DATABASE,
+			f"ALTER ROLE xy1272_missing_secret_log_role SET {role_setting_canary_guc} = "
+			f"'{role_setting_secret_canary}'",
+			env,
+			expect_failure=True,
+		)
+		assert_postgres_logs_redact((log_path,), canary_markers)
+		psql_secret(
+			DATABASE,
+			f"ALTER ROLE {RUNTIME_ROLE} SET {role_setting_canary_guc} = "
+			f"'{role_setting_secret_canary}'",
+			env,
+		)
+		try:
+			catalog_probe = psql_secret(
+				DATABASE,
+				"SELECT count(*) FROM pg_catalog.pg_db_role_setting AS setting "
+				"CROSS JOIN LATERAL pg_catalog.unnest(setting.setconfig) AS item(value) "
+				f"WHERE setting.setrole='{RUNTIME_ROLE}'::pg_catalog.regrole "
+				"AND setting.setdatabase=0 "
+				f"AND item.value='{role_setting_canary_guc}={role_setting_secret_canary}'",
+				env,
+			)
+			if catalog_probe != "1":
+				raise TestFailure("secret-bearing role-setting canary is absent from the live catalog")
+			dump_schema_manifest(canary_manifest_path, env)
+			canary_manifest = canary_manifest_path.read_text(encoding="utf-8")
+			if json.loads(canary_manifest)["authority"] == json.loads(live_manifest)["authority"]:
+				raise TestFailure("secret-bearing role setting did not change configured authority")
+			if (
+				role_setting_secret_canary in canary_manifest
+				or role_setting_canary_guc in canary_manifest
+			):
+				raise TestFailure(
+					"configured authority manifest serialized a role-setting canary"
+				)
+		finally:
+			psql_secret(
+				DATABASE,
+				f"ALTER ROLE {RUNTIME_ROLE} RESET {role_setting_canary_guc}",
+				env,
+			)
+		if psql_secret(
+			DATABASE,
+			"SELECT count(*) FROM pg_catalog.pg_db_role_setting AS setting "
+			"CROSS JOIN LATERAL pg_catalog.unnest(setting.setconfig) AS item(value) "
+			f"WHERE setting.setrole='{RUNTIME_ROLE}'::pg_catalog.regrole "
+			"AND setting.setdatabase=0 "
+			f"AND pg_catalog.split_part(item.value,'=',1)='{role_setting_canary_guc}'",
+			env,
+		) != "0":
+			raise TestFailure("secret-bearing role-setting canary was not restored")
+		authority_digest = hashlib.sha256(
+			json.loads(live_manifest)["authority"].encode("utf-8")
+		).hexdigest()
+		print(
+			f"configured PostgreSQL authority manifest SHA-256: {authority_digest}",
+			flush=True,
 		)
 
 		create_database(DEFAULT_ACL_TAMPER_DATABASE, env)
@@ -1649,6 +1904,7 @@ def main() -> int:
 			"schema-default-acl",
 			work,
 			env,
+			unsafe_authority=True,
 		)
 		default_acl_probe = (
 			"SELECT count(*) "
@@ -1693,6 +1949,226 @@ def main() -> int:
 			],
 			env,
 		)
+		authority_drift_cases = [
+			(
+				f"ALTER ROLE {RUNTIME_ROLE} SET {role_setting_canary_guc} = "
+				f"'{role_setting_secret_canary}'",
+				f"ALTER ROLE {RUNTIME_ROLE} RESET {role_setting_canary_guc}",
+				"credential-setting-redaction",
+				True,
+			),
+			(
+				f"GRANT CONNECT ON DATABASE {DATABASE} TO {MISSING_SELECT_ROLE}",
+				f"REVOKE CONNECT ON DATABASE {DATABASE} FROM {MISSING_SELECT_ROLE}",
+				"database-acl-equivalent-grantee",
+				False,
+			),
+			(
+				f"ALTER DATABASE {DATABASE} OWNER TO {FUNCTION_OWNER_ROLE}",
+				f"ALTER DATABASE {DATABASE} OWNER TO {MIGRATION_ROLE}",
+				"database-owner",
+				True,
+			),
+			(
+				f"GRANT USAGE ON SCHEMA decodex TO {MISSING_SELECT_ROLE}",
+				f"REVOKE USAGE ON SCHEMA decodex FROM {MISSING_SELECT_ROLE}",
+				"namespace-acl-equivalent-grantee",
+				False,
+			),
+			(
+				f"ALTER SCHEMA decodex OWNER TO {FUNCTION_OWNER_ROLE}",
+				f"ALTER SCHEMA decodex OWNER TO {MIGRATION_ROLE}",
+				"namespace-owner",
+				True,
+			),
+			(
+				f"GRANT SELECT ON TABLE decodex.accounts TO {MISSING_SELECT_ROLE}",
+				f"REVOKE SELECT ON TABLE decodex.accounts FROM {MISSING_SELECT_ROLE}",
+				"relation-acl-equivalent-grantee",
+				False,
+			),
+			(
+				f"ALTER TABLE decodex.accounts OWNER TO {FUNCTION_OWNER_ROLE}",
+				f"ALTER TABLE decodex.accounts OWNER TO {MIGRATION_ROLE}",
+				"relation-owner",
+				True,
+			),
+			(
+				f"GRANT SELECT (account_id) ON TABLE decodex.accounts TO {MISSING_SELECT_ROLE}",
+				f"REVOKE SELECT (account_id) ON TABLE decodex.accounts FROM {MISSING_SELECT_ROLE}",
+				"column-acl",
+				False,
+			),
+			(
+				f"GRANT USAGE ON SEQUENCE decodex.activity_sequence_seq TO {MISSING_SELECT_ROLE}",
+				f"REVOKE USAGE ON SEQUENCE decodex.activity_sequence_seq FROM {MISSING_SELECT_ROLE}",
+				"sequence-acl-equivalent-grantee",
+				False,
+			),
+			(
+				f"ALTER TABLE decodex.activity OWNER TO {FUNCTION_OWNER_ROLE}",
+				f"ALTER TABLE decodex.activity OWNER TO {MIGRATION_ROLE}",
+				"identity-sequence-owner-via-table",
+				True,
+			),
+			(
+				f"GRANT USAGE ON TYPE decodex.account_state TO {MISSING_SELECT_ROLE}",
+				f"REVOKE USAGE ON TYPE decodex.account_state FROM {MISSING_SELECT_ROLE}",
+				"type-acl-equivalent-grantee",
+				False,
+			),
+			(
+				f"ALTER TYPE decodex.account_state OWNER TO {FUNCTION_OWNER_ROLE}",
+				f"ALTER TYPE decodex.account_state OWNER TO {MIGRATION_ROLE}",
+				"type-owner",
+				True,
+			),
+			(
+				f"GRANT EXECUTE ON FUNCTION decodex.is_canonical_media_type(text) TO {MISSING_SELECT_ROLE}",
+				f"REVOKE EXECUTE ON FUNCTION decodex.is_canonical_media_type(text) FROM {MISSING_SELECT_ROLE}",
+				"function-acl-equivalent-grantee",
+				False,
+			),
+			(
+				f"ALTER FUNCTION decodex.is_canonical_media_type(text) OWNER TO {FUNCTION_OWNER_ROLE}",
+				f"ALTER FUNCTION decodex.is_canonical_media_type(text) OWNER TO {MIGRATION_ROLE}",
+				"function-owner",
+				True,
+			),
+			(
+				f"GRANT SELECT ON TABLE public.refinery_schema_history TO {MISSING_SELECT_ROLE}",
+				f"REVOKE SELECT ON TABLE public.refinery_schema_history FROM {MISSING_SELECT_ROLE}",
+				"migration-ledger-equivalent-grantee",
+				False,
+			),
+			(
+				f"GRANT SELECT (version) ON TABLE public.refinery_schema_history "
+				f"TO {MISSING_SELECT_ROLE}",
+				f"REVOKE SELECT (version) ON TABLE public.refinery_schema_history "
+				f"FROM {MISSING_SELECT_ROLE}",
+				"migration-ledger-column-acl-equivalent-grantee",
+				False,
+			),
+			(
+				f"ALTER TABLE public.refinery_schema_history OWNER TO {FUNCTION_OWNER_ROLE}",
+				f"ALTER TABLE public.refinery_schema_history OWNER TO {MIGRATION_ROLE}",
+				"migration-ledger-owner",
+				True,
+			),
+			(
+				f"ALTER DEFAULT PRIVILEGES FOR ROLE {MIGRATION_ROLE} IN SCHEMA decodex "
+				f"GRANT SELECT ON TABLES TO {MISSING_SELECT_ROLE}",
+				f"ALTER DEFAULT PRIVILEGES FOR ROLE {MIGRATION_ROLE} IN SCHEMA decodex "
+				f"REVOKE SELECT ON TABLES FROM {MISSING_SELECT_ROLE}",
+				"default-acl-equivalent-grantee",
+				False,
+			),
+			(
+				"CREATE RULE xy1272_unexpected_rule AS ON INSERT TO decodex.accounts "
+				"DO ALSO NOTHING",
+				"DROP RULE xy1272_unexpected_rule ON decodex.accounts",
+				"rule-definition",
+				False,
+			),
+			(
+				"CREATE POLICY xy1272_unexpected_policy ON decodex.accounts TO PUBLIC USING (true)",
+				"DROP POLICY xy1272_unexpected_policy ON decodex.accounts",
+				"policy-definition",
+				False,
+			),
+			(
+				f"GRANT {FUNCTION_OWNER_ROLE} TO {RUNTIME_ROLE} "
+				"WITH ADMIN FALSE, INHERIT FALSE, SET FALSE",
+				f"REVOKE {FUNCTION_OWNER_ROLE} FROM {RUNTIME_ROLE}",
+				"membership-no-options",
+				True,
+			),
+			(
+				f"GRANT {FUNCTION_OWNER_ROLE} TO {RUNTIME_ROLE} "
+				"WITH ADMIN TRUE, INHERIT TRUE, SET TRUE",
+				f"REVOKE {FUNCTION_OWNER_ROLE} FROM {RUNTIME_ROLE}",
+				"membership-admin-inherit-set",
+				True,
+			),
+			(
+				f"ALTER ROLE {MIGRATION_ROLE} RENAME TO decodex_migration_renamed",
+				f"ALTER ROLE decodex_migration_renamed RENAME TO {MIGRATION_ROLE}",
+				"configured-migration-rename",
+				True,
+			),
+			(
+				f"ALTER ROLE {RUNTIME_ROLE} RENAME TO decodex_runtime_renamed",
+				f"ALTER ROLE decodex_runtime_renamed RENAME TO {RUNTIME_ROLE}",
+				"configured-runtime-rename",
+				True,
+			),
+		]
+		for role in (MIGRATION_ROLE, RUNTIME_ROLE):
+			for suffix, mutation, restore in (
+				("superuser", "SUPERUSER", "NOSUPERUSER"),
+				("inherit", "INHERIT", "NOINHERIT"),
+				("create-role", "CREATEROLE", "NOCREATEROLE"),
+				("create-database", "CREATEDB", "NOCREATEDB"),
+				("login", "NOLOGIN", "LOGIN"),
+				("replication", "REPLICATION", "NOREPLICATION"),
+				("bypass-rls", "BYPASSRLS", "NOBYPASSRLS"),
+				("connection-limit", "CONNECTION LIMIT 7", "CONNECTION LIMIT -1"),
+				(
+					"validity",
+					"VALID UNTIL '2030-01-01 00:00:00+00'",
+					"VALID UNTIL 'infinity'",
+				),
+			):
+				authority_drift_cases.append((
+					f"ALTER ROLE {role} {mutation}",
+					f"ALTER ROLE {role} {restore}",
+					f"{role}-{suffix}",
+					True,
+				))
+			authority_drift_cases.extend((
+				(
+					f"ALTER ROLE {role} SET statement_timeout = '1s'",
+					f"ALTER ROLE {role} RESET statement_timeout",
+					f"{role}-global-setting",
+					True,
+				),
+				(
+					f"ALTER ROLE {role} IN DATABASE {DATABASE} "
+					"SET search_path = hostile, public, pg_catalog",
+					f"ALTER ROLE {role} IN DATABASE {DATABASE} RESET search_path",
+					f"{role}-database-setting",
+					True,
+				),
+			))
+		authority_drift_outputs = []
+		for mutation, restore, case, cluster_authority in authority_drift_cases:
+			secret_sql = case == "credential-setting-redaction"
+			mutation_probe = None
+			if case == "migration-ledger-column-acl-equivalent-grantee":
+				mutation_probe = (
+					f"SELECT pg_catalog.has_column_privilege('{MISSING_SELECT_ROLE}', "
+					"'public.refinery_schema_history', 'version', 'SELECT') "
+					f"AND NOT pg_catalog.has_table_privilege('{MISSING_SELECT_ROLE}', "
+					"'public.refinery_schema_history', 'SELECT')"
+				)
+			output = run_authority_drift_case(
+				bootstrap_root,
+				DATABASE,
+				mutation,
+				restore,
+				case,
+				work,
+				env,
+				cluster_authority=cluster_authority,
+				secret_sql=secret_sql,
+				mutation_probe=mutation_probe,
+			)
+			if secret_sql and (
+				role_setting_secret_canary in output or role_setting_canary_guc in output
+			):
+				raise TestFailure("doctor output leaked a role-setting canary")
+			authority_drift_outputs.append(output)
+		assert_postgres_logs_redact((log_path,), canary_markers)
 		print(migration_output)
 		print(restart_output)
 		print(v8_boundary_output)
@@ -1707,10 +2183,12 @@ def main() -> int:
 		print(missing_extension_live_doctor_output)
 		print(identity_cast_output)
 		print(incompatible_authority_output)
+		print(hostile_startup_path_output)
 		print(hostile_search_output)
 		print(restore_output)
 		print(default_acl_live_doctor_output)
 		print(default_acl_restore_output)
+		print("\n".join(authority_drift_outputs))
 		return 0
 	finally:
 		stop_error: Exception | None = None


### PR DESCRIPTION
## Summary

- close PostgreSQL 18 configured-principal, membership, owner, ACL, and migration-ledger authority against landed V8
- pin startup-packet search path and keep readiness/doctor fail-closed
- cover ledger column ACL drift and failure-safe dynamic credential-canary logging without serializing secret values
- align normative vNext authority and gate documentation

## Validation

- full isolated PostgreSQL 18 harness passed, including restart, dump/restore, hostile search path, ledger-column ACL, forced secret-log failure, and doctor/readiness negatives
- `cargo nextest run -p decodex-postgres -p decodex-runtime --all-targets --all-features`: 135 passed
- `SCCACHE_DISABLE=1 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`: 398 passed, 24 skipped
- architecture: 19 passed; gate/vstyle contract: 10 passed; CLI diagnostics: 3 passed
- fresh visible reviewer `019f6c55-43af-77c3-8531-016b2bd490c2`: APPROVED/READY, no P0-P3 findings
- exact reviewed commit: `ecbb0fbf5ce53e11f709d61866dcc1a02b21a71c`

Linear: XY-1272