### PR TITLE
Fix cached unauthorized account login recovery

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -81,6 +81,7 @@ struct ResetCardAccountState: Identifiable, Equatable {
 			return true
 		}
 		return profileUnavailable?.error == .unauthorized
+			|| profile?.refreshError == .unauthorized
 	}
 }
 

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountProfileStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountProfileStoreTests.swift
@@ -135,7 +135,7 @@ final class AccountProfileStoreTests: XCTestCase {
 		XCTAssertNil(store.accounts.first?.error)
 	}
 
-	func testCachedProfileUnauthorizedDoesNotDriveAccountLoginRecovery() {
+	func testCachedProfileUnauthorizedRequiresLoginRefresh() {
 		let profile = profileObservation(
 			observedAt: 300,
 			lifetimeTokens: 3_000,
@@ -149,7 +149,7 @@ final class AccountProfileStoreTests: XCTestCase {
 			profile: profile
 		)
 
-		XCTAssertFalse(availableState.requiresLoginRefresh)
+		XCTAssertTrue(availableState.requiresLoginRefresh)
 		XCTAssertEqual(
 			availableState.profileDegradationText,
 			AccountProfileObservationError.unauthorized.presentation


### PR DESCRIPTION
## Summary
- treat a cached profile refresh `unauthorized` result as requiring account login refresh
- preserve cached profile metrics while exposing the existing Refresh Login recovery action
- update the focused regression test

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app --filter AccountProfileStoreTests/testCachedProfileUnauthorizedRequiresLoginRefresh`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app` (167 tests passed)