### PR TITLE
Adapt Codex upstream stable_release c8ea4c7159621712

### DIFF
--- a/crates/decodex-codex/src/schema.rs
+++ b/crates/decodex-codex/src/schema.rs
@@ -708,6 +708,36 @@ mod tests {
 	}
 
 	#[test]
+	fn marker_validation_rejects_the_rust_v0_145_0_schema_digest_set() {
+		let mut marker = SchemaMarker::accepted();
+		for (file, digest) in [
+			(
+				"ClientRequest.json",
+				"92085c18742dd355e5afa7d570170c74629635082e8e3341a952068735dc28b2",
+			),
+			(
+				"ServerNotification.json",
+				"97c6bf194b9edfa1e2ffe62547e4497fa5ea8a1af5c94687956b69966ac6f9e2",
+			),
+			(
+				"codex_app_server_protocol.v2.schemas.json",
+				"27f8d983f19d8e1a5548d52176de0a460fb05aaf2a72110f913c6f4af2bd4f27",
+			),
+		] {
+			marker.canonical_sha256.insert(file.into(), digest.into());
+		}
+
+		assert_eq!(
+			SchemaContract::validate(marker).unwrap_err(),
+			[
+				"digest:ClientRequest.json",
+				"digest:ServerNotification.json",
+				"digest:codex_app_server_protocol.v2.schemas.json",
+			]
+		);
+	}
+
+	#[test]
 	fn canonical_digest_ignores_json_object_order() {
 		let first: serde_json::Value =
 			serde_json::from_str(r#"{"b":2,"a":{"d":4,"c":3}}"#).unwrap();

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -705,7 +705,13 @@ The accepted marker now binds Codex CLI `0.146.0-alpha.3.1` to
 `189dc3b9bf8e96a115cf1102e60c379d8e34382ddca2868d1b2b46847d122166`, and
 aggregate v2 schema digest
 `2ad5e818b870a6a26387678bbe276e4c67b3b078f6ac03143fba623b0969605d`.
-The prior three-digest set is rejected as one incompatible build.
+Codex CLI release `rust-v0.145.0` is rejected as an obsolete exact build. Its
+`ClientRequest.json`, `ServerNotification.json`, and aggregate v2 schema digests are
+`92085c18742dd355e5afa7d570170c74629635082e8e3341a952068735dc28b2`,
+`97c6bf194b9edfa1e2ffe62547e4497fa5ea8a1af5c94687956b69966ac6f9e2`, and
+`27f8d983f19d8e1a5548d52176de0a460fb05aaf2a72110f913c6f4af2bd4f27`.
+No compatibility shim for that release is retained. The previously accepted three-digest
+set is also rejected as an incompatible build.
 The ignored live test is strictly read-only: `initialize`, `initialized`, `account/read`,
 bounded `thread/list(useStateDbOnly=true)`, optional exact-ID
 `thread/read(includeTurns=false)`, and fixed-nonmatching-term bounded `thread/search`.


### PR DESCRIPTION
## Summary

Autonomous Codex upstream adaptation for `stable_release` candidate `c8ea4c7159621712`.

## Source

- Range: `none..25af12f7e61572b0bc18ddb1008be543b91519b0`
- Release: `rust-v0.145.0`
- Codex: `codex-cli 0.146.0-alpha.3.1`
- Contract gaps at discovery: `repository_digest:ClientRequest.json, repository_digest:ServerNotification.json, repository_digest:codex_app_server_protocol.v2.schemas.json`

## Verification

Every validation profile required by the trusted changed-path classification passed for the exact PR head. The independent reviewer repeats the same required profile set before Decodex land is allowed.
