### PR TITLE
Repair upstream preflight and watchdog identity

### DIFF
--- a/automations/upstream/scripts/agent_watchdog.py
+++ b/automations/upstream/scripts/agent_watchdog.py
@@ -185,31 +185,57 @@ def _remove_auth_capsule(path: Path) -> None:
             os.close(directory_descriptor)
 
 
+def _normalize_process_start(value: str) -> str:
+    fields = value.split()
+    if len(fields) != 5:
+        raise OSError("process start time invalid")
+    return " ".join(fields)
+
+
 def _process_table() -> dict[int, tuple[int, int, str]]:
-    completed = subprocess.run(
-        ["/bin/ps", "-axo", "pid=,ppid=,uid=,lstart="],
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        close_fds=True,
-        check=False,
-        timeout=5,
-        env={"LC_ALL": "C", "PATH": "/usr/bin:/bin"},
-    )
+    try:
+        completed = subprocess.run(
+            ["/bin/ps", "-axo", "pid=,ppid=,uid=,lstart="],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            check=False,
+            timeout=5,
+            env={"LC_ALL": "C", "PATH": "/usr/bin:/bin"},
+        )
+    except subprocess.TimeoutExpired as error:
+        raise OSError("process table timed out") from error
     if (
         completed.returncode != 0
         or not 1 <= len(completed.stdout) <= MAX_PROCESS_TABLE_BYTES
     ):
         raise OSError("process table unavailable")
     table: dict[int, tuple[int, int, str]] = {}
-    for raw_line in completed.stdout.decode("ascii", errors="strict").splitlines():
+    try:
+        lines = completed.stdout.decode(
+            "ascii",
+            errors="strict",
+        ).splitlines()
+    except UnicodeDecodeError as error:
+        raise OSError("process table invalid") from error
+    for raw_line in lines:
         fields = raw_line.strip().split(maxsplit=3)
         if len(fields) != 4:
             raise OSError("process table invalid")
-        pid, parent_pid, uid = (int(value) for value in fields[:3])
+        try:
+            pid, parent_pid, uid = (
+                int(value) for value in fields[:3]
+            )
+        except ValueError as error:
+            raise OSError("process table invalid") from error
         if pid < 1 or parent_pid < 0 or not fields[3]:
             raise OSError("process table invalid")
-        table[pid] = (parent_pid, uid, fields[3])
+        table[pid] = (
+            parent_pid,
+            uid,
+            _normalize_process_start(fields[3]),
+        )
     return table
 
 
@@ -350,9 +376,11 @@ def _marked_processes(marker: bytes) -> dict[int, str]:
                 raise OSError("process marker scan invalid")
             if pid != os.getpid() and marker in fields[6]:
                 try:
-                    discovered[pid] = b" ".join(fields[1:6]).decode(
-                        "ascii",
-                        errors="strict",
+                    discovered[pid] = _normalize_process_start(
+                        b" ".join(fields[1:6]).decode(
+                            "ascii",
+                            errors="strict",
+                        )
                     )
                 except UnicodeDecodeError as error:
                     raise OSError("process marker scan invalid") from error

--- a/automations/upstream/scripts/upstream_autopilot_lib/cli.py
+++ b/automations/upstream/scripts/upstream_autopilot_lib/cli.py
@@ -1124,6 +1124,23 @@ def _execute(args: argparse.Namespace) -> dict[str, Any]:
                     raise AutopilotError(
                         "pre_publish_stale_refresh_base_invalid"
                     )
+                current_main_tree = run_command(
+                    [
+                        "git",
+                        "rev-parse",
+                        "--verify",
+                        f"{preflight['head']}^{{tree}}",
+                    ],
+                    cwd=repo_root,
+                    failure_code=(
+                        "pre_publish_stale_refresh_tree_unavailable"
+                    ),
+                    max_output_bytes=128,
+                )
+                if SHA_PATTERN.fullmatch(current_main_tree) is None:
+                    raise AutopilotError(
+                        "pre_publish_stale_refresh_tree_invalid"
+                    )
                 refresh_at = utc_now()
                 with locked_state(cache_root) as (state, state_path):
                     prepare_pre_publish_stale_refresh(
@@ -1132,7 +1149,7 @@ def _execute(args: argparse.Namespace) -> dict[str, Any]:
                         token=args.lease_token,
                         challenge_sha256=challenge_sha256,
                         current_main_head=preflight["head"],
-                        current_main_tree=preflight["tree"],
+                        current_main_tree=current_main_tree,
                         commit_receipt_sha256=sha256_value(recorded_commit),
                         now=refresh_at,
                     )

--- a/automations/upstream/tests/test_upstream_autopilot.py
+++ b/automations/upstream/tests/test_upstream_autopilot.py
@@ -3907,6 +3907,7 @@ os._exit(0)
 
             remote_head = mock.Mock(return_value=None)
             ancestor = mock.Mock(return_value=True)
+            git_command = mock.Mock(side_effect=git_read)
             read_diagnostic = mock.Mock(
                 return_value={"schema": "validation"}
             )
@@ -3923,14 +3924,15 @@ os._exit(0)
                 load_policy=mock.Mock(return_value=self.policy),
                 assert_primary_clean_main=mock.Mock(
                     return_value={
+                        "repo_root": str(repo_root),
+                        "branch": "main",
                         "head": target_base,
-                        "tree": target_tree,
                     }
                 ),
                 locked_state=mock.Mock(side_effect=locked),
                 save_state_guarded=mock.Mock(side_effect=save_state),
                 acquire_agent_run_fence=mock.Mock(return_value=fence),
-                run_command=mock.Mock(side_effect=git_read),
+                run_command=git_command,
                 assert_candidate_worktree=mock.Mock(
                     return_value=receipt["tree_sha"]
                 ),
@@ -4005,6 +4007,17 @@ os._exit(0)
                 cwd=repo_root,
                 failure_code="pre_publish_stale_refresh_base_unavailable",
             )
