### PR TITLE
Smooth Reset Card quota reconciliation

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -87,8 +87,15 @@ automatically. It does not keep a disabled confirmation countdown, show a
 separate transient message, or show a manual Resume control for the same
 operation. If an inventory read advances during a skeleton read, the app queues
 one newer skeleton read so the account row does not remain in its checking
-state. Expiry times use compact bordered controls so their click action remains
-visible without adding a second card container.
+state. The app keeps the last quota visible while it waits for the new account
+revision, but it does not expose Reset Cards from that old revision. It retains
+an advanced inventory until the matching account skeleton arrives, then applies
+that inventory without a duplicate provider read. This direct old-to-new update
+lets the quota bar animate to the restored value. A retryable detail-read failure
+keeps the last quota visible and shows a compact reconnecting indicator. Only a
+non-retryable failure shows the unavailable state. Expiry times use compact
+bordered controls so their click action remains visible without adding a second
+card container.
 
 The bounded recovery journal is
 `Application Support/Decodex/reset-card-pending-v1.json`. It uses an atomic

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -119,6 +119,65 @@ struct ResetCardPendingAttemptsView: View {
 	}
 }
 
+enum ResetCardInventoryPresentation: Equatable {
+	case loginRequired
+	case checking
+	case updating
+	case reconnecting(detail: String)
+	case unavailable(detail: String)
+	case reportedCount(UInt64)
+	case empty
+	case available
+
+	init(
+		state: ResetCardAccountState,
+		isAwaitingFreshAccountSkeleton: Bool
+	) {
+		if state.requiresLoginRefresh {
+			self = .loginRequired
+			return
+		}
+
+		if case .retryable(let detail) = state.inventoryFailure {
+			self = .reconnecting(detail: detail)
+			return
+		}
+		if case .unavailable(let detail) = state.inventoryFailure,
+			state.isRefreshing == false,
+			isAwaitingFreshAccountSkeleton == false
+		{
+			self = .unavailable(detail: detail)
+			return
+		}
+
+		if state.isRefreshing
+			|| isAwaitingFreshAccountSkeleton
+			|| (state.inventory != nil && state.inventoryIsCurrent == false)
+		{
+			self = state.inventory == nil ? .checking : .updating
+			return
+		}
+
+		if case .unavailable(let detail) = state.inventoryFailure {
+			self = .unavailable(detail: detail)
+			return
+		}
+		guard let inventory = state.inventory else {
+			self = .checking
+			return
+		}
+		guard inventory.detailsComplete else {
+			if let count = inventory.reportedAvailableCount {
+				self = .reportedCount(count)
+			} else {
+				self = .checking
+			}
+			return
+		}
+		self = state.targets.isEmpty ? .empty : .available
+	}
+}
+
 struct ResetCardAccountRow: View {
 	private static let confirmationWindowSeconds = 5
 
@@ -190,6 +249,7 @@ struct ResetCardAccountRow: View {
 			await runConfirmationCountdown(for: countdownAttempt)
 		}
 		.animation(rowStateAnimation, value: exceptionalStatusText)
+		.animation(rowStateAnimation, value: inventoryPresentation)
 	}
 
 	private var identityHeader: some View {
@@ -344,7 +404,8 @@ struct ResetCardAccountRow: View {
 
 	@ViewBuilder
 	private var cardInventory: some View {
-		if state.requiresLoginRefresh {
+		switch inventoryPresentation {
+		case .loginRequired:
 			Text("Reset Cards need this login")
 				.font(PanelFont.tertiary)
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
@@ -352,45 +413,43 @@ struct ResetCardAccountRow: View {
 				.help(
 					"Choose Refresh login in the menu bar app to sign in with the official Codex device login."
 				)
-		} else if let error = state.inventory?.observationError {
+		case .checking:
+			inventoryProgress(
+				"Checking Reset Cards…",
+				help: "Waiting for the current Reset Card inventory."
+			)
+		case .updating:
+			inventoryProgress(
+				"Updating usage…",
+				help: "Waiting for the current account revision and usage."
+			)
+		case .reconnecting(let detail):
+			inventoryProgress("Reconnecting…", help: detail)
+		case .unavailable(let detail):
 			Text("Reset Cards unavailable")
 				.font(PanelFont.tertiary)
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 				.lineLimit(1)
-				.help(error.presentation)
-		} else if let error = state.error {
-			Text("Reset Cards unavailable")
-				.font(PanelFont.tertiary)
-				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-				.lineLimit(1)
-				.help(error.localizedDescription)
-		} else if state.isRefreshing, state.inventory == nil {
-			Text("Checking Reset Cards…")
-				.font(PanelFont.tertiary)
-				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-		} else if let inventory = state.inventory,
-			inventory.detailsComplete == false
-		{
-			if let count = inventory.reportedAvailableCount {
-				Text(
-					count == 0
-						? "No Reset Cards"
-						: "\(count) Reset \(count == 1 ? "Card" : "Cards")"
-				)
-				.font(PanelFont.tertiary)
-				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-				.lineLimit(1)
-				.help(
-					count == 0
-						? "The provider reported no available Reset Cards."
-						: "The provider reported the count without expiration details."
-				)
-			}
-		} else if state.targets.isEmpty {
+				.help(detail)
+		case .reportedCount(let count):
+			Text(
+				count == 0
+					? "No Reset Cards"
+					: "\(count) Reset \(count == 1 ? "Card" : "Cards")"
+			)
+			.font(PanelFont.tertiary)
+			.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+			.lineLimit(1)
+			.help(
+				count == 0
+					? "The provider reported no available Reset Cards."
+					: "The provider reported the count without expiration details."
+			)
+		case .empty:
 			Text("No Reset Cards")
 				.font(PanelFont.tertiary)
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-		} else {
+		case .available:
 			ScrollView(.horizontal, showsIndicators: false) {
 				HStack(spacing: PanelSpacing.compact) {
 					ForEach(state.targets, id: \.self) { target in
@@ -421,6 +480,34 @@ struct ResetCardAccountRow: View {
 			.frame(height: 26)
 			.fixedSize(horizontal: false, vertical: true)
 		}
+	}
+
+	private func inventoryProgress(
+		_ text: String,
+		help: String
+	) -> some View {
+		HStack(spacing: PanelSpacing.related) {
+			ProgressView()
+				.controlSize(.mini)
+				.accessibilityHidden(true)
+
+			Text(text)
+				.font(PanelFont.tertiary)
+				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+				.lineLimit(1)
+		}
+		.help(help)
+		.accessibilityElement(children: .ignore)
+		.accessibilityLabel(text)
+	}
+
+	private var inventoryPresentation: ResetCardInventoryPresentation {
+		ResetCardInventoryPresentation(
+			state: state,
+			isAwaitingFreshAccountSkeleton: store.isAwaitingFreshAccountSkeleton(
+				state.account.accountID
+			)
+		)
 	}
 
 	private var countdownAttempt: ResetCardUseAttempt? {

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Observation
 
+enum ResetCardInventoryFailure: Equatable {
+	case retryable(detail: String)
+	case unavailable(detail: String)
+}
+
 struct ResetCardAccountState: Identifiable, Equatable {
 	let account: ResetCardAccountRecord
 	let inventory: ResetCardInventory?
@@ -43,8 +48,33 @@ struct ResetCardAccountState: Identifiable, Equatable {
 		inventory?.sevenDayQuota ?? account.sevenDayQuota
 	}
 
+	var inventoryIsCurrent: Bool {
+		guard let inventory else {
+			return false
+		}
+		return inventory.accountID == account.accountID
+			&& inventory.accountRevision == account.accountRevision
+	}
+
+	var inventoryFailure: ResetCardInventoryFailure? {
+		if let error {
+			return error.isRetryableReadFailure
+				? .retryable(detail: error.localizedDescription)
+				: .unavailable(detail: error.localizedDescription)
+		}
+		if let error = inventory?.observationError {
+			return error.isRetryableReadFailure
+				? .retryable(detail: error.presentation)
+				: .unavailable(detail: error.presentation)
+		}
+		return nil
+	}
+
 	var targets: [ResetCardUseTarget] {
 		guard let inventory,
+			inventoryIsCurrent,
+			error == nil,
+			inventory.observationError == nil,
 			inventory.detailsComplete
 		else {
 			return []
@@ -245,6 +275,9 @@ final class ResetCardStore {
 	@ObservationIgnored private var profilePrivacyEpoch: UInt64 = 0
 	@ObservationIgnored private var codexProjectionRequestGeneration: UInt64 = 0
 	@ObservationIgnored private var accountSkeletonRefreshGeneration: UInt64 = 0
+	@ObservationIgnored private var advancedInventoriesAwaitingSkeleton = [
+		String: ResetCardInventory
+	]()
 
 	init(
 		client: any ResetCardClient = DecodexNativeClient(),
@@ -568,12 +601,13 @@ final class ResetCardStore {
 						previous?.error?.isRetryableReadFailure == true
 							|| previous?.inventory?.observationError?.isRetryableReadFailure == true
 					)
-				let retainedInventory = sameRevision && retriesInventory == false
-					? previous?.inventory
-					: nil
-				let retainedError = sameRevision && retriesInventory == false
+				let retainedInventory = previous?.inventory
+				let retainedError = sameRevision
 					? previous?.error
 					: nil
+				let inventoryIsStale = retainedInventory.map {
+					$0.accountRevision != boundAccount.accountRevision
+				} ?? false
 				let retainedProfile = sameRevision
 					? previous?.profile
 					: nil
@@ -596,6 +630,8 @@ final class ResetCardStore {
 					inventory: retainedInventory,
 					error: retainedError,
 					isRefreshing: awaitsNewerSkeleton
+						|| inventoryIsStale
+						|| retriesInventory
 						|| (retainedInventory == nil && retainedError == nil),
 					profile: profileEmailsVisible
 						? retainedProfile
@@ -1488,7 +1524,10 @@ final class ResetCardStore {
 		}
 	}
 
-	private func refreshAccountDetails(_ accountID: String) async {
+	private func refreshAccountDetails(
+		_ accountID: String,
+		refreshInventory: Bool = true
+	) async {
 		guard let index = accounts.firstIndex(where: {
 			$0.account.accountID == accountID
 		}) else {
@@ -1512,17 +1551,19 @@ final class ResetCardStore {
 		}
 
 		await withTaskGroup(of: ResetCardAccountRead.self) { group in
-			group.addTask {
-				do {
-					return .inventoryAvailable(
-						accountID: accountID,
-						try await client.inventory(for: account)
-					)
-				} catch {
-					return .inventoryFailed(
-						accountID: accountID,
-						Self.clientError(error)
-					)
+			if refreshInventory {
+				group.addTask {
+					do {
+						return .inventoryAvailable(
+							accountID: accountID,
+							try await client.inventory(for: account)
+						)
+					} catch {
+						return .inventoryFailed(
+							accountID: accountID,
+							Self.clientError(error)
+						)
+					}
 				}
 			}
 			if let accountProfileClient, let profileRequest {
@@ -1606,7 +1647,10 @@ final class ResetCardStore {
 				}
 			)
 			routing = snapshot.routing
-			var accountsNeedingDetails = [String]()
+			var accountsNeedingDetails = [(
+				accountID: String,
+				refreshInventory: Bool
+			)]()
 			accounts = snapshot.accounts.map { account in
 				let previous = previousByID[account.accountID]
 				let authority = snapshot.authority
@@ -1616,17 +1660,39 @@ final class ResetCardStore {
 				let bound = Self.account(account, authority: authority)
 				let sameRevision = previous?.account.accountRevision
 					== bound.accountRevision
+				let advancedInventory = advancedInventoriesAwaitingSkeleton[
+					bound.accountID
+				].flatMap { inventory in
+					inventory.accountID == bound.accountID
+						&& inventory.accountRevision == bound.accountRevision
+						? inventory
+						: nil
+				}
+				let retainedInventory = advancedInventory ?? previous?.inventory
+				let inventoryIsCurrent = retainedInventory.map {
+					$0.accountID == bound.accountID
+						&& $0.accountRevision == bound.accountRevision
+				} ?? false
 				let awaitsNewerSkeleton = accountSkeletonRevisionTargets[
 					bound.accountID
 				].map { bound.accountRevision < $0 } ?? false
 				if sameRevision == false {
-					accountsNeedingDetails.append(bound.accountID)
+					accountsNeedingDetails.append(
+						(
+							accountID: bound.accountID,
+							refreshInventory: advancedInventory == nil
+								|| advancedInventory?.observationError != nil
+						)
+					)
 				}
 				return ResetCardAccountState(
 					account: bound,
-					inventory: sameRevision ? previous?.inventory : nil,
-					error: sameRevision ? previous?.error : nil,
-					isRefreshing: sameRevision == false || awaitsNewerSkeleton,
+					inventory: retainedInventory,
+					error: advancedInventory == nil && sameRevision
+						? previous?.error
+						: nil,
+					isRefreshing: awaitsNewerSkeleton
+						|| (sameRevision == false && inventoryIsCurrent == false),
 					profile: sameRevision ? previous?.profile : nil,
 					profileUnavailable: sameRevision
 						? previous?.profileUnavailable
@@ -1638,8 +1704,14 @@ final class ResetCardStore {
 			}
 			pruneProfileEmailCache()
 			reconcileAccountSkeletonRevisionTargets()
-			for accountID in accountsNeedingDetails {
-				scheduleAccountControlFollowUp(.account(accountID))
+			pruneAdvancedInventoriesAwaitingSkeleton()
+			for details in accountsNeedingDetails {
+				scheduleAccountControlFollowUp(
+					.account(
+						details.accountID,
+						refreshInventory: details.refreshInventory
+					)
+				)
 			}
 			if applyCodexAuthProjection(
 				await projectionRead ?? .unavailable,
@@ -1671,8 +1743,8 @@ final class ResetCardStore {
 		}
 		guard inventory.accountRevision == existing.accountRevision else {
 			rejectAdvancedInventory(
+				inventory,
 				accountID: accountID,
-				inventoryRevision: inventory.accountRevision,
 				index: index
 			)
 			return
@@ -1705,6 +1777,11 @@ final class ResetCardStore {
 			profileError: retainsProfileState ? accounts[index].profileError : nil,
 			isProfileRefreshing: accounts[index].isProfileRefreshing
 		)
+		if let deferred = advancedInventoriesAwaitingSkeleton[accountID],
+			deferred.accountRevision <= inventory.accountRevision
+		{
+			advancedInventoriesAwaitingSkeleton.removeValue(forKey: accountID)
+		}
 		if revisionChanged {
 			invalidateCodexProjectionAfterRevisionChange(
 				accountID: accountID,
@@ -1714,8 +1791,8 @@ final class ResetCardStore {
 	}
 
 	private func rejectAdvancedInventory(
+		_ inventory: ResetCardInventory,
 		accountID: String,
-		inventoryRevision: UInt64,
 		index: Int
 	) {
 		let existing = accounts[index]
@@ -1729,10 +1806,15 @@ final class ResetCardStore {
 			profileError: existing.profileError,
 			isProfileRefreshing: existing.isProfileRefreshing
 		)
+		if advancedInventoriesAwaitingSkeleton[accountID].map({
+			$0.accountRevision <= inventory.accountRevision
+		}) ?? true {
+			advancedInventoriesAwaitingSkeleton[accountID] = inventory
+		}
 
 		accountSkeletonRevisionTargets[accountID] = max(
 			accountSkeletonRevisionTargets[accountID] ?? 0,
-			inventoryRevision
+			inventory.accountRevision
 		)
 		scheduleFreshAccountSkeletonRead()
 	}
@@ -1764,6 +1846,21 @@ final class ResetCardStore {
 			}
 			return revision < targetRevision
 		}
+	}
+
+	private func pruneAdvancedInventoriesAwaitingSkeleton() {
+		let revisionsByID = Dictionary(
+			uniqueKeysWithValues: accounts.map {
+				($0.account.accountID, $0.account.accountRevision)
+			}
+		)
+		advancedInventoriesAwaitingSkeleton =
+			advancedInventoriesAwaitingSkeleton.filter { accountID, inventory in
+				guard let accountRevision = revisionsByID[accountID] else {
+					return false
+				}
+				return accountRevision < inventory.accountRevision
+			}
 	}
 
 	private func applyInventoryFailure(
@@ -2516,7 +2613,7 @@ final class ResetCardStore {
 
 	private enum AccountControlFollowUp {
 		case none
-		case account(String)
+		case account(String, refreshInventory: Bool)
 		case skeleton
 	}
 
@@ -2544,6 +2641,7 @@ final class ResetCardStore {
 			}
 			accounts.removeAll { $0.account.accountID == accountID }
 			accountSkeletonRevisionTargets.removeValue(forKey: accountID)
+			advancedInventoriesAwaitingSkeleton.removeValue(forKey: accountID)
 			return .skeleton
 		case .accountChanged(let account):
 			guard let index = accounts.firstIndex(where: {
@@ -2559,7 +2657,7 @@ final class ResetCardStore {
 			let sameRevision = existing.account.accountRevision == bound.accountRevision
 			accounts[index] = ResetCardAccountState(
 				account: bound,
-				inventory: sameRevision ? existing.inventory : nil,
+				inventory: existing.inventory,
 				error: nil,
 				isRefreshing: sameRevision == false,
 				profile: sameRevision ? existing.profile : nil,
@@ -2574,7 +2672,9 @@ final class ResetCardStore {
 					accountRevision: bound.accountRevision
 				)
 			}
-			return sameRevision ? .none : .account(account.accountID)
+			return sameRevision
+				? .none
+				: .account(account.accountID, refreshInventory: true)
 		}
 	}
 
@@ -2584,9 +2684,12 @@ final class ResetCardStore {
 		switch followUp {
 		case .none:
 			return
-		case .account(let accountID):
+		case .account(let accountID, let refreshInventory):
 			Task { [weak self] in
-				await self?.refreshAccountDetails(accountID)
+				await self?.refreshAccountDetails(
+					accountID,
+					refreshInventory: refreshInventory
+				)
 			}
 		case .skeleton:
 			Task { [weak self] in

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -247,6 +247,65 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(store.accounts.first?.inventory?.accountRevision, 8)
 	}
 
+	func testAdvancedInventoryIsReusedAfterItsSkeletonArrives() async throws {
+		let account = accountRecord()
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			maxSuccessfulInventoryReads: 2
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let attempt = ResetCardUseAttempt(
+			target: ResetCardUseTarget(
+				authority: authority,
+				accountID: accountID,
+				expectedRevision: 7,
+				descriptor: try ResetCardDescriptor(
+					grantedAtUnixSeconds: 100,
+					expiresAtUnixSeconds: 200
+				)
+			),
+			idempotencyKey: "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+		)
+		XCTAssertEqual(fixture.store.insert(attempt), [attempt])
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		await store.refresh()
+		XCTAssertEqual(store.accounts.first?.inventory?.accountRevision, 7)
+
+		await client.replaceAccount(accountRecord(revision: 8))
+		await client.setInventoryRevision(8, accountID: accountID)
+		await client.setResetCardStatus(.completed(.reset))
+		await store.checkPendingStatus(attempt)
+
+		for _ in 0 ..< 200 {
+			if store.accounts.first?.account.accountRevision == 8,
+				store.accounts.first?.inventory?.accountRevision == 8,
+				store.accounts.first?.isRefreshing == false
+			{
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+
+		let finalState = try XCTUnwrap(store.accounts.first)
+		XCTAssertEqual(finalState.account.accountRevision, 8)
+		XCTAssertEqual(finalState.inventory?.accountRevision, 8)
+		XCTAssertNil(finalState.error)
+		XCTAssertFalse(finalState.isRefreshing)
+		let reads = await client.readCounts()
+		XCTAssertEqual(
+			reads.inventory,
+			2,
+			"The advanced authoritative inventory must replace a duplicate provider read."
+		)
+	}
+
 	func testAdvancedInventoryQueuesAnotherSkeletonReadWhenOneIsInFlight() async throws {
 		let secondAccountID = "22222222-2222-4222-8222-222222222222"
 		let firstAccount = accountRecord()
@@ -1093,6 +1152,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 	private let capturesSnapshotBeforeWait: Bool
 	private let fixedSelectionGate: AccountControlReadGate?
 	private let inventoryRevisionOverride: UInt64?
+	private let maxSuccessfulInventoryReads: Int?
 	private var inventoryRevisionsByAccountID = [String: UInt64]()
 	private var resetCardStatus: ResetCardOperationState = .notFound
 	private let allowsEnrollment: Bool
@@ -1129,6 +1189,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 		capturesSnapshotBeforeWait: Bool = false,
 		suspendsFixedSelection: Bool = false,
 		inventoryRevisionOverride: UInt64? = nil,
+		maxSuccessfulInventoryReads: Int? = nil,
 		allowsEnrollment: Bool = false,
 		routing: AccountRoutingControl? = nil,
 		fixedSelectionError: AccountControlError? = nil,
@@ -1146,6 +1207,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 		self.capturesSnapshotBeforeWait = capturesSnapshotBeforeWait
 		fixedSelectionGate = suspendsFixedSelection ? AccountControlReadGate() : nil
 		self.inventoryRevisionOverride = inventoryRevisionOverride
+		self.maxSuccessfulInventoryReads = maxSuccessfulInventoryReads
 		self.allowsEnrollment = allowsEnrollment
 		self.routing = routing
 			?? AccountRoutingControl(
@@ -1188,6 +1250,11 @@ private actor AccountControlStoreClient: AccountControlClient {
 
 	func inventory(for account: ResetCardAccountRecord) async throws -> ResetCardInventory {
 		inventoryReadCount += 1
+		if let maxSuccessfulInventoryReads,
+			inventoryReadCount > maxSuccessfulInventoryReads
+		{
+			throw ResetCardClientError.commandFailed
+		}
 		if let inventoryGate {
 			await inventoryGate.wait()
 		}

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -262,6 +262,79 @@ final class AccountPanelPresentationTests: XCTestCase {
 		)
 	}
 
+	func testStaleInventoryKeepsQuotaVisibleWithoutExposingUseTargets() throws {
+		let authority = ResetCardAuthority(
+			profileName: "local",
+			serverID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+		)
+		let account = ResetCardAccountRecord(
+			authority: authority,
+			accountID: "11111111-1111-4111-8111-111111111111",
+			alias: "Account TEST0-00000",
+			accountRevision: 8,
+			enabled: true,
+			observedState: .available,
+			lifecycleReadiness: .ready,
+			fiveHourQuota: .unknown(durationMinutes: 300),
+			sevenDayQuota: .unknown(durationMinutes: 10_080)
+		)
+		let retainedQuota = ResetCardQuotaWindow(
+			durationMinutes: 300,
+			observedAtUnixMicros: 1_000_000,
+			state: .current(
+				usedPercent: 100,
+				resetsAtUnixMicros: 2_000_000
+			)
+		)
+		let staleInventory = ResetCardInventory(
+			authority: authority,
+			accountID: account.accountID,
+			accountRevision: 7,
+			cards: [
+				try ResetCardDescriptor(
+					grantedAtUnixSeconds: 100,
+					expiresAtUnixSeconds: 200
+				)
+			],
+			fiveHourQuota: retainedQuota,
+			sevenDayQuota: .unknown(durationMinutes: 10_080),
+			observationError: nil
+		)
+		let state = ResetCardAccountState(
+			account: account,
+			inventory: staleInventory,
+			error: .commandFailed,
+			isRefreshing: false
+		)
+
+		XCTAssertEqual(state.fiveHourQuota, retainedQuota)
+		XCTAssertTrue(
+			state.targets.isEmpty,
+			"A retained inventory is display-only after the account revision advances."
+		)
+		XCTAssertEqual(
+			ResetCardInventoryPresentation(
+				state: state,
+				isAwaitingFreshAccountSkeleton: false
+			),
+			.reconnecting(
+				detail: ResetCardClientError.commandFailed.localizedDescription
+			)
+		)
+		XCTAssertEqual(
+			ResetCardInventoryPresentation(
+				state: ResetCardAccountState(
+					account: account,
+					inventory: staleInventory,
+					error: nil,
+					isRefreshing: true
+				),
+				isAwaitingFreshAccountSkeleton: true
+			),
+			.updating
+		)
+	}
+
 	func testQuotaRowsPutTheFlexibleBarBeforeTheCompactPercentage() throws {
 		let source = try resetCardSectionSource()
 

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreStartupRetryTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreStartupRetryTests.swift
@@ -76,6 +76,76 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 		)
 	}
 
+	func testRevisionRefreshRetainsQuotaAcrossATransientInventoryFailure() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let oldInventory = try Self.inventory
+		let updatedAccount = ResetCardAccountRecord(
+			authority: Self.authority,
+			accountID: Self.account.accountID,
+			alias: Self.account.alias,
+			accountRevision: 8,
+			enabled: true,
+			observedState: .available,
+			lifecycleReadiness: .ready,
+			fiveHourQuota: .unknown(durationMinutes: 300),
+			sevenDayQuota: .unknown(durationMinutes: 10_080)
+		)
+		let restoredQuota = ResetCardQuotaWindow(
+			durationMinutes: 300,
+			observedAtUnixMicros: 2_000_000,
+			state: .current(
+				usedPercent: 0,
+				resetsAtUnixMicros: 4_000_000
+			)
+		)
+		let restoredInventory = ResetCardInventory(
+			authority: Self.authority,
+			accountID: updatedAccount.accountID,
+			accountRevision: updatedAccount.accountRevision,
+			cards: [],
+			fiveHourQuota: restoredQuota,
+			sevenDayQuota: .unknown(durationMinutes: 10_080),
+			observationError: nil
+		)
+		let client = ScriptedResetCardClient(
+			accountSteps: [
+				.value([Self.account]),
+				.value([updatedAccount]),
+				.value([updatedAccount]),
+			],
+			accountFallback: .value([updatedAccount]),
+			inventorySteps: [
+				.value(oldInventory),
+				.failure(.commandFailed),
+				.value(restoredInventory),
+			],
+			inventoryFallback: .value(restoredInventory)
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		await store.refresh()
+		XCTAssertEqual(store.accounts.first?.inventory, oldInventory)
+
+		await store.refresh()
+		let interrupted = try XCTUnwrap(store.accounts.first)
+		XCTAssertEqual(interrupted.account.accountRevision, 8)
+		XCTAssertEqual(interrupted.inventory, oldInventory)
+		XCTAssertEqual(interrupted.fiveHourQuota, oldInventory.fiveHourQuota)
+		XCTAssertEqual(interrupted.error, .commandFailed)
+		XCTAssertTrue(interrupted.targets.isEmpty)
+
+		await store.refresh()
+		let restored = try XCTUnwrap(store.accounts.first)
+		XCTAssertEqual(restored.inventory, restoredInventory)
+		XCTAssertEqual(restored.fiveHourQuota, restoredQuota)
+		XCTAssertNil(restored.error)
+	}
+
 	func testStartupDoesNotRetryPermanentReadFailure() async throws {
 		let fixture = try makePendingFixture()
 		defer { fixture.remove() }

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -207,7 +207,13 @@ decodex-publisher validate-social
   idempotency key. `decodexd` owns credentials, app-server, the opaque credit ID, the
   provider effect, and durable recovery. If inventory advances during a skeleton
   read, the app queues one newer skeleton read instead of leaving the row in a
-  checking state.
+  checking state. During that reconciliation, the app keeps the last quota visible
+  but does not expose Reset Cards from the old account revision. It holds an
+  advanced inventory until the matching account skeleton arrives and then applies
+  it without a duplicate provider read. A retryable detail-read failure shows a
+  compact reconnecting state while the retained quota remains visible. The next
+  current inventory replaces the retained value directly, so the quota bar can
+  animate to the restored value.
 - Uses an in-process Rust protocol client for active vNext account, profile, Reset Card,
   routing, Codex projection, and Fast requests. The app does not start the CLI, a
   service, or a credential helper, and Swift does not inject credentials. Operators


### PR DESCRIPTION
## Summary
- keep the last quota visible while Reset Card state reconciles
- reuse an advanced inventory after its exact account skeleton arrives
- replace unavailable flicker with updating or reconnecting progress states
- prevent retained old-revision cards from being used

## Verification
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test (185 tests)
- apps/decodex-app/script/build_and_run.sh --verify
- codesign --verify --deep --strict target/decodex-app/Decodex.app
- staged DecodexApp process path read back successfully