### PR TITLE
Make successful automation tasks self-archive

### DIFF
--- a/automations/decodex/prompts/content-manager.md
+++ b/automations/decodex/prompts/content-manager.md
@@ -40,8 +40,13 @@ Workflow:
    experiment. Do not store post text or any prohibited memory content.
 
 Success and stop conditions:
-- End with one validated candidate, one validated no-op, or no write when another unconsumed candidate
-  already exists.
+- A validated content candidate, a validated content no-op, or a validated no-write result when another
+  unconsumed candidate exists is a successful terminal outcome.
 - Report sources, selected consequence, decision, validation, API calls `0`, and X spend `$0.000`.
-- Keep the task visible only for invalid hard-boundary evidence or an ambiguous external effect. Research
-  uncertainty is a normal no-op, not a human-attention condition.
+- Only after all required validation, readback, and report evidence is complete, call native
+  `set_thread_archived` with `archived = true` for the current Codex task. Omit the task/thread ID so
+  the native current-task contract cannot archive another task. Never archive before evidence is complete.
+- Keep the current task visible when validation, a test, a check, landing, or definition repair failed;
+  authority or OAuth is missing; an external effect is ambiguous or unknown; safety state is damaged; a
+  user decision is unresolved; or any required action is not durably handed off.
+- Research uncertainty is a normal validated content no-op, not a human-attention condition.

--- a/automations/decodex/prompts/xurl-publisher.md
+++ b/automations/decodex/prompts/xurl-publisher.md
@@ -30,8 +30,10 @@ Workflow:
    `decodex-publisher social observe-due --run-id "$CODEX_THREAD_ID"`. It may process at most one due
    24-hour or 7-day outcome. It owns deterministic selection, budget reservation, xurl read, exact
    author/text verification, idempotency, and evidence write.
-5. Continue only if its exact status is `no_due_outcome`. Any other successful `observe-due` status ends
-   paid work for the run; continue with validation and cost reporting.
+5. Continue only if its exact status is `no_due_outcome`. This status is continuation-only, never a
+   terminal outcome, and never sufficient to archive; complete the candidate path through `publish-next`.
+   Any other successful `observe-due` status is a completed observation that ends paid work for the run;
+   continue with validation and cost reporting.
 6. Inspect the oldest unconsumed content evidence and perform a final quality check. Publish only when
    every claim is source-backed, the consequence is concrete, the wording is original and useful without
    a link, and the topic is not repetitive.
@@ -49,8 +51,9 @@ Workflow:
    update.
 
 Success and stop conditions:
-- A quality skip, a no-due result, an exact-readback publish, an observed outcome, or a validated
-  no-candidate no-op is a successful terminal outcome.
+- A completed observation, a publish with exact readback, a durable quality skip, or a validated
+  no-candidate no-op reached only after `publish-next` completes its candidate path is a successful
+  terminal outcome. `no_due_outcome` alone is continuation-only and not terminal.
 - Report post/outcome ID, canonical URL when published, exact author/text readback status, pricing
   refresh status, `ordinary_https_get_count` as free, zero X API calls and cost, current-run ceiling,
   monthly reserved and remaining ceilings, and blocker.

--- a/automations/decodex/prompts/xurl-publisher.md
+++ b/automations/decodex/prompts/xurl-publisher.md
@@ -49,9 +49,16 @@ Workflow:
    update.
 
 Success and stop conditions:
-- End with one observed outcome, one published or skipped candidate, or a proven no-op.
+- A quality skip, a no-due result, an exact-readback publish, an observed outcome, or a validated
+  no-candidate no-op is a successful terminal outcome.
 - Report post/outcome ID, canonical URL when published, exact author/text readback status, pricing
   refresh status, `ordinary_https_get_count` as free, zero X API calls and cost, current-run ceiling,
   monthly reserved and remaining ceilings, and blocker.
