### PR TITLE
Stabilize account card hover tracking

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelSupport.swift
@@ -1,6 +1,110 @@
 import AppKit
 import SwiftUI
 
+struct AccountCardHoverTrackingView: NSViewRepresentable {
+	let cardFrames: [String: CGRect]
+	let onHoveredAccountChanged: (String?) -> Void
+
+	func makeNSView(context _: Context) -> AccountCardHoverTrackingNSView {
+		let view = AccountCardHoverTrackingNSView(frame: .zero)
+		view.update(
+			cardFrames: cardFrames,
+			onHoveredAccountChanged: onHoveredAccountChanged
+		)
+		return view
+	}
+
+	func updateNSView(
+		_ nsView: AccountCardHoverTrackingNSView,
+		context _: Context
+	) {
+		nsView.update(
+			cardFrames: cardFrames,
+			onHoveredAccountChanged: onHoveredAccountChanged
+		)
+	}
+}
+
+@MainActor
+final class AccountCardHoverTrackingNSView: NSView {
+	private var cardFrames = [String: CGRect]()
+	private var onHoveredAccountChanged: (String?) -> Void = { _ in }
+	private var hoverTrackingArea: NSTrackingArea?
+	private var isPointerInside = false
+	private var hoveredAccountID: String?
+
+	override var isFlipped: Bool {
+		true
+	}
+
+	func update(
+		cardFrames: [String: CGRect],
+		onHoveredAccountChanged: @escaping (String?) -> Void
+	) {
+		self.cardFrames = cardFrames
+		self.onHoveredAccountChanged = onHoveredAccountChanged
+		guard isPointerInside, let window else {
+			return
+		}
+		reportHoveredAccount(
+			at: convert(window.mouseLocationOutsideOfEventStream, from: nil)
+		)
+	}
+
+	override func updateTrackingAreas() {
+		super.updateTrackingAreas()
+		guard hoverTrackingArea == nil else {
+			return
+		}
+		let trackingArea = NSTrackingArea(
+			rect: .zero,
+			options: [
+				.mouseEnteredAndExited,
+				.mouseMoved,
+				.activeAlways,
+				.inVisibleRect,
+			],
+			owner: self,
+			userInfo: nil
+		)
+		addTrackingArea(trackingArea)
+		hoverTrackingArea = trackingArea
+	}
+
+	override func mouseEntered(with event: NSEvent) {
+		isPointerInside = true
+		reportHoveredAccount(at: convert(event.locationInWindow, from: nil))
+	}
+
+	override func mouseExited(with _: NSEvent) {
+		isPointerInside = false
+		setHoveredAccount(nil)
+	}
+
+	override func mouseMoved(with event: NSEvent) {
+		reportHoveredAccount(at: convert(event.locationInWindow, from: nil))
+	}
+
+	override func hitTest(_: NSPoint) -> NSView? {
+		nil
+	}
+
+	private func reportHoveredAccount(at location: NSPoint) {
+		let accountID = cardFrames.first(where: { _, frame in
+			frame.contains(location)
+		})?.key
+		setHoveredAccount(accountID)
+	}
+
+	private func setHoveredAccount(_ accountID: String?) {
+		guard hoveredAccountID != accountID else {
+			return
+		}
+		hoveredAccountID = accountID
+		onHoveredAccountChanged(accountID)
+	}
+}
+
 enum AccountPanelLayout {
 	static let screenVerticalMargin: CGFloat = 44
 	static let panelVerticalPadding: CGFloat = 12

--- a/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountPanelView.swift
@@ -21,6 +21,7 @@ struct AccountPanelView: View {
 	@State private var measuredAccountListContentHeight: CGFloat = 0
 	@State private var accountCardFrames = [String: CGRect]()
 	@State private var accountReorderInteraction: AccountReorderInteraction?
+	@State private var hoveredAccountID: String?
 	@State private var isPresentingEnrollment = false
 	@State private var detailedAccountID: String?
 	@State private var fastMode: FastModeStore
@@ -349,6 +350,7 @@ struct AccountPanelView: View {
 							store: store,
 							showsEmail: accountPrivacy == AccountPrivacy.visible,
 							detailedAccountID: $detailedAccountID,
+							isAccountCardHovered: hoveredAccountID == state.id,
 							isReorderGestureEnabled: canDragAccount(state.id),
 							onReorderDragChanged: { translationY in
 								updateAccountReorder(
@@ -385,6 +387,13 @@ struct AccountPanelView: View {
 					}
 				}
 				.coordinateSpace(name: AccountCardReorderLayout.coordinateSpaceName)
+				.overlay {
+					AccountCardHoverTrackingView(
+						cardFrames: accountCardFrames,
+						onHoveredAccountChanged: updateHoveredAccount
+					)
+					.accessibilityHidden(true)
+				}
 				.padding(1)
 				.background(accountRowsHeightProbe)
 			}
@@ -413,6 +422,12 @@ struct AccountPanelView: View {
 		)
 		let states = interaction.baseOrder.compactMap { stateByID[$0] }
 		return states.count == store.accounts.count ? states : store.accounts
+	}
+
+	private func updateHoveredAccount(_ accountID: String?) {
+		if hoveredAccountID != accountID {
+			hoveredAccountID = accountID
+		}
 	}
 
 	private func updateAccountCardFrames(_ frames: [String: CGRect]) {

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -188,6 +188,7 @@ struct ResetCardAccountRow: View {
 	let state: ResetCardAccountState
 	let store: ResetCardStore
 	let showsEmail: Bool
+	let isAccountCardHovered: Bool
 	let isReorderGestureEnabled: Bool
 	let onReorderDragChanged: (CGFloat) -> Void
 	let onReorderDragEnded: () -> Void
@@ -196,7 +197,6 @@ struct ResetCardAccountRow: View {
 	@Environment(\.colorScheme) private var colorScheme
 	@State private var confirmation = ResetCardUseConfirmation()
 	@State private var confirmationSecondsRemaining = 0
-	@State private var isAccountCardHovered = false
 	@State private var isReorderHandleHovered = false
 	@State private var isReorderHandleDragging = false
 
@@ -205,6 +205,7 @@ struct ResetCardAccountRow: View {
 		store: ResetCardStore,
 		showsEmail: Bool = false,
 		detailedAccountID: Binding<String?> = .constant(nil),
+		isAccountCardHovered: Bool = false,
 		isReorderGestureEnabled: Bool = true,
 		onReorderDragChanged: @escaping (CGFloat) -> Void = { _ in },
 		onReorderDragEnded: @escaping () -> Void = {}
@@ -212,6 +213,7 @@ struct ResetCardAccountRow: View {
 		self.state = state
 		self.store = store
 		self.showsEmail = showsEmail
+		self.isAccountCardHovered = isAccountCardHovered
 		self.isReorderGestureEnabled = isReorderGestureEnabled
 		self.onReorderDragChanged = onReorderDragChanged
 		self.onReorderDragEnded = onReorderDragEnded
@@ -255,9 +257,6 @@ struct ResetCardAccountRow: View {
 				.offset(x: -PanelSpacing.micro)
 		}
 		.fixedSize(horizontal: false, vertical: true)
-		.onHover { isHovered in
-			isAccountCardHovered = isHovered
-		}
 		.accessibilityIdentifier("decodex.account.\(state.account.accountID)")
 		.onAppear {
 			confirmation.retainOnly(Set(state.targets))
@@ -340,7 +339,10 @@ struct ResetCardAccountRow: View {
 	private var showsReorderHandle: Bool {
 		store.canReorderAccounts
 			&& (
-				(isAccountCardHovered && isReorderGestureEnabled)
+				(
+					(isAccountCardHovered || isReorderHandleHovered)
+						&& isReorderGestureEnabled
+				)
 					|| isReorderHandleDragging
 			)
 	}

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -163,9 +163,45 @@ final class ResetCardArchitectureTests: XCTestCase {
 		)
 
 		XCTAssertTrue(rows.contains(#"Image(systemName: "line.3.horizontal")"#))
-		XCTAssertTrue(rows.contains("isAccountCardHovered"))
+		XCTAssertTrue(rows.contains("let isAccountCardHovered: Bool"))
+		XCTAssertFalse(rows.contains("@State private var isAccountCardHovered"))
+		XCTAssertFalse(rows.contains("isAccountCardHovered = isHovered"))
 		XCTAssertTrue(rows.contains("isReorderHandleHovered"))
 		XCTAssertTrue(rows.contains("isReorderHandleDragging"))
+		XCTAssertTrue(panel.contains("@State private var hoveredAccountID: String?"))
+		XCTAssertTrue(panel.contains(".panelCardSurface(cornerRadius: 16)"))
+		XCTAssertTrue(
+			panel.contains("isAccountCardHovered: hoveredAccountID == state.id")
+		)
+		XCTAssertEqual(
+			panel.components(separatedBy: "AccountCardHoverTrackingView(").count - 1,
+			1
+		)
+		XCTAssertTrue(
+			panel.contains("cardFrames: accountCardFrames")
+		)
+		XCTAssertTrue(
+			panel.contains("onHoveredAccountChanged: updateHoveredAccount")
+		)
+		XCTAssertFalse(panel.contains(".onContinuousHover"))
+		XCTAssertTrue(
+			support.contains("struct AccountCardHoverTrackingView: NSViewRepresentable")
+		)
+		XCTAssertTrue(support.contains("let cardFrames: [String: CGRect]"))
+		XCTAssertTrue(support.contains("NSTrackingArea("))
+		XCTAssertTrue(support.contains(".mouseEnteredAndExited"))
+		XCTAssertTrue(support.contains(".mouseMoved"))
+		XCTAssertTrue(support.contains(".inVisibleRect"))
+		XCTAssertTrue(support.contains("override func mouseMoved(with event: NSEvent)"))
+		XCTAssertTrue(
+			support.contains("override func hitTest(_: NSPoint) -> NSView?")
+		)
+		XCTAssertTrue(
+			rows.contains("isAccountCardHovered || isReorderHandleHovered")
+		)
+		XCTAssertFalse(rows.contains("DECODEX_HOVER_DEBUG"))
+		XCTAssertFalse(panel.contains("DECODEX_HOVER_DEBUG"))
+		XCTAssertFalse(support.contains("DECODEX_HOVER_DEBUG"))
 		XCTAssertTrue(rows.contains(".opacity(showsReorderHandle ? 1 : 0)"))
 		XCTAssertTrue(rows.contains(".frame(width: 14, height: 18)"))
 		XCTAssertTrue(rows.contains(".font(.system(size: 9, weight: .semibold))"))


### PR DESCRIPTION
Summary:
- Keep the account-card reorder handle visible across nested Reset Card content.
- Track hover once at list level without intercepting controls.
- Add architecture regression coverage.

Verification:
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app (202 passed)
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer scripts/macos/test_decodex_app_stage.sh