### PR TITLE
Modernize the macOS menu bar app for macOS 27

### DIFF
--- a/apps/decodex-app/Package.swift
+++ b/apps/decodex-app/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.4
 
 import PackageDescription
 
 let package = Package(
 	name: "DecodexApp",
-	platforms: [.macOS(.v14)],
+	platforms: [.macOS(.v27)],
 	products: [
 		.executable(name: "DecodexApp", targets: ["DecodexApp"]),
 	],

--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -48,6 +48,9 @@ percentage snapshots for account-pool display and does not contain token materia
 
 ## Development
 
+The app targets macOS 27 and uses the Swift 6.4 toolchain. Older macOS releases are
+not supported.
+
 Build the SwiftPM app in release mode:
 
 ```sh

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelSections.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelSections.swift
@@ -10,6 +10,7 @@ extension AccountPanelView {
 				.foregroundStyle(PanelPalette.actionBlue(colorScheme))
 				.frame(width: 20, height: 20)
 				.frame(width: 28, height: 28)
+				.accessibilityHidden(true)
 
 			VStack(alignment: .leading, spacing: 2) {
 				Text("Decodex")

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -3,8 +3,8 @@ import Foundation
 import SwiftUI
 
 struct AccountPanelView: View {
-	@ObservedObject var store: AccountStore
-	@ObservedObject var loginWindowState: LoginWindowState
+	let store: AccountStore
+	let loginWindowState: LoginWindowState
 	@Environment(\.colorScheme) var colorScheme
 	@State var accountScrollOffset: CGFloat = 0
 	@State var armedLogoutAccountID: String?
@@ -13,18 +13,17 @@ struct AccountPanelView: View {
 	@AppStorage("decodex.operator.accountPrivacy") var accountPrivacy = AccountPrivacy.hiddenValue
 
 	var body: some View {
-		Group {
-			if #available(macOS 26.0, *) {
-				GlassEffectContainer(spacing: 6) {
-					panelContent
-				}
-			} else {
-				panelContent
-			}
+		GlassEffectContainer(spacing: 6) {
+			panelContent
 		}
 		.background {
-			LoginPanelPresenter(store: store, state: loginWindowState)
-				.frame(width: 0, height: 0)
+			LoginPanelPresenter(
+				store: store,
+				state: loginWindowState,
+				isPresented: loginWindowState.isPresented,
+				mode: loginWindowState.mode
+			)
+			.frame(width: 0, height: 0)
 		}
 		.onDisappear {
 			disarmLogout()

--- a/apps/decodex-app/Sources/DecodexApp/AccountRunChipView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountRunChipView.swift
@@ -52,7 +52,7 @@ struct AccountRunChipView: View {
 	private func schedulePopover() {
 		hoverPopoverTask?.cancel()
 		hoverPopoverTask = Task {
-			try? await Task.sleep(nanoseconds: AccountRunChipLayout.popoverHoverDelayNanoseconds)
+			try? await Task.sleep(for: AccountRunChipLayout.popoverHoverDelay)
 			guard Task.isCancelled == false else {
 				return
 			}

--- a/apps/decodex-app/Sources/DecodexApp/AccountRunStripControls.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountRunStripControls.swift
@@ -113,7 +113,7 @@ struct AccountRunStripEdgeButton: View {
 		isPressed = true
 		clickAction()
 		pressTask = Task {
-			try? await Task.sleep(nanoseconds: AccountRunStripLayout.continuousScrollStartDelayNanoseconds)
+			try? await Task.sleep(for: AccountRunStripLayout.continuousScrollStartDelay)
 			guard Task.isCancelled == false else {
 				return
 			}

--- a/apps/decodex-app/Sources/DecodexApp/AccountRunStripLayout.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountRunStripLayout.swift
@@ -7,7 +7,7 @@ enum AccountRunChipLayout {
 	static let horizontalPadding: CGFloat = 6.5
 	static let iconWidth: CGFloat = 9.5
 	static let spacing: CGFloat = 4
-	static let popoverHoverDelayNanoseconds: UInt64 = 320_000_000
+	static let popoverHoverDelay: Duration = .milliseconds(320)
 }
 
 enum AccountRunStripLayout {
@@ -21,7 +21,7 @@ enum AccountRunStripLayout {
 	static let wheelLineDeltaScale: CGFloat = 11
 	static let wheelMinimumDelta: CGFloat = 0.1
 	static let clickScrollDuration: TimeInterval = 0.14
-	static let continuousScrollStartDelayNanoseconds: UInt64 = 200_000_000
+	static let continuousScrollStartDelay: Duration = .milliseconds(200)
 	static let continuousScrollTickInterval: TimeInterval = 1.0 / 120.0
 	static let continuousScrollMaximumFrameInterval: TimeInterval = 1.0 / 20.0
 	static let continuousScrollVelocity: CGFloat = 285

--- a/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
@@ -1,25 +1,29 @@
 import Foundation
+import Observation
 
 @MainActor
-final class AccountStore: ObservableObject {
-	@Published var accountList: AccountListResponse?
-	@Published var fastMode: CodexFastModeResponse?
-	@Published var operatorSnapshot: OperatorSnapshotResponse?
-	@Published var operatorPresentation: OperatorSnapshotPresentation?
-	@Published var operatorSnapshotUpdatedAt: Date?
-	@Published var isRefreshing = false
-	@Published var isLoggingIn = false
-	@Published var isSettingFastMode = false
-	@Published var loginTranscript = ""
-	@Published var notice: String?
-	@Published var pendingLogoutRemovalKeys = Set<String>()
+@Observable
+final class AccountStore {
+	var accountList: AccountListResponse?
+	var fastMode: CodexFastModeResponse?
+	var operatorSnapshot: OperatorSnapshotResponse?
+	var operatorPresentation: OperatorSnapshotPresentation?
+	var operatorSnapshotUpdatedAt: Date?
+	var isRefreshing = false
+	var isLoggingIn = false
+	var isSettingFastMode = false
+	var loginTranscript = ""
+	var notice: String?
+	var pendingLogoutRemovalKeys = Set<String>()
 
-	let bridge = DecodexAppBridge()
-	var automaticRefreshTask: Task<Void, Never>?
-	var operatorSnapshotStreamTask: Task<Void, Never>?
-	var operatorSnapshotPublishedAtUnixEpoch: Int64?
+	@ObservationIgnored let bridge = DecodexAppBridge()
+	@ObservationIgnored var startupTask: Task<Void, Never>?
+	@ObservationIgnored var automaticRefreshTask: Task<Void, Never>?
+	@ObservationIgnored var operatorSnapshotStreamTask: Task<Void, Never>?
+	@ObservationIgnored var operatorSnapshotPublishedAtUnixEpoch: Int64?
 
 	deinit {
+		startupTask?.cancel()
 		automaticRefreshTask?.cancel()
 		operatorSnapshotStreamTask?.cancel()
 	}
@@ -72,8 +76,8 @@ final class AccountStore: ObservableObject {
 			return "Ready"
 		}
 
-			return "Importing account"
-		}
+		return "Importing account"
+	}
 
 	func resetLoginSession() {
 		guard isLoggingIn == false else {

--- a/apps/decodex-app/Sources/DecodexApp/AccountStoreOperatorStream.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStoreOperatorStream.swift
@@ -2,8 +2,8 @@ import Foundation
 import OSLog
 
 private let accountStoreLog = Logger(subsystem: "ink.hack.DecodexApp", category: "AccountStore")
-private let operatorSnapshotReconnectInitialDelay: UInt64 = 1_000_000_000
-private let operatorSnapshotReconnectMaxDelay: UInt64 = 30_000_000_000
+private let operatorSnapshotReconnectInitialDelay: Duration = .seconds(1)
+private let operatorSnapshotReconnectMaxDelay: Duration = .seconds(30)
 
 extension AccountStore {
 	func startOperatorSnapshotStream() {
@@ -32,11 +32,11 @@ extension AccountStore {
 			}
 
 			do {
-				try await Task.sleep(nanoseconds: reconnectDelay)
+				try await Task.sleep(for: reconnectDelay)
 			} catch {
 				return
 			}
-			reconnectDelay = min(operatorSnapshotReconnectMaxDelay, reconnectDelay * 2)
+			reconnectDelay = min(operatorSnapshotReconnectMaxDelay, reconnectDelay + reconnectDelay)
 		}
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountStoreRefresh.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStoreRefresh.swift
@@ -1,8 +1,19 @@
 import Foundation
 
-private let accountUsageRefreshIntervalNanoseconds: UInt64 = 15_000_000_000
+private let accountUsageRefreshInterval: Duration = .seconds(15)
 
 extension AccountStore {
+	func start() {
+		guard startupTask == nil else {
+			return
+		}
+
+		startAutomaticRefresh()
+		startupTask = Task { [weak self] in
+			await self?.refreshIfNeeded()
+		}
+	}
+
 	func refresh(force: Bool = false) async {
 		guard isRefreshing == false else {
 			return
@@ -41,7 +52,7 @@ extension AccountStore {
 		automaticRefreshTask = Task { [weak self] in
 			while Task.isCancelled == false {
 				do {
-					try await Task.sleep(nanoseconds: accountUsageRefreshIntervalNanoseconds)
+					try await Task.sleep(for: accountUsageRefreshInterval)
 				} catch {
 					return
 				}

--- a/apps/decodex-app/Sources/DecodexApp/DecodexApp.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexApp.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Observation
 import SwiftUI
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -8,10 +9,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 }
 
 @MainActor
-final class AppAppearanceStore: ObservableObject {
-	@Published private(set) var colorScheme = AppAppearanceStore.currentColorScheme()
-	private var observation: NSKeyValueObservation?
-	private var distributedNotificationTokens = [NSObjectProtocol]()
+@Observable
+final class AppAppearanceStore {
+	private(set) var colorScheme = AppAppearanceStore.currentColorScheme()
+	@ObservationIgnored private var observation: NSKeyValueObservation?
+	@ObservationIgnored private var distributedNotificationTokens = [NSObjectProtocol]()
 
 	init() {
 		refreshColorScheme()
@@ -70,27 +72,25 @@ enum AppAssets {
 }
 
 @MainActor
-final class LoginWindowState: ObservableObject {
-	@Published var mode = AccountLoginSheetMode.newAccount
-	@Published var isPresented = false
+@Observable
+final class LoginWindowState {
+	var mode = AccountLoginSheetMode.newAccount
+	var isPresented = false
 }
 
 @main
 struct DecodexApp: App {
 	@NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-	@StateObject private var appAppearance = AppAppearanceStore()
-	@StateObject private var store: AccountStore
-	@StateObject private var loginWindowState = LoginWindowState()
+	@State private var appAppearance = AppAppearanceStore()
+	@State private var store: AccountStore
+	@State private var loginWindowState = LoginWindowState()
 
 	@MainActor
 	init() {
 		let accountStore = AccountStore()
 
-		_store = StateObject(wrappedValue: accountStore)
-		Task {
-			accountStore.startAutomaticRefresh()
-			await accountStore.refreshIfNeeded()
-		}
+		_store = State(initialValue: accountStore)
+		accountStore.start()
 	}
 
 	var body: some Scene {
@@ -109,19 +109,9 @@ struct DecodexApp: App {
 
 	@ViewBuilder
 	private var menuBarContent: some View {
-		let content = AccountPanelView(store: store, loginWindowState: loginWindowState)
+		AccountPanelView(store: store, loginWindowState: loginWindowState)
 			.environment(\.colorScheme, appAppearance.colorScheme)
 			.preferredColorScheme(appAppearance.colorScheme)
-			.task {
-				await store.refreshIfNeeded()
-				store.startOperatorSnapshotStream()
-			}
-
-		if #available(macOS 15.0, *) {
-			content
-				.containerBackground(.clear, for: .window)
-		} else {
-			content
-		}
+			.containerBackground(.clear, for: .window)
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/DecodexServerLifecycle.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexServerLifecycle.swift
@@ -60,7 +60,7 @@ extension DecodexServerBridge {
 				return defaultBaseURL
 			}
 
-			try await Task.sleep(nanoseconds: 100_000_000)
+			try await Task.sleep(for: .milliseconds(100))
 		}
 
 		throw DecodexAppBridgeError.launchFailed("Decodex server did not become ready on \(defaultListenAddress)")

--- a/apps/decodex-app/Sources/DecodexApp/LoginButtons.swift
+++ b/apps/decodex-app/Sources/DecodexApp/LoginButtons.swift
@@ -27,6 +27,7 @@ struct LoginIconActionButton: View {
 			}
 		}
 		.help(help)
+		.accessibilityLabel(help)
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/LoginPanelCoordinator.swift
+++ b/apps/decodex-app/Sources/DecodexApp/LoginPanelCoordinator.swift
@@ -2,8 +2,10 @@ import AppKit
 import SwiftUI
 
 struct LoginPanelPresenter: NSViewRepresentable {
-	@ObservedObject var store: AccountStore
-	@ObservedObject var state: LoginWindowState
+	let store: AccountStore
+	let state: LoginWindowState
+	let isPresented: Bool
+	let mode: AccountLoginSheetMode
 
 	func makeCoordinator() -> Coordinator {
 		Coordinator()
@@ -18,7 +20,12 @@ struct LoginPanelPresenter: NSViewRepresentable {
 
 	func updateNSView(_ nsView: NSView, context: Context) {
 		context.coordinator.hostView = nsView
-		context.coordinator.update(store: store, state: state)
+		context.coordinator.update(
+			store: store,
+			state: state,
+			isPresented: isPresented,
+			mode: mode
+		)
 	}
 }
 
@@ -88,15 +95,20 @@ extension LoginPanelPresenter {
 		private var isClosingProgrammatically = false
 
 		@MainActor
-		func update(store: AccountStore, state: LoginWindowState) {
+		func update(
+			store: AccountStore,
+			state: LoginWindowState,
+			isPresented: Bool,
+			mode: AccountLoginSheetMode
+		) {
 			self.state = state
 
-			guard state.isPresented else {
+			guard isPresented else {
 				closePanel()
 				return
 			}
 
-			let rootView = makeRootView(store: store, state: state)
+			let rootView = makeRootView(store: store, state: state, mode: mode)
 			if let panel, let hostingView {
 				hostingView.rootView = rootView
 				let parentChanged = show(panel)
@@ -138,10 +150,14 @@ extension LoginPanelPresenter {
 		}
 
 		@MainActor
-		private func makeRootView(store: AccountStore, state: LoginWindowState) -> LoginSheetView {
+		private func makeRootView(
+			store: AccountStore,
+			state: LoginWindowState,
+			mode: AccountLoginSheetMode
+		) -> LoginSheetView {
 			LoginSheetView(
 				store: store,
-				mode: state.mode,
+				mode: mode,
 				onCancel: { [weak state] in
 					state?.isPresented = false
 				},

--- a/apps/decodex-app/Sources/DecodexApp/LoginSheetView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/LoginSheetView.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 
 struct LoginSheetView: View {
-	@ObservedObject var store: AccountStore
+	let store: AccountStore
 	let mode: AccountLoginSheetMode
 	@Environment(\.colorScheme) private var colorScheme
 	@State private var requestStarted = false
@@ -26,14 +26,8 @@ struct LoginSheetView: View {
 	}
 
 	var body: some View {
-		Group {
-			if #available(macOS 26.0, *) {
-				GlassEffectContainer(spacing: 7) {
-					content
-				}
-			} else {
-				content
-			}
+		GlassEffectContainer(spacing: 7) {
+			content
 		}
 	}
 
@@ -146,7 +140,7 @@ struct LoginSheetView: View {
 		}
 
 		Task { @MainActor in
-			try? await Task.sleep(nanoseconds: 850_000_000)
+			try? await Task.sleep(for: .milliseconds(850))
 			guard copyFeedbackToken == token else {
 				return
 			}
@@ -164,7 +158,7 @@ struct LoginSheetView: View {
 		}
 
 		Task { @MainActor in
-			try? await Task.sleep(nanoseconds: 650_000_000)
+			try? await Task.sleep(for: .milliseconds(650))
 			guard openFeedbackToken == token else {
 				return
 			}

--- a/apps/decodex-app/Sources/DecodexApp/PanelControls.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelControls.swift
@@ -84,6 +84,7 @@ struct PanelIconButtonView: View {
 		.disabled(isDisabled)
 		.opacity(isDisabled && isActive == false ? 0.56 : 1)
 		.help(help)
+		.accessibilityLabel(help)
 	}
 
 	@ViewBuilder
@@ -142,4 +143,3 @@ struct PanelIconButtonView: View {
 		size * 0.5
 	}
 }
-

--- a/apps/decodex-app/Sources/DecodexApp/PanelGlassSurface.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelGlassSurface.swift
@@ -10,51 +10,30 @@ struct ModernGlassSurfaceModifier: ViewModifier {
 		let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
 		let appearanceID = colorScheme == .dark ? "dark" : "light"
 
-		if #available(macOS 26.0, *) {
-			content
-				.background {
-					shape.fill(surfaceFill)
-				}
-				.glassEffect(
-					configuredGlass,
-					in: shape
-				)
-				.overlay {
-					shape
-						.strokeBorder(surfaceStroke, lineWidth: strokeWidth)
-						.allowsHitTesting(false)
-				}
-				.shadow(
-					color: surfaceShadow,
-					radius: shadowRadius,
-					x: 0,
-					y: shadowY
-				)
-				// Menu-bar glass layers can keep a stale material across system appearance flips.
-				// Re-key only the surface wrapper so light/dark changes redraw immediately.
-				.id(appearanceID)
-		} else {
-			content
-				.background {
-					shape.fill(materialStyle)
-					shape.fill(surfaceFill)
-				}
-				.overlay {
-					shape
-						.strokeBorder(surfaceStroke, lineWidth: strokeWidth)
-						.allowsHitTesting(false)
-				}
-				.shadow(
-					color: surfaceShadow,
-					radius: shadowRadius,
-					x: 0,
-					y: shadowY
-				)
-				.id(appearanceID)
-		}
+		content
+			.background {
+				shape.fill(surfaceFill)
+			}
+			.glassEffect(
+				configuredGlass,
+				in: shape
+			)
+			.overlay {
+				shape
+					.strokeBorder(surfaceStroke, lineWidth: strokeWidth)
+					.allowsHitTesting(false)
+			}
+			.shadow(
+				color: surfaceShadow,
+				radius: shadowRadius,
+				x: 0,
+				y: shadowY
+			)
+			// Menu-bar glass layers can keep a stale material across system appearance flips.
+			// Re-key only the surface wrapper so light/dark changes redraw immediately.
+			.id(appearanceID)
 	}
 
-	@available(macOS 26.0, *)
 	var configuredGlass: Glass {
 		var glass = Glass.regular.tint(glassTint)
 		if depth == .control {

--- a/apps/decodex-app/Sources/DecodexApp/PanelGlassSurfaceAppearance.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelGlassSurfaceAppearance.swift
@@ -22,19 +22,6 @@ extension ModernGlassSurfaceModifier {
 		}
 	}
 
-	var materialStyle: AnyShapeStyle {
-		switch depth {
-		case .panel:
-			return AnyShapeStyle(.ultraThinMaterial)
-		case .section:
-			return AnyShapeStyle(.thinMaterial)
-		case .row:
-			return colorScheme == .dark ? AnyShapeStyle(.thinMaterial) : AnyShapeStyle(.ultraThinMaterial)
-		case .control:
-			return colorScheme == .dark ? AnyShapeStyle(.thinMaterial) : AnyShapeStyle(.ultraThinMaterial)
-		}
-	}
-
 	var surfaceFill: Color {
 		switch depth {
 		case .panel:

--- a/apps/decodex-app/script/build_and_run.sh
+++ b/apps/decodex-app/script/build_and_run.sh
@@ -7,7 +7,7 @@ EXECUTABLE_NAME="DecodexApp"
 HELPER_NAME="decodex-app-helper"
 SERVER_NAME="decodex"
 BUNDLE_ID="space.decodex.app"
-MIN_SYSTEM_VERSION="14.0"
+MIN_SYSTEM_VERSION="27.0"
 DEFAULT_SIGN_IDENTITY="x@acg.box"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
## Summary

- raise the Swift package and app bundle deployment floor to macOS 27 with Swift 6.4
- migrate app state to Observation and give AccountStore one app-lifetime startup owner
- remove obsolete availability/material fallbacks, adopt Duration sleeps, and improve icon-button accessibility
- preserve the attached login panel behavior while adapting its bridge to Observation

## Validation

- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcrun swift test --package-path apps/decodex-app -c release --scratch-path /tmp/decodex-menubar-modernization-final.DkOjlH --quiet (54 passed)
- bash -n apps/decodex-app/script/build_and_run.sh
- git diff --check HEAD^
- signed release UI launched from /Applications/Decodex.app with Mach-O minos/sdk 27.0 and live server health ok
- window-level live check confirmed the menu renders correctly and attached login opens, cancels, and reopens
- independent final review found no actionable P0/P1 findings

## Known boundary

The existing full-bundle stage script cannot currently rebuild the frozen legacy Rust helpers after their workspace exclusion. Runtime validation therefore retained the already installed helpers and replaced only the Swift UI executable.