### PR TITLE
Remove stale quota UI and stabilize account refresh

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -27,10 +27,16 @@ independent Reset Card and account-profile requests for each row. A slow or
 failed provider request affects only its account row and does not block another
 row or account action.
 
-Each row shows the exact 300-minute and 10,080-minute quota observations in a
-vertical stack, their current or stale state, the percentage left and reset
-time when known, and every complete public Reset Card expiry. The 300-minute
-row is absent when the provider does not return a supported observation.
+Each row shows the exact current 300-minute and 10,080-minute quota
+observations in a vertical stack, the percentage left and reset time when
+known, and every complete public Reset Card expiry. Expired observations are
+not shown as current data. The 300-minute row is absent when the provider does
+not return a supported observation.
+
+The app performs one non-overlapping refresh every 15 seconds, matching the
+pre-cutover native cadence. Opening the panel also requests one refresh. An
+already active refresh absorbs either trigger, and one failed account remains
+isolated to its row until the next cycle.
 
 Each account detail popover contains lifetime tokens, peak daily tokens,
 longest task, current and longest streaks, and a 36-day usage chart. The compact
@@ -78,10 +84,10 @@ preserved and blocks new use.
 The panel also exposes current daemon-owned account controls: enroll the
 currently signed-in shared Codex login, enable or disable, log out, and select
 fixed or balanced routing. An account with a provider-confirmed unauthorized
-profile shows `Refresh login`; that action presents the official device code,
-Copy, Open browser, and Cancel controls, then refreshes only that account after
-the daemon completes the exact credential replacement. Each account row has one `Route`
-control. It first projects that exact daemon-owned login to shared
+profile shows `Refresh login`; that action presents the official device code
+with fixed-size Copy, Open, and Cancel icon controls, then refreshes only that
+account after the daemon completes the exact credential replacement. Each
+account row has one `Route` control. It first projects that exact daemon-owned login to shared
 `~/.codex/auth.json` for future Codex launches, then selects the same account as
 the fixed Decodex route. The underlying typed commands remain independently
 fenced, and retrying the control completes whichever step is not current. The

