### PR TITLE
Restore native Reset Card inventory compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,12 +1596,14 @@ dependencies = [
 name = "decodex-runtime"
 version = "0.2.0"
 dependencies = [
+ "core-foundation 0.10.0",
  "decodex-codex",
  "decodex-core",
  "decodex-postgres",
  "decodex-protocol",
  "futures-util",
  "libc",
+ "security-framework",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ decodex-runtime  = { path = "crates/decodex-runtime" }
 base64             = { version = "0.22" }
 clap               = { version = "4.6", features = ["derive"] }
 color-eyre         = { version = "0.6" }
+core-foundation    = { version = "=0.10.0" }
 futures-util       = { version = "0.3.32" }
 getrandom          = { version = "=0.4.2" }
 globset            = { version = "0.4" }
@@ -47,6 +48,7 @@ libc               = { version = "0.2" }
 regex              = { version = "1.12" }
 reqwest            = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls"] }
 rusqlite           = { version = "0.40", features = ["bundled"] }
+security-framework = { version = "=3.7.0", default-features = false }
 serde              = { version = "1.0", features = ["derive"] }
 serde_json         = { version = "1.0" }
 serde_yaml         = { version = "0.9" }

--- a/apps/decodexd/src/local_supervisor.rs
+++ b/apps/decodexd/src/local_supervisor.rs
@@ -39,7 +39,8 @@ const CREDENTIAL_PROJECTION_FINGERPRINT_PROTOCOL: &[u8] =
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 // Reset-card provider work has a runtime-owned 212-second upper bound. The daemon grace period
 // also covers its five-second transport drain and leaves margin for scheduler and cleanup work.
-// The macOS LaunchAgent ExitTimeOut must exceed this plus the PostgreSQL grace period.
+// The macOS installer signals a loaded non-restarting generation and lets these runtime bounds
+// settle it before bootout. Launchd retains a 60-second final stop fallback for other stop paths.
 const DAEMON_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(240);
 const POSTGRES_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
 const LOCK_TIMEOUT: Duration = Duration::from_secs(5);
@@ -80,7 +81,11 @@ pub(super) async fn supervise(config: LocalSupervisorConfig) -> Result<(), Super
 	let ready =
 		wait_for_postgres(&config, &mut postgres, &mut signals, socket_directory_identity).await;
 	let postgres_identity = match ready {
-		Ok(identity) => identity,
+		Ok(PostgresStartup::Ready(identity)) => identity,
+		Ok(PostgresStartup::ShutdownRequested) => {
+			stop_child(&mut postgres, ChildKind::Postgres);
+			return Ok(());
+		},
 		Err(error) => {
 			stop_child(&mut postgres, ChildKind::Postgres);
 			return Err(error);
@@ -289,6 +294,11 @@ struct PostgresIdentity {
 	socket_directory: StableObjectIdentity,
 	socket: StableObjectIdentity,
 	generation: StableObjectIdentity,
+}
+
+enum PostgresStartup {
+	Ready(PostgresIdentity),
+	ShutdownRequested,
 }
 
 impl PostgresIdentity {
@@ -936,7 +946,7 @@ async fn wait_for_postgres(
 	postgres: &mut Child,
 	signals: &mut ShutdownSignals,
 	socket_directory_identity: StableObjectIdentity,
-) -> Result<PostgresIdentity, SupervisorError> {
+) -> Result<PostgresStartup, SupervisorError> {
 	let deadline = Instant::now() + STARTUP_TIMEOUT;
 
 	loop {
@@ -956,12 +966,12 @@ async fn wait_for_postgres(
 				return Err(SupervisorError::new("PostgreSQL generation is invalid"));
 			}
 
-			return Ok(PostgresIdentity {
+			return Ok(PostgresStartup::Ready(PostgresIdentity {
 				process_id,
 				socket_directory: socket_directory_identity,
 				socket,
 				generation,
-			});
+			}));
 		}
 		if Instant::now() >= deadline {
 			return Err(SupervisorError::new("PostgreSQL readiness timed out"));
@@ -970,7 +980,7 @@ async fn wait_for_postgres(
 		tokio::select! {
 			signal = signals.recv() => {
 				signal.map_err(|_| SupervisorError::new("supervisor signal handling failed"))?;
-				return Err(SupervisorError::new("supervisor stopped during PostgreSQL startup"));
+				return Ok(PostgresStartup::ShutdownRequested);
 			},
 			_ = tokio::time::sleep(POLL_INTERVAL) => {},
 		}
@@ -985,6 +995,8 @@ fn postgres_is_ready(config: &LocalSupervisorConfig) -> Result<bool, SupervisorE
 		.arg(&config.socket_directory)
 		.arg("-p")
 		.arg(config.port.to_string())
+		.arg("-d")
+		.arg("postgres")
 		.arg("-t")
 		.arg("1")
 		.current_dir(&config.working_directory)
@@ -1438,7 +1450,7 @@ mod tests {
 	}
 
 	#[test]
-	fn child_shutdown_grace_preserves_bounded_provider_work_and_launchd_margin() {
+	fn child_shutdown_grace_preserves_bounded_provider_work_and_installer_drain_margin() {
 		assert_eq!(child_shutdown_timeout(ChildKind::Daemon), DAEMON_SHUTDOWN_TIMEOUT);
 		assert_eq!(DAEMON_SHUTDOWN_TIMEOUT.as_secs(), 240);
 		assert!(DAEMON_SHUTDOWN_TIMEOUT > std::time::Duration::from_secs(212 + 5));

--- a/apps/decodexd/tests/local_supervisor.rs
+++ b/apps/decodexd/tests/local_supervisor.rs
@@ -26,6 +26,7 @@ use tempfile::TempDir;
 const PORT: u16 = 55_431;
 const ACCOUNT_ID: &str = "provider-account-one";
 const EMAIL: &str = "first@example.test";
+const POSTGRES_READINESS_BLOCK: &str = ".fixture-postgres-unready";
 
 #[test]
 fn account_pool_replacement_restarts_the_daemon_only_for_changed_credentials() {
@@ -46,6 +47,28 @@ fn account_pool_replacement_restarts_the_daemon_only_for_changed_credentials() {
 	assert!(!fixture.postgres_socket().exists());
 	assert!(UnixStream::connect(fixture.daemon_socket()).is_err());
 	for secret in ["access-one", "access-two", ACCOUNT_ID, EMAIL] {
+		assert!(!output.stdout.windows(secret.len()).any(|window| window == secret.as_bytes()));
+		assert!(!output.stderr.windows(secret.len()).any(|window| window == secret.as_bytes()));
+	}
+}
+
+#[test]
+fn signal_during_postgres_startup_stops_the_generation_and_exits_successfully() {
+	let fixture = SupervisorFixture::new();
+	fixture.write_accounts("access-one");
+	fixture.block_postgres_readiness();
+	let mut supervisor = fixture.start();
+	let postgres_process_id = fixture.wait_for_postgres_start(&mut supervisor);
+
+	let status = signal_and_wait(&mut supervisor, libc::SIGTERM);
+	let output = supervisor.wait_with_output().expect("collect supervisor output");
+
+	assert!(status.success(), "startup shutdown must be successful: {status}");
+	assert_process_absent(postgres_process_id);
+	assert!(!fixture.postgres_socket().exists());
+	assert!(!fixture.data_directory.join("postmaster.pid").exists());
+	assert!(UnixStream::connect(fixture.daemon_socket()).is_err());
+	for secret in ["access-one", ACCOUNT_ID, EMAIL] {
 		assert!(!output.stdout.windows(secret.len()).any(|window| window == secret.as_bytes()));
 		assert!(!output.stderr.windows(secret.len()).any(|window| window == secret.as_bytes()));
 	}
@@ -211,13 +234,17 @@ for path in (socket_path, pid_path):
 set -eu
 host=
 port=
+database=
 while [ "$#" -gt 0 ]; do
 	case "$1" in
 		-h) host=$2; shift 2 ;;
 		-p) port=$2; shift 2 ;;
+		-d) database=$2; shift 2 ;;
 		*) shift ;;
 	esac
 done
+[ "$database" = postgres ]
+[ ! -e "$host/.fixture-postgres-unready" ]
 [ -S "$host/.s.PGSQL.$port" ]
 "#,
 		);
@@ -237,6 +264,10 @@ done
 
 	fn write_accounts(&self, access_token: &str) {
 		secure_write(&self.accounts, &account_record(access_token, 1));
+	}
+
+	fn block_postgres_readiness(&self) {
+		secure_write(&self.socket_directory.join(POSTGRES_READINESS_BLOCK), "");
 	}
 
 	fn replace_accounts(&self, access_token: &str, generation: u64) {
@@ -338,6 +369,32 @@ done
 		self.socket_directory.join(format!(".s.PGSQL.{PORT}"))
 	}
 
+	fn wait_for_postgres_start(&self, supervisor: &mut Child) -> libc::pid_t {
+		let deadline = Instant::now() + Duration::from_secs(20);
+		loop {
+			if let Some(status) = supervisor.try_wait().expect("poll supervisor") {
+				let mut stderr = String::new();
+				supervisor
+					.stderr
+					.as_mut()
+					.expect("supervisor stderr")
+					.read_to_string(&mut stderr)
+					.expect("read supervisor stderr");
+				panic!("supervisor exited before PostgreSQL started: {status}: {stderr}");
+			}
+			if let Ok(body) = fs::read_to_string(self.data_directory.join("postmaster.pid"))
+				&& let Ok(process_id) = body.trim().parse::<libc::pid_t>()
+				&& self.postgres_socket().exists()
+			{
+				return process_id;
+			}
+			if Instant::now() >= deadline {
+				panic!("PostgreSQL did not start before timeout");
+			}
+			thread::sleep(Duration::from_millis(20));
+		}
+	}
+
 	fn stop_postgres(&self) {
 		let process_id = fs::read_to_string(self.data_directory.join("postmaster.pid"))
 			.expect("read fake PostgreSQL generation")
@@ -382,6 +439,12 @@ fn wait_for_exit(child: &mut Child) -> ExitStatus {
 		}
 		thread::sleep(Duration::from_millis(20));
 	}
+}
+
+fn assert_process_absent(process_id: libc::pid_t) {
+	// SAFETY: signal zero only checks whether the captured child PID still exists.
+	assert_eq!(unsafe { libc::kill(process_id, 0) }, -1);
+	assert_eq!(std::io::Error::last_os_error().raw_os_error(), Some(libc::ESRCH));
 }
 
 fn hex_sha256(bytes: &[u8]) -> String {

--- a/crates/decodex-runtime/Cargo.toml
+++ b/crates/decodex-runtime/Cargo.toml
@@ -32,6 +32,10 @@ tokio             = { workspace = true }
 tokio-tungstenite = { workspace = true }
 zeroize           = { workspace = true, features = ["serde"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation    = { workspace = true }
+security-framework = { workspace = true }
+
 [dev-dependencies]
 tempfile       = { workspace = true }
 tokio-postgres = { workspace = true }

--- a/crates/decodex-runtime/src/account_launch.rs
+++ b/crates/decodex-runtime/src/account_launch.rs
@@ -1,5 +1,6 @@
 //! Runtime-owned PostgreSQL authorization and bounded process-capacity composition.
 
+#[cfg(target_os = "macos")] mod macos_attested_spawn;
 mod process;
 mod protocol;
 mod reset_card;

--- a/crates/decodex-runtime/src/account_launch/macos_attested_spawn.rs
+++ b/crates/decodex-runtime/src/account_launch/macos_attested_spawn.rs
@@ -1,0 +1,1054 @@
+//! Suspended macOS process creation with exact code-identity verification.
+//!
+//! The caller first captures a statically validated identity from an immutable reference snapshot
+//! and proves that a separate canonical execution path has the same identity. A spawn executes the
+//! canonical path directly and stops it before user code runs. The caller can then repeat its
+//! filesystem checks before this module compares the kernel's dynamic code object with an exact
+//! CDHash requirement, the canonical path, and the captured `kSecCodeInfoUnique` value. The child
+//! resumes only after all checks succeed.
+
+use std::{
+	ffi::{CString, OsStr, OsString, c_char, c_short, c_void},
+	fmt::{Debug, Formatter},
+	fs::{self, File},
+	io::{self, ErrorKind},
+	os::{
+		fd::{AsRawFd as _, FromRawFd as _},
+		unix::{
+			ffi::OsStrExt as _,
+			fs::{FileTypeExt as _, MetadataExt as _, PermissionsExt as _},
+			process::ExitStatusExt as _,
+		},
+	},
+	path::{Path, PathBuf},
+	process::ExitStatus,
+	ptr, thread,
+	time::Duration,
+};
+
+use core_foundation::{
+	base::{CFGetTypeID, CFTypeRef, OSStatus, TCFType as _},
+	data::{CFDataGetBytePtr, CFDataGetLength, CFDataGetTypeID, CFDataRef},
+	dictionary::{CFDictionary, CFDictionaryGetValue, CFDictionaryRef},
+	string::CFStringRef,
+	url::CFURL,
+};
+use libc::{
+	EINTR, ESRCH, F_GETFD, F_GETFL, F_SETFL, FD_CLOEXEC, O_CLOEXEC, O_NOFOLLOW, O_NONBLOCK,
+	O_RDONLY, O_WRONLY, SIGCONT, SIGKILL, WNOHANG, posix_spawn_file_actions_t, posix_spawnattr_t,
+};
+use security_framework::os::macos::code_signing::{
+	Flags, GuestAttributes, SecCode, SecRequirement, SecStaticCode,
+};
+use tempfile::{Builder as TempDirBuilder, TempDir};
+
+const CHILD_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
+const MAX_CODE_IDENTITY_BYTES: usize = 64;
+const DYNAMIC_CODE_LOOKUP_ATTEMPTS: usize = 50;
+const DYNAMIC_CODE_LOOKUP_DELAY: Duration = Duration::from_millis(10);
+
+// Darwin defines this flag in <sys/spawn.h>, but libc does not currently expose it for Apple
+// targets. The other two Darwin flags are exposed as c_int and are converted together below.
+const POSIX_SPAWN_SETSID_DARWIN: c_short = 0x0400;
+
+// Static and dynamic validation must not consult the network. Static checking covers every
+// architecture so a universal executable cannot pass because only its host-native slice was
+// inspected.
+const STATIC_CODE_VALIDATION_FLAGS: u32 = Flags::CHECK_ALL_ARCHITECTURES.bits()
+	| Flags::STRICT_VALIDATE.bits()
+	| Flags::NO_NETWORK_ACCESS.bits();
+const DYNAMIC_CODE_VALIDATION_FLAGS: Flags =
+	Flags::from_bits_retain(Flags::STRICT_VALIDATE.bits() | Flags::NO_NETWORK_ACCESS.bits());
+
+#[link(name = "Security", kind = "framework")]
+unsafe extern "C" {
+	static kSecCodeInfoUnique: CFStringRef;
+
+	fn SecCodeCopySigningInformation(
+		code: *const c_void,
+		flags: u32,
+		information: *mut CFDictionaryRef,
+	) -> OSStatus;
+	fn SecStaticCodeCheckValidity(
+		code: *const c_void,
+		flags: u32,
+		requirement: *const c_void,
+	) -> OSStatus;
+}
+
+unsafe extern "C" {
+	fn posix_spawn_file_actions_addchdir_np(
+		actions: *mut posix_spawn_file_actions_t,
+		path: *const c_char,
+	) -> libc::c_int;
+}
+
+/// Statically validated identity rooted in a reference snapshot for one execution path.
+#[derive(Clone, Eq, PartialEq)]
+pub(super) struct AttestedCodeIdentity {
+	execution_path: PathBuf,
+	unique: [u8; MAX_CODE_IDENTITY_BYTES],
+	unique_len: u8,
+}
+
+impl AttestedCodeIdentity {
+	/// Capture an exact signed identity from a trusted snapshot and bind it to an execution path.
+	pub(super) fn capture(reference_snapshot: &Path, execution_path: &Path) -> io::Result<Self> {
+		let reference_snapshot = fs::canonicalize(reference_snapshot)?;
+		let execution_path = fs::canonicalize(execution_path)?;
+		let reference_code = validated_static_code(&reference_snapshot)?;
+		let execution_code = validated_static_code(&execution_path)?;
+		let (unique, unique_len) = copy_unique_identity(
+			reference_code.as_concrete_TypeRef().cast::<c_void>().cast_const(),
+		)?;
+		let (execution_unique, execution_unique_len) = copy_unique_identity(
+			execution_code.as_concrete_TypeRef().cast::<c_void>().cast_const(),
+		)?;
+
+		if execution_unique_len != unique_len
+			|| execution_unique[..usize::from(execution_unique_len)]
+				!= unique[..usize::from(unique_len)]
+		{
+			return Err(permission_denied(
+				"execution path does not match the reference code identity",
+			));
+		}
+
+		Ok(Self { execution_path, unique, unique_len })
+	}
+
+	/// Canonical path that can execute this captured identity.
+	pub(super) fn execution_path(&self) -> &Path {
+		&self.execution_path
+	}
+
+	fn unique(&self) -> &[u8] {
+		&self.unique[..usize::from(self.unique_len)]
+	}
+}
+
+impl Debug for AttestedCodeIdentity {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter
+			.debug_struct("AttestedCodeIdentity")
+			.field("execution_path", &self.execution_path)
+			.finish_non_exhaustive()
+	}
+}
+
+/// One resumed child plus the parent sides of its protocol pipes.
+pub(super) struct AttestedSpawn {
+	pub(super) child: AttestedChild,
+	pub(super) stdin: File,
+	pub(super) stdout: File,
+}
+
+impl Debug for AttestedSpawn {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter.debug_struct("AttestedSpawn").field("child", &self.child).finish_non_exhaustive()
+	}
+}
+
+/// One child that cannot run user code until its dynamic identity is attested.
+pub(super) struct SuspendedAttestedSpawn {
+	execution_path: PathBuf,
+	child: Option<AttestedChild>,
+	stdin: Option<File>,
+	stdout: Option<File>,
+}
+
+impl SuspendedAttestedSpawn {
+	/// OS process identifier for bounded filesystem re-verification while the child is suspended.
+	#[cfg(test)]
+	pub(super) fn id(&self) -> u32 {
+		self.child.as_ref().expect("a suspended spawn owns its child").id()
+	}
+
+	/// Verify the kernel's process identity and process-group contract, then resume the child.
+	pub(super) fn attest_and_resume(
+		mut self,
+		identity: &AttestedCodeIdentity,
+	) -> io::Result<AttestedSpawn> {
+		if self.execution_path != identity.execution_path {
+			return Err(permission_denied("suspended execution path changed before attestation"));
+		}
+
+		let pid = self.child.as_ref().expect("a suspended spawn owns its child").pid;
+
+		verify_dynamic_identity(pid, identity)?;
+		verify_session_and_process_group(pid)?;
+
+		// SAFETY: the positive pid names the unreaped, suspended child owned by this value.
+		if unsafe { libc::kill(pid, SIGCONT) } != 0 {
+			return Err(io::Error::last_os_error());
+		}
+
+		Ok(AttestedSpawn {
+			child: self.child.take().expect("a suspended spawn owns its child"),
+			stdin: self.stdin.take().expect("a suspended spawn owns its stdin pipe"),
+			stdout: self.stdout.take().expect("a suspended spawn owns its stdout pipe"),
+		})
+	}
+}
+
+impl Debug for SuspendedAttestedSpawn {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter
+			.debug_struct("SuspendedAttestedSpawn")
+			.field("execution_path", &self.execution_path)
+			.field("child", &self.child)
+			.finish_non_exhaustive()
+	}
+}
+
+impl Drop for SuspendedAttestedSpawn {
+	fn drop(&mut self) {
+		if let Some(child) = self.child.take() {
+			kill_and_reap(child.pid);
+		}
+	}
+}
+
+/// Spawn one canonical executable and return it still suspended.
+///
+/// `args` excludes `argv[0]`; the canonical executable path is always used for `argv[0]` and the
+/// executed path. The child receives only `HOME` and the fixed system `PATH` environment entries.
+pub(super) fn spawn_suspended(
+	identity: &AttestedCodeIdentity,
+	args: &[OsString],
+	working_directory: &Path,
+	home: &Path,
+) -> io::Result<SuspendedAttestedSpawn> {
+	let spawned_execution_path = identity.execution_path.clone();
+	let executable = os_string(identity.execution_path.as_os_str())?;
+	let working_directory = os_string(working_directory.as_os_str())?;
+	let mut argv = Vec::with_capacity(args.len() + 1);
+
+	argv.push(os_string(identity.execution_path.as_os_str())?);
+	argv.extend(args.iter().map(|arg| os_string(arg)).collect::<io::Result<Vec<_>>>()?);
+
+	let home_environment = environment_entry(b"HOME", home.as_os_str())?;
+	let path_environment = CString::new(format!("PATH={CHILD_PATH}"))
+		.map_err(|_| invalid_input("child PATH contains a NUL byte"))?;
+	let mut argv_pointers = argv
+		.iter()
+		.map(|value| value.as_ptr().cast_mut())
+		.chain(std::iter::once(ptr::null_mut()))
+		.collect::<Vec<_>>();
+	let mut environment_pointers = [
+		home_environment.as_ptr().cast_mut(),
+		path_environment.as_ptr().cast_mut(),
+		ptr::null_mut(),
+	];
+
+	let protocol = ProtocolFifos::new()?;
+	let mut actions = SpawnFileActions::new()?;
+
+	actions.open(libc::STDIN_FILENO, protocol.stdin_path(), O_RDONLY | O_NOFOLLOW, 0)?;
+	actions.open(libc::STDOUT_FILENO, protocol.stdout_path(), O_WRONLY | O_NOFOLLOW, 0)?;
+	actions.open(libc::STDERR_FILENO, c"/dev/null", O_WRONLY, 0)?;
+	actions.chdir(&working_directory)?;
+
+	let mut attributes = SpawnAttributes::new()?;
+	attributes.set_attested_flags()?;
+
+	let mut pid = -1;
+	// SAFETY: every pointer targets a live, NUL-terminated allocation for the duration of the call;
+	// the action and attribute handles were initialized successfully.
+	let result = unsafe {
+		libc::posix_spawn(
+			&mut pid,
+			executable.as_ptr(),
+			actions.as_ptr(),
+			attributes.as_ptr(),
+			argv_pointers.as_mut_ptr(),
+			environment_pointers.as_mut_ptr(),
+		)
+	};
+
+	if result != 0 {
+		return Err(io::Error::from_raw_os_error(result));
+	}
+	if pid <= 0 {
+		return Err(io::Error::other("posix_spawn returned an invalid child identifier"));
+	}
+
+	let mut suspended = SuspendedAttestedSpawn {
+		execution_path: spawned_execution_path,
+		child: Some(AttestedChild { pid, status: None }),
+		stdin: None,
+		stdout: None,
+	};
+	let (parent_stdin, parent_stdout) = protocol.finish_after_spawn()?;
+
+	suspended.stdin = Some(parent_stdin);
+	suspended.stdout = Some(parent_stdout);
+
+	Ok(suspended)
+}
+
+/// Minimal owned child handle for a pid returned directly by `posix_spawn`.
+pub(super) struct AttestedChild {
+	pid: libc::pid_t,
+	status: Option<ExitStatus>,
+}
+
+impl AttestedChild {
+	pub(super) fn id(&self) -> u32 {
+		u32::try_from(self.pid).expect("a positive macOS pid fits in u32")
+	}
+
+	pub(super) fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+		if let Some(status) = self.status {
+			return Ok(Some(status));
+		}
+
+		self.wait_with_options(WNOHANG)
+	}
+
+	pub(super) fn kill(&mut self) -> io::Result<()> {
+		if self.status.is_some() {
+			return Ok(());
+		}
+
+		// SAFETY: this handle retains exclusive wait ownership for its positive child pid.
+		if unsafe { libc::kill(self.pid, SIGKILL) } == 0 {
+			return Ok(());
+		}
+
+		let error = io::Error::last_os_error();
+		if error.raw_os_error() == Some(ESRCH) && self.try_wait()?.is_some() {
+			Ok(())
+		} else {
+			Err(error)
+		}
+	}
+
+	pub(super) fn wait(&mut self) -> io::Result<ExitStatus> {
+		if let Some(status) = self.status {
+			return Ok(status);
+		}
+
+		self.wait_with_options(0)?
+			.ok_or_else(|| io::Error::other("blocking wait returned no status"))
+	}
+
+	fn wait_with_options(&mut self, options: libc::c_int) -> io::Result<Option<ExitStatus>> {
+		loop {
+			let mut raw_status = 0;
+			// SAFETY: this handle exclusively waits for its own positive child pid and supplies a
+			// valid status pointer.
+			let waited = unsafe { libc::waitpid(self.pid, &mut raw_status, options) };
+
+			if waited == self.pid {
+				let status = ExitStatus::from_raw(raw_status);
+
+				self.status = Some(status);
+
+				return Ok(Some(status));
+			}
+			if waited == 0 {
+				return Ok(None);
+			}
+			if waited == -1 {
+				let error = io::Error::last_os_error();
+
+				if error.raw_os_error() == Some(EINTR) {
+					continue;
+				}
+
+				return Err(error);
+			}
+
+			return Err(io::Error::other("waitpid returned an unexpected child identifier"));
+		}
+	}
+}
+
+impl Debug for AttestedChild {
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+		formatter
+			.debug_struct("AttestedChild")
+			.field("pid", &self.pid)
+			.field("exited", &self.status.is_some())
+			.finish()
+	}
+}
+
+fn validated_static_code(canonical_path: &Path) -> io::Result<SecStaticCode> {
+	let url = CFURL::from_path(canonical_path, false)
+		.ok_or_else(|| invalid_input("canonical executable path is unavailable"))?;
+	let code = SecStaticCode::from_path(&url, Flags::NONE)
+		.map_err(|_| permission_denied("static code identity is unavailable"))?;
+
+	check_static_validity(&code)?;
+
+	let reported_path = code
+		.path(Flags::NONE)
+		.map_err(|_| invalid_data("static code path is unavailable"))?
+		.to_path()
+		.ok_or_else(|| invalid_data("static code path is malformed"))?;
+
+	if reported_path != canonical_path {
+		return Err(invalid_data("static code path does not match the canonical executable"));
+	}
+
+	Ok(code)
+}
+
+fn check_static_validity(code: &SecStaticCode) -> io::Result<()> {
+	// SAFETY: `code` is a live Security-framework object. A null requirement requests signature
+	// validation without an additional caller-defined requirement.
+	let status = unsafe {
+		SecStaticCodeCheckValidity(
+			code.as_concrete_TypeRef().cast::<c_void>(),
+			STATIC_CODE_VALIDATION_FLAGS,
+			ptr::null(),
+		)
+	};
+
+	security_status(status, "static code validation failed")
+}
+
+fn verify_dynamic_identity(pid: libc::pid_t, expected: &AttestedCodeIdentity) -> io::Result<()> {
+	let code = dynamic_code_for_pid(pid)?;
+	let requirement = exact_cdhash_requirement(expected.unique())?;
+
+	code.check_validity(DYNAMIC_CODE_VALIDATION_FLAGS, &requirement)
+		.map_err(|_| permission_denied("dynamic code validation failed"))?;
+
+	let reported_path = code
+		.path(Flags::NONE)
+		.map_err(|_| invalid_data("dynamic code path is unavailable"))?
+		.to_path()
+		.ok_or_else(|| invalid_data("dynamic code path is malformed"))?;
+
+	if reported_path != expected.execution_path {
+		return Err(permission_denied("dynamic code path changed during spawn"));
+	}
+
+	let (unique, unique_len) =
+		copy_unique_identity(code.as_concrete_TypeRef().cast::<c_void>().cast_const())?;
+
+	if &unique[..usize::from(unique_len)] != expected.unique() {
+		return Err(permission_denied("dynamic code identity changed during spawn"));
+	}
+
+	Ok(())
+}
+
+fn exact_cdhash_requirement(unique: &[u8]) -> io::Result<SecRequirement> {
+	const HEX: &[u8; 16] = b"0123456789abcdef";
+
+	let mut text = String::with_capacity("cdhash H\"\"".len() + unique.len() * 2);
+
+	text.push_str("cdhash H\"");
+	for byte in unique {
+		text.push(char::from(HEX[usize::from(byte >> 4)]));
+		text.push(char::from(HEX[usize::from(byte & 0x0f)]));
+	}
+	text.push('"');
+
+	text.parse().map_err(|_| invalid_data("exact CDHash requirement is unavailable"))
+}
+
+fn verify_session_and_process_group(pid: libc::pid_t) -> io::Result<()> {
+	// SAFETY: `pid` names the live suspended child; getsid only reads kernel process metadata.
+	let session = unsafe { libc::getsid(pid) };
+
+	if session == -1 {
+		return Err(io::Error::last_os_error());
+	}
+	if session != pid {
+		return Err(permission_denied("suspended child did not create its own session"));
+	}
+
+	// SAFETY: `pid` names the live suspended child; getpgid only reads kernel process metadata.
+	let process_group = unsafe { libc::getpgid(pid) };
+
+	if process_group == -1 {
+		return Err(io::Error::last_os_error());
+	}
+	if process_group != pid {
+		return Err(permission_denied("suspended child did not create its own process group"));
+	}
+
+	Ok(())
+}
+
+fn dynamic_code_for_pid(pid: libc::pid_t) -> io::Result<SecCode> {
+	for attempt in 0..DYNAMIC_CODE_LOOKUP_ATTEMPTS {
+		let mut attributes = GuestAttributes::new();
+
+		attributes.set_pid(pid);
+
+		match SecCode::copy_guest_with_attribues(None, &attributes, Flags::NONE) {
+			Ok(code) => return Ok(code),
+			Err(_) if attempt + 1 < DYNAMIC_CODE_LOOKUP_ATTEMPTS => {
+				thread::sleep(DYNAMIC_CODE_LOOKUP_DELAY);
+			},
+			Err(_) => break,
+		}
+	}
+
+	Err(io::Error::new(
+		ErrorKind::TimedOut,
+		"dynamic code identity was not available within the bounded lookup window",
+	))
+}
+
+fn copy_unique_identity(code: *const c_void) -> io::Result<([u8; MAX_CODE_IDENTITY_BYTES], u8)> {
+	let mut raw_information: CFDictionaryRef = ptr::null();
+	// SAFETY: `code` is a live SecCodeRef or SecStaticCodeRef. The returned dictionary follows the
+	// Create Rule and is immediately wrapped below.
+	let status = unsafe { SecCodeCopySigningInformation(code, 0, &mut raw_information) };
+
+	security_status(status, "code signing information is unavailable")?;
+	if raw_information.is_null() {
+		return Err(invalid_data("code signing information is empty"));
+	}
+
+	// SAFETY: a successful SecCodeCopySigningInformation call returns an owned CFDictionaryRef.
+	let information = unsafe {
+		CFDictionary::<*const c_void, *const c_void>::wrap_under_create_rule(raw_information)
+	};
+	// SAFETY: the dictionary and global key are live for this lookup.
+	let value = unsafe {
+		CFDictionaryGetValue(information.as_concrete_TypeRef(), kSecCodeInfoUnique.cast::<c_void>())
+	};
+
+	if value.is_null() {
+		return Err(invalid_data("signed code has no unique identity"));
+	}
+	// SAFETY: `value` is a retained dictionary member for the lifetime of `information`.
+	if unsafe { CFGetTypeID(value.cast::<c_void>() as CFTypeRef) } != unsafe { CFDataGetTypeID() } {
+		return Err(invalid_data("unique code identity has an unexpected type"));
+	}
+
+	let data = value.cast::<c_void>() as CFDataRef;
+	// SAFETY: the runtime type check above establishes that `data` is a CFDataRef.
+	let length = unsafe { CFDataGetLength(data) };
+	let length = usize::try_from(length)
+		.map_err(|_| invalid_data("unique code identity has a negative length"))?;
+
+	if length == 0 || length > MAX_CODE_IDENTITY_BYTES {
+		return Err(invalid_data("unique code identity exceeds its mechanical bound"));
+	}
+
+	// SAFETY: CFData promises `length` readable bytes; a positive length requires a non-null byte
+	// pointer. The bytes are copied before the dictionary is released.
+	let source = unsafe { CFDataGetBytePtr(data) };
+	if source.is_null() {
+		return Err(invalid_data("unique code identity has no bytes"));
+	}
+
+	let mut unique = [0_u8; MAX_CODE_IDENTITY_BYTES];
+
+	// SAFETY: both buffers are valid for `length`, which was checked against the destination bound.
+	unsafe { ptr::copy_nonoverlapping(source, unique.as_mut_ptr(), length) };
+
+	Ok((unique, u8::try_from(length).expect("the unique code identity bound fits in u8")))
+}
+
+struct ProtocolFifos {
+	directory: TempDir,
+	stdin_path: CString,
+	stdout_path: CString,
+	parent_stdin: File,
+	parent_stdout: File,
+}
+
+impl ProtocolFifos {
+	fn new() -> io::Result<Self> {
+		let directory = TempDirBuilder::new().prefix("decodex-app-server-fifos-").tempdir()?;
+
+		fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700))?;
+		validate_private_directory(directory.path())?;
+
+		let stdin_path = os_string(directory.path().join("stdin").as_os_str())?;
+		let stdout_path = os_string(directory.path().join("stdout").as_os_str())?;
+
+		create_fifo(&stdin_path)?;
+		create_fifo(&stdout_path)?;
+
+		// A temporary nonblocking reader lets the parent open its write endpoint atomically with
+		// O_CLOEXEC before the child exists. The retained writer then lets the child's fd 0 open
+		// complete during posix_spawn.
+		let temporary_stdin_reader =
+			open_fifo(&stdin_path, O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW)?;
+		let parent_stdin = open_fifo(&stdin_path, O_WRONLY | O_CLOEXEC | O_NOFOLLOW)?;
+
+		drop(temporary_stdin_reader);
+
+		// A nonblocking parent reader can open before a writer exists. It lets the child's fd 1
+		// open complete; the nonblocking flag is cleared after posix_spawn returns.
+		let parent_stdout =
+			open_fifo(&stdout_path, O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW)?;
+
+		validate_fifo(&stdin_path, &parent_stdin)?;
+		validate_fifo(&stdout_path, &parent_stdout)?;
+
+		Ok(Self { directory, stdin_path, stdout_path, parent_stdin, parent_stdout })
+	}
+
+	fn stdin_path(&self) -> &std::ffi::CStr {
+		&self.stdin_path
+	}
+
+	fn stdout_path(&self) -> &std::ffi::CStr {
+		&self.stdout_path
+	}
+
+	fn finish_after_spawn(self) -> io::Result<(File, File)> {
+		set_blocking(&self.parent_stdout)?;
+		validate_fifo(&self.stdin_path, &self.parent_stdin)?;
+		validate_fifo(&self.stdout_path, &self.parent_stdout)?;
+		unlink_fifo(&self.stdin_path)?;
+		unlink_fifo(&self.stdout_path)?;
+
+		let Self { directory, stdin_path: _, stdout_path: _, parent_stdin, parent_stdout } = self;
+
+		drop(directory);
+
+		Ok((parent_stdin, parent_stdout))
+	}
+}
+
+fn validate_private_directory(path: &Path) -> io::Result<()> {
+	let metadata = path.symlink_metadata()?;
+
+	if !metadata.is_dir()
+		|| metadata.uid() != unsafe { libc::geteuid() }
+		|| metadata.permissions().mode() & 0o777 != 0o700
+	{
+		return Err(permission_denied("protocol FIFO directory is not private"));
+	}
+
+	Ok(())
+}
+
+fn create_fifo(path: &std::ffi::CStr) -> io::Result<()> {
+	// SAFETY: `path` is NUL-terminated and names a not-yet-existing entry in a private directory.
+	if unsafe { libc::mkfifo(path.as_ptr(), 0o600) } == 0 {
+		Ok(())
+	} else {
+		Err(io::Error::last_os_error())
+	}
+}
+
+fn open_fifo(path: &std::ffi::CStr, flags: libc::c_int) -> io::Result<File> {
+	// SAFETY: `path` is NUL-terminated. The flags establish an atomic close-on-exec descriptor and
+	// O_NOFOLLOW rejects replacement by a symlink.
+	let descriptor = unsafe { libc::open(path.as_ptr(), flags) };
+
+	if descriptor == -1 {
+		return Err(io::Error::last_os_error());
+	}
+
+	// SAFETY: open returned one newly owned descriptor.
+	let file = unsafe { File::from_raw_fd(descriptor) };
+
+	if descriptor <= libc::STDERR_FILENO || !descriptor_is_close_on_exec(&file)? {
+		return Err(permission_denied("protocol FIFO descriptor boundary is invalid"));
+	}
+
+	Ok(file)
+}
+
+fn validate_fifo(path: &std::ffi::CStr, file: &File) -> io::Result<()> {
+	let path = Path::new(OsStr::from_bytes(path.to_bytes()));
+	let path_metadata = path.symlink_metadata()?;
+	let file_metadata = file.metadata()?;
+	let effective_user = unsafe { libc::geteuid() };
+	let valid = path_metadata.file_type().is_fifo()
+		&& file_metadata.file_type().is_fifo()
+		&& path_metadata.uid() == effective_user
+		&& file_metadata.uid() == effective_user
+		&& path_metadata.nlink() == 1
+		&& file_metadata.nlink() == 1
+		&& path_metadata.permissions().mode() & 0o777 == 0o600
+		&& file_metadata.permissions().mode() & 0o777 == 0o600
+		&& path_metadata.dev() == file_metadata.dev()
+		&& path_metadata.ino() == file_metadata.ino()
+		&& descriptor_is_close_on_exec(file)?;
+
+	if valid { Ok(()) } else { Err(permission_denied("protocol FIFO identity is invalid")) }
+}
+
+fn descriptor_is_close_on_exec(file: &File) -> io::Result<bool> {
+	// SAFETY: the File owns a live descriptor and F_GETFD only reads descriptor flags.
+	let flags = unsafe { libc::fcntl(file.as_raw_fd(), F_GETFD) };
+
+	if flags == -1 { Err(io::Error::last_os_error()) } else { Ok(flags & FD_CLOEXEC != 0) }
+}
+
+fn set_blocking(file: &File) -> io::Result<()> {
+	// SAFETY: the File owns a live descriptor and F_GETFL only reads its status flags.
+	let flags = unsafe { libc::fcntl(file.as_raw_fd(), F_GETFL) };
+
+	if flags == -1 {
+		return Err(io::Error::last_os_error());
+	}
+	// SAFETY: the File owns a live descriptor and F_SETFL accepts the updated integer flags.
+	if unsafe { libc::fcntl(file.as_raw_fd(), F_SETFL, flags & !O_NONBLOCK) } == -1 {
+		Err(io::Error::last_os_error())
+	} else {
+		Ok(())
+	}
+}
+
+fn unlink_fifo(path: &std::ffi::CStr) -> io::Result<()> {
+	// SAFETY: `path` is a live NUL-terminated FIFO name in the private temporary directory.
+	if unsafe { libc::unlink(path.as_ptr()) } == 0 {
+		Ok(())
+	} else {
+		Err(io::Error::last_os_error())
+	}
+}
+
+struct SpawnFileActions(posix_spawn_file_actions_t);
+
+impl SpawnFileActions {
+	fn new() -> io::Result<Self> {
+		let mut actions = ptr::null_mut();
+		// SAFETY: `actions` points to uninitialized storage expected by the initializer.
+		let result = unsafe { libc::posix_spawn_file_actions_init(&mut actions) };
+
+		if result == 0 { Ok(Self(actions)) } else { Err(io::Error::from_raw_os_error(result)) }
+	}
+
+	fn as_ptr(&self) -> *const posix_spawn_file_actions_t {
+		&self.0
+	}
+
+	fn open(
+		&mut self,
+		descriptor: libc::c_int,
+		path: &std::ffi::CStr,
+		flags: libc::c_int,
+		mode: libc::mode_t,
+	) -> io::Result<()> {
+		// SAFETY: the actions object is initialized and `path` is NUL-terminated.
+		let result = unsafe {
+			libc::posix_spawn_file_actions_addopen(
+				&mut self.0,
+				descriptor,
+				path.as_ptr(),
+				flags,
+				mode,
+			)
+		};
+
+		spawn_configuration_result(result)
+	}
+
+	fn chdir(&mut self, path: &CString) -> io::Result<()> {
+		// SAFETY: the actions object is initialized and `path` is NUL-terminated.
+		let result = unsafe { posix_spawn_file_actions_addchdir_np(&mut self.0, path.as_ptr()) };
+
+		spawn_configuration_result(result)
+	}
+}
+
+impl Drop for SpawnFileActions {
+	fn drop(&mut self) {
+		// SAFETY: this wrapper is constructed only after successful initialization and destroys the
+		// action object exactly once.
+		unsafe { libc::posix_spawn_file_actions_destroy(&mut self.0) };
+	}
+}
+
+struct SpawnAttributes(posix_spawnattr_t);
+
+impl SpawnAttributes {
+	fn new() -> io::Result<Self> {
+		let mut attributes = ptr::null_mut();
+		// SAFETY: `attributes` points to uninitialized storage expected by the initializer.
+		let result = unsafe { libc::posix_spawnattr_init(&mut attributes) };
+
+		if result == 0 { Ok(Self(attributes)) } else { Err(io::Error::from_raw_os_error(result)) }
+	}
+
+	fn as_ptr(&self) -> *const posix_spawnattr_t {
+		&self.0
+	}
+
+	fn set_attested_flags(&mut self) -> io::Result<()> {
+		let mut default_signals = std::mem::MaybeUninit::<libc::sigset_t>::uninit();
+		// SAFETY: sigemptyset initializes the complete output object before it is read.
+		if unsafe { libc::sigemptyset(default_signals.as_mut_ptr()) } != 0 {
+			return Err(io::Error::last_os_error());
+		}
+		// SAFETY: the set was initialized above and SIGPIPE is a valid signal number.
+		if unsafe { libc::sigaddset(default_signals.as_mut_ptr(), libc::SIGPIPE) } != 0 {
+			return Err(io::Error::last_os_error());
+		}
+		// SAFETY: both the spawn attributes and complete signal set are initialized and live.
+		let result =
+			unsafe { libc::posix_spawnattr_setsigdefault(&mut self.0, default_signals.as_ptr()) };
+
+		spawn_configuration_result(result)?;
+
+		let exposed = libc::POSIX_SPAWN_START_SUSPENDED
+			| libc::POSIX_SPAWN_CLOEXEC_DEFAULT
+			| libc::POSIX_SPAWN_SETSIGDEF;
+		let flags = c_short::try_from(exposed)
+			.map_err(|_| invalid_input("Darwin spawn flags do not fit posix_spawnattr_setflags"))?
+			| POSIX_SPAWN_SETSID_DARWIN;
+		// SAFETY: the attributes object is initialized and `flags` contains only Darwin-defined
+		// posix_spawn bits.
+		let result = unsafe { libc::posix_spawnattr_setflags(&mut self.0, flags) };
+
+		spawn_configuration_result(result)
+	}
+}
+
+impl Drop for SpawnAttributes {
+	fn drop(&mut self) {
+		// SAFETY: this wrapper is constructed only after successful initialization and destroys the
+		// attribute object exactly once.
+		unsafe { libc::posix_spawnattr_destroy(&mut self.0) };
+	}
+}
+
+fn kill_and_reap(pid: libc::pid_t) {
+	// SAFETY: the caller owns an unreaped positive child pid. ESRCH only means it has already
+	// exited; waitpid still collects its terminal status.
+	unsafe { libc::kill(pid, SIGKILL) };
+
+	loop {
+		let mut status = 0;
+		// SAFETY: `pid` is the caller's child and `status` is a valid output pointer.
+		let waited = unsafe { libc::waitpid(pid, &mut status, 0) };
+
+		if waited == pid {
+			return;
+		}
+		if waited == -1 && io::Error::last_os_error().raw_os_error() == Some(EINTR) {
+			continue;
+		}
+
+		return;
+	}
+}
+
+fn os_string(value: &OsStr) -> io::Result<CString> {
+	CString::new(value.as_bytes()).map_err(|_| invalid_input("spawn value contains a NUL byte"))
+}
+
+fn environment_entry(name: &[u8], value: &OsStr) -> io::Result<CString> {
+	let mut entry = Vec::with_capacity(name.len() + 1 + value.as_bytes().len());
+
+	entry.extend_from_slice(name);
+	entry.push(b'=');
+	entry.extend_from_slice(value.as_bytes());
+
+	CString::new(entry).map_err(|_| invalid_input("child environment value contains a NUL byte"))
+}
+
+fn security_status(status: OSStatus, message: &'static str) -> io::Result<()> {
+	if status == 0 { Ok(()) } else { Err(permission_denied(message)) }
+}
+
+fn spawn_configuration_result(result: libc::c_int) -> io::Result<()> {
+	if result == 0 { Ok(()) } else { Err(io::Error::from_raw_os_error(result)) }
+}
+
+fn invalid_input(message: &'static str) -> io::Error {
+	io::Error::new(ErrorKind::InvalidInput, message)
+}
+
+fn invalid_data(message: &'static str) -> io::Error {
+	io::Error::new(ErrorKind::InvalidData, message)
+}
+
+fn permission_denied(message: &'static str) -> io::Error {
+	io::Error::new(ErrorKind::PermissionDenied, message)
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		collections::BTreeMap,
+		io::{Read as _, Write as _},
+		process::Command,
+	};
+
+	use tempfile::TempDir;
+
+	use super::*;
+
+	fn system_identity(path: &str) -> AttestedCodeIdentity {
+		let path = Path::new(path);
+
+		AttestedCodeIdentity::capture(path, path).unwrap()
+	}
+
+	#[test]
+	fn captures_reference_snapshot_identity_for_a_separate_execution_path() {
+		let temporary = TempDir::new().unwrap();
+		let snapshot = temporary.path().join("signed-reference-image");
+
+		fs::copy("/bin/cat", &snapshot).unwrap();
+		fs::set_permissions(&snapshot, fs::Permissions::from_mode(0o500)).unwrap();
+
+		let identity = AttestedCodeIdentity::capture(&snapshot, Path::new("/bin/cat")).unwrap();
+
+		assert_eq!(identity.execution_path(), fs::canonicalize("/bin/cat").unwrap());
+		assert!(!identity.unique().is_empty());
+		assert!(identity.unique().len() <= MAX_CODE_IDENTITY_BYTES);
+	}
+
+	#[test]
+	fn captures_and_runs_the_exact_signed_identity_with_protocol_pipes() {
+		let identity = system_identity("/bin/cat");
+		let working = TempDir::new().unwrap();
+		let suspended = spawn_suspended(&identity, &[], working.path(), working.path()).unwrap();
+		let marker = b"attested-spawn-marker\n";
+
+		assert!(suspended.id() > 0);
+		assert!(suspended.stdin.as_ref().unwrap().as_raw_fd() > libc::STDERR_FILENO);
+		assert!(suspended.stdout.as_ref().unwrap().as_raw_fd() > libc::STDERR_FILENO);
+
+		let mut spawned = suspended.attest_and_resume(&identity).unwrap();
+
+		spawned.stdin.write_all(marker).unwrap();
+		drop(spawned.stdin);
+
+		let mut output = Vec::new();
+
+		spawned.stdout.read_to_end(&mut output).unwrap();
+
+		assert_eq!(output, marker);
+		assert!(spawned.child.wait().unwrap().success());
+		assert!(spawned.child.try_wait().unwrap().unwrap().success());
+	}
+
+	#[test]
+	fn protocol_fifo_parent_endpoints_are_atomic_cloexec_and_leave_no_names() {
+		let protocol = ProtocolFifos::new().unwrap();
+		let directory = protocol.directory.path().to_owned();
+		let descriptors = [protocol.parent_stdin.as_raw_fd(), protocol.parent_stdout.as_raw_fd()];
+
+		assert!(descriptors.iter().all(|descriptor| *descriptor > libc::STDERR_FILENO));
+		assert!(descriptor_is_close_on_exec(&protocol.parent_stdin).unwrap());
+		assert!(descriptor_is_close_on_exec(&protocol.parent_stdout).unwrap());
+
+		let probe = Command::new("/usr/bin/python3")
+			.arg("-c")
+			.arg("import os,sys\ndef is_open(fd):\n    try:\n        os.fstat(fd)\n        return True\n    except OSError:\n        return False\nprint(','.join('open' if is_open(int(fd)) else 'closed' for fd in sys.argv[1:]))")
+			.args(descriptors.map(|descriptor| descriptor.to_string()))
+			.output()
+			.unwrap();
+
+		assert!(probe.status.success());
+		assert_eq!(String::from_utf8(probe.stdout).unwrap().trim(), "closed,closed");
+
+		let (parent_stdin, parent_stdout) = protocol.finish_after_spawn().unwrap();
+
+		drop(parent_stdin);
+		drop(parent_stdout);
+
+		assert!(!directory.exists());
+	}
+
+	#[test]
+	fn child_receives_only_home_and_the_fixed_path() {
+		let identity = system_identity("/usr/bin/env");
+		let working = TempDir::new().unwrap();
+		let spawned = spawn_suspended(&identity, &[], working.path(), working.path())
+			.unwrap()
+			.attest_and_resume(&identity)
+			.unwrap();
+
+		drop(spawned.stdin);
+
+		let mut output = String::new();
+		let mut stdout = spawned.stdout;
+		let mut child = spawned.child;
+
+		stdout.read_to_string(&mut output).unwrap();
+
+		let environment =
+			output.lines().map(|line| line.split_once('=').unwrap()).collect::<BTreeMap<_, _>>();
+
+		assert!(child.wait().unwrap().success());
+		assert_eq!(environment.len(), 2);
+		assert_eq!(environment.get("HOME"), Some(&working.path().to_str().unwrap()));
+		assert_eq!(environment.get("PATH"), Some(&CHILD_PATH));
+	}
+
+	#[test]
+	fn identity_mismatch_fails_before_the_child_resumes() {
+		let identity = system_identity("/bin/cat");
+		let mut wrong_identity = identity.clone();
+		let working = TempDir::new().unwrap();
+		let suspended = spawn_suspended(&identity, &[], working.path(), working.path()).unwrap();
+
+		wrong_identity.unique[0] ^= 0xff;
+
+		let error = suspended.attest_and_resume(&wrong_identity).unwrap_err();
+
+		assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+	}
+
+	#[test]
+	fn dropping_a_suspended_child_never_runs_user_code() {
+		let identity = system_identity("/bin/sh");
+		let working = TempDir::new().unwrap();
+		let marker = working.path().join("must-not-exist");
+		let arguments = [
+			OsString::from("-c"),
+			OsString::from("printf ran > \"$1\""),
+			OsString::from("decodex-suspended-drop-test"),
+			marker.as_os_str().to_owned(),
+		];
+		let suspended =
+			spawn_suspended(&identity, &arguments, working.path(), working.path()).unwrap();
+
+		drop(suspended);
+
+		assert!(!marker.exists());
+	}
+
+	#[test]
+	fn raw_child_handle_kills_and_reaps_once() {
+		let identity = system_identity("/bin/sleep");
+		let working = TempDir::new().unwrap();
+		let mut spawned =
+			spawn_suspended(&identity, &[OsString::from("30")], working.path(), working.path())
+				.unwrap()
+				.attest_and_resume(&identity)
+				.unwrap();
+		let pid = spawned.child.id();
+
+		drop(spawned.stdin);
+		drop(spawned.stdout);
+		spawned.child.kill().unwrap();
+
+		let status = spawned.child.wait().unwrap();
+
+		assert!(!status.success());
+		assert_eq!(spawned.child.id(), pid);
+		assert_eq!(spawned.child.try_wait().unwrap(), Some(status));
+		assert!(spawned.child.kill().is_ok());
+	}
+
+	#[test]
+	fn child_restores_sigpipe_to_the_default_disposition() {
+		let identity = system_identity("/bin/cat");
+		let working = TempDir::new().unwrap();
+		let mut spawned = spawn_suspended(&identity, &[], working.path(), working.path())
+			.unwrap()
+			.attest_and_resume(&identity)
+			.unwrap();
+		let pid = libc::pid_t::try_from(spawned.child.id()).unwrap();
+
+		// SAFETY: the positive pid belongs to the live child retained above.
+		assert_eq!(unsafe { libc::kill(pid, libc::SIGPIPE) }, 0);
+
+		let status = spawned.child.wait().unwrap();
+
+		assert_eq!(status.signal(), Some(libc::SIGPIPE));
+	}
+}

--- a/crates/decodex-runtime/src/account_launch/process.rs
+++ b/crates/decodex-runtime/src/account_launch/process.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")] use std::os::fd::FromRawFd as _;
+#[cfg(target_os = "linux")] use std::os::fd::{AsRawFd as _, FromRawFd as _};
 #[cfg(test)] use std::sync::atomic::AtomicU32;
 use std::{
 	cell::UnsafeCell,
@@ -11,12 +11,11 @@ use std::{
 	mem::{self, MaybeUninit},
 	os::unix::{
 		fs::{FileExt as _, MetadataExt as _, PermissionsExt as _},
-		io::AsRawFd as _,
 		process::CommandExt as _,
 	},
 	panic::{self, AssertUnwindSafe},
 	path::{Path, PathBuf},
-	process::{Child, ChildStdin, ChildStdout, Command, ExitStatus, Stdio},
+	process::{Child, Command, ExitStatus, Stdio},
 	str,
 	sync::{
 		Arc, Condvar, Mutex, PoisonError,
@@ -54,6 +53,10 @@ use {
 };
 
 #[cfg(test)] use crate::account_launch::RunnerCapacity;
+#[cfg(target_os = "macos")]
+use crate::account_launch::macos_attested_spawn::{
+	AttestedChild, AttestedCodeIdentity, spawn_suspended,
+};
 use crate::account_launch::{
 	RunnerPermit,
 	protocol::{
@@ -175,6 +178,8 @@ pub(super) struct AppServerCommand {
 	program: PathBuf,
 	executable: Arc<ExecutableSnapshot>,
 	executable_digest: [u8; 32],
+	#[cfg(target_os = "macos")]
+	attested_code_identity: Option<AttestedCodeIdentity>,
 	app_server_args: Vec<OsString>,
 	version_args: Vec<OsString>,
 	schema_args: Vec<OsString>,
@@ -185,6 +190,8 @@ pub(super) struct AppServerCommand {
 	before_spawn_test: Option<BeforeSpawnTest>,
 	#[cfg(test)]
 	after_verification_test: Option<BeforeSpawnTest>,
+	#[cfg(all(test, target_os = "macos"))]
+	test_spawn_path: Option<PathBuf>,
 }
 impl AppServerCommand {
 	/// Construct the only production command shape: Codex app-server plus read-only attestation.
@@ -198,13 +205,25 @@ impl AppServerCommand {
 	/// ```
 	pub fn new(working_directory: impl Into<PathBuf>) -> Result<Self, SupervisionError> {
 		let (program, executable, executable_digest) = resolve_executable(OsStr::new("codex"))?;
-
-		Ok(Self::production_from_resolved(
+		let mut command = Self::production_from_resolved(
 			program,
 			executable,
 			executable_digest,
 			working_directory.into(),
-		))
+		);
+
+		#[cfg(target_os = "macos")]
+		{
+			command.attested_code_identity = Some(
+				AttestedCodeIdentity::capture(
+					&command.executable.execution_path(),
+					&command.program,
+				)
+				.map_err(|_| SupervisionError::ExecutableUnavailable)?,
+			);
+		}
+
+		Ok(command)
 	}
 
 	fn production_from_resolved(
@@ -217,6 +236,8 @@ impl AppServerCommand {
 			program,
 			executable,
 			executable_digest,
+			#[cfg(target_os = "macos")]
+			attested_code_identity: None,
 			app_server_args: vec!["app-server".into(), "--stdio".into()],
 			version_args: vec!["--version".into()],
 			schema_args: vec![
@@ -232,6 +253,8 @@ impl AppServerCommand {
 			before_spawn_test: None,
 			#[cfg(test)]
 			after_verification_test: None,
+			#[cfg(all(test, target_os = "macos"))]
+			test_spawn_path: None,
 		}
 	}
 
@@ -251,6 +274,8 @@ impl AppServerCommand {
 			program,
 			executable,
 			executable_digest,
+			#[cfg(target_os = "macos")]
+			attested_code_identity: None,
 			app_server_args: app_server_args.into_iter().map(Into::into).collect(),
 			version_args: version_args.into_iter().map(Into::into).collect(),
 			schema_args: schema_args.into_iter().map(Into::into).collect(),
@@ -258,6 +283,8 @@ impl AppServerCommand {
 			preflight_cleanup_test: None,
 			before_spawn_test: None,
 			after_verification_test: None,
+			#[cfg(target_os = "macos")]
+			test_spawn_path: None,
 		}
 	}
 
@@ -272,7 +299,7 @@ impl AppServerCommand {
 		let fixture =
 			Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fake_app_server.py");
 		let mut app_server_args =
-			vec![fixture.clone().into_os_string(), "serve".into(), mode.into()];
+			vec!["-B".into(), fixture.clone().into_os_string(), "serve".into(), mode.into()];
 
 		if let Some(extra) = extra {
 			app_server_args.push(extra.as_os_str().to_owned());
@@ -285,9 +312,12 @@ impl AppServerCommand {
 			program,
 			executable,
 			executable_digest,
+			#[cfg(target_os = "macos")]
+			attested_code_identity: None,
 			app_server_args,
-			version_args: vec![fixture.clone().into_os_string(), "--version".into()],
+			version_args: vec!["-B".into(), fixture.clone().into_os_string(), "--version".into()],
 			schema_args: vec![
+				"-B".into(),
 				fixture.into_os_string(),
 				"generate-json-schema".into(),
 				"--out".into(),
@@ -299,7 +329,16 @@ impl AppServerCommand {
 			before_spawn_test: None,
 			#[cfg(test)]
 			after_verification_test: None,
+			#[cfg(all(test, target_os = "macos"))]
+			test_spawn_path: None,
 		}
+	}
+
+	#[cfg(all(test, target_os = "macos"))]
+	fn with_spawn_path_for_test(mut self, path: PathBuf) -> Self {
+		self.test_spawn_path = Some(path);
+
+		self
 	}
 
 	#[cfg(test)]
@@ -361,6 +400,16 @@ impl AppServerCommand {
 		action: Arc<dyn Fn() + Send + Sync>,
 	) -> Self {
 		self.after_verification_test = Some(BeforeSpawnTest { trigger_spawn, spawn_count, action });
+
+		self
+	}
+
+	#[cfg(all(test, target_os = "macos"))]
+	fn with_attested_spawn_for_test(mut self) -> Self {
+		self.attested_code_identity = Some(
+			AttestedCodeIdentity::capture(&self.executable.execution_path(), &self.program)
+				.expect("the synthetic executable has a valid static code identity"),
+		);
 
 		self
 	}
@@ -460,30 +509,39 @@ pub(super) struct StdoutPump {
 	thread: Option<JoinHandle<()>>,
 }
 impl StdoutPump {
-	fn start(
-		reader: ChildStdout,
+	fn start<R>(
+		reader: R,
 		sender: SyncSender<InboundFrame>,
 		protocol_limit_exceeded: Arc<AtomicBool>,
-	) -> Result<Self, SupervisionError> {
+	) -> Result<Self, SupervisionError>
+	where
+		R: Read + std::os::fd::AsRawFd + Send + 'static,
+	{
 		Self::start_inner(reader, sender, protocol_limit_exceeded, None)
 	}
 
 	#[cfg(test)]
-	fn start_with_buffer_barrier(
-		reader: ChildStdout,
+	fn start_with_buffer_barrier<R>(
+		reader: R,
 		sender: SyncSender<InboundFrame>,
 		protocol_limit_exceeded: Arc<AtomicBool>,
 		buffered: Arc<AtomicBool>,
-	) -> Result<Self, SupervisionError> {
+	) -> Result<Self, SupervisionError>
+	where
+		R: Read + std::os::fd::AsRawFd + Send + 'static,
+	{
 		Self::start_inner(reader, sender, protocol_limit_exceeded, Some(buffered))
 	}
 
-	fn start_inner(
-		reader: ChildStdout,
+	fn start_inner<R>(
+		reader: R,
 		sender: SyncSender<InboundFrame>,
 		protocol_limit_exceeded: Arc<AtomicBool>,
 		buffered: Option<Arc<AtomicBool>>,
-	) -> Result<Self, SupervisionError> {
+	) -> Result<Self, SupervisionError>
+	where
+		R: Read + std::os::fd::AsRawFd + Send + 'static,
+	{
 		set_nonblocking(reader.as_raw_fd())?;
 
 		let cancelled = Arc::new(AtomicBool::new(false));
@@ -545,7 +603,7 @@ impl StdoutPump {
 /// Owned app-server child and its immutable account authority.
 pub(super) struct SupervisedProcess {
 	owner: ProcessGroupOwner,
-	stdin: ChildStdin,
+	stdin: Box<dyn Write + Send>,
 	stdout: Receiver<InboundFrame>,
 	protocol_limit_exceeded: Arc<AtomicBool>,
 	binding: AccountBinding,
@@ -583,30 +641,11 @@ impl SupervisedProcess {
 		run_before_spawn_test(&command);
 		verify_executable(&command)?;
 		run_after_verification_test(&command);
-
-		let mut process = Command::new(command.executable.execution_path());
-
-		process
-			.arg0(&command.program)
-			.args(&command.app_server_args)
-			.current_dir(&command.working_directory)
-			.stdin(Stdio::piped())
-			.stdout(Stdio::piped())
-			.stderr(Stdio::null());
-
-		configure_child_environment(&mut process, &binding)?;
-		configure_process_group(&mut process, None);
-
-		let child = process.spawn().map_err(|_| SupervisionError::SpawnFailed)?;
-		let mut owner = ProcessGroupOwner::new(child, guard);
-		let stdin = owner.child_mut().stdin.take().ok_or(SupervisionError::StdinUnavailable)?;
-		let stdout = owner.child_mut().stdout.take().ok_or(SupervisionError::InvalidProtocol)?;
 		let (sender, receiver) = mpsc::sync_channel(PROTOCOL_QUEUE_CAPACITY);
 		let protocol_limit_exceeded = Arc::new(AtomicBool::new(false));
 		let reader_limit_exceeded = Arc::clone(&protocol_limit_exceeded);
-		let pump = StdoutPump::start(stdout, sender, reader_limit_exceeded)?;
-
-		owner.attach_pump(pump);
+		let (owner, stdin) =
+			spawn_protocol_process(&command, &binding, guard, sender, reader_limit_exceeded)?;
 
 		Ok(Self {
 			owner,
@@ -744,7 +783,7 @@ impl SupervisedProcess {
 				if response.id != request_id {
 					return Err(RpcError::Supervision(SupervisionError::InvalidProtocol));
 				}
-				if response.jsonrpc.as_str() != "2.0" {
+				if !response.has_compatible_version() {
 					return Err(RpcError::Supervision(SupervisionError::InvalidProtocol));
 				}
 
@@ -780,7 +819,6 @@ impl SupervisedProcess {
 				&& let Some(id) = header.id
 			{
 				self.write_json(&serde_json::json!({
-					"jsonrpc": "2.0",
 					"id": id,
 					"error": {"code": -32_601, "message": "account-bound adapter does not service requests"}
 				}))
@@ -860,7 +898,7 @@ impl SupervisedProcess {
 	where
 		P: Serialize,
 	{
-		self.write_json(&OutboundNotification { jsonrpc: "2.0", method, params })
+		self.write_json(&OutboundNotification { method, params })
 	}
 
 	fn read_account_identity(&mut self, timeout: Duration) -> Result<AccountIdentity, ProbeError> {
@@ -1047,6 +1085,67 @@ impl Drop for SupervisedProcess {
 	fn drop(&mut self) {
 		let _ = self.shutdown_inner(Duration::from_millis(250));
 	}
+}
+
+fn spawn_protocol_process(
+	command: &AppServerCommand,
+	binding: &AccountBinding,
+	guard: Option<RunnerPermit>,
+	sender: SyncSender<InboundFrame>,
+	protocol_limit_exceeded: Arc<AtomicBool>,
+) -> Result<(ProcessGroupOwner, Box<dyn Write + Send>), SupervisionError> {
+	#[cfg(target_os = "macos")]
+	if let Some(identity) = &command.attested_code_identity {
+		let home = binding.expected_codex_home.parent().ok_or(SupervisionError::InvalidBinding)?;
+		let suspended =
+			spawn_suspended(identity, &command.app_server_args, &command.working_directory, home)
+				.map_err(|_| SupervisionError::SpawnFailed)?;
+
+		// The canonical filesystem object must still match the immutable full-digest snapshot after
+		// posix_spawn has bound the stopped child to its executable image. The dynamic code check
+		// below then binds that image to the snapshot's exact code identity before SIGCONT.
+		verify_executable(command)?;
+
+		let spawned =
+			suspended.attest_and_resume(identity).map_err(|_| SupervisionError::SpawnFailed)?;
+		let mut owner = ProcessGroupOwner::new(ManagedChild::Attested(spawned.child), guard);
+		let pump = StdoutPump::start(spawned.stdout, sender, protocol_limit_exceeded)?;
+
+		owner.attach_pump(pump);
+
+		return Ok((owner, Box::new(spawned.stdin)));
+	}
+
+	let mut process = Command::new(protected_spawn_path(command));
+
+	process
+		.arg0(&command.program)
+		.args(&command.app_server_args)
+		.current_dir(&command.working_directory)
+		.stdin(Stdio::piped())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::null());
+
+	configure_child_environment(&mut process, binding)?;
+	configure_process_group(&mut process, None);
+
+	let child = process.spawn().map_err(|_| SupervisionError::SpawnFailed)?;
+	let mut owner = ProcessGroupOwner::new(child, guard);
+	let (stdin, stdout) = match owner.child_mut() {
+		ManagedChild::Standard(child) => {
+			let stdin = child.stdin.take().ok_or(SupervisionError::StdinUnavailable)?;
+			let stdout = child.stdout.take().ok_or(SupervisionError::InvalidProtocol)?;
+
+			(stdin, stdout)
+		},
+		#[cfg(target_os = "macos")]
+		ManagedChild::Attested(_) => unreachable!("snapshot spawn created an attested child"),
+	};
+	let pump = StdoutPump::start(stdout, sender, protocol_limit_exceeded)?;
+
+	owner.attach_pump(pump);
+
+	Ok((owner, Box::new(stdin)))
 }
 
 /// Typed result from `initialize` plus a bounded `thread/list`; no raw JSON escapes.
@@ -1368,7 +1467,8 @@ impl ResetCardProcessError {
 
 	fn from_rpc(error: RpcError, method: ResetCardProcessMethod) -> Self {
 		match error {
-			RpcError::MethodRejected(_) => Self::MethodUnavailable(method),
+			RpcError::MethodRejected(-32_601) => Self::MethodUnavailable(method),
+			RpcError::MethodRejected(_) => Self::ProcessUnavailable,
 			RpcError::Supervision(error) => Self::from_supervision(error),
 		}
 	}
@@ -1721,7 +1821,6 @@ pub(super) struct OutboundRequest<'a, P>
 where
 	P: ?Sized,
 {
-	jsonrpc: &'static str,
 	id: u64,
 	method: &'static str,
 	params: &'a P,
@@ -1742,12 +1841,7 @@ fn exact_request_frame<P>(
 where
 	P: Serialize,
 {
-	ZeroizingOutboundFrame::serialize(&OutboundRequest {
-		jsonrpc: "2.0",
-		id: request_id,
-		method,
-		params,
-	})
+	ZeroizingOutboundFrame::serialize(&OutboundRequest { id: request_id, method, params })
 }
 
 pub(super) fn retained_title_name_set_request_digest(
@@ -1807,7 +1901,6 @@ pub(super) struct OutboundNotification<'a, P>
 where
 	P: ?Sized,
 {
-	jsonrpc: &'static str,
 	method: &'a str,
 	params: &'a P,
 }
@@ -1824,7 +1917,16 @@ pub(super) struct ChatgptAuthParams<'a> {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(super) struct CredentialProjectionResponse {}
+pub(super) struct CredentialProjectionResponse {
+	#[serde(rename = "type")]
+	_kind: CredentialProjectionResponseKind,
+}
+
+#[derive(Deserialize)]
+enum CredentialProjectionResponseKind {
+	#[serde(rename = "chatgptAuthTokens")]
+	ChatgptAuthTokens,
+}
 
 #[derive(Deserialize)]
 pub(super) struct InboundHeader {
@@ -1885,8 +1987,36 @@ impl<'a> ProbeNegotiation<'a> {
 	}
 }
 
+enum ManagedChild {
+	Standard(Child),
+	#[cfg(target_os = "macos")]
+	Attested(AttestedChild),
+}
+impl ManagedChild {
+	fn id(&self) -> u32 {
+		match self {
+			Self::Standard(child) => child.id(),
+			#[cfg(target_os = "macos")]
+			Self::Attested(child) => child.id(),
+		}
+	}
+
+	fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+		match self {
+			Self::Standard(child) => child.try_wait(),
+			#[cfg(target_os = "macos")]
+			Self::Attested(child) => child.try_wait(),
+		}
+	}
+}
+impl From<Child> for ManagedChild {
+	fn from(child: Child) -> Self {
+		Self::Standard(child)
+	}
+}
+
 pub(super) struct ReapJob {
-	child: Child,
+	child: ManagedChild,
 	process_group: u32,
 	pump: Option<StdoutPump>,
 	_guard: Option<RunnerPermit>,
@@ -1895,7 +2025,7 @@ pub(super) struct ReapJob {
 }
 
 pub(super) struct ProcessGroupOwner {
-	child: Option<Child>,
+	child: Option<ManagedChild>,
 	process_group: u32,
 	guard: Option<RunnerPermit>,
 	pump: Option<StdoutPump>,
@@ -1903,7 +2033,8 @@ pub(super) struct ProcessGroupOwner {
 	reap_not_before: Option<Instant>,
 }
 impl ProcessGroupOwner {
-	fn new(child: Child, guard: Option<RunnerPermit>) -> Self {
+	fn new(child: impl Into<ManagedChild>, guard: Option<RunnerPermit>) -> Self {
+		let child = child.into();
 		let process_group = child.id();
 
 		Self {
@@ -1922,7 +2053,7 @@ impl ProcessGroupOwner {
 		self.pump = Some(pump);
 	}
 
-	fn child_mut(&mut self) -> &mut Child {
+	fn child_mut(&mut self) -> &mut ManagedChild {
 		self.child.as_mut().expect("live owner must retain its child")
 	}
 
@@ -2726,7 +2857,6 @@ fn capture_platform_executable_snapshot(
 
 	Ok((snapshot, digest))
 }
-
 #[cfg(target_os = "linux")]
 fn capture_platform_executable_snapshot(
 	source: &File,
@@ -3377,6 +3507,19 @@ fn attest_executable(
 	Ok((build, generated, guard))
 }
 
+fn protected_spawn_path(command: &AppServerCommand) -> PathBuf {
+	// macOS 27 terminates relocated Apple platform binaries such as /usr/bin/python3 before their
+	// test fixture can start. Production Codex images remain relocatable and always use the
+	// protected snapshot here. Unit fixtures execute their already-verified canonical interpreter
+	// while still exercising snapshot capture, digest verification, immutability, and cleanup
+	// mechanics.
+	#[cfg(all(test, target_os = "macos"))]
+	return command.test_spawn_path.clone().unwrap_or_else(|| command.program.clone());
+
+	#[cfg(not(all(test, target_os = "macos")))]
+	command.executable.execution_path()
+}
+
 fn preflight_remaining(deadline: Instant) -> Result<Duration, SupervisionError> {
 	let remaining = deadline.saturating_duration_since(Instant::now());
 
@@ -3397,7 +3540,7 @@ fn run_preflight_command(
 	verify_executable(command)?;
 	run_after_verification_test(command);
 
-	let mut process = Command::new(command.executable.execution_path());
+	let mut process = Command::new(protected_spawn_path(command));
 
 	process
 		.arg0(&command.program)
@@ -3506,7 +3649,7 @@ fn validate_initialize(
 }
 
 fn terminate_process_group(
-	child: &mut Child,
+	child: &mut ManagedChild,
 	pid: u32,
 	timeout: Duration,
 ) -> Result<ShutdownOutcome, SupervisionError> {
@@ -3649,7 +3792,7 @@ fn process_group_exists(_pid: u32) -> Result<bool, SupervisionError> {
 mod tests {
 	use std::{
 		env,
-		ffi::OsStr,
+		ffi::{OsStr, OsString},
 		fs,
 		io::{self, Cursor, ErrorKind, Write},
 		mem,
@@ -3675,11 +3818,11 @@ mod tests {
 		RunnerCapacity, RunnerPermit,
 		process::{
 			self, AccountBinding, AccountIdentity, AppServerCommand, CredentialProjection,
-			CredentialVault, CredentialVaultError, ExactThreadReconciler,
-			ExactThreadReconciliation, ExactThreadReconciliationResult, PROTOCOL_QUEUE_CAPACITY,
-			ProbeError, ProcessQuarantine, ReadOnlyMethod, ReadOnlyProbe, ResetCardProcessError,
-			ResetCardProcessRunner, ShutdownOutcome, SupervisedProcess, SupervisionError,
-			UnavailableCredentialVault,
+			CredentialProjectionResponse, CredentialVault, CredentialVaultError,
+			ExactThreadReconciler, ExactThreadReconciliation, ExactThreadReconciliationResult,
+			PROTOCOL_QUEUE_CAPACITY, ProbeError, ProcessQuarantine, ReadOnlyMethod, ReadOnlyProbe,
+			ResetCardProcessError, ResetCardProcessMethod, ResetCardProcessRunner, RpcError,
+			ShutdownOutcome, SupervisedProcess, SupervisionError, UnavailableCredentialVault,
 		},
 		protocol::{
 			self, ClientInfo, InitializeCapabilities, InitializeParams, InitializeResponse,
@@ -3788,14 +3931,19 @@ mod tests {
 	fn fake_command(mode: &str, directory: &Path, extra: Option<&Path>) -> AppServerCommand {
 		let fixture =
 			Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fake_app_server.py");
-		let mut app_args = vec![fixture.clone().into_os_string(), "serve".into(), mode.into()];
+		let mut app_args =
+			vec!["-B".into(), fixture.clone().into_os_string(), "serve".into(), mode.into()];
 
 		if let Some(extra) = extra {
 			app_args.push(extra.as_os_str().to_owned());
 		}
 
-		let mut schema_args =
-			vec![fixture.clone().into_os_string(), "generate-json-schema".into(), "--out".into()];
+		let mut schema_args = vec![
+			"-B".into(),
+			fixture.clone().into_os_string(),
+			"generate-json-schema".into(),
+			"--out".into(),
+		];
 
 		if mode == "schema-missing" {
 			schema_args.push("--missing-required".into());
@@ -3845,7 +3993,7 @@ mod tests {
 		AppServerCommand::new_for_test(
 			"python3",
 			app_args,
-			[fixture.clone().into_os_string(), version_flag.into()],
+			["-B".into(), fixture.clone().into_os_string(), version_flag.into()],
 			schema_args,
 			directory,
 		)
@@ -3853,17 +4001,24 @@ mod tests {
 
 	fn replaceable_fake_command(mode: &str, directory: &Path, source: &Path) -> AppServerCommand {
 		let command = fake_command(mode, directory, None);
+		#[cfg(target_os = "macos")]
+		let spawn_path = command.program.clone();
 
 		fs::copy(&command.program, source).unwrap();
 		fs::set_permissions(source, fs::Permissions::from_mode(0o755)).unwrap();
 
-		AppServerCommand::new_for_test(
+		let command = AppServerCommand::new_for_test(
 			source,
 			command.app_server_args,
 			command.version_args,
 			command.schema_args,
 			command.working_directory,
-		)
+		);
+
+		#[cfg(target_os = "macos")]
+		let command = command.with_spawn_path_for_test(spawn_path);
+
+		command
 	}
 
 	fn binding() -> AccountBinding {
@@ -4005,6 +4160,68 @@ mod tests {
 	}
 
 	#[test]
+	fn app_server_envelope_accepts_legacy_v2_and_rejects_wrong_or_null_versions() {
+		let temp = TempDir::new().unwrap();
+		let result = ReadOnlyProbe::new_for_test(
+			fake_command("legacy-jsonrpc", temp.path(), None),
+			binding(),
+			SchemaMarker::accepted(),
+			Duration::from_secs(2),
+		)
+		.run(&mut CapabilityCache::default());
+
+		assert!(result.is_ok(), "legacy JSON-RPC response failed: {result:?}");
+
+		for mode in ["wrong-jsonrpc", "null-jsonrpc"] {
+			let temp = TempDir::new().unwrap();
+			let error = ReadOnlyProbe::new_for_test(
+				fake_command(mode, temp.path(), None),
+				binding(),
+				SchemaMarker::accepted(),
+				Duration::from_secs(2),
+			)
+			.run(&mut CapabilityCache::default())
+			.unwrap_err();
+
+			assert_eq!(error, ProbeError::Supervision(SupervisionError::InvalidProtocol));
+		}
+	}
+
+	#[test]
+	fn outbound_request_uses_the_native_bare_app_server_envelope() {
+		let frame = process::exact_request_frame(
+			7,
+			"fixture/method",
+			&serde_json::json!({"fixture": true}),
+		)
+		.unwrap();
+		let mut bytes = Vec::new();
+
+		frame.write_to(&mut bytes).unwrap();
+
+		assert_eq!(
+			bytes,
+			br#"{"id":7,"method":"fixture/method","params":{"fixture":true}}
+"#
+		);
+	}
+
+	#[test]
+	fn app_server_request_receives_bare_error_reply_before_probe_continues() {
+		let temp = TempDir::new().unwrap();
+		let result = ReadOnlyProbe::new_for_test(
+			fake_command("server-request", temp.path(), None),
+			binding(),
+			SchemaMarker::accepted(),
+			Duration::from_secs(2),
+		)
+		.run(&mut CapabilityCache::default())
+		.unwrap();
+
+		assert_eq!(result.profile.state(Capability::Initialize), &CapabilityState::Supported);
+	}
+
+	#[test]
 	fn reset_card_runner_requires_both_exact_schema_methods_before_spawn() {
 		let temp = TempDir::new().unwrap();
 		let spawn_marker = temp.path().join("reset-card-spawned");
@@ -4070,6 +4287,24 @@ mod tests {
 		assert_eq!(readback.outcome, ResetCardConsumeOutcome::Reset);
 		assert_eq!(readback.inventory.available_count(), 0);
 		assert_eq!(capacity.active(), 0);
+	}
+
+	#[test]
+	fn reset_card_rpc_errors_distinguish_missing_methods_from_provider_failures() {
+		assert_eq!(
+			ResetCardProcessError::from_rpc(
+				RpcError::MethodRejected(-32_601),
+				ResetCardProcessMethod::InventoryRead,
+			),
+			ResetCardProcessError::MethodUnavailable(ResetCardProcessMethod::InventoryRead)
+		);
+		assert_eq!(
+			ResetCardProcessError::from_rpc(
+				RpcError::MethodRejected(-32_603),
+				ResetCardProcessMethod::InventoryRead,
+			),
+			ResetCardProcessError::ProcessUnavailable
+		);
 	}
 
 	#[cfg(test)]
@@ -4211,18 +4446,41 @@ mod tests {
 
 	#[test]
 	fn credential_projection_rejects_and_redacts_unexpected_response_payload() {
-		let temp = TempDir::new().unwrap();
-		let error = ReadOnlyProbe::new_for_test(
-			fake_command("login-extra", temp.path(), None),
-			binding(),
-			SchemaMarker::accepted(),
-			Duration::from_secs(2),
-		)
-		.run_bound_for_test(&FixtureVault::matching(), &mut CapabilityCache::default())
-		.unwrap_err();
+		for mode in ["login-extra", "login-wrong-type", "login-missing-type"] {
+			let temp = TempDir::new().unwrap();
+			let error = ReadOnlyProbe::new_for_test(
+				fake_command(mode, temp.path(), None),
+				binding(),
+				SchemaMarker::accepted(),
+				Duration::from_secs(2),
+			)
+			.run_bound_for_test(&FixtureVault::matching(), &mut CapabilityCache::default())
+			.unwrap_err();
 
-		assert_eq!(error, ProbeError::CredentialVault(CredentialVaultError::ProjectionRejected));
-		assert!(!format!("{error:?}").contains("synthetic-nonsecret-sentinel"));
+			assert_eq!(
+				error,
+				ProbeError::CredentialVault(CredentialVaultError::ProjectionRejected)
+			);
+			assert!(!format!("{error:?}").contains("synthetic-nonsecret-sentinel"));
+		}
+	}
+
+	#[test]
+	fn credential_projection_response_requires_the_exact_chatgpt_token_variant() {
+		assert!(
+			serde_json::from_slice::<CredentialProjectionResponse>(
+				br#"{"type":"chatgptAuthTokens"}"#
+			)
+			.is_ok()
+		);
+
+		for json in [
+			br#"{}"#.as_slice(),
+			br#"{"type":"chatgpt"}"#.as_slice(),
+			br#"{"type":"chatgptAuthTokens","extra":true}"#.as_slice(),
+		] {
+			assert!(serde_json::from_slice::<CredentialProjectionResponse>(json).is_err());
+		}
 	}
 
 	#[test]
@@ -4242,7 +4500,7 @@ mod tests {
 		.unwrap_err();
 
 		assert_eq!(error, ProbeError::Supervision(SupervisionError::InvalidProtocol));
-		assert_eq!(protocol::sensitive_string_drops(), 4);
+		assert_eq!(protocol::sensitive_string_drops(), 3);
 		assert!(process::ZEROIZED_INBOUND_BLOCKS.load(Ordering::Acquire) > before);
 	}
 
@@ -4950,6 +5208,46 @@ mod tests {
 		.unwrap();
 
 		assert!(result.process_id > 0);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn canonical_image_replacement_after_verification_never_reaches_user_code() {
+		let temp = TempDir::new().unwrap();
+		let source = temp.path().join("verified-image");
+		let marker = temp.path().join("replacement-ran");
+		let source_for_action = source.clone();
+		let spawn_count = Arc::new(AtomicU32::new(0));
+
+		fs::copy("/bin/cat", &source).unwrap();
+		fs::set_permissions(&source, fs::Permissions::from_mode(0o755)).unwrap();
+
+		let command = AppServerCommand::new_for_test(
+			&source,
+			[
+				OsString::from("-c"),
+				OsString::from("printf ran > \"$1\""),
+				OsString::from("decodex-attested-spawn"),
+				marker.as_os_str().to_owned(),
+			],
+			std::iter::empty::<OsString>(),
+			std::iter::empty::<OsString>(),
+			temp.path(),
+		)
+		.with_attested_spawn_for_test()
+		.with_after_verification_for_test(
+			1,
+			Arc::clone(&spawn_count),
+			Arc::new(move || {
+				fs::copy("/bin/sh", &source_for_action).unwrap();
+				fs::set_permissions(&source_for_action, fs::Permissions::from_mode(0o755)).unwrap();
+			}),
+		);
+		let error = SupervisedProcess::spawn(command, binding()).unwrap_err();
+
+		assert_eq!(error, SupervisionError::ExecutableChanged);
+		assert_eq!(spawn_count.load(Ordering::Acquire), 1);
+		assert!(!marker.exists());
 	}
 
 	#[cfg(target_os = "linux")]

--- a/crates/decodex-runtime/src/account_launch/protocol.rs
+++ b/crates/decodex-runtime/src/account_launch/protocol.rs
@@ -3,7 +3,7 @@ use std::{
 	ops::Deref,
 };
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use zeroize::{Zeroize as _, Zeroizing};
 
 use decodex_codex::{
@@ -230,14 +230,34 @@ pub struct ProtocolThread {
 #[derive(Debug, Deserialize)]
 pub struct JsonRpcError {
 	pub code: i64,
+	#[serde(rename = "message")]
+	_message: SensitiveString,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct JsonRpcResponse<T> {
-	pub jsonrpc: SensitiveString,
+	/// Legacy JSON-RPC version marker. Codex app-server JSONL responses omit this field, while
+	/// older compatible peers can still send the standard marker.
+	#[serde(default, deserialize_with = "deserialize_present_jsonrpc_version")]
+	pub jsonrpc: Option<SensitiveString>,
 	pub id: u64,
 	pub result: Option<T>,
 	pub error: Option<JsonRpcError>,
+}
+impl<T> JsonRpcResponse<T> {
+	/// Accept the native Codex JSONL envelope and the legacy standard JSON-RPC marker only.
+	pub fn has_compatible_version(&self) -> bool {
+		self.jsonrpc.as_ref().is_none_or(|version| version.as_str() == "2.0")
+	}
+}
+
+fn deserialize_present_jsonrpc_version<'de, D>(
+	deserializer: D,
+) -> Result<Option<SensitiveString>, D::Error>
+where
+	D: Deserializer<'de>,
+{
+	SensitiveString::deserialize(deserializer).map(Some)
 }
 
 #[cfg(test)]
@@ -388,6 +408,78 @@ mod tests {
 
 		assert!(serde_json::from_slice::<JsonRpcResponse<ThreadReadResponse>>(json).is_err());
 		assert_eq!(super::sensitive_string_drops(), 3);
+	}
+
+	#[test]
+	fn app_server_response_accepts_bare_or_legacy_v2_envelopes_and_rejects_other_markers() {
+		for json in [
+			br#"{"id":7,"result":{}}"#.as_slice(),
+			br#"{"jsonrpc":"2.0","id":7,"result":{}}"#.as_slice(),
+		] {
+			let response =
+				serde_json::from_slice::<JsonRpcResponse<serde_json::Value>>(json).unwrap();
+
+			assert!(response.has_compatible_version());
+		}
+
+		let wrong = serde_json::from_slice::<JsonRpcResponse<serde_json::Value>>(
+			br#"{"jsonrpc":"1.0","id":7,"result":{}}"#,
+		)
+		.unwrap();
+
+		assert!(!wrong.has_compatible_version());
+
+		for json in [
+			br#"{"jsonrpc":null,"id":7,"result":{}}"#.as_slice(),
+			br#"{"jsonrpc":2,"id":7,"result":{}}"#.as_slice(),
+			br#"{"jsonrpc":{},"id":7,"result":{}}"#.as_slice(),
+		] {
+			assert!(serde_json::from_slice::<JsonRpcResponse<serde_json::Value>>(json).is_err());
+		}
+	}
+
+	#[test]
+	fn legacy_json_rpc_marker_is_zeroized_without_changing_bare_envelope_counts() {
+		super::reset_sensitive_string_drops();
+
+		let bare = serde_json::from_slice::<JsonRpcResponse<serde_json::Value>>(
+			br#"{"id":7,"result":{}}"#,
+		)
+		.unwrap();
+
+		drop(bare);
+		assert_eq!(super::sensitive_string_drops(), 0);
+
+		let legacy = serde_json::from_slice::<JsonRpcResponse<serde_json::Value>>(
+			br#"{"jsonrpc":"2.0","id":7,"result":{}}"#,
+		)
+		.unwrap();
+
+		drop(legacy);
+		assert_eq!(super::sensitive_string_drops(), 1);
+	}
+
+	#[test]
+	fn app_server_errors_require_and_zeroize_the_native_message() {
+		super::reset_sensitive_string_drops();
+
+		let response = serde_json::from_slice::<JsonRpcResponse<serde_json::Value>>(
+			br#"{"id":7,"error":{"code":-32601,"message":"private provider detail"}}"#,
+		)
+		.unwrap();
+		let debug = format!("{:?}", response.error.as_ref().unwrap());
+
+		assert!(!debug.contains("private provider detail"));
+		drop(response);
+		assert_eq!(super::sensitive_string_drops(), 1);
+
+		for json in [
+			br#"{"id":7,"error":{"code":-32601}}"#.as_slice(),
+			br#"{"id":7,"error":{"code":-32601,"message":null}}"#.as_slice(),
+			br#"{"id":7,"error":{"code":-32601,"message":7}}"#.as_slice(),
+		] {
+			assert!(serde_json::from_slice::<JsonRpcResponse<serde_json::Value>>(json).is_err());
+		}
 	}
 
 	#[test]

--- a/crates/decodex-runtime/tests/fixtures/fake_app_server.py
+++ b/crates/decodex-runtime/tests/fixtures/fake_app_server.py
@@ -167,12 +167,31 @@ exact_thread_reads = 0
 reset_card_consumed = False
 for line in sys.stdin:
     message = json.loads(line)
+    assert "jsonrpc" not in message
     if mode == "hang":
         time.sleep(60)
     method = message.get("method")
     if method == "initialize":
+        if mode == "server-request":
+            server_request_id = 90_001
+            print(json.dumps({
+                "id": server_request_id,
+                "method": "fixture/server/request",
+                "params": {},
+            }), flush=True)
+            reply_line = sys.stdin.readline()
+            assert reply_line
+            reply = json.loads(reply_line)
+            assert "jsonrpc" not in reply
+            assert reply == {
+                "id": server_request_id,
+                "error": {
+                    "code": -32601,
+                    "message": "account-bound adapter does not service requests",
+                },
+            }
         if mode == "escaped-error":
-            print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "error": {"code": -32000, "message": "secret\\quoted"}}), flush=True)
+            print(json.dumps({"id": message["id"], "error": {"code": -32000, "message": "secret\\quoted"}}), flush=True)
             continue
         if mode == "oversized-frame":
             sys.stdout.write("{" + ("x" * (1024 * 1024 + 1)))
@@ -180,7 +199,7 @@ for line in sys.stdin:
             time.sleep(60)
         if mode == "queue-overflow":
             for index in range(100):
-                print(json.dumps({"jsonrpc": "2.0", "method": "unrelated", "params": {"index": index}}), flush=True)
+                print(json.dumps({"method": "unrelated", "params": {"index": index}}), flush=True)
         # Apple's /usr/bin/python3 launcher adds only these toolchain/runtime
         # variables after exec; the parent projection itself is HOME/PATH-only.
         assert set(os.environ).issubset({
@@ -212,9 +231,13 @@ for line in sys.stdin:
         assert message["params"]["accessToken"] == "synthetic-nonsecret-sentinel"
         assert message["params"]["chatgptAccountId"] == "synthetic-provider-sentinel"
         result = (
-            {"unexpected": "synthetic-nonsecret-sentinel"}
+            {"type": "chatgptAuthTokens", "unexpected": "synthetic-nonsecret-sentinel"}
             if mode == "login-extra"
+            else {"type": "chatgpt"}
+            if mode == "login-wrong-type"
             else {}
+            if mode == "login-missing-type"
+            else {"type": "chatgptAuthTokens"}
         )
     elif method == "account/rateLimits/read" and mode == "reset-card":
         assert "params" in message
@@ -263,7 +286,7 @@ for line in sys.stdin:
         if message["params"]["includeTurns"]:
             exact_thread_reads += 1
             if mode == "exact-missing-post-archive-read" and exact_thread_reads > 1:
-                print(json.dumps({"jsonrpc": "2.0", "id": message["id"]}), flush=True)
+                print(json.dumps({"id": message["id"]}), flush=True)
                 continue
             if mode == "exact-oversized-read":
                 sys.stdout.write("{" + ("x" * (1024 * 1024 + 1)))
@@ -286,7 +309,7 @@ for line in sys.stdin:
     elif method == "thread/archive":
         assert message["params"] == {"threadId": exact_thread_id}
         if mode == "exact-unsupported-archive":
-            print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "error": {"code": -32601, "message": "unsupported"}}), flush=True)
+            print(json.dumps({"id": message["id"], "error": {"code": -32601, "message": "unsupported"}}), flush=True)
             continue
         if mode not in ("exact-ambiguous-unapplied", "exact-contradictory-readback"):
             exact_thread["archived"] = True
@@ -300,11 +323,18 @@ for line in sys.stdin:
     elif method == "initialized":
         continue
     else:
-        print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "error": {"code": -32601, "message": "unsupported"}}), flush=True)
+        print(json.dumps({"id": message["id"], "error": {"code": -32601, "message": "unsupported"}}), flush=True)
         continue
     if mode == "exact-wrong-correlation" and method == "thread/list" and "searchTerm" in message["params"]:
-        print(json.dumps({"jsonrpc": "2.0", "id": message["id"] + 1, "result": result}), flush=True)
+        print(json.dumps({"id": message["id"] + 1, "result": result}), flush=True)
     elif mode == "exact-missing-result" and method == "thread/list" and "searchTerm" in message["params"]:
-        print(json.dumps({"jsonrpc": "2.0", "id": message["id"]}), flush=True)
+        print(json.dumps({"id": message["id"]}), flush=True)
     else:
-        print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}), flush=True)
+        response = {"id": message["id"], "result": result}
+        if mode == "legacy-jsonrpc":
+            response["jsonrpc"] = "2.0"
+        elif mode == "wrong-jsonrpc":
+            response["jsonrpc"] = "1.0"
+        elif mode == "null-jsonrpc":
+            response["jsonrpc"] = None
+        print(json.dumps(response), flush=True)

--- a/crates/decodex-runtime/tests/supervised_validation.rs
+++ b/crates/decodex-runtime/tests/supervised_validation.rs
@@ -9,10 +9,12 @@ use std::{
 	time::{Duration, Instant},
 };
 
+#[cfg(target_os = "macos")] use core_foundation as _;
 use decodex_codex as _;
 use decodex_postgres as _;
 use decodex_protocol as _;
 use futures_util as _;
+#[cfg(target_os = "macos")] use security_framework as _;
 use serde as _;
 use serde_json as _;
 use sha2 as _;

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -1108,6 +1108,14 @@ digests rather than optional nickname/role fields. Build identity is an exact op
 fingerprint; statuses, activity kinds, tools, capability reasons, and read-only methods
 are closed enums, so protocol text is not exported through debug or serialization paths.
 
+The Codex app-server JSONL transport uses its native bare envelope. Outbound requests,
+notifications, and request-error replies omit a `jsonrpc` member. Inbound responses can
+omit the member or include the legacy string `"2.0"`; another value, an explicit null, or
+a non-string value fails closed. Credential projection also requires the exact typed
+`chatgptAuthTokens` success result. Exact request digests cover these native wire bytes,
+so a retained-title experiment prepared with the former envelope cannot be resumed as the
+same request and remains safely ambiguous.
+
 The production command opens the canonical `codex` executable and first rejects interpreter-driven
 files. On macOS, only current native 64-bit thin Mach-O images and native 32/64-bit universal Mach-O
 containers cross this boundary. On Linux, only native ELF images cross it, and account-bound launch
@@ -1123,14 +1131,26 @@ The runtime copies the accepted source descriptor into a bounded protected objec
 object for the opaque build identity. On macOS this is a private fsynced mode-0500 file protected by
 `UF_IMMUTABLE`. On Linux it is an fsynced mode-0500 memfd whose contents, size, executable mode, and
 seal set are irreversibly sealed; the runtime verifies every required seal and that
-`/proc/self/fd/<owned-fd>` resolves to the same object. Every version, schema, and app-server spawn
-executes that exact protected object. The Linux descriptor is close-on-exec: it remains open while
-the kernel resolves the native ELF image and is closed atomically on successful exec. Original-path
-identity and digest checks detect pre-launch drift, but are not the check-to-exec security
-primitive. A source replacement after the final verification cannot alter the protected object that
-executes or receives credentials. Failure to create, seal, resolve, or execute the object fails
-closed. This protection assumes the daemon process and its uid are not already compromised. Only
-tests can inject a fake executable. Preflight output/files, generated-schema file count/per-file/aggregate
+`/proc/self/fd/<owned-fd>` resolves to the same object. Linux version, schema, and app-server spawns
+execute the sealed memfd. The descriptor is close-on-exec: it remains open while the kernel resolves
+the native ELF image and is closed atomically on successful exec.
+
+macOS version and schema preflights execute the immutable snapshot. The final macOS app-server must
+use the canonical executable path because process-aware network extensions assign traffic policy to
+the loaded canonical image. The runtime uses `posix_spawn` to create that image in a new session and
+keeps it suspended before user code starts. While it is suspended, the runtime repeats the canonical
+inode and full SHA-256 check. It then requires the kernel dynamic-code object to match the snapshot's
+exact CDHash, canonical path, session, and process group. Only a complete match receives `SIGCONT`.
+The parent protocol endpoints use private, validated FIFOs opened with atomic close-on-exec flags;
+the FIFO names are removed while the child is still suspended. The child restores the default
+`SIGPIPE` disposition and receives only the fixed `HOME` and system `PATH` projection.
+
+Original-path identity and digest checks detect pre-launch drift. On macOS, suspended dynamic-code
+attestation closes the final check-to-exec interval; on Linux, sealed memfd execution is that
+primitive. A source replacement cannot run or receive credentials after the final check. Failure to
+create, seal, resolve, attest, or execute the selected object fails closed. This protection assumes
+the daemon process and its uid are not already compromised. Only tests can inject a fake executable.
+Preflight output/files, generated-schema file count/per-file/aggregate
 bytes/depth, inbound and outbound app-server frames, the stdout queue, collaboration
 receiver count, and thread-list/search results are mechanically bounded; schema traversal
 rejects symlinks and special files. Both preflight commands use bounded process-group

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -680,12 +680,18 @@ For app-server integration work:
 ```sh
 codex app-server generate-json-schema --experimental --out target/decodex-app-server-schema-check
 cargo test -p decodex-codex --all-targets --all-features
+cargo test -p decodex-runtime macos_attested_spawn --lib
 cargo test -p decodex-runtime live_read_only_probe_negotiates_without_dispatch -- --ignored
 ```
 
 Runtime's private supervisor validates the accepted receipt, captures and protects the exact
 executable snapshot, then structurally validates canonical generated-schema digests before
-app-server spawn. The Codex adapter owns the typed schema/capability contracts but exposes no
+app-server spawn. Linux executes the sealed snapshot. macOS runs preflights from the immutable
+snapshot, then starts the canonical final image suspended and checks its full source digest,
+snapshot-rooted CDHash, dynamic path, session, and process group before resume. Private FIFO
+endpoints are atomic close-on-exec and have no live names before user code starts. This canonical
+macOS image preserves process-attributed network-extension routing without moving Reset Card
+ownership into Swift. The Codex adapter owns the typed schema/capability contracts but exposes no
 launch surface.
 Markers are not capability promises. Focused tests cover the golden, exact-build cache
 conflicts, scripted fake server, structural history/collaboration-schema rejection, fixed
@@ -773,6 +779,15 @@ foreground PostgreSQL generation and one daemon generation. PostgreSQL exit or
 endpoint replacement stops the old daemon before the supervisor exits. After an
 atomic legacy account-file replacement, only a changed credential projection stops
 and restarts the daemon so its process-scoped environment receives current values.
+The LaunchAgent uses `KeepAlive = { SuccessfulExit = false }` and `ExitTimeOut=60`.
+For an installed job with that exact contract, the installer sends SIGTERM while the
+job remains loaded, lets the supervisor use its 240-second daemon and 30-second
+PostgreSQL bounds, waits for the job to become inactive, and then removes it. A legacy
+job receives one direct removal fallback, and that removal can use the remaining
+300-second settlement bound instead of the five-second control-command bound. Both paths bind the captured process tree by
+PID and full start time and wait at most 300 seconds before replacement; a concurrent
+removal cannot bypass that wait. PostgreSQL readiness probes name the existing
+`postgres` database so they do not emit missing-default-database warnings.
 The bridge requires the
 same UID, a private parent directory, private regular account and lock files, one
 link per file, bounded input, unique provider identities and email identities, and

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -282,7 +282,16 @@ LaunchAgent. `decodexd supervise-local` owns the PostgreSQL and daemon process
 generations. A PostgreSQL generation change stops the daemon and makes the
 supervisor exit; launchd then starts one new coherent generation. An atomic
 credential-file replacement restarts only the daemon when its injected credential
-projection changes. Swift remains a client and owns none of these effects.
+projection changes. The LaunchAgent restarts only unsuccessful exits and retains a
+60-second final stop timeout. When the installed job has that exact contract, the
+installer first signals the loaded supervisor, waits for its bounded daemon and
+PostgreSQL drain to leave the job inactive, and only then removes the job. The one-time
+legacy path removes the old job directly. Both paths bind observed processes by PID and
+full start time and wait at most 300 seconds before provisioning a replacement. Reset Card
+discovery, account binding, provider access, and typed results remain Rust runtime work.
+On macOS, the runtime starts the final canonical Codex image suspended and verifies it
+against its immutable snapshot before resume so process-aware network extensions can apply
+the correct route. Swift remains a client and owns none of these effects.
 
 ## First commands
 

--- a/scripts/macos/install_decodex_local_service.py
+++ b/scripts/macos/install_decodex_local_service.py
@@ -40,8 +40,13 @@ MAX_ACCOUNT_FILE_BYTES = 4 * 1024 * 1024
 MAX_ACCOUNT_LINE_BYTES = 128 * 1024
 MAX_CONFIG_FILE_BYTES = 1024 * 1024
 MAX_MAPPING_FILE_BYTES = 64 * 1024
+MAX_LAUNCH_AGENT_FILE_BYTES = 64 * 1024
 MAX_POSTGRES_VERSION_BYTES = 16
 LEGACY_LOCK_TIMEOUT_SECONDS = 5
+LOCAL_SERVICE_SETTLEMENT_TIMEOUT_SECONDS = 300
+LOCAL_SERVICE_SETTLEMENT_POLL_SECONDS = 0.25
+LOCAL_SERVICE_CONTROL_TIMEOUT_SECONDS = 5
+LAUNCHCTL_PRINT_NOT_FOUND_STATUS = 113
 MAX_ACCOUNTS = 64
 MAX_ACCESS_TOKEN_BYTES = 64 * 1024
 MAX_ACCOUNT_ID_BYTES = 1_024
@@ -72,6 +77,26 @@ HEX_DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
 class InstallError(RuntimeError):
     """A value-free local-service installation failure."""
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+    process_id: int
+    started_at: str
+
+
+@dataclass(frozen=True)
+class ProcessRecord:
+    parent_id: int
+    identity: ProcessIdentity
+
+
+@dataclass(frozen=True)
+class ServiceObservation:
+    loaded: bool
+    active_process_id: int | None
+    root: ProcessIdentity | None
+    generation: frozenset[ProcessIdentity]
 
 
 @dataclass(frozen=True)
@@ -793,8 +818,10 @@ def render_launch_agent(paths: InstallPaths) -> bytes:
             "PATH": launch_agent_path(paths),
         },
         "RunAtLoad": True,
-        "KeepAlive": True,
-        "ExitTimeOut": 360,
+        # A successful supervised drain leaves the loaded job inactive until the installer
+        # removes it. Unexpected failures remain restartable.
+        "KeepAlive": {"SuccessfulExit": False},
+        "ExitTimeOut": 60,
         "ThrottleInterval": 5,
         "ProcessType": "Background",
         "WorkingDirectory": str(paths.repository),
@@ -1005,6 +1032,8 @@ def wait_for_postgres(paths: InstallPaths, process: subprocess.Popen[Any]) -> No
                 str(paths.socket_directory),
                 "-p",
                 str(POSTGRES_PORT),
+                "-d",
+                "postgres",
             ],
             capture=True,
             check=False,
@@ -1225,26 +1254,240 @@ def migrate_and_provision(paths: InstallPaths, env: dict[str, str]) -> None:
     harness.provision_runtime(POSTGRES_DATABASE, POSTGRES_RUNTIME_ROLE, env)
 
 
-def bootout_service(uid: int) -> None:
-    service = f"gui/{uid}/{LAUNCH_AGENT_LABEL}"
-    completed = run(
-        ["launchctl", "bootout", service],
-        capture=True,
-        check=False,
-    )
-    if completed.returncode != 0:
-        loaded = run(
-            ["launchctl", "print", service],
+def parse_launch_agent_pid(output: str) -> int | None:
+    match = re.search(r"^\s*pid = ([1-9][0-9]*)\s*$", output, re.MULTILINE)
+    return int(match.group(1)) if match is not None else None
+
+
+def settlement_command_timeout(
+    deadline: float,
+    maximum: float = LOCAL_SERVICE_CONTROL_TIMEOUT_SECONDS,
+) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise InstallError("existing local service did not settle")
+    return min(maximum, remaining)
+
+
+def run_settlement_command(
+    command: list[str],
+    deadline: float,
+    failure: str,
+    maximum_timeout: float = LOCAL_SERVICE_CONTROL_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return run(
+            command,
             capture=True,
             check=False,
+            timeout=settlement_command_timeout(deadline, maximum_timeout),
         )
-        if loaded.returncode == 0:
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise InstallError(failure) from error
+
+
+def process_parent_map(deadline: float) -> dict[int, ProcessRecord]:
+    completed = run_settlement_command(
+        ["/bin/ps", "-axo", "pid=,ppid=,lstart="],
+        deadline,
+        "local service process inventory is unavailable",
+    )
+    if completed.returncode != 0:
+        raise InstallError("local service process inventory is unavailable")
+    processes: dict[int, ProcessRecord] = {}
+    for line in completed.stdout.splitlines():
+        fields = line.split()
+        if not fields:
+            continue
+        if (
+            len(fields) < 3
+            or not all(field.isascii() and field.isdecimal() for field in fields[:2])
+        ):
+            raise InstallError("local service process inventory is malformed")
+        process_id, parent_id = (int(field) for field in fields[:2])
+        started_at = " ".join(fields[2:])
+        if (
+            process_id <= 0
+            or parent_id < 0
+            or process_id in processes
+            or len(started_at) > 128
+            or contains_control(started_at)
+        ):
+            raise InstallError("local service process inventory is malformed")
+        processes[process_id] = ProcessRecord(
+            parent_id=parent_id,
+            identity=ProcessIdentity(process_id=process_id, started_at=started_at),
+        )
+    return processes
+
+
+def process_generation(
+    root_process_id: int, processes: dict[int, ProcessRecord]
+) -> frozenset[ProcessIdentity]:
+    if root_process_id not in processes:
+        return frozenset()
+    generation_process_ids = {root_process_id}
+    changed = True
+    while changed:
+        changed = False
+        for process_id, record in processes.items():
+            if (
+                record.parent_id in generation_process_ids
+                and process_id not in generation_process_ids
+            ):
+                generation_process_ids.add(process_id)
+                changed = True
+    return frozenset(
+        processes[process_id].identity for process_id in generation_process_ids
+    )
+
+
+def wait_for_process_generation_exit(
+    process_identities: set[ProcessIdentity], deadline: float
+) -> None:
+    if not process_identities:
+        return
+    while True:
+        current = process_parent_map(deadline)
+        live = {
+            identity
+            for identity in process_identities
+            if current.get(identity.process_id) is not None
+            and current[identity.process_id].identity == identity
+        }
+        if not live:
+            return
+        if time.monotonic() >= deadline:
+            raise InstallError("existing local service did not settle")
+        time.sleep(
+            min(
+                LOCAL_SERVICE_SETTLEMENT_POLL_SECONDS,
+                max(0, deadline - time.monotonic()),
+            )
+        )
+
+
+def installed_launch_agent_supports_graceful_drain(path: Path, uid: int) -> bool:
+    try:
+        body = read_owned_file(
+            path,
+            uid,
+            MAX_LAUNCH_AGENT_FILE_BYTES,
+            "installed LaunchAgent is unavailable",
+        )
+        document = plistlib.loads(body)
+    except (InstallError, ValueError, plistlib.InvalidFileException):
+        return False
+    if not isinstance(document, dict) or document.get("Label") != LAUNCH_AGENT_LABEL:
+        return False
+    keep_alive = document.get("KeepAlive")
+    return (
+        isinstance(keep_alive, dict)
+        and set(keep_alive) == {"SuccessfulExit"}
+        and keep_alive["SuccessfulExit"] is False
+        and type(document.get("ExitTimeOut")) is int
+        and document["ExitTimeOut"] == 60
+    )
+
+
+def observe_service(service: str, deadline: float) -> ServiceObservation:
+    completed = run_settlement_command(
+        ["/bin/launchctl", "print", service],
+        deadline,
+        "local service state is unavailable",
+    )
+    if completed.returncode == LAUNCHCTL_PRINT_NOT_FOUND_STATUS:
+        return ServiceObservation(False, None, None, frozenset())
+    if completed.returncode != 0:
+        raise InstallError("local service state is unavailable")
+    root_process_id = parse_launch_agent_pid(completed.stdout)
+    if root_process_id is None:
+        return ServiceObservation(True, None, None, frozenset())
+    generation = process_generation(root_process_id, process_parent_map(deadline))
+    root = next(
+        (
+            identity
+            for identity in generation
+            if identity.process_id == root_process_id
+        ),
+        None,
+    )
+    return ServiceObservation(True, root_process_id, root, generation)
+
+
+def drain_service(
+    service: str,
+    observation: ServiceObservation,
+    captured: set[ProcessIdentity],
+    deadline: float,
+) -> ServiceObservation:
+    signaled: set[ProcessIdentity] = set()
+    current = observation
+    while current.loaded and current.active_process_id is not None:
+        captured.update(current.generation)
+        if current.root is not None and current.root not in signaled:
+            completed = run_settlement_command(
+                ["/bin/launchctl", "kill", "SIGTERM", service],
+                deadline,
+                "existing local service could not be signaled",
+            )
+            if completed.returncode == 0:
+                signaled.add(current.root)
+            else:
+                after_failure = observe_service(service, deadline)
+                captured.update(after_failure.generation)
+                if after_failure.root == current.root:
+                    raise InstallError("existing local service could not be signaled")
+                current = after_failure
+                continue
+        time.sleep(
+            min(
+                LOCAL_SERVICE_SETTLEMENT_POLL_SECONDS,
+                max(0, deadline - time.monotonic()),
+            )
+        )
+        current = observe_service(service, deadline)
+    captured.update(current.generation)
+    return current
+
+
+def bootout_service(paths: InstallPaths, uid: int) -> None:
+    deadline = time.monotonic() + LOCAL_SERVICE_SETTLEMENT_TIMEOUT_SECONDS
+    service = f"gui/{uid}/{LAUNCH_AGENT_LABEL}"
+    observed = observe_service(service, deadline)
+    generation = set(observed.generation)
+    if installed_launch_agent_supports_graceful_drain(paths.launch_agent, uid):
+        observed = drain_service(service, observed, generation, deadline)
+
+    try:
+        completed = run_settlement_command(
+            ["/bin/launchctl", "bootout", service],
+            deadline,
+            "existing local service could not be stopped",
+            LOCAL_SERVICE_SETTLEMENT_TIMEOUT_SECONDS,
+        )
+    except InstallError:
+        wait_for_process_generation_exit(generation, deadline)
+        raise
+    if completed.returncode != 0:
+        loaded = observe_service(service, deadline)
+        generation.update(loaded.generation)
+        if loaded.loaded:
             raise InstallError("existing local service could not be stopped")
+    wait_for_process_generation_exit(generation, deadline)
 
 
 def bootstrap_service(paths: InstallPaths, uid: int) -> None:
-    run(["launchctl", "bootstrap", f"gui/{uid}", str(paths.launch_agent)])
-    run(["launchctl", "kickstart", "-k", f"gui/{uid}/{LAUNCH_AGENT_LABEL}"])
+    service = f"gui/{uid}/{LAUNCH_AGENT_LABEL}"
+    commands = (
+        ["/bin/launchctl", "bootstrap", f"gui/{uid}", str(paths.launch_agent)],
+        ["/bin/launchctl", "kickstart", service],
+    )
+    for command in commands:
+        try:
+            run(command, timeout=LOCAL_SERVICE_CONTROL_TIMEOUT_SECONDS)
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+            raise InstallError("local service could not be started") from error
 
 
 def query_reset_card(
@@ -1472,7 +1715,7 @@ def main(argv: list[str] | None = None) -> int:
     mapping = render_mapping(enrollments)
     launch_agent = render_launch_agent(paths)
 
-    bootout_service(uid)
+    bootout_service(paths, uid)
     initialize_cluster(paths, uid)
     postgres = start_temporary_postgres(paths)
     try:

--- a/tests/scripts/test_install_decodex_local_service.py
+++ b/tests/scripts/test_install_decodex_local_service.py
@@ -170,7 +170,8 @@ class LocalServiceInstallerTests(unittest.TestCase):
             plist_document["EnvironmentVariables"]["PATH"].split(os.pathsep)[0],
         )
         self.assertNotIn("--secret-run", plist_document["ProgramArguments"])
-        self.assertEqual(360, plist_document["ExitTimeOut"])
+        self.assertEqual({"SuccessfulExit": False}, plist_document["KeepAlive"])
+        self.assertEqual(60, plist_document["ExitTimeOut"])
 
     def test_parser_discovers_codex_without_copying_the_process_environment(self):
         discovered = Path("/Applications/ChatGPT.app/Contents/Resources/codex")
@@ -558,23 +559,404 @@ class LocalServiceInstallerTests(unittest.TestCase):
         self.assertEqual(str(paths.root), command[command.index("--root") + 1])
         self.assertNotIn("private-marker", str(run.call_args))
 
-    def test_bootout_distinguishes_absent_service_from_stop_failure(self):
-        absent = subprocess.CompletedProcess(["launchctl"], 3, "", "not found")
-        with mock.patch.object(
-            self.module,
-            "run",
-            side_effect=[absent, absent],
-        ):
-            self.module.bootout_service(os.geteuid())
+    def test_installed_launch_agent_contract_requires_exact_drain_settings(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            paths.launch_agent.write_bytes(self.module.render_launch_agent(paths))
+            paths.launch_agent.chmod(0o600)
+            self.assertTrue(
+                self.module.installed_launch_agent_supports_graceful_drain(
+                    paths.launch_agent, os.geteuid()
+                )
+            )
 
-        loaded = subprocess.CompletedProcess(["launchctl"], 0, "loaded", "")
-        with mock.patch.object(
-            self.module,
-            "run",
-            side_effect=[absent, loaded],
-        ):
-            with self.assertRaisesRegex(self.module.InstallError, "could not be stopped"):
-                self.module.bootout_service(os.geteuid())
+            legacy = plistlib.loads(self.module.render_launch_agent(paths))
+            legacy["KeepAlive"] = True
+            legacy["ExitTimeOut"] = 360
+            paths.launch_agent.write_bytes(plistlib.dumps(legacy))
+            paths.launch_agent.chmod(0o600)
+            self.assertFalse(
+                self.module.installed_launch_agent_supports_graceful_drain(
+                    paths.launch_agent, os.geteuid()
+                )
+            )
+
+    def test_graceful_contract_drains_loaded_service_before_bootout(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            active = subprocess.CompletedProcess(
+                ["launchctl"], 0, "service = {\n\tpid = 100\n}\n", ""
+            )
+            initial_processes = subprocess.CompletedProcess(
+                ["/bin/ps"],
+                0,
+                "100 1 Sat Jul 25 20:00:00 2026\n"
+                "101 100 Sat Jul 25 20:00:01 2026\n"
+                "200 1 Sat Jul 25 19:00:00 2026\n",
+                "",
+            )
+            signaled = subprocess.CompletedProcess(["launchctl"], 0, "", "")
+            inactive = subprocess.CompletedProcess(
+                ["launchctl"], 0, "service = {\n\tstate = exited\n}\n", ""
+            )
+            stopped = subprocess.CompletedProcess(["launchctl"], 0, "", "")
+            settled = subprocess.CompletedProcess(
+                ["/bin/ps"], 0, "200 1 Sat Jul 25 19:00:00 2026\n", ""
+            )
+
+            with mock.patch.object(
+                self.module,
+                "installed_launch_agent_supports_graceful_drain",
+                return_value=True,
+            ):
+                with mock.patch.object(
+                    self.module,
+                    "run",
+                    side_effect=[
+                        active,
+                        initial_processes,
+                        signaled,
+                        inactive,
+                        stopped,
+                        settled,
+                    ],
+                ) as run:
+                    with mock.patch.object(self.module.time, "sleep") as sleep:
+                        self.module.bootout_service(paths, os.geteuid())
+
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertEqual(
+            [
+                "/bin/launchctl",
+                "kill",
+                "SIGTERM",
+                f"gui/{os.geteuid()}/{self.module.LAUNCH_AGENT_LABEL}",
+            ],
+            commands[2],
+        )
+        self.assertEqual("bootout", commands[4][1])
+        sleep.assert_called_once_with(
+            self.module.LOCAL_SERVICE_SETTLEMENT_POLL_SECONDS
+        )
+
+    def test_legacy_contract_boots_out_then_waits_for_captured_generation(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            active = subprocess.CompletedProcess(
+                ["launchctl"], 0, "service = {\n\tpid = 100\n}\n", ""
+            )
+            initial_processes = subprocess.CompletedProcess(
+                ["/bin/ps"],
+                0,
+                "100 1 Sat Jul 25 20:00:00 2026\n"
+                "101 100 Sat Jul 25 20:00:01 2026\n",
+                "",
+            )
+            stopped = subprocess.CompletedProcess(["launchctl"], 0, "", "")
+            child_still_exiting = subprocess.CompletedProcess(
+                ["/bin/ps"],
+                0,
+                "101 1 Sat Jul 25 20:00:01 2026\n",
+                "",
+            )
+            settled = subprocess.CompletedProcess(["/bin/ps"], 0, "", "")
+
+            with mock.patch.object(
+                self.module,
+                "installed_launch_agent_supports_graceful_drain",
+                return_value=False,
+            ):
+                with mock.patch.object(
+                    self.module,
+                    "run",
+                    side_effect=[
+                        active,
+                        initial_processes,
+                        stopped,
+                        child_still_exiting,
+                        settled,
+                    ],
+                ) as run:
+                    with mock.patch.object(self.module.time, "sleep") as sleep:
+                        self.module.bootout_service(paths, os.geteuid())
+
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertEqual("bootout", commands[2][1])
+        self.assertGreater(
+            run.call_args_list[2].kwargs["timeout"],
+            self.module.LOCAL_SERVICE_CONTROL_TIMEOUT_SECONDS,
+        )
+        self.assertNotIn(
+            "kill", [argument for command in commands for argument in command]
+        )
+        sleep.assert_called_once_with(
+            self.module.LOCAL_SERVICE_SETTLEMENT_POLL_SECONDS
+        )
+
+    def test_nonzero_bootout_with_final_absence_still_waits_for_generation(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            active = subprocess.CompletedProcess(
+                ["launchctl"], 0, "service = {\n\tpid = 100\n}\n", ""
+            )
+            initial_processes = subprocess.CompletedProcess(
+                ["/bin/ps"], 0, "100 1 Sat Jul 25 20:00:00 2026\n", ""
+            )
+            bootout_absent = subprocess.CompletedProcess(
+                ["launchctl"], 3, "", "not found"
+            )
+            print_absent = subprocess.CompletedProcess(
+                ["launchctl"],
+                self.module.LAUNCHCTL_PRINT_NOT_FOUND_STATUS,
+                "",
+                "not found",
+            )
+            still_exiting = subprocess.CompletedProcess(
+                ["/bin/ps"], 0, "100 1 Sat Jul 25 20:00:00 2026\n", ""
+            )
+            settled = subprocess.CompletedProcess(["/bin/ps"], 0, "", "")
+
+            with mock.patch.object(
+                self.module,
+                "installed_launch_agent_supports_graceful_drain",
+                return_value=False,
+            ):
+                with mock.patch.object(
+                    self.module,
+                    "run",
+                    side_effect=[
+                        active,
+                        initial_processes,
+                        bootout_absent,
+                        print_absent,
+                        still_exiting,
+                        settled,
+                    ],
+                ):
+                    with mock.patch.object(self.module.time, "sleep") as sleep:
+                        self.module.bootout_service(paths, os.geteuid())
+
+        sleep.assert_called_once_with(
+            self.module.LOCAL_SERVICE_SETTLEMENT_POLL_SECONDS
+        )
+
+    def test_concurrent_bootout_during_graceful_drain_waits_for_initial_generation(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            active = subprocess.CompletedProcess(
+                ["launchctl"], 0, "service = {\n\tpid = 100\n}\n", ""
+            )
+            initial_processes = subprocess.CompletedProcess(
+                ["/bin/ps"], 0, "100 1 Sat Jul 25 20:00:00 2026\n", ""
+            )
+            kill_absent = subprocess.CompletedProcess(
+                ["launchctl"], 3, "", "not found"
+            )
+            bootout_absent = subprocess.CompletedProcess(
+                ["launchctl"], 3, "", "not found"
+            )
+            print_absent = subprocess.CompletedProcess(
+                ["launchctl"],
+                self.module.LAUNCHCTL_PRINT_NOT_FOUND_STATUS,
+                "",
+                "not found",
+            )
+            still_exiting = subprocess.CompletedProcess(
+                ["/bin/ps"], 0, "100 1 Sat Jul 25 20:00:00 2026\n", ""
+            )
+            settled = subprocess.CompletedProcess(["/bin/ps"], 0, "", "")
+
+            with mock.patch.object(
+                self.module,
+                "installed_launch_agent_supports_graceful_drain",
+                return_value=True,
+            ):
+                with mock.patch.object(
+                    self.module,
+                    "run",
+                    side_effect=[
+                        active,
+                        initial_processes,
+                        kill_absent,
+                        print_absent,
+                        bootout_absent,
+                        print_absent,
+                        still_exiting,
+                        settled,
+                    ],
+                ):
+                    with mock.patch.object(self.module.time, "sleep") as sleep:
+                        self.module.bootout_service(paths, os.geteuid())
+
+        sleep.assert_called_once_with(
+            self.module.LOCAL_SERVICE_SETTLEMENT_POLL_SECONDS
+        )
+
+    def test_pid_reuse_with_a_different_lstart_is_not_the_captured_process(self):
+        captured = {
+            self.module.ProcessIdentity(
+                process_id=100, started_at="Sat Jul 25 20:00:00 2026"
+            )
+        }
+        reused = subprocess.CompletedProcess(
+            ["/bin/ps"], 0, "100 1 Sat Jul 25 20:01:00 2026\n", ""
+        )
+        with mock.patch.object(self.module, "run", return_value=reused) as run:
+            with mock.patch.object(self.module.time, "sleep") as sleep:
+                self.module.wait_for_process_generation_exit(
+                    captured, self.module.time.monotonic() + 300
+                )
+
+        self.assertLessEqual(
+            run.call_args.kwargs["timeout"],
+            self.module.LOCAL_SERVICE_CONTROL_TIMEOUT_SECONDS,
+        )
+        sleep.assert_not_called()
+
+    def test_process_inventory_timeout_is_value_free_and_prevents_bootout(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            active = subprocess.CompletedProcess(
+                ["launchctl"], 0, "service = {\n\tpid = 100\n}\n", ""
+            )
+            timeout = subprocess.TimeoutExpired(["/bin/ps"], 5, "private-output")
+            with mock.patch.object(
+                self.module,
+                "installed_launch_agent_supports_graceful_drain",
+                return_value=False,
+            ):
+                with mock.patch.object(
+                    self.module, "run", side_effect=[active, timeout]
+                ) as run:
+                    with self.assertRaisesRegex(
+                        self.module.InstallError,
+                        "process inventory is unavailable",
+                    ):
+                        self.module.bootout_service(paths, os.geteuid())
+
+        self.assertEqual(2, run.call_count)
+        self.assertEqual("print", run.call_args_list[0].args[0][1])
+
+    def test_launchctl_state_error_is_not_misclassified_as_absence(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            unavailable = subprocess.CompletedProcess(
+                ["launchctl"], 5, "", "private-error"
+            )
+            with mock.patch.object(
+                self.module, "run", return_value=unavailable
+            ) as run:
+                with self.assertRaisesRegex(
+                    self.module.InstallError, "service state is unavailable"
+                ):
+                    self.module.bootout_service(paths, os.geteuid())
+
+        self.assertEqual(1, run.call_count)
+
+    def test_ambiguous_bootout_timeout_waits_for_captured_generation(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            active = subprocess.CompletedProcess(
+                ["launchctl"], 0, "service = {\n\tpid = 100\n}\n", ""
+            )
+            initial_processes = subprocess.CompletedProcess(
+                ["/bin/ps"], 0, "100 1 Sat Jul 25 20:00:00 2026\n", ""
+            )
+            timeout = subprocess.TimeoutExpired(
+                ["/bin/launchctl", "bootout"], 5, "private-output"
+            )
+            settled = subprocess.CompletedProcess(["/bin/ps"], 0, "", "")
+            with mock.patch.object(
+                self.module,
+                "installed_launch_agent_supports_graceful_drain",
+                return_value=False,
+            ):
+                with mock.patch.object(
+                    self.module,
+                    "run",
+                    side_effect=[active, initial_processes, timeout, settled],
+                ) as run:
+                    with self.assertRaisesRegex(
+                        self.module.InstallError, "could not be stopped"
+                    ):
+                        self.module.bootout_service(paths, os.geteuid())
+
+        self.assertEqual(4, run.call_count)
+        self.assertGreater(
+            run.call_args_list[2].kwargs["timeout"],
+            self.module.LOCAL_SERVICE_CONTROL_TIMEOUT_SECONDS,
+        )
+        self.assertEqual("/bin/ps", run.call_args_list[-1].args[0][0])
+
+    def test_bootout_distinguishes_absent_service_from_stop_failure(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            bootout_absent = subprocess.CompletedProcess(
+                ["launchctl"], 3, "", "not found"
+            )
+            print_absent = subprocess.CompletedProcess(
+                ["launchctl"],
+                self.module.LAUNCHCTL_PRINT_NOT_FOUND_STATUS,
+                "",
+                "not found",
+            )
+            with mock.patch.object(
+                self.module,
+                "installed_launch_agent_supports_graceful_drain",
+                return_value=False,
+            ):
+                with mock.patch.object(
+                    self.module,
+                    "run",
+                    side_effect=[print_absent, bootout_absent, print_absent],
+                ):
+                    self.module.bootout_service(paths, os.geteuid())
+
+            loaded = subprocess.CompletedProcess(["launchctl"], 0, "loaded", "")
+            with mock.patch.object(
+                self.module,
+                "installed_launch_agent_supports_graceful_drain",
+                return_value=False,
+            ):
+                with mock.patch.object(
+                    self.module,
+                    "run",
+                    side_effect=[loaded, bootout_absent, loaded],
+                ):
+                    with self.assertRaisesRegex(
+                        self.module.InstallError, "could not be stopped"
+                    ):
+                        self.module.bootout_service(paths, os.geteuid())
+
+    def test_bootstrap_does_not_kill_the_freshly_started_generation(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            with mock.patch.object(self.module, "run") as run:
+                self.module.bootstrap_service(paths, os.geteuid())
+
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertEqual("bootstrap", commands[0][1])
+        self.assertEqual("kickstart", commands[1][1])
+        self.assertNotIn("-k", commands[1])
+        self.assertTrue(
+            all(
+                call.kwargs["timeout"]
+                == self.module.LOCAL_SERVICE_CONTROL_TIMEOUT_SECONDS
+                for call in run.call_args_list
+            )
+        )
+
+    def test_postgres_readiness_uses_the_existing_postgres_database(self):
+        with tempfile.TemporaryDirectory() as temp:
+            paths = self.paths(Path(temp))
+            process = mock.Mock()
+            process.poll.return_value = None
+            ready = subprocess.CompletedProcess([str(paths.pg_isready)], 0, "", "")
+            with mock.patch.object(self.module, "run", return_value=ready) as run:
+                self.module.wait_for_postgres(paths, process)
+
+        command = run.call_args.args[0]
+        self.assertEqual("postgres", command[command.index("-d") + 1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- launch macOS Codex app-server from its canonical signed path under suspended runtime attestation so process-aware network extensions preserve connectivity
- accept the native bare app-server envelope, classify provider transport failures correctly, and keep credential/RPC payloads strict and zeroized
- make LaunchAgent replacement drain exact generations safely and probe the explicit postgres database to remove the readiness warning
- document core ownership and platform-specific execution details

Validation:
- cargo make check (Python 3.12, Xcode beta): passed; 581 workspace tests plus full PostgreSQL aggregate passed
- decodex-runtime all-targets/all-features: 129 passed, 2 ignored
- decodexd all-targets/all-features: passed, including startup SIGTERM cleanup
- installer unit tests: 27 passed
- Swift release tests: 132 passed
- signed macOS staging build: passed
- live branch install: six accounts and six inventory reads available; counts 0,2,2,2,2,3; no new database or provider transport warnings

Dependency review:
- adds exact already-locked core-foundation 0.10.0 and security-framework 3.7.0 direct edges on macOS only
- no new resolved package versions; cargo-audit delta is unchanged from baseline