### PR TITLE
Polish and stabilize Reset Card status flow

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -77,15 +77,18 @@ Reset Card controls use a subtle neutral border that remains visible on each
 material card. The armed confirmation uses the existing warning accent without
 changing the control size. Reset Card use requires two clicks on the same
 descriptor. The first click arms a five-second confirmation. The second click
-writes one credential-negative pending handle, then sends one native daemon
-request with the same account revision, descriptor, and operation key. Restart
-recovery reads durable status and retains that key. It never selects another
-card or generates a replacement key for an unresolved request. While the
-request is unresolved, the panel shows one compact status row and checks the
-saved request automatically. It does not show a separate transient message or
-a manual Resume control for the same operation. Expiry times use compact
-bordered controls so their click action remains visible without adding a second
-card container.
+ends the confirmation countdown, shows one busy indicator, writes one
+credential-negative pending handle, and sends one native daemon request with
+the same account revision, descriptor, and operation key. Restart recovery
+reads durable status and retains that key. It never selects another card or
+generates a replacement key for an unresolved request. While the request is
+unresolved, the panel shows one compact status row and checks the saved request
+automatically. It does not keep a disabled confirmation countdown, show a
+separate transient message, or show a manual Resume control for the same
+operation. If an inventory read advances during a skeleton read, the app queues
+one newer skeleton read so the account row does not remain in its checking
+state. Expiry times use compact bordered controls so their click action remains
+visible without adding a second card container.
 
 The bounded recovery journal is
 `Application Support/Decodex/reset-card-pending-v1.json`. It uses an atomic

--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -80,9 +80,12 @@ descriptor. The first click arms a five-second confirmation. The second click
 writes one credential-negative pending handle, then sends one native daemon
 request with the same account revision, descriptor, and operation key. Restart
 recovery reads durable status and retains that key. It never selects another
-card or generates a replacement key for an unresolved request. Expiry times use
-compact bordered controls so their click action remains visible without adding
-a second card container.
+card or generates a replacement key for an unresolved request. While the
+request is unresolved, the panel shows one compact status row and checks the
+saved request automatically. It does not show a separate transient message or
+a manual Resume control for the same operation. Expiry times use compact
+bordered controls so their click action remains visible without adding a second
+card container.
 
 The bounded recovery journal is
 `Application Support/Decodex/reset-card-pending-v1.json`. It uses an atomic

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -293,7 +293,9 @@ struct AccountPanelView: View {
 							}
 						}
 
-						if store.pendingAttempts.isEmpty == false {
+						if store.pendingAttempts.isEmpty == false,
+							store.message?.tone != .error
+						{
 							ResetCardPendingAttemptsView(store: store)
 						}
 					}
@@ -307,7 +309,7 @@ struct AccountPanelView: View {
 				}
 			}
 		}
