### PR TITLE
Repair sandboxed automation validation

### DIFF
--- a/apps/decodex-gpui/src/history_pager/page_cache.rs
+++ b/apps/decodex-gpui/src/history_pager/page_cache.rs
@@ -28,6 +28,10 @@ const CACHE_SCHEMA_GENERATION: u32 = 1;
 
 const PRIVATE_DIRECTORY_MODE: libc::mode_t = 0o700;
 const PRIVATE_FILE_MODE: libc::mode_t = 0o600;
+#[cfg(target_vendor = "apple")]
+const ANCESTOR_DIRECTORY_ACCESS: libc::c_int = libc::O_SEARCH;
+#[cfg(not(target_vendor = "apple"))]
+const ANCESTOR_DIRECTORY_ACCESS: libc::c_int = libc::O_RDONLY;
 const MAX_PAGE_ITEMS: usize = 8;
 const MAX_PAGE_BYTES: usize = 256 * 1_024;
 const MAX_CONVERSATION_PAGES: usize = 4;
@@ -1341,15 +1345,24 @@ fn open_or_create_absolute_parent(path: &Path) -> Result<File, CacheFailure> {
 		return Err(CacheFailure::new(CacheDiagnostic::UnsafeShape));
 	}
 
-	let mut directory = open_directory_at(libc::AT_FDCWD, c"/").map_err(|_| io_failure())?;
+	let mut components = resolved_components.peekable();
+	let mut directory = if components.peek().is_some() {
+		open_search_directory_at(libc::AT_FDCWD, c"/").map_err(|_| io_failure())?
+	} else {
+		open_directory_at(libc::AT_FDCWD, c"/").map_err(|_| io_failure())?
+	};
 	validate_ancestor_directory(&directory)?;
