### PR TITLE
Harden autonomous validation sandbox

### DIFF
--- a/apps/decodex-publisher/src/filesystem.rs
+++ b/apps/decodex-publisher/src/filesystem.rs
@@ -73,6 +73,25 @@ pub(crate) fn repo_root() -> Result<PathBuf> {
 	Ok(root)
 }
 
+#[cfg(test)]
+pub(crate) fn repo_local_test_directory(prefix: &str) -> tempfile::TempDir {
+	let repo_root = repo_root().expect("repository root");
+	let target = repo_root.join("target");
+	let configured = env::var_os("DECODEX_VALIDATION_REPO_OUTPUT")
+		.map(PathBuf::from)
+		.unwrap_or_else(|| target.clone());
+	let configured = clean_absolute_path(&configured).expect("repo-local test output path");
+	assert!(
+		configured == target || configured.parent() == Some(target.as_path()),
+		"repo-local test output must be target or one direct child"
+	);
+	ensure_private_directory(&configured).expect("repo-local test output directory");
+	tempfile::Builder::new()
+		.prefix(prefix)
+		.tempdir_in(configured)
+		.expect("repo-local temporary directory")
+}
+
 pub(crate) fn resolve_against(root: &Path, path: &Path) -> PathBuf {
 	if path.is_absolute() { path.to_path_buf() } else { root.join(path) }
 }

