### PR TITLE
Fix removed Codex exec network flag

### DIFF
--- a/automations/upstream/scripts/upstream_autopilot_lib/agent.py
+++ b/automations/upstream/scripts/upstream_autopilot_lib/agent.py
@@ -3133,7 +3133,6 @@ def _run_ephemeral_codex_agent_locked(
                 ),
                 "--config",
                 "permissions.autopilot.network.enabled=false",
-                "--sandbox-state-disable-network",
                 "--config",
                 'shell_environment_policy.inherit="none"',
                 "--config",

--- a/automations/upstream/tests/test_upstream_autopilot.py
+++ b/automations/upstream/tests/test_upstream_autopilot.py
@@ -1474,6 +1474,9 @@ class UpstreamAutopilotTests(unittest.TestCase):
                 result.pop("_agent_run_fence").close()
 
             command = next(value for value in captured if "exec" in value)
+            sandbox_commands = [
+                value for value in captured if "sandbox" in value
+            ]
             joined = " ".join(command)
             self.assertEqual(result["result"]["disposition"], "accept")
             self.assertIn("--ephemeral", command)
@@ -1509,6 +1512,13 @@ class UpstreamAutopilotTests(unittest.TestCase):
             )
             self.assertNotEqual(Path(workspace_argument), worktree.resolve())
             self.assertIn("permissions.autopilot.network.enabled=false", joined)
+            self.assertNotIn("--sandbox-state-disable-network", command)
+            self.assertEqual(len(sandbox_commands), 2)
+            for sandbox_command in sandbox_commands:
+                self.assertIn(
+                    "--sandbox-state-disable-network",
+                    sandbox_command,
+                )
             self.assertIn('shell_environment_policy.inherit="none"', joined)
             self.assertNotIn("--sandbox", command)
             self.assertNotIn("/usr/bin/sandbox-exec", command)


### PR DESCRIPTION
## Summary
- remove the retired `--sandbox-state-disable-network` argument from `codex exec`
- retain the explicit network-denied permission profile and both `codex sandbox` isolation probes
- add a regression test that distinguishes the exec and sandbox CLI surfaces

## Evidence
- reproduced live failure: current Codex CLI rejects the argument on `codex exec`
- `codex exec --help` omits it; `codex sandbox --help` retains it
- `cargo make test-automations`: 317 passed
- `cargo make check-upstream-automation`: passed in 536 seconds, including 873/873 workspace tests and the PostgreSQL authority/restore matrix
- X API calls: 0; X spend: $0