### PR TITLE
Unify account panel spacing rhythm

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -70,13 +70,16 @@ either that alias or the account email in the same identity slot without an
 identity icon. The canonical account UUID is the only row identity. There is no
 account rename surface.
 
-Reset Card use requires two clicks on the same descriptor. The first click arms
-a five-second confirmation. The second click writes one credential-negative
-pending handle, then sends one native daemon request with the same account
-revision, descriptor, and operation key. Restart recovery reads durable status
-and retains that key. It never selects another card or generates a replacement
-key for an unresolved request. Expiry times use compact bordered controls so
-their click action remains visible without adding a second card container.
+Reset Card controls use a subtle neutral border that remains visible on each
+material card. The armed confirmation uses the existing warning accent without
+changing the control size. Reset Card use requires two clicks on the same
+descriptor. The first click arms a five-second confirmation. The second click
+writes one credential-negative pending handle, then sends one native daemon
+request with the same account revision, descriptor, and operation key. Restart
+recovery reads durable status and retains that key. It never selects another
+card or generates a replacement key for an unresolved request. Expiry times use
+compact bordered controls so their click action remains visible without adding
+a second card container.
 
 The bounded recovery journal is
 `Application Support/Decodex/reset-card-pending-v1.json`. It uses an atomic

--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -56,6 +56,8 @@ the account list remains scrollable without a persistent scroll indicator.
 The header and aggregate overview share one compact appearance-adaptive
 frosted-material surface. Each account row uses its own separate system material
 surface with no opaque custom fill or drawn border.
+Primary cards use one shared compact spacing rhythm and identical content insets.
+Popovers and floating login recovery use one larger shared inset.
 The host window follows the system Light or Dark appearance and does not draw
 its own full-window shadow or backdrop. Login recovery uses a stronger floating
 material inside that same transparent window, without a window-wide modal dimmer.

