### PR TITLE
Constrain autonomous improvement reason retirement

### DIFF
--- a/automations/upstream/README.md
+++ b/automations/upstream/README.md
@@ -192,15 +192,27 @@ workspace manifest and patch digest, applies the patch to the unchanged candidat
 with `git apply --check --index --binary`, permits only regular file modes, rejects
 whitespace and unstaged or untracked residue, and authorizes every changed path for
 the candidate kind. It denies scheduler, GitHub Actions, authentication, landing,
-managed-repository, X execution, schema, and automation-control paths. The sole
-exception lets an `automation_repair` change the effect-free outcome evaluation
-module `upstream_autopilot_lib/effectiveness.py`; state persistence, CLI, effect,
-agent, watchdog, policy, manifest, and schema authority remain denied. Any rejected
-or internally invalid applied patch is reset to the exact clean baseline. A protected
-validator requires that module to remain non-executable `100644` source with exact
-imports, a bounded pure AST subset, no input mutation, no top-level execution, and no
-recursive call graph. Repairable tests cannot weaken this validator. The parent then
-writes the canonical create-only mode-`0600`
+managed-repository, X execution, schema, and automation-control paths. An
+`automation_repair` can change the effect-free outcome evaluation module
+`upstream_autopilot_lib/effectiveness.py`. A separate retirement-only exception can
+remove exactly one existing active reason literal per patch from the single
+`PROACTIVE_IMPROVEMENT_REASON_CODES = frozenset({...})` assignment in `core.py`.
+That active set owns new queue and CLI choices. The separate explicit
+`KNOWN_PROACTIVE_IMPROVEMENT_REASON_CODES` set is the immutable recognition
+authority for persisted candidates and retains retired identifiers.
+The parent compares the applied file with the exact non-executable `100644` blob at
+the expected head. The result must be non-empty and differ by exactly one removed
+reason, and the complete source must equal that blob with only that literal line
+removed. This path cannot edit the known set, add, rename, reformat, or otherwise
+grow authority.
+State persistence, CLI, effects, agent, watchdog, policy, manifest, schema,
+scheduler, landing, authentication, GitHub Actions, and X authority remain denied.
+Any rejected or
+internally invalid applied patch is reset to the exact clean baseline. A protected
+validator requires `effectiveness.py` to remain non-executable `100644` source with
+exact imports, a bounded pure AST subset, no input mutation, no top-level execution,
+and no recursive call graph. Repairable tests cannot weaken either validator. The
+parent then writes the canonical create-only mode-`0600`
 `decodex/codex-upstream-handoff-receipt/4` receipt. The receipt binds
 the fixed model and effort, Codex version and executable digest, command and
 permission digests, sandbox-probe, watchdog, workspace and evidence manifests,

--- a/automations/upstream/prompts/health.md
+++ b/automations/upstream/prompts/health.md
@@ -18,6 +18,12 @@ Authority:
 - Health may recover state, synchronize the five definitions, archive validated
   completed tasks, and queue concrete repair or improvement candidates. Maintainer
   and Reviewer own code changes and landing.
+- `PROACTIVE_IMPROVEMENT_REASON_CODES` is the active queue and CLI set.
+  `KNOWN_PROACTIVE_IMPROVEMENT_REASON_CODES` is immutable persisted-state
+  recognition and retains retired identifiers. An `automation_repair` may only
+  delete exactly one existing literal line per patch from the active assignment
+  under the trusted expected-head validator. It cannot edit the known set or grow
+  authority.
 
 Preflight:
 1. Run `pwd`, `git status --short --branch`, `git branch --show-current`, and

--- a/automations/upstream/prompts/maintainer.md
+++ b/automations/upstream/prompts/maintainer.md
@@ -144,14 +144,25 @@ Workflow:
    `automation_repair` may change only the exact effect-free outcome evaluation
    module
    `automations/upstream/scripts/upstream_autopilot_lib/effectiveness.py` in
-   addition to its normal repair paths. State persistence, CLI, effect, agent,
-   watchdog, policy, manifest, and schema authority remain denied. The protected
-   parent requires that module to remain non-executable `100644` source with fixed
-   imports, a bounded pure AST subset, no input mutation, no top-level execution,
-   and no recursive call graph. Repairable tests cannot weaken this check. A rejected
+   addition to its normal repair paths. It may also remove exactly one existing
+   active reason literal per patch from the single
+   `PROACTIVE_IMPROVEMENT_REASON_CODES = frozenset({...})` assignment in
+   `automations/upstream/scripts/upstream_autopilot_lib/core.py`. This is
+   retirement-only: leave at least one baseline reason, preserve the assignment and
+   call shape, and make no other source change. The active set controls new queue and
+   CLI choices. The explicit `KNOWN_PROACTIVE_IMPROVEMENT_REASON_CODES` set retains
+   immutable recognition of persisted reasons and must not change. The exception
+   cannot add or rename a reason or grow authority. The parent compares the result
+   with the exact non-executable
+   `100644` blob at the expected head. State persistence, CLI, effects, agent,
+   watchdog, policy, manifest, schema, scheduler, landing, authentication, GitHub
+   Actions, and X authority remain denied. The protected parent requires
+   `effectiveness.py` to remain non-executable `100644` source with fixed imports, a
+   bounded pure AST subset, no input mutation, no top-level execution, and no
+   recursive call graph. Repairable tests cannot weaken either check. A rejected
    patch is reset to the exact clean baseline. The parent then writes the canonical
