### PR TITLE
Define crate-private read-only WorkItem board page query

### DIFF
--- a/crates/decodex-runtime/src/lib.rs
+++ b/crates/decodex-runtime/src/lib.rs
@@ -32,6 +32,8 @@ mod provider_attempt_service;
 mod routing_orchestration;
 mod supervised_validation;
 mod websocket;
+#[expect(dead_code, reason = "waiting for the later board composition owner")]
+mod work_item_board;
 
 #[cfg(feature = "retained-title-experiment")]
 pub use account_launch::retained_title_experiment::{

--- a/crates/decodex-runtime/src/work_item_board.rs
+++ b/crates/decodex-runtime/src/work_item_board.rs
@@ -1,0 +1,29 @@
+//! Crate-private read-only WorkItem board queries.
+
+use decodex_core::{ProjectId, WorkItemId, WorkItemState};
+use decodex_postgres::{PostgresStore, StoreError, StoredWorkItem};
+
+/// Read-only access to canonical WorkItem board pages.
+pub(crate) struct WorkItemBoardQuery {
+	store: PostgresStore,
+}
+
+impl WorkItemBoardQuery {
+	/// Retain the canonical PostgreSQL product-state store.
+	pub(crate) fn new(store: PostgresStore) -> Self {
+		Self { store }
+	}
+
+	/// Read one deterministic Project lane/page after an optional WorkItem cursor.
+	///
+	/// The limit is forwarded unchanged so the store enforces its canonical bound.
+	pub(crate) async fn page(
+		&self,
+		project_id: &ProjectId,
+		state: Option<WorkItemState>,
+		after: Option<&WorkItemId>,
+		limit: usize,
+	) -> Result<Vec<StoredWorkItem>, StoreError> {
+		self.store.query_work_items(project_id, state, after, limit).await
+	}
+}


### PR DESCRIPTION
## Summary

- add a crate-private WorkItem board page query capability over the canonical PostgreSQL store
- preserve typed Project/state/UUID cursor/limit/result semantics without a second DTO or cache
- keep mutation, readiness, acceptance, execution, protocol, and UI authority out of this slice
- mark the intentionally uncomposed private module with a narrow documented dead-code expectation

## Evidence

- source-only and current-main integration reviews: APPROVED/READY
- no P0-P2 findings on the final refrozen candidate
- formatter/compile/Clippy/tests intentionally deferred under the active integrated-core validation policy

Linear: XY-1431