### PR TITLE
Follow system time zone for reset times

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountUsageSummaryViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountUsageSummaryViews.swift
@@ -87,15 +87,15 @@ struct AccountResetCreditsSummaryView: View {
 	private var accessibilityLabel: String {
 		let dates = account.availableResetCredits
 			.map { credit in
-				"expires \(formatResetCreditDate(credit.expiresAtUnixEpoch)) BJT"
+				"expires \(formatResetCreditDate(credit.expiresAtUnixEpoch))"
 			}
 			.joined(separator: ", ")
 
-		return dates.isEmpty ? "reset cards \(summaryText) BJT" : "reset cards \(summaryText) BJT, \(dates)"
+		return dates.isEmpty ? "reset cards \(summaryText)" : "reset cards \(summaryText), \(dates)"
 	}
 
 	private func resetCreditHelp(_ credit: AccountResetCredit) -> String {
-		"Expires \(formatResetCreditDate(credit.expiresAtUnixEpoch)) BJT"
+		"Expires \(formatResetCreditDate(credit.expiresAtUnixEpoch))"
 	}
 }
 
@@ -198,7 +198,7 @@ struct AccountResetCreditExpiryStripView: View {
 	}
 
 	private func resetCreditHelp(_ credit: AccountResetCredit) -> String {
-		"Expires \(formatResetCreditDate(credit.expiresAtUnixEpoch)) BJT"
+		"Expires \(formatResetCreditDate(credit.expiresAtUnixEpoch))"
 	}
 
 	private func updateScrollMetrics(_ metrics: AccountRunStripMetrics) {
@@ -234,7 +234,10 @@ struct AccountResetCreditExpiryStripView: View {
 	}
 }
 