+            git_command.assert_any_call(
+                [
+                    "git",
+                    "rev-parse",
+                    "--verify",
+                    f"{target_base}^{{tree}}",
+                ],
+                cwd=repo_root,
+                failure_code="pre_publish_stale_refresh_tree_unavailable",
+                max_output_bytes=128,
+            )
             self.assertEqual(
                 run_agent.call_args.kwargs["base_head"],
                 target_base,
@@ -4033,6 +4046,97 @@ os._exit(0)
                 candidate["branch_name"],
             )
             fence.close.assert_called_once()
+
+    def test_run_agent_cli_rejects_malformed_advanced_base_tree(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repo_root = (Path(directory) / "repo").resolve()
+            repo_root.mkdir()
+            policy_path = repo_root / "automations/upstream/policy.json"
+            policy_path.parent.mkdir(parents=True)
+            policy_path.write_text("{}\n", encoding="utf-8")
+            worktree = repo_root / ".worktrees/candidate"
+            worktree.mkdir(parents=True)
+            state, candidate_id, retry = self.committed_validation_retry(
+                now=int(time.time()) - 1_000,
+                prepare_retry_run=False,
+            )
+            candidate = self.autopilot.find_candidate(state, candidate_id)
+            before_candidate = deepcopy(candidate)
+            before_commit_receipt = deepcopy(candidate["commit_receipt"])
+            before_attempts = deepcopy(candidate["attempts"])
+            generation = candidate["handoff"]["generation"]
+            target_base = "3" * 40
+            self.autopilot.ensure_handoff_receipt_path(
+                repo_root / ".agent/automations/upstream/cache",
+                candidate_id=candidate_id,
+                role="maintainer",
+                generation=generation,
+            )
+            arguments = mock.Mock(
+                command="run-agent",
+                candidate_id=candidate_id,
+                role="maintainer",
+                lease_token=retry["lease_token"],
+                handoff_challenge=retry["handoff_challenge"],
+                worktree=worktree,
+            )
+
+            def locked(_cache_root):
+                return nullcontext(
+                    (
+                        state,
+                        repo_root
+                        / ".agent/automations/upstream/cache/state-v4.json",
+                    )
+                )
+
+            def git_read(command, **_kwargs):
+                if command == ["git", "rev-parse", "HEAD"]:
+                    return before_commit_receipt["head_sha"]
+                if command == [
+                    "git",
+                    "rev-parse",
+                    "--verify",
+                    f"{target_base}^{{tree}}",
+                ]:
+                    return "not-a-tree"
+                self.fail(f"unexpected git read: {command}")
+
+            run_agent = mock.Mock()
+            with mock.patch.multiple(
+                self.autopilot.cli_module,
+                REPO_ROOT=repo_root,
+                DEFAULT_POLICY_PATH=policy_path,
+                resolve_primary_checkout=mock.Mock(return_value=repo_root),
+                load_policy=mock.Mock(return_value=self.policy),
+                assert_primary_clean_main=mock.Mock(
+                    return_value={
+                        "repo_root": str(repo_root),
+                        "branch": "main",
+                        "head": target_base,
+                    }
+                ),
+                locked_state=mock.Mock(side_effect=locked),
+                save_state_guarded=mock.Mock(),
+                acquire_agent_run_fence=mock.Mock(return_value=mock.Mock()),
+                run_command=mock.Mock(side_effect=git_read),
+                assert_candidate_worktree=mock.Mock(
+                    return_value=before_commit_receipt["tree_sha"]
+                ),
+                remote_branch_head=mock.Mock(return_value=None),
+                command_succeeds=mock.Mock(return_value=True),
+                run_ephemeral_codex_agent=run_agent,
+            ):
+                with self.assertRaisesRegex(
+                    self.autopilot.AutopilotError,
+                    "pre_publish_stale_refresh_tree_invalid",
+                ):
+                    self.autopilot.cli_module.execute(arguments)
+
+            self.assertEqual(candidate, before_candidate)
+            self.assertEqual(candidate["commit_receipt"], before_commit_receipt)
+            self.assertEqual(candidate["attempts"], before_attempts)
+            run_agent.assert_not_called()
 
     def test_run_agent_fence_blocks_before_worktree_inspection(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/automations/upstream/tests/test_upstream_autopilot.py
+++ b/automations/upstream/tests/test_upstream_autopilot.py
@@ -23,6 +23,7 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = ROOT / "automations/upstream/scripts/upstream_autopilot.py"
+WATCHDOG_SCRIPT = ROOT / "automations/upstream/scripts/agent_watchdog.py"
 X_PRICING_FIXTURE = (
     ROOT / "automations/upstream/tests/fixtures/x-pricing-current.md"
 )
@@ -37,10 +38,22 @@ def load_module():
     return module
 
 
+def load_watchdog_module():
+    spec = importlib.util.spec_from_file_location(
+        "upstream_agent_watchdog",
+        WATCHDOG_SCRIPT,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
 class UpstreamAutopilotTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.autopilot = load_module()
+        cls.watchdog = load_watchdog_module()
         cls.policy = cls.autopilot.load_policy(
             ROOT / "automations/upstream/policy.json"
         )
@@ -1870,6 +1883,57 @@ class UpstreamAutopilotTests(unittest.TestCase):
                         pass
                 fcntl.flock(lock_descriptor, fcntl.LOCK_UN)
                 os.close(lock_descriptor)
+
+    def test_agent_watchdog_normalizes_single_digit_process_start(self):
+        started = "Sat Aug 1 08:47:20 2026"
+        completed = mock.Mock(
+            returncode=0,
+            stdout=(
+                f"42 1 {os.getuid()} Sat Aug  1 08:47:20 2026\n"
+            ).encode(),
+        )
+        with mock.patch.object(
+            self.watchdog.subprocess,
+            "run",
+            return_value=completed,
+        ):
+            table = self.watchdog._process_table()
+
+        self.assertEqual(table[42], (1, os.getuid(), started))
+        self.assertEqual(
+            self.watchdog._normalize_process_start(
+                "Sat Aug  1 08:47:20 2026"
+            ),
+            started,
+        )
+
+    def test_agent_watchdog_process_table_failures_are_os_errors(self):
+        invalid_outputs = (
+            b"not-a-pid 1 2 Sat Aug  1 08:47:20 2026\n",
+            b"42 1 2 Sat Aug  1 08:47:20 2026\xff\n",
+        )
+        for output in invalid_outputs:
+            with self.subTest(output=output), mock.patch.object(
+                self.watchdog.subprocess,
+                "run",
+                return_value=mock.Mock(returncode=0, stdout=output),
+            ):
+                with self.assertRaisesRegex(
+                    OSError,
+                    "process table invalid",
+                ):
+                    self.watchdog._process_table()
+
+        with mock.patch.object(
+            self.watchdog.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["/bin/ps"], 5),
+        ):
+            with self.assertRaisesRegex(
+                OSError,
+                "process table timed out",
+            ):
+                self.watchdog._process_table()
 
     def test_agent_run_fence_blocks_overlap_until_receipt_phase_closes(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Summary:
- derive the current main tree from the exact preflight head instead of reading a nonexistent preflight field
- bound and validate the tree read before stale-state migration
- normalize macOS ps lstart identity across single-digit dates so detached agent descendants cannot escape cleanup
- translate process-table timeout/decode/integer failures into fail-closed cleanup errors
- cover malformed tree state safety, Aug 1-9 process identity, and cleanup error handling

Validation:
- cargo make test-automations (324 passed)
- repeated setsid watchdog integration test (5/5 passed after the fix)
- cargo make check-upstream-automation (passed on dd1e2ebf, 505.52s)
- independent Sol max review: no P1/P2 blocker