-   create-only mode `0600` handoff receipt. State records the prepared child generation
-   before launch.
+   create-only mode `0600` handoff receipt. State records the prepared child
+   generation before launch.
    An active watchdog keeps retries at `agent_run_in_progress`; after a crash, the
    next retry either recovers the exact completed receipt or resets and reruns the
    same state-bound context. The fence must be held before any worktree inspection

--- a/automations/upstream/scripts/upstream_autopilot_lib/agent.py
+++ b/automations/upstream/scripts/upstream_autopilot_lib/agent.py
@@ -21,6 +21,7 @@ from typing import Any, Mapping, Sequence
 from .core import (
     ALLOWED_CANDIDATE_KINDS,
     CODEX_VERSION_PATTERN,
+    KNOWN_PROACTIVE_IMPROVEMENT_REASON_CODES,
     MAX_SCHEMA_BYTES,
     REASON_PATTERN,
     SHA_PATTERN,
@@ -155,6 +156,10 @@ AGENT_REPAIR_EVALUATION_EXACT_PATHS = {
     "automations/upstream/scripts/upstream_autopilot_lib/effectiveness.py",
 }
 AGENT_REPAIR_EVALUATION_MAX_BYTES = 64 * 1024
+AGENT_REPAIR_REASON_RETIREMENT_PATH = (
+    "automations/upstream/scripts/upstream_autopilot_lib/core.py"
+)
+AGENT_REPAIR_REASON_RETIREMENT_MAX_BYTES = 128 * 1024
 AGENT_PATCH_ALWAYS_DENIED_EXACT_PATHS = {
     "apps/decodex/src/accounts.rs",
     "apps/decodex/src/github.rs",
@@ -311,15 +316,26 @@ def _agent_patch_paths_authorized(
         if isinstance(path_summary, Mapping)
         else None
     )
-    if kind == "automation_repair" and reason_code == "x_pricing_contract_drift":
-        return all(path in X_PRICING_PATCH_PATHS for path in paths)
+    pricing_repair = bool(
+        kind == "automation_repair"
+        and reason_code == "x_pricing_contract_drift"
+    )
     for path in paths:
         evaluation_repair = bool(
             kind == "automation_repair"
             and path in AGENT_REPAIR_EVALUATION_EXACT_PATHS
         )
+        reason_retirement = bool(
+            kind == "automation_repair"
+            and path == AGENT_REPAIR_REASON_RETIREMENT_PATH
+        )
+        if pricing_repair:
+            if reason_retirement or path in X_PRICING_PATCH_PATHS:
+                continue
+            return False
         if (
             not evaluation_repair
+            and not reason_retirement
             and (
                 path in AGENT_PATCH_ALWAYS_DENIED_EXACT_PATHS
                 or any(
@@ -329,7 +345,7 @@ def _agent_patch_paths_authorized(
             )
         ):
             return False
-        if evaluation_repair:
+        if evaluation_repair or reason_retirement:
             continue
         if kind == "automation_repair":
             exact = AGENT_REPAIR_PATCH_ALLOWED_EXACT_PATHS
@@ -710,6 +726,293 @@ def _validate_repair_evaluation_file(path: Path) -> None:
     finally:
         if descriptor is not None:
             os.close(descriptor)
+
+
+def _reason_retirement_assignment(
+    source: bytes,
+) -> tuple[tuple[str, ...], dict[str, int]]:
+    failure_code = "agent_repair_reason_retirement_invalid"
+    if not isinstance(source, bytes) or not 1 <= len(source) <= (
+        AGENT_REPAIR_REASON_RETIREMENT_MAX_BYTES
+    ):
+        raise AutopilotError(failure_code)
+    try:
+        text = source.decode("utf-8")
+        tree = ast.parse(text, filename="core.py")
+    except (SyntaxError, UnicodeDecodeError, ValueError) as error:
+        raise AutopilotError(failure_code) from error
+
+    name = "PROACTIVE_IMPROVEMENT_REASON_CODES"
+    stored_names = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name)
+        and isinstance(node.ctx, ast.Store)
+        and node.id == name
+    ]
+    assignments = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == name
+    ]
+    if len(stored_names) != 1 or len(assignments) != 1:
+        raise AutopilotError(failure_code)
+
+    assignment = assignments[0]
+    target = assignment.targets[0]
+    call = assignment.value
+    if (
+        assignment.type_comment is not None
+        or not isinstance(target, ast.Name)
+        or not isinstance(target.ctx, ast.Store)
+        or not isinstance(call, ast.Call)
+        or not isinstance(call.func, ast.Name)
+        or not isinstance(call.func.ctx, ast.Load)
+        or call.func.id != "frozenset"
+        or len(call.args) != 1
+        or call.keywords
+        or not isinstance(call.args[0], ast.Set)
+        or not call.args[0].elts
+    ):
+        raise AutopilotError(failure_code)
+
+    lines = source.splitlines(keepends=True)
+    reasons: list[str] = []
+    reason_lines: dict[str, int] = {}
+    used_lines: set[int] = set()
+    for element in call.args[0].elts:
+        if (
+            not isinstance(element, ast.Constant)
+            or type(element.value) is not str
+            or REASON_PATTERN.fullmatch(element.value) is None
+            or element.lineno != element.end_lineno
+            or element.lineno < 1
+            or element.lineno > len(lines)
+            or element.col_offset < 0
+            or element.end_col_offset is None
+            or element.end_col_offset <= element.col_offset
+        ):
+            raise AutopilotError(failure_code)
+        reason = element.value
+        line_number = element.lineno
+        line = lines[line_number - 1]
+        prefix = line[: element.col_offset]
+        literal = line[element.col_offset : element.end_col_offset]
+        suffix = line[element.end_col_offset :]
+        expected_literal = f'"{reason}"'.encode("ascii")
+        if (
+            prefix.strip(b" \t")
+            or literal != expected_literal
+            or re.fullmatch(rb",[ \t]*(?:\r\n|\n)", suffix) is None
+            or reason in reason_lines
+            or line_number in used_lines
+        ):
+            raise AutopilotError(failure_code)
+        reasons.append(reason)
+        reason_lines[reason] = line_number
+        used_lines.add(line_number)
+    return tuple(reasons), reason_lines
+
+
+def _validate_reason_retirement_sources(
+    baseline: bytes,
+    applied: bytes,
+) -> None:
+    failure_code = "agent_repair_reason_retirement_invalid"
+    baseline_reasons, baseline_lines = _reason_retirement_assignment(baseline)
+    applied_reasons, _applied_lines = _reason_retirement_assignment(applied)
+    baseline_set = set(baseline_reasons)
+    applied_set = set(applied_reasons)
+    removed_reasons = baseline_set - applied_set
+    if (
+        not baseline_set <= KNOWN_PROACTIVE_IMPROVEMENT_REASON_CODES
+        or not applied_set
+        or not applied_set < baseline_set
+        or len(removed_reasons) != 1
+    ):
+        raise AutopilotError(failure_code)
+
+    removed_lines = {
+        baseline_lines[reason] for reason in removed_reasons
+    }
+    expected = b"".join(
+        line
+        for line_number, line in enumerate(
+            baseline.splitlines(keepends=True),
+            start=1,
+        )
+        if line_number not in removed_lines
+    )
+    if applied != expected:
+        raise AutopilotError(failure_code)
+
+
+def _expected_reason_retirement_blob(
+    worktree: Path,
+    *,
+    expected_head: str,
+    environment: Mapping[str, str],
+) -> bytes:
+    failure_code = "agent_repair_reason_retirement_invalid"
+    path = AGENT_REPAIR_REASON_RETIREMENT_PATH
+    entry = run_command(
+        ["git", "ls-tree", expected_head, "--", path],
+        cwd=worktree,
+        environment=environment,
+        inherit_environment=False,
+        failure_code=failure_code,
+        max_output_bytes=512,
+    )
+    try:
+        identity, observed_path = entry.split("\t", 1)
+        mode, object_type, object_id = identity.split(" ", 2)
+    except ValueError as error:
+        raise AutopilotError(failure_code) from error
+    if (
+        observed_path != path
+        or mode != "100644"
+        or object_type != "blob"
+        or SHA_PATTERN.fullmatch(object_id) is None
+    ):
+        raise AutopilotError(failure_code)
+
+    request = f"{object_id}\n{object_id}\n".encode("ascii")
+    output = run_command(
+        ["git", "cat-file", "--batch"],
+        cwd=worktree,
+        environment=environment,
+        inherit_environment=False,
+        input_bytes=request,
+        failure_code=failure_code,
+        max_input_bytes=len(request),
+        max_output_bytes=(AGENT_REPAIR_REASON_RETIREMENT_MAX_BYTES * 2) + 1024,
+    ).encode("utf-8")
+    header_end = output.find(b"\n")
+    if header_end < 0:
+        raise AutopilotError(failure_code)
+    header = output[:header_end]
+    try:
+        header_object_id, header_type, size_text = header.decode("ascii").split(
+            " ", 2
+        )
+        size = int(size_text)
+    except (UnicodeDecodeError, ValueError) as error:
+        raise AutopilotError(failure_code) from error
+    payload = output[header_end + 1 :]
+    if (
+        header_object_id != object_id
+        or header_type != "blob"
+        or not 1 <= size <= AGENT_REPAIR_REASON_RETIREMENT_MAX_BYTES
+        or len(payload) < size + 1
+        or payload[size : size + 1] != b"\n"
+        or not payload[size + 1 :].startswith(header + b"\n")
+    ):
+        raise AutopilotError(failure_code)
+    return payload[:size]
+
+
+def _applied_reason_retirement_source(
+    worktree: Path,
+    *,
+    environment: Mapping[str, str],
+) -> bytes:
+    failure_code = "agent_repair_reason_retirement_invalid"
+    path = AGENT_REPAIR_REASON_RETIREMENT_PATH
+    entry = run_command(
+        ["git", "ls-files", "--stage", "--", path],
+        cwd=worktree,
+        environment=environment,
+        inherit_environment=False,
+        failure_code=failure_code,
+        max_output_bytes=512,
+    )
+    try:
+        identity, observed_path = entry.split("\t", 1)
+        mode, object_id, stage = identity.split(" ", 2)
+    except ValueError as error:
+        raise AutopilotError(failure_code) from error
+    if (
+        observed_path != path
+        or mode != "100644"
+        or SHA_PATTERN.fullmatch(object_id) is None
+        or stage != "0"
+    ):
+        raise AutopilotError(failure_code)
+
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(worktree / path, os.O_RDONLY | os.O_NOFOLLOW)
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.getuid()
+            or metadata.st_nlink != 1
+            or metadata.st_mode & 0o022
+            or metadata.st_mode & 0o111
+            or not 1 <= metadata.st_size
+            <= AGENT_REPAIR_REASON_RETIREMENT_MAX_BYTES
+        ):
+            raise AutopilotError(failure_code)
+        source = bytearray()
+        while len(source) <= AGENT_REPAIR_REASON_RETIREMENT_MAX_BYTES:
+            chunk = os.read(
+                descriptor,
+                min(
+                    64 * 1024,
+                    AGENT_REPAIR_REASON_RETIREMENT_MAX_BYTES + 1 - len(source),
+                ),
+            )
+            if not chunk:
+                break
+            source.extend(chunk)
+        if len(source) != metadata.st_size:
+            raise AutopilotError(failure_code)
+    except AutopilotError:
+        raise
+    except OSError as error:
+        raise AutopilotError(failure_code) from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+    applied = bytes(source)
+    applied_object_id = run_command(
+        ["git", "hash-object", "--stdin"],
+        cwd=worktree,
+        environment=environment,
+        inherit_environment=False,
+        input_bytes=applied,
+        failure_code=failure_code,
+        max_input_bytes=AGENT_REPAIR_REASON_RETIREMENT_MAX_BYTES,
+        max_output_bytes=128,
+    )
+    if applied_object_id != object_id:
+        raise AutopilotError(failure_code)
+    return applied
+
+
+def _validate_repair_reason_retirement(
+    worktree: Path,
+    *,
+    candidate: Mapping[str, Any],
+    expected_head: str,
+    environment: Mapping[str, str],
+) -> None:
+    if candidate.get("kind") != "automation_repair":
+        raise AutopilotError("agent_repair_reason_retirement_invalid")
+    baseline = _expected_reason_retirement_blob(
+        worktree,
+        expected_head=expected_head,
+        environment=environment,
+    )
+    applied = _applied_reason_retirement_source(
+        worktree,
+        environment=environment,
+    )
+    _validate_reason_retirement_sources(baseline, applied)
 
 
 def _shell_environment_config(
@@ -2383,6 +2686,13 @@ def apply_agent_patch(
             changed_paths
         ):
             _validate_repair_evaluation_file(worktree / path)
+        if AGENT_REPAIR_REASON_RETIREMENT_PATH in changed_paths:
+            _validate_repair_reason_retirement(
+                worktree,
+                candidate=candidate,
+                expected_head=expected_head,
+                environment=environment,
+            )
         return changed_paths
     except BaseException:
         if applied:

--- a/automations/upstream/scripts/upstream_autopilot_lib/core.py
+++ b/automations/upstream/scripts/upstream_autopilot_lib/core.py
@@ -73,6 +73,18 @@ PROACTIVE_IMPROVEMENT_REASON_CODES = frozenset(
         "x_pricing_contract_drift",
     }
 )