--- a/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
@@ -5,7 +5,7 @@ struct AccountPrimaryActionsView: View {
 	let store: ResetCardStore
 
 	var body: some View {
-		HStack(spacing: 4) {
+		HStack(spacing: PanelSpacing.compact) {
 			CompactAccountActionButton(
 				title: isRouteCurrent ? "Routed" : "Route",
 				symbol: isRouteCurrent
@@ -69,7 +69,7 @@ struct AccountUtilityActionsView: View {
 	@State private var isLogoutArmed = false
 
 	var body: some View {
-		HStack(spacing: 2) {
+		HStack(spacing: PanelSpacing.micro) {
 			PanelIconButtonView(
 				symbol: "chart.bar.xaxis",
 				tint: PanelPalette.actionBlue(colorScheme),
@@ -126,7 +126,7 @@ struct AccountUtilityActionsView: View {
 	}
 
 	private var logoutConfirmation: some View {
-		VStack(alignment: .leading, spacing: 9) {
+		VStack(alignment: .leading, spacing: PanelSpacing.section) {
 			Text("Log out this account?")
 				.font(PanelFont.transientTitle)
 
@@ -154,7 +154,7 @@ struct AccountUtilityActionsView: View {
 			}
 		}
 		.frame(width: 240)
-		.padding(12)
+		.padding(PanelSpacing.popoverInset)
 	}
 
 	private var lifecycleActionIsDisabled: Bool {
@@ -227,7 +227,7 @@ private struct CompactAccountActionButton: View {
 					? PanelPalette.routeAccent(colorScheme)
 					: PanelPalette.primaryText(colorScheme).opacity(0.88)
 			)
-			.padding(.horizontal, 2)
+			.padding(.horizontal, PanelSpacing.micro)
 			.frame(minHeight: 20)
 			.contentShape(Rectangle())
 		}
@@ -248,7 +248,7 @@ struct AccountEnrollmentView: View {
 	let dismiss: () -> Void
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 10) {
+		VStack(alignment: .leading, spacing: PanelSpacing.section) {
 			Text("Add Codex login")
 				.font(PanelFont.transientTitle)
 
@@ -279,6 +279,6 @@ struct AccountEnrollmentView: View {
 			}
 		}
 		.frame(width: 260)
-		.padding(14)
+		.padding(PanelSpacing.popoverInset)
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
@@ -6,7 +6,7 @@ enum AccountPanelLayout {
 	static let panelVerticalPadding: CGFloat = 12
 	static let panelWidth: CGFloat = 276
 	static let minimumAccountListHeight: CGFloat = 110
-	static let estimatedAccountRowHeight: CGFloat = 74
+	static let estimatedAccountRowHeight: CGFloat = 84
 	static let statusMaximumHeight: CGFloat = 92
 	// Combined header/activity card and panel spacing.
 	static let fixedChromeHeight: CGFloat = 90
@@ -43,8 +43,9 @@ enum AccountPanelLayout {
 				- fixedChromeHeight
 				- boundedAdditionalChromeHeight
 		)
-		let rowCount = max(1, accountCount)
-		let contentEstimate = CGFloat(rowCount) * estimatedAccountRowHeight
+		let contentEstimate = estimatedAccountListContentHeight(
+			accountCount: accountCount
+		)
 		let contentHeight = resolvedAccountListContentHeight(
 			measured: measuredContentHeight,
 			estimated: contentEstimate
@@ -54,6 +55,19 @@ enum AccountPanelLayout {
 			screenBound,
 			max(minimumAccountListHeight, contentHeight)
 		)
+	}
+
+	static func estimatedAccountListContentHeight(
+		accountCount: Int
+	) -> CGFloat {
+		let rowCount = max(1, accountCount)
+		let rowHeights = CGFloat(rowCount) * estimatedAccountRowHeight
+		let rowGaps =
+			CGFloat(max(0, rowCount - 1))
+			* PanelSpacing.section
+		// The list keeps a one-point rendering inset on every edge so card
+		// shadows are not clipped.
+		return rowHeights + rowGaps + 2
 	}
 
 	static func resolvedAccountListContentHeight(

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -43,7 +43,7 @@ struct AccountPanelView: View {
 			}
 		}
 		.frame(width: AccountPanelLayout.panelWidth)
-		.padding(6)
+		.padding(PanelSpacing.related)
 		.controlSize(.small)
 		.symbolRenderingMode(.hierarchical)
 		.animation(PanelMotion.panelLayout, value: store.accounts.map(\.id))
@@ -92,7 +92,7 @@ struct AccountPanelView: View {
 	}
 
 	private var panelContent: some View {
-		VStack(alignment: .leading, spacing: 7) {
+		VStack(alignment: .leading, spacing: PanelSpacing.section) {
 			headerOverview
 
 			if hasTransientStatus {
@@ -105,7 +105,7 @@ struct AccountPanelView: View {
 	}
 
 	private var headerOverview: some View {
-		VStack(alignment: .leading, spacing: 6) {
+		VStack(alignment: .leading, spacing: PanelSpacing.related) {
 			header
 
 			if let profileAggregate {
@@ -115,8 +115,8 @@ struct AccountPanelView: View {
 					.transition(.panelSection)
 			}
 		}
-		.padding(.horizontal, 10)
-		.padding(.vertical, 8)
+		.padding(.horizontal, PanelSpacing.cardHorizontal)
+		.padding(.vertical, PanelSpacing.cardVertical)
 		.panelCardSurface(cornerRadius: 18)
 	}
 
@@ -133,7 +133,7 @@ struct AccountPanelView: View {
 	}
 
 	private var header: some View {
-		HStack(alignment: .center, spacing: 6) {
+		HStack(alignment: .center, spacing: PanelSpacing.related) {
 			Image(nsImage: AppAssets.statusBarIcon)
 				.resizable()
 				.renderingMode(.template)
@@ -269,10 +269,10 @@ struct AccountPanelView: View {
 	}
 
 	private var transientStatus: some View {
-		VStack(alignment: .leading, spacing: 5) {
+		VStack(alignment: .leading, spacing: PanelSpacing.related) {
 			if hasBoundedTransientStatus {
 				ScrollView(.vertical, showsIndicators: false) {
-					VStack(alignment: .leading, spacing: 5) {
+					VStack(alignment: .leading, spacing: PanelSpacing.related) {
 						if let errorMessage = fastMode.errorMessage {
 							ResetCardMessageView(
 								message: ResetCardStoreMessage(
@@ -338,7 +338,7 @@ struct AccountPanelView: View {
 			emptyOrLoadingState
 		} else {
 			ScrollView(.vertical, showsIndicators: false) {
-				VStack(alignment: .leading, spacing: 7) {
+				VStack(alignment: .leading, spacing: PanelSpacing.section) {
 					ForEach(store.accounts) { state in
 						ResetCardAccountRow(
 							state: state,
@@ -368,8 +368,9 @@ struct AccountPanelView: View {
 	private var accountListContentHeight: CGFloat {
 		AccountPanelLayout.resolvedAccountListContentHeight(
 			measured: measuredAccountListContentHeight,
-			estimated: CGFloat(max(1, store.accounts.count))
-				* AccountPanelLayout.estimatedAccountRowHeight
+			estimated: AccountPanelLayout.estimatedAccountListContentHeight(
+				accountCount: store.accounts.count
+			)
 		)
 	}
 
@@ -394,7 +395,7 @@ struct AccountPanelView: View {
 	}
 
 	private var emptyOrLoadingState: some View {
-		HStack(alignment: .center, spacing: 8) {
+		HStack(alignment: .center, spacing: PanelSpacing.section) {
 			if store.isInitialLoading {
 				ProgressView()
 					.controlSize(.small)
@@ -404,7 +405,7 @@ struct AccountPanelView: View {
 					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 			}
 
-			VStack(alignment: .leading, spacing: 2) {
+			VStack(alignment: .leading, spacing: PanelSpacing.micro) {
 				Text(store.isInitialLoading ? "Loading accounts" : "No accounts")
 					.font(PanelFont.emptyTitle)
 					.foregroundStyle(PanelPalette.primaryText(colorScheme))
@@ -419,7 +420,8 @@ struct AccountPanelView: View {
 			}
 		}
 		.frame(maxWidth: .infinity, alignment: .leading)
-		.padding(9)
+		.padding(.horizontal, PanelSpacing.cardHorizontal)
+		.padding(.vertical, PanelSpacing.cardVertical)
 		.panelCardSurface(cornerRadius: 16)
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/AccountProfileViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountProfileViews.swift
@@ -5,7 +5,7 @@ struct AccountProfileSummaryView: View {
 	@Environment(\.colorScheme) private var colorScheme
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 5) {
+		VStack(alignment: .leading, spacing: PanelSpacing.related) {
 			AccountProfileMetricsView(metrics: metrics)
 
 			if profile.dailyUsage.isEmpty == false {
@@ -34,7 +34,7 @@ struct AccountProfileDetailView: View {
 	@Environment(\.colorScheme) private var colorScheme
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 9) {
+		VStack(alignment: .leading, spacing: PanelSpacing.section) {
 			if let profile = state.profile {
 				AccountProfileSummaryView(profile: profile.snapshot)
 
@@ -51,7 +51,7 @@ struct AccountProfileDetailView: View {
 						.fixedSize(horizontal: false, vertical: true)
 				}
 			} else if state.isProfileRefreshing {
-				HStack(spacing: 6) {
+				HStack(spacing: PanelSpacing.related) {
 					ProgressView()
 						.controlSize(.mini)
 					Text("Loading saved activity")
@@ -73,7 +73,7 @@ struct AccountProfileDetailView: View {
 			}
 		}
 		.frame(width: 270)
-		.padding(12)
+		.padding(PanelSpacing.popoverInset)
 		.accessibilityElement(children: .contain)
 	}
 
@@ -105,7 +105,7 @@ struct AccountProfileOverviewView: View {
 	let aggregate: AccountProfileAggregate
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 4) {
+		VStack(alignment: .leading, spacing: PanelSpacing.compact) {
 			if aggregateMetrics.isEmpty == false {
 				AccountProfileMetricsView(
 					metrics: aggregateMetrics
@@ -119,7 +119,7 @@ struct AccountProfileOverviewView: View {
 			}
 		}
 		.frame(maxWidth: .infinity, alignment: .leading)
-		.padding(.horizontal, 2)
+		.padding(.horizontal, PanelSpacing.micro)
 		.accessibilityElement(children: .combine)
 	}
 
@@ -217,9 +217,9 @@ private struct AccountProfileMetricsView: View {
 
 	var body: some View {
 		if metrics.isEmpty == false {
-			HStack(alignment: .firstTextBaseline, spacing: 3) {
+			HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.micro) {
 				ForEach(metrics) { metric in
-					HStack(alignment: .firstTextBaseline, spacing: 2) {
+					HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.micro) {
 						Text(metric.label)
 							.font(PanelFont.usageLabel)
 							.foregroundStyle(PanelPalette.secondaryText(colorScheme))

--- a/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
@@ -10,7 +10,7 @@ struct AccountReauthenticationView: View {
 	@FocusState private var focusedAction: FocusedAction?
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 9) {
+		VStack(alignment: .leading, spacing: PanelSpacing.section) {
 			if let presentation = store.accountReauthentication {
 				let desiredFocus = desiredFocus(for: presentation)
 
@@ -23,7 +23,7 @@ struct AccountReauthenticationView: View {
 						.fixedSize(horizontal: false, vertical: true)
 				}
 
-				HStack(spacing: 8) {
+				HStack(spacing: PanelSpacing.section) {
 					if presentation.canCloseWithoutCancellation
 						|| presentation.canRequestCancellation
 					{
@@ -65,7 +65,7 @@ struct AccountReauthenticationView: View {
 			}
 		}
 		.frame(width: 220)
-		.padding(14)
+		.padding(PanelSpacing.popoverInset)
 		.controlSize(.small)
 		.accessibilityElement(children: .contain)
 		.accessibilityLabel("Refresh login")
@@ -85,15 +85,15 @@ struct AccountReauthenticationView: View {
 	private func header(
 		_ presentation: AccountReauthenticationPresentation
 	) -> some View {
-		VStack(alignment: .leading, spacing: 2) {
-			HStack(alignment: .firstTextBaseline, spacing: 5) {
+		VStack(alignment: .leading, spacing: PanelSpacing.micro) {
+			HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.related) {
 				Text("Refresh login")
 					.font(PanelFont.transientTitle)
 					.foregroundStyle(PanelPalette.primaryText(colorScheme))
 
 				Spacer(minLength: 6)
 
-				HStack(alignment: .firstTextBaseline, spacing: 3) {
+				HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.micro) {
 					if presentation.failureText == nil {
 						ProgressView()
 							.controlSize(.mini)

--- a/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
@@ -1,5 +1,20 @@
 import SwiftUI
 
+enum PanelSpacing {
+	// Compact 2-point rhythm for the menu-bar panel.
+	static let micro: CGFloat = 2
+	static let compact: CGFloat = 4
+	static let related: CGFloat = 6
+	static let section: CGFloat = 8
+
+	// All primary cards share the same content edge.
+	static let cardHorizontal: CGFloat = 10
+	static let cardVertical: CGFloat = 8
+
+	// Popovers and floating modal content use one larger inset.
+	static let popoverInset: CGFloat = 12
+}
+
 enum PanelMotion {
 	static let panelLayout = Animation.interactiveSpring(response: 0.3, dampingFraction: 0.92, blendDuration: 0.05)
 }

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -376,16 +376,12 @@ struct ResetCardAccountRow: View {
 						} label: {
 							cardChip(target)
 						}
-						.buttonStyle(.bordered)
-						.buttonBorderShape(.roundedRectangle(radius: 6))
-						.controlSize(.small)
-						.tint(
-							confirmation.isArmed(target)
-								? PanelPalette.warning(colorScheme)
-								: PanelPalette.actionBlue(colorScheme)
+						.buttonStyle(
+							ResetCardChipButtonStyle(
+								isArmed: confirmation.isArmed(target)
+							)
 						)
 						.disabled(store.blocksNewAttempt(for: target))
-						.frame(minHeight: 24)
 						.accessibilityLabel(accessibilityLabel(target))
 						.accessibilityHint(accessibilityHint(target))
 						.help(help(target))
@@ -570,6 +566,48 @@ struct ResetCardAccountRow: View {
 			timeZone.abbreviation(for: date)
 			?? timeZone.identifier
 		return "Reset Card, expires \(spokenExpiry) \(zone)"
+	}
+}
+
+private struct ResetCardChipButtonStyle: ButtonStyle {
+	let isArmed: Bool
+	@Environment(\.colorScheme) private var colorScheme
+	@Environment(\.isEnabled) private var isEnabled
+
+	func makeBody(configuration: Configuration) -> some View {
+		let shape = RoundedRectangle(cornerRadius: 6, style: .continuous)
+
+		configuration.label
+			.padding(.horizontal, PanelSpacing.compact)
+			.frame(minHeight: 24)
+			.background {
+				shape.fill(fillColor)
+			}
+			.overlay {
+				shape.strokeBorder(borderColor, lineWidth: 1)
+			}
+			.contentShape(shape)
+			.opacity(isEnabled ? (configuration.isPressed ? 0.76 : 1) : 0.46)
+			.scaleEffect(configuration.isPressed ? 0.985 : 1)
+			.animation(.easeOut(duration: 0.08), value: configuration.isPressed)
+	}
+
+	private var fillColor: Color {
+		if isArmed {
+			return PanelPalette.warning(colorScheme)
+				.opacity(colorScheme == .dark ? 0.12 : 0.09)
+		}
+		return PanelPalette.primaryText(colorScheme)
+			.opacity(colorScheme == .dark ? 0.055 : 0.04)
+	}
+
+	private var borderColor: Color {
+		if isArmed {
+			return PanelPalette.warning(colorScheme)
+				.opacity(colorScheme == .dark ? 0.72 : 0.62)
+		}
+		return PanelPalette.primaryText(colorScheme)
+			.opacity(colorScheme == .dark ? 0.22 : 0.18)
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -6,7 +6,7 @@ struct ResetCardMessageView: View {
 	@Environment(\.colorScheme) private var colorScheme
 
 	var body: some View {
-		HStack(alignment: .firstTextBaseline, spacing: 6) {
+		HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.related) {
 			Image(systemName: symbol)
 				.font(PanelFont.tertiary)
 				.foregroundStyle(color)
@@ -27,8 +27,8 @@ struct ResetCardMessageView: View {
 			.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 			.help("Dismiss message")
 		}
-		.padding(.horizontal, 8)
-		.padding(.vertical, 6)
+		.padding(.horizontal, PanelSpacing.cardHorizontal)
+		.padding(.vertical, PanelSpacing.cardVertical)
 		.panelCardSurface(cornerRadius: 14)
 	}
 
@@ -60,9 +60,9 @@ struct ResetCardPendingAttemptsView: View {
 	@Environment(\.colorScheme) private var colorScheme
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 5) {
+		VStack(alignment: .leading, spacing: PanelSpacing.related) {
 			ForEach(store.pendingAttempts, id: \.idempotencyKey) { attempt in
-				HStack(spacing: 6) {
+				HStack(spacing: PanelSpacing.related) {
 					Image(systemName: "clock.arrow.circlepath")
 						.font(PanelFont.tertiary)
 						.foregroundStyle(PanelPalette.warning(colorScheme))
@@ -95,8 +95,8 @@ struct ResetCardPendingAttemptsView: View {
 				}
 			}
 		}
-		.padding(.horizontal, 8)
-		.padding(.vertical, 6)
+		.padding(.horizontal, PanelSpacing.cardHorizontal)
+		.padding(.vertical, PanelSpacing.cardVertical)
 		.panelCardSurface(cornerRadius: 14)
 	}
 }
@@ -125,8 +125,8 @@ struct ResetCardAccountRow: View {
 	}
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 2) {
-			HStack(alignment: .center, spacing: 4) {
+		VStack(alignment: .leading, spacing: PanelSpacing.compact) {
+			HStack(alignment: .center, spacing: PanelSpacing.compact) {
 				identityHeader
 				AccountPrimaryActionsView(
 					state: state,
@@ -140,7 +140,7 @@ struct ResetCardAccountRow: View {
 
 			quotaWindows
 
-			HStack(alignment: .center, spacing: 4) {
+			HStack(alignment: .center, spacing: PanelSpacing.compact) {
 				cardInventory
 					.frame(maxWidth: .infinity, alignment: .leading)
 					.layoutPriority(1)
@@ -152,8 +152,8 @@ struct ResetCardAccountRow: View {
 				)
 			}
 		}
-		.padding(.horizontal, 9)
-		.padding(.vertical, 6)
+		.padding(.horizontal, PanelSpacing.cardHorizontal)
+		.padding(.vertical, PanelSpacing.cardVertical)
 		.fixedSize(horizontal: false, vertical: true)
 		.accessibilityIdentifier("decodex.account.\(state.account.accountID)")
 		.onAppear {
@@ -172,7 +172,7 @@ struct ResetCardAccountRow: View {
 	}
 
 	private var identityHeader: some View {
-		HStack(alignment: .firstTextBaseline, spacing: 5) {
+		HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.compact) {
 			Text(identity.text)
 				.font(PanelFont.accountName)
 				.foregroundStyle(PanelPalette.primaryText(colorScheme))
@@ -194,7 +194,7 @@ struct ResetCardAccountRow: View {
 	}
 
 	private var exceptionalStatus: some View {
-		HStack(spacing: 5) {
+		HStack(spacing: PanelSpacing.related) {
 			Text(exceptionalStatusText ?? "")
 				.font(PanelFont.accountDetail)
 				.foregroundStyle(exceptionalStatusColor)
@@ -303,7 +303,7 @@ struct ResetCardAccountRow: View {
 
 	@ViewBuilder
 	private var quotaWindows: some View {
-		VStack(alignment: .leading, spacing: 2) {
+		VStack(alignment: .leading, spacing: PanelSpacing.micro) {
 			if ResetCardQuotaPresentation(window: state.fiveHourQuota).isVisible {
 				ResetCardQuotaWindowView(
 					title: "5h",
@@ -369,7 +369,7 @@ struct ResetCardAccountRow: View {
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 		} else {
 			ScrollView(.horizontal, showsIndicators: false) {
-				HStack(spacing: 4) {
+				HStack(spacing: PanelSpacing.compact) {
 					ForEach(state.targets, id: \.self) { target in
 						Button {
 							tap(target)
@@ -420,7 +420,7 @@ struct ResetCardAccountRow: View {
 		.monospacedDigit()
 		.lineLimit(1)
 		.fixedSize(horizontal: true, vertical: false)
-		.padding(.horizontal, 1)
+		.padding(.horizontal, PanelSpacing.micro)
 		.contentShape(Rectangle())
 	}
 
@@ -633,7 +633,7 @@ private struct ResetCardQuotaWindowView: View {
 	var body: some View {
 		let presentation = ResetCardQuotaPresentation(window: window)
 
-		HStack(alignment: .center, spacing: 4) {
+		HStack(alignment: .center, spacing: PanelSpacing.compact) {
 			Text(title)
 				.font(PanelFont.quotaText)
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
@@ -659,7 +659,7 @@ private struct ResetCardQuotaWindowView: View {
 				.layoutPriority(1)
 			}
 
-			HStack(alignment: .firstTextBaseline, spacing: 3) {
+			HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.micro) {
 				Text(presentation.valueText)
 					.font(PanelFont.usageValue)
 

--- a/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
@@ -4,6 +4,16 @@ import SwiftUI
 import XCTest
 
 final class PanelWindowSizingLayoutTests: XCTestCase {
+	func testPanelSpacingUsesOneCompactTwoPointRhythm() {
+		XCTAssertEqual(PanelSpacing.micro, 2)
+		XCTAssertEqual(PanelSpacing.compact, 4)
+		XCTAssertEqual(PanelSpacing.related, 6)
+		XCTAssertEqual(PanelSpacing.section, 8)
+		XCTAssertEqual(PanelSpacing.cardHorizontal, 10)
+		XCTAssertEqual(PanelSpacing.cardVertical, 8)
+		XCTAssertEqual(PanelSpacing.popoverInset, 12)
+	}
+
 	@MainActor
 	func testPanelWindowHostStaysTransparentWithoutOverridingSystemAppearance() {
 		let window = NSWindow(
@@ -143,6 +153,21 @@ final class PanelWindowSizingLayoutTests: XCTestCase {
 				estimated: 730
 			),
 			730
+		)
+	}
+
+	func testAccountListEstimateUsesRowHeightAndSharedSectionSpacing() {
+		XCTAssertEqual(
+			AccountPanelLayout.estimatedAccountListContentHeight(
+				accountCount: 6
+			),
+			546
+		)
+		XCTAssertEqual(
+			AccountPanelLayout.estimatedAccountListContentHeight(
+				accountCount: 0
+			),
+			86
 		)
 	}
 

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -22,6 +22,47 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(accountPanel.contains("ForEach(store.accounts)"))
 	}
 
+	func testPanelCardsAndPopoversUseSharedSpacingTokens() throws {
+		let sourceURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
+		let panel = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountPanelView.swift"),
+			encoding: .utf8
+		)
+		let rows = try String(
+			contentsOf: sourceURL.appendingPathComponent("ResetCardSectionView.swift"),
+			encoding: .utf8
+		)
+		let details = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountProfileViews.swift"),
+			encoding: .utf8
+		)
+		let login = try String(
+			contentsOf: sourceURL.appendingPathComponent(
+				"AccountReauthenticationView.swift"
+			),
+			encoding: .utf8
+		)
+
+		for source in [panel, rows] {
+			XCTAssertTrue(
+				source.contains(
+					".padding(.horizontal, PanelSpacing.cardHorizontal)"
+				)
+			)
+			XCTAssertTrue(
+				source.contains(
+					".padding(.vertical, PanelSpacing.cardVertical)"
+				)
+			)
+		}
+		XCTAssertTrue(details.contains(".padding(PanelSpacing.popoverInset)"))
+		XCTAssertTrue(login.contains(".padding(PanelSpacing.popoverInset)"))
+	}
+
 	func testHeaderAndOverviewShareOneCardWithoutARedundantTitleRow() throws {
 		let sourceURL = URL(fileURLWithPath: #filePath)
 			.deletingLastPathComponent()
@@ -442,7 +483,7 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(view.contains("verificationURL"))
 		XCTAssertTrue(view.contains(".keyboardShortcut(.cancelAction)"))
 		XCTAssertTrue(view.contains(".frame(width: 220)"))
-		XCTAssertTrue(view.contains(".padding(14)"))
+		XCTAssertTrue(view.contains(".padding(PanelSpacing.popoverInset)"))
 		XCTAssertFalse(view.contains("Enter this one-time code"))
 		XCTAssertFalse(view.contains("Divider()"))
 		XCTAssertFalse(view.contains(".interactiveDismissDisabled"))

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -299,8 +299,10 @@ final class ResetCardArchitectureTests: XCTestCase {
 		)
 		XCTAssertFalse(statusPanel.contains(".preferredColorScheme"))
 		XCTAssertFalse(statusPanel.contains(".environment(\\.colorScheme"))
-		XCTAssertTrue(resetCards.contains(".buttonStyle(.bordered)"))
-		XCTAssertTrue(resetCards.contains(".controlSize(.small)"))
+		XCTAssertTrue(resetCards.contains("ResetCardChipButtonStyle("))
+		XCTAssertTrue(resetCards.contains("shape.strokeBorder(borderColor, lineWidth: 1)"))
+		XCTAssertTrue(resetCards.contains("configuration.isPressed ? 0.985 : 1"))
+		XCTAssertFalse(resetCards.contains(".buttonStyle(.bordered)"))
 		XCTAssertTrue(
 			resetCards.contains(
 				"Self.cardExpiryText(target.descriptor.expiresAtUnixSeconds)"


### PR DESCRIPTION
## Summary
- define one compact 2-point spacing rhythm for the menu-bar panel
- apply shared content insets to cards, popovers, and login recovery
- calibrate the initial account-list estimate to prevent an opening resize
- give Reset Card controls a subtle 1pt border and a stable warning confirmation state

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app` (172 tests)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer apps/decodex-app/script/build_and_run.sh stage`
- live six-account screenshot with full aggregate metrics and visible Reset Card borders
- immediate and settled panel size remain stable