### PR TITLE
Repair committed automation validation retries

### DIFF
--- a/automations/upstream/README.md
+++ b/automations/upstream/README.md
@@ -130,13 +130,18 @@ generation only when the original execution spent an attempt. A `base_stale`
 claim spends one attempt from a bounded credit. Only a completed child receipt for
 that generation refunds the attempt; a child failure, block, or expired lease keeps
 it spent.
+After a supported publish-validation failure, `run-agent` passes the candidate's
+bounded diagnostic to the child. If `main` is unchanged, the child repairs the
+committed candidate. If `main` advanced, the same prepared generation is retargeted
+to current `main` before the child runs. This refresh has no attempt credit or refund.
+
 These receipts are non-replayable, state-bound handoffs. They are not cryptographic
 identity signatures. A prepared commit or started land effect keeps its original
 handoff receipt and intent generation across lease recovery; a new owner generation
 can resume only that exact intent and cannot replace its receipt.
 
 Standalone Codex app automations do not receive native multi-agent tools. The
-checked-in `run-agent` transaction therefore invokes one trusted
+checked-in `run-agent` transaction therefore invokes at most one trusted
 `codex exec --ephemeral` child. It fixes model `gpt-5.6-sol` and effort `max`,
 loads neither user configuration nor execution rules, disables network, clears the
 model shell environment, and sets `project_doc_max_bytes=0`. Its single Codex

--- a/automations/upstream/prompts/maintainer.md
+++ b/automations/upstream/prompts/maintainer.md
@@ -7,7 +7,7 @@ Authority:
   and state transitions. The parent automation must not edit or stage tracked
   candidate files.
 - The checked-in `run-agent` transaction is the only implementation delegation
-  path. It invokes one ephemeral Codex child with model `gpt-5.6-sol` and
+  path. It invokes at most one ephemeral Codex child with model `gpt-5.6-sol` and
   reasoning effort `max`. Never use `xhigh`. The child does not create a Codex
   task or retained session.
 - After a claim, use only direct `exec_command` calls for the exact state-tool
@@ -77,8 +77,16 @@ Workflow:
    differently owned path and fail closed. Do not repair residue manually. The
    trusted child transaction owns exact reset and cleanup after it acquires the
    candidate-and-role fence.
-7. Run exactly one trusted child transaction:
+7. Run exactly one trusted delegation transaction:
    `automations/upstream/scripts/run_upstream_autopilot run-agent --role maintainer --candidate-id <id> --lease-token <token> --handoff-challenge <challenge> --worktree <absolute-worktree> --json`
+   After a blocked publish-validation result, including
+   `validation_profile_focused_tests_failed`, the wrapper validates the exact
+   recorded commit, clean branch worktree, and remote branch. If primary `main`
+   still equals the commit base, it invokes the child against the committed head
+   with the candidate's bounded validation diagnostic. If `main` advanced, the
+   wrapper atomically retires the old commit receipt, retargets the same prepared
+   generation, and invokes the child against current `main` without an attempt
+   refund.
    The wrapper renews the lease to cover the 7,200-second child deadline and the
    complete post-child write guard. It acquires a candidate-and-role process
    fence, resets the automation-owned worktree to the recorded head and tree,
@@ -138,8 +146,7 @@ Workflow:
    the original execution spent an attempt. A `base_stale` refresh receives one
    bounded attempt credit: the claim spends an attempt, and only the completed
    child receipt for that generation refunds it. A child failure, block, or
-   expired lease keeps it spent. Require
-   status `agent_completed`, role
+   expired lease keeps it spent. Require status `agent_completed`, role
    `maintainer`, disposition `staged`, an empty `finding_codes` list, the exact
    returned `handoff_receipt_path`, and a 64-hex
    `agent_execution_sha256`. Receipt schema