-func formatResetCreditDate(_ seconds: Int?) -> String {
+func formatResetCreditDate(
+	_ seconds: Int?,
+	timeZone: TimeZone = .autoupdatingCurrent
+) -> String {
 	guard let seconds, seconds > 0 else {
 		return "-"
 	}
@@ -245,7 +248,7 @@ func formatResetCreditDate(_ seconds: Int?) -> String {
 
 	let formatter = DateFormatter()
 	formatter.locale = Locale(identifier: "en_US_POSIX")
-	formatter.timeZone = TimeZone(identifier: "Asia/Shanghai")
+	formatter.timeZone = timeZone
 	formatter.dateFormat = "MMM d HH:mm"
 	return formatter.string(from: date)
 }

--- a/apps/decodex-app/Sources/DecodexApp/UsageResetDisplay.swift
+++ b/apps/decodex-app/Sources/DecodexApp/UsageResetDisplay.swift
@@ -5,7 +5,11 @@ struct UsageResetDisplay {
 	let date: String
 	let accessibility: String
 
-	static func make(resetAtUnixEpoch: Int?, now: Date = Date()) -> UsageResetDisplay {
+	static func make(
+		resetAtUnixEpoch: Int?,
+		now: Date = Date(),
+		timeZone: TimeZone = .autoupdatingCurrent
+	) -> UsageResetDisplay {
 		guard let seconds = resetAtUnixEpoch, seconds > 0 else {
 			return UsageResetDisplay(
 				short: "-",
@@ -25,7 +29,7 @@ struct UsageResetDisplay {
 
 		let distanceSeconds = Int(floor(resetAt.timeIntervalSince(now)))
 		if distanceSeconds <= 0 {
-			let date = formatResetDate(resetAt, now: now)
+			let date = formatResetDate(resetAt, now: now, timeZone: timeZone)
 			return UsageResetDisplay(
 				short: "0m",
 				date: date,
@@ -34,7 +38,7 @@ struct UsageResetDisplay {
 		}
 
 		let short = formatResetDuration(distanceSeconds)
-		let date = formatResetDate(resetAt, now: now)
+		let date = formatResetDate(resetAt, now: now, timeZone: timeZone)
 		return UsageResetDisplay(
 			short: short,
 			date: date,
@@ -63,10 +67,12 @@ struct UsageResetDisplay {
 		return "\(minutes)m"
 	}
 
-	private static func formatResetDate(_ date: Date, now: Date) -> String {
+	private static func formatResetDate(_ date: Date, now: Date, timeZone: TimeZone) -> String {
 		let formatter = DateFormatter()
 		formatter.locale = Locale(identifier: "en_US_POSIX")
-		let calendar = Calendar(identifier: .gregorian)
+		formatter.timeZone = timeZone
+		var calendar = Calendar(identifier: .gregorian)
+		calendar.timeZone = timeZone
 		formatter.dateFormat = calendar.component(.year, from: date) == calendar.component(.year, from: now)
 			? "MMM d HH:mm"
 			: "MMM d yyyy HH:mm"

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountStatusModelTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountStatusModelTests.swift
@@ -119,14 +119,66 @@ final class AccountStatusModelTests: XCTestCase {
 		XCTAssertEqual(account.visibleResetCreditCount, 2)
 		XCTAssertEqual(account.availableResetCredits.count, 2)
 		XCTAssertEqual(
-			account.availableResetCredits.map { formatResetCreditDate($0.expiresAtUnixEpoch) },
-			["Jul 25 13:51", "Jul 25 13:51"]
+			account.availableResetCredits.map(\.expiresAtUnixEpoch),
+			[1_784_958_690, 1_784_958_690]
 		)
 	}
 
-	func testResetCreditDateUsesBeijingDisplayContract() {
-		XCTAssertEqual(formatResetCreditDate(1_784_958_690), "Jul 25 13:51")
-		XCTAssertEqual(formatResetCreditDate(nil), "-")
+	func testResetDatesUseProvidedTimeZone() throws {
+		let resetAtUnixEpoch = 1_784_958_690
+		let now = Date(timeIntervalSince1970: 1_784_950_000)
+		let newYork = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
+		let shanghai = try XCTUnwrap(TimeZone(identifier: "Asia/Shanghai"))
+
+		XCTAssertEqual(
+			formatResetCreditDate(resetAtUnixEpoch, timeZone: newYork),
+			"Jul 25 01:51"
+		)
+		XCTAssertEqual(
+			UsageResetDisplay.make(
+				resetAtUnixEpoch: resetAtUnixEpoch,
+				now: now,
+				timeZone: newYork
+			).date,
+			"Jul 25 01:51"
+		)
+		XCTAssertEqual(
+			formatResetCreditDate(resetAtUnixEpoch, timeZone: shanghai),
+			"Jul 25 13:51"
+		)
+		XCTAssertEqual(
+			UsageResetDisplay.make(
+				resetAtUnixEpoch: resetAtUnixEpoch,
+				now: now,
+				timeZone: shanghai
+			).date,
+			"Jul 25 13:51"
+		)
+		XCTAssertEqual(formatResetCreditDate(nil, timeZone: newYork), "-")
+	}
+
+	func testUsageResetDateUsesProvidedTimeZoneAtYearBoundary() throws {
+		let now = Date(timeIntervalSince1970: 1_798_731_000)
+		let resetAtUnixEpoch = 1_798_734_600
+		let newYork = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
+		let shanghai = try XCTUnwrap(TimeZone(identifier: "Asia/Shanghai"))
+
+		XCTAssertEqual(
+			UsageResetDisplay.make(
+				resetAtUnixEpoch: resetAtUnixEpoch,
+				now: now,
+				timeZone: newYork
+			).date,
+			"Dec 31 11:30"
+		)
+		XCTAssertEqual(
+			UsageResetDisplay.make(
+				resetAtUnixEpoch: resetAtUnixEpoch,
+				now: now,
+				timeZone: shanghai
+			).date,
+			"Jan 1 2027 00:30"
+		)
 	}
 
 	func testUsageResetDisplayUsesInjectedClock() {


### PR DESCRIPTION
## Summary

- Display menubar reset times in the macOS autoupdating system time zone.
- Use the same time zone for year-boundary formatting decisions.
- Add New York, Shanghai, and cross-year regression coverage.

## Validation

- All 55 DecodexApp Swift tests pass with TZ=America/New_York.
- All 55 DecodexApp Swift tests pass with TZ=Asia/Shanghai.
- Release build passes.
- git diff --check passes.