### PR TITLE
Accept exact Radar artifact file inputs

### DIFF
--- a/apps/radar/src/private_fs.rs
+++ b/apps/radar/src/private_fs.rs
@@ -194,6 +194,55 @@ impl PrivateCache {
 			.transpose()
 	}
 
+	pub(crate) fn entry_kind(&self, relative: &Path) -> Result<Option<PrivateEntryKind>> {
+		self.entry_kind_with(relative, || {})
+	}
+
+	fn entry_kind_with(
+		&self,
+		relative: &Path,
+		after_snapshot: impl FnOnce(),
+	) -> Result<Option<PrivateEntryKind>> {
+		let (parent, name) = match self.open_parent(relative, false) {
+			Ok(value) => value,
+			Err(error) if is_not_found(&error) => {
+				self.verify_binding()?;
+
+				return Ok(None);
+			},
+			Err(error) => return Err(error),
+		};
+		let Some(snapshot) = file_snapshot_at(parent.as_raw_fd(), &name)? else {
+			self.verify_binding()?;
+
+			return Ok(None);
+		};
+		after_snapshot();
+		let kind = if snapshot.file_type == u32::from(libc::S_IFREG) {
+			validate_private_file_snapshot(&snapshot, "entry")?;
+
+			PrivateEntryKind::File
+		} else if snapshot.file_type == u32::from(libc::S_IFDIR) {
+			validate_private_directory_snapshot(&snapshot, "entry")?;
+
+			PrivateEntryKind::Directory
+		} else {
+			eyre::bail!("Radar cache entry must be a regular file or non-symlink directory");
+		};
+		let (current_parent, current_name) = self.open_parent(relative, false)?;
+		let current =
+			file_snapshot_at(current_parent.as_raw_fd(), &current_name)?.ok_or_else(|| {
+				eyre::eyre!("Radar cache entry disappeared during metadata inspection")
+			})?;
+
+		if current != snapshot {
+			eyre::bail!("Radar cache entry changed during metadata inspection");
+		}
+		self.verify_binding()?;
+
+		Ok(Some(kind))
+	}
+
 	pub(crate) fn create_directory_all(&self, relative: &Path) -> Result<()> {
 		drop(self.open_directory(relative, true)?);
 		self.verify_binding()
@@ -1182,6 +1231,20 @@ fn validate_private_file_snapshot(snapshot: &FileSnapshot, label: &str) -> Resul
 	)
 }
 
