### PR TITLE
Use Luna max for non-Sol automations

### DIFF
--- a/automations/decodex/prompts/content-manager.md
+++ b/automations/decodex/prompts/content-manager.md
@@ -6,7 +6,7 @@ Role:
 
 Authority:
 - Run from the clean primary `main` checkout. A scheduled cwd is never a worktree.
-- Use model `gpt-5.6-terra` with reasoning effort `high`.
+- Use model `gpt-5.6-luna` with reasoning effort `max`.
 - Do not call X, xurl, a browser controller, X MCP, or a direct X API.
 - Do not use Decodex server, runtime, queue, planner, or MCP.
 - The Rust Publisher `record-candidate` command is the only content evidence writer.

--- a/automations/decodex/prompts/xurl-publisher.md
+++ b/automations/decodex/prompts/xurl-publisher.md
@@ -5,7 +5,7 @@ Role:
 
 Authority:
 - Run from the clean primary `main` checkout. A scheduled cwd is never a worktree.
-- Use model `gpt-5.6-luna` with reasoning effort `high`.
+- Use model `gpt-5.6-luna` with reasoning effort `max`.
 - The Rust Publisher is the only component that may invoke xurl. Never use browser control, X MCP, or a
   direct X API.
 - Target only `@decodexspace`. Keep one post per day, no URL, a `$1.25` monthly cap, and a `$0.030`

--- a/automations/decodex/scripts/config/automation_model_policy.py
+++ b/automations/decodex/scripts/config/automation_model_policy.py
@@ -6,18 +6,18 @@ from __future__ import annotations
 MODEL_BY_AUTOMATION_ID = {
     "codex-upstream-maintainer": "gpt-5.6-sol",
     "codex-upstream-reviewer": "gpt-5.6-sol",
-    "codex-upstream-health": "gpt-5.6-terra",
-    "decodex-content-manager": "gpt-5.6-terra",
+    "codex-upstream-health": "gpt-5.6-luna",
+    "decodex-content-manager": "gpt-5.6-luna",
     "decodex-xurl-publisher": "gpt-5.6-luna",
 }
 
-DEFAULT_REASONING_EFFORT = "high"
+DEFAULT_REASONING_EFFORT = "max"
 REASONING_EFFORT_BY_AUTOMATION_ID = {
     "codex-upstream-maintainer": "max",
     "codex-upstream-reviewer": "max",
-    "codex-upstream-health": "high",
-    "decodex-content-manager": "high",
-    "decodex-xurl-publisher": "high",
+    "codex-upstream-health": "max",
+    "decodex-content-manager": "max",
+    "decodex-xurl-publisher": "max",
 }
 
 

--- a/automations/decodex/scripts/config/tests/test_portfolio.py
+++ b/automations/decodex/scripts/config/tests/test_portfolio.py
@@ -26,13 +26,24 @@ class PortfolioTests(unittest.TestCase):
             {
                 "codex-upstream-maintainer": ("gpt-5.6-sol", "max"),
                 "codex-upstream-reviewer": ("gpt-5.6-sol", "max"),
-                "codex-upstream-health": ("gpt-5.6-terra", "high"),
-                "decodex-content-manager": ("gpt-5.6-terra", "high"),
-                "decodex-xurl-publisher": ("gpt-5.6-luna", "high"),
+                "codex-upstream-health": ("gpt-5.6-luna", "max"),
+                "decodex-content-manager": ("gpt-5.6-luna", "max"),
+                "decodex-xurl-publisher": ("gpt-5.6-luna", "max"),
             },
         )
         expected_cwd = str(portfolio.primary_worktree())
         for item in rendered:
+            if item["model"] == "gpt-5.6-sol":
+                self.assertIn(
+                    item["id"],
+                    {"codex-upstream-maintainer", "codex-upstream-reviewer"},
+                )
+                self.assertEqual(item["reasoning_effort"], "max")
+            else:
+                self.assertEqual(
+                    (item["model"], item["reasoning_effort"]),
+                    ("gpt-5.6-luna", "max"),
+                )
             self.assertEqual(item["cwds"], [expected_cwd])
             self.assertNotIn(".worktrees", item["cwds"][0])
             self.assertNotIn("xhigh", json.dumps(item).casefold())

--- a/automations/portfolio.toml
+++ b/automations/portfolio.toml
@@ -22,18 +22,18 @@ rrule            = "FREQ=HOURLY;INTERVAL=12;BYMINUTE=35;BYSECOND=0"
 
 [[automations]]
 id               = "codex-upstream-health"
-model            = "gpt-5.6-terra"
+model            = "gpt-5.6-luna"
 name             = "Decodex Automation Manager"
 prompt_file      = "automations/upstream/prompts/health.md"
-reasoning_effort = "high"
+reasoning_effort = "max"
 rrule            = "FREQ=DAILY;BYHOUR=6,18;BYMINUTE=0;BYSECOND=0"
 
 [[automations]]
 id               = "decodex-content-manager"
-model            = "gpt-5.6-terra"
+model            = "gpt-5.6-luna"
 name             = "Decodex Content Manager"
 prompt_file      = "automations/decodex/prompts/content-manager.md"
-reasoning_effort = "high"
+reasoning_effort = "max"
 rrule            = "FREQ=DAILY;BYHOUR=9;BYMINUTE=50;BYSECOND=0"
 
 [[automations]]
