### PR TITLE
Activate the exact-five automation portfolio

### DIFF
--- a/automations/decodex/scripts/config/tests/test_portfolio.py
+++ b/automations/decodex/scripts/config/tests/test_portfolio.py
@@ -37,13 +37,21 @@ class PortfolioTests(unittest.TestCase):
             self.assertNotIn(".worktrees", item["cwds"][0])
             self.assertNotIn("xhigh", json.dumps(item).casefold())
 
-    def test_paused_status_and_allowed_promotion_contract(self) -> None:
+    def test_status_and_allowed_promotion_contract(self) -> None:
         manifest = portfolio.load_manifest()
-        self.assertEqual(manifest["status"], "PAUSED")
-        self.assertEqual({item["status"] for item in portfolio.rendered_automations(manifest)}, {"PAUSED"})
-        active_manifest = {**manifest, "status": "ACTIVE"}
-        self.assertEqual(portfolio.validate_manifest(active_manifest), [])
-        active_rendered = portfolio.rendered_automations(active_manifest)
+        self.assertIn(manifest["status"], {"ACTIVE", "PAUSED"})
+        self.assertEqual(
+            {item["status"] for item in portfolio.rendered_automations(manifest)},
+            {manifest["status"]},
+        )
+        for status in ("PAUSED", "ACTIVE"):
+            candidate_manifest = {**manifest, "status": status}
+            self.assertEqual(portfolio.validate_manifest(candidate_manifest), [])
+            self.assertEqual(
+                {item["status"] for item in portfolio.rendered_automations(candidate_manifest)},
+                {status},
+            )
+        active_rendered = portfolio.rendered_automations({**manifest, "status": "ACTIVE"})
         self.assertEqual({item["status"] for item in active_rendered}, {"ACTIVE"})
         all_prompts = " ".join(" ".join(item["prompt"].split()) for item in active_rendered).casefold()
         for stale_claim in (
@@ -248,7 +256,7 @@ class PortfolioTests(unittest.TestCase):
             errors = next(item["errors"] for item in report["results"] if item["id"] == "codex-upstream-maintainer")
             self.assertIn("native created_at metadata is missing", errors)
 
-    def test_runtime_status_must_match_the_paused_manifest(self) -> None:
+    def test_runtime_status_must_match_the_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             codex_home = Path(directory)
             for item in portfolio.rendered_automations():
@@ -256,7 +264,7 @@ class PortfolioTests(unittest.TestCase):
                 path.parent.mkdir(parents=True)
                 values = {**item, "created_at": 1, "updated_at": 2}
                 if item["id"] == "codex-upstream-health":
-                    values["status"] = "ACTIVE"
+                    values["status"] = "PAUSED" if item["status"] == "ACTIVE" else "ACTIVE"
                 path.write_text(
                     "\n".join(f"{key} = {json.dumps(value)}" for key, value in values.items()) + "\n",
                     encoding="utf-8",

--- a/automations/portfolio.toml
+++ b/automations/portfolio.toml
@@ -1,7 +1,7 @@
 execution_environment = "local"
 kind                  = "cron"
 primary_cwd           = "{primary_worktree}"
-status                = "PAUSED"
+status                = "ACTIVE"
 version               = 1
 
 [[automations]]


### PR DESCRIPTION
## Summary

- Promote the checked-in exact-five portfolio from `PAUSED` to `ACTIVE` after live acceptance.
- Make the portfolio tests state-independent: both `PAUSED` and `ACTIVE` remain valid manifest states, rendered status must equal the manifest, and a deliberately opposite native status must fail.
- Keep the portfolio at exactly five local primary-worktree automations with the declared Sol/max, Terra/high, and Luna/high assignments.

## Live acceptance evidence

- Current Codex app-server adaptation landed through reviewed PR #1241 as signed merge `518bf7a4d271002f6821cc0ba7448b69f787ba62`.
- The adaptation demonstrated a real failing live probe, an implementation repair, a stale V32 assertion failure, and a passing complete PostgreSQL rerun.
- Native task archive succeeded for completed task `019fc439-f31e-7961-a3cb-1f5e463beaec`.
- PAUSED runtime definitions were repaired and the live exact-five evaluator passed with no extra managed IDs.
- A real xurl publication completed with exact account/text readback: https://x.com/decodexspace/status/2084044522401796177
- X calls: identity read 1, create 1, post read 1. Cost ceiling: $0.030. August remaining ceiling: $1.220.
- Publisher unit tests: 81 passed. Publisher Clippy passed.

## Verification

- `python3 automations/decodex/scripts/config/evaluate_automations.py --repo-only --json`
- `cargo make test-automations` (8 passed)
- `cargo make check-automations`
  - dependency and npm integrity/audit passed
  - site build and Astro checks passed
  - Rust check, format, Taplo, and strict Clippy passed
  - 63 script tests passed
  - 805 Rust tests passed
  - 24 architecture tests passed
  - full PostgreSQL aggregate and restore checks passed
- `git diff --check`

Native definitions remain PAUSED until this PR is independently reviewed, formally landed, and read back from `main`.