### PR TITLE
Align quota colors with panel theme

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -31,10 +31,10 @@ Each row shows the exact current 300-minute and 10,080-minute quota
 observations in a vertical stack, the percentage left and reset time when
 known, and every complete public Reset Card expiry. Expired observations are
 not shown as current data. The 300-minute row is absent when the provider does
-not return a supported observation. Current quota bars and percentages use
-system-adaptive capacity colors: green above 50% remaining, orange from 21% to
-50%, and red at 20% or below. The numeric percentage and accessibility value
-remain the primary status.
+not return a supported observation. Current quota bars and percentages stay
+inside the panel theme: accent blue above 50% remaining, warning amber from 21%
+to 50%, and destructive red at 20% or below. The numeric percentage and
+accessibility value remain the primary status.
 
 The app performs one non-overlapping refresh every 15 seconds, matching the
 pre-cutover native cadence. Opening the panel also requests one refresh. An

--- a/apps/decodex-app/Sources/DecodexApp/PanelPalette.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelPalette.swift
@@ -29,10 +29,6 @@ enum PanelPalette {
 		.accentColor
 	}
 
-	static func quotaHealthy(_: ColorScheme) -> Color {
-		.green
-	}
-
 	static func fastModeAccent(_ colorScheme: ColorScheme) -> Color {
 		colorScheme == .dark ? .yellow : .orange
 	}

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -749,7 +749,7 @@ private struct ResetCardQuotaWindowView: View {
 	private func stateColor(for tone: ResetCardQuotaPresentationTone) -> Color {
 		switch tone {
 		case .healthy:
-			return PanelPalette.quotaHealthy(colorScheme)
+			return PanelPalette.usageCyan(colorScheme)
 		case .warning:
 			return PanelPalette.warning(colorScheme)
 		case .critical, .error:


### PR DESCRIPTION
## Summary
- keep dynamic quota thresholds while using existing Decodex semantic colors
- use accent blue for healthy capacity, warning amber for mid capacity, and destructive red for low capacity
- remove the standalone battery-green palette role

## Validation
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer apps/decodex-app/script/build_and_run.sh --verify
- live Light-mode screenshot review