### PR TITLE
Show exact Reset Card expiry details

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -125,7 +125,6 @@ enum ResetCardInventoryPresentation: Equatable {
 	case updating(detail: String?)
 	case connecting(detail: String)
 	case unavailable(detail: String)
-	case reportedCount(UInt64)
 	case empty
 	case available
 
@@ -171,11 +170,7 @@ enum ResetCardInventoryPresentation: Equatable {
 			return
 		}
 		guard inventory.detailsComplete else {
-			if let count = inventory.reportedAvailableCount {
-				self = .reportedCount(count)
-			} else {
-				self = .checking
-			}
+			self = .checking
 			return
 		}
 		self = state.targets.isEmpty ? .empty : .available
@@ -551,20 +546,6 @@ struct ResetCardAccountRow: View {
 				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
 				.lineLimit(1)
 				.help(detail)
-		case .reportedCount(let count):
-			Text(
-				count == 0
-					? "No Reset Cards"
-					: "\(count) Reset \(count == 1 ? "Card" : "Cards")"
-			)
-			.font(PanelFont.tertiary)
-			.foregroundStyle(PanelPalette.secondaryText(colorScheme))
-			.lineLimit(1)
-			.help(
-				count == 0
-					? "The provider reported no available Reset Cards."
-					: "The provider reported the count without expiration details."
-			)
 		case .empty:
 			Text("No Reset Cards")
 				.font(PanelFont.tertiary)

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -406,6 +406,49 @@ final class AccountPanelPresentationTests: XCTestCase {
 		XCTAssertFalse(source.contains("Reconnecting…"))
 	}
 
+	func testIncompletePositiveResetCardInventoryKeepsCheckingForExpiryDetails() {
+		let authority = ResetCardAuthority(
+			profileName: "local",
+			serverID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+		)
+		let account = ResetCardAccountRecord(
+			authority: authority,
+			accountID: "11111111-1111-4111-8111-111111111111",
+			alias: "Blake",
+			accountRevision: 2,
+			enabled: true,
+			observedState: .available,
+			lifecycleReadiness: .ready,
+			fiveHourQuota: .unknown(durationMinutes: 300),
+			sevenDayQuota: .unknown(durationMinutes: 10_080)
+		)
+		let inventory = ResetCardInventory(
+			authority: authority,
+			accountID: account.accountID,
+			accountRevision: account.accountRevision,
+			reportedAvailableCount: 1,
+			detailsComplete: false,
+			cards: [],
+			fiveHourQuota: .unknown(durationMinutes: 300),
+			sevenDayQuota: .unknown(durationMinutes: 10_080),
+			observationError: nil
+		)
+		let state = ResetCardAccountState(
+			account: account,
+			inventory: inventory,
+			error: nil,
+			isRefreshing: false
+		)
+
+		XCTAssertEqual(
+			ResetCardInventoryPresentation(
+				state: state,
+				isAwaitingFreshAccountSkeleton: false
+			),
+			.checking
+		)
+	}
+
 	func testQuotaRowsPutTheFlexibleBarBeforeTheCompactPercentage() throws {
 		let source = try resetCardSectionSource()
 

--- a/crates/decodex-runtime/src/account_launch/process.rs
+++ b/crates/decodex-runtime/src/account_launch/process.rs
@@ -856,7 +856,7 @@ impl AttestedProcessChild {
 		Ok(())
 	}
 
-	/// Read one complete inventory and re-attest the immutable account before returning it.
+	/// Read one bounded inventory and re-attest the immutable account before returning it.
 	pub(super) fn read_reset_card_inventory(
 		&mut self,
 	) -> Result<ResetCardInventory, ResetCardProcessError> {
@@ -1981,7 +1981,7 @@ impl ResetCardProcessRunner {
 		self.binding.account_id()
 	}
 
-	/// Read one complete strict inventory under an already-reserved runner permit.
+	/// Read one bounded strict inventory under an already-reserved runner permit.
 	pub(super) fn read_inventory(
 		self,
 		vault: &dyn CredentialVault,
@@ -1999,7 +1999,7 @@ impl ResetCardProcessRunner {
 	}
 
 	/// Consume one already-persisted exact credit with its already-persisted key, then read a fresh
-	/// complete inventory before re-attesting the immutable account binding.
+	/// bounded inventory before re-attesting the immutable account binding.
 	pub(super) fn consume_and_readback(
 		self,
 		vault: &dyn CredentialVault,
@@ -2141,6 +2141,19 @@ impl ResetCardProcessError {
 }
 
 fn read_reset_card_inventory(
+	process: &mut SupervisedProcess,
+	timeout: Duration,
+) -> Result<ResetCardInventory, ResetCardProcessError> {
+	let inventory = request_reset_card_inventory(process, timeout)?;
+	if !inventory.details_complete()
+		&& inventory.reported_available_count().is_some_and(|count| count > 0)
+	{
+		return request_reset_card_inventory(process, timeout);
+	}
+	Ok(inventory)
+}
+
+fn request_reset_card_inventory(
 	process: &mut SupervisedProcess,
 	timeout: Duration,
 ) -> Result<ResetCardInventory, ResetCardProcessError> {
@@ -5004,7 +5017,7 @@ mod tests {
 		if mode == "preflight-uncertain-schema" {
 			schema_args.push("--preflight-hang".into());
 		}
-		if matches!(mode, "reset-card" | "callback-probe") {
+		if matches!(mode, "reset-card" | "reset-card-partial-first" | "callback-probe") {
 			schema_args.push("--reset-card".into());
 		}
 
@@ -5296,6 +5309,25 @@ mod tests {
 
 		assert_eq!(readback.outcome, ResetCardConsumeOutcome::Reset);
 		assert_eq!(readback.inventory.available_count(), 0);
+		assert_eq!(capacity.active(), 0);
+	}
+
+	#[test]
+	fn reset_card_runner_retries_an_incomplete_positive_inventory() {
+		let temp = TempDir::new().unwrap();
+		let capacity = TestCapacity::new(1);
+		let runner = ResetCardProcessRunner::new(
+			fake_command("reset-card-partial-first", temp.path(), None),
+			binding(),
+			Duration::from_secs(2),
+		);
+
+		let inventory =
+			runner.read_inventory(&FixtureVault::matching(), capacity.reserve().unwrap()).unwrap();
+
+		assert!(inventory.details_complete());
+		assert_eq!(inventory.reported_available_count(), Some(1));
+		assert_eq!(inventory.available_count(), 1);
 		assert_eq!(capacity.active(), 0);
 	}
 

--- a/crates/decodex-runtime/src/account_launch/reset_card.rs
+++ b/crates/decodex-runtime/src/account_launch/reset_card.rs
@@ -54,12 +54,12 @@ use super::{
 };
 
 const PROCESS_TIMEOUT: Duration = Duration::from_secs(30);
-// The longest consume path reserves seven sequential process deadlines, including conservative
-// startup headroom plus initialize, credential projection, initial account read, consume,
-// inventory readback, and account re-attestation. Process-group and stdout-pump shutdown add 1.25
-// seconds, rounded up to two seconds for this lease proof.
+// The longest consume path reserves eight sequential process deadlines, including conservative
+// startup headroom plus initialize, credential projection, initial account read, consume, one
+// incomplete-detail inventory retry, and account re-attestation. Process-group and stdout-pump
+// shutdown add 1.25 seconds, rounded up to two seconds for this lease proof.
 const MAX_BLOCKING_PROCESS_DEADLINE: Duration =
-	Duration::from_secs(PROCESS_TIMEOUT.as_secs() * 7 + 2);
+	Duration::from_secs(PROCESS_TIMEOUT.as_secs() * 8 + 2);
 // A query receives a typed row-scoped refusal before the protocol client's whole-request
 // deadline. The daemon-owned operation continues its already-bounded cleanup.
 const INVENTORY_RESPONSE_TIMEOUT: Duration = Duration::from_secs(25);
@@ -1704,8 +1704,8 @@ mod tests {
 
 	#[test]
 	fn queued_and_detached_process_deadlines_are_strictly_inside_the_initial_lease() {
-		assert_eq!(MAX_BLOCKING_PROCESS_DEADLINE, Duration::from_secs(212));
-		assert_eq!(MAX_CLAIM_WORK_START_DELAY, Duration::from_secs(117));
+		assert_eq!(MAX_BLOCKING_PROCESS_DEADLINE, Duration::from_secs(242));
+		assert_eq!(MAX_CLAIM_WORK_START_DELAY, Duration::from_secs(87));
 		assert!(
 			MAX_CLAIM_WORK_START_DELAY + MAX_BLOCKING_PROCESS_DEADLINE + CLAIM_HEARTBEAT_INTERVAL
 				< CLAIM_LEASE

--- a/crates/decodex-runtime/tests/fixtures/fake_app_server.py
+++ b/crates/decodex-runtime/tests/fixtures/fake_app_server.py
@@ -237,6 +237,7 @@ exact_thread = {
 }
 exact_thread_reads = 0
 reset_card_consumed = False
+rate_limit_reads = 0
 for line in sys.stdin:
     message = json.loads(line)
     assert "jsonrpc" not in message
@@ -348,7 +349,12 @@ for line in sys.stdin:
             if mode == "login-missing-type"
             else {"type": "chatgptAuthTokens"}
         )
-    elif method == "account/rateLimits/read" and mode in ("reset-card", "callback-probe"):
+    elif method == "account/rateLimits/read" and mode in (
+        "reset-card",
+        "reset-card-partial-first",
+        "callback-probe",
+    ):
+        rate_limit_reads += 1
         assert "params" in message
         assert message["params"] is None
         if mode == "callback-probe":
@@ -366,7 +372,11 @@ for line in sys.stdin:
             "rateLimits": {},
             "rateLimitResetCredits": {
                 "availableCount": len(credits),
-                "credits": credits,
+                "credits": (
+                    None
+                    if mode == "reset-card-partial-first" and rate_limit_reads == 1
+                    else credits
+                ),
             },
         }
     elif method == "account/rateLimitResetCredit/consume" and mode == "reset-card":


### PR DESCRIPTION
Fix intermittent count-only Reset Card inventory responses. Retry one incomplete positive provider read in the same attested process, and keep the native UI in Checking state until expiry details are complete.\n\nValidation: DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check; Swift release tests; signed app staging; local service installer tests.