### PR TITLE
Adapt account launch to the current Codex app server

### DIFF
--- a/crates/decodex-codex/schema/xy-1262-markers.json
+++ b/crates/decodex-codex/schema/xy-1262-markers.json
@@ -32,8 +32,14 @@
   ],
   "paginated_history": true,
   "canonical_sha256": {
-    "ClientRequest.json": "ee9fcbf5c0b3af8526dea54d3c1c7a6ca480f0847b049b9b7d4cde00ddd82735",
-    "ServerNotification.json": "189dc3b9bf8e96a115cf1102e60c379d8e34382ddca2868d1b2b46847d122166",
-    "codex_app_server_protocol.v2.schemas.json": "2ad5e818b870a6a26387678bbe276e4c67b3b078f6ac03143fba623b0969605d"
+    "ClientRequest.json": "6ffc593d603d21a051840539a4dbfad95cad2e7fec315e252b6722bd71bf37b4",
+    "ServerRequest.json": "6455b23a65fa3d9c7749ecd2ecbc4b829c9039f6cd8f9adc44d86ad4522e37ec",
+    "ServerNotification.json": "abbb54060ea6a6005e63267bc6996eacd70cbb7954a7e0d61f50ea02af4acf02",
+    "codex_app_server_protocol.v2.schemas.json": "e554a74bd59d38d16acb1744750b2999156ee3d65d0fe906b22ab52edf17fbbc",
+    "v2/LoginAccountParams.json": "3bec7003eb85aabbeaf0ba8a22ec54b68ec26d2657d6878a31ca0d01dfe642e0",
+    "ChatgptAuthTokensRefreshParams.json": "74d490082dab616ac01c94d388c9a836304c96092db37290cfdd10a46b0f3ef9",
+    "ChatgptAuthTokensRefreshResponse.json": "ff76f5cc58bff40216f9d5f3c5be921268059f6d66d6c034970cddf0e08f0ced",
+    "v2/ThreadReadResponse.json": "94689cd705b4936a5c361deaa51fed69101eaba0629899ef8a39b600180de9b3",
+    "v2/ThreadStartParams.json": "001c07a58981df5d860335bf8cee4d336df2165db6dc9c645cefed0467ccebbe"
   }
 }

--- a/crates/decodex-codex/src/schema.rs
+++ b/crates/decodex-codex/src/schema.rs
@@ -45,11 +45,32 @@ const COLLABORATION_MARKERS: &[&str] =
 	&["collabAgentToolCall", "parentThreadId", "agentNickname", "agentRole", "subAgentActivity"];
 const MAX_SCHEMA_DIRECTORY_DEPTH: usize = 8;
 const ACCEPTED_DIGESTS: &[(&str, &str)] = &[
-	("ClientRequest.json", "ee9fcbf5c0b3af8526dea54d3c1c7a6ca480f0847b049b9b7d4cde00ddd82735"),
-	("ServerNotification.json", "189dc3b9bf8e96a115cf1102e60c379d8e34382ddca2868d1b2b46847d122166"),
+	("ClientRequest.json", "6ffc593d603d21a051840539a4dbfad95cad2e7fec315e252b6722bd71bf37b4"),
+	("ServerRequest.json", "6455b23a65fa3d9c7749ecd2ecbc4b829c9039f6cd8f9adc44d86ad4522e37ec"),
+	("ServerNotification.json", "abbb54060ea6a6005e63267bc6996eacd70cbb7954a7e0d61f50ea02af4acf02"),
 	(
 		"codex_app_server_protocol.v2.schemas.json",
-		"2ad5e818b870a6a26387678bbe276e4c67b3b078f6ac03143fba623b0969605d",
+		"e554a74bd59d38d16acb1744750b2999156ee3d65d0fe906b22ab52edf17fbbc",
+	),
+	(
+		"v2/LoginAccountParams.json",
+		"3bec7003eb85aabbeaf0ba8a22ec54b68ec26d2657d6878a31ca0d01dfe642e0",
+	),
+	(
+		"ChatgptAuthTokensRefreshParams.json",
+		"74d490082dab616ac01c94d388c9a836304c96092db37290cfdd10a46b0f3ef9",
+	),
+	(
+		"ChatgptAuthTokensRefreshResponse.json",
+		"ff76f5cc58bff40216f9d5f3c5be921268059f6d66d6c034970cddf0e08f0ced",
+	),
+	(
+		"v2/ThreadReadResponse.json",
+		"94689cd705b4936a5c361deaa51fed69101eaba0629899ef8a39b600180de9b3",
+	),
+	(
+		"v2/ThreadStartParams.json",
+		"001c07a58981df5d860335bf8cee4d336df2165db6dc9c645cefed0467ccebbe",
 	),
 ];
 
