### PR TITLE
Describe profile queries as daemon-observed reads

### DIFF
--- a/apps/decodex-cli/src/account.rs
+++ b/apps/decodex-cli/src/account.rs
@@ -19,7 +19,7 @@ pub enum AccountCommand {
 	List,
 	/// Inspect one daemon-owned account row.
 	Inspect(AccountIdentityArgs),
-	/// Refresh and read one bounded account profile.
+	/// Read one bounded daemon-observed account profile.
 	Profile(AccountProfileArgs),
 	/// Read the current normal shared Codex authentication projection.
 	CodexProjection,


### PR DESCRIPTION
Summary:
- correct the account profile CLI help after daemon-owned observation cutover

Validation:
- cargo test -p decodex-cli --all-targets --all-features
- profile help readback