### PR TITLE
Move account observation into the daemon

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -23,9 +23,10 @@ provider-private Reset Card identifiers.
 
 The primary panel reads the complete account skeleton, uses the returned
 routing UUID order, and immediately renders every account. It then runs
-independent Reset Card and account-profile requests for each row. A slow or
-failed provider request affects only its account row and does not block another
-row or account action.
+independent Reset Card and account-profile value reads for every row. These
+reads use only daemon-owned observations and all rows start concurrently. They
+do not start provider work. A cold or failed observation affects only its
+account row and does not block another row or account action.
 
 Each row shows the exact current 300-minute and 10,080-minute quota
 observations in a vertical stack, the percentage left and reset time when
@@ -36,10 +37,16 @@ inside the panel theme: accent blue above 50% remaining, warning amber from 21%
 to 50%, and destructive red at 20% or below. The numeric percentage and
 accessibility value remain the primary status.
 
-The app performs one non-overlapping refresh every 15 seconds, matching the
-pre-cutover native cadence. Opening the panel also requests one refresh. An
-already active refresh absorbs either trigger, and one failed account remains
-isolated to its row until the next cycle.
+The app reloads daemon values every 15 seconds. Opening the panel also requests
+one reload. An active reload absorbs either trigger. Independently, the daemon
+starts one observation round immediately, repeats it every 15 seconds, and
+wakes it after account and Reset Card changes. It starts every independent
+account concurrently, keeps at most one active observation per account, and
+coalesces a lifecycle or effect wake for that account as its next round. A
+periodic tick does not hot-loop an already slow account. Within one account,
+Reset Card observation settles before profile observation so a credential
+rotation cannot race the profile read. A slow account does not delay
+publication or later scheduling for another account.
 
 The account plan appears beside the account identity. Each detail popover
 contains only lifetime tokens, peak daily tokens, longest task, current and
@@ -92,10 +99,10 @@ one newer skeleton read so the account row does not remain in its checking
 state. The app keeps the last quota visible while it waits for the new account
 revision, but it does not expose Reset Cards from that old revision. It retains
 an advanced inventory until the matching account skeleton arrives, then applies
-that inventory without a duplicate provider read. This direct old-to-new update
+that inventory without a duplicate daemon read. This direct old-to-new update
 lets the quota bar animate to the restored value. All callers share one
 per-account inventory coordinator: same-revision reads coalesce, a use gate
-waits for an older provider read, and fresh reads wait until the use dispatch
+waits for an older daemon read, and fresh reads wait until the use dispatch
 ends. A terminal use result ends the button activity immediately and starts
 bounded background reconciliation. Internal contention, provider
 cleanup, and other retryable detail failures keep the last quota visible under
@@ -115,7 +122,9 @@ currently signed-in shared Codex login, enable or disable, log out, and select
 fixed or balanced routing. An account with a provider-confirmed unauthorized
 profile shows `Refresh login`; that action presents the official device code
 with fixed-size Copy, Open, and Cancel icon controls, then refreshes only that
-account after the daemon completes the exact credential replacement. Each
+account after the daemon completes the exact credential replacement. The app
+then performs bounded short-interval daemon readback until the new background
+observation replaces any old unauthorized value. Each
 account row has one `Route` control. It first projects that exact daemon-owned login to shared
 `~/.codex/auth.json` for future Codex launches, then selects the same account as
 the fixed Decodex route. The underlying typed commands remain independently
@@ -123,9 +132,10 @@ fenced, and retrying the control completes whichever step is not current. The
 Fast control updates only the current Codex `[features].fast_mode` preference
 through the in-process native client.
 The overflow menu contains only `Refresh all`, the material selector, and Quit.
-`Refresh all` remains available while an automatic read is in progress because
-the store coalesces that request into the active refresh cycle. Account mutations
-and Reset Card submissions still disable it.
+`Refresh all` reloads all current daemon values; it does not contact a provider.
+It remains available while an automatic read is in progress because the store
+coalesces that request into the active reload. Account mutations and Reset Card
+submissions still disable it.
 
 Each account card reveals one compact trailing-edge reorder grip while the pointer
 is over that card. The grip overlays the card padding instead of reserving a layout

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardInventoryReadCoordinator.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardInventoryReadCoordinator.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-/// Owns the per-account provider-read ordering contract.
+/// Owns the per-account daemon-value read ordering contract.
 ///
 /// Reset Card reads can be requested by the periodic refresh, account-control
