### PR TITLE
Serialize Reset Card reconciliation

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -91,11 +91,16 @@ state. The app keeps the last quota visible while it waits for the new account
 revision, but it does not expose Reset Cards from that old revision. It retains
 an advanced inventory until the matching account skeleton arrives, then applies
 that inventory without a duplicate provider read. This direct old-to-new update
-lets the quota bar animate to the restored value. A retryable detail-read failure
-keeps the last quota visible and shows a compact reconnecting indicator. Only a
-non-retryable failure shows the unavailable state. Expiry times use compact
-bordered controls so their click action remains visible without adding a second
-card container.
+lets the quota bar animate to the restored value. All callers share one
+per-account inventory coordinator: same-revision reads coalesce, a use gate
+waits for an older provider read, and fresh reads wait until the use dispatch
+ends. A terminal use result ends the button activity immediately and starts
+bounded background reconciliation. Internal contention, provider
+cleanup, and other retryable detail failures keep the last quota visible under
+`Updating usage…`; they do not claim that the app disconnected. Only a typed
+local daemon transport loss shows `Connecting to Decodex…`. A non-retryable
+failure shows the unavailable state. Expiry times use compact bordered controls
+so their click action remains visible without adding a second card container.
 
 The bounded recovery journal is
 `Application Support/Decodex/reset-card-pending-v1.json`. It uses an atomic

--- a/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
@@ -134,10 +134,14 @@ enum AccountControlError: Error, Equatable, LocalizedError, Sendable {
 				return "The native Decodex client is unavailable."
 			case .timedOut:
 				return "The account request timed out."
+			case .transportDisconnected:
+				return "The Decodex daemon is not reachable."
+			case .transportBackpressured:
+				return "The Decodex account service is busy."
 			case .outputTooLarge:
 				return "The Decodex service returned too much account data."
 			case .commandRejected, .useDefinitelyNotDispatched,
-				.usePotentiallyDispatched, .commandFailed, .invalidResponse,
+				.usePotentiallyDispatched, .invalidResponse,
 				.service:
 				return "The Decodex account service is unavailable."
 			}

