### PR TITLE
Remove the enclosing macOS account panel shell

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -36,10 +36,11 @@ unavailable profile data remains row-scoped and never hides Reset Cards.
 The panel uses compact individual material cards with transparent gaps and
 shows every account when they fit on the active display. On shorter displays,
 the account list remains scrollable without a persistent scroll indicator.
-The window has a stable dark appearance. The header, overview, and each account
-row use separate system material surfaces with a restrained fill, border, and
-shadow. Transparent gaps remain visible; there is no background surface around
-the complete panel and no Liquid Glass effect.
+The header, overview, and each account row use separate dark system material
+surfaces with a restrained fill, border, and shadow. The host window keeps the
+system appearance and does not draw its own full-window shadow or dark backdrop.
+Transparent gaps remain visible; there is no background surface around the
+complete panel and no Liquid Glass effect.
 
 The app never identifies an account from its alias or vector position. The
 daemon derives a stable credential-negative alias. The canonical account UUID

--- a/apps/decodex-app/Sources/DecodexApp/PanelWindowSizing.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelWindowSizing.swift
@@ -167,7 +167,7 @@ enum PanelWindowAppearance {
 		guard let window else {
 			return
 		}
-		window.appearance = NSAppearance(named: .darkAqua)
+		window.hasShadow = false
 		window.isOpaque = false
 		window.backgroundColor = .clear
 	}

--- a/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
@@ -4,21 +4,23 @@ import XCTest
 
 final class PanelWindowSizingLayoutTests: XCTestCase {
 	@MainActor
-	func testPanelWindowHostUsesStableDarkAppearanceBehindSeparatedCards() {
+	func testPanelWindowHostStaysTransparentWithoutOverridingSystemAppearance() {
 		let window = NSWindow(
 			contentRect: NSRect(x: 0, y: 0, width: 320, height: 480),
 			styleMask: [.borderless],
 			backing: .buffered,
 			defer: false
 		)
+		window.hasShadow = true
 		window.isOpaque = true
 		window.backgroundColor = .windowBackgroundColor
 
 		PanelWindowAppearance.apply(to: window)
 
+		XCTAssertFalse(window.hasShadow)
 		XCTAssertFalse(window.isOpaque)
 		XCTAssertEqual(window.backgroundColor, .clear)
-		XCTAssertEqual(window.appearance?.name, .darkAqua)
+		XCTAssertNil(window.appearance)
 	}
 
 	@MainActor

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -48,6 +48,10 @@ final class ResetCardArchitectureTests: XCTestCase {
 			contentsOf: sourceURL.appendingPathComponent("DecodexApp.swift"),
 			encoding: .utf8
 		)
+		let panelWindow = try String(
+			contentsOf: sourceURL.appendingPathComponent("PanelWindowSizing.swift"),
+			encoding: .utf8
+		)
 
 		XCTAssertTrue(cardSurface.contains("shape.fill(.thinMaterial)"))
 		XCTAssertTrue(cardSurface.contains(".background"))
@@ -65,6 +69,8 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(resetCards.contains("ordinal"))
 		XCTAssertTrue(appScene.contains(".containerBackground(.clear, for: .window)"))
 		XCTAssertTrue(appScene.contains(".preferredColorScheme(.dark)"))
+		XCTAssertTrue(panelWindow.contains("window.hasShadow = false"))
+		XCTAssertFalse(panelWindow.contains("window.appearance ="))
 		XCTAssertFalse(
 			FileManager.default.fileExists(
 				atPath: sourceURL


### PR DESCRIPTION
## Summary
- stop forcing the MenuBarExtra host window to dark appearance
- disable the host window shadow while keeping transparent hosting and independent card shadows
- add regression coverage for the exact window policy

## Validation
- `SCCACHE_DISABLE=1 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app` (129 passed)
- signed release app build and launch succeeded
- independent read-only review: APPROVED / READY