-/// follow-ups, and terminal use reconciliation. The daemon starts a bounded
-/// provider process for each read or effect, so one account must never overlap
-/// those operations. An effect gate waits for an older read, blocks new reads
-/// through dispatch, and creates a fresh epoch for post-effect reconciliation.
+/// follow-ups, and terminal use reconciliation. Reads return daemon-owned cached
+/// values without starting provider work. An effect gate still waits for an older
+/// read, blocks new reads through dispatch, and creates a fresh epoch so a value
+/// started before the effect cannot publish as post-effect reconciliation.
 actor ResetCardInventoryReadCoordinator {
 	private struct Operation {
 		let id: UInt64

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -258,10 +258,9 @@ private enum ResetCardInventoryRefreshResult: Equatable {
 @MainActor
 @Observable
 final class ResetCardStore {
-	// Profile reads are cheap cached projections, while Reset Card reads start an
-	// account-bound provider process. Keep the progressive fan-out below the host
-	// process burst that can make otherwise healthy accounts fail transiently.
-	private static let maximumConcurrentAccountReads = 3
+	// These reads return daemon-owned observations and never start provider work.
+	// Fetch every independent account projection concurrently so one row cannot
+	// delay another row's first presentation.
 	private static let defaultAutomaticRefreshInterval: Duration = .seconds(15)
 	private static let defaultPostUseRetryDelays: [Duration] = [
 		.seconds(1),
@@ -276,6 +275,14 @@ final class ResetCardStore {
 		.seconds(8),
 		.seconds(15),
 		.seconds(30),
+	]
+	private static let defaultAccountObservationRetryDelays: [Duration] = [
+		.milliseconds(250),
+		.milliseconds(500),
+		.seconds(1),
+		.seconds(2),
+		.seconds(4),
+		.seconds(8),
 	]
 
 	private(set) var accounts = [ResetCardAccountState]()
@@ -306,6 +313,7 @@ final class ResetCardStore {
 	@ObservationIgnored private let postUseRetryDelays: [Duration]
 	@ObservationIgnored private let automaticRefreshInterval: Duration
 	@ObservationIgnored private let accountReauthenticationPollInterval: Duration
+	@ObservationIgnored private let accountObservationRetryDelays: [Duration]
 	@ObservationIgnored private let resolveCodexExecutable: @MainActor @Sendable () throws -> String
 	@ObservationIgnored private var startupTask: Task<Void, Never>?
 	@ObservationIgnored private var automaticRefreshTask: Task<Void, Never>?
@@ -334,6 +342,8 @@ final class ResetCardStore {
 		postUseRetryDelays: [Duration] = ResetCardStore.defaultPostUseRetryDelays,
 		automaticRefreshInterval: Duration = ResetCardStore.defaultAutomaticRefreshInterval,
 		accountReauthenticationPollInterval: Duration = .seconds(1),
+		accountObservationRetryDelays: [Duration] = ResetCardStore
+			.defaultAccountObservationRetryDelays,
 		resolveCodexExecutable: @escaping @MainActor @Sendable () throws -> String = {
 			try CodexExecutableResolver.resolve()
 		}
@@ -347,6 +357,7 @@ final class ResetCardStore {
 		self.postUseRetryDelays = postUseRetryDelays
 		self.automaticRefreshInterval = automaticRefreshInterval
 		self.accountReauthenticationPollInterval = accountReauthenticationPollInterval
+		self.accountObservationRetryDelays = accountObservationRetryDelays
 		self.resolveCodexExecutable = resolveCodexExecutable
 		let pendingLoad = pendingStore.load()
 		pendingAttempts = pendingLoad.attempts
@@ -806,11 +817,8 @@ final class ResetCardStore {
 				}
 			}
 			await withTaskGroup(of: ResetCardAccountRead.self) { group in
-				var nextRead = 0
-				let initialCount = min(Self.maximumConcurrentAccountReads, reads.count)
-				while nextRead < initialCount {
-					group.addTask(operation: reads[nextRead])
-					nextRead += 1
+				for read in reads {
+					group.addTask(operation: read)
 				}
 
 				while let read = await group.next() {
@@ -847,16 +855,19 @@ final class ResetCardStore {
 							applyProfileFailure(error, accountID: accountID, request: request)
 						}
 					}
-					if nextRead < reads.count {
-						group.addTask(operation: reads[nextRead])
-						nextRead += 1
-					}
 				}
 			}
 			for request in profileRequests {
 				finishProfileRequest(request)
 			}
 			_ = publishProfileEmailsIfReady(expectedEpoch: visibilityEpoch)
+			shouldRetry = accounts.contains { state in
+				state.error?.isRetryableReadFailure == true
+					|| state.inventory?.observationError?.isRetryableReadFailure == true
+					|| state.profileError?.isRetryableReadFailure == true
+					|| state.profileUnavailable?.error.isRetryableReadFailure == true
+					|| state.profile?.refreshError?.isRetryableReadFailure == true
+			}
 		} catch {
 			let clientError = Self.clientError(error)
 			shouldRetry = clientError.isRetryableReadFailure
@@ -2888,16 +2899,41 @@ final class ResetCardStore {
 			return
 		}
 		accountControlActivities.removeValue(forKey: accountID)
-		accountReauthenticationTask = nil
 		message = ResetCardStoreMessage(
 			tone: .success,
 			text: "Account login refreshed."
 		)
 		accountReauthentication = nil
-		await refreshReauthenticatedAccountAuthority(accountID)
+		await refreshReauthenticatedAccountAuthority(
+			accountID,
+			retryDelays: accountObservationRetryDelays
+		)
+		accountReauthenticationTask = nil
 	}
 
-	private func refreshReauthenticatedAccountAuthority(_ accountID: String) async {
+	private func refreshReauthenticatedAccountAuthority(
+		_ accountID: String,
+		retryDelays: [Duration] = []
+	) async {
+		await refreshReauthenticatedAccountAuthorityOnce(accountID)
+		for delay in retryDelays {
+			guard Task.isCancelled == false,
+				accounts.first(where: {
+					$0.account.accountID == accountID
+				})?.requiresLoginRefresh == true
+			else {
+				return
+			}
+			do {
+				try await Task.sleep(for: delay)
+			} catch {
+				return
+			}
+			await refreshReauthenticatedAccountAuthorityOnce(accountID)
+		}
+	}
+
+	private func refreshReauthenticatedAccountAuthorityOnce(_ accountID: String) async {
 		await refreshAccountSkeleton()
 		await refreshAccountDetails(accountID)
 		await refreshAccountSkeleton()

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -302,7 +302,7 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(
 			reads.inventory,
 			2,
-			"The advanced authoritative inventory must replace a duplicate provider read."
+			"The advanced authoritative inventory must replace a duplicate daemon read."
 		)
 	}
 
@@ -1035,7 +1035,8 @@ final class AccountControlStoreTests: XCTestCase {
 				.waitingForBrowser,
 				.installing,
 				.completed,
-			]
+			],
+			reauthenticationObservationDelayReads: 2
 		)
 		let fixture = pendingFixture()
 		defer { fixture.remove() }
@@ -1044,6 +1045,7 @@ final class AccountControlStoreTests: XCTestCase {
 			pendingStore: fixture.store,
 			startupRetryDelays: [],
 			accountReauthenticationPollInterval: .zero,
+			accountObservationRetryDelays: [.zero, .zero],
 			resolveCodexExecutable: {
 				"/Applications/ChatGPT.app/Contents/Resources/codex"
 			}
@@ -1054,7 +1056,8 @@ final class AccountControlStoreTests: XCTestCase {
 		store.beginAccountReauthentication(for: accountID)
 		for _ in 0 ..< 200 {
 			if store.accountReauthentication == nil,
-				store.accounts.first?.account.accountRevision == 8
+				store.accounts.first?.account.accountRevision == 8,
+				store.accounts.first?.account.observedState == .available
 			{
 				break
 			}
@@ -1081,7 +1084,7 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(cancelCount, 0)
 		let reads = await client.readCounts()
 		XCTAssertGreaterThanOrEqual(reads.snapshot, 3)
-		XCTAssertGreaterThanOrEqual(reads.inventory, 2)
+		XCTAssertGreaterThanOrEqual(reads.inventory, 4)
 	}
 
 	func testBrowserLoginRemainsActiveUntilExplicitCancel() async throws {
@@ -1312,6 +1315,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 	private var reauthenticationCancels = 0
 	private var reauthenticationSessionID: String?
 	private var reauthenticationCompleted = false
+	private var reauthenticationObservationDelayReads: Int
 	private let cancelReauthenticationWithOutcomeUnknown: Bool
 
 	init(
@@ -1331,6 +1335,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 		useAccountError: AccountControlError? = nil,
 		projection: CodexAuthProjection = .unmanaged,
 		reauthenticationStates: [AccountReauthenticationState] = [],
+		reauthenticationObservationDelayReads: Int = 0,
 		cancelReauthenticationWithOutcomeUnknown: Bool = false
 	) {
 		self.account = account
@@ -1354,6 +1359,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 		self.accountOrderError = accountOrderError
 		self.useAccountError = useAccountError
 		self.reauthenticationStates = reauthenticationStates
+		self.reauthenticationObservationDelayReads = reauthenticationObservationDelayReads
 		self.cancelReauthenticationWithOutcomeUnknown =
 			cancelReauthenticationWithOutcomeUnknown
 	}
@@ -1406,19 +1412,23 @@ private actor AccountControlStoreClient: AccountControlClient {
 			await inventoryGate.wait()
 		}
 		if reauthenticationCompleted, self.account.observedState == .authFailed {
-			self.account = ResetCardAccountRecord(
-				authority: self.account.authority,
-				accountID: self.account.accountID,
-				alias: self.account.alias,
-				accountRevision: self.account.accountRevision,
-				enabled: self.account.enabled,
-				observedState: .available,
-				lifecycleReadiness: self.account.lifecycleReadiness,
-				credentialBinding: self.account.credentialBinding,
-				unsettledOperation: self.account.unsettledOperation,
-				fiveHourQuota: self.account.fiveHourQuota,
-				sevenDayQuota: self.account.sevenDayQuota
-			)
+			if reauthenticationObservationDelayReads > 0 {
+				reauthenticationObservationDelayReads -= 1
+			} else {
+				self.account = ResetCardAccountRecord(
+					authority: self.account.authority,
+					accountID: self.account.accountID,
+					alias: self.account.alias,
+					accountRevision: self.account.accountRevision,
+					enabled: self.account.enabled,
+					observedState: .available,
+					lifecycleReadiness: self.account.lifecycleReadiness,
+					credentialBinding: self.account.credentialBinding,
+					unsettledOperation: self.account.unsettledOperation,
+					fiveHourQuota: self.account.fiveHourQuota,
+					sevenDayQuota: self.account.sevenDayQuota
+				)
+			}
 		}
 		return ResetCardInventory(
 			authority: authority,

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardInventoryReadCoordinatorTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardInventoryReadCoordinatorTests.swift
@@ -47,7 +47,7 @@ final class ResetCardInventoryReadCoordinatorTests: XCTestCase {
 		XCTAssertEqual(
 			callCountBeforeRelease,
 			1,
-			"A post-effect read must queue behind the older provider process."
+			"A post-effect read must queue behind the older daemon-value read."
 		)
 
 		await client.release(call: 1)

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreStartupRetryTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreStartupRetryTests.swift
@@ -39,7 +39,7 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 		)
 	}
 
-	func testStartupDoesNotLoopOnRowScopedInventoryFailure() async throws {
+	func testStartupRetriesRowScopedDaemonCacheMissUntilInventoryLoads() async throws {
 		let fixture = try makePendingFixture()
 		defer { fixture.remove() }
 		let expectedInventory = try Self.inventory
@@ -65,14 +65,11 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 		try await Task.sleep(for: .milliseconds(20))
 
 		let counts = await client.callCounts()
-		XCTAssertNil(store.accounts.first?.inventory)
-		XCTAssertEqual(
-			store.accounts.first?.error,
-			.service(.productStateUnavailable)
-		)
+		XCTAssertEqual(store.accounts.first?.inventory, expectedInventory)
+		XCTAssertNil(store.accounts.first?.error)
 		XCTAssertEqual(
 			counts,
-			ClientCallCounts(accounts: 1, inventory: 1, status: 0, use: 0)
+			ClientCallCounts(accounts: 2, inventory: 2, status: 0, use: 0)
 		)
 	}
 
@@ -468,6 +465,66 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 		XCTAssertTrue(store.accounts.allSatisfy { $0.isRefreshing == false })
 	}
 
+	func testRefreshStartsEveryDaemonValueReadWithoutAThreeAccountCap() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let aliases = ["Alex", "Avery", "Bailey", "Blake", "Casey", "Clara"]
+		let accounts = aliases.enumerated().map { offset, alias in
+			ResetCardAccountRecord(
+				authority: nil,
+				accountID: String(
+					format: "00000000-0000-4000-8000-%012d",
+					offset + 1
+				),
+				alias: alias,
+				accountRevision: UInt64(offset + 1),
+				enabled: true,
+				observedState: .available,
+				lifecycleReadiness: .ready,
+				fiveHourQuota: .unknown(durationMinutes: 300),
+				sevenDayQuota: .unknown(durationMinutes: 10_080)
+			)
+		}
+		let inventories = Dictionary(
+			uniqueKeysWithValues: accounts.map { account in
+				(
+					account.accountID,
+					ResetCardInventory(
+						authority: Self.authority,
+						accountID: account.accountID,
+						accountRevision: account.accountRevision,
+						cards: [],
+						fiveHourQuota: account.fiveHourQuota,
+						sevenDayQuota: account.sevenDayQuota,
+						observationError: nil
+					)
+				)
+			}
+		)
+		let client = ConcurrentDaemonValueClient(
+			accounts: accounts,
+			inventories: inventories
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		let refresh = Task {
+			await store.refresh()
+		}
+		try await waitUntil {
+			await client.startedCount() == accounts.count
+		}
+		let startedCount = await client.startedCount()
+		XCTAssertEqual(startedCount, 6)
+
+		await client.releaseAll()
+		await refresh.value
+		XCTAssertTrue(store.accounts.allSatisfy { $0.inventory != nil })
+	}
+
 	func testRefreshPinsTheAccountListToTheEstablishedAuthority() async throws {
 		let fixture = try makePendingFixture()
 		defer { fixture.remove() }
@@ -692,7 +749,7 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 		XCTAssertEqual(
 			useCallsBeforeReadRelease,
 			0,
-			"Use must wait for the older inventory provider process."
+			"Use must wait for the older daemon-value read."
 		)
 
 		await client.releaseInventoryCall(2)
@@ -1157,6 +1214,54 @@ private actor ProgressiveResetCardClient: ResetCardClient {
 	}
 
 	func releaseBlockedAccount() {
+		isReleased = true
+	}
+}
+
+private actor ConcurrentDaemonValueClient: ResetCardClient {
+	private let accountRecords: [ResetCardAccountRecord]
+	private let inventories: [String: ResetCardInventory]
+	private var startedAccountIDs = Set<String>()
+	private var isReleased = false
+
+	init(
+		accounts: [ResetCardAccountRecord],
+		inventories: [String: ResetCardInventory]
+	) {
+		accountRecords = accounts
+		self.inventories = inventories
+	}
+
+	func accounts(
+		authority: ResetCardAuthority?
+	) async throws -> [ResetCardAccountRecord] {
+		accountRecords
+	}
+
+	func inventory(for account: ResetCardAccountRecord) async throws -> ResetCardInventory {
+		startedAccountIDs.insert(account.accountID)
+		while isReleased == false {
+			try await Task.sleep(for: .milliseconds(1))
+		}
+		guard let inventory = inventories[account.accountID] else {
+			throw ResetCardClientError.invalidResponse
+		}
+		return inventory
+	}
+
+	func status(for attempt: ResetCardUseAttempt) async throws -> ResetCardOperationState {
+		.notFound
+	}
+
+	func use(_ attempt: ResetCardUseAttempt) async throws -> ResetCardOperationState {
+		.prepared
+	}
+
+	func startedCount() -> Int {
+		startedAccountIDs.count
+	}
+
+	func releaseAll() {
 		isReleased = true
 	}
 }

--- a/crates/decodex-runtime/src/account_launch/reset_card.rs
+++ b/crates/decodex-runtime/src/account_launch/reset_card.rs
@@ -60,9 +60,6 @@ const PROCESS_TIMEOUT: Duration = Duration::from_secs(30);
 // shutdown add 1.25 seconds, rounded up to two seconds for this lease proof.
 const MAX_BLOCKING_PROCESS_DEADLINE: Duration =
 	Duration::from_secs(PROCESS_TIMEOUT.as_secs() * 8 + 2);
-// A query receives a typed row-scoped refusal before the protocol client's whole-request
-// deadline. The daemon-owned operation continues its already-bounded cleanup.
-const INVENTORY_RESPONSE_TIMEOUT: Duration = Duration::from_secs(25);
 const CLAIM_LEASE: Duration = Duration::from_secs(360);
 const CLAIM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 // A detached blocking task must begin early enough that all bounded provider work finishes before
@@ -173,6 +170,7 @@ struct ResetCardRuntimeInner {
 	worker_id: String,
 	worker_lock: Mutex<()>,
 	worker_wakeup: Arc<Notify>,
+	observation_wakeup: Arc<Notify>,
 	provider_work: Arc<ProviderWorkLifecycle>,
 }
 
@@ -349,6 +347,7 @@ impl ResetCardRuntime {
 				worker_id,
 				worker_lock: Mutex::new(()),
 				worker_wakeup: Arc::new(Notify::new()),
+				observation_wakeup: Arc::new(Notify::new()),
 				provider_work: Arc::new(ProviderWorkLifecycle::new()),
 			}),
 		};
@@ -393,6 +392,11 @@ impl ResetCardRuntime {
 
 	pub(crate) fn vault_status(&self) -> ResetCardVaultStatus {
 		ResetCardVaultStatus::Ready
+	}
+
+	/// Share the coalescing wakeup emitted after one durable Reset Card worker claim settles.
+	pub(crate) fn observation_wakeup(&self) -> Arc<Notify> {
+		Arc::clone(&self.inner.observation_wakeup)
 	}
 
 	/// Run one bounded exact-image login, refresh callback, CAS, and provider-readback proof.
@@ -443,8 +447,12 @@ impl ResetCardRuntime {
 			.map_err(map_account_service_error)
 	}
 
-	/// Read one fresh, strict provider inventory under a PostgreSQL revision fence.
-	pub(crate) async fn inventory(
+	/// Observe one fresh, strict provider inventory under a PostgreSQL revision fence.
+	///
+	/// The daemon account observer awaits this owner through its bounded provider cleanup. Client
+	/// queries read the observer cache and therefore never impose a shorter response deadline that
+	/// could overlap two provider owners for the same account.
+	pub(crate) async fn observe_inventory(
 		&self,
 		account_id: &AccountId,
 	) -> Result<ResetCardInventoryObservation, ResetCardServiceError> {
@@ -456,11 +464,11 @@ impl ResetCardRuntime {
 		);
 		let inner = Arc::clone(&self.inner);
 		let account_id = account_id.clone();
-		let mut owner =
+		let owner =
 			task::spawn(
 				async move { Self::inventory_once(inner, account_id, provider_permit).await },
 			);
-		await_inventory_owner(&mut owner, INVENTORY_RESPONSE_TIMEOUT).await
+		owner.await.map_err(|_| ResetCardServiceError::ResourceExhausted)?
 	}
 
 	async fn inventory_once(
@@ -697,17 +705,6 @@ impl ResetCardRuntime {
 	}
 }
 
-async fn await_inventory_owner(
-	owner: &mut task::JoinHandle<InventoryResult>,
-	response_timeout: Duration,
-) -> InventoryResult {
-	match time::timeout(response_timeout, owner).await {
-		Ok(Ok(result)) => result,
-		Ok(Err(_)) => Err(ResetCardServiceError::ResourceExhausted),
-		Err(_) => Err(ResetCardServiceError::RequestTimedOut),
-	}
-}
-
 async fn run_worker(inner: Arc<ResetCardRuntimeInner>, mut stop: watch::Receiver<bool>) {
 	loop {
 		if *stop.borrow() {
@@ -746,6 +743,7 @@ async fn drain_worker(inner: Arc<ResetCardRuntimeInner>, stop: &watch::Receiver<
 			};
 
 		process_claim(Arc::clone(&inner), claim).await;
+		inner.observation_wakeup.notify_one();
 	}
 }
 
@@ -1679,11 +1677,7 @@ impl Debug for StoredCredentialVault {
 mod tests {
 	use std::{
 		future::{pending, ready},
-		sync::{
-			Arc,
-			atomic::{AtomicBool, Ordering},
-			mpsc,
-		},
+		sync::{Arc, mpsc},
 		time::Duration,
 	};
 
@@ -1697,9 +1691,9 @@ mod tests {
 	use super::{
 		CLAIM_HEARTBEAT_INTERVAL, CLAIM_LEASE, ClaimWorkGate, MAX_BLOCKING_PROCESS_DEADLINE,
 		MAX_CLAIM_WORK_START_DELAY, ProviderWorkLifecycle, ResetCardConsumeOutcome,
-		ResetCardFailureCode, ResetCardServiceError, await_inventory_owner, finish_guarded_work,
-		maintain_claim_heartbeat, map_prepare_store_error, provider_idempotency_key,
-		readback_confirms_outcome, require_claim_work_start,
+		ResetCardFailureCode, ResetCardServiceError, finish_guarded_work, maintain_claim_heartbeat,
+		map_prepare_store_error, provider_idempotency_key, readback_confirms_outcome,
+		require_claim_work_start,
 	};
 
 	#[test]
@@ -1893,31 +1887,6 @@ mod tests {
 		time::timeout(Duration::from_secs(1), lifecycle.wait_for_settlement())
 			.await
 			.expect("provider lifecycle must settle after its last registered work exits");
-	}
-
-	#[tokio::test]
-	async fn inventory_deadline_returns_typed_error_without_aborting_owned_cleanup() {
-		let cleanup_finished = Arc::new(AtomicBool::new(false));
-		let observed_cleanup = Arc::clone(&cleanup_finished);
-		let mut owner = task::spawn(async move {
-			time::sleep(Duration::from_millis(20)).await;
-			observed_cleanup.store(true, Ordering::Release);
-
-			Err(ResetCardServiceError::ProviderUnavailable)
-		});
-
-		assert_eq!(
-			await_inventory_owner(&mut owner, Duration::from_millis(1)).await,
-			Err(ResetCardServiceError::RequestTimedOut),
-		);
-		drop(owner);
-		time::timeout(Duration::from_secs(1), async {
-			while !cleanup_finished.load(Ordering::Acquire) {
-				task::yield_now().await;
-			}
-		})
-		.await
-		.expect("daemon-owned cleanup must finish after the response deadline");
 	}
 
 	#[test]

--- a/crates/decodex-runtime/src/account_observation.rs
+++ b/crates/decodex-runtime/src/account_observation.rs
@@ -1,0 +1,451 @@
+//! Daemon-owned background observation for every independent account.
+
+use std::{
+	collections::{HashMap, HashSet},
+	future,
+	sync::Arc,
+	time::Duration,
+};
+
+use decodex_core::{AccountId, AccountLifecycleReadiness};
+use tokio::{
+	sync::{Notify, RwLock, watch},
+	task::{Id as TaskId, JoinSet},
+	time::{self, MissedTickBehavior},
+};
+
+use crate::{
+	account_launch::{ResetCardInventoryObservation, ResetCardRuntime, ResetCardServiceError},
+	account_profile::{
+		AccountProfileRefreshStatus, AccountProfileRuntime, AccountProfileRuntimeResult,
+	},
+	account_service::{AccountLifecycleError, AccountService},
+};
+
+const OBSERVATION_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
+
+#[derive(Clone)]
+struct CachedResetCardInventory {
+	account_revision: i64,
+	result: Result<ResetCardInventoryObservation, ResetCardServiceError>,
+}
+
+#[derive(Default)]
+struct AccountObservationState {
+	reset_cards: HashMap<AccountId, CachedResetCardInventory>,
+	profiles: HashMap<AccountId, AccountProfileRefreshStatus>,
+}
+
+struct AccountObservationOutcome {
+	account_id: AccountId,
+	requested_revision: i64,
+	reset_cards: Option<Result<ResetCardInventoryObservation, ResetCardServiceError>>,
+	profile: Option<AccountProfileRefreshStatus>,
+}
+
+impl AccountObservationState {
+	fn retain_current(&mut self, current: &HashMap<AccountId, i64>) {
+		self.reset_cards.retain(|account_id, cached| {
+			current.get(account_id).is_some_and(|revision| *revision == cached.account_revision)
+		});
+		self.profiles.retain(|account_id, status| {
+			current.get(account_id).is_some_and(|revision| *revision == status.account_revision)
+		});
+	}
+
+	fn insert(&mut self, observation: AccountObservationOutcome) {
+		if let Some(reset_cards) = observation.reset_cards {
+			let inventory_revision = reset_cards
+				.as_ref()
+				.ok()
+				.map(inventory_revision)
+				.unwrap_or(observation.requested_revision);
+			self.reset_cards.insert(
+				observation.account_id.clone(),
+				CachedResetCardInventory {
+					account_revision: inventory_revision,
+					result: reset_cards,
+				},
+			);
+		}
+		if let Some(profile) = observation.profile {
+			self.profiles.insert(observation.account_id, profile);
+		}
+	}
+}
+
+/// One daemon-lifecycle observer that refreshes independent accounts concurrently.
+#[derive(Clone)]
+pub(crate) struct AccountObservationService {
+	accounts: Arc<AccountService>,
+	profiles: Option<AccountProfileRuntime>,
+	reset_cards: Option<ResetCardRuntime>,
+	state: Arc<RwLock<AccountObservationState>>,
+	refresh_requested: Arc<Notify>,
+}
+
+impl AccountObservationService {
+	pub(crate) fn new(
+		accounts: Arc<AccountService>,
+		profiles: Option<AccountProfileRuntime>,
+		reset_cards: Option<ResetCardRuntime>,
+	) -> Self {
+		Self {
+			accounts,
+			profiles,
+			reset_cards,
+			state: Arc::new(RwLock::new(AccountObservationState::default())),
+			refresh_requested: Arc::new(Notify::new()),
+		}
+	}
+
+	/// Request one coalesced background refresh without making a client wait for provider work.
+	pub(crate) fn request_refresh(&self) {
+		self.refresh_requested.notify_one();
+	}
+
+	/// Read one last daemon-owned Reset Card value without contacting the provider.
+	pub(crate) async fn reset_card_inventory(
+		&self,
+		account_id: &AccountId,
+	) -> Result<ResetCardInventoryObservation, ResetCardServiceError> {
+		if self.reset_cards.is_none() {
+			return Err(ResetCardServiceError::ProductStateUnavailable);
+		}
+		let cached = self
+			.state
+			.read()
+			.await
+			.reset_cards
+			.get(account_id)
+			.cloned()
+			.ok_or(ResetCardServiceError::ProviderUnavailable)?;
+		let current = self.accounts.inspect(account_id).await.map_err(|error| match error {
+			AccountLifecycleError::AccountMissing => ResetCardServiceError::AccountNotFound,
+			_ => ResetCardServiceError::ProductStateUnavailable,
+		})?;
+		if current.account.revision != cached.account_revision {
+			return Err(ResetCardServiceError::AccountChanged);
+		}
+		cached.result
+	}
+
+	/// Read one persisted profile projection using only daemon-owned refresh status.
+	pub(crate) async fn account_profile(
+		&self,
+		account_id: &AccountId,
+		include_email: bool,
+	) -> Option<AccountProfileRuntimeResult> {
+		let profiles = self.profiles.as_ref()?;
+		let status = self.state.read().await.profiles.get(account_id).copied();
+		Some(profiles.read_cached(account_id, include_email, status).await)
+	}
+
+	/// Run immediate startup observation and all later coalesced daemon refreshes.
+	pub(crate) async fn daemon_service(self, mut stop: watch::Receiver<bool>) {
+		let reset_card_wakeup = self.reset_cards.as_ref().map(ResetCardRuntime::observation_wakeup);
+		let mut interval = time::interval(OBSERVATION_REFRESH_INTERVAL);
+		interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+		let mut desired = HashMap::new();
+		let mut in_flight = HashMap::new();
+		let mut pending = HashSet::new();
+		let mut task_accounts = HashMap::new();
+		let mut observations = JoinSet::new();
+		loop {
+			if *stop.borrow() {
+				break;
+			}
+
+			tokio::select! {
+				biased;
+
+				result = stop.changed() => {
+					if result.is_err() || *stop.borrow_and_update() {
+						break;
+					}
+				},
+				() = self.refresh_requested.notified() => {
+					self.schedule_current_accounts(
+						true,
+						&mut desired,
+						&mut in_flight,
+						&mut pending,
+						&mut task_accounts,
+						&mut observations,
+					).await;
+				},
+				() = optional_notification(reset_card_wakeup.as_ref()) => {
+					self.schedule_current_accounts(
+						true,
+						&mut desired,
+						&mut in_flight,
+						&mut pending,
+						&mut task_accounts,
+						&mut observations,
+					).await;
+				},
+				_ = interval.tick() => {
+					self.schedule_current_accounts(
+						false,
+						&mut desired,
+						&mut in_flight,
+						&mut pending,
+						&mut task_accounts,
+						&mut observations,
+					).await;
+				},
+				result = observations.join_next_with_id(), if !observations.is_empty() => {
+					self.finish_observation(
+						result,
+						&desired,
+						&mut in_flight,
+						&mut pending,
+						&mut task_accounts,
+						&mut observations,
+					).await;
+				},
+			}
+		}
+
+		// Provider owners retain their own bounded cleanup. Drain the async observation
+		// owners so the daemon lifecycle cannot release authority while they are live.
+		while observations.join_next().await.is_some() {}
+	}
+
+	async fn schedule_current_accounts(
+		&self,
+		queue_in_flight_successor: bool,
+		desired: &mut HashMap<AccountId, i64>,
+		in_flight: &mut HashMap<AccountId, TaskId>,
+		pending: &mut HashSet<AccountId>,
+		task_accounts: &mut HashMap<TaskId, AccountId>,
+		observations: &mut JoinSet<AccountObservationOutcome>,
+	) {
+		let Ok((accounts, _routing)) = self.accounts.list_snapshot().await else {
+			return;
+		};
+		let current = accounts
+			.into_iter()
+			.filter(|inspection| {
+				!inspection.account.tombstoned
+					&& inspection.readiness == AccountLifecycleReadiness::Ready
+			})
+			.map(|inspection| (inspection.account.account_id, inspection.account.revision))
+			.collect::<HashMap<_, _>>();
+		{
+			let mut state = self.state.write().await;
+			state.retain_current(&current);
+		}
+		pending.retain(|account_id| current.contains_key(account_id));
+		*desired = current;
+
+		for (account_id, account_revision) in
+			plan_observation_round(desired, in_flight, pending, queue_in_flight_successor)
+		{
+			self.spawn_observation(
+				account_id,
+				account_revision,
+				in_flight,
+				task_accounts,
+				observations,
+			);
+		}
+	}
+
+	fn spawn_observation(
+		&self,
+		account_id: AccountId,
+		account_revision: i64,
+		in_flight: &mut HashMap<AccountId, TaskId>,
+		task_accounts: &mut HashMap<TaskId, AccountId>,
+		observations: &mut JoinSet<AccountObservationOutcome>,
+	) {
+		let profiles = self.profiles.clone();
+		let reset_cards = self.reset_cards.clone();
+		let task_account_id = account_id.clone();
+		let task = observations.spawn(async move {
+			// Reset Card observation can rotate the account credential. Complete it first so the
+			// profile observation uses that exact successor instead of racing an old revision.
+			let reset_cards = match reset_cards {
+				Some(reset_cards) => Some(reset_cards.observe_inventory(&task_account_id).await),
+				None => None,
+			};
+			let profile_revision = reset_cards
+				.as_ref()
+				.and_then(|result| result.as_ref().ok())
+				.map_or(account_revision, inventory_revision);
+			let profile = match profiles {
+				Some(profiles) => Some(
+					profiles.query(&task_account_id, false).await.refresh_status(profile_revision),
+				),
+				None => None,
+			};
+			AccountObservationOutcome {
+				account_id: task_account_id,
+				requested_revision: account_revision,
+				reset_cards,
+				profile,
+			}
+		});
+		let task_id = task.id();
+		in_flight.insert(account_id.clone(), task_id);
+		task_accounts.insert(task_id, account_id);
+	}
+
+	async fn finish_observation(
+		&self,
+		result: Option<Result<(TaskId, AccountObservationOutcome), tokio::task::JoinError>>,
+		desired: &HashMap<AccountId, i64>,
+		in_flight: &mut HashMap<AccountId, TaskId>,
+		pending: &mut HashSet<AccountId>,
+		task_accounts: &mut HashMap<TaskId, AccountId>,
+		observations: &mut JoinSet<AccountObservationOutcome>,
+	) {
+		let (task_id, observation) = match result {
+			Some(Ok((task_id, observation))) => (task_id, Some(observation)),
+			Some(Err(error)) => (error.id(), None),
+			None => return,
+		};
+		let Some(account_id) = task_accounts.remove(&task_id) else {
+			return;
+		};
+		if in_flight.get(&account_id) == Some(&task_id) {
+			in_flight.remove(&account_id);
+		}
+
+		if let Some(observation) = observation
+			&& observation.account_id == account_id
+			&& desired.get(&account_id) == Some(&observation.requested_revision)
+		{
+			let mut state = self.state.write().await;
+			state.insert(observation);
+		}
+
+		if pending.remove(&account_id)
+			&& let Some(account_revision) = desired.get(&account_id)
+		{
+			self.spawn_observation(
+				account_id,
+				*account_revision,
+				in_flight,
+				task_accounts,
+				observations,
+			);
+		}
+	}
+}
+
+async fn optional_notification(notify: Option<&Arc<Notify>>) {
+	match notify {
+		Some(notify) => notify.notified().await,
+		None => future::pending().await,
+	}
+}
+
+fn plan_observation_round<T>(
+	desired: &HashMap<AccountId, i64>,
+	in_flight: &HashMap<AccountId, T>,
+	pending: &mut HashSet<AccountId>,
+	queue_in_flight_successor: bool,
+) -> Vec<(AccountId, i64)> {
+	desired
+		.iter()
+		.filter_map(|(account_id, account_revision)| {
+			if in_flight.contains_key(account_id) {
+				if queue_in_flight_successor {
+					pending.insert(account_id.clone());
+				}
+				None
+			} else {
+				Some((account_id.clone(), *account_revision))
+			}
+		})
+		.collect()
+}
+
+const fn inventory_revision(observation: &ResetCardInventoryObservation) -> i64 {
+	match observation {
+		ResetCardInventoryObservation::Available(inventory) => inventory.account_revision,
+		ResetCardInventoryObservation::ObservationFailed(failure) => failure.account_revision,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::collections::{HashMap, HashSet};
+
+	use decodex_core::AccountId;
+
+	use super::{
+		AccountObservationOutcome, AccountObservationState, AccountProfileRefreshStatus,
+		ResetCardServiceError, plan_observation_round,
+	};
+
+	#[test]
+	fn one_round_starts_every_independent_account_without_a_global_cap() {
+		let desired =
+			(1..=12).map(|index| (account(index), i64::from(index))).collect::<HashMap<_, _>>();
+		let active = account(4);
+		let in_flight = HashMap::from([(active.clone(), ())]);
+		let mut pending = HashSet::new();
+
+		let scheduled = plan_observation_round(&desired, &in_flight, &mut pending, true);
+
+		assert_eq!(scheduled.len(), 11);
+		assert!(scheduled.iter().all(|(account_id, _)| account_id != &active));
+		assert_eq!(pending, HashSet::from([active]));
+	}
+
+	#[test]
+	fn periodic_round_does_not_hot_loop_a_slow_account() {
+		let active = account(1);
+		let desired = HashMap::from([(active.clone(), 7)]);
+		let in_flight = HashMap::from([(active, ())]);
+		let mut pending = HashSet::new();
+
+		let scheduled = plan_observation_round(&desired, &in_flight, &mut pending, false);
+
+		assert!(scheduled.is_empty());
+		assert!(pending.is_empty());
+	}
+
+	#[test]
+	fn revision_change_prunes_both_daemon_owned_account_values() {
+		let account_id = account(1);
+		let mut state = AccountObservationState::default();
+		state.insert(AccountObservationOutcome {
+			account_id: account_id.clone(),
+			requested_revision: 7,
+			reset_cards: Some(Err(ResetCardServiceError::ProviderUnavailable)),
+			profile: Some(AccountProfileRefreshStatus { account_revision: 7, refresh_error: None }),
+		});
+
+		state.retain_current(&HashMap::from([(account_id, 8)]));
+
+		assert!(state.reset_cards.is_empty());
+		assert!(state.profiles.is_empty());
+	}
+
+	#[test]
+	fn profile_observation_does_not_require_reset_card_capability() {
+		let account_id = account(2);
+		let mut state = AccountObservationState::default();
+		state.insert(AccountObservationOutcome {
+			account_id: account_id.clone(),
+			requested_revision: 9,
+			reset_cards: None,
+			profile: Some(AccountProfileRefreshStatus { account_revision: 9, refresh_error: None }),
+		});
+
+		assert!(state.reset_cards.is_empty());
+		assert_eq!(
+			state.profiles.get(&account_id),
+			Some(&AccountProfileRefreshStatus { account_revision: 9, refresh_error: None })
+		);
+	}
+
+	fn account(index: u16) -> AccountId {
+		AccountId::new(format!("00000000-0000-4000-8000-{index:012}"))
+			.expect("fixture account ID is canonical")
+	}
+}

--- a/crates/decodex-runtime/src/account_profile.rs
+++ b/crates/decodex-runtime/src/account_profile.rs
@@ -28,6 +28,35 @@ pub(crate) enum AccountProfileRuntimeResult {
 	Unavailable { claims: AccountProfileClaimsView, error: AccountProfileRuntimeError },
 }
 
+/// Daemon-owned refresh state for one exact account revision.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct AccountProfileRefreshStatus {
+	pub(crate) account_revision: i64,
+	pub(crate) refresh_error: Option<AccountProfileRuntimeError>,
+}
+
+impl AccountProfileRuntimeResult {
+	pub(crate) const fn refresh_status(
+		&self,
+		requested_revision: i64,
+	) -> AccountProfileRefreshStatus {
+		match self {
+			Self::Current(profile) => AccountProfileRefreshStatus {
+				account_revision: profile.snapshot.account_revision,
+				refresh_error: None,
+			},
+			Self::Cached { profile, refresh_error } => AccountProfileRefreshStatus {
+				account_revision: profile.snapshot.account_revision,
+				refresh_error: Some(*refresh_error),
+			},
+			Self::Unavailable { error, .. } => AccountProfileRefreshStatus {
+				account_revision: requested_revision,
+				refresh_error: Some(*error),
+			},
+		}
+	}
+}
+
 /// One persisted profile snapshot plus query-selected current credential claims.
 pub(crate) struct AccountProfileView {
 	pub(crate) snapshot: AccountProfileSnapshot,
@@ -132,7 +161,9 @@ impl AccountProfileProvider for OpenAiAccountProfileProvider {
 	}
 }
 
-/// Runtime owner for one independent profile request. It has no poller or retained secret state.
+/// Provider primitive for one independent profile request with no retained secret state.
+///
+/// `AccountObservationService` owns the daemon cadence and calls this primitive.
 #[derive(Clone)]
 pub(crate) struct AccountProfileRuntime {
 	store: PostgresStore,
@@ -148,6 +179,68 @@ impl AccountProfileRuntime {
 			provider: OpenAiAccountProfileProvider::new()
 				.ok()
 				.map(|provider| Arc::new(provider) as Arc<dyn AccountProfileProvider>),
+		}
+	}
+
+	/// Read only the latest daemon-owned profile value and current credential claims.
+	///
+	/// This path never contacts the provider. The background account-observation service owns
+	/// provider refresh and supplies the exact revision-scoped refresh status.
+	pub(crate) async fn read_cached(
+		&self,
+		account_id: &AccountId,
+		include_email: bool,
+		status: Option<AccountProfileRefreshStatus>,
+	) -> AccountProfileRuntimeResult {
+		let account = match self.store.read_account_registry(Some(account_id), 1).await {
+			Ok(accounts) => match accounts.into_iter().next() {
+				Some(account) if !account.tombstoned => account,
+				_ =>
+					return AccountProfileRuntimeResult::Unavailable {
+						claims: ProfileClaims::redacted().into_view(),
+						error: AccountProfileRuntimeError::AccountUnavailable,
+					},
+			},
+			Err(_) =>
+				return AccountProfileRuntimeResult::Unavailable {
+					claims: ProfileClaims::redacted().into_view(),
+					error: AccountProfileRuntimeError::ProductStateUnavailable,
+				},
+		};
+		let refresh_error = match status {
+			Some(status) if status.account_revision == account.revision => status.refresh_error,
+			Some(_) => Some(AccountProfileRuntimeError::AccountChanged),
+			None => Some(AccountProfileRuntimeError::ProviderUnavailable),
+		};
+		let snapshot = match self.store.read_account_profile(account_id).await {
+			Ok(Some(snapshot)) => snapshot,
+			Ok(None) =>
+				return self
+					.unavailable(
+						account_id,
+						include_email,
+						refresh_error.unwrap_or(AccountProfileRuntimeError::ProviderUnavailable),
+					)
+					.await,
+			Err(_) =>
+				return self
+					.unavailable(
+						account_id,
+						include_email,
+						AccountProfileRuntimeError::ProductStateUnavailable,
+					)
+					.await,
+		};
+		if snapshot.account_id != *account_id || snapshot.account_revision != account.revision {
+			return self
+				.unavailable(account_id, include_email, AccountProfileRuntimeError::AccountChanged)
+				.await;
+		}
+
+		let profile = self.profile_view(snapshot, include_email).await;
+		match refresh_error {
+			Some(refresh_error) => AccountProfileRuntimeResult::Cached { profile, refresh_error },
+			None => AccountProfileRuntimeResult::Current(profile),
 		}
 	}
 

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -55,9 +55,10 @@ use tokio::sync::watch;
 use crate::{
 	ProcessGenerationControl, ProviderAttemptControl,
 	account_launch::{ResetCardInventoryObservation, ResetCardRuntime, ResetCardServiceError},
+	account_observation::AccountObservationService,
 	account_profile::{
-		AccountProfileClaimsView, AccountProfileRuntime, AccountProfileRuntimeError,
-		AccountProfileRuntimeResult, AccountProfileView,
+		AccountProfileClaimsView, AccountProfileRuntimeError, AccountProfileRuntimeResult,
+		AccountProfileView,
 	},
 	account_service::{
 		AccountLifecycleError, AccountManualRecoveryAction, AccountManualRecoveryOutcome,
@@ -102,7 +103,9 @@ pub trait Application: Send + Sync + 'static {
 		command: &'a CommandEnvelope,
 	) -> impl Future<Output = Result<ApplicationPublication, CommandError>> + Send + 'a;
 
-	/// Execute one fresh observation without mutation receipts or replay semantics.
+	/// Execute one typed read without mutation receipts or replay semantics.
+	///
+	/// Each payload defines whether its value is freshly computed or daemon-observed.
 	fn query<'a>(
 		&'a self,
 		query: &'a QueryEnvelope,
@@ -191,8 +194,8 @@ pub(crate) struct ServiceApplication {
 	_codex: CodexAdapter,
 	blob_store: Option<BlobStore>,
 	accounts: Option<Arc<AccountService>>,
-	account_profiles: Option<AccountProfileRuntime>,
 	reset_cards: Option<ResetCardRuntime>,
+	account_observations: Option<AccountObservationService>,
 	doctor: DoctorReport,
 }
 impl ServiceApplication {
@@ -224,8 +227,8 @@ impl ServiceApplication {
 			_codex: codex,
 			blob_store,
 			accounts: None,
-			account_profiles: None,
 			reset_cards: None,
+			account_observations: None,
 			doctor,
 		}
 	}
@@ -236,19 +239,25 @@ impl ServiceApplication {
 		self
 	}
 
-	pub(crate) fn with_account_profiles(
-		mut self,
-		account_profiles: Option<AccountProfileRuntime>,
-	) -> Self {
-		self.account_profiles = account_profiles;
-
-		self
-	}
-
 	pub(crate) fn with_reset_cards(mut self, reset_cards: Option<ResetCardRuntime>) -> Self {
 		self.reset_cards = reset_cards;
 
 		self
+	}
+
+	pub(crate) fn with_account_observations(
+		mut self,
+		account_observations: Option<AccountObservationService>,
+	) -> Self {
+		self.account_observations = account_observations;
+
+		self
+	}
+
+	fn request_account_observation_refresh(&self) {
+		if let Some(observations) = &self.account_observations {
+			observations.request_refresh();
+		}
 	}
 
 	async fn refreshed_doctor(&self) -> DoctorReport {
@@ -351,10 +360,13 @@ impl ServiceApplication {
 		let Ok(account_id) = AccountId::new(account_id.as_str()) else {
 			return unavailable_account_profile(AccountProfileErrorDto::InvalidRequest);
 		};
-		let Some(runtime) = &self.account_profiles else {
+		let Some(observations) = &self.account_observations else {
 			return unavailable_account_profile(AccountProfileErrorDto::ProductStateUnavailable);
 		};
-		match runtime.query(&account_id, include_email).await {
+		let Some(profile) = observations.account_profile(&account_id, include_email).await else {
+			return unavailable_account_profile(AccountProfileErrorDto::ProductStateUnavailable);
+		};
+		match profile {
 			AccountProfileRuntimeResult::Current(profile) => account_profile_dto(profile)
 				.map(Box::new)
 				.map(AccountProfileResult::Current)
@@ -701,7 +713,7 @@ impl ServiceApplication {
 	}
 
 	async fn reset_card_inventory(&self, account_id: &EntityId) -> ResetCardInventoryResult {
-		let Some(runtime) = &self.reset_cards else {
+		let Some(observations) = &self.account_observations else {
 			return ResetCardInventoryResult::Unavailable {
 				error: ResetCardError::ProductStateUnavailable,
 			};
@@ -710,7 +722,7 @@ impl ServiceApplication {
 			return ResetCardInventoryResult::Unavailable { error: ResetCardError::InvalidRequest };
 		};
 
-		match runtime.inventory(&account_id).await {
+		match observations.reset_card_inventory(&account_id).await {
 			Ok(ResetCardInventoryObservation::Available(inventory)) => {
 				let account_id =
 					EntityId::new(inventory.account_id.as_str().to_owned()).map_err(|_| ());
@@ -943,7 +955,10 @@ impl Application for ServiceApplication {
 		}
 
 		if let Some(runtime) = &self.reset_cards {
-			tasks.push(Box::pin(runtime.clone().daemon_service(stop)));
+			tasks.push(Box::pin(runtime.clone().daemon_service(stop.clone())));
+		}
+		if let Some(observations) = &self.account_observations {
+			tasks.push(Box::pin(observations.clone().daemon_service(stop.clone())));
 		}
 
 		tasks
@@ -973,7 +988,11 @@ impl Application for ServiceApplication {
 			| CommandPayload::RefreshAccount { .. }
 			| CommandPayload::ReauthenticateAccountFromCredentialFile { .. }
 			| CommandPayload::RecoverAccountOperation { .. }
-			| CommandPayload::UseAccountInCodex { .. } => self.execute_account_command(command).await,
+			| CommandPayload::UseAccountInCodex { .. } => {
+				let publication = self.execute_account_command(command).await?;
+				self.request_account_observation_refresh();
+				Ok(publication)
+			},
 			CommandPayload::RefreshSystemObservation { .. } =>
 				Err(CommandError::ApplicationUnavailable {
 					message: WireText::new(
@@ -1014,6 +1033,7 @@ impl Application for ServiceApplication {
 				);
 				let descriptor = reset_descriptor_dto(prepared.descriptor);
 				let state = ResetCardOperationResult::Prepared;
+				self.request_account_observation_refresh();
 
 				Ok(ApplicationPublication {
 					channel: Channel::AccountsHealth,

--- a/crates/decodex-runtime/src/bootstrap.rs
+++ b/crates/decodex-runtime/src/bootstrap.rs
@@ -14,6 +14,7 @@ use std::{
 use crate::{
 	BoundServer, ProtocolServer, ServerConfig, ServerError,
 	account_launch::{AttestedAppServerProfile, ResetCardRuntime, ResetCardVaultStatus},
+	account_observation::AccountObservationService,
 	account_profile::AccountProfileRuntime,
 	account_service::{AccountInspection, AccountService, OpenAiCredentialRefresher},
 	application::{ProductStore, ServiceApplication},
@@ -163,6 +164,15 @@ impl ServiceBootstrap {
 			daemon_authority,
 		} = self;
 		let listener = daemon_authority.map_err(ServerError::LocalTransport)?;
+		let account_observations = match &accounts {
+			Some(accounts) if account_profiles.is_some() || reset_cards.is_some() =>
+				Some(AccountObservationService::new(
+					Arc::clone(accounts),
+					account_profiles.clone(),
+					reset_cards.clone(),
+				)),
+			_ => None,
+		};
 		let server = ProtocolServer::new(
 			server_id,
 			ServiceApplication::new(
@@ -177,8 +187,8 @@ impl ServiceBootstrap {
 				doctor,
 			)
 			.with_accounts(accounts)
-			.with_account_profiles(account_profiles)
-			.with_reset_cards(reset_cards),
+			.with_reset_cards(reset_cards)
+			.with_account_observations(account_observations),
 			config,
 		);
 		Ok(server.bind_listener(listener))

--- a/crates/decodex-runtime/src/lib.rs
+++ b/crates/decodex-runtime/src/lib.rs
@@ -14,6 +14,7 @@
 mod account_import;
 #[expect(dead_code, reason = "dormant until a later explicit product authority enables routing")]
 mod account_launch;
+mod account_observation;
 mod account_profile;
 mod account_service;
 mod application;

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -135,8 +135,11 @@ deadline receives a stable task identity but its command future is never polled.
 owner harvests `join_next_with_id`; it calls `abort_all` once only if the deadline
 expires, and it continues harvesting through `None`.
 
-The same top-level task also owns daemon service futures. Reset Card has no detached worker
-or heartbeat task. At the start of stopping, the application synchronously closes provider
+The same top-level task also owns daemon service futures. This includes the Reset Card
+worker and the account-observation scheduler. The scheduler starts all independent ready
+accounts concurrently, publishes each completion independently, and retains no more than
+one active observation owner for one Account UUID. Reset Card has no detached worker or
+heartbeat task. At the start of stopping, the application synchronously closes provider
 work registration and receives a cooperative service-stop signal. Queued blocking closures
 cannot start after that gate closes. An already registered provider operation uses its
 existing bounded process deadline and remains included in service settlement even if its
@@ -1293,7 +1296,12 @@ confirmation is presentation state only.
 Swift does not stage or read credentials, create a temporary Codex home, launch a process,
 resolve an opaque credit ID, or call the provider method. It persists only a credential-negative
 pending Reset Card operation handle so it can read durable daemon status after an app restart.
-Provider-effect retry and authoritative reconciliation remain daemon-only.
+Provider observation, provider-effect retry, and authoritative reconciliation remain
+daemon-only. The UI starts all independent daemon value reads concurrently. Its 15-second
+cycle and panel-open trigger reload cached values only; they do not start OpenAI or
+app-server work. After successful login replacement, bounded local readback waits for the
+daemon's new revision-scoped observation instead of treating an old unauthorized value as
+the result of the new login.
 
 After the caller creates and durably records an idempotency key for `use`, every CLI
 result repeats that key and one closed `dispatch_state`: `definitely_not_dispatched`,

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -168,9 +168,10 @@ decodex-publisher validate-social
   independent cards with transparent gaps, compact quota meters, and single-line
   Reset Card controls. The overflow menu stores one panel-wide appearance choice:
   `Thin` by default, or the system `Liquid Glass` effect. The same menu keeps only
-  `Refresh all`, that material selector, and Quit. A manual refresh remains available
-  during a background read and coalesces into the active refresh cycle; account
-  mutations and Reset Card submissions still disable it.
+  `Refresh all`, that material selector, and Quit. A manual reload remains available
+  during a background read and coalesces into the active reload cycle; it reads
+  daemon-owned values and does not start provider work. Account mutations and Reset
+  Card submissions still disable it.
 - Reveals a compact trailing-edge reorder grip over an account card's padding while
   the pointer is over that card, so the grip does not reserve a layout column. A
   drag uses the stable list coordinate space and keeps the full-size card on a
@@ -185,9 +186,12 @@ decodex-publisher validate-social
   an account control or Reset Card submission is in progress, when routing and
   account membership disagree, or when fewer than two accounts exist. The app does
   not persist a separate local order.
-- Loads quota windows and Reset Cards independently for each row. One slow or failed
-  provider request does not hide the other accounts. A provider-unsupported quota
-  duration stays a muted row-local fact and does not mark the account as failed.
+- Loads daemon-owned quota, Reset Card, and profile values concurrently for every row.
+  One cold or failed account observation does not hide the other accounts. The
+  [daemon account observer](../specs/account-lifecycle-authority.md#daemon-account-observation)
+  starts provider observations for all ready accounts concurrently without a small global
+  fan-out cap. A provider-unsupported quota duration stays a muted row-local fact and does
+  not mark the account as failed.
 - Uses Reset Cards from the common daemon service. The first click starts a
   five-second local confirmation. The second click ends the countdown, shows a busy
   indicator, persists a pending attempt, and submits one in-process Rust request with
@@ -198,8 +202,8 @@ decodex-publisher validate-social
   checking state. During that reconciliation, the app keeps the last quota visible
   but does not expose Reset Cards from the old account revision. It holds an
   advanced inventory until the matching account skeleton arrives and then applies
-  it without a duplicate provider read. One per-account coordinator coalesces
-  same-revision inventory calls. A use gate waits for any older provider read and
+  it without a duplicate daemon read. One per-account coordinator coalesces
+  same-revision inventory calls. A use gate waits for any older daemon read and
   blocks fresh reads until the effect dispatch ends. A terminal use result starts
   bounded background reconciliation without holding the button busy. Internal contention, provider
   cleanup, and other retryable detail failures show `Updating usage…` while the
@@ -213,10 +217,12 @@ decodex-publisher validate-social
   The macOS source-install path provisions that service with
   `scripts/macos/install_decodex_local_service.py`; its Rust supervisor owns the
   PostgreSQL and daemon process generations.
-- Retries only the bounded startup account-skeleton transport while the independently
-  supervised service becomes ready. Row-scoped profile or Reset Card failures remain
-  local until explicit refresh. It does not retry consume, replace an idempotency key,
-  or take service lifecycle ownership.
+- Uses one finite startup retry schedule for daemon transport and retryable row-scoped
+  cold-cache results while the independently supervised observer warms. Permanent
+  profile and Reset Card failures remain row-local. It does not retry consume, replace
+  an idempotency key, or take service lifecycle ownership. Successful login replacement
+  also uses bounded short-interval daemon readback so an old unauthorized observation
+  cannot look like the result of the new login.
 - Shows one compact status row for each retained attempt and checks durable status
   automatically. A nonterminal state or temporary read failure updates that row. A
   terminal result removes the row and shows the result message. The UI does not

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -302,13 +302,70 @@ before current enabled, readiness, health, operation, store, or revision gates. 
 terminal receipt never calls Codex or the provider again. Nonterminal status and required
 reconciliation also remain readable after a gate changes. They cannot start a new effect.
 
+## Daemon account observation
+
+`decodexd` owns the provider-observation cadence through the lifecycle composition described
+in [Runtime architecture](../architecture/runtime-architecture.md#account-lifecycle-and-credential-authority).
+Its account observer starts immediately, repeats every 15 seconds, and wakes after a
+successful account command or when a durable Reset Card worker claim settles. Each round
+discovers every non-tombstoned AccountLifecycle-ready account, including administratively
+disabled accounts because observation is not new-work admission. It starts one independent
+async owner for every account without a small global fan-out cap. Reset Card and profile
+provider work for different accounts runs concurrently. Within one account, the observer first
+settles the Reset Card owner because it can rotate credentials, then observes the profile with
+that exact successor. At most one observation owner is active for one Account UUID; another
+lifecycle or effect wake becomes that account's pending successor round. A periodic tick does
+not queue a hot-loop successor for an already slow account.
+
+One slow account does not delay completion or later scheduling for another account.
+Observation results publish progressively and only against the current Account revision.
+An account change prunes old Reset Card and profile refresh state before a later result
+can become current.
+
+Normal `GetResetCards` and `GetAccountProfile` queries do not contact OpenAI or start an
+app-server. They read daemon-owned values. PostgreSQL remains the persistence authority for
+quota facts and bounded profile snapshots. Public Reset Card inventory is instead a
+revision-fenced daemon-lifetime cache: restart discards it, immediately starts a new
+observation round, and returns a typed retryable unavailable result until that account is
+warm. No credential or provider-private Reset Card ID enters this cache.
+
+```mermaid
+sequenceDiagram
+    participant Timer as Daemon timer or wakeup
+    participant Observer as Account observation service
+    participant Accounts as Account service
+    participant Provider as Provider adapters
+    participant Store as PostgreSQL
+    participant Cache as Daemon Reset Card cache
+    participant Client as UI or protocol client
+
+    Timer->>Observer: Request coalesced observation round
+    Observer->>Accounts: List lifecycle-ready account revisions
+    par Each independent account
+        Observer->>Provider: Refresh profile and Reset Card values
+        Provider->>Store: Persist profile and quota facts
+        Provider-->>Observer: Return public inventory and refresh status
+        Observer->>Cache: Publish only matching revision
+    end
+    Client->>Observer: Read profile or Reset Card value
+    Observer->>Store: Read persisted profile projection
+    Observer->>Cache: Read revision-fenced public inventory
+    Observer-->>Client: Return daemon-owned value
+```
+
+The observation round separates daemon-owned provider refresh from client query readback;
+PostgreSQL retains profile and quota durability while Reset Card descriptors live only for
+the daemon lifetime.
+
 ## Bounded account profile
 
 Protocol V2.0 provides one independent `GetAccountProfile` query per Account UUID. It does
-not run as part of account listing or Reset Card inventory. One failed profile query
-affects only that account row.
+not run as part of account listing or Reset Card inventory. The query reads the latest
+persisted projection and the daemon observer's revision-scoped refresh status. One failed
+background profile observation affects only that account row.
 
-The daemon reads the exact current HostCredentialStore binding and calls only
+During a background observation, the daemon reads the exact current HostCredentialStore
+binding and calls only
 `https://chatgpt.com/backend-api/wham/profiles/me`. The request has bounded connect and
 total timeouts, no redirects, and a bounded response body. The daemon sends the access
 token and provider account ID only to that endpoint. It does not log or return the token,


### PR DESCRIPTION
Summary:
- make decodexd own scheduled OpenAI profile and Reset Card observation
- run all independent accounts concurrently with one owner per account
- make macOS UI queries read daemon-owned values only and retry cold/login readback

Validation:
- cargo test -p decodex-runtime --all-targets --all-features
- strict cargo clippy for decodex-runtime
- swift test --package-path apps/decodex-app (204 tests)
- python3 -m unittest tests/scripts/test_vnext_architecture.py
- signed release app staging