### PR TITLE
Restore compact all-account Reset Card panel

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -21,7 +21,10 @@ runs one independent `reset-card list` request for each row. A slow or failed
 provider request affects only its account row. Each row displays the exact
 300-minute and 10,080-minute quota observations, their current, stale, unknown,
 or error state, the percentage used and reset time when known, and every public
-Reset Card descriptor.
+Reset Card descriptor. The panel uses compact divider-separated rows so the
+normal six-account pool fits in one scan. A provider-unsupported quota duration
+is a muted row-local fact; it does not present the account or Reset Card service
+as failed.
 
 The app never identifies an account from its label or vector position. The
 canonical account UUID is the only row identity.

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
@@ -2,14 +2,14 @@ import AppKit
 import SwiftUI
 
 enum AccountPanelLayout {
+	static let accountListScrollSpace = "account-list-scroll"
 	static let screenVerticalMargin: CGFloat = 44
 	static let panelVerticalPadding: CGFloat = 18
-	static let panelWidth: CGFloat = 344
-	static let minimumAccountListHeight: CGFloat = 150
-	static let maximumAccountListHeight: CGFloat = 620
-	static let estimatedAccountRowHeight: CGFloat = 142
-	static let accountRowSpacing: CGFloat = 6
-	static let fixedChromeHeight: CGFloat = 116
+	static let panelWidth: CGFloat = 322
+	static let minimumAccountListHeight: CGFloat = 68
+	static let maximumAccountListHeight: CGFloat = 520
+	static let estimatedAccountRowHeight: CGFloat = 72
+	static let fixedChromeHeight: CGFloat = 96
 
 	static func activeScreenVisibleHeight() -> CGFloat {
 		let mouseLocation = NSEvent.mouseLocation
@@ -22,6 +22,7 @@ enum AccountPanelLayout {
 
 	static func accountListHeight(
 		accountCount: Int,
+		measuredContentHeight: CGFloat,
 		windowVisibleFrame: CGRect?,
 	) -> CGFloat {
 		let visibleHeight = resolvedScreenVisibleHeight(
@@ -34,12 +35,15 @@ enum AccountPanelLayout {
 		)
 		let rowCount = max(1, accountCount)
 		let contentEstimate = CGFloat(rowCount) * estimatedAccountRowHeight
-			+ CGFloat(max(0, rowCount - 1)) * accountRowSpacing
+		let contentHeight = resolvedAccountListContentHeight(
+			measured: measuredContentHeight,
+			estimated: contentEstimate
+		)
 
 		return min(
 			maximumAccountListHeight,
 			screenBound,
-			max(minimumAccountListHeight, contentEstimate)
+			max(minimumAccountListHeight, contentHeight)
 		)
 	}
 
@@ -64,5 +68,63 @@ enum AccountPanelLayout {
 			return fallback
 		}
 		return windowVisibleFrame.height
+	}
+}
+
+struct AccountScrollOffsetPreferenceKey: PreferenceKey {
+	static let defaultValue: CGFloat = 0
+
+	static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+		value = nextValue()
+	}
+}
+
+struct AccountRowsHeightPreferenceKey: PreferenceKey {
+	static let defaultValue: CGFloat = 0
+
+	static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+		let next = nextValue()
+		if next > 0 {
+			value = next
+		}
+	}
+}
+
+struct AccountListScrollIndicatorView: View {
+	let contentHeight: CGFloat
+	let viewportHeight: CGFloat
+	let scrollOffset: CGFloat
+	@Environment(\.colorScheme) private var colorScheme
+
+	var body: some View {
+		if contentHeight > viewportHeight + 1 {
+			ZStack(alignment: .top) {
+				Capsule(style: .continuous)
+					.fill(PanelPalette.secondaryText(colorScheme).opacity(0.12))
+					.frame(width: 3, height: viewportHeight)
+
+				Capsule(style: .continuous)
+					.fill(
+						PanelPalette.secondaryText(colorScheme)
+							.opacity(colorScheme == .dark ? 0.42 : 0.34)
+					)
+					.frame(width: 3.5, height: thumbHeight)
+					.offset(y: thumbOffset)
+			}
+			.frame(width: 8, height: viewportHeight)
+			.allowsHitTesting(false)
+		}
+	}
+
+	private var thumbHeight: CGFloat {
+		max(30, viewportHeight * min(1, viewportHeight / max(contentHeight, 1)))
+	}
+
+	private var thumbOffset: CGFloat {
+		let maxScrollOffset = max(1, contentHeight - viewportHeight)
+		let maxThumbOffset = max(0, viewportHeight - thumbHeight)
+		let progress = min(1, max(0, scrollOffset / maxScrollOffset))
+
+		return maxThumbOffset * progress
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -5,6 +5,8 @@ struct AccountPanelView: View {
 	let store: ResetCardStore
 	@Environment(\.colorScheme) private var colorScheme
 	@State private var panelScreenVisibleFrame: CGRect?
+	@State private var measuredAccountListContentHeight: CGFloat = 0
+	@State private var accountScrollOffset: CGFloat = 0
 
 	var body: some View {
 		GlassEffectContainer(spacing: 6) {
@@ -37,6 +39,9 @@ struct AccountPanelView: View {
 				}
 			}
 		}
+		// Re-key the singleton panel, rather than every repeated glass row, when
+		// system appearance changes.
+		.id(colorScheme == .dark ? "account-panel-dark" : "account-panel-light")
 	}
 
 	private var header: some View {
@@ -106,24 +111,92 @@ struct AccountPanelView: View {
 		if store.accounts.isEmpty {
 			emptyOrLoadingState
 		} else {
-			ScrollView(.vertical, showsIndicators: true) {
-				LazyVStack(alignment: .leading, spacing: AccountPanelLayout.accountRowSpacing) {
-					ForEach(store.accounts) { state in
+			ScrollView(.vertical, showsIndicators: false) {
+				VStack(alignment: .leading, spacing: 0) {
+					ForEach(Array(store.accounts.enumerated()), id: \.element.id) { index, state in
 						ResetCardAccountRow(
 							state: state,
 							store: store
 						)
+
+						if index < store.accounts.count - 1 {
+							Rectangle()
+								.fill(PanelPalette.separator(colorScheme))
+								.frame(height: 0.5)
+								.padding(.horizontal, 7)
+								.allowsHitTesting(false)
+						}
 					}
 				}
-				.padding(.trailing, 2)
+				.background(accountScrollProbe)
+				.background(accountRowsHeightProbe)
 			}
+			.coordinateSpace(name: AccountPanelLayout.accountListScrollSpace)
 			.frame(
-				height: AccountPanelLayout.accountListHeight(
-					accountCount: store.accounts.count,
-					windowVisibleFrame: panelScreenVisibleFrame
-				)
+				height: accountListViewportHeight
 			)
+			.overlay(alignment: .trailing) {
+				AccountListScrollIndicatorView(
+					contentHeight: accountListContentHeight,
+					viewportHeight: accountListViewportHeight,
+					scrollOffset: accountScrollOffset
+				)
+				.padding(.trailing, 1)
+			}
+			.onPreferenceChange(AccountScrollOffsetPreferenceKey.self) { minY in
+				let maximumOffset = max(0, accountListContentHeight - accountListViewportHeight)
+				accountScrollOffset = min(max(0, -minY), maximumOffset)
+			}
+			.onPreferenceChange(AccountRowsHeightPreferenceKey.self) { height in
+				let measuredHeight = ceil(height)
+				if abs(measuredAccountListContentHeight - measuredHeight) > 0.5 {
+					measuredAccountListContentHeight = measuredHeight
+				}
+			}
+			.onChange(of: accountListNeedsScrolling) { _, needsScrolling in
+				if needsScrolling == false {
+					accountScrollOffset = 0
+				}
+			}
 			.accessibilityLabel("Decodex accounts")
+		}
+	}
+
+	private var accountListContentHeight: CGFloat {
+		AccountPanelLayout.resolvedAccountListContentHeight(
+			measured: measuredAccountListContentHeight,
+			estimated: CGFloat(max(1, store.accounts.count))
+				* AccountPanelLayout.estimatedAccountRowHeight
+		)
+	}
+
+	private var accountListViewportHeight: CGFloat {
+		AccountPanelLayout.accountListHeight(
+			accountCount: store.accounts.count,
+			measuredContentHeight: measuredAccountListContentHeight,
+			windowVisibleFrame: panelScreenVisibleFrame
+		)
+	}
+
+	private var accountListNeedsScrolling: Bool {
+		accountListContentHeight > accountListViewportHeight + 1
+	}
+
+	private var accountScrollProbe: some View {
+		GeometryReader { proxy in
+			Color.clear.preference(
+				key: AccountScrollOffsetPreferenceKey.self,
+				value: proxy.frame(in: .named(AccountPanelLayout.accountListScrollSpace)).minY
+			)
+		}
+	}
+
+	private var accountRowsHeightProbe: some View {
+		GeometryReader { proxy in
+			Color.clear.preference(
+				key: AccountRowsHeightPreferenceKey.self,
+				value: proxy.size.height
+			)
 		}
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/PanelGlassSurface.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelGlassSurface.swift
@@ -8,7 +8,6 @@ struct ModernGlassSurfaceModifier: ViewModifier {
 	@ViewBuilder
 	func body(content: Content) -> some View {
 		let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-		let appearanceID = colorScheme == .dark ? "dark" : "light"
 
 		content
 			.background {
@@ -29,9 +28,6 @@ struct ModernGlassSurfaceModifier: ViewModifier {
 				x: 0,
 				y: shadowY
 			)
-			// Menu-bar glass layers can keep a stale material across system appearance flips.
-			// Re-key only the surface wrapper so light/dark changes redraw immediately.
-			.id(appearanceID)
 	}
 
 	var configuredGlass: Glass {

--- a/apps/decodex-app/Sources/DecodexApp/PanelPalette.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelPalette.swift
@@ -13,6 +13,12 @@ enum PanelPalette {
 			: Color(red: 0.34, green: 0.38, blue: 0.45).opacity(0.8)
 	}
 
+	static func separator(_ colorScheme: ColorScheme) -> Color {
+		colorScheme == .dark
+			? Color.white.opacity(0.065)
+			: Color(red: 0.32, green: 0.38, blue: 0.46).opacity(0.14)
+	}
+
 	static func actionBlue(_ colorScheme: ColorScheme) -> Color {
 		colorScheme == .dark
 			? Color(red: 0.86, green: 0.89, blue: 0.94)

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -110,14 +110,13 @@ struct ResetCardAccountRow: View {
 	@State private var confirmationSecondsRemaining = 0
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 7) {
+		VStack(alignment: .leading, spacing: 4) {
 			accountHeader
 			quotaWindows
 			cardInventory
 		}
-		.padding(.horizontal, 8)
-		.padding(.vertical, 7)
-		.modernGlassSurface(cornerRadius: 10, depth: .row)
+		.padding(.horizontal, 7)
+		.padding(.vertical, 5)
 		.onAppear {
 			confirmation.retainOnly(Set(state.targets))
 		}
@@ -134,17 +133,21 @@ struct ResetCardAccountRow: View {
 	}
 
 	private var accountHeader: some View {
-		HStack(alignment: .firstTextBaseline, spacing: 6) {
+		HStack(alignment: .center, spacing: 5) {
 			Text(state.account.displayLabel)
 				.font(PanelFont.accountName)
 				.foregroundStyle(PanelPalette.primaryText(colorScheme))
 				.lineLimit(1)
 				.truncationMode(.middle)
+				.layoutPriority(1)
+				.help("Account \(state.account.accountID)")
 
-			Text("…\(state.account.accountID.suffix(8))")
+			Text("…\(state.account.accountID.suffix(6))")
 				.font(PanelFont.tertiary)
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 				.monospaced()
+				.fixedSize(horizontal: true, vertical: false)
+				.accessibilityHidden(true)
 
 			Spacer(minLength: 3)
 
@@ -154,11 +157,23 @@ struct ResetCardAccountRow: View {
 					.help("Refreshing this account")
 			}
 
+			Circle()
+				.fill(accountStatusColor)
+				.frame(width: 4, height: 4)
+				.accessibilityHidden(true)
+
 			Text(state.account.statusLabel)
 				.font(PanelFont.tertiary)
 				.foregroundStyle(accountStatusColor)
 				.lineLimit(1)
 		}
+		.accessibilityElement(children: .ignore)
+		.accessibilityLabel(accountAccessibilityLabel)
+	}
+
+	private var accountAccessibilityLabel: String {
+		let refreshState = state.isRefreshing ? ", refreshing" : ""
+		return "Account \(state.account.displayLabel), \(state.account.accountID), \(state.account.statusLabel)\(refreshState)"
 	}
 
 	private var accountStatusColor: Color {
@@ -179,13 +194,19 @@ struct ResetCardAccountRow: View {
 	}
 
 	private var quotaWindows: some View {
-		HStack(spacing: 6) {
+		HStack(spacing: 7) {
 			ResetCardQuotaWindowView(
-				title: "5 hour",
+				title: "5h",
 				window: state.fiveHourQuota
 			)
+
+			Rectangle()
+				.fill(PanelPalette.separator(colorScheme))
+				.frame(width: 0.5, height: 19)
+				.allowsHitTesting(false)
+
 			ResetCardQuotaWindowView(
-				title: "7 day",
+				title: "7d",
 				window: state.sevenDayQuota
 			)
 		}
@@ -197,34 +218,47 @@ struct ResetCardAccountRow: View {
 			Text(error.presentation)
 				.font(PanelFont.tertiary)
 				.foregroundStyle(PanelPalette.destructive(colorScheme))
-				.fixedSize(horizontal: false, vertical: true)
+				.lineLimit(1)
+				.help(error.presentation)
 		} else if let error = state.error {
 			Text(error.localizedDescription)
 				.font(PanelFont.tertiary)
 				.foregroundStyle(PanelPalette.destructive(colorScheme))
-				.fixedSize(horizontal: false, vertical: true)
+				.lineLimit(1)
+				.help(error.localizedDescription)
 		} else if state.isRefreshing, state.inventory == nil {
-			Text("Loading Reset Cards")
-				.font(PanelFont.tertiary)
-				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+			HStack(spacing: 5) {
+				ProgressView()
+					.controlSize(.mini)
+				Text("Loading Reset Cards")
+					.font(PanelFont.tertiary)
+					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+			}
 		} else if state.targets.isEmpty {
 			Text("No available Reset Cards")
 				.font(PanelFont.tertiary)
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 		} else {
-			ScrollView(.horizontal, showsIndicators: false) {
-				HStack(spacing: 5) {
-					ForEach(state.targets, id: \.self) { target in
-						Button {
-							tap(target)
-						} label: {
-							cardChip(target)
+			HStack(spacing: 5) {
+				Text("Cards")
+					.font(PanelFont.tertiary)
+					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+					.fixedSize(horizontal: true, vertical: false)
+
+				ScrollView(.horizontal, showsIndicators: false) {
+					HStack(spacing: 4) {
+						ForEach(Array(state.targets.enumerated()), id: \.element) { index, target in
+							Button {
+								tap(target)
+							} label: {
+								cardChip(target, ordinal: index + 1)
+							}
+							.buttonStyle(.plain)
+							.disabled(store.blocksNewAttempt(for: target))
+							.accessibilityLabel(accessibilityLabel(target, ordinal: index + 1))
+							.accessibilityHint(accessibilityHint(target))
+							.help(help(target))
 						}
-						.buttonStyle(.plain)
-						.disabled(store.blocksNewAttempt(for: target))
-						.accessibilityLabel(accessibilityLabel(target))
-						.accessibilityHint(accessibilityHint(target))
-						.help(help(target))
 					}
 				}
 			}
@@ -235,31 +269,19 @@ struct ResetCardAccountRow: View {
 		confirmation.isSubmitting ? nil : confirmation.armedAttempt
 	}
 
-	private func cardChip(_ target: ResetCardUseTarget) -> some View {
-		VStack(alignment: .leading, spacing: 1) {
-			Text(cardChipTitle(target))
-				.font(PanelFont.usageValue)
-				.foregroundStyle(
-					confirmation.isArmed(target)
-						? PanelPalette.warning(colorScheme)
-						: PanelPalette.primaryText(colorScheme).opacity(0.9)
-				)
-				.monospacedDigit()
-				.lineLimit(1)
-
-			if confirmation.isArmed(target) == false,
-				confirmation.isSubmitting(target) == false
-			{
-				Text(cardWindow(target.descriptor))
-					.font(PanelFont.tertiary)
-					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-					.monospacedDigit()
-					.lineLimit(1)
-			}
-		}
-		.fixedSize(horizontal: true, vertical: false)
-		.padding(.horizontal, 6)
-		.padding(.vertical, 3)
+	private func cardChip(_ target: ResetCardUseTarget, ordinal: Int) -> some View {
+		Text(cardChipTitle(target, ordinal: ordinal))
+			.font(PanelFont.usageValue)
+			.foregroundStyle(
+				confirmation.isArmed(target)
+					? PanelPalette.warning(colorScheme)
+					: PanelPalette.primaryText(colorScheme).opacity(0.9)
+			)
+			.monospacedDigit()
+			.lineLimit(1)
+			.fixedSize(horizontal: true, vertical: false)
+		.padding(.horizontal, 5)
+		.padding(.vertical, 2)
 		.background(
 			confirmation.isArmed(target)
 				? PanelPalette.warning(colorScheme).opacity(colorScheme == .dark ? 0.2 : 0.14)
@@ -269,34 +291,34 @@ struct ResetCardAccountRow: View {
 		.contentShape(Rectangle())
 	}
 
-	private func cardChipTitle(_ target: ResetCardUseTarget) -> String {
+	private func cardChipTitle(_ target: ResetCardUseTarget, ordinal: Int) -> String {
 		if confirmation.isSubmitting(target) {
-			return "Using"
+			return "Using \(ordinal)…"
 		}
 		if confirmation.isArmed(target) {
 			let seconds = confirmationSecondsRemaining > 0
 				? confirmationSecondsRemaining
 				: Self.confirmationWindowSeconds
-			return "Confirm Use · \(seconds)s"
+			return "Confirm \(ordinal) · \(seconds)s"
 		}
 
-		return "Reset Card"
+		return "\(ordinal) · \(Self.cardDateRange(target.descriptor))"
 	}
 
 	private func cardWindow(_ descriptor: ResetCardDescriptor) -> String {
-		"\(Self.cardDate(descriptor.grantedAtUnixSeconds)) → \(Self.cardDate(descriptor.expiresAtUnixSeconds))"
+		"\(Self.cardDateTime(descriptor.grantedAtUnixSeconds)) → \(Self.cardDateTime(descriptor.expiresAtUnixSeconds))"
 	}
 
-	private func accessibilityLabel(_ target: ResetCardUseTarget) -> String {
+	private func accessibilityLabel(_ target: ResetCardUseTarget, ordinal: Int) -> String {
 		let window = cardWindow(target.descriptor)
 		if confirmation.isSubmitting(target) {
-			return "Using Reset Card, \(window)"
+			return "Using Reset Card \(ordinal), \(window)"
 		}
 		if confirmation.isArmed(target) {
-			return "Confirm use of Reset Card, \(window)"
+			return "Confirm use of Reset Card \(ordinal), \(window)"
 		}
 
-		return "Reset Card, \(window)"
+		return "Reset Card \(ordinal), \(window)"
 	}
 
 	private func accessibilityHint(_ target: ResetCardUseTarget) -> String {
@@ -387,15 +409,73 @@ struct ResetCardAccountRow: View {
 		return Int(components.seconds) + (components.attoseconds > 0 ? 1 : 0)
 	}
 
-	private static func cardDate(_ unixSeconds: Int64) -> String {
+	private static func cardDateRange(_ descriptor: ResetCardDescriptor) -> String {
+		let granted = Date(timeIntervalSince1970: TimeInterval(descriptor.grantedAtUnixSeconds))
+		let expires = Date(timeIntervalSince1970: TimeInterval(descriptor.expiresAtUnixSeconds))
+		let grantedDay = granted.formatted(.dateTime.month(.abbreviated).day())
+		let expiryDay = expires.formatted(.dateTime.month(.abbreviated).day())
+		return "\(grantedDay)→\(expiryDay)"
+	}
+
+	private static func cardDateTime(_ unixSeconds: Int64) -> String {
 		let date = Date(timeIntervalSince1970: TimeInterval(unixSeconds))
-		return date.formatted(
-			Date.FormatStyle()
-				.month(.abbreviated)
-				.day()
+		let day = date.formatted(.dateTime.month(.abbreviated).day())
+		let time = date.formatted(
+			.dateTime
 				.hour(.twoDigits(amPM: .omitted))
 				.minute(.twoDigits)
 		)
+		return "\(day) \(time)"
+	}
+}
+
+enum ResetCardQuotaPresentationTone: Equatable {
+	case current
+	case warning
+	case muted
+	case error
+}
+
+struct ResetCardQuotaPresentation: Equatable {
+	let valueText: String
+	let detailText: String?
+	let tone: ResetCardQuotaPresentationTone
+	let usedPercent: UInt8?
+	let resetDate: Date?
+
+	init(window: ResetCardQuotaWindow) {
+		switch window.state {
+		case .current(let usedPercent, _):
+			valueText = "\(usedPercent)% used"
+			detailText = nil
+			tone = .current
+			self.usedPercent = usedPercent
+			resetDate = window.resetDate
+		case .stale(let usedPercent, _):
+			valueText = "\(usedPercent)% stale"
+			detailText = nil
+			tone = .warning
+			self.usedPercent = usedPercent
+			resetDate = window.resetDate
+		case .unknown:
+			valueText = "—"
+			detailText = "No data"
+			tone = .muted
+			usedPercent = nil
+			resetDate = nil
+		case .error(.unsupportedWindow):
+			valueText = "—"
+			detailText = "Not reported"
+			tone = .muted
+			usedPercent = nil
+			resetDate = nil
+		case .error(let error):
+			valueText = "Error"
+			detailText = error.presentation
+			tone = .error
+			usedPercent = nil
+			resetDate = nil
+		}
 	}
 }
 
@@ -405,24 +485,46 @@ private struct ResetCardQuotaWindowView: View {
 	@Environment(\.colorScheme) private var colorScheme
 
 	var body: some View {
+		let presentation = ResetCardQuotaPresentation(window: window)
+
 		VStack(alignment: .leading, spacing: 3) {
 			HStack(alignment: .firstTextBaseline, spacing: 4) {
 				Text(title)
 					.font(PanelFont.usageLabel)
 					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+					.frame(width: 15, alignment: .leading)
+
+				Text(presentation.valueText)
+					.font(PanelFont.usageValue)
+					.foregroundStyle(stateColor(for: presentation.tone))
+					.monospacedDigit()
+					.lineLimit(1)
+
 				Spacer(minLength: 2)
-				Text(window.stateLabel)
-					.font(PanelFont.tertiary)
-					.foregroundStyle(stateColor)
+
+				if let resetDate = presentation.resetDate {
+					Text(Self.compactDateTime(resetDate))
+						.font(PanelFont.tertiary)
+						.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+						.monospacedDigit()
+						.lineLimit(1)
+				} else if let detailText = presentation.detailText {
+					Text(detailText)
+						.font(PanelFont.tertiary)
+						.foregroundStyle(stateColor(for: presentation.tone))
+						.lineLimit(1)
+						.truncationMode(.tail)
+				}
 			}
 
-			if let usedPercent = window.usedPercent {
-				GeometryReader { proxy in
-					ZStack(alignment: .leading) {
+			GeometryReader { proxy in
+				ZStack(alignment: .leading) {
+					Capsule(style: .continuous)
+						.fill(PanelPalette.progressTrack(colorScheme))
+
+					if let usedPercent = presentation.usedPercent {
 						Capsule(style: .continuous)
-							.fill(PanelPalette.progressTrack(colorScheme))
-						Capsule(style: .continuous)
-							.fill(stateColor.opacity(0.84))
+							.fill(stateColor(for: presentation.tone).opacity(0.84))
 							.frame(
 								width: proxy.size.width
 									* CGFloat(usedPercent)
@@ -430,46 +532,37 @@ private struct ResetCardQuotaWindowView: View {
 							)
 					}
 				}
-				.frame(height: 4)
-
-				HStack(spacing: 3) {
-					Text("\(usedPercent)% used")
-					Spacer(minLength: 2)
-					if let resetDate = window.resetDate {
-						Text(resetDate, format: .dateTime.month(.abbreviated).day().hour().minute())
-							.lineLimit(1)
-					}
-				}
-				.font(PanelFont.tertiary)
-				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-				.monospacedDigit()
-			} else {
-				Text(window.detailLabel)
-					.font(PanelFont.tertiary)
-					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-					.lineLimit(1)
 			}
+			.frame(height: 3.2)
 		}
-		.padding(.horizontal, 6)
-		.padding(.vertical, 5)
-		.frame(maxWidth: .infinity, minHeight: 49, alignment: .topLeading)
-		.background(
-			PanelPalette.progressTrack(colorScheme).opacity(0.55),
-			in: RoundedRectangle(cornerRadius: 6, style: .continuous)
-		)
+		.frame(maxWidth: .infinity, alignment: .leading)
+		.frame(height: 22, alignment: .topLeading)
 		.accessibilityElement(children: .ignore)
 		.accessibilityLabel("\(title) quota")
 		.accessibilityValue(window.accessibilityValue)
+		.help(window.accessibilityValue)
 	}
 
-	private var stateColor: Color {
-		switch window.state {
+	private func stateColor(for tone: ResetCardQuotaPresentationTone) -> Color {
+		switch tone {
 		case .current:
 			return PanelPalette.usageCyan(colorScheme)
-		case .stale, .unknown:
+		case .warning:
 			return PanelPalette.warning(colorScheme)
+		case .muted:
+			return PanelPalette.secondaryText(colorScheme)
 		case .error:
 			return PanelPalette.destructive(colorScheme)
 		}
+	}
+
+	private static func compactDateTime(_ date: Date) -> String {
+		let day = date.formatted(.dateTime.month(.abbreviated).day())
+		let time = date.formatted(
+			.dateTime
+				.hour(.twoDigits(amPM: .omitted))
+				.minute(.twoDigits)
+		)
+		return "\(day) \(time)"
 	}
 }

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -1,0 +1,71 @@
+@testable import DecodexApp
+import XCTest
+
+final class AccountPanelPresentationTests: XCTestCase {
+	func testUnsupportedQuotaWindowIsMutedInsteadOfDestructive() {
+		let presentation = ResetCardQuotaPresentation(
+			window: ResetCardQuotaWindow(
+				durationMinutes: 300,
+				observedAtUnixMicros: 1_000_000,
+				state: .error(.unsupportedWindow)
+			)
+		)
+
+		XCTAssertEqual(presentation.valueText, "—")
+		XCTAssertEqual(presentation.detailText, "Not reported")
+		XCTAssertEqual(presentation.tone, .muted)
+		XCTAssertNil(presentation.usedPercent)
+		XCTAssertNil(presentation.resetDate)
+	}
+
+	func testProtocolFailureRemainsDestructive() {
+		let presentation = ResetCardQuotaPresentation(
+			window: ResetCardQuotaWindow(
+				durationMinutes: 10_080,
+				observedAtUnixMicros: 1_000_000,
+				state: .error(.protocolUnavailable)
+			)
+		)
+
+		XCTAssertEqual(presentation.valueText, "Error")
+		XCTAssertEqual(presentation.detailText, "Invalid provider response")
+		XCTAssertEqual(presentation.tone, .error)
+	}
+
+	func testCurrentQuotaRetainsValueAndResetDate() {
+		let presentation = ResetCardQuotaPresentation(
+			window: ResetCardQuotaWindow(
+				durationMinutes: 10_080,
+				observedAtUnixMicros: 1_000_000,
+				state: .current(
+					usedPercent: 79,
+					resetsAtUnixMicros: 2_000_000
+				)
+			)
+		)
+
+		XCTAssertEqual(presentation.valueText, "79% used")
+		XCTAssertEqual(presentation.tone, .current)
+		XCTAssertEqual(presentation.usedPercent, 79)
+		XCTAssertNotNil(presentation.resetDate)
+	}
+
+	func testStaleQuotaHasANonColorStatusMarker() {
+		let presentation = ResetCardQuotaPresentation(
+			window: ResetCardQuotaWindow(
+				durationMinutes: 300,
+				observedAtUnixMicros: 1_000_000,
+				state: .stale(
+					usedPercent: 42,
+					resetsAtUnixMicros: 2_000_000
+				)
+			)
+		)
+
+		XCTAssertEqual(presentation.valueText, "42% stale")
+		XCTAssertNil(presentation.detailText)
+		XCTAssertEqual(presentation.tone, .warning)
+		XCTAssertEqual(presentation.usedPercent, 42)
+		XCTAssertNotNil(presentation.resetDate)
+	}
+}

--- a/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
@@ -54,6 +54,32 @@ final class PanelWindowSizingLayoutTests: XCTestCase {
 		)
 	}
 
+	func testSixCompactAccountRowsFitWithoutAFullHeightPanel() {
+		let height = AccountPanelLayout.accountListHeight(
+			accountCount: 6,
+			measuredContentHeight: 432,
+			windowVisibleFrame: NSRect(x: 0, y: 0, width: 800, height: 675)
+		)
+
+		XCTAssertEqual(height, 432)
+	}
+
+	func testMeasuredOverflowCapsAtTheAvailableScreenHeight() {
+		let height = AccountPanelLayout.accountListHeight(
+			accountCount: 12,
+			measuredContentHeight: 900,
+			windowVisibleFrame: NSRect(x: 0, y: 0, width: 800, height: 560)
+		)
+
+		XCTAssertEqual(
+			height,
+			560
+				- AccountPanelLayout.screenVerticalMargin
+				- AccountPanelLayout.panelVerticalPadding
+				- AccountPanelLayout.fixedChromeHeight
+		)
+	}
+
 	func testFrameKeepsTopEdgeAndCenterWhenContentShrinks() {
 		let currentFrame = NSRect(x: 120, y: 200, width: 360, height: 700)
 		let frame = PanelWindowSizingLayout.frame(

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -2,6 +2,26 @@ import Foundation
 import XCTest
 
 final class ResetCardArchitectureTests: XCTestCase {
+	func testRepeatedAccountRowsDoNotShareAnAppearanceIdentity() throws {
+		let sourceURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
+		let glassSurface = try String(
+			contentsOf: sourceURL.appendingPathComponent("PanelGlassSurface.swift"),
+			encoding: .utf8
+		)
+		let accountPanel = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountPanelView.swift"),
+			encoding: .utf8
+		)
+
+		XCTAssertFalse(glassSurface.contains(".id(appearanceID)"))
+		XCTAssertFalse(accountPanel.contains("LazyVStack"))
+		XCTAssertTrue(accountPanel.contains("id: \\.element.id"))
+	}
+
 	func testProductionSourceHasOneCLIResetCardAuthorityAndNoRetiredUISurfaces() throws {
 		let testsURL = URL(fileURLWithPath: #filePath)
 			.deletingLastPathComponent()

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -177,9 +177,12 @@ decodex-publisher validate-social
 (`apps/decodex-app/README.md`). It:
 
 - Reads the complete account skeleton from the common daemon service and renders one
-  UUID-keyed row for every account in canonical routing order.
+  compact UUID-keyed row for every account in canonical routing order. Rows use
+  divider-separated quota meters and single-line Reset Card controls instead of
+  nested account cards.
 - Loads quota windows and Reset Cards independently for each row. One slow or failed
-  provider request does not hide the other accounts.
+  provider request does not hide the other accounts. A provider-unsupported quota
+  duration stays a muted row-local fact and does not mark the account as failed.
 - Uses Reset Cards from the common daemon service. The first click starts a
   five-second local confirmation. The second click first persists a pending attempt,
   then invokes the bundled `decodex-cli` with a vNext account UUID, exact revision,


### PR DESCRIPTION
## Summary
- restore the compact divider-based account list while retaining the vNext account and Reset Card contract
- remove repeated SwiftUI appearance IDs that caused six accounts to render as one row
- keep quota and Reset Card controls single-line, preserve exact action identity, and treat unsupported quota windows as neutral capability state

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app -c release` (89 tests passed)
- signed staging gate: `scripts/macos/test_decodex_app_stage.sh`
- independent exact-diff review: APPROVED, no P0/P1/P2 findings