+fn validate_private_directory_snapshot(snapshot: &FileSnapshot, label: &str) -> Result<()> {
+	if snapshot.file_type != u32::from(libc::S_IFDIR) {
+		eyre::bail!("Radar cache {label} must be a non-symlink directory");
+	}
+	validate_owner_mode_link(
+		snapshot.uid,
+		snapshot.mode,
+		snapshot.nlink,
+		PRIVATE_DIR_MODE,
+		label,
+		false,
+	)
+}
+
 fn validate_private_directory(file: &File, label: &str) -> Result<DirectoryIdentity> {
 	let metadata = file.metadata()?;
 
@@ -1643,6 +1706,28 @@ pub(crate) fn private_file_exists(path: &Path) -> Result<bool> {
 	};
 
 	Ok(cache.metadata(&location.relative)?.is_some())
+}
+
+pub(crate) fn private_entry_kind(path: &Path) -> Result<Option<PrivateEntryKind>> {
+	let location = private_file_path(path)?;
+	let cache = match PrivateCache::open_existing(&location.root) {
+		Ok(cache) => cache,
+		Err(error) if is_not_found(&error) => return Ok(None),
+		Err(error) => return Err(error),
+	};
+
+	cache.entry_kind(&location.relative)
+}
+
+#[cfg(test)]
+pub(crate) fn private_entry_kind_after_snapshot(
+	path: &Path,
+	after_snapshot: impl FnOnce(),
+) -> Result<Option<PrivateEntryKind>> {
+	let location = private_file_path(path)?;
+	let cache = PrivateCache::open_existing(&location.root)?;
+
+	cache.entry_kind_with(&location.relative, after_snapshot)
 }
 
 pub(crate) fn private_file_exists_under_lock(lock: &RadarCacheLock, path: &Path) -> Result<bool> {

--- a/apps/radar/src/tests/artifacts/artifact_files.rs
+++ b/apps/radar/src/tests/artifacts/artifact_files.rs
@@ -1,4 +1,4 @@
-use std::{fs, sync::mpsc, thread};
+use std::{ffi::CString, fs, os::unix::ffi::OsStrExt as _, sync::mpsc, thread};
 
 use serde_json::Value;
 
@@ -81,6 +81,155 @@ fn validates_json_files_from_directory() {
 	.expect("valid temporary bundle should pass");
 
 	assert_eq!(report.checked_files, 1);
+}
+
+#[test]
+fn validates_explicit_private_cache_files_by_absolute_path() {
+	let temp_dir = crate::test_support::private_tempdir();
+	let pair = temp_dir
+		.path()
+		.join(crate::DEFAULT_CACHE_ROOT)
+		.join("github/content-review-pairs/test-pair");
+	let review = pair.join("review.json");
+	let impact = pair.join("impact.json");
+
+	crate::write_json(&review, &fixtures::valid_upstream_review())
+		.expect("private review should be written");
+	crate::write_json(&impact, &fixtures::valid_upstream_impact())
+		.expect("private impact should be written");
+	assert!(review.is_absolute());
+	assert!(impact.is_absolute());
+
+	let report = crate::validate(&RadarValidateRequest {
+		paths: vec![review, impact],
+		max_age_hours: None,
+		bootstrap: false,
+	})
+	.expect("exact private review and impact files should pass");
+
+	assert_eq!(report.checked_files, 2);
+}
+
+#[test]
+fn validates_json_files_from_explicit_private_cache_directory() {
+	let temp_dir = crate::test_support::private_tempdir();
+	let directory = temp_dir
+		.path()
+		.join(crate::DEFAULT_CACHE_ROOT)
+		.join("github/test-validation-directory.json");
+
+	crate::write_json(&directory.join("bundle.json"), &fixtures::valid_bundle())
+		.expect("private bundle should be written");
+
+	let report = crate::validate(&RadarValidateRequest {
+		paths: vec![directory],
+		max_age_hours: None,
+		bootstrap: false,
+	})
+	.expect("an explicit private cache directory should still be traversed");
+
+	assert_eq!(report.checked_files, 1);
+}
+
+#[test]
+fn explicit_private_cache_regular_file_applies_json_extension_filter_after_classification() {
+	let temp_dir = crate::test_support::private_tempdir();
+	let non_json = temp_dir
+		.path()
+		.join(crate::DEFAULT_CACHE_ROOT)
+		.join("github/content-review-pairs/test-pair/review.txt");
+
+	crate::write_private_file_atomic(&non_json, b"not a JSON artifact")
+		.expect("private non-JSON file should be written safely");
+
+	let report = crate::validate(&RadarValidateRequest {
+		paths: vec![non_json],
+		max_age_hours: None,
+		bootstrap: false,
+	})
+	.expect("an actual non-JSON private file should be filtered out");
+
+	assert_eq!(report.checked_files, 0);
+}
+
+#[test]
+fn explicit_private_cache_file_validation_rejects_symlink_leaf() {
+	let temp_dir = crate::test_support::private_tempdir();
+	let pair = temp_dir
+		.path()
+		.join(crate::DEFAULT_CACHE_ROOT)
+		.join("github/content-review-pairs/test-pair");
+	let review = pair.join("review.json");
+	let linked = pair.join("linked-review.json");
+
+	crate::write_json(&review, &fixtures::valid_upstream_review())
+		.expect("private review should be written");
+	std::os::unix::fs::symlink(&review, &linked).expect("symlink fixture should be created");
+
+	let error = crate::validate(&RadarValidateRequest {
+		paths: vec![linked],
+		max_age_hours: None,
+		bootstrap: false,
+	})
+	.expect_err("a symlinked private validation file must fail closed");
+
+	assert!(error.to_string().contains("symlink"), "unexpected symlink error: {error:?}");
+}
+
+#[test]
+fn explicit_private_cache_file_validation_rejects_unexpected_entry_type() {
+	let temp_dir = crate::test_support::private_tempdir();
+	let fifo = temp_dir
+		.path()
+		.join(crate::DEFAULT_CACHE_ROOT)
+		.join("github/content-review-pairs/test-pair/review.json");
+
+	crate::ensure_private_directory(fifo.parent().expect("FIFO parent should exist"))
+		.expect("private FIFO parent should be created");
+	let fifo_path =
+		CString::new(fifo.as_os_str().as_bytes()).expect("FIFO path should not contain NUL");
+
+	assert_eq!(
+		unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) },
+		0,
+		"FIFO fixture should be created"
+	);
+
+	let error = crate::validate(&RadarValidateRequest {
+		paths: vec![fifo],
+		max_age_hours: None,
+		bootstrap: false,
+	})
+	.expect_err("an unexpected private validation entry type must fail closed");
+
+	assert!(
+		error.to_string().contains("regular") || error.to_string().contains("unsupported"),
+		"unexpected entry-type error: {error:?}"
+	);
+}
+
+#[test]
+fn explicit_private_cache_file_validation_rejects_malformed_json() {
+	let temp_dir = crate::test_support::private_tempdir();
+	let malformed = temp_dir
+		.path()
+		.join(crate::DEFAULT_CACHE_ROOT)
+		.join("github/content-review-pairs/test-pair/review.json");
+
+	crate::write_private_file_atomic(&malformed, b"{not-json")
+		.expect("malformed private JSON should be written safely");
+
+	let error = crate::validate(&RadarValidateRequest {
+		paths: vec![malformed],
+		max_age_hours: None,
+		bootstrap: false,
+	})
+	.expect_err("malformed private validation JSON must fail closed");
+
+	assert!(
+		error.to_string().contains("Failed to parse JSON"),
+		"unexpected parse error: {error:?}"
+	);
 }
 
 #[test]

