### PR TITLE
Remove account panel shell and repair Reset Card observations

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/DecodexApp.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexApp.swift
@@ -1,9 +1,17 @@
 import AppKit
 import SwiftUI
 
+@MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
+	private var store: ResetCardStore?
+	private var statusPanelController: StatusPanelController?
+
 	func applicationDidFinishLaunching(_ notification: Notification) {
 		NSApp.setActivationPolicy(.accessory)
+		let store = ResetCardStore()
+		self.store = store
+		statusPanelController = StatusPanelController(store: store)
+		store.start()
 	}
 }
 
@@ -23,35 +31,10 @@ enum AppAssets {
 @main
 struct DecodexApp: App {
 	@NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-	@State private var store: ResetCardStore
-
-	@MainActor
-	init() {
-		let store = ResetCardStore()
-
-		_store = State(initialValue: store)
-		store.start()
-	}
 
 	var body: some Scene {
-		MenuBarExtra {
-			menuBarContent
-		} label: {
-			Label {
-				Text("Decodex")
-			} icon: {
-				Image(nsImage: AppAssets.statusBarIcon)
-			}
+		Settings {
+			EmptyView()
 		}
-		.menuBarExtraStyle(.window)
-		.windowResizability(.contentSize)
-	}
-
-	@ViewBuilder
-	private var menuBarContent: some View {
-		AccountPanelView(store: store)
-			.environment(\.colorScheme, .dark)
-			.preferredColorScheme(.dark)
-			.containerBackground(.clear, for: .window)
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
@@ -295,10 +295,35 @@ struct ResetCardInventory: Equatable, Sendable {
 	let authority: ResetCardAuthority
 	let accountID: String
 	let accountRevision: UInt64
+	let reportedAvailableCount: UInt64?
+	let detailsComplete: Bool
 	let cards: [ResetCardDescriptor]
 	let fiveHourQuota: ResetCardQuotaWindow
 	let sevenDayQuota: ResetCardQuotaWindow
 	let observationError: ResetCardServiceError?
+
+	init(
+		authority: ResetCardAuthority,
+		accountID: String,
+		accountRevision: UInt64,
+		reportedAvailableCount: UInt64? = nil,
+		detailsComplete: Bool = true,
+		cards: [ResetCardDescriptor],
+		fiveHourQuota: ResetCardQuotaWindow,
+		sevenDayQuota: ResetCardQuotaWindow,
+		observationError: ResetCardServiceError?
+	) {
+		self.authority = authority
+		self.accountID = accountID
+		self.accountRevision = accountRevision
+		self.reportedAvailableCount = reportedAvailableCount
+			?? (detailsComplete ? UInt64(cards.count) : nil)
+		self.detailsComplete = detailsComplete
+		self.cards = cards
+		self.fiveHourQuota = fiveHourQuota
+		self.sevenDayQuota = sevenDayQuota
+		self.observationError = observationError
+	}
 }
 
 enum ResetCardClientError: Error, Equatable, LocalizedError, Sendable, CustomDebugStringConvertible {
@@ -1177,7 +1202,8 @@ private struct ResetCardObservationWire: Decodable, Sendable {
 private struct ResetCardAvailableInventoryWireData: Decodable, Sendable {
 	let accountID: String
 	let accountRevision: UInt64
-	let availableCount: UInt16
+	let reportedAvailableCount: UInt64?
+	let detailsComplete: Bool
 	let cards: [ResetCardObservationWire]
 	let fiveHourQuota: ResetCardQuotaWindowWire
 	let sevenDayQuota: ResetCardQuotaWindowWire
@@ -1185,7 +1211,8 @@ private struct ResetCardAvailableInventoryWireData: Decodable, Sendable {
 	enum CodingKeys: String, CodingKey {
 		case accountID = "account_id"
 		case accountRevision = "account_revision"
-		case availableCount = "available_count"
+		case reportedAvailableCount = "reported_available_count"
+		case detailsComplete = "details_complete"
 		case cards
 		case fiveHourQuota = "five_hour_quota"
 		case sevenDayQuota = "seven_day_quota"
@@ -1197,7 +1224,8 @@ private struct ResetCardAvailableInventoryWireData: Decodable, Sendable {
 			allowed: [
 				"account_id",
 				"account_revision",
-				"available_count",
+				"reported_available_count",
+				"details_complete",
 				"cards",
 				"five_hour_quota",
 				"seven_day_quota",
@@ -1206,7 +1234,11 @@ private struct ResetCardAvailableInventoryWireData: Decodable, Sendable {
 		let container = try decoder.container(keyedBy: CodingKeys.self)
 		accountID = try container.decode(String.self, forKey: .accountID)
 		accountRevision = try container.decode(UInt64.self, forKey: .accountRevision)
-		availableCount = try container.decode(UInt16.self, forKey: .availableCount)
+		reportedAvailableCount = try container.decodeIfPresent(
+			UInt64.self,
+			forKey: .reportedAvailableCount
+		)
+		detailsComplete = try container.decode(Bool.self, forKey: .detailsComplete)
 		cards = try container.decode([ResetCardObservationWire].self, forKey: .cards)
 		fiveHourQuota = try container.decode(
 			ResetCardQuotaWindowWire.self,
@@ -1222,10 +1254,18 @@ private struct ResetCardAvailableInventoryWireData: Decodable, Sendable {
 		guard DecodexNativeClient.isValidAuthority(authority),
 			DecodexNativeClient.isCanonicalAccountID(accountID),
 			accountRevision > 0,
-			cards.count == Int(availableCount),
 			cards.count <= resetCardNativeItemLimit
 		else {
 			throw ResetCardClientError.invalidResponse
+		}
+		if detailsComplete {
+			guard reportedAvailableCount == UInt64(cards.count) else {
+				throw ResetCardClientError.invalidResponse
+			}
+		} else {
+			guard cards.isEmpty, reportedAvailableCount != 0 else {
+				throw ResetCardClientError.invalidResponse
+			}
 		}
 
 		let descriptors = try cards.map { try $0.descriptor.descriptor }
@@ -1239,6 +1279,8 @@ private struct ResetCardAvailableInventoryWireData: Decodable, Sendable {
 			authority: authority,
 			accountID: accountID,
 			accountRevision: accountRevision,
+			reportedAvailableCount: reportedAvailableCount,
+			detailsComplete: detailsComplete,
 			cards: descriptors,
 			fiveHourQuota: fiveHourQuota,
 			sevenDayQuota: sevenDayQuota,
@@ -1290,6 +1332,8 @@ private struct ResetCardFailedInventoryWireData: Decodable, Sendable {
 			authority: authority,
 			accountID: accountID,
 			accountRevision: accountRevision,
+			reportedAvailableCount: nil,
+			detailsComplete: false,
 			cards: [],
 			fiveHourQuota: try fiveHourQuota.window(expectedDuration: 300),
 			sevenDayQuota: try sevenDayQuota.window(expectedDuration: 10_080),

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -324,6 +324,24 @@ struct ResetCardAccountRow: View {
 			Text("Checking Reset Cards…")
 				.font(PanelFont.tertiary)
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+		} else if let inventory = state.inventory,
+			inventory.detailsComplete == false
+		{
+			if let count = inventory.reportedAvailableCount {
+				Text(
+					count == 0
+						? "No Reset Cards"
+						: "\(count) Reset \(count == 1 ? "Card" : "Cards")"
+				)
+				.font(PanelFont.tertiary)
+				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+				.lineLimit(1)
+				.help(
+					count == 0
+						? "The provider reported no available Reset Cards."
+						: "The provider reported the count without expiration details."
+				)
+			}
 		} else if state.targets.isEmpty {
 			Text("No Reset Cards")
 				.font(PanelFont.tertiary)

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -44,7 +44,9 @@ struct ResetCardAccountState: Identifiable, Equatable {
 	}
 
 	var targets: [ResetCardUseTarget] {
-		guard let inventory else {
+		guard let inventory,
+			inventory.detailsComplete
+		else {
 			return []
 		}
 

--- a/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
+++ b/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
@@ -1,0 +1,159 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class StatusPanelController: NSObject {
+	private static let screenMargin: CGFloat = 8
+	private static let menuBarGap: CGFloat = 4
+
+	private let statusItem: NSStatusItem
+	private let panel: TransparentStatusPanel
+	private let hostingView: NSHostingView<StatusPanelRootView>
+
+	init(store: ResetCardStore) {
+		statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+		panel = TransparentStatusPanel(
+			contentRect: .zero,
+			styleMask: [.borderless],
+			backing: .buffered,
+			defer: true
+		)
+		hostingView = NSHostingView(rootView: StatusPanelRootView(store: store))
+
+		super.init()
+
+		configureStatusItem()
+		configurePanel()
+	}
+
+	@objc
+	private func togglePanel() {
+		if panel.isVisible {
+			panel.orderOut(nil)
+			return
+		}
+
+		hostingView.layoutSubtreeIfNeeded()
+		let fittingSize = hostingView.fittingSize
+		if fittingSize.width > 0, fittingSize.height > 0 {
+			panel.setContentSize(fittingSize)
+		}
+		positionPanel()
+		NSApp.activate(ignoringOtherApps: true)
+		panel.makeKeyAndOrderFront(nil)
+	}
+
+	private func configureStatusItem() {
+		guard let button = statusItem.button else {
+			return
+		}
+
+		button.image = AppAssets.statusBarIcon
+		button.imagePosition = .imageOnly
+		button.target = self
+		button.action = #selector(togglePanel)
+		button.toolTip = "Decodex"
+		button.setAccessibilityLabel("Decodex")
+	}
+
+	private func configurePanel() {
+		panel.isReleasedWhenClosed = false
+		panel.isOpaque = false
+		panel.backgroundColor = .clear
+		panel.hasShadow = false
+		panel.hidesOnDeactivate = true
+		panel.isMovable = false
+		panel.level = .popUpMenu
+		panel.collectionBehavior = [
+			.transient,
+			.moveToActiveSpace,
+			.fullScreenAuxiliary,
+		]
+		panel.contentView = hostingView
+	}
+
+	private func positionPanel() {
+		guard let button = statusItem.button,
+			let statusWindow = button.window
+		else {
+			return
+		}
+
+		let anchorRect = statusWindow.convertToScreen(
+			button.convert(button.bounds, to: nil)
+		)
+		guard let screen = statusWindow.screen
+			?? NSScreen.screens.first(where: {
+				$0.frame.intersects(anchorRect)
+			})
+			?? NSScreen.main
+		else {
+			return
+		}
+
+		panel.setFrameOrigin(
+			StatusPanelLayout.origin(
+				anchorRect: anchorRect,
+				panelSize: panel.frame.size,
+				visibleFrame: screen.visibleFrame,
+				screenMargin: Self.screenMargin,
+				menuBarGap: Self.menuBarGap
+			)
+		)
+	}
+}
+
+enum StatusPanelLayout {
+	static func origin(
+		anchorRect: NSRect,
+		panelSize: NSSize,
+		visibleFrame: NSRect,
+		screenMargin: CGFloat = 8,
+		menuBarGap: CGFloat = 4
+	) -> NSPoint {
+		let minimumX = visibleFrame.minX + screenMargin
+		let maximumX = visibleFrame.maxX - panelSize.width - screenMargin
+		let proposedX = anchorRect.midX - panelSize.width / 2
+
+		let minimumY = visibleFrame.minY + screenMargin
+		let maximumY = visibleFrame.maxY - panelSize.height - screenMargin
+		let proposedY = anchorRect.minY - panelSize.height - menuBarGap
+
+		return NSPoint(
+			x: clamped(proposedX, minimum: minimumX, maximum: maximumX),
+			y: clamped(proposedY, minimum: minimumY, maximum: maximumY)
+		)
+	}
+
+	private static func clamped(
+		_ value: CGFloat,
+		minimum: CGFloat,
+		maximum: CGFloat
+	) -> CGFloat {
+		guard minimum <= maximum else {
+			return minimum
+		}
+		return min(max(value, minimum), maximum)
+	}
+}
+
+@MainActor
+final class TransparentStatusPanel: NSPanel {
+	override var canBecomeKey: Bool {
+		true
+	}
+
+	override var canBecomeMain: Bool {
+		false
+	}
+}
+
+private struct StatusPanelRootView: View {
+	let store: ResetCardStore
+
+	var body: some View {
+		AccountPanelView(store: store)
+			.environment(\.colorScheme, .dark)
+			.preferredColorScheme(.dark)
+	}
+}

--- a/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
@@ -28,6 +28,57 @@ final class PanelWindowSizingLayoutTests: XCTestCase {
 		PanelWindowAppearance.apply(to: nil)
 	}
 
+	@MainActor
+	func testCustomStatusPanelIsBorderlessTransparentAndKeyCapable() {
+		let panel = TransparentStatusPanel(
+			contentRect: NSRect(x: 0, y: 0, width: 320, height: 480),
+			styleMask: [.borderless],
+			backing: .buffered,
+			defer: false
+		)
+
+		PanelWindowAppearance.apply(to: panel)
+
+		XCTAssertEqual(panel.styleMask, [.borderless])
+		XCTAssertFalse(panel.isOpaque)
+		XCTAssertEqual(panel.backgroundColor, .clear)
+		XCTAssertFalse(panel.hasShadow)
+		XCTAssertTrue(panel.canBecomeKey)
+		XCTAssertFalse(panel.canBecomeMain)
+	}
+
+	func testStatusPanelOriginUsesTheStatusItemsDisplayAndKeepsThePanelVisible() {
+		let origin = StatusPanelLayout.origin(
+			anchorRect: NSRect(x: 2_470, y: 1_320, width: 30, height: 24),
+			panelSize: NSSize(width: 340, height: 620),
+			visibleFrame: NSRect(x: 1_920, y: 0, width: 1_080, height: 1_320)
+		)
+
+		XCTAssertEqual(origin, NSPoint(x: 2_315, y: 692))
+	}
+
+	func testStatusPanelOriginClampsAtBothHorizontalDisplayEdges() {
+		let visibleFrame = NSRect(x: 1_000, y: 100, width: 800, height: 600)
+		let panelSize = NSSize(width: 340, height: 400)
+
+		XCTAssertEqual(
+			StatusPanelLayout.origin(
+				anchorRect: NSRect(x: 1_000, y: 680, width: 24, height: 20),
+				panelSize: panelSize,
+				visibleFrame: visibleFrame
+			).x,
+			1_008
+		)
+		XCTAssertEqual(
+			StatusPanelLayout.origin(
+				anchorRect: NSRect(x: 1_776, y: 680, width: 24, height: 20),
+				panelSize: panelSize,
+				visibleFrame: visibleFrame
+			).x,
+			1_452
+		)
+	}
+
 	func testRoundedContentSizeCeilsFractionalDimensions() {
 		let size = PanelWindowSizingLayout.roundedContentSize(for: CGSize(width: 339.2, height: 641.1))
 

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -48,6 +48,10 @@ final class ResetCardArchitectureTests: XCTestCase {
 			contentsOf: sourceURL.appendingPathComponent("DecodexApp.swift"),
 			encoding: .utf8
 		)
+		let statusPanel = try String(
+			contentsOf: sourceURL.appendingPathComponent("StatusPanelController.swift"),
+			encoding: .utf8
+		)
 		let panelWindow = try String(
 			contentsOf: sourceURL.appendingPathComponent("PanelWindowSizing.swift"),
 			encoding: .utf8
@@ -72,8 +76,15 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(resetCards.contains("ordinal"))
 		XCTAssertTrue(resetCards.contains("Image(systemName: \"person.crop.circle\")"))
 		XCTAssertFalse(resetCards.contains("identity.showsEmail ? \"envelope\""))
-		XCTAssertTrue(appScene.contains(".containerBackground(.clear, for: .window)"))
-		XCTAssertTrue(appScene.contains(".preferredColorScheme(.dark)"))
+		XCTAssertFalse(appScene.contains("MenuBarExtra"))
+		XCTAssertFalse(appScene.contains(".menuBarExtraStyle"))
+		XCTAssertTrue(statusPanel.contains("NSStatusBar.system.statusItem"))
+		XCTAssertTrue(statusPanel.contains("TransparentStatusPanel"))
+		XCTAssertTrue(statusPanel.contains("styleMask: [.borderless]"))
+		XCTAssertTrue(statusPanel.contains("NSHostingView(rootView: StatusPanelRootView"))
+		XCTAssertTrue(statusPanel.contains("AccountPanelView(store: store)"))
+		XCTAssertTrue(statusPanel.contains("panel.hidesOnDeactivate = true"))
+		XCTAssertTrue(statusPanel.contains(".preferredColorScheme(.dark)"))
 		XCTAssertTrue(panelWindow.contains("window.hasShadow = false"))
 		XCTAssertFalse(panelWindow.contains("window.appearance ="))
 		XCTAssertFalse(

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardCLIClientTests.swift
@@ -83,7 +83,8 @@ final class ResetCardNativeClientTests: XCTestCase {
 					{"outcome":"available","data":{
 					  "account_id":"\(accountID)",
 					  "account_revision":7,
-					  "available_count":1,
+					  "reported_available_count":1,
+					  "details_complete":true,
 					  "cards":[{"descriptor":{"granted_at_unix_seconds":100,"expires_at_unix_seconds":200}}],
 					  "five_hour_quota":\(nativeQuotaJSON(duration: 300, used: 55, reset: 2_000_000)),
 					  "seven_day_quota":\(nativeQuotaJSON(duration: 10080, used: 90, reset: 3_000_000))
@@ -143,7 +144,7 @@ final class ResetCardNativeClientTests: XCTestCase {
 		let client = DecodexNativeClient { _, _ in
 			Data(
 				"""
-				{"schema":"decodex/app-native-client/1","outcome":"success","operation":"get_reset_cards","authority":{"profile_name":"local","server_id":"0939ea28-c79b-40d5-b78f-b0c4c6790c17"},"data":{"data":{"account_id":"b7639aa9-ccc1-4957-8bd8-9a54ee909c43","account_revision":8,"available_count":2,"cards":[{"descriptor":{"expires_at_unix_seconds":1785528152,"granted_at_unix_seconds":1782936152}},{"descriptor":{"expires_at_unix_seconds":1786556624,"granted_at_unix_seconds":1783964624}}],"five_hour_quota":{"duration_minutes":300,"observed_at_unix_micros":1785335237831965,"result":{"data":{"error":"unsupported_window"},"state":"error"}},"seven_day_quota":{"duration_minutes":10080,"observed_at_unix_micros":1785335237831965,"result":{"data":{"resets_at_unix_micros":1785940048000000,"used_percent":0},"state":"current"}}},"outcome":"available"}}
+				{"schema":"decodex/app-native-client/1","outcome":"success","operation":"get_reset_cards","authority":{"profile_name":"local","server_id":"0939ea28-c79b-40d5-b78f-b0c4c6790c17"},"data":{"data":{"account_id":"b7639aa9-ccc1-4957-8bd8-9a54ee909c43","account_revision":8,"reported_available_count":2,"details_complete":true,"cards":[{"descriptor":{"expires_at_unix_seconds":1785528152,"granted_at_unix_seconds":1782936152}},{"descriptor":{"expires_at_unix_seconds":1786556624,"granted_at_unix_seconds":1783964624}}],"five_hour_quota":{"duration_minutes":300,"observed_at_unix_micros":1785335237831965,"result":{"data":{"error":"unsupported_window"},"state":"error"}},"seven_day_quota":{"duration_minutes":10080,"observed_at_unix_micros":1785335237831965,"result":{"data":{"resets_at_unix_micros":1785940048000000,"used_percent":0},"state":"current"}}},"outcome":"available"}}
 				""".utf8
 			)
 		}
@@ -155,6 +156,76 @@ final class ResetCardNativeClientTests: XCTestCase {
 		XCTAssertEqual(inventory.cards.count, 2)
 		XCTAssertEqual(inventory.fiveHourQuota.state, .error(.unsupportedWindow))
 		XCTAssertEqual(inventory.sevenDayQuota.usedPercent, 0)
+	}
+
+	func testNativeInventoryAcceptsCountOnlyPartialDetailsWithoutSelectableCards() async throws {
+		let accountID = accountID
+		let authority = authority
+		let client = DecodexNativeClient { _, _ in
+			nativeSuccess(
+				operation: "get_reset_cards",
+				authority: authority,
+				data: """
+				{"outcome":"available","data":{
+				  "account_id":"\(accountID)",
+				  "account_revision":7,
+				  "reported_available_count":2,
+				  "details_complete":false,
+				  "cards":[],
+				  "five_hour_quota":\(nativeQuotaJSON(duration: 300, used: 55, reset: 2_000_000)),
+				  "seven_day_quota":\(nativeQuotaJSON(duration: 10080, used: 90, reset: 3_000_000))
+				}}
+				"""
+			)
+		}
+
+		let inventory = try await client.inventory(
+			for: nativeAccount(authority: authority, accountID: accountID, revision: 7)
+		)
+		let state = ResetCardAccountState(
+			account: nativeAccount(authority: authority, accountID: accountID, revision: 7),
+			inventory: inventory,
+			error: nil,
+			isRefreshing: false
+		)
+
+		XCTAssertEqual(inventory.reportedAvailableCount, 2)
+		XCTAssertFalse(inventory.detailsComplete)
+		XCTAssertTrue(inventory.cards.isEmpty)
+		XCTAssertTrue(state.targets.isEmpty)
+		XCTAssertEqual(inventory.fiveHourQuota.usedPercent, 55)
+		XCTAssertEqual(inventory.sevenDayQuota.usedPercent, 90)
+	}
+
+	func testNativeInventoryRejectsAZeroCountMarkedAsPartial() async {
+		let accountID = accountID
+		let authority = authority
+		let client = DecodexNativeClient { _, _ in
+			nativeSuccess(
+				operation: "get_reset_cards",
+				authority: authority,
+				data: """
+				{"outcome":"available","data":{
+				  "account_id":"\(accountID)",
+				  "account_revision":7,
+				  "reported_available_count":0,
+				  "details_complete":false,
+				  "cards":[],
+				  "five_hour_quota":{"duration_minutes":300,"observed_at_unix_micros":null,"result":{"state":"unknown"}},
+				  "seven_day_quota":{"duration_minutes":10080,"observed_at_unix_micros":null,"result":{"state":"unknown"}}
+				}}
+				"""
+			)
+		}
+
+		do {
+			_ = try await client.inventory(
+				for: nativeAccount(authority: authority, accountID: accountID, revision: 7)
+			)
+			XCTFail("zero reported count must be a complete empty inventory")
+		} catch {
+			XCTAssertEqual(error as? ResetCardClientError, .invalidResponse)
+		}
 	}
 
 	func testObservationFailureRetainsTypedQuotaStates() async throws {

--- a/apps/decodex-cli/src/reset_card.rs
+++ b/apps/decodex-cli/src/reset_card.rs
@@ -401,18 +401,25 @@ fn render_inventory(
 			ResetCardInventoryResult::Available {
 				account_id,
 				account_revision,
-				available_count,
+				reported_available_count,
+				details_complete,
 				cards,
 				five_hour_quota: _,
 				seven_day_quota: _,
 			} => {
+				let count = reported_available_count
+					.map(|value| value.to_string())
+					.unwrap_or_else(|| "not reported".into());
+				let detail_state =
+					if *details_complete { "complete" } else { "details unavailable" };
 				let mut output = format!(
 					concat!(
-						"reset cards for {}: {} available (revision {})\n",
+						"reset cards for {}: {} available, {} (revision {})\n",
 						"profile: {}\nserver: {}"
 					),
 					account_id.as_str(),
-					available_count,
+					count,
+					detail_state,
 					account_revision.0,
 					profile.name(),
 					profile.expected_server_id().as_str(),

--- a/crates/decodex-codex/src/reset_card.rs
+++ b/crates/decodex-codex/src/reset_card.rs
@@ -7,7 +7,7 @@ use std::{
 pub use decodex_core::MAX_RESET_CARD_ITEMS as MAX_RESET_CARDS_PER_INVENTORY;
 use decodex_core::{
 	AccountQuotaObservationError, AccountQuotaWindow, ResetCardConsumeOutcome, ResetCardDescriptor,
-	ResetCardError, ResetCardTimestamp,
+	ResetCardTimestamp,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
 use serde_json::Value;
@@ -111,79 +111,127 @@ impl AvailableResetCardObservation {
 	}
 }
 
-/// Complete validated provider inventory.
+/// Validated provider observation with explicit reset-card detail completeness.
 ///
-/// Public iteration exposes only grant and expiry. Exact credit identifiers remain redacted and
-/// can be resolved only by an exact public descriptor inside the adapter/runtime boundary.
+/// Public iteration exposes only fully decoded grant and expiry pairs. Exact credit identifiers
+/// remain redacted and can be resolved only when the observation is complete and one exact public
+/// descriptor matches inside the adapter/runtime boundary.
 #[derive(Clone, Eq, PartialEq)]
 pub struct ResetCardInventory {
 	available_cards: Vec<AvailableResetCardObservation>,
 	exact_ids: Vec<ExactResetCreditId>,
+	reported_available_count: Option<u64>,
+	details_complete: bool,
 	quota_windows: [AccountRateLimitObservation; 2],
 }
 impl ResetCardInventory {
 	fn from_wire(wire: ResetCardInventoryWire) -> Result<Self, ResetCardProtocolError> {
 		let quota_windows =
 			decode_quota_windows(wire.rate_limits_by_limit_id.as_ref(), wire.rate_limits.as_ref());
-		let summary =
-			wire.rate_limit_reset_credits.ok_or(ResetCardProtocolError::DetailsUnavailable)?;
-		let credits = summary.credits.ok_or(ResetCardProtocolError::DetailsUnavailable)?;
-		let available_count = usize::try_from(summary.available_count)
+		let Some(summary) = wire.rate_limit_reset_credits else {
+			return Ok(Self {
+				available_cards: Vec::new(),
+				exact_ids: Vec::new(),
+				reported_available_count: None,
+				details_complete: false,
+				quota_windows,
+			});
+		};
+		let reported_available_count = u64::try_from(summary.available_count)
 			.map_err(|_| ResetCardProtocolError::InvalidAvailableCount)?;
-
-		if available_count > MAX_RESET_CARDS_PER_INVENTORY
-			|| credits.len() > MAX_RESET_CARDS_PER_INVENTORY
-		{
-			return Err(ResetCardProtocolError::InventoryLimitExceeded);
-		}
-
-		let mut available_cards = Vec::with_capacity(credits.len());
-		let mut exact_ids = Vec::<ExactResetCreditId>::with_capacity(credits.len());
+		let Some(credits) = summary.credits else {
+			return Ok(Self {
+				available_cards: Vec::new(),
+				exact_ids: Vec::new(),
+				reported_available_count: Some(reported_available_count),
+				details_complete: reported_available_count == 0,
+				quota_windows,
+			});
+		};
+		let details_within_bound = credits.len() <= MAX_RESET_CARDS_PER_INVENTORY;
+		let retained_capacity = credits.len().min(MAX_RESET_CARDS_PER_INVENTORY);
+		let mut available_cards = Vec::with_capacity(retained_capacity);
+		let mut exact_ids = Vec::<ExactResetCreditId>::with_capacity(retained_capacity);
 		let mut descriptors = BTreeSet::new();
+		let mut details_complete = details_within_bound;
 
-		for credit in credits {
+		for credit in credits.into_iter().take(MAX_RESET_CARDS_PER_INVENTORY) {
 			match credit.status.as_str() {
 				"available" => {},
 				"redeeming" | "redeemed" => continue,
-				_ => return Err(ResetCardProtocolError::UnknownCreditStatus),
+				_ => {
+					details_complete = false;
+					continue;
+				},
 			}
 			if credit.reset_type != "codexRateLimits" {
-				return Err(ResetCardProtocolError::UnsupportedResetType);
+				details_complete = false;
+				continue;
 			}
 
-			let expires_at =
-				credit.expires_at.ok_or(ResetCardProtocolError::IncompleteCreditDetails)?;
-			let granted_at = ResetCardTimestamp::from_unix_seconds(credit.granted_at)
-				.map_err(map_timestamp_error)?;
-			let expires_at =
-				ResetCardTimestamp::from_unix_seconds(expires_at).map_err(map_timestamp_error)?;
-			let descriptor =
-				ResetCardDescriptor::new(granted_at, expires_at).map_err(map_descriptor_error)?;
-			let exact_id = ExactResetCreditId::from_zeroizing(credit.id.0)?;
+			let Some(expires_at) = credit.expires_at else {
+				details_complete = false;
+				continue;
+			};
+			let (Ok(granted_at), Ok(expires_at)) = (
+				ResetCardTimestamp::from_unix_seconds(credit.granted_at),
+				ResetCardTimestamp::from_unix_seconds(expires_at),
+			) else {
+				details_complete = false;
+				continue;
+			};
+			let Ok(descriptor) = ResetCardDescriptor::new(granted_at, expires_at) else {
+				details_complete = false;
+				continue;
+			};
+			let Ok(exact_id) = ExactResetCreditId::from_zeroizing(credit.id.0) else {
+				details_complete = false;
+				continue;
+			};
 
 			if exact_ids.iter().any(|existing| existing == &exact_id) {
-				return Err(ResetCardProtocolError::DuplicateCreditId);
+				details_complete = false;
+				continue;
 			}
 			if !descriptors.insert(descriptor) {
-				return Err(ResetCardProtocolError::DuplicatePublicDescriptor);
+				details_complete = false;
+				continue;
 			}
 
 			available_cards.push(AvailableResetCardObservation { descriptor });
 			exact_ids.push(exact_id);
 		}
-		if available_count != available_cards.len() {
-			return Err(ResetCardProtocolError::InventoryCountMismatch);
-		}
+		details_complete &=
+			reported_available_count == u64::try_from(available_cards.len()).unwrap_or(u64::MAX);
 
-		Ok(Self { available_cards, exact_ids, quota_windows })
+		Ok(Self {
+			available_cards,
+			exact_ids,
+			reported_available_count: Some(reported_available_count),
+			details_complete,
+			quota_windows,
+		})
 	}
 
-	/// Number of complete available cards in this exact observation.
+	/// Number of fully decoded available cards retained in this observation.
 	pub fn available_count(&self) -> usize {
 		self.available_cards.len()
 	}
 
-	/// Public complete cards in provider order.
+	/// Provider-reported available count, when the provider supplied reset-card summary data.
+	pub const fn reported_available_count(&self) -> Option<u64> {
+		self.reported_available_count
+	}
+
+	/// Whether every reported available card has one bounded, unique, selectable descriptor.
+	pub const fn details_complete(&self) -> bool {
+		self.details_complete
+	}
+
+	/// Public fully decoded cards in provider order.
+	///
+	/// Callers must also require [`Self::details_complete`] before they expose these descriptors
+	/// for selection.
 	pub fn available_cards(&self) -> &[AvailableResetCardObservation] {
 		&self.available_cards
 	}
@@ -206,6 +254,9 @@ impl ResetCardInventory {
 		&self,
 		descriptor: ResetCardDescriptor,
 	) -> Result<ExactResetCreditId, ResetCardResolutionError> {
+		if !self.details_complete {
+			return Err(ResetCardResolutionError::Incomplete);
+		}
 		let mut matches = self
 			.available_cards
 			.iter()
@@ -228,6 +279,8 @@ impl Debug for ResetCardInventory {
 		formatter
 			.debug_struct("ResetCardInventory")
 			.field("available_cards", &self.available_cards)
+			.field("reported_available_count", &self.reported_available_count)
+			.field("details_complete", &self.details_complete)
 			.field("quota_windows", &self.quota_windows)
 			.finish()
 	}
@@ -410,30 +463,10 @@ pub enum ResetCardProtocolError {
 	FrameLimitExceeded,
 	/// JSON, field types, or the strict provider result shape were invalid.
 	MalformedResponse,
-	/// The inventory summary or its full details were absent.
-	DetailsUnavailable,
 	/// `availableCount` was negative or not representable.
 	InvalidAvailableCount,
-	/// The provider count differed from the complete detail count.
-	InventoryCountMismatch,
-	/// The provider inventory exceeded the accepted collection bound.
-	InventoryLimitExceeded,
-	/// One provider credit omitted a required public timestamp.
-	IncompleteCreditDetails,
-	/// One provider credit timestamp was before the Unix epoch.
-	InvalidCreditTimestamp,
-	/// One provider credit expired no later than it was granted.
-	InvalidCreditChronology,
 	/// One exact provider credit identifier was empty, oversized, or not a safe scalar.
 	InvalidCreditId,
-	/// The provider repeated an exact credit identifier.
-	DuplicateCreditId,
-	/// The provider repeated a public grant/expiry descriptor.
-	DuplicatePublicDescriptor,
-	/// A credit used a reset type other than `codexRateLimits`.
-	UnsupportedResetType,
-	/// A credit used an unknown status.
-	UnknownCreditStatus,
 	/// An idempotency key was empty, oversized, or not a safe scalar.
 	InvalidIdempotencyKey,
 	/// The consume result used an unknown outcome.
@@ -446,19 +479,8 @@ impl Display for ResetCardProtocolError {
 		formatter.write_str(match self {
 			Self::FrameLimitExceeded => "reset-card app-server result exceeds the frame limit",
 			Self::MalformedResponse => "reset-card app-server result is malformed",
-			Self::DetailsUnavailable => "complete reset-card details are unavailable",
 			Self::InvalidAvailableCount => "reset-card available count is invalid",
-			Self::InventoryCountMismatch =>
-				"reset-card available count does not match complete details",
-			Self::InventoryLimitExceeded => "reset-card inventory exceeds its collection limit",
-			Self::IncompleteCreditDetails => "reset-card public details are incomplete",
-			Self::InvalidCreditTimestamp => "reset-card provider timestamp is invalid",
-			Self::InvalidCreditChronology => "reset-card provider chronology is invalid",
 			Self::InvalidCreditId => "reset-card provider credit identity is invalid",
-			Self::DuplicateCreditId => "reset-card provider credit identity is duplicated",
-			Self::DuplicatePublicDescriptor => "reset-card public descriptor is duplicated",
-			Self::UnsupportedResetType => "reset-card provider type is unsupported",
-			Self::UnknownCreditStatus => "reset-card provider status is unknown",
 			Self::InvalidIdempotencyKey => "reset-card idempotency key is invalid",
 			Self::UnknownConsumeOutcome => "reset-card consume outcome is unknown",
 		})
@@ -468,6 +490,8 @@ impl Display for ResetCardProtocolError {
 /// Exact-descriptor resolution failure.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ResetCardResolutionError {
+	/// The provider did not return every exact selectable detail for the reported inventory.
+	Incomplete,
 	/// The current complete inventory did not contain the descriptor.
 	NotFound,
 	/// More than one current credit had the descriptor.
@@ -478,6 +502,7 @@ impl Error for ResetCardResolutionError {}
 impl Display for ResetCardResolutionError {
 	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
 		formatter.write_str(match self {
+			Self::Incomplete => "reset-card inventory details are incomplete",
 			Self::NotFound => "reset-card descriptor was not found",
 			Self::Ambiguous => "reset-card descriptor is ambiguous",
 		})
@@ -496,7 +521,7 @@ struct ResetCardInventoryWire {
 }
 
 #[derive(Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 struct ResetCardSummaryWire {
 	available_count: i64,
 	#[serde(default)]
@@ -504,7 +529,7 @@ struct ResetCardSummaryWire {
 }
 
 #[derive(Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 struct ResetCardCreditWire {
 	id: ZeroizingWireText,
 	granted_at: i64,
@@ -595,10 +620,10 @@ fn parse_quota_window(
 		.and_then(Value::as_u64)
 		.and_then(|value| u8::try_from(value).ok())
 		.ok_or(AccountQuotaObservationError::ProtocolUnavailable)?;
-	let resets_at_seconds = window
-		.get("resetsAt")
-		.and_then(Value::as_i64)
-		.ok_or(AccountQuotaObservationError::ProtocolUnavailable)?;
+	let resets_at_seconds = match window.get("resetsAt") {
+		Some(Value::Null) | None => return Err(AccountQuotaObservationError::UnsupportedWindow),
+		Some(value) => value.as_i64().ok_or(AccountQuotaObservationError::ProtocolUnavailable)?,
+	};
 	let resets_at_micros = resets_at_seconds
 		.checked_mul(1_000_000)
 		.ok_or(AccountQuotaObservationError::ProtocolUnavailable)?;
@@ -639,20 +664,6 @@ fn is_bounded_scalar(value: &str, max_bytes: usize) -> bool {
 		&& value.len() <= max_bytes
 		&& value.trim() == value
 		&& !value.chars().any(char::is_control)
-}
-
-fn map_timestamp_error(error: ResetCardError) -> ResetCardProtocolError {
-	match error {
-		ResetCardError::NegativeTimestamp => ResetCardProtocolError::InvalidCreditTimestamp,
-		ResetCardError::ExpirationNotAfterGrant => ResetCardProtocolError::InvalidCreditChronology,
-	}
-}
-
-fn map_descriptor_error(error: ResetCardError) -> ResetCardProtocolError {
-	match error {
-		ResetCardError::NegativeTimestamp => ResetCardProtocolError::InvalidCreditTimestamp,
-		ResetCardError::ExpirationNotAfterGrant => ResetCardProtocolError::InvalidCreditChronology,
-	}
 }
 
 #[cfg(test)]
@@ -730,6 +741,8 @@ mod tests {
 		let inventory = decode_reset_card_inventory(&bytes).unwrap();
 
 		assert_eq!(inventory.available_count(), 2);
+		assert_eq!(inventory.reported_available_count(), Some(2));
+		assert!(inventory.details_complete());
 		assert_eq!(
 			inventory.available_cards().iter().map(|card| card.descriptor()).collect::<Vec<_>>(),
 			vec![descriptor(100, 200), descriptor(300, 400)]
@@ -880,6 +893,31 @@ mod tests {
 			inventory.quota_windows()[1].result(),
 			Err(AccountQuotaObservationError::UnsupportedWindow)
 		);
+
+		let null_reset = inventory_with_limits(
+			json!({
+				"primary": {
+					"usedPercent": 9,
+					"windowDurationMins": 300,
+					"resetsAt": null
+				},
+				"secondary": {
+					"usedPercent": 19,
+					"windowDurationMins": 10_080,
+					"resetsAt": "invalid"
+				}
+			}),
+			json!(null),
+		);
+		let inventory = decode_reset_card_inventory(&null_reset).unwrap();
+		assert_eq!(
+			inventory.quota_windows()[0].result(),
+			Err(AccountQuotaObservationError::UnsupportedWindow)
+		);
+		assert_eq!(
+			inventory.quota_windows()[1].result(),
+			Err(AccountQuotaObservationError::ProtocolUnavailable)
+		);
 	}
 
 	#[test]
@@ -945,24 +983,43 @@ mod tests {
 	}
 
 	#[test]
-	fn inventory_rejects_missing_or_capped_details() {
+	fn inventory_accepts_missing_null_capped_and_bounded_partial_details() {
+		let missing = decode_reset_card_inventory(br#"{"rateLimits":{}}"#).unwrap();
+		assert_eq!(missing.reported_available_count(), None);
+		assert!(!missing.details_complete());
+		assert!(missing.available_cards().is_empty());
+
+		let null_details = decode_reset_card_inventory(
+			br#"{"rateLimitResetCredits":{"availableCount":1,"credits":null}}"#,
+		)
+		.unwrap();
+		assert_eq!(null_details.reported_available_count(), Some(1));
+		assert!(!null_details.details_complete());
 		assert_eq!(
-			decode_reset_card_inventory(br#"{"rateLimits":{}}"#),
-			Err(ResetCardProtocolError::DetailsUnavailable)
+			null_details.resolve_exact_credit_id(descriptor(100, 200)),
+			Err(ResetCardResolutionError::Incomplete)
 		);
+		let definitive_empty = decode_reset_card_inventory(
+			br#"{"rateLimitResetCredits":{"availableCount":0,"credits":null}}"#,
+		)
+		.unwrap();
+		assert_eq!(definitive_empty.reported_available_count(), Some(0));
+		assert!(definitive_empty.details_complete());
+		assert!(definitive_empty.available_cards().is_empty());
+
+		let capped = decode_reset_card_inventory(&inventory_json(
+			json!([credit("credit-a", 100, json!(200))]),
+			2,
+		))
+		.unwrap();
+		assert_eq!(capped.reported_available_count(), Some(2));
+		assert_eq!(capped.available_count(), 1);
+		assert!(!capped.details_complete());
 		assert_eq!(
-			decode_reset_card_inventory(
-				br#"{"rateLimitResetCredits":{"availableCount":1,"credits":null}}"#
-			),
-			Err(ResetCardProtocolError::DetailsUnavailable)
+			capped.resolve_exact_credit_id(descriptor(100, 200)),
+			Err(ResetCardResolutionError::Incomplete)
 		);
-		assert_eq!(
-			decode_reset_card_inventory(&inventory_json(
-				json!([credit("credit-a", 100, json!(200))]),
-				2
-			)),
-			Err(ResetCardProtocolError::InventoryCountMismatch)
-		);
+
 		assert_eq!(
 			decode_reset_card_inventory(
 				br#"{"rateLimitResetCredits":{"availableCount":-1,"credits":[]}}"#
@@ -981,36 +1038,45 @@ mod tests {
 
 		assert_eq!(super::MAX_RESET_CARDS_PER_INVENTORY, 64);
 		assert_eq!(inventory.available_count(), 64);
+		assert_eq!(inventory.reported_available_count(), Some(64));
+		assert!(inventory.details_complete());
 
 		let oversized = (0..=super::MAX_RESET_CARDS_PER_INVENTORY)
 			.map(|index| credit(&format!("credit-{index}"), index as i64, json!(index + 1)))
 			.collect::<Vec<_>>();
-
+		let oversized = decode_reset_card_inventory(&inventory_json(
+			json!(oversized),
+			(super::MAX_RESET_CARDS_PER_INVENTORY + 1) as i64,
+		))
+		.unwrap();
+		assert_eq!(oversized.available_count(), super::MAX_RESET_CARDS_PER_INVENTORY);
 		assert_eq!(
-			decode_reset_card_inventory(&inventory_json(
-				json!(oversized),
-				(super::MAX_RESET_CARDS_PER_INVENTORY + 1) as i64
-			)),
-			Err(ResetCardProtocolError::InventoryLimitExceeded)
+			oversized.reported_available_count(),
+			Some((super::MAX_RESET_CARDS_PER_INVENTORY + 1) as u64)
 		);
+		assert!(!oversized.details_complete());
 	}
 
 	#[test]
-	fn inventory_rejects_duplicate_public_or_private_identity() {
-		assert_eq!(
+	fn duplicate_public_or_private_identity_makes_details_non_selectable() {
+		for inventory in [
 			decode_reset_card_inventory(&inventory_json(
 				json!([credit("credit-a", 100, json!(200)), credit("credit-b", 100, json!(200))]),
-				2
-			)),
-			Err(ResetCardProtocolError::DuplicatePublicDescriptor)
-		);
-		assert_eq!(
+				2,
+			))
+			.unwrap(),
 			decode_reset_card_inventory(&inventory_json(
 				json!([credit("credit-a", 100, json!(200)), credit("credit-a", 300, json!(400))]),
-				2
-			)),
-			Err(ResetCardProtocolError::DuplicateCreditId)
-		);
+				2,
+			))
+			.unwrap(),
+		] {
+			assert!(!inventory.details_complete());
+			assert_eq!(
+				inventory.resolve_exact_credit_id(descriptor(100, 200)),
+				Err(ResetCardResolutionError::Incomplete)
+			);
+		}
 	}
 
 	#[test]
@@ -1035,50 +1101,87 @@ mod tests {
 			!inventory
 				.contains_exact_credit_id(&ExactResetCreditId::new("credit-redeemed").unwrap())
 		);
-		assert_eq!(
-			decode_reset_card_inventory(&inventory_json(credits, 2)),
-			Err(ResetCardProtocolError::InventoryCountMismatch)
-		);
+		let count_mismatch = decode_reset_card_inventory(&inventory_json(credits, 2)).unwrap();
+		assert_eq!(count_mismatch.reported_available_count(), Some(2));
+		assert!(!count_mismatch.details_complete());
 	}
 
 	#[test]
-	fn inventory_rejects_incomplete_invalid_or_unknown_card_fields() {
+	fn incomplete_invalid_unknown_or_extended_card_fields_are_non_selectable_partial_details() {
 		let cases = [
-			(credit("credit-a", 100, Value::Null), ResetCardProtocolError::IncompleteCreditDetails),
-			(credit("credit-a", -1, json!(200)), ResetCardProtocolError::InvalidCreditTimestamp),
-			(credit("credit-a", 200, json!(200)), ResetCardProtocolError::InvalidCreditChronology),
-			(
-				{
-					let mut value = credit("credit-a", 100, json!(200));
-					value["resetType"] = json!("unknown");
-					value
-				},
-				ResetCardProtocolError::UnsupportedResetType,
-			),
-			(
-				{
-					let mut value = credit("credit-a", 100, json!(200));
-					value["status"] = json!("unknown");
-					value
-				},
-				ResetCardProtocolError::UnknownCreditStatus,
-			),
+			credit("credit-a", 100, Value::Null),
+			credit("credit-a", -1, json!(200)),
+			credit("credit-a", 200, json!(200)),
+			{
+				let mut value = credit("credit-a", 100, json!(200));
+				value["resetType"] = json!("unknown");
+				value
+			},
+			{
+				let mut value = credit("credit-a", 100, json!(200));
+				value["status"] = json!("unknown");
+				value
+			},
 		];
 
-		for (credit, expected) in cases {
-			assert_eq!(
-				decode_reset_card_inventory(&inventory_json(json!([credit]), 1)),
-				Err(expected)
-			);
+		for credit in cases {
+			let inventory =
+				decode_reset_card_inventory(&inventory_json(json!([credit]), 1)).unwrap();
+			assert_eq!(inventory.reported_available_count(), Some(1));
+			assert!(inventory.available_cards().is_empty());
+			assert!(!inventory.details_complete());
 		}
 
 		let mut unknown_field = credit("credit-a", 100, json!(200));
 		unknown_field["providerExtension"] = json!(true);
+		let mut extended =
+			serde_json::from_slice::<Value>(&inventory_json(json!([unknown_field]), 1)).unwrap();
+		extended["rateLimitResetCredits"]["providerExtension"] = json!("ignored");
+		let inventory =
+			decode_reset_card_inventory(&serde_json::to_vec(&extended).unwrap()).unwrap();
+		assert!(inventory.details_complete());
+		assert_eq!(inventory.available_count(), 1);
+	}
 
-		assert_eq!(
-			decode_reset_card_inventory(&inventory_json(json!([unknown_field]), 1)),
-			Err(ResetCardProtocolError::MalformedResponse)
-		);
+	#[test]
+	fn partial_reset_card_details_do_not_discard_valid_quota_windows() {
+		let quota = json!({
+			"primary": {
+				"usedPercent": 12,
+				"windowDurationMins": 300,
+				"resetsAt": 2_000
+			},
+			"secondary": {
+				"usedPercent": 34,
+				"windowDurationMins": 10_080,
+				"resetsAt": 3_000
+			}
+		});
+		for reset_credits in [
+			Value::Null,
+			json!({"availableCount": 2, "credits": null}),
+			json!({
+				"availableCount": 2,
+				"credits": [credit("credit-a", 100, json!(200))]
+			}),
+		] {
+			let bytes = serde_json::to_vec(&json!({
+				"rateLimits": quota,
+				"rateLimitResetCredits": reset_credits
+			}))
+			.unwrap();
+			let inventory = decode_reset_card_inventory(&bytes).unwrap();
+
+			assert!(!inventory.details_complete());
+			assert_eq!(
+				inventory.quota_windows()[0].result(),
+				Ok(AccountQuotaWindow::new(300, 12, 2_000_000_000).unwrap())
+			);
+			assert_eq!(
+				inventory.quota_windows()[1].result(),
+				Ok(AccountQuotaWindow::new(10_080, 34, 3_000_000_000).unwrap())
+			);
+		}
 	}
 
 	#[test]

--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -392,7 +392,7 @@ impl ResetCardClient {
 		&self.profile
 	}
 
-	/// Read one fresh complete public reset-card inventory.
+	/// Read one fresh public reset-card observation with explicit detail completeness.
 	pub async fn list(
 		&self,
 		account_id: EntityId,

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -863,18 +863,20 @@ pub struct ResetCardObservationDto {
 	pub descriptor: ResetCardDescriptorDto,
 }
 
-/// Bounded current reset-card inventory for one account.
+/// Bounded current reset-card observation for one account.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ResetCardInventoryResult {
-	/// A complete inventory safe for explicit selection.
+	/// One observation whose descriptors are present only when detail completeness is true.
 	Available {
 		/// Canonical vNext account UUID.
 		account_id: EntityId,
 		/// Current optimistic account revision.
 		account_revision: EntityRevision,
-		/// Exact current number of available cards.
-		available_count: u16,
-		/// Complete unique public card observations.
+		/// Provider-reported current number of available cards, when reported.
+		reported_available_count: Option<u64>,
+		/// Whether every reported card has one complete unique public descriptor.
+		details_complete: bool,
+		/// Complete unique public card observations, present only when details are complete.
 		cards: Vec<ResetCardObservationDto>,
 		/// Freshness and value of the exact 300-minute window from this same provider call.
 		five_hour_quota: AccountQuotaWindowDto,
@@ -911,7 +913,8 @@ impl Serialize for ResetCardInventoryResult {
 			Available {
 				account_id: &'a EntityId,
 				account_revision: EntityRevision,
-				available_count: u16,
+				reported_available_count: Option<u64>,
+				details_complete: bool,
 				cards: &'a [ResetCardObservationDto],
 				five_hour_quota: AccountQuotaWindowDto,
 				seven_day_quota: AccountQuotaWindowDto,
@@ -932,7 +935,8 @@ impl Serialize for ResetCardInventoryResult {
 			Self::Available {
 				account_id,
 				account_revision,
-				available_count,
+				reported_available_count,
+				details_complete,
 				cards,
 				five_hour_quota,
 				seven_day_quota,
@@ -940,7 +944,8 @@ impl Serialize for ResetCardInventoryResult {
 				validate_reset_card_inventory(
 					account_id,
 					*account_revision,
-					*available_count,
+					*reported_available_count,
+					*details_complete,
 					cards,
 					*five_hour_quota,
 					*seven_day_quota,
@@ -949,7 +954,8 @@ impl Serialize for ResetCardInventoryResult {
 				RawResult::Available {
 					account_id,
 					account_revision: *account_revision,
-					available_count: *available_count,
+					reported_available_count: *reported_available_count,
+					details_complete: *details_complete,
 					cards,
 					five_hour_quota: *five_hour_quota,
 					seven_day_quota: *seven_day_quota,
@@ -994,7 +1000,8 @@ impl<'de> Deserialize<'de> for ResetCardInventoryResult {
 			Available {
 				account_id: EntityId,
 				account_revision: EntityRevision,
-				available_count: u16,
+				reported_available_count: Option<u64>,
+				details_complete: bool,
 				cards: Vec<ResetCardObservationDto>,
 				five_hour_quota: AccountQuotaWindowDto,
 				seven_day_quota: AccountQuotaWindowDto,
@@ -1015,7 +1022,8 @@ impl<'de> Deserialize<'de> for ResetCardInventoryResult {
 			RawResult::Available {
 				account_id,
 				account_revision,
-				available_count,
+				reported_available_count,
+				details_complete,
 				cards,
 				five_hour_quota,
 				seven_day_quota,
@@ -1023,7 +1031,8 @@ impl<'de> Deserialize<'de> for ResetCardInventoryResult {
 				validate_reset_card_inventory(
 					&account_id,
 					account_revision,
-					available_count,
+					reported_available_count,
+					details_complete,
 					&cards,
 					five_hour_quota,
 					seven_day_quota,
@@ -1033,7 +1042,8 @@ impl<'de> Deserialize<'de> for ResetCardInventoryResult {
 				Ok(Self::Available {
 					account_id,
 					account_revision,
-					available_count,
+					reported_available_count,
+					details_complete,
 					cards,
 					five_hour_quota,
 					seven_day_quota,
@@ -3279,7 +3289,8 @@ fn canonical_calendar_date(value: &str) -> bool {
 fn validate_reset_card_inventory(
 	account_id: &EntityId,
 	account_revision: EntityRevision,
-	available_count: u16,
+	reported_available_count: Option<u64>,
+	details_complete: bool,
 	cards: &[ResetCardObservationDto],
 	five_hour_quota: AccountQuotaWindowDto,
 	seven_day_quota: AccountQuotaWindowDto,
@@ -3293,8 +3304,17 @@ fn validate_reset_card_inventory(
 	if cards.len() > MAX_RESET_CARD_ITEMS {
 		return Err("reset-card inventory exceeds item bound");
 	}
-	if usize::from(available_count) != cards.len() {
-		return Err("reset-card inventory is incomplete");
+	if details_complete {
+		if reported_available_count != u64::try_from(cards.len()).ok() {
+			return Err("complete reset-card inventory does not match its reported count");
+		}
+	} else {
+		if !cards.is_empty() {
+			return Err("partial reset-card inventory exposes selectable descriptors");
+		}
+		if reported_available_count == Some(0) {
+			return Err("zero reset-card inventory must be complete");
+		}
 	}
 
 	let unique = cards.iter().map(|card| card.descriptor).collect::<HashSet<_>>();
@@ -3891,7 +3911,8 @@ mod tests {
 			"data":{
 				"account_id":account_id,
 				"account_revision":1,
-				"available_count":2,
+				"reported_available_count":2,
+				"details_complete":true,
 				"cards":[card.clone(),card.clone()],
 				"five_hour_quota":{"duration_minutes":300,"observed_at_unix_micros":null,"result":{"state":"unknown"}},
 				"seven_day_quota":{"duration_minutes":10080,"observed_at_unix_micros":null,"result":{"state":"unknown"}}
@@ -3902,7 +3923,8 @@ mod tests {
 			"data":{
 				"account_id":account_id,
 				"account_revision":1,
-				"available_count":2,
+				"reported_available_count":2,
+				"details_complete":true,
 				"cards":[card.clone()],
 				"five_hour_quota":{"duration_minutes":300,"observed_at_unix_micros":null,"result":{"state":"unknown"}},
 				"seven_day_quota":{"duration_minutes":10080,"observed_at_unix_micros":null,"result":{"state":"unknown"}}
@@ -3913,7 +3935,8 @@ mod tests {
 			"data":{
 				"account_id":account_id,
 				"account_revision":0,
-				"available_count":1,
+				"reported_available_count":1,
+				"details_complete":true,
 				"cards":[card.clone()],
 				"five_hour_quota":{"duration_minutes":300,"observed_at_unix_micros":null,"result":{"state":"unknown"}},
 				"seven_day_quota":{"duration_minutes":10080,"observed_at_unix_micros":null,"result":{"state":"unknown"}}
@@ -3924,7 +3947,8 @@ mod tests {
 			"data":{
 				"account_id":account_id,
 				"account_revision":1,
-				"available_count":u16::try_from(MAX_RESET_CARD_ITEMS + 1).unwrap(),
+				"reported_available_count":u64::try_from(MAX_RESET_CARD_ITEMS + 1).unwrap(),
+				"details_complete":true,
 				"cards":vec![card; MAX_RESET_CARD_ITEMS + 1],
 				"five_hour_quota":{"duration_minutes":300,"observed_at_unix_micros":null,"result":{"state":"unknown"}},
 				"seven_day_quota":{"duration_minutes":10080,"observed_at_unix_micros":null,"result":{"state":"unknown"}}
@@ -3945,7 +3969,8 @@ mod tests {
 			"data":{
 				"account_id":account_id,
 				"account_revision":1,
-				"available_count":u16::try_from(MAX_RESET_CARD_ITEMS).unwrap(),
+				"reported_available_count":u64::try_from(MAX_RESET_CARD_ITEMS).unwrap(),
+				"details_complete":true,
 				"cards":bounded_cards,
 				"five_hour_quota":{"duration_minutes":300,"observed_at_unix_micros":null,"result":{"state":"unknown"}},
 				"seven_day_quota":{"duration_minutes":10080,"observed_at_unix_micros":null,"result":{"state":"unknown"}}
@@ -3958,6 +3983,32 @@ mod tests {
 		assert!(serde_json::from_value::<ResetCardInventoryResult>(incomplete).is_err());
 		assert!(serde_json::from_value::<ResetCardInventoryResult>(zero_revision).is_err());
 		assert!(serde_json::from_value::<ResetCardInventoryResult>(oversized).is_err());
+		let partial = serde_json::json!({
+			"outcome":"available",
+			"data":{
+				"account_id":account_id,
+				"account_revision":1,
+				"reported_available_count":2,
+				"details_complete":false,
+				"cards":[],
+				"five_hour_quota":{"duration_minutes":300,"observed_at_unix_micros":null,"result":{"state":"unknown"}},
+				"seven_day_quota":{"duration_minutes":10080,"observed_at_unix_micros":null,"result":{"state":"unknown"}}
+			}
+		});
+		assert!(serde_json::from_value::<ResetCardInventoryResult>(partial).is_ok());
+		let contradictory_empty = serde_json::json!({
+			"outcome":"available",
+			"data":{
+				"account_id":account_id,
+				"account_revision":1,
+				"reported_available_count":0,
+				"details_complete":false,
+				"cards":[],
+				"five_hour_quota":{"duration_minutes":300,"observed_at_unix_micros":null,"result":{"state":"unknown"}},
+				"seven_day_quota":{"duration_minutes":10080,"observed_at_unix_micros":null,"result":{"state":"unknown"}}
+			}
+		});
+		assert!(serde_json::from_value::<ResetCardInventoryResult>(contradictory_empty).is_err());
 		assert_reset_card_outbound_bounds(account_id);
 	}
 
@@ -3974,7 +4025,8 @@ mod tests {
 		let bounded_outbound = ResetCardInventoryResult::Available {
 			account_id: EntityId::new(account_id).unwrap(),
 			account_revision: EntityRevision(1),
-			available_count: u16::try_from(MAX_RESET_CARD_ITEMS).unwrap(),
+			reported_available_count: u64::try_from(MAX_RESET_CARD_ITEMS).ok(),
+			details_complete: true,
 			cards: outbound_cards.clone(),
 			five_hour_quota: super::AccountQuotaWindowDto {
 				duration_minutes: 300,
@@ -3990,7 +4042,8 @@ mod tests {
 		let oversized_outbound = ResetCardInventoryResult::Available {
 			account_id: EntityId::new(account_id).unwrap(),
 			account_revision: EntityRevision(1),
-			available_count: u16::try_from(MAX_RESET_CARD_ITEMS + 1).unwrap(),
+			reported_available_count: u64::try_from(MAX_RESET_CARD_ITEMS + 1).ok(),
+			details_complete: true,
 			cards: outbound_cards
 				.into_iter()
 				.chain([super::ResetCardObservationDto {
@@ -4011,7 +4064,8 @@ mod tests {
 		let zero_revision_outbound = ResetCardInventoryResult::Available {
 			account_id: EntityId::new(account_id).unwrap(),
 			account_revision: EntityRevision(0),
-			available_count: 0,
+			reported_available_count: Some(0),
+			details_complete: true,
 			cards: Vec::new(),
 			five_hour_quota: super::AccountQuotaWindowDto {
 				duration_minutes: 300,

--- a/crates/decodex-runtime/src/account_launch/reset_card.rs
+++ b/crates/decodex-runtime/src/account_launch/reset_card.rs
@@ -89,11 +89,13 @@ enum InitialCredentialProjection {
 	CallbackProbe,
 }
 
-/// Complete public inventory plus the exact account revision observed around process work.
+/// Public reset-card observation plus the exact account revision observed around process work.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ResetCardInventoryView {
 	pub account_id: AccountId,
 	pub account_revision: i64,
+	pub reported_available_count: Option<u64>,
+	pub details_complete: bool,
 	pub cards: Vec<ResetCardDescriptor>,
 	pub five_hour_quota: AccountQuotaWindowObservation,
 	pub seven_day_quota: AccountQuotaWindowObservation,
@@ -441,13 +443,13 @@ impl ResetCardRuntime {
 		&self,
 		account_id: &AccountId,
 	) -> Result<ResetCardInventoryObservation, ResetCardServiceError> {
-		let account = self.observable_account(account_id).await?;
 		let credential = self
 			.inner
 			.accounts
-			.process_credential_for_observation(account_id, account.revision)
+			.process_credential_for_observation(account_id, MAX_BLOCKING_PROCESS_DEADLINE)
 			.await
 			.map_err(map_account_service_error)?;
+		let account_revision = credential.binding.account_revision;
 		let process_binding = credential.binding.clone();
 		let observed_at_unix_micros =
 			current_unix_micros().ok_or(ResetCardServiceError::ProductStateUnavailable)?;
@@ -480,11 +482,13 @@ impl ResetCardRuntime {
 				Ok(ResetCardInventoryObservation::Available(ResetCardInventoryView {
 					account_id: account_id.clone(),
 					account_revision: current.binding.account_revision,
-					cards: inventory
-						.available_cards()
-						.iter()
-						.map(|card| card.descriptor())
-						.collect(),
+					reported_available_count: inventory.reported_available_count(),
+					details_complete: inventory.details_complete(),
+					cards: if inventory.details_complete() {
+						inventory.available_cards().iter().map(|card| card.descriptor()).collect()
+					} else {
+						Vec::new()
+					},
 					five_hour_quota,
 					seven_day_quota,
 				}))
@@ -501,7 +505,7 @@ impl ResetCardRuntime {
 
 				Ok(ResetCardInventoryObservation::ObservationFailed(ResetCardObservationFailure {
 					account_id: account_id.clone(),
-					account_revision: account.revision,
+					account_revision,
 					five_hour_quota,
 					seven_day_quota,
 					error,
@@ -662,24 +666,6 @@ impl ResetCardRuntime {
 
 		Ok(account)
 	}
-
-	async fn observable_account(
-		&self,
-		account_id: &AccountId,
-	) -> Result<AccountRecord, ResetCardServiceError> {
-		let account = self
-			.inner
-			.accounts
-			.inspect(account_id)
-			.await
-			.map_err(map_account_service_error)?
-			.account;
-		if account.lifecycle_readiness != AccountLifecycleReadiness::Ready {
-			return Err(ResetCardServiceError::AccountStateRejected);
-		}
-
-		Ok(account)
-	}
 }
 
 async fn run_worker(inner: Arc<ResetCardRuntimeInner>, mut stop: watch::Receiver<bool>) {
@@ -795,7 +781,11 @@ async fn resolve_claim_credit_id(
 			};
 			let exact = match inventory.resolve_exact_credit_id(claim.descriptor) {
 				Ok(exact) => exact,
-				Err(ResetCardResolutionError::NotFound | ResetCardResolutionError::Ambiguous) => {
+				Err(
+					ResetCardResolutionError::Incomplete
+					| ResetCardResolutionError::NotFound
+					| ResetCardResolutionError::Ambiguous,
+				) => {
 					fail_before_effect(inner, claim, ResetCardFailureCode::InventoryChanged).await;
 
 					return None;
@@ -1007,6 +997,9 @@ async fn complete_reconciliation(
 	outcome: ResetCardConsumeOutcome,
 	inventory: &ResetCardInventory,
 ) {
+	if !inventory.details_complete() {
+		return;
+	}
 	let selected_exact_credit_available = inventory.contains_exact_credit_id(exact_credit_id);
 	let selected_descriptor_expired = current_unix_seconds()
 		.is_some_and(|now| now >= claim.descriptor.expires_at().unix_seconds());

--- a/crates/decodex-runtime/src/account_service.rs
+++ b/crates/decodex-runtime/src/account_service.rs
@@ -814,7 +814,6 @@ impl AccountService {
 	}
 
 	/// Refresh one exact account through either proactive or exact generation-bound authority.
-	#[allow(clippy::too_many_lines)] // Keep the generation-bound refresh state machine auditable as one sequence.
 	pub async fn refresh(
 		&self,
 		operation_id: AccountOperationId,
@@ -825,6 +824,27 @@ impl AccountService {
 	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
 		let lock = self.lock_for(account_id)?;
 		let _guard = lock.lock().await;
+		self.refresh_while_locked(
+			operation_id,
+			account_id,
+			expected_account_revision,
+			callback_generation,
+			previous_provider_account_id,
+			false,
+		)
+		.await
+	}
+
+	#[allow(clippy::too_many_lines)] // Keep the generation-bound refresh state machine auditable as one sequence.
+	async fn refresh_while_locked(
+		&self,
+		operation_id: AccountOperationId,
+		account_id: &AccountId,
+		expected_account_revision: Option<i64>,
+		callback_generation: Option<(&ProcessGenerationId, &ProcessGenerationAccountBinding)>,
+		previous_provider_account_id: Option<&str>,
+		allow_disabled: bool,
+	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
 		if let Some((generation_id, process_binding)) = callback_generation {
 			self.require_active_callback_generation(account_id, generation_id, process_binding)
 				.await?;
@@ -870,6 +890,8 @@ impl AccountService {
 		}
 		let stored = if callback_generation.is_some() {
 			self.read_exact_for_bound_callback(&account).await?
+		} else if allow_disabled {
+			self.read_exact_for_existing_work(&account).await?
 		} else {
 			self.read_exact_for_admission(&account).await?
 		};
@@ -908,9 +930,20 @@ impl AccountService {
 			)?;
 		}
 		let refresher = Arc::clone(&self.refresher);
-		let refreshed = tokio::task::spawn_blocking(move || refresher.refresh(stored.bundle()))
-			.await
-			.map_err(|_| AccountLifecycleError::Refresh(CredentialRefreshError::Ambiguous))?;
+		let refreshed =
+			match tokio::task::spawn_blocking(move || refresher.refresh(stored.bundle())).await {
+				Ok(refreshed) => refreshed,
+				Err(_) => {
+					self.recover_or_cancel(
+						&operation_id,
+						AccountOperationPhase::ProviderEffectPending,
+						"provider_refresh_ambiguous",
+						true,
+					)
+					.await?;
+					return Err(AccountLifecycleError::Refresh(CredentialRefreshError::Ambiguous));
+				},
+			};
 		let refreshed = match refreshed {
 			Ok(refreshed) => refreshed,
 			Err(CredentialRefreshError::Rejected) => {
@@ -2378,16 +2411,39 @@ impl AccountService {
 	pub(crate) async fn process_credential_for_observation(
 		&self,
 		account_id: &AccountId,
-		expected_revision: i64,
+		minimum_validity: Duration,
 	) -> Result<AccountProcessCredential, AccountLifecycleError> {
 		let launch_guard = self.lock_for(account_id)?.lock_owned().await;
-		let account = self.load_account(account_id).await?;
-		if account.revision != expected_revision {
-			return Err(AccountLifecycleError::StaleAccount);
+		let mut account = self.load_account(account_id).await?;
+		let mut stored = self.read_exact_for_existing_work(&account).await?;
+		let now_unix_micros = current_unix_micros()?;
+		if access_token_needs_refresh(
+			stored.bundle().access_token_expires_at_unix_micros(),
+			now_unix_micros,
+			minimum_validity,
+		)? {
+			let operation_id = AccountOperationId::generate()
+				.map_err(|_| AccountLifecycleError::InvalidOperation)?;
+			self.refresh_while_locked(
+				operation_id,
+				account_id,
+				Some(account.revision),
+				None,
+				None,
+				true,
+			)
+			.await?;
+			account = self.load_account(account_id).await?;
+			stored = self.read_exact_for_existing_work(&account).await?;
+			let refreshed_at_unix_micros = current_unix_micros()?;
+			require_refreshed_access_token_for_observation(
+				stored.bundle().access_token_expires_at_unix_micros(),
+				refreshed_at_unix_micros,
+				minimum_validity,
+			)?;
 		}
 		let credential =
 			account.credential.clone().ok_or(AccountLifecycleError::CredentialAbsent)?;
-		let stored = self.read_exact_for_existing_work(&account).await?;
 		let callback_profile = self.callback_profile().map_err(|_| {
 			AccountLifecycleError::NotReady(AccountLifecycleReadiness::CallbackCapabilityUnready)
 		})?;
@@ -2957,6 +3013,38 @@ fn projection(
 	}
 }
 
+fn current_unix_micros() -> Result<i64, AccountLifecycleError> {
+	SystemTime::now()
+		.duration_since(UNIX_EPOCH)
+		.ok()
+		.and_then(|duration| i64::try_from(duration.as_micros()).ok())
+		.ok_or(AccountLifecycleError::InvalidOperation)
+}
+
+fn access_token_needs_refresh(
+	expires_at_unix_micros: i64,
+	now_unix_micros: i64,
+	minimum_validity: Duration,
+) -> Result<bool, AccountLifecycleError> {
+	let minimum_validity_micros = i64::try_from(minimum_validity.as_micros())
+		.map_err(|_| AccountLifecycleError::InvalidOperation)?;
+	let required_until = now_unix_micros
+		.checked_add(minimum_validity_micros)
+		.ok_or(AccountLifecycleError::InvalidOperation)?;
+	Ok(expires_at_unix_micros <= required_until)
+}
+
+fn require_refreshed_access_token_for_observation(
+	expires_at_unix_micros: i64,
+	now_unix_micros: i64,
+	minimum_validity: Duration,
+) -> Result<(), AccountLifecycleError> {
+	if access_token_needs_refresh(expires_at_unix_micros, now_unix_micros, minimum_validity)? {
+		return Err(AccountLifecycleError::Refresh(CredentialRefreshError::Unavailable));
+	}
+	Ok(())
+}
+
 fn refreshed_credential_target(
 	current: &CredentialBinding,
 	account_id: &AccountId,
@@ -3167,9 +3255,11 @@ mod tests {
 	use super::{
 		ACCOUNT_ALIAS_WORDS, AccountLifecycleError, CredentialImportError, CredentialRefreshError,
 		CredentialSecretBundle, ImportedCredential, PROVIDER_REFRESH_OUTCOME_UNKNOWN,
-		RefreshResponse, UseInCodexProjectionError, account_lock_for, codex_auth_projection_digest,
-		credential_refresh_result, matching_shared_refresh, projection_binding,
-		refreshed_credential_target, stable_account_alias, use_in_codex_receipt_result,
+		RefreshResponse, UseInCodexProjectionError, access_token_needs_refresh, account_lock_for,
+		codex_auth_projection_digest, credential_refresh_result, matching_shared_refresh,
+		projection_binding, refreshed_credential_target,
+		require_refreshed_access_token_for_observation, stable_account_alias,
+		use_in_codex_receipt_result,
 	};
 	use std::{
 		collections::{HashMap, HashSet},
@@ -3179,6 +3269,28 @@ mod tests {
 	use tokio::time;
 
 	const OBSERVED_AT_MICROS: i64 = 1_000_000;
+
+	#[test]
+	fn observation_refreshes_only_when_the_access_token_cannot_cover_the_process_deadline() {
+		let now = 1_000_000_i64;
+		let minimum_validity = Duration::from_micros(500);
+
+		assert!(access_token_needs_refresh(now - 1, now, minimum_validity).unwrap());
+		assert!(access_token_needs_refresh(now + 500, now, minimum_validity).unwrap());
+		assert!(!access_token_needs_refresh(now + 501, now, minimum_validity).unwrap());
+		assert!(matches!(
+			access_token_needs_refresh(i64::MAX, i64::MAX, minimum_validity),
+			Err(AccountLifecycleError::InvalidOperation)
+		));
+		assert!(matches!(
+			require_refreshed_access_token_for_observation(now + 500, now, minimum_validity),
+			Err(AccountLifecycleError::Refresh(CredentialRefreshError::Unavailable))
+		));
+		assert!(
+			require_refreshed_access_token_for_observation(now + 501, now, minimum_validity)
+				.is_ok()
+		);
+	}
 
 	#[test]
 	fn stable_alias_uses_the_canonical_provider_binding_vector() {

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -679,7 +679,6 @@ impl ServiceApplication {
 					EntityId::new(inventory.account_id.as_str().to_owned()).map_err(|_| ());
 				let account_revision =
 					u64::try_from(inventory.account_revision).map(EntityRevision).map_err(|_| ());
-				let available_count = u16::try_from(inventory.cards.len()).map_err(|_| ());
 				let cards = inventory
 					.cards
 					.into_iter()
@@ -696,25 +695,18 @@ impl ServiceApplication {
 				let five_hour_quota = quota_dto(inventory.five_hour_quota);
 				let seven_day_quota = quota_dto(inventory.seven_day_quota);
 
-				match (
-					account_id,
-					account_revision,
-					available_count,
-					cards,
-					five_hour_quota,
-					seven_day_quota,
-				) {
+				match (account_id, account_revision, cards, five_hour_quota, seven_day_quota) {
 					(
 						Ok(account_id),
 						Ok(account_revision),
-						Ok(available_count),
 						Ok(cards),
 						Ok(five_hour_quota),
 						Ok(seven_day_quota),
 					) => ResetCardInventoryResult::Available {
 						account_id,
 						account_revision,
-						available_count,
+						reported_available_count: inventory.reported_available_count,
+						details_complete: inventory.details_complete,
 						cards,
 						five_hour_quota,
 						seven_day_quota,

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -1202,10 +1202,12 @@ all-depleted wake remain later XY-1304 obligations.
 
 ## Manual reset-card service
 
-Protocol V2.0 exposes bounded account discovery, complete reset-card inventory, manual
-consume, and durable operation-status reads. The public identity is one canonical vNext
-account UUID, its optimistic revision, and a card descriptor made only from grant and
-expiry timestamps. No protocol or client type carries the provider credit ID.
+Protocol V2.0 exposes bounded account discovery, reset-card observations, manual consume,
+and durable operation-status reads. An observation carries the provider-reported available
+count when present, an explicit detail-completeness flag, and public descriptors only for a
+complete unique inventory. The public identity is one canonical vNext account UUID, its
+optimistic revision, and a card descriptor made only from grant and expiry timestamps. No
+protocol or client type carries the provider credit ID.
 
 The shared Rust service and CLI contain no macOS-only reset-card implementation. They
 run on the supported macOS and Linux runtime hosts. Only the native SwiftUI client is
@@ -1229,12 +1231,18 @@ projection only.
 Before any reset-card read or consume, the Codex adapter requires the generated schema to
 advertise both `account/rateLimits/read` and
 `account/rateLimitResetCredit/consume`. It attests the configured account in an isolated
-app-server process and accepts only a complete, unique inventory. Quota decoding selects
-the upstream `codex` limit-ID snapshot, or the required default snapshot when that map
-entry is absent. It never merges unrelated limit-ID buckets. A null quota window becomes
-an independent unsupported-duration result and does not invalidate another duration. A
-client selects a public descriptor. The daemon resolves its one current opaque provider
-credit ID.
+app-server process. A read accepts the upstream count-only, capped, unknown-extension, or
+otherwise partial detail forms without discarding valid quota facts. A zero reported count
+is a definitive empty inventory even when the optional detail array is null. Only a complete,
+bounded, unique descriptor set can enter exact-credit resolution or effect reconciliation.
+Quota decoding selects the upstream `codex` limit-ID snapshot, or the required default
+snapshot when that map entry is absent. It never merges unrelated limit-ID buckets. A null
+quota window or reset timestamp becomes an independent unsupported-duration result and does
+not invalidate another duration. Before the read, the Account Service refreshes only an
+expired access token or one that cannot cover the bounded process deadline. It serializes
+that refresh under the existing per-account lock and reuses the existing journal and
+credential compare-and-swap. A client selects a public descriptor. The daemon resolves its
+one current opaque provider credit ID.
 
 The consume path commits the logical command, account UUID and revision, public
 descriptor, provider idempotency key, and then the exact provider credit ID before it

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -164,11 +164,18 @@ dispatch or automatic fallback.
 The Codex adapter must prove that one generated schema advertises both
 `account/rateLimits/read` and `account/rateLimitResetCredit/consume`. It must establish a
 complete unique inventory before it maps the public descriptor to one exact opaque credit
-ID. The daemon persists that exact ID and the unchanged logical-command idempotency key
-before it starts the provider effect. A terminal result requires a closed provider receipt
-and a fresh authoritative inventory readback. After an ambiguous stop, restart recovery
-may retry or reconcile only the persisted exact ID with the same key. It must never
-rematch a new inventory item or create a new provider key.
+ID. A read can publish a provider-reported available count with incomplete or absent detail
+rows, but it must publish no selectable descriptors from that partial inventory and must
+retain independently valid quota facts. A reported zero count is a definitive complete empty
+inventory. Null quota reset timestamps are unsupported windows, not protocol corruption.
+Before an observation, the Account Service refreshes only an expired access token or one
+that cannot cover the bounded provider-process deadline, under the existing account lock,
+refresh journal, and credential compare-and-swap. The daemon persists the resolved exact ID
+and the unchanged logical-command idempotency key before it starts the provider effect. A
+terminal result requires a closed provider receipt and a fresh complete authoritative
+inventory readback. After an ambiguous stop, restart recovery may retry or reconcile only
+the persisted exact ID with the same key. It must never rematch a new inventory item or
+create a new provider key.
 
 The caller creates and durably records the logical-command key before `use`. Account and
 inventory results bind the selected profile name and stable server UUID; all later


### PR DESCRIPTION
## Summary
- replace MenuBarExtra window hosting with a transparent borderless status panel so each account card remains visually independent
- accept legal partial Reset Card provider responses without discarding quota data or exposing incomplete cards for use
- refresh expiring account credentials through the existing account journal/CAS before bounded observations

## Validation
- cargo make check-rust
- swift test --package-path apps/decodex-app (139 tests)
- focused Rust Reset Card protocol/runtime tests
- signed release app staging and bundle verification
- independent source reviews for status-panel and Reset Card changes