### PR TITLE
Merge account header and activity overview

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -53,8 +53,9 @@ data remains row-scoped and never hides Reset Cards.
 The panel uses compact individual material cards with transparent gaps and
 shows every account when they fit on the active display. On shorter displays,
 the account list remains scrollable without a persistent scroll indicator.
-The header, overview, and each account row use separate appearance-adaptive
-system frosted-material surfaces with no opaque custom fill or drawn border.
+The header and aggregate overview share one compact appearance-adaptive
+frosted-material surface. Each account row uses its own separate system material
+surface with no opaque custom fill or drawn border.
 The host window follows the system Light or Dark appearance and does not draw
 its own full-window shadow or backdrop. Login recovery uses a stronger floating
 material inside that same transparent window, without a window-wide modal dimmer.

--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -38,11 +38,11 @@ pre-cutover native cadence. Opening the panel also requests one refresh. An
 already active refresh absorbs either trigger, and one failed account remains
 isolated to its row until the next cycle.
 
-Each account detail popover contains lifetime tokens, peak daily tokens,
-longest task, current and longest streaks, and a 36-day usage chart. The compact
-panel keeps aggregate total, peak, streak, and longest-task metrics with one
-daily chart across all accounts. It does not expose profile coverage counters
-as account status.
+The account plan appears beside the account identity. Each detail popover
+contains only lifetime tokens, peak daily tokens, longest task, current and
+longest streaks, and a 36-day usage chart. The compact panel keeps aggregate
+total, peak, streak, and longest-task metrics with one daily chart across all
+accounts. It does not expose profile coverage counters as account status.
 Email is redacted by default. The eye control changes only the published
 identity slot. Hiding email removes it from SwiftUI presentation state. A
 revision-bound, process-only cache keeps later visibility changes immediate and

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
@@ -8,8 +8,8 @@ enum AccountPanelLayout {
 	static let minimumAccountListHeight: CGFloat = 110
 	static let estimatedAccountRowHeight: CGFloat = 74
 	static let statusMaximumHeight: CGFloat = 92
-	// Compact header, aggregate activity card, and panel spacing.
-	static let fixedChromeHeight: CGFloat = 114
+	// Combined header/activity card and panel spacing.
+	static let fixedChromeHeight: CGFloat = 90
 
 	static func activeScreenVisibleHeight() -> CGFloat {
 		let mouseLocation = NSEvent.mouseLocation

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -93,26 +93,31 @@ struct AccountPanelView: View {
 
 	private var panelContent: some View {
 		VStack(alignment: .leading, spacing: 7) {
-			header
-				.padding(.horizontal, 10)
-				.padding(.vertical, 8)
-				.panelCardSurface(cornerRadius: 18)
+			headerOverview
 
 			if hasTransientStatus {
 				transientStatus
 					.transition(.panelSection)
 			}
 
+			accountContent
+		}
+	}
+
+	private var headerOverview: some View {
+		VStack(alignment: .leading, spacing: 6) {
+			header
+
 			if let profileAggregate {
 				AccountProfileOverviewView(
 					aggregate: profileAggregate
 				)
-					.panelCardSurface(cornerRadius: 16)
 					.transition(.panelSection)
 			}
-
-			accountContent
 		}
+		.padding(.horizontal, 10)
+		.padding(.vertical, 8)
+		.panelCardSurface(cornerRadius: 18)
 	}
 
 	private var reauthenticationOverlay: some View {
@@ -134,8 +139,8 @@ struct AccountPanelView: View {
 				.renderingMode(.template)
 				.scaledToFit()
 				.foregroundStyle(PanelPalette.actionBlue(colorScheme))
-				.frame(width: 19, height: 19)
-				.frame(width: 26, height: 26)
+				.frame(width: 17, height: 17)
+				.frame(width: 24, height: 24)
 				.accessibilityHidden(true)
 
 			Text("Decodex")

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -140,7 +140,6 @@ struct AccountPanelView: View {
 				.scaledToFit()
 				.foregroundStyle(PanelPalette.actionBlue(colorScheme))
 				.frame(width: 17, height: 17)
-				.frame(width: 24, height: 24)
 				.accessibilityHidden(true)
 
 			Text("Decodex")
@@ -256,7 +255,6 @@ struct AccountPanelView: View {
 			.help("Decodex menu")
 			.accessibilityLabel("Decodex menu")
 		}
-		.padding(.horizontal, 2)
 	}
 
 	private var hasTransientStatus: Bool {

--- a/apps/decodex-app/Sources/DecodexApp/AccountProfileViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountProfileViews.swift
@@ -120,23 +120,9 @@ struct AccountProfileDetailView: View {
 
 struct AccountProfileOverviewView: View {
 	let aggregate: AccountProfileAggregate
-	@Environment(\.colorScheme) private var colorScheme
 
 	var body: some View {
 		VStack(alignment: .leading, spacing: 4) {
-			HStack(alignment: .firstTextBaseline, spacing: 3) {
-				Image(systemName: "chart.bar.xaxis")
-					.font(PanelFont.tertiary)
-					.foregroundStyle(PanelPalette.usageCyan(colorScheme))
-					.accessibilityHidden(true)
-
-				Text("All accounts")
-					.font(PanelFont.usageValue)
-					.foregroundStyle(PanelPalette.primaryText(colorScheme))
-
-				Spacer(minLength: 0)
-			}
-
 			if aggregateMetrics.isEmpty == false {
 				AccountProfileMetricsView(
 					metrics: aggregateMetrics
@@ -149,8 +135,7 @@ struct AccountProfileOverviewView: View {
 				)
 			}
 		}
-		.padding(.horizontal, 10)
-		.padding(.vertical, 7)
+		.frame(maxWidth: .infinity, alignment: .leading)
 		.accessibilityElement(children: .combine)
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountProfileViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountProfileViews.swift
@@ -35,19 +35,6 @@ struct AccountProfileDetailView: View {
 
 	var body: some View {
 		VStack(alignment: .leading, spacing: 9) {
-			HStack(alignment: .firstTextBaseline) {
-				Text("Account details")
-					.font(PanelFont.transientTitle)
-
-				Spacer()
-
-				if let planType {
-					Text(planType)
-						.font(PanelFont.tertiary)
-						.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-				}
-			}
-
 			if let profile = state.profile {
 				AccountProfileSummaryView(profile: profile.snapshot)
 
@@ -88,10 +75,6 @@ struct AccountProfileDetailView: View {
 		.frame(width: 270)
 		.padding(12)
 		.accessibilityElement(children: .contain)
-	}
-
-	private var planType: String? {
-		state.profile?.planType ?? state.profileUnavailable?.claims.planType
 	}
 
 	private var quotaDiagnostic: String? {
@@ -136,6 +119,7 @@ struct AccountProfileOverviewView: View {
 			}
 		}
 		.frame(maxWidth: .infinity, alignment: .leading)
+		.padding(.horizontal, 2)
 		.accessibilityElement(children: .combine)
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/PanelTypography.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelTypography.swift
@@ -21,7 +21,7 @@ enum PanelFont {
 	static let loginCode = text(19, weight: .semibold, design: .monospaced)
 	static let usageLabel = text(9.8, weight: .regular)
 	static let usageValue = text(10.4, weight: .medium)
-	static let resetCardAction = usageValue
+	static let resetCardAction = text(9.4, weight: .medium)
 	static let quotaText = text(10.4, weight: .regular)
 	static let tertiary = text(9.5, weight: .regular)
 	static let compactAction = text(9.8, weight: .medium)

--- a/apps/decodex-app/Sources/DecodexApp/PanelTypography.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelTypography.swift
@@ -9,7 +9,7 @@ enum PanelFont {
 		.system(size: size, weight: weight, design: design)
 	}
 
-	static let headerTitle = text(15.4, weight: .semibold)
+	static let headerTitle = text(14.2, weight: .semibold)
 
 	static let emptyIcon = text(17, weight: .medium)
 	static let emptyTitle = text(12.5, weight: .semibold)

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -270,7 +270,7 @@ struct ResetCardAccountRow: View {
 		case .authFailed:
 			return "Login refresh required"
 		case .depleted:
-			return "Weekly quota depleted"
+			return nil
 		case .pluginUnready:
 			return "Provider update required"
 		case .unknown:
@@ -282,7 +282,6 @@ struct ResetCardAccountRow: View {
 
 	private var exceptionalStatusColor: Color {
 		if state.account.enabled == false
-			|| state.account.observedState == .depleted
 			|| state.account.observedState == .unknown
 			|| state.account.observedState == .pluginUnready
 		{

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -172,19 +172,25 @@ struct ResetCardAccountRow: View {
 	}
 
 	private var identityHeader: some View {
-		Text(identity.text)
-			.font(PanelFont.accountName)
-			.foregroundStyle(PanelPalette.primaryText(colorScheme))
-			.lineLimit(1)
-			.truncationMode(.middle)
-			.layoutPriority(1)
-			.frame(maxWidth: .infinity, alignment: .leading)
-			.accessibilityElement(children: .ignore)
-			.accessibilityLabel(
-				identity.showsEmail
-					? "Account email \(identity.text)"
-					: "Account \(identity.text)"
-			)
+		HStack(alignment: .firstTextBaseline, spacing: 5) {
+			Text(identity.text)
+				.font(PanelFont.accountName)
+				.foregroundStyle(PanelPalette.primaryText(colorScheme))
+				.lineLimit(1)
+				.truncationMode(.middle)
+				.layoutPriority(1)
+
+			if let planType {
+				Text(planType)
+					.font(PanelFont.tertiary)
+					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+					.lineLimit(1)
+					.fixedSize(horizontal: true, vertical: false)
+			}
+		}
+		.frame(maxWidth: .infinity, alignment: .leading)
+		.accessibilityElement(children: .ignore)
+		.accessibilityLabel(identityAccessibilityLabel)
 	}
 
 	private var exceptionalStatus: some View {
@@ -216,6 +222,21 @@ struct ResetCardAccountRow: View {
 
 	private var profileEmail: String? {
 		state.profile?.email ?? state.profileUnavailable?.claims.email
+	}
+
+	private var planType: String? {
+		state.profile?.planType ?? state.profileUnavailable?.claims.planType
+	}
+
+	private var identityAccessibilityLabel: String {
+		let accountLabel =
+			identity.showsEmail
+			? "Account email \(identity.text)"
+			: "Account \(identity.text)"
+		guard let planType else {
+			return accountLabel
+		}
+		return "\(accountLabel), \(planType) plan"
 	}
 
 	private var exceptionalStatusText: String? {

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -414,7 +414,7 @@ struct ResetCardAccountRow: View {
 				.foregroundStyle(
 					confirmation.isArmed(target)
 						? PanelPalette.warning(colorScheme)
-						: PanelPalette.primaryText(colorScheme).opacity(0.9)
+						: PanelPalette.secondaryText(colorScheme)
 				)
 		}
 		.font(PanelFont.resetCardAction)

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -164,6 +164,10 @@ final class ResetCardArchitectureTests: XCTestCase {
 			contentsOf: sourceURL.appendingPathComponent("ResetCardSectionView.swift"),
 			encoding: .utf8
 		)
+		let typography = try String(
+			contentsOf: sourceURL.appendingPathComponent("PanelTypography.swift"),
+			encoding: .utf8
+		)
 		let appScene = try String(
 			contentsOf: sourceURL.appendingPathComponent("DecodexApp.swift"),
 			encoding: .utf8
@@ -224,6 +228,12 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(resetCards.contains("Image(systemName: \"person.crop.circle\")"))
 		XCTAssertFalse(resetCards.contains("identity.showsEmail ? \"envelope\""))
 		XCTAssertTrue(resetCards.contains(".font(PanelFont.quotaText)"))
+		XCTAssertTrue(
+			typography.contains(
+				"static let resetCardAction = text(9.4, weight: .medium)"
+			)
+		)
+		XCTAssertTrue(resetCards.contains(": PanelPalette.secondaryText(colorScheme)"))
 		XCTAssertFalse(appScene.contains("MenuBarExtra"))
 		XCTAssertFalse(appScene.contains(".menuBarExtraStyle"))
 		XCTAssertTrue(statusPanel.contains("NSStatusBar.system.statusItem"))

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -267,6 +267,7 @@ final class ResetCardArchitectureTests: XCTestCase {
 		)
 		XCTAssertFalse(resetCards.contains("\"Use · "))
 		XCTAssertFalse(resetCards.contains("Image(systemName: \"creditcard\")"))
+		XCTAssertFalse(resetCards.contains("Weekly quota depleted"))
 		XCTAssertTrue(resetCards.contains(".frame(minWidth: 88, maxWidth: .infinity)"))
 		XCTAssertFalse(accountPanel.contains("headerState("))
 		XCTAssertFalse(accountPanel.contains("routingSubtitle"))

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -22,19 +22,27 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(accountPanel.contains("ForEach(store.accounts)"))
 	}
 
-	func testAllAccountsOverviewShowsAggregateMetricsWithoutCoverageCounters() throws {
+	func testHeaderAndOverviewShareOneCardWithoutARedundantTitleRow() throws {
 		let sourceURL = URL(fileURLWithPath: #filePath)
 			.deletingLastPathComponent()
 			.deletingLastPathComponent()
 			.deletingLastPathComponent()
 			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
+		let accountPanel = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountPanelView.swift"),
+			encoding: .utf8
+		)
 		let profileViews = try String(
 			contentsOf: sourceURL.appendingPathComponent("AccountProfileViews.swift"),
 			encoding: .utf8
 		)
 
-		XCTAssertTrue(profileViews.contains("Text(\"All accounts\")"))
+		XCTAssertTrue(accountPanel.contains("private var headerOverview: some View"))
+		XCTAssertTrue(accountPanel.contains("AccountProfileOverviewView("))
+		XCTAssertTrue(accountPanel.contains(".panelCardSurface(cornerRadius: 18)"))
+		XCTAssertFalse(profileViews.contains("Text(\"All accounts\")"))
 		XCTAssertFalse(profileViews.contains("Text(\"All Accounts\")"))
+		XCTAssertFalse(profileViews.contains("Image(systemName: \"chart.bar.xaxis\")"))
 		XCTAssertTrue(profileViews.contains("lifetimeTokens: aggregate.lifetimeTokens"))
 		XCTAssertTrue(profileViews.contains("peakDailyTokens: aggregate.peakDailyTokens"))
 		XCTAssertTrue(profileViews.contains("longestTaskSeconds: aggregate.longestTaskSeconds"))

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -53,6 +53,32 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(profileViews.contains("showsAxis"))
 	}
 
+	func testPlanTierLivesBesideIdentityAndNotInTheDetailPopoverHeader() throws {
+		let sourceURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
+		let accountRows = try String(
+			contentsOf: sourceURL.appendingPathComponent("ResetCardSectionView.swift"),
+			encoding: .utf8
+		)
+		let profileViews = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountProfileViews.swift"),
+			encoding: .utf8
+		)
+
+		XCTAssertTrue(accountRows.contains("if let planType"))
+		XCTAssertTrue(accountRows.contains("Text(planType)"))
+		XCTAssertTrue(
+			accountRows.contains(
+				"state.profile?.planType ?? state.profileUnavailable?.claims.planType"
+			)
+		)
+		XCTAssertFalse(profileViews.contains("Text(\"Account details\")"))
+		XCTAssertFalse(profileViews.contains("Text(planType)"))
+	}
+
 	func testAccountPanelControlsUseSentenceCase() throws {
 		let sourceURL = URL(fileURLWithPath: #filePath)
 			.deletingLastPathComponent()


### PR DESCRIPTION
## Summary
- merge the Decodex header and aggregate activity overview into one material card
- remove the redundant All accounts title row and chart icon
- tighten the title/icon scale and reclaim account-list viewport height

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app` (168 tests)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer apps/decodex-app/script/build_and_run.sh stage`
- live six-account screenshot review of the staged signed app