### PR TITLE
Amend vNext routing authority boundaries

### DIFF
--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -277,6 +277,16 @@ fresh exact PostgreSQL pre- and post-observations for the same manually selected
 inventory, automatic selector, weighting, stickiness, fallback, quota wake, or live routing API;
 XY-1304 remains the separate failed dispatch gate.
 
+The accepted XY-1355 target adds no executable path here. V14 will make PostgreSQL the sole owner
+of a revisioned complete routing-policy snapshot over the entire account inventory, canonical
+user order, explicit per-member disposition, sticky affinity plus source RuntimeSession revision,
+account/profile/build compatibility, exact evidence revisions, and required-capability
+applicability. Runtime and callers cannot supply that universe. The core routing component will be
+a pure kernel over the database-produced snapshot; V16 will atomically persist its decision and
+complete evidence linkage. Codex remains a positive-evidence adapter. An unknown required
+capability blocks, while an empty required-capability set makes unknown plugin inventory non-
+applicable rather than positive readiness evidence.
+
 V1.2 also carries `get_conversation_history`. Its request contains a logical Conversation UUID,
 an optional opaque PostgreSQL-issued Conversation-bound snapshot cursor, and a page size capped at
 eight on the wire (the repository's internal cap is 100). PostgreSQL assigns append-only
@@ -369,8 +379,9 @@ insert/update/delete poisoning while the deferred parent reference prevents orph
 rollover/fallback rows are proposals only: their schema
 forces dispatch disabled. This slice exposes no account selection, live turn start/resume/steer,
 automatic rollover, Context-Pack dispatch, ambiguous replay, or scheduler wake; XY-1304 remains the
-separate failed enablement gate. XY-1304 owns experiment creation and positive observation
-acquisition; XY-1276 owns production Quick Task creation. XY-1272 owns only PostgreSQL
+separate failed enablement gate. XY-1358/V15 owns experiment creation and positive-only observation
+authority; XY-1360 owns continuation and atomic Context-Pack fallback; XY-1362 owns scheduler wake;
+XY-1276 owns production Quick Task creation. XY-1272 owns only PostgreSQL
 configured-principal and ACL authority closure against V8. XY-1345 owns accepted exact-command
 authority/prototype evidence, XY-1346 owns expected V9 exact receipts plus RoleProfiles, and
 re-bounded XY-1337 owns expected V10 RuntimeSession snapshots and transitions.
@@ -485,6 +496,13 @@ PostgreSQL-administrator boundary and may redefine authority; V1 has no automati
 rollback detection. XY-1349 solely owns V13 persistence, XY-1350 owns only read-only acquisition
 and executor/readback mechanics against this contract, and XY-1351 owns the first shared saga path.
 
+V13 is accepted. The routing migration order is XY-1356/V14 complete policy and candidate-set
+authority, XY-1358/V15 causal experiment authority, then XY-1359/V16 atomic routing decisions; no
+V17 is reserved. XY-1361 composes these boundaries only with production dispatch disabled. The
+existing ManagedRun barrier, submitted-turn receipt, and repository/worktree/Git/artifact
+reconciliation authorities retain ambiguous-effect ownership; routing never reclassifies or
+replays those effects.
+
 The production runtime composes those three accepted owners exactly once during daemon bootstrap.
 When PostgreSQL is available, it opens the pinned executor, constructs the repository saga over the
 same `PostgresStore`, and performs bounded readback-only restart reconciliation before the protocol
@@ -533,6 +551,12 @@ case-sensitive regular expressions under the built-in `C` collation. The integra
 repeats credential vectors in a Turkish ICU database so database-default case rules cannot
 weaken the direct-SQL boundary; this crate exposes no
 eligibility, account selection, fallback, wake scheduling, or credential storage.
+
+Provider ingress must additionally retain the exact raw timestamp representation until exact UTC
+Unix-microsecond construction succeeds. V14 through V16 do not assume a provider precision and
+fail closed on any value that would require rounding or truncation. Natural characterization and
+retained-title Desktop discovery remain post-freeze evidence owned by XY-1357 and XY-1363,
+respectively; neither is a runtime authority path.
 
 ## Owned vNext paths, configuration, blobs, and cache
 

--- a/openwiki/decisions/vnext-authority.md
+++ b/openwiki/decisions/vnext-authority.md
@@ -35,17 +35,18 @@ migration is an atomic zero-state boundary that locks every quota writer surface
 structurally classified pre-V8 quota evidence, and alters the proven-empty `quota_windows`
 table in place. Populated V7 conversion and table drop/recreation are not compatibility
 features. Recovery is whole disposable pre-release database recreation; XY-1302 retains
-whole-ledger production-baseline and cutover authority. XY-1304 must capture natural upstream
-timestamp precision before live quota ingestion or routing, and a non-exact-microsecond result
-reopens the architecture around PostgreSQL-in-transaction canonicalization. The normative
+whole-ledger production-baseline and cutover authority. XY-1357 must retain and characterize the
+natural raw upstream timestamp before live quota ingestion or routing, and a value that cannot be
+converted exactly to UTC Unix microseconds keeps production routing disabled and reopens only the
+ingress authority. The normative
 details and proof gates live in the authority contract and gate manifest; the three rejected
 old-boundary candidates remain historical provenance in the runtime proof.
 
 XY-1272 PostgreSQL-authority reset accepted 2026-07-16: XY-1272 owns only configured-principal
 and ACL manifest/readiness closure against landed V8. It owns no migration or Codex creation,
 mapping, or reconciliation surface. Under the later XY-1345 reset, XY-1346 owns expected V9 and
-re-bounded XY-1337 owns expected V10; XY-1304 owns experiment creation
-and positive observation acquisition; XY-1276 owns production Quick Task creation. Lossy or
+re-bounded XY-1337 owns expected V10; XY-1358/V15 owns causal experiment creation
+and positive-only observation authority; XY-1276 owns production Quick Task creation. Lossy or
 paginated Codex evidence cannot authorize negative `Present`, `Complete`, or context-free `Absent`
 authority. A future configured PostgreSQL role must atomically extend configuration, bootstrap,
 manifest/readiness, and negative tests.
@@ -117,11 +118,56 @@ reacquisition and pinned Git 2.54 remain unchanged. Rejected candidate trees
 authority. The accepted V11 commit `33159d0cb2da7f86748f1a380def0927970a409a`
 and V12 commit `a6bfb0aefc72f2a65d14fc3755b556f959ec2d4e` remain unchanged.
 
-V13 is reserved solely for XY-1349 managed-repository PostgreSQL authority. XY-1304
-experiment creation and positive-observation persistence move to the next available
-migration, expected V14. Migration allocation, the embedded ledger, migration authority,
-schema/digest inventory, and aggregate migration evidence remain one non-commutative
-singleton serial-writer domain; an unlanded number is not a reusable parallel reservation.
+V13 is accepted on `main` as the sole XY-1349 managed-repository PostgreSQL authority
+migration. The next serial migration owners are fixed: XY-1356 solely owns V14 durable
+routing-policy and complete candidate-set authority; XY-1358 solely owns V15 causal Codex
+experiment authority; and XY-1359 solely owns V16 atomic routing decisions. No V17 is
+reserved. A later owner may allocate another migration only after source inspection proves
+that new durable state is required. Migration allocation, the embedded ledger, migration
+authority, schema/digest inventory, and aggregate migration evidence remain one
+non-commutative singleton serial-writer domain.
+
+XY-1355 live-routing authority reset accepted 2026-07-18 after three materially rejected
+XY-1304 candidates: PostgreSQL owns one revisioned complete routing-authority snapshot.
+Runtime and callers cannot supply authoritative policy order, candidate membership, sticky
+identity, eligibility facts, or exclusions. The database-produced snapshot binds every
+account-inventory member to an explicit disposition; canonical user-owned order and accepted
+Policy revision; sticky affinity and the exact RuntimeSession revision from which it was
+derived; account, RoleProfile, and Codex-build compatibility; exact account and evidence
+revisions; and the required capabilities plus applicability for each member. An omitted or
+unknown inventory member is a blocker, never silent absence or an eligible candidate.
+The existing bounded inert `PolicySnapshot` remains accepted Policy-revision content only; it is
+not a complete routing snapshot and cannot prove candidate completeness or provenance.
+
+`decodex-core` remains a pure decision kernel over that complete database-produced value.
+PostgreSQL persists the atomic decision and evidence linkage; runtime sequences only effects;
+Codex supplies positive capability evidence and never routing authority. One app-server process
+remains immutably bound to one account, credentials never switch in a live process, and separate
+account quotas are never represented as a merged pool.
+
+Account-owned readiness is evaluated only for capabilities explicitly required by the accepted
+routing policy. Unknown never satisfies a required capability. When the accepted required-
+capability set is empty, unknown plugin inventory is non-applicable rather than positive readiness
+evidence. XY-1336 remains future passive-receipt tracking outside this routing chain. Host-owned
+before/after receipts establish only no-mutation integrity.
+
+Ingress retains the exact raw provider timestamp value. UTC Unix-microsecond construction must be
+exact and rejects every rounding or truncation path. V14 through V16 remain precision-agnostic and
+fail closed, allowing XY-1357 natural provider evidence to remain in the unified post-freeze gate.
+
+After V16, XY-1360 owns same-thread continuation and one atomic Context-Pack fallback;
+XY-1361 owns runtime orchestration while production dispatch remains structurally disabled;
+XY-1362 owns `waiting_usage` wake lifecycle under scheduler authority; and XY-1363 owns
+retained-title Codex Desktop discovery evidence. Ambiguous-turn replay and repository,
+worktree, Git, and artifact reconciliation remain in the accepted ManagedRun and repository-
+effect authorities, not routing. XY-1304 is only the final aggregate live gate and the owner of
+a separate reviewed enablement amendment.
+
+The rejected dirty combined XY-1304/V14 candidate, its partial fourth repair, its caller-
+authoritative request shape, Rust authorization wrapper used as provenance, global
+`SupportedPositive` plugin requirement, combined experiment/routing schema, and sequential
+exclusion -> RuntimeSession -> decision composition are superseded evidence only. They must not
+be repaired, revived, or wholesale transplanted.
 
 The V1 trust boundary is one trusted single-host service. `decodexd` remains the sole
 repository-effect owner. Its in-process repository executor is a correctness,

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -344,8 +344,8 @@ and unsupported, oversized, or credential-shaped forms are rejected.
 `thread/read(includeTurns=true)` and paginated/list evidence are lossy reconciliation sources.
 They may support positive observations, but never authorize a negative `Present`, `Complete`, or
 context-free `Absent` conclusion. Missing, truncated, or unobserved evidence remains unknown.
-Experiment creation and positive observation acquisition belong to XY-1304; production Quick Task
-creation belongs to XY-1276. External Codex activity may be provenance-imported for ordinary
+Experiment creation and positive-only observation authority belong to XY-1358/V15; production
+Quick Task creation belongs to XY-1276. External Codex activity may be provenance-imported for ordinary
 Quick/Advisor/Lead conversations; on an active ManagedRun it marks the session `diverged` and blocks
 side effects until tool/repository readback reconciles them.
 
@@ -421,10 +421,12 @@ proof that no pre-release database becomes production state.
 
 Separate typed 300-minute and 10080-minute observations remain mandatory. This persistence
 boundary enables no account assignment, fallback, `waiting_usage` registration, wake scheduling,
-continuation, replay of external effects, or live dispatch. Before any live quota ingestion or
-routing, XY-1304 must capture the natural app-server/provider timestamp precision. If upstream
-timestamps are not exact microseconds, routing remains blocked and the architecture reopens around
-PostgreSQL-in-transaction canonicalization; silent rounding or truncation remains forbidden.
+continuation, replay of external effects, or live dispatch. Ingress retains the exact raw provider
+timestamp value. Construction of UTC Unix microseconds must be exact; any conversion that would
+round or truncate is rejected. V14 through V16 consume only exact values, remain otherwise
+precision-agnostic, and fail closed. XY-1357 owns the one natural precision receipt in the unified
+post-freeze gate. An incompatible receipt leaves production routing disabled and reopens only the
+ingress authority; it does not require a moving-core schema or decision rewrite.
 
 The dormant manual account observation path checks an exact PostgreSQL account revision in the
 `available` state before mechanics and checks the same predicate again after cleanup. Each check
@@ -452,16 +454,65 @@ the absence of future wrappers, or Rust friend visibility against arbitrary new 
 dependencies. Daemon/host crash can orphan OS descendants; restart reconstructs neither assignment
 nor launch authority and requires fresh exact PostgreSQL observations.
 
-Routing honors an available sticky Advisor/Lead account, otherwise chooses an available
-compatible account by user policy and quota facts. Every known depleted window excludes
-an account until reset; unknown is distinct and receives bounded probe/backoff. When all
-accounts are depleted, persist `waiting_usage` and the earliest ready time. Persist the
-specific account/window exclusion before rate-limit failover.
+### Durable routing-policy and candidate-set authority
 
-Cross-account resume of the same Codex thread is allowed only after the two-account E2E
-gate. Otherwise start a new RuntimeSession from a Context Pack while preserving the
-Conversation and ManagedRun. Never replay a possibly side-effecting turn without receipt,
-worktree/Git, and artifact reconciliation.
+PostgreSQL owns a revisioned complete routing-authority snapshot and is the only authority that
+may construct the candidate universe. A routing-resolution request supplies identity and
+idempotency inputs only. Runtime, protocol clients, adapters, and tests cannot supply or override
+authoritative policy order, candidate membership, sticky identity, eligibility facts, exclusions,
+or a preclassified candidate array.
+
+The current `decodex-core::PolicySnapshot` remains a bounded inert value inside one accepted
+Project Policy revision. It neither enumerates the account inventory nor establishes routing
+completeness, eligibility, evidence provenance, or persistence freshness. V14 must introduce the
+distinct database-owned complete routing snapshot rather than widening a Rust wrapper into
+authorization authority.
+
+One snapshot binds, under the database locks that establish its revision boundary:
+
+- the exact accepted routing Policy revision and canonical user-owned account order;
+- every current account-inventory member exactly once, with an explicit included or excluded
+  disposition and an exact account revision;
+- sticky affinity, when present, plus the exact source RuntimeSession identity and revision;
+- required account, RoleProfile, and Codex-build compatibility facts and their exact revisions;
+- each exact quota, authentication, capability, and administrative evidence revision used;
+- the accepted required-capability set and capability applicability for every member; and
+- explicit blocker facts for every unknown or otherwise unusable member.
+
+Completeness is fail-closed. A duplicate, omitted, foreign, newly added, concurrently removed, or
+revision-changed inventory member; an unbound sticky source; or an unknown required fact blocks the
+snapshot or decision. Silence never means excluded, eligible, or non-applicable.
+
+`decodex-core` is a pure deterministic decision kernel over this database-produced snapshot. It
+does not establish provenance or completeness. PostgreSQL atomically persists the resulting V16
+decision, its complete normalized exclusions, and every evidence reference. Runtime consumes one
+exact persisted decision and sequences effects only; it cannot substitute a decision. Codex is a
+positive-evidence capability adapter and cannot determine membership, policy, or eligibility.
+One app-server process remains bound to one account, credentials never switch in a live process,
+and the separate 300-minute and 10080-minute quota facts for separate accounts are never merged.
+
+Sticky affinity wins only when the bound member is independently eligible under the same complete
+snapshot. Every known depleted window excludes its account until reset. Unknown, stale,
+incompatible, disabled, authentication-failed, missing-duration, low-confidence, or precision-
+incompatible evidence blocks eligibility. When every otherwise eligible account is excluded only
+by usage, V16 persists `waiting_usage` and the exact earliest-ready time. XY-1362 owns one
+restart-safe scheduler wake and always re-enters fresh authoritative resolution; routing owns no
+wake lifecycle.
+
+Account-owned readiness is evaluated only for capabilities explicitly required by the accepted
+routing Policy revision. Unknown never satisfies a required capability. If the accepted required-
+capability set is empty, unknown account-owned plugin inventory is non-applicable; it is not
+positive readiness evidence and does not change an account to ready. XY-1336 remains future
+passive-receipt tracking. Host-owned before/after receipts prove causal no-mutation integrity only
+and cannot establish account-owned readiness.
+
+XY-1358 owns causal positive-only experiment evidence. After an exact V16 decision, XY-1360 owns
+same-thread continuation when exact positive account/profile/build evidence permits it, otherwise
+one atomic Context-Pack plus RuntimeSession fallback that preserves Conversation and ManagedRun
+identity. It allocates no V17 in advance. XY-1361 composes these authorities with production
+dispatch still structurally disabled. Ambiguous-turn replay remains blocked until the accepted
+ManagedRun submitted-turn, effect-barrier, repository/worktree/Git, and artifact authorities
+reconcile it; routing never owns or weakens that boundary.
 
 Those paragraphs define the target behavior, not current enablement. Until the separate
 [XY-1262 live account-routing enablement gate](https://linear.app/hack-ink/issue/XY-1304)
@@ -484,15 +535,18 @@ availability. In particular, unknown or stale quota is fail-closed: no assignmen
 automatic fallback is permitted; the unavailable/unknown condition must be surfaced for
 human resolution or bounded observation.
 
-Readiness cannot authorize account eligibility, assignment, reassignment, fallback,
-scheduling, wakeup, continuation, or production routing. A future operator-triggered
-active diagnostic requires a separate authority decision and remains non-routing evidence.
+Readiness outside the accepted capability-applicability rule cannot authorize account eligibility,
+assignment, reassignment, fallback, scheduling, wakeup, continuation, or production routing. A
+future operator-triggered active diagnostic requires a separate authority decision and remains
+non-routing evidence.
 
 Users exclusively select the four global RoleProfiles. Runtime cannot alter model,
 reasoning, or service tier. Each RuntimeSession snapshots its profile. Decodex keeps a
 user-owned desired inventory only as intent. Until a stable passive account-owned receipt
-exists, V1 reports plugin readiness as `unknown` and does not compare host facts into an
-account-readiness conclusion or guide mutation from such a conclusion.
+exists, V1 reports plugin readiness as `unknown`; that unknown is blocking only when the exact
+accepted routing policy requires the corresponding capability, and is non-applicable when the
+required-capability set is empty. Host facts never become positive account-readiness evidence or
+guide mutation from such a conclusion.
 
 ## Automation and protocol
 

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -17,9 +17,9 @@ its dependent implementation uses the result.
 
 | Range | Accepted downstream ownership |
 | --- | --- |
-| [XY-1261](https://linear.app/hack-ink/issue/XY-1261)-[XY-1264](https://linear.app/hack-ink/issue/XY-1264), with live continuation moved to [XY-1304](https://linear.app/hack-ink/issue/XY-1304) | v0.2 freeze and PostgreSQL/blob/cache proof are accepted; the XY-1262 foundation is accepted, live continuation remains failed in XY-1304, and XY-1263 accepts only the isolated pinned GPUI foundation. |
+| [XY-1261](https://linear.app/hack-ink/issue/XY-1261)-[XY-1264](https://linear.app/hack-ink/issue/XY-1264), with the failed live gate aggregated by [XY-1304](https://linear.app/hack-ink/issue/XY-1304) | v0.2 freeze and PostgreSQL/blob/cache proof are accepted; the XY-1262 foundation is accepted, XY-1360 owns the still-disabled live-continuation and atomic Context-Pack fallback implementation after V16, XY-1304 owns only its final aggregate gate and enablement amendment, and XY-1263 accepts only the isolated pinned GPUI foundation. |
 | [XY-1265](https://linear.app/hack-ink/issue/XY-1265)-[XY-1269](https://linear.app/hack-ink/issue/XY-1269) | Workspace ownership boundaries, `decodexd` protocol, PostgreSQL persistence, `~/.decodex`/API-only CLI, and the serial P/K/L/S GPUI client decomposition defined below. |
-| [XY-1270](https://linear.app/hack-ink/issue/XY-1270)-[XY-1276](https://linear.app/hack-ink/issue/XY-1276), plus [XY-1304](https://linear.app/hack-ink/issue/XY-1304) | Typed app-server, Conversation/RuntimeSession/history, shared-home, vault/runner-binding, quota-calculation, and profile foundations; XY-1304 separately owns live routing enablement and blocks the Quick Task slice. XY-1336 is upstream-blocked tracking outside this critical path. |
+| [XY-1270](https://linear.app/hack-ink/issue/XY-1270)-[XY-1276](https://linear.app/hack-ink/issue/XY-1276), plus [XY-1304](https://linear.app/hack-ink/issue/XY-1304) | Typed app-server, Conversation/RuntimeSession/history, shared-home, vault/runner-binding, quota-calculation, and profile foundations; the XY-1355-XY-1363 reset chain supplies the missing routing authorities and evidence, while XY-1304 owns only the final aggregate gate and separate enablement amendment and continues to block the Quick Task slice. XY-1336 is upstream-blocked tracking outside this critical path. |
 | [XY-1277](https://linear.app/hack-ink/issue/XY-1277)-[XY-1286](https://linear.app/hack-ink/issue/XY-1286) | Projects/Advisor/Lead, context, messages/collaboration, decision queues, Programs/Objectives, WorkItems, ManagedRuns, repository services, Task-owned independent review/repair/landing, and Project/Program authority policy. |
 | [XY-1287](https://linear.app/hack-ink/issue/XY-1287)-[XY-1290](https://linear.app/hack-ink/issue/XY-1290) | Automation definitions/firings, materiality/loop safety, removal of manager agents, and PubFi/SEO/GEO/Radar/Publisher dogfood. |
 | [XY-1291](https://linear.app/hack-ink/issue/XY-1291)-[XY-1297](https://linear.app/hack-ink/issue/XY-1297) | GPUI conversations, project/run workspace, graph/timeline, operational surfaces, multi-GB pagination/cache/search, thin menubar, and accessibility/interaction gates. |
@@ -103,7 +103,7 @@ Permission is issue-scoped and does not bypass each issue's own dependencies:
 | XY-1274 | Exact-microsecond quota persistence, `/2` canonical mutation identity, atomic V8 zero-state migration, and durable exclusion transaction tests using synthetic fixtures only; no live exclusion, fallback assignment, or wake scheduling. |
 | XY-1275 | Umbrella for user-owned profile persistence and RuntimeSession snapshots. It closes only through the serial XY-1345 -> XY-1346 -> XY-1337 order. Account-owned plugin, skill, and MCP readiness remains typed `unknown`; XY-1336 neither closes nor blocks this issue. |
 | XY-1276 | Production Quick Task creation; remains blocked by XY-1304. |
-| XY-1304 | Experiment thread creation and positive observation acquisition, plus live routing enablement. Lossy or paginated evidence cannot authorize negative `Present`, `Complete`, or context-free `Absent` conclusions. |
+| XY-1304 | Final aggregate live-routing gate and separate reviewed enablement amendment only. It owns no migration, policy snapshot, candidate construction, experiment schema, continuation, orchestration, wake lifecycle, or Desktop discovery implementation. |
 | XY-1345 | Accepted exact-command authority and isolated PostgreSQL 18 prototype only; no production migration or Rust command path. |
 | XY-1346 | PostgreSQL V9: separate exact receipts plus immutable global RoleProfile bootstrap/update. Starts only after XY-1345 lands. |
 | XY-1337 | Re-bounded RuntimeSession snapshot creation/transition migration, expected V10 after XY-1346. It does not own exact-receipt or RoleProfile redesign. |
@@ -112,11 +112,20 @@ Permission is issue-scoped and does not bypass each issue's own dependencies:
 | XY-1284 | Accepted two-stage managed-repository authority reset; stage two is finalized by XY-1348 and consumes accepted XY-1354 unchanged. |
 | XY-1347 | One bounded macOS/Git feasibility spike for ordinary repositories and linked worktrees; evidence only, with no production source or schema. |
 | XY-1348 | Accepted mechanism-neutral transition contract and stage-two PostgreSQL/executor authority boundary; no V13 persistence. |
-| XY-1349 | Sole V13 and migration-ledger writer for managed-repository PostgreSQL authority. XY-1304 persistence follows in the next available migration, expected V14. |
+| XY-1349 | Accepted sole V13 managed-repository PostgreSQL authority migration. |
 | XY-1350 | Read-only allocation evidence plus accepted Git/filesystem executor and readback only; may proceed in parallel against the accepted contract, with no persistence, receipt, saga, provider, or shared composition ownership. |
 | XY-1351 | First shared repository effect saga path, composing preparation, fresh receipt consumption, execution, readback, and terminal reconciliation; no migration, executor-internal, or provider ownership. |
 | XY-1352 | GitHub PR/check effect and reconciliation boundary with explicit provider identities and positive readback; no local repository discovery. |
 | XY-1353 | Serial integration, final authority/OpenWiki alignment, deferred-validation inventory, and exact-candidate freeze; it blocks XY-1285. |
+| XY-1355 | Normative live-routing authority and capability-applicability reset only; no executable implementation or validation. |
+| XY-1356 | Sole V14 migration owner for revisioned complete routing-policy and candidate-set authority. |
+| XY-1357 | One post-freeze natural provider timestamp-precision receipt; no deliberate quota consumption or routing enablement. |
+| XY-1358 | Sole V15 migration owner for causal positive-only Codex experiment authority. |
+| XY-1359 | Sole V16 migration owner plus pure routing kernel and atomic persisted decisions; no dispatch. |
+| XY-1360 | Same-thread continuation and one atomic Context-Pack/RuntimeSession fallback after V16; no migration is pre-reserved. |
+| XY-1361 | Runtime orchestration over persisted authorities with production dispatch structurally disabled. |
+| XY-1362 | Scheduler-owned `waiting_usage` wake lifecycle and fresh re-resolution; no selection authority. |
+| XY-1363 | Post-freeze retained-title Codex Desktop discovery evidence only. |
 
 XY-1336 is an upstream-blocked tracking issue outside the M2 critical path. A host file,
 manifest, configuration value, remote catalog entry, process binding, or user declaration
@@ -205,12 +214,12 @@ XY-1349 + XY-1350 + XY-1351 + XY-1352 ──────────> XY-1353 in
 XY-1353 ─────────────────────────────────────────> XY-1285
 ```
 
-The migration ledger is a singleton serial-writer domain. XY-1349 alone owns V13 and all
-physical persistence, transaction, retention, privilege, migration, and frozen database
-evidence details. XY-1304 creation and positive-observation persistence move to the next
-available migration after V13, expected V14. XY-1350 may proceed in parallel only against
-this accepted semantic contract and without touching or claiming the writer domain.
-XY-1351 owns the first shared saga path.
+The migration ledger is a singleton serial-writer domain. XY-1349's V13 is accepted on
+`main`. The fixed next order is XY-1356/V14 durable routing-policy authority, then
+XY-1358/V15 causal experiment authority, then XY-1359/V16 atomic routing decisions. No
+V17 is reserved. XY-1360 may allocate a later migration only if then-current source
+inspection proves additional durable state is required. XY-1350 and the remaining
+managed-repository children retain their accepted non-routing ownership.
 
 No managed-repository implementation executes validation before the integration tree is
 frozen. One complete unified validation runs once on that exact frozen tree. Its concise
@@ -690,43 +699,57 @@ production routing.
 ### Failed live account-routing enablement gate
 
 The [live gate issue](https://linear.app/hack-ink/issue/XY-1304) remains failed and
-fail-closed. Before any gated capability is enabled, an account must become **naturally
-depleted**; quota must not be deliberately consumed to manufacture acceptance. A fixed
-no-tool marker must then return a typed provider quota failure. Durable readback must
-show the submitted turn and unknown side-effect state, followed by the specific
-duration-typed 300/10080 account/window exclusion committed and crash-recoverable before
-any fallback assignment.
+fail-closed. It is only the final aggregate evidence gate and owner of a later separate
+repository-authority enablement amendment. Production routing remains structurally default-
+disabled until XY-1355, V14, V15, V16, continuation, disabled orchestration, scheduler wake,
+natural timestamp evidence, and Desktop discovery have all landed and one post-freeze aggregate
+gate passes.
 
-Before live quota ingestion or routing begins, XY-1304 must also capture the natural
-app-server/provider quota timestamp precision. Only exact-microsecond upstream values may enter the
-accepted XY-1274 ingress boundary. If the natural value has other precision, live routing remains
-blocked and the architecture must reopen around PostgreSQL-in-transaction canonicalization. No
-probe, adapter, or migration may silently round or truncate it.
+The required dependency order is:
 
-A different fresh eligible account must produce exactly one useful continuation on the
-same thread when supported. Otherwise, a real denied/incompatible response must end the
-old RuntimeSession and create exactly one Context-Pack RuntimeSession. Injected crashes
-at each exclusion, assignment, resume, and fallback boundary must read back exactly one
-continuation, correct `waiting_usage` plus the earliest ready time when all accounts are
-freshly depleted, and no duplicate tool, worktree, Git, or artifact effect. Normal
-`~/.codex/auth.json`, the Decodex account pool, and supported shared plugin files or
-configuration must have exact before/after equality receipts. The receipt manifest must
-name each supported host-owned, non-transient surface. These receipts are causal integrity
-evidence only, never account readiness. The experiment's protocol trace
-and admitted Decodex control-plane method set must contain no plugin, skill, MCP, or
-marketplace inventory or management call and no install, enable, disable, update, remove,
-login-management, or OAuth-management call. Normal process-scoped
-`account/login/start` authentication and ordinary execution of an already-enabled tool
-inside a turn are not control-plane inventory or management calls. Account-owned
-installed/enabled state remains unobserved and `unknown`; it is not an XY-1304 acceptance
-fact. An external or cloud change outside Decodex causal
-authority is not a Decodex mutation merely because it overlaps the experiment. Neither
-`plugin/list`, `skills/list`, `mcpServerStatus/list`, `app/list`, a catalog scan, nor an
-active diagnostic may substitute for this evidence; any future operator-triggered active
-diagnostic requires separate authority and remains non-routing.
+```text
+XY-1355 authority amendment
+-> XY-1356 / V14 complete routing-policy authority
+-> XY-1358 / V15 causal experiment authority
+-> XY-1359 / V16 atomic routing decisions
+-> XY-1360 continuation and atomic Context-Pack fallback
+-> XY-1361 runtime orchestration with dispatch disabled
 
-Separately, the retained title must be returned by supported Codex Desktop discovery
-after normal indexing before any global visibility claim.
+XY-1359 -> XY-1362 scheduler-owned waiting_usage wake lifecycle
+XY-1358 -> XY-1363 retained-title Desktop discovery evidence
+XY-1355 -> XY-1357 natural timestamp precision evidence
+
+all children + XY-1300 unified post-freeze acceptance -> XY-1304 aggregate gate
+-> separate reviewed repository amendment to enable production routing
+```
+
+The aggregate gate must bind one exact source tree and prove PostgreSQL-produced complete
+routing snapshots and decisions. Caller omission, reordering, substitution, duplicate facts,
+or stale revisions must not change the authoritative universe. Every inventory member has an
+explicit disposition; unknown or omitted members block. Sticky affinity is bound to its exact
+RuntimeSession revision and wins only when independently eligible. Required capabilities and
+their applicability are explicit: unknown never satisfies a required capability, while an empty
+required-capability set makes unknown plugin inventory non-applicable rather than positive
+readiness evidence.
+
+The natural provider receipt retains the exact raw timestamp and must convert exactly to UTC Unix
+microseconds without rounding or truncation. A precision-incompatible receipt leaves routing
+disabled and reopens only ingress authority. A naturally depleted account, never deliberately
+exhausted for evidence, must return the typed quota failure for a fixed no-tool marker. Durable
+readback must bind the submitted turn, unknown side-effect state, exact duration-typed exclusion,
+complete decision evidence, and either exactly one supported same-thread continuation or exactly
+one atomic Context-Pack RuntimeSession after genuine denied/incompatible evidence. All-depleted
+state must persist the exact earliest-ready time and one restart-safe scheduler wake that performs
+fresh resolution.
+
+Crash injection at every external-effect boundary must produce no duplicate turn, tool,
+repository, worktree, Git, or artifact effect. Possibly side-effecting turn replay remains under
+the accepted ManagedRun submitted-turn/effect-barrier and repository-effect reconciliation
+authorities, not routing. Host-owned before/after receipts prove no-mutation integrity only. The
+experiment and gate must not use plugin, skill, MCP, marketplace, login-management, OAuth-
+management, or account-configuration inventory/mutation calls to manufacture readiness. XY-1363
+must independently prove supported retained-title Desktop discovery after normal indexing without
+deriving absence from pagination, list exhaustion, missing events, or lossy readback.
 
 Until all of that evidence passes and a later explicit repository amendment enables the
 path, sticky or policy assignment, quota-driven exclusion causing another assignment,
@@ -742,6 +765,15 @@ later milestone, a synthetic test, or an otherwise completed dependency cannot a
 managed production routing. Other later foundation or UI work may proceed only when its
 own scope can remain inert and its other gates pass; it cannot claim live-routing,
 dogfood, cutover, or release acceptance.
+
+The dirty combined XY-1304/V14 candidate, partial fourth repair, caller-authoritative request
+shape, Rust authorization wrapper as provenance, global `SupportedPositive` plugin requirement,
+combined experiment/routing schema, and sequential exclusion -> RuntimeSession -> decision
+composition are superseded and must not be revived. Before core freeze, executable validation is
+deferred: no formatter, compile/check/lint, migration or SQL parser, tests or matrices, wrappers or
+generators, PostgreSQL, live experiments, or UI/Accessibility/Desktop checks. After freeze,
+XY-1300 owns one mechanical preflight, one unified complete gate, coherent batched repairs, and one
+final aggregate rerun.
 
 
 ## Cutover gate


### PR DESCRIPTION
## Summary
- make PostgreSQL the complete revisioned routing-authority owner
- define capability applicability, exact timestamp handling, and V14-V16 ownership
- preserve default-disabled production routing until the post-freeze aggregate gate

## Validation
- intentionally deferred under the moving-core validation policy
- exact four-document candidate received fresh gpt-5.6-sol medium source review with no blocking findings after one batched repair