### PR TITLE
Adapt Codex upstream prerelease_release eb7c7ccdc8cd4b02

### DIFF
--- a/crates/decodex-codex/src/schema.rs
+++ b/crates/decodex-codex/src/schema.rs
@@ -738,6 +738,36 @@ mod tests {
 	}
 
 	#[test]
+	fn marker_validation_rejects_the_rust_v0_146_0_alpha_11_schema_digest_set() {
+		let mut marker = SchemaMarker::accepted();
+		for (file, digest) in [
+			(
+				"ClientRequest.json",
+				"6755a5eb5fcc0502a9d3b56c8ebd43a857f2c22820cf9cfa12e2dd0d5d48234c",
+			),
+			(
+				"ServerNotification.json",
+				"28fd2f3e9020a1a26503facff7038f84137c2a0139df8443eab6d63a71deb240",
+			),
+			(
+				"codex_app_server_protocol.v2.schemas.json",
+				"5ff4540622e002308ad5e6bac6df49b7ab5d52d79c8f71537b1098951b946b2d",
+			),
+		] {
+			marker.canonical_sha256.insert(file.into(), digest.into());
+		}
+
+		assert_eq!(
+			SchemaContract::validate(marker).unwrap_err(),
+			[
+				"digest:ClientRequest.json",
+				"digest:ServerNotification.json",
+				"digest:codex_app_server_protocol.v2.schemas.json",
+			]
+		);
+	}
+
+	#[test]
 	fn canonical_digest_ignores_json_object_order() {
 		let first: serde_json::Value =
 			serde_json::from_str(r#"{"b":2,"a":{"d":4,"c":3}}"#).unwrap();

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -710,8 +710,13 @@ Codex CLI release `rust-v0.145.0` is rejected as an obsolete exact build. Its
 `92085c18742dd355e5afa7d570170c74629635082e8e3341a952068735dc28b2`,
 `97c6bf194b9edfa1e2ffe62547e4497fa5ea8a1af5c94687956b69966ac6f9e2`, and
 `27f8d983f19d8e1a5548d52176de0a460fb05aaf2a72110f913c6f4af2bd4f27`.
-No compatibility shim for that release is retained. The previously accepted three-digest
-set is also rejected as an incompatible build.
+Codex CLI prerelease `rust-v0.146.0-alpha.11` is also rejected as an incompatible exact
+build. Its three digests are
+`6755a5eb5fcc0502a9d3b56c8ebd43a857f2c22820cf9cfa12e2dd0d5d48234c`,
+`28fd2f3e9020a1a26503facff7038f84137c2a0139df8443eab6d63a71deb240`, and
+`5ff4540622e002308ad5e6bac6df49b7ab5d52d79c8f71537b1098951b946b2d`.
+No compatibility shim for either release is retained. The previously accepted
+three-digest set is also rejected as an incompatible build.
 The ignored live test is strictly read-only: `initialize`, `initialized`, `account/read`,
 bounded `thread/list(useStateDbOnly=true)`, optional exact-ID
 `thread/read(includeTurns=false)`, and fixed-nonmatching-term bounded `thread/search`.


### PR DESCRIPTION
## Summary

Autonomous Codex upstream adaptation for `prerelease_release` candidate `eb7c7ccdc8cd4b02`.

## Source

- Range: `none..d790c86ddf6aba059897c071b2303179ae20fdd7`
- Release: `rust-v0.146.0-alpha.11`
- Codex: `codex-cli 0.146.0-alpha.3.1`
- Contract gaps at discovery: `repository_digest:ClientRequest.json, repository_digest:ServerNotification.json, repository_digest:codex_app_server_protocol.v2.schemas.json`

## Verification

Every validation profile required by the trusted changed-path classification passed for the exact PR head. The independent reviewer repeats the same required profile set before Decodex land is allowed.
