### PR TITLE
Adapt X pricing unit statement

### DIFF
--- a/automations/upstream/scripts/upstream_autopilot_lib/pricing.py
+++ b/automations/upstream/scripts/upstream_autopilot_lib/pricing.py
@@ -74,7 +74,8 @@ _TABLE_SEPARATOR_PATTERN = re.compile(r"^:?-{3,}:?$")
 _TARGET_SECTION_HEADING = "## Credit consumption details"
 _TARGET_SECTION_UNIT_STATEMENT = (
     "All prices are per resource fetched (reads) or per request "
-    "(writes/actions)."
+    "(writes/actions). [Purchase credits](https://console.x.com) in the "
+    "Developer Console."
 )
 _READ_HEADING = "### Read operations"
 _WRITE_HEADING = "### Write operations"

--- a/automations/upstream/tests/fixtures/x-pricing-current.md
+++ b/automations/upstream/tests/fixtures/x-pricing-current.md
@@ -2,7 +2,7 @@
 
 ## Credit consumption details
 
-All prices are per resource fetched (reads) or per request (writes/actions).
+All prices are per resource fetched (reads) or per request (writes/actions). [Purchase credits](https://console.x.com) in the Developer Console.
 
 ### Read operations
 

--- a/automations/upstream/tests/test_upstream_autopilot.py
+++ b/automations/upstream/tests/test_upstream_autopilot.py
@@ -9208,9 +9208,22 @@ class UpstreamAutopilotTests(unittest.TestCase):
                 b"Unit Cost",
                 1,
             ),
-            "extended unit statement": current.replace(
+            "legacy unit statement": current.replace(
+                (
+                    b"(writes/actions). [Purchase credits]"
+                    b"(https://console.x.com) in the Developer Console."
+                ),
                 b"(writes/actions).",
-                b"(writes/actions). Additional text.",
+                1,
+            ),
+            "changed purchase destination": current.replace(
+                b"https://console.x.com",
+                b"https://example.com",
+                1,
+            ),
+            "extended unit statement": current.replace(
+                b"Developer Console.",
+                b"Developer Console. Additional text.",
                 1,
             ),
             "per thousand": current.replace(


### PR DESCRIPTION
## Summary
- update the fail-closed pricing parser to the current full official unit statement
- keep all four compiled X API rates unchanged
- reject the legacy sentence, changed purchase destination, and appended text

## Evidence
- direct current official Markdown parse: post create 15000, URL create 200000, post read 5000, user read 10000 micro-USD
- `cargo make test-automations`: 255 passed
- upstream and content repo-only automation evaluators: passed
- independent review: Accept, no P1/P2/P3 findings