-		.accessibilityLabel("Decodex status and pending actions")
+		.accessibilityLabel("Decodex status and pending requests")
 	}
 
 	private var displayedIntrinsicMessage: ResetCardStoreMessage? {

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
@@ -346,11 +346,11 @@ enum ResetCardClientError: Error, Equatable, LocalizedError, Sendable, CustomDeb
 		case .commandRejected:
 			return "The reset-card request was rejected. Refresh and try again."
 		case .useDefinitelyNotDispatched:
-			return "The reset-card request was not dispatched. Resume the pending request with the same operation key."
+			return "The reset-card request was not dispatched."
 		case .usePotentiallyDispatched:
-			return "The reset-card request may have been dispatched. Resume the pending request to check authoritative state with the same operation key."
+			return "The reset-card request may have been dispatched."
 		case .commandFailed:
-			return "The reset-card service is unavailable. Start decodexd, then resume the pending request."
+			return "The reset-card service is unavailable. Start decodexd."
 		case .invalidResponse:
 			return "The Decodex service returned an invalid reset-card response."
 		case .service(let error):

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -15,9 +15,9 @@ struct ResetCardMessageView: View {
 			Text(message.text)
 				.font(PanelFont.tertiary)
 				.foregroundStyle(color)
+				.frame(maxWidth: .infinity, alignment: .leading)
 				.fixedSize(horizontal: false, vertical: true)
-
-			Spacer(minLength: 2)
+				.layoutPriority(1)
 
 			Button(action: dismiss) {
 				Image(systemName: "xmark")
@@ -25,7 +25,9 @@ struct ResetCardMessageView: View {
 			}
 			.buttonStyle(PanelPressButtonStyle(pressedScale: 0.9))
 			.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+			.fixedSize()
 			.help("Dismiss message")
+			.accessibilityLabel("Dismiss message")
 		}
 		.padding(.horizontal, PanelSpacing.cardHorizontal)
 		.padding(.vertical, PanelSpacing.cardVertical)
@@ -62,42 +64,58 @@ struct ResetCardPendingAttemptsView: View {
 	var body: some View {
 		VStack(alignment: .leading, spacing: PanelSpacing.related) {
 			ForEach(store.pendingAttempts, id: \.idempotencyKey) { attempt in
+				let accountLabel = store.accountLabel(for: attempt.target.accountID)
+				let status = store.pendingStatus(for: attempt)
+
 				HStack(spacing: PanelSpacing.related) {
 					Image(systemName: "clock.arrow.circlepath")
 						.font(PanelFont.tertiary)
 						.foregroundStyle(PanelPalette.warning(colorScheme))
 						.accessibilityHidden(true)
 
-					Text(
-						"\(store.accountLabel(for: attempt.target.accountID)) · pending …\(attempt.idempotencyKey.suffix(8))"
-					)
-					.font(PanelFont.tertiary)
-					.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-					.lineLimit(1)
-					.truncationMode(.middle)
+					Text(accountLabel)
+						.font(PanelFont.tertiary)
+						.foregroundStyle(PanelPalette.primaryText(colorScheme).opacity(0.88))
+						.lineLimit(1)
+						.truncationMode(.tail)
 
-					Spacer(minLength: 2)
+					Text("·")
+						.font(PanelFont.tertiary)
+						.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+						.fixedSize()
 
-					Button("Resume") {
-						Task {
-							await store.resume(attempt)
-						}
-					}
-					.buttonStyle(.borderless)
-					.controlSize(.mini)
-					.frame(minHeight: 24)
-					.disabled(store.submittingKey != nil)
-					.help(
-						store.isPendingRecoveryBlocked
-							? "Read durable status only. Repair the recovery journal before any retry."
-							: "Read durable status and use the same operation key if the command is absent."
-					)
+					Text(status.text)
+						.font(PanelFont.tertiary)
+						.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+						.lineLimit(1)
+						.fixedSize(horizontal: true, vertical: false)
+						.layoutPriority(1)
+
+					Spacer(minLength: 0)
 				}
+				.help(helpText(for: status, attempt: attempt))
+				.accessibilityElement(children: .ignore)
+				.accessibilityLabel("\(accountLabel). \(status.accessibilityText).")
+				.accessibilityHint(
+					"Saved operation ending in \(attempt.idempotencyKey.suffix(8)). Decodex checks automatically."
+				)
 			}
 		}
 		.padding(.horizontal, PanelSpacing.cardHorizontal)
 		.padding(.vertical, PanelSpacing.cardVertical)
 		.panelCardSurface(cornerRadius: 14)
+	}
+
+	private func helpText(
+		for status: ResetCardPendingStatus,
+		attempt: ResetCardUseAttempt
+	) -> String {
+		let automaticCheck = "Decodex checks this saved request automatically."
+		let operation = "Operation …\(attempt.idempotencyKey.suffix(8))."
+		guard let detail = status.detail else {
+			return "\(automaticCheck) \(operation)"
+		}
+		return "\(detail) \(automaticCheck) \(operation)"
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -401,7 +401,8 @@ struct ResetCardAccountRow: View {
 						}
 						.buttonStyle(
 							ResetCardChipButtonStyle(
-								isArmed: confirmation.isArmed(target)
+								isArmed: confirmation.isArmed(target),
+								isBusy: confirmation.isSubmitting(target)
 							)
 						)
 						.disabled(store.blocksNewAttempt(for: target))
@@ -434,13 +435,17 @@ struct ResetCardAccountRow: View {
 			Text("Confirm · \(Self.confirmationWindowSeconds)s")
 				.hidden()
 
-			Text(cardChipTitle(target))
-				.contentTransition(.opacity)
-				.foregroundStyle(
-					confirmation.isArmed(target)
-						? PanelPalette.warning(colorScheme)
-						: PanelPalette.secondaryText(colorScheme)
-				)
+			HStack(spacing: PanelSpacing.micro) {
+				if confirmation.isSubmitting(target) {
+					ProgressView()
+						.controlSize(.mini)
+						.accessibilityHidden(true)
+				}
+
+				Text(cardChipTitle(target))
+					.contentTransition(.opacity)
+			}
+			.foregroundStyle(cardChipForeground(target))
 		}
 		.font(PanelFont.resetCardAction)
 		.monospacedDigit()
@@ -481,6 +486,15 @@ struct ResetCardAccountRow: View {
 		Self.cardExpiryText(target.descriptor.expiresAtUnixSeconds)
 	}
 
+	private func cardChipForeground(_ target: ResetCardUseTarget) -> Color {
+		if confirmation.isSubmitting(target) {
+			return PanelPalette.actionBlue(colorScheme)
+		}
+		return confirmation.isArmed(target)
+			? PanelPalette.warning(colorScheme)
+			: PanelPalette.secondaryText(colorScheme)
+	}
+
 	private func accessibilityLabel(_ target: ResetCardUseTarget) -> String {
 		Self.cardAccessibilityLabel(
 			expiresAtUnixSeconds: target.descriptor.expiresAtUnixSeconds
@@ -517,6 +531,7 @@ struct ResetCardAccountRow: View {
 		guard let attempt = confirmation.tap(target) else {
 			return
 		}
+		confirmationSecondsRemaining = 0
 
 		Task {
 			let completion = await store.use(attempt)
@@ -628,6 +643,7 @@ struct ResetCardAccountRow: View {
 
 private struct ResetCardChipButtonStyle: ButtonStyle {
 	let isArmed: Bool
+	let isBusy: Bool
 	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.colorScheme) private var colorScheme
 	@Environment(\.isEnabled) private var isEnabled
@@ -645,7 +661,11 @@ private struct ResetCardChipButtonStyle: ButtonStyle {
 				shape.strokeBorder(borderColor, lineWidth: 1)
 			}
 			.contentShape(shape)
-			.opacity(isEnabled ? (configuration.isPressed ? 0.76 : 1) : 0.46)
+			.opacity(
+				isEnabled || isBusy
+					? (configuration.isPressed ? 0.76 : 1)
+					: 0.46
+			)
 			.scaleEffect(configuration.isPressed ? 0.985 : 1)
 			.animation(
 				reduceMotion ? nil : PanelMotion.press,
@@ -658,6 +678,10 @@ private struct ResetCardChipButtonStyle: ButtonStyle {
 	}
 
 	private var fillColor: Color {
+		if isBusy {
+			return PanelPalette.actionBlue(colorScheme)
+				.opacity(colorScheme == .dark ? 0.12 : 0.09)
+		}
 		if isArmed {
 			return PanelPalette.warning(colorScheme)
 				.opacity(colorScheme == .dark ? 0.12 : 0.09)
@@ -667,6 +691,10 @@ private struct ResetCardChipButtonStyle: ButtonStyle {
 	}
 
 	private var borderColor: Color {
+		if isBusy {
+			return PanelPalette.actionBlue(colorScheme)
+				.opacity(colorScheme == .dark ? 0.72 : 0.62)
+		}
 		if isArmed {
 			return PanelPalette.warning(colorScheme)
 				.opacity(colorScheme == .dark ? 0.72 : 0.62)

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -244,6 +244,7 @@ final class ResetCardStore {
 	@ObservationIgnored private var requestedProfileEmailVisibility = false
 	@ObservationIgnored private var profilePrivacyEpoch: UInt64 = 0
 	@ObservationIgnored private var codexProjectionRequestGeneration: UInt64 = 0
+	@ObservationIgnored private var accountSkeletonRefreshGeneration: UInt64 = 0
 
 	init(
 		client: any ResetCardClient = DecodexNativeClient(),
@@ -1582,9 +1583,13 @@ final class ResetCardStore {
 		else {
 			return
 		}
+		let refreshGeneration = accountSkeletonRefreshGeneration
 		isRefreshingAccountSkeleton = true
 		defer {
 			isRefreshingAccountSkeleton = false
+			if refreshGeneration != accountSkeletonRefreshGeneration {
+				scheduleFreshAccountSkeletonRead()
+			}
 		}
 		do {
 			let projectionGeneration = beginCodexProjectionRequest()
@@ -1725,18 +1730,19 @@ final class ResetCardStore {
 			isProfileRefreshing: existing.isProfileRefreshing
 		)
 
-		if let target = accountSkeletonRevisionTargets[accountID] {
-			accountSkeletonRevisionTargets[accountID] = max(target, inventoryRevision)
-			return
-		}
-		accountSkeletonRevisionTargets[accountID] = inventoryRevision
+		accountSkeletonRevisionTargets[accountID] = max(
+			accountSkeletonRevisionTargets[accountID] ?? 0,
+			inventoryRevision
+		)
 		scheduleFreshAccountSkeletonRead()
 	}
 
 	private func scheduleFreshAccountSkeletonRead() {
-		guard accountSkeletonRevisionTargets.isEmpty == false,
-			isAccountControlInProgress == false
-		else {
+		guard accountSkeletonRevisionTargets.isEmpty == false else {
+			return
+		}
+		accountSkeletonRefreshGeneration &+= 1
+		guard isAccountControlInProgress == false else {
 			return
 		}
 		Task { [weak self] in

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -128,6 +128,38 @@ struct ResetCardStoreMessage: Equatable {
 	let text: String
 }
 
+enum ResetCardPendingStatus: Equatable {
+	case checking(detail: String?)
+	case retrying(detail: String)
+
+	var text: String {
+		switch self {
+		case .checking:
+			return "Checking reset result…"
+		case .retrying:
+			return "Check delayed; retrying…"
+		}
+	}
+
+	var accessibilityText: String {
+		switch self {
+		case .checking:
+			return "Checking reset result"
+		case .retrying:
+			return "Reset result check delayed; retrying"
+		}
+	}
+
+	var detail: String? {
+		switch self {
+		case .checking(let detail):
+			return detail
+		case .retrying(let detail):
+			return detail
+		}
+	}
+}
+
 enum AccountControlActivity: Equatable {
 	case lifecycle
 	case loginRefresh
@@ -187,6 +219,7 @@ final class ResetCardStore {
 	private(set) var isRoutingAccountControl = false
 	private(set) var accountSkeletonRevisionTargets = [String: UInt64]()
 	private(set) var pendingAttempts: [ResetCardUseAttempt]
+	private(set) var pendingStatuses: [String: ResetCardPendingStatus]
 	private(set) var isPendingRecoveryBlocked: Bool
 	private(set) var profileEmailsVisible = false
 	private(set) var accountReauthentication: AccountReauthenticationPresentation?
@@ -232,6 +265,11 @@ final class ResetCardStore {
 		self.resolveCodexExecutable = resolveCodexExecutable
 		let pendingLoad = pendingStore.load()
 		pendingAttempts = pendingLoad.attempts
+		pendingStatuses = Dictionary(
+			uniqueKeysWithValues: pendingLoad.attempts.map {
+				($0.idempotencyKey, ResetCardPendingStatus.checking(detail: nil))
+			}
+		)
 		isPendingRecoveryBlocked = pendingLoad.isRecoveryBlocked
 		if isPendingRecoveryBlocked {
 			message = Self.pendingRecoveryBlockedMessage
@@ -270,6 +308,10 @@ final class ResetCardStore {
 				$0.target.accountID == target.accountID
 					&& $0.target.descriptor == target.descriptor
 			})
+	}
+
+	func pendingStatus(for attempt: ResetCardUseAttempt) -> ResetCardPendingStatus {
+		pendingStatuses[attempt.idempotencyKey] ?? .checking(detail: nil)
 	}
 
 	func start() {
@@ -744,14 +786,16 @@ final class ResetCardStore {
 			)
 			return ResetCardUseCompletion(resolved: true)
 		}
-		guard pendingAttempts.contains(where: {
+		if let pendingAttempt = pendingAttempts.first(where: {
 			$0.target.accountID == attempt.target.accountID
 				&& $0.target.descriptor == attempt.target.descriptor
-		}) == false
-		else {
-			message = ResetCardStoreMessage(
-				tone: .information,
-				text: "Resume the pending request for this reset card with its existing operation key."
+		}) {
+			clearStaleControlError()
+			setPendingStatus(
+				.checking(
+					detail: "This saved Reset Card request is already being checked automatically."
+				),
+				for: pendingAttempt
 			)
 			return ResetCardUseCompletion(resolved: true)
 		}
@@ -767,7 +811,7 @@ final class ResetCardStore {
 		return await submit(attempt)
 	}
 
-	func resume(_ attempt: ResetCardUseAttempt) async {
+	func checkPendingStatus(_ attempt: ResetCardUseAttempt) async {
 		guard submittingKey == nil,
 			pendingAttempts.contains(attempt)
 		else {
@@ -775,6 +819,7 @@ final class ResetCardStore {
 		}
 
 		clearStaleControlError()
+		setPendingStatus(.checking(detail: nil), for: attempt)
 		submittingKey = attempt.idempotencyKey
 		defer {
 			submittingKey = nil
@@ -808,9 +853,14 @@ final class ResetCardStore {
 			shouldRemove: \.removesPendingAttempt
 		) else {
 			reloadPendingJournal()
-			message = isPendingRecoveryBlocked
-				? Self.pendingRecoveryBlockedMessage
-				: Self.pendingDispatchUnavailableMessage
+			if isPendingRecoveryBlocked {
+				message = Self.pendingRecoveryBlockedMessage
+			} else {
+				setPendingStatus(
+					.retrying(detail: Self.pendingDispatchUnavailableDetail),
+					for: attempt
+				)
+			}
 			return
 		}
 		_ = await apply(dispatch, to: attempt)
@@ -1218,6 +1268,8 @@ final class ResetCardStore {
 	}
 
 	private func submit(_ attempt: ResetCardUseAttempt) async -> ResetCardUseCompletion {
+		message = nil
+		setPendingStatus(.checking(detail: nil), for: attempt)
 		submittingKey = attempt.idempotencyKey
 		defer {
 			submittingKey = nil
@@ -1237,9 +1289,14 @@ final class ResetCardStore {
 			shouldRemove: \.removesPendingAttempt
 		) else {
 			reloadPendingJournal()
-			message = isPendingRecoveryBlocked
-				? Self.pendingRecoveryBlockedMessage
-				: Self.pendingDispatchUnavailableMessage
+			if isPendingRecoveryBlocked {
+				message = Self.pendingRecoveryBlockedMessage
+			} else {
+				setPendingStatus(
+					.retrying(detail: Self.pendingDispatchUnavailableDetail),
+					for: attempt
+				)
+			}
 			return ResetCardUseCompletion(resolved: false)
 		}
 
@@ -1277,13 +1334,12 @@ final class ResetCardStore {
 		to attempt: ResetCardUseAttempt,
 		removeTerminalAttempt: Bool = true
 	) async -> ResetCardUseCompletion {
-		message = ResetCardStoreMessage(
-			tone: .error,
-			text: error.localizedDescription
-		)
-
 		switch error {
 		case .commandRejected:
+			message = ResetCardStoreMessage(
+				tone: .error,
+				text: error.localizedDescription
+			)
 			if removeTerminalAttempt {
 				forget(attempt)
 			}
@@ -1293,6 +1349,10 @@ final class ResetCardStore {
 			.useDefinitelyNotDispatched, .usePotentiallyDispatched,
 			.commandFailed, .invalidResponse, .service:
 			reloadPendingJournal()
+			setPendingStatus(
+				.retrying(detail: error.localizedDescription),
+				for: attempt
+			)
 			return ResetCardUseCompletion(resolved: false)
 		}
 	}
@@ -1302,13 +1362,12 @@ final class ResetCardStore {
 		to attempt: ResetCardUseAttempt,
 		removeTerminalAttempt: Bool = true
 	) async -> ResetCardUseCompletion {
-		message = ResetCardStoreMessage(
-			tone: Self.messageTone(for: state),
-			text: state.presentation
-		)
-
 		switch state {
 		case .completed, .failedBeforeEffect:
+			message = ResetCardStoreMessage(
+				tone: Self.messageTone(for: state),
+				text: state.presentation
+			)
 			if removeTerminalAttempt {
 				forget(attempt)
 			}
@@ -1316,6 +1375,7 @@ final class ResetCardStore {
 			return ResetCardUseCompletion(resolved: true)
 		case .prepared, .effectAmbiguous, .notFound, .unavailable:
 			reloadPendingJournal()
+			setPendingStatus(Self.pendingStatus(for: state), for: attempt)
 			return ResetCardUseCompletion(resolved: false)
 		}
 	}
@@ -1338,29 +1398,21 @@ final class ResetCardStore {
 					_ = await apply(state, to: attempt)
 				case .prepared, .effectAmbiguous:
 					shouldRetry = true
-					message = ResetCardStoreMessage(
-						tone: Self.messageTone(for: state),
-						text: state.presentation
-					)
+					_ = await apply(state, to: attempt)
 				case .unavailable(let error):
 					shouldRetry = shouldRetry || error.isRetryableReadFailure
-					message = ResetCardStoreMessage(
-						tone: Self.messageTone(for: state),
-						text: state.presentation
-					)
+					_ = await apply(state, to: attempt)
 				case .notFound:
 					shouldRetry = true
-					message = ResetCardStoreMessage(
-						tone: .information,
-						text: "A pending reset-card request can be resumed with the same operation key."
-					)
+					_ = await apply(state, to: attempt)
 				}
 			} catch {
 				let clientError = Self.clientError(error)
 				shouldRetry = shouldRetry || clientError.isRetryableReadFailure
-				message = ResetCardStoreMessage(
-					tone: .error,
-					text: clientError.localizedDescription
+				reloadPendingJournal()
+				setPendingStatus(
+					.retrying(detail: clientError.localizedDescription),
+					for: attempt
 				)
 			}
 		}
@@ -1380,6 +1432,7 @@ final class ResetCardStore {
 			return false
 		}
 		pendingAttempts = updated
+		reconcilePendingStatuses()
 		return true
 	}
 
@@ -1389,6 +1442,7 @@ final class ResetCardStore {
 		}
 		if let updated = pendingStore.remove(attempt) {
 			pendingAttempts = updated
+			reconcilePendingStatuses()
 		}
 	}
 
@@ -1396,6 +1450,27 @@ final class ResetCardStore {
 		let load = pendingStore.load()
 		pendingAttempts = load.attempts
 		isPendingRecoveryBlocked = load.isRecoveryBlocked
+		reconcilePendingStatuses()
+	}
+
+	private func setPendingStatus(
+		_ status: ResetCardPendingStatus,
+		for attempt: ResetCardUseAttempt
+	) {
+		guard pendingAttempts.contains(attempt) else {
+			pendingStatuses.removeValue(forKey: attempt.idempotencyKey)
+			return
+		}
+		pendingStatuses[attempt.idempotencyKey] = status
+	}
+
+	private func reconcilePendingStatuses() {
+		let pendingKeys = Set(pendingAttempts.map(\.idempotencyKey))
+		pendingStatuses = pendingStatuses.filter { pendingKeys.contains($0.key) }
+		for attempt in pendingAttempts
+		where pendingStatuses[attempt.idempotencyKey] == nil {
+			pendingStatuses[attempt.idempotencyKey] = .checking(detail: nil)
+		}
 	}
 
 	private func refreshAccount(_ accountID: String) async {
@@ -2600,19 +2675,38 @@ final class ResetCardStore {
 		}
 	}
 
+	private static func pendingStatus(
+		for state: ResetCardOperationState
+	) -> ResetCardPendingStatus {
+		switch state {
+		case .prepared:
+			return .checking(detail: "The service accepted this Reset Card request.")
+		case .effectAmbiguous:
+			return .checking(
+				detail: "The service is reconciling authoritative Reset Card state."
+			)
+		case .notFound:
+			return .checking(
+				detail: "No durable Reset Card operation was found yet."
+			)
+		case .unavailable(let error):
+			return .retrying(detail: error.presentation)
+		case .completed, .failedBeforeEffect:
+			return .checking(detail: nil)
+		}
+	}
+
 	private static let pendingRecoveryBlockedMessage = ResetCardStoreMessage(
 		tone: .error,
 		text: "The pending reset-card recovery journal is invalid or unavailable. New use is blocked. Preserve the journal for manual inspection; no automatic repair is available."
 	)
 
-	private static let pendingDispatchUnavailableMessage = ResetCardStoreMessage(
-		tone: .information,
-		text: "Another app instance changed or is using this pending reset-card request. Refresh before continuing."
-	)
+	private static let pendingDispatchUnavailableDetail =
+		"Another app instance changed or is checking this saved Reset Card request."
 
 	private static let pendingTerminalRemovalFailedMessage = ResetCardStoreMessage(
 		tone: .error,
-		text: "The reset-card operation is terminal, but the recovery journal could not be updated. Preserve the journal and resume this request before starting another."
+		text: "The Reset Card operation finished, but the recovery journal could not be updated. Preserve the journal and refresh before starting another request."
 	)
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardUse.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardUse.swift
@@ -76,16 +76,14 @@ struct ResetCardUseConfirmation: Equatable {
 
 	mutating func finish(
 		_ attempt: ResetCardUseAttempt,
-		completion: ResetCardUseCompletion
+		completion _: ResetCardUseCompletion
 	) {
 		guard armedAttempt == attempt else {
 			return
 		}
 
 		isSubmitting = false
-		if completion.resolved {
-			armedAttempt = nil
-		}
+		armedAttempt = nil
 	}
 
 	@discardableResult

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -247,6 +247,100 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(store.accounts.first?.inventory?.accountRevision, 8)
 	}
 
+	func testAdvancedInventoryQueuesAnotherSkeletonReadWhenOneIsInFlight() async throws {
+		let secondAccountID = "22222222-2222-4222-8222-222222222222"
+		let firstAccount = accountRecord()
+		let secondAccount = accountRecord(
+			accountID: secondAccountID,
+			alias: "Account 00000-00002"
+		)
+		let client = AccountControlStoreClient(
+			account: firstAccount,
+			secondaryAccount: secondAccount,
+			authority: authority,
+			suspendsSnapshotAfterFirstRead: true,
+			capturesSnapshotBeforeWait: true
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let attempt = ResetCardUseAttempt(
+			target: ResetCardUseTarget(
+				authority: authority,
+				accountID: secondAccountID,
+				expectedRevision: 7,
+				descriptor: try ResetCardDescriptor(
+					grantedAtUnixSeconds: 100,
+					expiresAtUnixSeconds: 200
+				)
+			),
+			idempotencyKey: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+		)
+		XCTAssertEqual(fixture.store.insert(attempt), [attempt])
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		await store.refresh()
+		await store.logoutAccount(accountID)
+		for _ in 0 ..< 200 {
+			if await client.snapshotIsPending() {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+		guard await client.snapshotIsPending() else {
+			await client.releaseSnapshot()
+			return XCTFail("Skeleton reconciliation did not enter the pending state.")
+		}
+
+		await client.replaceSecondaryAccount(
+			accountRecord(
+				accountID: secondAccountID,
+				alias: "Account 00000-00002",
+				revision: 8
+			)
+		)
+		await client.setInventoryRevision(8, accountID: secondAccountID)
+		await client.setResetCardStatus(.completed(.reset))
+		await store.checkPendingStatus(attempt)
+		await Task.yield()
+
+		XCTAssertTrue(store.isAwaitingFreshAccountSkeleton(secondAccountID))
+		XCTAssertTrue(
+			store.accounts.first(where: {
+				$0.account.accountID == secondAccountID
+			})?.isRefreshing == true
+		)
+
+		await client.releaseSnapshot()
+		for _ in 0 ..< 200 {
+			let state = store.accounts.first(where: {
+				$0.account.accountID == secondAccountID
+			})
+			if state?.account.accountRevision == 8,
+				state?.inventory?.accountRevision == 8,
+				store.isAwaitingFreshAccountSkeleton(secondAccountID) == false
+			{
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+
+		let finalState = try XCTUnwrap(
+			store.accounts.first(where: {
+				$0.account.accountID == secondAccountID
+			})
+		)
+		XCTAssertEqual(finalState.account.accountRevision, 8)
+		XCTAssertEqual(finalState.inventory?.accountRevision, 8)
+		XCTAssertFalse(finalState.isRefreshing)
+		XCTAssertFalse(store.isAwaitingFreshAccountSkeleton(secondAccountID))
+		let reads = await client.readCounts()
+		XCTAssertGreaterThanOrEqual(reads.snapshot, 3)
+	}
+
 	func testRoutingCompletesWhileDetailReadIsPendingWithoutFullRefresh() async throws {
 		let account = accountRecord()
 		let client = AccountControlStoreClient(
@@ -992,12 +1086,15 @@ private struct AccountControlStoreCounts: Equatable, Sendable {
 
 private actor AccountControlStoreClient: AccountControlClient {
 	private var account: ResetCardAccountRecord
-	private let secondaryAccount: ResetCardAccountRecord?
+	private var secondaryAccount: ResetCardAccountRecord?
 	private let authority: ResetCardAuthority
 	private let inventoryGate: AccountControlReadGate?
 	private let snapshotGate: AccountControlReadGate?
+	private let capturesSnapshotBeforeWait: Bool
 	private let fixedSelectionGate: AccountControlReadGate?
 	private let inventoryRevisionOverride: UInt64?
+	private var inventoryRevisionsByAccountID = [String: UInt64]()
+	private var resetCardStatus: ResetCardOperationState = .notFound
 	private let allowsEnrollment: Bool
 	private var routing: AccountRoutingControl
 	private var fixedSelectionError: AccountControlError?
@@ -1029,6 +1126,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 		authority: ResetCardAuthority,
 		suspendsInventory: Bool = false,
 		suspendsSnapshotAfterFirstRead: Bool = false,
+		capturesSnapshotBeforeWait: Bool = false,
 		suspendsFixedSelection: Bool = false,
 		inventoryRevisionOverride: UInt64? = nil,
 		allowsEnrollment: Bool = false,
@@ -1045,6 +1143,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 		self.projection = projection
 		inventoryGate = suspendsInventory ? AccountControlReadGate() : nil
 		snapshotGate = suspendsSnapshotAfterFirstRead ? AccountControlReadGate() : nil
+		self.capturesSnapshotBeforeWait = capturesSnapshotBeforeWait
 		fixedSelectionGate = suspendsFixedSelection ? AccountControlReadGate() : nil
 		self.inventoryRevisionOverride = inventoryRevisionOverride
 		self.allowsEnrollment = allowsEnrollment
@@ -1068,12 +1167,15 @@ private actor AccountControlStoreClient: AccountControlClient {
 			throw ResetCardClientError.invalidResponse
 		}
 		snapshotReadCount += 1
+		let capturedAccounts = [account] + (secondaryAccount.map { [$0] } ?? [])
 		if snapshotReadCount > 1, let snapshotGate {
 			await snapshotGate.wait()
 		}
 		return AccountControlSnapshot(
 			authority: authority,
-			accounts: [account] + (secondaryAccount.map { [$0] } ?? []),
+			accounts: capturesSnapshotBeforeWait
+				? capturedAccounts
+				: [account] + (secondaryAccount.map { [$0] } ?? []),
 			routing: routing
 		)
 	}
@@ -1107,7 +1209,9 @@ private actor AccountControlStoreClient: AccountControlClient {
 		return ResetCardInventory(
 			authority: authority,
 			accountID: account.accountID,
-			accountRevision: inventoryRevisionOverride ?? account.accountRevision,
+			accountRevision: inventoryRevisionsByAccountID[account.accountID]
+				?? inventoryRevisionOverride
+				?? account.accountRevision,
 			cards: [],
 			fiveHourQuota: account.fiveHourQuota,
 			sevenDayQuota: account.sevenDayQuota,
@@ -1120,7 +1224,15 @@ private actor AccountControlStoreClient: AccountControlClient {
 	}
 
 	func status(for attempt: ResetCardUseAttempt) async throws -> ResetCardOperationState {
-		.notFound
+		resetCardStatus
+	}
+
+	func setResetCardStatus(_ status: ResetCardOperationState) {
+		resetCardStatus = status
+	}
+
+	func setInventoryRevision(_ revision: UInt64, accountID: String) {
+		inventoryRevisionsByAccountID[accountID] = revision
 	}
 
 	func setFixedSelection(
@@ -1211,6 +1323,10 @@ private actor AccountControlStoreClient: AccountControlClient {
 
 	func replaceAccount(_ account: ResetCardAccountRecord) {
 		self.account = account
+	}
+
+	func replaceSecondaryAccount(_ account: ResetCardAccountRecord) {
+		secondaryAccount = account
 	}
 
 	func enrollFromSharedCodex(

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -177,6 +177,38 @@ final class AccountPanelPresentationTests: XCTestCase {
 		)
 	}
 
+	func testPendingStatusRowStaysCompactAtPanelWidth() throws {
+		let directory = FileManager.default.temporaryDirectory
+			.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		defer { try? FileManager.default.removeItem(at: directory) }
+		try FileManager.default.createDirectory(
+			at: directory,
+			withIntermediateDirectories: true
+		)
+		try FileManager.default.setAttributes(
+			[.posixPermissions: 0o700],
+			ofItemAtPath: directory.path
+		)
+		let pendingStore = ResetCardPendingAttemptStore(
+			journalURL: directory.appendingPathComponent("pending.json")
+		)
+		let attempt = try pendingAttempt(1)
+		XCTAssertEqual(pendingStore.insert(attempt), [attempt])
+		let store = ResetCardStore(
+			client: AccountPanelLayoutClient(),
+			pendingStore: pendingStore,
+			startupRetryDelays: []
+		)
+		let hostingView = NSHostingView(
+			rootView: ResetCardPendingAttemptsView(store: store)
+				.frame(width: 276)
+		)
+
+		hostingView.layoutSubtreeIfNeeded()
+
+		XCTAssertLessThanOrEqual(hostingView.fittingSize.height, 44)
+	}
+
 	func testUnavailableProfileUnauthorizedPresentsLoginRecoveryWithoutHidingCanonicalInventory()
 		throws
 	{
@@ -448,7 +480,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 		XCTAssertLessThanOrEqual(hostingView.fittingSize.height, 1_350)
 	}
 
-	func testPendingActionsUseTheirOwnBoundedScrollWithoutHidingAccounts() async throws {
+	func testPendingRequestsUseTheirOwnBoundedScrollWithoutHidingAccounts() async throws {
 		let directory = FileManager.default.temporaryDirectory
 			.appendingPathComponent(UUID().uuidString, isDirectory: true)
 		defer { try? FileManager.default.removeItem(at: directory) }

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -2,6 +2,34 @@ import Foundation
 import XCTest
 
 final class ResetCardArchitectureTests: XCTestCase {
+	func testPendingResetCardUsesOneAutomaticStatusRow() throws {
+		let sourceURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
+		let rows = try String(
+			contentsOf: sourceURL.appendingPathComponent("ResetCardSectionView.swift"),
+			encoding: .utf8
+		)
+		let store = try String(
+			contentsOf: sourceURL.appendingPathComponent("ResetCardStore.swift"),
+			encoding: .utf8
+		)
+
+		XCTAssertTrue(rows.contains("Text(status.text)"))
+		XCTAssertTrue(
+			rows.contains("Decodex checks this saved request automatically.")
+		)
+		XCTAssertTrue(
+			rows.contains(".frame(maxWidth: .infinity, alignment: .leading)")
+		)
+		XCTAssertTrue(store.contains("Checking reset result…"))
+		XCTAssertTrue(store.contains("Check delayed; retrying…"))
+		XCTAssertFalse(rows.contains("Button(\"Resume\")"))
+		XCTAssertFalse(store.contains("Resume the pending request"))
+	}
+
 	func testQuotaMotionTracksOnlyTheAuthoritativeRemainingValue() throws {
 		let sourceURL = URL(fileURLWithPath: #filePath)
 			.deletingLastPathComponent()

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreRecoveryTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreRecoveryTests.swift
@@ -35,11 +35,11 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 		await store.refresh()
 
 		XCTAssertEqual(store.pendingAttempts, [fixture.attempt])
+		XCTAssertNil(store.message)
 		XCTAssertEqual(
-			store.message,
-			ResetCardStoreMessage(
-				tone: .information,
-				text: "Reset-card use is reconciling authoritative state."
+			store.pendingStatus(for: fixture.attempt),
+			ResetCardPendingStatus.checking(
+				detail: "The service is reconciling authoritative Reset Card state."
 			)
 		)
 		XCTAssertEqual(fixture.pendingStore.load(), .available([fixture.attempt]))
@@ -60,11 +60,11 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 
 		XCTAssertEqual(store.pendingAttempts, [fixture.attempt])
 		XCTAssertEqual(fixture.pendingStore.load(), .available([fixture.attempt]))
+		XCTAssertNil(store.message)
 		XCTAssertEqual(
-			store.message,
-			ResetCardStoreMessage(
-				tone: .information,
-				text: "Authoritative reset-card status is unavailable. Authoritative reset-card state is unavailable."
+			store.pendingStatus(for: fixture.attempt),
+			ResetCardPendingStatus.retrying(
+				detail: "Authoritative reset-card state is unavailable."
 			)
 		)
 	}
@@ -88,16 +88,16 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 		XCTAssertEqual(completion, ResetCardUseCompletion(resolved: false))
 		XCTAssertEqual(store.pendingAttempts, [fixture.attempt])
 		XCTAssertEqual(fixture.pendingStore.load(), .available([fixture.attempt]))
+		XCTAssertNil(store.message)
 		XCTAssertEqual(
-			store.message,
-			ResetCardStoreMessage(
-				tone: .error,
-				text: "The reset-card request was not dispatched. Resume the pending request with the same operation key."
+			store.pendingStatus(for: fixture.attempt),
+			ResetCardPendingStatus.retrying(
+				detail: "The reset-card request was not dispatched."
 			)
 		)
 	}
 
-	func testPotentiallyDispatchedResumeChecksStatusWithoutRedispatch() async throws {
+	func testPotentiallyDispatchedStatusCheckDoesNotRedispatch() async throws {
 		let fixture = try makeSubmissionFixture(
 			useDocument: """
 			{"schema":"decodex/reset-card-cli/1","command":"use","outcome":"failure","idempotency_key":"018f0f9e-7b6e-4a31-8f4c-1d2e3f405161","dispatch_state":"potentially_dispatched","failure":"protocol_timeout"}
@@ -112,15 +112,15 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 		await store.refresh()
 		_ = await store.use(fixture.attempt)
 
-		await store.resume(fixture.attempt)
+		await store.checkPendingStatus(fixture.attempt)
 
 		XCTAssertEqual(store.pendingAttempts, [fixture.attempt])
 		XCTAssertEqual(fixture.pendingStore.load(), .available([fixture.attempt]))
+		XCTAssertNil(store.message)
 		XCTAssertEqual(
-			store.message,
-			ResetCardStoreMessage(
-				tone: .information,
-				text: "No durable reset-card operation was found."
+			store.pendingStatus(for: fixture.attempt),
+			ResetCardPendingStatus.checking(
+				detail: "No durable Reset Card operation was found yet."
 			)
 		)
 		let invocations = try fixture.invocations()
@@ -199,11 +199,11 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 			try fixture.invocations().filter { $0.contains("reset-card use") },
 			[]
 		)
+		XCTAssertNil(store.message)
 		XCTAssertEqual(
-			store.message,
-			ResetCardStoreMessage(
-				tone: .information,
-				text: "Resume the pending request for this reset card with its existing operation key."
+			store.pendingStatus(for: fixture.attempt),
+			ResetCardPendingStatus.checking(
+				detail: "This saved Reset Card request is already being checked automatically."
 			)
 		)
 	}
@@ -320,7 +320,7 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 		)
 
 		await store.refresh()
-		await store.resume(fixture.attempt)
+		await store.checkPendingStatus(fixture.attempt)
 
 		XCTAssertTrue(store.isPendingRecoveryBlocked)
 		XCTAssertEqual(store.pendingAttempts, [fixture.attempt])
@@ -337,7 +337,7 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 		)
 	}
 
-	func testPendingResumeKeepsItsPinnedAuthorityAfterActiveProfileChanges() async throws {
+	func testPendingStatusCheckKeepsItsPinnedAuthorityAfterActiveProfileChanges() async throws {
 		let fixture = try makeSubmissionFixture(
 			useDocument: """
 			{"schema":"decodex/reset-card-cli/1","command":"use","outcome":"accepted","idempotency_key":"018f0f9e-7b6e-4a31-8f4c-1d2e3f405161","dispatch_state":"durably_accepted","account_id":"018f0f9e-7b6e-4a31-8f4c-1d2e3f405160","descriptor":{"granted_at_unix_seconds":100,"expires_at_unix_seconds":200},"account_revision":7,"state":{"state":"prepared","data":{"account_id":"018f0f9e-7b6e-4a31-8f4c-1d2e3f405160","account_revision":7,"descriptor":{"granted_at_unix_seconds":100,"expires_at_unix_seconds":200}}}}
@@ -354,7 +354,7 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 		)
 
 		await store.refresh()
-		await store.resume(fixture.attempt)
+		await store.checkPendingStatus(fixture.attempt)
 
 		let invocations = try fixture.invocations()
 		let statusInvocations = invocations.filter { $0.contains("reset-card status") }
@@ -372,7 +372,7 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 		)
 	}
 
-	func testStaleInstanceCannotResumeAfterAnotherInstanceRemovesTheKey() async throws {
+	func testStaleInstanceCannotCheckAfterAnotherInstanceRemovesTheKey() async throws {
 		let fixture = try makeSubmissionFixture(
 			useDocument: """
 			{"schema":"decodex/reset-card-cli/1","command":"use","outcome":"failure","idempotency_key":"018f0f9e-7b6e-4a31-8f4c-1d2e3f405161","dispatch_state":"potentially_dispatched","failure":"protocol_timeout"}
@@ -388,7 +388,7 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 		await staleStore.refresh()
 		XCTAssertEqual(fixture.pendingStore.remove(fixture.attempt), [])
 
-		await staleStore.resume(fixture.attempt)
+		await staleStore.checkPendingStatus(fixture.attempt)
 
 		XCTAssertEqual(staleStore.pendingAttempts, [])
 		let invocations = try fixture.invocations()
@@ -400,13 +400,8 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 			invocations.filter { $0.contains("reset-card status") }.count,
 			1
 		)
-		XCTAssertEqual(
-			staleStore.message,
-			ResetCardStoreMessage(
-				tone: .information,
-				text: "Another app instance changed or is using this pending reset-card request. Refresh before continuing."
-			)
-		)
+		XCTAssertNil(staleStore.message)
+		XCTAssertEqual(staleStore.pendingStatuses, [:])
 	}
 
 	func testConcurrentStatusCompletionRemovesTheKeyWithoutRedispatch() async throws {
@@ -420,7 +415,7 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 			client: fixture.client,
 			pendingStore: fixture.pendingStore
 		)
-		let resumingStore = ResetCardStore(
+		let checkingStore = ResetCardStore(
 			client: fixture.client,
 			pendingStore: ResetCardPendingAttemptStore(
 				journalURL: fixture.journalURL
@@ -428,19 +423,19 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 		)
 
 		let completion = Task {
-			await completingStore.resume(fixture.attempt)
+			await completingStore.checkPendingStatus(fixture.attempt)
 		}
 		try await waitForFile(fixture.statusEnteredURL)
 
-		let concurrentResume = Task {
-			await resumingStore.resume(fixture.attempt)
+		let concurrentCheck = Task {
+			await checkingStore.checkPendingStatus(fixture.attempt)
 		}
-		await concurrentResume.value
+		await concurrentCheck.value
+		XCTAssertNil(checkingStore.message)
 		XCTAssertEqual(
-			resumingStore.message,
-			ResetCardStoreMessage(
-				tone: .information,
-				text: "Another app instance changed or is using this pending reset-card request. Refresh before continuing."
+			checkingStore.pendingStatus(for: fixture.attempt),
+			ResetCardPendingStatus.retrying(
+				detail: "Another app instance changed or is checking this saved Reset Card request."
 			)
 		)
 
@@ -457,9 +452,9 @@ final class ResetCardStoreRecoveryTests: XCTestCase {
 			)
 		)
 
-		await resumingStore.resume(fixture.attempt)
+		await checkingStore.checkPendingStatus(fixture.attempt)
 
-		XCTAssertEqual(resumingStore.pendingAttempts, [])
+		XCTAssertEqual(checkingStore.pendingAttempts, [])
 		let invocations = try fixture.invocations()
 		XCTAssertEqual(
 			invocations.filter { $0.contains("reset-card status") }.count,

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardUseConfirmationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardUseConfirmationTests.swift
@@ -22,22 +22,21 @@ final class ResetCardUseConfirmationTests: XCTestCase {
 		XCTAssertTrue(confirmation.isSubmitting(target))
 	}
 
-	func testUnresolvedAttemptRetainsTheOriginalPublicTargetAndKey() throws {
+	func testSubmittedAttemptDisarmsWhileDurableStatusRemainsPending() throws {
 		let target = try makeTarget(expiresAt: 200)
 		var confirmation = ResetCardUseConfirmation()
 		XCTAssertNil(
 			confirmation.tap(target, makeIdempotencyKey: { "attempt-1" })
 		)
-		let firstAttempt = try XCTUnwrap(confirmation.tap(target))
+		let attempt = try XCTUnwrap(confirmation.tap(target))
 
 		confirmation.finish(
-			firstAttempt,
+			attempt,
 			completion: ResetCardUseCompletion(resolved: false)
 		)
-		let retry = try XCTUnwrap(confirmation.tap(target))
 
-		XCTAssertEqual(retry.target, target)
-		XCTAssertEqual(retry.idempotencyKey, "attempt-1")
+		XCTAssertFalse(confirmation.isArmed(target))
+		XCTAssertFalse(confirmation.isSubmitting)
 	}
 
 	func testResolvedAttemptDisarmsTheCard() throws {

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -216,10 +216,10 @@ decodex-publisher validate-social
   supervised service becomes ready. Row-scoped profile or Reset Card failures remain
   local until explicit refresh. It does not retry consume, replace an idempotency key,
   or take service lifecycle ownership.
-- Shows a `Resume` action for retained attempts. Resume checks durable status first and,
-  only when the daemon reports `not_found`, may invoke `use` again with the same profile,
-  server UUID, selection, and idempotency key. It never substitutes a new key for that
-  pending card.
+- Shows one compact status row for each retained attempt and checks durable status
+  automatically. A nonterminal state or temporary read failure updates that row. A
+  terminal result removes the row and shows the result message. The UI does not
+  redispatch `use` or substitute a new key for that pending card.
 
 The reset-card path is not the scheduler, project registry owner, credential owner,
 app-server process owner, or runtime authority. Its bounded private journal retains at

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -201,10 +201,13 @@ decodex-publisher validate-social
   provider request does not hide the other accounts. A provider-unsupported quota
   duration stays a muted row-local fact and does not mark the account as failed.
 - Uses Reset Cards from the common daemon service. The first click starts a
-  five-second local confirmation. The second click first persists a pending attempt,
-  then submits one in-process Rust request with a vNext account UUID, exact revision,
-  public grant/expiry descriptor, and one idempotency key. `decodexd` owns credentials,
-  app-server, the opaque credit ID, the provider effect, and durable recovery.
+  five-second local confirmation. The second click ends the countdown, shows a busy
+  indicator, persists a pending attempt, and submits one in-process Rust request with
+  a vNext account UUID, exact revision, public grant/expiry descriptor, and one
+  idempotency key. `decodexd` owns credentials, app-server, the opaque credit ID, the
+  provider effect, and durable recovery. If inventory advances during a skeleton
+  read, the app queues one newer skeleton read instead of leaving the row in a
+  checking state.
 - Uses an in-process Rust protocol client for active vNext account, profile, Reset Card,
   routing, Codex projection, and Fast requests. The app does not start the CLI, a
   service, or a credential helper, and Swift does not inject credentials. Operators


### PR DESCRIPTION
## Summary
- consolidate unresolved Reset Card work into one automatic status row
- remove the manual Resume control and duplicate nonterminal message
- end the Confirm countdown immediately after submission and show a clear busy state
- queue a newer account-skeleton read when Reset Card inventory advances during an in-flight reconciliation
- give message text the remaining card width before wrapping

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app` (182 passed)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build --package-path apps/decodex-app -c release`
- deterministic overlapping-skeleton regression test
- 276pt pending-status layout test