+KNOWN_PROACTIVE_IMPROVEMENT_REASON_CODES = frozenset(
+    {
+        "assessment_only_churn",
+        "content_loop_degraded",
+        "lead_time_sla_missed",
+        "live_configuration_drift",
+        "repeated_blocked_attempts",
+        "repeated_review_repairs",
+        "task_retention_contract_drift",
+        "x_pricing_contract_drift",
+    }
+)
 X_PRICING_AUDIT_EVIDENCE_SCHEMA = "decodex/x-pricing-drift-evidence/1"
 X_PRICING_PARSER_VERSION = "x-pricing-markdown-table/1"
 X_PRICING_SOURCE_URL = (
@@ -950,7 +962,7 @@ def validate_path_summary(candidate: dict[str, Any]) -> None:
             or not is_sha256(summary["evidence_sha256"])
             or (
                 candidate.get("repair_of") is None
-                and reason_code not in PROACTIVE_IMPROVEMENT_REASON_CODES
+                and reason_code not in KNOWN_PROACTIVE_IMPROVEMENT_REASON_CODES
             )
         ):
             raise AutopilotError("candidate_path_summary_invalid")

--- a/automations/upstream/tests/test_upstream_autopilot.py
+++ b/automations/upstream/tests/test_upstream_autopilot.py
@@ -92,6 +92,118 @@ class UpstreamAutopilotTests(unittest.TestCase):
     def pricing_fixture(self) -> bytes:
         return X_PRICING_FIXTURE.read_bytes()
 
