### PR TITLE
Enable safe reset-card use in the macOS app

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -23,6 +23,7 @@ operations and interactive login flows that need streamed command output:
 - pin future Decodex runs to one account
 - return future Decodex runs to balanced selection
 - force Codex itself to use a stored account
+- use an available reset card after an inline confirmation
 - run isolated Codex device login, then import the resulting auth file
 - remove a stored account from the local pool
 
@@ -109,6 +110,16 @@ staples the staged app before packaging; `APPLE_NOTARY_ISSUER` is used when pres
 The "Use in Codex" action overwrites Codex's `auth.json` from one stored
 `~/.codex/decodex/accounts.jsonl` entry. The destination is `$CODEX_HOME/auth.json`
 when `CODEX_HOME` is set, otherwise `~/.codex/auth.json`.
+
+The reset-card action requires two clicks on the same card. The first click reads the
+current opaque credit ID and then shows `Confirm Use` with a five-second countdown.
+The confirmation cancels when the countdown expires or the panel closes. A second
+click during the countdown consumes that exact ID and reuses one idempotency key for
+retries. Each request uses an isolated Codex app-server session with a short-lived
+file-auth copy for the selected account. The copy contains the current access token
+and a disabled refresh placeholder, not the managed refresh token. The action does
+not overwrite the user's normal Codex `auth.json`. Ambiguous duplicate cards and
+incomplete card-detail lists fail closed.
 
 App icon assets live under `assets/app-icon/` with `source/`, `composer/`, and
 `generated/` lanes. Menu bar icon assets live under `assets/tray-icon/` with matching

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -78,28 +78,27 @@ struct AccountPanelView: View {
 	}
 
 	private var accountList: some View {
-		Group {
-			if accountListNeedsScrolling {
-				ScrollView(.vertical, showsIndicators: false) {
-					accountRows
-						.background(accountScrollProbe)
-				}
-				.coordinateSpace(name: AccountPanelLayout.accountListScrollSpace)
-				.frame(height: accountListViewportHeight)
-				.overlay(alignment: .trailing) {
-					AccountListScrollIndicatorView(
-						contentHeight: accountListContentHeight,
-						viewportHeight: accountListViewportHeight,
-						scrollOffset: accountScrollOffset
-					)
-					.padding(.trailing, 1)
-				}
-				.onPreferenceChange(AccountScrollOffsetPreferenceKey.self) { minY in
-					let maxOffset = max(0, accountListContentHeight - accountListViewportHeight)
-					accountScrollOffset = min(max(0, -minY), maxOffset)
-				}
-			} else {
-				accountRows
+		ScrollView(.vertical, showsIndicators: false) {
+			accountRows
+				.background(accountScrollProbe)
+		}
+		.coordinateSpace(name: AccountPanelLayout.accountListScrollSpace)
+		.frame(height: accountListViewportHeight)
+		.overlay(alignment: .trailing) {
+			AccountListScrollIndicatorView(
+				contentHeight: accountListContentHeight,
+				viewportHeight: accountListViewportHeight,
+				scrollOffset: accountScrollOffset
+			)
+			.padding(.trailing, 1)
+		}
+		.onPreferenceChange(AccountScrollOffsetPreferenceKey.self) { minY in
+			let maxOffset = max(0, accountListContentHeight - accountListViewportHeight)
+			accountScrollOffset = min(max(0, -minY), maxOffset)
+		}
+		.onChange(of: accountListNeedsScrolling) { _, needsScrolling in
+			if needsScrolling == false {
+				accountScrollOffset = 0
 			}
 		}
 	}
@@ -119,10 +118,17 @@ struct AccountPanelView: View {
 					isLogoutArmed: armedLogoutAccountID == account.id,
 					isLogoutPending: deletingLogoutAccountID == account.id,
 					logoutErrorMessage: armedLogoutAccountID == account.id ? logoutErrorMessage : nil,
+					usageRefillAnimation: store.usageRefillAnimations[account.accountFingerprint],
 					useInCodex: {
 						Task {
 							await store.useInCodex(account)
 						}
+					},
+					prepareResetCredit: { preparation in
+						await store.prepareResetCredit(preparation, for: account)
+					},
+					consumeResetCredit: { attempt in
+						await store.consumeResetCredit(attempt, for: account)
 					},
 					routeRunsHere: {
 						Task {

--- a/apps/decodex-app/Sources/DecodexApp/AccountRowView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountRowView.swift
@@ -8,7 +8,10 @@ struct AccountRowView: View {
 	let isLogoutArmed: Bool
 	let isLogoutPending: Bool
 	let logoutErrorMessage: String?
+	let usageRefillAnimation: AccountUsageRefillAnimation?
 	let useInCodex: () -> Void
+	let prepareResetCredit: (ResetCreditUsePreparation) async -> String?
+	let consumeResetCredit: (ResetCreditUseAttempt) async -> Bool
 	let routeRunsHere: () -> Void
 	let login: () -> Void
 	let logout: () -> Void
@@ -65,7 +68,12 @@ struct AccountRowView: View {
 			}
 
 			if account.hasUsageSummary {
-				AccountUsageSummaryView(account: account)
+				AccountUsageSummaryView(
+					account: account,
+					usageRefillAnimation: usageRefillAnimation,
+					prepareResetCredit: prepareResetCredit,
+					consumeResetCredit: consumeResetCredit
+				)
 					.transition(.panelInline)
 			}
 		}

--- a/apps/decodex-app/Sources/DecodexApp/AccountRunStripAppKitScrolling.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountRunStripAppKitScrolling.swift
@@ -52,6 +52,17 @@ final class AccountRunDragHostingView<Content: View>: NSHostingView<Content> {
 	weak var dragScrollView: NSScrollView?
 	var onDragScroll: (() -> Void)?
 	var onClick: ((NSPoint) -> Void)?
+	var allowsPointerPanning = true {
+		didSet {
+			guard allowsPointerPanning != oldValue else {
+				return
+			}
+
+			dragStartPoint = nil
+			isDraggingContent = false
+			window?.invalidateCursorRects(for: self)
+		}
+	}
 	private var dragStartPoint: NSPoint?
 	private var dragStartOffset: CGFloat = 0
 	private var isDraggingContent = false
@@ -113,7 +124,7 @@ final class AccountRunDragHostingView<Content: View>: NSHostingView<Content> {
 	}
 
 	private var canDrag: Bool {
-		guard let dragScrollView else {
+		guard allowsPointerPanning, let dragScrollView else {
 			return false
 		}
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountRunStripScrolling.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountRunStripScrolling.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct AccountRunStripScrollView<Content: View>: NSViewRepresentable {
 	let placementStore: AccountRunStripPlacementStore
 	let scrollProxy: AccountRunStripScrollProxy
+	let allowsPointerPanning: Bool
 	let onMetricsChange: (AccountRunStripMetrics) -> Void
 	@ViewBuilder let content: () -> Content
 
@@ -15,7 +16,8 @@ struct AccountRunStripScrollView<Content: View>: NSViewRepresentable {
 	func makeNSView(context: Context) -> AccountRunStripContainerView<Content> {
 		let view = AccountRunStripContainerView(
 			rootView: content(),
-			placementStore: placementStore
+			placementStore: placementStore,
+			allowsPointerPanning: allowsPointerPanning
 		)
 		scrollProxy.attach(view)
 		view.onMetricsChange = { metrics in
@@ -31,6 +33,7 @@ struct AccountRunStripScrollView<Content: View>: NSViewRepresentable {
 		nsView.onMetricsChange = { metrics in
 			context.coordinator.publish(metrics)
 		}
+		nsView.allowsPointerPanning = allowsPointerPanning
 		nsView.update(rootView: content())
 	}
 
@@ -92,10 +95,23 @@ final class AccountRunStripContainerView<Content: View>: NSView, AccountRunStrip
 	let placementStore: AccountRunStripPlacementStore
 	var measuredContentWidth: CGFloat = 0
 	var onMetricsChange: ((AccountRunStripMetrics) -> Void)?
+	var allowsPointerPanning: Bool {
+		get {
+			hostingView.allowsPointerPanning
+		}
+		set {
+			hostingView.allowsPointerPanning = newValue
+		}
+	}
 
-	init(rootView: Content, placementStore: AccountRunStripPlacementStore) {
+	init(
+		rootView: Content,
+		placementStore: AccountRunStripPlacementStore,
+		allowsPointerPanning: Bool
+	) {
 		self.placementStore = placementStore
 		hostingView = AccountRunDragHostingView(rootView: rootView)
+		hostingView.allowsPointerPanning = allowsPointerPanning
 
 		super.init(frame: .zero)
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountRunStripView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountRunStripView.swift
@@ -26,6 +26,7 @@ struct AccountRunSummaryView: View {
 			AccountRunStripScrollView(
 				placementStore: placementStore,
 				scrollProxy: scrollProxy,
+				allowsPointerPanning: true,
 				onMetricsChange: { metrics in
 					updateScrollMetrics(metrics)
 				}

--- a/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
@@ -15,17 +15,22 @@ final class AccountStore {
 	var loginTranscript = ""
 	var notice: String?
 	var pendingLogoutRemovalKeys = Set<String>()
+	var usageRefillAnimations: [String: AccountUsageRefillAnimation] = [:]
 
 	@ObservationIgnored let bridge = DecodexAppBridge()
 	@ObservationIgnored var startupTask: Task<Void, Never>?
 	@ObservationIgnored var automaticRefreshTask: Task<Void, Never>?
 	@ObservationIgnored var operatorSnapshotStreamTask: Task<Void, Never>?
 	@ObservationIgnored var operatorSnapshotPublishedAtUnixEpoch: Int64?
+	@ObservationIgnored var usageRefillCleanupTasks: [String: Task<Void, Never>] = [:]
 
 	deinit {
 		startupTask?.cancel()
 		automaticRefreshTask?.cancel()
 		operatorSnapshotStreamTask?.cancel()
+		for task in usageRefillCleanupTasks.values {
+			task.cancel()
+		}
 	}
 
 	var isInitialLoading: Bool {

--- a/apps/decodex-app/Sources/DecodexApp/AccountStoreActions.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStoreActions.swift
@@ -109,4 +109,343 @@ extension AccountStore {
 
 		isLoggingIn = false
 	}
+
+	func prepareResetCredit(
+		_ preparation: ResetCreditUsePreparation,
+		for account: CodexAccount
+	) async -> String? {
+		guard preparation.target.accountID == account.accountFingerprint else {
+			notice = ResetCreditUseError.accountChanged.localizedDescription
+			return nil
+		}
+		guard await refreshAccountsForResetCredit() else {
+			return nil
+		}
+
+		do {
+			let codexHomeURL = try makeResetCreditCodexHome()
+			defer {
+				try? FileManager.default.removeItem(at: codexHomeURL)
+			}
+
+			let credentials = try await resetCreditCredentials(
+				for: account,
+				in: codexHomeURL
+			)
+			let codexExecutableURL = URL(fileURLWithPath: try bridge.codexExecutablePath())
+			let creditID = try await CodexResetCreditBridge().prepare(
+				codexExecutableURL: codexExecutableURL,
+				codexHomeURL: codexHomeURL,
+				credentials: credentials,
+				preparation: preparation
+			)
+
+			notice = nil
+			return creditID
+		} catch {
+			notice = error.localizedDescription
+			return nil
+		}
+	}
+
+	func consumeResetCredit(
+		_ attempt: ResetCreditUseAttempt,
+		for account: CodexAccount
+	) async -> Bool {
+		cancelUsageRefillAnimation(for: account.accountFingerprint)
+		guard attempt.target.accountID == account.accountFingerprint else {
+			notice = ResetCreditUseError.accountChanged.localizedDescription
+			return false
+		}
+		guard await refreshAccountsForResetCredit() else {
+			return false
+		}
+
+		do {
+			let freshAccount = try uniqueFreshResetCreditAccount(matching: account)
+			let refillAnimation = AccountUsageRefillAnimation.make(from: freshAccount)
+			let codexHomeURL = try makeResetCreditCodexHome()
+			defer {
+				try? FileManager.default.removeItem(at: codexHomeURL)
+			}
+
+			let credentials = try await resetCreditCredentials(
+				for: account,
+				in: codexHomeURL
+			)
+			let codexExecutableURL = URL(fileURLWithPath: try bridge.codexExecutablePath())
+			let outcome = try await CodexResetCreditBridge().consume(
+				codexExecutableURL: codexExecutableURL,
+				codexHomeURL: codexHomeURL,
+				credentials: credentials,
+				attempt: attempt
+			)
+
+			let outcomeNotice = resetCreditNotice(for: outcome)
+			if outcome == .reset {
+				beginUsageRefillAnimation(refillAnimation)
+			}
+			let refreshSucceeded = await refreshAccountsForResetCredit()
+			finishUsageRefillAnimation(
+				refillAnimation,
+				refreshSucceeded: outcome == .reset && refreshSucceeded
+			)
+			if refreshSucceeded {
+				notice = outcomeNotice
+			} else {
+				let refreshNotice = notice ?? "Account refresh failed."
+				notice = "\(outcomeNotice) \(refreshNotice)"
+			}
+			return true
+		} catch {
+			cancelUsageRefillAnimation(for: account.accountFingerprint)
+			_ = await refreshAccountsForResetCredit()
+			notice = error.localizedDescription
+			return false
+		}
+	}
+
+	private func refreshAccountsForResetCredit() async -> Bool {
+		while isRefreshing {
+			guard Task.isCancelled == false else {
+				return false
+			}
+
+			try? await Task.sleep(for: .milliseconds(25))
+		}
+
+		return await refresh(force: true)
+	}
+
+	private func resetCreditCredentials(
+		for account: CodexAccount,
+		in codexHomeURL: URL
+	) async throws -> CodexResetCreditCredentials {
+		let account = try uniqueFreshResetCreditAccount(matching: account)
+		let expectedEmail = normalizedEmail(account.email)
+
+		let exportedAuthURL = codexHomeURL.appendingPathComponent("selected-account.json")
+		defer {
+			try? FileManager.default.removeItem(at: exportedAuthURL)
+		}
+
+		let authResponse = try await bridge.runJSON(
+			.accountUse(
+				selector: account.selector,
+				authJsonPath: exportedAuthURL.path
+			),
+			as: CodexAuthUseResponse.self
+		)
+		if let expectedEmail,
+			normalizedEmail(authResponse.account.email) != expectedEmail
+		{
+			throw ResetCreditUseError.accountChanged
+		}
+		guard pathsReferToSameLocation(authResponse.codexAuthPath, exportedAuthURL.path) else {
+			throw ResetCreditUseError.authPathChanged
+		}
+		guard try exportedAuthURL
+			.resourceValues(forKeys: [.isRegularFileKey])
+			.isRegularFile == true
+		else {
+			throw ResetCreditUseError.authPathChanged
+		}
+
+		let authData = try Data(contentsOf: exportedAuthURL)
+		let auth = try JSONDecoder().decode(ResetCreditStoredAuth.self, from: authData)
+		let accessToken = auth.tokens.accessToken
+			.trimmingCharacters(in: .whitespacesAndNewlines)
+		let accountID = auth.tokens.accountID
+			.trimmingCharacters(in: .whitespacesAndNewlines)
+		guard accessToken.isEmpty == false, accountID.isEmpty == false else {
+			throw ResetCreditUseError.invalidAuth
+		}
+		guard resetCreditFingerprint(for: accountID) == account.accountFingerprint else {
+			throw ResetCreditUseError.accountChanged
+		}
+
+		let stagedAuthData = try auth.stagedData(
+			refreshToken: "decodex-disabled-refresh-\(UUID().uuidString)"
+		)
+		let stagedAuthURL = codexHomeURL.appendingPathComponent("auth.json")
+		guard FileManager.default.createFile(
+			atPath: stagedAuthURL.path,
+			contents: stagedAuthData,
+			attributes: [.posixPermissions: 0o600]
+		) else {
+			throw ResetCreditUseError.authPathChanged
+		}
+
+		return CodexResetCreditCredentials(expectedEmail: expectedEmail)
+	}
+
+	func uniqueFreshResetCreditAccount(matching account: CodexAccount) throws -> CodexAccount {
+		let expectedEmail = normalizedEmail(account.email)
+		let matches = accounts.filter { candidate in
+			guard candidate.accountFingerprint == account.accountFingerprint else {
+				return false
+			}
+			guard let expectedEmail else {
+				return true
+			}
+
+			return normalizedEmail(candidate.email) == expectedEmail
+		}
+
+		guard matches.isEmpty == false else {
+			throw ResetCreditUseError.accountChanged
+		}
+		guard matches.count == 1 else {
+			throw ResetCreditUseError.accountAmbiguous
+		}
+
+		return matches[0]
+	}
+
+	private func normalizedEmail(_ value: String?) -> String? {
+		guard let email = value?
+			.trimmingCharacters(in: .whitespacesAndNewlines)
+			.lowercased(),
+			email.isEmpty == false
+		else {
+			return nil
+		}
+
+		return email
+	}
+
+	private func resetCreditFingerprint(for accountID: String) -> String {
+		let tail = String(accountID.suffix(6))
+		return tail.isEmpty ? "unknown" : "...\(tail)"
+	}
+
+	private func makeResetCreditCodexHome() throws -> URL {
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("decodex-reset-credit-\(UUID().uuidString)", isDirectory: true)
+		try FileManager.default.createDirectory(
+			at: url,
+			withIntermediateDirectories: false,
+			attributes: [.posixPermissions: 0o700]
+		)
+		return url
+	}
+
+	private func pathsReferToSameLocation(_ left: String, _ right: String) -> Bool {
+		URL(fileURLWithPath: left)
+			.standardizedFileURL
+			.resolvingSymlinksInPath()
+			== URL(fileURLWithPath: right)
+				.standardizedFileURL
+				.resolvingSymlinksInPath()
+	}
+
+	private func resetCreditNotice(for outcome: ResetCreditConsumeOutcome) -> String {
+		switch outcome {
+		case .reset:
+			return "Reset card used."
+		case .alreadyRedeemed:
+			return "Reset card was already used."
+		case .nothingToReset:
+			return "No current rate limit can be reset."
+		case .noCredit:
+			return "No reset card is available."
+		}
+	}
+}
+
+private enum ResetCreditUseError: LocalizedError {
+	case accountAmbiguous
+	case accountChanged
+	case authPathChanged
+	case invalidAuth
+
+	var errorDescription: String? {
+		switch self {
+		case .accountAmbiguous:
+			return "More than one stored account matches this reset card. Remove the duplicate account and try again."
+		case .accountChanged:
+			return "The account changed. Refresh and try again."
+		case .authPathChanged:
+			return "Could not create an isolated Codex account session."
+		case .invalidAuth:
+			return "The selected account has no usable Codex access token."
+		}
+	}
+}
+
+struct ResetCreditStoredAuth: Decodable {
+	let email: String?
+	let authMode: String?
+	let lastRefresh: String?
+	let tokens: Tokens
+
+	struct Tokens: Decodable {
+		let email: String?
+		let idToken: String?
+		let accessToken: String
+		let refreshToken: String
+		let accountID: String
+
+		enum CodingKeys: String, CodingKey {
+			case email
+			case idToken = "id_token"
+			case accessToken = "access_token"
+			case refreshToken = "refresh_token"
+			case accountID = "account_id"
+		}
+	}
+
+	enum CodingKeys: String, CodingKey {
+		case email
+		case authMode = "auth_mode"
+		case lastRefresh = "last_refresh"
+		case tokens
+	}
+
+	func stagedData(refreshToken: String) throws -> Data {
+		try JSONEncoder().encode(
+			StagedAuth(
+				email: email,
+				authMode: "chatgpt",
+				lastRefresh: lastRefresh,
+				tokens: StagedAuth.Tokens(
+					email: tokens.email,
+					idToken: tokens.idToken,
+					accessToken: tokens.accessToken,
+					refreshToken: refreshToken,
+					accountID: tokens.accountID
+				)
+			)
+		)
+	}
+
+	private struct StagedAuth: Encodable {
+		let email: String?
+		let authMode: String
+		let lastRefresh: String?
+		let tokens: Tokens
+
+		struct Tokens: Encodable {
+			let email: String?
+			let idToken: String?
+			let accessToken: String
+			let refreshToken: String
+			let accountID: String
+
+			enum CodingKeys: String, CodingKey {
+				case email
+				case idToken = "id_token"
+				case accessToken = "access_token"
+				case refreshToken = "refresh_token"
+				case accountID = "account_id"
+			}
+		}
+
+		enum CodingKeys: String, CodingKey {
+			case email
+			case authMode = "auth_mode"
+			case lastRefresh = "last_refresh"
+			case tokens
+		}
+	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/AccountStoreRefresh.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStoreRefresh.swift
@@ -14,9 +14,10 @@ extension AccountStore {
 		}
 	}
 
-	func refresh(force: Bool = false) async {
+	@discardableResult
+	func refresh(force: Bool = false) async -> Bool {
 		guard isRefreshing == false else {
-			return
+			return false
 		}
 
 		isRefreshing = true
@@ -31,8 +32,10 @@ extension AccountStore {
 			))
 			notice = nil
 			await refreshFastMode()
+			return true
 		} catch {
 			notice = error.localizedDescription
+			return false
 		}
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountUsageMeterPresentation.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountUsageMeterPresentation.swift
@@ -25,6 +25,10 @@ extension AccountUsageMeterView {
 	}
 
 	var progress: CGFloat {
+		Self.normalizedProgress(for: remainingPercent)
+	}
+
+	static func normalizedProgress(for remainingPercent: Int?) -> CGFloat {
 		guard let remainingPercent else {
 			return 0
 		}
@@ -32,7 +36,21 @@ extension AccountUsageMeterView {
 		return CGFloat(max(0, min(100, remainingPercent))) / 100
 	}
 
-	func fillWidth(in width: CGFloat) -> CGFloat {
+	static func shouldAnimateRefill(
+		_ refillAnimation: AccountUsageMeterRefillAnimation?,
+		to current: Int?
+	) -> Bool {
+		guard let refillAnimation, let current else {
+			return false
+		}
+
+		return refillAnimation.fromPercent < 100 && current >= 100
+	}
+
+	func fillWidth(
+		in width: CGFloat,
+		progress: CGFloat
+	) -> CGFloat {
 		guard remainingPercent != nil else {
 			return 0
 		}

--- a/apps/decodex-app/Sources/DecodexApp/AccountUsageMeterView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountUsageMeterView.swift
@@ -8,7 +8,33 @@ struct AccountUsageMeterView: View {
 	let dailyAveragePercent: Double?
 	let tone: AccountTone
 	let currentTime: Date
+	let refillAnimation: AccountUsageMeterRefillAnimation?
 	@Environment(\.colorScheme) var colorScheme
+	@Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+	@State private var displayedProgress: CGFloat
+
+	init(
+		label: String,
+		remainingPercent: Int?,
+		resetAtUnixEpoch: Int?,
+		dailyAveragePercent: Double?,
+		tone: AccountTone,
+		currentTime: Date,
+		refillAnimation: AccountUsageMeterRefillAnimation? = nil
+	) {
+		self.label = label
+		self.remainingPercent = remainingPercent
+		self.resetAtUnixEpoch = resetAtUnixEpoch
+		self.dailyAveragePercent = dailyAveragePercent
+		self.tone = tone
+		self.currentTime = currentTime
+		self.refillAnimation = refillAnimation
+		_displayedProgress = State(
+			initialValue: Self.normalizedProgress(
+				for: refillAnimation?.fromPercent ?? remainingPercent
+			)
+		)
+	}
 
 	var body: some View {
 		VStack(alignment: .leading, spacing: 3) {
@@ -61,7 +87,10 @@ struct AccountUsageMeterView: View {
 
 			GeometryReader { proxy in
 				ZStack(alignment: .leading) {
-					let width = fillWidth(in: proxy.size.width)
+					let width = fillWidth(
+						in: proxy.size.width,
+						progress: displayedProgress
+					)
 
 					Capsule()
 						.fill(trackColor)
@@ -75,7 +104,6 @@ struct AccountUsageMeterView: View {
 						.fill(fillStyle)
 						.frame(width: width)
 						.clipShape(Capsule())
-						.animation(PanelMotion.state, value: remainingPercent)
 						.shadow(
 							color: color.opacity(colorScheme == .dark ? 0.09 : 0.07),
 							radius: colorScheme == .dark ? 1.2 : 1,
@@ -91,7 +119,65 @@ struct AccountUsageMeterView: View {
 		}
 		.lineLimit(1)
 		.frame(height: 22)
-			.frame(maxWidth: .infinity, alignment: .leading)
-			.accessibilityLabel(accessibilityText)
+		.frame(maxWidth: .infinity, alignment: .leading)
+		.accessibilityLabel(accessibilityText)
+		.onChange(of: remainingPercent) { _, current in
+			guard refillAnimation == nil else {
+				return
+			}
+
+			setDisplayedProgressWithoutAnimation(
+				Self.normalizedProgress(for: current)
+			)
+		}
+		.onChange(of: accessibilityReduceMotion) { _, reduceMotion in
+			guard reduceMotion else {
+				return
+			}
+
+			setDisplayedProgressWithoutAnimation(progress)
+		}
+		.task(id: refillAnimation?.id) {
+			await runRefillAnimation(refillAnimation)
+		}
+	}
+
+	@MainActor
+	private func runRefillAnimation(
+		_ refillAnimation: AccountUsageMeterRefillAnimation?
+	) async {
+		guard let refillAnimation else {
+			setDisplayedProgressWithoutAnimation(progress)
+			return
+		}
+		guard Self.shouldAnimateRefill(refillAnimation, to: remainingPercent) else {
+			setDisplayedProgressWithoutAnimation(progress)
+			return
+		}
+
+		setDisplayedProgressWithoutAnimation(
+			Self.normalizedProgress(for: refillAnimation.fromPercent)
+		)
+		await Task.yield()
+		guard Task.isCancelled == false else {
+			setDisplayedProgressWithoutAnimation(progress)
+			return
+		}
+		guard accessibilityReduceMotion == false else {
+			setDisplayedProgressWithoutAnimation(progress)
+			return
+		}
+
+		withAnimation(PanelMotion.meterRefill) {
+			displayedProgress = progress
+		}
+	}
+
+	private func setDisplayedProgressWithoutAnimation(_ nextProgress: CGFloat) {
+		var transaction = Transaction()
+		transaction.disablesAnimations = true
+		withTransaction(transaction) {
+			displayedProgress = nextProgress
+		}
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/AccountUsageRefillAnimation.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountUsageRefillAnimation.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+enum AccountUsageMeterSlot: Sendable {
+	case primary
+	case secondary
+}
+
+struct AccountUsageMeterRefillAnimation: Equatable, Identifiable, Sendable {
+	let eventID: UUID
+	let fromPercent: Int
+
+	var id: UUID {
+		eventID
+	}
+}
+
+struct AccountUsageRefillAnimation: Equatable, Identifiable, Sendable {
+	let id: UUID
+	let accountID: String
+	let primaryFromPercent: Int?
+	let secondaryFromPercent: Int?
+
+	init(
+		id: UUID = UUID(),
+		accountID: String,
+		primaryFromPercent: Int?,
+		secondaryFromPercent: Int?
+	) {
+		self.id = id
+		self.accountID = accountID
+		self.primaryFromPercent = Self.refillCandidate(primaryFromPercent)
+		self.secondaryFromPercent = Self.refillCandidate(secondaryFromPercent)
+	}
+
+	static func make(
+		from account: CodexAccount,
+		id: UUID = UUID()
+	) -> Self? {
+		let animation = Self(
+			id: id,
+			accountID: account.accountFingerprint,
+			primaryFromPercent: account.primaryRemainingPercent,
+			secondaryFromPercent: account.secondaryRemainingPercent
+		)
+
+		return animation.primaryFromPercent != nil
+			|| animation.secondaryFromPercent != nil
+			? animation
+			: nil
+	}
+
+	func meterAnimation(
+		for slot: AccountUsageMeterSlot,
+		currentPercent: Int?
+	) -> AccountUsageMeterRefillAnimation? {
+		guard let currentPercent, currentPercent >= 100 else {
+			return nil
+		}
+
+		let fromPercent = switch slot {
+		case .primary:
+			primaryFromPercent
+		case .secondary:
+			secondaryFromPercent
+		}
+		guard let fromPercent else {
+			return nil
+		}
+
+		return AccountUsageMeterRefillAnimation(
+			eventID: id,
+			fromPercent: fromPercent
+		)
+	}
+
+	private static func refillCandidate(_ percent: Int?) -> Int? {
+		guard let percent, percent < 100 else {
+			return nil
+		}
+
+		return percent
+	}
+}
+
+extension AccountStore {
+	func beginUsageRefillAnimation(_ animation: AccountUsageRefillAnimation?) {
+		guard let animation else {
+			return
+		}
+
+		usageRefillCleanupTasks[animation.accountID]?.cancel()
+		usageRefillCleanupTasks[animation.accountID] = nil
+		usageRefillAnimations[animation.accountID] = animation
+	}
+
+	func finishUsageRefillAnimation(
+		_ animation: AccountUsageRefillAnimation?,
+		refreshSucceeded: Bool
+	) {
+		guard let animation,
+			usageRefillAnimations[animation.accountID]?.id == animation.id
+		else {
+			return
+		}
+		guard refreshSucceeded else {
+			usageRefillCleanupTasks[animation.accountID]?.cancel()
+			usageRefillCleanupTasks[animation.accountID] = nil
+			usageRefillAnimations[animation.accountID] = nil
+			return
+		}
+
+		usageRefillCleanupTasks[animation.accountID] = Task { [weak self] in
+			do {
+				try await Task.sleep(for: .seconds(2))
+			} catch {
+				return
+			}
+			guard self?.usageRefillAnimations[animation.accountID]?.id == animation.id else {
+				return
+			}
+
+			self?.usageRefillAnimations[animation.accountID] = nil
+			self?.usageRefillCleanupTasks[animation.accountID] = nil
+		}
+	}
+
+	func cancelUsageRefillAnimation(for accountID: String) {
+		usageRefillCleanupTasks[accountID]?.cancel()
+		usageRefillCleanupTasks[accountID] = nil
+		usageRefillAnimations[accountID] = nil
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/AccountUsageSummaryViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountUsageSummaryViews.swift
@@ -3,6 +3,9 @@ import SwiftUI
 
 struct AccountUsageSummaryView: View {
 	let account: CodexAccount
+	let usageRefillAnimation: AccountUsageRefillAnimation?
+	let prepareResetCredit: (ResetCreditUsePreparation) async -> String?
+	let consumeResetCredit: (ResetCreditUseAttempt) async -> Bool
 
 	var body: some View {
 		TimelineView(.periodic(from: Date(), by: 30)) { timeline in
@@ -13,7 +16,11 @@ struct AccountUsageSummaryView: View {
 				}
 
 				if account.hasResetCreditsSummary {
-					AccountResetCreditsSummaryView(account: account)
+					AccountResetCreditsSummaryView(
+						account: account,
+						prepareResetCredit: prepareResetCredit,
+						consumeResetCredit: consumeResetCredit
+					)
 						.transition(.panelInline)
 				}
 
@@ -26,7 +33,11 @@ struct AccountUsageSummaryView: View {
 							forWindowSeconds: account.primaryWindowSeconds
 						),
 						tone: account.usageTone(remainingPercent: account.primaryRemainingPercent),
-						currentTime: timeline.date
+						currentTime: timeline.date,
+						refillAnimation: usageRefillAnimation?.meterAnimation(
+							for: .primary,
+							currentPercent: account.primaryRemainingPercent
+						)
 					)
 					.transition(.panelInline)
 				}
@@ -40,7 +51,11 @@ struct AccountUsageSummaryView: View {
 							forWindowSeconds: account.secondaryWindowSeconds
 						),
 						tone: account.usageTone(remainingPercent: account.secondaryRemainingPercent),
-						currentTime: timeline.date
+						currentTime: timeline.date,
+						refillAnimation: usageRefillAnimation?.meterAnimation(
+							for: .secondary,
+							currentPercent: account.secondaryRemainingPercent
+						)
 					)
 					.transition(.panelInline)
 				}
@@ -58,6 +73,8 @@ struct AccountUsageSummaryView: View {
 
 struct AccountResetCreditsSummaryView: View {
 	let account: CodexAccount
+	let prepareResetCredit: (ResetCreditUsePreparation) async -> String?
+	let consumeResetCredit: (ResetCreditUseAttempt) async -> Bool
 	@Environment(\.colorScheme) private var colorScheme
 
 	var body: some View {
@@ -66,17 +83,24 @@ struct AccountResetCreditsSummaryView: View {
 				symbol: "arrow.counterclockwise.circle",
 				tint: PanelPalette.routeAccent(colorScheme).opacity(0.84)
 			)
+				.accessibilityHidden(true)
 
 			Text(summaryText)
 				.font(PanelFont.usageLabel)
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme).opacity(0.86))
 				.lineLimit(1)
 				.fixedSize(horizontal: true, vertical: false)
+				.accessibilityHidden(true)
 
-			AccountResetCreditExpiryStripView(account: account)
+			AccountResetCreditExpiryStripView(
+				account: account,
+				prepareResetCredit: prepareResetCredit,
+				consumeResetCredit: consumeResetCredit
+			)
 		}
 		.frame(minHeight: 18)
-		.accessibilityLabel(accessibilityLabel)
+		.accessibilityElement(children: .contain)
+		.accessibilityLabel("Reset cards, \(summaryText)")
 	}
 
 	private var summaryText: String {
@@ -84,28 +108,21 @@ struct AccountResetCreditsSummaryView: View {
 		return "\(count) reset"
 	}
 
-	private var accessibilityLabel: String {
-		let dates = account.availableResetCredits
-			.map { credit in
-				"expires \(formatResetCreditDate(credit.expiresAtUnixEpoch))"
-			}
-			.joined(separator: ", ")
-
-		return dates.isEmpty ? "reset cards \(summaryText)" : "reset cards \(summaryText), \(dates)"
-	}
-
-	private func resetCreditHelp(_ credit: AccountResetCredit) -> String {
-		"Expires \(formatResetCreditDate(credit.expiresAtUnixEpoch))"
-	}
 }
 
 struct AccountResetCreditExpiryStripView: View {
+	private static let confirmationWindowSeconds = 5
+
 	let account: CodexAccount
+	let prepareResetCredit: (ResetCreditUsePreparation) async -> String?
+	let consumeResetCredit: (ResetCreditUseAttempt) async -> Bool
 	@Environment(\.colorScheme) private var colorScheme
 	@State private var placementStore = AccountRunStripPlacementStore()
 	@State private var scrollProxy = AccountRunStripScrollProxy()
 	@State private var scrollMetrics = AccountRunStripMetrics()
 	@State private var showsEdgeControls = false
+	@State private var confirmation = ResetCreditUseConfirmation()
+	@State private var confirmationSecondsRemaining = 0
 
 	var body: some View {
 		HStack(spacing: AccountRunStripLayout.edgeControlSpacing) {
@@ -117,20 +134,34 @@ struct AccountResetCreditExpiryStripView: View {
 			AccountRunStripScrollView(
 				placementStore: placementStore,
 				scrollProxy: scrollProxy,
+				allowsPointerPanning: false,
 				onMetricsChange: { metrics in
 					updateScrollMetrics(metrics)
 				}
 			) {
 				HStack(spacing: 4) {
 					ForEach(Array(account.availableResetCredits.enumerated()), id: \.offset) { index, credit in
-						resetCreditChip(formatResetCreditDate(credit.expiresAtUnixEpoch))
+						let target = resetCreditTargets[index]
+
+						Button {
+							tapResetCredit(target)
+						} label: {
+							resetCreditChip(
+								formatResetCreditDate(credit.expiresAtUnixEpoch),
+								target: target
+							)
+						}
+							.buttonStyle(.plain)
 							.modifier(
 								AccountRunChipPlacementReporter(
 									runID: "reset-\(index)",
 									placementStore: placementStore
 								)
 							)
-							.help(resetCreditHelp(credit))
+							.disabled(confirmation.isBusy)
+							.accessibilityLabel(resetCreditAccessibilityLabel(credit, target: target))
+							.accessibilityHint(resetCreditAccessibilityHint(target))
+							.help(resetCreditHelp(credit, target: target))
 					}
 				}
 				.padding(.trailing, 1)
@@ -151,15 +182,38 @@ struct AccountResetCreditExpiryStripView: View {
 		.frame(maxWidth: .infinity, alignment: .leading)
 		.onAppear {
 			placementStore.retainOnly(resetCreditIDs)
+			confirmation.retainOnly(Set(resetCreditTargets))
+		}
+		.onDisappear {
+			confirmation.cancelPendingConfirmation()
+			confirmationSecondsRemaining = 0
 		}
 		.onChange(of: resetCreditIDs) { _, ids in
 			placementStore.retainOnly(ids)
 		}
+		.onChange(of: resetCreditTargets) { _, targets in
+			confirmation.retainOnly(Set(targets))
+		}
+		.task(id: confirmationCountdownAttempt) {
+			await runConfirmationCountdown(for: confirmationCountdownAttempt)
+		}
 		.animation(PanelMotion.inlineLayout, value: showsEdgeControls)
+	}
+
+	private var resetCreditTargets: [ResetCreditUseTarget] {
+		ResetCreditUseTarget.makeTargets(
+			accountID: account.accountFingerprint,
+			reportedAvailableCount: account.resetCreditsAvailableCount,
+			credits: account.availableResetCredits
+		)
 	}
 
 	private var resetCreditIDs: Set<String> {
 		Set(account.availableResetCredits.indices.map { "reset-\($0)" })
+	}
+
+	private var confirmationCountdownAttempt: ResetCreditUseAttempt? {
+		confirmation.isSubmitting ? nil : confirmation.armedAttempt
 	}
 
 	private func edgeButton(_ direction: AccountRunStripScrollDirection) -> some View {
@@ -181,24 +235,191 @@ struct AccountResetCreditExpiryStripView: View {
 		}
 	}
 
-	private func resetCreditChip(_ text: String) -> some View {
-		Text(text)
+	private func resetCreditChip(
+		_ expiryText: String,
+		target: ResetCreditUseTarget
+	) -> some View {
+		Text(resetCreditChipText(expiryText, target: target))
 			.font(PanelFont.usageValue)
-			.foregroundStyle(PanelPalette.primaryText(colorScheme).opacity(0.88))
+			.foregroundStyle(resetCreditChipForeground(target))
 			.monospacedDigit()
 			.lineLimit(1)
 			.fixedSize(horizontal: true, vertical: false)
 			.padding(.horizontal, 4)
 			.padding(.vertical, 1)
-			.background(resetCreditChipBackground)
+			.background(resetCreditChipBackground(target))
+			.contentShape(Rectangle())
 	}
 
-	private var resetCreditChipBackground: some ShapeStyle {
-		PanelPalette.routeAccent(colorScheme).opacity(colorScheme == .dark ? 0.16 : 0.11)
+	private func resetCreditChipText(
+		_ expiryText: String,
+		target: ResetCreditUseTarget
+	) -> String {
+		if confirmation.isPreparing(target) {
+			return "Preparing"
+		}
+		if confirmation.isSubmitting(target) {
+			return "Using"
+		}
+		if confirmation.isArmed(target) {
+			let seconds = confirmationSecondsRemaining > 0
+				? confirmationSecondsRemaining
+				: Self.confirmationWindowSeconds
+			return "Confirm Use · \(seconds)s"
+		}
+
+		return expiryText
 	}
 
-	private func resetCreditHelp(_ credit: AccountResetCredit) -> String {
-		"Expires \(formatResetCreditDate(credit.expiresAtUnixEpoch))"
+	private func resetCreditChipForeground(_ target: ResetCreditUseTarget) -> Color {
+		if confirmation.isPreparing(target) || confirmation.isArmed(target) {
+			return PanelPalette.warning(colorScheme)
+		}
+
+		return PanelPalette.primaryText(colorScheme).opacity(0.88)
+	}
+
+	private func resetCreditChipBackground(_ target: ResetCreditUseTarget) -> Color {
+		if confirmation.isPreparing(target) || confirmation.isArmed(target) {
+			return PanelPalette.warning(colorScheme).opacity(colorScheme == .dark ? 0.2 : 0.14)
+		}
+
+		return PanelPalette.routeAccent(colorScheme).opacity(colorScheme == .dark ? 0.16 : 0.11)
+	}
+
+	private func resetCreditHelp(
+		_ credit: AccountResetCredit,
+		target: ResetCreditUseTarget
+	) -> String {
+		let expiry = formatResetCreditDate(credit.expiresAtUnixEpoch)
+		if confirmation.isPreparing {
+			return confirmation.isPreparing(target)
+				? "Preparing reset card that expires \(expiry)"
+				: "Wait until the current reset-card request finishes."
+		}
+		if confirmation.isSubmitting {
+			return confirmation.isSubmitting(target)
+				? "Using reset card that expires \(expiry)"
+				: "Wait until the current reset-card request finishes."
+		}
+		if confirmation.isArmed(target) {
+			return "Click again within \(Self.confirmationWindowSeconds) seconds to use the reset card that expires \(expiry). Otherwise, confirmation cancels automatically."
+		}
+
+		return "Expires \(expiry). Click once to prepare this reset card."
+	}
+
+	private func resetCreditAccessibilityLabel(
+		_ credit: AccountResetCredit,
+		target: ResetCreditUseTarget
+	) -> String {
+		let expiry = formatResetCreditDate(credit.expiresAtUnixEpoch)
+		if confirmation.isPreparing(target) {
+			return "Preparing reset card that expires \(expiry)"
+		}
+		if confirmation.isSubmitting(target) {
+			return "Using reset card that expires \(expiry)"
+		}
+		if confirmation.isArmed(target) {
+			let seconds = confirmationSecondsRemaining > 0
+				? confirmationSecondsRemaining
+				: Self.confirmationWindowSeconds
+			return "Confirm use of reset card that expires \(expiry), \(seconds) seconds remaining"
+		}
+
+		return "Reset card, expires \(expiry)"
+	}
+
+	private func resetCreditAccessibilityHint(_ target: ResetCreditUseTarget) -> String {
+		if confirmation.isPreparing {
+			return confirmation.isPreparing(target)
+				? "The reset card is being prepared for confirmation."
+				: "Wait until the current reset-card request finishes."
+		}
+		if confirmation.isSubmitting {
+			return confirmation.isSubmitting(target)
+				? "The reset-card request is in progress."
+				: "Wait until the current reset-card request finishes."
+		}
+
+		return confirmation.isArmed(target)
+			? "Activate again to use this reset card. Confirmation cancels automatically after \(Self.confirmationWindowSeconds) seconds."
+			: "Activate once to prepare this reset card."
+	}
+
+	@MainActor
+	private func runConfirmationCountdown(
+		for attempt: ResetCreditUseAttempt?
+	) async {
+		guard let attempt else {
+			confirmationSecondsRemaining = 0
+			return
+		}
+
+		let clock = ContinuousClock()
+		let deadline = clock.now.advanced(
+			by: .seconds(Self.confirmationWindowSeconds)
+		)
+		confirmationSecondsRemaining = Self.confirmationWindowSeconds
+
+		while clock.now < deadline {
+			let nextWake = min(
+				clock.now.advanced(by: .seconds(1)),
+				deadline
+			)
+			do {
+				try await clock.sleep(until: nextWake)
+			} catch {
+				return
+			}
+			guard Task.isCancelled == false,
+				confirmation.isArmed(attempt),
+				confirmation.isSubmitting == false
+			else {
+				return
+			}
+
+			confirmationSecondsRemaining = Self.roundedUpSeconds(
+				clock.now.duration(to: deadline)
+			)
+		}
+		guard Task.isCancelled == false,
+			confirmation.isArmed(attempt),
+			confirmation.isSubmitting == false
+		else {
+			return
+		}
+
+		confirmation.disarm(attempt)
+		confirmationSecondsRemaining = 0
+	}
+
+	private static func roundedUpSeconds(_ duration: Duration) -> Int {
+		let components = duration.components
+		guard components.seconds >= 0 else {
+			return 0
+		}
+
+		return Int(components.seconds) + (components.attoseconds > 0 ? 1 : 0)
+	}
+
+	private func tapResetCredit(_ target: ResetCreditUseTarget) {
+		guard let action = confirmation.tap(target) else {
+			return
+		}
+
+		switch action {
+		case .prepare(let preparation):
+			Task {
+				let creditID = await prepareResetCredit(preparation)
+				confirmation.finishPreparation(preparation, creditID: creditID)
+			}
+		case .consume(let attempt):
+			Task {
+				let resolved = await consumeResetCredit(attempt)
+				confirmation.finish(attempt, resolved: resolved)
+			}
+		}
 	}
 
 	private func updateScrollMetrics(_ metrics: AccountRunStripMetrics) {

--- a/apps/decodex-app/Sources/DecodexApp/AppBridgeRequest.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AppBridgeRequest.swift
@@ -31,8 +31,15 @@ struct AppBridgeRequest: Encodable, Sendable {
 
 	static let accountClear = AppBridgeRequest(operation: "account_clear", includeUsage: true)
 
-	static func accountUse(selector: String) -> AppBridgeRequest {
-		AppBridgeRequest(operation: "account_use", selector: selector)
+	static func accountUse(
+		selector: String,
+		authJsonPath: String? = nil
+	) -> AppBridgeRequest {
+		AppBridgeRequest(
+			operation: "account_use",
+			selector: selector,
+			authJsonPath: authJsonPath
+		)
 	}
 
 	static func accountSelect(selector: String) -> AppBridgeRequest {

--- a/apps/decodex-app/Sources/DecodexApp/CodexResetCreditBridge.swift
+++ b/apps/decodex-app/Sources/DecodexApp/CodexResetCreditBridge.swift
@@ -1,0 +1,560 @@
+import Darwin
+import Foundation
+
+enum ResetCreditConsumeOutcome: String, Decodable, Sendable {
+	case reset
+	case nothingToReset
+	case noCredit
+	case alreadyRedeemed
+}
+
+enum CodexResetCreditBridgeError: LocalizedError {
+	case launchFailed(String)
+	case requestFailed(Int, String)
+	case invalidResponse(String)
+	case responseTimedOut
+	case serverExited(Int32)
+	case accountHomeMismatch
+	case creditChanged
+
+	var errorDescription: String? {
+		switch self {
+		case .launchFailed(let message):
+			return "Could not start the Codex app server: \(message)"
+		case .requestFailed(let code, let message):
+			return "Codex app server request failed (\(code)): \(message)"
+		case .invalidResponse(let message):
+			return "Invalid Codex app server response: \(message)"
+		case .responseTimedOut:
+			return "The Codex app server did not respond in time."
+		case .serverExited(let status):
+			return "The Codex app server exited before it completed the reset request (status \(status))."
+		case .accountHomeMismatch:
+			return "The Codex app server did not use the isolated account session."
+		case .creditChanged:
+			return "The reset cards changed. Refresh and try again."
+		}
+	}
+}
+
+struct CodexResetCreditCredentials: Sendable {
+	let expectedEmail: String?
+}
+
+struct CodexResetCreditBridge: Sendable {
+	private let environment: [String: String]
+	private let responseTimeout: TimeInterval
+
+	init(
+		environment: [String: String] = ProcessInfo.processInfo.environment,
+		responseTimeout: TimeInterval = 20
+	) {
+		self.environment = environment
+		self.responseTimeout = responseTimeout
+	}
+
+	func prepare(
+		codexExecutableURL: URL,
+		codexHomeURL: URL,
+		credentials: CodexResetCreditCredentials,
+		preparation: ResetCreditUsePreparation
+	) async throws -> String {
+		try await Task.detached(priority: .userInitiated) {
+			try prepareSynchronously(
+				codexExecutableURL: codexExecutableURL,
+				codexHomeURL: codexHomeURL,
+				credentials: credentials,
+				preparation: preparation
+			)
+		}
+		.value
+	}
+
+	func consume(
+		codexExecutableURL: URL,
+		codexHomeURL: URL,
+		credentials: CodexResetCreditCredentials,
+		attempt: ResetCreditUseAttempt
+	) async throws -> ResetCreditConsumeOutcome {
+		try await Task.detached(priority: .userInitiated) {
+			try consumeSynchronously(
+				codexExecutableURL: codexExecutableURL,
+				codexHomeURL: codexHomeURL,
+				credentials: credentials,
+				attempt: attempt
+			)
+		}
+		.value
+	}
+
+	func resolveCreditID(
+		for target: ResetCreditUseTarget,
+		availableCount: Int,
+		in credits: [CodexRateLimitResetCredit]
+	) throws -> String {
+		guard target.detailsComplete, target.descriptorMultiplicity == 1 else {
+			throw CodexResetCreditBridgeError.creditChanged
+		}
+
+		let availableCredits = credits.filter { $0.status == "available" }
+		guard availableCount == availableCredits.count else {
+			throw CodexResetCreditBridgeError.creditChanged
+		}
+
+		let matchingCredits = availableCredits.filter { credit in
+			credit.status == "available"
+				&& credit.resetType == "codexRateLimits"
+				&& credit.grantedAt == target.descriptor.grantedAtUnixEpoch
+				&& credit.expiresAt == target.descriptor.expiresAtUnixEpoch
+		}
+		guard matchingCredits.count == 1 else {
+			throw CodexResetCreditBridgeError.creditChanged
+		}
+
+		let creditID = matchingCredits[0].id
+			.trimmingCharacters(in: .whitespacesAndNewlines)
+		guard creditID.isEmpty == false else {
+			throw CodexResetCreditBridgeError.invalidResponse(
+				"the selected reset card has no identifier"
+			)
+		}
+
+		return creditID
+	}
+
+	private func prepareSynchronously(
+		codexExecutableURL: URL,
+		codexHomeURL: URL,
+		credentials: CodexResetCreditCredentials,
+		preparation: ResetCreditUsePreparation
+	) throws -> String {
+		let session = try makeSession(
+			codexExecutableURL: codexExecutableURL,
+			codexHomeURL: codexHomeURL,
+			credentials: credentials
+		)
+		defer {
+			session.stop()
+		}
+
+		try bootstrap(
+			session: session,
+			codexHomeURL: codexHomeURL,
+			credentials: credentials
+		)
+		let rateLimits = try readRateLimits(session: session, requestID: 3)
+		guard let resetCredits = rateLimits.rateLimitResetCredits,
+			let credits = resetCredits.credits
+		else {
+			throw CodexResetCreditBridgeError.invalidResponse(
+				"reset-card details are unavailable"
+			)
+		}
+
+		return try resolveCreditID(
+			for: preparation.target,
+			availableCount: resetCredits.availableCount,
+			in: credits
+		)
+	}
+
+	private func consumeSynchronously(
+		codexExecutableURL: URL,
+		codexHomeURL: URL,
+		credentials: CodexResetCreditCredentials,
+		attempt: ResetCreditUseAttempt
+	) throws -> ResetCreditConsumeOutcome {
+		let session = try makeSession(
+			codexExecutableURL: codexExecutableURL,
+			codexHomeURL: codexHomeURL,
+			credentials: credentials
+		)
+		defer {
+			session.stop()
+		}
+
+		try bootstrap(
+			session: session,
+			codexHomeURL: codexHomeURL,
+			credentials: credentials
+		)
+		let creditID = attempt.creditID.trimmingCharacters(in: .whitespacesAndNewlines)
+		guard creditID.isEmpty == false else {
+			throw CodexResetCreditBridgeError.invalidResponse(
+				"the selected reset card has no identifier"
+			)
+		}
+
+		try session.sendRequest(
+			id: 3,
+			method: "account/rateLimitResetCredit/consume",
+			params: [
+				"creditId": creditID,
+				"idempotencyKey": attempt.idempotencyKey,
+			]
+		)
+		let response = try session.readResponse(
+			id: 3,
+			as: CodexConsumeResetCreditResponse.self
+		)
+
+		if response.outcome == .reset || response.outcome == .alreadyRedeemed {
+			_ = try readRateLimits(session: session, requestID: 4)
+		}
+
+		return response.outcome
+	}
+
+	private func makeSession(
+		codexExecutableURL: URL,
+		codexHomeURL: URL,
+		credentials: CodexResetCreditCredentials
+	) throws -> CodexAppServerSession {
+		try CodexAppServerSession(
+			executableURL: codexExecutableURL,
+			codexHomeURL: codexHomeURL,
+			environment: environment,
+			responseTimeout: responseTimeout
+		)
+	}
+
+	private func bootstrap(
+		session: CodexAppServerSession,
+		codexHomeURL: URL,
+		credentials: CodexResetCreditCredentials
+	) throws {
+		try session.sendRequest(
+			id: 1,
+			method: "initialize",
+			params: [
+				"clientInfo": [
+					"name": "decodex-app",
+					"version": "0.2.0",
+				],
+			]
+		)
+		let initialize = try session.readResponse(id: 1, as: CodexInitializeResponse.self)
+		guard pathsReferToSameLocation(initialize.codexHome, codexHomeURL.path) else {
+			throw CodexResetCreditBridgeError.accountHomeMismatch
+		}
+
+		try session.sendNotification(method: "initialized")
+		try session.sendRequest(
+			id: 2,
+			method: "account/read",
+			params: [
+				"refreshToken": false,
+			]
+		)
+		let account = try session.readResponse(id: 2, as: CodexAccountReadResponse.self)
+		guard account.account?.type == "chatgpt" else {
+			throw CodexResetCreditBridgeError.invalidResponse(
+				"the isolated account does not match the selected account"
+			)
+		}
+		if let expectedEmail = normalizedEmail(credentials.expectedEmail),
+			normalizedEmail(account.account?.email) != expectedEmail
+		{
+			throw CodexResetCreditBridgeError.invalidResponse(
+				"the isolated account does not match the selected account"
+			)
+		}
+	}
+
+	private func normalizedEmail(_ value: String?) -> String? {
+		guard let email = value?
+			.trimmingCharacters(in: .whitespacesAndNewlines)
+			.lowercased(),
+			email.isEmpty == false
+		else {
+			return nil
+		}
+
+		return email
+	}
+
+	private func readRateLimits(
+		session: CodexAppServerSession,
+		requestID: Int
+	) throws -> CodexRateLimitsResponse {
+		try session.sendRequest(
+			id: requestID,
+			method: "account/rateLimits/read"
+		)
+		return try session.readResponse(id: requestID, as: CodexRateLimitsResponse.self)
+	}
+
+	private func pathsReferToSameLocation(_ left: String, _ right: String) -> Bool {
+		URL(fileURLWithPath: left)
+			.standardizedFileURL
+			.resolvingSymlinksInPath()
+			== URL(fileURLWithPath: right)
+				.standardizedFileURL
+				.resolvingSymlinksInPath()
+	}
+}
+
+struct CodexRateLimitResetCredit: Decodable, Equatable, Sendable {
+	let id: String
+	let grantedAt: Int
+	let expiresAt: Int?
+	let resetType: String
+	let status: String
+}
+
+private struct CodexRateLimitResetCreditsSummary: Decodable {
+	let availableCount: Int
+	let credits: [CodexRateLimitResetCredit]?
+}
+
+private struct CodexRateLimitsResponse: Decodable {
+	let rateLimitResetCredits: CodexRateLimitResetCreditsSummary?
+}
+
+private struct CodexInitializeResponse: Decodable {
+	let codexHome: String
+}
+
+private struct CodexConsumeResetCreditResponse: Decodable {
+	let outcome: ResetCreditConsumeOutcome
+}
+
+private struct CodexAccountReadResponse: Decodable {
+	let account: Account?
+
+	struct Account: Decodable {
+		let type: String
+		let email: String?
+	}
+}
+
+private final class CodexAppServerSession {
+	private static let maximumBufferedOutputBytes = 1_048_576
+	private let process = Process()
+	private let inputPipe = Pipe()
+	private let outputPipe = Pipe()
+	private let responseTimeout: TimeInterval
+	private var bufferedOutput = Data()
+	private var didStop = false
+
+	init(
+		executableURL: URL,
+		codexHomeURL: URL,
+		environment: [String: String],
+		responseTimeout: TimeInterval
+	) throws {
+		self.responseTimeout = responseTimeout
+
+		var processEnvironment = environment
+		processEnvironment["CODEX_HOME"] = codexHomeURL.path
+		processEnvironment["CODEX_SQLITE_HOME"] = codexHomeURL.path
+		processEnvironment.removeValue(forKey: "CODEX_ACCESS_TOKEN")
+		processEnvironment.removeValue(forKey: "OPENAI_API_KEY")
+
+		process.executableURL = executableURL
+		process.arguments = [
+			"app-server",
+			"--stdio",
+			"-c",
+			"cli_auth_credentials_store=\"file\"",
+		]
+		process.environment = processEnvironment
+		process.currentDirectoryURL = codexHomeURL
+		process.standardInput = inputPipe
+		process.standardOutput = outputPipe
+		process.standardError = FileHandle.nullDevice
+
+		do {
+			try process.run()
+		} catch {
+			throw CodexResetCreditBridgeError.launchFailed(error.localizedDescription)
+		}
+	}
+
+	deinit {
+		stop()
+	}
+
+	func sendRequest(id: Int, method: String, params: Any) throws {
+		try send([
+			"jsonrpc": "2.0",
+			"id": id,
+			"method": method,
+			"params": params,
+		])
+	}
+
+	func sendRequest(id: Int, method: String) throws {
+		try send([
+			"jsonrpc": "2.0",
+			"id": id,
+			"method": method,
+		])
+	}
+
+	func sendNotification(method: String) throws {
+		try send([
+			"jsonrpc": "2.0",
+			"method": method,
+		])
+	}
+
+	func readResponse<Response: Decodable>(
+		id: Int,
+		as type: Response.Type
+	) throws -> Response {
+		let deadline = Date().addingTimeInterval(responseTimeout)
+
+		while true {
+			let message = try readMessage(deadline: deadline)
+			guard messageID(message["id"]) == id else {
+				if message["id"] != nil, let method = message["method"] as? String {
+					throw CodexResetCreditBridgeError.invalidResponse(
+						"unsupported server request \(method)"
+					)
+				}
+				continue
+			}
+
+			if let error = message["error"] as? [String: Any] {
+				let code = (error["code"] as? NSNumber)?.intValue ?? -1
+				let message = error["message"] as? String ?? "unknown error"
+				throw CodexResetCreditBridgeError.requestFailed(code, message)
+			}
+			guard let result = message["result"] else {
+				throw CodexResetCreditBridgeError.invalidResponse(
+					"request \(id) has no result"
+				)
+			}
+
+			do {
+				let data = try JSONSerialization.data(
+					withJSONObject: result,
+					options: [.fragmentsAllowed]
+				)
+				return try JSONDecoder().decode(type, from: data)
+			} catch let error as CodexResetCreditBridgeError {
+				throw error
+			} catch {
+				throw CodexResetCreditBridgeError.invalidResponse(
+					"request \(id) could not be decoded: \(error.localizedDescription)"
+				)
+			}
+		}
+	}
+
+	func stop() {
+		guard didStop == false else {
+			return
+		}
+		didStop = true
+
+		try? inputPipe.fileHandleForWriting.close()
+		guard process.isRunning else {
+			return
+		}
+
+		process.terminate()
+		let deadline = Date().addingTimeInterval(1)
+		while process.isRunning, Date() < deadline {
+			usleep(10_000)
+		}
+		if process.isRunning {
+			kill(process.processIdentifier, SIGKILL)
+		}
+		process.waitUntilExit()
+	}
+
+	private func send(_ message: [String: Any]) throws {
+		do {
+			var data = try JSONSerialization.data(withJSONObject: message)
+			data.append(0x0a)
+			try inputPipe.fileHandleForWriting.write(contentsOf: data)
+		} catch {
+			throw CodexResetCreditBridgeError.invalidResponse(
+				"could not write a request: \(error.localizedDescription)"
+			)
+		}
+	}
+
+	private func readMessage(deadline: Date) throws -> [String: Any] {
+		while true {
+			if let newlineIndex = bufferedOutput.firstIndex(of: 0x0a) {
+				let line = bufferedOutput[..<newlineIndex]
+				bufferedOutput.removeSubrange(...newlineIndex)
+				if line.isEmpty {
+					continue
+				}
+
+				do {
+					let object = try JSONSerialization.jsonObject(with: Data(line))
+					guard let message = object as? [String: Any] else {
+						throw CodexResetCreditBridgeError.invalidResponse(
+							"app-server output is not a JSON object"
+						)
+					}
+					return message
+				} catch let error as CodexResetCreditBridgeError {
+					throw error
+				} catch {
+					throw CodexResetCreditBridgeError.invalidResponse(
+						"app-server output is not valid JSON: \(error.localizedDescription)"
+					)
+				}
+			}
+
+			let remainingMilliseconds = Int32(
+				max(0, min(Double(Int32.max), ceil(deadline.timeIntervalSinceNow * 1_000)))
+			)
+			guard remainingMilliseconds > 0 else {
+				throw CodexResetCreditBridgeError.responseTimedOut
+			}
+
+			var descriptor = pollfd(
+				fd: outputPipe.fileHandleForReading.fileDescriptor,
+				events: Int16(POLLIN | POLLHUP),
+				revents: 0
+			)
+			let result = Darwin.poll(&descriptor, 1, remainingMilliseconds)
+			if result == 0 {
+				throw CodexResetCreditBridgeError.responseTimedOut
+			}
+			if result < 0 {
+				if errno == EINTR {
+					continue
+				}
+				throw CodexResetCreditBridgeError.invalidResponse(
+					"could not read app-server output"
+				)
+			}
+			if descriptor.revents & Int16(POLLERR | POLLNVAL) != 0 {
+				throw CodexResetCreditBridgeError.invalidResponse(
+					"the app-server output stream failed"
+				)
+			}
+
+			let data = outputPipe.fileHandleForReading.availableData
+			guard data.isEmpty == false else {
+				let status = process.isRunning ? -1 : process.terminationStatus
+				throw CodexResetCreditBridgeError.serverExited(status)
+			}
+			bufferedOutput.append(data)
+			guard bufferedOutput.count <= Self.maximumBufferedOutputBytes else {
+				throw CodexResetCreditBridgeError.invalidResponse(
+					"the app-server response is too large"
+				)
+			}
+		}
+	}
+
+	private func messageID(_ value: Any?) -> Int? {
+		if let number = value as? NSNumber {
+			return number.intValue
+		}
+		if let string = value as? String {
+			return Int(string)
+		}
+
+		return nil
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
@@ -28,6 +28,7 @@ enum PanelMotion {
 	static let inlineLayout = Animation.interactiveSpring(response: 0.2, dampingFraction: 0.9, blendDuration: 0.03)
 	static let panelLayout = Animation.interactiveSpring(response: 0.3, dampingFraction: 0.92, blendDuration: 0.05)
 	static let accountRemoval = Animation.interactiveSpring(response: 0.28, dampingFraction: 0.94, blendDuration: 0.04)
+	static let meterRefill = Animation.timingCurve(0.18, 0.82, 0.24, 1, duration: 0.72)
 }
 
 enum GlassSurfaceDepth {

--- a/apps/decodex-app/Sources/DecodexApp/ResetCreditUse.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCreditUse.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+struct ResetCreditDescriptor: Hashable, Sendable {
+	let grantedAtUnixEpoch: Int?
+	let expiresAtUnixEpoch: Int?
+
+	init(credit: AccountResetCredit) {
+		grantedAtUnixEpoch = credit.grantedAtUnixEpoch
+		expiresAtUnixEpoch = credit.expiresAtUnixEpoch
+	}
+}
+
+struct ResetCreditUseTarget: Hashable, Sendable {
+	let accountID: String
+	let descriptor: ResetCreditDescriptor
+	let occurrence: Int
+	let descriptorMultiplicity: Int
+	let detailsComplete: Bool
+
+	static func makeTargets(
+		accountID: String,
+		reportedAvailableCount: Int?,
+		credits: [AccountResetCredit]
+	) -> [ResetCreditUseTarget] {
+		let descriptors = credits.map(ResetCreditDescriptor.init)
+		let multiplicityByDescriptor = Dictionary(
+			grouping: descriptors,
+			by: { $0 }
+		)
+		.mapValues(\.count)
+		var occurrenceByDescriptor = [ResetCreditDescriptor: Int]()
+		let detailsComplete = reportedAvailableCount == credits.count
+
+		return descriptors.map { descriptor in
+			let occurrence = occurrenceByDescriptor[descriptor, default: 0]
+			occurrenceByDescriptor[descriptor] = occurrence + 1
+
+			return ResetCreditUseTarget(
+				accountID: accountID,
+				descriptor: descriptor,
+				occurrence: occurrence,
+				descriptorMultiplicity: multiplicityByDescriptor[descriptor, default: 0],
+				detailsComplete: detailsComplete
+			)
+		}
+	}
+}
+
+struct ResetCreditUsePreparation: Equatable, Sendable {
+	let target: ResetCreditUseTarget
+	let idempotencyKey: String
+}
+
+struct ResetCreditUseAttempt: Equatable, Sendable {
+	let target: ResetCreditUseTarget
+	let creditID: String
+	let idempotencyKey: String
+}
+
+enum ResetCreditUseAction: Equatable, Sendable {
+	case prepare(ResetCreditUsePreparation)
+	case consume(ResetCreditUseAttempt)
+}
+
+struct ResetCreditUseConfirmation: Equatable {
+	private(set) var pendingPreparation: ResetCreditUsePreparation?
+	private(set) var armedAttempt: ResetCreditUseAttempt?
+	private(set) var isPreparing = false
+	private(set) var isSubmitting = false
+
+	func isArmed(_ target: ResetCreditUseTarget) -> Bool {
+		armedAttempt?.target == target
+	}
+
+	func isArmed(_ attempt: ResetCreditUseAttempt) -> Bool {
+		armedAttempt == attempt
+	}
+
+	func isPreparing(_ target: ResetCreditUseTarget) -> Bool {
+		isPreparing && pendingPreparation?.target == target
+	}
+
+	func isSubmitting(_ target: ResetCreditUseTarget) -> Bool {
+		isSubmitting && isArmed(target)
+	}
+
+	var isBusy: Bool {
+		isPreparing || isSubmitting
+	}
+
+	mutating func tap(
+		_ target: ResetCreditUseTarget,
+		makeIdempotencyKey: () -> String = { UUID().uuidString }
+	) -> ResetCreditUseAction? {
+		guard isBusy == false else {
+			return nil
+		}
+
+		if let armedAttempt, armedAttempt.target == target {
+			isSubmitting = true
+			return .consume(armedAttempt)
+		}
+
+		let preparation = ResetCreditUsePreparation(
+			target: target,
+			idempotencyKey: makeIdempotencyKey()
+		)
+		pendingPreparation = preparation
+		armedAttempt = nil
+		isPreparing = true
+
+		return .prepare(preparation)
+	}
+
+	@discardableResult
+	mutating func finishPreparation(
+		_ preparation: ResetCreditUsePreparation,
+		creditID: String?
+	) -> ResetCreditUseAttempt? {
+		guard pendingPreparation == preparation else {
+			return nil
+		}
+
+		pendingPreparation = nil
+		isPreparing = false
+
+		guard let creditID = creditID?
+			.trimmingCharacters(in: .whitespacesAndNewlines),
+			creditID.isEmpty == false
+		else {
+			return nil
+		}
+
+		let attempt = ResetCreditUseAttempt(
+			target: preparation.target,
+			creditID: creditID,
+			idempotencyKey: preparation.idempotencyKey
+		)
+		armedAttempt = attempt
+		return attempt
+	}
+
+	mutating func finish(_ attempt: ResetCreditUseAttempt, resolved: Bool) {
+		guard armedAttempt == attempt else {
+			return
+		}
+
+		isSubmitting = false
+		if resolved {
+			armedAttempt = nil
+		}
+	}
+
+	@discardableResult
+	mutating func disarm(_ attempt: ResetCreditUseAttempt) -> Bool {
+		guard isSubmitting == false, armedAttempt == attempt else {
+			return false
+		}
+
+		armedAttempt = nil
+		return true
+	}
+
+	mutating func cancelPendingConfirmation() {
+		guard isSubmitting == false else {
+			return
+		}
+
+		pendingPreparation = nil
+		armedAttempt = nil
+		isPreparing = false
+	}
+
+	mutating func retainOnly(_ targets: Set<ResetCreditUseTarget>) {
+		if let armedAttempt, targets.contains(armedAttempt.target) == false {
+			self.armedAttempt = nil
+			isSubmitting = false
+		}
+
+		if let pendingPreparation,
+			targets.contains(pendingPreparation.target) == false
+		{
+			self.pendingPreparation = nil
+			isPreparing = false
+		}
+	}
+}

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountUsageMeterPresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountUsageMeterPresentationTests.swift
@@ -1,0 +1,62 @@
+@testable import DecodexApp
+import Foundation
+import XCTest
+
+final class AccountUsageMeterPresentationTests: XCTestCase {
+	@MainActor
+	func testProgressIsClampedToTheMeterRange() {
+		XCTAssertEqual(AccountUsageMeterView.normalizedProgress(for: nil), 0)
+		XCTAssertEqual(AccountUsageMeterView.normalizedProgress(for: -1), 0)
+		XCTAssertEqual(AccountUsageMeterView.normalizedProgress(for: 24), 0.24)
+		XCTAssertEqual(AccountUsageMeterView.normalizedProgress(for: 100), 1)
+		XCTAssertEqual(AccountUsageMeterView.normalizedProgress(for: 101), 1)
+	}
+
+	@MainActor
+	func testOnlyAnExplicitResetCardEventStartsTheRefillAnimation() {
+		let refill = AccountUsageMeterRefillAnimation(
+			eventID: UUID(),
+			fromPercent: 24
+		)
+
+		XCTAssertTrue(AccountUsageMeterView.shouldAnimateRefill(refill, to: 100))
+		XCTAssertTrue(AccountUsageMeterView.shouldAnimateRefill(refill, to: 101))
+		XCTAssertFalse(AccountUsageMeterView.shouldAnimateRefill(nil, to: 100))
+		XCTAssertFalse(AccountUsageMeterView.shouldAnimateRefill(refill, to: 99))
+	}
+
+	func testResetCardEventTargetsOnlyMetersThatActuallyReachedFull() {
+		let eventID = UUID()
+		let refill = AccountUsageRefillAnimation(
+			id: eventID,
+			accountID: "account-a",
+			primaryFromPercent: 24,
+			secondaryFromPercent: 100
+		)
+
+		XCTAssertEqual(
+			refill.meterAnimation(for: .primary, currentPercent: 100),
+			AccountUsageMeterRefillAnimation(eventID: eventID, fromPercent: 24)
+		)
+		XCTAssertNil(refill.meterAnimation(for: .primary, currentPercent: 99))
+		XCTAssertNil(refill.meterAnimation(for: .secondary, currentPercent: 100))
+	}
+
+	@MainActor
+	func testRefillEventSurvivesSuccessfulRefreshAndClearsAfterFailure() {
+		let store = AccountStore()
+		let refill = AccountUsageRefillAnimation(
+			accountID: "account-a",
+			primaryFromPercent: 24,
+			secondaryFromPercent: nil
+		)
+
+		store.beginUsageRefillAnimation(refill)
+		store.finishUsageRefillAnimation(refill, refreshSucceeded: true)
+		XCTAssertEqual(store.usageRefillAnimations["account-a"], refill)
+
+		store.finishUsageRefillAnimation(refill, refreshSucceeded: false)
+		XCTAssertNil(store.usageRefillAnimations["account-a"])
+		store.cancelUsageRefillAnimation(for: "account-a")
+	}
+}

--- a/apps/decodex-app/Tests/DecodexAppTests/CodexResetCreditBridgeTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/CodexResetCreditBridgeTests.swift
@@ -1,0 +1,338 @@
+@testable import DecodexApp
+import Foundation
+import XCTest
+
+final class CodexResetCreditBridgeTests: XCTestCase {
+	func testResolveCreditIDUsesTheUniqueCompleteCurrentCredit() throws {
+		let credits = [
+			makeCredit(id: "credit-a", grantedAt: 100, expiresAt: 300),
+			makeCredit(id: "credit-b", grantedAt: 100, expiresAt: 200),
+		]
+		let target = makeTarget()
+
+		XCTAssertEqual(
+			try CodexResetCreditBridge().resolveCreditID(
+				for: target,
+				availableCount: 2,
+				in: credits
+			),
+			"credit-b"
+		)
+	}
+
+	func testResolveCreditIDRejectsAChangedCardList() {
+		XCTAssertThrowsError(
+			try CodexResetCreditBridge().resolveCreditID(
+				for: makeTarget(),
+				availableCount: 1,
+				in: [makeCredit(id: "other", grantedAt: 100, expiresAt: 300)]
+			)
+		) { error in
+			XCTAssertEqual(
+				error.localizedDescription,
+				"The reset cards changed. Refresh and try again."
+			)
+		}
+	}
+
+	func testResolveCreditIDRejectsAnOriginallyAmbiguousDescriptor() {
+		XCTAssertThrowsError(
+			try CodexResetCreditBridge().resolveCreditID(
+				for: makeTarget(descriptorMultiplicity: 2),
+				availableCount: 1,
+				in: [makeCredit(id: "credit-b", grantedAt: 100, expiresAt: 200)]
+			)
+		)
+	}
+
+	func testResolveCreditIDRejectsANewDuplicateDescriptor() {
+		XCTAssertThrowsError(
+			try CodexResetCreditBridge().resolveCreditID(
+				for: makeTarget(),
+				availableCount: 2,
+				in: [
+					makeCredit(id: "credit-a", grantedAt: 100, expiresAt: 200),
+					makeCredit(id: "credit-b", grantedAt: 100, expiresAt: 200),
+				]
+			)
+		)
+	}
+
+	func testResolveCreditIDRejectsIncompletePresentedDetails() {
+		XCTAssertThrowsError(
+			try CodexResetCreditBridge().resolveCreditID(
+				for: makeTarget(detailsComplete: false),
+				availableCount: 1,
+				in: [makeCredit(id: "credit-b", grantedAt: 100, expiresAt: 200)]
+			)
+		)
+	}
+
+	func testResolveCreditIDRejectsIncompleteFreshDetails() {
+		XCTAssertThrowsError(
+			try CodexResetCreditBridge().resolveCreditID(
+				for: makeTarget(),
+				availableCount: 2,
+				in: [makeCredit(id: "credit-b", grantedAt: 100, expiresAt: 200)]
+			)
+		)
+	}
+
+	func testResolveCreditIDRejectsAnUnsupportedResetType() {
+		XCTAssertThrowsError(
+			try CodexResetCreditBridge().resolveCreditID(
+				for: makeTarget(),
+				availableCount: 1,
+				in: [
+					makeCredit(
+						id: "credit-b",
+						grantedAt: 100,
+						expiresAt: 200,
+						resetType: "unknown"
+					),
+				]
+			)
+		)
+	}
+
+	func testPreparationArmsTheExactCurrentCreditThroughExternalAuth() async throws {
+		let fixture = try makeFixture(
+			scriptBody: """
+			IFS= read -r line || exit 10
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '{"jsonrpc":"2.0","id":1,"result":{"codexHome":"%s","platformFamily":"unix","platformOs":"macos","userAgent":"fake"}}\\n' "$CODEX_HOME"
+			IFS= read -r line || exit 11
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			IFS= read -r line || exit 12
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":2,"result":{"account":{"type":"chatgpt","email":"copy@example.com","planType":"pro"},"requiresOpenaiAuth":true}}'
+			IFS= read -r line || exit 13
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":3,"result":{"rateLimits":{},"rateLimitResetCredits":{"availableCount":2,"credits":[{"id":"credit-a","grantedAt":100,"expiresAt":300,"resetType":"codexRateLimits","status":"available"},{"id":"credit-b","grantedAt":100,"expiresAt":200,"resetType":"codexRateLimits","status":"available"}]}}}'
+			"""
+		)
+		defer { fixture.remove() }
+
+		let preparation = ResetCreditUsePreparation(
+			target: makeTarget(),
+			idempotencyKey: "attempt-1"
+		)
+		let creditID = try await CodexResetCreditBridge(responseTimeout: 2).prepare(
+			codexExecutableURL: fixture.executableURL,
+			codexHomeURL: fixture.codexHomeURL,
+			credentials: credentials,
+			preparation: preparation
+		)
+
+		XCTAssertEqual(creditID, "credit-b")
+		let messages = try readMessages(from: fixture.logURL)
+		XCTAssertEqual(messages.count, 4)
+		try assertBootstrap(messages)
+		XCTAssertEqual(messages[3]["method"] as? String, "account/rateLimits/read")
+		XCTAssertNil(messages[3]["params"])
+	}
+
+	func testPreparationAcceptsAnEmailLessBoundAccount() async throws {
+		let fixture = try makeFixture(
+			scriptBody: """
+			IFS= read -r line || exit 10
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '{"jsonrpc":"2.0","id":1,"result":{"codexHome":"%s","platformFamily":"unix","platformOs":"macos","userAgent":"fake"}}\\n' "$CODEX_HOME"
+			IFS= read -r line || exit 11
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			IFS= read -r line || exit 12
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":2,"result":{"account":{"type":"chatgpt","email":null,"planType":"pro"},"requiresOpenaiAuth":true}}'
+			IFS= read -r line || exit 13
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":3,"result":{"rateLimits":{},"rateLimitResetCredits":{"availableCount":1,"credits":[{"id":"credit-b","grantedAt":100,"expiresAt":200,"resetType":"codexRateLimits","status":"available"}]}}}'
+			"""
+		)
+		defer { fixture.remove() }
+
+		let creditID = try await CodexResetCreditBridge(responseTimeout: 2).prepare(
+			codexExecutableURL: fixture.executableURL,
+			codexHomeURL: fixture.codexHomeURL,
+			credentials: CodexResetCreditCredentials(expectedEmail: nil),
+			preparation: ResetCreditUsePreparation(
+				target: makeTarget(),
+				idempotencyKey: "attempt-1"
+			)
+		)
+
+		XCTAssertEqual(creditID, "credit-b")
+	}
+
+	func testConsumeReusesTheArmedCreditIDWithoutOrdinalRemapping() async throws {
+		let fixture = try makeFixture(
+			scriptBody: """
+			IFS= read -r line || exit 10
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '{"jsonrpc":"2.0","id":1,"result":{"codexHome":"%s","platformFamily":"unix","platformOs":"macos","userAgent":"fake"}}\\n' "$CODEX_HOME"
+			IFS= read -r line || exit 11
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			IFS= read -r line || exit 12
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":2,"result":{"account":{"type":"chatgpt","email":"copy@example.com","planType":"pro"},"requiresOpenaiAuth":true}}'
+			IFS= read -r line || exit 13
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":3,"result":{"outcome":"reset"}}'
+			IFS= read -r line || exit 14
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":4,"result":{"rateLimits":{},"rateLimitResetCredits":{"availableCount":1,"credits":[]}}}'
+			"""
+		)
+		defer { fixture.remove() }
+
+		let attempt = ResetCreditUseAttempt(
+			target: makeTarget(),
+			creditID: "credit-b",
+			idempotencyKey: "attempt-1"
+		)
+		let outcome = try await CodexResetCreditBridge(responseTimeout: 2).consume(
+			codexExecutableURL: fixture.executableURL,
+			codexHomeURL: fixture.codexHomeURL,
+			credentials: credentials,
+			attempt: attempt
+		)
+
+		XCTAssertEqual(outcome, .reset)
+		let messages = try readMessages(from: fixture.logURL)
+		XCTAssertEqual(messages.count, 5)
+		try assertBootstrap(messages)
+
+		let consume = messages[3]
+		XCTAssertEqual(
+			consume["method"] as? String,
+			"account/rateLimitResetCredit/consume"
+		)
+		let params = try XCTUnwrap(consume["params"] as? [String: Any])
+		XCTAssertEqual(params["creditId"] as? String, "credit-b")
+		XCTAssertEqual(params["idempotencyKey"] as? String, "attempt-1")
+		XCTAssertEqual(messages[4]["method"] as? String, "account/rateLimits/read")
+	}
+
+	private var credentials: CodexResetCreditCredentials {
+		CodexResetCreditCredentials(expectedEmail: "copy@example.com")
+	}
+
+	private func assertBootstrap(
+		_ messages: [[String: Any]],
+		file: StaticString = #filePath,
+		line: UInt = #line
+	) throws {
+		XCTAssertEqual(
+			Set(messages.compactMap { $0["jsonrpc"] as? String }),
+			["2.0"],
+			file: file,
+			line: line
+		)
+		XCTAssertEqual(messages[0]["method"] as? String, "initialize", file: file, line: line)
+		XCTAssertEqual(messages[1]["method"] as? String, "initialized", file: file, line: line)
+		XCTAssertNil(messages[1]["params"], file: file, line: line)
+		XCTAssertEqual(messages[2]["method"] as? String, "account/read", file: file, line: line)
+		let accountRead = try XCTUnwrap(
+			messages[2]["params"] as? [String: Any],
+			file: file,
+			line: line
+		)
+		XCTAssertEqual(accountRead["refreshToken"] as? Bool, false, file: file, line: line)
+		XCTAssertFalse(
+			messages.contains { message in String(describing: message).contains("access-token") },
+			file: file,
+			line: line
+		)
+	}
+
+	private func makeTarget(
+		occurrence: Int = 0,
+		descriptorMultiplicity: Int = 1,
+		detailsComplete: Bool = true
+	) -> ResetCreditUseTarget {
+		ResetCreditUseTarget(
+			accountID: "account-a",
+			descriptor: ResetCreditDescriptor(
+				credit: AccountResetCredit(
+					grantedAtUnixEpoch: 100,
+					expiresAtUnixEpoch: 200,
+					status: "available"
+				)
+			),
+			occurrence: occurrence,
+			descriptorMultiplicity: descriptorMultiplicity,
+			detailsComplete: detailsComplete
+		)
+	}
+
+	private func makeCredit(
+		id: String,
+		grantedAt: Int,
+		expiresAt: Int,
+		resetType: String = "codexRateLimits"
+	) -> CodexRateLimitResetCredit {
+		CodexRateLimitResetCredit(
+			id: id,
+			grantedAt: grantedAt,
+			expiresAt: expiresAt,
+			resetType: resetType,
+			status: "available"
+		)
+	}
+
+	private func makeFixture(scriptBody: String) throws -> AppServerFixture {
+		let directoryURL = FileManager.default.temporaryDirectory
+			.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		let codexHomeURL = directoryURL.appendingPathComponent("codex-home", isDirectory: true)
+		let executableURL = directoryURL.appendingPathComponent("fake-codex")
+		let logURL = directoryURL.appendingPathComponent("requests.jsonl")
+		try FileManager.default.createDirectory(
+			at: codexHomeURL,
+			withIntermediateDirectories: true
+		)
+
+		let script = """
+		#!/bin/sh
+		[ -z "$CODEX_ACCESS_TOKEN" ] || exit 9
+		[ -z "$OPENAI_API_KEY" ] || exit 8
+		[ "$1" = "app-server" ] || exit 7
+		[ "$2" = "--stdio" ] || exit 6
+		[ "$3" = "-c" ] || exit 5
+		[ "$4" = 'cli_auth_credentials_store="file"' ] || exit 4
+		\(scriptBody.replacingOccurrences(of: "__LOG_PATH__", with: logURL.path))
+		"""
+		try script.write(to: executableURL, atomically: true, encoding: .utf8)
+		try FileManager.default.setAttributes(
+			[.posixPermissions: 0o700],
+			ofItemAtPath: executableURL.path
+		)
+
+		return AppServerFixture(
+			directoryURL: directoryURL,
+			codexHomeURL: codexHomeURL,
+			executableURL: executableURL,
+			logURL: logURL
+		)
+	}
+
+	private func readMessages(from url: URL) throws -> [[String: Any]] {
+		try String(contentsOf: url, encoding: .utf8)
+			.split(separator: "\n")
+			.map { line in
+				let data = Data(line.utf8)
+				return try XCTUnwrap(
+					JSONSerialization.jsonObject(with: data) as? [String: Any]
+				)
+			}
+	}
+}
+
+private struct AppServerFixture {
+	let directoryURL: URL
+	let codexHomeURL: URL
+	let executableURL: URL
+	let logURL: URL
+
+	func remove() {
+		try? FileManager.default.removeItem(at: directoryURL)
+	}
+}

--- a/apps/decodex-app/Tests/DecodexAppTests/DecodexAppBridgeTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/DecodexAppBridgeTests.swift
@@ -140,4 +140,19 @@ final class DecodexAppBridgeTests: XCTestCase {
 		XCTAssertEqual(payload["codex_bin"] as? String, codexBin)
 		XCTAssertEqual(payload["include_usage"] as? Bool, true)
 	}
+
+	func testAccountUseRequestEncodesAnIsolatedAuthPath() throws {
+		let authPath = "/tmp/decodex-reset-credit/auth.json"
+		let data = try JSONEncoder().encode(
+			AppBridgeRequest.accountUse(
+				selector: "copy@example.com",
+				authJsonPath: authPath
+			)
+		)
+		let payload = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+		XCTAssertEqual(payload["operation"] as? String, "account_use")
+		XCTAssertEqual(payload["selector"] as? String, "copy@example.com")
+		XCTAssertEqual(payload["auth_json_path"] as? String, authPath)
+	}
 }

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCreditAuthStagingTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCreditAuthStagingTests.swift
@@ -1,0 +1,140 @@
+@testable import DecodexApp
+import Foundation
+import XCTest
+
+final class ResetCreditAuthStagingTests: XCTestCase {
+	func testStagingKeepsSelectedAccountAndExcludesManagedRefreshToken() throws {
+		let auth = ResetCreditStoredAuth(
+			email: nil,
+			authMode: "chatgpt",
+			lastRefresh: "2026-07-24T12:00:00Z",
+			tokens: ResetCreditStoredAuth.Tokens(
+				email: nil,
+				idToken: "selected-id-token",
+				accessToken: "selected-access-token",
+				refreshToken: "managed-refresh-secret",
+				accountID: "selected-account-id"
+			)
+		)
+
+		let data = try auth.stagedData(refreshToken: "disabled-refresh-placeholder")
+		let object = try XCTUnwrap(
+			JSONSerialization.jsonObject(with: data) as? [String: Any]
+		)
+		let tokens = try XCTUnwrap(object["tokens"] as? [String: Any])
+
+		XCTAssertEqual(object["auth_mode"] as? String, "chatgpt")
+		XCTAssertEqual(object["last_refresh"] as? String, "2026-07-24T12:00:00Z")
+		XCTAssertEqual(tokens["id_token"] as? String, "selected-id-token")
+		XCTAssertEqual(tokens["access_token"] as? String, "selected-access-token")
+		XCTAssertEqual(tokens["account_id"] as? String, "selected-account-id")
+		XCTAssertEqual(tokens["refresh_token"] as? String, "disabled-refresh-placeholder")
+		XCTAssertFalse(String(decoding: data, as: UTF8.self).contains("managed-refresh-secret"))
+	}
+
+	@MainActor
+	func testFreshAccountBindingRejectsAnAmbiguousEmailLessFingerprint() throws {
+		let target = try makeAccount(
+			fingerprint: "...123456",
+			email: nil,
+			selector: "...123456"
+		)
+		let store = AccountStore()
+		store.accountList = makeAccountList([
+			target,
+			try makeAccount(
+				fingerprint: "...123456",
+				email: "other@example.com",
+				selector: "other@example.com"
+			),
+		])
+
+		XCTAssertThrowsError(try store.uniqueFreshResetCreditAccount(matching: target)) { error in
+			XCTAssertEqual(
+				error.localizedDescription,
+				"More than one stored account matches this reset card. Remove the duplicate account and try again."
+			)
+		}
+	}
+
+	@MainActor
+	func testFreshAccountBindingAllowsAUniqueEmailLessFingerprint() throws {
+		let target = try makeAccount(
+			fingerprint: "...123456",
+			email: nil,
+			selector: "...123456"
+		)
+		let store = AccountStore()
+		store.accountList = makeAccountList([target])
+
+		XCTAssertEqual(
+			try store.uniqueFreshResetCreditAccount(matching: target),
+			target
+		)
+	}
+
+	@MainActor
+	func testFreshAccountBindingUsesNormalizedEmailWithTheFingerprint() throws {
+		let target = try makeAccount(
+			fingerprint: "...123456",
+			email: " COPY@example.com ",
+			selector: " COPY@example.com "
+		)
+		let expected = try makeAccount(
+			fingerprint: "...123456",
+			email: "copy@EXAMPLE.com",
+			selector: "copy@EXAMPLE.com"
+		)
+		let store = AccountStore()
+		store.accountList = makeAccountList([
+			expected,
+			try makeAccount(
+				fingerprint: "...123456",
+				email: "other@example.com",
+				selector: "other@example.com"
+			),
+		])
+
+		XCTAssertEqual(
+			try store.uniqueFreshResetCreditAccount(matching: target),
+			expected
+		)
+	}
+
+	@MainActor
+	func testFreshAccountBindingRejectsAMissingAccount() throws {
+		let target = try makeAccount(
+			fingerprint: "...123456",
+			email: nil,
+			selector: "...123456"
+		)
+		let store = AccountStore()
+		store.accountList = makeAccountList([])
+
+		XCTAssertThrowsError(try store.uniqueFreshResetCreditAccount(matching: target)) { error in
+			XCTAssertEqual(
+				error.localizedDescription,
+				"The account changed. Refresh and try again."
+			)
+		}
+	}
+
+	private func makeAccount(
+		fingerprint: String,
+		email: String?,
+		selector: String
+	) throws -> CodexAccount {
+		let data = try JSONSerialization.data(withJSONObject: [
+			"account_fingerprint": fingerprint,
+			"email": email.map { $0 as Any } ?? NSNull(),
+			"selector": selector,
+			"status": "available",
+			"selected": false,
+			"codex_active": false,
+			"disabled": false,
+			"refresh_token_present": true,
+		])
+
+		return try JSONDecoder().decode(CodexAccount.self, from: data)
+	}
+}

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCreditUseConfirmationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCreditUseConfirmationTests.swift
@@ -1,0 +1,208 @@
+@testable import DecodexApp
+import XCTest
+
+final class ResetCreditUseConfirmationTests: XCTestCase {
+	func testFirstTapPreparesAndSecondTapConsumesTheExactArmedCredit() throws {
+		let target = makeTarget(accountID: "account-a", expiresAt: 200)
+		var confirmation = ResetCreditUseConfirmation()
+
+		let preparation = try unwrapPreparation(
+			confirmation.tap(target, makeIdempotencyKey: { "attempt-1" })
+		)
+		XCTAssertTrue(confirmation.isPreparing(target))
+		XCTAssertFalse(confirmation.isArmed(target))
+
+		confirmation.finishPreparation(preparation, creditID: "credit-1")
+		XCTAssertFalse(confirmation.isPreparing(target))
+		XCTAssertTrue(confirmation.isArmed(target))
+
+		let attempt = try unwrapAttempt(
+			confirmation.tap(target, makeIdempotencyKey: { "unexpected-key" })
+		)
+		XCTAssertEqual(attempt.creditID, "credit-1")
+		XCTAssertEqual(attempt.idempotencyKey, "attempt-1")
+		XCTAssertTrue(confirmation.isSubmitting(target))
+	}
+
+	func testFailedPreparationDisarmsTheCard() throws {
+		let target = makeTarget(accountID: "account-a", expiresAt: 200)
+		var confirmation = ResetCreditUseConfirmation()
+
+		let preparation = try unwrapPreparation(confirmation.tap(target))
+		confirmation.finishPreparation(preparation, creditID: nil)
+
+		XCTAssertFalse(confirmation.isPreparing(target))
+		XCTAssertFalse(confirmation.isArmed(target))
+		XCTAssertFalse(confirmation.isBusy)
+	}
+
+	func testUnresolvedConsumeRetainsExactCreditAndIdempotencyKey() throws {
+		let target = makeTarget(accountID: "account-a", expiresAt: 200)
+		var confirmation = ResetCreditUseConfirmation()
+		let preparation = try unwrapPreparation(
+			confirmation.tap(target, makeIdempotencyKey: { "attempt-1" })
+		)
+		confirmation.finishPreparation(preparation, creditID: "credit-1")
+
+		let firstAttempt = try unwrapAttempt(confirmation.tap(target))
+		confirmation.finish(firstAttempt, resolved: false)
+		let retry = try unwrapAttempt(confirmation.tap(target))
+
+		XCTAssertEqual(retry.creditID, "credit-1")
+		XCTAssertEqual(retry.idempotencyKey, "attempt-1")
+	}
+
+	func testResolvedAttemptDisarmsTheCard() throws {
+		let target = makeTarget(accountID: "account-a", expiresAt: 200)
+		var confirmation = ResetCreditUseConfirmation()
+		let preparation = try unwrapPreparation(confirmation.tap(target))
+		confirmation.finishPreparation(preparation, creditID: "credit-1")
+
+		let attempt = try unwrapAttempt(confirmation.tap(target))
+		confirmation.finish(attempt, resolved: true)
+
+		XCTAssertFalse(confirmation.isArmed(target))
+		XCTAssertFalse(confirmation.isSubmitting(target))
+	}
+
+	func testConfirmationWindowCanDisarmTheExactAttempt() throws {
+		let target = makeTarget(accountID: "account-a", expiresAt: 200)
+		var confirmation = ResetCreditUseConfirmation()
+		let preparation = try unwrapPreparation(confirmation.tap(target))
+		let attempt = try XCTUnwrap(
+			confirmation.finishPreparation(preparation, creditID: "credit-1")
+		)
+
+		XCTAssertTrue(confirmation.disarm(attempt))
+		XCTAssertFalse(confirmation.isArmed(target))
+	}
+
+	func testStaleConfirmationWindowCannotDisarmANewerAttempt() throws {
+		let first = makeTarget(accountID: "account-a", expiresAt: 200)
+		let second = makeTarget(accountID: "account-a", expiresAt: 300)
+		var confirmation = ResetCreditUseConfirmation()
+		let firstPreparation = try unwrapPreparation(confirmation.tap(first))
+		let staleAttempt = try XCTUnwrap(
+			confirmation.finishPreparation(firstPreparation, creditID: "credit-1")
+		)
+		let secondPreparation = try unwrapPreparation(confirmation.tap(second))
+		let currentAttempt = try XCTUnwrap(
+			confirmation.finishPreparation(secondPreparation, creditID: "credit-2")
+		)
+
+		XCTAssertFalse(confirmation.disarm(staleAttempt))
+		XCTAssertTrue(confirmation.isArmed(currentAttempt))
+	}
+
+	func testClosingThePanelCancelsPreparationAndPreventsLateArming() throws {
+		let target = makeTarget(accountID: "account-a", expiresAt: 200)
+		var confirmation = ResetCreditUseConfirmation()
+		let preparation = try unwrapPreparation(confirmation.tap(target))
+
+		confirmation.cancelPendingConfirmation()
+		let attempt = confirmation.finishPreparation(preparation, creditID: "credit-1")
+
+		XCTAssertNil(attempt)
+		XCTAssertFalse(confirmation.isPreparing(target))
+		XCTAssertFalse(confirmation.isArmed(target))
+	}
+
+	func testTappingAnotherCardStartsASeparatePreparation() throws {
+		let first = makeTarget(accountID: "account-a", expiresAt: 200)
+		let second = makeTarget(accountID: "account-a", expiresAt: 300)
+		var confirmation = ResetCreditUseConfirmation()
+		let firstPreparation = try unwrapPreparation(
+			confirmation.tap(first, makeIdempotencyKey: { "attempt-1" })
+		)
+		confirmation.finishPreparation(firstPreparation, creditID: "credit-1")
+
+		let secondPreparation = try unwrapPreparation(
+			confirmation.tap(second, makeIdempotencyKey: { "attempt-2" })
+		)
+
+		XCTAssertFalse(confirmation.isArmed(first))
+		XCTAssertTrue(confirmation.isPreparing(second))
+		XCTAssertEqual(secondPreparation.idempotencyKey, "attempt-2")
+	}
+
+	func testRemovedCardClearsPreparationAndConfirmation() throws {
+		let target = makeTarget(accountID: "account-a", expiresAt: 200)
+		var preparing = ResetCreditUseConfirmation()
+		_ = try unwrapPreparation(preparing.tap(target))
+		preparing.retainOnly([])
+		XCTAssertFalse(preparing.isBusy)
+
+		var armed = ResetCreditUseConfirmation()
+		let preparation = try unwrapPreparation(armed.tap(target))
+		armed.finishPreparation(preparation, creditID: "credit-1")
+		armed.retainOnly([])
+		XCTAssertFalse(armed.isArmed(target))
+	}
+
+	func testTargetsDistinguishDuplicateCardsByOccurrence() {
+		let duplicate = AccountResetCredit(
+			grantedAtUnixEpoch: 100,
+			expiresAtUnixEpoch: 200,
+			status: "available"
+		)
+		let targets = ResetCreditUseTarget.makeTargets(
+			accountID: "account-a",
+			reportedAvailableCount: 2,
+			credits: [duplicate, duplicate]
+		)
+
+		XCTAssertEqual(targets.map(\.occurrence), [0, 1])
+		XCTAssertEqual(targets.map(\.descriptorMultiplicity), [2, 2])
+		XCTAssertTrue(targets.allSatisfy(\.detailsComplete))
+		XCTAssertEqual(Set(targets).count, 2)
+	}
+
+	private func unwrapPreparation(
+		_ action: ResetCreditUseAction?,
+		file: StaticString = #filePath,
+		line: UInt = #line
+	) throws -> ResetCreditUsePreparation {
+		guard case .prepare(let preparation) = try XCTUnwrap(action, file: file, line: line) else {
+			XCTFail("Expected a prepare action.", file: file, line: line)
+			throw TestFailure.unexpectedAction
+		}
+
+		return preparation
+	}
+
+	private func unwrapAttempt(
+		_ action: ResetCreditUseAction?,
+		file: StaticString = #filePath,
+		line: UInt = #line
+	) throws -> ResetCreditUseAttempt {
+		guard case .consume(let attempt) = try XCTUnwrap(action, file: file, line: line) else {
+			XCTFail("Expected a consume action.", file: file, line: line)
+			throw TestFailure.unexpectedAction
+		}
+
+		return attempt
+	}
+
+	private func makeTarget(
+		accountID: String,
+		expiresAt: Int
+	) -> ResetCreditUseTarget {
+		ResetCreditUseTarget(
+			accountID: accountID,
+			descriptor: ResetCreditDescriptor(
+				credit: AccountResetCredit(
+					grantedAtUnixEpoch: 100,
+					expiresAtUnixEpoch: expiresAt,
+					status: "available"
+				)
+			),
+			occurrence: 0,
+			descriptorMultiplicity: 1,
+			detailsComplete: true
+		)
+	}
+
+	private enum TestFailure: Error {
+		case unexpectedAction
+	}
+}

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -147,6 +147,12 @@ decodex-publisher validate-social .agent/automations/decodex/cache/social/x
 - Lists stored accounts without token material.
 - Pins future Decodex runs to one account or returns to balanced selection.
 - Forces Codex to use a stored account by writing `auth.json`.
+- Uses a selected reset card after a second-click confirmation. The App resolves
+  the exact opaque credit ID before confirmation and reuses the same ID and
+  idempotency key for retries in an isolated file-auth app-server session. The
+  confirmation expires after five seconds and also clears when the menu-bar panel
+  closes. The isolated copy excludes the managed refresh token. Ambiguous or
+  incomplete card-detail lists fail closed.
 - Runs isolated Codex device login and imports the resulting auth file. The App
   honors an explicit `CODEX_CLI_PATH` override; otherwise it resolves the login
   executable from the Codex macOS application registered with Launch Services,


### PR DESCRIPTION
## Summary

- replace reset-card pointer dragging with a two-click exact-card confirmation flow
- consume through an isolated Codex app-server auth context with fail-closed ID matching
- expire confirmation automatically and keep the meaningful countdown separator
- animate usage meters from their pre-reset value to 100% after a successful reset
- document the bridge contract and add focused tests

## Validation

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app` (85 tests)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build -c release --package-path apps/decodex-app`
- `git diff --check`
- read-only probe against the bundled Codex app-server; no reset card consumed