### PR TITLE
Polish account route transitions

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
@@ -1,5 +1,30 @@
 import SwiftUI
 
+struct AccountRouteActionPresentation: Equatable {
+	let isCurrent: Bool
+	let canSelect: Bool
+	let canPerformDirectAccountControl: Bool
+	let isAccountControlInProgress: Bool
+	let isSubmittingResetCard: Bool
+
+	var isDisabled: Bool {
+		isCurrent
+			|| canSelect == false
+			|| canPerformDirectAccountControl == false
+			|| isAccountControlInProgress
+			|| isSubmittingResetCard
+	}
+
+	var isVisuallyDisabled: Bool {
+		isCurrent == false
+			&& (
+				canSelect == false
+					|| canPerformDirectAccountControl == false
+					|| isSubmittingResetCard
+			)
+	}
+}
+
 struct AccountPrimaryActionsView: View {
 	let state: ResetCardAccountState
 	let store: ResetCardStore
@@ -7,17 +32,18 @@ struct AccountPrimaryActionsView: View {
 	var body: some View {
 		HStack(spacing: PanelSpacing.compact) {
 			CompactAccountActionButton(
-				title: isRouteCurrent ? "Routed" : "Route",
-				symbol: isRouteCurrent
+				title: presentation.isCurrent ? "Routed" : "Route",
+				symbol: presentation.isCurrent
 					? "point.3.connected.trianglepath.dotted"
 					: "arrow.triangle.branch",
-				isActive: isRouteCurrent,
-				isDisabled: routeActionIsDisabled,
+				isActive: presentation.isCurrent,
+				isDisabled: presentation.isDisabled,
+				isVisuallyDisabled: presentation.isVisuallyDisabled,
 				isBusy: store.isControllingAccount(
 					state.account.accountID,
 					activity: .route
 				),
-				help: isRouteCurrent
+				help: presentation.isCurrent
 					? "This account is used by Decodex routing and new Codex processes."
 					: "Route Decodex and use this account for new Codex processes."
 			) {
@@ -38,12 +64,14 @@ struct AccountPrimaryActionsView: View {
 		isCodexProjection && isFixed
 	}
 
-	private var routeActionIsDisabled: Bool {
-		isRouteCurrent
-			|| canSelect == false
-			|| store.canPerformDirectAccountControl == false
-			|| store.isAccountControlInProgress
-			|| store.submittingKey != nil
+	private var presentation: AccountRouteActionPresentation {
+		AccountRouteActionPresentation(
+			isCurrent: isRouteCurrent,
+			canSelect: canSelect,
+			canPerformDirectAccountControl: store.canPerformDirectAccountControl,
+			isAccountControlInProgress: store.isAccountControlInProgress,
+			isSubmittingResetCard: store.submittingKey != nil
+		)
 	}
 
 	private var canSelect: Bool {
@@ -175,6 +203,7 @@ struct AccountRefreshLoginButton: View {
 			symbol: "person.crop.circle.badge.plus",
 			isActive: false,
 			isDisabled: isDisabled,
+			isVisuallyDisabled: isDisabled,
 			isBusy: store.isControllingAccount(
 				state.account.accountID,
 				activity: .loginRefresh
@@ -202,20 +231,34 @@ private struct CompactAccountActionButton: View {
 	let symbol: String
 	let isActive: Bool
 	let isDisabled: Bool
+	let isVisuallyDisabled: Bool
 	let isBusy: Bool
 	let help: String
 	let action: () -> Void
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.colorScheme) private var colorScheme
 
 	var body: some View {
 		Button(action: action) {
 			ZStack {
-				Label(title, systemImage: symbol)
+				HStack(spacing: PanelSpacing.compact) {
+					Image(systemName: symbol)
+						.contentTransition(.symbolEffect(.replace))
+
+					Text(title)
+						.contentTransition(.opacity)
+				}
 					.opacity(isBusy ? 0 : 1)
+					.scaleEffect(isBusy ? 0.96 : 1)
 
 				if isBusy {
 					ProgressView()
 						.controlSize(.mini)
+						.transition(
+							.opacity.combined(
+								with: .scale(scale: 0.88)
+							)
+						)
 						.accessibilityHidden(true)
 				}
 			}
@@ -232,13 +275,19 @@ private struct CompactAccountActionButton: View {
 		}
 		.buttonStyle(.plain)
 		.disabled(isDisabled)
-		.opacity(isDisabled && isActive == false ? 0.44 : 1)
+		.opacity(isVisuallyDisabled && isActive == false ? 0.44 : 1)
+		.animation(controlStateAnimation, value: isActive)
+		.animation(controlStateAnimation, value: isBusy)
 		.help(help)
 		.accessibilityLabel(title)
 		.accessibilityHint(help)
 		.accessibilityValue(
 			isBusy ? "In progress" : (isActive ? "Current" : "")
 		)
+	}
+
+	private var controlStateAnimation: Animation? {
+		reduceMotion ? nil : PanelMotion.controlState
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
@@ -17,6 +17,7 @@ enum PanelSpacing {
 
 enum PanelMotion {
 	static let panelLayout = Animation.interactiveSpring(response: 0.3, dampingFraction: 0.92, blendDuration: 0.05)
+	static let controlState = Animation.easeInOut(duration: 0.16)
 }
 
 extension View {

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -6,6 +6,32 @@ import XCTest
 
 @MainActor
 final class AccountPanelPresentationTests: XCTestCase {
+	func testSharedRouteOperationBlocksWithoutDimmingOtherAvailableRoutes() {
+		let presentation = AccountRouteActionPresentation(
+			isCurrent: false,
+			canSelect: true,
+			canPerformDirectAccountControl: true,
+			isAccountControlInProgress: true,
+			isSubmittingResetCard: false
+		)
+
+		XCTAssertTrue(presentation.isDisabled)
+		XCTAssertFalse(presentation.isVisuallyDisabled)
+	}
+
+	func testUnavailableRouteRemainsVisiblyDisabled() {
+		let presentation = AccountRouteActionPresentation(
+			isCurrent: false,
+			canSelect: false,
+			canPerformDirectAccountControl: true,
+			isAccountControlInProgress: false,
+			isSubmittingResetCard: false
+		)
+
+		XCTAssertTrue(presentation.isDisabled)
+		XCTAssertTrue(presentation.isVisuallyDisabled)
+	}
+
 	func testUnsupportedQuotaWindowIsHidden() {
 		let presentation = ResetCardQuotaPresentation(
 			window: ResetCardQuotaWindow(


### PR DESCRIPTION
## Summary
- keep unrelated account rows visually stable while a route request is serialized
- animate Route/Routed and progress-state transitions locally with reduced-motion support
- cover disabled interaction separately from visual availability

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app` (177 passed)
- `SCCACHE_DISABLE=1 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer apps/decodex-app/script/build_and_run.sh --verify`