--- a/automations/upstream/scripts/upstream_autopilot_lib/cli.py
+++ b/automations/upstream/scripts/upstream_autopilot_lib/cli.py
@@ -48,7 +48,10 @@ from . import (
     check_lease_budget,
     classify_commit_entry,
     classify_land_entry,
+    candidate_has_blocked_publish_validation,
+    candidate_has_pre_publish_stale_refresh,
     claim_candidate,
+    command_succeeds,
     collect_observation,
     cleanup_stale_agent_runs,
     commit_execution_receipt,
@@ -70,6 +73,7 @@ from . import (
     observation_session_lock,
     prepare_effect,
     prepare_agent_run,
+    prepare_pre_publish_stale_refresh,
     prepare_stale_pull_request_refresh,
     prepare_observation_plan,
     plan_task_retention,
@@ -1049,6 +1053,94 @@ def _execute(args: argparse.Namespace) -> dict[str, Any]:
             )
 
         result = candidate.get("result")
+        recorded_commit = candidate.get("commit_receipt")
+        recorded_refresh = candidate.get("stale_refresh")
+        pre_publish_refresh = (
+            recorded_refresh
+            if isinstance(recorded_refresh, dict)
+            and candidate_has_pre_publish_stale_refresh(candidate)
+            else None
+        )
+        if (
+            isinstance(pre_publish_refresh, dict)
+            and preflight["head"]
+            != pre_publish_refresh["target_base_head"]
+        ):
+            raise AutopilotError("pre_publish_stale_refresh_base_changed")
+        if isinstance(pre_publish_refresh, dict) and remote_branch_head(
+            args.worktree,
+            candidate["branch_name"],
+        ) not in {None, pre_publish_refresh["old_base_head"]}:
+            raise AutopilotError("pre_publish_candidate_remote_conflict")
+        if (
+            args.role == "maintainer"
+            and isinstance(recorded_commit, dict)
+            and candidate_has_blocked_publish_validation(candidate)
+            and candidate.get("pull_request") is None
+            and candidate.get("decision") is None
+            and candidate.get("effect") is None
+        ):
+            current_worktree_head = run_command(
+                ["git", "rev-parse", "HEAD"],
+                cwd=args.worktree,
+                failure_code="pre_publish_candidate_worktree_invalid",
+            )
+            if current_worktree_head != recorded_commit["head_sha"]:
+                raise AutopilotError(
+                    "pre_publish_candidate_worktree_invalid"
+                )
+            worktree_tree = assert_candidate_worktree(
+                repo_root,
+                args.worktree,
+                policy,
+                branch=candidate["branch_name"],
+                head_sha=recorded_commit["head_sha"],
+            )
+            if worktree_tree != recorded_commit["tree_sha"]:
+                raise AutopilotError(
+                    "pre_publish_candidate_worktree_invalid"
+                )
+            if remote_branch_head(
+                args.worktree,
+                candidate["branch_name"],
+            ) not in {None, recorded_commit["base_head"]}:
+                raise AutopilotError(
+                    "pre_publish_candidate_remote_conflict"
+                )
+            if preflight["head"] != recorded_commit["base_head"]:
+                if not command_succeeds(
+                    [
+                        "git",
+                        "merge-base",
+                        "--is-ancestor",
+                        recorded_commit["base_head"],
+                        preflight["head"],
+                    ],
+                    cwd=repo_root,
+                    failure_code=(
+                        "pre_publish_stale_refresh_base_unavailable"
+                    ),
+                ):
+                    raise AutopilotError(
+                        "pre_publish_stale_refresh_base_invalid"
+                    )
+                refresh_at = utc_now()
+                with locked_state(cache_root) as (state, state_path):
+                    prepare_pre_publish_stale_refresh(
+                        state,
+                        candidate_id=args.candidate_id,
+                        token=args.lease_token,
+                        challenge_sha256=challenge_sha256,
+                        current_main_head=preflight["head"],
+                        current_main_tree=preflight["tree"],
+                        commit_receipt_sha256=sha256_value(recorded_commit),
+                        now=refresh_at,
+                    )
+                    candidate = deepcopy(
+                        find_candidate(state, args.candidate_id)
+                    )
+                    persist(state, state_path, at=refresh_at)
+
         stale_pull_request = candidate.get("pull_request")
         if (
             args.role == "maintainer"
@@ -1150,6 +1242,12 @@ def _execute(args: argparse.Namespace) -> dict[str, Any]:
                 accepted_worktree_heads.add(
                     stale_refresh["target_base_head"]
                 )
+                if (
+                    candidate_has_pre_publish_stale_refresh(candidate)
+                ):
+                    accepted_worktree_heads.add(
+                        stale_refresh["old_head_sha"]
+                    )
             if current_worktree_head not in accepted_worktree_heads:
                 raise AutopilotError(
                     "candidate_worktree_identity_mismatch"
@@ -1237,18 +1335,32 @@ def _execute(args: argparse.Namespace) -> dict[str, Any]:
                     evidence=pricing_audit,
                 )
             )
-        if isinstance(repair_target, dict):
+        diagnostic_candidate = None
+        if candidate_has_blocked_publish_validation(candidate):
+            diagnostic_candidate = candidate
+        elif isinstance(repair_target, dict):
             target_result = repair_target.get("result")
             if (
                 isinstance(target_result, dict)
-                and target_result.get("reason_code") == "validation_failed"
-                and isinstance(target_result.get("error_digest"), str)
+                and (
+                    target_result.get("reason_code") == "validation_failed"
+                    or candidate_has_blocked_publish_validation(
+                        repair_target
+                    )
+                )
+            ):
+                diagnostic_candidate = repair_target
+        if isinstance(diagnostic_candidate, dict):
+            validation_result = diagnostic_candidate.get("result")
+            if (
+                isinstance(validation_result, dict)
+                and isinstance(validation_result.get("error_digest"), str)
             ):
                 try:
                     diagnostics["validation_failure"] = (
                         read_validation_failure_diagnostic(
                             repo_root,
-                            cause_digest=target_result["error_digest"],
+                            cause_digest=validation_result["error_digest"],
                         )
                     )
                 except AutopilotError as error:

--- a/automations/upstream/scripts/upstream_autopilot_lib/state.py
+++ b/automations/upstream/scripts/upstream_autopilot_lib/state.py
@@ -88,6 +88,14 @@ STALE_REFRESH_KEYS = {
     "prepared_at",
     "updated_at",
 }
+PUBLISH_VALIDATION_REPAIR_REASON_CODES = frozenset(
+    {
+        "validation_diff_invalid",
+        "validation_profile_cargo_make_check_failed",
+        "validation_profile_cargo_make_check_upstream_automation_failed",
+        "validation_profile_focused_tests_failed",
+    }
+)
 LEGACY_STATE_NAMES = (
     "state.json",
     "state.recovery.json",
@@ -161,6 +169,30 @@ def validate_agent_run(value: Any) -> None:
         )
     ):
         raise AutopilotError("candidate_agent_run_invalid")
+
+
+def candidate_has_blocked_publish_validation(
+    candidate: Mapping[str, Any],
+) -> bool:
+    result = candidate.get("result")
+    return bool(
+        isinstance(result, Mapping)
+        and result.get("outcome") == "blocked"
+        and result.get("reason_code")
+        in PUBLISH_VALIDATION_REPAIR_REASON_CODES
+    )
+
+
+def candidate_has_pre_publish_stale_refresh(
+    candidate: Mapping[str, Any],
+) -> bool:
+    stale_refresh = candidate.get("stale_refresh")
+    return bool(
+        isinstance(stale_refresh, Mapping)
+        and candidate_has_blocked_publish_validation(candidate)
+        and candidate.get("pull_request") is None
+        and candidate.get("commit_receipt") is None
+    )
 
 
 def valid_owned_worktrees(value: Any) -> bool:
