### PR TITLE
Restore Reset Card local service lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,10 +1628,16 @@ dependencies = [
 name = "decodexd"
 version = "0.2.0"
 dependencies = [
+ "base64",
+ "clap",
  "decodex-runtime",
  "libc",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
  "tempfile",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]

--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -78,6 +78,38 @@ or use. The CLI and app cannot bypass daemon admission or recover an operation b
 calling Codex directly. The app bundle includes `decodexd` as a distribution artifact,
 but Swift does not start it or inject its database and vault credentials.
 
+For a source installation on macOS, install the local user service after the new
+CLI and daemon binaries are in `~/.local/bin`:
+
+```sh
+python3 scripts/macos/install_decodex_local_service.py --replace-config
+```
+
+The installer requires PostgreSQL 18. It creates one checksummed cluster below
+`~/.decodex/postgres`, disables TCP, uses a private Unix-socket directory, creates
+separate migration and runtime roles, applies the embedded migrations and exact
+runtime grants, and installs the `space.decodex.local-service` user LaunchAgent.
+The LaunchAgent runs `decodexd supervise-local`. The Rust supervisor starts the
+daemon only after PostgreSQL is ready. A PostgreSQL process or socket generation
+change stops the daemon and makes the supervisor exit; launchd starts the next
+coherent generation.
+
+The current local cutover uses an explicit, bounded bridge for accounts that are
+already in `~/.codex/decodex/accounts.jsonl`. The installer generates independent
+vNext account UUIDs and stores only fixed slot references and SHA-256 provider-ID
+selectors. The supervisor reads the account file under its existing lock and passes
+current values only in the child process environment. After an atomic account-file
+replacement, it restarts the daemon only when that credential projection changes.
+It does not copy credentials to the Decodex
+config, LaunchAgent, mapping file, logs, Infisical, or Keychain. A changed account
+set fails closed and requires an operator-managed enrollment migration before the
+installer can run again. This bridge is a local migration exception. It does not
+make the legacy pool a vNext product-state authority or fallback.
+
+The app retries startup-only Reset Card reads for a bounded period while the local
+service becomes ready. It never retries a consume request or changes a retained
+idempotency key.
+
 The staging script follows the local Rsnap-style signing path: it writes
 `target/decodex-app/Decodex.app`, signs the bundle with an Apple Development
 identity, enables hardened runtime, and verifies the signature before launch. Override

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
@@ -185,7 +185,14 @@ enum ResetCardClientError: Error, Equatable, LocalizedError, Sendable, CustomDeb
 	}
 }
 
