### PR TITLE
Fix Codex account login path resolution on macOS

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -26,6 +26,13 @@ operations and interactive login flows that need streamed command output:
 - run isolated Codex device login, then import the resulting auth file
 - remove a stored account from the local pool
 
+For account login, an explicitly configured `CODEX_CLI_PATH` overrides automatic
+discovery. Otherwise, the App first resolves the CLI from the Codex macOS application
+registered with Launch Services, then falls back to a `codex` executable in the
+inherited `PATH`. This keeps Finder-launched builds independent of a shell-initialized
+`PATH`; the resolved executable is passed to the helper through its existing
+`codex_bin` request field.
+
 The app does not schedule Decodex runs itself, own project registration, or replace the
 Rust control plane. It is a native UI over the shared Rust account-management service
 and uses the bundled `decodex` server only when no compatible local server is already

--- a/apps/decodex-app/Sources/DecodexApp/AccountStoreActions.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStoreActions.swift
@@ -92,9 +92,15 @@ extension AccountStore {
 		notice = nil
 
 		do {
-			applyAccountList(try await bridge.runStreaming(.accountLogin(), as: AccountListResponse.self) { [weak self] chunk in
-				self?.loginTranscript += chunk
-			})
+			let codexBin = try bridge.codexExecutablePath()
+			applyAccountList(
+				try await bridge.runStreaming(
+					.accountLogin(codexBin: codexBin),
+					as: AccountListResponse.self
+				) { [weak self] chunk in
+					self?.loginTranscript += chunk
+				}
+			)
 			notice = nil
 			await refreshFastMode()
 		} catch {

--- a/apps/decodex-app/Sources/DecodexApp/AppBridgeRequest.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AppBridgeRequest.swift
@@ -43,8 +43,8 @@ struct AppBridgeRequest: Encodable, Sendable {
 		AppBridgeRequest(operation: "account_logout", selector: selector, includeUsage: true)
 	}
 
-	static func accountLogin() -> AppBridgeRequest {
-		AppBridgeRequest(operation: "account_login", includeUsage: true)
+	static func accountLogin(codexBin: String) -> AppBridgeRequest {
+		AppBridgeRequest(operation: "account_login", codexBin: codexBin, includeUsage: true)
 	}
 
 	static let codexFastModeStatus = AppBridgeRequest(operation: "codex_fast_mode_status")

--- a/apps/decodex-app/Sources/DecodexApp/DecodexAppBridge.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexAppBridge.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 enum DecodexAppBridgeError: LocalizedError {
@@ -21,6 +22,9 @@ enum DecodexAppBridgeError: LocalizedError {
 }
 
 struct DecodexAppBridge: Sendable {
+	static let codexApplicationBundleIdentifier = "com.openai.codex"
+	static let codexExecutableOverrideKey = "CODEX_CLI_PATH"
+
 	func runJSON<T: Decodable & Sendable>(_ request: AppBridgeRequest, as type: T.Type) async throws -> T {
 		try await runStreaming(request, as: type, onOutput: nil)
 	}
@@ -117,5 +121,76 @@ struct DecodexAppBridge: Sendable {
 		throw DecodexAppBridgeError.helperMissing(
 			"Bundled Decodex App helper is missing. Rebuild the app bundle with apps/decodex-app/script/build_and_run.sh."
 		)
+	}
+
+	@MainActor
+	func codexExecutablePath() throws -> String {
+		let applicationURL = NSWorkspace.shared.urlForApplication(
+			withBundleIdentifier: Self.codexApplicationBundleIdentifier
+		)
+		let resourceURL = applicationURL.flatMap {
+			Bundle(url: $0)?.url(forResource: "codex", withExtension: nil)
+		}
+
+		return try Self.codexExecutablePath(
+			environment: ProcessInfo.processInfo.environment,
+			applicationResourceURL: resourceURL,
+			isExecutableFile: FileManager.default.isExecutableFile(atPath:)
+		)
+	}
+
+	static func codexExecutablePath(
+		environment: [String: String],
+		applicationResourceURL: URL?,
+		isExecutableFile: (String) -> Bool
+	) throws -> String {
+		if let override = environment[codexExecutableOverrideKey]?
+			.trimmingCharacters(in: .whitespacesAndNewlines),
+			override.isEmpty == false
+		{
+			guard let path = executablePath(override, isExecutableFile: isExecutableFile) else {
+				throw DecodexAppBridgeError.helperMissing(
+					"CODEX_CLI_PATH does not point to an executable Codex CLI."
+				)
+			}
+
+			return path
+		}
+
+		if let applicationResourceURL,
+			let path = executablePath(
+				applicationResourceURL.path,
+				isExecutableFile: isExecutableFile
+			)
+		{
+			return path
+		}
+
+		if let searchPath = environment["PATH"] {
+			for directory in searchPath.split(separator: ":", omittingEmptySubsequences: true) {
+				let candidate = URL(fileURLWithPath: String(directory), isDirectory: true)
+					.appendingPathComponent("codex")
+				if let path = executablePath(candidate.path, isExecutableFile: isExecutableFile) {
+					return path
+				}
+			}
+		}
+
+		throw DecodexAppBridgeError.helperMissing(
+			"Codex CLI executable was not found. Install the Codex app, add codex to PATH, or set CODEX_CLI_PATH to its executable path."
+		)
+	}
+
+	private static func executablePath(
+		_ path: String,
+		isExecutableFile: (String) -> Bool
+	) -> String? {
+		let standardizedURL = URL(fileURLWithPath: path).standardizedFileURL
+		let resourceValues = try? standardizedURL.resourceValues(forKeys: [.isDirectoryKey])
+		guard resourceValues?.isDirectory != true else {
+			return nil
+		}
+
+		return isExecutableFile(standardizedURL.path) ? standardizedURL.path : nil
 	}
 }

--- a/apps/decodex-app/Tests/DecodexAppTests/DecodexAppBridgeTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/DecodexAppBridgeTests.swift
@@ -1,0 +1,143 @@
+@testable import DecodexApp
+import Foundation
+import XCTest
+
+final class DecodexAppBridgeTests: XCTestCase {
+	func testCodexExecutableOverrideTakesPrecedence() throws {
+		let override = "/custom/Codex CLI/codex"
+		let pathCandidate = "/tools/codex"
+		let appCandidate = "/Applications/ChatGPT.app/Contents/Resources/codex"
+
+		XCTAssertEqual(
+			try DecodexAppBridge.codexExecutablePath(
+				environment: [
+					"CODEX_CLI_PATH": "  \(override)\n",
+					"PATH": "/tools",
+				],
+				applicationResourceURL: URL(fileURLWithPath: appCandidate),
+				isExecutableFile: { [override, pathCandidate, appCandidate].contains($0) }
+			),
+			override
+		)
+	}
+
+	func testCodexExecutableUsesApplicationResourceBeforePath() throws {
+		let pathCandidate = "/tools/codex"
+		let appCandidate = "/Applications/ChatGPT.app/Contents/Resources/codex"
+
+		XCTAssertEqual(
+			try DecodexAppBridge.codexExecutablePath(
+				environment: ["PATH": "/usr/bin:/tools:/bin"],
+				applicationResourceURL: URL(fileURLWithPath: appCandidate),
+				isExecutableFile: { [pathCandidate, appCandidate].contains($0) }
+			),
+			appCandidate
+		)
+	}
+
+	func testBlankCodexExecutableOverrideDoesNotBlockAutomaticDiscovery() throws {
+		let appCandidate = "/Applications/ChatGPT.app/Contents/Resources/codex"
+
+		XCTAssertEqual(
+			try DecodexAppBridge.codexExecutablePath(
+				environment: [
+					"CODEX_CLI_PATH": "  \n",
+					"PATH": "/tools",
+				],
+				applicationResourceURL: URL(fileURLWithPath: appCandidate),
+				isExecutableFile: { $0 == appCandidate }
+			),
+			appCandidate
+		)
+	}
+
+	func testCodexExecutableUsesPathWhenApplicationResourceIsUnavailable() throws {
+		let pathCandidate = "/tools/codex"
+		let appCandidate = "/Applications/ChatGPT.app/Contents/Resources/codex"
+
+		XCTAssertEqual(
+			try DecodexAppBridge.codexExecutablePath(
+				environment: ["PATH": "/usr/bin:/tools:/bin"],
+				applicationResourceURL: URL(fileURLWithPath: appCandidate),
+				isExecutableFile: { $0 == pathCandidate }
+			),
+			pathCandidate
+		)
+	}
+
+	func testCodexExecutableUsesApplicationResourceWithMinimalPath() throws {
+		let appCandidate = "/Applications/ChatGPT.app/Contents/Resources/codex"
+
+		XCTAssertEqual(
+			try DecodexAppBridge.codexExecutablePath(
+				environment: ["PATH": "/usr/bin:/bin:/usr/sbin:/sbin"],
+				applicationResourceURL: URL(fileURLWithPath: appCandidate),
+				isExecutableFile: { $0 == appCandidate }
+			),
+			appCandidate
+		)
+	}
+
+	func testInvalidCodexExecutableOverrideFailsClearly() {
+		XCTAssertThrowsError(
+			try DecodexAppBridge.codexExecutablePath(
+				environment: [
+					"CODEX_CLI_PATH": "/missing/codex",
+					"PATH": "/tools",
+				],
+				applicationResourceURL: nil,
+				isExecutableFile: { $0 == "/tools/codex" }
+			)
+		) { error in
+			XCTAssertEqual(
+				error.localizedDescription,
+				"CODEX_CLI_PATH does not point to an executable Codex CLI."
+			)
+		}
+	}
+
+	func testCodexExecutableOverrideRejectsDirectory() throws {
+		let directory = FileManager.default.temporaryDirectory
+			.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+		defer { try? FileManager.default.removeItem(at: directory) }
+
+		XCTAssertThrowsError(
+			try DecodexAppBridge.codexExecutablePath(
+				environment: ["CODEX_CLI_PATH": directory.path],
+				applicationResourceURL: nil,
+				isExecutableFile: { $0 == directory.path }
+			)
+		) { error in
+			XCTAssertEqual(
+				error.localizedDescription,
+				"CODEX_CLI_PATH does not point to an executable Codex CLI."
+			)
+		}
+	}
+
+	func testMissingCodexExecutableFailsClearly() {
+		XCTAssertThrowsError(
+			try DecodexAppBridge.codexExecutablePath(
+				environment: ["PATH": "/usr/bin:/bin"],
+				applicationResourceURL: nil,
+				isExecutableFile: { _ in false }
+			)
+		) { error in
+			XCTAssertEqual(
+				error.localizedDescription,
+				"Codex CLI executable was not found. Install the Codex app, add codex to PATH, or set CODEX_CLI_PATH to its executable path."
+			)
+		}
+	}
+
+	func testAccountLoginRequestEncodesCodexExecutableAsOneValue() throws {
+		let codexBin = "/Applications/Codex Preview.app/Contents/Resources/codex"
+		let data = try JSONEncoder().encode(AppBridgeRequest.accountLogin(codexBin: codexBin))
+		let payload = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+		XCTAssertEqual(payload["operation"] as? String, "account_login")
+		XCTAssertEqual(payload["codex_bin"] as? String, codexBin)
+		XCTAssertEqual(payload["include_usage"] as? Bool, true)
+	}
+}

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -147,7 +147,10 @@ decodex-publisher validate-social .agent/automations/decodex/cache/social/x
 - Lists stored accounts without token material.
 - Pins future Decodex runs to one account or returns to balanced selection.
 - Forces Codex to use a stored account by writing `auth.json`.
-- Runs isolated Codex device login and imports the resulting auth file.
+- Runs isolated Codex device login and imports the resulting auth file. The App
+  honors an explicit `CODEX_CLI_PATH` override; otherwise it resolves the login
+  executable from the Codex macOS application registered with Launch Services,
+  then falls back to a `codex` executable in the inherited `PATH`.
 - Removes stored accounts from the local pool.
 - Connects to a default local `decodex serve` when available, otherwise starts bundled `decodex serve --listen-address 127.0.0.1:8192`.
 


### PR DESCRIPTION
## Summary

- resolve the Codex CLI from CODEX_CLI_PATH, the registered Codex macOS app, then PATH
- pass the absolute executable path through the existing codex_bin bridge field
- cover precedence, fallbacks, invalid paths, spaces, and Finder-style minimal PATH

## Validation

- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app -c release
- 54 tests passed
- Launch Services resolves /Applications/ChatGPT.app/Contents/Resources/codex