### PR TITLE
Refine macOS account panel materials

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -48,10 +48,12 @@ The panel uses compact individual material cards with transparent gaps and
 shows every account when they fit on the active display. On shorter displays,
 the account list remains scrollable without a persistent scroll indicator.
 The header, overview, and each account row use separate appearance-adaptive
-system material surfaces with a restrained fill, border, and shadow. The host
-window follows the system Light or Dark appearance and does not draw its own
-full-window shadow or backdrop. Transparent gaps remain visible; there is no
-background surface around the complete panel and no Liquid Glass effect.
+system frosted-material surfaces with no opaque custom fill or drawn border.
+The host window follows the system Light or Dark appearance and does not draw
+its own full-window shadow or backdrop. Login recovery uses a stronger floating
+material inside that same transparent window, without a window-wide modal dimmer.
+Transparent gaps remain visible; there is no background surface around the
+complete panel and no Liquid Glass effect.
 
 The app never identifies an account from its alias or vector position. The
 daemon derives a stable credential-negative one-word alias. The row displays

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -26,26 +26,21 @@ struct AccountPanelView: View {
 	}
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 7) {
-			header
-				.padding(.horizontal, 10)
-				.padding(.vertical, 8)
-				.panelCardSurface(cornerRadius: 18)
+		ZStack {
+			panelContent
+				.disabled(store.accountReauthentication != nil)
+				.allowsHitTesting(store.accountReauthentication == nil)
+				.accessibilityHidden(store.accountReauthentication != nil)
 
-			if hasTransientStatus {
-				transientStatus
-					.transition(.panelSection)
+			if store.accountReauthentication != nil {
+				reauthenticationOverlay
+					.transition(
+						.opacity.combined(
+							with: .scale(scale: 0.98, anchor: .center)
+						)
+					)
+					.zIndex(1)
 			}
-
-			if let profileAggregate {
-				AccountProfileOverviewView(
-					aggregate: profileAggregate
-				)
-				.panelCardSurface(cornerRadius: 16)
-				.transition(.panelSection)
-			}
-
-			accountContent
 		}
 		.frame(width: AccountPanelLayout.panelWidth)
 		.padding(6)
@@ -65,16 +60,7 @@ struct AccountPanelView: View {
 				isPresentingEnrollment = false
 			}
 		}
-		.sheet(
-			isPresented: Binding(
-				get: {
-					store.accountReauthentication != nil
-				},
-				set: { _ in }
-			)
-		) {
-			AccountReauthenticationView(store: store)
-		}
+		.animation(PanelMotion.panelLayout, value: store.accountReauthentication != nil)
 		.task {
 			guard loadsExternalState else {
 				return
@@ -102,6 +88,42 @@ struct AccountPanelView: View {
 				return
 			}
 			store.dismissMessage()
+		}
+	}
+
+	private var panelContent: some View {
+		VStack(alignment: .leading, spacing: 7) {
+			header
+				.padding(.horizontal, 10)
+				.padding(.vertical, 8)
+				.panelCardSurface(cornerRadius: 18)
+
+			if hasTransientStatus {
+				transientStatus
+					.transition(.panelSection)
+			}
+
+			if let profileAggregate {
+				AccountProfileOverviewView(
+					aggregate: profileAggregate
+				)
+					.panelCardSurface(cornerRadius: 16)
+					.transition(.panelSection)
+			}
+
+			accountContent
+		}
+	}
+
+	private var reauthenticationOverlay: some View {
+		ZStack {
+			Color.clear
+				.contentShape(Rectangle())
+				.accessibilityHidden(true)
+
+			AccountReauthenticationView(store: store)
+				.panelModalSurface(cornerRadius: 16)
+				.accessibilityAddTraits(.isModal)
 		}
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
@@ -2,14 +2,22 @@ import AppKit
 import SwiftUI
 
 struct AccountReauthenticationView: View {
+	private enum FocusedAction: Hashable {
+		case cancel
+		case openBrowser
+	}
+
 	let store: ResetCardStore
 	@Environment(\.colorScheme) private var colorScheme
+	@FocusState private var focusedAction: FocusedAction?
 	@State private var copyFeedback = false
 	@State private var openFeedback = false
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 8) {
+		VStack(alignment: .leading, spacing: 9) {
 			if let presentation = store.accountReauthentication {
+				let desiredFocus = desiredFocus(for: presentation)
+
 				header(presentation)
 
 				if let prompt = presentation.prompt {
@@ -23,17 +31,7 @@ struct AccountReauthenticationView: View {
 						.fixedSize(horizontal: false, vertical: true)
 				}
 
-				HStack {
-					if let prompt = presentation.prompt {
-						Button(openFeedback ? "Opened" : "Open browser") {
-							open(prompt.verificationURL)
-						}
-						.buttonStyle(.borderedProminent)
-						.accessibilityHint("Opens the official Codex device sign-in page.")
-					}
-
-					Spacer()
-
+				HStack(spacing: 8) {
 					Button(
 						presentation.canCloseWithoutCancellation
 							? "Close"
@@ -52,59 +50,94 @@ struct AccountReauthenticationView: View {
 							&& presentation.canRequestCancellation == false
 					)
 					.keyboardShortcut(.cancelAction)
+					.focused($focusedAction, equals: .cancel)
+
+					Spacer(minLength: 8)
+
+					if let prompt = presentation.prompt {
+						Button(openFeedback ? "Opened" : "Open browser") {
+							open(prompt.verificationURL)
+						}
+						.buttonStyle(.borderedProminent)
+						.focused($focusedAction, equals: .openBrowser)
+						.accessibilityHint("Opens the official Codex device sign-in page.")
+					}
+				}
+				.task(id: desiredFocus) {
+					await Task.yield()
+					guard Task.isCancelled == false else {
+						return
+					}
+					focusedAction = desiredFocus
 				}
 			}
 		}
-		.frame(width: 256)
-		.padding(12)
+		.frame(width: 220)
+		.padding(14)
 		.controlSize(.small)
-		.interactiveDismissDisabled(true)
+		.accessibilityElement(children: .contain)
+		.accessibilityLabel("Refresh login")
+	}
+
+	private func desiredFocus(
+		for presentation: AccountReauthenticationPresentation
+	) -> FocusedAction? {
+		if presentation.prompt != nil {
+			return .openBrowser
+		}
+		if presentation.canRequestCancellation
+			|| presentation.canCloseWithoutCancellation
+		{
+			return .cancel
+		}
+		return nil
 	}
 
 	private func header(
 		_ presentation: AccountReauthenticationPresentation
 	) -> some View {
-		VStack(alignment: .leading, spacing: 3) {
-			Text("Refresh login")
-				.font(PanelFont.transientTitle)
-				.foregroundStyle(PanelPalette.primaryText(colorScheme))
+		VStack(alignment: .leading, spacing: 2) {
+			HStack(alignment: .firstTextBaseline, spacing: 5) {
+				Text("Refresh login")
+					.font(PanelFont.transientTitle)
+					.foregroundStyle(PanelPalette.primaryText(colorScheme))
 
-			HStack(alignment: .firstTextBaseline, spacing: 4) {
-				if presentation.prompt == nil,
-					presentation.failureText == nil
-				{
-					ProgressView()
-						.controlSize(.mini)
-						.accessibilityHidden(true)
+				Spacer(minLength: 6)
+
+				HStack(alignment: .firstTextBaseline, spacing: 3) {
+					if presentation.prompt == nil,
+						presentation.failureText == nil
+					{
+						ProgressView()
+							.controlSize(.mini)
+							.accessibilityHidden(true)
+					}
+
+					Text(presentation.accountLabel)
+						.font(PanelFont.tertiary)
+						.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+						.lineLimit(1)
+						.truncationMode(.middle)
 				}
-
-				Text(presentation.accountLabel)
-					.font(PanelFont.transientBody)
-					.foregroundStyle(PanelPalette.primaryText(colorScheme).opacity(0.86))
-					.lineLimit(1)
-					.truncationMode(.middle)
-
-				Text("· \(presentation.statusText)")
-					.font(PanelFont.tertiary)
-					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-					.lineLimit(1)
-					.truncationMode(.tail)
 			}
 			.accessibilityElement(children: .combine)
 			.accessibilityLabel(
-				"\(presentation.accountLabel), \(presentation.statusText)"
+				"Refresh login for \(presentation.accountLabel)"
 			)
+
+			Text(presentation.statusText)
+				.font(PanelFont.transientBody)
+				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+				.lineLimit(1)
+				.truncationMode(.tail)
+				.accessibilityLabel(presentation.statusText)
 		}
 	}
 
 	private func promptContent(
 		_ prompt: AccountReauthenticationPrompt
 	) -> some View {
-		VStack(alignment: .leading, spacing: 6) {
-			Text("One-time code")
-				.font(PanelFont.tertiary)
-				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-
+		VStack(alignment: .leading, spacing: 0) {
 			HStack(spacing: 8) {
 				Text(prompt.userCode)
 					.font(PanelFont.loginCode)
@@ -122,20 +155,10 @@ struct AccountReauthenticationView: View {
 				.accessibilityHint("Copies the one-time Codex login code.")
 			}
 			.padding(.horizontal, 9)
-			.padding(.vertical, 7)
-			.background(
-				RoundedRectangle(cornerRadius: 8, style: .continuous)
-					.fill(
-						PanelPalette.secondaryText(colorScheme)
-							.opacity(colorScheme == .dark ? 0.12 : 0.08)
-					)
-			)
-			.overlay {
-				RoundedRectangle(cornerRadius: 8, style: .continuous)
-					.stroke(
-						PanelPalette.separator(colorScheme),
-						lineWidth: 1
-					)
+			.padding(.vertical, 8)
+			.background {
+				RoundedRectangle(cornerRadius: 9, style: .continuous)
+					.fill(.ultraThinMaterial)
 			}
 			.accessibilityElement(children: .contain)
 			.accessibilityLabel("One-time login code \(prompt.userCode)")

--- a/apps/decodex-app/Sources/DecodexApp/PanelCardSurface.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelCardSurface.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 struct PanelCardSurfaceModifier: ViewModifier {
@@ -12,30 +11,33 @@ struct PanelCardSurfaceModifier: ViewModifier {
 		content
 			.background {
 				shape.fill(.thinMaterial)
-				shape.fill(cardFill)
-			}
-			.overlay {
-				shape
-					.strokeBorder(cardStroke, lineWidth: 0.7)
-					.allowsHitTesting(false)
 			}
 			.shadow(
-				color: Color.black.opacity(colorScheme == .dark ? 0.24 : 0.12),
-				radius: 8,
+				color: Color.black.opacity(colorScheme == .dark ? 0.14 : 0.07),
+				radius: 3,
 				x: 0,
-				y: 3
+				y: 1
 			)
 	}
+}
 
-	private var cardFill: Color {
-		colorScheme == .dark
-			? Color(red: 0.2, green: 0.2, blue: 0.21).opacity(0.82)
-			: Color(nsColor: .controlBackgroundColor).opacity(0.84)
-	}
+struct PanelModalSurfaceModifier: ViewModifier {
+	@Environment(\.colorScheme) private var colorScheme
+	let cornerRadius: CGFloat
 
-	private var cardStroke: Color {
-		colorScheme == .dark
-			? Color.white.opacity(0.07)
-			: Color.black.opacity(0.1)
+	@ViewBuilder
+	func body(content: Content) -> some View {
+		let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+
+		content
+			.background {
+				shape.fill(.regularMaterial)
+			}
+			.shadow(
+				color: Color.black.opacity(colorScheme == .dark ? 0.3 : 0.18),
+				radius: 10,
+				x: 0,
+				y: 4
+			)
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
@@ -12,6 +12,14 @@ extension View {
 			)
 		)
 	}
+
+	func panelModalSurface(cornerRadius: CGFloat) -> some View {
+		modifier(
+			PanelModalSurfaceModifier(
+				cornerRadius: cornerRadius
+			)
+		)
+	}
 }
 
 extension AnyTransition {

--- a/apps/decodex-app/Sources/DecodexApp/PanelWindowSizing.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelWindowSizing.swift
@@ -170,6 +170,8 @@ enum PanelWindowAppearance {
 		window.hasShadow = false
 		window.isOpaque = false
 		window.backgroundColor = .clear
+		window.contentView?.wantsLayer = true
+		window.contentView?.layer?.backgroundColor = NSColor.clear.cgColor
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
+++ b/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
@@ -8,7 +8,7 @@ final class StatusPanelController: NSObject {
 
 	private let statusItem: NSStatusItem
 	private let panel: TransparentStatusPanel
-	private let hostingView: NSHostingView<StatusPanelRootView>
+	private let hostingView: TransparentHostingView<StatusPanelRootView>
 
 	init(store: ResetCardStore) {
 		statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
@@ -18,7 +18,7 @@ final class StatusPanelController: NSObject {
 			backing: .buffered,
 			defer: true
 		)
-		hostingView = NSHostingView(rootView: StatusPanelRootView(store: store))
+		hostingView = TransparentHostingView(rootView: StatusPanelRootView(store: store))
 
 		super.init()
 
@@ -57,6 +57,8 @@ final class StatusPanelController: NSObject {
 	}
 
 	private func configurePanel() {
+		hostingView.wantsLayer = true
+		hostingView.layer?.backgroundColor = NSColor.clear.cgColor
 		panel.isReleasedWhenClosed = false
 		panel.isOpaque = false
 		panel.backgroundColor = .clear
@@ -70,6 +72,7 @@ final class StatusPanelController: NSObject {
 			.fullScreenAuxiliary,
 		]
 		panel.contentView = hostingView
+		PanelWindowAppearance.apply(to: panel)
 	}
 
 	private func positionPanel() {
@@ -100,6 +103,13 @@ final class StatusPanelController: NSObject {
 				menuBarGap: Self.menuBarGap
 			)
 		)
+	}
+}
+
+@MainActor
+final class TransparentHostingView<Content: View>: NSHostingView<Content> {
+	override var isOpaque: Bool {
+		false
 	}
 }
 

--- a/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 @testable import DecodexApp
 import XCTest
 
@@ -20,7 +21,15 @@ final class PanelWindowSizingLayoutTests: XCTestCase {
 		XCTAssertFalse(window.hasShadow)
 		XCTAssertFalse(window.isOpaque)
 		XCTAssertEqual(window.backgroundColor, .clear)
+		XCTAssertEqual(window.contentView?.layer?.backgroundColor?.alpha, 0)
 		XCTAssertNil(window.appearance)
+	}
+
+	@MainActor
+	func testStatusPanelHostingViewDoesNotPaintAWindowSizedBackdrop() {
+		let hostingView = TransparentHostingView(rootView: Text("Decodex"))
+
+		XCTAssertFalse(hostingView.isOpaque)
 	}
 
 	@MainActor

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -143,9 +143,16 @@ final class ResetCardArchitectureTests: XCTestCase {
 		)
 
 		XCTAssertTrue(cardSurface.contains("shape.fill(.thinMaterial)"))
+		XCTAssertTrue(cardSurface.contains("shape.fill(.regularMaterial)"))
 		XCTAssertTrue(cardSurface.contains(".background"))
-		XCTAssertTrue(cardSurface.contains(".overlay"))
 		XCTAssertTrue(cardSurface.contains(".shadow"))
+		XCTAssertTrue(cardSurface.contains("radius: 3"))
+		XCTAssertTrue(cardSurface.contains("radius: 10"))
+		XCTAssertTrue(cardSurface.contains("y: 1"))
+		XCTAssertTrue(cardSurface.contains("y: 4"))
+		XCTAssertFalse(cardSurface.contains("cardFill"))
+		XCTAssertFalse(cardSurface.contains("cardStroke"))
+		XCTAssertFalse(cardSurface.contains("strokeBorder"))
 		XCTAssertFalse(cardSurface.contains("Glass"))
 		XCTAssertFalse(cardSurface.contains("glassEffect"))
 		XCTAssertFalse(accountPanel.contains("GlassEffectContainer"))
@@ -167,7 +174,8 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(statusPanel.contains("NSStatusBar.system.statusItem"))
 		XCTAssertTrue(statusPanel.contains("TransparentStatusPanel"))
 		XCTAssertTrue(statusPanel.contains("styleMask: [.borderless]"))
-		XCTAssertTrue(statusPanel.contains("NSHostingView(rootView: StatusPanelRootView"))
+		XCTAssertTrue(statusPanel.contains("TransparentHostingView(rootView: StatusPanelRootView"))
+		XCTAssertTrue(statusPanel.contains("override var isOpaque"))
 		XCTAssertTrue(statusPanel.contains("AccountPanelView(store: store)"))
 		XCTAssertTrue(statusPanel.contains("panel.hidesOnDeactivate = true"))
 		XCTAssertFalse(statusPanel.contains(".preferredColorScheme"))
@@ -181,6 +189,11 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(accountPanel.contains("routingSubtitle"))
 		XCTAssertFalse(accountPanel.contains("codexProjectionSubtitle"))
 		XCTAssertTrue(panelWindow.contains("window.hasShadow = false"))
+		XCTAssertTrue(
+			panelWindow.contains(
+				"window.contentView?.layer?.backgroundColor = NSColor.clear.cgColor"
+			)
+		)
 		XCTAssertFalse(panelWindow.contains("window.appearance ="))
 		XCTAssertFalse(
 			FileManager.default.fileExists(
@@ -325,6 +338,10 @@ final class ResetCardArchitectureTests: XCTestCase {
 			),
 			encoding: .utf8
 		)
+		let panel = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountPanelView.swift"),
+			encoding: .utf8
+		)
 		let app = try String(
 			contentsOf: sourceURL.appendingPathComponent("DecodexApp.swift"),
 			encoding: .utf8
@@ -337,12 +354,25 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(view.contains("\"Copy\""))
 		XCTAssertTrue(view.contains("\"Open browser\""))
 		XCTAssertTrue(view.contains("\"Cancel\""))
-		XCTAssertTrue(view.contains(".frame(width: 256)"))
+		XCTAssertTrue(view.contains(".frame(width: 220)"))
+		XCTAssertTrue(view.contains(".padding(14)"))
 		XCTAssertFalse(view.contains("Enter this one-time code"))
 		XCTAssertFalse(view.contains("Divider()"))
-		XCTAssertTrue(view.contains(".interactiveDismissDisabled(true)"))
+		XCTAssertFalse(view.contains(".interactiveDismissDisabled"))
 		XCTAssertFalse(view.contains(".onDisappear"))
 		XCTAssertFalse(view.contains(".onChange(of:"))
+		XCTAssertTrue(panel.contains("reauthenticationOverlay"))
+		XCTAssertTrue(panel.contains(".disabled(store.accountReauthentication != nil)"))
+		XCTAssertTrue(panel.contains(".allowsHitTesting(store.accountReauthentication == nil)"))
+		XCTAssertTrue(panel.contains(".accessibilityHidden(store.accountReauthentication != nil)"))
+		XCTAssertTrue(panel.contains(".panelModalSurface(cornerRadius: 16)"))
+		XCTAssertTrue(panel.contains(".accessibilityAddTraits(.isModal)"))
+		XCTAssertFalse(panel.contains(".padding(.horizontal, 20)"))
+		XCTAssertFalse(panel.contains("isPresented: Binding("))
+		XCTAssertTrue(view.contains("@FocusState private var focusedAction"))
+		XCTAssertTrue(view.contains(".focused($focusedAction, equals: .openBrowser)"))
+		XCTAssertTrue(view.contains(".task(id: desiredFocus)"))
+		XCTAssertTrue(view.contains("presentation.canCloseWithoutCancellation"))
 		XCTAssertTrue(
 			controls.contains("store.beginAccountReauthentication(for:")
 		)


### PR DESCRIPTION
## Summary
- remove the window-sized panel veil by keeping the AppKit host fully transparent and constraining card shadows
- use adaptive system materials for all account cards without custom opaque fills or drawn borders
- replace the opaque login sheet with a compact in-panel material modal with keyboard and accessibility fencing

## Validation
- `swift test --package-path apps/decodex-app -c release` (163 tests)
- `scripts/macos/test_decodex_app_stage.sh`
- independent exact-diff review: APPROVED / READY

Authority: XY-1427