### PR TITLE
Record old-route cleanup readback

### DIFF
--- a/openwiki/evidence/v0.2-freeze.md
+++ b/openwiki/evidence/v0.2-freeze.md
@@ -156,3 +156,52 @@ Before destructive v0.2 removal or vNext startup, a later task must:
 Stop if the tag or backup changes, a frozen PR/branch/worktree disappears, an automation
 becomes active without explicit adoption, credentials appear in repository/PostgreSQL
 state, or the missing SQLite evidence is silently treated as recovered.
+
+## Post-freeze old-route cleanup readback
+
+Read back: 2026-07-20.
+
+This section records owner-authorized cleanup after the 2026-07-13 freeze. It does not
+change the at-freeze facts above or the historical
+[`v0.2-freeze-worktrees.tsv`](v0.2-freeze-worktrees.tsv) snapshot.
+
+For current guidance, this readback supersedes prerequisite 4 and the old-route
+branch/worktree disappearance stop condition above. Deleted old-route branches, remote
+branch heads, and related worktrees are not future prerequisites or stop conditions.
+All other prerequisites and stop conditions remain.
+
+| PR | Current GitHub state and exact head |
+| --- | --- |
+| #1061 | Closed and unmerged at `3be55f9c4864c730605aed723b00843b693f136a`. |
+| #1068 | Closed and unmerged at `cf5914d5534316a2198f4e4a034f6920de7229a6`. |
+| #1073 | Closed and unmerged at `2377fb44a3c89b7ef8aa46714472d972191bd522`. |
+| #1090 | Closed and unmerged at `85454ccf28f0fd3cb9cf43ca4ec5c16e188f2af9`. |
+| #1092 | Closed and unmerged at `32a0589b94987f265013ffd3c8b322f9c57f5097`. |
+
+All five local branches, remote branch heads, and related worktrees are absent. The
+#1068 and #1073 artifacts were already absent. This cleanup removed the #1061, #1090,
+and #1092 artifacts.
+
+Each corresponding GitHub `refs/pull/<PR>/head` ref still resolves to the exact table
+head. GitHub retains each PR history, comments, and reviews.
+
+The cleanup intentionally discarded the #1092 worktree state after independent review:
+
+- 15 modified tracked files, with binary diff SHA-256
+  `ea1498c96c6108f2eea07bad55eb2b6d47fd75dcde13c5d24ee542ab97803086`.
+- untracked `apps/decodex/src/tracker/linear/client/resolution.rs`, with SHA-256
+  `f35608c0eb32a7dac0da92ebb1ad6185f3f3597aa718ec27662124715fd32677`.
+
+The signed tag object `36708769264bbcbdbb6583e7058d5e93f945a4f0` still peels to
+`f9d6c4e70198e94e5b9461b8cac7518ae14d41ef` with a good signature. The cold backup
+checksum verification passed.
+
+XY-1248, XY-1250, and XY-1251 are `Canceled` as superseded, not completed. XY-1249
+remains separate `Backlog` evidence and was not canceled.
+
+No old implementation is carried into vNext. The #1068 implementation is obsolete.
+The current vNext roadmap and XY-1303 continue to own CI, Pages, dependency updates,
+signing, notarization, and release requirements.
+
+Historical Lane Authority v2 decision, specification, and checkpoint documents remain
+provenance only. They must not be deleted or implemented.


### PR DESCRIPTION
## Summary
- add a dated 2026-07-20 post-freeze readback for the old-route PR cleanup
- preserve the 2026-07-13 freeze receipt and worktree inventory as historical snapshots
- record retained pull refs, discarded dirty bytes, canceled legacy issues, and current vNext ownership

## Validation
- `git diff --check`
- independent old-route disposition review: `APPROVED_FOR_CLEANUP`
- signed commit verification