+    def create_reason_retirement_repository(self, directory, *, core_source=None):
+        worktree = Path(directory) / "repo"
+        worktree.mkdir()
+        subprocess.run(
+            ["git", "init", "-q", "--initial-branch=main"],
+            cwd=worktree,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.invalid"],
+            cwd=worktree,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=worktree,
+            check=True,
+        )
+        hooks = Path(directory) / "empty-hooks"
+        hooks.mkdir()
+        subprocess.run(
+            ["git", "config", "core.hooksPath", str(hooks)],
+            cwd=worktree,
+            check=True,
+        )
+        library = (
+            worktree
+            / "automations/upstream/scripts/upstream_autopilot_lib"
+        )
+        library.mkdir(parents=True)
+        source = (
+            core_source
+            if core_source is not None
+            else (
+                ROOT
+                / "automations/upstream/scripts/upstream_autopilot_lib/core.py"
+            ).read_bytes()
+        )
+        (library / "core.py").write_bytes(source)
+        (library / "state.py").write_text("STATE = 1\n", encoding="utf-8")
+        (library / "cli.py").write_text("CLI = 1\n", encoding="utf-8")
+        (library / "effects.py").write_text(
+            "EFFECTS = 1\n",
+            encoding="utf-8",
+        )
+        upstream = worktree / "automations/upstream"
+        (upstream / "policy.json").write_text("{}\n", encoding="utf-8")
+        (upstream / "README.md").write_text("base\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=worktree, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "base"],
+            cwd=worktree,
+            check=True,
+        )
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=worktree,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        tree = subprocess.run(
+            ["git", "rev-parse", "HEAD^{tree}"],
+            cwd=worktree,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        return worktree, library, head, tree
+
+    def build_agent_patch(
+        self,
+        worktree,
+        path,
+        source,
+        *,
+        extra_changes=(),
+        executable=False,
+    ):
+        path.write_bytes(source)
+        for extra_path, extra_source in extra_changes:
+            extra_path.write_bytes(extra_source)
+        if executable:
+            path.chmod(0o755)
+        subprocess.run(["git", "add", "-A"], cwd=worktree, check=True)
+        patch = subprocess.run(
+            ["git", "diff", "--cached", "--binary"],
+            cwd=worktree,
+            check=True,
+            capture_output=True,
+        ).stdout
+        self.assertTrue(patch)
+        subprocess.run(
+            ["git", "reset", "--hard", "-q", "HEAD"],
+            cwd=worktree,
+            check=True,
+        )
+        return patch
+
+    def assert_agent_patch_rolled_back(self, worktree, path, baseline):
+        self.assertEqual(path.read_bytes(), baseline)
+        self.assertEqual(
+            subprocess.run(
+                ["git", "status", "--porcelain=v1"],
+                cwd=worktree,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout,
+            "",
+        )
+
     def write_task_retention_evidence(
         self,
         repo_root,
@@ -2682,6 +2794,446 @@ def effectiveness_improvement_reason(state: dict[str, Any], *, now: int) -> str 
                 ):
                     validate(source.encode("utf-8"))
 
+    def test_automation_repair_can_retire_existing_reason_code(self):
+        with tempfile.TemporaryDirectory() as directory:
+            worktree, library, head, tree = (
+                self.create_reason_retirement_repository(directory)
+            )
+            core = library / "core.py"
+            baseline = core.read_bytes()
+            reason_line = b'        "repeated_blocked_attempts",\n'
+            self.assertEqual(baseline.count(reason_line), 2)
+            retired = baseline.replace(reason_line, b"", 1)
+            patch = self.build_agent_patch(worktree, core, retired)
+
+            changed = self.autopilot.apply_agent_patch(
+                worktree,
+                candidate={
+                    "id": "1" * 16,
+                    "kind": "automation_repair",
+                    "path_summary": {
+                        "reason_code": "repeated_blocked_attempts"
+                    },
+                },
+                patch=patch,
+                patch_sha256=hashlib.sha256(patch).hexdigest(),
+                expected_head=head,
+                expected_tree=tree,
+            )
+
+            self.assertEqual(
+                changed,
+                (
+                    "automations/upstream/scripts/"
+                    "upstream_autopilot_lib/core.py",
+                ),
+            )
+            self.assertEqual(core.read_bytes(), retired)
+            self.assertTrue(
+                subprocess.run(
+                    [
+                        "git",
+                        "ls-files",
+                        "--stage",
+                        "--",
+                        str(core.relative_to(worktree)),
+                    ],
+                    cwd=worktree,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout.startswith("100644 ")
+            )
+
+    def test_reason_retirement_source_validator_fails_closed(self):
+        baseline = (
+            ROOT
+            / "automations/upstream/scripts/upstream_autopilot_lib/core.py"
+        ).read_bytes()
+        validate = (
+            self.autopilot.agent_module._validate_reason_retirement_sources
+        )
+        reason_line = b'        "repeated_blocked_attempts",\n'
+        self.assertEqual(baseline.count(reason_line), 2)
+        retired = baseline.replace(reason_line, b"", 1)
+        validate(baseline, retired)
+
+        reasons, reason_lines = (
+            self.autopilot.agent_module._reason_retirement_assignment(baseline)
+        )
+        empty = b"".join(
+            line
+            for line_number, line in enumerate(
+                baseline.splitlines(keepends=True),
+                start=1,
+            )
+            if line_number not in set(reason_lines.values())
+        )
+        invalid_sources = {
+            "addition": baseline.replace(
+                reason_line,
+                b'        "new_reason",\n' + reason_line,
+                1,
+            ),
+            "rename": baseline.replace(
+                reason_line,
+                b'        "renamed_reason",\n',
+                1,
+            ),
+            "duplicate": baseline.replace(
+                reason_line,
+                reason_line + reason_line,
+                1,
+            ),
+            "non_string": baseline.replace(
+                reason_line,
+                b"        7,\n",
+                1,
+            ),
+            "empty": empty,
+            "missing_assignment": baseline.replace(
+                b"PROACTIVE_IMPROVEMENT_REASON_CODES =",
+                b"RETIRED_IMPROVEMENT_REASON_CODES =",
+                1,
+            ),
+            "multiple_assignments": retired
+            + b'\nPROACTIVE_IMPROVEMENT_REASON_CODES = frozenset({"extra"})\n',
+            "altered_shape": retired.replace(
+                b"PROACTIVE_IMPROVEMENT_REASON_CODES = frozenset(",
+                b"PROACTIVE_IMPROVEMENT_REASON_CODES = set(",
+                1,
+            ),
+            "formatting": retired.replace(
+                b'        "assessment_only_churn",\n',
+                b'            "assessment_only_churn",\n',
+                1,
+            ),
+            "comment": retired.replace(
+                b'        "assessment_only_churn",\n',
+                b'        "assessment_only_churn",  # retained\n',
+                1,
+            ),
+            "multiple_deletions": retired.replace(
+                b'        "assessment_only_churn",\n',
+                b"",
+                1,
+            ),
+            "non_utf8": retired + b"\xff",
+            "recognition_set": retired.replace(
+                b'        "repeated_blocked_attempts",\n',
+                b'        "renamed_reason",\n',
+                1,
+            ),
+        }
+        self.assertGreater(len(reasons), 1)
+        for kind, source in invalid_sources.items():
+            with self.subTest(kind=kind):
+                with self.assertRaisesRegex(
+                    self.autopilot.AutopilotError,
+                    "agent_repair_reason_retirement_invalid",
+                ):
+                    validate(baseline, source)
+
+        unrecognized_baseline = baseline.replace(
+            reason_line,
+            b'        "unrecognized_active_reason",\n' + reason_line,
+            1,
+        )
+        unrecognized_retirement = unrecognized_baseline.replace(
+            reason_line,
+            b"",
+            1,
+        )
+        with self.assertRaisesRegex(
+            self.autopilot.AutopilotError,
+            "agent_repair_reason_retirement_invalid",
+        ):
+            validate(unrecognized_baseline, unrecognized_retirement)
+
+    def test_reason_retirement_rejects_mode_and_source_changes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            worktree, library, head, tree = (
+                self.create_reason_retirement_repository(directory)
+            )
+            core = library / "core.py"
+            baseline = core.read_bytes()
+            retired = baseline.replace(
+                b'        "repeated_blocked_attempts",\n',
+                b"",
+                1,
+            )
+            variants = {
+                "addition": (
+                    baseline.replace(
+                        b'        "repeated_blocked_attempts",\n',
+                        b'        "new_reason",\n'
+                        b'        "repeated_blocked_attempts",\n',
+                        1,
+                    ),
+                    False,
+                ),
+                "unrelated": (
+                    retired.replace(
+                        b"MAX_STATE_CANDIDATES = 512",
+                        b"MAX_STATE_CANDIDATES = 513",
+                        1,
+                    ),
+                    False,
+                ),
+                "executable": (retired, True),
+                "formatting": (
+                    retired.replace(
+                        b'        "assessment_only_churn",\n',
+                        b'            "assessment_only_churn",\n',
+                        1,
+                    ),
+                    False,
+                ),
+                "comment": (
+                    retired.replace(
+                        b'        "assessment_only_churn",\n',
+                        b'        "assessment_only_churn",  # retained\n',
+                        1,
+                    ),
+                    False,
+                ),
+                "multiple_deletions": (
+                    retired.replace(
+                        b'        "assessment_only_churn",\n',
+                        b"",
+                        1,
+                    ),
+                    False,
+                ),
+                "recognition_set": (
+                    retired.replace(
+                        b'        "repeated_blocked_attempts",\n',
+                        b'        "renamed_reason",\n',
+                        1,
+                    ),
+                    False,
+                ),
+                "non_utf8": (retired + b"\xff", False),
+            }
+            for kind, (source, executable) in variants.items():
+                with self.subTest(kind=kind):
+                    patch = self.build_agent_patch(
+                        worktree,
+                        core,
+                        source,
+                        executable=executable,
+                    )
+                    with self.assertRaisesRegex(
+                        self.autopilot.AutopilotError,
+                        "agent_repair_reason_retirement_invalid",
+                    ):
+                        self.autopilot.apply_agent_patch(
+                            worktree,
+                            candidate={
+                                "id": "1" * 16,
+                                "kind": "automation_repair",
+                            },
+                            patch=patch,
+                            patch_sha256=hashlib.sha256(patch).hexdigest(),
+                            expected_head=head,
+                            expected_tree=tree,
+                        )
+                    self.assert_agent_patch_rolled_back(
+                        worktree,
+                        core,
+                        baseline,
+                    )
+
+    def test_reason_retirement_uses_exact_expected_head_blob_bytes(self):
+        baseline = (
+            ROOT
+            / "automations/upstream/scripts/upstream_autopilot_lib/core.py"
+        ).read_bytes() + b"\n"
+        self.assertTrue(baseline.endswith(b"\n\n"))
+        with tempfile.TemporaryDirectory() as directory:
+            worktree, library, head, tree = (
+                self.create_reason_retirement_repository(
+                    directory,
+                    core_source=baseline,
+                )
+            )
+            environment = {
+                "GIT_CONFIG_GLOBAL": "/dev/null",
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_TERMINAL_PROMPT": "0",
+                "GIT_OPTIONAL_LOCKS": "0",
+                "HOME": "/var/empty",
+                "LANG": "C.UTF-8",
+            }
+            core = library / "core.py"
+            core.write_bytes(b"worktree-only source\n")
+            observed = (
+                self.autopilot.agent_module._expected_reason_retirement_blob(
+                    worktree,
+                    expected_head=head,
+                    environment=environment,
+                )
+            )
+            self.assertEqual(observed, baseline)
+            subprocess.run(
+                ["git", "reset", "--hard", "-q", "HEAD"],
+                cwd=worktree,
+                check=True,
+            )
+            self.assertEqual(core.read_bytes(), baseline)
+
+            retired = baseline.replace(
+                b'        "repeated_blocked_attempts",\n',
+                b"",
+                1,
+            )
+            patch = self.build_agent_patch(worktree, core, retired)
+            changed = self.autopilot.apply_agent_patch(
+                worktree,
+                candidate={
+                    "id": "1" * 16,
+                    "kind": "automation_repair",
+                },
+                patch=patch,
+                patch_sha256=hashlib.sha256(patch).hexdigest(),
+                expected_head=head,
+                expected_tree=tree,
+            )
+            self.assertEqual(
+                changed,
+                (
+                    "automations/upstream/scripts/"
+                    "upstream_autopilot_lib/core.py",
+                ),
+            )
+            self.assertEqual(core.read_bytes(), retired)
+
+    def test_x_pricing_repair_can_retire_its_active_reason(self):
+        with tempfile.TemporaryDirectory() as directory:
+            worktree, library, head, tree = (
+                self.create_reason_retirement_repository(directory)
+            )
+            core = library / "core.py"
+            baseline = core.read_bytes()
+            retired = baseline.replace(
+                b'        "x_pricing_contract_drift",\n',
+                b"",
+                1,
+            )
+            readme = worktree / "automations/upstream/README.md"
+            readme_baseline = readme.read_bytes()
+            patch = self.build_agent_patch(
+                worktree,
+                core,
+                retired,
+                extra_changes=((readme, b"pricing retired\n"),),
+            )
+
+            changed = self.autopilot.apply_agent_patch(
+                worktree,
+                candidate={
+                    "id": "2" * 16,
+                    "kind": "automation_repair",
+                    "path_summary": {
+                        "reason_code": "x_pricing_contract_drift"
+                    },
+                },
+                patch=patch,
+                patch_sha256=hashlib.sha256(patch).hexdigest(),
+                expected_head=head,
+                expected_tree=tree,
+            )
+            self.assertEqual(
+                set(changed),
+                {
+                    "automations/upstream/README.md",
+                    "automations/upstream/scripts/"
+                    "upstream_autopilot_lib/core.py",
+                },
+            )
+            self.assertEqual(core.read_bytes(), retired)
+            self.assertNotEqual(readme.read_bytes(), readme_baseline)
+
+    def test_non_automation_candidate_cannot_retire_reason_code(self):
+        with tempfile.TemporaryDirectory() as directory:
+            worktree, library, head, tree = (
+                self.create_reason_retirement_repository(directory)
+            )
+            core = library / "core.py"
+            baseline = core.read_bytes()
+            retired = baseline.replace(
+                b'        "repeated_blocked_attempts",\n',
+                b"",
+                1,
+            )
+            patch = self.build_agent_patch(worktree, core, retired)
+
+            with self.assertRaisesRegex(
+                self.autopilot.AutopilotError,
+                "agent_patch_path_unauthorized",
+            ):
+                self.autopilot.apply_agent_patch(
+                    worktree,
+                    candidate={"id": "0" * 16, "kind": "bootstrap"},
+                    patch=patch,
+                    patch_sha256=hashlib.sha256(patch).hexdigest(),
+                    expected_head=head,
+                    expected_tree=tree,
+                )
+            self.assert_agent_patch_rolled_back(worktree, core, baseline)
+
+    def test_reason_retirement_mixed_with_control_plane_change_is_denied(self):
+        with tempfile.TemporaryDirectory() as directory:
+            worktree, library, head, tree = (
+                self.create_reason_retirement_repository(directory)
+            )
+            core = library / "core.py"
+            core_baseline = core.read_bytes()
+            retired = core_baseline.replace(
+                b'        "repeated_blocked_attempts",\n',
+                b"",
+                1,
+            )
+            candidate = {
+                "id": "1" * 16,
+                "kind": "automation_repair",
+            }
+            denied_paths = (
+                library / "state.py",
+                library / "cli.py",
+                library / "effects.py",
+                worktree / "automations/upstream/policy.json",
+            )
+            for path in denied_paths:
+                baseline = path.read_bytes()
+                patch = self.build_agent_patch(
+                    worktree,
+                    core,
+                    retired,
+                    extra_changes=(
+                        (path, baseline + b"EXTRA_AUTHORITY = True\n"),
+                    ),
+                )
+                with self.subTest(path=path.relative_to(worktree)):
+                    with self.assertRaisesRegex(
+                        self.autopilot.AutopilotError,
+                        "agent_patch_path_unauthorized",
+                    ):
+                        self.autopilot.apply_agent_patch(
+                            worktree,
+                            candidate=candidate,
+                            patch=patch,
+                            patch_sha256=hashlib.sha256(patch).hexdigest(),
+                            expected_head=head,
+                            expected_tree=tree,
+                        )
+                    self.assertEqual(core.read_bytes(), core_baseline)
+                    self.assert_agent_patch_rolled_back(
+                        worktree,
+                        path,
+                        baseline,
+                    )
+
     def test_agent_patch_authorization_denies_control_planes_and_rolls_back(
         self,
     ):
@@ -2716,6 +3268,24 @@ def effectiveness_improvement_reason(state: dict[str, Any], *, now: int) -> str 
                 ],
             )
         )
