### PR TITLE
Fix macOS account-panel interaction races

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
@@ -275,7 +275,7 @@ struct AccountEnrollmentView: View {
 					}
 				}
 				.keyboardShortcut(.defaultAction)
-				.disabled(store.isEnrollingAccount)
+				.disabled(store.canBeginEnrollment == false)
 			}
 		}
 		.frame(width: 260)

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -180,9 +180,6 @@ struct AccountPanelView: View {
 				symbol: "plus",
 				tint: PanelPalette.actionBlue(colorScheme),
 				isActive: false,
-				isDisabled: store.isAccountControlInProgress
-					|| store.isRefreshing
-					|| store.isRefreshingAccountSkeleton,
 				isSubtle: true,
 				isPrimary: true,
 				size: 24,

--- a/apps/decodex-app/Sources/DecodexApp/PanelControls.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelControls.swift
@@ -43,14 +43,13 @@ struct PanelIconButtonView: View {
 		}
 		.buttonStyle(.plain)
 		.disabled(isDisabled)
-		.opacity(isDisabled && isActive == false ? 0.56 : 1)
 		.help(help)
 		.accessibilityLabel(help)
 	}
 
 	private var buttonLabel: some View {
 		iconContent
-			.opacity(isDisabled && isActive == false ? 0.34 : 0.9)
+			.opacity(isDisabled && isActive == false ? 0.5 : 0.9)
 	}
 
 	private var iconContent: some View {
@@ -67,7 +66,7 @@ struct PanelIconButtonView: View {
 			return tint.opacity(colorScheme == .dark ? 0.98 : 0.92)
 		}
 		if isDisabled {
-			return PanelPalette.secondaryText(colorScheme).opacity(0.38)
+			return PanelPalette.secondaryText(colorScheme)
 		}
 		if isDestructive {
 			return tint.opacity(colorScheme == .dark ? 0.96 : 0.9)

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -254,6 +254,12 @@ final class ResetCardStore {
 			&& (isRefreshing == false || refreshSkeletonIsPublished)
 	}
 
+	var canBeginEnrollment: Bool {
+		accountControlClient != nil
+			&& canPerformDirectAccountControl
+			&& isAccountControlInProgress == false
+	}
+
 	func blocksNewAttempt(for target: ResetCardUseTarget) -> Bool {
 		isPendingRecoveryBlocked
 			|| submittingKey != nil
@@ -835,9 +841,7 @@ final class ResetCardStore {
 	}
 
 	func enrollFromSharedCodex(enabled: Bool = true) async {
-		guard isRefreshing == false,
-			isRefreshingAccountSkeleton == false,
-			isAccountControlInProgress == false,
+		guard canBeginEnrollment,
 			let accountControlClient
 		else {
 			presentAccountControlUnavailable()
@@ -853,6 +857,7 @@ final class ResetCardStore {
 		let idempotencyKey = Self.newCanonicalUUID()
 		await performAccountControl(
 			isEnrollment: true,
+			allowsDuringRefresh: true,
 			successMessage: "Account login imported.",
 			operation: {
 				try await accountControlClient.enrollFromSharedCodex(

--- a/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
+++ b/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
@@ -26,15 +26,24 @@ final class StatusPanelController: NSObject {
 
 		configureStatusItem()
 		configurePanel()
+		observeApplicationLifecycle()
+	}
+
+	deinit {
+		NotificationCenter.default.removeObserver(self)
 	}
 
 	@objc
 	private func togglePanel() {
 		if panel.isVisible {
-			panel.orderOut(nil)
+			hidePanel()
 			return
 		}
 
+		showPanel()
+	}
+
+	private func showPanel() {
 		hostingView.layoutSubtreeIfNeeded()
 		let fittingSize = hostingView.fittingSize
 		if fittingSize.width > 0, fittingSize.height > 0 {
@@ -46,6 +55,15 @@ final class StatusPanelController: NSObject {
 		store.requestRefresh()
 	}
 
+	private func hidePanel() {
+		panel.orderOut(nil)
+	}
+
+	@objc
+	private func applicationDidResignActive(_: Notification) {
+		hidePanel()
+	}
+
 	private func configureStatusItem() {
 		guard let button = statusItem.button else {
 			return
@@ -55,6 +73,7 @@ final class StatusPanelController: NSObject {
 		button.imagePosition = .imageOnly
 		button.target = self
 		button.action = #selector(togglePanel)
+		button.sendAction(on: [.leftMouseDown])
 		button.toolTip = "Decodex"
 		button.setAccessibilityLabel("Decodex")
 	}
@@ -66,7 +85,10 @@ final class StatusPanelController: NSObject {
 		panel.isOpaque = false
 		panel.backgroundColor = .clear
 		panel.hasShadow = false
-		panel.hidesOnDeactivate = true
+		// AppKit's automatic deactivate hiding can restore the panel before a
+		// status-item mouse-up action and turn the first click into a close.
+		// Own the deactivate transition explicitly instead.
+		panel.hidesOnDeactivate = false
 		panel.isMovable = false
 		panel.level = .popUpMenu
 		panel.collectionBehavior = [
@@ -76,6 +98,15 @@ final class StatusPanelController: NSObject {
 		]
 		panel.contentView = hostingView
 		PanelWindowAppearance.apply(to: panel)
+	}
+
+	private func observeApplicationLifecycle() {
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(applicationDidResignActive(_:)),
+			name: NSApplication.didResignActiveNotification,
+			object: NSApp
+		)
 	}
 
 	private func positionPanel() {

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -306,6 +306,46 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(finalReads.inventory, 1)
 	}
 
+	func testEnrollmentStartsAfterSkeletonPublishesWhileDetailReadIsPending() async throws {
+		let account = accountRecord()
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			suspendsInventory: true,
+			allowsEnrollment: true
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		let refreshTask = Task { await store.refresh() }
+		for _ in 0 ..< 200 {
+			if await client.inventoryIsPending() {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+
+		XCTAssertTrue(store.isRefreshing)
+		XCTAssertTrue(store.refreshSkeletonIsPublished)
+		XCTAssertTrue(store.canBeginEnrollment)
+
+		await store.enrollFromSharedCodex()
+
+		let enrollmentRequestCount = await client.enrollmentRequestCount()
+		XCTAssertTrue(store.isRefreshing)
+		XCTAssertEqual(enrollmentRequestCount, 1)
+		XCTAssertEqual(store.message?.tone, .success)
+
+		await client.releaseInventory()
+		await refreshTask.value
+		XCTAssertFalse(store.isRefreshing)
+	}
+
 	func testUseInCodexCompletesWhileDetailReadIsPendingWithoutChangingRouting() async throws {
 		let account = accountRecord()
 		let client = AccountControlStoreClient(
@@ -844,6 +884,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 	private let snapshotGate: AccountControlReadGate?
 	private let fixedSelectionGate: AccountControlReadGate?
 	private let inventoryRevisionOverride: UInt64?
+	private let allowsEnrollment: Bool
 	private var routing: AccountRoutingControl
 	private var fixedSelectionError: AccountControlError?
 	private let useAccountError: AccountControlError?
@@ -857,6 +898,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 	private var projectionReads = 0
 	private var snapshotReadCount = 0
 	private var inventoryReadCount = 0
+	private var enrollmentRequests = 0
 	private var reauthenticationStates: [AccountReauthenticationState]
 	private var lastReauthenticationStartRequest: AccountControlStoreReauthenticationRequest?
 	private var reauthenticationPolls = 0
@@ -873,6 +915,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 		suspendsSnapshotAfterFirstRead: Bool = false,
 		suspendsFixedSelection: Bool = false,
 		inventoryRevisionOverride: UInt64? = nil,
+		allowsEnrollment: Bool = false,
 		routing: AccountRoutingControl? = nil,
 		fixedSelectionError: AccountControlError? = nil,
 		useAccountError: AccountControlError? = nil,
@@ -888,6 +931,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 		snapshotGate = suspendsSnapshotAfterFirstRead ? AccountControlReadGate() : nil
 		fixedSelectionGate = suspendsFixedSelection ? AccountControlReadGate() : nil
 		self.inventoryRevisionOverride = inventoryRevisionOverride
+		self.allowsEnrollment = allowsEnrollment
 		self.routing = routing
 			?? AccountRoutingControl(
 				revision: 9,
@@ -1060,7 +1104,20 @@ private actor AccountControlStoreClient: AccountControlClient {
 		enabled: Bool,
 		idempotencyKey: String
 	) async throws -> AccountControlResult {
-		throw AccountControlError.applicationUnavailable
+		guard allowsEnrollment,
+			DecodexNativeClient.isCanonicalUUID(operationID),
+			DecodexNativeClient.isCanonicalUUID(accountID),
+			DecodexNativeClient.isCanonicalUUID(idempotencyKey),
+			enabled
+		else {
+			throw AccountControlError.applicationUnavailable
+		}
+		enrollmentRequests += 1
+		return .accountChanged(account)
+	}
+
+	func enrollmentRequestCount() -> Int {
+		enrollmentRequests
 	}
 
 	func codexAuthProjection(

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -144,6 +144,22 @@ final class ResetCardArchitectureTests: XCTestCase {
 			contentsOf: sourceURL.appendingPathComponent("PanelWindowSizing.swift"),
 			encoding: .utf8
 		)
+		let panelControls = try String(
+			contentsOf: sourceURL.appendingPathComponent("PanelControls.swift"),
+			encoding: .utf8
+		)
+		let addControlStart = try XCTUnwrap(
+			accountPanel.range(of: "symbol: \"plus\"")
+		)
+		let addControlEnd = try XCTUnwrap(
+			accountPanel.range(
+				of: "help: \"Add Codex login\"",
+				range: addControlStart.lowerBound ..< accountPanel.endIndex
+			)
+		)
+		let addControl = accountPanel[
+			addControlStart.lowerBound ..< addControlEnd.upperBound
+		]
 
 		XCTAssertTrue(cardSurface.contains("shape.fill(.thinMaterial)"))
 		XCTAssertTrue(cardSurface.contains("shape.fill(.regularMaterial)"))
@@ -159,6 +175,7 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(cardSurface.contains("Glass"))
 		XCTAssertFalse(cardSurface.contains("glassEffect"))
 		XCTAssertFalse(accountPanel.contains("GlassEffectContainer"))
+		XCTAssertFalse(addControl.contains("isDisabled:"))
 		XCTAssertTrue(accountPanel.contains(".panelCardSurface(cornerRadius: 18)"))
 		XCTAssertTrue(accountPanel.contains(".panelCardSurface(cornerRadius: 16)"))
 		XCTAssertFalse(accountPanel.contains(".panelCardSurface(cornerRadius: 20"))
@@ -166,6 +183,9 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(accountControls.contains("\"Use in Codex\""))
 		XCTAssertTrue(accountControls.contains("await store.routeAccount("))
 		XCTAssertFalse(accountControls.contains("await store.useAccountInCodex("))
+		XCTAssertTrue(
+			accountControls.contains(".disabled(store.canBeginEnrollment == false)")
+		)
 		XCTAssertFalse(resetCards.contains(".panelCardSurface(cornerRadius: 6"))
 		XCTAssertFalse(resetCards.contains(".enumerated()"))
 		XCTAssertFalse(resetCards.contains("ordinal"))
@@ -180,7 +200,20 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(statusPanel.contains("TransparentHostingView(rootView: StatusPanelRootView"))
 		XCTAssertTrue(statusPanel.contains("override var isOpaque"))
 		XCTAssertTrue(statusPanel.contains("AccountPanelView(store: store)"))
-		XCTAssertTrue(statusPanel.contains("panel.hidesOnDeactivate = true"))
+		XCTAssertTrue(statusPanel.contains("panel.hidesOnDeactivate = false"))
+		XCTAssertTrue(statusPanel.contains("button.sendAction(on: [.leftMouseDown])"))
+		XCTAssertTrue(
+			statusPanel.contains("NSApplication.didResignActiveNotification")
+		)
+		XCTAssertTrue(
+			statusPanel.contains("#selector(applicationDidResignActive(_:))")
+		)
+		XCTAssertEqual(
+			panelControls.components(
+				separatedBy: "isDisabled && isActive == false"
+			).count - 1,
+			1
+		)
 		XCTAssertFalse(statusPanel.contains(".preferredColorScheme"))
 		XCTAssertFalse(statusPanel.contains(".environment(\\.colorScheme"))
 		XCTAssertTrue(resetCards.contains(".buttonStyle(.bordered)"))


### PR DESCRIPTION
## Summary
- decouple Add Account presentation from background account refresh
- preserve real enrollment readiness inside the enrollment sheet
- make the menu-bar panel own its deactivate lifecycle and dispatch on mouse-down
- remove compounded disabled-icon opacity

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app -c release` (167 tests)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer apps/decodex-app/script/build_and_run.sh stage`
- `git diff --check`