--- a/apps/decodex-app/Sources/DecodexApp/DecodexNativeClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexNativeClient.swift
@@ -116,8 +116,10 @@ enum DecodexNativeFailure: String, Decodable, Sendable {
 		switch self {
 		case .protocolTimeout:
 			return .timedOut
-		case .protocolDisconnected, .protocolBackpressure:
-			return .commandFailed
+		case .protocolDisconnected:
+			return .transportDisconnected
+		case .protocolBackpressure:
+			return .transportBackpressured
 		case .runtimeUnavailable, .invalidHandle, .internalFailure:
 			return .nativeClientUnavailable
 		case .applicationAcceptanceUnknown:

--- a/apps/decodex-app/Sources/DecodexApp/FastModeControl.swift
+++ b/apps/decodex-app/Sources/DecodexApp/FastModeControl.swift
@@ -59,11 +59,13 @@ extension DecodexNativeClient: FastModeClient {
 				throw FastModeClientError.unavailable
 			case .timedOut:
 				throw FastModeClientError.timedOut
+			case .transportDisconnected:
+				throw FastModeClientError.unavailable
 			case .commandRejected:
 				throw FastModeClientError.rejected
 			case .outputTooLarge,
 				.useDefinitelyNotDispatched, .usePotentiallyDispatched,
-				.commandFailed, .invalidResponse, .service:
+				.transportBackpressured, .invalidResponse, .service:
 				throw FastModeClientError.invalidResponse
 			}
 		} catch {

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
@@ -327,11 +327,12 @@ struct ResetCardInventory: Equatable, Sendable {
 enum ResetCardClientError: Error, Equatable, LocalizedError, Sendable, CustomDebugStringConvertible {
 	case nativeClientUnavailable
 	case timedOut
+	case transportDisconnected
+	case transportBackpressured
 	case outputTooLarge
 	case commandRejected
 	case useDefinitelyNotDispatched
 	case usePotentiallyDispatched
-	case commandFailed
 	case invalidResponse
 	case service(ResetCardServiceError)
 
@@ -341,6 +342,10 @@ enum ResetCardClientError: Error, Equatable, LocalizedError, Sendable, CustomDeb
 			return "The native Decodex client is unavailable."
 		case .timedOut:
 			return "The Decodex request timed out."
+		case .transportDisconnected:
+			return "The Decodex daemon is not reachable."
+		case .transportBackpressured:
+			return "The Decodex service is busy."
 		case .outputTooLarge:
 			return "The Decodex service returned too much data."
 		case .commandRejected:
@@ -349,8 +354,6 @@ enum ResetCardClientError: Error, Equatable, LocalizedError, Sendable, CustomDeb
 			return "The reset-card request was not dispatched."
 		case .usePotentiallyDispatched:
 			return "The reset-card request may have been dispatched."
-		case .commandFailed:
-			return "The reset-card service is unavailable. Start decodexd."
 		case .invalidResponse:
 			return "The Decodex service returned an invalid reset-card response."
 		case .service(let error):
@@ -364,6 +367,10 @@ enum ResetCardClientError: Error, Equatable, LocalizedError, Sendable, CustomDeb
 			return "ResetCardClientError.nativeClientUnavailable"
 		case .timedOut:
 			return "ResetCardClientError.timedOut"
+		case .transportDisconnected:
+			return "ResetCardClientError.transportDisconnected"
+		case .transportBackpressured:
+			return "ResetCardClientError.transportBackpressured"
 		case .outputTooLarge:
 			return "ResetCardClientError.outputTooLarge"
 		case .commandRejected:
@@ -372,8 +379,6 @@ enum ResetCardClientError: Error, Equatable, LocalizedError, Sendable, CustomDeb
 			return "ResetCardClientError.useDefinitelyNotDispatched"
 		case .usePotentiallyDispatched:
 			return "ResetCardClientError.usePotentiallyDispatched"
-		case .commandFailed:
-			return "ResetCardClientError.commandFailed"
 		case .invalidResponse:
 			return "ResetCardClientError.invalidResponse"
 		case .service(let error):

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardInventoryReadCoordinator.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardInventoryReadCoordinator.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// Owns the per-account provider-read ordering contract.
+///
+/// Reset Card reads can be requested by the periodic refresh, account-control
+/// follow-ups, and terminal use reconciliation. The daemon starts a bounded
+/// provider process for each read or effect, so one account must never overlap
+/// those operations. An effect gate waits for an older read, blocks new reads
+/// through dispatch, and creates a fresh epoch for post-effect reconciliation.
+actor ResetCardInventoryReadCoordinator {
+	private struct Operation {
+		let id: UInt64
+		let accountRevision: UInt64
+		let epoch: UInt64
+		let task: Task<ResetCardInventory, Error>
+	}
+
+	private let client: any ResetCardClient
+	private var epochs = [String: UInt64]()
+	private var operations = [String: Operation]()
+	private var effectAccountIDs = Set<String>()
+	private var effectWaiters = [
+		String: [CheckedContinuation<Void, Never>]
+	]()
+	private var nextOperationID: UInt64 = 0
+
+	init(client: any ResetCardClient) {
+		self.client = client
+	}
+
+	func invalidate(_ accountID: String) {
+		epochs[accountID, default: 0] &+= 1
+	}
+
+	func beginEffect(_ accountID: String) async {
+		while effectAccountIDs.contains(accountID) {
+			await waitForEffect(accountID)
+		}
+		effectAccountIDs.insert(accountID)
+		invalidate(accountID)
+		if let predecessor = operations[accountID]?.task {
+			_ = try? await predecessor.value
+		}
+	}
+
+	func endEffect(_ accountID: String) {
+		guard effectAccountIDs.remove(accountID) != nil else {
+			return
+		}
+		resumeEffectWaiters(accountID)
+	}
+
+	func inventory(
+		for account: ResetCardAccountRecord
+	) async throws -> ResetCardInventory {
+		let accountID = account.accountID
+		while effectAccountIDs.contains(accountID) {
+			await waitForEffect(accountID)
+		}
+		let epoch = epochs[accountID, default: 0]
+		if let operation = operations[accountID],
+			operation.accountRevision == account.accountRevision,
+			operation.epoch == epoch
+		{
+			return try await operation.task.value
+		}
+
+		let predecessor = operations[accountID]?.task
+		nextOperationID &+= 1
+		let operationID = nextOperationID
+		let client = self.client
+		let task = Task { () throws -> ResetCardInventory in
+			if let predecessor {
+				_ = try? await predecessor.value
+			}
+			try Task.checkCancellation()
+			return try await client.inventory(for: account)
+		}
+		operations[accountID] = Operation(
+			id: operationID,
+			accountRevision: account.accountRevision,
+			epoch: epoch,
+			task: task
+		)
+
+		do {
+			let inventory = try await task.value
+			finish(accountID: accountID, operationID: operationID)
+			return inventory
+		} catch {
+			finish(accountID: accountID, operationID: operationID)
+			throw error
+		}
+	}
+
+	func discard(_ accountID: String) {
+		operations.removeValue(forKey: accountID)?.task.cancel()
+		epochs.removeValue(forKey: accountID)
+		effectAccountIDs.remove(accountID)
+		resumeEffectWaiters(accountID)
+	}
+
+	func cancelAll() {
+		for operation in operations.values {
+			operation.task.cancel()
+		}
+		operations.removeAll()
+		epochs.removeAll()
+		effectAccountIDs.removeAll()
+		let waiters = Array(effectWaiters.values.joined())
+		effectWaiters.removeAll()
+		for waiter in waiters {
+			waiter.resume()
+		}
+	}
+
+	private func waitForEffect(_ accountID: String) async {
+		await withCheckedContinuation { continuation in
+			effectWaiters[accountID, default: []].append(continuation)
+		}
+	}
+
+	private func resumeEffectWaiters(_ accountID: String) {
+		let waiters = effectWaiters.removeValue(forKey: accountID) ?? []
+		for waiter in waiters {
+			waiter.resume()
+		}
+	}
+
+	private func finish(accountID: String, operationID: UInt64) {
+		guard operations[accountID]?.id == operationID else {
+			return
+		}
+		operations.removeValue(forKey: accountID)
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -122,8 +122,8 @@ struct ResetCardPendingAttemptsView: View {
 enum ResetCardInventoryPresentation: Equatable {
 	case loginRequired
 	case checking
-	case updating
-	case reconnecting(detail: String)
+	case updating(detail: String?)
+	case connecting(detail: String)
 	case unavailable(detail: String)
 	case reportedCount(UInt64)
 	case empty
@@ -138,8 +138,12 @@ enum ResetCardInventoryPresentation: Equatable {
 			return
 		}
 
-		if case .retryable(let detail) = state.inventoryFailure {
-			self = .reconnecting(detail: detail)
+		if case .connecting(let detail) = state.inventoryFailure {
+			self = .connecting(detail: detail)
+			return
+		}
+		if case .updating(let detail) = state.inventoryFailure {
+			self = .updating(detail: detail)
 			return
 		}
 		if case .unavailable(let detail) = state.inventoryFailure,
@@ -154,7 +158,7 @@ enum ResetCardInventoryPresentation: Equatable {
 			|| isAwaitingFreshAccountSkeleton
 			|| (state.inventory != nil && state.inventoryIsCurrent == false)
 		{
-			self = state.inventory == nil ? .checking : .updating
+			self = state.inventory == nil ? .checking : .updating(detail: nil)
 			return
 		}
 
@@ -418,13 +422,14 @@ struct ResetCardAccountRow: View {
 				"Checking Reset Cards…",
 				help: "Waiting for the current Reset Card inventory."
 			)
-		case .updating:
+		case .updating(let detail):
 			inventoryProgress(
 				"Updating usage…",
-				help: "Waiting for the current account revision and usage."
+				help: detail
+					?? "Waiting for the current account revision and usage."
 			)
-		case .reconnecting(let detail):
-			inventoryProgress("Reconnecting…", help: detail)
+		case .connecting(let detail):
+			inventoryProgress("Connecting to Decodex…", help: detail)
 		case .unavailable(let detail):
 			Text("Reset Cards unavailable")
 				.font(PanelFont.tertiary)

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -2,7 +2,8 @@ import Foundation
 import Observation
 
 enum ResetCardInventoryFailure: Equatable {
-	case retryable(detail: String)
+	case updating(detail: String)
+	case connecting(detail: String)
 	case unavailable(detail: String)
 }
 
@@ -41,11 +42,17 @@ struct ResetCardAccountState: Identifiable, Equatable {
 	}
 
 	var fiveHourQuota: ResetCardQuotaWindow {
-		inventory?.fiveHourQuota ?? account.fiveHourQuota
+		Self.preferredQuota(
+			inventory?.fiveHourQuota,
+			account.fiveHourQuota
+		)
 	}
 
 	var sevenDayQuota: ResetCardQuotaWindow {
-		inventory?.sevenDayQuota ?? account.sevenDayQuota
+		Self.preferredQuota(
+			inventory?.sevenDayQuota,
+			account.sevenDayQuota
+		)
 	}
 
 	var inventoryIsCurrent: Bool {
@@ -58,16 +65,38 @@ struct ResetCardAccountState: Identifiable, Equatable {
 
 	var inventoryFailure: ResetCardInventoryFailure? {
 		if let error {
+			if error.isConnectionFailure {
+				return .connecting(detail: error.localizedDescription)
+			}
 			return error.isRetryableReadFailure
-				? .retryable(detail: error.localizedDescription)
+				? .updating(detail: error.localizedDescription)
 				: .unavailable(detail: error.localizedDescription)
 		}
 		if let error = inventory?.observationError {
 			return error.isRetryableReadFailure
-				? .retryable(detail: error.presentation)
+				? .updating(detail: error.presentation)
 				: .unavailable(detail: error.presentation)
 		}
 		return nil
+	}
+
+	private static func preferredQuota(
+		_ inventory: ResetCardQuotaWindow?,
+		_ account: ResetCardQuotaWindow
+	) -> ResetCardQuotaWindow {
+		guard let inventory else {
+			return account
+		}
+		guard case .current = account.state else {
+			return inventory
+		}
+		guard case .current = inventory.state else {
+			return account
+		}
+		return (account.observedAtUnixMicros ?? 0)
+			> (inventory.observedAtUnixMicros ?? 0)
+			? account
+			: inventory
 	}
 
 	var targets: [ResetCardUseTarget] {
@@ -218,6 +247,14 @@ private enum ResetCardRefreshResult: Equatable {
 	case skipped
 }
 
+private enum ResetCardInventoryRefreshResult: Equatable {
+	case current
+	case awaitingSkeleton
+	case retryNeeded
+	case failed
+	case missing
+}
+
 @MainActor
 @Observable
 final class ResetCardStore {
@@ -226,6 +263,11 @@ final class ResetCardStore {
 	// process burst that can make otherwise healthy accounts fail transiently.
 	private static let maximumConcurrentAccountReads = 3
 	private static let defaultAutomaticRefreshInterval: Duration = .seconds(15)
+	private static let defaultPostUseRetryDelays: [Duration] = [
+		.seconds(1),
+		.seconds(3),
+		.seconds(7),
+	]
 
 	private static let defaultStartupRetryDelays: [Duration] = [
 		.seconds(1),
@@ -256,10 +298,12 @@ final class ResetCardStore {
 	var message: ResetCardStoreMessage?
 
 	@ObservationIgnored private let client: any ResetCardClient
+	@ObservationIgnored private let inventoryReads: ResetCardInventoryReadCoordinator
 	@ObservationIgnored private let accountControlClient: (any AccountControlClient)?
 	@ObservationIgnored private let accountProfileClient: (any AccountProfileClient)?
 	@ObservationIgnored private let pendingStore: ResetCardPendingAttemptStore
 	@ObservationIgnored private let startupRetryDelays: [Duration]
+	@ObservationIgnored private let postUseRetryDelays: [Duration]
 	@ObservationIgnored private let automaticRefreshInterval: Duration
 	@ObservationIgnored private let accountReauthenticationPollInterval: Duration
 	@ObservationIgnored private let resolveCodexExecutable: @MainActor @Sendable () throws -> String
@@ -268,6 +312,10 @@ final class ResetCardStore {
 	@ObservationIgnored private var refreshCycleTask: Task<Void, Never>?
 	@ObservationIgnored private var pendingRecoveryTask: Task<Void, Never>?
 	@ObservationIgnored private var accountReauthenticationTask: Task<Void, Never>?
+	@ObservationIgnored private var postUseReconciliationTasks = [
+		String: Task<Void, Never>
+	]()
+	@ObservationIgnored private var postUseReconciliationAccountIDs = Set<String>()
 	@ObservationIgnored private(set) var isPreparingForTermination = false
 	@ObservationIgnored private var profileRequestGenerations = [String: UInt64]()
 	@ObservationIgnored private var profileEmailCache = [String: CachedAccountEmail]()
@@ -283,6 +331,7 @@ final class ResetCardStore {
 		client: any ResetCardClient = DecodexNativeClient(),
 		pendingStore: ResetCardPendingAttemptStore = ResetCardPendingAttemptStore(),
 		startupRetryDelays: [Duration] = ResetCardStore.defaultStartupRetryDelays,
+		postUseRetryDelays: [Duration] = ResetCardStore.defaultPostUseRetryDelays,
 		automaticRefreshInterval: Duration = ResetCardStore.defaultAutomaticRefreshInterval,
 		accountReauthenticationPollInterval: Duration = .seconds(1),
 		resolveCodexExecutable: @escaping @MainActor @Sendable () throws -> String = {
@@ -290,10 +339,12 @@ final class ResetCardStore {
 		}
 	) {
 		self.client = client
+		inventoryReads = ResetCardInventoryReadCoordinator(client: client)
 		accountControlClient = client as? any AccountControlClient
 		accountProfileClient = client as? any AccountProfileClient
 		self.pendingStore = pendingStore
 		self.startupRetryDelays = startupRetryDelays
+		self.postUseRetryDelays = postUseRetryDelays
 		self.automaticRefreshInterval = automaticRefreshInterval
 		self.accountReauthenticationPollInterval = accountReauthenticationPollInterval
 		self.resolveCodexExecutable = resolveCodexExecutable
@@ -316,6 +367,9 @@ final class ResetCardStore {
 		refreshCycleTask?.cancel()
 		pendingRecoveryTask?.cancel()
 		accountReauthenticationTask?.cancel()
+		for task in postUseReconciliationTasks.values {
+			task.cancel()
+		}
 	}
 
 	var isInitialLoading: Bool {
@@ -336,6 +390,7 @@ final class ResetCardStore {
 	func blocksNewAttempt(for target: ResetCardUseTarget) -> Bool {
 		isPendingRecoveryBlocked
 			|| submittingKey != nil
+			|| postUseReconciliationAccountIDs.contains(target.accountID)
 			|| isAwaitingFreshAccountSkeleton(target.accountID)
 			|| pendingAttempts.count >= ResetCardPendingAttemptStore.maximumAttempts
 			|| pendingAttempts.contains(where: {
@@ -415,6 +470,9 @@ final class ResetCardStore {
 		let inFlightRefreshCycleTask = refreshCycleTask
 		let inFlightPendingRecoveryTask = pendingRecoveryTask
 		let inFlightAccountReauthenticationTask = accountReauthenticationTask
+		let inFlightPostUseReconciliationTasks = Array(
+			postUseReconciliationTasks.values
+		)
 
 		startupTask?.cancel()
 		startupTask = nil
@@ -426,12 +484,20 @@ final class ResetCardStore {
 		pendingRecoveryTask = nil
 		accountReauthenticationTask?.cancel()
 		accountReauthenticationTask = nil
+		for task in inFlightPostUseReconciliationTasks {
+			task.cancel()
+		}
+		postUseReconciliationTasks.removeAll()
 
 		await inFlightStartupTask?.value
 		await inFlightAutomaticRefreshTask?.value
 		await inFlightRefreshCycleTask?.value
 		await inFlightPendingRecoveryTask?.value
 		await inFlightAccountReauthenticationTask?.value
+		for task in inFlightPostUseReconciliationTasks {
+			await task.value
+		}
+		await inventoryReads.cancelAll()
 	}
 
 	private func startAutomaticRefresh() {
@@ -632,6 +698,9 @@ final class ResetCardStore {
 					isRefreshing: awaitsNewerSkeleton
 						|| inventoryIsStale
 						|| retriesInventory
+						|| postUseReconciliationAccountIDs.contains(
+							account.accountID
+						)
 						|| (retainedInventory == nil && retainedError == nil),
 					profile: profileEmailsVisible
 						? retainedProfile
@@ -646,6 +715,7 @@ final class ResetCardStore {
 					&& retainedProfileError == nil
 				)
 			}
+			prunePostUseReconciliationsForCurrentAccounts()
 			pruneProfileEmailCache()
 			reconcileAccountSkeletonRevisionTargets()
 			if let projectionReadback,
@@ -660,7 +730,7 @@ final class ResetCardStore {
 			}
 			refreshSkeletonIsPublished = true
 
-			let client = self.client
+			let inventoryReads = self.inventoryReads
 			let accountProfileClient = self.accountProfileClient
 			let includeEmail = true
 			var profileRequests = [AccountProfileRequest]()
@@ -673,7 +743,7 @@ final class ResetCardStore {
 					do {
 						return .inventoryAvailable(
 							accountID: account.accountID,
-							try await client.inventory(for: account)
+							try await inventoryReads.inventory(for: account)
 						)
 					} catch {
 						return .inventoryFailed(
@@ -1311,6 +1381,7 @@ final class ResetCardStore {
 		defer {
 			submittingKey = nil
 		}
+		await inventoryReads.beginEffect(attempt.target.accountID)
 
 		guard let dispatch = await pendingStore.withDispatchLock(
 			for: attempt,
@@ -1325,6 +1396,7 @@ final class ResetCardStore {
 			},
 			shouldRemove: \.removesPendingAttempt
 		) else {
+			await inventoryReads.endEffect(attempt.target.accountID)
 			reloadPendingJournal()
 			if isPendingRecoveryBlocked {
 				message = Self.pendingRecoveryBlockedMessage
@@ -1337,7 +1409,9 @@ final class ResetCardStore {
 			return ResetCardUseCompletion(resolved: false)
 		}
 
-		return await apply(dispatch, to: attempt)
+		let completion = await apply(dispatch, to: attempt)
+		await inventoryReads.endEffect(attempt.target.accountID)
+		return completion
 	}
 
 	private func apply(
@@ -1380,11 +1454,12 @@ final class ResetCardStore {
 			if removeTerminalAttempt {
 				forget(attempt)
 			}
-			await refreshAccount(attempt.target.accountID)
+			await beginPostUseReconciliation(attempt.target.accountID)
 			return ResetCardUseCompletion(resolved: true)
 		case .nativeClientUnavailable, .timedOut, .outputTooLarge,
 			.useDefinitelyNotDispatched, .usePotentiallyDispatched,
-			.commandFailed, .invalidResponse, .service:
+			.transportDisconnected, .transportBackpressured,
+			.invalidResponse, .service:
 			reloadPendingJournal()
 			setPendingStatus(
 				.retrying(detail: error.localizedDescription),
@@ -1408,7 +1483,7 @@ final class ResetCardStore {
 			if removeTerminalAttempt {
 				forget(attempt)
 			}
-			await refreshAccount(attempt.target.accountID)
+			await beginPostUseReconciliation(attempt.target.accountID)
 			return ResetCardUseCompletion(resolved: true)
 		case .prepared, .effectAmbiguous, .notFound, .unavailable:
 			reloadPendingJournal()
@@ -1510,17 +1585,180 @@ final class ResetCardStore {
 		}
 	}
 
-	private func refreshAccount(_ accountID: String) async {
-		guard let index = accounts.firstIndex(where: { $0.account.accountID == accountID }) else {
+	private func beginPostUseReconciliation(_ accountID: String) async {
+		guard postUseReconciliationTasks[accountID] == nil else {
 			return
+		}
+
+		// A terminal use result is an effect boundary. A read that started before
+		// this point may finish, but it must not satisfy the post-effect refresh.
+		await inventoryReads.invalidate(accountID)
+		guard isPreparingForTermination == false,
+			let index = accounts.firstIndex(where: {
+				$0.account.accountID == accountID
+			})
+		else {
+			return
+		}
+
+		postUseReconciliationAccountIDs.insert(accountID)
+		let existing = accounts[index]
+		accounts[index] = ResetCardAccountState(
+			account: existing.account,
+			inventory: existing.inventory,
+			error: nil,
+			isRefreshing: true,
+			profile: existing.profile,
+			profileUnavailable: existing.profileUnavailable,
+			profileError: existing.profileError,
+			isProfileRefreshing: existing.isProfileRefreshing
+		)
+
+		postUseReconciliationTasks[accountID] = Task { [weak self] in
+			await self?.runPostUseReconciliation(accountID)
+		}
+	}
+
+	private func runPostUseReconciliation(_ accountID: String) async {
+		defer {
+			postUseReconciliationTasks.removeValue(forKey: accountID)
+		}
+
+		var result = await refreshAccount(
+			accountID,
+			completesPostUseReconciliation: true
+		)
+		if await finishPostUseReconciliationStep(
+			result,
+			accountID: accountID
+		) {
+			return
+		}
+
+		for delay in postUseRetryDelays {
+			do {
+				try await Task.sleep(for: delay)
+			} catch {
+				return
+			}
+			guard Task.isCancelled == false else {
+				return
+			}
+			guard postUseReconciliationAccountIDs.contains(accountID) else {
+				return
+			}
+
+			result = await refreshAccount(
+				accountID,
+				completesPostUseReconciliation: true
+			)
+			if await finishPostUseReconciliationStep(
+				result,
+				accountID: accountID
+			) {
+				return
+			}
+		}
+	}
+
+	private func finishPostUseReconciliationStep(
+		_ result: ResetCardInventoryRefreshResult,
+		accountID: String
+	) async -> Bool {
+		switch result {
+		case .current, .failed, .missing:
+			return true
+		case .awaitingSkeleton:
+			await refreshAccountSkeleton()
+			if canCompletePostUseReconciliation(accountID) {
+				completePostUseReconciliation(accountID)
+				return true
+			}
+			return postUseReconciliationAccountIDs.contains(accountID) == false
+		case .retryNeeded:
+			if isAwaitingFreshAccountSkeleton(accountID) {
+				await refreshAccountSkeleton()
+			}
+			return postUseReconciliationAccountIDs.contains(accountID) == false
+		}
+	}
+
+	private func canCompletePostUseReconciliation(_ accountID: String) -> Bool {
+		guard let state = accounts.first(where: {
+			$0.account.accountID == accountID
+		}) else {
+			return false
+		}
+		return state.inventoryIsCurrent
+			&& state.error == nil
+			&& state.inventory?.observationError == nil
+	}
+
+	private func completePostUseReconciliation(_ accountID: String) {
+		guard postUseReconciliationAccountIDs.remove(accountID) != nil else {
+			return
+		}
+		guard let index = accounts.firstIndex(where: {
+			$0.account.accountID == accountID
+		}) else {
+			return
+		}
+		let existing = accounts[index]
+		accounts[index] = ResetCardAccountState(
+			account: existing.account,
+			inventory: existing.inventory,
+			error: existing.error,
+			isRefreshing: isAwaitingFreshAccountSkeleton(accountID),
+			profile: existing.profile,
+			profileUnavailable: existing.profileUnavailable,
+			profileError: existing.profileError,
+			isProfileRefreshing: existing.isProfileRefreshing
+		)
+	}
+
+	private func prunePostUseReconciliationsForCurrentAccounts() {
+		let currentAccountIDs = Set(accounts.map(\.account.accountID))
+		let removedAccountIDs = postUseReconciliationAccountIDs.subtracting(
+			currentAccountIDs
+		)
+		guard removedAccountIDs.isEmpty == false else {
+			return
+		}
+
+		for accountID in removedAccountIDs {
+			postUseReconciliationAccountIDs.remove(accountID)
+			postUseReconciliationTasks.removeValue(forKey: accountID)?.cancel()
+			Task { [inventoryReads] in
+				await inventoryReads.discard(accountID)
+			}
+		}
+	}
+
+	private func refreshAccount(
+		_ accountID: String,
+		completesPostUseReconciliation: Bool = false
+	) async -> ResetCardInventoryRefreshResult {
+		guard let index = accounts.firstIndex(where: { $0.account.accountID == accountID }) else {
+			postUseReconciliationAccountIDs.remove(accountID)
+			return .missing
 		}
 
 		let existing = accounts[index]
 		do {
-			let inventory = try await client.inventory(for: existing.account)
-			applyInventory(inventory, accountID: accountID)
+			let inventory = try await inventoryReads.inventory(for: existing.account)
+			return applyInventory(
+				inventory,
+				accountID: accountID,
+				completesPostUseReconciliation: completesPostUseReconciliation
+			)
 		} catch {
-			applyInventoryFailure(Self.clientError(error), accountID: accountID)
+			let clientError = Self.clientError(error)
+			applyInventoryFailure(
+				clientError,
+				accountID: accountID,
+				completesPostUseReconciliation: completesPostUseReconciliation
+			)
+			return clientError.isRetryableReadFailure ? .retryNeeded : .failed
 		}
 	}
 
@@ -1534,7 +1772,7 @@ final class ResetCardStore {
 			return
 		}
 		let account = accounts[index].account
-		let client = self.client
+		let inventoryReads = self.inventoryReads
 		let includeEmail = true
 			let profileRequest = accountProfileClient.map { _ in
 				AccountProfileRequest(
@@ -1556,7 +1794,7 @@ final class ResetCardStore {
 					do {
 						return .inventoryAvailable(
 							accountID: accountID,
-							try await client.inventory(for: account)
+							try await inventoryReads.inventory(for: account)
 						)
 					} catch {
 						return .inventoryFailed(
@@ -1651,6 +1889,7 @@ final class ResetCardStore {
 				accountID: String,
 				refreshInventory: Bool
 			)]()
+			var postUseReconciledAccountIDs = Set<String>()
 			accounts = snapshot.accounts.map { account in
 				let previous = previousByID[account.accountID]
 				let authority = snapshot.authority
@@ -1667,6 +1906,12 @@ final class ResetCardStore {
 						&& inventory.accountRevision == bound.accountRevision
 						? inventory
 						: nil
+				}
+				let reconcilesPostUse = advancedInventory != nil
+					&& postUseReconciliationAccountIDs.contains(bound.accountID)
+					&& postUseReconciliationTasks[bound.accountID] == nil
+				if reconcilesPostUse {
+					postUseReconciledAccountIDs.insert(bound.accountID)
 				}
 				let retainedInventory = advancedInventory ?? previous?.inventory
 				let inventoryIsCurrent = retainedInventory.map {
@@ -1692,7 +1937,11 @@ final class ResetCardStore {
 						? previous?.error
 						: nil,
 					isRefreshing: awaitsNewerSkeleton
-						|| (sameRevision == false && inventoryIsCurrent == false),
+						|| (sameRevision == false && inventoryIsCurrent == false)
+						|| (
+							postUseReconciliationAccountIDs.contains(bound.accountID)
+								&& reconcilesPostUse == false
+						),
 					profile: sameRevision ? previous?.profile : nil,
 					profileUnavailable: sameRevision
 						? previous?.profileUnavailable
@@ -1702,6 +1951,10 @@ final class ResetCardStore {
 					&& accountProfileClient != nil
 				)
 			}
+			postUseReconciliationAccountIDs.subtract(
+				postUseReconciledAccountIDs
+			)
+			prunePostUseReconciliationsForCurrentAccounts()
 			pruneProfileEmailCache()
 			reconcileAccountSkeletonRevisionTargets()
 			pruneAdvancedInventoriesAwaitingSkeleton()
@@ -1727,19 +1980,50 @@ final class ResetCardStore {
 		}
 	}
 
+	@discardableResult
 	private func applyInventory(
 		_ inventory: ResetCardInventory,
-		accountID: String
-	) {
+		accountID: String,
+		completesPostUseReconciliation: Bool = false
+	) -> ResetCardInventoryRefreshResult {
+		if completesPostUseReconciliation == false,
+			postUseReconciliationAccountIDs.contains(accountID),
+			postUseReconciliationTasks[accountID] != nil
+		{
+			return .retryNeeded
+		}
 		guard inventory.accountID == accountID,
 			let index = accounts.firstIndex(where: { $0.account.accountID == accountID })
 		else {
-			applyInventoryFailure(.invalidResponse, accountID: accountID)
-			return
+			applyInventoryFailure(
+				.invalidResponse,
+				accountID: accountID,
+				completesPostUseReconciliation: completesPostUseReconciliation
+			)
+			return .failed
 		}
 		let existing = accounts[index].account
 		guard inventory.accountRevision >= existing.accountRevision else {
-			return
+			return .retryNeeded
+		}
+		if let observationError = inventory.observationError {
+			if inventory.accountRevision > existing.accountRevision {
+				accountSkeletonRevisionTargets[accountID] = max(
+					accountSkeletonRevisionTargets[accountID] ?? 0,
+					inventory.accountRevision
+				)
+			}
+			applyInventoryFailure(
+				.service(observationError),
+				accountID: accountID,
+				completesPostUseReconciliation: completesPostUseReconciliation
+			)
+			if inventory.accountRevision > existing.accountRevision {
+				scheduleFreshAccountSkeletonRead()
+			}
+			return observationError.isRetryableReadFailure
+				? .retryNeeded
+				: .failed
 		}
 		guard inventory.accountRevision == existing.accountRevision else {
 			rejectAdvancedInventory(
@@ -1747,7 +2031,7 @@ final class ResetCardStore {
 				accountID: accountID,
 				index: index
 			)
-			return
+			return .awaitingSkeleton
 		}
 		let account = ResetCardAccountRecord(
 			authority: inventory.authority,
@@ -1769,7 +2053,8 @@ final class ResetCardStore {
 			account: account,
 			inventory: inventory,
 			error: nil,
-			isRefreshing: false,
+			isRefreshing: postUseReconciliationAccountIDs.contains(accountID)
+				|| isAwaitingFreshAccountSkeleton(accountID),
 			profile: retainsProfileState ? accounts[index].profile : nil,
 			profileUnavailable: retainsProfileState
 				? accounts[index].profileUnavailable
@@ -1777,6 +2062,11 @@ final class ResetCardStore {
 			profileError: retainsProfileState ? accounts[index].profileError : nil,
 			isProfileRefreshing: accounts[index].isProfileRefreshing
 		)
+		if completesPostUseReconciliation
+			|| postUseReconciliationTasks[accountID] == nil
+		{
+			completePostUseReconciliation(accountID)
+		}
 		if let deferred = advancedInventoriesAwaitingSkeleton[accountID],
 			deferred.accountRevision <= inventory.accountRevision
 		{
@@ -1788,6 +2078,7 @@ final class ResetCardStore {
 				accountRevision: inventory.accountRevision
 			)
 		}
+		return .current
 	}
 
 	private func rejectAdvancedInventory(
@@ -1865,17 +2156,37 @@ final class ResetCardStore {
 
 	private func applyInventoryFailure(
 		_ error: ResetCardClientError,
-		accountID: String
+		accountID: String,
+		completesPostUseReconciliation: Bool = false
 	) {
+		guard completesPostUseReconciliation
+			|| postUseReconciliationAccountIDs.contains(accountID) == false
+			|| postUseReconciliationTasks[accountID] == nil
+		else {
+			return
+		}
 		guard let index = accounts.firstIndex(where: { $0.account.accountID == accountID }) else {
 			return
+		}
+		let isRetryable = error.isRetryableReadFailure
+		if isRetryable == false
+			&& (
+				completesPostUseReconciliation
+					|| postUseReconciliationTasks[accountID] == nil
+			)
+		{
+			postUseReconciliationAccountIDs.remove(accountID)
 		}
 		let existing = accounts[index]
 		accounts[index] = ResetCardAccountState(
 			account: existing.account,
 			inventory: existing.inventory,
 			error: error,
-			isRefreshing: false,
+			isRefreshing: isRetryable
+				&& (
+					postUseReconciliationAccountIDs.contains(accountID)
+						|| isAwaitingFreshAccountSkeleton(accountID)
+				),
 			profile: existing.profile,
 			profileUnavailable: existing.profileUnavailable,
 			profileError: existing.profileError,
@@ -2640,8 +2951,13 @@ final class ResetCardStore {
 				codexAuthProjection = nil
 			}
 			accounts.removeAll { $0.account.accountID == accountID }
+			postUseReconciliationAccountIDs.remove(accountID)
+			postUseReconciliationTasks.removeValue(forKey: accountID)?.cancel()
 			accountSkeletonRevisionTargets.removeValue(forKey: accountID)
 			advancedInventoriesAwaitingSkeleton.removeValue(forKey: accountID)
+			Task { [inventoryReads] in
+				await inventoryReads.discard(accountID)
+			}
 			return .skeleton
 		case .accountChanged(let account):
 			guard let index = accounts.firstIndex(where: {
@@ -2820,9 +3136,21 @@ final class ResetCardStore {
 }
 
 private extension ResetCardClientError {
+	var isConnectionFailure: Bool {
+		switch self {
+		case .transportDisconnected:
+			return true
+		case .nativeClientUnavailable, .timedOut, .transportBackpressured,
+			.outputTooLarge, .commandRejected, .useDefinitelyNotDispatched,
+			.usePotentiallyDispatched, .invalidResponse, .service:
+			return false
+		}
+	}
+
 	var isRetryableReadFailure: Bool {
 		switch self {
-		case .nativeClientUnavailable, .timedOut, .commandFailed:
+		case .nativeClientUnavailable, .timedOut, .transportDisconnected,
+			.transportBackpressured:
 			return true
 		case .service(let error):
 			return error.isRetryableReadFailure

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -364,7 +364,12 @@ final class AccountControlStoreTests: XCTestCase {
 		await client.setInventoryRevision(8, accountID: secondAccountID)
 		await client.setResetCardStatus(.completed(.reset))
 		await store.checkPendingStatus(attempt)
-		await Task.yield()
+		for _ in 0 ..< 200 {
+			if store.isAwaitingFreshAccountSkeleton(secondAccountID) {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
 
 		XCTAssertTrue(store.isAwaitingFreshAccountSkeleton(secondAccountID))
 		XCTAssertTrue(
@@ -1253,7 +1258,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 		if let maxSuccessfulInventoryReads,
 			inventoryReadCount > maxSuccessfulInventoryReads
 		{
-			throw ResetCardClientError.commandFailed
+			throw ResetCardClientError.transportBackpressured
 		}
 		if let inventoryGate {
 			await inventoryGate.wait()

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -87,6 +87,58 @@ final class AccountPanelPresentationTests: XCTestCase {
 		XCTAssertNotNil(presentation.resetDate)
 	}
 
+	func testQuotaUsesTheNewestCurrentObservationDuringReconciliation() {
+		let authority = ResetCardAuthority(
+			profileName: "local",
+			serverID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+		)
+		let inventoryQuota = ResetCardQuotaWindow(
+			durationMinutes: 300,
+			observedAtUnixMicros: 1_000_000,
+			state: .current(
+				usedPercent: 100,
+				resetsAtUnixMicros: 2_000_000
+			)
+		)
+		let skeletonQuota = ResetCardQuotaWindow(
+			durationMinutes: 300,
+			observedAtUnixMicros: 2_000_000,
+			state: .current(
+				usedPercent: 0,
+				resetsAtUnixMicros: 4_000_000
+			)
+		)
+		let account = ResetCardAccountRecord(
+			authority: authority,
+			accountID: "11111111-1111-4111-8111-111111111111",
+			alias: "Account TEST0-00000",
+			accountRevision: 8,
+			enabled: true,
+			observedState: .available,
+			lifecycleReadiness: .ready,
+			fiveHourQuota: skeletonQuota,
+			sevenDayQuota: .unknown(durationMinutes: 10_080)
+		)
+		let retainedInventory = ResetCardInventory(
+			authority: authority,
+			accountID: account.accountID,
+			accountRevision: 7,
+			cards: [],
+			fiveHourQuota: inventoryQuota,
+			sevenDayQuota: .unknown(durationMinutes: 10_080),
+			observationError: nil
+		)
+
+		let state = ResetCardAccountState(
+			account: account,
+			inventory: retainedInventory,
+			error: nil,
+			isRefreshing: true
+		)
+
+		XCTAssertEqual(state.fiveHourQuota, skeletonQuota)
+	}
+
 	func testCurrentQuotaToneTracksRemainingCapacity() {
 		func tone(usedPercent: UInt8) -> ResetCardQuotaPresentationTone {
 			ResetCardQuotaPresentation(
@@ -303,7 +355,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 		let state = ResetCardAccountState(
 			account: account,
 			inventory: staleInventory,
-			error: .commandFailed,
+			error: .transportBackpressured,
 			isRefreshing: false
 		)
 
@@ -317,8 +369,22 @@ final class AccountPanelPresentationTests: XCTestCase {
 				state: state,
 				isAwaitingFreshAccountSkeleton: false
 			),
-			.reconnecting(
-				detail: ResetCardClientError.commandFailed.localizedDescription
+			.updating(
+				detail: ResetCardClientError.transportBackpressured.localizedDescription
+			)
+		)
+		XCTAssertEqual(
+			ResetCardInventoryPresentation(
+				state: ResetCardAccountState(
+					account: account,
+					inventory: staleInventory,
+					error: .transportDisconnected,
+					isRefreshing: false
+				),
+				isAwaitingFreshAccountSkeleton: false
+			),
+			.connecting(
+				detail: ResetCardClientError.transportDisconnected.localizedDescription
 			)
 		)
 		XCTAssertEqual(
@@ -331,8 +397,13 @@ final class AccountPanelPresentationTests: XCTestCase {
 				),
 				isAwaitingFreshAccountSkeleton: true
 			),
-			.updating
+			.updating(detail: nil)
 		)
+
+		let source = try resetCardSectionSource()
+		XCTAssertTrue(source.contains("Updating usage…"))
+		XCTAssertTrue(source.contains("Connecting to Decodex…"))
+		XCTAssertFalse(source.contains("Reconnecting…"))
 	}
 
 	func testQuotaRowsPutTheFlexibleBarBeforeTheCompactPercentage() throws {

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardCLIClientTests.swift
@@ -435,7 +435,8 @@ final class ResetCardNativeClientTests: XCTestCase {
 		let authority = authority
 		let cases: [(String, ResetCardClientError)] = [
 			("protocol_timeout", .timedOut),
-			("protocol_disconnected", .commandFailed),
+			("protocol_disconnected", .transportDisconnected),
+			("protocol_backpressure", .transportBackpressured),
 			("runtime_unavailable", .nativeClientUnavailable),
 			("protocol_malformed", .invalidResponse),
 		]

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardInventoryReadCoordinatorTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardInventoryReadCoordinatorTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import XCTest
+@testable import DecodexApp
+
+final class ResetCardInventoryReadCoordinatorTests: XCTestCase {
+	func testSameRevisionReadsCoalesceIntoOneProviderCall() async throws {
+		let account = Self.account
+		let client = CoordinatedInventoryClient(account: account)
+		let coordinator = ResetCardInventoryReadCoordinator(client: client)
+		let first = Task.detached {
+			try await coordinator.inventory(for: account)
+		}
+		try await waitForCallCount(1, client: client)
+		let second = Task.detached {
+			try await coordinator.inventory(for: account)
+		}
+
+		try await Task.sleep(for: .milliseconds(20))
+		let coalescedCallCount = await client.callCount()
+		XCTAssertEqual(coalescedCallCount, 1)
+		await client.release(call: 1)
+
+		let firstInventory = try await first.value
+		let secondInventory = try await second.value
+		let finalCallCount = await client.callCount()
+		let maximumActiveCallCount = await client.maximumActiveCallCount()
+		XCTAssertEqual(firstInventory, secondInventory)
+		XCTAssertEqual(finalCallCount, 1)
+		XCTAssertEqual(maximumActiveCallCount, 1)
+	}
+
+	func testInvalidatedReadWaitsForThePreEffectReadToFinish() async throws {
+		let account = Self.account
+		let client = CoordinatedInventoryClient(account: account)
+		let coordinator = ResetCardInventoryReadCoordinator(client: client)
+		let preEffect = Task.detached {
+			try await coordinator.inventory(for: account)
+		}
+		try await waitForCallCount(1, client: client)
+
+		await coordinator.invalidate(account.accountID)
+		let postEffect = Task.detached {
+			try await coordinator.inventory(for: account)
+		}
+		try await Task.sleep(for: .milliseconds(20))
+		let callCountBeforeRelease = await client.callCount()
+		XCTAssertEqual(
+			callCountBeforeRelease,
+			1,
+			"A post-effect read must queue behind the older provider process."
+		)
+
+		await client.release(call: 1)
+		try await waitForCallCount(2, client: client)
+		let maximumActiveCallCount = await client.maximumActiveCallCount()
+		XCTAssertEqual(maximumActiveCallCount, 1)
+		await client.release(call: 2)
+
+		_ = try await preEffect.value
+		_ = try await postEffect.value
+		let finalCallCount = await client.callCount()
+		let finalMaximumActiveCallCount = await client.maximumActiveCallCount()
+		XCTAssertEqual(finalCallCount, 2)
+		XCTAssertEqual(finalMaximumActiveCallCount, 1)
+	}
+
+	func testEffectBlocksFreshReadsUntilDispatchEnds() async throws {
+		let account = Self.account
+		let client = CoordinatedInventoryClient(account: account)
+		let coordinator = ResetCardInventoryReadCoordinator(client: client)
+		let preEffect = Task.detached {
+			try await coordinator.inventory(for: account)
+		}
+		try await waitForCallCount(1, client: client)
+
+		let effect = Task.detached {
+			await coordinator.beginEffect(account.accountID)
+		}
+		try await Task.sleep(for: .milliseconds(20))
+		await client.release(call: 1)
+		await effect.value
+
+		let postEffect = Task.detached {
+			try await coordinator.inventory(for: account)
+		}
+		try await Task.sleep(for: .milliseconds(20))
+		let callCountDuringEffect = await client.callCount()
+		XCTAssertEqual(
+			callCountDuringEffect,
+			1,
+			"A fresh read must wait until the use dispatch releases its effect gate."
+		)
+
+		await coordinator.endEffect(account.accountID)
+		try await waitForCallCount(2, client: client)
+		await client.release(call: 2)
+		_ = try await preEffect.value
+		_ = try await postEffect.value
+
+		let finalCallCount = await client.callCount()
+		let maximumActiveCallCount = await client.maximumActiveCallCount()
+		XCTAssertEqual(finalCallCount, 2)
+		XCTAssertEqual(maximumActiveCallCount, 1)
+	}
+
+	private func waitForCallCount(
+		_ expected: Int,
+		client: CoordinatedInventoryClient
+	) async throws {
+		for _ in 0 ..< 200 {
+			if await client.callCount() >= expected {
+				return
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+		await client.releaseAll()
+		XCTFail("Timed out waiting for provider call \(expected).")
+		throw CoordinatorTestError.timedOut
+	}
+
+	private static let authority = ResetCardAuthority(
+		profileName: "local",
+		serverID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	)
+
+	private static let account = ResetCardAccountRecord(
+		authority: authority,
+		accountID: "018f0f9e-7b6e-4a31-8f4c-1d2e3f405160",
+		alias: "Account 00000-00001",
+		accountRevision: 7,
+		enabled: true,
+		observedState: .available,
+		lifecycleReadiness: .ready,
+		fiveHourQuota: .unknown(durationMinutes: 300),
+		sevenDayQuota: .unknown(durationMinutes: 10_080)
+	)
+}
+
+private enum CoordinatorTestError: Error {
+	case timedOut
+}
+
+private actor CoordinatedInventoryClient: ResetCardClient {
+	private let account: ResetCardAccountRecord
+	private var calls = 0
+	private var activeCalls = 0
+	private var maximumActiveCalls = 0
+	private var pendingCalls = [Int: CheckedContinuation<Void, Never>]()
+
+	init(account: ResetCardAccountRecord) {
+		self.account = account
+	}
+
+	func accounts(
+		authority: ResetCardAuthority?
+	) async throws -> [ResetCardAccountRecord] {
+		[account]
+	}
+
+	func inventory(
+		for account: ResetCardAccountRecord
+	) async throws -> ResetCardInventory {
+		calls += 1
+		let call = calls
+		activeCalls += 1
+		maximumActiveCalls = max(maximumActiveCalls, activeCalls)
+		await withCheckedContinuation { continuation in
+			pendingCalls[call] = continuation
+		}
+		activeCalls -= 1
+		return ResetCardInventory(
+			authority: Self.authority(for: account),
+			accountID: account.accountID,
+			accountRevision: account.accountRevision,
+			cards: [],
+			fiveHourQuota: account.fiveHourQuota,
+			sevenDayQuota: account.sevenDayQuota,
+			observationError: nil
+		)
+	}
+
+	func use(_ attempt: ResetCardUseAttempt) async throws -> ResetCardOperationState {
+		.prepared
+	}
+
+	func status(for attempt: ResetCardUseAttempt) async throws -> ResetCardOperationState {
+		.notFound
+	}
+
+	func callCount() -> Int {
+		calls
+	}
+
+	func maximumActiveCallCount() -> Int {
+		maximumActiveCalls
+	}
+
+	func release(call: Int) {
+		pendingCalls.removeValue(forKey: call)?.resume()
+	}
+
+	func releaseAll() {
+		let continuations = pendingCalls.values
+		pendingCalls.removeAll()
+		for continuation in continuations {
+			continuation.resume()
+		}
+	}
+
+	nonisolated private static func authority(
+		for account: ResetCardAccountRecord
+	) -> ResetCardAuthority {
+		account.authority
+			?? ResetCardAuthority(
+				profileName: "local",
+				serverID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+			)
+	}
+}

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreStartupRetryTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreStartupRetryTests.swift
@@ -11,7 +11,7 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 		let expectedInventory = try Self.inventory
 		let client = ScriptedResetCardClient(
 			accountSteps: [
-				.failure(.commandFailed),
+				.failure(.transportDisconnected),
 				.failure(.service(.productStateUnavailable)),
 				.value([account]),
 			],
@@ -117,7 +117,7 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 			accountFallback: .value([updatedAccount]),
 			inventorySteps: [
 				.value(oldInventory),
-				.failure(.commandFailed),
+				.failure(.transportBackpressured),
 				.value(restoredInventory),
 			],
 			inventoryFallback: .value(restoredInventory)
@@ -136,7 +136,7 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 		XCTAssertEqual(interrupted.account.accountRevision, 8)
 		XCTAssertEqual(interrupted.inventory, oldInventory)
 		XCTAssertEqual(interrupted.fiveHourQuota, oldInventory.fiveHourQuota)
-		XCTAssertEqual(interrupted.error, .commandFailed)
+		XCTAssertEqual(interrupted.error, .transportBackpressured)
 		XCTAssertTrue(interrupted.targets.isEmpty)
 
 		await store.refresh()
@@ -186,7 +186,7 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 		defer { fixture.remove() }
 		let client = ScriptedResetCardClient(
 			accountSteps: [],
-			accountFallback: .failure(.commandFailed),
+			accountFallback: .failure(.transportDisconnected),
 			inventoryFallback: .value(try Self.inventory)
 		)
 		let store = ResetCardStore(
@@ -218,7 +218,7 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 		defer { fixture.remove() }
 		let client = ScriptedResetCardClient(
 			accountSteps: [],
-			accountFallback: .failure(.commandFailed),
+			accountFallback: .failure(.transportDisconnected),
 			inventoryFallback: .value(try Self.inventory)
 		)
 		let store = ResetCardStore(
@@ -514,6 +514,219 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 		XCTAssertNil(store.accounts.first?.error)
 	}
 
+	func testObservationFailureRetainsTheLastCompleteInventory() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let retainedInventory = try Self.inventory
+		let failedObservation = ResetCardInventory(
+			authority: Self.authority,
+			accountID: Self.account.accountID,
+			accountRevision: Self.account.accountRevision,
+			cards: [],
+			fiveHourQuota: .unknown(durationMinutes: 300),
+			sevenDayQuota: .unknown(durationMinutes: 10_080),
+			observationError: .providerUnavailable
+		)
+		let client = ScriptedResetCardClient(
+			accountSteps: [],
+			accountFallback: .value([Self.account]),
+			inventorySteps: [
+				.value(retainedInventory),
+				.value(failedObservation),
+			],
+			inventoryFallback: .value(failedObservation)
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		await store.refresh()
+		await store.refresh()
+
+		let state = try XCTUnwrap(store.accounts.first)
+		XCTAssertEqual(state.inventory, retainedInventory)
+		XCTAssertEqual(state.fiveHourQuota, retainedInventory.fiveHourQuota)
+		XCTAssertEqual(state.error, .service(.providerUnavailable))
+		XCTAssertTrue(state.targets.isEmpty)
+		XCTAssertEqual(
+			ResetCardInventoryPresentation(
+				state: state,
+				isAwaitingFreshAccountSkeleton: false
+			),
+			.updating(detail: ResetCardServiceError.providerUnavailable.presentation)
+		)
+	}
+
+	func testCompletedUseReconcilesInBackgroundAcrossTransientContention() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let retainedInventory = try Self.inventory
+		let restoredQuota = ResetCardQuotaWindow(
+			durationMinutes: 300,
+			observedAtUnixMicros: 2_000_000,
+			state: .current(
+				usedPercent: 0,
+				resetsAtUnixMicros: 4_000_000
+			)
+		)
+		let restoredInventory = ResetCardInventory(
+			authority: Self.authority,
+			accountID: Self.account.accountID,
+			accountRevision: Self.account.accountRevision,
+			cards: [],
+			fiveHourQuota: restoredQuota,
+			sevenDayQuota: retainedInventory.sevenDayQuota,
+			observationError: nil
+		)
+		let contendedObservation = ResetCardInventory(
+			authority: Self.authority,
+			accountID: Self.account.accountID,
+			accountRevision: Self.account.accountRevision,
+			cards: [],
+			fiveHourQuota: .unknown(durationMinutes: 300),
+			sevenDayQuota: .unknown(durationMinutes: 10_080),
+			observationError: .resourceExhausted
+		)
+		let client = ScriptedResetCardClient(
+			accountSteps: [],
+			accountFallback: .value([Self.account]),
+			inventorySteps: [
+				.value(retainedInventory),
+				.value(contendedObservation),
+				.value(restoredInventory),
+			],
+			inventoryFallback: .value(restoredInventory),
+			useFallback: .value(.completed(.reset))
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [],
+			postUseRetryDelays: [.milliseconds(100)]
+		)
+		await store.refresh()
+
+		let attempt = try Self.attempt
+		let completion = await store.use(attempt)
+		XCTAssertEqual(completion, ResetCardUseCompletion(resolved: true))
+		try await waitUntil {
+			store.accounts.first?.error == .service(.resourceExhausted)
+		}
+
+		let updating = try XCTUnwrap(store.accounts.first)
+		XCTAssertEqual(updating.inventory, retainedInventory)
+		XCTAssertEqual(updating.fiveHourQuota, retainedInventory.fiveHourQuota)
+		XCTAssertTrue(updating.isRefreshing)
+		XCTAssertTrue(store.blocksNewAttempt(for: attempt.target))
+		XCTAssertEqual(
+			ResetCardInventoryPresentation(
+				state: updating,
+				isAwaitingFreshAccountSkeleton: false
+			),
+			.updating(detail: ResetCardServiceError.resourceExhausted.presentation)
+		)
+
+		try await waitUntil {
+			store.accounts.first?.inventory == restoredInventory
+				&& store.accounts.first?.isRefreshing == false
+		}
+		let restored = try XCTUnwrap(store.accounts.first)
+		XCTAssertEqual(restored.fiveHourQuota, restoredQuota)
+		XCTAssertNil(restored.error)
+		let counts = await client.callCounts()
+		XCTAssertEqual(
+			counts,
+			ClientCallCounts(accounts: 1, inventory: 3, status: 0, use: 1)
+		)
+	}
+
+	func testUseWaitsForPreEffectReadAndReconciliationRemainsAuthoritative() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let retainedInventory = try Self.inventory
+		let restoredInventory = ResetCardInventory(
+			authority: Self.authority,
+			accountID: Self.account.accountID,
+			accountRevision: Self.account.accountRevision,
+			cards: [],
+			fiveHourQuota: ResetCardQuotaWindow(
+				durationMinutes: 300,
+				observedAtUnixMicros: 2_000_000,
+				state: .current(
+					usedPercent: 0,
+					resetsAtUnixMicros: 4_000_000
+				)
+			),
+			sevenDayQuota: retainedInventory.sevenDayQuota,
+			observationError: nil
+		)
+		let client = OverlappingPostUseClient(
+			account: Self.account,
+			retainedInventory: retainedInventory,
+			restoredInventory: restoredInventory,
+			preEffectFailure: .invalidResponse
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [],
+			postUseRetryDelays: []
+		)
+		await store.refresh()
+
+		let preEffectRefresh = Task {
+			await store.refresh()
+		}
+		try await waitUntil {
+			await client.isInventoryCallPending(2)
+		}
+
+		let attempt = try Self.attempt
+		let useTask = Task {
+			await store.use(attempt)
+		}
+		try await Task.sleep(for: .milliseconds(20))
+		let useCallsBeforeReadRelease = await client.useCallCount()
+		XCTAssertEqual(
+			useCallsBeforeReadRelease,
+			0,
+			"Use must wait for the older inventory provider process."
+		)
+
+		await client.releaseInventoryCall(2)
+		let completion = await useTask.value
+		XCTAssertEqual(completion, ResetCardUseCompletion(resolved: true))
+		try await waitUntil {
+			await client.isInventoryCallPending(3)
+		}
+		await preEffectRefresh.value
+
+		let afterPreEffectRead = try XCTUnwrap(store.accounts.first)
+		XCTAssertEqual(afterPreEffectRead.inventory, retainedInventory)
+		XCTAssertNil(afterPreEffectRead.error)
+		XCTAssertTrue(afterPreEffectRead.isRefreshing)
+		XCTAssertTrue(store.blocksNewAttempt(for: attempt.target))
+		XCTAssertEqual(
+			ResetCardInventoryPresentation(
+				state: afterPreEffectRead,
+				isAwaitingFreshAccountSkeleton: false
+			),
+			.updating(detail: nil)
+		)
+
+		await client.releaseInventoryCall(3)
+		try await waitUntil {
+			store.accounts.first?.inventory == restoredInventory
+				&& store.accounts.first?.isRefreshing == false
+		}
+		let maximumActiveInventoryCalls = await client.maximumActiveInventoryCalls()
+		let useOverlappedInventory = await client.didUseOverlapInventory()
+		XCTAssertEqual(maximumActiveInventoryCalls, 1)
+		XCTAssertFalse(useOverlappedInventory)
+	}
+
 	func testExplicitUseDispatchesOnlyOnce() async throws {
 		let fixture = try makePendingFixture()
 		defer { fixture.remove() }
@@ -667,6 +880,8 @@ private actor ScriptedResetCardClient: ResetCardClient {
 	private let inventoryFallback: ClientStep<ResetCardInventory>
 	private var statusSteps: [ClientStep<ResetCardOperationState>]
 	private let statusFallback: ClientStep<ResetCardOperationState>
+	private var useSteps: [ClientStep<ResetCardOperationState>]
+	private let useFallback: ClientStep<ResetCardOperationState>
 	private let requiredInventoryAuthority: ResetCardAuthority?
 	private var counts = ClientCallCounts(accounts: 0, inventory: 0, status: 0, use: 0)
 	private var requestedAccountAuthorities = [ResetCardAuthority?]()
@@ -678,6 +893,8 @@ private actor ScriptedResetCardClient: ResetCardClient {
 		inventoryFallback: ClientStep<ResetCardInventory>,
 		statusSteps: [ClientStep<ResetCardOperationState>] = [],
 		statusFallback: ClientStep<ResetCardOperationState> = .value(.notFound),
+		useSteps: [ClientStep<ResetCardOperationState>] = [],
+		useFallback: ClientStep<ResetCardOperationState> = .value(.prepared),
 		requiredInventoryAuthority: ResetCardAuthority? = nil
 	) {
 		self.accountSteps = accountSteps
@@ -686,6 +903,8 @@ private actor ScriptedResetCardClient: ResetCardClient {
 		self.inventoryFallback = inventoryFallback
 		self.statusSteps = statusSteps
 		self.statusFallback = statusFallback
+		self.useSteps = useSteps
+		self.useFallback = useFallback
 		self.requiredInventoryAuthority = requiredInventoryAuthority
 	}
 
@@ -740,7 +959,9 @@ private actor ScriptedResetCardClient: ResetCardClient {
 			status: counts.status,
 			use: counts.use + 1
 		)
-		return .prepared
+		return try Self.resolve(
+			useSteps.isEmpty ? useFallback : useSteps.removeFirst()
+		)
 	}
 
 	func callCounts() -> ClientCallCounts {
@@ -760,6 +981,88 @@ private actor ScriptedResetCardClient: ResetCardClient {
 		case .failure(let error):
 			throw error
 		}
+	}
+}
+
+private actor OverlappingPostUseClient: ResetCardClient {
+	private let account: ResetCardAccountRecord
+	private let retainedInventory: ResetCardInventory
+	private let restoredInventory: ResetCardInventory
+	private let preEffectFailure: ResetCardClientError?
+	private var inventoryCalls = 0
+	private var activeInventoryCalls = 0
+	private var maximumActiveCalls = 0
+	private var useCalls = 0
+	private var useOverlappedInventory = false
+	private var pendingInventoryCalls = [
+		Int: CheckedContinuation<Void, Never>
+	]()
+
+	init(
+		account: ResetCardAccountRecord,
+		retainedInventory: ResetCardInventory,
+		restoredInventory: ResetCardInventory,
+		preEffectFailure: ResetCardClientError? = nil
+	) {
+		self.account = account
+		self.retainedInventory = retainedInventory
+		self.restoredInventory = restoredInventory
+		self.preEffectFailure = preEffectFailure
+	}
+
+	func accounts(
+		authority: ResetCardAuthority?
+	) async throws -> [ResetCardAccountRecord] {
+		[account]
+	}
+
+	func inventory(
+		for account: ResetCardAccountRecord
+	) async throws -> ResetCardInventory {
+		inventoryCalls += 1
+		let call = inventoryCalls
+		activeInventoryCalls += 1
+		maximumActiveCalls = max(maximumActiveCalls, activeInventoryCalls)
+		if call > 1 {
+			await withCheckedContinuation { continuation in
+				pendingInventoryCalls[call] = continuation
+			}
+		}
+		activeInventoryCalls -= 1
+		if call == 2, let preEffectFailure {
+			throw preEffectFailure
+		}
+		return call < 3 ? retainedInventory : restoredInventory
+	}
+
+	func use(_ attempt: ResetCardUseAttempt) async throws -> ResetCardOperationState {
+		useCalls += 1
+		useOverlappedInventory = activeInventoryCalls > 0
+		return .completed(.reset)
+	}
+
+	func status(for attempt: ResetCardUseAttempt) async throws -> ResetCardOperationState {
+		.notFound
+	}
+
+	func isInventoryCallPending(_ call: Int) -> Bool {
+		pendingInventoryCalls[call] != nil
+	}
+
+	func releaseInventoryCall(_ call: Int) {
+		pendingInventoryCalls.removeValue(forKey: call)?.resume()
+	}
+
+	func maximumActiveInventoryCalls() -> Int {
+		maximumActiveCalls
+	}
+
+	func useCallCount() -> Int {
+		useCalls
+	}
+
+	func didUseOverlapInventory() -> Bool {
+		useOverlappedInventory
 	}
 }
 

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -213,10 +213,14 @@ decodex-publisher validate-social
   checking state. During that reconciliation, the app keeps the last quota visible
   but does not expose Reset Cards from the old account revision. It holds an
   advanced inventory until the matching account skeleton arrives and then applies
-  it without a duplicate provider read. A retryable detail-read failure shows a
-  compact reconnecting state while the retained quota remains visible. The next
-  current inventory replaces the retained value directly, so the quota bar can
-  animate to the restored value.
+  it without a duplicate provider read. One per-account coordinator coalesces
+  same-revision inventory calls. A use gate waits for any older provider read and
+  blocks fresh reads until the effect dispatch ends. A terminal use result starts
+  bounded background reconciliation without holding the button busy. Internal contention, provider
+  cleanup, and other retryable detail failures show `Updating usage…` while the
+  retained quota remains visible. Only a typed local daemon transport loss shows
+  `Connecting to Decodex…`. The next current inventory replaces the retained value
+  directly, so the quota bar can animate to the restored value.
 - Uses an in-process Rust protocol client for active vNext account, profile, Reset Card,
   routing, Codex projection, and Fast requests. The app does not start the CLI, a
   service, or a credential helper, and Swift does not inject credentials. Operators


### PR DESCRIPTION
## Summary

- serialize per-account Reset Card inventory reads with use dispatch so provider processes cannot overlap
- keep the last authoritative quota visible and reconcile terminal use results in the background with bounded retries
- distinguish internal updating and service contention from verified daemon transport loss
- add overlap, retry, retained-quota, and presentation regression coverage

## Validation

- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app -c release (192 tests)
- scripts/macos/test_decodex_app_stage.sh
- codesign --verify --deep --strict target/decodex-app/Decodex.app