@@ -41,5 +41,5 @@ id               = "decodex-xurl-publisher"
 model            = "gpt-5.6-luna"
 name             = "Decodex Xurl Publisher"
 prompt_file      = "automations/decodex/prompts/xurl-publisher.md"
-reasoning_effort = "high"
+reasoning_effort = "max"
 rrule            = "FREQ=DAILY;BYHOUR=10,16,22;BYMINUTE=20;BYSECOND=0"

--- a/automations/upstream/README.md
+++ b/automations/upstream/README.md
@@ -7,13 +7,18 @@ automation portfolio. It declares exactly five native Codex tasks:
 | --- | --- | --- | --- | --- |
 | `codex-upstream-maintainer` | Research and implement Codex compatibility work | `gpt-5.6-sol` | `max` | Every 6 hours |
 | `codex-upstream-reviewer` | Independently review, test, and land upstream PRs | `gpt-5.6-sol` | `max` | Every 12 hours |
-| `codex-upstream-health` | Manage portfolio quality and repair drift | `gpt-5.6-terra` | `high` | Twice daily |
-| `decodex-content-manager` | Research and record one content decision | `gpt-5.6-terra` | `high` | Daily |
-| `decodex-xurl-publisher` | Publish or observe through the X safety boundary | `gpt-5.6-luna` | `high` | Three times daily |
+| `codex-upstream-health` | Manage portfolio quality and repair drift | `gpt-5.6-luna` | `max` | Twice daily |
+| `decodex-content-manager` | Research and record one content decision | `gpt-5.6-luna` | `max` | Daily |
+| `decodex-xurl-publisher` | Publish or observe through the X safety boundary | `gpt-5.6-luna` | `max` | Three times daily |
 
 No managed task uses `xhigh`. Every native definition has local execution and
 uses `/Users/x/code/y/hack-ink/decodex` as its scheduled cwd. A scheduled task
 must never use a task worktree as its cwd.
+
+The two Sol roles are difficult protocol and code tasks, so both use `max`.
+Future Sol assignments use `medium` for routine work and `max` only for difficult
+implementation, protocol, or independent review work. Every non-Sol role uses
+Luna with `max`.
 
 ## Operating Model
 

--- a/automations/upstream/prompts/health.md
+++ b/automations/upstream/prompts/health.md
@@ -6,7 +6,7 @@ Role:
 
 Authority:
 - Run from the clean primary `main` checkout. A scheduled cwd is never a worktree.
-- Use model `gpt-5.6-terra` with reasoning effort `high` for management and evaluation.
+- Use model `gpt-5.6-luna` with reasoning effort `max` for management and evaluation.
 - Use native automation and task tools for runtime definitions and task archiving. Never write native
   scheduler TOML.
 - Do not use Decodex server, runtime, queue, planner, or MCP. Repository changes use one ephemeral

--- a/openwiki/operations/codex-upstream-autopilot.md
+++ b/openwiki/operations/codex-upstream-autopilot.md
@@ -13,7 +13,7 @@ upstream loop has three roles:
 | --- | --- | --- | --- |
 | Maintainer | `gpt-5.6-sol` | `max` | Every 6 hours |
 | Reviewer | `gpt-5.6-sol` | `max` | Every 12 hours |
-| Manager | `gpt-5.6-terra` | `high` | Twice daily |
+| Manager | `gpt-5.6-luna` | `max` | Twice daily |
 
 ## Activation State
 

--- a/openwiki/operations/decodex-content-automation.md
+++ b/openwiki/operations/decodex-content-automation.md
@@ -9,8 +9,8 @@ measurement loop for `@decodexspace`.
 
 | Role | Model | Effort | Frequency |
 | --- | --- | --- | --- |
-| Content Manager | `gpt-5.6-terra` | `high` | Daily at 09:50 |
-| Xurl Publisher | `gpt-5.6-luna` | `high` | Daily at 10:20, 16:20, and 22:20 |
+| Content Manager | `gpt-5.6-luna` | `max` | Daily at 09:50 |
+| Xurl Publisher | `gpt-5.6-luna` | `max` | Daily at 10:20, 16:20, and 22:20 |
 
 Both use the clean primary checkout as scheduled cwd. They do not use Decodex
 server, runtime, queue, planner, or MCP.


### PR DESCRIPTION
## Summary

- use `gpt-5.6-luna` with `max` reasoning for every non-Sol automation
- keep difficult protocol implementation and independent review on `gpt-5.6-sol` with `max` reasoning
- codify the Sol difficulty rule: routine Sol work uses `medium`; difficult work uses `max`
- align prompts, tests, and OpenWiki operations documentation

## Validation

- `cargo make check-automations`
- `cargo make test-automations`
- `python3 -m unittest automations.decodex.scripts.config.tests.test_portfolio`
- `python3 automations/decodex/scripts/config/evaluate_automations.py --repo-only --json`
- `python3 automations/decodex/scripts/config/render_automation_plan.py --json`
- `git diff --check`

Validated exact head: `c1eb4704a973a61f37ad3394e6eb6008e5bda16e`
Validated exact base: `c34ad5063e2ec68a6186c0a0c12713b6a5b56121`