### PR TITLE
Refine macOS account notices and panel sizing

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountNotice.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountNotice.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+struct AccountNotice: Equatable, Identifiable, Sendable {
+	enum Tone: Equatable, Sendable {
+		case success
+		case information
+		case error
+	}
+
+	enum Scope: Equatable, Sendable {
+		case general
+		case signIn
+	}
+
+	enum Source: Equatable, Sendable {
+		case accountAction
+		case accountRefresh
+		case fastMode
+		case resetCredit
+		case signIn
+	}
+
+	let id: UUID
+	let tone: Tone
+	let scope: Scope
+	let source: Source
+	let summary: String
+	let details: String?
+
+	init(
+		id: UUID = UUID(),
+		tone: Tone,
+		scope: Scope = .general,
+		source: Source = .accountAction,
+		summary: String,
+		details: String? = nil
+	) {
+		self.id = id
+		self.tone = tone
+		self.scope = scope
+		self.source = source
+		self.summary = summary
+		self.details = details
+	}
+
+	static func success(
+		_ summary: String,
+		source: Source = .accountAction
+	) -> Self {
+		Self(tone: .success, source: source, summary: summary)
+	}
+
+	static func information(
+		_ summary: String,
+		source: Source = .accountAction
+	) -> Self {
+		Self(tone: .information, source: source, summary: summary)
+	}
+
+	static func error(
+		_ summary: String,
+		details: String,
+		scope: Scope = .general,
+		source: Source = .accountAction
+	) -> Self {
+		Self(
+			tone: .error,
+			scope: scope,
+			source: source,
+			summary: summary,
+			details: details
+		)
+	}
+
+	func hasSamePresentation(as other: Self) -> Bool {
+		tone == other.tone
+			&& scope == other.scope
+			&& source == other.source
+			&& summary == other.summary
+			&& details == other.details
+	}
+
+	var copyText: String {
+		details ?? summary
+	}
+
+	var automaticDismissalDelay: Duration? {
+		switch tone {
+		case .success, .information:
+			return .seconds(4)
+		case .error:
+			return nil
+		}
+	}
+}
+
+extension AccountNotice {
+	static func resetCreditOutcome(
+		_ outcome: ResetCreditConsumeOutcome,
+		refreshError: String? = nil
+	) -> Self {
+		let result: Self
+		switch outcome {
+		case .reset:
+			result = .success("Usage restored", source: .resetCredit)
+		case .alreadyRedeemed:
+			result = .information("Card already used", source: .resetCredit)
+		case .nothingToReset:
+			result = .information("Nothing to reset", source: .resetCredit)
+		case .noCredit:
+			result = .information("No reset card available", source: .resetCredit)
+		}
+
+		guard let refreshError else {
+			return result
+		}
+
+		if outcome == .reset {
+			return .error(
+				"Usage restored; refresh failed",
+				details: refreshError,
+				source: .resetCredit
+			)
+		}
+
+		return .error(
+			"Couldn’t refresh account status",
+			details: "\(result.summary)\n\n\(refreshError)",
+			source: .resetCredit
+		)
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelScrolling.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelScrolling.swift
@@ -8,6 +8,17 @@ struct AccountScrollOffsetPreferenceKey: PreferenceKey {
 	}
 }
 
+struct AccountRowsHeightPreferenceKey: PreferenceKey {
+	static let defaultValue: CGFloat = 0
+
+	static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+		let next = nextValue()
+		if next > 0 {
+			value = next
+		}
+	}
+}
+
 struct AccountListScrollIndicatorView: View {
 	let contentHeight: CGFloat
 	let viewportHeight: CGFloat
@@ -46,9 +57,14 @@ struct AccountListScrollIndicatorView: View {
 
 extension AccountPanelView {
 	var accountListContentHeight: CGFloat {
-		store.accounts.reduce(CGFloat(1)) { total, account in
+		let estimatedHeight = store.accounts.reduce(CGFloat(1)) { total, account in
 			total + accountRowHeight(for: account)
 		}
+
+		return AccountPanelLayout.resolvedAccountListContentHeight(
+			measured: measuredAccountListContentHeight,
+			estimated: estimatedHeight
+		)
 	}
 
 	var accountListViewportHeight: CGFloat {
@@ -60,7 +76,10 @@ extension AccountPanelView {
 	}
 
 	var accountListAvailableHeight: CGFloat {
-		let visibleHeight = AccountPanelLayout.activeScreenVisibleHeight()
+		let visibleHeight = AccountPanelLayout.resolvedScreenVisibleHeight(
+			windowVisibleFrame: panelScreenVisibleFrame,
+			fallback: AccountPanelLayout.activeScreenVisibleHeight()
+		)
 		let availableHeight = visibleHeight - accountPanelChromeHeight
 		let minimumHeight = min(
 			AccountPanelLayout.minimumScrollableListHeight,
@@ -95,6 +114,15 @@ extension AccountPanelView {
 			Color.clear.preference(
 				key: AccountScrollOffsetPreferenceKey.self,
 				value: proxy.frame(in: .named(AccountPanelLayout.accountListScrollSpace)).minY
+			)
+		}
+	}
+
+	var accountRowsHeightProbe: some View {
+		GeometryReader { proxy in
+			Color.clear.preference(
+				key: AccountRowsHeightPreferenceKey.self,
+				value: proxy.size.height
 			)
 		}
 	}

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
@@ -16,8 +16,19 @@ enum AccountPanelLayout {
 	static let telemetryProfileHeight: CGFloat = 50
 	static let telemetryPoolHeight: CGFloat = 16
 	static let telemetryPoolMeasuredHeight: CGFloat = 29
-	static let noticeHeight: CGFloat = 44
+	static let noticeHeight: CGFloat = 30
 	static let minimumScrollableListHeight: CGFloat = 312
+
+	static func resolvedAccountListContentHeight(
+		measured: CGFloat,
+		estimated: CGFloat
+	) -> CGFloat {
+		guard measured.isFinite, measured > 0 else {
+			return estimated
+		}
+
+		return ceil(measured)
+	}
 
 	static func activeScreenVisibleHeight() -> CGFloat {
 		let mouseLocation = NSEvent.mouseLocation
@@ -26,6 +37,20 @@ enum AccountPanelLayout {
 		} ?? NSScreen.main
 
 		return screen?.visibleFrame.height ?? 760
+	}
+
+	static func resolvedScreenVisibleHeight(
+		windowVisibleFrame: CGRect?,
+		fallback: CGFloat
+	) -> CGFloat {
+		guard let windowVisibleFrame,
+			windowVisibleFrame.height.isFinite,
+			windowVisibleFrame.height > 0
+		else {
+			return fallback
+		}
+
+		return windowVisibleFrame.height
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -10,6 +10,8 @@ struct AccountPanelView: View {
 	@State var armedLogoutAccountID: String?
 	@State var deletingLogoutAccountID: String?
 	@State var logoutErrorMessage: String?
+	@State var measuredAccountListContentHeight: CGFloat = 0
+	@State var panelScreenVisibleFrame: CGRect?
 	@AppStorage("decodex.operator.accountPrivacy") var accountPrivacy = AccountPrivacy.hiddenValue
 
 	var body: some View {
@@ -45,12 +47,18 @@ struct AccountPanelView: View {
 			}
 
 			if let notice = store.notice {
-				NoticeView(text: notice)
+				NoticeView(notice: notice, onDismiss: store.clearNotice)
+					.id(notice.id)
 					.transition(.panelSection)
 			}
 
 			if let usageProbeError = store.accountList?.usageProbeError {
-				NoticeView(text: "Usage probe: \(usageProbeError)")
+				NoticeView(
+					notice: .error(
+						"Some usage data is unavailable",
+						details: usageProbeError
+					)
+				)
 					.transition(.panelSection)
 			}
 
@@ -74,13 +82,18 @@ struct AccountPanelView: View {
 		.controlSize(.small)
 		.symbolRenderingMode(.hierarchical)
 		.animation(PanelMotion.panelLayout, value: panelAnimationKey)
-		.sizesPanelWindowToContent()
+		.sizesPanelWindowToContent { visibleFrame in
+			if panelScreenVisibleFrame != visibleFrame {
+				panelScreenVisibleFrame = visibleFrame
+			}
+		}
 	}
 
 	private var accountList: some View {
 		ScrollView(.vertical, showsIndicators: false) {
 			accountRows
 				.background(accountScrollProbe)
+				.background(accountRowsHeightProbe)
 		}
 		.coordinateSpace(name: AccountPanelLayout.accountListScrollSpace)
 		.frame(height: accountListViewportHeight)
@@ -95,6 +108,12 @@ struct AccountPanelView: View {
 		.onPreferenceChange(AccountScrollOffsetPreferenceKey.self) { minY in
 			let maxOffset = max(0, accountListContentHeight - accountListViewportHeight)
 			accountScrollOffset = min(max(0, -minY), maxOffset)
+		}
+		.onPreferenceChange(AccountRowsHeightPreferenceKey.self) { height in
+			let measuredHeight = ceil(height)
+			if abs(measuredAccountListContentHeight - measuredHeight) > 0.5 {
+				measuredAccountListContentHeight = measuredHeight
+			}
 		}
 		.onChange(of: accountListNeedsScrolling) { _, needsScrolling in
 			if needsScrolling == false {

--- a/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStore.swift
@@ -13,7 +13,8 @@ final class AccountStore {
 	var isLoggingIn = false
 	var isSettingFastMode = false
 	var loginTranscript = ""
-	var notice: String?
+	var notice: AccountNotice?
+	var loginNotice: AccountNotice?
 	var pendingLogoutRemovalKeys = Set<String>()
 	var usageRefillAnimations: [String: AccountUsageRefillAnimation] = [:]
 
@@ -23,11 +24,13 @@ final class AccountStore {
 	@ObservationIgnored var operatorSnapshotStreamTask: Task<Void, Never>?
 	@ObservationIgnored var operatorSnapshotPublishedAtUnixEpoch: Int64?
 	@ObservationIgnored var usageRefillCleanupTasks: [String: Task<Void, Never>] = [:]
+	@ObservationIgnored var noticeDismissalTask: Task<Void, Never>?
 
 	deinit {
 		startupTask?.cancel()
 		automaticRefreshTask?.cancel()
 		operatorSnapshotStreamTask?.cancel()
+		noticeDismissalTask?.cancel()
 		for task in usageRefillCleanupTasks.values {
 			task.cancel()
 		}
@@ -71,7 +74,7 @@ final class AccountStore {
 		if isLoggingIn {
 			return loginPrompt == nil ? "Requesting code" : "Waiting for browser sign-in"
 		}
-		if notice != nil {
+		if loginNotice?.tone == .error {
 			return "Login failed"
 		}
 		if loginPrompt != nil {
@@ -90,7 +93,80 @@ final class AccountStore {
 		}
 
 		loginTranscript = ""
+		clearLoginNotice()
+	}
+
+	func presentNotice(_ notice: AccountNotice) {
+		guard notice.scope == .general else {
+			loginNotice = notice
+			return
+		}
+
+		if notice.tone == .error,
+			self.notice?.hasSamePresentation(as: notice) == true
+		{
+			return
+		}
+
+		noticeDismissalTask?.cancel()
+		self.notice = notice
+
+		guard let delay = notice.automaticDismissalDelay else {
+			noticeDismissalTask = nil
+			return
+		}
+
+		let noticeID = notice.id
+		noticeDismissalTask = Task { [weak self] in
+			do {
+				try await Task.sleep(for: delay)
+			} catch {
+				return
+			}
+
+			guard let self, self.notice?.id == noticeID else {
+				return
+			}
+
+			self.notice = nil
+			self.noticeDismissalTask = nil
+		}
+	}
+
+	func presentError(
+		_ summary: String,
+		error: Error,
+		scope: AccountNotice.Scope = .general,
+		source: AccountNotice.Source = .accountAction
+	) {
+		presentNotice(.error(
+			summary,
+			details: error.localizedDescription,
+			scope: scope,
+			source: source
+		))
+	}
+
+	func clearNotice() {
+		dismissCurrentNotice()
+	}
+
+	func clearNotice(source: AccountNotice.Source) {
+		guard notice?.source == source else {
+			return
+		}
+
+		dismissCurrentNotice()
+	}
+
+	private func dismissCurrentNotice() {
+		noticeDismissalTask?.cancel()
+		noticeDismissalTask = nil
 		notice = nil
+	}
+
+	func clearLoginNotice() {
+		loginNotice = nil
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountStoreActions.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStoreActions.swift
@@ -3,7 +3,7 @@ import Foundation
 extension AccountStore {
 	func useInCodex(_ account: CodexAccount) async {
 		let previousAccountList = accountList
-		notice = nil
+		clearNotice(source: .accountAction)
 		accountList = accountList?.updatingCodexAuth(account.authIdentity)
 
 		do {
@@ -12,10 +12,10 @@ extension AccountStore {
 				as: CodexAuthUseResponse.self
 			)
 			accountList = accountList?.updatingCodexAuth(response.account)
-			notice = nil
+			clearNotice(source: .accountAction)
 		} catch {
 			accountList = previousAccountList
-			notice = error.localizedDescription
+			presentError("Couldn’t switch Codex account", error: error)
 		}
 	}
 
@@ -29,18 +29,18 @@ extension AccountStore {
 					as: AccountListResponse.self
 				))
 			}
-			notice = nil
+			clearNotice(source: .accountAction)
 		} catch {
-			notice = error.localizedDescription
+			presentError("Couldn’t update account routing", error: error)
 		}
 	}
 
 	func clearSelection() async {
 		do {
 			applyAccountList(try await bridge.runJSON(.accountClear, as: AccountListResponse.self))
-			notice = nil
+			clearNotice(source: .accountAction)
 		} catch {
-			notice = error.localizedDescription
+			presentError("Couldn’t update account routing", error: error)
 		}
 	}
 
@@ -64,10 +64,10 @@ extension AccountStore {
 				.codexFastModeSet(enabled: enabled),
 				as: CodexFastModeResponse.self
 			)
-			notice = nil
+			clearNotice(source: .fastMode)
 		} catch {
 			fastMode = previous
-			notice = error.localizedDescription
+			presentError("Couldn’t update fast mode", error: error, source: .fastMode)
 		}
 	}
 
@@ -79,17 +79,21 @@ extension AccountStore {
 				.accountLogout(selector: account.selector),
 				as: AccountListResponse.self
 			))
-			notice = nil
+			clearNotice(source: .accountAction)
 		} catch {
 			cancelOptimisticLogoutRemoval(account)
 			throw error
 		}
 	}
 
-	func login() async {
+	@discardableResult
+	func login() async -> Bool {
 		isLoggingIn = true
 		loginTranscript = ""
-		notice = nil
+		clearLoginNotice()
+		defer {
+			isLoggingIn = false
+		}
 
 		do {
 			let codexBin = try bridge.codexExecutablePath()
@@ -101,13 +105,18 @@ extension AccountStore {
 					self?.loginTranscript += chunk
 				}
 			)
-			notice = nil
+			clearLoginNotice()
 			await refreshFastMode()
+			return true
 		} catch {
-			notice = error.localizedDescription
+			presentError(
+				"Sign-in failed",
+				error: error,
+				scope: .signIn,
+				source: .signIn
+			)
+			return false
 		}
-
-		isLoggingIn = false
 	}
 
 	func prepareResetCredit(
@@ -115,7 +124,11 @@ extension AccountStore {
 		for account: CodexAccount
 	) async -> String? {
 		guard preparation.target.accountID == account.accountFingerprint else {
-			notice = ResetCreditUseError.accountChanged.localizedDescription
+			presentError(
+				"Couldn’t prepare reset card",
+				error: ResetCreditUseError.accountChanged,
+				source: .resetCredit
+			)
 			return nil
 		}
 		guard await refreshAccountsForResetCredit() else {
@@ -140,10 +153,10 @@ extension AccountStore {
 				preparation: preparation
 			)
 
-			notice = nil
+			clearNotice(source: .resetCredit)
 			return creditID
 		} catch {
-			notice = error.localizedDescription
+			presentError("Couldn’t prepare reset card", error: error, source: .resetCredit)
 			return nil
 		}
 	}
@@ -154,7 +167,11 @@ extension AccountStore {
 	) async -> Bool {
 		cancelUsageRefillAnimation(for: account.accountFingerprint)
 		guard attempt.target.accountID == account.accountFingerprint else {
-			notice = ResetCreditUseError.accountChanged.localizedDescription
+			presentError(
+				"Couldn’t use reset card",
+				error: ResetCreditUseError.accountChanged,
+				source: .resetCredit
+			)
 			return false
 		}
 		guard await refreshAccountsForResetCredit() else {
@@ -181,7 +198,6 @@ extension AccountStore {
 				attempt: attempt
 			)
 
-			let outcomeNotice = resetCreditNotice(for: outcome)
 			if outcome == .reset {
 				beginUsageRefillAnimation(refillAnimation)
 			}
@@ -191,16 +207,16 @@ extension AccountStore {
 				refreshSucceeded: outcome == .reset && refreshSucceeded
 			)
 			if refreshSucceeded {
-				notice = outcomeNotice
+				presentNotice(.resetCreditOutcome(outcome))
 			} else {
-				let refreshNotice = notice ?? "Account refresh failed."
-				notice = "\(outcomeNotice) \(refreshNotice)"
+				let refreshError = notice?.copyText ?? "Account refresh failed."
+				presentNotice(.resetCreditOutcome(outcome, refreshError: refreshError))
 			}
 			return true
 		} catch {
 			cancelUsageRefillAnimation(for: account.accountFingerprint)
 			_ = await refreshAccountsForResetCredit()
-			notice = error.localizedDescription
+			presentError("Couldn’t use reset card", error: error, source: .resetCredit)
 			return false
 		}
 	}
@@ -339,18 +355,6 @@ extension AccountStore {
 				.resolvingSymlinksInPath()
 	}
 
-	private func resetCreditNotice(for outcome: ResetCreditConsumeOutcome) -> String {
-		switch outcome {
-		case .reset:
-			return "Reset card used."
-		case .alreadyRedeemed:
-			return "Reset card was already used."
-		case .nothingToReset:
-			return "No current rate limit can be reset."
-		case .noCredit:
-			return "No reset card is available."
-		}
-	}
 }
 
 private enum ResetCreditUseError: LocalizedError {

--- a/apps/decodex-app/Sources/DecodexApp/AccountStoreRefresh.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStoreRefresh.swift
@@ -30,11 +30,15 @@ extension AccountStore {
 				.accountList(forceRefresh: force),
 				as: AccountListResponse.self
 			))
-			notice = nil
+			clearNotice(source: .accountRefresh)
 			await refreshFastMode()
 			return true
 		} catch {
-			notice = error.localizedDescription
+			presentError(
+				"Couldn’t refresh accounts",
+				error: error,
+				source: .accountRefresh
+			)
 			return false
 		}
 	}
@@ -73,8 +77,13 @@ extension AccountStore {
 				.codexFastModeStatus,
 				as: CodexFastModeResponse.self
 			)
+			clearNotice(source: .fastMode)
 		} catch {
-			notice = error.localizedDescription
+			presentError(
+				"Couldn’t refresh fast mode",
+				error: error,
+				source: .fastMode
+			)
 		}
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/LoginSheetView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/LoginSheetView.swift
@@ -4,7 +4,6 @@ import SwiftUI
 struct LoginSheetView: View {
 	let store: AccountStore
 	let mode: AccountLoginSheetMode
-	@Environment(\.colorScheme) private var colorScheme
 	@State private var requestStarted = false
 	@State private var copyFeedback = false
 	@State private var copyFeedbackToken = UUID()
@@ -36,7 +35,9 @@ struct LoginSheetView: View {
 			LoginSheetHeaderView(
 				mode: mode,
 				statusLabel: store.loginStatusLabel,
-				isActive: store.isLoggingIn || store.loginPrompt != nil || store.notice != nil
+				isActive: store.isLoggingIn
+					|| store.loginPrompt != nil
+					|| store.loginNotice != nil
 			)
 			LoginCodeCardView(
 				code: store.loginPrompt?.compactCode ?? "",
@@ -54,12 +55,9 @@ struct LoginSheetView: View {
 					.transition(.opacity.combined(with: .move(edge: .top)))
 			}
 
-			if let notice = store.notice {
-				Text(notice)
-					.font(LoginFont.caption)
-					.foregroundStyle(LoginPalette.warning(colorScheme))
-					.lineLimit(2)
-					.fixedSize(horizontal: false, vertical: true)
+			if let notice = store.loginNotice {
+				NoticeView(notice: notice, onDismiss: store.clearLoginNotice)
+					.id(notice.id)
 			}
 
 			LoginSheetActionsView(
@@ -83,7 +81,7 @@ struct LoginSheetView: View {
 				requestStarted = false
 			}
 		}
-		.onChange(of: store.notice) { _, notice in
+		.onChange(of: store.loginNotice) { _, notice in
 			if notice != nil {
 				requestStarted = false
 			}
@@ -105,9 +103,9 @@ struct LoginSheetView: View {
 	private func requestLogin() {
 		requestStarted = true
 		Task {
-			await store.login()
+			let succeeded = await store.login()
 			requestStarted = false
-			if store.notice == nil {
+			if succeeded {
 				onComplete()
 			}
 		}

--- a/apps/decodex-app/Sources/DecodexApp/NoticeView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/NoticeView.swift
@@ -1,22 +1,134 @@
+import AppKit
 import SwiftUI
 
 struct NoticeView: View {
-	let text: String
+	let notice: AccountNotice
+	var onDismiss: (() -> Void)?
 	@Environment(\.colorScheme) private var colorScheme
+	@State private var isShowingDetails = false
+	@State private var copyFeedback = false
+	@State private var copyFeedbackToken = UUID()
 
 	var body: some View {
-		HStack(alignment: .top, spacing: 7) {
-			Image(systemName: "exclamationmark.triangle")
-				.foregroundStyle(PanelPalette.warning(colorScheme))
-			Text(text)
+		HStack(spacing: 6) {
+			Image(systemName: symbolName)
+				.font(.system(size: 11, weight: .semibold))
+				.foregroundStyle(tint)
+				.accessibilityHidden(true)
+
+			Text(notice.summary)
 				.font(PanelFont.notice)
-				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-				.fixedSize(horizontal: false, vertical: true)
+				.foregroundStyle(PanelPalette.primaryText(colorScheme).opacity(0.9))
+				.lineLimit(1)
+				.truncationMode(.tail)
+				.frame(maxWidth: .infinity, alignment: .leading)
+
+			if notice.details != nil {
+				Button("Details") {
+					isShowingDetails = true
+				}
+				.buttonStyle(.plain)
+				.font(PanelFont.notice)
+				.foregroundStyle(PanelPalette.actionBlue(colorScheme))
+				.popover(isPresented: $isShowingDetails, arrowEdge: .trailing) {
+					detailsPopover
+				}
+			}
+
+			if let onDismiss {
+				Button(action: onDismiss) {
+					Image(systemName: "xmark")
+						.font(.system(size: 9, weight: .bold))
+						.frame(width: 16, height: 16)
+						.contentShape(Rectangle())
+				}
+				.buttonStyle(.plain)
+				.foregroundStyle(PanelPalette.secondaryText(colorScheme).opacity(0.72))
+				.help("Dismiss")
+				.accessibilityLabel("Dismiss notice")
+			}
 		}
-		.padding(8)
+		.padding(.horizontal, 8)
+		.frame(height: AccountPanelLayout.noticeHeight)
 		.modernGlassSurface(
-			cornerRadius: 9,
+			cornerRadius: 8,
 			depth: .section
 		)
+	}
+
+	private var detailsPopover: some View {
+		VStack(alignment: .leading, spacing: 9) {
+			HStack(spacing: 7) {
+				Image(systemName: symbolName)
+					.foregroundStyle(tint)
+					.accessibilityHidden(true)
+				Text(notice.summary)
+					.font(PanelFont.accountName)
+					.foregroundStyle(PanelPalette.primaryText(colorScheme))
+			}
+
+			ScrollView {
+				Text(notice.copyText)
+					.font(PanelFont.notice)
+					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+					.textSelection(.enabled)
+					.frame(maxWidth: .infinity, alignment: .leading)
+			}
+			.frame(maxHeight: 150)
+
+			HStack {
+				Spacer()
+				Button(copyFeedback ? "Copied" : "Copy details") {
+					copyDetails()
+				}
+				.buttonStyle(.bordered)
+				.controlSize(.small)
+			}
+		}
+		.padding(12)
+		.frame(width: 280)
+	}
+
+	private var symbolName: String {
+		switch notice.tone {
+		case .success:
+			return "checkmark.circle.fill"
+		case .information:
+			return "info.circle.fill"
+		case .error:
+			return "exclamationmark.triangle.fill"
+		}
+	}
+
+	private var tint: Color {
+		switch notice.tone {
+		case .success:
+			return PanelPalette.capacityAccent(colorScheme)
+		case .information:
+			return PanelPalette.secondaryText(colorScheme)
+		case .error:
+			return PanelPalette.warning(colorScheme)
+		}
+	}
+
+	private func copyDetails() {
+		NSPasteboard.general.clearContents()
+		NSPasteboard.general.setString(notice.copyText, forType: .string)
+
+		let token = UUID()
+		copyFeedbackToken = token
+		withAnimation(PanelMotion.state) {
+			copyFeedback = true
+		}
+
+		Task { @MainActor in
+			try? await Task.sleep(for: .milliseconds(900))
+			guard copyFeedbackToken == token else {
+				return
+			}
+			withAnimation(PanelMotion.state) {
+				copyFeedback = false
+			}
+		}
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/PanelWindowSizing.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelWindowSizing.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 private struct PanelWindowSizeReporter: NSViewRepresentable {
 	let contentSize: CGSize
+	let screenParametersRevision: Int
+	let onVisibleFrameChange: (NSRect?) -> Void
 
 	func makeNSView(context: Context) -> NSView {
 		let view = PanelWindowSizingProbeView(frame: .zero)
@@ -13,7 +15,12 @@ private struct PanelWindowSizeReporter: NSViewRepresentable {
 	}
 
 	func updateNSView(_ nsView: NSView, context: Context) {
-		context.coordinator.scheduleResize(from: nsView, contentSize: contentSize)
+		context.coordinator.scheduleResize(
+			from: nsView,
+			contentSize: contentSize,
+			screenParametersRevision: screenParametersRevision,
+			onVisibleFrameChange: onVisibleFrameChange
+		)
 	}
 
 	func makeCoordinator() -> Coordinator {
@@ -21,17 +28,28 @@ private struct PanelWindowSizeReporter: NSViewRepresentable {
 	}
 
 	final class Coordinator {
-		private var lastAppliedSize = NSSize.zero
+		private var lastAppliedScreenParametersRevision = -1
 		private var pendingSize = CGSize.zero
+		private var pendingScreenParametersRevision = 0
+		private var pendingVisibleFrameCallback: (NSRect?) -> Void = { _ in }
 		private var resizeIsScheduled = false
+		private var hasReportedVisibleFrame = false
+		private var lastReportedVisibleFrame: NSRect?
 
 		@MainActor
-		func scheduleResize(from view: NSView, contentSize: CGSize) {
+		func scheduleResize(
+			from view: NSView,
+			contentSize: CGSize,
+			screenParametersRevision: Int,
+			onVisibleFrameChange: @escaping (NSRect?) -> Void
+		) {
 			guard contentSize.width > 0, contentSize.height > 0 else {
 				return
 			}
 
 			pendingSize = contentSize
+			pendingScreenParametersRevision = screenParametersRevision
+			pendingVisibleFrameCallback = onVisibleFrameChange
 			guard resizeIsScheduled == false else {
 				return
 			}
@@ -42,33 +60,53 @@ private struct PanelWindowSizeReporter: NSViewRepresentable {
 					return
 				}
 				self.resizeIsScheduled = false
-				self.resizeWindow(from: view, contentSize: self.pendingSize)
+				self.resizeWindow(
+					from: view,
+					contentSize: self.pendingSize,
+					screenParametersRevision: self.pendingScreenParametersRevision,
+					onVisibleFrameChange: self.pendingVisibleFrameCallback
+				)
 			}
 		}
 
 		@MainActor
-		private func resizeWindow(from view: NSView, contentSize: CGSize) {
+		private func resizeWindow(
+			from view: NSView,
+			contentSize: CGSize,
+			screenParametersRevision: Int,
+			onVisibleFrameChange: (NSRect?) -> Void
+		) {
 			guard let window = view.window else {
 				return
 			}
 
+			let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame
+			reportVisibleFrameIfNeeded(
+				visibleFrame,
+				onVisibleFrameChange: onVisibleFrameChange
+			)
 			let targetSize = PanelWindowSizingLayout.roundedContentSize(for: contentSize)
-			guard Self.sizeDiffers(targetSize, lastAppliedSize)
-				|| Self.sizeDiffers(targetSize, window.contentLayoutRect.size)
-			else {
-				return
-			}
-
 			let frame = PanelWindowSizingLayout.frame(
 				forContentSize: targetSize,
 				currentFrame: window.frame
 			) { contentSize in
 				window.frameRect(forContentRect: NSRect(origin: .zero, size: contentSize)).size
 			} visibleFrame: {
-				(window.screen ?? NSScreen.main)?.visibleFrame
+				visibleFrame
 			}
+			let screenParametersChanged =
+				screenParametersRevision != lastAppliedScreenParametersRevision
+			let frameChanged = Self.frameDiffers(frame, window.frame)
+			guard screenParametersChanged || frameChanged else {
+				return
+			}
+
+			lastAppliedScreenParametersRevision = screenParametersRevision
+			guard frameChanged else {
+				return
+			}
+
 			window.setFrame(frame, display: true)
-			lastAppliedSize = targetSize
 		}
 
 		@MainActor
@@ -77,17 +115,54 @@ private struct PanelWindowSizeReporter: NSViewRepresentable {
 				return
 			}
 
-			scheduleResize(from: view, contentSize: pendingSize)
+			scheduleResize(
+				from: view,
+				contentSize: pendingSize,
+				screenParametersRevision: pendingScreenParametersRevision,
+				onVisibleFrameChange: pendingVisibleFrameCallback
+			)
 		}
 
-		private static func sizeDiffers(_ lhs: NSSize, _ rhs: NSSize) -> Bool {
-			abs(lhs.width - rhs.width) > 0.5 || abs(lhs.height - rhs.height) > 0.5
+		@MainActor
+		private func reportVisibleFrameIfNeeded(
+			_ visibleFrame: NSRect?,
+			onVisibleFrameChange: (NSRect?) -> Void
+		) {
+			guard hasReportedVisibleFrame == false
+				|| Self.rectDiffers(visibleFrame, lastReportedVisibleFrame)
+			else {
+				return
+			}
+
+			hasReportedVisibleFrame = true
+			lastReportedVisibleFrame = visibleFrame
+			onVisibleFrameChange(visibleFrame)
+		}
+
+		private static func frameDiffers(_ lhs: NSRect, _ rhs: NSRect) -> Bool {
+			abs(lhs.minX - rhs.minX) > 0.5
+				|| abs(lhs.minY - rhs.minY) > 0.5
+				|| abs(lhs.width - rhs.width) > 0.5
+				|| abs(lhs.height - rhs.height) > 0.5
+		}
+
+		private static func rectDiffers(_ lhs: NSRect?, _ rhs: NSRect?) -> Bool {
+			switch (lhs, rhs) {
+			case (.none, .none):
+				return false
+			case (.none, .some), (.some, .none):
+				return true
+			case (.some(let lhs), .some(let rhs)):
+				return frameDiffers(lhs, rhs)
+			}
 		}
 	}
 }
 
 private struct PanelWindowSizingModifier: ViewModifier {
+	let onVisibleFrameChange: (NSRect?) -> Void
 	@State private var contentSize = CGSize.zero
+	@State private var screenParametersRevision = 0
 
 	func body(content: Content) -> some View {
 		content
@@ -101,15 +176,37 @@ private struct PanelWindowSizingModifier: ViewModifier {
 				contentSize = size
 			}
 			.background {
-				PanelWindowSizeReporter(contentSize: contentSize)
+				PanelWindowSizeReporter(
+					contentSize: contentSize,
+					screenParametersRevision: screenParametersRevision,
+					onVisibleFrameChange: onVisibleFrameChange
+				)
 					.frame(width: 0, height: 0)
+			}
+			.onReceive(
+				NotificationCenter.default.publisher(
+					for: NSApplication.didChangeScreenParametersNotification
+				)
+			) { _ in
+				screenParametersRevision &+= 1
+			}
+			.onReceive(
+				NotificationCenter.default.publisher(
+					for: NSWindow.didChangeScreenNotification
+				)
+			) { _ in
+				screenParametersRevision &+= 1
 			}
 	}
 }
 
 extension View {
-	func sizesPanelWindowToContent() -> some View {
-		modifier(PanelWindowSizingModifier())
+	func sizesPanelWindowToContent(
+		onVisibleFrameChange: @escaping (NSRect?) -> Void = { _ in }
+	) -> some View {
+		modifier(PanelWindowSizingModifier(
+			onVisibleFrameChange: onVisibleFrameChange
+		))
 	}
 }
 
@@ -150,16 +247,26 @@ enum PanelWindowSizingLayout {
 		frameSizeForContentSize: (NSSize) -> NSSize,
 		visibleFrame: () -> NSRect?
 	) -> NSRect {
-		let frameSize = frameSizeForContentSize(contentSize)
+		let requestedFrameSize = frameSizeForContentSize(contentSize)
+		guard let visibleFrame = visibleFrame() else {
+			return NSRect(
+				x: currentFrame.midX - requestedFrameSize.width / 2,
+				y: currentFrame.maxY - requestedFrameSize.height,
+				width: requestedFrameSize.width,
+				height: requestedFrameSize.height
+			)
+		}
+
+		let frameSize = fittedFrameSize(
+			requestedFrameSize,
+			inside: visibleFrame
+		)
 		let proposedFrame = NSRect(
 			x: currentFrame.midX - frameSize.width / 2,
 			y: currentFrame.maxY - frameSize.height,
 			width: frameSize.width,
 			height: frameSize.height
 		)
-		guard let visibleFrame = visibleFrame() else {
-			return proposedFrame
-		}
 
 		return NSRect(
 			x: clamped(
@@ -174,6 +281,19 @@ enum PanelWindowSizingLayout {
 			),
 			width: frameSize.width,
 			height: frameSize.height
+		)
+	}
+
+	private static func fittedFrameSize(
+		_ frameSize: NSSize,
+		inside visibleFrame: NSRect
+	) -> NSSize {
+		let maximumWidth = max(1, visibleFrame.width - placementMargin * 2)
+		let maximumHeight = max(1, visibleFrame.height - placementMargin * 2)
+
+		return NSSize(
+			width: min(frameSize.width, maximumWidth),
+			height: min(frameSize.height, maximumHeight)
 		)
 	}
 

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountNoticePresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountNoticePresentationTests.swift
@@ -1,0 +1,107 @@
+@testable import DecodexApp
+import XCTest
+
+final class AccountNoticePresentationTests: XCTestCase {
+	func testResetCreditOutcomesUseConciseSemanticNotices() {
+		let reset = AccountNotice.resetCreditOutcome(.reset)
+		XCTAssertEqual(reset.tone, .success)
+		XCTAssertEqual(reset.summary, "Usage restored")
+		XCTAssertNil(reset.details)
+
+		let alreadyUsed = AccountNotice.resetCreditOutcome(.alreadyRedeemed)
+		XCTAssertEqual(alreadyUsed.tone, .information)
+		XCTAssertEqual(alreadyUsed.summary, "Card already used")
+
+		let nothingToReset = AccountNotice.resetCreditOutcome(.nothingToReset)
+		XCTAssertEqual(nothingToReset.tone, .information)
+		XCTAssertEqual(nothingToReset.summary, "Nothing to reset")
+
+		let noCredit = AccountNotice.resetCreditOutcome(.noCredit)
+		XCTAssertEqual(noCredit.tone, .information)
+		XCTAssertEqual(noCredit.summary, "No reset card available")
+	}
+
+	func testResetSuccessWithRefreshFailurePreservesBothFacts() {
+		let notice = AccountNotice.resetCreditOutcome(
+			.reset,
+			refreshError: "The account service did not respond."
+		)
+
+		XCTAssertEqual(notice.tone, .error)
+		XCTAssertEqual(notice.summary, "Usage restored; refresh failed")
+		XCTAssertEqual(notice.details, "The account service did not respond.")
+		XCTAssertEqual(notice.copyText, "The account service did not respond.")
+	}
+
+	func testErrorSeparatesReadableSummaryFromCopyableDetails() {
+		let notice = AccountNotice.error(
+			"Couldn’t refresh accounts",
+			details: "Server request failed (503): unavailable"
+		)
+
+		XCTAssertEqual(notice.summary, "Couldn’t refresh accounts")
+		XCTAssertEqual(notice.copyText, "Server request failed (503): unavailable")
+		XCTAssertNil(notice.automaticDismissalDelay)
+	}
+
+	@MainActor
+	func testLoginStatusTreatsOnlySignInErrorsAsFailure() {
+		let store = AccountStore()
+
+		store.presentNotice(.information("Nothing to reset"))
+		XCTAssertEqual(store.loginStatusLabel, "Ready")
+		XCTAssertEqual(store.notice?.summary, "Nothing to reset")
+
+		store.presentNotice(.error(
+			"Couldn’t refresh fast mode",
+			details: "Network unavailable"
+		))
+		XCTAssertEqual(store.loginStatusLabel, "Ready")
+		XCTAssertNil(store.loginNotice)
+		XCTAssertEqual(store.notice?.summary, "Couldn’t refresh fast mode")
+
+		store.presentNotice(.error(
+			"Sign-in failed",
+			details: "Network unavailable",
+			scope: .signIn
+		))
+		XCTAssertEqual(store.loginStatusLabel, "Login failed")
+		XCTAssertEqual(store.loginNotice?.summary, "Sign-in failed")
+		XCTAssertEqual(store.notice?.summary, "Couldn’t refresh fast mode")
+
+		store.clearNotice()
+		XCTAssertEqual(store.loginStatusLabel, "Login failed")
+		store.clearLoginNotice()
+	}
+
+	@MainActor
+	func testSourceSpecificClearingPreservesUnrelatedNotice() {
+		let store = AccountStore()
+		store.presentNotice(.resetCreditOutcome(.reset))
+
+		store.clearNotice(source: .accountRefresh)
+		XCTAssertEqual(store.notice?.summary, "Usage restored")
+
+		store.clearNotice(source: .resetCredit)
+		XCTAssertNil(store.notice)
+	}
+
+	@MainActor
+	func testRepeatedIdenticalErrorsKeepTheVisibleNoticeIdentity() {
+		let store = AccountStore()
+		store.presentNotice(.error(
+			"Couldn’t refresh fast mode",
+			details: "Service unavailable",
+			source: .fastMode
+		))
+		let firstID = store.notice?.id
+
+		store.presentNotice(.error(
+			"Couldn’t refresh fast mode",
+			details: "Service unavailable",
+			source: .fastMode
+		))
+
+		XCTAssertEqual(store.notice?.id, firstID)
+	}
+}

--- a/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
@@ -9,6 +9,51 @@ final class PanelWindowSizingLayoutTests: XCTestCase {
 		XCTAssertEqual(size, NSSize(width: 340, height: 642))
 	}
 
+	func testMeasuredAccountRowsHeightOverridesAnInflatedEstimate() {
+		let height = AccountPanelLayout.resolvedAccountListContentHeight(
+			measured: 612.2,
+			estimated: 730
+		)
+
+		XCTAssertEqual(height, 613)
+	}
+
+	func testAccountRowsHeightUsesEstimateUntilMeasurementArrives() {
+		XCTAssertEqual(
+			AccountPanelLayout.resolvedAccountListContentHeight(
+				measured: 0,
+				estimated: 730
+			),
+			730
+		)
+		XCTAssertEqual(
+			AccountPanelLayout.resolvedAccountListContentHeight(
+				measured: .nan,
+				estimated: 730
+			),
+			730
+		)
+	}
+
+	func testHostingWindowScreenHeightOverridesPointerScreenFallback() {
+		let height = AccountPanelLayout.resolvedScreenVisibleHeight(
+			windowVisibleFrame: NSRect(x: 1_000, y: 0, width: 800, height: 620),
+			fallback: 1_000
+		)
+
+		XCTAssertEqual(height, 620)
+	}
+
+	func testPointerScreenHeightIsFallbackBeforeWindowAttachment() {
+		XCTAssertEqual(
+			AccountPanelLayout.resolvedScreenVisibleHeight(
+				windowVisibleFrame: nil,
+				fallback: 760
+			),
+			760
+		)
+	}
+
 	func testFrameKeepsTopEdgeAndCenterWhenContentShrinks() {
 		let currentFrame = NSRect(x: 120, y: 200, width: 360, height: 700)
 		let frame = PanelWindowSizingLayout.frame(
@@ -41,16 +86,39 @@ final class PanelWindowSizingLayoutTests: XCTestCase {
 	}
 
 	func testOversizedFrameFallsBackToVisibleFrameLeadingMargin() {
+		let visibleFrame = NSRect(x: 0, y: 0, width: 800, height: 700)
 		let frame = PanelWindowSizingLayout.frame(
 			forContentSize: NSSize(width: 900, height: 760),
 			currentFrame: NSRect(x: 100, y: 100, width: 340, height: 220)
 		) { contentSize in
 			contentSize
 		} visibleFrame: {
-			NSRect(x: 0, y: 0, width: 800, height: 700)
+			visibleFrame
 		}
 
 		XCTAssertEqual(frame.minX, 8)
 		XCTAssertEqual(frame.minY, 8)
+		XCTAssertEqual(frame.width, 784)
+		XCTAssertEqual(frame.height, 684)
+		XCTAssertEqual(frame.maxX, 792)
+		XCTAssertEqual(frame.maxY, 692)
+	}
+
+	func testOversizedFittedFrameConvergesOnTheSecondLayoutPass() {
+		let visibleFrame = NSRect(x: 0, y: 0, width: 800, height: 700)
+		let firstFrame = PanelWindowSizingLayout.frame(
+			forContentSize: NSSize(width: 900, height: 760),
+			currentFrame: NSRect(x: 100, y: 100, width: 340, height: 220)
+		) { $0 } visibleFrame: {
+			visibleFrame
+		}
+		let secondFrame = PanelWindowSizingLayout.frame(
+			forContentSize: NSSize(width: 900, height: 760),
+			currentFrame: firstFrame
+		) { $0 } visibleFrame: {
+			visibleFrame
+		}
+
+		XCTAssertEqual(secondFrame, firstFrame)
 	}
 }


### PR DESCRIPTION
Adds compact semantic account notices, measured panel content sizing, and display-change reclamping. Validation: 96 Swift tests, Release build, diff check, and independent review.