### PR TITLE
Stabilize account reordering and panel placement

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
@@ -160,27 +160,47 @@ enum AccountCardReorderLayout {
 		frames: [String: CGRect],
 		spacing: CGFloat
 	) -> CGFloat {
-		guard visualOrder.count == baseOrder.count,
-			Set(visualOrder) == Set(baseOrder),
-			let originalFrame = frames[accountID],
-			let firstID = baseOrder.first,
-			let firstFrame = frames[firstID],
-			baseOrder.allSatisfy({ frames[$0] != nil })
+		guard let originalFrame = frames[accountID],
+			let projectedFrame = rebasedFrames(
+				from: baseOrder,
+				to: visualOrder,
+				frames: frames,
+				spacing: spacing
+			)?[accountID]
 		else {
 			return 0
 		}
+		return projectedFrame.minY - originalFrame.minY
+	}
 
-		var projectedMinY = firstFrame.minY
-		for orderedID in visualOrder {
-			guard let frame = frames[orderedID] else {
-				return 0
-			}
-			if orderedID == accountID {
-				return projectedMinY - originalFrame.minY
-			}
-			projectedMinY += frame.height + spacing
+	static func rebasedFrames(
+		from baseOrder: [String],
+		to reorderedAccountIDs: [String],
+		frames: [String: CGRect],
+		spacing: CGFloat
+	) -> [String: CGRect]? {
+		guard spacing.isFinite,
+			baseOrder.count == reorderedAccountIDs.count,
+			Set(baseOrder).count == baseOrder.count,
+			Set(reorderedAccountIDs) == Set(baseOrder),
+			let firstAccountID = baseOrder.first,
+			let firstFrame = frames[firstAccountID],
+			baseOrder.allSatisfy({ frames[$0] != nil })
+		else {
+			return nil
 		}
-		return 0
+
+		var nextMinY = firstFrame.minY
+		var rebasedFrames = [String: CGRect]()
+		for accountID in reorderedAccountIDs {
+			guard var frame = frames[accountID] else {
+				return nil
+			}
+			frame.origin.y = nextMinY
+			rebasedFrames[accountID] = frame
+			nextMinY += frame.height + spacing
+		}
+		return rebasedFrames
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -521,7 +521,25 @@ struct AccountPanelView: View {
 			guard accountReorderInteraction?.token == token else {
 				return
 			}
-			accountReorderInteraction = nil
+			let authoritativeOrder = store.accounts.map(\.id)
+			let authoritativeFrames =
+				AccountCardReorderLayout.rebasedFrames(
+					from: interaction.baseOrder,
+					to: authoritativeOrder,
+					frames: interaction.frames,
+					spacing: PanelSpacing.section
+				) ?? [:]
+			if authoritativeOrder == finalOrder {
+				var handoffTransaction = Transaction(animation: nil)
+				handoffTransaction.disablesAnimations = true
+				withTransaction(handoffTransaction) {
+					accountCardFrames = authoritativeFrames
+					accountReorderInteraction = nil
+				}
+			} else {
+				accountCardFrames = authoritativeFrames
+				accountReorderInteraction = nil
+			}
 		}
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
+++ b/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
@@ -117,6 +117,20 @@ final class StatusPanelController: NSObject {
 			name: NSApplication.didResignActiveNotification,
 			object: NSApp
 		)
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(panelDidResize(_:)),
+			name: NSWindow.didResizeNotification,
+			object: panel
+		)
+	}
+
+	@objc
+	private func panelDidResize(_: Notification) {
+		guard panel.isVisible else {
+			return
+		}
+		positionPanel()
 	}
 
 	private func positionPanel() {
@@ -126,14 +140,19 @@ final class StatusPanelController: NSObject {
 			return
 		}
 
-		guard let screen = statusWindow.screen
-			?? NSScreen.screens.first(where: {
-				$0.frame.intersects(anchorRect)
-			})
-			?? NSScreen.main
-		else {
+		let screens = NSScreen.screens
+		let fallbackScreen = statusWindow.screen ?? NSScreen.main
+		let fallbackIndex = fallbackScreen.flatMap { fallbackScreen in
+			screens.firstIndex(where: { $0 === fallbackScreen })
+		}
+		guard let screenIndex = StatusPanelLayout.screenIndex(
+			containing: anchorRect,
+			screenFrames: screens.map(\.frame),
+			fallbackIndex: fallbackIndex
+		) else {
 			return
 		}
+		let screen = screens[screenIndex]
 
 		panel.setFrameOrigin(
 			StatusPanelLayout.origin(
@@ -166,6 +185,31 @@ final class TransparentHostingView<Content: View>: NSHostingView<Content> {
 }
 
 enum StatusPanelLayout {
+	static func screenIndex(
+		containing anchorRect: NSRect,
+		screenFrames: [NSRect],
+		fallbackIndex: Int?
+	) -> Int? {
+		let anchorCenter = NSPoint(x: anchorRect.midX, y: anchorRect.midY)
+		if let containingIndex = screenFrames.firstIndex(where: {
+			$0.contains(anchorCenter)
+		}) {
+			return containingIndex
+		}
+
+		if let intersectingIndex = screenFrames.firstIndex(where: {
+			$0.intersects(anchorRect)
+		}) {
+			return intersectingIndex
+		}
+
+		if let fallbackIndex, screenFrames.indices.contains(fallbackIndex) {
+			return fallbackIndex
+		}
+
+		return screenFrames.indices.first
+	}
+
 	static func origin(
 		anchorRect: NSRect,
 		panelSize: NSSize,

--- a/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
@@ -89,6 +89,41 @@ final class PanelWindowSizingLayoutTests: XCTestCase {
 		)
 	}
 
+	func testAccountReorderRebasesFramesBeforeASecondDrag() throws {
+		let initialOrder = ["first", "second", "third"]
+		let reordered = ["second", "first", "third"]
+		let rebasedFrames = try XCTUnwrap(
+			AccountCardReorderLayout.rebasedFrames(
+				from: initialOrder,
+				to: reordered,
+				frames: accountReorderFrames(),
+				spacing: PanelSpacing.section
+			)
+		)
+
+		XCTAssertEqual(rebasedFrames["second"]?.minY, 0)
+		XCTAssertEqual(rebasedFrames["first"]?.minY, 88)
+		XCTAssertEqual(rebasedFrames["third"]?.minY, 176)
+		XCTAssertEqual(
+			AccountCardReorderLayout.constrainedTranslationY(
+				for: "third",
+				baseOrder: reordered,
+				frames: rebasedFrames,
+				proposed: -500
+			),
+			-176
+		)
+		XCTAssertEqual(
+			AccountCardReorderLayout.reorderedAccountIDs(
+				dragging: "third",
+				baseOrder: reordered,
+				frames: rebasedFrames,
+				translationY: -176
+			),
+			["third", "second", "first"]
+		)
+	}
+
 	private func accountReorderFrames() -> [String: CGRect] {
 		[
 			"first": CGRect(x: 0, y: 0, width: 260, height: 80),
@@ -157,6 +192,22 @@ final class PanelWindowSizingLayoutTests: XCTestCase {
 		)
 
 		XCTAssertEqual(origin, NSPoint(x: 2_315, y: 692))
+	}
+
+	func testStatusPanelSelectsTheDisplayContainingTheStatusItemBeforeAStaleFallback() {
+		let screenFrames = [
+			NSRect(x: 0, y: 0, width: 1_920, height: 1_080),
+			NSRect(x: 1_920, y: 0, width: 1_080, height: 1_344),
+		]
+
+		XCTAssertEqual(
+			StatusPanelLayout.screenIndex(
+				containing: NSRect(x: 2_470, y: 1_320, width: 30, height: 24),
+				screenFrames: screenFrames,
+				fallbackIndex: 0
+			),
+			1
+		)
 	}
 
 	func testStatusPanelOriginClampsAtBothHorizontalDisplayEdges() {

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -179,6 +179,10 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(panel.contains(".reorderContainer("))
 		XCTAssertTrue(panel.contains(".offset(y: accountReorderOffset"))
 		XCTAssertTrue(panel.contains("interaction.isSettling = true"))
+		XCTAssertTrue(panel.contains("let authoritativeOrder = store.accounts.map(\\.id)"))
+		XCTAssertTrue(panel.contains("AccountCardReorderLayout.rebasedFrames("))
+		XCTAssertTrue(panel.contains("handoffTransaction.disablesAnimations = true"))
+		XCTAssertTrue(panel.contains("withTransaction(handoffTransaction)"))
 		XCTAssertTrue(panel.contains("PanelMotion.accountReorder"))
 		XCTAssertTrue(support.contains("constrainedTranslationY("))
 		XCTAssertTrue(support.contains("reorderedAccountIDs("))
@@ -505,6 +509,8 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(
 			statusPanel.contains("#selector(applicationDidResignActive(_:))")
 		)
+		XCTAssertTrue(statusPanel.contains("NSWindow.didResizeNotification"))
+		XCTAssertTrue(statusPanel.contains("#selector(panelDidResize(_:))"))
 		XCTAssertEqual(
 			panelControls.components(
 				separatedBy: "isDisabled && isActive == false"


### PR DESCRIPTION
## Summary
- rebase cached account-card frames after a persisted reorder so later drags use the current positions
- hand off a settled drag to the authoritative layout without a second spring animation
- keep the status panel anchored to the actual menu-bar item across screen selection and asynchronous resizing

## Validation
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app (202 tests)
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer apps/decodex-app/script/build_and_run.sh stage