### PR TITLE
Retry Reset Card reads with missing details

### DIFF
--- a/crates/decodex-runtime/src/account_launch/process.rs
+++ b/crates/decodex-runtime/src/account_launch/process.rs
@@ -2145,9 +2145,7 @@ fn read_reset_card_inventory(
 	timeout: Duration,
 ) -> Result<ResetCardInventory, ResetCardProcessError> {
 	let inventory = request_reset_card_inventory(process, timeout)?;
-	if !inventory.details_complete()
-		&& inventory.reported_available_count().is_some_and(|count| count > 0)
-	{
+	if !inventory.details_complete() {
 		return request_reset_card_inventory(process, timeout);
 	}
 	Ok(inventory)
@@ -5017,7 +5015,13 @@ mod tests {
 		if mode == "preflight-uncertain-schema" {
 			schema_args.push("--preflight-hang".into());
 		}
-		if matches!(mode, "reset-card" | "reset-card-partial-first" | "callback-probe") {
+		if matches!(
+			mode,
+			"reset-card"
+				| "reset-card-partial-first"
+				| "reset-card-missing-first"
+				| "callback-probe"
+		) {
 			schema_args.push("--reset-card".into());
 		}
 
@@ -5318,6 +5322,25 @@ mod tests {
 		let capacity = TestCapacity::new(1);
 		let runner = ResetCardProcessRunner::new(
 			fake_command("reset-card-partial-first", temp.path(), None),
+			binding(),
+			Duration::from_secs(2),
+		);
+
+		let inventory =
+			runner.read_inventory(&FixtureVault::matching(), capacity.reserve().unwrap()).unwrap();
+
+		assert!(inventory.details_complete());
+		assert_eq!(inventory.reported_available_count(), Some(1));
+		assert_eq!(inventory.available_count(), 1);
+		assert_eq!(capacity.active(), 0);
+	}
+
+	#[test]
+	fn reset_card_runner_retries_an_inventory_with_missing_count_and_details() {
+		let temp = TempDir::new().unwrap();
+		let capacity = TestCapacity::new(1);
+		let runner = ResetCardProcessRunner::new(
+			fake_command("reset-card-missing-first", temp.path(), None),
 			binding(),
 			Duration::from_secs(2),
 		);

--- a/crates/decodex-runtime/tests/fixtures/fake_app_server.py
+++ b/crates/decodex-runtime/tests/fixtures/fake_app_server.py
@@ -352,6 +352,7 @@ for line in sys.stdin:
     elif method == "account/rateLimits/read" and mode in (
         "reset-card",
         "reset-card-partial-first",
+        "reset-card-missing-first",
         "callback-probe",
     ):
         rate_limit_reads += 1
@@ -370,14 +371,18 @@ for line in sys.stdin:
         }]
         result = {
             "rateLimits": {},
-            "rateLimitResetCredits": {
-                "availableCount": len(credits),
-                "credits": (
-                    None
-                    if mode == "reset-card-partial-first" and rate_limit_reads == 1
-                    else credits
-                ),
-            },
+            "rateLimitResetCredits": (
+                None
+                if mode == "reset-card-missing-first" and rate_limit_reads == 1
+                else {
+                    "availableCount": len(credits),
+                    "credits": (
+                        None
+                        if mode == "reset-card-partial-first" and rate_limit_reads == 1
+                        else credits
+                    ),
+                }
+            ),
         }
     elif method == "account/rateLimitResetCredit/consume" and mode == "reset-card":
         assert message["params"] == {


### PR DESCRIPTION
## Summary

- retry one incomplete Reset Card inventory read in the same daemon operation
- cover responses where both the reported count and card details are missing
- keep the retry bounded and read-only

## Validation

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check`
- 881/881 nextest tests passed