+        self.assertTrue(
+            authorize(
+                repair,
+                [
+                    "automations/upstream/scripts/"
+                    "upstream_autopilot_lib/core.py"
+                ],
+            )
+        )
+        self.assertFalse(
+            authorize(
+                normal,
+                [
+                    "automations/upstream/scripts/"
+                    "upstream_autopilot_lib/core.py"
+                ],
+            )
+        )
         for path in (
             ".github/workflows/ci.yml",
             "apps/decodex/src/manual/land.rs",
@@ -2734,6 +3304,8 @@ def effectiveness_improvement_reason(state: dict[str, Any], *, now: int) -> str 
                 [
                     "apps/decodex-publisher/src/social_xurl/pricing.rs",
                     "automations/upstream/tests/fixtures/x-pricing-current.md",
+                    "automations/upstream/scripts/"
+                    "upstream_autopilot_lib/core.py",
                 ],
             )
         )
@@ -2746,6 +3318,17 @@ def effectiveness_improvement_reason(state: dict[str, Any], *, now: int) -> str 
                 [
                     "automations/upstream/scripts/"
                     "upstream_autopilot_lib/effectiveness.py"
+                ],
+            )
+        )
+        self.assertFalse(
+            authorize(
+                pricing,
+                [
+                    "automations/upstream/scripts/"
+                    "upstream_autopilot_lib/core.py",
+                    "automations/upstream/scripts/"
+                    "upstream_autopilot_lib/state.py",
                 ],
             )
         )
