### PR TITLE
Refine account panel copy and compact layout

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -76,8 +76,8 @@ preserved and blocks new use.
 The panel also exposes current daemon-owned account controls: enroll the
 currently signed-in shared Codex login, enable or disable, log out, and select
 fixed or balanced routing. An account with a provider-confirmed unauthorized
-profile shows `Refresh Login`; that action presents the official device code,
-Copy, Open Browser, and Cancel controls, then refreshes only that account after
+profile shows `Refresh login`; that action presents the official device code,
+Copy, Open browser, and Cancel controls, then refreshes only that account after
 the daemon completes the exact credential replacement. Each account row has one `Route`
 control. It first projects that exact daemon-owned login to shared
 `~/.codex/auth.json` for future Codex launches, then selects the same account as

--- a/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
@@ -87,7 +87,7 @@ struct AccountUtilityActionsView: View {
 			}
 
 			Menu {
-				Button(state.account.enabled ? "Disable Account" : "Enable Account") {
+				Button(state.account.enabled ? "Disable account" : "Enable account") {
 					Task {
 						await store.setAccount(
 							state.account.accountID,
@@ -99,7 +99,7 @@ struct AccountUtilityActionsView: View {
 
 				Divider()
 
-				Button("Log Out…", role: .destructive) {
+				Button("Log out…", role: .destructive) {
 					isLogoutArmed = true
 				}
 				.disabled(lifecycleActionIsDisabled)
@@ -143,7 +143,7 @@ struct AccountUtilityActionsView: View {
 
 				Spacer()
 
-				Button("Log Out", role: .destructive) {
+				Button("Log out", role: .destructive) {
 					Task {
 						await store.logoutAccount(state.account.accountID)
 						isLogoutArmed = false
@@ -172,7 +172,7 @@ struct AccountRefreshLoginButton: View {
 
 	var body: some View {
 		CompactAccountActionButton(
-			title: "Refresh Login",
+			title: "Refresh login",
 			symbol: "person.crop.circle.badge.plus",
 			isActive: false,
 			isDisabled: isDisabled,

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
@@ -8,14 +8,15 @@ enum AccountPanelLayout {
 	static let minimumAccountListHeight: CGFloat = 110
 	static let estimatedAccountRowHeight: CGFloat = 74
 	static let statusMaximumHeight: CGFloat = 92
-	// Header, routing/projection status, aggregate activity card, and panel spacing.
-	static let fixedChromeHeight: CGFloat = 142
+	// Compact header, aggregate activity card, and panel spacing.
+	static let fixedChromeHeight: CGFloat = 114
 
 	static func activeScreenVisibleHeight() -> CGFloat {
 		let mouseLocation = NSEvent.mouseLocation
-		let screen = NSScreen.screens.first { screen in
-			screen.frame.contains(mouseLocation)
-		} ?? NSScreen.main
+		let screen =
+			NSScreen.screens.first { screen in
+				screen.frame.contains(mouseLocation)
+			} ?? NSScreen.main
 
 		return screen?.visibleFrame.height ?? 760
 	}
@@ -30,7 +31,8 @@ enum AccountPanelLayout {
 			windowVisibleFrame: windowVisibleFrame,
 			fallback: activeScreenVisibleHeight()
 		)
-		let boundedAdditionalChromeHeight = additionalChromeHeight.isFinite
+		let boundedAdditionalChromeHeight =
+			additionalChromeHeight.isFinite
 			? max(0, additionalChromeHeight)
 			: 0
 		let screenBound = max(
@@ -96,27 +98,6 @@ struct AccountIdentityPresentation: Equatable, Sendable {
 		} else {
 			text = alias
 			showsEmail = false
-		}
-	}
-}
-
-struct CodexProjectionPresentation: Equatable, Sendable {
-	let text: String
-
-	init(
-		projection: CodexAuthProjection?,
-		currentIdentity: String?,
-		isInitialLoading: Bool
-	) {
-		switch projection {
-		case .current:
-			text = currentIdentity ?? "Checking account"
-		case .unmanaged:
-			text = "Not managed by Decodex"
-		case .unavailable:
-			text = "Unavailable"
-		case nil:
-			text = isInitialLoading ? "Loading" : "Checking"
 		}
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -106,139 +106,131 @@ struct AccountPanelView: View {
 	}
 
 	private var header: some View {
-		VStack(alignment: .leading, spacing: 4) {
-			HStack(alignment: .center, spacing: 6) {
-				Image(nsImage: AppAssets.statusBarIcon)
-					.resizable()
-					.renderingMode(.template)
-					.scaledToFit()
-					.foregroundStyle(PanelPalette.actionBlue(colorScheme))
-					.frame(width: 19, height: 19)
-					.frame(width: 26, height: 26)
-					.accessibilityHidden(true)
+		HStack(alignment: .center, spacing: 6) {
+			Image(nsImage: AppAssets.statusBarIcon)
+				.resizable()
+				.renderingMode(.template)
+				.scaledToFit()
+				.foregroundStyle(PanelPalette.actionBlue(colorScheme))
+				.frame(width: 19, height: 19)
+				.frame(width: 26, height: 26)
+				.accessibilityHidden(true)
 
-				Text("Decodex")
-					.font(PanelFont.headerTitle)
-					.foregroundStyle(PanelPalette.primaryText(colorScheme))
+			Text("Decodex")
+				.font(PanelFont.headerTitle)
+				.foregroundStyle(PanelPalette.primaryText(colorScheme))
 
-				Spacer(minLength: 4)
+			Spacer(minLength: 4)
 
-				PanelIconButtonView(
-					symbol: accountPrivacy == AccountPrivacy.visible ? "eye" : "eye.slash",
-					tint: PanelPalette.actionBlue(colorScheme),
-					isActive: accountPrivacy == AccountPrivacy.visible,
-					isSubtle: true,
-					size: 24,
-					action: {
-						accountPrivacy = accountPrivacy == AccountPrivacy.hidden
-							? AccountPrivacy.visible
-							: AccountPrivacy.hidden
-					},
-					help: accountPrivacy == AccountPrivacy.hidden
+			PanelIconButtonView(
+				symbol: accountPrivacy == AccountPrivacy.visible ? "eye" : "eye.slash",
+				tint: PanelPalette.actionBlue(colorScheme),
+				isActive: accountPrivacy == AccountPrivacy.visible,
+				isSubtle: true,
+				size: 24,
+				action: {
+					accountPrivacy =
+						accountPrivacy == AccountPrivacy.hidden
+						? AccountPrivacy.visible
+						: AccountPrivacy.hidden
+				},
+				help: accountPrivacy == AccountPrivacy.hidden
+					? "Show email addresses"
+					: "Hide email addresses"
+			)
+
+			PanelIconButtonView(
+				symbol: fastMode.isEnabled ? "bolt.fill" : "bolt",
+				tint: PanelPalette.fastModeAccent(colorScheme),
+				isActive: fastMode.isEnabled,
+				isDisabled: fastMode.isLoading,
+				isSubtle: true,
+				size: 24,
+				action: {
+					Task {
+						await fastMode.toggle()
+					}
+				},
+				help: fastMode.isEnabled ? "Turn Fast mode off" : "Turn Fast mode on"
+			)
+
+			PanelIconButtonView(
+				symbol: "plus",
+				tint: PanelPalette.actionBlue(colorScheme),
+				isActive: false,
+				isDisabled: store.isAccountControlInProgress
+					|| store.isRefreshing
+					|| store.isRefreshingAccountSkeleton,
+				isSubtle: true,
+				isPrimary: true,
+				size: 24,
+				action: {
+					isPresentingEnrollment = true
+				},
+				help: "Add Codex login"
+			)
+
+			Menu {
+				Button(
+					accountPrivacy == AccountPrivacy.hidden
 						? "Show email addresses"
 						: "Hide email addresses"
-				)
-
-				PanelIconButtonView(
-					symbol: fastMode.isEnabled ? "bolt.fill" : "bolt",
-					tint: PanelPalette.fastModeAccent(colorScheme),
-					isActive: fastMode.isEnabled,
-					isDisabled: fastMode.isLoading,
-					isSubtle: true,
-					size: 24,
-					action: {
-						Task {
-							await fastMode.toggle()
-						}
-					},
-					help: fastMode.isEnabled ? "Turn Fast Mode off" : "Turn Fast Mode on"
-				)
-
-				PanelIconButtonView(
-					symbol: "plus",
-					tint: PanelPalette.actionBlue(colorScheme),
-					isActive: false,
-					isDisabled: store.isAccountControlInProgress
-						|| store.isRefreshing
-						|| store.isRefreshingAccountSkeleton,
-					isSubtle: true,
-					isPrimary: true,
-					size: 24,
-					action: {
-						isPresentingEnrollment = true
-					},
-					help: "Add Codex login"
-				)
-
-				Menu {
-					Button(
+				) {
+					accountPrivacy =
 						accountPrivacy == AccountPrivacy.hidden
-							? "Show Email Addresses"
-							: "Hide Email Addresses"
-					) {
-						accountPrivacy = accountPrivacy == AccountPrivacy.hidden
-							? AccountPrivacy.visible
-							: AccountPrivacy.hidden
-					}
+						? AccountPrivacy.visible
+						: AccountPrivacy.hidden
+				}
 
-					Button(fastMode.isEnabled ? "Turn Fast Mode Off" : "Turn Fast Mode On") {
-						Task {
-							await fastMode.toggle()
-						}
+				Button(fastMode.isEnabled ? "Turn Fast mode off" : "Turn Fast mode on") {
+					Task {
+						await fastMode.toggle()
 					}
-					.disabled(fastMode.isLoading)
+				}
+				.disabled(fastMode.isLoading)
 
-					Button("Refresh All") {
+				Button("Refresh all") {
+					Task {
+						await store.refresh()
+					}
+				}
+				.disabled(
+					store.isRefreshing
+						|| store.isRefreshingAccountSkeleton
+						|| store.isAccountControlInProgress
+						|| store.submittingKey != nil
+				)
+
+				if case .fixed = store.routing?.mode {
+					Button("Use balanced routing") {
 						Task {
-							await store.refresh()
+							await store.selectBalancedAccounts()
 						}
 					}
 					.disabled(
-						store.isRefreshing
-							|| store.isRefreshingAccountSkeleton
-							|| store.isAccountControlInProgress
+						store.canPerformDirectAccountControl == false
+							|| store.isRoutingAccountControl
 							|| store.submittingKey != nil
 					)
-
-					if case .fixed = store.routing?.mode {
-						Button("Use Balanced Routing") {
-							Task {
-								await store.selectBalancedAccounts()
-							}
-						}
-						.disabled(
-							store.canPerformDirectAccountControl == false
-								|| store.isRoutingAccountControl
-								|| store.submittingKey != nil
-						)
-					}
-
-					Divider()
-
-					Button("Quit Decodex") {
-						NSApplication.shared.terminate(nil)
-					}
-				} label: {
-					Image(systemName: "ellipsis")
-						.font(PanelFont.iconButton)
-						.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-						.frame(width: 26, height: 26)
-						.contentShape(Rectangle())
 				}
-				.menuStyle(.borderlessButton)
-				.menuIndicator(.hidden)
-				.fixedSize()
-				.help("Decodex menu")
-				.accessibilityLabel("Decodex menu")
-			}
 
-			VStack(alignment: .leading, spacing: 1) {
-				headerState(label: "Routing", value: routingSubtitle)
-				.accessibilityLabel("Decodex routing, \(routingSubtitle)")
-				headerState(label: "Codex", value: codexProjectionSubtitle)
-				.accessibilityLabel("Shared Codex login, \(codexProjectionSubtitle)")
+				Divider()
+
+				Button("Quit Decodex") {
+					NSApplication.shared.terminate(nil)
+				}
+			} label: {
+				Image(systemName: "ellipsis")
+					.font(PanelFont.iconButton)
+					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+					.frame(width: 26, height: 26)
+					.contentShape(Rectangle())
 			}
-			.padding(.leading, 32)
+			.menuStyle(.borderlessButton)
+			.menuIndicator(.hidden)
+			.fixedSize()
+			.help("Decodex menu")
+			.accessibilityLabel("Decodex menu")
 		}
 		.padding(.horizontal, 2)
 	}
@@ -315,55 +307,6 @@ struct AccountPanelView: View {
 	private var profiledAccountStates: [ResetCardAccountState] {
 		store.accounts.filter {
 			$0.profile?.snapshot.hasContent == true
-		}
-	}
-
-	private var routingSubtitle: String {
-		guard let routing = store.routing else {
-			return store.isInitialLoading ? "Loading" : "Unavailable"
-		}
-		switch routing.mode {
-		case .balanced:
-			return "Balanced"
-		case .fixed(let accountID):
-			let state = store.accounts.first {
-				$0.account.accountID == accountID
-			}
-			return state.map(accountIdentity(for:)) ?? "Fixed account"
-		}
-	}
-
-	private var codexProjectionSubtitle: String {
-		let state = store.accounts.first(where: {
-			store.isCodexProjection($0.account.accountID)
-		})
-		return CodexProjectionPresentation(
-			projection: store.codexAuthProjection,
-			currentIdentity: state.map(accountIdentity(for:)),
-			isInitialLoading: store.isInitialLoading
-		).text
-	}
-
-	private func accountIdentity(for state: ResetCardAccountState) -> String {
-		AccountIdentityPresentation(
-			alias: state.account.alias,
-			email: state.profile?.email ?? state.profileUnavailable?.claims.email,
-			revealsEmail: accountPrivacy == AccountPrivacy.visible
-		).text
-	}
-
-	private func headerState(label: String, value: String) -> some View {
-		HStack(alignment: .firstTextBaseline, spacing: 4) {
-			Text("\(label):")
-				.font(PanelFont.tertiary)
-				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-				.frame(width: 43, alignment: .leading)
-
-			Text(value)
-				.font(PanelFont.headerSubtitle)
-				.foregroundStyle(PanelPalette.primaryText(colorScheme).opacity(0.9))
-				.lineLimit(1)
-				.truncationMode(.middle)
 		}
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountProfileViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountProfileViews.swift
@@ -10,8 +10,7 @@ struct AccountProfileSummaryView: View {
 
 			if profile.dailyUsage.isEmpty == false {
 				AccountDailyUsageChart(
-					records: profile.dailyUsage,
-					showsAxis: false
+					records: profile.dailyUsage
 				)
 			}
 		}
@@ -146,8 +145,7 @@ struct AccountProfileOverviewView: View {
 
 			if aggregate.dailyUsage.isEmpty == false {
 				AccountDailyUsageChart(
-					records: aggregate.dailyUsage,
-					showsAxis: true
+					records: aggregate.dailyUsage
 				)
 			}
 		}
@@ -275,7 +273,6 @@ private struct AccountProfileMetricsView: View {
 
 struct AccountDailyUsageChart: View {
 	let records: [AccountProfileDailyUsage]
-	let showsAxis: Bool
 	@Environment(\.colorScheme) private var colorScheme
 
 	var body: some View {
@@ -285,56 +282,42 @@ struct AccountDailyUsageChart: View {
 			$0.addingWithoutOverflow($1.tokens)
 		}
 
-		VStack(alignment: .leading, spacing: 2) {
-			GeometryReader { proxy in
-				ZStack(alignment: .bottom) {
-					Rectangle()
-						.fill(PanelPalette.separator(colorScheme))
-						.frame(height: 0.5)
+		GeometryReader { proxy in
+			ZStack(alignment: .bottom) {
+				Rectangle()
+					.fill(PanelPalette.separator(colorScheme))
+					.frame(height: 0.5)
 
-					HStack(alignment: .bottom, spacing: 1.5) {
-						ForEach(values) { record in
-							RoundedRectangle(cornerRadius: 1.5, style: .continuous)
-								.fill(barColor(record.tokens, peak: peak))
-								.frame(
-									maxWidth: .infinity,
-									minHeight: 1,
-									maxHeight: barHeight(
-										record.tokens,
-										peak: peak,
-										available: proxy.size.height
-									)
+				HStack(alignment: .bottom, spacing: 1.5) {
+					ForEach(values) { record in
+						RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+							.fill(barColor(record.tokens, peak: peak))
+							.frame(
+								maxWidth: .infinity,
+								minHeight: 1,
+								maxHeight: barHeight(
+									record.tokens,
+									peak: peak,
+									available: proxy.size.height
 								)
-								.help(
-									"\(compactUsageDate(record.date)): "
-										+ "\(record.tokens.formatted()) tokens"
-								)
-						}
+							)
+							.help(
+								"\(compactUsageDate(record.date)): "
+									+ "\(record.tokens.formatted()) tokens"
+							)
 					}
-					.frame(maxHeight: .infinity, alignment: .bottom)
 				}
-			}
-			.frame(height: showsAxis ? 20 : 16)
-
-			if showsAxis {
-				HStack {
-					Text(values.first.map { compactUsageDate($0.date) } ?? "")
-						.frame(maxWidth: .infinity, alignment: .leading)
-					Text(values.last.map { compactUsageDate($0.date) } ?? "")
-						.frame(maxWidth: .infinity, alignment: .trailing)
-				}
-				.font(PanelFont.tertiary)
-				.foregroundStyle(PanelPalette.secondaryText(colorScheme).opacity(0.72))
-				.lineLimit(1)
+				.frame(maxHeight: .infinity, alignment: .bottom)
 			}
 		}
+		.frame(height: 16)
 		.accessibilityElement(children: .ignore)
 		.accessibilityLabel(
-				"Daily token usage from \(values.first?.date ?? "unknown") "
-					+ "through \(values.last?.date ?? "unknown"), "
-					+ "\(totalTokens.formatted()) tokens total, "
-					+ "\(values.map(\.tokens).max().map { $0.formatted() } ?? "0") tokens peak"
-			)
+			"Daily token usage from \(values.first?.date ?? "unknown") "
+				+ "through \(values.last?.date ?? "unknown"), "
+				+ "\(totalTokens.formatted()) tokens total, "
+				+ "\(values.map(\.tokens).max().map { $0.formatted() } ?? "0") tokens peak"
+		)
 	}
 
 	private var displayRecords: [AccountProfileDailyUsage] {

--- a/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
@@ -8,20 +8,12 @@ struct AccountReauthenticationView: View {
 	@State private var openFeedback = false
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 10) {
+		VStack(alignment: .leading, spacing: 8) {
 			if let presentation = store.accountReauthentication {
 				header(presentation)
 
 				if let prompt = presentation.prompt {
 					promptContent(prompt)
-				} else if presentation.failureText == nil {
-					HStack(spacing: 7) {
-						ProgressView()
-							.controlSize(.small)
-						Text(presentation.statusText)
-							.font(PanelFont.transientBody)
-							.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-					}
 				}
 
 				if let failure = presentation.failureText {
@@ -31,10 +23,17 @@ struct AccountReauthenticationView: View {
 						.fixedSize(horizontal: false, vertical: true)
 				}
 
-				Divider()
-
 				HStack {
+					if let prompt = presentation.prompt {
+						Button(openFeedback ? "Opened" : "Open browser") {
+							open(prompt.verificationURL)
+						}
+						.buttonStyle(.borderedProminent)
+						.accessibilityHint("Opens the official Codex device sign-in page.")
+					}
+
 					Spacer()
+
 					Button(
 						presentation.canCloseWithoutCancellation
 							? "Close"
@@ -56,8 +55,8 @@ struct AccountReauthenticationView: View {
 				}
 			}
 		}
-		.frame(width: 300)
-		.padding(14)
+		.frame(width: 256)
+		.padding(12)
 		.controlSize(.small)
 		.interactiveDismissDisabled(true)
 	}
@@ -66,70 +65,80 @@ struct AccountReauthenticationView: View {
 		_ presentation: AccountReauthenticationPresentation
 	) -> some View {
 		VStack(alignment: .leading, spacing: 3) {
-			Text("Refresh Login")
+			Text("Refresh login")
 				.font(PanelFont.transientTitle)
 				.foregroundStyle(PanelPalette.primaryText(colorScheme))
 
-			Text(presentation.accountLabel)
-				.font(PanelFont.transientBody)
-				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-				.lineLimit(1)
-				.truncationMode(.middle)
+			HStack(alignment: .firstTextBaseline, spacing: 4) {
+				if presentation.prompt == nil,
+					presentation.failureText == nil
+				{
+					ProgressView()
+						.controlSize(.mini)
+						.accessibilityHidden(true)
+				}
 
-			if presentation.prompt != nil {
-				Text(presentation.statusText)
+				Text(presentation.accountLabel)
+					.font(PanelFont.transientBody)
+					.foregroundStyle(PanelPalette.primaryText(colorScheme).opacity(0.86))
+					.lineLimit(1)
+					.truncationMode(.middle)
+
+				Text("· \(presentation.statusText)")
 					.font(PanelFont.tertiary)
 					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+					.lineLimit(1)
+					.truncationMode(.tail)
 			}
+			.accessibilityElement(children: .combine)
+			.accessibilityLabel(
+				"\(presentation.accountLabel), \(presentation.statusText)"
+			)
 		}
 	}
 
 	private func promptContent(
 		_ prompt: AccountReauthenticationPrompt
 	) -> some View {
-		VStack(alignment: .leading, spacing: 8) {
-			Text("Enter this one-time code in the Codex sign-in page.")
-				.font(PanelFont.transientBody)
+		VStack(alignment: .leading, spacing: 6) {
+			Text("One-time code")
+				.font(PanelFont.tertiary)
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-				.fixedSize(horizontal: false, vertical: true)
 
-			Text(prompt.userCode)
-				.font(.system(size: 24, weight: .semibold, design: .monospaced))
-				.monospacedDigit()
-				.tracking(1.4)
-				.foregroundStyle(PanelPalette.primaryText(colorScheme))
-				.textSelection(.enabled)
-				.frame(maxWidth: .infinity)
-				.padding(.vertical, 10)
-				.background(
-					RoundedRectangle(cornerRadius: 9, style: .continuous)
-						.fill(
-							PanelPalette.secondaryText(colorScheme)
-								.opacity(colorScheme == .dark ? 0.12 : 0.08)
-						)
-				)
-				.overlay {
-					RoundedRectangle(cornerRadius: 9, style: .continuous)
-						.stroke(
-							PanelPalette.separator(colorScheme),
-							lineWidth: 1
-						)
-				}
-				.accessibilityLabel("One-time login code \(prompt.userCode)")
+			HStack(spacing: 8) {
+				Text(prompt.userCode)
+					.font(PanelFont.loginCode)
+					.monospacedDigit()
+					.tracking(1)
+					.foregroundStyle(PanelPalette.primaryText(colorScheme))
+					.textSelection(.enabled)
 
-			HStack(spacing: 7) {
-				Button(copyFeedback ? "Copied" : "Copy Code") {
+				Spacer(minLength: 4)
+
+				Button(copyFeedback ? "Copied" : "Copy") {
 					copy(prompt.userCode)
 				}
 				.buttonStyle(.bordered)
 				.accessibilityHint("Copies the one-time Codex login code.")
-
-				Button(openFeedback ? "Opened" : "Open Browser") {
-					open(prompt.verificationURL)
-				}
-				.buttonStyle(.borderedProminent)
-				.accessibilityHint("Opens the official Codex device sign-in page.")
 			}
+			.padding(.horizontal, 9)
+			.padding(.vertical, 7)
+			.background(
+				RoundedRectangle(cornerRadius: 8, style: .continuous)
+					.fill(
+						PanelPalette.secondaryText(colorScheme)
+							.opacity(colorScheme == .dark ? 0.12 : 0.08)
+					)
+			)
+			.overlay {
+				RoundedRectangle(cornerRadius: 8, style: .continuous)
+					.stroke(
+						PanelPalette.separator(colorScheme),
+						lineWidth: 1
+					)
+			}
+			.accessibilityElement(children: .contain)
+			.accessibilityLabel("One-time login code \(prompt.userCode)")
 		}
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/PanelTypography.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelTypography.swift
@@ -10,7 +10,6 @@ enum PanelFont {
 	}
 
 	static let headerTitle = text(15.4, weight: .semibold)
-	static let headerSubtitle = text(10.8, weight: .regular)
 
 	static let emptyIcon = text(17, weight: .medium)
 	static let emptyTitle = text(12.5, weight: .semibold)
@@ -19,6 +18,7 @@ enum PanelFont {
 	static let transientBody = emptyBody
 	static let accountName = text(12.4, weight: .semibold)
 	static let accountDetail = text(10.6, weight: .regular)
+	static let loginCode = text(19, weight: .semibold, design: .monospaced)
 	static let usageLabel = text(9.8, weight: .regular)
 	static let usageValue = text(10.4, weight: .medium)
 	static let resetCardAction = usageValue

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -178,13 +178,13 @@ struct ResetCardAccountRow: View {
 			.lineLimit(1)
 			.truncationMode(.middle)
 			.layoutPriority(1)
-		.frame(maxWidth: .infinity, alignment: .leading)
-		.accessibilityElement(children: .ignore)
-		.accessibilityLabel(
-			identity.showsEmail
-				? "Account email \(identity.text)"
-				: "Account \(identity.text)"
-		)
+			.frame(maxWidth: .infinity, alignment: .leading)
+			.accessibilityElement(children: .ignore)
+			.accessibilityLabel(
+				identity.showsEmail
+					? "Account email \(identity.text)"
+					: "Account \(identity.text)"
+			)
 	}
 
 	private var exceptionalStatus: some View {
@@ -307,7 +307,7 @@ struct ResetCardAccountRow: View {
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 				.lineLimit(1)
 				.help(
-					"Choose Refresh Login in the menu bar app to sign in with the official Codex device login."
+					"Choose Refresh login in the menu bar app to sign in with the official Codex device login."
 				)
 		} else if let error = state.inventory?.observationError {
 			Text("Reset Cards unavailable")
@@ -409,7 +409,8 @@ struct ResetCardAccountRow: View {
 			return "Using…"
 		}
 		if confirmation.isArmed(target) {
-			let seconds = confirmationSecondsRemaining > 0
+			let seconds =
+				confirmationSecondsRemaining > 0
 				? confirmationSecondsRemaining
 				: Self.confirmationWindowSeconds
 			return "Confirm · \(seconds)s"
@@ -545,7 +546,8 @@ struct ResetCardAccountRow: View {
 			spokenExpiry = expiry
 		}
 		let date = Date(timeIntervalSince1970: TimeInterval(expiresAtUnixSeconds))
-		let zone = timeZone.abbreviation(for: date)
+		let zone =
+			timeZone.abbreviation(for: date)
 			?? timeZone.identifier
 		return "Reset Card, expires \(spokenExpiry) \(zone)"
 	}
@@ -572,7 +574,7 @@ struct ResetCardQuotaPresentation: Equatable {
 		case .current(let usedPercent, _):
 			isVisible = true
 			let remainingPercent = 100 - min(100, usedPercent)
-			valueText = "\(remainingPercent)% left"
+			valueText = "\(remainingPercent)%"
 			detailText = nil
 			tone = .current
 			self.usedPercent = usedPercent
@@ -581,7 +583,7 @@ struct ResetCardQuotaPresentation: Equatable {
 		case .stale(let usedPercent, _):
 			isVisible = true
 			let remainingPercent = 100 - min(100, usedPercent)
-			valueText = "\(remainingPercent)% left"
+			valueText = "\(remainingPercent)%"
 			detailText = "stale"
 			tone = .current
 			self.usedPercent = usedPercent
@@ -598,7 +600,8 @@ struct ResetCardQuotaPresentation: Equatable {
 		case .error(let error):
 			isVisible = false
 			valueText = "—"
-			detailText = error == .unsupportedWindow
+			detailText =
+				error == .unsupportedWindow
 				? "Not reported"
 				: error.presentation
 			tone = .muted
@@ -610,9 +613,7 @@ struct ResetCardQuotaPresentation: Equatable {
 }
 
 private struct ResetCardQuotaWindowView: View {
-	private static let titleColumnWidth: CGFloat = 16
-	private static let valueColumnWidth: CGFloat = 86
-	private static let resetDateColumnWidth: CGFloat = 80
+	private static let titleColumnWidth: CGFloat = 17
 
 	let title: String
 	let window: ResetCardQuotaWindow
@@ -626,22 +627,6 @@ private struct ResetCardQuotaWindowView: View {
 				.font(PanelFont.quotaText)
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 				.frame(width: Self.titleColumnWidth, alignment: .leading)
-
-			HStack(alignment: .firstTextBaseline, spacing: 3) {
-				Text(presentation.valueText)
-					.font(PanelFont.usageValue)
-
-				if let detailText = presentation.detailText,
-					presentation.resetDate != nil
-				{
-					Text(detailText)
-						.font(PanelFont.quotaText)
-				}
-			}
-			.foregroundStyle(stateColor(for: presentation.tone))
-			.monospacedDigit()
-			.lineLimit(1)
-			.frame(width: Self.valueColumnWidth, alignment: .leading)
 
 			if let remainingPercent = presentation.remainingPercent {
 				GeometryReader { proxy in
@@ -658,9 +643,26 @@ private struct ResetCardQuotaWindowView: View {
 							)
 					}
 				}
-				.frame(minWidth: 72, maxWidth: .infinity)
-				.frame(height: 4)
+				.frame(minWidth: 88, maxWidth: .infinity)
+				.frame(height: 5)
+				.layoutPriority(1)
 			}
+
+			HStack(alignment: .firstTextBaseline, spacing: 3) {
+				Text(presentation.valueText)
+					.font(PanelFont.usageValue)
+
+				if let detailText = presentation.detailText,
+					presentation.resetDate != nil
+				{
+					Text(detailText)
+						.font(PanelFont.quotaText)
+				}
+			}
+			.foregroundStyle(stateColor(for: presentation.tone))
+			.monospacedDigit()
+			.lineLimit(1)
+			.fixedSize(horizontal: true, vertical: false)
 
 			if let resetDate = presentation.resetDate {
 				Text(Self.compactDateTime(resetDate))
@@ -668,21 +670,14 @@ private struct ResetCardQuotaWindowView: View {
 					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 					.monospacedDigit()
 					.lineLimit(1)
-					.layoutPriority(1)
-					.frame(
-						width: Self.resetDateColumnWidth,
-						alignment: .trailing
-					)
+					.fixedSize(horizontal: true, vertical: false)
 			} else if let detailText = presentation.detailText {
 				Text(detailText)
 					.font(PanelFont.quotaText)
 					.foregroundStyle(stateColor(for: presentation.tone))
 					.lineLimit(1)
 					.truncationMode(.tail)
-					.frame(
-						width: Self.resetDateColumnWidth,
-						alignment: .trailing
-					)
+					.frame(maxWidth: .infinity, alignment: .trailing)
 			}
 		}
 		.frame(maxWidth: .infinity, alignment: .leading)

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -1,7 +1,8 @@
 import AppKit
-@testable import DecodexApp
 import SwiftUI
 import XCTest
+
+@testable import DecodexApp
 
 @MainActor
 final class AccountPanelPresentationTests: XCTestCase {
@@ -51,7 +52,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 		)
 
 		XCTAssertTrue(presentation.isVisible)
-		XCTAssertEqual(presentation.valueText, "21% left")
+		XCTAssertEqual(presentation.valueText, "21%")
 		XCTAssertEqual(presentation.tone, .current)
 		XCTAssertEqual(presentation.usedPercent, 79)
 		XCTAssertEqual(presentation.remainingPercent, 21)
@@ -71,7 +72,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 		)
 
 		XCTAssertTrue(presentation.isVisible)
-		XCTAssertEqual(presentation.valueText, "58% left")
+		XCTAssertEqual(presentation.valueText, "58%")
 		XCTAssertEqual(presentation.detailText, "stale")
 		XCTAssertEqual(presentation.tone, .current)
 		XCTAssertEqual(presentation.usedPercent, 42)
@@ -177,7 +178,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 					try ResetCardDescriptor(
 						grantedAtUnixSeconds: 1_700_000_000,
 						expiresAtUnixSeconds: 1_800_000_000
-					),
+					)
 				],
 				fiveHourQuota: .unknown(durationMinutes: 300),
 				sevenDayQuota: .unknown(durationMinutes: 10_080),
@@ -202,7 +203,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 		)
 	}
 
-	func testQuotaRowsUseSharedFixedColumnsAroundAFlexibleLongBar() throws {
+	func testQuotaRowsPutTheFlexibleBarBeforeTheCompactPercentage() throws {
 		let source = try resetCardSectionSource()
 
 		XCTAssertTrue(
@@ -210,60 +211,18 @@ final class AccountPanelPresentationTests: XCTestCase {
 				".frame(width: Self.titleColumnWidth, alignment: .leading)"
 			)
 		)
-		XCTAssertTrue(
-			source.contains(
-				".frame(width: Self.valueColumnWidth, alignment: .leading)"
-			)
+		let progressRange = try XCTUnwrap(
+			source.range(of: ".frame(minWidth: 88, maxWidth: .infinity)")
 		)
-		XCTAssertTrue(
-			source.contains("width: Self.resetDateColumnWidth")
+		let valueRange = try XCTUnwrap(
+			source.range(of: "Text(presentation.valueText)")
 		)
-		XCTAssertTrue(
-			source.contains(".frame(minWidth: 72, maxWidth: .infinity)")
+		XCTAssertLessThan(
+			source.distance(from: source.startIndex, to: progressRange.lowerBound),
+			source.distance(from: source.startIndex, to: valueRange.lowerBound)
 		)
-	}
-
-	func testCodexProjectionDistinguishesUnmanagedUnavailableAndCurrent() {
-		XCTAssertEqual(
-			CodexProjectionPresentation(
-				projection: .unmanaged,
-				currentIdentity: nil,
-				isInitialLoading: false
-			).text,
-			"Not managed by Decodex"
-		)
-		XCTAssertEqual(
-			CodexProjectionPresentation(
-				projection: .unavailable,
-				currentIdentity: nil,
-				isInitialLoading: false
-			).text,
-			"Unavailable"
-		)
-		XCTAssertEqual(
-			CodexProjectionPresentation(
-				projection: .current(
-					accountID: "11111111-1111-4111-8111-111111111111",
-					accountRevision: 7,
-					projectionDigest: String(repeating: "a", count: 64)
-				),
-				currentIdentity: "iris@example.com",
-				isInitialLoading: false
-			).text,
-			"iris@example.com"
-		)
-		XCTAssertEqual(
-			CodexProjectionPresentation(
-				projection: .current(
-					accountID: "11111111-1111-4111-8111-111111111111",
-					accountRevision: 8,
-					projectionDigest: String(repeating: "b", count: 64)
-				),
-				currentIdentity: nil,
-				isInitialLoading: false
-			).text,
-			"Checking account"
-		)
+		XCTAssertFalse(source.contains("valueColumnWidth"))
+		XCTAssertFalse(source.contains("resetDateColumnWidth"))
 	}
 
 	func testResetCardChipAndAccessibilityExposeExpiryOnly() {
@@ -296,7 +255,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 			profileName: "local",
 			serverID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
 		)
-		let states = try (1 ... 6).map { index in
+		let states = try (1...6).map { index in
 			let accountID = String(
 				format: "018f0f9e-7b6e-4a31-8f4c-%012d",
 				index
@@ -320,7 +279,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 					try ResetCardDescriptor(
 						grantedAtUnixSeconds: 1_700_000_000,
 						expiresAtUnixSeconds: 1_800_000_000
-					),
+					)
 				],
 				fiveHourQuota: ResetCardQuotaWindow(
 					durationMinutes: 300,
@@ -363,7 +322,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 							AccountProfileDailyUsage(
 								date: "2026-07-28",
 								tokens: UInt64(index) * 1_000
-							),
+							)
 						]
 					),
 					freshness: .current
@@ -429,10 +388,11 @@ final class AccountPanelPresentationTests: XCTestCase {
 			defer: false
 		)
 		window.contentView = hostingView
-		hostingView.frame = window.contentView?.bounds
+		hostingView.frame =
+			window.contentView?.bounds
 			?? NSRect(x: 0, y: 0, width: 306, height: 1_350)
 
-		for _ in 0 ..< 2 {
+		for _ in 0..<2 {
 			hostingView.layoutSubtreeIfNeeded()
 			try await Task.sleep(for: .milliseconds(20))
 		}
@@ -476,7 +436,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 		let pendingStore = ResetCardPendingAttemptStore(
 			journalURL: directory.appendingPathComponent("pending.json")
 		)
-		for index in 1 ... 64 {
+		for index in 1...64 {
 			XCTAssertNotNil(pendingStore.insert(try pendingAttempt(index)))
 		}
 		let store = ResetCardStore(
@@ -508,10 +468,11 @@ final class AccountPanelPresentationTests: XCTestCase {
 			defer: false
 		)
 		window.contentView = hostingView
-		hostingView.frame = window.contentView?.bounds
+		hostingView.frame =
+			window.contentView?.bounds
 			?? NSRect(x: 0, y: 0, width: 340, height: 675)
 
-		for _ in 0 ..< 2 {
+		for _ in 0..<2 {
 			hostingView.layoutSubtreeIfNeeded()
 			try await Task.sleep(for: .milliseconds(20))
 		}
@@ -528,10 +489,10 @@ final class AccountPanelPresentationTests: XCTestCase {
 		XCTAssertGreaterThanOrEqual(overflowingScrollViews.count, 2)
 		XCTAssertTrue(
 			overflowingScrollViews.contains { scrollView in
-					abs(
-						scrollView.contentView.bounds.height
-							- AccountPanelLayout.statusMaximumHeight
-					) < 4
+				abs(
+					scrollView.contentView.bounds.height
+						- AccountPanelLayout.statusMaximumHeight
+				) < 4
 			}
 		)
 		XCTAssertLessThanOrEqual(hostingView.fittingSize.height, 675)
@@ -556,7 +517,8 @@ private func descendants<T: NSView>(
 private func resetCardSectionSource() throws -> String {
 	let testsURL = URL(fileURLWithPath: #filePath)
 		.deletingLastPathComponent()
-	let sourceURL = testsURL
+	let sourceURL =
+		testsURL
 		.deletingLastPathComponent()
 		.deletingLastPathComponent()
 		.appendingPathComponent("Sources/DecodexApp/ResetCardSectionView.swift")
@@ -603,7 +565,7 @@ private actor FullAccountPanelClient: ResetCardClient, AccountProfileClient {
 	func accounts(
 		authority _: ResetCardAuthority?
 	) async throws -> [ResetCardAccountRecord] {
-		(1 ... 6).map(Self.account)
+		(1...6).map(Self.account)
 	}
 
 	func inventory(
@@ -617,7 +579,7 @@ private actor FullAccountPanelClient: ResetCardClient, AccountProfileClient {
 				try ResetCardDescriptor(
 					grantedAtUnixSeconds: 1_700_000_000,
 					expiresAtUnixSeconds: 1_800_000_000
-				),
+				)
 			],
 			fiveHourQuota: ResetCardQuotaWindow(
 				durationMinutes: 300,
@@ -662,7 +624,7 @@ private actor FullAccountPanelClient: ResetCardClient, AccountProfileClient {
 						AccountProfileDailyUsage(
 							date: "2026-07-28",
 							tokens: account.accountRevision * 1_000
-						),
+						)
 					]
 				),
 				freshness: .current

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -34,6 +34,7 @@ final class ResetCardArchitectureTests: XCTestCase {
 		)
 
 		XCTAssertTrue(profileViews.contains("Text(\"All accounts\")"))
+		XCTAssertFalse(profileViews.contains("Text(\"All Accounts\")"))
 		XCTAssertTrue(profileViews.contains("lifetimeTokens: aggregate.lifetimeTokens"))
 		XCTAssertTrue(profileViews.contains("peakDailyTokens: aggregate.peakDailyTokens"))
 		XCTAssertTrue(profileViews.contains("longestTaskSeconds: aggregate.longestTaskSeconds"))
@@ -41,6 +42,69 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(profileViews.contains("AccountProfileMetric.makeOverview("))
 		XCTAssertFalse(profileViews.contains("profiles current"))
 		XCTAssertFalse(profileViews.contains(" of \\(totalAccountCount) daily"))
+		XCTAssertFalse(profileViews.contains("showsAxis"))
+	}
+
+	func testAccountPanelControlsUseSentenceCase() throws {
+		let sourceURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
+		let panel = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountPanelView.swift"),
+			encoding: .utf8
+		)
+		let controls = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountControlViews.swift"),
+			encoding: .utf8
+		)
+		let login = try String(
+			contentsOf: sourceURL.appendingPathComponent(
+				"AccountReauthenticationView.swift"
+			),
+			encoding: .utf8
+		)
+		let source = panel + controls + login
+
+		for canonicalLabel in [
+			"Show email addresses",
+			"Hide email addresses",
+			"Turn Fast mode off",
+			"Turn Fast mode on",
+			"Refresh all",
+			"Use balanced routing",
+			"Disable account",
+			"Enable account",
+			"Log out",
+			"Refresh login",
+			"Open browser",
+		] {
+			XCTAssertTrue(
+				source.contains("\"\(canonicalLabel)"),
+				"Missing sentence-case label: \(canonicalLabel)"
+			)
+		}
+
+		for retiredLabel in [
+			"All Accounts",
+			"Show Email Addresses",
+			"Hide Email Addresses",
+			"Turn Fast Mode",
+			"Refresh All",
+			"Use Balanced Routing",
+			"Disable Account",
+			"Enable Account",
+			"Log Out",
+			"Refresh Login",
+			"Open Browser",
+			"Copy Code",
+		] {
+			XCTAssertFalse(
+				source.contains(retiredLabel),
+				"Found retired title-case label: \(retiredLabel)"
+			)
+		}
 	}
 
 	func testPanelUsesSeparatedMaterialCardsWithoutLiquidGlass() throws {
@@ -112,12 +176,16 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(resetCards.contains(".controlSize(.small)"))
 		XCTAssertTrue(resetCards.contains("\"Use · \\(Self.cardExpiryText"))
 		XCTAssertFalse(resetCards.contains("Image(systemName: \"creditcard\")"))
-		XCTAssertTrue(resetCards.contains(".frame(minWidth: 72, maxWidth: .infinity)"))
+		XCTAssertTrue(resetCards.contains(".frame(minWidth: 88, maxWidth: .infinity)"))
+		XCTAssertFalse(accountPanel.contains("headerState("))
+		XCTAssertFalse(accountPanel.contains("routingSubtitle"))
+		XCTAssertFalse(accountPanel.contains("codexProjectionSubtitle"))
 		XCTAssertTrue(panelWindow.contains("window.hasShadow = false"))
 		XCTAssertFalse(panelWindow.contains("window.appearance ="))
 		XCTAssertFalse(
 			FileManager.default.fileExists(
-				atPath: sourceURL
+				atPath:
+					sourceURL
 					.appendingPathComponent("PanelInteractiveButtonStyle.swift")
 					.path
 			)
@@ -127,10 +195,12 @@ final class ResetCardArchitectureTests: XCTestCase {
 	func testProductionSourceUsesOnlyTheNativeResetCardAuthority() throws {
 		let testsURL = URL(fileURLWithPath: #filePath)
 			.deletingLastPathComponent()
-		let appURL = testsURL
+		let appURL =
+			testsURL
 			.deletingLastPathComponent()
 			.deletingLastPathComponent()
-		let sourceURL = appURL
+		let sourceURL =
+			appURL
 			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
 		let fileManager = FileManager.default
 		let swiftFiles = try XCTUnwrap(
@@ -139,10 +209,10 @@ final class ResetCardArchitectureTests: XCTestCase {
 				includingPropertiesForKeys: [.isRegularFileKey]
 			)
 		)
-			.compactMap { $0 as? URL }
-			.filter { url in
-				url.pathExtension == "swift"
-			}
+		.compactMap { $0 as? URL }
+		.filter { url in
+			url.pathExtension == "swift"
+		}
 
 		XCTAssertFalse(swiftFiles.isEmpty)
 		let banned = [
@@ -201,7 +271,8 @@ final class ResetCardArchitectureTests: XCTestCase {
 	func testBundleStagesTheAppAndNativeClientWithoutCLI() throws {
 		let testsURL = URL(fileURLWithPath: #filePath)
 			.deletingLastPathComponent()
-		let appURL = testsURL
+		let appURL =
+			testsURL
 			.deletingLastPathComponent()
 			.deletingLastPathComponent()
 		let script = try String(
@@ -263,9 +334,12 @@ final class ResetCardArchitectureTests: XCTestCase {
 			encoding: .utf8
 		)
 
-		XCTAssertTrue(view.contains("\"Copy Code\""))
-		XCTAssertTrue(view.contains("\"Open Browser\""))
+		XCTAssertTrue(view.contains("\"Copy\""))
+		XCTAssertTrue(view.contains("\"Open browser\""))
 		XCTAssertTrue(view.contains("\"Cancel\""))
+		XCTAssertTrue(view.contains(".frame(width: 256)"))
+		XCTAssertFalse(view.contains("Enter this one-time code"))
+		XCTAssertFalse(view.contains("Divider()"))
 		XCTAssertTrue(view.contains(".interactiveDismissDisabled(true)"))
 		XCTAssertFalse(view.contains(".onDisappear"))
 		XCTAssertFalse(view.contains(".onChange(of:"))

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -1284,7 +1284,7 @@ same exact request can reclaim it after expiry.
 The macOS UI calls an in-process Rust protocol client and decodes the stable JSON
 projection returned across that private ABI. The Rust bridge may start one finite official
 Codex device-login child in an owner-private temporary home when the user explicitly chooses
-`Refresh Login`; it never starts the Decodex CLI, a helper, or app-server. The bridge exposes
+`Refresh login`; it never starts the Decodex CLI, a helper, or app-server. The bridge exposes
 only the official URL, one-time code, and closed session state to Swift. It gives the resulting
 private auth-file descriptor to the daemon, which verifies the exact provider, account revision,
 and credential binding before a host-store CAS, then removes the temporary home after success,


### PR DESCRIPTION
## Summary
- standardize account-panel controls on sentence case
- remove redundant routing/Codex header state and chart axis labels
- place quota progress before a compact percentage and tighten login recovery

## Validation
- `swift test --package-path apps/decodex-app -c release` (162 passed)
- focused presentation/architecture tests (21 passed)
- `scripts/macos/test_decodex_app_stage.sh`
- independent source review: APPROVED/READY