### PR TITLE
Simplify Reset Card expiry labels

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -420,7 +420,7 @@ struct ResetCardAccountRow: View {
 	}
 
 	private func normalCardChipTitle(_ target: ResetCardUseTarget) -> String {
-		"Use · \(Self.cardExpiryText(target.descriptor.expiresAtUnixSeconds))"
+		Self.cardExpiryText(target.descriptor.expiresAtUnixSeconds)
 	}
 
 	private func accessibilityLabel(_ target: ResetCardUseTarget) -> String {

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -182,7 +182,12 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(statusPanel.contains(".environment(\\.colorScheme"))
 		XCTAssertTrue(resetCards.contains(".buttonStyle(.bordered)"))
 		XCTAssertTrue(resetCards.contains(".controlSize(.small)"))
-		XCTAssertTrue(resetCards.contains("\"Use · \\(Self.cardExpiryText"))
+		XCTAssertTrue(
+			resetCards.contains(
+				"Self.cardExpiryText(target.descriptor.expiresAtUnixSeconds)"
+			)
+		)
+		XCTAssertFalse(resetCards.contains("\"Use · "))
 		XCTAssertFalse(resetCards.contains("Image(systemName: \"creditcard\")"))
 		XCTAssertTrue(resetCards.contains(".frame(minWidth: 88, maxWidth: .infinity)"))
 		XCTAssertFalse(accountPanel.contains("headerState("))


### PR DESCRIPTION
## Summary
- remove the redundant `Use ·` prefix from Reset Card buttons
- retain the expiry timestamp, confirmation state, submission state, and accessibility text

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app -c release` (163 passed)
- `DECODEX_APP_CARGO_LOCKED=1 scripts/macos/test_decodex_app_stage.sh`
- independent exact-diff review: APPROVED