@@ -828,19 +849,43 @@ mod tests {
 		let marker = SchemaMarker::accepted();
 
 		assert_eq!(marker.receipt, ACCEPTED_SCHEMA_RECEIPT);
-		assert_eq!(marker.canonical_digests().len(), 3);
+		assert_eq!(marker.canonical_digests().len(), 9);
 		for (file, digest) in [
 			(
 				"ClientRequest.json",
-				"ee9fcbf5c0b3af8526dea54d3c1c7a6ca480f0847b049b9b7d4cde00ddd82735",
+				"6ffc593d603d21a051840539a4dbfad95cad2e7fec315e252b6722bd71bf37b4",
+			),
+			(
+				"ServerRequest.json",
+				"6455b23a65fa3d9c7749ecd2ecbc4b829c9039f6cd8f9adc44d86ad4522e37ec",
 			),
 			(
 				"ServerNotification.json",
-				"189dc3b9bf8e96a115cf1102e60c379d8e34382ddca2868d1b2b46847d122166",
+				"abbb54060ea6a6005e63267bc6996eacd70cbb7954a7e0d61f50ea02af4acf02",
 			),
 			(
 				"codex_app_server_protocol.v2.schemas.json",
-				"2ad5e818b870a6a26387678bbe276e4c67b3b078f6ac03143fba623b0969605d",
+				"e554a74bd59d38d16acb1744750b2999156ee3d65d0fe906b22ab52edf17fbbc",
+			),
+			(
+				"v2/LoginAccountParams.json",
+				"3bec7003eb85aabbeaf0ba8a22ec54b68ec26d2657d6878a31ca0d01dfe642e0",
+			),
+			(
+				"ChatgptAuthTokensRefreshParams.json",
+				"74d490082dab616ac01c94d388c9a836304c96092db37290cfdd10a46b0f3ef9",
+			),
+			(
+				"ChatgptAuthTokensRefreshResponse.json",
+				"ff76f5cc58bff40216f9d5f3c5be921268059f6d66d6c034970cddf0e08f0ced",
+			),
+			(
+				"v2/ThreadReadResponse.json",
+				"94689cd705b4936a5c361deaa51fed69101eaba0629899ef8a39b600180de9b3",
+			),
+			(
+				"v2/ThreadStartParams.json",
+				"001c07a58981df5d860335bf8cee4d336df2165db6dc9c645cefed0467ccebbe",
 			),
 		] {
 			assert_eq!(marker.canonical_digests().get(file).map(String::as_str), Some(digest));
@@ -899,6 +944,36 @@ mod tests {
 			(
 				"codex_app_server_protocol.v2.schemas.json",
 				"f5e8d20f3a8f9bb5e5b23ab0c5aa6bde7b12e7e0713606c5d0132651a4959d37",
+			),
+		] {
+			marker.canonical_sha256.insert(file.into(), digest.into());
+		}
+
+		assert_eq!(
+			SchemaContract::validate(marker).unwrap_err(),
+			[
+				"digest:ClientRequest.json",
+				"digest:ServerNotification.json",
+				"digest:codex_app_server_protocol.v2.schemas.json",
+			]
+		);
+	}
+
+	#[test]
+	fn marker_validation_rejects_the_previous_supported_build_schema_digest_set() {
+		let mut marker = SchemaMarker::accepted();
+		for (file, digest) in [
+			(
+				"ClientRequest.json",
+				"ee9fcbf5c0b3af8526dea54d3c1c7a6ca480f0847b049b9b7d4cde00ddd82735",
+			),
+			(
+				"ServerNotification.json",
+				"189dc3b9bf8e96a115cf1102e60c379d8e34382ddca2868d1b2b46847d122166",
+			),
+			(
+				"codex_app_server_protocol.v2.schemas.json",
+				"2ad5e818b870a6a26387678bbe276e4c67b3b078f6ac03143fba623b0969605d",
 			),
 		] {
 			marker.canonical_sha256.insert(file.into(), digest.into());

--- a/crates/decodex-postgres/migrations/V32__codex_0146_alpha_9_2_capability.sql
+++ b/crates/decodex-postgres/migrations/V32__codex_0146_alpha_9_2_capability.sql
@@ -1,0 +1,289 @@
+-- Rebind account launch to the current signed Codex release and callback profile.
+
+CREATE OR REPLACE FUNCTION decodex.read_account_registry_exact(
+	p_account_id uuid,
+	p_limit bigint
+) RETURNS TABLE(
+	account_id uuid,display_label text,enabled boolean,state decodex.account_state,revision bigint,
+		provider_kind decodex.account_provider_kind,provider_account_id text,
+		credential_store_schema_version integer,credential_version bigint,
+		credential_fingerprint text,credential_writer_operation_id uuid,tombstoned boolean,
+		lifecycle_readiness text,unsettled_operation_id uuid,
+		unsettled_kind decodex.account_operation_kind,
+		unsettled_phase decodex.account_operation_phase,unsettled_recovery_code text,
+		five_hour_disposition text,five_hour_used_percent integer,
+		five_hour_resets_at_micros bigint,five_hour_observed_at_micros bigint,
+		five_hour_error_code decodex.account_quota_observation_error,
+		seven_day_disposition text,seven_day_used_percent integer,
+		seven_day_resets_at_micros bigint,seven_day_observed_at_micros bigint,
+		seven_day_error_code decodex.account_quota_observation_error
+) LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path=pg_catalog,decodex AS $$
+	BEGIN
+	IF p_limit IS NULL OR p_limit < 1 OR p_limit > 512 THEN
+		RAISE EXCEPTION 'account registry read limit is invalid' USING ERRCODE='22023';
+	END IF;
+	IF p_account_id IS NULL AND
+		(SELECT pg_catalog.count(*) FROM decodex.accounts WHERE tombstoned_at IS NULL) > 512
+	THEN
+		RAISE EXCEPTION 'account registry cardinality exceeds the supported bound'
+			USING ERRCODE='54000';
+	END IF;
+	RETURN QUERY
+	SELECT account.account_id,account.display_label,account.enabled,account.state,account.revision,
+		account.provider_kind,account.provider_account_id,
+		account.credential_store_schema_version,account.credential_version,
+		account.credential_fingerprint,account.credential_writer_operation_id,
+		account.tombstoned_at IS NOT NULL,
+		CASE
+			WHEN account.tombstoned_at IS NOT NULL THEN 'tombstoned'
+			WHEN operation.operation_id IS NOT NULL THEN 'operation_unsettled'
+			WHEN account.credential_version IS NULL THEN 'credential_absent'
+			WHEN NOT EXISTS (
+				SELECT 1 FROM decodex.codex_account_capability AS capability
+				WHERE capability.singleton
+					AND capability.build_identity='codex-cli 0.146.0-alpha.9.2'
+					AND capability.executable_sha256='d96ae1ca1ff6fc8587842fa04c92d3ee4d31651a811c2f89b65fcfd9c28473e2'
+					AND capability.callback_profile_sha256='64a98c3328d1eba74aaf18a3995523e07fd2f1395bc6fb4a121b74338c404a29'
+					AND capability.login_chatgpt_auth_tokens AND capability.refresh_callback
+			) THEN 'callback_capability_unready'
+			WHEN account.credential_store_observation='exact' THEN 'ready'
+			WHEN account.credential_store_observation='unavailable' THEN 'store_unavailable'
+			WHEN account.credential_store_observation='provider_mismatch' THEN 'provider_mismatch'
+			ELSE 'store_mismatch'
+		END,
+		operation.operation_id,operation.kind,operation.phase,operation.recovery_code,
+		CASE WHEN five_hour.account_id IS NULL THEN 'unknown'
+			WHEN five_hour.error_code IS NOT NULL THEN 'error'
+			WHEN five_hour.resets_at_micros<=
+				(extract(epoch FROM pg_catalog.clock_timestamp())*1000000)::bigint
+				OR five_hour.observed_at_micros+300000000<
+				(extract(epoch FROM pg_catalog.clock_timestamp())*1000000)::bigint
+			THEN 'stale' ELSE 'current' END,
+		five_hour.used_percent,
+		five_hour.resets_at_micros,
+		five_hour.observed_at_micros,
+		five_hour.error_code,
+		CASE WHEN seven_day.account_id IS NULL THEN 'unknown'
+			WHEN seven_day.error_code IS NOT NULL THEN 'error'
+			WHEN seven_day.resets_at_micros<=
+				(extract(epoch FROM pg_catalog.clock_timestamp())*1000000)::bigint
+				OR seven_day.observed_at_micros+300000000<
+				(extract(epoch FROM pg_catalog.clock_timestamp())*1000000)::bigint
+			THEN 'stale' ELSE 'current' END,
+		seven_day.used_percent,
+		seven_day.resets_at_micros,
+		seven_day.observed_at_micros,
+		seven_day.error_code
+	FROM decodex.accounts AS account
+	LEFT JOIN decodex.account_operations AS operation
+		ON operation.account_id=account.account_id
+		AND operation.phase NOT IN ('committed','cancelled')
+	LEFT JOIN decodex.account_quota_facts AS five_hour
+		ON five_hour.account_id=account.account_id AND five_hour.duration_minutes=300
+	LEFT JOIN decodex.account_quota_facts AS seven_day
+		ON seven_day.account_id=account.account_id AND seven_day.duration_minutes=10080
+	LEFT JOIN decodex.account_routing_order AS ordering ON ordering.account_id=account.account_id
+	WHERE (p_account_id IS NULL AND account.tombstoned_at IS NULL)
+		OR account.account_id=p_account_id
+	ORDER BY ordering.position NULLS LAST,account.account_id
+	LIMIT p_limit;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION decodex.read_reset_card_account_admission_exact(
+	p_account_id uuid,p_callback_profile_sha256 text
+) RETURNS TABLE(
+	state decodex.account_state,revision bigint,enabled boolean,tombstoned boolean,
+	credential_store_schema_version integer,credential_version bigint,
+	credential_fingerprint text,credential_writer_operation_id uuid,
+	provider_kind decodex.account_provider_kind,provider_account_id text,
+	credential_store_observation decodex.account_store_observation,
+	operation_unsettled boolean,callback_profile_ready boolean
+) LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog,decodex AS $$
+BEGIN
+	RETURN QUERY SELECT account.state,account.revision,account.enabled,
+		account.tombstoned_at IS NOT NULL,account.credential_store_schema_version,
+		account.credential_version,account.credential_fingerprint,
+		account.credential_writer_operation_id,account.provider_kind,
+		account.provider_account_id,account.credential_store_observation,
+		EXISTS (
+			SELECT 1 FROM decodex.account_operations AS operation
+			WHERE operation.account_id=account.account_id
+				AND operation.phase NOT IN ('committed','cancelled')
+		),
+		EXISTS (
+			SELECT 1 FROM decodex.codex_account_capability AS capability
+			WHERE capability.singleton
+				AND capability.build_identity='codex-cli 0.146.0-alpha.9.2'
+				AND capability.executable_sha256='d96ae1ca1ff6fc8587842fa04c92d3ee4d31651a811c2f89b65fcfd9c28473e2'
+				AND capability.schema_sha256 ~ '^[0-9a-f]{64}$'
+				AND capability.callback_profile_sha256='64a98c3328d1eba74aaf18a3995523e07fd2f1395bc6fb4a121b74338c404a29'
+				AND capability.login_chatgpt_auth_tokens
+				AND capability.refresh_callback
+				AND capability.callback_profile_sha256=p_callback_profile_sha256
+		)
+	FROM decodex.accounts AS account
+	WHERE account.account_id=p_account_id
+	FOR SHARE OF account;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION decodex.attest_codex_account_capability_exact(
+	p_build_identity text,p_executable_sha256 text,p_schema_sha256 text,
+	p_callback_profile_sha256 text,p_login_chatgpt_auth_tokens boolean,p_refresh_callback boolean
+) RETURNS text LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog,decodex AS $$
+BEGIN
+	INSERT INTO decodex.codex_account_capability(
+		singleton,build_identity,executable_sha256,schema_sha256,callback_profile_sha256,
+		login_chatgpt_auth_tokens,refresh_callback
+	) VALUES (true,p_build_identity,p_executable_sha256,p_schema_sha256,p_callback_profile_sha256,
+		p_login_chatgpt_auth_tokens,p_refresh_callback)
+	ON CONFLICT(singleton) DO UPDATE SET build_identity=EXCLUDED.build_identity,
+		executable_sha256=EXCLUDED.executable_sha256,schema_sha256=EXCLUDED.schema_sha256,
+		callback_profile_sha256=EXCLUDED.callback_profile_sha256,
+		login_chatgpt_auth_tokens=EXCLUDED.login_chatgpt_auth_tokens,
+		refresh_callback=EXCLUDED.refresh_callback,observed_at=pg_catalog.clock_timestamp();
+	RETURN CASE WHEN p_build_identity='codex-cli 0.146.0-alpha.9.2'
+		AND p_executable_sha256='d96ae1ca1ff6fc8587842fa04c92d3ee4d31651a811c2f89b65fcfd9c28473e2'
+		AND p_schema_sha256 ~ '^[0-9a-f]{64}$'
+		AND p_callback_profile_sha256='64a98c3328d1eba74aaf18a3995523e07fd2f1395bc6fb4a121b74338c404a29'
+		AND p_login_chatgpt_auth_tokens AND p_refresh_callback
+		THEN 'ready' ELSE 'unready' END;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION decodex.prepare_process_generation_exact(
+	p_generation_id uuid,p_account_id uuid,p_execution_epoch_id uuid,
+	p_authorization_digest text,p_runner_identity text,p_intended_boot_id text,
+	p_control_kind decodex.process_generation_control_kind,
+	p_isolation_kind decodex.process_generation_isolation_kind,
+	p_initial_account_revision bigint,p_credential_store_schema_version integer,
+	p_credential_version bigint,p_credential_fingerprint text,
+	p_credential_writer_operation_id uuid,
+	p_provider_kind decodex.account_provider_kind,p_provider_account_id text,
+	p_refresh_callback_profile_sha256 text,
+	p_reset_card_outbox_id bigint,p_reset_card_worker_id uuid,p_reset_card_claim_token uuid
+) RETURNS TABLE(result_code text,revision bigint,state decodex.process_generation_state,
+	created_at_micros bigint,updated_at_micros bigint)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog,decodex AS $$
+DECLARE existing decodex.process_generations%ROWTYPE;
+DECLARE account decodex.accounts%ROWTYPE;
+DECLARE now_value timestamptz;
+DECLARE reconciliation_authorized boolean:=false;
+BEGIN
+	PERFORM pg_catalog.pg_advisory_xact_lock_shared(1400);
+	PERFORM pg_catalog.pg_advisory_xact_lock(1400,pg_catalog.hashtext(p_generation_id::text));
+	PERFORM pg_catalog.pg_advisory_xact_lock(1401,pg_catalog.hashtext(p_account_id::text));
+	SELECT * INTO existing FROM decodex.process_generations
+	WHERE generation_id=p_generation_id FOR UPDATE;
+	IF FOUND THEN
+		IF (existing.account_id,existing.execution_epoch_id,existing.runner_identity,
+			existing.intended_boot_id,existing.control_kind,existing.isolation_kind,
+			existing.initial_account_revision,existing.credential_store_schema_version,
+			existing.credential_version,existing.credential_fingerprint,
+			existing.credential_writer_operation_id,
+			existing.provider_kind,existing.provider_account_id,
+			existing.refresh_callback_profile_sha256) IS DISTINCT FROM
+			(p_account_id,p_execution_epoch_id,p_runner_identity,p_intended_boot_id,
+			p_control_kind,p_isolation_kind,p_initial_account_revision,
+			p_credential_store_schema_version,p_credential_version,p_credential_fingerprint,
+			p_credential_writer_operation_id,
+			p_provider_kind,p_provider_account_id,p_refresh_callback_profile_sha256)
+		THEN RETURN QUERY SELECT 'identity_conflict',existing.revision,existing.state,
+			(extract(epoch FROM existing.created_at)*1000000)::bigint,
+			(extract(epoch FROM existing.updated_at)*1000000)::bigint;
+		ELSE RETURN QUERY SELECT 'replayed',existing.revision,existing.state,
+			(extract(epoch FROM existing.created_at)*1000000)::bigint,
+			(extract(epoch FROM existing.updated_at)*1000000)::bigint;
+		END IF;
+		RETURN;
+	END IF;
+	IF p_authorization_digest IS NULL OR p_authorization_digest !~ '^[0-9a-f]{64}$' THEN
+		RETURN QUERY SELECT 'restore_authority_unavailable',0::bigint,
+			'starting'::decodex.process_generation_state,0::bigint,0::bigint;
+		RETURN;
+	END IF;
+	PERFORM 1 FROM decodex.process_generation_execution_epochs AS epoch
+	WHERE epoch.execution_epoch_id=p_execution_epoch_id
+		AND epoch.authorization_digest=p_authorization_digest AND epoch.retired_at IS NULL FOR SHARE;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'restore_authority_unavailable',0::bigint,
+		'starting'::decodex.process_generation_state,0::bigint,0::bigint; RETURN; END IF;
+	SELECT * INTO account FROM decodex.accounts WHERE account_id=p_account_id FOR KEY SHARE;
+	IF NOT FOUND THEN RETURN QUERY SELECT 'account_missing',0::bigint,
+		'starting'::decodex.process_generation_state,0::bigint,0::bigint; RETURN; END IF;
+	IF (p_reset_card_outbox_id IS NULL,p_reset_card_worker_id IS NULL,
+		p_reset_card_claim_token IS NULL) NOT IN ((true,true,true),(false,false,false))
+	THEN RETURN QUERY SELECT 'account_lifecycle_unready',0::bigint,
+		'starting'::decodex.process_generation_state,0::bigint,0::bigint; RETURN; END IF;
+	IF p_reset_card_outbox_id IS NOT NULL THEN
+		SELECT EXISTS (
+			SELECT 1 FROM decodex.outbox AS work
+			WHERE work.id=p_reset_card_outbox_id
+				AND work.aggregate_kind='reset_card_operation'
+				AND work.state='in_flight'
+				AND work.lease_holder=p_reset_card_worker_id
+				AND work.claim_token=p_reset_card_claim_token
+				AND work.lease_expires_at>pg_catalog.clock_timestamp()
+				AND work.effect_state IN ('ambiguous','receipt_recorded')
+				AND work.payload #>> '{payload,account_id}'=p_account_id::text
+				AND work.payload #>> '{payload,provider_kind}'=p_provider_kind::text
+				AND work.payload #>> '{payload,provider_account_id}'=p_provider_account_id
+				AND work.payload #>> '{payload,refresh_callback_profile_sha256}'=
+					p_refresh_callback_profile_sha256
+		) INTO reconciliation_authorized;
+		IF NOT reconciliation_authorized THEN
+			RETURN QUERY SELECT 'account_lifecycle_unready',0::bigint,
+				'starting'::decodex.process_generation_state,0::bigint,0::bigint;
+			RETURN;
+		END IF;
+	END IF;
+	IF account.tombstoned_at IS NOT NULL OR account.revision<>p_initial_account_revision
+		OR account.credential_store_observation<>'exact'
+		OR account.credential_store_schema_version<>p_credential_store_schema_version
+		OR account.credential_version<>p_credential_version
+		OR account.credential_fingerprint<>p_credential_fingerprint
+		OR account.credential_writer_operation_id<>p_credential_writer_operation_id
+		OR account.provider_kind<>p_provider_kind
+		OR account.provider_account_id<>p_provider_account_id
+		OR p_refresh_callback_profile_sha256 !~ '^[0-9a-f]{64}$'
+		OR (NOT reconciliation_authorized AND (NOT account.enabled OR EXISTS (
+			SELECT 1 FROM decodex.account_operations AS operation
+			WHERE operation.account_id=p_account_id
+				AND operation.phase NOT IN ('committed','cancelled'))))
+	THEN RETURN QUERY SELECT 'account_lifecycle_unready',0::bigint,
+		'starting'::decodex.process_generation_state,0::bigint,0::bigint; RETURN; END IF;
+	IF NOT reconciliation_authorized AND NOT EXISTS (
+		SELECT 1 FROM decodex.codex_account_capability AS capability
+		WHERE capability.singleton AND capability.login_chatgpt_auth_tokens
+			AND capability.refresh_callback
+			AND capability.build_identity='codex-cli 0.146.0-alpha.9.2'
+			AND capability.executable_sha256='d96ae1ca1ff6fc8587842fa04c92d3ee4d31651a811c2f89b65fcfd9c28473e2'
+			AND capability.callback_profile_sha256='64a98c3328d1eba74aaf18a3995523e07fd2f1395bc6fb4a121b74338c404a29'
+			AND capability.callback_profile_sha256=p_refresh_callback_profile_sha256)
+	THEN RETURN QUERY SELECT 'callback_capability_unready',0::bigint,
+		'starting'::decodex.process_generation_state,0::bigint,0::bigint; RETURN; END IF;
+	IF EXISTS (SELECT 1 FROM decodex.process_generations AS generation
+		WHERE generation.account_id=p_account_id AND generation.state<>'dead')
+	THEN RETURN QUERY SELECT 'account_quarantined',0::bigint,
+		'starting'::decodex.process_generation_state,0::bigint,0::bigint; RETURN; END IF;
+	now_value:=pg_catalog.clock_timestamp();
+	INSERT INTO decodex.process_generations(
+		generation_id,account_id,execution_epoch_id,runner_identity,intended_boot_id,
+		control_kind,isolation_kind,state,revision,created_at,updated_at,
+		initial_account_revision,credential_store_schema_version,credential_version,
+		credential_fingerprint,credential_writer_operation_id,provider_kind,
+		provider_account_id,refresh_callback_profile_sha256
+	) VALUES (
+		p_generation_id,p_account_id,p_execution_epoch_id,p_runner_identity,p_intended_boot_id,
+		p_control_kind,p_isolation_kind,'starting',1,now_value,now_value,
+		p_initial_account_revision,p_credential_store_schema_version,p_credential_version,
+		p_credential_fingerprint,p_credential_writer_operation_id,
+		p_provider_kind,p_provider_account_id,
+		p_refresh_callback_profile_sha256
+	);
+	RETURN QUERY SELECT 'prepared',1::bigint,'starting'::decodex.process_generation_state,
+		(extract(epoch FROM now_value)*1000000)::bigint,
+		(extract(epoch FROM now_value)*1000000)::bigint;
+END
+$$;

--- a/crates/decodex-postgres/src/authority.rs
+++ b/crates/decodex-postgres/src/authority.rs
@@ -50,7 +50,9 @@ const CURRENT_CODEX_ACCOUNT_CAPABILITY_MIGRATION: &str =
 	include_str!("../migrations/V30__current_codex_account_capability.sql");
 const OFFICIAL_CODEX_RELEASE_CAPABILITY_MIGRATION: &str =
 	include_str!("../migrations/V31__official_codex_release_capability.sql");
-const CANONICAL_FUNCTION_MIGRATIONS: [&str; 27] = [
+const CURRENT_OFFICIAL_CODEX_RELEASE_CAPABILITY_MIGRATION: &str =
+	include_str!("../migrations/V32__codex_0146_alpha_9_2_capability.sql");
+const CANONICAL_FUNCTION_MIGRATIONS: [&str; 28] = [
 	FOUNDATION_MIGRATION,
 	CONVERSATION_MIGRATION,
 	PROJECT_AGENT_MIGRATION,
@@ -78,6 +80,7 @@ const CANONICAL_FUNCTION_MIGRATIONS: [&str; 27] = [
 	ACCOUNT_PROFILE_ARRAY_ZIP_MIGRATION,
 	CURRENT_CODEX_ACCOUNT_CAPABILITY_MIGRATION,
 	OFFICIAL_CODEX_RELEASE_CAPABILITY_MIGRATION,
+	CURRENT_OFFICIAL_CODEX_RELEASE_CAPABILITY_MIGRATION,
 ];
 const ALLOWED_EXECUTION_DEPENDENCIES: [&str; 1] =
 	["public.digest(pg_catalog.bytea,pg_catalog.text)"];
@@ -4429,8 +4432,8 @@ SELECT
   )
 "#;
 const SCHEMA_CONTRACT_SHA256: [u8; 32] = [
-	0x47, 0x89, 0xf7, 0x86, 0x43, 0x87, 0x67, 0x63, 0x24, 0x25, 0xbe, 0x07, 0x7f, 0xd4, 0x62, 0x1e,
-	0xcd, 0xc8, 0x16, 0xaf, 0x58, 0xb5, 0x7f, 0xfa, 0x04, 0x68, 0x59, 0x6b, 0xdd, 0xcc, 0xf8, 0xba,
+	0x02, 0xb6, 0x4d, 0xf1, 0xc7, 0x0e, 0xc4, 0xda, 0x16, 0x15, 0xea, 0x25, 0x31, 0x50, 0x6b, 0x03,
+	0x98, 0x8d, 0x74, 0x89, 0xdd, 0x82, 0xd8, 0xda, 0xa8, 0x83, 0x87, 0xc2, 0x95, 0x1c, 0x33, 0xbd,
 ];
 // The shipped authority permits no role settings. Record only cardinality so any setting
 // fails closed without copying an arbitrary custom-GUC value into the manifest or digest input.
@@ -6295,7 +6298,7 @@ mod tests {
 
 	#[test]
 	fn canonical_inventory_covers_every_shipped_decodex_function_once() {
-		assert_eq!(CANONICAL_FUNCTION_MIGRATIONS.len(), 27);
+		assert_eq!(CANONICAL_FUNCTION_MIGRATIONS.len(), 28);
 		assert_eq!(FUNCTION_CONTRACTS.len(), 201);
 		let created_function_count = CANONICAL_FUNCTION_MIGRATIONS
 			.into_iter()

--- a/crates/decodex-postgres/src/lib.rs
+++ b/crates/decodex-postgres/src/lib.rs
@@ -256,7 +256,7 @@ impl PostgresStore {
 
 	/// Parse and prepare every changed V22/V27/V28 embedded SQL source without executing it.
 	///
-	/// V29 through V31 change only database-owned functions and add no adapter SQL.
+	/// V29 through V32 change only database-owned functions and add no adapter SQL.
 	#[cfg(feature = "test-support")]
 	#[doc(hidden)]
 	pub async fn prepare_changed_sql_fixture(client: &TokioClient) -> Result<usize, StoreError> {

--- a/crates/decodex-postgres/src/migrations.rs
+++ b/crates/decodex-postgres/src/migrations.rs
@@ -8,7 +8,7 @@ use deadpool_postgres::Client;
 use crate::{REQUIRED_POSTGRES_MAJOR, StoreError};
 use embedded::migrations;
 
-const EXPECTED_LATEST_MIGRATION_VERSION: i32 = 31;
+const EXPECTED_LATEST_MIGRATION_VERSION: i32 = 32;
 #[cfg(test)]
 const CONSTRAINT_RESTORE_CANONICALIZATION_MIGRATION: &str =
 	include_str!("../migrations/V20__constraint_restore_canonicalization.sql");
@@ -27,6 +27,9 @@ const CURRENT_CODEX_ACCOUNT_CAPABILITY_MIGRATION: &str =
 #[cfg(test)]
 const OFFICIAL_CODEX_RELEASE_CAPABILITY_MIGRATION: &str =
 	include_str!("../migrations/V31__official_codex_release_capability.sql");
+#[cfg(test)]
+const CURRENT_OFFICIAL_CODEX_RELEASE_CAPABILITY_MIGRATION: &str =
+	include_str!("../migrations/V32__codex_0146_alpha_9_2_capability.sql");
 
 pub(crate) async fn run(client: &mut Client) -> Result<(), StoreError> {
 	migrations::runner().run_async(&mut ***client).await?;
@@ -120,7 +123,7 @@ async fn verify_exact_ledger(
 		&& expected.last().map(|migration| migration.version()) != Some(terminal_version)
 	{
 		return Err(StoreError::Incompatible(
-			"embedded migration inventory does not end at the canonical V31 ledger".into(),
+			"embedded migration inventory does not end at the canonical V32 ledger".into(),
 		));
 	}
 	expected.retain(|migration| migration.version() <= terminal_version);
@@ -172,7 +175,8 @@ mod tests {
 	use super::{
 		ACCOUNT_PROFILE_ARRAY_ZIP_MIGRATION, ACCOUNT_PROFILE_OBSERVATIONS_MIGRATION,
 		CONSTRAINT_RESTORE_CANONICALIZATION_MIGRATION, CURRENT_CODEX_ACCOUNT_CAPABILITY_MIGRATION,
-		MAC_ACCOUNT_LIFECYCLE_MIGRATION, OFFICIAL_CODEX_RELEASE_CAPABILITY_MIGRATION, migrations,
+		CURRENT_OFFICIAL_CODEX_RELEASE_CAPABILITY_MIGRATION, MAC_ACCOUNT_LIFECYCLE_MIGRATION,
+		OFFICIAL_CODEX_RELEASE_CAPABILITY_MIGRATION, migrations,
 	};
 
 	const POSTGRESQL_SYNTAX_CONSTRUCTS: [&str; 7] =
@@ -488,6 +492,42 @@ mod tests {
 		);
 		for forbidden in [
 			"fb2b6b35789e59c885cf4d2aee12475809dd67b2c10df580e638122fd6b3438e",
+			"CREATE TABLE",
+			"CREATE TYPE",
+			"GRANT ",
+			"REVOKE ",
+			"account_migration",
+			"legacy",
+		] {
+			assert!(!migration.contains(forbidden), "{forbidden}");
+		}
+	}
+
+	#[test]
+	fn v32_rebinds_only_the_current_official_codex_release_capability() {
+		let migration = CURRENT_OFFICIAL_CODEX_RELEASE_CAPABILITY_MIGRATION;
+
+		for function in [
+			"read_account_registry_exact",
+			"read_reset_card_account_admission_exact",
+			"attest_codex_account_capability_exact",
+			"prepare_process_generation_exact",
+		] {
+			assert!(
+				migration.contains(&format!("CREATE OR REPLACE FUNCTION decodex.{function}(")),
+				"{function}"
+			);
+		}
+		for exact_value in [
+			"codex-cli 0.146.0-alpha.9.2",
+			"d96ae1ca1ff6fc8587842fa04c92d3ee4d31651a811c2f89b65fcfd9c28473e2",
+			"64a98c3328d1eba74aaf18a3995523e07fd2f1395bc6fb4a121b74338c404a29",
+		] {
+			assert_eq!(migration.matches(exact_value).count(), 4, "{exact_value}");
+		}
+		for forbidden in [
+			"codex-cli 0.146.0-alpha.3.1",
+			"fa0cb7c5f80e6a192563fcb1d9f98857f4a808a28cb29289400ed7110291bce4",
 			"CREATE TABLE",
 			"CREATE TYPE",
 			"GRANT ",

--- a/crates/decodex-postgres/tests/postgres_store.rs
+++ b/crates/decodex-postgres/tests/postgres_store.rs
@@ -2260,7 +2260,7 @@ async fn postgres_v8_empty_boundary_contract() -> Result<(), Box<dyn std::error:
 			 (SELECT data_type='USER-DEFINED' AND udt_name='quota_window_class' \
 			  FROM information_schema.columns WHERE table_schema='decodex' \
 			  AND table_name='quota_windows' AND column_name='window_class'), \
-				 (SELECT count(*)=31 FROM public.refinery_schema_history)",
+				 (SELECT count(*)=32 FROM public.refinery_schema_history)",
 			&[],
 		)
 		.await?;

--- a/crates/decodex-postgres/tests/postgres_store.rs
+++ b/crates/decodex-postgres/tests/postgres_store.rs
@@ -984,7 +984,7 @@ async fn postgres_account_routing_and_logout_share_one_lock_order()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "requires the isolated PostgreSQL 18 V31 preparation harness"]
+#[ignore = "requires the isolated PostgreSQL 18 V32 preparation harness"]
 #[cfg(feature = "test-support")]
 async fn postgres_changed_sql_preparation_contract() -> Result<(), Box<dyn std::error::Error>> {
 	let (_, mut runtime) = separated_configs("DECODEX_TEST")?;
@@ -4319,6 +4319,7 @@ async fn assert_bootstrap_and_history(client: &Client) -> Result<(), Box<dyn std
 		"account_profile_array_zip",
 		"current_codex_account_capability",
 		"official_codex_release_capability",
+		"codex_0146_alpha_9_2_capability",
 	];
 	assert_eq!(history.len(), expected_history.len());
 	for (index, ((version, name, checksum), expected_name)) in

--- a/crates/decodex-postgres/tests/postgres_store/reset_cards.rs
+++ b/crates/decodex-postgres/tests/postgres_store/reset_cards.rs
@@ -1,10 +1,10 @@
 use std::{error::Error, sync::Arc, time::Duration};
 
 use decodex_core::{
-	AccountOperationId, AccountOperationKind, AccountOperationPhase, AccountProvider,
-	AccountQuotaWindow, CredentialBinding, CredentialFingerprint, CredentialStoreSchemaVersion,
-	CredentialVersion, ProcessGenerationAccountBinding, ProviderIdentity, ResetCardConsumeOutcome,
-	ResetCardDescriptor, ResetCardTimestamp,
+	AccountLifecycleReadiness, AccountOperationId, AccountOperationKind, AccountOperationPhase,
+	AccountProvider, AccountQuotaWindow, CredentialBinding, CredentialFingerprint,
+	CredentialStoreSchemaVersion, CredentialVersion, ProcessGenerationAccountBinding,
+	ProviderIdentity, ResetCardConsumeOutcome, ResetCardDescriptor, ResetCardTimestamp,
 };
 use decodex_postgres::{
 	AccountAdministrationOutcome, AccountCommandKind, AccountCommandReceiptClaim, AccountId,
@@ -47,7 +47,7 @@ const PENDING_OPERATION_KEY: &str = "reset-card-integration-pending-operation";
 const EXACT_PROVIDER_CREDIT_ID: &str = "sk-live-provider-id";
 const CREDENTIAL_FINGERPRINT: &str =
 	"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-const CALLBACK_PROFILE: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+const CALLBACK_PROFILE: &str = "64a98c3328d1eba74aaf18a3995523e07fd2f1395bc6fb4a121b74338c404a29";
 const CREDENTIAL_WRITER: &str = "71000000-0000-4000-8000-000000000010";
 const ROTATED_CREDENTIAL_FINGERPRINT: &str =
 	"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
@@ -1482,7 +1482,7 @@ async fn reject_pending_replay_after_account_change(
 		completed_reset_card_receipt(owner, "reset-card-expired-state-rejected").await?;
 	owner
 		.execute(
-			"UPDATE decodex.accounts SET state='available' \
+			"UPDATE decodex.accounts SET state='available',enabled=true \
 				 WHERE account_id=$1::text::uuid AND revision=$2",
 			&[&account_id.as_str(), &FINAL_ACCOUNT_REVISION],
 		)
@@ -1884,9 +1884,9 @@ async fn enroll_v27_account(
 	assert!(
 		store
 			.attest_codex_account_capability(&CodexAccountCapabilityAttestation {
-				build_identity: "codex-cli 0.146.0-alpha.3.1".to_owned(),
+				build_identity: "codex-cli 0.146.0-alpha.9.2".to_owned(),
 				executable_sha256:
-					"fa0cb7c5f80e6a192563fcb1d9f98857f4a808a28cb29289400ed7110291bce4".to_owned(),
+					"d96ae1ca1ff6fc8587842fa04c92d3ee4d31651a811c2f89b65fcfd9c28473e2".to_owned(),
 				schema_sha256: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
 					.to_owned(),
 				callback_profile_sha256: CALLBACK_PROFILE.to_owned(),
@@ -1895,6 +1895,8 @@ async fn enroll_v27_account(
 			})
 			.await?
 	);
+	let account = &store.read_account_registry(Some(account_id), 1).await?[0];
+	assert_eq!(account.lifecycle_readiness, AccountLifecycleReadiness::Ready);
 	Ok(())
 }
 

--- a/crates/decodex-postgres/tests/postgres_store/routing_decision.rs
+++ b/crates/decodex-postgres/tests/postgres_store/routing_decision.rs
@@ -40,9 +40,9 @@ const PROCESS_AUTHORIZATION_DIGEST: &str =
 const PROCESS_CREDENTIAL_FINGERPRINT: &str =
 	"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 const PROCESS_CALLBACK_PROFILE: &str =
-	"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+	"64a98c3328d1eba74aaf18a3995523e07fd2f1395bc6fb4a121b74338c404a29";
 const CURRENT_CODEX_EXECUTABLE_SHA256: &str =
-	"fa0cb7c5f80e6a192563fcb1d9f98857f4a808a28cb29289400ed7110291bce4";
+	"d96ae1ca1ff6fc8587842fa04c92d3ee4d31651a811c2f89b65fcfd9c28473e2";
 
 #[derive(Clone)]
 pub(super) struct RoutingFixture {
@@ -662,7 +662,7 @@ async fn prepare_routing_process_generations(
 	assert!(
 		store
 			.attest_codex_account_capability(&decodex_postgres::CodexAccountCapabilityAttestation {
-				build_identity: "codex-cli 0.146.0-alpha.3.1".to_owned(),
+				build_identity: "codex-cli 0.146.0-alpha.9.2".to_owned(),
 				executable_sha256: CURRENT_CODEX_EXECUTABLE_SHA256.to_owned(),
 				schema_sha256: SCHEMA_FINGERPRINT.to_owned(),
 				callback_profile_sha256: PROCESS_CALLBACK_PROFILE.to_owned(),

--- a/crates/decodex-runtime/src/account_launch/process.rs
+++ b/crates/decodex-runtime/src/account_launch/process.rs
@@ -62,7 +62,6 @@ use crate::account_launch::{
 		RetainedTitleNameSetResponse, RetainedTitleThreadStartParams,
 		RetainedTitleThreadStartResponse, ThreadArchiveParams, ThreadArchiveResponse,
 		ThreadListParams, ThreadListResponse, ThreadReadParams, ThreadReadResponse,
-		ThreadSearchParams, ThreadSearchResponse,
 	},
 };
 use decodex_codex::{
@@ -93,15 +92,14 @@ const PRIVATE_STDIO_STARTUP_VALUE: &str = "1";
 const PRIVATE_STDIO_CAPABILITY_ID: &str =
 	"codex-app-server-private-stdio-disabled-ephemeral-startup-v1";
 const STDIO_ONLY_ATTESTED_PLATFORM: &str = "macos-aarch64";
-const STDIO_ONLY_ATTESTED_VERSION: &str = "codex-cli 0.146.0-alpha.3.1";
+const STDIO_ONLY_ATTESTED_VERSION: &str = "codex-cli 0.146.0-alpha.9.2";
 const STDIO_ONLY_ATTESTED_EXECUTABLE_SHA256: &str =
-	"fa0cb7c5f80e6a192563fcb1d9f98857f4a808a28cb29289400ed7110291bce4";
+	"d96ae1ca1ff6fc8587842fa04c92d3ee4d31651a811c2f89b65fcfd9c28473e2";
 const PROTOCOL_QUEUE_CAPACITY: usize = 64;
 const THREAD_LIST_LIMIT: usize = 100;
-const THREAD_SEARCH_LIMIT: usize = 10;
+const THREAD_LIST_PROBE_SEARCH_TERM: &str = "decodex-capability-probe-no-match-6f5aa91b28cf4bc6";
 const MAX_VERSION_OUTPUT_BYTES: u64 = 4 * 1_024;
 const MAX_EXECUTABLE_BYTES: u64 = 512 * 1_024 * 1_024;
-const CAPABILITY_SEARCH_TERM: &str = "decodex-capability-probe-7f57a41a";
 const RETAINED_TITLE_DEVELOPER_INSTRUCTIONS: &str =
 	"This is an inert Decodex retained-title experiment. Do not start a turn or perform work.";
 const ACCOUNT_MISMATCH_SHUTDOWN: Duration = Duration::from_secs(1);
@@ -1941,7 +1939,6 @@ impl ReadOnlyProbe {
 		let list = probe_thread_list(&mut process, self.timeout, &mut negotiation)?;
 
 		probe_thread_read(&mut process, &list, self.timeout, &mut negotiation)?;
-		probe_thread_search(&mut process, self.timeout, &mut negotiation)?;
 
 		let profile = negotiation.cache_profile()?;
 		let process_id = process.process_id();
@@ -2471,8 +2468,6 @@ pub enum ReadOnlyMethod {
 	ThreadList,
 	/// Read one exact thread without turns.
 	ThreadRead,
-	/// Exercise bounded `thread/search` method availability.
-	ThreadSearch,
 }
 impl ReadOnlyMethod {
 	fn as_str(self) -> &'static str {
@@ -2482,7 +2477,6 @@ impl ReadOnlyMethod {
 			Self::AccountRead => "account/read",
 			Self::ThreadList => "thread/list",
 			Self::ThreadRead => "thread/read",
-			Self::ThreadSearch => "thread/search",
 		}
 	}
 }
@@ -4167,7 +4161,11 @@ fn probe_thread_list(
 ) -> Result<ThreadListResponse, ProbeError> {
 	let list = match process.request::<_, ThreadListResponse>(
 		ReadOnlyMethod::ThreadList,
-		&ThreadListParams { limit: THREAD_LIST_LIMIT as u32, use_state_db_only: true },
+		&ThreadListParams {
+			search_term: THREAD_LIST_PROBE_SEARCH_TERM,
+			limit: THREAD_LIST_LIMIT as u32,
+			use_state_db_only: true,
+		},
 		timeout,
 	) {
 		Ok(list) => list,
@@ -4218,54 +4216,6 @@ fn probe_thread_read(
 		},
 		Err(error) => {
 			negotiation.observations.push(failed_observation(Capability::ThreadRead, &error));
-
-			(!matches!(&error, ProbeError::MethodRejected { .. })).then_some(error)
-		},
-	};
-
-	negotiation.re_attest_account(process, timeout)?;
-
-	if let Some(error) = terminal_error {
-		negotiation.cache_profile()?;
-
-		return Err(error);
-	}
-
-	Ok(())
-}
-
-fn probe_thread_search(
-	process: &mut SupervisedProcess,
-	timeout: Duration,
-	negotiation: &mut ProbeNegotiation<'_>,
-) -> Result<(), ProbeError> {
-	if !negotiation.generated.contract().advertises_request("thread/search") {
-		return Ok(());
-	}
-
-	let search = process.request::<_, ThreadSearchResponse>(
-		ReadOnlyMethod::ThreadSearch,
-		&ThreadSearchParams {
-			search_term: CAPABILITY_SEARCH_TERM,
-			limit: THREAD_SEARCH_LIMIT as u32,
-		},
-		timeout,
-	);
-	let terminal_error = match search {
-		Ok(response) if response.data.len() <= THREAD_SEARCH_LIMIT => {
-			negotiation.observe(Capability::ThreadSearch, LiveMethodOutcome::Supported);
-
-			None
-		},
-		Ok(_) => {
-			let error = ProbeError::Supervision(SupervisionError::ProtocolLimitExceeded);
-
-			negotiation.observations.push(failed_observation(Capability::ThreadSearch, &error));
-
-			Some(error)
-		},
-		Err(error) => {
-			negotiation.observations.push(failed_observation(Capability::ThreadSearch, &error));
 
 			(!matches!(&error, ProbeError::MethodRejected { .. })).then_some(error)
 		},
@@ -5645,7 +5595,7 @@ mod tests {
 	}
 
 	#[test]
-	fn safe_optional_probes_record_live_contradictions_by_exact_build() {
+	fn unexercised_optional_methods_remain_not_probed() {
 		let temp = TempDir::new().unwrap();
 		let result = ReadOnlyProbe::new_for_test(
 			fake_command("optional-unsupported", temp.path(), None),
@@ -5659,15 +5609,9 @@ mod tests {
 		for capability in [Capability::ThreadRead, Capability::ThreadSearch] {
 			assert_eq!(
 				result.profile.state(capability),
-				&CapabilityState::Unsupported { reason: UnsupportedReason::MethodNotFound }
+				&CapabilityState::Unavailable { reason: UnavailableReason::NotProbed }
 			);
-			assert!(
-				result
-					.profile
-					.contradictions()
-					.iter()
-					.any(|contradiction| contradiction.capability == capability)
-			);
+			assert!(result.profile.contradictions().is_empty());
 		}
 	}
 

--- a/crates/decodex-runtime/src/account_launch/protocol.rs
+++ b/crates/decodex-runtime/src/account_launch/protocol.rs
@@ -110,6 +110,7 @@ pub struct InitializeResponse {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadListParams {
+	pub search_term: &'static str,
 	pub limit: u32,
 	pub use_state_db_only: bool,
 }
@@ -184,21 +185,6 @@ pub struct ThreadArchiveParams<'a> {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ThreadArchiveResponse {}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ThreadSearchParams<'a> {
-	pub search_term: &'a str,
-	pub limit: u32,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ThreadSearchResponse {
-	pub data: Vec<ProtocolThread>,
-	#[serde(rename = "nextCursor")]
-	pub _next_cursor: Option<SensitiveString>,
-}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/decodex-runtime/tests/fixtures/fake_app_server.py
+++ b/crates/decodex-runtime/tests/fixtures/fake_app_server.py
@@ -377,7 +377,27 @@ for line in sys.stdin:
         reset_card_consumed = True
         result = {"outcome": "reset"}
     elif method == "thread/list":
-        if "searchTerm" in message["params"]:
+        if message["params"].get("searchTerm", "").startswith(
+            "decodex-capability-probe-no-match-"
+        ):
+            assert set(message["params"]) == {"limit", "searchTerm", "useStateDbOnly"}
+            assert message["params"]["useStateDbOnly"] is True
+            assert message["params"]["limit"] <= 100
+            count = 0 if mode == "optional-unsupported" else 1
+            if mode == "oversized-thread-list":
+                count = 101
+            result = {
+                "data": [
+                    {
+                        "id": f"00000000-0000-4000-8000-{index:012d}",
+                        "archived": False,
+                        "parentThreadId": None,
+                    }
+                    for index in range(1, count + 1)
+                ],
+                "nextCursor": None,
+            }
+        elif "searchTerm" in message["params"]:
             assert set(message["params"]) == {"archived", "limit", "searchTerm"}
             assert message["params"]["searchTerm"] == exact_thread["name"]
             assert message["params"]["limit"] <= 100

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -559,7 +559,7 @@ code, path, session, and process-group verification. After spawn, the supervisor
 boot, PID, process-start, process-group, and session identities.
 
 The current launch profile accepts only the source-attested macOS
-`codex-cli 0.146.0-alpha.3.1` image and forces
+`codex-cli 0.146.0-alpha.9.2` image and forces
 `CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1`. This is exact-build startup-state
 evidence: it selects disabled-ephemeral remote-control mode, but it is not a permanent denial
 policy. The supervisor retains child stdin and stdout privately for lifetime ownership.
@@ -568,7 +568,7 @@ protocol writer. Every other build, including the current unrecorded Linux image
 before profile-dependent version or schema preflight spawn.
 
 That accepted lifetime profile is not by itself an AccountLifecycle readiness receipt. The
-exact `codex-cli 0.146.0-alpha.3.1` profile recognizes the root
+exact `codex-cli 0.146.0-alpha.9.2` profile recognizes the root
 `account/chatgptAuthTokens/refresh` request and response schemas and services that callback
 through the Account Service. Readiness is issued only after the exact executable, generated
 schema, and live callback preflights pass. The callback path rechecks the account revision,
@@ -1437,14 +1437,15 @@ group, and lifetime guard to the hard-capped fair quarantine rather than relinqu
 authority. Transfer is bounded; background retries are isolated per round and may intentionally
 retain capacity indefinitely when group death cannot be confirmed.
 
-The probe sends `initialize`, `initialized`, read-only `account/read`, bounded
-`thread/list(useStateDbOnly=true)`, exact-ID `thread/read(includeTurns=false)` when a listed
-thread exists, and `thread/search` with a fixed nonmatching term and bounded result count.
-The latter two calls establish method availability only; they do not claim global title
-discovery. Account identity is pseudonymized and re-attested after every authority read;
+The probe sends `initialize`, `initialized`, read-only `account/read`, and bounded
+`thread/list(useStateDbOnly=true)` with a fixed nonmatching search term. It sends exact-ID
+`thread/read(includeTurns=false)` only if that filtered list unexpectedly returns a thread.
+The exact `alpha.9.2` image advertises `thread/search`, but the method did not return during the
+bounded live check. The probe does not call it and records it as `not_probed`; it does not claim
+global title discovery. Account identity is pseudonymized and re-attested after every authority read;
 an identity change discards the in-progress negotiation, and restart retains the expected
-identity for re-attestation. Archive, paginated persisted history, and native collaboration
-remain explicitly `not_probed` while their side-effect/event gates are closed. Paginated
+identity for re-attestation. Search, archive, paginated persisted history, and native collaboration
+remain explicitly `not_probed` while their method or side-effect/event gates are closed. Paginated
 history schema evidence comes from the structural `ThreadStartParams.historyMode` /
 `ThreadHistoryMode` contract, never from a list cursor.
 Current `DispatchGate` has no enabled state and denies thread start/resume, turn

--- a/openwiki/decisions/vnext-authority.md
+++ b/openwiki/decisions/vnext-authority.md
@@ -50,7 +50,7 @@ plugin, rollout, and thread visibility authority.
 
 The exact protected Codex build must positively prove the
 `account/chatgptAuthTokens/refresh` callback before readiness. The current exact
-`codex-cli 0.146.0-alpha.3.1` profile handles the root refresh request and response through
+`codex-cli 0.146.0-alpha.9.2` profile handles the root refresh request and response through
 the Account Service, subject to exact-image, generated-schema, and live callback
 preflights. The existing V23 ProcessGeneration intent, manifest, fence, and readback bind
 the initial account revision, canonical credential version/fingerprint, provider identity,

--- a/openwiki/evidence/xy-1422-codex-0146-account-callback.md
+++ b/openwiki/evidence/xy-1422-codex-0146-account-callback.md
@@ -12,7 +12,7 @@ observed upstream head is byte-identical to the release.
 | Fact | Accepted value |
 | --- | --- |
 | Upstream repository | `openai/codex` |
-| Observed upstream head | [`9949245d1d2b4a39a6f1841922322f767fa146ad`](https://github.com/openai/codex/commit/9949245d1d2b4a39a6f1841922322f767fa146ad) |
+| Observed upstream head | [`5157493c23713ac12034cf250ffb0a8ce0670277`](https://github.com/openai/codex/commit/5157493c23713ac12034cf250ffb0a8ce0670277) |
 | Release | [`rust-v0.146.0-alpha.9.2`](https://github.com/openai/codex/releases/tag/rust-v0.146.0-alpha.9.2) |
 | Release publication time | `2026-07-29T23:53:10Z` |
 | Platform | macOS arm64 |
@@ -26,6 +26,14 @@ observed upstream head is byte-identical to the release.
 | Unsigned payload SHA-256 | `eca7b04fcad0d9102eae75dc3cb74974c096cc394df65a1bab9a68343ccecfeb` |
 | Code-signing team | `2DC432GLL2` |
 | Installed signing timestamp | 2026-07-31 |
+
+The reviewed range from `9949245d1d2b4a39a6f1841922322f767fa146ad` through the observed head contains
+one protocol change. It adds an optional `onboardingEntrypoint` field to the
+`account/login/completed` notification. Decodex does not consume that notification, and the field
+is not present in the generated schema of the installed image accepted by this receipt. No current
+runtime behavior changes. A future installed image with the upstream field will change the pinned
+`ServerNotification.json` and aggregate schema digests, so the exact-image gate will reject that
+image until a separate adaptation accepts it.
 
 The GitHub release executable and the installed executable have different full-file SHA-256
 values. Both have the same Mach-O UUID. After signatures were removed from private copies, the

--- a/openwiki/evidence/xy-1422-codex-0146-account-callback.md
+++ b/openwiki/evidence/xy-1422-codex-0146-account-callback.md
@@ -1,35 +1,88 @@
-# Codex 0.146 account-callback receipt
+# Codex 0.146.0-alpha.9.2 account-callback receipt
 
-Date: 2026-07-29
+Date: 2026-08-02
 
-This receipt binds the current macOS account-launch profile to one exact Codex image and its
-generated app-server schema. It does not authorize another Codex build.
+This receipt binds the current macOS account-launch profile to one exact installed Codex image and
+its generated app-server schema. It does not authorize another Codex build. The upstream source
+observation and the release artifact are separate facts; this receipt does not claim that the
+observed upstream head is byte-identical to the release.
+
+## Source and release
 
 | Fact | Accepted value |
 | --- | --- |
+| Upstream repository | `openai/codex` |
+| Observed upstream head | [`9949245d1d2b4a39a6f1841922322f767fa146ad`](https://github.com/openai/codex/commit/9949245d1d2b4a39a6f1841922322f767fa146ad) |
+| Release | [`rust-v0.146.0-alpha.9.2`](https://github.com/openai/codex/releases/tag/rust-v0.146.0-alpha.9.2) |
+| Release publication time | `2026-07-29T23:53:10Z` |
 | Platform | macOS arm64 |
-| Codex version | `codex-cli 0.146.0-alpha.3.1` |
-| Executable SHA-256 | `fa0cb7c5f80e6a192563fcb1d9f98857f4a808a28cb29289400ed7110291bce4` |
-| Release archive SHA-256 | `147297da351dc408e4f1e7f9d9c4d96873f4da70c13af6d5416d3c5e1cef4cd4` |
+| Installed path | `/Applications/ChatGPT.app/Contents/Resources/codex` |
+| Codex version | `codex-cli 0.146.0-alpha.9.2` |
+| Installed executable SHA-256 | `d96ae1ca1ff6fc8587842fa04c92d3ee4d31651a811c2f89b65fcfd9c28473e2` |
+| Release archive SHA-256 | `dc578db9698a8f76be3d576fa6f5fa7008e1fd329582c44fde2c82db4d5d27b5` |
+| Extracted release executable SHA-256 | `a2795588f2492f8839bc03c3f6ffc0d4ac2950812ae8c66800122db584a8af04` |
+| Mach-O UUID | `6B87DCFB-91F9-3249-8B01-56255808E271` |
+| Unsigned payload size | `268490400` bytes |
+| Unsigned payload SHA-256 | `eca7b04fcad0d9102eae75dc3cb74974c096cc394df65a1bab9a68343ccecfeb` |
 | Code-signing team | `2DC432GLL2` |
-| `ClientRequest.json` | `ee9fcbf5c0b3af8526dea54d3c1c7a6ca480f0847b049b9b7d4cde00ddd82735` |
-| `ServerNotification.json` | `189dc3b9bf8e96a115cf1102e60c379d8e34382ddca2868d1b2b46847d122166` |
-| Aggregate v2 schema | `2ad5e818b870a6a26387678bbe276e4c67b3b078f6ac03143fba623b0969605d` |
-| Account refresh method | `account/chatgptAuthTokens/refresh` |
-| Refresh request schema | root `ChatgptAuthTokensRefreshParams.json` |
-| Refresh response schema | root `ChatgptAuthTokensRefreshResponse.json` |
-| Callback profile SHA-256 | `918c879482dd6b6732335b05a2b208b518467b42ae827fd08d01a45f2c907587` |
+| Installed signing timestamp | 2026-07-31 |
 
-The operator generated the schema with:
+The GitHub release executable and the installed executable have different full-file SHA-256
+values. Both have the same Mach-O UUID. After signatures were removed from private copies, the
+two copies were byte-identical at the size and SHA-256 recorded above. This evidence supports an
+OpenAI re-signing explanation for the full-file difference. It proves matching unsigned payloads;
+it does not claim that the signed files are identical.
+
+## Generated schema
+
+The operator generated the schema from the installed executable with:
 
 ```sh
 codex app-server generate-json-schema --experimental --out ABSOLUTE_PRIVATE_DIRECTORY
 ```
 
-The generated directory contained 347 regular schema files. `GeneratedSchemaEvidence::load`
-reproduced the checked-in schema digests and callback profile for this exact replacement image.
-The final local-service installation must pass the daemon callback preflight and report the
-credential vault ready.
+The owner-private directory had mode `0700`, contained 349 regular files with no symlinks, and
+used 4,328 KiB. The file count remains below the fixed 512-file safety limit.
 
-The accepted executable is the signed `codex-aarch64-apple-darwin` binary from the
-OpenAI Codex [`rust-v0.146.0-alpha.3.1` release](https://github.com/openai/codex/releases/tag/rust-v0.146.0-alpha.3.1).
+| Schema file | Canonical SHA-256 |
+| --- | --- |
+| `ClientRequest.json` | `6ffc593d603d21a051840539a4dbfad95cad2e7fec315e252b6722bd71bf37b4` |
+| `ServerNotification.json` | `abbb54060ea6a6005e63267bc6996eacd70cbb7954a7e0d61f50ea02af4acf02` |
+| `codex_app_server_protocol.v2.schemas.json` | `e554a74bd59d38d16acb1744750b2999156ee3d65d0fe906b22ab52edf17fbbc` |
+| `ServerRequest.json` | `6455b23a65fa3d9c7749ecd2ecbc4b829c9039f6cd8f9adc44d86ad4522e37ec` |
+| `v2/LoginAccountParams.json` | `3bec7003eb85aabbeaf0ba8a22ec54b68ec26d2657d6878a31ca0d01dfe642e0` |
+| `ChatgptAuthTokensRefreshParams.json` | `74d490082dab616ac01c94d388c9a836304c96092db37290cfdd10a46b0f3ef9` |
+| `ChatgptAuthTokensRefreshResponse.json` | `ff76f5cc58bff40216f9d5f3c5be921268059f6d66d6c034970cddf0e08f0ced` |
+| `v2/ThreadReadResponse.json` | `94689cd705b4936a5c361deaa51fed69101eaba0629899ef8a39b600180de9b3` |
+| `v2/ThreadStartParams.json` | `001c07a58981df5d860335bf8cee4d336df2165db6dc9c645cefed0467ccebbe` |
+| Callback profile SHA-256 | `64a98c3328d1eba74aaf18a3995523e07fd2f1395bc6fb4a121b74338c404a29` |
+
+`GeneratedSchemaEvidence::load` independently reproduced the callback profile from these files.
+The exact account refresh method remains `account/chatgptAuthTokens/refresh`, with root
+`ChatgptAuthTokensRefreshParams.json` and `ChatgptAuthTokensRefreshResponse.json` request and
+response schemas.
+
+## Failure and repair
+
+Before this adaptation, the exact ignored live read-only probe failed with `SchemaMissing` for the
+three checked-in marker digests. After the digest update, an unfiltered `thread/list` response
+included the new `preview` field and JSON escapes. The zero-scratch safety gate rejected that frame
+before typed decoding. A direct structural check showed that bounded `thread/list` with the fixed
+nonmatching search term returned zero rows in a 71-byte response with no backslash bytes.
+
+The exact schema advertises `thread/search`, but a direct bounded check received no response within
+20 seconds. The live foundation probe therefore does not invoke that method. It records
+`Capability::ThreadSearch` as `Unavailable(NotProbed)` unless separate live evidence exists. This
+change does not weaken frame validation or a timeout.
+
+The first acceptance run after this repair failed closed during cold preflight with
+`Supervision(PreflightFailed)`. The same unmodified command then passed in 35.28 seconds. It
+negotiated the installed image and used only schema generation, version inspection, and read-only
+RPCs; it did not dispatch a turn. A final repeat run with all nine file digests pinned also passed
+in 34.67 seconds:
+
+```sh
+cargo test --locked -p decodex-runtime account_launch::process::tests::live_read_only_probe_negotiates_without_dispatch -- --ignored --exact --nocapture
+```
+
+The V32 migration and current source profile remove support for the prior `alpha.3.1` image.

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -904,13 +904,16 @@ conflicts, scripted fake server, structural history/collaboration-schema rejecti
 production command construction, bounded executable/preflight/schema/frame/queue/result
 inputs, timeout and descendant/orphan cleanup, typed or hashed untrusted event strings,
 shared-home/account re-attestation, redacted debug surfaces, and default-disabled dispatch.
-The accepted marker now binds Codex CLI `0.146.0-alpha.3.1` to
+The accepted marker now binds Codex CLI `0.146.0-alpha.9.2` to
 `ClientRequest.json` digest
-`ee9fcbf5c0b3af8526dea54d3c1c7a6ca480f0847b049b9b7d4cde00ddd82735`,
+`6ffc593d603d21a051840539a4dbfad95cad2e7fec315e252b6722bd71bf37b4`,
 `ServerNotification.json` digest
-`189dc3b9bf8e96a115cf1102e60c379d8e34382ddca2868d1b2b46847d122166`, and
+`abbb54060ea6a6005e63267bc6996eacd70cbb7954a7e0d61f50ea02af4acf02`, and
 aggregate v2 schema digest
-`2ad5e818b870a6a26387678bbe276e4c67b3b078f6ac03143fba623b0969605d`.
+`e554a74bd59d38d16acb1744750b2999156ee3d65d0fe906b22ab52edf17fbbc`.
+It also pins `ServerRequest.json`, `v2/LoginAccountParams.json`, both root refresh schemas,
+`v2/ThreadReadResponse.json`, and `v2/ThreadStartParams.json` to the digests in the
+[exact image receipt](../evidence/xy-1422-codex-0146-account-callback.md).
 Codex CLI release `rust-v0.145.0` is rejected as an obsolete exact build. Its
 `ClientRequest.json`, `ServerNotification.json`, and aggregate v2 schema digests are
 `92085c18742dd355e5afa7d570170c74629635082e8e3341a952068735dc28b2`,
@@ -923,12 +926,13 @@ build. Its three digests are
 `5ff4540622e002308ad5e6bac6df49b7ab5d52d79c8f71537b1098951b946b2d`.
 No compatibility shim for either release is retained. The previously accepted
 three-digest set is also rejected as an incompatible build.
-The ignored live test is strictly read-only: `initialize`, `initialized`, `account/read`,
-bounded `thread/list(useStateDbOnly=true)`, optional exact-ID
-`thread/read(includeTurns=false)`, and fixed-nonmatching-term bounded `thread/search`.
-The optional probes prove method availability only and do not establish global title
-discovery. Do not replace the live test with excluded v0.2 `decodex probe stdio://`, which
-starts a proof turn.
+The ignored live test is strictly read-only: `initialize`, `initialized`, `account/read`, and
+bounded `thread/list(useStateDbOnly=true)` with a fixed nonmatching search term. It sends optional
+exact-ID `thread/read(includeTurns=false)` only if the filtered list unexpectedly returns a thread.
+The exact `alpha.9.2` schema advertises `thread/search`, but the method did not return during the
+bounded live check. The test does not invoke it and records it as `not_probed`. These probes do not
+establish global title discovery. Do not replace the live test with excluded v0.2
+`decodex probe stdio://`, which starts a proof turn.
 
 ## Plugin and automation checks
 

--- a/openwiki/operations/xy-1368-retained-title-validation.md
+++ b/openwiki/operations/xy-1368-retained-title-validation.md
@@ -18,7 +18,7 @@ The command uses one private PostgreSQL 18 cluster. It reports three complete st
    principal. The one configured
    post-migration provisioner owns the final runtime ACL.
 2. It parses and prepares all 30 changed V22/V27/V28 embedded PostgreSQL statements in one Rust process.
-3. It verifies the generated schema and configured-authority digests, including the exact 27
+3. It verifies the generated schema and configured-authority digests, including the exact 28
    migration-owned function sources and 201 final function contracts in `authority.rs`.
 
 The command does not execute the prepared statements.

--- a/openwiki/operations/xy-1368-retained-title-validation.md
+++ b/openwiki/operations/xy-1368-retained-title-validation.md
@@ -12,9 +12,9 @@ cargo make check-vnext-retained-title-preparation
 
 The command uses one private PostgreSQL 18 cluster. It reports three complete stages:
 
-1. It checks the full V1-V31 migration syntax, applies and canonically provisions a fresh
+1. It checks the full V1-V32 migration syntax, applies and canonically provisions a fresh
    full ledger, and separately verifies the closed migration-only authority delta from V24
-   through V31. V28, V29, V30, and the V31 exact-release repair do not derive or grant a runtime
+   through V32. V28, V29, V30, V31, and the V32 exact-release repair do not derive or grant a runtime
    principal. The one configured
    post-migration provisioner owns the final runtime ACL.
 2. It parses and prepares all 30 changed V22/V27/V28 embedded PostgreSQL statements in one Rust process.

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -247,7 +247,7 @@ Codex build must prove all of these facts:
   bound to launch authority.
 
 Unsupported, unprobed, contradictory, or changed builds fail closed. The current exact
-`codex-cli 0.146.0-alpha.3.1` adapter services the root refresh request through the Account
+`codex-cli 0.146.0-alpha.9.2` adapter services the root refresh request through the Account
 Service and returns the root refresh response. This source capability can satisfy
 `AccountLifecycle`, `MacDogfoodReady`, and runner readiness only when the exact-image,
 generated-schema, and live callback preflights also pass. Initial token projection alone is
@@ -343,7 +343,7 @@ fields are absent when the provider or current credential does not supply them.
 The product has no legacy-account migration mode. Normal startup and installation do
 not read an old account pool, mapping, helper, environment projection, migration
 manifest, or migration receipt. V27 is the landed clean-break account schema in the
-current V1–V31 migration ledger and accepts only an empty Account Registry. A populated
+current V1–V32 migration ledger and accepts only an empty Account Registry. A populated
 older registry requires a fresh local product database.
 
 An operator can move credentials once by creating owner-private

--- a/openwiki/specs/process-generation-authority.md
+++ b/openwiki/specs/process-generation-authority.md
@@ -87,8 +87,8 @@ The current accepted profile is intentionally narrow:
 | Field | Accepted value |
 | --- | --- |
 | Platform evidence | macOS arm64 |
-| Version | `codex-cli 0.146.0-alpha.3.1` |
-| Executable SHA-256 | `fa0cb7c5f80e6a192563fcb1d9f98857f4a808a28cb29289400ed7110291bce4` |
+| Version | `codex-cli 0.146.0-alpha.9.2` |
+| Executable SHA-256 | `d96ae1ca1ff6fc8587842fa04c92d3ee4d31651a811c2f89b65fcfd9c28473e2` |
 | Command | canonical Codex path as both executable and argv0, suspended before user code, with fixed `app-server --stdio` arguments |
 | Startup state | `CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1` selects `DisabledEphemeral`; no remote-control argument |
 | Protocol boundary | Child stdin and stdout remain private to `ProcessSupervisor`; `FencedProcess` returns no protocol handle |
@@ -99,9 +99,9 @@ The current exact image and callback receipt is
 [the Codex 0.146 account-callback receipt](../evidence/xy-1422-codex-0146-account-callback.md).
 For the same exact tag, Codex reads the marker at startup and selects
 `DisabledEphemeral` for stdio without a remote-control argument in the upstream
-[CLI selection](https://github.com/openai/codex/blob/rust-v0.146.0-alpha.3.1/codex-rs/cli/src/main.rs)
+[CLI selection](https://github.com/openai/codex/blob/rust-v0.146.0-alpha.9.2/codex-rs/cli/src/main.rs)
 and
-[remote-control transport module](https://github.com/openai/codex/blob/rust-v0.146.0-alpha.3.1/codex-rs/app-server-transport/src/transport/remote_control/mod.rs).
+[remote-control transport module](https://github.com/openai/codex/blob/rust-v0.146.0-alpha.9.2/codex-rs/app-server-transport/src/transport/remote_control/mod.rs).
 The marker is startup-state evidence only. It is not a permanent denial policy: the
 same exact build can process an alternate-control enable RPC if a protocol writer can
 send one. This pre-dispatch slice therefore returns no raw stdin, raw stdout, generic
@@ -119,7 +119,7 @@ alone cannot mint launch authority.
 
 MacDogfoodReady requires an exact-build account-capability receipt for the callback.
 Version text, generated request types, or upstream implementation presence alone is not
-proof. The current exact `codex-cli 0.146.0-alpha.3.1` profile handles the root refresh
+proof. The current exact `codex-cli 0.146.0-alpha.9.2` profile handles the root refresh
 request and response, but it mints readiness only after the exact-image, generated-schema,
 and live callback preflights pass. An unsupported build or callback shape fails closed
 before account launch. The private-stdio lifetime profile does not independently claim

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -577,7 +577,7 @@ V23 before a fresh fence can authorize one spawn. Intent, launch manifest, prepa
 transition, and readback carry the same non-secret binding. No new process or effect ledger is
 added. The supervisor then binds the exact PID, process-start identity, process group, and session.
 
-The current lifetime profile accepts only the recorded macOS `codex-cli 0.146.0-alpha.3.1` image. It
+The current lifetime profile accepts only the recorded macOS `codex-cli 0.146.0-alpha.9.2` image. It
 sets `CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1` and supplies no remote-control
 argument. The marker proves only the exact build's startup state. `ProcessSupervisor` retains the
 raw channels privately for lifetime ownership, and no returned ProcessGeneration capability

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -870,7 +870,7 @@ added. No retained-title evidence gate enables production routing.
 
 ### Account lifecycle and Mac dogfood gate
 
-The accepted Mac gate covers only the latest architecture. It starts a fresh V1–V31
+The accepted Mac gate covers only the latest architecture. It starts a fresh V1–V32
 PostgreSQL database with an empty Account Registry, verifies the signed daemon wrapper
 and same-UID Unix transport, imports test accounts through the ordinary public account
 command, restarts once for exact-build callback attestation, and verifies list, routing,

--- a/scripts/vnext/postgres_store_test.py
+++ b/scripts/vnext/postgres_store_test.py
@@ -3895,7 +3895,16 @@ def prepare_postgres_authority_inventory(
 		work, POSTGRES_PREPARATION_DATABASE, env, working_binding
 	)
 	if fresh_inventory["actual_digests"] != fresh_inventory["expected_digests"]:
-		raise TestFailure("V31 fresh closed-authority digests do not match authority.rs")
+		raise TestFailure(
+			"V32 fresh closed-authority digests do not match authority.rs: "
+			+ json.dumps(
+				{
+					"actual": fresh_inventory["actual_digests"],
+					"expected": fresh_inventory["expected_digests"],
+				},
+				sort_keys=True,
+			)
+		)
 	fresh_runtime_authority = capture_runtime_authority(
 		POSTGRES_PREPARATION_DATABASE, env
 	)
@@ -3905,7 +3914,7 @@ def prepare_postgres_authority_inventory(
 		or fresh_runtime_authority["direct_non_grantable_type_usage_count"]
 		!= len(RUNTIME_TYPE_NAMES)
 	):
-		raise TestFailure("V31 fresh runtime authority counts are not exact")
+		raise TestFailure("V32 fresh runtime authority counts are not exact")
 
 	create_database(AUTHORITY_CAPTURE_UPGRADE_DATABASE, env)
 	set_contract_urls(
@@ -3930,31 +3939,31 @@ def prepare_postgres_authority_inventory(
 		AUTHORITY_CAPTURE_UPGRADE_DATABASE, env
 	)
 	run_migration(env)
-	upgrade_v31_ledger = capture_migration_ledger(
+	upgrade_v32_ledger = capture_migration_ledger(
 		AUTHORITY_CAPTURE_UPGRADE_DATABASE, env
 	)
 	if (
 		len(upgrade_v24_ledger) != 24
 		or upgrade_v24_ledger[-1].get("version") != 24
-		or len(upgrade_v31_ledger) != 31
-		or upgrade_v31_ledger[-1].get("version") != 31
-		or upgrade_v31_ledger[-1].get("name") != "official_codex_release_capability"
+		or len(upgrade_v32_ledger) != 32
+		or upgrade_v32_ledger[-1].get("version") != 32
+		or upgrade_v32_ledger[-1].get("name") != "codex_0146_alpha_9_2_capability"
 	):
-		raise TestFailure("V31 upgrade migration ledger is not exact")
+		raise TestFailure("V32 upgrade migration ledger is not exact")
 	upgrade_runtime_authority = capture_upgrade_runtime_authority(
 		AUTHORITY_CAPTURE_UPGRADE_DATABASE, env
 	)
 
 	return json.dumps({
 		"schema": "decodex/postgres-preparation-stage/1",
-		"stage": "v31_closed_authority",
+		"stage": "v32_closed_authority",
 		"fresh_inventory": fresh_inventory,
 		"fresh_runtime_authority": fresh_runtime_authority,
 		"upgrade": {
 			"v24_ledger": upgrade_v24_ledger,
 			"pre_v27_anchor_binding": upgrade_anchor_binding,
 			"pre_v27_type_bindings": upgrade_type_bindings,
-			"v31_ledger": upgrade_v31_ledger,
+			"v32_ledger": upgrade_v32_ledger,
 			"runtime_authority": upgrade_runtime_authority,
 		},
 	}, sort_keys=True)
@@ -6104,12 +6113,12 @@ def prepare_changed_postgres_migrations(
 	run_migration(env)
 	ledger = capture_migration_ledger(POSTGRES_PREPARATION_DATABASE, env)
 	if (
-		len(ledger) != 31
-		or ledger[-1].get("version") != 31
-		or ledger[-1].get("name") != "official_codex_release_capability"
+		len(ledger) != 32
+		or ledger[-1].get("version") != 32
+		or ledger[-1].get("name") != "codex_0146_alpha_9_2_capability"
 		or not isinstance(ledger[-1].get("checksum"), str)
 	):
-		raise TestFailure("PostgreSQL preparation did not reach the exact V1-V31 ledger")
+		raise TestFailure("PostgreSQL preparation did not reach the exact V1-V32 ledger")
 	return json.dumps({
 		"schema": "decodex/postgres-preparation-stage/1",
 		"stage": "migration_syntax",
@@ -6475,7 +6484,7 @@ def capture_upgrade_runtime_authority(database: str, env: dict[str, str]) -> dic
 			for row in function_grants
 		)
 	):
-		raise TestFailure("V31 upgrade runtime function authority is not exact")
+		raise TestFailure("V32 upgrade runtime function authority is not exact")
 	if (
 		not isinstance(type_grants, list)
 		or [row.get("identity") for row in type_grants if isinstance(row, dict)]
@@ -6488,7 +6497,7 @@ def capture_upgrade_runtime_authority(database: str, env: dict[str, str]) -> dic
 			for row in type_grants
 		)
 	):
-		raise TestFailure("V31 upgrade runtime type authority is not exact")
+		raise TestFailure("V32 upgrade runtime type authority is not exact")
 	if (
 		not isinstance(internal_sealing, list)
 		or [row.get("identity") for row in internal_sealing if isinstance(row, dict)]
@@ -6505,7 +6514,7 @@ def capture_upgrade_runtime_authority(database: str, env: dict[str, str]) -> dic
 	if not isinstance(unrelated_authority, dict) or any(
 		value != 0 for value in unrelated_authority.values()
 	):
-		raise TestFailure("V31 upgrade added unrelated runtime authority")
+		raise TestFailure("V32 upgrade added unrelated runtime authority")
 
 	return {
 		"database": database,
@@ -6827,26 +6836,26 @@ def validate_phase_a_receipt_document(document: object) -> dict[str, object]:
 		receipt["migration_ledger"], checkpoints, "Phase A ledger checkpoints are malformed"
 	)
 	for ledger in ledgers.values():
-		require_receipt_ledger(ledger, through_version=31)
+		require_receipt_ledger(ledger, through_version=32)
 	if ledgers["source"] != ledgers["restored_once"] or ledgers["source"] != ledgers["restored_twice"]:
-		raise TestFailure("Phase A V31 ledgers differ across restore checkpoints")
-	if ledgers["source"][-1]["name"] != "official_codex_release_capability":
-		raise TestFailure("Phase A ledger does not end at V31")
+		raise TestFailure("Phase A V32 ledgers differ across restore checkpoints")
+	if ledgers["source"][-1]["name"] != "codex_0146_alpha_9_2_capability":
+		raise TestFailure("Phase A ledger does not end at V32")
 	upgrade = require_exact_keys(
 		receipt["one_grantee_upgrade"],
 		{
 			"database", "pre_v27_anchor_binding", "pre_v27_type_bindings",
-			"runtime_authority", "v24_ledger", "v31_ledger",
+			"runtime_authority", "v24_ledger", "v32_ledger",
 		},
 		"Phase A one-grantee upgrade evidence is malformed",
 	)
 	require_receipt_ledger(upgrade["v24_ledger"], through_version=24)
-	upgrade_v31 = require_receipt_ledger(upgrade["v31_ledger"], through_version=31)
+	upgrade_v32 = require_receipt_ledger(upgrade["v32_ledger"], through_version=32)
 	if (
 		upgrade["database"] != AUTHORITY_CAPTURE_UPGRADE_DATABASE
-		or upgrade_v31 != ledgers["source"]
+		or upgrade_v32 != ledgers["source"]
 	):
-		raise TestFailure("Phase A one-grantee upgrade does not reach the exact V31 ledger")
+		raise TestFailure("Phase A one-grantee upgrade does not reach the exact V32 ledger")
 	upgrade_authority = require_exact_keys(
 		upgrade["runtime_authority"],
 		{
@@ -8252,7 +8261,7 @@ def run_authority_candidate_capture(
 		AUTHORITY_CAPTURE_UPGRADE_DATABASE, env
 	)
 	run_migration(env)
-	upgrade_v31_ledger = capture_migration_ledger(AUTHORITY_CAPTURE_UPGRADE_DATABASE, env)
+	upgrade_v32_ledger = capture_migration_ledger(AUTHORITY_CAPTURE_UPGRADE_DATABASE, env)
 	upgrade_runtime_authority = capture_upgrade_runtime_authority(
 		AUTHORITY_CAPTURE_UPGRADE_DATABASE, env
 	)
@@ -8559,7 +8568,7 @@ def run_authority_candidate_capture(
 			"v24_ledger": upgrade_v24_ledger,
 			"pre_v27_anchor_binding": upgrade_anchor_binding,
 			"pre_v27_type_bindings": upgrade_type_bindings,
-			"v31_ledger": upgrade_v31_ledger,
+			"v32_ledger": upgrade_v32_ledger,
 			"runtime_authority": upgrade_runtime_authority,
 		}
 		if phase_b_upgrade != phase_a.document["one_grantee_upgrade"]:
@@ -8599,7 +8608,7 @@ def run_authority_candidate_capture(
 			"v24_ledger": upgrade_v24_ledger,
 			"pre_v27_anchor_binding": upgrade_anchor_binding,
 			"pre_v27_type_bindings": upgrade_type_bindings,
-			"v31_ledger": upgrade_v31_ledger,
+			"v32_ledger": upgrade_v32_ledger,
 			"runtime_authority": upgrade_runtime_authority,
 		},
 		"runtime_authority": {
@@ -10430,7 +10439,7 @@ def main(
 					"checkpoint_state": restore_report,
 				}
 				raise TestFailure(
-					"aggregate V14-V31 PostgreSQL acceptance failure:\n"
+					"aggregate V14-V32 PostgreSQL acceptance failure:\n"
 					+ json.dumps(diagnostics, sort_keys=True)
 				)
 			return json.dumps(artifact_evidence, sort_keys=True)


### PR DESCRIPTION
## Summary

- Replace the retired Codex alpha.3.1 launch profile with the exact installed `codex-cli 0.146.0-alpha.9.2` image, generated schema markers, and callback profile.
- Keep the live foundation probe read-only and bounded by using a fixed nonmatching `thread/list` query; do not dispatch a turn or weaken zero-scratch frame validation.
- Add forward-only V32 capability authority and remove the prior image from current support.
- Review the current official upstream head. Its one post-baseline protocol change adds an optional onboarding hint to an unconsumed login-completion notification; the installed image does not yet contain it, and the exact schema gate will reject a future changed image until reviewed.

## Official evidence

- Upstream head: https://github.com/openai/codex/commit/5157493c23713ac12034cf250ffb0a8ce0670277
- Installed/release build: https://github.com/openai/codex/releases/tag/rust-v0.146.0-alpha.9.2
- Installed executable SHA-256: `d96ae1ca1ff6fc8587842fa04c92d3ee4d31651a811c2f89b65fcfd9c28473e2`
- Release executable SHA-256: `a2795588f2492f8839bc03c3f6ffc0d4ac2950812ae8c66800122db584a8af04`
- Matching unsigned payload SHA-256: `eca7b04fcad0d9102eae75dc3cb74974c096cc394df65a1bab9a68343ccecfeb`
- Generated aggregate schema SHA-256: `e554a74bd59d38d16acb1744750b2999156ee3d65d0fe906b22ab52edf17fbbc`
- Callback profile SHA-256: `64a98c3328d1eba74aaf18a3995523e07fd2f1395bc6fb4a121b74338c404a29`

## Failure and repair evidence

The baseline ignored live probe failed with `SchemaMissing` for the three current schema markers. The adapted probe passes against the installed image without dispatch. The first full PostgreSQL acceptance run then exposed a stale migration-history assertion of 31 after V32 was added. The assertion was corrected to 32, and the complete suite passed on rerun.

## Verification

- `cargo make fmt-rust-check`
- `cargo test --locked -p decodex-codex` (55 tests plus doc test)
- `cargo test --locked -p decodex-postgres --lib` (70 tests)
- `cargo test --locked -p decodex-runtime account_launch::process::tests` (84 passed, one ignored)
- `cargo test --locked -p decodex-runtime account_launch::process::tests::live_read_only_probe_negotiates_without_dispatch -- --ignored --exact --nocapture` (passed in 34.64s)
- `cargo make test-vnext-architecture` (24 tests)
- `cargo make test-vnext-postgres-store` (all stages passed in 416.49s)
- `cargo make check-rust-headless`
- `git diff --check`

The full GUI-inclusive `cargo make check-rust` reached `gpui_macos` and stopped because this host has no Apple Metal compiler (`xcrun: unable to find utility metal`). The repository headless gate passes; GitHub CI provides the remaining independent build checks.

X API spend: $0.00.

Upstream-Codex-Head: 5157493c23713ac12034cf250ffb0a8ce0670277