### PR TITLE
Use stable word aliases for account privacy

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -43,8 +43,10 @@ Transparent gaps remain visible; there is no background surface around the
 complete panel and no Liquid Glass effect.
 
 The app never identifies an account from its alias or vector position. The
-daemon derives a stable credential-negative alias. The canonical account UUID
-is the only row identity. There is no account rename surface.
+daemon derives a stable credential-negative one-word alias. The row displays
+either that alias or the account email in the same identity slot, and keeps the
+same account icon in both privacy states. The canonical account UUID is the only
+row identity. There is no account rename surface.
 
 Reset Card use requires two clicks on the same descriptor. The first click arms
 a five-second confirmation. The second click writes one credential-negative

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
@@ -812,15 +812,13 @@ struct ResetCardAccountWire: Decodable, Sendable {
 
 	private static func isCanonicalAlias(_ value: String) -> Bool {
 		let bytes = Array(value.utf8)
-		guard bytes.count == 19,
-			Array(bytes[0..<8]) == Array("Account ".utf8),
-			bytes[13] == 45
+		guard (2 ... 16).contains(bytes.count),
+			let first = bytes.first,
+			(65 ... 90).contains(first)
 		else {
 			return false
 		}
-		let alphabet = Set("0123456789ABCDEFGHJKMNPQRSTVWXYZ".utf8)
-		return bytes[8..<13].allSatisfy(alphabet.contains)
-			&& bytes[14..<19].allSatisfy(alphabet.contains)
+		return bytes.dropFirst().allSatisfy { (97 ... 122).contains($0) }
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -173,7 +173,7 @@ struct ResetCardAccountRow: View {
 
 	private var identityHeader: some View {
 		HStack(alignment: .firstTextBaseline, spacing: 5) {
-			Image(systemName: identity.showsEmail ? "envelope" : "person.crop.circle")
+			Image(systemName: "person.crop.circle")
 				.font(PanelFont.tertiary)
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 				.accessibilityHidden(true)

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
@@ -25,7 +25,7 @@ final class AccountControlNativeClientTests: XCTestCase {
 				data: """
 				{"outcome":"available","data":{
 				  "accounts":[
-				    \(controlAccountJSON(accountID: accountID, alias: "Account 00000-00001", revision: 7)),
+				    \(controlAccountJSON(accountID: accountID, alias: "Iris", revision: 7)),
 				    \(controlUnsettledAccountJSON(accountID: secondAccountID, operationID: operationID))
 				  ],
 				  "routing":{"revision":9,"mode":{"mode":"fixed","account_id":"\(secondAccountID)"},"order":["\(secondAccountID)","\(accountID)"]}
@@ -104,7 +104,7 @@ final class AccountControlNativeClientTests: XCTestCase {
 				payload = """
 				{"outcome":"applied","data":{"entity_revision":8,
 				  "result":{"name":"account_changed","data":{"account":
-				    \(controlAccountJSON(accountID: accountID, alias: "Account 00000-00001", revision: 8, enabled: enabled))
+				    \(controlAccountJSON(accountID: accountID, alias: "Iris", revision: 8, enabled: enabled))
 				  }}}}
 				"""
 			}
@@ -364,7 +364,7 @@ private func controlUnsettledAccountJSON(
 	operationID: String
 ) -> String {
 	"""
-	{"account_id":"\(accountID)","alias":"Account 00000-00002","enabled":true,
+	{"account_id":"\(accountID)","alias":"Jamie","enabled":true,
 	 "account_revision":8,"observed_state":"unknown","lifecycle_readiness":"operation_unsettled",
 	 "credential_binding":{"schema_version":1,"version":2,
 	   "fingerprint_sha256":"\(String(repeating: "b", count: 64))",

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -92,7 +92,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 
 	func testIdentityUsesExactlyOneEmailOrAliasSlot() {
 		let visible = AccountIdentityPresentation(
-			alias: "Account 7M4K-P2Q8",
+			alias: "Iris",
 			email: "iris@example.com",
 			revealsEmail: true
 		)
@@ -100,20 +100,20 @@ final class AccountPanelPresentationTests: XCTestCase {
 		XCTAssertTrue(visible.showsEmail)
 
 		let hidden = AccountIdentityPresentation(
-			alias: "Account 7M4K-P2Q8",
+			alias: "Iris",
 			email: "iris@example.com",
 			revealsEmail: false
 		)
-		XCTAssertEqual(hidden.text, "Account 7M4K-P2Q8")
+		XCTAssertEqual(hidden.text, "Iris")
 		XCTAssertFalse(hidden.showsEmail)
 
 		XCTAssertEqual(
 			AccountIdentityPresentation(
-				alias: "Account 7M4K-P2Q8",
+				alias: "Iris",
 				email: "  ",
 				revealsEmail: true
 			).text,
-			"Account 7M4K-P2Q8"
+			"Iris"
 		)
 	}
 

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -70,6 +70,8 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(resetCards.contains(".panelCardSurface(cornerRadius: 6"))
 		XCTAssertFalse(resetCards.contains(".enumerated()"))
 		XCTAssertFalse(resetCards.contains("ordinal"))
+		XCTAssertTrue(resetCards.contains("Image(systemName: \"person.crop.circle\")"))
+		XCTAssertFalse(resetCards.contains("identity.showsEmail ? \"envelope\""))
 		XCTAssertTrue(appScene.contains(".containerBackground(.clear, for: .window)"))
 		XCTAssertTrue(appScene.contains(".preferredColorScheme(.dark)"))
 		XCTAssertTrue(panelWindow.contains("window.hasShadow = false"))

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardCLIClientTests.swift
@@ -22,8 +22,8 @@ final class ResetCardNativeClientTests: XCTestCase {
 		  "outcome":"available",
 		  "data":{
 		    "accounts":[
-		      \(nativeAccountJSON(accountID: accountID, alias: "Account 00000-00001", revision: 7)),
-		      \(nativeAccountJSON(accountID: secondAccountID, alias: "Account 00000-00002", revision: 8))
+		      \(nativeAccountJSON(accountID: accountID, alias: "Iris", revision: 7)),
+		      \(nativeAccountJSON(accountID: secondAccountID, alias: "Jamie", revision: 8))
 		    ],
 		    "routing":{
 		      "revision":3,
@@ -344,7 +344,7 @@ final class ResetCardNativeClientTests: XCTestCase {
 		let documents = [
 			"""
 			{"outcome":"available","data":{"accounts":[
-			  {"account_id":"\(accountID)","alias":"Account 00000-00001","enabled":true,
+			  {"account_id":"\(accountID)","alias":"Iris","enabled":true,
 			   "account_revision":7,"observed_state":"available","lifecycle_readiness":"ready",
 			   "unexpected":true,
 			   "credential_binding":{"schema_version":1,"version":1,"fingerprint_sha256":"\(String(repeating: "a", count: 64))","provider":"chatgpt","provider_account_id":"provider-a"},
@@ -354,8 +354,13 @@ final class ResetCardNativeClientTests: XCTestCase {
 			""",
 			"""
 			{"outcome":"available","data":{"accounts":[
-			  \(nativeAccountJSON(accountID: accountID, alias: "Account 00000-00001", revision: 7))
+			  \(nativeAccountJSON(accountID: accountID, alias: "Iris", revision: 7))
 			],"routing":{"revision":3,"mode":{"mode":"fixed","account_id":"\(secondAccountID)"},"order":["\(accountID)"]}}}
+			""",
+			"""
+			{"outcome":"available","data":{"accounts":[
+			  \(nativeAccountJSON(accountID: accountID, alias: "Account 00000-00001", revision: 7))
+			],"routing":{"revision":3,"mode":{"mode":"balanced"},"order":["\(accountID)"]}}}
 			""",
 		]
 		for data in documents {

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -3120,15 +3120,7 @@ fn validate_account_dto(account: &AccountDto) -> Result<(), &'static str> {
 	if !is_canonical_uuid(account.account_id.as_str()) || account.account_revision.0 == 0 {
 		return Err("account identity or revision is invalid");
 	}
-	let alias = account.alias.as_str().as_bytes();
-	if alias.len() != 19
-		|| &alias[..8] != b"Account "
-		|| alias[13] != b'-'
-		|| alias[8..13]
-			.iter()
-			.chain(&alias[14..])
-			.any(|byte| !b"0123456789ABCDEFGHJKMNPQRSTVWXYZ".contains(byte))
-	{
+	if !is_canonical_account_alias(account.alias.as_str()) {
 		return Err("account alias is invalid");
 	}
 	if matches!(account.lifecycle_readiness, AccountLifecycleReadinessDto::Tombstoned) {
@@ -3176,6 +3168,13 @@ fn validate_account_dto(account: &AccountDto) -> Result<(), &'static str> {
 	validate_quota_window(account.five_hour_quota, 300)?;
 	validate_quota_window(account.seven_day_quota, 10_080)?;
 	Ok(())
+}
+
+fn is_canonical_account_alias(value: &str) -> bool {
+	let bytes = value.as_bytes();
+	(2..=16).contains(&bytes.len())
+		&& bytes[0].is_ascii_uppercase()
+		&& bytes[1..].iter().all(u8::is_ascii_lowercase)
 }
 
 fn validate_account_profile(profile: &AccountProfileDto) -> Result<(), &'static str> {
@@ -3371,6 +3370,25 @@ mod tests {
 			ResumeCursor, decode_client_message,
 		},
 	};
+
+	#[test]
+	fn account_alias_accepts_only_one_canonical_word() {
+		assert!(super::is_canonical_account_alias("Iris"));
+		assert!(super::is_canonical_account_alias("Val"));
+		for invalid in [
+			"",
+			"A",
+			"iris",
+			"IRIS",
+			"Iris1",
+			"Iris Smith",
+			"Account DQ6WF-G8BTT",
+			"Éden",
+			"Abcdefghijklmnopq",
+		] {
+			assert!(!super::is_canonical_account_alias(invalid), "{invalid}");
+		}
+	}
 
 	#[test]
 	fn command_wire_shape_is_structured_and_round_trips() {

--- a/crates/decodex-runtime/src/account_service.rs
+++ b/crates/decodex-runtime/src/account_service.rs
@@ -46,9 +46,15 @@ const REFRESH_ENDPOINT: &str = "https://auth.openai.com/oauth/token";
 const CHATGPT_OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const MAX_ACCOUNT_READ: u16 = 512;
 const PROVIDER_REFRESH_OUTCOME_UNKNOWN: &str = "provider_refresh_outcome_unknown";
-const ACCOUNT_ALIAS_DOMAIN: &[u8] = b"decodex/account-alias/v1\0";
+const ACCOUNT_ALIAS_DOMAIN: &[u8] = b"decodex/account-alias/v2\0";
 const CODEX_AUTH_PROJECTION_DOMAIN: &[u8] = b"decodex/codex-auth-projection/v1\0";
-const CROCKFORD_BASE32: &[u8; 32] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const ACCOUNT_ALIAS_WORDS: [&str; 44] = [
+	"Alex", "Avery", "Bailey", "Blake", "Casey", "Charlie", "Clara", "Dana", "Drew", "Eden",
+	"Elliot", "Emery", "Evan", "Finley", "Harper", "Hayden", "Iris", "Jamie", "Jordan", "Kai",
+	"Kendall", "Lane", "Liam", "Logan", "Mason", "Maya", "Mia", "Morgan", "Noah", "Nora", "Owen",
+	"Paige", "Parker", "Quinn", "Reese", "Remy", "Riley", "Rowan", "Sage", "Sasha", "Sidney",
+	"Taylor", "Theo", "Val",
+];
 
 /// Derive the stable public account alias from the canonical credential-negative provider binding.
 pub(crate) fn stable_account_alias(provider: &ProviderIdentity) -> String {
@@ -61,16 +67,14 @@ pub(crate) fn stable_account_alias(provider: &ProviderIdentity) -> String {
 		.chain_update(b"\0")
 		.chain_update(provider.account_id().as_bytes())
 		.finalize();
-	let mut encoded = [b'0'; 10];
-	for (index, output) in encoded.iter_mut().enumerate() {
-		let bit = index * 5;
-		let byte = bit / 8;
-		let shift = 11_usize.saturating_sub(bit % 8);
-		let pair = u16::from_be_bytes([digest[byte], digest[byte + 1]]);
-		*output = CROCKFORD_BASE32[((pair >> shift) & 0x1f) as usize];
-	}
-	let encoded = std::str::from_utf8(&encoded).expect("Crockford alphabet is ASCII");
-	format!("Account {}-{}", &encoded[..5], &encoded[5..])
+	let selector = u64::from_be_bytes([
+		digest[0], digest[1], digest[2], digest[3], digest[4], digest[5], digest[6], digest[7],
+	]);
+	let word_count =
+		u64::try_from(ACCOUNT_ALIAS_WORDS.len()).expect("account alias word count fits u64");
+	let index =
+		usize::try_from(selector % word_count).expect("account alias word index fits usize");
+	ACCOUNT_ALIAS_WORDS[index].to_owned()
 }
 
 fn codex_auth_projection_digest(account: &AccountRecord, binding: &CredentialBinding) -> String {
@@ -3161,14 +3165,14 @@ mod tests {
 	use serde_json::json;
 
 	use super::{
-		AccountLifecycleError, CredentialImportError, CredentialRefreshError,
+		ACCOUNT_ALIAS_WORDS, AccountLifecycleError, CredentialImportError, CredentialRefreshError,
 		CredentialSecretBundle, ImportedCredential, PROVIDER_REFRESH_OUTCOME_UNKNOWN,
 		RefreshResponse, UseInCodexProjectionError, account_lock_for, codex_auth_projection_digest,
 		credential_refresh_result, matching_shared_refresh, projection_binding,
 		refreshed_credential_target, stable_account_alias, use_in_codex_receipt_result,
 	};
 	use std::{
-		collections::HashMap,
+		collections::{HashMap, HashSet},
 		sync::{Arc, Mutex},
 		time::Duration,
 	};
@@ -3182,7 +3186,19 @@ mod tests {
 			ProviderIdentity::new(AccountProvider::Chatgpt, "433463f7-74ae-4a7e-ab10-9667f9e4919e")
 				.unwrap();
 
-		assert_eq!(stable_account_alias(&provider), "Account DQ6WF-G8BTT");
+		assert_eq!(stable_account_alias(&provider), "Val");
+	}
+
+	#[test]
+	fn stable_alias_word_table_is_closed_unique_and_canonical() {
+		assert_eq!(ACCOUNT_ALIAS_WORDS.len(), 44);
+		assert_eq!(ACCOUNT_ALIAS_WORDS.iter().copied().collect::<HashSet<_>>().len(), 44);
+		assert!(ACCOUNT_ALIAS_WORDS.iter().all(|word| {
+			let bytes = word.as_bytes();
+			(2..=16).contains(&bytes.len())
+				&& bytes[0].is_ascii_uppercase()
+				&& bytes[1..].iter().all(u8::is_ascii_lowercase)
+		}));
 	}
 
 	#[tokio::test]

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -1984,7 +1984,7 @@ mod tests {
 	fn prepared_account_uses_its_immutable_derived_alias_without_a_current_binding() {
 		let account = AccountRecord {
 			account_id: AccountId::new("40000000-0000-4000-8000-000000000002").unwrap(),
-			label: "Account DQ6WF-G8BTT".to_owned(),
+			label: "Val".to_owned(),
 			enabled: true,
 			revision: 1,
 			observed_state: AccountState::Unknown,
@@ -2010,7 +2010,7 @@ mod tests {
 
 		assert_eq!(
 			account_dto(account).expect("prepared account must remain listable").alias.as_str(),
-			"Account DQ6WF-G8BTT",
+			"Val",
 		);
 	}
 

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -54,19 +54,36 @@ binding:
 
 ```text
 digest = SHA-256(
-  "decodex/account-alias/v1\0"
+  "decodex/account-alias/v2\0"
   || canonical_provider_kind
   || "\0"
   || canonical_provider_account_id
 )
-alias = "Account " || CrockfordBase32(first 50 big-endian digest bits)
+selector = first 64 big-endian digest bits
+alias = ACCOUNT_ALIAS_WORDS[selector mod 44]
 ```
 
-Render the ten uppercase Crockford digits as `Account ABCDE-FGHIJ`. Do not accept a
-user label, rename command, random suffix, dictionary, or collision table. The ChatGPT
-provider identity `433463f7-74ae-4a7e-ab10-9667f9e4919e` has digest
-`6dcdc7c10bd6adc626af7ec7c20817934ca8e42a80d58d44f7d5636b71099e98` and alias
-`Account DQ6WF-G8BTT`.
+`ACCOUNT_ALIAS_WORDS` is this fixed ordered list:
+
+```text
+Alex, Avery, Bailey, Blake, Casey, Charlie, Clara, Dana, Drew, Eden, Elliot,
+Emery, Evan, Finley, Harper, Hayden, Iris, Jamie, Jordan, Kai, Kendall, Lane,
+Liam, Logan, Mason, Maya, Mia, Morgan, Noah, Nora, Owen, Paige, Parker, Quinn,
+Reese, Remy, Riley, Rowan, Sage, Sasha, Sidney, Taylor, Theo, Val
+```
+
+The alias is one name with no prefix or suffix. It is a privacy-preserving
+presentation substitute for the email address, not an identifier, and two
+accounts can have the same alias. Account UUID remains the only row identity. Do
+not accept a user label or rename command, and do not add a random suffix,
+collision table, or mutable reroll. The ChatGPT provider identity
+`433463f7-74ae-4a7e-ab10-9667f9e4919e` has digest
+`d6ac83189beb33b78f71052e9f0a2134605e8c67cebbadbbfabcf926a2222165` and alias
+`Val`.
+
+Wire and native-client boundaries accept only one 2–16-byte ASCII word with one
+initial uppercase letter and lowercase remaining letters. They reject the v1
+`Account ABCDE-FGHIJ` form rather than retaining a compatibility branch.
 
 ## HostCredentialStore
 


### PR DESCRIPTION
Switch the account privacy presentation from Account ID-like codes to deterministic one-word aliases derived from the stable provider identity. Keep email and alias in one identity slot, use one fixed account icon, and clean-break the Rust and Swift alias validators.\n\nValidation:\n- cargo make check-rust\n- cargo test -p decodex-runtime -p decodex-protocol alias\n- swift test --package-path apps/decodex-app (134 passed)