--- a/apps/radar/src/tests/automation/cache.rs
+++ b/apps/radar/src/tests/automation/cache.rs
@@ -378,6 +378,77 @@ fn private_cache_read_stops_at_the_bound_when_a_file_grows_after_metadata() {
 }
 
 #[test]
+fn private_entry_kind_rejects_replacement_between_snapshots() {
+	let temp_dir = crate::test_support::private_tempdir();
+	let path =
+		temp_dir.path().join(crate::DEFAULT_CACHE_ROOT).join("github/test-files/review.json");
+	let displaced = path.with_file_name("original-review.json");
+
+	private_file(&path, b"old", SystemTime::now());
+	let replacement = path.clone();
+	let error = crate::private_fs::private_entry_kind_after_snapshot(&path, move || {
+		fs::rename(&replacement, displaced).expect("original entry should be displaced");
+		private_file(&replacement, b"new", SystemTime::now());
+	})
+	.expect_err("entry replacement between snapshots must fail closed");
+
+	assert!(
+		error.to_string().contains("changed during metadata inspection"),
+		"unexpected replacement error: {error:?}"
+	);
+	assert_eq!(fs::read(path).expect("replacement entry should remain"), b"new");
+}
+
+#[test]
+fn private_entry_kind_rejects_disappearance_between_snapshots() {
+	let temp_dir = crate::test_support::private_tempdir();
+	let path =
+		temp_dir.path().join(crate::DEFAULT_CACHE_ROOT).join("github/test-files/review.json");
+
+	private_file(&path, b"old", SystemTime::now());
+	let removed = path.clone();
+	let error = crate::private_fs::private_entry_kind_after_snapshot(&path, move || {
+		fs::remove_file(removed).expect("entry should be removed after its first snapshot");
+	})
+	.expect_err("entry disappearance between snapshots must fail closed");
+
+	assert!(
+		error.to_string().contains("disappeared during metadata inspection"),
+		"unexpected disappearance error: {error:?}"
+	);
+	assert!(!path.exists());
+}
+
+#[test]
+fn private_entry_kind_rejects_symlink_substitution_between_snapshots() {
+	let temp_dir = crate::test_support::private_tempdir();
+	let path =
+		temp_dir.path().join(crate::DEFAULT_CACHE_ROOT).join("github/test-files/review.json");
+	let displaced = path.with_file_name("original-review.json");
+
+	private_file(&path, b"old", SystemTime::now());
+	let substitute = path.clone();
+	let target = displaced.clone();
+	let error = crate::private_fs::private_entry_kind_after_snapshot(&path, move || {
+		fs::rename(&substitute, &target).expect("original entry should be displaced");
+		std::os::unix::fs::symlink(&target, &substitute)
+			.expect("symlink substitute should be installed");
+	})
+	.expect_err("symlink substitution between snapshots must fail closed");
+
+	assert!(
+		error.to_string().contains("changed during metadata inspection"),
+		"unexpected symlink substitution error: {error:?}"
+	);
+	assert!(
+		fs::symlink_metadata(path)
+			.expect("symlink substitute should remain")
+			.file_type()
+			.is_symlink()
+	);
+}
+
+#[test]
 fn cache_lock_serializes_writers_and_gc_deletion_revalidates_identity() {
 	let temp_dir = crate::test_support::private_tempdir();
 	let root = temp_dir.path().join(crate::DEFAULT_CACHE_ROOT);

--- a/apps/radar/src/validation_files/files.rs
+++ b/apps/radar/src/validation_files/files.rs
@@ -34,7 +34,22 @@ pub(crate) fn collect_json_files(
 
 fn collect_json_path(path: &Path, files: &mut Vec<PathBuf>) -> crate::prelude::Result<()> {
 	if crate::is_radar_cache_path(path) {
-		files.extend(crate::collect_private_json_files(path)?);
+		match crate::private_fs::private_entry_kind(path)? {
+			Some(crate::private_fs::PrivateEntryKind::File) => {
+				if path.extension().is_some_and(|extension| extension == "json") {
+					files.push(path.to_path_buf());
+				}
+			},
+			Some(crate::private_fs::PrivateEntryKind::Directory) => {
+				files.extend(crate::collect_private_json_files(path)?);
+			},
+			None => {
+				return Err(eyre::eyre!(
+					"Radar validation path does not exist: {}",
+					path.display()
+				));
+			},
+		}
 
 		return Ok(());
 	}

--- a/apps/radar/tests/validate_cli.rs
+++ b/apps/radar/tests/validate_cli.rs
@@ -1,0 +1,66 @@
+//! CLI regressions for Radar validation paths.
+
+#![allow(unused_crate_dependencies)]
+
+use std::{fs, os::unix::fs::PermissionsExt as _, path::Path, process::Command};
+
+use serde_json::Value;
+
+#[path = "../src/tests/fixtures/valid_upstream_impact.rs"] mod valid_upstream_impact_fixture;
+#[path = "../src/tests/fixtures/valid_upstream_review.rs"] mod valid_upstream_review_fixture;
+
+const CACHE_ROOT: &str = ".agent/automations/radar/cache";
+const PAIR_ROOT: &str =
+	".agent/automations/radar/cache/github/content-review-pairs/content-manager--fixture";
+const REVIEW_PATH: &str = ".agent/automations/radar/cache/github/content-review-pairs/content-manager--fixture/review.json";
+const IMPACT_PATH: &str = ".agent/automations/radar/cache/github/content-review-pairs/content-manager--fixture/impact.json";
+
+#[test]
+fn validate_cli_accepts_content_manager_relative_pair_paths_from_an_isolated_cwd() {
+	let cwd = tempfile::tempdir().expect("isolated CLI cwd should be created");
+	let pair_root = cwd.path().join(PAIR_ROOT);
+
+	fs::create_dir_all(&pair_root).expect("private pair directory should be created");
+	for relative in [
+		CACHE_ROOT,
+		".agent/automations/radar/cache/github",
+		".agent/automations/radar/cache/github/content-review-pairs",
+		PAIR_ROOT,
+	] {
+		fs::set_permissions(cwd.path().join(relative), fs::Permissions::from_mode(0o700))
+			.expect("private cache directory mode should be set");
+	}
+	write_private_json(
+		&cwd.path().join(REVIEW_PATH),
+		&valid_upstream_review_fixture::valid_upstream_review(),
+	);
+	write_private_json(
+		&cwd.path().join(IMPACT_PATH),
+		&valid_upstream_impact_fixture::valid_upstream_impact(),
+	);
+
+	let output = Command::new(env!("CARGO_BIN_EXE_radar"))
+		.current_dir(cwd.path())
+		.args(["validate", REVIEW_PATH, IMPACT_PATH])
+		.output()
+		.expect("Radar CLI should run");
+
+	assert!(
+		output.status.success(),
+		"relative Content Manager validation failed: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let report: Value =
+		serde_json::from_slice(&output.stdout).expect("Radar CLI report should be JSON");
+
+	assert_eq!(report["checked_files"], 2);
+}
+
+fn write_private_json(path: &Path, value: &Value) {
+	let mut payload = serde_json::to_vec_pretty(value).expect("fixture should serialize");
+
+	payload.push(b'\n');
+	fs::write(path, payload).expect("private fixture should be written");
+	fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+		.expect("private fixture mode should be set");
+}


### PR DESCRIPTION
## Summary

- accept exact review and impact artifact file paths in `radar validate`
- classify private-cache entries by descriptor-relative filesystem type instead of filename suffix
- fail closed if an input is replaced, removed, or changed to a symlink during validation
- cover the exact relative CLI workflow used by Content Manager

## Verification

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-upstream-automation`
- 110 Radar unit tests and the relative CLI integration test passed
- strict clippy, nightly format, private-cache fence tests, PostgreSQL matrix, and restore checks passed
- independent Sol/max review found no remaining P0-P2 findings

## Live incident

Repairs a real Content Manager cycle in which a valid Radar review/impact pair passed full cache validation but failed the required exact-file command with `Not a directory (os error 20)`. The original live artifact pair now validates successfully with this build. No X API call or publication is part of this change.