### PR TITLE
Add account card reordering and panel appearance controls

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -57,15 +57,17 @@ The panel uses compact individual material cards with transparent gaps and
 shows every account when they fit on the active display. On shorter displays,
 the account list remains scrollable without a persistent scroll indicator.
 The header and aggregate overview share one compact appearance-adaptive
-frosted-material surface. Each account row uses its own separate system material
-surface with no opaque custom fill or drawn border.
+surface. The overflow menu stores one panel-wide card material preference. It
+defaults to `Thin`, or the operator can select the system `Liquid Glass` effect.
+Each account row uses its own separate surface with no opaque custom fill or drawn
+border.
 Primary cards use one shared compact spacing rhythm and identical content insets.
 Popovers and floating login recovery use one larger shared inset.
 The host window follows the system Light or Dark appearance and does not draw
 its own full-window shadow or backdrop. Login recovery uses a stronger floating
 material inside that same transparent window, without a window-wide modal dimmer.
 Transparent gaps remain visible; there is no background surface around the
-complete panel and no Liquid Glass effect.
+complete panel.
 
 The app never identifies an account from its alias or vector position. The
 daemon derives a stable credential-negative one-word alias. The row displays
@@ -120,6 +122,22 @@ the fixed Decodex route. The underlying typed commands remain independently
 fenced, and retrying the control completes whichever step is not current. The
 Fast control updates only the current Codex `[features].fast_mode` preference
 through the in-process native client.
+The overflow menu contains only `Refresh all`, the material selector, and Quit.
+`Refresh all` remains available while an automatic read is in progress because
+the store coalesces that request into the active refresh cycle. Account mutations
+and Reset Card submissions still disable it.
+
+Each account card reveals one compact trailing-edge reorder grip while the pointer
+is over that card. The grip overlays the card padding instead of reserving a layout
+column. Dragging uses the list's stable coordinate space, keeps the complete card
+at its original size and horizontal position, and moves it only on the vertical
+track. When it crosses an adjacent card's center, that card springs into the open
+slot. On release, the dragged card springs into its final slot, then the app sends
+one complete `set_account_order` command with the current routing revision. The
+card order follows the daemon result. A rejected command restores the last
+authoritative order. The grip also provides Move up and Move down accessibility
+actions through the same command path. The app does not save a separate local
+account order.
 
 The app is intentionally menu-bar-only and uses the accessory activation
 policy. It does not own daemon startup or credential persistence.

--- a/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
@@ -271,6 +271,13 @@ protocol AccountControlClient: ResetCardClient {
 		idempotencyKey: String
 	) async throws -> AccountControlResult
 
+	func setAccountOrder(
+		authority: ResetCardAuthority?,
+		order: [String],
+		expectedRoutingRevision: UInt64,
+		idempotencyKey: String
+	) async throws -> AccountControlResult
+
 	func refreshAccountCredentials(
 		authority: ResetCardAuthority?,
 		operationID: String,
@@ -518,6 +525,33 @@ extension DecodexNativeClient: AccountControlClient {
 			),
 			authority: authority,
 			expected: .routing(mode: .balanced)
+		)
+	}
+
+	func setAccountOrder(
+		authority: ResetCardAuthority?,
+		order: [String],
+		expectedRoutingRevision: UInt64,
+		idempotencyKey: String
+	) async throws -> AccountControlResult {
+		guard authority.map(Self.isValidAuthority) ?? true,
+			expectedRoutingRevision > 0,
+			order.count <= 512,
+			order.allSatisfy(Self.isCanonicalAccountID),
+			Set(order).count == order.count,
+			Self.isCanonicalUUID(idempotencyKey)
+		else {
+			throw AccountControlError.invalidInput
+		}
+		return try await executeAccountControl(
+			request: DecodexNativeRequest(
+				operation: "set_account_order",
+				expectedRoutingRevision: expectedRoutingRevision,
+				order: order,
+				idempotencyKey: idempotencyKey
+			),
+			authority: authority,
+			expected: .routingOrder(order)
 		)
 	}
 
@@ -770,6 +804,7 @@ private enum AccountControlExpectedResult {
 	case accountChanged(accountID: String, enabled: Bool?)
 	case accountLoggedOut(accountID: String)
 	case routing(mode: AccountRoutingMode)
+	case routingOrder([String])
 	case codexAuthProjected(accountID: String, accountRevision: UInt64)
 }
 
