### PR TITLE
Stabilize the Codex live attestation proof

### DIFF
--- a/crates/decodex-runtime/src/account_launch/process.rs
+++ b/crates/decodex-runtime/src/account_launch/process.rs
@@ -1835,6 +1835,8 @@ pub(super) struct ReadOnlyProbe {
 	schema_marker: SchemaMarker,
 	enforce_generated_digests: bool,
 	timeout: Duration,
+	#[cfg(test)]
+	attestation_timeout_override: Option<Duration>,
 }
 impl ReadOnlyProbe {
 	/// Configure a probe. Schema validation is deferred to `run` but precedes spawn.
@@ -1845,6 +1847,8 @@ impl ReadOnlyProbe {
 			schema_marker: SchemaMarker::accepted(),
 			enforce_generated_digests: true,
 			timeout,
+			#[cfg(test)]
+			attestation_timeout_override: None,
 		}
 	}
 
@@ -1862,7 +1866,21 @@ impl ReadOnlyProbe {
 		schema_marker: SchemaMarker,
 		timeout: Duration,
 	) -> Self {
-		Self { command, binding, schema_marker, enforce_generated_digests: false, timeout }
+		Self {
+			command,
+			binding,
+			schema_marker,
+			enforce_generated_digests: false,
+			timeout,
+			attestation_timeout_override: None,
+		}
+	}
+
+	#[cfg(test)]
+	fn with_attestation_timeout_for_test(mut self, timeout: Duration) -> Self {
+		self.attestation_timeout_override = Some(timeout);
+
+		self
 	}
 
 	/// Construct a synthetic probe using checked-in schema and process fixtures.
@@ -1875,6 +1893,7 @@ impl ReadOnlyProbe {
 			schema_marker: SchemaMarker::accepted(),
 			enforce_generated_digests: false,
 			timeout,
+			attestation_timeout_override: None,
 		}
 	}
 
@@ -1924,8 +1943,17 @@ impl ReadOnlyProbe {
 
 		let expected_digests =
 			self.enforce_generated_digests.then_some(self.schema_marker.canonical_digests());
-		let (build, generated, guard) =
-			attest_executable(&self.command, &self.binding, expected_digests, self.timeout, guard)?;
+		#[cfg(test)]
+		let attestation_timeout = self.attestation_timeout_override.unwrap_or(self.timeout);
+		#[cfg(not(test))]
+		let attestation_timeout = self.timeout;
+		let (build, generated, guard) = attest_executable(
+			&self.command,
+			&self.binding,
+			expected_digests,
+			attestation_timeout,
+			guard,
+		)?;
 		let mut negotiation = ProbeNegotiation::new(cache, &build, &generated);
 		let account_id = self.binding.account_id.clone();
 		let guard = guard.ok_or(SupervisionError::SpawnFailed)?;
@@ -6821,6 +6849,9 @@ mod tests {
 			.unwrap(),
 			Duration::from_secs(10),
 		)
+		// The debug test profile repeatedly hashes the large canonical executable and its
+		// snapshot. Extend only attestation; keep each live protocol operation at ten seconds.
+		.with_attestation_timeout_for_test(Duration::from_secs(60))
 		.run(&mut CapabilityCache::default())
 		.unwrap();
 


### PR DESCRIPTION
## Decision

The official Codex change at `bb5054fe47abe73ecbbd454751066a28c89f4bb9` is protocol-compatible with the exact installed and receipt-bound `codex-cli 0.146.0-alpha.9.2` image. It adds provider-only rollout budget units and excludes them from protocol serialization, JSON Schema, and TypeScript export. Official mirror blob identity confirms that the experimental app-server export, `ClientRequest`, `ServerNotification`, aggregate v2 schema, and config schema are unchanged from baseline `5157493c23713ac12034cf250ffb0a8ce0670277` to this target. The removed-feature registries are also unchanged.

This PR repairs the installed-Codex evidence gate. In an unoptimized Rust test build, repeated SHA-256 verification of the 258 MiB canonical executable and its immutable snapshot can consume the shared 10-second live-proof timeout before schema preflight starts. The change adds a `cfg(test)`-only 60-second attestation budget. Production attestation and every live RPC remain bounded by the existing 10-second timeout. Digest, schema, protocol, and read-only checks are unchanged.

The branch is refreshed onto current `main` at `e327373cfb5b06b3cd6344209e34d55b35c09854` after dependency PR #1257 landed. The unrelated OpenWiki commit identified by Reviewer was removed. The PR now changes only `crates/decodex-runtime/src/account_launch/process.rs`.

## Dependency state

Dependency PR #1257 repaired the current-main gate and landed as `0f5ba65761d3754201747d299b27286d19b18873`. This branch was refreshed after that landing; no unresolved dependency remains.

## Official evidence

- Reviewed upstream commit: https://github.com/openai/codex/commit/bb5054fe47abe73ecbbd454751066a28c89f4bb9
- Reviewed range: https://github.com/openai/codex/compare/5157493c23713ac12034cf250ffb0a8ce0670277...bb5054fe47abe73ecbbd454751066a28c89f4bb9
- Experimental app-server schema export: https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/app-server-protocol/schema/precomputed/app-server-exports-experimental.json.zst
- Config schema: https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/core/config.schema.json
- Removed-feature evidence: https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/features/src/legacy.rs
- Feature registry evidence: https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/features/src/feature_configs.rs
- Accepted exact build: https://github.com/openai/codex/releases/tag/rust-v0.146.0-alpha.9.2

## Validation

- Base `main`: `e327373cfb5b06b3cd6344209e34d55b35c09854`
- Signed PR head: `e765458b26ab38c6c2ba0ad56affb2b645d8fca6`
- `git verify-commit HEAD`: good signature
- `cargo test --locked -p decodex-runtime account_launch::process::tests`: 86 passed, 1 ignored
- Exact ignored installed-Codex live probe: 1 passed in 34.95 seconds
- `git diff --check`: passed
- Full `cargo make check-automations` on current `main`: passed
- X API spend: $0.00
Upstream-Codex-Head: bb5054fe47abe73ecbbd454751066a28c89f4bb9

Decodex-Autonomy: upstream-compatibility
Decodex-Dependencies: none