@@ -1221,26 +1253,72 @@ def validate_state(state: dict[str, Any]) -> None:
                 or not isinstance(stale_refresh.get("updated_at"), int)
                 or stale_refresh["updated_at"]
                 < stale_refresh["prepared_at"]
-                or status
-                not in {
-                    "repair_requested",
-                    "implementing",
-                    "retry_wait",
-                    "needs_attention",
-                    "repair_pending",
-                }
-                or not isinstance(pull_request, dict)
-                or not isinstance(result, dict)
-                or result.get("outcome") != "repair_requested"
-                or "base_stale" not in result.get("finding_codes", [])
-                or stale_refresh["old_base_head"]
-                != pull_request["validation_receipt"]["base_head"]
-                or stale_refresh["old_head_sha"]
-                != pull_request["head_sha"]
-                or commit_receipt is not None
-                or decision is not None
             ):
                 raise AutopilotError("candidate_stale_refresh_invalid")
+            if not candidate_has_pre_publish_stale_refresh(candidate):
+                if (
+                    status
+                    not in {
+                        "repair_requested",
+                        "implementing",
+                        "retry_wait",
+                        "needs_attention",
+                        "repair_pending",
+                    }
+                    or not isinstance(pull_request, dict)
+                    or not isinstance(result, dict)
+                    or result.get("outcome") != "repair_requested"
+                    or "base_stale"
+                    not in result.get("finding_codes", [])
+                    or stale_refresh["old_base_head"]
+                    != pull_request["validation_receipt"]["base_head"]
+                    or stale_refresh["old_head_sha"]
+                    != pull_request["head_sha"]
+                    or commit_receipt is not None
+                    or decision is not None
+                ):
+                    raise AutopilotError("candidate_stale_refresh_invalid")
+            else:
+                handoff = candidate.get("handoff")
+                agent_run = (
+                    handoff.get("agent_run")
+                    if isinstance(handoff, dict)
+                    else None
+                )
+                effect = candidate.get("effect")
+                pre_publish_commit_effect = bool(
+                    isinstance(effect, Mapping)
+                    and effect.get("kind") == "commit"
+                    and effect.get("phase") == "prepared"
+                    and effect.get("head_sha")
+                    == stale_refresh["target_base_head"]
+                    and isinstance(handoff, Mapping)
+                    and isinstance(agent_run, Mapping)
+                    and agent_run.get("phase") == "completed"
+                    and handoff.get("consumed")
+                    == effect.get("handoff_receipt")
+                )
+                if (
+                    status != "implementing"
+                    or result["at"] > stale_refresh["prepared_at"]
+                    or candidate["attempts"]["maintainer"] < 2
+                    or not isinstance(agent_run, Mapping)
+                    or pull_request is not None
+                    or decision is not None
+                    or (
+                        effect is not None
+                        and not pre_publish_commit_effect
+                    )
+                    or commit_receipt is not None
+                    or stale_credit is not None
+                    or agent_run["base_head"]
+                    != stale_refresh["target_base_head"]
+                    or agent_run["input_head"]
+                    != stale_refresh["target_base_head"]
+                    or agent_run["repository_head"]
+                    != stale_refresh["target_base_head"]
+                ):
+                    raise AutopilotError("candidate_stale_refresh_invalid")
         if isinstance(result, dict) and result.get("outcome") == "repair_requested":
             codes = result["finding_codes"]
             disposition = result["reviewer_handoff"]["disposition"]