-struct ResetCardCLIClient: Sendable, CustomDebugStringConvertible {
+protocol ResetCardClient: Sendable {
+	func accounts() async throws -> [ResetCardAccountRecord]
+	func inventory(for account: ResetCardAccountRecord) async throws -> ResetCardInventory
+	func use(_ attempt: ResetCardUseAttempt) async throws -> ResetCardOperationState
+	func status(for attempt: ResetCardUseAttempt) async throws -> ResetCardOperationState
+}
+
+struct ResetCardCLIClient: ResetCardClient, Sendable, CustomDebugStringConvertible {
 	static let executableOverrideKey = "DECODEX_APP_CLI"
 
 	private let executableURL: URL?

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -53,9 +53,24 @@ private enum ResetCardDispatchOutcome {
 	}
 }
 
+private enum ResetCardRefreshResult: Equatable {
+	case complete
+	case retryNeeded
+	case skipped
+}
+
 @MainActor
 @Observable
 final class ResetCardStore {
+	private static let defaultStartupRetryDelays: [Duration] = [
+		.seconds(1),
+		.seconds(2),
+		.seconds(4),
+		.seconds(8),
+		.seconds(15),
+		.seconds(30),
+	]
+
 	private(set) var accounts = [ResetCardAccountState]()
 	private(set) var isRefreshing = false
 	private(set) var hasLoaded = false
@@ -64,16 +79,19 @@ final class ResetCardStore {
 	private(set) var isPendingRecoveryBlocked: Bool
 	var message: ResetCardStoreMessage?
 
-	@ObservationIgnored private let client: ResetCardCLIClient
+	@ObservationIgnored private let client: any ResetCardClient
 	@ObservationIgnored private let pendingStore: ResetCardPendingAttemptStore
+	@ObservationIgnored private let startupRetryDelays: [Duration]
 	@ObservationIgnored private var startupTask: Task<Void, Never>?
 
 	init(
-		client: ResetCardCLIClient = ResetCardCLIClient(),
-		pendingStore: ResetCardPendingAttemptStore = ResetCardPendingAttemptStore()
+		client: any ResetCardClient = ResetCardCLIClient(),
+		pendingStore: ResetCardPendingAttemptStore = ResetCardPendingAttemptStore(),
+		startupRetryDelays: [Duration] = ResetCardStore.defaultStartupRetryDelays
 	) {
 		self.client = client
 		self.pendingStore = pendingStore
+		self.startupRetryDelays = startupRetryDelays
 		let pendingLoad = pendingStore.load()
 		pendingAttempts = pendingLoad.attempts
 		isPendingRecoveryBlocked = pendingLoad.isRecoveryBlocked
@@ -105,14 +123,40 @@ final class ResetCardStore {
 			return
 		}
 
+		let retryDelays = startupRetryDelays
 		startupTask = Task { [weak self] in
-			await self?.refresh()
+			// Keep automatic retries on account, inventory, and pending-status reads.
+			// Only an explicit user action can reach the reset-card use command.
+			guard var result = await self?.refreshReadState() else {
+				return
+			}
+
+			for delay in retryDelays {
+				guard result == .retryNeeded, Task.isCancelled == false else {
+					return
+				}
+
+				do {
+					try await Task.sleep(for: delay)
+				} catch {
+					return
+				}
+
+				guard let refreshed = await self?.refreshReadState() else {
+					return
+				}
+				result = refreshed
+			}
 		}
 	}
 
 	func refresh() async {
+		_ = await refreshReadState()
+	}
+
+	private func refreshReadState() async -> ResetCardRefreshResult {
 		guard isRefreshing == false else {
-			return
+			return .skipped
 		}
 
 		isRefreshing = true
@@ -121,6 +165,7 @@ final class ResetCardStore {
 			hasLoaded = true
 		}
 
+		var shouldRetry = false
 		do {
 			let discovered = try await client.accounts()
 			var refreshed = [ResetCardAccountState]()
@@ -128,7 +173,7 @@ final class ResetCardStore {
 
 			for account in discovered {
 				guard Task.isCancelled == false else {
-					return
+					return .complete
 				}
 
 				do {
@@ -148,11 +193,13 @@ final class ResetCardStore {
 						)
 					)
 				} catch {
+					let clientError = Self.clientError(error)
+					shouldRetry = shouldRetry || clientError.isRetryableReadFailure
 					refreshed.append(
 						ResetCardAccountState(
 							account: account,
 							inventory: nil,
-							error: Self.clientError(error)
+							error: clientError
 						)
 					)
 				}
@@ -163,17 +210,21 @@ final class ResetCardStore {
 				message = nil
 			}
 		} catch {
+			let clientError = Self.clientError(error)
+			shouldRetry = clientError.isRetryableReadFailure
 			accounts = []
 			message = ResetCardStoreMessage(
 				tone: .error,
-				text: Self.clientError(error).localizedDescription
+				text: clientError.localizedDescription
 			)
 		}
 
-		await recoverPendingAttempts()
+		shouldRetry = await recoverPendingAttempts() || shouldRetry
 		if isPendingRecoveryBlocked {
 			message = Self.pendingRecoveryBlockedMessage
 		}
+
+		return shouldRetry ? .retryNeeded : .complete
 	}
 
 	func use(_ attempt: ResetCardUseAttempt) async -> ResetCardUseCompletion {
@@ -370,14 +421,15 @@ final class ResetCardStore {
 		}
 	}
 
-	private func recoverPendingAttempts() async {
+	private func recoverPendingAttempts() async -> Bool {
 		guard submittingKey == nil else {
-			return
+			return false
 		}
 
+		var shouldRetry = false
 		for attempt in pendingAttempts {
 			guard Task.isCancelled == false else {
-				return
+				return false
 			}
 
 			do {
@@ -385,7 +437,14 @@ final class ResetCardStore {
 				switch state {
 				case .completed, .failedBeforeEffect:
 					_ = await apply(state, to: attempt)
-				case .prepared, .effectAmbiguous, .unavailable:
+				case .prepared, .effectAmbiguous:
+					shouldRetry = true
+					message = ResetCardStoreMessage(
+						tone: Self.messageTone(for: state),
+						text: state.presentation
+					)
+				case .unavailable(let error):
+					shouldRetry = shouldRetry || error.isRetryableReadFailure
 					message = ResetCardStoreMessage(
 						tone: Self.messageTone(for: state),
 						text: state.presentation
@@ -397,15 +456,19 @@ final class ResetCardStore {
 					)
 				}
 			} catch {
+				let clientError = Self.clientError(error)
+				shouldRetry = shouldRetry || clientError.isRetryableReadFailure
 				message = ResetCardStoreMessage(
 					tone: .error,
-					text: Self.clientError(error).localizedDescription
+					text: clientError.localizedDescription
 				)
 			}
 		}
 		if isPendingRecoveryBlocked {
 			message = Self.pendingRecoveryBlockedMessage
 		}
+
+		return shouldRetry
 	}
 
 	@discardableResult
@@ -493,4 +556,31 @@ final class ResetCardStore {
 		tone: .error,
 		text: "The reset-card operation is terminal, but the recovery journal could not be updated. Preserve the journal and resume this request before starting another."
 	)
+}
+
+private extension ResetCardClientError {
+	var isRetryableReadFailure: Bool {
+		switch self {
+		case .timedOut, .commandFailed:
+			return true
+		case .service(let error):
+			return error.isRetryableReadFailure
+		case .executableMissing, .launchFailed, .outputTooLarge, .commandRejected,
+			.useDefinitelyNotDispatched, .usePotentiallyDispatched, .invalidResponse:
+			return false
+		}
+	}
+}
+
+private extension ResetCardServiceError {
+	var isRetryableReadFailure: Bool {
+		switch self {
+		case .accountNotFound, .accountStateRejected, .vaultUnavailable, .providerUnavailable,
+			.inventoryIncomplete, .inventoryChanged, .resourceExhausted,
+			.productStateUnavailable, .effectAmbiguous:
+			return true
+		case .invalidRequest, .schemaUnsupported:
+			return false
+		}
+	}
 }

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreStartupRetryTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreStartupRetryTests.swift
@@ -1,0 +1,488 @@
+import Foundation
+import XCTest
+@testable import DecodexApp
+
+@MainActor
+final class ResetCardStoreStartupRetryTests: XCTestCase {
+	func testStartupRetriesDisconnectedAndUnavailableReadsUntilInventoryLoads() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let account = Self.account
+		let expectedInventory = try Self.inventory
+		let client = ScriptedResetCardClient(
+			accountSteps: [
+				.failure(.commandFailed),
+				.failure(.service(.productStateUnavailable)),
+				.value([account]),
+			],
+			accountFallback: .value([account]),
+			inventoryFallback: .value(expectedInventory)
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [.milliseconds(0), .milliseconds(0)]
+		)
+
+		store.start()
+		try await waitUntil {
+			store.accounts.first?.inventory == expectedInventory
+				&& store.isRefreshing == false
+		}
+
+		let counts = await client.callCounts()
+		XCTAssertNil(store.message)
+		XCTAssertTrue(store.hasLoaded)
+		XCTAssertEqual(
+			counts,
+			ClientCallCounts(accounts: 3, inventory: 1, status: 0, use: 0)
+		)
+	}
+
+	func testStartupRetriesTransientInventoryReadUntilItLoads() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let expectedInventory = try Self.inventory
+		let client = ScriptedResetCardClient(
+			accountSteps: [],
+			accountFallback: .value([Self.account]),
+			inventorySteps: [
+				.failure(.service(.productStateUnavailable)),
+				.value(expectedInventory),
+			],
+			inventoryFallback: .value(expectedInventory)
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [.milliseconds(0)]
+		)
+
+		store.start()
+		try await waitUntil {
+			store.accounts.first?.inventory == expectedInventory
+				&& store.isRefreshing == false
+		}
+
+		let counts = await client.callCounts()
+		XCTAssertNil(store.message)
+		XCTAssertEqual(
+			counts,
+			ClientCallCounts(accounts: 2, inventory: 2, status: 0, use: 0)
+		)
+	}
+
+	func testStartupDoesNotRetryPermanentReadFailure() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let client = ScriptedResetCardClient(
+			accountSteps: [.failure(.service(.schemaUnsupported))],
+			accountFallback: .value([Self.account]),
+			inventoryFallback: .value(try Self.inventory)
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [.milliseconds(0), .milliseconds(0)]
+		)
+
+		store.start()
+		try await waitUntil {
+			let counts = await client.callCounts()
+			return counts.accounts == 1 && store.hasLoaded && store.isRefreshing == false
+		}
+		try await Task.sleep(for: .milliseconds(20))
+
+		let counts = await client.callCounts()
+		XCTAssertEqual(
+			counts,
+			ClientCallCounts(accounts: 1, inventory: 0, status: 0, use: 0)
+		)
+		XCTAssertEqual(
+			store.message,
+			ResetCardStoreMessage(
+				tone: .error,
+				text: "The selected Codex version does not support reset cards."
+			)
+		)
+	}
+
+	func testStartupRetryScheduleIsFinite() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let client = ScriptedResetCardClient(
+			accountSteps: [],
+			accountFallback: .failure(.commandFailed),
+			inventoryFallback: .value(try Self.inventory)
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [
+				.milliseconds(0),
+				.milliseconds(0),
+				.milliseconds(0),
+			]
+		)
+
+		store.start()
+		try await waitUntil {
+			let counts = await client.callCounts()
+			return counts.accounts == 4 && store.isRefreshing == false
+		}
+		try await Task.sleep(for: .milliseconds(20))
+
+		let counts = await client.callCounts()
+		XCTAssertEqual(
+			counts,
+			ClientCallCounts(accounts: 4, inventory: 0, status: 0, use: 0)
+		)
+	}
+
+	func testManualRefreshPerformsOneReadWithoutStartingAutomaticRetries() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let client = ScriptedResetCardClient(
+			accountSteps: [],
+			accountFallback: .failure(.commandFailed),
+			inventoryFallback: .value(try Self.inventory)
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [
+				.milliseconds(0),
+				.milliseconds(0),
+				.milliseconds(0),
+			]
+		)
+
+		await store.refresh()
+
+		let counts = await client.callCounts()
+		XCTAssertEqual(
+			counts,
+			ClientCallCounts(accounts: 1, inventory: 0, status: 0, use: 0)
+		)
+	}
+
+	func testManualRefreshChecksPendingStatusOnceWithoutDispatchingUse() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let attempt = try Self.attempt
+		XCTAssertEqual(fixture.store.insert(attempt), [attempt])
+		let client = ScriptedResetCardClient(
+			accountSteps: [],
+			accountFallback: .value([]),
+			inventoryFallback: .value(try Self.inventory),
+			statusSteps: [.value(.unavailable(.productStateUnavailable))],
+			statusFallback: .value(.completed(.reset))
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [.milliseconds(0), .milliseconds(0)]
+		)
+
+		await store.refresh()
+
+		let counts = await client.callCounts()
+		XCTAssertEqual(
+			counts,
+			ClientCallCounts(accounts: 1, inventory: 0, status: 1, use: 0)
+		)
+		XCTAssertEqual(store.pendingAttempts, [attempt])
+	}
+
+	func testStartupRetriesPendingStatusReadWithoutDispatchingUse() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let attempt = try Self.attempt
+		XCTAssertEqual(fixture.store.insert(attempt), [attempt])
+		let client = ScriptedResetCardClient(
+			accountSteps: [],
+			accountFallback: .value([]),
+			inventoryFallback: .value(try Self.inventory),
+			statusSteps: [
+				.value(.unavailable(.productStateUnavailable)),
+				.value(.prepared),
+				.value(.effectAmbiguous),
+				.value(.completed(.reset)),
+			],
+			statusFallback: .value(.completed(.reset))
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [
+				.milliseconds(0),
+				.milliseconds(0),
+				.milliseconds(0),
+			]
+		)
+
+		store.start()
+		try await waitUntil {
+			store.pendingAttempts.isEmpty
+				&& fixture.store.load() == .available([])
+		}
+
+		let counts = await client.callCounts()
+		XCTAssertEqual(
+			counts,
+			ClientCallCounts(accounts: 4, inventory: 0, status: 4, use: 0)
+		)
+		XCTAssertEqual(
+			store.message,
+			ResetCardStoreMessage(tone: .success, text: "Usage restored.")
+		)
+	}
+
+	func testStartupStopsAtMissingPendingStatusWithoutDispatchingUse() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let attempt = try Self.attempt
+		XCTAssertEqual(fixture.store.insert(attempt), [attempt])
+		let client = ScriptedResetCardClient(
+			accountSteps: [],
+			accountFallback: .value([]),
+			inventoryFallback: .value(try Self.inventory),
+			statusSteps: [.value(.notFound)],
+			statusFallback: .value(.completed(.reset))
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [.milliseconds(0), .milliseconds(0)]
+		)
+
+		store.start()
+		try await waitUntil {
+			let counts = await client.callCounts()
+			return counts.status == 1 && store.isRefreshing == false
+		}
+		try await Task.sleep(for: .milliseconds(20))
+
+		let counts = await client.callCounts()
+		XCTAssertEqual(
+			counts,
+			ClientCallCounts(accounts: 1, inventory: 0, status: 1, use: 0)
+		)
+		XCTAssertEqual(store.pendingAttempts, [attempt])
+	}
+
+	func testExplicitUseDispatchesOnlyOnce() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let inventory = try Self.inventory
+		let client = ScriptedResetCardClient(
+			accountSteps: [],
+			accountFallback: .value([Self.account]),
+			inventoryFallback: .value(inventory)
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [.milliseconds(0), .milliseconds(0)]
+		)
+		await store.refresh()
+
+		let completion = await store.use(try Self.attempt)
+		try await Task.sleep(for: .milliseconds(20))
+
+		let counts = await client.callCounts()
+		XCTAssertEqual(completion, ResetCardUseCompletion(resolved: false))
+		XCTAssertEqual(
+			counts,
+			ClientCallCounts(accounts: 1, inventory: 1, status: 0, use: 1)
+		)
+	}
+
+	private func makePendingFixture() throws -> StartupRetryPendingFixture {
+		let directory = FileManager.default.temporaryDirectory
+			.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		try FileManager.default.createDirectory(
+			at: directory,
+			withIntermediateDirectories: true
+		)
+		try FileManager.default.setAttributes(
+			[.posixPermissions: 0o700],
+			ofItemAtPath: directory.path
+		)
+
+		return StartupRetryPendingFixture(
+			directory: directory,
+			store: ResetCardPendingAttemptStore(
+				journalURL: directory.appendingPathComponent("pending.json")
+			)
+		)
+	}
+
+	private func waitUntil(
+		_ predicate: @escaping @MainActor () async -> Bool
+	) async throws {
+		for _ in 0..<200 {
+			if await predicate() {
+				return
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+
+		XCTFail("Timed out waiting for the startup retry state.")
+	}
+
+	private static let authority = ResetCardAuthority(
+		profileName: "local",
+		serverID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	)
+
+	private static let account = ResetCardAccountRecord(
+		authority: authority,
+		accountID: "018f0f9e-7b6e-4a31-8f4c-1d2e3f405160",
+		displayLabel: "Account A",
+		accountRevision: 7,
+		admissionState: .depleted
+	)
+
+	private static var inventory: ResetCardInventory {
+		get throws {
+			ResetCardInventory(
+				authority: authority,
+				accountID: account.accountID,
+				accountRevision: account.accountRevision,
+				cards: [
+					try ResetCardDescriptor(
+						grantedAtUnixSeconds: 100,
+						expiresAtUnixSeconds: 200
+					),
+				]
+			)
+		}
+	}
+
+	private static var attempt: ResetCardUseAttempt {
+		get throws {
+			ResetCardUseAttempt(
+				target: ResetCardUseTarget(
+					authority: authority,
+					accountID: account.accountID,
+					expectedRevision: account.accountRevision,
+					descriptor: try ResetCardDescriptor(
+						grantedAtUnixSeconds: 100,
+						expiresAtUnixSeconds: 200
+					)
+				),
+				idempotencyKey: "018f0f9e-7b6e-4a31-8f4c-1d2e3f405161"
+			)
+		}
+	}
+}
+
+private enum ClientStep<Value: Sendable>: Sendable {
+	case value(Value)
+	case failure(ResetCardClientError)
+}
+
+private struct ClientCallCounts: Equatable, Sendable {
+	let accounts: Int
+	let inventory: Int
+	let status: Int
+	let use: Int
+}
+
+private actor ScriptedResetCardClient: ResetCardClient {
+	private var accountSteps: [ClientStep<[ResetCardAccountRecord]>]
+	private let accountFallback: ClientStep<[ResetCardAccountRecord]>
+	private var inventorySteps: [ClientStep<ResetCardInventory>]
+	private let inventoryFallback: ClientStep<ResetCardInventory>
+	private var statusSteps: [ClientStep<ResetCardOperationState>]
+	private let statusFallback: ClientStep<ResetCardOperationState>
+	private var counts = ClientCallCounts(accounts: 0, inventory: 0, status: 0, use: 0)
+
+	init(
+		accountSteps: [ClientStep<[ResetCardAccountRecord]>],
+		accountFallback: ClientStep<[ResetCardAccountRecord]>,
+		inventorySteps: [ClientStep<ResetCardInventory>] = [],
+		inventoryFallback: ClientStep<ResetCardInventory>,
+		statusSteps: [ClientStep<ResetCardOperationState>] = [],
+		statusFallback: ClientStep<ResetCardOperationState> = .value(.notFound)
+	) {
+		self.accountSteps = accountSteps
+		self.accountFallback = accountFallback
+		self.inventorySteps = inventorySteps
+		self.inventoryFallback = inventoryFallback
+		self.statusSteps = statusSteps
+		self.statusFallback = statusFallback
+	}
+
+	func accounts() async throws -> [ResetCardAccountRecord] {
+		counts = ClientCallCounts(
+			accounts: counts.accounts + 1,
+			inventory: counts.inventory,
+			status: counts.status,
+			use: counts.use
+		)
+		return try Self.resolve(
+			accountSteps.isEmpty ? accountFallback : accountSteps.removeFirst()
+		)
+	}
+
+	func inventory(for account: ResetCardAccountRecord) async throws -> ResetCardInventory {
+		counts = ClientCallCounts(
+			accounts: counts.accounts,
+			inventory: counts.inventory + 1,
+			status: counts.status,
+			use: counts.use
+		)
+		return try Self.resolve(
+			inventorySteps.isEmpty ? inventoryFallback : inventorySteps.removeFirst()
+		)
+	}
+
+	func status(for attempt: ResetCardUseAttempt) async throws -> ResetCardOperationState {
+		counts = ClientCallCounts(
+			accounts: counts.accounts,
+			inventory: counts.inventory,
+			status: counts.status + 1,
+			use: counts.use
+		)
+		return try Self.resolve(
+			statusSteps.isEmpty ? statusFallback : statusSteps.removeFirst()
+		)
+	}
+
+	func use(_ attempt: ResetCardUseAttempt) async throws -> ResetCardOperationState {
+		counts = ClientCallCounts(
+			accounts: counts.accounts,
+			inventory: counts.inventory,
+			status: counts.status,
+			use: counts.use + 1
+		)
+		return .prepared
+	}
+
+	func callCounts() -> ClientCallCounts {
+		counts
+	}
+
+	private static func resolve<Value: Sendable>(
+		_ step: ClientStep<Value>
+	) throws -> Value {
+		switch step {
+		case .value(let value):
+			return value
+		case .failure(let error):
+			throw error
+		}
+	}
+}
+
+@MainActor
+private struct StartupRetryPendingFixture {
+	let directory: URL
+	let store: ResetCardPendingAttemptStore
+
+	func remove() {
+		try? FileManager.default.removeItem(at: directory)
+	}
+}

--- a/apps/decodex/src/accounts.rs
+++ b/apps/decodex/src/accounts.rs
@@ -17,6 +17,7 @@ pub(crate) use self::{
 		hydrate_account_list_usage, run_account_clear, run_account_import, run_account_list,
 		run_account_logout, run_account_select, run_account_use,
 	},
+	file_security::secure_account_file,
 	login::{account_login, run_account_login},
 	types::{
 		AccountIdentitySummary, AccountImportRequest, AccountListResponse, AccountLoginRequest,

--- a/apps/decodex/src/accounts/file_security.rs
+++ b/apps/decodex/src/accounts/file_security.rs
@@ -3,14 +3,17 @@ use std::{fs, path::Path};
 
 use crate::prelude::Result;
 
-pub(in crate::accounts) fn secure_account_file(path: &Path) -> Result<()> {
+pub(crate) fn secure_account_file(path: &Path) -> Result<()> {
 	#[cfg(unix)]
 	{
 		let mode = if path.is_dir() { 0o700 } else { 0o600 };
 		let mut permissions = fs::metadata(path)?.permissions();
 
-		permissions.set_mode(mode);
+		if permissions.mode() & 0o7777 == mode {
+			return Ok(());
+		}
 
+		permissions.set_mode(mode);
 		fs::set_permissions(path, permissions)?;
 	}
 

--- a/apps/decodex/src/agent/codex_accounts/storage.rs
+++ b/apps/decodex/src/agent/codex_accounts/storage.rs
@@ -1,9 +1,12 @@
+#[cfg(unix)] use std::os::unix::fs::OpenOptionsExt as _;
 use std::{
 	fs::{self, File, OpenOptions},
+	io::Write as _,
 	process,
 };
 
 use crate::{
+	accounts::secure_account_file,
 	agent::codex_accounts::{AccountPoolRecord, CodexAccountPool, record},
 	prelude::{Result, eyre},
 };
@@ -30,15 +33,17 @@ impl CodexAccountPool {
 			.and_then(|name| name.to_str())
 			.ok_or_else(|| eyre::eyre!("Codex accounts path must end in a valid file name."))?;
 		let lock_path = parent.join(format!(".{file_name}.lock"));
-		let file = OpenOptions::new()
-			.read(true)
-			.write(true)
-			.create(true)
-			.truncate(false)
-			.open(&lock_path)
-			.map_err(|error| {
-				eyre::eyre!("Failed to open Codex accounts lock `{}`: {error}", lock_path.display())
-			})?;
+		let mut options = OpenOptions::new();
+
+		options.read(true).write(true).create(true).truncate(false);
+		#[cfg(unix)]
+		options.mode(0o600);
+
+		let file = options.open(&lock_path).map_err(|error| {
+			eyre::eyre!("Failed to open Codex accounts lock `{}`: {error}", lock_path.display())
+		})?;
+
+		secure_account_file(&lock_path)?;
 
 		file.lock().map_err(|error| {
 			eyre::eyre!("Failed to lock Codex accounts `{}`: {error}", self.path.display())
@@ -67,8 +72,20 @@ impl CodexAccountPool {
 			body.push('\n');
 		}
 
-		fs::write(&temp_path, body)?;
+		let mut options = OpenOptions::new();
+
+		options.write(true).create(true).truncate(true);
+		#[cfg(unix)]
+		options.mode(0o600);
+
+		let mut temp_file = options.open(&temp_path)?;
+
+		secure_account_file(&temp_path)?;
+		temp_file.write_all(body.as_bytes())?;
+		drop(temp_file);
+		secure_account_file(&temp_path)?;
 		fs::rename(temp_path, &self.path)?;
+		secure_account_file(&self.path)?;
 
 		Ok(())
 	}
@@ -76,4 +93,118 @@ impl CodexAccountPool {
 
 pub(super) struct AccountPoolFileLock {
 	_file: File,
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+	use std::{
+		fs,
+		os::unix::fs::{MetadataExt as _, PermissionsExt as _},
+		path::Path,
+		thread,
+		time::Duration,
+	};
+
+	use tempfile::TempDir;
+
+	use super::*;
+	use crate::agent::codex_accounts::{
+		DEFAULT_REFRESH_ENDPOINT, DEFAULT_RESET_CREDITS_ENDPOINT, DEFAULT_USAGE_ENDPOINT,
+	};
+
+	#[test]
+	fn writer_secures_new_and_reused_temp_file_before_atomic_replace() {
+		let temp_dir = TempDir::new().expect("temp dir should exist");
+		let accounts_path = temp_dir.path().join("accounts.jsonl");
+		let staged_path = temp_dir.path().join(format!(".accounts.jsonl.tmp-{}", process::id()));
+
+		fs::create_dir(&accounts_path).expect("blocking accounts directory should exist");
+
+		let pool = account_pool(&accounts_path);
+
+		let _error = pool.save_records(&[]).expect_err("replace over a directory should fail");
+		assert_eq!(file_mode(&staged_path), 0o600);
+
+		set_mode(&staged_path, 0o666);
+		let _error =
+			pool.save_records(&[]).expect_err("replace over a directory should still fail");
+		assert_eq!(file_mode(&staged_path), 0o600);
+	}
+
+	#[test]
+	fn writer_secures_accounts_file_after_every_atomic_replace() {
+		let temp_dir = TempDir::new().expect("temp dir should exist");
+		let accounts_path = temp_dir.path().join("accounts.jsonl");
+		let pool = account_pool(&accounts_path);
+
+		pool.save_records(&[]).expect("initial accounts write should succeed");
+		assert_eq!(file_mode(&accounts_path), 0o600);
+
+		set_mode(&accounts_path, 0o666);
+		pool.save_records(&[]).expect("replacement accounts write should succeed");
+		assert_eq!(file_mode(&accounts_path), 0o600);
+	}
+
+	#[test]
+	fn lock_file_is_owner_only_when_created_and_reopened() {
+		let temp_dir = TempDir::new().expect("temp dir should exist");
+		let accounts_path = temp_dir.path().join("accounts.jsonl");
+		let lock_path = temp_dir.path().join(".accounts.jsonl.lock");
+		let pool = account_pool(&accounts_path);
+
+		let lock = pool.lock_records().expect("lock file should open");
+
+		assert_eq!(file_mode(&lock_path), 0o600);
+
+		drop(lock);
+		set_mode(&lock_path, 0o666);
+
+		let _lock = pool.lock_records().expect("existing lock file should reopen");
+
+		assert_eq!(file_mode(&lock_path), 0o600);
+	}
+
+	#[test]
+	fn reopening_secure_lock_does_not_change_its_metadata() {
+		let temp_dir = TempDir::new().expect("temp dir should exist");
+		let accounts_path = temp_dir.path().join("accounts.jsonl");
+		let lock_path = temp_dir.path().join(".accounts.jsonl.lock");
+		let pool = account_pool(&accounts_path);
+
+		drop(pool.lock_records().expect("lock file should open"));
+		let before = changed_time(&lock_path);
+
+		thread::sleep(Duration::from_millis(20));
+		drop(pool.lock_records().expect("secure lock file should reopen"));
+
+		assert_eq!(changed_time(&lock_path), before);
+	}
+
+	fn account_pool(path: &Path) -> CodexAccountPool {
+		CodexAccountPool::new_with_fixed_account(
+			path,
+			DEFAULT_USAGE_ENDPOINT,
+			DEFAULT_RESET_CREDITS_ENDPOINT,
+			DEFAULT_REFRESH_ENDPOINT,
+			None,
+		)
+		.expect("account pool should initialize")
+	}
+
+	fn set_mode(path: &Path, mode: u32) {
+		let mut permissions = fs::metadata(path).expect("file metadata should exist").permissions();
+
+		permissions.set_mode(mode);
+		fs::set_permissions(path, permissions).expect("file permissions should update");
+	}
+
+	fn file_mode(path: &Path) -> u32 {
+		fs::metadata(path).expect("file metadata should exist").permissions().mode() & 0o777
+	}
+
+	fn changed_time(path: &Path) -> (i64, i64) {
+		let metadata = fs::metadata(path).expect("file metadata should exist");
+
+		(metadata.ctime(), metadata.ctime_nsec())
+	}
 }

--- a/apps/decodexd/Cargo.toml
+++ b/apps/decodexd/Cargo.toml
@@ -9,8 +9,15 @@ repository.workspace = true
 version.workspace    = true
 
 [dependencies]
+base64          = { workspace = true }
+clap            = { workspace = true }
 decodex-runtime = { workspace = true }
+libc            = { workspace = true }
+serde           = { workspace = true }
+serde_json      = { workspace = true }
+sha2            = { workspace = true }
 tokio           = { workspace = true }
+zeroize         = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/apps/decodexd/src/local_supervisor.rs
+++ b/apps/decodexd/src/local_supervisor.rs
@@ -1,0 +1,1535 @@
+//! Unix-local lifecycle owner for PostgreSQL and the credential-injected daemon.
+
+use std::{
+	collections::{BTreeMap, BTreeSet},
+	error::Error,
+	ffi::OsString,
+	fmt::{Display, Formatter},
+	fs::{self, File, OpenOptions},
+	io::{Read as _, Write as _},
+	os::unix::fs::{FileTypeExt as _, MetadataExt as _, OpenOptionsExt as _, PermissionsExt as _},
+	path::{Path, PathBuf},
+	process::{Child, Command, ExitStatus, Stdio},
+	thread,
+	time::{Duration, Instant},
+};
+
+use base64::{
+	Engine as _,
+	engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
+};
+use serde::Deserialize;
+use sha2::{Digest as _, Sha256};
+use zeroize::{Zeroize as _, Zeroizing};
+
+use crate::ShutdownSignals;
+
+const MAPPING_SCHEMA: &str = "decodex/reset-card-legacy-bridge/1";
+const MAX_ACCOUNTS: usize = 64;
+const MAX_MAPPING_BYTES: u64 = 64 * 1024;
+const MAX_ACCOUNTS_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_LINE_BYTES: usize = 128 * 1024;
+const MAX_ACCESS_TOKEN_BYTES: usize = 64 * 1024;
+const MAX_ID_TOKEN_BYTES: usize = 64 * 1024;
+const MAX_PROVIDER_ACCOUNT_ID_BYTES: usize = 1_024;
+const MAX_EMAIL_BYTES: usize = 320;
+const MAX_PLAN_TYPE_BYTES: usize = 64;
+const CREDENTIAL_PROJECTION_FINGERPRINT_PROTOCOL: &[u8] =
+	b"decodex/local-supervisor-credential-projection/1\0";
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+// Reset-card provider work has a runtime-owned 212-second upper bound. The daemon grace period
+// also covers its five-second transport drain and leaves margin for scheduler and cleanup work.
+// The macOS LaunchAgent ExitTimeOut must exceed this plus the PostgreSQL grace period.
+const DAEMON_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(240);
+const POSTGRES_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+const LOCK_TIMEOUT: Duration = Duration::from_secs(5);
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+pub(super) struct LocalSupervisorConfig {
+	pub(super) postgres: PathBuf,
+	pub(super) pg_isready: PathBuf,
+	pub(super) data_directory: PathBuf,
+	pub(super) socket_directory: PathBuf,
+	pub(super) port: u16,
+	pub(super) legacy_accounts: PathBuf,
+	pub(super) legacy_mapping: PathBuf,
+	pub(super) working_directory: PathBuf,
+}
+
+pub(super) async fn supervise(config: LocalSupervisorConfig) -> Result<(), SupervisorError> {
+	validate_absolute_paths(&config)?;
+	if config.port == 0 {
+		return Err(SupervisorError::new("PostgreSQL port is invalid"));
+	}
+	validate_command_path(&config.postgres)?;
+	validate_command_path(&config.pg_isready)?;
+	validate_private_data_directory(&config.data_directory)?;
+	validate_directory(&config.working_directory)?;
+
+	let socket_directory_identity = secure_directory_identity(&config.socket_directory)?;
+	let executable =
+		std::env::current_exe().map_err(|_| SupervisorError::new("cannot resolve decodexd"))?;
+	let mut signals = ShutdownSignals::new()
+		.map_err(|_| SupervisorError::new("cannot install supervisor signal handlers"))?;
+	let lock_path = account_lock_path(&config.legacy_accounts)?;
+	let (mut credentials, mut watched_accounts) =
+		load_credentials(&config.legacy_accounts, &lock_path, &config.legacy_mapping)?;
+	let mut credential_projection = credential_projection_fingerprint(&credentials);
+	let mut postgres = spawn_postgres(&config)?;
+
+	let ready =
+		wait_for_postgres(&config, &mut postgres, &mut signals, socket_directory_identity).await;
+	let postgres_identity = match ready {
+		Ok(identity) => identity,
+		Err(error) => {
+			stop_child(&mut postgres, ChildKind::Postgres);
+			return Err(error);
+		},
+	};
+	let mut daemon = match spawn_daemon(&config, &executable, &credentials) {
+		Ok(child) => child,
+		Err(error) => {
+			stop_child(&mut postgres, ChildKind::Postgres);
+			return Err(error);
+		},
+	};
+
+	credentials.clear();
+	let _ = writeln!(std::io::stdout().lock(), "decodexd local supervisor ready");
+
+	macro_rules! observe_or_stop {
+		($observation:expr) => {
+			match $observation {
+				Ok(value) => value,
+				Err(error) => {
+					stop_child(&mut daemon, ChildKind::Daemon);
+					stop_child(&mut postgres, ChildKind::Postgres);
+					return Err(error);
+				},
+			}
+		};
+	}
+
+	loop {
+		tokio::select! {
+			signal = signals.recv() => {
+				if signal.is_err() {
+					stop_child(&mut daemon, ChildKind::Daemon);
+					stop_child(&mut postgres, ChildKind::Postgres);
+					return Err(SupervisorError::new("supervisor signal handling failed"));
+				}
+				stop_child(&mut daemon, ChildKind::Daemon);
+				stop_child(&mut postgres, ChildKind::Postgres);
+				return Ok(());
+			},
+			_ = tokio::time::sleep(POLL_INTERVAL) => {},
+		}
+
+		if observe_or_stop!(child_exit(&mut postgres)).is_some() {
+			stop_child(&mut daemon, ChildKind::Daemon);
+			return Err(SupervisorError::new("PostgreSQL exited"));
+		}
+		if !observe_or_stop!(postgres_identity.is_current(&config)) {
+			stop_child(&mut daemon, ChildKind::Daemon);
+			stop_child(&mut postgres, ChildKind::Postgres);
+			return Err(SupervisorError::new("PostgreSQL identity changed"));
+		}
+		if observe_or_stop!(child_exit(&mut daemon)).is_some() {
+			stop_child(&mut postgres, ChildKind::Postgres);
+			return Err(SupervisorError::new("decodexd child exited"));
+		}
+
+		let current = observe_or_stop!(WatchedCredentialFiles::capture(
+			&config.legacy_accounts,
+			&lock_path,
+			&config.legacy_mapping,
+		));
+		if current != watched_accounts {
+			let (mut reloaded, reloaded_watch) = observe_or_stop!(load_credentials(
+				&config.legacy_accounts,
+				&lock_path,
+				&config.legacy_mapping,
+			));
+			let reloaded_projection = credential_projection_fingerprint(&reloaded);
+
+			if reloaded_projection.as_ref() == credential_projection.as_ref() {
+				reloaded.clear();
+				watched_accounts = reloaded_watch;
+
+				continue;
+			}
+
+			stop_child(&mut daemon, ChildKind::Daemon);
+			daemon = match spawn_daemon(&config, &executable, &reloaded) {
+				Ok(child) => child,
+				Err(error) => {
+					stop_child(&mut postgres, ChildKind::Postgres);
+					return Err(error);
+				},
+			};
+			reloaded.clear();
+			credential_projection = reloaded_projection;
+			watched_accounts = reloaded_watch;
+		}
+	}
+}
+
+fn validate_absolute_paths(config: &LocalSupervisorConfig) -> Result<(), SupervisorError> {
+	for path in [
+		&config.postgres,
+		&config.pg_isready,
+		&config.data_directory,
+		&config.socket_directory,
+		&config.legacy_accounts,
+		&config.legacy_mapping,
+		&config.working_directory,
+	] {
+		if !path.is_absolute() {
+			return Err(SupervisorError::new("local supervisor paths must be absolute"));
+		}
+	}
+
+	Ok(())
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct FileIdentity {
+	device: u64,
+	inode: u64,
+	uid: u32,
+	mode: u32,
+	links: u64,
+	length: u64,
+	modified_seconds: i64,
+	modified_nanoseconds: i64,
+	changed_seconds: i64,
+	changed_nanoseconds: i64,
+	kind: FileKind,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum FileKind {
+	Directory,
+	Regular,
+	Socket,
+}
+
+impl FileIdentity {
+	fn from_metadata(metadata: &fs::Metadata) -> Result<Self, SupervisorError> {
+		let file_type = metadata.file_type();
+		let kind = if file_type.is_dir() {
+			FileKind::Directory
+		} else if file_type.is_file() {
+			FileKind::Regular
+		} else if file_type.is_socket() {
+			FileKind::Socket
+		} else {
+			return Err(SupervisorError::new("unsupported filesystem object"));
+		};
+
+		Ok(Self {
+			device: metadata.dev(),
+			inode: metadata.ino(),
+			uid: metadata.uid(),
+			mode: metadata.permissions().mode() & 0o777,
+			links: metadata.nlink(),
+			length: metadata.len(),
+			modified_seconds: metadata.mtime(),
+			modified_nanoseconds: metadata.mtime_nsec(),
+			changed_seconds: metadata.ctime(),
+			changed_nanoseconds: metadata.ctime_nsec(),
+			kind,
+		})
+	}
+
+	fn stable_object(self) -> StableObjectIdentity {
+		StableObjectIdentity {
+			device: self.device,
+			inode: self.inode,
+			uid: self.uid,
+			mode: self.mode,
+			kind: self.kind,
+		}
+	}
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct StableObjectIdentity {
+	device: u64,
+	inode: u64,
+	uid: u32,
+	mode: u32,
+	kind: FileKind,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct WatchedCredentialFiles {
+	parent: StableObjectIdentity,
+	accounts: FileIdentity,
+	lock: StableObjectIdentity,
+	mapping_parent: StableObjectIdentity,
+	mapping: FileIdentity,
+}
+
+impl WatchedCredentialFiles {
+	fn capture(accounts: &Path, lock: &Path, mapping: &Path) -> Result<Self, SupervisorError> {
+		Ok(Self {
+			parent: secure_parent_identity(accounts)?.stable_object(),
+			accounts: secure_regular_file_identity(accounts, MAX_ACCOUNTS_BYTES)?,
+			lock: secure_regular_file_identity(lock, 0)?.stable_object(),
+			mapping_parent: secure_parent_identity(mapping)?.stable_object(),
+			mapping: secure_regular_file_identity(mapping, MAX_MAPPING_BYTES)?,
+		})
+	}
+}
+
+#[derive(Clone, Copy)]
+struct PostgresIdentity {
+	process_id: u32,
+	socket_directory: StableObjectIdentity,
+	socket: StableObjectIdentity,
+	generation: StableObjectIdentity,
+}
+
+impl PostgresIdentity {
+	fn is_current(self, config: &LocalSupervisorConfig) -> Result<bool, SupervisorError> {
+		let current_directory = secure_directory_identity(&config.socket_directory)?;
+		if current_directory != self.socket_directory {
+			return Ok(false);
+		}
+
+		let current_socket = socket_identity(&postgres_socket_path(config))?;
+		if current_socket != self.socket {
+			return Ok(false);
+		}
+
+		let generation_path = config.data_directory.join("postmaster.pid");
+		let current_generation =
+			secure_regular_file_identity(&generation_path, 64 * 1024)?.stable_object();
+		if current_generation != self.generation {
+			return Ok(false);
+		}
+
+		Ok(read_postmaster_pid(&generation_path)? == self.process_id)
+	}
+}
+
+fn validate_command_path(path: &Path) -> Result<(), SupervisorError> {
+	let metadata = fs::symlink_metadata(path)
+		.map_err(|_| SupervisorError::new("required executable is unavailable"))?;
+	if metadata.file_type().is_symlink()
+		|| !metadata.is_file()
+		|| metadata.permissions().mode() & 0o111 == 0
+	{
+		return Err(SupervisorError::new("required executable is unsafe"));
+	}
+
+	Ok(())
+}
+
+fn validate_private_data_directory(path: &Path) -> Result<(), SupervisorError> {
+	let metadata = fs::symlink_metadata(path)
+		.map_err(|_| SupervisorError::new("PostgreSQL data directory is unavailable"))?;
+	// SAFETY: `geteuid` has no arguments or failure return.
+	let effective_uid = unsafe { libc::geteuid() };
+
+	if metadata.file_type().is_symlink()
+		|| !metadata.is_dir()
+		|| metadata.uid() != effective_uid
+		|| metadata.permissions().mode() & 0o777 != 0o700
+	{
+		return Err(SupervisorError::new("PostgreSQL data directory is unsafe"));
+	}
+
+	Ok(())
+}
+
+fn validate_directory(path: &Path) -> Result<(), SupervisorError> {
+	let metadata = fs::symlink_metadata(path)
+		.map_err(|_| SupervisorError::new("required directory missing"))?;
+	if metadata.file_type().is_symlink() || !metadata.is_dir() {
+		return Err(SupervisorError::new("required directory is unsafe"));
+	}
+
+	Ok(())
+}
+
+fn account_lock_path(accounts: &Path) -> Result<PathBuf, SupervisorError> {
+	let parent =
+		accounts.parent().ok_or_else(|| SupervisorError::new("legacy account path is invalid"))?;
+	let name = accounts
+		.file_name()
+		.and_then(|name| name.to_str())
+		.ok_or_else(|| SupervisorError::new("legacy account path is invalid"))?;
+
+	Ok(parent.join(format!(".{name}.lock")))
+}
+
+fn secure_parent_identity(path: &Path) -> Result<FileIdentity, SupervisorError> {
+	let parent =
+		path.parent().ok_or_else(|| SupervisorError::new("credential parent is invalid"))?;
+	let metadata = fs::symlink_metadata(parent)
+		.map_err(|_| SupervisorError::new("credential parent is unavailable"))?;
+	let identity = FileIdentity::from_metadata(&metadata)?;
+	// SAFETY: `geteuid` has no arguments or failure return.
+	let effective_uid = unsafe { libc::geteuid() };
+
+	if metadata.file_type().is_symlink()
+		|| identity.kind != FileKind::Directory
+		|| identity.uid != effective_uid
+		|| identity.mode != 0o700
+	{
+		return Err(SupervisorError::new("credential parent is unsafe"));
+	}
+
+	Ok(identity)
+}
+
+fn secure_directory_identity(path: &Path) -> Result<StableObjectIdentity, SupervisorError> {
+	let metadata = fs::symlink_metadata(path)
+		.map_err(|_| SupervisorError::new("PostgreSQL socket directory is unavailable"))?;
+	let identity = FileIdentity::from_metadata(&metadata)?;
+	// SAFETY: `geteuid` has no arguments or failure return.
+	let effective_uid = unsafe { libc::geteuid() };
+
+	if metadata.file_type().is_symlink()
+		|| identity.kind != FileKind::Directory
+		|| identity.uid != effective_uid
+		|| identity.mode != 0o700
+	{
+		return Err(SupervisorError::new("PostgreSQL socket directory is unsafe"));
+	}
+
+	Ok(identity.stable_object())
+}
+
+fn secure_regular_file_identity(
+	path: &Path,
+	maximum_bytes: u64,
+) -> Result<FileIdentity, SupervisorError> {
+	let metadata =
+		fs::symlink_metadata(path).map_err(|_| SupervisorError::new("credential file missing"))?;
+	let identity = FileIdentity::from_metadata(&metadata)?;
+	// SAFETY: `geteuid` has no arguments or failure return.
+	let effective_uid = unsafe { libc::geteuid() };
+
+	if metadata.file_type().is_symlink()
+		|| identity.kind != FileKind::Regular
+		|| identity.uid != effective_uid
+		|| identity.mode != 0o600
+		|| identity.links != 1
+		|| identity.length > maximum_bytes
+	{
+		return Err(SupervisorError::new("credential file is unsafe"));
+	}
+
+	Ok(identity)
+}
+
+fn open_secure_regular(
+	path: &Path,
+	maximum_bytes: u64,
+) -> Result<(File, FileIdentity), SupervisorError> {
+	let expected = secure_regular_file_identity(path, maximum_bytes)?;
+	let file = OpenOptions::new()
+		.read(true)
+		.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+		.open(path)
+		.map_err(|_| SupervisorError::new("credential file cannot be opened"))?;
+	let actual = FileIdentity::from_metadata(
+		&file
+			.metadata()
+			.map_err(|_| SupervisorError::new("credential file cannot be inspected"))?,
+	)?;
+
+	if actual != expected {
+		return Err(SupervisorError::new("credential file changed during open"));
+	}
+
+	Ok((file, actual))
+}
+
+fn load_credentials(
+	accounts_path: &Path,
+	lock_path: &Path,
+	mapping_path: &Path,
+) -> Result<(Vec<SlotCredential>, WatchedCredentialFiles), SupervisorError> {
+	secure_parent_identity(accounts_path)?;
+	secure_parent_identity(mapping_path)?;
+	let (lock, lock_identity) = open_secure_regular(lock_path, 0)?;
+	acquire_shared_lock(&lock)?;
+	let loaded = (|| {
+		let before = WatchedCredentialFiles::capture(accounts_path, lock_path, mapping_path)?;
+		if before.lock != lock_identity.stable_object() {
+			return Err(SupervisorError::new("credential lock changed during acquisition"));
+		}
+		let mapping = read_mapping(mapping_path)?;
+		let accounts = read_legacy_accounts(accounts_path)?;
+		let credentials = map_credentials(mapping, accounts)?;
+		let after = WatchedCredentialFiles::capture(accounts_path, lock_path, mapping_path)?;
+		if before != after {
+			return Err(SupervisorError::new("credential files changed during load"));
+		}
+
+		Ok((credentials, after))
+	})();
+	unlock(&lock);
+
+	loaded
+}
+
+fn acquire_shared_lock(file: &File) -> Result<(), SupervisorError> {
+	use std::os::fd::AsRawFd as _;
+
+	let deadline = Instant::now() + LOCK_TIMEOUT;
+	loop {
+		// SAFETY: the descriptor remains owned by `file` for the duration of this call.
+		let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_SH | libc::LOCK_NB) };
+		if result == 0 {
+			return Ok(());
+		}
+		let error = std::io::Error::last_os_error();
+		let error_code = error.raw_os_error();
+		if error_code != Some(libc::EWOULDBLOCK) && error_code != Some(libc::EAGAIN) {
+			return Err(SupervisorError::new("credential lock failed"));
+		}
+		if Instant::now() >= deadline {
+			return Err(SupervisorError::new("credential lock timed out"));
+		}
+		thread::sleep(Duration::from_millis(20));
+	}
+}
+
+fn unlock(file: &File) {
+	use std::os::fd::AsRawFd as _;
+
+	// SAFETY: the descriptor remains valid here; dropping it also releases the lock.
+	let _ = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MappingManifest {
+	schema: String,
+	accounts: Vec<MappingEntry>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MappingEntry {
+	slot: u8,
+	provider_account_id_sha256: String,
+}
+
+fn read_mapping(path: &Path) -> Result<Vec<MappingEntry>, SupervisorError> {
+	let (file, identity) = open_secure_regular(path, MAX_MAPPING_BYTES)?;
+	let mut bytes = Vec::with_capacity(identity.length as usize);
+	file.take(MAX_MAPPING_BYTES + 1)
+		.read_to_end(&mut bytes)
+		.map_err(|_| SupervisorError::new("mapping manifest cannot be read"))?;
+	if bytes.len() as u64 > MAX_MAPPING_BYTES {
+		return Err(SupervisorError::new("mapping manifest is too large"));
+	}
+	let manifest = serde_json::from_slice::<MappingManifest>(&bytes)
+		.map_err(|_| SupervisorError::new("mapping manifest is malformed"))?;
+
+	if manifest.schema != MAPPING_SCHEMA
+		|| manifest.accounts.is_empty()
+		|| manifest.accounts.len() > MAX_ACCOUNTS
+	{
+		return Err(SupervisorError::new("mapping manifest is invalid"));
+	}
+
+	let mut slots = BTreeSet::new();
+	let mut digests = BTreeSet::new();
+	for entry in &manifest.accounts {
+		if !(1..=MAX_ACCOUNTS as u8).contains(&entry.slot)
+			|| !is_lower_hex_sha256(&entry.provider_account_id_sha256)
+			|| !slots.insert(entry.slot)
+			|| !digests.insert(entry.provider_account_id_sha256.as_str())
+		{
+			return Err(SupervisorError::new("mapping manifest is invalid"));
+		}
+	}
+	let expected_slots = (1..=manifest.accounts.len() as u8).collect::<BTreeSet<_>>();
+	if slots != expected_slots {
+		return Err(SupervisorError::new("mapping manifest slots are not contiguous"));
+	}
+
+	Ok(manifest.accounts)
+}
+
+fn is_lower_hex_sha256(value: &str) -> bool {
+	value.len() == 64
+		&& value.bytes().all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+struct LegacyLine {
+	email: Option<String>,
+	tokens: Option<LegacyTokens>,
+	auth: Option<LegacyAuth>,
+}
+
+#[derive(Deserialize)]
+struct LegacyLineSerde {
+	email: Option<String>,
+	tokens: Option<LegacyTokens>,
+	auth: Option<LegacyAuth>,
+}
+
+impl From<LegacyLineSerde> for LegacyLine {
+	fn from(value: LegacyLineSerde) -> Self {
+		Self { email: value.email, tokens: value.tokens, auth: value.auth }
+	}
+}
+
+impl Drop for LegacyLine {
+	fn drop(&mut self) {
+		self.email.zeroize();
+	}
+}
+
+#[derive(Deserialize)]
+struct LegacyAuth {
+	email: Option<String>,
+	tokens: Option<LegacyTokens>,
+}
+
+impl Drop for LegacyAuth {
+	fn drop(&mut self) {
+		self.email.zeroize();
+	}
+}
+
+#[derive(Deserialize)]
+struct LegacyTokens {
+	id_token: String,
+	access_token: String,
+	account_id: Option<String>,
+	email: Option<String>,
+}
+
+impl Drop for LegacyTokens {
+	fn drop(&mut self) {
+		self.id_token.zeroize();
+		self.access_token.zeroize();
+		self.account_id.zeroize();
+		self.email.zeroize();
+	}
+}
+
+#[derive(Deserialize)]
+struct IdentityClaims {
+	email: Option<String>,
+	#[serde(rename = "https://api.openai.com/auth")]
+	authority: Option<IdentityAuthority>,
+}
+
+impl Drop for IdentityClaims {
+	fn drop(&mut self) {
+		self.email.zeroize();
+	}
+}
+
+#[derive(Deserialize)]
+struct IdentityAuthority {
+	chatgpt_account_id: Option<String>,
+	chatgpt_plan_type: Option<String>,
+}
+
+impl Drop for IdentityAuthority {
+	fn drop(&mut self) {
+		self.chatgpt_account_id.zeroize();
+		self.chatgpt_plan_type.zeroize();
+	}
+}
+
+struct LegacyCredential {
+	access_token: Zeroizing<String>,
+	account_id: Zeroizing<String>,
+	email: Zeroizing<String>,
+	digest: String,
+}
+
+fn read_legacy_accounts(path: &Path) -> Result<Vec<LegacyCredential>, SupervisorError> {
+	let (file, identity) = open_secure_regular(path, MAX_ACCOUNTS_BYTES)?;
+	let mut bytes = Zeroizing::new(Vec::with_capacity(identity.length as usize));
+	file.take(MAX_ACCOUNTS_BYTES + 1)
+		.read_to_end(&mut bytes)
+		.map_err(|_| SupervisorError::new("legacy accounts cannot be read"))?;
+	if bytes.len() as u64 > MAX_ACCOUNTS_BYTES {
+		return Err(SupervisorError::new("legacy accounts are too large"));
+	}
+
+	let mut accounts = Vec::new();
+	for raw_line in bytes.split(|byte| *byte == b'\n') {
+		let line = trim_ascii(raw_line);
+		if line.is_empty() || line.starts_with(b"#") {
+			continue;
+		}
+		if line.len() > MAX_LINE_BYTES || accounts.len() == MAX_ACCOUNTS {
+			return Err(SupervisorError::new("legacy accounts exceed their bound"));
+		}
+		let parsed = serde_json::from_slice::<LegacyLineSerde>(line)
+			.map_err(|_| SupervisorError::new("legacy accounts are malformed"))?;
+		accounts.push(extract_legacy_credential(parsed.into())?);
+	}
+	if accounts.is_empty() {
+		return Err(SupervisorError::new("legacy accounts are empty"));
+	}
+
+	let mut account_ids = BTreeSet::new();
+	let mut emails = BTreeSet::new();
+	for account in &accounts {
+		let normalized_email = Zeroizing::new(account.email.to_lowercase());
+		if !account_ids.insert(account.digest.clone())
+			|| !emails.insert(hex_sha256(normalized_email.as_bytes()))
+		{
+			return Err(SupervisorError::new("legacy account identities are not unique"));
+		}
+	}
+
+	Ok(accounts)
+}
+
+fn trim_ascii(mut bytes: &[u8]) -> &[u8] {
+	while bytes.first().is_some_and(u8::is_ascii_whitespace) {
+		bytes = &bytes[1..];
+	}
+	while bytes.last().is_some_and(u8::is_ascii_whitespace) {
+		bytes = &bytes[..bytes.len() - 1];
+	}
+
+	bytes
+}
+
+fn extract_legacy_credential(mut line: LegacyLine) -> Result<LegacyCredential, SupervisorError> {
+	if line.tokens.is_some() == line.auth.is_some() {
+		return Err(SupervisorError::new("legacy account shape is invalid"));
+	}
+	let (auth_email, mut tokens) = if let Some(mut auth) = line.auth.take() {
+		let email = auth.email.take();
+		let tokens = auth
+			.tokens
+			.take()
+			.ok_or_else(|| SupervisorError::new("legacy account tokens are missing"))?;
+
+		(email, tokens)
+	} else {
+		(
+			None,
+			line.tokens
+				.take()
+				.ok_or_else(|| SupervisorError::new("legacy account tokens are missing"))?,
+		)
+	};
+	let access_token = Zeroizing::new(std::mem::take(&mut tokens.access_token));
+	if !valid_scalar(&access_token, MAX_ACCESS_TOKEN_BYTES) {
+		return Err(SupervisorError::new("legacy access token is invalid"));
+	}
+	let id_token = Zeroizing::new(std::mem::take(&mut tokens.id_token));
+	if !valid_scalar(&id_token, MAX_ID_TOKEN_BYTES) {
+		return Err(SupervisorError::new("legacy identity token is invalid"));
+	}
+	let account_id = Zeroizing::new(
+		tokens
+			.account_id
+			.take()
+			.ok_or_else(|| SupervisorError::new("legacy provider account identity is missing"))?,
+	);
+	if !valid_scalar(&account_id, MAX_PROVIDER_ACCOUNT_ID_BYTES) {
+		return Err(SupervisorError::new("legacy provider account identity is invalid"));
+	}
+	let email = Zeroizing::new(
+		line.email
+			.take()
+			.or(auth_email)
+			.ok_or_else(|| SupervisorError::new("legacy account email is missing"))?,
+	);
+	if !valid_scalar(&email, MAX_EMAIL_BYTES) || !email.contains('@') {
+		return Err(SupervisorError::new("legacy account email is invalid"));
+	}
+	validate_identity_token(&id_token, &account_id, &email)?;
+
+	let digest = hex_sha256(account_id.as_bytes());
+
+	Ok(LegacyCredential { access_token, account_id, email, digest })
+}
+
+fn valid_scalar(value: &str, maximum_bytes: usize) -> bool {
+	!value.is_empty()
+		&& value.len() <= maximum_bytes
+		&& value.trim() == value
+		&& !value.chars().any(char::is_control)
+}
+
+fn validate_identity_token(
+	token: &str,
+	account_id: &str,
+	email: &str,
+) -> Result<(), SupervisorError> {
+	let mut components = token.split('.');
+	let header = components.next();
+	let payload = components.next();
+	let signature = components.next();
+	if header.is_none_or(str::is_empty)
+		|| payload.is_none_or(str::is_empty)
+		|| signature.is_none_or(str::is_empty)
+		|| components.next().is_some()
+	{
+		return Err(SupervisorError::new("legacy identity token is malformed"));
+	}
+	let payload = payload.expect("nonempty identity-token payload was checked");
+	let decoded = if payload.ends_with('=') {
+		URL_SAFE.decode(payload)
+	} else {
+		URL_SAFE_NO_PAD.decode(payload)
+	}
+	.map_err(|_| SupervisorError::new("legacy identity token is malformed"))?;
+	let decoded = Zeroizing::new(decoded);
+	let mut claims = serde_json::from_slice::<IdentityClaims>(&decoded)
+		.map_err(|_| SupervisorError::new("legacy identity token is malformed"))?;
+	let mut authority = claims
+		.authority
+		.take()
+		.ok_or_else(|| SupervisorError::new("legacy identity token lacks account authority"))?;
+	let claimed_account_id = Zeroizing::new(
+		authority
+			.chatgpt_account_id
+			.take()
+			.ok_or_else(|| SupervisorError::new("legacy identity claims are incomplete"))?,
+	);
+	let claimed_plan = Zeroizing::new(
+		authority
+			.chatgpt_plan_type
+			.take()
+			.ok_or_else(|| SupervisorError::new("legacy identity claims are incomplete"))?,
+	);
+	if !valid_scalar(&claimed_account_id, MAX_PROVIDER_ACCOUNT_ID_BYTES)
+		|| claimed_account_id.as_str() != account_id
+		|| !valid_scalar(&claimed_plan, MAX_PLAN_TYPE_BYTES)
+		|| !valid_plan_type(&claimed_plan)
+	{
+		return Err(SupervisorError::new("legacy identity claims are inconsistent"));
+	}
+	if let Some(claimed_email) = claims.email.take() {
+		let claimed_email = Zeroizing::new(claimed_email);
+		if !valid_scalar(&claimed_email, MAX_EMAIL_BYTES) {
+			return Err(SupervisorError::new("legacy identity email claim is invalid"));
+		}
+		let normalized_claim = Zeroizing::new(claimed_email.to_lowercase());
+		let normalized_email = Zeroizing::new(email.to_lowercase());
+		if normalized_claim != normalized_email {
+			return Err(SupervisorError::new("legacy identity email claim is inconsistent"));
+		}
+	}
+
+	Ok(())
+}
+
+fn valid_plan_type(value: &str) -> bool {
+	matches!(
+		value,
+		"free"
+			| "go" | "plus"
+			| "pro" | "prolite"
+			| "team" | "self_serve_business_usage_based"
+			| "business"
+			| "enterprise_cbp_usage_based"
+			| "enterprise"
+			| "edu" | "unknown"
+	)
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+	Sha256::digest(bytes).iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+struct SlotCredential {
+	slot: u8,
+	access_token: Zeroizing<String>,
+	account_id: Zeroizing<String>,
+	email: Zeroizing<String>,
+}
+
+fn credential_projection_fingerprint(credentials: &[SlotCredential]) -> Zeroizing<[u8; 32]> {
+	let mut digest = Sha256::new();
+
+	digest.update(CREDENTIAL_PROJECTION_FINGERPRINT_PROTOCOL);
+	digest.update(
+		u64::try_from(credentials.len())
+			.expect("bounded credential count fits in u64")
+			.to_be_bytes(),
+	);
+	for credential in credentials {
+		update_length_delimited(&mut digest, &[credential.slot]);
+		update_length_delimited(&mut digest, credential.access_token.as_bytes());
+		update_length_delimited(&mut digest, credential.account_id.as_bytes());
+		update_length_delimited(&mut digest, credential.email.as_bytes());
+	}
+
+	Zeroizing::new(digest.finalize().into())
+}
+
+fn update_length_delimited(digest: &mut Sha256, value: &[u8]) {
+	digest.update(
+		u64::try_from(value.len()).expect("bounded credential field fits in u64").to_be_bytes(),
+	);
+	digest.update(value);
+}
+
+fn map_credentials(
+	mapping: Vec<MappingEntry>,
+	accounts: Vec<LegacyCredential>,
+) -> Result<Vec<SlotCredential>, SupervisorError> {
+	if mapping.len() != accounts.len() {
+		return Err(SupervisorError::new("credential mapping count does not match"));
+	}
+	let mut by_digest = accounts
+		.into_iter()
+		.map(|credential| (credential.digest.clone(), credential))
+		.collect::<BTreeMap<_, _>>();
+	let mut mapped = Vec::with_capacity(mapping.len());
+
+	for entry in mapping {
+		let credential = by_digest
+			.remove(&entry.provider_account_id_sha256)
+			.ok_or_else(|| SupervisorError::new("credential mapping does not match"))?;
+
+		mapped.push(SlotCredential {
+			slot: entry.slot,
+			access_token: credential.access_token,
+			account_id: credential.account_id,
+			email: credential.email,
+		});
+	}
+	if !by_digest.is_empty() {
+		return Err(SupervisorError::new("credential mapping does not match"));
+	}
+	mapped.sort_by_key(|credential| credential.slot);
+
+	Ok(mapped)
+}
+
+fn spawn_postgres(config: &LocalSupervisorConfig) -> Result<Child, SupervisorError> {
+	let mut command = Command::new(&config.postgres);
+	command
+		.arg("-D")
+		.arg(&config.data_directory)
+		.arg("-k")
+		.arg(&config.socket_directory)
+		.arg("-p")
+		.arg(config.port.to_string())
+		.arg("-c")
+		.arg("listen_addresses=")
+		.current_dir(&config.working_directory)
+		.stdin(Stdio::null())
+		.stdout(Stdio::inherit())
+		.stderr(Stdio::inherit());
+	scrub_slot_environment(&mut command);
+
+	command.spawn().map_err(|_| SupervisorError::new("PostgreSQL cannot be started"))
+}
+
+async fn wait_for_postgres(
+	config: &LocalSupervisorConfig,
+	postgres: &mut Child,
+	signals: &mut ShutdownSignals,
+	socket_directory_identity: StableObjectIdentity,
+) -> Result<PostgresIdentity, SupervisorError> {
+	let deadline = Instant::now() + STARTUP_TIMEOUT;
+
+	loop {
+		if child_exit(postgres)?.is_some() {
+			return Err(SupervisorError::new("PostgreSQL exited before readiness"));
+		}
+		if secure_directory_identity(&config.socket_directory)? != socket_directory_identity {
+			return Err(SupervisorError::new("PostgreSQL socket directory changed"));
+		}
+		if postgres_is_ready(config)? {
+			let socket = socket_identity(&postgres_socket_path(config))?;
+			let generation_path = config.data_directory.join("postmaster.pid");
+			let generation =
+				secure_regular_file_identity(&generation_path, 64 * 1024)?.stable_object();
+			let process_id = read_postmaster_pid(&generation_path)?;
+			if process_id != postgres.id() {
+				return Err(SupervisorError::new("PostgreSQL generation is invalid"));
+			}
+
+			return Ok(PostgresIdentity {
+				process_id,
+				socket_directory: socket_directory_identity,
+				socket,
+				generation,
+			});
+		}
+		if Instant::now() >= deadline {
+			return Err(SupervisorError::new("PostgreSQL readiness timed out"));
+		}
+
+		tokio::select! {
+			signal = signals.recv() => {
+				signal.map_err(|_| SupervisorError::new("supervisor signal handling failed"))?;
+				return Err(SupervisorError::new("supervisor stopped during PostgreSQL startup"));
+			},
+			_ = tokio::time::sleep(POLL_INTERVAL) => {},
+		}
+	}
+}
+
+fn postgres_is_ready(config: &LocalSupervisorConfig) -> Result<bool, SupervisorError> {
+	let mut command = Command::new(&config.pg_isready);
+	command
+		.arg("-q")
+		.arg("-h")
+		.arg(&config.socket_directory)
+		.arg("-p")
+		.arg(config.port.to_string())
+		.arg("-t")
+		.arg("1")
+		.current_dir(&config.working_directory)
+		.stdin(Stdio::null())
+		.stdout(Stdio::null())
+		.stderr(Stdio::null());
+	scrub_slot_environment(&mut command);
+	let status =
+		command.status().map_err(|_| SupervisorError::new("PostgreSQL readiness probe failed"))?;
+
+	Ok(status.success())
+}
+
+fn postgres_socket_path(config: &LocalSupervisorConfig) -> PathBuf {
+	config.socket_directory.join(format!(".s.PGSQL.{}", config.port))
+}
+
+fn socket_identity(path: &Path) -> Result<StableObjectIdentity, SupervisorError> {
+	let metadata = fs::symlink_metadata(path)
+		.map_err(|_| SupervisorError::new("PostgreSQL socket is unavailable"))?;
+	let identity = FileIdentity::from_metadata(&metadata)?;
+	// SAFETY: `geteuid` has no arguments or failure return.
+	let effective_uid = unsafe { libc::geteuid() };
+
+	if metadata.file_type().is_symlink()
+		|| identity.kind != FileKind::Socket
+		|| identity.uid != effective_uid
+	{
+		return Err(SupervisorError::new("PostgreSQL socket is unsafe"));
+	}
+
+	Ok(identity.stable_object())
+}
+
+fn read_postmaster_pid(path: &Path) -> Result<u32, SupervisorError> {
+	let (file, _) = open_secure_regular_relaxed_mode(path, 64 * 1024)?;
+	let mut bytes = Vec::new();
+	file.take(64 * 1024 + 1)
+		.read_to_end(&mut bytes)
+		.map_err(|_| SupervisorError::new("PostgreSQL generation cannot be read"))?;
+	let first_line = bytes
+		.split(|byte| *byte == b'\n')
+		.next()
+		.ok_or_else(|| SupervisorError::new("PostgreSQL generation is invalid"))?;
+	let value = std::str::from_utf8(first_line)
+		.map_err(|_| SupervisorError::new("PostgreSQL generation is invalid"))?
+		.parse::<u32>()
+		.map_err(|_| SupervisorError::new("PostgreSQL generation is invalid"))?;
+
+	Ok(value)
+}
+
+fn open_secure_regular_relaxed_mode(
+	path: &Path,
+	maximum_bytes: u64,
+) -> Result<(File, FileIdentity), SupervisorError> {
+	let expected_metadata = fs::symlink_metadata(path)
+		.map_err(|_| SupervisorError::new("PostgreSQL generation is unavailable"))?;
+	let expected = FileIdentity::from_metadata(&expected_metadata)?;
+	// SAFETY: `geteuid` has no arguments or failure return.
+	let effective_uid = unsafe { libc::geteuid() };
+	if expected_metadata.file_type().is_symlink()
+		|| expected.kind != FileKind::Regular
+		|| expected.uid != effective_uid
+		|| expected.links != 1
+		|| expected.length > maximum_bytes
+	{
+		return Err(SupervisorError::new("PostgreSQL generation is unsafe"));
+	}
+	let file = OpenOptions::new()
+		.read(true)
+		.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+		.open(path)
+		.map_err(|_| SupervisorError::new("PostgreSQL generation cannot be opened"))?;
+	let actual = FileIdentity::from_metadata(
+		&file
+			.metadata()
+			.map_err(|_| SupervisorError::new("PostgreSQL generation cannot be inspected"))?,
+	)?;
+	if actual != expected {
+		return Err(SupervisorError::new("PostgreSQL generation changed during open"));
+	}
+
+	Ok((file, actual))
+}
+
+fn spawn_daemon(
+	config: &LocalSupervisorConfig,
+	executable: &Path,
+	credentials: &[SlotCredential],
+) -> Result<Child, SupervisorError> {
+	daemon_command(config, executable, credentials)
+		.spawn()
+		.map_err(|_| SupervisorError::new("decodexd child cannot be started"))
+}
+
+fn daemon_command(
+	config: &LocalSupervisorConfig,
+	executable: &Path,
+	credentials: &[SlotCredential],
+) -> Command {
+	let mut command = Command::new(executable);
+	command
+		.arg("serve")
+		.current_dir(&config.working_directory)
+		.stdin(Stdio::null())
+		.stdout(Stdio::inherit())
+		.stderr(Stdio::inherit());
+
+	scrub_slot_environment(&mut command);
+	for credential in credentials {
+		command.env(
+			slot_environment_name(credential.slot, "ACCESS_TOKEN"),
+			credential.access_token.as_str(),
+		);
+		command.env(
+			slot_environment_name(credential.slot, "ACCOUNT_ID"),
+			credential.account_id.as_str(),
+		);
+		command.env(slot_environment_name(credential.slot, "EMAIL"), credential.email.as_str());
+	}
+
+	command
+}
+
+fn scrub_slot_environment(command: &mut Command) {
+	for slot in 1..=MAX_ACCOUNTS {
+		for suffix in ["ACCESS_TOKEN", "ACCOUNT_ID", "EMAIL"] {
+			command.env_remove(slot_environment_name(slot as u8, suffix));
+		}
+	}
+}
+
+fn slot_environment_name(slot: u8, suffix: &str) -> OsString {
+	OsString::from(format!("DECODEX_RESET_CARD_SLOT_{slot:02}_{suffix}"))
+}
+
+fn child_exit(child: &mut Child) -> Result<Option<ExitStatus>, SupervisorError> {
+	child.try_wait().map_err(|_| SupervisorError::new("child process cannot be inspected"))
+}
+
+#[derive(Clone, Copy)]
+enum ChildKind {
+	Daemon,
+	Postgres,
+}
+
+fn stop_child(child: &mut Child, kind: ChildKind) {
+	if child.try_wait().ok().flatten().is_some() {
+		return;
+	}
+	#[cfg(unix)]
+	{
+		// SAFETY: the PID came from a live `Child`; SIGTERM is a defined Unix signal.
+		let _ = unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGTERM) };
+	}
+
+	let deadline = Instant::now() + child_shutdown_timeout(kind);
+	while Instant::now() < deadline {
+		match child.try_wait() {
+			Ok(Some(_)) => return,
+			Ok(None) => thread::sleep(Duration::from_millis(20)),
+			Err(_) => break,
+		}
+	}
+	let _ = child.kill();
+	let _ = child.wait();
+
+	let message = match kind {
+		ChildKind::Daemon => "decodexd child required forced termination",
+		ChildKind::Postgres => "PostgreSQL child required forced termination",
+	};
+	let _ = writeln!(std::io::stderr().lock(), "{message}");
+}
+
+const fn child_shutdown_timeout(kind: ChildKind) -> Duration {
+	match kind {
+		ChildKind::Daemon => DAEMON_SHUTDOWN_TIMEOUT,
+		ChildKind::Postgres => POSTGRES_SHUTDOWN_TIMEOUT,
+	}
+}
+
+pub(super) struct SupervisorError {
+	message: &'static str,
+}
+
+impl SupervisorError {
+	const fn new(message: &'static str) -> Self {
+		Self { message }
+	}
+}
+
+impl Display for SupervisorError {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(self.message)
+	}
+}
+
+impl std::fmt::Debug for SupervisorError {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.write_str(self.message)
+	}
+}
+
+impl Error for SupervisorError {}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		collections::BTreeMap,
+		ffi::OsString,
+		fs,
+		os::unix::fs::{PermissionsExt as _, symlink},
+		path::{Path, PathBuf},
+	};
+
+	use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+	use tempfile::TempDir;
+	use zeroize::Zeroizing;
+
+	use super::{
+		ChildKind, DAEMON_SHUTDOWN_TIMEOUT, LocalSupervisorConfig, MAPPING_SCHEMA,
+		POSTGRES_SHUTDOWN_TIMEOUT, SlotCredential, WatchedCredentialFiles, account_lock_path,
+		child_shutdown_timeout, credential_projection_fingerprint, daemon_command, hex_sha256,
+		load_credentials, slot_environment_name,
+	};
+
+	#[test]
+	fn secure_mapping_loads_exact_slots_without_retaining_unmapped_accounts() {
+		let fixture = CredentialFixture::new();
+		fixture.write_accounts(&[
+			("first@example.test", "provider-first", "access-first"),
+			("second@example.test", "provider-second", "access-second"),
+		]);
+		fixture.write_mapping(&[(2, "provider-second"), (1, "provider-first")]);
+
+		let (loaded, _) =
+			load_credentials(&fixture.accounts, &fixture.lock, &fixture.mapping).expect("load");
+
+		assert_eq!(loaded.len(), 2);
+		assert_eq!(loaded[0].slot, 1);
+		assert_eq!(loaded[0].account_id.as_str(), "provider-first");
+		assert_eq!(loaded[0].email.as_str(), "first@example.test");
+		assert_eq!(loaded[0].access_token.as_str(), "access-first");
+		assert_eq!(
+			slot_environment_name(loaded[1].slot, "ACCESS_TOKEN"),
+			"DECODEX_RESET_CARD_SLOT_02_ACCESS_TOKEN"
+		);
+	}
+
+	#[test]
+	fn mapping_requires_an_exact_legacy_account_count_and_digest_set() {
+		let fixture = CredentialFixture::new();
+		fixture.write_accounts(&[
+			("first@example.test", "provider-first", "access-first"),
+			("second@example.test", "provider-second", "access-second"),
+		]);
+		fixture.write_mapping(&[(1, "provider-first")]);
+
+		assert!(load_credentials(&fixture.accounts, &fixture.lock, &fixture.mapping).is_err());
+
+		fixture.write_mapping(&[(1, "provider-first"), (2, "wrong-provider")]);
+		assert!(load_credentials(&fixture.accounts, &fixture.lock, &fixture.mapping).is_err());
+
+		fixture.write_mapping(&[(1, "provider-first"), (3, "provider-second")]);
+		assert!(load_credentials(&fixture.accounts, &fixture.lock, &fixture.mapping).is_err());
+	}
+
+	#[test]
+	fn legacy_accounts_require_unique_provider_identity_and_email() {
+		let fixture = CredentialFixture::new();
+		fixture.write_accounts(&[
+			("same@example.test", "provider-first", "access-first"),
+			("SAME@example.test", "provider-second", "access-second"),
+		]);
+		fixture.write_mapping(&[(1, "provider-first"), (2, "provider-second")]);
+
+		assert!(load_credentials(&fixture.accounts, &fixture.lock, &fixture.mapping).is_err());
+	}
+
+	#[test]
+	fn legacy_account_reader_rejects_symlink_and_insecure_mode() {
+		let fixture = CredentialFixture::new();
+		fixture.write_accounts(&[("first@example.test", "provider-first", "access-first")]);
+		fixture.write_mapping(&[(1, "provider-first")]);
+
+		fs::set_permissions(&fixture.accounts, fs::Permissions::from_mode(0o644))
+			.expect("make accounts unsafe");
+		assert!(load_credentials(&fixture.accounts, &fixture.lock, &fixture.mapping).is_err());
+
+		fs::set_permissions(&fixture.accounts, fs::Permissions::from_mode(0o600))
+			.expect("restore accounts");
+		let target = fixture.root.path().join("mapping-target.json");
+		fs::rename(&fixture.mapping, &target).expect("move mapping");
+		symlink(&target, &fixture.mapping).expect("symlink mapping");
+		assert!(load_credentials(&fixture.accounts, &fixture.lock, &fixture.mapping).is_err());
+	}
+
+	#[test]
+	fn legacy_account_reader_rejects_identity_claim_drift() {
+		let fixture = CredentialFixture::new();
+		fixture.write_mapping(&[(1, "provider-first")]);
+
+		for (claimed_account, claimed_email, claimed_plan) in [
+			("different-provider", "first@example.test", "pro"),
+			("provider-first", "different@example.test", "pro"),
+			("provider-first", "first@example.test", "private-plan"),
+		] {
+			let identity_token = identity_token(claimed_account, claimed_email, claimed_plan);
+			secure_write(
+				&fixture.accounts,
+				&format!(
+					r#"{{"email":"first@example.test","tokens":{{"id_token":"{identity_token}","access_token":"access-first","refresh_token":"not-read","account_id":"provider-first"}}}}
+"#
+				),
+			);
+
+			assert!(load_credentials(&fixture.accounts, &fixture.lock, &fixture.mapping).is_err());
+		}
+	}
+
+	#[test]
+	fn legacy_account_reader_rejects_scalar_whitespace_instead_of_normalizing_it() {
+		let fixture = CredentialFixture::new();
+		let identity_token = identity_token("provider-first", "first@example.test", "pro");
+		secure_write(
+			&fixture.accounts,
+			&format!(
+				r#"{{"email":"first@example.test","tokens":{{"id_token":"{identity_token}","access_token":" access-first","refresh_token":"not-read","account_id":"provider-first"}}}}
+"#
+			),
+		);
+		fixture.write_mapping(&[(1, "provider-first")]);
+
+		assert!(load_credentials(&fixture.accounts, &fixture.lock, &fixture.mapping).is_err());
+	}
+
+	#[test]
+	fn legacy_writer_lock_path_is_hidden_next_to_the_accounts_file() {
+		assert_eq!(
+			account_lock_path(Path::new("/tmp/pool/accounts.jsonl")).expect("derive lock"),
+			PathBuf::from("/tmp/pool/.accounts.jsonl.lock")
+		);
+	}
+
+	#[test]
+	fn credential_watch_tracks_exact_files_without_restarting_for_unrelated_parent_entries() {
+		let fixture = CredentialFixture::new();
+		fixture.write_accounts(&[("first@example.test", "provider-first", "access-first")]);
+		fixture.write_mapping(&[(1, "provider-first")]);
+		let (_, loaded_watch) =
+			load_credentials(&fixture.accounts, &fixture.lock, &fixture.mapping).expect("load");
+
+		secure_write(
+			&fixture.mapping.parent().expect("mapping parent").join("unrelated-state"),
+			"unrelated",
+		);
+		let unrelated_watch =
+			WatchedCredentialFiles::capture(&fixture.accounts, &fixture.lock, &fixture.mapping)
+				.expect("capture unrelated parent change");
+		assert!(loaded_watch == unrelated_watch);
+
+		fs::set_permissions(&fixture.lock, fs::Permissions::from_mode(0o600))
+			.expect("reapply secure lock mode");
+		let metadata_only_lock_watch =
+			WatchedCredentialFiles::capture(&fixture.accounts, &fixture.lock, &fixture.mapping)
+				.expect("capture metadata-only lock change");
+		assert!(loaded_watch == metadata_only_lock_watch);
+
+		let replacement_lock = fixture.root.path().join("replacement.lock");
+		secure_write(&replacement_lock, "");
+		fs::rename(&replacement_lock, &fixture.lock).expect("replace lock inode");
+		let replaced_lock_watch =
+			WatchedCredentialFiles::capture(&fixture.accounts, &fixture.lock, &fixture.mapping)
+				.expect("capture lock replacement");
+		assert!(loaded_watch != replaced_lock_watch);
+	}
+
+	#[test]
+	fn daemon_restart_requires_a_changed_credential_projection() {
+		let fixture = CredentialFixture::new();
+		let accounts = [("first@example.test", "provider-first", "access-first")];
+
+		fixture.write_accounts(&accounts);
+		fixture.write_mapping(&[(1, "provider-first")]);
+		let (loaded, loaded_watch) =
+			load_credentials(&fixture.accounts, &fixture.lock, &fixture.mapping).expect("load");
+		let loaded_projection = credential_projection_fingerprint(&loaded);
+
+		fixture.replace_accounts(&accounts, 2);
+		let (same_credentials, same_credentials_watch) =
+			load_credentials(&fixture.accounts, &fixture.lock, &fixture.mapping)
+				.expect("reload same credentials");
+		let same_projection = credential_projection_fingerprint(&same_credentials);
+
+		assert!(loaded_watch != same_credentials_watch);
+		assert!(loaded_projection.as_ref() == same_projection.as_ref());
+
+		fixture.replace_accounts(&[("first@example.test", "provider-first", "access-second")], 3);
+		let (changed_credentials, _) =
+			load_credentials(&fixture.accounts, &fixture.lock, &fixture.mapping)
+				.expect("reload changed credentials");
+		let changed_projection = credential_projection_fingerprint(&changed_credentials);
+
+		assert!(loaded_projection.as_ref() != changed_projection.as_ref());
+	}
+
+	#[test]
+	fn daemon_command_injects_only_the_exact_mapped_slots() {
+		let path = PathBuf::from("/unused");
+		let config = LocalSupervisorConfig {
+			postgres: path.clone(),
+			pg_isready: path.clone(),
+			data_directory: path.clone(),
+			socket_directory: path.clone(),
+			port: 1,
+			legacy_accounts: path.clone(),
+			legacy_mapping: path.clone(),
+			working_directory: PathBuf::from("/"),
+		};
+		let credentials = [SlotCredential {
+			slot: 1,
+			access_token: Zeroizing::new(String::from("access-first")),
+			account_id: Zeroizing::new(String::from("provider-first")),
+			email: Zeroizing::new(String::from("first@example.test")),
+		}];
+		let command = daemon_command(&config, Path::new("/path/to/decodexd"), &credentials);
+		let environments = command
+			.get_envs()
+			.map(|(name, value)| (name.to_owned(), value.map(OsString::from)))
+			.collect::<BTreeMap<_, _>>();
+
+		assert_eq!(command.get_program(), "/path/to/decodexd");
+		assert_eq!(command.get_args().collect::<Vec<_>>(), ["serve"]);
+		assert_eq!(
+			environments.get(&OsString::from("DECODEX_RESET_CARD_SLOT_01_ACCESS_TOKEN")),
+			Some(&Some(OsString::from("access-first")))
+		);
+		assert_eq!(
+			environments.get(&OsString::from("DECODEX_RESET_CARD_SLOT_01_ACCOUNT_ID")),
+			Some(&Some(OsString::from("provider-first")))
+		);
+		assert_eq!(
+			environments.get(&OsString::from("DECODEX_RESET_CARD_SLOT_01_EMAIL")),
+			Some(&Some(OsString::from("first@example.test")))
+		);
+		assert_eq!(
+			environments.get(&OsString::from("DECODEX_RESET_CARD_SLOT_02_ACCESS_TOKEN")),
+			Some(&None)
+		);
+	}
+
+	#[test]
+	fn child_shutdown_grace_preserves_bounded_provider_work_and_launchd_margin() {
+		assert_eq!(child_shutdown_timeout(ChildKind::Daemon), DAEMON_SHUTDOWN_TIMEOUT);
+		assert_eq!(DAEMON_SHUTDOWN_TIMEOUT.as_secs(), 240);
+		assert!(DAEMON_SHUTDOWN_TIMEOUT > std::time::Duration::from_secs(212 + 5));
+		assert_eq!(child_shutdown_timeout(ChildKind::Postgres), POSTGRES_SHUTDOWN_TIMEOUT);
+		assert_eq!(POSTGRES_SHUTDOWN_TIMEOUT.as_secs(), 30);
+		assert!(
+			DAEMON_SHUTDOWN_TIMEOUT + POSTGRES_SHUTDOWN_TIMEOUT
+				< std::time::Duration::from_secs(300)
+		);
+	}
+
+	struct CredentialFixture {
+		root: TempDir,
+		accounts: PathBuf,
+		lock: PathBuf,
+		mapping: PathBuf,
+	}
+
+	impl CredentialFixture {
+		fn new() -> Self {
+			let root = TempDir::new().expect("create fixture");
+			fs::set_permissions(root.path(), fs::Permissions::from_mode(0o700))
+				.expect("secure fixture");
+			let accounts = root.path().join("accounts.jsonl");
+			let lock = root.path().join(".accounts.jsonl.lock");
+			let mapping_parent = root.path().join("mapping");
+			fs::create_dir(&mapping_parent).expect("create mapping parent");
+			fs::set_permissions(&mapping_parent, fs::Permissions::from_mode(0o700))
+				.expect("secure mapping parent");
+			let mapping = mapping_parent.join("legacy.json");
+
+			secure_write(&lock, "");
+
+			Self { root, accounts, lock, mapping }
+		}
+
+		fn write_accounts(&self, accounts: &[(&str, &str, &str)]) {
+			secure_write(&self.accounts, &accounts_body(accounts, 1));
+		}
+
+		fn replace_accounts(&self, accounts: &[(&str, &str, &str)], generation: u64) {
+			let replacement = self.root.path().join("accounts-replacement.jsonl");
+
+			secure_write(&replacement, &accounts_body(accounts, generation));
+			fs::rename(replacement, &self.accounts).expect("replace accounts atomically");
+		}
+
+		fn write_mapping(&self, entries: &[(u8, &str)]) {
+			let accounts = entries
+				.iter()
+				.map(|(slot, provider)| {
+					format!(
+						r#"{{"slot":{slot},"provider_account_id_sha256":"{}"}}"#,
+						hex_sha256(provider.as_bytes())
+					)
+				})
+				.collect::<Vec<_>>()
+				.join(",");
+			secure_write(
+				&self.mapping,
+				&format!(r#"{{"schema":"{MAPPING_SCHEMA}","accounts":[{accounts}]}}"#),
+			);
+		}
+	}
+
+	fn accounts_body(accounts: &[(&str, &str, &str)], generation: u64) -> String {
+		let body = accounts
+			.iter()
+			.map(|(email, account_id, access_token)| {
+				let identity_token = identity_token(account_id, email, "pro");
+
+				format!(
+					r#"{{"email":"{email}","last_selected_at_unix_epoch":{generation},"tokens":{{"id_token":"{identity_token}","access_token":"{access_token}","refresh_token":"not-read","account_id":"{account_id}"}}}}"#
+				)
+			})
+			.collect::<Vec<_>>()
+			.join("\n");
+
+		body + "\n"
+	}
+
+	fn identity_token(account_id: &str, email: &str, plan_type: &str) -> String {
+		let payload = format!(
+			r#"{{"email":"{email}","https://api.openai.com/auth":{{"chatgpt_account_id":"{account_id}","chatgpt_plan_type":"{plan_type}"}}}}"#
+		);
+
+		format!("header.{}.signature", URL_SAFE_NO_PAD.encode(payload))
+	}
+
+	fn secure_write(path: &Path, body: &str) {
+		fs::write(path, body).expect("write fixture");
+		fs::set_permissions(path, fs::Permissions::from_mode(0o600)).expect("secure fixture file");
+	}
+}

--- a/apps/decodexd/src/main.rs
+++ b/apps/decodexd/src/main.rs
@@ -1,12 +1,84 @@
 //! Sole Decodex vNext server composition root.
 
-use std::error::Error;
+#[cfg(unix)] mod local_supervisor;
 
+use std::error::Error;
+#[cfg(unix)] use std::path::PathBuf;
+
+#[cfg(unix)] use clap::Args;
+use clap::{Parser, Subcommand};
 use decodex_runtime::{ServerConfig, ServiceComposition};
 #[cfg(test)] use {libc as _, tempfile as _};
 
+#[derive(Parser)]
+#[command(about, version)]
+struct Cli {
+	#[command(subcommand)]
+	command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+	/// Serve the same-UID Decodex vNext protocol.
+	Serve,
+	/// Supervise the local PostgreSQL and credential-injected daemon processes.
+	#[cfg(unix)]
+	SuperviseLocal(SuperviseLocalArgs),
+}
+
+#[cfg(unix)]
+#[derive(Args)]
+struct SuperviseLocalArgs {
+	/// PostgreSQL 18 foreground server executable.
+	#[arg(long)]
+	postgres: PathBuf,
+	/// PostgreSQL 18 readiness probe executable.
+	#[arg(long)]
+	pg_isready: PathBuf,
+	/// Initialized PostgreSQL 18 data directory.
+	#[arg(long)]
+	data_directory: PathBuf,
+	/// Private PostgreSQL Unix socket directory.
+	#[arg(long)]
+	socket_directory: PathBuf,
+	/// PostgreSQL Unix socket port.
+	#[arg(long)]
+	port: u16,
+	/// Legacy account-pool JSONL file read under its writer lock.
+	#[arg(long)]
+	legacy_accounts: PathBuf,
+	/// Non-secret legacy-to-vNext slot mapping manifest.
+	#[arg(long)]
+	legacy_mapping: PathBuf,
+	/// Working directory inherited by supervised children.
+	#[arg(long)]
+	working_directory: PathBuf,
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+	match Cli::parse().command {
+		None | Some(Command::Serve) => serve().await,
+		#[cfg(unix)]
+		Some(Command::SuperviseLocal(arguments)) => {
+			local_supervisor::supervise(local_supervisor::LocalSupervisorConfig {
+				postgres: arguments.postgres,
+				pg_isready: arguments.pg_isready,
+				data_directory: arguments.data_directory,
+				socket_directory: arguments.socket_directory,
+				port: arguments.port,
+				legacy_accounts: arguments.legacy_accounts,
+				legacy_mapping: arguments.legacy_mapping,
+				working_directory: arguments.working_directory,
+			})
+			.await?;
+
+			Ok(())
+		},
+	}
+}
+
+async fn serve() -> Result<(), Box<dyn Error>> {
 	let bootstrap = ServiceComposition::bootstrap_default().await;
 	let mut bound = bootstrap.bind(ServerConfig::default()).await?;
 	let mut signals = ShutdownSignals::new()?;
@@ -64,5 +136,23 @@ impl ShutdownSignals {
 
 	async fn recv(&mut self) -> std::io::Result<()> {
 		tokio::signal::ctrl_c().await
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use clap::{CommandFactory as _, Parser as _};
+
+	use super::{Cli, Command};
+
+	#[test]
+	fn command_surface_keeps_no_argument_serve_and_explicit_supervisor() {
+		let default = Cli::try_parse_from(["decodexd"]).expect("parse default serve");
+		assert!(default.command.is_none());
+
+		let explicit = Cli::try_parse_from(["decodexd", "serve"]).expect("parse explicit serve");
+		assert!(matches!(explicit.command, Some(Command::Serve)));
+
+		Cli::command().debug_assert();
 	}
 }

--- a/apps/decodexd/tests/cli.rs
+++ b/apps/decodexd/tests/cli.rs
@@ -1,0 +1,43 @@
+//! Process-level checks for informational CLI exits.
+
+#![allow(unused_crate_dependencies)]
+
+use std::process::Command;
+
+use tempfile::TempDir;
+
+#[test]
+fn version_exits_without_starting_the_daemon() {
+	let home = TempDir::new().expect("create isolated home");
+	let output = Command::new(env!("CARGO_BIN_EXE_decodexd"))
+		.arg("--version")
+		.env("HOME", home.path())
+		.output()
+		.expect("run version");
+
+	assert!(output.status.success());
+	assert_eq!(
+		String::from_utf8(output.stdout).expect("version output is UTF-8"),
+		format!("decodexd {}\n", env!("CARGO_PKG_VERSION"))
+	);
+	assert!(output.stderr.is_empty());
+	assert!(!home.path().join(".decodex").exists());
+}
+
+#[test]
+fn help_exits_without_starting_the_daemon() {
+	let home = TempDir::new().expect("create isolated home");
+	let output = Command::new(env!("CARGO_BIN_EXE_decodexd"))
+		.arg("--help")
+		.env("HOME", home.path())
+		.output()
+		.expect("run help");
+	let stdout = String::from_utf8(output.stdout).expect("help output is UTF-8");
+
+	assert!(output.status.success());
+	assert!(stdout.contains("supervise-local"));
+	assert!(stdout.contains("serve"));
+	assert!(!stdout.contains("secret-run"));
+	assert!(output.stderr.is_empty());
+	assert!(!home.path().join(".decodex").exists());
+}

--- a/apps/decodexd/tests/local_supervisor.rs
+++ b/apps/decodexd/tests/local_supervisor.rs
@@ -1,0 +1,413 @@
+//! Process-level proof for the Unix local supervisor restart and shutdown contract.
+
+#![cfg(any(target_os = "linux", target_os = "macos"))]
+#![allow(unused_crate_dependencies)]
+
+use std::{
+	fs::{self, File, OpenOptions},
+	io::{Read as _, Write as _},
+	os::{
+		fd::AsRawFd as _,
+		unix::{
+			fs::{MetadataExt as _, PermissionsExt as _},
+			net::UnixStream,
+		},
+	},
+	path::{Path, PathBuf},
+	process::{Child, Command, ExitStatus, Stdio},
+	thread,
+	time::{Duration, Instant},
+};
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use sha2::{Digest as _, Sha256};
+use tempfile::TempDir;
+
+const PORT: u16 = 55_431;
+const ACCOUNT_ID: &str = "provider-account-one";
+const EMAIL: &str = "first@example.test";
+
+#[test]
+fn account_pool_replacement_restarts_the_daemon_only_for_changed_credentials() {
+	let fixture = SupervisorFixture::new();
+	fixture.write_accounts("access-one");
+	let mut supervisor = fixture.start();
+
+	let first_generation = fixture.wait_for_daemon_generation(None, &mut supervisor);
+	fixture.replace_accounts("access-one", 2);
+	fixture.assert_daemon_generation_stable(first_generation, &mut supervisor);
+	fixture.replace_accounts("access-two", 3);
+	fixture.wait_for_daemon_generation(Some(first_generation), &mut supervisor);
+
+	let status = signal_and_wait(&mut supervisor, libc::SIGTERM);
+	let output = supervisor.wait_with_output().expect("collect supervisor output");
+
+	assert!(status.success(), "supervisor must stop cleanly: {status}");
+	assert!(!fixture.postgres_socket().exists());
+	assert!(UnixStream::connect(fixture.daemon_socket()).is_err());
+	for secret in ["access-one", "access-two", ACCOUNT_ID, EMAIL] {
+		assert!(!output.stdout.windows(secret.len()).any(|window| window == secret.as_bytes()));
+		assert!(!output.stderr.windows(secret.len()).any(|window| window == secret.as_bytes()));
+	}
+}
+
+#[test]
+fn postgres_exit_stops_the_daemon_and_fails_the_supervisor_generation() {
+	let fixture = SupervisorFixture::new();
+	fixture.write_accounts("access-one");
+	let mut supervisor = fixture.start();
+
+	fixture.wait_for_daemon_generation(None, &mut supervisor);
+	fixture.stop_postgres();
+	let status = wait_for_exit(&mut supervisor);
+	let output = supervisor.wait_with_output().expect("collect supervisor output");
+
+	assert!(!status.success(), "a lost PostgreSQL generation must fail the supervisor");
+	assert!(!fixture.postgres_socket().exists());
+	assert!(UnixStream::connect(fixture.daemon_socket()).is_err());
+	for secret in ["access-one", ACCOUNT_ID, EMAIL] {
+		assert!(!output.stdout.windows(secret.len()).any(|window| window == secret.as_bytes()));
+		assert!(!output.stderr.windows(secret.len()).any(|window| window == secret.as_bytes()));
+	}
+}
+
+struct SupervisorFixture {
+	_home: TempDir,
+	canonical_home: PathBuf,
+	accounts: PathBuf,
+	lock: PathBuf,
+	mapping: PathBuf,
+	postgres: PathBuf,
+	pg_isready: PathBuf,
+	data_directory: PathBuf,
+	socket_directory: PathBuf,
+	working_directory: PathBuf,
+}
+
+impl SupervisorFixture {
+	#[allow(clippy::too_many_lines)] // One complete local-supervisor process fixture.
+	fn new() -> Self {
+		let home = TempDir::new().expect("create supervisor fixture");
+		secure_directory(home.path());
+		let canonical_home = home.path().canonicalize().expect("canonical fixture home");
+		let decodex_root = canonical_home.join(".decodex");
+		let server = decodex_root.join("server");
+		let legacy_parent = canonical_home.join(".codex/decodex");
+		let data_directory = canonical_home.join("data");
+		let socket_directory = canonical_home.join("pg");
+		let database_socket = canonical_home.join("db");
+		let working_directory = canonical_home.join("repository");
+
+		for directory in [
+			&decodex_root,
+			&server,
+			&legacy_parent,
+			&data_directory,
+			&socket_directory,
+			&database_socket,
+			&working_directory,
+		] {
+			fs::create_dir_all(directory).expect("create fixture directory");
+			secure_directory(directory);
+		}
+		let accounts = legacy_parent.join("accounts.jsonl");
+		let lock = legacy_parent.join(".accounts.jsonl.lock");
+		let mapping = decodex_root.join("reset-card-legacy-bridge.json");
+		let postgres = canonical_home.join("fake-postgres.py");
+		let pg_isready = canonical_home.join("fake-pg-isready.sh");
+
+		secure_write(&lock, "");
+		secure_write(
+			&mapping,
+			&format!(
+				r#"{{"schema":"decodex/reset-card-legacy-bridge/1","accounts":[{{"slot":1,"provider_account_id_sha256":"{}"}}]}}"#,
+				hex_sha256(ACCOUNT_ID.as_bytes())
+			),
+		);
+		secure_write(
+			&decodex_root.join("config.toml"),
+			&format!(
+				r#"version = 1
+active_profile = "local"
+
+[profiles.local]
+kind = "local"
+policy = "same_uid"
+service_owner_uid = {}
+
+[server_host.repositories.fixture]
+host_path = "{}"
+
+[server_host.reset_card_accounts."10000000-0000-4000-8000-000000000001"]
+display_label = "Fixture"
+initial_state = "available"
+access_token_env_var = "DECODEX_RESET_CARD_SLOT_01_ACCESS_TOKEN"
+provider_account_id_env_var = "DECODEX_RESET_CARD_SLOT_01_ACCOUNT_ID"
+expected_email_env_var = "DECODEX_RESET_CARD_SLOT_01_EMAIL"
+plan_type = "pro"
+
+[postgres]
+socket_directory = "{}"
+expected_peer_uid = {}
+port = 5432
+database = "decodex"
+
+[postgres.migration]
+user = "decodex_migration"
+
+[postgres.runtime]
+user = "decodex_runtime"
+
+[cache]
+max_entries = 16
+max_bytes = 1048576
+max_entry_bytes = 65536
+"#,
+				fs::metadata(&decodex_root).expect("inspect root").uid(),
+				working_directory.display(),
+				database_socket.display(),
+				fs::metadata(&decodex_root).expect("inspect root").uid(),
+			),
+		);
+		write_executable(
+			&postgres,
+			r#"#!/usr/bin/env python3
+import os
+import signal
+import socket
+import sys
+import time
+
+args = sys.argv[1:]
+data = args[args.index("-D") + 1]
+socket_dir = args[args.index("-k") + 1]
+port = args[args.index("-p") + 1]
+socket_path = os.path.join(socket_dir, ".s.PGSQL." + port)
+pid_path = os.path.join(data, "postmaster.pid")
+with open(pid_path, "w", encoding="ascii") as handle:
+    handle.write(str(os.getpid()) + "\n")
+os.chmod(pid_path, 0o600)
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(socket_path)
+running = True
+def stop(_signal, _frame):
+    global running
+    running = False
+signal.signal(signal.SIGTERM, stop)
+signal.signal(signal.SIGINT, stop)
+while running:
+    time.sleep(0.02)
+server.close()
+for path in (socket_path, pid_path):
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+"#,
+		);
+		write_executable(
+			&pg_isready,
+			r#"#!/bin/sh
+set -eu
+host=
+port=
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-h) host=$2; shift 2 ;;
+		-p) port=$2; shift 2 ;;
+		*) shift ;;
+	esac
+done
+[ -S "$host/.s.PGSQL.$port" ]
+"#,
+		);
+		Self {
+			_home: home,
+			canonical_home,
+			accounts,
+			lock,
+			mapping,
+			postgres,
+			pg_isready,
+			data_directory,
+			socket_directory,
+			working_directory,
+		}
+	}
+
+	fn write_accounts(&self, access_token: &str) {
+		secure_write(&self.accounts, &account_record(access_token, 1));
+	}
+
+	fn replace_accounts(&self, access_token: &str, generation: u64) {
+		let lock = OpenOptions::new().read(true).write(true).open(&self.lock).expect("open lock");
+		// SAFETY: the descriptor remains valid until after the matching unlock.
+		assert_eq!(unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX) }, 0);
+		let temporary = self.accounts.with_file_name(".accounts.jsonl.integration.tmp");
+
+		secure_write(&temporary, &account_record(access_token, generation));
+		fs::rename(&temporary, &self.accounts).expect("atomically replace accounts");
+		// SAFETY: the descriptor still owns the acquired lock.
+		assert_eq!(unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_UN) }, 0);
+	}
+
+	fn start(&self) -> Child {
+		Command::new(env!("CARGO_BIN_EXE_decodexd"))
+			.arg("supervise-local")
+			.arg("--postgres")
+			.arg(&self.postgres)
+			.arg("--pg-isready")
+			.arg(&self.pg_isready)
+			.arg("--data-directory")
+			.arg(&self.data_directory)
+			.arg("--socket-directory")
+			.arg(&self.socket_directory)
+			.arg("--port")
+			.arg(PORT.to_string())
+			.arg("--legacy-accounts")
+			.arg(&self.accounts)
+			.arg("--legacy-mapping")
+			.arg(&self.mapping)
+			.arg("--working-directory")
+			.arg(&self.working_directory)
+			.env("HOME", &self.canonical_home)
+			.stdout(Stdio::piped())
+			.stderr(Stdio::piped())
+			.spawn()
+			.expect("start local supervisor")
+	}
+
+	fn wait_for_daemon_generation(
+		&self,
+		previous_inode: Option<u64>,
+		supervisor: &mut Child,
+	) -> u64 {
+		let deadline = Instant::now() + Duration::from_secs(20);
+		loop {
+			if let Some(status) = supervisor.try_wait().expect("poll supervisor") {
+				let mut stderr = String::new();
+				supervisor
+					.stderr
+					.as_mut()
+					.expect("supervisor stderr")
+					.read_to_string(&mut stderr)
+					.expect("read supervisor stderr");
+				panic!("supervisor exited before daemon generation: {status}: {stderr}");
+			}
+			if let Ok(metadata) = fs::symlink_metadata(self.daemon_socket()) {
+				let inode = metadata.ino();
+				if previous_inode != Some(inode) {
+					return inode;
+				}
+			}
+			if Instant::now() >= deadline {
+				panic!("new daemon generation did not start");
+			}
+			thread::sleep(Duration::from_millis(20));
+		}
+	}
+
+	fn assert_daemon_generation_stable(&self, expected_inode: u64, supervisor: &mut Child) {
+		let deadline = Instant::now() + Duration::from_millis(1_500);
+
+		loop {
+			if let Some(status) = supervisor.try_wait().expect("poll supervisor") {
+				let mut stderr = String::new();
+				supervisor
+					.stderr
+					.as_mut()
+					.expect("supervisor stderr")
+					.read_to_string(&mut stderr)
+					.expect("read supervisor stderr");
+				panic!(
+					"supervisor exited while daemon generation should remain stable: {status}: {stderr}"
+				);
+			}
+			let metadata = fs::symlink_metadata(self.daemon_socket())
+				.expect("stable daemon socket should remain published");
+
+			assert_eq!(metadata.ino(), expected_inode, "daemon generation changed unexpectedly");
+			if Instant::now() >= deadline {
+				return;
+			}
+			thread::sleep(Duration::from_millis(20));
+		}
+	}
+
+	fn postgres_socket(&self) -> PathBuf {
+		self.socket_directory.join(format!(".s.PGSQL.{PORT}"))
+	}
+
+	fn stop_postgres(&self) {
+		let process_id = fs::read_to_string(self.data_directory.join("postmaster.pid"))
+			.expect("read fake PostgreSQL generation")
+			.lines()
+			.next()
+			.expect("PostgreSQL PID line")
+			.parse::<libc::pid_t>()
+			.expect("PostgreSQL PID");
+		// SAFETY: the PID is written by the live supervised PostgreSQL fixture.
+		assert_eq!(unsafe { libc::kill(process_id, libc::SIGTERM) }, 0);
+	}
+
+	fn daemon_socket(&self) -> PathBuf {
+		self.canonical_home.join(".decodex/server/decodex.sock")
+	}
+}
+
+fn account_record(access_token: &str, generation: u64) -> String {
+	let identity_token = identity_token(ACCOUNT_ID, EMAIL, "pro");
+
+	format!(
+		r#"{{"email":"{EMAIL}","last_selected_at_unix_epoch":{generation},"tokens":{{"id_token":"{identity_token}","access_token":"{access_token}","refresh_token":"not-read","account_id":"{ACCOUNT_ID}"}}}}
+"#
+	)
+}
+
+fn signal_and_wait(child: &mut Child, signal: libc::c_int) -> ExitStatus {
+	// SAFETY: the PID came from `Child`; the test passes a defined Unix signal.
+	assert_eq!(unsafe { libc::kill(child.id() as libc::pid_t, signal) }, 0);
+	wait_for_exit(child)
+}
+
+fn wait_for_exit(child: &mut Child) -> ExitStatus {
+	let deadline = Instant::now() + Duration::from_secs(20);
+	loop {
+		if let Some(status) = child.try_wait().expect("poll supervisor exit") {
+			return status;
+		}
+		if Instant::now() >= deadline {
+			let _ = child.kill();
+			panic!("supervisor did not stop before timeout");
+		}
+		thread::sleep(Duration::from_millis(20));
+	}
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+	Sha256::digest(bytes).iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn identity_token(account_id: &str, email: &str, plan_type: &str) -> String {
+	let payload = format!(
+		r#"{{"email":"{email}","https://api.openai.com/auth":{{"chatgpt_account_id":"{account_id}","chatgpt_plan_type":"{plan_type}"}}}}"#
+	);
+
+	format!("header.{}.signature", URL_SAFE_NO_PAD.encode(payload))
+}
+
+fn secure_directory(path: &Path) {
+	fs::set_permissions(path, fs::Permissions::from_mode(0o700)).expect("secure fixture directory");
+}
+
+fn secure_write(path: &Path, body: &str) {
+	let mut file = File::create(path).expect("create fixture file");
+	file.write_all(body.as_bytes()).expect("write fixture file");
+	file.sync_all().expect("sync fixture file");
+	fs::set_permissions(path, fs::Permissions::from_mode(0o600)).expect("secure fixture file");
+}
+
+fn write_executable(path: &Path, body: &str) {
+	fs::write(path, body).expect("write fixture executable");
+	fs::set_permissions(path, fs::Permissions::from_mode(0o700)).expect("make fixture executable");
+}

--- a/crates/decodex-postgres/src/conversations.rs
+++ b/crates/decodex-postgres/src/conversations.rs
@@ -3,11 +3,12 @@
 //! This owner intentionally exposes no account selection, process start, Codex dispatch,
 //! rollover executor, fallback executor, or wake scheduler.
 
-use std::{env, fs, path::PathBuf, time::Duration};
+use std::time::Duration;
+#[cfg(debug_assertions)] use std::{env, fs, path::PathBuf};
 
 use deadpool_postgres::{Client, ClientWrapper};
 use serde_json::{self, Value};
-use tokio::time;
+#[cfg(debug_assertions)] use tokio::time;
 use tokio_postgres::{Row, Transaction, error::SqlState};
 
 use crate::{

--- a/decodex.example.toml
+++ b/decodex.example.toml
@@ -58,7 +58,9 @@ host_path = "/absolute/path/on/server/to/decodex"
 # Explicit PostgreSQL endpoint data for the server host. decodexd uses the migration
 # identity only for forward migration and verification, then retains a separately
 # configured least-privilege runtime identity. It does not install, initialize, start,
-# or provision PostgreSQL. Store no password here: only named environment variables are
+# or provision a general PostgreSQL service. The macOS source-install helper provisions
+# one private same-UID PostgreSQL 18 cluster for its local LaunchAgent. Store no password
+# here: only named environment variables are
 # resolved at daemon bootstrap, and their values are never reported. Runtime readiness
 # also requires a closed exact-signature function inventory whose metadata and bodies match the
 # immutable migration, an exact trigger/rule/policy execution-path inventory, dependency-based

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -173,6 +173,20 @@ live in `decodex-postgres`.
 `decodexd` loads only the typed `~/.decodex/config.toml` and passes its explicit Unix-socket
 directory, port, database, operator-pinned expected PostgreSQL peer UID, and distinct
 migration/runtime identities with independently resolved optional credentials to that adapter.
+For the macOS source-install path, a separate `decodexd supervise-local` process owns one
+foreground PostgreSQL child and one service child. It starts the service child only after
+PostgreSQL is ready. PostgreSQL exit or any pinned process, directory, or socket generation
+change stops the service child before the supervisor exits. Launchd then starts one new
+coherent generation. Swift does not participate in this lifecycle.
+
+The current source installer also has one bounded local migration bridge. It maps an exact
+set of legacy provider identities to independent vNext UUID slots through SHA-256 selectors.
+It reads the credential file under the existing lock and passes values only through the
+service child's environment. An atomic file replacement causes a graceful daemon restart
+only when the injected credential projection changes. Account-set, identity, permission,
+or mapping drift fails closed. This bridge does
+not make legacy account storage a product-state authority, and it does not add a runtime
+fallback when PostgreSQL is unavailable.
 The adapter opens each directory component relative to a retained descriptor, pins the directory
 and socket device/inode identities, requires the final directory and socket to be owned by the
 configured UID with no group/other directory write access, and verifies the connected kernel peer

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -190,9 +190,15 @@ decodex-publisher validate-social
 - Removes stored accounts from the local pool.
 - Invokes the bundled `decodex-cli` for active vNext reset-card requests. The bundle
   also distributes `decodexd`, but Swift does not start it or inject credentials.
-  Operators must run the independently configured daemon service. Separate bundled
+  Operators must run the independently configured daemon service. The macOS
+  source-install path provisions this service with
+  `scripts/macos/install_decodex_local_service.py`; its Rust supervisor owns the
+  PostgreSQL and daemon process generations. Separate bundled
   legacy `decodex` and `decodex-app-helper` executables remain for unrelated existing
   account UI; they have no vNext reset-card authority.
+- Retries bounded startup-only Reset Card reads while the independently supervised
+  service becomes ready. It does not retry consume, replace an idempotency key, or
+  take service lifecycle ownership.
 - Shows a `Resume` action for retained attempts. Resume checks durable status first and,
   only when the daemon reports `not_found`, may invoke `use` again with the same profile,
   server UUID, selection, and idempotency key. It never substitutes a new key for that
@@ -213,6 +219,7 @@ Build/stage commands:
 swift build --package-path apps/decodex-app -c release
 apps/decodex-app/script/build_and_run.sh
 scripts/macos/test_decodex_app_stage.sh
+python3 -m unittest tests.scripts.test_install_decodex_local_service
 ```
 
 ## Static site

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -511,7 +511,9 @@ Use the owner path to choose the first validation surface:
 - `site/`: Astro/TypeScript public static site and app download entry; validate with site type/build commands rather than runtime checks.
 - `apps/decodex-app/`: native SwiftPM macOS app for local account-pool management and bundled Decodex helper/server workflows.
 - `spikes/vnext-storage/`: isolated XY-1264 PostgreSQL, blob, and bounded-cache feasibility proof; validate it with `cargo make test-vnext-storage-proof` and use [the evidence record](../evidence/vnext-storage-feasibility.md) for accepted choices and boundaries.
-- `scripts/`: repository helpers; `scripts/assets/` owns checked-in asset generation and `scripts/macos/` owns macOS app packaging checks.
+- `scripts/`: repository helpers; `scripts/assets/` owns checked-in asset generation,
+  and `scripts/macos/` owns macOS app packaging checks and the source-install local
+  service installer.
 - `.github/`: repository automation such as CodeQL code scanning ruleset support.
 
 ## Targeted Rust checks
@@ -750,10 +752,12 @@ swift build --package-path apps/decodex-app -c release
 swift test --package-path apps/decodex-app -c release
 apps/decodex-app/script/build_and_run.sh
 scripts/macos/test_decodex_app_stage.sh
+python3 -m unittest tests.scripts.test_install_decodex_local_service
 ```
 
 The Swift suite covers reset-card architecture boundaries, stable CLI decoding,
-second-click confirmation, bounded pending-journal safety, and same-key restart recovery.
+second-click confirmation, bounded startup read recovery, bounded pending-journal
+safety, and same-key restart recovery.
 Together with the focused PostgreSQL proof, it verifies the native client relationship to
 the shared [runtime service](../architecture/runtime-architecture.md); the native app's
 full boundary is documented with the other [auxiliary tools](../integrations/plugins-automations-and-auxiliary-tools.md).
@@ -762,6 +766,17 @@ The staging script builds Swift and Rust release artifacts and copies four signe
 executables into the app bundle: legacy `decodex` and `decodex-app-helper` for
 unrelated existing account UI, plus active `decodexd` and `decodex-cli` for vNext.
 It verifies all four.
+
+The local-service installer test verifies credential-negative config, bridge mapping,
+and LaunchAgent output. The installed `decodexd supervise-local` process owns one
+foreground PostgreSQL generation and one daemon generation. PostgreSQL exit or
+endpoint replacement stops the old daemon before the supervisor exits. After an
+atomic legacy account-file replacement, only a changed credential projection stops
+and restarts the daemon so its process-scoped environment receives current values.
+The bridge requires the
+same UID, a private parent directory, private regular account and lock files, one
+link per file, bounded input, unique provider identities and email identities, and
+an exact slot-to-digest mapping.
 
 ## Radar and Publisher checks
 

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -270,10 +270,19 @@ The API-only diagnostic CLI operations `decodex status` and `decodex doctor` are
 The `decodex reset-card accounts`, `list`, `use`, and `status` operations are active
 clients of the common daemon service. Other unsupported or mutating product CLI operations
 remain unavailable and belong to later slices, as do
-scheduling, account routing, a PostgreSQL installation or administration plane, live Codex dispatch,
+scheduling, account routing, a general PostgreSQL administration plane, live Codex dispatch,
 an authenticated HTTP artifact path, remote or cross-UID binding, and GPUI product behavior.
 Kernel same-UID credentials are the complete local V1 principal. Application PKI and remote
 TLS remain outside this boundary and belong to the later remote-security gate.
+
+The macOS source-install path is narrower than a general administration plane.
+`scripts/macos/install_decodex_local_service.py` initializes one same-UID PostgreSQL
+18 cluster, provisions the exact Decodex roles and grants, and installs one user
+LaunchAgent. `decodexd supervise-local` owns the PostgreSQL and daemon process
+generations. A PostgreSQL generation change stops the daemon and makes the
+supervisor exit; launchd then starts one new coherent generation. An atomic
+credential-file replacement restarts only the daemon when its injected credential
+projection changes. Swift remains a client and owns none of these effects.
 
 ## First commands
 
@@ -281,6 +290,7 @@ Use these as discovery and validation entrypoints:
 
 ```sh
 cargo run -p decodexd
+cargo run -p decodexd -- --version
 cargo run -p decodex-cli -- status
 cargo run -p decodex-cli -- doctor --output json
 cargo run -p decodex-cli -- reset-card accounts
@@ -291,7 +301,10 @@ cargo make test-vnext-postgres-store
 cargo make check
 ```
 
-`decodexd` starts the same-UID Unix WebSocket service and runs until stopped. The CLI selects
+`decodexd` with no arguments, or with `serve`, starts the same-UID Unix WebSocket
+service and runs until stopped. `decodexd --version` prints the version and does
+not start a service. `decodexd supervise-local --help` describes the bounded
+Unix service supervisor used by the macOS source installer. The CLI selects
 the configured active profile by default; `--profile NAME` selects an explicit declared
 profile and `--root PATH` selects a typed Decodex root. Human output is the default and
 diagnostic `--output json` emits `decodex/cli-diagnostics/1`; reset-card JSON emits
@@ -313,7 +326,11 @@ PostgreSQL, Swift, and signed app-staging checks described in
 - Do not read `.env` files or live secret-bearing config. `decodex.example.toml` is the
   bounded vNext setup model and stores only a PostgreSQL credential environment-variable
   name, never its value.
-- Do not route vNext through `apps/decodex`, legacy SQLite, Linear lanes, or the legacy operator transport.
+- Do not route vNext product state through `apps/decodex`, legacy SQLite, Linear
+  lanes, or the legacy operator transport. The macOS local source installer has
+  one explicit migration bridge for an exact configured legacy account set. The
+  bridge projects current credentials only to the supervised daemon environment;
+  it is not product-state authority or a fallback.
 - Use `decodex commit` and `decodex land` for Decodex-owned commit/landing authority; the installable plugin hook blocks raw `git commit` and `gh pr merge` inside Decodex scope (`plugins/decodex/scripts/decodex_lifecycle_hook`).
 - PostgreSQL is the vNext product-state authority when explicitly configured; unavailable is the only supported service state otherwise, with no fallback authority.
 - For project knowledge work, update OpenWiki directly and keep it aligned with source, tests, and manifests.

--- a/scripts/macos/install_decodex_local_service.py
+++ b/scripts/macos/install_decodex_local_service.py
@@ -1,0 +1,1518 @@
+#!/usr/bin/env python3
+"""Provision and install the same-UID Decodex local service on macOS.
+
+This source-install tool owns only the local development installation. It creates
+no credential copy. The transitional bridge reads the existing legacy account
+pool under its file lock and passes current credentials only to the supervised
+daemon process.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import fcntl
+import hashlib
+import importlib.util
+import json
+import os
+import plistlib
+import pwd
+import re
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import time
+import unicodedata
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+
+MAPPING_SCHEMA = "decodex/reset-card-legacy-bridge/1"
+LAUNCH_AGENT_LABEL = "space.decodex.local-service"
+MAX_ACCOUNT_FILE_BYTES = 4 * 1024 * 1024
+MAX_ACCOUNT_LINE_BYTES = 128 * 1024
+MAX_CONFIG_FILE_BYTES = 1024 * 1024
+MAX_MAPPING_FILE_BYTES = 64 * 1024
+MAX_POSTGRES_VERSION_BYTES = 16
+LEGACY_LOCK_TIMEOUT_SECONDS = 5
+MAX_ACCOUNTS = 64
+MAX_ACCESS_TOKEN_BYTES = 64 * 1024
+MAX_ACCOUNT_ID_BYTES = 1_024
+MAX_EMAIL_BYTES = 320
+POSTGRES_PORT = 55_432
+POSTGRES_DATABASE = "decodex"
+POSTGRES_MIGRATION_ROLE = "decodex_migration"
+POSTGRES_RUNTIME_ROLE = "decodex_runtime"
+PLAN_TYPES = {
+    "free",
+    "go",
+    "plus",
+    "pro",
+    "prolite",
+    "team",
+    "self_serve_business_usage_based",
+    "business",
+    "enterprise_cbp_usage_based",
+    "enterprise",
+    "edu",
+    "unknown",
+}
+UUID_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+HEX_DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+class InstallError(RuntimeError):
+    """A value-free local-service installation failure."""
+
+
+@dataclass(frozen=True)
+class LegacyAccount:
+    provider_account_id: str
+    email: str
+    plan_type: str
+
+    @property
+    def provider_account_id_sha256(self) -> str:
+        return hashlib.sha256(self.provider_account_id.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class Enrollment:
+    slot: int
+    provider_account_id_sha256: str
+    account_id: str
+    display_label: str
+    initial_state: str
+    plan_type: str
+
+
+@dataclass(frozen=True)
+class ExistingEnrollment:
+    account_id: str
+    display_label: str
+
+
+@dataclass(frozen=True)
+class InstallPaths:
+    repository: Path
+    root: Path
+    config: Path
+    mapping: Path
+    data_directory: Path
+    socket_directory: Path
+    log_directory: Path
+    postgres_log: Path
+    service_log: Path
+    legacy_accounts: Path
+    launch_agent: Path
+    decodexd: Path
+    decodex_cli: Path
+    codex: Path
+    postgres: Path
+    initdb: Path
+    pg_isready: Path
+    psql: Path
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    home = Path.home()
+    discovered_codex = shutil.which("codex")
+    parser = argparse.ArgumentParser(
+        description="Provision the Decodex PostgreSQL 18 local service and LaunchAgent."
+    )
+    parser.add_argument(
+        "--repository",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+    )
+    parser.add_argument("--root", type=Path, default=home / ".decodex")
+    parser.add_argument(
+        "--legacy-accounts",
+        type=Path,
+        default=home / ".codex" / "decodex" / "accounts.jsonl",
+    )
+    parser.add_argument(
+        "--launch-agent",
+        type=Path,
+        default=home / "Library" / "LaunchAgents" / f"{LAUNCH_AGENT_LABEL}.plist",
+    )
+    parser.add_argument(
+        "--decodexd",
+        type=Path,
+        default=home / ".local" / "bin" / "decodexd",
+    )
+    parser.add_argument(
+        "--decodex-cli",
+        type=Path,
+        default=home / ".local" / "bin" / "decodex",
+    )
+    parser.add_argument(
+        "--codex",
+        type=Path,
+        default=(
+            Path(discovered_codex)
+            if discovered_codex is not None
+            else home / ".codex" / "shims" / "codex"
+        ),
+        help="Codex executable made discoverable to the supervised daemon.",
+    )
+    parser.add_argument(
+        "--postgres",
+        type=Path,
+        default=Path("/run/current-system/sw/bin/postgres"),
+    )
+    parser.add_argument(
+        "--initdb",
+        type=Path,
+        default=Path("/run/current-system/sw/bin/initdb"),
+    )
+    parser.add_argument(
+        "--pg-isready",
+        type=Path,
+        default=Path("/run/current-system/sw/bin/pg_isready"),
+    )
+    parser.add_argument(
+        "--psql",
+        type=Path,
+        default=Path("/run/current-system/sw/bin/psql"),
+    )
+    parser.add_argument(
+        "--replace-config",
+        action="store_true",
+        help="Replace the current vNext config without creating a backup.",
+    )
+    parser.add_argument(
+        "--no-launch",
+        action="store_true",
+        help="Provision files and PostgreSQL, but do not bootstrap the LaunchAgent.",
+    )
+    return parser.parse_args(argv)
+
+
+def install_paths(args: argparse.Namespace) -> InstallPaths:
+    root = args.root.expanduser().resolve()
+    repository = args.repository.expanduser().resolve()
+    return InstallPaths(
+        repository=repository,
+        root=root,
+        config=root / "config.toml",
+        mapping=root / "reset-card-legacy-map.json",
+        data_directory=root / "postgres" / "data",
+        socket_directory=root / "postgres" / "socket",
+        log_directory=root / "logs",
+        postgres_log=root / "logs" / "postgres.log",
+        service_log=root / "logs" / "local-service.log",
+        legacy_accounts=args.legacy_accounts.expanduser().resolve(),
+        launch_agent=args.launch_agent.expanduser().resolve(),
+        decodexd=args.decodexd.expanduser().resolve(),
+        decodex_cli=args.decodex_cli.expanduser().resolve(),
+        codex=args.codex.expanduser().resolve(),
+        postgres=args.postgres.expanduser().resolve(),
+        initdb=args.initdb.expanduser().resolve(),
+        pg_isready=args.pg_isready.expanduser().resolve(),
+        psql=args.psql.expanduser().resolve(),
+    )
+
+
+def require_regular_executable(path: Path, name: str) -> None:
+    try:
+        metadata = path.stat()
+    except OSError as error:
+        raise InstallError(f"{name} executable is unavailable") from error
+    if not stat.S_ISREG(metadata.st_mode) or not os.access(path, os.X_OK):
+        raise InstallError(f"{name} executable is unavailable")
+
+
+def require_private_directory(path: Path, uid: int) -> None:
+    try:
+        metadata = path.lstat()
+    except OSError as error:
+        raise InstallError("legacy account directory is unavailable") from error
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != uid
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise InstallError("legacy account directory is not private")
+
+
+def secure_legacy_file(path: Path, uid: int, *, create: bool = False) -> int:
+    flags = os.O_RDWR if create else os.O_RDONLY
+    if create:
+        flags |= os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError as error:
+        raise InstallError("legacy account file authority is unsafe") from error
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != uid
+            or metadata.st_nlink != 1
+        ):
+            raise InstallError("legacy account file authority is unsafe")
+        os.fchmod(descriptor, 0o600)
+    except BaseException:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def read_bounded_descriptor(descriptor: int, maximum_bytes: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = maximum_bytes + 1
+    while remaining > 0:
+        chunk = os.read(descriptor, min(64 * 1024, remaining))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def file_identity(metadata: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def read_owned_file(path: Path, uid: int, maximum_bytes: int, failure: str) -> bytes:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        raise InstallError(failure) from error
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != uid
+            or metadata.st_nlink != 1
+            or metadata.st_size > maximum_bytes
+        ):
+            raise InstallError(failure)
+        os.fchmod(descriptor, 0o600)
+        expected_identity = file_identity(os.fstat(descriptor))
+        body = read_bounded_descriptor(descriptor, maximum_bytes)
+        if len(body) > maximum_bytes or file_identity(os.fstat(descriptor)) != expected_identity:
+            raise InstallError(failure)
+        return body
+    except OSError as error:
+        raise InstallError(failure) from error
+    finally:
+        os.close(descriptor)
+
+
+def acquire_legacy_lock(descriptor: int) -> None:
+    deadline = time.monotonic() + LEGACY_LOCK_TIMEOUT_SECONDS
+    while True:
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return
+        except BlockingIOError as error:
+            if time.monotonic() >= deadline:
+                raise InstallError("legacy account lock is unavailable") from error
+            time.sleep(0.05)
+
+
+def bounded_scalar(value: Any, limit: int) -> str | None:
+    if not isinstance(value, str):
+        return None
+    encoded = value.encode("utf-8")
+    if (
+        not encoded
+        or len(encoded) > limit
+        or value.strip() != value
+        or contains_control(value)
+    ):
+        return None
+    return value
+
+
+def contains_control(value: str) -> bool:
+    return any(unicodedata.category(character).startswith("C") for character in value)
+
+
+def decode_id_token_claims(token: str) -> dict[str, Any]:
+    components = token.split(".")
+    if len(components) != 3 or any(not component for component in components):
+        raise InstallError("legacy account identity token is malformed")
+    payload = components[1]
+    payload += "=" * (-len(payload) % 4)
+    try:
+        decoded = base64.b64decode(
+            payload.encode("ascii"),
+            altchars=b"-_",
+            validate=True,
+        )
+        claims = json.loads(decoded)
+    except (UnicodeEncodeError, ValueError, json.JSONDecodeError) as error:
+        raise InstallError("legacy account identity token is malformed") from error
+    if not isinstance(claims, dict):
+        raise InstallError("legacy account identity token is malformed")
+    return claims
+
+
+def account_from_record(record: Any) -> LegacyAccount:
+    if not isinstance(record, dict):
+        raise InstallError("legacy account record is malformed")
+    has_tokens = record.get("tokens") is not None
+    has_auth = record.get("auth") is not None
+    if has_tokens == has_auth:
+        raise InstallError("legacy account shape is invalid")
+    if has_auth:
+        if not isinstance(record.get("auth"), dict):
+            raise InstallError("legacy account shape is invalid")
+        auth = record["auth"]
+        outer_email = record.get("email")
+    else:
+        auth = record
+        outer_email = record.get("email")
+    tokens = auth.get("tokens")
+    if not isinstance(tokens, dict):
+        raise InstallError("legacy account credentials are unavailable")
+    provider_account_id = bounded_scalar(tokens.get("account_id"), MAX_ACCOUNT_ID_BYTES)
+    access_token = bounded_scalar(tokens.get("access_token"), MAX_ACCESS_TOKEN_BYTES)
+    id_token = bounded_scalar(tokens.get("id_token"), MAX_ACCESS_TOKEN_BYTES)
+    email_value = outer_email if outer_email is not None else auth.get("email")
+    email = bounded_scalar(email_value, MAX_EMAIL_BYTES)
+    if provider_account_id is None:
+        raise InstallError("legacy provider account identity is invalid")
+    if access_token is None or id_token is None or email is None or "@" not in email:
+        raise InstallError("legacy account credentials are unavailable")
+    claims = decode_id_token_claims(id_token)
+    authority = claims.get("https://api.openai.com/auth")
+    if not isinstance(authority, dict):
+        raise InstallError("legacy account identity token lacks account authority")
+    claimed_account_id = bounded_scalar(
+        authority.get("chatgpt_account_id"), MAX_ACCOUNT_ID_BYTES
+    )
+    plan_type = bounded_scalar(authority.get("chatgpt_plan_type"), 64)
+    if claimed_account_id != provider_account_id or plan_type not in PLAN_TYPES:
+        raise InstallError("legacy account identity claims are inconsistent")
+    claimed_email_value = claims.get("email")
+    if claimed_email_value is not None:
+        claimed_email = bounded_scalar(claimed_email_value, MAX_EMAIL_BYTES)
+        if claimed_email is None or claimed_email.lower() != email.lower():
+            raise InstallError("legacy account email claims are inconsistent")
+    return LegacyAccount(
+        provider_account_id=provider_account_id,
+        email=email,
+        plan_type=plan_type,
+    )
+
+
+def read_legacy_accounts(path: Path, uid: int) -> list[LegacyAccount]:
+    parent = path.parent
+    require_private_directory(parent, uid)
+    lock_path = parent / f".{path.name}.lock"
+    lock_descriptor = secure_legacy_file(lock_path, uid, create=True)
+    try:
+        acquire_legacy_lock(lock_descriptor)
+        descriptor = secure_legacy_file(path, uid)
+        try:
+            body = read_bounded_descriptor(descriptor, MAX_ACCOUNT_FILE_BYTES)
+        finally:
+            os.close(descriptor)
+    finally:
+        fcntl.flock(lock_descriptor, fcntl.LOCK_UN)
+        os.close(lock_descriptor)
+    if len(body) > MAX_ACCOUNT_FILE_BYTES:
+        raise InstallError("legacy account file exceeds the supported bound")
+    try:
+        text = body.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise InstallError("legacy account file is not UTF-8") from error
+    accounts = []
+    for line in text.splitlines():
+        if len(line.encode("utf-8")) > MAX_ACCOUNT_LINE_BYTES:
+            raise InstallError("legacy account record exceeds the supported bound")
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        try:
+            record = json.loads(stripped)
+        except json.JSONDecodeError as error:
+            raise InstallError("legacy account record is malformed") from error
+        accounts.append(account_from_record(record))
+    if not accounts or len(accounts) > MAX_ACCOUNTS:
+        raise InstallError("legacy account count is outside the supported bound")
+    provider_ids = {account.provider_account_id for account in accounts}
+    emails = {account.email.casefold() for account in accounts}
+    if len(provider_ids) != len(accounts) or len(emails) != len(accounts):
+        raise InstallError("legacy account identities are not unique")
+    return sorted(accounts, key=lambda account: account.provider_account_id)
+
+
+def read_usage_presentations() -> dict[str, dict[str, Any]]:
+    request = urllib.request.Request(
+        "http://127.0.0.1:8192/api/accounts?refresh=1",
+        headers={"Accept": "application/json"},
+    )
+    try:
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        with opener.open(request, timeout=20) as response:
+            body = response.read(MAX_ACCOUNT_FILE_BYTES + 1)
+            if len(body) > MAX_ACCOUNT_FILE_BYTES:
+                return {}
+            payload = json.loads(body)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return {}
+    rows = payload.get("accounts") if isinstance(payload, dict) else None
+    if not isinstance(rows, list) or len(rows) > MAX_ACCOUNTS:
+        return {}
+    presentations: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            return {}
+        email = bounded_scalar(row.get("email"), MAX_EMAIL_BYTES)
+        if email is None or email.casefold() in presentations:
+            return {}
+        presentations[email.casefold()] = row
+    return presentations
+
+
+def managed_path_exists(path: Path, failure: str) -> bool:
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as error:
+        raise InstallError(failure) from error
+    return True
+
+
+def load_existing_mapping(path: Path, uid: int) -> dict[str, int]:
+    if not managed_path_exists(path, "existing reset-card mapping is malformed"):
+        return {}
+    try:
+        payload = json.loads(
+            read_owned_file(
+                path,
+                uid,
+                MAX_MAPPING_FILE_BYTES,
+                "existing reset-card mapping is malformed",
+            ).decode("utf-8")
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise InstallError("existing reset-card mapping is malformed") from error
+    if not isinstance(payload, dict) or set(payload) != {"schema", "accounts"}:
+        raise InstallError("existing reset-card mapping is malformed")
+    if payload["schema"] != MAPPING_SCHEMA or not isinstance(payload["accounts"], list):
+        raise InstallError("existing reset-card mapping is malformed")
+    mapping: dict[str, int] = {}
+    slots: set[int] = set()
+    for row in payload["accounts"]:
+        if not isinstance(row, dict) or set(row) != {
+            "slot",
+            "provider_account_id_sha256",
+        }:
+            raise InstallError("existing reset-card mapping is malformed")
+        slot = row["slot"]
+        digest = row["provider_account_id_sha256"]
+        if (
+            not isinstance(slot, int)
+            or isinstance(slot, bool)
+            or not 1 <= slot <= MAX_ACCOUNTS
+            or not isinstance(digest, str)
+            or not HEX_DIGEST_PATTERN.fullmatch(digest)
+            or slot in slots
+            or digest in mapping
+        ):
+            raise InstallError("existing reset-card mapping is malformed")
+        mapping[digest] = slot
+        slots.add(slot)
+    if sorted(slots) != list(range(1, len(slots) + 1)):
+        raise InstallError("existing reset-card mapping slots are not contiguous")
+    return mapping
+
+
+def existing_enrollments(
+    config_path: Path,
+    uid: int,
+) -> dict[int, ExistingEnrollment]:
+    if not managed_path_exists(config_path, "existing Decodex config is malformed"):
+        return {}
+    try:
+        lines = read_owned_file(
+            config_path,
+            uid,
+            MAX_CONFIG_FILE_BYTES,
+            "existing Decodex config is malformed",
+        ).decode("utf-8").splitlines()
+    except UnicodeDecodeError as error:
+        raise InstallError("existing Decodex config is malformed") from error
+    result: dict[int, ExistingEnrollment] = {}
+    current_account_id: str | None = None
+    current_reference: str | None = None
+    current_display_label: str | None = None
+
+    def finish_account() -> None:
+        nonlocal current_account_id, current_reference, current_display_label
+        if current_account_id is None:
+            return
+        if current_reference is None or current_display_label is None:
+            raise InstallError("existing reset-card enrollment is not bridge-owned")
+        match = re.fullmatch(
+            r"DECODEX_RESET_CARD_SLOT_([0-9]{2})_ACCESS_TOKEN",
+            current_reference,
+        )
+        if match is None:
+            raise InstallError("existing reset-card enrollment is not bridge-owned")
+        slot = int(match.group(1))
+        if not 1 <= slot <= MAX_ACCOUNTS:
+            raise InstallError("existing reset-card enrollment has an invalid slot")
+        if slot in result:
+            raise InstallError("existing reset-card enrollment has duplicate slots")
+        result[slot] = ExistingEnrollment(
+            account_id=current_account_id,
+            display_label=current_display_label,
+        )
+        current_account_id = None
+        current_reference = None
+        current_display_label = None
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("["):
+            finish_account()
+            match = re.fullmatch(
+                r'\[server_host\.reset_card_accounts\."([^"]+)"\]',
+                stripped,
+            )
+            if match is not None:
+                account_id = match.group(1)
+                if not UUID_PATTERN.fullmatch(account_id):
+                    raise InstallError("existing reset-card enrollment is malformed")
+                current_account_id = account_id
+            elif stripped.startswith("[server_host.reset_card_accounts."):
+                raise InstallError("existing reset-card enrollment is malformed")
+            continue
+        if current_account_id is not None:
+            match = re.fullmatch(r'access_token_env_var\s*=\s*"([^"]+)"', stripped)
+            if match is not None:
+                if current_reference is not None:
+                    raise InstallError("existing reset-card enrollment is malformed")
+                current_reference = match.group(1)
+                continue
+            if re.match(r"access_token_env_var\s*=", stripped):
+                raise InstallError("existing reset-card enrollment is malformed")
+            if re.match(r"display_label\s*=", stripped):
+                match = re.fullmatch(
+                    r'display_label\s*=\s*("(?:[^"\\]|\\.)*")',
+                    stripped,
+                )
+                if match is None or current_display_label is not None:
+                    raise InstallError("existing reset-card enrollment is malformed")
+                try:
+                    decoded_label = json.loads(match.group(1))
+                except json.JSONDecodeError as error:
+                    raise InstallError(
+                        "existing reset-card enrollment is malformed"
+                    ) from error
+                current_display_label = bounded_scalar(decoded_label, 128)
+                if current_display_label is None:
+                    raise InstallError("existing reset-card enrollment is malformed")
+    finish_account()
+    return result
+
+
+def build_enrollments(
+    accounts: list[LegacyAccount],
+    existing_mapping: dict[str, int],
+    existing: dict[int, ExistingEnrollment],
+    presentations: dict[str, dict[str, Any]],
+) -> list[Enrollment]:
+    digests = {account.provider_account_id_sha256 for account in accounts}
+    if existing_mapping and set(existing_mapping) != digests:
+        raise InstallError("legacy account set changed; explicit reconciliation is required")
+    if (
+        existing_mapping
+        and existing
+        and set(existing_mapping.values()) != set(existing)
+    ):
+        raise InstallError("existing mapping and enrollment config do not agree")
+    if not existing_mapping and existing:
+        raise InstallError("existing enrollment lacks its bridge mapping")
+    mapping = existing_mapping or {
+        account.provider_account_id_sha256: index
+        for index, account in enumerate(accounts, start=1)
+    }
+    enrollments = []
+    for account in accounts:
+        slot = mapping[account.provider_account_id_sha256]
+        presentation = presentations.get(account.email.casefold(), {})
+        observed_plan = presentation.get("plan_type")
+        if observed_plan is not None and observed_plan != account.plan_type:
+            raise InstallError("legacy account plan observations do not agree")
+        prior_enrollment = existing.get(slot)
+        if prior_enrollment is None:
+            label = bounded_scalar(presentation.get("random_name"), 128)
+            if label is None:
+                label = f"Account {slot:02d}"
+            account_id = str(uuid.uuid4())
+        else:
+            label = prior_enrollment.display_label
+            account_id = prior_enrollment.account_id
+        available_count = presentation.get("reset_credits_available_count")
+        initial_state = (
+            "depleted"
+            if isinstance(available_count, int)
+            and not isinstance(available_count, bool)
+            and available_count == 0
+            else "available"
+        )
+        enrollments.append(
+            Enrollment(
+                slot=slot,
+                provider_account_id_sha256=account.provider_account_id_sha256,
+                account_id=account_id,
+                display_label=label,
+                initial_state=initial_state,
+                plan_type=account.plan_type,
+            )
+        )
+    return sorted(enrollments, key=lambda enrollment: enrollment.slot)
+
+
+def toml_string(value: str | Path) -> str:
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def render_config(paths: InstallPaths, uid: int, enrollments: list[Enrollment]) -> str:
+    lines = [
+        "version = 1",
+        'active_profile = "local"',
+        "",
+        "[profiles.local]",
+        'kind = "local"',
+        'policy = "same_uid"',
+        f"service_owner_uid = {uid}",
+        "",
+        "[server_host.repositories.decodex]",
+        f"host_path = {toml_string(paths.repository)}",
+        "",
+    ]
+    for enrollment in enrollments:
+        prefix = f"DECODEX_RESET_CARD_SLOT_{enrollment.slot:02d}"
+        lines.extend(
+            [
+                f'[server_host.reset_card_accounts."{enrollment.account_id}"]',
+                f"display_label = {toml_string(enrollment.display_label)}",
+                f'initial_state = "{enrollment.initial_state}"',
+                f'access_token_env_var = "{prefix}_ACCESS_TOKEN"',
+                f'provider_account_id_env_var = "{prefix}_ACCOUNT_ID"',
+                f'expected_email_env_var = "{prefix}_EMAIL"',
+                f'plan_type = "{enrollment.plan_type}"',
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "[postgres]",
+            f"socket_directory = {toml_string(paths.socket_directory)}",
+            f"expected_peer_uid = {uid}",
+            f"port = {POSTGRES_PORT}",
+            f'database = "{POSTGRES_DATABASE}"',
+            "",
+            "[postgres.migration]",
+            f'user = "{POSTGRES_MIGRATION_ROLE}"',
+            "",
+            "[postgres.runtime]",
+            f'user = "{POSTGRES_RUNTIME_ROLE}"',
+            "",
+            "[cache]",
+            "max_entries = 2048",
+            "max_bytes = 134217728",
+            "max_entry_bytes = 4194304",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_mapping(enrollments: list[Enrollment]) -> bytes:
+    payload = {
+        "schema": MAPPING_SCHEMA,
+        "accounts": [
+            {
+                "slot": enrollment.slot,
+                "provider_account_id_sha256": enrollment.provider_account_id_sha256,
+            }
+            for enrollment in enrollments
+        ],
+    }
+    return (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def render_launch_agent(paths: InstallPaths) -> bytes:
+    arguments = [
+        str(paths.decodexd),
+        "supervise-local",
+        "--postgres",
+        str(paths.postgres),
+        "--pg-isready",
+        str(paths.pg_isready),
+        "--data-directory",
+        str(paths.data_directory),
+        "--socket-directory",
+        str(paths.socket_directory),
+        "--port",
+        str(POSTGRES_PORT),
+        "--legacy-accounts",
+        str(paths.legacy_accounts),
+        "--legacy-mapping",
+        str(paths.mapping),
+        "--working-directory",
+        str(paths.repository),
+    ]
+    payload = {
+        "Label": LAUNCH_AGENT_LABEL,
+        "ProgramArguments": arguments,
+        "EnvironmentVariables": {
+            "HOME": str(paths.root.parent),
+            "PATH": launch_agent_path(paths),
+        },
+        "RunAtLoad": True,
+        "KeepAlive": True,
+        "ExitTimeOut": 360,
+        "ThrottleInterval": 5,
+        "ProcessType": "Background",
+        "WorkingDirectory": str(paths.repository),
+        "StandardOutPath": str(paths.service_log),
+        "StandardErrorPath": str(paths.service_log),
+    }
+    return plistlib.dumps(payload, fmt=plistlib.FMT_XML, sort_keys=True)
+
+
+def launch_agent_path(paths: InstallPaths) -> str:
+    directories = [
+        str(paths.codex.parent),
+        "/usr/local/bin",
+        "/opt/homebrew/bin",
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",
+        "/sbin",
+    ]
+    return os.pathsep.join(dict.fromkeys(directories))
+
+
+def require_owned_directory(path: Path, uid: int, failure: str) -> os.stat_result:
+    try:
+        metadata = path.lstat()
+    except OSError as error:
+        raise InstallError(failure) from error
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != uid
+    ):
+        raise InstallError(failure)
+    return metadata
+
+
+def atomic_write(path: Path, content: bytes, mode: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    uid = os.geteuid()
+    require_owned_directory(path.parent, uid, "installation destination is unsafe")
+    candidate = path.parent / f".{path.name}.install-{uuid.uuid4().hex}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    candidate_created = False
+    try:
+        descriptor = os.open(candidate, flags, mode)
+        candidate_created = True
+        try:
+            with os.fdopen(descriptor, "wb", closefd=False) as output:
+                output.write(content)
+                output.flush()
+                os.fsync(output.fileno())
+            os.fchmod(descriptor, mode)
+        finally:
+            os.close(descriptor)
+        os.replace(candidate, path)
+        metadata = path.lstat()
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_uid != uid
+            or metadata.st_nlink != 1
+            or stat.S_IMODE(metadata.st_mode) != mode
+        ):
+            raise InstallError("installed file authority is unsafe")
+        directory_flags = os.O_RDONLY
+        if hasattr(os, "O_DIRECTORY"):
+            directory_flags |= os.O_DIRECTORY
+        directory = os.open(path.parent, directory_flags)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except BaseException:
+        if candidate_created:
+            try:
+                candidate.unlink()
+            except FileNotFoundError:
+                pass
+        raise
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    capture: bool = False,
+    check: bool = True,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=check,
+        text=True,
+        capture_output=capture,
+        timeout=timeout,
+    )
+
+
+def postgres_major(postgres: Path) -> int:
+    completed = run([str(postgres), "--version"], capture=True)
+    match = re.search(r"\b([0-9]+)(?:\.[0-9]+)?\b", completed.stdout)
+    if match is None:
+        raise InstallError("PostgreSQL version is unavailable")
+    return int(match.group(1))
+
+
+def open_private_append_file(path: Path, uid: int) -> int:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError as error:
+        raise InstallError("local service log authority is unsafe") from error
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != uid
+            or metadata.st_nlink != 1
+        ):
+            raise InstallError("local service log authority is unsafe")
+        os.fchmod(descriptor, 0o600)
+    except BaseException:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def ensure_directories(paths: InstallPaths, uid: int) -> None:
+    for path in [
+        paths.root,
+        paths.data_directory.parent,
+        paths.data_directory,
+        paths.socket_directory,
+        paths.log_directory,
+    ]:
+        path.mkdir(parents=True, exist_ok=True, mode=0o700)
+        require_owned_directory(path, uid, "local service directory authority is unsafe")
+        os.chmod(path, 0o700)
+    service_log = open_private_append_file(paths.service_log, uid)
+    os.close(service_log)
+
+
+def postgres_version(paths: InstallPaths, uid: int) -> str | None:
+    version_file = paths.data_directory / "PG_VERSION"
+    if not managed_path_exists(version_file, "PostgreSQL cluster version is unsafe"):
+        return None
+    try:
+        return read_owned_file(
+            version_file,
+            uid,
+            MAX_POSTGRES_VERSION_BYTES,
+            "PostgreSQL cluster version is unsafe",
+        ).decode("ascii").strip()
+    except UnicodeDecodeError as error:
+        raise InstallError("PostgreSQL cluster version is unsafe") from error
+
+
+def initialize_cluster(paths: InstallPaths, uid: int) -> None:
+    version = postgres_version(paths, uid)
+    if version is not None:
+        if version != "18":
+            raise InstallError("existing PostgreSQL cluster is not version 18")
+        return
+    if any(paths.data_directory.iterdir()):
+        raise InstallError("PostgreSQL data directory is nonempty and uninitialized")
+    share_directory = paths.initdb.parent.parent / "share" / "postgresql"
+    try:
+        share_metadata = share_directory.lstat()
+    except OSError as error:
+        raise InstallError("PostgreSQL 18 share directory is unavailable") from error
+    if not stat.S_ISDIR(share_metadata.st_mode) or stat.S_ISLNK(share_metadata.st_mode):
+        raise InstallError("PostgreSQL 18 share directory is unavailable")
+    run(
+        [
+            str(paths.initdb),
+            "-D",
+            str(paths.data_directory),
+            "--auth-local=trust",
+            "--auth-host=reject",
+            "--encoding=UTF8",
+            "--locale=C",
+            "--data-checksums",
+            "-L",
+            str(share_directory),
+        ]
+    )
+    os.chmod(paths.data_directory, 0o700)
+    if postgres_version(paths, uid) != "18":
+        raise InstallError("PostgreSQL 18 initialization did not complete")
+
+
+def wait_for_postgres(paths: InstallPaths, process: subprocess.Popen[Any]) -> None:
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise InstallError("PostgreSQL exited during local-service startup")
+        completed = run(
+            [
+                str(paths.pg_isready),
+                "-h",
+                str(paths.socket_directory),
+                "-p",
+                str(POSTGRES_PORT),
+            ],
+            capture=True,
+            check=False,
+        )
+        if completed.returncode == 0:
+            return
+        time.sleep(0.25)
+    raise InstallError("PostgreSQL did not become ready")
+
+
+def start_temporary_postgres(paths: InstallPaths) -> subprocess.Popen[Any]:
+    log_descriptor = open_private_append_file(paths.postgres_log, os.geteuid())
+    try:
+        process = subprocess.Popen(
+            [
+                str(paths.postgres),
+                "-D",
+                str(paths.data_directory),
+                "-k",
+                str(paths.socket_directory),
+                "-p",
+                str(POSTGRES_PORT),
+                "-h",
+                "",
+            ],
+            stdout=log_descriptor,
+            stderr=subprocess.STDOUT,
+            close_fds=True,
+        )
+    finally:
+        os.close(log_descriptor)
+    try:
+        wait_for_postgres(paths, process)
+    except BaseException:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=10)
+        raise
+    return process
+
+
+def stop_temporary_postgres(process: subprocess.Popen[Any]) -> None:
+    if process.poll() is not None:
+        return
+    process.send_signal(signal.SIGTERM)
+    try:
+        process.wait(timeout=30)
+    except subprocess.TimeoutExpired as error:
+        process.kill()
+        process.wait(timeout=10)
+        raise InstallError("PostgreSQL did not stop gracefully") from error
+
+
+def psql_environment(paths: InstallPaths) -> dict[str, str]:
+    environment = os.environ.copy()
+    for name in list(environment):
+        if name.startswith("PG"):
+            del environment[name]
+    try:
+        database_superuser = pwd.getpwuid(os.geteuid()).pw_name
+    except KeyError as error:
+        raise InstallError("PostgreSQL bootstrap user is unavailable") from error
+    environment.update(
+        {
+            "PATH": f"{paths.psql.parent}{os.pathsep}{environment.get('PATH', '')}",
+            "PGHOST": str(paths.socket_directory),
+            "PGPORT": str(POSTGRES_PORT),
+            "PGUSER": database_superuser,
+        }
+    )
+    return environment
+
+
+def psql_scalar(paths: InstallPaths, database: str, sql: str, env: dict[str, str]) -> str:
+    completed = run(
+        [
+            str(paths.psql),
+            "-X",
+            "-qAt",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-d",
+            database,
+            "-c",
+            sql,
+        ],
+        env=env,
+        capture=True,
+    )
+    return completed.stdout.strip()
+
+
+def ensure_roles_and_database(paths: InstallPaths, env: dict[str, str]) -> None:
+    for role in [POSTGRES_MIGRATION_ROLE, POSTGRES_RUNTIME_ROLE]:
+        exists = psql_scalar(
+            paths,
+            "postgres",
+            f"SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='{role}'",
+            env,
+        )
+        if exists != "1":
+            psql_scalar(
+                paths,
+                "postgres",
+                f"CREATE ROLE {role} LOGIN NOINHERIT NOSUPERUSER NOCREATEDB "
+                "NOCREATEROLE NOREPLICATION NOBYPASSRLS CONNECTION LIMIT -1 "
+                "VALID UNTIL 'infinity'",
+                env,
+            )
+        safe = psql_scalar(
+            paths,
+            "postgres",
+            "SELECT CASE WHEN role.rolcanlogin AND NOT role.rolinherit "
+            "AND NOT role.rolsuper AND NOT role.rolcreatedb "
+            "AND NOT role.rolcreaterole AND NOT role.rolreplication "
+            "AND NOT role.rolbypassrls AND role.rolconnlimit = -1 "
+            "AND role.rolvaliduntil = 'infinity'::timestamptz "
+            "AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_db_role_setting AS setting "
+            "WHERE setting.setrole = role.oid) "
+            "AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members AS membership "
+            "WHERE membership.roleid = role.oid OR membership.member = role.oid) "
+            f"THEN 1 ELSE 0 END FROM pg_catalog.pg_roles AS role WHERE role.rolname='{role}'",
+            env,
+        )
+        if safe != "1":
+            raise InstallError("existing PostgreSQL role authority is unsafe")
+    database_exists = psql_scalar(
+        paths,
+        "postgres",
+        "SELECT 1 FROM pg_catalog.pg_database "
+        f"WHERE datname='{POSTGRES_DATABASE}'",
+        env,
+    )
+    if database_exists != "1":
+        psql_scalar(
+            paths,
+            "postgres",
+            f"CREATE DATABASE {POSTGRES_DATABASE} WITH TEMPLATE template0 "
+            f"ENCODING 'UTF8' OWNER {POSTGRES_MIGRATION_ROLE}",
+            env,
+        )
+    owner = psql_scalar(
+        paths,
+        "postgres",
+        "SELECT role.rolname FROM pg_catalog.pg_database AS database "
+        "JOIN pg_catalog.pg_roles AS role ON role.oid=database.datdba "
+        f"WHERE database.datname='{POSTGRES_DATABASE}'",
+        env,
+    )
+    if owner != POSTGRES_MIGRATION_ROLE:
+        raise InstallError("existing Decodex database has an unexpected owner")
+    psql_scalar(
+        paths,
+        POSTGRES_DATABASE,
+        f"GRANT USAGE, CREATE ON SCHEMA public TO {POSTGRES_MIGRATION_ROLE}",
+        env,
+    )
+    psql_scalar(
+        paths,
+        "postgres",
+        f"REVOKE CREATE ON DATABASE {POSTGRES_DATABASE} FROM PUBLIC; "
+        f"GRANT CONNECT, CREATE ON DATABASE {POSTGRES_DATABASE} "
+        f"TO {POSTGRES_MIGRATION_ROLE}; "
+        f"GRANT CONNECT ON DATABASE {POSTGRES_DATABASE} TO {POSTGRES_RUNTIME_ROLE}",
+        env,
+    )
+
+
+def database_url(paths: InstallPaths, role: str) -> str:
+    return (
+        f"postgresql://{role}@/{POSTGRES_DATABASE}"
+        f"?host={paths.socket_directory.as_posix()}&port={POSTGRES_PORT}"
+    )
+
+
+def load_postgres_harness(paths: InstallPaths) -> ModuleType:
+    harness_path = paths.repository / "scripts" / "vnext" / "postgres_store_test.py"
+    spec = importlib.util.spec_from_file_location("decodex_postgres_store_test", harness_path)
+    if spec is None or spec.loader is None:
+        raise InstallError("PostgreSQL provisioning helper is unavailable")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def migrate_and_provision(paths: InstallPaths, env: dict[str, str]) -> None:
+    migration_env = env.copy()
+    migration_env["DECODEX_TEST_MIGRATION_DATABASE_URL"] = database_url(
+        paths, POSTGRES_MIGRATION_ROLE
+    )
+    migration_env["DECODEX_TEST_RUNTIME_DATABASE_URL"] = database_url(
+        paths, POSTGRES_RUNTIME_ROLE
+    )
+    run(
+        [
+            "cargo",
+            "nextest",
+            "run",
+            "-p",
+            "decodex-postgres",
+            "--test",
+            "postgres_store",
+            "--run-ignored",
+            "all",
+            "--",
+            "postgres_migration_contract",
+            "--exact",
+        ],
+        cwd=paths.repository,
+        env=migration_env,
+    )
+    harness = load_postgres_harness(paths)
+    harness.provision_runtime(POSTGRES_DATABASE, POSTGRES_RUNTIME_ROLE, env)
+
+
+def bootout_service(uid: int) -> None:
+    service = f"gui/{uid}/{LAUNCH_AGENT_LABEL}"
+    completed = run(
+        ["launchctl", "bootout", service],
+        capture=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        loaded = run(
+            ["launchctl", "print", service],
+            capture=True,
+            check=False,
+        )
+        if loaded.returncode == 0:
+            raise InstallError("existing local service could not be stopped")
+
+
+def bootstrap_service(paths: InstallPaths, uid: int) -> None:
+    run(["launchctl", "bootstrap", f"gui/{uid}", str(paths.launch_agent)])
+    run(["launchctl", "kickstart", "-k", f"gui/{uid}/{LAUNCH_AGENT_LABEL}"])
+
+
+def query_reset_card(
+    paths: InstallPaths,
+    arguments: list[str],
+) -> dict[str, Any] | None:
+    try:
+        completed = run(
+            [
+                str(paths.decodex_cli),
+                "--root",
+                str(paths.root),
+                "--output",
+                "json",
+                "reset-card",
+                *arguments,
+            ],
+            cwd=paths.repository,
+            capture=True,
+            check=False,
+            timeout=45,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    try:
+        document = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return None
+    if (
+        not isinstance(document, dict)
+        or document.get("schema") != "decodex/reset-card-cli/1"
+        or document.get("outcome") != "available"
+    ):
+        return None
+    return document
+
+
+def critical_doctor_is_ready(document: Any) -> bool:
+    if (
+        not isinstance(document, dict)
+        or document.get("schema") != "decodex/cli-diagnostics/1"
+        or document.get("command") != "doctor"
+        or document.get("outcome") != "report"
+    ):
+        return False
+    report = document.get("report")
+    checks = report.get("checks") if isinstance(report, dict) else None
+    if not isinstance(checks, list):
+        return False
+    required = {
+        "configuration",
+        "database",
+        "protocol",
+        "protocol_version",
+        "server_identity",
+        "server_repositories",
+        "credential_vault",
+    }
+    observed: set[str] = set()
+    for check in checks:
+        if not isinstance(check, dict):
+            return False
+        component = check.get("component")
+        status = check.get("status")
+        kind = component.get("kind") if isinstance(component, dict) else None
+        if kind in required:
+            if kind in observed or status != {"state": "ready"}:
+                return False
+            observed.add(kind)
+    return observed == required
+
+
+def query_doctor(paths: InstallPaths) -> bool:
+    try:
+        completed = run(
+            [
+                str(paths.decodex_cli),
+                "--root",
+                str(paths.root),
+                "--output",
+                "json",
+                "doctor",
+            ],
+            cwd=paths.repository,
+            capture=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if completed.returncode not in {0, 1}:
+        return False
+    try:
+        document = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return False
+    return critical_doctor_is_ready(document)
+
+
+def account_ids_from_result(document: dict[str, Any]) -> list[str] | None:
+    if document.get("command") != "accounts":
+        return None
+    result = document.get("result")
+    if not isinstance(result, dict) or result.get("outcome") != "available":
+        return None
+    data = result.get("data")
+    accounts = data.get("accounts") if isinstance(data, dict) else None
+    if not isinstance(accounts, list):
+        return None
+    account_ids: list[str] = []
+    for account in accounts:
+        account_id = account.get("account_id") if isinstance(account, dict) else None
+        if not isinstance(account_id, str) or not UUID_PATTERN.fullmatch(account_id):
+            return None
+        account_ids.append(account_id)
+    if len(set(account_ids)) != len(account_ids):
+        return None
+    return account_ids
+
+
+def inventory_is_available(document: dict[str, Any], account_id: str) -> bool:
+    if document.get("command") != "list":
+        return False
+    result = document.get("result")
+    if not isinstance(result, dict) or result.get("outcome") != "available":
+        return False
+    data = result.get("data")
+    return isinstance(data, dict) and data.get("account_id") == account_id
+
+
+def wait_for_service(paths: InstallPaths, expected_account_ids: set[str]) -> None:
+    deadline = time.monotonic() + 180
+    last_issue = "reset-card service did not answer"
+    while time.monotonic() < deadline:
+        if not query_doctor(paths):
+            last_issue = "local-service authority is unavailable"
+            time.sleep(1)
+            continue
+        accounts_document = query_reset_card(paths, ["accounts"])
+        account_ids = (
+            account_ids_from_result(accounts_document)
+            if accounts_document is not None
+            else None
+        )
+        if account_ids is None:
+            last_issue = "reset-card account discovery is unavailable"
+        elif set(account_ids) != expected_account_ids:
+            last_issue = "reset-card account discovery set does not agree"
+        else:
+            inventories_ready = True
+            for account_id in account_ids:
+                inventory = query_reset_card(
+                    paths,
+                    ["list", "--account", account_id],
+                )
+                if inventory is None or not inventory_is_available(inventory, account_id):
+                    inventories_ready = False
+                    last_issue = "reset-card inventory is unavailable"
+                    break
+            if inventories_ready:
+                return
+        time.sleep(1)
+    raise InstallError(last_issue)
+
+
+def validate_host(paths: InstallPaths) -> int:
+    if sys.platform != "darwin":
+        raise InstallError("the local-service installer is macOS-only")
+    if sys.version_info < (3, 9):
+        raise InstallError("Python 3.9 or newer is required")
+    uid = os.geteuid()
+    if uid == 0:
+        raise InstallError("the local service must not be installed as root")
+    try:
+        user_home = Path(pwd.getpwuid(uid).pw_dir).resolve()
+    except KeyError as error:
+        raise InstallError("the current user home is unavailable") from error
+    if not (paths.repository / "Cargo.toml").is_file():
+        raise InstallError("repository root is invalid")
+    expected_root = user_home / ".decodex"
+    if paths.root != expected_root:
+        raise InstallError("the local service root must be the platform default")
+    if paths.codex.name != "codex":
+        raise InstallError("Codex executable name is invalid")
+    for name, path in [
+        ("decodexd", paths.decodexd),
+        ("Decodex CLI", paths.decodex_cli),
+        ("Codex", paths.codex),
+        ("postgres", paths.postgres),
+        ("initdb", paths.initdb),
+        ("pg_isready", paths.pg_isready),
+        ("psql", paths.psql),
+    ]:
+        require_regular_executable(path, name)
+    if postgres_major(paths.postgres) != 18:
+        raise InstallError("PostgreSQL 18 is required")
+    return uid
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    paths = install_paths(args)
+    uid = validate_host(paths)
+    ensure_directories(paths, uid)
+    accounts = read_legacy_accounts(paths.legacy_accounts, uid)
+    existing_mapping = load_existing_mapping(paths.mapping, uid)
+    config_exists = managed_path_exists(
+        paths.config,
+        "existing Decodex config is malformed",
+    )
+    existing = existing_enrollments(paths.config, uid) if config_exists else {}
+    if config_exists and (not existing_mapping or not existing):
+        if not args.replace_config:
+            raise InstallError("existing config requires explicit --replace-config")
+        existing = {}
+    enrollments = build_enrollments(
+        accounts,
+        existing_mapping,
+        existing,
+        read_usage_presentations(),
+    )
+    config = render_config(paths, uid, enrollments).encode("utf-8")
+    mapping = render_mapping(enrollments)
+    launch_agent = render_launch_agent(paths)
+
+    bootout_service(uid)
+    initialize_cluster(paths, uid)
+    postgres = start_temporary_postgres(paths)
+    try:
+        environment = psql_environment(paths)
+        ensure_roles_and_database(paths, environment)
+        migrate_and_provision(paths, environment)
+    finally:
+        stop_temporary_postgres(postgres)
+
+    atomic_write(paths.mapping, mapping, 0o600)
+    atomic_write(paths.config, config, 0o600)
+    atomic_write(paths.launch_agent, launch_agent, 0o600)
+
+    if not args.no_launch:
+        bootstrap_service(paths, uid)
+        wait_for_service(
+            paths,
+            {enrollment.account_id for enrollment in enrollments},
+        )
+
+    print(
+        json.dumps(
+            {
+                "schema": "decodex/local-service-install/1",
+                "outcome": "success",
+                "account_count": len(enrollments),
+                "postgres_major": 18,
+                "launch_agent": LAUNCH_AGENT_LABEL,
+                "launched": not args.no_launch,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except InstallError as error:
+        print(f"decodex local-service install failed: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/tests/scripts/test_install_decodex_local_service.py
+++ b/tests/scripts/test_install_decodex_local_service.py
@@ -1,0 +1,581 @@
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import os
+import plistlib
+import pwd
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/macos/install_decodex_local_service.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("install_decodex_local_service", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def jwt(claims: dict[str, object]) -> str:
+    payload = base64.urlsafe_b64encode(
+        json.dumps(claims, separators=(",", ":")).encode()
+    ).decode().rstrip("=")
+    return f"header.{payload}.signature"
+
+
+class LocalServiceInstallerTests(unittest.TestCase):
+    def setUp(self):
+        self.module = load_module()
+
+    def account_record(
+        self,
+        *,
+        account_id: str = "provider-account-1",
+        email: str = "one@example.test",
+        plan_type: str = "pro",
+        access_token: str = "private-access-token",
+    ) -> dict[str, object]:
+        id_token = jwt(
+            {
+                "email": email,
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": account_id,
+                    "chatgpt_plan_type": plan_type,
+                },
+            }
+        )
+        return {
+            "email": email,
+            "tokens": {
+                "access_token": access_token,
+                "account_id": account_id,
+                "id_token": id_token,
+                "refresh_token": "private-refresh-token",
+            },
+        }
+
+    def paths(self, root: Path):
+        return self.module.InstallPaths(
+            repository=REPO_ROOT,
+            root=root,
+            config=root / "config.toml",
+            mapping=root / "reset-card-legacy-map.json",
+            data_directory=root / "postgres/data",
+            socket_directory=root / "postgres/socket",
+            log_directory=root / "logs",
+            postgres_log=root / "logs/postgres.log",
+            service_log=root / "logs/local-service.log",
+            legacy_accounts=root / "legacy/accounts.jsonl",
+            launch_agent=root / "space.decodex.local-service.plist",
+            decodexd=root / "bin/decodexd",
+            decodex_cli=root / "bin/decodex",
+            codex=root / "codex-bin/codex",
+            postgres=root / "bin/postgres",
+            initdb=root / "bin/initdb",
+            pg_isready=root / "bin/pg_isready",
+            psql=root / "bin/psql",
+        )
+
+    def test_account_parser_cross_checks_identity_without_exposing_values(self):
+        record = self.account_record()
+        account = self.module.account_from_record(record)
+
+        self.assertEqual("provider-account-1", account.provider_account_id)
+        self.assertEqual("one@example.test", account.email)
+        self.assertEqual("pro", account.plan_type)
+        self.assertRegex(account.provider_account_id_sha256, r"^[0-9a-f]{64}$")
+
+        changed = self.account_record()
+        changed["tokens"]["account_id"] = "other-provider-account"
+        with self.assertRaisesRegex(
+            self.module.InstallError, "identity claims are inconsistent"
+        ):
+            self.module.account_from_record(changed)
+
+        malformed_shape = self.account_record()
+        malformed_shape["auth"] = {"tokens": malformed_shape["tokens"]}
+        with self.assertRaisesRegex(self.module.InstallError, "shape is invalid"):
+            self.module.account_from_record(malformed_shape)
+
+        malformed_token = self.account_record()
+        malformed_token["tokens"]["id_token"] += ".extra"
+        with self.assertRaisesRegex(self.module.InstallError, "token is malformed"):
+            self.module.account_from_record(malformed_token)
+
+        nested = self.account_record()
+        nested = {
+            "email": " invalid@example.test",
+            "auth": {
+                "email": "one@example.test",
+                "tokens": nested["tokens"],
+            },
+        }
+        with self.assertRaisesRegex(self.module.InstallError, "credentials are unavailable"):
+            self.module.account_from_record(nested)
+
+    def test_config_mapping_and_plist_are_credential_negative(self):
+        account = self.module.account_from_record(self.account_record())
+        enrollment = self.module.build_enrollments(
+            [account],
+            {},
+            {},
+            {
+                account.email: {
+                    "email": account.email,
+                    "plan_type": "pro",
+                    "random_name": "Amber Otter",
+                    "reset_credits_available_count": 2,
+                }
+            },
+        )
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            config = self.module.render_config(paths, 501, enrollment)
+            mapping = self.module.render_mapping(enrollment).decode()
+            plist_bytes = self.module.render_launch_agent(paths)
+            plist = plist_bytes.decode()
+            plist_document = plistlib.loads(plist_bytes)
+
+        combined = config + mapping + plist
+        self.assertNotIn(account.provider_account_id, combined)
+        self.assertNotIn(account.email, combined)
+        self.assertNotIn("private-access-token", combined)
+        self.assertNotIn("secret-run", combined)
+        self.assertIn("DECODEX_RESET_CARD_SLOT_01_ACCESS_TOKEN", config)
+        self.assertIn('"schema":"decodex/reset-card-legacy-bridge/1"', mapping)
+        self.assertIn("supervise-local", plist)
+        self.assertIn("Amber Otter", config)
+        self.assertEqual(
+            {"HOME", "PATH"},
+            set(plist_document["EnvironmentVariables"]),
+        )
+        self.assertEqual(
+            str(paths.root.parent),
+            plist_document["EnvironmentVariables"]["HOME"],
+        )
+        self.assertEqual(
+            str(paths.codex.parent),
+            plist_document["EnvironmentVariables"]["PATH"].split(os.pathsep)[0],
+        )
+        self.assertNotIn("--secret-run", plist_document["ProgramArguments"])
+        self.assertEqual(360, plist_document["ExitTimeOut"])
+
+    def test_parser_discovers_codex_without_copying_the_process_environment(self):
+        discovered = Path("/Applications/ChatGPT.app/Contents/Resources/codex")
+        with mock.patch.object(self.module.shutil, "which", return_value=str(discovered)):
+            arguments = self.module.parse_args([])
+
+        self.assertEqual(discovered, arguments.codex)
+
+    def test_existing_mapping_is_stable_and_account_set_change_fails_closed(self):
+        account = self.module.account_from_record(self.account_record())
+        digest = account.provider_account_id_sha256
+        account_id = "10000000-0000-4000-8000-000000000001"
+        existing = self.module.ExistingEnrollment(account_id, "Pinned Label")
+        enrollment = self.module.build_enrollments(
+            [account],
+            {digest: 1},
+            {1: existing},
+            {account.email: {"random_name": "Changed Label"}},
+        )
+
+        self.assertEqual(account_id, enrollment[0].account_id)
+        self.assertEqual("Pinned Label", enrollment[0].display_label)
+        recovered = self.module.build_enrollments(
+            [account],
+            {digest: 1},
+            {},
+            {},
+        )
+        self.assertEqual(1, recovered[0].slot)
+        self.assertRegex(recovered[0].account_id, self.module.UUID_PATTERN)
+        with self.assertRaisesRegex(
+            self.module.InstallError,
+            "enrollment lacks its bridge mapping",
+        ):
+            self.module.build_enrollments(
+                [account],
+                {},
+                {1: existing},
+                {},
+            )
+        second = self.module.account_from_record(
+            self.account_record(
+                account_id="provider-account-2",
+                email="two@example.test",
+            )
+        )
+        with self.assertRaisesRegex(
+            self.module.InstallError, "explicit reconciliation is required"
+        ):
+            self.module.build_enrollments(
+                [account, second],
+                {digest: 1},
+                {1: existing},
+                {},
+            )
+
+    def test_rerun_pins_display_label_across_presentation_changes(self):
+        account = self.module.account_from_record(self.account_record())
+        mapping = {account.provider_account_id_sha256: 1}
+        presentation = {
+            account.email: {
+                "plan_type": account.plan_type,
+                "random_name": "Amber Otter",
+            }
+        }
+        cases = [
+            (presentation, {}, "Amber Otter"),
+            ({}, presentation, "Account 01"),
+        ]
+
+        for initial_presentation, rerun_presentation, expected_label in cases:
+            with self.subTest(expected_label=expected_label):
+                initial = self.module.build_enrollments(
+                    [account],
+                    {},
+                    {},
+                    initial_presentation,
+                )
+                with tempfile.TemporaryDirectory() as temp:
+                    paths = self.paths(Path(temp))
+                    paths.config.write_text(
+                        self.module.render_config(paths, os.geteuid(), initial),
+                        encoding="utf-8",
+                    )
+                    paths.config.chmod(0o600)
+                    existing = self.module.existing_enrollments(
+                        paths.config,
+                        os.geteuid(),
+                    )
+
+                rerun = self.module.build_enrollments(
+                    [account],
+                    mapping,
+                    existing,
+                    rerun_presentation,
+                )
+
+                self.assertEqual(initial[0].account_id, rerun[0].account_id)
+                self.assertEqual(expected_label, rerun[0].display_label)
+
+        recovered = self.module.build_enrollments(
+            [account],
+            mapping,
+            {},
+            presentation,
+        )
+        self.assertEqual("Amber Otter", recovered[0].display_label)
+        self.assertRegex(recovered[0].account_id, self.module.UUID_PATTERN)
+
+    def test_mapping_parser_rejects_unknown_fields_and_noncontiguous_slots(self):
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "mapping.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema": self.module.MAPPING_SCHEMA,
+                        "accounts": [
+                            {
+                                "slot": 2,
+                                "provider_account_id_sha256": "a" * 64,
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                self.module.InstallError, "slots are not contiguous"
+            ):
+                self.module.load_existing_mapping(path, os.geteuid())
+
+    def test_bounded_descriptor_read_collects_partial_reads_and_surfaces_overflow(self):
+        with mock.patch.object(
+            self.module.os,
+            "read",
+            side_effect=[b"ab", b"cd", b""],
+        ) as read:
+            self.assertEqual(
+                b"abcd",
+                self.module.read_bounded_descriptor(19, 8),
+            )
+        self.assertEqual(3, read.call_count)
+
+        with mock.patch.object(
+            self.module.os,
+            "read",
+            side_effect=[b"ab", b"cd", b"e"],
+        ):
+            self.assertEqual(
+                5,
+                len(self.module.read_bounded_descriptor(19, 4)),
+            )
+
+    def test_legacy_read_repairs_exact_file_and_lock_permissions(self):
+        with tempfile.TemporaryDirectory() as temp:
+            parent = Path(temp) / "legacy"
+            parent.mkdir(mode=0o700)
+            account_path = parent / "accounts.jsonl"
+            account_path.write_text(
+                json.dumps(self.account_record()) + "\n",
+                encoding="utf-8",
+            )
+            account_path.chmod(0o644)
+
+            accounts = self.module.read_legacy_accounts(account_path, os.geteuid())
+
+            self.assertEqual(1, len(accounts))
+            self.assertEqual(0o600, stat.S_IMODE(account_path.stat().st_mode))
+            self.assertEqual(
+                0o600,
+                stat.S_IMODE((parent / ".accounts.jsonl.lock").stat().st_mode),
+            )
+
+    def test_managed_mapping_symlink_is_rejected_without_following_it(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            target = root / "target.json"
+            target.write_text(
+                json.dumps({"schema": self.module.MAPPING_SCHEMA, "accounts": []}),
+                encoding="utf-8",
+            )
+            link = root / "mapping.json"
+            link.symlink_to(target)
+
+            with self.assertRaisesRegex(self.module.InstallError, "mapping is malformed"):
+                self.module.load_existing_mapping(link, os.geteuid())
+
+    def test_atomic_write_replaces_without_backup_and_cleans_failed_candidate(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            target = root / "config.toml"
+            target.write_bytes(b"old")
+
+            self.module.atomic_write(target, b"new", 0o600)
+
+            self.assertEqual(b"new", target.read_bytes())
+            self.assertEqual(0o600, stat.S_IMODE(target.stat().st_mode))
+            self.assertEqual(["config.toml"], sorted(path.name for path in root.iterdir()))
+
+            with mock.patch.object(
+                self.module.os,
+                "replace",
+                side_effect=OSError("injected replace failure"),
+            ):
+                with self.assertRaises(OSError):
+                    self.module.atomic_write(target, b"not-installed", 0o600)
+
+            self.assertEqual(b"new", target.read_bytes())
+            self.assertEqual(["config.toml"], sorted(path.name for path in root.iterdir()))
+
+    def test_missing_postgres_data_directory_is_created_and_initialized_once(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            paths = self.paths(root)
+            self.module.ensure_directories(paths, os.geteuid())
+            share = paths.initdb.parent.parent / "share/postgresql"
+            share.mkdir(parents=True)
+
+            def initialize(command, **_kwargs):
+                self.assertIn("--auth-local=trust", command)
+                self.assertIn("--auth-host=reject", command)
+                (paths.data_directory / "PG_VERSION").write_text(
+                    "18\n",
+                    encoding="ascii",
+                )
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with mock.patch.object(
+                self.module,
+                "run",
+                side_effect=initialize,
+            ) as run:
+                self.module.initialize_cluster(paths, os.geteuid())
+                self.module.initialize_cluster(paths, os.geteuid())
+
+            self.assertEqual(1, run.call_count)
+            self.assertEqual(0o700, stat.S_IMODE(paths.data_directory.stat().st_mode))
+            self.assertEqual(
+                0o600,
+                stat.S_IMODE((paths.data_directory / "PG_VERSION").stat().st_mode),
+            )
+            self.assertEqual(0o600, stat.S_IMODE(paths.service_log.stat().st_mode))
+
+    def test_psql_environment_uses_os_identity_and_drops_inherited_pg_settings(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "USER": "spoofed-user",
+                    "PGPASSWORD": "must-not-propagate",
+                    "PGOPTIONS": "must-not-propagate",
+                },
+                clear=False,
+            ):
+                environment = self.module.psql_environment(paths)
+
+        self.assertEqual(pwd.getpwuid(os.geteuid()).pw_name, environment["PGUSER"])
+        self.assertNotIn("PGPASSWORD", environment)
+        self.assertNotIn("PGOPTIONS", environment)
+
+    def test_service_readiness_requires_every_expected_inventory(self):
+        first_account = "10000000-0000-4000-8000-000000000001"
+        second_account = "10000000-0000-4000-8000-000000000002"
+        accounts = {
+            "schema": "decodex/reset-card-cli/1",
+            "command": "accounts",
+            "outcome": "available",
+            "result": {
+                "outcome": "available",
+                "data": {
+                    "accounts": [
+                        {"account_id": first_account},
+                        {"account_id": second_account},
+                    ]
+                },
+            },
+        }
+
+        def inventory(account_id):
+            return {
+                "schema": "decodex/reset-card-cli/1",
+                "command": "list",
+                "outcome": "available",
+                "result": {
+                    "outcome": "available",
+                    "data": {"account_id": account_id},
+                },
+            }
+
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            doctor = mock.patch.object(
+                self.module,
+                "query_doctor",
+                return_value=True,
+            )
+            reset_card = mock.patch.object(
+                self.module,
+                "query_reset_card",
+                side_effect=[
+                    accounts,
+                    inventory(first_account),
+                    inventory(second_account),
+                ],
+            )
+            with doctor, reset_card as query:
+                self.module.wait_for_service(paths, {first_account, second_account})
+
+        self.assertEqual(
+            [
+                mock.call(paths, ["accounts"]),
+                mock.call(paths, ["list", "--account", first_account]),
+                mock.call(paths, ["list", "--account", second_account]),
+            ],
+            query.call_args_list,
+        )
+
+    def test_doctor_accepts_report_shape_with_only_designed_unknown_checks(self):
+        required = [
+            "configuration",
+            "database",
+            "protocol",
+            "protocol_version",
+            "server_identity",
+            "server_repositories",
+            "credential_vault",
+        ]
+        document = {
+            "schema": "decodex/cli-diagnostics/1",
+            "command": "doctor",
+            "outcome": "report",
+            "status": "unknown",
+            "checks": 9,
+            "report": {
+                "checks": [
+                    {
+                        "component": {"kind": kind},
+                        "status": {"state": "ready"},
+                    }
+                    for kind in required
+                ]
+                + [
+                    {
+                        "component": {"kind": "plugin_readiness"},
+                        "status": {"state": "unknown", "issue": "plugin"},
+                    }
+                ],
+            },
+        }
+
+        self.assertTrue(self.module.critical_doctor_is_ready(document))
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            completed = subprocess.CompletedProcess(
+                [str(paths.decodex_cli)],
+                1,
+                json.dumps(document),
+                "",
+            )
+            with mock.patch.object(self.module, "run", return_value=completed):
+                self.assertTrue(self.module.query_doctor(paths))
+        document["outcome"] = "success"
+        self.assertFalse(self.module.critical_doctor_is_ready(document))
+        document["outcome"] = "report"
+        document["report"]["checks"][1]["status"] = {
+            "state": "unavailable",
+            "issue": "database_unreachable",
+        }
+        self.assertFalse(self.module.critical_doctor_is_ready(document))
+
+    def test_query_uses_explicit_root_and_does_not_log_captured_failure(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            completed = subprocess.CompletedProcess(
+                [str(paths.decodex_cli)],
+                2,
+                '{"outcome":"failure"}',
+                "private-marker",
+            )
+            with mock.patch.object(self.module, "run", return_value=completed) as run:
+                self.assertIsNone(self.module.query_reset_card(paths, ["accounts"]))
+
+        command = run.call_args.args[0]
+        self.assertEqual(str(paths.root), command[command.index("--root") + 1])
+        self.assertNotIn("private-marker", str(run.call_args))
+
+    def test_bootout_distinguishes_absent_service_from_stop_failure(self):
+        absent = subprocess.CompletedProcess(["launchctl"], 3, "", "not found")
+        with mock.patch.object(
+            self.module,
+            "run",
+            side_effect=[absent, absent],
+        ):
+            self.module.bootout_service(os.geteuid())
+
+        loaded = subprocess.CompletedProcess(["launchctl"], 0, "loaded", "")
+        with mock.patch.object(
+            self.module,
+            "run",
+            side_effect=[absent, loaded],
+        ):
+            with self.assertRaisesRegex(self.module.InstallError, "could not be stopped"):
+                self.module.bootout_service(os.geteuid())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a Unix core supervisor that owns coherent PostgreSQL and Decodex daemon generations
- add a credential-negative macOS LaunchAgent installer with no backup copies
- bridge the exact legacy account set into independent vNext Reset Card enrollments
- make legacy account and lock writes persist at mode 0600 without ctime churn
- retry only bounded startup reads in the menu bar UI; never retry Reset Card consumption
- remove the release unused-import warning and document the local lifecycle boundary

## Validation

- cargo make fmt-rust-check
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make lint-rust
- cargo test -p decodexd (19 tests)
- /usr/bin/python3 -m unittest tests.scripts.test_install_decodex_local_service (16 tests)
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app -c release (132 tests)
- DECODEX_APP_CARGO_LOCKED=1 scripts/macos/test_decodex_app_stage.sh
- cargo check --manifest-path apps/decodex/standalone/Cargo.toml

## Deployment

After landing, install the landed CLI, daemon, LaunchAgent, PostgreSQL enrollment, and signed app without creating rollback backups. Verify all enrolled account inventories and the menu bar read path.
