### PR TITLE
Color quota capacity states

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -31,7 +31,10 @@ Each row shows the exact current 300-minute and 10,080-minute quota
 observations in a vertical stack, the percentage left and reset time when
 known, and every complete public Reset Card expiry. Expired observations are
 not shown as current data. The 300-minute row is absent when the provider does
-not return a supported observation.
+not return a supported observation. Current quota bars and percentages use
+system-adaptive capacity colors: green above 50% remaining, orange from 21% to
+50%, and red at 20% or below. The numeric percentage and accessibility value
+remain the primary status.
 
 The app performs one non-overlapping refresh every 15 seconds, matching the
 pre-cutover native cadence. Opening the panel also requests one refresh. An

--- a/apps/decodex-app/Sources/DecodexApp/PanelPalette.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelPalette.swift
@@ -29,6 +29,10 @@ enum PanelPalette {
 		.accentColor
 	}
 
+	static func quotaHealthy(_: ColorScheme) -> Color {
+		.green
+	}
+
 	static func fastModeAccent(_ colorScheme: ColorScheme) -> Color {
 		colorScheme == .dark ? .yellow : .orange
 	}

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -612,8 +612,9 @@ private struct ResetCardChipButtonStyle: ButtonStyle {
 }
 
 enum ResetCardQuotaPresentationTone: Equatable {
-	case current
+	case healthy
 	case warning
+	case critical
 	case muted
 	case error
 }
@@ -634,7 +635,15 @@ struct ResetCardQuotaPresentation: Equatable {
 			let remainingPercent = 100 - min(100, usedPercent)
 			valueText = "\(remainingPercent)%"
 			detailText = nil
-			tone = .current
+			tone =
+				switch remainingPercent {
+				case 51...:
+					.healthy
+				case 21...:
+					.warning
+				default:
+					.critical
+				}
 			self.usedPercent = usedPercent
 			self.remainingPercent = remainingPercent
 			resetDate = window.resetDate
@@ -739,14 +748,14 @@ private struct ResetCardQuotaWindowView: View {
 
 	private func stateColor(for tone: ResetCardQuotaPresentationTone) -> Color {
 		switch tone {
-		case .current:
-			return PanelPalette.usageCyan(colorScheme)
+		case .healthy:
+			return PanelPalette.quotaHealthy(colorScheme)
 		case .warning:
 			return PanelPalette.warning(colorScheme)
+		case .critical, .error:
+			return PanelPalette.destructive(colorScheme)
 		case .muted:
 			return PanelPalette.secondaryText(colorScheme)
-		case .error:
-			return PanelPalette.destructive(colorScheme)
 		}
 	}
 

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -53,10 +53,31 @@ final class AccountPanelPresentationTests: XCTestCase {
 
 		XCTAssertTrue(presentation.isVisible)
 		XCTAssertEqual(presentation.valueText, "21%")
-		XCTAssertEqual(presentation.tone, .current)
+		XCTAssertEqual(presentation.tone, .warning)
 		XCTAssertEqual(presentation.usedPercent, 79)
 		XCTAssertEqual(presentation.remainingPercent, 21)
 		XCTAssertNotNil(presentation.resetDate)
+	}
+
+	func testCurrentQuotaToneTracksRemainingCapacity() {
+		func tone(usedPercent: UInt8) -> ResetCardQuotaPresentationTone {
+			ResetCardQuotaPresentation(
+				window: ResetCardQuotaWindow(
+					durationMinutes: 10_080,
+					observedAtUnixMicros: 1_000_000,
+					state: .current(
+						usedPercent: usedPercent,
+						resetsAtUnixMicros: 2_000_000
+					)
+				)
+			).tone
+		}
+
+		XCTAssertEqual(tone(usedPercent: 49), .healthy)
+		XCTAssertEqual(tone(usedPercent: 50), .warning)
+		XCTAssertEqual(tone(usedPercent: 79), .warning)
+		XCTAssertEqual(tone(usedPercent: 80), .critical)
+		XCTAssertEqual(tone(usedPercent: 100), .critical)
 	}
 
 	func testUnknownOptionalQuotaWindowIsHidden() {


### PR DESCRIPTION
## Summary
- color quota bars and remaining percentages by capacity
- use green above 50%, orange from 21% to 50%, and red at 20% or below
- retain numeric and accessibility status so color is not the only signal

## Validation
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer apps/decodex-app/script/build_and_run.sh --verify
- live Light-mode screenshot review