### PR TITLE
Make reset-card confirmation immediate

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -111,15 +111,17 @@ The "Use in Codex" action overwrites Codex's `auth.json` from one stored
 `~/.codex/decodex/accounts.jsonl` entry. The destination is `$CODEX_HOME/auth.json`
 when `CODEX_HOME` is set, otherwise `~/.codex/auth.json`.
 
-The reset-card action requires two clicks on the same card. The first click reads the
-current opaque credit ID and then shows `Confirm Use` with a five-second countdown.
-The confirmation cancels when the countdown expires or the panel closes. A second
-click during the countdown consumes that exact ID and reuses one idempotency key for
-retries. Each request uses an isolated Codex app-server session with a short-lived
-file-auth copy for the selected account. The copy contains the current access token
-and a disabled refresh placeholder, not the managed refresh token. The action does
-not overwrite the user's normal Codex `auth.json`. Ambiguous duplicate cards and
-incomplete card-detail lists fail closed.
+The reset-card action requires two clicks on the same card. The first click is a
+local-only state change that immediately shows `Confirm Use` with a five-second
+countdown. The confirmation cancels when the countdown expires or the panel closes.
+A second click during the countdown starts one isolated Codex app-server session. In
+that session, the App validates the selected account, reads the current opaque credit
+ID, and consumes that exact ID. A retry keeps the resolved ID and the same
+idempotency key. The session uses a short-lived file-auth copy for the selected
+account. The copy contains the current access token and a disabled refresh
+placeholder, not the managed refresh token. The action does not overwrite the user's
+normal Codex `auth.json`. Ambiguous duplicate cards and incomplete card-detail lists
+fail closed.
 
 App icon assets live under `assets/app-icon/` with `source/`, `composer/`, and
 `generated/` lanes. Menu bar icon assets live under `assets/tray-icon/` with matching

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -143,9 +143,6 @@ struct AccountPanelView: View {
 							await store.useInCodex(account)
 						}
 					},
-					prepareResetCredit: { preparation in
-						await store.prepareResetCredit(preparation, for: account)
-					},
 					consumeResetCredit: { attempt in
 						await store.consumeResetCredit(attempt, for: account)
 					},