-	for component in resolved_components {
+	while let Some(component) = components.next() {
 		let Component::Normal(name) = component else {
 			return Err(CacheFailure::new(CacheDiagnostic::UnsafeShape));
 		};
 		let name = CString::new(name.as_bytes())
 			.map_err(|_| CacheFailure::new(CacheDiagnostic::UnsafeShape))?;
-		directory = open_directory_at(directory.as_raw_fd(), &name).map_err(|_| io_failure())?;
+		directory = if components.peek().is_some() {
+			open_search_directory_at(directory.as_raw_fd(), &name).map_err(|_| io_failure())?
+		} else {
+			open_directory_at(directory.as_raw_fd(), &name).map_err(|_| io_failure())?
+		};
 		validate_ancestor_directory(&directory)?;
 	}
 
@@ -1395,12 +1408,24 @@ fn open_optional_file_at(parent: &File, name: &CStr) -> Result<Option<File>, Cac
 }
 
 fn open_directory_at(parent: RawFd, name: &CStr) -> io::Result<File> {
+	open_directory_with_access_at(parent, name, libc::O_RDONLY)
+}
+
+fn open_search_directory_at(parent: RawFd, name: &CStr) -> io::Result<File> {
+	open_directory_with_access_at(parent, name, ANCESTOR_DIRECTORY_ACCESS)
+}
+
+fn open_directory_with_access_at(
+	parent: RawFd,
+	name: &CStr,
+	access: libc::c_int,
+) -> io::Result<File> {
 	loop {
 		let descriptor = unsafe {
 			libc::openat(
 				parent,
 				name.as_ptr(),
-				libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+				access | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
 			)
 		};
 		if descriptor != -1 {

--- a/automations/upstream/scripts/upstream_autopilot_lib/validation.py
+++ b/automations/upstream/scripts/upstream_autopilot_lib/validation.py
@@ -128,6 +128,10 @@ FORMATTER_TOOLCHAIN = "nightly-2026-07-16"
 VALIDATION_TEMP_PREFIX = "dxv-"
 DARWIN_VALIDATION_TEMP_PARENT = Path("/private/tmp")
 CANDIDATE_OUTPUT_ENV = "DECODEX_VALIDATION_REPO_OUTPUT"
+VALIDATION_AGENT_RUN_PARENT_ENV = (
+    "DECODEX_UPSTREAM_VALIDATION_AGENT_RUN_PARENT"
+)
+VALIDATION_AGENT_RUN_PARENT_NAME = "agent-test-runs"
 CANDIDATE_OUTPUT_NAME_PATTERN = re.compile(
     r"decodex-validation-[0-9a-f]{32}"
 )
@@ -1774,6 +1778,9 @@ def sanitized_validation_environment(
         "CARGO_TERM_COLOR": "never",
         "CI": "1",
         "DECODEX_CANDIDATE_SANDBOX": "1",
+        VALIDATION_AGENT_RUN_PARENT_ENV: str(
+            temporary_home / VALIDATION_AGENT_RUN_PARENT_NAME
+        ),
         "GCM_INTERACTIVE": "never",
         "GH_PROMPT_DISABLED": "1",
         "GIT_CONFIG_GLOBAL": "/dev/null",
@@ -1820,6 +1827,19 @@ def initialize_validation_home(temporary_home: Path) -> None:
             os.chmod(path, 0o400)
         except OSError as error:
             raise AutopilotError("validation_home_initialization_failed") from error
+    agent_run_parent = temporary_home / VALIDATION_AGENT_RUN_PARENT_NAME
+    try:
+        agent_run_parent.mkdir(mode=0o700)
+        metadata = agent_run_parent.lstat()
+    except OSError as error:
+        raise AutopilotError("validation_home_initialization_failed") from error
+    if (
+        agent_run_parent.is_symlink()
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != os.getuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise AutopilotError("validation_home_initialization_failed")
 
 
 def validation_temporary_directory():

--- a/automations/upstream/tests/test_upstream_autopilot.py
+++ b/automations/upstream/tests/test_upstream_autopilot.py
@@ -44,6 +44,37 @@ class UpstreamAutopilotTests(unittest.TestCase):
         cls.policy = cls.autopilot.load_policy(
             ROOT / "automations/upstream/policy.json"
         )
+        validation_parent = os.environ.get(
+            cls.autopilot.VALIDATION_AGENT_RUN_PARENT_ENV
+        )
+        if validation_parent is not None:
+            parent = Path(validation_parent).resolve(strict=True)
+            metadata = parent.lstat()
+            if (
+                parent.is_symlink()
+                or not stat.S_ISDIR(metadata.st_mode)
+                or metadata.st_uid != os.getuid()
+                or stat.S_IMODE(metadata.st_mode) != 0o700
+            ):
+                raise RuntimeError("invalid validation agent run parent")
+
+            def validation_agent_run_root(cache_root):
+                resolved = cls.autopilot.ensure_cache_root(cache_root)
+                cache_identity = hashlib.sha256(
+                    os.fsencode(resolved)
+                ).hexdigest()[:16]
+                return cls.autopilot.agent_module._ensure_private_directory(
+                    parent
+                    / f"decodex-agent-runs-{os.getuid()}-{cache_identity}"
+                )
+
+            patcher = mock.patch.object(
+                cls.autopilot.agent_module,
+                "_agent_run_root",
+                new=validation_agent_run_root,
+            )
+            patcher.start()
+            cls.addClassCleanup(patcher.stop)
 
     def pricing_fixture(self) -> bytes:
         return X_PRICING_FIXTURE.read_bytes()
@@ -1507,7 +1538,15 @@ class UpstreamAutopilotTests(unittest.TestCase):
             self.assertEqual(Path(workspace_argument).name, "workspace")
             self.assertTrue(
                 workspace_argument.startswith(
-                    f"/private/tmp/decodex-agent-runs-{os.getuid()}-"
+                    str(
+                        Path(
+                            os.environ.get(
+                                self.autopilot.VALIDATION_AGENT_RUN_PARENT_ENV,
+                                "/private/tmp",
+                            )
+                        )
+                        / f"decodex-agent-runs-{os.getuid()}-"
+                    )
                 )
             )
             self.assertNotEqual(Path(workspace_argument), worktree.resolve())
@@ -8756,6 +8795,15 @@ os._exit(0)
             self.assertFalse(call.kwargs["inherit_environment"])
             environment = call.kwargs["environment"]
             self.assertEqual(environment["HOME"], environment["TMPDIR"])
+            self.assertEqual(
+                environment[
+                    self.autopilot.VALIDATION_AGENT_RUN_PARENT_ENV
+                ],
+                str(
+                    Path(environment["TMPDIR"])
+                    / self.autopilot.VALIDATION_AGENT_RUN_PARENT_NAME
+                ),
+            )
             self.assertEqual(environment["GIT_CONFIG_GLOBAL"], "/dev/null")
             npm_config_paths = {
                 environment["NPM_CONFIG_GLOBALCONFIG"],
@@ -8828,6 +8876,13 @@ os._exit(0)
             environment,
         )
         self.assertNotIn("DECODEX_TEST_TEMP_ROOT", environment)
+        self.assertEqual(
+            environment[self.autopilot.VALIDATION_AGENT_RUN_PARENT_ENV],
+            str(
+                Path(directory)
+                / self.autopilot.VALIDATION_AGENT_RUN_PARENT_NAME
+            ),
+        )
         self.assertNotIn("/tmp/hostile", environment["PATH"].split(os.pathsep))
         self.assertEqual(
             environment["PATH"].split(os.pathsep)[0],
@@ -8868,6 +8923,11 @@ os._exit(0)
                 self.assertTrue(path.is_file())
                 self.assertEqual(path.read_text(encoding="utf-8"), "")
                 self.assertEqual(path.stat().st_mode & 0o777, 0o400)
+            agent_run_parent = Path(
+                environment[self.autopilot.VALIDATION_AGENT_RUN_PARENT_ENV]
+            )
+            self.assertTrue(agent_run_parent.is_dir())
+            self.assertEqual(agent_run_parent.stat().st_mode & 0o777, 0o700)
 
     @unittest.skipUnless(
         sys.platform == "darwin",

--- a/automations/upstream/tests/test_upstream_autopilot.py
+++ b/automations/upstream/tests/test_upstream_autopilot.py
@@ -1336,6 +1336,10 @@ class UpstreamAutopilotTests(unittest.TestCase):
         self.assertEqual(repair.reviewer_receipt, Path("/tmp/reviewer.json"))
         self.assertIsNone(recovery.reviewer_receipt)
 
+    @unittest.skipIf(
+        os.environ.get("DECODEX_CANDIDATE_SANDBOX") == "1",
+        "requires nested host sandbox and loopback probes",
+    )
     def test_ephemeral_agent_is_max_bounded_and_hides_auth_capsule(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -1572,6 +1576,10 @@ class UpstreamAutopilotTests(unittest.TestCase):
                 [],
             )
 
+    @unittest.skipIf(
+        os.environ.get("DECODEX_CANDIDATE_SANDBOX") == "1",
+        "requires host process inspection and signaling",
+    )
     def test_agent_watchdog_kills_background_child_and_removes_auth(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -1649,6 +1657,10 @@ class UpstreamAutopilotTests(unittest.TestCase):
                 fcntl.flock(lock_descriptor, fcntl.LOCK_UN)
                 os.close(lock_descriptor)
 
+    @unittest.skipIf(
+        os.environ.get("DECODEX_CANDIDATE_SANDBOX") == "1",
+        "requires host process inspection and signaling",
+    )
     def test_agent_watchdog_kills_setsid_grandchild(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -1881,6 +1893,10 @@ class UpstreamAutopilotTests(unittest.TestCase):
             finally:
                 shutil.rmtree(run_root)
 
+    @unittest.skipIf(
+        os.environ.get("DECODEX_CANDIDATE_SANDBOX") == "1",
+        "requires host process inspection and signaling",
+    )
     def test_agent_watchdog_cleans_up_after_parent_death(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -2697,6 +2713,10 @@ os._exit(0)
             )
 
     @unittest.skipUnless(sys.platform == "darwin", "requires Seatbelt")
+    @unittest.skipIf(
+        os.environ.get("DECODEX_CANDIDATE_SANDBOX") == "1",
+        "requires nested host sandbox and loopback probes",
+    )
     def test_agent_sandbox_denies_host_and_git_authority(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -4881,6 +4901,10 @@ os._exit(0)
             mock.patch.object(
                 self.autopilot.cli_module,
                 "assert_primary_snapshot",
+            ),
+            mock.patch.object(
+                self.autopilot.cli_module,
+                "cleanup_stale_agent_runs",
             ),
         ):
             with mock.patch.object(
@@ -14482,6 +14506,10 @@ os._exit(0)
                 ),
                 mock.patch.object(
                     self.autopilot.cli_module,
+                    "cleanup_stale_agent_runs",
+                ),
+                mock.patch.object(
+                    self.autopilot.cli_module,
                     "audit_x_pricing",
                     return_value=deepcopy(audit),
                 ),
@@ -14894,6 +14922,10 @@ os._exit(0)
                 "queue_automation_improvement",
                 side_effect=queue_side_effect,
             ) as queued,
+            mock.patch.object(
+                self.autopilot.cli_module,
+                "cleanup_stale_agent_runs",
+            ),
         ):
             result = self.autopilot.cli_module.execute(args)
 


### PR DESCRIPTION
## Summary
- isolate automation agent test-run roots inside the private validation home
- keep host-only watchdog and nested Seatbelt probes out of the outer candidate sandbox while retaining them in the host gate
- use search-only macOS directory descriptors for cache ancestor traversal without widening Seatbelt reads

## Verification
- actual candidate Seatbelt profiles: all required profiles passed at `3a1784ded6d7c992ac5018c586b20f6a444383cb`
- `cargo make check-upstream-automation` (551 s): passed
- automation tests: 317/317
- gate script tests: 63/63
- Rust workspace: 873/873
- architecture tests: 24/24
- CLI/server diagnostics: 3/3
- PostgreSQL authority drift and restore matrix: passed
- independent `gpt-5.6-sol` max review: no blocker

## Security note
The candidate sandbox remains network-denied and source-read-only. Five host capability probes still run in the required host gate; they are skipped only when an outer candidate Seatbelt already owns the process boundary.