### PR TITLE
Record final old-route cleanup addendum

### DIFF
--- a/openwiki/evidence/v0.2-freeze.md
+++ b/openwiki/evidence/v0.2-freeze.md
@@ -205,3 +205,41 @@ signing, notarization, and release requirements.
 
 Historical Lane Authority v2 decision, specification, and checkpoint documents remain
 provenance only. They must not be deleted or implemented.
+
+### Final residual cleanup
+
+The same 2026-07-20 readback records two final residual candidates.
+
+- XY-1319 was the legacy manual landing candidate. Cleanup removed worktree
+  `.worktrees/xy-1319-manual-land-integrity` and local branch
+  `xv/xy-1319-manual-land-integrity`. No remote branch or PR existed.
+  The candidate base was `2f5e637a2c65ee88c1946df22d5c3649f664f467`.
+  The candidate had 34 modified tracked paths and 4 untracked paths.
+  The diff had 1,236 insertions and 191 deletions.
+  The frozen tree was `889fad957e9b14521671ebe516c8c9420e8e8456`.
+  The binary diff SHA-256 was
+  `a38f27cba5a45fbab09fe019a45e701faf4e30470ea06211038c1bf6db904279`.
+  The full-index SHA-256 was
+  `b30bdbcf7149fd324908aa68d1cf9e4e15cb2db84df3bee5939931dd682c5524`.
+- XY-1322 was the legacy v0.2 two-phase bootstrap authority candidate. Cleanup removed
+  worktree `.worktrees/xy-1322-manual-landing-authority` and local branch
+  `xv/xy-1322-manual-landing-authority`. No remote branch or PR existed.
+  The candidate base was `2f5e637a2c65ee88c1946df22d5c3649f664f467`.
+  The candidate had 6 modified OpenWiki paths.
+  The diff had 520 insertions and 2 deletions.
+  The binary diff SHA-256 was
+  `429ecd1dcf718fe9c5de46180b911bbcbeaa888b437093db044f9c44ba266680`.
+  The full-index SHA-256 was
+  `3100c413c5232c12caafcb4a7e7753dd6d99691c84b0abecd0b4dd75cb5594d8`.
+
+An independent skeptic returned `APPROVED_FOR_COMPLETE_CLEANUP`. No implementation or
+unlanded documentation bytes require transplantation. Preserve only incident lessons
+and provenance.
+
+Linear XY-1319, XY-1322, and XY-1323 are `Canceled` as obsolete, not completed. XY-1324
+remains `Duplicate`. Retained provenance includes the Linear histories, PR #1112
+identity, hashes, rejection findings, and archived task IDs.
+
+XY-1284 and XY-1285 retain generalized vNext repository and landing ownership. XY-1285
+records the policy-configured fast landing requirement. Do not import the legacy shim
+design.


### PR DESCRIPTION
Records the independently approved disposal of the residual XY-1319 and XY-1322 legacy candidates, their exact fingerprints, Linear disposition, and retained vNext ownership. Documentation only; git diff --check passed.