### PR TITLE
Fix account browser login and menu bar toggle

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
@@ -158,7 +158,7 @@ enum AccountControlError: Error, Equatable, LocalizedError, Sendable {
 }
 
 enum AccountReauthenticationState: String, Decodable, Equatable, Sendable {
-	case requestingCode = "requesting_code"
+	case openingBrowser = "opening_browser"
 	case waitingForBrowser = "waiting_for_browser"
 	case installing
 	case completed
@@ -186,7 +186,7 @@ enum AccountReauthenticationFailure: String, Decodable, Equatable, Sendable {
 		case .loginFailed:
 			return "Codex could not complete the login."
 		case .loginTimedOut:
-			return "The login code expired. Request a new code."
+			return "The browser login timed out. Try again."
 		case .accountMismatch:
 			return "This login belongs to a different account."
 		case .accountChanged:
@@ -207,21 +207,9 @@ enum AccountReauthenticationFailure: String, Decodable, Equatable, Sendable {
 	}
 }
 
-struct AccountReauthenticationPrompt: Equatable, Sendable {
-	static let verificationURL = URL(string: "https://auth.openai.com/codex/device")!
-
-	let verificationURL: URL
-	let userCode: String
-
-	var compactCode: String {
-		userCode.replacingOccurrences(of: "-", with: "")
-	}
-}
-
 struct AccountReauthenticationStatus: Equatable, Sendable {
 	let sessionID: String
 	let state: AccountReauthenticationState
-	let prompt: AccountReauthenticationPrompt?
 	let failure: AccountReauthenticationFailure?
 }
 
@@ -731,7 +719,7 @@ private struct AccountReauthenticationWire: Decodable {
 	init(from decoder: Decoder) throws {
 		try rejectUnknownFields(
 			in: decoder,
-			allowed: ["session_id", "state", "prompt", "failure"]
+			allowed: ["session_id", "state", "failure"]
 		)
 		let container = try decoder.container(keyedBy: CodingKeys.self)
 		let sessionID = try container.decode(String.self, forKey: .sessionID)
@@ -739,96 +727,38 @@ private struct AccountReauthenticationWire: Decodable {
 			AccountReauthenticationState.self,
 			forKey: .state
 		)
-		let prompt = try container.decodeIfPresent(
-			PromptWire.self,
-			forKey: .prompt
-		)?.value
 		let failure = try container.decodeIfPresent(
 			AccountReauthenticationFailure.self,
 			forKey: .failure
 		)
 		guard DecodexNativeClient.isCanonicalUUID(sessionID),
-			Self.hasValidShape(state: state, prompt: prompt, failure: failure)
+			Self.hasValidShape(state: state, failure: failure)
 		else {
 			throw AccountControlError.invalidResponse
 		}
 		value = AccountReauthenticationStatus(
 			sessionID: sessionID,
 			state: state,
-			prompt: prompt,
 			failure: failure
 		)
 	}
 
 	private static func hasValidShape(
 		state: AccountReauthenticationState,
-		prompt: AccountReauthenticationPrompt?,
 		failure: AccountReauthenticationFailure?
 	) -> Bool {
 		switch state {
-		case .requestingCode:
-			return prompt == nil && failure == nil
-		case .waitingForBrowser:
-			return prompt != nil && failure == nil
-		case .installing:
-			return prompt == nil && failure == nil
-		case .completed, .cancelled:
-			return prompt == nil && failure == nil
+		case .openingBrowser, .waitingForBrowser, .installing,
+			.completed, .cancelled:
+			return failure == nil
 		case .failed:
-			return prompt == nil && failure != nil
-		}
-	}
-
-	private struct PromptWire: Decodable {
-		let value: AccountReauthenticationPrompt
-
-		init(from decoder: Decoder) throws {
-			try requireExactFields(
-				in: decoder,
-				expected: ["verification_url", "user_code"]
-			)
-			let container = try decoder.container(keyedBy: CodingKeys.self)
-			let verificationURLText = try container.decode(
-				String.self,
-				forKey: .verificationURL
-			)
-			let userCode = try container.decode(String.self, forKey: .userCode)
-			guard let verificationURL = URL(string: verificationURLText),
-				verificationURL == AccountReauthenticationPrompt.verificationURL,
-				Self.isValidUserCode(userCode)
-			else {
-				throw AccountControlError.invalidResponse
-			}
-			value = AccountReauthenticationPrompt(
-				verificationURL: verificationURL,
-				userCode: userCode
-			)
-		}
-
-		private static func isValidUserCode(_ value: String) -> Bool {
-			let bytes = Array(value.utf8)
-			guard bytes.count == 10, bytes[4] == 0x2d else {
-				return false
-			}
-			return bytes.enumerated().allSatisfy { index, byte in
-				if index == 4 {
-					return true
-				}
-				return (byte >= 0x30 && byte <= 0x39)
-					|| (byte >= 0x41 && byte <= 0x5a)
-			}
-		}
-
-		private enum CodingKeys: String, CodingKey {
-			case verificationURL = "verification_url"
-			case userCode = "user_code"
+			return failure != nil
 		}
 	}
 
 	private enum CodingKeys: String, CodingKey {
 		case sessionID = "session_id"
 		case state
-		case prompt
 		case failure
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationPresentation.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationPresentation.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum AccountReauthenticationPhase: Equatable {
 	case resolvingCodex
-	case requestingCode
+	case openingBrowser
 	case waitingForBrowser
 	case installing
 	case failed(String)
@@ -15,7 +15,6 @@ struct AccountReauthenticationPresentation: Identifiable, Equatable {
 	let sessionID: String
 	let authority: ResetCardAuthority?
 	let phase: AccountReauthenticationPhase
-	let prompt: AccountReauthenticationPrompt?
 
 	var id: String {
 		sessionID
@@ -25,8 +24,8 @@ struct AccountReauthenticationPresentation: Identifiable, Equatable {
 		switch phase {
 		case .resolvingCodex:
 			return "Finding Codex"
-		case .requestingCode:
-			return "Requesting a one-time code"
+		case .openingBrowser:
+			return "Opening browser sign-in"
 		case .waitingForBrowser:
 			return "Waiting for browser sign-in"
 		case .installing:
@@ -42,7 +41,7 @@ struct AccountReauthenticationPresentation: Identifiable, Equatable {
 		switch phase {
 		case .failed(let message), .cancellationFailed(let message):
 			return message
-		case .resolvingCodex, .requestingCode, .waitingForBrowser, .installing:
+		case .resolvingCodex, .openingBrowser, .waitingForBrowser, .installing:
 			return nil
 		}
 	}

--- a/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
@@ -1,16 +1,13 @@
-import AppKit
 import SwiftUI
 
 struct AccountReauthenticationView: View {
 	private enum FocusedAction: Hashable {
 		case cancel
-		case openBrowser
 	}
 
 	let store: ResetCardStore
 	@Environment(\.colorScheme) private var colorScheme
 	@FocusState private var focusedAction: FocusedAction?
-	@State private var copyFeedback = false
 
 	var body: some View {
 		VStack(alignment: .leading, spacing: 9) {
@@ -18,10 +15,6 @@ struct AccountReauthenticationView: View {
 				let desiredFocus = desiredFocus(for: presentation)
 
 				header(presentation)
-
-				if let prompt = presentation.prompt {
-					promptContent(prompt)
-				}
 
 				if let failure = presentation.failureText {
 					Text(failure)
@@ -61,23 +54,6 @@ struct AccountReauthenticationView: View {
 							.help("Saving login")
 							.accessibilityLabel("Saving login")
 					}
-
-					Spacer(minLength: 8)
-
-					if let prompt = presentation.prompt {
-						Button {
-							open(prompt.verificationURL)
-						} label: {
-							Image(systemName: "safari")
-								.frame(width: 22, height: 18)
-						}
-						.buttonStyle(.borderedProminent)
-						.keyboardShortcut(.defaultAction)
-						.focused($focusedAction, equals: .openBrowser)
-						.help("Open Codex sign-in page")
-						.accessibilityLabel("Open Codex sign-in page")
-						.accessibilityHint("Opens the official Codex device sign-in page.")
-					}
 				}
 				.task(id: desiredFocus) {
 					await Task.yield()
@@ -98,9 +74,6 @@ struct AccountReauthenticationView: View {
 	private func desiredFocus(
 		for presentation: AccountReauthenticationPresentation
 	) -> FocusedAction? {
-		if presentation.prompt != nil {
-			return .openBrowser
-		}
 		if presentation.canRequestCancellation
 			|| presentation.canCloseWithoutCancellation
 		{
@@ -121,9 +94,7 @@ struct AccountReauthenticationView: View {
 				Spacer(minLength: 6)
 
 				HStack(alignment: .firstTextBaseline, spacing: 3) {
-					if presentation.prompt == nil,
-						presentation.failureText == nil
-					{
+					if presentation.failureText == nil {
 						ProgressView()
 							.controlSize(.mini)
 							.accessibilityHidden(true)
@@ -148,57 +119,5 @@ struct AccountReauthenticationView: View {
 				.truncationMode(.tail)
 				.accessibilityLabel(presentation.statusText)
 		}
-	}
-
-	private func promptContent(
-		_ prompt: AccountReauthenticationPrompt
-	) -> some View {
-		VStack(alignment: .leading, spacing: 0) {
-			HStack(spacing: 8) {
-				Text(prompt.userCode)
-					.font(PanelFont.loginCode)
-					.monospacedDigit()
-					.tracking(1)
-					.foregroundStyle(PanelPalette.primaryText(colorScheme))
-					.textSelection(.enabled)
-					.lineLimit(1)
-					.frame(maxWidth: .infinity, alignment: .leading)
-					.layoutPriority(1)
-
-				Button {
-					copy(prompt.userCode)
-				} label: {
-					Image(systemName: copyFeedback ? "checkmark" : "doc.on.doc")
-						.frame(width: 22, height: 18)
-				}
-				.buttonStyle(.bordered)
-				.help(copyFeedback ? "Copied" : "Copy one-time code")
-				.accessibilityLabel("Copy one-time code")
-				.accessibilityValue(copyFeedback ? "Copied" : "")
-				.accessibilityHint("Copies the one-time Codex login code.")
-			}
-			.padding(.horizontal, 9)
-			.padding(.vertical, 8)
-			.background {
-				RoundedRectangle(cornerRadius: 9, style: .continuous)
-					.fill(.ultraThinMaterial)
-			}
-			.accessibilityElement(children: .contain)
-			.accessibilityLabel("One-time login code \(prompt.userCode)")
-		}
-	}
-
-	private func copy(_ code: String) {
-		NSPasteboard.general.clearContents()
-		NSPasteboard.general.setString(code, forType: .string)
-		copyFeedback = true
-		Task { @MainActor in
-			try? await Task.sleep(for: .milliseconds(850))
-			copyFeedback = false
-		}
-	}
-
-	private func open(_ url: URL) {
-		NSWorkspace.shared.open(url)
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -1085,8 +1085,7 @@ final class ResetCardStore {
 			).text,
 			sessionID: sessionID,
 			authority: authority,
-			phase: .resolvingCodex,
-			prompt: nil
+			phase: .resolvingCodex
 		)
 		accountReauthenticationTask = Task { [weak self] in
 			await self?.runAccountReauthentication(
@@ -1145,7 +1144,7 @@ final class ResetCardStore {
 						?? AccountControlError.invalidResponse.localizedDescription,
 					failure: status.failure
 				)
-			case .requestingCode, .waitingForBrowser, .installing:
+			case .openingBrowser, .waitingForBrowser, .installing:
 				setAccountReauthenticationPhase(
 					.cancellationFailed(
 						"The login is still active. Choose Cancel again."
@@ -2150,7 +2149,7 @@ final class ResetCardStore {
 				return
 			}
 			setAccountReauthenticationPhase(
-				.requestingCode,
+				.openingBrowser,
 				sessionID: sessionID
 			)
 			var status = try await client.startAccountReauthentication(
@@ -2222,25 +2221,16 @@ final class ResetCardStore {
 		}
 
 		switch status.state {
-		case .requestingCode:
+		case .openingBrowser:
 			setAccountReauthenticationPhase(
-				.requestingCode,
+				.openingBrowser,
 				sessionID: sessionID
 			)
 			return false
 		case .waitingForBrowser:
-			guard let prompt = status.prompt else {
-				await failAccountReauthentication(
-					accountID: accountID,
-					sessionID: sessionID,
-					message: AccountControlError.invalidResponse.localizedDescription
-				)
-				return true
-			}
 			setAccountReauthenticationPhase(
 				.waitingForBrowser,
-				sessionID: sessionID,
-				prompt: prompt
+				sessionID: sessionID
 			)
 			return false
 		case .installing:
@@ -2275,27 +2265,19 @@ final class ResetCardStore {
 
 	private func setAccountReauthenticationPhase(
 		_ phase: AccountReauthenticationPhase,
-		sessionID: String,
-		prompt: AccountReauthenticationPrompt? = nil
+		sessionID: String
 	) {
 		guard let presentation = accountReauthentication,
 			presentation.sessionID == sessionID
 		else {
 			return
 		}
-		let nextPrompt: AccountReauthenticationPrompt? = switch phase {
-		case .waitingForBrowser, .cancellationFailed:
-			prompt ?? presentation.prompt
-		case .resolvingCodex, .requestingCode, .installing, .failed:
-			nil
-		}
 		accountReauthentication = AccountReauthenticationPresentation(
 			accountID: presentation.accountID,
 			accountLabel: presentation.accountLabel,
 			sessionID: sessionID,
 			authority: presentation.authority,
-			phase: phase,
-			prompt: nextPrompt
+			phase: phase
 		)
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
+++ b/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
@@ -61,6 +61,16 @@ final class StatusPanelController: NSObject {
 
 	@objc
 	private func applicationDidResignActive(_: Notification) {
+		if let eventType = NSApp.currentEvent?.type,
+			let statusItemRect = statusItemScreenRect(),
+			StatusPanelInteraction.isStatusItemPress(
+				eventType: eventType,
+				mouseLocation: NSEvent.mouseLocation,
+				statusItemRect: statusItemRect
+			)
+		{
+			return
+		}
 		hidePanel()
 	}
 
@@ -110,15 +120,12 @@ final class StatusPanelController: NSObject {
 	}
 
 	private func positionPanel() {
-		guard let button = statusItem.button,
-			let statusWindow = button.window
+		guard let anchorRect = statusItemScreenRect(),
+			let statusWindow = statusItem.button?.window
 		else {
 			return
 		}
 
-		let anchorRect = statusWindow.convertToScreen(
-			button.convert(button.bounds, to: nil)
-		)
 		guard let screen = statusWindow.screen
 			?? NSScreen.screens.first(where: {
 				$0.frame.intersects(anchorRect)
@@ -136,6 +143,17 @@ final class StatusPanelController: NSObject {
 				screenMargin: Self.screenMargin,
 				menuBarGap: Self.menuBarGap
 			)
+		)
+	}
+
+	private func statusItemScreenRect() -> NSRect? {
+		guard let button = statusItem.button,
+			let statusWindow = button.window
+		else {
+			return nil
+		}
+		return statusWindow.convertToScreen(
+			button.convert(button.bounds, to: nil)
 		)
 	}
 }
@@ -178,6 +196,16 @@ enum StatusPanelLayout {
 			return minimum
 		}
 		return min(max(value, minimum), maximum)
+	}
+}
+
+enum StatusPanelInteraction {
+	static func isStatusItemPress(
+		eventType: NSEvent.EventType,
+		mouseLocation: NSPoint,
+		statusItemRect: NSRect
+	) -> Bool {
+		eventType == .leftMouseDown && statusItemRect.contains(mouseLocation)
 	}
 }
 

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
@@ -353,13 +353,11 @@ final class AccountControlNativeClientTests: XCTestCase {
 			switch operation {
 			case "start_account_reauthentication":
 				data = """
-					{"session_id":"\(sessionID)","state":"requesting_code"}
+					{"session_id":"\(sessionID)","state":"opening_browser"}
 					"""
 			case "poll_account_reauthentication":
 				data = """
-					{"session_id":"\(sessionID)","state":"waiting_for_browser",
-					 "prompt":{"verification_url":"https://auth.openai.com/codex/device",
-					 "user_code":"AB12-CDE34"}}
+					{"session_id":"\(sessionID)","state":"waiting_for_browser"}
 					"""
 			case "cancel_account_reauthentication":
 				data = """
@@ -393,14 +391,8 @@ final class AccountControlNativeClientTests: XCTestCase {
 			sessionID: sessionID
 		)
 
-		XCTAssertEqual(started.state, .requestingCode)
-		XCTAssertEqual(
-			polled.prompt,
-			AccountReauthenticationPrompt(
-				verificationURL: AccountReauthenticationPrompt.verificationURL,
-				userCode: "AB12-CDE34"
-			)
-		)
+		XCTAssertEqual(started.state, .openingBrowser)
+		XCTAssertEqual(polled.state, .waitingForBrowser)
 		XCTAssertEqual(cancelled.state, .cancelled)
 
 		let requests = try recorder.requests.map { try nativeJSONObject($0.data) }
@@ -461,7 +453,6 @@ final class AccountControlNativeClientTests: XCTestCase {
 
 		XCTAssertEqual(status.state, .failed)
 		XCTAssertEqual(status.failure, .accountMismatch)
-		XCTAssertNil(status.prompt)
 	}
 
 	func testAccountReauthenticationRejectsMalformedOrUnexpectedPromptState() async {
@@ -492,7 +483,7 @@ final class AccountControlNativeClientTests: XCTestCase {
 			{"session_id":"\(sessionID)","state":"failed","failure":"future_failure"}
 			""",
 			"""
-			{"session_id":"\(sessionID)","state":"requesting_code","unexpected":true}
+			{"session_id":"\(sessionID)","state":"opening_browser","unexpected":true}
 			""",
 		]
 

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -656,7 +656,7 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(finalProjectionReads, 2)
 	}
 
-	func testDeviceLoginCompletesAndRefreshesOnlyTheChangedAccountAuthority() async throws {
+	func testBrowserLoginCompletesAndRefreshesOnlyTheChangedAccountAuthority() async throws {
 		let account = accountRecord(observedState: .authFailed)
 		let client = AccountControlStoreClient(
 			account: account,
@@ -714,7 +714,7 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertGreaterThanOrEqual(reads.inventory, 2)
 	}
 
-	func testDeviceLoginRemainsActiveUntilExplicitCancel() async throws {
+	func testBrowserLoginRemainsActiveUntilExplicitCancel() async throws {
 		let account = accountRecord(observedState: .authFailed)
 		let client = AccountControlStoreClient(
 			account: account,
@@ -736,15 +736,12 @@ final class AccountControlStoreTests: XCTestCase {
 
 		store.beginAccountReauthentication(for: accountID)
 		for _ in 0 ..< 200 {
-			if store.accountReauthentication?.prompt != nil {
+			if store.accountReauthentication?.phase == .waitingForBrowser {
 				break
 			}
 			try await Task.sleep(for: .milliseconds(5))
 		}
-		XCTAssertEqual(
-			store.accountReauthentication?.prompt?.userCode,
-			"AB12-CDE34"
-		)
+		XCTAssertEqual(store.accountReauthentication?.phase, .waitingForBrowser)
 		XCTAssertTrue(store.isControllingAccount(accountID))
 
 		await store.cancelAccountReauthentication()
@@ -778,7 +775,7 @@ final class AccountControlStoreTests: XCTestCase {
 
 		store.beginAccountReauthentication(for: accountID)
 		for _ in 0 ..< 200 {
-			if store.accountReauthentication?.prompt != nil {
+			if store.accountReauthentication?.phase == .waitingForBrowser {
 				break
 			}
 			try await Task.sleep(for: .milliseconds(5))
@@ -1312,16 +1309,9 @@ private actor AccountControlStoreClient: AccountControlClient {
 		sessionID: String,
 		failure: AccountReauthenticationFailure? = nil
 	) -> AccountReauthenticationStatus {
-		let prompt = state == .waitingForBrowser
-			? AccountReauthenticationPrompt(
-				verificationURL: AccountReauthenticationPrompt.verificationURL,
-				userCode: "AB12-CDE34"
-			)
-			: nil
 		return AccountReauthenticationStatus(
 			sessionID: sessionID,
 			state: state,
-			prompt: prompt,
 			failure: failure
 		)
 	}

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -103,8 +103,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 			accountLabel: "Val",
 			sessionID: "20000000-0000-4000-8000-000000000001",
 			authority: nil,
-			phase: .installing,
-			prompt: nil
+			phase: .installing
 		)
 
 		XCTAssertFalse(presentation.canRequestCancellation)

--- a/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
@@ -88,6 +88,32 @@ final class PanelWindowSizingLayoutTests: XCTestCase {
 		)
 	}
 
+	func testStatusItemPressDefersDeactivateHideForTheToggleAction() {
+		let statusItemRect = NSRect(x: 400, y: 900, width: 28, height: 24)
+
+		XCTAssertTrue(
+			StatusPanelInteraction.isStatusItemPress(
+				eventType: .leftMouseDown,
+				mouseLocation: NSPoint(x: 414, y: 912),
+				statusItemRect: statusItemRect
+			)
+		)
+		XCTAssertFalse(
+			StatusPanelInteraction.isStatusItemPress(
+				eventType: .leftMouseDown,
+				mouseLocation: NSPoint(x: 300, y: 700),
+				statusItemRect: statusItemRect
+			)
+		)
+		XCTAssertFalse(
+			StatusPanelInteraction.isStatusItemPress(
+				eventType: .leftMouseUp,
+				mouseLocation: NSPoint(x: 414, y: 912),
+				statusItemRect: statusItemRect
+			)
+		)
+	}
+
 	func testRoundedContentSizeCeilsFractionalDimensions() {
 		let size = PanelWindowSizingLayout.roundedContentSize(for: CGSize(width: 339.2, height: 641.1))
 

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -78,8 +78,6 @@ final class ResetCardArchitectureTests: XCTestCase {
 			"Enable account",
 			"Log out",
 			"Refresh login",
-			"Open Codex sign-in page",
-			"Copy one-time code",
 			"Cancel login",
 			"Close login",
 		] {
@@ -361,7 +359,7 @@ final class ResetCardArchitectureTests: XCTestCase {
 		}
 	}
 
-	func testLoginRecoveryUsesExplicitNativePromptControlsAndNoPanelDisappearCancel() throws {
+	func testLoginRecoveryUsesNativeBrowserOAuthAndNoPanelDisappearCancel() throws {
 		let sourceURL = URL(fileURLWithPath: #filePath)
 			.deletingLastPathComponent()
 			.deletingLastPathComponent()
@@ -393,25 +391,11 @@ final class ResetCardArchitectureTests: XCTestCase {
 		)
 
 		XCTAssertTrue(view.contains(#"Image(systemName: "xmark")"#))
-		XCTAssertTrue(view.contains(#"Image(systemName: "safari")"#))
-		XCTAssertTrue(
-			view.contains(#"copyFeedback ? "checkmark" : "doc.on.doc""#)
-		)
-		XCTAssertTrue(view.contains(".lineLimit(1)"))
-		XCTAssertTrue(
-			view.contains(".frame(maxWidth: .infinity, alignment: .leading)")
-		)
-		XCTAssertTrue(view.contains(".layoutPriority(1)"))
-		XCTAssertTrue(view.contains(".accessibilityLabel(\"Copy one-time code\")"))
-		XCTAssertTrue(view.contains(".accessibilityLabel(\"Open Codex sign-in page\")"))
-		XCTAssertTrue(view.contains(".keyboardShortcut(.defaultAction)"))
+		XCTAssertFalse(view.contains(#"Image(systemName: "safari")"#))
+		XCTAssertFalse(view.contains("doc.on.doc"))
+		XCTAssertFalse(view.contains("one-time code"))
+		XCTAssertFalse(view.contains("verificationURL"))
 		XCTAssertTrue(view.contains(".keyboardShortcut(.cancelAction)"))
-		XCTAssertFalse(
-			view.contains(#"Button(copyFeedback ? "Copied" : "Copy")"#)
-		)
-		XCTAssertFalse(
-			view.contains(#"Button(openFeedback ? "Opened" : "Open browser")"#)
-		)
 		XCTAssertTrue(view.contains(".frame(width: 220)"))
 		XCTAssertTrue(view.contains(".padding(14)"))
 		XCTAssertFalse(view.contains("Enter this one-time code"))
@@ -428,7 +412,7 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(panel.contains(".padding(.horizontal, 20)"))
 		XCTAssertFalse(panel.contains("isPresented: Binding("))
 		XCTAssertTrue(view.contains("@FocusState private var focusedAction"))
-		XCTAssertTrue(view.contains(".focused($focusedAction, equals: .openBrowser)"))
+		XCTAssertTrue(view.contains(".focused($focusedAction, equals: .cancel)"))
 		XCTAssertTrue(view.contains(".task(id: desiredFocus)"))
 		XCTAssertTrue(view.contains("presentation.canCloseWithoutCancellation"))
 		XCTAssertTrue(

--- a/crates/decodex-app-client-ffi/src/account_reauthentication.rs
+++ b/crates/decodex-app-client-ffi/src/account_reauthentication.rs
@@ -24,7 +24,7 @@ use decodex_protocol::{
 use serde::Serialize;
 use tokio::runtime::Handle;
 
-const DEVICE_LOGIN_URL: &str = "https://auth.openai.com/codex/device";
+const FILE_AUTH_STORE_CONFIG: &str = r#"cli_auth_credentials_store="file""#;
 const LOGIN_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(40);
 const MAX_LOGIN_OUTPUT_BYTES: usize = 64 * 1024;
@@ -50,7 +50,7 @@ pub(crate) enum Failure {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 enum State {
-	RequestingCode,
+	OpeningBrowser,
 	WaitingForBrowser,
 	Installing,
 	Completed,
@@ -59,49 +59,36 @@ enum State {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-pub(crate) struct Prompt {
-	verification_url: &'static str,
-	user_code: String,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub(crate) struct Status {
 	session_id: String,
 	state: State,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	prompt: Option<Prompt>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	failure: Option<Failure>,
 }
 
 impl Status {
-	fn requesting(session_id: String) -> Self {
-		Self { session_id, state: State::RequestingCode, prompt: None, failure: None }
+	fn opening_browser(session_id: String) -> Self {
+		Self { session_id, state: State::OpeningBrowser, failure: None }
 	}
 
-	fn waiting(session_id: String, user_code: String) -> Self {
-		Self {
-			session_id,
-			state: State::WaitingForBrowser,
-			prompt: Some(Prompt { verification_url: DEVICE_LOGIN_URL, user_code }),
-			failure: None,
-		}
+	fn waiting(session_id: String) -> Self {
+		Self { session_id, state: State::WaitingForBrowser, failure: None }
 	}
 
 	fn installing(session_id: String) -> Self {
-		Self { session_id, state: State::Installing, prompt: None, failure: None }
+		Self { session_id, state: State::Installing, failure: None }
 	}
 
 	fn completed(session_id: String) -> Self {
-		Self { session_id, state: State::Completed, prompt: None, failure: None }
+		Self { session_id, state: State::Completed, failure: None }
 	}
 
 	fn failed(session_id: String, failure: Failure) -> Self {
-		Self { session_id, state: State::Failed, prompt: None, failure: Some(failure) }
+		Self { session_id, state: State::Failed, failure: Some(failure) }
 	}
 
 	fn cancelled(session_id: String) -> Self {
-		Self { session_id, state: State::Cancelled, prompt: None, failure: None }
+		Self { session_id, state: State::Cancelled, failure: None }
 	}
 
 	fn is_terminal(&self) -> bool {
@@ -126,7 +113,7 @@ struct Shared {
 impl Shared {
 	fn new(session_id: String) -> Self {
 		Self {
-			status: Mutex::new(Status::requesting(session_id)),
+			status: Mutex::new(Status::opening_browser(session_id)),
 			cancel_requested: AtomicBool::new(false),
 		}
 	}
@@ -317,27 +304,11 @@ fn run_login_in_home(
 	login_home: &Path,
 ) -> Status {
 	let session_id = start.session_id.clone();
-	let mut child = match Command::new(codex_bin)
-		.arg("login")
-		.arg("--device-auth")
-		.current_dir(login_home)
-		.env_remove("OPENAI_API_KEY")
-		.env_remove("CODEX_API_KEY")
-		.env_remove("CODEX_ACCESS_TOKEN")
-		.env_remove("CHATGPT_ACCESS_TOKEN")
-		.env_remove("CODEX_HOME")
-		.env_remove("CODEX_SQLITE_HOME")
-		.env("CODEX_HOME", login_home)
-		.env("CODEX_SQLITE_HOME", login_home)
-		.stdin(Stdio::null())
-		.stdout(Stdio::piped())
-		.stderr(Stdio::piped())
-		.process_group(0)
-		.spawn()
-	{
+	let mut child = match browser_login_command(&codex_bin, login_home).spawn() {
 		Ok(child) => child,
 		Err(_) => return Status::failed(session_id, Failure::CodexUnavailable),
 	};
+	shared.set_status(Status::waiting(session_id.clone()));
 	let Some(stdout) = child.stdout.take() else {
 		terminate_child(&mut child);
 		return Status::failed(session_id, Failure::LoginFailed);
@@ -373,7 +344,7 @@ fn run_login_in_home(
 		Ok(output) => output,
 		Err(status) => return status,
 	};
-	if output.reader_failed || !output.exit.success() || !output.prompt_published {
+	if output.reader_failed || !output.exit.success() {
 		return Status::failed(session_id, Failure::LoginFailed);
 	}
 	if shared.cancel_requested.load(Ordering::Acquire) {
@@ -391,10 +362,31 @@ fn run_login_in_home(
 	}
 }
 
+fn browser_login_command(codex_bin: &Path, login_home: &Path) -> Command {
+	let mut command = Command::new(codex_bin);
+	command
+		.arg("login")
+		.arg("-c")
+		.arg(FILE_AUTH_STORE_CONFIG)
+		.current_dir(login_home)
+		.env_remove("OPENAI_API_KEY")
+		.env_remove("CODEX_API_KEY")
+		.env_remove("CODEX_ACCESS_TOKEN")
+		.env_remove("CHATGPT_ACCESS_TOKEN")
+		.env_remove("CODEX_HOME")
+		.env_remove("CODEX_SQLITE_HOME")
+		.env("CODEX_HOME", login_home)
+		.env("CODEX_SQLITE_HOME", login_home)
+		.stdin(Stdio::null())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped())
+		.process_group(0);
+	command
+}
+
 struct LoginChildOutput {
 	exit: ExitStatus,
 	reader_failed: bool,
-	prompt_published: bool,
 }
 
 fn collect_login_child(
@@ -408,7 +400,6 @@ fn collect_login_child(
 	let deadline = Instant::now() + LOGIN_TIMEOUT;
 	let mut output = Vec::new();
 	let mut reader_failed = false;
-	let mut prompt_published = false;
 	let mut open_readers = 2_u8;
 	let mut exit = None;
 	loop {
@@ -423,20 +414,12 @@ fn collect_login_child(
 			return Err(Status::failed(session_id.to_owned(), Failure::LoginTimedOut));
 		}
 		match receiver.recv_timeout(CHILD_POLL_INTERVAL) {
-			Ok(PipeEvent::Bytes(bytes)) => {
+			Ok(PipeEvent::Bytes(bytes)) =>
 				if append_output(&mut output, &bytes).is_err() {
 					terminate_child(child);
 					join_readers(stdout_reader, stderr_reader);
 					return Err(Status::failed(session_id.to_owned(), Failure::LoginFailed));
-				}
-				if !prompt_published
-					&& let Some(code) = parse_device_code(&output)
-					&& contains_device_url(&output)
-				{
-					shared.set_status(Status::waiting(session_id.to_owned(), code));
-					prompt_published = true;
-				}
-			},
+				},
 			Ok(PipeEvent::Closed { failed }) => {
 				reader_failed |= failed;
 				open_readers = open_readers.saturating_sub(1);
@@ -462,7 +445,7 @@ fn collect_login_child(
 			&& let Some(exit) = exit
 		{
 			join_readers(stdout_reader, stderr_reader);
-			return Ok(LoginChildOutput { exit, reader_failed, prompt_published });
+			return Ok(LoginChildOutput { exit, reader_failed });
 		}
 	}
 }
@@ -626,23 +609,6 @@ fn append_output(output: &mut Vec<u8>, bytes: &[u8]) -> Result<(), ()> {
 	Ok(())
 }
 
-fn contains_device_url(output: &[u8]) -> bool {
-	output.windows(DEVICE_LOGIN_URL.len()).any(|window| window == DEVICE_LOGIN_URL.as_bytes())
-}
-
-fn parse_device_code(output: &[u8]) -> Option<String> {
-	output.windows(10).find_map(|candidate| {
-		if candidate[4] != b'-' {
-			return None;
-		}
-		let valid = candidate
-			.iter()
-			.enumerate()
-			.all(|(index, byte)| index == 4 || byte.is_ascii_uppercase() || byte.is_ascii_digit());
-		valid.then(|| String::from_utf8_lossy(candidate).into_owned())
-	})
-}
-
 struct LoginHome {
 	path: PathBuf,
 	device: u64,
@@ -720,19 +686,15 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn parser_accepts_the_exact_device_prompt_across_ansi_output() {
-		let output =
-			b"\x1b[32mOpen https://auth.openai.com/codex/device\x1b[0m\nCode: ZL92-P3SQ0\n";
+	fn browser_login_forces_the_private_file_credential_store() {
+		let command = browser_login_command(
+			Path::new("/Applications/ChatGPT.app/Contents/Resources/codex"),
+			Path::new("/private/tmp/decodex-login"),
+		);
+		let args =
+			command.get_args().map(|arg| arg.to_string_lossy().into_owned()).collect::<Vec<_>>();
 
-		assert!(contains_device_url(output));
-		assert_eq!(parse_device_code(output).as_deref(), Some("ZL92-P3SQ0"));
-	}
-
-	#[test]
-	fn parser_rejects_noncanonical_codes() {
-		assert_eq!(parse_device_code(b"zl92-p3sq0"), None);
-		assert_eq!(parse_device_code(b"ZL9-P3SQ0"), None);
-		assert_eq!(parse_device_code(b"ZL92_P3SQ0"), None);
+		assert_eq!(args, ["login", "-c", r#"cli_auth_credentials_store="file""#]);
 	}
 
 	#[test]
@@ -907,7 +869,7 @@ mod tests {
 				.arg("-c")
 				.arg(
 					"printf '%s' \"$$\" > \"$1\"; \
-					 printf 'Open https://auth.openai.com/codex/device\\nCode: AB12-CDE34\\n'; \
+					 printf 'Waiting for browser login\\n'; \
 					 (sleep 60) & exit 0",
 				)
 				.arg("decodex-login-fixture")
@@ -932,10 +894,7 @@ mod tests {
 				stderr_reader,
 				&worker_session_id,
 			) {
-				Ok(output)
-					if output.exit.success()
-						&& !output.reader_failed
-						&& output.prompt_published =>
+				Ok(output) if output.exit.success() && !output.reader_failed =>
 					Status::completed(worker_session_id),
 				Ok(_) => Status::failed(worker_session_id, Failure::LoginFailed),
 				Err(status) => status,


### PR DESCRIPTION
## Summary
- replace restricted device-code reauthentication with Codex standard browser OAuth in a private file-backed login home
- remove the retired one-time-code bridge and presentation
- prevent deactivate handling from reopening an already-visible status panel on the same menu bar click

## Validation
- `cargo test -p decodex-app-client-ffi account_reauthentication --all-features` (11 passed)
- `swift test --package-path apps/decodex-app` (168 passed)
- `cargo make fmt-rust-check`
- `SCCACHE_DISABLE=1 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-rust`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer apps/decodex-app/script/build_and_run.sh stage`