--- a/apps/decodex-publisher/src/filesystem.rs
+++ b/apps/decodex-publisher/src/filesystem.rs
@@ -81,15 +81,40 @@ pub(crate) fn repo_local_test_directory(prefix: &str) -> tempfile::TempDir {
 		.map(PathBuf::from)
 		.unwrap_or_else(|| target.clone());
 	let configured = clean_absolute_path(&configured).expect("repo-local test output path");
-	assert!(
-		configured == target || configured.parent() == Some(target.as_path()),
-		"repo-local test output must be target or one direct child"
-	);
-	ensure_private_directory(&configured).expect("repo-local test output directory");
+	if env::var_os("DECODEX_CANDIDATE_SANDBOX").as_deref() == Some(OsStr::new("1")) {
+		validate_sandbox_test_output(&target, &configured)
+			.expect("sandboxed repo-local test output directory");
+	} else {
+		assert!(
+			configured == target || configured.parent() == Some(target.as_path()),
+			"repo-local test output must be target or one direct child"
+		);
+		ensure_private_directory(&configured).expect("repo-local test output directory");
+	}
 	tempfile::Builder::new()
 		.prefix(prefix)
 		.tempdir_in(configured)
 		.expect("repo-local temporary directory")
+}
+
+#[cfg(test)]
+fn validate_sandbox_test_output(target: &Path, configured: &Path) -> Result<()> {
+	if configured == target || configured.parent() != Some(target) {
+		return Err(eyre::eyre!(
+			"sandboxed repo-local test output must be one direct child of target"
+		));
+	}
+	let metadata = fs::symlink_metadata(configured)?;
+	if !metadata.is_dir()
+		|| metadata.uid() != current_uid()
+		|| metadata.permissions().mode() & 0o7777 != u32::from(PRIVATE_DIRECTORY_MODE)
+	{
+		return Err(eyre::eyre!(
+			"sandboxed repo-local test output must be an owned mode-0700 directory"
+		));
+	}
+
+	Ok(())
 }
 
 pub(crate) fn resolve_against(root: &Path, path: &Path) -> PathBuf {
@@ -870,11 +895,44 @@ fn current_uid() -> u32 {
 
 #[cfg(test)]
 mod tests {
-	use std::{fs, os::unix::fs::symlink};
+	use std::{
+		fs,
+		os::unix::fs::{PermissionsExt as _, symlink},
+	};
 
 	use serde_json::json;
 
-	use super::{open_private_directory, write_new_json_in_parent};
+	use super::{open_private_directory, validate_sandbox_test_output, write_new_json_in_parent};
+
+	#[test]
+	fn sandbox_test_output_requires_an_exact_private_direct_child() {
+		let temp = tempfile::tempdir().expect("temporary directory");
+		let target = temp.path().join("target");
+		let output = target.join("decodex-validation-test");
+		fs::create_dir(&target).expect("target directory");
+		fs::create_dir(&output).expect("output directory");
+		fs::set_permissions(&output, fs::Permissions::from_mode(0o700))
+			.expect("private output mode");
+
+		validate_sandbox_test_output(&target, &output).expect("valid direct child");
+		assert!(validate_sandbox_test_output(&target, &target).is_err());
+
+		let outside = temp.path().join("outside");
+		fs::create_dir(&outside).expect("outside directory");
+		assert!(validate_sandbox_test_output(&target, &outside).is_err());
+
+		fs::set_permissions(&output, fs::Permissions::from_mode(0o755))
+			.expect("unsafe output mode");
+		assert!(validate_sandbox_test_output(&target, &output).is_err());
+
+		fs::set_permissions(&output, fs::Permissions::from_mode(0o1700))
+			.expect("sticky output mode");
+		assert!(validate_sandbox_test_output(&target, &output).is_err());
+
+		fs::remove_dir(&output).expect("remove output");
+		symlink(&outside, &output).expect("symlink output");
+		assert!(validate_sandbox_test_output(&target, &output).is_err());
+	}
 
 	#[test]
 	fn descriptor_relative_publish_stays_in_the_opened_directory_after_path_replacement() {

--- a/apps/decodex-publisher/src/filesystem.rs
+++ b/apps/decodex-publisher/src/filesystem.rs
@@ -666,6 +666,13 @@ fn read_json_bytes_bounded(
 
 fn open_private_directory(path: &Path, create: bool) -> Result<PrivateDirectory> {
 	let path = clean_absolute_path(path)?;
+	#[cfg(test)]
+	if let Some(current) = open_sandbox_private_root(&path, create)? {
+		let relative = path
+			.strip_prefix(&current.path)
+			.map_err(|_| eyre::eyre!("sandboxed private path escaped its pinned root"))?;
+		return descend_private_directory(current, relative.components(), create);
+	}
 	let root_fd = unix_fs::open(
 		"/",
 		OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
@@ -679,7 +686,100 @@ fn open_private_directory(path: &Path, create: bool) -> Result<PrivateDirectory>
 	let metadata = current.file.metadata()?;
 	current.private_anchor_found = validate_directory_metadata(&current.path, &metadata, false)?;
 
-	for component in path.components() {
+	descend_private_directory(current, path.components(), create)
+}
+
+#[cfg(test)]
+fn open_sandbox_private_root(path: &Path, create: bool) -> Result<Option<PrivateDirectory>> {
+	if env::var_os("DECODEX_CANDIDATE_SANDBOX").as_deref() != Some(OsStr::new("1")) {
+		return Ok(None);
+	}
+	let roots = ["DECODEX_VALIDATION_REPO_OUTPUT", "TMPDIR"]
+		.into_iter()
+		.filter_map(env::var_os)
+		.map(PathBuf::from)
+		.map(|root| clean_absolute_path(&root))
+		.collect::<Result<Vec<_>>>()?;
+	if matching_sandbox_root(path, roots.clone()).is_some() {
+		return Ok(Some(open_pinned_sandbox_private_root(path, roots)?));
+	}
+	let candidate = repo_root()?;
+	if path == candidate || path.starts_with(&candidate) {
+		if create {
+			return Err(eyre::eyre!("sandboxed private path is outside its writable pinned roots"));
+		}
+		return Ok(Some(open_pinned_sandbox_read_root(candidate)?));
+	}
+
+	Err(eyre::eyre!("sandboxed private path is outside its pinned roots"))
+}
+
+#[cfg(test)]
+fn open_pinned_sandbox_private_root(path: &Path, roots: Vec<PathBuf>) -> Result<PrivateDirectory> {
+	let root = matching_sandbox_root(path, roots)
+		.ok_or_else(|| eyre::eyre!("sandboxed private path is outside its pinned roots"))?;
+	open_pinned_sandbox_root(root, true)
+}
+
+#[cfg(test)]
+fn matching_sandbox_root(path: &Path, mut roots: Vec<PathBuf>) -> Option<PathBuf> {
+	roots.sort_by_key(|root| root.components().count());
+	roots.into_iter().rev().find(|root| path == root || path.starts_with(root))
+}
+
+#[cfg(test)]
+fn open_pinned_sandbox_read_root(root: PathBuf) -> Result<PrivateDirectory> {
+	open_pinned_sandbox_root(root, false)
+}
+
+#[cfg(test)]
+fn open_pinned_sandbox_root(root: PathBuf, exact_private: bool) -> Result<PrivateDirectory> {
+	let before = fs::symlink_metadata(&root)?;
+	let private_anchor_found = if exact_private {
+		validate_exact_sandbox_private_directory_metadata(&before)?;
+		true
+	} else {
+		validate_directory_metadata(&root, &before, false)?
+	};
+	let fd = unix_fs::open(
+		&root,
+		OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+		Mode::empty(),
+	)?;
+	let file = File::from(fd);
+	let after = file.metadata()?;
+	if exact_private {
+		validate_exact_sandbox_private_directory_metadata(&after)?;
+	} else if validate_directory_metadata(&root, &after, false)? != private_anchor_found {
+		return Err(eyre::eyre!("sandboxed read root authority changed while opening"));
+	}
+	if (before.dev(), before.ino()) != (after.dev(), after.ino()) {
+		return Err(eyre::eyre!("sandboxed private root changed while opening"));
+	}
+
+	Ok(PrivateDirectory { file, path: root, private_anchor_found })
+}
+
+#[cfg(test)]
+fn validate_exact_sandbox_private_directory_metadata(metadata: &fs::Metadata) -> Result<()> {
+	if !metadata.is_dir()
+		|| metadata.uid() != current_uid()
+		|| metadata.permissions().mode() & 0o7777 != u32::from(PRIVATE_DIRECTORY_MODE)
+	{
+		return Err(eyre::eyre!(
+			"sandboxed private root is not an owned exact mode-0700 directory"
+		));
+	}
+
+	Ok(())
+}
+
+fn descend_private_directory<'a>(
+	mut current: PrivateDirectory,
+	components: impl Iterator<Item = Component<'a>>,
+	create: bool,
+) -> Result<PrivateDirectory> {
+	for component in components {
 		let Component::Normal(name) = component else {
 			continue;
 		};
@@ -902,7 +1002,10 @@ mod tests {
 
 	use serde_json::json;
 
-	use super::{open_private_directory, validate_sandbox_test_output, write_new_json_in_parent};
+	use super::{
+		open_pinned_sandbox_private_root, open_pinned_sandbox_read_root, open_private_directory,
+		validate_sandbox_test_output, write_new_json_in_parent,
+	};
 
 	#[test]
 	fn sandbox_test_output_requires_an_exact_private_direct_child() {
@@ -932,6 +1035,43 @@ mod tests {
 		fs::remove_dir(&output).expect("remove output");
 		symlink(&outside, &output).expect("symlink output");
 		assert!(validate_sandbox_test_output(&target, &output).is_err());
+	}
+
+	#[test]
+	fn sandbox_private_root_is_opened_directly_and_rejects_unsafe_roots() {
+		let temp = tempfile::tempdir().expect("temporary directory");
+		let root = temp.path().join("root");
+		let outside = temp.path().join("outside");
+		fs::create_dir(&root).expect("private root");
+		fs::create_dir(&outside).expect("outside directory");
+		fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).expect("private root mode");
+		let path = root.join("child");
+
+		let pinned = open_pinned_sandbox_private_root(&path, vec![root.clone()])
+			.expect("pinned sandbox root");
+		assert_eq!(pinned.path, root);
+		assert!(open_pinned_sandbox_private_root(&outside, vec![root.clone()]).is_err());
+
+		fs::set_permissions(&root, fs::Permissions::from_mode(0o1700)).expect("sticky root mode");
+		assert!(open_pinned_sandbox_private_root(&path, vec![root.clone()]).is_err());
+
+		fs::remove_dir(&root).expect("remove unsafe root");
+		symlink(&outside, &root).expect("replace root with symlink");
+		assert!(open_pinned_sandbox_private_root(&path, vec![root]).is_err());
+	}
+
+	#[test]
+	fn sandbox_read_root_allows_safe_read_only_candidate_modes() {
+		let temp = tempfile::tempdir().expect("temporary directory");
+		let root = temp.path().join("candidate");
+		fs::create_dir(&root).expect("candidate root");
+		fs::set_permissions(&root, fs::Permissions::from_mode(0o755)).expect("candidate mode");
+		let pinned = open_pinned_sandbox_read_root(root.clone()).expect("pinned read root");
+		assert_eq!(pinned.path, root);
+
+		fs::set_permissions(&root, fs::Permissions::from_mode(0o775))
+			.expect("unsafe candidate mode");
+		assert!(open_pinned_sandbox_read_root(root).is_err());
 	}
 
 	#[test]

--- a/apps/decodex-publisher/src/lib.rs
+++ b/apps/decodex-publisher/src/lib.rs
@@ -15,6 +15,7 @@ mod prelude {
 	pub use color_eyre::{Result, eyre};
 }
 
+#[cfg(test)] pub(crate) use self::filesystem::repo_local_test_directory;
 pub(crate) use self::{
 	filesystem::{
 		collect_json_files, ensure_private_directory, load_json, load_json_bytes_with_sha256,

--- a/apps/decodex-publisher/src/social_gc/tests.rs
+++ b/apps/decodex-publisher/src/social_gc/tests.rs
@@ -80,11 +80,7 @@ struct RadarFixture {
 impl RadarFixture {
 	fn create() -> Self {
 		let repo_root = crate::repo_root().expect("repo root");
-		let target = repo_root.join("target");
-		let temp = tempfile::Builder::new()
-			.prefix("social-gc-radar-")
-			.tempdir_in(&target)
-			.expect("private Radar fixture directory");
+		let temp = crate::repo_local_test_directory("social-gc-radar-");
 		let queue_dir = temp.path().join("github/review-queue");
 		let pairs_dir = temp.path().join("github/content-review-pairs");
 		crate::ensure_private_directory(&queue_dir).expect("private Radar queue collection");

--- a/apps/decodex-publisher/src/social_xurl/runtime.rs
+++ b/apps/decodex-publisher/src/social_xurl/runtime.rs
@@ -1348,8 +1348,7 @@ mod tests {
 
 	#[test]
 	fn private_xurl_entrypoint_accepts_only_the_fixed_secure_home_relative_path() {
-		let root = crate::repo_root().expect("repository root");
-		let temp = tempfile::tempdir_in(root).expect("tempdir");
+		let temp = crate::repo_local_test_directory("xurl-home-");
 		let bin = temp.path().join(".local/bin");
 		fs::create_dir_all(&bin).expect("private bin");
 		let script = executable_script(&bin, "xurl", "#!/bin/sh\nexit 0\n");
@@ -1362,10 +1361,9 @@ mod tests {
 
 	#[test]
 	fn private_xurl_entrypoint_rejects_group_or_world_writable_home_parents_and_file() {
-		let root = crate::repo_root().expect("repository root");
 		for mode in [0o770, 0o707] {
 			for relative in ["", ".local", ".local/bin", ".local/bin/xurl"] {
-				let temp = tempfile::tempdir_in(&root).expect("tempdir");
+				let temp = crate::repo_local_test_directory("xurl-home-");
 				let bin = temp.path().join(".local/bin");
 				fs::create_dir_all(&bin).expect("private bin");
 				executable_script(&bin, "xurl", "#!/bin/sh\nexit 0\n");
@@ -1387,8 +1385,7 @@ mod tests {
 
 	#[test]
 	fn private_xurl_entrypoint_rejects_a_final_symlink() {
-		let root = crate::repo_root().expect("repository root");
-		let temp = tempfile::tempdir_in(root).expect("tempdir");
+		let temp = crate::repo_local_test_directory("xurl-home-");
 		let bin = temp.path().join(".local/bin");
 		fs::create_dir_all(&bin).expect("private bin");
 		let target = executable_script(&bin, "xurl-real", "#!/bin/sh\nexit 0\n");

--- a/apps/decodex-publisher/src/tests.rs
+++ b/apps/decodex-publisher/src/tests.rs
@@ -188,7 +188,7 @@ fn rejects_short_publish_text_and_free_form_claim_evidence() {
 #[test]
 fn internal_evidence_digest_is_rechecked_before_reservation_and_publication() {
 	let repo_root = crate::repo_root().expect("repo root");
-	let temp = tempfile::tempdir_in(&repo_root).expect("repo-local temporary directory");
+	let temp = crate::repo_local_test_directory("publisher-evidence-");
 	let evidence_path = temp.path().join("evidence/signal.json");
 	let original_evidence = json!({
 		"schema": "signal_entry/v1",
@@ -249,7 +249,7 @@ fn internal_evidence_digest_is_rechecked_before_reservation_and_publication() {
 #[test]
 fn internal_evidence_rejects_missing_and_unsupported_sources() {
 	let repo_root = crate::repo_root().expect("repo root");
-	let temp = tempfile::tempdir_in(&repo_root).expect("repo-local temporary directory");
+	let temp = crate::repo_local_test_directory("publisher-evidence-");
 	let missing_path = temp.path().join("evidence/missing.json");
 	let missing_ref = crate::path_arg(&repo_root, &missing_path);
 	let mut missing_candidate = valid_social_candidate();
@@ -3050,12 +3050,7 @@ fn attach_test_radar_lineage(candidate: &mut Value) -> Vec<tempfile::TempDir> {
 	}
 
 	let repo_root = crate::repo_root().expect("repo root");
-	let target = repo_root.join("target");
-	crate::ensure_private_directory(&target).expect("test target directory");
-	let directory = tempfile::Builder::new()
-		.prefix("publisher-radar-")
-		.tempdir_in(&target)
-		.expect("private Radar test directory");
+	let directory = crate::repo_local_test_directory("publisher-radar-");
 	let queue_dir = directory.path().join("github/review-queue");
 	let pairs_dir = directory.path().join("github/content-review-pairs");
 	crate::ensure_private_directory(&queue_dir).expect("private Radar queue collection");

--- a/apps/radar/src/github_api.rs
+++ b/apps/radar/src/github_api.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, thread};
 
 use reqwest::{
 	Error, StatusCode, Url,
-	blocking::Client,
+	blocking::{Client, ClientBuilder},
 	header::{ACCEPT, AUTHORIZATION, HeaderMap, LINK, RETRY_AFTER, USER_AGENT},
 };
 use serde_json::{self, Value};
@@ -29,22 +29,26 @@ impl GitHubApi {
 	}
 
 	fn new_with_origin(token: Option<String>, origin: Url) -> crate::prelude::Result<Self> {
-		Ok(Self {
-			client: Client::builder()
-				.timeout(GITHUB_REQUEST_TIMEOUT)
-				.redirect(reqwest::redirect::Policy::none())
-				.build()?,
-			origin,
-			token,
-		})
+		Ok(Self { client: Self::client_builder().build()?, origin, token })
+	}
+
+	fn client_builder() -> ClientBuilder {
+		Client::builder()
+			.timeout(GITHUB_REQUEST_TIMEOUT)
+			.redirect(reqwest::redirect::Policy::none())
 	}
 
 	#[cfg(test)]
 	pub(crate) fn new_for_test(
 		token: Option<String>,
 		origin: &str,
+		unix_socket: &std::path::Path,
 	) -> crate::prelude::Result<Self> {
-		Self::new_with_origin(token, Url::parse(origin)?)
+		Ok(Self {
+			client: Self::client_builder().unix_socket(unix_socket).build()?,
+			origin: Url::parse(origin)?,
+			token,
+		})
 	}
 
 	pub(super) fn get(&self, url: &str) -> crate::prelude::Result<GitHubResponse> {

--- a/apps/radar/src/private_fs.rs
+++ b/apps/radar/src/private_fs.rs
@@ -936,6 +936,17 @@ fn open_directory_path_direct(path: &Path) -> Result<File> {
 
 #[cfg(test)]
 fn open_test_parent_path(path: &Path) -> Result<File> {
+	if std::env::var_os("DECODEX_CANDIDATE_SANDBOX").as_deref() == Some(OsStr::new("1")) {
+		let sandbox_root = std::env::var_os("TMPDIR")
+			.ok_or_else(|| eyre::eyre!("sandboxed Radar tests require TMPDIR"))?;
+		let sandbox_root = absolute_path_without_traversal(Path::new(&sandbox_root))?;
+		let relative = path
+			.strip_prefix(&sandbox_root)
+			.map_err(|_| eyre::eyre!("sandboxed Radar test parent must stay under TMPDIR"))?;
+
+		return Ok(open_sandbox_private_cache_root(path, &sandbox_root, relative, false)?.root);
+	}
+
 	let (_, components) = absolute_components(path)?;
 	let mut directory = File::open("/")?;
 

--- a/apps/radar/src/private_fs.rs
+++ b/apps/radar/src/private_fs.rs
@@ -66,6 +66,8 @@ pub(crate) struct PrivateCache {
 	root_path: PathBuf,
 	root: File,
 	root_identity: DirectoryIdentity,
+	#[cfg(test)]
+	direct_root: bool,
 }
 impl PrivateCache {
 	pub(crate) fn root_path(&self) -> &Path {
@@ -273,6 +275,13 @@ impl PrivateCache {
 	}
 
 	fn verify_binding(&self) -> Result<()> {
+		#[cfg(test)]
+		let reopened = if self.direct_root {
+			open_directory_path_direct(&self.root_path)?
+		} else {
+			open_cache_root_file(&self.root_path, false)?
+		};
+		#[cfg(not(test))]
 		let reopened = open_cache_root_file(&self.root_path, false)?;
 		let identity = validate_private_directory(&reopened, "root")?;
 
@@ -558,7 +567,64 @@ struct DirectoryIdentity {
 	ino: u64,
 }
 
-#[derive(Clone, Debug)]
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct PrivateTestDirectory {
+	parent_path: PathBuf,
+	parent: File,
+	parent_identity: DirectoryIdentity,
+	name: CString,
+	path: PathBuf,
+	directory: File,
+	identity: DirectoryIdentity,
+}
+#[cfg(test)]
+impl PrivateTestDirectory {
+	pub(crate) fn path(&self) -> &Path {
+		&self.path
+	}
+
+	fn remove(&self) -> Result<()> {
+		self.remove_with_before_unlink(|| {})
+	}
+
+	pub(crate) fn remove_with_before_unlink(&self, before_unlink: impl FnOnce()) -> Result<()> {
+		verify_test_parent_binding(&self.parent_path, &self.parent, &self.parent_identity)?;
+		let identity = directory_identity(&self.directory, "test directory")?;
+
+		if identity != self.identity {
+			eyre::bail!("Radar test directory identity changed before cleanup");
+		}
+		remove_test_directory_contents(&self.directory)?;
+		before_unlink();
+		verify_directory_binding_at(
+			self.parent.as_raw_fd(),
+			&self.name,
+			&self.identity,
+			"test directory",
+		)?;
+		if unsafe {
+			libc::unlinkat(self.parent.as_raw_fd(), self.name.as_ptr(), libc::AT_REMOVEDIR)
+		} == -1
+		{
+			return Err(std::io::Error::last_os_error().into());
+		}
+		self.parent.sync_all()?;
+		verify_test_parent_binding(&self.parent_path, &self.parent, &self.parent_identity)
+	}
+}
+#[cfg(test)]
+impl Drop for PrivateTestDirectory {
+	fn drop(&mut self) {
+		if let Err(error) = self.remove()
+			&& !std::thread::panicking()
+		{
+			panic!("private Radar test directory cleanup failed: {error}");
+		}
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct FileSnapshot {
 	identity: PrivateFileIdentity,
 	mode: u32,
@@ -569,10 +635,139 @@ struct FileSnapshot {
 
 fn open_cache_root(path: &Path, create: bool) -> Result<PrivateCache> {
 	let root_path = absolute_path_without_traversal(path)?;
+
+	#[cfg(test)]
+	if std::env::var_os("DECODEX_CANDIDATE_SANDBOX").is_some_and(|value| value == OsStr::new("1"))
+		&& let Some(cache) = open_sandbox_cache_root(&root_path, create)?
+	{
+		return Ok(cache);
+	}
+
 	let root = open_cache_root_file(&root_path, create)?;
 	let root_identity = validate_private_directory(&root, "root")?;
 
-	Ok(PrivateCache { root_path, root, root_identity })
+	Ok(PrivateCache {
+		root_path,
+		root,
+		root_identity,
+		#[cfg(test)]
+		direct_root: false,
+	})
+}
+
+#[cfg(test)]
+fn open_sandbox_cache_root(path: &Path, create: bool) -> Result<Option<PrivateCache>> {
+	let sandbox_root = std::env::var_os("TMPDIR")
+		.ok_or_else(|| eyre::eyre!("sandboxed Radar tests require TMPDIR"))?;
+	let sandbox_root = absolute_path_without_traversal(Path::new(&sandbox_root))?;
+
+	if let Ok(relative) = path.strip_prefix(&sandbox_root) {
+		return open_sandbox_private_cache_root(path, &sandbox_root, relative, create).map(Some);
+	}
+
+	let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+	let candidate = manifest
+		.parent()
+		.and_then(Path::parent)
+		.ok_or_else(|| eyre::eyre!("Radar manifest must be inside the candidate repository"))?;
+
+	if let Ok(relative) = path.strip_prefix(candidate) {
+		if create {
+			eyre::bail!(
+				"sandboxed Radar tests cannot create state inside the candidate repository"
+			);
+		}
+
+		return open_sandbox_candidate_cache_root(path, candidate, relative).map(Some);
+	}
+
+	Ok(None)
+}
+
+#[cfg(test)]
+fn open_sandbox_private_cache_root(
+	path: &Path,
+	sandbox_root: &Path,
+	relative: &Path,
+	create: bool,
+) -> Result<PrivateCache> {
+	let metadata = std::fs::symlink_metadata(sandbox_root)?;
+
+	if metadata.file_type().is_symlink() || !metadata.is_dir() {
+		eyre::bail!("sandboxed Radar test root must be a non-symlink directory");
+	}
+	validate_owner_mode_link(
+		metadata.uid(),
+		metadata.mode() & 0o777,
+		metadata.nlink(),
+		PRIVATE_DIR_MODE,
+		"sandboxed test root",
+		false,
+	)?;
+
+	let mut directory = open_directory_path_direct(sandbox_root)?;
+	let sandbox_identity = validate_private_directory(&directory, "sandboxed test root")?;
+
+	if sandbox_identity != (DirectoryIdentity { dev: metadata.dev(), ino: metadata.ino() }) {
+		eyre::bail!("sandboxed Radar test root identity changed during open");
+	}
+	for component in relative_components(relative)? {
+		let name = c_string(&component)?;
+
+		directory = open_or_create_directory(directory.as_raw_fd(), &name, create)?;
+		validate_private_directory(&directory, "sandboxed test directory")?;
+	}
+
+	let root_identity = validate_private_directory(&directory, "root")?;
+
+	Ok(PrivateCache {
+		root_path: path.to_path_buf(),
+		root: directory,
+		root_identity,
+		direct_root: true,
+	})
+}
+
+#[cfg(test)]
+fn open_sandbox_candidate_cache_root(
+	path: &Path,
+	candidate: &Path,
+	relative: &Path,
+) -> Result<PrivateCache> {
+	let metadata = std::fs::symlink_metadata(candidate)?;
+
+	if metadata.file_type().is_symlink() || !metadata.is_dir() {
+		eyre::bail!("sandboxed Radar candidate root must be a non-symlink directory");
+	}
+
+	let mut directory = open_directory_path_direct(candidate)?;
+	let opened = directory.metadata()?;
+
+	if opened.dev() != metadata.dev() || opened.ino() != metadata.ino() {
+		eyre::bail!("sandboxed Radar candidate root identity changed during open");
+	}
+
+	let (_, candidate_components) = absolute_components(candidate)?;
+	let (_, path_components) = absolute_components(path)?;
+	let private_start = cache_private_start(&path_components);
+
+	for (offset, component) in relative_components(relative)?.into_iter().enumerate() {
+		let name = c_string(&component)?;
+
+		directory = open_or_create_directory(directory.as_raw_fd(), &name, false)?;
+		if candidate_components.len() + offset >= private_start {
+			validate_private_directory(&directory, "sandboxed candidate cache directory")?;
+		}
+	}
+
+	let root_identity = validate_private_directory(&directory, "root")?;
+
+	Ok(PrivateCache {
+		root_path: path.to_path_buf(),
+		root: directory,
+		root_identity,
+		direct_root: true,
+	})
 }
 
 fn open_cache_root_file(path: &Path, create: bool) -> Result<File> {
@@ -719,6 +914,76 @@ fn open_directory_at(parent: RawFd, name: &CStr) -> std::io::Result<File> {
 	} else {
 		Ok(unsafe { File::from_raw_fd(fd) })
 	}
+}
+
+#[cfg(test)]
+fn open_directory_path_direct(path: &Path) -> Result<File> {
+	let path = CString::new(path.as_os_str().as_bytes())
+		.map_err(|_| eyre::eyre!("Radar test root path contains NUL"))?;
+	let fd = unsafe {
+		libc::open(
+			path.as_ptr(),
+			libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+		)
+	};
+
+	if fd == -1 {
+		Err(std::io::Error::last_os_error().into())
+	} else {
+		Ok(unsafe { File::from_raw_fd(fd) })
+	}
+}
+
+#[cfg(test)]
+fn open_test_parent_path(path: &Path) -> Result<File> {
+	let (_, components) = absolute_components(path)?;
+	let mut directory = File::open("/")?;
+
+	for component in components {
+		directory = open_directory_at(directory.as_raw_fd(), &c_string(&component)?)?;
+	}
+
+	Ok(directory)
+}
+
+#[cfg(test)]
+fn validate_test_parent_directory(directory: &File) -> Result<DirectoryIdentity> {
+	let metadata = directory.metadata()?;
+
+	if !metadata.is_dir() {
+		eyre::bail!("Radar test parent must be a directory");
+	}
+
+	let permissions = metadata.mode() & 0o777;
+	let private_parent =
+		metadata.uid() == unsafe { libc::geteuid() } && permissions == PRIVATE_DIR_MODE;
+	let system_temporary_parent =
+		metadata.uid() == 0 && permissions == 0o777 && metadata.mode() & 0o1000 == 0o1000;
+
+	if !private_parent && !system_temporary_parent {
+		eyre::bail!(
+			"Radar test parent must be owner-private or a root-owned sticky temporary directory"
+		);
+	}
+
+	Ok(DirectoryIdentity { dev: metadata.dev(), ino: metadata.ino() })
+}
+
+#[cfg(test)]
+fn verify_test_parent_binding(
+	path: &Path,
+	held: &File,
+	expected: &DirectoryIdentity,
+) -> Result<()> {
+	let held_identity = validate_test_parent_directory(held)?;
+	let reopened = open_test_parent_path(path)?;
+	let reopened_identity = validate_test_parent_directory(&reopened)?;
+
+	if &held_identity != expected || &reopened_identity != expected {
+		eyre::bail!("Radar test parent identity changed");
+	}
+
+	Ok(())
 }
 
 fn open_regular_file(parent: RawFd, name: &CStr) -> Result<File> {
@@ -1052,6 +1317,25 @@ fn temporary_name() -> Result<CString> {
 		.map_err(|_| eyre::eyre!("generated Radar temporary name unexpectedly contains NUL"))
 }
 
+#[cfg(test)]
+fn test_temporary_name() -> Result<CString> {
+	let mut nonce = [0_u8; 8];
+
+	getrandom::fill(&mut nonce)
+		.map_err(|error| eyre::eyre!("failed to create a Radar test-directory nonce: {error}"))?;
+	let mut name = String::with_capacity(3 + nonce.len() * 2);
+
+	name.push_str("rt-");
+	for byte in nonce {
+		use std::fmt::Write as _;
+
+		write!(&mut name, "{byte:02x}").expect("writing into a String must not fail");
+	}
+
+	CString::new(name)
+		.map_err(|_| eyre::eyre!("generated Radar test name unexpectedly contains NUL"))
+}
+
 fn unlink_at(parent: RawFd, name: &CStr) -> Result<()> {
 	if unsafe { libc::unlinkat(parent, name.as_ptr(), 0) } == -1 {
 		Err(std::io::Error::last_os_error().into())
@@ -1078,6 +1362,117 @@ fn remove_directory_tree_at(parent: RawFd, name: &CStr) -> Result<()> {
 	}
 
 	Ok(())
+}
+
+#[cfg(test)]
+fn remove_test_directory_contents(directory: &File) -> Result<()> {
+	let duplicate = duplicate_fd(directory.as_raw_fd())?;
+	let stream = unsafe { libc::fdopendir(duplicate) };
+
+	if stream.is_null() {
+		let error = std::io::Error::last_os_error();
+
+		unsafe {
+			libc::close(duplicate);
+		}
+
+		return Err(error.into());
+	}
+
+	let stream = DirectoryStream(stream);
+	let mut entries = Vec::new();
+	loop {
+		let entry = unsafe { libc::readdir(stream.0) };
+
+		if entry.is_null() {
+			break;
+		}
+
+		let child_name = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) };
+		if child_name.to_bytes() == b"." || child_name.to_bytes() == b".." {
+			continue;
+		}
+		let snapshot = file_snapshot_at(directory.as_raw_fd(), child_name)?
+			.ok_or_else(|| eyre::eyre!("Radar test entry changed during cleanup"))?;
+
+		entries.push((child_name.to_owned(), snapshot));
+	}
+	drop(stream);
+
+	for (child_name, expected) in entries {
+		let current = file_snapshot_at(directory.as_raw_fd(), &child_name)?
+			.ok_or_else(|| eyre::eyre!("Radar test entry disappeared during cleanup"))?;
+
+		if current != expected {
+			eyre::bail!("Radar test entry identity changed during cleanup");
+		}
+
+		if expected.file_type == u32::from(libc::S_IFDIR) {
+			let child = open_directory_at(directory.as_raw_fd(), &child_name)?;
+			let identity = directory_identity(&child, "test child directory")?;
+			let expected_identity =
+				DirectoryIdentity { dev: expected.identity.dev, ino: expected.identity.ino };
+
+			if identity != expected_identity {
+				eyre::bail!("Radar test child directory identity changed during cleanup");
+			}
+			remove_test_directory_contents(&child)?;
+			verify_directory_binding_at(
+				directory.as_raw_fd(),
+				&child_name,
+				&expected_identity,
+				"test child directory",
+			)?;
+			if unsafe {
+				libc::unlinkat(directory.as_raw_fd(), child_name.as_ptr(), libc::AT_REMOVEDIR)
+			} == -1
+			{
+				return Err(std::io::Error::last_os_error().into());
+			}
+		} else {
+			let rebound = file_snapshot_at(directory.as_raw_fd(), &child_name)?
+				.ok_or_else(|| eyre::eyre!("Radar test entry disappeared before cleanup"))?;
+
+			if rebound != expected {
+				eyre::bail!("Radar test entry identity changed before cleanup");
+			}
+			unlink_at(directory.as_raw_fd(), &child_name)?;
+		}
+	}
+
+	Ok(())
+}
+
+#[cfg(test)]
+fn verify_directory_binding_at(
+	parent: RawFd,
+	name: &CStr,
+	expected: &DirectoryIdentity,
+	label: &str,
+) -> Result<()> {
+	let snapshot = file_snapshot_at(parent, name)?
+		.ok_or_else(|| eyre::eyre!("Radar {label} disappeared during cleanup"))?;
+	let current = DirectoryIdentity { dev: snapshot.identity.dev, ino: snapshot.identity.ino };
+
+	if snapshot.file_type != u32::from(libc::S_IFDIR) || &current != expected {
+		eyre::bail!("Radar {label} identity changed during cleanup");
+	}
+
+	Ok(())
+}
+
+#[cfg(test)]
+fn directory_identity(directory: &File, label: &str) -> Result<DirectoryIdentity> {
+	let metadata = directory.metadata()?;
+
+	if !metadata.is_dir() {
+		eyre::bail!("Radar {label} must remain a directory");
+	}
+	if metadata.uid() != unsafe { libc::geteuid() } {
+		eyre::bail!("Radar {label} must remain owned by the current user");
+	}
+
+	Ok(DirectoryIdentity { dev: metadata.dev(), ino: metadata.ino() })
 }
 
 fn c_string(value: &OsStr) -> Result<CString> {
@@ -1313,6 +1708,77 @@ pub(crate) fn ensure_private_directory(path: &Path) -> Result<()> {
 	drop(PrivateCache::open_or_create(path)?);
 
 	Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn create_private_test_directory(parent_path: &Path) -> Result<PrivateTestDirectory> {
+	create_private_test_directory_with(parent_path, || {})
+}
+
+#[cfg(test)]
+pub(crate) fn create_private_test_directory_with(
+	parent_path: &Path,
+	after_parent_open: impl FnOnce(),
+) -> Result<PrivateTestDirectory> {
+	let resolved_parent = parent_path.canonicalize()?;
+	let parent = open_test_parent_path(&resolved_parent)?;
+	let parent_identity = validate_test_parent_directory(&parent)?;
+
+	verify_test_parent_binding(&resolved_parent, &parent, &parent_identity)?;
+	after_parent_open();
+	verify_test_parent_binding(&resolved_parent, &parent, &parent_identity)?;
+
+	let name = test_temporary_name()?;
+	if unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), PRIVATE_DIR_MODE as libc::mode_t) }
+		== -1
+	{
+		return Err(std::io::Error::last_os_error().into());
+	}
+
+	let result = (|| -> Result<(PathBuf, File, DirectoryIdentity)> {
+		let directory = open_directory_at(parent.as_raw_fd(), &name)?;
+		let identity = validate_private_directory(&directory, "test directory")?;
+
+		parent.sync_all()?;
+		verify_test_parent_binding(&resolved_parent, &parent, &parent_identity)?;
+
+		let name = OsStr::from_bytes(name.to_bytes());
+
+		Ok((resolved_parent.join(name), directory, identity))
+	})();
+
+	match result {
+		Ok((path, directory, identity)) => Ok(PrivateTestDirectory {
+			parent_path: resolved_parent,
+			parent,
+			parent_identity,
+			name,
+			path,
+			directory,
+			identity,
+		}),
+		Err(error) => {
+			if let Ok(directory) = open_directory_at(parent.as_raw_fd(), &name)
+				&& let Ok(identity) = directory_identity(&directory, "partial test directory")
+			{
+				let _ = remove_test_directory_contents(&directory);
+				if verify_directory_binding_at(
+					parent.as_raw_fd(),
+					&name,
+					&identity,
+					"partial test directory",
+				)
+				.is_ok()
+				{
+					unsafe {
+						libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR);
+					}
+				}
+			}
+
+			Err(error)
+		},
+	}
 }
 
 #[cfg(test)]

--- a/apps/radar/src/test_support.rs
+++ b/apps/radar/src/test_support.rs
@@ -1,8 +1,4 @@
-use std::{
-	os::unix::fs::PermissionsExt as _,
-	path::PathBuf,
-	sync::{Mutex, MutexGuard, OnceLock},
-};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
 pub(crate) struct TestEnvLockGuard {
 	_lock: MutexGuard<'static, ()>,
@@ -14,22 +10,133 @@ pub(crate) fn lock_test_env() -> TestEnvLockGuard {
 	}
 }
 
-pub(crate) fn private_tempdir() -> tempfile::TempDir {
-	let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-	let workspace = manifest
-		.parent()
-		.and_then(std::path::Path::parent)
-		.expect("Radar manifest must be inside the workspace");
-	let parent = workspace.join("target/radar-private-tests");
-
-	std::fs::create_dir_all(&parent).expect("private test root should be created");
-	std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o700))
-		.expect("private test root should be owner-only");
-	tempfile::tempdir_in(parent).expect("private temporary directory should be created")
+pub(crate) fn private_tempdir() -> crate::private_fs::PrivateTestDirectory {
+	crate::private_fs::create_private_test_directory(&std::env::temp_dir())
+		.expect("private temporary directory should be created")
 }
 
 fn test_env_mutex() -> &'static Mutex<()> {
 	static TEST_ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
 
 	TEST_ENV_MUTEX.get_or_init(|| Mutex::new(()))
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		fs,
+		os::unix::fs::{MetadataExt as _, PermissionsExt as _},
+	};
+
+	use super::private_tempdir;
+
+	fn private_fixture_directory(path: &std::path::Path) {
+		fs::create_dir(path).expect("fixture directory should be created");
+		fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+			.expect("fixture directory should be private");
+	}
+
+	#[test]
+	fn private_tempdir_is_private_and_removes_unsafe_test_entries() {
+		let temporary = private_tempdir();
+		let path = temporary.path().to_path_buf();
+		let file = path.join("ordinary");
+		let link = path.join("link");
+
+		fs::write(&file, b"fixture").expect("fixture file should be written");
+		std::os::unix::fs::symlink(&file, &link).expect("fixture link should be created");
+		assert_eq!(fs::metadata(&path).expect("temporary root metadata").mode() & 0o777, 0o700);
+
+		drop(temporary);
+		assert!(!path.exists());
+	}
+
+	#[test]
+	fn private_tempdir_accepts_standard_public_tmp_parent() {
+		if std::env::var_os("DECODEX_CANDIDATE_SANDBOX").as_deref()
+			== Some(std::ffi::OsStr::new("1"))
+		{
+			return;
+		}
+
+		let temporary =
+			crate::private_fs::create_private_test_directory(std::path::Path::new("/tmp"))
+				.expect("standard public temporary parent should be accepted");
+		let path = temporary.path().to_path_buf();
+
+		assert_eq!(fs::metadata(&path).expect("temporary root metadata").mode() & 0o777, 0o700);
+		drop(temporary);
+		assert!(!path.exists());
+	}
+
+	#[test]
+	fn private_tempdir_rejects_non_private_parent_and_resolves_private_symlink() {
+		let fixture = private_tempdir();
+		let open_parent = fixture.path().join("open-parent");
+		let private_parent = fixture.path().join("private-parent");
+		let linked_parent = fixture.path().join("linked-parent");
+
+		fs::create_dir(&open_parent).expect("open parent should be created");
+		fs::set_permissions(&open_parent, fs::Permissions::from_mode(0o755))
+			.expect("open parent mode should be set");
+		private_fixture_directory(&private_parent);
+		std::os::unix::fs::symlink(&private_parent, &linked_parent)
+			.expect("parent symlink should be created");
+
+		assert!(crate::private_fs::create_private_test_directory(&open_parent).is_err());
+		let linked = crate::private_fs::create_private_test_directory(&linked_parent)
+			.expect("a canonicalized private parent symlink should be accepted");
+		let path = linked.path().to_path_buf();
+
+		drop(linked);
+		assert!(!path.exists());
+	}
+
+	#[test]
+	fn private_tempdir_detects_parent_replacement_without_writing_to_replacement() {
+		let fixture = private_tempdir();
+		let parent = fixture.path().join("parent");
+		let displaced = fixture.path().join("displaced");
+
+		private_fixture_directory(&parent);
+		let replacement = parent.clone();
+		let error = crate::private_fs::create_private_test_directory_with(&parent, || {
+			fs::rename(&replacement, &displaced).expect("parent should be displaced");
+			private_fixture_directory(&replacement);
+		})
+		.expect_err("parent replacement must fail closed");
+
+		assert!(
+			error.to_string().contains("parent identity changed"),
+			"unexpected replacement error: {error:?}"
+		);
+		assert_eq!(fs::read_dir(&parent).expect("replacement should be readable").count(), 0);
+		assert_eq!(fs::read_dir(&displaced).expect("displaced root should be readable").count(), 0);
+	}
+
+	#[test]
+	fn private_tempdir_cleanup_does_not_remove_a_replacement_directory() {
+		let fixture = private_tempdir();
+		let temporary = crate::private_fs::create_private_test_directory(fixture.path())
+			.expect("nested temporary directory should be created");
+		let path = temporary.path().to_path_buf();
+		let displaced = fixture.path().join("displaced-cleanup-root");
+		let marker = path.join("replacement-marker");
+		let error = temporary
+			.remove_with_before_unlink(|| {
+				fs::rename(&path, &displaced).expect("test directory should be displaced");
+				private_fixture_directory(&path);
+				fs::write(&marker, b"replacement").expect("replacement marker should be written");
+			})
+			.expect_err("cleanup must reject a replacement binding");
+
+		assert!(error.to_string().contains("identity changed"));
+		assert_eq!(fs::read(&marker).expect("replacement marker should remain"), b"replacement");
+
+		fs::remove_file(&marker).expect("replacement marker should be removed");
+		fs::remove_dir(&path).expect("replacement directory should be removed");
+		fs::rename(&displaced, &path).expect("original directory binding should be restored");
+		drop(temporary);
+		assert!(!path.exists());
+	}
 }

--- a/apps/radar/src/tests/automation/content_pair.rs
+++ b/apps/radar/src/tests/automation/content_pair.rs
@@ -318,7 +318,7 @@ fn cache_gc_recovers_an_interrupted_temporary_pair_directory() {
 	assert!(!temporary.exists());
 }
 
-fn fresh_cache() -> (tempfile::TempDir, std::path::PathBuf) {
+fn fresh_cache() -> (crate::private_fs::PrivateTestDirectory, std::path::PathBuf) {
 	let temp = crate::test_support::private_tempdir();
 	let cache_root = temp.path().join(crate::DEFAULT_CACHE_ROOT);
 

--- a/apps/radar/src/tests/automation/content_review.rs
+++ b/apps/radar/src/tests/automation/content_review.rs
@@ -205,7 +205,7 @@ fn selection_and_report_creation_hold_one_cache_lock() {
 	assert_no_authoritative_artifacts(&cache_root);
 }
 
-fn fresh_cache() -> (tempfile::TempDir, std::path::PathBuf) {
+fn fresh_cache() -> (crate::private_fs::PrivateTestDirectory, std::path::PathBuf) {
 	let temp_dir = crate::test_support::private_tempdir();
 	let cache_root = temp_dir.path().join(crate::DEFAULT_CACHE_ROOT);
 

--- a/apps/radar/src/tests/automation/github_api.rs
+++ b/apps/radar/src/tests/automation/github_api.rs
@@ -1,7 +1,14 @@
 use std::{
+	collections::VecDeque,
 	io::{Read as _, Write as _},
-	net::TcpListener,
+	os::unix::net::UnixListener,
+	path::PathBuf,
+	sync::{
+		Arc, Mutex,
+		atomic::{AtomicBool, Ordering},
+	},
 	thread,
+	time::Duration,
 };
 
 use crate::GitHubApi;
@@ -9,36 +16,36 @@ use crate::GitHubApi;
 #[test]
 fn retries_truncated_success_body_for_idempotent_get() {
 	let valid_body = r#"{"ok":true}"#;
-	let (url, server) = spawn_server(vec![
+	let server = spawn_server(vec![
 		format!(
 			"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 32\r\nConnection: close\r\n\r\n{{}}"
 		),
 		response("200 OK", &[], valid_body),
 	]);
-	let api = GitHubApi::new_for_test(None, &url).expect("GitHub API client should build");
-	let response = api.get(&url).expect("truncated body should be retried");
+	let api = server.api(None);
+	let response = api.get(server.url()).expect("truncated body should be retried");
 
 	assert_eq!(response.payload["ok"], true);
-	server.join().expect("test server should finish");
+	server.finish();
 }
 
 #[test]
 fn retries_invalid_json_for_idempotent_get() {
-	let (url, server) = spawn_server(vec![
+	let server = spawn_server(vec![
 		response("200 OK", &[], r#"{"incomplete":"#),
 		response("200 OK", &[], r#"{"ok":true}"#),
 	]);
-	let api = GitHubApi::new_for_test(None, &url).expect("GitHub API client should build");
-	let response = api.get(&url).expect("invalid JSON should be retried");
+	let api = server.api(None);
+	let response = api.get(server.url()).expect("invalid JSON should be retried");
 
 	assert_eq!(response.payload["ok"], true);
-	server.join().expect("test server should finish");
+	server.finish();
 }
 
 #[test]
 fn reports_structured_rate_limit_without_retrying() {
 	let body = r#"{"message":"API rate limit exceeded for test address."}"#;
-	let (url, server) = spawn_server(vec![response(
+	let server = spawn_server(vec![response(
 		"403 Forbidden",
 		&[
 			("X-RateLimit-Remaining", "0"),
@@ -47,8 +54,8 @@ fn reports_structured_rate_limit_without_retrying() {
 		],
 		body,
 	)]);
-	let api = GitHubApi::new_for_test(None, &url).expect("GitHub API client should build");
-	let error = api.get(&url).expect_err("rate limit must fail without retry");
+	let api = server.api(None);
+	let error = api.get(server.url()).expect_err("rate limit must fail without retry");
 	let message = error.to_string();
 
 	assert!(message.contains("GitHub API rate limit exceeded"));
@@ -57,7 +64,7 @@ fn reports_structured_rate_limit_without_retrying() {
 	assert!(message.contains("remaining=0"));
 	assert!(message.contains("reset_epoch=1785132000"));
 	assert!(message.contains("retry_after=120"));
-	server.join().expect("single-response server proves there was no retry");
+	server.finish();
 }
 
 #[test]
@@ -72,43 +79,44 @@ fn production_client_requires_the_exact_https_github_api_origin() {
 
 #[test]
 fn pagination_rejects_cross_origin_links_before_forwarding_credentials() {
-	let adversary = TcpListener::bind("127.0.0.1:0").expect("adversary listener should bind");
-	let adversary_url =
-		format!("http://{}/capture", adversary.local_addr().expect("address should exist"));
-	let (url, server) = spawn_server(vec![response(
+	let adversary_url = "http://adversary.test/capture";
+	let server = spawn_server(vec![response(
 		"200 OK",
 		&[("Link", &format!("<{adversary_url}>; rel=\"next\""))],
 		"[]",
 	)]);
-	let api = GitHubApi::new_for_test(Some("test-secret".into()), &url)
-		.expect("GitHub API client should build");
-	let error =
-		api.get_paginated_for_test(&url, 10, 100).expect_err("cross-origin pagination must fail");
+	let api = server.api(Some("test-secret".into()));
+	let error = api
+		.get_paginated_for_test(server.url(), 10, 100)
+		.expect_err("cross-origin pagination must fail");
 
 	assert!(error.to_string().contains("pinned origin"));
-	server.join().expect("trusted server should finish");
-	adversary.set_nonblocking(true).expect("adversary listener should become nonblocking");
-	assert!(
-		adversary.accept().is_err_and(|error| error.kind() == std::io::ErrorKind::WouldBlock),
-		"cross-origin target must receive no request"
-	);
+	let requests = server.finish_with_requests();
+
+	assert_eq!(requests.len(), 1, "cross-origin pagination must not send a second request");
+	let request = requests[0].to_ascii_lowercase();
+
+	assert!(request.contains("host: github.test"));
+	assert!(request.contains("authorization: bearer test-secret"));
+	assert!(!request.contains("adversary.test"));
 }
 
 #[test]
 fn pagination_detects_cycles_without_repeating_a_request() {
-	let (url, server) = spawn_server_with(1, |url, _| {
+	let server = spawn_server_with(1, |url, _| {
 		response("200 OK", &[("Link", &format!("<{url}>; rel=\"next\""))], "[]")
 	});
-	let api = GitHubApi::new_for_test(None, &url).expect("GitHub API client should build");
-	let error = api.get_paginated_for_test(&url, 10, 100).expect_err("cyclic pagination must fail");
+	let api = server.api(None);
+	let error =
+		api.get_paginated_for_test(server.url(), 10, 100).expect_err("cyclic pagination must fail");
 
 	assert!(error.to_string().contains("cycle detected"));
-	server.join().expect("one request proves the cycle was not followed");
+	server.finish();
 }
 
 #[test]
 fn pagination_enforces_page_and_item_limits() {
-	let (page_url, page_server) = spawn_server_with(2, |url, index| {
+	let page_server = spawn_server_with(2, |url, index| {
 		let next = if index == 0 {
 			url.replace("/test", "/page-2")
 		} else {
@@ -117,63 +125,112 @@ fn pagination_enforces_page_and_item_limits() {
 
 		response("200 OK", &[("Link", &format!("<{next}>; rel=\"next\""))], "[]")
 	});
-	let page_api =
-		GitHubApi::new_for_test(None, &page_url).expect("GitHub API client should build");
+	let page_api = page_server.api(None);
 	let page_error = page_api
-		.get_paginated_for_test(&page_url, 2, 100)
+		.get_paginated_for_test(page_server.url(), 2, 100)
 		.expect_err("third page must exceed the bound");
 
 	assert!(page_error.to_string().contains("2-page limit"));
-	page_server.join().expect("bounded page server should finish");
+	page_server.finish();
 
-	let (item_url, item_server) = spawn_server(vec![response("200 OK", &[], "[1,2,3]")]);
-	let item_api =
-		GitHubApi::new_for_test(None, &item_url).expect("GitHub API client should build");
+	let item_server = spawn_server(vec![response("200 OK", &[], "[1,2,3]")]);
+	let item_api = item_server.api(None);
 	let item_error = item_api
-		.get_paginated_for_test(&item_url, 2, 2)
+		.get_paginated_for_test(item_server.url(), 2, 2)
 		.expect_err("oversized item page must exceed the bound");
 
 	assert!(item_error.to_string().contains("2-item limit"));
-	item_server.join().expect("bounded item server should finish");
+	item_server.finish();
 }
 
-fn spawn_server(responses: Vec<String>) -> (String, thread::JoinHandle<()>) {
-	let listener = TcpListener::bind("127.0.0.1:0").expect("test listener should bind");
-	let address = listener.local_addr().expect("test listener should have an address");
-	let server = thread::spawn(move || {
-		for response in responses {
-			let (mut stream, _) = listener.accept().expect("test request should connect");
-			let mut request = [0_u8; 4096];
-			let _ = stream.read(&mut request);
+struct TestServer {
+	_directory: crate::private_fs::PrivateTestDirectory,
+	socket: PathBuf,
+	thread: thread::JoinHandle<()>,
+	requests: Arc<Mutex<Vec<String>>>,
+	stop: Arc<AtomicBool>,
+	url: String,
+}
+impl TestServer {
+	fn api(&self, token: Option<String>) -> GitHubApi {
+		GitHubApi::new_for_test(token, &self.url, &self.socket)
+			.expect("GitHub API client should build")
+	}
 
-			stream.write_all(response.as_bytes()).expect("test response should write");
-			stream.flush().expect("test response should flush");
-		}
-	});
+	fn finish(self) {
+		drop(self.finish_with_requests());
+	}
 
-	(format!("http://{address}/test"), server)
+	fn finish_with_requests(self) -> Vec<String> {
+		self.stop.store(true, Ordering::Release);
+		self.thread.join().expect("test server should finish");
+		self.requests.lock().expect("request log should not be poisoned").clone()
+	}
+
+	fn url(&self) -> &str {
+		&self.url
+	}
 }
 
-fn spawn_server_with(
-	response_count: usize,
-	builder: impl Fn(&str, usize) -> String,
-) -> (String, thread::JoinHandle<()>) {
-	let listener = TcpListener::bind("127.0.0.1:0").expect("test listener should bind");
-	let address = listener.local_addr().expect("test listener should have an address");
-	let url = format!("http://{address}/test");
-	let responses = (0..response_count).map(|index| builder(&url, index)).collect::<Vec<_>>();
-	let server = thread::spawn(move || {
-		for response in responses {
-			let (mut stream, _) = listener.accept().expect("test request should connect");
-			let mut request = [0_u8; 4096];
-			let _ = stream.read(&mut request);
+fn spawn_server(responses: Vec<String>) -> TestServer {
+	spawn_server_responses(responses)
+}
 
-			stream.write_all(response.as_bytes()).expect("test response should write");
-			stream.flush().expect("test response should flush");
+fn spawn_server_responses(responses: Vec<String>) -> TestServer {
+	let directory = crate::test_support::private_tempdir();
+	let socket = directory.path().join("g.sock");
+	let listener = UnixListener::bind(&socket).expect("test listener should bind");
+	listener.set_nonblocking(true).expect("test listener should become nonblocking");
+	let url = "http://github.test/test".to_owned();
+	let requests = Arc::new(Mutex::new(Vec::new()));
+	let server_requests = Arc::clone(&requests);
+	let stop = Arc::new(AtomicBool::new(false));
+	let server_stop = Arc::clone(&stop);
+	let server = thread::spawn(move || {
+		let mut responses = VecDeque::from(responses);
+
+		loop {
+			match listener.accept() {
+				Ok((mut stream, _)) => {
+					stream
+						.set_nonblocking(false)
+						.expect("accepted test stream should become blocking");
+					let mut request = [0_u8; 4096];
+					let read = stream.read(&mut request).expect("test request should be readable");
+
+					server_requests
+						.lock()
+						.expect("request log should not be poisoned")
+						.push(String::from_utf8_lossy(&request[..read]).into_owned());
+
+					let response = responses.pop_front().unwrap_or_else(|| {
+						response("500 Internal Server Error", &[], r#"{"unexpected":true}"#)
+					});
+
+					stream.write_all(response.as_bytes()).expect("test response should write");
+					stream.flush().expect("test response should flush");
+				},
+				Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+					if server_stop.load(Ordering::Acquire) {
+						break;
+					}
+					thread::sleep(Duration::from_millis(1));
+				},
+				Err(error) => panic!("test request should connect: {error}"),
+			}
 		}
+
+		assert!(responses.is_empty(), "test server did not receive all expected requests");
 	});
 
-	(url, server)
+	TestServer { _directory: directory, socket, thread: server, requests, stop, url }
+}
+
+fn spawn_server_with(response_count: usize, builder: impl Fn(&str, usize) -> String) -> TestServer {
+	let url = "http://github.test/test";
+	let responses = (0..response_count).map(|index| builder(url, index)).collect::<Vec<_>>();
+
+	spawn_server_responses(responses)
 }
 
 fn response(status: &str, headers: &[(&str, &str)], body: &str) -> String {

--- a/apps/radar/src/tests/automation/ledger/ledger_bounds_are_enforced_at_write_time.rs
+++ b/apps/radar/src/tests/automation/ledger/ledger_bounds_are_enforced_at_write_time.rs
@@ -99,7 +99,7 @@ fn ledger_writer_prunes_oldest_rows_before_commit() {
 	connection.close().expect("bounded ledger should close");
 }
 
-fn private_temp_dir() -> tempfile::TempDir {
+fn private_temp_dir() -> crate::private_fs::PrivateTestDirectory {
 	let temp_dir = crate::test_support::private_tempdir();
 
 	std::fs::set_permissions(temp_dir.path(), std::fs::Permissions::from_mode(0o700))

--- a/automations/decodex/scripts/config/tests/test_upstream_automation_config.py
+++ b/automations/decodex/scripts/config/tests/test_upstream_automation_config.py
@@ -674,7 +674,15 @@ class UpstreamAutomationConfigTests(unittest.TestCase):
 		self.assertNotIn("--codex-home", help_result.stdout)
 
 		with tempfile.TemporaryDirectory() as directory:
-			codex_home = Path(directory)
+			temp_root = Path(directory)
+			codex_home = temp_root / "codex-home"
+			repo_root = temp_root / "primary"
+			subprocess.run(
+				["git", "init", "--initial-branch=main", str(repo_root)],
+				check=True,
+				capture_output=True,
+				text=True,
+			)
 			runtime = (
 				codex_home
 				/ "automations"
@@ -691,7 +699,13 @@ class UpstreamAutomationConfigTests(unittest.TestCase):
 			environment["CODEX_HOME"] = str(codex_home)
 
 			result = subprocess.run(
-				[sys.executable, str(plan_script), "--json"],
+				[
+					sys.executable,
+					str(plan_script),
+					"--repo-root",
+					str(repo_root),
+					"--json",
+				],
 				check=True,
 				capture_output=True,
 				text=True,
@@ -702,6 +716,13 @@ class UpstreamAutomationConfigTests(unittest.TestCase):
 			self.assertEqual(payload["status"], "pass")
 			self.assertEqual(payload["mode"], "native-lifecycle-plan")
 			self.assertEqual(len(payload["definitions"]), 5)
+			self.assertEqual(
+				{
+					tuple(item["native_fields"]["cwds"])
+					for item in payload["definitions"]
+				},
+				{(str(repo_root.resolve()),)},
+			)
 			self.assertEqual(
 				payload["retirements"],
 				["decodex-x-browser-publisher"],

--- a/automations/upstream/README.md
+++ b/automations/upstream/README.md
@@ -156,6 +156,9 @@ bounded test IDs, exception classes, reason codes, and counts. It never stores r
 command output, absolute paths, credentials, email addresses, or private prose. The
 failed command returns the stable cause digest as its `error_digest`. The named
 artifact is the unambiguous local lookup for that cause.
+If candidate output contamination or cleanup also fails, the command keeps the
+profile failure as `error_code` and returns the additional bounded reason in
+`related_error_codes`.
 Maintainer and Health read it only through
 `run_upstream_autopilot validation-diagnostic --error-digest <digest> --json`, which
 revalidates the cause identity and the separate artifact digest. Maintainer passes

--- a/automations/upstream/prompts/maintainer.md
+++ b/automations/upstream/prompts/maintainer.md
@@ -209,7 +209,9 @@ Workflow:
     succeeds. Preserve the branch for Reviewer. On failure, use `block` with a
     bounded reason code and the exact `error_digest` returned by the wrapper when a
     bounded validation diagnostic exists. Do not replace, recompute, or omit that
-    digest. Accept `auto_repair_pending` only
+    digest. Preserve any `related_error_codes` in the bounded run report and treat
+    candidate-output change or cleanup failures as automation repair evidence.
+    Accept `auto_repair_pending` only
     when its repair candidate IDs are present in the persisted readback. Do not
     store raw logs, prompts, paths, credentials, identities, or upstream prose.
 

--- a/automations/upstream/scripts/upstream_autopilot_lib/cli.py
+++ b/automations/upstream/scripts/upstream_autopilot_lib/cli.py
@@ -2012,6 +2012,10 @@ def main() -> int:
         fields: dict[str, Any] = {"error_code": error.code}
         if error.diagnostic_sha256 is not None:
             fields["error_digest"] = error.diagnostic_sha256
+        if error.related_error_codes:
+            fields["related_error_codes"] = list(
+                error.related_error_codes
+            )
         payload = result_payload("failed", **fields)
         print(
             json.dumps(

--- a/automations/upstream/scripts/upstream_autopilot_lib/core.py
+++ b/automations/upstream/scripts/upstream_autopilot_lib/core.py
@@ -247,6 +247,7 @@ class AutopilotError(RuntimeError):
         code: str,
         *,
         diagnostic_sha256: str | None = None,
+        related_error_codes: tuple[str, ...] = (),
     ) -> None:
         if not REASON_PATTERN.fullmatch(code):
             code = "unclassified_failure"
@@ -256,7 +257,21 @@ class AutopilotError(RuntimeError):
             diagnostic_sha256 = None
         self.code = code
         self.diagnostic_sha256 = diagnostic_sha256
+        self.related_error_codes: tuple[str, ...] = ()
+        for related_code in related_error_codes:
+            self.add_related_error_code(related_code)
         super().__init__(code)
+
+    def add_related_error_code(self, code: str) -> None:
+        """Attach one bounded secondary failure without masking the primary."""
+
+        if REASON_PATTERN.fullmatch(code) is None:
+            code = "unclassified_failure"
+        if code == self.code or code in self.related_error_codes:
+            return
+        self.related_error_codes = tuple(
+            sorted((*self.related_error_codes, code))
+        )[:4]
 
 
 class CommandFailure(AutopilotError):

--- a/automations/upstream/scripts/upstream_autopilot_lib/validation.py
+++ b/automations/upstream/scripts/upstream_autopilot_lib/validation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from dataclasses import dataclass
 import fcntl
 import json
 import os
@@ -118,6 +119,10 @@ SANDBOX_EVIDENCE_KEYS = {
 FORMATTER_TOOLCHAIN = "nightly-2026-07-16"
 VALIDATION_TEMP_PREFIX = "dxv-"
 DARWIN_VALIDATION_TEMP_PARENT = Path("/private/tmp")
+CANDIDATE_OUTPUT_ENV = "DECODEX_VALIDATION_REPO_OUTPUT"
+CANDIDATE_OUTPUT_NAME_PATTERN = re.compile(
+    r"decodex-validation-[0-9a-f]{32}"
+)
 VALIDATION_DIAGNOSTIC_SCHEMA = (
     "decodex/codex-upstream-validation-diagnostic/2"
 )
@@ -2029,10 +2034,316 @@ def prepare_dependency_cache(
     )
 
 
+@dataclass(frozen=True)
+class PinnedCandidateOutput:
+    """Descriptor-pinned candidate-local validation output."""
+
+    path: Path
+    name: str
+    candidate_descriptor: int
+    target_descriptor: int
+    output_descriptor: int
+
+
+def _candidate_output_identity(
+    parent_descriptor: int,
+    name: str,
+    *,
+    failure_code: str,
+) -> tuple[int, int]:
+    try:
+        metadata = os.stat(
+            name,
+            dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+    except OSError as error:
+        raise AutopilotError(failure_code) from error
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != os.getuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise AutopilotError(failure_code)
+    return metadata.st_dev, metadata.st_ino
+
+
+def _verify_pinned_directory(
+    parent_descriptor: int,
+    name: str,
+    descriptor: int,
+    *,
+    exact_mode: int | None,
+    failure_code: str,
+) -> None:
+    try:
+        pinned = os.fstat(descriptor)
+        current = os.stat(
+            name,
+            dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+    except OSError as error:
+        raise AutopilotError(failure_code) from error
+    pinned_mode = stat.S_IMODE(pinned.st_mode)
+    current_mode = stat.S_IMODE(current.st_mode)
+    if (
+        not stat.S_ISDIR(pinned.st_mode)
+        or not stat.S_ISDIR(current.st_mode)
+        or pinned.st_uid != os.getuid()
+        or current.st_uid != os.getuid()
+        or pinned_mode & 0o022
+        or current_mode & 0o022
+        or (exact_mode is not None and pinned_mode != exact_mode)
+        or (exact_mode is not None and current_mode != exact_mode)
+        or (pinned.st_dev, pinned.st_ino)
+        != (current.st_dev, current.st_ino)
+    ):
+        raise AutopilotError(failure_code)
+
+
+def _verify_candidate_output_directory(
+    output: PinnedCandidateOutput,
+    *,
+    changed: bool,
+) -> None:
+    failure_code = (
+        "validation_candidate_output_changed"
+        if changed
+        else "validation_candidate_output_invalid"
+    )
+    _verify_pinned_directory(
+        output.candidate_descriptor,
+        "target",
+        output.target_descriptor,
+        exact_mode=None,
+        failure_code=failure_code,
+    )
+    _verify_pinned_directory(
+        output.target_descriptor,
+        output.name,
+        output.output_descriptor,
+        exact_mode=0o700,
+        failure_code=failure_code,
+    )
+
+
+def _verify_candidate_output_empty(
+    output: PinnedCandidateOutput,
+    *,
+    changed: bool,
+) -> None:
+    _verify_candidate_output_directory(output, changed=changed)
+    failure_code = (
+        "validation_candidate_output_changed"
+        if changed
+        else "validation_candidate_output_invalid"
+    )
+    try:
+        entries = os.listdir(output.output_descriptor)
+    except OSError as error:
+        raise AutopilotError(failure_code) from error
+    if entries:
+        raise AutopilotError(failure_code)
+
+
+@contextmanager
+def pinned_candidate_output_directory(
+    worktree: Path,
+) -> Iterator[PinnedCandidateOutput]:
+    """Pin the only candidate-local directory writable during validation."""
+
+    candidate = worktree.resolve()
+    candidate_descriptor: int | None = None
+    target_descriptor: int | None = None
+    output_descriptor: int | None = None
+    output: PinnedCandidateOutput | None = None
+    output_created = False
+    output_identity: tuple[int, int] | None = None
+    output_name = f"decodex-validation-{secrets.token_hex(16)}"
+    try:
+        candidate_descriptor = os.open(
+            candidate,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+        try:
+            os.mkdir(
+                "target",
+                mode=0o700,
+                dir_fd=candidate_descriptor,
+            )
+        except FileExistsError:
+            pass
+        target_descriptor = os.open(
+            "target",
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            dir_fd=candidate_descriptor,
+        )
+        _verify_pinned_directory(
+            candidate_descriptor,
+            "target",
+            target_descriptor,
+            exact_mode=None,
+            failure_code="validation_candidate_output_invalid",
+        )
+        os.mkdir(
+            output_name,
+            mode=0o700,
+            dir_fd=target_descriptor,
+        )
+        output_created = True
+        output_identity = _candidate_output_identity(
+            target_descriptor,
+            output_name,
+            failure_code="validation_candidate_output_invalid",
+        )
+        output_descriptor = os.open(
+            output_name,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            dir_fd=target_descriptor,
+        )
+        output = PinnedCandidateOutput(
+            path=candidate / "target" / output_name,
+            name=output_name,
+            candidate_descriptor=candidate_descriptor,
+            target_descriptor=target_descriptor,
+            output_descriptor=output_descriptor,
+        )
+        _verify_candidate_output_empty(
+            output,
+            changed=False,
+        )
+        yield output
+    except AutopilotError:
+        raise
+    except OSError as error:
+        raise AutopilotError(
+            "validation_candidate_output_invalid"
+        ) from error
+    finally:
+        active_error = sys.exception()
+        cleanup_error: BaseException | None = None
+        if output_created and target_descriptor is not None:
+            try:
+                if output is not None:
+                    _verify_pinned_directory(
+                        output.target_descriptor,
+                        output.name,
+                        output.output_descriptor,
+                        exact_mode=0o700,
+                        failure_code=(
+                            "validation_candidate_output_cleanup_failed"
+                        ),
+                    )
+                elif output_identity is None or (
+                    _candidate_output_identity(
+                        target_descriptor,
+                        output_name,
+                        failure_code=(
+                            "validation_candidate_output_cleanup_failed"
+                        ),
+                    )
+                    != output_identity
+                ):
+                    raise AutopilotError(
+                        "validation_candidate_output_cleanup_failed"
+                    )
+                if not shutil.rmtree.avoids_symlink_attacks:
+                    raise OSError("descriptor-safe rmtree unavailable")
+                shutil.rmtree(
+                    output_name,
+                    dir_fd=target_descriptor,
+                )
+            except OSError as error:
+                cleanup_error = error
+            except AutopilotError as error:
+                cleanup_error = error
+        if output_descriptor is not None:
+            os.close(output_descriptor)
+        if target_descriptor is not None:
+            os.close(target_descriptor)
+        if candidate_descriptor is not None:
+            os.close(candidate_descriptor)
+        if cleanup_error is not None:
+            if isinstance(active_error, AutopilotError):
+                active_error.add_related_error_code(
+                    "validation_candidate_output_cleanup_failed"
+                )
+            elif active_error is not None:
+                active_error.add_note(
+                    "validation_candidate_output_cleanup_failed"
+                )
+            else:
+                raise AutopilotError(
+                    "validation_candidate_output_cleanup_failed"
+                ) from cleanup_error
+
+
+def _validation_profile_failure(
+    repo_root: Path,
+    candidate_output: PinnedCandidateOutput,
+    *,
+    profile: str,
+    repository_head: str,
+    repository_tree: str,
+    failure: CommandFailure,
+) -> AutopilotError:
+    diagnostic_sha256 = write_validation_failure_diagnostic(
+        repo_root,
+        profile=profile,
+        repository_head=repository_head,
+        repository_tree=repository_tree,
+        failure=failure,
+    )
+    result = AutopilotError(
+        failure.code,
+        diagnostic_sha256=diagnostic_sha256,
+    )
+    try:
+        _verify_candidate_output_empty(
+            candidate_output,
+            changed=True,
+        )
+    except AutopilotError as related:
+        result.add_related_error_code(related.code)
+    return result
+
+
+def _validate_candidate_output_path(
+    candidate: Path,
+    output: Path,
+) -> None:
+    expected_parent = candidate / "target"
+    if (
+        output.parent != expected_parent
+        or CANDIDATE_OUTPUT_NAME_PATTERN.fullmatch(output.name) is None
+    ):
+        raise AutopilotError(
+            "validation_candidate_output_invalid"
+        )
+    try:
+        target_metadata = expected_parent.lstat()
+        output_metadata = output.lstat()
+    except OSError as error:
+        raise AutopilotError(
+            "validation_candidate_output_invalid"
+        ) from error
+    if (
+        not stat.S_ISDIR(target_metadata.st_mode)
+        or not stat.S_ISDIR(output_metadata.st_mode)
+        or target_metadata.st_uid != os.getuid()
+        or output_metadata.st_uid != os.getuid()
+        or target_metadata.st_mode & 0o022
+        or stat.S_IMODE(output_metadata.st_mode) != 0o700
+    ):
+        raise AutopilotError("validation_candidate_output_invalid")
+
+
 def validation_sandbox_profile(
     repo_root: Path,
     worktree: Path,
     temporary_home: Path,
+    candidate_output: Path,
 ) -> str:
     root = repo_root.resolve()
     candidate = worktree.resolve()
@@ -2040,6 +2351,7 @@ def validation_sandbox_profile(
     rustup_home = trusted_rustup_home()
     git_common_directory = repository_git_common_directory(root)
     trusted_makefile = root / "Makefile.toml"
+    _validate_candidate_output_path(candidate, candidate_output)
     if (
         not candidate.is_dir()
         or not root.is_dir()
@@ -2050,8 +2362,9 @@ def validation_sandbox_profile(
     ):
         raise AutopilotError("validation_sandbox_path_invalid")
 
-    def literal(path: Path) -> str:
-        return json.dumps(str(path.resolve(strict=False)))
+    def literal(path: Path, *, resolve: bool = True) -> str:
+        value = path.resolve(strict=False) if resolve else path.absolute()
+        return json.dumps(str(value))
 
     readable = (
         candidate,
@@ -2060,8 +2373,8 @@ def validation_sandbox_profile(
         rustup_home / "settings.toml",
         temporary_home,
     )
-    writable = (
-        temporary_home,
+    candidate_writable = (
+        candidate_output,
         candidate / "site/.astro",
         candidate / "site/dist",
         candidate / "site/node_modules/.astro",
@@ -2118,8 +2431,12 @@ def validation_sandbox_profile(
     lines.append(
         f"(allow file-read* (literal {literal(trusted_makefile)}))"
     )
+    lines.append(
+        f"(allow file-write* (subpath {literal(temporary_home)}))"
+    )
     lines.extend(
-        f"(allow file-write* (subpath {literal(path)}))" for path in writable
+        f"(allow file-write* (subpath {literal(path, resolve=False)}))"
+        for path in candidate_writable
     )
     lines.append('(allow file-write* (literal "/dev/null"))')
     cargo_home = temporary_home / "cargo-home"
@@ -2203,7 +2520,10 @@ def run_validation_profiles(
         ),
         "RUSTFMT": str(formatter_tools["rustfmt"]),
     }
-    with validation_temporary_directory() as temporary:
+    with (
+        validation_temporary_directory() as temporary,
+        pinned_candidate_output_directory(worktree) as candidate_output,
+    ):
         temporary_home = Path(temporary).resolve()
         initialize_validation_home(temporary_home)
         acquisition_environment = sanitized_validation_environment(
@@ -2244,11 +2564,21 @@ def run_validation_profiles(
                 trusted_audit,
             )
         )
-        profile_environment.update(formatter_environment)
+        profile_environment.update(
+            {
+                **formatter_environment,
+                CANDIDATE_OUTPUT_ENV: str(candidate_output.path),
+            }
+        )
+        _verify_candidate_output_empty(
+            candidate_output,
+            changed=True,
+        )
         profile = validation_sandbox_profile(
             repo_root,
             worktree,
             temporary_home,
+            candidate_output.path,
         )
         profile_path = temporary_home / "validation.sb"
         try:
@@ -2283,12 +2613,19 @@ def run_validation_profiles(
                     overrides={
                         **xcode_environment,
                         **formatter_environment,
+                        CANDIDATE_OUTPUT_ENV: str(
+                            candidate_output.path
+                        ),
                     },
                 )
             profile_command = trusted_profile_command(
                 repo_root,
                 name,
                 cargo_executable=tool_paths["cargo"],
+            )
+            _verify_candidate_output_empty(
+                candidate_output,
+                changed=True,
             )
             try:
                 output = run_command(
@@ -2306,17 +2643,18 @@ def run_validation_profiles(
                     capture_failure_diagnostic=True,
                 )
             except CommandFailure as error:
-                diagnostic_sha256 = write_validation_failure_diagnostic(
+                raise _validation_profile_failure(
                     repo_root,
+                    candidate_output,
                     profile=name,
                     repository_head=head,
                     repository_tree=tree,
                     failure=error,
-                )
-                raise AutopilotError(
-                    error.code,
-                    diagnostic_sha256=diagnostic_sha256,
                 ) from error
+            _verify_candidate_output_empty(
+                candidate_output,
+                changed=True,
+            )
             current_head, current_tree = repository_identity(worktree)
             if current_head != head or current_tree != tree:
                 raise AutopilotError("validation_repository_changed")

--- a/automations/upstream/scripts/upstream_autopilot_lib/validation.py
+++ b/automations/upstream/scripts/upstream_autopilot_lib/validation.py
@@ -96,12 +96,20 @@ TRUSTED_TOOL_DISCOVERY_PATHS = tuple(
     str(path) for path in TRUSTED_SYSTEM_TOOL_DIRECTORIES
 )
 FULL_XCODE_EVIDENCE_KEYS = {
+    "clang_sha256",
+    "clangxx_sha256",
     "developer_dir_sha256",
     "metal_sha256",
+    "metallib_sha256",
+    "sdk_root_sha256",
     "xcode_select_sha256",
     "xcode_version_sha256",
     "xcodebuild_sha256",
     "xcrun_sha256",
+    "xcrun_proxy_sha256",
+}
+FULL_XCODE_DISCOVERY_EVIDENCE_KEYS = FULL_XCODE_EVIDENCE_KEYS - {
+    "xcrun_proxy_sha256"
 }
 TOOLCHAIN_EVIDENCE_KEYS = {
     "full_xcode",
@@ -156,6 +164,18 @@ _DIAGNOSTIC_REASON_MARKERS = {
     "process_killed": ("killed",),
     "timed_out": ("timed out", "timeout expired"),
 }
+
+
+@dataclass(frozen=True)
+class FullXcodeConfiguration:
+    """Bind a full-gate environment to exact Xcode tools and read roots."""
+
+    environment: dict[str, str]
+    evidence: dict[str, str]
+    developer_dir: Path
+    metal_toolchain_root: Path
+    sdk_root: Path
+    xcrun_tools: tuple[tuple[str, Path], ...]
 
 
 def validation_failure_facts(output_tail: bytes) -> dict[str, Any]:
@@ -1233,7 +1253,14 @@ def sandbox_task_graph_sha256(repo_root: Path) -> str:
     )
 
 
-def full_xcode_environment() -> tuple[dict[str, str], dict[str, str]]:
+def _xctoolchain_root(path: Path) -> Path:
+    for parent in (path, *path.parents):
+        if parent.name.endswith(".xctoolchain"):
+            return parent
+    raise AutopilotError("full_xcode_unavailable")
+
+
+def full_xcode_environment() -> FullXcodeConfiguration:
     xcode_select = Path("/usr/bin/xcode-select")
     xcrun = Path("/usr/bin/xcrun")
     if (
@@ -1280,8 +1307,17 @@ def full_xcode_environment() -> tuple[dict[str, str], dict[str, str]]:
         if xcodebuild.is_symlink() or not xcodebuild.is_file():
             continue
         environment = {"DEVELOPER_DIR": str(resolved)}
-        metal = run_command(
-            [str(xcrun), "--find", "metal"],
+        discovered_tools = {
+            name: run_command(
+                [str(xcrun), "--find", name],
+                environment=environment,
+                failure_code="full_xcode_unavailable",
+                allow_failure=True,
+            )
+            for name in ("clang", "clang++", "metal", "metallib")
+        }
+        sdk_root = run_command(
+            [str(xcrun), "--sdk", "macosx", "--show-sdk-path"],
             environment=environment,
             failure_code="full_xcode_unavailable",
             allow_failure=True,
@@ -1292,22 +1328,166 @@ def full_xcode_environment() -> tuple[dict[str, str], dict[str, str]]:
             failure_code="full_xcode_unavailable",
             allow_failure=True,
         )
-        if not metal or not version:
+        if not all(discovered_tools.values()) or not sdk_root or not version:
             continue
         try:
-            metal_path = Path(metal).resolve(strict=True)
+            execution_paths = {
+                name: Path(value).expanduser().absolute().parent.resolve(
+                    strict=True
+                )
+                / Path(value).name
+                for name, value in discovered_tools.items()
+            }
+            tool_paths = {
+                name: path.resolve(strict=True)
+                for name, path in execution_paths.items()
+            }
+            sdk_path = Path(sdk_root).resolve(strict=True)
+            metal_root = _xctoolchain_root(tool_paths["metal"])
+            metal_execution_root = _xctoolchain_root(
+                execution_paths["metal"]
+            ).resolve(strict=True)
+            if (
+                _xctoolchain_root(tool_paths["metallib"]) != metal_root
+                or _xctoolchain_root(
+                    execution_paths["metallib"]
+                ).resolve(strict=True)
+                != metal_execution_root
+                or metal_execution_root != metal_root
+                or not tool_paths["clang"].is_relative_to(resolved)
+                or not tool_paths["clang++"].is_relative_to(resolved)
+                or not execution_paths["clang"].is_relative_to(resolved)
+                or not execution_paths["clang++"].is_relative_to(resolved)
+                or not sdk_path.is_relative_to(resolved)
+            ):
+                continue
+            full_environment = {
+                "CC": str(execution_paths["clang"]),
+                "CXX": str(execution_paths["clang++"]),
+                "DEVELOPER_DIR": str(resolved),
+                "SDKROOT": str(sdk_path),
+                "CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER": str(
+                    execution_paths["clang"]
+                ),
+                "CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER": str(
+                    execution_paths["clang"]
+                ),
+            }
             evidence = {
+                "clang_sha256": hash_file_bounded(tool_paths["clang"]),
+                "clangxx_sha256": hash_file_bounded(
+                    tool_paths["clang++"]
+                ),
                 "developer_dir_sha256": sha256_value(str(resolved)),
+                "metallib_sha256": hash_file_bounded(
+                    tool_paths["metallib"]
+                ),
+                "sdk_root_sha256": sha256_value(str(sdk_path)),
                 "xcode_select_sha256": hash_file_bounded(xcode_select),
                 "xcode_version_sha256": sha256_value(version),
                 "xcodebuild_sha256": hash_file_bounded(xcodebuild),
                 "xcrun_sha256": hash_file_bounded(xcrun),
-                "metal_sha256": hash_file_bounded(metal_path),
+                "metal_sha256": hash_file_bounded(tool_paths["metal"]),
             }
         except (OSError, AutopilotError):
             continue
-        return environment, evidence
+        if set(evidence) != FULL_XCODE_DISCOVERY_EVIDENCE_KEYS:
+            raise AutopilotError("full_xcode_unavailable")
+        return FullXcodeConfiguration(
+            environment=full_environment,
+            evidence=evidence,
+            developer_dir=resolved,
+            metal_toolchain_root=metal_root,
+            sdk_root=sdk_path,
+            xcrun_tools=tuple(
+                (name, execution_paths[name])
+                for name in ("metal", "metallib")
+            ),
+        )
     raise AutopilotError("full_xcode_unavailable")
+
+
+def initialize_xcrun_proxy(
+    temporary_home: Path,
+    configuration: FullXcodeConfiguration,
+    python_executable: Path,
+) -> tuple[Path, str]:
+    """Create a fail-closed xcrun proxy that cannot touch the host cache."""
+
+    temporary_home = temporary_home.resolve(strict=True)
+    tools = {name: str(path) for name, path in configuration.xcrun_tools}
+    payload = (
+        f"#!{python_executable}\n"
+        "import os\n"
+        "import sys\n"
+        f"SDK_ROOT = {str(configuration.sdk_root)!r}\n"
+        f"MODULE_CACHE = {str(temporary_home / 'metal-module-cache')!r}\n"
+        f"TOOLS = {tools!r}\n"
+        "args = sys.argv[1:]\n"
+        "sdk_queries = ([\"--show-sdk-path\"], "
+        "[\"--sdk\", \"macosx\", \"--show-sdk-path\"], "
+        "[\"-sdk\", \"macosx\", \"--show-sdk-path\"], "
+        "[\"--show-sdk-path\", \"--sdk\", \"macosx\"], "
+        "[\"--show-sdk-path\", \"-sdk\", \"macosx\"])\n"
+        "if args in sdk_queries:\n"
+        "    print(SDK_ROOT)\n"
+        "    raise SystemExit(0)\n"
+        "if len(args) == 2 and args[0] in {\"--find\", \"-f\"}:\n"
+        "    tool = TOOLS.get(args[1])\n"
+        "    if tool is not None:\n"
+        "        print(tool)\n"
+        "        raise SystemExit(0)\n"
+        "if (len(args) >= 3 and args[0] in {\"--sdk\", \"-sdk\"} "
+        "and args[1] == \"macosx\"):\n"
+        "    tool = TOOLS.get(args[2])\n"
+        "    if tool is not None:\n"
+        "        os.environ[\"SDKROOT\"] = SDK_ROOT\n"
+        "        tool_args = args[3:]\n"
+        "        if args[2] == \"metal\":\n"
+        "            tool_args = [*tool_args, "
+        "f\"-fmodules-cache-path={MODULE_CACHE}\"]\n"
+        "        os.execv(tool, [tool, *tool_args])\n"
+        "print(\"sandbox xcrun invocation denied\", file=sys.stderr)\n"
+        "raise SystemExit(64)\n"
+    ).encode("utf-8")
+    proxy_directory = temporary_home / "trusted-xcrun"
+    proxy = proxy_directory / "xcrun"
+    descriptor: int | None = None
+    try:
+        proxy_directory.mkdir(mode=0o700)
+        descriptor = os.open(
+            proxy,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o500,
+        )
+        written = 0
+        while written < len(payload):
+            count = os.write(descriptor, payload[written:])
+            if count <= 0:
+                raise OSError("xcrun proxy write made no progress")
+            written += count
+        os.fsync(descriptor)
+        metadata = os.fstat(descriptor)
+        directory_metadata = proxy_directory.stat()
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.getuid()
+            or metadata.st_nlink != 1
+            or stat.S_IMODE(metadata.st_mode) != 0o500
+            or metadata.st_size != len(payload)
+            or not stat.S_ISDIR(directory_metadata.st_mode)
+            or directory_metadata.st_uid != os.getuid()
+            or stat.S_IMODE(directory_metadata.st_mode) != 0o700
+        ):
+            raise AutopilotError("full_xcode_proxy_invalid")
+    except AutopilotError:
+        raise
+    except OSError as error:
+        raise AutopilotError("full_xcode_proxy_invalid") from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+    return proxy, hash_file_bounded(proxy)
 
 
 def validation_tools(
@@ -2344,6 +2524,9 @@ def validation_sandbox_profile(
     worktree: Path,
     temporary_home: Path,
     candidate_output: Path,
+    *,
+    full_xcode: FullXcodeConfiguration | None = None,
+    xcrun_proxy: Path | None = None,
 ) -> str:
     root = repo_root.resolve()
     candidate = worktree.resolve()
@@ -2352,6 +2535,31 @@ def validation_sandbox_profile(
     git_common_directory = repository_git_common_directory(root)
     trusted_makefile = root / "Makefile.toml"
     _validate_candidate_output_path(candidate, candidate_output)
+    if (full_xcode is None) != (xcrun_proxy is None):
+        raise AutopilotError("validation_sandbox_path_invalid")
+    if full_xcode is not None and xcrun_proxy is not None:
+        try:
+            proxy_metadata = xcrun_proxy.lstat()
+            proxy_directory_metadata = xcrun_proxy.parent.lstat()
+        except OSError as error:
+            raise AutopilotError(
+                "validation_sandbox_path_invalid"
+            ) from error
+        if (
+            xcrun_proxy.absolute()
+            != temporary_home / "trusted-xcrun/xcrun"
+            or not full_xcode.developer_dir.is_dir()
+            or not full_xcode.metal_toolchain_root.is_dir()
+            or not full_xcode.sdk_root.is_dir()
+            or not stat.S_ISREG(proxy_metadata.st_mode)
+            or proxy_metadata.st_uid != os.getuid()
+            or proxy_metadata.st_nlink != 1
+            or stat.S_IMODE(proxy_metadata.st_mode) != 0o500
+            or not stat.S_ISDIR(proxy_directory_metadata.st_mode)
+            or proxy_directory_metadata.st_uid != os.getuid()
+            or stat.S_IMODE(proxy_directory_metadata.st_mode) != 0o700
+        ):
+            raise AutopilotError("validation_sandbox_path_invalid")
     if (
         not candidate.is_dir()
         or not root.is_dir()
@@ -2366,13 +2574,21 @@ def validation_sandbox_profile(
         value = path.resolve(strict=False) if resolve else path.absolute()
         return json.dumps(str(value))
 
-    readable = (
+    readable = [
         candidate,
         git_common_directory,
         rustup_home / "toolchains",
         rustup_home / "settings.toml",
         temporary_home,
-    )
+    ]
+    if full_xcode is not None and xcrun_proxy is not None:
+        readable.extend(
+            (
+                full_xcode.developer_dir,
+                full_xcode.metal_toolchain_root,
+                xcrun_proxy.parent,
+            )
+        )
     candidate_writable = (
         candidate_output,
         candidate / "site/.astro",
@@ -2434,6 +2650,10 @@ def validation_sandbox_profile(
     lines.append(
         f"(allow file-write* (subpath {literal(temporary_home)}))"
     )
+    if xcrun_proxy is not None:
+        lines.append(
+            f"(deny file-write* (subpath {literal(xcrun_proxy.parent)}))"
+        )
     lines.extend(
         f"(allow file-write* (subpath {literal(path, resolve=False)}))"
         for path in candidate_writable
@@ -2507,6 +2727,11 @@ def run_validation_profiles(
     task_graph_sha256 = sandbox_task_graph_sha256(repo_root)
     results: list[dict[str, Any]] = []
     profile_names = required_profile_names(scope["requires_full_gate"])
+    full_xcode = (
+        full_xcode_environment()
+        if FULL_VALIDATION_PROFILE in profile_names
+        else None
+    )
     trusted_audit = (repo_root / "scripts/audit_node_lock.py").resolve()
     tool_paths, tool_evidence = validation_tools(repo_root)
     formatter_tools = trusted_formatter_tools(
@@ -2526,6 +2751,14 @@ def run_validation_profiles(
     ):
         temporary_home = Path(temporary).resolve()
         initialize_validation_home(temporary_home)
+        xcrun_proxy: Path | None = None
+        xcrun_proxy_sha256: str | None = None
+        if full_xcode is not None:
+            xcrun_proxy, xcrun_proxy_sha256 = initialize_xcrun_proxy(
+                temporary_home,
+                full_xcode,
+                tool_paths["python3"],
+            )
         acquisition_environment = sanitized_validation_environment(
             temporary_home,
             tool_paths,
@@ -2579,6 +2812,8 @@ def run_validation_profiles(
             worktree,
             temporary_home,
             candidate_output.path,
+            full_xcode=full_xcode,
+            xcrun_proxy=xcrun_proxy,
         )
         profile_path = temporary_home / "validation.sb"
         try:
@@ -2602,19 +2837,32 @@ def run_validation_profiles(
             full_xcode_evidence = None
             current_environment = profile_environment
             if name == FULL_VALIDATION_PROFILE:
-                xcode_environment, full_xcode_evidence = (
-                    full_xcode_environment()
-                )
+                if (
+                    full_xcode is None
+                    or xcrun_proxy is None
+                    or xcrun_proxy_sha256 is None
+                ):
+                    raise AutopilotError("full_xcode_unavailable")
+                full_xcode_evidence = {
+                    **full_xcode.evidence,
+                    "xcrun_proxy_sha256": xcrun_proxy_sha256,
+                }
                 current_environment = sanitized_validation_environment(
                     temporary_home,
                     tool_paths,
                     cargo_home=temporary_home / "cargo-home",
                     offline=True,
                     overrides={
-                        **xcode_environment,
+                        **full_xcode.environment,
                         **formatter_environment,
                         CANDIDATE_OUTPUT_ENV: str(
                             candidate_output.path
+                        ),
+                        "PATH": os.pathsep.join(
+                            (
+                                str(xcrun_proxy.parent),
+                                *_validation_path_entries(tool_paths),
+                            )
                         ),
                     },
                 )
@@ -2664,6 +2912,18 @@ def run_validation_profiles(
                 raise AutopilotError("validation_task_graph_changed")
             if validation_tool_evidence(tool_paths) != tool_evidence:
                 raise AutopilotError("validation_tool_changed")
+            if (
+                xcrun_proxy is not None
+                and xcrun_proxy_sha256 is not None
+                and hash_file_bounded(xcrun_proxy)
+                != xcrun_proxy_sha256
+            ):
+                raise AutopilotError("validation_xcode_proxy_changed")
+            if (
+                name == FULL_VALIDATION_PROFILE
+                and full_xcode_environment() != full_xcode
+            ):
+                raise AutopilotError("validation_xcode_changed")
             trusted_node_provenance = run_command(
                 [
                     str(tool_paths["python3"]),

--- a/automations/upstream/tests/test_upstream_autopilot.py
+++ b/automations/upstream/tests/test_upstream_autopilot.py
@@ -4874,11 +4874,25 @@ class UpstreamAutopilotTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             developer = Path(directory) / "Xcode.app/Contents/Developer"
             xcodebuild = developer / "usr/bin/xcodebuild"
-            metal = Path(directory) / "Metal.xctoolchain/usr/bin/metal"
+            toolchain = developer / "Toolchains/XcodeDefault.xctoolchain"
+            clang = toolchain / "usr/bin/clang"
+            clangxx = toolchain / "usr/bin/clang++"
+            metal_root = Path(directory) / "Metal.xctoolchain"
+            metal = metal_root / "usr/bin/metal"
+            metallib = metal_root / "usr/bin/metallib"
+            sdk_root = (
+                developer
+                / "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+            )
             xcodebuild.parent.mkdir(parents=True)
             metal.parent.mkdir(parents=True)
+            clang.parent.mkdir(parents=True)
+            sdk_root.mkdir(parents=True)
             xcodebuild.write_bytes(b"xcodebuild")
+            clang.write_bytes(b"clang")
+            clangxx.write_bytes(b"clang++")
             metal.write_bytes(b"metal")
+            metallib.write_bytes(b"metallib")
 
             def fake_run(arguments, **kwargs):
                 if arguments == ["/usr/bin/xcode-select", "-p"]:
@@ -4887,8 +4901,21 @@ class UpstreamAutopilotTests(unittest.TestCase):
                     kwargs["environment"],
                     {"DEVELOPER_DIR": str(developer.resolve())},
                 )
-                if arguments == ["/usr/bin/xcrun", "--find", "metal"]:
-                    return str(metal)
+                discovered = {
+                    "clang": clang,
+                    "clang++": clangxx,
+                    "metal": metal,
+                    "metallib": metallib,
+                }
+                if arguments[:2] == ["/usr/bin/xcrun", "--find"]:
+                    return str(discovered[arguments[2]])
+                if arguments == [
+                    "/usr/bin/xcrun",
+                    "--sdk",
+                    "macosx",
+                    "--show-sdk-path",
+                ]:
+                    return str(sdk_root)
                 if arguments == [str(xcodebuild.resolve()), "-version"]:
                     return "Xcode 27.0\nBuild version 27A5209h"
                 self.fail(f"unexpected command: {arguments}")
@@ -4904,31 +4931,188 @@ class UpstreamAutopilotTests(unittest.TestCase):
                     side_effect=fake_run,
                 ),
             ):
-                environment, evidence = (
-                    self.autopilot.full_xcode_environment()
-                )
+                configuration = self.autopilot.full_xcode_environment()
 
         self.assertEqual(
-            environment,
-            {"DEVELOPER_DIR": str(developer.resolve())},
+            configuration.environment["DEVELOPER_DIR"],
+            str(developer.resolve()),
         )
         self.assertEqual(
-            set(evidence),
-            {
-                "developer_dir_sha256",
-                "xcode_select_sha256",
-                "xcode_version_sha256",
-                "xcodebuild_sha256",
-                "xcrun_sha256",
-                "metal_sha256",
-            },
+            configuration.environment["SDKROOT"],
+            str(sdk_root.resolve()),
+        )
+        self.assertEqual(configuration.developer_dir, developer.resolve())
+        self.assertEqual(
+            configuration.metal_toolchain_root,
+            metal_root.resolve(),
+        )
+        self.assertEqual(
+            set(configuration.evidence),
+            self.autopilot.FULL_XCODE_DISCOVERY_EVIDENCE_KEYS,
         )
         self.assertTrue(
             all(
                 self.autopilot.is_sha256(value)
-                for value in evidence.values()
+                for value in configuration.evidence.values()
             )
         )
+
+    def test_xcrun_proxy_allows_only_bound_metal_tools(self):
+        with tempfile.TemporaryDirectory() as directory:
+            configuration = self.autopilot.FullXcodeConfiguration(
+                environment={},
+                evidence={},
+                developer_dir=Path("/trusted/Xcode.app/Contents/Developer"),
+                metal_toolchain_root=Path("/trusted/Metal.xctoolchain"),
+                sdk_root=Path("/trusted/MacOSX.sdk"),
+                xcrun_tools=(
+                    ("metal", Path("/bin/echo")),
+                    ("metallib", Path("/bin/echo")),
+                ),
+            )
+            proxy, digest = self.autopilot.initialize_xcrun_proxy(
+                Path(directory),
+                configuration,
+                Path(sys.executable).resolve(),
+            )
+
+            found = subprocess.run(
+                [str(proxy), "--find", "metal"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            sdk = subprocess.run(
+                [str(proxy), "--sdk", "macosx", "--show-sdk-path"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            invoked = subprocess.run(
+                [str(proxy), "-sdk", "macosx", "metal", "shader.metal"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            denied = subprocess.run(
+                [str(proxy), "--find", "clang"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(found.stdout.strip(), "/bin/echo")
+            self.assertEqual(sdk.stdout.strip(), "/trusted/MacOSX.sdk")
+            self.assertEqual(
+                invoked.stdout.strip(),
+                (
+                    "shader.metal -fmodules-cache-path="
+                    f"{Path(directory).resolve() / 'metal-module-cache'}"
+                ),
+            )
+            self.assertEqual(denied.returncode, 64)
+            self.assertEqual(
+                denied.stderr.strip(),
+                "sandbox xcrun invocation denied",
+            )
+            self.assertEqual(proxy.stat().st_mode & 0o777, 0o500)
+            self.assertEqual(self.autopilot.hash_file_bounded(proxy), digest)
+
+    @unittest.skipUnless(
+        sys.platform == "darwin" and Path("/usr/bin/sandbox-exec").is_file(),
+        "requires the macOS sandbox",
+    )
+    @unittest.skipIf(
+        os.environ.get("DECODEX_CANDIDATE_SANDBOX") == "1",
+        "the outer validation sandbox owns this probe",
+    )
+    def test_validation_sandbox_keeps_the_xcrun_proxy_read_only(self):
+        with tempfile.TemporaryDirectory() as directory:
+            outer = Path(directory).resolve()
+            candidate = outer / "candidate"
+            temporary_home = outer / "sandbox"
+            developer = outer / "Xcode.app/Contents/Developer"
+            metal_root = outer / "Metal.xctoolchain"
+            sdk_root = developer / "SDKs/MacOSX.sdk"
+            candidate.mkdir()
+            temporary_home.mkdir()
+            metal_root.mkdir()
+            sdk_root.mkdir(parents=True)
+            configuration = self.autopilot.FullXcodeConfiguration(
+                environment={},
+                evidence={},
+                developer_dir=developer,
+                metal_toolchain_root=metal_root,
+                sdk_root=sdk_root,
+                xcrun_tools=(
+                    ("metal", Path("/bin/echo")),
+                    ("metallib", Path("/bin/echo")),
+                ),
+            )
+            proxy, _digest = self.autopilot.initialize_xcrun_proxy(
+                temporary_home,
+                configuration,
+                Path(sys.executable).resolve(),
+            )
+            with self.autopilot.pinned_candidate_output_directory(
+                candidate
+            ) as output:
+                profile = self.autopilot.validation_sandbox_profile(
+                    ROOT,
+                    candidate,
+                    temporary_home,
+                    output.path,
+                    full_xcode=configuration,
+                    xcrun_proxy=proxy,
+                )
+
+            mutation_attempts = (
+                f"import os; os.chmod({str(proxy)!r}, 0o700)",
+                f"import os; os.unlink({str(proxy)!r})",
+                (
+                    "import os; "
+                    f"os.rename({str(proxy.parent)!r}, "
+                    f"{str(temporary_home / 'moved')!r})"
+                ),
+                (
+                    "import os; "
+                    f"os.mkdir({str(temporary_home / 'replacement')!r}); "
+                    f"os.replace({str(temporary_home / 'replacement')!r}, "
+                    f"{str(proxy.parent)!r})"
+                ),
+            )
+            denied = [
+                self.autopilot.run_command(
+                    [
+                        "/usr/bin/sandbox-exec",
+                        "-p",
+                        profile,
+                        sys.executable,
+                        "-c",
+                        script,
+                    ],
+                    cwd=candidate,
+                    failure_code="sandbox_probe_failed",
+                    allow_failure=True,
+                )
+                for script in mutation_attempts
+            ]
+            invoked = self.autopilot.run_command(
+                [
+                    "/usr/bin/sandbox-exec",
+                    "-p",
+                    profile,
+                    str(proxy),
+                    "--find",
+                    "metal",
+                ],
+                cwd=candidate,
+                failure_code="sandbox_probe_failed",
+            )
+
+            self.assertEqual(denied, ["", "", "", ""])
+            self.assertEqual(proxy.stat().st_mode & 0o777, 0o500)
+            self.assertEqual(invoked, "/bin/echo")
 
     def test_full_validation_profile_receives_only_the_xcode_environment(self):
         head = "2" * 40
@@ -4939,16 +5123,32 @@ class UpstreamAutopilotTests(unittest.TestCase):
             "closure_sha256": "5" * 64,
         }
         xcode_environment = {
-            "DEVELOPER_DIR": "/Applications/Xcode-test.app/Contents/Developer"
+            "CC": "/Applications/Xcode-test.app/clang",
+            "CXX": "/Applications/Xcode-test.app/clang++",
+            "DEVELOPER_DIR": "/Applications/Xcode-test.app/Contents/Developer",
+            "SDKROOT": "/Applications/Xcode-test.app/MacOSX.sdk",
+            "CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER": (
+                "/Applications/Xcode-test.app/clang"
+            ),
+            "CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER": (
+                "/Applications/Xcode-test.app/clang"
+            ),
         }
         xcode_evidence = {
-            "developer_dir_sha256": "6" * 64,
-            "xcode_version_sha256": "7" * 64,
-            "xcodebuild_sha256": "8" * 64,
-            "metal_sha256": "9" * 64,
-            "xcode_select_sha256": "a" * 64,
-            "xcrun_sha256": "b" * 64,
+            key: self.autopilot.sha256_value({"xcode": key})
+            for key in self.autopilot.FULL_XCODE_DISCOVERY_EVIDENCE_KEYS
         }
+        xcode_configuration = self.autopilot.FullXcodeConfiguration(
+            environment=xcode_environment,
+            evidence=xcode_evidence,
+            developer_dir=Path(xcode_environment["DEVELOPER_DIR"]),
+            metal_toolchain_root=Path("/trusted/Metal.xctoolchain"),
+            sdk_root=Path(xcode_environment["SDKROOT"]),
+            xcrun_tools=(
+                ("metal", Path("/trusted/bin/metal")),
+                ("metallib", Path("/trusted/bin/metallib")),
+            ),
+        )
         trusted_paths = {
             name: Path(f"/trusted/bin/{name}")
             for name in self.autopilot.VALIDATION_TOOL_NAMES
@@ -4992,7 +5192,7 @@ class UpstreamAutopilotTests(unittest.TestCase):
             mock.patch.object(
                 self.autopilot.validation_module,
                 "full_xcode_environment",
-                return_value=(xcode_environment, xcode_evidence),
+                return_value=xcode_configuration,
             ),
             mock.patch.object(
                 self.autopilot.validation_module,
@@ -5100,6 +5300,16 @@ class UpstreamAutopilotTests(unittest.TestCase):
         self.assertEqual(
             cargo_calls[2].kwargs["environment"]["DEVELOPER_DIR"],
             xcode_environment["DEVELOPER_DIR"],
+        )
+        self.assertEqual(
+            cargo_calls[2].kwargs["environment"]["SDKROOT"],
+            xcode_environment["SDKROOT"],
+        )
+        self.assertEqual(
+            Path(cargo_calls[2].kwargs["environment"]["PATH"].split(
+                os.pathsep
+            )[0]).name,
+            "trusted-xcrun",
         )
         self.assertTrue(receipt["requires_full_gate"])
 

--- a/automations/upstream/tests/test_upstream_autopilot.py
+++ b/automations/upstream/tests/test_upstream_autopilot.py
@@ -1062,6 +1062,42 @@ class UpstreamAutopilotTests(unittest.TestCase):
             },
         )
 
+    def test_autopilot_error_bounds_and_normalizes_related_codes(self):
+        normalized = self.autopilot.AutopilotError(
+            "primary_failure",
+            related_error_codes=(
+                "primary_failure",
+                "invalid code",
+                "alpha_failure",
+                "alpha_failure",
+            ),
+        )
+        self.assertEqual(
+            normalized.related_error_codes,
+            ("alpha_failure", "unclassified_failure"),
+        )
+
+        bounded = self.autopilot.AutopilotError(
+            "primary_failure",
+            related_error_codes=(
+                "epsilon_failure",
+                "delta_failure",
+                "gamma_failure",
+                "beta_failure",
+                "alpha_failure",
+            ),
+        )
+        self.assertEqual(
+            bounded.related_error_codes,
+            (
+                "alpha_failure",
+                "beta_failure",
+                "delta_failure",
+                "epsilon_failure",
+            ),
+        )
+        self.assertEqual(len(bounded.related_error_codes), 4)
+
     def test_cli_failure_returns_the_exact_validation_diagnostic_digest(self):
         digest = "a" * 64
         output = io.StringIO()
@@ -1078,6 +1114,9 @@ class UpstreamAutopilotTests(unittest.TestCase):
                 side_effect=self.autopilot.AutopilotError(
                     "validation_profile_focused_tests_failed",
                     diagnostic_sha256=digest,
+                    related_error_codes=(
+                        "validation_candidate_output_cleanup_failed",
+                    ),
                 ),
             ),
             mock.patch.object(sys, "stdout", output),
@@ -1092,6 +1131,9 @@ class UpstreamAutopilotTests(unittest.TestCase):
                 "status": "failed",
                 "error_code": "validation_profile_focused_tests_failed",
                 "error_digest": digest,
+                "related_error_codes": [
+                    "validation_candidate_output_cleanup_failed"
+                ],
             },
         )
 
@@ -4918,6 +4960,19 @@ class UpstreamAutopilotTests(unittest.TestCase):
         git_common_directory = (
             self.autopilot.repository_git_common_directory(ROOT)
         )
+        candidate_output = self.autopilot.PinnedCandidateOutput(
+            path=Path(
+                "/candidate/target/"
+                "decodex-validation-00000000000000000000000000000000"
+            ),
+            name=(
+                "decodex-validation-"
+                "00000000000000000000000000000000"
+            ),
+            candidate_descriptor=-1,
+            target_descriptor=-1,
+            output_descriptor=-1,
+        )
         with (
             mock.patch.object(
                 self.autopilot.validation_module,
@@ -4974,6 +5029,20 @@ class UpstreamAutopilotTests(unittest.TestCase):
             ),
             mock.patch.object(
                 self.autopilot.validation_module,
+                "pinned_candidate_output_directory",
+                return_value=nullcontext(candidate_output),
+            ),
+            mock.patch.object(
+                self.autopilot.validation_module,
+                "_verify_candidate_output_empty",
+            ),
+            mock.patch.object(
+                self.autopilot.validation_module,
+                "validation_sandbox_profile",
+                return_value="(version 1)\n(deny default)\n",
+            ),
+            mock.patch.object(
+                self.autopilot.validation_module,
                 "run_command",
                 return_value="validated",
             ) as run,
@@ -5020,6 +5089,10 @@ class UpstreamAutopilotTests(unittest.TestCase):
                 environment["RUSTFMT"],
                 "/trusted/bin/nightly-rustfmt",
             )
+            self.assertEqual(
+                environment["DECODEX_VALIDATION_REPO_OUTPUT"],
+                str(candidate_output.path),
+            )
             for secret in ("GH_TOKEN", "OPENAI_API_KEY", "SSH_AUTH_SOCK"):
                 self.assertNotIn(secret, environment)
         self.assertNotIn("DEVELOPER_DIR", cargo_calls[0].kwargs["environment"])
@@ -5043,6 +5116,7 @@ class UpstreamAutopilotTests(unittest.TestCase):
                     "GH_TOKEN": "secret",
                     "OPENAI_API_KEY": "secret",
                     "SSH_AUTH_SOCK": "/tmp/secret-agent",
+                    "DECODEX_VALIDATION_REPO_OUTPUT": "/tmp/hostile",
                     "PATH": "/tmp/hostile",
                 },
                 clear=False,
@@ -5055,6 +5129,10 @@ class UpstreamAutopilotTests(unittest.TestCase):
 
         for secret in ("GH_TOKEN", "OPENAI_API_KEY", "SSH_AUTH_SOCK"):
             self.assertNotIn(secret, environment)
+        self.assertNotIn(
+            "DECODEX_VALIDATION_REPO_OUTPUT",
+            environment,
+        )
         self.assertNotIn("DECODEX_TEST_TEMP_ROOT", environment)
         self.assertNotIn("/tmp/hostile", environment["PATH"].split(os.pathsep))
         self.assertEqual(
@@ -5199,6 +5277,269 @@ class UpstreamAutopilotTests(unittest.TestCase):
             all(not str(path).startswith(str(hostile)) for path in tools.values())
         )
 
+    def test_candidate_validation_output_rejects_symlink_and_replacement(self):
+        with tempfile.TemporaryDirectory() as directory:
+            candidate = Path(directory) / "candidate"
+            temporary_home = Path(directory) / "sandbox"
+            candidate.mkdir()
+            temporary_home.mkdir()
+            source = candidate / "source.txt"
+            source.write_text("source", encoding="utf-8")
+            target = candidate / "target"
+            target.symlink_to(".", target_is_directory=True)
+
+            with self.assertRaises(self.autopilot.AutopilotError) as rejected:
+                with self.autopilot.pinned_candidate_output_directory(candidate):
+                    pass
+            self.assertEqual(
+                rejected.exception.code,
+                "validation_candidate_output_invalid",
+            )
+
+            target.unlink()
+            with self.autopilot.pinned_candidate_output_directory(
+                candidate
+            ) as output:
+                profile = self.autopilot.validation_sandbox_profile(
+                    ROOT,
+                    candidate,
+                    temporary_home,
+                    output.path,
+                )
+                self.assertIn(str(output.path), profile)
+                self.assertNotIn(
+                    f'(allow file-write* (subpath "{candidate}"))',
+                    profile,
+                )
+
+                hardlink = output.path / "preexisting-hardlink"
+                os.link(source, hardlink)
+                with self.assertRaises(
+                    self.autopilot.AutopilotError
+                ) as populated:
+                    self.autopilot.validation_module._verify_candidate_output_empty(
+                        output,
+                        changed=True,
+                    )
+                self.assertEqual(
+                    populated.exception.code,
+                    "validation_candidate_output_changed",
+                )
+                hardlink.unlink()
+                self.assertEqual(source.read_text(encoding="utf-8"), "source")
+
+                retained = candidate / "retained-target"
+                target.rename(retained)
+                target.mkdir(mode=0o700)
+                with self.assertRaises(
+                    self.autopilot.AutopilotError
+                ) as changed:
+                    self.autopilot.validation_module._verify_candidate_output_directory(
+                        output,
+                        changed=True,
+                    )
+                self.assertEqual(
+                    changed.exception.code,
+                    "validation_candidate_output_changed",
+                )
+                target.rmdir()
+                retained.rename(target)
+                self.autopilot.validation_module._verify_candidate_output_empty(
+                    output,
+                    changed=True,
+                )
+
+    def test_candidate_validation_output_cleanup_is_descriptor_relative(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = root / "candidate"
+            outside = root / "outside"
+            candidate.mkdir()
+            outside.mkdir()
+
+            with self.autopilot.pinned_candidate_output_directory(
+                candidate
+            ) as output:
+                target = candidate / "target"
+                retained = candidate / "retained-target"
+                target.rename(retained)
+                external_output = outside / output.name
+                external_output.mkdir(mode=0o700)
+                sentinel = external_output / "sentinel"
+                sentinel.write_text("outside", encoding="utf-8")
+                target.symlink_to(outside, target_is_directory=True)
+
+            self.assertFalse((retained / output.name).exists())
+            self.assertEqual(
+                sentinel.read_text(encoding="utf-8"),
+                "outside",
+            )
+
+    def test_candidate_output_cleanup_preserves_an_active_error(self):
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch.object(
+                self.autopilot.validation_module.shutil,
+                "rmtree",
+                side_effect=OSError("cleanup failed"),
+            ),
+        ):
+            candidate = Path(directory) / "candidate"
+            candidate.mkdir()
+            with self.assertRaises(self.autopilot.AutopilotError) as raised:
+                with self.autopilot.pinned_candidate_output_directory(
+                    candidate
+                ):
+                    raise self.autopilot.AutopilotError(
+                        "original_validation_failure"
+                    )
+
+            self.assertEqual(
+                raised.exception.code,
+                "original_validation_failure",
+            )
+            self.assertEqual(
+                raised.exception.related_error_codes,
+                (
+                    "validation_candidate_output_cleanup_failed",
+                ),
+            )
+
+    def test_candidate_output_open_failure_removes_the_created_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            candidate = Path(directory) / "candidate"
+            candidate.mkdir()
+            real_open = os.open
+            output_open_failed = False
+
+            def fail_output_open_once(
+                path,
+                flags,
+                mode=0o777,
+                *,
+                dir_fd=None,
+            ):
+                nonlocal output_open_failed
+                if (
+                    not output_open_failed
+                    and isinstance(path, str)
+                    and self.autopilot.CANDIDATE_OUTPUT_NAME_PATTERN.fullmatch(
+                        path
+                    )
+                ):
+                    output_open_failed = True
+                    raise OSError("output open failed")
+                return real_open(
+                    path,
+                    flags,
+                    mode,
+                    dir_fd=dir_fd,
+                )
+
+            with (
+                mock.patch.object(
+                    self.autopilot.validation_module.os,
+                    "open",
+                    side_effect=fail_output_open_once,
+                ),
+                self.assertRaises(self.autopilot.AutopilotError) as raised,
+            ):
+                with self.autopilot.pinned_candidate_output_directory(
+                    candidate
+                ):
+                    pass
+
+            self.assertTrue(output_open_failed)
+            self.assertEqual(
+                raised.exception.code,
+                "validation_candidate_output_invalid",
+            )
+            self.assertEqual(
+                list((candidate / "target").iterdir()),
+                [],
+            )
+
+    def test_candidate_output_cleanup_failure_is_primary_without_active_error(
+        self,
+    ):
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch.object(
+                self.autopilot.validation_module.shutil,
+                "rmtree",
+                side_effect=OSError("cleanup failed"),
+            ),
+        ):
+            candidate = Path(directory) / "candidate"
+            candidate.mkdir()
+            with self.assertRaises(self.autopilot.AutopilotError) as raised:
+                with self.autopilot.pinned_candidate_output_directory(
+                    candidate
+                ):
+                    pass
+
+            self.assertEqual(
+                raised.exception.code,
+                "validation_candidate_output_cleanup_failed",
+            )
+
+    def test_profile_failure_preserves_diagnostic_and_output_contamination(self):
+        diagnostic = "a" * 64
+        failure = self.autopilot.CommandFailure(
+            "validation_profile_focused_tests_failed",
+            failure_kind="nonzero_exit",
+            output_tail=b"failed",
+            output_sha256="b" * 64,
+            return_code=1,
+        )
+        candidate_output = self.autopilot.PinnedCandidateOutput(
+            path=Path(
+                "/candidate/target/"
+                "decodex-validation-00000000000000000000000000000000"
+            ),
+            name=(
+                "decodex-validation-"
+                "00000000000000000000000000000000"
+            ),
+            candidate_descriptor=-1,
+            target_descriptor=-1,
+            output_descriptor=-1,
+        )
+        with (
+            mock.patch.object(
+                self.autopilot.validation_module,
+                "write_validation_failure_diagnostic",
+                return_value=diagnostic,
+            ),
+            mock.patch.object(
+                self.autopilot.validation_module,
+                "_verify_candidate_output_empty",
+                side_effect=self.autopilot.AutopilotError(
+                    "validation_candidate_output_changed"
+                ),
+            ),
+        ):
+            result = (
+                self.autopilot.validation_module._validation_profile_failure(
+                    ROOT,
+                    candidate_output,
+                    profile="focused_tests",
+                    repository_head="1" * 40,
+                    repository_tree="2" * 40,
+                    failure=failure,
+                )
+            )
+
+        self.assertEqual(
+            result.code,
+            "validation_profile_focused_tests_failed",
+        )
+        self.assertEqual(result.diagnostic_sha256, diagnostic)
+        self.assertEqual(
+            result.related_error_codes,
+            ("validation_candidate_output_changed",),
+        )
+
     @unittest.skipUnless(
         sys.platform == "darwin" and Path("/usr/bin/sandbox-exec").is_file(),
         "requires the macOS sandbox",
@@ -5218,6 +5559,15 @@ class UpstreamAutopilotTests(unittest.TestCase):
             host_secret.write_text("private", encoding="utf-8")
             candidate_file = candidate / "source.txt"
             candidate_file.write_text("source", encoding="utf-8")
+            candidate_target = candidate / "target"
+            candidate_target.mkdir(mode=0o700)
+            candidate_output = candidate_target / (
+                "decodex-validation-" + "0" * 32
+            )
+            candidate_output.mkdir(mode=0o700)
+            candidate_output.joinpath("source-link").symlink_to(
+                candidate_file
+            )
             cargo_source = (
                 temporary_home / "cargo-home/registry/src/example"
             )
@@ -5226,6 +5576,7 @@ class UpstreamAutopilotTests(unittest.TestCase):
                 ROOT,
                 candidate,
                 temporary_home,
+                candidate_output.resolve(),
             )
 
             def sandbox(script):
@@ -5255,6 +5606,22 @@ class UpstreamAutopilotTests(unittest.TestCase):
             self.assertEqual(
                 sandbox(
                     "from pathlib import Path; "
+                    f"Path({str(candidate_output / 'allowed')!r}).write_text('ok'); "
+                    "print('written')"
+                ),
+                "written",
+            )
+            self.assertEqual(
+                sandbox(
+                    "from pathlib import Path; "
+                    f"Path({str(candidate_target / 'sibling')!r}).write_text('x'); "
+                    "print('written')"
+                ),
+                "",
+            )
+            self.assertEqual(
+                sandbox(
+                    "from pathlib import Path; "
                     f"Path({str(ROOT / 'Makefile.toml')!r}).read_bytes(); "
                     "print('readable')"
                 ),
@@ -5276,6 +5643,27 @@ class UpstreamAutopilotTests(unittest.TestCase):
                 "",
             )
             self.assertEqual(candidate_file.read_text(encoding="utf-8"), "source")
+            self.assertEqual(
+                sandbox(
+                    "from pathlib import Path; "
+                    f"Path({str(candidate_output / 'source-link')!r}).write_text('changed'); "
+                    "print('written')"
+                ),
+                "",
+            )
+            self.assertEqual(candidate_file.read_text(encoding="utf-8"), "source")
+            self.assertEqual(
+                sandbox(
+                    "import os; "
+                    f"os.link({str(candidate_file)!r}, "
+                    f"{str(candidate_output / 'source-hardlink')!r}); "
+                    "print('linked')"
+                ),
+                "",
+            )
+            self.assertFalse(
+                (candidate_output / "source-hardlink").exists()
+            )
             self.assertEqual(
                 sandbox(
                     "from pathlib import Path; "
@@ -5364,11 +5752,15 @@ class UpstreamAutopilotTests(unittest.TestCase):
             receipt = private_directory / "candidate.json"
             receipt.write_bytes(b'{"schema":"candidate"}\n')
             receipt.chmod(0o600)
-            profile = self.autopilot.validation_sandbox_profile(
-                ROOT,
-                ROOT,
-                temporary_home,
-            )
+            with self.autopilot.pinned_candidate_output_directory(
+                ROOT
+            ) as candidate_output:
+                profile = self.autopilot.validation_sandbox_profile(
+                    ROOT,
+                    ROOT,
+                    temporary_home,
+                    candidate_output.path,
+                )
             git_output = self.autopilot.run_command(
                 [
                     "/usr/bin/sandbox-exec",

--- a/crates/decodex-app-client-ffi/src/lib.rs
+++ b/crates/decodex-app-client-ffi/src/lib.rs
@@ -631,26 +631,13 @@ async fn execute_request(
 ) -> Result<Value, RequestFailure> {
 	let profile = native_client.profile.clone();
 	match request {
-		Request::ListAccounts { .. } =>
-			to_value(AccountClient::new(profile).list().await.map_err(RequestFailure::Client)?),
+		Request::ListAccounts { .. } => list_accounts(profile).await,
 		Request::GetResetCards { account_id, .. } => get_reset_cards(profile, account_id).await,
 		Request::GetAccountProfile { account_id, include_email, .. } =>
 			get_account_profile(profile, account_id, include_email).await,
-		Request::GetCodexAuthProjection { .. } => to_value(
-			AccountClient::new(profile)
-				.codex_auth_projection()
-				.await
-				.map_err(RequestFailure::Client)?,
-		),
-		Request::ResetCardStatus { idempotency_key, .. } => {
-			let idempotency_key = parse_idempotency_key(idempotency_key)?;
-			to_value(
-				ResetCardClient::new(profile)
-					.status(idempotency_key)
-					.await
-					.map_err(RequestFailure::Client)?,
-			)
-		},
+		Request::GetCodexAuthProjection { .. } => get_codex_auth_projection(profile).await,
+		Request::ResetCardStatus { idempotency_key, .. } =>
+			get_reset_card_status(profile, idempotency_key).await,
 		Request::UseResetCard {
 			account_id,
 			granted_at_unix_seconds,
@@ -668,14 +655,8 @@ async fn execute_request(
 				idempotency_key,
 			)
 			.await,
-		Request::EnrollAccount { operation_id, account_id, enabled, idempotency_key, .. } => {
-			let payload = CommandPayload::EnrollAccountFromSharedCodex {
-				operation_id: entity_id(&operation_id)?,
-				account_id: entity_id(&account_id)?,
-				enabled,
-			};
-			execute_account_command(profile, payload, None, idempotency_key).await
-		},
+		Request::EnrollAccount { operation_id, account_id, enabled, idempotency_key, .. } =>
+			enroll_account(profile, operation_id, account_id, enabled, idempotency_key).await,
 		Request::EnableAccount { account_id, expected_revision, idempotency_key, .. } =>
 			set_account_enabled(profile, account_id, true, expected_revision, idempotency_key).await,
 		Request::DisableAccount { account_id, expected_revision, idempotency_key, .. } =>
@@ -687,19 +668,9 @@ async fn execute_request(
 			expected_revision,
 			idempotency_key,
 			..
-		} => {
-			let payload = CommandPayload::LogoutAccount {
-				operation_id: entity_id(&operation_id)?,
-				account_id: entity_id(&account_id)?,
-			};
-			execute_account_command(
-				profile,
-				payload,
-				Some(revision(expected_revision)?),
-				idempotency_key,
-			)
-			.await
-		},
+		} =>
+			logout_account(profile, operation_id, account_id, expected_revision, idempotency_key)
+				.await,
 		Request::SetFixedSelection {
 			account_id,
 			expected_account_revision,
@@ -723,19 +694,9 @@ async fn execute_request(
 			expected_revision,
 			idempotency_key,
 			..
-		} => {
-			let payload = CommandPayload::RefreshAccount {
-				operation_id: entity_id(&operation_id)?,
-				account_id: entity_id(&account_id)?,
-			};
-			execute_account_command(
-				profile,
-				payload,
-				Some(revision(expected_revision)?),
-				idempotency_key,
-			)
-			.await
-		},
+		} =>
+			refresh_account(profile, operation_id, account_id, expected_revision, idempotency_key)
+				.await,
 		Request::StartAccountReauthentication {
 			session_id,
 			operation_id,
@@ -744,56 +705,173 @@ async fn execute_request(
 			idempotency_key,
 			codex_bin,
 			..
-		} => {
-			if !is_canonical_uuid(&session_id)
-				|| codex_bin.is_empty()
-				|| codex_bin.len() > 4_096
-				|| codex_bin.chars().any(char::is_control)
-			{
-				return Err(RequestFailure::Bridge(BridgeFailure::InvalidInput));
-			}
-			let start = account_reauthentication::Start {
+		} => start_account_reauthentication(
+			&native_client,
+			profile,
+			AccountReauthenticationInput {
 				session_id,
-				operation_id: entity_id(&operation_id)?,
-				account_id: entity_id(&account_id)?,
-				expected_revision: revision(expected_revision)?,
-				idempotency_key: parse_idempotency_key(idempotency_key)?,
-				codex_bin: PathBuf::from(codex_bin),
-			};
-			to_value(native_client.account_reauthentication.start(
-				start,
-				profile,
-				tokio::runtime::Handle::current(),
-			))
-		},
-		Request::PollAccountReauthentication { session_id, .. } => {
-			if !is_canonical_uuid(&session_id) {
-				return Err(RequestFailure::Bridge(BridgeFailure::InvalidInput));
-			}
-			to_value(native_client.account_reauthentication.poll(&session_id))
-		},
-		Request::CancelAccountReauthentication { session_id, .. } => {
-			if !is_canonical_uuid(&session_id) {
-				return Err(RequestFailure::Bridge(BridgeFailure::InvalidInput));
-			}
-			to_value(native_client.account_reauthentication.cancel(&session_id))
-		},
+				operation_id,
+				account_id,
+				expected_revision,
+				idempotency_key,
+				codex_bin,
+			},
+		),
+		Request::PollAccountReauthentication { session_id, .. } =>
+			poll_account_reauthentication(&native_client, session_id),
+		Request::CancelAccountReauthentication { session_id, .. } =>
+			cancel_account_reauthentication(&native_client, session_id),
 		Request::UseAccountInCodex { account_id, expected_revision, idempotency_key, .. } =>
 			use_account_in_codex(profile, account_id, expected_revision, idempotency_key).await,
-		Request::FastModeStatus { .. } => {
-			let enabled = fast_mode::status().map_err(RequestFailure::FastMode)?;
-			to_value(FastModeData { enabled })
-		},
-		Request::SetFastMode { enabled, .. } => {
-			let enabled = fast_mode::set_enabled(enabled).map_err(RequestFailure::FastMode)?;
-			to_value(FastModeData { enabled })
-		},
+		Request::FastModeStatus { .. } => fast_mode_status(),
+		Request::SetFastMode { enabled, .. } => set_fast_mode(enabled),
 	}
 }
 
 #[derive(Serialize)]
 struct FastModeData {
 	enabled: bool,
+}
+
+struct AccountReauthenticationInput {
+	session_id: String,
+	operation_id: String,
+	account_id: String,
+	expected_revision: u64,
+	idempotency_key: String,
+	codex_bin: String,
+}
+
+async fn list_accounts(profile: ClientProfile) -> Result<Value, RequestFailure> {
+	to_value(AccountClient::new(profile).list().await.map_err(RequestFailure::Client)?)
+}
+
+async fn get_codex_auth_projection(profile: ClientProfile) -> Result<Value, RequestFailure> {
+	to_value(
+		AccountClient::new(profile)
+			.codex_auth_projection()
+			.await
+			.map_err(RequestFailure::Client)?,
+	)
+}
+
+async fn get_reset_card_status(
+	profile: ClientProfile,
+	idempotency_key: String,
+) -> Result<Value, RequestFailure> {
+	let idempotency_key = parse_idempotency_key(idempotency_key)?;
+	to_value(
+		ResetCardClient::new(profile)
+			.status(idempotency_key)
+			.await
+			.map_err(RequestFailure::Client)?,
+	)
+}
+
+async fn enroll_account(
+	profile: ClientProfile,
+	operation_id: String,
+	account_id: String,
+	enabled: bool,
+	idempotency_key: String,
+) -> Result<Value, RequestFailure> {
+	let payload = CommandPayload::EnrollAccountFromSharedCodex {
+		operation_id: entity_id(&operation_id)?,
+		account_id: entity_id(&account_id)?,
+		enabled,
+	};
+	execute_account_command(profile, payload, None, idempotency_key).await
+}
+
+async fn logout_account(
+	profile: ClientProfile,
+	operation_id: String,
+	account_id: String,
+	expected_revision: u64,
+	idempotency_key: String,
+) -> Result<Value, RequestFailure> {
+	let payload = CommandPayload::LogoutAccount {
+		operation_id: entity_id(&operation_id)?,
+		account_id: entity_id(&account_id)?,
+	};
+	execute_account_command(profile, payload, Some(revision(expected_revision)?), idempotency_key)
+		.await
+}
+
+async fn refresh_account(
+	profile: ClientProfile,
+	operation_id: String,
+	account_id: String,
+	expected_revision: u64,
+	idempotency_key: String,
+) -> Result<Value, RequestFailure> {
+	let payload = CommandPayload::RefreshAccount {
+		operation_id: entity_id(&operation_id)?,
+		account_id: entity_id(&account_id)?,
+	};
+	execute_account_command(profile, payload, Some(revision(expected_revision)?), idempotency_key)
+		.await
+}
+
+fn start_account_reauthentication(
+	native_client: &NativeClient,
+	profile: ClientProfile,
+	input: AccountReauthenticationInput,
+) -> Result<Value, RequestFailure> {
+	if !is_canonical_uuid(&input.session_id)
+		|| input.codex_bin.is_empty()
+		|| input.codex_bin.len() > 4_096
+		|| input.codex_bin.chars().any(char::is_control)
+	{
+		return Err(RequestFailure::Bridge(BridgeFailure::InvalidInput));
+	}
+	let start = account_reauthentication::Start {
+		session_id: input.session_id,
+		operation_id: entity_id(&input.operation_id)?,
+		account_id: entity_id(&input.account_id)?,
+		expected_revision: revision(input.expected_revision)?,
+		idempotency_key: parse_idempotency_key(input.idempotency_key)?,
+		codex_bin: PathBuf::from(input.codex_bin),
+	};
+	to_value(native_client.account_reauthentication.start(
+		start,
+		profile,
+		tokio::runtime::Handle::current(),
+	))
+}
+
+fn poll_account_reauthentication(
+	native_client: &NativeClient,
+	session_id: String,
+) -> Result<Value, RequestFailure> {
+	validate_session_id(&session_id)?;
+	to_value(native_client.account_reauthentication.poll(&session_id))
+}
+
+fn cancel_account_reauthentication(
+	native_client: &NativeClient,
+	session_id: String,
+) -> Result<Value, RequestFailure> {
+	validate_session_id(&session_id)?;
+	to_value(native_client.account_reauthentication.cancel(&session_id))
+}
+
+fn validate_session_id(session_id: &str) -> Result<(), RequestFailure> {
+	if is_canonical_uuid(session_id) {
+		Ok(())
+	} else {
+		Err(RequestFailure::Bridge(BridgeFailure::InvalidInput))
+	}
+}
+
+fn fast_mode_status() -> Result<Value, RequestFailure> {
+	let enabled = fast_mode::status().map_err(RequestFailure::FastMode)?;
+	to_value(FastModeData { enabled })
+}
+
+fn set_fast_mode(enabled: bool) -> Result<Value, RequestFailure> {
+	let enabled = fast_mode::set_enabled(enabled).map_err(RequestFailure::FastMode)?;
+	to_value(FastModeData { enabled })
 }
 
 async fn get_reset_cards(

--- a/crates/decodex-runtime/src/account_service.rs
+++ b/crates/decodex-runtime/src/account_service.rs
@@ -366,6 +366,14 @@ pub enum AccountManualRecoveryOutcome {
 	StillRequiresRecovery,
 }
 
+struct ReauthenticationCommandInput<'a> {
+	operation_id: AccountOperationId,
+	account_id: &'a AccountId,
+	expected_account_revision: i64,
+	source_descriptor: &'a str,
+	account: &'a AccountRecord,
+}
+
 /// Sole account lifecycle coordinator in `decodexd`.
 pub struct AccountService {
 	store: PostgresStore,
@@ -1032,149 +1040,155 @@ impl AccountService {
 	{
 		let lock = self.lock_for(account_id)?;
 		let _guard = lock.lock().await;
-		let mut build_response = Some(build_response);
 		let account = match self.load_account(account_id).await {
 			Ok(account) => account,
 			Err(error) => {
-				return self
-					.complete_account_command_error(
-						lease,
-						error,
-						build_response.take().expect("builder is retained"),
-					)
-					.await;
+				return self.complete_account_command_error(lease, error, build_response).await;
 			},
 		};
 		if let Some(operation) = self.store.read_account_operation(&operation_id).await? {
-			if let Err(error) = self.require_operation_identity(
-				&operation,
-				account_id,
-				AccountOperationKind::Refresh,
-			) {
-				return self
-					.complete_account_command_error(
-						lease,
-						error,
-						build_response.take().expect("builder is retained"),
-					)
-					.await;
-			}
-			if operation.expected_account_revision != Some(expected_account_revision) {
-				return self
-					.complete_account_command_error(
-						lease,
-						AccountLifecycleError::StaleAccount,
-						build_response.take().expect("builder is retained"),
-					)
-					.await;
-			}
-			match classify_reauthentication_replay(
-				operation.phase,
-				operation.expected.as_ref(),
-				operation.target.as_ref(),
-				|binding| self.credentials.read_exact(account_id, binding).map(|_| ()),
-			) {
-				ReauthenticationReplayDisposition::Complete => {
-					if !matches!(
-						operation.phase,
-						AccountOperationPhase::StoreApplied | AccountOperationPhase::Committed
-					) {
-						accepted_phase(
-							self.store
-								.advance_account_operation(
-									&operation_id,
-									operation.phase,
-									AccountOperationPhase::StoreApplied,
-									None,
-								)
-								.await?,
-						)?;
-					}
-					return self
-						.complete_account_operation_success(
-							lease,
-							&operation_id,
-							AccountOperationPhase::StoreApplied,
-							AccountOperationPhase::Committed,
-							build_response.take().expect("builder is retained"),
-						)
-						.await;
-				},
-				ReauthenticationReplayDisposition::Cancel => {
-					return self
-						.complete_account_operation_error(
-							lease,
-							&operation_id,
-							operation.phase,
-							AccountOperationPhase::Cancelled,
-							None,
-							AccountLifecycleError::InvalidOperation,
-							build_response.take().expect("builder is retained"),
-						)
-						.await;
-				},
-				ReauthenticationReplayDisposition::Recover => {
-					return self
-						.complete_account_operation_error(
-							lease,
-							&operation_id,
-							operation.phase,
-							AccountOperationPhase::RecoveryRequired,
-							Some("credential_reauthentication_reconciliation"),
-							AccountLifecycleError::NotReady(
-								AccountLifecycleReadiness::OperationUnsettled,
-							),
-							build_response.take().expect("builder is retained"),
-						)
-						.await;
-				},
-			}
-		}
-		let current = match reauthentication_current(&account, expected_account_revision) {
-			Ok(current) => current,
-			Err(error) => {
-				return self
-					.complete_account_command_error(
-						lease,
-						error,
-						build_response.take().expect("builder is retained"),
-					)
-					.await;
-			},
-		};
-		let imported = match read_explicit_shared_codex_credential_file(source_descriptor) {
-			Ok(imported) => imported,
-			Err(error) => {
-				return self
-					.complete_account_command_error(
-						lease,
-						error.into(),
-						build_response.take().expect("builder is retained"),
-					)
-					.await;
-			},
-		};
-		let target = match reauthentication_target(&current, account_id, &operation_id, &imported) {
-			Ok(target) => target,
-			Err(error) => {
-				return self
-					.complete_account_command_error(
-						lease,
-						error,
-						build_response.take().expect("builder is retained"),
-					)
-					.await;
-			},
-		};
-		if let Err(error) = self.credentials.read_exact(account_id, &current) {
 			return self
-				.complete_account_command_error(
+				.complete_reauthentication_replay(
 					lease,
-					error.into(),
-					build_response.take().expect("builder is retained"),
+					&operation_id,
+					account_id,
+					expected_account_revision,
+					&operation,
+					build_response,
 				)
 				.await;
 		}
+		let input = ReauthenticationCommandInput {
+			operation_id,
+			account_id,
+			expected_account_revision,
+			source_descriptor,
+			account: &account,
+		};
+		self.continue_reauthentication_command(lease, input, build_response).await
+	}
+
+	async fn complete_reauthentication_replay<F>(
+		&self,
+		lease: AccountCommandReceiptLease,
+		operation_id: &AccountOperationId,
+		account_id: &AccountId,
+		expected_account_revision: i64,
+		operation: &AccountOperation,
+		build_response: F,
+	) -> Result<Value, AccountLifecycleError>
+	where
+		F: FnOnce(Result<&AccountRecord, AccountLifecycleError>) -> Result<Value, StoreError>
+			+ Send,
+	{
+		let disposition = match self.reauthentication_replay_disposition(
+			operation,
+			account_id,
+			expected_account_revision,
+		) {
+			Ok(disposition) => disposition,
+			Err(error) => {
+				return self.complete_account_command_error(lease, error, build_response).await;
+			},
+		};
+		match disposition {
+			ReauthenticationReplayDisposition::Complete => {
+				if !matches!(
+					operation.phase,
+					AccountOperationPhase::StoreApplied | AccountOperationPhase::Committed
+				) {
+					accepted_phase(
+						self.store
+							.advance_account_operation(
+								operation_id,
+								operation.phase,
+								AccountOperationPhase::StoreApplied,
+								None,
+							)
+							.await?,
+					)?;
+				}
+				self.complete_account_operation_success(
+					lease,
+					operation_id,
+					AccountOperationPhase::StoreApplied,
+					AccountOperationPhase::Committed,
+					build_response,
+				)
+				.await
+			},
+			ReauthenticationReplayDisposition::Cancel =>
+				self.complete_account_operation_error(
+					lease,
+					operation_id,
+					operation.phase,
+					AccountOperationPhase::Cancelled,
+					None,
+					AccountLifecycleError::InvalidOperation,
+					build_response,
+				)
+				.await,
+			ReauthenticationReplayDisposition::Recover =>
+				self.complete_account_operation_error(
+					lease,
+					operation_id,
+					operation.phase,
+					AccountOperationPhase::RecoveryRequired,
+					Some("credential_reauthentication_reconciliation"),
+					AccountLifecycleError::NotReady(AccountLifecycleReadiness::OperationUnsettled),
+					build_response,
+				)
+				.await,
+		}
+	}
+
+	fn reauthentication_replay_disposition(
+		&self,
+		operation: &AccountOperation,
+		account_id: &AccountId,
+		expected_account_revision: i64,
+	) -> Result<ReauthenticationReplayDisposition, AccountLifecycleError> {
+		self.require_operation_identity(operation, account_id, AccountOperationKind::Refresh)?;
+		if operation.expected_account_revision != Some(expected_account_revision) {
+			return Err(AccountLifecycleError::StaleAccount);
+		}
+		Ok(classify_reauthentication_replay(
+			operation.phase,
+			operation.expected.as_ref(),
+			operation.target.as_ref(),
+			|binding| self.credentials.read_exact(account_id, binding).map(|_| ()),
+		))
+	}
+
+	async fn continue_reauthentication_command<F>(
+		&self,
+		lease: AccountCommandReceiptLease,
+		input: ReauthenticationCommandInput<'_>,
+		build_response: F,
+	) -> Result<Value, AccountLifecycleError>
+	where
+		F: FnOnce(Result<&AccountRecord, AccountLifecycleError>) -> Result<Value, StoreError>
+			+ Send,
+	{
+		let ReauthenticationCommandInput {
+			operation_id,
+			account_id,
+			expected_account_revision,
+			source_descriptor,
+			account,
+		} = input;
+		let (current, imported, target) = match self.reauthentication_material(
+			account,
+			expected_account_revision,
+			account_id,
+			&operation_id,
+			source_descriptor,
+		) {
+			Ok(material) => material,
+			Err(error) => {
+				return self.complete_account_command_error(lease, error, build_response).await;
+			},
+		};
 		let preparation = AccountOperationPreparation {
 			operation_id: operation_id.clone(),
 			account_id: account_id.clone(),
@@ -1184,7 +1198,7 @@ impl AccountService {
 			expected_account_revision: Some(expected_account_revision),
 			expected: Some(current.clone()),
 			target: Some(target.clone()),
-			provider: imported.provider,
+			provider: imported.provider.clone(),
 		};
 		let phase = match self.store.prepare_account_operation(&preparation).await? {
 			AccountLifecycleMutationOutcome::Applied(mutation)
@@ -1194,7 +1208,7 @@ impl AccountService {
 					.complete_account_command_error(
 						lease,
 						AccountLifecycleError::OperationRejected(rejection),
-						build_response.take().expect("builder is retained"),
+						build_response,
 					)
 					.await;
 			},
@@ -1204,7 +1218,7 @@ impl AccountService {
 				.complete_account_command_error(
 					lease,
 					AccountLifecycleError::InvalidOperation,
-					build_response.take().expect("builder is retained"),
+					build_response,
 				)
 				.await;
 		}
@@ -1230,7 +1244,7 @@ impl AccountService {
 					},
 					ambiguous.then_some("credential_reauthentication_reconciliation"),
 					error.into(),
-					build_response.take().expect("builder is retained"),
+					build_response,
 				)
 				.await;
 		}
@@ -1249,9 +1263,25 @@ impl AccountService {
 			&operation_id,
 			AccountOperationPhase::StoreApplied,
 			AccountOperationPhase::Committed,
-			build_response.take().expect("builder is retained"),
+			build_response,
 		)
 		.await
+	}
+
+	fn reauthentication_material(
+		&self,
+		account: &AccountRecord,
+		expected_account_revision: i64,
+		account_id: &AccountId,
+		operation_id: &AccountOperationId,
+		source_descriptor: &str,
+	) -> Result<(CredentialBinding, ImportedCredential, CredentialBinding), AccountLifecycleError>
+	{
+		let current = reauthentication_current(account, expected_account_revision)?;
+		let imported = read_explicit_shared_codex_credential_file(source_descriptor)?;
+		let target = reauthentication_target(&current, account_id, operation_id, &imported)?;
+		self.credentials.read_exact(account_id, &current)?;
+		Ok((current, imported, target))
 	}
 
 	/// Refresh one account and atomically commit the exact final registry result with its logical
@@ -3019,144 +3049,121 @@ impl AccountService {
 		&self,
 		operation: &AccountOperation,
 	) -> Result<ReconciliationDisposition, AccountLifecycleError> {
-		if operation.phase == AccountOperationPhase::Committed {
-			return Ok(ReconciliationDisposition::Committed);
-		}
-		if operation.phase == AccountOperationPhase::Cancelled {
-			return Ok(ReconciliationDisposition::Cancelled);
-		}
-		if operation.phase == AccountOperationPhase::RecoveryRequired {
-			return Ok(ReconciliationDisposition::Manual);
-		}
-		if operation.phase == AccountOperationPhase::StoreApplied {
-			self.commit_store_applied(&operation.operation_id).await?;
-			return Ok(ReconciliationDisposition::Committed);
+		if let Some(disposition) = self.reconcile_terminal_phase(operation).await? {
+			return Ok(disposition);
 		}
 		match operation.kind {
-			AccountOperationKind::Enroll | AccountOperationKind::Import => {
-				let target =
-					operation.target.as_ref().ok_or(AccountLifecycleError::InvalidOperation)?;
-				match self.credentials.read_exact(&operation.account_id, target) {
-					Ok(_) => {
-						accepted_phase(
-							self.store
-								.advance_account_operation(
-									&operation.operation_id,
-									operation.phase,
-									AccountOperationPhase::StoreApplied,
-									None,
-								)
-								.await?,
-						)?;
-						self.commit_store_applied(&operation.operation_id).await?;
-						Ok(ReconciliationDisposition::Committed)
-					},
-					Err(CredentialStoreError::NotFound)
-						if operation.phase == AccountOperationPhase::Prepared =>
-					{
-						accepted_phase(
-							self.store
-								.advance_account_operation(
-									&operation.operation_id,
-									operation.phase,
-									AccountOperationPhase::Cancelled,
-									None,
-								)
-								.await?,
-						)?;
-						Ok(ReconciliationDisposition::Cancelled)
-					},
-					Err(_) => self.mark_manual(operation, "credential_import_reconciliation").await,
-				}
-			},
-			AccountOperationKind::Refresh => {
-				if operation.phase == AccountOperationPhase::Prepared {
-					return match classify_prepared_refresh_reconciliation(
-						operation.expected.as_ref(),
-						operation.target.as_ref(),
-						|binding| {
-							self.credentials.read_exact(&operation.account_id, binding).map(|_| ())
-						},
-					) {
-						PreparedRefreshReconciliation::StoreApplied => {
-							accepted_phase(
-								self.store
-									.advance_account_operation(
-										&operation.operation_id,
-										operation.phase,
-										AccountOperationPhase::StoreApplied,
-										None,
-									)
-									.await?,
-							)?;
-							self.commit_store_applied(&operation.operation_id).await?;
-							Ok(ReconciliationDisposition::Committed)
-						},
-						PreparedRefreshReconciliation::NotApplied => {
-							accepted_phase(
-								self.store
-									.advance_account_operation(
-										&operation.operation_id,
-										operation.phase,
-										AccountOperationPhase::Cancelled,
-										None,
-									)
-									.await?,
-							)?;
-							Ok(ReconciliationDisposition::Cancelled)
-						},
-						PreparedRefreshReconciliation::RecoveryRequired =>
-							self.mark_manual(
-								operation,
-								"credential_reauthentication_reconciliation",
-							)
-							.await,
-					};
-				}
-				let Some(target) = operation.target.as_ref() else {
-					return self.mark_manual(operation, PROVIDER_REFRESH_OUTCOME_UNKNOWN).await;
-				};
-				match self.credentials.read_exact(&operation.account_id, target) {
-					Ok(_) => {
-						accepted_phase(
-							self.store
-								.advance_account_operation(
-									&operation.operation_id,
-									operation.phase,
-									AccountOperationPhase::StoreApplied,
-									None,
-								)
-								.await?,
-						)?;
-						self.commit_store_applied(&operation.operation_id).await?;
-						Ok(ReconciliationDisposition::Committed)
-					},
-					Err(_) =>
-						self.mark_manual(operation, "credential_refresh_reconciliation").await,
-				}
-			},
-			AccountOperationKind::Logout => {
-				let expected =
-					operation.expected.as_ref().ok_or(AccountLifecycleError::InvalidOperation)?;
-				match self.credentials.delete(&operation.account_id, expected) {
-					Ok(()) | Err(CredentialStoreError::NotFound) => {
-						accepted_phase(
-							self.store
-								.advance_account_operation(
-									&operation.operation_id,
-									operation.phase,
-									AccountOperationPhase::StoreApplied,
-									None,
-								)
-								.await?,
-						)?;
-						self.commit_store_applied(&operation.operation_id).await?;
-						Ok(ReconciliationDisposition::Committed)
-					},
-					Err(_) => self.mark_manual(operation, "credential_logout_reconciliation").await,
-				}
-			},
+			AccountOperationKind::Enroll | AccountOperationKind::Import =>
+				self.reconcile_import_operation(operation).await,
+			AccountOperationKind::Refresh => self.reconcile_refresh_operation(operation).await,
+			AccountOperationKind::Logout => self.reconcile_logout_operation(operation).await,
 		}
+	}
+
+	async fn reconcile_terminal_phase(
+		&self,
+		operation: &AccountOperation,
+	) -> Result<Option<ReconciliationDisposition>, AccountLifecycleError> {
+		match operation.phase {
+			AccountOperationPhase::Committed => Ok(Some(ReconciliationDisposition::Committed)),
+			AccountOperationPhase::Cancelled => Ok(Some(ReconciliationDisposition::Cancelled)),
+			AccountOperationPhase::RecoveryRequired => Ok(Some(ReconciliationDisposition::Manual)),
+			AccountOperationPhase::StoreApplied => {
+				self.commit_store_applied(&operation.operation_id).await?;
+				Ok(Some(ReconciliationDisposition::Committed))
+			},
+			AccountOperationPhase::Prepared | AccountOperationPhase::ProviderEffectPending =>
+				Ok(None),
+		}
+	}
+
+	async fn reconcile_import_operation(
+		&self,
+		operation: &AccountOperation,
+	) -> Result<ReconciliationDisposition, AccountLifecycleError> {
+		let target = operation.target.as_ref().ok_or(AccountLifecycleError::InvalidOperation)?;
+		match self.credentials.read_exact(&operation.account_id, target) {
+			Ok(_) => self.commit_reconciled_operation(operation).await,
+			Err(CredentialStoreError::NotFound)
+				if operation.phase == AccountOperationPhase::Prepared =>
+				self.cancel_reconciled_operation(operation).await,
+			Err(_) => self.mark_manual(operation, "credential_import_reconciliation").await,
+		}
+	}
+
+	async fn reconcile_refresh_operation(
+		&self,
+		operation: &AccountOperation,
+	) -> Result<ReconciliationDisposition, AccountLifecycleError> {
+		if operation.phase == AccountOperationPhase::Prepared {
+			return match classify_prepared_refresh_reconciliation(
+				operation.expected.as_ref(),
+				operation.target.as_ref(),
+				|binding| self.credentials.read_exact(&operation.account_id, binding).map(|_| ()),
+			) {
+				PreparedRefreshReconciliation::StoreApplied =>
+					self.commit_reconciled_operation(operation).await,
+				PreparedRefreshReconciliation::NotApplied =>
+					self.cancel_reconciled_operation(operation).await,
+				PreparedRefreshReconciliation::RecoveryRequired =>
+					self.mark_manual(operation, "credential_reauthentication_reconciliation").await,
+			};
+		}
+		let Some(target) = operation.target.as_ref() else {
+			return self.mark_manual(operation, PROVIDER_REFRESH_OUTCOME_UNKNOWN).await;
+		};
+		match self.credentials.read_exact(&operation.account_id, target) {
+			Ok(_) => self.commit_reconciled_operation(operation).await,
+			Err(_) => self.mark_manual(operation, "credential_refresh_reconciliation").await,
+		}
+	}
+
+	async fn reconcile_logout_operation(
+		&self,
+		operation: &AccountOperation,
+	) -> Result<ReconciliationDisposition, AccountLifecycleError> {
+		let expected =
+			operation.expected.as_ref().ok_or(AccountLifecycleError::InvalidOperation)?;
+		match self.credentials.delete(&operation.account_id, expected) {
+			Ok(()) | Err(CredentialStoreError::NotFound) =>
+				self.commit_reconciled_operation(operation).await,
+			Err(_) => self.mark_manual(operation, "credential_logout_reconciliation").await,
+		}
+	}
+
+	async fn commit_reconciled_operation(
+		&self,
+		operation: &AccountOperation,
+	) -> Result<ReconciliationDisposition, AccountLifecycleError> {
+		accepted_phase(
+			self.store
+				.advance_account_operation(
+					&operation.operation_id,
+					operation.phase,
+					AccountOperationPhase::StoreApplied,
+					None,
+				)
+				.await?,
+		)?;
+		self.commit_store_applied(&operation.operation_id).await?;
+		Ok(ReconciliationDisposition::Committed)
+	}
+
+	async fn cancel_reconciled_operation(
+		&self,
+		operation: &AccountOperation,
+	) -> Result<ReconciliationDisposition, AccountLifecycleError> {
+		accepted_phase(
+			self.store
+				.advance_account_operation(
+					&operation.operation_id,
+					operation.phase,
+					AccountOperationPhase::Cancelled,
+					None,
+				)
+				.await?,
+		)?;
+		Ok(ReconciliationDisposition::Cancelled)
 	}
 
 	async fn mark_manual(

--- a/crates/decodex-runtime/src/auth_projection.rs
+++ b/crates/decodex-runtime/src/auth_projection.rs
@@ -406,6 +406,15 @@ fn now_rfc3339() -> Result<String, CodexAuthProjectionError> {
 }
 
 fn open_codex_directory(home: &Path) -> Result<File, CodexAuthProjectionError> {
+	#[cfg(test)]
+	if std::env::var_os("DECODEX_CANDIDATE_SANDBOX").as_deref() == Some(std::ffi::OsStr::new("1")) {
+		let root = std::env::var_os("TMPDIR")
+			.filter(|value| !value.is_empty())
+			.map(PathBuf::from)
+			.ok_or(CodexAuthProjectionError::UnsafePath)?;
+		return open_pinned_sandbox_codex_directory(home, &root);
+	}
+
 	if !home.is_absolute() {
 		return Err(CodexAuthProjectionError::UnsafePath);
 	}
@@ -426,6 +435,168 @@ fn open_codex_directory(home: &Path) -> Result<File, CodexAuthProjectionError> {
 	let codex = open_directory_at(current.as_raw_fd(), CODEX_DIRECTORY_NAME.to_bytes())?;
 	validate_ancestor(&codex, true)?;
 	Ok(codex)
+}
+
+#[cfg(test)]
+fn open_pinned_sandbox_codex_directory(
+	home: &Path,
+	root: &Path,
+) -> Result<File, CodexAuthProjectionError> {
+	if !root.is_absolute() || home == root || !home.starts_with(root) {
+		return Err(CodexAuthProjectionError::UnsafePath);
+	}
+	let mut current = open_exact_sandbox_root(root)?;
+	let relative = home.strip_prefix(root).map_err(|_| CodexAuthProjectionError::UnsafePath)?;
+	for component in relative.components() {
+		let Component::Normal(name) = component else {
+			return Err(CodexAuthProjectionError::UnsafePath);
+		};
+		current = open_directory_at(current.as_raw_fd(), name.as_bytes())?;
+		validate_ancestor(&current, true)?;
+	}
+	let codex = open_directory_at(current.as_raw_fd(), CODEX_DIRECTORY_NAME.to_bytes())?;
+	validate_ancestor(&codex, true)?;
+	Ok(codex)
+}
+
+#[cfg(test)]
+fn open_exact_sandbox_root(root: &Path) -> Result<File, CodexAuthProjectionError> {
+	open_exact_sandbox_root_after_metadata(root, || {})
+}
+
+#[cfg(test)]
+fn open_exact_sandbox_root_after_metadata<F>(
+	root: &Path,
+	after_metadata: F,
+) -> Result<File, CodexAuthProjectionError>
+where
+	F: FnOnce(),
+{
+	if !root.is_absolute() {
+		return Err(CodexAuthProjectionError::UnsafePath);
+	}
+	let before =
+		std::fs::symlink_metadata(root).map_err(|_| CodexAuthProjectionError::UnsafePath)?;
+	validate_exact_sandbox_root(&before)?;
+	after_metadata();
+	let current = open_directory_path(root)?;
+	let after = current.metadata().map_err(|_| CodexAuthProjectionError::UnsafePath)?;
+	validate_exact_sandbox_root(&after)?;
+	if before.dev() != after.dev() || before.ino() != after.ino() {
+		return Err(CodexAuthProjectionError::UnsafePath);
+	}
+	Ok(current)
+}
+
+#[cfg(test)]
+fn validate_exact_sandbox_root(
+	metadata: &std::fs::Metadata,
+) -> Result<(), CodexAuthProjectionError> {
+	let effective_uid = unsafe { libc::geteuid() };
+	if !metadata.is_dir() || metadata.uid() != effective_uid || metadata.mode() & 0o7777 != 0o700 {
+		return Err(CodexAuthProjectionError::UnsafePath);
+	}
+	Ok(())
+}
+
+#[cfg(test)]
+struct PinnedSandboxFixtureHome {
+	root: File,
+	home: File,
+	codex: File,
+	path: PathBuf,
+	name: CString,
+}
+
+#[cfg(test)]
+impl PinnedSandboxFixtureHome {
+	fn new() -> Result<Self, CodexAuthProjectionError> {
+		let root_path = std::env::var_os("TMPDIR")
+			.filter(|value| !value.is_empty())
+			.map(PathBuf::from)
+			.ok_or(CodexAuthProjectionError::UnsafePath)?;
+		let root = open_exact_sandbox_root(&root_path)?;
+		let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+		let name =
+			CString::new(format!("auth-projection-fixture-{}-{sequence}", std::process::id()))
+				.map_err(|_| CodexAuthProjectionError::UnsafePath)?;
+		let home = create_exact_private_directory_at(&root, &name)?;
+		let codex = match create_exact_private_directory_at(&home, CODEX_DIRECTORY_NAME) {
+			Ok(codex) => codex,
+			Err(error) => {
+				let _ =
+					unsafe { libc::unlinkat(root.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR) };
+				return Err(error);
+			},
+		};
+		let path = root_path.join(std::ffi::OsStr::from_bytes(name.to_bytes()));
+		Ok(Self { root, home, codex, path, name })
+	}
+
+	fn path(&self) -> &Path {
+		&self.path
+	}
+}
+
+#[cfg(test)]
+impl Drop for PinnedSandboxFixtureHome {
+	fn drop(&mut self) {
+		let _ = unsafe { libc::unlinkat(self.codex.as_raw_fd(), AUTH_FILE_NAME.as_ptr(), 0) };
+		let _ = unsafe { libc::unlinkat(self.home.as_raw_fd(), c"outside".as_ptr(), 0) };
+		if directory_entry_matches(&self.home, CODEX_DIRECTORY_NAME, &self.codex) {
+			let _ = unsafe {
+				libc::unlinkat(
+					self.home.as_raw_fd(),
+					CODEX_DIRECTORY_NAME.as_ptr(),
+					libc::AT_REMOVEDIR,
+				)
+			};
+		}
+		if directory_entry_matches(&self.root, &self.name, &self.home) {
+			let _ = unsafe {
+				libc::unlinkat(self.root.as_raw_fd(), self.name.as_ptr(), libc::AT_REMOVEDIR)
+			};
+		}
+	}
+}
+
+#[cfg(test)]
+fn create_exact_private_directory_at(
+	parent: &File,
+	name: &CStr,
+) -> Result<File, CodexAuthProjectionError> {
+	if unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o700) } != 0 {
+		return Err(CodexAuthProjectionError::UnsafePath);
+	}
+	let directory = match open_directory_at(parent.as_raw_fd(), name.to_bytes()) {
+		Ok(directory) => directory,
+		Err(error) => {
+			let _ =
+				unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR) };
+			return Err(error);
+		},
+	};
+	if unsafe { libc::fchmod(directory.as_raw_fd(), 0o700) } != 0
+		|| validate_exact_sandbox_root(
+			&directory.metadata().map_err(|_| CodexAuthProjectionError::UnsafePath)?,
+		)
+		.is_err()
+	{
+		let _ = unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR) };
+		return Err(CodexAuthProjectionError::UnsafePath);
+	}
+	Ok(directory)
+}
+
+#[cfg(test)]
+fn directory_entry_matches(parent: &File, name: &CStr, expected: &File) -> bool {
+	let Ok(current) = open_directory_at(parent.as_raw_fd(), name.to_bytes()) else {
+		return false;
+	};
+	let (Ok(current), Ok(expected)) = (current.metadata(), expected.metadata()) else {
+		return false;
+	};
+	current.dev() == expected.dev() && current.ino() == expected.ino()
 }
 
 fn open_directory_path(path: &Path) -> Result<File, CodexAuthProjectionError> {
@@ -647,11 +818,27 @@ mod tests {
 	use tempfile::tempdir_in;
 
 	use super::{
-		CodexAuthProjectionError, ProjectionFault, SharedCodexAuthIdentity, current_auth_matches,
-		open_codex_directory, project_shared_codex_auth_at, project_to_directory,
+		CodexAuthProjectionError, PinnedSandboxFixtureHome, ProjectionFault,
+		SharedCodexAuthIdentity, current_auth_matches, open_codex_directory,
+		open_exact_sandbox_root, open_exact_sandbox_root_after_metadata,
+		open_pinned_sandbox_codex_directory, project_shared_codex_auth_at, project_to_directory,
 		read_identity_from_directory,
 	};
 	use crate::host_credentials::CredentialSecretBundle;
+
+	enum FixtureHome {
+		Ordinary(tempfile::TempDir),
+		Sandboxed(PinnedSandboxFixtureHome),
+	}
+
+	impl FixtureHome {
+		fn path(&self) -> &Path {
+			match self {
+				Self::Ordinary(home) => home.path(),
+				Self::Sandboxed(home) => home.path(),
+			}
+		}
+	}
 
 	fn bundle(id_token: Option<&str>, suffix: &str) -> CredentialSecretBundle {
 		CredentialSecretBundle::chatgpt(
@@ -666,11 +853,64 @@ mod tests {
 		.unwrap()
 	}
 
-	fn fixture_home() -> tempfile::TempDir {
-		let current = std::env::current_dir().unwrap();
-		let home = tempdir_in(current).unwrap();
-		fs::create_dir(home.path().join(".codex")).unwrap();
-		home
+	fn fixture_home() -> FixtureHome {
+		if std::env::var_os("DECODEX_CANDIDATE_SANDBOX").as_deref()
+			== Some(std::ffi::OsStr::new("1"))
+		{
+			FixtureHome::Sandboxed(PinnedSandboxFixtureHome::new().unwrap())
+		} else {
+			let home = tempdir_in(std::env::current_dir().unwrap()).unwrap();
+			fs::create_dir(home.path().join(".codex")).unwrap();
+			FixtureHome::Ordinary(home)
+		}
+	}
+
+	#[test]
+	fn sandbox_codex_root_is_exact_private_and_descriptor_pinned() {
+		let fixture = fixture_home();
+		let root = fixture.path().join("sandbox");
+		let home = root.join("home");
+		fs::create_dir(&root).unwrap();
+		fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+		fs::create_dir(&home).unwrap();
+		fs::create_dir(home.join(".codex")).unwrap();
+
+		open_pinned_sandbox_codex_directory(&home, &root).unwrap();
+		assert!(open_pinned_sandbox_codex_directory(fixture.path(), &root).is_err());
+		fs::set_permissions(&root, fs::Permissions::from_mode(0o1700)).unwrap();
+		assert!(open_pinned_sandbox_codex_directory(&home, &root).is_err());
+		fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+
+		let root_link = fixture.path().join("root-link");
+		symlink(&root, &root_link).unwrap();
+		assert!(open_exact_sandbox_root(&root_link).is_err());
+		fs::remove_file(&root_link).unwrap();
+
+		let retained = fixture.path().join("retained-root");
+		assert!(
+			open_exact_sandbox_root_after_metadata(&root, || {
+				fs::rename(&root, &retained).unwrap();
+				symlink(&retained, &root).unwrap();
+			})
+			.is_err()
+		);
+		fs::remove_file(&root).unwrap();
+		fs::rename(&retained, &root).unwrap();
+
+		let symlink_home = root.join("symlink-home");
+		symlink(&home, &symlink_home).unwrap();
+		assert!(open_pinned_sandbox_codex_directory(&symlink_home, &root).is_err());
+		fs::remove_file(symlink_home).unwrap();
+
+		let linked_codex_home = root.join("linked-codex-home");
+		fs::create_dir(&linked_codex_home).unwrap();
+		symlink(home.join(".codex"), linked_codex_home.join(".codex")).unwrap();
+		assert!(open_pinned_sandbox_codex_directory(&linked_codex_home, &root).is_err());
+		fs::remove_file(linked_codex_home.join(".codex")).unwrap();
+		fs::remove_dir(linked_codex_home).unwrap();
+		fs::remove_dir(home.join(".codex")).unwrap();
+		fs::remove_dir(home).unwrap();
+		fs::remove_dir(root).unwrap();
 	}
 
 	fn read_auth(home: &Path) -> Value {

--- a/crates/decodex-runtime/src/host_credentials.rs
+++ b/crates/decodex-runtime/src/host_credentials.rs
@@ -675,9 +675,11 @@ mod macos {
 				return;
 			}
 
+			let temporary_root =
+				fs::canonicalize(env::temp_dir()).expect("temporary root is canonical");
 			let temporary = tempfile::Builder::new()
 				.prefix("decodex-keychain-lock-")
-				.tempdir_in("/private/tmp")
+				.tempdir_in(temporary_root)
 				.expect("temporary root exists");
 			let root = DecodexRoot::new(temporary.path().join("decodex-root"))
 				.expect("temporary Decodex root is valid");


### PR DESCRIPTION
## Summary
- isolate full Xcode validation from host xcrun and Metal caches
- bind and revalidate exact Xcode, SDK, compiler, Metal, and proxy evidence
- harden Radar, Publisher, auth, account, and Keychain sandbox fixtures

## Validation
- formal maintainer profiles: focused_tests, check-upstream-automation-sandboxed, check-sandboxed all passed
- cargo make test-automations: 265 passed
- real deny-default workspace cargo check and strict Clippy passed
- independent high-reasoning review: ACCEPT