--- a/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
@@ -11,7 +11,6 @@ struct AccountReauthenticationView: View {
 	@Environment(\.colorScheme) private var colorScheme
 	@FocusState private var focusedAction: FocusedAction?
 	@State private var copyFeedback = false
-	@State private var openFeedback = false
 
 	var body: some View {
 		VStack(alignment: .leading, spacing: 9) {
@@ -32,34 +31,51 @@ struct AccountReauthenticationView: View {
 				}
 
 				HStack(spacing: 8) {
-					Button(
-						presentation.canCloseWithoutCancellation
-							? "Close"
-							: presentation.canRequestCancellation ? "Cancel" : "Saving…"
-					) {
-						if presentation.canCloseWithoutCancellation {
-							store.closeAccountReauthentication()
-						} else if presentation.canRequestCancellation {
-							Task {
-								await store.cancelAccountReauthentication()
+					if presentation.canCloseWithoutCancellation
+						|| presentation.canRequestCancellation
+					{
+						let actionLabel = presentation.canCloseWithoutCancellation
+							? "Close login"
+							: "Cancel login"
+						Button {
+							if presentation.canCloseWithoutCancellation {
+								store.closeAccountReauthentication()
+							} else {
+								Task {
+									await store.cancelAccountReauthentication()
+								}
 							}
+						} label: {
+							Image(systemName: "xmark")
+								.frame(width: 22, height: 18)
 						}
+						.buttonStyle(.bordered)
+						.keyboardShortcut(.cancelAction)
+						.focused($focusedAction, equals: .cancel)
+						.help(actionLabel)
+						.accessibilityLabel(actionLabel)
+					} else {
+						ProgressView()
+							.controlSize(.mini)
+							.frame(width: 38, height: 24)
+							.help("Saving login")
+							.accessibilityLabel("Saving login")
 					}
-					.disabled(
-						presentation.canCloseWithoutCancellation == false
-							&& presentation.canRequestCancellation == false
-					)
-					.keyboardShortcut(.cancelAction)
-					.focused($focusedAction, equals: .cancel)
 
 					Spacer(minLength: 8)
 
 					if let prompt = presentation.prompt {
-						Button(openFeedback ? "Opened" : "Open browser") {
+						Button {
 							open(prompt.verificationURL)
+						} label: {
+							Image(systemName: "safari")
+								.frame(width: 22, height: 18)
 						}
 						.buttonStyle(.borderedProminent)
+						.keyboardShortcut(.defaultAction)
 						.focused($focusedAction, equals: .openBrowser)
+						.help("Open Codex sign-in page")
+						.accessibilityLabel("Open Codex sign-in page")
 						.accessibilityHint("Opens the official Codex device sign-in page.")
 					}
 				}
@@ -145,13 +161,20 @@ struct AccountReauthenticationView: View {
 					.tracking(1)
 					.foregroundStyle(PanelPalette.primaryText(colorScheme))
 					.textSelection(.enabled)
+					.lineLimit(1)
+					.frame(maxWidth: .infinity, alignment: .leading)
+					.layoutPriority(1)
 
-				Spacer(minLength: 4)
-
-				Button(copyFeedback ? "Copied" : "Copy") {
+				Button {
 					copy(prompt.userCode)
+				} label: {
+					Image(systemName: copyFeedback ? "checkmark" : "doc.on.doc")
+						.frame(width: 22, height: 18)
 				}
 				.buttonStyle(.bordered)
+				.help(copyFeedback ? "Copied" : "Copy one-time code")
+				.accessibilityLabel("Copy one-time code")
+				.accessibilityValue(copyFeedback ? "Copied" : "")
 				.accessibilityHint("Copies the one-time Codex login code.")
 			}
 			.padding(.horizontal, 9)
@@ -176,11 +199,6 @@ struct AccountReauthenticationView: View {
 	}
 
 	private func open(_ url: URL) {
-		openFeedback = true
 		NSWorkspace.shared.open(url)
-		Task { @MainActor in
-			try? await Task.sleep(for: .milliseconds(650))
-			openFeedback = false
-		}
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/DecodexApp.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexApp.swift
@@ -20,8 +20,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 			return .terminateLater
 		}
 		terminationIsPending = true
-		store?.prepareForApplicationTermination()
-		Task {
+		Task { [store] in
+			await store?.prepareForApplicationTermination()
 			await DecodexNativeClient.shutdownSharedSession()
 			sender.reply(toApplicationShouldTerminate: true)
 		}

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
@@ -136,7 +136,6 @@ enum ResetCardQuotaError: String, Decodable, Equatable, Sendable {
 enum ResetCardQuotaState: Equatable, Sendable {
 	case unknown
 	case current(usedPercent: UInt8, resetsAtUnixMicros: Int64)
-	case stale(usedPercent: UInt8, resetsAtUnixMicros: Int64)
 	case error(ResetCardQuotaError)
 }
 
@@ -147,7 +146,7 @@ struct ResetCardQuotaWindow: Equatable, Sendable {
 
 	var usedPercent: UInt8? {
 		switch state {
-		case .current(let usedPercent, _), .stale(let usedPercent, _):
+		case .current(let usedPercent, _):
 			return usedPercent
 		case .unknown, .error:
 			return nil
@@ -157,7 +156,7 @@ struct ResetCardQuotaWindow: Equatable, Sendable {
 	var resetDate: Date? {
 		let micros: Int64
 		switch state {
-		case .current(_, let resetsAtUnixMicros), .stale(_, let resetsAtUnixMicros):
+		case .current(_, let resetsAtUnixMicros):
 			micros = resetsAtUnixMicros
 		case .unknown, .error:
 			return nil
@@ -172,8 +171,6 @@ struct ResetCardQuotaWindow: Equatable, Sendable {
 			return "Unknown"
 		case .current:
 			return "Current"
-		case .stale:
-			return "Stale"
 		case .error:
 			return "Error"
 		}
@@ -185,7 +182,7 @@ struct ResetCardQuotaWindow: Equatable, Sendable {
 			return "No observation"
 		case .error(let error):
 			return error.presentation
-		case .current, .stale:
+		case .current:
 			return ""
 		}
 	}
@@ -196,8 +193,6 @@ struct ResetCardQuotaWindow: Equatable, Sendable {
 			return "Unknown, no observation"
 		case .current(let usedPercent, _):
 			return "Current, \(usedPercent) percent used, resets \(resetDate?.formatted() ?? "unknown")"
-		case .stale(let usedPercent, _):
-			return "Stale, \(usedPercent) percent used, resets \(resetDate?.formatted() ?? "unknown")"
 		case .error(let error):
 			return "Error, \(error.presentation)"
 		}
@@ -1033,7 +1028,6 @@ private struct ResetCardQuotaWindowWire: Decodable, Sendable {
 private enum ResetCardQuotaStateWire: Decodable, Sendable {
 	case unknown
 	case current(ResetCardQuotaValueWire)
-	case stale(ResetCardQuotaValueWire)
 	case error(ResetCardQuotaError)
 
 	init(from decoder: Decoder) throws {
@@ -1045,11 +1039,6 @@ private enum ResetCardQuotaStateWire: Decodable, Sendable {
 		case "current":
 			try rejectUnknownFields(in: decoder, allowed: ["state", "data"])
 			self = .current(
-				try container.decode(ResetCardQuotaValueWire.self, forKey: .data)
-			)
-		case "stale":
-			try rejectUnknownFields(in: decoder, allowed: ["state", "data"])
-			self = .stale(
 				try container.decode(ResetCardQuotaValueWire.self, forKey: .data)
 			)
 		case "error":
@@ -1077,18 +1066,6 @@ private enum ResetCardQuotaStateWire: Decodable, Sendable {
 				throw ResetCardClientError.invalidResponse
 			}
 			return .current(
-				usedPercent: value.usedPercent,
-				resetsAtUnixMicros: value.resetsAtUnixMicros
-			)
-		case .stale(let value):
-			let observed = try validatedObservation(
-				observedAtUnixMicros,
-				value: value
-			)
-			guard value.resetsAtUnixMicros > observed else {
-				throw ResetCardClientError.invalidResponse
-			}
-			return .stale(
 				usedPercent: value.usedPercent,
 				resetsAtUnixMicros: value.resetsAtUnixMicros
 			)

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -580,15 +580,6 @@ struct ResetCardQuotaPresentation: Equatable {
 			self.usedPercent = usedPercent
 			self.remainingPercent = remainingPercent
 			resetDate = window.resetDate
-		case .stale(let usedPercent, _):
-			isVisible = true
-			let remainingPercent = 100 - min(100, usedPercent)
-			valueText = "\(remainingPercent)%"
-			detailText = "stale"
-			tone = .current
-			self.usedPercent = usedPercent
-			self.remainingPercent = remainingPercent
-			resetDate = window.resetDate
 		case .unknown:
 			isVisible = false
 			valueText = "—"

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -162,6 +162,7 @@ final class ResetCardStore {
 	// account-bound provider process. Keep the progressive fan-out below the host
 	// process burst that can make otherwise healthy accounts fail transiently.
 	private static let maximumConcurrentAccountReads = 3
+	private static let defaultAutomaticRefreshInterval: Duration = .seconds(15)
 
 	private static let defaultStartupRetryDelays: [Duration] = [
 		.seconds(1),
@@ -195,11 +196,15 @@ final class ResetCardStore {
 	@ObservationIgnored private let accountProfileClient: (any AccountProfileClient)?
 	@ObservationIgnored private let pendingStore: ResetCardPendingAttemptStore
 	@ObservationIgnored private let startupRetryDelays: [Duration]
+	@ObservationIgnored private let automaticRefreshInterval: Duration
 	@ObservationIgnored private let accountReauthenticationPollInterval: Duration
 	@ObservationIgnored private let resolveCodexExecutable: @MainActor @Sendable () throws -> String
 	@ObservationIgnored private var startupTask: Task<Void, Never>?
+	@ObservationIgnored private var automaticRefreshTask: Task<Void, Never>?
+	@ObservationIgnored private var refreshCycleTask: Task<Void, Never>?
 	@ObservationIgnored private var pendingRecoveryTask: Task<Void, Never>?
 	@ObservationIgnored private var accountReauthenticationTask: Task<Void, Never>?
+	@ObservationIgnored private(set) var isPreparingForTermination = false
 	@ObservationIgnored private var profileRequestGenerations = [String: UInt64]()
 	@ObservationIgnored private var profileEmailCache = [String: CachedAccountEmail]()
 	@ObservationIgnored private var requestedProfileEmailVisibility = false
@@ -210,6 +215,7 @@ final class ResetCardStore {
 		client: any ResetCardClient = DecodexNativeClient(),
 		pendingStore: ResetCardPendingAttemptStore = ResetCardPendingAttemptStore(),
 		startupRetryDelays: [Duration] = ResetCardStore.defaultStartupRetryDelays,
+		automaticRefreshInterval: Duration = ResetCardStore.defaultAutomaticRefreshInterval,
 		accountReauthenticationPollInterval: Duration = .seconds(1),
 		resolveCodexExecutable: @escaping @MainActor @Sendable () throws -> String = {
 			try CodexExecutableResolver.resolve()
@@ -220,6 +226,7 @@ final class ResetCardStore {
 		accountProfileClient = client as? any AccountProfileClient
 		self.pendingStore = pendingStore
 		self.startupRetryDelays = startupRetryDelays
+		self.automaticRefreshInterval = automaticRefreshInterval
 		self.accountReauthenticationPollInterval = accountReauthenticationPollInterval
 		self.resolveCodexExecutable = resolveCodexExecutable
 		let pendingLoad = pendingStore.load()
@@ -232,6 +239,8 @@ final class ResetCardStore {
 
 	deinit {
 		startupTask?.cancel()
+		automaticRefreshTask?.cancel()
+		refreshCycleTask?.cancel()
 		pendingRecoveryTask?.cancel()
 		accountReauthenticationTask?.cancel()
 	}
@@ -257,10 +266,14 @@ final class ResetCardStore {
 	}
 
 	func start() {
-		guard startupTask == nil, pendingRecoveryTask == nil else {
+		guard startupTask == nil,
+			automaticRefreshTask == nil,
+			pendingRecoveryTask == nil
+		else {
 			return
 		}
 
+		startAutomaticRefresh()
 		let retryDelays = startupRetryDelays
 		startupTask = Task { [weak self] in
 			guard var result = await self?.refreshReadState() else {
@@ -308,28 +321,104 @@ final class ResetCardStore {
 		}
 	}
 
-	func prepareForApplicationTermination() {
+	func prepareForApplicationTermination() async {
+		guard isPreparingForTermination == false else {
+			return
+		}
+		isPreparingForTermination = true
+
+		let inFlightStartupTask = startupTask
+		let inFlightAutomaticRefreshTask = automaticRefreshTask
+		let inFlightRefreshCycleTask = refreshCycleTask
+		let inFlightPendingRecoveryTask = pendingRecoveryTask
+		let inFlightAccountReauthenticationTask = accountReauthenticationTask
+
 		startupTask?.cancel()
 		startupTask = nil
+		automaticRefreshTask?.cancel()
+		automaticRefreshTask = nil
+		refreshCycleTask?.cancel()
+		refreshCycleTask = nil
 		pendingRecoveryTask?.cancel()
 		pendingRecoveryTask = nil
 		accountReauthenticationTask?.cancel()
 		accountReauthenticationTask = nil
+
+		await inFlightStartupTask?.value
+		await inFlightAutomaticRefreshTask?.value
+		await inFlightRefreshCycleTask?.value
+		await inFlightPendingRecoveryTask?.value
+		await inFlightAccountReauthenticationTask?.value
+	}
+
+	private func startAutomaticRefresh() {
+		let clock = ContinuousClock()
+		let interval = automaticRefreshInterval
+		automaticRefreshTask = Task { [weak self] in
+			var nextRefresh = clock.now.advanced(by: interval)
+			while Task.isCancelled == false {
+				do {
+					try await clock.sleep(until: nextRefresh)
+				} catch {
+					return
+				}
+
+				guard Task.isCancelled == false, let self else {
+					return
+				}
+				self.requestRefresh()
+				repeat {
+					nextRefresh = nextRefresh.advanced(by: interval)
+				} while nextRefresh <= clock.now
+			}
+		}
+	}
+
+	func requestRefresh() {
+		guard isPreparingForTermination == false,
+			refreshCycleTask == nil
+		else {
+			return
+		}
+
+		refreshCycleTask = Task { [weak self] in
+			guard let self else {
+				return
+			}
+			await self.performRefreshCycle()
+			self.refreshCycleTask = nil
+		}
 	}
 
 	func refresh() async {
+		requestRefresh()
+		await refreshCycleTask?.value
+	}
+
+	private func performRefreshCycle() async {
 		guard isRefreshing == false,
 			isRefreshingAccountSkeleton == false,
 			isAccountControlInProgress == false
 		else {
 			return
 		}
+		let inFlightStartupTask = startupTask
+		let inFlightPendingRecoveryTask = pendingRecoveryTask
 		startupTask?.cancel()
 		startupTask = nil
 		pendingRecoveryTask?.cancel()
 		pendingRecoveryTask = nil
+		await inFlightStartupTask?.value
+		await inFlightPendingRecoveryTask?.value
+
+		guard Task.isCancelled == false else {
+			return
+		}
 		clearStaleControlError()
 		_ = await refreshReadState()
+		guard Task.isCancelled == false else {
+			return
+		}
 		_ = await recoverPendingAttempts()
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
+++ b/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
@@ -9,8 +9,10 @@ final class StatusPanelController: NSObject {
 	private let statusItem: NSStatusItem
 	private let panel: TransparentStatusPanel
 	private let hostingView: TransparentHostingView<StatusPanelRootView>
+	private let store: ResetCardStore
 
 	init(store: ResetCardStore) {
+		self.store = store
 		statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
 		panel = TransparentStatusPanel(
 			contentRect: .zero,
@@ -41,6 +43,7 @@ final class StatusPanelController: NSObject {
 		positionPanel()
 		NSApp.activate(ignoringOtherApps: true)
 		panel.makeKeyAndOrderFront(nil)
+		store.requestRefresh()
 	}
 
 	private func configureStatusItem() {

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -59,27 +59,6 @@ final class AccountPanelPresentationTests: XCTestCase {
 		XCTAssertNotNil(presentation.resetDate)
 	}
 
-	func testStaleQuotaHasANonColorStatusMarker() {
-		let presentation = ResetCardQuotaPresentation(
-			window: ResetCardQuotaWindow(
-				durationMinutes: 300,
-				observedAtUnixMicros: 1_000_000,
-				state: .stale(
-					usedPercent: 42,
-					resetsAtUnixMicros: 2_000_000
-				)
-			)
-		)
-
-		XCTAssertTrue(presentation.isVisible)
-		XCTAssertEqual(presentation.valueText, "58%")
-		XCTAssertEqual(presentation.detailText, "stale")
-		XCTAssertEqual(presentation.tone, .current)
-		XCTAssertEqual(presentation.usedPercent, 42)
-		XCTAssertEqual(presentation.remainingPercent, 58)
-		XCTAssertNotNil(presentation.resetDate)
-	}
-
 	func testUnknownOptionalQuotaWindowIsHidden() {
 		let presentation = ResetCardQuotaPresentation(
 			window: .unknown(durationMinutes: 300)

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -78,7 +78,10 @@ final class ResetCardArchitectureTests: XCTestCase {
 			"Enable account",
 			"Log out",
 			"Refresh login",
-			"Open browser",
+			"Open Codex sign-in page",
+			"Copy one-time code",
+			"Cancel login",
+			"Close login",
 		] {
 			XCTAssertTrue(
 				source.contains("\"\(canonicalLabel)"),
@@ -356,9 +359,26 @@ final class ResetCardArchitectureTests: XCTestCase {
 			encoding: .utf8
 		)
 
-		XCTAssertTrue(view.contains("\"Copy\""))
-		XCTAssertTrue(view.contains("\"Open browser\""))
-		XCTAssertTrue(view.contains("\"Cancel\""))
+		XCTAssertTrue(view.contains(#"Image(systemName: "xmark")"#))
+		XCTAssertTrue(view.contains(#"Image(systemName: "safari")"#))
+		XCTAssertTrue(
+			view.contains(#"copyFeedback ? "checkmark" : "doc.on.doc""#)
+		)
+		XCTAssertTrue(view.contains(".lineLimit(1)"))
+		XCTAssertTrue(
+			view.contains(".frame(maxWidth: .infinity, alignment: .leading)")
+		)
+		XCTAssertTrue(view.contains(".layoutPriority(1)"))
+		XCTAssertTrue(view.contains(".accessibilityLabel(\"Copy one-time code\")"))
+		XCTAssertTrue(view.contains(".accessibilityLabel(\"Open Codex sign-in page\")"))
+		XCTAssertTrue(view.contains(".keyboardShortcut(.defaultAction)"))
+		XCTAssertTrue(view.contains(".keyboardShortcut(.cancelAction)"))
+		XCTAssertFalse(
+			view.contains(#"Button(copyFeedback ? "Copied" : "Copy")"#)
+		)
+		XCTAssertFalse(
+			view.contains(#"Button(openFeedback ? "Opened" : "Open browser")"#)
+		)
 		XCTAssertTrue(view.contains(".frame(width: 220)"))
 		XCTAssertTrue(view.contains(".padding(14)"))
 		XCTAssertFalse(view.contains("Enter this one-time code"))
@@ -387,5 +407,37 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(app.contains("await DecodexNativeClient.shutdownSharedSession()"))
 		XCTAssertTrue(native.contains("sharedSession.shutdown()"))
 		XCTAssertTrue(native.contains("library.destroy(handle)"))
+	}
+
+	func testAccountDataUsesTheFormerFifteenSecondRefreshCadence() throws {
+		let sourceURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
+		let store = try String(
+			contentsOf: sourceURL.appendingPathComponent("ResetCardStore.swift"),
+			encoding: .utf8
+		)
+		let panel = try String(
+			contentsOf: sourceURL.appendingPathComponent("StatusPanelController.swift"),
+			encoding: .utf8
+		)
+
+		XCTAssertTrue(
+			store.contains(
+				"defaultAutomaticRefreshInterval: Duration = .seconds(15)"
+			)
+		)
+		XCTAssertTrue(store.contains("private var automaticRefreshTask"))
+		XCTAssertTrue(store.contains("private var refreshCycleTask"))
+		XCTAssertTrue(store.contains("startAutomaticRefresh()"))
+		XCTAssertTrue(store.contains("automaticRefreshTask?.cancel()"))
+		XCTAssertTrue(store.contains("ContinuousClock()"))
+		XCTAssertTrue(store.contains("clock.sleep(until: nextRefresh)"))
+		XCTAssertTrue(store.contains("self.requestRefresh()"))
+		XCTAssertTrue(store.contains("await self.performRefreshCycle()"))
+		XCTAssertFalse(store.contains("Timer.publish"))
+		XCTAssertTrue(panel.contains("store.requestRefresh()"))
 	}
 }

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardCLIClientTests.swift
@@ -158,6 +158,37 @@ final class ResetCardNativeClientTests: XCTestCase {
 		XCTAssertEqual(inventory.sevenDayQuota.usedPercent, 0)
 	}
 
+	func testNativeInventoryRejectsRetiredStaleQuotaState() async {
+		let accountID = accountID
+		let authority = authority
+		let client = DecodexNativeClient { _, _ in
+			nativeSuccess(
+				operation: "get_reset_cards",
+				authority: authority,
+				data: """
+				{"outcome":"available","data":{
+				  "account_id":"\(accountID)",
+				  "account_revision":7,
+				  "reported_available_count":0,
+				  "details_complete":true,
+				  "cards":[],
+				  "five_hour_quota":{"duration_minutes":300,"observed_at_unix_micros":1000000,"result":{"state":"stale","data":{"used_percent":20,"resets_at_unix_micros":2000000}}},
+				  "seven_day_quota":{"duration_minutes":10080,"observed_at_unix_micros":null,"result":{"state":"unknown"}}
+				}}
+				"""
+			)
+		}
+
+		do {
+			_ = try await client.inventory(
+				for: nativeAccount(authority: authority, accountID: accountID, revision: 7)
+			)
+			XCTFail("retired stale quota state must be rejected")
+		} catch {
+			XCTAssertEqual(error as? ResetCardClientError, .invalidResponse)
+		}
+	}
+
 	func testNativeInventoryAcceptsCountOnlyPartialDetailsWithoutSelectableCards() async throws {
 		let accountID = accountID
 		let authority = authority

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreStartupRetryTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreStartupRetryTests.swift
@@ -170,6 +170,69 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 		)
 	}
 
+	func testAutomaticRefreshRepeatsUntilApplicationTermination() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let client = ScriptedResetCardClient(
+			accountSteps: [],
+			accountFallback: .value([Self.account]),
+			inventoryFallback: .value(try Self.inventory)
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [],
+			automaticRefreshInterval: .milliseconds(5)
+		)
+
+		store.start()
+		try await waitUntil {
+			let counts = await client.callCounts()
+			return counts.accounts >= 2
+				&& counts.inventory >= 2
+				&& store.isRefreshing == false
+		}
+
+		await store.prepareForApplicationTermination()
+		let stoppedCounts = await client.callCounts()
+		try await Task.sleep(for: .milliseconds(20))
+		let finalCounts = await client.callCounts()
+		XCTAssertEqual(finalCounts, stoppedCounts)
+	}
+
+	func testTerminationRejectsRefreshWhileDrainingTheActiveCycle() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let client = TerminationBlockingResetCardClient(
+			account: Self.account,
+			inventory: try Self.inventory
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		store.requestRefresh()
+		try await waitUntil {
+			await client.isAccountReadBlocked()
+		}
+
+		let termination = Task {
+			await store.prepareForApplicationTermination()
+		}
+		try await waitUntil {
+			store.isPreparingForTermination
+		}
+
+		store.requestRefresh()
+		await client.releaseAccountRead()
+		await termination.value
+
+		let accountCallCount = await client.accountCallCount()
+		XCTAssertEqual(accountCallCount, 1)
+	}
+
 	func testManualRefreshChecksPendingStatusOnceWithoutDispatchingUse() async throws {
 		let fixture = try makePendingFixture()
 		defer { fixture.remove() }
@@ -487,7 +550,7 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 				sevenDayQuota: ResetCardQuotaWindow(
 					durationMinutes: 10_080,
 					observedAtUnixMicros: 1_000_000,
-					state: .stale(
+					state: .current(
 						usedPercent: 80,
 						resetsAtUnixMicros: 3_000_000
 					)
@@ -627,6 +690,54 @@ private actor ScriptedResetCardClient: ResetCardClient {
 		case .failure(let error):
 			throw error
 		}
+	}
+}
+
+private actor TerminationBlockingResetCardClient: ResetCardClient {
+	private let account: ResetCardAccountRecord
+	private let retainedInventory: ResetCardInventory
+	private var accountCalls = 0
+	private var blockedAccountRead: CheckedContinuation<Void, Never>?
+
+	init(account: ResetCardAccountRecord, inventory: ResetCardInventory) {
+		self.account = account
+		retainedInventory = inventory
+	}
+
+	func accounts(
+		authority: ResetCardAuthority?
+	) async throws -> [ResetCardAccountRecord] {
+		accountCalls += 1
+		await withCheckedContinuation { continuation in
+			blockedAccountRead = continuation
+		}
+		return [account]
+	}
+
+	func inventory(for account: ResetCardAccountRecord) async throws -> ResetCardInventory {
+		retainedInventory
+	}
+
+	func status(for attempt: ResetCardUseAttempt) async throws -> ResetCardOperationState {
+		.notFound
+	}
+
+	func use(_ attempt: ResetCardUseAttempt) async throws -> ResetCardOperationState {
+		.prepared
+	}
+
+	func isAccountReadBlocked() -> Bool {
+		blockedAccountRead != nil
+	}
+
+	func releaseAccountRead() {
+		let continuation = blockedAccountRead
+		blockedAccountRead = nil
+		continuation?.resume()
+	}
+
+	func accountCallCount() -> Int {
+		accountCalls
 	}
 }
 

--- a/apps/decodex-cli/src/reset_card.rs
+++ b/apps/decodex-cli/src/reset_card.rs
@@ -476,8 +476,6 @@ fn quota_summary(quota: &AccountQuotaWindowDto) -> String {
 		AccountQuotaStateDto::Unknown => "unknown".to_owned(),
 		AccountQuotaStateDto::Current { used_percent, resets_at_unix_micros } =>
 			format!("current:{used_percent}:{resets_at_unix_micros}"),
-		AccountQuotaStateDto::Stale { used_percent, resets_at_unix_micros } =>
-			format!("stale:{used_percent}:{resets_at_unix_micros}"),
 		AccountQuotaStateDto::Error { error } => format!("error:{error:?}"),
 	};
 	format!("{}:{observed}:{result}", quota.duration_minutes)

--- a/crates/decodex-postgres/src/account_lifecycle.rs
+++ b/crates/decodex-postgres/src/account_lifecycle.rs
@@ -1432,3 +1432,31 @@ fn validate_account_command_response(value: &Value) -> Result<(), StoreError> {
 fn incompatible(value: &'static str) -> StoreError {
 	StoreError::Incompatible(format!("stored {value} is malformed"))
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn expired_quota_remains_stale_inside_the_store_boundary() {
+		let observation = parse_quota(
+			AccountQuotaWindow::FIVE_HOURS_MINUTES,
+			"stale",
+			Some(42),
+			Some(2_000_000),
+			Some(1_000_000),
+			None,
+		)
+		.expect("valid expired quota should remain readable");
+
+		assert_eq!(observation.observed_at_unix_micros, Some(1_000_000));
+		assert!(matches!(
+			observation.disposition,
+			AccountQuotaDisposition::Stale(AccountQuotaWindow {
+				used_percent: 42,
+				resets_at_unix_micros: 2_000_000,
+				..
+			})
+		));
+	}
+}

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -1293,21 +1293,14 @@ pub enum AccountQuotaErrorDto {
 	UnsupportedWindow,
 }
 
-/// Server-owned quota freshness and value classification.
+/// Server-owned quota value classification.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "state", content = "data", rename_all = "snake_case", deny_unknown_fields)]
 pub enum AccountQuotaStateDto {
-	/// No observation exists.
+	/// No current public quota fact is available.
 	Unknown,
 	/// The retained quota fact is current.
 	Current {
-		/// Provider-reported percentage used.
-		used_percent: u8,
-		/// Provider-reported reset time in Unix microseconds.
-		resets_at_unix_micros: i64,
-	},
-	/// The retained quota fact is no longer current.
-	Stale {
 		/// Provider-reported percentage used.
 		used_percent: u8,
 		/// Provider-reported reset time in Unix microseconds.
@@ -1580,7 +1573,7 @@ pub struct AccountQuotaWindowDto {
 	pub duration_minutes: u32,
 	/// Exact observation time, absent only when state is unknown.
 	pub observed_at_unix_micros: Option<i64>,
-	/// Closed current, unknown, stale, or error result.
+	/// Closed current, unknown, or error result.
 	pub result: AccountQuotaStateDto,
 }
 
@@ -3386,9 +3379,6 @@ fn validate_quota_window(
 		(Some(observed), AccountQuotaStateDto::Current { used_percent, resets_at_unix_micros })
 			if observed > 0 && used_percent <= 100 && resets_at_unix_micros > observed =>
 			Ok(()),
-		(Some(observed), AccountQuotaStateDto::Stale { used_percent, resets_at_unix_micros })
-			if observed > 0 && used_percent <= 100 && resets_at_unix_micros > observed =>
-			Ok(()),
 		(Some(observed), AccountQuotaStateDto::Error { .. }) if observed > 0 => Ok(()),
 		_ => Err("account quota observation shape is invalid"),
 	}
@@ -3406,9 +3396,10 @@ mod tests {
 	use crate::{
 		AccountCommandRejectionDto, AccountInitialSelectionResult, AccountProfileDailyUsageDto,
 		AccountProfileDto, AccountProfileEmailDto, AccountProfileErrorDto, AccountProfileResult,
-		CURRENT_VERSION, CausationId, ClientCommandId, CodexAuthProjectionResult, CommandError,
-		CorrelationId, EntityId, EventPayload, HistoryCursorToken, HistoryText, IdempotencyKey,
-		MAX_HISTORY_INLINE_BYTES, MAX_HISTORY_METADATA_FIELDS, MAX_HISTORY_METADATA_KEY_BYTES,
+		AccountQuotaStateDto, CURRENT_VERSION, CausationId, ClientCommandId,
+		CodexAuthProjectionResult, CommandError, CorrelationId, EntityId, EventPayload,
+		HistoryCursorToken, HistoryText, IdempotencyKey, MAX_HISTORY_INLINE_BYTES,
+		MAX_HISTORY_METADATA_FIELDS, MAX_HISTORY_METADATA_KEY_BYTES,
 		MAX_HISTORY_METADATA_VALUE_BYTES, MAX_HISTORY_PAGE_SIZE, MAX_IDEMPOTENCY_KEY_BYTES,
 		MAX_RESET_CARD_ITEMS, MAX_WIRE_TEXT_BYTES, QueryId, ResetCardDescriptorDto,
 		ResetCardOutcome, ResultPayload, ServerId, ServerInstanceId, Sha256Digest, WireText,
@@ -3418,6 +3409,19 @@ mod tests {
 			ResumeCursor, decode_client_message,
 		},
 	};
+
+	#[test]
+	fn retired_stale_quota_state_is_rejected() {
+		let stale = serde_json::json!({
+			"state": "stale",
+			"data": {
+				"used_percent": 42,
+				"resets_at_unix_micros": 2_000_000,
+			},
+		});
+
+		assert!(serde_json::from_value::<AccountQuotaStateDto>(stale).is_err());
+	}
 
 	#[test]
 	fn account_alias_accepts_only_one_canonical_word() {

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -1764,28 +1764,31 @@ fn decode_account_command_receipt(
 }
 
 fn quota_dto(observation: AccountQuotaWindowObservation) -> Result<AccountQuotaWindowDto, ()> {
-	let result = match observation.disposition {
-		AccountQuotaDisposition::Unknown => AccountQuotaStateDto::Unknown,
-		AccountQuotaDisposition::Current(fact) => AccountQuotaStateDto::Current {
-			used_percent: fact.used_percent,
-			resets_at_unix_micros: fact.resets_at_unix_micros,
-		},
-		AccountQuotaDisposition::Stale(fact) => AccountQuotaStateDto::Stale {
-			used_percent: fact.used_percent,
-			resets_at_unix_micros: fact.resets_at_unix_micros,
-		},
-		AccountQuotaDisposition::Error(error) => AccountQuotaStateDto::Error {
-			error: match error {
-				AccountQuotaObservationError::ProviderUnavailable =>
-					AccountQuotaErrorDto::ProviderUnavailable,
-				AccountQuotaObservationError::ProtocolUnavailable =>
-					AccountQuotaErrorDto::ProtocolUnavailable,
-				AccountQuotaObservationError::AccountMismatch =>
-					AccountQuotaErrorDto::AccountMismatch,
-				AccountQuotaObservationError::UnsupportedWindow =>
-					AccountQuotaErrorDto::UnsupportedWindow,
+	let (observed_at_unix_micros, result) = match observation.disposition {
+		AccountQuotaDisposition::Unknown => (None, AccountQuotaStateDto::Unknown),
+		AccountQuotaDisposition::Current(fact) => (
+			observation.observed_at_unix_micros,
+			AccountQuotaStateDto::Current {
+				used_percent: fact.used_percent,
+				resets_at_unix_micros: fact.resets_at_unix_micros,
 			},
-		},
+		),
+		AccountQuotaDisposition::Stale(_) => (None, AccountQuotaStateDto::Unknown),
+		AccountQuotaDisposition::Error(error) => (
+			observation.observed_at_unix_micros,
+			AccountQuotaStateDto::Error {
+				error: match error {
+					AccountQuotaObservationError::ProviderUnavailable =>
+						AccountQuotaErrorDto::ProviderUnavailable,
+					AccountQuotaObservationError::ProtocolUnavailable =>
+						AccountQuotaErrorDto::ProtocolUnavailable,
+					AccountQuotaObservationError::AccountMismatch =>
+						AccountQuotaErrorDto::AccountMismatch,
+					AccountQuotaObservationError::UnsupportedWindow =>
+						AccountQuotaErrorDto::UnsupportedWindow,
+				},
+			},
+		),
 	};
 	if !matches!(observation.duration_minutes, 300 | 10_080) {
 		return Err(());
@@ -1793,7 +1796,7 @@ fn quota_dto(observation: AccountQuotaWindowObservation) -> Result<AccountQuotaW
 
 	Ok(AccountQuotaWindowDto {
 		duration_minutes: observation.duration_minutes,
-		observed_at_unix_micros: observation.observed_at_unix_micros,
+		observed_at_unix_micros,
 		result,
 	})
 }
@@ -1961,16 +1964,17 @@ fn history_dto(entry: HistoryEntry) -> Result<HistoryItemDto, ()> {
 mod tests {
 	use decodex_core::{
 		AccountId, AccountLifecycleReadiness, AccountOperationId, AccountOperationKind,
-		AccountOperationPhase, AccountOperationStatus, AccountProvider, AccountQuotaWindow,
-		AccountQuotaWindowObservation, AccountRecord, AccountState, ProviderIdentity,
+		AccountOperationPhase, AccountOperationStatus, AccountProvider, AccountQuotaDisposition,
+		AccountQuotaWindow, AccountQuotaWindowObservation, AccountRecord, AccountState,
+		ProviderIdentity,
 	};
 	use decodex_postgres::{
 		AccountLifecycleRejection, AccountProfileDailyUsage, AccountProfileSnapshot,
 		ResetCardFailureCode, ResetCardOperationStatus,
 	};
 	use decodex_protocol::{
-		AccountCommandRejectionDto, AccountProfileEmailDto, CommandError, ResetCardError,
-		ResetCardOperationResult,
+		AccountCommandRejectionDto, AccountProfileEmailDto, AccountQuotaStateDto, CommandError,
+		ResetCardError, ResetCardOperationResult,
 	};
 
 	use super::{
@@ -1979,8 +1983,24 @@ mod tests {
 		StoredAccountCommandOutcome, account_dto, account_lifecycle_command_error,
 		account_profile_dto, account_profile_unavailable_dto, decode_account_command_receipt,
 		encode_account_command_receipt, lifecycle_rejection, operation_query_result,
-		protocol_reset_error,
+		protocol_reset_error, quota_dto,
 	};
+
+	#[test]
+	fn stale_internal_quota_is_publicly_unknown_without_old_values() {
+		let dto = quota_dto(AccountQuotaWindowObservation {
+			duration_minutes: AccountQuotaWindow::SEVEN_DAYS_MINUTES,
+			observed_at_unix_micros: Some(1_000_000),
+			disposition: AccountQuotaDisposition::Stale(
+				AccountQuotaWindow::new(AccountQuotaWindow::SEVEN_DAYS_MINUTES, 42, 2_000_000)
+					.unwrap(),
+			),
+		})
+		.expect("supported stale quota should have a bounded public projection");
+
+		assert_eq!(dto.observed_at_unix_micros, None);
+		assert_eq!(dto.result, AccountQuotaStateDto::Unknown);
+	}
 
 	#[test]
 	fn account_profile_projection_keeps_email_visibility_and_bounded_daily_facts_explicit() {


### PR DESCRIPTION
Summary:
- remove the public quota stale state while preserving internal fail-closed freshness
- refresh account data on an absolute 15-second single-flight cadence and when the panel opens
- use fixed-size icon controls in the login prompt so copy feedback cannot reflow the code

Validation:
- cargo make fmt-check
- cargo make check-rust
- focused protocol, PostgreSQL, and runtime quota tests
- Swift release tests: 165 passed
- final refresh lifecycle tests: 14 passed
- two independent read-only reviews approved the frozen diff