### PR TITLE
Fix macOS account callback and Reset Card readback

### DIFF
--- a/crates/decodex-codex/src/reset_card.rs
+++ b/crates/decodex-codex/src/reset_card.rs
@@ -536,45 +536,47 @@ impl<'de> Deserialize<'de> for ZeroizingWireText {
 
 fn decode_quota_windows(
 	by_limit_id: Option<&Value>,
-	legacy: Option<&Value>,
+	default_snapshot: Option<&Value>,
 ) -> [AccountRateLimitObservation; 2] {
 	let mut decoded =
 		BTreeMap::<u32, Result<AccountQuotaWindow, AccountQuotaObservationError>>::new();
-	let buckets = by_limit_id
-		.and_then(Value::as_object)
-		.filter(|buckets| !buckets.is_empty())
-		.map(|buckets| buckets.values().collect::<Vec<_>>())
-		.or_else(|| legacy.map(|bucket| vec![bucket]));
-
-	let Some(buckets) = buckets.filter(|buckets| buckets.len() <= 64) else {
+	let bucket = match by_limit_id {
+		Some(Value::Object(buckets)) if buckets.len() <= 64 =>
+			buckets.get("codex").or(default_snapshot),
+		Some(Value::Object(_)) =>
+			return required_quota_errors(AccountQuotaObservationError::ProtocolUnavailable),
+		Some(Value::Null) | None => default_snapshot,
+		Some(_) => return required_quota_errors(AccountQuotaObservationError::ProtocolUnavailable),
+	};
+	let Some(bucket) = bucket else {
 		return required_quota_errors(AccountQuotaObservationError::ProtocolUnavailable);
 	};
-	for bucket in buckets {
-		let Some(bucket) = bucket.as_object() else {
-			return required_quota_errors(AccountQuotaObservationError::ProtocolUnavailable);
+	let Some(bucket) = bucket.as_object() else {
+		return required_quota_errors(AccountQuotaObservationError::ProtocolUnavailable);
+	};
+	for field in ["primary", "secondary"] {
+		let window = match bucket.get(field) {
+			Some(Value::Object(window)) => window,
+			Some(Value::Null) | None => continue,
+			Some(_) =>
+				return required_quota_errors(AccountQuotaObservationError::ProtocolUnavailable),
 		};
-		for field in ["primary", "secondary"] {
-			let Some(window) = bucket.get(field) else { continue };
-			let Some(window) = window.as_object() else {
-				return required_quota_errors(AccountQuotaObservationError::ProtocolUnavailable);
-			};
-			let Some(duration) = window
-				.get("windowDurationMins")
-				.and_then(Value::as_u64)
-				.and_then(|value| u32::try_from(value).ok())
-			else {
-				continue;
-			};
-			if !matches!(
-				duration,
-				AccountQuotaWindow::FIVE_HOURS_MINUTES | AccountQuotaWindow::SEVEN_DAYS_MINUTES
-			) {
-				continue;
-			}
-			let parsed = parse_quota_window(duration, window);
-			if decoded.insert(duration, parsed).is_some() {
-				decoded.insert(duration, Err(AccountQuotaObservationError::ProtocolUnavailable));
-			}
+		let Some(duration) = window
+			.get("windowDurationMins")
+			.and_then(Value::as_u64)
+			.and_then(|value| u32::try_from(value).ok())
+		else {
+			continue;
+		};
+		if !matches!(
+			duration,
+			AccountQuotaWindow::FIVE_HOURS_MINUTES | AccountQuotaWindow::SEVEN_DAYS_MINUTES
+		) {
+			continue;
+		}
+		let parsed = parse_quota_window(duration, window);
+		if decoded.insert(duration, parsed).is_some() {
+			decoded.insert(duration, Err(AccountQuotaObservationError::ProtocolUnavailable));
 		}
 	}
 
@@ -657,7 +659,10 @@ fn map_descriptor_error(error: ResetCardError) -> ResetCardProtocolError {
 mod tests {
 	use std::collections::BTreeSet;
 
-	use decodex_core::{ResetCardConsumeOutcome, ResetCardDescriptor, ResetCardTimestamp};
+	use decodex_core::{
+		AccountQuotaObservationError, AccountQuotaWindow, ResetCardConsumeOutcome,
+		ResetCardDescriptor, ResetCardTimestamp,
+	};
 	use serde_json::{Value, json};
 
 	use crate::{
@@ -684,6 +689,18 @@ mod tests {
 			"rateLimitResetCredits": {
 				"availableCount": available_count,
 				"credits": credits
+			}
+		}))
+		.unwrap()
+	}
+
+	fn inventory_with_limits(rate_limits: Value, rate_limits_by_limit_id: Value) -> Vec<u8> {
+		serde_json::to_vec(&json!({
+			"rateLimits": rate_limits,
+			"rateLimitsByLimitId": rate_limits_by_limit_id,
+			"rateLimitResetCredits": {
+				"availableCount": 0,
+				"credits": []
 			}
 		}))
 		.unwrap()
@@ -742,6 +759,126 @@ mod tests {
 		assert_eq!(
 			inventory.resolve_exact_credit_id(descriptor(100, 200)).unwrap().as_str(),
 			"private-credit"
+		);
+	}
+
+	#[test]
+	fn quota_windows_select_the_canonical_codex_bucket_from_a_multi_bucket_response() {
+		let default_snapshot = json!({
+			"primary": {
+				"usedPercent": 12,
+				"windowDurationMins": 300,
+				"resetsAt": 2_000
+			},
+			"secondary": {
+				"usedPercent": 34,
+				"windowDurationMins": 10_080,
+				"resetsAt": 3_000
+			}
+		});
+		let bytes = inventory_with_limits(
+			default_snapshot.clone(),
+			json!({
+				"codex": default_snapshot,
+				"codex_bengalfox": {
+					"primary": {
+						"usedPercent": 56,
+						"windowDurationMins": 300,
+						"resetsAt": 4_000
+					},
+					"secondary": {
+						"usedPercent": 78,
+						"windowDurationMins": 10_080,
+						"resetsAt": 5_000
+					}
+				}
+			}),
+		);
+		let inventory = decode_reset_card_inventory(&bytes).unwrap();
+
+		assert_eq!(
+			inventory.quota_windows()[0].result(),
+			Ok(AccountQuotaWindow::new(300, 12, 2_000_000_000).unwrap())
+		);
+		assert_eq!(
+			inventory.quota_windows()[1].result(),
+			Ok(AccountQuotaWindow::new(10_080, 34, 3_000_000_000).unwrap())
+		);
+	}
+
+	#[test]
+	fn quota_windows_fall_back_to_the_required_single_bucket_view() {
+		let default_snapshot = json!({
+			"primary": {
+				"usedPercent": 21,
+				"windowDurationMins": 300,
+				"resetsAt": 6_000
+			},
+			"secondary": {
+				"usedPercent": 43,
+				"windowDurationMins": 10_080,
+				"resetsAt": 7_000
+			}
+		});
+		for by_limit_id in [
+			json!(null),
+			json!({
+				"codex_other": {
+					"primary": {
+						"usedPercent": 65,
+						"windowDurationMins": 10_080,
+						"resetsAt": 8_000
+					}
+				}
+			}),
+		] {
+			let bytes = inventory_with_limits(default_snapshot.clone(), by_limit_id);
+			let inventory = decode_reset_card_inventory(&bytes).unwrap();
+
+			assert_eq!(
+				inventory.quota_windows()[0].result(),
+				Ok(AccountQuotaWindow::new(300, 21, 6_000_000_000).unwrap())
+			);
+			assert_eq!(
+				inventory.quota_windows()[1].result(),
+				Ok(AccountQuotaWindow::new(10_080, 43, 7_000_000_000).unwrap())
+			);
+		}
+
+		let malformed = inventory_with_limits(json!({}), json!(["not", "a", "map"]));
+		let inventory = decode_reset_card_inventory(&malformed).unwrap();
+		assert_eq!(
+			inventory.quota_windows()[0].result(),
+			Err(AccountQuotaObservationError::ProtocolUnavailable)
+		);
+		assert_eq!(
+			inventory.quota_windows()[1].result(),
+			Err(AccountQuotaObservationError::ProtocolUnavailable)
+		);
+	}
+
+	#[test]
+	fn nullable_windows_remain_independent_missing_window_observations() {
+		let bytes = inventory_with_limits(
+			json!({
+				"primary": {
+					"usedPercent": 9,
+					"windowDurationMins": 300,
+					"resetsAt": 9_000
+				},
+				"secondary": null
+			}),
+			json!(null),
+		);
+		let inventory = decode_reset_card_inventory(&bytes).unwrap();
+
+		assert_eq!(
+			inventory.quota_windows()[0].result(),
+			Ok(AccountQuotaWindow::new(300, 9, 9_000_000_000).unwrap())
+		);
+		assert_eq!(
+			inventory.quota_windows()[1].result(),
+			Err(AccountQuotaObservationError::UnsupportedWindow)
 		);
 	}
 

--- a/crates/decodex-runtime/src/account_launch/macos_attested_spawn.rs
+++ b/crates/decodex-runtime/src/account_launch/macos_attested_spawn.rs
@@ -43,6 +43,9 @@ use security_framework::os::macos::code_signing::{
 use tempfile::{Builder as TempDirBuilder, TempDir};
 
 const CHILD_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
+pub(super) const PRIVATE_STDIO_STARTUP_ENV: &str =
+	"CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED";
+pub(super) const PRIVATE_STDIO_STARTUP_VALUE: &str = "1";
 const MAX_CODE_IDENTITY_BYTES: usize = 64;
 const DYNAMIC_CODE_LOOKUP_ATTEMPTS: usize = 50;
 const DYNAMIC_CODE_LOOKUP_DELAY: Duration = Duration::from_millis(10);
@@ -219,6 +222,46 @@ pub(super) fn spawn_suspended(
 	working_directory: &Path,
 	home: &Path,
 ) -> io::Result<SuspendedAttestedSpawn> {
+	spawn_suspended_with_environment(
+		identity,
+		args,
+		working_directory,
+		home,
+		SuspendedEnvironment::HomeAndSystemPath,
+	)
+}
+
+/// Spawn the accepted private-stdio profile from the canonical executable and keep it suspended.
+///
+/// This is a closed environment profile. It cannot project caller-selected names or values.
+pub(super) fn spawn_private_stdio_suspended(
+	identity: &AttestedCodeIdentity,
+	args: &[OsString],
+	working_directory: &Path,
+	home: &Path,
+) -> io::Result<SuspendedAttestedSpawn> {
+	spawn_suspended_with_environment(
+		identity,
+		args,
+		working_directory,
+		home,
+		SuspendedEnvironment::PrivateStdioDisabledEphemeral,
+	)
+}
+
+#[derive(Clone, Copy)]
+enum SuspendedEnvironment {
+	HomeAndSystemPath,
+	PrivateStdioDisabledEphemeral,
+}
+
+fn spawn_suspended_with_environment(
+	identity: &AttestedCodeIdentity,
+	args: &[OsString],
+	working_directory: &Path,
+	home: &Path,
+	environment: SuspendedEnvironment,
+) -> io::Result<SuspendedAttestedSpawn> {
 	let spawned_execution_path = identity.execution_path.clone();
 	let executable = os_string(identity.execution_path.as_os_str())?;
 	let working_directory = os_string(working_directory.as_os_str())?;
@@ -230,16 +273,25 @@ pub(super) fn spawn_suspended(
 	let home_environment = environment_entry(b"HOME", home.as_os_str())?;
 	let path_environment = CString::new(format!("PATH={CHILD_PATH}"))
 		.map_err(|_| invalid_input("child PATH contains a NUL byte"))?;
+	let private_stdio_environment = match environment {
+		SuspendedEnvironment::HomeAndSystemPath => None,
+		SuspendedEnvironment::PrivateStdioDisabledEphemeral => Some(environment_entry(
+			PRIVATE_STDIO_STARTUP_ENV.as_bytes(),
+			OsStr::new(PRIVATE_STDIO_STARTUP_VALUE),
+		)?),
+	};
 	let mut argv_pointers = argv
 		.iter()
 		.map(|value| value.as_ptr().cast_mut())
 		.chain(std::iter::once(ptr::null_mut()))
 		.collect::<Vec<_>>();
-	let mut environment_pointers = [
-		home_environment.as_ptr().cast_mut(),
-		path_environment.as_ptr().cast_mut(),
-		ptr::null_mut(),
-	];
+	let mut environment_pointers =
+		[Some(&home_environment), Some(&path_environment), private_stdio_environment.as_ref()]
+			.into_iter()
+			.flatten()
+			.map(|value| value.as_ptr().cast_mut())
+			.chain(std::iter::once(ptr::null_mut()))
+			.collect::<Vec<_>>();
 
 	let protocol = ProtocolFifos::new()?;
 	let mut actions = SpawnFileActions::new()?;
@@ -976,6 +1028,36 @@ mod tests {
 		assert_eq!(environment.len(), 2);
 		assert_eq!(environment.get("HOME"), Some(&working.path().to_str().unwrap()));
 		assert_eq!(environment.get("PATH"), Some(&CHILD_PATH));
+	}
+
+	#[test]
+	fn private_stdio_spawn_uses_canonical_path_and_exact_closed_environment() {
+		let identity = system_identity("/usr/bin/env");
+		let canonical = fs::canonicalize("/usr/bin/env").unwrap();
+		let working = TempDir::new().unwrap();
+		let suspended =
+			spawn_private_stdio_suspended(&identity, &[], working.path(), working.path()).unwrap();
+
+		assert_eq!(suspended.execution_path, canonical);
+
+		let spawned = suspended.attest_and_resume(&identity).unwrap();
+
+		drop(spawned.stdin);
+
+		let mut output = String::new();
+		let mut stdout = spawned.stdout;
+		let mut child = spawned.child;
+
+		stdout.read_to_string(&mut output).unwrap();
+
+		let environment =
+			output.lines().map(|line| line.split_once('=').unwrap()).collect::<BTreeMap<_, _>>();
+
+		assert!(child.wait().unwrap().success());
+		assert_eq!(environment.len(), 3);
+		assert_eq!(environment.get("HOME"), Some(&working.path().to_str().unwrap()));
+		assert_eq!(environment.get("PATH"), Some(&CHILD_PATH));
+		assert_eq!(environment.get(PRIVATE_STDIO_STARTUP_ENV), Some(&PRIVATE_STDIO_STARTUP_VALUE));
 	}
 
 	#[test]

--- a/crates/decodex-runtime/src/account_launch/process.rs
+++ b/crates/decodex-runtime/src/account_launch/process.rs
@@ -50,7 +50,8 @@ use {
 #[cfg(test)] use crate::account_launch::RunnerCapacity;
 #[cfg(target_os = "macos")]
 use crate::account_launch::macos_attested_spawn::{
-	AttestedChild, AttestedCodeIdentity, spawn_suspended,
+	AttestedChild, AttestedCodeIdentity, PRIVATE_STDIO_STARTUP_ENV, PRIVATE_STDIO_STARTUP_VALUE,
+	spawn_private_stdio_suspended, spawn_suspended,
 };
 use crate::account_launch::{
 	RunnerPermit,
@@ -72,10 +73,7 @@ use decodex_codex::{
 	RESET_CARD_READ_METHOD, ResetCardCapabilityProfile, ResetCardCapabilityState,
 	ResetCardConsumeParams, ResetCardConsumeResult, ResetCardIdempotencyKey, ResetCardInventory,
 	ThreadSummary, UnavailableReason,
-	schema::{
-		ACCOUNT_LOGIN_METHOD, GeneratedSchemaEvidence, MAX_SCHEMA_FILE_BYTES, SchemaContract,
-		SchemaMarker,
-	},
+	schema::{GeneratedSchemaEvidence, MAX_SCHEMA_FILE_BYTES, SchemaContract, SchemaMarker},
 };
 use decodex_core::{
 	AccountId, ProcessBootIdentity, ProcessControlKind, ProcessExecutionAuthorization,
@@ -88,7 +86,9 @@ use decodex_postgres::CodexAccountCapabilityAttestation;
 pub const MAX_PROCESS_QUARANTINE: usize = 64;
 
 const CHILD_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
+#[cfg(not(target_os = "macos"))]
 const PRIVATE_STDIO_STARTUP_ENV: &str = "CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED";
+#[cfg(not(target_os = "macos"))]
 const PRIVATE_STDIO_STARTUP_VALUE: &str = "1";
 const PRIVATE_STDIO_CAPABILITY_ID: &str =
 	"codex-app-server-private-stdio-disabled-ephemeral-startup-v1";
@@ -713,7 +713,9 @@ impl AttestedAppServerLaunch {
 			.expect("attested launch always has an account binding")
 	}
 
-	/// Spawn the exact retained image. This method returns an error only before a child exists.
+	/// Spawn the canonical macOS image under snapshot-rooted dynamic attestation.
+	///
+	/// This method returns an error only before a child exists.
 	pub(crate) fn spawn(self) -> Result<AttestedProcessChild, SupervisionError> {
 		if ExactBuildLaunchCapability::attest_profile(&self.command)? != self.capability {
 			return Err(SupervisionError::LaunchCapabilityUnavailable);
@@ -786,6 +788,30 @@ impl AttestedProcessChild {
 		Ok(())
 	}
 
+	/// Initialize one fresh callback-capability child with the synthetic probe credential.
+	///
+	/// Cloud-config's unauthorized response during the synthetic initial login triggers the refresh
+	/// callback. The later inventory read and account readback only prove the installed real
+	/// successor.
+	pub(super) fn initialize_callback_probe(
+		&mut self,
+		vault: &dyn CredentialVault,
+	) -> Result<(), ResetCardProcessError> {
+		if self.initialized {
+			return Err(ResetCardProcessError::ProcessUnavailable);
+		}
+		let reset_profile = ResetCardCapabilityProfile::from_schema(self.generated.contract());
+		if !reset_profile.is_supported() {
+			return Err(ResetCardProcessError::SchemaUnsupported(reset_profile.state()));
+		}
+		let mut cache = CapabilityCache::default();
+		let mut negotiation = ProbeNegotiation::new(&mut cache, &self.build, &self.generated);
+		initialize_probe_projection(&mut self.process, vault, self.timeout, &mut negotiation)
+			.map_err(ResetCardProcessError::from_probe)?;
+		self.initialized = true;
+		Ok(())
+	}
+
 	/// Read one complete inventory and re-attest the immutable account before returning it.
 	pub(super) fn read_reset_card_inventory(
 		&mut self,
@@ -798,35 +824,11 @@ impl AttestedProcessChild {
 		Ok(inventory)
 	}
 
-	/// Prove the exact login, unauthorized refresh callback, and provider readback path once.
+	/// Prove the unauthorized refresh callback and exact successor readback path once.
 	pub(super) fn prove_refresh_callback(&mut self) -> Result<(), ResetCardProcessError> {
 		if !self.initialized {
 			return Err(ResetCardProcessError::ProcessUnavailable);
 		}
-		let provider_account_id = self
-			.process
-			.binding
-			.process_binding()
-			.map_err(ResetCardProcessError::from_supervision)?
-			.credential
-			.provider
-			.account_id()
-			.to_owned();
-		let probe_access_token = callback_probe_access_token(&provider_account_id)?;
-		self.process
-			.request_rpc::<_, CredentialProjectionResponse>(
-				ACCOUNT_LOGIN_METHOD,
-				&ChatgptAuthParams {
-					kind: "chatgptAuthTokens",
-					access_token: probe_access_token.as_str(),
-					chatgpt_account_id: &provider_account_id,
-					chatgpt_plan_type: Some(CALLBACK_PROBE_PLAN_TYPE),
-				},
-				self.timeout,
-			)
-			.map_err(|error| {
-				ResetCardProcessError::from_rpc(error, ResetCardProcessMethod::RefreshProbe)
-			})?;
 		let _ = read_reset_card_inventory(&mut self.process, self.timeout)?;
 		re_attest_reset_card_account(&mut self.process, self.timeout)
 	}
@@ -946,6 +948,20 @@ impl CredentialProjection<'_> {
 			)
 			.map(|_| ())
 			.map_err(|_| CredentialVaultError::ProjectionRejected)
+	}
+
+	/// Authenticate one fresh callback-capability child with the non-secret synthetic probe JWT.
+	pub fn authenticate_callback_probe(
+		&mut self,
+		provider_account_id: &str,
+	) -> Result<(), CredentialVaultError> {
+		let access_token = callback_probe_access_token(provider_account_id)
+			.map_err(|_| CredentialVaultError::ProjectionRejected)?;
+		self.authenticate_chatgpt(
+			access_token.as_str(),
+			provider_account_id,
+			Some(CALLBACK_PROBE_PLAN_TYPE),
+		)
 	}
 }
 
@@ -1263,6 +1279,11 @@ impl SupervisedProcess {
 			let header: InboundHeader = serde_json::from_slice(&line)
 				.map_err(|_| RpcError::Supervision(SupervisionError::InvalidProtocol))?;
 
+			if let (Some(id), Some(method)) = (header.id, header.method.as_deref()) {
+				self.service_inbound_request(id, method, &line).map_err(rpc_supervision)?;
+				continue;
+			}
+
 			if header.id == Some(request_id) {
 				let response_digest = hex_digest(&Sha256::digest(&line));
 				let response: JsonRpcResponse<R> = serde_json::from_slice(&line)
@@ -1301,10 +1322,6 @@ impl SupervisedProcess {
 				if header.method.is_none() {
 					return Err(RpcError::Supervision(SupervisionError::InvalidProtocol));
 				}
-			}
-
-			if let (Some(id), Some(method)) = (header.id, header.method.as_deref()) {
-				self.service_inbound_request(id, method, &line).map_err(rpc_supervision)?;
 			}
 		}
 	}
@@ -1701,23 +1718,58 @@ fn spawn_attested_protocol_process(
 	sender: SyncSender<InboundFrame>,
 	protocol_limit_exceeded: Arc<AtomicBool>,
 ) -> Result<(ProcessGroupOwner, Box<dyn Write + Send>), SupervisionError> {
-	let mut process = configured_attested_app_server_process(command, binding, capability)?;
-	let child = process.spawn().map_err(|_| SupervisionError::SpawnFailed)?;
-	let mut owner = ProcessGroupOwner::new(child, Some(guard));
-	let (stdin, stdout) = match owner.child_mut() {
-		ManagedChild::Standard(child) => {
-			let stdin = child.stdin.take().ok_or(SupervisionError::StdinUnavailable)?;
-			let stdout = child.stdout.take().ok_or(SupervisionError::InvalidProtocol)?;
+	#[cfg(target_os = "macos")]
+	{
+		let identity = command
+			.attested_code_identity
+			.as_ref()
+			.ok_or(SupervisionError::LaunchCapabilityUnavailable)?;
+		let home = binding.expected_codex_home.parent().ok_or(SupervisionError::InvalidBinding)?;
+		let suspended = match capability {
+			ExactBuildLaunchCapability::PrivateStdioDisabledEphemeralStartupV1 =>
+				spawn_private_stdio_suspended(
+					identity,
+					&command.app_server_args,
+					&command.working_directory,
+					home,
+				),
+		}
+		.map_err(|_| SupervisionError::SpawnFailed)?;
 
-			(stdin, stdout)
-		},
-		#[cfg(target_os = "macos")]
-		ManagedChild::Attested(_) => unreachable!("configured spawn created a standard child"),
-	};
-	let pump = StdoutPump::start(stdout, sender, protocol_limit_exceeded)?;
-	owner.attach_pump(pump);
+		// The canonical source must still match the immutable snapshot after posix_spawn has
+		// bound the suspended child. Dynamic attestation then binds that child to the snapshot's
+		// exact code identity and canonical path before any user code can run.
+		verify_executable(command)?;
 
-	Ok((owner, Box::new(stdin)))
+		let spawned =
+			suspended.attest_and_resume(identity).map_err(|_| SupervisionError::SpawnFailed)?;
+		let mut owner = ProcessGroupOwner::new(ManagedChild::Attested(spawned.child), Some(guard));
+		let pump = StdoutPump::start(spawned.stdout, sender, protocol_limit_exceeded)?;
+		owner.attach_pump(pump);
+
+		return Ok((owner, Box::new(spawned.stdin)));
+	}
+
+	#[cfg(not(target_os = "macos"))]
+	{
+		let mut process = configured_attested_app_server_process(command, binding, capability)?;
+		let child = process.spawn().map_err(|_| SupervisionError::SpawnFailed)?;
+		let mut owner = ProcessGroupOwner::new(child, Some(guard));
+		let (stdin, stdout) = match owner.child_mut() {
+			ManagedChild::Standard(child) => {
+				let stdin = child.stdin.take().ok_or(SupervisionError::StdinUnavailable)?;
+				let stdout = child.stdout.take().ok_or(SupervisionError::InvalidProtocol)?;
+
+				(stdin, stdout)
+			},
+			#[cfg(target_os = "macos")]
+			ManagedChild::Attested(_) => unreachable!("configured spawn created a standard child"),
+		};
+		let pump = StdoutPump::start(stdout, sender, protocol_limit_exceeded)?;
+		owner.attach_pump(pump);
+
+		Ok((owner, Box::new(stdin)))
+	}
 }
 
 /// Typed result from `initialize` plus a bounded `thread/list`; no raw JSON escapes.
@@ -1989,7 +2041,6 @@ impl Debug for ResetCardConsumeReadback {
 pub(super) enum ResetCardProcessMethod {
 	InventoryRead,
 	Consume,
-	RefreshProbe,
 }
 
 /// Sanitized reset-card process failure.
@@ -3733,6 +3784,7 @@ fn run_after_verification_test(_command: &AppServerCommand) {
 	}
 }
 
+#[cfg(not(target_os = "macos"))]
 fn configured_app_server_process(
 	command: &AppServerCommand,
 	binding: &AccountBinding,
@@ -3756,6 +3808,7 @@ fn configured_app_server_process(
 	Ok(process)
 }
 
+#[cfg(not(target_os = "macos"))]
 fn configured_attested_app_server_process(
 	command: &AppServerCommand,
 	binding: &AccountBinding,
@@ -3781,7 +3834,7 @@ fn attested_launch_identity(
 	let mut digest = Sha256::new();
 
 	hash_launch_field(&mut digest, b"schema", b"decodex/attested-app-server-launch/1");
-	hash_launch_field(&mut digest, b"exec-policy", b"protected-snapshot-v1");
+	hash_launch_field(&mut digest, b"exec-policy", b"macos-canonical-suspended-v1");
 	hash_launch_field(&mut digest, b"platform", STDIO_ONLY_ATTESTED_PLATFORM.as_bytes());
 	hash_launch_field(
 		&mut digest,
@@ -3939,6 +3992,48 @@ fn initialize_probe(
 	timeout: Duration,
 	negotiation: &mut ProbeNegotiation<'_>,
 ) -> Result<AccountIdentity, ProbeError> {
+	if let Some(vault) = vault {
+		initialize_probe_projection(process, vault, timeout, negotiation)?;
+	} else {
+		initialize_probe_connection(process, timeout, negotiation)?;
+	}
+
+	let identity = match process.read_account_identity(timeout) {
+		Ok(identity) => identity,
+		Err(error) => return negotiation.fail(Capability::AccountRead, error),
+	};
+
+	negotiation.observe(Capability::AccountRead, LiveMethodOutcome::Supported);
+
+	Ok(identity)
+}
+
+fn initialize_probe_projection(
+	process: &mut SupervisedProcess,
+	vault: &dyn CredentialVault,
+	timeout: Duration,
+	negotiation: &mut ProbeNegotiation<'_>,
+) -> Result<(), ProbeError> {
+	initialize_probe_connection(process, timeout, negotiation)?;
+	let account_id = process.binding.account_id().clone();
+	let mut projection = CredentialProjection { process, timeout, used: false };
+	let expected =
+		vault.project(&account_id, &mut projection).map_err(ProbeError::CredentialVault)?;
+
+	if !projection.used {
+		return Err(ProbeError::CredentialVault(CredentialVaultError::Unavailable));
+	}
+
+	projection.process.expected_account_identity = Some(expected);
+
+	Ok(())
+}
+
+fn initialize_probe_connection(
+	process: &mut SupervisedProcess,
+	timeout: Duration,
+	negotiation: &mut ProbeNegotiation<'_>,
+) -> Result<(), ProbeError> {
 	let initialize = match process.request::<_, InitializeResponse>(
 		ReadOnlyMethod::Initialize,
 		&InitializeParams {
@@ -3960,27 +4055,8 @@ fn initialize_probe(
 	if let Err(error) = process.notify("initialized", &serde_json::json!({})) {
 		return negotiation.fail(Capability::Initialize, error);
 	}
-	if let Some(vault) = vault {
-		let account_id = process.binding.account_id().clone();
-		let mut projection = CredentialProjection { process, timeout, used: false };
-		let expected =
-			vault.project(&account_id, &mut projection).map_err(ProbeError::CredentialVault)?;
 
-		if !projection.used {
-			return Err(ProbeError::CredentialVault(CredentialVaultError::Unavailable));
-		}
-
-		projection.process.expected_account_identity = Some(expected);
-	}
-
-	let identity = match process.read_account_identity(timeout) {
-		Ok(identity) => identity,
-		Err(error) => return negotiation.fail(Capability::AccountRead, error),
-	};
-
-	negotiation.observe(Capability::AccountRead, LiveMethodOutcome::Supported);
-
-	Ok(identity)
+	Ok(())
 }
 
 pub(super) fn launch_retained_title_process(
@@ -4310,10 +4386,10 @@ fn attest_executable_for_home(
 
 fn protected_spawn_path(command: &AppServerCommand) -> PathBuf {
 	// macOS 27 terminates relocated Apple platform binaries such as /usr/bin/python3 before their
-	// test fixture can start. Production Codex images remain relocatable and always use the
-	// protected snapshot here. Unit fixtures execute their already-verified canonical interpreter
-	// while still exercising snapshot capture, digest verification, immutability, and cleanup
-	// mechanics.
+	// test fixture can start. Production version/schema preflights execute the protected snapshot;
+	// the final macOS app-server instead uses canonical suspended dynamic attestation. Unit
+	// fixtures execute their already-verified canonical interpreter while still exercising
+	// snapshot capture, digest verification, immutability, and cleanup mechanics.
 	#[cfg(all(test, target_os = "macos"))]
 	return command.test_spawn_path.clone().unwrap_or_else(|| command.program.clone());
 
@@ -4603,8 +4679,9 @@ mod tests {
 	use crate::account_launch::{
 		RunnerCapacity, RunnerPermit,
 		process::{
-			self, AccountBinding, AccountIdentity, AppServerCommand, CALLBACK_PROBE_EMAIL,
-			CALLBACK_PROBE_PLAN_TYPE, CALLBACK_PROBE_SIGNATURE, CredentialProjection,
+			self, AccountBinding, AccountIdentity, AccountRefreshCallback, AppServerCommand,
+			AttestedProcessChild, CALLBACK_PROBE_EMAIL, CALLBACK_PROBE_PLAN_TYPE,
+			CALLBACK_PROBE_SIGNATURE, ChatgptRefreshProjection, CredentialProjection,
 			CredentialProjectionResponse, CredentialVault, CredentialVaultError,
 			ExactThreadReconciler, ExactThreadReconciliation, ExactThreadReconciliationResult,
 			PROTOCOL_QUEUE_CAPACITY, ProbeError, ProcessQuarantine, ReadOnlyMethod, ReadOnlyProbe,
@@ -4623,7 +4700,11 @@ mod tests {
 		ExactThreadListFilter, ResetCardCapabilityState, ResetCardIdempotencyKey, SchemaMarker,
 		ThreadArchivedFilter, UnavailableReason, UnsupportedReason,
 	};
-	use decodex_core::{AccountId, ResetCardConsumeOutcome};
+	use decodex_core::{
+		AccountId, AccountOperationId, AccountProvider, CredentialBinding, CredentialFingerprint,
+		CredentialStoreSchemaVersion, CredentialVersion, ProcessGenerationAccountBinding,
+		ProviderIdentity, ResetCardConsumeOutcome,
+	};
 
 	struct TestCapacity {
 		inner: RunnerCapacity,
@@ -4684,6 +4765,67 @@ mod tests {
 			}
 
 			Ok(AccountIdentity::from_observation("chatgpt", Some(self.expected_email), true))
+		}
+	}
+
+	struct CallbackProbeFixtureVault;
+	impl CredentialVault for CallbackProbeFixtureVault {
+		fn project(
+			&self,
+			account_id: &AccountId,
+			projection: &mut CredentialProjection<'_>,
+		) -> Result<AccountIdentity, CredentialVaultError> {
+			assert_eq!(account_id, binding().account_id());
+			projection.authenticate_callback_probe("callback-provider-account")?;
+			Ok(AccountIdentity::from_observation("chatgpt", Some("private@example.test"), true))
+		}
+	}
+
+	#[derive(Default)]
+	struct FixtureRefreshCallback {
+		calls: AtomicU32,
+	}
+	impl AccountRefreshCallback for FixtureRefreshCallback {
+		fn refresh(
+			&self,
+			account_id: &AccountId,
+			initial_binding: &ProcessGenerationAccountBinding,
+			reason: &str,
+			previous_provider_account_id: Option<&str>,
+		) -> Result<ChatgptRefreshProjection, CredentialVaultError> {
+			assert_eq!(account_id, binding().account_id());
+			assert_eq!(
+				initial_binding.credential.provider.account_id(),
+				"callback-provider-account"
+			);
+			assert_eq!(reason, "unauthorized");
+			assert_eq!(previous_provider_account_id, Some("callback-provider-account"));
+			self.calls.fetch_add(1, Ordering::AcqRel);
+			ChatgptRefreshProjection::new(
+				"synthetic-successor-token".to_owned(),
+				"callback-provider-account".to_owned(),
+				Some("business".to_owned()),
+			)
+		}
+	}
+
+	fn callback_binding(callback: Arc<dyn AccountRefreshCallback>) -> AccountBinding {
+		let credential = CredentialBinding {
+			schema_version: CredentialStoreSchemaVersion::V1,
+			version: CredentialVersion::new(1).unwrap(),
+			fingerprint: CredentialFingerprint::new("1".repeat(64)).unwrap(),
+			provider: ProviderIdentity::new(AccountProvider::Chatgpt, "callback-provider-account")
+				.unwrap(),
+			writer_operation_id: AccountOperationId::new("20000000-0000-4000-8000-000000000001")
+				.unwrap(),
+		};
+		AccountBinding {
+			account_id: binding().account_id().clone(),
+			expected_codex_home: PathBuf::from("/tmp/.codex"),
+			process_binding: Some(
+				ProcessGenerationAccountBinding::new(1, credential, "2".repeat(64)).unwrap(),
+			),
+			refresh_callback: Some(callback),
 		}
 	}
 
@@ -4771,7 +4913,7 @@ mod tests {
 		if mode == "preflight-uncertain-schema" {
 			schema_args.push("--preflight-hang".into());
 		}
-		if mode == "reset-card" {
+		if matches!(mode, "reset-card" | "callback-probe") {
 			schema_args.push("--reset-card".into());
 		}
 
@@ -4983,17 +5125,19 @@ mod tests {
 
 	#[test]
 	fn app_server_request_receives_bare_error_reply_before_probe_continues() {
-		let temp = TempDir::new().unwrap();
-		let result = ReadOnlyProbe::new_for_test(
-			fake_command("server-request", temp.path(), None),
-			binding(),
-			SchemaMarker::accepted(),
-			Duration::from_secs(2),
-		)
-		.run(&mut CapabilityCache::default())
-		.unwrap();
+		for mode in ["server-request", "server-request-id-collision"] {
+			let temp = TempDir::new().unwrap();
+			let result = ReadOnlyProbe::new_for_test(
+				fake_command(mode, temp.path(), None),
+				binding(),
+				SchemaMarker::accepted(),
+				Duration::from_secs(2),
+			)
+			.run(&mut CapabilityCache::default())
+			.unwrap();
 
-		assert_eq!(result.profile.state(Capability::Initialize), &CapabilityState::Supported);
+			assert_eq!(result.profile.state(Capability::Initialize), &CapabilityState::Supported);
+		}
 	}
 
 	#[test]
@@ -5061,6 +5205,41 @@ mod tests {
 
 		assert_eq!(readback.outcome, ResetCardConsumeOutcome::Reset);
 		assert_eq!(readback.inventory.available_count(), 0);
+		assert_eq!(capacity.active(), 0);
+	}
+
+	#[test]
+	fn callback_probe_uses_one_initial_synthetic_login_then_re_attests_the_real_successor() {
+		let temp = TempDir::new().unwrap();
+		let timeout = Duration::from_secs(2);
+		let capacity = TestCapacity::new(1);
+		let command = fake_command("callback-probe", temp.path(), None);
+		let callback = Arc::new(FixtureRefreshCallback::default());
+		let process_binding =
+			callback_binding(Arc::clone(&callback) as Arc<dyn AccountRefreshCallback>);
+		let (build, generated, guard) = process::attest_executable(
+			&command,
+			&process_binding,
+			None,
+			timeout,
+			Some(capacity.reserve().unwrap()),
+		)
+		.unwrap();
+		let process = SupervisedProcess::spawn_bound(
+			command,
+			process_binding,
+			guard.expect("the test supplied one runner permit"),
+		)
+		.unwrap();
+		let mut child =
+			AttestedProcessChild { process, build, generated, timeout, initialized: false };
+
+		child.initialize_callback_probe(&CallbackProbeFixtureVault).unwrap();
+		child.prove_refresh_callback().unwrap();
+
+		assert_eq!(callback.calls.load(Ordering::Acquire), 1);
+		let AttestedProcessChild { process, .. } = child;
+		process.shutdown(Duration::from_secs(1)).unwrap();
 		assert_eq!(capacity.active(), 0);
 	}
 

--- a/crates/decodex-runtime/src/account_launch/reset_card.rs
+++ b/crates/decodex-runtime/src/account_launch/reset_card.rs
@@ -48,8 +48,9 @@ use super::{
 	CapacityExhausted, RunnerCapacity,
 	process::{
 		AccountBinding, AccountIdentity, AccountRefreshCallback, AppServerCommand,
-		AttestedAppServerLaunch, ChatgptRefreshProjection, CredentialProjection, CredentialVault,
-		CredentialVaultError, ResetCardConsumeReadback, ResetCardProcessError,
+		AttestedAppServerLaunch, AttestedProcessChild, ChatgptRefreshProjection,
+		CredentialProjection, CredentialVault, CredentialVaultError, ResetCardConsumeReadback,
+		ResetCardProcessError,
 	},
 };
 
@@ -81,6 +82,12 @@ const _: () = assert!(
 const WORKER_IDLE_POLL: Duration = Duration::from_secs(5);
 const RETENTION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 const RECONCILIATION_DELAY: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Copy)]
+enum InitialCredentialProjection {
+	Stored,
+	CallbackProbe,
+}
 
 /// Complete public inventory plus the exact account revision observed around process work.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -406,6 +413,7 @@ impl ResetCardRuntime {
 			Arc::clone(&provider_permit),
 			None,
 			None,
+			InitialCredentialProjection::CallbackProbe,
 		)
 		.await?;
 		let control = self.inner.process_generations.clone();
@@ -1069,6 +1077,7 @@ async fn run_inventory(
 		Arc::clone(&provider_permit),
 		reconciliation,
 		claim_permit.clone(),
+		InitialCredentialProjection::Stored,
 	)
 	.await?;
 	let control = inner.process_generations.clone();
@@ -1105,6 +1114,7 @@ async fn run_consume(
 		Arc::clone(&provider_permit),
 		Some(reconciliation),
 		Some(claim_permit.clone()),
+		InitialCredentialProjection::Stored,
 	)
 	.await?;
 	let control = inner.process_generations.clone();
@@ -1131,6 +1141,7 @@ async fn prepare_fenced_reset_process(
 	provider_permit: Arc<ProviderWorkPermit>,
 	reconciliation: Option<ResetCardReconciliationLaunch>,
 	claim_permit: Option<ClaimWorkPermit>,
+	initial_projection: InitialCredentialProjection,
 ) -> Result<FencedProcess, ResetCardServiceError> {
 	let generated =
 		AccountOperationId::generate().map_err(|_| ResetCardServiceError::ResourceExhausted)?;
@@ -1158,7 +1169,8 @@ async fn prepare_fenced_reset_process(
 			refresh_callback,
 		)
 		.map_err(|_| ResetCardServiceError::ProviderUnavailable)?;
-		let vault = StoredCredentialVault::new(account_id.clone(), credential.stored);
+		let vault =
+			StoredCredentialVault::new(account_id.clone(), credential.stored, initial_projection);
 		let launch_guard = credential.launch_guard;
 		let capacity_permit = capacity
 			.reserve(account_id, account_revision)
@@ -1198,7 +1210,7 @@ async fn prepare_fenced_reset_process(
 	let initialized = task::spawn_blocking(move || {
 		require_provider_work_start(&permit_for_init, claim_permit.as_ref())?;
 		control
-			.with_fenced_child(&process_for_init, |child| child.initialize_reset_card(&vault))
+			.with_fenced_child(&process_for_init, |child| vault.initialize(child))
 			.map_err(map_process_supervisor_error)?
 			.map_err(map_process_error)
 	})
@@ -1570,10 +1582,22 @@ impl Debug for AccountServiceRefreshCallback {
 struct StoredCredentialVault {
 	account_id: AccountId,
 	stored: StoredCredential,
+	initial_projection: InitialCredentialProjection,
 }
 impl StoredCredentialVault {
-	fn new(account_id: AccountId, stored: StoredCredential) -> Self {
-		Self { account_id, stored }
+	fn new(
+		account_id: AccountId,
+		stored: StoredCredential,
+		initial_projection: InitialCredentialProjection,
+	) -> Self {
+		Self { account_id, stored, initial_projection }
+	}
+
+	fn initialize(&self, child: &mut AttestedProcessChild) -> Result<(), ResetCardProcessError> {
+		match self.initial_projection {
+			InitialCredentialProjection::Stored => child.initialize_reset_card(self),
+			InitialCredentialProjection::CallbackProbe => child.initialize_callback_probe(self),
+		}
 	}
 }
 impl CredentialVault for StoredCredentialVault {
@@ -1587,11 +1611,15 @@ impl CredentialVault for StoredCredentialVault {
 		}
 		let binding = self.stored.binding();
 		let bundle = self.stored.bundle();
-		projection.authenticate_chatgpt(
-			bundle.access_token(),
-			binding.provider.account_id(),
-			bundle.plan_type(),
-		)?;
+		match self.initial_projection {
+			InitialCredentialProjection::Stored => projection.authenticate_chatgpt(
+				bundle.access_token(),
+				binding.provider.account_id(),
+				bundle.plan_type(),
+			)?,
+			InitialCredentialProjection::CallbackProbe =>
+				projection.authenticate_callback_probe(binding.provider.account_id())?,
+		}
 
 		Ok(AccountIdentity::from_observation("chatgpt", Some(bundle.provider_email()), true))
 	}

--- a/crates/decodex-runtime/tests/fixtures/fake_app_server.py
+++ b/crates/decodex-runtime/tests/fixtures/fake_app_server.py
@@ -194,6 +194,8 @@ if mode == "crash":
     raise SystemExit(17)
 
 account_reads = 0
+login_count = 0
+callback_serviced = False
 exact_thread_id = "thread:XY-1317/non-uuid_Case-Sensitive._~:@+$,;=[]{}()!%&'*? #"
 exact_thread = {
     "id": exact_thread_id,
@@ -213,8 +215,10 @@ for line in sys.stdin:
         time.sleep(60)
     method = message.get("method")
     if method == "initialize":
-        if mode == "server-request":
-            server_request_id = 90_001
+        if mode in ("server-request", "server-request-id-collision"):
+            server_request_id = (
+                message["id"] if mode == "server-request-id-collision" else 90_001
+            )
             print(json.dumps({
                 "id": server_request_id,
                 "method": "fixture/server/request",
@@ -264,13 +268,48 @@ for line in sys.stdin:
         }
     elif method == "account/read":
         account_reads += 1
-        email = "changed@example.test" if mode == "account-switch" and account_reads > 1 else "private@example.test"
+        email = (
+            "changed@example.test"
+            if mode == "account-switch" and account_reads > 1
+            else "decodex-callback-capability-probe.invalid"
+            if mode == "callback-probe" and not callback_serviced
+            else "private@example.test"
+        )
         account = None if mode == "account-none" else {"type": "chatgpt", "email": email}
         result = {"account": account, "requiresOpenaiAuth": True}
     elif method == "account/login/start":
+        login_count += 1
         assert message["params"]["type"] == "chatgptAuthTokens"
-        assert message["params"]["accessToken"] == "synthetic-nonsecret-sentinel"
-        assert message["params"]["chatgptAccountId"] == "synthetic-provider-sentinel"
+        if mode == "callback-probe":
+            assert login_count == 1
+            assert message["params"]["accessToken"] != "synthetic-successor-token"
+            assert message["params"]["accessToken"].count(".") == 2
+            assert message["params"]["chatgptAccountId"] == "callback-provider-account"
+            assert message["params"]["chatgptPlanType"] == "business"
+            assert not callback_serviced
+            print(json.dumps({
+                "id": message["id"],
+                "method": "account/chatgptAuthTokens/refresh",
+                "params": {
+                    "reason": "unauthorized",
+                    "previousAccountId": "callback-provider-account",
+                },
+            }), flush=True)
+            reply_line = sys.stdin.readline()
+            assert reply_line
+            reply = json.loads(reply_line)
+            assert reply == {
+                "id": message["id"],
+                "result": {
+                    "accessToken": "synthetic-successor-token",
+                    "chatgptAccountId": "callback-provider-account",
+                    "chatgptPlanType": "business",
+                },
+            }
+            callback_serviced = True
+        else:
+            assert message["params"]["accessToken"] == "synthetic-nonsecret-sentinel"
+            assert message["params"]["chatgptAccountId"] == "synthetic-provider-sentinel"
         result = (
             {"type": "chatgptAuthTokens", "unexpected": "synthetic-nonsecret-sentinel"}
             if mode == "login-extra"
@@ -280,9 +319,11 @@ for line in sys.stdin:
             if mode == "login-missing-type"
             else {"type": "chatgptAuthTokens"}
         )
-    elif method == "account/rateLimits/read" and mode == "reset-card":
+    elif method == "account/rateLimits/read" and mode in ("reset-card", "callback-probe"):
         assert "params" in message
         assert message["params"] is None
+        if mode == "callback-probe":
+            assert callback_serviced
         credits = [] if reset_card_consumed else [{
             "id": "fixture-reset-credit",
             "grantedAt": 1700000000,
@@ -379,3 +420,7 @@ for line in sys.stdin:
         elif mode == "null-jsonrpc":
             response["jsonrpc"] = None
         print(json.dumps(response), flush=True)
+
+if mode == "callback-probe":
+    assert login_count == 1
+    assert callback_serviced

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -550,14 +550,17 @@ V23 adds the durable ProcessGeneration owner described in
 [the XY-1400 authority specification](../specs/process-generation-authority.md). PostgreSQL
 commits one account-exclusive `starting` intent before `ProcessSupervisor` can receive a fresh
 spawn fence. Replay is readback only. One private `AttestedAppServerLaunch` retains the protected
-executable snapshot and derives the intent's account and launch-manifest hash. That hash binds the
-exact image and BuildId, command, fixed `app-server --stdio` arguments, working directory,
-clear-then-set environment, account, initial account revision, canonical credential
-version/fingerprint, provider binding, and exact-build startup/lifetime/account-callback
-capability. The same non-secret facts are part of the existing V23 intent, prepare fence,
-ready transition, and strict readback. No new ledger is added. The supervisor accepts no
-independent runner digest or raw `Command`. After spawn, it persists the exact boot, PID,
-process-start, process-group, and session identities.
+executable reference snapshot and canonical macOS execution identity, then derives the intent's
+account and launch-manifest hash. That hash binds the exact image and BuildId, canonical-suspended
+execution policy, command, fixed `app-server --stdio` arguments, working directory, clear-then-set
+environment, account, initial account revision, canonical credential version/fingerprint, provider
+binding, and exact-build startup/lifetime/account-callback capability. The same non-secret facts
+are part of the existing V23 intent, prepare fence, ready transition, and strict readback. No new
+ledger is added. The supervisor accepts no independent runner digest or raw `Command`. The
+immutable snapshot supplies preflight bytes and the static code-identity reference. The final
+macOS app-server executes the canonical image while suspended and resumes only after exact dynamic
+code, path, session, and process-group verification. After spawn, the supervisor persists the exact
+boot, PID, process-start, process-group, and session identities.
 
 The current launch profile accepts only the source-attested macOS
 `codex-cli 0.146.0-alpha.3.1` image and forces
@@ -1228,8 +1231,12 @@ projection only.
 Before any reset-card read or consume, the Codex adapter requires the generated schema to
 advertise both `account/rateLimits/read` and
 `account/rateLimitResetCredit/consume`. It attests the configured account in an isolated
-app-server process and accepts only a complete, unique inventory. A client selects a public
-descriptor. The daemon resolves its one current opaque provider credit ID.
+app-server process and accepts only a complete, unique inventory. Quota decoding selects
+the upstream `codex` limit-ID snapshot, or the required default snapshot when that map
+entry is absent. It never merges unrelated limit-ID buckets. A null quota window becomes
+an independent unsupported-duration result and does not invalidate another duration. A
+client selects a public descriptor. The daemon resolves its one current opaque provider
+credit ID.
 
 The consume path commits the logical command, account UUID and revision, public
 descriptor, provider idempotency key, and then the exact provider credit ID before it
@@ -1401,7 +1408,8 @@ inode and full SHA-256 check. It then requires the kernel dynamic-code object to
 exact CDHash, canonical path, session, and process group. Only a complete match receives `SIGCONT`.
 The parent protocol endpoints use private, validated FIFOs opened with atomic close-on-exec flags;
 the FIFO names are removed while the child is still suspended. The child restores the default
-`SIGPIPE` disposition and receives only the fixed `HOME` and system `PATH` projection.
+`SIGPIPE` disposition and receives only the fixed `HOME`, system `PATH`, and
+`CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1` projection.
 
 Original-path identity and digest checks detect pre-launch drift. On macOS, suspended dynamic-code
 attestation closes the final check-to-exec interval; on Linux, sealed memfd execution is that

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -878,8 +878,9 @@ snapshot, then starts the canonical final image suspended and checks its full so
 snapshot-rooted CDHash, dynamic path, session, and process group before resume. Private FIFO
 endpoints are atomic close-on-exec and have no live names before user code starts. This canonical
 macOS image preserves process-attributed network-extension routing without moving Reset Card
-ownership into Swift. The Codex adapter owns the typed schema/capability contracts but exposes no
-launch surface.
+ownership into Swift. The child receives only the fixed `HOME`, system `PATH`, and
+`CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1` projection. The Codex adapter owns the typed
+schema/capability contracts but exposes no launch surface.
 Markers are not capability promises. Focused tests cover the golden, exact-build cache
 conflicts, scripted fake server, structural history/collaboration-schema rejection, fixed
 production command construction, bounded executable/preflight/schema/frame/queue/result

--- a/openwiki/specs/process-generation-authority.md
+++ b/openwiki/specs/process-generation-authority.md
@@ -66,19 +66,21 @@ facts agree:
 - the environment policy is clear-then-set with exact `HOME`, `PATH`, and
   `CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1` startup-state values;
 - the exact-build profile derives one macOS private-stdio lifetime capability; and
-- the working directory and protected snapshot remain inside the opaque authority.
+- the working directory, protected reference snapshot, and canonical macOS execution identity
+  remain inside the opaque authority.
 
-The launch-manifest SHA-256 binds its schema, protected-snapshot execution policy,
-platform, control and session-isolation kinds, `BuildId`, exact image digest, command
-identity, ordered arguments, working directory, complete sanitized environment,
-account, initial account revision, canonical credential version and fingerprint,
-provider binding, and exact-build account capability. `ProcessSupervisor` derives
-durable `runner_identity` from this object. Its spawn API accepts no
-caller-supplied runner digest, raw `Command`, command arguments, environment, account,
-or control kind. After a fresh fence, the object re-attests the retained profile,
-constructs the command internally, and executes the same protected snapshot.
-Unsupported platform, argument, and image profiles reject before a profile-dependent
-version or schema preflight can spawn a child.
+The launch-manifest SHA-256 binds its schema, macOS canonical-suspended execution policy,
+platform, control and session-isolation kinds, `BuildId`, exact image digest, command identity,
+ordered arguments, working directory, complete sanitized environment, account, initial account
+revision, canonical credential version and fingerprint, provider binding, and exact-build account
+capability. `ProcessSupervisor` derives durable `runner_identity` from this object. Its spawn API
+accepts no caller-supplied runner digest, raw `Command`, command arguments, environment, account, or
+control kind. After a fresh fence, the object re-attests the retained profile and constructs the
+command internally. On macOS, version and schema preflights execute the protected snapshot. The
+final app-server executes the canonical image while suspended, and it resumes only after the
+snapshot-rooted dynamic code identity, canonical path, session, and process group match.
+Unsupported platform, argument, and image profiles reject before a profile-dependent version or
+schema preflight can spawn a child.
 
 The current accepted profile is intentionally narrow:
 
@@ -87,7 +89,7 @@ The current accepted profile is intentionally narrow:
 | Platform evidence | macOS arm64 |
 | Version | `codex-cli 0.146.0-alpha.3.1` |
 | Executable SHA-256 | `6d8be49e49751554df16572369e636cbe02c84b208cad3dc35528c846eeca223` |
-| Command | protected snapshot with argv0 set to the resolved Codex path and fixed `app-server --stdio` arguments |
+| Command | canonical Codex path as both executable and argv0, suspended before user code, with fixed `app-server --stdio` arguments |
 | Startup state | `CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1` selects `DisabledEphemeral`; no remote-control argument |
 | Protocol boundary | Child stdin and stdout remain private to `ProcessSupervisor`; `FencedProcess` returns no protocol handle |
 | Capability | `codex-app-server-private-stdio-disabled-ephemeral-startup-v1` |
@@ -289,7 +291,7 @@ tree without enabling provider effects or production dispatch.
 | Manifest refreeze | Capture PostgreSQL 18 source S0, restore R1, and second restore R2. Require S0=R1 and R1=R2. Regenerate and accept complete V23 schema and configured-authority digests. Remove the temporary `process_generation` exclusion that keeps the accepted V22 digest base during this source-only slice. |
 | ACL and catalog hostility | Prove the expected 81 relations, 172 functions, 70 safety functions, 147 triggers, 62 runtime-callable functions, five new enums, exact ownership, no PUBLIC authority, no runtime relation DML, no grant option, closed dependencies, hostile `search_path`, overload/default-ACL rejection, and populated restore parity. |
 | State machine | Exercise every legal transition. Reject every illegal transition, combined bind/state transition, identity rewrite, partial identity, history rewrite, deletion, truncation, explicit-null or stale revision, cross-generation evidence, and malformed evidence shape. |
-| Opaque launch mismatch | Prove that callers cannot mismatch runner identity, executable image, command, argv0, fixed arguments, working directory, environment, account, initial account revision, credential version/fingerprint, provider binding, BuildId, or exact-build capability. Prove that only the retained protected snapshot can reach exec. |
+| Opaque launch mismatch | Prove that callers cannot mismatch runner identity, executable image, command, argv0, fixed arguments, working directory, environment, account, initial account revision, credential version/fingerprint, provider binding, BuildId, or exact-build capability. Prove that macOS preflights execute only the retained protected snapshot and that the final app-server executes only the canonical path after snapshot-rooted suspended dynamic attestation. |
 | Credential binding and readback | Rotate, remove, replace, disable, or change the provider between prepare, fence, spawn, callback, and ready. Every stale combination rejects or quarantines without a second launch. Intent, manifest, V23 row, transition readback, and diagnostics agree on the canonical non-secret binding. No credential material is stored. |
 | Exact-build private stdio | For each accepted profile, prove fixed `app-server --stdio`, environment clearing, the exact startup marker, absence of a remote-control argument, `DisabledEphemeral` startup selection, no raw stdin/stdout or generic protocol writer in any returned capability, and rejection of changed images, versions, arguments, environment, or capability. Prove the exact `account/chatgptAuthTokens/refresh` callback round trip and reject unknown callback methods or shapes. Unsupported profiles reject before version/schema preflight spawn. The gateway source-rejects alternate-control RPCs before enablement. |
 | Fence concurrency | Exercise replay, changed-intent conflict, same-account competitors, credential rotation, provider disagreement, different-account progress, epoch retirement, account deletion, transaction abort, deadlock, serialization failure, lost commit result, and restart. Only one fresh fence can authorize spawn. |


### PR DESCRIPTION
## Outcome
- start the canonical Codex app-server under suspended macOS attestation so account refresh callbacks reach the bound Account Service
- dispatch app-server callbacks before client-response correlation
- decode quota windows from the canonical `codex` bucket without merging unrelated limit IDs
- keep nullable 300/10080 windows independent

## Validation
- `cargo make fmt-check`
- fixed-prefix `cargo make check-rust`
- `cargo test -p decodex-codex` (49 passed)
- focused macOS spawn/callback tests (11 passed)
- Swift release suite (82 passed)
- local-service/wrapper Python suites with a canonical private TMPDIR (32 passed)
- live read-only proof: all 6 accounts ready, all 6 weekly windows current, no Reset Card consumed

Independent exact-diff review: APPROVED/READY, no P0/P1/P2, proportionality proceed.