@@ -1040,6 +1075,12 @@ private enum AccountControlResultPayloadWire: Decodable {
 		case (.routingChanged(let wire), .routing(let expectedMode)):
 			let routing = wire.routing
 			guard routing.revision == entityRevision, routing.mode == expectedMode else {
+				throw AccountControlError.invalidResponse
+			}
+			return .routingChanged(routing)
+		case (.routingChanged(let wire), .routingOrder(let expectedOrder)):
+			let routing = wire.routing
+			guard routing.revision == entityRevision, routing.order == expectedOrder else {
 				throw AccountControlError.invalidResponse
 			}
 			return .routingChanged(routing)

--- a/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
@@ -34,7 +34,7 @@ struct AccountPrimaryActionsView: View {
 	let store: ResetCardStore
 
 	var body: some View {
-		HStack(spacing: PanelSpacing.compact) {
+		HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.compact) {
 			CompactAccountActionButton(
 				title: presentation.isCurrent ? "Routed" : "Route",
 				symbol: presentation.isCurrent
@@ -253,7 +253,7 @@ private struct CompactAccountActionButton: View {
 			action()
 		} label: {
 			ZStack {
-				HStack(spacing: PanelSpacing.compact) {
+				HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.compact) {
 					Image(systemName: symbol)
 						.contentTransition(.symbolEffect(.replace))
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
@@ -99,6 +99,91 @@ enum AccountPrivacy {
 	static let visible = "visible"
 }
 
+enum AccountCardReorderLayout {
+	static let coordinateSpaceName = "decodex.account-reorder-list"
+
+	static func constrainedTranslationY(
+		for accountID: String,
+		baseOrder: [String],
+		frames: [String: CGRect],
+		proposed: CGFloat
+	) -> CGFloat {
+		guard proposed.isFinite,
+			let draggedFrame = frames[accountID],
+			let firstID = baseOrder.first,
+			let firstFrame = frames[firstID],
+			let lastID = baseOrder.last,
+			let lastFrame = frames[lastID]
+		else {
+			return 0
+		}
+		return min(
+			max(proposed, firstFrame.minY - draggedFrame.minY),
+			lastFrame.maxY - draggedFrame.maxY
+		)
+	}
+
+	static func reorderedAccountIDs(
+		dragging accountID: String,
+		baseOrder: [String],
+		frames: [String: CGRect],
+		translationY: CGFloat
+	) -> [String] {
+		guard let draggedFrame = frames[accountID],
+			baseOrder.contains(accountID),
+			baseOrder.allSatisfy({ frames[$0] != nil })
+		else {
+			return baseOrder
+		}
+
+		let draggedCenter = draggedFrame.midY + translationY
+		let remaining = baseOrder.filter { $0 != accountID }
+		let insertionIndex = remaining.prefix { otherID in
+			guard let otherFrame = frames[otherID] else {
+				return false
+			}
+			if translationY > 0 {
+				return otherFrame.midY <= draggedCenter
+			}
+			return otherFrame.midY < draggedCenter
+		}.count
+
+		var reordered = remaining
+		reordered.insert(accountID, at: insertionIndex)
+		return reordered
+	}
+
+	static func verticalOffset(
+		for accountID: String,
+		baseOrder: [String],
+		visualOrder: [String],
+		frames: [String: CGRect],
+		spacing: CGFloat
+	) -> CGFloat {
+		guard visualOrder.count == baseOrder.count,
+			Set(visualOrder) == Set(baseOrder),
+			let originalFrame = frames[accountID],
+			let firstID = baseOrder.first,
+			let firstFrame = frames[firstID],
+			baseOrder.allSatisfy({ frames[$0] != nil })
+		else {
+			return 0
+		}
+
+		var projectedMinY = firstFrame.minY
+		for orderedID in visualOrder {
+			guard let frame = frames[orderedID] else {
+				return 0
+			}
+			if orderedID == accountID {
+				return projectedMinY - originalFrame.minY
+			}
+			projectedMinY += frame.height + spacing
+		}
+		return 0
+	}
+}
+
 struct AccountIdentityPresentation: Equatable, Sendable {
 	let text: String
 	let showsEmail: Bool
@@ -124,5 +209,16 @@ struct AccountRowsHeightPreferenceKey: PreferenceKey {
 		if next > 0 {
 			value = next
 		}
+	}
+}
+
+struct AccountCardFramesPreferenceKey: PreferenceKey {
+	static let defaultValue = [String: CGRect]()
+
+	static func reduce(
+		value: inout [String: CGRect],
+		nextValue: () -> [String: CGRect]
+	) {
+		value.merge(nextValue()) { _, newFrame in newFrame }
 	}
 }

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -1,6 +1,16 @@
 import AppKit
 import SwiftUI
 
+private struct AccountReorderInteraction {
+	let token = UUID()
+	let accountID: String
+	let baseOrder: [String]
+	var visualOrder: [String]
+	let frames: [String: CGRect]
+	var draggedOffsetY: CGFloat
+	var isSettling = false
+}
+
 struct AccountPanelView: View {
 	let store: ResetCardStore
 	private let layoutVisibleFrameOverride: CGRect?
@@ -9,10 +19,13 @@ struct AccountPanelView: View {
 	@Environment(\.colorScheme) private var colorScheme
 	@State private var panelScreenVisibleFrame: CGRect?
 	@State private var measuredAccountListContentHeight: CGFloat = 0
+	@State private var accountCardFrames = [String: CGRect]()
+	@State private var accountReorderInteraction: AccountReorderInteraction?
 	@State private var isPresentingEnrollment = false
 	@State private var detailedAccountID: String?
 	@State private var fastMode: FastModeStore
 	@AppStorage("decodex.operator.accountPrivacy") private var accountPrivacy = AccountPrivacy.hidden
+	@AppStorage(PanelCardMaterial.storageKey) private var panelCardMaterialRawValue = PanelCardMaterial.thin.rawValue
 
 	init(
 		store: ResetCardStore,
@@ -27,22 +40,25 @@ struct AccountPanelView: View {
 	}
 
 	var body: some View {
-		ZStack {
-			panelContent
-				.disabled(store.accountReauthentication != nil)
-				.allowsHitTesting(store.accountReauthentication == nil)
-				.accessibilityHidden(store.accountReauthentication != nil)
+		GlassEffectContainer(spacing: 0) {
+			ZStack {
+				panelContent
+					.disabled(store.accountReauthentication != nil)
+					.allowsHitTesting(store.accountReauthentication == nil)
+					.accessibilityHidden(store.accountReauthentication != nil)
 
-			if store.accountReauthentication != nil {
-				reauthenticationOverlay
-					.transition(
-						.opacity.combined(
-							with: .scale(scale: 0.98, anchor: .center)
+				if store.accountReauthentication != nil {
+					reauthenticationOverlay
+						.transition(
+							.opacity.combined(
+								with: .scale(scale: 0.98, anchor: .center)
+							)
 						)
-					)
-					.zIndex(1)
+						.zIndex(1)
+				}
 			}
 		}
+		.environment(\.panelCardMaterial, panelCardMaterial)
 		.frame(width: AccountPanelLayout.panelWidth)
 		.padding(PanelSpacing.related)
 		.controlSize(.small)
@@ -90,6 +106,17 @@ struct AccountPanelView: View {
 			}
 			store.dismissMessage()
 		}
+	}
+
+	private var panelCardMaterial: PanelCardMaterial {
+		PanelCardMaterial(rawValue: panelCardMaterialRawValue) ?? .thin
+	}
+
+	private var panelCardMaterialSelection: Binding<PanelCardMaterial> {
+		Binding(
+			get: { panelCardMaterial },
+			set: { panelCardMaterialRawValue = $0.rawValue }
+		)
 	}
 
 	private var panelContent: some View {
@@ -197,47 +224,19 @@ struct AccountPanelView: View {
 			)
 
 			Menu {
-				Button(
-					accountPrivacy == AccountPrivacy.hidden
-						? "Show email addresses"
-						: "Hide email addresses"
-				) {
-					accountPrivacy =
-						accountPrivacy == AccountPrivacy.hidden
-						? AccountPrivacy.visible
-						: AccountPrivacy.hidden
-				}
-
-				Button(fastMode.isEnabled ? "Turn Fast mode off" : "Turn Fast mode on") {
-					Task {
-						await fastMode.toggle()
-					}
-				}
-				.disabled(fastMode.isLoading)
-
 				Button("Refresh all") {
-					Task {
-						await store.refresh()
-					}
+					store.requestRefresh()
 				}
 				.disabled(
-					store.isRefreshing
-						|| store.isRefreshingAccountSkeleton
-						|| store.isAccountControlInProgress
+					store.isAccountControlInProgress
 						|| store.submittingKey != nil
 				)
 
-				if case .fixed = store.routing?.mode {
-					Button("Use balanced routing") {
-						Task {
-							await store.selectBalancedAccounts()
-						}
+				Picker("Material", selection: panelCardMaterialSelection) {
+					ForEach(PanelCardMaterial.allCases) { material in
+						Text(material.title)
+							.tag(material)
 					}
-					.disabled(
-						store.canPerformDirectAccountControl == false
-							|| store.isRoutingAccountControl
-							|| store.submittingKey != nil
-					)
 				}
 
 				Divider()
@@ -344,17 +343,48 @@ struct AccountPanelView: View {
 		} else {
 			ScrollView(.vertical, showsIndicators: false) {
 				VStack(alignment: .leading, spacing: PanelSpacing.section) {
-					ForEach(store.accounts) { state in
+					ForEach(presentedAccountStates) { state in
 						ResetCardAccountRow(
 							state: state,
 							store: store,
 							showsEmail: accountPrivacy == AccountPrivacy.visible,
-							detailedAccountID: $detailedAccountID
+							detailedAccountID: $detailedAccountID,
+							isReorderGestureEnabled: canDragAccount(state.id),
+							onReorderDragChanged: { translationY in
+								updateAccountReorder(
+									accountID: state.id,
+									translationY: translationY
+								)
+							},
+							onReorderDragEnded: {
+								finishAccountReorder(accountID: state.id)
+							}
 						)
 						.panelCardSurface(cornerRadius: 16)
+						.background {
+							GeometryReader { proxy in
+								Color.clear.preference(
+									key: AccountCardFramesPreferenceKey.self,
+									value: [
+										state.id: proxy.frame(
+											in: .named(
+												AccountCardReorderLayout.coordinateSpaceName
+											)
+										)
+									]
+								)
+							}
+						}
+						.offset(y: accountReorderOffset(for: state.id))
+						.zIndex(isDraggedAccount(state.id) ? 1 : 0)
+						.animation(
+							accountReorderAnimation(for: state.id),
+							value: accountReorderOffset(for: state.id)
+						)
 						.transition(.panelSection)
 					}
 				}
+				.coordinateSpace(name: AccountCardReorderLayout.coordinateSpaceName)
 				.padding(1)
 				.background(accountRowsHeightProbe)
 			}
@@ -367,8 +397,177 @@ struct AccountPanelView: View {
 					measuredAccountListContentHeight = measuredHeight
 				}
 			}
+			.onPreferenceChange(AccountCardFramesPreferenceKey.self) { frames in
+				updateAccountCardFrames(frames)
+			}
 			.accessibilityLabel("Decodex accounts")
 		}
+	}
+
+	private var presentedAccountStates: [ResetCardAccountState] {
+		guard let interaction = accountReorderInteraction else {
+			return store.accounts
+		}
+		let stateByID = Dictionary(
+			uniqueKeysWithValues: store.accounts.map { ($0.id, $0) }
+		)
+		let states = interaction.baseOrder.compactMap { stateByID[$0] }
+		return states.count == store.accounts.count ? states : store.accounts
+	}
+
+	private func updateAccountCardFrames(_ frames: [String: CGRect]) {
+		guard accountReorderInteraction == nil else {
+			return
+		}
+		let accountIDs = Set(store.accounts.map(\.id))
+		let currentFrames = frames.filter { accountIDs.contains($0.key) }
+		if accountCardFrames != currentFrames {
+			accountCardFrames = currentFrames
+		}
+	}
+
+	private func canDragAccount(_ accountID: String) -> Bool {
+		guard store.canReorderAccounts else {
+			return false
+		}
+		guard let interaction = accountReorderInteraction else {
+			return true
+		}
+		return interaction.accountID == accountID
+			&& interaction.isSettling == false
+	}
+
+	private func updateAccountReorder(
+		accountID: String,
+		translationY: CGFloat
+	) {
+		if accountReorderInteraction == nil {
+			let baseOrder = store.accounts.map(\.id)
+			guard store.canReorderAccounts,
+				baseOrder.contains(accountID),
+				baseOrder.allSatisfy({ accountCardFrames[$0] != nil })
+			else {
+				return
+			}
+			accountReorderInteraction = AccountReorderInteraction(
+				accountID: accountID,
+				baseOrder: baseOrder,
+				visualOrder: baseOrder,
+				frames: accountCardFrames,
+				draggedOffsetY: 0
+			)
+		}
+
+		guard var interaction = accountReorderInteraction,
+			interaction.accountID == accountID,
+			interaction.isSettling == false
+		else {
+			return
+		}
+		let constrainedTranslation = AccountCardReorderLayout.constrainedTranslationY(
+			for: accountID,
+			baseOrder: interaction.baseOrder,
+			frames: interaction.frames,
+			proposed: translationY
+		)
+		interaction.draggedOffsetY = constrainedTranslation
+		interaction.visualOrder = AccountCardReorderLayout.reorderedAccountIDs(
+			dragging: accountID,
+			baseOrder: interaction.baseOrder,
+			frames: interaction.frames,
+			translationY: constrainedTranslation
+		)
+		accountReorderInteraction = interaction
+	}
+
+	private func finishAccountReorder(accountID: String) {
+		guard var interaction = accountReorderInteraction,
+			interaction.accountID == accountID,
+			interaction.isSettling == false
+		else {
+			return
+		}
+		interaction.isSettling = true
+		interaction.draggedOffsetY = AccountCardReorderLayout.verticalOffset(
+			for: accountID,
+			baseOrder: interaction.baseOrder,
+			visualOrder: interaction.visualOrder,
+			frames: interaction.frames,
+			spacing: PanelSpacing.section
+		)
+		accountReorderInteraction = interaction
+
+		let token = interaction.token
+		let finalOrder = interaction.visualOrder
+		let targetAccountID = accountIDAfter(
+			accountID,
+			in: finalOrder
+		)
+		Task {
+			if reduceMotion == false {
+				try? await Task.sleep(for: .milliseconds(240))
+			}
+			guard Task.isCancelled == false,
+				accountReorderInteraction?.token == token
+			else {
+				return
+			}
+			if finalOrder != interaction.baseOrder {
+				await store.moveAccounts(
+					[accountID],
+					before: targetAccountID
+				)
+			}
+			guard accountReorderInteraction?.token == token else {
+				return
+			}
+			accountReorderInteraction = nil
+		}
+	}
+
+	private func accountIDAfter(
+		_ accountID: String,
+		in order: [String]
+	) -> String? {
+		guard let index = order.firstIndex(of: accountID),
+			order.indices.contains(index + 1)
+		else {
+			return nil
+		}
+		return order[index + 1]
+	}
+
+	private func accountReorderOffset(for accountID: String) -> CGFloat {
+		guard let interaction = accountReorderInteraction else {
+			return 0
+		}
+		if interaction.accountID == accountID {
+			return interaction.draggedOffsetY
+		}
+		return AccountCardReorderLayout.verticalOffset(
+			for: accountID,
+			baseOrder: interaction.baseOrder,
+			visualOrder: interaction.visualOrder,
+			frames: interaction.frames,
+			spacing: PanelSpacing.section
+		)
+	}
+
+	private func isDraggedAccount(_ accountID: String) -> Bool {
+		accountReorderInteraction?.accountID == accountID
+	}
+
+	private func accountReorderAnimation(for accountID: String) -> Animation? {
+		guard reduceMotion == false else {
+			return nil
+		}
+		if let interaction = accountReorderInteraction,
+			interaction.accountID == accountID,
+			interaction.isSettling == false
+		{
+			return nil
+		}
+		return PanelMotion.accountReorder
 	}
 
 	private var accountListContentHeight: CGFloat {

--- a/apps/decodex-app/Sources/DecodexApp/DecodexNativeClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexNativeClient.swift
@@ -17,6 +17,7 @@ struct DecodexNativeRequest: Encodable, Sendable {
 	var expectedRevision: UInt64? = nil
 	var expectedAccountRevision: UInt64? = nil
 	var expectedRoutingRevision: UInt64? = nil
+	var order: [String]? = nil
 	var idempotencyKey: String? = nil
 	var operationID: String? = nil
 	var sessionID: String? = nil
@@ -33,6 +34,7 @@ struct DecodexNativeRequest: Encodable, Sendable {
 		case expectedRevision = "expected_revision"
 		case expectedAccountRevision = "expected_account_revision"
 		case expectedRoutingRevision = "expected_routing_revision"
+		case order
 		case idempotencyKey = "idempotency_key"
 		case operationID = "operation_id"
 		case sessionID = "session_id"

--- a/apps/decodex-app/Sources/DecodexApp/PanelCardSurface.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelCardSurface.swift
@@ -1,23 +1,59 @@
 import SwiftUI
 
+enum PanelCardMaterial: String, CaseIterable, Identifiable, Sendable {
+	static let storageKey = "decodex.operator.panelCardMaterial"
+
+	case thin
+	case liquidGlass = "liquid-glass"
+
+	var id: Self { self }
+
+	var title: String {
+		switch self {
+		case .thin:
+			"Thin"
+		case .liquidGlass:
+			"Liquid Glass"
+		}
+	}
+}
+
+private struct PanelCardMaterialKey: EnvironmentKey {
+	static let defaultValue = PanelCardMaterial.thin
+}
+
+extension EnvironmentValues {
+	var panelCardMaterial: PanelCardMaterial {
+		get { self[PanelCardMaterialKey.self] }
+		set { self[PanelCardMaterialKey.self] = newValue }
+	}
+}
+
 struct PanelCardSurfaceModifier: ViewModifier {
 	@Environment(\.colorScheme) private var colorScheme
+	@Environment(\.panelCardMaterial) private var panelCardMaterial
 	let cornerRadius: CGFloat
 
 	@ViewBuilder
 	func body(content: Content) -> some View {
 		let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
 
-		content
-			.background {
-				shape.fill(.thinMaterial)
-			}
-			.shadow(
-				color: Color.black.opacity(colorScheme == .dark ? 0.14 : 0.07),
-				radius: 3,
-				x: 0,
-				y: 1
-			)
+		switch panelCardMaterial {
+		case .thin:
+			content
+				.background {
+					shape.fill(.thinMaterial)
+				}
+				.shadow(
+					color: Color.black.opacity(colorScheme == .dark ? 0.14 : 0.07),
+					radius: 3,
+					x: 0,
+					y: 1
+				)
+		case .liquidGlass:
+			content
+				.glassEffect(.regular, in: shape)
+		}
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/PanelSupport.swift
@@ -18,6 +18,7 @@ enum PanelSpacing {
 enum PanelMotion {
 	static let press = Animation.easeOut(duration: 0.08)
 	static let panelLayout = Animation.interactiveSpring(response: 0.3, dampingFraction: 0.92, blendDuration: 0.05)
+	static let accountReorder = Animation.interactiveSpring(response: 0.24, dampingFraction: 0.88, blendDuration: 0.03)
 	static let controlState = Animation.easeInOut(duration: 0.16)
 	static let identity = Animation.easeInOut(duration: 0.2)
 	static let quotaValue = Animation.easeOut(duration: 0.46)

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -188,27 +188,39 @@ struct ResetCardAccountRow: View {
 	let state: ResetCardAccountState
 	let store: ResetCardStore
 	let showsEmail: Bool
+	let isReorderGestureEnabled: Bool
+	let onReorderDragChanged: (CGFloat) -> Void
+	let onReorderDragEnded: () -> Void
 	@Binding private var detailedAccountID: String?
 	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.colorScheme) private var colorScheme
 	@State private var confirmation = ResetCardUseConfirmation()
 	@State private var confirmationSecondsRemaining = 0
+	@State private var isAccountCardHovered = false
+	@State private var isReorderHandleHovered = false
+	@State private var isReorderHandleDragging = false
 
 	init(
 		state: ResetCardAccountState,
 		store: ResetCardStore,
 		showsEmail: Bool = false,
-		detailedAccountID: Binding<String?> = .constant(nil)
+		detailedAccountID: Binding<String?> = .constant(nil),
+		isReorderGestureEnabled: Bool = true,
+		onReorderDragChanged: @escaping (CGFloat) -> Void = { _ in },
+		onReorderDragEnded: @escaping () -> Void = {}
 	) {
 		self.state = state
 		self.store = store
 		self.showsEmail = showsEmail
+		self.isReorderGestureEnabled = isReorderGestureEnabled
+		self.onReorderDragChanged = onReorderDragChanged
+		self.onReorderDragEnded = onReorderDragEnded
 		_detailedAccountID = detailedAccountID
 	}
 
 	var body: some View {
 		VStack(alignment: .leading, spacing: PanelSpacing.compact) {
-			HStack(alignment: .center, spacing: PanelSpacing.compact) {
+			HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.compact) {
 				identityHeader
 				AccountPrimaryActionsView(
 					state: state,
@@ -235,9 +247,17 @@ struct ResetCardAccountRow: View {
 				)
 			}
 		}
+		.frame(maxWidth: .infinity, alignment: .leading)
 		.padding(.horizontal, PanelSpacing.cardHorizontal)
 		.padding(.vertical, PanelSpacing.cardVertical)
+		.overlay(alignment: .trailing) {
+			reorderHandle
+				.offset(x: -PanelSpacing.micro)
+		}
 		.fixedSize(horizontal: false, vertical: true)
+		.onHover { isHovered in
+			isAccountCardHovered = isHovered
+		}
 		.accessibilityIdentifier("decodex.account.\(state.account.accountID)")
 		.onAppear {
 			confirmation.retainOnly(Set(state.targets))
@@ -254,6 +274,99 @@ struct ResetCardAccountRow: View {
 		}
 		.animation(rowStateAnimation, value: exceptionalStatusText)
 		.animation(rowStateAnimation, value: inventoryPresentation)
+		.animation(rowStateAnimation, value: showsReorderHandle)
+		.animation(rowStateAnimation, value: isReorderHandleHovered)
+	}
+
+	private var reorderHandle: some View {
+		ZStack {
+			RoundedRectangle(cornerRadius: 5, style: .continuous)
+				.frame(width: 14, height: 18)
+				.foregroundStyle(
+					isReorderHandleHovered
+						? PanelPalette.actionBlue(colorScheme).opacity(0.15)
+						: PanelPalette.primaryText(colorScheme).opacity(
+							colorScheme == .dark ? 0.08 : 0.055
+						)
+				)
+
+			Image(systemName: "line.3.horizontal")
+				.font(.system(size: 9, weight: .semibold))
+				.foregroundStyle(
+					isReorderHandleHovered
+						? PanelPalette.actionBlue(colorScheme)
+						: PanelPalette.secondaryText(colorScheme).opacity(0.68)
+				)
+		}
+			.frame(width: 18, height: 28)
+			.opacity(showsReorderHandle ? 1 : 0)
+			.contentShape(Rectangle())
+			.highPriorityGesture(
+				DragGesture(
+					minimumDistance: 1,
+					coordinateSpace: .named(
+						AccountCardReorderLayout.coordinateSpaceName
+					)
+				)
+					.onChanged { value in
+						isReorderHandleDragging = true
+						onReorderDragChanged(value.translation.height)
+					}
+					.onEnded { _ in
+						isReorderHandleDragging = false
+						onReorderDragEnded()
+					}
+			)
+			.allowsHitTesting(
+				store.canReorderAccounts && isReorderGestureEnabled
+			)
+			.onHover { isHovered in
+				isReorderHandleHovered = isHovered
+			}
+			.help("Drag to reorder accounts")
+			.accessibilityElement()
+			.accessibilityLabel("Reorder \(identity.text)")
+			.accessibilityValue(reorderAccessibilityValue)
+			.accessibilityHint("Drag to change the account routing order.")
+			.accessibilityHidden(store.canReorderAccounts == false)
+			.accessibilityAction(named: Text("Move up")) {
+				moveAccount(by: -1)
+			}
+			.accessibilityAction(named: Text("Move down")) {
+				moveAccount(by: 1)
+			}
+	}
+
+	private var showsReorderHandle: Bool {
+		store.canReorderAccounts
+			&& (
+				(isAccountCardHovered && isReorderGestureEnabled)
+					|| isReorderHandleDragging
+			)
+	}
+
+	private var reorderAccessibilityValue: String {
+		guard let index = store.accounts.firstIndex(where: {
+			$0.account.accountID == state.account.accountID
+		}) else {
+			return ""
+		}
+		return "Position \(index + 1) of \(store.accounts.count)"
+	}
+
+	private func moveAccount(by offset: Int) {
+		guard store.canReorderAccounts,
+			let index = store.accounts.firstIndex(where: {
+				$0.account.accountID == state.account.accountID
+			}),
+			store.accounts.indices.contains(index + offset)
+		else {
+			return
+		}
+		let targetAccountID = store.accounts[index + offset].account.accountID
+		Task {
+			await store.moveAccount(state.account.accountID, onto: targetAccountID)
+		}
 	}
 
 	private var identityHeader: some View {

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -387,6 +387,20 @@ final class ResetCardStore {
 			&& isAccountControlInProgress == false
 	}
 
+	var canReorderAccounts: Bool {
+		guard let routing else {
+			return false
+		}
+		let accountIDs = accounts.map { $0.account.accountID }
+		return accountControlClient != nil
+			&& accountIDs.count > 1
+			&& accountIDs.count == routing.order.count
+			&& Set(accountIDs) == Set(routing.order)
+			&& canPerformDirectAccountControl
+			&& isAccountControlInProgress == false
+			&& submittingKey == nil
+	}
+
 	func blocksNewAttempt(for target: ResetCardUseTarget) -> Bool {
 		isPendingRecoveryBlocked
 			|| submittingKey != nil
@@ -1179,6 +1193,100 @@ final class ResetCardStore {
 				)
 			}
 		)
+	}
+
+	func moveAccount(_ accountID: String, onto targetAccountID: String) async {
+		guard canReorderAccounts,
+			accountID != targetAccountID,
+			let routing,
+			let accountControlClient,
+			let sourceIndex = routing.order.firstIndex(of: accountID),
+			let targetIndex = routing.order.firstIndex(of: targetAccountID)
+		else {
+			return
+		}
+
+		var order = routing.order
+		order.remove(at: sourceIndex)
+		guard let retainedTargetIndex = order.firstIndex(of: targetAccountID) else {
+			return
+		}
+		let insertionIndex = sourceIndex < targetIndex
+			? retainedTargetIndex + 1
+			: retainedTargetIndex
+		order.insert(accountID, at: insertionIndex)
+		guard reorderAccountStates(to: order) else {
+			return
+		}
+		await persistAccountOrder(
+			order,
+			replacing: routing,
+			using: accountControlClient
+		)
+	}
+
+	func moveAccounts(
+		_ accountIDs: [String],
+		before targetAccountID: String?
+	) async {
+		guard canReorderAccounts,
+			let routing,
+			let accountControlClient,
+			accountIDs.isEmpty == false
+		else {
+			return
+		}
+		let movingIDs = Set(accountIDs)
+		guard movingIDs.count == accountIDs.count,
+			movingIDs.isSubset(of: Set(routing.order)),
+			targetAccountID.map({ movingIDs.contains($0) == false }) ?? true
+		else {
+			return
+		}
+
+		let movingOrder = routing.order.filter(movingIDs.contains)
+		var order = routing.order.filter { movingIDs.contains($0) == false }
+		let insertionIndex: Int
+		if let targetAccountID {
+			guard let targetIndex = order.firstIndex(of: targetAccountID) else {
+				return
+			}
+			insertionIndex = targetIndex
+		} else {
+			insertionIndex = order.endIndex
+		}
+		order.insert(contentsOf: movingOrder, at: insertionIndex)
+		guard order != routing.order,
+			reorderAccountStates(to: order)
+		else {
+			return
+		}
+		await persistAccountOrder(
+			order,
+			replacing: routing,
+			using: accountControlClient
+		)
+	}
+
+	private func persistAccountOrder(
+		_ order: [String],
+		replacing routing: AccountRoutingControl,
+		using accountControlClient: any AccountControlClient
+	) async {
+		await performAccountControl(
+			isRoutingControl: true,
+			allowsDuringRefresh: true,
+			successMessage: nil,
+			operation: {
+				try await accountControlClient.setAccountOrder(
+					authority: establishedAuthority,
+					order: order,
+					expectedRoutingRevision: routing.revision,
+					idempotencyKey: Self.newCanonicalUUID()
+				)
+			}
+		)
+		_ = reorderAccountStates(to: self.routing?.order ?? routing.order)
 	}
 
 	func refreshCredentials(for accountID: String) async {
@@ -2942,6 +3050,7 @@ final class ResetCardStore {
 			return .none
 		case .routingChanged(let routing):
 			self.routing = routing
+			_ = reorderAccountStates(to: routing.order)
 			return .none
 		case .accountLoggedOut(let accountID, _):
 			if case .current(let projectedID, _, _) = codexAuthProjection,
@@ -2992,6 +3101,26 @@ final class ResetCardStore {
 				? .none
 				: .account(account.accountID, refreshInventory: true)
 		}
+	}
+
+	@discardableResult
+	private func reorderAccountStates(to order: [String]) -> Bool {
+		guard order.count == accounts.count else {
+			return false
+		}
+		let statesByID = Dictionary(
+			uniqueKeysWithValues: accounts.map {
+				($0.account.accountID, $0)
+			}
+		)
+		guard statesByID.count == accounts.count,
+			Set(statesByID.keys) == Set(order),
+			Set(order).count == order.count
+		else {
+			return false
+		}
+		accounts = order.compactMap { statesByID[$0] }
+		return true
 	}
 
 	private func scheduleAccountControlFollowUp(

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
@@ -100,6 +100,12 @@ final class AccountControlNativeClientTests: XCTestCase {
 					mode: #"{"mode":"balanced"}"#,
 					order: [accountID, secondAccountID]
 				)
+			case "set_account_order":
+				payload = controlRoutingAppliedJSON(
+					revision: 10,
+					mode: #"{"mode":"balanced"}"#,
+					order: [secondAccountID, accountID]
+				)
 			default:
 				payload = """
 				{"outcome":"applied","data":{"entity_revision":8,
@@ -163,6 +169,12 @@ final class AccountControlNativeClientTests: XCTestCase {
 			expectedRoutingRevision: 9,
 			idempotencyKey: idempotencyKey
 		)
+		_ = try await client.setAccountOrder(
+			authority: authority,
+			order: [secondAccountID, accountID],
+			expectedRoutingRevision: 9,
+			idempotencyKey: idempotencyKey
+		)
 		_ = try await client.refreshAccountCredentials(
 			authority: authority,
 			operationID: operationID,
@@ -178,7 +190,7 @@ final class AccountControlNativeClientTests: XCTestCase {
 				"enroll_account", "get_codex_auth_projection", "use_account_in_codex",
 				"disable_account",
 				"logout_account", "set_fixed_selection",
-				"set_balanced_selection", "refresh_account",
+				"set_balanced_selection", "set_account_order", "refresh_account",
 			]
 		)
 		XCTAssertEqual(
@@ -198,8 +210,44 @@ final class AccountControlNativeClientTests: XCTestCase {
 		XCTAssertEqual(Set(requests[6].keys), [
 			"schema", "operation", "expected_routing_revision", "idempotency_key",
 		])
-		XCTAssertEqual(requests[7]["operation_id"] as? String, operationID)
-		XCTAssertEqual(recorder.requests.map(\.authority), Array(repeating: authority, count: 8))
+		XCTAssertEqual(
+			requests[7]["order"] as? [String],
+			[secondAccountID, accountID]
+		)
+		XCTAssertEqual(Set(requests[7].keys), [
+			"schema", "operation", "order", "expected_routing_revision", "idempotency_key",
+		])
+		XCTAssertEqual(requests[8]["operation_id"] as? String, operationID)
+		XCTAssertEqual(recorder.requests.map(\.authority), Array(repeating: authority, count: 9))
+	}
+
+	func testAccountOrderRejectsAContradictoryAppliedOrder() async throws {
+		let authority = authority
+		let accountID = accountID
+		let secondAccountID = secondAccountID
+		let client = DecodexNativeClient { _, _ in
+			nativeSuccess(
+				operation: "set_account_order",
+				authority: authority,
+				data: controlRoutingAppliedJSON(
+					revision: 10,
+					mode: #"{"mode":"balanced"}"#,
+					order: [accountID, secondAccountID]
+				)
+			)
+		}
+
+		do {
+			_ = try await client.setAccountOrder(
+				authority: authority,
+				order: [secondAccountID, accountID],
+				expectedRoutingRevision: 9,
+				idempotencyKey: idempotencyKey
+			)
+			XCTFail("A contradictory account order must not appear applied")
+		} catch let error as AccountControlError {
+			XCTAssertEqual(error, .invalidResponse)
+		}
 	}
 
 	func testUseInCodexRejectsNoncanonicalIdentityRevisionAndAuthorityBeforeDispatch() async {

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -639,6 +639,127 @@ final class AccountControlStoreTests: XCTestCase {
 		await refreshTask.value
 	}
 
+	func testMovingAccountsPersistsEachCompleteRoutingOrder() async throws {
+		let secondAccountID = "22222222-2222-4222-8222-222222222222"
+		let account = accountRecord()
+		let client = AccountControlStoreClient(
+			account: account,
+			secondaryAccount: accountRecord(
+				accountID: secondAccountID,
+				alias: "Account 00000-00002"
+			),
+			authority: authority
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		await store.refresh()
+		XCTAssertTrue(store.canReorderAccounts)
+
+		await store.moveAccount(accountID, onto: secondAccountID)
+
+		let order = [secondAccountID, accountID]
+		XCTAssertEqual(store.accounts.map { $0.account.accountID }, order)
+		XCTAssertEqual(store.routing?.order, order)
+		XCTAssertEqual(store.routing?.revision, 10)
+		let request = await client.orderRequest()
+		XCTAssertEqual(
+			request,
+			AccountControlStoreOrderRequest(
+				authority: authority,
+				order: order,
+				expectedRoutingRevision: 9
+			)
+		)
+		XCTAssertNil(store.message)
+
+		await store.moveAccount(accountID, onto: secondAccountID)
+
+		let restoredOrder = [accountID, secondAccountID]
+		XCTAssertEqual(store.accounts.map { $0.account.accountID }, restoredOrder)
+		XCTAssertEqual(store.routing?.order, restoredOrder)
+		XCTAssertEqual(store.routing?.revision, 11)
+		let secondRequest = await client.orderRequest()
+		XCTAssertEqual(
+			secondRequest,
+			AccountControlStoreOrderRequest(
+				authority: authority,
+				order: restoredOrder,
+				expectedRoutingRevision: 10
+			)
+		)
+
+		await store.moveAccounts([accountID], before: nil)
+
+		XCTAssertEqual(
+			store.accounts.map { $0.account.accountID },
+			[secondAccountID, accountID]
+		)
+		let endRequest = await client.orderRequest()
+		XCTAssertEqual(
+			endRequest,
+			AccountControlStoreOrderRequest(
+				authority: authority,
+				order: [secondAccountID, accountID],
+				expectedRoutingRevision: 11
+			)
+		)
+
+		await store.moveAccounts([accountID], before: secondAccountID)
+
+		XCTAssertEqual(
+			store.accounts.map { $0.account.accountID },
+			[accountID, secondAccountID]
+		)
+		let beforeRequest = await client.orderRequest()
+		XCTAssertEqual(
+			beforeRequest,
+			AccountControlStoreOrderRequest(
+				authority: authority,
+				order: [accountID, secondAccountID],
+				expectedRoutingRevision: 12
+			)
+		)
+	}
+
+	func testRejectedAccountOrderRestoresTheAuthoritativeRows() async throws {
+		let secondAccountID = "22222222-2222-4222-8222-222222222222"
+		let account = accountRecord()
+		let client = AccountControlStoreClient(
+			account: account,
+			secondaryAccount: accountRecord(
+				accountID: secondAccountID,
+				alias: "Account 00000-00002"
+			),
+			authority: authority,
+			accountOrderError: .rejected(
+				.staleRoutingControl,
+				actualRevision: 10
+			)
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		await store.refresh()
+		await store.moveAccount(accountID, onto: secondAccountID)
+
+		let authoritativeOrder = [accountID, secondAccountID]
+		XCTAssertEqual(store.accounts.map { $0.account.accountID }, authoritativeOrder)
+		XCTAssertEqual(store.routing?.order, authoritativeOrder)
+		XCTAssertEqual(store.routing?.revision, 9)
+		XCTAssertNotNil(store.message)
+	}
+
 	func testRouteAccountProjectsThenSelectsFixedRouting() async throws {
 		let account = accountRecord()
 		let client = AccountControlStoreClient(
@@ -1138,6 +1259,12 @@ private struct AccountControlStoreReauthenticationRequest: Equatable, Sendable {
 	let codexBin: String
 }
 
+private struct AccountControlStoreOrderRequest: Equatable, Sendable {
+	let authority: ResetCardAuthority?
+	let order: [String]
+	let expectedRoutingRevision: UInt64
+}
+
 private enum AccountControlStoreOperation: Equatable, Sendable {
 	case codexProjection
 	case fixedRouting
@@ -1163,12 +1290,14 @@ private actor AccountControlStoreClient: AccountControlClient {
 	private let allowsEnrollment: Bool
 	private var routing: AccountRoutingControl
 	private var fixedSelectionError: AccountControlError?
+	private let accountOrderError: AccountControlError?
 	private let useAccountError: AccountControlError?
 	private var lastFixedRequest: AccountControlStoreFixedRequest?
 	private var lastUseRequest: AccountControlStoreUseRequest?
 	private var lastRefreshRequest: AccountControlStoreRefreshRequest?
 	private var lastEnabledRequest: AccountControlStoreEnabledRequest?
 	private var lastLogoutRequest: AccountControlStoreLogoutRequest?
+	private var lastOrderRequest: AccountControlStoreOrderRequest?
 	private var controlOperations = [AccountControlStoreOperation]()
 	private var fixedRequestCount = 0
 	private var projectionRequestCount = 0
@@ -1198,6 +1327,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 		allowsEnrollment: Bool = false,
 		routing: AccountRoutingControl? = nil,
 		fixedSelectionError: AccountControlError? = nil,
+		accountOrderError: AccountControlError? = nil,
 		useAccountError: AccountControlError? = nil,
 		projection: CodexAuthProjection = .unmanaged,
 		reauthenticationStates: [AccountReauthenticationState] = [],
@@ -1221,6 +1351,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 				order: [account.accountID] + (secondaryAccount.map { [$0.accountID] } ?? [])
 			)
 		self.fixedSelectionError = fixedSelectionError
+		self.accountOrderError = accountOrderError
 		self.useAccountError = useAccountError
 		self.reauthenticationStates = reauthenticationStates
 		self.cancelReauthenticationWithOutcomeUnknown =
@@ -1234,7 +1365,11 @@ private actor AccountControlStoreClient: AccountControlClient {
 			throw ResetCardClientError.invalidResponse
 		}
 		snapshotReadCount += 1
-		let capturedAccounts = [account] + (secondaryAccount.map { [$0] } ?? [])
+		let availableAccounts = [account] + (secondaryAccount.map { [$0] } ?? [])
+		let accountsByID = Dictionary(
+			uniqueKeysWithValues: availableAccounts.map { ($0.accountID, $0) }
+		)
+		let capturedAccounts = routing.order.compactMap { accountsByID[$0] }
 		if snapshotReadCount > 1, let snapshotGate {
 			await snapshotGate.wait()
 		}
@@ -1242,7 +1377,14 @@ private actor AccountControlStoreClient: AccountControlClient {
 			authority: authority,
 			accounts: capturesSnapshotBeforeWait
 				? capturedAccounts
-				: [account] + (secondaryAccount.map { [$0] } ?? []),
+				: routing.order.compactMap { accountID in
+					if account.accountID == accountID {
+						return account
+					}
+					return secondaryAccount?.accountID == accountID
+						? secondaryAccount
+						: nil
+				},
 			routing: routing
 		)
 	}
@@ -1546,6 +1688,39 @@ private actor AccountControlStoreClient: AccountControlClient {
 		idempotencyKey: String
 	) async throws -> AccountControlResult {
 		throw AccountControlError.applicationUnavailable
+	}
+
+	func setAccountOrder(
+		authority: ResetCardAuthority?,
+		order: [String],
+		expectedRoutingRevision: UInt64,
+		idempotencyKey: String
+	) async throws -> AccountControlResult {
+		guard DecodexNativeClient.isCanonicalUUID(idempotencyKey),
+			expectedRoutingRevision == routing.revision,
+			order.count == routing.order.count,
+			Set(order) == Set(routing.order)
+		else {
+			throw AccountControlError.invalidInput
+		}
+		lastOrderRequest = AccountControlStoreOrderRequest(
+			authority: authority,
+			order: order,
+			expectedRoutingRevision: expectedRoutingRevision
+		)
+		if let accountOrderError {
+			throw accountOrderError
+		}
+		routing = AccountRoutingControl(
+			revision: routing.revision + 1,
+			mode: routing.mode,
+			order: order
+		)
+		return .routingChanged(routing)
+	}
+
+	func orderRequest() -> AccountControlStoreOrderRequest? {
+		lastOrderRequest
 	}
 
 	func refreshAccountCredentials(

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountProfileStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountProfileStoreTests.swift
@@ -1192,6 +1192,15 @@ private actor PerAccountGenerationClient: AccountControlClient, AccountProfileCl
 		throw AccountControlError.applicationUnavailable
 	}
 
+	func setAccountOrder(
+		authority _: ResetCardAuthority?,
+		order _: [String],
+		expectedRoutingRevision _: UInt64,
+		idempotencyKey _: String
+	) async throws -> AccountControlResult {
+		throw AccountControlError.applicationUnavailable
+	}
+
 	func useAccountInCodex(
 		authority _: ResetCardAuthority?,
 		accountID _: String,

--- a/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
@@ -14,6 +14,89 @@ final class PanelWindowSizingLayoutTests: XCTestCase {
 		XCTAssertEqual(PanelSpacing.popoverInset, 12)
 	}
 
+	func testAccountReorderMovesOnlyAfterCrossingAnAdjacentCardCenter() {
+		let order = ["first", "second", "third"]
+		let frames = accountReorderFrames()
+
+		XCTAssertEqual(
+			AccountCardReorderLayout.reorderedAccountIDs(
+				dragging: "first",
+				baseOrder: order,
+				frames: frames,
+				translationY: 87
+			),
+			order
+		)
+		XCTAssertEqual(
+			AccountCardReorderLayout.reorderedAccountIDs(
+				dragging: "first",
+				baseOrder: order,
+				frames: frames,
+				translationY: 88
+			),
+			["second", "first", "third"]
+		)
+	}
+
+	func testAccountReorderConstrainKeepsTheWholeCardInItsVerticalTrack() {
+		let order = ["first", "second", "third"]
+		let frames = accountReorderFrames()
+
+		XCTAssertEqual(
+			AccountCardReorderLayout.constrainedTranslationY(
+				for: "first",
+				baseOrder: order,
+				frames: frames,
+				proposed: 500
+			),
+			176
+		)
+		XCTAssertEqual(
+			AccountCardReorderLayout.constrainedTranslationY(
+				for: "third",
+				baseOrder: order,
+				frames: frames,
+				proposed: -500
+			),
+			-176
+		)
+	}
+
+	func testAccountReorderOffsetsOpenTheSelectedSlot() {
+		let order = ["first", "second", "third"]
+		let visualOrder = ["second", "first", "third"]
+		let frames = accountReorderFrames()
+
+		XCTAssertEqual(
+			AccountCardReorderLayout.verticalOffset(
+				for: "second",
+				baseOrder: order,
+				visualOrder: visualOrder,
+				frames: frames,
+				spacing: PanelSpacing.section
+			),
+			-88
+		)
+		XCTAssertEqual(
+			AccountCardReorderLayout.verticalOffset(
+				for: "first",
+				baseOrder: order,
+				visualOrder: visualOrder,
+				frames: frames,
+				spacing: PanelSpacing.section
+			),
+			88
+		)
+	}
+
+	private func accountReorderFrames() -> [String: CGRect] {
+		[
+			"first": CGRect(x: 0, y: 0, width: 260, height: 80),
+			"second": CGRect(x: 0, y: 88, width: 260, height: 80),
+			"third": CGRect(x: 0, y: 176, width: 260, height: 80),
+		]
+	}
+
 	@MainActor
 	func testPanelWindowHostStaysTransparentWithoutOverridingSystemAppearance() {
 		let window = NSWindow(

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -128,7 +128,72 @@ final class ResetCardArchitectureTests: XCTestCase {
 
 		XCTAssertFalse(cardSurface.contains(".id(appearanceID)"))
 		XCTAssertFalse(accountPanel.contains("LazyVStack"))
-		XCTAssertTrue(accountPanel.contains("ForEach(store.accounts)"))
+		XCTAssertTrue(accountPanel.contains("ForEach(presentedAccountStates)"))
+	}
+
+	func testAccountCardsUseConstrainedWholeCardReorderingWithAnOverlayGrip() throws {
+		let sourceURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
+		let rows = try String(
+			contentsOf: sourceURL.appendingPathComponent("ResetCardSectionView.swift"),
+			encoding: .utf8
+		)
+		let panel = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountPanelView.swift"),
+			encoding: .utf8
+		)
+		let controls = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountControlViews.swift"),
+			encoding: .utf8
+		)
+		let store = try String(
+			contentsOf: sourceURL.appendingPathComponent("ResetCardStore.swift"),
+			encoding: .utf8
+		)
+		let support = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountPanelSupport.swift"),
+			encoding: .utf8
+		)
+		let motion = try String(
+			contentsOf: sourceURL.appendingPathComponent("PanelSupport.swift"),
+			encoding: .utf8
+		)
+
+		XCTAssertTrue(rows.contains(#"Image(systemName: "line.3.horizontal")"#))
+		XCTAssertTrue(rows.contains("isAccountCardHovered"))
+		XCTAssertTrue(rows.contains("isReorderHandleHovered"))
+		XCTAssertTrue(rows.contains("isReorderHandleDragging"))
+		XCTAssertTrue(rows.contains(".opacity(showsReorderHandle ? 1 : 0)"))
+		XCTAssertTrue(rows.contains(".frame(width: 14, height: 18)"))
+		XCTAssertTrue(rows.contains(".font(.system(size: 9, weight: .semibold))"))
+		XCTAssertTrue(rows.contains(".overlay(alignment: .trailing)"))
+		XCTAssertTrue(rows.contains("DragGesture("))
+		XCTAssertTrue(rows.contains("coordinateSpace: .named("))
+		XCTAssertTrue(rows.contains("value.translation.height"))
+		XCTAssertFalse(rows.contains(".draggable("))
+		XCTAssertFalse(rows.contains(".dropDestination("))
+		XCTAssertFalse(panel.contains(".reorderable()"))
+		XCTAssertFalse(panel.contains(".reorderContainer("))
+		XCTAssertTrue(panel.contains(".offset(y: accountReorderOffset"))
+		XCTAssertTrue(panel.contains("interaction.isSettling = true"))
+		XCTAssertTrue(panel.contains("PanelMotion.accountReorder"))
+		XCTAssertTrue(support.contains("constrainedTranslationY("))
+		XCTAssertTrue(support.contains("reorderedAccountIDs("))
+		XCTAssertTrue(support.contains("verticalOffset("))
+		XCTAssertTrue(motion.contains("static let accountReorder"))
+		XCTAssertTrue(
+			[rows, controls].allSatisfy {
+				$0.contains("HStack(alignment: .firstTextBaseline")
+			}
+		)
+		XCTAssertTrue(rows.contains(#"Text("Move up")"#))
+		XCTAssertTrue(rows.contains(#"Text("Move down")"#))
+		XCTAssertTrue(store.contains("func moveAccount("))
+		XCTAssertTrue(store.contains("func moveAccounts("))
+		XCTAssertTrue(store.contains("setAccountOrder("))
 	}
 
 	func testPanelCardsAndPopoversUseSharedSpacingTokens() throws {
@@ -257,7 +322,6 @@ final class ResetCardArchitectureTests: XCTestCase {
 			"Turn Fast mode off",
 			"Turn Fast mode on",
 			"Refresh all",
-			"Use balanced routing",
 			"Disable account",
 			"Enable account",
 			"Log out",
@@ -292,7 +356,39 @@ final class ResetCardArchitectureTests: XCTestCase {
 		}
 	}
 
-	func testPanelUsesSeparatedMaterialCardsWithoutLiquidGlass() throws {
+	func testOverflowMenuKeepsOnlyUsefulGlobalActions() throws {
+		let sourceURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
+		let accountPanel = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountPanelView.swift"),
+			encoding: .utf8
+		)
+		let menuStart = try XCTUnwrap(accountPanel.range(of: "\n\t\t\tMenu {"))
+		let menuEnd = try XCTUnwrap(
+			accountPanel.range(
+				of: "\n\t\t\t} label: {",
+				range: menuStart.lowerBound ..< accountPanel.endIndex
+			)
+		)
+		let menu = accountPanel[menuStart.lowerBound ..< menuEnd.upperBound]
+
+		XCTAssertTrue(menu.contains("Button(\"Refresh all\")"))
+		XCTAssertTrue(menu.contains("store.requestRefresh()"))
+		XCTAssertFalse(menu.contains("await store.refresh()"))
+		XCTAssertFalse(menu.contains("store.isRefreshing"))
+		XCTAssertFalse(menu.contains("store.isRefreshingAccountSkeleton"))
+		XCTAssertTrue(menu.contains("store.isAccountControlInProgress"))
+		XCTAssertTrue(menu.contains("Picker(\"Material\""))
+		XCTAssertFalse(menu.contains("Show email addresses"))
+		XCTAssertFalse(menu.contains("Hide email addresses"))
+		XCTAssertFalse(menu.contains("Turn Fast mode"))
+		XCTAssertFalse(menu.contains("Use balanced routing"))
+	}
+
+	func testPanelOffersThinAndLiquidGlassCardMaterials() throws {
 		let sourceURL = URL(fileURLWithPath: #filePath)
 			.deletingLastPathComponent()
 			.deletingLastPathComponent()
@@ -349,6 +445,9 @@ final class ResetCardArchitectureTests: XCTestCase {
 
 		XCTAssertTrue(cardSurface.contains("shape.fill(.thinMaterial)"))
 		XCTAssertTrue(cardSurface.contains("shape.fill(.regularMaterial)"))
+		XCTAssertTrue(cardSurface.contains("case liquidGlass = \"liquid-glass\""))
+		XCTAssertTrue(cardSurface.contains("static let defaultValue = PanelCardMaterial.thin"))
+		XCTAssertTrue(cardSurface.contains(".glassEffect(.regular, in: shape)"))
 		XCTAssertTrue(cardSurface.contains(".background"))
 		XCTAssertTrue(cardSurface.contains(".shadow"))
 		XCTAssertTrue(cardSurface.contains("radius: 3"))
@@ -358,9 +457,15 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(cardSurface.contains("cardFill"))
 		XCTAssertFalse(cardSurface.contains("cardStroke"))
 		XCTAssertFalse(cardSurface.contains("strokeBorder"))
-		XCTAssertFalse(cardSurface.contains("Glass"))
-		XCTAssertFalse(cardSurface.contains("glassEffect"))
-		XCTAssertFalse(accountPanel.contains("GlassEffectContainer"))
+		XCTAssertTrue(accountPanel.contains("GlassEffectContainer(spacing: 0)"))
+		XCTAssertTrue(
+			accountPanel.contains(".environment(\\.panelCardMaterial, panelCardMaterial)")
+		)
+		XCTAssertTrue(
+			accountPanel.contains(
+				"@AppStorage(PanelCardMaterial.storageKey) private var panelCardMaterialRawValue = PanelCardMaterial.thin.rawValue"
+			)
+		)
 		XCTAssertFalse(addControl.contains("isDisabled:"))
 		XCTAssertTrue(accountPanel.contains(".panelCardSurface(cornerRadius: 18)"))
 		XCTAssertTrue(accountPanel.contains(".panelCardSurface(cornerRadius: 16)"))

--- a/crates/decodex-app-client-ffi/src/lib.rs
+++ b/crates/decodex-app-client-ffi/src/lib.rs
@@ -120,6 +120,12 @@ enum Request {
 		expected_routing_revision: u64,
 		idempotency_key: String,
 	},
+	SetAccountOrder {
+		schema: String,
+		order: Vec<String>,
+		expected_routing_revision: u64,
+		idempotency_key: String,
+	},
 	RefreshAccount {
 		schema: String,
 		operation_id: String,
@@ -174,6 +180,7 @@ impl Request {
 			Self::LogoutAccount { .. } => "logout_account",
 			Self::SetFixedSelection { .. } => "set_fixed_selection",
 			Self::SetBalancedSelection { .. } => "set_balanced_selection",
+			Self::SetAccountOrder { .. } => "set_account_order",
 			Self::RefreshAccount { .. } => "refresh_account",
 			Self::StartAccountReauthentication { .. } => "start_account_reauthentication",
 			Self::PollAccountReauthentication { .. } => "poll_account_reauthentication",
@@ -198,6 +205,7 @@ impl Request {
 			| Self::LogoutAccount { schema, .. }
 			| Self::SetFixedSelection { schema, .. }
 			| Self::SetBalancedSelection { schema, .. }
+			| Self::SetAccountOrder { schema, .. }
 			| Self::RefreshAccount { schema, .. }
 			| Self::StartAccountReauthentication { schema, .. }
 			| Self::PollAccountReauthentication { schema, .. }
@@ -688,6 +696,8 @@ async fn execute_request(
 			.await,
 		Request::SetBalancedSelection { expected_routing_revision, idempotency_key, .. } =>
 			set_balanced_selection(profile, expected_routing_revision, idempotency_key).await,
+		Request::SetAccountOrder { order, expected_routing_revision, idempotency_key, .. } =>
+			set_account_order(profile, order, expected_routing_revision, idempotency_key).await,
 		Request::RefreshAccount {
 			operation_id,
 			account_id,
@@ -955,6 +965,27 @@ async fn set_balanced_selection(
 	to_value(response)
 }
 
+async fn set_account_order(
+	profile: ClientProfile,
+	order: Vec<String>,
+	expected_routing_revision: u64,
+	idempotency_key: String,
+) -> Result<Value, RequestFailure> {
+	let order = order
+		.into_iter()
+		.map(|account_id| entity_id(&account_id))
+		.collect::<Result<Vec<_>, _>>()?;
+	let response = AccountClient::new(profile)
+		.set_account_order(
+			order,
+			revision(expected_routing_revision)?,
+			parse_idempotency_key(idempotency_key)?,
+		)
+		.await
+		.map_err(RequestFailure::Client)?;
+	to_value(response)
+}
+
 async fn use_account_in_codex(
 	profile: ClientProfile,
 	account_id: String,
@@ -1104,6 +1135,7 @@ mod tests {
 	use super::*;
 
 	const ACCOUNT_ID: &str = "018f0f9e-7b6e-4a31-8f4c-1d2e3f405162";
+	const SECOND_ACCOUNT_ID: &str = "028f0f9e-7b6e-4a31-8f4c-1d2e3f405163";
 
 	#[test]
 	fn strict_request_accepts_the_versioned_operations() {
@@ -1126,6 +1158,24 @@ mod tests {
 		assert_eq!(request.operation(), "use_account_in_codex");
 		assert!(serde_json::from_str::<Request>(&format!(
 			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"use_account_in_codex","account_id":"{ACCOUNT_ID}","idempotency_key":"use-account-test"}}"#
+		))
+		.is_err());
+	}
+
+	#[test]
+	fn account_order_request_is_exact_and_routing_revision_fenced() {
+		let request = serde_json::from_str::<Request>(&format!(
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"set_account_order","order":["{SECOND_ACCOUNT_ID}","{ACCOUNT_ID}"],"expected_routing_revision":9,"idempotency_key":"account-order-test"}}"#
+		))
+		.expect("account-order request must decode");
+
+		assert_eq!(request.operation(), "set_account_order");
+		assert!(serde_json::from_str::<Request>(&format!(
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"set_account_order","order":["{SECOND_ACCOUNT_ID}","{ACCOUNT_ID}"],"idempotency_key":"account-order-test"}}"#
+		))
+		.is_err());
+		assert!(serde_json::from_str::<Request>(&format!(
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"set_account_order","order":["{SECOND_ACCOUNT_ID}","{ACCOUNT_ID}"],"expected_routing_revision":9,"idempotency_key":"account-order-test","extra":true}}"#
 		))
 		.is_err());
 	}

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -198,8 +198,26 @@ decodex-publisher validate-social
 
 - Reads the complete account skeleton from the common daemon service and renders one
   compact UUID-keyed row for every account in canonical routing order. Rows use
-  independent material cards with transparent gaps, compact quota meters, and
-  single-line Reset Card controls.
+  independent cards with transparent gaps, compact quota meters, and single-line
+  Reset Card controls. The overflow menu stores one panel-wide appearance choice:
+  `Thin` by default, or the system `Liquid Glass` effect. The same menu keeps only
+  `Refresh all`, that material selector, and Quit. A manual refresh remains available
+  during a background read and coalesces into the active refresh cycle; account
+  mutations and Reset Card submissions still disable it.
+- Reveals a compact trailing-edge reorder grip over an account card's padding while
+  the pointer is over that card, so the grip does not reserve a layout column. A
+  drag uses the stable list coordinate space and keeps the full-size card on a
+  fixed vertical track. Crossing an adjacent card's center springs that card into
+  the open slot, and release springs the dragged card into its final slot. A
+  completed reorder, or the grip's accessible Move up or Move down action, sends
+  one complete `set_account_order` request through the in-process native client
+  with the current routing revision. The daemon-owned
+  [Account Lifecycle Authority](../specs/account-lifecycle-authority.md#versioned-account-controls)
+  remains canonical. The returned routing order replaces the immediate order, and a
+  rejection restores the last authoritative order. Reordering is unavailable while
+  an account control or Reset Card submission is in progress, when routing and
+  account membership disagree, or when fewer than two accounts exist. The app does
+  not persist a separate local order.
 - Loads quota windows and Reset Cards independently for each row. One slow or failed
   provider request does not hide the other accounts. A provider-unsupported quota
   duration stays a muted row-local fact and does not mark the account as failed.


### PR DESCRIPTION
Summary

- Add daemon-persisted whole-card drag reordering with spring displacement and accessible move actions.
- Refine the compact hover-only reorder handle and stable drag coordinate calculations.
- Simplify the overflow menu, keep Refresh all available during coalesced background refreshes, and add Thin/Liquid Glass card material choices.

Validation

- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test (200 passed)
- cargo nextest run -p decodex-app-client-ffi --all-features (28 passed)
- scripts/macos/test_decodex_app_stage.sh (release build, signing, bundle checks passed)
- cargo make fmt (passed)

Known repository gate issue

- cargo make test reached the unrelated upstream automation suite and failed twice because test_agent_watchdog_kills_setsid_grandchild timed out only in the full suite; the exact test passed when rerun alone.