### PR TITLE
Restore native account login recovery

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -11,9 +11,15 @@ import, or runtime scheduling.
 ## Scope
 
 The app has one account authority: the Decodex daemon. Its in-process Rust
-client connects to the daemon through the owner-only Unix transport. The app
-does not start a CLI process. Swift does not read account credentials,
-PostgreSQL, Keychain, or provider-private Reset Card identifiers.
+client connects to the daemon through the owner-only Unix transport. When the
+user explicitly refreshes an expired login, the Rust bridge starts one finite
+official Codex device-login child in an owner-private temporary home. It shows
+Swift only the official URL, one-time code, and closed session state. The daemon
+verifies and installs the exact account credential, and the bridge removes the
+temporary home on success, failure, cancellation, or App exit. The app never
+starts the Decodex CLI, helper, app-server, or legacy account process. Swift
+does not read account credentials, auth-file paths, PostgreSQL, Keychain, or
+provider-private Reset Card identifiers.
 
 The primary panel reads the complete account skeleton, uses the returned
 routing UUID order, and immediately renders every account. It then runs
@@ -68,8 +74,11 @@ modes, and one cross-process dispatch lock. A malformed or unsafe journal is
 preserved and blocks new use.
 
 The panel also exposes current daemon-owned account controls: enroll the
-currently signed-in shared Codex login, enable or disable, refresh credentials,
-log out, and select fixed or balanced routing. Each account row has one `Route`
+currently signed-in shared Codex login, enable or disable, log out, and select
+fixed or balanced routing. An account with a provider-confirmed unauthorized
+profile shows `Refresh Login`; that action presents the official device code,
+Copy, Open Browser, and Cancel controls, then refreshes only that account after
+the daemon completes the exact credential replacement. Each account row has one `Route`
 control. It first projects that exact daemon-owned login to shared
 `~/.codex/auth.json` for future Codex launches, then selects the same account as
 the fixed Decodex route. The underlying typed commands remain independently

--- a/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
@@ -157,6 +157,74 @@ enum AccountControlError: Error, Equatable, LocalizedError, Sendable {
 	}
 }
 
+enum AccountReauthenticationState: String, Decodable, Equatable, Sendable {
+	case requestingCode = "requesting_code"
+	case waitingForBrowser = "waiting_for_browser"
+	case installing
+	case completed
+	case failed
+	case cancelled
+}
+
+enum AccountReauthenticationFailure: String, Decodable, Equatable, Sendable {
+	case codexUnavailable = "codex_unavailable"
+	case loginFailed = "login_failed"
+	case loginTimedOut = "login_timed_out"
+	case accountMismatch = "account_mismatch"
+	case accountChanged = "account_changed"
+	case accountUnavailable = "account_unavailable"
+	case credentialStoreUnavailable = "credential_store_unavailable"
+	case serviceUnavailable = "service_unavailable"
+	case outcomeUnknown = "outcome_unknown"
+	case sessionNotFound = "session_not_found"
+	case busy
+
+	var presentation: String {
+		switch self {
+		case .codexUnavailable:
+			return "The Codex login tool is unavailable."
+		case .loginFailed:
+			return "Codex could not complete the login."
+		case .loginTimedOut:
+			return "The login code expired. Request a new code."
+		case .accountMismatch:
+			return "This login belongs to a different account."
+		case .accountChanged:
+			return "The account changed. Close this login and try again."
+		case .accountUnavailable:
+			return "This account is not available for login."
+		case .credentialStoreUnavailable:
+			return "The credential store is unavailable."
+		case .serviceUnavailable:
+			return "The Decodex account service is unavailable."
+		case .outcomeUnknown:
+			return "The login may have completed. Refresh the account before trying again."
+		case .sessionNotFound:
+			return "This login session is no longer available."
+		case .busy:
+			return "Another account login is already in progress."
+		}
+	}
+}
+
+struct AccountReauthenticationPrompt: Equatable, Sendable {
+	static let verificationURL = URL(string: "https://auth.openai.com/codex/device")!
+
+	let verificationURL: URL
+	let userCode: String
+
+	var compactCode: String {
+		userCode.replacingOccurrences(of: "-", with: "")
+	}
+}
+
+struct AccountReauthenticationStatus: Equatable, Sendable {
+	let sessionID: String
+	let state: AccountReauthenticationState
+	let prompt: AccountReauthenticationPrompt?
+	let failure: AccountReauthenticationFailure?
+}
+
 protocol AccountControlClient: ResetCardClient {
 	func accountSnapshot(
 		authority: ResetCardAuthority?
@@ -218,6 +286,54 @@ protocol AccountControlClient: ResetCardClient {
 		expectedRevision: UInt64,
 		idempotencyKey: String
 	) async throws -> AccountControlResult
+
+	func startAccountReauthentication(
+		authority: ResetCardAuthority?,
+		sessionID: String,
+		operationID: String,
+		accountID: String,
+		expectedRevision: UInt64,
+		idempotencyKey: String,
+		codexBin: String
+	) async throws -> AccountReauthenticationStatus
+
+	func pollAccountReauthentication(
+		authority: ResetCardAuthority?,
+		sessionID: String
+	) async throws -> AccountReauthenticationStatus
+
+	func cancelAccountReauthentication(
+		authority: ResetCardAuthority?,
+		sessionID: String
+	) async throws -> AccountReauthenticationStatus
+}
+
+extension AccountControlClient {
+	func startAccountReauthentication(
+		authority _: ResetCardAuthority?,
+		sessionID _: String,
+		operationID _: String,
+		accountID _: String,
+		expectedRevision _: UInt64,
+		idempotencyKey _: String,
+		codexBin _: String
+	) async throws -> AccountReauthenticationStatus {
+		throw AccountControlError.applicationUnavailable
+	}
+
+	func pollAccountReauthentication(
+		authority _: ResetCardAuthority?,
+		sessionID _: String
+	) async throws -> AccountReauthenticationStatus {
+		throw AccountControlError.applicationUnavailable
+	}
+
+	func cancelAccountReauthentication(
+		authority _: ResetCardAuthority?,
+		sessionID _: String
+	) async throws -> AccountReauthenticationStatus {
+		throw AccountControlError.applicationUnavailable
+	}
 }
 
 extension DecodexNativeClient: AccountControlClient {
@@ -443,6 +559,64 @@ extension DecodexNativeClient: AccountControlClient {
 		)
 	}
 
+	func startAccountReauthentication(
+		authority: ResetCardAuthority?,
+		sessionID: String,
+		operationID: String,
+		accountID: String,
+		expectedRevision: UInt64,
+		idempotencyKey: String,
+		codexBin: String
+	) async throws -> AccountReauthenticationStatus {
+		try Self.validateAccountControlInput(
+			authority: authority,
+			accountID: accountID,
+			operationID: operationID,
+			expectedRevision: expectedRevision,
+			idempotencyKey: idempotencyKey
+		)
+		guard Self.isCanonicalUUID(sessionID),
+			Self.isValidCodexExecutablePath(codexBin)
+		else {
+			throw AccountControlError.invalidInput
+		}
+		return try await executeAccountReauthentication(
+			request: DecodexNativeRequest(
+				operation: "start_account_reauthentication",
+				accountID: accountID,
+				expectedRevision: expectedRevision,
+				idempotencyKey: idempotencyKey,
+				operationID: operationID,
+				sessionID: sessionID,
+				codexBin: codexBin
+			),
+			authority: authority,
+			expectedSessionID: sessionID
+		)
+	}
+
+	func pollAccountReauthentication(
+		authority: ResetCardAuthority?,
+		sessionID: String
+	) async throws -> AccountReauthenticationStatus {
+		try await accountReauthenticationSessionRequest(
+			operation: "poll_account_reauthentication",
+			authority: authority,
+			sessionID: sessionID
+		)
+	}
+
+	func cancelAccountReauthentication(
+		authority: ResetCardAuthority?,
+		sessionID: String
+	) async throws -> AccountReauthenticationStatus {
+		try await accountReauthenticationSessionRequest(
+			operation: "cancel_account_reauthentication",
+			authority: authority,
+			sessionID: sessionID
+		)
+	}
+
 	private static func validateAccountControlInput(
 		authority: ResetCardAuthority?,
 		accountID: String,
@@ -458,6 +632,62 @@ extension DecodexNativeClient: AccountControlClient {
 		else {
 			throw AccountControlError.invalidInput
 		}
+	}
+
+	private static func isValidCodexExecutablePath(_ value: String) -> Bool {
+		guard value.utf8.count <= 4_096,
+			value.utf8.contains(0) == false
+		else {
+			return false
+		}
+		let url = URL(fileURLWithPath: value)
+		return url.path.hasPrefix("/")
+			&& url.standardizedFileURL.path == value
+	}
+
+	private func accountReauthenticationSessionRequest(
+		operation: String,
+		authority: ResetCardAuthority?,
+		sessionID: String
+	) async throws -> AccountReauthenticationStatus {
+		guard authority.map(Self.isValidAuthority) ?? true,
+			Self.isCanonicalUUID(sessionID)
+		else {
+			throw AccountControlError.invalidInput
+		}
+		return try await executeAccountReauthentication(
+			request: DecodexNativeRequest(
+				operation: operation,
+				sessionID: sessionID
+			),
+			authority: authority,
+			expectedSessionID: sessionID
+		)
+	}
+
+	private func executeAccountReauthentication(
+		request: DecodexNativeRequest,
+		authority: ResetCardAuthority?,
+		expectedSessionID: String
+	) async throws -> AccountReauthenticationStatus {
+		let response: (
+			authority: ResetCardAuthority,
+			data: AccountReauthenticationWire
+		)
+		do {
+			response = try await perform(request, authority: authority)
+		} catch let error as ResetCardClientError {
+			if error == .invalidResponse {
+				throw AccountControlError.invalidResponse
+			}
+			throw AccountControlError.client(error)
+		} catch {
+			throw AccountControlError.invalidResponse
+		}
+		guard response.data.value.sessionID == expectedSessionID else {
+			throw AccountControlError.invalidResponse
+		}
+		return response.data.value
 	}
 
 	private func executeAccountControl(
@@ -492,6 +722,114 @@ extension DecodexNativeClient: AccountControlClient {
 		case .potentiallyDispatched:
 			throw AccountControlError.potentiallyDispatched
 		}
+	}
+}
+
+private struct AccountReauthenticationWire: Decodable {
+	let value: AccountReauthenticationStatus
+
+	init(from decoder: Decoder) throws {
+		try rejectUnknownFields(
+			in: decoder,
+			allowed: ["session_id", "state", "prompt", "failure"]
+		)
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		let sessionID = try container.decode(String.self, forKey: .sessionID)
+		let state = try container.decode(
+			AccountReauthenticationState.self,
+			forKey: .state
+		)
+		let prompt = try container.decodeIfPresent(
+			PromptWire.self,
+			forKey: .prompt
+		)?.value
+		let failure = try container.decodeIfPresent(
+			AccountReauthenticationFailure.self,
+			forKey: .failure
+		)
+		guard DecodexNativeClient.isCanonicalUUID(sessionID),
+			Self.hasValidShape(state: state, prompt: prompt, failure: failure)
+		else {
+			throw AccountControlError.invalidResponse
+		}
+		value = AccountReauthenticationStatus(
+			sessionID: sessionID,
+			state: state,
+			prompt: prompt,
+			failure: failure
+		)
+	}
+
+	private static func hasValidShape(
+		state: AccountReauthenticationState,
+		prompt: AccountReauthenticationPrompt?,
+		failure: AccountReauthenticationFailure?
+	) -> Bool {
+		switch state {
+		case .requestingCode:
+			return prompt == nil && failure == nil
+		case .waitingForBrowser:
+			return prompt != nil && failure == nil
+		case .installing:
+			return prompt == nil && failure == nil
+		case .completed, .cancelled:
+			return prompt == nil && failure == nil
+		case .failed:
+			return prompt == nil && failure != nil
+		}
+	}
+
+	private struct PromptWire: Decodable {
+		let value: AccountReauthenticationPrompt
+
+		init(from decoder: Decoder) throws {
+			try requireExactFields(
+				in: decoder,
+				expected: ["verification_url", "user_code"]
+			)
+			let container = try decoder.container(keyedBy: CodingKeys.self)
+			let verificationURLText = try container.decode(
+				String.self,
+				forKey: .verificationURL
+			)
+			let userCode = try container.decode(String.self, forKey: .userCode)
+			guard let verificationURL = URL(string: verificationURLText),
+				verificationURL == AccountReauthenticationPrompt.verificationURL,
+				Self.isValidUserCode(userCode)
+			else {
+				throw AccountControlError.invalidResponse
+			}
+			value = AccountReauthenticationPrompt(
+				verificationURL: verificationURL,
+				userCode: userCode
+			)
+		}
+
+		private static func isValidUserCode(_ value: String) -> Bool {
+			let bytes = Array(value.utf8)
+			guard bytes.count == 10, bytes[4] == 0x2d else {
+				return false
+			}
+			return bytes.enumerated().allSatisfy { index, byte in
+				if index == 4 {
+					return true
+				}
+				return (byte >= 0x30 && byte <= 0x39)
+					|| (byte >= 0x41 && byte <= 0x5a)
+			}
+		}
+
+		private enum CodingKeys: String, CodingKey {
+			case verificationURL = "verification_url"
+			case userCode = "user_code"
+		}
+	}
+
+	private enum CodingKeys: String, CodingKey {
+		case sessionID = "session_id"
+		case state
+		case prompt
+		case failure
 	}
 }
 private enum AccountControlExpectedResult {

--- a/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
@@ -180,11 +180,9 @@ struct AccountRefreshLoginButton: View {
 				state.account.accountID,
 				activity: .loginRefresh
 			),
-			help: "Refresh the saved login for this account from the matching shared Codex login."
+			help: "Sign in to this account with the official Codex device login."
 		) {
-			Task {
-				await store.refreshCredentials(for: state.account.accountID)
-			}
+			store.beginAccountReauthentication(for: state.account.accountID)
 		}
 	}
 
@@ -195,6 +193,7 @@ struct AccountRefreshLoginButton: View {
 			|| store.isControllingAccount(state.account.accountID)
 			|| store.isEnrollingAccount
 			|| store.isRoutingAccountControl
+			|| store.accountReauthentication != nil
 			|| store.submittingKey != nil
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -65,6 +65,16 @@ struct AccountPanelView: View {
 				isPresentingEnrollment = false
 			}
 		}