@@ -15249,6 +15832,74 @@ def effectiveness_improvement_reason(state: dict[str, Any], *, now: int) -> str 
             "repeated_review_repairs",
         )
         self.autopilot.validate_state(state)
+
+    def test_inactive_proactive_reason_remains_loadable_from_state(self):
+        reason = "repeated_blocked_attempts"
+        self.assertLessEqual(
+            self.autopilot.PROACTIVE_IMPROVEMENT_REASON_CODES,
+            self.autopilot.KNOWN_PROACTIVE_IMPROVEMENT_REASON_CODES,
+        )
+        self.assertIn(
+            reason,
+            self.autopilot.KNOWN_PROACTIVE_IMPROVEMENT_REASON_CODES,
+        )
+        state, candidate_id = self.bootstrap(now=100)
+        self.resolve_bootstrap(state, candidate_id, now=101)
+        improvement = self.autopilot.queue_automation_improvement(
+            state,
+            self.policy,
+            reason_code=reason,
+            repository_head="9" * 40,
+            now=200,
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state-v4.json"
+            self.autopilot.save_state(state, path, 201)
+            inactive = frozenset(
+                self.autopilot.PROACTIVE_IMPROVEMENT_REASON_CODES - {reason}
+            )
+            with (
+                mock.patch.object(
+                    self.autopilot.core_module,
+                    "PROACTIVE_IMPROVEMENT_REASON_CODES",
+                    inactive,
+                ),
+                mock.patch.object(
+                    self.autopilot.state_module,
+                    "PROACTIVE_IMPROVEMENT_REASON_CODES",
+                    inactive,
+                ),
+                mock.patch.object(
+                    self.autopilot.cli_module,
+                    "PROACTIVE_IMPROVEMENT_REASON_CODES",
+                    inactive,
+                ),
+            ):
+                loaded = self.autopilot.load_state(path)
+                persisted = self.autopilot.find_candidate(
+                    loaded,
+                    improvement["id"],
+                )
+                self.assertEqual(
+                    persisted["path_summary"]["reason_code"],
+                    reason,
+                )
+                self.assertNotIn(
+                    reason,
+                    self.autopilot.cli_module.PROACTIVE_IMPROVEMENT_REASON_CODES,
+                )
+                with self.assertRaisesRegex(
+                    self.autopilot.AutopilotError,
+                    "improvement_reason_invalid",
+                ):
+                    self.autopilot.queue_automation_improvement(
+                        loaded,
+                        self.policy,
+                        reason_code=reason,
+                        repository_head="9" * 40,
+                        now=202,
+                    )
 
     def test_live_drift_is_not_suppressed_by_another_active_improvement(self):
         state, candidate_id = self.bootstrap(now=100)

--- a/openwiki/operations/codex-upstream-autopilot.md
+++ b/openwiki/operations/codex-upstream-autopilot.md
@@ -96,14 +96,24 @@ digests, applies the patch to the unchanged candidate with Git's indexed binary
 patch path, permits only regular modes, and authorizes each changed path for the
 candidate kind. Scheduler, GitHub Actions, authentication, landing,
 managed-repository, X execution, schema, and automation-control paths are denied.
-The sole exception lets an `automation_repair` change the effect-free outcome
-evaluation module `upstream_autopilot_lib/effectiveness.py`; state persistence,
-CLI, effect, agent, watchdog, policy, manifest, and schema authority remain denied.
-The protected parent requires that module to remain non-executable `100644` source
-with fixed imports, a bounded pure AST subset, no input mutation, no top-level
-execution, and no recursive call graph. Repairable tests cannot weaken this check.
-Any rejected or internally invalid applied patch is reset to the exact clean
-baseline. The parent then writes the create-only mode-`0600` handoff receipt. The
+An `automation_repair` can change the effect-free outcome evaluation module
+`upstream_autopilot_lib/effectiveness.py`. A separate retirement-only exception can
+remove exactly one existing active reason literal per patch from the single
+`PROACTIVE_IMPROVEMENT_REASON_CODES = frozenset({...})` assignment in `core.py`.
+This active set controls new queue and CLI choices. The separate explicit
+`KNOWN_PROACTIVE_IMPROVEMENT_REASON_CODES` set is immutable persisted-state
+recognition and retains identifiers after retirement.
+The parent compares the applied source with the exact non-executable `100644` blob
+at the expected head. The new reason set must be non-empty and differ by exactly one
+removed reason, and no other source byte can change. The exception cannot edit the
+known set, add or rename reasons, or grow control-plane authority. State persistence,
+CLI, effects, agent, watchdog, policy, manifest, schema, scheduler, landing,
+authentication, GitHub Actions, and X paths remain denied. The protected parent
+requires `effectiveness.py` to retain fixed imports, a bounded pure AST subset, no
+input mutation, no top-level execution, and no recursive call graph. Repairable
+tests cannot weaken either validator. Any rejected or internally invalid applied
+patch is reset to the exact clean baseline. The parent then writes the create-only
+mode-`0600` handoff receipt. The
 candidate-and-role lock remains held through receipt persistence. A global root lock
 serializes stale-run cleanup and safe removal of inactive candidate lock files. A
 retry cannot overlap an active child, and lock-file churn cannot consume the run-root


### PR DESCRIPTION
## Summary
- separate active improvement reasons from persisted-state recognition
- allow automation repair to retire exactly one active reason under exact-head, byte, mode, and rollback checks
- preserve X-pricing path restrictions and document the authority boundary

## Verification
- independent Sol/max review: no findings
- `cargo make test-automations` (342 passed)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-upstream-automation` (passed in 531.82s)
- `git diff --check`