+- Only after all required validation, readback, and report evidence is complete, call native
+  `set_thread_archived` with `archived = true` for the current Codex task. Omit the task/thread ID so
+  the native current-task contract cannot archive another task. Never archive before evidence is complete.
+- Keep the current task visible when validation, a test, a check, landing, or definition repair failed;
+  authority or OAuth is missing; an external effect is ambiguous or unknown; safety state is damaged; a
+  user decision is unresolved; or any required action is not durably handed off.
 - Human attention is allowed only for missing OAuth, an unknown create result, or damaged immutable X
   safety state. Candidate quality failure is an autonomous skip.

--- a/automations/decodex/scripts/config/tests/test_portfolio.py
+++ b/automations/decodex/scripts/config/tests/test_portfolio.py
@@ -96,10 +96,10 @@ class PortfolioTests(unittest.TestCase):
             "codex-upstream-health": ("successful manager audit",),
             "decodex-content-manager": ("validated content candidate", "validated content no-op"),
             "decodex-xurl-publisher": (
-                "quality skip",
-                "no-due result",
-                "exact-readback publish",
-                "observed outcome",
+                "completed observation",
+                "publish with exact readback",
+                "durable quality skip",
+                "validated no-candidate no-op",
             ),
         }
         shared_contract = (
@@ -128,6 +128,12 @@ class PortfolioTests(unittest.TestCase):
         self.assertNotIn("list_threads", manager)
         self.assertNotIn("sqlite", manager)
         self.assertNotIn("database", manager)
+
+        publisher = prompts["decodex-xurl-publisher"]
+        self.assertIn("`no_due_outcome` alone is continuation-only and not terminal", publisher)
+        self.assertIn("never a terminal outcome", publisher)
+        self.assertIn("never sufficient to archive", publisher)
+        self.assertIn("only after `publish-next` completes its candidate path", publisher)
 
     def test_advisory_memory_contracts(self) -> None:
         rendered = {item["id"]: item["prompt"] for item in portfolio.rendered_automations()}
@@ -207,7 +213,10 @@ class PortfolioTests(unittest.TestCase):
 
         publisher = " ".join(prompts["decodex-xurl-publisher"].split())
         self.assertIn("only if its exact status is `no_due_outcome`", publisher)
-        self.assertIn("Any other successful `observe-due` status ends paid work for the run", publisher)
+        self.assertIn("this status is continuation-only", publisher.casefold())
+        self.assertIn("complete the candidate path through `publish-next`", publisher)
+        self.assertIn("Any other successful `observe-due` status is a completed observation", publisher)
+        self.assertIn("ends paid work for the run", publisher)
         self.assertIn("--decision publish", publisher)
         self.assertIn('--decision skip --reason "$SKIP_REASON"', publisher)
         self.assertIn("bounded, evidence-backed reason", publisher)

--- a/automations/decodex/scripts/config/tests/test_portfolio.py
+++ b/automations/decodex/scripts/config/tests/test_portfolio.py
@@ -78,7 +78,7 @@ class PortfolioTests(unittest.TestCase):
         self.assertIn("--expected-head-oid", reviewer)
         self.assertIn("merge tree equal to the reviewed head tree", reviewer)
         self.assertIn("set_thread_archived", manager)
-        self.assertIn("failed, active, ambiguous", " ".join(manager.casefold().split()))
+        self.assertIn("Keep the current task visible", manager)
         self.assertIn("CodexRadar", content)
         self.assertIn("secondary editorial", content)
         self.assertIn("decodex/content-evidence/1", content)
@@ -87,6 +87,47 @@ class PortfolioTests(unittest.TestCase):
         self.assertIn("observe-due", publisher)
         self.assertIn("refresh-pricing", publisher)
         self.assertIn("Never use browser control", publisher)
+
+    def test_each_role_self_archives_terminal_success_and_keeps_failures_visible(self) -> None:
+        prompts = {item["id"]: " ".join(item["prompt"].split()).casefold() for item in portfolio.rendered_automations()}
+        successful_outcomes = {
+            "codex-upstream-maintainer": ("source-backed no-op", "safely created or updated"),
+            "codex-upstream-reviewer": ("completed review with durable feedback", "signed landed pr"),
+            "codex-upstream-health": ("successful manager audit",),
+            "decodex-content-manager": ("validated content candidate", "validated content no-op"),
+            "decodex-xurl-publisher": (
+                "quality skip",
+                "no-due result",
+                "exact-readback publish",
+                "observed outcome",
+            ),
+        }
+        shared_contract = (
+            "successful terminal outcome",
+            "set_thread_archived",
+            "archived = true",
+            "current codex task",
+            "omit the task/thread id",
+            "only after all required validation, readback, and report evidence is complete",
+            "validation, a test, a check, landing, or definition repair failed",
+            "authority or oauth is missing",
+            "external effect is ambiguous or unknown",
+            "safety state is damaged",
+            "user decision is unresolved",
+            "required action is not durably handed off",
+        )
+        for automation_id, prompt in prompts.items():
+            with self.subTest(automation_id=automation_id):
+                for phrase in (*shared_contract, *successful_outcomes[automation_id]):
+                    self.assertIn(phrase, prompt)
+
+        manager = prompts["codex-upstream-health"]
+        self.assertIn("known completed managed task", manager)
+        self.assertIn("bounded native readback", manager)
+        self.assertIn("do not depend on an unbounded global scan", manager)
+        self.assertNotIn("list_threads", manager)
+        self.assertNotIn("sqlite", manager)
+        self.assertNotIn("database", manager)
 
     def test_advisory_memory_contracts(self) -> None:
         rendered = {item["id"]: item["prompt"] for item in portfolio.rendered_automations()}

--- a/automations/upstream/prompts/health.md
+++ b/automations/upstream/prompts/health.md
@@ -8,7 +8,7 @@ Authority:
 - Run from the clean primary `main` checkout. A scheduled cwd is never a worktree.
 - Use model `gpt-5.6-terra` with reasoning effort `high` for management and evaluation.
 - Use native automation and task tools for runtime definitions and task archiving. Never write native
-  scheduler TOML or inspect a Codex database.
+  scheduler TOML.
 - Do not use Decodex server, runtime, queue, planner, or MCP. Repository changes use one ephemeral
   Sol/max subagent, a temporary worktree, signed `decodex commit`, and Reviewer landing.
 - Advisory memory is only `$CODEX_HOME/automations/codex-upstream-health/memory.md`. Use or write it only
@@ -38,10 +38,10 @@ Every run:
    exact `@decodexspace` readback, unresolved write effects, and due 24-hour and 7-day outcomes.
 7. Check Content Manager results for official evidence, concrete usefulness, repetition, and unsupported
    claims. Check CodexRadar only as secondary editorial evidence.
-8. Use native `list_threads` and `read_thread` for recent managed Codex tasks. Call
-   `set_thread_archived` only for a completed successful task with terminal evidence and no unresolved
-   effect, failure, user continuation, or decision request. Read back the archived state. Failed,
-   active, ambiguous, and human-decision tasks stay visible.
+8. Enforce self-archive policy from the exact-five definitions and observed results. Do not depend on an
+   unbounded global scan. Manager may inspect and archive one known completed managed task only when
+   bounded native readback for that exact task is available and proves terminal success with no unresolved
+   effect, failure, continuation, or decision request.
 9. Memory may record only the last completed weekly review with measured outcomes, repairs, archive results,
    and the next experiment. It is advisory only and never workflow authority; actual evidence must be rechecked.
 
@@ -61,6 +61,13 @@ Initial acceptance sequence:
 Success and stop conditions:
 - Report exact-five health, upstream latency, PR outcomes, content/X outcomes, monthly cost, archived
   task IDs, autonomous repairs, and remaining external blockers.
+- A successful Manager audit with all required repairs and readbacks complete is a successful terminal outcome.
+- Only after all required validation, readback, and report evidence is complete, call native
+  `set_thread_archived` with `archived = true` for the current Codex task. Omit the task/thread ID so
+  the native current-task contract cannot archive another task. Never archive before evidence is complete.
+- Keep the current task visible when validation, a test, a check, landing, or definition repair failed;
+  authority or OAuth is missing; an external effect is ambiguous or unknown; safety state is damaged; a
+  user decision is unresolved; or any required action is not durably handed off.
 - Human attention is allowed only for missing OAuth, an unknown X create result, unavailable repository
   authority, or a real product-policy choice. Do not stop after analysis when an autonomous repair is
   possible.

--- a/automations/upstream/prompts/maintainer.md
+++ b/automations/upstream/prompts/maintainer.md
@@ -50,11 +50,17 @@ Workflow:
    head branch, exact head OID, body evidence, and checks. Remove the temporary worktree after push.
 
 Success:
-- End with either a source-backed no-change result or one open, tested, signed, deterministic PR.
+- A source-backed no-op or one safely created or updated, tested, signed, deterministic PR is a
+  successful terminal outcome.
 - A Reviewer repair request is normal work. Repair it autonomously on the same PR in the next run.
+- Only after all required validation, readback, and report evidence is complete, call native
+  `set_thread_archived` with `archived = true` for the current Codex task. Omit the task/thread ID so
+  the native current-task contract cannot archive another task. Never archive before evidence is complete.
 
 Stop conditions:
-- Keep the task visible only for missing repository/GitHub authority, ambiguous destructive ownership,
-  or a decision that changes product policy. Ordinary code, test, rebase, or review failures are not
-  human-attention conditions.
+- Keep the current task visible when validation, a test, a check, landing, or definition repair failed;
+  authority or OAuth is missing; an external effect is ambiguous or unknown; safety state is damaged; a
+  user decision is unresolved; or any required action is not durably handed off.
+- Ordinary code, test, rebase, or review failures remain autonomous repair work, not human-attention
+  conditions. Archive only after a later successful terminal outcome satisfies the evidence gate above.
 - Report upstream head, decision, PR URL and head OID when present, tests, and zero X API spend.

--- a/automations/upstream/prompts/reviewer.md
+++ b/automations/upstream/prompts/reviewer.md
@@ -37,10 +37,17 @@ Workflow:
    signature, remote `main`, closed PR, and branch cleanup. Remove the temporary worktree.
 
 Success:
-- End with either actionable repair feedback on the same PR or one signed, exact-head merge.
+- A verified no-eligible-PR no-op, a completed review with durable feedback read back on the same PR,
+  or a signed landed PR with exact-head merge readback is a successful terminal outcome.
 - Re-running after a merge is a no-op because GitHub and Git refs are the workflow state.
+- Only after all required validation, readback, and report evidence is complete, call native
+  `set_thread_archived` with `archived = true` for the current Codex task. Omit the task/thread ID so
+  the native current-task contract cannot archive another task. Never archive before evidence is complete.
 
 Stop conditions:
-- Keep the task visible only for ambiguous external merge state, missing landing authority, or a true
-  product-policy decision. Test failures, stale bases, and code defects return to Maintainer.
+- Keep the current task visible when validation, a test, a check, landing, or definition repair failed;
+  authority or OAuth is missing; an external effect is ambiguous or unknown; safety state is damaged; a
+  user decision is unresolved; or any required action is not durably handed off.
+- A test, check, or code finding becomes a successful completed review only after actionable feedback is
+  durably submitted and read back; otherwise it stays visible. Stale bases and defects return to Maintainer.
 - Report PR URL, reviewed base/head, findings or merge OID, checks, and zero X API spend.

--- a/openwiki/operations/codex-upstream-autopilot.md
+++ b/openwiki/operations/codex-upstream-autopilot.md
@@ -128,10 +128,20 @@ The Manager repairs native-definition drift directly through native automation
 tools and verifies full readback. Repository repairs use one ephemeral Sol/max
 subagent and the normal Maintainer/Reviewer PR path.
 
-The Manager uses native task listing and readback. It archives only a completed
-successful task that has terminal evidence and no unresolved external effect,
-failure, continuation, or decision request. Failed, active, ambiguous, and
-human-decision tasks stay visible.
+Each role is the primary cleanup owner for its current Codex task. After a
+terminal successful outcome, it completes all required validation, readback, and
+report evidence, then calls native `set_thread_archived` for the current task
+without supplying another task ID. It never archives before that evidence is
+complete. Successful outcomes include a source-backed no-op, a safely created or
+updated PR, durable review feedback, a signed landing, and a successful Manager
+audit.
+
+Failed validation, tests, checks, landing, or definition repair stay visible, as
+do missing authority or OAuth, ambiguous external effects, damaged safety state,
+unresolved user decisions, and work not durably handed off. Manager enforces this
+policy. It may inspect and archive one specifically known completed managed task
+only when bounded native readback for that exact task is available. Normal
+cleanup never depends on an unbounded global task scan.
 
 ## Human Stop Conditions
 

--- a/openwiki/operations/decodex-content-automation.md
+++ b/openwiki/operations/decodex-content-automation.md
@@ -142,10 +142,19 @@ editorial improvement and verifies its later effect.
 
 ## Task Cleanup
 
-The Manager archives completed successful Codex tasks through native task tools.
-A task stays visible when it is active, failed, ambiguous, waiting for a user
-decision, or linked to an unresolved external effect. There is no retention
-receipt, archive queue, or local archive state.
+Each content role archives its current Codex task through native
+`set_thread_archived` only after a terminal successful result and all required
+validation, readback, and report evidence are complete. Successful results are a
+validated candidate or no-op, a quality skip, a no-due result, an exact-readback
+publish, or an observed outcome. The current task ID is implicit; the role does
+not supply another task ID.
+
+A task stays visible for failed validation or checks, missing OAuth or authority,
+an ambiguous external effect, damaged safety state, an unresolved user decision,
+or required work not durably handed off. Manager may enforce the policy for one
+known completed task when bounded exact-task readback is available, but cleanup
+does not depend on a global scan. There is no retention receipt, archive queue,
+or local archive state.
 
 ## Stop Conditions
 

--- a/openwiki/operations/decodex-content-automation.md
+++ b/openwiki/operations/decodex-content-automation.md
@@ -83,9 +83,11 @@ decodex-publisher social observe-due --run-id "$CODEX_THREAD_ID"
 ```
 
 Proceed to editorial review only when the exact successful status is
-`no_due_outcome`. Any other successful `observe-due` status ends paid work for
-the run, followed by validation and cost reporting. The review either publishes
-or records a quality skip:
+`no_due_outcome`. This result is continuation-only, is never a terminal outcome,
+and is never sufficient to archive. The Publisher must complete the candidate
+path through `publish-next`. Any other successful `observe-due` status is a
+completed observation that ends paid work for the run, followed by validation
+and cost reporting. The review either publishes or records a quality skip:
 
 ```sh
 decodex-publisher social publish-next \
@@ -144,10 +146,12 @@ editorial improvement and verifies its later effect.
 
 Each content role archives its current Codex task through native
 `set_thread_archived` only after a terminal successful result and all required
-validation, readback, and report evidence are complete. Successful results are a
-validated candidate or no-op, a quality skip, a no-due result, an exact-readback
-publish, or an observed outcome. The current task ID is implicit; the role does
-not supply another task ID.
+validation, readback, and report evidence are complete. Content Manager success
+is a validated candidate or no-op. Publisher success is a completed observation,
+a publish with exact readback, a durable quality skip, or a validated no-candidate
+no-op reached only after `publish-next` completes its candidate path.
+`no_due_outcome` alone is continuation-only and never sufficient to archive. The
+current task ID is implicit; the role does not supply another task ID.
 
 A task stays visible for failed validation or checks, missing OAuth or authority,
 an ambiguous external effect, damaged safety state, an unresolved user decision,


### PR DESCRIPTION
## Why

The exact-five prompts described successful cleanup but depended on a later global Manager scan. Live native task listing did not return within two minutes at the current task volume, so successful runs could remain visible indefinitely.

## What changed

- each exact-five role archives only its current task after terminal success and complete evidence
- failed, ambiguous, damaged-safety, missing-authority, and unresolved-decision tasks remain visible
- Manager enforces policy without an unbounded global scan
- compact portfolio tests cover all five roles

## Verification

- `python3 -m unittest automations.decodex.scripts.config.tests.test_portfolio`
- `python3 automations/decodex/scripts/config/evaluate_automations.py --repo-only --json`
- `cargo make test-automations`
- `git diff --check`

X API calls: 0. X spend: $0.000.