+		.sheet(
+			isPresented: Binding(
+				get: {
+					store.accountReauthentication != nil
+				},
+				set: { _ in }
+			)
+		) {
+			AccountReauthenticationView(store: store)
+		}
 		.task {
 			guard loadsExternalState else {
 				return

--- a/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationPresentation.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationPresentation.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+enum AccountReauthenticationPhase: Equatable {
+	case resolvingCodex
+	case requestingCode
+	case waitingForBrowser
+	case installing
+	case failed(String)
+	case cancellationFailed(String)
+}
+
+struct AccountReauthenticationPresentation: Identifiable, Equatable {
+	let accountID: String
+	let accountLabel: String
+	let sessionID: String
+	let authority: ResetCardAuthority?
+	let phase: AccountReauthenticationPhase
+	let prompt: AccountReauthenticationPrompt?
+
+	var id: String {
+		sessionID
+	}
+
+	var statusText: String {
+		switch phase {
+		case .resolvingCodex:
+			return "Finding Codex"
+		case .requestingCode:
+			return "Requesting a one-time code"
+		case .waitingForBrowser:
+			return "Waiting for browser sign-in"
+		case .installing:
+			return "Saving this login"
+		case .failed:
+			return "Login failed"
+		case .cancellationFailed:
+			return "Could not cancel login"
+		}
+	}
+
+	var failureText: String? {
+		switch phase {
+		case .failed(let message), .cancellationFailed(let message):
+			return message
+		case .resolvingCodex, .requestingCode, .waitingForBrowser, .installing:
+			return nil
+		}
+	}
+
+	var canCloseWithoutCancellation: Bool {
+		if case .failed = phase {
+			return true
+		}
+		return false
+	}
+
+	var canRequestCancellation: Bool {
+		if case .installing = phase {
+			return false
+		}
+		return canCloseWithoutCancellation == false
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
@@ -1,0 +1,154 @@
+import AppKit
+import SwiftUI
+
+struct AccountReauthenticationView: View {
+	let store: ResetCardStore
+	@Environment(\.colorScheme) private var colorScheme
+	@State private var copyFeedback = false
+	@State private var openFeedback = false
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 10) {
+			if let presentation = store.accountReauthentication {
+				header(presentation)
+
+				if let prompt = presentation.prompt {
+					promptContent(prompt)
+				} else if presentation.failureText == nil {
+					HStack(spacing: 7) {
+						ProgressView()
+							.controlSize(.small)
+						Text(presentation.statusText)
+							.font(PanelFont.transientBody)
+							.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+					}
+				}
+
+				if let failure = presentation.failureText {
+					Text(failure)
+						.font(PanelFont.transientBody)
+						.foregroundStyle(PanelPalette.destructive(colorScheme))
+						.fixedSize(horizontal: false, vertical: true)
+				}
+
+				Divider()
+
+				HStack {
+					Spacer()
+					Button(
+						presentation.canCloseWithoutCancellation
+							? "Close"
+							: presentation.canRequestCancellation ? "Cancel" : "Saving…"
+					) {
+						if presentation.canCloseWithoutCancellation {
+							store.closeAccountReauthentication()
+						} else if presentation.canRequestCancellation {
+							Task {
+								await store.cancelAccountReauthentication()
+							}
+						}
+					}
+					.disabled(
+						presentation.canCloseWithoutCancellation == false
+							&& presentation.canRequestCancellation == false
+					)
+					.keyboardShortcut(.cancelAction)
+				}
+			}
+		}
+		.frame(width: 300)
+		.padding(14)
+		.controlSize(.small)
+		.interactiveDismissDisabled(true)
+	}
+
+	private func header(
+		_ presentation: AccountReauthenticationPresentation
+	) -> some View {
+		VStack(alignment: .leading, spacing: 3) {
+			Text("Refresh Login")
+				.font(PanelFont.transientTitle)
+				.foregroundStyle(PanelPalette.primaryText(colorScheme))
+
+			Text(presentation.accountLabel)
+				.font(PanelFont.transientBody)
+				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+				.lineLimit(1)
+				.truncationMode(.middle)
+
+			if presentation.prompt != nil {
+				Text(presentation.statusText)
+					.font(PanelFont.tertiary)
+					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+			}
+		}
+	}
+
+	private func promptContent(
+		_ prompt: AccountReauthenticationPrompt
+	) -> some View {
+		VStack(alignment: .leading, spacing: 8) {
+			Text("Enter this one-time code in the Codex sign-in page.")
+				.font(PanelFont.transientBody)
+				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+				.fixedSize(horizontal: false, vertical: true)
+
+			Text(prompt.userCode)
+				.font(.system(size: 24, weight: .semibold, design: .monospaced))
+				.monospacedDigit()
+				.tracking(1.4)
+				.foregroundStyle(PanelPalette.primaryText(colorScheme))
+				.textSelection(.enabled)
+				.frame(maxWidth: .infinity)
+				.padding(.vertical, 10)
+				.background(
+					RoundedRectangle(cornerRadius: 9, style: .continuous)
+						.fill(
+							PanelPalette.secondaryText(colorScheme)
+								.opacity(colorScheme == .dark ? 0.12 : 0.08)
+						)
+				)
+				.overlay {
+					RoundedRectangle(cornerRadius: 9, style: .continuous)
+						.stroke(
+							PanelPalette.separator(colorScheme),
+							lineWidth: 1
+						)
+				}
+				.accessibilityLabel("One-time login code \(prompt.userCode)")
+
+			HStack(spacing: 7) {
+				Button(copyFeedback ? "Copied" : "Copy Code") {
+					copy(prompt.userCode)
+				}
+				.buttonStyle(.bordered)
+				.accessibilityHint("Copies the one-time Codex login code.")
+
+				Button(openFeedback ? "Opened" : "Open Browser") {
+					open(prompt.verificationURL)
+				}
+				.buttonStyle(.borderedProminent)
+				.accessibilityHint("Opens the official Codex device sign-in page.")
+			}
+		}
+	}
+
+	private func copy(_ code: String) {
+		NSPasteboard.general.clearContents()
+		NSPasteboard.general.setString(code, forType: .string)
+		copyFeedback = true
+		Task { @MainActor in
+			try? await Task.sleep(for: .milliseconds(850))
+			copyFeedback = false
+		}
+	}
+
+	private func open(_ url: URL) {
+		openFeedback = true
+		NSWorkspace.shared.open(url)
+		Task { @MainActor in
+			try? await Task.sleep(for: .milliseconds(650))
+			openFeedback = false
+		}
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/CodexExecutableResolver.swift
+++ b/apps/decodex-app/Sources/DecodexApp/CodexExecutableResolver.swift
@@ -1,0 +1,105 @@
+import AppKit
+import Foundation
+
+enum CodexExecutableResolutionError: Error, Equatable, LocalizedError {
+	case invalidOverride
+	case unavailable
+
+	var errorDescription: String? {
+		switch self {
+		case .invalidOverride:
+			return "CODEX_CLI_PATH does not point to an executable Codex login tool."
+		case .unavailable:
+			return "Codex is not installed. Install the Codex app, add codex to PATH, or set CODEX_CLI_PATH."
+		}
+	}
+}
+
+enum CodexExecutableResolver {
+	static let applicationBundleIdentifier = "com.openai.codex"
+	static let overrideEnvironmentKey = "CODEX_CLI_PATH"
+
+	@MainActor
+	static func resolve() throws -> String {
+		let applicationResourceURL = NSWorkspace.shared.urlForApplication(
+			withBundleIdentifier: applicationBundleIdentifier
+		).flatMap { applicationURL in
+			Bundle(url: applicationURL)?.url(forResource: "codex", withExtension: nil)
+		}
+		return try resolve(
+			environment: ProcessInfo.processInfo.environment,
+			applicationResourceURL: applicationResourceURL,
+			isExecutableFile: FileManager.default.isExecutableFile(atPath:)
+		)
+	}
+
+	static func resolve(
+		environment: [String: String],
+		applicationResourceURL: URL?,
+		isExecutableFile: (String) -> Bool
+	) throws -> String {
+		if let override = environment[overrideEnvironmentKey]?
+			.trimmingCharacters(in: .whitespacesAndNewlines),
+			override.isEmpty == false
+		{
+			guard let path = executablePath(
+				override,
+				isExecutableFile: isExecutableFile
+			) else {
+				throw CodexExecutableResolutionError.invalidOverride
+			}
+			return path
+		}
+
+		if let applicationResourceURL,
+			let path = executablePath(
+				applicationResourceURL.path,
+				isExecutableFile: isExecutableFile
+			)
+		{
+			return path
+		}
+
+		if let searchPath = environment["PATH"] {
+			for directory in searchPath.split(
+				separator: ":",
+				omittingEmptySubsequences: true
+			) {
+				let candidate = URL(
+					fileURLWithPath: String(directory),
+					isDirectory: true
+				).appendingPathComponent("codex")
+				if let path = executablePath(
+					candidate.path,
+					isExecutableFile: isExecutableFile
+				) {
+					return path
+				}
+			}
+		}
+
+		throw CodexExecutableResolutionError.unavailable
+	}
+
+	private static func executablePath(
+		_ value: String,
+		isExecutableFile: (String) -> Bool
+	) -> String? {
+		guard value.hasPrefix("/") else {
+			return nil
+		}
+		let inputURL = URL(fileURLWithPath: value).standardizedFileURL
+		guard inputURL.path == value else {
+			return nil
+		}
+		let executableURL = inputURL
+			.resolvingSymlinksInPath()
+			.standardizedFileURL
+		guard executableURL.path.hasPrefix("/"),
+			isExecutableFile(executableURL.path)
+		else {
+			return nil
+		}
+		return executableURL.path
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/DecodexApp.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexApp.swift
@@ -5,6 +5,7 @@ import SwiftUI
 final class AppDelegate: NSObject, NSApplicationDelegate {
 	private var store: ResetCardStore?
 	private var statusPanelController: StatusPanelController?
+	private var terminationIsPending = false
 
 	func applicationDidFinishLaunching(_ notification: Notification) {
 		NSApp.setActivationPolicy(.accessory)
@@ -12,6 +13,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		self.store = store
 		statusPanelController = StatusPanelController(store: store)
 		store.start()
+	}
+
+	func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+		guard terminationIsPending == false else {
+			return .terminateLater
+		}
+		terminationIsPending = true
+		store?.prepareForApplicationTermination()
+		Task {
+			await DecodexNativeClient.shutdownSharedSession()
+			sender.reply(toApplicationShouldTerminate: true)
+		}
+		return .terminateLater
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/DecodexNativeClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexNativeClient.swift
@@ -19,6 +19,8 @@ struct DecodexNativeRequest: Encodable, Sendable {
 	var expectedRoutingRevision: UInt64? = nil
 	var idempotencyKey: String? = nil
 	var operationID: String? = nil
+	var sessionID: String? = nil
+	var codexBin: String? = nil
 	var enabled: Bool? = nil
 
 	enum CodingKeys: String, CodingKey {
@@ -33,6 +35,8 @@ struct DecodexNativeRequest: Encodable, Sendable {
 		case expectedRoutingRevision = "expected_routing_revision"
 		case idempotencyKey = "idempotency_key"
 		case operationID = "operation_id"
+		case sessionID = "session_id"
+		case codexBin = "codex_bin"
 		case enabled
 	}
 }
@@ -217,6 +221,12 @@ final class DecodexNativeClient: @unchecked Sendable, CustomDebugStringConvertib
 		"DecodexNativeClient(transport: in-process)"
 	}
 
+	static func shutdownSharedSession() async {
+		await Task.detached {
+			sharedSession.shutdown()
+		}.value
+	}
+
 	func perform<Payload: Decodable>(
 		_ request: DecodexNativeRequest,
 		authority requestedAuthority: ResetCardAuthority?,
@@ -312,6 +322,7 @@ private final class DecodexNativeSession: @unchecked Sendable {
 	private let lock = NSLock()
 	private var client: UnsafeMutableRawPointer?
 	private var authority: ResetCardAuthority?
+	private var closed = false
 
 	func request(
 		_ requestData: Data,
@@ -319,7 +330,8 @@ private final class DecodexNativeSession: @unchecked Sendable {
 	) throws -> Data {
 		let library = try DecodexNativeLibrary.shared.get()
 		let handle = try lock.withLock {
-			guard authority == nil
+			guard closed == false,
+				authority == nil
 				|| requestedAuthority == nil
 				|| authority == requestedAuthority
 			else {
@@ -391,14 +403,22 @@ private final class DecodexNativeSession: @unchecked Sendable {
 		return Data(bytes: responseBuffer, count: responseLength)
 	}
 
-	deinit {
+	func shutdown() {
 		let handle = lock.withLock {
-			defer { client = nil }
+			closed = true
+			defer {
+				client = nil
+				authority = nil
+			}
 			return client
 		}
 		if let handle, let library = try? DecodexNativeLibrary.shared.get() {
 			library.destroy(handle)
 		}
+	}
+
+	deinit {
+		shutdown()
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -307,7 +307,7 @@ struct ResetCardAccountRow: View {
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 				.lineLimit(1)
 				.help(
-					"Sign in to this account in Codex, then choose Refresh Login."
+					"Choose Refresh Login in the menu bar app to sign in with the official Codex device login."
 				)
 		} else if let error = state.inventory?.observationError {
 			Text("Reset Cards unavailable")

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -77,7 +77,10 @@ struct ResetCardAccountState: Identifiable, Equatable {
 	}
 
 	var requiresLoginRefresh: Bool {
-		account.observedState == .authFailed
+		if account.observedState == .authFailed {
+			return true
+		}
+		return profileUnavailable?.error == .unauthorized
 	}
 }
 
@@ -184,6 +187,7 @@ final class ResetCardStore {
 	private(set) var pendingAttempts: [ResetCardUseAttempt]
 	private(set) var isPendingRecoveryBlocked: Bool
 	private(set) var profileEmailsVisible = false
+	private(set) var accountReauthentication: AccountReauthenticationPresentation?
 	var message: ResetCardStoreMessage?
 
 	@ObservationIgnored private let client: any ResetCardClient
@@ -191,8 +195,11 @@ final class ResetCardStore {
 	@ObservationIgnored private let accountProfileClient: (any AccountProfileClient)?
 	@ObservationIgnored private let pendingStore: ResetCardPendingAttemptStore
 	@ObservationIgnored private let startupRetryDelays: [Duration]
+	@ObservationIgnored private let accountReauthenticationPollInterval: Duration
+	@ObservationIgnored private let resolveCodexExecutable: @MainActor @Sendable () throws -> String
 	@ObservationIgnored private var startupTask: Task<Void, Never>?
 	@ObservationIgnored private var pendingRecoveryTask: Task<Void, Never>?
+	@ObservationIgnored private var accountReauthenticationTask: Task<Void, Never>?
 	@ObservationIgnored private var profileRequestGenerations = [String: UInt64]()
 	@ObservationIgnored private var profileEmailCache = [String: CachedAccountEmail]()
 	@ObservationIgnored private var requestedProfileEmailVisibility = false
@@ -202,13 +209,19 @@ final class ResetCardStore {
 	init(
 		client: any ResetCardClient = DecodexNativeClient(),
 		pendingStore: ResetCardPendingAttemptStore = ResetCardPendingAttemptStore(),
-		startupRetryDelays: [Duration] = ResetCardStore.defaultStartupRetryDelays
+		startupRetryDelays: [Duration] = ResetCardStore.defaultStartupRetryDelays,
+		accountReauthenticationPollInterval: Duration = .seconds(1),
+		resolveCodexExecutable: @escaping @MainActor @Sendable () throws -> String = {
+			try CodexExecutableResolver.resolve()
+		}
 	) {
 		self.client = client
 		accountControlClient = client as? any AccountControlClient
 		accountProfileClient = client as? any AccountProfileClient
 		self.pendingStore = pendingStore
 		self.startupRetryDelays = startupRetryDelays
+		self.accountReauthenticationPollInterval = accountReauthenticationPollInterval
+		self.resolveCodexExecutable = resolveCodexExecutable
 		let pendingLoad = pendingStore.load()
 		pendingAttempts = pendingLoad.attempts
 		isPendingRecoveryBlocked = pendingLoad.isRecoveryBlocked
@@ -220,6 +233,7 @@ final class ResetCardStore {
 	deinit {
 		startupTask?.cancel()
 		pendingRecoveryTask?.cancel()
+		accountReauthenticationTask?.cancel()
 	}
 
 	var isInitialLoading: Bool {
@@ -292,6 +306,15 @@ final class ResetCardStore {
 				shouldRetry = retry
 			}
 		}
+	}
+
+	func prepareForApplicationTermination() {
+		startupTask?.cancel()
+		startupTask = nil
+		pendingRecoveryTask?.cancel()
+		pendingRecoveryTask = nil
+		accountReauthenticationTask?.cancel()
+		accountReauthenticationTask = nil
 	}
 
 	func refresh() async {
@@ -927,6 +950,134 @@ final class ResetCardStore {
 					idempotencyKey: idempotencyKey
 				)
 			}
+		)
+	}
+
+	func beginAccountReauthentication(for accountID: String) {
+		guard accountReauthentication == nil,
+			accountReauthenticationTask == nil,
+			let state = accounts.first(where: {
+				$0.account.accountID == accountID
+			}),
+			state.requiresLoginRefresh,
+			state.account.credentialBinding != nil,
+			let accountControlClient,
+			canPerformDirectAccountControl,
+			isAwaitingFreshAccountSkeleton(accountID) == false,
+			accountControlActivities[accountID] == nil,
+			isEnrollingAccount == false,
+			isRoutingAccountControl == false,
+			submittingKey == nil
+		else {
+			presentAccountControlUnavailable()
+			return
+		}
+
+		let sessionID = Self.newCanonicalUUID()
+		let operationID = Self.newCanonicalUUID()
+		let idempotencyKey = Self.newCanonicalUUID()
+		let account = state.account
+		let authority = account.authority ?? establishedAuthority
+		accountControlActivities[accountID] = .loginRefresh
+		clearStaleControlError()
+		accountReauthentication = AccountReauthenticationPresentation(
+			accountID: accountID,
+			accountLabel: AccountIdentityPresentation(
+				alias: account.alias,
+				email: state.profile?.email
+					?? state.profileUnavailable?.claims.email,
+				revealsEmail: profileEmailsVisible
+			).text,
+			sessionID: sessionID,
+			authority: authority,
+			phase: .resolvingCodex,
+			prompt: nil
+		)
+		accountReauthenticationTask = Task { [weak self] in
+			await self?.runAccountReauthentication(
+				client: accountControlClient,
+				authority: authority,
+				account: account,
+				sessionID: sessionID,
+				operationID: operationID,
+				idempotencyKey: idempotencyKey
+			)
+		}
+	}
+
+	func cancelAccountReauthentication() async {
+		guard let presentation = accountReauthentication,
+			let accountControlClient,
+			presentation.canRequestCancellation
+		else {
+			return
+		}
+		if presentation.canCloseWithoutCancellation {
+			closeAccountReauthentication()
+			return
+		}
+
+		do {
+			let status = try await accountControlClient.cancelAccountReauthentication(
+				authority: presentation.authority,
+				sessionID: presentation.sessionID
+			)
+			guard accountReauthentication?.sessionID == presentation.sessionID else {
+				return
+			}
+			switch status.state {
+			case .cancelled:
+				accountReauthenticationTask?.cancel()
+				accountReauthenticationTask = nil
+				finishAccountReauthentication(
+					accountID: presentation.accountID,
+					sessionID: presentation.sessionID
+				)
+			case .completed:
+				accountReauthenticationTask?.cancel()
+				accountReauthenticationTask = nil
+				await completeAccountReauthentication(
+					accountID: presentation.accountID,
+					sessionID: presentation.sessionID
+				)
+			case .failed:
+				accountReauthenticationTask?.cancel()
+				accountReauthenticationTask = nil
+				await failAccountReauthentication(
+					accountID: presentation.accountID,
+					sessionID: presentation.sessionID,
+					message: status.failure?.presentation
+						?? AccountControlError.invalidResponse.localizedDescription,
+					failure: status.failure
+				)
+			case .requestingCode, .waitingForBrowser, .installing:
+				setAccountReauthenticationPhase(
+					.cancellationFailed(
+						"The login is still active. Choose Cancel again."
+					),
+					sessionID: presentation.sessionID
+				)
+			}
+		} catch {
+			guard accountReauthentication?.sessionID == presentation.sessionID else {
+				return
+			}
+			setAccountReauthenticationPhase(
+				.cancellationFailed(Self.accountControlMessage(error)),
+				sessionID: presentation.sessionID
+			)
+		}
+	}
+
+	func closeAccountReauthentication() {
+		guard let presentation = accountReauthentication,
+			presentation.canCloseWithoutCancellation
+		else {
+			return
+		}
+		finishAccountReauthentication(
+			accountID: presentation.accountID,
+			sessionID: presentation.sessionID
 		)
 	}
 
@@ -1888,6 +2039,234 @@ final class ResetCardStore {
 
 	private func accountRecord(_ accountID: String) -> ResetCardAccountRecord? {
 		accounts.first(where: { $0.account.accountID == accountID })?.account
+	}
+
+	private func runAccountReauthentication(
+		client: any AccountControlClient,
+		authority: ResetCardAuthority?,
+		account: ResetCardAccountRecord,
+		sessionID: String,
+		operationID: String,
+		idempotencyKey: String
+	) async {
+		do {
+			let codexBin = try resolveCodexExecutable()
+			guard accountReauthentication?.sessionID == sessionID else {
+				return
+			}
+			setAccountReauthenticationPhase(
+				.requestingCode,
+				sessionID: sessionID
+			)
+			var status = try await client.startAccountReauthentication(
+				authority: authority,
+				sessionID: sessionID,
+				operationID: operationID,
+				accountID: account.accountID,
+				expectedRevision: account.accountRevision,
+				idempotencyKey: idempotencyKey,
+				codexBin: codexBin
+			)
+
+			while Task.isCancelled == false,
+				accountReauthentication?.sessionID == sessionID
+			{
+				if await applyAccountReauthenticationStatus(
+					status,
+					accountID: account.accountID,
+					sessionID: sessionID
+				) {
+					return
+				}
+				try await Task.sleep(for: accountReauthenticationPollInterval)
+				status = try await client.pollAccountReauthentication(
+					authority: authority,
+					sessionID: sessionID
+				)
+			}
+		} catch is CancellationError {
+			return
+		} catch {
+			guard accountReauthentication?.sessionID == sessionID else {
+				return
+			}
+			if let cancellationStatus = try? await client.cancelAccountReauthentication(
+				authority: authority,
+				sessionID: sessionID
+			),
+				await applyAccountReauthenticationStatus(
+					cancellationStatus,
+					accountID: account.accountID,
+					sessionID: sessionID
+				)
+			{
+				return
+			}
+			await failAccountReauthentication(
+				accountID: account.accountID,
+				sessionID: sessionID,
+				message: Self.accountControlMessage(error)
+			)
+		}
+	}
+
+	private func applyAccountReauthenticationStatus(
+		_ status: AccountReauthenticationStatus,
+		accountID: String,
+		sessionID: String
+	) async -> Bool {
+		guard status.sessionID == sessionID,
+			accountReauthentication?.sessionID == sessionID
+		else {
+			await failAccountReauthentication(
+				accountID: accountID,
+				sessionID: sessionID,
+				message: AccountControlError.invalidResponse.localizedDescription
+			)
+			return true
+		}
+
+		switch status.state {
+		case .requestingCode:
+			setAccountReauthenticationPhase(
+				.requestingCode,
+				sessionID: sessionID
+			)
+			return false
+		case .waitingForBrowser:
+			guard let prompt = status.prompt else {
+				await failAccountReauthentication(
+					accountID: accountID,
+					sessionID: sessionID,
+					message: AccountControlError.invalidResponse.localizedDescription
+				)
+				return true
+			}
+			setAccountReauthenticationPhase(
+				.waitingForBrowser,
+				sessionID: sessionID,
+				prompt: prompt
+			)
+			return false
+		case .installing:
+			setAccountReauthenticationPhase(
+				.installing,
+				sessionID: sessionID
+			)
+			return false
+		case .completed:
+			await completeAccountReauthentication(
+				accountID: accountID,
+				sessionID: sessionID
+			)
+			return true
+		case .failed:
+			await failAccountReauthentication(
+				accountID: accountID,
+				sessionID: sessionID,
+				message: status.failure?.presentation
+					?? AccountControlError.invalidResponse.localizedDescription,
+				failure: status.failure
+			)
+			return true
+		case .cancelled:
+			finishAccountReauthentication(
+				accountID: accountID,
+				sessionID: sessionID
+			)
+			return true
+		}
+	}
+
+	private func setAccountReauthenticationPhase(
+		_ phase: AccountReauthenticationPhase,
+		sessionID: String,
+		prompt: AccountReauthenticationPrompt? = nil
+	) {
+		guard let presentation = accountReauthentication,
+			presentation.sessionID == sessionID
+		else {
+			return
+		}
+		let nextPrompt: AccountReauthenticationPrompt? = switch phase {
+		case .waitingForBrowser, .cancellationFailed:
+			prompt ?? presentation.prompt
+		case .resolvingCodex, .requestingCode, .installing, .failed:
+			nil
+		}
+		accountReauthentication = AccountReauthenticationPresentation(
+			accountID: presentation.accountID,
+			accountLabel: presentation.accountLabel,
+			sessionID: sessionID,
+			authority: presentation.authority,
+			phase: phase,
+			prompt: nextPrompt
+		)
+	}
+
+	private func completeAccountReauthentication(
+		accountID: String,
+		sessionID: String
+	) async {
+		guard accountReauthentication?.sessionID == sessionID else {
+			return
+		}
+		accountControlActivities.removeValue(forKey: accountID)
+		accountReauthenticationTask = nil
+		message = ResetCardStoreMessage(
+			tone: .success,
+			text: "Account login refreshed."
+		)
+		accountReauthentication = nil
+		await refreshReauthenticatedAccountAuthority(accountID)
+	}
+
+	private func refreshReauthenticatedAccountAuthority(_ accountID: String) async {
+		await refreshAccountSkeleton()
+		await refreshAccountDetails(accountID)
+		await refreshAccountSkeleton()
+	}
+
+	private func failAccountReauthentication(
+		accountID: String,
+		sessionID: String,
+		message: String,
+		failure: AccountReauthenticationFailure? = nil
+	) async {
+		guard accountReauthentication?.sessionID == sessionID else {
+			return
+		}
+		accountControlActivities.removeValue(forKey: accountID)
+		accountReauthenticationTask = nil
+		setAccountReauthenticationPhase(
+			.failed(message),
+			sessionID: sessionID
+		)
+		if failure == .outcomeUnknown {
+			await refreshReauthenticatedAccountAuthority(accountID)
+		}
+	}
+
+	private func finishAccountReauthentication(
+		accountID: String,
+		sessionID: String
+	) {
+		guard accountReauthentication?.sessionID == sessionID else {
+			return
+		}
+		accountReauthenticationTask?.cancel()
+		accountReauthenticationTask = nil
+		accountControlActivities.removeValue(forKey: accountID)
+		accountReauthentication = nil
+	}
+
+	nonisolated private static func accountControlMessage(_ error: Error) -> String {
+		if let error = error as? LocalizedError,
+			let description = error.errorDescription
+		{
+			return description
+		}
+		return AccountControlError.invalidResponse.localizedDescription
 	}
 
 	private func performAccountControl(

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
@@ -340,6 +340,183 @@ final class AccountControlNativeClientTests: XCTestCase {
 			}
 		}
 	}
+
+	func testAccountReauthenticationUsesExactStartPollAndCancelRequests() async throws {
+		let authority = authority
+		let sessionID = "55555555-5555-4555-8555-555555555555"
+		let recorder = NativeRequestRecorder()
+		let client = DecodexNativeClient { request, requestedAuthority in
+			recorder.append(request, authority: requestedAuthority)
+			let object = try nativeJSONObject(request)
+			let operation = try XCTUnwrap(object["operation"] as? String)
+			let data: String
+			switch operation {
+			case "start_account_reauthentication":
+				data = """
+					{"session_id":"\(sessionID)","state":"requesting_code"}
+					"""
+			case "poll_account_reauthentication":
+				data = """
+					{"session_id":"\(sessionID)","state":"waiting_for_browser",
+					 "prompt":{"verification_url":"https://auth.openai.com/codex/device",
+					 "user_code":"AB12-CDE34"}}
+					"""
+			case "cancel_account_reauthentication":
+				data = """
+					{"session_id":"\(sessionID)","state":"cancelled"}
+					"""
+			default:
+				return nativeFailure(operation: operation, failure: "invalid_request")
+			}
+			return nativeSuccess(
+				operation: operation,
+				authority: authority,
+				data: data
+			)
+		}
+
+		let started = try await client.startAccountReauthentication(
+			authority: authority,
+			sessionID: sessionID,
+			operationID: operationID,
+			accountID: accountID,
+			expectedRevision: 7,
+			idempotencyKey: idempotencyKey,
+			codexBin: "/Applications/ChatGPT.app/Contents/Resources/codex"
+		)
+		let polled = try await client.pollAccountReauthentication(
+			authority: authority,
+			sessionID: sessionID
+		)
+		let cancelled = try await client.cancelAccountReauthentication(
+			authority: authority,
+			sessionID: sessionID
+		)
+
+		XCTAssertEqual(started.state, .requestingCode)
+		XCTAssertEqual(
+			polled.prompt,
+			AccountReauthenticationPrompt(
+				verificationURL: AccountReauthenticationPrompt.verificationURL,
+				userCode: "AB12-CDE34"
+			)
+		)
+		XCTAssertEqual(cancelled.state, .cancelled)
+
+		let requests = try recorder.requests.map { try nativeJSONObject($0.data) }
+		XCTAssertEqual(
+			requests.compactMap { $0["operation"] as? String },
+			[
+				"start_account_reauthentication",
+				"poll_account_reauthentication",
+				"cancel_account_reauthentication",
+			]
+		)
+		XCTAssertEqual(
+			Set(requests[0].keys),
+			[
+				"schema", "operation", "session_id", "operation_id",
+				"account_id", "expected_revision", "idempotency_key", "codex_bin",
+			]
+		)
+		XCTAssertEqual(requests[0]["session_id"] as? String, sessionID)
+		XCTAssertEqual(requests[0]["account_id"] as? String, accountID)
+		XCTAssertEqual(requests[0]["expected_revision"] as? NSNumber, 7)
+		XCTAssertEqual(
+			requests[0]["codex_bin"] as? String,
+			"/Applications/ChatGPT.app/Contents/Resources/codex"
+		)
+		XCTAssertEqual(
+			Set(requests[1].keys),
+			["schema", "operation", "session_id"]
+		)
+		XCTAssertEqual(
+			Set(requests[2].keys),
+			["schema", "operation", "session_id"]
+		)
+		XCTAssertEqual(
+			recorder.requests.map(\.authority),
+			Array(repeating: authority, count: 3)
+		)
+	}
+
+	func testAccountReauthenticationDecodesClosedFailure() async throws {
+		let authority = authority
+		let sessionID = "55555555-5555-4555-8555-555555555555"
+		let client = DecodexNativeClient { _, _ in
+			nativeSuccess(
+				operation: "poll_account_reauthentication",
+				authority: authority,
+				data: """
+					{"session_id":"\(sessionID)","state":"failed",
+					 "failure":"account_mismatch"}
+					"""
+			)
+		}
+
+		let status = try await client.pollAccountReauthentication(
+			authority: authority,
+			sessionID: sessionID
+		)
+
+		XCTAssertEqual(status.state, .failed)
+		XCTAssertEqual(status.failure, .accountMismatch)
+		XCTAssertNil(status.prompt)
+	}
+
+	func testAccountReauthenticationRejectsMalformedOrUnexpectedPromptState() async {
+		let authority = authority
+		let sessionID = "55555555-5555-4555-8555-555555555555"
+		let malformed = [
+			"""
+			{"session_id":"\(sessionID)","state":"waiting_for_browser",
+			 "prompt":{"verification_url":"http://auth.openai.com/codex/device",
+			 "user_code":"AB12-CDE34"}}
+			""",
+			"""
+			{"session_id":"\(sessionID)","state":"waiting_for_browser",
+			 "prompt":{"verification_url":"https://auth.openai.com/codex/device",
+			 "user_code":"AB12-cde34"}}
+			""",
+			"""
+			{"session_id":"\(sessionID)","state":"completed",
+			 "prompt":{"verification_url":"https://auth.openai.com/codex/device",
+			 "user_code":"AB12-CDE34"}}
+			""",
+			"""
+			{"session_id":"\(sessionID)","state":"installing",
+			 "prompt":{"verification_url":"https://auth.openai.com/codex/device",
+			 "user_code":"AB12-CDE34"}}
+			""",
+			"""
+			{"session_id":"\(sessionID)","state":"failed","failure":"future_failure"}
+			""",
+			"""
+			{"session_id":"\(sessionID)","state":"requesting_code","unexpected":true}
+			""",
+		]
+
+		for data in malformed {
+			let client = DecodexNativeClient { _, _ in
+				nativeSuccess(
+					operation: "poll_account_reauthentication",
+					authority: authority,
+					data: data
+				)
+			}
+			do {
+				_ = try await client.pollAccountReauthentication(
+					authority: authority,
+					sessionID: sessionID
+				)
+				XCTFail("Malformed login status must fail")
+			} catch let error as AccountControlError {
+				XCTAssertEqual(error, .invalidResponse)
+			} catch {
+				XCTFail("Unexpected error: \(error)")
+			}
+		}
+	}
 }
 
 private func controlAccountJSON(

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -616,6 +616,150 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(finalProjectionReads, 2)
 	}
 
+	func testDeviceLoginCompletesAndRefreshesOnlyTheChangedAccountAuthority() async throws {
+		let account = accountRecord(observedState: .authFailed)
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			reauthenticationStates: [
+				.waitingForBrowser,
+				.installing,
+				.completed,
+			]
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [],
+			accountReauthenticationPollInterval: .zero,
+			resolveCodexExecutable: {
+				"/Applications/ChatGPT.app/Contents/Resources/codex"
+			}
+		)
+		await store.refresh()
+		XCTAssertTrue(store.accounts.first?.requiresLoginRefresh == true)
+
+		store.beginAccountReauthentication(for: accountID)
+		for _ in 0 ..< 200 {
+			if store.accountReauthentication == nil,
+				store.accounts.first?.account.accountRevision == 8
+			{
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+
+		XCTAssertNil(store.accountReauthentication)
+		XCTAssertFalse(store.isControllingAccount(accountID))
+		XCTAssertEqual(store.accounts.first?.account.accountRevision, 8)
+		XCTAssertEqual(store.accounts.first?.account.observedState, .available)
+		XCTAssertFalse(store.accounts.first?.requiresLoginRefresh ?? true)
+		XCTAssertEqual(store.message?.text, "Account login refreshed.")
+		let recordedRequest = await client.reauthenticationStartRequest()
+		let request = try XCTUnwrap(recordedRequest)
+		XCTAssertEqual(request.accountID, accountID)
+		XCTAssertEqual(request.expectedRevision, 7)
+		XCTAssertEqual(
+			request.codexBin,
+			"/Applications/ChatGPT.app/Contents/Resources/codex"
+		)
+		let pollCount = await client.reauthenticationPollCount()
+		let cancelCount = await client.reauthenticationCancelCount()
+		XCTAssertEqual(pollCount, 2)
+		XCTAssertEqual(cancelCount, 0)
+		let reads = await client.readCounts()
+		XCTAssertGreaterThanOrEqual(reads.snapshot, 3)
+		XCTAssertGreaterThanOrEqual(reads.inventory, 2)
+	}
+
+	func testDeviceLoginRemainsActiveUntilExplicitCancel() async throws {
+		let account = accountRecord(observedState: .authFailed)
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			reauthenticationStates: [.waitingForBrowser]
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [],
+			accountReauthenticationPollInterval: .seconds(60),
+			resolveCodexExecutable: {
+				"/Applications/ChatGPT.app/Contents/Resources/codex"
+			}
+		)
+		await store.refresh()
+
+		store.beginAccountReauthentication(for: accountID)
+		for _ in 0 ..< 200 {
+			if store.accountReauthentication?.prompt != nil {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+		XCTAssertEqual(
+			store.accountReauthentication?.prompt?.userCode,
+			"AB12-CDE34"
+		)
+		XCTAssertTrue(store.isControllingAccount(accountID))
+
+		await store.cancelAccountReauthentication()
+
+		XCTAssertNil(store.accountReauthentication)
+		XCTAssertFalse(store.isControllingAccount(accountID))
+		let cancelCount = await client.reauthenticationCancelCount()
+		XCTAssertEqual(cancelCount, 1)
+	}
+
+	func testCancelOutcomeUnknownKeepsFailureWhileReadingBackAuthoritativeState() async throws {
+		let account = accountRecord(observedState: .authFailed)
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			reauthenticationStates: [.waitingForBrowser],
+			cancelReauthenticationWithOutcomeUnknown: true
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [],
+			accountReauthenticationPollInterval: .seconds(60),
+			resolveCodexExecutable: {
+				"/Applications/ChatGPT.app/Contents/Resources/codex"
+			}
+		)
+		await store.refresh()
+
+		store.beginAccountReauthentication(for: accountID)
+		for _ in 0 ..< 200 {
+			if store.accountReauthentication?.prompt != nil {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+		await store.cancelAccountReauthentication()
+
+		XCTAssertEqual(
+			store.accountReauthentication?.failureText,
+			AccountReauthenticationFailure.outcomeUnknown.presentation
+		)
+		XCTAssertNotEqual(store.message?.text, "Account login refreshed.")
+		XCTAssertEqual(store.accounts.first?.account.accountRevision, 8)
+		XCTAssertEqual(store.accounts.first?.account.observedState, .available)
+		XCTAssertFalse(store.accounts.first?.requiresLoginRefresh ?? true)
+		let cancelCount = await client.reauthenticationCancelCount()
+		XCTAssertEqual(cancelCount, 1)
+		let reads = await client.readCounts()
+		XCTAssertGreaterThanOrEqual(reads.snapshot, 3)
+		XCTAssertGreaterThanOrEqual(reads.inventory, 2)
+	}
+
 	private func accountRecord(
 		accountID: String? = nil,
 		alias: String = "Account 00000-00001",
@@ -676,6 +820,12 @@ private struct AccountControlStoreRefreshRequest: Equatable, Sendable {
 	let expectedRevision: UInt64
 }
 
+private struct AccountControlStoreReauthenticationRequest: Equatable, Sendable {
+	let accountID: String
+	let expectedRevision: UInt64
+	let codexBin: String
+}
+
 private enum AccountControlStoreOperation: Equatable, Sendable {
 	case codexProjection
 	case fixedRouting
@@ -707,6 +857,13 @@ private actor AccountControlStoreClient: AccountControlClient {
 	private var projectionReads = 0
 	private var snapshotReadCount = 0
 	private var inventoryReadCount = 0
+	private var reauthenticationStates: [AccountReauthenticationState]
+	private var lastReauthenticationStartRequest: AccountControlStoreReauthenticationRequest?
+	private var reauthenticationPolls = 0
+	private var reauthenticationCancels = 0
+	private var reauthenticationSessionID: String?
+	private var reauthenticationCompleted = false
+	private let cancelReauthenticationWithOutcomeUnknown: Bool
 
 	init(
 		account: ResetCardAccountRecord,
@@ -719,7 +876,9 @@ private actor AccountControlStoreClient: AccountControlClient {
 		routing: AccountRoutingControl? = nil,
 		fixedSelectionError: AccountControlError? = nil,
 		useAccountError: AccountControlError? = nil,
-		projection: CodexAuthProjection = .unmanaged
+		projection: CodexAuthProjection = .unmanaged,
+		reauthenticationStates: [AccountReauthenticationState] = [],
+		cancelReauthenticationWithOutcomeUnknown: Bool = false
 	) {
 		self.account = account
 		self.secondaryAccount = secondaryAccount
@@ -737,6 +896,9 @@ private actor AccountControlStoreClient: AccountControlClient {
 			)
 		self.fixedSelectionError = fixedSelectionError
 		self.useAccountError = useAccountError
+		self.reauthenticationStates = reauthenticationStates
+		self.cancelReauthenticationWithOutcomeUnknown =
+			cancelReauthenticationWithOutcomeUnknown
 	}
 
 	func accountSnapshot(
@@ -766,6 +928,21 @@ private actor AccountControlStoreClient: AccountControlClient {
 		inventoryReadCount += 1
 		if let inventoryGate {
 			await inventoryGate.wait()
+		}
+		if reauthenticationCompleted, self.account.observedState == .authFailed {
+			self.account = ResetCardAccountRecord(
+				authority: self.account.authority,
+				accountID: self.account.accountID,
+				alias: self.account.alias,
+				accountRevision: self.account.accountRevision,
+				enabled: self.account.enabled,
+				observedState: .available,
+				lifecycleReadiness: self.account.lifecycleReadiness,
+				credentialBinding: self.account.credentialBinding,
+				unsettledOperation: self.account.unsettledOperation,
+				fiveHourQuota: self.account.fiveHourQuota,
+				sevenDayQuota: self.account.sevenDayQuota
+			)
 		}
 		return ResetCardInventory(
 			authority: authority,
@@ -999,6 +1176,114 @@ private actor AccountControlStoreClient: AccountControlClient {
 
 	func refreshRequest() -> AccountControlStoreRefreshRequest? {
 		lastRefreshRequest
+	}
+
+	func startAccountReauthentication(
+		authority _: ResetCardAuthority?,
+		sessionID: String,
+		operationID _: String,
+		accountID: String,
+		expectedRevision: UInt64,
+		idempotencyKey _: String,
+		codexBin: String
+	) async throws -> AccountReauthenticationStatus {
+		guard reauthenticationStates.isEmpty == false else {
+			throw AccountControlError.applicationUnavailable
+		}
+		reauthenticationSessionID = sessionID
+		lastReauthenticationStartRequest = AccountControlStoreReauthenticationRequest(
+			accountID: accountID,
+			expectedRevision: expectedRevision,
+			codexBin: codexBin
+		)
+		return reauthenticationStatus(
+			state: reauthenticationStates.removeFirst(),
+			sessionID: sessionID
+		)
+	}
+
+	func pollAccountReauthentication(
+		authority _: ResetCardAuthority?,
+		sessionID: String
+	) async throws -> AccountReauthenticationStatus {
+		guard sessionID == reauthenticationSessionID,
+			reauthenticationStates.isEmpty == false
+		else {
+			throw AccountControlError.invalidResponse
+		}
+		reauthenticationPolls += 1
+		let state = reauthenticationStates.removeFirst()
+		if state == .completed {
+			markReauthenticationCompleted()
+		}
+		return reauthenticationStatus(state: state, sessionID: sessionID)
+	}
+
+	func cancelAccountReauthentication(
+		authority _: ResetCardAuthority?,
+		sessionID: String
+	) async throws -> AccountReauthenticationStatus {
+		guard sessionID == reauthenticationSessionID else {
+			throw AccountControlError.invalidResponse
+		}
+		reauthenticationCancels += 1
+		if cancelReauthenticationWithOutcomeUnknown {
+			markReauthenticationCompleted()
+			return reauthenticationStatus(
+				state: .failed,
+				sessionID: sessionID,
+				failure: .outcomeUnknown
+			)
+		}
+		return reauthenticationStatus(state: .cancelled, sessionID: sessionID)
+	}
+
+	func reauthenticationStartRequest() -> AccountControlStoreReauthenticationRequest? {
+		lastReauthenticationStartRequest
+	}
+
+	func reauthenticationPollCount() -> Int {
+		reauthenticationPolls
+	}
+
+	func reauthenticationCancelCount() -> Int {
+		reauthenticationCancels
+	}
+
+	private func reauthenticationStatus(
+		state: AccountReauthenticationState,
+		sessionID: String,
+		failure: AccountReauthenticationFailure? = nil
+	) -> AccountReauthenticationStatus {
+		let prompt = state == .waitingForBrowser
+			? AccountReauthenticationPrompt(
+				verificationURL: AccountReauthenticationPrompt.verificationURL,
+				userCode: "AB12-CDE34"
+			)
+			: nil
+		return AccountReauthenticationStatus(
+			sessionID: sessionID,
+			state: state,
+			prompt: prompt,
+			failure: failure
+		)
+	}
+
+	private func markReauthenticationCompleted() {
+		reauthenticationCompleted = true
+		account = ResetCardAccountRecord(
+			authority: account.authority,
+			accountID: account.accountID,
+			alias: account.alias,
+			accountRevision: account.accountRevision + 1,
+			enabled: account.enabled,
+			observedState: account.observedState,
+			lifecycleReadiness: .ready,
+			credentialBinding: account.credentialBinding,
+			unsettledOperation: nil,
+			fiveHourQuota: account.fiveHourQuota,
+			sevenDayQuota: account.sevenDayQuota
+		)
 	}
 }
 

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -117,6 +117,20 @@ final class AccountPanelPresentationTests: XCTestCase {
 		)
 	}
 
+	func testInstallingLoginCannotBeCancelledOrClosed() {
+		let presentation = AccountReauthenticationPresentation(
+			accountID: "10000000-0000-4000-8000-000000000001",
+			accountLabel: "Val",
+			sessionID: "20000000-0000-4000-8000-000000000001",
+			authority: nil,
+			phase: .installing,
+			prompt: nil
+		)
+
+		XCTAssertFalse(presentation.canRequestCancellation)
+		XCTAssertFalse(presentation.canCloseWithoutCancellation)
+	}
+
 	func testMissingAccountLabelDoesNotExposeAccountID() {
 		let directory = FileManager.default.temporaryDirectory
 			.appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -135,7 +149,9 @@ final class AccountPanelPresentationTests: XCTestCase {
 		)
 	}
 
-	func testProfileUnauthorizedCannotPresentLoginRecoveryOrHideCanonicalInventory() throws {
+	func testUnavailableProfileUnauthorizedPresentsLoginRecoveryWithoutHidingCanonicalInventory()
+		throws
+	{
 		let authority = ResetCardAuthority(
 			profileName: "local",
 			serverID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
@@ -175,7 +191,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 			)
 		)
 
-		XCTAssertFalse(state.requiresLoginRefresh)
+		XCTAssertTrue(state.requiresLoginRefresh)
 		XCTAssertEqual(state.targets.count, 1)
 
 		let source = try resetCardSectionSource()

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountProfileStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountProfileStoreTests.swift
@@ -131,10 +131,11 @@ final class AccountProfileStoreTests: XCTestCase {
 			store.accounts.first?.profileUnavailable?.error,
 			.providerUnavailable
 		)
+		XCTAssertFalse(store.accounts.first?.requiresLoginRefresh ?? true)
 		XCTAssertNil(store.accounts.first?.error)
 	}
 
-	func testProfileUnauthorizedDoesNotDriveAccountLoginRecovery() {
+	func testCachedProfileUnauthorizedDoesNotDriveAccountLoginRecovery() {
 		let profile = profileObservation(
 			observedAt: 300,
 			lifetimeTokens: 3_000,
@@ -149,7 +150,6 @@ final class AccountProfileStoreTests: XCTestCase {
 		)
 
 		XCTAssertFalse(availableState.requiresLoginRefresh)
-		XCTAssertFalse(availableState.requiresLoginRefresh)
 		XCTAssertEqual(
 			availableState.profileDegradationText,
 			AccountProfileObservationError.unauthorized.presentation
@@ -163,7 +163,21 @@ final class AccountProfileStoreTests: XCTestCase {
 			profile: profile
 		)
 		XCTAssertTrue(authFailedState.requiresLoginRefresh)
-		XCTAssertTrue(authFailedState.requiresLoginRefresh)
+	}
+
+	func testUnavailableUnauthorizedRequiresLoginRefresh() {
+		let state = ResetCardAccountState(
+			account: profileTestAccount(),
+			inventory: nil,
+			error: nil,
+			isRefreshing: false,
+			profileUnavailable: AccountProfileUnavailable(
+				error: .unauthorized,
+				claims: AccountProfileClaims(email: nil, planType: "pro")
+			)
+		)
+
+		XCTAssertTrue(state.requiresLoginRefresh)
 	}
 
 	func testOlderObservationCannotReplaceNewerRetainedProfile() async throws {

--- a/apps/decodex-app/Tests/DecodexAppTests/CodexExecutableResolverTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/CodexExecutableResolverTests.swift
@@ -1,0 +1,122 @@
+@testable import DecodexApp
+import Foundation
+import XCTest
+
+final class CodexExecutableResolverTests: XCTestCase {
+	func testExplicitOverridePrecedesInstalledApplicationAndPath() throws {
+		let executables = Set([
+			"/private/override/codex",
+			"/Applications/ChatGPT.app/Contents/Resources/codex",
+			"/usr/local/bin/codex",
+		])
+
+		let resolved = try CodexExecutableResolver.resolve(
+			environment: [
+				"CODEX_CLI_PATH": "/private/override/codex",
+				"PATH": "/usr/local/bin",
+			],
+			applicationResourceURL: URL(
+				fileURLWithPath: "/Applications/ChatGPT.app/Contents/Resources/codex"
+			),
+			isExecutableFile: executables.contains
+		)
+
+		XCTAssertEqual(resolved, "/private/override/codex")
+	}
+
+	func testInstalledApplicationPrecedesPathFallback() throws {
+		let executables = Set([
+			"/Applications/ChatGPT.app/Contents/Resources/codex",
+			"/usr/local/bin/codex",
+		])
+
+		let resolved = try CodexExecutableResolver.resolve(
+			environment: ["PATH": "/usr/local/bin"],
+			applicationResourceURL: URL(
+				fileURLWithPath: "/Applications/ChatGPT.app/Contents/Resources/codex"
+			),
+			isExecutableFile: executables.contains
+		)
+
+		XCTAssertEqual(
+			resolved,
+			"/Applications/ChatGPT.app/Contents/Resources/codex"
+		)
+	}
+
+	func testPathFallbackUsesFirstExecutableCodex() throws {
+		let resolved = try CodexExecutableResolver.resolve(
+			environment: ["PATH": "/not-installed:/opt/homebrew/bin:/usr/local/bin"],
+			applicationResourceURL: nil,
+			isExecutableFile: { $0 == "/opt/homebrew/bin/codex" }
+		)
+
+		XCTAssertEqual(resolved, "/opt/homebrew/bin/codex")
+	}
+
+	func testPathFallbackReturnsTheResolvedExecutableInsteadOfASymlink() throws {
+		let root = FileManager.default.temporaryDirectory
+			.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		defer {
+			try? FileManager.default.removeItem(at: root)
+		}
+		try FileManager.default.createDirectory(
+			at: root,
+			withIntermediateDirectories: true
+		)
+		let executable = root.appendingPathComponent("codex-real")
+		try Data().write(to: executable)
+		let symlink = root.appendingPathComponent("codex")
+		try FileManager.default.createSymbolicLink(
+			at: symlink,
+			withDestinationURL: executable
+		)
+		let expected = executable
+			.resolvingSymlinksInPath()
+			.standardizedFileURL
+			.path
+
+		let resolved = try CodexExecutableResolver.resolve(
+			environment: ["PATH": root.path],
+			applicationResourceURL: nil,
+			isExecutableFile: { $0 == expected }
+		)
+
+		XCTAssertEqual(resolved, expected)
+	}
+
+	func testInvalidExplicitOverrideFailsWithoutFallback() {
+		XCTAssertThrowsError(
+			try CodexExecutableResolver.resolve(
+				environment: [
+					"CODEX_CLI_PATH": "relative/codex",
+					"PATH": "/usr/local/bin",
+				],
+				applicationResourceURL: URL(
+					fileURLWithPath: "/Applications/ChatGPT.app/Contents/Resources/codex"
+				),
+				isExecutableFile: { _ in true }
+			)
+		) { error in
+			XCTAssertEqual(
+				error as? CodexExecutableResolutionError,
+				.invalidOverride
+			)
+		}
+	}
+
+	func testUnavailableWhenNoCandidateIsExecutable() {
+		XCTAssertThrowsError(
+			try CodexExecutableResolver.resolve(
+				environment: ["PATH": "/usr/local/bin"],
+				applicationResourceURL: nil,
+				isExecutableFile: { _ in false }
+			)
+		) { error in
+			XCTAssertEqual(
+				error as? CodexExecutableResolutionError,
+				.unavailable
+			)
+		}
+	}
+}

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -235,4 +235,48 @@ final class ResetCardArchitectureTests: XCTestCase {
 			)
 		}
 	}
+
+	func testLoginRecoveryUsesExplicitNativePromptControlsAndNoPanelDisappearCancel() throws {
+		let sourceURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
+		let view = try String(
+			contentsOf: sourceURL.appendingPathComponent(
+				"AccountReauthenticationView.swift"
+			),
+			encoding: .utf8
+		)
+		let controls = try String(
+			contentsOf: sourceURL.appendingPathComponent(
+				"AccountControlViews.swift"
+			),
+			encoding: .utf8
+		)
+		let app = try String(
+			contentsOf: sourceURL.appendingPathComponent("DecodexApp.swift"),
+			encoding: .utf8
+		)
+		let native = try String(
+			contentsOf: sourceURL.appendingPathComponent("DecodexNativeClient.swift"),
+			encoding: .utf8
+		)
+
+		XCTAssertTrue(view.contains("\"Copy Code\""))
+		XCTAssertTrue(view.contains("\"Open Browser\""))
+		XCTAssertTrue(view.contains("\"Cancel\""))
+		XCTAssertTrue(view.contains(".interactiveDismissDisabled(true)"))
+		XCTAssertFalse(view.contains(".onDisappear"))
+		XCTAssertFalse(view.contains(".onChange(of:"))
+		XCTAssertTrue(
+			controls.contains("store.beginAccountReauthentication(for:")
+		)
+		XCTAssertFalse(
+			controls.contains("await store.refreshCredentials(for:")
+		)
+		XCTAssertTrue(app.contains("await DecodexNativeClient.shutdownSharedSession()"))
+		XCTAssertTrue(native.contains("sharedSession.shutdown()"))
+		XCTAssertTrue(native.contains("library.destroy(handle)"))
+	}
 }

--- a/crates/decodex-app-client-ffi/src/account_reauthentication.rs
+++ b/crates/decodex-app-client-ffi/src/account_reauthentication.rs
@@ -1,0 +1,972 @@
+use std::{
+	fs,
+	io::Read,
+	os::unix::{
+		fs::{MetadataExt as _, PermissionsExt as _},
+		process::CommandExt as _,
+	},
+	path::{Path, PathBuf},
+	process::{Child, Command, ExitStatus, Stdio},
+	sync::{
+		Arc, Mutex,
+		atomic::{AtomicBool, Ordering},
+		mpsc::{self, Receiver, RecvTimeoutError, Sender},
+	},
+	thread::{self, JoinHandle},
+	time::{Duration, Instant},
+};
+
+use decodex_protocol::{
+	AccountClient, AccountCommandRejectionDto, AccountCommandResponse, ClientFailure,
+	ClientProfile, CommandError, CommandPayload, EntityId, EntityRevision, IdempotencyKey,
+	ResultPayload, WireText,
+};
+use serde::Serialize;
+use tokio::runtime::Handle;
+
+const DEVICE_LOGIN_URL: &str = "https://auth.openai.com/codex/device";
+const LOGIN_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(40);
+const MAX_LOGIN_OUTPUT_BYTES: usize = 64 * 1024;
+const INSTALL_DISPATCH_ATTEMPTS: usize = 3;
+const INSTALL_REPLAY_DELAY: Duration = Duration::from_millis(100);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Failure {
+	CodexUnavailable,
+	LoginFailed,
+	LoginTimedOut,
+	AccountMismatch,
+	AccountChanged,
+	AccountUnavailable,
+	CredentialStoreUnavailable,
+	ServiceUnavailable,
+	OutcomeUnknown,
+	SessionNotFound,
+	Busy,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum State {
+	RequestingCode,
+	WaitingForBrowser,
+	Installing,
+	Completed,
+	Failed,
+	Cancelled,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct Prompt {
+	verification_url: &'static str,
+	user_code: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct Status {
+	session_id: String,
+	state: State,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	prompt: Option<Prompt>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	failure: Option<Failure>,
+}
+
+impl Status {
+	fn requesting(session_id: String) -> Self {
+		Self { session_id, state: State::RequestingCode, prompt: None, failure: None }
+	}
+
+	fn waiting(session_id: String, user_code: String) -> Self {
+		Self {
+			session_id,
+			state: State::WaitingForBrowser,
+			prompt: Some(Prompt { verification_url: DEVICE_LOGIN_URL, user_code }),
+			failure: None,
+		}
+	}
+
+	fn installing(session_id: String) -> Self {
+		Self { session_id, state: State::Installing, prompt: None, failure: None }
+	}
+
+	fn completed(session_id: String) -> Self {
+		Self { session_id, state: State::Completed, prompt: None, failure: None }
+	}
+
+	fn failed(session_id: String, failure: Failure) -> Self {
+		Self { session_id, state: State::Failed, prompt: None, failure: Some(failure) }
+	}
+
+	fn cancelled(session_id: String) -> Self {
+		Self { session_id, state: State::Cancelled, prompt: None, failure: None }
+	}
+
+	fn is_terminal(&self) -> bool {
+		matches!(self.state, State::Completed | State::Failed | State::Cancelled)
+	}
+}
+
+pub(crate) struct Start {
+	pub session_id: String,
+	pub operation_id: EntityId,
+	pub account_id: EntityId,
+	pub expected_revision: EntityRevision,
+	pub idempotency_key: IdempotencyKey,
+	pub codex_bin: PathBuf,
+}
+
+struct Shared {
+	status: Mutex<Status>,
+	cancel_requested: AtomicBool,
+}
+
+impl Shared {
+	fn new(session_id: String) -> Self {
+		Self {
+			status: Mutex::new(Status::requesting(session_id)),
+			cancel_requested: AtomicBool::new(false),
+		}
+	}
+
+	fn status(&self) -> Status {
+		match self.status.lock() {
+			Ok(status) => status.clone(),
+			Err(poisoned) => poisoned.into_inner().clone(),
+		}
+	}
+
+	fn set_status(&self, status: Status) {
+		match self.status.lock() {
+			Ok(mut current) => *current = status,
+			Err(poisoned) => *poisoned.into_inner() = status,
+		}
+	}
+}
+
+struct Session {
+	session_id: String,
+	shared: Arc<Shared>,
+	worker: Option<JoinHandle<()>>,
+}
+
+pub(crate) struct Manager {
+	session: Mutex<Option<Session>>,
+	closed: AtomicBool,
+}
+
+impl Default for Manager {
+	fn default() -> Self {
+		Self { session: Mutex::new(None), closed: AtomicBool::new(false) }
+	}
+}
+
+impl Manager {
+	pub(crate) fn start(&self, start: Start, profile: ClientProfile, runtime: Handle) -> Status {
+		let mut slot = self.lock_session();
+		if self.closed.load(Ordering::Acquire) {
+			return Status::failed(start.session_id, Failure::ServiceUnavailable);
+		}
+		if let Some(session) = slot.as_ref() {
+			if session.session_id == start.session_id {
+				return session.shared.status();
+			}
+			if !session.shared.status().is_terminal() {
+				return Status::failed(start.session_id, Failure::Busy);
+			}
+		}
+		let shared = Arc::new(Shared::new(start.session_id.clone()));
+		let worker_shared = Arc::clone(&shared);
+		let worker = match thread::Builder::new()
+			.name("decodex-account-login".to_owned())
+			.spawn(move || run_login(worker_shared, start, profile, runtime))
+		{
+			Ok(worker) => Some(worker),
+			Err(_) => {
+				shared.set_status(Status::failed(
+					shared.status().session_id,
+					Failure::ServiceUnavailable,
+				));
+				None
+			},
+		};
+		let status = shared.status();
+		*slot = Some(Session { session_id: status.session_id.clone(), shared, worker });
+		status
+	}
+
+	pub(crate) fn poll(&self, session_id: &str) -> Status {
+		let slot = self.lock_session();
+		slot.as_ref().filter(|session| session.session_id == session_id).map_or_else(
+			|| Status::failed(session_id.to_owned(), Failure::SessionNotFound),
+			|session| session.shared.status(),
+		)
+	}
+
+	pub(crate) fn cancel(&self, session_id: &str) -> Status {
+		let (shared, worker) = {
+			let mut slot = self.lock_session();
+			let Some(session) = slot.as_ref().filter(|session| session.session_id == session_id)
+			else {
+				return Status::failed(session_id.to_owned(), Failure::SessionNotFound);
+			};
+			let shared = Arc::clone(&session.shared);
+			shared.cancel_requested.store(true, Ordering::Release);
+			let worker = slot.as_mut().and_then(|session| session.worker.take());
+			(shared, worker)
+		};
+		if let Some(worker) = worker
+			&& worker.join().is_err()
+		{
+			shared.set_status(Status::failed(session_id.to_owned(), Failure::ServiceUnavailable));
+		}
+		wait_for_terminal(&shared)
+	}
+
+	pub(crate) fn shutdown(&self) {
+		self.closed.store(true, Ordering::Release);
+		let session = {
+			let mut slot = self.lock_session();
+			slot.as_mut().map(|session| {
+				session.shared.cancel_requested.store(true, Ordering::Release);
+				(Arc::clone(&session.shared), session.worker.take())
+			})
+		};
+		if let Some((shared, worker)) = session {
+			if let Some(worker) = worker
+				&& worker.join().is_err()
+			{
+				shared.set_status(Status::failed(
+					shared.status().session_id,
+					Failure::ServiceUnavailable,
+				));
+			}
+			wait_for_terminal(&shared);
+		}
+	}
+
+	fn lock_session(&self) -> std::sync::MutexGuard<'_, Option<Session>> {
+		match self.session.lock() {
+			Ok(session) => session,
+			Err(poisoned) => poisoned.into_inner(),
+		}
+	}
+}
+
+fn wait_for_terminal(shared: &Shared) -> Status {
+	loop {
+		let status = shared.status();
+		if status.is_terminal() {
+			return status;
+		}
+		thread::sleep(Duration::from_millis(10));
+	}
+}
+
+impl Drop for Manager {
+	fn drop(&mut self) {
+		self.shutdown();
+	}
+}
+
+fn run_login(shared: Arc<Shared>, start: Start, profile: ClientProfile, runtime: Handle) {
+	let status = run_login_session(&shared, start, profile, runtime);
+	shared.set_status(status);
+}
+
+fn run_login_session(
+	shared: &Shared,
+	start: Start,
+	profile: ClientProfile,
+	runtime: Handle,
+) -> Status {
+	let session_id = start.session_id.clone();
+	let codex_bin = match canonical_executable(&start.codex_bin) {
+		Ok(codex_bin) => codex_bin,
+		Err(failure) => return Status::failed(session_id, failure),
+	};
+	let mut login_home = match LoginHome::create(&start.session_id) {
+		Ok(home) => home,
+		Err(_) => return Status::failed(session_id, Failure::ServiceUnavailable),
+	};
+	let status = run_login_in_home(shared, start, profile, runtime, codex_bin, login_home.path());
+	finalize_login_status(&mut login_home, session_id, status)
+}
+
+fn finalize_login_status(login_home: &mut LoginHome, session_id: String, status: Status) -> Status {
+	if login_home.cleanup().is_ok() {
+		return status;
+	}
+	let failure =
+		if status.state == State::Completed || status.failure == Some(Failure::OutcomeUnknown) {
+			Failure::OutcomeUnknown
+		} else {
+			Failure::ServiceUnavailable
+		};
+	Status::failed(session_id, failure)
+}
+
+fn run_login_in_home(
+	shared: &Shared,
+	start: Start,
+	profile: ClientProfile,
+	runtime: Handle,
+	codex_bin: PathBuf,
+	login_home: &Path,
+) -> Status {
+	let session_id = start.session_id.clone();
+	let mut child = match Command::new(codex_bin)
+		.arg("login")
+		.arg("--device-auth")
+		.current_dir(login_home)
+		.env_remove("OPENAI_API_KEY")
+		.env_remove("CODEX_API_KEY")
+		.env_remove("CODEX_ACCESS_TOKEN")
+		.env_remove("CHATGPT_ACCESS_TOKEN")
+		.env_remove("CODEX_HOME")
+		.env_remove("CODEX_SQLITE_HOME")
+		.env("CODEX_HOME", login_home)
+		.env("CODEX_SQLITE_HOME", login_home)
+		.stdin(Stdio::null())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped())
+		.process_group(0)
+		.spawn()
+	{
+		Ok(child) => child,
+		Err(_) => return Status::failed(session_id, Failure::CodexUnavailable),
+	};
+	let Some(stdout) = child.stdout.take() else {
+		terminate_child(&mut child);
+		return Status::failed(session_id, Failure::LoginFailed);
+	};
+	let Some(stderr) = child.stderr.take() else {
+		terminate_child(&mut child);
+		return Status::failed(session_id, Failure::LoginFailed);
+	};
+	let (sender, receiver) = mpsc::channel();
+	let stdout_reader = match spawn_reader(stdout, sender.clone()) {
+		Ok(reader) => reader,
+		Err(()) => {
+			terminate_child(&mut child);
+			return Status::failed(session_id, Failure::ServiceUnavailable);
+		},
+	};
+	let stderr_reader = match spawn_reader(stderr, sender) {
+		Ok(reader) => reader,
+		Err(()) => {
+			terminate_child(&mut child);
+			let _ = stdout_reader.join();
+			return Status::failed(session_id, Failure::ServiceUnavailable);
+		},
+	};
+	let output = match collect_login_child(
+		shared,
+		&mut child,
+		receiver,
+		stdout_reader,
+		stderr_reader,
+		&session_id,
+	) {
+		Ok(output) => output,
+		Err(status) => return status,
+	};
+	if output.reader_failed || !output.exit.success() || !output.prompt_published {
+		return Status::failed(session_id, Failure::LoginFailed);
+	}
+	if shared.cancel_requested.load(Ordering::Acquire) {
+		return Status::cancelled(session_id);
+	}
+	let auth_path = match canonical_auth_file(login_home) {
+		Ok(path) => path,
+		Err(_) => return Status::failed(session_id, Failure::LoginFailed),
+	};
+	shared.set_status(Status::installing(session_id.clone()));
+	let outcome = runtime.block_on(install_credential(profile, start, auth_path));
+	match outcome {
+		Ok(()) => Status::completed(session_id),
+		Err(failure) => Status::failed(session_id, failure),
+	}
+}
+
+struct LoginChildOutput {
+	exit: ExitStatus,
+	reader_failed: bool,
+	prompt_published: bool,
+}
+
+fn collect_login_child(
+	shared: &Shared,
+	child: &mut Child,
+	receiver: Receiver<PipeEvent>,
+	stdout_reader: JoinHandle<()>,
+	stderr_reader: JoinHandle<()>,
+	session_id: &str,
+) -> Result<LoginChildOutput, Status> {
+	let deadline = Instant::now() + LOGIN_TIMEOUT;
+	let mut output = Vec::new();
+	let mut reader_failed = false;
+	let mut prompt_published = false;
+	let mut open_readers = 2_u8;
+	let mut exit = None;
+	loop {
+		if shared.cancel_requested.load(Ordering::Acquire) {
+			terminate_child(child);
+			join_readers(stdout_reader, stderr_reader);
+			return Err(Status::cancelled(session_id.to_owned()));
+		}
+		if Instant::now() >= deadline {
+			terminate_child(child);
+			join_readers(stdout_reader, stderr_reader);
+			return Err(Status::failed(session_id.to_owned(), Failure::LoginTimedOut));
+		}
+		match receiver.recv_timeout(CHILD_POLL_INTERVAL) {
+			Ok(PipeEvent::Bytes(bytes)) => {
+				if append_output(&mut output, &bytes).is_err() {
+					terminate_child(child);
+					join_readers(stdout_reader, stderr_reader);
+					return Err(Status::failed(session_id.to_owned(), Failure::LoginFailed));
+				}
+				if !prompt_published
+					&& let Some(code) = parse_device_code(&output)
+					&& contains_device_url(&output)
+				{
+					shared.set_status(Status::waiting(session_id.to_owned(), code));
+					prompt_published = true;
+				}
+			},
+			Ok(PipeEvent::Closed { failed }) => {
+				reader_failed |= failed;
+				open_readers = open_readers.saturating_sub(1);
+			},
+			Err(RecvTimeoutError::Timeout) => {},
+			Err(RecvTimeoutError::Disconnected) => {
+				reader_failed = true;
+				open_readers = 0;
+			},
+		}
+		if exit.is_none() {
+			match child.try_wait() {
+				Ok(Some(status)) => exit = Some(status),
+				Ok(None) => {},
+				Err(_) => {
+					terminate_child(child);
+					join_readers(stdout_reader, stderr_reader);
+					return Err(Status::failed(session_id.to_owned(), Failure::LoginFailed));
+				},
+			}
+		}
+		if open_readers == 0
+			&& let Some(exit) = exit
+		{
+			join_readers(stdout_reader, stderr_reader);
+			return Ok(LoginChildOutput { exit, reader_failed, prompt_published });
+		}
+	}
+}
+
+async fn install_credential(
+	profile: ClientProfile,
+	start: Start,
+	auth_path: PathBuf,
+) -> Result<(), Failure> {
+	let source_descriptor = WireText::new(auth_path.to_string_lossy().into_owned())
+		.map_err(|_| Failure::LoginFailed)?;
+	for attempt in 0..INSTALL_DISPATCH_ATTEMPTS {
+		let response = AccountClient::new(profile.clone())
+			.execute(
+				CommandPayload::ReauthenticateAccountFromCredentialFile {
+					operation_id: start.operation_id.clone(),
+					account_id: start.account_id.clone(),
+					source_descriptor: source_descriptor.clone(),
+				},
+				Some(start.expected_revision),
+				start.idempotency_key.clone(),
+			)
+			.await
+			.map_err(map_client_failure)?;
+		match response {
+			AccountCommandResponse::Applied { result, .. } => match result.as_ref() {
+				ResultPayload::AccountChanged { account }
+					if account.account_id == start.account_id =>
+					return Ok(()),
+				_ => return Err(Failure::ServiceUnavailable),
+			},
+			AccountCommandResponse::Rejected { error } => return Err(map_command_error(&error)),
+			AccountCommandResponse::PotentiallyDispatched { .. }
+				if attempt + 1 < INSTALL_DISPATCH_ATTEMPTS =>
+			{
+				tokio::time::sleep(INSTALL_REPLAY_DELAY).await;
+			},
+			AccountCommandResponse::PotentiallyDispatched { .. } =>
+				return Err(Failure::OutcomeUnknown),
+		}
+	}
+	Err(Failure::OutcomeUnknown)
+}
+
+fn map_client_failure(_failure: ClientFailure) -> Failure {
+	Failure::ServiceUnavailable
+}
+
+fn map_command_error(error: &CommandError) -> Failure {
+	match error {
+		CommandError::ExpectedRevisionMismatch { .. } => Failure::AccountChanged,
+		CommandError::AccountCommandRejected { rejection, .. } => match rejection {
+			AccountCommandRejectionDto::ProviderMismatch => Failure::AccountMismatch,
+			AccountCommandRejectionDto::StaleAccount => Failure::AccountChanged,
+			AccountCommandRejectionDto::CredentialStoreUnavailable =>
+				Failure::CredentialStoreUnavailable,
+			AccountCommandRejectionDto::AccountNotFound
+			| AccountCommandRejectionDto::CredentialAbsent
+			| AccountCommandRejectionDto::LifecycleUnready
+			| AccountCommandRejectionDto::OperationUnsettled
+			| AccountCommandRejectionDto::OperationNotFound
+			| AccountCommandRejectionDto::ManualRecoveryRequired
+			| AccountCommandRejectionDto::InvalidRequest
+			| AccountCommandRejectionDto::AccountInUse
+			| AccountCommandRejectionDto::RoutingOrderInvalid => Failure::AccountUnavailable,
+			AccountCommandRejectionDto::StaleRoutingControl => Failure::AccountChanged,
+		},
+		CommandError::IdempotencyConflict
+		| CommandError::IdempotencyCapacityExceeded { .. }
+		| CommandError::ApplicationUnavailable { .. }
+		| CommandError::AcceptanceUnknown => Failure::ServiceUnavailable,
+	}
+}
+
+fn canonical_executable(path: &Path) -> Result<PathBuf, Failure> {
+	if !path.is_absolute() {
+		return Err(Failure::CodexUnavailable);
+	}
+	let canonical = fs::canonicalize(path).map_err(|_| Failure::CodexUnavailable)?;
+	if canonical != path {
+		return Err(Failure::CodexUnavailable);
+	}
+	let metadata = fs::symlink_metadata(path).map_err(|_| Failure::CodexUnavailable)?;
+	if !metadata.file_type().is_file() || metadata.permissions().mode() & 0o111 == 0 {
+		return Err(Failure::CodexUnavailable);
+	}
+	Ok(canonical)
+}
+
+fn canonical_auth_file(login_home: &Path) -> Result<PathBuf, ()> {
+	let expected = login_home.join("auth.json");
+	let canonical = fs::canonicalize(&expected).map_err(|_| ())?;
+	if canonical != expected {
+		return Err(());
+	}
+	let metadata = fs::symlink_metadata(&expected).map_err(|_| ())?;
+	if !metadata.file_type().is_file()
+		|| metadata.uid() != unsafe { libc::geteuid() }
+		|| metadata.permissions().mode() & 0o077 != 0
+	{
+		return Err(());
+	}
+	Ok(canonical)
+}
+
+enum PipeEvent {
+	Bytes(Vec<u8>),
+	Closed { failed: bool },
+}
+
+fn spawn_reader(
+	mut reader: impl Read + Send + 'static,
+	sender: Sender<PipeEvent>,
+) -> Result<JoinHandle<()>, ()> {
+	thread::Builder::new()
+		.name("decodex-account-login-pipe".to_owned())
+		.spawn(move || {
+			let mut buffer = [0_u8; 4_096];
+			loop {
+				match reader.read(&mut buffer) {
+					Ok(0) => {
+						let _ = sender.send(PipeEvent::Closed { failed: false });
+						return;
+					},
+					Ok(length) =>
+						if sender.send(PipeEvent::Bytes(buffer[..length].to_vec())).is_err() {
+							return;
+						},
+					Err(_) => {
+						let _ = sender.send(PipeEvent::Closed { failed: true });
+						return;
+					},
+				}
+			}
+		})
+		.map_err(|_| ())
+}
+
+fn join_readers(stdout: JoinHandle<()>, stderr: JoinHandle<()>) {
+	let _ = stdout.join();
+	let _ = stderr.join();
+}
+
+fn terminate_child(child: &mut Child) {
+	if let Ok(process_group) = i32::try_from(child.id()) {
+		// SAFETY: The child was started as its own process-group leader. A
+		// negative PID targets that exact group and does not name another group.
+		unsafe {
+			libc::kill(-process_group, libc::SIGKILL);
+		}
+	}
+	let _ = child.kill();
+	let _ = child.wait();
+}
+
+fn append_output(output: &mut Vec<u8>, bytes: &[u8]) -> Result<(), ()> {
+	if output.len().saturating_add(bytes.len()) > MAX_LOGIN_OUTPUT_BYTES {
+		return Err(());
+	}
+	output.extend_from_slice(bytes);
+	Ok(())
+}
+
+fn contains_device_url(output: &[u8]) -> bool {
+	output.windows(DEVICE_LOGIN_URL.len()).any(|window| window == DEVICE_LOGIN_URL.as_bytes())
+}
+
+fn parse_device_code(output: &[u8]) -> Option<String> {
+	output.windows(10).find_map(|candidate| {
+		if candidate[4] != b'-' {
+			return None;
+		}
+		let valid = candidate
+			.iter()
+			.enumerate()
+			.all(|(index, byte)| index == 4 || byte.is_ascii_uppercase() || byte.is_ascii_digit());
+		valid.then(|| String::from_utf8_lossy(candidate).into_owned())
+	})
+}
+
+struct LoginHome {
+	path: PathBuf,
+	device: u64,
+	inode: u64,
+	cleaned: bool,
+}
+
+impl LoginHome {
+	fn create(session_id: &str) -> Result<Self, ()> {
+		let base = fs::canonicalize(std::env::temp_dir()).map_err(|_| ())?;
+		let path = base.join(format!("decodex-codex-device-login-{session_id}"));
+		fs::create_dir(&path).map_err(|_| ())?;
+		if fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).is_err() {
+			let _ = fs::remove_dir(&path);
+			return Err(());
+		}
+		let metadata = match fs::symlink_metadata(&path) {
+			Ok(metadata) => metadata,
+			Err(_) => {
+				let _ = fs::remove_dir(&path);
+				return Err(());
+			},
+		};
+		if !metadata.file_type().is_dir()
+			|| metadata.uid() != unsafe { libc::geteuid() }
+			|| metadata.permissions().mode() & 0o077 != 0
+		{
+			let _ = fs::remove_dir(&path);
+			return Err(());
+		}
+		Ok(Self { path, device: metadata.dev(), inode: metadata.ino(), cleaned: false })
+	}
+
+	fn path(&self) -> &Path {
+		&self.path
+	}
+
+	fn cleanup(&mut self) -> Result<(), ()> {
+		if self.cleaned {
+			return Ok(());
+		}
+		let metadata = match fs::symlink_metadata(&self.path) {
+			Ok(metadata) => metadata,
+			Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+				self.cleaned = true;
+				return Ok(());
+			},
+			Err(_) => return Err(()),
+		};
+		if !metadata.file_type().is_dir()
+			|| metadata.dev() != self.device
+			|| metadata.ino() != self.inode
+		{
+			return Err(());
+		}
+		fs::remove_dir_all(&self.path).map_err(|_| ())?;
+		match fs::symlink_metadata(&self.path) {
+			Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+				self.cleaned = true;
+				Ok(())
+			},
+			Ok(_) | Err(_) => Err(()),
+		}
+	}
+}
+
+impl Drop for LoginHome {
+	fn drop(&mut self) {
+		let _ = self.cleanup();
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parser_accepts_the_exact_device_prompt_across_ansi_output() {
+		let output =
+			b"\x1b[32mOpen https://auth.openai.com/codex/device\x1b[0m\nCode: ZL92-P3SQ0\n";
+
+		assert!(contains_device_url(output));
+		assert_eq!(parse_device_code(output).as_deref(), Some("ZL92-P3SQ0"));
+	}
+
+	#[test]
+	fn parser_rejects_noncanonical_codes() {
+		assert_eq!(parse_device_code(b"zl92-p3sq0"), None);
+		assert_eq!(parse_device_code(b"ZL9-P3SQ0"), None);
+		assert_eq!(parse_device_code(b"ZL92_P3SQ0"), None);
+	}
+
+	#[test]
+	fn login_home_is_private_and_removed_on_drop() {
+		let session_id = "018f0f9e-7b6e-4a31-8f4c-1d2e3f405162";
+		let home = LoginHome::create(session_id).expect("private login home");
+		let path = home.path().to_owned();
+		let metadata = fs::metadata(&path).expect("login home metadata");
+
+		assert_eq!(metadata.permissions().mode() & 0o777, 0o700);
+		drop(home);
+		assert!(!path.exists());
+	}
+
+	#[test]
+	fn login_home_cleanup_proves_absence() {
+		let session_id = "028f0f9e-7b6e-4a31-8f4c-1d2e3f405162";
+		let mut home = LoginHome::create(session_id).expect("private login home");
+		let path = home.path().to_owned();
+		fs::write(path.join("auth.json"), b"secret").expect("temporary credential");
+
+		home.cleanup().expect("explicit cleanup");
+
+		assert!(!path.exists());
+		assert!(home.cleaned);
+	}
+
+	#[test]
+	fn login_home_cleanup_rejects_identity_drift() {
+		let session_id = "038f0f9e-7b6e-4a31-8f4c-1d2e3f405162";
+		let mut home = LoginHome::create(session_id).expect("private login home");
+		let path = home.path().to_owned();
+		let moved = path.with_extension("moved");
+		fs::rename(&path, &moved).expect("move original home");
+		fs::create_dir(&path).expect("replacement home");
+
+		assert!(home.cleanup().is_err());
+		assert!(path.exists());
+
+		fs::remove_dir(&path).expect("remove replacement");
+		fs::rename(&moved, &path).expect("restore original");
+		home.cleanup().expect("cleanup restored home");
+	}
+
+	#[test]
+	fn completed_install_with_unproven_cleanup_is_outcome_unknown() {
+		let session_id = "048f0f9e-7b6e-4a31-8f4c-1d2e3f405162";
+		let mut home = LoginHome::create(session_id).expect("private login home");
+		let path = home.path().to_owned();
+		let moved = path.with_extension("moved");
+		fs::rename(&path, &moved).expect("move original home");
+		fs::create_dir(&path).expect("replacement home");
+
+		let status = finalize_login_status(
+			&mut home,
+			session_id.to_owned(),
+			Status::completed(session_id.to_owned()),
+		);
+
+		assert_eq!(status.state, State::Failed);
+		assert_eq!(status.failure, Some(Failure::OutcomeUnknown));
+
+		fs::remove_dir(&path).expect("remove replacement");
+		fs::rename(&moved, &path).expect("restore original");
+		home.cleanup().expect("cleanup restored home");
+	}
+
+	#[test]
+	fn uncertain_install_with_unproven_cleanup_remains_outcome_unknown() {
+		let session_id = "048f0f9e-7b6e-4a31-8f4c-1d2e3f405163";
+		let mut home = LoginHome::create(session_id).expect("private login home");
+		let path = home.path().to_owned();
+		let moved = path.with_extension("moved");
+		fs::rename(&path, &moved).expect("move original home");
+		fs::create_dir(&path).expect("replacement home");
+
+		let status = finalize_login_status(
+			&mut home,
+			session_id.to_owned(),
+			Status::failed(session_id.to_owned(), Failure::OutcomeUnknown),
+		);
+
+		assert_eq!(status.state, State::Failed);
+		assert_eq!(status.failure, Some(Failure::OutcomeUnknown));
+
+		fs::remove_dir(&path).expect("remove replacement");
+		fs::rename(&moved, &path).expect("restore original");
+		home.cleanup().expect("cleanup restored home");
+	}
+
+	#[test]
+	fn cancel_reaps_a_descendant_that_holds_login_pipes_after_leader_exit() {
+		let session_id = "058f0f9e-7b6e-4a31-8f4c-1d2e3f405162".to_owned();
+		let (manager, _, _fixture) = pipe_holding_login_manager(&session_id);
+
+		let started = Instant::now();
+		let status = manager.cancel(&session_id);
+
+		assert_eq!(status.state, State::Cancelled);
+		assert!(started.elapsed() < Duration::from_secs(2));
+	}
+
+	#[test]
+	fn shutdown_reaps_a_descendant_that_holds_login_pipes_after_leader_exit() {
+		let session_id = "068f0f9e-7b6e-4a31-8f4c-1d2e3f405162".to_owned();
+		let (manager, shared, _fixture) = pipe_holding_login_manager(&session_id);
+
+		let started = Instant::now();
+		manager.shutdown();
+
+		assert_eq!(shared.status().state, State::Cancelled);
+		assert!(started.elapsed() < Duration::from_secs(2));
+	}
+
+	#[test]
+	fn cancel_waits_for_worker_terminal_cleanup() {
+		let manager = Manager::default();
+		let session_id = "078f0f9e-7b6e-4a31-8f4c-1d2e3f405162".to_owned();
+		let shared = Arc::new(Shared::new(session_id.clone()));
+		let worker_shared = Arc::clone(&shared);
+		let worker_session_id = session_id.clone();
+		let worker = thread::spawn(move || {
+			while !worker_shared.cancel_requested.load(Ordering::Acquire) {
+				thread::yield_now();
+			}
+			worker_shared.set_status(Status::cancelled(worker_session_id));
+		});
+		*manager.lock_session() =
+			Some(Session { session_id: session_id.clone(), shared, worker: Some(worker) });
+
+		let status = manager.cancel(&session_id);
+
+		assert_eq!(status.state, State::Cancelled);
+		assert!(manager.lock_session().as_ref().is_some_and(|session| session.worker.is_none()));
+	}
+
+	#[test]
+	fn shutdown_closes_start_fence_and_joins_installing_worker() {
+		let manager = Manager::default();
+		let session_id = "088f0f9e-7b6e-4a31-8f4c-1d2e3f405162".to_owned();
+		let shared = Arc::new(Shared::new(session_id.clone()));
+		shared.set_status(Status::installing(session_id.clone()));
+		let worker_shared = Arc::clone(&shared);
+		let worker_session_id = session_id.clone();
+		let worker = thread::spawn(move || {
+			thread::sleep(Duration::from_millis(5));
+			worker_shared.set_status(Status::completed(worker_session_id));
+		});
+		*manager.lock_session() = Some(Session {
+			session_id: session_id.clone(),
+			shared: Arc::clone(&shared),
+			worker: Some(worker),
+		});
+
+		manager.shutdown();
+
+		assert!(manager.closed.load(Ordering::Acquire));
+		assert_eq!(shared.status().state, State::Completed);
+		assert!(manager.lock_session().as_ref().is_some_and(|session| session.worker.is_none()));
+	}
+
+	fn pipe_holding_login_manager(session_id: &str) -> (Manager, Arc<Shared>, tempfile::TempDir) {
+		let manager = Manager::default();
+		let shared = Arc::new(Shared::new(session_id.to_owned()));
+		let worker_shared = Arc::clone(&shared);
+		let worker_session_id = session_id.to_owned();
+		let fixture = tempfile::tempdir().expect("fixture directory");
+		let leader_path = fixture.path().join("leader.pid");
+		let worker_leader_path = leader_path.clone();
+		let worker = thread::spawn(move || {
+			let mut child = Command::new("/bin/sh")
+				.arg("-c")
+				.arg(
+					"printf '%s' \"$$\" > \"$1\"; \
+					 printf 'Open https://auth.openai.com/codex/device\\nCode: AB12-CDE34\\n'; \
+					 (sleep 60) & exit 0",
+				)
+				.arg("decodex-login-fixture")
+				.arg(worker_leader_path)
+				.stdin(Stdio::null())
+				.stdout(Stdio::piped())
+				.stderr(Stdio::piped())
+				.process_group(0)
+				.spawn()
+				.expect("login fixture");
+			let stdout = child.stdout.take().expect("fixture stdout");
+			let stderr = child.stderr.take().expect("fixture stderr");
+			let (sender, receiver) = mpsc::channel();
+			let stdout_reader =
+				spawn_reader(stdout, sender.clone()).expect("fixture stdout reader");
+			let stderr_reader = spawn_reader(stderr, sender).expect("fixture stderr reader");
+			let status = match collect_login_child(
+				&worker_shared,
+				&mut child,
+				receiver,
+				stdout_reader,
+				stderr_reader,
+				&worker_session_id,
+			) {
+				Ok(output)
+					if output.exit.success()
+						&& !output.reader_failed
+						&& output.prompt_published =>
+					Status::completed(worker_session_id),
+				Ok(_) => Status::failed(worker_session_id, Failure::LoginFailed),
+				Err(status) => status,
+			};
+			worker_shared.set_status(status);
+		});
+		*manager.lock_session() = Some(Session {
+			session_id: session_id.to_owned(),
+			shared: Arc::clone(&shared),
+			worker: Some(worker),
+		});
+
+		let mut leader_reaped = false;
+		for _ in 0..200 {
+			if let Ok(text) = fs::read_to_string(&leader_path)
+				&& let Ok(pid) = text.parse::<i32>()
+			{
+				// SAFETY: Signal zero performs a liveness query and does not
+				// mutate the fixture process.
+				let result = unsafe { libc::kill(pid, 0) };
+				if result == -1
+					&& std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+				{
+					leader_reaped = true;
+					break;
+				}
+			}
+			thread::sleep(Duration::from_millis(5));
+		}
+		assert!(leader_reaped, "fixture leader must exit while its descendant holds the pipes");
+
+		(manager, shared, fixture)
+	}
+}

--- a/crates/decodex-app-client-ffi/src/lib.rs
+++ b/crates/decodex-app-client-ffi/src/lib.rs
@@ -1,15 +1,18 @@
 //! In-process C ABI for the native Decodex app.
 //!
 //! The bridge is a credential-negative client of the one local `decodexd`
-//! service. It reuses the typed Rust protocol clients directly and never starts
-//! a command-line process.
+//! service. It reuses the typed Rust protocol clients directly. Its only child
+//! process is one bounded official Codex device-login session; Swift never
+//! receives credential bytes or a credential-file path.
 
+mod account_reauthentication;
 mod fast_mode;
 
 use std::{
 	collections::HashMap,
 	ffi::c_void,
 	panic::{AssertUnwindSafe, catch_unwind},
+	path::PathBuf,
 	ptr, slice,
 	sync::{
 		Arc, Mutex, OnceLock,
@@ -34,9 +37,9 @@ static RUNTIME: OnceLock<Result<Runtime, ()>> = OnceLock::new();
 static CLIENTS: OnceLock<Mutex<HashMap<usize, Arc<NativeClient>>>> = OnceLock::new();
 static NEXT_CLIENT_ID: AtomicUsize = AtomicUsize::new(1);
 
-#[derive(Clone)]
 struct NativeClient {
 	profile: ClientProfile,
+	account_reauthentication: account_reauthentication::Manager,
 }
 
 #[derive(Deserialize)]
@@ -124,6 +127,23 @@ enum Request {
 		expected_revision: u64,
 		idempotency_key: String,
 	},
+	StartAccountReauthentication {
+		schema: String,
+		session_id: String,
+		operation_id: String,
+		account_id: String,
+		expected_revision: u64,
+		idempotency_key: String,
+		codex_bin: String,
+	},
+	PollAccountReauthentication {
+		schema: String,
+		session_id: String,
+	},
+	CancelAccountReauthentication {
+		schema: String,
+		session_id: String,
+	},
 	UseAccountInCodex {
 		schema: String,
 		account_id: String,
@@ -155,6 +175,9 @@ impl Request {
 			Self::SetFixedSelection { .. } => "set_fixed_selection",
 			Self::SetBalancedSelection { .. } => "set_balanced_selection",
 			Self::RefreshAccount { .. } => "refresh_account",
+			Self::StartAccountReauthentication { .. } => "start_account_reauthentication",
+			Self::PollAccountReauthentication { .. } => "poll_account_reauthentication",
+			Self::CancelAccountReauthentication { .. } => "cancel_account_reauthentication",
 			Self::UseAccountInCodex { .. } => "use_account_in_codex",
 			Self::FastModeStatus { .. } => "fast_mode_status",
 			Self::SetFastMode { .. } => "set_fast_mode",
@@ -176,6 +199,9 @@ impl Request {
 			| Self::SetFixedSelection { schema, .. }
 			| Self::SetBalancedSelection { schema, .. }
 			| Self::RefreshAccount { schema, .. }
+			| Self::StartAccountReauthentication { schema, .. }
+			| Self::PollAccountReauthentication { schema, .. }
+			| Self::CancelAccountReauthentication { schema, .. }
 			| Self::UseAccountInCodex { schema, .. }
 			| Self::FastModeStatus { schema }
 			| Self::SetFastMode { schema, .. } => schema,
@@ -332,13 +358,12 @@ pub extern "C" fn decodex_app_native_client_destroy(client: *mut c_void) {
 	}
 	let client_id = client as usize;
 	let clients = clients();
-	match clients.lock() {
-		Ok(mut clients) => {
-			clients.remove(&client_id);
-		},
-		Err(poisoned) => {
-			poisoned.into_inner().remove(&client_id);
-		},
+	let client = match clients.lock() {
+		Ok(mut clients) => clients.remove(&client_id),
+		Err(poisoned) => poisoned.into_inner().remove(&client_id),
+	};
+	if let Some(client) = client {
+		client.account_reauthentication.shutdown();
 	}
 }
 
@@ -484,7 +509,10 @@ fn create_client(
 	};
 
 	let client_id = next_client_id();
-	let client = Arc::new(NativeClient { profile });
+	let client = Arc::new(NativeClient {
+		profile,
+		account_reauthentication: account_reauthentication::Manager::default(),
+	});
 	match clients().lock() {
 		Ok(mut clients) => {
 			clients.insert(client_id, client);
@@ -564,7 +592,7 @@ fn request(
 		server_id: native_client.profile.expected_server_id().as_str().to_owned(),
 	};
 
-	match runtime.block_on(execute_request(native_client.profile.clone(), request)) {
+	match runtime.block_on(execute_request(native_client, request)) {
 		Ok(data) => write_serialized(
 			out_response_json,
 			out_response_len,
@@ -598,9 +626,10 @@ fn request(
 }
 
 async fn execute_request(
-	profile: ClientProfile,
+	native_client: Arc<NativeClient>,
 	request: Request,
 ) -> Result<Value, RequestFailure> {
+	let profile = native_client.profile.clone();
 	match request {
 		Request::ListAccounts { .. } =>
 			to_value(AccountClient::new(profile).list().await.map_err(RequestFailure::Client)?),
@@ -706,6 +735,48 @@ async fn execute_request(
 				idempotency_key,
 			)
 			.await
+		},
+		Request::StartAccountReauthentication {
+			session_id,
+			operation_id,
+			account_id,
+			expected_revision,
+			idempotency_key,
+			codex_bin,
+			..
+		} => {
+			if !is_canonical_uuid(&session_id)
+				|| codex_bin.is_empty()
+				|| codex_bin.len() > 4_096
+				|| codex_bin.chars().any(char::is_control)
+			{
+				return Err(RequestFailure::Bridge(BridgeFailure::InvalidInput));
+			}
+			let start = account_reauthentication::Start {
+				session_id,
+				operation_id: entity_id(&operation_id)?,
+				account_id: entity_id(&account_id)?,
+				expected_revision: revision(expected_revision)?,
+				idempotency_key: parse_idempotency_key(idempotency_key)?,
+				codex_bin: PathBuf::from(codex_bin),
+			};
+			to_value(native_client.account_reauthentication.start(
+				start,
+				profile,
+				tokio::runtime::Handle::current(),
+			))
+		},
+		Request::PollAccountReauthentication { session_id, .. } => {
+			if !is_canonical_uuid(&session_id) {
+				return Err(RequestFailure::Bridge(BridgeFailure::InvalidInput));
+			}
+			to_value(native_client.account_reauthentication.poll(&session_id))
+		},
+		Request::CancelAccountReauthentication { session_id, .. } => {
+			if !is_canonical_uuid(&session_id) {
+				return Err(RequestFailure::Bridge(BridgeFailure::InvalidInput));
+			}
+			to_value(native_client.account_reauthentication.cancel(&session_id))
 		},
 		Request::UseAccountInCodex { account_id, expected_revision, idempotency_key, .. } =>
 			use_account_in_codex(profile, account_id, expected_revision, idempotency_key).await,
@@ -979,6 +1050,40 @@ mod tests {
 			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"use_account_in_codex","account_id":"{ACCOUNT_ID}","idempotency_key":"use-account-test"}}"#
 		))
 		.is_err());
+	}
+
+	#[test]
+	fn account_reauthentication_requests_are_exact_and_revision_fenced() {
+		let session_id = "028f0f9e-7b6e-4a31-8f4c-1d2e3f405163";
+		let operation_id = "038f0f9e-7b6e-4a31-8f4c-1d2e3f405164";
+		let start = serde_json::from_str::<Request>(&format!(
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"start_account_reauthentication","session_id":"{session_id}","operation_id":"{operation_id}","account_id":"{ACCOUNT_ID}","expected_revision":7,"idempotency_key":"{operation_id}","codex_bin":"/Applications/Codex.app/Contents/Resources/codex"}}"#
+		))
+		.expect("start request must decode");
+		let poll = serde_json::from_str::<Request>(&format!(
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"poll_account_reauthentication","session_id":"{session_id}"}}"#
+		))
+		.expect("poll request must decode");
+		let cancel = serde_json::from_str::<Request>(&format!(
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"cancel_account_reauthentication","session_id":"{session_id}"}}"#
+		))
+		.expect("cancel request must decode");
+
+		assert_eq!(start.operation(), "start_account_reauthentication");
+		assert_eq!(poll.operation(), "poll_account_reauthentication");
+		assert_eq!(cancel.operation(), "cancel_account_reauthentication");
+		assert!(
+			serde_json::from_str::<Request>(&format!(
+				r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"start_account_reauthentication","session_id":"{session_id}","operation_id":"{operation_id}","account_id":"{ACCOUNT_ID}","idempotency_key":"{operation_id}","codex_bin":"/Applications/Codex.app/Contents/Resources/codex"}}"#
+			))
+			.is_err()
+		);
+		assert!(
+			serde_json::from_str::<Request>(&format!(
+				r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"poll_account_reauthentication","session_id":"{session_id}","extra":true}}"#
+			))
+			.is_err()
+		);
 	}
 
 	#[test]

--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -1015,6 +1015,7 @@ impl AccountClient {
 				| CommandPayload::SetBalancedAccountSelection
 				| CommandPayload::SetAccountOrder { .. }
 				| CommandPayload::RefreshAccount { .. }
+				| CommandPayload::ReauthenticateAccountFromCredentialFile { .. }
 				| CommandPayload::UseAccountInCodex { .. }
 				| CommandPayload::RecoverAccountOperation { .. }
 		) {
@@ -1117,8 +1118,9 @@ impl AccountClient {
 				},
 				ServerMessage::Event(event) =>
 					self.transport.verify_version_and_server(event.version, &event.server_id)?,
-				ServerMessage::Refusal(refusal) =>
-					return Err(self.transport.refusal_failure(refusal)),
+				ServerMessage::Refusal(refusal) => {
+					return Err(self.transport.refusal_failure(refusal));
+				},
 				_ => return Err(ClientFailure::ProtocolMalformed),
 			}
 		}
@@ -1149,6 +1151,10 @@ fn account_result_matches(
 		)
 		| (
 			CommandPayload::RefreshAccount { account_id, .. },
+			ResultPayload::AccountChanged { account },
+		)
+		| (
+			CommandPayload::ReauthenticateAccountFromCredentialFile { account_id, .. },
 			ResultPayload::AccountChanged { account },
 		) => account_id == &account.account_id && entity_revision == account.account_revision,
 		(
@@ -2618,6 +2624,48 @@ max_entry_bytes = 0
 
 		assert!(super::account_result_matches(&command, EntityRevision(11), &exact));
 		assert!(!super::account_result_matches(&command, EntityRevision(11), &stale));
+	}
+
+	#[test]
+	fn reauthentication_result_requires_exact_account_and_revision() {
+		let account_id =
+			EntityId::new("42234567-89ab-4def-8123-456789abcdef").expect("canonical account ID");
+		let command = crate::CommandPayload::ReauthenticateAccountFromCredentialFile {
+			operation_id: EntityId::new("43234567-89ab-4def-8123-456789abcdef")
+				.expect("canonical operation ID"),
+			account_id: account_id.clone(),
+			source_descriptor: crate::WireText::new("/private/tmp/login/auth.json")
+				.expect("bounded source descriptor"),
+		};
+		let account = serde_json::from_value::<crate::AccountDto>(serde_json::json!({
+			"account_id": account_id.as_str(),
+			"alias": "Val",
+			"enabled": true,
+			"account_revision": 12,
+			"observed_state": "unknown",
+			"lifecycle_readiness": "credential_absent",
+			"five_hour_quota": {
+				"duration_minutes": 300,
+				"observed_at_unix_micros": null,
+				"result": {"state": "unknown"}
+			},
+			"seven_day_quota": {
+				"duration_minutes": 10080,
+				"observed_at_unix_micros": null,
+				"result": {"state": "unknown"}
+			}
+		}))
+		.expect("account fixture is valid");
+		let exact = ResultPayload::AccountChanged { account: Box::new(account.clone()) };
+		let stale = ResultPayload::AccountChanged {
+			account: Box::new(crate::AccountDto {
+				account_revision: EntityRevision(11),
+				..account
+			}),
+		};
+
+		assert!(super::account_result_matches(&command, EntityRevision(12), &exact));
+		assert!(!super::account_result_matches(&command, EntityRevision(12), &stale));
 	}
 
 	#[tokio::test]

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -2221,6 +2221,15 @@ pub enum CommandPayload {
 		/// Canonical account identity.
 		account_id: EntityId,
 	},
+	/// Replace one exact account credential from an owner-private Codex auth file.
+	ReauthenticateAccountFromCredentialFile {
+		/// Stable finite lifecycle operation identity.
+		operation_id: EntityId,
+		/// Canonical existing account identity.
+		account_id: EntityId,
+		/// Owner-private Codex auth path descriptor opened by the daemon.
+		source_descriptor: WireText,
+	},
 	/// Project one exact daemon-owned account into the normal Codex shared auth file.
 	UseAccountInCodex {
 		/// Canonical account identity.
@@ -2995,6 +3004,23 @@ fn validate_account_command(command: &CommandEnvelope) -> Result<(), &'static st
 			validate_canonical_account(account_id)?;
 			positive_expected.then_some(()).ok_or("account revision is required")
 		},
+		CommandPayload::ReauthenticateAccountFromCredentialFile {
+			operation_id,
+			account_id,
+			source_descriptor,
+		} => {
+			validate_canonical_operation(operation_id)?;
+			validate_canonical_account(account_id)?;
+			if !positive_expected {
+				return Err("account revision is required");
+			}
+			let source = source_descriptor.as_str();
+			if source.is_empty() || source.len() > 4096 || source.chars().any(char::is_control) {
+				Err("account credential source descriptor is invalid")
+			} else {
+				Ok(())
+			}
+		},
 		CommandPayload::UseAccountInCodex { account_id } => {
 			validate_canonical_account(account_id)?;
 			positive_expected.then_some(()).ok_or("account revision is required")
@@ -3562,6 +3588,54 @@ mod tests {
 				},
 			}))
 			.is_err(),
+		);
+	}
+
+	#[test]
+	fn account_reauthentication_is_revision_fenced_and_path_only() {
+		let account_id =
+			EntityId::new("31234567-89ab-4def-8123-456789abcdef").expect("canonical account ID");
+		let operation_id =
+			EntityId::new("32234567-89ab-4def-8123-456789abcdef").expect("canonical operation ID");
+		let payload = CommandPayload::ReauthenticateAccountFromCredentialFile {
+			operation_id: operation_id.clone(),
+			account_id: account_id.clone(),
+			source_descriptor: WireText::new("/private/tmp/decodex-login/auth.json")
+				.expect("bounded source descriptor"),
+		};
+		let message = |payload, expected_revision| {
+			ClientMessage::Command(CommandEnvelope {
+				version: CURRENT_VERSION,
+				client_command_id: ClientCommandId::new("reauth-command").unwrap(),
+				idempotency_key: IdempotencyKey::new("reauth-key").unwrap(),
+				expected_revision,
+				correlation_id: CorrelationId::new("reauth-command").unwrap(),
+				causation_id: None,
+				payload,
+			})
+		};
+		let encoded =
+			serde_json::to_string(&message(payload.clone(), Some(EntityRevision(7)))).unwrap();
+
+		assert!(decode_client_message(&encoded).is_ok());
+		assert!(encoded.contains("\"name\":\"reauthenticate_account_from_credential_file\""));
+		assert!(!encoded.contains("access_token"));
+		assert!(
+			decode_client_message(&serde_json::to_string(&message(payload.clone(), None)).unwrap())
+				.is_err()
+		);
+		let invalid = CommandPayload::ReauthenticateAccountFromCredentialFile {
+			operation_id,
+			account_id,
+			source_descriptor: WireText::new("relative/auth.json").unwrap(),
+		};
+		// Absolute-path enforcement belongs to the daemon's no-follow source reader.
+		// The public wire still rejects empty and control-bearing descriptors.
+		assert!(
+			decode_client_message(
+				&serde_json::to_string(&message(invalid, Some(EntityRevision(7)))).unwrap()
+			)
+			.is_ok()
 		);
 	}
 

--- a/crates/decodex-runtime/src/account_import.rs
+++ b/crates/decodex-runtime/src/account_import.rs
@@ -47,6 +47,20 @@ pub(crate) fn read_shared_codex_credential() -> Result<ImportedCredential, Crede
 pub(crate) fn read_explicit_credential_file(
 	descriptor: &str,
 ) -> Result<ImportedCredential, CredentialImportError> {
+	read_explicit_source(descriptor, SourceKind::VersionedImport)
+}
+
+/// Read one explicit owner-private Codex auth file for an existing-account reauthentication.
+pub(crate) fn read_explicit_shared_codex_credential_file(
+	descriptor: &str,
+) -> Result<ImportedCredential, CredentialImportError> {
+	read_explicit_source(descriptor, SourceKind::SharedCodex)
+}
+
+fn read_explicit_source(
+	descriptor: &str,
+	source_kind: SourceKind,
+) -> Result<ImportedCredential, CredentialImportError> {
 	if descriptor.is_empty() || descriptor.len() > 4096 || descriptor.chars().any(char::is_control)
 	{
 		return Err(CredentialImportError::InvalidSource);
@@ -55,7 +69,7 @@ pub(crate) fn read_explicit_credential_file(
 	if !path.is_absolute() {
 		return Err(CredentialImportError::InvalidSource);
 	}
-	read_credential_file(path, SourceKind::VersionedImport)
+	read_credential_file(path, source_kind)
 }
 
 #[derive(Clone, Copy)]
@@ -324,14 +338,28 @@ pub(crate) enum CredentialImportError {
 
 #[cfg(test)]
 mod tests {
+	use std::{fs, os::unix::fs::PermissionsExt as _};
+
 	use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 	use serde_json::json;
+	use tempfile::tempdir;
 
-	use super::{CredentialImportError, decode_chatgpt_identity};
+	use super::{
+		CredentialImportError, decode_chatgpt_identity, read_explicit_shared_codex_credential_file,
+	};
 
 	fn token(claims: serde_json::Value) -> String {
 		let payload = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap());
 		format!("header.{payload}.signature")
+	}
+
+	fn owner_private_json(value: serde_json::Value) -> (tempfile::TempDir, String) {
+		let temp = tempdir().unwrap();
+		let root = fs::canonicalize(temp.path()).unwrap();
+		let path = root.join("auth.json");
+		fs::write(&path, serde_json::to_vec(&value).unwrap()).unwrap();
+		fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+		(temp, path.to_string_lossy().into_owned())
 	}
 
 	#[test]
@@ -370,5 +398,56 @@ mod tests {
 				Err(CredentialImportError::InvalidCredential)
 			));
 		}
+	}
+
+	#[test]
+	fn explicit_shared_codex_source_parses_only_owner_private_auth_json() {
+		let account_id = "fresh-provider-account";
+		let id_token = token(json!({
+			"email": "fresh@example.test",
+			"https://api.openai.com/auth": {
+				"chatgpt_account_id": account_id,
+				"chatgpt_plan_type": "pro"
+			}
+		}));
+		let access_token = token(json!({"exp": 2_000_000_000_i64}));
+		let (_temp, path) = owner_private_json(json!({
+			"auth_mode": "chatgpt",
+			"OPENAI_API_KEY": null,
+			"tokens": {
+				"id_token": id_token,
+				"access_token": access_token,
+				"refresh_token": "fresh-refresh",
+				"account_id": account_id
+			},
+			"last_refresh": null
+		}));
+
+		let imported = read_explicit_shared_codex_credential_file(&path).unwrap();
+
+		assert_eq!(imported.provider.account_id(), account_id);
+		assert_eq!(imported.bundle.provider_email(), "fresh@example.test");
+		assert_eq!(imported.bundle.plan_type(), Some("pro"));
+	}
+
+	#[test]
+	fn explicit_shared_codex_source_rejects_relative_public_or_wrong_shape_inputs() {
+		assert!(matches!(
+			read_explicit_shared_codex_credential_file("auth.json"),
+			Err(CredentialImportError::InvalidSource)
+		));
+		let (_temp, path) = owner_private_json(json!({
+			"schema": "decodex/account-credential-import/1",
+			"provider": "chatgpt"
+		}));
+		assert!(matches!(
+			read_explicit_shared_codex_credential_file(&path),
+			Err(CredentialImportError::InvalidCredential)
+		));
+		fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+		assert!(matches!(
+			read_explicit_shared_codex_credential_file(&path),
+			Err(CredentialImportError::UnsafeSource)
+		));
 	}
 }

--- a/crates/decodex-runtime/src/account_service.rs
+++ b/crates/decodex-runtime/src/account_service.rs
@@ -31,7 +31,8 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use crate::{
 	account_import::{
 		CredentialImportError, ImportedCredential, decode_chatgpt_identity,
-		read_explicit_credential_file, read_shared_codex_credential,
+		read_explicit_credential_file, read_explicit_shared_codex_credential_file,
+		read_shared_codex_credential,
 	},
 	auth_projection::{
 		CodexAuthProjectionError, SharedCodexAuthIdentity, project_shared_codex_auth,
@@ -1012,6 +1013,245 @@ impl AccountService {
 				.await?;
 		}
 		Ok(projection(&target, &projection_bundle))
+	}
+
+	/// Replace one exact account credential from a private Codex auth file.
+	#[allow(clippy::too_many_arguments)] // The receipt, operation, account fence, private source, and response owner are independent inputs.
+	pub(crate) async fn reauthenticate_from_credential_file_command<F>(
+		&self,
+		lease: AccountCommandReceiptLease,
+		operation_id: AccountOperationId,
+		account_id: &AccountId,
+		expected_account_revision: i64,
+		source_descriptor: &str,
+		build_response: F,
+	) -> Result<Value, AccountLifecycleError>
+	where
+		F: FnOnce(Result<&AccountRecord, AccountLifecycleError>) -> Result<Value, StoreError>
+			+ Send,
+	{
+		let lock = self.lock_for(account_id)?;
+		let _guard = lock.lock().await;
+		let mut build_response = Some(build_response);
+		let account = match self.load_account(account_id).await {
+			Ok(account) => account,
+			Err(error) => {
+				return self
+					.complete_account_command_error(
+						lease,
+						error,
+						build_response.take().expect("builder is retained"),
+					)
+					.await;
+			},
+		};
+		if let Some(operation) = self.store.read_account_operation(&operation_id).await? {
+			if let Err(error) = self.require_operation_identity(
+				&operation,
+				account_id,
+				AccountOperationKind::Refresh,
+			) {
+				return self
+					.complete_account_command_error(
+						lease,
+						error,
+						build_response.take().expect("builder is retained"),
+					)
+					.await;
+			}
+			if operation.expected_account_revision != Some(expected_account_revision) {
+				return self
+					.complete_account_command_error(
+						lease,
+						AccountLifecycleError::StaleAccount,
+						build_response.take().expect("builder is retained"),
+					)
+					.await;
+			}
+			match classify_reauthentication_replay(
+				operation.phase,
+				operation.expected.as_ref(),
+				operation.target.as_ref(),
+				|binding| self.credentials.read_exact(account_id, binding).map(|_| ()),
+			) {
+				ReauthenticationReplayDisposition::Complete => {
+					if !matches!(
+						operation.phase,
+						AccountOperationPhase::StoreApplied | AccountOperationPhase::Committed
+					) {
+						accepted_phase(
+							self.store
+								.advance_account_operation(
+									&operation_id,
+									operation.phase,
+									AccountOperationPhase::StoreApplied,
+									None,
+								)
+								.await?,
+						)?;
+					}
+					return self
+						.complete_account_operation_success(
+							lease,
+							&operation_id,
+							AccountOperationPhase::StoreApplied,
+							AccountOperationPhase::Committed,
+							build_response.take().expect("builder is retained"),
+						)
+						.await;
+				},
+				ReauthenticationReplayDisposition::Cancel => {
+					return self
+						.complete_account_operation_error(
+							lease,
+							&operation_id,
+							operation.phase,
+							AccountOperationPhase::Cancelled,
+							None,
+							AccountLifecycleError::InvalidOperation,
+							build_response.take().expect("builder is retained"),
+						)
+						.await;
+				},
+				ReauthenticationReplayDisposition::Recover => {
+					return self
+						.complete_account_operation_error(
+							lease,
+							&operation_id,
+							operation.phase,
+							AccountOperationPhase::RecoveryRequired,
+							Some("credential_reauthentication_reconciliation"),
+							AccountLifecycleError::NotReady(
+								AccountLifecycleReadiness::OperationUnsettled,
+							),
+							build_response.take().expect("builder is retained"),
+						)
+						.await;
+				},
+			}
+		}
+		let current = match reauthentication_current(&account, expected_account_revision) {
+			Ok(current) => current,
+			Err(error) => {
+				return self
+					.complete_account_command_error(
+						lease,
+						error,
+						build_response.take().expect("builder is retained"),
+					)
+					.await;
+			},
+		};
+		let imported = match read_explicit_shared_codex_credential_file(source_descriptor) {
+			Ok(imported) => imported,
+			Err(error) => {
+				return self
+					.complete_account_command_error(
+						lease,
+						error.into(),
+						build_response.take().expect("builder is retained"),
+					)
+					.await;
+			},
+		};
+		let target = match reauthentication_target(&current, account_id, &operation_id, &imported) {
+			Ok(target) => target,
+			Err(error) => {
+				return self
+					.complete_account_command_error(
+						lease,
+						error,
+						build_response.take().expect("builder is retained"),
+					)
+					.await;
+			},
+		};
+		if let Err(error) = self.credentials.read_exact(account_id, &current) {
+			return self
+				.complete_account_command_error(
+					lease,
+					error.into(),
+					build_response.take().expect("builder is retained"),
+				)
+				.await;
+		}
+		let preparation = AccountOperationPreparation {
+			operation_id: operation_id.clone(),
+			account_id: account_id.clone(),
+			kind: AccountOperationKind::Refresh,
+			display_label: None,
+			enabled: None,
+			expected_account_revision: Some(expected_account_revision),
+			expected: Some(current.clone()),
+			target: Some(target.clone()),
+			provider: imported.provider,
+		};
+		let phase = match self.store.prepare_account_operation(&preparation).await? {
+			AccountLifecycleMutationOutcome::Applied(mutation)
+			| AccountLifecycleMutationOutcome::Replayed(mutation) => mutation.phase,
+			AccountLifecycleMutationOutcome::Rejected { rejection, .. } => {
+				return self
+					.complete_account_command_error(
+						lease,
+						AccountLifecycleError::OperationRejected(rejection),
+						build_response.take().expect("builder is retained"),
+					)
+					.await;
+			},
+		};
+		if phase != AccountOperationPhase::Prepared {
+			return self
+				.complete_account_command_error(
+					lease,
+					AccountLifecycleError::InvalidOperation,
+					build_response.take().expect("builder is retained"),
+				)
+				.await;
+		}
+		let rotation = self.credentials.compare_and_swap_rotate(
+			account_id,
+			&current,
+			&target,
+			imported.bundle,
+		);
+		let target_is_exact =
+			rotation.is_err() && self.credentials.read_exact(account_id, &target).is_ok();
+		if let Err(error) = resolve_reauthentication_store_effect(rotation, target_is_exact) {
+			let ambiguous = store_effect_may_be_ambiguous(error);
+			return self
+				.complete_account_operation_error(
+					lease,
+					&operation_id,
+					AccountOperationPhase::Prepared,
+					if ambiguous {
+						AccountOperationPhase::RecoveryRequired
+					} else {
+						AccountOperationPhase::Cancelled
+					},
+					ambiguous.then_some("credential_reauthentication_reconciliation"),
+					error.into(),
+					build_response.take().expect("builder is retained"),
+				)
+				.await;
+		}
+		accepted_phase(
+			self.store
+				.advance_account_operation(
+					&operation_id,
+					AccountOperationPhase::Prepared,
+					AccountOperationPhase::StoreApplied,
+					None,
+				)
+				.await?,
+		)?;
+		self.complete_account_operation_success(
+			lease,
+			&operation_id,
+			AccountOperationPhase::StoreApplied,
+			AccountOperationPhase::Committed,
+			build_response.take().expect("builder is retained"),
+		)
+		.await
 	}
 
 	/// Refresh one account and atomically commit the exact final registry result with its logical
@@ -2831,17 +3071,47 @@ impl AccountService {
 			},
 			AccountOperationKind::Refresh => {
 				if operation.phase == AccountOperationPhase::Prepared {
-					accepted_phase(
-						self.store
-							.advance_account_operation(
-								&operation.operation_id,
-								operation.phase,
-								AccountOperationPhase::Cancelled,
-								None,
+					return match classify_prepared_refresh_reconciliation(
+						operation.expected.as_ref(),
+						operation.target.as_ref(),
+						|binding| {
+							self.credentials.read_exact(&operation.account_id, binding).map(|_| ())
+						},
+					) {
+						PreparedRefreshReconciliation::StoreApplied => {
+							accepted_phase(
+								self.store
+									.advance_account_operation(
+										&operation.operation_id,
+										operation.phase,
+										AccountOperationPhase::StoreApplied,
+										None,
+									)
+									.await?,
+							)?;
+							self.commit_store_applied(&operation.operation_id).await?;
+							Ok(ReconciliationDisposition::Committed)
+						},
+						PreparedRefreshReconciliation::NotApplied => {
+							accepted_phase(
+								self.store
+									.advance_account_operation(
+										&operation.operation_id,
+										operation.phase,
+										AccountOperationPhase::Cancelled,
+										None,
+									)
+									.await?,
+							)?;
+							Ok(ReconciliationDisposition::Cancelled)
+						},
+						PreparedRefreshReconciliation::RecoveryRequired =>
+							self.mark_manual(
+								operation,
+								"credential_reauthentication_reconciliation",
 							)
-							.await?,
-					)?;
-					return Ok(ReconciliationDisposition::Cancelled);
+							.await,
+					};
 				}
 				let Some(target) = operation.target.as_ref() else {
 					return self.mark_manual(operation, PROVIDER_REFRESH_OUTCOME_UNKNOWN).await;
@@ -3062,6 +3332,47 @@ fn refreshed_credential_target(
 		.map_err(Into::into)
 }
 
+fn reauthentication_current(
+	account: &AccountRecord,
+	expected_account_revision: i64,
+) -> Result<CredentialBinding, AccountLifecycleError> {
+	if account.revision != expected_account_revision {
+		return Err(AccountLifecycleError::StaleAccount);
+	}
+	account.credential.clone().ok_or(AccountLifecycleError::CredentialAbsent)
+}
+
+fn reauthentication_target(
+	current: &CredentialBinding,
+	account_id: &AccountId,
+	operation_id: &AccountOperationId,
+	imported: &ImportedCredential,
+) -> Result<CredentialBinding, AccountLifecycleError> {
+	if imported.provider != current.provider {
+		return Err(AccountLifecycleError::ProviderMismatch);
+	}
+	imported
+		.bundle
+		.binding_for(
+			account_id,
+			operation_id,
+			current.version.successor().map_err(|_| AccountLifecycleError::InvalidOperation)?,
+			&imported.provider,
+		)
+		.map_err(Into::into)
+}
+
+const fn resolve_reauthentication_store_effect(
+	rotation: Result<(), CredentialStoreError>,
+	target_is_exact: bool,
+) -> Result<(), CredentialStoreError> {
+	match rotation {
+		Ok(()) => Ok(()),
+		Err(_) if target_is_exact => Ok(()),
+		Err(error) => Err(error),
+	}
+}
+
 fn matching_shared_refresh(
 	current: &CredentialBinding,
 	current_bundle: &CredentialSecretBundle,
@@ -3090,6 +3401,75 @@ fn same_refresh_bundle(first: &CredentialSecretBundle, second: &CredentialSecret
 		&& first.token_type() == second.token_type()
 		&& first.access_token_expires_at_unix_micros()
 			== second.access_token_expires_at_unix_micros()
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReauthenticationReplayDisposition {
+	Complete,
+	Cancel,
+	Recover,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PreparedRefreshReconciliation {
+	StoreApplied,
+	NotApplied,
+	RecoveryRequired,
+}
+
+fn classify_prepared_refresh_reconciliation<F>(
+	expected: Option<&CredentialBinding>,
+	target: Option<&CredentialBinding>,
+	mut read_exact: F,
+) -> PreparedRefreshReconciliation
+where
+	F: FnMut(&CredentialBinding) -> Result<(), CredentialStoreError>,
+{
+	// Ordinary refresh reaches ProviderEffectPending before it records a target. A target-backed
+	// Prepared refresh is reauthentication and can have completed its store CAS before a crash.
+	let Some(target) = target else {
+		return PreparedRefreshReconciliation::NotApplied;
+	};
+	match read_exact(target) {
+		Ok(()) => PreparedRefreshReconciliation::StoreApplied,
+		Err(CredentialStoreError::Unavailable) => PreparedRefreshReconciliation::RecoveryRequired,
+		Err(_) => match expected {
+			Some(expected) if read_exact(expected).is_ok() =>
+				PreparedRefreshReconciliation::NotApplied,
+			Some(_) | None => PreparedRefreshReconciliation::RecoveryRequired,
+		},
+	}
+}
+
+fn classify_reauthentication_replay<F>(
+	phase: AccountOperationPhase,
+	expected: Option<&CredentialBinding>,
+	target: Option<&CredentialBinding>,
+	mut read_exact: F,
+) -> ReauthenticationReplayDisposition
+where
+	F: FnMut(&CredentialBinding) -> Result<(), CredentialStoreError>,
+{
+	match phase {
+		AccountOperationPhase::Committed | AccountOperationPhase::StoreApplied =>
+			ReauthenticationReplayDisposition::Complete,
+		AccountOperationPhase::Cancelled => ReauthenticationReplayDisposition::Cancel,
+		AccountOperationPhase::Prepared =>
+			match classify_prepared_refresh_reconciliation(expected, target, read_exact) {
+				PreparedRefreshReconciliation::StoreApplied =>
+					ReauthenticationReplayDisposition::Complete,
+				PreparedRefreshReconciliation::NotApplied =>
+					ReauthenticationReplayDisposition::Cancel,
+				PreparedRefreshReconciliation::RecoveryRequired =>
+					ReauthenticationReplayDisposition::Recover,
+			},
+		AccountOperationPhase::ProviderEffectPending | AccountOperationPhase::RecoveryRequired =>
+			if target.is_some_and(|target| read_exact(target).is_ok()) {
+				ReauthenticationReplayDisposition::Complete
+			} else {
+				ReauthenticationReplayDisposition::Recover
+			},
+	}
 }
 
 fn projection_binding(
@@ -3245,21 +3625,23 @@ impl From<CredentialImportError> for AccountLifecycleError {
 mod tests {
 	use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 	use decodex_core::{
-		AccountId, AccountLifecycleReadiness, AccountOperationId, AccountProvider,
-		AccountQuotaWindow, AccountQuotaWindowObservation, AccountRecord, AccountState,
-		CredentialBinding, CredentialFingerprint, CredentialStoreSchemaVersion, CredentialVersion,
-		ProviderIdentity,
+		AccountId, AccountLifecycleReadiness, AccountOperationId, AccountOperationPhase,
+		AccountProvider, AccountQuotaWindow, AccountQuotaWindowObservation, AccountRecord,
+		AccountState, CredentialBinding, CredentialFingerprint, CredentialStoreSchemaVersion,
+		CredentialVersion, ProviderIdentity,
 	};
 	use serde_json::json;
 
 	use super::{
 		ACCOUNT_ALIAS_WORDS, AccountLifecycleError, CredentialImportError, CredentialRefreshError,
 		CredentialSecretBundle, ImportedCredential, PROVIDER_REFRESH_OUTCOME_UNKNOWN,
-		RefreshResponse, UseInCodexProjectionError, access_token_needs_refresh, account_lock_for,
+		PreparedRefreshReconciliation, ReauthenticationReplayDisposition, RefreshResponse,
+		UseInCodexProjectionError, access_token_needs_refresh, account_lock_for,
+		classify_prepared_refresh_reconciliation, classify_reauthentication_replay,
 		codex_auth_projection_digest, credential_refresh_result, matching_shared_refresh,
-		projection_binding, refreshed_credential_target,
-		require_refreshed_access_token_for_observation, stable_account_alias,
-		use_in_codex_receipt_result,
+		projection_binding, reauthentication_current, reauthentication_target,
+		refreshed_credential_target, require_refreshed_access_token_for_observation,
+		resolve_reauthentication_store_effect, stable_account_alias, use_in_codex_receipt_result,
 	};
 	use std::{
 		collections::{HashMap, HashSet},
@@ -3311,6 +3693,193 @@ mod tests {
 				&& bytes[0].is_ascii_uppercase()
 				&& bytes[1..].iter().all(u8::is_ascii_lowercase)
 		}));
+	}
+
+	#[test]
+	fn exact_reauthentication_builds_only_the_immediate_same_provider_successor() {
+		let account_id = AccountId::new("20000000-0000-4000-8000-000000000097").unwrap();
+		let operation_id = AccountOperationId::new("10000000-0000-4000-8000-000000000097").unwrap();
+		let current = binding("reauth-provider", 7);
+		let imported = imported("reauth-provider", "new-access", 3_000_000);
+
+		let target =
+			reauthentication_target(&current, &account_id, &operation_id, &imported).unwrap();
+
+		assert_eq!(target.version.get(), 8);
+		assert_eq!(target.provider, current.provider);
+		assert_eq!(target.writer_operation_id, operation_id);
+		assert_ne!(target.fingerprint, current.fingerprint);
+		assert_eq!(resolve_reauthentication_store_effect(Ok(()), false), Ok(()));
+		assert_eq!(
+			resolve_reauthentication_store_effect(
+				Err(super::CredentialStoreError::VersionConflict),
+				true
+			),
+			Ok(())
+		);
+	}
+
+	#[test]
+	fn provider_mismatch_and_stale_revision_stop_before_a_reauthentication_target_exists() {
+		let account_id = AccountId::new("20000000-0000-4000-8000-000000000096").unwrap();
+		let operation_id = AccountOperationId::new("10000000-0000-4000-8000-000000000096").unwrap();
+		let current = binding("expected-provider", 3);
+		let mismatched = imported("other-provider", "new-access", 3_000_000);
+		assert!(matches!(
+			reauthentication_target(&current, &account_id, &operation_id, &mismatched),
+			Err(AccountLifecycleError::ProviderMismatch)
+		));
+
+		let account = projection_account(Some(current.clone()));
+		assert!(matches!(
+			reauthentication_current(&account, account.revision + 1),
+			Err(AccountLifecycleError::StaleAccount)
+		));
+		assert_eq!(account.credential.as_ref(), Some(&current));
+	}
+
+	#[test]
+	fn same_operation_replay_after_source_cleanup_uses_only_persisted_target_evidence() {
+		let expected = binding("reauth-provider", 7);
+		let target = binding("reauth-provider", 8);
+		for phase in [
+			AccountOperationPhase::Prepared,
+			AccountOperationPhase::ProviderEffectPending,
+			AccountOperationPhase::RecoveryRequired,
+			AccountOperationPhase::StoreApplied,
+			AccountOperationPhase::Committed,
+		] {
+			assert_eq!(
+				classify_reauthentication_replay(
+					phase,
+					Some(&expected),
+					Some(&target),
+					|binding| {
+						assert_eq!(binding, &target);
+						Ok(())
+					},
+				),
+				ReauthenticationReplayDisposition::Complete
+			);
+		}
+		assert_eq!(
+			classify_reauthentication_replay(
+				AccountOperationPhase::Prepared,
+				Some(&expected),
+				Some(&target),
+				|binding| {
+					if binding == &expected {
+						Ok(())
+					} else {
+						Err(super::CredentialStoreError::NotFound)
+					}
+				},
+			),
+			ReauthenticationReplayDisposition::Cancel
+		);
+		assert_eq!(
+			classify_reauthentication_replay(
+				AccountOperationPhase::Cancelled,
+				Some(&expected),
+				Some(&target),
+				|_| panic!("cancelled replay does not read credentials"),
+			),
+			ReauthenticationReplayDisposition::Cancel
+		);
+		assert_eq!(
+			classify_reauthentication_replay(
+				AccountOperationPhase::RecoveryRequired,
+				Some(&expected),
+				Some(&target),
+				|_| Err(super::CredentialStoreError::Unavailable),
+			),
+			ReauthenticationReplayDisposition::Recover
+		);
+		assert_eq!(
+			classify_reauthentication_replay(
+				AccountOperationPhase::Prepared,
+				Some(&expected),
+				Some(&target),
+				|_| Err(super::CredentialStoreError::Unavailable),
+			),
+			ReauthenticationReplayDisposition::Recover
+		);
+	}
+
+	#[test]
+	fn prepared_target_backed_refresh_startup_commits_an_exact_applied_target() {
+		let expected = binding("reauth-provider", 7);
+		let target = binding("reauth-provider", 8);
+		let mut reads = 0_u8;
+
+		let disposition =
+			classify_prepared_refresh_reconciliation(Some(&expected), Some(&target), |binding| {
+				reads += 1;
+				assert_eq!(binding, &target);
+				Ok(())
+			});
+
+		assert_eq!(disposition, PreparedRefreshReconciliation::StoreApplied);
+		assert_eq!(reads, 1);
+	}
+
+	#[test]
+	fn prepared_target_backed_refresh_startup_cancels_when_the_target_was_not_applied() {
+		let expected = binding("reauth-provider", 7);
+		let target = binding("reauth-provider", 8);
+		let mut reads = Vec::new();
+
+		let exact_expected =
+			classify_prepared_refresh_reconciliation(Some(&expected), Some(&target), |binding| {
+				reads.push(binding.version.get());
+				if binding == &target {
+					Err(super::CredentialStoreError::VersionConflict)
+				} else {
+					Ok(())
+				}
+			});
+		assert_eq!(exact_expected, PreparedRefreshReconciliation::NotApplied);
+		assert_eq!(reads, vec![8, 7]);
+
+		let absent =
+			classify_prepared_refresh_reconciliation(Some(&expected), Some(&target), |_| {
+				Err(super::CredentialStoreError::NotFound)
+			});
+		assert_eq!(absent, PreparedRefreshReconciliation::RecoveryRequired);
+	}
+
+	#[test]
+	fn prepared_target_backed_refresh_startup_requires_recovery_for_ambiguous_or_unavailable_store()
+	{
+		let expected = binding("reauth-provider", 7);
+		let target = binding("reauth-provider", 8);
+
+		let ambiguous =
+			classify_prepared_refresh_reconciliation(Some(&expected), Some(&target), |binding| {
+				if binding == &target {
+					Err(super::CredentialStoreError::VersionConflict)
+				} else {
+					Err(super::CredentialStoreError::FingerprintMismatch)
+				}
+			});
+		assert_eq!(ambiguous, PreparedRefreshReconciliation::RecoveryRequired);
+
+		let unavailable =
+			classify_prepared_refresh_reconciliation(Some(&expected), Some(&target), |_| {
+				Err(super::CredentialStoreError::Unavailable)
+			});
+		assert_eq!(unavailable, PreparedRefreshReconciliation::RecoveryRequired);
+	}
+
+	#[test]
+	fn ordinary_prepared_refresh_startup_still_cancels_without_reading_the_store() {
+		let expected = binding("refresh-provider", 7);
+
+		let disposition = classify_prepared_refresh_reconciliation(Some(&expected), None, |_| {
+			panic!("ordinary refresh Prepared has no store effect to inspect")
+		});
+
+		assert_eq!(disposition, PreparedRefreshReconciliation::NotApplied);
 	}
 
 	#[tokio::test]

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -513,6 +513,31 @@ impl ServiceApplication {
 					})
 					.await
 			},
+			CommandPayload::ReauthenticateAccountFromCredentialFile {
+				operation_id,
+				account_id,
+				source_descriptor,
+			} => {
+				let operation_id = operation_id_from_wire(operation_id)?;
+				let account_id = account_id_from_wire(account_id)?;
+				let expected = required_expected_revision(command)?;
+				service
+					.reauthenticate_from_credential_file_command(
+						lease,
+						operation_id,
+						&account_id,
+						expected,
+						source_descriptor.as_str(),
+						|result| {
+							encode_account_command_receipt(
+								&result.map_err(account_lifecycle_command_error).and_then(
+									|account| account_changed_publication(account.clone()),
+								),
+							)
+						},
+					)
+					.await
+			},
 			CommandPayload::RecoverAccountOperation { operation_id, action } => {
 				let operation_id = operation_id_from_wire(operation_id)?;
 				let expected = required_expected_revision(command)?;
@@ -879,6 +904,7 @@ impl Application for ServiceApplication {
 			| CommandPayload::SetBalancedAccountSelection
 			| CommandPayload::SetAccountOrder { .. }
 			| CommandPayload::RefreshAccount { .. }
+			| CommandPayload::ReauthenticateAccountFromCredentialFile { .. }
 			| CommandPayload::RecoverAccountOperation { .. }
 			| CommandPayload::UseAccountInCodex { .. } => self.execute_account_command(command).await,
 			CommandPayload::RefreshSystemObservation { .. } =>
@@ -1389,6 +1415,8 @@ fn account_command_descriptor(
 			(AccountCommandKind::SetAccountOrder, "account-routing"),
 		CommandPayload::RefreshAccount { account_id, .. } =>
 			(AccountCommandKind::Refresh, account_id.as_str()),
+		CommandPayload::ReauthenticateAccountFromCredentialFile { account_id, .. } =>
+			(AccountCommandKind::Refresh, account_id.as_str()),
 		CommandPayload::RecoverAccountOperation { operation_id, .. } =>
 			(AccountCommandKind::Recover, operation_id.as_str()),
 		_ => return Err(account_rejection(AccountCommandRejectionDto::InvalidRequest, None)),
@@ -1413,6 +1441,19 @@ fn validate_account_command_envelope(command: &CommandEnvelope) -> Result<(), Co
 			let _ = operation_id_from_wire(operation_id)?;
 			let _ = account_id_from_wire(account_id)?;
 			let _ = required_expected_revision(command)?;
+		},
+		CommandPayload::ReauthenticateAccountFromCredentialFile {
+			operation_id,
+			account_id,
+			source_descriptor,
+		} => {
+			let _ = operation_id_from_wire(operation_id)?;
+			let _ = account_id_from_wire(account_id)?;
+			let _ = required_expected_revision(command)?;
+			let source = source_descriptor.as_str();
+			if source.is_empty() || source.len() > 4096 || source.chars().any(char::is_control) {
+				return Err(account_rejection(AccountCommandRejectionDto::InvalidRequest, None));
+			}
 		},
 		CommandPayload::SetFixedAccountSelection { account_id, expected_account_revision } => {
 			let _ = account_id_from_wire(account_id)?;

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -1282,11 +1282,17 @@ preparation failure leaves the receipt pending; it remains `AcceptanceUnknown` u
 same exact request can reclaim it after expiry.
 
 The macOS UI calls an in-process Rust protocol client and decodes the stable JSON
-projection returned across that private ABI. It never starts a CLI process. Its
-five-second second-click confirmation is presentation state only.
-Swift does not stage credentials, create a temporary Codex home, launch app-server, resolve
-an opaque credit ID, or call the provider method. It persists only a credential-negative
-pending operation handle so it can read durable daemon status after an app restart.
+projection returned across that private ABI. The Rust bridge may start one finite official
+Codex device-login child in an owner-private temporary home when the user explicitly chooses
+`Refresh Login`; it never starts the Decodex CLI, a helper, or app-server. The bridge exposes
+only the official URL, one-time code, and closed session state to Swift. It gives the resulting
+private auth-file descriptor to the daemon, which verifies the exact provider, account revision,
+and credential binding before a host-store CAS, then removes the temporary home after success,
+failure, cancellation, or client destruction. Its five-second Reset Card second-click
+confirmation is presentation state only.
+Swift does not stage or read credentials, create a temporary Codex home, launch a process,
+resolve an opaque credit ID, or call the provider method. It persists only a credential-negative
+pending Reset Card operation handle so it can read durable daemon status after an app restart.
 Provider-effect retry and authoritative reconciliation remain daemon-only.
 
 After the caller creates and durably records an idempotency key for `use`, every CLI

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -133,8 +133,11 @@ evidence only after that point. It is not a runtime or future-work input.
   contain a local account pool, helper/server path, credential authority, or service
   lifecycle owner (`apps/decodex-app/README.md`).
 - `crates/decodex-app-client-ffi/` owns the app's credential-negative in-process
-  protocol client and private `decodex/app-native-client/1` ABI. It does not own
-  credentials, account state, daemon lifecycle, or a CLI process.
+  protocol client and private `decodex/app-native-client/1` ABI. Its only child
+  process is one user-requested, finite official Codex device-login session in an
+  owner-private temporary home. It exposes no credential bytes or file path to
+  Swift and does not start the Decodex CLI, helper, app-server, or legacy account
+  process. It does not own credentials, account state, or daemon lifecycle.
 - `site/` is the static Astro product site; it must not depend on live daemon state (`site/package.json`, `openwiki/integrations/plugins-automations-and-auxiliary-tools.md`).
 - `plugins/decodex/` contains the installable Decodex plugin, narrow routing skills, and lifecycle guardrail hooks (`plugins/decodex/.codex-plugin/plugin.json`).
 - `automations/upstream/` contains the current standalone Codex App upstream

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -253,9 +253,18 @@ Service and returns the root refresh response. This source capability can satisf
 generated-schema, and live callback preflights also pass. Initial token projection alone is
 insufficient.
 
-The supported macOS build must also prove that device login can write to an isolated
-daemon-readable auth backend without changing ambient `~/.codex`. Ambient `Use in
-Codex` is a separate later capability and is not required for Mac dogfood.
+The supported macOS bridge can launch one explicit official Codex device-login in an
+owner-private temporary home without changing ambient `~/.codex`. It publishes only the
+official URL, one-time code, and closed session state to Swift. On successful login, the
+daemon opens that private `auth.json`, verifies the exact provider identity and current
+account revision, journals an existing-account `Refresh`, and applies only the immediate
+next HostCredentialStore version by compare-and-swap. The temporary home is removed on
+success, failure, cancellation, timeout, or bridge destruction. Ambient `Use in Codex`
+remains a separate explicit projection command; neither action implies the other.
+An acceptance-unknown install replays only the same operation and idempotency key while
+the private source exists. Prepared-operation startup and command replay compare both the
+expected and target bindings; only an exact expected binding can prove that cancellation
+is safe, and ambiguous store state becomes `RecoveryRequired`.
 
 ## ProcessGeneration binding
 


### PR DESCRIPTION
## Summary

- add official Codex device login to the macOS account panel
- replace only the exact account credential under revision and binding fences
- recover startup, cancellation, uncertain dispatch, cleanup, and app termination safely
- refresh the affected account authority so stale login-required state clears

## Validation

- cargo make fmt
- cargo make check-rust
- cargo test -p decodex-app-client-ffi --all-features --all-targets (28 passed)
- swift test --package-path apps/decodex-app -c release (162 passed)
- scripts/macos/test_decodex_app_stage.sh
- independent exact-tree review: APPROVED/READY