### PR TITLE
Repair autonomous upstream validation on current main

### DIFF
--- a/apps/decodex-cli/src/lib.rs
+++ b/apps/decodex-cli/src/lib.rs
@@ -510,7 +510,7 @@ mod tests {
 
 	fn report(statuses: impl IntoIterator<Item = DoctorStatus>) -> DoctorReport {
 		DoctorReport::new(
-			ServerId::new(SERVER_ID).unwrap(),
+			ServerId::new(SERVER_ID).expect("test operation must succeed"),
 			CURRENT_VERSION,
 			DoctorComponent::ALL
 				.into_iter()
@@ -518,18 +518,20 @@ mod tests {
 				.map(|(component, status)| DoctorCheck::new(component, status))
 				.collect(),
 		)
-		.unwrap()
+		.expect("test operation must succeed")
 	}
 
 	#[test]
 	fn command_surface_is_multi_command_without_aliases() {
 		Cli::command().debug_assert();
 
-		let doctor = Cli::try_parse_from(["decodex", "--profile", "remote", "doctor"]).unwrap();
-		let status = Cli::try_parse_from(["decodex", "status", "--output", "json"]).unwrap();
+		let doctor = Cli::try_parse_from(["decodex", "--profile", "remote", "doctor"])
+			.expect("test operation must succeed");
+		let status = Cli::try_parse_from(["decodex", "status", "--output", "json"])
+			.expect("test operation must succeed");
 		let commit =
 			Cli::try_parse_from(["decodex", "commit", "Exact candidate", "--manual-authority"])
-				.unwrap();
+				.expect("test operation must succeed");
 		let land = Cli::try_parse_from([
 			"decodex",
 			"land",
@@ -542,10 +544,10 @@ mod tests {
 			"--expected-head-oid",
 			"2222222222222222222222222222222222222222",
 		])
-		.unwrap();
+		.expect("test operation must succeed");
 		let git_hook =
 			Cli::try_parse_from(["decodex", "git-hook", "commit-msg", ".git/COMMIT_EDITMSG"])
-				.unwrap();
+				.expect("test operation must succeed");
 
 		assert_eq!(doctor.command, Command::Doctor);
 		assert_eq!(doctor.profile.as_deref(), Some("remote"));
@@ -584,7 +586,7 @@ mod tests {
 			"018f0f9e-7b6e-4a31-8f4c-1d2e3f405162",
 			"doctor",
 		])
-		.unwrap();
+		.expect("test operation must succeed");
 		let debug = format!("{cli:?}");
 
 		assert!(!debug.contains(profile_marker));
@@ -627,8 +629,10 @@ mod tests {
 			assert!(human.text().contains(crate::issue_name(issue)));
 		}
 
-		let value: serde_json::Value = serde_json::from_str(json.text()).unwrap();
-		let decoded: DoctorReport = serde_json::from_value(value["report"].clone()).unwrap();
+		let value: serde_json::Value =
+			serde_json::from_str(json.text()).expect("test operation must succeed");
+		let decoded: DoctorReport =
+			serde_json::from_value(value["report"].clone()).expect("test operation must succeed");
 
 		assert_eq!(decoded, report);
 		assert_eq!(human.exit_code(), 1);
@@ -687,7 +691,8 @@ mod tests {
 				crate::render_failure(DiagnosticCommand::Doctor, OutputFormat::Human, failure);
 			let json =
 				crate::render_failure(DiagnosticCommand::Doctor, OutputFormat::Json, failure);
-			let value: serde_json::Value = serde_json::from_str(json.text()).unwrap();
+			let value: serde_json::Value =
+				serde_json::from_str(json.text()).expect("test operation must succeed");
 
 			assert_eq!(human.exit_code(), 2);
 			assert!(human.is_error_stream());
@@ -718,20 +723,24 @@ mod tests {
 	fn incomplete_ready_reports_render_as_closed_protocol_failures() {
 		let complete = report(vec![DoctorStatus::Ready; DoctorComponent::ALL.len()]);
 		let cases = [
-			DoctorReport::new(ServerId::new(SERVER_ID).unwrap(), CURRENT_VERSION, Vec::new())
-				.unwrap(),
 			DoctorReport::new(
-				ServerId::new(SERVER_ID).unwrap(),
+				ServerId::new(SERVER_ID).expect("test operation must succeed"),
+				CURRENT_VERSION,
+				Vec::new(),
+			)
+			.expect("test operation must succeed"),
+			DoctorReport::new(
+				ServerId::new(SERVER_ID).expect("test operation must succeed"),
 				CURRENT_VERSION,
 				vec![DoctorCheck::new(DoctorComponent::Configuration, DoctorStatus::Ready)],
 			)
-			.unwrap(),
+			.expect("test operation must succeed"),
 			DoctorReport::new(
-				ServerId::new(SERVER_ID).unwrap(),
+				ServerId::new(SERVER_ID).expect("test operation must succeed"),
 				CURRENT_VERSION,
 				complete.checks()[1..].to_vec(),
 			)
-			.unwrap(),
+			.expect("test operation must succeed"),
 		];
 
 		for report in cases {
@@ -746,7 +755,8 @@ mod tests {
 				assert_eq!(output.exit_code(), 2);
 
 				if format == OutputFormat::Json {
-					let value: serde_json::Value = serde_json::from_str(output.text()).unwrap();
+					let value: serde_json::Value =
+						serde_json::from_str(output.text()).expect("test operation must succeed");
 
 					assert_eq!(value["failure"], "protocol_malformed");
 				}
@@ -761,8 +771,12 @@ mod tests {
 
 		checks.reverse();
 
-		let report =
-			DoctorReport::new(ServerId::new(SERVER_ID).unwrap(), CURRENT_VERSION, checks).unwrap();
+		let report = DoctorReport::new(
+			ServerId::new(SERVER_ID).expect("test operation must succeed"),
+			CURRENT_VERSION,
+			checks,
+		)
+		.expect("test operation must succeed");
 		let output = crate::render_report(
 			DiagnosticCommand::Status,
 			OutputFormat::Json,

--- a/apps/decodex-cli/src/reset_card.rs
+++ b/apps/decodex-cli/src/reset_card.rs
@@ -851,7 +851,7 @@ mod tests {
 		let service_owner_uid = {
 			use std::os::unix::fs::MetadataExt as _;
 
-			standard::fs::metadata(root).unwrap().uid()
+			standard::fs::metadata(root).expect("test operation must succeed").uid()
 		};
 		#[cfg(not(unix))]
 		let service_owner_uid = 0_u32;
@@ -883,28 +883,29 @@ cache = {{}}
 		);
 		let path = root.join("config.toml");
 
-		standard::fs::write(&path, config).unwrap();
+		standard::fs::write(&path, config).expect("test operation must succeed");
 
 		#[cfg(unix)]
 		{
 			use std::os::unix::fs::PermissionsExt as _;
 
 			standard::fs::set_permissions(path, standard::fs::Permissions::from_mode(0o600))
-				.unwrap();
+				.expect("test operation must succeed");
 		}
 	}
 
 	fn prepare_client_root(temp: &tempfile::TempDir, kind: &str) -> std::path::PathBuf {
-		let root = temp.path().canonicalize().unwrap().join(".decodex");
+		let root =
+			temp.path().canonicalize().expect("test operation must succeed").join(".decodex");
 
-		standard::fs::create_dir(&root).unwrap();
+		standard::fs::create_dir(&root).expect("test operation must succeed");
 
 		#[cfg(unix)]
 		{
 			use std::os::unix::fs::PermissionsExt as _;
 
 			standard::fs::set_permissions(&root, standard::fs::Permissions::from_mode(0o700))
-				.unwrap();
+				.expect("test operation must succeed");
 		}
 
 		write_client_config(&root, kind);
@@ -913,17 +914,18 @@ cache = {{}}
 	}
 
 	fn local_profile() -> ClientProfile {
-		let temp = tempfile::TempDir::new().unwrap();
+		let temp = tempfile::TempDir::new().expect("test operation must succeed");
 		let root = prepare_client_root(&temp, "local");
 
-		ClientProfile::load(&root, None).unwrap()
+		ClientProfile::load(&root, None).expect("test operation must succeed")
 	}
 
 	#[test]
 	fn reset_card_surface_parses_exact_commands_and_requires_confirmation() {
 		Cli::command().debug_assert();
 
-		let accounts = Cli::try_parse_from(["decodex", "reset-card", "accounts"]).unwrap();
+		let accounts = Cli::try_parse_from(["decodex", "reset-card", "accounts"])
+			.expect("test operation must succeed");
 		let list = Cli::try_parse_from([
 			"decodex",
 			"reset-card",
@@ -931,7 +933,7 @@ cache = {{}}
 			"--account",
 			"40000000-0000-4000-8000-000000000001",
 		])
-		.unwrap();
+		.expect("test operation must succeed");
 		let use_card = Cli::try_parse_from([
 			"decodex",
 			"--output",
@@ -950,7 +952,7 @@ cache = {{}}
 			"operator-key",
 			"--yes",
 		])
-		.unwrap();
+		.expect("test operation must succeed");
 		let status = Cli::try_parse_from([
 			"decodex",
 			"reset-card",
@@ -958,7 +960,7 @@ cache = {{}}
 			"--idempotency-key",
 			"operator-key",
 		])
-		.unwrap();
+		.expect("test operation must succeed");
 
 		assert!(matches!(accounts.command, Command::ResetCard(super::ResetCardCommand::Accounts)));
 		assert!(matches!(list.command, Command::ResetCard(super::ResetCardCommand::List { .. })));
@@ -1016,7 +1018,7 @@ cache = {{}}
 				"--yes",
 			],
 		] {
-			let cli = Cli::try_parse_from(args).unwrap();
+			let cli = Cli::try_parse_from(args).expect("test operation must succeed");
 
 			assert!(!format!("{cli:?}").contains(marker));
 		}
@@ -1031,7 +1033,7 @@ cache = {{}}
 			"--expected-server-id",
 			SERVER_ID,
 		])
-		.unwrap();
+		.expect("test operation must succeed");
 		let debug = format!("{cli:?}");
 
 		assert_eq!(cli.expected_server_id.as_deref(), Some(SERVER_ID));
@@ -1041,7 +1043,7 @@ cache = {{}}
 
 	#[tokio::test]
 	async fn valid_use_key_is_retained_for_every_pre_send_failure() {
-		let root = tempfile::TempDir::new().unwrap();
+		let root = tempfile::TempDir::new().expect("test operation must succeed");
 		let cases = [
 			(
 				super::ResetCardCommand::Use {
@@ -1092,7 +1094,8 @@ cache = {{}}
 		for (command, expected_failure) in cases {
 			let output =
 				super::execute(command, OutputFormat::Json, Some(root.path()), None, None).await;
-			let value: serde_json::Value = serde_json::from_str(output.text()).unwrap();
+			let value: serde_json::Value =
+				serde_json::from_str(output.text()).expect("test operation must succeed");
 
 			assert_eq!(value["command"], "use");
 			assert_eq!(value["outcome"], "failure");
@@ -1105,11 +1108,11 @@ cache = {{}}
 
 	#[tokio::test]
 	async fn omitted_confirmation_reaches_stable_key_preserving_output() {
-		let root = tempfile::TempDir::new().unwrap();
+		let root = tempfile::TempDir::new().expect("test operation must succeed");
 		let cli = Cli::try_parse_from([
 			"decodex",
 			"--root",
-			root.path().to_str().unwrap(),
+			root.path().to_str().expect("test operation must succeed"),
 			"--output",
 			"json",
 			"reset-card",
@@ -1125,9 +1128,10 @@ cache = {{}}
 			"--idempotency-key",
 			"operator-key",
 		])
-		.unwrap();
+		.expect("test operation must succeed");
 		let output = crate::execute(cli).await;
-		let value: serde_json::Value = serde_json::from_str(output.text()).unwrap();
+		let value: serde_json::Value =
+			serde_json::from_str(output.text()).expect("test operation must succeed");
 
 		assert_eq!(value["failure"], "confirmation_required");
 		assert_eq!(value["idempotency_key"], "operator-key");
@@ -1136,7 +1140,7 @@ cache = {{}}
 
 	#[tokio::test]
 	async fn invalid_use_key_wins_before_other_pre_send_validation() {
-		let root = tempfile::TempDir::new().unwrap();
+		let root = tempfile::TempDir::new().expect("test operation must succeed");
 		let output = super::execute(
 			super::ResetCardCommand::Use {
 				account: "not-an-account".into(),
@@ -1152,7 +1156,8 @@ cache = {{}}
 			None,
 		)
 		.await;
-		let value: serde_json::Value = serde_json::from_str(output.text()).unwrap();
+		let value: serde_json::Value =
+			serde_json::from_str(output.text()).expect("test operation must succeed");
 
 		assert_eq!(value["failure"], "invalid_idempotency_key");
 		assert!(value.get("idempotency_key").is_none());
@@ -1161,7 +1166,7 @@ cache = {{}}
 
 	#[tokio::test]
 	async fn invalid_server_pin_preserves_a_valid_use_key_before_dispatch() {
-		let temp = tempfile::TempDir::new().unwrap();
+		let temp = tempfile::TempDir::new().expect("test operation must succeed");
 		let root = prepare_client_root(&temp, "local");
 
 		let output = super::execute(
@@ -1179,7 +1184,8 @@ cache = {{}}
 			Some("not-a-canonical-server-id"),
 		)
 		.await;
-		let value: serde_json::Value = serde_json::from_str(output.text()).unwrap();
+		let value: serde_json::Value =
+			serde_json::from_str(output.text()).expect("test operation must succeed");
 
 		assert_eq!(value["failure"], "configuration_malformed");
 		assert_eq!(value["idempotency_key"], "operator-key");
@@ -1188,7 +1194,7 @@ cache = {{}}
 
 	#[tokio::test]
 	async fn remote_profile_is_rejected_before_reset_card_transport() {
-		let temp = tempfile::TempDir::new().unwrap();
+		let temp = tempfile::TempDir::new().expect("test operation must succeed");
 		let root = prepare_client_root(&temp, "remote");
 
 		let output = super::execute(
@@ -1199,7 +1205,8 @@ cache = {{}}
 			None,
 		)
 		.await;
-		let value: serde_json::Value = serde_json::from_str(output.text()).unwrap();
+		let value: serde_json::Value =
+			serde_json::from_str(output.text()).expect("test operation must succeed");
 
 		assert_eq!(value["failure"], "remote_mutation_unsupported");
 		assert_eq!(output.exit_code(), 2);
@@ -1222,7 +1229,8 @@ cache = {{}}
 		);
 
 		for output in [accounts, inventory] {
-			let value: serde_json::Value = serde_json::from_str(output.text()).unwrap();
+			let value: serde_json::Value =
+				serde_json::from_str(output.text()).expect("test operation must succeed");
 
 			assert_eq!(value["authority"]["profile_name"], "selected");
 			assert_eq!(value["authority"]["server_id"], SERVER_ID);
@@ -1231,17 +1239,19 @@ cache = {{}}
 
 	#[test]
 	fn stable_json_use_result_has_no_provider_identifier() {
-		let key = IdempotencyKey::new("operator-key").unwrap();
-		let account = EntityId::new("40000000-0000-4000-8000-000000000001").unwrap();
+		let key = IdempotencyKey::new("operator-key").expect("test operation must succeed");
+		let account = EntityId::new("40000000-0000-4000-8000-000000000001")
+			.expect("test operation must succeed");
 		let output = super::render_use(
 			OutputFormat::Json,
 			&key,
 			&account,
-			ResetCardDescriptorDto::new(1, 2).unwrap(),
+			ResetCardDescriptorDto::new(1, 2).expect("test operation must succeed"),
 			EntityRevision(8),
 			ResetCardOperationResult::Completed { outcome: ResetCardOutcome::Reset },
 		);
-		let value: serde_json::Value = serde_json::from_str(output.text()).unwrap();
+		let value: serde_json::Value =
+			serde_json::from_str(output.text()).expect("test operation must succeed");
 
 		assert_eq!(value["schema"], "decodex/reset-card-cli/1");
 		assert_eq!(value["command"], "use");
@@ -1256,7 +1266,7 @@ cache = {{}}
 
 	#[test]
 	fn use_outputs_retain_the_key_and_typed_dispatch_state_after_key_creation() {
-		let key = IdempotencyKey::new("operator-key").unwrap();
+		let key = IdempotencyKey::new("operator-key").expect("test operation must succeed");
 
 		for (dispatch_state, expected) in [
 			(super::UseDispatchState::DefinitelyNotDispatched, "definitely_not_dispatched"),
@@ -1268,7 +1278,8 @@ cache = {{}}
 				dispatch_state,
 				ClientFailure::ProtocolDisconnected,
 			);
-			let value: serde_json::Value = serde_json::from_str(output.text()).unwrap();
+			let value: serde_json::Value =
+				serde_json::from_str(output.text()).expect("test operation must succeed");
 
 			assert_eq!(value["schema"], "decodex/reset-card-cli/1");
 			assert_eq!(value["command"], "use");
@@ -1282,7 +1293,8 @@ cache = {{}}
 
 		let rejected =
 			super::render_rejected(OutputFormat::Json, &key, &CommandError::IdempotencyConflict);
-		let value: serde_json::Value = serde_json::from_str(rejected.text()).unwrap();
+		let value: serde_json::Value =
+			serde_json::from_str(rejected.text()).expect("test operation must succeed");
 
 		assert_eq!(value["idempotency_key"], "operator-key");
 		assert_eq!(value["dispatch_state"], "rejected_before_acceptance");
@@ -1293,7 +1305,8 @@ cache = {{}}
 			super::UseDispatchState::PotentiallyDispatched,
 			ClientFailure::ApplicationAcceptanceUnknown,
 		);
-		let value: serde_json::Value = serde_json::from_str(unknown.text()).unwrap();
+		let value: serde_json::Value =
+			serde_json::from_str(unknown.text()).expect("test operation must succeed");
 
 		assert_eq!(value["failure"], "application_acceptance_unknown");
 		assert_eq!(value["dispatch_state"], "potentially_dispatched");
@@ -1312,7 +1325,7 @@ cache = {{}}
 
 	#[test]
 	fn operation_exit_codes_distinguish_terminal_success_from_uncertainty() {
-		let key = IdempotencyKey::new("operator-key").unwrap();
+		let key = IdempotencyKey::new("operator-key").expect("test operation must succeed");
 
 		assert_eq!(
 			super::render_operation(
@@ -1342,7 +1355,8 @@ cache = {{}}
 				error: decodex_protocol::ResetCardError::ProductStateUnavailable,
 			},
 		);
-		let value: serde_json::Value = serde_json::from_str(unavailable.text()).unwrap();
+		let value: serde_json::Value =
+			serde_json::from_str(unavailable.text()).expect("test operation must succeed");
 
 		assert_eq!(unavailable.exit_code(), 2);
 		assert_eq!(value["outcome"], "unavailable");
@@ -1352,17 +1366,19 @@ cache = {{}}
 	#[test]
 	fn status_poll_failure_cannot_downgrade_proved_durable_acceptance() {
 		let state = super::accepted_state_after_poll(Err(ClientFailure::ProtocolDisconnected));
-		let key = IdempotencyKey::new("operator-key").unwrap();
-		let account = EntityId::new("40000000-0000-4000-8000-000000000001").unwrap();
+		let key = IdempotencyKey::new("operator-key").expect("test operation must succeed");
+		let account = EntityId::new("40000000-0000-4000-8000-000000000001")
+			.expect("test operation must succeed");
 		let output = super::render_use(
 			OutputFormat::Json,
 			&key,
 			&account,
-			ResetCardDescriptorDto::new(1, 2).unwrap(),
+			ResetCardDescriptorDto::new(1, 2).expect("test operation must succeed"),
 			EntityRevision(7),
 			state,
 		);
-		let value: serde_json::Value = serde_json::from_str(output.text()).unwrap();
+		let value: serde_json::Value =
+			serde_json::from_str(output.text()).expect("test operation must succeed");
 
 		assert_eq!(state, ResetCardOperationResult::Prepared);
 		assert_eq!(value["dispatch_state"], "durably_accepted");

--- a/apps/decodex-gpui/src/client_lifecycle/tests.rs
+++ b/apps/decodex-gpui/src/client_lifecycle/tests.rs
@@ -551,7 +551,17 @@ async fn event_publication_retains_the_complete_authoritative_state_before_confi
 	assert_eq!(lifecycle.state.len(), 2);
 	assert_eq!(lifecycle.state["first"].revision, EntityRevision(3));
 	assert_eq!(lifecycle.state["second"].revision, EntityRevision(2));
-	assert_eq!(lifecycle.cache.as_ref().unwrap().inspect_current().unwrap().unwrap().records, 2);
+	assert_eq!(
+		lifecycle
+			.cache
+			.as_ref()
+			.expect("test operation must succeed")
+			.inspect_current()
+			.expect("test operation must succeed")
+			.expect("test operation must succeed")
+			.records,
+		2
+	);
 	assert_eq!(
 		*io.confirmations.lock().expect("confirmation log is available"),
 		vec![Cursor(5), Cursor(6)]
@@ -637,8 +647,8 @@ async fn resume_reuses_only_the_attested_checkpoint_and_fallback_rebuilds_state(
 			.as_ref()
 			.expect("cache is available")
 			.inspect_current()
-			.unwrap()
-			.unwrap()
+			.expect("test operation must succeed")
+			.expect("test operation must succeed")
 			.records,
 		1
 	);
@@ -862,12 +872,18 @@ fn corrupt_cache_is_disposed_and_rebuilt_while_unsafe_root_requires_an_operator(
 		}
 	);
 	assert_eq!(
-		rebuilt.cache.as_ref().expect("rebuilt cache is available").inspect_current().unwrap(),
+		rebuilt
+			.cache
+			.as_ref()
+			.expect("rebuilt cache is available")
+			.inspect_current()
+			.expect("test operation must succeed"),
 		None
 	);
 
 	let unsafe_temporary = TempDir::new().expect("temporary directory is available");
-	let unsafe_root = unsafe_temporary.path().canonicalize().unwrap().join("cache");
+	let unsafe_root =
+		unsafe_temporary.path().canonicalize().expect("test operation must succeed").join("cache");
 	fs::write(&unsafe_root, b"not a directory").expect("unsafe cache root is created");
 	let unsafe_lifecycle = lifecycle(&unsafe_root);
 	assert_eq!(

--- a/apps/decodex-gpui/src/shell.rs
+++ b/apps/decodex-gpui/src/shell.rs
@@ -654,7 +654,10 @@ mod tests {
 		let (shell, visual) = open_shell(cx);
 		for expected in Destination::ALL {
 			let focused = shell.read_with(visual, |shell, _| {
-				let index = Destination::ALL.iter().position(|value| *value == expected).unwrap();
+				let index = Destination::ALL
+					.iter()
+					.position(|value| *value == expected)
+					.expect("test operation must succeed");
 				shell.destination_focus[index].clone()
 			});
 			assert!(visual.update(|window, _| focused.is_focused(window)));

--- a/apps/decodexd/src/main.rs
+++ b/apps/decodexd/src/main.rs
@@ -3,6 +3,7 @@
 use std::error::Error;
 
 use decodex_runtime::{ServerConfig, ServiceComposition};
+#[cfg(test)] use {libc as _, tempfile as _};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/automations/upstream/scripts/upstream_autopilot_lib/validation.py
+++ b/automations/upstream/scripts/upstream_autopilot_lib/validation.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import re
 import shutil
+import sys
 import tempfile
 import tomllib
 from typing import Any
@@ -18,6 +19,7 @@ from .core import (
     REQUIRED_VALIDATION_PROFILES,
     REASON_PATTERN,
     SHA_PATTERN,
+    TRUSTED_SYSTEM_EXECUTABLE_ROOTS,
     TRUSTED_SYSTEM_TOOL_DIRECTORIES,
     VALIDATION_AUTHORITY_PATHS,
     VALIDATION_AUTHORITY_PREFIXES,
@@ -114,6 +116,7 @@ GIT_SOURCE_PATTERN = re.compile(
     r"^git\+(https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:\.git)?)"
     r"\?rev=([0-9a-f]{40})#([0-9a-f]{40})$"
 )
+MINIMUM_VALIDATION_PYTHON = (3, 11)
 
 
 def repository_identity(worktree: Path) -> tuple[str, str]:
@@ -363,6 +366,9 @@ def validation_tools(
     paths: dict[str, Path] = {}
     discovery_path = os.pathsep.join(TRUSTED_TOOL_DISCOVERY_PATHS)
     for name in VALIDATION_TOOL_NAMES:
+        if name == "python3":
+            paths[name] = trusted_validation_python(repo_root)
+            continue
         located = shutil.which(name, path=discovery_path)
         if located is None:
             raise AutopilotError("validation_tool_unavailable")
@@ -404,6 +410,44 @@ def validation_tools(
         if selected is None or Path(selected).absolute() != expected:
             raise AutopilotError("validation_tool_path_conflict")
     return paths, validation_tool_evidence(paths)
+
+
+def trusted_validation_python(repo_root: Path) -> Path:
+    if not MINIMUM_VALIDATION_PYTHON <= sys.version_info[:2] < (4, 0):
+        raise AutopilotError("validation_python_runtime_unsupported")
+    runtime = Path(sys.executable).absolute()
+    candidate = runtime.parent / "python3"
+    try:
+        candidate_metadata = candidate.lstat()
+        parent_metadata = candidate.parent.stat()
+        resolved = candidate.resolve(strict=True)
+        resolved_metadata = resolved.stat()
+        runtime_resolved = runtime.resolve(strict=True)
+    except OSError as error:
+        raise AutopilotError("validation_python_runtime_unavailable") from error
+    if (
+        candidate.name != "python3"
+        or resolved != runtime_resolved
+        or not resolved.is_file()
+        or candidate_metadata.st_uid != 0
+        or parent_metadata.st_uid != 0
+        or resolved_metadata.st_uid != 0
+        or candidate_metadata.st_mode & 0o022
+        or parent_metadata.st_mode & 0o022
+        or resolved_metadata.st_mode & 0o022
+        or not any(
+            _path_is_within(candidate, root)
+            and _path_is_within(resolved, root)
+            for root in TRUSTED_SYSTEM_EXECUTABLE_ROOTS
+        )
+        or _path_is_within(candidate, repo_root)
+        or _path_is_within(resolved, repo_root)
+        or ".worktrees" in candidate.parts
+        or ".worktrees" in resolved.parts
+    ):
+        raise AutopilotError("validation_python_runtime_untrusted")
+    hash_file_bounded(resolved)
+    return candidate
 
 
 def _path_is_within(path: Path, root: Path) -> bool:

--- a/automations/upstream/tests/test_upstream_autopilot.py
+++ b/automations/upstream/tests/test_upstream_autopilot.py
@@ -2126,6 +2126,14 @@ class UpstreamAutopilotTests(unittest.TestCase):
 
         self.assertEqual(set(tools), set(self.autopilot.VALIDATION_TOOL_NAMES))
         self.assertEqual(
+            tools["python3"].resolve(),
+            Path(sys.executable).resolve(),
+        )
+        self.assertGreaterEqual(
+            sys.version_info[:2],
+            self.autopilot.MINIMUM_VALIDATION_PYTHON,
+        )
+        self.assertEqual(
             set(evidence),
             set(self.autopilot.VALIDATION_TOOL_NAMES),
         )

--- a/crates/decodex-core/tests/config.rs
+++ b/crates/decodex-core/tests/config.rs
@@ -179,7 +179,7 @@ plan_type = "pro"
 #[test]
 fn landed_portless_postgres_config_keeps_the_standard_typed_default() {
 	let input = support::valid_config().replace("port = 5432\n", "");
-	let config = DecodexConfig::parse(input.as_bytes()).unwrap();
+	let config = DecodexConfig::parse(input.as_bytes()).expect("test operation must succeed");
 
 	assert_eq!(config.postgres().port(), 5_432);
 }
@@ -235,9 +235,11 @@ fn remote_client_projection_never_validates_server_host_paths() {
 
 #[test]
 fn client_profile_selection_supports_active_and_explicit_names() {
-	let client = DecodexClientConfig::parse(support::valid_config().as_bytes()).unwrap();
-	let (active_name, active) = client.selected_profile(None).unwrap();
-	let (remote_name, remote) = client.selected_profile(Some("remote")).unwrap();
+	let client = DecodexClientConfig::parse(support::valid_config().as_bytes())
+		.expect("test operation must succeed");
+	let (active_name, active) = client.selected_profile(None).expect("test operation must succeed");
+	let (remote_name, remote) =
+		client.selected_profile(Some("remote")).expect("test operation must succeed");
 
 	assert_eq!(client.version(), 1);
 	assert_eq!(client.active_profile_name().as_str(), "local");

--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -1013,11 +1013,11 @@ mod tests {
 	const SERVER_ID: &str = "018f0f9e-7b6e-4a31-8f4c-1d2e3f405162";
 
 	fn typed(message: ServerMessage) -> Message {
-		Message::Text(serde_json::to_string(&message).unwrap().into())
+		Message::Text(serde_json::to_string(&message).expect("test operation must succeed").into())
 	}
 
 	fn initial(server_id: &str) -> Vec<Message> {
-		let server_id = ServerId::new(server_id).unwrap();
+		let server_id = ServerId::new(server_id).expect("test operation must succeed");
 
 		vec![
 			typed(ServerMessage::Welcome(ServerWelcome {
@@ -1039,7 +1039,7 @@ mod tests {
 
 	fn report() -> DoctorReport {
 		DoctorReport::new(
-			ServerId::new(SERVER_ID).unwrap(),
+			ServerId::new(SERVER_ID).expect("test operation must succeed"),
 			CURRENT_VERSION,
 			DoctorComponent::ALL
 				.into_iter()
@@ -1049,14 +1049,15 @@ mod tests {
 				})
 				.collect(),
 		)
-		.unwrap()
+		.expect("test operation must succeed")
 	}
 
 	fn result(report: DoctorReport) -> Message {
 		typed(ServerMessage::QueryResult(QueryResultEnvelope {
 			version: CURRENT_VERSION,
-			server_id: ServerId::new(SERVER_ID).unwrap(),
-			query_id: crate::QueryId::new("decodex-cli-doctor").unwrap(),
+			server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
+			query_id: crate::QueryId::new("decodex-cli-doctor")
+				.expect("test operation must succeed"),
 			payload: QueryResultPayload::DoctorStatus(report),
 		}))
 	}
@@ -1064,51 +1065,58 @@ mod tests {
 	fn event(version: ProtocolVersion, server_id: &str) -> Message {
 		typed(ServerMessage::Event(EventEnvelope {
 			version,
-			server_id: ServerId::new(server_id).unwrap(),
+			server_id: ServerId::new(server_id).expect("test operation must succeed"),
 			cursor: Cursor(1),
 			channel: Channel::SystemHealth,
-			entity_id: EntityId::new("system").unwrap(),
+			entity_id: EntityId::new("system").expect("test operation must succeed"),
 			entity_revision: EntityRevision(1),
-			correlation_id: CorrelationId::new("doctor-correlation").unwrap(),
+			correlation_id: CorrelationId::new("doctor-correlation")
+				.expect("test operation must succeed"),
 			causation_id: None,
 			payload: EventPayload::SystemObservationRefreshed {
-				status: WireText::new("bounded").unwrap(),
+				status: WireText::new("bounded").expect("test operation must succeed"),
 			},
 		}))
 	}
 
 	fn refusal(server_id: &str, refusal: Refusal) -> Message {
 		typed(ServerMessage::Refusal(RefusalEnvelope {
-			server_id: ServerId::new(server_id).unwrap(),
+			server_id: ServerId::new(server_id).expect("test operation must succeed"),
 			refusal,
 		}))
 	}
 
 	fn local_transport() -> (TempDir, LocalTransportAuthority) {
-		let temp = TempDir::new().unwrap();
-		let root = DecodexRoot::new(temp.path().canonicalize().unwrap().join(".decodex")).unwrap();
+		let temp = TempDir::new().expect("test operation must succeed");
+		let root = DecodexRoot::new(
+			temp.path().canonicalize().expect("test operation must succeed").join(".decodex"),
+		)
+		.expect("test operation must succeed");
 		let paths = root.paths();
 
-		paths.ensure_layout().unwrap();
+		paths.ensure_layout().expect("test operation must succeed");
 
 		// SAFETY: `geteuid` has no arguments or failure return.
 		let service_owner_uid = unsafe { libc::geteuid() };
 		let authority =
 			LocalTransportAuthority::new(paths, LocalTrustPolicy::SameUid, Some(service_owner_uid))
-				.unwrap();
+				.expect("test operation must succeed");
 
 		(temp, authority)
 	}
 
 	#[test]
 	fn active_local_profile_uses_stable_identity_and_remote_uses_only_profile_data() {
-		let temp = TempDir::new().unwrap();
-		let root = DecodexRoot::new(temp.path().canonicalize().unwrap().join(".decodex")).unwrap();
+		let temp = TempDir::new().expect("test operation must succeed");
+		let root = DecodexRoot::new(
+			temp.path().canonicalize().expect("test operation must succeed").join(".decodex"),
+		)
+		.expect("test operation must succeed");
 		let paths = root.paths();
 
-		paths.ensure_layout().unwrap();
+		paths.ensure_layout().expect("test operation must succeed");
 
-		let identity = ServerIdentity::load_or_create(&paths).unwrap();
+		let identity = ServerIdentity::load_or_create(&paths).expect("test operation must succeed");
 		// SAFETY: `geteuid` has no arguments or failure return.
 		let service_owner_uid = unsafe { libc::geteuid() };
 		let config = format!(
@@ -1147,16 +1155,17 @@ max_entry_bytes = 0
 "#,
 		);
 
-		fs::write(paths.config_file(), config).unwrap();
+		fs::write(paths.config_file(), config).expect("test operation must succeed");
 
 		#[cfg(unix)]
 		{
 			fs::set_permissions(paths.config_file(), std::fs::Permissions::from_mode(0o600))
-				.unwrap();
+				.expect("test operation must succeed");
 		}
 
-		let local = ClientProfile::load(root.as_path(), None).unwrap();
-		let remote = ClientProfile::load(root.as_path(), Some("remote")).unwrap();
+		let local = ClientProfile::load(root.as_path(), None).expect("test operation must succeed");
+		let remote = ClientProfile::load(root.as_path(), Some("remote"))
+			.expect("test operation must succeed");
 
 		assert_eq!(local.name(), "local");
 		assert_eq!(local.kind(), ProfileKind::Local);
@@ -1172,8 +1181,9 @@ max_entry_bytes = 0
 		assert_eq!(remote.name(), "remote");
 		assert_eq!(remote.kind(), ProfileKind::Remote);
 		assert_eq!(remote.expected_server_id().as_str(), SERVER_ID);
-		let stricter =
-			remote.clone().with_expected_server_id(ServerId::new("retained-authority").unwrap());
+		let stricter = remote.clone().with_expected_server_id(
+			ServerId::new("retained-authority").expect("test operation must succeed"),
+		);
 		assert_eq!(stricter.name(), "remote");
 		assert_eq!(stricter.expected_server_id().as_str(), "retained-authority");
 		assert_eq!(
@@ -1196,12 +1206,13 @@ max_entry_bytes = 0
 			profile_name: "remote".into(),
 			kind: ProfileKind::Remote,
 			local_transport: None,
-			expected_server_id: ServerId::new(SERVER_ID).unwrap(),
+			expected_server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 		};
 		let client = ResetCardClient::new(profile);
-		let account = EntityId::new("40000000-0000-4000-8000-000000000001").unwrap();
-		let key = IdempotencyKey::new("remote-reset-key").unwrap();
-		let descriptor = ResetCardDescriptorDto::new(1, 2).unwrap();
+		let account = EntityId::new("40000000-0000-4000-8000-000000000001")
+			.expect("test operation must succeed");
+		let key = IdempotencyKey::new("remote-reset-key").expect("test operation must succeed");
+		let descriptor = ResetCardDescriptorDto::new(1, 2).expect("test operation must succeed");
 
 		assert_eq!(client.accounts().await.unwrap_err(), ClientFailure::RemoteMutationUnsupported);
 		assert_eq!(
@@ -1223,19 +1234,29 @@ max_entry_bytes = 0
 		query: Vec<Message>,
 	) -> (ClientProfile, JoinHandle<()>) {
 		let (temp, authority) = local_transport();
-		let mut listener = authority.bind().await.unwrap();
+		let mut listener = authority.bind().await.expect("test operation must succeed");
 		let task = tokio::spawn(async move {
 			let _temp = temp;
-			let stream = listener.accept().await.unwrap();
-			let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
-			let hello = socket.next().await.unwrap().unwrap();
+			let stream = listener.accept().await.expect("test operation must succeed");
+			let mut socket =
+				tokio_tungstenite::accept_async(stream).await.expect("test operation must succeed");
+			let hello = socket
+				.next()
+				.await
+				.expect("test operation must succeed")
+				.expect("test operation must succeed");
 			let Message::Text(hello) = hello else { panic!("expected text hello") };
-			let ClientMessage::Hello(hello) = serde_json::from_str(&hello).unwrap() else {
+			let ClientMessage::Hello(hello) =
+				serde_json::from_str(&hello).expect("test operation must succeed")
+			else {
 				panic!("expected typed hello")
 			};
 
 			assert_eq!(hello.version, CURRENT_VERSION);
-			assert_eq!(hello.expected_server_id.unwrap().as_str(), SERVER_ID);
+			assert_eq!(
+				hello.expected_server_id.expect("test operation must succeed").as_str(),
+				SERVER_ID
+			);
 
 			for response in initial {
 				// A fail-closed client can drop the stream while the server flushes
@@ -1246,23 +1267,31 @@ max_entry_bytes = 0
 			}
 
 			if !query.is_empty() {
-				let request = socket.next().await.unwrap().unwrap();
+				let request = socket
+					.next()
+					.await
+					.expect("test operation must succeed")
+					.expect("test operation must succeed");
 				let Message::Text(request) = request else { panic!("expected text query") };
 
 				assert!(matches!(
-					serde_json::from_str::<ClientMessage>(&request).unwrap(),
+					serde_json::from_str::<ClientMessage>(&request)
+						.expect("test operation must succeed"),
 					ClientMessage::Query(_)
 				));
 
 				for response in query {
-					socket.send(response).await.unwrap();
+					socket.send(response).await.expect("test operation must succeed");
 				}
 			}
 
 			drop(socket);
-			listener.cleanup().unwrap();
+			listener.cleanup().expect("test operation must succeed");
 		});
-		let profile = ClientProfile::fixture(authority, ServerId::new(SERVER_ID).unwrap());
+		let profile = ClientProfile::fixture(
+			authority,
+			ServerId::new(SERVER_ID).expect("test operation must succeed"),
+		);
 
 		(profile, task)
 	}
@@ -1271,31 +1300,35 @@ max_entry_bytes = 0
 	async fn client_accepts_only_a_fully_verified_typed_report() {
 		let expected = report();
 		let (profile, task) = fixture(initial(SERVER_ID), vec![result(expected.clone())]).await;
-		let actual = DoctorClient::new(profile).query().await.unwrap();
+		let actual = DoctorClient::new(profile).query().await.expect("test operation must succeed");
 
 		assert_eq!(actual, expected);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
 	async fn client_rejects_every_incomplete_current_report_but_accepts_arbitrary_order() {
 		let complete = report();
 		let incomplete = [
-			DoctorReport::new(ServerId::new(SERVER_ID).unwrap(), CURRENT_VERSION, Vec::new())
-				.unwrap(),
 			DoctorReport::new(
-				ServerId::new(SERVER_ID).unwrap(),
+				ServerId::new(SERVER_ID).expect("test operation must succeed"),
+				CURRENT_VERSION,
+				Vec::new(),
+			)
+			.expect("test operation must succeed"),
+			DoctorReport::new(
+				ServerId::new(SERVER_ID).expect("test operation must succeed"),
 				CURRENT_VERSION,
 				vec![DoctorCheck::new(DoctorComponent::Configuration, DoctorStatus::Ready)],
 			)
-			.unwrap(),
+			.expect("test operation must succeed"),
 			DoctorReport::new(
-				ServerId::new(SERVER_ID).unwrap(),
+				ServerId::new(SERVER_ID).expect("test operation must succeed"),
 				CURRENT_VERSION,
 				complete.checks()[..complete.checks().len() - 1].to_vec(),
 			)
-			.unwrap(),
+			.expect("test operation must succeed"),
 		];
 
 		for report in incomplete {
@@ -1306,21 +1339,27 @@ max_entry_bytes = 0
 				ClientFailure::ProtocolMalformed,
 			);
 
-			task.await.unwrap();
+			task.await.expect("test operation must succeed");
 		}
 
 		let mut reversed = complete.checks().to_vec();
 
 		reversed.reverse();
 
-		let reversed =
-			DoctorReport::new(ServerId::new(SERVER_ID).unwrap(), CURRENT_VERSION, reversed)
-				.unwrap();
+		let reversed = DoctorReport::new(
+			ServerId::new(SERVER_ID).expect("test operation must succeed"),
+			CURRENT_VERSION,
+			reversed,
+		)
+		.expect("test operation must succeed");
 		let (profile, task) = fixture(initial(SERVER_ID), vec![result(reversed.clone())]).await;
 
-		assert_eq!(DoctorClient::new(profile).query().await.unwrap(), reversed);
+		assert_eq!(
+			DoctorClient::new(profile).query().await.expect("test operation must succeed"),
+			reversed
+		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1342,8 +1381,8 @@ max_entry_bytes = 0
 			),
 			(
 				Refusal::ServerIdentityMismatch {
-					expected: ServerId::new(SERVER_ID).unwrap(),
-					actual: ServerId::new("wrong-server").unwrap(),
+					expected: ServerId::new(SERVER_ID).expect("test operation must succeed"),
+					actual: ServerId::new("wrong-server").expect("test operation must succeed"),
 				},
 				ClientFailure::ServerIdentityMismatch,
 			),
@@ -1351,14 +1390,14 @@ max_entry_bytes = 0
 
 		for (refusal, expected) in cases {
 			let response = typed(ServerMessage::Refusal(RefusalEnvelope {
-				server_id: ServerId::new(SERVER_ID).unwrap(),
+				server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 				refusal,
 			}));
 			let (profile, task) = fixture(vec![response], Vec::new()).await;
 
 			assert_eq!(DoctorClient::new(profile).query().await.unwrap_err(), expected);
 
-			task.await.unwrap();
+			task.await.expect("test operation must succeed");
 		}
 	}
 
@@ -1378,13 +1417,15 @@ max_entry_bytes = 0
 			ClientFailure::ServerIdentityMismatch,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let mut wrong_protocol = initial(SERVER_ID);
 
 		wrong_protocol[1] = refusal(
 			"wrong-server",
-			Refusal::ProtocolViolation { message: WireText::new("untrusted-order").unwrap() },
+			Refusal::ProtocolViolation {
+				message: WireText::new("untrusted-order").expect("test operation must succeed"),
+			},
 		);
 
 		let (profile, task) = fixture(wrong_protocol, Vec::new()).await;
@@ -1394,7 +1435,7 @@ max_entry_bytes = 0
 			ClientFailure::ServerIdentityMismatch,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let wrong_backpressure =
 			refusal("wrong-server", Refusal::Backpressure { queue_capacity: 1 });
@@ -1405,7 +1446,7 @@ max_entry_bytes = 0
 			ClientFailure::ServerIdentityMismatch,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1421,12 +1462,12 @@ max_entry_bytes = 0
 			ClientFailure::ServerIdentityMismatch,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let wrong_welcome_version = typed(ServerMessage::Welcome(ServerWelcome {
 			version: PREVIOUS_MINOR_VERSION,
 			supported: SupportedVersions::current(),
-			server_id: ServerId::new(SERVER_ID).unwrap(),
+			server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 			instance_id: None,
 			cursor: Cursor(0),
 			reconnect: ReconnectMode::Snapshot,
@@ -1438,13 +1479,13 @@ max_entry_bytes = 0
 			ClientFailure::ProtocolMinorMismatch,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let mut wrong_snapshot = initial(SERVER_ID);
 
 		wrong_snapshot[1] = typed(ServerMessage::Snapshot(SnapshotEnvelope {
 			version: CURRENT_VERSION,
-			server_id: ServerId::new("wrong-server").unwrap(),
+			server_id: ServerId::new("wrong-server").expect("test operation must succeed"),
 			cursor: Cursor(0),
 			items: Vec::new(),
 		}));
@@ -1456,12 +1497,12 @@ max_entry_bytes = 0
 			ClientFailure::ServerIdentityMismatch,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let wrong_result_identity = typed(ServerMessage::QueryResult(QueryResultEnvelope {
 			version: CURRENT_VERSION,
-			server_id: ServerId::new("wrong-server").unwrap(),
-			query_id: QueryId::new("decodex-cli-doctor").unwrap(),
+			server_id: ServerId::new("wrong-server").expect("test operation must succeed"),
+			query_id: QueryId::new("decodex-cli-doctor").expect("test operation must succeed"),
 			payload: QueryResultPayload::DoctorStatus(report()),
 		}));
 		let (profile, task) = fixture(initial(SERVER_ID), vec![wrong_result_identity]).await;
@@ -1471,14 +1512,14 @@ max_entry_bytes = 0
 			ClientFailure::ServerIdentityMismatch,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let wrong_report_identity = DoctorReport::new(
-			ServerId::new("wrong-server").unwrap(),
+			ServerId::new("wrong-server").expect("test operation must succeed"),
 			CURRENT_VERSION,
 			report().checks().to_vec(),
 		)
-		.unwrap();
+		.expect("test operation must succeed");
 		let (profile, task) =
 			fixture(initial(SERVER_ID), vec![result(wrong_report_identity)]).await;
 
@@ -1487,15 +1528,15 @@ max_entry_bytes = 0
 			ClientFailure::ServerIdentityMismatch,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let mut wrong_report = report();
-		let encoded = serde_json::to_value(&wrong_report).unwrap();
-		let mut encoded = encoded.as_object().unwrap().clone();
+		let encoded = serde_json::to_value(&wrong_report).expect("test operation must succeed");
+		let mut encoded = encoded.as_object().expect("test operation must succeed").clone();
 
 		encoded.insert("version".into(), serde_json::json!({"major": 1, "minor": 1}));
 
-		wrong_report = serde_json::from_value(encoded.into()).unwrap();
+		wrong_report = serde_json::from_value(encoded.into()).expect("test operation must succeed");
 
 		let (profile, task) = fixture(initial(SERVER_ID), vec![result(wrong_report)]).await;
 
@@ -1504,7 +1545,7 @@ max_entry_bytes = 0
 			ClientFailure::ProtocolMinorMismatch,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1513,7 +1554,7 @@ max_entry_bytes = 0
 
 		wrong_snapshot_version[1] = typed(ServerMessage::Snapshot(SnapshotEnvelope {
 			version: PREVIOUS_MINOR_VERSION,
-			server_id: ServerId::new(SERVER_ID).unwrap(),
+			server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 			cursor: Cursor(0),
 			items: Vec::new(),
 		}));
@@ -1525,12 +1566,12 @@ max_entry_bytes = 0
 			ClientFailure::ProtocolMinorMismatch,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let wrong_result_version = typed(ServerMessage::QueryResult(QueryResultEnvelope {
 			version: PREVIOUS_MINOR_VERSION,
-			server_id: ServerId::new(SERVER_ID).unwrap(),
-			query_id: QueryId::new("decodex-cli-doctor").unwrap(),
+			server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
+			query_id: QueryId::new("decodex-cli-doctor").expect("test operation must succeed"),
 			payload: QueryResultPayload::DoctorStatus(report()),
 		}));
 		let (profile, task) = fixture(initial(SERVER_ID), vec![wrong_result_version]).await;
@@ -1540,12 +1581,12 @@ max_entry_bytes = 0
 			ClientFailure::ProtocolMinorMismatch,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let wrong_query_id = typed(ServerMessage::QueryResult(QueryResultEnvelope {
 			version: CURRENT_VERSION,
-			server_id: ServerId::new(SERVER_ID).unwrap(),
-			query_id: QueryId::new("wrong-query").unwrap(),
+			server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
+			query_id: QueryId::new("wrong-query").expect("test operation must succeed"),
 			payload: QueryResultPayload::DoctorStatus(report()),
 		}));
 		let (profile, task) = fixture(initial(SERVER_ID), vec![wrong_query_id]).await;
@@ -1555,7 +1596,7 @@ max_entry_bytes = 0
 			ClientFailure::ProtocolMalformed,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let mut wrong_order = initial(SERVER_ID);
 
@@ -1568,7 +1609,7 @@ max_entry_bytes = 0
 			ClientFailure::ProtocolMalformed,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1581,73 +1622,93 @@ max_entry_bytes = 0
 
 			assert_eq!(DoctorClient::new(profile).query().await.unwrap_err(), expected);
 
-			task.await.unwrap();
+			task.await.expect("test operation must succeed");
 		}
 
 		let expected = report();
 		let responses = vec![event(CURRENT_VERSION, SERVER_ID), result(expected.clone())];
 		let (profile, task) = fixture(initial(SERVER_ID), responses).await;
 
-		assert_eq!(DoctorClient::new(profile).query().await.unwrap(), expected);
+		assert_eq!(
+			DoctorClient::new(profile).query().await.expect("test operation must succeed"),
+			expected
+		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
 	async fn reset_card_account_query_accepts_interleaved_verified_events() {
 		let accounts = ResetCardAccountsResult::Available {
 			accounts: vec![ResetCardAccountDto {
-				account_id: EntityId::new("40000000-0000-4000-8000-000000000001").unwrap(),
-				display_label: WireText::new("Primary").unwrap(),
+				account_id: EntityId::new("40000000-0000-4000-8000-000000000001")
+					.expect("test operation must succeed"),
+				display_label: WireText::new("Primary").expect("test operation must succeed"),
 				account_revision: EntityRevision(7),
 				admission_state: ResetCardAdmissionState::Depleted,
 			}],
 		};
 		let result = typed(ServerMessage::QueryResult(QueryResultEnvelope {
 			version: CURRENT_VERSION,
-			server_id: ServerId::new(SERVER_ID).unwrap(),
-			query_id: QueryId::new("decodex-reset-card-accounts").unwrap(),
+			server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
+			query_id: QueryId::new("decodex-reset-card-accounts")
+				.expect("test operation must succeed"),
 			payload: QueryResultPayload::ResetCardAccounts(accounts.clone()),
 		}));
 		let (profile, task) =
 			fixture(initial(SERVER_ID), vec![event(CURRENT_VERSION, SERVER_ID), result]).await;
 
-		assert_eq!(ResetCardClient::new(profile).accounts().await.unwrap(), accounts);
+		assert_eq!(
+			ResetCardClient::new(profile).accounts().await.expect("test operation must succeed"),
+			accounts
+		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
 	async fn reset_card_consume_sends_once_and_verifies_receipt_and_result() {
 		let (temp, authority) = local_transport();
-		let mut listener = authority.bind().await.unwrap();
-		let descriptor = ResetCardDescriptorDto::new(1_700_000_000, 1_700_003_600).unwrap();
+		let mut listener = authority.bind().await.expect("test operation must succeed");
+		let descriptor = ResetCardDescriptorDto::new(1_700_000_000, 1_700_003_600)
+			.expect("test operation must succeed");
 		let expected_descriptor = descriptor;
 		let task = tokio::spawn(async move {
 			let _temp = temp;
-			let stream = listener.accept().await.unwrap();
-			let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
-			let hello = socket.next().await.unwrap().unwrap();
+			let stream = listener.accept().await.expect("test operation must succeed");
+			let mut socket =
+				tokio_tungstenite::accept_async(stream).await.expect("test operation must succeed");
+			let hello = socket
+				.next()
+				.await
+				.expect("test operation must succeed")
+				.expect("test operation must succeed");
 			let Message::Text(hello) = hello else { panic!("expected text hello") };
 
 			assert!(matches!(
-				serde_json::from_str::<ClientMessage>(&hello).unwrap(),
+				serde_json::from_str::<ClientMessage>(&hello).expect("test operation must succeed"),
 				ClientMessage::Hello(_)
 			));
 
 			for response in initial(SERVER_ID) {
-				socket.send(response).await.unwrap();
+				socket.send(response).await.expect("test operation must succeed");
 			}
 
-			let request = socket.next().await.unwrap().unwrap();
+			let request = socket
+				.next()
+				.await
+				.expect("test operation must succeed")
+				.expect("test operation must succeed");
 			let Message::Text(request) = request else { panic!("expected text command") };
-			let ClientMessage::Command(command) =
-				serde_json::from_str::<ClientMessage>(&request).unwrap()
+			let ClientMessage::Command(command) = serde_json::from_str::<ClientMessage>(&request)
+				.expect("test operation must succeed")
 			else {
 				panic!("expected typed command")
 			};
-			let client_command_id = ClientCommandId::new("reset-card-use:operator-key").unwrap();
-			let idempotency_key = IdempotencyKey::new("operator-key").unwrap();
+			let client_command_id = ClientCommandId::new("reset-card-use:operator-key")
+				.expect("test operation must succeed");
+			let idempotency_key =
+				IdempotencyKey::new("operator-key").expect("test operation must succeed");
 
 			assert_eq!(command.client_command_id, client_command_id);
 			assert_eq!(command.idempotency_key, idempotency_key);
@@ -1656,32 +1717,36 @@ max_entry_bytes = 0
 			socket
 				.send(typed(ServerMessage::CommandReceipt(CommandReceipt {
 					version: CURRENT_VERSION,
-					server_id: ServerId::new(SERVER_ID).unwrap(),
+					server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 					client_command_id: client_command_id.clone(),
 					idempotency_key: idempotency_key.clone(),
 					disposition: ReceiptDisposition::Executed,
 					original_client_command_id: client_command_id.clone(),
 				})))
 				.await
-				.unwrap();
-			socket.send(event(CURRENT_VERSION, SERVER_ID)).await.unwrap();
+				.expect("test operation must succeed");
+			socket
+				.send(event(CURRENT_VERSION, SERVER_ID))
+				.await
+				.expect("test operation must succeed");
 			socket
 				.send(typed(ServerMessage::CommandResult(CommandResultEnvelope {
 					version: CURRENT_VERSION,
-					server_id: ServerId::new(SERVER_ID).unwrap(),
+					server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 					client_command_id,
 					idempotency_key,
 					outcome: CommandOutcome::Succeeded,
 					entity_revision: Some(EntityRevision(7)),
 					payload: Some(ResultPayload::ResetCardOperationAccepted {
-						account_id: EntityId::new("40000000-0000-4000-8000-000000000001").unwrap(),
+						account_id: EntityId::new("40000000-0000-4000-8000-000000000001")
+							.expect("test operation must succeed"),
 						descriptor: expected_descriptor,
 						state: ResetCardOperationResult::Prepared,
 					}),
 					error: None,
 				})))
 				.await
-				.unwrap();
+				.expect("test operation must succeed");
 
 			if let Ok(Some(Ok(Message::Text(message)))) =
 				time::timeout(Duration::from_millis(50), socket.next()).await
@@ -1696,49 +1761,59 @@ max_entry_bytes = 0
 			}
 
 			drop(socket);
-			listener.cleanup().unwrap();
+			listener.cleanup().expect("test operation must succeed");
 		});
-		let profile = ClientProfile::fixture(authority, ServerId::new(SERVER_ID).unwrap());
+		let profile = ClientProfile::fixture(
+			authority,
+			ServerId::new(SERVER_ID).expect("test operation must succeed"),
+		);
 		let response = ResetCardClient::new(profile)
 			.consume(
-				EntityId::new("40000000-0000-4000-8000-000000000001").unwrap(),
+				EntityId::new("40000000-0000-4000-8000-000000000001")
+					.expect("test operation must succeed"),
 				descriptor,
 				EntityRevision(7),
-				IdempotencyKey::new("operator-key").unwrap(),
+				IdempotencyKey::new("operator-key").expect("test operation must succeed"),
 			)
 			.await
-			.unwrap();
+			.expect("test operation must succeed");
 
 		assert_eq!(
 			response,
 			ResetCardConsumeResponse::Accepted {
-				account_id: EntityId::new("40000000-0000-4000-8000-000000000001").unwrap(),
+				account_id: EntityId::new("40000000-0000-4000-8000-000000000001")
+					.expect("test operation must succeed"),
 				descriptor,
 				state: ResetCardOperationResult::Prepared,
 				entity_revision: EntityRevision(7),
 			}
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
 	async fn reset_card_consume_preserves_key_when_application_acceptance_is_unknown() {
 		let (temp, authority) = local_transport();
-		let mut listener = authority.bind().await.unwrap();
+		let mut listener = authority.bind().await.expect("test operation must succeed");
 		let task = tokio::spawn(async move {
 			let _temp = temp;
-			let stream = listener.accept().await.unwrap();
-			let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+			let stream = listener.accept().await.expect("test operation must succeed");
+			let mut socket =
+				tokio_tungstenite::accept_async(stream).await.expect("test operation must succeed");
 
 			let _ = socket.next().await;
 			for response in initial(SERVER_ID) {
-				socket.send(response).await.unwrap();
+				socket.send(response).await.expect("test operation must succeed");
 			}
-			let request = socket.next().await.unwrap().unwrap();
+			let request = socket
+				.next()
+				.await
+				.expect("test operation must succeed")
+				.expect("test operation must succeed");
 			let Message::Text(request) = request else { panic!("expected text command") };
-			let ClientMessage::Command(command) =
-				serde_json::from_str::<ClientMessage>(&request).unwrap()
+			let ClientMessage::Command(command) = serde_json::from_str::<ClientMessage>(&request)
+				.expect("test operation must succeed")
 			else {
 				panic!("expected typed command")
 			};
@@ -1746,18 +1821,18 @@ max_entry_bytes = 0
 			socket
 				.send(typed(ServerMessage::CommandReceipt(CommandReceipt {
 					version: CURRENT_VERSION,
-					server_id: ServerId::new(SERVER_ID).unwrap(),
+					server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 					client_command_id: command.client_command_id.clone(),
 					idempotency_key: command.idempotency_key.clone(),
 					disposition: ReceiptDisposition::Executed,
 					original_client_command_id: command.client_command_id.clone(),
 				})))
 				.await
-				.unwrap();
+				.expect("test operation must succeed");
 			socket
 				.send(typed(ServerMessage::CommandResult(CommandResultEnvelope {
 					version: CURRENT_VERSION,
-					server_id: ServerId::new(SERVER_ID).unwrap(),
+					server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 					client_command_id: command.client_command_id,
 					idempotency_key: command.idempotency_key,
 					outcome: CommandOutcome::AcceptanceUnknown,
@@ -1766,21 +1841,25 @@ max_entry_bytes = 0
 					error: Some(CommandError::AcceptanceUnknown),
 				})))
 				.await
-				.unwrap();
+				.expect("test operation must succeed");
 
 			drop(socket);
-			listener.cleanup().unwrap();
+			listener.cleanup().expect("test operation must succeed");
 		});
-		let profile = ClientProfile::fixture(authority, ServerId::new(SERVER_ID).unwrap());
+		let profile = ClientProfile::fixture(
+			authority,
+			ServerId::new(SERVER_ID).expect("test operation must succeed"),
+		);
 		let response = ResetCardClient::new(profile)
 			.consume(
-				EntityId::new("40000000-0000-4000-8000-000000000001").unwrap(),
-				ResetCardDescriptorDto::new(1, 2).unwrap(),
+				EntityId::new("40000000-0000-4000-8000-000000000001")
+					.expect("test operation must succeed"),
+				ResetCardDescriptorDto::new(1, 2).expect("test operation must succeed"),
 				EntityRevision(7),
-				IdempotencyKey::new("operator-key").unwrap(),
+				IdempotencyKey::new("operator-key").expect("test operation must succeed"),
 			)
 			.await
-			.unwrap();
+			.expect("test operation must succeed");
 
 		assert_eq!(
 			response,
@@ -1789,51 +1868,58 @@ max_entry_bytes = 0
 			},
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
 	async fn reset_card_consume_rejects_a_mismatched_receipt_key() {
 		let (temp, authority) = local_transport();
-		let mut listener = authority.bind().await.unwrap();
+		let mut listener = authority.bind().await.expect("test operation must succeed");
 		let task = tokio::spawn(async move {
 			let _temp = temp;
-			let stream = listener.accept().await.unwrap();
-			let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+			let stream = listener.accept().await.expect("test operation must succeed");
+			let mut socket =
+				tokio_tungstenite::accept_async(stream).await.expect("test operation must succeed");
 
 			let _ = socket.next().await;
 			for response in initial(SERVER_ID) {
-				socket.send(response).await.unwrap();
+				socket.send(response).await.expect("test operation must succeed");
 			}
 			let _ = socket.next().await;
 
-			let client_command_id = ClientCommandId::new("reset-card-use:operator-key").unwrap();
+			let client_command_id = ClientCommandId::new("reset-card-use:operator-key")
+				.expect("test operation must succeed");
 
 			socket
 				.send(typed(ServerMessage::CommandReceipt(CommandReceipt {
 					version: CURRENT_VERSION,
-					server_id: ServerId::new(SERVER_ID).unwrap(),
+					server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 					client_command_id: client_command_id.clone(),
-					idempotency_key: IdempotencyKey::new("wrong-key").unwrap(),
+					idempotency_key: IdempotencyKey::new("wrong-key")
+						.expect("test operation must succeed"),
 					disposition: ReceiptDisposition::Executed,
 					original_client_command_id: client_command_id,
 				})))
 				.await
-				.unwrap();
+				.expect("test operation must succeed");
 
 			drop(socket);
-			listener.cleanup().unwrap();
+			listener.cleanup().expect("test operation must succeed");
 		});
-		let profile = ClientProfile::fixture(authority, ServerId::new(SERVER_ID).unwrap());
+		let profile = ClientProfile::fixture(
+			authority,
+			ServerId::new(SERVER_ID).expect("test operation must succeed"),
+		);
 		let response = ResetCardClient::new(profile)
 			.consume(
-				EntityId::new("40000000-0000-4000-8000-000000000001").unwrap(),
-				ResetCardDescriptorDto::new(1, 2).unwrap(),
+				EntityId::new("40000000-0000-4000-8000-000000000001")
+					.expect("test operation must succeed"),
+				ResetCardDescriptorDto::new(1, 2).expect("test operation must succeed"),
 				EntityRevision(7),
-				IdempotencyKey::new("operator-key").unwrap(),
+				IdempotencyKey::new("operator-key").expect("test operation must succeed"),
 			)
 			.await
-			.unwrap();
+			.expect("test operation must succeed");
 
 		assert_eq!(
 			response,
@@ -1842,28 +1928,33 @@ max_entry_bytes = 0
 			}
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
 	async fn reset_card_consume_rejects_success_after_a_refused_receipt() {
 		let (temp, authority) = local_transport();
-		let mut listener = authority.bind().await.unwrap();
-		let descriptor = ResetCardDescriptorDto::new(1, 2).unwrap();
+		let mut listener = authority.bind().await.expect("test operation must succeed");
+		let descriptor = ResetCardDescriptorDto::new(1, 2).expect("test operation must succeed");
 		let result_descriptor = descriptor;
 		let task = tokio::spawn(async move {
 			let _temp = temp;
-			let stream = listener.accept().await.unwrap();
-			let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+			let stream = listener.accept().await.expect("test operation must succeed");
+			let mut socket =
+				tokio_tungstenite::accept_async(stream).await.expect("test operation must succeed");
 
 			let _ = socket.next().await;
 			for response in initial(SERVER_ID) {
-				socket.send(response).await.unwrap();
+				socket.send(response).await.expect("test operation must succeed");
 			}
-			let request = socket.next().await.unwrap().unwrap();
+			let request = socket
+				.next()
+				.await
+				.expect("test operation must succeed")
+				.expect("test operation must succeed");
 			let Message::Text(request) = request else { panic!("expected text command") };
-			let ClientMessage::Command(command) =
-				serde_json::from_str::<ClientMessage>(&request).unwrap()
+			let ClientMessage::Command(command) = serde_json::from_str::<ClientMessage>(&request)
+				.expect("test operation must succeed")
 			else {
 				panic!("expected typed command")
 			};
@@ -1871,45 +1962,50 @@ max_entry_bytes = 0
 			socket
 				.send(typed(ServerMessage::CommandReceipt(CommandReceipt {
 					version: CURRENT_VERSION,
-					server_id: ServerId::new(SERVER_ID).unwrap(),
+					server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 					client_command_id: command.client_command_id.clone(),
 					idempotency_key: command.idempotency_key.clone(),
 					disposition: ReceiptDisposition::Refused,
 					original_client_command_id: command.client_command_id.clone(),
 				})))
 				.await
-				.unwrap();
+				.expect("test operation must succeed");
 			socket
 				.send(typed(ServerMessage::CommandResult(CommandResultEnvelope {
 					version: CURRENT_VERSION,
-					server_id: ServerId::new(SERVER_ID).unwrap(),
+					server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 					client_command_id: command.client_command_id,
 					idempotency_key: command.idempotency_key,
 					outcome: CommandOutcome::Succeeded,
 					entity_revision: Some(EntityRevision(7)),
 					payload: Some(ResultPayload::ResetCardOperationAccepted {
-						account_id: EntityId::new("40000000-0000-4000-8000-000000000001").unwrap(),
+						account_id: EntityId::new("40000000-0000-4000-8000-000000000001")
+							.expect("test operation must succeed"),
 						descriptor: result_descriptor,
 						state: ResetCardOperationResult::Prepared,
 					}),
 					error: None,
 				})))
 				.await
-				.unwrap();
+				.expect("test operation must succeed");
 
 			drop(socket);
-			listener.cleanup().unwrap();
+			listener.cleanup().expect("test operation must succeed");
 		});
-		let profile = ClientProfile::fixture(authority, ServerId::new(SERVER_ID).unwrap());
+		let profile = ClientProfile::fixture(
+			authority,
+			ServerId::new(SERVER_ID).expect("test operation must succeed"),
+		);
 		let response = ResetCardClient::new(profile)
 			.consume(
-				EntityId::new("40000000-0000-4000-8000-000000000001").unwrap(),
+				EntityId::new("40000000-0000-4000-8000-000000000001")
+					.expect("test operation must succeed"),
 				descriptor,
 				EntityRevision(7),
-				IdempotencyKey::new("operator-key").unwrap(),
+				IdempotencyKey::new("operator-key").expect("test operation must succeed"),
 			)
 			.await
-			.unwrap();
+			.expect("test operation must succeed");
 
 		assert_eq!(
 			response,
@@ -1918,28 +2014,33 @@ max_entry_bytes = 0
 			}
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
 	async fn reset_card_consume_rejects_a_mismatched_returned_revision() {
 		let (temp, authority) = local_transport();
-		let mut listener = authority.bind().await.unwrap();
-		let descriptor = ResetCardDescriptorDto::new(1, 2).unwrap();
+		let mut listener = authority.bind().await.expect("test operation must succeed");
+		let descriptor = ResetCardDescriptorDto::new(1, 2).expect("test operation must succeed");
 		let result_descriptor = descriptor;
 		let task = tokio::spawn(async move {
 			let _temp = temp;
-			let stream = listener.accept().await.unwrap();
-			let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+			let stream = listener.accept().await.expect("test operation must succeed");
+			let mut socket =
+				tokio_tungstenite::accept_async(stream).await.expect("test operation must succeed");
 
 			let _ = socket.next().await;
 			for response in initial(SERVER_ID) {
-				socket.send(response).await.unwrap();
+				socket.send(response).await.expect("test operation must succeed");
 			}
-			let request = socket.next().await.unwrap().unwrap();
+			let request = socket
+				.next()
+				.await
+				.expect("test operation must succeed")
+				.expect("test operation must succeed");
 			let Message::Text(request) = request else { panic!("expected text command") };
-			let ClientMessage::Command(command) =
-				serde_json::from_str::<ClientMessage>(&request).unwrap()
+			let ClientMessage::Command(command) = serde_json::from_str::<ClientMessage>(&request)
+				.expect("test operation must succeed")
 			else {
 				panic!("expected typed command")
 			};
@@ -1947,45 +2048,50 @@ max_entry_bytes = 0
 			socket
 				.send(typed(ServerMessage::CommandReceipt(CommandReceipt {
 					version: CURRENT_VERSION,
-					server_id: ServerId::new(SERVER_ID).unwrap(),
+					server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 					client_command_id: command.client_command_id.clone(),
 					idempotency_key: command.idempotency_key.clone(),
 					disposition: ReceiptDisposition::Executed,
 					original_client_command_id: command.client_command_id.clone(),
 				})))
 				.await
-				.unwrap();
+				.expect("test operation must succeed");
 			socket
 				.send(typed(ServerMessage::CommandResult(CommandResultEnvelope {
 					version: CURRENT_VERSION,
-					server_id: ServerId::new(SERVER_ID).unwrap(),
+					server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 					client_command_id: command.client_command_id,
 					idempotency_key: command.idempotency_key,
 					outcome: CommandOutcome::Succeeded,
 					entity_revision: Some(EntityRevision(8)),
 					payload: Some(ResultPayload::ResetCardOperationAccepted {
-						account_id: EntityId::new("40000000-0000-4000-8000-000000000001").unwrap(),
+						account_id: EntityId::new("40000000-0000-4000-8000-000000000001")
+							.expect("test operation must succeed"),
 						descriptor: result_descriptor,
 						state: ResetCardOperationResult::Prepared,
 					}),
 					error: None,
 				})))
 				.await
-				.unwrap();
+				.expect("test operation must succeed");
 
 			drop(socket);
-			listener.cleanup().unwrap();
+			listener.cleanup().expect("test operation must succeed");
 		});
-		let profile = ClientProfile::fixture(authority, ServerId::new(SERVER_ID).unwrap());
+		let profile = ClientProfile::fixture(
+			authority,
+			ServerId::new(SERVER_ID).expect("test operation must succeed"),
+		);
 		let response = ResetCardClient::new(profile)
 			.consume(
-				EntityId::new("40000000-0000-4000-8000-000000000001").unwrap(),
+				EntityId::new("40000000-0000-4000-8000-000000000001")
+					.expect("test operation must succeed"),
 				descriptor,
 				EntityRevision(7),
-				IdempotencyKey::new("operator-key").unwrap(),
+				IdempotencyKey::new("operator-key").expect("test operation must succeed"),
 			)
 			.await
-			.unwrap();
+			.expect("test operation must succeed");
 
 		assert_eq!(
 			response,
@@ -1994,19 +2100,23 @@ max_entry_bytes = 0
 			}
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
 	async fn reset_card_consume_error_before_send_guarantees_no_dispatch() {
 		let (_temp, authority) = local_transport();
-		let profile = ClientProfile::fixture(authority, ServerId::new(SERVER_ID).unwrap());
+		let profile = ClientProfile::fixture(
+			authority,
+			ServerId::new(SERVER_ID).expect("test operation must succeed"),
+		);
 		let failure = ResetCardClient::new(profile)
 			.consume(
-				EntityId::new("40000000-0000-4000-8000-000000000001").unwrap(),
-				ResetCardDescriptorDto::new(1, 2).unwrap(),
+				EntityId::new("40000000-0000-4000-8000-000000000001")
+					.expect("test operation must succeed"),
+				ResetCardDescriptorDto::new(1, 2).expect("test operation must succeed"),
 				EntityRevision(7),
-				IdempotencyKey::new("operator-key").unwrap(),
+				IdempotencyKey::new("operator-key").expect("test operation must succeed"),
 			)
 			.await
 			.unwrap_err();
@@ -2017,7 +2127,10 @@ max_entry_bytes = 0
 	#[tokio::test]
 	async fn disconnected_malformed_oversized_and_timeout_fail_closed() {
 		let (_temp, authority) = local_transport();
-		let profile = ClientProfile::fixture(authority, ServerId::new(SERVER_ID).unwrap());
+		let profile = ClientProfile::fixture(
+			authority,
+			ServerId::new(SERVER_ID).expect("test operation must succeed"),
+		);
 
 		assert_eq!(
 			DoctorClient::new(profile).query().await.unwrap_err(),
@@ -2031,7 +2144,7 @@ max_entry_bytes = 0
 		assert_eq!(error, ClientFailure::ProtocolMalformed);
 		assert!(!format!("{error:?} {error}").contains("untrusted-parser-marker"));
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let oversized = Message::Text("x".repeat(super::MAX_CLIENT_MESSAGE_BYTES + 1).into());
 		let (profile, task) = fixture(vec![oversized], Vec::new()).await;
@@ -2041,19 +2154,23 @@ max_entry_bytes = 0
 			ClientFailure::ProtocolBackpressure,
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let (temp, authority) = local_transport();
-		let mut listener = authority.bind().await.unwrap();
+		let mut listener = authority.bind().await.expect("test operation must succeed");
 		let task = tokio::spawn(async move {
 			let _temp = temp;
-			let stream = listener.accept().await.unwrap();
-			let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+			let stream = listener.accept().await.expect("test operation must succeed");
+			let mut socket =
+				tokio_tungstenite::accept_async(stream).await.expect("test operation must succeed");
 			let _ = socket.next().await;
 
 			time::sleep(Duration::from_secs(1)).await;
 		});
-		let profile = ClientProfile::fixture(authority, ServerId::new(SERVER_ID).unwrap());
+		let profile = ClientProfile::fixture(
+			authority,
+			ServerId::new(SERVER_ID).expect("test operation must succeed"),
+		);
 		let client = DoctorClient { profile, timeout: Duration::from_millis(20) };
 
 		assert_eq!(client.query().await.unwrap_err(), ClientFailure::ProtocolTimeout);

--- a/crates/decodex-protocol/src/lib.rs
+++ b/crates/decodex-protocol/src/lib.rs
@@ -168,11 +168,14 @@ mod tests {
 		use crate::{LocalTransportAuthority, LocalTransportRefusal};
 		use decodex_core::{DecodexRoot, LocalTrustPolicy};
 
-		let temp = tempfile::tempdir().unwrap();
-		let root = DecodexRoot::new(temp.path().canonicalize().unwrap().join(".decodex")).unwrap();
+		let temp = tempfile::tempdir().expect("test operation must succeed");
+		let root = DecodexRoot::new(
+			temp.path().canonicalize().expect("test operation must succeed").join(".decodex"),
+		)
+		.expect("test operation must succeed");
 		let paths = root.paths();
 
-		paths.ensure_layout().unwrap();
+		paths.ensure_layout().expect("test operation must succeed");
 
 		// SAFETY: `geteuid` has no arguments or failure return.
 		let uid = unsafe { libc::geteuid() };

--- a/crates/decodex-protocol/src/retained_session.rs
+++ b/crates/decodex-protocol/src/retained_session.rs
@@ -945,11 +945,11 @@ mod tests {
 	}
 
 	fn server_id(value: &str) -> ServerId {
-		ServerId::new(value).unwrap()
+		ServerId::new(value).expect("test operation must succeed")
 	}
 
 	fn instance_id(value: &str) -> ServerInstanceId {
-		ServerInstanceId::new(value).unwrap()
+		ServerInstanceId::new(value).expect("test operation must succeed")
 	}
 
 	fn checkpoint(instance: &str, cursor: u64) -> SessionCheckpoint {
@@ -978,9 +978,9 @@ mod tests {
 			server_id: server_id(server),
 			cursor: Cursor(cursor),
 			items: vec![SnapshotItem::SystemState {
-				entity_id: EntityId::new("system").unwrap(),
+				entity_id: EntityId::new("system").expect("test operation must succeed"),
 				revision: EntityRevision(cursor),
-				status: WireText::new("ready").unwrap(),
+				status: WireText::new("ready").expect("test operation must succeed"),
 			}],
 		})
 	}
@@ -991,12 +991,14 @@ mod tests {
 			server_id: server_id(SERVER_ID),
 			cursor: Cursor(cursor),
 			channel: Channel::SystemHealth,
-			entity_id: EntityId::new("system").unwrap(),
+			entity_id: EntityId::new("system").expect("test operation must succeed"),
 			entity_revision: EntityRevision(cursor),
-			correlation_id: CorrelationId::new(format!("correlation-{cursor}")).unwrap(),
+			correlation_id: CorrelationId::new(format!("correlation-{cursor}"))
+				.expect("test operation must succeed"),
 			causation_id: None,
 			payload: EventPayload::SystemObservationRefreshed {
-				status: WireText::new(format!("event-{cursor}")).unwrap(),
+				status: WireText::new(format!("event-{cursor}"))
+					.expect("test operation must succeed"),
 			},
 		})
 	}
@@ -1005,23 +1007,27 @@ mod tests {
 		ServerMessage::CommandReceipt(CommandReceipt {
 			version: CURRENT_VERSION,
 			server_id: server_id(SERVER_ID),
-			client_command_id: ClientCommandId::new("command-1").unwrap(),
-			idempotency_key: IdempotencyKey::new("key-1").unwrap(),
+			client_command_id: ClientCommandId::new("command-1")
+				.expect("test operation must succeed"),
+			idempotency_key: IdempotencyKey::new("key-1").expect("test operation must succeed"),
 			disposition: ReceiptDisposition::Executed,
-			original_client_command_id: ClientCommandId::new("command-1").unwrap(),
+			original_client_command_id: ClientCommandId::new("command-1")
+				.expect("test operation must succeed"),
 		})
 	}
 
 	fn command() -> CommandEnvelope {
 		CommandEnvelope {
 			version: CURRENT_VERSION,
-			client_command_id: ClientCommandId::new("command-1").unwrap(),
-			idempotency_key: IdempotencyKey::new("key-1").unwrap(),
+			client_command_id: ClientCommandId::new("command-1")
+				.expect("test operation must succeed"),
+			idempotency_key: IdempotencyKey::new("key-1").expect("test operation must succeed"),
 			expected_revision: None,
-			correlation_id: CorrelationId::new("correlation-command").unwrap(),
+			correlation_id: CorrelationId::new("correlation-command")
+				.expect("test operation must succeed"),
 			causation_id: None,
 			payload: CommandPayload::RefreshSystemObservation {
-				entity_id: EntityId::new("system").unwrap(),
+				entity_id: EntityId::new("system").expect("test operation must succeed"),
 			},
 		}
 	}
@@ -1030,8 +1036,9 @@ mod tests {
 		ServerMessage::CommandResult(CommandResultEnvelope {
 			version: CURRENT_VERSION,
 			server_id: server_id(SERVER_ID),
-			client_command_id: ClientCommandId::new("command-1").unwrap(),
-			idempotency_key: IdempotencyKey::new("key-1").unwrap(),
+			client_command_id: ClientCommandId::new("command-1")
+				.expect("test operation must succeed"),
+			idempotency_key: IdempotencyKey::new("key-1").expect("test operation must succeed"),
 			outcome: CommandOutcome::Rejected,
 			entity_revision: None,
 			payload: None,
@@ -1040,17 +1047,20 @@ mod tests {
 	}
 
 	fn local_transport() -> (TempDir, LocalTransportAuthority) {
-		let temp = TempDir::new().unwrap();
-		let root = DecodexRoot::new(temp.path().canonicalize().unwrap().join(".decodex")).unwrap();
+		let temp = TempDir::new().expect("test operation must succeed");
+		let root = DecodexRoot::new(
+			temp.path().canonicalize().expect("test operation must succeed").join(".decodex"),
+		)
+		.expect("test operation must succeed");
 		let paths = root.paths();
 
-		paths.ensure_layout().unwrap();
+		paths.ensure_layout().expect("test operation must succeed");
 
 		// SAFETY: `geteuid` has no arguments or failure return.
 		let service_owner_uid = unsafe { libc::geteuid() };
 		let authority =
 			LocalTransportAuthority::new(paths, LocalTrustPolicy::SameUid, Some(service_owner_uid))
-				.unwrap();
+				.expect("test operation must succeed");
 
 		(temp, authority)
 	}
@@ -1066,15 +1076,21 @@ mod tests {
 	}
 
 	async fn send(socket: &mut WebSocketStream<LocalTransportStream>, message: ServerMessage) {
-		let text = serde_json::to_string(&message).unwrap();
+		let text = serde_json::to_string(&message).expect("test operation must succeed");
 
-		socket.send(Message::Text(text.into())).await.unwrap();
+		socket.send(Message::Text(text.into())).await.expect("test operation must succeed");
 	}
 
 	async fn hello(socket: &mut WebSocketStream<LocalTransportStream>) -> ClientHello {
-		let message = socket.next().await.unwrap().unwrap();
+		let message = socket
+			.next()
+			.await
+			.expect("test operation must succeed")
+			.expect("test operation must succeed");
 		let Message::Text(text) = message else { panic!("expected text hello") };
-		let ClientMessage::Hello(hello) = serde_json::from_str(&text).unwrap() else {
+		let ClientMessage::Hello(hello) =
+			serde_json::from_str(&text).expect("test operation must succeed")
+		else {
 			panic!("expected typed hello")
 		};
 
@@ -1090,13 +1106,14 @@ mod tests {
 		Fut: Future<Output = ()> + Send + 'static,
 	{
 		let (temp, authority) = local_transport();
-		let mut listener = authority.bind().await.unwrap();
+		let mut listener = authority.bind().await.expect("test operation must succeed");
 		let task = tokio::spawn(async move {
-			let stream = listener.accept().await.unwrap();
-			let socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+			let stream = listener.accept().await.expect("test operation must succeed");
+			let socket =
+				tokio_tungstenite::accept_async(stream).await.expect("test operation must succeed");
 
 			handler(socket).await;
-			listener.cleanup().unwrap();
+			listener.cleanup().expect("test operation must succeed");
 		});
 		let config = RetainedSessionConfig::new(authority, server_id(SERVER_ID));
 
@@ -1134,13 +1151,15 @@ mod tests {
 			send(&mut socket, snapshot(SERVER_ID, 7)).await;
 		})
 		.await;
-		let mut session =
-			RetainedSession::connect(config, None, SessionCancellation::new()).await.unwrap();
+		let mut session = RetainedSession::connect(config, None, SessionCancellation::new())
+			.await
+			.expect("test operation must succeed");
 
 		assert_eq!(session.welcome_high_water(), Cursor(7));
 		assert_eq!(session.checkpoint(), None);
 
-		let SessionDelivery::Snapshot { snapshot, confirmation } = session.next().await.unwrap()
+		let SessionDelivery::Snapshot { snapshot, confirmation } =
+			session.next().await.expect("test operation must succeed")
 		else {
 			panic!("expected snapshot")
 		};
@@ -1163,7 +1182,7 @@ mod tests {
 		);
 		assert_eq!(session.checkpoint(), None);
 
-		let applied = session.confirm_applied(confirmation).unwrap();
+		let applied = session.confirm_applied(confirmation).expect("test operation must succeed");
 
 		assert_eq!(applied.server_id(), &server_id(SERVER_ID));
 		assert_eq!(applied.instance_id(), &instance_id(INSTANCE_ID));
@@ -1171,7 +1190,7 @@ mod tests {
 
 		drop(session);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1179,7 +1198,7 @@ mod tests {
 		let resume = checkpoint(INSTANCE_ID, 1);
 		let expected_resume = resume.clone();
 		let (config, task, _temp) = fixture(move |mut socket| async move {
-			let actual = hello(&mut socket).await.resume.unwrap();
+			let actual = hello(&mut socket).await.resume.expect("test operation must succeed");
 
 			assert_eq!(actual.server_id, expected_resume.server_id);
 			assert_eq!(actual.instance_id.as_ref(), Some(&expected_resume.instance_id));
@@ -1190,12 +1209,18 @@ mod tests {
 			send(&mut socket, event(2)).await;
 			send(&mut socket, event(3)).await;
 
-			let Message::Text(message) = socket.next().await.unwrap().unwrap() else {
+			let Message::Text(message) = socket
+				.next()
+				.await
+				.expect("test operation must succeed")
+				.expect("test operation must succeed")
+			else {
 				panic!("expected command")
 			};
 
 			assert_eq!(
-				serde_json::from_str::<ClientMessage>(&message).unwrap(),
+				serde_json::from_str::<ClientMessage>(&message)
+					.expect("test operation must succeed"),
 				ClientMessage::Command(command())
 			);
 
@@ -1206,38 +1231,48 @@ mod tests {
 		let mut session =
 			RetainedSession::connect(config, Some(resume), SessionCancellation::new())
 				.await
-				.unwrap();
+				.expect("test operation must succeed");
 
-		assert_eq!(session.checkpoint().unwrap().cursor(), Cursor(1));
+		assert_eq!(session.checkpoint().expect("test operation must succeed").cursor(), Cursor(1));
 
-		let SessionDelivery::Event { event, confirmation } = session.next().await.unwrap() else {
+		let SessionDelivery::Event { event, confirmation } =
+			session.next().await.expect("test operation must succeed")
+		else {
 			panic!("expected first event")
 		};
 
 		assert_eq!(event.cursor, Cursor(2));
 
-		session.confirm_applied(confirmation).unwrap();
+		session.confirm_applied(confirmation).expect("test operation must succeed");
 
-		let SessionDelivery::Event { event, confirmation } = session.next().await.unwrap() else {
+		let SessionDelivery::Event { event, confirmation } =
+			session.next().await.expect("test operation must succeed")
+		else {
 			panic!("expected second event")
 		};
 
 		assert_eq!(event.cursor, Cursor(3));
-		assert_eq!(session.checkpoint().unwrap().cursor(), Cursor(2));
+		assert_eq!(session.checkpoint().expect("test operation must succeed").cursor(), Cursor(2));
 		assert_eq!(
 			session.next().await.unwrap_err(),
 			RetainedSessionFailure::ApplicationConfirmationRequired
 		);
 
-		session.confirm_applied(confirmation).unwrap();
-		session.send_command(command()).await.unwrap();
+		session.confirm_applied(confirmation).expect("test operation must succeed");
+		session.send_command(command()).await.expect("test operation must succeed");
 
-		assert!(matches!(session.next().await.unwrap(), SessionDelivery::CommandReceipt(_)));
-		assert!(matches!(session.next().await.unwrap(), SessionDelivery::CommandResult(_)));
+		assert!(matches!(
+			session.next().await.expect("test operation must succeed"),
+			SessionDelivery::CommandReceipt(_)
+		));
+		assert!(matches!(
+			session.next().await.expect("test operation must succeed"),
+			SessionDelivery::CommandResult(_)
+		));
 
 		drop(session);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1255,12 +1290,12 @@ mod tests {
 			SessionCancellation::new(),
 		)
 		.await
-		.unwrap();
+		.expect("test operation must succeed");
 
 		assert_eq!(session.next().await.unwrap_err(), RetainedSessionFailure::PublicationOrder);
 		assert_eq!(session.next().await.unwrap_err(), RetainedSessionFailure::Closed);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1268,7 +1303,7 @@ mod tests {
 		let old_checkpoint = checkpoint(INSTANCE_ID, 5);
 		let (config, task, _temp) = fixture(|mut socket| async move {
 			assert_eq!(
-				hello(&mut socket).await.resume.unwrap().instance_id,
+				hello(&mut socket).await.resume.expect("test operation must succeed").instance_id,
 				Some(instance_id(INSTANCE_ID))
 			);
 
@@ -1283,21 +1318,24 @@ mod tests {
 		let mut session =
 			RetainedSession::connect(config, Some(old_checkpoint), SessionCancellation::new())
 				.await
-				.unwrap();
+				.expect("test operation must succeed");
 
 		assert_eq!(session.checkpoint(), None);
 
-		let SessionDelivery::Snapshot { confirmation, .. } = session.next().await.unwrap() else {
+		let SessionDelivery::Snapshot { confirmation, .. } =
+			session.next().await.expect("test operation must succeed")
+		else {
 			panic!("expected fallback snapshot")
 		};
-		let checkpoint = session.confirm_applied(confirmation).unwrap();
+		let checkpoint =
+			session.confirm_applied(confirmation).expect("test operation must succeed");
 
 		assert_eq!(checkpoint.instance_id(), &instance_id(NEW_INSTANCE_ID));
 		assert_eq!(checkpoint.cursor(), Cursor(8));
 
 		drop(session);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1333,7 +1371,7 @@ mod tests {
 			RetainedSessionFailure::ServerIdentityMismatch
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let (config, task, _temp) = fixture(|mut socket| async move {
 			hello(&mut socket).await;
@@ -1353,7 +1391,7 @@ mod tests {
 			RetainedSessionFailure::CheckpointIdentityMismatch
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1361,7 +1399,10 @@ mod tests {
 		let (config, task, _temp) = fixture(|mut socket| async move {
 			hello(&mut socket).await;
 
-			socket.send(Message::Binary(vec![1, 2, 3].into())).await.unwrap();
+			socket
+				.send(Message::Binary(vec![1, 2, 3].into()))
+				.await
+				.expect("test operation must succeed");
 		})
 		.await;
 
@@ -1370,7 +1411,7 @@ mod tests {
 			RetainedSessionFailure::Malformed
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let (config, task, _temp) = fixture(|mut socket| async move {
 			hello(&mut socket).await;
@@ -1379,7 +1420,8 @@ mod tests {
 				ServerMessage::Refusal(RefusalEnvelope {
 					server_id: server_id(SERVER_ID),
 					refusal: Refusal::ProtocolViolation {
-						message: WireText::new("untrusted server detail").unwrap(),
+						message: WireText::new("untrusted server detail")
+							.expect("test operation must succeed"),
 					},
 				}),
 			)
@@ -1392,7 +1434,7 @@ mod tests {
 		assert_eq!(failure, RetainedSessionFailure::ProtocolViolation);
 		assert!(!failure.to_string().contains("untrusted"));
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let (config, task, _temp) = fixture(|mut socket| async move {
 			hello(&mut socket).await;
@@ -1414,7 +1456,7 @@ mod tests {
 			RetainedSessionFailure::ProtocolMinorMismatch
 		);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1426,12 +1468,12 @@ mod tests {
 			send(&mut socket, welcome(SERVER_ID, Some(INSTANCE_ID), 0, ReconnectMode::Resume))
 				.await;
 
-			idle_sender.send(()).unwrap();
+			idle_sender.send(()).expect("test operation must succeed");
 
 			tokio::select! {
 				biased;
 
-				result = release_receiver => result.unwrap(),
+				result = release_receiver => result.expect("test operation must succeed"),
 				message = socket.next() => panic!("idle session emitted or closed: {message:?}"),
 			}
 
@@ -1444,16 +1486,18 @@ mod tests {
 			SessionCancellation::new(),
 		)
 		.await
-		.unwrap();
+		.expect("test operation must succeed");
 
 		session.set_operation_timeout(std::time::Duration::ZERO);
-		idle_receiver.await.unwrap();
+		idle_receiver.await.expect("test operation must succeed");
 
 		task::yield_now().await;
 
-		release_sender.send(()).unwrap();
+		release_sender.send(()).expect("test operation must succeed");
 
-		let SessionDelivery::Event { event, .. } = session.next().await.unwrap() else {
+		let SessionDelivery::Event { event, .. } =
+			session.next().await.expect("test operation must succeed")
+		else {
 			panic!("expected event after idle release")
 		};
 
@@ -1461,7 +1505,7 @@ mod tests {
 
 		drop(session);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1473,11 +1517,11 @@ mod tests {
 			send(&mut socket, welcome(SERVER_ID, Some(INSTANCE_ID), 0, ReconnectMode::Resume))
 				.await;
 
-			ready_sender.send(()).unwrap();
+			ready_sender.send(()).expect("test operation must succeed");
 
 			while socket.next().await.is_some() {}
 
-			closed_sender.send(()).unwrap();
+			closed_sender.send(()).expect("test operation must succeed");
 		})
 		.await;
 		let cancellation = SessionCancellation::new();
@@ -1487,9 +1531,9 @@ mod tests {
 			cancellation.clone(),
 		)
 		.await
-		.unwrap();
+		.expect("test operation must succeed");
 
-		ready_receiver.await.unwrap();
+		ready_receiver.await.expect("test operation must succeed");
 
 		let client_task = tokio::spawn(async move { session.next().await });
 
@@ -1497,10 +1541,13 @@ mod tests {
 
 		cancellation.cancel();
 
-		assert_eq!(client_task.await.unwrap().unwrap_err(), RetainedSessionFailure::Cancelled);
+		assert_eq!(
+			client_task.await.expect("test operation must succeed").unwrap_err(),
+			RetainedSessionFailure::Cancelled
+		);
 
-		closed_receiver.await.unwrap();
-		server_task.await.unwrap();
+		closed_receiver.await.expect("test operation must succeed");
+		server_task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1521,11 +1568,11 @@ mod tests {
 			SessionCancellation::new(),
 		)
 		.await
-		.unwrap();
+		.expect("test operation must succeed");
 
 		assert_eq!(session.next().await.unwrap_err(), RetainedSessionFailure::Backpressure);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 
 		let (config, task, _temp) = fixture(|mut socket| async move {
 			hello(&mut socket).await;
@@ -1547,11 +1594,11 @@ mod tests {
 			SessionCancellation::new(),
 		)
 		.await
-		.unwrap();
+		.expect("test operation must succeed");
 
 		assert_eq!(session.next().await.unwrap_err(), RetainedSessionFailure::Backpressure);
 
-		task.await.unwrap();
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1562,12 +1609,16 @@ mod tests {
 			send(&mut socket, welcome(SERVER_ID, Some(INSTANCE_ID), 0, ReconnectMode::Resume))
 				.await;
 
-			let message = socket.next().await.unwrap().unwrap();
+			let message = socket
+				.next()
+				.await
+				.expect("test operation must succeed")
+				.expect("test operation must succeed");
 
 			assert!(matches!(message, Message::Close(_)));
 
-			socket.flush().await.unwrap();
-			closed_sender.send(()).unwrap();
+			socket.flush().await.expect("test operation must succeed");
+			closed_sender.send(()).expect("test operation must succeed");
 		})
 		.await;
 		let session = RetainedSession::connect(
@@ -1576,11 +1627,11 @@ mod tests {
 			SessionCancellation::new(),
 		)
 		.await
-		.unwrap();
+		.expect("test operation must succeed");
 
-		session.close().await.unwrap();
-		closed_receiver.await.unwrap();
-		task.await.unwrap();
+		session.close().await.expect("test operation must succeed");
+		closed_receiver.await.expect("test operation must succeed");
+		task.await.expect("test operation must succeed");
 	}
 
 	#[tokio::test]
@@ -1592,11 +1643,11 @@ mod tests {
 			send(&mut socket, welcome(SERVER_ID, Some(INSTANCE_ID), 0, ReconnectMode::Resume))
 				.await;
 
-			release_receiver.await.unwrap();
+			release_receiver.await.expect("test operation must succeed");
 
 			while socket.next().await.is_some() {}
 
-			closed_sender.send(()).unwrap();
+			closed_sender.send(()).expect("test operation must succeed");
 		})
 		.await;
 		let mut session = RetainedSession::connect(
@@ -1605,14 +1656,14 @@ mod tests {
 			SessionCancellation::new(),
 		)
 		.await
-		.unwrap();
+		.expect("test operation must succeed");
 
 		session.set_operation_timeout(std::time::Duration::ZERO);
 
 		assert_eq!(session.close().await.unwrap_err(), RetainedSessionFailure::OperationTimeout);
 
-		release_sender.send(()).unwrap();
-		closed_receiver.await.unwrap();
-		task.await.unwrap();
+		release_sender.send(()).expect("test operation must succeed");
+		closed_receiver.await.expect("test operation must succeed");
+		task.await.expect("test operation must succeed");
 	}
 }

--- a/crates/decodex-runtime/tests/bootstrap_doctor.rs
+++ b/crates/decodex-runtime/tests/bootstrap_doctor.rs
@@ -656,9 +656,10 @@ async fn doctor_crosses_the_daemon_protocol_and_wrong_server_is_refused() {
 		&mut client,
 		ClientMessage::Query(QueryEnvelope {
 			version: CURRENT_VERSION,
-			query_id: QueryId::new("history-unavailable").unwrap(),
+			query_id: QueryId::new("history-unavailable").expect("test operation must succeed"),
 			payload: QueryPayload::GetConversationHistory {
-				conversation_id: EntityId::new("40000000-0000-4000-8000-000000000001").unwrap(),
+				conversation_id: EntityId::new("40000000-0000-4000-8000-000000000001")
+					.expect("test operation must succeed"),
 				after: None,
 				page_size: 1,
 			},

--- a/crates/decodex-runtime/tests/websocket_protocol.rs
+++ b/crates/decodex-runtime/tests/websocket_protocol.rs
@@ -445,7 +445,7 @@ async fn current_previous_minor_and_exact_major_refusal_use_real_websockets() {
 		server("version-server", FixtureApplication::default(), ServerConfig::default())
 			.bind(transport.clone())
 			.await
-			.unwrap();
+			.expect("test operation must succeed");
 
 	for (index, version) in [PREVIOUS_MINOR_VERSION, CURRENT_VERSION].into_iter().enumerate() {
 		let mut client = connect(&transport, version).await;
@@ -459,7 +459,7 @@ async fn current_previous_minor_and_exact_major_refusal_use_real_websockets() {
 
 		execute_and_receive_event(&mut client, version, index as u64 + 1).await;
 
-		client.close(None).await.unwrap();
+		client.close(None).await.expect("test operation must succeed");
 	}
 
 	let mut client = connect(&transport, ProtocolVersion { major: 2, minor: 0 }).await;
@@ -486,7 +486,7 @@ async fn current_previous_minor_and_exact_major_refusal_use_real_websockets() {
 
 	drop(client);
 
-	bound.shutdown().await.unwrap();
+	bound.shutdown().await.expect("test operation must succeed");
 }
 
 #[tokio::test]
@@ -576,7 +576,7 @@ async fn duplicate_command_returns_the_original_receipt_and_mutates_once() {
 	let mut bound = server("idempotency-server", application.clone(), ServerConfig::default())
 		.bind(transport.clone())
 		.await
-		.unwrap();
+		.expect("test operation must succeed");
 	let mut client = connect(&transport, CURRENT_VERSION).await;
 	let (_, instance_id, _, _) = receive_initial(&mut client).await;
 
@@ -635,7 +635,7 @@ async fn duplicate_command_returns_the_original_receipt_and_mutates_once() {
 
 	drop(client);
 
-	bound.shutdown().await.unwrap();
+	bound.shutdown().await.expect("test operation must succeed");
 }
 
 #[tokio::test]
@@ -645,7 +645,7 @@ async fn expected_revision_mismatch_is_rejected_without_publication() {
 	let mut bound = server("revision-server", application.clone(), ServerConfig::default())
 		.bind(transport.clone())
 		.await
-		.unwrap();
+		.expect("test operation must succeed");
 	let mut client = connect(&transport, CURRENT_VERSION).await;
 
 	receive_initial(&mut client).await;
@@ -676,7 +676,7 @@ async fn expected_revision_mismatch_is_rejected_without_publication() {
 
 	drop(client);
 
-	bound.shutdown().await.unwrap();
+	bound.shutdown().await.expect("test operation must succeed");
 }
 
 #[tokio::test]
@@ -687,7 +687,7 @@ async fn acceptance_unknown_is_not_cached_and_same_key_can_recover() {
 		server("acceptance-unknown-server", application.clone(), ServerConfig::default())
 			.bind(transport.clone())
 			.await
-			.unwrap();
+			.expect("test operation must succeed");
 	let mut client = connect(&transport, CURRENT_VERSION).await;
 
 	receive_initial(&mut client).await;
@@ -724,7 +724,7 @@ async fn acceptance_unknown_is_not_cached_and_same_key_can_recover() {
 	assert_eq!(application.executions(), 1);
 
 	drop(client);
-	bound.shutdown().await.unwrap();
+	bound.shutdown().await.expect("test operation must succeed");
 }
 
 #[tokio::test]
@@ -734,7 +734,7 @@ async fn reconnect_resumes_ordered_deltas_and_falls_back_to_a_snapshot() {
 	let mut bound = server("resume-server", FixtureApplication::default(), config)
 		.bind(transport.clone())
 		.await
-		.unwrap();
+		.expect("test operation must succeed");
 	let mut first = connect(&transport, CURRENT_VERSION).await;
 	let (server_id, instance_id, _, _) = receive_initial(&mut first).await;
 	let persisted = execute_and_receive_event(&mut first, CURRENT_VERSION, 1).await;
@@ -825,7 +825,7 @@ async fn reconnect_resumes_ordered_deltas_and_falls_back_to_a_snapshot() {
 
 	drop(previous);
 
-	bound.shutdown().await.unwrap();
+	bound.shutdown().await.expect("test operation must succeed");
 }
 
 #[tokio::test]
@@ -1305,19 +1305,19 @@ async fn restart_with_stable_server_identity_rejects_equal_and_overlapping_old_e
 	let mut first = server("stable-restart", application.clone(), ServerConfig::default())
 		.bind(transport.clone())
 		.await
-		.unwrap();
+		.expect("test operation must succeed");
 	let mut client = connect(&transport, CURRENT_VERSION).await;
 	let (server_id, old_instance_id, initial_cursor, _) = receive_initial(&mut client).await;
 	let overlapping_cursor = execute_and_receive_event(&mut client, CURRENT_VERSION, 1).await;
 
 	drop(client);
 
-	first.shutdown().await.unwrap();
+	first.shutdown().await.expect("test operation must succeed");
 
 	let mut restarted = server("stable-restart", application, ServerConfig::default())
 		.bind(transport.clone())
 		.await
-		.unwrap();
+		.expect("test operation must succeed");
 	let mut client = reconnect(
 		&transport,
 		CURRENT_VERSION,
@@ -1365,7 +1365,7 @@ async fn restart_with_stable_server_identity_rejects_equal_and_overlapping_old_e
 
 	drop(client);
 
-	restarted.shutdown().await.unwrap();
+	restarted.shutdown().await.expect("test operation must succeed");
 }
 
 #[tokio::test]

--- a/openwiki/operations/codex-upstream-autopilot.md
+++ b/openwiki/operations/codex-upstream-autopilot.md
@@ -177,8 +177,10 @@ and no external network. It can read the exact candidate, trusted primary Git da
 Rust toolchains, system runtime files, and its private temporary directory. Personal
 roots and unrelated temporary data remain unreadable. It can write only private build
 outputs and approved site caches. Cargo registry and Git source caches are read-only
-during candidate execution. The receipt binds the dependency-preparation digest,
-sandbox profile digest, and exact sandbox executable digest.
+during candidate execution. The validator binds the root-owned, read-only Python
+3.11-or-later runtime that loaded the automation. It places that exact runtime before
+macOS system shims in the sandbox path. The receipt binds the dependency-preparation
+digest, sandbox profile digest, and exact sandbox executable digest.
 
 A source change cannot become terminal until a separate Reviewer repeats all required
 validation profiles on the same pull-request HEAD and tree. The commit and landing

--- a/scripts/vnext/postgres_store_test.py
+++ b/scripts/vnext/postgres_store_test.py
@@ -38,7 +38,7 @@ AUTHORITY_CANDIDATE_SCHEMA = "decodex/postgres-authority-candidate/3"
 AUTHORITY_CANDIDATE_RECEIPT_MAX_BYTES = 128 * 1024
 POSTGRES_START_LOG_EXCERPT_MAX_BYTES = 4 * 1024
 # Darwin's sockaddr_un.sun_path is 104 bytes, including the terminating NUL.
-POSTGRES_UNIX_SOCKET_PATH_MAX_BYTES = 104
+PORTABLE_UNIX_SOCKET_PATH_MAX_BYTES = 104
 GIT_READ_TIMEOUT_SECONDS = 5.0
 GIT_METADATA_MAX_BYTES = 4 * 1024
 GIT_COMMIT_MAX_BYTES = 64 * 1024
@@ -5843,6 +5843,14 @@ def write_bootstrap_config(
 	runtime_role: str,
 ) -> None:
 	"""Write one private typed daemon-bootstrap root without credentials."""
+	local_transport_stage = root / "server" / "decodex.sock.stage"
+	local_transport_path_bytes = len(os.fsencode(local_transport_stage)) + 1
+	if local_transport_path_bytes > PORTABLE_UNIX_SOCKET_PATH_MAX_BYTES:
+		raise TestFailure(
+			"Decodex local transport Unix socket path is too long: "
+			f"{local_transport_path_bytes} bytes including the terminating NUL exceeds "
+			f"the portable {PORTABLE_UNIX_SOCKET_PATH_MAX_BYTES}-byte limit"
+		)
 	root.mkdir(mode=0o700)
 	config_path = root / "config.toml"
 	config_path.write_text(
@@ -6025,11 +6033,11 @@ def main() -> int | AuthorityCandidatePublication:
 			log_path = work / "postgres.log"
 			socket_path = socket_dir / f".s.PGSQL.{port}"
 			socket_path_bytes = len(os.fsencode(socket_path)) + 1
-			if socket_path_bytes > POSTGRES_UNIX_SOCKET_PATH_MAX_BYTES:
+			if socket_path_bytes > PORTABLE_UNIX_SOCKET_PATH_MAX_BYTES:
 				raise TestFailure(
 					"PostgreSQL Unix socket path is too long: "
 					f"{socket_path_bytes} bytes including the terminating NUL exceeds "
-					f"the portable {POSTGRES_UNIX_SOCKET_PATH_MAX_BYTES}-byte limit; "
+					f"the portable {PORTABLE_UNIX_SOCKET_PATH_MAX_BYTES}-byte limit; "
 					"set DECODEX_TEST_TEMP_ROOT to a shorter absolute directory"
 				)
 			role_setting_canary_guc = f"xy1272.canary_{secrets.token_hex(16)}"
@@ -6348,7 +6356,7 @@ def main() -> int | AuthorityCandidatePublication:
 			], env),
 			depends_on=("primary_foundation",),
 		)
-		bootstrap_root = work / "decodex-root"
+		bootstrap_root = work / "dx-main"
 		def bootstrap_configuration() -> None:
 			write_bootstrap_config(
 				bootstrap_root, socket_dir, port, DATABASE, MIGRATION_ROLE, RUNTIME_ROLE
@@ -6393,7 +6401,7 @@ def main() -> int | AuthorityCandidatePublication:
 			], env),
 			depends_on=("primary_foundation",),
 		)
-		auth_bootstrap_root = work / "decodex-auth-root"
+		auth_bootstrap_root = work / "dx-auth"
 		def authentication_rejection() -> str:
 			write_bootstrap_config(
 				auth_bootstrap_root,
@@ -6522,13 +6530,13 @@ def main() -> int | AuthorityCandidatePublication:
 					invariant_sql=expand(invariant_sql),
 				))
 				if case_id == "truncate":
-					root = work / "decodex-unsafe-truncate"
+					root = work / "dx-unsafe"
 					write_bootstrap_config(
 						root, socket_dir, port, case_database, MIGRATION_ROLE, role
 					)
 					env["DECODEX_TEST_UNSAFE_AUTHORITY_ROOT"] = str(root)
 				elif case_id == "missing-ledger-select":
-					root = work / "decodex-incompatible-missing-history-select"
+					root = work / "dx-incompat"
 					write_bootstrap_config(
 						root, socket_dir, port, case_database, MIGRATION_ROLE, role
 					)
@@ -6636,7 +6644,7 @@ def main() -> int | AuthorityCandidatePublication:
 					],
 					env,
 				))
-				for database, case_id, mutation in (
+				for live_index, (database, case_id, mutation) in enumerate((
 					(
 						LEDGER_TAMPER_DATABASE,
 						"ledger-tamper",
@@ -6647,10 +6655,10 @@ def main() -> int | AuthorityCandidatePublication:
 						"missing-pgcrypto",
 						"DROP EXTENSION pgcrypto CASCADE",
 					),
-				):
+				)):
 					clone_authority_database(AUTHORITY_DATABASE, database, env)
 					provision_runtime(database, RUNTIME_ROLE, env)
-					root = work / f"decodex-incompatible-live-{case_id}"
+					root = work / f"dx-live-{live_index}"
 					write_bootstrap_config(
 						root, socket_dir, port, database, MIGRATION_ROLE, RUNTIME_ROLE
 					)
@@ -6747,7 +6755,7 @@ def main() -> int | AuthorityCandidatePublication:
 				env,
 			) != "t":
 				raise TestFailure("hostile callable shadow reached Decodex runtime DML")
-			hostile_search_root = work / "decodex-hostile-search-path"
+			hostile_search_root = work / "dx-hostile"
 			write_bootstrap_config(
 				hostile_search_root,
 				socket_dir,
@@ -7005,7 +7013,7 @@ def main() -> int | AuthorityCandidatePublication:
 				],
 				env,
 			)
-			default_acl_tamper_root = work / "decodex-incompatible-schema-default-acl"
+			default_acl_tamper_root = work / "dx-acl"
 			write_bootstrap_config(
 				default_acl_tamper_root,
 				socket_dir,

--- a/tests/scripts/test_postgres_authority_capture.py
+++ b/tests/scripts/test_postgres_authority_capture.py
@@ -101,6 +101,25 @@ def runtime_authority(database):
 
 
 class PostgresAuthorityCaptureDiagnosticTests(unittest.TestCase):
+    def test_bootstrap_config_rejects_overlong_local_transport_path(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / ("x" * 104)
+
+            with self.assertRaisesRegex(
+                POSTGRES_STORE_TEST.TestFailure,
+                "Decodex local transport Unix socket path is too long",
+            ):
+                POSTGRES_STORE_TEST.write_bootstrap_config(
+                    root,
+                    Path(temporary) / "socket",
+                    54_321,
+                    "decodex_test",
+                    "decodex_migration",
+                    "decodex_runtime",
+                )
+
+            self.assertFalse(root.exists())
+
     def test_secret_logging_reader_consumes_coalesced_pipe_frames(self):
         read_descriptor, write_descriptor = os.pipe()
         try:


### PR DESCRIPTION
## Summary
- bind sandbox validation to the trusted Python runtime that launched the upstream automation
- restore strict current-main Clippy gates after the local transport landing
- shorten integration bootstrap roots and reject overlong Decodex Unix socket paths before runtime classification

## Evidence
- `cargo make check`
- `python3 scripts/vnext/postgres_store_test.py --focus-authority-classification`
- `python3 -m unittest tests.scripts.test_postgres_authority_capture`

All commands passed with the trusted Python 3.14 runtime and Xcode beta developer directory.