### PR TITLE
Remove misleading account refresh glyphs

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -172,14 +172,6 @@ struct ResetCardAccountRow: View {
 				.layoutPriority(1)
 
 			Spacer(minLength: 2)
-
-			if state.isRefreshing || state.isProfileRefreshing {
-				Image(systemName: "arrow.triangle.2.circlepath")
-					.font(PanelFont.tertiary)
-					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-					.accessibilityLabel("Refreshing account data")
-					.help("Refreshing account data")
-			}
 		}
 		.accessibilityElement(children: .ignore)
 		.accessibilityLabel(


### PR DESCRIPTION
Removes the persistent per-row refresh glyph while six provider reads update progressively in the background. Data refresh, direct actions, first-load checking text, errors, and details feedback remain unchanged. Full Swift test suite: 125 passed. Independent proportionality review: approved.