### PR TITLE
Polish account panel motion

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
@@ -285,7 +285,7 @@ private struct CompactAccountActionButton: View {
 			.frame(minHeight: 20)
 			.contentShape(Rectangle())
 		}
-		.buttonStyle(.plain)
+		.buttonStyle(PanelPressButtonStyle(pressedScale: 0.97))
 		.disabled(usesDisabledEnvironment)
 		.allowsHitTesting(isDisabled == false)
 		.opacity(isVisuallyDisabled && isActive == false ? 0.44 : 1)

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -5,6 +5,7 @@ struct AccountPanelView: View {
 	let store: ResetCardStore
 	private let layoutVisibleFrameOverride: CGRect?
 	private let loadsExternalState: Bool
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.colorScheme) private var colorScheme
 	@State private var panelScreenVisibleFrame: CGRect?
 	@State private var measuredAccountListContentHeight: CGFloat = 0
@@ -46,7 +47,7 @@ struct AccountPanelView: View {
 		.padding(PanelSpacing.related)
 		.controlSize(.small)
 		.symbolRenderingMode(.hierarchical)
-		.animation(PanelMotion.panelLayout, value: store.accounts.map(\.id))
+		.animation(panelLayoutAnimation, value: store.accounts.map(\.id))
 		.sizesPanelWindowToContent { visibleFrame in
 			if panelScreenVisibleFrame != visibleFrame {
 				panelScreenVisibleFrame = visibleFrame
@@ -60,7 +61,7 @@ struct AccountPanelView: View {
 				isPresentingEnrollment = false
 			}
 		}
-		.animation(PanelMotion.panelLayout, value: store.accountReauthentication != nil)
+		.animation(panelLayoutAnimation, value: store.accountReauthentication != nil)
 		.task {
 			guard loadsExternalState else {
 				return
@@ -102,6 +103,7 @@ struct AccountPanelView: View {
 
 			accountContent
 		}
+		.animation(panelLayoutAnimation, value: hasTransientStatus)
 	}
 
 	private var headerOverview: some View {
@@ -118,6 +120,7 @@ struct AccountPanelView: View {
 		.padding(.horizontal, PanelSpacing.cardHorizontal)
 		.padding(.vertical, PanelSpacing.cardVertical)
 		.panelCardSurface(cornerRadius: 18)
+		.animation(panelLayoutAnimation, value: profileAggregate != nil)
 	}
 
 	private var reauthenticationOverlay: some View {
@@ -347,6 +350,7 @@ struct AccountPanelView: View {
 							detailedAccountID: $detailedAccountID
 						)
 						.panelCardSurface(cornerRadius: 16)
+						.transition(.panelSection)
 					}
 				}
 				.padding(1)
@@ -392,6 +396,10 @@ struct AccountPanelView: View {
 				value: proxy.size.height
 			)
 		}
+	}
+
+	private var panelLayoutAnimation: Animation? {
+		reduceMotion ? nil : PanelMotion.panelLayout
 	}
 
 	private var emptyOrLoadingState: some View {

--- a/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountReauthenticationView.swift
@@ -6,6 +6,7 @@ struct AccountReauthenticationView: View {
 	}
 
 	let store: ResetCardStore
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.colorScheme) private var colorScheme
 	@FocusState private var focusedAction: FocusedAction?
 
@@ -21,6 +22,7 @@ struct AccountReauthenticationView: View {
 						.font(PanelFont.transientBody)
 						.foregroundStyle(PanelPalette.destructive(colorScheme))
 						.fixedSize(horizontal: false, vertical: true)
+						.transition(.panelInline)
 				}
 
 				HStack(spacing: PanelSpacing.section) {
@@ -47,12 +49,22 @@ struct AccountReauthenticationView: View {
 						.focused($focusedAction, equals: .cancel)
 						.help(actionLabel)
 						.accessibilityLabel(actionLabel)
+						.transition(
+							.opacity.combined(
+								with: .scale(scale: 0.94, anchor: .leading)
+							)
+						)
 					} else {
 						ProgressView()
 							.controlSize(.mini)
 							.frame(width: 38, height: 24)
 							.help("Saving login")
 							.accessibilityLabel("Saving login")
+							.transition(
+								.opacity.combined(
+									with: .scale(scale: 0.9)
+								)
+							)
 					}
 				}
 				.task(id: desiredFocus) {
@@ -69,6 +81,10 @@ struct AccountReauthenticationView: View {
 		.controlSize(.small)
 		.accessibilityElement(children: .contain)
 		.accessibilityLabel("Refresh login")
+		.animation(
+			phaseTransitionAnimation,
+			value: store.accountReauthentication?.phase
+		)
 	}
 
 	private func desiredFocus(
@@ -97,6 +113,7 @@ struct AccountReauthenticationView: View {
 					if presentation.failureText == nil {
 						ProgressView()
 							.controlSize(.mini)
+							.transition(.opacity)
 							.accessibilityHidden(true)
 					}
 
@@ -115,9 +132,14 @@ struct AccountReauthenticationView: View {
 			Text(presentation.statusText)
 				.font(PanelFont.transientBody)
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+				.contentTransition(.opacity)
 				.lineLimit(1)
 				.truncationMode(.tail)
 				.accessibilityLabel(presentation.statusText)
 		}
+	}
+
+	private var phaseTransitionAnimation: Animation? {
+		reduceMotion ? nil : PanelMotion.controlState
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/PanelControls.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelControls.swift
@@ -11,6 +11,7 @@ struct PanelIconButtonView: View {
 	let size: CGFloat
 	let action: () -> Void
 	let help: String
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.colorScheme) private var colorScheme
 
 	init(
@@ -41,8 +42,10 @@ struct PanelIconButtonView: View {
 		Button(action: action) {
 			buttonLabel
 		}
-		.buttonStyle(.plain)
+		.buttonStyle(PanelPressButtonStyle())
 		.disabled(isDisabled)
+		.animation(controlStateAnimation, value: symbol)
+		.animation(controlStateAnimation, value: isActive)
 		.help(help)
 		.accessibilityLabel(help)
 	}
@@ -56,9 +59,14 @@ struct PanelIconButtonView: View {
 		Image(systemName: symbol)
 			.font(PanelFont.iconButton)
 			.symbolRenderingMode(.monochrome)
+			.contentTransition(.symbolEffect(.replace))
 			.foregroundStyle(foregroundColor)
 			.frame(width: size, height: size)
 			.contentShape(RoundedRectangle(cornerRadius: iconCornerRadius, style: .continuous))
+	}
+
+	private var controlStateAnimation: Animation? {
+		reduceMotion ? nil : PanelMotion.controlState
 	}
 
 	private var foregroundColor: Color {
@@ -82,5 +90,24 @@ struct PanelIconButtonView: View {
 
 	private var iconCornerRadius: CGFloat {
 		size * 0.5
+	}
+}
+
+struct PanelPressButtonStyle: ButtonStyle {
+	let pressedScale: CGFloat
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+	init(pressedScale: CGFloat = 0.92) {
+		self.pressedScale = pressedScale
+	}
+
+	func makeBody(configuration: Configuration) -> some View {
+		configuration.label
+			.opacity(configuration.isPressed ? 0.7 : 1)
+			.scaleEffect(configuration.isPressed ? pressedScale : 1)
+			.animation(
+				reduceMotion ? nil : PanelMotion.press,
+				value: configuration.isPressed
+			)
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
@@ -16,8 +16,10 @@ enum PanelSpacing {
 }
 
 enum PanelMotion {
+	static let press = Animation.easeOut(duration: 0.08)
 	static let panelLayout = Animation.interactiveSpring(response: 0.3, dampingFraction: 0.92, blendDuration: 0.05)
 	static let controlState = Animation.easeInOut(duration: 0.16)
+	static let identity = Animation.easeInOut(duration: 0.2)
 	static let quotaValue = Animation.easeOut(duration: 0.46)
 }
 
@@ -40,6 +42,12 @@ extension View {
 }
 
 extension AnyTransition {
+	static var panelInline: AnyTransition {
+		.opacity.combined(
+			with: .scale(scale: 0.985, anchor: .leading)
+		)
+	}
+
 	static var panelSection: AnyTransition {
 		.asymmetric(
 			insertion: .opacity

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -23,7 +23,7 @@ struct ResetCardMessageView: View {
 				Image(systemName: "xmark")
 					.font(PanelFont.tertiary)
 			}
-			.buttonStyle(.plain)
+			.buttonStyle(PanelPressButtonStyle(pressedScale: 0.9))
 			.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 			.help("Dismiss message")
 		}
@@ -108,6 +108,7 @@ struct ResetCardAccountRow: View {
 	let store: ResetCardStore
 	let showsEmail: Bool
 	@Binding private var detailedAccountID: String?
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.colorScheme) private var colorScheme
 	@State private var confirmation = ResetCardUseConfirmation()
 	@State private var confirmationSecondsRemaining = 0
@@ -136,6 +137,7 @@ struct ResetCardAccountRow: View {
 
 			if exceptionalStatusText != nil {
 				exceptionalStatus
+					.transition(.panelInline)
 			}
 
 			quotaWindows
@@ -169,6 +171,7 @@ struct ResetCardAccountRow: View {
 		.task(id: countdownAttempt) {
 			await runConfirmationCountdown(for: countdownAttempt)
 		}
+		.animation(rowStateAnimation, value: exceptionalStatusText)
 	}
 
 	private var identityHeader: some View {
@@ -176,9 +179,11 @@ struct ResetCardAccountRow: View {
 			Text(identity.text)
 				.font(PanelFont.accountName)
 				.foregroundStyle(PanelPalette.primaryText(colorScheme))
+				.contentTransition(.opacity)
 				.lineLimit(1)
 				.truncationMode(.middle)
 				.layoutPriority(1)
+				.animation(identityTransitionAnimation, value: identity.text)
 
 			if let planType {
 				Text(planType)
@@ -385,8 +390,14 @@ struct ResetCardAccountRow: View {
 						.accessibilityLabel(accessibilityLabel(target))
 						.accessibilityHint(accessibilityHint(target))
 						.help(help(target))
+						.transition(
+							.opacity.combined(
+								with: .scale(scale: 0.96)
+							)
+						)
 					}
 				}
+				.animation(rowStateAnimation, value: state.targets)
 			}
 			.frame(height: 26)
 			.fixedSize(horizontal: false, vertical: true)
@@ -406,6 +417,7 @@ struct ResetCardAccountRow: View {
 				.hidden()
 
 			Text(cardChipTitle(target))
+				.contentTransition(.opacity)
 				.foregroundStyle(
 					confirmation.isArmed(target)
 						? PanelPalette.warning(colorScheme)
@@ -418,6 +430,18 @@ struct ResetCardAccountRow: View {
 		.fixedSize(horizontal: true, vertical: false)
 		.padding(.horizontal, PanelSpacing.micro)
 		.contentShape(Rectangle())
+		.animation(
+			rowStateAnimation,
+			value: confirmation.isArmed(target)
+		)
+		.animation(
+			rowStateAnimation,
+			value: confirmation.isSubmitting(target)
+		)
+		.animation(
+			rowStateAnimation,
+			value: confirmationSecondsRemaining
+		)
 	}
 
 	private func cardChipTitle(_ target: ResetCardUseTarget) -> String {
@@ -482,6 +506,14 @@ struct ResetCardAccountRow: View {
 		}
 	}
 
+	private var identityTransitionAnimation: Animation? {
+		reduceMotion ? nil : PanelMotion.identity
+	}
+
+	private var rowStateAnimation: Animation? {
+		reduceMotion ? nil : PanelMotion.controlState
+	}
+
 	@MainActor
 	private func runConfirmationCountdown(
 		for attempt: ResetCardUseAttempt?
@@ -538,12 +570,19 @@ struct ResetCardAccountRow: View {
 		timeZone: TimeZone = .current
 	) -> String {
 		let date = Date(timeIntervalSince1970: TimeInterval(unixSeconds))
-		let formatter = DateFormatter()
-		formatter.locale = Locale(identifier: "en_US_POSIX")
-		formatter.calendar = Calendar(identifier: .gregorian)
-		formatter.timeZone = timeZone
-		formatter.dateFormat = "MMM d HH:mm"
-		return formatter.string(from: date)
+		var dayStyle = Date.FormatStyle.dateTime
+			.month(.abbreviated)
+			.day()
+		dayStyle.locale = Locale(identifier: "en_US_POSIX")
+		dayStyle.calendar = Calendar(identifier: .gregorian)
+		dayStyle.timeZone = timeZone
+		var timeStyle = Date.FormatStyle.dateTime
+			.hour(.twoDigits(amPM: .omitted))
+			.minute(.twoDigits)
+		timeStyle.locale = Locale(identifier: "en_US_POSIX@hours=h23")
+		timeStyle.calendar = Calendar(identifier: .gregorian)
+		timeStyle.timeZone = timeZone
+		return "\(date.formatted(dayStyle)) \(date.formatted(timeStyle))"
 	}
 
 	static func cardAccessibilityLabel(
@@ -571,6 +610,7 @@ struct ResetCardAccountRow: View {
 
 private struct ResetCardChipButtonStyle: ButtonStyle {
 	let isArmed: Bool
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.colorScheme) private var colorScheme
 	@Environment(\.isEnabled) private var isEnabled
 
@@ -589,7 +629,14 @@ private struct ResetCardChipButtonStyle: ButtonStyle {
 			.contentShape(shape)
 			.opacity(isEnabled ? (configuration.isPressed ? 0.76 : 1) : 0.46)
 			.scaleEffect(configuration.isPressed ? 0.985 : 1)
-			.animation(.easeOut(duration: 0.08), value: configuration.isPressed)
+			.animation(
+				reduceMotion ? nil : PanelMotion.press,
+				value: configuration.isPressed
+			)
+			.animation(
+				reduceMotion ? nil : PanelMotion.controlState,
+				value: isArmed
+			)
 	}
 
 	private var fillColor: Color {

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -29,6 +29,60 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(accountRows.contains("withAnimation"))
 	}
 
+	func testPanelMotionStaysLocalAndHonorsReduceMotion() throws {
+		let sourceURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
+		let panel = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountPanelView.swift"),
+			encoding: .utf8
+		)
+		let controls = try String(
+			contentsOf: sourceURL.appendingPathComponent("PanelControls.swift"),
+			encoding: .utf8
+		)
+		let accountControls = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountControlViews.swift"),
+			encoding: .utf8
+		)
+		let rows = try String(
+			contentsOf: sourceURL.appendingPathComponent("ResetCardSectionView.swift"),
+			encoding: .utf8
+		)
+		let login = try String(
+			contentsOf: sourceURL.appendingPathComponent(
+				"AccountReauthenticationView.swift"
+			),
+			encoding: .utf8
+		)
+		let motion = try String(
+			contentsOf: sourceURL.appendingPathComponent("PanelSupport.swift"),
+			encoding: .utf8
+		)
+		let combined = panel + controls + accountControls + rows + login
+
+		XCTAssertTrue(motion.contains("static let press"))
+		XCTAssertTrue(motion.contains("static let identity"))
+		XCTAssertTrue(controls.contains("PanelPressButtonStyle"))
+		XCTAssertTrue(
+			controls.contains(".contentTransition(.symbolEffect(.replace))")
+		)
+		XCTAssertTrue(rows.contains("value: identity.text"))
+		XCTAssertTrue(rows.contains("value: state.targets"))
+		XCTAssertTrue(rows.contains("value: confirmationSecondsRemaining"))
+		XCTAssertTrue(
+			login.contains("value: store.accountReauthentication?.phase")
+		)
+		XCTAssertTrue(
+			[panel, controls, rows, login].allSatisfy {
+				$0.contains("@Environment(\\.accessibilityReduceMotion)")
+			}
+		)
+		XCTAssertFalse(combined.contains("withAnimation"))
+	}
+
 	func testRepeatedAccountRowsUseIndependentCardSurfaces() throws {
 		let sourceURL = URL(fileURLWithPath: #filePath)
 			.deletingLastPathComponent()


### PR DESCRIPTION
## Summary
- animate privacy identity changes, header icons, route controls, Reset Card confirmation/removal, login phases, and account-card insertion locally
- keep periodic refreshes out of a global animation transaction and honor Reduce Motion throughout
- replace per-render Reset Card DateFormatter construction with stable 24-hour FormatStyle presentation

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app` (179 tests)
- `SCCACHE_DISABLE=1 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer apps/decodex-app/script/build_and_run.sh --verify`
- staged bundle signature verification and launch readback