@@ -2723,6 +2801,10 @@ def recover_expired_leases(
         if lease is None or lease["expires_at"] > now:
             continue
         role = lease["role"]
+        pre_publish_stale_refresh = bool(
+            role == "maintainer"
+            and candidate_has_pre_publish_stale_refresh(candidate)
+        )
         handoff = candidate.get("handoff")
         agent_run = (
             handoff.get("agent_run")
@@ -2741,6 +2823,8 @@ def recover_expired_leases(
             candidate,
             role=role,
         )
+        if pre_publish_stale_refresh:
+            candidate["stale_refresh"] = None
         if completed_handoff is not None:
             candidate["lease"] = None
             candidate["updated_at"] = now
@@ -2853,7 +2937,11 @@ def abandon_missing_completed_agent_run(
         and candidate["result"].get("outcome") == "repair_requested"
         and candidate["result"].get("finding_codes") == ["base_stale"]
     )
-    if not stale_base_recovery:
+    pre_publish_stale_refresh = bool(
+        role == "maintainer"
+        and candidate_has_pre_publish_stale_refresh(candidate)
+    )
+    if not stale_base_recovery and not pre_publish_stale_refresh:
         candidate["attempts"][role] = max(
             0,
             candidate["attempts"][role] - 1,
@@ -2862,6 +2950,8 @@ def abandon_missing_completed_agent_run(
         candidate["stale_refresh_credit"] = None
     candidate["lease"] = None
     candidate["handoff"] = None
+    if pre_publish_stale_refresh:
+        candidate["stale_refresh"] = None
     candidate["updated_at"] = now
     if role == "reviewer":
         candidate["status"] = "review_pending"
@@ -4264,6 +4354,106 @@ def requeue_stale_decision(
     )
 
 
+def prepare_pre_publish_stale_refresh(
+    state: dict[str, Any],
+    *,
+    candidate_id: str,
+    token: str,
+    challenge_sha256: str,
+    current_main_head: str,
+    current_main_tree: str,
+    commit_receipt_sha256: str,
+    now: int,
+) -> None:
+    if (
+        SHA_PATTERN.fullmatch(current_main_head) is None
+        or SHA_PATTERN.fullmatch(current_main_tree) is None
+        or not is_sha256(challenge_sha256)
+        or not is_sha256(commit_receipt_sha256)
+    ):
+        raise AutopilotError("pre_publish_stale_refresh_invalid")
+    candidate = find_candidate(state, candidate_id)
+    lease_matches(candidate, "maintainer", token, now)
+    result = candidate.get("result")
+    handoff = candidate.get("handoff")
+    agent_run = (
+        handoff.get("agent_run") if isinstance(handoff, dict) else None
+    )
+    commit_receipt = candidate.get("commit_receipt")
+    prepared_old_commit_run = bool(
+        isinstance(agent_run, dict)
+        and agent_run.get("phase") == "prepared"
+        and agent_run.get("role") == "maintainer"
+        and agent_run.get("generation") == handoff.get("generation")
+        and hmac.compare_digest(
+            str(agent_run.get("challenge_sha256", "")),
+            challenge_sha256,
+        )
+        and isinstance(commit_receipt, dict)
+        and agent_run.get("base_head") == commit_receipt.get("base_head")
+        and agent_run.get("input_head") == commit_receipt.get("head_sha")
+        and agent_run.get("repository_head")
+        == commit_receipt.get("base_head")
+        and agent_run.get("input_tree") == commit_receipt.get("tree_sha")
+    )
+    if (
+        candidate["status"] != "implementing"
+        or candidate["attempts"]["maintainer"] < 2
+        or not candidate_has_blocked_publish_validation(candidate)
+        or not isinstance(commit_receipt, dict)
+        or not hmac.compare_digest(
+            sha256_value(commit_receipt),
+            commit_receipt_sha256,
+        )
+        or result["at"] < commit_receipt["committed_at"]
+        or current_main_head
+        in {commit_receipt["base_head"], commit_receipt["head_sha"]}
+        or not isinstance(handoff, dict)
+        or handoff.get("role") != "maintainer"
+        or handoff.get("generation") != candidate["lease"]["generation"]
+        or handoff.get("consumed") is not None
+        or not hmac.compare_digest(
+            str(handoff.get("challenge_sha256", "")),
+            challenge_sha256,
+        )
+        or candidate.get("pull_request") is not None
+        or candidate.get("decision") is not None
+        or candidate.get("effect") is not None
+        or candidate.get("stale_refresh") is not None
+        or candidate.get("stale_refresh_credit") is not None
+        or (agent_run is not None and not prepared_old_commit_run)
+    ):
+        raise AutopilotError("pre_publish_stale_refresh_invalid")
+
+    prepare_agent_run(
+        state,
+        candidate_id=candidate_id,
+        role="maintainer",
+        token=token,
+        challenge_sha256=challenge_sha256,
+        base_head=current_main_head,
+        input_head=current_main_head,
+        repository_head=current_main_head,
+        input_tree=current_main_tree,
+        now=now,
+    )
+    candidate["commit_receipt"] = None
+    candidate["stale_refresh"] = {
+        "old_base_head": commit_receipt["base_head"],
+        "old_head_sha": commit_receipt["head_sha"],
+        "target_base_head": current_main_head,
+        "prepared_at": now,
+        "updated_at": now,
+    }
+    append_event(
+        state,
+        "pre_publish_stale_refresh_prepared",
+        now,
+        candidate_id=candidate_id,
+        reason_code=result["reason_code"],
+    )
+
+
 def prepare_stale_pull_request_refresh(
     state: dict[str, Any],
     *,
@@ -4602,6 +4792,10 @@ def block_candidate(
         and candidate["result"].get("finding_codes") == ["base_stale"]
     )
     stale_credit = candidate.get("stale_refresh_credit")
+    pre_publish_stale_refresh = bool(
+        role == "maintainer"
+        and candidate_has_pre_publish_stale_refresh(candidate)
+    )
     if (
         isinstance(stale_credit, dict)
         and stale_credit.get("generation")
@@ -4617,6 +4811,8 @@ def block_candidate(
         candidate["effect"] = None
     candidate["lease"] = None
     candidate["handoff"] = None
+    if pre_publish_stale_refresh:
+        candidate["stale_refresh"] = None
     candidate["retry_role"] = role
     if not stale_base_retry:
         candidate["result"] = {

--- a/automations/upstream/tests/test_upstream_autopilot.py
+++ b/automations/upstream/tests/test_upstream_autopilot.py
@@ -563,6 +563,116 @@ class UpstreamAutopilotTests(unittest.TestCase):
         )
         self.autopilot.validate_state(state)
 
+    def test_pre_publish_refresh_commit_effect_survives_validation(self):
+        state, candidate_id, retry = self.committed_validation_retry()
+        candidate = self.autopilot.find_candidate(state, candidate_id)
+        old_receipt = deepcopy(candidate["commit_receipt"])
+        target_base = "3" * 40
+        target_tree = "4" * 40
+        committed_tree = "5" * 40
+        committed_head = "6" * 40
+        generation = candidate["handoff"]["generation"]
+        attempts = candidate["attempts"]["maintainer"]
+        refresh_at = candidate["lease"]["issued_at"] + 2
+        self.autopilot.prepare_pre_publish_stale_refresh(
+            state,
+            candidate_id=candidate_id,
+            token=retry["lease_token"],
+            challenge_sha256=hashlib.sha256(
+                retry["handoff_challenge"].encode("utf-8")
+            ).hexdigest(),
+            current_main_head=target_base,
+            current_main_tree=target_tree,
+            commit_receipt_sha256=self.autopilot.sha256_value(
+                old_receipt
+            ),
+            now=refresh_at,
+        )
+        run = candidate["handoff"]["agent_run"]
+        self.assertIsNone(candidate["commit_receipt"])
+        self.assertTrue(
+            self.autopilot.candidate_has_pre_publish_stale_refresh(
+                candidate
+            )
+        )
+        self.assertEqual(run["generation"], generation)
+        self.assertEqual(run["base_head"], target_base)
+        self.assertEqual(run["input_head"], target_base)
+        self.assertEqual(run["repository_head"], target_base)
+        self.assertEqual(run["input_tree"], target_tree)
+        self.assertEqual(candidate["attempts"]["maintainer"], attempts)
+        self.autopilot.validate_state(state)
+
+        worker_handoff = self.record_test_commit(
+            state,
+            candidate_id,
+            retry,
+            base_head=target_base,
+            head_sha=committed_head,
+            tree=committed_tree,
+            input_tree=target_tree,
+            validate_transitions=True,
+            now=refresh_at + 2,
+        )
+
+        self.assertIsNone(candidate["stale_refresh"])
+        self.assertIsNone(candidate["effect"])
+        self.assertEqual(candidate["commit_receipt"]["base_head"], target_base)
+        self.assertEqual(
+            candidate["commit_receipt"]["worker_handoff"],
+            worker_handoff,
+        )
+        self.autopilot.validate_state(state)
+
+    def test_pre_publish_refresh_rejects_other_agent_run_states(self):
+        state, candidate_id, retry = self.committed_validation_retry()
+        candidate = self.autopilot.find_candidate(state, candidate_id)
+        challenge_sha256 = hashlib.sha256(
+            retry["handoff_challenge"].encode("utf-8")
+        ).hexdigest()
+        mutations = {
+            "completed": {"phase": "completed"},
+            "wrong_role": {"role": "reviewer"},
+            "wrong_generation": {
+                "generation": candidate["handoff"]["generation"] + 1
+            },
+            "wrong_challenge": {"challenge_sha256": "0" * 64},
+            "wrong_base": {"base_head": "7" * 40},
+            "wrong_input": {"input_head": "8" * 40},
+            "wrong_repository": {"repository_head": "9" * 40},
+            "wrong_tree": {"input_tree": "a" * 40},
+        }
+        for name, mutation in mutations.items():
+            with self.subTest(name=name):
+                rejected_state = deepcopy(state)
+                rejected_candidate = self.autopilot.find_candidate(
+                    rejected_state,
+                    candidate_id,
+                )
+                rejected_candidate["handoff"]["agent_run"].update(
+                    mutation
+                )
+                before = deepcopy(rejected_state)
+                with self.assertRaisesRegex(
+                    self.autopilot.AutopilotError,
+                    "pre_publish_stale_refresh_invalid",
+                ):
+                    self.autopilot.prepare_pre_publish_stale_refresh(
+                        rejected_state,
+                        candidate_id=candidate_id,
+                        token=retry["lease_token"],
+                        challenge_sha256=challenge_sha256,
+                        current_main_head="3" * 40,
+                        current_main_tree="4" * 40,
+                        commit_receipt_sha256=(
+                            self.autopilot.sha256_value(
+                                rejected_candidate["commit_receipt"]
+                            )
+                        ),
+                        now=rejected_candidate["lease"]["issued_at"] + 2,
+                    )
+                self.assertEqual(rejected_state, before)
+
     def test_completed_agent_run_survives_lease_expiry_for_same_generation(self):
         state, candidate_id = self.bootstrap()
         claim = self.autopilot.claim_candidate(
@@ -3614,6 +3724,316 @@ os._exit(0)
                 "completed",
             )
 
+    def test_run_agent_cli_repairs_same_base_with_own_diagnostic(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repo_root = (Path(directory) / "repo").resolve()
+            repo_root.mkdir()
+            policy_path = repo_root / "automations/upstream/policy.json"
+            policy_path.parent.mkdir(parents=True)
+            policy_path.write_text("{}\n", encoding="utf-8")
+            worktree = repo_root / ".worktrees/candidate"
+            worktree.mkdir(parents=True)
+            state, candidate_id, retry = self.committed_validation_retry(
+                now=int(time.time()) - 1_000,
+            )
+            candidate = self.autopilot.find_candidate(state, candidate_id)
+            receipt = deepcopy(candidate["commit_receipt"])
+            generation = candidate["handoff"]["generation"]
+            self.autopilot.ensure_handoff_receipt_path(
+                repo_root / ".agent/automations/upstream/cache",
+                candidate_id=candidate_id,
+                role="maintainer",
+                generation=generation,
+            )
+            fence = mock.Mock()
+            arguments = mock.Mock(
+                command="run-agent",
+                candidate_id=candidate_id,
+                role="maintainer",
+                lease_token=retry["lease_token"],
+                handoff_challenge=retry["handoff_challenge"],
+                worktree=worktree,
+            )
+
+            def locked(_cache_root):
+                return nullcontext(
+                    (
+                        state,
+                        repo_root
+                        / ".agent/automations/upstream/cache/state-v4.json",
+                    )
+                )
+
+            def git_read(arguments, **_kwargs):
+                if arguments == ["git", "rev-parse", "HEAD"]:
+                    return receipt["head_sha"]
+                if arguments == [
+                    "git",
+                    "rev-parse",
+                    "--verify",
+                    f"{receipt['head_sha']}^{{tree}}",
+                ]:
+                    return receipt["tree_sha"]
+                self.fail(f"unexpected git read: {arguments}")
+
+            remote_head = mock.Mock(return_value=None)
+            ancestor = mock.Mock()
+            read_diagnostic = mock.Mock(
+                return_value={"schema": "validation"}
+            )
+            run_agent = mock.Mock(
+                side_effect=self.autopilot.AutopilotError(
+                    "agent_execution_failed"
+                )
+            )
+            with mock.patch.multiple(
+                self.autopilot.cli_module,
+                REPO_ROOT=repo_root,
+                DEFAULT_POLICY_PATH=policy_path,
+                resolve_primary_checkout=mock.Mock(return_value=repo_root),
+                load_policy=mock.Mock(return_value=self.policy),
+                assert_primary_clean_main=mock.Mock(
+                    return_value={
+                        "head": receipt["base_head"],
+                        "tree": "4" * 40,
+                    }
+                ),
+                locked_state=mock.Mock(side_effect=locked),
+                save_state_guarded=mock.Mock(),
+                acquire_agent_run_fence=mock.Mock(return_value=fence),
+                run_command=mock.Mock(side_effect=git_read),
+                assert_candidate_worktree=mock.Mock(
+                    return_value=receipt["tree_sha"]
+                ),
+                remote_branch_head=remote_head,
+                command_succeeds=ancestor,
+                read_validation_failure_diagnostic=read_diagnostic,
+                run_ephemeral_codex_agent=run_agent,
+            ):
+                with self.assertRaisesRegex(
+                    self.autopilot.AutopilotError,
+                    "agent_execution_failed",
+                ):
+                    self.autopilot.cli_module.execute(arguments)
+
+            self.assertEqual(candidate["commit_receipt"], receipt)
+            self.assertEqual(
+                run_agent.call_args.kwargs["base_head"],
+                receipt["base_head"],
+            )
+            self.assertEqual(
+                run_agent.call_args.kwargs["head_sha"],
+                receipt["head_sha"],
+            )
+            self.assertEqual(
+                run_agent.call_args.kwargs["diagnostics"],
+                {"validation_failure": {"schema": "validation"}},
+            )
+            self.assertTrue(run_agent.call_args.kwargs["recover_prepared"])
+            read_diagnostic.assert_called_once_with(
+                repo_root,
+                cause_digest="c" * 64,
+            )
+            remote_head.assert_called_once_with(
+                worktree,
+                candidate["branch_name"],
+            )
+            ancestor.assert_not_called()
+            fence.close.assert_called_once()
+
+    def test_run_agent_cli_refreshes_advanced_base_from_fresh_retry_claim(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as directory:
+            repo_root = (Path(directory) / "repo").resolve()
+            repo_root.mkdir()
+            policy_path = repo_root / "automations/upstream/policy.json"
+            policy_path.parent.mkdir(parents=True)
+            policy_path.write_text("{}\n", encoding="utf-8")
+            worktree = repo_root / ".worktrees/candidate"
+            worktree.mkdir(parents=True)
+            state, candidate_id, retry = self.committed_validation_retry(
+                now=int(time.time()) - 1_000,
+                prepare_retry_run=False,
+            )
+            candidate = self.autopilot.find_candidate(state, candidate_id)
+            receipt = deepcopy(candidate["commit_receipt"])
+            generation = candidate["handoff"]["generation"]
+            attempts = candidate["attempts"]["maintainer"]
+            target_base = "3" * 40
+            target_tree = "4" * 40
+            self.assertIsNone(candidate["handoff"]["agent_run"])
+            self.autopilot.ensure_handoff_receipt_path(
+                repo_root / ".agent/automations/upstream/cache",
+                candidate_id=candidate_id,
+                role="maintainer",
+                generation=generation,
+            )
+            fence = mock.Mock()
+            arguments = mock.Mock(
+                command="run-agent",
+                candidate_id=candidate_id,
+                role="maintainer",
+                lease_token=retry["lease_token"],
+                handoff_challenge=retry["handoff_challenge"],
+                worktree=worktree,
+            )
+            persisted = []
+
+            def locked(_cache_root):
+                return nullcontext(
+                    (
+                        state,
+                        repo_root
+                        / ".agent/automations/upstream/cache/state-v4.json",
+                    )
+                )
+
+            def save_state(value, _path, _now, **_kwargs):
+                self.autopilot.validate_state(value)
+                persisted.append(deepcopy(value))
+
+            def git_read(arguments, **_kwargs):
+                if arguments == ["git", "rev-parse", "HEAD"]:
+                    return receipt["head_sha"]
+                if arguments == [
+                    "git",
+                    "rev-parse",
+                    "--verify",
+                    f"{target_base}^{{tree}}",
+                ]:
+                    return target_tree
+                self.fail(f"unexpected git read: {arguments}")
+
+            remote_head = mock.Mock(return_value=None)
+            ancestor = mock.Mock(return_value=True)
+            read_diagnostic = mock.Mock(
+                return_value={"schema": "validation"}
+            )
+            run_agent = mock.Mock(
+                side_effect=self.autopilot.AutopilotError(
+                    "agent_execution_failed"
+                )
+            )
+            with mock.patch.multiple(
+                self.autopilot.cli_module,
+                REPO_ROOT=repo_root,
+                DEFAULT_POLICY_PATH=policy_path,
+                resolve_primary_checkout=mock.Mock(return_value=repo_root),
+                load_policy=mock.Mock(return_value=self.policy),
+                assert_primary_clean_main=mock.Mock(
+                    return_value={
+                        "head": target_base,
+                        "tree": target_tree,
+                    }
+                ),
+                locked_state=mock.Mock(side_effect=locked),
+                save_state_guarded=mock.Mock(side_effect=save_state),
+                acquire_agent_run_fence=mock.Mock(return_value=fence),
+                run_command=mock.Mock(side_effect=git_read),
+                assert_candidate_worktree=mock.Mock(
+                    return_value=receipt["tree_sha"]
+                ),
+                remote_branch_head=remote_head,
+                command_succeeds=ancestor,
+                read_validation_failure_diagnostic=read_diagnostic,
+                run_ephemeral_codex_agent=run_agent,
+            ):
+                with self.assertRaisesRegex(
+                    self.autopilot.AutopilotError,
+                    "agent_execution_failed",
+                ):
+                    self.autopilot.cli_module.execute(arguments)
+
+            self.assertIsNone(candidate["commit_receipt"])
+            self.assertEqual(candidate["attempts"]["maintainer"], attempts)
+            self.assertEqual(candidate["lease"]["generation"], generation)
+            self.assertEqual(candidate["handoff"]["generation"], generation)
+            run = candidate["handoff"]["agent_run"]
+            self.assertEqual(run["generation"], generation)
+            self.assertEqual(run["base_head"], target_base)
+            self.assertEqual(run["input_head"], target_base)
+            self.assertEqual(run["repository_head"], target_base)
+            self.assertEqual(run["input_tree"], target_tree)
+            stale_refresh = candidate["stale_refresh"]
+            self.assertEqual(
+                set(stale_refresh),
+                {
+                    "old_base_head",
+                    "old_head_sha",
+                    "target_base_head",
+                    "prepared_at",
+                    "updated_at",
+                },
+            )
+            self.assertEqual(
+                stale_refresh["old_base_head"],
+                receipt["base_head"],
+            )
+            self.assertEqual(
+                stale_refresh["old_head_sha"],
+                receipt["head_sha"],
+            )
+            self.assertEqual(
+                stale_refresh["target_base_head"],
+                target_base,
+            )
+            self.assertEqual(
+                stale_refresh["prepared_at"],
+                stale_refresh["updated_at"],
+            )
+            self.assertTrue(
+                any(
+                    self.autopilot.candidate_has_pre_publish_stale_refresh(
+                        self.autopilot.find_candidate(
+                            snapshot,
+                            candidate_id,
+                        )
+                    )
+                    for snapshot in persisted
+                )
+            )
+            self.autopilot.validate_state(state)
+            ancestor.assert_called_once_with(
+                [
+                    "git",
+                    "merge-base",
+                    "--is-ancestor",
+                    receipt["base_head"],
+                    target_base,
+                ],
+                cwd=repo_root,
+                failure_code="pre_publish_stale_refresh_base_unavailable",
+            )
+            self.assertEqual(
+                run_agent.call_args.kwargs["base_head"],
+                target_base,
+            )
+            self.assertEqual(
+                run_agent.call_args.kwargs["head_sha"],
+                target_base,
+            )
+            self.assertEqual(
+                run_agent.call_args.kwargs["tree_sha"],
+                target_tree,
+            )
+            self.assertEqual(
+                run_agent.call_args.kwargs["diagnostics"],
+                {"validation_failure": {"schema": "validation"}},
+            )
+            self.assertFalse(
+                run_agent.call_args.kwargs["recover_prepared"]
+            )
+            read_diagnostic.assert_called_once_with(
+                repo_root,
+                cause_digest="c" * 64,
+            )
+            remote_head.assert_called_once_with(
+                worktree,
+                candidate["branch_name"],
+            )
+            fence.close.assert_called_once()
+
     def test_run_agent_fence_blocks_before_worktree_inspection(self):
         with tempfile.TemporaryDirectory() as directory:
             repo_root = Path(directory) / "repo"
@@ -4243,6 +4663,7 @@ os._exit(0)
         base_head,
         tree,
         now,
+        input_tree=None,
     ):
         staged_paths_sha256 = "c" * 64
         raw = self.handoff_receipt(
@@ -4264,7 +4685,7 @@ os._exit(0)
             role="maintainer",
             base_head=base_head,
             repository_head=base_head,
-            input_tree=base_head,
+            input_tree=base_head if input_tree is None else input_tree,
             now=now,
         )
         return self.autopilot.consume_handoff_receipt(
@@ -6791,6 +7212,143 @@ os._exit(0)
         ]
         return state, queued[0]
 
+    def commit_execution(self, effect, identity, now):
+        return self.autopilot.commit_execution_receipt(
+            intent_sha256=effect["intent_sha256"],
+            process_evidence={
+                "schema": "decodex/codex-upstream-commit-execution/1",
+                "execution_mode": "command_completed",
+                "decodex_version": identity["version"],
+                "decodex_executable_sha256": identity[
+                    "executable_sha256"
+                ],
+                "started_at": now,
+                "completed_at": now + 1,
+                "stdout_sha256": "b" * 64,
+            },
+        )
+
+    def record_test_commit(
+        self,
+        state,
+        candidate_id,
+        claim,
+        *,
+        base_head,
+        head_sha,
+        tree,
+        now,
+        input_tree=None,
+        validate_transitions=False,
+    ):
+        candidate = self.autopilot.find_candidate(state, candidate_id)
+        worker_handoff = self.consume_worker_handoff(
+            state,
+            candidate_id,
+            claim,
+            base_head=base_head,
+            tree=tree,
+            now=now,
+            input_tree=input_tree,
+        )
+        if validate_transitions:
+            self.autopilot.validate_state(state)
+        identity = {
+            "version": "decodex 0.2.0-test",
+            "executable_sha256": "9" * 64,
+        }
+        effect = self.autopilot.prepare_effect(
+            state,
+            self.policy,
+            candidate_id=candidate_id,
+            role="maintainer",
+            token=claim["lease_token"],
+            kind="commit",
+            branch=candidate["branch_name"],
+            head_sha=base_head,
+            pr_url=None,
+            handoff_receipt=worker_handoff,
+            decodex_identity=identity,
+            now=now,
+        )
+        if validate_transitions:
+            self.autopilot.validate_state(state)
+        self.autopilot.record_candidate_commit(
+            state,
+            candidate_id=candidate_id,
+            token=claim["lease_token"],
+            base_head=base_head,
+            head_sha=head_sha,
+            tree_sha=tree,
+            message_sha256="a" * 64,
+            execution_receipt=self.commit_execution(
+                effect,
+                identity,
+                now,
+            ),
+            now=now + 1,
+        )
+        return worker_handoff
+
+    def committed_validation_retry(
+        self,
+        *,
+        now=100,
+        prepare_retry_run=True,
+    ):
+        state, candidate_id = self.bootstrap(now=now)
+        maintainer = self.autopilot.claim_candidate(
+            state,
+            self.policy,
+            "maintainer",
+            now + 1,
+        )
+        candidate = self.autopilot.find_candidate(state, candidate_id)
+        base_head = "1" * 40
+        head_sha = "2" * 40
+        tree_sha = "d" * 40
+        self.record_test_commit(
+            state,
+            candidate_id,
+            maintainer,
+            base_head=base_head,
+            head_sha=head_sha,
+            tree=tree_sha,
+            now=now + 2,
+        )
+        self.autopilot.block_candidate(
+            state,
+            self.policy,
+            candidate_id=candidate_id,
+            role="maintainer",
+            token=maintainer["lease_token"],
+            reason_code="validation_profile_focused_tests_failed",
+            error_digest="c" * 64,
+            now=now + 4,
+        )
+        retry = self.autopilot.claim_candidate(
+            state,
+            self.policy,
+            "maintainer",
+            candidate["next_retry_at"],
+        )
+        if prepare_retry_run:
+            self.autopilot.prepare_agent_run(
+                state,
+                candidate_id=candidate_id,
+                role="maintainer",
+                token=retry["lease_token"],
+                challenge_sha256=hashlib.sha256(
+                    retry["handoff_challenge"].encode("utf-8")
+                ).hexdigest(),
+                base_head=base_head,
+                input_head=head_sha,
+                repository_head=base_head,
+                input_tree=tree_sha,
+                now=candidate["lease"]["issued_at"] + 1,
+            )
+        return state, candidate_id, retry
+
     def automatic_repair_state(self):
         state, blocked_id = self.bootstrap()
         blocked = self.autopilot.find_candidate(state, blocked_id)
@@ -6958,56 +7516,14 @@ os._exit(0)
     ):
         candidate = self.autopilot.find_candidate(state, candidate_id)
         base_head = "1" * 40
-        identity = {
-            "version": "decodex 0.2.0-test",
-            "executable_sha256": "9" * 64,
-        }
-        worker_handoff = self.consume_worker_handoff(
+        self.record_test_commit(
             state,
             candidate_id,
             claim,
             base_head=base_head,
+            head_sha=head,
             tree=tree,
             now=now,
-        )
-        effect = self.autopilot.prepare_effect(
-            state,
-            self.policy,
-            candidate_id=candidate_id,
-            role="maintainer",
-            token=claim["lease_token"],
-            kind="commit",
-            branch=candidate["branch_name"],
-            head_sha=base_head,
-            pr_url=None,
-            handoff_receipt=worker_handoff,
-            decodex_identity=identity,
-            now=now,
-        )
-        commit_execution = self.autopilot.commit_execution_receipt(
-            intent_sha256=effect["intent_sha256"],
-            process_evidence={
-                "schema": "decodex/codex-upstream-commit-execution/1",
-                "execution_mode": "command_completed",
-                "decodex_version": identity["version"],
-                "decodex_executable_sha256": identity[
-                    "executable_sha256"
-                ],
-                "started_at": now,
-                "completed_at": now + 1,
-                "stdout_sha256": "b" * 64,
-            },
-        )
-        self.autopilot.record_candidate_commit(
-            state,
-            candidate_id=candidate_id,
-            token=claim["lease_token"],
-            base_head=base_head,
-            head_sha=head,
-            tree_sha=tree,
-            message_sha256="a" * 64,
-            execution_receipt=commit_execution,
-            now=now + 1,
         )
         receipt = self.validation_receipt(
             "maintainer",

--- a/openwiki/operations/codex-upstream-autopilot.md
+++ b/openwiki/operations/codex-upstream-autopilot.md
@@ -61,8 +61,8 @@ no-change/rejected decision.
 After a claim, each parent has a closed command surface. It can use only direct
 read-only commands, the state-tool transaction for its role, and exact
 managed-worktree lifecycle commands. Standalone scheduled tasks do not receive
-native multi-agent tools. The checked-in `run-agent` transaction invokes one
-`codex exec --ephemeral` child with model `gpt-5.6-sol`, effort `max`, no network,
+native multi-agent tools. The checked-in `run-agent` transaction invokes at most
+one `codex exec --ephemeral` child with model `gpt-5.6-sol`, effort `max`, no network,
 no user configuration or execution rules, an empty model shell environment, and
 `project_doc_max_bytes=0`. The child sandbox uses root read access to prevent
 automatic `:minimal` injection, denies every discovered top-level root, then reopens
@@ -108,6 +108,11 @@ from the expected staged receipt head. It can retarget to a new primary `main` w
 the child still reads the prior committed candidate. A receipt that predates that
 retarget is removed only after its generation and old context are verified. The
 parent never repairs code or review evidence.
+
+After a supported publish-validation failure, `run-agent` passes the candidate's
+bounded diagnostic to the child. If `main` is unchanged, the child repairs the
+committed candidate. If `main` advanced, the same prepared generation is retargeted
+to current `main` before the child runs. This refresh has no attempt credit or refund.
 
 The scheduled tasks do not use Decodex server, runtime, MCP, planning, or queue
 surfaces. Only the state wrapper can invoke `decodex commit` or `decodex land` after


### PR DESCRIPTION
## Summary
- repair supported publish-validation failures against the committed candidate
- retarget advanced-base retries to current main without attempt refunds
- preserve crash-safe state transitions and bounded validation diagnostics
- add natural fresh-claim and recovery regression coverage

## Validation
- cargo make check-upstream-automation
- cargo make test-automations (321 tests)
- independent Sol max review: no blocking findings
- exact live-state migration probe
