### PR TITLE
Persist WorkItem authority and inert ManagedRun safety

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -221,15 +221,16 @@ args = [
 ]
 
 # Test
-# | task                       | type      | cwd |
-# | -------------------------- | --------- | --- |
-# | test                       | composite |     |
-# | test-gate-contract         | command   |     |
-# | test-rust                  | command   |     |
-# | test-vnext-architecture    | command   |     |
-# | test-vnext-cli-diagnostics | command   |     |
-# | test-vnext-postgres-store  | command   |     |
-# | test-vnext-storage-proof   | command   |     |
+# | task                               | type      | cwd |
+# | ---------------------------------- | --------- | --- |
+# | test                               | composite |     |
+# | test-gate-contract                 | command   |     |
+# | test-rust                          | command   |     |
+# | test-vnext-architecture            | command   |     |
+# | test-vnext-cli-diagnostics         | command   |     |
+# | test-vnext-postgres-managed-runs   | command   |     |
+# | test-vnext-postgres-store          | command   |     |
+# | test-vnext-storage-proof           | command   |     |
 
 [tasks.test]
 clear = true
@@ -276,6 +277,14 @@ workspace = false
 command = "python3"
 args = [
 	"scripts/vnext/cli_diagnostics_test.py",
+]
+
+[tasks.test-vnext-postgres-managed-runs]
+workspace = false
+command = "python3"
+args = [
+	"scripts/vnext/postgres_store_test.py",
+	"--focus-managed-runs",
 ]
 
 [tasks.test-vnext-postgres-store]

--- a/crates/decodex-core/src/lib.rs
+++ b/crates/decodex-core/src/lib.rs
@@ -7,6 +7,7 @@ mod cache;
 mod config;
 mod conversation;
 mod identity;
+mod managed_run;
 #[cfg(unix)] mod path_unix;
 mod paths;
 mod policy;
@@ -50,6 +51,11 @@ pub use self::{
 		contains_credential_material, is_canonical_media_type, is_credential_metadata_key,
 	},
 	identity::ServerIdentity,
+	managed_run::{
+		EffectId, ExecutionAssignment, ExecutionAssignmentRole, ManagedRunError, ManagedRunId,
+		ManagedRunIdentity, ManagedRunLifecycle, ManagedRunPhase, ManagedRunSafetyInput,
+		ManagedRunState, ManagedRunWaitReason, SafetyObservationId, SubmittedTurnReceiptId,
+	},
 	paths::{DecodexPaths, DecodexRoot, PathError},
 	policy::{
 		AcceptedPolicyRevision, MAX_POLICY_PROVENANCE_BYTES, MAX_POLICY_SNAPSHOT_FIELDS,

--- a/crates/decodex-core/src/managed_run.rs
+++ b/crates/decodex-core/src/managed_run.rs
@@ -1,0 +1,314 @@
+//! Inert ManagedRun identities, execution assignments, and fail-closed safety algebra.
+
+use std::{
+	error::Error,
+	fmt::{Display, Formatter},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ProjectId, RuntimeSessionId, TurnId, WorkItemId};
+
+macro_rules! managed_run_id {
+	($name:ident, $label:literal, $error:ident) => {
+		#[doc = concat!("Canonical ", $label, " identity.")]
+		#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+		pub struct $name(String);
+		impl $name {
+			#[doc = concat!("Parse one lowercase RFC 9562 UUID-v4 ", $label, " identity.")]
+			pub fn new(value: impl Into<String>) -> Result<Self, ManagedRunError> {
+				let value = value.into();
+				if !is_canonical_uuid_v4(&value) {
+					return Err(ManagedRunError::$error);
+				}
+				Ok(Self(value))
+			}
+
+			/// Borrow the canonical identity text.
+			pub fn as_str(&self) -> &str {
+				&self.0
+			}
+		}
+		impl Display for $name {
+			fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+				formatter.write_str(&self.0)
+			}
+		}
+	};
+}
+
+managed_run_id!(ManagedRunId, "ManagedRun", InvalidManagedRunId);
+managed_run_id!(EffectId, "ManagedRun effect", InvalidEffectId);
+managed_run_id!(SubmittedTurnReceiptId, "submitted-turn receipt", InvalidReceiptId);
+managed_run_id!(SafetyObservationId, "safety observation", InvalidObservationId);
+
+/// Closed ManagedRun validation error without caller-controlled text.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ManagedRunError {
+	/// ManagedRun identity was not canonical UUID-v4 text.
+	InvalidManagedRunId,
+	/// Effect identity was not canonical UUID-v4 text.
+	InvalidEffectId,
+	/// Submitted-turn receipt identity was not canonical UUID-v4 text.
+	InvalidReceiptId,
+	/// Safety observation identity was not canonical UUID-v4 text.
+	InvalidObservationId,
+	/// Lifecycle, phase, and wait reason did not form a legal state.
+	InvalidState,
+	/// An optimistic revision was not positive.
+	InvalidRevision,
+}
+impl Error for ManagedRunError {}
+impl Display for ManagedRunError {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(match self {
+			Self::InvalidManagedRunId => "invalid ManagedRun identity",
+			Self::InvalidEffectId => "invalid ManagedRun effect identity",
+			Self::InvalidReceiptId => "invalid submitted-turn receipt identity",
+			Self::InvalidObservationId => "invalid safety observation identity",
+			Self::InvalidState => "invalid ManagedRun lifecycle, phase, and wait combination",
+			Self::InvalidRevision => "invalid ManagedRun revision",
+		})
+	}
+}
+
+/// Complete lifecycle vocabulary; persistence in this slice accepts only `waiting`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ManagedRunLifecycle {
+	/// Execution has not been acquired.
+	Queued,
+	/// A future owner is actively advancing the run.
+	Active,
+	/// Progress is explicitly blocked.
+	Waiting,
+	/// A future owner ended the run.
+	Terminal,
+}
+
+/// Closed phase vocabulary independent of lifecycle.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ManagedRunPhase {
+	/// Prepare exact execution inputs.
+	Prepare,
+	/// Perform implementation work.
+	Execute,
+	/// Validate owned output.
+	Validate,
+	/// Obtain independent review.
+	Review,
+	/// Repair accepted findings.
+	Repair,
+	/// Land accepted work.
+	Land,
+	/// Close the execution record.
+	Close,
+}
+
+/// Typed reason that keeps a ManagedRun inert.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ManagedRunWaitReason {
+	/// Usage capacity is unavailable or unproven.
+	Usage,
+	/// Authentication is unavailable or unproven.
+	Auth,
+	/// Required plugin readiness is unavailable or unproven.
+	Plugin,
+	/// A declared dependency prevents progress.
+	Dependency,
+	/// Required approval is absent.
+	Approval,
+	/// Explicit user input is required.
+	User,
+	/// An external authority or readback remains unresolved.
+	External,
+	/// No independent reviewer is available.
+	ReviewerUnavailable,
+	/// Independent review failed without accepted completion.
+	ReviewerFailed,
+}
+
+/// Pure, validated lifecycle algebra.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ManagedRunState {
+	/// The only legal queued state.
+	Queued,
+	/// Active state for a non-close phase.
+	Active(ManagedRunPhase),
+	/// Inert state with an exact phase and typed reason.
+	Waiting(ManagedRunPhase, ManagedRunWaitReason),
+	/// The only legal terminal state.
+	Terminal,
+}
+impl ManagedRunState {
+	/// Validate raw persistence parts and reject every non-canonical combination.
+	pub const fn from_parts(
+		lifecycle: ManagedRunLifecycle,
+		phase: ManagedRunPhase,
+		wait_reason: Option<ManagedRunWaitReason>,
+	) -> Result<Self, ManagedRunError> {
+		match (lifecycle, phase, wait_reason) {
+			(ManagedRunLifecycle::Queued, ManagedRunPhase::Prepare, None) => Ok(Self::Queued),
+			(ManagedRunLifecycle::Active, active_phase, None)
+				if !matches!(active_phase, ManagedRunPhase::Close) =>
+				Ok(Self::Active(active_phase)),
+			(ManagedRunLifecycle::Waiting, waiting_phase, Some(reason)) =>
+				Ok(Self::Waiting(waiting_phase, reason)),
+			(ManagedRunLifecycle::Terminal, ManagedRunPhase::Close, None) => Ok(Self::Terminal),
+			_ => Err(ManagedRunError::InvalidState),
+		}
+	}
+
+	/// Return canonical raw parts for persistence or readback.
+	pub const fn parts(
+		self,
+	) -> (ManagedRunLifecycle, ManagedRunPhase, Option<ManagedRunWaitReason>) {
+		match self {
+			Self::Queued => (ManagedRunLifecycle::Queued, ManagedRunPhase::Prepare, None),
+			Self::Active(phase) => (ManagedRunLifecycle::Active, phase, None),
+			Self::Waiting(phase, reason) => (ManagedRunLifecycle::Waiting, phase, Some(reason)),
+			Self::Terminal => (ManagedRunLifecycle::Terminal, ManagedRunPhase::Close, None),
+		}
+	}
+}
+
+/// Execution-only role that cannot represent Advisor or Lead authority.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionAssignmentRole {
+	/// Owning implementation Task for this exact run.
+	Task,
+	/// Independent Reviewer for this exact run.
+	Reviewer,
+}
+
+/// Exact-run execution identity; it is not a durable Agent.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExecutionAssignment {
+	/// Owning ManagedRun identity.
+	pub managed_run_id: ManagedRunId,
+	/// Exact RuntimeSession bound to this assignment.
+	pub runtime_session_id: RuntimeSessionId,
+	/// Execution-only role.
+	pub role: ExecutionAssignmentRole,
+}
+
+/// Structural inert ManagedRun readback identity.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ManagedRunIdentity {
+	/// Canonical run identity.
+	pub managed_run_id: ManagedRunId,
+	/// Exact owning Project.
+	pub project_id: ProjectId,
+	/// Exact canonical WorkItem.
+	pub work_item_id: WorkItemId,
+	/// Authoritative RuntimeSession for safety transitions.
+	pub runtime_session_id: RuntimeSessionId,
+	/// Positive optimistic revision.
+	pub revision: u64,
+}
+impl ManagedRunIdentity {
+	/// Reject a non-positive stored revision.
+	pub const fn validate(&self) -> Result<(), ManagedRunError> {
+		if self.revision == 0 { Err(ManagedRunError::InvalidRevision) } else { Ok(()) }
+	}
+}
+
+/// Monotonic positive or explicitly inconclusive input accepted by the safety transaction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ManagedRunSafetyInput {
+	/// A positively observed exact turn not owned by a matching submitted-turn receipt.
+	PositivelyObservedUnknownTurn {
+		/// Durable observation identity.
+		observation_id: SafetyObservationId,
+		/// Exact RuntimeSession observed.
+		runtime_session_id: RuntimeSessionId,
+		/// Positively observed exact turn identity.
+		turn_id: TurnId,
+	},
+	/// A Decodex-owned submitted-turn receipt consumed without authorizing progress.
+	SubmittedTurnReceipt {
+		/// Durable receipt identity.
+		receipt_id: SubmittedTurnReceiptId,
+		/// Exact RuntimeSession recorded by the receipt.
+		runtime_session_id: RuntimeSessionId,
+		/// Exact submitted turn identity.
+		turn_id: TurnId,
+	},
+	/// Explicitly inconclusive observation; absence is never synthesized into this value.
+	InconclusiveObservation {
+		/// Durable observation identity.
+		observation_id: SafetyObservationId,
+		/// Exact RuntimeSession observed.
+		runtime_session_id: RuntimeSessionId,
+	},
+}
+
+fn is_canonical_uuid_v4(value: &str) -> bool {
+	let bytes = value.as_bytes();
+	if bytes.len() != 36
+		|| bytes[8] != b'-'
+		|| bytes[13] != b'-'
+		|| bytes[18] != b'-'
+		|| bytes[23] != b'-'
+		|| bytes[14] != b'4'
+		|| !matches!(bytes[19], b'8' | b'9' | b'a' | b'b')
+	{
+		return false;
+	}
+	bytes.iter().enumerate().all(|(index, byte)| {
+		matches!(index, 8 | 13 | 18 | 23) || byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{ManagedRunLifecycle, ManagedRunPhase, ManagedRunState, ManagedRunWaitReason};
+
+	#[test]
+	fn state_algebra_accepts_only_canonical_lifecycle_phase_wait_combinations() {
+		let lifecycles = [
+			ManagedRunLifecycle::Queued,
+			ManagedRunLifecycle::Active,
+			ManagedRunLifecycle::Waiting,
+			ManagedRunLifecycle::Terminal,
+		];
+		let phases = [
+			ManagedRunPhase::Prepare,
+			ManagedRunPhase::Execute,
+			ManagedRunPhase::Validate,
+			ManagedRunPhase::Review,
+			ManagedRunPhase::Repair,
+			ManagedRunPhase::Land,
+			ManagedRunPhase::Close,
+		];
+		let reasons =
+			[None, Some(ManagedRunWaitReason::Usage), Some(ManagedRunWaitReason::ReviewerFailed)];
+
+		for lifecycle in lifecycles {
+			for phase in phases {
+				for reason in reasons {
+					let expected = matches!(
+						(lifecycle, phase, reason),
+						(ManagedRunLifecycle::Queued, ManagedRunPhase::Prepare, None)
+							| (
+								ManagedRunLifecycle::Active,
+								ManagedRunPhase::Prepare
+									| ManagedRunPhase::Execute | ManagedRunPhase::Validate
+									| ManagedRunPhase::Review | ManagedRunPhase::Repair
+									| ManagedRunPhase::Land,
+								None
+							) | (ManagedRunLifecycle::Waiting, _, Some(_))
+							| (ManagedRunLifecycle::Terminal, ManagedRunPhase::Close, None)
+					);
+					assert_eq!(
+						ManagedRunState::from_parts(lifecycle, phase, reason).is_ok(),
+						expected
+					);
+				}
+			}
+		}
+	}
+}

--- a/crates/decodex-postgres/migrations/V11__work_item_authority.sql
+++ b/crates/decodex-postgres/migrations/V11__work_item_authority.sql
@@ -1,0 +1,1108 @@
+-- XY-1343 canonical WorkItems, transactional readiness, and Lead acceptance.
+-- Keep the final V11 schema at the PostgreSQL 18 pg_dump/pg_restore fixed point.
+ALTER TABLE decodex.account_snapshots
+	DROP CONSTRAINT account_snapshots_facts,
+	ADD CONSTRAINT account_snapshots_facts CHECK (
+		pg_catalog.octet_length(display_label) >= 1
+		AND pg_catalog.octet_length(display_label) <= 128
+		AND NOT decodex.has_credential_material(display_label)
+	);
+
+ALTER TABLE decodex.exact_command_receipts
+	DROP CONSTRAINT exact_command_receipts_identity_bounded,
+	ADD CONSTRAINT exact_command_receipts_identity_bounded CHECK (
+		pg_catalog.octet_length(protocol_version) >= 1
+		AND pg_catalog.octet_length(protocol_version) <= 64
+		AND protocol_version COLLATE pg_catalog."C" ~ '^[a-z0-9][a-z0-9._/-]{0,63}$'
+		AND pg_catalog.octet_length(idempotency_key) >= 1
+		AND pg_catalog.octet_length(idempotency_key) <= 256
+		AND NOT decodex.has_credential_material(idempotency_key)
+	);
+
+ALTER TABLE decodex.role_profile_revisions
+	DROP CONSTRAINT role_profile_revisions_configuration,
+	ADD CONSTRAINT role_profile_revisions_configuration CHECK (
+		pg_catalog.octet_length(model) >= 1
+		AND pg_catalog.octet_length(model) <= 128
+		AND pg_catalog.octet_length(reasoning_effort) >= 1
+		AND pg_catalog.octet_length(reasoning_effort) <= 32
+		AND reasoning_effort COLLATE pg_catalog."C" ~ '^[a-z][a-z0-9_-]{0,31}$'
+		AND pg_catalog.octet_length(service_tier) >= 1
+		AND pg_catalog.octet_length(service_tier) <= 32
+		AND service_tier COLLATE pg_catalog."C" ~ '^[a-z][a-z0-9_-]{0,31}$'
+		AND pg_catalog.octet_length(instructions) >= 1
+		AND pg_catalog.octet_length(instructions) <= 65536
+		AND (provenance IS NULL OR (
+			pg_catalog.octet_length(provenance) >= 1
+			AND pg_catalog.octet_length(provenance) <= 4096
+		))
+		AND model COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND reasoning_effort COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND service_tier COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND instructions COLLATE pg_catalog."C" !~ U&'[\0080-\009F]'
+		AND (provenance IS NULL OR provenance COLLATE pg_catalog."C" !~ U&'[\0080-\009F]')
+		AND NOT decodex.has_credential_material(model)
+		AND NOT decodex.has_credential_material(reasoning_effort)
+		AND NOT decodex.has_credential_material(service_tier)
+		AND NOT decodex.has_credential_material(instructions)
+		AND (provenance IS NULL OR NOT decodex.has_credential_material(provenance))
+	);
+
+CREATE TYPE decodex.work_item_priority AS ENUM ('urgent', 'high', 'medium', 'low', 'none');
+CREATE TYPE decodex.work_item_state AS ENUM (
+	'inbox', 'planned', 'ready', 'running', 'review', 'blocked', 'done', 'canceled'
+);
+CREATE TYPE decodex.work_item_edge_kind AS ENUM ('depends_on', 'blocked_by');
+CREATE TYPE decodex.work_item_blocker_kind AS ENUM (
+	'project_inactive', 'lead_inactive', 'program_inactive', 'objective_inactive',
+	'dependency_incomplete', 'blocker_active', 'dependency_cycle'
+);
+
+CREATE FUNCTION decodex.is_work_item_text(value text, maximum_bytes integer)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+STRICT
+SET search_path = pg_catalog, decodex
+AS $$
+SELECT maximum_bytes > 0
+	AND pg_catalog.octet_length(value) BETWEEN 1 AND maximum_bytes
+	AND value COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+	AND value COLLATE pg_catalog."C" !~ U&'[\0080-\009F]'
+	AND NOT decodex.has_credential_material(value)
+$$;
+
+CREATE FUNCTION decodex.is_work_item_criteria(document text[])
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE item text;
+BEGIN
+	IF pg_catalog.array_ndims(document) <> 1
+		OR pg_catalog.cardinality(document) NOT BETWEEN 1 AND 32
+	THEN RETURN false; END IF;
+	FOREACH item IN ARRAY document LOOP
+		IF item IS NULL OR NOT decodex.is_work_item_text(item, 4096) THEN RETURN false; END IF;
+	END LOOP;
+	RETURN pg_catalog.cardinality(document) = (
+		SELECT pg_catalog.count(DISTINCT criterion)
+		FROM pg_catalog.unnest(document) AS criterion
+	);
+END
+$$;
+
+CREATE TABLE decodex.work_items (
+	work_item_id uuid PRIMARY KEY,
+	project_id uuid NOT NULL REFERENCES decodex.projects(project_id) ON DELETE RESTRICT,
+	lead_agent_id uuid NOT NULL,
+	program_id uuid,
+	title text NOT NULL,
+	description text NOT NULL,
+	priority decodex.work_item_priority NOT NULL,
+	acceptance_criteria text[] NOT NULL,
+	validation_criteria text[] NOT NULL,
+	state decodex.work_item_state NOT NULL DEFAULT 'inbox',
+	revision bigint NOT NULL DEFAULT 1 CHECK (revision > 0),
+	last_changed_by uuid NOT NULL,
+	last_correlation_id uuid NOT NULL,
+	last_provenance text NOT NULL,
+	created_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	updated_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	CONSTRAINT work_items_identity_project_revision_unique
+		UNIQUE (work_item_id, project_id, revision),
+	CONSTRAINT work_items_identity_project_unique UNIQUE (work_item_id, project_id),
+	CONSTRAINT work_items_lead_project_fk FOREIGN KEY (lead_agent_id, project_id)
+		REFERENCES decodex.agents(agent_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT work_items_program_project_fk FOREIGN KEY (program_id, project_id)
+		REFERENCES decodex.programs(program_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT work_items_actor_project_fk FOREIGN KEY (last_changed_by, project_id)
+		REFERENCES decodex.agents(agent_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT work_items_ids_canonical CHECK (
+		work_item_id::text COLLATE pg_catalog."C" ~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+		AND last_correlation_id::text COLLATE pg_catalog."C" ~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	),
+	CONSTRAINT work_items_text_bounded CHECK (
+		decodex.is_work_item_text(title, 256)
+		AND decodex.is_work_item_text(description, 4096)
+		AND decodex.is_work_item_text(last_provenance, 4096)
+	),
+	CONSTRAINT work_items_criteria_bounded CHECK (
+		decodex.is_work_item_criteria(acceptance_criteria)
+		AND decodex.is_work_item_criteria(validation_criteria)
+	),
+	CONSTRAINT work_items_finite_times CHECK (
+		pg_catalog.isfinite(created_at) AND pg_catalog.isfinite(updated_at)
+		AND created_at >= TIMESTAMPTZ 'epoch'
+		AND updated_at <= TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+		AND updated_at >= created_at
+	)
+);
+
+CREATE TABLE decodex.work_item_objectives (
+	project_id uuid NOT NULL,
+	work_item_id uuid NOT NULL,
+	objective_id uuid NOT NULL,
+	CONSTRAINT work_item_objectives_pkey PRIMARY KEY (work_item_id, objective_id),
+	CONSTRAINT work_item_objectives_item_project_fk FOREIGN KEY (work_item_id, project_id)
+		REFERENCES decodex.work_items(work_item_id, project_id) ON DELETE CASCADE,
+	CONSTRAINT work_item_objectives_objective_project_fk FOREIGN KEY (objective_id, project_id)
+		REFERENCES decodex.objectives(objective_id, project_id) ON DELETE RESTRICT
+);
+
+CREATE TABLE decodex.work_item_edges (
+	project_id uuid NOT NULL,
+	work_item_id uuid NOT NULL,
+	related_work_item_id uuid NOT NULL,
+	kind decodex.work_item_edge_kind NOT NULL,
+	CONSTRAINT work_item_edges_pkey PRIMARY KEY (work_item_id, related_work_item_id),
+	CONSTRAINT work_item_edges_item_project_fk FOREIGN KEY (work_item_id, project_id)
+		REFERENCES decodex.work_items(work_item_id, project_id) ON DELETE CASCADE,
+	CONSTRAINT work_item_edges_related_project_fk FOREIGN KEY (related_work_item_id, project_id)
+		REFERENCES decodex.work_items(work_item_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT work_item_edges_not_self CHECK (work_item_id <> related_work_item_id)
+);
+CREATE INDEX work_item_edges_related_idx
+	ON decodex.work_item_edges(project_id, related_work_item_id, work_item_id);
+
+CREATE TABLE decodex.work_item_readiness_blockers (
+	project_id uuid NOT NULL,
+	work_item_id uuid NOT NULL,
+	work_item_revision bigint NOT NULL CHECK (work_item_revision > 0),
+	ordinal integer NOT NULL CHECK (ordinal BETWEEN 1 AND 16384),
+	kind decodex.work_item_blocker_kind NOT NULL,
+	subject_id uuid,
+	observed_state text,
+	recorded_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	CONSTRAINT work_item_readiness_blockers_pkey
+		PRIMARY KEY (work_item_id, work_item_revision, ordinal),
+	CONSTRAINT work_item_readiness_blockers_item_revision_fk
+		FOREIGN KEY (work_item_id, project_id, work_item_revision)
+		REFERENCES decodex.work_items(work_item_id, project_id, revision) ON DELETE CASCADE,
+	CONSTRAINT work_item_readiness_blockers_shape CHECK (
+		(kind IN ('project_inactive', 'lead_inactive', 'dependency_cycle')
+			AND subject_id IS NULL AND observed_state IS NOT NULL)
+		OR (kind IN ('program_inactive', 'objective_inactive',
+			'dependency_incomplete', 'blocker_active')
+			AND subject_id IS NOT NULL AND observed_state IS NOT NULL)
+	),
+	CONSTRAINT work_item_readiness_blockers_state_bounded CHECK (
+		pg_catalog.octet_length(observed_state) >= 1
+		AND pg_catalog.octet_length(observed_state) <= 64
+		AND observed_state COLLATE pg_catalog."C" ~ '^[a-z][a-z0-9_]{0,63}$'
+	),
+	CONSTRAINT work_item_readiness_blockers_finite_time CHECK (
+		pg_catalog.isfinite(recorded_at)
+		AND recorded_at BETWEEN TIMESTAMPTZ 'epoch'
+			AND TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+	)
+);
+
+CREATE TABLE decodex.work_item_acceptances (
+	acceptance_id uuid PRIMARY KEY,
+	project_id uuid NOT NULL,
+	work_item_id uuid NOT NULL,
+	work_item_revision bigint NOT NULL CHECK (work_item_revision > 0),
+	work_item_updated_at timestamptz NOT NULL,
+	accepted_by uuid NOT NULL,
+	acceptance_criteria text[] NOT NULL,
+	validation_criteria text[] NOT NULL,
+	criteria_provenance text NOT NULL,
+	evidence_summary text NOT NULL,
+	evidence_provenance text NOT NULL,
+	correlation_id uuid NOT NULL,
+	accepted_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	CONSTRAINT work_item_acceptances_exact_revision_unique
+		UNIQUE (work_item_id, work_item_revision),
+	CONSTRAINT work_item_acceptances_item_project_fk FOREIGN KEY (work_item_id, project_id)
+		REFERENCES decodex.work_items(work_item_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT work_item_acceptances_lead_project_fk FOREIGN KEY (accepted_by, project_id)
+		REFERENCES decodex.agents(agent_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT work_item_acceptances_ids_canonical CHECK (
+		acceptance_id::text COLLATE pg_catalog."C" ~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+		AND correlation_id::text COLLATE pg_catalog."C" ~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	),
+	CONSTRAINT work_item_acceptances_criteria_bounded CHECK (
+		decodex.is_work_item_criteria(acceptance_criteria)
+		AND decodex.is_work_item_criteria(validation_criteria)
+	),
+	CONSTRAINT work_item_acceptances_provenance_bounded CHECK (
+		decodex.is_work_item_text(criteria_provenance, 4096)
+		AND decodex.is_work_item_text(evidence_summary, 4096)
+		AND decodex.is_work_item_text(evidence_provenance, 4096)
+	),
+	CONSTRAINT work_item_acceptances_chronology CHECK (
+		pg_catalog.isfinite(work_item_updated_at) AND pg_catalog.isfinite(accepted_at)
+		AND work_item_updated_at BETWEEN TIMESTAMPTZ 'epoch'
+			AND TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+		AND accepted_at BETWEEN TIMESTAMPTZ 'epoch'
+			AND TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+		AND accepted_at >= work_item_updated_at
+	)
+);
+
+CREATE FUNCTION decodex.enforce_work_item_state()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+BEGIN
+	IF TG_OP = 'INSERT' THEN
+		IF NEW.state <> 'inbox' OR NEW.revision <> 1 OR NEW.updated_at <> NEW.created_at THEN
+			RAISE EXCEPTION 'new WorkItem must be inbox revision one'
+				USING ERRCODE = '23514', CONSTRAINT = 'work_items_state_guard';
+		END IF;
+		RETURN NEW;
+	END IF;
+	IF TG_OP = 'DELETE' THEN
+		RAISE EXCEPTION 'WorkItems cannot be deleted'
+			USING ERRCODE = '23514', CONSTRAINT = 'work_items_state_guard';
+	END IF;
+	IF NEW.work_item_id <> OLD.work_item_id OR NEW.project_id <> OLD.project_id
+		OR NEW.lead_agent_id <> OLD.lead_agent_id OR NEW.created_at <> OLD.created_at
+		OR NEW.revision <> OLD.revision + 1 OR NEW.updated_at < OLD.updated_at
+		OR NOT (
+			(OLD.state = 'inbox' AND NEW.state IN ('inbox', 'planned', 'canceled'))
+			OR (OLD.state = 'planned' AND NEW.state IN ('inbox', 'planned', 'ready', 'blocked', 'canceled'))
+			OR (OLD.state = 'ready' AND NEW.state IN ('planned', 'blocked', 'canceled'))
+			OR (OLD.state = 'running' AND NEW.state IN ('review', 'blocked', 'canceled'))
+			OR (OLD.state = 'review' AND NEW.state IN ('blocked', 'canceled'))
+			OR (OLD.state = 'blocked' AND NEW.state IN ('planned', 'ready', 'blocked', 'canceled'))
+		)
+	THEN
+		RAISE EXCEPTION 'invalid WorkItem revision or lifecycle mutation'
+			USING ERRCODE = '23514', CONSTRAINT = 'work_items_state_guard';
+	END IF;
+	RETURN NEW;
+END
+$$;
+CREATE TRIGGER work_items_state_guard
+BEFORE INSERT OR UPDATE OR DELETE ON decodex.work_items
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_work_item_state();
+
+CREATE FUNCTION decodex.enforce_work_item_command_owner()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE owner_name name;
+BEGIN
+	SELECT pg_catalog.pg_get_userbyid(class.relowner) INTO owner_name
+	FROM pg_catalog.pg_class AS class WHERE class.oid = TG_RELID;
+	IF current_user::name <> owner_name THEN
+		RAISE EXCEPTION 'WorkItem state is command-owned'
+			USING ERRCODE = '42501', CONSTRAINT = 'work_item_command_owner';
+	END IF;
+	RETURN NULL;
+END
+$$;
+CREATE TRIGGER work_items_command_owner
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON decodex.work_items
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_work_item_command_owner();
+CREATE TRIGGER work_item_objectives_command_owner
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON decodex.work_item_objectives
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_work_item_command_owner();
+CREATE TRIGGER work_item_edges_command_owner
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON decodex.work_item_edges
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_work_item_command_owner();
+CREATE TRIGGER work_item_readiness_blockers_command_owner
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON decodex.work_item_readiness_blockers
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_work_item_command_owner();
+CREATE TRIGGER work_item_acceptances_command_owner
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON decodex.work_item_acceptances
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_work_item_command_owner();
+
+CREATE FUNCTION decodex.forbid_work_item_acceptance_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+BEGIN
+	RAISE EXCEPTION 'WorkItem acceptances are immutable'
+		USING ERRCODE = '23514', CONSTRAINT = 'work_item_acceptances_immutable';
+END
+$$;
+CREATE TRIGGER work_item_acceptances_immutable
+BEFORE UPDATE OR DELETE ON decodex.work_item_acceptances
+FOR EACH ROW EXECUTE FUNCTION decodex.forbid_work_item_acceptance_mutation();
+
+CREATE FUNCTION decodex.enforce_work_item_acceptance_coherence()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE item record;
+BEGIN
+	SELECT revision, updated_at, state, lead_agent_id, acceptance_criteria, validation_criteria
+	INTO item FROM decodex.work_items
+	WHERE work_item_id = NEW.work_item_id AND project_id = NEW.project_id;
+	IF NOT FOUND OR item.revision <> NEW.work_item_revision OR item.updated_at <> NEW.work_item_updated_at
+		OR item.state <> 'review' OR item.lead_agent_id <> NEW.accepted_by
+		OR item.acceptance_criteria <> NEW.acceptance_criteria
+		OR item.validation_criteria <> NEW.validation_criteria
+	THEN
+		RAISE EXCEPTION 'WorkItem acceptance does not bind the exact review revision'
+			USING ERRCODE = '23514', CONSTRAINT = 'work_item_acceptance_coherence';
+	END IF;
+	RETURN NULL;
+END
+$$;
+CREATE CONSTRAINT TRIGGER work_item_acceptance_coherence
+AFTER INSERT ON decodex.work_item_acceptances
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_work_item_acceptance_coherence();
+
+CREATE FUNCTION decodex.enforce_work_item_event_namespace()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE owner_name name;
+DECLARE linked boolean := false;
+BEGIN
+	SELECT pg_catalog.pg_get_userbyid(class.relowner) INTO owner_name
+	FROM pg_catalog.pg_class AS class WHERE class.oid = TG_RELID;
+	IF TG_TABLE_NAME = 'activity' THEN
+		linked := NEW.aggregate_kind = 'work_item'
+			OR NEW.event_kind IN ('work_item_created', 'work_item_updated',
+				'work_item_readiness_blocked', 'work_item_ready', 'work_item_accepted')
+			OR pg_catalog.jsonb_path_exists(NEW.payload, '$.** ? (
+				@.aggregate_kind == "work_item" || @.kind == "work_item" ||
+				exists(@.work_item) || exists(@.work_item_id) ||
+				exists(@.readiness_blockers) || exists(@.acceptance)
+			)');
+		IF TG_OP = 'UPDATE' THEN
+			linked := linked OR OLD.aggregate_kind = 'work_item'
+				OR OLD.event_kind IN ('work_item_created', 'work_item_updated',
+					'work_item_readiness_blocked', 'work_item_ready', 'work_item_accepted')
+				OR pg_catalog.jsonb_path_exists(OLD.payload, '$.** ? (
+					@.aggregate_kind == "work_item" || @.kind == "work_item" ||
+					exists(@.work_item) || exists(@.work_item_id) ||
+					exists(@.readiness_blockers) || exists(@.acceptance)
+				)');
+		END IF;
+	ELSE
+		linked := NEW.aggregate_kind = 'work_item'
+			OR pg_catalog.jsonb_path_exists(NEW.payload, '$.** ? (
+				@.aggregate_kind == "work_item" || @.kind == "work_item" ||
+				exists(@.work_item) || exists(@.work_item_id) ||
+				exists(@.readiness_blockers) || exists(@.acceptance)
+			)') OR EXISTS (
+				SELECT 1 FROM pg_catalog.jsonb_path_query(
+					NEW.payload, '$.**.activity_sequence'
+				) AS link(value)
+				JOIN decodex.activity AS activity ON activity.sequence = CASE
+					WHEN link.value #>> '{}' ~ '^[0-9]+$' THEN (link.value #>> '{}')::bigint
+				END WHERE activity.aggregate_kind = 'work_item'
+			);
+		IF TG_OP = 'UPDATE' THEN
+			linked := linked OR OLD.aggregate_kind = 'work_item'
+				OR pg_catalog.jsonb_path_exists(OLD.payload, '$.** ? (
+					@.aggregate_kind == "work_item" || @.kind == "work_item" ||
+					exists(@.work_item) || exists(@.work_item_id) ||
+					exists(@.readiness_blockers) || exists(@.acceptance)
+				)') OR EXISTS (
+					SELECT 1 FROM pg_catalog.jsonb_path_query(
+						OLD.payload, '$.**.activity_sequence'
+					) AS link(value)
+					JOIN decodex.activity AS activity ON activity.sequence = CASE
+						WHEN link.value #>> '{}' ~ '^[0-9]+$' THEN (link.value #>> '{}')::bigint
+					END WHERE activity.aggregate_kind = 'work_item'
+				);
+		END IF;
+	END IF;
+	IF linked AND current_user::name <> owner_name THEN
+		IF TG_TABLE_NAME = 'activity' OR TG_OP = 'INSERT' THEN
+			RAISE EXCEPTION 'WorkItem activity/outbox namespace is command-owned'
+				USING ERRCODE = '42501', CONSTRAINT = 'work_item_event_namespace';
+		ELSIF NEW.id IS DISTINCT FROM OLD.id
+			OR NEW.effect_key IS DISTINCT FROM OLD.effect_key
+			OR NEW.aggregate_kind IS DISTINCT FROM OLD.aggregate_kind
+			OR NEW.aggregate_id IS DISTINCT FROM OLD.aggregate_id
+			OR NEW.aggregate_revision IS DISTINCT FROM OLD.aggregate_revision
+			OR NEW.payload IS DISTINCT FROM OLD.payload
+			OR NEW.created_at IS DISTINCT FROM OLD.created_at
+		THEN
+			RAISE EXCEPTION 'WorkItem outbox authority fields are command-owned'
+				USING ERRCODE = '42501', CONSTRAINT = 'work_item_event_namespace';
+		END IF;
+	END IF;
+	RETURN NEW;
+EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+	RAISE EXCEPTION 'WorkItem activity/outbox link is malformed'
+		USING ERRCODE = '42501', CONSTRAINT = 'work_item_event_namespace';
+END
+$$;
+CREATE TRIGGER activity_work_item_namespace
+BEFORE INSERT OR UPDATE ON decodex.activity
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_work_item_event_namespace();
+CREATE TRIGGER outbox_work_item_namespace
+BEFORE INSERT OR UPDATE ON decodex.outbox
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_work_item_event_namespace();
+
+CREATE FUNCTION decodex.work_item_document(p_work_item_id uuid)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, decodex
+AS $$
+SELECT pg_catalog.jsonb_build_object(
+	'work_item_id', item.work_item_id, 'project_id', item.project_id,
+	'lead_agent_id', item.lead_agent_id, 'program_id', item.program_id,
+	'objective_ids', COALESCE((SELECT pg_catalog.jsonb_agg(link.objective_id ORDER BY link.objective_id)
+		FROM decodex.work_item_objectives AS link WHERE link.work_item_id = item.work_item_id), '[]'::jsonb),
+	'edges', COALESCE((SELECT pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+		'kind', edge.kind, 'related_work_item_id', edge.related_work_item_id
+	) ORDER BY edge.related_work_item_id) FROM decodex.work_item_edges AS edge
+		WHERE edge.work_item_id = item.work_item_id), '[]'::jsonb),
+	'title', item.title, 'description', item.description, 'priority', item.priority,
+	'acceptance_criteria', item.acceptance_criteria,
+	'validation_criteria', item.validation_criteria, 'state', item.state,
+	'revision', item.revision, 'last_changed_by', item.last_changed_by,
+	'last_correlation_id', item.last_correlation_id,
+	'last_provenance', item.last_provenance,
+	'created_at_microseconds', (EXTRACT(EPOCH FROM item.created_at)*1000000)::bigint,
+	'updated_at_microseconds', (EXTRACT(EPOCH FROM item.updated_at)*1000000)::bigint,
+	'accepted_revision', (SELECT pg_catalog.max(acceptance.work_item_revision)
+		FROM decodex.work_item_acceptances AS acceptance
+		WHERE acceptance.work_item_id = item.work_item_id)
+) FROM decodex.work_items AS item WHERE item.work_item_id = p_work_item_id
+$$;
+
+CREATE FUNCTION decodex.complete_exact_work_item_rejection(
+	p_protocol text, p_idempotency_key text, p_code text
+) RETURNS bytea
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE effect_value jsonb;
+DECLARE response_value bytea;
+DECLARE request_value jsonb;
+BEGIN
+	SELECT request_envelope INTO STRICT request_value FROM decodex.exact_command_receipts
+	WHERE protocol_version = p_protocol AND idempotency_key = p_idempotency_key;
+	effect_value := pg_catalog.jsonb_build_object(
+		'changed', false, 'code', p_code, 'request', request_value
+	);
+	response_value := pg_catalog.convert_to(pg_catalog.jsonb_build_object(
+		'classification', 'stable_domain_rejection', 'code', p_code, 'effect', effect_value
+	)::text, 'UTF8');
+	UPDATE decodex.exact_command_receipts
+	SET receipt_state = 'completed_rejected', outcome_class = 'stable_domain_rejection',
+		effect_envelope = effect_value, response_bytes = response_value,
+		completed_at = pg_catalog.clock_timestamp()
+	WHERE protocol_version = p_protocol AND idempotency_key = p_idempotency_key;
+	RETURN response_value;
+END
+$$;
+
+CREATE FUNCTION decodex.complete_exact_work_item_success(
+	p_protocol text, p_idempotency_key text, p_event_kind text,
+	p_work_item_id uuid, p_effect jsonb
+) RETURNS bytea
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE item_value jsonb;
+DECLARE activity_sequence bigint;
+DECLARE activity_payload jsonb;
+DECLARE outbox_id bigint;
+DECLARE outbox_payload jsonb;
+DECLARE effect_value jsonb;
+DECLARE response_value bytea;
+BEGIN
+	item_value := decodex.work_item_document(p_work_item_id);
+	activity_payload := pg_catalog.jsonb_build_object(
+		'kind', 'work_item', 'work_item', item_value
+	) || p_effect;
+	INSERT INTO decodex.activity(
+		aggregate_kind, aggregate_id, revision, event_kind, correlation_key, payload
+	) VALUES (
+		'work_item', p_work_item_id::text, (item_value->>'revision')::bigint,
+		p_event_kind, p_idempotency_key, activity_payload
+	) RETURNING sequence, payload INTO activity_sequence, activity_payload;
+	outbox_payload := pg_catalog.jsonb_build_object(
+		'activity_sequence', activity_sequence, 'event_kind', p_event_kind,
+		'aggregate_kind', 'work_item', 'aggregate_id', p_work_item_id,
+		'revision', (item_value->>'revision')::bigint, 'payload', activity_payload
+	);
+	INSERT INTO decodex.outbox(
+		effect_key, aggregate_kind, aggregate_id, aggregate_revision, payload
+	) VALUES (
+		'activity/' || activity_sequence::text, 'work_item', p_work_item_id::text,
+		(item_value->>'revision')::bigint, outbox_payload
+	) RETURNING id, payload INTO outbox_id, outbox_payload;
+	effect_value := pg_catalog.jsonb_build_object(
+		'work_item', item_value, 'activity_sequence', activity_sequence,
+		'activity_payload', activity_payload, 'outbox_id', outbox_id,
+		'outbox_payload', outbox_payload
+	) || p_effect;
+	response_value := pg_catalog.convert_to(pg_catalog.jsonb_build_object(
+		'classification', 'success', 'effect', effect_value
+	)::text, 'UTF8');
+	UPDATE decodex.exact_command_receipts
+	SET receipt_state = 'completed_success', outcome_class = 'success',
+		effect_envelope = effect_value, response_bytes = response_value,
+		completed_at = pg_catalog.clock_timestamp()
+	WHERE protocol_version = p_protocol AND idempotency_key = p_idempotency_key;
+	RETURN response_value;
+END
+$$;
+
+CREATE FUNCTION decodex.reserve_exact_work_item_command(
+	p_protocol text, p_idempotency_key text, p_request jsonb
+) RETURNS bytea
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE existing_request jsonb;
+DECLARE existing_response bytea;
+DECLARE inserted_count integer;
+BEGIN
+	IF p_protocol IS NULL OR p_idempotency_key IS NULL OR p_request IS NULL THEN
+		RAISE EXCEPTION 'exact WorkItem command identity is incomplete' USING ERRCODE = '22004';
+	END IF;
+	IF pg_catalog.octet_length(p_protocol) NOT BETWEEN 1 AND 64
+		OR p_protocol COLLATE pg_catalog."C" !~ '^[a-z0-9][a-z0-9._/-]{0,63}$'
+		OR pg_catalog.octet_length(p_idempotency_key) NOT BETWEEN 1 AND 256
+		OR decodex.has_credential_material(p_idempotency_key)
+	THEN RAISE EXCEPTION 'exact WorkItem command identity is invalid' USING ERRCODE = '22023';
+	END IF;
+	INSERT INTO decodex.exact_command_receipts(
+		protocol_version, idempotency_key, request_envelope, request_digest, receipt_state
+	) VALUES (
+		p_protocol, p_idempotency_key, p_request,
+		public.digest(pg_catalog.convert_to(p_request::text, 'UTF8'), 'sha256'), 'executing'
+	) ON CONFLICT (protocol_version, idempotency_key) DO NOTHING;
+	GET DIAGNOSTICS inserted_count = ROW_COUNT;
+	IF inserted_count = 0 THEN
+		SELECT request_envelope, response_bytes INTO existing_request, existing_response
+		FROM decodex.exact_command_receipts
+		WHERE protocol_version = p_protocol AND idempotency_key = p_idempotency_key FOR UPDATE;
+		IF existing_request <> p_request THEN
+			RAISE EXCEPTION 'exact idempotency conflict' USING ERRCODE = 'DX001';
+		END IF;
+		IF existing_response IS NULL THEN
+			RAISE EXCEPTION 'incomplete exact receipt is not replayable' USING ERRCODE = 'DX002';
+		END IF;
+		RETURN existing_response;
+	END IF;
+	RETURN NULL;
+END
+$$;
+
+CREATE FUNCTION decodex.work_item_graph_cycle(p_project_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, decodex
+AS $$
+WITH RECURSIVE reach(origin, node) AS (
+	SELECT edge.work_item_id, edge.related_work_item_id
+	FROM decodex.work_item_edges AS edge WHERE edge.project_id = p_project_id
+	UNION
+	SELECT reach.origin, edge.related_work_item_id
+	FROM reach JOIN decodex.work_item_edges AS edge
+		ON edge.project_id = p_project_id AND edge.work_item_id = reach.node
+)
+SELECT EXISTS (SELECT 1 FROM reach WHERE origin = node)
+$$;
+
+CREATE FUNCTION decodex.work_item_readiness(p_work_item_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE item record;
+DECLARE blockers jsonb := '[]'::jsonb;
+BEGIN
+	SELECT work.project_id, work.lead_agent_id, work.program_id,
+		project.status AS project_state, lead.status AS lead_state, lead.role AS lead_role
+	INTO STRICT item
+	FROM decodex.work_items AS work
+	JOIN decodex.projects AS project USING (project_id)
+	JOIN decodex.agents AS lead ON lead.agent_id = work.lead_agent_id
+	WHERE work.work_item_id = p_work_item_id;
+	IF item.project_state <> 'active' THEN blockers := blockers || pg_catalog.jsonb_build_array(
+		pg_catalog.jsonb_build_object('kind','project_inactive','subject_id',NULL,
+			'observed_state',item.project_state)); END IF;
+	IF item.lead_state <> 'active' OR item.lead_role <> 'lead' THEN
+		blockers := blockers || pg_catalog.jsonb_build_array(
+		pg_catalog.jsonb_build_object('kind','lead_inactive','subject_id',NULL,
+			'observed_state',CASE WHEN item.lead_state <> 'active' THEN item.lead_state
+				ELSE 'not_lead' END)); END IF;
+	IF item.program_id IS NOT NULL THEN blockers := blockers || COALESCE((
+		SELECT pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+			'kind','program_inactive','subject_id',program.program_id,
+			'observed_state',program.state) ORDER BY program.program_id)
+		FROM decodex.programs AS program WHERE program.program_id = item.program_id
+			AND program.state <> 'active'), '[]'::jsonb); END IF;
+	blockers := blockers || COALESCE((
+		SELECT pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+			'kind','objective_inactive','subject_id',objective.objective_id,
+			'observed_state',objective.state) ORDER BY objective.objective_id)
+		FROM decodex.work_item_objectives AS link
+		JOIN decodex.objectives AS objective USING (objective_id)
+		WHERE link.work_item_id = p_work_item_id AND objective.state <> 'active'
+	), '[]'::jsonb);
+	blockers := blockers || COALESCE((
+		SELECT pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+			'kind', CASE edge.kind WHEN 'depends_on' THEN 'dependency_incomplete'
+				ELSE 'blocker_active' END,
+			'subject_id', related.work_item_id, 'observed_state', related.state
+		) ORDER BY edge.related_work_item_id)
+		FROM decodex.work_item_edges AS edge
+		JOIN decodex.work_items AS related ON related.work_item_id = edge.related_work_item_id
+		WHERE edge.work_item_id = p_work_item_id AND (
+			(edge.kind = 'depends_on' AND related.state <> 'done') OR
+			(edge.kind = 'blocked_by' AND related.state NOT IN ('done','canceled'))
+		)
+	), '[]'::jsonb);
+	IF decodex.work_item_graph_cycle(item.project_id) THEN
+		blockers := blockers || pg_catalog.jsonb_build_array(pg_catalog.jsonb_build_object(
+			'kind','dependency_cycle','subject_id',NULL,'observed_state','cycle'));
+	END IF;
+	RETURN blockers;
+END
+$$;
+
+CREATE FUNCTION decodex.create_work_item_exact(
+	p_protocol text, p_idempotency_key text, p_work_item_id uuid, p_project_id uuid,
+	p_lead_agent_id uuid, p_program_id uuid, p_objective_ids uuid[],
+	p_depends_on_ids uuid[], p_blocked_by_ids uuid[], p_title text, p_description text,
+	p_priority decodex.work_item_priority, p_acceptance_criteria text[],
+	p_validation_criteria text[], p_actor_id uuid, p_correlation_id uuid, p_provenance text
+) RETURNS bytea
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE request_value jsonb;
+DECLARE replay bytea;
+DECLARE project_ok boolean;
+DECLARE invalid_count bigint;
+DECLARE operation_time timestamptz := pg_catalog.clock_timestamp();
+BEGIN
+	request_value := pg_catalog.jsonb_build_object(
+		'protocol_version',p_protocol,'operation','create_work_item','work_item_id',p_work_item_id,
+		'project_id',p_project_id,'lead_agent_id',p_lead_agent_id,'program_id',p_program_id,
+		'objective_ids',p_objective_ids,'depends_on_ids',p_depends_on_ids,
+		'blocked_by_ids',p_blocked_by_ids,'title',p_title,'description',p_description,
+		'priority',p_priority,'acceptance_criteria',p_acceptance_criteria,
+		'validation_criteria',p_validation_criteria,'actor_id',p_actor_id,
+		'correlation_id',p_correlation_id,'provenance',p_provenance
+	);
+	replay := decodex.reserve_exact_work_item_command(p_protocol,p_idempotency_key,request_value);
+	IF replay IS NOT NULL THEN RETURN replay; END IF;
+	IF p_work_item_id IS NULL OR p_project_id IS NULL OR p_lead_agent_id IS NULL
+		OR p_objective_ids IS NULL OR p_depends_on_ids IS NULL OR p_blocked_by_ids IS NULL
+		OR p_title IS NULL OR p_description IS NULL OR p_priority IS NULL
+		OR p_acceptance_criteria IS NULL OR p_validation_criteria IS NULL
+		OR p_actor_id IS NULL OR p_correlation_id IS NULL OR p_provenance IS NULL
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_input'); END IF;
+	IF NOT decodex.is_work_item_text(p_title,256)
+		OR NOT decodex.is_work_item_text(p_description,4096)
+		OR NOT decodex.is_work_item_text(p_provenance,4096)
+		OR NOT decodex.is_work_item_criteria(p_acceptance_criteria)
+		OR NOT decodex.is_work_item_criteria(p_validation_criteria)
+		OR pg_catalog.cardinality(p_objective_ids) > 32
+		OR pg_catalog.cardinality(p_depends_on_ids) + pg_catalog.cardinality(p_blocked_by_ids) > 256
+		OR COALESCE(pg_catalog.array_ndims(p_objective_ids),1) <> 1
+		OR COALESCE(pg_catalog.array_ndims(p_depends_on_ids),1) <> 1
+		OR COALESCE(pg_catalog.array_ndims(p_blocked_by_ids),1) <> 1
+		OR pg_catalog.array_position(p_objective_ids,NULL) IS NOT NULL
+		OR pg_catalog.array_position(p_depends_on_ids,NULL) IS NOT NULL
+		OR pg_catalog.array_position(p_blocked_by_ids,NULL) IS NOT NULL
+		OR p_work_item_id = ANY(p_depends_on_ids) OR p_work_item_id = ANY(p_blocked_by_ids)
+		OR p_work_item_id::text COLLATE pg_catalog."C" !~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+		OR p_correlation_id::text COLLATE pg_catalog."C" !~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_input'); END IF;
+	IF (SELECT pg_catalog.count(*) FROM pg_catalog.unnest(p_objective_ids) value)
+		<> (SELECT pg_catalog.count(DISTINCT value) FROM pg_catalog.unnest(p_objective_ids) value)
+		OR (SELECT pg_catalog.count(*) FROM pg_catalog.unnest(p_depends_on_ids || p_blocked_by_ids) value)
+		<> (SELECT pg_catalog.count(DISTINCT value) FROM pg_catalog.unnest(p_depends_on_ids || p_blocked_by_ids) value)
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'duplicate_relation'); END IF;
+	PERFORM pg_catalog.pg_advisory_xact_lock(1343,pg_catalog.hashtext(p_project_id::text));
+	PERFORM pg_catalog.pg_advisory_xact_lock(1344,pg_catalog.hashtext(p_work_item_id::text));
+	IF EXISTS (SELECT 1 FROM decodex.work_items WHERE work_item_id=p_work_item_id) THEN
+		RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'duplicate_target'); END IF;
+	IF (SELECT pg_catalog.count(*) FROM decodex.work_items WHERE project_id=p_project_id) >= 4096
+		OR (SELECT pg_catalog.count(*) FROM decodex.work_item_edges WHERE project_id=p_project_id)
+			+ pg_catalog.cardinality(p_depends_on_ids) + pg_catalog.cardinality(p_blocked_by_ids) > 16384
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_input'); END IF;
+	IF EXISTS (SELECT 1 FROM pg_catalog.unnest(p_objective_ids) id LEFT JOIN decodex.objectives objective
+		ON objective.objective_id=id AND objective.project_id=p_project_id WHERE objective.objective_id IS NULL)
+		OR (p_program_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM decodex.programs
+			WHERE program_id=p_program_id AND project_id=p_project_id))
+		OR EXISTS (SELECT 1 FROM pg_catalog.unnest(p_depends_on_ids||p_blocked_by_ids) id
+			LEFT JOIN decodex.work_items related ON related.work_item_id=id AND related.project_id=p_project_id
+			WHERE related.work_item_id IS NULL)
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_relation'); END IF;
+	PERFORM 1 FROM decodex.programs WHERE program_id=p_program_id FOR SHARE;
+	PERFORM 1 FROM decodex.objectives WHERE objective_id=ANY(p_objective_ids)
+		ORDER BY objective_id FOR SHARE;
+	PERFORM 1 FROM decodex.work_items WHERE work_item_id=ANY(p_depends_on_ids||p_blocked_by_ids)
+		ORDER BY work_item_id FOR SHARE;
+	SELECT project.status = 'active' AND lead.role = 'lead' AND lead.status = 'active'
+		AND lead.project_id = project.project_id AND lead.agent_id = p_lead_agent_id
+		AND p_actor_id = lead.agent_id INTO project_ok
+	FROM decodex.projects AS project JOIN decodex.agents AS lead ON lead.project_id=project.project_id
+		AND lead.role='lead' WHERE project.project_id=p_project_id FOR SHARE OF project,lead;
+	IF project_ok IS DISTINCT FROM true THEN
+		RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_authority'); END IF;
+	SELECT pg_catalog.count(*) INTO invalid_count FROM pg_catalog.unnest(p_objective_ids) id
+	LEFT JOIN decodex.objectives objective ON objective.objective_id=id AND objective.project_id=p_project_id
+	WHERE objective.objective_id IS NULL;
+	IF invalid_count > 0 OR (p_program_id IS NOT NULL AND NOT EXISTS (
+		SELECT 1 FROM decodex.programs WHERE program_id=p_program_id AND project_id=p_project_id
+	)) OR EXISTS (
+		SELECT 1 FROM pg_catalog.unnest(p_depends_on_ids || p_blocked_by_ids) id
+		LEFT JOIN decodex.work_items related ON related.work_item_id=id AND related.project_id=p_project_id
+		WHERE related.work_item_id IS NULL
+	) THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_relation'); END IF;
+	INSERT INTO decodex.work_items(work_item_id,project_id,lead_agent_id,program_id,title,
+		description,priority,acceptance_criteria,validation_criteria,last_changed_by,
+		last_correlation_id,last_provenance,created_at,updated_at)
+	VALUES(p_work_item_id,p_project_id,p_lead_agent_id,p_program_id,p_title,p_description,
+		p_priority,p_acceptance_criteria,p_validation_criteria,p_actor_id,p_correlation_id,
+		p_provenance,operation_time,operation_time);
+	INSERT INTO decodex.work_item_objectives(project_id,work_item_id,objective_id)
+	SELECT p_project_id,p_work_item_id,id FROM pg_catalog.unnest(p_objective_ids) id ORDER BY id;
+	INSERT INTO decodex.work_item_edges(project_id,work_item_id,related_work_item_id,kind)
+	SELECT p_project_id,p_work_item_id,id,'depends_on'::decodex.work_item_edge_kind
+	FROM pg_catalog.unnest(p_depends_on_ids) id
+	UNION ALL SELECT p_project_id,p_work_item_id,id,'blocked_by'::decodex.work_item_edge_kind
+	FROM pg_catalog.unnest(p_blocked_by_ids) id ORDER BY 3;
+	RETURN decodex.complete_exact_work_item_success(p_protocol,p_idempotency_key,
+		'work_item_created',p_work_item_id,pg_catalog.jsonb_build_object('request',request_value));
+END
+$$;
+
+CREATE FUNCTION decodex.update_work_item_exact(
+	p_protocol text, p_idempotency_key text, p_work_item_id uuid, p_project_id uuid,
+	p_expected_revision bigint, p_program_id uuid, p_objective_ids uuid[],
+	p_depends_on_ids uuid[], p_blocked_by_ids uuid[], p_title text, p_description text,
+	p_priority decodex.work_item_priority, p_acceptance_criteria text[],
+	p_validation_criteria text[], p_target_state decodex.work_item_state,
+	p_actor_id uuid, p_correlation_id uuid, p_provenance text
+) RETURNS bytea
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE request_value jsonb;
+DECLARE replay bytea;
+DECLARE item record;
+DECLARE project_state text;
+DECLARE lead_state text;
+DECLARE lead_role text;
+BEGIN
+	request_value := pg_catalog.jsonb_build_object(
+		'protocol_version',p_protocol,'operation','update_work_item','work_item_id',p_work_item_id,
+		'project_id',p_project_id,'expected_revision',p_expected_revision,'program_id',p_program_id,
+		'objective_ids',p_objective_ids,'depends_on_ids',p_depends_on_ids,'blocked_by_ids',p_blocked_by_ids,
+		'title',p_title,'description',p_description,'priority',p_priority,
+		'acceptance_criteria',p_acceptance_criteria,'validation_criteria',p_validation_criteria,
+		'target_state',p_target_state,'actor_id',p_actor_id,'correlation_id',p_correlation_id,
+		'provenance',p_provenance);
+	replay := decodex.reserve_exact_work_item_command(p_protocol,p_idempotency_key,request_value);
+	IF replay IS NOT NULL THEN RETURN replay; END IF;
+	IF p_work_item_id IS NULL OR p_project_id IS NULL OR p_expected_revision IS NULL
+		OR p_objective_ids IS NULL OR p_depends_on_ids IS NULL OR p_blocked_by_ids IS NULL
+		OR p_title IS NULL OR p_description IS NULL OR p_priority IS NULL
+		OR p_acceptance_criteria IS NULL OR p_validation_criteria IS NULL
+		OR p_target_state IS NULL OR p_actor_id IS NULL OR p_correlation_id IS NULL
+		OR p_provenance IS NULL OR p_expected_revision <= 0
+		OR p_work_item_id::text COLLATE pg_catalog."C" !~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_input'); END IF;
+	PERFORM pg_catalog.pg_advisory_xact_lock(1343,pg_catalog.hashtext(p_project_id::text));
+	SELECT work.* INTO item FROM decodex.work_items work
+	WHERE work.work_item_id=p_work_item_id AND work.project_id=p_project_id FOR UPDATE OF work;
+	IF NOT FOUND THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'missing_target'); END IF;
+	IF item.revision <> p_expected_revision THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'stale_revision'); END IF;
+	IF p_target_state IN ('ready','running','done') OR NOT (
+		(item.state='inbox' AND p_target_state IN ('inbox','planned','canceled')) OR
+		(item.state='planned' AND p_target_state IN ('inbox','planned','blocked','canceled')) OR
+		(item.state='ready' AND p_target_state IN ('planned','blocked','canceled')) OR
+		(item.state='running' AND p_target_state IN ('review','blocked','canceled')) OR
+		(item.state='review' AND p_target_state IN ('blocked','canceled')) OR
+		(item.state='blocked' AND p_target_state IN ('planned','canceled'))
+	) THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'illegal_transition'); END IF;
+	IF NOT decodex.is_work_item_text(p_title,256) OR NOT decodex.is_work_item_text(p_description,4096)
+		OR NOT decodex.is_work_item_text(p_provenance,4096)
+		OR NOT decodex.is_work_item_criteria(p_acceptance_criteria)
+		OR NOT decodex.is_work_item_criteria(p_validation_criteria)
+		OR pg_catalog.cardinality(p_objective_ids)>32
+		OR pg_catalog.cardinality(p_depends_on_ids)+pg_catalog.cardinality(p_blocked_by_ids)>256
+		OR COALESCE(pg_catalog.array_ndims(p_objective_ids),1) <> 1
+		OR COALESCE(pg_catalog.array_ndims(p_depends_on_ids),1) <> 1
+		OR COALESCE(pg_catalog.array_ndims(p_blocked_by_ids),1) <> 1
+		OR pg_catalog.array_position(p_objective_ids,NULL) IS NOT NULL
+		OR pg_catalog.array_position(p_depends_on_ids,NULL) IS NOT NULL
+		OR pg_catalog.array_position(p_blocked_by_ids,NULL) IS NOT NULL
+		OR p_work_item_id=ANY(p_depends_on_ids) OR p_work_item_id=ANY(p_blocked_by_ids)
+		OR p_correlation_id::text COLLATE pg_catalog."C" !~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_input'); END IF;
+	IF EXISTS (SELECT 1 FROM pg_catalog.unnest(p_objective_ids) id LEFT JOIN decodex.objectives objective
+		ON objective.objective_id=id AND objective.project_id=p_project_id WHERE objective.objective_id IS NULL)
+		OR (p_program_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM decodex.programs
+			WHERE program_id=p_program_id AND project_id=p_project_id))
+		OR EXISTS (SELECT 1 FROM pg_catalog.unnest(p_depends_on_ids||p_blocked_by_ids) id
+			LEFT JOIN decodex.work_items related ON related.work_item_id=id AND related.project_id=p_project_id
+			WHERE related.work_item_id IS NULL)
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_relation'); END IF;
+	PERFORM 1 FROM decodex.programs WHERE program_id=p_program_id FOR SHARE;
+	PERFORM 1 FROM decodex.objectives WHERE objective_id=ANY(p_objective_ids)
+		ORDER BY objective_id FOR SHARE;
+	PERFORM 1 FROM decodex.work_items WHERE work_item_id=ANY(p_depends_on_ids||p_blocked_by_ids)
+		ORDER BY work_item_id FOR SHARE;
+	SELECT project.status,lead.status,lead.role INTO project_state,lead_state,lead_role
+	FROM decodex.projects project JOIN decodex.agents lead
+		ON lead.agent_id=item.lead_agent_id AND lead.project_id=project.project_id
+	WHERE project.project_id=p_project_id FOR SHARE OF project,lead;
+	IF project_state <> 'active' OR lead_state <> 'active' OR lead_role <> 'lead'
+		OR p_actor_id <> item.lead_agent_id THEN
+		RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_authority'); END IF;
+	IF (SELECT pg_catalog.count(*) FROM pg_catalog.unnest(p_objective_ids) value)
+		<> (SELECT pg_catalog.count(DISTINCT value) FROM pg_catalog.unnest(p_objective_ids) value)
+		OR (SELECT pg_catalog.count(*) FROM pg_catalog.unnest(p_depends_on_ids||p_blocked_by_ids) value)
+		<> (SELECT pg_catalog.count(DISTINCT value) FROM pg_catalog.unnest(p_depends_on_ids||p_blocked_by_ids) value)
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'duplicate_relation'); END IF;
+	IF EXISTS (SELECT 1 FROM pg_catalog.unnest(p_objective_ids) id LEFT JOIN decodex.objectives objective
+		ON objective.objective_id=id AND objective.project_id=p_project_id WHERE objective.objective_id IS NULL)
+		OR (p_program_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM decodex.programs
+			WHERE program_id=p_program_id AND project_id=p_project_id))
+		OR EXISTS (SELECT 1 FROM pg_catalog.unnest(p_depends_on_ids||p_blocked_by_ids) id
+			LEFT JOIN decodex.work_items related ON related.work_item_id=id AND related.project_id=p_project_id
+			WHERE related.work_item_id IS NULL)
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_relation'); END IF;
+	IF (SELECT pg_catalog.count(*) FROM decodex.work_items WHERE project_id=p_project_id) > 4096
+		OR (SELECT pg_catalog.count(*) FROM decodex.work_item_edges
+			WHERE project_id=p_project_id AND work_item_id<>p_work_item_id)
+			+ pg_catalog.cardinality(p_depends_on_ids) + pg_catalog.cardinality(p_blocked_by_ids) > 16384
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_input'); END IF;
+	BEGIN
+		DELETE FROM decodex.work_item_readiness_blockers WHERE work_item_id=p_work_item_id;
+		DELETE FROM decodex.work_item_objectives WHERE work_item_id=p_work_item_id;
+		DELETE FROM decodex.work_item_edges WHERE work_item_id=p_work_item_id;
+		INSERT INTO decodex.work_item_objectives(project_id,work_item_id,objective_id)
+		SELECT p_project_id,p_work_item_id,id FROM pg_catalog.unnest(p_objective_ids) id ORDER BY id;
+		INSERT INTO decodex.work_item_edges(project_id,work_item_id,related_work_item_id,kind)
+		SELECT p_project_id,p_work_item_id,id,'depends_on'::decodex.work_item_edge_kind
+		FROM pg_catalog.unnest(p_depends_on_ids) id
+		UNION ALL SELECT p_project_id,p_work_item_id,id,'blocked_by'::decodex.work_item_edge_kind
+		FROM pg_catalog.unnest(p_blocked_by_ids) id ORDER BY 3;
+		IF decodex.work_item_graph_cycle(p_project_id) THEN
+			RAISE EXCEPTION 'candidate WorkItem graph contains a cycle' USING ERRCODE='P1343';
+		END IF;
+	EXCEPTION WHEN SQLSTATE 'P1343' THEN
+		RETURN decodex.complete_exact_work_item_rejection(
+			p_protocol,p_idempotency_key,'dependency_cycle');
+	END;
+	UPDATE decodex.work_items SET program_id=p_program_id,title=p_title,description=p_description,
+		priority=p_priority,acceptance_criteria=p_acceptance_criteria,
+		validation_criteria=p_validation_criteria,state=p_target_state,revision=revision+1,
+		last_changed_by=p_actor_id,last_correlation_id=p_correlation_id,last_provenance=p_provenance,
+		updated_at=pg_catalog.clock_timestamp() WHERE work_item_id=p_work_item_id;
+	RETURN decodex.complete_exact_work_item_success(p_protocol,p_idempotency_key,
+		'work_item_updated',p_work_item_id,pg_catalog.jsonb_build_object('request',request_value));
+END
+$$;
+
+CREATE FUNCTION decodex.assess_work_item_readiness_exact(
+	p_protocol text, p_idempotency_key text, p_work_item_id uuid, p_project_id uuid,
+	p_expected_revision bigint, p_actor_id uuid, p_correlation_id uuid, p_provenance text
+) RETURNS bytea
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE request_value jsonb;
+DECLARE replay bytea;
+DECLARE item record;
+DECLARE blockers jsonb;
+DECLARE target_state decodex.work_item_state;
+DECLARE event_kind text;
+DECLARE project_state text;
+DECLARE lead_state text;
+DECLARE lead_role text;
+BEGIN
+	request_value := pg_catalog.jsonb_build_object('protocol_version',p_protocol,
+		'operation','assess_work_item_readiness','work_item_id',p_work_item_id,
+		'project_id',p_project_id,'expected_revision',p_expected_revision,
+		'actor_id',p_actor_id,'correlation_id',p_correlation_id,'provenance',p_provenance);
+	replay := decodex.reserve_exact_work_item_command(p_protocol,p_idempotency_key,request_value);
+	IF replay IS NOT NULL THEN RETURN replay; END IF;
+	IF p_work_item_id IS NULL OR p_project_id IS NULL OR p_expected_revision IS NULL
+		OR p_actor_id IS NULL OR p_correlation_id IS NULL OR p_provenance IS NULL
+		OR p_expected_revision <= 0 OR NOT decodex.is_work_item_text(p_provenance,4096)
+		OR p_work_item_id::text COLLATE pg_catalog."C" !~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+		OR p_correlation_id::text COLLATE pg_catalog."C" !~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_input'); END IF;
+	PERFORM pg_catalog.pg_advisory_xact_lock(1343,pg_catalog.hashtext(p_project_id::text));
+	SELECT work.* INTO item FROM decodex.work_items work
+	WHERE work.work_item_id=p_work_item_id AND work.project_id=p_project_id FOR UPDATE OF work;
+	IF NOT FOUND THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'missing_target'); END IF;
+	IF item.revision<>p_expected_revision THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'stale_revision'); END IF;
+	IF item.state NOT IN ('planned','blocked') THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'illegal_transition'); END IF;
+	IF p_actor_id<>item.lead_agent_id THEN
+		RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_authority'); END IF;
+	-- All authority inputs are selected again inside this transaction after the exact row lock.
+	PERFORM 1 FROM decodex.programs WHERE program_id=item.program_id FOR SHARE;
+	PERFORM 1 FROM decodex.objectives objective JOIN decodex.work_item_objectives link USING(objective_id)
+		WHERE link.work_item_id=p_work_item_id ORDER BY objective.objective_id FOR SHARE OF objective;
+	PERFORM 1 FROM decodex.work_items related JOIN decodex.work_item_edges edge
+		ON edge.related_work_item_id=related.work_item_id WHERE edge.work_item_id=p_work_item_id
+		ORDER BY related.work_item_id FOR SHARE OF related;
+	SELECT project.status,lead.status,lead.role INTO project_state,lead_state,lead_role
+	FROM decodex.projects project JOIN decodex.agents lead
+		ON lead.agent_id=item.lead_agent_id AND lead.project_id=project.project_id
+	WHERE project.project_id=p_project_id FOR SHARE OF project,lead;
+	blockers := decodex.work_item_readiness(p_work_item_id);
+	DELETE FROM decodex.work_item_readiness_blockers WHERE work_item_id=p_work_item_id;
+	target_state := CASE WHEN pg_catalog.jsonb_array_length(blockers)=0 THEN 'ready' ELSE 'blocked' END;
+	event_kind := CASE WHEN target_state='ready' THEN 'work_item_ready' ELSE 'work_item_readiness_blocked' END;
+	UPDATE decodex.work_items SET state=target_state,revision=revision+1,last_changed_by=p_actor_id,
+		last_correlation_id=p_correlation_id,last_provenance=p_provenance,
+		updated_at=pg_catalog.clock_timestamp() WHERE work_item_id=p_work_item_id;
+	IF target_state='blocked' THEN
+		INSERT INTO decodex.work_item_readiness_blockers(project_id,work_item_id,work_item_revision,
+			ordinal,kind,subject_id,observed_state)
+		SELECT p_project_id,p_work_item_id,p_expected_revision+1,entry.ordinality,
+			(entry.value->>'kind')::decodex.work_item_blocker_kind,
+			(entry.value->>'subject_id')::uuid,entry.value->>'observed_state'
+		FROM pg_catalog.jsonb_array_elements(blockers) WITH ORDINALITY AS entry(value,ordinality);
+	END IF;
+	RETURN decodex.complete_exact_work_item_success(p_protocol,p_idempotency_key,event_kind,
+		p_work_item_id,pg_catalog.jsonb_build_object('request',request_value,
+			'readiness_blockers',blockers,'ready',target_state='ready'));
+END
+$$;
+
+CREATE FUNCTION decodex.accept_work_item_exact(
+	p_protocol text, p_idempotency_key text, p_acceptance_id uuid,
+	p_work_item_id uuid, p_project_id uuid, p_expected_revision bigint,
+	p_actor_id uuid, p_correlation_id uuid, p_provenance text, p_criteria_provenance text,
+	p_evidence_summary text, p_evidence_provenance text
+) RETURNS bytea
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE request_value jsonb;
+DECLARE replay bytea;
+DECLARE item record;
+DECLARE accepted_revision bigint;
+BEGIN
+	request_value := pg_catalog.jsonb_build_object('protocol_version',p_protocol,
+		'operation','accept_work_item','acceptance_id',p_acceptance_id,
+		'work_item_id',p_work_item_id,'project_id',p_project_id,
+		'expected_revision',p_expected_revision,'actor_id',p_actor_id,
+		'correlation_id',p_correlation_id,'criteria_provenance',p_criteria_provenance,
+		'provenance',p_provenance,'evidence_summary',p_evidence_summary,
+		'evidence_provenance',p_evidence_provenance);
+	replay := decodex.reserve_exact_work_item_command(p_protocol,p_idempotency_key,request_value);
+	IF replay IS NOT NULL THEN RETURN replay; END IF;
+	IF p_acceptance_id IS NULL OR p_work_item_id IS NULL OR p_project_id IS NULL
+		OR p_expected_revision IS NULL OR p_actor_id IS NULL OR p_correlation_id IS NULL
+		OR p_provenance IS NULL OR p_criteria_provenance IS NULL OR p_evidence_summary IS NULL
+		OR p_evidence_provenance IS NULL OR p_expected_revision <= 0
+		OR p_acceptance_id::text COLLATE pg_catalog."C" !~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+		OR p_work_item_id::text COLLATE pg_catalog."C" !~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+		OR p_correlation_id::text COLLATE pg_catalog."C" !~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_input'); END IF;
+	PERFORM pg_catalog.pg_advisory_xact_lock(1345,pg_catalog.hashtext(p_acceptance_id::text));
+	SELECT work.*,project.status AS project_state,lead.status AS lead_state,lead.role AS lead_role
+	INTO item FROM decodex.work_items work JOIN decodex.projects project USING(project_id)
+	JOIN decodex.agents lead ON lead.agent_id=work.lead_agent_id
+	WHERE work.work_item_id=p_work_item_id AND work.project_id=p_project_id
+	FOR UPDATE OF work FOR SHARE OF project,lead;
+	IF NOT FOUND THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'missing_target'); END IF;
+	IF item.revision<>p_expected_revision THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'stale_revision'); END IF;
+	IF item.state<>'review' THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'illegal_transition'); END IF;
+	IF item.project_state<>'active' OR item.lead_state<>'active' OR item.lead_role<>'lead'
+		OR p_actor_id<>item.lead_agent_id THEN
+		RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_authority'); END IF;
+	IF NOT decodex.is_work_item_text(p_provenance,4096)
+		OR NOT decodex.is_work_item_text(p_criteria_provenance,4096)
+		OR NOT decodex.is_work_item_text(p_evidence_summary,4096)
+		OR NOT decodex.is_work_item_text(p_evidence_provenance,4096)
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'invalid_input'); END IF;
+	IF EXISTS (SELECT 1 FROM decodex.work_item_acceptances
+		WHERE acceptance_id=p_acceptance_id OR (work_item_id=p_work_item_id AND work_item_revision=p_expected_revision))
+	THEN RETURN decodex.complete_exact_work_item_rejection(p_protocol,p_idempotency_key,'duplicate_acceptance'); END IF;
+	INSERT INTO decodex.work_item_acceptances(acceptance_id,project_id,work_item_id,
+		work_item_revision,work_item_updated_at,accepted_by,acceptance_criteria,
+		validation_criteria,criteria_provenance,evidence_summary,evidence_provenance,correlation_id)
+	VALUES(p_acceptance_id,p_project_id,p_work_item_id,p_expected_revision,item.updated_at,
+		p_actor_id,item.acceptance_criteria,item.validation_criteria,p_criteria_provenance,
+		p_evidence_summary,p_evidence_provenance,p_correlation_id)
+	RETURNING work_item_revision INTO accepted_revision;
+	-- Acceptance intentionally does not update WorkItem state or revision. Completion is unowned.
+	RETURN decodex.complete_exact_work_item_success(p_protocol,p_idempotency_key,
+		'work_item_accepted',p_work_item_id,pg_catalog.jsonb_build_object(
+			'request',request_value,'acceptance_recorded',pg_catalog.jsonb_build_object(
+				'acceptance_id',p_acceptance_id,'work_item_revision',accepted_revision)));
+END
+$$;
+
+CREATE FUNCTION decodex.guard_work_item_running_resume(
+	p_work_item_id uuid, p_project_id uuid, p_expected_revision bigint
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE item record;
+DECLARE blockers jsonb;
+BEGIN
+	PERFORM pg_catalog.pg_advisory_xact_lock(1343,pg_catalog.hashtext(p_project_id::text));
+	SELECT work.revision,work.state,work.program_id,work.lead_agent_id INTO item
+	FROM decodex.work_items work
+	WHERE work.work_item_id=p_work_item_id AND work.project_id=p_project_id FOR UPDATE OF work;
+	IF NOT FOUND OR item.revision<>p_expected_revision OR item.state NOT IN ('ready','running') THEN
+		RAISE EXCEPTION 'future WorkItem running/resume guard rejected current state'
+			USING ERRCODE='55000',CONSTRAINT='work_item_running_resume_guard';
+	END IF;
+	PERFORM 1 FROM decodex.programs WHERE program_id=item.program_id FOR SHARE;
+	PERFORM 1 FROM decodex.objectives objective JOIN decodex.work_item_objectives link USING(objective_id)
+		WHERE link.work_item_id=p_work_item_id ORDER BY objective.objective_id FOR SHARE OF objective;
+	PERFORM 1 FROM decodex.work_items related JOIN decodex.work_item_edges edge
+		ON edge.related_work_item_id=related.work_item_id WHERE edge.work_item_id=p_work_item_id
+		ORDER BY related.work_item_id FOR SHARE OF related;
+	PERFORM 1 FROM decodex.projects project JOIN decodex.agents lead
+		ON lead.agent_id=item.lead_agent_id AND lead.project_id=project.project_id
+		WHERE project.project_id=p_project_id FOR SHARE OF project,lead;
+	blockers := decodex.work_item_readiness(p_work_item_id);
+	IF pg_catalog.jsonb_array_length(blockers)<>0 THEN
+		RAISE EXCEPTION 'future WorkItem running/resume guard found current blockers'
+			USING ERRCODE='55000',CONSTRAINT='work_item_running_resume_guard';
+	END IF;
+	-- Intentionally no transition, receipt, lease, assignment, dispatch, or side effect.
+END
+$$;
+
+REVOKE ALL ON TABLE decodex.work_items, decodex.work_item_objectives,
+	decodex.work_item_edges, decodex.work_item_readiness_blockers,
+	decodex.work_item_acceptances FROM PUBLIC;
+REVOKE ALL ON TYPE decodex.work_item_priority, decodex.work_item_state,
+	decodex.work_item_edge_kind, decodex.work_item_blocker_kind FROM PUBLIC;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA decodex FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON TYPES FROM PUBLIC;

--- a/crates/decodex-postgres/migrations/V12__managed_run_safety.sql
+++ b/crates/decodex-postgres/migrations/V12__managed_run_safety.sql
@@ -1,0 +1,1306 @@
+-- XY-1338 inert ManagedRuns and fail-closed effect barriers.
+-- V12 creates no scheduler, acquisition, progress, completion, or dispatch authority.
+CREATE TYPE decodex.managed_run_lifecycle AS ENUM ('queued', 'active', 'waiting', 'terminal');
+CREATE TYPE decodex.managed_run_phase AS ENUM (
+	'prepare', 'execute', 'validate', 'review', 'repair', 'land', 'close'
+);
+CREATE TYPE decodex.managed_run_wait_reason AS ENUM (
+	'usage', 'auth', 'plugin', 'dependency', 'approval', 'user', 'external',
+	'reviewer_unavailable', 'reviewer_failed'
+);
+CREATE TYPE decodex.execution_assignment_role AS ENUM ('task', 'reviewer');
+CREATE TYPE decodex.effect_barrier_state AS ENUM ('guarded', 'closed');
+CREATE TYPE decodex.managed_run_effect_kind AS ENUM ('tool', 'repository', 'git', 'artifact');
+CREATE TYPE decodex.managed_run_effect_state AS ENUM ('recorded');
+CREATE TYPE decodex.managed_run_safety_input_kind AS ENUM (
+	'positively_observed_unknown_turn', 'submitted_turn_receipt', 'inconclusive_observation'
+);
+
+ALTER TABLE decodex.runtime_sessions
+	ADD CONSTRAINT runtime_sessions_identity_revision_unique
+	UNIQUE (runtime_session_id, revision);
+
+CREATE TABLE decodex.managed_runs (
+	managed_run_id uuid PRIMARY KEY,
+	project_id uuid NOT NULL,
+	work_item_id uuid NOT NULL,
+	runtime_session_id uuid NOT NULL,
+	runtime_session_revision bigint NOT NULL CHECK (runtime_session_revision > 0),
+	lifecycle decodex.managed_run_lifecycle NOT NULL DEFAULT 'waiting',
+	phase decodex.managed_run_phase NOT NULL,
+	wait_reason decodex.managed_run_wait_reason NOT NULL,
+	revision bigint NOT NULL DEFAULT 1 CHECK (revision > 0),
+	diverged boolean NOT NULL DEFAULT false,
+	blocked boolean NOT NULL DEFAULT true,
+	created_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	updated_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	CONSTRAINT managed_runs_identity_project_unique UNIQUE (managed_run_id, project_id),
+	CONSTRAINT managed_runs_identity_project_work_item_unique
+		UNIQUE (managed_run_id, project_id, work_item_id),
+	CONSTRAINT managed_runs_work_item_unique UNIQUE (work_item_id),
+	CONSTRAINT managed_runs_work_item_project_fk FOREIGN KEY (work_item_id, project_id)
+		REFERENCES decodex.work_items(work_item_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT managed_runs_runtime_session_revision_fk
+		FOREIGN KEY (runtime_session_id, runtime_session_revision)
+		REFERENCES decodex.runtime_sessions(runtime_session_id, revision) ON DELETE RESTRICT
+		DEFERRABLE INITIALLY DEFERRED,
+	CONSTRAINT managed_runs_identity_canonical CHECK (
+		managed_run_id::text COLLATE pg_catalog."C" ~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	),
+	CONSTRAINT managed_runs_inert_waiting_only CHECK (
+		lifecycle = 'waiting' AND wait_reason IS NOT NULL AND blocked
+	),
+	CONSTRAINT managed_runs_finite_times CHECK (
+		pg_catalog.isfinite(created_at) AND pg_catalog.isfinite(updated_at)
+		AND created_at BETWEEN TIMESTAMPTZ 'epoch'
+			AND TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+		AND updated_at BETWEEN created_at
+			AND TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+	)
+);
+
+CREATE TABLE decodex.managed_run_assignments (
+	managed_run_id uuid NOT NULL,
+	project_id uuid NOT NULL,
+	runtime_session_id uuid NOT NULL,
+	role decodex.execution_assignment_role NOT NULL,
+	created_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	CONSTRAINT managed_run_assignments_pkey PRIMARY KEY (managed_run_id, role),
+	CONSTRAINT managed_run_assignments_runtime_session_unique UNIQUE (runtime_session_id),
+	CONSTRAINT managed_run_assignments_run_project_fk FOREIGN KEY (managed_run_id, project_id)
+		REFERENCES decodex.managed_runs(managed_run_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT managed_run_assignments_session_fk FOREIGN KEY (runtime_session_id)
+		REFERENCES decodex.runtime_sessions(runtime_session_id) ON DELETE RESTRICT,
+	CONSTRAINT managed_run_assignments_finite_time CHECK (
+		pg_catalog.isfinite(created_at)
+		AND created_at BETWEEN TIMESTAMPTZ 'epoch'
+			AND TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+	)
+);
+
+CREATE TABLE decodex.managed_run_effect_barriers (
+	managed_run_id uuid PRIMARY KEY,
+	project_id uuid NOT NULL,
+	work_item_id uuid NOT NULL,
+	state decodex.effect_barrier_state NOT NULL DEFAULT 'guarded',
+	revision bigint NOT NULL DEFAULT 1 CHECK (revision > 0),
+	closure_input_id uuid,
+	closure_input_kind decodex.managed_run_safety_input_kind,
+	created_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	closed_at timestamptz,
+	CONSTRAINT managed_run_effect_barriers_run_scope_fk
+		FOREIGN KEY (managed_run_id, project_id, work_item_id)
+		REFERENCES decodex.managed_runs(managed_run_id, project_id, work_item_id)
+		ON DELETE RESTRICT,
+	CONSTRAINT managed_run_effect_barriers_shape CHECK (
+		(state = 'guarded' AND revision = 1 AND closure_input_id IS NULL
+			AND closure_input_kind IS NULL AND closed_at IS NULL)
+		OR (state = 'closed' AND revision = 2 AND closure_input_id IS NOT NULL
+			AND closure_input_kind IS NOT NULL AND closed_at IS NOT NULL)
+	),
+	CONSTRAINT managed_run_effect_barriers_finite_times CHECK (
+		pg_catalog.isfinite(created_at) AND (closed_at IS NULL OR pg_catalog.isfinite(closed_at))
+		AND created_at BETWEEN TIMESTAMPTZ 'epoch'
+			AND TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+		AND (closed_at IS NULL OR closed_at BETWEEN created_at
+			AND TIMESTAMPTZ '9999-12-31 23:59:59.999999+00')
+	)
+);
+
+CREATE TABLE decodex.managed_run_effects (
+	effect_id uuid PRIMARY KEY,
+	managed_run_id uuid NOT NULL,
+	project_id uuid NOT NULL,
+	work_item_id uuid NOT NULL,
+	ordinal integer NOT NULL CHECK (ordinal BETWEEN 1 AND 16384),
+	kind decodex.managed_run_effect_kind NOT NULL,
+	effect_key text NOT NULL,
+	state decodex.managed_run_effect_state NOT NULL DEFAULT 'recorded',
+	created_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	CONSTRAINT managed_run_effects_run_ordinal_unique UNIQUE (managed_run_id, ordinal),
+	CONSTRAINT managed_run_effects_run_scope_fk
+		FOREIGN KEY (managed_run_id, project_id, work_item_id)
+		REFERENCES decodex.managed_runs(managed_run_id, project_id, work_item_id)
+		ON DELETE RESTRICT,
+	CONSTRAINT managed_run_effects_barrier_fk FOREIGN KEY (managed_run_id)
+		REFERENCES decodex.managed_run_effect_barriers(managed_run_id) ON DELETE RESTRICT,
+	CONSTRAINT managed_run_effects_identity_canonical CHECK (
+		effect_id::text COLLATE pg_catalog."C" ~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	),
+	CONSTRAINT managed_run_effects_key_bounded CHECK (
+		pg_catalog.octet_length(effect_key) >= 1
+		AND pg_catalog.octet_length(effect_key) <= 256
+		AND effect_key COLLATE pg_catalog."C" !~ '[[:cntrl:]]'
+		AND NOT decodex.has_credential_material(effect_key)
+	),
+	CONSTRAINT managed_run_effects_finite_time CHECK (
+		pg_catalog.isfinite(created_at)
+		AND created_at BETWEEN TIMESTAMPTZ 'epoch'
+			AND TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+	)
+);
+
+CREATE TABLE decodex.managed_run_submitted_turn_receipts (
+	receipt_id uuid PRIMARY KEY,
+	managed_run_id uuid NOT NULL,
+	project_id uuid NOT NULL,
+	runtime_session_id uuid NOT NULL,
+	runtime_session_revision bigint NOT NULL CHECK (runtime_session_revision > 0),
+	turn_id uuid NOT NULL,
+	submitted_at timestamptz NOT NULL,
+	CONSTRAINT managed_run_submitted_turn_receipts_exact_turn_unique
+		UNIQUE (managed_run_id, runtime_session_id, turn_id),
+	CONSTRAINT managed_run_submitted_turn_receipts_run_project_fk
+		FOREIGN KEY (managed_run_id, project_id)
+		REFERENCES decodex.managed_runs(managed_run_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT managed_run_submitted_turn_receipts_session_fk FOREIGN KEY (runtime_session_id)
+		REFERENCES decodex.runtime_sessions(runtime_session_id) ON DELETE RESTRICT,
+	CONSTRAINT managed_run_submitted_turn_receipts_ids_canonical CHECK (
+		receipt_id::text COLLATE pg_catalog."C" ~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	),
+	CONSTRAINT managed_run_submitted_turn_receipts_finite_time CHECK (
+		pg_catalog.isfinite(submitted_at)
+		AND submitted_at BETWEEN TIMESTAMPTZ 'epoch'
+			AND TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+	)
+);
+
+CREATE TABLE decodex.managed_run_safety_inputs (
+	input_id uuid PRIMARY KEY,
+	managed_run_id uuid NOT NULL,
+	project_id uuid NOT NULL,
+	runtime_session_id uuid NOT NULL,
+	kind decodex.managed_run_safety_input_kind NOT NULL,
+	turn_id uuid,
+	managed_run_revision bigint NOT NULL CHECK (managed_run_revision > 1),
+	runtime_session_revision bigint NOT NULL CHECK (runtime_session_revision > 0),
+	barrier_revision bigint NOT NULL CHECK (barrier_revision > 0),
+	stale_receipt boolean NOT NULL,
+	request_envelope jsonb NOT NULL,
+	effect_envelope jsonb NOT NULL,
+	response_bytes bytea NOT NULL,
+	applied_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+	CONSTRAINT managed_run_safety_inputs_run_project_fk
+		FOREIGN KEY (managed_run_id, project_id)
+		REFERENCES decodex.managed_runs(managed_run_id, project_id) ON DELETE RESTRICT,
+	CONSTRAINT managed_run_safety_inputs_session_fk FOREIGN KEY (runtime_session_id)
+		REFERENCES decodex.runtime_sessions(runtime_session_id) ON DELETE RESTRICT,
+	CONSTRAINT managed_run_safety_inputs_shape CHECK (
+		(kind IN ('positively_observed_unknown_turn', 'submitted_turn_receipt') AND turn_id IS NOT NULL)
+		OR (kind = 'inconclusive_observation' AND turn_id IS NULL)
+	),
+	CONSTRAINT managed_run_safety_inputs_ids_canonical CHECK (
+		input_id::text COLLATE pg_catalog."C" ~
+			'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+	),
+	CONSTRAINT managed_run_safety_inputs_response_bounded CHECK (
+		pg_catalog.octet_length(response_bytes) BETWEEN 1 AND 1048576
+	),
+	CONSTRAINT managed_run_safety_inputs_finite_time CHECK (
+		pg_catalog.isfinite(applied_at)
+		AND applied_at BETWEEN TIMESTAMPTZ 'epoch'
+			AND TIMESTAMPTZ '9999-12-31 23:59:59.999999+00'
+	)
+);
+
+CREATE FUNCTION decodex.enforce_managed_run_command_owner()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE owner_name name;
+BEGIN
+	SELECT pg_catalog.pg_get_userbyid(class.relowner) INTO owner_name
+	FROM pg_catalog.pg_class AS class WHERE class.oid = TG_RELID;
+	IF current_user::name <> owner_name THEN
+		RAISE EXCEPTION 'ManagedRun state is command-owned'
+			USING ERRCODE = '42501', CONSTRAINT = 'managed_run_command_owner';
+	END IF;
+	RETURN NULL;
+END
+$$;
+
+CREATE TRIGGER managed_runs_command_owner
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON decodex.managed_runs
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_managed_run_command_owner();
+CREATE TRIGGER managed_run_assignments_command_owner
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON decodex.managed_run_assignments
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_managed_run_command_owner();
+CREATE TRIGGER managed_run_effect_barriers_command_owner
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON decodex.managed_run_effect_barriers
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_managed_run_command_owner();
+CREATE TRIGGER managed_run_effects_command_owner
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON decodex.managed_run_effects
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_managed_run_command_owner();
+CREATE TRIGGER managed_run_submitted_turn_receipts_command_owner
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON decodex.managed_run_submitted_turn_receipts
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_managed_run_command_owner();
+CREATE TRIGGER managed_run_safety_inputs_command_owner
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON decodex.managed_run_safety_inputs
+FOR EACH STATEMENT EXECUTE FUNCTION decodex.enforce_managed_run_command_owner();
+
+CREATE FUNCTION decodex.forbid_managed_run_immutable_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+BEGIN
+	RAISE EXCEPTION 'ManagedRun immutable evidence cannot be changed'
+		USING ERRCODE = '23514', CONSTRAINT = 'managed_run_immutable_evidence';
+END
+$$;
+CREATE TRIGGER managed_run_assignments_immutable
+BEFORE UPDATE OR DELETE ON decodex.managed_run_assignments
+FOR EACH ROW EXECUTE FUNCTION decodex.forbid_managed_run_immutable_mutation();
+CREATE TRIGGER managed_run_effects_immutable
+BEFORE UPDATE OR DELETE ON decodex.managed_run_effects
+FOR EACH ROW EXECUTE FUNCTION decodex.forbid_managed_run_immutable_mutation();
+CREATE TRIGGER managed_run_submitted_turn_receipts_immutable
+BEFORE UPDATE OR DELETE ON decodex.managed_run_submitted_turn_receipts
+FOR EACH ROW EXECUTE FUNCTION decodex.forbid_managed_run_immutable_mutation();
+CREATE TRIGGER managed_run_safety_inputs_immutable
+BEFORE UPDATE OR DELETE ON decodex.managed_run_safety_inputs
+FOR EACH ROW EXECUTE FUNCTION decodex.forbid_managed_run_immutable_mutation();
+
+CREATE FUNCTION decodex.enforce_managed_run_assignment_scope()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE run_session uuid;
+DECLARE snapshot_role decodex.role_profile_role;
+BEGIN
+	SELECT run.runtime_session_id INTO run_session FROM decodex.managed_runs AS run
+	WHERE run.managed_run_id = NEW.managed_run_id AND run.project_id = NEW.project_id;
+	SELECT profile.role INTO snapshot_role
+	FROM decodex.runtime_sessions AS session
+	JOIN decodex.profile_snapshots AS profile USING (profile_snapshot_id)
+	WHERE session.runtime_session_id = NEW.runtime_session_id;
+	IF snapshot_role::text <> NEW.role::text
+		OR (NEW.role = 'task' AND NEW.runtime_session_id <> run_session)
+	THEN
+		RAISE EXCEPTION 'execution assignment is not exact-run Task/Reviewer identity'
+			USING ERRCODE = '23514', CONSTRAINT = 'managed_run_assignment_scope';
+	END IF;
+	RETURN NULL;
+END
+$$;
+CREATE CONSTRAINT TRIGGER managed_run_assignment_scope
+AFTER INSERT ON decodex.managed_run_assignments
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_managed_run_assignment_scope();
+
+CREATE FUNCTION decodex.enforce_managed_run_state()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+BEGIN
+	IF TG_OP = 'INSERT' THEN
+		IF NEW.lifecycle <> 'waiting' OR NOT NEW.blocked OR NEW.revision <> 1
+			OR NEW.updated_at <> NEW.created_at
+		THEN
+			RAISE EXCEPTION 'new ManagedRun must be inert waiting revision one'
+				USING ERRCODE = '23514', CONSTRAINT = 'managed_runs_inert_state';
+		END IF;
+		RETURN NEW;
+	END IF;
+	IF TG_OP = 'DELETE' THEN
+		RAISE EXCEPTION 'ManagedRuns cannot be deleted'
+			USING ERRCODE = '23514', CONSTRAINT = 'managed_runs_inert_state';
+	END IF;
+	IF NEW.managed_run_id <> OLD.managed_run_id OR NEW.project_id <> OLD.project_id
+		OR NEW.work_item_id <> OLD.work_item_id
+		OR NEW.runtime_session_id <> OLD.runtime_session_id
+		OR NEW.lifecycle <> 'waiting' OR NOT NEW.blocked
+		OR NEW.phase <> OLD.phase OR NEW.created_at <> OLD.created_at
+		OR NEW.revision <> OLD.revision + 1 OR NEW.updated_at < OLD.updated_at
+		OR (OLD.diverged AND NOT NEW.diverged)
+	THEN
+		RAISE EXCEPTION 'ManagedRun update must remain monotonic and inert'
+			USING ERRCODE = '23514', CONSTRAINT = 'managed_runs_inert_state';
+	END IF;
+	RETURN NEW;
+END
+$$;
+CREATE TRIGGER managed_runs_inert_state
+BEFORE INSERT OR UPDATE OR DELETE ON decodex.managed_runs
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_managed_run_state();
+
+CREATE FUNCTION decodex.enforce_effect_barrier_state()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+BEGIN
+	IF TG_OP = 'INSERT' THEN
+		IF NEW.state <> 'guarded' OR NEW.revision <> 1 OR NEW.closed_at IS NOT NULL THEN
+			RAISE EXCEPTION 'new effect barrier must be guarded and fail closed'
+				USING ERRCODE = '23514', CONSTRAINT = 'managed_run_effect_barrier_state';
+		END IF;
+		RETURN NEW;
+	END IF;
+	IF TG_OP = 'DELETE' OR OLD.state = 'closed'
+		OR NEW.managed_run_id <> OLD.managed_run_id
+		OR NEW.project_id <> OLD.project_id OR NEW.work_item_id <> OLD.work_item_id
+		OR NEW.created_at <> OLD.created_at OR NEW.state <> 'closed'
+		OR NEW.revision <> 2 OR NEW.closure_input_id IS NULL
+		OR NEW.closure_input_kind IS NULL OR NEW.closed_at IS NULL
+	THEN
+		RAISE EXCEPTION 'effect barrier may only close exactly once'
+			USING ERRCODE = '23514', CONSTRAINT = 'managed_run_effect_barrier_state';
+	END IF;
+	RETURN NEW;
+END
+$$;
+CREATE TRIGGER managed_run_effect_barriers_state
+BEFORE INSERT OR UPDATE OR DELETE ON decodex.managed_run_effect_barriers
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_effect_barrier_state();
+
+-- Divergence is the fail-closed exception to the V3 active-turn terminal guard. An active
+-- turn remains active and therefore cannot be mistaken for completion or replay authority.
+CREATE OR REPLACE FUNCTION decodex.enforce_runtime_session_state()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE parent_status decodex.conversation_status;
+DECLARE transition_time timestamptz;
+BEGIN
+	SELECT status INTO parent_status FROM decodex.conversations
+		WHERE conversation_id = NEW.conversation_id FOR UPDATE;
+	IF parent_status <> 'open' THEN RAISE EXCEPTION 'runtime session requires an open conversation'; END IF;
+	IF TG_OP = 'INSERT' THEN
+		IF NEW.state NOT IN ('starting', 'active') OR NEW.revision <> 1 THEN
+			RAISE EXCEPTION 'illegal initial runtime session state';
+		END IF;
+		NEW.created_at := pg_catalog.clock_timestamp(); NEW.updated_at := NEW.created_at;
+		NEW.ended_at := NULL; RETURN NEW;
+	END IF;
+	IF OLD.state IN ('ended', 'diverged') THEN RAISE EXCEPTION 'terminal runtime session is immutable'; END IF;
+	IF NEW.runtime_session_id <> OLD.runtime_session_id
+		OR NEW.conversation_id <> OLD.conversation_id
+		OR NEW.profile_snapshot_id <> OLD.profile_snapshot_id
+		OR NEW.account_snapshot_id <> OLD.account_snapshot_id
+		OR NEW.codex_thread_id IS DISTINCT FROM OLD.codex_thread_id
+		OR NEW.last_known_turn_id IS DISTINCT FROM OLD.last_known_turn_id
+		OR NEW.created_at IS DISTINCT FROM OLD.created_at OR NEW.revision <> OLD.revision + 1
+		OR NOT ((OLD.state = 'starting' AND NEW.state IN ('active', 'ended', 'diverged'))
+			OR (OLD.state = 'active' AND NEW.state IN ('ended', 'diverged'))) THEN
+		RAISE EXCEPTION 'illegal runtime session transition';
+	END IF;
+	IF NEW.state = 'ended' AND EXISTS (SELECT 1 FROM decodex.turns
+		WHERE runtime_session_id = NEW.runtime_session_id AND status = 'active')
+	THEN RAISE EXCEPTION 'runtime session has active turns'; END IF;
+	transition_time := pg_catalog.clock_timestamp(); NEW.updated_at := transition_time;
+	NEW.ended_at := CASE WHEN NEW.state IN ('ended', 'diverged') THEN transition_time ELSE NULL END;
+	RETURN NEW;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION decodex.create_runtime_session_exact(
+	p_protocol text, p_idempotency_key text,
+	p_session_id uuid, p_conversation_id uuid, p_role decodex.role_profile_role,
+	p_account_snapshot_id uuid, p_source_account_id uuid, p_display_label text,
+	p_observed_state decodex.account_state, p_account_source_revision bigint,
+	p_codex_thread_id uuid, p_initial_state decodex.runtime_session_state
+) RETURNS bytea
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE request_value jsonb;
+DECLARE existing_request jsonb;
+DECLARE existing_response bytea;
+DECLARE inserted_count integer;
+DECLARE conversation_status decodex.conversation_status;
+DECLARE identity_lock bigint;
+DECLARE thread_lock bigint;
+DECLARE created_profile_snapshot_id uuid;
+DECLARE profile_value jsonb;
+DECLARE account_value jsonb;
+DECLARE session_value jsonb;
+DECLARE activity_sequence bigint;
+DECLARE activity_aggregate_kind text;
+DECLARE activity_aggregate_id text;
+DECLARE activity_revision bigint;
+DECLARE activity_event_kind text;
+DECLARE activity_payload jsonb;
+DECLARE outbox_id bigint;
+DECLARE outbox_effect_key text;
+DECLARE outbox_aggregate_kind text;
+DECLARE outbox_aggregate_id text;
+DECLARE outbox_aggregate_revision bigint;
+DECLARE outbox_payload jsonb;
+DECLARE effect_value jsonb;
+DECLARE response_value bytea;
+BEGIN
+	IF p_protocol IS NULL OR p_idempotency_key IS NULL OR p_session_id IS NULL
+		OR p_conversation_id IS NULL OR p_role IS NULL OR p_account_snapshot_id IS NULL
+		OR p_source_account_id IS NULL OR p_display_label IS NULL
+		OR p_observed_state IS NULL OR p_account_source_revision IS NULL
+		OR p_initial_state IS NULL
+	THEN
+		RAISE EXCEPTION 'exact RuntimeSession creation is incomplete' USING ERRCODE = '22004';
+	END IF;
+	IF pg_catalog.octet_length(p_protocol) NOT BETWEEN 1 AND 64
+		OR p_protocol COLLATE pg_catalog."C" !~ '^[a-z0-9][a-z0-9._/-]{0,63}$'
+		OR pg_catalog.octet_length(p_idempotency_key) NOT BETWEEN 1 AND 256
+		OR decodex.has_credential_material(p_idempotency_key)
+	THEN
+		RAISE EXCEPTION 'exact RuntimeSession command identity is invalid' USING ERRCODE = '22023';
+	END IF;
+
+	request_value := decodex.build_runtime_session_create_request(
+		p_protocol, p_session_id, p_conversation_id, p_role,
+		p_account_snapshot_id, p_source_account_id, p_display_label,
+		p_observed_state, p_account_source_revision, p_codex_thread_id, p_initial_state
+	);
+	INSERT INTO decodex.exact_command_receipts(
+		protocol_version, idempotency_key, request_envelope, request_digest, receipt_state
+	) VALUES (
+		p_protocol, p_idempotency_key, request_value,
+		public.digest(pg_catalog.convert_to(request_value::text, 'UTF8'), 'sha256'), 'executing'
+	) ON CONFLICT (protocol_version, idempotency_key) DO NOTHING;
+	GET DIAGNOSTICS inserted_count = ROW_COUNT;
+
+	IF inserted_count = 0 THEN
+		SELECT request_envelope, response_bytes INTO existing_request, existing_response
+		FROM decodex.exact_command_receipts
+		WHERE protocol_version = p_protocol AND idempotency_key = p_idempotency_key
+		FOR UPDATE;
+		IF existing_request <> request_value THEN
+			RAISE EXCEPTION 'exact idempotency conflict' USING ERRCODE = 'DX001';
+		END IF;
+		IF existing_response IS NULL THEN
+			RAISE EXCEPTION 'incomplete exact receipt is not replayable' USING ERRCODE = 'DX002';
+		END IF;
+		RETURN existing_response;
+	END IF;
+
+	IF p_initial_state NOT IN ('starting', 'active') THEN
+		RETURN decodex.complete_exact_runtime_session_rejection(
+			p_protocol, p_idempotency_key, 'illegal_transition'
+		);
+	END IF;
+	IF p_account_source_revision < 1
+		OR pg_catalog.octet_length(p_display_label) NOT BETWEEN 1 AND 128
+		OR decodex.has_credential_material(p_display_label)
+	THEN
+		RETURN decodex.complete_exact_runtime_session_rejection(
+			p_protocol, p_idempotency_key, 'invalid_account_snapshot'
+		);
+	END IF;
+
+	-- Match the statement-level hierarchy trigger order: acquire the outer coordinator
+	-- before selecting or locking a Conversation or RuntimeSession tuple.
+	PERFORM pg_catalog.pg_advisory_xact_lock(1271);
+
+	-- The row lock is both the Conversation eligibility proof and the canonical create order.
+	SELECT status INTO conversation_status FROM decodex.conversations
+	WHERE conversation_id = p_conversation_id FOR UPDATE;
+	IF NOT FOUND THEN
+		RETURN decodex.complete_exact_runtime_session_rejection(
+			p_protocol, p_idempotency_key, 'missing_target'
+		);
+	END IF;
+	IF conversation_status <> 'open' THEN
+		RETURN decodex.complete_exact_runtime_session_rejection(
+			p_protocol, p_idempotency_key, 'illegal_transition'
+		);
+	END IF;
+
+	-- Serialize both unique RuntimeSession identities in canonical order even when
+	-- hostile callers name different Conversations. Hash collisions only add safe
+	-- serialization; they cannot weaken uniqueness or rejection classification.
+	identity_lock := pg_catalog.hashtextextended(
+		'runtime_session/id/' || p_session_id::text, 0
+	);
+	thread_lock := CASE WHEN p_codex_thread_id IS NULL THEN identity_lock ELSE
+		pg_catalog.hashtextextended('runtime_session/thread/' || p_codex_thread_id::text, 0)
+	END;
+	PERFORM pg_catalog.pg_advisory_xact_lock(
+		CASE WHEN identity_lock <= thread_lock THEN identity_lock ELSE thread_lock END
+	);
+	IF thread_lock <> identity_lock THEN
+		PERFORM pg_catalog.pg_advisory_xact_lock(
+			CASE WHEN identity_lock > thread_lock THEN identity_lock ELSE thread_lock END
+		);
+	END IF;
+	IF EXISTS (
+		SELECT 1 FROM decodex.runtime_sessions
+		WHERE runtime_session_id = p_session_id
+			OR (p_codex_thread_id IS NOT NULL AND codex_thread_id = p_codex_thread_id)
+	) THEN
+		RETURN decodex.complete_exact_runtime_session_rejection(
+			p_protocol, p_idempotency_key, 'duplicate_target'
+		);
+	END IF;
+
+	-- FOR SHARE prevents a concurrent profile advance until the complete selected
+	-- revision has been copied, yielding either the old or new immutable revision.
+	SELECT pg_catalog.jsonb_build_object(
+		'role', revision.role, 'revision', revision.revision,
+		'model', revision.model, 'reasoning_effort', revision.reasoning_effort,
+		'service_tier', revision.service_tier, 'instructions', revision.instructions,
+		'provenance', revision.provenance, 'created_at', revision.created_at
+	) INTO profile_value
+	FROM decodex.role_profiles AS profile
+	JOIN decodex.role_profile_revisions AS revision
+		ON (revision.role, revision.revision) = (profile.role, profile.current_revision)
+	WHERE profile.role = p_role
+	FOR SHARE OF profile;
+	IF NOT FOUND THEN
+		RETURN decodex.complete_exact_runtime_session_rejection(
+			p_protocol, p_idempotency_key, 'missing_target'
+		);
+	END IF;
+
+	INSERT INTO decodex.account_snapshots(
+		account_snapshot_id, source_account_id, display_label, observed_state, source_revision
+	) VALUES (
+		p_account_snapshot_id, p_source_account_id, p_display_label,
+		p_observed_state, p_account_source_revision
+	) ON CONFLICT (account_snapshot_id) DO NOTHING;
+	SELECT pg_catalog.jsonb_build_object(
+		'account_snapshot_id', account_snapshot_id,
+		'source_account_id', source_account_id, 'display_label', display_label,
+		'observed_state', observed_state, 'source_revision', source_revision,
+		'created_at', created_at
+	) INTO account_value
+	FROM decodex.account_snapshots WHERE account_snapshot_id = p_account_snapshot_id;
+	IF account_value->>'source_account_id' <> p_source_account_id::text
+		OR account_value->>'display_label' <> p_display_label
+		OR account_value->>'observed_state' <> p_observed_state::text
+		OR (account_value->>'source_revision')::bigint <> p_account_source_revision
+	THEN
+		RETURN decodex.complete_exact_runtime_session_rejection(
+			p_protocol, p_idempotency_key, 'account_snapshot_conflict'
+		);
+	END IF;
+
+	created_profile_snapshot_id := pg_catalog.gen_random_uuid();
+	INSERT INTO decodex.profile_snapshots(
+		profile_snapshot_id, source_profile_id, role, model, reasoning_effort,
+		service_tier, instructions_digest, instructions, provenance, source_revision
+	) VALUES (
+		created_profile_snapshot_id, profile_value->>'role', p_role,
+		profile_value->>'model', profile_value->>'reasoning_effort',
+		profile_value->>'service_tier',
+		pg_catalog.encode(public.digest(
+			pg_catalog.convert_to(profile_value->>'instructions', 'UTF8'), 'sha256'
+		), 'hex'), profile_value->>'instructions', profile_value->>'provenance',
+		(profile_value->>'revision')::bigint
+	) RETURNING pg_catalog.jsonb_build_object(
+		'profile_snapshot_id', profile_snapshot_id,
+		'source_profile_id', source_profile_id, 'role', role,
+		'model', model, 'reasoning_effort', reasoning_effort,
+		'service_tier', service_tier, 'instructions_digest', instructions_digest,
+		'instructions', instructions, 'provenance', provenance,
+		'source_revision', source_revision, 'created_at', created_at
+	) INTO profile_value;
+
+	INSERT INTO decodex.runtime_sessions(
+		runtime_session_id, conversation_id, profile_snapshot_id,
+		account_snapshot_id, codex_thread_id, state, last_known_turn_id
+	) VALUES (
+		p_session_id, p_conversation_id, created_profile_snapshot_id,
+		p_account_snapshot_id, p_codex_thread_id, p_initial_state, NULL
+	) RETURNING pg_catalog.jsonb_build_object(
+		'runtime_session_id', runtime_session_id, 'conversation_id', conversation_id,
+		'profile_snapshot_id', profile_snapshot_id,
+		'account_snapshot_id', account_snapshot_id,
+		'codex_thread_id', codex_thread_id, 'last_known_turn_id', last_known_turn_id,
+		'state', state, 'revision', revision, 'created_at', created_at,
+		'updated_at', updated_at, 'ended_at', ended_at
+	) INTO session_value;
+
+	activity_payload := pg_catalog.jsonb_build_object(
+		'kind', 'runtime_session', 'runtime_session_snapshot', session_value,
+		'profile_snapshot', profile_value, 'account_snapshot', account_value
+	);
+	INSERT INTO decodex.activity(
+		aggregate_kind, aggregate_id, revision, event_kind, correlation_key, payload
+	) VALUES (
+		'runtime_session', p_session_id::text, 1, 'runtime_session_created',
+		p_idempotency_key, activity_payload
+	) RETURNING sequence, aggregate_kind, aggregate_id, revision, event_kind, payload
+	INTO activity_sequence, activity_aggregate_kind, activity_aggregate_id,
+		activity_revision, activity_event_kind, activity_payload;
+	outbox_payload := pg_catalog.jsonb_build_object(
+		'activity_sequence', activity_sequence, 'event_kind', 'runtime_session_created',
+		'aggregate_kind', 'runtime_session', 'aggregate_id', p_session_id,
+		'revision', 1, 'payload', activity_payload
+	);
+	INSERT INTO decodex.outbox(
+		effect_key, aggregate_kind, aggregate_id, aggregate_revision, payload
+	) VALUES (
+		'activity/' || activity_sequence::text, 'runtime_session', p_session_id::text,
+		1, outbox_payload
+	) RETURNING id, effect_key, aggregate_kind, aggregate_id, aggregate_revision, payload
+	INTO outbox_id, outbox_effect_key, outbox_aggregate_kind,
+		outbox_aggregate_id, outbox_aggregate_revision, outbox_payload;
+
+	effect_value := pg_catalog.jsonb_build_object(
+		'request', request_value,
+		'runtime_session_snapshot', session_value, 'profile_snapshot', profile_value,
+		'account_snapshot', account_value, 'prior_state', NULL,
+		'new_state', p_initial_state, 'prior_revision', NULL, 'new_revision', 1,
+		'activity_sequence', activity_sequence,
+		'activity_aggregate_kind', activity_aggregate_kind,
+		'activity_aggregate_id', activity_aggregate_id,
+		'activity_revision', activity_revision,
+		'activity_event_kind', activity_event_kind,
+		'activity_payload', activity_payload,
+		'outbox_id', outbox_id, 'outbox_effect_key', outbox_effect_key,
+		'outbox_aggregate_kind', outbox_aggregate_kind,
+		'outbox_aggregate_id', outbox_aggregate_id,
+		'outbox_aggregate_revision', outbox_aggregate_revision,
+		'outbox_payload', outbox_payload
+	);
+	response_value := pg_catalog.convert_to(pg_catalog.jsonb_build_object(
+		'classification', 'success', 'effect', effect_value
+	)::text, 'UTF8');
+	UPDATE decodex.exact_command_receipts
+	SET receipt_state = 'completed_success', outcome_class = 'success',
+		effect_envelope = effect_value, response_bytes = response_value,
+		completed_at = pg_catalog.clock_timestamp()
+	WHERE protocol_version = p_protocol AND idempotency_key = p_idempotency_key;
+
+	RETURN response_value;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION decodex.transition_runtime_session_exact(
+	p_protocol text, p_idempotency_key text, p_session_id uuid,
+	p_expected_revision bigint, p_target_state decodex.runtime_session_state
+) RETURNS bytea
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE request_value jsonb;
+DECLARE existing_request jsonb;
+DECLARE existing_response bytea;
+DECLARE inserted_count integer;
+DECLARE prior_state decodex.runtime_session_state;
+DECLARE actual_revision bigint;
+DECLARE profile_value jsonb;
+DECLARE account_value jsonb;
+DECLARE session_value jsonb;
+DECLARE activity_sequence bigint;
+DECLARE activity_aggregate_kind text;
+DECLARE activity_aggregate_id text;
+DECLARE activity_revision bigint;
+DECLARE activity_event_kind text;
+DECLARE activity_payload jsonb;
+DECLARE outbox_id bigint;
+DECLARE outbox_effect_key text;
+DECLARE outbox_aggregate_kind text;
+DECLARE outbox_aggregate_id text;
+DECLARE outbox_aggregate_revision bigint;
+DECLARE outbox_payload jsonb;
+DECLARE effect_value jsonb;
+DECLARE response_value bytea;
+BEGIN
+	IF p_protocol IS NULL OR p_idempotency_key IS NULL OR p_session_id IS NULL
+		OR p_expected_revision IS NULL OR p_target_state IS NULL
+	THEN
+		RAISE EXCEPTION 'exact RuntimeSession transition is incomplete' USING ERRCODE = '22004';
+	END IF;
+	IF pg_catalog.octet_length(p_protocol) NOT BETWEEN 1 AND 64
+		OR p_protocol COLLATE pg_catalog."C" !~ '^[a-z0-9][a-z0-9._/-]{0,63}$'
+		OR pg_catalog.octet_length(p_idempotency_key) NOT BETWEEN 1 AND 256
+		OR decodex.has_credential_material(p_idempotency_key)
+	THEN
+		RAISE EXCEPTION 'exact RuntimeSession command identity is invalid' USING ERRCODE = '22023';
+	END IF;
+
+	request_value := decodex.build_runtime_session_transition_request(
+		p_protocol, p_session_id, p_expected_revision, p_target_state
+	);
+	INSERT INTO decodex.exact_command_receipts(
+		protocol_version, idempotency_key, request_envelope, request_digest, receipt_state
+	) VALUES (
+		p_protocol, p_idempotency_key, request_value,
+		public.digest(pg_catalog.convert_to(request_value::text, 'UTF8'), 'sha256'), 'executing'
+	) ON CONFLICT (protocol_version, idempotency_key) DO NOTHING;
+	GET DIAGNOSTICS inserted_count = ROW_COUNT;
+
+	IF inserted_count = 0 THEN
+		SELECT request_envelope, response_bytes INTO existing_request, existing_response
+		FROM decodex.exact_command_receipts
+		WHERE protocol_version = p_protocol AND idempotency_key = p_idempotency_key
+		FOR UPDATE;
+		IF existing_request <> request_value THEN
+			RAISE EXCEPTION 'exact idempotency conflict' USING ERRCODE = 'DX001';
+		END IF;
+		IF existing_response IS NULL THEN
+			RAISE EXCEPTION 'incomplete exact receipt is not replayable' USING ERRCODE = 'DX002';
+		END IF;
+		RETURN existing_response;
+	END IF;
+
+	-- The following UPDATE has the same outer coordinator as every hierarchy mutation.
+	-- Acquire it before the executor can select and lock the RuntimeSession tuple below.
+	PERFORM pg_catalog.pg_advisory_xact_lock(1271);
+
+	SELECT session.state, session.revision,
+		pg_catalog.jsonb_build_object(
+			'profile_snapshot_id', profile.profile_snapshot_id,
+			'source_profile_id', profile.source_profile_id, 'role', profile.role,
+			'model', profile.model, 'reasoning_effort', profile.reasoning_effort,
+			'service_tier', profile.service_tier,
+			'instructions_digest', profile.instructions_digest,
+			'instructions', profile.instructions, 'provenance', profile.provenance,
+			'source_revision', profile.source_revision, 'created_at', profile.created_at
+		),
+		pg_catalog.jsonb_build_object(
+			'account_snapshot_id', account.account_snapshot_id,
+			'source_account_id', account.source_account_id,
+			'display_label', account.display_label, 'observed_state', account.observed_state,
+			'source_revision', account.source_revision, 'created_at', account.created_at
+		)
+	INTO prior_state, actual_revision, profile_value, account_value
+	FROM decodex.runtime_sessions AS session
+	JOIN decodex.profile_snapshots AS profile USING (profile_snapshot_id)
+	JOIN decodex.account_snapshots AS account USING (account_snapshot_id)
+	WHERE session.runtime_session_id = p_session_id
+	FOR UPDATE OF session;
+	IF NOT FOUND THEN
+		RETURN decodex.complete_exact_runtime_session_rejection(
+			p_protocol, p_idempotency_key, 'missing_target'
+		);
+	END IF;
+	IF actual_revision <> p_expected_revision THEN
+		RETURN decodex.complete_exact_runtime_session_rejection(
+			p_protocol, p_idempotency_key, 'stale_revision'
+		);
+	END IF;
+	IF NOT (
+		(prior_state = 'starting' AND p_target_state IN ('active', 'ended', 'diverged'))
+		OR (prior_state = 'active' AND p_target_state IN ('ended', 'diverged'))
+	) OR (p_target_state IN ('ended', 'diverged') AND EXISTS (
+		SELECT 1 FROM decodex.turns
+		WHERE runtime_session_id = p_session_id AND status = 'active'
+	)) THEN
+		RETURN decodex.complete_exact_runtime_session_rejection(
+			p_protocol, p_idempotency_key, 'illegal_transition'
+		);
+	END IF;
+
+	UPDATE decodex.runtime_sessions
+	SET state = p_target_state, revision = revision + 1
+	WHERE runtime_session_id = p_session_id AND revision = p_expected_revision
+	RETURNING pg_catalog.jsonb_build_object(
+		'runtime_session_id', runtime_session_id, 'conversation_id', conversation_id,
+		'profile_snapshot_id', profile_snapshot_id,
+		'account_snapshot_id', account_snapshot_id,
+		'codex_thread_id', codex_thread_id, 'last_known_turn_id', last_known_turn_id,
+		'state', state, 'revision', revision, 'created_at', created_at,
+		'updated_at', updated_at, 'ended_at', ended_at
+	) INTO session_value;
+	IF session_value IS NULL THEN
+		RAISE EXCEPTION 'RuntimeSession compare-and-swap lost after row lock' USING ERRCODE = '40001';
+	END IF;
+
+	activity_payload := pg_catalog.jsonb_build_object(
+		'kind', 'runtime_session', 'runtime_session_snapshot', session_value,
+		'profile_snapshot', profile_value, 'account_snapshot', account_value,
+		'prior_state', prior_state, 'new_state', p_target_state,
+		'prior_revision', p_expected_revision,
+		'new_revision', (session_value->>'revision')::bigint
+	);
+	INSERT INTO decodex.activity(
+		aggregate_kind, aggregate_id, revision, event_kind, correlation_key, payload
+	) VALUES (
+		'runtime_session', p_session_id::text, (session_value->>'revision')::bigint,
+		'runtime_session_transitioned', p_idempotency_key, activity_payload
+	) RETURNING sequence, aggregate_kind, aggregate_id, revision, event_kind, payload
+	INTO activity_sequence, activity_aggregate_kind, activity_aggregate_id,
+		activity_revision, activity_event_kind, activity_payload;
+	outbox_payload := pg_catalog.jsonb_build_object(
+		'activity_sequence', activity_sequence, 'event_kind', 'runtime_session_transitioned',
+		'aggregate_kind', 'runtime_session', 'aggregate_id', p_session_id,
+		'revision', (session_value->>'revision')::bigint, 'payload', activity_payload
+	);
+	INSERT INTO decodex.outbox(
+		effect_key, aggregate_kind, aggregate_id, aggregate_revision, payload
+	) VALUES (
+		'activity/' || activity_sequence::text, 'runtime_session', p_session_id::text,
+		(session_value->>'revision')::bigint, outbox_payload
+	) RETURNING id, effect_key, aggregate_kind, aggregate_id, aggregate_revision, payload
+	INTO outbox_id, outbox_effect_key, outbox_aggregate_kind,
+		outbox_aggregate_id, outbox_aggregate_revision, outbox_payload;
+
+	effect_value := pg_catalog.jsonb_build_object(
+		'request', request_value,
+		'runtime_session_snapshot', session_value, 'profile_snapshot', profile_value,
+		'account_snapshot', account_value, 'prior_state', prior_state,
+		'new_state', p_target_state, 'prior_revision', p_expected_revision,
+		'new_revision', (session_value->>'revision')::bigint,
+		'activity_sequence', activity_sequence,
+		'activity_aggregate_kind', activity_aggregate_kind,
+		'activity_aggregate_id', activity_aggregate_id,
+		'activity_revision', activity_revision,
+		'activity_event_kind', activity_event_kind,
+		'activity_payload', activity_payload,
+		'outbox_id', outbox_id, 'outbox_effect_key', outbox_effect_key,
+		'outbox_aggregate_kind', outbox_aggregate_kind,
+		'outbox_aggregate_id', outbox_aggregate_id,
+		'outbox_aggregate_revision', outbox_aggregate_revision,
+		'outbox_payload', outbox_payload
+	);
+	response_value := pg_catalog.convert_to(pg_catalog.jsonb_build_object(
+		'classification', 'success', 'effect', effect_value
+	)::text, 'UTF8');
+	UPDATE decodex.exact_command_receipts
+	SET receipt_state = 'completed_success', outcome_class = 'success',
+		effect_envelope = effect_value, response_bytes = response_value,
+		completed_at = pg_catalog.clock_timestamp()
+	WHERE protocol_version = p_protocol AND idempotency_key = p_idempotency_key;
+
+	RETURN response_value;
+END
+$$;
+
+-- V3 locked RuntimeSessions from invoker-rights Turn and HistoryItem triggers. V10 made
+-- RuntimeSessions SELECT-only for runtime, so V12 rolls those triggers forward without an
+-- authority-expanding UPDATE grant. The statement-level hierarchy coordinator remains the
+-- serialization owner; unsupported transaction isolation fails closed before hierarchy reads.
+CREATE OR REPLACE FUNCTION decodex.enforce_turn_state() RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE parent_state decodex.runtime_session_state;
+DECLARE parent_status decodex.conversation_status;
+DECLARE transition_time timestamptz;
+BEGIN
+	IF pg_catalog.current_setting('transaction_isolation') <> 'read committed' THEN
+		RAISE EXCEPTION 'turn hierarchy writes require READ COMMITTED'
+			USING ERRCODE = '40001';
+	END IF;
+	SELECT c.status, rs.state INTO parent_status, parent_state
+		FROM decodex.conversations c JOIN decodex.runtime_sessions rs
+		ON rs.conversation_id = c.conversation_id
+		WHERE c.conversation_id = NEW.conversation_id
+			AND rs.runtime_session_id = NEW.runtime_session_id FOR UPDATE OF c;
+	IF TG_OP = 'INSERT' THEN
+		IF parent_status <> 'open' OR parent_state <> 'active'
+			OR NEW.status <> 'active' OR NEW.revision <> 1 THEN
+			RAISE EXCEPTION 'turn requires an active parent';
+		END IF;
+		NEW.created_at := pg_catalog.clock_timestamp();
+		NEW.updated_at := NEW.created_at;
+		NEW.completed_at := NULL;
+		RETURN NEW;
+	END IF;
+	IF OLD.status IN ('completed', 'failed') THEN RAISE EXCEPTION 'terminal turn is immutable'; END IF;
+	IF NEW.turn_id <> OLD.turn_id OR NEW.conversation_id <> OLD.conversation_id
+		OR NEW.runtime_session_id <> OLD.runtime_session_id OR NEW.sequence <> OLD.sequence
+		OR NEW.role <> OLD.role OR NEW.possible_side_effects <> OLD.possible_side_effects
+		OR NEW.created_at IS DISTINCT FROM OLD.created_at
+		OR NEW.revision <> OLD.revision + 1 OR NEW.status NOT IN ('completed', 'failed') THEN
+		RAISE EXCEPTION 'illegal turn transition';
+	END IF;
+	IF EXISTS (SELECT 1 FROM decodex.history_items WHERE turn_id = NEW.turn_id
+		AND status = 'streaming') THEN RAISE EXCEPTION 'turn has streaming items'; END IF;
+	transition_time := pg_catalog.clock_timestamp();
+	NEW.updated_at := transition_time;
+	NEW.completed_at := transition_time;
+	RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION decodex.enforce_history_item_state() RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE turn_state decodex.turn_status;
+DECLARE session_state decodex.runtime_session_state;
+DECLARE conversation_state decodex.conversation_status;
+DECLARE artifact_state decodex.artifact_status;
+DECLARE next_position bigint;
+BEGIN
+	IF pg_catalog.current_setting('transaction_isolation') <> 'read committed' THEN
+		RAISE EXCEPTION 'history hierarchy writes require READ COMMITTED'
+			USING ERRCODE = '40001';
+	END IF;
+	SELECT t.status, rs.state, c.status INTO turn_state, session_state, conversation_state
+		FROM decodex.turns t JOIN decodex.runtime_sessions rs
+		ON (rs.runtime_session_id, rs.conversation_id) = (t.runtime_session_id, t.conversation_id)
+		JOIN decodex.conversations c ON c.conversation_id = t.conversation_id
+		WHERE (t.turn_id, t.conversation_id) = (NEW.turn_id, NEW.conversation_id)
+			FOR UPDATE OF c, t;
+	IF turn_state <> 'active' OR session_state <> 'active' OR conversation_state <> 'open' THEN
+		RAISE EXCEPTION 'history write requires active parents';
+	END IF;
+	IF NEW.kind = 'artifact' THEN
+		SELECT status INTO artifact_state FROM decodex.artifacts
+			WHERE (artifact_id, conversation_id) = (NEW.artifact_id, NEW.conversation_id)
+			FOR UPDATE;
+		IF artifact_state <> 'active' THEN
+			RAISE EXCEPTION 'history Artifact reference requires active Artifact';
+		END IF;
+	END IF;
+	IF TG_OP = 'INSERT' THEN
+		IF NEW.revision <> 1 THEN RAISE EXCEPTION 'history item must start at revision 1'; END IF;
+		SELECT COALESCE(max(history_position), 0) + 1 INTO next_position
+			FROM decodex.history_items WHERE conversation_id = NEW.conversation_id;
+		NEW.history_position := next_position;
+		NEW.created_at := pg_catalog.clock_timestamp();
+		NEW.updated_at := NEW.created_at;
+		RETURN NEW;
+	END IF;
+	IF OLD.status IN ('completed', 'failed') THEN RAISE EXCEPTION 'terminal history item is immutable'; END IF;
+	IF NEW.history_item_id <> OLD.history_item_id OR NEW.conversation_id <> OLD.conversation_id
+		OR NEW.history_position <> OLD.history_position OR NEW.turn_id <> OLD.turn_id
+		OR NEW.ordinal <> OLD.ordinal OR NEW.kind <> OLD.kind
+		OR NEW.artifact_id IS DISTINCT FROM OLD.artifact_id
+		OR NEW.artifact_revision IS DISTINCT FROM OLD.artifact_revision
+		OR NEW.created_at IS DISTINCT FROM OLD.created_at
+		OR NEW.revision <> OLD.revision + 1 THEN
+		RAISE EXCEPTION 'illegal history item transition';
+	END IF;
+	NEW.updated_at := pg_catalog.clock_timestamp();
+	RETURN NEW;
+END;
+$$;
+
+CREATE FUNCTION decodex.enforce_managed_run_event_namespace()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE owner_name name;
+DECLARE linked boolean := false;
+BEGIN
+	SELECT pg_catalog.pg_get_userbyid(class.relowner) INTO owner_name
+	FROM pg_catalog.pg_class AS class WHERE class.oid = TG_RELID;
+	IF TG_TABLE_NAME = 'activity' THEN
+		linked := NEW.aggregate_kind = 'managed_run'
+			OR NEW.event_kind LIKE 'managed_run_%'
+			OR pg_catalog.jsonb_path_exists(NEW.payload, '$.** ? (
+				@.aggregate_kind == "managed_run" || @.kind == "managed_run" ||
+				@.event_kind like_regex "^managed_run_" ||
+				exists(@.managed_run) || exists(@.managed_run_id) ||
+				exists(@.effect_barrier) || exists(@.effect_barrier_id)
+			)');
+		IF TG_OP = 'UPDATE' THEN
+			linked := linked OR OLD.aggregate_kind = 'managed_run'
+				OR OLD.event_kind LIKE 'managed_run_%'
+				OR pg_catalog.jsonb_path_exists(OLD.payload, '$.** ? (
+					@.aggregate_kind == "managed_run" || @.kind == "managed_run" ||
+					@.event_kind like_regex "^managed_run_" ||
+					exists(@.managed_run) || exists(@.managed_run_id) ||
+					exists(@.effect_barrier) || exists(@.effect_barrier_id)
+				)');
+		END IF;
+	ELSE
+		IF EXISTS (
+			SELECT 1 FROM pg_catalog.jsonb_path_query(
+				NEW.payload, '$.**.activity_sequence'
+			) AS link(value)
+			WHERE pg_catalog.jsonb_typeof(link.value) NOT IN ('number', 'string')
+				OR link.value #>> '{}' !~ '^[0-9]+$'
+		) THEN
+			RAISE EXCEPTION 'ManagedRun activity/outbox link is malformed'
+				USING ERRCODE = '42501', CONSTRAINT = 'managed_run_event_namespace';
+		END IF;
+		linked := NEW.aggregate_kind = 'managed_run'
+			OR pg_catalog.jsonb_path_exists(NEW.payload, '$.** ? (
+				@.aggregate_kind == "managed_run" || @.kind == "managed_run" ||
+				@.event_kind like_regex "^managed_run_" ||
+				exists(@.managed_run) || exists(@.managed_run_id) ||
+				exists(@.effect_barrier) || exists(@.effect_barrier_id)
+			)') OR EXISTS (
+				SELECT 1 FROM pg_catalog.jsonb_path_query(
+					NEW.payload, '$.**.activity_sequence'
+				) AS link(value)
+				JOIN decodex.activity AS activity ON activity.sequence = CASE
+					WHEN pg_catalog.jsonb_typeof(link.value) IN ('number', 'string')
+						AND link.value #>> '{}' ~ '^[0-9]+$'
+					THEN (link.value #>> '{}')::bigint
+				END WHERE activity.aggregate_kind = 'managed_run'
+					OR activity.event_kind LIKE 'managed_run_%'
+					OR pg_catalog.jsonb_path_exists(activity.payload, '$.** ? (
+						@.aggregate_kind == "managed_run" || @.kind == "managed_run" ||
+						@.event_kind like_regex "^managed_run_" ||
+						exists(@.managed_run) || exists(@.managed_run_id) ||
+						exists(@.effect_barrier) || exists(@.effect_barrier_id)
+					)')
+			);
+		IF TG_OP = 'UPDATE' THEN
+			IF EXISTS (
+				SELECT 1 FROM pg_catalog.jsonb_path_query(
+					OLD.payload, '$.**.activity_sequence'
+				) AS link(value)
+				WHERE pg_catalog.jsonb_typeof(link.value) NOT IN ('number', 'string')
+					OR link.value #>> '{}' !~ '^[0-9]+$'
+			) THEN
+				RAISE EXCEPTION 'ManagedRun activity/outbox link is malformed'
+					USING ERRCODE = '42501', CONSTRAINT = 'managed_run_event_namespace';
+			END IF;
+			linked := linked OR OLD.aggregate_kind = 'managed_run'
+				OR pg_catalog.jsonb_path_exists(OLD.payload, '$.** ? (
+					@.aggregate_kind == "managed_run" || @.kind == "managed_run" ||
+					@.event_kind like_regex "^managed_run_" ||
+					exists(@.managed_run) || exists(@.managed_run_id) ||
+					exists(@.effect_barrier) || exists(@.effect_barrier_id)
+				)') OR EXISTS (
+					SELECT 1 FROM pg_catalog.jsonb_path_query(
+						OLD.payload, '$.**.activity_sequence'
+					) AS link(value)
+					JOIN decodex.activity AS activity ON activity.sequence = CASE
+						WHEN pg_catalog.jsonb_typeof(link.value) IN ('number', 'string')
+							AND link.value #>> '{}' ~ '^[0-9]+$'
+						THEN (link.value #>> '{}')::bigint
+					END WHERE activity.aggregate_kind = 'managed_run'
+						OR activity.event_kind LIKE 'managed_run_%'
+						OR pg_catalog.jsonb_path_exists(activity.payload, '$.** ? (
+							@.aggregate_kind == "managed_run" || @.kind == "managed_run" ||
+							@.event_kind like_regex "^managed_run_" ||
+							exists(@.managed_run) || exists(@.managed_run_id) ||
+							exists(@.effect_barrier) || exists(@.effect_barrier_id)
+						)')
+				);
+		END IF;
+	END IF;
+	IF linked AND current_user::name <> owner_name THEN
+		IF TG_TABLE_NAME = 'activity' OR TG_OP = 'INSERT' THEN
+			RAISE EXCEPTION 'ManagedRun activity/outbox namespace is command-owned'
+				USING ERRCODE = '42501', CONSTRAINT = 'managed_run_event_namespace';
+		ELSIF NEW.id IS DISTINCT FROM OLD.id
+			OR NEW.effect_key IS DISTINCT FROM OLD.effect_key
+			OR NEW.aggregate_kind IS DISTINCT FROM OLD.aggregate_kind
+			OR NEW.aggregate_id IS DISTINCT FROM OLD.aggregate_id
+			OR NEW.aggregate_revision IS DISTINCT FROM OLD.aggregate_revision
+			OR NEW.payload IS DISTINCT FROM OLD.payload
+			OR NEW.created_at IS DISTINCT FROM OLD.created_at
+		THEN
+			RAISE EXCEPTION 'ManagedRun outbox authority fields are command-owned'
+				USING ERRCODE = '42501', CONSTRAINT = 'managed_run_event_namespace';
+		END IF;
+	END IF;
+	RETURN NEW;
+EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+	RAISE EXCEPTION 'ManagedRun activity/outbox link is malformed'
+		USING ERRCODE = '42501', CONSTRAINT = 'managed_run_event_namespace';
+END
+$$;
+CREATE TRIGGER activity_managed_run_namespace
+BEFORE INSERT OR UPDATE ON decodex.activity
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_managed_run_event_namespace();
+CREATE TRIGGER outbox_managed_run_namespace
+BEFORE INSERT OR UPDATE ON decodex.outbox
+FOR EACH ROW EXECUTE FUNCTION decodex.enforce_managed_run_event_namespace();
+
+CREATE FUNCTION decodex.reserve_exact_managed_run_safety_command(
+	p_protocol text, p_idempotency_key text, p_request jsonb
+) RETURNS bytea
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE inserted_count bigint;
+DECLARE existing_request jsonb;
+DECLARE existing_response bytea;
+BEGIN
+	IF p_protocol IS NULL OR p_idempotency_key IS NULL OR p_request IS NULL
+		OR pg_catalog.octet_length(p_protocol) NOT BETWEEN 1 AND 64
+		OR p_protocol COLLATE pg_catalog."C" !~ '^[a-z0-9][a-z0-9._/-]{0,63}$'
+		OR pg_catalog.octet_length(p_idempotency_key) NOT BETWEEN 1 AND 256
+		OR decodex.has_credential_material(p_idempotency_key)
+	THEN RAISE EXCEPTION 'exact ManagedRun safety command identity is invalid' USING ERRCODE='22023'; END IF;
+	INSERT INTO decodex.exact_command_receipts(
+		protocol_version,idempotency_key,request_envelope,request_digest,receipt_state
+	) VALUES (p_protocol,p_idempotency_key,p_request,
+		public.digest(pg_catalog.convert_to(p_request::text,'UTF8'),'sha256'),'executing')
+	ON CONFLICT (protocol_version,idempotency_key) DO NOTHING;
+	GET DIAGNOSTICS inserted_count = ROW_COUNT;
+	IF inserted_count = 0 THEN
+		SELECT request_envelope,response_bytes INTO existing_request,existing_response
+		FROM decodex.exact_command_receipts
+		WHERE protocol_version=p_protocol AND idempotency_key=p_idempotency_key FOR UPDATE;
+		IF existing_request <> p_request THEN RAISE EXCEPTION 'exact idempotency conflict' USING ERRCODE='DX001'; END IF;
+		IF existing_response IS NULL THEN RAISE EXCEPTION 'incomplete exact receipt is not replayable' USING ERRCODE='DX002'; END IF;
+		RETURN existing_response;
+	END IF;
+	RETURN NULL;
+END
+$$;
+
+CREATE FUNCTION decodex.complete_exact_managed_run_safety_rejection(
+	p_protocol text, p_idempotency_key text, p_reason text, p_request jsonb
+) RETURNS bytea
+LANGUAGE plpgsql
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE effect_value jsonb;
+DECLARE response_value bytea;
+BEGIN
+	effect_value := pg_catalog.jsonb_build_object('request',p_request,'reason',p_reason);
+	response_value := pg_catalog.convert_to(pg_catalog.jsonb_build_object(
+		'classification','stable_domain_rejection','effect',effect_value)::text,'UTF8');
+	UPDATE decodex.exact_command_receipts SET receipt_state='completed_rejected',
+		outcome_class='stable_domain_rejection',effect_envelope=effect_value,response_bytes=response_value,
+		completed_at=pg_catalog.clock_timestamp()
+	WHERE protocol_version=p_protocol AND idempotency_key=p_idempotency_key;
+	RETURN response_value;
+END
+$$;
+
+CREATE FUNCTION decodex.apply_managed_run_safety_input_exact(
+	p_protocol text, p_idempotency_key text, p_managed_run_id uuid, p_project_id uuid,
+	p_expected_run_revision bigint, p_input_kind decodex.managed_run_safety_input_kind,
+	p_input_id uuid, p_runtime_session_id uuid, p_turn_id uuid
+) RETURNS bytea
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, decodex
+AS $$
+DECLARE request_value jsonb;
+DECLARE replay bytea;
+DECLARE prior_input record;
+DECLARE run_row record;
+DECLARE session_row record;
+DECLARE barrier_row record;
+DECLARE submitted_row record;
+DECLARE stale_receipt boolean := false;
+DECLARE unknown_turn boolean := false;
+DECLARE barrier_closed_now boolean := false;
+DECLARE new_run_revision bigint;
+DECLARE new_session_revision bigint;
+DECLARE new_barrier_revision bigint;
+DECLARE effect_value jsonb;
+DECLARE response_value bytea;
+BEGIN
+	request_value := pg_catalog.jsonb_build_object(
+		'protocol_version',p_protocol,'operation','apply_managed_run_safety_input',
+		'managed_run_id',p_managed_run_id,'project_id',p_project_id,
+		'expected_run_revision',p_expected_run_revision,'input_kind',p_input_kind,
+		'input_id',p_input_id,'runtime_session_id',p_runtime_session_id,'turn_id',p_turn_id);
+	replay := decodex.reserve_exact_managed_run_safety_command(
+		p_protocol,p_idempotency_key,request_value);
+	IF replay IS NOT NULL THEN RETURN replay; END IF;
+	IF p_managed_run_id IS NULL OR p_project_id IS NULL OR p_expected_run_revision IS NULL
+		OR p_input_kind IS NULL OR p_input_id IS NULL OR p_runtime_session_id IS NULL
+		OR p_expected_run_revision <= 0
+		OR (p_input_kind IN ('positively_observed_unknown_turn','submitted_turn_receipt')
+			AND p_turn_id IS NULL)
+		OR (p_input_kind='inconclusive_observation' AND p_turn_id IS NOT NULL)
+	THEN RETURN decodex.complete_exact_managed_run_safety_rejection(
+		p_protocol,p_idempotency_key,'invalid_input',request_value); END IF;
+
+	PERFORM pg_catalog.pg_advisory_xact_lock(1271);
+	PERFORM pg_catalog.pg_advisory_xact_lock(1338,pg_catalog.hashtext(p_managed_run_id::text));
+	SELECT * INTO prior_input FROM decodex.managed_run_safety_inputs WHERE input_id=p_input_id FOR UPDATE;
+	IF FOUND THEN
+		IF prior_input.request_envelope<>request_value
+			OR prior_input.managed_run_id<>p_managed_run_id OR prior_input.project_id<>p_project_id
+			OR prior_input.runtime_session_id<>p_runtime_session_id OR prior_input.kind<>p_input_kind
+			OR prior_input.turn_id IS DISTINCT FROM p_turn_id
+		THEN RETURN decodex.complete_exact_managed_run_safety_rejection(
+			p_protocol,p_idempotency_key,'input_identity_conflict',request_value); END IF;
+		UPDATE decodex.exact_command_receipts SET receipt_state='completed_success',
+			outcome_class='success',effect_envelope=prior_input.effect_envelope,
+			response_bytes=prior_input.response_bytes,completed_at=pg_catalog.clock_timestamp()
+		WHERE protocol_version=p_protocol AND idempotency_key=p_idempotency_key;
+		RETURN prior_input.response_bytes;
+	END IF;
+
+	SELECT * INTO run_row FROM decodex.managed_runs
+	WHERE managed_run_id=p_managed_run_id AND project_id=p_project_id FOR UPDATE;
+	IF NOT FOUND THEN RETURN decodex.complete_exact_managed_run_safety_rejection(
+		p_protocol,p_idempotency_key,'missing_target',request_value); END IF;
+	IF run_row.revision<>p_expected_run_revision THEN
+		RETURN decodex.complete_exact_managed_run_safety_rejection(
+			p_protocol,p_idempotency_key,'stale_revision',request_value); END IF;
+	IF run_row.runtime_session_id<>p_runtime_session_id THEN
+		RETURN decodex.complete_exact_managed_run_safety_rejection(
+			p_protocol,p_idempotency_key,'wrong_runtime_session',request_value); END IF;
+	SELECT * INTO session_row FROM decodex.runtime_sessions
+	WHERE runtime_session_id=p_runtime_session_id FOR UPDATE;
+	SELECT * INTO barrier_row FROM decodex.managed_run_effect_barriers
+	WHERE managed_run_id=p_managed_run_id FOR UPDATE;
+	IF session_row.runtime_session_id IS NULL OR barrier_row.managed_run_id IS NULL THEN
+		RETURN decodex.complete_exact_managed_run_safety_rejection(
+			p_protocol,p_idempotency_key,'missing_target',request_value); END IF;
+
+	IF p_input_kind='submitted_turn_receipt' THEN
+		SELECT * INTO submitted_row FROM decodex.managed_run_submitted_turn_receipts
+		WHERE receipt_id=p_input_id AND managed_run_id=p_managed_run_id
+			AND project_id=p_project_id AND runtime_session_id=p_runtime_session_id
+			AND turn_id=p_turn_id FOR SHARE;
+		IF NOT FOUND THEN RETURN decodex.complete_exact_managed_run_safety_rejection(
+			p_protocol,p_idempotency_key,'missing_submitted_turn_receipt',request_value); END IF;
+		stale_receipt := submitted_row.runtime_session_revision<>session_row.revision;
+	ELSIF p_input_kind='positively_observed_unknown_turn' THEN
+		unknown_turn := NOT EXISTS (SELECT 1 FROM decodex.managed_run_submitted_turn_receipts
+			WHERE managed_run_id=p_managed_run_id AND runtime_session_id=p_runtime_session_id
+				AND turn_id=p_turn_id)
+			AND NOT EXISTS (SELECT 1 FROM decodex.turns WHERE turn_id=p_turn_id);
+		IF NOT unknown_turn THEN
+			RETURN decodex.complete_exact_managed_run_safety_rejection(
+				p_protocol,p_idempotency_key,'turn_already_owned_or_known',request_value);
+		END IF;
+	END IF;
+
+	IF unknown_turn AND session_row.state IN ('starting','active') THEN
+		UPDATE decodex.runtime_sessions SET state='diverged',revision=revision+1
+		WHERE runtime_session_id=p_runtime_session_id;
+	END IF;
+	SELECT revision INTO new_session_revision FROM decodex.runtime_sessions
+	WHERE runtime_session_id=p_runtime_session_id;
+
+	UPDATE decodex.managed_runs SET runtime_session_revision=new_session_revision,
+		revision=revision+1,diverged=diverged OR unknown_turn,blocked=true,
+		wait_reason='external',updated_at=pg_catalog.clock_timestamp()
+	WHERE managed_run_id=p_managed_run_id RETURNING revision INTO new_run_revision;
+
+	IF barrier_row.state='guarded' THEN
+		UPDATE decodex.managed_run_effect_barriers SET state='closed',revision=2,
+			closure_input_id=p_input_id,closure_input_kind=p_input_kind,
+			closed_at=pg_catalog.clock_timestamp()
+		WHERE managed_run_id=p_managed_run_id RETURNING revision INTO new_barrier_revision;
+		barrier_closed_now := true;
+	ELSE
+		new_barrier_revision := barrier_row.revision;
+	END IF;
+
+	effect_value := pg_catalog.jsonb_build_object(
+		'request',request_value,'managed_run_id',p_managed_run_id,
+		'managed_run_revision',new_run_revision,'runtime_session_id',p_runtime_session_id,
+		'runtime_session_revision',new_session_revision,
+		'runtime_session_diverged',unknown_turn,'managed_run_blocked',true,
+		'effect_barrier_state','closed','effect_barrier_revision',new_barrier_revision,
+		'effect_barrier_closed_now',barrier_closed_now,'stale_receipt',stale_receipt);
+	response_value := pg_catalog.convert_to(pg_catalog.jsonb_build_object(
+		'classification','success','effect',effect_value)::text,'UTF8');
+	INSERT INTO decodex.managed_run_safety_inputs(
+		input_id,managed_run_id,project_id,runtime_session_id,kind,turn_id,
+		managed_run_revision,runtime_session_revision,barrier_revision,stale_receipt,
+		request_envelope,effect_envelope,response_bytes
+	) VALUES (p_input_id,p_managed_run_id,p_project_id,p_runtime_session_id,p_input_kind,p_turn_id,
+		new_run_revision,new_session_revision,new_barrier_revision,stale_receipt,
+		request_value,effect_value,response_value);
+	UPDATE decodex.exact_command_receipts SET receipt_state='completed_success',
+		outcome_class='success',effect_envelope=effect_value,response_bytes=response_value,
+		completed_at=pg_catalog.clock_timestamp()
+	WHERE protocol_version=p_protocol AND idempotency_key=p_idempotency_key;
+	RETURN response_value;
+END
+$$;
+
+REVOKE ALL ON TABLE decodex.managed_runs, decodex.managed_run_assignments,
+	decodex.managed_run_effect_barriers, decodex.managed_run_effects,
+	decodex.managed_run_submitted_turn_receipts, decodex.managed_run_safety_inputs FROM PUBLIC;
+REVOKE ALL ON TYPE decodex.managed_run_lifecycle, decodex.managed_run_phase,
+	decodex.managed_run_wait_reason, decodex.execution_assignment_role,
+	decodex.effect_barrier_state, decodex.managed_run_effect_kind,
+	decodex.managed_run_effect_state, decodex.managed_run_safety_input_kind FROM PUBLIC;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA decodex FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON TYPES FROM PUBLIC;

--- a/crates/decodex-postgres/src/authority.rs
+++ b/crates/decodex-postgres/src/authority.rs
@@ -15,9 +15,10 @@ const QUOTA_MIGRATION: &str = include_str!("../migrations/V8__quota_exclusions.s
 const ROLE_PROFILE_MIGRATION: &str = include_str!("../migrations/V9__exact_role_profiles.sql");
 const RUNTIME_SESSION_MIGRATION: &str =
 	include_str!("../migrations/V10__runtime_session_snapshots.sql");
+const WORK_ITEM_MIGRATION: &str = include_str!("../migrations/V11__work_item_authority.sql");
 const ALLOWED_EXECUTION_DEPENDENCIES: [&str; 1] =
 	["public.digest(pg_catalog.bytea,pg_catalog.text)"];
-const FUNCTION_CONTRACTS: [FunctionContract; 80] = [
+const FUNCTION_CONTRACTS: [FunctionContract; 98] = [
 	FunctionContract {
 		name: "is_canonical_media_type",
 		lookup_signature: "decodex.is_canonical_media_type(pg_catalog.text)",
@@ -672,8 +673,148 @@ const FUNCTION_CONTRACTS: [FunctionContract; 80] = [
 		"plpgsql",
 		"v",
 	),
+	immutable_function_contract(
+		"is_work_item_text",
+		"decodex.is_work_item_text(pg_catalog.text,pg_catalog.int4)",
+		"is_work_item_text(value text, maximum_bytes integer)",
+		"value text, maximum_bytes integer",
+		"boolean",
+		"sql",
+	),
+	immutable_function_contract(
+		"is_work_item_criteria",
+		"decodex.is_work_item_criteria(pg_catalog._text)",
+		"is_work_item_criteria(document text[])",
+		"document text[]",
+		"boolean",
+		"plpgsql",
+	),
+	trigger_contract(
+		"enforce_work_item_state",
+		"decodex.enforce_work_item_state()",
+		"enforce_work_item_state()",
+	),
+	trigger_contract(
+		"enforce_work_item_command_owner",
+		"decodex.enforce_work_item_command_owner()",
+		"enforce_work_item_command_owner()",
+	),
+	trigger_contract(
+		"forbid_work_item_acceptance_mutation",
+		"decodex.forbid_work_item_acceptance_mutation()",
+		"forbid_work_item_acceptance_mutation()",
+	),
+	trigger_contract(
+		"enforce_work_item_acceptance_coherence",
+		"decodex.enforce_work_item_acceptance_coherence()",
+		"enforce_work_item_acceptance_coherence()",
+	),
+	trigger_contract(
+		"enforce_work_item_event_namespace",
+		"decodex.enforce_work_item_event_namespace()",
+		"enforce_work_item_event_namespace()",
+	),
+	exact_function_contract(
+		"work_item_document",
+		"decodex.work_item_document(pg_catalog.uuid)",
+		"work_item_document(p_work_item_id uuid)",
+		"p_work_item_id uuid",
+		"jsonb",
+		"sql",
+		"s",
+	),
+	exact_function_contract(
+		"complete_exact_work_item_rejection",
+		"decodex.complete_exact_work_item_rejection(pg_catalog.text,pg_catalog.text,pg_catalog.text)",
+		"complete_exact_work_item_rejection(\n\tp_protocol text, p_idempotency_key text, p_code text\n)",
+		"p_protocol text, p_idempotency_key text, p_code text",
+		"bytea",
+		"plpgsql",
+		"v",
+	),
+	exact_function_contract(
+		"complete_exact_work_item_success",
+		"decodex.complete_exact_work_item_success(pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.jsonb)",
+		"complete_exact_work_item_success(\n\tp_protocol text, p_idempotency_key text, p_event_kind text,\n\tp_work_item_id uuid, p_effect jsonb\n)",
+		"p_protocol text, p_idempotency_key text, p_event_kind text, p_work_item_id uuid, p_effect jsonb",
+		"bytea",
+		"plpgsql",
+		"v",
+	),
+	exact_function_contract(
+		"reserve_exact_work_item_command",
+		"decodex.reserve_exact_work_item_command(pg_catalog.text,pg_catalog.text,pg_catalog.jsonb)",
+		"reserve_exact_work_item_command(\n\tp_protocol text, p_idempotency_key text, p_request jsonb\n)",
+		"p_protocol text, p_idempotency_key text, p_request jsonb",
+		"bytea",
+		"plpgsql",
+		"v",
+	),
+	exact_function_contract(
+		"work_item_graph_cycle",
+		"decodex.work_item_graph_cycle(pg_catalog.uuid)",
+		"work_item_graph_cycle(p_project_id uuid)",
+		"p_project_id uuid",
+		"boolean",
+		"sql",
+		"s",
+	),
+	exact_function_contract(
+		"work_item_readiness",
+		"decodex.work_item_readiness(pg_catalog.uuid)",
+		"work_item_readiness(p_work_item_id uuid)",
+		"p_work_item_id uuid",
+		"jsonb",
+		"plpgsql",
+		"s",
+	),
+	exact_function_contract(
+		"create_work_item_exact",
+		"decodex.create_work_item_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid,pg_catalog._uuid,pg_catalog._uuid,pg_catalog._uuid,pg_catalog.text,pg_catalog.text,decodex.work_item_priority,pg_catalog._text,pg_catalog._text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text)",
+		"create_work_item_exact(\n\tp_protocol text, p_idempotency_key text, p_work_item_id uuid, p_project_id uuid,\n\tp_lead_agent_id uuid, p_program_id uuid, p_objective_ids uuid[],\n\tp_depends_on_ids uuid[], p_blocked_by_ids uuid[], p_title text, p_description text,\n\tp_priority decodex.work_item_priority, p_acceptance_criteria text[],\n\tp_validation_criteria text[], p_actor_id uuid, p_correlation_id uuid, p_provenance text\n)",
+		"p_protocol text, p_idempotency_key text, p_work_item_id uuid, p_project_id uuid, p_lead_agent_id uuid, p_program_id uuid, p_objective_ids uuid[], p_depends_on_ids uuid[], p_blocked_by_ids uuid[], p_title text, p_description text, p_priority decodex.work_item_priority, p_acceptance_criteria text[], p_validation_criteria text[], p_actor_id uuid, p_correlation_id uuid, p_provenance text",
+		"bytea",
+		"plpgsql",
+		"v",
+	),
+	exact_function_contract(
+		"update_work_item_exact",
+		"decodex.update_work_item_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,pg_catalog.uuid,pg_catalog._uuid,pg_catalog._uuid,pg_catalog._uuid,pg_catalog.text,pg_catalog.text,decodex.work_item_priority,pg_catalog._text,pg_catalog._text,decodex.work_item_state,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text)",
+		"update_work_item_exact(\n\tp_protocol text, p_idempotency_key text, p_work_item_id uuid, p_project_id uuid,\n\tp_expected_revision bigint, p_program_id uuid, p_objective_ids uuid[],\n\tp_depends_on_ids uuid[], p_blocked_by_ids uuid[], p_title text, p_description text,\n\tp_priority decodex.work_item_priority, p_acceptance_criteria text[],\n\tp_validation_criteria text[], p_target_state decodex.work_item_state,\n\tp_actor_id uuid, p_correlation_id uuid, p_provenance text\n)",
+		"p_protocol text, p_idempotency_key text, p_work_item_id uuid, p_project_id uuid, p_expected_revision bigint, p_program_id uuid, p_objective_ids uuid[], p_depends_on_ids uuid[], p_blocked_by_ids uuid[], p_title text, p_description text, p_priority decodex.work_item_priority, p_acceptance_criteria text[], p_validation_criteria text[], p_target_state decodex.work_item_state, p_actor_id uuid, p_correlation_id uuid, p_provenance text",
+		"bytea",
+		"plpgsql",
+		"v",
+	),
+	exact_function_contract(
+		"assess_work_item_readiness_exact",
+		"decodex.assess_work_item_readiness_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text)",
+		"assess_work_item_readiness_exact(\n\tp_protocol text, p_idempotency_key text, p_work_item_id uuid, p_project_id uuid,\n\tp_expected_revision bigint, p_actor_id uuid, p_correlation_id uuid, p_provenance text\n)",
+		"p_protocol text, p_idempotency_key text, p_work_item_id uuid, p_project_id uuid, p_expected_revision bigint, p_actor_id uuid, p_correlation_id uuid, p_provenance text",
+		"bytea",
+		"plpgsql",
+		"v",
+	),
+	exact_function_contract(
+		"accept_work_item_exact",
+		"decodex.accept_work_item_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.text)",
+		"accept_work_item_exact(\n\tp_protocol text, p_idempotency_key text, p_acceptance_id uuid,\n\tp_work_item_id uuid, p_project_id uuid, p_expected_revision bigint,\n\tp_actor_id uuid, p_correlation_id uuid, p_provenance text, p_criteria_provenance text,\n\tp_evidence_summary text, p_evidence_provenance text\n)",
+		"p_protocol text, p_idempotency_key text, p_acceptance_id uuid, p_work_item_id uuid, p_project_id uuid, p_expected_revision bigint, p_actor_id uuid, p_correlation_id uuid, p_provenance text, p_criteria_provenance text, p_evidence_summary text, p_evidence_provenance text",
+		"bytea",
+		"plpgsql",
+		"v",
+	),
+	exact_function_contract(
+		"guard_work_item_running_resume",
+		"decodex.guard_work_item_running_resume(pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8)",
+		"guard_work_item_running_resume(\n\tp_work_item_id uuid, p_project_id uuid, p_expected_revision bigint\n)",
+		"p_work_item_id uuid, p_project_id uuid, p_expected_revision bigint",
+		"void",
+		"plpgsql",
+		"v",
+	),
 ];
-const RUNTIME_EXECUTE_FUNCTIONS: [&str; 30] = [
+const RUNTIME_EXECUTE_FUNCTIONS: [&str; 35] = [
 	"decodex.is_canonical_media_type(pg_catalog.text)",
 	"decodex.is_history_metadata_projection(pg_catalog.jsonb)",
 	"decodex.normalize_unicode_whitespace(pg_catalog.text)",
@@ -704,8 +845,13 @@ const RUNTIME_EXECUTE_FUNCTIONS: [&str; 30] = [
 	"decodex.update_role_profile_exact(pg_catalog.text,pg_catalog.text,decodex.role_profile_role,pg_catalog.int8,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.text)",
 	"decodex.create_runtime_session_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,decodex.role_profile_role,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text,decodex.account_state,pg_catalog.int8,pg_catalog.uuid,decodex.runtime_session_state)",
 	"decodex.transition_runtime_session_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.int8,decodex.runtime_session_state)",
+	"decodex.create_work_item_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid,pg_catalog._uuid,pg_catalog._uuid,pg_catalog._uuid,pg_catalog.text,pg_catalog.text,decodex.work_item_priority,pg_catalog._text,pg_catalog._text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text)",
+	"decodex.update_work_item_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,pg_catalog.uuid,pg_catalog._uuid,pg_catalog._uuid,pg_catalog._uuid,pg_catalog.text,pg_catalog.text,decodex.work_item_priority,pg_catalog._text,pg_catalog._text,decodex.work_item_state,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text)",
+	"decodex.assess_work_item_readiness_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text)",
+	"decodex.accept_work_item_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.text)",
+	"decodex.guard_work_item_running_resume(pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8)",
 ];
-const SAFETY_FUNCTIONS: [&str; 37] = [
+const SAFETY_FUNCTIONS: [&str; 42] = [
 	"enforce_lease_operation_time",
 	"enforce_outbox_operation_time",
 	"enforce_quota_observation_monotonicity",
@@ -743,8 +889,13 @@ const SAFETY_FUNCTIONS: [&str; 37] = [
 	"enforce_runtime_session_command_owner",
 	"forbid_runtime_snapshot_mutation",
 	"enforce_runtime_session_event_namespace",
+	"enforce_work_item_state",
+	"enforce_work_item_command_owner",
+	"forbid_work_item_acceptance_mutation",
+	"enforce_work_item_acceptance_coherence",
+	"enforce_work_item_event_namespace",
 ];
-const SAFETY_TRIGGER_COUNT: usize = 59;
+const SAFETY_TRIGGER_COUNT: usize = 69;
 // PostgreSQL 18 catalogs with an owner and a containing namespace, plus the namespace
 // itself. Namespace-scoped catalogs without an independent owner (constraints, triggers,
 // text-search parsers/templates, and dependent rows) inherit authority from one of these.
@@ -926,7 +1077,12 @@ WITH set_roles AS (
   ('objective_completion_evidence', true, false, false, false),
   ('exact_command_receipts', false, false, false, false),
   ('role_profiles', false, false, false, false),
-  ('role_profile_revisions', false, false, false, false)
+  ('role_profile_revisions', false, false, false, false),
+  ('work_items', true, false, false, false),
+  ('work_item_objectives', true, false, false, false),
+  ('work_item_edges', true, false, false, false),
+  ('work_item_readiness_blockers', true, false, false, false),
+  ('work_item_acceptances', true, false, false, false)
 ), tables AS (
   SELECT class.oid, class.relname, expected.*
   FROM pg_catalog.pg_class AS class
@@ -935,7 +1091,7 @@ WITH set_roles AS (
   WHERE namespace.nspname = 'decodex' AND class.relkind IN ('r', 'p')
 )
 SELECT
-  (SELECT count(*) FROM tables WHERE table_name IS NOT NULL) = 31
+  (SELECT count(*) FROM tables WHERE table_name IS NOT NULL) = 36
     AND COALESCE((
       SELECT pg_catalog.bool_and(
         pg_catalog.has_table_privilege(session_user, oid, 'SELECT') = can_select
@@ -1150,6 +1306,16 @@ WITH expected(table_name, trigger_name, function_name, trigger_type) AS (VALUES
 	  ('account_snapshots', 'account_snapshots_immutable', 'forbid_runtime_snapshot_mutation', 27),
 	  ('activity', 'activity_runtime_session_namespace', 'enforce_runtime_session_event_namespace', 23),
 	  ('outbox', 'outbox_runtime_session_namespace', 'enforce_runtime_session_event_namespace', 23)
+	,('work_items', 'work_items_state_guard', 'enforce_work_item_state', 31)
+	,('work_items', 'work_items_command_owner', 'enforce_work_item_command_owner', 62)
+	,('work_item_objectives', 'work_item_objectives_command_owner', 'enforce_work_item_command_owner', 62)
+	,('work_item_edges', 'work_item_edges_command_owner', 'enforce_work_item_command_owner', 62)
+	,('work_item_readiness_blockers', 'work_item_readiness_blockers_command_owner', 'enforce_work_item_command_owner', 62)
+	,('work_item_acceptances', 'work_item_acceptances_command_owner', 'enforce_work_item_command_owner', 62)
+	,('work_item_acceptances', 'work_item_acceptances_immutable', 'forbid_work_item_acceptance_mutation', 27)
+	,('work_item_acceptances', 'work_item_acceptance_coherence', 'enforce_work_item_acceptance_coherence', 5)
+	,('activity', 'activity_work_item_namespace', 'enforce_work_item_event_namespace', 23)
+	,('outbox', 'outbox_work_item_namespace', 'enforce_work_item_event_namespace', 23)
 )
 SELECT
   expected.function_name,
@@ -1158,15 +1324,15 @@ SELECT
     AND trigger.tgtype = expected.trigger_type
     AND trigger.tgparentid = 0
     AND (trigger.tgconstraint <> 0) = (
-      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence', 'exact_receipts_complete_at_commit', 'role_profiles_exact_global_set')
+      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence', 'exact_receipts_complete_at_commit', 'role_profiles_exact_global_set', 'work_item_acceptance_coherence')
     )
     AND trigger.tgconstrrelid = 0
     AND trigger.tgconstrindid = 0
     AND trigger.tgdeferrable = (
-      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence', 'exact_receipts_complete_at_commit', 'role_profiles_exact_global_set')
+      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence', 'exact_receipts_complete_at_commit', 'role_profiles_exact_global_set', 'work_item_acceptance_coherence')
     )
     AND trigger.tginitdeferred = (
-      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence', 'exact_receipts_complete_at_commit', 'role_profiles_exact_global_set')
+      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence', 'exact_receipts_complete_at_commit', 'role_profiles_exact_global_set', 'work_item_acceptance_coherence')
     )
     AND trigger.tgnargs = 0
     AND trigger.tgattr = ''::pg_catalog.int2vector
@@ -1326,6 +1492,16 @@ WITH catalog_context AS MATERIALIZED (
 	  ('account_snapshots', 'account_snapshots_immutable', 'decodex.forbid_runtime_snapshot_mutation()'),
 	  ('activity', 'activity_runtime_session_namespace', 'decodex.enforce_runtime_session_event_namespace()'),
 	  ('outbox', 'outbox_runtime_session_namespace', 'decodex.enforce_runtime_session_event_namespace()')
+	,('work_items', 'work_items_state_guard', 'decodex.enforce_work_item_state()')
+	,('work_items', 'work_items_command_owner', 'decodex.enforce_work_item_command_owner()')
+	,('work_item_objectives', 'work_item_objectives_command_owner', 'decodex.enforce_work_item_command_owner()')
+	,('work_item_edges', 'work_item_edges_command_owner', 'decodex.enforce_work_item_command_owner()')
+	,('work_item_readiness_blockers', 'work_item_readiness_blockers_command_owner', 'decodex.enforce_work_item_command_owner()')
+	,('work_item_acceptances', 'work_item_acceptances_command_owner', 'decodex.enforce_work_item_command_owner()')
+	,('work_item_acceptances', 'work_item_acceptances_immutable', 'decodex.forbid_work_item_acceptance_mutation()')
+	,('work_item_acceptances', 'work_item_acceptance_coherence', 'decodex.enforce_work_item_acceptance_coherence()')
+	,('activity', 'activity_work_item_namespace', 'decodex.enforce_work_item_event_namespace()')
+	,('outbox', 'outbox_work_item_namespace', 'decodex.enforce_work_item_event_namespace()')
 ), actual_triggers AS (
   SELECT
     class.relname AS table_name,
@@ -1795,8 +1971,8 @@ SELECT pg_catalog.jsonb_agg(
 FROM contract_rows
 "#;
 const SCHEMA_CONTRACT_SHA256: [u8; 32] = [
-	0x90, 0xad, 0xd2, 0x3f, 0x9a, 0xd9, 0xd9, 0x9c, 0x81, 0xb7, 0xae, 0xc1, 0x7a, 0x3f, 0xbf, 0x1f,
-	0xe6, 0xb2, 0x6c, 0x28, 0x8d, 0x2d, 0x04, 0xfd, 0x9b, 0x5c, 0x4b, 0xad, 0x9d, 0xda, 0xd2, 0xbe,
+	0xc4, 0x8f, 0x7b, 0x49, 0x8d, 0xac, 0x7f, 0xd1, 0x6f, 0x2d, 0x1b, 0xe8, 0xc7, 0x49, 0x5e, 0xf8,
+	0xcf, 0xda, 0xb3, 0x09, 0xfd, 0xd8, 0x27, 0xb9, 0x47, 0x76, 0x80, 0x9a, 0x18, 0x97, 0x1b, 0x1b,
 ];
 // The shipped authority permits no role settings. Record only cardinality so any setting
 // fails closed without copying an arbitrary custom-GUC value into the manifest or digest input.
@@ -2275,8 +2451,8 @@ SELECT pg_catalog.jsonb_agg(
 FROM contract_rows
 "#;
 const CONFIGURED_AUTHORITY_SHA256: [u8; 32] = [
-	0xc4, 0x43, 0xc4, 0xe0, 0xb0, 0x6e, 0x01, 0xd5, 0xb9, 0x28, 0x36, 0xf2, 0xfd, 0xf3, 0xf9, 0x15,
-	0xd2, 0x96, 0xce, 0x40, 0xd3, 0x9b, 0x8c, 0x0c, 0xa1, 0x48, 0x9b, 0xe9, 0x65, 0xb5, 0xdb, 0xc1,
+	0xbf, 0x89, 0x19, 0x59, 0x3a, 0xe4, 0x3c, 0xc9, 0x01, 0x13, 0x4d, 0x14, 0x8f, 0x6c, 0x7d, 0xcf,
+	0x10, 0xc0, 0xeb, 0xf3, 0x4c, 0x1f, 0xea, 0xd9, 0xb5, 0x98, 0xdf, 0x45, 0xba, 0x6b, 0x9d, 0xd2,
 ];
 const EXTENSION_AUTHORITY_SQL: &str = r#"
 WITH set_roles AS (
@@ -2556,6 +2732,7 @@ fn canonical_function_source(contract: &FunctionContract) -> Option<&'static str
 		QUOTA_MIGRATION,
 		ROLE_PROFILE_MIGRATION,
 		RUNTIME_SESSION_MIGRATION,
+		WORK_ITEM_MIGRATION,
 	]
 	.into_iter()
 	.find(|migration| migration.contains(&declaration))?;
@@ -2630,7 +2807,6 @@ async fn verify_configured_authority(
 
 	Ok(())
 }
-
 async fn verify_execution_path_contract(client: &Client) -> Result<(), StoreError> {
 	let allowed_functions = FUNCTION_CONTRACTS
 		.iter()
@@ -2721,6 +2897,11 @@ async fn verify_function_contract(client: &Client) -> Result<(), StoreError> {
 				| "update_role_profile_exact"
 				| "create_runtime_session_exact"
 				| "transition_runtime_session_exact"
+				| "create_work_item_exact"
+				| "update_work_item_exact"
+				| "assess_work_item_readiness_exact"
+				| "accept_work_item_exact"
+				| "guard_work_item_running_resume"
 		);
 		let expected_executable = RUNTIME_EXECUTE_FUNCTIONS.contains(&contract.lookup_signature);
 		let expected_settings = vec!["search_path=pg_catalog, decodex".to_owned()];
@@ -2877,6 +3058,7 @@ mod tests {
 		OWNED_OBJECT_CATALOGS, POLICY_MIGRATION, PROGRAM_OBJECTIVE_MIGRATION,
 		PROJECT_AGENT_MIGRATION, QUOTA_MIGRATION, ROLE_AUTHORITY_SQL, ROLE_PROFILE_MIGRATION,
 		RUNTIME_SESSION_MIGRATION, SAFETY_FUNCTIONS, SCHEMA_CONTRACT_SHA256, SCHEMA_CONTRACT_SQL,
+		WORK_ITEM_MIGRATION,
 	};
 
 	#[test]
@@ -3011,6 +3193,7 @@ mod tests {
 				QUOTA_MIGRATION,
 				ROLE_PROFILE_MIGRATION,
 				RUNTIME_SESSION_MIGRATION,
+				WORK_ITEM_MIGRATION,
 			]
 			.into_iter()
 			.map(|migration| migration.matches("CREATE FUNCTION decodex.").count())
@@ -3032,6 +3215,7 @@ mod tests {
 					QUOTA_MIGRATION,
 					ROLE_PROFILE_MIGRATION,
 					RUNTIME_SESSION_MIGRATION,
+					WORK_ITEM_MIGRATION,
 				]
 				.into_iter()
 				.map(|migration| migration

--- a/crates/decodex-postgres/src/authority.rs
+++ b/crates/decodex-postgres/src/authority.rs
@@ -16,9 +16,10 @@ const ROLE_PROFILE_MIGRATION: &str = include_str!("../migrations/V9__exact_role_
 const RUNTIME_SESSION_MIGRATION: &str =
 	include_str!("../migrations/V10__runtime_session_snapshots.sql");
 const WORK_ITEM_MIGRATION: &str = include_str!("../migrations/V11__work_item_authority.sql");
+const MANAGED_RUN_MIGRATION: &str = include_str!("../migrations/V12__managed_run_safety.sql");
 const ALLOWED_EXECUTION_DEPENDENCIES: [&str; 1] =
 	["public.digest(pg_catalog.bytea,pg_catalog.text)"];
-const FUNCTION_CONTRACTS: [FunctionContract; 98] = [
+const FUNCTION_CONTRACTS: [FunctionContract; 107] = [
 	FunctionContract {
 		name: "is_canonical_media_type",
 		lookup_signature: "decodex.is_canonical_media_type(pg_catalog.text)",
@@ -813,8 +814,65 @@ const FUNCTION_CONTRACTS: [FunctionContract; 98] = [
 		"plpgsql",
 		"v",
 	),
+	trigger_contract(
+		"enforce_managed_run_command_owner",
+		"decodex.enforce_managed_run_command_owner()",
+		"enforce_managed_run_command_owner()",
+	),
+	trigger_contract(
+		"forbid_managed_run_immutable_mutation",
+		"decodex.forbid_managed_run_immutable_mutation()",
+		"forbid_managed_run_immutable_mutation()",
+	),
+	trigger_contract(
+		"enforce_managed_run_assignment_scope",
+		"decodex.enforce_managed_run_assignment_scope()",
+		"enforce_managed_run_assignment_scope()",
+	),
+	trigger_contract(
+		"enforce_managed_run_state",
+		"decodex.enforce_managed_run_state()",
+		"enforce_managed_run_state()",
+	),
+	trigger_contract(
+		"enforce_effect_barrier_state",
+		"decodex.enforce_effect_barrier_state()",
+		"enforce_effect_barrier_state()",
+	),
+	trigger_contract(
+		"enforce_managed_run_event_namespace",
+		"decodex.enforce_managed_run_event_namespace()",
+		"enforce_managed_run_event_namespace()",
+	),
+	exact_function_contract(
+		"reserve_exact_managed_run_safety_command",
+		"decodex.reserve_exact_managed_run_safety_command(pg_catalog.text,pg_catalog.text,pg_catalog.jsonb)",
+		"reserve_exact_managed_run_safety_command(\n\tp_protocol text, p_idempotency_key text, p_request jsonb\n)",
+		"p_protocol text, p_idempotency_key text, p_request jsonb",
+		"bytea",
+		"plpgsql",
+		"v",
+	),
+	exact_function_contract(
+		"complete_exact_managed_run_safety_rejection",
+		"decodex.complete_exact_managed_run_safety_rejection(pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.jsonb)",
+		"complete_exact_managed_run_safety_rejection(\n\tp_protocol text, p_idempotency_key text, p_reason text, p_request jsonb\n)",
+		"p_protocol text, p_idempotency_key text, p_reason text, p_request jsonb",
+		"bytea",
+		"plpgsql",
+		"v",
+	),
+	exact_function_contract(
+		"apply_managed_run_safety_input_exact",
+		"decodex.apply_managed_run_safety_input_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,decodex.managed_run_safety_input_kind,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid)",
+		"apply_managed_run_safety_input_exact(\n\tp_protocol text, p_idempotency_key text, p_managed_run_id uuid, p_project_id uuid,\n\tp_expected_run_revision bigint, p_input_kind decodex.managed_run_safety_input_kind,\n\tp_input_id uuid, p_runtime_session_id uuid, p_turn_id uuid\n)",
+		"p_protocol text, p_idempotency_key text, p_managed_run_id uuid, p_project_id uuid, p_expected_run_revision bigint, p_input_kind decodex.managed_run_safety_input_kind, p_input_id uuid, p_runtime_session_id uuid, p_turn_id uuid",
+		"bytea",
+		"plpgsql",
+		"v",
+	),
 ];
-const RUNTIME_EXECUTE_FUNCTIONS: [&str; 35] = [
+const RUNTIME_EXECUTE_FUNCTIONS: [&str; 36] = [
 	"decodex.is_canonical_media_type(pg_catalog.text)",
 	"decodex.is_history_metadata_projection(pg_catalog.jsonb)",
 	"decodex.normalize_unicode_whitespace(pg_catalog.text)",
@@ -850,8 +908,9 @@ const RUNTIME_EXECUTE_FUNCTIONS: [&str; 35] = [
 	"decodex.assess_work_item_readiness_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text)",
 	"decodex.accept_work_item_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.text)",
 	"decodex.guard_work_item_running_resume(pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8)",
+	"decodex.apply_managed_run_safety_input_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,decodex.managed_run_safety_input_kind,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid)",
 ];
-const SAFETY_FUNCTIONS: [&str; 42] = [
+const SAFETY_FUNCTIONS: [&str; 48] = [
 	"enforce_lease_operation_time",
 	"enforce_outbox_operation_time",
 	"enforce_quota_observation_monotonicity",
@@ -894,8 +953,14 @@ const SAFETY_FUNCTIONS: [&str; 42] = [
 	"forbid_work_item_acceptance_mutation",
 	"enforce_work_item_acceptance_coherence",
 	"enforce_work_item_event_namespace",
+	"enforce_managed_run_command_owner",
+	"forbid_managed_run_immutable_mutation",
+	"enforce_managed_run_assignment_scope",
+	"enforce_managed_run_state",
+	"enforce_effect_barrier_state",
+	"enforce_managed_run_event_namespace",
 ];
-const SAFETY_TRIGGER_COUNT: usize = 69;
+const SAFETY_TRIGGER_COUNT: usize = 84;
 // PostgreSQL 18 catalogs with an owner and a containing namespace, plus the namespace
 // itself. Namespace-scoped catalogs without an independent owner (constraints, triggers,
 // text-search parsers/templates, and dependent rows) inherit authority from one of these.
@@ -1083,6 +1148,12 @@ WITH set_roles AS (
   ('work_item_edges', true, false, false, false),
   ('work_item_readiness_blockers', true, false, false, false),
   ('work_item_acceptances', true, false, false, false)
+  ,('managed_runs', true, false, false, false)
+  ,('managed_run_assignments', true, false, false, false)
+  ,('managed_run_effect_barriers', true, false, false, false)
+  ,('managed_run_effects', true, false, false, false)
+  ,('managed_run_submitted_turn_receipts', true, false, false, false)
+  ,('managed_run_safety_inputs', true, false, false, false)
 ), tables AS (
   SELECT class.oid, class.relname, expected.*
   FROM pg_catalog.pg_class AS class
@@ -1091,7 +1162,7 @@ WITH set_roles AS (
   WHERE namespace.nspname = 'decodex' AND class.relkind IN ('r', 'p')
 )
 SELECT
-  (SELECT count(*) FROM tables WHERE table_name IS NOT NULL) = 36
+  (SELECT count(*) FROM tables WHERE table_name IS NOT NULL) = 42
     AND COALESCE((
       SELECT pg_catalog.bool_and(
         pg_catalog.has_table_privilege(session_user, oid, 'SELECT') = can_select
@@ -1316,6 +1387,21 @@ WITH expected(table_name, trigger_name, function_name, trigger_type) AS (VALUES
 	,('work_item_acceptances', 'work_item_acceptance_coherence', 'enforce_work_item_acceptance_coherence', 5)
 	,('activity', 'activity_work_item_namespace', 'enforce_work_item_event_namespace', 23)
 	,('outbox', 'outbox_work_item_namespace', 'enforce_work_item_event_namespace', 23)
+	,('managed_runs', 'managed_runs_command_owner', 'enforce_managed_run_command_owner', 62)
+	,('managed_run_assignments', 'managed_run_assignments_command_owner', 'enforce_managed_run_command_owner', 62)
+	,('managed_run_effect_barriers', 'managed_run_effect_barriers_command_owner', 'enforce_managed_run_command_owner', 62)
+	,('managed_run_effects', 'managed_run_effects_command_owner', 'enforce_managed_run_command_owner', 62)
+	,('managed_run_submitted_turn_receipts', 'managed_run_submitted_turn_receipts_command_owner', 'enforce_managed_run_command_owner', 62)
+	,('managed_run_safety_inputs', 'managed_run_safety_inputs_command_owner', 'enforce_managed_run_command_owner', 62)
+	,('managed_run_assignments', 'managed_run_assignments_immutable', 'forbid_managed_run_immutable_mutation', 27)
+	,('managed_run_effects', 'managed_run_effects_immutable', 'forbid_managed_run_immutable_mutation', 27)
+	,('managed_run_submitted_turn_receipts', 'managed_run_submitted_turn_receipts_immutable', 'forbid_managed_run_immutable_mutation', 27)
+	,('managed_run_safety_inputs', 'managed_run_safety_inputs_immutable', 'forbid_managed_run_immutable_mutation', 27)
+	,('managed_run_assignments', 'managed_run_assignment_scope', 'enforce_managed_run_assignment_scope', 5)
+	,('managed_runs', 'managed_runs_inert_state', 'enforce_managed_run_state', 31)
+	,('managed_run_effect_barriers', 'managed_run_effect_barriers_state', 'enforce_effect_barrier_state', 31)
+	,('activity', 'activity_managed_run_namespace', 'enforce_managed_run_event_namespace', 23)
+	,('outbox', 'outbox_managed_run_namespace', 'enforce_managed_run_event_namespace', 23)
 )
 SELECT
   expected.function_name,
@@ -1324,15 +1410,15 @@ SELECT
     AND trigger.tgtype = expected.trigger_type
     AND trigger.tgparentid = 0
     AND (trigger.tgconstraint <> 0) = (
-      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence', 'exact_receipts_complete_at_commit', 'role_profiles_exact_global_set', 'work_item_acceptance_coherence')
+      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence', 'exact_receipts_complete_at_commit', 'role_profiles_exact_global_set', 'work_item_acceptance_coherence', 'managed_run_assignment_scope')
     )
     AND trigger.tgconstrrelid = 0
     AND trigger.tgconstrindid = 0
     AND trigger.tgdeferrable = (
-      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence', 'exact_receipts_complete_at_commit', 'role_profiles_exact_global_set', 'work_item_acceptance_coherence')
+      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence', 'exact_receipts_complete_at_commit', 'role_profiles_exact_global_set', 'work_item_acceptance_coherence', 'managed_run_assignment_scope')
     )
     AND trigger.tginitdeferred = (
-      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence', 'exact_receipts_complete_at_commit', 'role_profiles_exact_global_set', 'work_item_acceptance_coherence')
+      expected.trigger_name IN ('objectives_completion_coherence', 'objective_evidence_completion_coherence', 'exact_receipts_complete_at_commit', 'role_profiles_exact_global_set', 'work_item_acceptance_coherence', 'managed_run_assignment_scope')
     )
     AND trigger.tgnargs = 0
     AND trigger.tgattr = ''::pg_catalog.int2vector
@@ -1502,6 +1588,21 @@ WITH catalog_context AS MATERIALIZED (
 	,('work_item_acceptances', 'work_item_acceptance_coherence', 'decodex.enforce_work_item_acceptance_coherence()')
 	,('activity', 'activity_work_item_namespace', 'decodex.enforce_work_item_event_namespace()')
 	,('outbox', 'outbox_work_item_namespace', 'decodex.enforce_work_item_event_namespace()')
+	,('managed_runs', 'managed_runs_command_owner', 'decodex.enforce_managed_run_command_owner()')
+	,('managed_run_assignments', 'managed_run_assignments_command_owner', 'decodex.enforce_managed_run_command_owner()')
+	,('managed_run_effect_barriers', 'managed_run_effect_barriers_command_owner', 'decodex.enforce_managed_run_command_owner()')
+	,('managed_run_effects', 'managed_run_effects_command_owner', 'decodex.enforce_managed_run_command_owner()')
+	,('managed_run_submitted_turn_receipts', 'managed_run_submitted_turn_receipts_command_owner', 'decodex.enforce_managed_run_command_owner()')
+	,('managed_run_safety_inputs', 'managed_run_safety_inputs_command_owner', 'decodex.enforce_managed_run_command_owner()')
+	,('managed_run_assignments', 'managed_run_assignments_immutable', 'decodex.forbid_managed_run_immutable_mutation()')
+	,('managed_run_effects', 'managed_run_effects_immutable', 'decodex.forbid_managed_run_immutable_mutation()')
+	,('managed_run_submitted_turn_receipts', 'managed_run_submitted_turn_receipts_immutable', 'decodex.forbid_managed_run_immutable_mutation()')
+	,('managed_run_safety_inputs', 'managed_run_safety_inputs_immutable', 'decodex.forbid_managed_run_immutable_mutation()')
+	,('managed_run_assignments', 'managed_run_assignment_scope', 'decodex.enforce_managed_run_assignment_scope()')
+	,('managed_runs', 'managed_runs_inert_state', 'decodex.enforce_managed_run_state()')
+	,('managed_run_effect_barriers', 'managed_run_effect_barriers_state', 'decodex.enforce_effect_barrier_state()')
+	,('activity', 'activity_managed_run_namespace', 'decodex.enforce_managed_run_event_namespace()')
+	,('outbox', 'outbox_managed_run_namespace', 'decodex.enforce_managed_run_event_namespace()')
 ), actual_triggers AS (
   SELECT
     class.relname AS table_name,
@@ -1971,8 +2072,8 @@ SELECT pg_catalog.jsonb_agg(
 FROM contract_rows
 "#;
 const SCHEMA_CONTRACT_SHA256: [u8; 32] = [
-	0xc4, 0x8f, 0x7b, 0x49, 0x8d, 0xac, 0x7f, 0xd1, 0x6f, 0x2d, 0x1b, 0xe8, 0xc7, 0x49, 0x5e, 0xf8,
-	0xcf, 0xda, 0xb3, 0x09, 0xfd, 0xd8, 0x27, 0xb9, 0x47, 0x76, 0x80, 0x9a, 0x18, 0x97, 0x1b, 0x1b,
+	0x99, 0xb6, 0x41, 0xfb, 0xd0, 0xee, 0x07, 0xc1, 0xd8, 0x19, 0x06, 0x0b, 0x89, 0xcd, 0x2d, 0x39,
+	0x6a, 0xe5, 0xca, 0x80, 0xee, 0x46, 0x61, 0xab, 0x3c, 0x71, 0xea, 0xd6, 0xaa, 0x34, 0x7b, 0xf0,
 ];
 // The shipped authority permits no role settings. Record only cardinality so any setting
 // fails closed without copying an arbitrary custom-GUC value into the manifest or digest input.
@@ -2451,8 +2552,8 @@ SELECT pg_catalog.jsonb_agg(
 FROM contract_rows
 "#;
 const CONFIGURED_AUTHORITY_SHA256: [u8; 32] = [
-	0xbf, 0x89, 0x19, 0x59, 0x3a, 0xe4, 0x3c, 0xc9, 0x01, 0x13, 0x4d, 0x14, 0x8f, 0x6c, 0x7d, 0xcf,
-	0x10, 0xc0, 0xeb, 0xf3, 0x4c, 0x1f, 0xea, 0xd9, 0xb5, 0x98, 0xdf, 0x45, 0xba, 0x6b, 0x9d, 0xd2,
+	0x83, 0x8a, 0x95, 0x63, 0x93, 0x2c, 0x50, 0xb7, 0xe5, 0xea, 0xa6, 0x0b, 0xa0, 0x32, 0x84, 0x47,
+	0xba, 0x24, 0xec, 0x85, 0x4e, 0x0b, 0x5f, 0xd8, 0x7c, 0x09, 0x57, 0x85, 0xfd, 0x8a, 0xe5, 0x1e,
 ];
 const EXTENSION_AUTHORITY_SQL: &str = r#"
 WITH set_roles AS (
@@ -2722,8 +2823,11 @@ fn canonical_safety_function_source(function_name: &str) -> Option<&'static str>
 }
 
 fn canonical_function_source(contract: &FunctionContract) -> Option<&'static str> {
-	let declaration = format!("CREATE FUNCTION decodex.{}", contract.migration_signature);
-	let migration = [
+	let declarations = [
+		format!("CREATE FUNCTION decodex.{}", contract.migration_signature),
+		format!("CREATE OR REPLACE FUNCTION decodex.{}", contract.migration_signature),
+	];
+	[
 		FOUNDATION_MIGRATION,
 		CONVERSATION_MIGRATION,
 		PROJECT_AGENT_MIGRATION,
@@ -2733,14 +2837,22 @@ fn canonical_function_source(contract: &FunctionContract) -> Option<&'static str
 		ROLE_PROFILE_MIGRATION,
 		RUNTIME_SESSION_MIGRATION,
 		WORK_ITEM_MIGRATION,
+		MANAGED_RUN_MIGRATION,
 	]
 	.into_iter()
-	.find(|migration| migration.contains(&declaration))?;
-	let (_, declaration_and_tail) = migration.split_once(&declaration)?;
-	let (_, source_and_tail) = declaration_and_tail.split_once("\nAS $$")?;
-	let (source, _) = source_and_tail.split_once("$$;")?;
-
-	Some(source)
+	.rev()
+	.find_map(|migration| {
+		let (declaration_index, declaration_length) = declarations
+			.iter()
+			.filter_map(|declaration| {
+				migration.rfind(declaration.as_str()).map(|index| (index, declaration.len()))
+			})
+			.max_by_key(|(index, _)| *index)?;
+		let declaration_and_tail = &migration[declaration_index + declaration_length..];
+		let (_, source_and_tail) = declaration_and_tail.split_once("\nAS $$")?;
+		let (source, _) = source_and_tail.split_once("$$;")?;
+		Some(source)
+	})
 }
 
 async fn verify_identity_cast_authority(client: &Client) -> Result<(), StoreError> {
@@ -2902,6 +3014,7 @@ async fn verify_function_contract(client: &Client) -> Result<(), StoreError> {
 				| "assess_work_item_readiness_exact"
 				| "accept_work_item_exact"
 				| "guard_work_item_running_resume"
+				| "apply_managed_run_safety_input_exact"
 		);
 		let expected_executable = RUNTIME_EXECUTE_FUNCTIONS.contains(&contract.lookup_signature);
 		let expected_settings = vec!["search_path=pg_catalog, decodex".to_owned()];
@@ -3055,10 +3168,10 @@ mod tests {
 	use crate::authority::{
 		CONFIGURED_AUTHORITY_SHA256, CONFIGURED_AUTHORITY_SQL, CONVERSATION_MIGRATION,
 		FOUNDATION_MIGRATION, FUNCTION_CONTRACTS, IDENTITY_CAST_AUTHORITY_SQL,
-		OWNED_OBJECT_CATALOGS, POLICY_MIGRATION, PROGRAM_OBJECTIVE_MIGRATION,
-		PROJECT_AGENT_MIGRATION, QUOTA_MIGRATION, ROLE_AUTHORITY_SQL, ROLE_PROFILE_MIGRATION,
-		RUNTIME_SESSION_MIGRATION, SAFETY_FUNCTIONS, SCHEMA_CONTRACT_SHA256, SCHEMA_CONTRACT_SQL,
-		WORK_ITEM_MIGRATION,
+		MANAGED_RUN_MIGRATION, OWNED_OBJECT_CATALOGS, POLICY_MIGRATION,
+		PROGRAM_OBJECTIVE_MIGRATION, PROJECT_AGENT_MIGRATION, QUOTA_MIGRATION, ROLE_AUTHORITY_SQL,
+		ROLE_PROFILE_MIGRATION, RUNTIME_SESSION_MIGRATION, SAFETY_FUNCTIONS,
+		SCHEMA_CONTRACT_SHA256, SCHEMA_CONTRACT_SQL, WORK_ITEM_MIGRATION,
 	};
 
 	#[test]
@@ -3194,6 +3307,7 @@ mod tests {
 				ROLE_PROFILE_MIGRATION,
 				RUNTIME_SESSION_MIGRATION,
 				WORK_ITEM_MIGRATION,
+				MANAGED_RUN_MIGRATION,
 			]
 			.into_iter()
 			.map(|migration| migration.matches("CREATE FUNCTION decodex.").count())
@@ -3216,6 +3330,7 @@ mod tests {
 					ROLE_PROFILE_MIGRATION,
 					RUNTIME_SESSION_MIGRATION,
 					WORK_ITEM_MIGRATION,
+					MANAGED_RUN_MIGRATION,
 				]
 				.into_iter()
 				.map(|migration| migration

--- a/crates/decodex-postgres/src/lib.rs
+++ b/crates/decodex-postgres/src/lib.rs
@@ -4,8 +4,9 @@
 //! immutable migrations, idempotent optimistic transactions, expiring leases, transactional
 //! activity/outbox evidence, inert account/quota-window metadata, normalized history, blob
 //! references, Context Packs, inert transition proposals, exact in-transaction receipts, and
-//! immutable global RoleProfiles. It does not select accounts, route work, store credentials,
-//! dispatch transitions, or expose protocol/client behavior.
+//! immutable global RoleProfiles, inert ManagedRuns, and fail-closed effect barriers. It does not
+//! select accounts, route work, store credentials, schedule or advance runs, dispatch transitions,
+//! or expose protocol/client behavior.
 
 mod accounts;
 mod authority;
@@ -13,6 +14,7 @@ mod conversations;
 mod error;
 mod exact_commands;
 mod leases;
+mod managed_runs;
 mod migrations;
 mod outbox;
 mod policies;
@@ -21,9 +23,9 @@ mod project_agents;
 mod quota;
 mod role_profiles;
 mod runtime_sessions;
-mod work_items;
 #[cfg(unix)] mod socket;
 mod types;
+mod work_items;
 
 pub use self::{
 	conversations::{
@@ -32,6 +34,11 @@ pub use self::{
 		StoredArtifact, StoredConversation,
 	},
 	error::{BootstrapFailure, StoreError},
+	managed_runs::{
+		ManagedRunEffectBarrier, ManagedRunEffectBarrierState, ManagedRunEffectKind,
+		ManagedRunEffectLineage, ManagedRunSafetyEffect, ManagedRunSafetyOutcome,
+		ManagedRunSafetyRejection, StoredManagedRun,
+	},
 	programs::{ObjectiveRecord, ProgramRecord, UpdateProgramContext},
 	role_profiles::{
 		BootstrapRoleProfiles, RoleProfileCommandOutcome, RoleProfileConfiguration,
@@ -42,27 +49,30 @@ pub use self::{
 		RuntimeSessionCommandEffect, RuntimeSessionCommandOutcome, RuntimeSessionProfileSnapshot,
 		RuntimeSessionRejection, StoredRuntimeSession,
 	},
-	work_items::{
-		AcceptWorkItem, CreateWorkItem, StoredWorkItem, UpdateWorkItem, WorkItemCommandEffect,
-		WorkItemCommandOutcome, WorkItemReadinessBlocker, WorkItemReadinessBlockerKind,
-		WorkItemRejection, WorkItemRelations,
-	},
 	types::{
 		AccountMetadata, AccountMutation, ActivityRecord, CommandIdentity, CreateProject,
 		HypotheticalFallbackFact, LeaseClaim, OutboxClaim, OutboxReconciliation, OutboxState,
 		QuotaExclusionMutation, QuotaExclusionReceipt, QuotaTimestampMicros, QuotaWindow,
 		QuotaWindowMutation, ReconciliationOutcome,
 	},
+	work_items::{
+		AcceptWorkItem, CreateWorkItem, StoredWorkItem, UpdateWorkItem, WorkItemCommandEffect,
+		WorkItemCommandOutcome, WorkItemReadinessBlocker, WorkItemReadinessBlockerKind,
+		WorkItemRejection, WorkItemRelations,
+	},
 };
 pub use decodex_core::{
 	AcceptedPolicyRevision, AccountId, AccountState, Agent, AgentId, AgentRole, AgentStatus,
-	Objective, ObjectiveCompletionEvidence, ObjectiveEvidenceId, ObjectiveId, ObjectiveState,
-	Policy, PolicyId, PolicyProvenance, PolicyRevision, PolicyRevisionAcceptance, PolicyRevisionId,
-	PolicySnapshot, PolicySnapshotValue, PolicyStatus, PolicyTimestamp, Program,
-	ProgramCorrelationId, ProgramError, ProgramId, ProgramMetric, ProgramObservationId,
-	ProgramObservationProvenance, ProgramProvenance, ProgramSignal, ProgramState, ProgramTimestamp,
-	Project, ProjectAuthority, ProjectId, ProjectMetadata, ProjectMetadataValue,
-	ProjectRepositoryBinding, ProjectStatus, RepositoryIdentity, ReviewCadence, WorkItem,
+	EffectId, ExecutionAssignment, ExecutionAssignmentRole, ManagedRunError, ManagedRunId,
+	ManagedRunIdentity, ManagedRunLifecycle, ManagedRunPhase, ManagedRunSafetyInput,
+	ManagedRunState, ManagedRunWaitReason, Objective, ObjectiveCompletionEvidence,
+	ObjectiveEvidenceId, ObjectiveId, ObjectiveState, Policy, PolicyId, PolicyProvenance,
+	PolicyRevision, PolicyRevisionAcceptance, PolicyRevisionId, PolicySnapshot,
+	PolicySnapshotValue, PolicyStatus, PolicyTimestamp, Program, ProgramCorrelationId,
+	ProgramError, ProgramId, ProgramMetric, ProgramObservationId, ProgramObservationProvenance,
+	ProgramProvenance, ProgramSignal, ProgramState, ProgramTimestamp, Project, ProjectAuthority,
+	ProjectId, ProjectMetadata, ProjectMetadataValue, ProjectRepositoryBinding, ProjectStatus,
+	RepositoryIdentity, ReviewCadence, SafetyObservationId, SubmittedTurnReceiptId, WorkItem,
 	WorkItemCorrelationId, WorkItemEdge, WorkItemEdgeKind, WorkItemError, WorkItemId, WorkItemNode,
 	WorkItemObjectiveRef, WorkItemPriority, WorkItemProgramRef, WorkItemProvenance, WorkItemState,
 	WorkItemTimestamp,

--- a/crates/decodex-postgres/src/lib.rs
+++ b/crates/decodex-postgres/src/lib.rs
@@ -21,6 +21,7 @@ mod project_agents;
 mod quota;
 mod role_profiles;
 mod runtime_sessions;
+mod work_items;
 #[cfg(unix)] mod socket;
 mod types;
 
@@ -41,6 +42,11 @@ pub use self::{
 		RuntimeSessionCommandEffect, RuntimeSessionCommandOutcome, RuntimeSessionProfileSnapshot,
 		RuntimeSessionRejection, StoredRuntimeSession,
 	},
+	work_items::{
+		AcceptWorkItem, CreateWorkItem, StoredWorkItem, UpdateWorkItem, WorkItemCommandEffect,
+		WorkItemCommandOutcome, WorkItemReadinessBlocker, WorkItemReadinessBlockerKind,
+		WorkItemRejection, WorkItemRelations,
+	},
 	types::{
 		AccountMetadata, AccountMutation, ActivityRecord, CommandIdentity, CreateProject,
 		HypotheticalFallbackFact, LeaseClaim, OutboxClaim, OutboxReconciliation, OutboxState,
@@ -56,7 +62,10 @@ pub use decodex_core::{
 	ProgramCorrelationId, ProgramError, ProgramId, ProgramMetric, ProgramObservationId,
 	ProgramObservationProvenance, ProgramProvenance, ProgramSignal, ProgramState, ProgramTimestamp,
 	Project, ProjectAuthority, ProjectId, ProjectMetadata, ProjectMetadataValue,
-	ProjectRepositoryBinding, ProjectStatus, RepositoryIdentity, ReviewCadence,
+	ProjectRepositoryBinding, ProjectStatus, RepositoryIdentity, ReviewCadence, WorkItem,
+	WorkItemCorrelationId, WorkItemEdge, WorkItemEdgeKind, WorkItemError, WorkItemId, WorkItemNode,
+	WorkItemObjectiveRef, WorkItemPriority, WorkItemProgramRef, WorkItemProvenance, WorkItemState,
+	WorkItemTimestamp,
 };
 pub use quota::parse_quota_timestamp_rfc3339;
 

--- a/crates/decodex-postgres/src/managed_runs.rs
+++ b/crates/decodex-postgres/src/managed_runs.rs
@@ -1,0 +1,528 @@
+use serde_json::Value;
+
+use crate::{
+	PostgresStore, StoreError,
+	exact_commands::{EXACT_COMMAND_PROTOCOL, validate_exact_key},
+};
+use decodex_core::{
+	EffectId, ExecutionAssignment, ExecutionAssignmentRole, ManagedRunId, ManagedRunLifecycle,
+	ManagedRunPhase, ManagedRunSafetyInput, ManagedRunState, ManagedRunWaitReason, ProjectId,
+	RuntimeSessionId, RuntimeSessionState, SafetyObservationId, SubmittedTurnReceiptId, TurnId,
+	WorkItemId,
+};
+
+/// One inert effect-lineage record owned by a ManagedRun.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ManagedRunEffectLineage {
+	/// Canonical effect identity.
+	pub effect_id: EffectId,
+	/// Stable typed effect category.
+	pub kind: ManagedRunEffectKind,
+	/// Exact run-local effect key.
+	pub effect_key: String,
+	/// Positive deterministic run-local ordinal.
+	pub ordinal: i32,
+}
+
+/// Closed effect categories; none is an execution authorization.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ManagedRunEffectKind {
+	/// Tool-side effect lineage.
+	Tool,
+	/// Repository/filesystem effect lineage.
+	Repository,
+	/// Git effect lineage.
+	Git,
+	/// Artifact effect lineage.
+	Artifact,
+}
+
+/// Persisted fail-closed barrier readback.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ManagedRunEffectBarrier {
+	/// Guarded and closed both deny effects in this slice.
+	pub state: ManagedRunEffectBarrierState,
+	/// Positive monotonic barrier revision.
+	pub revision: i64,
+	/// Exact input that closed the barrier, when permanently closed.
+	pub closure_input_id: Option<String>,
+	/// PostgreSQL-authored closure timestamp.
+	pub closed_at: Option<String>,
+}
+
+/// Fail-closed barrier states. There is intentionally no open state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ManagedRunEffectBarrierState {
+	/// Initial inert state; no effect may execute.
+	Guarded,
+	/// Permanently closed by one supported safety input.
+	Closed,
+}
+
+/// Exact revisioned restart readback for one inert ManagedRun.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StoredManagedRun {
+	/// Canonical ManagedRun identity.
+	pub managed_run_id: ManagedRunId,
+	/// Exact owning Project.
+	pub project_id: ProjectId,
+	/// Exact canonical WorkItem.
+	pub work_item_id: WorkItemId,
+	/// Exact authoritative RuntimeSession.
+	pub runtime_session_id: RuntimeSessionId,
+	/// Exact current RuntimeSession revision.
+	pub runtime_session_revision: i64,
+	/// Current RuntimeSession lifecycle read in the same query.
+	pub runtime_session_state: RuntimeSessionState,
+	/// Validated inert ManagedRun state.
+	pub state: ManagedRunState,
+	/// Positive ManagedRun revision.
+	pub revision: i64,
+	/// Monotonic divergence marker.
+	pub diverged: bool,
+	/// Always true in this slice.
+	pub blocked: bool,
+	/// PostgreSQL-authored creation timestamp.
+	pub created_at: String,
+	/// PostgreSQL-authored current-revision timestamp.
+	pub updated_at: String,
+	/// Exact-run Task and optional Reviewer assignments.
+	pub assignments: Vec<ExecutionAssignment>,
+	/// FK-backed effect lineage.
+	pub effects: Vec<ManagedRunEffectLineage>,
+	/// Fail-closed effect barrier.
+	pub barrier: ManagedRunEffectBarrier,
+}
+
+/// Complete effect of one supported safety input.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ManagedRunSafetyEffect {
+	/// Canonical ManagedRun identity.
+	pub managed_run_id: ManagedRunId,
+	/// New positive ManagedRun revision.
+	pub managed_run_revision: i64,
+	/// Exact authoritative RuntimeSession.
+	pub runtime_session_id: RuntimeSessionId,
+	/// Current positive RuntimeSession revision.
+	pub runtime_session_revision: i64,
+	/// Whether this input positively established divergence.
+	pub runtime_session_diverged: bool,
+	/// Always true for a committed safety input.
+	pub managed_run_blocked: bool,
+	/// Current positive barrier revision.
+	pub effect_barrier_revision: i64,
+	/// Whether this input performed the single guarded-to-closed transition.
+	pub effect_barrier_closed_now: bool,
+	/// Whether an owned submitted-turn receipt was stale at atomic readback.
+	pub stale_receipt: bool,
+}
+
+/// Stable safety-command rejection stored for exact replay.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ManagedRunSafetyRejection {
+	/// Required fields or shape were invalid.
+	InvalidInput,
+	/// ManagedRun, RuntimeSession, or barrier did not exist in exact scope.
+	MissingTarget,
+	/// Expected ManagedRun revision was stale.
+	StaleRevision,
+	/// RuntimeSession did not match the run's authoritative association.
+	WrongRuntimeSession,
+	/// Submitted-turn input did not reference a durable owned receipt.
+	MissingSubmittedTurnReceipt,
+	/// The asserted unknown turn was already owned or persisted.
+	TurnAlreadyOwnedOrKnown,
+	/// One durable safety input identity was reused for different facts.
+	InputIdentityConflict,
+}
+
+/// Parsed exact safety command result.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ManagedRunSafetyOutcome {
+	/// Safety state committed atomically.
+	Success(ManagedRunSafetyEffect),
+	/// Stable domain rejection committed without a safety mutation.
+	Rejected(ManagedRunSafetyRejection),
+}
+
+impl PostgresStore {
+	/// Read one exact ManagedRun revision and all restart-critical inert state in one query.
+	pub async fn read_managed_run_exact(
+		&self,
+		project_id: &ProjectId,
+		managed_run_id: &ManagedRunId,
+		expected_revision: i64,
+	) -> Result<StoredManagedRun, StoreError> {
+		if expected_revision <= 0 {
+			return Err(StoreError::InvalidInput("ManagedRun revision must be positive"));
+		}
+		let client = self.pool().get().await?;
+		let row = client
+			.query_opt(
+				READ_MANAGED_RUN_SQL,
+				&[&managed_run_id.as_str(), &project_id.as_str(), &expected_revision],
+			)
+			.await?
+			.ok_or(StoreError::InvalidInput("exact ManagedRun revision readback did not match"))?;
+		parse_readback(row.get(0))
+	}
+
+	/// Apply one positive or explicitly inconclusive input through the V12 safety owner.
+	pub async fn apply_managed_run_safety_input(
+		&self,
+		idempotency_key: &str,
+		project_id: &ProjectId,
+		managed_run_id: &ManagedRunId,
+		expected_run_revision: i64,
+		input: &ManagedRunSafetyInput,
+	) -> Result<ManagedRunSafetyOutcome, StoreError> {
+		validate_exact_key(idempotency_key)?;
+		if expected_run_revision <= 0 {
+			return Err(StoreError::InvalidInput("ManagedRun revision must be positive"));
+		}
+		let parts = SafetyInputParts::from(input);
+		let response = self
+			.execute_exact_with_retry(
+				"SELECT decodex.apply_managed_run_safety_input_exact(\
+			 $1,$2,$3::text::uuid,$4::text::uuid,$5,\
+			 $6::text::decodex.managed_run_safety_input_kind,$7::text::uuid,\
+			 $8::text::uuid,$9::text::uuid)",
+				&[
+					&EXACT_COMMAND_PROTOCOL,
+					&idempotency_key,
+					&managed_run_id.as_str(),
+					&project_id.as_str(),
+					&expected_run_revision,
+					&parts.kind,
+					&parts.input_id,
+					&parts.runtime_session_id,
+					&parts.turn_id,
+				],
+			)
+			.await?;
+		parse_safety_response(&response, managed_run_id, &parts)
+	}
+}
+
+struct SafetyInputParts<'a> {
+	kind: &'static str,
+	input_id: &'a str,
+	runtime_session_id: &'a str,
+	turn_id: Option<&'a str>,
+}
+impl<'a> From<&'a ManagedRunSafetyInput> for SafetyInputParts<'a> {
+	fn from(input: &'a ManagedRunSafetyInput) -> Self {
+		match input {
+			ManagedRunSafetyInput::PositivelyObservedUnknownTurn {
+				observation_id,
+				runtime_session_id,
+				turn_id,
+			} => Self::observed(observation_id, runtime_session_id, turn_id),
+			ManagedRunSafetyInput::SubmittedTurnReceipt {
+				receipt_id,
+				runtime_session_id,
+				turn_id,
+			} => Self::submitted(receipt_id, runtime_session_id, turn_id),
+			ManagedRunSafetyInput::InconclusiveObservation {
+				observation_id,
+				runtime_session_id,
+			} => Self {
+				kind: "inconclusive_observation",
+				input_id: observation_id.as_str(),
+				runtime_session_id: runtime_session_id.as_str(),
+				turn_id: None,
+			},
+		}
+	}
+}
+impl<'a> SafetyInputParts<'a> {
+	fn observed(
+		observation_id: &'a SafetyObservationId,
+		runtime_session_id: &'a RuntimeSessionId,
+		turn_id: &'a TurnId,
+	) -> Self {
+		Self {
+			kind: "positively_observed_unknown_turn",
+			input_id: observation_id.as_str(),
+			runtime_session_id: runtime_session_id.as_str(),
+			turn_id: Some(turn_id.as_str()),
+		}
+	}
+
+	fn submitted(
+		receipt_id: &'a SubmittedTurnReceiptId,
+		runtime_session_id: &'a RuntimeSessionId,
+		turn_id: &'a TurnId,
+	) -> Self {
+		Self {
+			kind: "submitted_turn_receipt",
+			input_id: receipt_id.as_str(),
+			runtime_session_id: runtime_session_id.as_str(),
+			turn_id: Some(turn_id.as_str()),
+		}
+	}
+}
+
+const READ_MANAGED_RUN_SQL: &str = "
+SELECT pg_catalog.jsonb_build_object(
+ 'managed_run_id',run.managed_run_id,'project_id',run.project_id,
+ 'work_item_id',run.work_item_id,'runtime_session_id',run.runtime_session_id,
+ 'runtime_session_revision',run.runtime_session_revision,
+ 'runtime_session_state',session.state,'lifecycle',run.lifecycle,'phase',run.phase,
+ 'wait_reason',run.wait_reason,'revision',run.revision,'diverged',run.diverged,
+ 'blocked',run.blocked,'created_at',run.created_at,'updated_at',run.updated_at,
+ 'barrier',pg_catalog.jsonb_build_object('state',barrier.state,'revision',barrier.revision,
+   'closure_input_id',barrier.closure_input_id,'closed_at',barrier.closed_at),
+ 'assignments',COALESCE((SELECT pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+   'runtime_session_id',assignment.runtime_session_id,'role',assignment.role)
+   ORDER BY assignment.role) FROM decodex.managed_run_assignments assignment
+   WHERE assignment.managed_run_id=run.managed_run_id),'[]'::jsonb),
+ 'effects',COALESCE((SELECT pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+   'effect_id',effect.effect_id,'ordinal',effect.ordinal,'kind',effect.kind,
+   'effect_key',effect.effect_key) ORDER BY effect.ordinal)
+   FROM decodex.managed_run_effects effect
+   WHERE effect.managed_run_id=run.managed_run_id),'[]'::jsonb)
+) FROM decodex.managed_runs run
+JOIN decodex.runtime_sessions session ON session.runtime_session_id=run.runtime_session_id
+ AND session.revision=run.runtime_session_revision
+JOIN decodex.managed_run_effect_barriers barrier USING(managed_run_id)
+WHERE run.managed_run_id=$1::text::uuid AND run.project_id=$2::text::uuid AND run.revision=$3";
+
+fn parse_readback(document: Value) -> Result<StoredManagedRun, StoreError> {
+	let managed_run_id = parse_run_id(required_str(&document, "managed_run_id")?)?;
+	let lifecycle = lifecycle(required_str(&document, "lifecycle")?)?;
+	let phase = phase(required_str(&document, "phase")?)?;
+	let wait_reason = wait_reason(required_str(&document, "wait_reason")?)?;
+	let state = ManagedRunState::from_parts(lifecycle, phase, Some(wait_reason))
+		.map_err(|_| incompatible("stored ManagedRun state is invalid"))?;
+	let assignments =
+		parse_assignments(required_array(&document, "assignments")?, &managed_run_id)?;
+	let effects = parse_effects(required_array(&document, "effects")?)?;
+	let barrier_value = required_value(&document, "barrier")?;
+	let barrier = ManagedRunEffectBarrier {
+		state: barrier_state(required_str(barrier_value, "state")?)?,
+		revision: positive_i64(barrier_value, "revision")?,
+		closure_input_id: optional_str(barrier_value, "closure_input_id")?,
+		closed_at: optional_str(barrier_value, "closed_at")?,
+	};
+	validate_barrier(&barrier)?;
+	let blocked = required_bool(&document, "blocked")?;
+	if !blocked {
+		return Err(incompatible("stored ManagedRun is not inert"));
+	}
+	Ok(StoredManagedRun {
+		managed_run_id,
+		project_id: ProjectId::new(required_str(&document, "project_id")?)
+			.map_err(|_| incompatible("stored Project identity is invalid"))?,
+		work_item_id: WorkItemId::new(required_str(&document, "work_item_id")?)
+			.map_err(|_| incompatible("stored WorkItem identity is invalid"))?,
+		runtime_session_id: parse_session_id(required_str(&document, "runtime_session_id")?)?,
+		runtime_session_revision: positive_i64(&document, "runtime_session_revision")?,
+		runtime_session_state: session_state(required_str(&document, "runtime_session_state")?)?,
+		state,
+		revision: positive_i64(&document, "revision")?,
+		diverged: required_bool(&document, "diverged")?,
+		blocked,
+		created_at: required_str(&document, "created_at")?.to_owned(),
+		updated_at: required_str(&document, "updated_at")?.to_owned(),
+		assignments,
+		effects,
+		barrier,
+	})
+}
+
+fn parse_assignments(
+	values: &[Value],
+	managed_run_id: &ManagedRunId,
+) -> Result<Vec<ExecutionAssignment>, StoreError> {
+	values
+		.iter()
+		.map(|value| {
+			Ok(ExecutionAssignment {
+				managed_run_id: managed_run_id.clone(),
+				runtime_session_id: parse_session_id(required_str(value, "runtime_session_id")?)?,
+				role: match required_str(value, "role")? {
+					"task" => ExecutionAssignmentRole::Task,
+					"reviewer" => ExecutionAssignmentRole::Reviewer,
+					_ => return Err(incompatible("stored execution assignment role is invalid")),
+				},
+			})
+		})
+		.collect()
+}
+
+fn parse_effects(values: &[Value]) -> Result<Vec<ManagedRunEffectLineage>, StoreError> {
+	values
+		.iter()
+		.map(|value| {
+			Ok(ManagedRunEffectLineage {
+				effect_id: EffectId::new(required_str(value, "effect_id")?)
+					.map_err(|_| incompatible("stored effect identity is invalid"))?,
+				kind: match required_str(value, "kind")? {
+					"tool" => ManagedRunEffectKind::Tool,
+					"repository" => ManagedRunEffectKind::Repository,
+					"git" => ManagedRunEffectKind::Git,
+					"artifact" => ManagedRunEffectKind::Artifact,
+					_ => return Err(incompatible("stored effect kind is invalid")),
+				},
+				effect_key: required_str(value, "effect_key")?.to_owned(),
+				ordinal: i32::try_from(positive_i64(value, "ordinal")?)
+					.map_err(|_| incompatible("stored effect ordinal is invalid"))?,
+			})
+		})
+		.collect()
+}
+
+fn parse_safety_response(
+	response: &[u8],
+	managed_run_id: &ManagedRunId,
+	parts: &SafetyInputParts<'_>,
+) -> Result<ManagedRunSafetyOutcome, StoreError> {
+	let document: Value = serde_json::from_slice(response)
+		.map_err(|_| incompatible("exact ManagedRun safety response bytes are invalid"))?;
+	let effect = required_value(&document, "effect")?;
+	match required_str(&document, "classification")? {
+		"stable_domain_rejection" =>
+			return parse_rejection(required_str(effect, "reason")?)
+				.map(ManagedRunSafetyOutcome::Rejected),
+		"success" => {},
+		_ => return Err(incompatible("exact ManagedRun safety classification is invalid")),
+	}
+	if required_str(effect, "managed_run_id")? != managed_run_id.as_str()
+		|| required_str(effect, "runtime_session_id")? != parts.runtime_session_id
+		|| required_str(effect, "effect_barrier_state")? != "closed"
+		|| !required_bool(effect, "managed_run_blocked")?
+	{
+		return Err(incompatible("exact ManagedRun safety effect is inconsistent"));
+	}
+	Ok(ManagedRunSafetyOutcome::Success(ManagedRunSafetyEffect {
+		managed_run_id: managed_run_id.clone(),
+		managed_run_revision: positive_i64(effect, "managed_run_revision")?,
+		runtime_session_id: parse_session_id(parts.runtime_session_id)?,
+		runtime_session_revision: positive_i64(effect, "runtime_session_revision")?,
+		runtime_session_diverged: required_bool(effect, "runtime_session_diverged")?,
+		managed_run_blocked: true,
+		effect_barrier_revision: positive_i64(effect, "effect_barrier_revision")?,
+		effect_barrier_closed_now: required_bool(effect, "effect_barrier_closed_now")?,
+		stale_receipt: required_bool(effect, "stale_receipt")?,
+	}))
+}
+
+fn parse_rejection(value: &str) -> Result<ManagedRunSafetyRejection, StoreError> {
+	Ok(match value {
+		"invalid_input" => ManagedRunSafetyRejection::InvalidInput,
+		"missing_target" => ManagedRunSafetyRejection::MissingTarget,
+		"stale_revision" => ManagedRunSafetyRejection::StaleRevision,
+		"wrong_runtime_session" => ManagedRunSafetyRejection::WrongRuntimeSession,
+		"missing_submitted_turn_receipt" => ManagedRunSafetyRejection::MissingSubmittedTurnReceipt,
+		"turn_already_owned_or_known" => ManagedRunSafetyRejection::TurnAlreadyOwnedOrKnown,
+		"input_identity_conflict" => ManagedRunSafetyRejection::InputIdentityConflict,
+		_ => return Err(incompatible("exact ManagedRun safety rejection is invalid")),
+	})
+}
+
+fn lifecycle(value: &str) -> Result<ManagedRunLifecycle, StoreError> {
+	match value {
+		"queued" => Ok(ManagedRunLifecycle::Queued),
+		"active" => Ok(ManagedRunLifecycle::Active),
+		"waiting" => Ok(ManagedRunLifecycle::Waiting),
+		"terminal" => Ok(ManagedRunLifecycle::Terminal),
+		_ => Err(incompatible("stored ManagedRun lifecycle is invalid")),
+	}
+}
+fn phase(value: &str) -> Result<ManagedRunPhase, StoreError> {
+	match value {
+		"prepare" => Ok(ManagedRunPhase::Prepare),
+		"execute" => Ok(ManagedRunPhase::Execute),
+		"validate" => Ok(ManagedRunPhase::Validate),
+		"review" => Ok(ManagedRunPhase::Review),
+		"repair" => Ok(ManagedRunPhase::Repair),
+		"land" => Ok(ManagedRunPhase::Land),
+		"close" => Ok(ManagedRunPhase::Close),
+		_ => Err(incompatible("stored ManagedRun phase is invalid")),
+	}
+}
+fn wait_reason(value: &str) -> Result<ManagedRunWaitReason, StoreError> {
+	match value {
+		"usage" => Ok(ManagedRunWaitReason::Usage),
+		"auth" => Ok(ManagedRunWaitReason::Auth),
+		"plugin" => Ok(ManagedRunWaitReason::Plugin),
+		"dependency" => Ok(ManagedRunWaitReason::Dependency),
+		"approval" => Ok(ManagedRunWaitReason::Approval),
+		"user" => Ok(ManagedRunWaitReason::User),
+		"external" => Ok(ManagedRunWaitReason::External),
+		"reviewer_unavailable" => Ok(ManagedRunWaitReason::ReviewerUnavailable),
+		"reviewer_failed" => Ok(ManagedRunWaitReason::ReviewerFailed),
+		_ => Err(incompatible("stored ManagedRun wait reason is invalid")),
+	}
+}
+fn session_state(value: &str) -> Result<RuntimeSessionState, StoreError> {
+	match value {
+		"starting" => Ok(RuntimeSessionState::Starting),
+		"active" => Ok(RuntimeSessionState::Active),
+		"ended" => Ok(RuntimeSessionState::Ended),
+		"diverged" => Ok(RuntimeSessionState::Diverged),
+		_ => Err(incompatible("stored RuntimeSession state is invalid")),
+	}
+}
+fn barrier_state(value: &str) -> Result<ManagedRunEffectBarrierState, StoreError> {
+	match value {
+		"guarded" => Ok(ManagedRunEffectBarrierState::Guarded),
+		"closed" => Ok(ManagedRunEffectBarrierState::Closed),
+		_ => Err(incompatible("stored effect barrier state is invalid")),
+	}
+}
+fn validate_barrier(value: &ManagedRunEffectBarrier) -> Result<(), StoreError> {
+	match (value.state, value.revision, value.closure_input_id.is_some(), value.closed_at.is_some())
+	{
+		(ManagedRunEffectBarrierState::Guarded, 1, false, false)
+		| (ManagedRunEffectBarrierState::Closed, 2, true, true) => Ok(()),
+		_ => Err(incompatible("stored effect barrier shape is invalid")),
+	}
+}
+fn parse_run_id(value: &str) -> Result<ManagedRunId, StoreError> {
+	ManagedRunId::new(value).map_err(|_| incompatible("stored ManagedRun identity is invalid"))
+}
+fn parse_session_id(value: &str) -> Result<RuntimeSessionId, StoreError> {
+	RuntimeSessionId::new(value)
+		.map_err(|_| incompatible("stored RuntimeSession identity is invalid"))
+}
+fn required_value<'a>(value: &'a Value, key: &str) -> Result<&'a Value, StoreError> {
+	value.get(key).ok_or_else(|| incompatible("ManagedRun document is missing a field"))
+}
+fn required_str<'a>(value: &'a Value, key: &str) -> Result<&'a str, StoreError> {
+	required_value(value, key)?
+		.as_str()
+		.ok_or_else(|| incompatible("ManagedRun string field is invalid"))
+}
+fn required_bool(value: &Value, key: &str) -> Result<bool, StoreError> {
+	required_value(value, key)?
+		.as_bool()
+		.ok_or_else(|| incompatible("ManagedRun boolean field is invalid"))
+}
+fn positive_i64(value: &Value, key: &str) -> Result<i64, StoreError> {
+	let number = required_value(value, key)?
+		.as_i64()
+		.ok_or_else(|| incompatible("ManagedRun numeric field is invalid"))?;
+	if number <= 0 {
+		Err(incompatible("ManagedRun numeric field is not positive"))
+	} else {
+		Ok(number)
+	}
+}
+fn required_array<'a>(value: &'a Value, key: &str) -> Result<&'a [Value], StoreError> {
+	required_value(value, key)?
+		.as_array()
+		.map(Vec::as_slice)
+		.ok_or_else(|| incompatible("ManagedRun array field is invalid"))
+}
+fn optional_str(value: &Value, key: &str) -> Result<Option<String>, StoreError> {
+	match required_value(value, key)? {
+		Value::Null => Ok(None),
+		Value::String(text) => Ok(Some(text.clone())),
+		_ => Err(incompatible("ManagedRun optional string field is invalid")),
+	}
+}
+fn incompatible(message: &'static str) -> StoreError {
+	StoreError::Incompatible(message.into())
+}

--- a/crates/decodex-postgres/src/migrations.rs
+++ b/crates/decodex-postgres/src/migrations.rs
@@ -8,7 +8,7 @@ use deadpool_postgres::Client;
 use crate::{REQUIRED_POSTGRES_MAJOR, StoreError};
 use embedded::migrations;
 
-const EXPECTED_LATEST_MIGRATION_VERSION: i32 = 10;
+const EXPECTED_LATEST_MIGRATION_VERSION: i32 = 11;
 
 pub(crate) async fn run(client: &mut Client) -> Result<(), StoreError> {
 	migrations::runner().run_async(&mut ***client).await?;
@@ -80,7 +80,7 @@ pub(crate) async fn verify(client: &Client) -> Result<(), StoreError> {
 		!= Some(EXPECTED_LATEST_MIGRATION_VERSION)
 	{
 		return Err(StoreError::Incompatible(
-			"embedded migration inventory does not end at the canonical V10 ledger".into(),
+			"embedded migration inventory does not end at the canonical V11 ledger".into(),
 		));
 	}
 	if actual.len() != expected.len() {

--- a/crates/decodex-postgres/src/migrations.rs
+++ b/crates/decodex-postgres/src/migrations.rs
@@ -8,7 +8,7 @@ use deadpool_postgres::Client;
 use crate::{REQUIRED_POSTGRES_MAJOR, StoreError};
 use embedded::migrations;
 
-const EXPECTED_LATEST_MIGRATION_VERSION: i32 = 11;
+const EXPECTED_LATEST_MIGRATION_VERSION: i32 = 12;
 
 pub(crate) async fn run(client: &mut Client) -> Result<(), StoreError> {
 	migrations::runner().run_async(&mut ***client).await?;
@@ -80,7 +80,7 @@ pub(crate) async fn verify(client: &Client) -> Result<(), StoreError> {
 		!= Some(EXPECTED_LATEST_MIGRATION_VERSION)
 	{
 		return Err(StoreError::Incompatible(
-			"embedded migration inventory does not end at the canonical V11 ledger".into(),
+			"embedded migration inventory does not end at the canonical V12 ledger".into(),
 		));
 	}
 	if actual.len() != expected.len() {

--- a/crates/decodex-postgres/src/runtime_sessions.rs
+++ b/crates/decodex-postgres/src/runtime_sessions.rs
@@ -280,7 +280,7 @@ fn parse_response(
 
 	let effect = required_pointer(&document, "/effect")?;
 	validate_request_context(required_value(effect, "request")?, context)?;
-	let session = required_value(effect, "runtime_session")?;
+	let session = required_value(effect, "runtime_session_snapshot")?;
 	let profile = profile_from_value(required_value(effect, "profile_snapshot")?)?;
 	let account = account_from_value(required_value(effect, "account_snapshot")?)?;
 	let state = session_state_from_sql(required_str(session, "state")?)?;
@@ -355,7 +355,7 @@ fn parse_response(
 		|| required_str(effect, "outbox_aggregate_kind")? != "runtime_session"
 		|| required_str(effect, "outbox_aggregate_id")? != session_id
 		|| required_i64(effect, "outbox_aggregate_revision")? != new_revision
-		|| activity_payload.get("runtime_session") != Some(session)
+		|| activity_payload.get("runtime_session_snapshot") != Some(session)
 		|| activity_payload.get("profile_snapshot") != effect.get("profile_snapshot")
 		|| activity_payload.get("account_snapshot") != effect.get("account_snapshot")
 		|| activity_payload.get("kind").and_then(Value::as_str) != Some("runtime_session")
@@ -756,7 +756,8 @@ mod tests {
 
 	#[test]
 	fn success_parser_requires_complete_immutable_snapshots() {
-		let incomplete = br#"{"classification":"success","effect":{"runtime_session":{}}}"#;
+		let incomplete =
+			br#"{"classification":"success","effect":{"runtime_session_snapshot":{}}}"#;
 		assert!(parse_create_response(incomplete, &create()).is_err());
 	}
 
@@ -798,7 +799,7 @@ mod tests {
 		});
 		let activity = json!({
 			"kind": "runtime_session",
-			"runtime_session": session,
+			"runtime_session_snapshot": session,
 			"profile_snapshot": profile,
 			"account_snapshot": account
 		});
@@ -814,7 +815,7 @@ mod tests {
 			"classification": "success",
 			"effect": {
 				"request": create_request(),
-				"runtime_session": session,
+				"runtime_session_snapshot": session,
 				"profile_snapshot": profile,
 				"account_snapshot": account,
 				"prior_state": null,
@@ -844,7 +845,7 @@ mod tests {
 		assert_eq!(effect.activity_sequence, 1);
 
 		let mut substituted = response;
-		substituted["effect"]["runtime_session"]["profile_snapshot_id"] =
+		substituted["effect"]["runtime_session_snapshot"]["profile_snapshot_id"] =
 			json!("42000000-0000-4000-8000-000000000099");
 		assert!(
 			parse_create_response(&serde_json::to_vec(&substituted).unwrap(), &create()).is_err()
@@ -855,7 +856,7 @@ mod tests {
 	fn success_parser_rejects_wrong_request_and_malformed_stored_uuid_as_incompatible() {
 		let incomplete = json!({
 			"classification": "success",
-			"effect": {"request": create_request(), "runtime_session": {}}
+			"effect": {"request": create_request(), "runtime_session_snapshot": {}}
 		});
 		let mut wrong = create();
 		wrong.account_snapshot.display_label = "Other account".into();
@@ -881,7 +882,7 @@ mod tests {
 			"classification": "success",
 			"effect": {
 				"request": create_request(),
-				"runtime_session": {},
+				"runtime_session_snapshot": {},
 				"profile_snapshot": malformed,
 				"account_snapshot": {}
 			}

--- a/crates/decodex-postgres/src/work_items.rs
+++ b/crates/decodex-postgres/src/work_items.rs
@@ -452,7 +452,9 @@ fn parse_command_response(response: &[u8]) -> Result<WorkItemCommandOutcome, Sto
 		},
 		Some("success") => {},
 		_ => {
-			return Err(StoreError::Incompatible("exact WorkItem classification is invalid".into()));
+			return Err(StoreError::Incompatible(
+				"exact WorkItem classification is invalid".into(),
+			));
 		},
 	}
 	let effect = required_value(&document, "effect")?;
@@ -474,9 +476,16 @@ fn parse_command_response(response: &[u8]) -> Result<WorkItemCommandOutcome, Sto
 		|| outbox_payload.get("revision").and_then(Value::as_i64)
 			!= i64::try_from(work_item.work_item.revision()).ok()
 		|| outbox_payload.get("payload") != Some(&activity_payload)
-		|| !matches!(event_kind, Some("work_item_created" | "work_item_updated"
-			| "work_item_readiness_blocked" | "work_item_ready" | "work_item_accepted"))
-	{
+		|| !matches!(
+			event_kind,
+			Some(
+				"work_item_created"
+					| "work_item_updated"
+					| "work_item_readiness_blocked"
+					| "work_item_ready"
+					| "work_item_accepted"
+			)
+		) {
 		return Err(StoreError::Incompatible("exact WorkItem audit effect is inconsistent".into()));
 	}
 	Ok(WorkItemCommandOutcome::Success(Box::new(WorkItemCommandEffect {
@@ -579,7 +588,9 @@ fn rejection_from_document(value: &Value) -> Result<WorkItemRejection, StoreErro
 	if effect.get("changed").and_then(Value::as_bool) != Some(false)
 		|| effect.get("code").and_then(Value::as_str) != code
 	{
-		return Err(StoreError::Incompatible("exact WorkItem rejection effect is inconsistent".into()));
+		return Err(StoreError::Incompatible(
+			"exact WorkItem rejection effect is inconsistent".into(),
+		));
 	}
 	match code {
 		Some("missing_target") => Ok(WorkItemRejection::MissingTarget),

--- a/crates/decodex-postgres/src/work_items.rs
+++ b/crates/decodex-postgres/src/work_items.rs
@@ -1,0 +1,748 @@
+//! Exact PostgreSQL WorkItem commands and non-transferable stored projections.
+
+use serde_json::Value;
+use tokio_postgres::Row;
+
+use crate::{
+	PostgresStore, StoreError,
+	exact_commands::{EXACT_COMMAND_PROTOCOL, validate_exact_key},
+};
+use decodex_core::{
+	AgentId, ObjectiveId, ProgramId, ProjectId, WorkItem, WorkItemCorrelationId, WorkItemEdge,
+	WorkItemEdgeKind, WorkItemId, WorkItemPriority, WorkItemProgramRef, WorkItemProvenance,
+	WorkItemState, WorkItemTimestamp,
+};
+
+const WORK_ITEM_DOCUMENT_SELECT: &str = r#"
+SELECT pg_catalog.jsonb_build_object(
+	'work_item_id', item.work_item_id, 'project_id', item.project_id,
+	'lead_agent_id', item.lead_agent_id, 'program_id', item.program_id,
+	'objective_ids', COALESCE((SELECT pg_catalog.jsonb_agg(link.objective_id ORDER BY link.objective_id)
+		FROM decodex.work_item_objectives AS link WHERE link.work_item_id=item.work_item_id),'[]'::jsonb),
+	'edges', COALESCE((SELECT pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+		'kind',edge.kind,'related_work_item_id',edge.related_work_item_id
+	) ORDER BY edge.related_work_item_id) FROM decodex.work_item_edges AS edge
+		WHERE edge.work_item_id=item.work_item_id),'[]'::jsonb),
+	'title',item.title,'description',item.description,'priority',item.priority,
+	'acceptance_criteria',item.acceptance_criteria,'validation_criteria',item.validation_criteria,
+	'state',item.state,'revision',item.revision,'last_changed_by',item.last_changed_by,
+	'last_correlation_id',item.last_correlation_id,'last_provenance',item.last_provenance,
+	'created_at_microseconds',(EXTRACT(EPOCH FROM item.created_at)*1000000)::bigint,
+	'updated_at_microseconds',(EXTRACT(EPOCH FROM item.updated_at)*1000000)::bigint,
+	'accepted_revision',(SELECT pg_catalog.max(acceptance.work_item_revision)
+		FROM decodex.work_item_acceptances AS acceptance
+		WHERE acceptance.work_item_id=item.work_item_id)
+) FROM decodex.work_items AS item WHERE item.work_item_id=$1::pg_catalog.text::pg_catalog.uuid
+"#;
+
+/// Normalized same-Project relations supplied to a create or update command.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct WorkItemRelations {
+	/// Same-Project Objective identities.
+	pub objective_ids: Vec<ObjectiveId>,
+	/// Related WorkItems that must be done.
+	pub depends_on_ids: Vec<WorkItemId>,
+	/// Related WorkItems that must be terminal.
+	pub blocked_by_ids: Vec<WorkItemId>,
+}
+
+/// Complete caller-selected input for revision-one WorkItem creation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreateWorkItem {
+	/// Caller-selected canonical WorkItem identity.
+	pub work_item_id: WorkItemId,
+	/// Project that owns the WorkItem.
+	pub project_id: ProjectId,
+	/// Canonical Lead responsible for the WorkItem.
+	pub lead_agent_id: AgentId,
+	/// Optional same-Project Program association.
+	pub program_id: Option<ProgramId>,
+	/// Normalized same-Project relations.
+	pub relations: WorkItemRelations,
+	/// Human-readable WorkItem title.
+	pub title: String,
+	/// Bounded WorkItem description.
+	pub description: String,
+	/// Initial canonical priority.
+	pub priority: WorkItemPriority,
+	/// Criteria the Lead will later accept against an exact revision.
+	pub acceptance_criteria: Vec<String>,
+	/// Criteria used to validate the exact revision.
+	pub validation_criteria: Vec<String>,
+	/// Actor, correlation, and summary provenance for creation.
+	pub provenance: WorkItemProvenance,
+}
+
+/// Complete optimistic replacement of mutable WorkItem structure and ordinary lifecycle.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpdateWorkItem {
+	/// Canonical identity of the WorkItem to replace.
+	pub work_item_id: WorkItemId,
+	/// Owning Project identity.
+	pub project_id: ProjectId,
+	/// Revision that must still be current.
+	pub expected_revision: u64,
+	/// Replacement optional same-Project Program association.
+	pub program_id: Option<ProgramId>,
+	/// Replacement normalized same-Project relations.
+	pub relations: WorkItemRelations,
+	/// Replacement title.
+	pub title: String,
+	/// Replacement bounded description.
+	pub description: String,
+	/// Replacement canonical priority.
+	pub priority: WorkItemPriority,
+	/// Replacement acceptance criteria.
+	pub acceptance_criteria: Vec<String>,
+	/// Replacement validation criteria.
+	pub validation_criteria: Vec<String>,
+	/// Requested ordinary lifecycle state.
+	pub target_state: WorkItemState,
+	/// Actor, correlation, and summary provenance for the update.
+	pub provenance: WorkItemProvenance,
+}
+
+/// Exact-revision Lead acceptance input. PostgreSQL snapshots the criteria and authors time.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptWorkItem {
+	/// Immutable canonical acceptance identity.
+	pub acceptance_id: String,
+	/// Canonical WorkItem identity.
+	pub work_item_id: WorkItemId,
+	/// Owning Project identity.
+	pub project_id: ProjectId,
+	/// Exact review revision being accepted.
+	pub expected_revision: u64,
+	/// Canonical Lead and correlation provenance.
+	pub provenance: WorkItemProvenance,
+	/// Provenance for the snapshotted criteria.
+	pub criteria_provenance: String,
+	/// Bounded summary of the acceptance evidence.
+	pub evidence_summary: String,
+	/// Provenance for the acceptance evidence.
+	pub evidence_provenance: String,
+}
+
+/// Persisted WorkItem with normalized edges and a non-authoritative acceptance observation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StoredWorkItem {
+	/// Canonical WorkItem projection.
+	pub work_item: WorkItem,
+	/// Normalized typed dependency and blocker edges.
+	pub edges: Vec<WorkItemEdge>,
+	/// Latest accepted exact revision, if any. This is readback, not a completion permit.
+	pub accepted_revision: Option<u64>,
+}
+
+/// Typed current-state blocker persisted by an exact readiness transaction.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkItemReadinessBlockerKind {
+	/// The owning Project is not active.
+	ProjectInactive,
+	/// The canonical Lead is not active in the Project.
+	LeadInactive,
+	/// The associated Program is not active.
+	ProgramInactive,
+	/// An associated Objective is not active.
+	ObjectiveInactive,
+	/// A dependency has not reached `done`.
+	DependencyIncomplete,
+	/// A blocker has not reached a terminal state.
+	BlockerActive,
+	/// The current dependency graph contains a cycle.
+	DependencyCycle,
+}
+
+/// Inspectable blocker fact. It is not reusable transition authority.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkItemReadinessBlocker {
+	/// Typed reason readiness was denied.
+	pub kind: WorkItemReadinessBlockerKind,
+	/// Related authority identity, when the blocker has one.
+	pub subject_id: Option<String>,
+	/// Current state observed by the readiness transaction.
+	pub observed_state: String,
+}
+
+/// Complete committed exact-command effect.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkItemCommandEffect {
+	/// Committed canonical WorkItem projection.
+	pub work_item: StoredWorkItem,
+	/// Current blockers recorded by readiness, otherwise empty.
+	pub readiness_blockers: Vec<WorkItemReadinessBlocker>,
+	/// Append-only activity sequence emitted by the command.
+	pub activity_sequence: i64,
+	/// Exact credential-negative activity payload.
+	pub activity_payload: Value,
+	/// Transactional outbox row identity.
+	pub outbox_id: i64,
+	/// Exact credential-negative outbox payload.
+	pub outbox_payload: Value,
+}
+
+/// Stable WorkItem domain rejection committed into the exact receipt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkItemRejection {
+	/// The target WorkItem does not exist.
+	MissingTarget,
+	/// Creation targeted an existing WorkItem.
+	DuplicateTarget,
+	/// The expected revision is no longer current.
+	StaleRevision,
+	/// The requested lifecycle transition is not allowed.
+	IllegalTransition,
+	/// Current Project, Lead, or association authority is invalid.
+	InvalidAuthority,
+	/// A bounded or typed command value is invalid.
+	InvalidInput,
+	/// A relation is not valid for the owning Project.
+	InvalidRelation,
+	/// A normalized relation was supplied more than once.
+	DuplicateRelation,
+	/// The candidate dependency graph contains a cycle.
+	DependencyCycle,
+	/// The exact revision already has an acceptance.
+	DuplicateAcceptance,
+}
+
+/// Exact command outcome parsed from PostgreSQL-owned immutable response bytes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WorkItemCommandOutcome {
+	/// Committed exact-command effect.
+	Success(Box<WorkItemCommandEffect>),
+	/// Stable domain rejection committed into the exact receipt.
+	Rejected(WorkItemRejection),
+}
+
+impl PostgresStore {
+	/// Create one canonical inbox WorkItem through the command-complete V11 owner.
+	pub async fn create_work_item(
+		&self,
+		idempotency_key: &str,
+		create: &CreateWorkItem,
+	) -> Result<WorkItemCommandOutcome, StoreError> {
+		validate_exact_key(idempotency_key)?;
+		let relations = relation_parameters(&create.relations);
+		let program_id = create.program_id.as_ref().map(ToString::to_string);
+		let priority = create.priority.as_str();
+		let response = self
+			.execute_exact_with_retry(
+				"SELECT decodex.create_work_item_exact($1,$2,$3::text::uuid,$4::text::uuid,\
+				 $5::text::uuid,$6::text::uuid,$7::text[]::uuid[],$8::text[]::uuid[],\
+				 $9::text[]::uuid[],$10,$11,$12::text::decodex.work_item_priority,\
+				 $13,$14,$15::text::uuid,$16::text::uuid,$17)",
+				&[
+					&EXACT_COMMAND_PROTOCOL,
+					&idempotency_key,
+					&create.work_item_id.as_str(),
+					&create.project_id.as_str(),
+					&create.lead_agent_id.as_str(),
+					&program_id,
+					&relations.objectives,
+					&relations.depends_on,
+					&relations.blocked_by,
+					&create.title,
+					&create.description,
+					&priority,
+					&create.acceptance_criteria,
+					&create.validation_criteria,
+					&create.provenance.actor_id().as_str(),
+					&create.provenance.correlation_id().as_str(),
+					&create.provenance.summary(),
+				],
+			)
+			.await?;
+		parse_command_response(&response)
+	}
+
+	/// Replace mutable WorkItem structure and perform one ordinary lifecycle transition.
+	pub async fn update_work_item(
+		&self,
+		idempotency_key: &str,
+		update: &UpdateWorkItem,
+	) -> Result<WorkItemCommandOutcome, StoreError> {
+		validate_exact_key(idempotency_key)?;
+		let expected_revision = positive_revision(update.expected_revision)?;
+		let relations = relation_parameters(&update.relations);
+		let program_id = update.program_id.as_ref().map(ToString::to_string);
+		let priority = update.priority.as_str();
+		let target_state = update.target_state.as_str();
+		let response = self
+			.execute_exact_with_retry(
+				"SELECT decodex.update_work_item_exact($1,$2,$3::text::uuid,$4::text::uuid,$5,\
+				 $6::text::uuid,$7::text[]::uuid[],$8::text[]::uuid[],$9::text[]::uuid[],\
+				 $10,$11,$12::text::decodex.work_item_priority,$13,$14,\
+				 $15::text::decodex.work_item_state,$16::text::uuid,$17::text::uuid,$18)",
+				&[
+					&EXACT_COMMAND_PROTOCOL,
+					&idempotency_key,
+					&update.work_item_id.as_str(),
+					&update.project_id.as_str(),
+					&expected_revision,
+					&program_id,
+					&relations.objectives,
+					&relations.depends_on,
+					&relations.blocked_by,
+					&update.title,
+					&update.description,
+					&priority,
+					&update.acceptance_criteria,
+					&update.validation_criteria,
+					&target_state,
+					&update.provenance.actor_id().as_str(),
+					&update.provenance.correlation_id().as_str(),
+					&update.provenance.summary(),
+				],
+			)
+			.await?;
+		parse_command_response(&response)
+	}
+
+	/// Re-read every readiness input and atomically persist blockers or enter `ready`.
+	pub async fn assess_work_item_readiness(
+		&self,
+		idempotency_key: &str,
+		work_item_id: &WorkItemId,
+		project_id: &ProjectId,
+		expected_revision: u64,
+		provenance: &WorkItemProvenance,
+	) -> Result<WorkItemCommandOutcome, StoreError> {
+		validate_exact_key(idempotency_key)?;
+		let expected_revision = positive_revision(expected_revision)?;
+		let response = self
+			.execute_exact_with_retry(
+				"SELECT decodex.assess_work_item_readiness_exact(\
+				 $1,$2,$3::text::uuid,$4::text::uuid,$5,$6::text::uuid,$7::text::uuid,$8)",
+				&[
+					&EXACT_COMMAND_PROTOCOL,
+					&idempotency_key,
+					&work_item_id.as_str(),
+					&project_id.as_str(),
+					&expected_revision,
+					&provenance.actor_id().as_str(),
+					&provenance.correlation_id().as_str(),
+					&provenance.summary(),
+				],
+			)
+			.await?;
+		parse_command_response(&response)
+	}
+
+	/// Persist immutable canonical-Lead acceptance without changing WorkItem lifecycle or revision.
+	pub async fn accept_work_item(
+		&self,
+		idempotency_key: &str,
+		acceptance: &AcceptWorkItem,
+	) -> Result<WorkItemCommandOutcome, StoreError> {
+		validate_exact_key(idempotency_key)?;
+		validate_uuid(&acceptance.acceptance_id, "invalid WorkItem acceptance identity")?;
+		let expected_revision = positive_revision(acceptance.expected_revision)?;
+		let response = self
+			.execute_exact_with_retry(
+				"SELECT decodex.accept_work_item_exact($1,$2,$3::text::uuid,$4::text::uuid,\
+				 $5::text::uuid,$6,$7::text::uuid,$8::text::uuid,$9,$10,$11,$12)",
+				&[
+					&EXACT_COMMAND_PROTOCOL,
+					&idempotency_key,
+					&acceptance.acceptance_id,
+					&acceptance.work_item_id.as_str(),
+					&acceptance.project_id.as_str(),
+					&expected_revision,
+					&acceptance.provenance.actor_id().as_str(),
+					&acceptance.provenance.correlation_id().as_str(),
+					&acceptance.provenance.summary(),
+					&acceptance.criteria_provenance,
+					&acceptance.evidence_summary,
+					&acceptance.evidence_provenance,
+				],
+			)
+			.await?;
+		parse_command_response(&response)
+	}
+
+	/// Read one current canonical WorkItem projection.
+	pub async fn read_work_item(
+		&self,
+		work_item_id: &WorkItemId,
+	) -> Result<Option<StoredWorkItem>, StoreError> {
+		let client = crate::checkout(self.pool(), &self.connector).await?;
+		client
+			.query_opt(WORK_ITEM_DOCUMENT_SELECT, &[&work_item_id.as_str()])
+			.await?
+			.map(document_from_row)
+			.transpose()
+	}
+
+	/// Query one deterministic bounded Project page ordered by WorkItem identity.
+	pub async fn query_work_items(
+		&self,
+		project_id: &ProjectId,
+		state: Option<WorkItemState>,
+		after: Option<&WorkItemId>,
+		limit: usize,
+	) -> Result<Vec<StoredWorkItem>, StoreError> {
+		if !(1..=256).contains(&limit) {
+			return Err(StoreError::InvalidInput("WorkItem query limit must be 1..=256"));
+		}
+		let state = state.map(|value| value.as_str());
+		let after = after.map(WorkItemId::as_str);
+		let limit = i64::try_from(limit)
+			.map_err(|_| StoreError::InvalidInput("WorkItem query limit is invalid"))?;
+		let client = crate::checkout(self.pool(), &self.connector).await?;
+		let statement = WORK_ITEM_DOCUMENT_SELECT.replace(
+			"WHERE item.work_item_id=$1::pg_catalog.text::pg_catalog.uuid",
+			"WHERE item.project_id=$1::pg_catalog.text::pg_catalog.uuid \
+			 AND ($2::text IS NULL OR item.state=$2::text::decodex.work_item_state) \
+			 AND ($3::text IS NULL OR item.work_item_id>$3::text::uuid) \
+			 ORDER BY item.work_item_id LIMIT $4",
+		);
+		let rows =
+			client.query(&statement, &[&project_id.as_str(), &state, &after, &limit]).await?;
+		rows.into_iter().map(document_from_row).collect()
+	}
+
+	/// Inert future running/resume check. The transaction returns no permit or authority object.
+	pub async fn guard_work_item_running_resume(
+		&self,
+		work_item_id: &WorkItemId,
+		project_id: &ProjectId,
+		expected_revision: u64,
+	) -> Result<(), StoreError> {
+		let expected_revision = positive_revision(expected_revision)?;
+		let mut client = crate::checkout(self.pool(), &self.connector).await?;
+		let transaction = client.transaction().await?;
+		transaction
+			.query_one(
+				"SELECT decodex.guard_work_item_running_resume($1::text::uuid,$2::text::uuid,$3)",
+				&[&work_item_id.as_str(), &project_id.as_str(), &expected_revision],
+			)
+			.await?;
+		transaction.commit().await?;
+		Ok(())
+	}
+}
+
+struct RelationParameters {
+	objectives: Vec<String>,
+	depends_on: Vec<String>,
+	blocked_by: Vec<String>,
+}
+
+fn relation_parameters(relations: &WorkItemRelations) -> RelationParameters {
+	let mut objectives =
+		relations.objective_ids.iter().map(ToString::to_string).collect::<Vec<_>>();
+	let mut depends_on =
+		relations.depends_on_ids.iter().map(ToString::to_string).collect::<Vec<_>>();
+	let mut blocked_by =
+		relations.blocked_by_ids.iter().map(ToString::to_string).collect::<Vec<_>>();
+	objectives.sort();
+	depends_on.sort();
+	blocked_by.sort();
+	RelationParameters { objectives, depends_on, blocked_by }
+}
+
+fn parse_command_response(response: &[u8]) -> Result<WorkItemCommandOutcome, StoreError> {
+	let document: Value = serde_json::from_slice(response).map_err(|_| {
+		StoreError::Incompatible("exact WorkItem response bytes are invalid".into())
+	})?;
+	match document.get("classification").and_then(Value::as_str) {
+		Some("stable_domain_rejection") => {
+			return rejection_from_document(&document).map(WorkItemCommandOutcome::Rejected);
+		},
+		Some("success") => {},
+		_ => {
+			return Err(StoreError::Incompatible("exact WorkItem classification is invalid".into()));
+		},
+	}
+	let effect = required_value(&document, "effect")?;
+	let work_item = stored_from_value(required_value(effect, "work_item")?)?;
+	let readiness_blockers =
+		effect.get("readiness_blockers").map(blockers_from_value).transpose()?.unwrap_or_default();
+	let activity_sequence = positive_i64(effect, "activity_sequence")?;
+	let outbox_id = positive_i64(effect, "outbox_id")?;
+	let activity_payload = required_value(effect, "activity_payload")?.clone();
+	let outbox_payload = required_value(effect, "outbox_payload")?.clone();
+	let event_kind = outbox_payload.get("event_kind").and_then(Value::as_str);
+	if activity_payload.get("kind").and_then(Value::as_str) != Some("work_item")
+		|| activity_payload.get("work_item") != effect.get("work_item")
+		|| outbox_payload.get("activity_sequence").and_then(Value::as_i64)
+			!= Some(activity_sequence)
+		|| outbox_payload.get("aggregate_kind").and_then(Value::as_str) != Some("work_item")
+		|| outbox_payload.get("aggregate_id").and_then(Value::as_str)
+			!= Some(work_item.work_item.id().as_str())
+		|| outbox_payload.get("revision").and_then(Value::as_i64)
+			!= i64::try_from(work_item.work_item.revision()).ok()
+		|| outbox_payload.get("payload") != Some(&activity_payload)
+		|| !matches!(event_kind, Some("work_item_created" | "work_item_updated"
+			| "work_item_readiness_blocked" | "work_item_ready" | "work_item_accepted"))
+	{
+		return Err(StoreError::Incompatible("exact WorkItem audit effect is inconsistent".into()));
+	}
+	Ok(WorkItemCommandOutcome::Success(Box::new(WorkItemCommandEffect {
+		work_item,
+		readiness_blockers,
+		activity_sequence,
+		activity_payload,
+		outbox_id,
+		outbox_payload,
+	})))
+}
+
+fn document_from_row(row: Row) -> Result<StoredWorkItem, StoreError> {
+	stored_from_value(&row.get::<_, Value>(0))
+}
+
+fn stored_from_value(value: &Value) -> Result<StoredWorkItem, StoreError> {
+	let work_item_id = WorkItemId::new(required_str(value, "work_item_id")?).map_err(domain)?;
+	let project_id = ProjectId::new(required_str(value, "project_id")?).map_err(domain)?;
+	let lead_agent_id = AgentId::new(required_str(value, "lead_agent_id")?).map_err(domain)?;
+	let program = optional_str(value, "program_id")?
+		.map(|id| ProgramId::new(id).map(|id| WorkItemProgramRef::new(id, project_id.clone())))
+		.transpose()
+		.map_err(domain)?;
+	let objective_ids = required_array(value, "objective_ids")?;
+	let objectives = objective_ids
+		.iter()
+		.map(|id| -> Result<_, StoreError> {
+			let id = id.as_str().ok_or_else(incompatible)?;
+			let id = ObjectiveId::new(id).map_err(domain)?;
+			Ok(decodex_core::WorkItemObjectiveRef::new(id, project_id.clone()))
+		})
+		.collect::<Result<Vec<_>, _>>()?;
+	let provenance = WorkItemProvenance::new(
+		AgentId::new(required_str(value, "last_changed_by")?).map_err(domain)?,
+		WorkItemCorrelationId::new(required_str(value, "last_correlation_id")?).map_err(domain)?,
+		required_str(value, "last_provenance")?,
+	)
+	.map_err(domain)?;
+	let work_item = WorkItem::from_stored(
+		work_item_id.clone(),
+		project_id.clone(),
+		lead_agent_id,
+		program,
+		objectives,
+		required_str(value, "title")?.to_owned(),
+		required_str(value, "description")?.to_owned(),
+		priority_from_sql(required_str(value, "priority")?)?,
+		string_array(value, "acceptance_criteria")?,
+		string_array(value, "validation_criteria")?,
+		state_from_sql(required_str(value, "state")?)?,
+		positive_u64(value, "revision")?,
+		WorkItemTimestamp::from_unix_microseconds(required_i64(value, "created_at_microseconds")?)
+			.map_err(domain)?,
+		WorkItemTimestamp::from_unix_microseconds(required_i64(value, "updated_at_microseconds")?)
+			.map_err(domain)?,
+		provenance,
+	)
+	.map_err(domain)?;
+	let edges = required_array(value, "edges")?
+		.iter()
+		.map(|edge| -> Result<_, StoreError> {
+			WorkItemEdge::new(
+				edge_kind_from_sql(required_str(edge, "kind")?)?,
+				work_item_id.clone(),
+				project_id.clone(),
+				WorkItemId::new(required_str(edge, "related_work_item_id")?).map_err(domain)?,
+				project_id.clone(),
+			)
+			.map_err(domain)
+		})
+		.collect::<Result<Vec<_>, _>>()?;
+	let accepted_revision = optional_positive_u64(value, "accepted_revision")?;
+	if accepted_revision.is_some_and(|revision| revision > work_item.revision()) {
+		return Err(incompatible());
+	}
+	Ok(StoredWorkItem { work_item, edges, accepted_revision })
+}
+
+fn blockers_from_value(value: &Value) -> Result<Vec<WorkItemReadinessBlocker>, StoreError> {
+	value
+		.as_array()
+		.ok_or_else(incompatible)?
+		.iter()
+		.map(|value| {
+			Ok(WorkItemReadinessBlocker {
+				kind: blocker_kind_from_sql(required_str(value, "kind")?)?,
+				subject_id: optional_str(value, "subject_id")?
+					.map(|id| WorkItemId::new(id).map(|id| id.to_string()).map_err(domain))
+					.transpose()?,
+				observed_state: required_str(value, "observed_state")?.to_owned(),
+			})
+		})
+		.collect()
+}
+
+fn rejection_from_document(value: &Value) -> Result<WorkItemRejection, StoreError> {
+	let code = value.get("code").and_then(Value::as_str);
+	let effect = required_value(value, "effect")?;
+	if effect.get("changed").and_then(Value::as_bool) != Some(false)
+		|| effect.get("code").and_then(Value::as_str) != code
+	{
+		return Err(StoreError::Incompatible("exact WorkItem rejection effect is inconsistent".into()));
+	}
+	match code {
+		Some("missing_target") => Ok(WorkItemRejection::MissingTarget),
+		Some("duplicate_target") => Ok(WorkItemRejection::DuplicateTarget),
+		Some("stale_revision") => Ok(WorkItemRejection::StaleRevision),
+		Some("illegal_transition") => Ok(WorkItemRejection::IllegalTransition),
+		Some("invalid_authority") => Ok(WorkItemRejection::InvalidAuthority),
+		Some("invalid_input") => Ok(WorkItemRejection::InvalidInput),
+		Some("invalid_relation") => Ok(WorkItemRejection::InvalidRelation),
+		Some("duplicate_relation") => Ok(WorkItemRejection::DuplicateRelation),
+		Some("dependency_cycle") => Ok(WorkItemRejection::DependencyCycle),
+		Some("duplicate_acceptance") => Ok(WorkItemRejection::DuplicateAcceptance),
+		_ => Err(StoreError::Incompatible("exact WorkItem rejection code is invalid".into())),
+	}
+}
+
+fn priority_from_sql(value: &str) -> Result<WorkItemPriority, StoreError> {
+	match value {
+		"urgent" => Ok(WorkItemPriority::Urgent),
+		"high" => Ok(WorkItemPriority::High),
+		"medium" => Ok(WorkItemPriority::Medium),
+		"low" => Ok(WorkItemPriority::Low),
+		"none" => Ok(WorkItemPriority::None),
+		_ => Err(incompatible()),
+	}
+}
+
+fn state_from_sql(value: &str) -> Result<WorkItemState, StoreError> {
+	match value {
+		"inbox" => Ok(WorkItemState::Inbox),
+		"planned" => Ok(WorkItemState::Planned),
+		"ready" => Ok(WorkItemState::Ready),
+		"running" => Ok(WorkItemState::Running),
+		"review" => Ok(WorkItemState::Review),
+		"blocked" => Ok(WorkItemState::Blocked),
+		"done" => Ok(WorkItemState::Done),
+		"canceled" => Ok(WorkItemState::Canceled),
+		_ => Err(incompatible()),
+	}
+}
+
+fn edge_kind_from_sql(value: &str) -> Result<WorkItemEdgeKind, StoreError> {
+	match value {
+		"depends_on" => Ok(WorkItemEdgeKind::DependsOn),
+		"blocked_by" => Ok(WorkItemEdgeKind::BlockedBy),
+		_ => Err(incompatible()),
+	}
+}
+
+fn blocker_kind_from_sql(value: &str) -> Result<WorkItemReadinessBlockerKind, StoreError> {
+	match value {
+		"project_inactive" => Ok(WorkItemReadinessBlockerKind::ProjectInactive),
+		"lead_inactive" => Ok(WorkItemReadinessBlockerKind::LeadInactive),
+		"program_inactive" => Ok(WorkItemReadinessBlockerKind::ProgramInactive),
+		"objective_inactive" => Ok(WorkItemReadinessBlockerKind::ObjectiveInactive),
+		"dependency_incomplete" => Ok(WorkItemReadinessBlockerKind::DependencyIncomplete),
+		"blocker_active" => Ok(WorkItemReadinessBlockerKind::BlockerActive),
+		"dependency_cycle" => Ok(WorkItemReadinessBlockerKind::DependencyCycle),
+		_ => Err(incompatible()),
+	}
+}
+
+fn required_value<'a>(value: &'a Value, key: &str) -> Result<&'a Value, StoreError> {
+	value.get(key).ok_or_else(incompatible)
+}
+
+fn required_str<'a>(value: &'a Value, key: &str) -> Result<&'a str, StoreError> {
+	value.get(key).and_then(Value::as_str).ok_or_else(incompatible)
+}
+
+fn optional_str(value: &Value, key: &str) -> Result<Option<String>, StoreError> {
+	match value.get(key) {
+		Some(Value::Null) => Ok(None),
+		Some(Value::String(value)) => Ok(Some(value.clone())),
+		_ => Err(incompatible()),
+	}
+}
+
+fn required_array<'a>(value: &'a Value, key: &str) -> Result<&'a [Value], StoreError> {
+	value.get(key).and_then(Value::as_array).map(Vec::as_slice).ok_or_else(incompatible)
+}
+
+fn string_array(value: &Value, key: &str) -> Result<Vec<String>, StoreError> {
+	required_array(value, key)?
+		.iter()
+		.map(|value| value.as_str().map(ToOwned::to_owned).ok_or_else(incompatible))
+		.collect()
+}
+
+fn required_i64(value: &Value, key: &str) -> Result<i64, StoreError> {
+	value.get(key).and_then(Value::as_i64).ok_or_else(incompatible)
+}
+
+fn positive_i64(value: &Value, key: &str) -> Result<i64, StoreError> {
+	let value = required_i64(value, key)?;
+	if value > 0 { Ok(value) } else { Err(incompatible()) }
+}
+
+fn positive_u64(value: &Value, key: &str) -> Result<u64, StoreError> {
+	u64::try_from(positive_i64(value, key)?).map_err(|_| incompatible())
+}
+
+fn optional_positive_u64(value: &Value, key: &str) -> Result<Option<u64>, StoreError> {
+	match value.get(key) {
+		Some(Value::Null) => Ok(None),
+		Some(_) => positive_u64(value, key).map(Some),
+		None => Err(incompatible()),
+	}
+}
+
+fn positive_revision(value: u64) -> Result<i64, StoreError> {
+	i64::try_from(value)
+		.ok()
+		.filter(|value| *value > 0)
+		.ok_or(StoreError::InvalidInput("WorkItem revision must be positive and fit bigint"))
+}
+
+fn validate_uuid(value: &str, message: &'static str) -> Result<(), StoreError> {
+	if WorkItemId::new(value).is_ok() { Ok(()) } else { Err(StoreError::InvalidInput(message)) }
+}
+
+fn incompatible() -> StoreError {
+	StoreError::Incompatible("stored WorkItem projection is invalid".into())
+}
+
+fn domain(error: impl std::fmt::Display) -> StoreError {
+	StoreError::Incompatible(format!("stored WorkItem domain is invalid: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+	use serde_json::json;
+
+	use super::{WorkItemReadinessBlockerKind, blockers_from_value, stored_from_value};
+
+	#[test]
+	fn stored_projection_reconstructs_canonical_work_item() {
+		let value = json!({
+			"work_item_id":"51000000-0000-4000-8000-000000000001",
+			"project_id":"21000000-0000-4000-8000-000000000001",
+			"lead_agent_id":"31000000-0000-4000-8000-000000000001",
+			"program_id":null,"objective_ids":[],"edges":[],"title":"Persist WorkItems",
+			"description":"Exact PostgreSQL authority.","priority":"high",
+			"acceptance_criteria":["Stored"],"validation_criteria":["Validated"],
+			"state":"inbox","revision":1,
+			"last_changed_by":"31000000-0000-4000-8000-000000000001",
+			"last_correlation_id":"61000000-0000-4000-8000-000000000001",
+			"last_provenance":"XY-1343","created_at_microseconds":1,
+			"updated_at_microseconds":1,"accepted_revision":null
+		});
+		let stored = stored_from_value(&value).unwrap();
+		assert_eq!(stored.work_item.revision(), 1);
+		assert_eq!(stored.accepted_revision, None);
+	}
+
+	#[test]
+	fn readiness_blockers_are_typed_and_order_preserving() {
+		let blockers = blockers_from_value(&json!([{
+			"kind":"dependency_incomplete",
+			"subject_id":"51000000-0000-4000-8000-000000000002",
+			"observed_state":"planned"
+		}]))
+		.unwrap();
+		assert_eq!(blockers[0].kind, WorkItemReadinessBlockerKind::DependencyIncomplete);
+	}
+}

--- a/crates/decodex-postgres/tests/postgres_store.rs
+++ b/crates/decodex-postgres/tests/postgres_store.rs
@@ -1,5 +1,8 @@
 //! Real PostgreSQL contract coverage for the XY-1267 persistence foundation.
 
+#[cfg(feature = "test-support")]
+#[path = "postgres_store/managed_runs.rs"]
+mod managed_runs;
 #[path = "postgres_store/quota.rs"] mod quota;
 #[cfg(feature = "test-support")]
 #[path = "postgres_store/role_profiles.rs"]
@@ -133,6 +136,7 @@ const RUNTIME_EXECUTE_SIGNATURES: &[&str] = &[
 	"decodex.update_role_profile_exact(pg_catalog.text,pg_catalog.text,decodex.role_profile_role,pg_catalog.int8,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.text)",
 	"decodex.create_runtime_session_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,decodex.role_profile_role,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text,decodex.account_state,pg_catalog.int8,pg_catalog.uuid,decodex.runtime_session_state)",
 	"decodex.transition_runtime_session_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.int8,decodex.runtime_session_state)",
+	"decodex.apply_managed_run_safety_input_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,decodex.managed_run_safety_input_kind,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid)",
 ];
 const TRIGGER_ONLY_SIGNATURES: &[&str] = &[
 	"decodex.enforce_lease_operation_time()",
@@ -171,6 +175,12 @@ const TRIGGER_ONLY_SIGNATURES: &[&str] = &[
 	"decodex.enforce_runtime_session_command_owner()",
 	"decodex.forbid_runtime_snapshot_mutation()",
 	"decodex.enforce_runtime_session_event_namespace()",
+	"decodex.enforce_managed_run_command_owner()",
+	"decodex.forbid_managed_run_immutable_mutation()",
+	"decodex.enforce_managed_run_assignment_scope()",
+	"decodex.enforce_managed_run_state()",
+	"decodex.enforce_effect_barrier_state()",
+	"decodex.enforce_managed_run_event_namespace()",
 ];
 const INVALID_PROJECT_AGENT_SQL_CALLS: &[(&str, &str)] = &[
 	(

--- a/crates/decodex-postgres/tests/postgres_store.rs
+++ b/crates/decodex-postgres/tests/postgres_store.rs
@@ -7,6 +7,9 @@ mod role_profiles;
 #[cfg(feature = "test-support")]
 #[path = "postgres_store/runtime_sessions.rs"]
 mod runtime_sessions;
+#[cfg(feature = "test-support")]
+#[path = "postgres_store/work_items.rs"]
+mod work_items;
 
 use std::{
 	collections::{BTreeMap, HashSet},

--- a/crates/decodex-postgres/tests/postgres_store/managed_runs.rs
+++ b/crates/decodex-postgres/tests/postgres_store/managed_runs.rs
@@ -1,0 +1,1008 @@
+use std::time::Duration;
+
+use tokio::task::JoinSet;
+use tokio_postgres::{Client, NoTls, error::SqlState};
+
+use super::{expected_peer_uid, separated_configs, wait_for_any_blocked_by};
+use decodex_core::{
+	AgentId, ConversationId, ManagedRunId, ManagedRunSafetyInput, ProjectId, RuntimeSessionId,
+	RuntimeSessionState, SafetyObservationId, SubmittedTurnReceiptId, TurnId,
+	WorkItemCorrelationId, WorkItemId, WorkItemPriority, WorkItemProvenance,
+};
+use decodex_postgres::{
+	AccountId, AccountState, BootstrapRoleProfiles, CommandIdentity, CreateConversation,
+	CreateRuntimeSession, CreateRuntimeSessionAccountSnapshot, CreateWorkItem,
+	ManagedRunEffectBarrierState, ManagedRunSafetyOutcome, OutboxReconciliation, PostgresStore,
+	ManagedRunSafetyRejection, ReconciliationOutcome, RoleProfileCommandOutcome,
+	RoleProfileConfiguration, RoleProfileRole, RuntimeSessionCommandOutcome, WorkItemCommandOutcome,
+	WorkItemRelations,
+};
+
+const PROJECT_ID: &str = "22000000-0000-4000-8000-000000001338";
+const LEAD_ID: &str = "32000000-0000-4000-8000-000000001338";
+const OUTBOX_WORKER_ID: &str = "82000000-0000-4000-8000-000000001338";
+
+fn uuid(prefix: u8, marker: u8) -> String {
+	format!("{prefix:02}000000-0000-4000-8000-{marker:012}")
+}
+
+fn non_v4_turn_uuid(prefix: u8, marker: u8) -> String {
+	format!("{prefix:02}000000-0000-1000-8000-{marker:012}")
+}
+
+fn profile(role: &str) -> RoleProfileConfiguration {
+	RoleProfileConfiguration {
+		model: format!("gpt-5.6-{role}"),
+		reasoning_effort: "medium".into(),
+		service_tier: "priority".into(),
+		instructions: format!("Inert XY-1338 {role} fixture."),
+		provenance: Some("XY-1338 synthetic fixture".into()),
+	}
+}
+
+fn profiles() -> BootstrapRoleProfiles {
+	BootstrapRoleProfiles {
+		advisor: profile("advisor"),
+		lead: profile("lead"),
+		task: profile("task"),
+		reviewer: profile("reviewer"),
+	}
+}
+
+async fn create_project(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
+	client
+		.query_one(
+			"SELECT project_id FROM decodex.create_project(\
+		 $1::text::decodex.canonical_uuid_v4_text,$2,$3,$3,'{}'::jsonb,\
+		 $4::text::decodex.canonical_uuid_v4_text)",
+			&[&PROJECT_ID, &"xy-1338/managed-runs", &"/srv/xy-1338-managed-runs", &LEAD_ID],
+		)
+		.await?;
+	Ok(())
+}
+
+async fn create_session(
+	store: &PostgresStore,
+	marker: u8,
+	role: RoleProfileRole,
+) -> Result<RuntimeSessionId, Box<dyn std::error::Error>> {
+	let conversation_id = ConversationId::new(uuid(40, marker))?;
+	store
+		.create_conversation(
+			&CommandIdentity::new(format!("run-conversation-{marker}"), b"xy-1338")?,
+			&CreateConversation {
+				conversation_id: conversation_id.clone(),
+				title: format!("ManagedRun fixture {marker}"),
+			},
+		)
+		.await?;
+	let runtime_session_id = RuntimeSessionId::new(uuid(41, marker))?;
+	let create = CreateRuntimeSession {
+		runtime_session_id: runtime_session_id.clone(),
+		conversation_id,
+		role,
+		account_snapshot: CreateRuntimeSessionAccountSnapshot {
+			account_snapshot_id: uuid(43, marker),
+			source_account_id: AccountId::new(uuid(13, marker))?,
+			display_label: format!("ManagedRun account {marker}"),
+			observed_state: AccountState::Unknown,
+			source_revision: 1,
+		},
+		codex_thread_id: Some(uuid(44, marker)),
+		initial_state: RuntimeSessionState::Active,
+	};
+	assert!(matches!(
+		store.create_runtime_session(&format!("run-session-{marker}"), &create,).await?,
+		RuntimeSessionCommandOutcome::Success(_)
+	));
+	Ok(runtime_session_id)
+}
+
+fn work_item(marker: u8) -> Result<CreateWorkItem, Box<dyn std::error::Error>> {
+	Ok(CreateWorkItem {
+		work_item_id: WorkItemId::new(uuid(51, marker))?,
+		project_id: ProjectId::new(PROJECT_ID)?,
+		lead_agent_id: AgentId::new(LEAD_ID)?,
+		program_id: None,
+		relations: WorkItemRelations::default(),
+		title: format!("ManagedRun WorkItem {marker}"),
+		description: "Inert safety fixture.".into(),
+		priority: WorkItemPriority::High,
+		acceptance_criteria: vec!["Safety remains fail closed.".into()],
+		validation_criteria: vec!["No progress path exists.".into()],
+		provenance: WorkItemProvenance::new(
+			AgentId::new(LEAD_ID)?,
+			WorkItemCorrelationId::new(uuid(61, marker))?,
+			"XY-1338 fixture",
+		)?,
+	})
+}
+
+struct RunFixture {
+	managed_run_id: ManagedRunId,
+	work_item_id: WorkItemId,
+	runtime_session_id: RuntimeSessionId,
+}
+
+async fn create_run_fixture(
+	store: &PostgresStore,
+	owner: &Client,
+	marker: u8,
+) -> Result<RunFixture, Box<dyn std::error::Error>> {
+	let runtime_session_id = create_session(store, marker, RoleProfileRole::Task).await?;
+	let create_work_item = work_item(marker)?;
+	assert!(matches!(
+		store.create_work_item(&format!("run-work-item-{marker}"), &create_work_item,).await?,
+		WorkItemCommandOutcome::Success(_)
+	));
+	let managed_run_id = ManagedRunId::new(uuid(71, marker))?;
+	owner
+		.execute(
+			r#"INSERT INTO decodex.managed_runs(
+		 managed_run_id,project_id,work_item_id,runtime_session_id,runtime_session_revision,
+		 phase,wait_reason,created_at,updated_at) SELECT $1::text::uuid,$2::text::uuid,
+		 $3::text::uuid,$4::text::uuid,1,'execute','external',observed_at,observed_at
+		 FROM (SELECT pg_catalog.clock_timestamp() AS observed_at) AS observation"#,
+			&[
+				&managed_run_id.as_str(),
+				&PROJECT_ID,
+				&create_work_item.work_item_id.as_str(),
+				&runtime_session_id.as_str(),
+			],
+		)
+		.await?;
+	owner
+		.execute(
+			"INSERT INTO decodex.managed_run_assignments(\
+		 managed_run_id,project_id,runtime_session_id,role)\
+		 VALUES($1::text::uuid,$2::text::uuid,$3::text::uuid,'task')",
+			&[&managed_run_id.as_str(), &PROJECT_ID, &runtime_session_id.as_str()],
+		)
+		.await?;
+	owner
+		.execute(
+			"INSERT INTO decodex.managed_run_effect_barriers(\
+		 managed_run_id,project_id,work_item_id) VALUES($1::text::uuid,$2::text::uuid,$3::text::uuid)",
+			&[&managed_run_id.as_str(), &PROJECT_ID, &create_work_item.work_item_id.as_str()],
+		)
+		.await?;
+	owner
+		.execute(
+			"INSERT INTO decodex.managed_run_effects(\
+		 effect_id,managed_run_id,project_id,work_item_id,ordinal,kind,effect_key)\
+		 VALUES($1::text::uuid,$2::text::uuid,$3::text::uuid,$4::text::uuid,1,'git',$5)",
+			&[
+				&uuid(81, marker),
+				&managed_run_id.as_str(),
+				&PROJECT_ID,
+				&create_work_item.work_item_id.as_str(),
+				&format!("git/{marker}"),
+			],
+		)
+		.await?;
+	Ok(RunFixture {
+		managed_run_id,
+		work_item_id: create_work_item.work_item_id,
+		runtime_session_id,
+	})
+}
+
+async fn assert_unknown_turn_truth_table(
+	store: &PostgresStore,
+	owner: &Client,
+	runtime: &tokio_postgres::Config,
+	fixture: &RunFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let active_turn = uuid(91, 1);
+	let (runtime_client, runtime_connection) = runtime.connect(NoTls).await?;
+	let runtime_task = tokio::spawn(runtime_connection);
+	runtime_client
+		.execute(
+			"INSERT INTO decodex.turns(turn_id,conversation_id,runtime_session_id,sequence,role)\
+		 SELECT $1::text::uuid,conversation_id,runtime_session_id,1,'assistant'\
+		 FROM decodex.runtime_sessions WHERE runtime_session_id=$2::text::uuid",
+			&[&active_turn, &fixture.runtime_session_id.as_str()],
+		)
+		.await?;
+	let input = ManagedRunSafetyInput::PositivelyObservedUnknownTurn {
+		observation_id: SafetyObservationId::new(uuid(92, 1))?,
+		runtime_session_id: fixture.runtime_session_id.clone(),
+		turn_id: TurnId::new(non_v4_turn_uuid(93, 1))?,
+	};
+	owner.batch_execute("BEGIN").await?;
+	owner
+		.query_one(
+			"SELECT decodex.apply_managed_run_safety_input_exact(\
+		 'decodex/exact-command/1','rolled-back-input',$1::text::uuid,$2::text::uuid,1,\
+		 'positively_observed_unknown_turn',$3::text::uuid,$4::text::uuid,$5::text::uuid)",
+			&[
+				&fixture.managed_run_id.as_str(),
+				&PROJECT_ID,
+				&uuid(92, 1),
+				&fixture.runtime_session_id.as_str(),
+				&non_v4_turn_uuid(93, 1),
+			],
+		)
+		.await?;
+	owner.batch_execute("ROLLBACK").await?;
+	let first = store
+		.apply_managed_run_safety_input(
+			"unknown-turn-a",
+			&ProjectId::new(PROJECT_ID)?,
+			&fixture.managed_run_id,
+			1,
+			&input,
+		)
+		.await?;
+	let replay = store
+		.apply_managed_run_safety_input(
+			"unknown-turn-b",
+			&ProjectId::new(PROJECT_ID)?,
+			&fixture.managed_run_id,
+			1,
+			&input,
+		)
+		.await?;
+	assert_eq!(first, replay);
+	for (protocol, key, expected_revision) in [
+		("decodex/exact-command/1", "unknown-turn-changed-revision", 2_i64),
+		("decodex/exact-command/2", "unknown-turn-changed-protocol", 1_i64),
+	] {
+		let response: Vec<u8> = owner
+			.query_one(
+				"SELECT decodex.apply_managed_run_safety_input_exact(\
+			 $1,$2,$3::text::uuid,$4::text::uuid,$5,'positively_observed_unknown_turn',\
+			 $6::text::uuid,$7::text::uuid,$8::text::uuid)",
+				&[
+					&protocol,
+					&key,
+					&fixture.managed_run_id.as_str(),
+					&PROJECT_ID,
+					&expected_revision,
+					&uuid(92, 1),
+					&fixture.runtime_session_id.as_str(),
+					&non_v4_turn_uuid(93, 1),
+				],
+			)
+			.await?
+			.get(0);
+		let rejection: serde_json::Value = serde_json::from_slice(&response)?;
+		assert_eq!(rejection["classification"], "stable_domain_rejection");
+		assert_eq!(rejection["effect"]["reason"], "input_identity_conflict");
+	}
+	let ManagedRunSafetyOutcome::Success(effect) = first else { panic!("unknown turn rejected") };
+	assert!(effect.runtime_session_diverged);
+	assert!(effect.effect_barrier_closed_now);
+	let row = owner
+		.query_one(
+			r#"SELECT run.revision,run.diverged,session.state::text,session.revision,barrier.state::text,
+		 (SELECT count(*) FROM decodex.turns WHERE turn_id=$2::text::uuid AND status='active'),
+			 (SELECT count(*) FROM decodex.managed_run_safety_inputs WHERE managed_run_id=run.managed_run_id),
+			 (SELECT count(*) FROM decodex.exact_command_receipts WHERE idempotency_key IN
+			 ('unknown-turn-a','unknown-turn-b','unknown-turn-changed-revision',
+			 'unknown-turn-changed-protocol')),
+			 (SELECT count(*) FROM decodex.exact_command_receipts WHERE idempotency_key IN
+			 ('unknown-turn-a','unknown-turn-b') AND receipt_state='completed_success'
+			 AND outcome_class='success'),
+			 (SELECT count(*) FROM decodex.exact_command_receipts WHERE idempotency_key IN
+			 ('unknown-turn-changed-revision','unknown-turn-changed-protocol')
+			 AND receipt_state='completed_rejected' AND outcome_class='stable_domain_rejection'),
+			 (SELECT count(*) FROM decodex.managed_run_effects WHERE managed_run_id=run.managed_run_id),
+			 barrier.revision
+		 FROM decodex.managed_runs run JOIN decodex.runtime_sessions session
+		 ON session.runtime_session_id=run.runtime_session_id
+		 JOIN decodex.managed_run_effect_barriers barrier USING(managed_run_id)
+		 WHERE run.managed_run_id=$1::text::uuid"#,
+			&[&fixture.managed_run_id.as_str(), &active_turn],
+		)
+		.await?;
+	assert_eq!(row.get::<_, i64>(0), 2);
+	assert!(row.get::<_, bool>(1));
+	assert_eq!(row.get::<_, String>(2), "diverged");
+	assert_eq!(row.get::<_, i64>(3), 2);
+	assert_eq!(row.get::<_, String>(4), "closed");
+	assert_eq!(row.get::<_, i64>(5), 1);
+	assert_eq!(row.get::<_, i64>(6), 1);
+	assert_eq!(row.get::<_, i64>(7), 4);
+	assert_eq!(row.get::<_, i64>(8), 2);
+	assert_eq!(row.get::<_, i64>(9), 2);
+	assert_eq!(row.get::<_, i64>(10), 1);
+	assert_eq!(row.get::<_, i64>(11), 2);
+	drop(runtime_client);
+	runtime_task.await??;
+	Ok(())
+}
+
+async fn assert_unknown_turn_insert_serialization(
+	store: &PostgresStore,
+	owner: &Client,
+	runtime: &tokio_postgres::Config,
+	fixture: &RunFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let turn_id = uuid(94, 1);
+	let history_item_id = uuid(95, 1);
+	let observation_id = uuid(96, 1);
+	let (runtime_client, runtime_connection) = runtime.connect(NoTls).await?;
+	let runtime_task = tokio::spawn(runtime_connection);
+	let holder_pid: i32 = runtime_client.query_one("SELECT pg_backend_pid()", &[]).await?.get(0);
+
+	runtime_client.batch_execute("BEGIN").await?;
+	runtime_client
+		.execute(
+			r#"INSERT INTO decodex.turns(
+		 turn_id,conversation_id,runtime_session_id,sequence,role)
+		 SELECT $1::text::uuid,conversation_id,runtime_session_id,2,'assistant'
+		 FROM decodex.runtime_sessions WHERE runtime_session_id=$2::text::uuid"#,
+			&[&turn_id, &fixture.runtime_session_id.as_str()],
+		)
+		.await?;
+	runtime_client
+		.execute(
+			r#"INSERT INTO decodex.history_items(
+		 history_item_id,conversation_id,history_position,turn_id,ordinal,kind,status,
+		 inline_text,media_type)
+		 SELECT $1::text::uuid,conversation_id,1,$2::text::uuid,0,'message','completed',
+		 'runtime hierarchy fixture','text/plain'
+		 FROM decodex.runtime_sessions WHERE runtime_session_id=$3::text::uuid"#,
+			&[&history_item_id, &turn_id, &fixture.runtime_session_id.as_str()],
+		)
+		.await?;
+
+	let task_store = store.clone();
+	let managed_run_id = fixture.managed_run_id.clone();
+	let runtime_session_id = fixture.runtime_session_id.clone();
+	let safety_task = tokio::spawn(async move {
+		task_store
+			.apply_managed_run_safety_input(
+				"unknown-turn-concurrent-insert",
+				&ProjectId::new(PROJECT_ID).expect("fixture Project ID is canonical"),
+				&managed_run_id,
+				1,
+				&ManagedRunSafetyInput::PositivelyObservedUnknownTurn {
+					observation_id: SafetyObservationId::new(observation_id)
+						.expect("fixture observation ID is canonical"),
+					runtime_session_id,
+					turn_id: TurnId::new(turn_id).expect("fixture Turn ID is canonical"),
+				},
+			)
+			.await
+	});
+
+	assert!(
+		wait_for_any_blocked_by(owner, holder_pid).await?,
+		"ManagedRun safety waited on the hierarchy coordinator held by the Turn writer"
+	);
+	let run_scope_unheld: bool = owner
+		.query_one(
+			"SELECT pg_catalog.pg_try_advisory_xact_lock(1338,\
+			 pg_catalog.hashtext($1))",
+			&[&fixture.managed_run_id.as_str()],
+		)
+		.await?
+		.get(0);
+	assert!(run_scope_unheld, "safety acquired run scope before hierarchy authority");
+	runtime_client.batch_execute("COMMIT").await?;
+
+	let outcome = tokio::time::timeout(Duration::from_secs(2), safety_task).await???;
+	assert!(matches!(
+		outcome,
+		ManagedRunSafetyOutcome::Rejected(ManagedRunSafetyRejection::TurnAlreadyOwnedOrKnown)
+	));
+	let state = owner
+		.query_one(
+			r#"SELECT run.revision,barrier.state::text,
+		 (SELECT count(*) FROM decodex.managed_run_safety_inputs
+		  WHERE input_id=$2::text::uuid),receipt.receipt_state::text,receipt.outcome_class
+		 FROM decodex.managed_runs run
+		 JOIN decodex.managed_run_effect_barriers barrier USING(managed_run_id)
+		 JOIN decodex.exact_command_receipts receipt
+		  ON receipt.protocol_version='decodex/exact-command/1'
+		  AND receipt.idempotency_key='unknown-turn-concurrent-insert'
+		 WHERE run.managed_run_id=$1::text::uuid"#,
+			&[&fixture.managed_run_id.as_str(), &uuid(96, 1)],
+		)
+		.await?;
+	assert_eq!(state.get::<_, i64>(0), 1);
+	assert_eq!(state.get::<_, String>(1), "guarded");
+	assert_eq!(state.get::<_, i64>(2), 0);
+	assert_eq!(state.get::<_, String>(3), "completed_rejected");
+	assert_eq!(state.get::<_, String>(4), "stable_domain_rejection");
+
+	runtime_client.batch_execute("BEGIN ISOLATION LEVEL REPEATABLE READ").await?;
+	let turn_error = runtime_client
+		.execute(
+			r#"INSERT INTO decodex.turns(
+		 turn_id,conversation_id,runtime_session_id,sequence,role)
+		 SELECT $1::text::uuid,conversation_id,runtime_session_id,3,'assistant'
+		 FROM decodex.runtime_sessions WHERE runtime_session_id=$2::text::uuid"#,
+			&[&uuid(97, 1), &fixture.runtime_session_id.as_str()],
+		)
+		.await
+		.expect_err("non-READ-COMMITTED Turn write must fail closed");
+	assert_eq!(turn_error.code(), Some(&SqlState::T_R_SERIALIZATION_FAILURE));
+	runtime_client.batch_execute("ROLLBACK").await?;
+
+	runtime_client.batch_execute("BEGIN ISOLATION LEVEL SERIALIZABLE").await?;
+	let history_error = runtime_client
+		.execute(
+			r#"INSERT INTO decodex.history_items(
+		 history_item_id,conversation_id,history_position,turn_id,ordinal,kind,status,
+		 inline_text,media_type)
+		 SELECT $1::text::uuid,conversation_id,2,$2::text::uuid,1,'message','completed',
+		 'unsupported isolation fixture','text/plain'
+		 FROM decodex.runtime_sessions WHERE runtime_session_id=$3::text::uuid"#,
+			&[&uuid(98, 1), &uuid(94, 1), &fixture.runtime_session_id.as_str()],
+		)
+		.await
+		.expect_err("non-READ-COMMITTED HistoryItem write must fail closed");
+	assert_eq!(history_error.code(), Some(&SqlState::T_R_SERIALIZATION_FAILURE));
+	runtime_client.batch_execute("ROLLBACK").await?;
+
+	drop(runtime_client);
+	runtime_task.await??;
+	Ok(())
+}
+
+async fn assert_receipt_case(
+	store: &PostgresStore,
+	owner: &Client,
+	fixture: &RunFixture,
+	marker: u8,
+	receipt_revision: i64,
+	expected_stale: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let receipt_id = SubmittedTurnReceiptId::new(uuid(82, marker))?;
+	let turn_id = TurnId::new(non_v4_turn_uuid(83, marker))?;
+	owner.execute(
+		"INSERT INTO decodex.managed_run_submitted_turn_receipts(\
+		 receipt_id,managed_run_id,project_id,runtime_session_id,runtime_session_revision,turn_id,submitted_at)\
+		 VALUES($1::text::uuid,$2::text::uuid,$3::text::uuid,$4::text::uuid,$5,$6::text::uuid,\
+		 pg_catalog.clock_timestamp())",
+		&[&receipt_id.as_str(), &fixture.managed_run_id.as_str(), &PROJECT_ID,
+			&fixture.runtime_session_id.as_str(), &receipt_revision, &turn_id.as_str()],
+	).await?;
+	let outcome = store
+		.apply_managed_run_safety_input(
+			&format!("submitted-receipt-{marker}"),
+			&ProjectId::new(PROJECT_ID)?,
+			&fixture.managed_run_id,
+			1,
+			&ManagedRunSafetyInput::SubmittedTurnReceipt {
+				receipt_id,
+				runtime_session_id: fixture.runtime_session_id.clone(),
+				turn_id,
+			},
+		)
+		.await?;
+	let ManagedRunSafetyOutcome::Success(effect) = outcome else { panic!("receipt rejected") };
+	assert_eq!(effect.stale_receipt, expected_stale);
+	assert!(!effect.runtime_session_diverged);
+	assert!(effect.effect_barrier_closed_now);
+	Ok(())
+}
+
+async fn assert_inconclusive_case(
+	store: &PostgresStore,
+	fixture: &RunFixture,
+	marker: u8,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let outcome = store
+		.apply_managed_run_safety_input(
+			&format!("inconclusive-{marker}"),
+			&ProjectId::new(PROJECT_ID)?,
+			&fixture.managed_run_id,
+			1,
+			&ManagedRunSafetyInput::InconclusiveObservation {
+				observation_id: SafetyObservationId::new(uuid(84, marker))?,
+				runtime_session_id: fixture.runtime_session_id.clone(),
+			},
+		)
+		.await?;
+	let ManagedRunSafetyOutcome::Success(effect) = outcome else { panic!("inconclusive rejected") };
+	assert!(!effect.runtime_session_diverged);
+	assert!(!effect.stale_receipt);
+	assert!(effect.managed_run_blocked);
+	Ok(())
+}
+
+async fn assert_fk_and_role_scope(
+	owner: &Client,
+	fixture: &RunFixture,
+	lead_session_id: &RuntimeSessionId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	assert!(
+		owner
+			.execute(
+				"INSERT INTO decodex.managed_run_effects(\
+		 effect_id,managed_run_id,project_id,work_item_id,ordinal,kind,effect_key)\
+		 VALUES($1::text::uuid,$2::text::uuid,$3::text::uuid,$4::text::uuid,2,'tool','cross-scope')",
+				&[
+					&uuid(85, 1),
+					&fixture.managed_run_id.as_str(),
+					&uuid(22, 99),
+					&fixture.work_item_id.as_str()
+				],
+			)
+			.await
+			.is_err()
+	);
+	assert!(
+		owner
+			.execute(
+				"INSERT INTO decodex.managed_run_assignments(\
+		 managed_run_id,project_id,runtime_session_id,role)\
+		 VALUES($1::text::uuid,$2::text::uuid,$3::text::uuid,'reviewer')",
+				&[&fixture.managed_run_id.as_str(), &PROJECT_ID, &lead_session_id.as_str()],
+			)
+			.await
+			.is_err()
+	);
+	Ok(())
+}
+
+async fn assert_namespace_rejected(
+	runtime: &Client,
+	statement: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let error = runtime
+		.batch_execute(statement)
+		.await
+		.expect_err("ManagedRun-linked activity/outbox authority must reject the runtime role");
+	let database = error.as_db_error().ok_or("namespace rejection was not a database error")?;
+	assert_eq!(database.code(), &SqlState::INSUFFICIENT_PRIVILEGE);
+	assert_eq!(database.constraint(), Some("managed_run_event_namespace"));
+	Ok(())
+}
+
+struct EventNamespaceFixture {
+	protected_activity: i64,
+	protected_outbox: i64,
+	generic_outbox: i64,
+}
+
+async fn create_event_namespace_fixture(
+	owner: &Client,
+	fixture: &RunFixture,
+) -> Result<EventNamespaceFixture, Box<dyn std::error::Error>> {
+	let protected_activity: i64 = owner
+		.query_one(
+			"INSERT INTO decodex.activity(aggregate_kind,aggregate_id,revision,event_kind,\
+			 correlation_key,payload) VALUES('managed_run',$1::text,1,'managed_run_safety_recorded',\
+			 'xy-1338-namespace-owner',jsonb_build_object('managed_run_id',$1::text)) RETURNING sequence",
+			&[&fixture.managed_run_id.as_str()],
+		)
+		.await?
+		.get(0);
+	let protected_outbox: i64 = owner
+		.query_one(
+			"INSERT INTO decodex.outbox(effect_key,aggregate_kind,aggregate_id,\
+		 aggregate_revision,payload,available_at) VALUES('xy-1338-protected-delivery','generic',\
+			 'linked-managed-run',1,jsonb_build_object('nested',jsonb_build_object(\
+			 'activity_sequence',$1::bigint)),clock_timestamp()+interval '1 hour') RETURNING id",
+			&[&protected_activity],
+		)
+		.await?
+		.get(0);
+	let generic_outbox: i64 = owner
+		.query_one(
+			"INSERT INTO decodex.outbox(effect_key,aggregate_kind,aggregate_id,\
+		 aggregate_revision,payload,available_at) VALUES('xy-1338-generic-delivery','generic',\
+		 'generic',1,'{\"fixture\":\"generic\"}',clock_timestamp()+interval '1 hour') RETURNING id",
+			&[],
+		)
+		.await?
+		.get(0);
+	Ok(EventNamespaceFixture { protected_activity, protected_outbox, generic_outbox })
+}
+
+async fn assert_event_namespace_insert_rejections(
+	runtime: &Client,
+	fixture: &RunFixture,
+	namespace: &EventNamespaceFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+	assert_namespace_rejected(
+		runtime,
+		&format!(
+			"INSERT INTO decodex.activity(aggregate_kind,aggregate_id,revision,event_kind,\
+			 correlation_key,payload) VALUES('managed_run','{}',1,'managed_run_injected',\
+			 'xy-1338-namespace-new','{{}}')",
+			fixture.managed_run_id.as_str(),
+		),
+	)
+	.await?;
+	assert_namespace_rejected(
+		runtime,
+		&format!(
+			"INSERT INTO decodex.outbox(effect_key,aggregate_kind,aggregate_id,\
+			 aggregate_revision,payload) VALUES('xy-1338-linked-injected','generic','generic',1,\
+			 '{{\"nested\":{{\"activity_sequence\":{}}}}}')",
+			namespace.protected_activity,
+		),
+	)
+	.await?;
+	assert_namespace_rejected(
+		runtime,
+		"INSERT INTO decodex.outbox(effect_key,aggregate_kind,aggregate_id,aggregate_revision,payload) \
+		 VALUES('xy-1338-malformed-link','generic','generic',1,\
+		 '{\"activity_sequence\":\"malformed\"}')",
+	)
+	.await?;
+	assert_namespace_rejected(
+		runtime,
+		"INSERT INTO decodex.outbox(effect_key,aggregate_kind,aggregate_id,aggregate_revision,payload) \
+		 VALUES('xy-1338-overflow-link','generic','generic',1,\
+		 '{\"activity_sequence\":999999999999999999999999999999}')",
+	)
+	.await?;
+	Ok(())
+}
+
+async fn assert_event_namespace_update_rejections(
+	owner: &Client,
+	runtime: &Client,
+	runtime_config: &tokio_postgres::Config,
+	fixture: &RunFixture,
+	namespace: &EventNamespaceFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+	assert_namespace_rejected(
+		runtime,
+		&format!(
+			"UPDATE decodex.outbox SET aggregate_id='rewritten' WHERE id={}",
+			namespace.protected_outbox,
+		),
+	)
+	.await?;
+	assert_namespace_rejected(
+		runtime,
+		&format!(
+			"UPDATE decodex.outbox SET aggregate_kind='generic',payload='{{}}' WHERE id={}",
+			namespace.protected_outbox,
+		),
+	)
+	.await?;
+	assert_namespace_rejected(
+		runtime,
+		&format!(
+			"UPDATE decodex.outbox SET aggregate_kind='managed_run',aggregate_id='{}' \
+			 WHERE id={}",
+			fixture.managed_run_id.as_str(),
+			namespace.generic_outbox,
+		),
+	)
+	.await?;
+
+	let runtime_role = runtime_config.get_user().ok_or("runtime role is absent")?;
+	owner
+		.batch_execute(&format!(
+			"ALTER TABLE decodex.activity DISABLE TRIGGER activity_append_only; \
+			 GRANT UPDATE ON decodex.activity TO {runtime_role}"
+		))
+		.await?;
+	let old_activity_result = assert_namespace_rejected(
+		runtime,
+		&format!(
+			"UPDATE decodex.activity SET aggregate_kind='generic',event_kind='generic_recorded',\
+			 payload='{{}}' WHERE sequence={}",
+			namespace.protected_activity,
+		),
+	)
+	.await;
+	owner
+		.batch_execute(&format!(
+			"REVOKE UPDATE ON decodex.activity FROM {runtime_role}; \
+			 ALTER TABLE decodex.activity ENABLE TRIGGER activity_append_only"
+		))
+		.await?;
+	old_activity_result?;
+	Ok(())
+}
+
+async fn deliver_protected_outbox(
+	store: &PostgresStore,
+	owner: &Client,
+	fixture: &RunFixture,
+	protected_outbox: i64,
+) -> Result<(), Box<dyn std::error::Error>> {
+	owner
+		.execute(
+			"UPDATE decodex.outbox SET available_at=CASE WHEN id=$1 THEN clock_timestamp()\
+		 ELSE clock_timestamp()+interval '1 hour' END WHERE state='pending'",
+			&[&protected_outbox],
+		)
+		.await?;
+	let claim = store
+		.claim_outbox(OUTBOX_WORKER_ID, 1, Duration::from_secs(5))
+		.await?
+		.pop()
+		.ok_or("protected ManagedRun outbox row was not claimable")?;
+	assert_eq!(claim.id, protected_outbox);
+	store.begin_outbox_effect(claim.id, OUTBOX_WORKER_ID, &claim.claim_token).await?;
+	store
+		.record_outbox_receipt(
+			claim.id,
+			OUTBOX_WORKER_ID,
+			&claim.claim_token,
+			&serde_json::json!({"provider_receipt": "xy-1338"}),
+		)
+		.await?;
+	store
+		.reconcile_outbox(
+			claim.id,
+			OUTBOX_WORKER_ID,
+			&claim.claim_token,
+			&OutboxReconciliation {
+				readback: serde_json::json!({"managed_run_id": fixture.managed_run_id.as_str()}),
+				outcome: ReconciliationOutcome::EffectPresent,
+			},
+			Duration::from_millis(1),
+			Duration::from_secs(1),
+		)
+		.await?;
+	assert_eq!(
+		owner
+			.query_one("SELECT state::text FROM decodex.outbox WHERE id=$1", &[&protected_outbox])
+			.await?
+			.get::<_, String>(0),
+		"delivered",
+	);
+	Ok(())
+}
+
+async fn assert_event_namespace_contract(
+	store: &PostgresStore,
+	owner: &Client,
+	runtime_config: &tokio_postgres::Config,
+	fixture: &RunFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let namespace = create_event_namespace_fixture(owner, fixture).await?;
+	let (runtime, runtime_connection) = runtime_config.connect(NoTls).await?;
+	let runtime_task = tokio::spawn(runtime_connection);
+	assert_event_namespace_insert_rejections(&runtime, fixture, &namespace).await?;
+	assert_event_namespace_update_rejections(owner, &runtime, runtime_config, fixture, &namespace)
+		.await?;
+	deliver_protected_outbox(store, owner, fixture, namespace.protected_outbox).await?;
+	drop(runtime);
+	runtime_task.await??;
+	Ok(())
+}
+
+fn inconclusive_input(
+	fixture: &RunFixture,
+	marker: u8,
+) -> Result<ManagedRunSafetyInput, Box<dyn std::error::Error>> {
+	Ok(ManagedRunSafetyInput::InconclusiveObservation {
+		observation_id: SafetyObservationId::new(uuid(86, marker))?,
+		runtime_session_id: fixture.runtime_session_id.clone(),
+	})
+}
+
+async fn apply_inconclusive_exact(
+	client: &Client,
+	key: &str,
+	fixture: &RunFixture,
+	marker: u8,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+	Ok(client
+		.query_one(
+			"SELECT decodex.apply_managed_run_safety_input_exact(\
+		 'decodex/exact-command/1',$1,$2::text::uuid,$3::text::uuid,1,\
+		 'inconclusive_observation',$4::text::uuid,$5::text::uuid,NULL::uuid)",
+			&[
+				&key,
+				&fixture.managed_run_id.as_str(),
+				&PROJECT_ID,
+				&uuid(86, marker),
+				&fixture.runtime_session_id.as_str(),
+			],
+		)
+		.await?
+		.get(0))
+}
+
+async fn assert_single_safety_application(
+	owner: &Client,
+	fixture: &RunFixture,
+	key: &str,
+	marker: u8,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let state = owner
+		.query_one(
+			r#"SELECT run.revision,barrier.revision,barrier.closure_input_id::text,
+		 (SELECT count(*) FROM decodex.managed_run_safety_inputs input
+		  WHERE input.managed_run_id=run.managed_run_id),
+		 (SELECT count(*) FROM decodex.exact_command_receipts WHERE idempotency_key=$2),
+		 (SELECT count(*) FROM decodex.managed_run_effects effect
+		  WHERE effect.managed_run_id=run.managed_run_id)
+		 FROM decodex.managed_runs run JOIN decodex.managed_run_effect_barriers barrier
+		 USING(managed_run_id) WHERE run.managed_run_id=$1::text::uuid"#,
+			&[&fixture.managed_run_id.as_str(), &key],
+		)
+		.await?;
+	assert_eq!(state.get::<_, i64>(0), 2);
+	assert_eq!(state.get::<_, i64>(1), 2);
+	assert_eq!(state.get::<_, String>(2), uuid(86, marker));
+	assert_eq!(state.get::<_, i64>(3), 1);
+	assert_eq!(state.get::<_, i64>(4), 1);
+	assert_eq!(state.get::<_, i64>(5), 1);
+	Ok(())
+}
+
+async fn assert_precommit_connection_loss_retry(
+	store: &PostgresStore,
+	owner: &Client,
+	migration: &tokio_postgres::Config,
+	fixture: &RunFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let (precommit_client, precommit_connection) = migration.connect(NoTls).await?;
+	let precommit_task = tokio::spawn(precommit_connection);
+	precommit_client.batch_execute("BEGIN").await?;
+	let _lost_before_commit =
+		apply_inconclusive_exact(&precommit_client, "managed-run-precommit-retry", fixture, 5)
+			.await?;
+	drop(precommit_client);
+	precommit_task.await??;
+	assert!(matches!(
+		store
+			.apply_managed_run_safety_input(
+				"managed-run-precommit-retry",
+				&ProjectId::new(PROJECT_ID)?,
+				&fixture.managed_run_id,
+				1,
+				&inconclusive_input(fixture, 5)?,
+			)
+			.await?,
+		ManagedRunSafetyOutcome::Success(_)
+	));
+	assert_single_safety_application(owner, fixture, "managed-run-precommit-retry", 5).await?;
+	Ok(())
+}
+
+async fn assert_postcommit_lost_result_replay(
+	store: &PostgresStore,
+	owner: &Client,
+	migration: &tokio_postgres::Config,
+	fixture: &RunFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let (postcommit_client, postcommit_connection) = migration.connect(NoTls).await?;
+	let postcommit_task = tokio::spawn(postcommit_connection);
+	postcommit_client.batch_execute("BEGIN").await?;
+	let lost_after_commit =
+		apply_inconclusive_exact(&postcommit_client, "managed-run-postcommit-replay", fixture, 6)
+			.await?;
+	postcommit_client.batch_execute("COMMIT").await?;
+	drop(postcommit_client);
+	postcommit_task.await??;
+	assert!(matches!(
+		store
+			.apply_managed_run_safety_input(
+				"managed-run-postcommit-replay",
+				&ProjectId::new(PROJECT_ID)?,
+				&fixture.managed_run_id,
+				1,
+				&inconclusive_input(fixture, 6)?,
+			)
+			.await?,
+		ManagedRunSafetyOutcome::Success(_)
+	));
+	assert_eq!(
+		owner
+			.query_one(
+				r#"SELECT response_bytes FROM decodex.exact_command_receipts
+			 WHERE protocol_version='decodex/exact-command/1'
+			 AND idempotency_key='managed-run-postcommit-replay'"#,
+				&[],
+			)
+			.await?
+			.get::<_, Vec<u8>>(0),
+		lost_after_commit,
+	);
+	assert_single_safety_application(owner, fixture, "managed-run-postcommit-replay", 6).await?;
+	Ok(())
+}
+
+async fn assert_concurrent_identical_retries(
+	store: &PostgresStore,
+	owner: &Client,
+	fixture: &RunFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let input = inconclusive_input(fixture, 7)?;
+	let mut retries = JoinSet::new();
+	for _ in 0..2 {
+		let store = store.clone();
+		let input = input.clone();
+		let managed_run_id = fixture.managed_run_id.clone();
+		retries.spawn(async move {
+			store
+				.apply_managed_run_safety_input(
+					"managed-run-concurrent-retry",
+					&ProjectId::new(PROJECT_ID).expect("fixture Project ID is canonical"),
+					&managed_run_id,
+					1,
+					&input,
+				)
+				.await
+		});
+	}
+	let mut outcome = None;
+	while let Some(result) = retries.join_next().await {
+		let current = result??;
+		assert!(matches!(current, ManagedRunSafetyOutcome::Success(_)));
+		if let Some(expected) = &outcome {
+			assert_eq!(&current, expected);
+		} else {
+			outcome = Some(current);
+		}
+	}
+	assert_single_safety_application(owner, fixture, "managed-run-concurrent-retry", 7).await?;
+	Ok(())
+}
+
+async fn assert_crash_retry_contract(
+	store: &PostgresStore,
+	owner: &Client,
+	migration: &tokio_postgres::Config,
+	precommit: &RunFixture,
+	postcommit: &RunFixture,
+	concurrent: &RunFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+	assert_precommit_connection_loss_retry(store, owner, migration, precommit).await?;
+	assert_postcommit_lost_result_replay(store, owner, migration, postcommit).await?;
+	assert_concurrent_identical_retries(store, owner, concurrent).await?;
+	Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires an isolated PostgreSQL 18 V12 ManagedRun database"]
+async fn postgres_managed_run_safety_contract() -> Result<(), Box<dyn std::error::Error>> {
+	let (migration, runtime) = separated_configs("DECODEX_TEST")?;
+	let store =
+		PostgresStore::connect(migration.clone(), runtime.clone(), expected_peer_uid()).await?;
+	let (owner, connection) = migration.connect(NoTls).await?;
+	let owner_task = tokio::spawn(connection);
+	create_project(&owner).await?;
+	assert!(matches!(
+		store.bootstrap_role_profiles("managed-run-profiles", &profiles()).await?,
+		RoleProfileCommandOutcome::Success(_)
+	));
+	let unknown = create_run_fixture(&store, &owner, 1).await?;
+	let current = create_run_fixture(&store, &owner, 2).await?;
+	let stale = create_run_fixture(&store, &owner, 3).await?;
+	let inconclusive = create_run_fixture(&store, &owner, 4).await?;
+	let precommit = create_run_fixture(&store, &owner, 5).await?;
+	let postcommit = create_run_fixture(&store, &owner, 6).await?;
+	let concurrent = create_run_fixture(&store, &owner, 7).await?;
+	let lead_session_id = create_session(&store, 9, RoleProfileRole::Lead).await?;
+	assert_unknown_turn_insert_serialization(&store, &owner, &runtime, &unknown).await?;
+	assert_unknown_turn_truth_table(&store, &owner, &runtime, &unknown).await?;
+	assert_receipt_case(&store, &owner, &current, 2, 1, false).await?;
+	assert_receipt_case(&store, &owner, &stale, 3, 99, true).await?;
+	assert_inconclusive_case(&store, &inconclusive, 4).await?;
+	assert_fk_and_role_scope(&owner, &unknown, &lead_session_id).await?;
+	assert_event_namespace_contract(&store, &owner, &runtime, &unknown).await?;
+	assert_crash_retry_contract(&store, &owner, &migration, &precommit, &postcommit, &concurrent)
+		.await?;
+	let readback = store
+		.read_managed_run_exact(&ProjectId::new(PROJECT_ID)?, &unknown.managed_run_id, 2)
+		.await?;
+	assert!(readback.diverged && readback.blocked);
+	assert_eq!(readback.assignments.len(), 1);
+	assert_eq!(readback.effects.len(), 1);
+	assert_eq!(readback.barrier.state, ManagedRunEffectBarrierState::Closed);
+	drop(owner);
+	owner_task.await??;
+	Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a restored PostgreSQL 18 V12 ManagedRun database"]
+async fn postgres_managed_run_safety_restore() -> Result<(), Box<dyn std::error::Error>> {
+	let (migration, runtime) = separated_configs("DECODEX_TEST")?;
+	let store = PostgresStore::connect(migration, runtime, expected_peer_uid()).await?;
+	let readback = store
+		.read_managed_run_exact(&ProjectId::new(PROJECT_ID)?, &ManagedRunId::new(uuid(71, 1))?, 2)
+		.await?;
+	assert!(readback.diverged && readback.blocked);
+	assert_eq!(readback.runtime_session_state, RuntimeSessionState::Diverged);
+	assert_eq!(readback.barrier.state, ManagedRunEffectBarrierState::Closed);
+	Ok(())
+}

--- a/crates/decodex-postgres/tests/postgres_store/runtime_sessions.rs
+++ b/crates/decodex-postgres/tests/postgres_store/runtime_sessions.rs
@@ -774,7 +774,7 @@ async fn postgres_v10_fences_blocked_old_runtime_writer() -> Result<(), Box<dyn 
 	assert_eq!(error.code().map(|code| code.code()), Some("42501"));
 	let fenced: bool = admin
 		.query_one(
-			"SELECT (SELECT max(version)=10 FROM public.refinery_schema_history) \
+			"SELECT (SELECT max(version)=11 FROM public.refinery_schema_history) \
 			 AND NOT EXISTS (SELECT 1 FROM decodex.profile_snapshots)",
 			&[],
 		)
@@ -880,7 +880,7 @@ async fn postgres_exact_runtime_session_restore() -> Result<(), Box<dyn std::err
 	let valid: bool = client
 		.query_one(
 			"SELECT \
-			 (SELECT max(version)=10 FROM public.refinery_schema_history) AND \
+			 (SELECT max(version)=11 FROM public.refinery_schema_history) AND \
 			 NOT EXISTS (SELECT 1 FROM decodex.exact_command_receipts \
 			  WHERE receipt_state='executing' OR response_bytes IS NULL \
 			  OR convert_from(response_bytes,'UTF8')::jsonb->'effect' IS DISTINCT FROM effect_envelope) AND \

--- a/crates/decodex-postgres/tests/postgres_store/work_items.rs
+++ b/crates/decodex-postgres/tests/postgres_store/work_items.rs
@@ -1,0 +1,687 @@
+use std::time::Duration;
+
+use tokio::task::JoinSet;
+use tokio_postgres::{NoTls, error::SqlState};
+
+use super::{expected_peer_uid, separated_configs};
+use decodex_core::{
+	AgentId, ProjectId, WorkItemCorrelationId, WorkItemId, WorkItemPriority, WorkItemProvenance,
+	WorkItemState,
+};
+use decodex_postgres::{
+	AcceptWorkItem, CreateWorkItem, OutboxReconciliation, PostgresStore, ReconciliationOutcome,
+	UpdateWorkItem, WorkItemCommandOutcome, WorkItemReadinessBlockerKind, WorkItemRejection,
+	WorkItemRelations,
+};
+
+const PROJECT_ID: &str = "21000000-0000-4000-8000-000000001343";
+const LEAD_ID: &str = "31000000-0000-4000-8000-000000001343";
+const OUTBOX_WORKER_ID: &str = "81000000-0000-4000-8000-000000001343";
+
+fn work_item_id(value: u8) -> WorkItemId {
+	WorkItemId::new(format!("51000000-0000-4000-8000-{value:012}"))
+		.expect("fixture WorkItem ID is canonical")
+}
+
+fn provenance(value: u8) -> WorkItemProvenance {
+	WorkItemProvenance::new(
+		AgentId::new(LEAD_ID).expect("fixture Lead ID is canonical"),
+		WorkItemCorrelationId::new(format!("61000000-0000-4000-8000-{value:012}"))
+			.expect("fixture correlation ID is canonical"),
+		format!("XY-1343 WorkItem fixture {value}"),
+	)
+	.expect("fixture provenance is bounded")
+}
+
+fn create(value: u8, relations: WorkItemRelations) -> CreateWorkItem {
+	CreateWorkItem {
+		work_item_id: work_item_id(value),
+		project_id: ProjectId::new(PROJECT_ID).expect("fixture Project ID is canonical"),
+		lead_agent_id: AgentId::new(LEAD_ID).expect("fixture Lead ID is canonical"),
+		program_id: None,
+		relations,
+		title: format!("WorkItem {value}"),
+		description: "Transactional PostgreSQL WorkItem authority fixture.".into(),
+		priority: WorkItemPriority::High,
+		acceptance_criteria: vec!["Canonical state is persisted.".into()],
+		validation_criteria: vec!["Exact effects are auditable.".into()],
+		provenance: provenance(value),
+	}
+}
+
+fn update(
+	value: u8,
+	expected_revision: u64,
+	target_state: WorkItemState,
+	relations: WorkItemRelations,
+) -> UpdateWorkItem {
+	let created = create(value, relations.clone());
+	UpdateWorkItem {
+		work_item_id: created.work_item_id,
+		project_id: created.project_id,
+		expected_revision,
+		program_id: None,
+		relations,
+		title: created.title,
+		description: created.description,
+		priority: created.priority,
+		acceptance_criteria: created.acceptance_criteria,
+		validation_criteria: created.validation_criteria,
+		target_state,
+		provenance: provenance(value.saturating_add(20)),
+	}
+}
+
+async fn create_project(
+	migration: &tokio_postgres::Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let (client, connection) = migration.connect(NoTls).await?;
+	let task = tokio::spawn(connection);
+	client
+		.query_one(
+			"SELECT project_id FROM decodex.create_project(\
+			 $1::text::decodex.canonical_uuid_v4_text,$2,$3,$3,'{}'::jsonb,\
+			 $4::text::decodex.canonical_uuid_v4_text)",
+			&[&PROJECT_ID, &"xy-1343/work-items", &"/srv/xy-1343-work-items", &LEAD_ID],
+		)
+		.await?;
+	drop(client);
+	task.await??;
+	Ok(())
+}
+
+fn success(outcome: WorkItemCommandOutcome) -> Box<decodex_postgres::WorkItemCommandEffect> {
+	match outcome {
+		WorkItemCommandOutcome::Success(effect) => effect,
+		WorkItemCommandOutcome::Rejected(rejection) => {
+			panic!("unexpected rejection: {rejection:?}")
+		},
+	}
+}
+
+fn postgres_error_diagnostic(error: &tokio_postgres::Error) -> serde_json::Value {
+	let database_error = error.as_db_error();
+	serde_json::json!({
+		"sqlstate": database_error.map(|error| error.code().code()),
+		"message": database_error.map_or_else(|| error.to_string(), |error| error.message().into()),
+		"constraint": database_error.and_then(|error| error.constraint()),
+		"schema": database_error.and_then(|error| error.schema()),
+		"table": database_error.and_then(|error| error.table()),
+		"column": database_error.and_then(|error| error.column()),
+		"detail": database_error.and_then(|error| error.detail()),
+		"hint": database_error.and_then(|error| error.hint()),
+		"where_context": database_error.and_then(|error| error.where_()),
+	})
+}
+
+async fn exercise_outbox_authority_case(
+	runtime: &tokio_postgres::Config,
+	label: &str,
+	sql: &str,
+) -> (bool, serde_json::Value) {
+	let mut begin_status = "not_attempted".to_owned();
+	let mut begin_error = serde_json::Value::Null;
+	let mut execution_outcome = "not_attempted".to_owned();
+	let mut execution_error = serde_json::Value::Null;
+	let mut execution_matches = false;
+	let mut rollback_status = "not_attempted".to_owned();
+	let mut rollback_error = serde_json::Value::Null;
+	let (connection_completion_status, connection_error) = match runtime.connect(NoTls).await {
+		Err(error) => {
+			("connect_failed".to_owned(), postgres_error_diagnostic(&error))
+		}
+		Ok((client, connection)) => {
+			let connection_task = tokio::spawn(connection);
+			match client.batch_execute("BEGIN").await {
+				Ok(()) => begin_status = "began".into(),
+				Err(error) => {
+					begin_status = "begin_failed".into();
+					begin_error = postgres_error_diagnostic(&error);
+				}
+			}
+			if begin_status == "began" {
+				match client.batch_execute(sql).await {
+					Ok(()) => execution_outcome = "unexpected_success".into(),
+					Err(error) => {
+						execution_outcome = if error.as_db_error().is_some() {
+							"server_error".into()
+						} else {
+							"non_database_error".into()
+						};
+						execution_matches = error.as_db_error().is_some_and(|error| {
+							error.code() == &SqlState::INSUFFICIENT_PRIVILEGE
+								&& error.constraint() == Some("work_item_event_namespace")
+						});
+						execution_error = postgres_error_diagnostic(&error);
+					}
+				}
+			}
+			match client.batch_execute("ROLLBACK").await {
+				Ok(()) => rollback_status = "rolled_back".into(),
+				Err(error) => {
+					rollback_status = "rollback_failed".into();
+					rollback_error = postgres_error_diagnostic(&error);
+				}
+			}
+			drop(client);
+			match connection_task.await {
+				Ok(Ok(())) => ("completed".to_owned(), serde_json::Value::Null),
+				Ok(Err(error)) =>
+					("connection_failed".to_owned(), postgres_error_diagnostic(&error)),
+				Err(error) => (
+					"connection_task_failed".to_owned(),
+					serde_json::json!({"message": error.to_string()}),
+				),
+			}
+		}
+	};
+
+	let matched = begin_status == "began"
+		&& execution_outcome == "server_error"
+		&& execution_matches
+		&& rollback_status == "rolled_back"
+		&& connection_completion_status == "completed";
+	let diagnostic = serde_json::json!({
+		"label": label,
+		"sql": sql,
+		"assignment": sql.split_once(" SET ").map(|(_, tail)| tail),
+		"execution_outcome": execution_outcome,
+		"sqlstate": execution_error.get("sqlstate").cloned().unwrap_or(serde_json::Value::Null),
+		"message": execution_error.get("message").cloned().unwrap_or(serde_json::Value::Null),
+		"constraint": execution_error.get("constraint").cloned().unwrap_or(serde_json::Value::Null),
+		"schema": execution_error.get("schema").cloned().unwrap_or(serde_json::Value::Null),
+		"table": execution_error.get("table").cloned().unwrap_or(serde_json::Value::Null),
+		"column": execution_error.get("column").cloned().unwrap_or(serde_json::Value::Null),
+		"detail": execution_error.get("detail").cloned().unwrap_or(serde_json::Value::Null),
+		"hint": execution_error.get("hint").cloned().unwrap_or(serde_json::Value::Null),
+		"where_context": execution_error.get("where_context").cloned().unwrap_or(serde_json::Value::Null),
+		"transaction_begin_status": begin_status,
+		"transaction_begin_error": begin_error,
+		"rollback_status": rollback_status,
+		"rollback_error": rollback_error,
+		"connection_completion_status": connection_completion_status,
+		"connection_error": connection_error,
+		"matches_expected_authority_failure": matched,
+	});
+	(matched, diagnostic)
+}
+
+async fn deliver_work_item_outbox(
+	store: &PostgresStore,
+	owner: &tokio_postgres::Client,
+) -> Result<i64, Box<dyn std::error::Error>> {
+	let protected_id = owner
+		.query_one(
+			"SELECT min(id) FROM decodex.outbox WHERE aggregate_kind='work_item'",
+			&[],
+		)
+		.await?
+		.get::<_, Option<i64>>(0)
+		.expect("WorkItem command must emit an outbox row");
+	owner
+		.execute(
+			"UPDATE decodex.outbox SET available_at = CASE WHEN id=$1 THEN clock_timestamp() \
+			 ELSE clock_timestamp() + interval '1 hour' END",
+			&[&protected_id],
+		)
+		.await?;
+
+	let claim = store
+		.claim_outbox(OUTBOX_WORKER_ID, 1, Duration::from_secs(1))
+		.await?
+		.pop()
+		.expect("the selected WorkItem outbox row must be claimable");
+	assert_eq!(claim.id, protected_id);
+	store.begin_outbox_effect(claim.id, OUTBOX_WORKER_ID, &claim.claim_token).await?;
+	store
+		.record_outbox_receipt(
+			claim.id,
+			OUTBOX_WORKER_ID,
+			&claim.claim_token,
+			&serde_json::json!({"provider_receipt": "xy-1343"}),
+		)
+		.await?;
+	store
+		.reconcile_outbox(
+			claim.id,
+			OUTBOX_WORKER_ID,
+			&claim.claim_token,
+			&OutboxReconciliation {
+				readback: serde_json::json!({"effect_key": claim.effect_key, "observed": true}),
+				outcome: ReconciliationOutcome::EffectPresent,
+			},
+			Duration::from_millis(1),
+			Duration::from_secs(1),
+		)
+		.await?;
+	let state: String = owner
+		.query_one("SELECT state::text FROM decodex.outbox WHERE id=$1", &[&claim.id])
+		.await?
+		.get(0);
+	assert_eq!(state, "delivered");
+	Ok(claim.id)
+}
+
+async fn select_work_item_outbox_authority_rows(
+	owner: &tokio_postgres::Client,
+	delivered_id: i64,
+) -> Result<(i64, i64), Box<dyn std::error::Error>> {
+	let authority_id = owner
+		.query_one(
+			"SELECT min(id) FROM decodex.outbox \
+			 WHERE aggregate_kind='work_item' AND id<>$1 \
+			 AND state='pending' AND effect_state='not_started' \
+			 AND lease_holder IS NULL AND claim_token IS NULL \
+			 AND lease_acquired_at IS NULL AND lease_expires_at IS NULL \
+			 AND delivered_at IS NULL AND dead_lettered_at IS NULL",
+			&[&delivered_id],
+		)
+		.await?
+		.get::<_, Option<i64>>(0)
+		.expect("an undelivered pending WorkItem outbox row must exist");
+
+	let generic_id: i64 = owner
+		.query_one(
+			"INSERT INTO decodex.outbox( \
+			 effect_key,aggregate_kind,aggregate_id,aggregate_revision,payload,available_at \
+			 ) VALUES ('xy-1343-generic-outbox','generic','generic-1',1, \
+			 '{\"fixture\":\"generic\"}'::jsonb,clock_timestamp()+interval '1 hour') \
+			 RETURNING id",
+			&[],
+		)
+		.await?
+		.get(0);
+	Ok((authority_id, generic_id))
+}
+
+fn work_item_outbox_authority_cases(
+	authority_id: i64,
+	generic_id: i64,
+) -> Vec<(&'static str, String)> {
+	let mut cases = vec![
+		(
+			"effect_key",
+			format!(
+				"UPDATE decodex.outbox SET effect_key=effect_key||'/rewrite' WHERE id={authority_id}"
+			),
+		),
+		(
+			"aggregate_kind_old_linked_escape",
+			format!("UPDATE decodex.outbox SET aggregate_kind='other' WHERE id={authority_id}"),
+		),
+		(
+			"aggregate_id",
+			format!("UPDATE decodex.outbox SET aggregate_id='rewritten' WHERE id={authority_id}"),
+		),
+		(
+			"aggregate_revision",
+			format!(
+				"UPDATE decodex.outbox SET aggregate_revision=aggregate_revision+1 WHERE id={authority_id}"
+			),
+		),
+		(
+			"payload_old_linked_escape",
+			format!(
+				"UPDATE decodex.outbox SET payload='{{\"kind\":\"other\"}}'::jsonb WHERE id={authority_id}"
+			),
+		),
+		(
+			"created_at",
+			format!(
+				"UPDATE decodex.outbox SET created_at=created_at-interval '1 microsecond' WHERE id={authority_id}"
+			),
+		),
+		(
+			"generic_to_work_item_new_linked_escape",
+			format!(
+				"UPDATE decodex.outbox SET aggregate_kind='work_item',aggregate_id='{}', \
+				 payload=jsonb_build_object('work_item_id','{}') WHERE id={generic_id}",
+				work_item_id(1),
+				work_item_id(1),
+			),
+		),
+	];
+	// PostgreSQL identity sequences are not transactional. Keep DEFAULT last because its
+	// rejected UPDATE still advances outbox_id_seq; no subsequent assertion depends on IDs.
+	cases.push((
+		"id_identity_default",
+		format!("UPDATE decodex.outbox SET id=DEFAULT WHERE id={authority_id}"),
+	));
+	cases
+}
+
+async fn assert_work_item_outbox_authority_cases(
+	runtime: &tokio_postgres::Config,
+	cases: Vec<(&'static str, String)>,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let mut diagnostics = Vec::with_capacity(cases.len());
+	let mut mismatch_count = 0usize;
+	for (label, sql) in cases {
+		let (matched, diagnostic) = exercise_outbox_authority_case(runtime, label, &sql).await;
+		if !matched {
+			mismatch_count += 1;
+		}
+		diagnostics.push(diagnostic);
+	}
+	if mismatch_count != 0 {
+		return Err(std::io::Error::other(format!(
+			"{mismatch_count} WorkItem outbox authority cases mismatched:\n{}",
+			serde_json::Value::Array(diagnostics),
+		))
+		.into());
+	}
+	Ok(())
+}
+
+async fn assert_work_item_outbox_delivery_and_authority(
+	store: &PostgresStore,
+	migration: &tokio_postgres::Config,
+	runtime: &tokio_postgres::Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let (owner, owner_connection) = migration.connect(NoTls).await?;
+	let owner_task = tokio::spawn(owner_connection);
+	let delivered_id = deliver_work_item_outbox(store, &owner).await?;
+	let (authority_id, generic_id) =
+		select_work_item_outbox_authority_rows(&owner, delivered_id).await?;
+	let cases = work_item_outbox_authority_cases(authority_id, generic_id);
+	assert_work_item_outbox_authority_cases(runtime, cases).await?;
+	drop(owner);
+	owner_task.await??;
+	Ok(())
+}
+
+async fn assert_create_and_concurrent_replay(
+	store: &PostgresStore,
+) -> Result<CreateWorkItem, Box<dyn std::error::Error>> {
+	let dependency = create(1, WorkItemRelations::default());
+	let first = success(store.create_work_item("work-item-create-1", &dependency).await?);
+	assert_eq!(first.work_item.work_item.revision(), 1);
+	assert_eq!(
+		store.create_work_item("work-item-create-1", &dependency).await?,
+		WorkItemCommandOutcome::Success(first),
+		"same exact request must replay immutable stored bytes",
+	);
+	let contested = create(7, WorkItemRelations::default());
+	let mut concurrent_replays = JoinSet::new();
+	for _ in 0..8 {
+		let store = store.clone();
+		let contested = contested.clone();
+		concurrent_replays.spawn(async move {
+			store.create_work_item("work-item-concurrent-create-7", &contested).await
+		});
+	}
+	let mut converged = None;
+	while let Some(result) = concurrent_replays.join_next().await {
+		let outcome = result??;
+		assert!(matches!(outcome, WorkItemCommandOutcome::Success(_)));
+		if let Some(expected) = &converged {
+			assert_eq!(&outcome, expected, "concurrent exact retries must converge");
+		} else {
+			converged = Some(outcome);
+		}
+	}
+	Ok(dependency)
+}
+
+async fn assert_dependency_readiness_blocked(
+	store: &PostgresStore,
+	project_id: &ProjectId,
+	dependency: &CreateWorkItem,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let dependent_relations = WorkItemRelations {
+		depends_on_ids: vec![dependency.work_item_id.clone()],
+		..WorkItemRelations::default()
+	};
+	let dependent = create(2, dependent_relations.clone());
+	success(store.create_work_item("work-item-create-2", &dependent).await?);
+	success(
+		store
+			.update_work_item(
+				"work-item-plan-2",
+				&update(2, 1, WorkItemState::Planned, dependent_relations.clone()),
+			)
+			.await?,
+	);
+	let blocked = success(
+		store
+			.assess_work_item_readiness(
+				"work-item-ready-2",
+				&dependent.work_item_id,
+				project_id,
+				2,
+				&provenance(42),
+			)
+			.await?,
+	);
+	assert_eq!(blocked.work_item.work_item.state(), WorkItemState::Blocked);
+	assert_eq!(blocked.work_item.work_item.revision(), 3);
+	assert_eq!(blocked.readiness_blockers.len(), 1);
+	assert_eq!(
+		blocked.readiness_blockers[0].kind,
+		WorkItemReadinessBlockerKind::DependencyIncomplete,
+	);
+	Ok(())
+}
+
+async fn assert_ready_and_running_guard(
+	store: &PostgresStore,
+	project_id: &ProjectId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let ready_item = create(3, WorkItemRelations::default());
+	success(store.create_work_item("work-item-create-3", &ready_item).await?);
+	success(
+		store
+			.update_work_item(
+				"work-item-plan-3",
+				&update(3, 1, WorkItemState::Planned, WorkItemRelations::default()),
+			)
+			.await?,
+	);
+	let ready = success(
+		store
+			.assess_work_item_readiness(
+				"work-item-ready-3",
+				&ready_item.work_item_id,
+				project_id,
+				2,
+				&provenance(43),
+			)
+			.await?,
+	);
+	assert_eq!(ready.work_item.work_item.state(), WorkItemState::Ready);
+	assert!(ready.readiness_blockers.is_empty());
+	store.guard_work_item_running_resume(&ready_item.work_item_id, project_id, 3).await?;
+	Ok(())
+}
+
+async fn assert_cycle_rejected(
+	store: &PostgresStore,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let cycle_a = create(4, WorkItemRelations::default());
+	let cycle_b = create(5, WorkItemRelations::default());
+	success(store.create_work_item("work-item-create-4", &cycle_a).await?);
+	success(store.create_work_item("work-item-create-5", &cycle_b).await?);
+	success(
+		store
+			.update_work_item(
+				"work-item-edge-4",
+				&update(
+					4,
+					1,
+					WorkItemState::Planned,
+					WorkItemRelations {
+						depends_on_ids: vec![cycle_b.work_item_id.clone()],
+						..WorkItemRelations::default()
+					},
+				),
+			)
+			.await?,
+	);
+	let cycle_request = update(
+		5,
+		1,
+		WorkItemState::Planned,
+		WorkItemRelations {
+			depends_on_ids: vec![cycle_a.work_item_id.clone()],
+			..WorkItemRelations::default()
+		},
+	);
+	assert_eq!(
+		store.update_work_item("work-item-cycle-5", &cycle_request).await?,
+		WorkItemCommandOutcome::Rejected(WorkItemRejection::DependencyCycle),
+	);
+	let cycle_b_stored = store
+		.read_work_item(&cycle_b.work_item_id)
+		.await?
+		.expect("cycle fixture WorkItem must remain stored");
+	assert_eq!(cycle_b_stored.work_item.revision(), 1);
+	assert!(cycle_b_stored.edges.is_empty(), "rejected candidate graph must roll back");
+	Ok(())
+}
+
+async fn assert_lead_acceptance(
+	store: &PostgresStore,
+	project_id: &ProjectId,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let accepted_item = create(6, WorkItemRelations::default());
+	success(store.create_work_item("work-item-create-6", &accepted_item).await?);
+	success(
+		store
+			.update_work_item(
+				"work-item-plan-6",
+				&update(6, 1, WorkItemState::Planned, WorkItemRelations::default()),
+			)
+			.await?,
+	);
+	success(
+		store
+			.assess_work_item_readiness(
+				"work-item-ready-6",
+				&accepted_item.work_item_id,
+				project_id,
+				2,
+				&provenance(46),
+			)
+			.await?,
+	);
+	let mut fixture_config = tokio_postgres::Config::new();
+	fixture_config
+		.host(std::env::var("PGHOST")?)
+		.port(std::env::var("PGPORT")?.parse()?)
+		.user(std::env::var("PGUSER")?)
+		.dbname("decodex_xy1343_work_items");
+	let (fixture_client, fixture_connection) = fixture_config.connect(NoTls).await?;
+	let fixture_task = tokio::spawn(fixture_connection);
+	fixture_client
+		.batch_execute(
+			"BEGIN; SET LOCAL session_replication_role='replica'; \
+			 WITH operation AS (SELECT clock_timestamp() AS operation_time) \
+			 UPDATE decodex.work_items SET state='review', revision=revision+1, \
+			 last_changed_by='31000000-0000-4000-8000-000000001343', \
+			 last_correlation_id='61000000-0000-4000-8000-000000000046', \
+			 last_provenance='XY-1343 external review-state fixture', \
+			 updated_at=operation.operation_time FROM operation \
+			 WHERE work_item_id='51000000-0000-4000-8000-000000000006'; COMMIT;",
+		)
+		.await?;
+	drop(fixture_client);
+	fixture_task.await??;
+	let acceptance = AcceptWorkItem {
+		acceptance_id: "71000000-0000-4000-8000-000000001343".into(),
+		work_item_id: accepted_item.work_item_id.clone(),
+		project_id: project_id.clone(),
+		expected_revision: 4,
+		provenance: provenance(47),
+		criteria_provenance: "Exact revision-four criteria snapshot.".into(),
+		evidence_summary: "Focused PostgreSQL evidence passed.".into(),
+		evidence_provenance: "XY-1343 focused harness.".into(),
+	};
+	let accepted = success(store.accept_work_item("work-item-accept-6", &acceptance).await?);
+	assert_eq!(accepted.work_item.work_item.state(), WorkItemState::Review);
+	assert_eq!(accepted.work_item.work_item.revision(), 4);
+	assert_eq!(accepted.work_item.accepted_revision, Some(4));
+	assert_eq!(
+		store
+			.accept_work_item(
+				"work-item-duplicate-accept-6",
+				&AcceptWorkItem {
+					acceptance_id: "71000000-0000-4000-8000-000000001344".into(),
+					..acceptance
+				},
+			)
+			.await?,
+		WorkItemCommandOutcome::Rejected(WorkItemRejection::DuplicateAcceptance),
+	);
+	Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires the focused isolated PostgreSQL 18 V11 harness"]
+async fn postgres_exact_work_item_commands() -> Result<(), Box<dyn std::error::Error>> {
+	let (migration, runtime) = separated_configs("DECODEX_TEST")?;
+	create_project(&migration).await?;
+	let store =
+		PostgresStore::connect(migration.clone(), runtime.clone(), expected_peer_uid()).await?;
+	let project_id = ProjectId::new(PROJECT_ID)?;
+	let dependency = assert_create_and_concurrent_replay(&store).await?;
+	assert_dependency_readiness_blocked(&store, &project_id, &dependency).await?;
+	assert_ready_and_running_guard(&store, &project_id).await?;
+	assert_cycle_rejected(&store).await?;
+	assert_lead_acceptance(&store, &project_id).await?;
+
+	let page = store.query_work_items(&project_id, None, None, 16).await?;
+	assert_eq!(page.len(), 7);
+	assert!(page.windows(2).all(|pair| pair[0].work_item.id() < pair[1].work_item.id()));
+	assert!(page.iter().all(|item| item.work_item.state() != WorkItemState::Done));
+	assert_work_item_outbox_delivery_and_authority(&store, &migration, &runtime).await?;
+	store.close();
+	Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires the focused isolated PostgreSQL 18 V11 restore harness"]
+async fn postgres_exact_work_item_restore() -> Result<(), Box<dyn std::error::Error>> {
+	let (migration, runtime) = separated_configs("DECODEX_TEST")?;
+	let store = PostgresStore::connect(migration.clone(), runtime, expected_peer_uid()).await?;
+	let project_id = ProjectId::new(PROJECT_ID)?;
+	let page = store.query_work_items(&project_id, None, None, 16).await?;
+	assert_eq!(page.len(), 7);
+	let accepted = store
+		.read_work_item(&work_item_id(6))
+		.await?
+		.expect("accepted fixture WorkItem must survive restore");
+	assert_eq!(accepted.work_item.state(), WorkItemState::Review);
+	assert_eq!(accepted.work_item.revision(), 4);
+	assert_eq!(accepted.accepted_revision, Some(4));
+	let (client, connection) = migration.connect(NoTls).await?;
+	let task = tokio::spawn(connection);
+	let counts = client
+		.query_one(
+			"SELECT (SELECT count(*) FROM decodex.exact_command_receipts \
+			 WHERE request_envelope->>'operation' LIKE '%work_item%' \
+			 AND receipt_state='completed_success'), \
+			 (SELECT count(*) FROM decodex.activity WHERE aggregate_kind='work_item'), \
+			 (SELECT count(*) FROM decodex.outbox WHERE aggregate_kind='work_item'), \
+			 (SELECT count(*) FROM decodex.work_item_acceptances)",
+			&[],
+		)
+		.await?;
+	assert_eq!(counts.get::<_, i64>(0), counts.get::<_, i64>(1));
+	assert_eq!(counts.get::<_, i64>(1), counts.get::<_, i64>(2));
+	assert_eq!(counts.get::<_, i64>(3), 1);
+	let mutation = client
+		.execute(
+			"UPDATE decodex.work_item_acceptances SET evidence_summary='mutated'",
+			&[],
+		)
+		.await
+		.expect_err("immutable acceptance UPDATE must fail");
+	assert_eq!(
+		mutation.as_db_error().and_then(|error| error.constraint()),
+		Some("work_item_acceptances_immutable"),
+	);
+	drop(client);
+	task.await??;
+	store.close();
+	Ok(())
+}

--- a/crates/decodex-postgres/tests/postgres_store/work_items.rs
+++ b/crates/decodex-postgres/tests/postgres_store/work_items.rs
@@ -127,9 +127,7 @@ async fn exercise_outbox_authority_case(
 	let mut rollback_status = "not_attempted".to_owned();
 	let mut rollback_error = serde_json::Value::Null;
 	let (connection_completion_status, connection_error) = match runtime.connect(NoTls).await {
-		Err(error) => {
-			("connect_failed".to_owned(), postgres_error_diagnostic(&error))
-		}
+		Err(error) => ("connect_failed".to_owned(), postgres_error_diagnostic(&error)),
 		Ok((client, connection)) => {
 			let connection_task = tokio::spawn(connection);
 			match client.batch_execute("BEGIN").await {
@@ -137,7 +135,7 @@ async fn exercise_outbox_authority_case(
 				Err(error) => {
 					begin_status = "begin_failed".into();
 					begin_error = postgres_error_diagnostic(&error);
-				}
+				},
 			}
 			if begin_status == "began" {
 				match client.batch_execute(sql).await {
@@ -153,7 +151,7 @@ async fn exercise_outbox_authority_case(
 								&& error.constraint() == Some("work_item_event_namespace")
 						});
 						execution_error = postgres_error_diagnostic(&error);
-					}
+					},
 				}
 			}
 			match client.batch_execute("ROLLBACK").await {
@@ -161,7 +159,7 @@ async fn exercise_outbox_authority_case(
 				Err(error) => {
 					rollback_status = "rollback_failed".into();
 					rollback_error = postgres_error_diagnostic(&error);
-				}
+				},
 			}
 			drop(client);
 			match connection_task.await {
@@ -173,7 +171,7 @@ async fn exercise_outbox_authority_case(
 					serde_json::json!({"message": error.to_string()}),
 				),
 			}
-		}
+		},
 	};
 
 	let matched = begin_status == "began"
@@ -211,10 +209,7 @@ async fn deliver_work_item_outbox(
 	owner: &tokio_postgres::Client,
 ) -> Result<i64, Box<dyn std::error::Error>> {
 	let protected_id = owner
-		.query_one(
-			"SELECT min(id) FROM decodex.outbox WHERE aggregate_kind='work_item'",
-			&[],
-		)
+		.query_one("SELECT min(id) FROM decodex.outbox WHERE aggregate_kind='work_item'", &[])
 		.await?
 		.get::<_, Option<i64>>(0)
 		.expect("WorkItem command must emit an outbox row");
@@ -494,9 +489,7 @@ async fn assert_ready_and_running_guard(
 	Ok(())
 }
 
-async fn assert_cycle_rejected(
-	store: &PostgresStore,
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn assert_cycle_rejected(store: &PostgresStore) -> Result<(), Box<dyn std::error::Error>> {
 	let cycle_a = create(4, WorkItemRelations::default());
 	let cycle_b = create(5, WorkItemRelations::default());
 	success(store.create_work_item("work-item-create-4", &cycle_a).await?);
@@ -670,10 +663,7 @@ async fn postgres_exact_work_item_restore() -> Result<(), Box<dyn std::error::Er
 	assert_eq!(counts.get::<_, i64>(1), counts.get::<_, i64>(2));
 	assert_eq!(counts.get::<_, i64>(3), 1);
 	let mutation = client
-		.execute(
-			"UPDATE decodex.work_item_acceptances SET evidence_summary='mutated'",
-			&[],
-		)
+		.execute("UPDATE decodex.work_item_acceptances SET evidence_summary='mutated'", &[])
 		.await
 		.expect_err("immutable acceptance UPDATE must fail");
 	assert_eq!(

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -119,22 +119,22 @@ runtime-effective, regardless of `pg_extension.extnamespace`.
 Superuser/BYPASSRLS/role/database administration, database/schema CREATE,
 TRUNCATE/TRIGGER/REFERENCES/MAINTAIN, excess table DML or grant options,
 `session_replication_role` SET/ALTER SYSTEM, and any effective non-`origin` login value are unsafe
-in any reachable authority state. At the V11 boundary, the audit verifies all sixty-nine shipped
+in any reachable authority state. At the V12 boundary, the audit verifies all eighty-four shipped
 non-internal trigger bindings, including regular and deferred constraint triggers, by table, event
 mask, row/statement level, constraint and deferral state, origin-enabled mode, and function binding,
 then compares
 each bound function's exact metadata and `pg_proc.prosrc` bytes with the canonical body embedded in
-the immutable forward migration ledger through V11. It additionally closes the entire runtime-callable `decodex` function
+the immutable forward migration ledger through V12. It additionally closes the entire runtime-callable `decodex` function
 namespace over exact signatures and overloads, argument/result shape, language, volatility,
 parallel/strict/set behavior, planner metadata, exact security-invoker/definer state and exact per-function settings,
 and canonical source. Unexpected functions, overloads, owner-executed functions, or unsafe settings
 are unsafe; missing functions or noncanonical source are incompatible. Disabled or misbound triggers
 are unsafe; a replaced same-signature safety-function body is incompatible.
-Every non-internal trigger on a Decodex runtime relation must be one of those sixty-nine exact V11 bindings.
+Every non-internal trigger on a Decodex runtime relation must be one of those eighty-four exact V12 bindings.
 The same closed execution-path audit permits no user rule, row-security policy, or enabled/forced RLS
 on those relations and rejects non-`pg_catalog` function/operator dependencies from defaults,
 generated expressions, constraints, indexes, rules, or policies unless they resolve to one of the
-ninety-eight canonical V11 functions. Every canonical function has the exact function-local
+107 canonical V12 functions. Every canonical function has the exact function-local
 `pg_catalog, decodex` search path, so runtime-selected callable or operator shadows cannot redirect
 trigger or constraint execution. A trigger cannot therefore invoke an adjacent public owner-executed
 function merely because runtime DML fires it.
@@ -158,22 +158,23 @@ string-to-system-catalog identity explicitly qualifies `pg_catalog`; the
 authority audit and schema-qualified migration-ledger verification remain correct under a hostile
 runtime `search_path` that shadows both ledger and system-catalog names. Missing required schema,
 table, sequence, function, or ledger-read authority is incompatible.
-At the V11 boundary, twenty-three canonical `SECURITY DEFINER` functions comprise the three V3
+At the V12 boundary, twenty-four canonical `SECURITY DEFINER` functions comprise the three V3
 cursor/history functions, eleven V5-V7 Project/Policy/Program/Objective command entrypoints, and two
 V9 RoleProfile command entrypoints, two V10 RuntimeSession command entrypoints, and four V11 exact
-WorkItem commands plus the inert future running/resume guard. The cursor issuer derives Conversation,
+WorkItem commands, the inert future running/resume guard, and the one V12 ManagedRun safety
+consumer. The cursor issuer derives Conversation,
 snapshot version, parent, page size, position, item identity, and expiry under serialized
 Conversation authority; the bounded pruner is callable by runtime, while the capture function is
 trigger-only and runtime cannot execute it directly. Runtime has no cursor-table INSERT authority.
-The other seventy-five canonical V11 functions are security invokers. The additional-function adversarial fixture creates a fixture-only ninety-ninth migration-owned,
+The other eighty-three canonical V12 functions are security invokers. The additional-function adversarial fixture creates a fixture-only 108th migration-owned,
 runtime-executable `SECURITY DEFINER` function with an unsafe per-function setting and migration-owner
 trigger authority, proves runtime direct trigger DDL is denied, executes the owner-authority effect,
 and restores the trigger before the independent doctor rejection. A separate public-function trigger
 fixture proves runtime DML can execute an owner effect without direct function `EXECUTE`, protected
-table `UPDATE`, or `TRIGGER`; the exact sixty-nine-trigger V11 inventory rejects that path. A public,
+table `UPDATE`, or `TRIGGER`; the exact eighty-four-trigger V12 inventory rejects that path. A public,
 runtime-owned extension fixture attaches a migration-owned Decodex collation as an extension member,
 proves the runtime can transactionally drop it, and is rejected through the dependency audit. The
-closed ninety-eight-function V11 inventory remains independent of the distinct same-signature canonical-source
+closed 107-function V12 inventory remains independent of the distinct same-signature canonical-source
 substitution fixture. Missing, malformed, unsafe, unreachable,
 authentication-failed, or incompatible bootstrap retains a typed unavailable adapter;
 there is no ambient/default database or alternate state authority. Repository and
@@ -431,6 +432,17 @@ stale, illegal, invalid-account, and account-snapshot-conflict outcomes are comm
 rejections. Runtime retains SELECT-only snapshot/session readback and can execute only the two
 public command owners; direct DML, private helpers, and forged RuntimeSession activity/outbox
 namespaces are closed.
+
+V12 rolls the V3 invoker-rights Turn and HistoryItem state guards forward after V10 made
+RuntimeSessions SELECT-only for runtime. Their statement-level `BEFORE` guards acquire hierarchy
+coordinator 1271 before row-trigger reads; the Turn guard retains only its Conversation row lock,
+and the HistoryItem guard retains only its Conversation and Turn row locks while reading the exact
+RuntimeSession without locking it. Both direct hierarchy paths require `READ COMMITTED` and fail
+retryably with `40001` under any other isolation level. The ManagedRun safety owner follows the
+same global order: reserve the exact receipt, validate the request, acquire 1271, acquire the
+run-scoped `(1338, hash(run))` lock, and only then read or lock hierarchy, run, session, barrier,
+receipt, or Turn state. This prevents an unknown-turn absence decision from crossing a concurrent
+same-session Turn insertion without granting runtime `UPDATE` on RuntimeSessions.
 
 Legacy `command_receipts` retain the receipt-first fenced-claim protocol only for unrelated blob,
 filesystem, external, or long-running sagas whose point of no return cannot fit in one PostgreSQL

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -119,22 +119,22 @@ runtime-effective, regardless of `pg_extension.extnamespace`.
 Superuser/BYPASSRLS/role/database administration, database/schema CREATE,
 TRUNCATE/TRIGGER/REFERENCES/MAINTAIN, excess table DML or grant options,
 `session_replication_role` SET/ALTER SYSTEM, and any effective non-`origin` login value are unsafe
-in any reachable authority state. At the V10 boundary, the audit verifies all fifty-nine shipped
+in any reachable authority state. At the V11 boundary, the audit verifies all sixty-nine shipped
 non-internal trigger bindings, including regular and deferred constraint triggers, by table, event
 mask, row/statement level, constraint and deferral state, origin-enabled mode, and function binding,
 then compares
 each bound function's exact metadata and `pg_proc.prosrc` bytes with the canonical body embedded in
-the immutable forward migration ledger through V10. It additionally closes the entire runtime-callable `decodex` function
+the immutable forward migration ledger through V11. It additionally closes the entire runtime-callable `decodex` function
 namespace over exact signatures and overloads, argument/result shape, language, volatility,
 parallel/strict/set behavior, planner metadata, exact security-invoker/definer state and exact per-function settings,
 and canonical source. Unexpected functions, overloads, owner-executed functions, or unsafe settings
 are unsafe; missing functions or noncanonical source are incompatible. Disabled or misbound triggers
 are unsafe; a replaced same-signature safety-function body is incompatible.
-Every non-internal trigger on a Decodex runtime relation must be one of those fifty-nine exact V10 bindings.
+Every non-internal trigger on a Decodex runtime relation must be one of those sixty-nine exact V11 bindings.
 The same closed execution-path audit permits no user rule, row-security policy, or enabled/forced RLS
 on those relations and rejects non-`pg_catalog` function/operator dependencies from defaults,
 generated expressions, constraints, indexes, rules, or policies unless they resolve to one of the
-eighty canonical V10 functions. Every canonical function has the exact function-local
+ninety-eight canonical V11 functions. Every canonical function has the exact function-local
 `pg_catalog, decodex` search path, so runtime-selected callable or operator shadows cannot redirect
 trigger or constraint execution. A trigger cannot therefore invoke an adjacent public owner-executed
 function merely because runtime DML fires it.
@@ -158,21 +158,22 @@ string-to-system-catalog identity explicitly qualifies `pg_catalog`; the
 authority audit and schema-qualified migration-ledger verification remain correct under a hostile
 runtime `search_path` that shadows both ledger and system-catalog names. Missing required schema,
 table, sequence, function, or ledger-read authority is incompatible.
-At the V10 boundary, eighteen canonical `SECURITY DEFINER` functions comprise the three V3
+At the V11 boundary, twenty-three canonical `SECURITY DEFINER` functions comprise the three V3
 cursor/history functions, eleven V5-V7 Project/Policy/Program/Objective command entrypoints, and two
-V9 RoleProfile command entrypoints plus two V10 RuntimeSession command entrypoints. The cursor issuer derives Conversation,
+V9 RoleProfile command entrypoints, two V10 RuntimeSession command entrypoints, and four V11 exact
+WorkItem commands plus the inert future running/resume guard. The cursor issuer derives Conversation,
 snapshot version, parent, page size, position, item identity, and expiry under serialized
 Conversation authority; the bounded pruner is callable by runtime, while the capture function is
 trigger-only and runtime cannot execute it directly. Runtime has no cursor-table INSERT authority.
-The other sixty-two canonical V10 functions are security invokers. The additional-function adversarial fixture creates a fixture-only eighty-first migration-owned,
+The other seventy-five canonical V11 functions are security invokers. The additional-function adversarial fixture creates a fixture-only ninety-ninth migration-owned,
 runtime-executable `SECURITY DEFINER` function with an unsafe per-function setting and migration-owner
 trigger authority, proves runtime direct trigger DDL is denied, executes the owner-authority effect,
 and restores the trigger before the independent doctor rejection. A separate public-function trigger
 fixture proves runtime DML can execute an owner effect without direct function `EXECUTE`, protected
-table `UPDATE`, or `TRIGGER`; the exact fifty-nine-trigger V10 inventory rejects that path. A public,
+table `UPDATE`, or `TRIGGER`; the exact sixty-nine-trigger V11 inventory rejects that path. A public,
 runtime-owned extension fixture attaches a migration-owned Decodex collation as an extension member,
 proves the runtime can transactionally drop it, and is rejected through the dependency audit. The
-closed eighty-function V10 inventory remains independent of the distinct same-signature canonical-source
+closed ninety-eight-function V11 inventory remains independent of the distinct same-signature canonical-source
 substitution fixture. Missing, malformed, unsafe, unreachable,
 authentication-failed, or incompatible bootstrap retains a typed unavailable adapter;
 there is no ambient/default database or alternate state authority. Repository and

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -90,7 +90,7 @@ untrusted server-text cases.
 
 The XY-1267/XY-1307 integration command and XY-1264 storage proof are intentionally separate because they require an intended macOS host with one PostgreSQL 18 distribution. Each creates and removes its own isolated temporary checksummed cluster with TCP disabled and never enumerates or changes an existing service. The PostgreSQL command provisions fixture-only migration/runtime roles, proves least-privilege daemon bootstrap, and rejects 27 unsafe roots covering direct, inherited, NOINHERIT/SET-only, and membership-admin paths to forbidden role attributes, PostgreSQL 18 namespace-object ownership (including distinct collation, conversion, operator, and text-search cases), DDL, table/ledger/sequence mutation, grant options, `session_replication_role` SET/ALTER SYSTEM, retention bypass, trigger drift, extension-member control, an indirect public-function trigger, and a genuinely additional function. It closes every runtime-callable Decodex function over exact signatures, overloads, metadata, settings, and canonical source. At the frozen V9 boundary, all 72 shipped functions have the exact secure `pg_catalog, decodex` function-local search path, and all 52 non-internal shipped trigger bindings—including deferred constraint triggers—have exact catalog attestations. The 16 shipped security definers comprise three V3 cursor/history functions, eleven V5-V7 Project/Policy/Program/Objective command entrypoints, and two V9 RoleProfile command entrypoints; runtime cannot insert cursors or execute capture directly. The additional fixture-only seventy-third function is migration-owned, runtime-executable, `SECURITY DEFINER`, configured with an unsafe setting, and is invoked as runtime to perform owner-authority trigger DDL before fixture restoration and independent rejection. The separate substitution fixture replaces a shipped safety body without changing its signature. The indirect-trigger fixture proves runtime DML executes a public definer function despite direct `EXECUTE`, protected-table `UPDATE`, and `TRIGGER` all being denied. The extension fixture proves a public runtime-owned extension can transactionally drop it. Six incompatible roots cover missing ledger SELECT, canonical-function drift, a dropped credential constraint with demonstrated credential insertion, an external child cascade with demonstrated runtime-mediated deletion, a same-count tampered migration ledger, and absent `pgcrypto`. The canonical PostgreSQL 18 schema manifest closes defaults, constraints on both foreign-key sides, indexes, enums, and internal constraint-trigger semantics. Descriptor-pinned socket unit fixtures reject a same-UID pre-planted endpoint in a world-writable configured directory, a mismatched operator UID pin, replaced ancestors, replaced endpoints, and deterministic replacement between precheck and failed connect; an unchanged secure stale socket maps to unreachable. An isolated daemon fixture starts Ready, replaces the configured endpoint, and proves a fresh V1.2 doctor query becomes unsafe-host-path without migration or repinning. The runtime protocol tests keep mutation receipt lookup/capacity independent across V1.1/V1.2 and prove repeated, ordered, concurrent live queries neither replay nor consume receipts. The adapter contract tampers a ledger name at constant row count and removes `pgcrypto` after bootstrap, proving read-only live revalidation reports both as incompatible before restoration. The harness also exercises an in-flight Rust BlobSession across an immediate PostgreSQL restart: the old session loses its hash lock and transaction-B connection, its stale claim cannot complete, and a reassigned exact retry verifies already-published bytes before committing metadata. It also proves `setval` denial, same-signature callable hostile-`search_path` safety, Turkish ICU credential behavior, and populated dump/restore. The XY-1264 proof additionally exercises rollback, blob, and cache behavior (`crates/decodex-postgres/src/socket.rs`, `crates/decodex-runtime/tests/bootstrap_doctor.rs`, `scripts/vnext/postgres_store_test.py`, `spikes/vnext-storage/proof.py`, `spikes/vnext-storage/README.md`).
 
-The V10 extension raises the closed production inventory to 80 functions, 59 non-internal
+The V10 extension raised the closed production inventory to 80 functions, 59 non-internal
 triggers, and 18 security definers. The two additional definers are the command-complete
 RuntimeSession creation and transition owners; the other three new private/builder routines and
 three new trigger routines are security invokers. Runtime receives EXECUTE only on the two command
@@ -102,6 +102,20 @@ identity-preserving upgrade, and populated restore. The manager-owned final Post
 clean V1-to-V10 bootstrap, classified zero-state and blocked-old-writer cutover, whole-transaction
 retry, crash/restart, dump/restore, and stress schedules; those live gates are deliberately not run
 during candidate construction.
+
+V11 adds canonical PostgreSQL WorkItems without introducing execution ownership. The closed
+inventory is 98 functions, 69 non-internal triggers, and 23 security definers. Runtime can execute
+four exact WorkItem command owners plus one inert future running/resume guard, and receives
+SELECT-only access to five normalized WorkItem relations. Readiness re-reads and locks the current
+WorkItem, Project, canonical Lead, Program/Objectives, dependency/blocker graph, lifecycle, and
+revision state in one transaction before recording typed blockers or entering `ready`. Lead
+acceptance snapshots exact-review-revision criteria, evidence provenance, and database chronology
+without changing lifecycle or revision; completion remains unowned. The focused V11 harness mode
+covers exact replay and concurrent convergence, cycle rollback, readiness blocker persistence,
+guard inertness, acceptance immutability and non-completion, clean V1-to-V11 bootstrap, and populated
+dump/restore.
+The final schema produced by every migration version must be a PostgreSQL 18 dump/restore fixed
+point so the one exact full-manifest digest remains identical before and after logical restore.
 
 The XY-1345 command is a separate non-production architecture proof. It requires exactly
 PostgreSQL 18.4, creates a private temporary cluster with TCP disabled, installs only fixture
@@ -119,8 +133,8 @@ active implementation uses targeted Rust compilation, parser/unit contracts, and
 syntax checks. See
 [the durable evidence page](../evidence/xy-1345-exact-command-authority.md).
 
-The PostgreSQL integration harness bootstraps the shipped V1-V10 migration history, from the `V1`
-foundation through the forward-only `V10` RuntimeSession snapshot authority, and verifies
+The PostgreSQL integration harness bootstraps the shipped V1-V11 migration history, from the `V1`
+foundation through the forward-only `V11` WorkItem authority, and verifies
 transaction/idempotency/revision behavior, Conversation-lock serialization with append-only history-derived
 positions, snapshot high-water, and immutable item-version sequence with no writable stored next-position counter, page-only opaque
 issued-cursor pagination with never-issued/expired/cross-Conversation/edited-chain rejection,

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -114,6 +114,21 @@ without changing lifecycle or revision; completion remains unowned. The focused 
 covers exact replay and concurrent convergence, cycle rollback, readiness blocker persistence,
 guard inertness, acceptance immutability and non-completion, clean V1-to-V11 bootstrap, and populated
 dump/restore.
+
+V12 adds only inert blocked/waiting ManagedRuns and one safety consumer transaction. The closed
+inventory is 107 functions, 84 non-internal triggers, and 24 security definers. Runtime receives
+SELECT-only access to six ManagedRun/effect/readback relations and EXECUTE on one command-complete
+safety entrypoint; it has no ManagedRun creation, acquisition, activation, progress, completion,
+assignment, submitted-receipt production, or effect-lineage writer authority. Task and Reviewer
+assignments bind exact RuntimeSessions and cannot encode Advisor, Lead, or durable Agent identity.
+The barrier has only fail-closed `guarded` and `closed` states. The focused V12 command
+`cargo make test-vnext-postgres-managed-runs` covers Project/WorkItem/RuntimeSession FK scope,
+state algebra, unknown-turn divergence with an active turn retained, current/stale submitted
+receipts, explicit inconclusive input, rollback/retry, durable cross-key input replay, exactly-once
+barrier closure, exact revisioned restart readback, runtime-role Turn and HistoryItem writes through
+the V12 forward-repaired invoker guards, fail-closed non-`READ COMMITTED` hierarchy DML, and the
+receipt-before-1271-before-1338 unknown-turn/Turn-insert schedule, plus clean V1-to-V12 bootstrap
+and populated restore.
 The final schema produced by every migration version must be a PostgreSQL 18 dump/restore fixed
 point so the one exact full-manifest digest remains identical before and after logical restore.
 
@@ -133,8 +148,8 @@ active implementation uses targeted Rust compilation, parser/unit contracts, and
 syntax checks. See
 [the durable evidence page](../evidence/xy-1345-exact-command-authority.md).
 
-The PostgreSQL integration harness bootstraps the shipped V1-V11 migration history, from the `V1`
-foundation through the forward-only `V11` WorkItem authority, and verifies
+The PostgreSQL integration harness bootstraps the shipped V1-V12 migration history, from the `V1`
+foundation through the forward-only `V12` ManagedRun safety authority, and verifies
 transaction/idempotency/revision behavior, Conversation-lock serialization with append-only history-derived
 positions, snapshot high-water, and immutable item-version sequence with no writable stored next-position counter, page-only opaque
 issued-cursor pagination with never-issued/expired/cross-Conversation/edited-chain rejection,

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -106,11 +106,12 @@ not extension schema, so a runtime-controlled extension cannot own or drop a Dec
 ordered versions, names, and checksums must exactly equal the embedded migration inventory;
 missing SELECT is incompatible, while ownership, SET-reachable authority, table/column grant
 options, writes, and table DDL privileges are unsafe. All canonical database functions have an exact
-function-local `pg_catalog, decodex` search path. Exactly eighteen narrowly scoped functions are
+function-local `pg_catalog, decodex` search path. Exactly twenty-three narrowly scoped functions are
 security definers: three history cursor/version functions, eleven Project/Agent/Policy/Program/Objective
-commands, two command-complete exact RoleProfile entrypoints, and two command-complete exact
-RuntimeSession entrypoints. Runtime cannot insert cursor, exact-receipt, RoleProfile,
-RuntimeSession, or RuntimeSession snapshot rows or execute trigger/private helpers directly.
+commands, two command-complete exact RoleProfile entrypoints, two command-complete exact
+RuntimeSession entrypoints, four command-complete exact WorkItem entrypoints, and one inert future
+running/resume guard. Runtime cannot insert cursor, exact-receipt, RoleProfile, RuntimeSession,
+RuntimeSession snapshot, or WorkItem rows or execute trigger/private helpers directly.
 The two bound identity sequences require
 USAGE only; UPDATE/`setval`, SELECT, ownership, grant options, and SET-reachable surplus authority
 are unsafe. Explicit qualification keeps bootstrap correct under a hostile runtime `search_path`.

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -92,7 +92,7 @@ superuser/BYPASSRLS, database/schema/table DDL, TRUNCATE,
 grant options, trigger authority, `session_replication_role` SET/ALTER SYSTEM, or any other
 retention bypass. The effective login value must be `origin`. Readiness requires a closed inventory
 of every runtime-callable Decodex function with exact signatures, overloads, metadata, settings, and
-source bodies matching the canonical embedded migrations. The fifty-nine expected safety/state/retention
+source bodies matching the canonical embedded migrations. The eighty-four expected safety/state/retention
 triggers must also remain enabled, correctly shaped, and bound to their canonical functions; no
 additional user trigger, rule, policy, RLS mode, or noncanonical expression dependency may add an
 indirect execution path on a runtime relation. One canonical PostgreSQL 18 schema manifest also
@@ -106,12 +106,14 @@ not extension schema, so a runtime-controlled extension cannot own or drop a Dec
 ordered versions, names, and checksums must exactly equal the embedded migration inventory;
 missing SELECT is incompatible, while ownership, SET-reachable authority, table/column grant
 options, writes, and table DDL privileges are unsafe. All canonical database functions have an exact
-function-local `pg_catalog, decodex` search path. Exactly twenty-three narrowly scoped functions are
+function-local `pg_catalog, decodex` search path. Exactly twenty-four narrowly scoped functions are
 security definers: three history cursor/version functions, eleven Project/Agent/Policy/Program/Objective
 commands, two command-complete exact RoleProfile entrypoints, two command-complete exact
-RuntimeSession entrypoints, four command-complete exact WorkItem entrypoints, and one inert future
-running/resume guard. Runtime cannot insert cursor, exact-receipt, RoleProfile, RuntimeSession,
-RuntimeSession snapshot, or WorkItem rows or execute trigger/private helpers directly.
+RuntimeSession entrypoints, four command-complete exact WorkItem entrypoints, one inert future
+running/resume guard, and one command-complete ManagedRun safety consumer. Runtime cannot insert
+cursor, exact-receipt, RoleProfile, RuntimeSession, RuntimeSession snapshot, WorkItem, ManagedRun,
+assignment, submitted-turn receipt, or effect-lineage rows or execute trigger/private helpers
+directly.
 The two bound identity sequences require
 USAGE only; UPDATE/`setval`, SELECT, ownership, grant options, and SET-reachable surplus authority
 are unsafe. Explicit qualification keeps bootstrap correct under a hostile runtime `search_path`.

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -73,6 +73,30 @@ reviewer, PR, harness, or Goal. A ManagedRun separates:
 - wait reason: `usage`, `auth`, `plugin`, `dependency`, `approval`, `user`, `external`,
   `reviewer_unavailable`, `reviewer_failed`.
 
+The inert V12 boundary persists only `waiting` ManagedRuns that remain blocked. Every run is
+foreign-key bound to its exact Project, canonical WorkItem, and authoritative RuntimeSession
+revision. Task and Reviewer assignments are exact-run RuntimeSession identities whose closed role
+type cannot represent Advisor or Lead and contains no durable Agent identity. Effect lineage is
+foreign-key bound to one run and one barrier. Barrier states are `guarded` or permanently `closed`;
+both deny effects, and there is no open state or positive execution transition in V12.
+
+The only V12 mutation consumes a positively observed unknown exact turn, a Decodex-owned exact
+submitted-turn receipt, or an explicit inconclusive observation. It atomically preserves a blocked
+waiting run, records divergence only from positive unknown-turn evidence, closes the barrier once,
+and stores exact replay bytes. A stale submitted receipt and an inconclusive observation remain
+fail-closed without asserting divergence. Missing, empty, exhausted, not-found, scan-exhaustion,
+no-event, or method-result absence is not an input and cannot authorize progress. Experiment
+creation, observation production, run creation/acquisition, scheduling, dispatch, progress,
+validation, completion, review verdicts, repair, and landing remain outside V12 and blocked by
+XY-1304 or later owners.
+
+The safety transaction reserves its exact receipt and validates input before acquiring hierarchy
+coordinator 1271, then the run-scoped 1338 lock, before any run/session/barrier/Turn read or lock.
+V12 also forward-repairs the V3 Turn and HistoryItem invoker-rights guards for V10's SELECT-only
+RuntimeSession authority: they read but never row-lock RuntimeSessions, retain their legal
+Conversation and Turn row locks, and accept direct hierarchy DML only in `READ COMMITTED`.
+Unsupported isolation fails retryably with `40001`; it never authorizes a stale absence decision.
+
 Project/Program policy is versioned authority over allowed repositories, tools, paths, merge
 behavior, parallelism, budgets, approvals, and quiet periods. Commands use expected
 revisions and idempotency keys. Side effects require receipts and authoritative readback;

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -107,6 +107,8 @@ Permission is issue-scoped and does not bypass each issue's own dependencies:
 | XY-1345 | Accepted exact-command authority and isolated PostgreSQL 18 prototype only; no production migration or Rust command path. |
 | XY-1346 | PostgreSQL V9: separate exact receipts plus immutable global RoleProfile bootstrap/update. Starts only after XY-1345 lands. |
 | XY-1337 | Re-bounded RuntimeSession snapshot creation/transition migration, expected V10 after XY-1346. It does not own exact-receipt or RoleProfile redesign. |
+| XY-1343 | PostgreSQL V11 canonical WorkItems, transactional readiness blockers, and immutable Lead acceptance; no run execution or completion. |
+| XY-1338 | PostgreSQL V12 inert waiting ManagedRuns, exact-run Task/Reviewer assignments, exact RuntimeSession revision binding, FK-backed effect lineage, the fail-closed positive/inconclusive safety transaction, and the forward repair that removes illegal RuntimeSession row locks from V3 Turn/History invoker guards while preserving 1271 serialization. No producer, scheduler, acquisition, dispatch, progress, or completion path. |
 
 XY-1336 is an upstream-blocked tracking issue outside the M2 critical path. A host file,
 manifest, configuration value, remote catalog entry, process binding, or user declaration

--- a/scripts/vnext/postgres_store_test.py
+++ b/scripts/vnext/postgres_store_test.py
@@ -56,6 +56,8 @@ RUNTIME_SESSION_RESTORE_SOURCE_DATABASE = "decodex_xy1337_restore_source"
 RUNTIME_SESSION_RESTORE_DATABASE = "decodex_xy1337_restore"
 WORK_ITEM_DATABASE = "decodex_xy1343_work_items"
 WORK_ITEM_RESTORE_DATABASE = "decodex_xy1343_work_items_restore"
+MANAGED_RUN_DATABASE = "decodex_xy1338_managed_runs"
+MANAGED_RUN_RESTORE_DATABASE = "decodex_xy1338_managed_runs_restore"
 MIGRATION_ROLE = "decodex_migration"
 RUNTIME_ROLE = "decodex_runtime"
 FUNCTION_OWNER_ROLE = "decodex_function_owner"
@@ -126,6 +128,7 @@ RUNTIME_EXECUTE_SIGNATURES = (
 	"decodex.assess_work_item_readiness_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text)",
 	"decodex.accept_work_item_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.text)",
 	"decodex.guard_work_item_running_resume(pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8)",
+	"decodex.apply_managed_run_safety_input_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,decodex.managed_run_safety_input_kind,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid)",
 )
 TRIGGER_ONLY_SIGNATURES = (
 	"decodex.enforce_lease_operation_time()",
@@ -170,6 +173,12 @@ TRIGGER_ONLY_SIGNATURES = (
 	"decodex.forbid_work_item_acceptance_mutation()",
 	"decodex.enforce_work_item_acceptance_coherence()",
 	"decodex.enforce_work_item_event_namespace()",
+	"decodex.enforce_managed_run_command_owner()",
+	"decodex.forbid_managed_run_immutable_mutation()",
+	"decodex.enforce_managed_run_assignment_scope()",
+	"decodex.enforce_managed_run_state()",
+	"decodex.enforce_effect_barrier_state()",
+	"decodex.enforce_managed_run_event_namespace()",
 )
 RUNTIME_TYPE_NAMES = (
 	"decodex.account_state",
@@ -200,6 +209,14 @@ RUNTIME_TYPE_NAMES = (
 	"decodex.work_item_state",
 	"decodex.work_item_edge_kind",
 	"decodex.work_item_blocker_kind",
+	"decodex.managed_run_lifecycle",
+	"decodex.managed_run_phase",
+	"decodex.managed_run_wait_reason",
+	"decodex.execution_assignment_role",
+	"decodex.effect_barrier_state",
+	"decodex.managed_run_effect_kind",
+	"decodex.managed_run_effect_state",
+	"decodex.managed_run_safety_input_kind",
 )
 
 
@@ -787,6 +804,17 @@ def run_work_item_test(test: str, env: dict[str, str]) -> str:
 	)
 
 
+def run_managed_run_test(test: str, env: dict[str, str]) -> str:
+	return run(
+		[
+			"cargo", "nextest", "run", "-p", "decodex-postgres", "--features",
+			"test-support", "--test", "postgres_store", "--run-ignored", "all", "--",
+			f"managed_runs::{test}", "--exact",
+		],
+		env,
+	)
+
+
 def rust_digest_constant(name: str) -> str:
 	authority = (
 		REPO_ROOT / "crates/decodex-postgres/src/authority.rs"
@@ -1016,6 +1044,109 @@ def run_work_item_focused_contracts(
 			+ "\n\n".join(failures)
 		)
 	return "\n".join((migration_output, command_output, restore_output))
+
+
+def run_managed_run_focused_contracts(
+	socket_dir: Path, port: int, work: Path, env: dict[str, str]
+) -> str:
+	static_output = run(
+		[
+			"python3", "-m", "unittest",
+			"tests/scripts/test_managed_run_authority.py",
+		],
+		env,
+	)
+	create_database(MANAGED_RUN_DATABASE, env)
+	set_contract_urls(env, socket_dir, port, MANAGED_RUN_DATABASE, RUNTIME_ROLE)
+	migration_output = run_migration(env)
+	provision_runtime(MANAGED_RUN_DATABASE, RUNTIME_ROLE, env)
+	paths = {
+		"baseline": work / "xy1338-baseline-manifest.json",
+		"post_attempt": work / "xy1338-post-attempt-manifest.json",
+		"restored": work / "xy1338-restored-manifest.json",
+	}
+	checkpoints: dict[str, dict[str, str] | None] = dict.fromkeys(paths)
+	stage_failures: list[str] = []
+	command_output = ""
+	restore_output = ""
+	source_behavior_error: Exception | None = None
+
+	try:
+		dump_schema_manifest(paths["baseline"], env)
+		checkpoints["baseline"] = load_semantic_manifest(paths["baseline"])
+	except Exception as error:
+		stage_failures.append(f"baseline manifest capture failed:\n{error}")
+	if checkpoints["baseline"] is not None:
+		try:
+			command_output = run_managed_run_test(
+				"postgres_managed_run_safety_contract", env
+			)
+		except Exception as error:
+			source_behavior_error = error
+	else:
+		source_behavior_error = TestFailure(
+			"source behavior was not run because the baseline manifest is unavailable"
+		)
+	try:
+		dump_schema_manifest(paths["post_attempt"], env)
+		checkpoints["post_attempt"] = load_semantic_manifest(paths["post_attempt"])
+	except Exception as error:
+		stage_failures.append(f"post-attempt manifest capture failed:\n{error}")
+
+	dump_path = work / "xy1338-managed-runs.dump"
+	dump_succeeded = False
+	restore_database_created = False
+	try:
+		run(["pg_dump", "-Fc", "-f", str(dump_path), MANAGED_RUN_DATABASE], env)
+		dump_succeeded = True
+	except Exception as error:
+		stage_failures.append(f"post-attempt pg_dump failed:\n{error}")
+	if dump_succeeded:
+		try:
+			create_database(MANAGED_RUN_RESTORE_DATABASE, env)
+			restore_database_created = True
+		except Exception as error:
+			stage_failures.append(f"restore database creation failed:\n{error}")
+	if restore_database_created:
+		try:
+			run(
+				["pg_restore", "--exit-on-error", "-d", MANAGED_RUN_RESTORE_DATABASE,
+				 str(dump_path)],
+				env,
+			)
+		except Exception as error:
+			stage_failures.append(f"post-attempt pg_restore failed:\n{error}")
+		set_contract_urls(env, socket_dir, port, MANAGED_RUN_RESTORE_DATABASE, RUNTIME_ROLE)
+		try:
+			dump_schema_manifest(paths["restored"], env)
+			checkpoints["restored"] = load_semantic_manifest(paths["restored"])
+		except Exception as error:
+			stage_failures.append(f"restored manifest capture failed:\n{error}")
+
+	diagnostics, manifest_failures = manifest_diagnostics(checkpoints)
+	print(
+		"XY-1338 V12 semantic manifest diagnostics:\n"
+		+ json.dumps(diagnostics, indent=2, sort_keys=True),
+		file=sys.stderr,
+		flush=True,
+	)
+	failures = list(stage_failures)
+	if source_behavior_error is not None:
+		failures.append(f"source verifier/behavior failed:\n{source_behavior_error}")
+	failures.extend(manifest_failures)
+	if not failures:
+		try:
+			restore_output = run_managed_run_test(
+				"postgres_managed_run_safety_restore", env
+			)
+		except Exception as error:
+			failures.append(f"restored verifier/behavior failed:\n{error}")
+	if failures:
+		raise TestFailure(
+			"XY-1338 focused evidence finalized with failures:\n\n"
+			+ "\n\n".join(failures)
+		)
+	return "\n".join((static_output, migration_output, command_output, restore_output))
 
 
 def run_runtime_session_crash_recovery(
@@ -1251,6 +1382,10 @@ def provision_runtime(database: str, role: str, env: dict[str, str]) -> None:
 		f"GRANT SELECT ON TABLE decodex.work_items, decodex.work_item_objectives, "
 		f"decodex.work_item_edges, decodex.work_item_readiness_blockers, "
 		f"decodex.work_item_acceptances TO {role}; "
+		f"GRANT SELECT ON TABLE decodex.managed_runs, decodex.managed_run_assignments, "
+		f"decodex.managed_run_effect_barriers, decodex.managed_run_effects, "
+		f"decodex.managed_run_submitted_turn_receipts, "
+		f"decodex.managed_run_safety_inputs TO {role}; "
 		f"GRANT DELETE ON TABLE decodex.blob_objects TO {role}; "
 		f"GRANT SELECT, INSERT ON TABLE decodex.activity TO {role}; "
 		f"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE decodex.outbox TO {role}; "
@@ -1308,8 +1443,11 @@ max_entry_bytes = 4096
 
 def main() -> int:
 	focused_work_items = sys.argv[1:] == ["--focus-work-items"]
-	if sys.argv[1:] and not focused_work_items:
-		raise TestFailure("usage: postgres_store_test.py [--focus-work-items]")
+	focused_managed_runs = sys.argv[1:] == ["--focus-managed-runs"]
+	if sys.argv[1:] and not (focused_work_items or focused_managed_runs):
+		raise TestFailure(
+			"usage: postgres_store_test.py [--focus-work-items|--focus-managed-runs]"
+		)
 	temp_root_value = os.environ.get("DECODEX_TEST_TEMP_ROOT")
 	temp_root = None
 	if temp_root_value:
@@ -1324,7 +1462,8 @@ def main() -> int:
 		temp_root = requested_root.resolve(strict=True)
 	work = Path(
 		tempfile.mkdtemp(
-			prefix="decodex-xy1343-" if focused_work_items else "decodex-xy1267-",
+			prefix=("decodex-xy1343-" if focused_work_items else
+				"decodex-xy1338-" if focused_managed_runs else "decodex-xy1267-"),
 			dir=temp_root,
 		)
 	).resolve()
@@ -1408,6 +1547,10 @@ def main() -> int:
 
 		if focused_work_items:
 			output = run_work_item_focused_contracts(socket_dir, port, work, env)
+			print(output)
+			return 0
+		if focused_managed_runs:
+			output = run_managed_run_focused_contracts(socket_dir, port, work, env)
 			print(output)
 			return 0
 

--- a/scripts/vnext/postgres_store_test.py
+++ b/scripts/vnext/postgres_store_test.py
@@ -3,11 +3,13 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from enum import Enum
 import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import secrets
 import select
 import shutil
@@ -52,6 +54,8 @@ RUNTIME_SESSION_FENCE_DATABASE = "decodex_xy1337_fence"
 RUNTIME_SESSION_CRASH_DATABASE = "decodex_xy1337_crash"
 RUNTIME_SESSION_RESTORE_SOURCE_DATABASE = "decodex_xy1337_restore_source"
 RUNTIME_SESSION_RESTORE_DATABASE = "decodex_xy1337_restore"
+WORK_ITEM_DATABASE = "decodex_xy1343_work_items"
+WORK_ITEM_RESTORE_DATABASE = "decodex_xy1343_work_items_restore"
 MIGRATION_ROLE = "decodex_migration"
 RUNTIME_ROLE = "decodex_runtime"
 FUNCTION_OWNER_ROLE = "decodex_function_owner"
@@ -117,6 +121,11 @@ RUNTIME_EXECUTE_SIGNATURES = (
 	"decodex.update_role_profile_exact(pg_catalog.text,pg_catalog.text,decodex.role_profile_role,pg_catalog.int8,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.text)",
 	"decodex.create_runtime_session_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,decodex.role_profile_role,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text,decodex.account_state,pg_catalog.int8,pg_catalog.uuid,decodex.runtime_session_state)",
 	"decodex.transition_runtime_session_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.int8,decodex.runtime_session_state)",
+	"decodex.create_work_item_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid,pg_catalog._uuid,pg_catalog._uuid,pg_catalog._uuid,pg_catalog.text,pg_catalog.text,decodex.work_item_priority,pg_catalog._text,pg_catalog._text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text)",
+	"decodex.update_work_item_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,pg_catalog.uuid,pg_catalog._uuid,pg_catalog._uuid,pg_catalog._uuid,pg_catalog.text,pg_catalog.text,decodex.work_item_priority,pg_catalog._text,pg_catalog._text,decodex.work_item_state,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text)",
+	"decodex.assess_work_item_readiness_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text)",
+	"decodex.accept_work_item_exact(pg_catalog.text,pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.text)",
+	"decodex.guard_work_item_running_resume(pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int8)",
 )
 TRIGGER_ONLY_SIGNATURES = (
 	"decodex.enforce_lease_operation_time()",
@@ -156,6 +165,11 @@ TRIGGER_ONLY_SIGNATURES = (
 	"decodex.enforce_runtime_session_command_owner()",
 	"decodex.forbid_runtime_snapshot_mutation()",
 	"decodex.enforce_runtime_session_event_namespace()",
+	"decodex.enforce_work_item_state()",
+	"decodex.enforce_work_item_command_owner()",
+	"decodex.forbid_work_item_acceptance_mutation()",
+	"decodex.enforce_work_item_acceptance_coherence()",
+	"decodex.enforce_work_item_event_namespace()",
 )
 RUNTIME_TYPE_NAMES = (
 	"decodex.account_state",
@@ -182,6 +196,10 @@ RUNTIME_TYPE_NAMES = (
 	"decodex.quota_window_class",
 	"decodex.observation_confidence",
 	"decodex.role_profile_role",
+	"decodex.work_item_priority",
+	"decodex.work_item_state",
+	"decodex.work_item_edge_kind",
+	"decodex.work_item_blocker_kind",
 )
 
 
@@ -758,6 +776,248 @@ def run_runtime_session_test(test: str, env: dict[str, str]) -> str:
 	)
 
 
+def run_work_item_test(test: str, env: dict[str, str]) -> str:
+	return run(
+		[
+			"cargo", "nextest", "run", "-p", "decodex-postgres", "--features",
+			"test-support", "--test", "postgres_store", "--run-ignored", "all", "--",
+			f"work_items::{test}", "--exact",
+		],
+		env,
+	)
+
+
+def rust_digest_constant(name: str) -> str:
+	authority = (
+		REPO_ROOT / "crates/decodex-postgres/src/authority.rs"
+	).read_text(encoding="utf-8")
+	match = re.search(
+		rf"const {re.escape(name)}: \[u8; 32\] = \[(.*?)\];",
+		authority,
+		flags=re.DOTALL,
+	)
+	if match is None:
+		raise TestFailure(f"missing Rust digest constant {name}")
+	values = re.findall(r"0x([0-9a-fA-F]{2})", match.group(1))
+	if len(values) != 32:
+		raise TestFailure(f"invalid Rust digest constant {name}")
+	return "".join(value.lower() for value in values)
+
+
+def load_semantic_manifest(path: Path) -> dict[str, str]:
+	document = json.loads(path.read_text(encoding="utf-8"))
+	if set(document) != {"schema", "authority"} or not all(
+		isinstance(document[key], str) for key in ("schema", "authority")
+	):
+		raise TestFailure(f"invalid semantic manifest at {path}")
+	for component in ("schema", "authority"):
+		rows = json.loads(document[component])
+		if not isinstance(rows, list):
+			raise TestFailure(f"invalid {component} row manifest at {path}")
+	return document
+
+
+def semantic_row_diff(before: str, after: str) -> dict[str, list[object]]:
+	before_rows = json.loads(before)
+	after_rows = json.loads(after)
+	if not isinstance(before_rows, list) or not isinstance(after_rows, list):
+		raise TestFailure("semantic manifest component is not a row array")
+	encode = lambda row: json.dumps(row, sort_keys=True, separators=(",", ":"))
+	before_counter = Counter(encode(row) for row in before_rows)
+	after_counter = Counter(encode(row) for row in after_rows)
+	return {
+		"before_only": [
+			json.loads(row)
+			for row, count in sorted((before_counter - after_counter).items())
+			for _ in range(count)
+		],
+		"after_only": [
+			json.loads(row)
+			for row, count in sorted((after_counter - before_counter).items())
+			for _ in range(count)
+		],
+	}
+
+
+def manifest_diagnostics(
+	checkpoints: dict[str, dict[str, str] | None],
+) -> tuple[dict[str, object], list[str]]:
+	shipped_expected = {
+		"schema": rust_digest_constant("SCHEMA_CONTRACT_SHA256"),
+		"authority": rust_digest_constant("CONFIGURED_AUTHORITY_SHA256"),
+	}
+	actual = {
+		checkpoint: None if manifest is None else {
+			component: hashlib.sha256(value.encode("utf-8")).hexdigest()
+			for component, value in manifest.items()
+		}
+		for checkpoint, manifest in checkpoints.items()
+	}
+	missing_checkpoints = [
+		checkpoint for checkpoint, manifest in checkpoints.items() if manifest is None
+	]
+	component_results: dict[str, object] = {}
+	manifest_failures = [
+		f"missing semantic manifest checkpoint: {checkpoint}"
+		for checkpoint in missing_checkpoints
+	]
+	for component in ("schema", "authority"):
+		matches_shipped = {
+			checkpoint: None if manifest is None else manifest[component] == shipped_expected[component]
+			for checkpoint, manifest in actual.items()
+		}
+		available_values = [
+			manifest[component] for manifest in actual.values() if manifest is not None
+		]
+		available_equal = len(set(available_values)) <= 1
+		checkpoints_equal = (
+			len(available_values) == len(checkpoints)
+			and available_equal
+		)
+		component_results[component] = {
+			"matches_shipped": matches_shipped,
+			"checkpoints_equal": checkpoints_equal,
+		}
+		for checkpoint, matches in matches_shipped.items():
+			if matches is False:
+				manifest_failures.append(
+					f"{checkpoint} {component} digest differs from the shipped singleton"
+				)
+		if len(available_values) > 1 and not available_equal:
+			manifest_failures.append(
+				f"{component} manifest changed across available checkpoints"
+			)
+	diagnostics: dict[str, object] = {
+		"shipped_expected": shipped_expected,
+		"actual": actual,
+		"missing_checkpoints": missing_checkpoints,
+		"component_results": component_results,
+		"semantic_row_diffs": {},
+	}
+	diffs = diagnostics["semantic_row_diffs"]
+	assert isinstance(diffs, dict)
+	for comparison, before_name, after_name in (
+		("baseline_to_post_attempt", "baseline", "post_attempt"),
+		("post_attempt_to_restored", "post_attempt", "restored"),
+		("baseline_to_restored", "baseline", "restored"),
+	):
+		diffs[comparison] = {}
+		for component in ("schema", "authority"):
+			before = checkpoints[before_name]
+			after = checkpoints[after_name]
+			if before is None or after is None:
+				diffs[comparison][component] = {
+					"unavailable": [
+						name for name, manifest in ((before_name, before), (after_name, after))
+						if manifest is None
+					]
+				}
+			else:
+				diffs[comparison][component] = semantic_row_diff(
+					before[component], after[component]
+				)
+	return diagnostics, manifest_failures
+
+
+def run_work_item_focused_contracts(
+	socket_dir: Path, port: int, work: Path, env: dict[str, str]
+) -> str:
+	create_database(WORK_ITEM_DATABASE, env)
+	set_contract_urls(env, socket_dir, port, WORK_ITEM_DATABASE, RUNTIME_ROLE)
+	migration_output = run_migration(env)
+	provision_runtime(WORK_ITEM_DATABASE, RUNTIME_ROLE, env)
+	baseline_path = work / "xy1343-baseline-manifest.json"
+	post_attempt_path = work / "xy1343-post-attempt-manifest.json"
+	restored_path = work / "xy1343-restored-manifest.json"
+	checkpoints: dict[str, dict[str, str] | None] = {
+		"baseline": None,
+		"post_attempt": None,
+		"restored": None,
+	}
+	stage_failures: list[str] = []
+	command_output = ""
+	source_behavior_error: Exception | None = None
+	restore_output = ""
+
+	try:
+		dump_schema_manifest(baseline_path, env)
+		checkpoints["baseline"] = load_semantic_manifest(baseline_path)
+	except Exception as error:
+		stage_failures.append(f"baseline manifest capture failed:\n{error}")
+
+	if checkpoints["baseline"] is not None:
+		try:
+			command_output = run_work_item_test("postgres_exact_work_item_commands", env)
+		except Exception as error:
+			source_behavior_error = error
+	else:
+		source_behavior_error = TestFailure(
+			"source behavior was not run because the baseline manifest is unavailable"
+		)
+
+	try:
+		dump_schema_manifest(post_attempt_path, env)
+		checkpoints["post_attempt"] = load_semantic_manifest(post_attempt_path)
+	except Exception as error:
+		stage_failures.append(f"post-attempt manifest capture failed:\n{error}")
+
+	dump_path = work / "xy1343-work-items.dump"
+	dump_succeeded = False
+	restore_database_created = False
+	try:
+		run(["pg_dump", "-Fc", "-f", str(dump_path), WORK_ITEM_DATABASE], env)
+		dump_succeeded = True
+	except Exception as error:
+		stage_failures.append(f"post-attempt pg_dump failed:\n{error}")
+	if dump_succeeded:
+		try:
+			create_database(WORK_ITEM_RESTORE_DATABASE, env)
+			restore_database_created = True
+		except Exception as error:
+			stage_failures.append(f"restore database creation failed:\n{error}")
+	if restore_database_created:
+		try:
+			run(
+				[
+					"pg_restore", "--exit-on-error", "-d", WORK_ITEM_RESTORE_DATABASE,
+					str(dump_path),
+				],
+				env,
+			)
+		except Exception as error:
+			stage_failures.append(f"post-attempt pg_restore failed:\n{error}")
+		set_contract_urls(env, socket_dir, port, WORK_ITEM_RESTORE_DATABASE, RUNTIME_ROLE)
+		try:
+			dump_schema_manifest(restored_path, env)
+			checkpoints["restored"] = load_semantic_manifest(restored_path)
+		except Exception as error:
+			stage_failures.append(f"restored manifest capture failed:\n{error}")
+
+	diagnostics, manifest_failures = manifest_diagnostics(checkpoints)
+	print(
+		"XY-1343 V11 semantic manifest diagnostics:\n"
+		+ json.dumps(diagnostics, indent=2, sort_keys=True),
+		file=sys.stderr,
+		flush=True,
+	)
+
+	failures = list(stage_failures)
+	if source_behavior_error is not None:
+		failures.append(f"source verifier/behavior failed:\n{source_behavior_error}")
+	failures.extend(manifest_failures)
+	if not failures:
+		try:
+			restore_output = run_work_item_test("postgres_exact_work_item_restore", env)
+		except Exception as error:
+			failures.append(f"restored verifier/behavior failed:\n{error}")
+	if failures:
+		raise TestFailure(
+			"XY-1343 focused evidence finalized with failures:\n\n"
+			+ "\n\n".join(failures)
+		)
+	return "\n".join((migration_output, command_output, restore_output))
+
+
 def run_runtime_session_crash_recovery(
 	data_dir: Path,
 	log_path: Path,
@@ -988,6 +1248,9 @@ def provision_runtime(database: str, role: str, env: dict[str, str]) -> None:
 		f"decodex.policies, decodex.policy_revisions TO {role}; "
 		f"GRANT SELECT ON TABLE decodex.programs, decodex.objectives, "
 		f"decodex.objective_completion_evidence TO {role}; "
+		f"GRANT SELECT ON TABLE decodex.work_items, decodex.work_item_objectives, "
+		f"decodex.work_item_edges, decodex.work_item_readiness_blockers, "
+		f"decodex.work_item_acceptances TO {role}; "
 		f"GRANT DELETE ON TABLE decodex.blob_objects TO {role}; "
 		f"GRANT SELECT, INSERT ON TABLE decodex.activity TO {role}; "
 		f"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE decodex.outbox TO {role}; "
@@ -1044,7 +1307,27 @@ max_entry_bytes = 4096
 
 
 def main() -> int:
-	work = Path(tempfile.mkdtemp(prefix="decodex-xy1267-")).resolve()
+	focused_work_items = sys.argv[1:] == ["--focus-work-items"]
+	if sys.argv[1:] and not focused_work_items:
+		raise TestFailure("usage: postgres_store_test.py [--focus-work-items]")
+	temp_root_value = os.environ.get("DECODEX_TEST_TEMP_ROOT")
+	temp_root = None
+	if temp_root_value:
+		requested_root = Path(temp_root_value)
+		if not requested_root.is_absolute():
+			raise TestFailure("DECODEX_TEST_TEMP_ROOT must be absolute")
+		for component in (requested_root, *requested_root.parents):
+			if component.is_symlink():
+				raise TestFailure("DECODEX_TEST_TEMP_ROOT must not contain a symlink")
+		if not requested_root.is_dir():
+			raise TestFailure("DECODEX_TEST_TEMP_ROOT must be a real existing directory")
+		temp_root = requested_root.resolve(strict=True)
+	work = Path(
+		tempfile.mkdtemp(
+			prefix="decodex-xy1343-" if focused_work_items else "decodex-xy1267-",
+			dir=temp_root,
+		)
+	).resolve()
 	data_dir = work / "postgres"
 	socket_dir = work / "socket"
 	log_path = work / "postgres.log"
@@ -1122,6 +1405,11 @@ def main() -> int:
 			elif role == UNSAFE_ROLES["superuser"]:
 				attributes += " SUPERUSER"
 			psql("postgres", f"CREATE ROLE {role}{attributes}", env)
+
+		if focused_work_items:
+			output = run_work_item_focused_contracts(socket_dir, port, work, env)
+			print(output)
+			return 0
 
 		create_database(DATABASE, env)
 		set_contract_urls(env, socket_dir, port, DATABASE, RUNTIME_ROLE)
@@ -2514,6 +2802,7 @@ def main() -> int:
 		print("\n".join(authority_drift_outputs))
 		return 0
 	finally:
+		primary_failure = sys.exc_info()[0] is not None
 		stop_error: Exception | None = None
 		stop_failures: list[str] = []
 		status = postgres_status(data_dir, env) if data_dir.exists() else ClusterStatus.STOPPED
@@ -2548,9 +2837,21 @@ def main() -> int:
 					f"PostgreSQL shutdown recovered after an error:{stop_diagnostics}",
 					file=sys.stderr,
 				)
-			shutil.rmtree(work, ignore_errors=True)
+			try:
+				shutil.rmtree(work)
+			except Exception as error:
+				cleanup_error = TestFailure(
+					f"failed to remove stopped task-owned PostgreSQL directory {work}: {error}"
+				)
+				if primary_failure:
+					print(cleanup_error, file=sys.stderr)
+				else:
+					raise cleanup_error
 		elif stop_error is not None:
-			raise stop_error
+			if primary_failure:
+				print(stop_error, file=sys.stderr)
+			else:
+				raise stop_error
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_managed_run_authority.py
+++ b/tests/scripts/test_managed_run_authority.py
@@ -1,0 +1,311 @@
+"""Static regressions for the inert XY-1338 V12 ManagedRun boundary."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION = ROOT / "crates/decodex-postgres/migrations/V12__managed_run_safety.sql"
+CONVERSATION_MIGRATION = (
+    ROOT / "crates/decodex-postgres/migrations/V3__conversation_history.sql"
+)
+RUNTIME_SESSION_MIGRATION = (
+    ROOT / "crates/decodex-postgres/migrations/V10__runtime_session_snapshots.sql"
+)
+RUST_API = ROOT / "crates/decodex-postgres/src/managed_runs.rs"
+RUNTIME_SESSION_RUST_API = ROOT / "crates/decodex-postgres/src/runtime_sessions.rs"
+CORE = ROOT / "crates/decodex-core/src/managed_run.rs"
+AUTHORITY = ROOT / "crates/decodex-postgres/src/authority.rs"
+MIGRATIONS = ROOT / "crates/decodex-postgres/src/migrations.rs"
+
+
+class ManagedRunAuthorityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.migration = MIGRATION.read_text(encoding="utf-8")
+        cls.conversation_migration = CONVERSATION_MIGRATION.read_text(
+            encoding="utf-8"
+        )
+        cls.runtime_session_migration = RUNTIME_SESSION_MIGRATION.read_text(
+            encoding="utf-8"
+        )
+        cls.rust_api = RUST_API.read_text(encoding="utf-8")
+        cls.runtime_session_rust_api = RUNTIME_SESSION_RUST_API.read_text(
+            encoding="utf-8"
+        )
+        cls.core = CORE.read_text(encoding="utf-8")
+        cls.authority = AUTHORITY.read_text(encoding="utf-8")
+        cls.migrations = MIGRATIONS.read_text(encoding="utf-8")
+
+    def test_v12_is_the_only_next_forward_migration(self) -> None:
+        versions = sorted(
+            int(path.name.split("__", 1)[0][1:])
+            for path in MIGRATION.parent.glob("V*.sql")
+        )
+        self.assertEqual(versions, list(range(1, 13)))
+        self.assertIn("EXPECTED_LATEST_MIGRATION_VERSION: i32 = 12", self.migrations)
+        self.assertIn("MANAGED_RUN_MIGRATION", self.authority)
+
+    def test_execution_path_trigger_inventory_matches_canonical_full_identities(self) -> None:
+        canonical_source = self.authority.split(
+            'const TRIGGER_CONTRACT_SQL: &str = r#"', 1
+        )[1].split('"#;', 1)[0]
+        execution_source = self.authority.split(
+            'const EXECUTION_PATH_CONTRACT_SQL: &str = r#"', 1
+        )[1].split('"#;', 1)[0]
+        canonical = set(re.findall(
+            r"\('([^']+)', '([^']+)', '([^']+)', \d+\)",
+            canonical_source,
+        ))
+        execution = set(re.findall(
+            r"\('([^']+)', '([^']+)', 'decodex\.([^']+)\(\)'\)",
+            execution_source,
+        ))
+        self.assertEqual(len(canonical), 84)
+        self.assertEqual(execution, canonical)
+
+    def test_event_namespace_uses_relation_aware_row_shapes(self) -> None:
+        body = self.migration.split(
+            "CREATE FUNCTION decodex.enforce_managed_run_event_namespace()", 1
+        )[1].split("CREATE TRIGGER activity_managed_run_namespace", 1)[0]
+        activity, outbox = body.split("IF TG_TABLE_NAME = 'activity' THEN", 1)[1].split(
+            "\n\tELSE\n", 1
+        )
+        outbox = outbox.split("\n\tEND IF;\n\tIF linked", 1)[0]
+        for row in ("NEW", "OLD"):
+            self.assertIn(f"{row}.aggregate_kind", activity)
+            self.assertIn(f"{row}.event_kind", activity)
+            self.assertIn(f"{row}.payload", activity)
+            self.assertIn(f"{row}.aggregate_kind", outbox)
+            self.assertIn(f"{row}.payload", outbox)
+            self.assertNotIn(f"{row}.event_kind", outbox)
+        self.assertIn("NEW.payload, '$.**.activity_sequence'", outbox)
+        self.assertIn("OLD.payload, '$.**.activity_sequence'", outbox)
+        self.assertIn("invalid_text_representation OR numeric_value_out_of_range", body)
+        self.assertIn("NEW.id IS DISTINCT FROM OLD.id", body)
+
+    def test_v12_replaces_the_ambiguous_runtime_session_snapshot_local(self) -> None:
+        signature = "decodex.create_runtime_session_exact("
+        replacement = f"CREATE OR REPLACE FUNCTION {signature}"
+        self.assertEqual(self.migration.count(replacement), 1)
+        replacement_body = self.migration.split(replacement, 1)[1].split("$$;", 1)[0]
+        self.assertIn("DECLARE created_profile_snapshot_id uuid;", replacement_body)
+        self.assertNotIn("DECLARE profile_snapshot_id uuid;", replacement_body)
+        self.assertEqual(replacement_body.count("created_profile_snapshot_id"), 4)
+        self.assertEqual(
+            replacement_body.count("'profile_snapshot_id', profile_snapshot_id"), 2
+        )
+
+        transition_signature = "decodex.transition_runtime_session_exact("
+        transition_replacement = f"CREATE OR REPLACE FUNCTION {transition_signature}"
+        self.assertEqual(self.migration.count(transition_replacement), 1)
+        transition_body = self.migration.split(transition_replacement, 1)[1].split(
+            "$$;", 1
+        )[0]
+        for body in (replacement_body, transition_body):
+            self.assertEqual(
+                body.count("'runtime_session_snapshot', session_value"), 2
+            )
+            self.assertNotIn("'runtime_session', session_value", body)
+        self.assertIn(
+            'required_value(effect, "runtime_session_snapshot")',
+            self.runtime_session_rust_api,
+        )
+        self.assertIn(
+            'activity_payload.get("runtime_session_snapshot")',
+            self.runtime_session_rust_api,
+        )
+        self.assertNotIn(
+            'required_value(effect, "runtime_session")', self.runtime_session_rust_api
+        )
+        self.assertNotIn(
+            'activity_payload.get("runtime_session")', self.runtime_session_rust_api
+        )
+
+        resolver = self.authority.split(
+            "fn canonical_function_source", 1
+        )[1].split("async fn verify_identity_cast_authority", 1)[0]
+        self.assertIn('format!("CREATE FUNCTION decodex.{}"', resolver)
+        self.assertIn('format!("CREATE OR REPLACE FUNCTION decodex.{}"', resolver)
+        self.assertIn(".rev()", resolver)
+        self.assertIn("migration.rfind(declaration.as_str())", resolver)
+
+        canonical_body = None
+        for migration in (self.runtime_session_migration, self.migration):
+            definitions = []
+            for prefix in ("CREATE FUNCTION ", "CREATE OR REPLACE FUNCTION "):
+                declaration = f"{prefix}{signature}"
+                index = migration.rfind(declaration)
+                if index >= 0:
+                    definitions.append((index, declaration))
+            if definitions:
+                index, declaration = max(definitions)
+                canonical_body = migration[index + len(declaration):].split(
+                    "$$;", 1
+                )[0]
+        self.assertEqual(canonical_body, replacement_body)
+
+    def test_v12_repairs_invoker_hierarchy_locks_without_runtime_session_update(self) -> None:
+        for signature, retained_lock, removed_lock in (
+            (
+                "decodex.enforce_turn_state()",
+                "FOR UPDATE OF c;",
+                "FOR UPDATE OF c, rs",
+            ),
+            (
+                "decodex.enforce_history_item_state()",
+                "FOR UPDATE OF c, t;",
+                "FOR UPDATE OF c, rs",
+            ),
+        ):
+            replacement = f"CREATE OR REPLACE FUNCTION {signature}"
+            self.assertEqual(self.migration.count(replacement), 1)
+            replacement_body = self.migration.split(replacement, 1)[1].split(
+                "$$;", 1
+            )[0]
+            self.assertIn("SET search_path = pg_catalog, decodex", replacement_body)
+            self.assertIn(
+                "current_setting('transaction_isolation') <> 'read committed'",
+                replacement_body,
+            )
+            self.assertIn("ERRCODE = '40001'", replacement_body)
+            self.assertIn(retained_lock, replacement_body)
+            self.assertNotIn(removed_lock, replacement_body)
+            self.assertNotIn("SECURITY DEFINER", replacement_body)
+
+            canonical_body = None
+            for migration in (self.conversation_migration, self.migration):
+                definitions = []
+                for prefix in ("CREATE FUNCTION ", "CREATE OR REPLACE FUNCTION "):
+                    declaration = f"{prefix}{signature}"
+                    index = migration.rfind(declaration)
+                    if index >= 0:
+                        definitions.append((index, declaration))
+                if definitions:
+                    index, declaration = max(definitions)
+                    canonical_body = migration[index + len(declaration):].split(
+                        "$$;", 1
+                    )[0]
+            self.assertEqual(canonical_body, replacement_body)
+
+    def test_persistence_is_exactly_project_work_item_and_session_scoped(self) -> None:
+        for constraint in (
+            "managed_runs_work_item_project_fk",
+            "managed_runs_runtime_session_revision_fk",
+            "managed_run_assignments_run_project_fk",
+            "managed_run_effects_run_scope_fk",
+            "managed_run_effects_barrier_fk",
+        ):
+            self.assertIn(constraint, self.migration)
+        self.assertIn("DEFERRABLE INITIALLY DEFERRED", self.migration)
+        self.assertIn("runtime_session_revision", self.rust_api)
+
+    def test_turn_identity_preserves_the_accepted_canonical_uuid_domain(self) -> None:
+        receipt_table = self.migration.split(
+            "CREATE TABLE decodex.managed_run_submitted_turn_receipts", 1
+        )[1].split("CREATE TABLE decodex.managed_run_safety_inputs", 1)[0]
+        safety_table = self.migration.split(
+            "CREATE TABLE decodex.managed_run_safety_inputs", 1
+        )[1].split("CREATE FUNCTION decodex.enforce_managed_run_command_owner", 1)[0]
+        self.assertNotIn("turn_id::text COLLATE", receipt_table)
+        self.assertNotIn("turn_id::text COLLATE", safety_table)
+        self.assertIn("receipt_id::text COLLATE", receipt_table)
+        self.assertIn("input_id::text COLLATE", safety_table)
+
+    def test_execution_assignments_cannot_encode_advisor_or_lead(self) -> None:
+        assignment_type = self.migration.split(
+            "CREATE TYPE decodex.execution_assignment_role", 1
+        )[1].split(";", 1)[0]
+        self.assertIn("'task', 'reviewer'", assignment_type)
+        self.assertNotIn("advisor", assignment_type)
+        self.assertNotIn("lead", assignment_type)
+        self.assertNotIn("agent_id", self.migration.split(
+            "CREATE TABLE decodex.managed_run_assignments", 1
+        )[1].split(");", 1)[0])
+        self.assertIn("snapshot_role::text <> NEW.role::text", self.migration)
+
+    def test_only_waiting_blocked_runs_and_fail_closed_barriers_persist(self) -> None:
+        self.assertIn("managed_runs_inert_waiting_only", self.migration)
+        self.assertIn("lifecycle = 'waiting'", self.migration)
+        self.assertIn("AND blocked", self.migration)
+        barrier_type = self.migration.split(
+            "CREATE TYPE decodex.effect_barrier_state", 1
+        )[1].split(";", 1)[0]
+        self.assertEqual(barrier_type.count("'guarded'"), 1)
+        self.assertEqual(barrier_type.count("'closed'"), 1)
+        self.assertNotIn("open", barrier_type.lower())
+        self.assertIn("effect barrier may only close exactly once", self.migration)
+
+    def test_safety_inputs_are_positive_or_explicitly_inconclusive(self) -> None:
+        safety_type = self.migration.split(
+            "CREATE TYPE decodex.managed_run_safety_input_kind", 1
+        )[1].split(";", 1)[0]
+        for supported in (
+            "positively_observed_unknown_turn",
+            "submitted_turn_receipt",
+            "inconclusive_observation",
+        ):
+            self.assertIn(supported, safety_type)
+        forbidden = (
+            "present", "complete", "present_empty", "absent", "not_found",
+            "scan_exhaust", "no_event", "empty", "missing_method_result",
+        )
+        for value in forbidden:
+            self.assertNotIn(value, safety_type.lower())
+        self.assertNotIn("timestamped_method", safety_type)
+
+    def test_atomic_command_closes_before_return_and_replays_durable_bytes(self) -> None:
+        command = self.migration.split(
+            "CREATE FUNCTION decodex.apply_managed_run_safety_input_exact", 1
+        )[1].split("REVOKE ALL ON TABLE", 1)[0]
+        for operation in (
+            "UPDATE decodex.runtime_sessions",
+            "UPDATE decodex.managed_runs",
+            "UPDATE decodex.managed_run_effect_barriers",
+            "INSERT INTO decodex.managed_run_safety_inputs",
+            "UPDATE decodex.exact_command_receipts",
+        ):
+            self.assertIn(operation, command)
+        self.assertLess(command.index("UPDATE decodex.managed_run_effect_barriers"),
+                        command.index("response_value :="))
+        self.assertIn("RETURN prior_input.response_bytes", command)
+        self.assertIn("RETURN existing_response", self.migration)
+        self.assertIn("prior_input.request_envelope<>request_value", command)
+        self.assertIn("request_envelope,effect_envelope,response_bytes", command)
+        reservation = command.index(
+            "replay := decodex.reserve_exact_managed_run_safety_command"
+        )
+        validation = command.index("IF p_managed_run_id IS NULL")
+        hierarchy = command.index("pg_advisory_xact_lock(1271)")
+        run_scope = command.index("pg_advisory_xact_lock(1338")
+        first_hierarchy_read = command.index("SELECT * INTO prior_input")
+        self.assertLess(reservation, validation)
+        self.assertLess(validation, hierarchy)
+        self.assertLess(hierarchy, run_scope)
+        self.assertLess(run_scope, first_hierarchy_read)
+
+    def test_no_positive_run_mutation_or_producer_surface_exists(self) -> None:
+        for forbidden in (
+            "create_managed_run", "acquire_managed_run", "activate_managed_run",
+            "advance_managed_run", "resume_managed_run", "complete_managed_run",
+            "validate_managed_run", "dispatch_managed_run", "scan_codex",
+            "submit_turn", "create_thread", "pagination", "wake_registration",
+        ):
+            self.assertNotIn(forbidden, self.rust_api.lower())
+            self.assertNotIn(f"decodex.{forbidden}", self.migration.lower())
+        self.assertNotIn("pub async fn create_", self.rust_api)
+        self.assertNotIn("pub async fn transition_", self.rust_api)
+        self.assertIn("read_managed_run_exact", self.rust_api)
+        self.assertIn("apply_managed_run_safety_input", self.rust_api)
+
+    def test_state_algebra_is_pure_and_exhaustively_fixture_driven(self) -> None:
+        self.assertIn("pub const fn from_parts", self.core)
+        self.assertIn("InvalidState", self.core)
+        self.assertIn("state_algebra_accepts_only_canonical", self.core)
+        self.assertNotIn("Postgres", self.core)
+        self.assertNotIn("tokio", self.core)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_runtime_session_authority.py
+++ b/tests/scripts/test_runtime_session_authority.py
@@ -22,13 +22,13 @@ class RuntimeSessionAuthorityTests(unittest.TestCase):
         cls.authority = AUTHORITY.read_text(encoding="utf-8")
         cls.migrations = MIGRATIONS.read_text(encoding="utf-8")
 
-    def test_v10_is_the_one_next_forward_zero_state_cutover(self) -> None:
+    def test_v10_remains_the_zero_state_predecessor_to_v11(self) -> None:
         versions = sorted(
             int(path.name.split("__", 1)[0][1:])
             for path in MIGRATION.parent.glob("V*.sql")
         )
-        self.assertEqual(versions, list(range(1, 11)))
-        self.assertIn("EXPECTED_LATEST_MIGRATION_VERSION: i32 = 10", self.migrations)
+        self.assertEqual(versions, list(range(1, 12)))
+        self.assertIn("EXPECTED_LATEST_MIGRATION_VERSION: i32 = 11", self.migrations)
         self.assertIn("IN ACCESS EXCLUSIVE MODE", self.migration)
         self.assertIn("runtime_session_v10_zero_state", self.migration)
         self.assertIn("operation IN ('create_runtime_session', 'transition_runtime_session')", self.migration)

--- a/tests/scripts/test_runtime_session_authority.py
+++ b/tests/scripts/test_runtime_session_authority.py
@@ -22,13 +22,13 @@ class RuntimeSessionAuthorityTests(unittest.TestCase):
         cls.authority = AUTHORITY.read_text(encoding="utf-8")
         cls.migrations = MIGRATIONS.read_text(encoding="utf-8")
 
-    def test_v10_remains_the_zero_state_predecessor_to_v11(self) -> None:
+    def test_v10_remains_the_zero_state_predecessor_in_the_v12_ledger(self) -> None:
         versions = sorted(
             int(path.name.split("__", 1)[0][1:])
             for path in MIGRATION.parent.glob("V*.sql")
         )
-        self.assertEqual(versions, list(range(1, 12)))
-        self.assertIn("EXPECTED_LATEST_MIGRATION_VERSION: i32 = 11", self.migrations)
+        self.assertEqual(versions, list(range(1, 13)))
+        self.assertIn("EXPECTED_LATEST_MIGRATION_VERSION: i32 = 12", self.migrations)
         self.assertIn("IN ACCESS EXCLUSIVE MODE", self.migration)
         self.assertIn("runtime_session_v10_zero_state", self.migration)
         self.assertIn("operation IN ('create_runtime_session', 'transition_runtime_session')", self.migration)

--- a/tests/scripts/test_work_item_authority.py
+++ b/tests/scripts/test_work_item_authority.py
@@ -21,13 +21,13 @@ class WorkItemAuthorityTests(unittest.TestCase):
         cls.migrations = MIGRATIONS.read_text(encoding="utf-8")
         cls.harness = HARNESS.read_text(encoding="utf-8")
 
-    def test_v11_is_the_only_next_forward_migration(self) -> None:
+    def test_v11_remains_the_exact_predecessor_to_v12(self) -> None:
         versions = sorted(
             int(path.name.split("__", 1)[0][1:])
             for path in MIGRATION.parent.glob("V*.sql")
         )
-        self.assertEqual(versions, list(range(1, 12)))
-        self.assertIn("EXPECTED_LATEST_MIGRATION_VERSION: i32 = 11", self.migrations)
+        self.assertEqual(versions, list(range(1, 13)))
+        self.assertIn("EXPECTED_LATEST_MIGRATION_VERSION: i32 = 12", self.migrations)
         self.assertIn("WORK_ITEM_MIGRATION", self.authority)
 
     def test_v11_schema_is_a_singleton_pg18_restore_fixed_point(self) -> None:
@@ -85,7 +85,7 @@ class WorkItemAuthorityTests(unittest.TestCase):
             self.assertNotIn("VALIDATE CONSTRAINT", statement)
 
         self.assertIn(
-            "0xc4, 0x8f, 0x7b, 0x49, 0x8d, 0xac, 0x7f, 0xd1",
+            "0x99, 0xb6, 0x41, 0xfb, 0xd0, 0xee, 0x07, 0xc1",
             self.authority,
         )
         self.assertNotIn("expected_manifest_digest", self.authority)

--- a/tests/scripts/test_work_item_authority.py
+++ b/tests/scripts/test_work_item_authority.py
@@ -1,0 +1,195 @@
+"""Static regressions for the XY-1343 V11 exact WorkItem boundary."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION = ROOT / "crates/decodex-postgres/migrations/V11__work_item_authority.sql"
+RUST_API = ROOT / "crates/decodex-postgres/src/work_items.rs"
+AUTHORITY = ROOT / "crates/decodex-postgres/src/authority.rs"
+MIGRATIONS = ROOT / "crates/decodex-postgres/src/migrations.rs"
+HARNESS = ROOT / "scripts/vnext/postgres_store_test.py"
+
+
+class WorkItemAuthorityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.migration = MIGRATION.read_text(encoding="utf-8")
+        cls.rust_api = RUST_API.read_text(encoding="utf-8")
+        cls.authority = AUTHORITY.read_text(encoding="utf-8")
+        cls.migrations = MIGRATIONS.read_text(encoding="utf-8")
+        cls.harness = HARNESS.read_text(encoding="utf-8")
+
+    def test_v11_is_the_only_next_forward_migration(self) -> None:
+        versions = sorted(
+            int(path.name.split("__", 1)[0][1:])
+            for path in MIGRATION.parent.glob("V*.sql")
+        )
+        self.assertEqual(versions, list(range(1, 12)))
+        self.assertIn("EXPECTED_LATEST_MIGRATION_VERSION: i32 = 11", self.migrations)
+        self.assertIn("WORK_ITEM_MIGRATION", self.authority)
+
+    def test_v11_schema_is_a_singleton_pg18_restore_fixed_point(self) -> None:
+        canonical_constraints = {
+            "account_snapshots_facts": (
+                "pg_catalog.octet_length(display_label) >= 1",
+                "pg_catalog.octet_length(display_label) <= 128",
+            ),
+            "exact_command_receipts_identity_bounded": (
+                "pg_catalog.octet_length(protocol_version) >= 1",
+                "pg_catalog.octet_length(protocol_version) <= 64",
+                "pg_catalog.octet_length(idempotency_key) >= 1",
+                "pg_catalog.octet_length(idempotency_key) <= 256",
+            ),
+            "role_profile_revisions_configuration": (
+                "pg_catalog.octet_length(model) >= 1",
+                "pg_catalog.octet_length(model) <= 128",
+                "pg_catalog.octet_length(reasoning_effort) >= 1",
+                "pg_catalog.octet_length(reasoning_effort) <= 32",
+                "pg_catalog.octet_length(service_tier) >= 1",
+                "pg_catalog.octet_length(service_tier) <= 32",
+                "pg_catalog.octet_length(instructions) >= 1",
+                "pg_catalog.octet_length(instructions) <= 65536",
+                "pg_catalog.octet_length(provenance) >= 1",
+                "pg_catalog.octet_length(provenance) <= 4096",
+            ),
+            "work_item_readiness_blockers_state_bounded": (
+                "pg_catalog.octet_length(observed_state) >= 1",
+                "pg_catalog.octet_length(observed_state) <= 64",
+            ),
+        }
+        for name, predicates in canonical_constraints.items():
+            self.assertEqual(self.migration.count(f"CONSTRAINT {name} CHECK"), 1)
+            definition = self.migration.split(f"CONSTRAINT {name} CHECK", 1)[1]
+            end = min(
+                definition.index(marker)
+                for marker in ("\n\t),", "\n\t);")
+                if marker in definition
+            )
+            definition = definition[:end]
+            self.assertNotIn("BETWEEN", definition)
+            for predicate in predicates:
+                self.assertIn(predicate, definition)
+
+        for table, constraint in (
+            ("account_snapshots", "account_snapshots_facts"),
+            ("exact_command_receipts", "exact_command_receipts_identity_bounded"),
+            ("role_profile_revisions", "role_profile_revisions_configuration"),
+        ):
+            statement = self.migration.split(f"ALTER TABLE decodex.{table}", 1)[1]
+            statement = statement.split(";", 1)[0]
+            self.assertIn(f"DROP CONSTRAINT {constraint}", statement)
+            self.assertIn(f"ADD CONSTRAINT {constraint} CHECK", statement)
+            self.assertNotIn("NOT VALID", statement)
+            self.assertNotIn("VALIDATE CONSTRAINT", statement)
+
+        self.assertIn(
+            "0xc4, 0x8f, 0x7b, 0x49, 0x8d, 0xac, 0x7f, 0xd1",
+            self.authority,
+        )
+        self.assertNotIn("expected_manifest_digest", self.authority)
+        for override in (
+            "DECODEX_TEST_GENERATED_MANIFEST_DIGESTS",
+            "DECODEX_TEST_EXPECTED_SCHEMA_SHA256",
+            "DECODEX_TEST_EXPECTED_CONFIGURED_AUTHORITY_SHA256",
+        ):
+            self.assertNotIn(override, self.authority)
+            self.assertNotIn(override, self.harness)
+
+    def test_focused_harness_finalizes_evidence_before_propagating_failure(self) -> None:
+        focused = self.harness.split("def run_work_item_focused_contracts", 1)[1]
+        focused = focused.split("\ndef run_runtime_session_crash_recovery", 1)[0]
+        baseline = 'checkpoints["baseline"] = load_semantic_manifest'
+        behavior = 'run_work_item_test("postgres_exact_work_item_commands", env)'
+        post_attempt = 'checkpoints["post_attempt"] = load_semantic_manifest'
+        diagnostics = 'diagnostics, manifest_failures = manifest_diagnostics(checkpoints)'
+        aggregate = 'raise TestFailure(\n\t\t\t"XY-1343 focused evidence finalized with failures:'
+        self.assertLess(focused.index(baseline), focused.index(behavior))
+        self.assertLess(focused.index(behavior), focused.index(post_attempt))
+        self.assertLess(focused.index(post_attempt), focused.index(diagnostics))
+        self.assertLess(focused.index(diagnostics), focused.index(aggregate))
+        self.assertEqual(focused.count('run(["pg_dump"'), 1)
+        self.assertEqual(focused.count('"pg_restore", "--exit-on-error"'), 1)
+        self.assertIn("source_behavior_error = error", focused)
+        self.assertIn("failures.extend(manifest_failures)", focused)
+        self.assertIn("if not failures:", focused)
+        self.assertIn('run_work_item_test("postgres_exact_work_item_restore", env)', focused)
+        self.assertIn('for component in ("schema", "authority")', self.harness)
+        self.assertIn('"checkpoints_equal": checkpoints_equal', self.harness)
+
+    def test_normalized_relations_are_same_project_and_bounded(self) -> None:
+        for table in (
+            "work_items", "work_item_objectives", "work_item_edges",
+            "work_item_readiness_blockers", "work_item_acceptances",
+        ):
+            self.assertIn(f"CREATE TABLE decodex.{table}", self.migration)
+        self.assertGreaterEqual(self.migration.count("FOREIGN KEY (work_item_id, project_id)"), 3)
+        self.assertIn("pg_catalog.cardinality(p_depends_on_ids) +", self.migration)
+        self.assertIn("> 16384", self.migration)
+        self.assertIn(">= 4096", self.migration)
+
+    def test_exact_commands_own_receipts_activity_and_outbox(self) -> None:
+        for function in (
+            "create_work_item_exact", "update_work_item_exact",
+            "assess_work_item_readiness_exact", "accept_work_item_exact",
+        ):
+            self.assertIn(f"CREATE FUNCTION decodex.{function}", self.migration)
+            self.assertIn(function, self.authority)
+        self.assertIn("decodex.exact_command_receipts", self.migration)
+        self.assertIn("INSERT INTO decodex.activity", self.migration)
+        self.assertIn("INSERT INTO decodex.outbox", self.migration)
+        self.assertIn("exact idempotency conflict", self.migration)
+
+    def test_readiness_is_current_state_transactional_and_nontransferable(self) -> None:
+        readiness = self.migration.split(
+            "CREATE FUNCTION decodex.assess_work_item_readiness_exact", 1
+        )[1].split("CREATE FUNCTION decodex.accept_work_item_exact", 1)[0]
+        self.assertIn("FOR UPDATE OF work", readiness)
+        self.assertIn("FOR SHARE OF project,lead", readiness)
+        self.assertIn("FOR SHARE OF objective", readiness)
+        self.assertIn("FOR SHARE OF related", readiness)
+        self.assertIn("work_item_readiness_blockers", readiness)
+        self.assertIn("target_state='ready'", readiness)
+        self.assertNotIn("RETURNS TABLE", readiness)
+        self.assertNotIn("permit", readiness.lower())
+
+    def test_cycle_rejection_rolls_back_candidate_relations(self) -> None:
+        update = self.migration.split(
+            "CREATE FUNCTION decodex.update_work_item_exact", 1
+        )[1].split("CREATE FUNCTION decodex.assess_work_item_readiness_exact", 1)[0]
+        self.assertIn("BEGIN\n\t\tDELETE FROM decodex.work_item_readiness_blockers", update)
+        self.assertIn("RAISE EXCEPTION 'candidate WorkItem graph contains a cycle'", update)
+        self.assertIn("EXCEPTION WHEN SQLSTATE 'P1343'", update)
+        self.assertIn("'dependency_cycle'", update)
+
+    def test_acceptance_is_exact_revision_immutable_and_never_completes(self) -> None:
+        acceptance = self.migration.split(
+            "CREATE FUNCTION decodex.accept_work_item_exact", 1
+        )[1].split("CREATE FUNCTION decodex.guard_work_item_running_resume", 1)[0]
+        self.assertIn("item.state<>'review'", acceptance)
+        self.assertIn("p_actor_id<>item.lead_agent_id", acceptance)
+        self.assertIn("'provenance',p_provenance", acceptance)
+        self.assertIn("work_item_revision", acceptance)
+        self.assertIn("item.acceptance_criteria", acceptance)
+        self.assertNotIn("UPDATE decodex.work_items", acceptance)
+        self.assertIn("WorkItem acceptances are immutable", self.migration)
+
+    def test_future_guard_is_inert_and_returns_no_authority(self) -> None:
+        guard = self.migration.split(
+            "CREATE FUNCTION decodex.guard_work_item_running_resume", 1
+        )[1].split("REVOKE ALL ON TABLE", 1)[0]
+        self.assertIn(") RETURNS void", guard)
+        self.assertIn("FOR UPDATE", guard)
+        self.assertIn("FOR SHARE OF project,lead", guard)
+        self.assertIn("work_item_readiness", guard)
+        for forbidden in (
+            "INSERT INTO", "UPDATE decodex", "DELETE FROM",
+            "decodex.exact_command_receipts", "decodex.outbox",
+        ):
+            self.assertNotIn(forbidden, guard)
+        self.assertIn("Result<(), StoreError>", self.rust_api)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- persist canonical WorkItems with transactional readiness and Lead acceptance (XY-1343)
- add inert V12 ManagedRun identity, exact-run assignments, RuntimeSession binding, effect barriers, and positive/inconclusive safety inputs (XY-1338)
- repair hierarchy lock authority with receipt -> 1271 -> 1338 ordering

## Evidence
- independent exact-tree reviews approved both signed commits
- PostgreSQL V12 schema and configured-authority manifests derived exactly with restore equality
- the single focused run stopped at a fixture-only parameter typing defect; both complete same-class casts were source-reviewed

## Deferred
Per the current migration test-economy policy, the post-repair focused rerun and full workspace validation are deferred to the unified frozen integration boundary. No CI wait is required for fast landing.