### PR TITLE
XY-1429: connect bounded history paging to GPUI lifecycle

### DIFF
--- a/apps/decodex-gpui/src/client_lifecycle.rs
+++ b/apps/decodex-gpui/src/client_lifecycle.rs
@@ -15,13 +15,17 @@ use tokio::sync::Notify;
 
 use decodex_protocol::{
 	ApplicationConfirmation, CURRENT_VERSION, ClientFailure, Cursor, EntityId, EntityRevision,
-	EventEnvelope, RetainedSession, RetainedSessionConfig, RetainedSessionFailure, ServerId,
-	SessionCancellation, SessionCheckpoint, SessionDelivery, SnapshotEnvelope, SnapshotItem,
+	EventEnvelope, QueryEnvelope, QueryResultEnvelope, RetainedSession, RetainedSessionConfig,
+	RetainedSessionFailure, ServerId, SessionCancellation, SessionCheckpoint, SessionDelivery,
+	SnapshotEnvelope, SnapshotItem,
 };
 
-use crate::client_cache::{
-	CacheAuthority, CacheError, CacheLimits, ClientCache, GenerationInspection, ObjectCertainty,
-	ObjectInput,
+use crate::{
+	client_cache::{
+		CacheAuthority, CacheError, CacheLimits, ClientCache, GenerationInspection,
+		ObjectCertainty, ObjectInput,
+	},
+	history_pager::{HistoryDispatch, HistoryPager, HistoryRouteOutcome},
 };
 
 const RETRY_DELAYS: [Duration; 4] = [
@@ -186,7 +190,13 @@ struct CachedFact {
 enum Delivery<C> {
 	Snapshot { snapshot: SnapshotEnvelope, confirmation: C },
 	Event { event: EventEnvelope, confirmation: C },
+	QueryResult(QueryResultEnvelope),
 	Other,
+}
+
+enum SessionStep<C> {
+	Delivery(Result<Delivery<C>, RetainedSessionFailure>),
+	History(HistoryDispatch),
 }
 
 /// The single private seam around retained-session operations and retry time.
@@ -200,6 +210,7 @@ trait LifecycleIo {
 		cancellation: &LifecycleCancellation,
 	) -> Result<Option<SessionCheckpoint>, RetainedSessionFailure>;
 	async fn next(&mut self) -> Result<Delivery<Self::Confirmation>, RetainedSessionFailure>;
+	async fn send_query(&mut self, query: QueryEnvelope) -> Result<(), RetainedSessionFailure>;
 	fn confirm_applied(
 		&mut self,
 		confirmation: Self::Confirmation,
@@ -241,10 +252,14 @@ impl LifecycleIo for TokioIo {
 				Ok(Delivery::Snapshot { snapshot, confirmation }),
 			SessionDelivery::Event { event, confirmation } =>
 				Ok(Delivery::Event { event, confirmation }),
-			SessionDelivery::CommandReceipt(_)
-			| SessionDelivery::CommandResult(_)
-			| SessionDelivery::QueryResult(_) => Ok(Delivery::Other),
+			SessionDelivery::QueryResult(result) => Ok(Delivery::QueryResult(result)),
+			SessionDelivery::CommandReceipt(_) | SessionDelivery::CommandResult(_) =>
+				Ok(Delivery::Other),
 		}
+	}
+
+	async fn send_query(&mut self, query: QueryEnvelope) -> Result<(), RetainedSessionFailure> {
+		self.session.as_mut().ok_or(RetainedSessionFailure::Closed)?.send_query(query).await
 	}
 
 	fn confirm_applied(
@@ -286,6 +301,7 @@ pub(crate) struct ClientLifecycle {
 	cache_limits: CacheLimits,
 	cache_authority: CacheAuthority,
 	cache: Option<ClientCache>,
+	history_pager: HistoryPager,
 	state: HashMap<String, AppliedEntity>,
 	last_cursor: Option<Cursor>,
 	binding: Option<CacheBinding>,
@@ -335,6 +351,7 @@ impl ClientLifecycle {
 			cache_limits,
 			cache_authority,
 			cache,
+			history_pager: HistoryPager::production(),
 			state: HashMap::new(),
 			last_cursor: None,
 			binding: None,
@@ -363,6 +380,18 @@ impl ClientLifecycle {
 	/// Cooperative handle that can terminate the caller-owned run future.
 	pub(crate) fn cancellation(&self) -> LifecycleCancellation {
 		self.cancellation.clone()
+	}
+
+	/// Clone the presentation-neutral history controller before moving the lifecycle task.
+	#[cfg_attr(
+		not(test),
+		allow(
+			dead_code,
+			reason = "XY-1429 exposes this handle for the later Conversation destination"
+		)
+	)]
+	pub(crate) fn history_pager(&self) -> HistoryPager {
+		self.history_pager.clone()
 	}
 
 	/// Run the bounded lifecycle without spawning or detaching any work.
@@ -415,62 +444,92 @@ impl ClientLifecycle {
 				requested_checkpoint.is_some(),
 				connected_checkpoint.as_ref(),
 			);
+			self.history_pager.bind_session(generation, self.server_id.clone());
 			let mut requires_snapshot = connected_checkpoint.is_none();
 
 			let failure = loop {
-				let delivery = io.next().await;
+				let history_pager = self.history_pager.clone();
+				let server_id = self.server_id.clone();
+				let step = tokio::select! {
+					delivery = io.next() => SessionStep::Delivery(delivery),
+					dispatch = history_pager.next_dispatch(generation, &server_id),
+						if !requires_snapshot => SessionStep::History(dispatch),
+				};
 
 				if self.ensure_generation(generation).is_err() {
 					break RetainedSessionFailure::PublicationOrder;
 				}
 
-				match delivery {
-					Ok(Delivery::Snapshot { snapshot, confirmation }) => {
-						let cursor = snapshot.cursor;
-						let inspection = match self.apply_snapshot(generation, snapshot) {
-							Ok(inspection) => inspection,
-							Err(failure) => break failure,
+				match step {
+					SessionStep::History(dispatch) => {
+						let Some(send_token) = self.history_pager.begin_send(&dispatch) else {
+							continue;
 						};
-						let checkpoint = match io.confirm_applied(confirmation) {
-							Ok(checkpoint) => checkpoint,
-							Err(_) => break self.confirmation_failure(),
-						};
+						let send_result = io.send_query(dispatch.envelope().clone()).await;
 
-						if self.bind_checkpoint(generation, cursor, checkpoint, inspection).is_err()
-						{
-							break RetainedSessionFailure::ApplicationConfirmationMismatch;
-						}
-						requires_snapshot = false;
-					},
-					Ok(Delivery::Event { event, confirmation }) => {
-						if requires_snapshot {
-							self.enter_quarantine(
-								QuarantineReason::ApplicationOrder,
-								QuarantineRecovery::VerifiedSnapshotReplacement,
-							);
-
-							break RetainedSessionFailure::PublicationOrder;
-						}
-						let cursor = event.cursor;
-						let inspection = match self.apply_event(generation, event) {
-							Ok(inspection) => inspection,
-							Err(failure) => break failure,
-						};
-						let checkpoint = match io.confirm_applied(confirmation) {
-							Ok(checkpoint) => checkpoint,
-							Err(_) => break self.confirmation_failure(),
-						};
-
-						if self.bind_checkpoint(generation, cursor, checkpoint, inspection).is_err()
-						{
-							break RetainedSessionFailure::ApplicationConfirmationMismatch;
+						self.history_pager.finish_send(&send_token);
+						if let Err(failure) = send_result {
+							break failure;
 						}
 					},
-					Ok(Delivery::Other) => {},
-					Err(failure) => break failure,
+					SessionStep::Delivery(delivery) => match delivery {
+						Ok(Delivery::Snapshot { snapshot, confirmation }) => {
+							let cursor = snapshot.cursor;
+							let inspection = match self.apply_snapshot(generation, snapshot) {
+								Ok(inspection) => inspection,
+								Err(failure) => break failure,
+							};
+							let checkpoint = match io.confirm_applied(confirmation) {
+								Ok(checkpoint) => checkpoint,
+								Err(_) => break self.confirmation_failure(),
+							};
+
+							if self
+								.bind_checkpoint(generation, cursor, checkpoint, inspection)
+								.is_err()
+							{
+								break RetainedSessionFailure::ApplicationConfirmationMismatch;
+							}
+							requires_snapshot = false;
+						},
+						Ok(Delivery::Event { event, confirmation }) => {
+							if requires_snapshot {
+								self.enter_quarantine(
+									QuarantineReason::ApplicationOrder,
+									QuarantineRecovery::VerifiedSnapshotReplacement,
+								);
+
+								break RetainedSessionFailure::PublicationOrder;
+							}
+							let cursor = event.cursor;
+							let inspection = match self.apply_event(generation, event) {
+								Ok(inspection) => inspection,
+								Err(failure) => break failure,
+							};
+							let checkpoint = match io.confirm_applied(confirmation) {
+								Ok(checkpoint) => checkpoint,
+								Err(_) => break self.confirmation_failure(),
+							};
+
+							if self
+								.bind_checkpoint(generation, cursor, checkpoint, inspection)
+								.is_err()
+							{
+								break RetainedSessionFailure::ApplicationConfirmationMismatch;
+							}
+						},
+						Ok(Delivery::QueryResult(result)) => {
+							if let Err(failure) = self.route_history_result(generation, result) {
+								break failure;
+							}
+						},
+						Ok(Delivery::Other) => {},
+						Err(failure) => break failure,
+					},
 				}
 			};
 
+			self.history_pager.session_ended(generation);
 			if self.quarantine.is_none() {
 				self.set_view(ConnectionView::ShuttingDown);
 			}
@@ -548,6 +607,21 @@ impl ClientLifecycle {
 
 				None
 			},
+		}
+	}
+
+	fn route_history_result(
+		&mut self,
+		generation: u64,
+		result: QueryResultEnvelope,
+	) -> Result<(), RetainedSessionFailure> {
+		match self.history_pager.route_result(generation, &self.server_id, result) {
+			HistoryRouteOutcome::Fresh
+			| HistoryRouteOutcome::Unavailable
+			| HistoryRouteOutcome::Closed
+			| HistoryRouteOutcome::Stale
+			| HistoryRouteOutcome::Unmatched
+			| HistoryRouteOutcome::ProtocolMismatch => Ok(()),
 		}
 	}
 

--- a/apps/decodex-gpui/src/client_lifecycle/tests.rs
+++ b/apps/decodex-gpui/src/client_lifecycle/tests.rs
@@ -5,21 +5,33 @@ use std::{
 	fs,
 	os::unix::fs::{MetadataExt as _, PermissionsExt as _},
 	path::{Path, PathBuf},
-	sync::{Arc, Mutex},
+	sync::{
+		Arc, Mutex,
+		atomic::{AtomicUsize, Ordering},
+	},
 	time::Duration,
 };
 
 use tempfile::TempDir;
 
 use decodex_protocol::{
-	CURRENT_VERSION, Channel, ClientProfile, CorrelationId, Cursor, EntityId, EntityRevision,
-	EventEnvelope, EventPayload, RetainedSessionConfig, RetainedSessionFailure, ServerId,
-	ServerInstanceId, SessionCheckpoint, SnapshotEnvelope, SnapshotItem, WireText,
+	CURRENT_VERSION, Channel, ClientProfile, ConversationHistoryPage, ConversationHistoryResult,
+	CorrelationId, Cursor, DoctorReport, EntityId, EntityRevision, EventEnvelope, EventPayload,
+	HistoryCursorToken, QueryEnvelope, QueryPayload, QueryResultEnvelope, QueryResultPayload,
+	RetainedSessionConfig, RetainedSessionFailure, ServerId, ServerInstanceId, SessionCheckpoint,
+	SnapshotEnvelope, SnapshotItem, WireText,
 };
 
-use crate::client_lifecycle::{
-	AppliedEntity, CacheLimits, ClientCache, ClientLifecycle, CompatibilityReason, ConnectionView,
-	Delivery, LifecycleCancellation, LifecycleIo, QuarantineReason, QuarantineRecovery, RunResult,
+use crate::{
+	client_lifecycle::{
+		AppliedEntity, CacheLimits, ClientCache, ClientLifecycle, CompatibilityReason,
+		ConnectionView, Delivery, LifecycleCancellation, LifecycleIo, QuarantineReason,
+		QuarantineRecovery, RunResult,
+	},
+	history_pager::{
+		HistoryCursorObservation, HistoryDispatch, HistoryLoadState, HistoryNavigationResult,
+		HistoryPageSource, HistoryRetryReason, HistoryStaleReason,
+	},
 };
 
 const SERVER: &str = "018f0f9e-7b6e-4a31-8f4c-1d2e3f405162";
@@ -33,12 +45,43 @@ struct FakeConfirmation {
 	previous_current: Option<Vec<u8>>,
 }
 
+struct PendingSendControl {
+	attempts: AtomicUsize,
+	entered: tokio::sync::Semaphore,
+	release: tokio::sync::Semaphore,
+}
+
+impl PendingSendControl {
+	fn new() -> Self {
+		Self {
+			attempts: AtomicUsize::new(0),
+			entered: tokio::sync::Semaphore::new(0),
+			release: tokio::sync::Semaphore::new(0),
+		}
+	}
+
+	async fn wait_until_entered(&self) {
+		self.entered.acquire().await.expect("pending-send signal remains open").forget();
+	}
+
+	fn release_first(&self) {
+		self.release.add_permits(1);
+	}
+
+	fn attempts(&self) -> usize {
+		self.attempts.load(Ordering::SeqCst)
+	}
+}
+
 enum SessionAction {
 	Snapshot(SnapshotEnvelope),
 	Event(EventEnvelope),
+	HistoryPage { next_cursor: Option<&'static str> },
 	Fail(RetainedSessionFailure),
+	FailAfterQuery(RetainedSessionFailure),
 	AwaitCancellation,
 	Cancel,
+	CancelAfterQuery,
 }
 
 struct FakeSession {
@@ -50,10 +93,46 @@ struct FakeSession {
 	cache_root: PathBuf,
 	server_id: ServerId,
 	instance_id: ServerInstanceId,
+	sent_queries: Arc<Mutex<Vec<QueryEnvelope>>>,
+	query_cursor: usize,
+	query_notify: Arc<tokio::sync::Notify>,
 }
 
 impl FakeSession {
+	async fn next_query(&mut self) -> QueryEnvelope {
+		loop {
+			let notified = self.query_notify.notified();
+			let query = self
+				.sent_queries
+				.lock()
+				.expect("query log is available")
+				.get(self.query_cursor)
+				.cloned();
+
+			if let Some(query) = query {
+				self.query_cursor += 1;
+
+				return query;
+			}
+
+			notified.await;
+		}
+	}
+
 	async fn next(&mut self) -> Result<Delivery<FakeConfirmation>, RetainedSessionFailure> {
+		let query = if matches!(
+			self.actions.front(),
+			Some(
+				SessionAction::HistoryPage { .. }
+					| SessionAction::FailAfterQuery(_)
+					| SessionAction::CancelAfterQuery
+			)
+		) {
+			Some(self.next_query().await)
+		} else {
+			None
+		};
+
 		match self.actions.pop_front().expect("fake session action is scripted") {
 			SessionAction::Snapshot(snapshot) => {
 				let confirmation = FakeConfirmation {
@@ -73,13 +152,36 @@ impl FakeSession {
 
 				Ok(Delivery::Event { event, confirmation })
 			},
+			SessionAction::HistoryPage { next_cursor } => {
+				let query = query.expect("history response waits for one outbound query");
+
+				Ok(Delivery::QueryResult(QueryResultEnvelope {
+					version: CURRENT_VERSION,
+					server_id: self.server_id.clone(),
+					query_id: query.query_id,
+					payload: QueryResultPayload::ConversationHistory(
+						ConversationHistoryResult::Page(history_page(next_cursor)),
+					),
+				}))
+			},
 			SessionAction::Fail(failure) => Err(failure),
+			SessionAction::FailAfterQuery(failure) => {
+				let _ = query.expect("scripted failure waits for one outbound query");
+
+				Err(failure)
+			},
 			SessionAction::AwaitCancellation => {
 				self.cancellation.cancelled().await;
 
 				Err(RetainedSessionFailure::Cancelled)
 			},
 			SessionAction::Cancel => {
+				self.cancellation.cancel();
+
+				Err(RetainedSessionFailure::Cancelled)
+			},
+			SessionAction::CancelAfterQuery => {
+				let _ = query.expect("scripted cancellation waits for one outbound query");
 				self.cancellation.cancel();
 
 				Err(RetainedSessionFailure::Cancelled)
@@ -199,6 +301,9 @@ struct FakeIo {
 	cancel_backoff: bool,
 	session: Option<FakeSession>,
 	requested_checkpoints: Vec<Option<SessionCheckpoint>>,
+	sent_queries: Arc<Mutex<Vec<QueryEnvelope>>>,
+	query_notify: Arc<tokio::sync::Notify>,
+	pending_send: Option<Arc<PendingSendControl>>,
 }
 
 impl FakeIo {
@@ -215,7 +320,14 @@ impl FakeIo {
 			cancel_backoff: false,
 			session: None,
 			requested_checkpoints: Vec::new(),
+			sent_queries: Arc::new(Mutex::new(Vec::new())),
+			query_notify: Arc::new(tokio::sync::Notify::new()),
+			pending_send: None,
 		}
+	}
+
+	fn hold_first_send(&mut self, control: Arc<PendingSendControl>) {
+		self.pending_send = Some(control);
 	}
 }
 
@@ -239,6 +351,7 @@ impl LifecycleIo for FakeIo {
 		match action {
 			ConnectAction::Session { actions, checkpoint, server_id, instance_id } => {
 				let initial_checkpoint = checkpoint.clone();
+				let query_cursor = self.sent_queries.lock().expect("query log is available").len();
 
 				self.session = Some(FakeSession {
 					actions,
@@ -250,6 +363,9 @@ impl LifecycleIo for FakeIo {
 					server_id: server(server_id),
 					instance_id: ServerInstanceId::new(instance_id)
 						.expect("instance identity is bounded"),
+					sent_queries: self.sent_queries.clone(),
+					query_cursor,
+					query_notify: self.query_notify.clone(),
 				});
 
 				Ok(initial_checkpoint)
@@ -265,6 +381,27 @@ impl LifecycleIo for FakeIo {
 
 	async fn next(&mut self) -> Result<Delivery<Self::Confirmation>, RetainedSessionFailure> {
 		self.session.as_mut().expect("fake session is connected").next().await
+	}
+
+	async fn send_query(&mut self, query: QueryEnvelope) -> Result<(), RetainedSessionFailure> {
+		assert_eq!(query.version, CURRENT_VERSION);
+		if let Some(control) = self.pending_send.as_ref() {
+			let attempt = control.attempts.fetch_add(1, Ordering::SeqCst) + 1;
+
+			if attempt == 1 {
+				control.entered.add_permits(1);
+				control
+					.release
+					.acquire()
+					.await
+					.expect("pending-send release remains open")
+					.forget();
+			}
+		}
+		self.sent_queries.lock().expect("query log is available").push(query);
+		self.query_notify.notify_waiters();
+
+		Ok(())
 	}
 
 	fn confirm_applied(
@@ -323,6 +460,29 @@ fn entity(value: &str) -> EntityId {
 	EntityId::new(value).expect("entity identity is bounded")
 }
 
+fn history_cursor(value: &str) -> HistoryCursorToken {
+	HistoryCursorToken::new(value).expect("history cursor is bounded")
+}
+
+fn history_page(next_cursor: Option<&str>) -> ConversationHistoryPage {
+	ConversationHistoryPage { items: Vec::new(), next_cursor: next_cursor.map(history_cursor) }
+}
+
+fn history_result(
+	dispatch: &HistoryDispatch,
+	server_id: &ServerId,
+	next_cursor: Option<&str>,
+) -> QueryResultEnvelope {
+	QueryResultEnvelope {
+		version: CURRENT_VERSION,
+		server_id: server_id.clone(),
+		query_id: dispatch.envelope().query_id.clone(),
+		payload: QueryResultPayload::ConversationHistory(ConversationHistoryResult::Page(
+			history_page(next_cursor),
+		)),
+	}
+}
+
 fn snapshot(cursor: u64, entity_id: &str, revision: u64) -> SnapshotEnvelope {
 	snapshot_for(SERVER, cursor, entity_id, revision)
 }
@@ -337,6 +497,21 @@ fn snapshot_for(server_id: &str, cursor: u64, entity_id: &str, revision: u64) ->
 			revision: EntityRevision(revision),
 			status: WireText::new("ready").expect("status is bounded"),
 		}],
+	}
+}
+
+fn maximum_snapshot(cursor: u64) -> SnapshotEnvelope {
+	SnapshotEnvelope {
+		version: CURRENT_VERSION,
+		server_id: server(SERVER),
+		cursor: Cursor(cursor),
+		items: (0..1_024)
+			.map(|index| SnapshotItem::SystemState {
+				entity_id: entity(&format!("system-{index:04}")),
+				revision: EntityRevision(1),
+				status: WireText::new("ready").expect("status is bounded"),
+			})
+			.collect(),
 	}
 }
 
@@ -436,6 +611,483 @@ async fn retry_progression_is_capped_and_uses_only_fake_time() {
 		]
 	);
 	assert_eq!(lifecycle.view(), ConnectionView::Stopped);
+}
+
+#[tokio::test]
+async fn run_with_io_dispatches_history_and_restarts_from_head_after_reconnect() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	let pager = lifecycle.history_pager();
+
+	pager.open(entity("conversation-run")).expect("history view opens");
+
+	let mut io = FakeIo::new(
+		root,
+		vec![
+			connected(
+				vec![
+					SessionAction::Snapshot(snapshot(1, "system", 1)),
+					SessionAction::HistoryPage { next_cursor: Some("cursor-1") },
+					SessionAction::FailAfterQuery(RetainedSessionFailure::Disconnected),
+				],
+				None,
+			),
+			connected(vec![SessionAction::CancelAfterQuery], Some(checkpoint(INSTANCE, 1))),
+		],
+	);
+	let sent_queries = io.sent_queries.clone();
+
+	assert_eq!(lifecycle.run_with_io(&mut io).await, RunResult::Stopped);
+
+	let queries = sent_queries.lock().expect("query log is available");
+
+	assert_eq!(queries.len(), 3);
+	assert_ne!(queries[0].query_id, queries[1].query_id);
+	assert_ne!(queries[0].query_id, queries[2].query_id);
+	assert_ne!(queries[1].query_id, queries[2].query_id);
+
+	let routes = queries
+		.iter()
+		.map(|query| match &query.payload {
+			QueryPayload::GetConversationHistory { conversation_id, after, .. } =>
+				(conversation_id.clone(), after.clone()),
+			_ => panic!("history pager sends only ConversationHistory queries"),
+		})
+		.collect::<Vec<_>>();
+
+	assert_eq!(
+		routes,
+		vec![
+			(entity("conversation-run"), None),
+			(entity("conversation-run"), Some(history_cursor("cursor-1"))),
+			(entity("conversation-run"), None),
+		]
+	);
+	assert!(lifecycle.quarantine.is_none());
+}
+
+#[tokio::test]
+async fn pending_history_send_blocks_replacement_until_settlement() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	let pager = lifecycle.history_pager();
+	let cancellation = lifecycle.cancellation();
+	let control = Arc::new(PendingSendControl::new());
+
+	pager.open(entity("conversation-old")).expect("initial history view opens");
+
+	let mut io = FakeIo::new(
+		root,
+		vec![connected(
+			vec![
+				SessionAction::Snapshot(snapshot(1, "system", 1)),
+				SessionAction::HistoryPage { next_cursor: Some("old-only-cursor") },
+				SessionAction::HistoryPage { next_cursor: None },
+				SessionAction::AwaitCancellation,
+			],
+			None,
+		)],
+	);
+	let sent_queries = io.sent_queries.clone();
+
+	io.hold_first_send(control.clone());
+
+	let run = lifecycle.run_with_io(&mut io);
+
+	tokio::pin!(run);
+	tokio::select! {
+		result = &mut run => panic!("lifecycle stopped before first send settled: {result:?}"),
+		_ = control.wait_until_entered() => {},
+	}
+
+	pager.open(entity("conversation-new")).expect("replacement history view opens");
+	for _ in 0..4 {
+		tokio::select! {
+			result = &mut run => panic!("lifecycle stopped with send unresolved: {result:?}"),
+			_ = tokio::task::yield_now() => {},
+		}
+	}
+
+	assert_eq!(control.attempts(), 1);
+	assert!(sent_queries.lock().expect("query log is available").is_empty());
+
+	control.release_first();
+
+	let mut upgraded = false;
+
+	for _ in 0..64 {
+		let snapshot = pager.snapshot();
+
+		if snapshot.conversation_id == Some(entity("conversation-new"))
+			&& snapshot.visible_source == Some(HistoryPageSource::FreshServer)
+		{
+			assert_eq!(
+				snapshot
+					.last_stale_cancellation
+					.expect("superseded send remains a stale request")
+					.reason,
+				HistoryStaleReason::ConversationChanged
+			);
+			assert_eq!(snapshot.visible.expect("replacement page is visible").next_cursor, None);
+			upgraded = true;
+
+			break;
+		}
+
+		tokio::select! {
+			result = &mut run => panic!("lifecycle stopped before replacement result: {result:?}"),
+			_ = tokio::task::yield_now() => {},
+		}
+	}
+
+	assert!(upgraded, "matching replacement result must become current");
+	assert_eq!(control.attempts(), 2);
+
+	let queries = sent_queries.lock().expect("query log is available").clone();
+
+	assert_eq!(queries.len(), 2);
+	assert_ne!(queries[0].query_id, queries[1].query_id);
+	assert!(matches!(
+		&queries[0].payload,
+		QueryPayload::GetConversationHistory { conversation_id, after: None, .. }
+			if conversation_id == &entity("conversation-old")
+	));
+	assert!(matches!(
+		&queries[1].payload,
+		QueryPayload::GetConversationHistory { conversation_id, after: None, .. }
+			if conversation_id == &entity("conversation-new")
+	));
+
+	cancellation.cancel();
+
+	assert_eq!(run.await, RunResult::Stopped);
+}
+
+#[tokio::test]
+async fn history_results_route_only_to_the_exact_current_view_request() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	let pager = lifecycle.history_pager();
+	let server_id = server(SERVER);
+
+	pager.bind_session(1, server_id.clone());
+	pager.open(entity("conversation-a")).expect("first view opens");
+
+	let first = pager.next_dispatch(1, &server_id).await;
+
+	lifecycle
+		.route_history_result(
+			1,
+			QueryResultEnvelope {
+				version: CURRENT_VERSION,
+				server_id: server_id.clone(),
+				query_id: first.envelope().query_id.clone(),
+				payload: QueryResultPayload::ConversationHistory(ConversationHistoryResult::Page(
+					ConversationHistoryPage { items: Vec::new(), next_cursor: None },
+				)),
+			},
+		)
+		.expect("exact result routes");
+
+	assert_eq!(pager.snapshot().visible_source, Some(HistoryPageSource::FreshServer));
+
+	pager.open(entity("conversation-b")).expect("second view opens");
+	let stale = pager.next_dispatch(1, &server_id).await;
+	pager.open(entity("conversation-c")).expect("replacement view opens");
+
+	lifecycle
+		.route_history_result(
+			1,
+			QueryResultEnvelope {
+				version: CURRENT_VERSION,
+				server_id,
+				query_id: stale.envelope().query_id.clone(),
+				payload: QueryResultPayload::ConversationHistory(ConversationHistoryResult::Page(
+					ConversationHistoryPage { items: Vec::new(), next_cursor: None },
+				)),
+			},
+		)
+		.expect("stale result is ignored without failing the session");
+
+	let snapshot = pager.snapshot();
+
+	assert_eq!(snapshot.conversation_id, Some(entity("conversation-c")));
+	assert!(snapshot.visible.is_none());
+	assert_eq!(
+		snapshot.last_stale_cancellation.expect("stale request is recorded").reason,
+		HistoryStaleReason::ConversationChanged
+	);
+}
+
+#[tokio::test]
+async fn history_pages_leave_maximum_authoritative_snapshot_inventory_unchanged() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let config = retained_config(&root, SERVER);
+	let mut lifecycle = ClientLifecycle::new(
+		config,
+		&root,
+		CacheLimits::new(8 * 1_024 * 1_024, 1_024, 16).expect("limits are valid"),
+		1,
+	)
+	.expect("lifecycle constructs");
+
+	lifecycle.connection_generation = 1;
+	let inspection = lifecycle
+		.apply_snapshot(1, maximum_snapshot(9))
+		.expect("maximum authoritative snapshot publishes");
+	lifecycle
+		.bind_checkpoint(1, Cursor(9), checkpoint(INSTANCE, 9), inspection)
+		.expect("maximum snapshot checkpoint binds");
+
+	let inspection_before = lifecycle
+		.cache
+		.as_ref()
+		.expect("cache is available")
+		.inspect_current()
+		.expect("cache inspection succeeds")
+		.expect("maximum snapshot generation exists");
+	let binding_before = lifecycle.binding.clone();
+	let inventory_before = lifecycle.state.clone();
+	let cursor_before = lifecycle.last_cursor;
+	let pager = lifecycle.history_pager();
+	let server_id = server(SERVER);
+
+	pager.bind_session(1, server_id.clone());
+	pager.open(entity("conversation-large")).expect("history view opens");
+	let head = pager.next_dispatch(1, &server_id).await;
+
+	lifecycle
+		.route_history_result(1, history_result(&head, &server_id, Some("cursor-1")))
+		.expect("history head routes");
+	let continuation = pager.next_dispatch(1, &server_id).await;
+
+	lifecycle
+		.route_history_result(1, history_result(&continuation, &server_id, None))
+		.expect("history continuation routes");
+
+	assert_eq!(pager.snapshot().retained_pages, 2);
+	assert_eq!(
+		lifecycle
+			.cache
+			.as_ref()
+			.expect("cache is available")
+			.inspect_current()
+			.expect("cache inspection succeeds")
+			.expect("maximum snapshot generation remains"),
+		inspection_before
+	);
+	assert_eq!(lifecycle.binding, binding_before);
+	assert_eq!(lifecycle.state, inventory_before);
+	assert_eq!(lifecycle.last_cursor, cursor_before);
+	assert!(lifecycle.quarantine.is_none());
+}
+
+#[tokio::test]
+async fn wrong_history_payload_is_request_local_and_preserves_authoritative_state() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+
+	lifecycle.connection_generation = 1;
+	let inspection = lifecycle
+		.apply_snapshot(1, snapshot(7, "system", 3))
+		.expect("authoritative snapshot publishes");
+	lifecycle
+		.bind_checkpoint(1, Cursor(7), checkpoint(INSTANCE, 7), inspection)
+		.expect("authoritative checkpoint binds");
+
+	let inspection_before = lifecycle
+		.cache
+		.as_ref()
+		.expect("cache is available")
+		.inspect_current()
+		.expect("cache inspection succeeds")
+		.expect("authoritative generation exists");
+	let binding_before = lifecycle.binding.clone();
+	let inventory_before = lifecycle.state.clone();
+	let cursor_before = lifecycle.last_cursor;
+	let pager = lifecycle.history_pager();
+	let server_id = server(SERVER);
+
+	pager.bind_session(1, server_id.clone());
+	pager.open(entity("conversation-protocol")).expect("history view opens");
+	let dispatch = pager.next_dispatch(1, &server_id).await;
+	let wrong_payload = DoctorReport::new(server_id.clone(), CURRENT_VERSION, Vec::new())
+		.expect("bounded doctor report constructs");
+
+	lifecycle
+		.route_history_result(
+			1,
+			QueryResultEnvelope {
+				version: CURRENT_VERSION,
+				server_id,
+				query_id: dispatch.envelope().query_id.clone(),
+				payload: QueryResultPayload::DoctorStatus(wrong_payload),
+			},
+		)
+		.expect("wrong history payload closes only the request");
+
+	assert_eq!(
+		pager.snapshot().load,
+		HistoryLoadState::ClosedUnavailable(
+			crate::history_pager::HistoryClosedReason::ProtocolMismatch,
+		)
+	);
+	assert_eq!(
+		lifecycle
+			.cache
+			.as_ref()
+			.expect("cache is available")
+			.inspect_current()
+			.expect("cache inspection succeeds")
+			.expect("authoritative generation remains"),
+		inspection_before
+	);
+	assert_eq!(lifecycle.binding, binding_before);
+	assert_eq!(lifecycle.state, inventory_before);
+	assert_eq!(lifecycle.last_cursor, cursor_before);
+	assert!(lifecycle.quarantine.is_none());
+	assert_eq!(
+		lifecycle.view(),
+		ConnectionView::Online { generation: 1, applied: Some(Cursor(7)) }
+	);
+}
+
+#[tokio::test]
+async fn session_replacement_requires_a_fresh_head_before_retained_topology_returns() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	let pager = lifecycle.history_pager();
+	let server_id = server(SERVER);
+
+	pager.bind_session(1, server_id.clone());
+	pager.open(entity("conversation-session")).expect("history view opens");
+	let head = pager.next_dispatch(1, &server_id).await;
+
+	lifecycle
+		.route_history_result(1, history_result(&head, &server_id, Some("old-cursor")))
+		.expect("old session head routes");
+	let retained_prefetch = pager.next_dispatch(1, &server_id).await;
+
+	lifecycle
+		.route_history_result(
+			1,
+			history_result(&retained_prefetch, &server_id, Some("old-next-cursor")),
+		)
+		.expect("old session prefetch is retained");
+
+	let retained = pager.snapshot();
+
+	assert_eq!(retained.retained_pages, 2);
+	assert_eq!(retained.visible_source, Some(HistoryPageSource::FreshServer));
+	assert_eq!(retained.cursor, HistoryCursorObservation::ContinuationAvailable);
+
+	pager.bind_session(2, server_id.clone());
+
+	let invalidated = pager.snapshot();
+
+	assert!(invalidated.visible.is_none());
+	assert_eq!(invalidated.cursor, HistoryCursorObservation::Unknown);
+	assert_eq!(invalidated.retained_pages, 0);
+	assert_eq!(pager.show_next(), HistoryNavigationResult::BoundaryUnknown);
+
+	let replacement = pager.next_dispatch(2, &server_id).await;
+
+	assert!(matches!(
+		&replacement.envelope().payload,
+		QueryPayload::GetConversationHistory {
+			conversation_id,
+			after: None,
+			..
+		} if conversation_id == &entity("conversation-session")
+	));
+	assert_eq!(pager.show_next(), HistoryNavigationResult::BoundaryUnknown);
+
+	lifecycle
+		.route_history_result(2, history_result(&replacement, &server_id, Some("new-cursor")))
+		.expect("matching new-session head restores authority");
+
+	let upgraded = pager.snapshot();
+
+	assert_eq!(upgraded.visible_source, Some(HistoryPageSource::FreshServer));
+	assert_eq!(upgraded.cursor, HistoryCursorObservation::ContinuationAvailable);
+
+	let new_prefetch = pager.next_dispatch(2, &server_id).await;
+
+	assert!(matches!(
+		&new_prefetch.envelope().payload,
+		QueryPayload::GetConversationHistory {
+			after: Some(after),
+			..
+		} if after == &history_cursor("new-cursor")
+	));
+}
+
+#[tokio::test]
+async fn prior_session_result_cannot_replace_session_invalidated_view() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_root(&temporary);
+	let mut lifecycle = lifecycle(&root);
+	let pager = lifecycle.history_pager();
+	let server_id = server(SERVER);
+
+	pager.bind_session(1, server_id.clone());
+	pager.open(entity("conversation-session")).expect("history view opens");
+	let head = pager.next_dispatch(1, &server_id).await;
+
+	lifecycle
+		.route_history_result(1, history_result(&head, &server_id, Some("old-cursor")))
+		.expect("old-session head routes");
+	let prior = pager.next_dispatch(1, &server_id).await;
+
+	pager.session_ended(1);
+
+	let offline = pager.snapshot();
+
+	assert!(offline.visible.is_none());
+	assert_eq!(offline.visible_source, None);
+	assert_eq!(offline.cursor, HistoryCursorObservation::Unknown);
+	assert_eq!(
+		offline.load,
+		HistoryLoadState::RetryableUnavailable(HistoryRetryReason::SessionUnavailable)
+	);
+	assert_eq!(pager.show_next(), HistoryNavigationResult::BoundaryUnknown);
+
+	pager.bind_session(2, server_id.clone());
+	let current = pager.next_dispatch(2, &server_id).await;
+
+	assert!(matches!(
+		&current.envelope().payload,
+		QueryPayload::GetConversationHistory {
+			conversation_id,
+			after: None,
+			..
+		} if conversation_id == &entity("conversation-session")
+	));
+	lifecycle
+		.route_history_result(1, history_result(&prior, &server_id, Some("prior-cursor")))
+		.expect("prior-session delivery is ignored");
+
+	let still_invalidated = pager.snapshot();
+
+	assert!(still_invalidated.visible.is_none());
+	assert_eq!(still_invalidated.visible_source, None);
+	assert_eq!(still_invalidated.cursor, HistoryCursorObservation::Unknown);
+	assert!(pager.dispatch_is_current(&current));
+
+	lifecycle
+		.route_history_result(2, history_result(&current, &server_id, None))
+		.expect("current-session result repopulates the invalidated view");
+
+	let fresh = pager.snapshot();
+
+	assert_eq!(fresh.visible_source, Some(HistoryPageSource::FreshServer));
+	assert_eq!(fresh.cursor, HistoryCursorObservation::NoContinuationObserved);
 }
 
 #[tokio::test]

--- a/apps/decodex-gpui/src/history_pager.rs
+++ b/apps/decodex-gpui/src/history_pager.rs
@@ -1,0 +1,1424 @@
+//! Presentation-neutral, bounded ConversationHistory paging for one GPUI view.
+
+use std::{
+	collections::VecDeque,
+	sync::{Arc, Mutex, MutexGuard},
+};
+
+use tokio::sync::Notify;
+
+use decodex_protocol::{
+	CURRENT_VERSION, ConversationHistoryPage, ConversationHistoryResult, EntityId,
+	HistoryCursorToken, HistoryQueryError, MAX_HISTORY_PAGE_SIZE, QueryEnvelope, QueryId,
+	QueryPayload, QueryResultEnvelope, QueryResultPayload, ServerId,
+};
+
+const MAX_CANCELLED_REQUESTS: usize = 8;
+const PRODUCTION_MAX_PAGE_BYTES: usize = 256 * 1_024;
+const PRODUCTION_MAX_WINDOW_BYTES: usize = 1_024 * 1_024;
+const PRODUCTION_MAX_WINDOW_ITEMS: usize = 32;
+const PRODUCTION_MAX_WINDOW_PAGES: usize = 4;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct HistoryPagerLimits {
+	max_page_bytes: usize,
+	max_window_bytes: usize,
+	max_window_items: usize,
+	max_window_pages: usize,
+}
+
+impl HistoryPagerLimits {
+	const fn production() -> Self {
+		Self {
+			max_page_bytes: PRODUCTION_MAX_PAGE_BYTES,
+			max_window_bytes: PRODUCTION_MAX_WINDOW_BYTES,
+			max_window_items: PRODUCTION_MAX_WINDOW_ITEMS,
+			max_window_pages: PRODUCTION_MAX_WINDOW_PAGES,
+		}
+	}
+}
+
+/// Current presentation-neutral state for one Conversation view.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct HistorySnapshot {
+	pub(crate) conversation_id: Option<EntityId>,
+	pub(crate) view_generation: u64,
+	pub(crate) load: HistoryLoadState,
+	pub(crate) visible: Option<ConversationHistoryPage>,
+	pub(crate) visible_source: Option<HistoryPageSource>,
+	pub(crate) cursor: HistoryCursorObservation,
+	pub(crate) retained_pages: usize,
+	pub(crate) retained_items: usize,
+	pub(crate) retained_bytes: usize,
+	pub(crate) last_stale_cancellation: Option<HistoryStaleCancellation>,
+}
+
+/// Finite loading state. None of these states asserts that product history is complete.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HistoryLoadState {
+	Inactive,
+	InitialLoading,
+	RefreshingVisible,
+	PrefetchingAdjacent,
+	Visible,
+	RetryableUnavailable(HistoryRetryReason),
+	ClosedUnavailable(HistoryClosedReason),
+}
+
+/// Origin of the visible bounded page.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HistoryPageSource {
+	FreshServer,
+}
+
+/// Latest page-level continuation observation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HistoryCursorObservation {
+	Unknown,
+	ContinuationAvailable,
+	NoContinuationObserved,
+}
+
+/// Retryable failures that do not prove product absence or completion.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HistoryRetryReason {
+	SessionUnavailable,
+	ResourceExhausted,
+	ProductStateUnavailable,
+	IntegrityUnavailable,
+}
+
+/// Closed request-local failures. Opening a fresh view may still succeed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HistoryClosedReason {
+	InvalidRequest,
+	LocalBounds,
+	MalformedContinuation,
+	ProtocolMismatch,
+	RequestIdentityExhausted,
+}
+
+/// One bounded stale request cancellation observation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct HistoryStaleCancellation {
+	pub(crate) request_sequence: u64,
+	pub(crate) reason: HistoryStaleReason,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HistoryStaleReason {
+	ConversationChanged,
+	NavigationChanged,
+	SessionReplaced,
+	ViewCancelled,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HistoryNavigationResult {
+	Moved,
+	BoundaryUnknown,
+	Inactive,
+	GenerationExhausted,
+}
+
+/// Cloneable view controller. It owns no task, transport, or product authority.
+#[derive(Clone)]
+pub(crate) struct HistoryPager {
+	inner: Arc<HistoryPagerInner>,
+}
+
+struct HistoryPagerInner {
+	state: Mutex<PagerState>,
+	notify: Notify,
+}
+
+impl HistoryPager {
+	pub(crate) fn production() -> Self {
+		Self::new(HistoryPagerLimits::production())
+	}
+
+	fn new(limits: HistoryPagerLimits) -> Self {
+		Self {
+			inner: Arc::new(HistoryPagerInner {
+				state: Mutex::new(PagerState::new(limits)),
+				notify: Notify::new(),
+			}),
+		}
+	}
+
+	/// Start a fresh view and cancel every result bound to the previous view.
+	pub(crate) fn open(&self, conversation_id: EntityId) -> Result<(), HistoryClosedReason> {
+		let mut state = self.lock();
+		let generation =
+			state.next_view_generation().ok_or(HistoryClosedReason::RequestIdentityExhausted)?;
+
+		state.cancel_in_flight(HistoryStaleReason::ConversationChanged);
+		state.active = Some(ActiveView::new(conversation_id, generation));
+		drop(state);
+		self.inner.notify.notify_one();
+
+		Ok(())
+	}
+
+	/// Move to the next retained page or request the exact observed continuation.
+	pub(crate) fn show_next(&self) -> HistoryNavigationResult {
+		let mut state = self.lock();
+		let Some(active) = state.active.as_ref() else {
+			return HistoryNavigationResult::Inactive;
+		};
+		if matches!(active.unavailable, Some(HistoryAvailability::Closed(_))) {
+			return HistoryNavigationResult::BoundaryUnknown;
+		}
+		let Some(visible_index) = active.visible_index else {
+			return HistoryNavigationResult::BoundaryUnknown;
+		};
+		let retained_next =
+			visible_index.checked_add(1).filter(|index| *index < active.pages.len());
+		let continuation = active.pages[visible_index].page.next_cursor.clone();
+
+		if retained_next.is_none() && continuation.is_none() {
+			return HistoryNavigationResult::BoundaryUnknown;
+		}
+		let conversation_id = active.conversation_id.clone();
+		let Some(generation) = state.next_view_generation() else {
+			state.set_closed(HistoryClosedReason::RequestIdentityExhausted);
+
+			return HistoryNavigationResult::GenerationExhausted;
+		};
+
+		state.cancel_in_flight(HistoryStaleReason::NavigationChanged);
+		let active = state.active.as_mut().expect("active view was just observed");
+
+		active.generation = generation;
+		active.unavailable = None;
+		active.retry_request = None;
+		if let Some(next_index) = retained_next {
+			active.visible_index = Some(next_index);
+			active.pending = None;
+			active.enqueue_adjacent_prefetch();
+		} else if let Some(after) = continuation {
+			active.pending = Some(PageRequest::new(
+				generation,
+				PageKey::new(conversation_id, Some(after)),
+				RequestPurpose::Visible,
+			));
+		}
+		drop(state);
+		self.inner.notify.notify_one();
+
+		HistoryNavigationResult::Moved
+	}
+
+	/// Move to the previous retained page. Evicted history remains unknown.
+	pub(crate) fn show_previous(&self) -> HistoryNavigationResult {
+		let mut state = self.lock();
+		let Some(active) = state.active.as_ref() else {
+			return HistoryNavigationResult::Inactive;
+		};
+		if matches!(active.unavailable, Some(HistoryAvailability::Closed(_))) {
+			return HistoryNavigationResult::BoundaryUnknown;
+		}
+		let Some(previous_index) = active.visible_index.and_then(|index| index.checked_sub(1))
+		else {
+			return HistoryNavigationResult::BoundaryUnknown;
+		};
+		let Some(generation) = state.next_view_generation() else {
+			state.set_closed(HistoryClosedReason::RequestIdentityExhausted);
+
+			return HistoryNavigationResult::GenerationExhausted;
+		};
+
+		state.cancel_in_flight(HistoryStaleReason::NavigationChanged);
+		let active = state.active.as_mut().expect("active view was just observed");
+
+		active.generation = generation;
+		active.visible_index = Some(previous_index);
+		active.pending = None;
+		active.unavailable = None;
+		active.retry_request = None;
+		active.enqueue_adjacent_prefetch();
+		drop(state);
+		self.inner.notify.notify_one();
+
+		HistoryNavigationResult::Moved
+	}
+
+	/// Retry only the exact request retained by the latest retryable failure.
+	pub(crate) fn retry(&self) -> bool {
+		let mut state = self.lock();
+		let Some(active) = state.active.as_mut() else {
+			return false;
+		};
+		let Some(request) = active.retry_request.take() else {
+			return false;
+		};
+
+		active.pending = Some(request);
+		active.unavailable = None;
+		drop(state);
+		self.inner.notify.notify_one();
+
+		true
+	}
+
+	/// Cancel the current view without claiming that its Conversation is absent.
+	pub(crate) fn cancel(&self) {
+		let mut state = self.lock();
+
+		state.cancel_in_flight(HistoryStaleReason::ViewCancelled);
+		state.active = None;
+		drop(state);
+		self.inner.notify.notify_one();
+	}
+
+	pub(crate) fn snapshot(&self) -> HistorySnapshot {
+		self.lock().snapshot()
+	}
+
+	pub(crate) fn dispatch_is_current(&self, dispatch: &HistoryDispatch) -> bool {
+		self.lock().matches_dispatch(dispatch)
+	}
+
+	/// Atomically transfer one current request into the transport-send phase.
+	pub(crate) fn begin_send(&self, dispatch: &HistoryDispatch) -> Option<HistorySendToken> {
+		let mut state = self.lock();
+
+		if state.send_in_flight.is_some() || !state.matches_dispatch(dispatch) {
+			return None;
+		}
+
+		let token = HistorySendToken::from_dispatch(dispatch);
+
+		state.send_in_flight = Some(token.clone());
+
+		Some(token)
+	}
+
+	/// Release one exact transport-send phase without restoring superseded authority.
+	pub(crate) fn finish_send(&self, token: &HistorySendToken) -> bool {
+		let mut state = self.lock();
+
+		if state.send_in_flight.as_ref() != Some(token) {
+			return false;
+		}
+
+		state.send_in_flight = None;
+		let remains_current = state
+			.active
+			.as_ref()
+			.and_then(|active| active.in_flight.as_ref())
+			.is_some_and(|in_flight| in_flight.matches_send_token(token));
+		drop(state);
+		self.inner.notify.notify_one();
+
+		remains_current
+	}
+
+	/// Bind future dispatch to one retained-session generation and stable server.
+	pub(crate) fn bind_session(&self, generation: u64, server_id: ServerId) {
+		let mut state = self.lock();
+		let binding = SessionBinding { generation, server_id };
+
+		if state.session.as_ref() != Some(&binding) {
+			state.cancel_in_flight(HistoryStaleReason::SessionReplaced);
+			if let Some(active) = state.active.as_mut() {
+				active.invalidate_session_authority(None);
+			}
+			state.session = Some(binding);
+		}
+		drop(state);
+		self.inner.notify.notify_one();
+	}
+
+	/// Invalidate every page and cursor observation when the owning session ends.
+	pub(crate) fn session_ended(&self, generation: u64) {
+		let mut state = self.lock();
+
+		if state.session.as_ref().is_some_and(|session| session.generation == generation) {
+			state.cancel_in_flight(HistoryStaleReason::SessionReplaced);
+			state.session = None;
+			if let Some(active) = state.active.as_mut() {
+				active.invalidate_session_authority(Some(HistoryAvailability::Retryable(
+					HistoryRetryReason::SessionUnavailable,
+				)));
+			}
+		}
+		drop(state);
+		self.inner.notify.notify_one();
+	}
+
+	/// Wait for and reserve one exact outbound request. No request queue is retained.
+	pub(crate) async fn next_dispatch(
+		&self,
+		session_generation: u64,
+		server_id: &ServerId,
+	) -> HistoryDispatch {
+		loop {
+			let notified = self.inner.notify.notified();
+
+			if let Some(dispatch) = self.try_take_dispatch(session_generation, server_id) {
+				return dispatch;
+			}
+
+			notified.await;
+		}
+	}
+
+	fn try_take_dispatch(
+		&self,
+		session_generation: u64,
+		server_id: &ServerId,
+	) -> Option<HistoryDispatch> {
+		let mut state = self.lock();
+		let expected =
+			SessionBinding { generation: session_generation, server_id: server_id.clone() };
+
+		if state.session.as_ref() != Some(&expected) {
+			return None;
+		}
+		if state.send_in_flight.is_some() {
+			return None;
+		}
+		if state.active.as_ref()?.in_flight.is_some() {
+			return None;
+		}
+
+		let request = state.active.as_mut()?.pending.take()?;
+		let request_sequence = match state.next_request_sequence.checked_add(1) {
+			Some(sequence) => {
+				state.next_request_sequence = sequence;
+				sequence
+			},
+			None => {
+				state.set_closed(HistoryClosedReason::RequestIdentityExhausted);
+
+				return None;
+			},
+		};
+		let query_id = QueryId::new(format!(
+			"gpui-history/{session_generation}/{}/{request_sequence}",
+			request.view_generation
+		))
+		.expect("bounded numeric query identity");
+		let envelope = QueryEnvelope {
+			version: CURRENT_VERSION,
+			query_id: query_id.clone(),
+			payload: QueryPayload::GetConversationHistory {
+				conversation_id: request.key.conversation_id.clone(),
+				after: request.key.after.clone(),
+				page_size: MAX_HISTORY_PAGE_SIZE,
+			},
+		};
+		let dispatch = HistoryDispatch {
+			envelope,
+			session_generation,
+			server_id: server_id.clone(),
+			request_sequence,
+			request: request.clone(),
+		};
+		let active = state.active.as_mut().expect("active view owns pending request");
+
+		active.in_flight = Some(InFlightRequest::from_dispatch(&dispatch));
+		active.unavailable = None;
+
+		Some(dispatch)
+	}
+
+	/// Route one query result through the exact request/session/server/cursor binding.
+	pub(crate) fn route_result(
+		&self,
+		session_generation: u64,
+		server_id: &ServerId,
+		result: QueryResultEnvelope,
+	) -> HistoryRouteOutcome {
+		let mut state = self.lock();
+		let Some(active_query) =
+			state.active.as_ref().and_then(|active| active.in_flight.as_ref()).map(|request| {
+				(request.query_id.clone(), request.session_generation, request.server_id.clone())
+			})
+		else {
+			return if result.version == CURRENT_VERSION
+				&& result.server_id == *server_id
+				&& state.is_cancelled_query(&result.query_id, session_generation, &result.server_id)
+			{
+				HistoryRouteOutcome::Stale
+			} else {
+				HistoryRouteOutcome::Unmatched
+			};
+		};
+
+		if active_query.0 != result.query_id {
+			return if result.version == CURRENT_VERSION
+				&& result.server_id == *server_id
+				&& state.is_cancelled_query(&result.query_id, session_generation, &result.server_id)
+			{
+				HistoryRouteOutcome::Stale
+			} else {
+				HistoryRouteOutcome::Unmatched
+			};
+		}
+		if result.version != CURRENT_VERSION
+			|| result.server_id != *server_id
+			|| active_query.1 != session_generation
+			|| active_query.2 != *server_id
+		{
+			state.set_closed(HistoryClosedReason::ProtocolMismatch);
+
+			return HistoryRouteOutcome::ProtocolMismatch;
+		}
+
+		let in_flight = state
+			.active
+			.as_mut()
+			.and_then(|active| active.in_flight.take())
+			.expect("active query was just observed");
+		let QueryResultPayload::ConversationHistory(history) = result.payload else {
+			state.set_closed(HistoryClosedReason::ProtocolMismatch);
+
+			return HistoryRouteOutcome::ProtocolMismatch;
+		};
+
+		match history {
+			ConversationHistoryResult::Unavailable { error } => {
+				let availability = history_availability(error);
+				let active = state.active.as_mut().expect("in-flight request has an active view");
+
+				active.unavailable = Some(availability);
+				active.retry_request = matches!(availability, HistoryAvailability::Retryable(_))
+					.then_some(in_flight.request);
+
+				HistoryRouteOutcome::Unavailable
+			},
+			ConversationHistoryResult::Page(page) => {
+				let limits = state.limits;
+				let request = in_flight.request;
+				let active = state.active.as_mut().expect("in-flight request has an active view");
+
+				if let Err(reason) = active.admit_live_page(request.clone(), page, limits) {
+					active.unavailable = Some(HistoryAvailability::Closed(reason));
+					active.retry_request = None;
+
+					return HistoryRouteOutcome::Closed;
+				}
+
+				active.unavailable = None;
+				active.retry_request = None;
+				if request.purpose != RequestPurpose::Prefetch {
+					active.enqueue_adjacent_prefetch();
+				}
+
+				if active.pending.is_some() {
+					self.inner.notify.notify_one();
+				}
+
+				HistoryRouteOutcome::Fresh
+			},
+		}
+	}
+
+	fn lock(&self) -> MutexGuard<'_, PagerState> {
+		self.inner.state.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct HistoryDispatch {
+	envelope: QueryEnvelope,
+	session_generation: u64,
+	server_id: ServerId,
+	request_sequence: u64,
+	request: PageRequest,
+}
+
+impl HistoryDispatch {
+	pub(crate) const fn envelope(&self) -> &QueryEnvelope {
+		&self.envelope
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct HistorySendToken {
+	query_id: QueryId,
+	session_generation: u64,
+	server_id: ServerId,
+	request_sequence: u64,
+}
+
+impl HistorySendToken {
+	fn from_dispatch(dispatch: &HistoryDispatch) -> Self {
+		Self {
+			query_id: dispatch.envelope.query_id.clone(),
+			session_generation: dispatch.session_generation,
+			server_id: dispatch.server_id.clone(),
+			request_sequence: dispatch.request_sequence,
+		}
+	}
+}
+
+pub(crate) enum HistoryRouteOutcome {
+	Fresh,
+	Unavailable,
+	Closed,
+	Stale,
+	Unmatched,
+	ProtocolMismatch,
+}
+
+struct PagerState {
+	limits: HistoryPagerLimits,
+	next_view_generation: u64,
+	next_request_sequence: u64,
+	session: Option<SessionBinding>,
+	send_in_flight: Option<HistorySendToken>,
+	active: Option<ActiveView>,
+	cancelled: VecDeque<CancelledRequest>,
+	last_stale_cancellation: Option<HistoryStaleCancellation>,
+}
+
+impl PagerState {
+	fn new(limits: HistoryPagerLimits) -> Self {
+		Self {
+			limits,
+			next_view_generation: 0,
+			next_request_sequence: 0,
+			session: None,
+			send_in_flight: None,
+			active: None,
+			cancelled: VecDeque::new(),
+			last_stale_cancellation: None,
+		}
+	}
+
+	fn next_view_generation(&mut self) -> Option<u64> {
+		let next = self.next_view_generation.checked_add(1)?;
+
+		self.next_view_generation = next;
+
+		Some(next)
+	}
+
+	fn cancel_in_flight(&mut self, reason: HistoryStaleReason) {
+		let in_flight = self.active.as_mut().and_then(|active| active.in_flight.take());
+		let Some(in_flight) = in_flight else {
+			return;
+		};
+
+		self.last_stale_cancellation =
+			Some(HistoryStaleCancellation { request_sequence: in_flight.request_sequence, reason });
+		self.cancelled.push_back(CancelledRequest {
+			query_id: in_flight.query_id,
+			session_generation: in_flight.session_generation,
+			server_id: in_flight.server_id,
+		});
+		while self.cancelled.len() > MAX_CANCELLED_REQUESTS {
+			self.cancelled.pop_front();
+		}
+	}
+
+	fn matches_dispatch(&self, dispatch: &HistoryDispatch) -> bool {
+		self.active
+			.as_ref()
+			.and_then(|active| active.in_flight.as_ref())
+			.is_some_and(|in_flight| in_flight.matches(dispatch))
+	}
+
+	fn is_cancelled_query(
+		&self,
+		query_id: &QueryId,
+		session_generation: u64,
+		server_id: &ServerId,
+	) -> bool {
+		self.cancelled.iter().any(|request| {
+			&request.query_id == query_id
+				&& request.session_generation == session_generation
+				&& &request.server_id == server_id
+		})
+	}
+
+	fn set_closed(&mut self, reason: HistoryClosedReason) {
+		if let Some(active) = self.active.as_mut() {
+			active.unavailable = Some(HistoryAvailability::Closed(reason));
+			active.pending = None;
+			active.in_flight = None;
+			active.retry_request = None;
+		}
+	}
+
+	fn snapshot(&self) -> HistorySnapshot {
+		let Some(active) = self.active.as_ref() else {
+			return HistorySnapshot {
+				conversation_id: None,
+				view_generation: self.next_view_generation,
+				load: HistoryLoadState::Inactive,
+				visible: None,
+				visible_source: None,
+				cursor: HistoryCursorObservation::Unknown,
+				retained_pages: 0,
+				retained_items: 0,
+				retained_bytes: 0,
+				last_stale_cancellation: self.last_stale_cancellation,
+			};
+		};
+		let visible = active.visible_index.and_then(|index| active.pages.get(index));
+		let current_request = active
+			.in_flight
+			.as_ref()
+			.map(|request| request.request.purpose)
+			.or_else(|| active.pending.as_ref().map(|request| request.purpose));
+		let load = match active.unavailable {
+			Some(HistoryAvailability::Retryable(reason)) =>
+				HistoryLoadState::RetryableUnavailable(reason),
+			Some(HistoryAvailability::Closed(reason)) =>
+				HistoryLoadState::ClosedUnavailable(reason),
+			None => match (visible.is_some(), current_request) {
+				(false, Some(_)) => HistoryLoadState::InitialLoading,
+				(true, Some(RequestPurpose::Prefetch)) => HistoryLoadState::PrefetchingAdjacent,
+				(true, Some(_)) => HistoryLoadState::RefreshingVisible,
+				(true, None) => HistoryLoadState::Visible,
+				(false, None) => HistoryLoadState::InitialLoading,
+			},
+		};
+		let cursor = visible.map_or(HistoryCursorObservation::Unknown, |page| {
+			if page.page.next_cursor.is_some() {
+				HistoryCursorObservation::ContinuationAvailable
+			} else {
+				HistoryCursorObservation::NoContinuationObserved
+			}
+		});
+		let retained_pages = active.pages.len();
+		let retained_items = active.pages.iter().map(|page| page.page.items.len()).sum::<usize>();
+		let retained_bytes = active.pages.iter().map(|page| page.byte_length).sum::<usize>();
+
+		HistorySnapshot {
+			conversation_id: Some(active.conversation_id.clone()),
+			view_generation: active.generation,
+			load,
+			visible: visible.map(|page| page.page.clone()),
+			visible_source: if visible.is_some() {
+				Some(HistoryPageSource::FreshServer)
+			} else {
+				None
+			},
+			cursor,
+			retained_pages,
+			retained_items,
+			retained_bytes,
+			last_stale_cancellation: self.last_stale_cancellation,
+		}
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SessionBinding {
+	generation: u64,
+	server_id: ServerId,
+}
+
+struct ActiveView {
+	conversation_id: EntityId,
+	generation: u64,
+	pages: VecDeque<RetainedPage>,
+	visible_index: Option<usize>,
+	pending: Option<PageRequest>,
+	in_flight: Option<InFlightRequest>,
+	retry_request: Option<PageRequest>,
+	unavailable: Option<HistoryAvailability>,
+}
+
+impl ActiveView {
+	fn new(conversation_id: EntityId, generation: u64) -> Self {
+		let initial = PageRequest::new(
+			generation,
+			PageKey::initial(conversation_id.clone()),
+			RequestPurpose::Initial,
+		);
+
+		Self {
+			conversation_id,
+			generation,
+			pages: VecDeque::new(),
+			visible_index: None,
+			pending: Some(initial),
+			in_flight: None,
+			retry_request: None,
+			unavailable: None,
+		}
+	}
+
+	fn invalidate_session_authority(&mut self, unavailable: Option<HistoryAvailability>) {
+		self.pages.clear();
+		self.visible_index = None;
+		self.pending = Some(PageRequest::new(
+			self.generation,
+			PageKey::initial(self.conversation_id.clone()),
+			RequestPurpose::Initial,
+		));
+		self.in_flight = None;
+		self.retry_request = None;
+		self.unavailable = unavailable;
+	}
+
+	fn admit_live_page(
+		&mut self,
+		request: PageRequest,
+		page: ConversationHistoryPage,
+		limits: HistoryPagerLimits,
+	) -> Result<(), HistoryClosedReason> {
+		if let Some(next_cursor) = page.next_cursor.as_ref()
+			&& (request.key.after.as_ref() == Some(next_cursor)
+				|| self
+					.pages
+					.iter()
+					.any(|retained| retained.key.after.as_ref() == Some(next_cursor)))
+		{
+			return Err(HistoryClosedReason::MalformedContinuation);
+		}
+
+		let bytes = serde_json::to_vec(&page).map_err(|_| HistoryClosedReason::LocalBounds)?;
+
+		if page.items.len() > usize::from(MAX_HISTORY_PAGE_SIZE)
+			|| bytes.len() > limits.max_page_bytes
+			|| bytes.len() > limits.max_window_bytes
+			|| page.items.len() > limits.max_window_items
+		{
+			return Err(HistoryClosedReason::LocalBounds);
+		}
+
+		let existing = self.pages.iter().position(|retained| retained.key == request.key);
+		let index = if let Some(index) = existing {
+			self.pages[index] =
+				RetainedPage { key: request.key.clone(), page, byte_length: bytes.len() };
+			index
+		} else {
+			self.pages.push_back(RetainedPage {
+				key: request.key.clone(),
+				page,
+				byte_length: bytes.len(),
+			});
+			self.pages.len() - 1
+		};
+
+		if request.purpose != RequestPurpose::Prefetch {
+			self.visible_index = Some(index);
+		}
+		self.evict_to_limits(limits);
+
+		Ok(())
+	}
+
+	fn enqueue_adjacent_prefetch(&mut self) {
+		if self.pending.is_some() || self.in_flight.is_some() {
+			return;
+		}
+		let Some(visible) = self.visible_index.and_then(|index| self.pages.get(index)) else {
+			return;
+		};
+		let Some(after) = visible.page.next_cursor.clone() else {
+			return;
+		};
+		let key = PageKey::new(self.conversation_id.clone(), Some(after));
+
+		if self.pages.iter().any(|page| page.key == key) {
+			return;
+		}
+
+		self.pending = Some(PageRequest::new(self.generation, key, RequestPurpose::Prefetch));
+	}
+
+	fn evict_to_limits(&mut self, limits: HistoryPagerLimits) {
+		// Keep the visible page and evict the farthest end, preferring the older
+		// front page when both ends are equally distant.
+		while self.pages.len() > limits.max_window_pages
+			|| self.pages.iter().map(|page| page.page.items.len()).sum::<usize>()
+				> limits.max_window_items
+			|| self.pages.iter().map(|page| page.byte_length).sum::<usize>()
+				> limits.max_window_bytes
+		{
+			let Some(visible) = self.visible_index else {
+				self.pages.pop_front();
+
+				continue;
+			};
+			let back_distance = self.pages.len().saturating_sub(1).saturating_sub(visible);
+
+			if visible == 0 {
+				self.pages.pop_back();
+			} else if visible >= back_distance {
+				self.pages.pop_front();
+				self.visible_index = visible.checked_sub(1);
+			} else {
+				self.pages.pop_back();
+			}
+		}
+	}
+}
+
+struct RetainedPage {
+	key: PageKey,
+	page: ConversationHistoryPage,
+	byte_length: usize,
+}
+
+#[derive(Clone, Copy)]
+enum HistoryAvailability {
+	Retryable(HistoryRetryReason),
+	Closed(HistoryClosedReason),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PageRequest {
+	view_generation: u64,
+	key: PageKey,
+	purpose: RequestPurpose,
+}
+
+impl PageRequest {
+	fn new(view_generation: u64, key: PageKey, purpose: RequestPurpose) -> Self {
+		Self { view_generation, key, purpose }
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PageKey {
+	conversation_id: EntityId,
+	after: Option<HistoryCursorToken>,
+}
+
+impl PageKey {
+	fn initial(conversation_id: EntityId) -> Self {
+		Self::new(conversation_id, None)
+	}
+
+	fn new(conversation_id: EntityId, after: Option<HistoryCursorToken>) -> Self {
+		Self { conversation_id, after }
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RequestPurpose {
+	Initial,
+	Visible,
+	Prefetch,
+}
+
+struct InFlightRequest {
+	query_id: QueryId,
+	session_generation: u64,
+	server_id: ServerId,
+	request_sequence: u64,
+	request: PageRequest,
+}
+
+impl InFlightRequest {
+	fn from_dispatch(dispatch: &HistoryDispatch) -> Self {
+		Self {
+			query_id: dispatch.envelope.query_id.clone(),
+			session_generation: dispatch.session_generation,
+			server_id: dispatch.server_id.clone(),
+			request_sequence: dispatch.request_sequence,
+			request: dispatch.request.clone(),
+		}
+	}
+
+	fn matches(&self, dispatch: &HistoryDispatch) -> bool {
+		self.query_id == dispatch.envelope.query_id
+			&& self.session_generation == dispatch.session_generation
+			&& self.server_id == dispatch.server_id
+			&& self.request_sequence == dispatch.request_sequence
+			&& self.request == dispatch.request
+	}
+
+	fn matches_send_token(&self, token: &HistorySendToken) -> bool {
+		self.query_id == token.query_id
+			&& self.session_generation == token.session_generation
+			&& self.server_id == token.server_id
+			&& self.request_sequence == token.request_sequence
+	}
+}
+
+struct CancelledRequest {
+	query_id: QueryId,
+	session_generation: u64,
+	server_id: ServerId,
+}
+
+fn history_availability(error: HistoryQueryError) -> HistoryAvailability {
+	match error {
+		HistoryQueryError::InvalidRequest =>
+			HistoryAvailability::Closed(HistoryClosedReason::InvalidRequest),
+		HistoryQueryError::ResourceExhausted =>
+			HistoryAvailability::Retryable(HistoryRetryReason::ResourceExhausted),
+		HistoryQueryError::ProductStateUnavailable =>
+			HistoryAvailability::Retryable(HistoryRetryReason::ProductStateUnavailable),
+		HistoryQueryError::IntegrityUnavailable =>
+			HistoryAvailability::Retryable(HistoryRetryReason::IntegrityUnavailable),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const SESSION_GENERATION: u64 = 7;
+
+	fn server(value: &str) -> ServerId {
+		ServerId::new(value).expect("test server identity is bounded")
+	}
+
+	fn entity(value: &str) -> EntityId {
+		EntityId::new(value).expect("test entity identity is bounded")
+	}
+
+	fn cursor(value: &str) -> HistoryCursorToken {
+		HistoryCursorToken::new(value).expect("test history cursor is bounded")
+	}
+
+	fn page(next_cursor: Option<&str>) -> ConversationHistoryPage {
+		ConversationHistoryPage { items: Vec::new(), next_cursor: next_cursor.map(cursor) }
+	}
+
+	fn result(
+		dispatch: &HistoryDispatch,
+		server_id: &ServerId,
+		history: ConversationHistoryResult,
+	) -> QueryResultEnvelope {
+		QueryResultEnvelope {
+			version: CURRENT_VERSION,
+			server_id: server_id.clone(),
+			query_id: dispatch.envelope.query_id.clone(),
+			payload: QueryResultPayload::ConversationHistory(history),
+		}
+	}
+
+	fn open_pager() -> (HistoryPager, ServerId) {
+		let pager = HistoryPager::production();
+		let server_id = server("server-a");
+
+		pager.bind_session(SESSION_GENERATION, server_id.clone());
+		pager.open(entity("conversation-a")).expect("view identity is available");
+
+		(pager, server_id)
+	}
+
+	#[test]
+	fn one_view_reserves_at_most_one_current_request() {
+		let (pager, server_id) = open_pager();
+		let dispatch = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("initial request is ready");
+
+		assert!(pager.dispatch_is_current(&dispatch));
+		assert!(pager.try_take_dispatch(SESSION_GENERATION, &server_id).is_none());
+		assert!(matches!(
+			&dispatch.envelope.payload,
+			QueryPayload::GetConversationHistory {
+				conversation_id,
+				after: None,
+				page_size: MAX_HISTORY_PAGE_SIZE,
+			} if conversation_id == &entity("conversation-a")
+		));
+	}
+
+	#[test]
+	fn empty_page_is_visible_without_proving_history_completion() {
+		let (pager, server_id) = open_pager();
+		let dispatch = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("initial request is ready");
+
+		assert!(matches!(
+			pager.route_result(
+				SESSION_GENERATION,
+				&server_id,
+				result(&dispatch, &server_id, ConversationHistoryResult::Page(page(None))),
+			),
+			HistoryRouteOutcome::Fresh
+		));
+
+		let snapshot = pager.snapshot();
+
+		assert_eq!(snapshot.load, HistoryLoadState::Visible);
+		assert_eq!(snapshot.cursor, HistoryCursorObservation::NoContinuationObserved);
+		assert_eq!(snapshot.visible.expect("empty page remains visible").items.len(), 0);
+		assert_eq!(pager.show_next(), HistoryNavigationResult::BoundaryUnknown);
+	}
+
+	#[test]
+	fn navigation_cancels_the_exact_prefetch_and_ignores_its_late_result() {
+		let (pager, server_id) = open_pager();
+		let initial = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("initial request is ready");
+
+		assert!(matches!(
+			pager.route_result(
+				SESSION_GENERATION,
+				&server_id,
+				result(
+					&initial,
+					&server_id,
+					ConversationHistoryResult::Page(page(Some("cursor-1"))),
+				),
+			),
+			HistoryRouteOutcome::Fresh
+		));
+
+		let stale_prefetch = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("adjacent prefetch is ready");
+
+		assert_eq!(pager.show_next(), HistoryNavigationResult::Moved);
+		assert!(matches!(
+			pager.route_result(
+				SESSION_GENERATION,
+				&server_id,
+				result(&stale_prefetch, &server_id, ConversationHistoryResult::Page(page(None)),),
+			),
+			HistoryRouteOutcome::Stale
+		));
+
+		let visible = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("visible continuation replaces the stale prefetch");
+
+		assert_ne!(visible.envelope.query_id, stale_prefetch.envelope.query_id);
+		assert!(matches!(
+			&visible.envelope.payload,
+			QueryPayload::GetConversationHistory {
+				after: Some(after),
+				..
+			} if after == &cursor("cursor-1")
+		));
+		assert_eq!(
+			pager.snapshot().last_stale_cancellation,
+			Some(HistoryStaleCancellation {
+				request_sequence: stale_prefetch.request_sequence,
+				reason: HistoryStaleReason::NavigationChanged,
+			})
+		);
+	}
+
+	#[test]
+	fn self_referential_continuation_closes_without_reissuing_the_cursor() {
+		let (pager, server_id) = open_pager();
+		let head = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("initial request is ready");
+
+		assert!(matches!(
+			pager.route_result(
+				SESSION_GENERATION,
+				&server_id,
+				result(&head, &server_id, ConversationHistoryResult::Page(page(Some("cursor-1"))),),
+			),
+			HistoryRouteOutcome::Fresh
+		));
+
+		let continuation = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("continuation prefetch is ready");
+
+		assert!(matches!(
+			pager.route_result(
+				SESSION_GENERATION,
+				&server_id,
+				result(
+					&continuation,
+					&server_id,
+					ConversationHistoryResult::Page(page(Some("cursor-1"))),
+				),
+			),
+			HistoryRouteOutcome::Closed
+		));
+		assert_eq!(
+			pager.snapshot().load,
+			HistoryLoadState::ClosedUnavailable(HistoryClosedReason::MalformedContinuation)
+		);
+		assert_eq!(pager.show_next(), HistoryNavigationResult::BoundaryUnknown);
+		assert!(pager.try_take_dispatch(SESSION_GENERATION, &server_id).is_none());
+	}
+
+	#[test]
+	fn continuation_to_a_retained_page_closes_without_creating_a_cycle() {
+		let (pager, server_id) = open_pager();
+		let head = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("initial request is ready");
+		let _ = pager.route_result(
+			SESSION_GENERATION,
+			&server_id,
+			result(&head, &server_id, ConversationHistoryResult::Page(page(Some("cursor-1")))),
+		);
+		let first_continuation = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("first continuation prefetch is ready");
+		let _ = pager.route_result(
+			SESSION_GENERATION,
+			&server_id,
+			result(
+				&first_continuation,
+				&server_id,
+				ConversationHistoryResult::Page(page(Some("cursor-2"))),
+			),
+		);
+
+		assert_eq!(pager.show_next(), HistoryNavigationResult::Moved);
+
+		let second_continuation = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("second continuation prefetch is ready");
+
+		assert!(matches!(
+			pager.route_result(
+				SESSION_GENERATION,
+				&server_id,
+				result(
+					&second_continuation,
+					&server_id,
+					ConversationHistoryResult::Page(page(Some("cursor-1"))),
+				),
+			),
+			HistoryRouteOutcome::Closed
+		));
+
+		let snapshot = pager.snapshot();
+
+		assert_eq!(
+			snapshot.load,
+			HistoryLoadState::ClosedUnavailable(HistoryClosedReason::MalformedContinuation)
+		);
+		assert_eq!(snapshot.retained_pages, 2);
+		assert_eq!(pager.show_next(), HistoryNavigationResult::BoundaryUnknown);
+		assert!(pager.try_take_dispatch(SESSION_GENERATION, &server_id).is_none());
+	}
+
+	#[test]
+	fn session_replacement_discards_visible_and_retained_fresh_topology() {
+		let (pager, server_id) = open_pager();
+		let initial = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("initial request is ready");
+
+		assert!(matches!(
+			pager.route_result(
+				SESSION_GENERATION,
+				&server_id,
+				result(
+					&initial,
+					&server_id,
+					ConversationHistoryResult::Page(page(Some("cursor-1"))),
+				),
+			),
+			HistoryRouteOutcome::Fresh
+		));
+		let retained_prefetch = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("adjacent prefetch is ready");
+
+		assert!(matches!(
+			pager.route_result(
+				SESSION_GENERATION,
+				&server_id,
+				result(
+					&retained_prefetch,
+					&server_id,
+					ConversationHistoryResult::Page(page(Some("old-session-cursor"))),
+				),
+			),
+			HistoryRouteOutcome::Fresh
+		));
+
+		let old_session = pager.snapshot();
+
+		assert_eq!(old_session.retained_pages, 2);
+		assert_eq!(old_session.visible_source, Some(HistoryPageSource::FreshServer));
+		assert_eq!(old_session.cursor, HistoryCursorObservation::ContinuationAvailable);
+
+		pager.bind_session(SESSION_GENERATION + 1, server_id.clone());
+
+		let invalidated = pager.snapshot();
+
+		assert!(invalidated.visible.is_none());
+		assert_eq!(invalidated.visible_source, None);
+		assert_eq!(invalidated.cursor, HistoryCursorObservation::Unknown);
+		assert_eq!(invalidated.retained_pages, 0);
+		assert_eq!(pager.show_next(), HistoryNavigationResult::BoundaryUnknown);
+
+		let replacement = pager
+			.try_take_dispatch(SESSION_GENERATION + 1, &server_id)
+			.expect("replacement session refreshes the conversation head");
+
+		assert!(matches!(
+			&replacement.envelope.payload,
+			QueryPayload::GetConversationHistory {
+				conversation_id,
+				after: None,
+				..
+			} if conversation_id == &entity("conversation-a")
+		));
+	}
+
+	#[test]
+	fn server_replacement_rejects_late_prefetch_until_matching_head_upgrade() {
+		let (pager, old_server) = open_pager();
+		let initial = pager
+			.try_take_dispatch(SESSION_GENERATION, &old_server)
+			.expect("initial request is ready");
+
+		assert!(matches!(
+			pager.route_result(
+				SESSION_GENERATION,
+				&old_server,
+				result(
+					&initial,
+					&old_server,
+					ConversationHistoryResult::Page(page(Some("old-cursor"))),
+				),
+			),
+			HistoryRouteOutcome::Fresh
+		));
+		let late_prefetch = pager
+			.try_take_dispatch(SESSION_GENERATION, &old_server)
+			.expect("old session prefetch is in flight");
+		let new_server = server("server-b");
+
+		pager.bind_session(SESSION_GENERATION + 1, new_server.clone());
+
+		assert_eq!(pager.show_next(), HistoryNavigationResult::BoundaryUnknown);
+		let replacement = pager
+			.try_take_dispatch(SESSION_GENERATION + 1, &new_server)
+			.expect("new server refreshes the conversation head");
+
+		assert!(matches!(
+			pager.route_result(
+				SESSION_GENERATION,
+				&old_server,
+				result(
+					&late_prefetch,
+					&old_server,
+					ConversationHistoryResult::Page(page(Some("late-cursor"))),
+				),
+			),
+			HistoryRouteOutcome::Stale
+		));
+		assert!(pager.dispatch_is_current(&replacement));
+		let stale_ignored = pager.snapshot();
+
+		assert!(stale_ignored.visible.is_none());
+		assert_eq!(
+			stale_ignored.last_stale_cancellation,
+			Some(HistoryStaleCancellation {
+				request_sequence: late_prefetch.request_sequence,
+				reason: HistoryStaleReason::SessionReplaced,
+			})
+		);
+
+		assert!(matches!(
+			pager.route_result(
+				SESSION_GENERATION + 1,
+				&new_server,
+				result(
+					&replacement,
+					&new_server,
+					ConversationHistoryResult::Page(page(Some("new-cursor"))),
+				),
+			),
+			HistoryRouteOutcome::Fresh
+		));
+
+		let upgraded = pager.snapshot();
+
+		assert_eq!(upgraded.visible_source, Some(HistoryPageSource::FreshServer));
+		assert_eq!(upgraded.cursor, HistoryCursorObservation::ContinuationAvailable);
+
+		let new_prefetch = pager
+			.try_take_dispatch(SESSION_GENERATION + 1, &new_server)
+			.expect("matching fresh topology enables prefetch");
+
+		assert!(matches!(
+			&new_prefetch.envelope.payload,
+			QueryPayload::GetConversationHistory {
+				after: Some(after),
+				..
+			} if after == &cursor("new-cursor")
+		));
+	}
+
+	#[test]
+	fn bounded_window_evicts_the_older_page_on_an_equal_distance_tie() {
+		let server_id = server("server-a");
+		let pager = HistoryPager::new(HistoryPagerLimits {
+			max_page_bytes: PRODUCTION_MAX_PAGE_BYTES,
+			max_window_bytes: PRODUCTION_MAX_WINDOW_BYTES,
+			max_window_items: PRODUCTION_MAX_WINDOW_ITEMS,
+			max_window_pages: 2,
+		});
+
+		pager.bind_session(SESSION_GENERATION, server_id.clone());
+		pager.open(entity("conversation-a")).expect("view identity is available");
+
+		let first = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("initial request is ready");
+		let _ = pager.route_result(
+			SESSION_GENERATION,
+			&server_id,
+			result(&first, &server_id, ConversationHistoryResult::Page(page(Some("cursor-1")))),
+		);
+		let second = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("second page prefetch is ready");
+		let _ = pager.route_result(
+			SESSION_GENERATION,
+			&server_id,
+			result(&second, &server_id, ConversationHistoryResult::Page(page(Some("cursor-2")))),
+		);
+
+		assert_eq!(pager.show_next(), HistoryNavigationResult::Moved);
+
+		let third = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("third page prefetch is ready");
+		let _ = pager.route_result(
+			SESSION_GENERATION,
+			&server_id,
+			result(&third, &server_id, ConversationHistoryResult::Page(page(None))),
+		);
+
+		let snapshot = pager.snapshot();
+
+		assert_eq!(snapshot.retained_pages, 2);
+		assert_eq!(snapshot.cursor, HistoryCursorObservation::ContinuationAvailable);
+		assert_eq!(pager.show_previous(), HistoryNavigationResult::BoundaryUnknown);
+	}
+
+	#[test]
+	fn page_bytes_over_the_local_bound_close_only_the_request_view() {
+		let server_id = server("server-a");
+		let pager = HistoryPager::new(HistoryPagerLimits {
+			max_page_bytes: 1,
+			max_window_bytes: PRODUCTION_MAX_WINDOW_BYTES,
+			max_window_items: PRODUCTION_MAX_WINDOW_ITEMS,
+			max_window_pages: PRODUCTION_MAX_WINDOW_PAGES,
+		});
+
+		pager.bind_session(SESSION_GENERATION, server_id.clone());
+		pager.open(entity("conversation-a")).expect("view identity is available");
+		let dispatch = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("initial request is ready");
+
+		assert!(matches!(
+			pager.route_result(
+				SESSION_GENERATION,
+				&server_id,
+				result(&dispatch, &server_id, ConversationHistoryResult::Page(page(None))),
+			),
+			HistoryRouteOutcome::Closed
+		));
+		assert_eq!(
+			pager.snapshot().load,
+			HistoryLoadState::ClosedUnavailable(HistoryClosedReason::LocalBounds)
+		);
+	}
+}

--- a/apps/decodex-gpui/src/main.rs
+++ b/apps/decodex-gpui/src/main.rs
@@ -9,6 +9,14 @@
 )]
 mod client_cache;
 mod client_lifecycle;
+#[cfg_attr(
+	not(test),
+	allow(
+		dead_code,
+		reason = "XY-1429 pager controls are composed by the later Conversation destination"
+	)
+)]
+mod history_pager;
 mod shell;
 
 use gpui::{App, AppContext as _, Bounds, WindowBounds, WindowOptions, px, size};


### PR DESCRIPTION
## Summary
- add an in-memory-only ConversationHistory pager bounded to 4 pages, 32 items, and 1 MiB
- route existing V1.2 history results through exact request/session/server correlation
- restart from a fresh head after reconnect without mutating ClientCache authority
- serialize pending transport sends and reject cyclic continuations

## Validation
- cargo make fmt-rust-check
- cargo check -p decodex-gpui --all-targets --all-features
- cargo test -p decodex-gpui history --all-features (14 passed)
- fresh source, repair, formatter, and current-main integration reviews: APPROVED/READY

Linear: XY-1429