### PR TITLE
Animate authoritative quota updates

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
@@ -18,6 +18,7 @@ enum PanelSpacing {
 enum PanelMotion {
 	static let panelLayout = Animation.interactiveSpring(response: 0.3, dampingFraction: 0.92, blendDuration: 0.05)
 	static let controlState = Animation.easeInOut(duration: 0.16)
+	static let quotaValue = Animation.easeOut(duration: 0.46)
 }
 
 extension View {

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -675,10 +675,12 @@ private struct ResetCardQuotaWindowView: View {
 
 	let title: String
 	let window: ResetCardQuotaWindow
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.colorScheme) private var colorScheme
 
 	var body: some View {
 		let presentation = ResetCardQuotaPresentation(window: window)
+		let remainingPercent = presentation.remainingPercent ?? 0
 
 		HStack(alignment: .center, spacing: PanelSpacing.compact) {
 			Text(title)
@@ -686,7 +688,7 @@ private struct ResetCardQuotaWindowView: View {
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 				.frame(width: Self.titleColumnWidth, alignment: .leading)
 
-			if let remainingPercent = presentation.remainingPercent {
+			if presentation.remainingPercent != nil {
 				GeometryReader { proxy in
 					ZStack(alignment: .leading) {
 						Capsule(style: .continuous)
@@ -699,6 +701,10 @@ private struct ResetCardQuotaWindowView: View {
 									* CGFloat(remainingPercent)
 									/ 100
 							)
+							.animation(
+								quotaValueAnimation,
+								value: remainingPercent
+							)
 					}
 				}
 				.frame(minWidth: 88, maxWidth: .infinity)
@@ -709,6 +715,9 @@ private struct ResetCardQuotaWindowView: View {
 			HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.micro) {
 				Text(presentation.valueText)
 					.font(PanelFont.usageValue)
+					.contentTransition(
+						.numericText(value: Double(remainingPercent))
+					)
 
 				if let detailText = presentation.detailText,
 					presentation.resetDate != nil
@@ -721,6 +730,7 @@ private struct ResetCardQuotaWindowView: View {
 			.monospacedDigit()
 			.lineLimit(1)
 			.fixedSize(horizontal: true, vertical: false)
+			.animation(quotaValueAnimation, value: remainingPercent)
 
 			if let resetDate = presentation.resetDate {
 				Text(Self.compactDateTime(resetDate))
@@ -744,6 +754,10 @@ private struct ResetCardQuotaWindowView: View {
 		.accessibilityLabel("\(title) quota")
 		.accessibilityValue(window.accessibilityValue)
 		.help(window.accessibilityValue)
+	}
+
+	private var quotaValueAnimation: Animation? {
+		reduceMotion ? nil : PanelMotion.quotaValue
 	}
 
 	private func stateColor(for tone: ResetCardQuotaPresentationTone) -> Color {

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -2,6 +2,33 @@ import Foundation
 import XCTest
 
 final class ResetCardArchitectureTests: XCTestCase {
+	func testQuotaMotionTracksOnlyTheAuthoritativeRemainingValue() throws {
+		let sourceURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
+		let accountRows = try String(
+			contentsOf: sourceURL.appendingPathComponent("ResetCardSectionView.swift"),
+			encoding: .utf8
+		)
+
+		XCTAssertTrue(
+			accountRows.contains(
+				".animation(quotaValueAnimation, value: remainingPercent)"
+			)
+		)
+		XCTAssertTrue(
+			accountRows.contains(
+				".numericText(value: Double(remainingPercent))"
+			)
+		)
+		XCTAssertTrue(
+			accountRows.contains("@Environment(\\.accessibilityReduceMotion)")
+		)
+		XCTAssertFalse(accountRows.contains("withAnimation"))
+	}
+
 	func testRepeatedAccountRowsUseIndependentCardSurfaces() throws {
 		let sourceURL = URL(fileURLWithPath: #filePath)
 			.deletingLastPathComponent()


### PR DESCRIPTION
## Summary
- animate each changed quota bar from its previous remaining value to the refreshed authoritative value
- transition the percentage digits and theme color with the same local motion
- honor Reduce Motion and avoid store-wide or synthetic 100% animation state

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app` (178 passed)
- `SCCACHE_DISABLE=1 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer apps/decodex-app/script/build_and_run.sh --verify`