--- a/apps/decodex-app/Sources/DecodexApp/AccountRowView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountRowView.swift
@@ -10,8 +10,7 @@ struct AccountRowView: View {
 	let logoutErrorMessage: String?
 	let usageRefillAnimation: AccountUsageRefillAnimation?
 	let useInCodex: () -> Void
-	let prepareResetCredit: (ResetCreditUsePreparation) async -> String?
-	let consumeResetCredit: (ResetCreditUseAttempt) async -> Bool
+	let consumeResetCredit: (ResetCreditUseAttempt) async -> ResetCreditUseCompletion
 	let routeRunsHere: () -> Void
 	let login: () -> Void
 	let logout: () -> Void
@@ -71,7 +70,6 @@ struct AccountRowView: View {
 				AccountUsageSummaryView(
 					account: account,
 					usageRefillAnimation: usageRefillAnimation,
-					prepareResetCredit: prepareResetCredit,
 					consumeResetCredit: consumeResetCredit
 				)
 					.transition(.panelInline)

--- a/apps/decodex-app/Sources/DecodexApp/AccountStoreActions.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountStoreActions.swift
@@ -119,52 +119,10 @@ extension AccountStore {
 		}
 	}
 
-	func prepareResetCredit(
-		_ preparation: ResetCreditUsePreparation,
-		for account: CodexAccount
-	) async -> String? {
-		guard preparation.target.accountID == account.accountFingerprint else {
-			presentError(
-				"Couldn’t prepare reset card",
-				error: ResetCreditUseError.accountChanged,
-				source: .resetCredit
-			)
-			return nil
-		}
-		guard await refreshAccountsForResetCredit() else {
-			return nil
-		}
-
-		do {
-			let codexHomeURL = try makeResetCreditCodexHome()
-			defer {
-				try? FileManager.default.removeItem(at: codexHomeURL)
-			}
-
-			let credentials = try await resetCreditCredentials(
-				for: account,
-				in: codexHomeURL
-			)
-			let codexExecutableURL = URL(fileURLWithPath: try bridge.codexExecutablePath())
-			let creditID = try await CodexResetCreditBridge().prepare(
-				codexExecutableURL: codexExecutableURL,
-				codexHomeURL: codexHomeURL,
-				credentials: credentials,
-				preparation: preparation
-			)
-
-			clearNotice(source: .resetCredit)
-			return creditID
-		} catch {
-			presentError("Couldn’t prepare reset card", error: error, source: .resetCredit)
-			return nil
-		}
-	}
-
 	func consumeResetCredit(
 		_ attempt: ResetCreditUseAttempt,
 		for account: CodexAccount
-	) async -> Bool {
+	) async -> ResetCreditUseCompletion {
 		cancelUsageRefillAnimation(for: account.accountFingerprint)
 		guard attempt.target.accountID == account.accountFingerprint else {
 			presentError(
@@ -172,15 +130,12 @@ extension AccountStore {
 				error: ResetCreditUseError.accountChanged,
 				source: .resetCredit
 			)
-			return false
-		}
-		guard await refreshAccountsForResetCredit() else {
-			return false
+			return ResetCreditUseCompletion(resolved: false, creditID: attempt.creditID)
 		}
 
 		do {
-			let freshAccount = try uniqueFreshResetCreditAccount(matching: account)
-			let refillAnimation = AccountUsageRefillAnimation.make(from: freshAccount)
+			let currentAccount = try uniqueResetCreditAccount(matching: account)
+			let refillAnimation = AccountUsageRefillAnimation.make(from: currentAccount)
 			let codexHomeURL = try makeResetCreditCodexHome()
 			defer {
 				try? FileManager.default.removeItem(at: codexHomeURL)
@@ -191,37 +146,39 @@ extension AccountStore {
 				in: codexHomeURL
 			)
 			let codexExecutableURL = URL(fileURLWithPath: try bridge.codexExecutablePath())
-			let outcome = try await CodexResetCreditBridge().consume(
+			let result = try await CodexResetCreditBridge().consume(
 				codexExecutableURL: codexExecutableURL,
 				codexHomeURL: codexHomeURL,
 				credentials: credentials,
 				attempt: attempt
 			)
 
-			if outcome == .reset {
+			if result.outcome == .reset {
 				beginUsageRefillAnimation(refillAnimation)
 			}
-			let refreshSucceeded = await refreshAccountsForResetCredit()
+			let refreshSucceeded = await refreshAccountsAfterResetCredit()
 			finishUsageRefillAnimation(
 				refillAnimation,
-				refreshSucceeded: outcome == .reset && refreshSucceeded
+				refreshSucceeded: result.outcome == .reset && refreshSucceeded
 			)
 			if refreshSucceeded {
-				presentNotice(.resetCreditOutcome(outcome))
+				presentNotice(.resetCreditOutcome(result.outcome))
 			} else {
 				let refreshError = notice?.copyText ?? "Account refresh failed."
-				presentNotice(.resetCreditOutcome(outcome, refreshError: refreshError))
+				presentNotice(.resetCreditOutcome(result.outcome, refreshError: refreshError))
 			}
-			return true
+			return ResetCreditUseCompletion(resolved: true, creditID: result.creditID)
 		} catch {
 			cancelUsageRefillAnimation(for: account.accountFingerprint)
-			_ = await refreshAccountsForResetCredit()
 			presentError("Couldn’t use reset card", error: error, source: .resetCredit)
-			return false
+			return ResetCreditUseCompletion(
+				resolved: false,
+				creditID: (error as? CodexResetCreditUseFailure)?.creditID ?? attempt.creditID
+			)
 		}
 	}
 
-	private func refreshAccountsForResetCredit() async -> Bool {
+	private func refreshAccountsAfterResetCredit() async -> Bool {
 		while isRefreshing {
 			guard Task.isCancelled == false else {
 				return false
@@ -237,7 +194,7 @@ extension AccountStore {
 		for account: CodexAccount,
 		in codexHomeURL: URL
 	) async throws -> CodexResetCreditCredentials {
-		let account = try uniqueFreshResetCreditAccount(matching: account)
+		let account = try uniqueResetCreditAccount(matching: account)
 		let expectedEmail = normalizedEmail(account.email)
 
 		let exportedAuthURL = codexHomeURL.appendingPathComponent("selected-account.json")
@@ -295,7 +252,7 @@ extension AccountStore {
 		return CodexResetCreditCredentials(expectedEmail: expectedEmail)
 	}
 
-	func uniqueFreshResetCreditAccount(matching account: CodexAccount) throws -> CodexAccount {
+	func uniqueResetCreditAccount(matching account: CodexAccount) throws -> CodexAccount {
 		let expectedEmail = normalizedEmail(account.email)
 		let matches = accounts.filter { candidate in
 			guard candidate.accountFingerprint == account.accountFingerprint else {

--- a/apps/decodex-app/Sources/DecodexApp/AccountUsageSummaryViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountUsageSummaryViews.swift
@@ -4,8 +4,7 @@ import SwiftUI
 struct AccountUsageSummaryView: View {
 	let account: CodexAccount
 	let usageRefillAnimation: AccountUsageRefillAnimation?
-	let prepareResetCredit: (ResetCreditUsePreparation) async -> String?
-	let consumeResetCredit: (ResetCreditUseAttempt) async -> Bool
+	let consumeResetCredit: (ResetCreditUseAttempt) async -> ResetCreditUseCompletion
 
 	var body: some View {
 		TimelineView(.periodic(from: Date(), by: 30)) { timeline in
@@ -18,7 +17,6 @@ struct AccountUsageSummaryView: View {
 				if account.hasResetCreditsSummary {
 					AccountResetCreditsSummaryView(
 						account: account,
-						prepareResetCredit: prepareResetCredit,
 						consumeResetCredit: consumeResetCredit
 					)
 						.transition(.panelInline)
@@ -73,8 +71,7 @@ struct AccountUsageSummaryView: View {
 
 struct AccountResetCreditsSummaryView: View {
 	let account: CodexAccount
-	let prepareResetCredit: (ResetCreditUsePreparation) async -> String?
-	let consumeResetCredit: (ResetCreditUseAttempt) async -> Bool
+	let consumeResetCredit: (ResetCreditUseAttempt) async -> ResetCreditUseCompletion
 	@Environment(\.colorScheme) private var colorScheme
 
 	var body: some View {
@@ -94,7 +91,6 @@ struct AccountResetCreditsSummaryView: View {
 
 			AccountResetCreditExpiryStripView(
 				account: account,
-				prepareResetCredit: prepareResetCredit,
 				consumeResetCredit: consumeResetCredit
 			)
 		}
@@ -114,8 +110,7 @@ struct AccountResetCreditExpiryStripView: View {
 	private static let confirmationWindowSeconds = 5
 
 	let account: CodexAccount
-	let prepareResetCredit: (ResetCreditUsePreparation) async -> String?
-	let consumeResetCredit: (ResetCreditUseAttempt) async -> Bool
+	let consumeResetCredit: (ResetCreditUseAttempt) async -> ResetCreditUseCompletion
 	@Environment(\.colorScheme) private var colorScheme
 	@State private var placementStore = AccountRunStripPlacementStore()
 	@State private var scrollProxy = AccountRunStripScrollProxy()
@@ -158,7 +153,7 @@ struct AccountResetCreditExpiryStripView: View {
 									placementStore: placementStore
 								)
 							)
-							.disabled(confirmation.isBusy)
+							.disabled(confirmation.isSubmitting)
 							.accessibilityLabel(resetCreditAccessibilityLabel(credit, target: target))
 							.accessibilityHint(resetCreditAccessibilityHint(target))
 							.help(resetCreditHelp(credit, target: target))
@@ -255,9 +250,6 @@ struct AccountResetCreditExpiryStripView: View {
 		_ expiryText: String,
 		target: ResetCreditUseTarget
 	) -> String {
-		if confirmation.isPreparing(target) {
-			return "Preparing"
-		}
 		if confirmation.isSubmitting(target) {
 			return "Using"
 		}
@@ -272,7 +264,7 @@ struct AccountResetCreditExpiryStripView: View {
 	}
 
 	private func resetCreditChipForeground(_ target: ResetCreditUseTarget) -> Color {
-		if confirmation.isPreparing(target) || confirmation.isArmed(target) {
+		if confirmation.isArmed(target) {
 			return PanelPalette.warning(colorScheme)
 		}
 
@@ -280,7 +272,7 @@ struct AccountResetCreditExpiryStripView: View {
 	}
 
 	private func resetCreditChipBackground(_ target: ResetCreditUseTarget) -> Color {
-		if confirmation.isPreparing(target) || confirmation.isArmed(target) {
+		if confirmation.isArmed(target) {
 			return PanelPalette.warning(colorScheme).opacity(colorScheme == .dark ? 0.2 : 0.14)
 		}
 
@@ -292,11 +284,6 @@ struct AccountResetCreditExpiryStripView: View {
 		target: ResetCreditUseTarget
 	) -> String {
 		let expiry = formatResetCreditDate(credit.expiresAtUnixEpoch)
-		if confirmation.isPreparing {
-			return confirmation.isPreparing(target)
-				? "Preparing reset card that expires \(expiry)"
-				: "Wait until the current reset-card request finishes."
-		}
 		if confirmation.isSubmitting {
 			return confirmation.isSubmitting(target)
 				? "Using reset card that expires \(expiry)"
@@ -306,7 +293,7 @@ struct AccountResetCreditExpiryStripView: View {
 			return "Click again within \(Self.confirmationWindowSeconds) seconds to use the reset card that expires \(expiry). Otherwise, confirmation cancels automatically."
 		}
 
-		return "Expires \(expiry). Click once to prepare this reset card."
+		return "Expires \(expiry). Click once to confirm use of this reset card."
 	}
 
 	private func resetCreditAccessibilityLabel(
@@ -314,9 +301,6 @@ struct AccountResetCreditExpiryStripView: View {
 		target: ResetCreditUseTarget
 	) -> String {
 		let expiry = formatResetCreditDate(credit.expiresAtUnixEpoch)
-		if confirmation.isPreparing(target) {
-			return "Preparing reset card that expires \(expiry)"
-		}
 		if confirmation.isSubmitting(target) {
 			return "Using reset card that expires \(expiry)"
 		}
@@ -331,11 +315,6 @@ struct AccountResetCreditExpiryStripView: View {
 	}
 
 	private func resetCreditAccessibilityHint(_ target: ResetCreditUseTarget) -> String {
-		if confirmation.isPreparing {
-			return confirmation.isPreparing(target)
-				? "The reset card is being prepared for confirmation."
-				: "Wait until the current reset-card request finishes."
-		}
 		if confirmation.isSubmitting {
 			return confirmation.isSubmitting(target)
 				? "The reset-card request is in progress."
@@ -344,7 +323,7 @@ struct AccountResetCreditExpiryStripView: View {
 
 		return confirmation.isArmed(target)
 			? "Activate again to use this reset card. Confirmation cancels automatically after \(Self.confirmationWindowSeconds) seconds."
-			: "Activate once to prepare this reset card."
+			: "Activate once to confirm use of this reset card."
 	}
 
 	@MainActor
@@ -404,21 +383,13 @@ struct AccountResetCreditExpiryStripView: View {
 	}
 
 	private func tapResetCredit(_ target: ResetCreditUseTarget) {
-		guard let action = confirmation.tap(target) else {
+		guard let attempt = confirmation.tap(target) else {
 			return
 		}
 
-		switch action {
-		case .prepare(let preparation):
-			Task {
-				let creditID = await prepareResetCredit(preparation)
-				confirmation.finishPreparation(preparation, creditID: creditID)
-			}
-		case .consume(let attempt):
-			Task {
-				let resolved = await consumeResetCredit(attempt)
-				confirmation.finish(attempt, resolved: resolved)
-			}
+		Task {
+			let completion = await consumeResetCredit(attempt)
+			confirmation.finish(attempt, completion: completion)
 		}
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/CodexResetCreditBridge.swift
+++ b/apps/decodex-app/Sources/DecodexApp/CodexResetCreditBridge.swift
@@ -41,6 +41,20 @@ struct CodexResetCreditCredentials: Sendable {
 	let expectedEmail: String?
 }
 
+struct CodexResetCreditConsumeResult: Sendable {
+	let outcome: ResetCreditConsumeOutcome
+	let creditID: String
+}
+
+struct CodexResetCreditUseFailure: LocalizedError, Sendable {
+	let creditID: String
+	let message: String
+
+	var errorDescription: String? {
+		message
+	}
+}
+
 struct CodexResetCreditBridge: Sendable {
 	private let environment: [String: String]
 	private let responseTimeout: TimeInterval
@@ -53,29 +67,12 @@ struct CodexResetCreditBridge: Sendable {
 		self.responseTimeout = responseTimeout
 	}
 
-	func prepare(
-		codexExecutableURL: URL,
-		codexHomeURL: URL,
-		credentials: CodexResetCreditCredentials,
-		preparation: ResetCreditUsePreparation
-	) async throws -> String {
-		try await Task.detached(priority: .userInitiated) {
-			try prepareSynchronously(
-				codexExecutableURL: codexExecutableURL,
-				codexHomeURL: codexHomeURL,
-				credentials: credentials,
-				preparation: preparation
-			)
-		}
-		.value
-	}
-
 	func consume(
 		codexExecutableURL: URL,
 		codexHomeURL: URL,
 		credentials: CodexResetCreditCredentials,
 		attempt: ResetCreditUseAttempt
-	) async throws -> ResetCreditConsumeOutcome {
+	) async throws -> CodexResetCreditConsumeResult {
 		try await Task.detached(priority: .userInitiated) {
 			try consumeSynchronously(
 				codexExecutableURL: codexExecutableURL,
@@ -122,48 +119,12 @@ struct CodexResetCreditBridge: Sendable {
 		return creditID
 	}
 
-	private func prepareSynchronously(
-		codexExecutableURL: URL,
-		codexHomeURL: URL,
-		credentials: CodexResetCreditCredentials,
-		preparation: ResetCreditUsePreparation
-	) throws -> String {
-		let session = try makeSession(
-			codexExecutableURL: codexExecutableURL,
-			codexHomeURL: codexHomeURL,
-			credentials: credentials
-		)
-		defer {
-			session.stop()
-		}
-
-		try bootstrap(
-			session: session,
-			codexHomeURL: codexHomeURL,
-			credentials: credentials
-		)
-		let rateLimits = try readRateLimits(session: session, requestID: 3)
-		guard let resetCredits = rateLimits.rateLimitResetCredits,
-			let credits = resetCredits.credits
-		else {
-			throw CodexResetCreditBridgeError.invalidResponse(
-				"reset-card details are unavailable"
-			)
-		}
-
-		return try resolveCreditID(
-			for: preparation.target,
-			availableCount: resetCredits.availableCount,
-			in: credits
-		)
-	}
-
 	private func consumeSynchronously(
 		codexExecutableURL: URL,
 		codexHomeURL: URL,
 		credentials: CodexResetCreditCredentials,
 		attempt: ResetCreditUseAttempt
-	) throws -> ResetCreditConsumeOutcome {
+	) throws -> CodexResetCreditConsumeResult {
 		let session = try makeSession(
 			codexExecutableURL: codexExecutableURL,
 			codexHomeURL: codexHomeURL,
@@ -178,31 +139,60 @@ struct CodexResetCreditBridge: Sendable {
 			codexHomeURL: codexHomeURL,
 			credentials: credentials
 		)
-		let creditID = attempt.creditID.trimmingCharacters(in: .whitespacesAndNewlines)
-		guard creditID.isEmpty == false else {
-			throw CodexResetCreditBridgeError.invalidResponse(
-				"the selected reset card has no identifier"
+		let creditID: String
+		if let existingCreditID = normalizedCreditID(attempt.creditID) {
+			creditID = existingCreditID
+		} else {
+			let rateLimits = try readRateLimits(session: session, requestID: 3)
+			guard let resetCredits = rateLimits.rateLimitResetCredits,
+				let credits = resetCredits.credits
+			else {
+				throw CodexResetCreditBridgeError.invalidResponse(
+					"reset-card details are unavailable"
+				)
+			}
+
+			creditID = try resolveCreditID(
+				for: attempt.target,
+				availableCount: resetCredits.availableCount,
+				in: credits
 			)
 		}
 
-		try session.sendRequest(
-			id: 3,
-			method: "account/rateLimitResetCredit/consume",
-			params: [
-				"creditId": creditID,
-				"idempotencyKey": attempt.idempotencyKey,
-			]
-		)
-		let response = try session.readResponse(
-			id: 3,
-			as: CodexConsumeResetCreditResponse.self
-		)
+		do {
+			try session.sendRequest(
+				id: 4,
+				method: "account/rateLimitResetCredit/consume",
+				params: [
+					"creditId": creditID,
+					"idempotencyKey": attempt.idempotencyKey,
+				]
+			)
+			let response = try session.readResponse(
+				id: 4,
+				as: CodexConsumeResetCreditResponse.self
+			)
 
-		if response.outcome == .reset || response.outcome == .alreadyRedeemed {
-			_ = try readRateLimits(session: session, requestID: 4)
+			return CodexResetCreditConsumeResult(
+				outcome: response.outcome,
+				creditID: creditID
+			)
+		} catch {
+			throw CodexResetCreditUseFailure(
+				creditID: creditID,
+				message: error.localizedDescription
+			)
+		}
+	}
+
+	private func normalizedCreditID(_ value: String?) -> String? {
+		guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+			value.isEmpty == false
+		else {
+			return nil
 		}
 
-		return response.outcome
+		return value
 	}
 
 	private func makeSession(

--- a/apps/decodex-app/Sources/DecodexApp/ResetCreditUse.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCreditUse.swift
@@ -46,26 +46,27 @@ struct ResetCreditUseTarget: Hashable, Sendable {
 	}
 }
 
-struct ResetCreditUsePreparation: Equatable, Sendable {
-	let target: ResetCreditUseTarget
-	let idempotencyKey: String
-}
-
 struct ResetCreditUseAttempt: Equatable, Sendable {
 	let target: ResetCreditUseTarget
-	let creditID: String
 	let idempotencyKey: String
+	let creditID: String?
+
+	func resolvingCreditID(_ creditID: String) -> ResetCreditUseAttempt {
+		ResetCreditUseAttempt(
+			target: target,
+			idempotencyKey: idempotencyKey,
+			creditID: creditID
+		)
+	}
 }
 
-enum ResetCreditUseAction: Equatable, Sendable {
-	case prepare(ResetCreditUsePreparation)
-	case consume(ResetCreditUseAttempt)
+struct ResetCreditUseCompletion: Equatable, Sendable {
+	let resolved: Bool
+	let creditID: String?
 }
 
 struct ResetCreditUseConfirmation: Equatable {
-	private(set) var pendingPreparation: ResetCreditUsePreparation?
 	private(set) var armedAttempt: ResetCreditUseAttempt?
-	private(set) var isPreparing = false
 	private(set) var isSubmitting = false
 
 	func isArmed(_ target: ResetCreditUseTarget) -> Bool {
@@ -76,78 +77,51 @@ struct ResetCreditUseConfirmation: Equatable {
 		armedAttempt == attempt
 	}
 
-	func isPreparing(_ target: ResetCreditUseTarget) -> Bool {
-		isPreparing && pendingPreparation?.target == target
-	}
-
 	func isSubmitting(_ target: ResetCreditUseTarget) -> Bool {
 		isSubmitting && isArmed(target)
-	}
-
-	var isBusy: Bool {
-		isPreparing || isSubmitting
 	}
 
 	mutating func tap(
 		_ target: ResetCreditUseTarget,
 		makeIdempotencyKey: () -> String = { UUID().uuidString }
-	) -> ResetCreditUseAction? {
-		guard isBusy == false else {
+	) -> ResetCreditUseAttempt? {
+		guard isSubmitting == false else {
 			return nil
 		}
 
 		if let armedAttempt, armedAttempt.target == target {
 			isSubmitting = true
-			return .consume(armedAttempt)
+			return armedAttempt
 		}
 
-		let preparation = ResetCreditUsePreparation(
+		armedAttempt = ResetCreditUseAttempt(
 			target: target,
-			idempotencyKey: makeIdempotencyKey()
+			idempotencyKey: makeIdempotencyKey(),
+			creditID: nil
 		)
-		pendingPreparation = preparation
-		armedAttempt = nil
-		isPreparing = true
 
-		return .prepare(preparation)
+		return nil
 	}
 
-	@discardableResult
-	mutating func finishPreparation(
-		_ preparation: ResetCreditUsePreparation,
-		creditID: String?
-	) -> ResetCreditUseAttempt? {
-		guard pendingPreparation == preparation else {
-			return nil
-		}
-
-		pendingPreparation = nil
-		isPreparing = false
-
-		guard let creditID = creditID?
-			.trimmingCharacters(in: .whitespacesAndNewlines),
-			creditID.isEmpty == false
-		else {
-			return nil
-		}
-
-		let attempt = ResetCreditUseAttempt(
-			target: preparation.target,
-			creditID: creditID,
-			idempotencyKey: preparation.idempotencyKey
-		)
-		armedAttempt = attempt
-		return attempt
-	}
-
-	mutating func finish(_ attempt: ResetCreditUseAttempt, resolved: Bool) {
+	mutating func finish(
+		_ attempt: ResetCreditUseAttempt,
+		completion: ResetCreditUseCompletion
+	) {
 		guard armedAttempt == attempt else {
 			return
 		}
 
 		isSubmitting = false
-		if resolved {
+		if completion.resolved {
 			armedAttempt = nil
+			return
+		}
+
+		if let creditID = completion.creditID?
+			.trimmingCharacters(in: .whitespacesAndNewlines),
+			creditID.isEmpty == false
+		{
+			armedAttempt = attempt.resolvingCreditID(creditID)
 		}
 	}
 
@@ -166,22 +140,16 @@ struct ResetCreditUseConfirmation: Equatable {
 			return
 		}
 
-		pendingPreparation = nil
 		armedAttempt = nil
-		isPreparing = false
 	}
 
 	mutating func retainOnly(_ targets: Set<ResetCreditUseTarget>) {
-		if let armedAttempt, targets.contains(armedAttempt.target) == false {
-			self.armedAttempt = nil
-			isSubmitting = false
+		guard isSubmitting == false else {
+			return
 		}
 
-		if let pendingPreparation,
-			targets.contains(pendingPreparation.target) == false
-		{
-			self.pendingPreparation = nil
-			isPreparing = false
+		if let armedAttempt, targets.contains(armedAttempt.target) == false {
+			self.armedAttempt = nil
 		}
 	}
 }

--- a/apps/decodex-app/Tests/DecodexAppTests/CodexResetCreditBridgeTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/CodexResetCreditBridgeTests.swift
@@ -95,7 +95,7 @@ final class CodexResetCreditBridgeTests: XCTestCase {
 		)
 	}
 
-	func testPreparationArmsTheExactCurrentCreditThroughExternalAuth() async throws {
+	func testConsumeReadsFreshCardsThenUsesTheExactCurrentIDInOneSession() async throws {
 		let fixture = try makeFixture(
 			scriptBody: """
 			IFS= read -r line || exit 10
@@ -109,30 +109,39 @@ final class CodexResetCreditBridgeTests: XCTestCase {
 			IFS= read -r line || exit 13
 			printf '%s\\n' "$line" >> '__LOG_PATH__'
 			printf '%s\\n' '{"jsonrpc":"2.0","id":3,"result":{"rateLimits":{},"rateLimitResetCredits":{"availableCount":2,"credits":[{"id":"credit-a","grantedAt":100,"expiresAt":300,"resetType":"codexRateLimits","status":"available"},{"id":"credit-b","grantedAt":100,"expiresAt":200,"resetType":"codexRateLimits","status":"available"}]}}}'
+			IFS= read -r line || exit 14
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":4,"result":{"outcome":"reset"}}'
 			"""
 		)
 		defer { fixture.remove() }
 
-		let preparation = ResetCreditUsePreparation(
-			target: makeTarget(),
-			idempotencyKey: "attempt-1"
-		)
-		let creditID = try await CodexResetCreditBridge(responseTimeout: 2).prepare(
+		let result = try await CodexResetCreditBridge(responseTimeout: 2).consume(
 			codexExecutableURL: fixture.executableURL,
 			codexHomeURL: fixture.codexHomeURL,
 			credentials: credentials,
-			preparation: preparation
+			attempt: makeAttempt()
 		)
 
-		XCTAssertEqual(creditID, "credit-b")
+		XCTAssertEqual(result.outcome, .reset)
+		XCTAssertEqual(result.creditID, "credit-b")
 		let messages = try readMessages(from: fixture.logURL)
-		XCTAssertEqual(messages.count, 4)
+		XCTAssertEqual(messages.count, 5)
 		try assertBootstrap(messages)
 		XCTAssertEqual(messages[3]["method"] as? String, "account/rateLimits/read")
 		XCTAssertNil(messages[3]["params"])
+		let consume = messages[4]
+		XCTAssertEqual(
+			consume["method"] as? String,
+			"account/rateLimitResetCredit/consume"
+		)
+		let params = try XCTUnwrap(consume["params"] as? [String: Any])
+		XCTAssertEqual(params["creditId"] as? String, "credit-b")
+		XCTAssertEqual(params["idempotencyKey"] as? String, "attempt-1")
+		XCTAssertEqual(try fixture.launchCount(), 1)
 	}
 
-	func testPreparationAcceptsAnEmailLessBoundAccount() async throws {
+	func testConsumeAcceptsAnEmailLessBoundAccount() async throws {
 		let fixture = try makeFixture(
 			scriptBody: """
 			IFS= read -r line || exit 10
@@ -146,24 +155,25 @@ final class CodexResetCreditBridgeTests: XCTestCase {
 			IFS= read -r line || exit 13
 			printf '%s\\n' "$line" >> '__LOG_PATH__'
 			printf '%s\\n' '{"jsonrpc":"2.0","id":3,"result":{"rateLimits":{},"rateLimitResetCredits":{"availableCount":1,"credits":[{"id":"credit-b","grantedAt":100,"expiresAt":200,"resetType":"codexRateLimits","status":"available"}]}}}'
+			IFS= read -r line || exit 14
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":4,"result":{"outcome":"nothingToReset"}}'
 			"""
 		)
 		defer { fixture.remove() }
 
-		let creditID = try await CodexResetCreditBridge(responseTimeout: 2).prepare(
+		let result = try await CodexResetCreditBridge(responseTimeout: 2).consume(
 			codexExecutableURL: fixture.executableURL,
 			codexHomeURL: fixture.codexHomeURL,
 			credentials: CodexResetCreditCredentials(expectedEmail: nil),
-			preparation: ResetCreditUsePreparation(
-				target: makeTarget(),
-				idempotencyKey: "attempt-1"
-			)
+			attempt: makeAttempt()
 		)
 
-		XCTAssertEqual(creditID, "credit-b")
+		XCTAssertEqual(result.outcome, .nothingToReset)
+		XCTAssertEqual(result.creditID, "credit-b")
 	}
 
-	func testConsumeReusesTheArmedCreditIDWithoutOrdinalRemapping() async throws {
+	func testConsumeRejectsChangedCardsBeforeMutation() async throws {
 		let fixture = try makeFixture(
 			scriptBody: """
 			IFS= read -r line || exit 10
@@ -176,31 +186,67 @@ final class CodexResetCreditBridgeTests: XCTestCase {
 			printf '%s\\n' '{"jsonrpc":"2.0","id":2,"result":{"account":{"type":"chatgpt","email":"copy@example.com","planType":"pro"},"requiresOpenaiAuth":true}}'
 			IFS= read -r line || exit 13
 			printf '%s\\n' "$line" >> '__LOG_PATH__'
-			printf '%s\\n' '{"jsonrpc":"2.0","id":3,"result":{"outcome":"reset"}}'
-			IFS= read -r line || exit 14
-			printf '%s\\n' "$line" >> '__LOG_PATH__'
-			printf '%s\\n' '{"jsonrpc":"2.0","id":4,"result":{"rateLimits":{},"rateLimitResetCredits":{"availableCount":1,"credits":[]}}}'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":3,"result":{"rateLimits":{},"rateLimitResetCredits":{"availableCount":1,"credits":[{"id":"credit-a","grantedAt":100,"expiresAt":300,"resetType":"codexRateLimits","status":"available"}]}}}'
 			"""
 		)
 		defer { fixture.remove() }
 
-		let attempt = ResetCreditUseAttempt(
-			target: makeTarget(),
-			creditID: "credit-b",
-			idempotencyKey: "attempt-1"
+		do {
+			_ = try await CodexResetCreditBridge(responseTimeout: 2).consume(
+				codexExecutableURL: fixture.executableURL,
+				codexHomeURL: fixture.codexHomeURL,
+				credentials: credentials,
+				attempt: makeAttempt()
+			)
+			XCTFail("Changed reset cards should fail before consume.")
+		} catch {
+			XCTAssertEqual(
+				error.localizedDescription,
+				"The reset cards changed. Refresh and try again."
+			)
+		}
+
+		let messages = try readMessages(from: fixture.logURL)
+		XCTAssertEqual(messages.count, 4)
+		try assertBootstrap(messages)
+		XCTAssertEqual(messages[3]["method"] as? String, "account/rateLimits/read")
+		XCTAssertFalse(
+			messages.contains {
+				$0["method"] as? String == "account/rateLimitResetCredit/consume"
+			}
 		)
-		let outcome = try await CodexResetCreditBridge(responseTimeout: 2).consume(
+	}
+
+	func testRetryUsesTheResolvedCreditWithoutRemapping() async throws {
+		let fixture = try makeFixture(
+			scriptBody: """
+			IFS= read -r line || exit 10
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '{"jsonrpc":"2.0","id":1,"result":{"codexHome":"%s","platformFamily":"unix","platformOs":"macos","userAgent":"fake"}}\\n' "$CODEX_HOME"
+			IFS= read -r line || exit 11
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			IFS= read -r line || exit 12
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":2,"result":{"account":{"type":"chatgpt","email":"copy@example.com","planType":"pro"},"requiresOpenaiAuth":true}}'
+			IFS= read -r line || exit 13
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":4,"result":{"outcome":"alreadyRedeemed"}}'
+			"""
+		)
+		defer { fixture.remove() }
+
+		let result = try await CodexResetCreditBridge(responseTimeout: 2).consume(
 			codexExecutableURL: fixture.executableURL,
 			codexHomeURL: fixture.codexHomeURL,
 			credentials: credentials,
-			attempt: attempt
+			attempt: makeAttempt(creditID: "credit-b")
 		)
 
-		XCTAssertEqual(outcome, .reset)
+		XCTAssertEqual(result.outcome, .alreadyRedeemed)
+		XCTAssertEqual(result.creditID, "credit-b")
 		let messages = try readMessages(from: fixture.logURL)
-		XCTAssertEqual(messages.count, 5)
+		XCTAssertEqual(messages.count, 4)
 		try assertBootstrap(messages)
-
 		let consume = messages[3]
 		XCTAssertEqual(
 			consume["method"] as? String,
@@ -209,7 +255,43 @@ final class CodexResetCreditBridgeTests: XCTestCase {
 		let params = try XCTUnwrap(consume["params"] as? [String: Any])
 		XCTAssertEqual(params["creditId"] as? String, "credit-b")
 		XCTAssertEqual(params["idempotencyKey"] as? String, "attempt-1")
-		XCTAssertEqual(messages[4]["method"] as? String, "account/rateLimits/read")
+		XCTAssertFalse(
+			messages.contains { $0["method"] as? String == "account/rateLimits/read" }
+		)
+	}
+
+	func testConsumeFailureRetainsTheResolvedCreditForRetry() async throws {
+		let fixture = try makeFixture(
+			scriptBody: """
+			IFS= read -r line || exit 10
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '{"jsonrpc":"2.0","id":1,"result":{"codexHome":"%s","platformFamily":"unix","platformOs":"macos","userAgent":"fake"}}\\n' "$CODEX_HOME"
+			IFS= read -r line || exit 11
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			IFS= read -r line || exit 12
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":2,"result":{"account":{"type":"chatgpt","email":"copy@example.com","planType":"pro"},"requiresOpenaiAuth":true}}'
+			IFS= read -r line || exit 13
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			printf '%s\\n' '{"jsonrpc":"2.0","id":3,"result":{"rateLimits":{},"rateLimitResetCredits":{"availableCount":1,"credits":[{"id":"credit-b","grantedAt":100,"expiresAt":200,"resetType":"codexRateLimits","status":"available"}]}}}'
+			IFS= read -r line || exit 14
+			printf '%s\\n' "$line" >> '__LOG_PATH__'
+			exit 15
+			"""
+		)
+		defer { fixture.remove() }
+
+		do {
+			_ = try await CodexResetCreditBridge(responseTimeout: 2).consume(
+				codexExecutableURL: fixture.executableURL,
+				codexHomeURL: fixture.codexHomeURL,
+				credentials: credentials,
+				attempt: makeAttempt()
+			)
+			XCTFail("A missing consume response should fail.")
+		} catch let error as CodexResetCreditUseFailure {
+			XCTAssertEqual(error.creditID, "credit-b")
+		}
 	}
 
 	private var credentials: CodexResetCreditCredentials {
@@ -264,6 +346,14 @@ final class CodexResetCreditBridgeTests: XCTestCase {
 		)
 	}
 
+	private func makeAttempt(creditID: String? = nil) -> ResetCreditUseAttempt {
+		ResetCreditUseAttempt(
+			target: makeTarget(),
+			idempotencyKey: "attempt-1",
+			creditID: creditID
+		)
+	}
+
 	private func makeCredit(
 		id: String,
 		grantedAt: Int,
@@ -285,6 +375,7 @@ final class CodexResetCreditBridgeTests: XCTestCase {
 		let codexHomeURL = directoryURL.appendingPathComponent("codex-home", isDirectory: true)
 		let executableURL = directoryURL.appendingPathComponent("fake-codex")
 		let logURL = directoryURL.appendingPathComponent("requests.jsonl")
+		let launchLogURL = directoryURL.appendingPathComponent("launches.log")
 		try FileManager.default.createDirectory(
 			at: codexHomeURL,
 			withIntermediateDirectories: true
@@ -292,6 +383,7 @@ final class CodexResetCreditBridgeTests: XCTestCase {
 
 		let script = """
 		#!/bin/sh
+		printf '%s\\n' "$$" >> '\(launchLogURL.path)'
 		[ -z "$CODEX_ACCESS_TOKEN" ] || exit 9
 		[ -z "$OPENAI_API_KEY" ] || exit 8
 		[ "$1" = "app-server" ] || exit 7
@@ -310,7 +402,8 @@ final class CodexResetCreditBridgeTests: XCTestCase {
 			directoryURL: directoryURL,
 			codexHomeURL: codexHomeURL,
 			executableURL: executableURL,
-			logURL: logURL
+			logURL: logURL,
+			launchLogURL: launchLogURL
 		)
 	}
 
@@ -331,6 +424,13 @@ private struct AppServerFixture {
 	let codexHomeURL: URL
 	let executableURL: URL
 	let logURL: URL
+	let launchLogURL: URL
+
+	func launchCount() throws -> Int {
+		try String(contentsOf: launchLogURL, encoding: .utf8)
+			.split(separator: "\n")
+			.count
+	}
 
 	func remove() {
 		try? FileManager.default.removeItem(at: directoryURL)

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCreditAuthStagingTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCreditAuthStagingTests.swift
@@ -33,7 +33,7 @@ final class ResetCreditAuthStagingTests: XCTestCase {
 	}
 
 	@MainActor
-	func testFreshAccountBindingRejectsAnAmbiguousEmailLessFingerprint() throws {
+	func testCurrentAccountBindingRejectsAnAmbiguousEmailLessFingerprint() throws {
 		let target = try makeAccount(
 			fingerprint: "...123456",
 			email: nil,
@@ -49,7 +49,7 @@ final class ResetCreditAuthStagingTests: XCTestCase {
 			),
 		])
 
-		XCTAssertThrowsError(try store.uniqueFreshResetCreditAccount(matching: target)) { error in
+		XCTAssertThrowsError(try store.uniqueResetCreditAccount(matching: target)) { error in
 			XCTAssertEqual(
 				error.localizedDescription,
 				"More than one stored account matches this reset card. Remove the duplicate account and try again."
@@ -58,7 +58,7 @@ final class ResetCreditAuthStagingTests: XCTestCase {
 	}
 
 	@MainActor
-	func testFreshAccountBindingAllowsAUniqueEmailLessFingerprint() throws {
+	func testCurrentAccountBindingAllowsAUniqueEmailLessFingerprint() throws {
 		let target = try makeAccount(
 			fingerprint: "...123456",
 			email: nil,
@@ -68,13 +68,13 @@ final class ResetCreditAuthStagingTests: XCTestCase {
 		store.accountList = makeAccountList([target])
 
 		XCTAssertEqual(
-			try store.uniqueFreshResetCreditAccount(matching: target),
+			try store.uniqueResetCreditAccount(matching: target),
 			target
 		)
 	}
 
 	@MainActor
-	func testFreshAccountBindingUsesNormalizedEmailWithTheFingerprint() throws {
+	func testCurrentAccountBindingUsesNormalizedEmailWithTheFingerprint() throws {
 		let target = try makeAccount(
 			fingerprint: "...123456",
 			email: " COPY@example.com ",
@@ -96,13 +96,13 @@ final class ResetCreditAuthStagingTests: XCTestCase {
 		])
 
 		XCTAssertEqual(
-			try store.uniqueFreshResetCreditAccount(matching: target),
+			try store.uniqueResetCreditAccount(matching: target),
 			expected
 		)
 	}
 
 	@MainActor
-	func testFreshAccountBindingRejectsAMissingAccount() throws {
+	func testCurrentAccountBindingRejectsAMissingAccount() throws {
 		let target = try makeAccount(
 			fingerprint: "...123456",
 			email: nil,
@@ -111,7 +111,7 @@ final class ResetCreditAuthStagingTests: XCTestCase {
 		let store = AccountStore()
 		store.accountList = makeAccountList([])
 
-		XCTAssertThrowsError(try store.uniqueFreshResetCreditAccount(matching: target)) { error in
+		XCTAssertThrowsError(try store.uniqueResetCreditAccount(matching: target)) { error in
 			XCTAssertEqual(
 				error.localizedDescription,
 				"The account changed. Refresh and try again."

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCreditUseConfirmationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCreditUseConfirmationTests.swift
@@ -2,64 +2,74 @@
 import XCTest
 
 final class ResetCreditUseConfirmationTests: XCTestCase {
-	func testFirstTapPreparesAndSecondTapConsumesTheExactArmedCredit() throws {
+	func testFirstTapArmsImmediatelyAndSecondTapSubmitsTheSameAttempt() throws {
 		let target = makeTarget(accountID: "account-a", expiresAt: 200)
 		var confirmation = ResetCreditUseConfirmation()
 
-		let preparation = try unwrapPreparation(
+		XCTAssertNil(
 			confirmation.tap(target, makeIdempotencyKey: { "attempt-1" })
 		)
-		XCTAssertTrue(confirmation.isPreparing(target))
-		XCTAssertFalse(confirmation.isArmed(target))
-
-		confirmation.finishPreparation(preparation, creditID: "credit-1")
-		XCTAssertFalse(confirmation.isPreparing(target))
 		XCTAssertTrue(confirmation.isArmed(target))
+		XCTAssertFalse(confirmation.isSubmitting)
+		XCTAssertEqual(confirmation.armedAttempt?.idempotencyKey, "attempt-1")
+		XCTAssertNil(confirmation.armedAttempt?.creditID)
 
-		let attempt = try unwrapAttempt(
+		let attempt = try XCTUnwrap(
 			confirmation.tap(target, makeIdempotencyKey: { "unexpected-key" })
 		)
-		XCTAssertEqual(attempt.creditID, "credit-1")
+
+		XCTAssertEqual(attempt.target, target)
 		XCTAssertEqual(attempt.idempotencyKey, "attempt-1")
+		XCTAssertNil(attempt.creditID)
 		XCTAssertTrue(confirmation.isSubmitting(target))
 	}
 
-	func testFailedPreparationDisarmsTheCard() throws {
+	func testUnresolvedAttemptRetainsResolvedCreditAndIdempotencyKey() throws {
 		let target = makeTarget(accountID: "account-a", expiresAt: 200)
 		var confirmation = ResetCreditUseConfirmation()
-
-		let preparation = try unwrapPreparation(confirmation.tap(target))
-		confirmation.finishPreparation(preparation, creditID: nil)
-
-		XCTAssertFalse(confirmation.isPreparing(target))
-		XCTAssertFalse(confirmation.isArmed(target))
-		XCTAssertFalse(confirmation.isBusy)
-	}
-
-	func testUnresolvedConsumeRetainsExactCreditAndIdempotencyKey() throws {
-		let target = makeTarget(accountID: "account-a", expiresAt: 200)
-		var confirmation = ResetCreditUseConfirmation()
-		let preparation = try unwrapPreparation(
+		XCTAssertNil(
 			confirmation.tap(target, makeIdempotencyKey: { "attempt-1" })
 		)
-		confirmation.finishPreparation(preparation, creditID: "credit-1")
+		let firstAttempt = try XCTUnwrap(confirmation.tap(target))
 
-		let firstAttempt = try unwrapAttempt(confirmation.tap(target))
-		confirmation.finish(firstAttempt, resolved: false)
-		let retry = try unwrapAttempt(confirmation.tap(target))
+		confirmation.finish(
+			firstAttempt,
+			completion: ResetCreditUseCompletion(resolved: false, creditID: "credit-1")
+		)
+		let retry = try XCTUnwrap(confirmation.tap(target))
 
 		XCTAssertEqual(retry.creditID, "credit-1")
+		XCTAssertEqual(retry.idempotencyKey, "attempt-1")
+	}
+
+	func testFailureBeforeResolutionRetainsTheOriginalAttempt() throws {
+		let target = makeTarget(accountID: "account-a", expiresAt: 200)
+		var confirmation = ResetCreditUseConfirmation()
+		XCTAssertNil(
+			confirmation.tap(target, makeIdempotencyKey: { "attempt-1" })
+		)
+		let firstAttempt = try XCTUnwrap(confirmation.tap(target))
+
+		confirmation.finish(
+			firstAttempt,
+			completion: ResetCreditUseCompletion(resolved: false, creditID: nil)
+		)
+		let retry = try XCTUnwrap(confirmation.tap(target))
+
+		XCTAssertNil(retry.creditID)
 		XCTAssertEqual(retry.idempotencyKey, "attempt-1")
 	}
 
 	func testResolvedAttemptDisarmsTheCard() throws {
 		let target = makeTarget(accountID: "account-a", expiresAt: 200)
 		var confirmation = ResetCreditUseConfirmation()
-		let preparation = try unwrapPreparation(confirmation.tap(target))
-		confirmation.finishPreparation(preparation, creditID: "credit-1")
+		XCTAssertNil(confirmation.tap(target))
+		let attempt = try XCTUnwrap(confirmation.tap(target))
 
-		let attempt = try unwrapAttempt(confirmation.tap(target))
-		confirmation.finish(attempt, resolved: true)
+		confirmation.finish(
+			attempt,
+			completion: ResetCreditUseCompletion(resolved: true, creditID: "credit-1")
+		)
 
 		XCTAssertFalse(confirmation.isArmed(target))
 		XCTAssertFalse(confirmation.isSubmitting(target))
@@ -68,10 +78,8 @@ final class ResetCreditUseConfirmationTests: XCTestCase {
 	func testConfirmationWindowCanDisarmTheExactAttempt() throws {
 		let target = makeTarget(accountID: "account-a", expiresAt: 200)
 		var confirmation = ResetCreditUseConfirmation()
-		let preparation = try unwrapPreparation(confirmation.tap(target))
-		let attempt = try XCTUnwrap(
-			confirmation.finishPreparation(preparation, creditID: "credit-1")
-		)
+		XCTAssertNil(confirmation.tap(target))
+		let attempt = try XCTUnwrap(confirmation.armedAttempt)
 
 		XCTAssertTrue(confirmation.disarm(attempt))
 		XCTAssertFalse(confirmation.isArmed(target))
@@ -81,62 +89,89 @@ final class ResetCreditUseConfirmationTests: XCTestCase {
 		let first = makeTarget(accountID: "account-a", expiresAt: 200)
 		let second = makeTarget(accountID: "account-a", expiresAt: 300)
 		var confirmation = ResetCreditUseConfirmation()
-		let firstPreparation = try unwrapPreparation(confirmation.tap(first))
-		let staleAttempt = try XCTUnwrap(
-			confirmation.finishPreparation(firstPreparation, creditID: "credit-1")
+		XCTAssertNil(
+			confirmation.tap(first, makeIdempotencyKey: { "attempt-1" })
 		)
-		let secondPreparation = try unwrapPreparation(confirmation.tap(second))
-		let currentAttempt = try XCTUnwrap(
-			confirmation.finishPreparation(secondPreparation, creditID: "credit-2")
+		let staleAttempt = try XCTUnwrap(confirmation.armedAttempt)
+		XCTAssertNil(
+			confirmation.tap(second, makeIdempotencyKey: { "attempt-2" })
 		)
+		let currentAttempt = try XCTUnwrap(confirmation.armedAttempt)
 
 		XCTAssertFalse(confirmation.disarm(staleAttempt))
 		XCTAssertTrue(confirmation.isArmed(currentAttempt))
 	}
 
-	func testClosingThePanelCancelsPreparationAndPreventsLateArming() throws {
+	func testClosingThePanelCancelsConfirmation() {
 		let target = makeTarget(accountID: "account-a", expiresAt: 200)
 		var confirmation = ResetCreditUseConfirmation()
-		let preparation = try unwrapPreparation(confirmation.tap(target))
+		XCTAssertNil(confirmation.tap(target))
 
 		confirmation.cancelPendingConfirmation()
-		let attempt = confirmation.finishPreparation(preparation, creditID: "credit-1")
 
-		XCTAssertNil(attempt)
-		XCTAssertFalse(confirmation.isPreparing(target))
 		XCTAssertFalse(confirmation.isArmed(target))
+		XCTAssertFalse(confirmation.isSubmitting)
 	}
 
-	func testTappingAnotherCardStartsASeparatePreparation() throws {
+	func testTappingAnotherCardImmediatelyMovesConfirmation() throws {
 		let first = makeTarget(accountID: "account-a", expiresAt: 200)
 		let second = makeTarget(accountID: "account-a", expiresAt: 300)
 		var confirmation = ResetCreditUseConfirmation()
-		let firstPreparation = try unwrapPreparation(
+		XCTAssertNil(
 			confirmation.tap(first, makeIdempotencyKey: { "attempt-1" })
 		)
-		confirmation.finishPreparation(firstPreparation, creditID: "credit-1")
 
-		let secondPreparation = try unwrapPreparation(
+		XCTAssertNil(
 			confirmation.tap(second, makeIdempotencyKey: { "attempt-2" })
 		)
 
 		XCTAssertFalse(confirmation.isArmed(first))
-		XCTAssertTrue(confirmation.isPreparing(second))
-		XCTAssertEqual(secondPreparation.idempotencyKey, "attempt-2")
+		XCTAssertTrue(confirmation.isArmed(second))
+		XCTAssertEqual(confirmation.armedAttempt?.idempotencyKey, "attempt-2")
 	}
 
-	func testRemovedCardClearsPreparationAndConfirmation() throws {
-		let target = makeTarget(accountID: "account-a", expiresAt: 200)
-		var preparing = ResetCreditUseConfirmation()
-		_ = try unwrapPreparation(preparing.tap(target))
-		preparing.retainOnly([])
-		XCTAssertFalse(preparing.isBusy)
+	func testSubmittingAttemptIgnoresOtherCardTaps() throws {
+		let first = makeTarget(accountID: "account-a", expiresAt: 200)
+		let second = makeTarget(accountID: "account-a", expiresAt: 300)
+		var confirmation = ResetCreditUseConfirmation()
+		XCTAssertNil(confirmation.tap(first))
+		let attempt = try XCTUnwrap(confirmation.tap(first))
 
-		var armed = ResetCreditUseConfirmation()
-		let preparation = try unwrapPreparation(armed.tap(target))
-		armed.finishPreparation(preparation, creditID: "credit-1")
-		armed.retainOnly([])
-		XCTAssertFalse(armed.isArmed(target))
+		XCTAssertNil(confirmation.tap(second))
+		XCTAssertTrue(confirmation.isSubmitting(first))
+		XCTAssertTrue(confirmation.isArmed(attempt))
+		XCTAssertFalse(confirmation.isArmed(second))
+	}
+
+	func testRemovedCardClearsConfirmation() {
+		let target = makeTarget(accountID: "account-a", expiresAt: 200)
+		var confirmation = ResetCreditUseConfirmation()
+		XCTAssertNil(confirmation.tap(target))
+
+		confirmation.retainOnly([])
+
+		XCTAssertFalse(confirmation.isArmed(target))
+		XCTAssertFalse(confirmation.isSubmitting)
+	}
+
+	func testSubmittingAttemptSurvivesTargetRemovalUntilItFinishes() throws {
+		let target = makeTarget(accountID: "account-a", expiresAt: 200)
+		var confirmation = ResetCreditUseConfirmation()
+		XCTAssertNil(confirmation.tap(target))
+		let attempt = try XCTUnwrap(confirmation.tap(target))
+
+		confirmation.retainOnly([])
+
+		XCTAssertTrue(confirmation.isArmed(attempt))
+		XCTAssertTrue(confirmation.isSubmitting(target))
+
+		confirmation.finish(
+			attempt,
+			completion: ResetCreditUseCompletion(resolved: true, creditID: "credit-1")
+		)
+
+		XCTAssertFalse(confirmation.isArmed(target))
+		XCTAssertFalse(confirmation.isSubmitting)
 	}
 
 	func testTargetsDistinguishDuplicateCardsByOccurrence() {
@@ -157,32 +192,6 @@ final class ResetCreditUseConfirmationTests: XCTestCase {
 		XCTAssertEqual(Set(targets).count, 2)
 	}
 
-	private func unwrapPreparation(
-		_ action: ResetCreditUseAction?,
-		file: StaticString = #filePath,
-		line: UInt = #line
-	) throws -> ResetCreditUsePreparation {
-		guard case .prepare(let preparation) = try XCTUnwrap(action, file: file, line: line) else {
-			XCTFail("Expected a prepare action.", file: file, line: line)
-			throw TestFailure.unexpectedAction
-		}
-
-		return preparation
-	}
-
-	private func unwrapAttempt(
-		_ action: ResetCreditUseAction?,
-		file: StaticString = #filePath,
-		line: UInt = #line
-	) throws -> ResetCreditUseAttempt {
-		guard case .consume(let attempt) = try XCTUnwrap(action, file: file, line: line) else {
-			XCTFail("Expected a consume action.", file: file, line: line)
-			throw TestFailure.unexpectedAction
-		}
-
-		return attempt
-	}
-
 	private func makeTarget(
 		accountID: String,
 		expiresAt: Int
@@ -200,9 +209,5 @@ final class ResetCreditUseConfirmationTests: XCTestCase {
 			descriptorMultiplicity: 1,
 			detailsComplete: true
 		)
-	}
-
-	private enum TestFailure: Error {
-		case unexpectedAction
 	}
 }

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -147,12 +147,13 @@ decodex-publisher validate-social .agent/automations/decodex/cache/social/x
 - Lists stored accounts without token material.
 - Pins future Decodex runs to one account or returns to balanced selection.
 - Forces Codex to use a stored account by writing `auth.json`.
-- Uses a selected reset card after a second-click confirmation. The App resolves
-  the exact opaque credit ID before confirmation and reuses the same ID and
-  idempotency key for retries in an isolated file-auth app-server session. The
-  confirmation expires after five seconds and also clears when the menu-bar panel
-  closes. The isolated copy excludes the managed refresh token. Ambiguous or
-  incomplete card-detail lists fail closed.
+- Uses a selected reset card after a second-click confirmation. The first click is
+  a local-only state change that immediately starts a five-second confirmation. The
+  second click opens one isolated file-auth app-server session, validates the
+  account, resolves the exact current opaque credit ID, and consumes it. Retries
+  keep the resolved ID and idempotency key. The confirmation also clears when the
+  menu-bar panel closes. The isolated copy excludes the managed refresh token.
+  Ambiguous or incomplete card-detail lists fail closed.
 - Runs isolated Codex device login and imports the resulting auth file. The App
   honors an explicit `CODEX_CLI_PATH` override; otherwise it resolves the login
   executable from the Codex macOS application registered with Launch Services,


### PR DESCRIPTION
## Summary
- make the first reset-card click a local-only five-second confirmation
- resolve and consume the exact opaque card ID in one isolated app-server session on the second click
- preserve the resolved ID and idempotency key across ambiguous retries

## Validation
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app (100 tests)
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build --package-path apps/decodex-app -c release
- independent read-only code review

## Note
The existing app staging script still references the retired Cargo package named decodex; this pre-existing packaging issue is outside this Swift-only change.